### PR TITLE
[PRISM] Add tests for several parameters nodes

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3393,18 +3393,11 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             }
 
             if (parameters_node->keyword_rest) {
-                switch (PM_NODE_TYPE(parameters_node->keyword_rest)) {
-                  case PM_NO_KEYWORDS_PARAMETER_NODE: {
-                      body->param.flags.accepts_no_kwarg = true;
-                      break;
-                  }
-                  case PM_KEYWORD_REST_PARAMETER_NODE: {
-                      body->param.flags.has_kwrest = true;
-                      break;
-                  }
-                  default: {
-                      rb_bug("Keyword rest is an unexpected type\n");
-                  }
+                if (PM_NODE_TYPE_P(parameters_node->keyword_rest, PM_NO_KEYWORDS_PARAMETER_NODE)) {
+                    body->param.flags.accepts_no_kwarg = true;
+                }
+                else {
+                    body->param.flags.has_kwrest = true;
                 }
             }
 

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1361,7 +1361,9 @@ pm_setup_args(pm_arguments_node_t *arguments_node, int *flags, struct rb_callinf
 
                                 *flags |= VM_CALL_KW_SPLAT | VM_CALL_KW_SPLAT_MUT;
 
-                                ADD_SEND(ret, &dummy_line_node, id_core_hash_merge_kwd, INT2FIX(2));
+                                if (len > 1) {
+                                    ADD_SEND(ret, &dummy_line_node, id_core_hash_merge_kwd, INT2FIX(2));
+                                }
 
                                 if ((i < len - 1) && !PM_NODE_TYPE_P(keyword_arg->elements.nodes[i + 1], cur_type)) {
                                     ADD_INSN1(ret, &dummy_line_node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
@@ -3354,7 +3356,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             body->param.keyword = keyword = ZALLOC_N(struct rb_iseq_param_keyword, 1);
             keyword->num = (int) keywords_list->size;
 
-            body->param.flags.has_kw = TRUE;
+            body->param.flags.has_kw = true;
             const VALUE default_values = rb_ary_hidden_new(1);
             const VALUE complex_mark = rb_str_tmp_new(0);
 
@@ -3397,6 +3399,10 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                     body->param.flags.accepts_no_kwarg = true;
                 }
                 else {
+                    if (!body->param.flags.has_kw) {
+                        body->param.keyword = keyword = ZALLOC_N(struct rb_iseq_param_keyword, 1);
+                    }
+                    keyword->rest_start = (int) locals_size;
                     body->param.flags.has_kwrest = true;
                 }
             }

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -917,6 +917,10 @@ module Prism
       assert_prism_eval("def prism_test_optional_param_node(bar = nil); end")
     end
 
+    def test_OptionalKeywordParameterNode
+      assert_prism_eval("def prism_test_optional_keyword_param_node(bar: nil); end")
+    end
+
     def test_ParametersNode
       assert_prism_eval("def prism_test_parameters_node(bar, baz); end")
       assert_prism_eval("def prism_test_parameters_node(a, b = 2); end")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -900,6 +900,14 @@ module Prism
       assert_prism_eval("[1].map { |a; b| b = 2; a + b}")
     end
 
+    def test_FowardingParameterNode
+      assert_prism_eval("def prism_test_forwarding_parameter_node(...); end")
+    end
+
+    def test_KeywordRestParameterNode
+      assert_prism_eval("def prism_test_keyword_rest_parameter_node(a, **b); end")
+    end
+
     def test_NoKeywordsParameterNode
       assert_prism_eval("def prism_test_no_keywords(**nil); end")
       assert_prism_eval("def prism_test_no_keywords(a, b = 2, **nil); end")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -889,6 +889,11 @@ module Prism
       assert_prism_eval("alias :prism_a :to_s")
     end
 
+    def test_BlockParameterNode
+      assert_prism_eval("def prism_test_block_parameter_node(&bar) end")
+      assert_prism_eval("->(b, c=1, *d, e, &f){}")
+    end
+
     def test_BlockParametersNode
       assert_prism_eval("Object.tap { || }")
       assert_prism_eval("[1].map { |num| num }")
@@ -907,6 +912,21 @@ module Prism
     def test_ParametersNode
       assert_prism_eval("def prism_test_parameters_node(bar, baz); end")
       assert_prism_eval("def prism_test_parameters_node(a, b = 2); end")
+    end
+
+    def test_RequiredParameterNode
+      assert_prism_eval("def prism_test_required_param_node(bar); end")
+      assert_prism_eval("def prism_test_required_param_node(foo, bar); end")
+    end
+
+    def test_RequiredKeywordParameterNode
+      assert_prism_eval("def prism_test_required_param_node(bar:); end")
+      assert_prism_eval("def prism_test_required_param_node(foo:, bar:); end")
+      assert_prism_eval("-> a, b = 1, c:, d:, &e { a }")
+    end
+
+    def test_RestParameterNode
+      assert_prism_eval("def prism_test_rest_parameter_node(*a); end")
     end
 
     def test_UndefNode
@@ -1038,7 +1058,11 @@ module Prism
       ruby_eval = RubyVM::InstructionSequence.compile(source).eval
       prism_eval = RubyVM::InstructionSequence.compile_prism(source).eval
 
-      assert_equal ruby_eval, prism_eval
+      if ruby_eval.is_a? Proc
+        assert_equal ruby_eval.class, prism_eval.class
+      else
+        assert_equal ruby_eval, prism_eval
+      end
     end
 
     def assert_prism_eval(source)


### PR DESCRIPTION
This commit adds tests for BlockParameterNode, RequiredParameterNode, RequiredKeywordParameterNode and RestParameterNode

Closes https://github.com/ruby/prism/issues/1664
Closes https://github.com/ruby/prism/issues/1672
Closes https://github.com/ruby/prism/issues/1779
Closes https://github.com/ruby/prism/issues/1673
Closes https://github.com/ruby/prism/issues/1666
Closes https://github.com/ruby/prism/issues/1668
Closes https://github.com/ruby/prism/issues/1778