### PR TITLE
`pthread_detach` after `pthread_setaffinity_np`

### DIFF
--- a/ext/socket/extconf.rb
+++ b/ext/socket/extconf.rb
@@ -704,7 +704,7 @@ SRC
 
   have_func("pthread_create")
   have_func("pthread_detach")
-  have_func("pthread_setaffinity_np")
+  have_func("pthread_attr_setaffinity_np")
   have_func("sched_getcpu")
 
   $VPATH << '$(topdir)' << '$(top_srcdir)'

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -482,10 +482,7 @@ start:
     }
 
     pthread_detach(th);
-#if defined(__s390__) || defined(__s390x__) || defined(__zarch__) || defined(__SYSC_ZARCH__)
-# define S390X
-#endif
-#if defined(HAVE_PTHREAD_SETAFFINITY_NP) && defined(HAVE_SCHED_GETCPU) && !defined(S390X)
+#if defined(HAVE_PTHREAD_SETAFFINITY_NP) && defined(HAVE_SCHED_GETCPU)
     cpu_set_t tmp_cpu_set;
     CPU_ZERO(&tmp_cpu_set);
     CPU_SET(sched_getcpu(), &tmp_cpu_set);
@@ -704,7 +701,7 @@ start:
     }
 
     pthread_detach(th);
-#if defined(HAVE_PTHREAD_SETAFFINITY_NP) && defined(HAVE_SCHED_GETCPU) && !defined(S390X)
+#if defined(HAVE_PTHREAD_SETAFFINITY_NP) && defined(HAVE_SCHED_GETCPU)
     cpu_set_t tmp_cpu_set;
     CPU_ZERO(&tmp_cpu_set);
     CPU_SET(sched_getcpu(), &tmp_cpu_set);

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -688,7 +688,7 @@ rb_getnameinfo(const struct sockaddr *sa, socklen_t salen,
                char *serv, size_t servlen, int flags)
 {
     int retry;
-    struct getnameinfo_arg *arg = allocate_getnameinfo_arg(sa, salen, hostlen, servlen, flags);
+    struct getnameinfo_arg *arg;
     int err;
 
 start:

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -483,8 +483,11 @@ start:
 #if defined(HAVE_PTHREAD_ATTR_SETAFFINITY_NP) && defined(HAVE_SCHED_GETCPU)
     cpu_set_t tmp_cpu_set;
     CPU_ZERO(&tmp_cpu_set);
-    CPU_SET(sched_getcpu(), &tmp_cpu_set);
-    pthread_attr_setaffinity_np(&attr, sizeof(cpu_set_t), &tmp_cpu_set);
+    int cpu = sched_getcpu();
+    if (cpu < CPU_SETSIZE) {
+        CPU_SET(cpu, &tmp_cpu_set);
+        pthread_attr_setaffinity_np(&attr, sizeof(cpu_set_t), &tmp_cpu_set);
+    }
 #endif
 
     pthread_t th;
@@ -707,8 +710,11 @@ start:
 #if defined(HAVE_PTHREAD_ATTR_SETAFFINITY_NP) && defined(HAVE_SCHED_GETCPU)
     cpu_set_t tmp_cpu_set;
     CPU_ZERO(&tmp_cpu_set);
-    CPU_SET(sched_getcpu(), &tmp_cpu_set);
-    pthread_attr_setaffinity_np(&attr, sizeof(cpu_set_t), &tmp_cpu_set);
+    int cpu = sched_getcpu();
+    if (cpu < CPU_SETSIZE) {
+        CPU_SET(cpu, &tmp_cpu_set);
+        pthread_attr_setaffinity_np(&attr, sizeof(cpu_set_t), &tmp_cpu_set);
+    }
 #endif
 
     pthread_t th;

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -481,13 +481,13 @@ start:
         return EAI_AGAIN;
     }
 
-    pthread_detach(th);
 #if defined(HAVE_PTHREAD_SETAFFINITY_NP) && defined(HAVE_SCHED_GETCPU)
     cpu_set_t tmp_cpu_set;
     CPU_ZERO(&tmp_cpu_set);
     CPU_SET(sched_getcpu(), &tmp_cpu_set);
     pthread_setaffinity_np(th, sizeof(cpu_set_t), &tmp_cpu_set);
 #endif
+    pthread_detach(th);
 
     rb_thread_call_without_gvl2(wait_getaddrinfo, arg, cancel_getaddrinfo, arg);
 
@@ -700,13 +700,13 @@ start:
         return EAI_AGAIN;
     }
 
-    pthread_detach(th);
 #if defined(HAVE_PTHREAD_SETAFFINITY_NP) && defined(HAVE_SCHED_GETCPU)
     cpu_set_t tmp_cpu_set;
     CPU_ZERO(&tmp_cpu_set);
     CPU_SET(sched_getcpu(), &tmp_cpu_set);
     pthread_setaffinity_np(th, sizeof(cpu_set_t), &tmp_cpu_set);
 #endif
+    pthread_detach(th);
 
     rb_thread_call_without_gvl2(wait_getnameinfo, arg, cancel_getnameinfo, arg);
 


### PR DESCRIPTION
After a pthread for getaddrinfo is detached, we cannot predict when the thread will exit. It would lead to a segfault by setting pthread_setaffinity to the terminated pthread.  I guess this problem would be more likely to occur in high-load environments.

https://bugs.ruby-lang.org/issues/19965#note-4
https://bugs.ruby-lang.org/issues/19965#note-7

This change detaches the pthread after pthread_setaffinity is called.