### PR TITLE
[PRISM] Fix stack consistency with Popped begin

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1559,7 +1559,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             PM_COMPILE((pm_node_t *)begin_node->statements);
         }
         else {
-            PM_PUTNIL;
+            PM_PUTNIL_UNLESS_POPPED;
         }
         return;
       }

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -554,6 +554,7 @@ module Prism
 
     def test_BeginNode
       assert_prism_eval("begin; 1; end")
+      assert_prism_eval("begin; end; 1")
     end
 
     def test_BreakNode


### PR DESCRIPTION
When a begin node is popped it only needs to putnil if that nil is going to be the return value, otherwise it can successfully be optimised out.