### PR TITLE
Update bundled gems

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -12,12 +12,12 @@ test-unit       3.6.1   https://github.com/test-unit/test-unit
 rexml           3.2.6   https://github.com/ruby/rexml
 rss             0.3.0   https://github.com/ruby/rss
 net-ftp         0.2.0   https://github.com/ruby/net-ftp
-net-imap        0.4.4   https://github.com/ruby/net-imap
+net-imap        0.4.5   https://github.com/ruby/net-imap
 net-pop         0.1.2   https://github.com/ruby/net-pop
 net-smtp        0.4.0   https://github.com/ruby/net-smtp
 matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
-rbs             3.2.2   https://github.com/ruby/rbs 33813a60752624d58dfe5ae770b39bfaf29fbaf1
+rbs             3.3.0   https://github.com/ruby/rbs
 typeprof        0.21.8  https://github.com/ruby/typeprof
 debug           1.8.0   https://github.com/ruby/debug 927587afb6aac69b358b86a01f602d207053e8d2
 racc            1.7.3   https://github.com/ruby/racc

--- a/tool/rbs_skip_tests
+++ b/tool/rbs_skip_tests
@@ -28,6 +28,8 @@ test_subtract_several_subtrahends(RBS::CliTest) running tests without Bundler
 test_subtract_write(RBS::CliTest) running tests without Bundler
 test_subtract_write_removes_definition_if_empty(RBS::CliTest) running tests without Bundler
 
+test_TOPDIR(RbConfigSingletonTest) `TOPDIR` is `nil` during CI while RBS type is declared as `String`
+
 test_aref(FiberSingletonTest) the method should not accept String keys
 
 NetSingletonTest depending on external resources


### PR DESCRIPTION
https://github.com/ruby/actions/actions/runs/6862152930/job/18659291807 is failing now. I fixed it at https://github.com/ruby/ruby/commit/e6b2cd15e34cbeaf07d8ced2db89d02272e9d5af

Try to upgrade manually.