### PR TITLE
Use `OPTIMIZED_CMP` instead of `<=>` in `r_less`

### DIFF
--- a/range.c
+++ b/range.c
@@ -198,11 +198,10 @@ range_eq(VALUE range, VALUE obj)
 static int
 r_less(VALUE a, VALUE b)
 {
-    VALUE r = rb_funcall(a, id_cmp, 1, b);
-
-    if (NIL_P(r))
-        return INT_MAX;
-    return rb_cmpint(r, a, b);
+    VALUE r;
+#define rb_cmpint(cmp, a, b) (NIL_P(r = (cmp)) ? INT_MAX : rb_cmpint(r, (a), (b)))
+    return OPTIMIZED_CMP(a, b);
+#undef rb_cmpint
 }
 
 static VALUE


### PR DESCRIPTION
This PR replaces the call of `<=>` in the `r_less` function with `OPTIMIZED_CMP`.
The original `OPTIMIZED_CMP` throws an exception when the arguments are non-comparable, so only that part has been adjusted.
As a result, methods that use `r_less`, such as Range#cover? and Range#overlap, are sped up.

## benchmark

As shown below, there is a improvement in speed across many cases, and under certain conditions,
the speed has increased by more than 3x.

Iteration per second (i/s)

|                         |c3b7f27561|PR|
|:------------------------|----------------------------------:|------------------------:|
|(0..5).cover?(3)         |                            14.798M|                  35.902M|
|                         |                                  -|                    2.43x|
|(0..5).cover?(10)        |                            15.326M|                  35.897M|
|                         |                                  -|                    2.34x|
|(0..5).cover?(-10)       |                            22.193M|                  39.036M|
|                         |                                  -|                    1.76x|
|(0..5).cover?(10**100)   |                             8.286M|                   8.446M|
|                         |                                  -|                    1.02x|
|(0..10**100).cover?(5)   |                            10.332M|                  13.156M|
|                         |                                  -|                    1.27x|
|(0..).cover?(10)         |                            22.364M|                  37.954M|
|                         |                                  -|                    1.70x|
|(0..).cover?(-10)        |                            22.323M|                  38.437M|
|                         |                                  -|                    1.72x|
|(..5).cover?(10)         |                            21.503M|                  38.339M|
|                         |                                  -|                    1.78x|
|(..5).cover?(0)          |                            22.140M|                  38.358M|
|                         |                                  -|                    1.73x|
|(0..5).cover?(2.5)       |                            13.399M|                  13.660M|
|                         |                                  -|                    1.02x|
|(0..5).cover?("a")       |                            11.775M|                  11.939M|
|                         |                                  -|                    1.01x|
|("c".."i").cover?("e")   |                            11.863M|                  19.308M|
|                         |                                  -|                    1.63x|
|("c".."i").cover?("z")   |                            12.050M|                  20.150M|
|                         |                                  -|                    1.67x|
|("c"..."i").cover?("i")  |                            11.858M|                  18.812M|
|                         |                                  -|                    1.59x|
|("c"..).cover?("e")      |                            15.769M|                  22.146M|
|                         |                                  -|                    1.40x|

|                                   |c3b7f27561|PR|
|:----------------------------------|----------------------------------:|------------------------:|
|(0..5).cover?(1..3)                |                             9.297M|                  19.618M|
|                                   |                                  -|                    2.11x|
|(0..5).cover?(-1..10)              |                            14.664M|                  37.770M|
|                                   |                                  -|                    2.58x|
|(0..5).cover?(-1..3)               |                            15.093M|                  35.195M|
|                                   |                                  -|                    2.33x|
|(0..5).cover?(1..10)               |                             9.208M|                  19.596M|
|                                   |                                  -|                    2.13x|
|(0..5).cover?(20..30)              |                            11.352M|                  34.932M|
|                                   |                                  -|                    3.08x|
|(0..5).cover?(10**100..10**200)    |                             7.017M|                   7.267M|
|                                   |                                  -|                    1.04x|
|(0..5).cover?(-10**200..-10**100)  |                            10.755M|                  11.045M|
|                                   |                                  -|                    1.03x|
|(0..5).cover?(-10**100..10**100)   |                            10.854M|                  11.087M|
|                                   |                                  -|                    1.02x|
|(0..5).cover?(1..)                 |                            42.844M|                  42.775M|
|                                   |                              1.00x|                        -|
|(0..5).cover?(..1)                 |                            41.977M|                  42.815M|
|                                   |                                  -|                    1.02x|
|(0..).cover?(1..3)                 |                            10.654M|                  18.162M|
|                                   |                                  -|                    1.70x|
|(0..).cover?(1..)                  |                            14.850M|                  22.623M|
|                                   |                                  -|                    1.52x|
|(0..).cover?(-3..-1)               |                            15.185M|                  37.284M|
|                                   |                                  -|                    2.46x|
|(0..).cover?(..-1)                 |                            43.946M|                  42.232M|
|                                   |                              1.04x|                        -|
|(..10).cover?(1..3)                |                            11.364M|                  20.151M|
|                                   |                                  -|                    1.77x|
|(..10).cover?(..1)                 |                            22.298M|                  21.648M|
|                                   |                              1.03x|                        -|
|(..10).cover?(20..30)              |                            15.246M|                  36.494M|
|                                   |                                  -|                    2.39x|
|(..10).cover?(20..)                |                            42.672M|                  41.852M|
|                                   |                              1.02x|                        -|
|(..nil).cover?(..1)                |                            19.347M|                  19.671M|
|                                   |                                  -|                    1.02x|
|("c".."i").cover?("d".."g")        |                             9.135M|                  16.174M|
|                                   |                                  -|                    1.77x|
|("c".."i").cover?("d".."z")        |                             9.084M|                  15.274M|
|                                   |                                  -|                    1.68x|
|("c".."i").cover?("d"..."z")       |                           806.760k|                 860.000k|
|                                   |                                  -|                    1.07x|
|("c".."i").cover?("a".."b")        |                            14.712M|                  30.472M|
|                                   |                                  -|                    2.07x|
|("c"..).cover?("a".."z")           |                            15.029M|                  30.149M|
|                                   |                                  -|                    2.01x|
|("c"..).cover?("e".."z")           |                            10.401M|                  15.737M|
|                                   |                                  -|                    1.51x|
|r_date.cover?(r_date2)             |                             6.636M|                   6.700M|
|                                   |                                  -|                    1.01x|

|                           |c3b7f27561|PR|
|:--------------------------|----------------------------------:|------------------------:|
|(2..3).overlap?(1..1)      |                            23.469M|                  44.254M|
|                           |                                  -|                    1.89x|
|(2..3).overlap?(2..4)      |                            15.567M|                  40.933M|
|                           |                                  -|                    2.63x|
|(2..3).overlap?(4..5)      |                            15.344M|                  38.025M|
|                           |                                  -|                    2.48x|
|(2..3).overlap?(2..1)      |                            23.537M|                  40.531M|
|                           |                                  -|                    1.72x|
|(2..3).overlap?(0..1)      |                            23.081M|                  41.004M|
|                           |                                  -|                    1.78x|
|(2..3).overlap?(...1)      |                            22.675M|                  40.935M|
|                           |                                  -|                    1.81x|
|(2...3).overlap?(..2)      |                             5.969M|                   7.747M|
|                           |                                  -|                    1.30x|
|(2...3).overlap?(3...)     |                            22.336M|                  40.311M|
|                           |                                  -|                    1.80x|
|(2..3).overlap?('a'..'d')  |                            15.012M|                  15.009M|
|                           |                              1.00x|                        -|
