### PR TITLE
[PRISM] Implement compilation for ConstantPath{And,Or,Operator}WriteNodes

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1342,6 +1342,43 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         PM_POP_IF_POPPED;
         return;
       }
+      case PM_CONSTANT_PATH_AND_WRITE_NODE: {
+        pm_constant_path_and_write_node_t *constant_path_and_write_node = (pm_constant_path_and_write_node_t*) node;
+
+        LABEL *lfin = NEW_LABEL(lineno);
+
+        pm_constant_path_node_t *target = constant_path_and_write_node->target;
+        PM_COMPILE(target->parent);
+
+        pm_constant_read_node_t *child = (pm_constant_read_node_t *)target->child;
+        VALUE child_name = ID2SYM(pm_constant_id_lookup(scope_node, child->name));
+
+        ADD_INSN(ret, &dummy_line_node, dup);
+        ADD_INSN1(ret, &dummy_line_node, putobject, Qtrue);
+        ADD_INSN1(ret, &dummy_line_node, getconstant, child_name);
+
+        PM_DUP_UNLESS_POPPED;
+        ADD_INSNL(ret, &dummy_line_node, branchunless, lfin);
+
+        PM_POP_UNLESS_POPPED;
+        PM_COMPILE(constant_path_and_write_node->value);
+
+        if (popped) {
+            ADD_INSN1(ret, &dummy_line_node, topn, INT2FIX(1));
+        }
+        else {
+            ADD_INSN1(ret, &dummy_line_node, dupn, INT2FIX(2));
+            ADD_INSN(ret, &dummy_line_node, swap);
+        }
+
+        ADD_INSN1(ret, &dummy_line_node, setconstant, child_name);
+        ADD_LABEL(ret, lfin);
+
+        if (!popped) ADD_INSN(ret, &dummy_line_node, swap);
+        PM_POP;
+
+        return;
+      }
       case PM_CONSTANT_PATH_OR_WRITE_NODE: {
         pm_constant_path_or_write_node_t *constant_path_or_write_node = (pm_constant_path_or_write_node_t*) node;
 

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -158,6 +158,10 @@ module Prism
       assert_prism_eval("::CPWN = 1")
     end
 
+    def test_ConstantPathOperatorWriteNode
+      assert_prism_eval("Prism::CPOWN = 0; Prism::CPOWN += 1")
+    end
+
     def test_GlobalVariableAndWriteNode
       assert_prism_eval("$pit = 0; $pit &&= 1")
     end

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -158,6 +158,11 @@ module Prism
       assert_prism_eval("::CPWN = 1")
     end
 
+    def test_ConstantPathOrWriteNode
+      assert_prism_eval("Prism::CPOrWN = nil; Prism::CPOrWN ||= 1")
+      assert_prism_eval("Prism::CPOrWN ||= 1")
+    end
+
     def test_ConstantPathOperatorWriteNode
       assert_prism_eval("Prism::CPOWN = 0; Prism::CPOWN += 1")
     end

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -158,6 +158,11 @@ module Prism
       assert_prism_eval("::CPWN = 1")
     end
 
+    def test_ConstantPathAndWriteNode
+      assert_prism_eval("Prism::CPAWN = 1; Prism::CPAWN &&= 2")
+      assert_prism_eval("Prism::CPAWN &&= 1")
+    end
+
     def test_ConstantPathOrWriteNode
       assert_prism_eval("Prism::CPOrWN = nil; Prism::CPOrWN ||= 1")
       assert_prism_eval("Prism::CPOrWN ||= 1")


### PR DESCRIPTION
Closes https://github.com/ruby/prism/issues/1643, closes https://github.com/ruby/prism/issues/1644, closes https://github.com/ruby/prism/issues/1645