### PR TITLE
[PRISM] Fix CallNode with arguments when popped

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1403,7 +1403,7 @@ pm_setup_args(pm_arguments_node_t *arguments_node, int *flags, struct rb_callinf
               default: {
                   orig_argc++;
                   post_splat_counter++;
-                  PM_COMPILE(argument);
+                  PM_COMPILE_NOT_POPPED(argument);
 
                   if (has_splat) {
                       // If the next node starts the keyword section of parameters

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -694,6 +694,12 @@ module Prism
 
     def test_CallNode
       assert_prism_eval("to_s")
+
+      # with arguments
+      assert_prism_eval("eval '1'")
+
+      # with arguments and popped
+      assert_prism_eval("eval '1'; 1")
     end
 
     def test_CallAndWriteNode


### PR DESCRIPTION
Previously emitting a call node with an argument followed by another node would cause the argument to be mistakenly omitted from the argument list causing a stack underflow.

```
PRISM: **************************************************
-- raw disasm--------
   0000 putself                                                          (   0)
   0001 send                 <calldata:puts, 1>, nil                     (   0)
*  0004 pop                                                              (   0)
   0005 putobject            1                                           (   0)
   0007 leave                                                            (   0)
---------------------
```