### PR TITLE
Add a --disable-yjit job for Ubuntu CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -37,6 +37,8 @@ jobs:
           - test_task: check
             arch: i686
           - test_task: check
+            configure: '--disable-yjit'
+          - test_task: check
             configure: '--enable-shared --enable-load-relative'
           - test_task: test-all TESTS=--repeat-count=2
           - test_task: test-all


### PR DESCRIPTION
Currently, we do not have an amd64 job that runs with YJIT disabled and runs the full check task.  Most amd64 jobs implicitly have YJIT enabled, even though --enable-yjit was not specified.  This makes it easier to determine whether a problem is YJIT-related or not by reviewing CI logs.