### PR TITLE
Make get_next_shape_internal idempotent

### DIFF
--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -207,6 +207,25 @@ class TestShapes < Test::Unit::TestCase
     end;
   end
 
+  def test_run_out_of_shape
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      class A
+        def initialize
+          @a = 1
+        end
+      end
+      # Try to run out of shapes
+      o = Object.new
+      i = 0
+      while RubyVM::Shape.shapes_available > 0
+        o.instance_variable_set(:"@i#{i}", 1)
+        i += 1
+        A.new
+      end
+    end;
+  end
+
   def test_use_all_shapes_module
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;


### PR DESCRIPTION
Since the check for MAX_SHAPE_ID was done before even checking if the transition we're looking for even exists, as soon as the max shape is reached, get_next_shape_internal would always return `TOO_COMPLEX` regardless of whether the transition we're looking for already exist or not.

In addition to entirely de-optimize all newly created objects, it also made an assertion fail in `vm_setivar`:

```
vm_setivar:rb_shape_get_next_iv_shape(rb_shape_get_shape_by_id(source_shape_id), id) == dest_shape
```