### PR TITLE
Refactor `rb_obj_evacuate_ivs_to_hash_table`

### DIFF
--- a/internal/variable.h
+++ b/internal/variable.h
@@ -47,7 +47,8 @@ VALUE rb_mod_set_temporary_name(VALUE, VALUE);
 
 struct gen_ivtbl;
 int rb_gen_ivtbl_get(VALUE obj, ID id, struct gen_ivtbl **ivtbl);
-int rb_obj_evacuate_ivs_to_hash_table(ID key, VALUE val, st_data_t arg);
+void rb_obj_copy_ivs_to_hash_table(VALUE obj, st_table *table);
+void rb_obj_convert_to_too_complex(VALUE obj, st_table *table);
 void rb_evict_ivars_to_hash(VALUE obj);
 
 RUBY_SYMBOL_EXPORT_BEGIN

--- a/shape.c
+++ b/shape.c
@@ -915,13 +915,6 @@ rb_shape_obj_too_complex(VALUE obj)
     return rb_shape_get_shape_id(obj) == OBJ_TOO_COMPLEX_SHAPE_ID;
 }
 
-void
-rb_shape_set_too_complex(VALUE obj)
-{
-    RUBY_ASSERT(!rb_shape_obj_too_complex(obj));
-    rb_shape_set_shape_id(obj, OBJ_TOO_COMPLEX_SHAPE_ID);
-}
-
 size_t
 rb_shape_edges_count(rb_shape_t *shape)
 {

--- a/shape.h
+++ b/shape.h
@@ -226,7 +226,6 @@ rb_shape_t *rb_shape_traverse_from_new_root(rb_shape_t *initial_shape, rb_shape_
 bool rb_shape_set_shape_id(VALUE obj, shape_id_t shape_id);
 
 VALUE rb_obj_debug_shape(VALUE self, VALUE obj);
-void rb_shape_set_too_complex(VALUE obj);
 
 // For ext/objspace
 RUBY_SYMBOL_EXPORT_BEGIN


### PR DESCRIPTION
That function is a bit too low level to called from multiple places. It's always used in tandem with `rb_shape_set_too_complex` and both have to know how the object is laid out to update the `iv_ptr`.

So instead we can provide two higher level function:

  - `rb_obj_copy_ivs_to_hash_table` to prepare a `st_table` from an arbitrary oject.
  - `rb_obj_convert_to_too_complex` to assign the new `st_table` to the old object, and safely free the old `iv_ptr`.

Unfortunately both can't be combined into one, because `rb_obj_copy_ivar` need `rb_obj_copy_ivs_to_hash_table` to copy from one object to another.