### PR TITLE
.travis.yml: Add arm64 case.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,14 +106,14 @@ matrix:
     # <internal:dir>:411:in glob: File name too long - (Errno::ENAMETOOLONG)
     # https://github.com/rubygems/rubygems/issues/7132
     - <<: *arm32-linux
-    # Comment out as the 2nd arm64 pipeline is unstable.
-    # - <<: *arm64-linux
+    - <<: *arm64-linux
     - <<: *ppc64le-linux
     - <<: *s390x-linux
   allow_failures:
     # Allow failures for the unstable jobs.
     # - name: arm32-linux
-    # - name: arm64-linux
+    # The 2nd arm64 pipeline may be unstable.
+    - name: arm64-linux
     # - name: ppc64le-linux
     # - name: s390x-linux
   fast_finish: true


### PR DESCRIPTION
In the past, I saw that the 2nd arm64 pipeline was unstable. Now I want to try it to check if it is stable enough to run again.

As far as I know, right now the only native arm64 cases are MacOS Arm `macos-arm-oss` on GitHub Actions. And I want to add Linux arm64 case on pull-request in CI.

First, I want to check it for a term by enabling `allow_failures` for the case.