### PR TITLE
thread_pthread.c: unbreak 10.5 Intel by restoring accidentally deleted macro

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -2729,7 +2729,12 @@ native_thread_native_thread_id(rb_thread_t *target_th)
     return INT2FIX(tid);
 #elif defined(__APPLE__)
     uint64_t tid;
-# if ((MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_6) || \
+/* The first condition is needed because MAC_OS_X_VERSION_10_6
+    is not defined on 10.5, and while __POWERPC__ takes care of ppc/ppc64,
+    i386 will be broken without this. Note, 10.5 is supported with GCC upstream,
+    so it has C++17 and everything needed to build modern Ruby. */
+# if (!defined(MAC_OS_X_VERSION_10_6) || \
+      (MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_6) || \
       defined(__POWERPC__) /* never defined for PowerPC platforms */)
     const bool no_pthread_threadid_np = true;
 #   define NO_PTHREAD_MACH_THREAD_NP 1


### PR DESCRIPTION
Commit https://github.com/ruby/ruby/commit/be1bbd5b7d40ad863ab35097765d3754726bbd54 accidentally dropped a macro which is needed for 10.5 Intel. As I explain in a comment to the code, 10.5 supports modern compilers, so there is no need to break it.

We could have a neater macro, if we switched to numeric ones: unlike `MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_10_6`, which does not work correctly on 10.5, `MAC_OS_X_VERSION_MAX_ALLOWED < 1060` would work on every macOS. However last time it was discussed here, non-numeric macros were favored for the sake of a better readability of the code. So I leave them in place.