### PR TITLE
Expand OP_ASGN1 nd_args to nd_index and nd_rvalue

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -480,8 +480,8 @@ node_children(rb_ast_t *ast, const NODE *node)
       case NODE_OP_ASGN1:
         return rb_ary_new_from_args(4, NEW_CHILD(ast, RNODE_OP_ASGN1(node)->nd_recv),
                                     ID2SYM(RNODE_OP_ASGN1(node)->nd_mid),
-                                    NEW_CHILD(ast, RNODE_ARGSCAT(RNODE_OP_ASGN1(node)->nd_args)->nd_head),
-                                    NEW_CHILD(ast, RNODE_ARGSCAT(RNODE_OP_ASGN1(node)->nd_args)->nd_body));
+                                    NEW_CHILD(ast, RNODE_OP_ASGN1(node)->nd_index),
+                                    NEW_CHILD(ast, RNODE_OP_ASGN1(node)->nd_rvalue));
       case NODE_OP_ASGN2:
         return rb_ary_new_from_args(5, NEW_CHILD(ast, RNODE_OP_ASGN2(node)->nd_recv),
                                     RBOOL(RNODE_OP_ASGN2(node)->nd_aid),

--- a/compile.c
+++ b/compile.c
@@ -8713,7 +8713,7 @@ compile_op_asgn1(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node
     }
     asgnflag = COMPILE_RECV(ret, "NODE_OP_ASGN1 recv", node, RNODE_OP_ASGN1(node)->nd_recv);
     CHECK(asgnflag != -1);
-    switch (nd_type(RNODE_OP_ASGN1(node)->nd_args->nd_head)) {
+    switch (nd_type(RNODE_OP_ASGN1(node)->nd_index)) {
       case NODE_ZLIST:
         argc = INT2FIX(0);
         break;
@@ -8721,7 +8721,7 @@ compile_op_asgn1(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node
         boff = 1;
         /* fall through */
       default:
-        argc = setup_args(iseq, ret, RNODE_OP_ASGN1(node)->nd_args->nd_head, &flag, NULL);
+        argc = setup_args(iseq, ret, RNODE_OP_ASGN1(node)->nd_index, &flag, NULL);
         CHECK(!NIL_P(argc));
     }
     ADD_INSN1(ret, node, dupn, FIXNUM_INC(argc, 1 + boff));
@@ -8749,7 +8749,7 @@ compile_op_asgn1(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node
         }
         ADD_INSN(ret, node, pop);
 
-        CHECK(COMPILE(ret, "NODE_OP_ASGN1 args->body: ", RNODE_OP_ASGN1(node)->nd_args->nd_body));
+        CHECK(COMPILE(ret, "NODE_OP_ASGN1 nd_rvalue: ", RNODE_OP_ASGN1(node)->nd_rvalue));
         if (!popped) {
             ADD_INSN1(ret, node, setn, FIXNUM_INC(argc, 2+boff));
         }
@@ -8783,7 +8783,7 @@ compile_op_asgn1(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node
         ADD_LABEL(ret, lfin);
     }
     else {
-        CHECK(COMPILE(ret, "NODE_OP_ASGN1 args->body: ", RNODE_OP_ASGN1(node)->nd_args->nd_body));
+        CHECK(COMPILE(ret, "NODE_OP_ASGN1 nd_rvalue: ", RNODE_OP_ASGN1(node)->nd_rvalue));
         ADD_SEND(ret, node, id, INT2FIX(1));
         if (!popped) {
             ADD_INSN1(ret, node, setn, FIXNUM_INC(argc, 2+boff));

--- a/node_dump.c
+++ b/node_dump.c
@@ -466,13 +466,13 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
 
       case NODE_OP_ASGN1:
         ANN("array assignment with operator");
-        ANN("format: [nd_recv] [ [nd_args->nd_head] ] [nd_mid]= [nd_args->nd_body]");
+        ANN("format: [nd_recv] [ [nd_index] ] [nd_mid]= [nd_rvalue]");
         ANN("example: ary[1] += foo");
         F_NODE(nd_recv, RNODE_OP_ASGN1, "receiver");
         F_ID(nd_mid, RNODE_OP_ASGN1, "operator");
-        F_NODE(nd_args->nd_head, RNODE_OP_ASGN1, "index");
+        F_NODE(nd_index, RNODE_OP_ASGN1, "index");
         LAST_NODE;
-        F_NODE(nd_args->nd_body, RNODE_OP_ASGN1, "rvalue");
+        F_NODE(nd_rvalue, RNODE_OP_ASGN1, "rvalue");
         return;
 
       case NODE_OP_ASGN2:

--- a/parse.y
+++ b/parse.y
@@ -891,7 +891,7 @@ static rb_node_gasgn_t *rb_node_gasgn_new(struct parser_params *p, ID nd_vid, NO
 static rb_node_iasgn_t *rb_node_iasgn_new(struct parser_params *p, ID nd_vid, NODE *nd_value, const YYLTYPE *loc);
 static rb_node_cdecl_t *rb_node_cdecl_new(struct parser_params *p, ID nd_vid, NODE *nd_value, NODE *nd_else, const YYLTYPE *loc);
 static rb_node_cvasgn_t *rb_node_cvasgn_new(struct parser_params *p, ID nd_vid, NODE *nd_value, const YYLTYPE *loc);
-static rb_node_op_asgn1_t *rb_node_op_asgn1_new(struct parser_params *p, NODE *nd_recv, ID nd_mid, rb_node_argscat_t *nd_args, const YYLTYPE *loc);
+static rb_node_op_asgn1_t *rb_node_op_asgn1_new(struct parser_params *p, NODE *nd_recv, ID nd_mid, NODE *index, NODE *rvalue, const YYLTYPE *loc);
 static rb_node_op_asgn2_t *rb_node_op_asgn2_new(struct parser_params *p, NODE *nd_recv, NODE *nd_value, ID nd_vid, ID nd_mid, bool nd_aid, const YYLTYPE *loc);
 static rb_node_op_asgn_or_t *rb_node_op_asgn_or_new(struct parser_params *p, NODE *nd_head, NODE *nd_value, const YYLTYPE *loc);
 static rb_node_op_asgn_and_t *rb_node_op_asgn_and_new(struct parser_params *p, NODE *nd_head, NODE *nd_value, const YYLTYPE *loc);
@@ -992,7 +992,7 @@ static rb_node_error_t *rb_node_error_new(struct parser_params *p, const YYLTYPE
 #define NEW_IASGN(v,val,loc) (NODE *)rb_node_iasgn_new(p,v,val,loc)
 #define NEW_CDECL(v,val,path,loc) (NODE *)rb_node_cdecl_new(p,v,val,path,loc)
 #define NEW_CVASGN(v,val,loc) (NODE *)rb_node_cvasgn_new(p,v,val,loc)
-#define NEW_OP_ASGN1(r,id,a,loc) (NODE *)rb_node_op_asgn1_new(p,r,id,a,loc)
+#define NEW_OP_ASGN1(r,id,idx,rval,loc) (NODE *)rb_node_op_asgn1_new(p,r,id,idx,rval,loc)
 #define NEW_OP_ASGN2(r,t,i,o,val,loc) (NODE *)rb_node_op_asgn2_new(p,r,val,i,o,t,loc)
 #define NEW_OP_ASGN_OR(i,val,loc) (NODE *)rb_node_op_asgn_or_new(p,i,val,loc)
 #define NEW_OP_ASGN_AND(i,val,loc) (NODE *)rb_node_op_asgn_and_new(p,i,val,loc)
@@ -11720,12 +11720,13 @@ rb_node_cvasgn_new(struct parser_params *p, ID nd_vid, NODE *nd_value, const YYL
 }
 
 static rb_node_op_asgn1_t *
-rb_node_op_asgn1_new(struct parser_params *p, NODE *nd_recv, ID nd_mid, rb_node_argscat_t *nd_args, const YYLTYPE *loc)
+rb_node_op_asgn1_new(struct parser_params *p, NODE *nd_recv, ID nd_mid, NODE *index, NODE *rvalue, const YYLTYPE *loc)
 {
     rb_node_op_asgn1_t *n = NODE_NEWNODE(NODE_OP_ASGN1, rb_node_op_asgn1_t, loc);
     n->nd_recv = nd_recv;
     n->nd_mid = nd_mid;
-    n->nd_args = nd_args;
+    n->nd_index = index;
+    n->nd_rvalue = rvalue;
 
     return n;
 }
@@ -14714,13 +14715,7 @@ new_ary_op_assign(struct parser_params *p, NODE *ary,
     NODE *asgn;
 
     args = make_list(args, args_loc);
-    if (nd_type_p(args, NODE_BLOCK_PASS)) {
-        args = NEW_ARGSCAT(args, rhs, loc);
-    }
-    else {
-        args = arg_concat(p, args, rhs, loc);
-    }
-    asgn = NEW_OP_ASGN1(ary, op, (rb_node_argscat_t *)args, loc);
+    asgn = NEW_OP_ASGN1(ary, op, args, rhs, loc);
     fixpos(asgn, ary);
     return asgn;
 }

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -402,7 +402,8 @@ typedef struct RNode_OP_ASGN1 {
 
     struct RNode *nd_recv;
     ID nd_mid;
-    struct RNode_ARGSCAT *nd_args;
+    struct RNode *nd_index;
+    struct RNode *nd_rvalue;
 } rb_node_op_asgn1_t;
 
 typedef struct RNode_OP_ASGN2 {


### PR DESCRIPTION
ARGSCAT has been used for nd_args to hold index and rvalue, because there was limitation on the number of members for Node. We can easily change structure of node now, let's expand it.