### PR TITLE
Make String.new size pools aware.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1175,6 +1175,7 @@ BUILTIN_RB_SRCS = \
 		$(srcdir)/array.rb \
 		$(srcdir)/kernel.rb \
 		$(srcdir)/ractor.rb \
+		$(srcdir)/string.rb \
 		$(srcdir)/symbol.rb \
 		$(srcdir)/timev.rb \
 		$(srcdir)/thread_sync.rb \
@@ -16890,6 +16891,7 @@ string.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 string.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 string.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 string.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
+string.$(OBJEXT): {$(VPATH)}builtin.h
 string.$(OBJEXT): {$(VPATH)}config.h
 string.$(OBJEXT): {$(VPATH)}constant.h
 string.$(OBJEXT): {$(VPATH)}debug_counter.h
@@ -17064,6 +17066,7 @@ string.$(OBJEXT): {$(VPATH)}rubyparser.h
 string.$(OBJEXT): {$(VPATH)}shape.h
 string.$(OBJEXT): {$(VPATH)}st.h
 string.$(OBJEXT): {$(VPATH)}string.c
+string.$(OBJEXT): {$(VPATH)}string.rbinc
 string.$(OBJEXT): {$(VPATH)}subst.h
 string.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 string.$(OBJEXT): {$(VPATH)}thread_native.h

--- a/inits.c
+++ b/inits.c
@@ -97,6 +97,7 @@ rb_call_builtin_inits(void)
     BUILTIN(warning);
     BUILTIN(array);
     BUILTIN(kernel);
+    BUILTIN(string);
     BUILTIN(symbol);
     BUILTIN(timev);
     BUILTIN(thread_sync);

--- a/string.rb
+++ b/string.rb
@@ -549,4 +549,14 @@
 #    as determined by a given record separator.
 #  - #upto: Calls the given block with each string value returned by successive calls to #succ.
 
-class String; end
+class String
+  def self.new(orig = (unspecified = true), encoding: nil, capacity: nil)
+    __builtin_string_create(orig, unspecified, encoding, capacity)
+  end
+
+  def self.inherited(child) # :nodoc:
+    if child.superclass == String
+      child.define_singleton_method(:new, Class.instance_method(:new))
+    end
+  end
+end

--- a/test/-ext-/string/test_capacity.rb
+++ b/test/-ext-/string/test_capacity.rb
@@ -23,7 +23,7 @@ class Test_StringCapacity < Test::Unit::TestCase
   def test_s_new_capacity
     assert_equal("", String.new(capacity: 1000))
     assert_equal(String, String.new(capacity: 1000).class)
-    assert_equal(10000, capa(String.new(capacity: 10000)))
+    assert_equal(10_000 - 1, capa(String.new(capacity: 10_000))) # Real capa doesn't account for termlen
 
     assert_equal("", String.new(capacity: -1000))
     assert_equal(capa(String.new(capacity: -10000)), capa(String.new(capacity: -1000)))


### PR DESCRIPTION
If the required capacity would fit in an embded string, returns one.

This can reduce malloc churn for code that use string buffers.

```
$ time ../miniruby-master -v -e '10_000_000.times { String.new(capacity: 512) }'
ruby 3.3.0dev (2023-11-02T16:15:48Z master ad4f973ecd) [arm64-darwin22]
last_commit=YJIT: Always define method codegen table at boot (#8807)

real	0m2.821s
user	0m2.460s
sys	0m0.249s
$ time ./miniruby -v -e '10_000_000.times { String.new(capacity: 512) }'
ruby 3.3.0dev (2023-11-02T16:58:58Z string-buffer-opt ee1dacb047) [arm64-darwin22]

real	0m1.127s
user	0m1.080s
sys	0m0.020s
```

However backward compatibility is tricky. `new` should forward all arguments to the subclass init.