### PR TITLE
Optimize `r_cover_range_p` (`Range#cover?`)

### DIFF
--- a/benchmark/range_cover_range.yml
+++ b/benchmark/range_cover_range.yml
@@ -1,0 +1,57 @@
+prelude: |
+  r_0_nil = (0..)
+  r_nil_10 = (..10)
+  r_1_3 = 1..3
+  r_1_nil = (1..)
+  r_m3_m1 = -3..-1
+  r_nil_m1 = (..-1)
+  r_20_30 = 20..30
+  r_20_nil = (20..)
+  r_0_5 = 0..5
+  r_m1_10 = -1..10
+  r_m1_3 = -1..3
+  r_1_10 = 1..10
+  r_nil_1 = (..1)
+  r_b100_b200 = 10**100..10**200
+  r_mb200_mb100 = -10**200..-10**100
+  r_mb100_b100 = -10**100..10**100
+  r_nil_nil = nil..nil
+  r_c_i = 'c'..'i'
+  r_c_nil = ('c'..)
+  r_d_g = 'd'..'g'
+  r_d_z = 'd'..'z'
+  r_d__z = 'd'...'z'
+  r_a_b = 'a'..'b'
+  r_a_z = 'a'..'z'
+  r_e_z = 'e'..'z'
+  require 'date'
+  r_date = Date.new(2023, 1, 1)..Date.new(2023, 12, 31)
+  r_date2 = Date.new(2023, 3, 1)..Date.new(2023, 3, 31)
+
+benchmark:
+  '(0..5).cover?(1..3)': r_0_5.cover?(r_1_3)
+  '(0..5).cover?(-1..10)': r_0_5.cover?(r_m1_10)
+  '(0..5).cover?(-1..3)': r_0_5.cover?(r_m1_3)
+  '(0..5).cover?(1..10)': r_0_5.cover?(r_1_10)
+  '(0..5).cover?(20..30)': r_0_5.cover?(r_20_30)
+  '(0..5).cover?(10**100..10**200)': r_0_5.cover?(r_b100_b200)
+  '(0..5).cover?(-10**200..-10**100)': r_0_5.cover?(r_mb200_mb100)
+  '(0..5).cover?(-10**100..10**100)': r_0_5.cover?(r_mb100_b100)
+  '(0..5).cover?(1..)': r_0_5.cover?(r_1_nil)
+  '(0..5).cover?(..1)': r_0_5.cover?(r_nil_1)
+  '(0..).cover?(1..3)': r_0_nil.cover?(r_1_3)
+  '(0..).cover?(1..)': r_0_nil.cover?(r_1_nil)
+  '(0..).cover?(-3..-1)': r_0_nil.cover?(r_m3_m1)
+  '(0..).cover?(..-1)': r_0_nil.cover?(r_nil_m1)
+  '(..10).cover?(1..3)': r_nil_10.cover?(r_1_3)
+  '(..10).cover?(..1)': r_nil_10.cover?(r_nil_1)
+  '(..10).cover?(20..30)': r_nil_10.cover?(r_20_30)
+  '(..10).cover?(20..)': r_nil_10.cover?(r_20_nil)
+  '(..nil).cover?(..1)': r_nil_nil.cover?(r_nil_1)
+  '("c".."i").cover?("d".."g")': r_c_i.cover?(r_d_g)
+  '("c".."i").cover?("d".."z")': r_c_i.cover?(r_d_z)
+  '("c".."i").cover?("d"..."z")': r_c_i.cover?(r_d__z)
+  '("c".."i").cover?("a".."b")': r_c_i.cover?(r_a_b)
+  '("c"..).cover?("a".."z")': r_c_nil.cover?(r_a_z)
+  '("c"..).cover?("e".."z")': r_c_nil.cover?(r_e_z)
+  'r_date.cover?(r_date2)': r_date.cover?(r_date2)

--- a/range.c
+++ b/range.c
@@ -2169,45 +2169,67 @@ r_call_max(VALUE r)
     return rb_funcallv(r, rb_intern("max"), 0, 0);
 }
 
+static bool empty_region_p(VALUE beg, VALUE end, int excl);
+
+static int
+r_cover_endpoints_p(VALUE range, VALUE beg, VALUE end, VALUE val, VALUE val_beg, VALUE val_end)
+{
+    VALUE val_max;
+    int cmp_end;
+
+    if (!NIL_P(end) && NIL_P(val_end)) return FALSE;
+    if (!NIL_P(beg) && NIL_P(val_beg)) return FALSE;
+    if (NIL_P(beg) && NIL_P(end)) {
+        return !NIL_P(val_end) || !(EXCL(range) && !EXCL(val));
+    }
+
+    int beg_check_required_p = FALSE, end_check_required_p = FALSE;
+    if (NIL_P(beg)) {
+        end_check_required_p = TRUE;
+    }
+    else {
+        if (NIL_P(val_end) && EXCL(range) && !EXCL(val)) return FALSE;
+        beg_check_required_p = TRUE;
+        end_check_required_p = !NIL_P(end);
+    }
+
+    if (beg_check_required_p) {
+        if (r_less(beg, val_beg) > 0) return FALSE;
+    }
+
+    if (end_check_required_p) {
+        VALUE r_cmp_end = rb_funcall(end, id_cmp, 1, val_end);
+        if (NIL_P(r_cmp_end)) return FALSE;
+        cmp_end = rb_cmpint(r_cmp_end, end, val_end);
+
+        if (EXCL(range) == EXCL(val)) {
+            return cmp_end >= 0;
+        }
+        else if (EXCL(range)) {
+            return cmp_end > 0;
+        }
+        else if (cmp_end >= 0) {
+            return TRUE;
+        }
+
+        val_max = rb_rescue2(r_call_max, val, 0, Qnil, rb_eTypeError, (VALUE)0);
+        if (NIL_P(val_max)) return FALSE;
+
+        return r_less(end, val_max) >= 0;
+    }
+
+    return TRUE;
+}
+
 static int
 r_cover_range_p(VALUE range, VALUE beg, VALUE end, VALUE val)
 {
-    VALUE val_beg, val_end, val_max;
-    int cmp_end;
+    VALUE val_beg, val_end;
 
     val_beg = RANGE_BEG(val);
     val_end = RANGE_END(val);
 
-    if (!NIL_P(end) && NIL_P(val_end)) return FALSE;
-    if (!NIL_P(beg) && NIL_P(val_beg)) return FALSE;
-    if (!NIL_P(val_beg) && !NIL_P(val_end) && r_less(val_beg, val_end) > (EXCL(val) ? -1 : 0)) return FALSE;
-    if (!NIL_P(val_beg) && !r_cover_p(range, beg, end, val_beg)) return FALSE;
-
-
-    if (!NIL_P(val_end) && !NIL_P(end)) {
-        VALUE r_cmp_end = rb_funcall(end, id_cmp, 1, val_end);
-        if (NIL_P(r_cmp_end)) return FALSE;
-        cmp_end = rb_cmpint(r_cmp_end, end, val_end);
-    }
-    else {
-        cmp_end = r_less(end, val_end);
-    }
-
-
-    if (EXCL(range) == EXCL(val)) {
-        return cmp_end >= 0;
-    }
-    else if (EXCL(range)) {
-        return cmp_end > 0;
-    }
-    else if (cmp_end >= 0) {
-        return TRUE;
-    }
-
-    val_max = rb_rescue2(r_call_max, val, 0, Qnil, rb_eTypeError, (VALUE)0);
-    if (NIL_P(val_max)) return FALSE;
-
-    return r_less(end, val_max) >= 0;
+    return r_cover_endpoints_p(range, beg, end, val, val_beg, val_end) && !empty_region_p(val_beg, val_end, EXCL(val));
 }
 
 static VALUE

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -901,6 +901,7 @@ class TestRange < Test::Unit::TestCase
     assert_operator(nil.., :cover?, nil...)
     assert_not_operator(nil..., :cover?, nil..)
     assert_not_operator(nil..., :cover?, 1..)
+    assert_not_operator(nil.., :cover?, 1..0)
   end
 
   def test_beg_len


### PR DESCRIPTION
This pull request improves performace of `r_cover_range_p` (which is used by `Range#cover?`) by appropriately organizing the possible conditions of the two ranges.

Checking for an empty range is deferred because it is assumed that the argument range is empty in few cases.


```
      beg     end   val_beg   val_end | result
---------------------------------------------------------
 (0)    *       *         *         * | BEG && END
 (1)    *       *         *       nil | false
 (2)    *       *       nil         * | false
 (3)    *       *       nil       nil | false
---------------------------------------------------------
 (4)    *     nil         *         * | BEG
 (5)    *     nil         *       nil | EX ? false : BEG
 (6)    *     nil       nil         * | false
 (7)    *     nil       nil       nil | false
---------------------------------------------------------
 (8)  nil       *         *         * | END
 (9)  nil       *         *       nil | false
(10)  nil       *       nil         * | END
(11)  nil       *       nil       nil | false
---------------------------------------------------------
(12)  nil     nil         *         * | true
(13)  nil     nil         *       nil | EX ? false : true
(14)  nil     nil       nil         * | true
(15)  nil     nil       nil       nil | EX ? false : true

*: non-nil
EX: EXCL(range) && !EXCL(val)
true: return true
false: return false
BEG: A comparison between beg and val_beg is required
END: A comparison between end and val_end is required
```


# benchmark

Iteration per second (i/s)


|                                   |e7d845b1d0|PR|
|:----------------------------------|----------------------------------:|-------------------------:|
|`(0..5).cover?(1..3)`               |                             9.331M|                   11.470M|
|                                   |                                  -|                     1.23x|
|`(0..5).cover?(1...6)`              |                             6.397M|                    7.460M|
|                                   |                                  -|                     1.17x|
|`(0..5).cover?(-1..10)`             |                            15.280M|                   22.356M|
|                                   |                                  -|                     1.46x|
|`(0..5).cover?(-1..3)`              |                            15.293M|                   22.748M|
|                                   |                                  -|                     1.49x|
|`(0..5).cover?(1..10)`              |                             9.272M|                   15.217M|
|                                   |                                  -|                     1.64x|
|`(0..5).cover?(20..30)`             |                            11.496M|                   15.329M|
|                                   |                                  -|                     1.33x|
|`(0..5).cover?(10**100..10**200)`   |                             7.187M|                    8.268M|
|                                   |                                  -|                     1.15x|
|`(0..5).cover?(-10**200..-10**100)` |                            10.690M|                   14.053M|
|                                   |                                  -|                     1.31x|
|`(0..5).cover?(-10**100..10**100)`  |                            10.660M|                   14.178M|
|                                   |                                  -|                     1.33x|
|`(0..5).cover?(1..)`                |                            42.806M|                   42.300M|
|                                   |                              1.01x|                         -|
|`(0..5).cover?(..1)`                |                            43.236M|                   42.303M|
|                                   |                              1.02x|                         -|
|`(0..).cover?(1..3)`                |                            10.570M|                   15.325M|
|                                   |                                  -|                     1.45x|
|`(0..).cover?(1..)`                 |                            15.611M|                   22.452M|
|                                   |                                  -|                     1.44x|
|`(0..).cover?(-3..-1)`              |                            15.426M|                   22.851M|
|                                   |                                  -|                     1.48x|
|`(0..).cover?(..-1)`                |                            42.460M|                   42.401M|
|                                   |                              1.00x|                         -|
|`(..10).cover?(1..3)`               |                            11.518M|                   14.992M|
|                                   |                                  -|                     1.30x|
|`(..10).cover?(..1)`                |                            22.507M|                   22.535M|
|                                   |                                  -|                     1.00x|
|`(..10).cover?(20..30)`             |                            15.286M|                   22.488M|
|                                   |                                  -|                     1.47x|
|`(..10).cover?(20..)`               |                            42.780M|                   42.472M|
|                                   |                              1.01x|                         -|
|`(..nil).cover?(..1)`               |                            19.202M|                   42.494M|
|                                   |                                  -|                     2.21x|
|`("c".."i").cover?("d".."g")`       |                             9.073M|                   11.214M|
|                                   |                                  -|                     1.24x|
|`("c".."i").cover?("d".."z")`       |                             9.064M|                   15.127M|
|                                   |                                  -|                     1.67x|
|`("c".."i").cover?("d"..."z")`      |                           808.435k|                  850.289k|
|                                   |                                  -|                     1.05x|
|`("c".."i").cover?("a".."b")`       |                            14.961M|                   22.466M|
|                                   |                                  -|                     1.50x|
|`("c"..).cover?("a".."z")`          |                            15.093M|                   22.748M|
|                                   |                                  -|                     1.51x|
|`("c"..).cover?("e".."z")`          |                            10.363M|                   14.985M|
|                                   |                                  -|                     1.45x|
|`r_date.cover?(r_date2)`            |                             6.669M|                    8.457M|
|                                   |                                  -|                     1.27x|
