### PR TITLE
[wasm] allocate Asyncify setjmp buffer in heap

### DIFF
--- a/eval_intern.h
+++ b/eval_intern.h
@@ -110,9 +110,11 @@ extern int select_large_fdset(int, fd_set *, fd_set *, fd_set *, struct timeval 
   _tag.tag = Qundef; \
   _tag.prev = _ec->tag; \
   _tag.lock_rec = rb_ec_vm_lock_rec(_ec); \
+  rb_vm_tag_jmpbuf_init(&_tag.buf); \
 
 #define EC_POP_TAG() \
   _ec->tag = _tag.prev; \
+  rb_vm_tag_jmpbuf_deinit(&_tag.buf); \
 } while (0)
 
 #define EC_TMPPOP_TAG() \
@@ -161,7 +163,7 @@ rb_ec_tag_jump(const rb_execution_context_t *ec, enum ruby_tag_type st)
 {
     RUBY_ASSERT(st != TAG_NONE);
     ec->tag->state = st;
-    ruby_longjmp(ec->tag->buf, 1);
+    ruby_longjmp(RB_VM_TAG_JMPBUF_GET(ec->tag->buf), 1);
 }
 
 /*
@@ -169,7 +171,7 @@ rb_ec_tag_jump(const rb_execution_context_t *ec, enum ruby_tag_type st)
   [ISO/IEC 9899:1999] 7.13.1.1
 */
 #define EC_EXEC_TAG() \
-    (UNLIKELY(ruby_setjmp(_tag.buf)) ? rb_ec_tag_state(VAR_FROM_MEMORY(_ec)) : (EC_REPUSH_TAG(), 0))
+    (UNLIKELY(ruby_setjmp(RB_VM_TAG_JMPBUF_GET(_tag.buf))) ? rb_ec_tag_state(VAR_FROM_MEMORY(_ec)) : (EC_REPUSH_TAG(), 0))
 
 #define EC_JUMP_TAG(ec, st) rb_ec_tag_jump(ec, st)
 

--- a/vm.c
+++ b/vm.c
@@ -2462,7 +2462,7 @@ vm_exec(rb_execution_context_t *ec)
 
     rb_wasm_try_catch_init(&try_catch, vm_exec_bottom_main, vm_exec_bottom_rescue, &ctx);
 
-    rb_wasm_try_catch_loop_run(&try_catch, &_tag.buf);
+    rb_wasm_try_catch_loop_run(&try_catch, &RB_VM_TAG_JMPBUF_GET(_tag.buf));
 
     result = ctx.result;
 #else


### PR DESCRIPTION
`rb_jmpbuf_t` type is considerably large due to inline-allocated Asyncify buffer, and it leads to stack overflow even with small number of C-method call frames. This commit allocates the Asyncify buffer used by `rb_wasm_setjmp` in heap to mitigate the issue.

This patch introduces a new type `rb_vm_tag_jmpbuf_t` to abstract the representation of a jump buffer, and init/deinit hook points to manage lifetime of the buffer. These changes are effectively NFC for non-wasm platforms.