### PR TITLE
[wasm] Enable more ext libraries on CI as much as possible

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -107,7 +107,7 @@ jobs:
           ../src/configure \
             --host wasm32-unknown-wasi \
             --with-static-linked-ext \
-            --with-ext=bigdecimal,ripper,monitor,stringio,pathname \
+            --with-ext=bigdecimal,cgi/escape,continuation,coverage,date,dbm,digest/bubblebabble,digest,digest/md5,digest/rmd160,digest/sha1,digest/sha2,etc,fcntl,fiber,gdbm,json,json/generator,json/parser,nkf,objspace,pathname,racc/cparse,rbconfig/sizeof,ripper,stringio,strscan,monitor \
             LDFLAGS=" \
               -Xlinker --stack-first \
               -Xlinker -z -Xlinker stack-size=16777216 \


### PR DESCRIPTION
Enable building exts that are already enabled in ruby.wasm CI excluding psych, zlib, and openssl since they require external build orchestration 