### PR TITLE
[DOC] Windows: Fix description of runtimes

### DIFF
--- a/doc/windows.md
+++ b/doc/windows.md
@@ -2,9 +2,9 @@
 
 Ruby supports a few native build platforms for Windows.
 
-* mswin: Build using Microsoft Visual C++ compiler
+* mswin: Build using Microsoft Visual C++ compiler with vcruntimeXXX.dll
 * mingw-msvcrt: Build using compiler for Mingw with msvcrtXX.dll
-* mingw-ucrt: Build using compiler for Mingw with vcruntime.dll
+* mingw-ucrt: Build using compiler for Mingw with Windows Universal CRT
 
 ## Building Ruby using Mingw with UCRT
 


### PR DESCRIPTION
`mswin` platform links to `vcruntimeXXX.dll` but `mingw-ucrt` doesn't.