### PR TITLE
.travis.yml: s390x: Use GCC 11.4.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ env:
   - &s390x-linux
     name: s390x-linux
     arch: s390x
-    compiler: gcc
+    <<: *gcc-11
     env:
       # Avoid possible test failures with the zlib applying the following patch
       # on s390x CPU architecture.


### PR DESCRIPTION
Use GCC version 11.4.0 (gcc-11 package) instead of the default GCC 11.3.0 to align with the GCC used in the RubyCI s390x server below.

```
$ /usr/bin/gcc --version
gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ ls -l /usr/bin/gcc
lrwxrwxrwx 1 root root 6 Aug  5  2021 /usr/bin/gcc -> gcc-11*

$ dpkg -S /usr/bin/gcc-11
gcc-11: /usr/bin/gcc-11
```

Ubuntu Jammy gcc-11: https://packages.ubuntu.com/jammy-updates/gcc-11