### PR TITLE
[Bug #19973] Warn duplicated keyword arguments after keyword splat

### DIFF
--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -335,6 +335,12 @@ class TestSyntax < Test::Unit::TestCase
     assert_warn(/duplicated/) {r = eval("a.f(**{k: a.add(1), j: a.add(2), k: a.add(3), k: a.add(4)})")}
     assert_equal(4, r)
     assert_equal([1, 2, 3, 4], a)
+    a.clear
+    r = nil
+    z = {}
+    assert_warn(/duplicated/) {r = eval("a.f(k: a.add(1), **z, k: a.add(2))")}
+    assert_equal(2, r)
+    assert_equal([1, 2], a)
   end
 
   def test_keyword_empty_splat


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19973