### PR TITLE
size_pool_idx_for_size: Include debugging info in error message

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2769,7 +2769,7 @@ size_pool_idx_for_size(size_t size)
     size_t size_pool_idx = 64 - nlz_int64(slot_count - 1);
 
     if (size_pool_idx >= SIZE_POOL_COUNT) {
-        rb_bug("size_pool_idx_for_size: allocation size too large");
+        rb_bug("size_pool_idx_for_size: allocation size too large (size=%lu, size_pool_idx=%lu)", size, size_pool_idx);
     }
 
 #if RGENGC_CHECK_MODE


### PR DESCRIPTION
We ran into that case on our CI, including some sizes would help debug it much easier.