### PR TITLE
YJIT: Always define method codegen table at boot

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -1793,8 +1793,7 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
         rb_rjit_init(&opt->rjit);
 #endif
 #if USE_YJIT
-    if (opt->yjit)
-        rb_yjit_init();
+    rb_yjit_init(opt->yjit);
 #endif
 
     ruby_set_script_name(opt->script_name);

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -85,6 +85,16 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_yjit_enable_with_monkey_patch
+    assert_separately(%w[--yjit-disable], <<~RUBY)
+      # This lets rb_method_entry_at(rb_mKernel, ...) return NULL
+      Kernel.prepend(Module.new)
+
+      # This must not crash with "undefined optimized method!"
+      RubyVM::YJIT.enable
+    RUBY
+  end
+
   def test_yjit_stats_and_v_no_error
     _stdout, stderr, _status = invoke_ruby(%w(-v --yjit-stats), '', true, true)
     refute_includes(stderr, "NoMethodError")

--- a/yjit.h
+++ b/yjit.h
@@ -35,7 +35,7 @@ void rb_yjit_cme_invalidate(rb_callable_method_entry_t *cme);
 void rb_yjit_collect_binding_alloc(void);
 void rb_yjit_collect_binding_set(void);
 void rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit_exception);
-void rb_yjit_init(void);
+void rb_yjit_init(bool yjit_enabled);
 void rb_yjit_bop_redefined(int redefined_flag, enum ruby_basic_operators bop);
 void rb_yjit_constant_state_changed(ID id);
 void rb_yjit_iseq_mark(void *payload);
@@ -57,7 +57,7 @@ static inline void rb_yjit_cme_invalidate(rb_callable_method_entry_t *cme) {}
 static inline void rb_yjit_collect_binding_alloc(void) {}
 static inline void rb_yjit_collect_binding_set(void) {}
 static inline void rb_yjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit_exception) {}
-static inline void rb_yjit_init(void) {}
+static inline void rb_yjit_init(bool yjit_enabled) {}
 static inline void rb_yjit_bop_redefined(int redefined_flag, enum ruby_basic_operators bop) {}
 static inline void rb_yjit_constant_state_changed(ID id) {}
 static inline void rb_yjit_iseq_mark(void *payload) {}

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -29,9 +29,12 @@ pub fn yjit_enabled_p() -> bool {
 
 /// This function is called from C code
 #[no_mangle]
-pub extern "C" fn rb_yjit_init() {
+pub extern "C" fn rb_yjit_init(yjit_enabled: bool) {
+    // Register the method codegen functions. This must be done at boot.
+    yjit_reg_method_codegen_fns();
+
     // If --yjit-disable, yjit_init() will not be called until RubyVM::YJIT.enable.
-    if !get_option!(disable) {
+    if yjit_enabled && !get_option!(disable) {
         yjit_init();
     }
 }


### PR DESCRIPTION
## Problem
```rb
require "debug"
RubyVM::YJIT.enable
```

This script currently crashes with "undefined optimized method!". It's because debug.gem prepends a module to `Kernel` and it lets `rb_method_entry_at(rb_mKernel, ...)` return NULL even if that method is not overridden by the module.

## Solution
Initialize method codegen table at boot. To minimize the memory overhead when YJIT is disabled, other `CodegenGlobals` are still not initialized at boot.

## Alternatives
I considered the following alternatives and deliberately avoided them.

* Initialize all `CodegenGlobals` at boot
    * We should probably minimize the impact on the interpreter's memory usage when YJIT is disabled.
* Ignore `NULL` from `rb_method_entry_at`
    * It could return `NULL` even if those methods are not patched, so less ideal in terms of performance.
* Use `rb_callable_method_entry` instead of `rb_method_entry_at` to get a `method_serial`
    * It still leaves the problem that the methods could have already been overridden. We want to get the method serials right after the Ruby VM is initialized.