### PR TITLE
Use Variable Width Allocation on procs 

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -130,7 +130,7 @@ static const rb_data_type_t proc_data_type = {
         proc_memsize,
         proc_mark_and_move,
     },
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE
 };
 
 VALUE

--- a/vm.c
+++ b/vm.c
@@ -1091,7 +1091,7 @@ vm_proc_create_from_captured(VALUE klass,
                              int8_t is_from_method, int8_t is_lambda)
 {
     VALUE procval = rb_proc_alloc(klass);
-    rb_proc_t *proc = RTYPEDDATA_DATA(procval);
+    rb_proc_t *proc = RTYPEDDATA_GET_DATA(procval);
 
     VM_ASSERT(VM_EP_IN_HEAP_P(GET_EC(), captured->ep));
 
@@ -1131,7 +1131,7 @@ static VALUE
 proc_create(VALUE klass, const struct rb_block *block, int8_t is_from_method, int8_t is_lambda)
 {
     VALUE procval = rb_proc_alloc(klass);
-    rb_proc_t *proc = RTYPEDDATA_DATA(procval);
+    rb_proc_t *proc = RTYPEDDATA_GET_DATA(procval);
 
     VM_ASSERT(VM_EP_IN_HEAP_P(GET_EC(), vm_block_ep(block)));
     rb_vm_block_copy(procval, &proc->block, block);
@@ -1304,7 +1304,7 @@ rb_proc_isolate_bang(VALUE self)
     const rb_iseq_t *iseq = vm_proc_iseq(self);
 
     if (iseq) {
-        rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_DATA(self);
+        rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_GET_DATA(self);
         if (proc->block.type != block_type_iseq) rb_raise(rb_eRuntimeError, "not supported yet");
 
         if (ISEQ_BODY(iseq)->outer_variables) {
@@ -1333,7 +1333,7 @@ rb_proc_ractor_make_shareable(VALUE self)
     const rb_iseq_t *iseq = vm_proc_iseq(self);
 
     if (iseq) {
-        rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_DATA(self);
+        rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_GET_DATA(self);
         if (proc->block.type != block_type_iseq) rb_raise(rb_eRuntimeError, "not supported yet");
 
         if (!rb_ractor_shareable_p(vm_block_self(&proc->block))) {

--- a/vm_core.h
+++ b/vm_core.h
@@ -1218,7 +1218,7 @@ RUBY_EXTERN VALUE rb_block_param_proxy;
 RUBY_SYMBOL_EXPORT_END
 
 #define GetProcPtr(obj, ptr) \
-  GetCoreDataFromValue((obj), rb_proc_t, (ptr))
+  ptr = (rb_proc_t*) RTYPEDDATA_GET_DATA((obj))
 
 typedef struct {
     const struct rb_block block;
@@ -1676,7 +1676,7 @@ static inline const struct rb_block *
 vm_proc_block(VALUE procval)
 {
     VM_ASSERT(rb_obj_is_proc(procval));
-    return &((rb_proc_t *)RTYPEDDATA_DATA(procval))->block;
+    return &((rb_proc_t *)RTYPEDDATA_GET_DATA(procval))->block;
 }
 
 static inline const rb_iseq_t *vm_block_iseq(const struct rb_block *block);


### PR DESCRIPTION
```ruby
require 'benchmark'

a = 100_000.times.map { proc{} }
puts Benchmark.measure { 1_000.times { a.each { |p| p.call } } }
``` 

this change
```ruby
  3.856084   0.006743   3.862827 (  3.863474) 
```

old 
```ruby
  3.895393   0.013311   3.908704 (  3.909022)
```

Co-authored-by: Peter Zhu <peter.zhu@shopify.com>