### PR TITLE
[PRISM] Fix LocalVariableWriteNodes within blocks

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2883,8 +2883,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         pm_local_variable_target_node_t *local_write_node = (pm_local_variable_target_node_t *) node;
 
         pm_constant_id_t constant_id = local_write_node->name;
-        for (size_t index = 0; index < local_write_node->depth; index++) scope_node = scope_node->previous;
-        int index = pm_lookup_local_index(iseq, scope_node, constant_id);
+        int index = pm_lookup_local_index_any_scope(iseq, scope_node, constant_id);
 
         ADD_SETLOCAL(ret, &dummy_line_node, index, local_write_node->depth);
         return;

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -268,6 +268,28 @@ module Prism
 
     def test_LocalVariableWriteNode
       assert_prism_eval("pit = 1")
+      assert_prism_eval(<<-CODE)
+        a = 0
+        [].each do
+          a = 1
+        end
+        a
+      CODE
+
+      assert_prism_eval(<<-CODE)
+        a = 1
+        d = 1
+        [1].each do
+          b = 2
+          a = 2
+          [2].each do
+            c = 3
+            d = 4
+            a = 2
+          end
+        end
+        [a, d]
+      CODE
     end
 
     def test_MatchWriteNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -350,6 +350,14 @@ module Prism
 
     def test_LocalVariableTargetNode
       assert_prism_eval("pit, pit1 = 1")
+      assert_prism_eval(<<-CODE)
+        a = 1
+        [1].each do
+          c = 2
+          a, b = 2
+        end
+        a
+      CODE
     end
 
     def test_MultiTargetNode


### PR DESCRIPTION
Prior to this commit, we weren't recursing up scopes to look for the local definition. With this commit, we do so, fixing local writes within blocks

Closes https://github.com/ruby/prism/issues/1890