### PR TITLE
YJIT: skip to_a in format_number

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -435,7 +435,7 @@ module RubyVM::YJIT
     # Format large numbers with comma separators for readability
     def format_number(pad, number)
       integer, decimal = number.to_s.split(".")
-      d_groups = integer.chars.to_a.reverse.each_slice(3)
+      d_groups = integer.chars.reverse.each_slice(3)
       with_commas = d_groups.map(&:join).join(',').reverse
       formatted = [with_commas, decimal].compact.join(".")
       formatted.rjust(pad, ' ')


### PR DESCRIPTION
String#chars returns an array instead of an enumerator since Ruby 2.0.