### PR TITLE
Raise TypeError for bad IO::Buffer.map argument

### DIFF
--- a/io.c
+++ b/io.c
@@ -2871,7 +2871,7 @@ rb_io_descriptor(VALUE io)
     }
     else {
         VALUE fileno = rb_check_funcall(io, id_fileno, 0, NULL);
-        if (fileno != Qundef) {
+        if (!UNDEF_P(fileno)) {
             return RB_NUM2INT(fileno);
         }
     }

--- a/io.c
+++ b/io.c
@@ -2878,7 +2878,7 @@ rb_io_descriptor(VALUE io)
 
     rb_raise(rb_eTypeError, "expected IO or #fileno, %"PRIsVALUE" given", rb_obj_class(io));
 
-    return -1;
+    UNREACHABLE_RETURN(-1);
 }
 
 int

--- a/io.c
+++ b/io.c
@@ -2870,8 +2870,15 @@ rb_io_descriptor(VALUE io)
         return fptr->fd;
     }
     else {
-        return RB_NUM2INT(rb_funcall(io, id_fileno, 0));
+        VALUE fileno = rb_check_funcall(io, id_fileno, 0, NULL);
+        if (fileno != Qundef) {
+            return RB_NUM2INT(fileno);
+        }
     }
+
+    rb_raise(rb_eTypeError, "expected IO or #fileno, %"PRIsVALUE" given", rb_obj_class(io));
+
+    return -1;
 }
 
 int

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -80,7 +80,7 @@ class TestIOBuffer < Test::Unit::TestCase
   end
 
   def test_file_mapped_invalid
-    assert_raise NoMethodError do
+    assert_raise TypeError do
       IO::Buffer.map("foobar")
     end
   end


### PR DESCRIPTION
The previous behavior here was to simply extract from an IO or else blindly call #fileno. An object that was not IO and did not implement #fileno would cause NoMethodError, a bit confusing. This PR changes it to use a checked funcall and the eventual error is a TypeError.

cc @ioquatix 