### PR TITLE
[PRISM] Implement once node for interpolated regex

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -427,6 +427,8 @@ module Prism
 
       assert_prism_eval('/pit/me')
       assert_prism_eval('/pit/ne')
+
+      assert_prism_eval('2.times.map { /#{1}/o }')
     end
 
     def test_StringConcatNode


### PR DESCRIPTION
This PR implements the once node on interpolated regexes.

There is a bug in Prism where the interpolated regex with the once flag only works when there is not a local variable so the test uses a "1". We'll need to fix that.