### PR TITLE
test: Assert only events originated from `test_settracefunc.rb`

### DIFF
--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -1923,7 +1923,11 @@ CODE
 
   def tp_return_value mid
     ary = []
-    TracePoint.new(:return, :b_return){|tp| next if !target_thread?; ary << [tp.event, tp.method_id, tp.return_value]}.enable{
+    TracePoint.new(:return, :b_return){|tp|
+      next if !target_thread?
+      next if tp.path != __FILE__
+      ary << [tp.event, tp.method_id, tp.return_value]
+    }.enable{
       send mid
     }
     ary.pop # last b_return event is not required.
@@ -2132,7 +2136,7 @@ CODE
     q = Thread::Queue.new
     t = Thread.new{
       Thread.current.add_trace_func proc{|ev, file, line, *args|
-        events << [ev, file, line]
+        events << [ev, line] if file == __FILE__
       } # do not stop trace. They will be stopped at Thread termination.
       q.push 1
       _x = 1
@@ -2142,15 +2146,15 @@ CODE
     q.pop
     method_for_test_thread_add_trace_func
     t.join
-    assert_equal ["c-return", __FILE__, base_line + 3], events[0]
-    assert_equal ["line", __FILE__, base_line + 6],     events[1]
-    assert_equal ["c-call", __FILE__, base_line + 6],   events[2]
-    assert_equal ["c-return", __FILE__, base_line + 6], events[3]
-    assert_equal ["line", __FILE__, base_line + 7],     events[4]
-    assert_equal ["line", __FILE__, base_line + 8],     events[5]
-    assert_equal ["call", __FILE__, base_line + -6],    events[6]
-    assert_equal ["return", __FILE__, base_line + -4],  events[7]
-    assert_equal ["line", __FILE__, base_line + 9],     events[8]
+    assert_equal ["c-return", base_line + 3], events[0]
+    assert_equal ["line", base_line + 6],     events[1]
+    assert_equal ["c-call", base_line + 6],   events[2]
+    assert_equal ["c-return", base_line + 6], events[3]
+    assert_equal ["line", base_line + 7],     events[4]
+    assert_equal ["line", base_line + 8],     events[5]
+    assert_equal ["call", base_line + -6],    events[6]
+    assert_equal ["return", base_line + -4],  events[7]
+    assert_equal ["line", base_line + 9],     events[8]
     assert_equal nil,                         events[9]
 
     # other thread


### PR DESCRIPTION
This test suite is flaky on CI, because the test asserts events from finalizers also. Tracing events from finalizers is not deterministic and is not a part of test interests, so this commit changes the test to assert only events originated from the test file itself.