### PR TITLE
YJIT: refactor format_number

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -437,11 +437,10 @@ module RubyVM::YJIT
 
     # Format large numbers with comma separators for readability
     def format_number(pad, number)
-      integer, decimal = number.to_s.split(".")
-      d_groups = integer.chars.reverse.each_slice(3)
-      with_commas = d_groups.map(&:join).join(',').reverse
-      formatted = [with_commas, decimal].compact.join(".")
-      formatted.rjust(pad, ' ')
+      s = number.to_s
+      i = s.index('.') || s.size
+      s.insert(i -= 3, ',') while i > 3
+      s.rjust(pad, ' ')
     end
 
     # Format a number along with a percentage over a total value


### PR DESCRIPTION
Replace enumerators with simpler and faster version that only inserts commas before '.' or end of integer string.
Note that this version generates the same results for both positive and negative integers and floats.

## Benchmark
```ruby
def format_number(pad, number)
  integer, decimal = number.to_s.split(".")
  d_groups = integer.chars.reverse.each_slice(3)
  with_commas = d_groups.map(&:join).join(',').reverse
  formatted = [with_commas, decimal].compact.join(".")
  formatted.rjust(pad, ' ')
end

def new_format_number(pad, number)
  s = number.to_s
  i = s.index('.') || s.size
  s.insert(i -= 3, ',') while i > 3
  s.rjust(pad, ' ')
end

pad = 10
number = 1_123_456.789
p format_number(pad, number)
p new_format_number(pad, number)
p format_number(pad, -123)
p new_format_number(pad, -123)

require 'benchmark'
n = 100_000
Benchmark.bm do |benchmark|
  benchmark.report("old format_number") do
    n.times do
      format_number(pad, number)
    end
  end
  benchmark.report("new format_number") do
    n.times do
      new_format_number(pad, number)
    end
  end
end
```
The result is ~3.5 times faster for 100_000 runs with Ruby 3.2.1.
```
"1,123,456.789"
"1,123,456.789"
"     -,123"
"     -,123"
       user     system      total        real
old format_number  1.170000   0.000000   1.170000 (  1.173373)
new format_number  0.328000   0.000000   0.328000 (  0.321516)
```
