### PR TITLE
Array#rassoc should try to convert to array implicitly. Fixes #20003

### DIFF
--- a/array.c
+++ b/array.c
@@ -5049,7 +5049,7 @@ rb_ary_rassoc(VALUE ary, VALUE value)
     VALUE v;
 
     for (i = 0; i < RARRAY_LEN(ary); ++i) {
-        v = RARRAY_AREF(ary, i);
+        v = rb_check_array_type(RARRAY_AREF(ary, i));
         if (RB_TYPE_P(v, T_ARRAY) &&
             RARRAY_LEN(v) > 1 &&
             rb_equal(RARRAY_AREF(v, 1), value))

--- a/spec/ruby/core/array/rassoc_spec.rb
+++ b/spec/ruby/core/array/rassoc_spec.rb
@@ -36,15 +36,17 @@ describe "Array#rassoc" do
     [[1, :foobar, o], [2, o, 1], [3, mock('foo')]].rassoc(key).should == [2, o, 1]
   end
 
-  it "calls to_ary on non-array elements" do
-    s1 = [1, 2]
-    s2 = ArraySpecs::ArrayConvertible.new(2, 3)
-    a = [s1, s2]
+  ruby_version_is "3.3" do
+    it "calls to_ary on non-array elements" do
+      s1 = [1, 2]
+      s2 = ArraySpecs::ArrayConvertible.new(2, 3)
+      a = [s1, s2]
 
-    s1.should_not_receive(:to_ary)
-    a.rassoc(2).should equal(s1)
+      s1.should_not_receive(:to_ary)
+      a.rassoc(2).should equal(s1)
 
-    a.rassoc(3).should == [2, 3]
-    s2.called.should equal(:to_ary)
+      a.rassoc(3).should == [2, 3]
+      s2.called.should equal(:to_ary)
+    end
   end
 end

--- a/spec/ruby/core/array/rassoc_spec.rb
+++ b/spec/ruby/core/array/rassoc_spec.rb
@@ -36,7 +36,7 @@ describe "Array#rassoc" do
     [[1, :foobar, o], [2, o, 1], [3, mock('foo')]].rassoc(key).should == [2, o, 1]
   end
 
-  it "does not call to_ary on non-array elements" do
+  it "calls to_ary on non-array elements" do
     s1 = [1, 2]
     s2 = ArraySpecs::ArrayConvertible.new(2, 3)
     a = [s1, s2]
@@ -44,7 +44,7 @@ describe "Array#rassoc" do
     s1.should_not_receive(:to_ary)
     a.rassoc(2).should equal(s1)
 
-    s2.should_not_receive(:to_ary)
-    a.rassoc(3).should equal(nil)
+    a.rassoc(3).should == [2, 3]
+    s2.called.should equal(:to_ary)
   end
 end

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -529,14 +529,19 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_assoc
+    def (a4 = Object.new).to_ary
+      %w( pork porcine )
+    end
+
     a1 = @cls[*%w( cat feline )]
     a2 = @cls[*%w( dog canine )]
     a3 = @cls[*%w( mule asinine )]
 
-    a = @cls[ a1, a2, a3 ]
+    a = @cls[ a1, a2, a3, a4 ]
 
     assert_equal(a1, a.assoc('cat'))
     assert_equal(a3, a.assoc('mule'))
+    assert_equal(%w( pork porcine ), a.assoc("pork"))
     assert_equal(nil, a.assoc('asinine'))
     assert_equal(nil, a.assoc('wombat'))
     assert_equal(nil, a.assoc(1..2))
@@ -1329,13 +1334,17 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_rassoc
+    def (a4 = Object.new).to_ary
+      %w( pork porcine )
+    end
     a1 = @cls[*%w( cat  feline )]
     a2 = @cls[*%w( dog  canine )]
     a3 = @cls[*%w( mule asinine )]
-    a  = @cls[ a1, a2, a3 ]
+    a  = @cls[ a1, a2, a3, a4 ]
 
     assert_equal(a1,  a.rassoc('feline'))
     assert_equal(a3,  a.rassoc('asinine'))
+    assert_equal(%w( pork porcine ), a.rassoc("porcine"))
     assert_equal(nil, a.rassoc('dog'))
     assert_equal(nil, a.rassoc('mule'))
     assert_equal(nil, a.rassoc(1..2))


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/20003

There is a difference between behaviour of `Array#assoc` and `Array#rassoc`. The first one performs implicit conversion (calls `#to_ary`) while the former does not.

```ruby
class ArrayConvertible
  def initialize(*values)
    @values = values;
  end

  def to_ary
    @values
  end
end

s1 = [1, 2]
s2 = ArrayConvertible.new(2, 3)
a = [s1, s2]
```

The `a.assoc(2)` call returns `[2, 3]` as expected. However, `a.rassoc(3)` returns `nil`

**Expected behaviour**: `a.rassoc(3)` returns `[2, 3]` in such cases.