### PR TITLE
[PRISM] Implement compilation for PostExecutionNode

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -640,6 +640,12 @@ module Prism
       assert_equal ruby_eval, prism_eval
     end
 
+    def test_PostExecutionNode
+      assert_prism_eval("END { 1 }")
+      assert_prism_eval("END { @b }; @b = 1")
+      assert_prism_eval("END { @b; 0 }; @b = 1")
+    end
+
     def test_ProgramNode
       assert_prism_eval("")
       assert_prism_eval("1")


### PR DESCRIPTION
Compiling the PostExecutionNode requires defining a way to create a new prism iseq with a callback. This commit includes that definition and all related ones, as well as the implementation of compilation for the PostExecutionNode.

Closes https://github.com/ruby/prism/issues/1655