### PR TITLE
YJIT: On test_bug_19316, only check the result

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1160,7 +1160,7 @@ class TestYJIT < Test::Unit::TestCase
   def test_bug_19316
     n = 2 ** 64
     # foo's extra param and the splats are relevant
-    assert_compiles(<<~'RUBY', result: [[n, -n], [n, -n]])
+    assert_compiles(<<~'RUBY', result: [[n, -n], [n, -n]], exits: :any)
       def foo(_, a, b, c)
         [a & b, ~c]
       end


### PR DESCRIPTION
Because the `&` call checks for interrupts, the test was accidentally
timing dependent. Stop checking for exits.

[Bug #19921]
https://bugs.ruby-lang.org/issues/19921#note-16
