### PR TITLE
Ensure keyword splat method argument is hash

### DIFF
--- a/test/ruby/test_call.rb
+++ b/test/ruby/test_call.rb
@@ -132,6 +132,15 @@ class TestCall < Test::Unit::TestCase
     assert_equal([0, 1, 2, b], aaa(0, *ary, &ary.pop), bug16504)
   end
 
+  def test_call_args_splat_with_nonhash_keyword_splat
+    o = Object.new
+    def o.to_hash; {a: 1} end
+    def self.f(*a, **kw)
+      kw
+    end
+    assert_equal Hash, f(*[], **o).class
+  end
+
   OVER_STACK_LEN = (ENV['RUBY_OVER_STACK_LEN'] || 150).to_i # Greater than VM_ARGC_STACK_MAX
   OVER_STACK_ARGV = OVER_STACK_LEN.times.to_a.freeze
 

--- a/vm_args.c
+++ b/vm_args.c
@@ -549,6 +549,8 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
             converted_keyword_hash = check_kwrestarg(converted_keyword_hash, &kw_flag);
             rb_ary_push(args->rest, converted_keyword_hash);
             keyword_hash = Qnil;
+        } else {
+            keyword_hash = converted_keyword_hash;
         }
 
         int len = RARRAY_LENINT(args->rest);


### PR DESCRIPTION
Commit e87d0882910001ef3b0c2ccd43bf00cee8c34a0c introduced a regression where the keyword splat object passed by the caller would be directly used by callee as keyword splat parameters, if it implemented #to_hash.  The return value of #to_hash would be ignored in this case.