### PR TITLE
[PRISM] Implement regex encoding flags

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -390,6 +390,14 @@ module Prism
       assert_prism_eval('/pit/mx')
       assert_prism_eval('/pit/xi')
       assert_prism_eval('/pit/ixm')
+
+      assert_prism_eval('/pit/u')
+      assert_prism_eval('/pit/e')
+      assert_prism_eval('/pit/s')
+      assert_prism_eval('/pit/n')
+
+      assert_prism_eval('/pit/me')
+      assert_prism_eval('/pit/ne')
     end
 
     def test_StringConcatNode


### PR DESCRIPTION
Added the  correct encoding to the allocated regex. This required making a new method to set the encoding and pass that to `rb_enc_reg_new` instead of `rb_reg_new`. The former `rb_reg_new` would set the encoding to ASCII8BIT regardless of encoding flag.