### PR TITLE
Revert ".travis.yml: Disable allow_failures for arm32."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ matrix:
     - <<: *s390x-linux
   allow_failures:
     # Allow failures for the unstable jobs.
-    # - name: arm32-linux
+    - name: arm32-linux
     # - name: arm64-linux
     - name: ppc64le-linux
     - name: s390x-linux


### PR DESCRIPTION
This reverts commit 49d442116470ca5e1fcc9eb198411640fbbe446a.

Unfortunately, Travis arm64 pipeline is unstable.
https://travis-ci.community/t/14028