### PR TITLE
File.directory? doc was overriding File::Stat#directory? doc

### DIFF
--- a/file.c
+++ b/file.c
@@ -1593,8 +1593,6 @@ rb_access(VALUE fname, int mode)
  */
 
 /*
- * Document-method: directory?
- *
  * call-seq:
  *   File.directory?(path) -> true or false
  *


### PR DESCRIPTION
`File::Stat#directory?` now gets its own documentation that was already in the code, just hidden previously because it picked up the File.directory? documentation comment instead.

before: 

https://ruby-doc.com/3.2.2/File/Stat.html#method-i-directory-3F

<img width="489" src="https://github.com/ruby/ruby/assets/295007/69810029-40b4-451b-80e4-b4743c2dd7e1">

after:

<img width="504" src="https://github.com/ruby/ruby/assets/295007/aca539de-3485-4f9b-8af2-c1a06dfcc300">

