### PR TITLE
"+MN" in description

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -2101,7 +2101,10 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
         opt->yjit = true; // set opt->yjit for Init_ruby_description() and calling rb_yjit_init()
     }
 #endif
+
+    ruby_mn_threads_params();
     Init_ruby_description(opt);
+
     if (opt->dump & (DUMP_BIT(version) | DUMP_BIT(version_v))) {
         ruby_show_version();
         if (opt->dump & DUMP_BIT(version)) return Qtrue;
@@ -2153,7 +2156,6 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
 #endif
 
     ruby_gc_set_params();
-    ruby_mn_threads_params();
     ruby_init_loadpath();
 
     Init_enc();

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -156,7 +156,7 @@ class TestRubyOptions < Test::Unit::TestCase
   VERSION_PATTERN_WITH_RJIT =
     case RUBY_ENGINE
     when 'ruby'
-      /^ruby #{q[RUBY_VERSION]}(?:[p ]|dev|rc).*? \+RJIT \[#{q[RUBY_PLATFORM]}\]$/
+      /^ruby #{q[RUBY_VERSION]}(?:[p ]|dev|rc).*? \+RJIT (\+MN )?\[#{q[RUBY_PLATFORM]}\]$/
     else
       VERSION_PATTERN
     end

--- a/version.c
+++ b/version.c
@@ -139,12 +139,15 @@ Init_version(void)
 #define YJIT_OPTS_ON 0
 #endif
 
+int ruby_mn_threads_enabled;
+
 void
 Init_ruby_description(ruby_cmdline_options_t *opt)
 {
     static char desc[
         sizeof(ruby_description)
         + rb_strlen_lit(YJIT_DESCRIPTION)
+        + rb_strlen_lit(" +MN")
         ];
 
     const char *const jit_opt =
@@ -152,9 +155,16 @@ Init_ruby_description(ruby_cmdline_options_t *opt)
         YJIT_OPTS_ON ? YJIT_DESCRIPTION :
         "";
 
-    int n = snprintf(desc, sizeof(desc), "%.*s" /* jit_opt */"%s" "%s",
+    const char *const threads_opt = ruby_mn_threads_enabled ? " +MN" : "";
+
+    int n = snprintf(desc, sizeof(desc),
+                     "%.*s"
+                     "%s" // jit_opt
+                     "%s" // threads_opts
+                     "%s",
                      ruby_description_opt_point, ruby_description,
                      jit_opt,
+                     threads_opt,
                      ruby_description + ruby_description_opt_point);
 
     VALUE description = rb_obj_freeze(rb_usascii_str_new_static(desc, n));


### PR DESCRIPTION
If `RUBY_MN_THREADS=1` is given, this patch shows `+MN` in `RUBY_DESCRIPTION` like:

```
$ RUBY_MN_THREADS=1 ./miniruby  --yjit -v
ruby 3.3.0dev (2023-10-17T04:10:14Z master 908f8fffa2) +YJIT +MN [x86_64-linux]
```

Before this patch, a warning is displayed if `$VERBOSE` is given. However it can make troubles with tests (with `$VERBOSE`), do not show any warning with a MN threads configuration.