### PR TITLE
Handle running out of shapes in `Object#dup`

### DIFF
--- a/object.c
+++ b/object.c
@@ -326,9 +326,18 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
         RUBY_ASSERT(initial_shape->type == SHAPE_T_OBJECT);
 
         shape_to_set_on_dest = rb_shape_rebuild_shape(initial_shape, src_shape);
+        if (UNLIKELY(rb_shape_id(shape_to_set_on_dest) == OBJ_TOO_COMPLEX_SHAPE_ID)) {
+            st_table * table = rb_st_init_numtable_with_size(src_num_ivs);
+
+            rb_ivar_foreach(obj, rb_obj_evacuate_ivs_to_hash_table, (st_data_t)table);
+            rb_shape_set_too_complex(dest);
+            ROBJECT(dest)->as.heap.ivptr = (VALUE *)table;
+
+            return;
+        }
     }
 
-    RUBY_ASSERT(src_num_ivs <= shape_to_set_on_dest->capacity);
+    RUBY_ASSERT(src_num_ivs <= shape_to_set_on_dest->capacity || rb_shape_id(shape_to_set_on_dest) == OBJ_TOO_COMPLEX_SHAPE_ID);
     if (initial_shape->capacity < shape_to_set_on_dest->capacity) {
         rb_ensure_iv_list_size(dest, initial_shape->capacity, shape_to_set_on_dest->capacity);
         dest_buf = ROBJECT_IVPTR(dest);

--- a/ractor.c
+++ b/ractor.c
@@ -2758,8 +2758,8 @@ obj_traverse_i(VALUE obj, struct obj_traverse_data *data)
     if (UNLIKELY(FL_TEST_RAW(obj, FL_EXIVAR))) {
         struct gen_ivtbl *ivtbl;
         rb_ivar_generic_ivtbl_lookup(obj, &ivtbl);
-        for (uint32_t i = 0; i < ivtbl->numiv; i++) {
-            VALUE val = ivtbl->ivptr[i];
+        for (uint32_t i = 0; i < ivtbl->as.shape.numiv; i++) {
+            VALUE val = ivtbl->as.shape.ivptr[i];
             if (!UNDEF_P(val) && obj_traverse_i(val, data)) return 1;
         }
     }
@@ -3229,9 +3229,9 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
     if (UNLIKELY(FL_TEST_RAW(obj, FL_EXIVAR))) {
         struct gen_ivtbl *ivtbl;
         rb_ivar_generic_ivtbl_lookup(obj, &ivtbl);
-        for (uint32_t i = 0; i < ivtbl->numiv; i++) {
-            if (!UNDEF_P(ivtbl->ivptr[i])) {
-                CHECK_AND_REPLACE(ivtbl->ivptr[i]);
+        for (uint32_t i = 0; i < ivtbl->as.shape.numiv; i++) {
+            if (!UNDEF_P(ivtbl->as.shape.ivptr[i])) {
+                CHECK_AND_REPLACE(ivtbl->as.shape.ivptr[i]);
             }
         }
     }

--- a/shape.c
+++ b/shape.c
@@ -539,7 +539,7 @@ move_iv(VALUE obj, ID id, attr_index_t from, attr_index_t to)
       default: {
         struct gen_ivtbl *ivtbl;
         rb_gen_ivtbl_get(obj, id, &ivtbl);
-        ivtbl->ivptr[to] = ivtbl->ivptr[from];
+        ivtbl->as.shape.ivptr[to] = ivtbl->as.shape.ivptr[from];
         break;
       }
     }
@@ -570,7 +570,7 @@ remove_shape_recursive(VALUE obj, ID id, rb_shape_t * shape, VALUE * removed)
               default: {
                 struct gen_ivtbl *ivtbl;
                 rb_gen_ivtbl_get(obj, id, &ivtbl);
-                *removed = ivtbl->ivptr[index];
+                *removed = ivtbl->as.shape.ivptr[index];
                 break;
               }
             }

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -226,6 +226,26 @@ class TestShapes < Test::Unit::TestCase
     end;
   end
 
+  def test_run_out_of_shape_generic_ivar_set
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      class TooComplex < Hash
+      end
+
+      # Try to run out of shapes
+      o = Object.new
+      i = 0
+      while RubyVM::Shape.shapes_available > 0
+        o.instance_variable_set(:"@i#{i}", 1)
+        i += 1
+      end
+
+      tc = TooComplex.new
+      tc.instance_variable_set(:@a, 1)
+      tc.instance_variable_set(:@b, 2)
+    end;
+  end
+
   def test_run_out_of_shape_rb_obj_copy_ivar
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -226,6 +226,32 @@ class TestShapes < Test::Unit::TestCase
     end;
   end
 
+  def test_run_out_of_shape_rb_obj_copy_ivar
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      class A
+        def initialize
+          init # Avoid right sizing
+        end
+
+        def init
+          @a = @b = @c = @d = @e = @f = 1
+        end
+      end
+
+      a = A.new
+
+      o = Object.new
+      i = 0
+      while RubyVM::Shape.shapes_available > 1
+        o.instance_variable_set(:"@i#{i}", 1)
+        i += 1
+      end
+
+      a.dup
+    end;
+  end
+
   def test_use_all_shapes_module
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -184,6 +184,32 @@ class TestShapes < Test::Unit::TestCase
     assert_empty obj.instance_variables
   end
 
+  def test_too_complex_geniv
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      class TooComplex < Hash
+        attr_reader :very_unique
+      end
+
+      obj = Object.new
+      i = 0
+      while RubyVM::Shape.shapes_available > 0
+        obj.instance_variable_set(:"@a#{i}", 1)
+        i += 1
+      end
+
+      (RubyVM::Shape::SHAPE_MAX_VARIATIONS * 2).times do
+        TooComplex.new.instance_variable_set(:"@unique_#{_1}", 1)
+      end
+
+      tc = TooComplex.new
+      tc.instance_variable_set(:@very_unique, 3)
+      tc.instance_variable_set(:@very_unique2, 4)
+      assert_equal 3, tc.instance_variable_get(:@very_unique)
+      assert_equal 4, tc.instance_variable_get(:@very_unique2)
+    end;
+  end
+
   def test_use_all_shapes_then_freeze
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;

--- a/variable.c
+++ b/variable.c
@@ -1424,7 +1424,8 @@ rb_complex_ivar_set(VALUE obj, ID id, VALUE val)
         break;
       default:
         if (!rb_gen_ivtbl_get(obj, 0, (struct gen_ivtbl **)&table)) {
-            rb_bug("Object should have a gen_iv entry");
+            table = st_init_numtable();
+            st_insert(generic_ivtbl(obj, id, false), (st_data_t)obj, (st_data_t)table);
         }
     }
 
@@ -1500,7 +1501,9 @@ generic_ivar_set(VALUE obj, ID id, VALUE val)
         index = shape->next_iv_index;
         next_shape = rb_shape_get_next(shape, obj, id);
         if (next_shape->type == SHAPE_OBJ_TOO_COMPLEX) {
-            rb_evict_ivars_to_hash(obj, shape);
+            if (shape->next_iv_index > 0) {
+                rb_evict_ivars_to_hash(obj, shape);
+            }
             rb_complex_ivar_set(obj, id, val);
             rb_shape_set_shape(obj, next_shape);
             FL_SET_RAW(obj, FL_EXIVAR);

--- a/variable.c
+++ b/variable.c
@@ -1483,6 +1483,11 @@ generic_ivar_set(VALUE obj, ID id, VALUE val)
 
     attr_index_t index;
     // The returned shape will have `id` in its iv_table
+    if (rb_shape_obj_too_complex(obj)) {
+        rb_complex_ivar_set(obj, id, val);
+        return;
+    }
+
     rb_shape_t *shape = rb_shape_get_shape(obj);
     if (UNLIKELY(shape->type == SHAPE_OBJ_TOO_COMPLEX)) {
         rb_complex_ivar_set(obj, id, val);
@@ -1498,6 +1503,7 @@ generic_ivar_set(VALUE obj, ID id, VALUE val)
             rb_evict_ivars_to_hash(obj, shape);
             rb_complex_ivar_set(obj, id, val);
             rb_shape_set_shape(obj, next_shape);
+            FL_SET_RAW(obj, FL_EXIVAR);
             return;
         }
         shape = next_shape;

--- a/variable.c
+++ b/variable.c
@@ -1484,6 +1484,11 @@ generic_ivar_set(VALUE obj, ID id, VALUE val)
     attr_index_t index;
     // The returned shape will have `id` in its iv_table
     rb_shape_t *shape = rb_shape_get_shape(obj);
+    if (UNLIKELY(shape->type == SHAPE_OBJ_TOO_COMPLEX)) {
+        rb_complex_ivar_set(obj, id, val);
+        return;
+    }
+
     bool found = rb_shape_get_iv_index(shape, id, &index);
     rb_shape_t *next_shape = shape;
     if (!found) {

--- a/variable.h
+++ b/variable.h
@@ -16,8 +16,15 @@ struct gen_ivtbl {
 #if !SHAPE_IN_BASIC_FLAGS
     uint16_t shape_id;
 #endif
-    uint32_t numiv;
-    VALUE ivptr[FLEX_ARY_LEN];
+    union {
+        struct {
+            uint32_t numiv;
+            VALUE ivptr[1];
+        } shape;
+        struct {
+            st_table *table;
+        } complex;
+    } as;
 };
 
 int rb_ivar_generic_ivtbl_lookup(VALUE obj, struct gen_ivtbl **);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1382,18 +1382,20 @@ vm_setivar_slowpath(VALUE obj, ID id, VALUE val, const rb_iseq_t *iseq, IVC ic, 
         {
             rb_ivar_set(obj, id, val);
             shape_id_t next_shape_id = rb_shape_get_shape_id(obj);
-            rb_shape_t *next_shape = rb_shape_get_shape_by_id(next_shape_id);
-            attr_index_t index;
+            if (next_shape_id != OBJ_TOO_COMPLEX_SHAPE_ID) {
+                rb_shape_t *next_shape = rb_shape_get_shape_by_id(next_shape_id);
+                attr_index_t index;
 
-            if (rb_shape_get_iv_index(next_shape, id, &index)) { // based off the hash stored in the transition tree
-                if (index >= MAX_IVARS) {
-                    rb_raise(rb_eArgError, "too many instance variables");
+                if (rb_shape_get_iv_index(next_shape, id, &index)) { // based off the hash stored in the transition tree
+                    if (index >= MAX_IVARS) {
+                        rb_raise(rb_eArgError, "too many instance variables");
+                    }
+
+                    populate_cache(index, next_shape_id, id, iseq, ic, cc, is_attr);
                 }
-
-                populate_cache(index, next_shape_id, id, iseq, ic, cc, is_attr);
-            }
-            else {
-                rb_bug("didn't find the id");
+                else {
+                    rb_bug("didn't find the id");
+                }
             }
 
             return val;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1227,7 +1227,7 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
 #if !SHAPE_IN_BASIC_FLAGS
             shape_id = ivtbl->shape_id;
 #endif
-            ivar_list = ivtbl->ivptr;
+            ivar_list = ivtbl->as.shape.ivptr;
         }
         else {
             return default_value;
@@ -1456,7 +1456,7 @@ vm_setivar_default(VALUE obj, ID id, VALUE val, shape_id_t dest_shape_id, attr_i
         return Qundef;
     }
 
-    VALUE *ptr = ivtbl->ivptr;
+    VALUE *ptr = ivtbl->as.shape.ivptr;
 
     RB_OBJ_WRITE(obj, &ptr[index], val);
 


### PR DESCRIPTION
There is a handful of call sites where we may transition to OBJ_TOO_COMPLEX_SHAPE if we just ran out of shapes, but that weren't handling it properly.

cc @tenderlove @jemmaissroff 