### PR TITLE
Revert "Make attr_index_t uint8_t"

### DIFF
--- a/rjit_c.rb
+++ b/rjit_c.rb
@@ -898,7 +898,7 @@ module RubyVM::RJIT # :nodoc: all
   end
 
   def C.attr_index_t
-    @attr_index_t ||= CType::Immediate.parse("uint8_t")
+    @attr_index_t ||= CType::Immediate.parse("uint32_t")
   end
 
   def C.iseq_inline_constant_cache
@@ -1479,7 +1479,7 @@ module RubyVM::RJIT # :nodoc: all
       edges: [CType::Pointer.new { self.rb_id_table }, Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), edges)")],
       edge_name: [self.ID, Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), edge_name)")],
       next_iv_index: [self.attr_index_t, Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), next_iv_index)")],
-      capacity: [self.attr_index_t, Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), capacity)")],
+      capacity: [CType::Immediate.parse("uint32_t"), Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), capacity)")],
       type: [CType::Immediate.parse("uint8_t"), Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), type)")],
       size_pool_index: [CType::Immediate.parse("uint8_t"), Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), size_pool_index)")],
       parent_id: [self.shape_id_t, Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), parent_id)")],

--- a/shape.h
+++ b/shape.h
@@ -6,11 +6,12 @@
 #if (SIZEOF_UINT64_T <= SIZEOF_VALUE)
 #define SIZEOF_SHAPE_T 4
 #define SHAPE_IN_BASIC_FLAGS 1
+typedef uint32_t attr_index_t;
 #else
 #define SIZEOF_SHAPE_T 2
 #define SHAPE_IN_BASIC_FLAGS 0
+typedef uint16_t attr_index_t;
 #endif
-typedef uint8_t attr_index_t;
 
 #define MAX_IVARS (attr_index_t)(-1)
 
@@ -43,7 +44,7 @@ struct rb_shape {
     struct rb_id_table * edges; // id_table from ID (ivar) to next shape
     ID edge_name; // ID (ivar) for transition from parent to rb_shape
     attr_index_t next_iv_index;
-    attr_index_t capacity; // Total capacity of the object with this shape
+    uint32_t capacity; // Total capacity of the object with this shape
     uint8_t type;
     uint8_t size_pool_index;
     shape_id_t parent_id;

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -413,6 +413,18 @@ class TestVariable < Test::Unit::TestCase
     assert_equal(%i(v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11), v, bug11674)
   end
 
+  def test_many_instance_variables
+    objects = [Object.new, Hash.new, Module.new]
+    objects.each do |obj|
+      1000.times do |i|
+        obj.instance_variable_set("@var#{i}", i)
+      end
+      1000.times do |i|
+        assert_equal(i, obj.instance_variable_get("@var#{i}"))
+      end
+    end
+  end
+
   private
   def with_kwargs_11(v1:, v2:, v3:, v4:, v5:, v6:, v7:, v8:, v9:, v10:, v11:)
     local_variables

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2264,7 +2264,7 @@ fn gen_get_ivar(
     let ivar_index = unsafe {
         let shape_id = comptime_receiver.shape_id_of();
         let shape = rb_shape_get_shape_by_id(shape_id);
-        let mut ivar_index: u8 = 0;
+        let mut ivar_index: u32 = 0;
         if rb_shape_get_iv_index(shape, ivar_name, &mut ivar_index) {
             Some(ivar_index as usize)
         } else {
@@ -2450,7 +2450,7 @@ fn gen_setinstancevariable(
     let ivar_index = if !shape_too_complex {
         let shape_id = comptime_receiver.shape_id_of();
         let shape = unsafe { rb_shape_get_shape_by_id(shape_id) };
-        let mut ivar_index: u8 = 0;
+        let mut ivar_index: u32 = 0;
         if unsafe { rb_shape_get_iv_index(shape, ivar_name, &mut ivar_index) } {
             Some(ivar_index as usize)
         } else {
@@ -2717,7 +2717,7 @@ fn gen_definedivar(
     let shape_id = comptime_receiver.shape_id_of();
     let ivar_exists = unsafe {
         let shape = rb_shape_get_shape_by_id(shape_id);
-        let mut ivar_index: u8 = 0;
+        let mut ivar_index: u32 = 0;
         rb_shape_get_iv_index(shape, ivar_name, &mut ivar_index)
     };
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -588,7 +588,7 @@ pub const VM_ENV_FLAG_ESCAPED: vm_frame_env_flags = 4;
 pub const VM_ENV_FLAG_WB_REQUIRED: vm_frame_env_flags = 8;
 pub const VM_ENV_FLAG_ISOLATED: vm_frame_env_flags = 16;
 pub type vm_frame_env_flags = u32;
-pub type attr_index_t = u8;
+pub type attr_index_t = u32;
 pub type shape_id_t = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -596,7 +596,7 @@ pub struct rb_shape {
     pub edges: *mut rb_id_table,
     pub edge_name: ID,
     pub next_iv_index: attr_index_t,
-    pub capacity: attr_index_t,
+    pub capacity: u32,
     pub type_: u8,
     pub size_pool_index: u8,
     pub parent_id: shape_id_t,


### PR DESCRIPTION
We ran into a bug at GitHub in a module with hundreds of ivars. We traced the bug back to this commit: https://github.com/ruby/ruby/commit/e3afc212ec059525fe4e5387b2a3be920ffe0f0e. The assumption about maximum ivars in https://github.com/ruby/ruby/pull/8618 didn't seem to hold for Modules or object like Hashes.