### PR TITLE
make-snapshot: update RUBY_PATCHLEVEL_STR regexp

### DIFF
--- a/tool/make-snapshot
+++ b/tool/make-snapshot
@@ -364,7 +364,7 @@ def package(vcs, rev, destdir, tmp = nil)
     end
   elsif prerelease
     versionhdr ||= IO.read("#{v}/version.h")
-    versionhdr.sub!(/^\#define\s+RUBY_PATCHLEVEL_STR\s+"\K.+?(?=")/, tag)
+    versionhdr.sub!(/^\#\s*define\s+RUBY_PATCHLEVEL_STR\s+"\K.+?(?=")/, tag) or raise "no match of RUBY_PATCHLEVEL_STR to replace"
     IO.write("#{v}/version.h", versionhdr)
   else
     tag ||= vcs.revision_name(revision)


### PR DESCRIPTION
Ruby 3.3.0.preview3 tarball has `#define RUBY_PATCHLEVEL_STR "dev"` instead of `"preview3"`.

The regexp to replace RUBY_PATCHLEVEL_STR for prerelease snapshots doesn't match since GH-8578.

follow-up: https://github.com/ruby/ruby/pull/8578
follow-up: 68df43788dc237a1071f02b2d82768f844696315