### PR TITLE
[DOC] README.md: Remove Cirrus CI badge image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Actions Status: Windows](https://github.com/ruby/ruby/workflows/Windows/badge.svg)](https://github.com/ruby/ruby/actions?query=workflow%3A"Windows")
 [![AppVeyor status](https://ci.appveyor.com/api/projects/status/0sy8rrxut4o0k960/branch/master?svg=true)](https://ci.appveyor.com/project/ruby/ruby/branch/master)
 [![Travis Status](https://app.travis-ci.com/ruby/ruby.svg?branch=master)](https://app.travis-ci.com/ruby/ruby)
-[![Cirrus Status](https://api.cirrus-ci.com/github/ruby/ruby.svg)](https://cirrus-ci.com/github/ruby/ruby/master)
 
 # What is Ruby?
 


### PR DESCRIPTION
We removed the `.cirrus.yml` at the commit 01b5d1d2ff6ca91b2909dfa67295f59b53e6f065 .
Let's remove the badge image too.

You can check the modified README [here](https://github.com/junaruga/ruby/blob/wip/doc-cirrus-badge/README.md) on my forked repository.
