### PR TITLE
Windows - mingw.yml - remove encoding, run tests in cmd shell

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -125,6 +125,7 @@ jobs:
       - name: test
         timeout-minutes: 30
         run: make test
+        shell: cmd
         env:
           GNUMAKEFLAGS: ''
           RUBY_TESTOPTS: '-v --tty=no'
@@ -132,9 +133,8 @@ jobs:
 
       - name: test-all
         timeout-minutes: 45
+        shell: cmd
         run: |
-          # Actions uses UTF8, causes test failures, similar to normal OS setup
-          chcp.com 437
           make ${{ StartsWith(matrix.test_task, 'test/') && matrix.test_task || 'test-all' }}
         env:
           RUBY_TESTOPTS: >-
@@ -147,6 +147,7 @@ jobs:
         timeout-minutes: 10
         run: |
           make ${{ StartsWith(matrix.test_task, 'spec/') && matrix.test_task || 'test-spec' }}
+        shell: cmd
         if: ${{ matrix.test_task == 'check' || matrix.test_task == 'test-spec' || StartsWith(matrix.test_task, 'spec/') }}
 
       - uses: ./src/.github/actions/slack


### PR DESCRIPTION
1. ruby-loco (third party software) has always run tests in a Windows shell.
2. ruby-loco (third party software) removed any encoding changes in CI several months ago.

Two recent commits failed in CI, see:

https://github.com/ruby/ruby/actions/runs/6894631520/job/18756875955
https://github.com/ruby/ruby/actions/runs/6894437553/job/18756254878

Both were the mingw workflow, related to recent changes and related testing of encoding in Prism.

All Windows workflows passed in my fork.

ping @kddnewton
