### PR TITLE
Do not allow test-all to load the bundled gems

### DIFF
--- a/test/runner.rb
+++ b/test/runner.rb
@@ -1,16 +1,9 @@
 # frozen_string_literal: true
 
 # Should be done in rubygems test files?
-ENV["GEM_SKIP"] = "".freeze
+ENV["GEM_SKIP"] = ENV["GEM_HOME"] = ENV["GEM_PATH"] = "".freeze
 ENV.delete("RUBY_CODESIGN")
 
 Warning[:experimental] = false
-
-gem_path = [
-  File.realdirpath(".bundle"),
-  File.realdirpath("../.bundle", __dir__),
-]
-ENV["GEM_PATH"] = gem_path.join(File::PATH_SEPARATOR)
-ENV["GEM_HOME"] = gem_path.first
 
 require_relative '../tool/test/runner'


### PR DESCRIPTION
This change prevents default gems from inadvertently depending on bundled gems. This issue was discovered by being able to `require "rbs"` from test/irb.