### PR TITLE
test/rdoc/test_rdoc_generator_json_index.rb: pend in Travis ppc64le.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,8 @@ env:
     - travis_apt_get_options="-yq --no-install-suggests --no-install-recommends $travis_apt_get_options"
     # -g0 disables backtraces when SEGV. Do not set that.
     - debugflags=-ggdb3
-    - RUBY_TESTOPTS="$JOBS -q --tty=no"
+    # --show-skip is to print pending tests.
+    - RUBY_TESTOPTS="$JOBS -q --show-skip"
 
 .org.ruby-lang.ci.matrix-definitions:
   - &gcc-11

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,9 +111,7 @@ matrix:
     # Allow failures for the unstable jobs.
     # - name: arm32-linux
     # - name: arm64-linux
-    # FIXME: TestRDocGeneratorJsonIndex#test_generate fails randomly.
-    # https://app.travis-ci.com/github/ruby/ruby/jobs/612380961#L2900
-    - name: ppc64le-linux
+    # - name: ppc64le-linux
     # - name: s390x-linux
   fast_finish: true
 

--- a/test/rdoc/test_rdoc_generator_json_index.rb
+++ b/test/rdoc/test_rdoc_generator_json_index.rb
@@ -104,6 +104,17 @@ class TestRDocGeneratorJsonIndex < RDoc::TestCase
     orig_file = Pathname(File.join srcdir, 'generator/template/json_index/js/navigation.js')
     generated_file = Pathname(File.join @tmpdir, 'js/navigation.js')
 
+    # This fails randomly on Travis ppc64le.
+    # https://github.com/ruby/rdoc/issues/1048
+    if orig_file.mtime.inspect != generated_file.mtime.inspect &&
+      ENV['TRAVIS'] && ENV['TRAVIS_CPU_ARCH'] == 'ppc64le'
+      pend <<~EOC
+        Unstable test in Travis ppc64le
+        orig_file.mtime.inspect: #{orig_file.mtime.inspect}
+        generated_file.mtime.inspect: #{generated_file.mtime.inspect}
+      EOC
+    end
+
     # This is dirty hack on JRuby
     assert_equal orig_file.mtime.inspect, generated_file.mtime.inspect,
       '.js files should be the same timestamp of original'


### PR DESCRIPTION
This is a workaround for Travis ppc64le `test/rdoc/test_rdoc_generator_json_index.rb` failing randomly https://github.com/ruby/rdoc/issues/1048. I think pending the test disabling the `allow_failures` in Travis CI ppc64le is better because we can avoid unintentional new test failures on the case.

After testing it on this repository, I plan to send another PR to ruby/rdoc repository with the 1st commit.
