### PR TITLE
Show the first non-internal frame at exception when debug

### DIFF
--- a/internal/vm.h
+++ b/internal/vm.h
@@ -116,6 +116,7 @@ const struct rb_iseq_struct *rb_get_iseq_from_frame_info(VALUE obj);
 
 VALUE rb_ec_backtrace_object(const struct rb_execution_context_struct *ec);
 void rb_backtrace_use_iseq_first_lineno_for_last_location(VALUE self);
+VALUE rb_ec_first_backtrace_location(const struct rb_execution_context_struct *ec, int *line);
 
 #define RUBY_DTRACE_CREATE_HOOK(name, arg) \
     RUBY_DTRACE_HOOK(name##_CREATE, arg)

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -458,6 +458,17 @@ end.join
     assert_not_match(/:0/, stderr, "[ruby-dev:39116]")
   end
 
+  def test_debug_exception
+    pattern = /-e:1 - cannot load such file/
+    Tempfile.create(%w"debug_exception .rb") do |f|
+      path = f.path
+      f.close
+      File.unlink(path)
+      assert_in_out_err(["-e", "$DEBUG = true; require ARGV[0]", "--", path], "", [], pattern)
+      assert_in_out_err(["--enable=gems", "-e", "$DEBUG = true; require ARGV[0]", "--", path], "", [], pattern)
+    end
+  end
+
   def test_errinfo
     begin
       raise "foo"

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -790,6 +790,24 @@ rb_backtrace_to_location_ary(VALUE self)
     return bt->locary;
 }
 
+VALUE
+rb_ec_first_backtrace_location(const rb_execution_context_t *ec, int *line)
+{
+    rb_backtrace_t *bt;
+    rb_backtrace_location_t *loc;
+    const rb_iseq_t *iseq;
+    VALUE path;
+    VALUE btobj = rb_ec_partial_backtrace_object(ec, 0, 1, NULL, true, FALSE);
+    GetCoreDataFromValue(btobj, rb_backtrace_t, bt);
+    if (bt->backtrace_size != 1 || !(loc = &bt->backtrace[0]) || !loc->pc ||
+        !(iseq = location_iseq(loc)) || NIL_P(path = rb_iseq_path(iseq))) {
+        if (line) *line = 0;
+        return Qnil;
+    }
+    if (line) *line = calc_lineno(iseq, loc->pc);
+    return path;
+}
+
 static VALUE
 backtrace_dump_data(VALUE self)
 {


### PR DESCRIPTION
When failed in `require`, it always shows just the path of the rubygems code and useless.