### PR TITLE
[DOC] Indentation fix in comments of MatchData#inspect

### DIFF
--- a/re.c
+++ b/re.c
@@ -2489,10 +2489,10 @@ match_inspect_name_iter(const OnigUChar *name, const OnigUChar *name_end,
 }
 
 /*
- * call-seq:
- *   inspect -> string
+ *  call-seq:
+ *    inspect -> string
  *
- * Returns a string representation of +self+:
+ *  Returns a string representation of +self+:
  *
  *    m = /.$/.match("foo")
  *    # => #<MatchData "o">
@@ -2507,7 +2507,6 @@ match_inspect_name_iter(const OnigUChar *name, const OnigUChar *name_end,
  *    m.inspect # => "#<MatchData \"fo\" 1:\"f\" 2:nil 3:\"o\">"
  *
  *  Related: MatchData#to_s.
- *
  */
 
 static VALUE


### PR DESCRIPTION
The old version did not add syntax highlighting to the code block, and included the "Related:" line in the code block as well.