### PR TITLE
Fix ordering for auto compaction in get_overloaded_cme()

### DIFF
--- a/vm_method.c
+++ b/vm_method.c
@@ -1033,14 +1033,14 @@ get_overloaded_cme(const rb_callable_method_entry_t *cme)
     else {
         // create
         rb_method_definition_t *def = rb_method_definition_create(VM_METHOD_TYPE_ISEQ, cme->def->original_id);
-        def->body.iseq.cref = cme->def->body.iseq.cref;
-        def->body.iseq.iseqptr = ISEQ_BODY(cme->def->body.iseq.iseqptr)->mandatory_only_iseq;
-
         rb_method_entry_t *me = rb_method_entry_alloc(cme->called_id,
                                                       cme->owner,
                                                       cme->defined_class,
                                                       def,
                                                       false);
+
+        RB_OBJ_WRITE(me, &def->body.iseq.cref, cme->def->body.iseq.cref);
+        RB_OBJ_WRITE(me, &def->body.iseq.iseqptr, ISEQ_BODY(cme->def->body.iseq.iseqptr)->mandatory_only_iseq);
 
         ASSERT_vm_locking();
         st_insert(overloaded_cme_table(), (st_data_t)cme, (st_data_t)me);


### PR DESCRIPTION
Found through GC.stress + GC.auto_compact crashes in GH-8932. Previously, the compaction run within `rb_method_entry_alloc()` could move the `def->body.iseq.cref` and `iseqptr` set up before the call and leave the `def` pointing to moved addresses. Nothing was marking `def` during that GC run.
