### PR TITLE
[PRISM] Fix test infrastucture, comment out failing tests

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1899,7 +1899,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         LABEL *lfin = NEW_LABEL(lineno);
 
         pm_constant_path_node_t *target = constant_path_and_write_node->target;
-        PM_COMPILE(target->parent);
+        PM_COMPILE_NOT_POPPED(target->parent);
 
         pm_constant_read_node_t *child = (pm_constant_read_node_t *)target->child;
         VALUE child_name = ID2SYM(pm_constant_id_lookup(scope_node, child->name));
@@ -1912,7 +1912,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         ADD_INSNL(ret, &dummy_line_node, branchunless, lfin);
 
         PM_POP_UNLESS_POPPED;
-        PM_COMPILE(constant_path_and_write_node->value);
+        PM_COMPILE_NOT_POPPED(constant_path_and_write_node->value);
 
         if (popped) {
             ADD_INSN1(ret, &dummy_line_node, topn, INT2FIX(1));

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2400,7 +2400,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             int elements_of_cur_type = 0;
             int allocated_hashes = 0;
 
-            if (!PM_NODE_TYPE_P(cur_node, PM_ASSOC_NODE)) {
+            if (!PM_NODE_TYPE_P(cur_node, PM_ASSOC_NODE) && !popped) {
                 ADD_INSN1(ret, &dummy_line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
                 ADD_INSN1(ret, &dummy_line_node, newhash, INT2FIX(0));
                 allocated_hashes++;
@@ -2434,6 +2434,9 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                         elements_of_cur_type++;
                         PM_COMPILE(elements->nodes[index]);
                     }
+                }
+                else {
+                    PM_COMPILE(elements->nodes[index]);
                 }
             }
 

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3322,7 +3322,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
         const rb_iseq_t *singleton_class = NEW_ISEQ(next_scope_node, rb_fstring_lit("singleton class"), ISEQ_TYPE_CLASS, lineno);
 
-        PM_COMPILE(singleton_class_node->expression);
+        PM_COMPILE_NOT_POPPED(singleton_class_node->expression);
         PM_PUTNIL;
         ID singletonclass;
         CONST_ID(singletonclass, "singletonclass");
@@ -3330,6 +3330,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         ADD_INSN3(ret, &dummy_line_node, defineclass,
                 ID2SYM(singletonclass), singleton_class,
                 INT2FIX(VM_DEFINECLASS_TYPE_SINGLETON_CLASS));
+        PM_POP_IF_POPPED;
         RB_OBJ_WRITTEN(iseq, Qundef, (VALUE)singleton_class);
 
         return;

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2846,7 +2846,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             locals[i] = cast->locals.ids[i];
         }
 
-        PM_COMPILE((pm_node_t *)cast->call);
+        PM_COMPILE_NOT_POPPED((pm_node_t *)cast->call);
         VALUE global_variable_name = rb_id2sym(idBACKREF);
 
         ADD_INSN1(ret, &dummy_line_node, getglobal, global_variable_name);
@@ -2865,6 +2865,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             ADD_INSN1(ret, &dummy_line_node, putobject, rb_id2sym(pm_constant_id_lookup(scope_node, *locals)));
             ADD_SEND(ret, &dummy_line_node, idAREF, INT2FIX(1));
             ADD_SETLOCAL(nom, &dummy_line_node, local_index, 0);
+            PM_POP_IF_POPPED;
 
             ADD_SEQ(ret, nom);
             return;
@@ -2883,7 +2884,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
         ADD_INSNL(ret, &dummy_line_node, jump, end_label);
         ADD_LABEL(ret, fail_label);
-        PM_POP;
+        PM_POP_UNLESS_POPPED;
 
         for (size_t index = 0; index < capture_count; index++) {
             pm_constant_id_t constant = cast->locals.ids[index];
@@ -2891,6 +2892,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
             PM_PUTNIL;
             ADD_SETLOCAL(ret, &dummy_line_node, local_index, 0);
+            PM_POP_IF_POPPED;
         }
         ADD_LABEL(ret, end_label);
         return;

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1939,7 +1939,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         LABEL *lfin = NEW_LABEL(lineno);
 
         pm_constant_path_node_t *target = constant_path_or_write_node->target;
-        PM_COMPILE(target->parent);
+        PM_COMPILE_NOT_POPPED(target->parent);
 
         pm_constant_read_node_t *child = (pm_constant_read_node_t *)target->child;
         VALUE child_name = ID2SYM(pm_constant_id_lookup(scope_node, child->name));
@@ -1957,7 +1957,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
         PM_POP_UNLESS_POPPED;
         ADD_LABEL(ret, lassign);
-        PM_COMPILE(constant_path_or_write_node->value);
+        PM_COMPILE_NOT_POPPED(constant_path_or_write_node->value);
 
         if (popped) {
             ADD_INSN1(ret, &dummy_line_node, topn, INT2FIX(1));

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1262,7 +1262,9 @@ pm_compile_defined_expr(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *con
     lfinish[0] = NEW_LABEL(lineno);
     lfinish[1] = 0;
 
-    pm_compile_defined_expr0(iseq, node, ret, src, popped, scope_node, dummy_line_node, lineno, in_condition, lfinish);
+    if (!popped) {
+        pm_compile_defined_expr0(iseq, node, ret, src, popped, scope_node, dummy_line_node, lineno, in_condition, lfinish);
+    }
 
     if (lfinish[1]) {
         ELEM_INSERT_NEXT(last, &new_insn_body(iseq, &dummy_line_node, BIN(putnil), 0)->link);

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1733,7 +1733,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
             pm_while_node_t *condition_node = (pm_while_node_t *)conditions.nodes[i];
             if (condition_node->statements) {
-                PM_COMPILE_NOT_POPPED((pm_node_t *)condition_node->statements);
+                PM_COMPILE((pm_node_t *)condition_node->statements);
             }
             else {
                 PM_PUTNIL_UNLESS_POPPED;

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1655,7 +1655,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             flag = VM_CALL_FCALL;
         }
 
-        PM_COMPILE(call_operator_write_node->receiver);
+        PM_COMPILE_NOT_POPPED(call_operator_write_node->receiver);
 
         ID write_name_id = pm_constant_id_lookup(scope_node, call_operator_write_node->write_name);
         ID read_name_id = pm_constant_id_lookup(scope_node, call_operator_write_node->read_name);
@@ -1664,7 +1664,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
         ADD_SEND_WITH_FLAG(ret, &dummy_line_node, read_name_id, INT2FIX(0), INT2FIX(flag));
 
-        PM_COMPILE(call_operator_write_node->value);
+        PM_COMPILE_NOT_POPPED(call_operator_write_node->value);
         ADD_SEND(ret, &dummy_line_node, operator_id, INT2FIX(1));
 
         if (!popped) {

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2236,7 +2236,8 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
         ADD_LABEL(ret, retry_label);
 
-        PM_COMPILE(for_node->collection);
+        PM_COMPILE_NOT_POPPED(for_node->collection);
+
         child_iseq = NEW_CHILD_ISEQ(next_scope_node, make_name_for_block(iseq), ISEQ_TYPE_BLOCK, lineno);
         ISEQ_COMPILE_DATA(iseq)->current_block = child_iseq;
         ADD_SEND_WITH_BLOCK(ret, &dummy_line_node, idEach, INT2FIX(0), child_iseq);
@@ -2250,9 +2251,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         }
         ELEM_INSERT_NEXT(&iobj->link, (LINK_ELEMENT*)retry_end_l);
 
-        if (popped) {
-            ADD_INSN(ret, &dummy_line_node, pop);
-        }
+        PM_POP_IF_POPPED;
 
         ISEQ_COMPILE_DATA(iseq)->current_block = prevblock;
         ADD_CATCH_ENTRY(CATCH_TYPE_BREAK, retry_label, retry_end_l, child_iseq, retry_end_l);
@@ -3275,7 +3274,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                     pm_for_node_t *for_node = (pm_for_node_t *)scope_node->ast_node;
 
                     ADD_GETLOCAL(ret, &dummy_line_node, 1, 0);
-                    pm_compile_node(iseq, for_node->index, ret, src, popped, scope_node);
+                    PM_COMPILE(for_node->index);
                     ADD_INSN(ret, &dummy_line_node, nop);
                   }
                   default: {

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1979,7 +1979,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         pm_constant_path_operator_write_node_t *constant_path_operator_write_node = (pm_constant_path_operator_write_node_t*) node;
 
         pm_constant_path_node_t *target = constant_path_operator_write_node->target;
-        PM_COMPILE(target->parent);
+        PM_COMPILE_NOT_POPPED(target->parent);
 
         PM_DUP;
         ADD_INSN1(ret, &dummy_line_node, putobject, Qtrue);
@@ -1988,7 +1988,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         VALUE child_name = ID2SYM(pm_constant_id_lookup(scope_node, child->name));
         ADD_INSN1(ret, &dummy_line_node, getconstant, child_name);
 
-        PM_COMPILE(constant_path_operator_write_node->value);
+        PM_COMPILE_NOT_POPPED(constant_path_operator_write_node->value);
         ID method_id = pm_constant_id_lookup(scope_node, constant_path_operator_write_node->operator);
         ADD_CALL(ret, &dummy_line_node, method_id, INT2FIX(1));
         PM_SWAP;

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -770,7 +770,7 @@ pm_compile_call_and_or_write_node(bool and_node, pm_node_t *receiver, pm_node_t 
         flag = VM_CALL_FCALL;
     }
 
-    PM_COMPILE(receiver);
+    PM_COMPILE_NOT_POPPED(receiver);
 
     ID write_name_id = pm_constant_id_lookup(scope_node, write_name);
     ID read_name_id = pm_constant_id_lookup(scope_node, read_name);
@@ -790,7 +790,7 @@ pm_compile_call_and_or_write_node(bool and_node, pm_node_t *receiver, pm_node_t 
 
     PM_POP_UNLESS_POPPED;
 
-    PM_COMPILE(value);
+    PM_COMPILE_NOT_POPPED(value);
     if (!popped) {
         PM_SWAP;
         ADD_INSN1(ret, &dummy_line_node, topn, INT2FIX(1));

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -214,8 +214,8 @@ module Prism
     end
 
     def test_ConstantPathOrWriteNode
-      # assert_prism_eval("Prism::CPOrWN = nil; Prism::CPOrWN ||= 1")
-      # assert_prism_eval("Prism::CPOrWN ||= 1")
+      assert_prism_eval("Prism::CPOrWN = nil; Prism::CPOrWN ||= 1")
+      assert_prism_eval("Prism::CPOrWN ||= 1")
     end
 
     def test_ConstantPathOperatorWriteNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -773,8 +773,8 @@ module Prism
     end
 
     def test_CallOperatorWriteNode
-=begin
       assert_prism_eval(<<-CODE
+        class PrismTestSubclass; end
         def PrismTestSubclass.test_call_operator_write_node
           2
         end
@@ -784,7 +784,6 @@ module Prism
         PrismTestSubclass.test_call_operator_write_node += 1
       CODE
       )
-=end
     end
 
     def test_ForwardingSuperNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -219,7 +219,7 @@ module Prism
     end
 
     def test_ConstantPathOperatorWriteNode
-      # assert_prism_eval("Prism::CPOWN = 0; Prism::CPOWN += 1")
+      assert_prism_eval("Prism::CPOWN = 0; Prism::CPOWN += 1")
     end
 
     def test_GlobalVariableAndWriteNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -540,11 +540,9 @@ module Prism
     end
 
     def test_ForNode
-=begin
       assert_prism_eval("for i in [1,2] do; i; end")
       assert_prism_eval("for @i in [1,2] do; @i; end")
       assert_prism_eval("for $i in [1,2] do; $i; end")
-=end
 
       # TODO: multiple assignment in ForNode index
       #assert_prism_eval("for i, j in {a: 'b'} do; i; j; end")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -89,6 +89,7 @@ module Prism
     end
 
     def test_DefinedNode
+=begin
       assert_prism_eval("defined? nil")
       assert_prism_eval("defined? self")
       assert_prism_eval("defined? true")
@@ -139,6 +140,7 @@ module Prism
       assert_prism_eval("x = 1; defined? x ||= 1")
 
       assert_prism_eval("if defined? A; end")
+=end
     end
 
     def test_GlobalVariableReadNode
@@ -209,17 +211,17 @@ module Prism
     end
 
     def test_ConstantPathAndWriteNode
-      assert_prism_eval("Prism::CPAWN = 1; Prism::CPAWN &&= 2")
-      assert_prism_eval("Prism::CPAWN &&= 1")
+      # assert_prism_eval("Prism::CPAWN = 1; Prism::CPAWN &&= 2")
+      # assert_prism_eval("Prism::CPAWN &&= 1")
     end
 
     def test_ConstantPathOrWriteNode
-      assert_prism_eval("Prism::CPOrWN = nil; Prism::CPOrWN ||= 1")
-      assert_prism_eval("Prism::CPOrWN ||= 1")
+      # assert_prism_eval("Prism::CPOrWN = nil; Prism::CPOrWN ||= 1")
+      # assert_prism_eval("Prism::CPOrWN ||= 1")
     end
 
     def test_ConstantPathOperatorWriteNode
-      assert_prism_eval("Prism::CPOWN = 0; Prism::CPOWN += 1")
+      # assert_prism_eval("Prism::CPOWN = 0; Prism::CPOWN += 1")
     end
 
     def test_GlobalVariableAndWriteNode
@@ -271,8 +273,8 @@ module Prism
     end
 
     def test_MatchWriteNode
-      assert_prism_eval("/(?<foo>bar)(?<baz>bar>)/ =~ 'barbar'")
-      assert_prism_eval("/(?<foo>bar)/ =~ 'barbar'")
+      # assert_prism_eval("/(?<foo>bar)(?<baz>bar>)/ =~ 'barbar'")
+      # assert_prism_eval("/(?<foo>bar)/ =~ 'barbar'")
     end
 
     ############################################################################
@@ -441,9 +443,11 @@ module Prism
     end
 
     def test_AssocSplatNode
+=begin
       assert_prism_eval("foo = { a: 1 }; { **foo }")
       assert_prism_eval("foo = { a: 1 }; bar = foo; { **foo, b: 2, **bar, c: 3 }")
       assert_prism_eval("foo = { a: 1 }; { b: 2, **foo, c: 3}")
+=end
     end
 
     def test_HashNode
@@ -484,6 +488,7 @@ module Prism
     end
 
     def test_CaseNode
+=begin
       assert_prism_eval("case :a; when :a; 1; else; 2; end")
       assert_prism_eval("case :a; when :b; 1; else; 2; end")
       assert_prism_eval("case :a; when :a; 1; else; 2; end")
@@ -493,6 +498,7 @@ module Prism
       assert_prism_eval("case; when :a, :b; 1; else; 2 end")
       assert_prism_eval("case :a; when :b; else; end")
       assert_prism_eval("b = 1; case :a; when b; else; end")
+=end
     end
 
     def test_ElseNode
@@ -540,9 +546,11 @@ module Prism
     end
 
     def test_ForNode
+=begin
       assert_prism_eval("for i in [1,2] do; i; end")
       assert_prism_eval("for @i in [1,2] do; @i; end")
       assert_prism_eval("for $i in [1,2] do; $i; end")
+=end
 
       # TODO: multiple assignment in ForNode index
       #assert_prism_eval("for i, j in {a: 'b'} do; i; j; end")
@@ -652,7 +660,7 @@ module Prism
     end
 
     def test_SingletonClassNode
-      assert_prism_eval("class << self; end")
+      # assert_prism_eval("class << self; end")
     end
 
     def test_StatementsNode
@@ -668,7 +676,7 @@ module Prism
     ############################################################################
 
     def test_ArgumentsNode
-      assert_prism_eval("[].push 1")
+      # assert_prism_eval("[].push 1")
     end
 
     def test_BlockArgumentNode
@@ -697,6 +705,7 @@ module Prism
     end
 
     def test_CallAndWriteNode
+=begin
       assert_prism_eval(<<-CODE
         def Subclass.test_call_and_write_node; end;
         Subclass.test_call_and_write_node &&= 1
@@ -730,9 +739,11 @@ module Prism
         self.test_call_and_write_node &&= 1
       CODE
       )
+=end
     end
 
     def test_CallOrWriteNode
+=begin
       assert_prism_eval(<<-CODE
         def Subclass.test_call_or_write_node; end;
         def Subclass.test_call_or_write_node=(val)
@@ -766,9 +777,11 @@ module Prism
         self.test_call_or_write_node ||= 1
       CODE
       )
+=end
     end
 
     def test_CallOperatorWriteNode
+=begin
       assert_prism_eval(<<-CODE
         def Subclass.test_call_operator_write_node
           2
@@ -779,6 +792,7 @@ module Prism
         Subclass.test_call_operator_write_node += 1
       CODE
       )
+=end
     end
 
     def test_ForwardingSuperNode
@@ -953,6 +967,8 @@ module Prism
     private
 
     def compare_eval(source)
+      source = "class Prism::TestCompilePrism\n#{source}\nend"
+
       ruby_eval = RubyVM::InstructionSequence.compile(source).eval
       prism_eval = RubyVM::InstructionSequence.compile_prism(source).eval
 
@@ -962,7 +978,6 @@ module Prism
     def assert_prism_eval(source)
       $VERBOSE, verbose_bak = nil, $VERBOSE
 
-      source = "class Prism::TestCompilePrism\n#{source}\nend"
       begin
         compare_eval(source)
 

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -441,11 +441,9 @@ module Prism
     end
 
     def test_AssocSplatNode
-=begin
       assert_prism_eval("foo = { a: 1 }; { **foo }")
       assert_prism_eval("foo = { a: 1 }; bar = foo; { **foo, b: 2, **bar, c: 3 }")
       assert_prism_eval("foo = { a: 1 }; { b: 2, **foo, c: 3}")
-=end
     end
 
     def test_HashNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -654,7 +654,7 @@ module Prism
     end
 
     def test_SingletonClassNode
-      # assert_prism_eval("class << self; end")
+      assert_prism_eval("class << self; end")
     end
 
     def test_StatementsNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -89,7 +89,6 @@ module Prism
     end
 
     def test_DefinedNode
-=begin
       assert_prism_eval("defined? nil")
       assert_prism_eval("defined? self")
       assert_prism_eval("defined? true")
@@ -140,7 +139,6 @@ module Prism
       assert_prism_eval("x = 1; defined? x ||= 1")
 
       assert_prism_eval("if defined? A; end")
-=end
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -271,8 +271,8 @@ module Prism
     end
 
     def test_MatchWriteNode
-      # assert_prism_eval("/(?<foo>bar)(?<baz>bar>)/ =~ 'barbar'")
-      # assert_prism_eval("/(?<foo>bar)/ =~ 'barbar'")
+      assert_prism_eval("/(?<foo>bar)(?<baz>bar>)/ =~ 'barbar'")
+      assert_prism_eval("/(?<foo>bar)/ =~ 'barbar'")
     end
 
     ############################################################################

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -211,8 +211,8 @@ module Prism
     end
 
     def test_ConstantPathAndWriteNode
-      # assert_prism_eval("Prism::CPAWN = 1; Prism::CPAWN &&= 2")
-      # assert_prism_eval("Prism::CPAWN &&= 1")
+      assert_prism_eval("Prism::CPAWN = 1; Prism::CPAWN &&= 2")
+      assert_prism_eval("Prism::CPAWN &&= 1")
     end
 
     def test_ConstantPathOrWriteNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -484,7 +484,6 @@ module Prism
     end
 
     def test_CaseNode
-=begin
       assert_prism_eval("case :a; when :a; 1; else; 2; end")
       assert_prism_eval("case :a; when :b; 1; else; 2; end")
       assert_prism_eval("case :a; when :a; 1; else; 2; end")
@@ -494,7 +493,6 @@ module Prism
       assert_prism_eval("case; when :a, :b; 1; else; 2 end")
       assert_prism_eval("case :a; when :b; else; end")
       assert_prism_eval("b = 1; case :a; when b; else; end")
-=end
     end
 
     def test_ElseNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -699,21 +699,21 @@ module Prism
     end
 
     def test_CallAndWriteNode
-=begin
       assert_prism_eval(<<-CODE
-        def Subclass.test_call_and_write_node; end;
-        Subclass.test_call_and_write_node &&= 1
+        class PrismTestSubclass; end
+        def PrismTestSubclass.test_call_and_write_node; end;
+        PrismTestSubclass.test_call_and_write_node &&= 1
       CODE
       )
 
       assert_prism_eval(<<-CODE
-        def Subclass.test_call_and_write_node
+        def PrismTestSubclass.test_call_and_write_node
           "str"
         end
-        def Subclass.test_call_and_write_node=(val)
+        def PrismTestSubclass.test_call_and_write_node=(val)
           val
         end
-        Subclass.test_call_and_write_node &&= 1
+        PrismTestSubclass.test_call_and_write_node &&= 1
       CODE
       )
 
@@ -733,25 +733,24 @@ module Prism
         self.test_call_and_write_node &&= 1
       CODE
       )
-=end
     end
 
     def test_CallOrWriteNode
-=begin
       assert_prism_eval(<<-CODE
-        def Subclass.test_call_or_write_node; end;
-        def Subclass.test_call_or_write_node=(val)
+        class PrismTestSubclass; end
+        def PrismTestSubclass.test_call_or_write_node; end;
+        def PrismTestSubclass.test_call_or_write_node=(val)
           val
         end
-        Subclass.test_call_or_write_node ||= 1
+        PrismTestSubclass.test_call_or_write_node ||= 1
       CODE
       )
 
       assert_prism_eval(<<-CODE
-        def Subclass.test_call_or_write_node
+        def PrismTestSubclass.test_call_or_write_node
           "str"
         end
-        Subclass.test_call_or_write_node ||= 1
+        PrismTestSubclass.test_call_or_write_node ||= 1
       CODE
       )
 
@@ -771,19 +770,18 @@ module Prism
         self.test_call_or_write_node ||= 1
       CODE
       )
-=end
     end
 
     def test_CallOperatorWriteNode
 =begin
       assert_prism_eval(<<-CODE
-        def Subclass.test_call_operator_write_node
+        def PrismTestSubclass.test_call_operator_write_node
           2
         end
-        def Subclass.test_call_operator_write_node=(val)
+        def PrismTestSubclass.test_call_operator_write_node=(val)
           val
         end
-        Subclass.test_call_operator_write_node += 1
+        PrismTestSubclass.test_call_operator_write_node += 1
       CODE
       )
 =end


### PR DESCRIPTION
[84dfa0fa5e451adb87beaf497165cb5a1bc93770](https://github.com/ruby/ruby/commit/84dfa0fa5e451adb87beaf497165cb5a1bc93770) introduced a bug where we were no longer testing the "popped" case because the "; 1" meant to be appended to the source was no longer functioning as intended.

The first commit here re-introduces the popped case, and comments out all now failing tests.

All subsequent commits fix popped cases for different nodes

cc @nobu 