### PR TITLE
Remove compile context

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -967,17 +967,10 @@ rb_iseq_compile_node(rb_iseq_t *iseq, const NODE *node)
     return iseq_setup(iseq, ret);
 }
 
-typedef struct pm_compile_context {
-    pm_parser_t *parser;
-    struct pm_compile_context *previous;
-    ID *constants;
-    st_table *index_lookup_table;
-} pm_compile_context_t;
-
-static VALUE rb_translate_prism(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, pm_compile_context_t *compile_context);
+static VALUE rb_translate_prism(rb_iseq_t *iseq, const pm_scope_node_t node, LINK_ANCHOR *const ret);
 
 VALUE
-rb_iseq_compile_prism_node(rb_iseq_t * iseq, const pm_node_t *node, pm_parser_t *parser)
+rb_iseq_compile_prism_node(rb_iseq_t * iseq, pm_scope_node_t scope_node, pm_parser_t *parser)
 {
     DECL_ANCHOR(ret);
     INIT_ANCHOR(ret);
@@ -990,13 +983,9 @@ rb_iseq_compile_prism_node(rb_iseq_t * iseq, const pm_node_t *node, pm_parser_t 
         constants[index] = rb_intern3((const char *) constant->start, constant->length, encoding);
     }
 
-    pm_compile_context_t compile_context = {
-        .parser = parser,
-        .previous = NULL,
-        .constants = constants
-    };
+    scope_node.constants = (void *)constants;
 
-    CHECK(rb_translate_prism(iseq, node, ret, &compile_context));
+    CHECK(rb_translate_prism(iseq, scope_node, ret));
     free(constants);
 
     CHECK(iseq_setup_insn(iseq, ret));

--- a/compile.c
+++ b/compile.c
@@ -967,10 +967,10 @@ rb_iseq_compile_node(rb_iseq_t *iseq, const NODE *node)
     return iseq_setup(iseq, ret);
 }
 
-static VALUE rb_translate_prism(rb_iseq_t *iseq, const pm_scope_node_t node, LINK_ANCHOR *const ret);
+static VALUE rb_translate_prism(rb_iseq_t *iseq, const pm_scope_node_t *scope_node, LINK_ANCHOR *const ret);
 
 VALUE
-rb_iseq_compile_prism_node(rb_iseq_t * iseq, pm_scope_node_t scope_node, pm_parser_t *parser)
+rb_iseq_compile_prism_node(rb_iseq_t * iseq, pm_scope_node_t *scope_node, pm_parser_t *parser)
 {
     DECL_ANCHOR(ret);
     INIT_ANCHOR(ret);
@@ -983,7 +983,7 @@ rb_iseq_compile_prism_node(rb_iseq_t * iseq, pm_scope_node_t scope_node, pm_pars
         constants[index] = rb_intern3((const char *) constant->start, constant->length, encoding);
     }
 
-    scope_node.constants = (void *)constants;
+    scope_node->constants = (void *)constants;
 
     CHECK(rb_translate_prism(iseq, scope_node, ret));
     free(constants);

--- a/iseq.c
+++ b/iseq.c
@@ -939,10 +939,10 @@ rb_iseq_new_with_opt(const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE rea
     return iseq_translate(iseq);
 }
 
-VALUE rb_iseq_compile_prism_node(rb_iseq_t * iseq, pm_scope_node_t scope_node, pm_parser_t *parser);
+VALUE rb_iseq_compile_prism_node(rb_iseq_t * iseq, pm_scope_node_t *scope_node, pm_parser_t *parser);
 
 rb_iseq_t *
-pm_iseq_new_with_opt(pm_scope_node_t scope_node, pm_parser_t *parser, VALUE name, VALUE path, VALUE realpath,
+pm_iseq_new_with_opt(pm_scope_node_t *scope_node, pm_parser_t *parser, VALUE name, VALUE path, VALUE realpath,
                      int first_lineno, const rb_iseq_t *parent, int isolated_depth,
                      enum rb_iseq_type type, const rb_compile_option_t *option)
 {
@@ -952,8 +952,8 @@ pm_iseq_new_with_opt(pm_scope_node_t scope_node, pm_parser_t *parser, VALUE name
 
     if (!option) option = &COMPILE_OPTION_DEFAULT;
 
-    pm_line_column_t start_line_col = pm_newline_list_line_column(&parser->newline_list, scope_node.base.location.start);
-    pm_line_column_t end_line_col = pm_newline_list_line_column(&parser->newline_list, scope_node.base.location.end);
+    pm_line_column_t start_line_col = pm_newline_list_line_column(&parser->newline_list, scope_node->base.location.start);
+    pm_line_column_t end_line_col = pm_newline_list_line_column(&parser->newline_list, scope_node->base.location.end);
 
     code_loc = (rb_code_location_t) {
         .beg_pos = {
@@ -1444,7 +1444,7 @@ iseqw_s_compile_prism(int argc, VALUE *argv, VALUE self)
 
     pm_scope_node_t scope_node;
     pm_scope_node_init(node, &scope_node, NULL, &parser);
-    rb_iseq_compile_prism_node(iseq, scope_node, &parser);
+    rb_iseq_compile_prism_node(iseq, &scope_node, &parser);
 
     finish_iseq_build(iseq);
     pm_node_destroy(&parser, node);

--- a/iseq.c
+++ b/iseq.c
@@ -952,6 +952,8 @@ pm_iseq_new_with_opt(pm_scope_node_t scope_node, pm_parser_t *parser, VALUE name
 
     if (!option) option = &COMPILE_OPTION_DEFAULT;
 
+    /*
+     * TODO: Fix the below
     pm_line_column_t start_line_col = pm_newline_list_line_column(&parser->newline_list, scope_node.base.location.start);
     pm_line_column_t end_line_col = pm_newline_list_line_column(&parser->newline_list, scope_node.base.location.end);
 
@@ -965,6 +967,7 @@ pm_iseq_new_with_opt(pm_scope_node_t scope_node, pm_parser_t *parser, VALUE name
             .column = (int) end_line_col.column
         },
     };
+    */
 
     // TODO: node_id
     int node_id = -1;

--- a/iseq.c
+++ b/iseq.c
@@ -952,8 +952,6 @@ pm_iseq_new_with_opt(pm_scope_node_t scope_node, pm_parser_t *parser, VALUE name
 
     if (!option) option = &COMPILE_OPTION_DEFAULT;
 
-    /*
-     * TODO: Fix the below
     pm_line_column_t start_line_col = pm_newline_list_line_column(&parser->newline_list, scope_node.base.location.start);
     pm_line_column_t end_line_col = pm_newline_list_line_column(&parser->newline_list, scope_node.base.location.end);
 
@@ -967,7 +965,6 @@ pm_iseq_new_with_opt(pm_scope_node_t scope_node, pm_parser_t *parser, VALUE name
             .column = (int) end_line_col.column
         },
     };
-    */
 
     // TODO: node_id
     int node_id = -1;

--- a/iseq.c
+++ b/iseq.c
@@ -939,10 +939,10 @@ rb_iseq_new_with_opt(const rb_ast_body_t *ast, VALUE name, VALUE path, VALUE rea
     return iseq_translate(iseq);
 }
 
-VALUE rb_iseq_compile_prism_node(rb_iseq_t * iseq, const pm_node_t *node, pm_parser_t *parser);
+VALUE rb_iseq_compile_prism_node(rb_iseq_t * iseq, pm_scope_node_t scope_node, pm_parser_t *parser);
 
 rb_iseq_t *
-pm_iseq_new_with_opt(pm_node_t *node, pm_parser_t *parser, VALUE name, VALUE path, VALUE realpath,
+pm_iseq_new_with_opt(pm_scope_node_t scope_node, pm_parser_t *parser, VALUE name, VALUE path, VALUE realpath,
                      int first_lineno, const rb_iseq_t *parent, int isolated_depth,
                      enum rb_iseq_type type, const rb_compile_option_t *option)
 {
@@ -952,28 +952,26 @@ pm_iseq_new_with_opt(pm_node_t *node, pm_parser_t *parser, VALUE name, VALUE pat
 
     if (!option) option = &COMPILE_OPTION_DEFAULT;
 
-    if (node) {
-        pm_line_column_t start_line_col = pm_newline_list_line_column(&parser->newline_list, node->location.start);
-        pm_line_column_t end_line_col = pm_newline_list_line_column(&parser->newline_list, node->location.end);
+    pm_line_column_t start_line_col = pm_newline_list_line_column(&parser->newline_list, scope_node.base.location.start);
+    pm_line_column_t end_line_col = pm_newline_list_line_column(&parser->newline_list, scope_node.base.location.end);
 
-        code_loc = (rb_code_location_t) {
-            .beg_pos = {
-                .lineno = (int) start_line_col.line,
-                .column = (int) start_line_col.column
-            },
-            .end_pos = {
-                .lineno = (int) end_line_col.line,
-                .column = (int) end_line_col.column
-            },
-        };
-    }
+    code_loc = (rb_code_location_t) {
+        .beg_pos = {
+            .lineno = (int) start_line_col.line,
+            .column = (int) start_line_col.column
+        },
+        .end_pos = {
+            .lineno = (int) end_line_col.line,
+            .column = (int) end_line_col.column
+        },
+    };
 
     // TODO: node_id
     int node_id = -1;
     prepare_iseq_build(iseq, name, path, realpath, first_lineno, &code_loc, node_id,
             parent, isolated_depth, type, script_lines, option);
 
-    rb_iseq_compile_prism_node(iseq, node, parser);
+    rb_iseq_compile_prism_node(iseq, scope_node, parser);
 
     finish_iseq_build(iseq);
 
@@ -1444,7 +1442,9 @@ iseqw_s_compile_prism(int argc, VALUE *argv, VALUE self)
     prepare_iseq_build(iseq, name, file, path, first_lineno, &node_location, node_id,
                        parent, 0, (enum rb_iseq_type)iseq_type, Qnil, &option);
 
-    rb_iseq_compile_prism_node(iseq, node, &parser);
+    pm_scope_node_t scope_node;
+    pm_scope_node_init(node, &scope_node, NULL, &parser);
+    rb_iseq_compile_prism_node(iseq, scope_node, &parser);
 
     finish_iseq_build(iseq);
     pm_node_destroy(&parser, node);

--- a/prism/node.h
+++ b/prism/node.h
@@ -33,10 +33,17 @@ PRISM_EXPORTED_FUNCTION const char * pm_node_type_to_str(pm_node_type_t node_typ
 // declare them here to avoid generating them.
 typedef struct pm_scope_node {
     pm_node_t base;
+    struct pm_scope_node *previous;
     pm_node_t *ast_node;
     struct pm_parameters_node *parameters;
     pm_node_t *body;
     pm_constant_id_list_t locals;
+    pm_parser_t *parser;
+
+    // We don't have the CRuby types ID and st_table within Prism
+    // so we use void *
+    void *constants; // ID *constants
+    void *index_lookup_table; // st_table *index_lookup_table
 } pm_scope_node_t;
 
 #endif // PRISM_NODE_H

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -654,14 +654,22 @@ pm_arguments_validate_block(pm_parser_t *parser, pm_arguments_t *arguments, pm_b
 
 // Generate a scope node from the given node.
 void
-pm_scope_node_init(pm_node_t *node, pm_scope_node_t *scope) {
+pm_scope_node_init(const pm_node_t *node, pm_scope_node_t *scope, pm_scope_node_t *previous, pm_parser_t *parser) {
     scope->base.type = PM_SCOPE_NODE;
     scope->base.location.start = node->location.start;
     scope->base.location.end = node->location.end;
 
-    scope->ast_node = node;
+    scope->previous = previous;
+    scope->parser = parser;
+    scope->ast_node = (pm_node_t *)node;
     scope->parameters = NULL;
     scope->body = NULL;
+    scope->constants = NULL;
+    if (previous) {
+        scope->constants = previous->constants;
+    }
+    scope->index_lookup_table = NULL;
+
     pm_constant_id_list_init(&scope->locals);
 
     switch (PM_NODE_TYPE(node)) {

--- a/prism/prism.h
+++ b/prism/prism.h
@@ -34,7 +34,7 @@ void pm_print_node(pm_parser_t *parser, pm_node_t *node);
 void pm_parser_metadata(pm_parser_t *parser, const char *metadata);
 
 // Generate a scope node from the given node.
-void pm_scope_node_init(pm_node_t *node, pm_scope_node_t *dest);
+void pm_scope_node_init(const pm_node_t *node, pm_scope_node_t *scope, pm_scope_node_t *previous, pm_parser_t *parser);
 
 // The prism version and the serialization format.
 PRISM_EXPORTED_FUNCTION const char * pm_version(void);

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -34,7 +34,7 @@
     if (!popped) ADD_INSN(ret, &dummy_line_node, putnil);
 
 rb_iseq_t *
-pm_iseq_new_with_opt(pm_scope_node_t node, pm_parser_t *parser, VALUE name, VALUE path, VALUE realpath,
+pm_iseq_new_with_opt(pm_scope_node_t *scope_node, pm_parser_t *parser, VALUE name, VALUE path, VALUE realpath,
                      int first_lineno, const rb_iseq_t *parent, int isolated_depth,
                      enum rb_iseq_type type, const rb_compile_option_t *option);
 
@@ -579,7 +579,7 @@ pm_new_child_iseq(rb_iseq_t *iseq, pm_scope_node_t node, pm_parser_t *parser,
 {
     debugs("[new_child_iseq]> ---------------------------------------\n");
     int isolated_depth = ISEQ_COMPILE_DATA(iseq)->isolated_depth;
-    rb_iseq_t * ret_iseq = pm_iseq_new_with_opt(node, parser, name,
+    rb_iseq_t * ret_iseq = pm_iseq_new_with_opt(&node, parser, name,
             rb_iseq_path(iseq), rb_iseq_realpath(iseq),
             line_no, parent,
             isolated_depth ? isolated_depth + 1 : 0,
@@ -2530,11 +2530,11 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 }
 
 static VALUE
-rb_translate_prism(rb_iseq_t *iseq, const pm_scope_node_t scope_node, LINK_ANCHOR *const ret)
+rb_translate_prism(rb_iseq_t *iseq, const pm_scope_node_t *scope_node, LINK_ANCHOR *const ret)
 {
     RUBY_ASSERT(ISEQ_COMPILE_DATA(iseq));
 
-    pm_compile_node(iseq, (pm_node_t *)&scope_node, ret, scope_node.base.location.start, false, (pm_scope_node_t *)&scope_node);
+    pm_compile_node(iseq, (pm_node_t *)scope_node, ret, scope_node->base.location.start, false, (pm_scope_node_t *)scope_node);
     iseq_set_sequence(iseq, ret);
     return Qnil;
 }

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -34,7 +34,7 @@
     if (!popped) ADD_INSN(ret, &dummy_line_node, putnil);
 
 rb_iseq_t *
-pm_iseq_new_with_opt(pm_scope_node_t *node, pm_parser_t *parser, VALUE name, VALUE path, VALUE realpath,
+pm_iseq_new_with_opt(pm_scope_node_t node, pm_parser_t *parser, VALUE name, VALUE path, VALUE realpath,
                      int first_lineno, const rb_iseq_t *parent, int isolated_depth,
                      enum rb_iseq_type type, const rb_compile_option_t *option);
 
@@ -574,7 +574,7 @@ pm_constant_id_lookup(pm_scope_node_t *scope_node, pm_constant_id_t constant_id)
 }
 
 static rb_iseq_t *
-pm_new_child_iseq(rb_iseq_t *iseq, pm_scope_node_t * node, pm_parser_t *parser,
+pm_new_child_iseq(rb_iseq_t *iseq, pm_scope_node_t node, pm_parser_t *parser,
                VALUE name, const rb_iseq_t *parent, enum rb_iseq_type type, int line_no)
 {
     debugs("[new_child_iseq]> ---------------------------------------\n");
@@ -1029,7 +1029,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             pm_scope_node_t next_scope_node;
             pm_scope_node_init(call_node->block, &next_scope_node, scope_node, parser);
 
-            const rb_iseq_t *block_iseq = NEW_CHILD_ISEQ(&next_scope_node, make_name_for_block(iseq), ISEQ_TYPE_BLOCK, lineno);
+            const rb_iseq_t *block_iseq = NEW_CHILD_ISEQ(next_scope_node, make_name_for_block(iseq), ISEQ_TYPE_BLOCK, lineno);
             ISEQ_COMPILE_DATA(iseq)->current_block = block_iseq;
             ADD_SEND_WITH_BLOCK(ret, &dummy_line_node, method_id, INT2FIX(orig_argc), block_iseq);
         }
@@ -1065,7 +1065,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
         VALUE class_name = rb_str_freeze(rb_sprintf("<class:%"PRIsVALUE">", rb_id2str(class_id)));
 
-        const rb_iseq_t *class_iseq = NEW_CHILD_ISEQ(&next_scope_node, class_name, ISEQ_TYPE_CLASS, lineno);
+        const rb_iseq_t *class_iseq = NEW_CHILD_ISEQ(next_scope_node, class_name, ISEQ_TYPE_CLASS, lineno);
 
         // TODO: Once we merge constant path nodes correctly, fix this flag
         const int flags = VM_DEFINECLASS_TYPE_CLASS |
@@ -1344,7 +1344,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         ID method_name = pm_constant_id_lookup(scope_node, def_node->name);
         pm_scope_node_t next_scope_node;
         pm_scope_node_init((pm_node_t *)def_node, &next_scope_node, scope_node, parser);
-        rb_iseq_t *method_iseq = NEW_ISEQ(&next_scope_node, rb_id2str(method_name), ISEQ_TYPE_METHOD, lineno);
+        rb_iseq_t *method_iseq = NEW_ISEQ(next_scope_node, rb_id2str(method_name), ISEQ_TYPE_METHOD, lineno);
 
         ADD_INSN2(ret, &dummy_line_node, definemethod, ID2SYM(method_name), method_iseq);
         RB_OBJ_WRITTEN(iseq, Qundef, (VALUE)method_iseq);
@@ -1787,7 +1787,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         pm_scope_node_t next_scope_node;
         pm_scope_node_init(node, &next_scope_node, scope_node, parser);
 
-        const rb_iseq_t *block = NEW_CHILD_ISEQ(&next_scope_node, make_name_for_block(iseq), ISEQ_TYPE_BLOCK, lineno);
+        const rb_iseq_t *block = NEW_CHILD_ISEQ(next_scope_node, make_name_for_block(iseq), ISEQ_TYPE_BLOCK, lineno);
         VALUE argc = INT2FIX(0);
 
         ADD_INSN1(ret, &dummy_line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
@@ -2029,7 +2029,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         ID module_id = pm_constant_id_lookup(scope_node, module_node->name);
         VALUE module_name = rb_str_freeze(rb_sprintf("<module:%"PRIsVALUE">", rb_id2str(module_id)));
 
-        const rb_iseq_t *module_iseq = NEW_CHILD_ISEQ(&next_scope_node, module_name, ISEQ_TYPE_CLASS, lineno);
+        const rb_iseq_t *module_iseq = NEW_CHILD_ISEQ(next_scope_node, module_name, ISEQ_TYPE_CLASS, lineno);
 
         const int flags = VM_DEFINECLASS_TYPE_MODULE |
             pm_compile_class_path(ret, iseq, module_node->constant_path, &dummy_line_node, src, false, scope_node);
@@ -2349,7 +2349,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         pm_scope_node_t next_scope_node;
         pm_scope_node_init((pm_node_t *)singleton_class_node, &next_scope_node, scope_node, parser);
 
-        const rb_iseq_t *singleton_class = NEW_ISEQ(&next_scope_node, rb_fstring_lit("singleton class"), ISEQ_TYPE_CLASS, lineno);
+        const rb_iseq_t *singleton_class = NEW_ISEQ(next_scope_node, rb_fstring_lit("singleton class"), ISEQ_TYPE_CLASS, lineno);
 
         PM_COMPILE(singleton_class_node->expression);
         ADD_INSN(ret, &dummy_line_node, putnil);

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -3,7 +3,7 @@
 module Prism
   class TestCompilePrism < Test::Unit::TestCase
     def test_empty_program
-#      test_prism_eval("")
+      test_prism_eval("")
     end
 
     ############################################################################

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -488,8 +488,30 @@ module Prism
     ############################################################################
 
     def test_ScopeNode
-      test_prism_eval("a = 1; tap do; { a: }; end")
-      test_prism_eval("a = 1; def foo(a); a; end")
+      assert_separately(%w[], "#{<<-'begin;'}\n#{<<-'end;'}")
+                        begin;
+    def compare_eval(source)
+      ruby_eval = RubyVM::InstructionSequence.compile(source).eval
+      prism_eval = RubyVM::InstructionSequence.compile_prism(source).eval
+
+      assert_equal ruby_eval, prism_eval
+    end
+
+    def test_prism_eval(source)
+      $VERBOSE, verbose_bak = nil, $VERBOSE
+
+      begin
+        compare_eval(source)
+
+        # Test "popped" functionality
+        compare_eval("#{source}; 1")
+      ensure
+        $VERBOSE = verbose_bak
+      end
+    end
+        test_prism_eval("a = 1; tap do; { a: }; end")
+        test_prism_eval("a = 1; def foo(a); a; end")
+                        end;
     end
 
     private

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -3,7 +3,7 @@
 module Prism
   class TestCompilePrism < Test::Unit::TestCase
     def test_empty_program
-      test_prism_eval("")
+#      test_prism_eval("")
     end
 
     ############################################################################
@@ -481,6 +481,15 @@ module Prism
       test_prism_eval("module Prism; @prism = 1; 1 in ^@prism; end")
       test_prism_eval("$prism = 1; 1 in ^$prism")
       test_prism_eval("prism = 1; 1 in ^prism")
+    end
+
+    ############################################################################
+    #  Miscellaneous                                                           #
+    ############################################################################
+
+    def test_ScopeNode
+      test_prism_eval("a = 1; tap do; { a: }; end")
+      test_prism_eval("a = 1; def foo(a); a; end")
     end
 
     private


### PR DESCRIPTION
    Remove pm_compile_context_t, move the context onto ScopeNode
    
    We changed ScopeNodes to point to their parent (previous) ScopeNodes.
    Accordingly, we can remove pm_compile_context_t, and store all
    necessary context in ScopeNodes, allowing us to access locals from
    outer scopes.