### PR TITLE
YJIT: Use RbConfig.ruby instead of EnvUtil.rubybin

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1519,6 +1519,6 @@ class TestYJIT < Test::Unit::TestCase
   # A wrapper of EnvUtil.invoke_ruby that uses RbConfig.ruby instead of EnvUtil.ruby
   # that might use a wrong Ruby depending on your environment.
   def invoke_ruby(*args, **kwargs)
-    EnvUtil.invoke_ruby(*args, **{ rubybin: RbConfig.ruby, **kwargs })
+    EnvUtil.invoke_ruby(*args, rubybin: RbConfig.ruby, **kwargs)
   end
 end

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -75,7 +75,7 @@ class TestYJIT < Test::Unit::TestCase
   end
 
   def test_yjit_stats_and_v_no_error
-    _stdout, stderr, _status = EnvUtil.invoke_ruby(%w(-v --yjit-stats), '', true, true)
+    _stdout, stderr, _status = invoke_ruby(%w(-v --yjit-stats), '', true, true)
     refute_includes(stderr, "NoMethodError")
   end
 
@@ -1504,9 +1504,7 @@ class TestYJIT < Test::Unit::TestCase
       stats = stats_r.read
       stats_r.close
     end
-    out, err, status = EnvUtil.invoke_ruby(args,
-      '', true, true, timeout: timeout, ios: {3 => stats_w}
-    )
+    out, err, status = invoke_ruby(args, '', true, true, timeout: timeout, ios: { 3 => stats_w })
     stats_w.close
     stats_reader.join(timeout)
     stats = Marshal.load(stats) if !stats.empty?
@@ -1516,5 +1514,11 @@ class TestYJIT < Test::Unit::TestCase
     stats_reader&.join(timeout)
     stats_r&.close
     stats_w&.close
+  end
+
+  # A wrapper of EnvUtil.invoke_ruby that uses RbConfig.ruby instead of EnvUtil.ruby
+  # that might use a wrong Ruby depending on your environment.
+  def invoke_ruby(*args, **kwargs)
+    EnvUtil.invoke_ruby(*args, **{ rubybin: RbConfig.ruby, **kwargs })
   end
 end


### PR DESCRIPTION
`EnvUtil.invoke_ruby` uses `EnvUtil.rubybin` by default, which has [a weird fallback logic](https://github.com/ruby/ruby/blob/2abd061e8beefbdead0296377948ce7a0098277b/tool/lib/envutil.rb#L23-L31) that is not necessary for test_yjit.

Since there are folks reporting [test_yjit failures we can't reproduce](https://bugs.ruby-lang.org/issues/19921), I want to rule out that possibility by always using `RbConfig.ruby`.