### PR TITLE
Extract IO::Buffer.for string locking test

### DIFF
--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -102,17 +102,22 @@ class TestIOBuffer < Test::Unit::TestCase
     IO::Buffer.for(string) do |buffer|
       refute buffer.readonly?
 
-      # Cannot modify string as it's locked by the buffer:
-      assert_raise RuntimeError do
-        string[0] = "h"
-      end
-
       buffer.set_value(:U8, 0, "h".ord)
 
       # Buffer releases it's ownership of the string:
       buffer.free
 
       assert_equal "hello World", string
+    end
+  end
+
+  def test_string_mapped_buffer_locked
+    string = "Hello World"
+    IO::Buffer.for(string) do |buffer|
+      # Cannot modify string as it's locked by the buffer:
+      assert_raise RuntimeError do
+        string[0] = "h"
+      end
     end
   end
 


### PR DESCRIPTION
String locking with locktmp is not really part of the public API, and the test relies in a side effect of using it to protect the buffer. On other implementations without locktmp this does not fail. Separate into its own test so it can be excluded from public API expectations.

It might be worth discussing what parts of the internal String lock are actually public, specified behavior.