### PR TITLE
ast.rb: Fix bug for source of multibyte characters

### DIFF
--- a/ast.rb
+++ b/ast.rb
@@ -265,8 +265,8 @@ module RubyVM::AbstractSyntaxTree
       lines = script_lines
       if lines
         lines = lines[first_lineno - 1 .. last_lineno - 1]
-        lines[-1] = lines[-1][0...last_column]
-        lines[0] = lines[0][first_column..-1]
+        lines[-1] = lines[-1].byteslice(0...last_column)
+        lines[0] = lines[0].byteslice(first_column..-1)
         lines.join
       else
         nil

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -746,6 +746,14 @@ dummy
     assert_equal("def test_keep_script_lines_for_of\n", node_method.source.lines.first)
   end
 
+  def test_source_with_multibyte_characters
+    ast = RubyVM::AbstractSyntaxTree.parse(%{a("\u00a7");b("\u00a9")}, keep_script_lines: true)
+    a_fcall, b_fcall = ast.children[2].children
+
+    assert_equal(%{a("\u00a7")}, a_fcall.source)
+    assert_equal(%{b("\u00a9")}, b_fcall.source)
+  end
+
   def test_keep_tokens_for_parse
     node = RubyVM::AbstractSyntaxTree.parse(<<~END, keep_tokens: true)
     1.times do


### PR DESCRIPTION
`RubyVM::AbstractSyntaxTree::Node`'s `#first_column` and `#last_column` return byte positions, but existing implementations did not consider multi-byte.

```ruby
ast = RubyVM::AbstractSyntaxTree.parse(%{a("§");b("©")}, keep_script_lines: true)
a_fcall, b_fcall = ast.children[2].children

puts a_fcall.source
puts b_fcall.source
```

```ruby
# before
a("§");
("©")

# after
a("§")
b("©")
```