### PR TITLE
Add "Optimization" section to regexp.rdoc

### DIFF
--- a/doc/regexp.rdoc
+++ b/doc/regexp.rdoc
@@ -1228,6 +1228,34 @@ when regexp.timeout is non-+nil+, that value controls timing out:
   |         nil          |         Float        | Times out in Float seconds. |
   |        Float         |          Any         | Times out in Float seconds. |
 
+== Optimization
+
+Regexp matching time may increase explosively depending on a pattern and an
+target string. A vulnerability caused by this is known as {regular expression
+denial-of-service (ReDoS)}[https://en.wikipedia.org/wiki/ReDoS].
+
+Ruby's regexp matching applies an optimization to prevent ReDoS. When the
+optimization is applied, matching time increases in linear to the input's
+length; that is ReDoS does not cause.  For applying this optimization, a
+pattern satisfy the following conditions:
+
+- no backreferences
+- no subexpression calls
+- no nested lookaround anchors and atomic groups
+- no nested quantifiers with counting (i.e. no nested <tt>{n}</tt>,
+  <tt>{min,}</tt>, <tt>{,max}</tt>, or <tt>{min,max}</tt> style quantifiers)
+
+For a regexp source or object, Regexp.linear_time? can check whether the above
+conditions are satisfied.
+
+  Regexp.linear_time?(/a*/)     # => true
+  Regexp.linear_time?('a*')     # => true
+  Regexp.linear_time?(/(a*)\1/) # => false
+
+However, you should not consider an untrusted source is safe for use even if
+this method returns +true+. Since we use memoization for this optimization,
+the untrusted source may invoke large memory consumption.
+
 == References
 
 Read (online PDF books):

--- a/doc/regexp.rdoc
+++ b/doc/regexp.rdoc
@@ -1230,31 +1230,30 @@ when regexp.timeout is non-+nil+, that value controls timing out:
 
 == Optimization
 
-Regexp matching time may increase explosively depending on a pattern and an
-target string. A vulnerability caused by this is known as {regular expression
-denial-of-service (ReDoS)}[https://en.wikipedia.org/wiki/ReDoS].
+For certain values of the pattern and target string,
+matching time can grow polynomially or exponentially in relation to the input size;
+the potential vulnerability arising from this is the {regular expression denial-of-service}[https://en.wikipedia.org/wiki/ReDoS] (ReDoS) attack.
 
-Ruby's regexp matching applies an optimization to prevent ReDoS. When the
-optimization is applied, matching time increases in linear to the input's
-length; that is ReDoS does not cause.  For applying this optimization, a
-pattern satisfy the following conditions:
+\Regexp matching can apply an optimization to prevent ReDoS attacks.
+When the optimization is applied, matching time increases linearly (not polynomially or exponentially)
+in relation to the input size, and a ReDoS attach is not possible.
 
-- no backreferences
-- no subexpression calls
-- no nested lookaround anchors and atomic groups
-- no nested quantifiers with counting (i.e. no nested <tt>{n}</tt>,
+This optimization is applied if the pattern meets these criteria:
+
+- No backreferences.
+- No subexpression calls.
+- No nested lookaround anchors or atomic groups.
+- No nested quantifiers with counting (i.e. no nested <tt>{n}</tt>,
   <tt>{min,}</tt>, <tt>{,max}</tt>, or <tt>{min,max}</tt> style quantifiers)
 
-For a regexp source or object, Regexp.linear_time? can check whether the above
-conditions are satisfied.
+You can use method Regexp.linear_time? to determine whether a pattern meets these criteria:
 
   Regexp.linear_time?(/a*/)     # => true
   Regexp.linear_time?('a*')     # => true
   Regexp.linear_time?(/(a*)\1/) # => false
 
-However, you should not consider an untrusted source is safe for use even if
-this method returns +true+. Since we use memoization for this optimization,
-the untrusted source may invoke large memory consumption.
+However, an untrusted source may not be safe even if the method returns +true+,
+because the optimization uses memoization (which may invoke large memory consumption).
 
 == References
 


### PR DESCRIPTION
This PR adds "Optimization" section to regexp.rdoc. The added contents are followed by #7931 changes.

@BurdetteLamar Could you polish this and the overall regexp.rdoc? I believe you are an expert on this file.