### PR TITLE
Range check in `prism_constant_id_lookup`

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -719,6 +719,9 @@ pm_lookup_local_index_with_depth(rb_iseq_t *iseq, pm_scope_node_t *scope_node, p
 static ID
 pm_constant_id_lookup(pm_scope_node_t *scope_node, pm_constant_id_t constant_id)
 {
+    if (constant_id < 1 || constant_id > scope_node->parser->constant_pool.size) {
+        rb_raise(rb_eArgError, "[PRISM] constant_id out of range: %u", (unsigned int)constant_id);
+    }
     return scope_node->constants[constant_id - 1];
 }
 

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -719,7 +719,7 @@ pm_lookup_local_index_with_depth(rb_iseq_t *iseq, pm_scope_node_t *scope_node, p
 static ID
 pm_constant_id_lookup(pm_scope_node_t *scope_node, pm_constant_id_t constant_id)
 {
-    return ((ID *)scope_node->constants)[constant_id - 1];
+    return scope_node->constants[constant_id - 1];
 }
 
 static rb_iseq_t *
@@ -3782,7 +3782,7 @@ rb_translate_prism(pm_parser_t *parser, rb_iseq_t *iseq, pm_scope_node_t *scope_
     for (size_t i = 0; i < locals->size; i++) {
         st_insert(index_lookup_table, locals->ids[i], i);
     }
-    scope_node->constants = (void *)constants;
+    scope_node->constants = constants;
     scope_node->index_lookup_table = index_lookup_table;
 
     pm_compile_node(iseq, (pm_node_t *)scope_node, ret, scope_node->base.location.start, false, (pm_scope_node_t *)scope_node);


### PR DESCRIPTION
Seems out-of-range access happens on some, probably 32bit, platforms.