### PR TITLE
YJIT: Skip printing stats at exit if --yjit-disable

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1388,6 +1388,10 @@ class TestYJIT < Test::Unit::TestCase
     assert_no_exits('0xfff_ffff_ffff_ffff * 0x10')
   end
 
+  def test_disable_stats
+    assert_in_out_err(%w[--yjit-stats --yjit-disable])
+  end
+
   private
 
   def code_gc_helpers

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -515,7 +515,7 @@ pub extern "C" fn rb_yjit_stats_enabled_p(_ec: EcPtr, _ruby_self: VALUE) -> VALU
 /// Check if stats generation should print at exit
 #[no_mangle]
 pub extern "C" fn rb_yjit_print_stats_p(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
-    if get_option!(print_stats) {
+    if yjit_enabled_p() && get_option!(print_stats) {
         return Qtrue;
     } else {
         return Qfalse;


### PR DESCRIPTION
Currently, using `--yjit-stats --yjit-disable` and exiting the process without calling `RubyVM::YJIT.enable` fails as below:

```
$ ruby --yjit-disable --yjit-stats -e0
***YJIT: Printing YJIT statistics on exit***
<internal:yjit>:409:in `print_counters': undefined method `filter' for nil (NoMethodError)
        from <internal:yjit>:250:in `_print_stats_reasons'
        from <internal:yjit>:293:in `_print_stats'
        from <internal:yjit>:230:in `block in <module:YJIT>'
```

This PR makes it skip printing stats in that case.