### PR TITLE
TypedData_Make_Struct0: cast RTYPEDDATA_GET_DATA return pointer

### DIFF
--- a/include/ruby/internal/core/rtypeddata.h
+++ b/include/ruby/internal/core/rtypeddata.h
@@ -464,7 +464,7 @@ RBIMPL_SYMBOL_EXPORT_END()
  */
 #define TypedData_Make_Struct0(result, klass, type, size, data_type, sval) \
     VALUE result = rb_data_typed_object_zalloc(klass, size, data_type);    \
-    (sval) = RTYPEDDATA_GET_DATA(result); \
+    (sval) = (type *)RTYPEDDATA_GET_DATA(result); \
     RBIMPL_CAST(/*suppress unused variable warnings*/(void)(sval))
 
 /**


### PR DESCRIPTION
Fixes:

```
/usr/local/ruby/include/ruby-3.3.0+0/ruby/internal/core/rtypeddata.h:467:33:
error: invalid conversion from ‘void*’ to ‘parser_t*’ [-fpermissive]
  467 |     (sval) = RTYPEDDATA_GET_DATA(result); \
      |              ~~~~~~~~~~~~~~~~~~~^~~~~~~~
      |                                 |
      |                                 void*
```

FYI: @peterzhu2118 