### PR TITLE
YJIT: Print a disasm path to stderr

### DIFF
--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -232,7 +232,7 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
             directory => {
                 let pid = std::process::id();
                 let path = format!("{directory}/yjit_{pid}.log");
-                println!("YJIT disasm dump: {path}");
+                eprintln!("YJIT disasm dump: {path}");
                 unsafe { OPTIONS.dump_disasm = Some(DumpDisasm::File(path)) }
             }
          },


### PR DESCRIPTION
At Shopify, we have tests that fail when Ruby outputs something in stdout. Because we want to debug YJIT with disasm enabled on CI, it seems useful to print this message to stderr instead, which indeed doesn't fail the CI.