### PR TITLE
[Bug #19994] Mark cc->cme_ for refinement callcaches as well

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7216,12 +7216,13 @@ gc_mark_imemo(rb_objspace_t *objspace, VALUE obj)
          * - On the multi-Ractors, cme will be collected with global GC
          *   so that it is safe if GC is not interleaving while accessing
          *   cc and cme.
-         * - However, cc_type_super is not chained from cc so the cc->cme
-         *   should be marked.
+         * - However, cc_type_super and cc_type_refinement are not chained
+         *   from ccs so cc->cme should be marked; the cme might be
+         *   reachable only through cc in these cases.
          */
         {
             const struct rb_callcache *cc = (const struct rb_callcache *)obj;
-            if (vm_cc_super_p(cc)) {
+            if (vm_cc_super_p(cc) || vm_cc_refinement_p(cc)) {
                 gc_mark(objspace, (VALUE)cc->cme_);
             }
         }


### PR DESCRIPTION
This seems to be required for the same reason that it's required for super (added in 36023d5cb751d62fca0c27901c07527b20170f4d). I'm not exactly sure _how_ this is possible though; surely the CME must be strongly held by the refinement module?

I think this will fix https://bugs.ruby-lang.org/issues/19994. 

I'm _fairly_ sure this is a consequence of the intersection of the following three PR's:

* https://github.com/ruby/ruby/pull/8120 - makes `rb_callcache` objects _not_ mark method entries
* https://github.com/ruby/ruby/pull/8145 - undoes that, but _only_ for `super` callcaches
* https://github.com/ruby/ruby/pull/8129 - adds a new callcache type for refinements.

I guess the refinement callcaches are "orphaned" in the same way that the super ones are; they're not added to the classes `rb_class_cc_entries` table, so it doesn't get invalidated when e.g. the class is freed. What I _don't_ understand is how the callcache can ever get used again though in that circumstance - how would the iseq holding the callcache be actually callable by anything?

@ko1 - :pray: would you be able to see if this looks right to you? And if so.... could you tell me _why_ it's right? :)

[Fixes #19994]