### PR TITLE
Fix concurrent calls to ObjectSpace.dump_all crashing

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -11898,7 +11898,11 @@ static void
 reachable_objects_from_callback(VALUE obj)
 {
     rb_ractor_t *cr = GET_RACTOR();
-    cr->mfd->mark_func(obj, cr->mfd->data);
+    struct gc_mark_func_data_struct *cur_mfd = cr->mfd;
+    cur_mfd->mark_func(obj, cr->mfd->data);
+    /* mark_func might give up the GVL, in which time some other thread might set
+       mfd. In that case, set it back to the right value for this thread. */
+    cr->mfd = cur_mfd;
 }
 
 void

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -918,6 +918,14 @@ class TestObjSpace < Test::Unit::TestCase
     assert_equal 2, ObjectSpace.dump_shapes(output: :string, since: RubyVM.stat(:next_shape_id) - 2).lines.size
   end
 
+  def test_dump_all_in_parallel_bug_19922
+    dump_ten_times = ->() { 10.times { ObjectSpace.dump_all.tap { _1.close } } }
+    t = Thread.new { dump_ten_times.call }
+    dump_ten_times.call
+    t.value
+    # Bug #19922 would cause this test to crash.
+  end
+
   private
 
   def utf8_❨╯°□°❩╯︵┻━┻


### PR DESCRIPTION
This should fix https://bugs.ruby-lang.org/issues/19922 I believe. Since calling `mark_func` can yield the GVL, and set `cr->mfd` to something else, we need to set it back.

Fixes: #19922