### PR TITLE
Revert "[ruby/irb] Skip TypeCompletion test in ruby ci"

### DIFF
--- a/test/irb/test_context.rb
+++ b/test/irb/test_context.rb
@@ -653,7 +653,6 @@ module TestIRB
     end
 
     def test_build_completor
-      pend 'set ENV["WITH_TYPE_COMPLETION_TEST"] to run this test' unless ENV['WITH_TYPE_COMPLETION_TEST']
       verbose, $VERBOSE = $VERBOSE, nil
       original_completor = IRB.conf[:COMPLETOR]
       IRB.conf[:COMPLETOR] = :regexp

--- a/test/irb/type_completion/test_scope.rb
+++ b/test/irb/type_completion/test_scope.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return unless ENV['WITH_TYPE_COMPLETION_TEST']
-
 return unless RUBY_VERSION >= '3.0.0'
 return if RUBY_ENGINE == 'truffleruby' # needs endless method definition
 

--- a/test/irb/type_completion/test_type_analyze.rb
+++ b/test/irb/type_completion/test_type_analyze.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return unless ENV['WITH_TYPE_COMPLETION_TEST']
-
 # Run test only when Ruby >= 3.0 and %w[prism rbs] are available
 return unless RUBY_VERSION >= '3.0.0'
 return if RUBY_ENGINE == 'truffleruby' # needs endless method definition

--- a/test/irb/type_completion/test_type_completor.rb
+++ b/test/irb/type_completion/test_type_completor.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return unless ENV['WITH_TYPE_COMPLETION_TEST']
-
 # Run test only when Ruby >= 3.0 and %w[prism rbs] are available
 return unless RUBY_VERSION >= '3.0.0'
 return if RUBY_ENGINE == 'truffleruby' # needs endless method definition

--- a/test/irb/type_completion/test_types.rb
+++ b/test/irb/type_completion/test_types.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-return unless ENV['WITH_TYPE_COMPLETION_TEST']
-
 return unless RUBY_VERSION >= '3.0.0'
 return if RUBY_ENGINE == 'truffleruby' # needs endless method definition
 


### PR DESCRIPTION
This guard is unnecessary with https://github.com/ruby/ruby/commit/486b674e2a8437bacb00c48038c04aec420c47a0

This reverts commit 8da33bff8c871508b03776580e46bc90c722bd57.