### PR TITLE
Replace guard object with ensure for Dir.pwd

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -1341,27 +1341,29 @@ dir_chdir(VALUE dir)
 }
 
 #ifndef _WIN32
+static VALUE
+create_path_try(VALUE args)
+{
+    char *path = (char *)args;
+#ifdef __APPLE__
+    return rb_str_normalize_ospath(path, strlen(path));
+#else
+    return rb_str_new2(path);
+#endif
+}
+
+static VALUE
+create_path_ensure(VALUE args)
+{
+    xfree((char *)args);
+    return Qnil;
+}
+
 VALUE
 rb_dir_getwd_ospath(void)
 {
-    char *path;
-    VALUE cwd;
-    VALUE path_guard;
-
-#undef RUBY_UNTYPED_DATA_WARNING
-#define RUBY_UNTYPED_DATA_WARNING 0
-    path_guard = Data_Wrap_Struct((VALUE)0, NULL, RUBY_DEFAULT_FREE, NULL);
-    path = ruby_getcwd();
-    DATA_PTR(path_guard) = path;
-#ifdef __APPLE__
-    cwd = rb_str_normalize_ospath(path, strlen(path));
-#else
-    cwd = rb_str_new2(path);
-#endif
-    DATA_PTR(path_guard) = 0;
-
-    xfree(path);
-    return cwd;
+    char *path = ruby_getcwd();
+    return rb_ensure(create_path_try, (VALUE)path, create_path_ensure, (VALUE)path);
 }
 #endif
 


### PR DESCRIPTION
We can avoid an allocation by using an ensure block rather than using a temporary object to free the memory when an exception is raised.