### PR TITLE
Various commits to clean up shape code

### DIFF
--- a/object.c
+++ b/object.c
@@ -292,7 +292,7 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
     RUBY_ASSERT(BUILTIN_TYPE(dest) == BUILTIN_TYPE(obj));
     rb_shape_t * src_shape = rb_shape_get_shape(obj);
 
-    if (rb_shape_id(src_shape) == OBJ_TOO_COMPLEX_SHAPE_ID) {
+    if (rb_shape_obj_too_complex(obj)) {
         st_table * table = rb_st_init_numtable_with_size(rb_st_table_size(ROBJECT_IV_HASH(obj)));
 
         rb_ivar_foreach(obj, rb_obj_evacuate_ivs_to_hash_table, (st_data_t)table);

--- a/shape.c
+++ b/shape.c
@@ -1182,7 +1182,6 @@ Init_shape(void)
     rb_define_const(rb_cShape, "SPECIAL_CONST_SHAPE_ID", INT2NUM(SPECIAL_CONST_SHAPE_ID));
     rb_define_const(rb_cShape, "OBJ_TOO_COMPLEX_SHAPE_ID", INT2NUM(OBJ_TOO_COMPLEX_SHAPE_ID));
     rb_define_const(rb_cShape, "SHAPE_MAX_VARIATIONS", INT2NUM(SHAPE_MAX_VARIATIONS));
-    rb_define_const(rb_cShape, "SHAPE_MAX_NUM_IVS", INT2NUM(SHAPE_MAX_NUM_IVS));
 
     rb_define_singleton_method(rb_cShape, "transition_tree", shape_transition_tree, 0);
     rb_define_singleton_method(rb_cShape, "find_by_id", rb_shape_find_by_id, 1);

--- a/shape.c
+++ b/shape.c
@@ -435,7 +435,7 @@ rb_shape_alloc_new_child(ID id, rb_shape_t * shape, enum shape_type shape_type)
 }
 
 static rb_shape_t*
-get_next_shape_internal(rb_shape_t * shape, ID id, enum shape_type shape_type, bool * variation_created, bool new_shapes_allowed)
+get_next_shape_internal(rb_shape_t * shape, ID id, enum shape_type shape_type, bool * variation_created, bool new_variations_allowed)
 {
     rb_shape_t *res = NULL;
 
@@ -444,7 +444,7 @@ get_next_shape_internal(rb_shape_t * shape, ID id, enum shape_type shape_type, b
 
     *variation_created = false;
 
-    if ((new_shapes_allowed && (GET_SHAPE_TREE()->next_shape_id <= MAX_SHAPE_ID))) {
+    if (GET_SHAPE_TREE()->next_shape_id <= MAX_SHAPE_ID) {
         RB_VM_LOCK_ENTER();
         {
             // If the current shape has children
@@ -478,10 +478,12 @@ get_next_shape_internal(rb_shape_t * shape, ID id, enum shape_type shape_type, b
                 // we know we need a new child shape, and that we must insert
                 // it in to the table.
                 if (!res) {
-                    *variation_created = true;
-                    rb_shape_t * new_shape = rb_shape_alloc_new_child(id, shape, shape_type);
-                    rb_id_table_insert(shape->edges, id, (VALUE)new_shape);
-                    res = new_shape;
+                    if (new_variations_allowed) {
+                        *variation_created = true;
+                        rb_shape_t * new_shape = rb_shape_alloc_new_child(id, shape, shape_type);
+                        rb_id_table_insert(shape->edges, id, (VALUE)new_shape);
+                        res = new_shape;
+                    }
                 }
             }
             else {

--- a/shape.c
+++ b/shape.c
@@ -484,6 +484,9 @@ get_next_shape_internal(rb_shape_t * shape, ID id, enum shape_type shape_type, b
                         rb_id_table_insert(shape->edges, id, (VALUE)new_shape);
                         res = new_shape;
                     }
+                    else {
+                        res = rb_shape_get_shape_by_id(OBJ_TOO_COMPLEX_SHAPE_ID);
+                    }
                 }
             }
             else {
@@ -495,6 +498,9 @@ get_next_shape_internal(rb_shape_t * shape, ID id, enum shape_type shape_type, b
             }
         }
         RB_VM_LOCK_LEAVE();
+    }
+    else {
+        res = rb_shape_get_shape_by_id(OBJ_TOO_COMPLEX_SHAPE_ID);
     }
     return res;
 }
@@ -611,9 +617,6 @@ rb_shape_transition_shape_frozen(VALUE obj)
     bool dont_care;
     next_shape = get_next_shape_internal(shape, (ID)id_frozen, SHAPE_FROZEN, &dont_care, true);
 
-    if (!next_shape) {
-        next_shape = rb_shape_get_shape_by_id(OBJ_TOO_COMPLEX_SHAPE_ID);
-    }
     RUBY_ASSERT(next_shape);
     return next_shape;
 }
@@ -645,10 +648,6 @@ rb_shape_get_next(rb_shape_t* shape, VALUE obj, ID id)
 
     bool variation_created = false;
     rb_shape_t * new_shape = get_next_shape_internal(shape, id, SHAPE_IVAR, &variation_created, allow_new_shape);
-
-    if (!new_shape) {
-        new_shape = rb_shape_get_shape_by_id(OBJ_TOO_COMPLEX_SHAPE_ID);
-    }
 
     // Check if we should update max_iv_count on the object's class
     if (BUILTIN_TYPE(obj) == T_OBJECT) {
@@ -683,6 +682,7 @@ rb_shape_transition_shape_capa_create(rb_shape_t* shape, size_t new_capacity)
     ID edge_name = rb_make_temporary_id(new_capacity);
     bool dont_care;
     rb_shape_t * new_shape = get_next_shape_internal(shape, edge_name, SHAPE_CAPACITY_CHANGE, &dont_care, true);
+    RUBY_ASSERT(rb_shape_id(new_shape) != OBJ_TOO_COMPLEX_SHAPE_ID);
     new_shape->capacity = (uint32_t)new_capacity;
     return new_shape;
 }

--- a/shape.c
+++ b/shape.c
@@ -384,29 +384,20 @@ rb_shape_alloc(ID edge_name, rb_shape_t * parent, enum shape_type type)
 static redblack_node_t *
 redblack_cache_ancestors(rb_shape_t * shape)
 {
-    if (shape->ancestor_index) {
-        return shape->ancestor_index;
-    }
-    else {
-        if (shape->parent_id == INVALID_SHAPE_ID) {
-            // We're at the root
-            return shape->ancestor_index;
+    if (!(shape->ancestor_index || shape->parent_id == INVALID_SHAPE_ID)) {
+        redblack_node_t * parent_index;
+
+        parent_index = redblack_cache_ancestors(rb_shape_get_parent(shape));
+
+        if (shape->type == SHAPE_IVAR) {
+            shape->ancestor_index = redblack_insert(parent_index, shape->edge_name, shape);
         }
         else {
-            redblack_node_t * parent_index;
-
-            parent_index = redblack_cache_ancestors(rb_shape_get_parent(shape));
-
-            if (shape->type == SHAPE_IVAR) {
-                shape->ancestor_index = redblack_insert(parent_index, shape->edge_name, shape);
-            }
-            else {
-                shape->ancestor_index = parent_index;
-            }
-
-            return shape->ancestor_index;
+            shape->ancestor_index = parent_index;
         }
     }
+
+    return shape->ancestor_index;
 }
 #else
 static redblack_node_t *

--- a/shape.h
+++ b/shape.h
@@ -33,7 +33,6 @@ typedef uint16_t redblack_id_t;
 # define SHAPE_FLAG_SHIFT ((SIZEOF_VALUE * 8) - SHAPE_ID_NUM_BITS)
 
 # define SHAPE_MAX_VARIATIONS 8
-# define SHAPE_MAX_NUM_IVS 80
 
 # define MAX_SHAPE_ID (SHAPE_BUFFER_SIZE - 1)
 # define INVALID_SHAPE_ID SHAPE_MASK

--- a/shape.h
+++ b/shape.h
@@ -178,7 +178,7 @@ ROBJECT_IV_CAPACITY(VALUE obj)
     RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
     // Asking for capacity doesn't make sense when the object is using
     // a hash table for storing instance variables
-    RUBY_ASSERT(ROBJECT_SHAPE_ID(obj) != OBJ_TOO_COMPLEX_SHAPE_ID);
+    RUBY_ASSERT(!rb_shape_obj_too_complex(obj));
     return rb_shape_get_shape_by_id(ROBJECT_SHAPE_ID(obj))->capacity;
 }
 
@@ -186,7 +186,7 @@ static inline st_table *
 ROBJECT_IV_HASH(VALUE obj)
 {
     RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
-    RUBY_ASSERT(ROBJECT_SHAPE_ID(obj) == OBJ_TOO_COMPLEX_SHAPE_ID);
+    RUBY_ASSERT(rb_shape_obj_too_complex(obj));
     return (st_table *)ROBJECT(obj)->as.heap.ivptr;
 }
 
@@ -194,7 +194,7 @@ static inline void
 ROBJECT_SET_IV_HASH(VALUE obj, const st_table *tbl)
 {
     RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
-    RUBY_ASSERT(ROBJECT_SHAPE_ID(obj) == OBJ_TOO_COMPLEX_SHAPE_ID);
+    RUBY_ASSERT(rb_shape_obj_too_complex(obj));
     ROBJECT(obj)->as.heap.ivptr = (VALUE *)tbl;
 }
 
@@ -203,12 +203,12 @@ size_t rb_id_table_size(const struct rb_id_table *tbl);
 static inline uint32_t
 ROBJECT_IV_COUNT(VALUE obj)
 {
-    if (ROBJECT_SHAPE_ID(obj) == OBJ_TOO_COMPLEX_SHAPE_ID) {
+    if (rb_shape_obj_too_complex(obj)) {
         return (uint32_t)rb_st_table_size(ROBJECT_IV_HASH(obj));
     }
     else {
         RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
-        RUBY_ASSERT(ROBJECT_SHAPE_ID(obj) != OBJ_TOO_COMPLEX_SHAPE_ID);
+        RUBY_ASSERT(!rb_shape_obj_too_complex(obj));
         return rb_shape_get_shape_by_id(ROBJECT_SHAPE_ID(obj))->next_iv_index;
     }
 }

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -5,6 +5,8 @@ require 'json'
 
 # These test the functionality of object shapes
 class TestShapes < Test::Unit::TestCase
+  MANY_IVS = 80
+
   class IVOrder
     def expected_ivs
       %w{ @a @b @c @d @e @f @g @h @i @j @k }
@@ -149,7 +151,7 @@ class TestShapes < Test::Unit::TestCase
   def test_too_many_ivs_on_class
     obj = Class.new
 
-    (RubyVM::Shape::SHAPE_MAX_NUM_IVS + 1).times do
+    (MANY_IVS + 1).times do
       obj.instance_variable_set(:"@a#{_1}", 1)
     end
 
@@ -159,10 +161,10 @@ class TestShapes < Test::Unit::TestCase
   def test_removing_when_too_many_ivs_on_class
     obj = Class.new
 
-    (RubyVM::Shape::SHAPE_MAX_NUM_IVS + 2).times do
+    (MANY_IVS + 2).times do
       obj.instance_variable_set(:"@a#{_1}", 1)
     end
-    (RubyVM::Shape::SHAPE_MAX_NUM_IVS + 2).times do
+    (MANY_IVS + 2).times do
       obj.remove_instance_variable(:"@a#{_1}")
     end
 
@@ -172,10 +174,10 @@ class TestShapes < Test::Unit::TestCase
   def test_removing_when_too_many_ivs_on_module
     obj = Module.new
 
-    (RubyVM::Shape::SHAPE_MAX_NUM_IVS + 2).times do
+    (MANY_IVS + 2).times do
       obj.instance_variable_set(:"@a#{_1}", 1)
     end
-    (RubyVM::Shape::SHAPE_MAX_NUM_IVS + 2).times do
+    (MANY_IVS + 2).times do
       obj.remove_instance_variable(:"@a#{_1}")
     end
 

--- a/variable.c
+++ b/variable.c
@@ -76,7 +76,7 @@ static inline st_table *
 RCLASS_IV_HASH(VALUE obj)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, RUBY_T_CLASS) || RB_TYPE_P(obj, RUBY_T_MODULE));
-    RUBY_ASSERT(RCLASS_SHAPE_ID(obj) == OBJ_TOO_COMPLEX_SHAPE_ID);
+    RUBY_ASSERT(rb_shape_obj_too_complex(obj));
     return (st_table *)RCLASS_IVPTR(obj);
 }
 
@@ -84,7 +84,7 @@ static inline void
 RCLASS_SET_IV_HASH(VALUE obj, const st_table *tbl)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, RUBY_T_CLASS) || RB_TYPE_P(obj, RUBY_T_MODULE));
-    RUBY_ASSERT(RCLASS_SHAPE_ID(obj) == OBJ_TOO_COMPLEX_SHAPE_ID);
+    RUBY_ASSERT(rb_shape_obj_too_complex(obj));
     RCLASS_IVPTR(obj) = (VALUE *)tbl;
 }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5493,7 +5493,7 @@ vm_define_method(const rb_execution_context_t *ec, VALUE obj, ID id, VALUE iseqv
 
     rb_add_method_iseq(klass, id, (const rb_iseq_t *)iseqval, cref, visi);
     // Set max_iv_count on klasses based on number of ivar sets that are in the initialize method
-    if (id == rb_intern("initialize") && klass != rb_cObject &&  RB_TYPE_P(klass, T_CLASS) && (rb_get_alloc_func(klass) == rb_class_allocate_instance)) {
+    if (id == idInitialize && klass != rb_cObject &&  RB_TYPE_P(klass, T_CLASS) && (rb_get_alloc_func(klass) == rb_class_allocate_instance)) {
 
         RCLASS_EXT(klass)->max_iv_count = rb_estimate_iv_count(klass, (const rb_iseq_t *)iseqval);
     }


### PR DESCRIPTION
This PR simplifies the `get_next_shape_internal` interface.  It removes a boolean from the function signature.  It also guarantees that `get_next_shape_internal` will always return a shape.  If it runs out of memory, or isn't allowed to create a new variation, the function will return the "TOO COMPLEX" shape.  All object types now support "too complex", so it's safe to return "too complex" in the case we run out of shapes.

This PR also removes some dead code (specifically `SHAPE_MAX_NUM_IVS`).  `SHAPE_MAX_NUM_IVS` was used as a work around for the [IV10K problem](https://bugs.ruby-lang.org/issues/19334).  It limited the number of IVs to 80, forcing objects with `> 80` ivs to become "too complex".  The redblack tree works well at any depth, thus removing the need for an artificial cap.