### PR TITLE
YJIT: Take simple suggestions from Clippy

### DIFF
--- a/yjit/src/asm/arm64/arg/bitmask_imm.rs
+++ b/yjit/src/asm/arm64/arg/bitmask_imm.rs
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn test_failures() {
-        vec![5, 9, 10, 11, 13, 17, 18, 19].iter().for_each(|&imm| {
+        [5, 9, 10, 11, 13, 17, 18, 19].iter().for_each(|&imm| {
             assert!(BitmaskImmediate::try_from(imm).is_err());
         });
     }

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1097,7 +1097,7 @@ impl Assembler
         let side_exit = match self.side_exits.get(&side_exit_context) {
             None => {
                 let exit_code = gen_outlined_exit(side_exit_context.pc, &side_exit_context.get_ctx(), ocb)?;
-                self.side_exits.insert(side_exit_context.clone(), exit_code);
+                self.side_exits.insert(*side_exit_context, exit_code);
                 exit_code
             }
             Some(code_ptr) => *code_ptr,

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -410,7 +410,7 @@ fn verify_ctx(jit: &JITState, ctx: &Context) {
                 }
             }
             TempMappingKind::MapToLocal => {
-                let local_idx: u8 = learned_mapping.get_local_idx().into();
+                let local_idx: u8 = learned_mapping.get_local_idx();
                 let local_val = jit.peek_at_local(local_idx.into());
                 if local_val != stack_val {
                     panic!(
@@ -2680,7 +2680,7 @@ fn gen_definedivar(
         jit_prepare_routine_call(jit, asm);
 
         // Call rb_ivar_defined(recv, ivar_name)
-        let def_result = asm.ccall(rb_ivar_defined as *const u8, vec![recv.into(), ivar_name.into()]);
+        let def_result = asm.ccall(rb_ivar_defined as *const u8, vec![recv, ivar_name.into()]);
 
         // if (rb_ivar_defined(recv, ivar_name)) {
         //  val = pushval;
@@ -5028,7 +5028,7 @@ fn jit_obj_respond_to(
         (METHOD_VISI_UNDEF, _) => {
             // No method, we can return false given respond_to_missing? hasn't been overridden.
             // In the future, we might want to jit the call to respond_to_missing?
-            if !assume_method_basic_definition(jit, asm, ocb, recv_class, ID!(respond_to_missing).into()) {
+            if !assume_method_basic_definition(jit, asm, ocb, recv_class, ID!(respond_to_missing)) {
                 return false;
             }
             Qfalse

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2459,7 +2459,7 @@ fn gen_setinstancevariable(
         // If the VM ran out of shapes, or this class generated too many leaf,
         // it may be de-optimized into OBJ_TOO_COMPLEX_SHAPE (hash-table).
         if next_shape_id == OBJ_TOO_COMPLEX_SHAPE_ID {
-            Some((next_shape_id, None, 0 as usize))
+            Some((next_shape_id, None, 0_usize))
         } else {
             let current_capacity = unsafe { (*current_shape).capacity };
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -514,8 +514,8 @@ impl BranchGenFn {
                     BranchShape::Next0 => asm.jz(target1.unwrap()),
                     BranchShape::Next1 => asm.jnz(target0),
                     BranchShape::Default => {
-                        asm.jnz(target0.into());
-                        asm.jmp(target1.unwrap().into());
+                        asm.jnz(target0);
+                        asm.jmp(target1.unwrap());
                     }
                 }
             }
@@ -544,11 +544,11 @@ impl BranchGenFn {
                     panic!("Branch shape Next1 not allowed in JumpToTarget0!");
                 }
                 if shape.get() == BranchShape::Default {
-                    asm.jmp(target0.into());
+                    asm.jmp(target0);
                 }
             }
             BranchGenFn::JNZToTarget0 => {
-                asm.jnz(target0.into())
+                asm.jnz(target0)
             }
             BranchGenFn::JZToTarget0 => {
                 asm.jz(target0)
@@ -1835,7 +1835,7 @@ impl Context {
                 MapToLocal => {
                     let idx = mapping.get_local_idx();
                     if idx as usize == local_idx {
-                        let local_type = self.get_local_type(local_idx.into());
+                        let local_type = self.get_local_type(local_idx);
                         TempMapping::map_to_stack(local_type)
                     } else {
                         TempMapping::map_to_local(idx)
@@ -2015,7 +2015,7 @@ impl Assembler {
             return self.stack_push(Type::Unknown);
         }
 
-        return self.stack_push_mapping(TempMapping::map_to_local((local_idx as u8).into()));
+        return self.stack_push_mapping(TempMapping::map_to_local(local_idx as u8));
     }
 
     // Pop N values off the stack

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1847,7 +1847,7 @@ impl Context {
         // Update the type bits
         let type_bits = local_type as u32;
         assert!(type_bits <= 0b1111);
-        let mask_bits = (0b1111 as u32) << (4 * local_idx);
+        let mask_bits = 0b1111_u32 << (4 * local_idx);
         let shifted_bits = type_bits << (4 * local_idx);
         self.local_types = (self.local_types & !mask_bits) | shifted_bits;
     }
@@ -2044,7 +2044,7 @@ impl Assembler {
     pub fn shift_stack(&mut self, argc: usize) {
         assert!(argc < self.ctx.stack_size.into());
 
-        let method_name_index = (self.ctx.stack_size as usize) - (argc as usize) - 1;
+        let method_name_index = (self.ctx.stack_size as usize) - argc - 1;
 
         for i in method_name_index..(self.ctx.stack_size - 1) as usize {
             if i + 1 < MAX_TEMP_TYPES {


### PR DESCRIPTION
These are simple mechanical changes, hopefully uncontroversial. Down to just 3 warnings after this. 

--- 

- YJIT: Auto fix for clippy::clone_on_copy
- YJIT: Auto fix for clippy::unnecessary_cast
- YJIT: Take cargo --fix for unnecessary calls to into()
- YJIT: Fix `clippy::useless_vec` in a test
