### PR TITLE
Revert 8858 ktsanaktsidis/dump all threadsafe

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -11935,11 +11935,7 @@ static void
 reachable_objects_from_callback(VALUE obj)
 {
     rb_ractor_t *cr = GET_RACTOR();
-    struct gc_mark_func_data_struct *cur_mfd = cr->mfd;
-    cur_mfd->mark_func(obj, cr->mfd->data);
-    /* mark_func might give up the GVL, in which time some other thread might set
-       mfd. In that case, set it back to the right value for this thread. */
-    cr->mfd = cur_mfd;
+    cr->mfd->mark_func(obj, cr->mfd->data);
 }
 
 void

--- a/gc.c
+++ b/gc.c
@@ -11987,23 +11987,19 @@ objspace_reachable_objects_from_root(rb_objspace_t *objspace, void (func)(const 
 {
     if (during_gc) rb_bug("objspace_reachable_objects_from_root() is not supported while during_gc == true");
 
-    RB_VM_LOCK_ENTER();
-    {
-        rb_ractor_t *cr = GET_RACTOR();
-        struct root_objects_data data = {
-            .func = func,
-            .data = passing_data,
-        };
-        struct gc_mark_func_data_struct mfd = {
-            .mark_func = root_objects_from,
-            .data = &data,
-        }, *prev_mfd = cr->mfd;
+    rb_ractor_t *cr = GET_RACTOR();
+    struct root_objects_data data = {
+        .func = func,
+        .data = passing_data,
+    };
+    struct gc_mark_func_data_struct mfd = {
+        .mark_func = root_objects_from,
+        .data = &data,
+    }, *prev_mfd = cr->mfd;
 
-        cr->mfd = &mfd;
-        gc_mark_roots(objspace, &data.category);
-        cr->mfd = prev_mfd;
-    }
-    RB_VM_LOCK_LEAVE();
+    cr->mfd = &mfd;
+    gc_mark_roots(objspace, &data.category);
+    cr->mfd = prev_mfd;
 }
 
 /*

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -918,14 +918,6 @@ class TestObjSpace < Test::Unit::TestCase
     assert_equal 2, ObjectSpace.dump_shapes(output: :string, since: RubyVM.stat(:next_shape_id) - 2).lines.size
   end
 
-  def test_dump_all_in_parallel_bug_19922
-    dump_ten_times = ->() { 10.times { ObjectSpace.dump_all.tap { _1.close } } }
-    t = Thread.new { dump_ten_times.call }
-    dump_ten_times.call
-    t.value
-    # Bug #19922 would cause this test to crash.
-  end
-
   private
 
   def utf8_❨╯°□°❩╯︵┻━┻


### PR DESCRIPTION
Revert #8858 which introduced a failure on Ruby CI.

```
  1) Failure:
TestGCCompact#test_moving_hashes_down_size_pools [/home/chkbuild/chkbuild/tmp/build/20231112T183003Z/ruby/test/ruby/test_gc_compact.rb:442]:
Expected 499 to be >= 500.
```

cc @KJTsanaktsidis @mame 

Ultimately I think we should probably just lock the VM when dumping the heap. If we let other threads execute in the middle, we're not going to give a proper snapshot.