### PR TITLE
[Bug #19968] Revert RBS revision to test

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -17,7 +17,7 @@ net-pop         0.1.2   https://github.com/ruby/net-pop
 net-smtp        0.4.0   https://github.com/ruby/net-smtp
 matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
-rbs             3.2.2   https://github.com/ruby/rbs 2cac4e78dfd76e85342ab2c332d3fae046b36961
+rbs             3.2.2   https://github.com/ruby/rbs 33813a60752624d58dfe5ae770b39bfaf29fbaf1
 typeprof        0.21.8  https://github.com/ruby/typeprof
 debug           1.8.0   https://github.com/ruby/debug 927587afb6aac69b358b86a01f602d207053e8d2
 racc            1.7.1   https://github.com/ruby/racc

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -36,7 +36,6 @@ File.foreach("#{gem_dir}/bundled_gems") do |line|
   when "rbs"
     # TODO: We should skip test file instead of test class/methods
     skip_test_files = %w[
-      test/stdlib/RbConfig_test.rb
     ]
 
     skip_test_files.each do |file|


### PR DESCRIPTION
This reverts the commits for the master branch of RBS:

- commit f717faac632dd8664d0967f8e639b84d5d032854: "Update rbs revision to test"

    The target revision to test is in master branch, not for 3.2.x.

- commit 9e93af5329f35092c3de3ea37d4e9e181b800bb2: "Skip RBS `RbConfig::TOPDIR` test that is `nil` before installation"

    RbConfig_test.rb is not updated in 3.2.x branch.