### PR TITLE
YJIT: make --yjit-max-versions=N option undocumented

### DIFF
--- a/doc/yjit/yjit.md
+++ b/doc/yjit/yjit.md
@@ -172,7 +172,6 @@ compiled, lower values mean less code is compiled (default 200000)
 - `--yjit-stats`: print statistics after the execution of a program (incurs a run-time cost)
 - `--yjit-stats=quiet`: gather statistics while running a program but don't print them. Stats are accessible through `RubyVM::YJIT.runtime_stats`. (incurs a run-time cost)
 - `--yjit-trace-exits`: produce a Marshal dump of backtraces from specific exits. Automatically enables `--yjit-stats`
-- `--yjit-max-versions=N`: maximum number of versions to generate per basic block (default 4)
 - `--yjit-perf`: Enable frame pointers and profiling with the `perf` tool
 
 Note that there is also an environment variable `RUBY_YJIT_ENABLE` which can be used to enable YJIT.

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -100,7 +100,7 @@ pub static mut OPTIONS: Options = Options {
 };
 
 /// YJIT option descriptions for `ruby --help`.
-static YJIT_OPTIONS: [(&str, &str); 9] = [
+static YJIT_OPTIONS: [(&str, &str); 8] = [
     ("--yjit-stats",                    "Enable collecting YJIT statistics"),
     ("--yjit-trace-exits",              "Record Ruby source location when exiting from generated code"),
     ("--yjit-trace-exits-sample-rate",  "Trace exit locations only every Nth occurrence"),
@@ -108,7 +108,6 @@ static YJIT_OPTIONS: [(&str, &str); 9] = [
     ("--yjit-code-gc",                  "Run code GC when the code size reaches the limit"),
     ("--yjit-call-threshold=num",       "Number of calls to trigger JIT"),
     ("--yjit-cold-threshold=num",       "Global call after which ISEQs not compiled (default: 200K)"),
-    ("--yjit-max-versions=num",         "Maximum number of versions per basic block (default: 4)"),
     ("--yjit-perf",                     "Enable frame pointers and perf profiling"),
 ];
 


### PR DESCRIPTION
Not useful for the vast majority of end users to change this option.