### PR TITLE
Keep unused literal nodes

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -12291,14 +12291,6 @@ block_append(struct parser_params *p, NODE *head, NODE *tail)
 
     if (h == 0) return tail;
     switch (nd_type(h)) {
-      case NODE_LIT:
-      case NODE_STR:
-      case NODE_SELF:
-      case NODE_TRUE:
-      case NODE_FALSE:
-      case NODE_NIL:
-        parser_warning(p, h, "unused literal ignored");
-        return tail;
       default:
         h = end = NEW_BLOCK(head, &head->nd_loc);
         RNODE_BLOCK(end)->nd_end = end;

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -876,7 +876,6 @@ x = __ENCODING__
   def test_void_expr_stmts_value
     x = 1
     useless_use = /useless use/
-    unused = /unused/
     assert_nil assert_warning(useless_use) {eval("x; nil")}
     assert_nil assert_warning(useless_use) {eval("1+1; nil")}
     assert_nil assert_warning('') {eval("1.+(1); nil")}
@@ -884,10 +883,10 @@ x = __ENCODING__
     assert_nil assert_warning(useless_use) {eval("::TestParse; nil")}
     assert_nil assert_warning(useless_use) {eval("x..x; nil")}
     assert_nil assert_warning(useless_use) {eval("x...x; nil")}
-    assert_nil assert_warning(unused) {eval("self; nil")}
-    assert_nil assert_warning(unused) {eval("nil; nil")}
-    assert_nil assert_warning(unused) {eval("true; nil")}
-    assert_nil assert_warning(unused) {eval("false; nil")}
+    assert_nil assert_warning(useless_use) {eval("self; nil")}
+    assert_nil assert_warning(useless_use) {eval("nil; nil")}
+    assert_nil assert_warning(useless_use) {eval("true; nil")}
+    assert_nil assert_warning(useless_use) {eval("false; nil")}
     assert_nil assert_warning(useless_use) {eval("defined?(1); nil")}
     assert_equal 1, x
 

--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -1161,7 +1161,7 @@ END
       end
     end
 
-    bug18890 = assert_warning(/(?:.*:[47]: warning: unused literal ignored\n){2}/) do
+    bug18890 = assert_warning(/(?:.*:[47]: warning: possibly useless use of a literal in void context\n){2}/) do
       eval("#{<<~';;;'}")
       proc do |i|
         case i


### PR DESCRIPTION
For static analysis, it's better to keep unused literal nodes. If simply change block_append to fall through, both "unused literal ignored" and "possibly useless use of a literal in void context" warnings are shown for the same line. But it's verbose then remove "unused literal ignored" warning.