### PR TITLE
YJIT: implement two-step call threshold

### DIFF
--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -108,7 +108,7 @@ static YJIT_OPTIONS: [(&str, &str); 11] = [
     ("--yjit-call-threshold=num",       "Number of calls to trigger JIT"),
     ("--yjit-small-threshold=num",      "Call threshold for small apps (default: 30)"),
     ("--yjit-large-threshold=num",      "Call threshold for large deployments (default: 120)"),
-    ("--yjit-large-iseq-count=num",     "Live ISEQs to consider an app large (default: 40000)"),
+    ("--yjit-large-iseq-count=num",     "Live ISEQs to consider an app large (default: 40K)"),
     ("--yjit-cold-threshold=num",       "Global call after which ISEQs not compiled (default: 200K)"),
 
     ("--yjit-max-versions=num",         "Maximum number of versions per basic block (default: 4)"),

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -134,10 +134,11 @@ pub extern "C" fn rb_yjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exc
         return std::ptr::null();
     }
 
-    // If this is a large application (has very many ISEQs), switch to
+    // If a custom call threshold was not specified on the command-line and
+    // this is a large application (has very many ISEQs), switch to
     // using the call threshold for large applications after this entry point
     use crate::stats::rb_yjit_live_iseq_count;
-    if unsafe { rb_yjit_live_iseq_count } > LARGE_ISEQ_COUNT {
+    if unsafe { rb_yjit_call_threshold } == SMALL_CALL_THRESHOLD && unsafe { rb_yjit_live_iseq_count } > LARGE_ISEQ_COUNT {
         unsafe { rb_yjit_call_threshold = LARGE_CALL_THRESHOLD; };
     }
 

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -137,9 +137,8 @@ pub extern "C" fn rb_yjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exc
     // If this is a large application (has very many ISEQs), switch to
     // using the call threshold for large applications after this entry point
     use crate::stats::rb_yjit_live_iseq_count;
-    if unsafe { rb_yjit_live_iseq_count } > get_option!(large_iseq_count) {
-        let large_threshold = get_option!(large_threshold);
-        unsafe { rb_yjit_call_threshold = large_threshold; };
+    if unsafe { rb_yjit_live_iseq_count } > LARGE_ISEQ_COUNT {
+        unsafe { rb_yjit_call_threshold = LARGE_CALL_THRESHOLD; };
     }
 
     let maybe_code_ptr = with_compile_time(|| { gen_entry_point(iseq, ec, jit_exception) });


### PR DESCRIPTION
Automatically switch call threshold to a larger value for larger, production-sized apps, while still allowing smaller apps and command-line programs to start with a lower threshold.