### PR TITLE
Disable iseq-dumped builtin module for universal (macOS x86_64 + arm64) binaries

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -3,7 +3,7 @@
 #include "iseq.h"
 #include "builtin.h"
 
-#ifdef CROSS_COMPILING
+#if defined(CROSS_COMPILING) || defined(UNIVERSAL_BINARY)
 
 #define INCLUDED_BY_BUILTIN_C 1
 #include "mini_builtin.c"

--- a/common.mk
+++ b/common.mk
@@ -1303,7 +1303,7 @@ preludes: {$(srcdir)}golf_prelude.c
 
 builtin_binary.inc: $(PREP) $(BUILTIN_RB_SRCS) $(srcdir)/template/builtin_binary.inc.tmpl
 	$(Q) $(MINIRUBY) $(tooldir)/generic_erb.rb -o $@ \
-		$(srcdir)/template/builtin_binary.inc.tmpl -- --cross=$(CROSS_COMPILING)
+		$(srcdir)/template/builtin_binary.inc.tmpl -- --cross=$(CROSS_COMPILING) --universal=$(UNIVERSAL_BINARY)
 
 $(BUILTIN_RB_INCS): $(top_srcdir)/tool/mk_builtin_loader.rb
 

--- a/configure.ac
+++ b/configure.ac
@@ -4341,6 +4341,8 @@ AC_SUBST(CONFIGURE, "`echo $0 | sed 's|.*/||'`")dnl
 AC_SUBST(configure_args, "`echo "${ac_configure_args}" | sed 's/\\$/$$/g'`")dnl
 
 AS_IF([test "${universal_binary-no}" = yes ], [
+    AC_DEFINE(UNIVERSAL_BINARY, 1)
+    AC_SUBST(UNIVERSAL_BINARY)
     arch="universal-${target_os}"
     AS_IF([test "${rb_cv_architecture_available}" = yes], [
 	AC_DEFINE_UNQUOTED(RUBY_PLATFORM_CPU, __ARCHITECTURE__)

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -65,6 +65,7 @@ rubyarchhdrdir = @rubyarchhdrdir@
 ruby_version = @ruby_version@
 RUBY_VERSION_NAME = @RUBY_VERSION_NAME@
 UNIVERSAL_ARCHNAMES = @UNIVERSAL_ARCHNAMES@
+UNIVERSAL_BINARY = @UNIVERSAL_BINARY@
 
 TESTUI = console
 TESTS =

--- a/template/builtin_binary.inc.tmpl
+++ b/template/builtin_binary.inc.tmpl
@@ -2,7 +2,7 @@
 // DO NOT MODIFY THIS FILE DIRECTLY.
 // auto-generated file by tool/generic_erb.rb
 // with template/builtin_binary.inc.tmpl
-% unless ARGV.include?('--cross=yes')
+% unless ARGV.include?('--cross=yes') or ARGV.include?('--universal=yes')
 %   ary = RubyVM.enum_for(:each_builtin).to_a
 %   ary.each{|feature, iseq|
 


### PR DESCRIPTION
During the build, Ruby has special logic to serialize its own builtin module to disk using the binary `iseq` format during the build (I assume for speed so it doesn't have to parse builtin every time it starts up).

However, since `iseq` format is architecture-specific, when *building* on `x86_64` for universal `x86_64` + `arm64`, the serialized builtin module is written with the `x86_64` architecture of the build machine, which fails this check whenever ruby imports the builtin module on `arm64`:

https://github.com/ruby/ruby/blob/1fdaa0666086529b3aae2d509a2e71c4247c3a12/compile.c#L13243

Thankfully, there's logic to disable this feature for cross-compiled builds:

https://github.com/ruby/ruby/blob/1fdaa0666086529b3aae2d509a2e71c4247c3a12/builtin.c#L6

This disables the `iseq` logic for universal builds as well.

Fixes [Bug #18286]

(This is duplicating pull request #7367 which has lingered without getting merged.)