### PR TITLE
teach prism `defined?` to compile basic types

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -87,8 +87,52 @@ module Prism
     end
 
     def test_DefinedNode
-      # TODO:
-      # assert_prism_eval("defined? foo")
+      assert_prism_eval("defined? nil")
+      assert_prism_eval("defined? self")
+      assert_prism_eval("defined? true")
+      assert_prism_eval("defined? false")
+      assert_prism_eval("defined? 'str'")
+      assert_prism_eval("defined? a && b")
+      assert_prism_eval("defined? a || b")
+
+      assert_prism_eval("defined? @a")
+      assert_prism_eval("defined? $a")
+      assert_prism_eval("defined? @@a")
+      assert_prism_eval("defined? A")
+      assert_prism_eval("defined? yield")
+      assert_prism_eval("defined? super")
+
+      assert_prism_eval("defined? X = 1")
+      assert_prism_eval("defined? X *= 1")
+      assert_prism_eval("defined? X /= 1")
+      assert_prism_eval("defined? X &= 1")
+      assert_prism_eval("defined? X ||= 1")
+
+      assert_prism_eval("defined? $X = 1")
+      assert_prism_eval("defined? $X *= 1")
+      assert_prism_eval("defined? $X /= 1")
+      assert_prism_eval("defined? $X &= 1")
+      assert_prism_eval("defined? $X ||= 1")
+
+      assert_prism_eval("defined? @@X = 1")
+      assert_prism_eval("defined? @@X *= 1")
+      assert_prism_eval("defined? @@X /= 1")
+      assert_prism_eval("defined? @@X &= 1")
+      assert_prism_eval("defined? @@X ||= 1")
+
+      assert_prism_eval("defined? @X = 1")
+      assert_prism_eval("defined? @X *= 1")
+      assert_prism_eval("defined? @X /= 1")
+      assert_prism_eval("defined? @X &= 1")
+      assert_prism_eval("defined? @X ||= 1")
+
+      assert_prism_eval("x = 1; defined? x = 1")
+      assert_prism_eval("x = 1; defined? x *= 1")
+      assert_prism_eval("x = 1; defined? x /= 1")
+      assert_prism_eval("x = 1; defined? x &= 1")
+      assert_prism_eval("x = 1; defined? x ||= 1")
+
+      assert_prism_eval("if defined? A; end")
     end
 
     def test_GlobalVariableReadNode


### PR DESCRIPTION
Basic types the `PM_DEFINED_NODE` should handle.

Remaining types `defined?` should handle:

* list
* (op/v/f)call
* path reads
* backreferences

Additionally, compilation including branching are not attempted here.


CC: @jemmaissroff 