### PR TITLE
[DOC] Correct Time class timezone example

### DIFF
--- a/timev.rb
+++ b/timev.rb
@@ -66,9 +66,10 @@
 #
 #   Time.new(2002, 10, 31, 2, 2, 2, "+02:00") #=> 2002-10-31 02:02:02 +0200
 #
-# Or a timezone object:
+# Or a {TZInfo}[https://github.com/tzinfo/tzinfo] timezone object:
 #
-#   zone = timezone("Europe/Athens")      # Eastern European Time, UTC+2
+#   require "tzinfo"
+#   zone = TZInfo::Timezone.get("Europe/Athens") # Eastern European Time, UTC+2
 #   Time.new(2002, 10, 31, 2, 2, 2, zone) #=> 2002-10-31 02:02:02 +0200
 #
 # You can also use Time.local and Time.utc to infer


### PR DESCRIPTION
The Time documentation seemed to suggest there was such a method as `timezone()` which doesn't exist but it does have an equivalent in the TZInfo gem which is (officially?) supported by the Ruby Time class per [time.c][1].

We could also remove this example since it depends on a third-party gem, but TZInfo is a valuable Ruby tool, so I don't think that would be advisable.

[1]: https://github.com/olivierlacan/ruby/blob/5bb756287244923f2817a5989fe9dc78930b4380/time.c#L5700-L5705