### PR TITLE
Get rid of useless dsize functions

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -11146,15 +11146,13 @@ pinned_list_mark(void *ptr)
     }
 }
 
-static size_t
-pinned_list_memsize(const void *ptr)
-{
-    return 0;
-}
-
 static const rb_data_type_t pinned_list_type = {
     "pinned_list",
-    {pinned_list_mark, RUBY_DEFAULT_FREE, pinned_list_memsize,},
+    {
+        pinned_list_mark,
+        RUBY_DEFAULT_FREE,
+        NULL, // No external memory to report,
+    },
     0, 0, RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_EMBEDDABLE
 };
 

--- a/proc.c
+++ b/proc.c
@@ -1597,18 +1597,12 @@ bm_mark_and_move(void *ptr)
     rb_gc_mark_and_move_ptr((rb_method_entry_t **)&data->me);
 }
 
-static size_t
-bm_memsize(const void *ptr)
-{
-    return 0;
-}
-
 static const rb_data_type_t method_data_type = {
     "method",
     {
         bm_mark_and_move,
         RUBY_TYPED_DEFAULT_FREE,
-        bm_memsize,
+        NULL, // No external memory to report,
         bm_mark_and_move,
     },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE

--- a/time.c
+++ b/time.c
@@ -1841,15 +1841,13 @@ time_mark(void *ptr)
     rb_gc_mark(tobj->vtm.zone);
 }
 
-static size_t
-time_memsize(const void *tobj)
-{
-    return 0;
-}
-
 static const rb_data_type_t time_data_type = {
     "time",
-    {time_mark, RUBY_TYPED_DEFAULT_FREE, time_memsize,},
+    {
+        time_mark,
+        RUBY_TYPED_DEFAULT_FREE,
+        NULL, // No external memory to report,
+    },
     0, 0,
     (RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_FROZEN_SHAREABLE | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE),
 };

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -159,15 +159,13 @@ location_mark_entry(rb_backtrace_location_t *fi)
     }
 }
 
-static size_t
-location_memsize(const void *ptr)
-{
-    return 0;
-}
-
 static const rb_data_type_t location_data_type = {
     "frame_info",
-    {location_mark, RUBY_TYPED_DEFAULT_FREE, location_memsize,},
+    {
+        location_mark,
+        RUBY_TYPED_DEFAULT_FREE,
+        NULL, // No external memory to report,
+    },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE
 };
 
@@ -503,15 +501,14 @@ backtrace_update(void *ptr)
     bt->locary = rb_gc_location(bt->locary);
 }
 
-static size_t
-backtrace_memsize(const void *ptr)
-{
-    return 0;
-}
-
 static const rb_data_type_t backtrace_data_type = {
     "backtrace",
-    {backtrace_mark, RUBY_DEFAULT_FREE, backtrace_memsize, backtrace_update},
+    {
+        backtrace_mark,
+        RUBY_DEFAULT_FREE,
+        NULL, // No external memory to report,
+        backtrace_update,
+    },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE
 };
 


### PR DESCRIPTION
If we always return 0, we might as well not define the function at all.

@peterzhu2118 