### PR TITLE
GVL Instrumentation: pass thread->self as part of event data

### DIFF
--- a/include/ruby/thread.h
+++ b/include/ruby/thread.h
@@ -227,7 +227,9 @@ void *rb_nogvl(void *(*func)(void *), void *data1,
 
 #define RUBY_INTERNAL_THREAD_EVENT_MASK       0xff /** All Thread events */
 
-typedef void rb_internal_thread_event_data_t; // for future extension.
+typedef struct rb_internal_thread_event_data {
+   VALUE thread;
+} rb_internal_thread_event_data_t;
 
 typedef void (*rb_internal_thread_event_callback)(rb_event_flag_t event,
               const rb_internal_thread_event_data_t *event_data,

--- a/test/-ext-/thread/test_instrumentation_api.rb
+++ b/test/-ext-/thread/test_instrumentation_api.rb
@@ -22,6 +22,7 @@ class TestThreadInstrumentation < Test::Unit::TestCase
   def teardown
     return if /mswin|mingw|bccwin/ =~ RUBY_PLATFORM
     Bug::ThreadInstrumentation::unregister_callback
+    Bug::ThreadInstrumentation.last_spawned_thread = nil
   end
 
   THREADS_COUNT = 3
@@ -66,6 +67,12 @@ class TestThreadInstrumentation < Test::Unit::TestCase
   def test_thread_instrumentation_unregister
     Bug::ThreadInstrumentation::unregister_callback
     assert Bug::ThreadInstrumentation::register_and_unregister_callbacks
+  end
+
+  def test_thread_instrumentation_event_data
+    assert_nil Bug::ThreadInstrumentation.last_spawned_thread
+    thr = Thread.new{ }.join
+    assert_same thr, Bug::ThreadInstrumentation.last_spawned_thread
   end
 
   private

--- a/thread.c
+++ b/thread.c
@@ -5409,7 +5409,7 @@ Init_Thread(void)
             // thread_sched_to_running(sched, th);
 
 #ifdef RB_INTERNAL_THREAD_HOOK
-            RB_INTERNAL_THREAD_HOOK(RUBY_INTERNAL_THREAD_EVENT_RESUMED);
+            RB_INTERNAL_THREAD_HOOK(RUBY_INTERNAL_THREAD_EVENT_RESUMED, th);
 #endif
 
             th->pending_interrupt_queue = rb_ary_hidden_new(0);


### PR DESCRIPTION
Replaces: https://github.com/ruby/ruby/pull/6189
Context: https://github.com/ivoanjo/gvl-tracing/pull/4

Some hooks may want to collect data on a per thread basis. Right now the only way to identify the concerned thread is to use `rb_nativethread_self()` or similar, but even then because of the thread cache or MaNy, two distinct Ruby threads may report the same native thread id.

By passing `thread->self`, hooks can use it as a key to store the metadata.

NB: Most hooks are executed outside the GVL, so such data collection need to use a thread-safe data-structure, and shouldn't use the reference in other ways from inside the hook.

They must also either pin that value or handle compaction.

cc @ko1 @tenderlove @ivoanjo 