### PR TITLE
Reduce implicit array allocations on caller side of method calling

### DIFF
--- a/benchmark/vm_method_splat_calls.yml
+++ b/benchmark/vm_method_splat_calls.yml
@@ -1,0 +1,13 @@
+prelude: |
+  def f(x=0, y: 0) end
+  a = [1]
+  ea = []
+  kw = {y: 1}
+  b = lambda{}
+benchmark:
+  arg_splat: "f(1, *ea)"
+  arg_splat_block: "f(1, *ea, &b)"
+  splat_kw_splat: "f(*a, **kw)"
+  splat_kw_splat_block: "f(*a, **kw, &b)"
+  splat_kw: "f(*a, y: 1)"
+  splat_kw_block: "f(*a, y: 1, &b)"

--- a/compile.c
+++ b/compile.c
@@ -3872,6 +3872,21 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
                     if ((flag & VM_CALL_ARGS_BLOCKARG) && !(flag & VM_CALL_KW_SPLAT)) {
                         OPERAND_AT(iobj, 0) = Qfalse;
                     }
+
+                    /*
+                    * Eliminate array allocation for f(*a, **lvar) and f(*a, **@iv)
+                    *
+                    *  splatarray true
+                    *  getlocal / getinstancevariable
+                    *  send ARGS_SPLAT|KW_SPLAT and not ARGS_BLOCKARG
+                    * =>
+                    *  splatarray false
+                    *  getlocal / getinstancevariable
+                    *  send
+                    */
+                    else if (!(flag & VM_CALL_ARGS_BLOCKARG) && (flag & VM_CALL_KW_SPLAT)) {
+                        OPERAND_AT(iobj, 0) = Qfalse;
+                    }
                 }
             }
         }

--- a/compile.c
+++ b/compile.c
@@ -3936,6 +3936,32 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
                     OPERAND_AT(iobj, 0) = Qfalse;
                 }
             }
+            else if (IS_NEXT_INSN_ID(niobj, getlocal) || IS_NEXT_INSN_ID(niobj, getinstancevariable)) {
+                niobj = niobj->next;
+
+                /*
+                * Eliminate array allocation for f(*a, kw: 1, &lvar) and f(*a, kw: 1, &@iv)
+                *
+                *  splatarray true
+                *  duphash
+                *  getlocal / getinstancevariable
+                *  send ARGS_SPLAT|KW_SPLAT|KW_SPLAT_MUT|ARGS_BLOCKARG
+                * =>
+                *  splatarray false
+                *  duphash
+                *  getlocal / getinstancevariable
+                *  send
+                */
+                if (IS_NEXT_INSN_ID(niobj, send)) {
+                    niobj = niobj->next;
+                    unsigned int flag = vm_ci_flag((const struct rb_callinfo *)OPERAND_AT(niobj, 0));
+
+                    if ((flag & VM_CALL_ARGS_SPLAT) && (flag & VM_CALL_KW_SPLAT) &&
+                            (flag & VM_CALL_KW_SPLAT_MUT) && (flag & VM_CALL_ARGS_BLOCKARG)) {
+                        OPERAND_AT(iobj, 0) = Qfalse;
+                    }
+                }
+            }
         }
     }
 

--- a/compile.c
+++ b/compile.c
@@ -3888,6 +3888,30 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
                         OPERAND_AT(iobj, 0) = Qfalse;
                     }
                 }
+            } else if (IS_NEXT_INSN_ID(niobj, getlocal) || IS_NEXT_INSN_ID(niobj, getinstancevariable)) {
+                niobj = niobj->next;
+
+                /*
+                * Eliminate array allocation for f(*a, **lvar, &lvar) and f(*a, **@iv, &@iv)
+                *
+                *  splatarray true
+                *  getlocal / getinstancevariable
+                *  getlocal / getinstancevariable
+                *  send ARGS_SPLAT|KW_SPLAT|ARGS_BLOCKARG
+                * =>
+                *  splatarray false
+                *  getlocal / getinstancevariable
+                *  getlocal / getinstancevariable
+                *  send
+                */
+                if (IS_NEXT_INSN_ID(niobj, send)) {
+                    niobj = niobj->next;
+                    unsigned int flag = vm_ci_flag((const struct rb_callinfo *)OPERAND_AT(niobj, 0));
+
+                    if ((flag & VM_CALL_ARGS_SPLAT) && (flag & VM_CALL_KW_SPLAT) && (flag & VM_CALL_ARGS_BLOCKARG)) {
+                        OPERAND_AT(iobj, 0) = Qfalse;
+                    }
+                }
             }
         }
     }

--- a/compile.c
+++ b/compile.c
@@ -3888,7 +3888,9 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
                         OPERAND_AT(iobj, 0) = Qfalse;
                     }
                 }
-            } else if (IS_NEXT_INSN_ID(niobj, getlocal) || IS_NEXT_INSN_ID(niobj, getinstancevariable)) {
+            }
+            else if (IS_NEXT_INSN_ID(niobj, getlocal) || IS_NEXT_INSN_ID(niobj, getinstancevariable) ||
+                   IS_NEXT_INSN_ID(niobj, getblockparamproxy)) {
                 niobj = niobj->next;
 
                 /*
@@ -3896,12 +3898,12 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
                 *
                 *  splatarray true
                 *  getlocal / getinstancevariable
-                *  getlocal / getinstancevariable
+                *  getlocal / getinstancevariable / getblockparamproxy
                 *  send ARGS_SPLAT|KW_SPLAT|ARGS_BLOCKARG
                 * =>
                 *  splatarray false
                 *  getlocal / getinstancevariable
-                *  getlocal / getinstancevariable
+                *  getlocal / getinstancevariable / getblockparamproxy
                 *  send
                 */
                 if (IS_NEXT_INSN_ID(niobj, send)) {
@@ -3913,7 +3915,31 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
                     }
                 }
             }
-        } else if (IS_NEXT_INSN_ID(niobj, duphash)) {
+        }
+        else if (IS_NEXT_INSN_ID(niobj, getblockparamproxy)) {
+            niobj = niobj->next;
+
+            if (IS_NEXT_INSN_ID(niobj, send)) {
+                niobj = niobj->next;
+                unsigned int flag = vm_ci_flag((const struct rb_callinfo *)OPERAND_AT(niobj, 0));
+
+                /*
+                * Eliminate array allocation for f(1, *a, &arg)
+                *
+                *  splatarray true
+                *  getblockparamproxy
+                *  send ARGS_SPLAT|ARGS_BLOCKARG and not KW_SPLAT
+                * =>
+                *  splatarray false
+                *  getblockparamproxy
+                *  send
+                */
+                if ((flag & VM_CALL_ARGS_BLOCKARG) & (flag & VM_CALL_ARGS_SPLAT) && !(flag & VM_CALL_KW_SPLAT)) {
+                        OPERAND_AT(iobj, 0) = Qfalse;
+                }
+            }
+        }
+        else if (IS_NEXT_INSN_ID(niobj, duphash)) {
             niobj = niobj->next;
 
             /*
@@ -3936,7 +3962,8 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
                     OPERAND_AT(iobj, 0) = Qfalse;
                 }
             }
-            else if (IS_NEXT_INSN_ID(niobj, getlocal) || IS_NEXT_INSN_ID(niobj, getinstancevariable)) {
+            else if (IS_NEXT_INSN_ID(niobj, getlocal) || IS_NEXT_INSN_ID(niobj, getinstancevariable) ||
+                   IS_NEXT_INSN_ID(niobj, getblockparamproxy)) {
                 niobj = niobj->next;
 
                 /*
@@ -3944,12 +3971,12 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
                 *
                 *  splatarray true
                 *  duphash
-                *  getlocal / getinstancevariable
+                *  getlocal / getinstancevariable / getblockparamproxy
                 *  send ARGS_SPLAT|KW_SPLAT|KW_SPLAT_MUT|ARGS_BLOCKARG
                 * =>
                 *  splatarray false
                 *  duphash
-                *  getlocal / getinstancevariable
+                *  getlocal / getinstancevariable / getblockparamproxy
                 *  send
                 */
                 if (IS_NEXT_INSN_ID(niobj, send)) {

--- a/test/ruby/test_call.rb
+++ b/test/ruby/test_call.rb
@@ -100,6 +100,12 @@ class TestCall < Test::Unit::TestCase
     }
   end
 
+  def test_frozen_splat_and_keywords
+   a = [1, 2].freeze
+   def self.f(*a); a end
+   assert_equal([1, 2, {kw: 3}], f(*a, kw: 3))
+  end
+
   def test_call_bmethod_proc
     pr = proc{|sym| sym}
     define_singleton_method(:a, &pr)

--- a/vm_args.c
+++ b/vm_args.c
@@ -542,11 +542,13 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
         else if (UNLIKELY(ISEQ_BODY(iseq)->param.flags.ruby2_keywords)) {
             converted_keyword_hash = check_kwrestarg(converted_keyword_hash, &kw_flag);
             flag_keyword_hash = converted_keyword_hash;
+            arg_rest_dup(args);
             rb_ary_push(args->rest, converted_keyword_hash);
             keyword_hash = Qnil;
         }
         else if (!ISEQ_BODY(iseq)->param.flags.has_kwrest && !ISEQ_BODY(iseq)->param.flags.has_kw) {
             converted_keyword_hash = check_kwrestarg(converted_keyword_hash, &kw_flag);
+            arg_rest_dup(args);
             rb_ary_push(args->rest, converted_keyword_hash);
             keyword_hash = Qnil;
         }


### PR DESCRIPTION
This eliminates array allocations for the following common cases:

```ruby
f(1, *a)
f(1, *a, &lvar)
f(*a, **lvar)
f(*a, **lvar, &lvar)
```

This also eliminates array allocations for these less common cases that I think are still worth optimizing:

```ruby
f(1, *a, &@ivar)
f(*a, **@ivar)
f(*a, **@ivar, &@ivar)
f(*a, kw: 1)
f(*a, kw:1, &lvar)
f(*a, kw:1, &@ivar)
```

This is handled via the peephole optimizer.

In terms of safety, currently, `f(*a, &lvar)` and `f(*a, &@ivar)` both avoid array allocations, and all of the above are as safe as those in terms of safety.