### PR TITLE
[DOC] Updated building_ruby.md to include reference for building on Windows

### DIFF
--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -105,6 +105,10 @@
 
 If you are having unexplainable build errors, after saving all your work, try running `git clean -xfd` in the source root to remove all git ignored local files. If you are working from a source directory that's been updated several times, you may have temporary build artifacts from previous releases which can cause build failures.
 
+## Building on Windows
+
+The documentation for building on Windows can be found [here](https://github.com/ruby/ruby/blob/master/doc/windows.md).
+
 ## More details
 
 If you're interested in continuing development on Ruby, here are more details


### PR DESCRIPTION
Looking at building_ruby.md it is unclear that you are able to build Ruby on Windows. To fix that a reference has been added to the windows.md file.