### PR TITLE
YJIT: Remove call to compile() on empty Assembler

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7760,16 +7760,13 @@ fn gen_invokesuper_specialized(
 fn gen_leave(
     _jit: &mut JITState,
     asm: &mut Assembler,
-    ocb: &mut OutlinedCb,
+    _ocb: &mut OutlinedCb,
 ) -> Option<CodegenStatus> {
     // Only the return value should be on the stack
     assert_eq!(1, asm.ctx.get_stack_size(), "leave instruction expects stack size 1, but was: {}", asm.ctx.get_stack_size());
 
-    let ocb_asm = Assembler::new();
-
     // Check for interrupts
     gen_check_ints(asm, Counter::leave_se_interrupt);
-    ocb_asm.compile(ocb.unwrap(), None);
 
     // Pop the current frame (ec->cfp++)
     // Note: the return PC is already in the previous CFP


### PR DESCRIPTION
Looks like defer_compilation() is really the main use of ocb that's left, now that asm.compile() takes both cb and ocb. Maybe at some point we can do the a big refactoring and remove the ocb parameter from all the gen_* functions.