### PR TITLE
Optimization of `Range#overlap?` for beginless ranges

### DIFF
--- a/benchmark/range_overlap.yml
+++ b/benchmark/range_overlap.yml
@@ -16,4 +16,5 @@ benchmark:
   - (2..3).overlap?(...1)
   - (2...3).overlap?(..2)
   - (2...3).overlap?(3...)
+  - (..2).overlap?(2..3)
   - (2..3).overlap?('a'..'d')

--- a/range.c
+++ b/range.c
@@ -2421,7 +2421,7 @@ range_overlap(VALUE range, VALUE other)
     if (empty_region_p(other_beg, self_end, self_excl)) return Qfalse;
 
     /* if both begin values are equal, no more comparisons needed */
-    if (rb_equal(self_beg, other_beg)) return Qtrue;
+    if (NIL_P(self_beg) == NIL_P(other_beg) && rb_equal(self_beg, other_beg)) return Qtrue;
 
     if (empty_region_p(self_beg, self_end, self_excl)) return Qfalse;
     if (empty_region_p(other_beg, other_end, other_excl)) return Qfalse;


### PR DESCRIPTION
This PR optimizes `Range#overlap?` for the forms `(b..e).overlap?(..e2)` and `(..e).overlap?(b2..e2)`.

If one of `self_beg` or `other_beg` is `nil` and the other is not, `rb_equal(self_beg, other_beg)` will not evaluate to true.
Therefore, by checking for `nil` beforehand, it is possible to skip the call of `rb_equal`.


# benchmark

As shown below, `(2...3).overlap?(..2)` has become more than 3x faster.

Iteration per second (i/s)

|                           |c2d4c92a98|PR|
|:--------------------------|----------------------------------:|------------------------:|
|(2..3).overlap?(1..1)      |                            23.342M|                  23.232M|
|                           |                              1.00x|                        -|
|(2..3).overlap?(2..4)      |                            15.624M|                  15.864M|
|                           |                                  -|                    1.02x|
|(2..3).overlap?(4..5)      |                            15.520M|                  15.127M|
|                           |                              1.03x|                        -|
|(2..3).overlap?(2..1)      |                            22.793M|                  23.066M|
|                           |                                  -|                    1.01x|
|(2..3).overlap?(0..1)      |                            23.210M|                  23.018M|
|                           |                              1.01x|                        -|
|(2..3).overlap?(...1)      |                            23.251M|                  23.019M|
|                           |                              1.01x|                        -|
|(2...3).overlap?(..2)      |                             6.022M|                  23.327M|
|                           |                                  -|                    3.87x|
|(2...3).overlap?(3...)     |                            22.854M|                  23.070M|
|                           |                                  -|                    1.01x|
|(..2).overlap?(2..3)       |                            14.195M|                  22.794M|
|                           |                                  -|                    1.61x|
|(2..3).overlap?('a'..'d')  |                            15.156M|                  14.903M|
|                           |                              1.02x|                        -|


While `(..2).overlap?(2..3)` has a smaller improvement margin than `(2...3).overlap?(..2)`, it seems that this is because `rb_equal(Qnil, INT2FIX(2))` is faster than `rb_equal(INT2FIX(2), Qnil)`.
