### PR TITLE
YJIT: Skip dump-disasm if it fails to create a file

### DIFF
--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -1,4 +1,4 @@
-use std::{ffi::{CStr, CString}, ptr::null};
+use std::{ffi::{CStr, CString}, ptr::null, fs::File};
 use crate::backend::current::TEMP_REGS;
 use std::os::raw::{c_char, c_int, c_uint};
 
@@ -230,10 +230,14 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         ("dump-disasm", _) => match opt_val {
             "" => unsafe { OPTIONS.dump_disasm = Some(DumpDisasm::Stdout) },
             directory => {
-                let pid = std::process::id();
-                let path = format!("{directory}/yjit_{pid}.log");
-                println!("YJIT disasm dump: {path}");
-                unsafe { OPTIONS.dump_disasm = Some(DumpDisasm::File(path)) }
+                let path = format!("{directory}/yjit_{}.log", std::process::id());
+                match File::options().create(true).append(true).open(&path) {
+                    Ok(_) => {
+                        eprintln!("YJIT disasm dump: {path}");
+                        unsafe { OPTIONS.dump_disasm = Some(DumpDisasm::File(path)) }
+                    }
+                    Err(err) => eprintln!("Failed to create {path}: {err}"),
+                }
             }
          },
 


### PR DESCRIPTION
We sometimes set `--yjit-dump-disasm=/buildkite-artifacts` in a bash script that is globally shared to configure YJIT so that disasm shows up as Artifacts on Buildkite. However, because this directory is specific to some CI workflows and the directory doesn't necessarily exist, it could crash on such workflows.

Panicking the Ruby because it failed to disasm YJIT code seems extreme, so this PR fixes it to only warn that it failed to create a file. It would help us easily add such options on CI without complicating the logic to skip it for some workflows.