### PR TITLE
YJIT: handle out of shape situation in gen_setinstancevariable

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2473,7 +2473,11 @@ fn gen_setinstancevariable(
         };
 
         let dest_shape = if let Some(capa_shape) = capa_shape {
-            unsafe { rb_shape_get_next(capa_shape, comptime_receiver, ivar_name) }
+            if OBJ_TOO_COMPLEX_SHAPE_ID == unsafe { rb_shape_id(capa_shape) } {
+              capa_shape
+            } else {
+              unsafe { rb_shape_get_next(capa_shape, comptime_receiver, ivar_name) }
+            }
         } else {
             unsafe { rb_shape_get_next(shape, comptime_receiver, ivar_name) }
         };


### PR DESCRIPTION
If the VM ran out of shape, `rb_shape_transition_shape_capa` might return `OBJ_TOO_COMPLEX_SHAPE`.

cc @maximecb @XrXr @k0kubun 

NB: this case is tested in `test/ruby/test_shapes.rb`, it's unclear to me why it didn't catch that YJIT bug. I tried to figure out how to make it fail, but couldn't figure it out.