### PR TITLE
YJIT: Disable code GC

### DIFF
--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -63,7 +63,7 @@ jobs:
             yjit_opts: '--yjit'
           - test_task: 'check'
             configure: '--enable-yjit=dev'
-            yjit_opts: '--yjit-call-threshold=1 --yjit-verify-ctx'
+            yjit_opts: '--yjit-call-threshold=1 --yjit-verify-ctx --yjit-code-gc'
       fail-fast: false
 
     env:

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -99,7 +99,7 @@ jobs:
 
           - test_task: 'check'
             configure: '--enable-yjit=dev'
-            yjit_opts: '--yjit-call-threshold=1 --yjit-verify-ctx'
+            yjit_opts: '--yjit-call-threshold=1 --yjit-verify-ctx --yjit-code-gc'
 
           - test_task: 'test-bundled-gems'
             configure: '--enable-yjit=dev'


### PR DESCRIPTION
## Changes
This PR disables code GC in the default mode, and adds `--yjit-code-gc` to optionally turn it on.

## Background
Enabling Code GC can be helpful for the following two purposes:

1. Throw away code that is used only during application boot
2. Reoder code to improve locality for the current "phase" of the application usage

We haven't observed any real impact of (2) in production or local benchmarks. (1) has a more measurable impact, but this isn't that significant either at least on SFR. Also, the combination of https://github.com/ruby/ruby/pull/8705 and https://github.com/rails/rails/pull/49947 may semi-automatically achieve (1) on Rails going forward. So it may not necessarily be useful to enable code GC in Ruby 3.3+.

On the other hand, you may want to disable code GC in the following two scenarios:

* `--yjit-exec-mem-size` is too small for the application, which runs code GC too frequently.
* Reforking with Pitchfork: It gives better CoW efficiency.

We've already learned from https://github.com/ruby/ruby/pull/8522 that skipping compilation of long-tail cold code doesn't significantly impact production performance. Similarly, when experimenting with disabling code GC in production, it performed just as well as enabling it.

So, given that it not only is the behavior we use (for reforking with Pitchfork) but also removes the burden of monitoring `code_gc_count` from casual YJIT users, we thought it's better to disable code GC by default.