### PR TITLE
Revert ".travis.yml: Drop s390x temporarily."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ matrix:
     # Comment out as the 2nd arm64 pipeline is unstable.
     # - <<: *arm64-linux
     - <<: *ppc64le-linux
-    # - <<: *s390x-linux
+    - <<: *s390x-linux
   allow_failures:
     # Allow failures for the unstable jobs.
     # - name: arm32-linux


### PR DESCRIPTION
It seems the Travis s390x is recovered again now.

This reverts commit 95cc0f946eb641be8dea4b7118598be77d993183.
