### PR TITLE
[DOC] Fix markup for == and ===

### DIFF
--- a/doc/syntax/control_expressions.rdoc
+++ b/doc/syntax/control_expressions.rdoc
@@ -189,7 +189,7 @@ The same is true for +unless+.
 The +case+ expression can be used in two ways.
 
 The most common way is to compare an object against multiple patterns.  The
-patterns are matched using the +===+ method which is aliased to +==+ on
+patterns are matched using the <code>===</code> method which is aliased to <code>==</code> on
 Object.  Other classes must override it to give meaningful behavior.  See
 Module#=== and Regexp#=== for examples.
 

--- a/numeric.c
+++ b/numeric.c
@@ -1550,8 +1550,8 @@ rb_float_pow(VALUE x, VALUE y)
  *    1.eql?(Rational(1, 1)) # => false
  *    1.eql?(Complex(1, 0))  # => false
  *
- *  \Method +eql?+ is different from +==+ in that +eql?+ requires matching types,
- *  while +==+ does not.
+ *  \Method +eql?+ is different from <code>==</code> in that +eql?+ requires matching types,
+ *  while <code>==</code> does not.
  *
  */
 


### PR DESCRIPTION
It seems that `+==+` and `+===+` are not being parsed as intended.

https://docs.ruby-lang.org/en/master/Numeric.html#method-i-eql-3F