### PR TITLE
YJIT: Inline basic Ruby methods

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4196,3 +4196,24 @@ assert_equal '[6, -6, 9671406556917033397649408, -9671406556917033397649408, 212
 
 # Integer multiplication and overflow (minimized regression test from test-basic)
 assert_equal '8515157028618240000', %q{2128789257154560000 * 4}
+
+# Inlined method calls
+assert_equal 'nil', %q{
+  def putnil = nil
+  def entry = putnil
+  entry.inspect
+}
+assert_equal '1', %q{
+  def putobject_1 = 1
+  def entry = putobject_1
+  entry
+}
+assert_equal 'false', %q{
+  def putobject(_unused_arg1) = false
+  def entry = putobject(nil)
+  entry
+}
+assert_equal 'true', %q{
+  def entry = yield
+  entry { true }
+}

--- a/yjit.rb
+++ b/yjit.rb
@@ -302,6 +302,9 @@ module RubyVM::YJIT
       out.puts "num_send_polymorphic:  " + format_number_pct(13, stats[:num_send_polymorphic], stats[:num_send])
       out.puts "num_send_megamorphic:  " + format_number_pct(13, stats[:send_megamorphic], stats[:num_send])
       out.puts "num_send_dynamic:      " + format_number_pct(13, stats[:num_send_dynamic], stats[:num_send])
+      out.puts "num_send_inline:       " + format_number_pct(13, stats[:num_send_inline], stats[:num_send])
+      out.puts "num_send_leaf_builtin: " + format_number_pct(13, stats[:num_send_leaf_builtin], stats[:num_send])
+      out.puts "num_send_known_cfunc:  " + format_number_pct(13, stats[:num_send_known_cfunc], stats[:num_send])
       if stats[:num_send_x86_rel32] != 0 || stats[:num_send_x86_reg] != 0
         out.puts "num_send_x86_rel32:    " + format_number(13,  stats[:num_send_x86_rel32])
         out.puts "num_send_x86_reg:      " + format_number(13, stats[:num_send_x86_reg])

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2748,7 +2748,6 @@ fn gen_checktype(
     if let RUBY_T_STRING | RUBY_T_ARRAY | RUBY_T_HASH = type_val {
         let val_type = asm.ctx.get_opnd_type(StackOpnd(0));
         let val = asm.stack_pop(1);
-        let val = asm.load(val);
 
         // Check if we know from type information
         match val_type.known_value_type() {
@@ -2766,6 +2765,7 @@ fn gen_checktype(
 
         let ret = asm.new_label("ret");
 
+        let val = asm.load(val);
         if !val_type.is_heap() {
             // if (SPECIAL_CONST_P(val)) {
             // Return Qfalse via REG1 if not on heap

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -252,6 +252,12 @@ pub fn iseq_pc_to_insn_idx(iseq: IseqPtr, pc: *mut VALUE) -> Option<u16> {
     unsafe { pc.offset_from(pc_zero) }.try_into().ok()
 }
 
+/// Given an ISEQ pointer and an instruction index, return an opcode.
+pub fn iseq_opcode_at_idx(iseq: IseqPtr, insn_idx: u32) -> u32 {
+    let pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx) };
+    unsafe { rb_iseq_opcode_at_pc(iseq, pc) as u32 }
+}
+
 /// Opaque execution-context type from vm_core.h
 #[repr(C)]
 pub struct rb_execution_context_struct {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -480,6 +480,9 @@ make_counters! {
     num_send_x86_rel32,
     num_send_x86_reg,
     num_send_dynamic,
+    num_send_inline,
+    num_send_leaf_builtin,
+    num_send_known_cfunc,
 
     num_getivar_megamorphic,
     num_setivar_megamorphic,


### PR DESCRIPTION
This PR optimizes calls of an ISEQ that consists of only `putnil`/`putobject` and `leave` into a single `mov` instruction. By specializing the inlining logic for such cases, it simplifies the implementation more than the previous attempt https://github.com/ruby/ruby/pull/7097.

## Benchmark
erubi-rails seems to have a higher ratio of such method calls than other headline benchmarks:

```
num_send_inline:          18,258,990 ( 3.8%)
```

Here's a benchmark result on erubi-rails:

```
before: ruby 3.3.0dev (2023-11-06T19:39:09Z master 49b6dc8f07) +YJIT [x86_64-linux]
after: ruby 3.3.0dev (2023-11-07T01:17:48Z yjit-basic-inlining a8ea580d9d) +YJIT [x86_64-linux]

-----------  -----------  ----------  ----------  ----------  -------------  ------------
bench        before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
erubi-rails  1613.3       1.0         1567.3      1.4         1.02           1.03
-----------  -----------  ----------  ----------  ----------  -------------  ------------
```