### PR TITLE
.travis.yml: Run arm64 without allow_failiures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,20 +102,20 @@ env:
 
 matrix:
   include:
+    - <<: *arm64-linux
+    - <<: *ppc64le-linux
+    - <<: *s390x-linux
     # FIXME: lib/rubygems/util.rb:104 glob_files_in_dir -
     # <internal:dir>:411:in glob: File name too long - (Errno::ENAMETOOLONG)
     # https://github.com/rubygems/rubygems/issues/7132
     - <<: *arm32-linux
-    - <<: *arm64-linux
-    - <<: *ppc64le-linux
-    - <<: *s390x-linux
   allow_failures:
     # Allow failures for the unstable jobs.
-    # - name: arm32-linux
-    # The 2nd arm64 pipeline may be unstable.
-    - name: arm64-linux
+    # - name: arm64-linux
     # - name: ppc64le-linux
     # - name: s390x-linux
+    # The 2nd arm64 pipeline may be unstable.
+    # - name: arm32-linux
   fast_finish: true
 
 before_script:


### PR DESCRIPTION
Checking the past 10 builds in Travis CI arm64, it looks stable. So, disable `allow_failures`.

Also sorted the order of the jobs for the priority. The arm64 is the first. And I would like to run arm32 using the arm64 pipeline a bit later after the arm64 using the same arm64 pipeline. So, the arm32 is the last.

## The past 10 builds in Travis CI.

I can see all the tests in the arm64 case are ok.

* `#61462`: ok
  https://app.travis-ci.com/github/ruby/ruby/builds/267163169
* `#61457`: ok
  https://app.travis-ci.com/github/ruby/ruby/builds/267155680
* `#61455`: ok
  https://app.travis-ci.com/github/ruby/ruby/builds/267155315
* `#61454`: ok
  https://app.travis-ci.com/github/ruby/ruby/builds/267154544
* `#61452`: ok
  https://app.travis-ci.com/github/ruby/ruby/builds/267153533
* `#61451`: arm32: IRB test failing with the commit itself: ok
  https://app.travis-ci.com/github/ruby/ruby/builds/267152940
* `#61450`: ok
  https://app.travis-ci.com/github/ruby/ruby/builds/267152882
* `#61440`: ok
  https://app.travis-ci.com/github/ruby/ruby/builds/267143243
* `#61436`: ok
  https://app.travis-ci.com/github/ruby/ruby/builds/267139565
* `#61434`: ok
  https://app.travis-ci.com/github/ruby/ruby/builds/267138883