### PR TITLE
Prohibit conversion to st_table during iteration of ar_table

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -811,6 +811,14 @@ ar_add_direct_with_hash(VALUE hash, st_data_t key, st_data_t val, st_hash_t hash
     }
 }
 
+static void
+ensure_ar_table(VALUE hash)
+{
+    if (!RHASH_AR_TABLE_P(hash)) {
+        rb_raise(rb_eRuntimeError, "hash representation was changed during iteration");
+    }
+}
+
 static int
 ar_general_foreach(VALUE hash, st_foreach_check_callback_func *func, st_update_callback_func *replace, st_data_t arg)
 {
@@ -822,6 +830,7 @@ ar_general_foreach(VALUE hash, st_foreach_check_callback_func *func, st_update_c
 
             ar_table_pair *pair = RHASH_AR_TABLE_REF(hash, i);
             enum st_retval retval = (*func)(pair->key, pair->val, arg, 0);
+            ensure_ar_table(hash);
             /* pair may be not valid here because of theap */
 
             switch (retval) {
@@ -896,6 +905,7 @@ ar_foreach_check(VALUE hash, st_foreach_check_callback_func *func, st_data_t arg
             hint = ar_hint(hash, i);
 
             retval = (*func)(key, pair->val, arg, 0);
+            ensure_ar_table(hash);
             hash_verify(hash);
 
             switch (retval) {
@@ -956,6 +966,7 @@ ar_update(VALUE hash, st_data_t key,
     old_key = key;
     retval = (*func)(&key, &value, arg, existing);
     /* pair can be invalid here because of theap */
+    ensure_ar_table(hash);
 
     switch (retval) {
       case ST_CONTINUE:

--- a/hash.c
+++ b/hash.c
@@ -4367,6 +4367,9 @@ rb_hash_compare_by_id(VALUE hash)
     if (rb_hash_compare_by_id_p(hash)) return hash;
 
     rb_hash_modify_check(hash);
+    if (hash_iterating_p(hash)) {
+        rb_raise(rb_eRuntimeError, "compare_by_identity during iteration");
+    }
     ar_force_convert_table(hash, __FILE__, __LINE__);
     HASH_ASSERT(RHASH_ST_TABLE_P(hash));
 

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -2272,4 +2272,13 @@ class TestHashOnly < Test::Unit::TestCase
       end;
     end
   end
+
+  def test_compare_by_identity_during_iteration
+    h = { 1 => 1 }
+    h.each do
+      assert_raise(RuntimeError, "compare_by_identity during iteration") do
+        h.compare_by_identity
+      end
+    end
+  end
 end


### PR DESCRIPTION
The following dumps core.

```ruby
c = {1=>:A, 2=>:B}
c.delete_if {
  c.assoc(1)
  true
}
```

This issue occurs because `Hash#assoc` converts the Hash internal representation to `st_table` during iteration of the Hash.

This changeset prevents the catastrophy by stopping the iteration of ar_table when the conversion occurs. Also, it makes `Hash#assoc` not use `ar_force_convert_table`, and prohibit `Hash#compare_by_identity` to be called during its iteration.

This issue was reported by [SuperS](https://hackerone.com/superss)