### PR TITLE
.travis.yml: Disable ppc64le allow_failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,9 +111,7 @@ matrix:
     # Allow failures for the unstable jobs.
     # - name: arm32-linux
     # - name: arm64-linux
-    # FIXME: TestRDocGeneratorJsonIndex#test_generate fails randomly.
-    # https://app.travis-ci.com/github/ruby/ruby/jobs/612380961#L2900
-    - name: ppc64le-linux
+    # - name: ppc64le-linux
     # - name: s390x-linux
   fast_finish: true
 


### PR DESCRIPTION
Now I expect that Travis ppc64le always passes without any random failures by the commit 1f1b9b0942ec12dde1af8000f8cb84692904fccc that is a workaround to pass the `test/rdoc/test_rdoc_generator_json_index.rb` in Travis ppc64le case.