### PR TITLE
remove_instance_variable: Handle running out of shapes

### DIFF
--- a/shape.h
+++ b/shape.h
@@ -162,7 +162,7 @@ void rb_shape_set_shape(VALUE obj, rb_shape_t* shape);
 rb_shape_t* rb_shape_get_shape(VALUE obj);
 int rb_shape_frozen_shape_p(rb_shape_t* shape);
 rb_shape_t* rb_shape_transition_shape_frozen(VALUE obj);
-void rb_shape_transition_shape_remove_ivar(VALUE obj, ID id, rb_shape_t *shape, VALUE * removed);
+bool rb_shape_transition_shape_remove_ivar(VALUE obj, ID id, rb_shape_t *shape, VALUE * removed);
 rb_shape_t * rb_shape_transition_shape_capa(rb_shape_t * shape);
 rb_shape_t* rb_shape_get_next(rb_shape_t* shape, VALUE obj, ID id);
 

--- a/variable.c
+++ b/variable.c
@@ -2198,37 +2198,38 @@ rb_obj_remove_instance_variable(VALUE obj, VALUE name)
       case T_CLASS:
       case T_MODULE:
         IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(id);
-        if (rb_shape_obj_too_complex(obj)) {
+        if (!rb_shape_transition_shape_remove_ivar(obj, id, shape, &val)) {
+            if (!rb_shape_obj_too_complex(obj)) {
+                rb_evict_ivars_to_hash(obj, shape);
+            }
             if (!st_delete(RCLASS_IV_HASH(obj), (st_data_t *)&id, (st_data_t *)&val)) {
                 val = Qundef;
             }
         }
-        else {
-            rb_shape_transition_shape_remove_ivar(obj, id, shape, &val);
-        }
         break;
       case T_OBJECT: {
-        if (rb_shape_obj_too_complex(obj)) {
+        if (!rb_shape_transition_shape_remove_ivar(obj, id, shape, &val)) {
+            if (!rb_shape_obj_too_complex(obj)) {
+                rb_evict_ivars_to_hash(obj, shape);
+            }
             if (rb_st_lookup(ROBJECT_IV_HASH(obj), (st_data_t)id, (st_data_t *)&val)) {
                 rb_st_delete(ROBJECT_IV_HASH(obj), (st_data_t *)&id, 0);
             }
         }
-        else {
-            rb_shape_transition_shape_remove_ivar(obj, id, shape, &val);
-        }
         break;
       }
       default: {
-        if (rb_shape_obj_too_complex(obj)) {
+        if (!rb_shape_transition_shape_remove_ivar(obj, id, shape, &val)) {
+            if (!rb_shape_obj_too_complex(obj)) {
+                rb_evict_ivars_to_hash(obj, shape);
+            }
+
             struct gen_ivtbl *ivtbl;
             if (rb_gen_ivtbl_get(obj, 0, &ivtbl)) {
                 if (!st_delete(ivtbl->as.complex.table, (st_data_t *)&id, (st_data_t *)&val)) {
                     val = Qundef;
                 }
             }
-        }
-        else {
-            rb_shape_transition_shape_remove_ivar(obj, id, shape, &val);
         }
         break;
       }


### PR DESCRIPTION
`remove_shape_recursive` wasn't considering that if we run out of shapes, it might have to transition to SHAPE_TOO_COMPLEX.

When this happens, we now return with an error and the caller initiates the evacuation.