### PR TITLE
[Prism] Compile ForNode

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -968,7 +968,7 @@ rb_iseq_compile_node(rb_iseq_t *iseq, const NODE *node)
     return iseq_setup(iseq, ret);
 }
 
-static VALUE rb_translate_prism(rb_iseq_t *iseq, const pm_scope_node_t *scope_node, LINK_ANCHOR *const ret);
+static VALUE rb_translate_prism(pm_parser_t *parser, rb_iseq_t *iseq, pm_scope_node_t *scope_node, LINK_ANCHOR *const ret);
 
 VALUE
 rb_iseq_compile_prism_node(rb_iseq_t * iseq, pm_scope_node_t *scope_node, pm_parser_t *parser)
@@ -976,24 +976,7 @@ rb_iseq_compile_prism_node(rb_iseq_t * iseq, pm_scope_node_t *scope_node, pm_par
     DECL_ANCHOR(ret);
     INIT_ANCHOR(ret);
 
-    ID *constants = calloc(parser->constant_pool.size, sizeof(ID));
-    rb_encoding *encoding = rb_enc_find(parser->encoding.name);
-
-    for (uint32_t index = 0; index < parser->constant_pool.size; index++) {
-        pm_constant_t *constant = &parser->constant_pool.constants[index];
-        constants[index] = rb_intern3((const char *) constant->start, constant->length, encoding);
-    }
-
-    st_table *index_lookup_table = st_init_numtable();
-    pm_constant_id_list_t *locals = &scope_node->locals;
-    for (size_t i = 0; i < locals->size; i++) {
-        st_insert(index_lookup_table, locals->ids[i], i);
-    }
-
-    scope_node->constants = (void *)constants;
-    scope_node->index_lookup_table = index_lookup_table;
-    CHECK(rb_translate_prism(iseq, scope_node, ret));
-    free(constants);
+    CHECK(rb_translate_prism(parser, iseq, scope_node, ret));
 
     CHECK(iseq_setup_insn(iseq, ret));
     return iseq_setup(iseq, ret);

--- a/compile.c
+++ b/compile.c
@@ -984,8 +984,14 @@ rb_iseq_compile_prism_node(rb_iseq_t * iseq, pm_scope_node_t *scope_node, pm_par
         constants[index] = rb_intern3((const char *) constant->start, constant->length, encoding);
     }
 
-    scope_node->constants = constants;
+    st_table *index_lookup_table = st_init_numtable();
+    pm_constant_id_list_t *locals = &scope_node->locals;
+    for (size_t i = 0; i < locals->size; i++) {
+        st_insert(index_lookup_table, locals->ids[i], i);
+    }
 
+    scope_node->constants = (void *)constants;
+    scope_node->index_lookup_table = index_lookup_table;
     CHECK(rb_translate_prism(iseq, scope_node, ret));
     free(constants);
 

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1211,7 +1211,7 @@ pm_compile_defined_expr(rb_iseq_t *iseq, const pm_defined_node_t *defined_node, 
  *
  * iseq -            The current instruction sequence object (used for locals)
  * node -            The prism node to compile
- * ret -             The linked list of instruction sequences to append instructions onto
+ * ret -             The linked list of instructions to append instructions onto
  * popped -          True if compiling something with no side effects, so instructions don't
  *                   need to be added
  * scope_node - Stores parser and local information

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -48,6 +48,17 @@
 #define PM_SWAP_UNLESS_POPPED \
     if (!popped) PM_SWAP;
 
+/**
+ * We're using the top most bit of a pm_constant_id_t as a tag to represent an
+ * anonymous local. When a child iseq is created and needs access to a value
+ * that has yet to be defined, or is defined by the parent node's iseq. This can
+ * be added to it's local table and then handled accordingly when compiling the
+ * scope node associated with the child iseq.
+ *
+ * See the compilation process for PM_FOR_NODE: as an example, where the
+ * variable referenced inside the StatementsNode is defined as part of the top
+ * level ForLoop node.
+*/
 #define TEMP_CONSTANT_IDENTIFIER ((pm_constant_id_t)(1 << 31))
 
 rb_iseq_t *
@@ -2951,7 +2962,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             pm_constant_id_t constant_id = locals.ids[i];
             ID local;
             if (constant_id & TEMP_CONSTANT_IDENTIFIER) {
-                local = rb_make_temporary_id(i);
+                // local = rb_make_temporary_id(i);
             } else {
                 local = pm_constant_id_lookup(scope_node, constant_id);
             }

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -535,6 +535,15 @@ module Prism
       assert_prism_eval("a = 0; while a != 1; a = a + 1; end")
     end
 
+    def test_ForNode
+      assert_prism_eval("for i in [1,2] do; i; end")
+      assert_prism_eval("for @i in [1,2] do; @i; end")
+      assert_prism_eval("for $i in [1,2] do; $i; end")
+
+      # TODO: multiple assignment in ForNode index
+      #assert_prism_eval("for i, j in {a: 'b'} do; i; j; end")
+    end
+
     ############################################################################
     #  Throws                                                                  #
     ############################################################################


### PR DESCRIPTION
Fixes https://github.com/ruby/prism/issues/1648

This currently supports ForNodes with a single instance variable. Multiple assigments aren't fully implemented yet.

eg.

```
for i, j in {a: 'b'} do
  puts i
  puts j
end
```

will result in a stack underflow. This is dependant on the implementation of `MultiTargetNode` (https://github.com/ruby/prism/issues/1646)