### PR TITLE
Move some defines from shape.h to shape.c

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -19,12 +19,19 @@
 #define SHAPE_DEBUG (VM_CHECK_MODE > 0)
 #endif
 
+#if SIZEOF_SHAPE_T == 4
+#define SHAPE_BUFFER_SIZE 0x80000
+#else
+#define SHAPE_BUFFER_SIZE 0x8000
+#endif
+
 #define SINGLE_CHILD_TAG 0x1
 #define TAG_SINGLE_CHILD(x) (struct rb_id_table *)((uintptr_t)x | SINGLE_CHILD_TAG)
 #define SINGLE_CHILD_MASK (~((uintptr_t)SINGLE_CHILD_TAG))
 #define SINGLE_CHILD_P(x) (((uintptr_t)x) & SINGLE_CHILD_TAG)
 #define SINGLE_CHILD(x) (rb_shape_t *)((uintptr_t)x & SINGLE_CHILD_MASK)
 #define ANCESTOR_CACHE_THRESHOLD 10
+#define MAX_SHAPE_ID (SHAPE_BUFFER_SIZE - 1)
 
 static ID id_frozen;
 static ID id_t_object;

--- a/shape.h
+++ b/shape.h
@@ -11,7 +11,6 @@ typedef uint32_t attr_index_t;
 typedef uint32_t shape_id_t;
 typedef uint32_t redblack_id_t;
 # define SHAPE_ID_NUM_BITS 32
-# define SHAPE_BUFFER_SIZE 0x80000
 
 #else
 
@@ -21,7 +20,6 @@ typedef uint16_t attr_index_t;
 typedef uint16_t shape_id_t;
 typedef uint16_t redblack_id_t;
 # define SHAPE_ID_NUM_BITS 16
-# define SHAPE_BUFFER_SIZE 0x8000
 
 #endif
 
@@ -34,7 +32,6 @@ typedef uint16_t redblack_id_t;
 
 # define SHAPE_MAX_VARIATIONS 8
 
-# define MAX_SHAPE_ID (SHAPE_BUFFER_SIZE - 1)
 # define INVALID_SHAPE_ID SHAPE_MASK
 # define ROOT_SHAPE_ID 0x0
 


### PR DESCRIPTION
If they are only used there, we might as well not expose them.

@tenderlove 