### PR TITLE
Fix regex match cache out-of-bounds access

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -4092,7 +4092,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	  if (num_match_cache_points >= LONG_MAX_LIMIT) {
 	    return ONIGERR_MEMORY;
 	  }
-	  size_t match_cache_buf_length = (num_match_cache_points >> 3) + (num_match_cache_points & 7 ? 1 : 0);
+	  size_t match_cache_buf_length = (num_match_cache_points >> 3) + (num_match_cache_points & 7 ? 1 : 0) + 1;
 	  uint8_t* match_cache_buf = (uint8_t*)xmalloc(match_cache_buf_length * sizeof(uint8_t));
 	  if (match_cache_buf == NULL) {
 	    return ONIGERR_MEMORY;


### PR DESCRIPTION
Previously the following read and wrote 1 byte out-of-bounds:

    $ valgrind ruby -e 'p /(\W+)[bx]\?/i.match? "aaaaaa aaaaaaaaa aaaa aaaaaaaa aaa aaaaxaaaaaaaaaaa aaaaa aaaaaaaaaaaa a ? aaa aaaa a ?"' 2> >(grep Invalid -A 30)

Because of the `match_cache_point_index + 1` in
memoize_extended_match_cache_point() and
check_extended_match_cache_point(), we need one more byte of space.

---

Sorry, I don't understand this code well enough to give a better reproducer. Since the corruption is just one byte, I also couldn't make a test case, but it does eventually lead to crashes in a private app.