### PR TITLE
Make the name resolution interruptible

### DIFF
--- a/ext/socket/extconf.rb
+++ b/ext/socket/extconf.rb
@@ -327,6 +327,8 @@ end
   net/if_dl.h
   arpa/nameser.h
   resolv.h
+  pthread.h
+  sched.h
 ].each {|h|
   if have_header(h, headers)
     headers << h
@@ -699,6 +701,11 @@ SRC
       "not needed"
     end
   end
+
+  have_func("pthread_create")
+  have_func("pthread_detach")
+  have_func("pthread_setaffinity_np")
+  have_func("sched_getcpu")
 
   $VPATH << '$(topdir)' << '$(top_srcdir)'
   create_makefile("socket")

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -472,13 +472,13 @@ start:
 
     arg = allocate_getaddrinfo_arg(hostp, portp, hints);
     if (!arg) {
-        return ENOMEM;
+        return EAI_MEMORY;
     }
 
     pthread_t th;
     if (pthread_create(&th, 0, do_getaddrinfo, arg) != 0) {
         free_getaddrinfo_arg(arg);
-        return EAGAIN;
+        return EAI_AGAIN;
     }
 
     pthread_detach(th);
@@ -499,7 +499,7 @@ start:
             if (err == 0) *ai = arg->ai;
         }
         else if (arg->cancelled) {
-            err = EAGAIN;
+            err = EAI_AGAIN;
         }
         else {
             // If already interrupted, rb_thread_call_without_gvl2 may return without calling wait_getaddrinfo.
@@ -691,13 +691,13 @@ start:
 
     arg = allocate_getnameinfo_arg(sa, salen, hostlen, servlen, flags);
     if (!arg) {
-        return ENOMEM;
+        return EAI_MEMORY;
     }
 
     pthread_t th;
     if (pthread_create(&th, 0, do_getnameinfo, arg) != 0) {
         free_getnameinfo_arg(arg);
-        return EAGAIN;
+        return EAI_AGAIN;
     }
 
     pthread_detach(th);
@@ -720,7 +720,7 @@ start:
         }
     }
     else if (arg->cancelled) {
-        err = EAGAIN;
+        err = EAI_AGAIN;
     }
     else {
         // If already interrupted, rb_thread_call_without_gvl2 may return without calling wait_getnameinfo.

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -18,7 +18,7 @@
 #ifndef GETADDRINFO_IMPL
 #  ifdef GETADDRINFO_EMU
 #    define GETADDRINFO_IMPL 0
-#  elif !defined(HAVE_PTHREAD_CREATE) || !defined(HAVE_PTHREAD_DETACH)
+#  elif !defined(HAVE_PTHREAD_CREATE) || !defined(HAVE_PTHREAD_DETACH) || defined(__MINGW32__) || defined(__MINGW64__)
 #    define GETADDRINFO_IMPL 1
 #  else
 #    define GETADDRINFO_IMPL 2


### PR DESCRIPTION
When pthread_create is available, rb_getaddrinfo creates a pthread and
executes getaddrinfo(3) in it. The caller thread waits for the pthread
to complete, but detaches it if interrupted. This allows name resolution
to be interuppted by Timeout.timeout, etc. even if it takes a long time
(for example, when the DNS server does not respond).