### PR TITLE
Speed up instance variable cache misses

### DIFF
--- a/benchmark/vm_ivar_ic_miss.yml
+++ b/benchmark/vm_ivar_ic_miss.yml
@@ -1,0 +1,20 @@
+prelude: |
+  class Foo
+    def initialize diverge
+      if diverge
+        @a = 1
+      end
+  
+      @a0 = @a1 = @a2 = @a3 = @a4 = @a5 = @a6 = @a7 = @a8 = @a9 = @a10 = @a11 = @a12 = @a13 = @a14 = @a15 = @a16 = @a17 = @a18 = @a19 = @a20 = @a21 = @a22 = @a23 = @a24 = @a25 = @a26 = @a27 = @a28 = @a29 = @a30 = @a31 = @a32 = @a33 = @a34 = @a35 = @a36 = @a37 = @a38 = @a39 = @a40 = @a41 = @a42 = @a43 = @a44 = @a45 = @a46 = @a47 = @a48 = @a49 = @a50 = @a51 = @a52 = @a53 = @a54 = @a55 = @a56 = @a57 = @a58 = @a59 = @a60 = @a61 = @a62 = @a63 = @a64 = @a65 = @a66 = @a67 = @a68 = @a69 = @a70 = @a71 = @a72 = @a73 = @a74 = @b = 1
+    end
+
+    def b; @b; end
+  end
+  
+  a = Foo.new false
+  b = Foo.new true
+benchmark:
+  vm_ivar_ic_miss: |
+    a.b
+    b.b
+loop_count: 30000000

--- a/benchmark/vm_ivar_ic_miss.yml
+++ b/benchmark/vm_ivar_ic_miss.yml
@@ -4,13 +4,13 @@ prelude: |
       if diverge
         @a = 1
       end
-  
+
       @a0 = @a1 = @a2 = @a3 = @a4 = @a5 = @a6 = @a7 = @a8 = @a9 = @a10 = @a11 = @a12 = @a13 = @a14 = @a15 = @a16 = @a17 = @a18 = @a19 = @a20 = @a21 = @a22 = @a23 = @a24 = @a25 = @a26 = @a27 = @a28 = @a29 = @a30 = @a31 = @a32 = @a33 = @a34 = @a35 = @a36 = @a37 = @a38 = @a39 = @a40 = @a41 = @a42 = @a43 = @a44 = @a45 = @a46 = @a47 = @a48 = @a49 = @a50 = @a51 = @a52 = @a53 = @a54 = @a55 = @a56 = @a57 = @a58 = @a59 = @a60 = @a61 = @a62 = @a63 = @a64 = @a65 = @a66 = @a67 = @a68 = @a69 = @a70 = @a71 = @a72 = @a73 = @a74 = @b = 1
     end
 
     def b; @b; end
   end
-  
+
   a = Foo.new false
   b = Foo.new true
 benchmark:

--- a/gc.c
+++ b/gc.c
@@ -3533,9 +3533,13 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
       case T_CLASS:
         rb_id_table_free(RCLASS_M_TBL(obj));
         cc_table_free(objspace, obj, FALSE);
-        if (RCLASS_IVPTR(obj)) {
+        if (rb_shape_obj_too_complex(obj)) {
+            st_free_table((st_table *)RCLASS_IVPTR(obj));
+        }
+        else if (RCLASS_IVPTR(obj)) {
             xfree(RCLASS_IVPTR(obj));
         }
+
         if (RCLASS_CONST_TBL(obj)) {
             rb_free_const_table(RCLASS_CONST_TBL(obj));
         }
@@ -7256,8 +7260,13 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
         mark_m_tbl(objspace, RCLASS_M_TBL(obj));
         mark_cvc_tbl(objspace, obj);
         cc_table_mark(objspace, obj);
-        for (attr_index_t i = 0; i < RCLASS_IV_COUNT(obj); i++) {
-            gc_mark(objspace, RCLASS_IVPTR(obj)[i]);
+        if (rb_shape_obj_too_complex(obj)) {
+            mark_tbl(objspace, (st_table *)RCLASS_IVPTR(obj));
+        }
+        else {
+            for (attr_index_t i = 0; i < RCLASS_IV_COUNT(obj); i++) {
+                gc_mark(objspace, RCLASS_IVPTR(obj)[i]);
+            }
         }
         mark_const_tbl(objspace, RCLASS_CONST_TBL(obj));
 

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -48,6 +48,7 @@ VALUE rb_mod_set_temporary_name(VALUE, VALUE);
 struct gen_ivtbl;
 int rb_gen_ivtbl_get(VALUE obj, ID id, struct gen_ivtbl **ivtbl);
 int rb_obj_evacuate_ivs_to_hash_table(ID key, VALUE val, st_data_t arg);
+void rb_evict_ivars_to_hash(VALUE obj, rb_shape_t * shape);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* variable.c (export) */

--- a/object.c
+++ b/object.c
@@ -463,7 +463,13 @@ mutable_obj_clone(VALUE obj, VALUE kwfreeze)
         rb_funcall(clone, id_init_clone, 1, obj);
         RBASIC(clone)->flags |= RBASIC(obj)->flags & FL_FREEZE;
         if (RB_OBJ_FROZEN(obj)) {
-            rb_shape_transition_shape_frozen(clone);
+            rb_shape_t * next_shape = rb_shape_transition_shape_frozen(clone);
+            if (!rb_shape_obj_too_complex(clone) && next_shape->type == SHAPE_OBJ_TOO_COMPLEX) {
+                rb_evict_ivars_to_hash(clone, rb_shape_get_shape(clone));
+            }
+            else {
+                rb_shape_set_shape(clone, next_shape);
+            }
         }
         break;
       case Qtrue: {
@@ -479,7 +485,15 @@ mutable_obj_clone(VALUE obj, VALUE kwfreeze)
         argv[1] = freeze_true_hash;
         rb_funcallv_kw(clone, id_init_clone, 2, argv, RB_PASS_KEYWORDS);
         RBASIC(clone)->flags |= FL_FREEZE;
-        rb_shape_transition_shape_frozen(clone);
+        rb_shape_t * next_shape = rb_shape_transition_shape_frozen(clone);
+        // If we're out of shapes, but we want to freeze, then we need to
+        // evacuate this clone to a hash
+        if (!rb_shape_obj_too_complex(clone) && next_shape->type == SHAPE_OBJ_TOO_COMPLEX) {
+            rb_evict_ivars_to_hash(clone, rb_shape_get_shape(clone));
+        }
+        else {
+            rb_shape_set_shape(clone, next_shape);
+        }
         break;
       }
       case Qfalse: {

--- a/rjit_c.rb
+++ b/rjit_c.rb
@@ -1483,6 +1483,7 @@ module RubyVM::RJIT # :nodoc: all
       type: [CType::Immediate.parse("uint8_t"), Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), type)")],
       size_pool_index: [CType::Immediate.parse("uint8_t"), Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), size_pool_index)")],
       parent_id: [self.shape_id_t, Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), parent_id)")],
+      ancestor_index: [CType::Pointer.new { self.redblack_node_t }, Primitive.cexpr!("OFFSETOF((*((struct rb_shape *)NULL)), ancestor_index)")],
     )
   end
 
@@ -1639,6 +1640,10 @@ module RubyVM::RJIT # :nodoc: all
 
   def C._Bool
     CType::Bool.new
+  end
+
+  def C.redblack_node_t
+    CType::Stub.new(:redblack_node_t)
   end
 
   def C.ccan_list_node

--- a/shape.c
+++ b/shape.c
@@ -592,7 +592,7 @@ rb_shape_transition_shape_remove_ivar(VALUE obj, ID id, rb_shape_t *shape, VALUE
     }
 }
 
-void
+rb_shape_t *
 rb_shape_transition_shape_frozen(VALUE obj)
 {
     rb_shape_t* shape = rb_shape_get_shape(obj);
@@ -600,21 +600,23 @@ rb_shape_transition_shape_frozen(VALUE obj)
     RUBY_ASSERT(RB_OBJ_FROZEN(obj));
 
     if (rb_shape_frozen_shape_p(shape) || rb_shape_obj_too_complex(obj)) {
-        return;
+        return shape;
     }
 
     rb_shape_t* next_shape;
 
     if (shape == rb_shape_get_root_shape()) {
-        rb_shape_set_shape_id(obj, SPECIAL_CONST_SHAPE_ID);
-        return;
+        return rb_shape_get_shape_by_id(SPECIAL_CONST_SHAPE_ID);
     }
 
     bool dont_care;
     next_shape = get_next_shape_internal(shape, (ID)id_frozen, SHAPE_FROZEN, &dont_care, true, false);
 
+    if (!next_shape) {
+        next_shape = rb_shape_get_shape_by_id(OBJ_TOO_COMPLEX_SHAPE_ID);
+    }
     RUBY_ASSERT(next_shape);
-    rb_shape_set_shape(obj, next_shape);
+    return next_shape;
 }
 
 /*

--- a/shape.c
+++ b/shape.c
@@ -380,6 +380,7 @@ rb_shape_alloc(ID edge_name, rb_shape_t * parent, enum shape_type type)
     return shape;
 }
 
+#ifdef HAVE_MMAP
 static redblack_node_t *
 redblack_cache_ancestors(rb_shape_t * shape)
 {
@@ -407,6 +408,13 @@ redblack_cache_ancestors(rb_shape_t * shape)
         }
     }
 }
+#else
+static redblack_node_t *
+redblack_cache_ancestors(rb_shape_t * shape)
+{
+    return LEAF;
+}
+#endif
 
 static rb_shape_t *
 rb_shape_alloc_new_child(ID id, rb_shape_t * shape, enum shape_type shape_type)

--- a/shape.c
+++ b/shape.c
@@ -63,7 +63,10 @@ redblack_right(redblack_node_t * node)
 static redblack_node_t *
 redblack_find(redblack_node_t * tree, ID key)
 {
-    if (tree != LEAF) {
+    if (tree == LEAF) {
+        return LEAF;
+    }
+    else {
         if (tree->key == key) {
             return tree;
         }
@@ -75,9 +78,6 @@ redblack_find(redblack_node_t * tree, ID key)
                 return redblack_find(redblack_right(tree), key);
             }
         }
-    }
-    else {
-        return 0;
     }
 }
 

--- a/shape.h
+++ b/shape.h
@@ -17,10 +17,12 @@ typedef uint16_t attr_index_t;
 
 #if SIZEOF_SHAPE_T == 4
 typedef uint32_t shape_id_t;
+typedef uint32_t redblack_id_t;
 # define SHAPE_ID_NUM_BITS 32
 # define SHAPE_BUFFER_SIZE 0x80000
 #else
 typedef uint16_t shape_id_t;
+typedef uint16_t redblack_id_t;
 # define SHAPE_ID_NUM_BITS 16
 # define SHAPE_BUFFER_SIZE 0x8000
 #endif
@@ -40,6 +42,8 @@ typedef uint16_t shape_id_t;
 # define SPECIAL_CONST_SHAPE_ID (SIZE_POOL_COUNT * 2)
 # define OBJ_TOO_COMPLEX_SHAPE_ID (SPECIAL_CONST_SHAPE_ID + 1)
 
+typedef struct redblack_node redblack_node_t;
+
 struct rb_shape {
     struct rb_id_table * edges; // id_table from ID (ivar) to next shape
     ID edge_name; // ID (ivar) for transition from parent to rb_shape
@@ -48,9 +52,17 @@ struct rb_shape {
     uint8_t type;
     uint8_t size_pool_index;
     shape_id_t parent_id;
+    redblack_node_t * ancestor_index;
 };
 
 typedef struct rb_shape rb_shape_t;
+
+struct redblack_node {
+    ID key;
+    rb_shape_t * value;
+    redblack_id_t l;
+    redblack_id_t r;
+};
 
 enum shape_type {
     SHAPE_ROOT,
@@ -67,6 +79,9 @@ typedef struct {
     rb_shape_t *shape_list;
     rb_shape_t *root_shape;
     shape_id_t next_shape_id;
+
+    redblack_node_t *shape_cache;
+    unsigned int cache_size;
 } rb_shape_tree_t;
 RUBY_EXTERN rb_shape_tree_t *rb_shape_tree_ptr;
 

--- a/shape.h
+++ b/shape.h
@@ -4,28 +4,28 @@
 #include "internal/gc.h"
 
 #if (SIZEOF_UINT64_T <= SIZEOF_VALUE)
+
 #define SIZEOF_SHAPE_T 4
 #define SHAPE_IN_BASIC_FLAGS 1
 typedef uint32_t attr_index_t;
-#else
-#define SIZEOF_SHAPE_T 2
-#define SHAPE_IN_BASIC_FLAGS 0
-typedef uint16_t attr_index_t;
-#endif
-
-#define MAX_IVARS (attr_index_t)(-1)
-
-#if SIZEOF_SHAPE_T == 4
 typedef uint32_t shape_id_t;
 typedef uint32_t redblack_id_t;
 # define SHAPE_ID_NUM_BITS 32
 # define SHAPE_BUFFER_SIZE 0x80000
+
 #else
+
+#define SIZEOF_SHAPE_T 2
+#define SHAPE_IN_BASIC_FLAGS 0
+typedef uint16_t attr_index_t;
 typedef uint16_t shape_id_t;
 typedef uint16_t redblack_id_t;
 # define SHAPE_ID_NUM_BITS 16
 # define SHAPE_BUFFER_SIZE 0x8000
+
 #endif
+
+#define MAX_IVARS (attr_index_t)(-1)
 
 # define SHAPE_MASK (((uintptr_t)1 << SHAPE_ID_NUM_BITS) - 1)
 # define SHAPE_FLAG_MASK (((VALUE)-1) >> SHAPE_ID_NUM_BITS)
@@ -33,7 +33,7 @@ typedef uint16_t redblack_id_t;
 # define SHAPE_FLAG_SHIFT ((SIZEOF_VALUE * 8) - SHAPE_ID_NUM_BITS)
 
 # define SHAPE_MAX_VARIATIONS 8
-# define SHAPE_MAX_NUM_IVS 80
+# define SHAPE_MAX_NUM_IVS (SHAPE_BUFFER_SIZE - 1)
 
 # define MAX_SHAPE_ID SHAPE_BUFFER_SIZE
 # define INVALID_SHAPE_ID SHAPE_MASK

--- a/shape.h
+++ b/shape.h
@@ -33,7 +33,7 @@ typedef uint16_t redblack_id_t;
 # define SHAPE_FLAG_SHIFT ((SIZEOF_VALUE * 8) - SHAPE_ID_NUM_BITS)
 
 # define SHAPE_MAX_VARIATIONS 8
-# define SHAPE_MAX_NUM_IVS (SHAPE_BUFFER_SIZE - 1)
+# define SHAPE_MAX_NUM_IVS 80
 
 # define MAX_SHAPE_ID (SHAPE_BUFFER_SIZE - 1)
 # define INVALID_SHAPE_ID SHAPE_MASK
@@ -165,7 +165,7 @@ bool rb_shape_obj_too_complex(VALUE obj);
 void rb_shape_set_shape(VALUE obj, rb_shape_t* shape);
 rb_shape_t* rb_shape_get_shape(VALUE obj);
 int rb_shape_frozen_shape_p(rb_shape_t* shape);
-void rb_shape_transition_shape_frozen(VALUE obj);
+rb_shape_t* rb_shape_transition_shape_frozen(VALUE obj);
 void rb_shape_transition_shape_remove_ivar(VALUE obj, ID id, rb_shape_t *shape, VALUE * removed);
 rb_shape_t * rb_shape_transition_shape_capa(rb_shape_t * shape);
 rb_shape_t* rb_shape_get_next(rb_shape_t* shape, VALUE obj, ID id);

--- a/shape.h
+++ b/shape.h
@@ -35,7 +35,7 @@ typedef uint16_t redblack_id_t;
 # define SHAPE_MAX_VARIATIONS 8
 # define SHAPE_MAX_NUM_IVS (SHAPE_BUFFER_SIZE - 1)
 
-# define MAX_SHAPE_ID SHAPE_BUFFER_SIZE
+# define MAX_SHAPE_ID (SHAPE_BUFFER_SIZE - 1)
 # define INVALID_SHAPE_ID SHAPE_MASK
 # define ROOT_SHAPE_ID 0x0
 
@@ -191,7 +191,7 @@ ROBJECT_IV_HASH(VALUE obj)
 }
 
 static inline void
-ROBJECT_SET_IV_HASH(VALUE obj, const struct rb_id_table *tbl)
+ROBJECT_SET_IV_HASH(VALUE obj, const st_table *tbl)
 {
     RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
     RUBY_ASSERT(ROBJECT_SHAPE_ID(obj) == OBJ_TOO_COMPLEX_SHAPE_ID);

--- a/variable.c
+++ b/variable.c
@@ -72,6 +72,22 @@ struct ivar_update {
 #endif
 };
 
+static inline st_table *
+RCLASS_IV_HASH(VALUE obj)
+{
+    RUBY_ASSERT(RB_TYPE_P(obj, RUBY_T_CLASS) || RB_TYPE_P(obj, RUBY_T_MODULE));
+    RUBY_ASSERT(RCLASS_SHAPE_ID(obj) == OBJ_TOO_COMPLEX_SHAPE_ID);
+    return (st_table *)RCLASS_IVPTR(obj);
+}
+
+static inline void
+RCLASS_SET_IV_HASH(VALUE obj, const st_table *tbl)
+{
+    RUBY_ASSERT(RB_TYPE_P(obj, RUBY_T_CLASS) || RB_TYPE_P(obj, RUBY_T_MODULE));
+    RUBY_ASSERT(RCLASS_SHAPE_ID(obj) == OBJ_TOO_COMPLEX_SHAPE_ID);
+    RCLASS_IVPTR(obj) = (VALUE *)tbl;
+}
+
 void
 Init_var_tables(void)
 {
@@ -1231,7 +1247,7 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
       case T_CLASS:
       case T_MODULE:
         {
-            bool found;
+            bool found = false;
             VALUE val;
 
             RB_VM_LOCK_ENTER();
@@ -1240,18 +1256,30 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
                 shape_id = RCLASS_SHAPE_ID(obj);
 #endif
 
-                attr_index_t index = 0;
-                shape = rb_shape_get_shape_by_id(shape_id);
-                found = rb_shape_get_iv_index(shape, id, &index);
-
-                if (found) {
-                    ivar_list = RCLASS_IVPTR(obj);
-                    RUBY_ASSERT(ivar_list);
-
-                    val = ivar_list[index];
+                if (rb_shape_obj_too_complex(obj)) {
+                    st_table * iv_table = RCLASS_IV_HASH(obj);
+                    if (rb_st_lookup(iv_table, (st_data_t)id, (st_data_t *)&val)) {
+                        found = true;
+                    }
+                    else {
+                        val = undef;
+                    }
                 }
                 else {
-                    val = undef;
+
+                    attr_index_t index = 0;
+                    shape = rb_shape_get_shape_by_id(shape_id);
+                    found = rb_shape_get_iv_index(shape, id, &index);
+
+                    if (found) {
+                        ivar_list = RCLASS_IVPTR(obj);
+                        RUBY_ASSERT(ivar_list);
+
+                        val = ivar_list[index];
+                    }
+                    else {
+                        val = undef;
+                    }
                 }
             }
             RB_VM_LOCK_LEAVE();
@@ -1439,6 +1467,60 @@ rb_ensure_generic_iv_list_size(VALUE obj, rb_shape_t *shape, uint32_t newsize)
     return ivtbl;
 }
 
+static int
+rb_complex_ivar_set(VALUE obj, ID id, VALUE val)
+{
+    st_table * table;
+    RUBY_ASSERT(rb_shape_obj_too_complex(obj));
+
+    switch (BUILTIN_TYPE(obj)) {
+      case T_OBJECT:
+        table = ROBJECT_IV_HASH(obj);
+        break;
+      case T_CLASS:
+      case T_MODULE:
+        table = RCLASS_IV_HASH(obj);
+        break;
+      default:
+        rb_bug("oh no");
+    }
+
+    int found = st_insert(table, (st_data_t)id, (st_data_t)val);
+    RB_OBJ_WRITTEN(obj, Qundef, val);
+    return found;
+}
+
+static void
+rb_evict_ivars_to_hash(VALUE obj, rb_shape_t * shape)
+{
+    RUBY_ASSERT(!rb_shape_obj_too_complex(obj));
+
+    st_table * table = st_init_numtable_with_size(shape->next_iv_index);
+
+    // Evacuate all previous values from shape into id_table
+    rb_ivar_foreach(obj, rb_obj_evacuate_ivs_to_hash_table, (st_data_t)table);
+
+    rb_shape_set_too_complex(obj);
+    RUBY_ASSERT(rb_shape_obj_too_complex(obj));
+
+    switch (BUILTIN_TYPE(obj)) {
+      case T_OBJECT:
+        if (!(RBASIC(obj)->flags & ROBJECT_EMBED)) {
+            xfree(ROBJECT(obj)->as.heap.ivptr);
+        }
+
+        ROBJECT_SET_IV_HASH(obj, table);
+        break;
+      case T_CLASS:
+      case T_MODULE:
+        xfree(RCLASS_IVPTR(obj));
+        RCLASS_SET_IV_HASH(obj, table);
+        break;
+      default:
+        rb_bug("oops!");
+    }
+}
+
 // @note May raise when there are too many instance variables.
 rb_shape_t *
 rb_grow_iv_list(VALUE obj)
@@ -1446,10 +1528,13 @@ rb_grow_iv_list(VALUE obj)
     rb_shape_t * initial_shape = rb_shape_get_shape(obj);
     RUBY_ASSERT(initial_shape->capacity > 0);
     rb_shape_t * res = rb_shape_transition_shape_capa(initial_shape);
-
-    rb_ensure_iv_list_size(obj, initial_shape->capacity, res->capacity);
-
-    rb_shape_set_shape(obj, res);
+    if (res->type == SHAPE_OBJ_TOO_COMPLEX) { // Out of shapes
+        rb_evict_ivars_to_hash(obj, initial_shape);
+    }
+    else {
+        rb_ensure_iv_list_size(obj, initial_shape->capacity, res->capacity);
+        rb_shape_set_shape(obj, res);
+    }
 
     return res;
 }
@@ -1470,11 +1555,11 @@ rb_obj_ivar_set(VALUE obj, ID id, VALUE val)
     uint32_t num_iv = shape->capacity;
 
     if (rb_shape_obj_too_complex(obj)) {
-        st_table * table = ROBJECT_IV_HASH(obj);
-        st_insert(table, (st_data_t)id, (st_data_t)val);
-        RB_OBJ_WRITTEN(obj, Qundef, val);
+        rb_complex_ivar_set(obj, id, val);
         return 0;
     }
+
+    rb_shape_t *next_shape;
 
     if (!rb_shape_get_iv_index(shape, id, &index)) {
         index = shape->next_iv_index;
@@ -1487,31 +1572,20 @@ rb_obj_ivar_set(VALUE obj, ID id, VALUE val)
         if (UNLIKELY(shape->next_iv_index >= num_iv)) {
             RUBY_ASSERT(shape->next_iv_index == num_iv);
 
-            shape = rb_grow_iv_list(obj);
+            next_shape = rb_grow_iv_list(obj);
+            if (next_shape->type == SHAPE_OBJ_TOO_COMPLEX) {
+                rb_complex_ivar_set(obj, id, val);
+                return 0;
+            }
+            shape = next_shape;
             RUBY_ASSERT(shape->type == SHAPE_CAPACITY_CHANGE);
         }
 
-        rb_shape_t *next_shape = rb_shape_get_next(shape, obj, id);
+        next_shape = rb_shape_get_next(shape, obj, id);
 
         if (next_shape->type == SHAPE_OBJ_TOO_COMPLEX) {
-            st_table * table = st_init_numtable_with_size(shape->next_iv_index);
-
-            // Evacuate all previous values from shape into id_table
-            rb_ivar_foreach(obj, rb_obj_evacuate_ivs_to_hash_table, (st_data_t)table);
-
-            // Insert new value too
-            st_insert(table, (st_data_t)id, (st_data_t)val);
-            RB_OBJ_WRITTEN(obj, Qundef, val);
-
-            rb_shape_set_too_complex(obj);
-            RUBY_ASSERT(rb_shape_obj_too_complex(obj));
-
-            if (!(RBASIC(obj)->flags & ROBJECT_EMBED)) {
-                xfree(ROBJECT(obj)->as.heap.ivptr);
-            }
-
-            ROBJECT(obj)->as.heap.ivptr = (VALUE *)table;
-
+            rb_evict_ivars_to_hash(obj, shape);
+            rb_complex_ivar_set(obj, id, val);
             return 0;
         }
         else {
@@ -1765,7 +1839,13 @@ class_ivar_each(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg)
     struct iv_itr_data itr_data;
     itr_data.obj = obj;
     itr_data.arg = arg;
-    iterate_over_shapes_with_callback(shape, func, &itr_data);
+    itr_data.func = func;
+    if (rb_shape_obj_too_complex(obj)) {
+        rb_st_foreach(RCLASS_IV_HASH(obj), each_hash_iv, (st_data_t)&itr_data);
+    }
+    else {
+        iterate_over_shapes_with_callback(shape, func, &itr_data);
+    }
 }
 
 void
@@ -3989,40 +4069,50 @@ int
 rb_class_ivar_set(VALUE obj, ID key, VALUE value)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE));
-    int found;
+    int found = 0;
     rb_check_frozen(obj);
 
     RB_VM_LOCK_ENTER();
     {
         rb_shape_t * shape = rb_shape_get_shape(obj);
-        attr_index_t idx;
-        found = rb_shape_get_iv_index(shape, key, &idx);
-
-        if (found) {
-            // Changing an existing instance variable
-            RUBY_ASSERT(RCLASS_IVPTR(obj));
-
-            RCLASS_IVPTR(obj)[idx] = value;
-            RB_OBJ_WRITTEN(obj, Qundef, value);
+        if (shape->type == SHAPE_OBJ_TOO_COMPLEX) {
+            found = rb_complex_ivar_set(obj, key, value);
         }
         else {
-            // Creating and setting a new instance variable
+            attr_index_t idx;
+            found = rb_shape_get_iv_index(shape, key, &idx);
 
-            // Move to a shape which fits the new ivar
-            idx = shape->next_iv_index;
-            shape = rb_shape_get_next(shape, obj, key);
+            if (found) {
+                // Changing an existing instance variable
+                RUBY_ASSERT(RCLASS_IVPTR(obj));
 
-            // We always allocate a power of two sized IV array. This way we
-            // only need to realloc when we expand into a new power of two size
-            if ((idx & (idx - 1)) == 0) {
-                size_t newsize = idx ? idx * 2 : 1;
-                REALLOC_N(RCLASS_IVPTR(obj), VALUE, newsize);
+                RCLASS_IVPTR(obj)[idx] = value;
+                RB_OBJ_WRITTEN(obj, Qundef, value);
             }
+            else {
+                // Creating and setting a new instance variable
 
-            RUBY_ASSERT(RCLASS_IVPTR(obj));
+                // Move to a shape which fits the new ivar
+                idx = shape->next_iv_index;
+                rb_shape_t * next_shape = rb_shape_get_next(shape, obj, key);
+                if (next_shape->type == SHAPE_OBJ_TOO_COMPLEX) {
+                    rb_evict_ivars_to_hash(obj, shape);
+                    rb_complex_ivar_set(obj, key, value);
+                }
+                else {
+                    // We always allocate a power of two sized IV array. This way we
+                    // only need to realloc when we expand into a new power of two size
+                    if ((idx & (idx - 1)) == 0) {
+                        size_t newsize = idx ? idx * 2 : 1;
+                        REALLOC_N(RCLASS_IVPTR(obj), VALUE, newsize);
+                    }
 
-            RB_OBJ_WRITE(obj, &RCLASS_IVPTR(obj)[idx], value);
-            rb_shape_set_shape(obj, shape);
+                    RUBY_ASSERT(RCLASS_IVPTR(obj));
+
+                    RB_OBJ_WRITE(obj, &RCLASS_IVPTR(obj)[idx], value);
+                    rb_shape_set_shape(obj, next_shape);
+                }
+            }
         }
     }
     RB_VM_LOCK_LEAVE();

--- a/vm.c
+++ b/vm.c
@@ -633,6 +633,8 @@ rb_dtrace_setup(rb_execution_context_t *ec, VALUE klass, ID id,
     return FALSE;
 }
 
+extern unsigned int redblack_buffer_size;
+
 /*
  *  call-seq:
  *    RubyVM.stat -> Hash
@@ -660,6 +662,7 @@ static VALUE
 vm_stat(int argc, VALUE *argv, VALUE self)
 {
     static VALUE sym_constant_cache_invalidations, sym_constant_cache_misses, sym_global_cvar_state, sym_next_shape_id;
+    static VALUE sym_shape_cache_size;
     VALUE arg = Qnil;
     VALUE hash = Qnil, key = Qnil;
 
@@ -681,6 +684,7 @@ vm_stat(int argc, VALUE *argv, VALUE self)
     S(constant_cache_misses);
         S(global_cvar_state);
     S(next_shape_id);
+    S(shape_cache_size);
 #undef S
 
 #define SET(name, attr) \
@@ -693,6 +697,7 @@ vm_stat(int argc, VALUE *argv, VALUE self)
     SET(constant_cache_misses, ruby_vm_constant_cache_misses);
     SET(global_cvar_state, ruby_vm_global_cvar_state);
     SET(next_shape_id, (rb_serial_t)GET_SHAPE_TREE()->next_shape_id);
+    SET(shape_cache_size, (rb_serial_t)GET_SHAPE_TREE()->cache_size);
 #undef SET
 
 #if USE_DEBUG_COUNTER
@@ -3069,7 +3074,8 @@ vm_memsize(const void *ptr)
         vm_memsize_builtin_function_table(vm->builtin_function_table) +
         rb_id_table_memsize(vm->negative_cme_table) +
         rb_st_memsize(vm->overloaded_cme_table) +
-        vm_memsize_constant_cache()
+        vm_memsize_constant_cache() +
+        GET_SHAPE_TREE()->cache_size * sizeof(redblack_node_t)
     );
 
     // TODO

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -590,6 +590,8 @@ pub const VM_ENV_FLAG_ISOLATED: vm_frame_env_flags = 16;
 pub type vm_frame_env_flags = u32;
 pub type attr_index_t = u32;
 pub type shape_id_t = u32;
+pub type redblack_id_t = u32;
+pub type redblack_node_t = redblack_node;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct rb_shape {
@@ -600,8 +602,17 @@ pub struct rb_shape {
     pub type_: u8,
     pub size_pool_index: u8,
     pub parent_id: shape_id_t,
+    pub ancestor_index: *mut redblack_node_t,
 }
 pub type rb_shape_t = rb_shape;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct redblack_node {
+    pub key: ID,
+    pub value: *mut rb_shape_t,
+    pub l: redblack_id_t,
+    pub r: redblack_id_t,
+}
 #[repr(C)]
 pub struct rb_cvar_class_tbl_entry {
     pub index: u32,


### PR DESCRIPTION
This PR speeds up instance variable cache misses by introducing a red-black tree as a shape cache.  With the red-black tree, we can easily check whether an instance variable has been set and what index the IV uses.  Before this change, in the worst case, IV lookup would be `O(n)`, but with the red-black tree, the worst case is `O(log n)` (where `n` == shape depth).

I added a benchmark to show the difference:

```
$ make benchmark ITEM=vm_ivar_ic_miss
/Users/aaron/.rubies/arm64/ruby-trunk/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
	            --executables="compare-ruby::/Users/aaron/.rubies/arm64/ruby-trunk/bin/ruby --disable=gems -I.ext/common --disable-gem" \
	            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
	            --output=markdown --output-compare -v $(find ./benchmark -maxdepth 1 -name 'vm_ivar_ic_miss' -o -name '*vm_ivar_ic_miss*.yml' -o -name '*vm_ivar_ic_miss*.rb' | sort) 
compare-ruby: ruby 3.3.0dev (2023-10-23T15:37:50Z master 62c674f98c) [arm64-darwin23]
built-ruby: ruby 3.3.0dev (2023-10-23T22:56:14Z rb-shape-index 4a7b24be69) [arm64-darwin23]
# Iteration per second (i/s)

|                 |compare-ruby|built-ruby|
|:----------------|-----------:|---------:|
|vm_ivar_ic_miss  |      3.465M|   23.031M|
|                 |           -|     6.65x|
```

This change has an impact on YJIT as well.  When IV sites become megamorphic, rather than exit, the JIT will generate machine code that does a "slow path" read on the IV.  Below is a benchmark to demonstrate:

```ruby
class Foo
  def initialize idx
    case idx
    when 0; then @c0 = 1
    when 1; then @c1 = 1
    when 2; then @c2 = 1
    when 3; then @c3 = 1
    when 4; then @c4 = 1
    when 5; then @c5 = 1
    when 6; then @c6 = 1
    when 7; then @c7 = 1
    when 8; then @c8 = 1
    end

    @a0 = @a1 = @a2 = @a3 = @a4 = @a5 = @a6 = @a7 = @a8 = @a9 = @a10 = @a11 = @a12 = @a13 = @a14 = @a15 = @a16 = @a17 = @a18 = @a19 = @a20 = @a21 = @a22 = @a23 = @a24 = @a25 = @a26 = @a27 = @a28 = @a29 = @a30 = @a31 = @a32 = @a33 = @a34 = @a35 = @a36 = @a37 = @a38 = @a39 = @a40 = @a41 = @a42 = @a43 = @a44 = @a45 = @a46 = @a47 = @a48 = @a49 = @a50 = @a51 = @a52 = @a53 = @a54 = @a55 = @a56 = @a57 = @a58 = @a59 = @a60 = @a61 = @a62 = @a63 = @a64 = @a65 = @a66 = @a67 = @a68 = @a69 = @a70 = @a71 = @a72 = @a73 = @a74 = @b = 1
  end

  def b; @b; end
end

# Force the `@b` site to be megamorphic
9.times { Class.new(Foo).new(_1).b }
obj = Foo.new(8)
60000000.times { obj.b }
```

With YJIT on master:

```
$ time ruby --yjit --yjit-call-threshold=2 -v test.rb
ruby 3.3.0dev (2023-10-23T15:37:50Z master 62c674f98c) +YJIT [arm64-darwin23]

________________________________________________________
Executed in   10.37 secs    fish           external
   usr time   10.28 secs   30.29 millis   10.25 secs
   sys time    0.13 secs    5.12 millis    0.12 secs
```

With YJIT on this branch:

```
$ time ./ruby --yjit --yjit-call-threshold=2 -v test.rb
ruby 3.3.0dev (2023-10-23T22:56:14Z rb-shape-index 4a7b24be69) +YJIT [arm64-darwin23]

________________________________________________________
Executed in    2.61 secs    fish           external
   usr time    2.45 secs    0.10 millis    2.45 secs
   sys time    0.04 secs    2.15 millis    0.04 secs
```