### PR TITLE
YJIT: Add --yjit-perf

### DIFF
--- a/doc/yjit/yjit.md
+++ b/doc/yjit/yjit.md
@@ -173,6 +173,7 @@ compiled, lower values mean less code is compiled (default 200000)
 - `--yjit-trace-exits`: produce a Marshal dump of backtraces from specific exits. Automatically enables `--yjit-stats`
 - `--yjit-max-versions=N`: maximum number of versions to generate per basic block (default 4)
 - `--yjit-greedy-versioning`: greedy versioning mode (disabled by default, may increase code size)
+- `--yjit-perf`: Enable frame pointers and perf profiling
 
 Note that there is also an environment variable `RUBY_YJIT_ENABLE` which can be used to enable YJIT.
 This can be useful for some deployment scripts where specifying an extra command-line option to Ruby is not practical.
@@ -428,3 +429,30 @@ While in your i386 shell, install Cargo and Homebrew, then hack away!
 2. Cargo will install in $HOME/.cargo by default, and I don't know a good way to change architectures after install
 
 If you use Fish shell you can [read this link](https://tenderlovemaking.com/2022/01/07/homebrew-rosetta-and-ruby.html) for information on making the dev environment easier.
+
+## Profiling with Linux perf
+
+`--yjit-perf` allows you to profile JIT-ed methods along with other native functions using Linux perf.
+When you run Ruby with `perf record`, perf looks up `/tmp/perf-{pid}.map` to resolve symbols in JIT code,
+and this option lets YJIT write method symbols into that file as well as enabling frame pointers.
+
+Here's an example way to use this option with [Firefox Profiler](https://profiler.firefox.com)
+(See also: [Profiling with Linux perf](https://profiler.firefox.com/docs/#/./guide-perf-profiling)):
+
+```bash
+# Compile the interpreter with frame pointers enabled
+./configure --enable-yjit --prefix=$HOME/.rubies/ruby-yjit --disable-install-doc cflags=-fno-omit-frame-pointer
+make -j && make install
+
+# [Optional] Allow running perf without sudo
+echo 0 | sudo tee /proc/sys/kernel/kptr_restrict
+echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
+
+# Profile Ruby with --yjit-perf
+cd ../yjit-bench
+perf record --call-graph fp -- ruby --yjit-perf -Iharness-perf benchmarks/liquid-render/benchmark.rb
+
+# View results on Firefox Profiler https://profiler.firefox.com.
+# Create /tmp/test.perf as below and upload it using "Load a profile from file".
+perf script --fields +pid > /tmp/test.perf
+```

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -323,7 +323,6 @@ impl CodeBlock {
     }
 
     /// Return the address ranges of a given address range that this CodeBlock can write.
-    #[cfg(any(feature = "disasm", target_arch = "aarch64"))]
     #[allow(dead_code)]
     pub fn writable_addrs(&self, start_ptr: CodePtr, end_ptr: CodePtr) -> Vec<(usize, usize)> {
         let region_start = self.get_ptr(0).into_usize();

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -498,8 +498,21 @@ impl Assembler
                     cb.write_byte(0);
                 },
 
-                Insn::FrameSetup => {},
-                Insn::FrameTeardown => {},
+                // Set up RBP to work with frame pointer unwinding
+                // (e.g. with Linux `perf record --call-graph fp`)
+                Insn::FrameSetup => {
+                    if get_option!(frame_pointer) {
+                        push(cb, RBP);
+                        mov(cb, RBP, RSP);
+                        push(cb, RBP);
+                    }
+                },
+                Insn::FrameTeardown => {
+                    if get_option!(frame_pointer) {
+                        pop(cb, RBP);
+                        pop(cb, RBP);
+                    }
+                },
 
                 Insn::Add { left, right, .. } => {
                     let opnd1 = emit_64bit_immediate(cb, right);

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -577,7 +577,6 @@ pub fn rust_str_to_sym(str: &str) -> VALUE {
 }
 
 /// Produce an owned Rust String from a C char pointer
-#[cfg(feature = "disasm")]
 pub fn cstr_to_rust_string(c_char_ptr: *const c_char) -> Option<String> {
     assert!(c_char_ptr != std::ptr::null());
 

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -206,7 +206,7 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
                 OPTIONS.perf_map = true;
             },
             "fp" => unsafe { OPTIONS.frame_pointer = true },
-            "maps" => unsafe { OPTIONS.perf_map = true },
+            "map" => unsafe { OPTIONS.perf_map = true },
             _ => return None,
          },
 

--- a/yjit/src/utils.rs
+++ b/yjit/src/utils.rs
@@ -73,7 +73,7 @@ pub(crate) use offset_of;
 // Convert a CRuby UTF-8-encoded RSTRING into a Rust string.
 // This should work fine on ASCII strings and anything else
 // that is considered legal UTF-8, including embedded nulls.
-fn ruby_str_to_rust(v: VALUE) -> String {
+pub fn ruby_str_to_rust(v: VALUE) -> String {
     let str_ptr = unsafe { rb_RSTRING_PTR(v) } as *mut u8;
     let str_len: usize = unsafe { rb_RSTRING_LEN(v) }.try_into().unwrap();
     let str_slice: &[u8] = unsafe { slice::from_raw_parts(str_ptr, str_len) };

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -72,6 +72,13 @@ pub extern "C" fn rb_yjit_init_rust() {
         println!("YJIT: rb_yjit_init_rust() panicked. Aborting.");
         std::process::abort();
     }
+
+    // Make sure --yjit-perf doesn't append symbols to an old file
+    if get_option!(perf_map) {
+        let perf_map = format!("/tmp/perf-{}.map", std::process::id());
+        let _ = std::fs::remove_file(&perf_map);
+        println!("YJIT perf map: {perf_map}");
+    }
 }
 
 /// At the moment, we abort in all cases we panic.


### PR DESCRIPTION
This PR puts together Alan's [yjit-linux-perf-c-cf-push-self-time](https://github.com/XrXr/ruby/tree/yjit-linux-perf-c-cf-push-self-time) and [yjit-x64-frame-pointer](https://github.com/XrXr/ruby/tree/yjit-x64-frame-pointer) branches, changes the symbols to method names, and wraps them with a `--yjit-perf` option.

`--yjit-perf` enables the following two features:

* frame_pointer: It sets up RBP register on x86_64. (Arm64 sets up X29 by default)
* perf_map: Writes address ranges for each method on `/tmp/perf-{pid}.map`, which Linux perf

Each of them has an undocumented suboption `--yjit-perf=fp` and `--yjit-perf=map` to enable only part of them, but it's for YJIT developers and users are supposed to use `--yjit-perf`.

This should enable profiling JIT-ed code with Linux perf, including caller frames. 