### PR TITLE
rb_evict_ivars_to_hash: get rid of the shape parameter

### DIFF
--- a/internal/variable.h
+++ b/internal/variable.h
@@ -48,7 +48,7 @@ VALUE rb_mod_set_temporary_name(VALUE, VALUE);
 struct gen_ivtbl;
 int rb_gen_ivtbl_get(VALUE obj, ID id, struct gen_ivtbl **ivtbl);
 int rb_obj_evacuate_ivs_to_hash_table(ID key, VALUE val, st_data_t arg);
-void rb_evict_ivars_to_hash(VALUE obj, rb_shape_t * shape);
+void rb_evict_ivars_to_hash(VALUE obj);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* variable.c (export) */

--- a/object.c
+++ b/object.c
@@ -474,7 +474,7 @@ mutable_obj_clone(VALUE obj, VALUE kwfreeze)
         if (RB_OBJ_FROZEN(obj)) {
             rb_shape_t * next_shape = rb_shape_transition_shape_frozen(clone);
             if (!rb_shape_obj_too_complex(clone) && next_shape->type == SHAPE_OBJ_TOO_COMPLEX) {
-                rb_evict_ivars_to_hash(clone, rb_shape_get_shape(clone));
+                rb_evict_ivars_to_hash(clone);
             }
             else {
                 rb_shape_set_shape(clone, next_shape);
@@ -498,7 +498,7 @@ mutable_obj_clone(VALUE obj, VALUE kwfreeze)
         // If we're out of shapes, but we want to freeze, then we need to
         // evacuate this clone to a hash
         if (!rb_shape_obj_too_complex(clone) && next_shape->type == SHAPE_OBJ_TOO_COMPLEX) {
-            rb_evict_ivars_to_hash(clone, rb_shape_get_shape(clone));
+            rb_evict_ivars_to_hash(clone);
         }
         else {
             rb_shape_set_shape(clone, next_shape);


### PR DESCRIPTION
It's only used to allocate the table with the right size, but in some case we were passing `rb_shape_get_shape_by_id(SHAPE_OBJ_TOO_COMPLEX)` which `next_iv_index` is a bit undefined.

So overall we're better to just allocate a table the size of the existing object, it should be close enough in the vast majority of cases, and that's already a de-optimizaton path anyway.

@XrXr, @peterzhu2118, @tenderlove, @jemmaissroff 