### PR TITLE
Use Variable Width Allocation on procs

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2500,7 +2500,7 @@ rb_fiber_start(rb_fiber_t *fiber)
         rb_context_t *cont = &VAR_FROM_MEMORY(fiber)->cont;
         int argc;
         const VALUE *argv, args = cont->value;
-        GetProcPtr(fiber->first_proc, proc);
+        proc = rb_proc_ptr(fiber->first_proc);
         argv = (argc = cont->argc) > 1 ? RARRAY_CONST_PTR(args) : &args;
         cont->value = Qnil;
         th->ec->errinfo = Qnil;
@@ -3308,7 +3308,7 @@ fiber_to_s(VALUE fiber_value)
         rb_str_cat_cstr(str, status_info);
         return str;
     }
-    GetProcPtr(fiber->first_proc, proc);
+    proc = rb_proc_ptr(fiber->first_proc);
     return rb_block_to_s(fiber_value, &proc->block, status_info);
 }
 

--- a/proc.c
+++ b/proc.c
@@ -130,7 +130,7 @@ static const rb_data_type_t proc_data_type = {
         proc_memsize,
         proc_mark_and_move,
     },
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE
 };
 
 VALUE

--- a/rjit_c.c
+++ b/rjit_c.c
@@ -160,8 +160,7 @@ mprotect_exec(rb_execution_context_t *ec, VALUE self, VALUE rb_mem_block, VALUE 
 static VALUE
 rjit_optimized_call(VALUE *recv, rb_execution_context_t *ec, int argc, VALUE *argv, int kw_splat, VALUE block_handler)
 {
-    rb_proc_t *proc;
-    GetProcPtr(recv, proc);
+    rb_proc_t *proc = rb_proc_ptr(*recv);
     return rb_vm_invoke_proc(ec, proc, argc, argv, kw_splat, block_handler);
 }
 
@@ -230,11 +229,9 @@ rjit_full_cfunc_return(rb_execution_context_t *ec, VALUE return_value)
 }
 
 static rb_proc_t *
-rjit_get_proc_ptr(VALUE procv)
+rjit_get_proc_ptr(VALUE procval)
 {
-    rb_proc_t *proc;
-    GetProcPtr(procv, proc);
-    return proc;
+    return rb_proc_ptr(procval);
 }
 
 // Use the same buffer size as Stackprof.

--- a/signal.c
+++ b/signal.c
@@ -1209,8 +1209,7 @@ trap_handler(VALUE *cmd, int sig)
             }
         }
         else {
-            rb_proc_t *proc;
-            GetProcPtr(*cmd, proc);
+            rb_proc_t *proc = rb_proc_ptr(*cmd);
             (void)proc;
         }
     }

--- a/thread.c
+++ b/thread.c
@@ -550,8 +550,7 @@ thread_do_start_proc(rb_thread_t *th)
     const VALUE *args_ptr;
     int args_len;
     VALUE procval = th->invoke_arg.proc.proc;
-    rb_proc_t *proc;
-    GetProcPtr(procval, proc);
+    rb_proc_t *proc = rb_proc_ptr(procval);
 
     th->ec->errinfo = Qnil;
     th->ec->root_lep = rb_vm_proc_local_ep(procval);

--- a/vm.c
+++ b/vm.c
@@ -1146,9 +1146,7 @@ VALUE
 rb_proc_dup(VALUE self)
 {
     VALUE procval;
-    rb_proc_t *src;
-
-    GetProcPtr(self, src);
+    rb_proc_t *src = rb_proc_ptr(self);
     procval = proc_create(rb_obj_class(self), &src->block, src->is_from_method, src->is_lambda);
     if (RB_OBJ_SHAREABLE_P(self)) FL_SET_RAW(procval, RUBY_FL_SHAREABLE);
     RB_GC_GUARD(self); /* for: body = rb_proc_dup(body) */

--- a/vm.c
+++ b/vm.c
@@ -1091,7 +1091,7 @@ vm_proc_create_from_captured(VALUE klass,
                              int8_t is_from_method, int8_t is_lambda)
 {
     VALUE procval = rb_proc_alloc(klass);
-    rb_proc_t *proc = RTYPEDDATA_DATA(procval);
+    rb_proc_t *proc = RTYPEDDATA_GET_DATA(procval);
 
     VM_ASSERT(VM_EP_IN_HEAP_P(GET_EC(), captured->ep));
 
@@ -1131,7 +1131,7 @@ static VALUE
 proc_create(VALUE klass, const struct rb_block *block, int8_t is_from_method, int8_t is_lambda)
 {
     VALUE procval = rb_proc_alloc(klass);
-    rb_proc_t *proc = RTYPEDDATA_DATA(procval);
+    rb_proc_t *proc = RTYPEDDATA_GET_DATA(procval);
 
     VM_ASSERT(VM_EP_IN_HEAP_P(GET_EC(), vm_block_ep(block)));
     rb_vm_block_copy(procval, &proc->block, block);
@@ -1304,7 +1304,7 @@ rb_proc_isolate_bang(VALUE self)
     const rb_iseq_t *iseq = vm_proc_iseq(self);
 
     if (iseq) {
-        rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_DATA(self);
+        rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_GET_DATA(self);
         if (proc->block.type != block_type_iseq) rb_raise(rb_eRuntimeError, "not supported yet");
 
         if (ISEQ_BODY(iseq)->outer_variables) {
@@ -1333,7 +1333,7 @@ rb_proc_ractor_make_shareable(VALUE self)
     const rb_iseq_t *iseq = vm_proc_iseq(self);
 
     if (iseq) {
-        rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_DATA(self);
+        rb_proc_t *proc = (rb_proc_t *)RTYPEDDATA_GET_DATA(self);
         if (proc->block.type != block_type_iseq) rb_raise(rb_eRuntimeError, "not supported yet");
 
         if (!rb_ractor_shareable_p(vm_block_self(&proc->block))) {

--- a/vm_core.h
+++ b/vm_core.h
@@ -1218,7 +1218,7 @@ RUBY_EXTERN VALUE rb_block_param_proxy;
 RUBY_SYMBOL_EXPORT_END
 
 #define GetProcPtr(obj, ptr) \
-  GetCoreDataFromValue((obj), rb_proc_t, (ptr))
+  ptr = (rb_proc_t*) RTYPEDDATA_GET_DATA((obj))
 
 typedef struct {
     const struct rb_block block;
@@ -1676,7 +1676,7 @@ static inline const struct rb_block *
 vm_proc_block(VALUE procval)
 {
     VM_ASSERT(rb_obj_is_proc(procval));
-    return &((rb_proc_t *)RTYPEDDATA_DATA(procval))->block;
+    return &((rb_proc_t *)RTYPEDDATA_GET_DATA(procval))->block;
 }
 
 static inline const rb_iseq_t *vm_block_iseq(const struct rb_block *block);

--- a/vm_core.h
+++ b/vm_core.h
@@ -1217,15 +1217,18 @@ RUBY_EXTERN VALUE rb_mRubyVMFrozenCore;
 RUBY_EXTERN VALUE rb_block_param_proxy;
 RUBY_SYMBOL_EXPORT_END
 
-#define GetProcPtr(obj, ptr) \
-  ptr = (rb_proc_t*) RTYPEDDATA_GET_DATA((obj))
-
 typedef struct {
     const struct rb_block block;
     unsigned int is_from_method: 1;	/* bool */
     unsigned int is_lambda: 1;		/* bool */
     unsigned int is_isolated: 1;        /* bool */
 } rb_proc_t;
+
+static inline rb_proc_t*
+rb_proc_ptr(VALUE obj)
+{
+    return RTYPEDDATA_GET_DATA(obj);
+}
 
 RUBY_SYMBOL_EXPORT_BEGIN
 VALUE rb_proc_isolate(VALUE self);

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -292,8 +292,7 @@ vm_call0_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const
             goto success;
           case OPTIMIZED_METHOD_TYPE_CALL:
             {
-                rb_proc_t *proc;
-                GetProcPtr(calling->recv, proc);
+                rb_proc_t *proc = rb_proc_ptr(calling->recv);
                 ret = rb_vm_invoke_proc(ec, proc, calling->argc, argv, calling->kw_splat, calling->block_handler);
                 goto success;
             }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3689,8 +3689,6 @@ vm_call_attrset(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_c
 static inline VALUE
 vm_call_bmethod_body(rb_execution_context_t *ec, struct rb_calling_info *calling, const VALUE *argv)
 {
-    rb_proc_t *proc;
-    VALUE val;
     const struct rb_callcache *cc = calling->cc;
     const rb_callable_method_entry_t *cme = vm_cc_cme(cc);
     VALUE procv = cme->def->body.bmethod.proc;
@@ -3701,8 +3699,8 @@ vm_call_bmethod_body(rb_execution_context_t *ec, struct rb_calling_info *calling
     }
 
     /* control block frame */
-    GetProcPtr(procv, proc);
-    val = rb_vm_invoke_bmethod(ec, proc, calling->recv, CALLING_ARGC(calling), argv, calling->kw_splat, calling->block_handler, vm_cc_cme(cc));
+    rb_proc_t *proc = rb_proc_ptr(procv);
+    VALUE val = rb_vm_invoke_bmethod(ec, proc, calling->recv, CALLING_ARGC(calling), argv, calling->kw_splat, calling->block_handler, vm_cc_cme(cc));
 
     return val;
 }
@@ -3724,8 +3722,7 @@ vm_call_iseq_bmethod(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct
         rb_raise(rb_eRuntimeError, "defined with an un-shareable Proc in a different Ractor");
     }
 
-    rb_proc_t *proc;
-    GetProcPtr(procv, proc);
+    rb_proc_t *proc = rb_proc_ptr(procv);
     const struct rb_block *block = &proc->block;
 
     while (vm_block_type(block) == block_type_proc) {
@@ -3791,8 +3788,8 @@ vm_call_bmethod(rb_execution_context_t *ec, rb_control_frame_t *cfp, struct rb_c
     const struct rb_callcache *cc = calling->cc;
     const rb_callable_method_entry_t *cme = vm_cc_cme(cc);
     VALUE procv = cme->def->body.bmethod.proc;
-    rb_proc_t *proc;
-    GetProcPtr(procv, proc);
+    rb_proc_t *proc = rb_proc_ptr(procv);
+
     const struct rb_block *block = &proc->block;
 
     while (vm_block_type(block) == block_type_proc) {
@@ -4736,11 +4733,8 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
 static inline int
 block_proc_is_lambda(const VALUE procval)
 {
-    rb_proc_t *proc;
-
     if (procval) {
-        GetProcPtr(procval, proc);
-        return proc->is_lambda;
+        return rb_proc_ptr(procval)->is_lambda;
     }
     else {
         return 0;

--- a/yjit.c
+++ b/yjit.c
@@ -467,9 +467,7 @@ rb_RSTRING_PTR(VALUE str)
 rb_proc_t *
 rb_yjit_get_proc_ptr(VALUE procv)
 {
-    rb_proc_t *proc;
-    GetProcPtr(procv, proc);
-    return proc;
+    return rb_proc_ptr(procv);
 }
 
 // This is defined only as a named struct inside rb_iseq_constant_body.
@@ -722,8 +720,7 @@ rb_get_iseq_body_param_opt_table(const rb_iseq_t *iseq)
 VALUE
 rb_optimized_call(VALUE *recv, rb_execution_context_t *ec, int argc, VALUE *argv, int kw_splat, VALUE block_handler)
 {
-    rb_proc_t *proc;
-    GetProcPtr(recv, proc);
+    rb_proc_t *proc = rb_proc_ptr(*recv);
     return rb_vm_invoke_proc(ec, proc, argc, argv, kw_splat, block_handler);
 }
 


### PR DESCRIPTION
Continuation of https://github.com/ruby/ruby/pull/8910

Trying to see if I can figure out the CI crashes.

```
compare-ruby: ruby 3.3.0dev (2023-11-20T02:02:55Z master 701b0650de) [arm64-darwin22]
last_commit=[ruby/prism] feat: add encoding for IBM865 (https://github.com/ruby/prism/pull/1884)
built-ruby: ruby 3.3.0dev (2023-11-20T17:47:00Z vwa-proc 3b295e4643) [arm64-darwin22]
warming up.
# Iteration per second (i/s)

|            |compare-ruby|built-ruby|
|:-----------|-----------:|---------:|
|proc_alloc  |      7.791M|   10.633M|
|            |           -|     1.36x|
```