### PR TITLE
Allow core methods defined in Ruby to be considered "basic"

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -88,7 +88,6 @@ ruby_setup(void)
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
         rb_call_inits();
         ruby_prog_init();
-        GET_VM()->running = 1;
     }
     EC_POP_TAG();
 
@@ -119,6 +118,7 @@ ruby_options(int argc, char **argv)
     EC_PUSH_TAG(ec);
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
         SAVE_ROOT_JMPBUF(GET_THREAD(), iseq = ruby_process_options(argc, argv));
+        GET_VM()->running = 1;
     }
     else {
         rb_ec_clear_current_thread_trace_func(ec);

--- a/inits.c
+++ b/inits.c
@@ -107,6 +107,7 @@ rb_call_builtin_inits(void)
     BUILTIN(rjit_c);
     BUILTIN(rjit);
 #endif
+    CALL(vm_redefined);
     Init_builtin_prelude();
 }
 #undef CALL

--- a/vm.c
+++ b/vm.c
@@ -2087,14 +2087,7 @@ vm_redefinition_check_method_type(const rb_method_entry_t *me)
         return FALSE;
     }
 
-    const rb_method_definition_t *def = me->def;
-    switch (def->type) {
-      case VM_METHOD_TYPE_CFUNC:
-      case VM_METHOD_TYPE_OPTIMIZED:
-        return TRUE;
-      default:
-        return FALSE;
-    }
+    return METHOD_ENTRY_BASIC(me);
 }
 
 static void
@@ -2155,9 +2148,6 @@ vm_init_redefined_flag(void)
 {
     ID mid;
     VALUE bop;
-
-    vm_opt_method_def_table = st_init_numtable();
-    vm_opt_mid_table = st_init_numtable();
 
 #define OP(mid_, bop_) (mid = id##mid_, bop = BOP_##bop_, ruby_vm_redefined_flag[bop] = 0)
 #define C(k) add_opt_method(rb_c##k, mid, bop)
@@ -4066,7 +4056,9 @@ Init_VM(void)
 
         rb_objspace_gc_enable(vm->objspace);
     }
-    vm_init_redefined_flag();
+
+    vm_opt_method_def_table = st_init_numtable();
+    vm_opt_mid_table = st_init_numtable();
 
     rb_block_param_proxy = rb_obj_alloc(rb_cObject);
     rb_add_method_optimized(rb_singleton_class(rb_block_param_proxy), idCall,
@@ -4076,6 +4068,12 @@ Init_VM(void)
 
     /* vm_backtrace.c */
     Init_vm_backtrace();
+}
+
+void
+Init_vm_redefined(void)
+{
+    vm_init_redefined_flag();
 }
 
 void


### PR DESCRIPTION
This commit flags core methods that are defined in Ruby (for example Array#pack) as "basic" methods.  This means we can differentiate those Ruby methods from methods defined by user code.  Since we can differentiate "core basic" methods from user methods, we can use this flag for monkey patch detection

This is part of #8734