### PR TITLE
[PRISM] Rename flag to CONTAINS_KEYWORD_SPLAT

### DIFF
--- a/prism/config.yml
+++ b/prism/config.yml
@@ -331,7 +331,7 @@ tokens:
 flags:
   - name: ArgumentsNodeFlags
     values:
-      - name: KEYWORD_SPLAT
+      - name: CONTAINS_KEYWORD_SPLAT
         comment: "if arguments contain keyword splat"
     comment: Flags for arguments nodes.
   - name: CallNodeFlags

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -11144,7 +11144,7 @@ parse_arguments(pm_parser_t *parser, pm_arguments_t *arguments, bool accepts_for
                 parsed_bare_hash = true;
                 parse_arguments_append(parser, arguments, argument);
                 if (contains_keyword_splat) {
-                    arguments->arguments->base.flags |= PM_ARGUMENTS_NODE_FLAGS_KEYWORD_SPLAT;
+                    arguments->arguments->base.flags |= PM_ARGUMENTS_NODE_FLAGS_CONTAINS_KEYWORD_SPLAT;
                 }
                 break;
             }
@@ -11258,7 +11258,7 @@ parse_arguments(pm_parser_t *parser, pm_arguments_t *arguments, bool accepts_for
 
                 parse_arguments_append(parser, arguments, argument);
                 if (contains_keyword_splat) {
-                    arguments->arguments->base.flags |= PM_ARGUMENTS_NODE_FLAGS_KEYWORD_SPLAT;
+                    arguments->arguments->base.flags |= PM_ARGUMENTS_NODE_FLAGS_CONTAINS_KEYWORD_SPLAT;
                 }
                 break;
             }

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1324,7 +1324,7 @@ pm_setup_args(pm_arguments_node_t *arguments_node, int *flags, struct rb_callinf
     else {
         pm_node_list_t arguments_node_list = arguments_node->arguments;
 
-        bool has_keyword_splat = (arguments_node->base.flags & PM_ARGUMENTS_NODE_FLAGS_KEYWORD_SPLAT);
+        bool has_keyword_splat = (arguments_node->base.flags & PM_ARGUMENTS_NODE_FLAGS_CONTAINS_KEYWORD_SPLAT);
         bool has_splat = false;
 
         // We count the number of elements post the splat node that are not keyword elements to

--- a/test/prism/snapshots/constants.txt
+++ b/test/prism/snapshots/constants.txt
@@ -128,7 +128,7 @@
         │   │   │               │   ├── flags: variable_call
         │   │   │               │   └── name: :bar
         │   │   │               └── operator_loc: (17,4)-(17,6) = "**"
-        │   │   └── flags: keyword_splat
+        │   │   └── flags: contains_keyword_splat
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -209,7 +209,7 @@
         │   │   │               │   ├── flags: variable_call
         │   │   │               │   └── name: :baz
         │   │   │               └── operator_loc: (23,9)-(23,11) = "**"
-        │   │   └── flags: keyword_splat
+        │   │   └── flags: contains_keyword_splat
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/method_calls.txt
+++ b/test/prism/snapshots/method_calls.txt
@@ -318,7 +318,7 @@
         │   │   │               │   ├── flags: variable_call
         │   │   │               │   └── name: :kwargs
         │   │   │               └── operator_loc: (27,2)-(27,4) = "**"
-        │   │   └── flags: keyword_splat
+        │   │   └── flags: contains_keyword_splat
         │   ├── closing_loc: (27,10)-(27,11) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1030,7 +1030,7 @@
         │   │   │               │   ├── closing_loc: ∅
         │   │   │               │   └── unescaped: "dog"
         │   │   │               └── operator_loc: ∅
-        │   │   └── flags: keyword_splat
+        │   │   └── flags: contains_keyword_splat
         │   ├── closing_loc: ∅
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -1080,7 +1080,7 @@
         │   │   │               │   ├── closing_loc: ∅
         │   │   │               │   └── unescaped: "dog"
         │   │   │               └── operator_loc: ∅
-        │   │   └── flags: keyword_splat
+        │   │   └── flags: contains_keyword_splat
         │   ├── closing_loc: (70,40)-(70,41) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/methods.txt
+++ b/test/prism/snapshots/methods.txt
@@ -1285,7 +1285,7 @@
         │   │           │   │               │   ├── flags: variable_call
         │   │           │   │               │   └── name: :qux
         │   │           │   │               └── operator_loc: (139,25)-(139,27) = "**"
-        │   │           │   └── flags: keyword_splat
+        │   │           │   └── flags: contains_keyword_splat
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
         │   │           ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_arg_assoc_kwsplat.txt
+++ b/test/prism/snapshots/seattlerb/call_arg_assoc_kwsplat.txt
@@ -31,7 +31,7 @@
             │   │               │   @ IntegerNode (location: (1,14)-(1,15))
             │   │               │   └── flags: decimal
             │   │               └── operator_loc: (1,12)-(1,14) = "**"
-            │   └── flags: keyword_splat
+            │   └── flags: contains_keyword_splat
             ├── closing_loc: (1,15)-(1,16) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_arg_kwsplat.txt
+++ b/test/prism/snapshots/seattlerb/call_arg_kwsplat.txt
@@ -28,7 +28,7 @@
             │   │               │   @ IntegerNode (location: (1,7)-(1,8))
             │   │               │   └── flags: decimal
             │   │               └── operator_loc: (1,5)-(1,7) = "**"
-            │   └── flags: keyword_splat
+            │   └── flags: contains_keyword_splat
             ├── closing_loc: (1,8)-(1,9) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/call_kwsplat.txt
+++ b/test/prism/snapshots/seattlerb/call_kwsplat.txt
@@ -18,7 +18,7 @@
             │   │               │   @ IntegerNode (location: (1,4)-(1,5))
             │   │               │   └── flags: decimal
             │   │               └── operator_loc: (1,2)-(1,4) = "**"
-            │   └── flags: keyword_splat
+            │   └── flags: contains_keyword_splat
             ├── closing_loc: (1,5)-(1,6) = ")"
             ├── block: ∅
             ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/defn_kwarg_env.txt
+++ b/test/prism/snapshots/seattlerb/defn_kwarg_env.txt
@@ -39,7 +39,7 @@
             │           │   │               │   ├── name: :testing
             │           │   │               │   └── depth: 0
             │           │   │               └── operator_loc: (1,31)-(1,33) = "**"
-            │           │   └── flags: keyword_splat
+            │           │   └── flags: contains_keyword_splat
             │           ├── closing_loc: (1,40)-(1,41) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/send.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/send.txt
@@ -1655,7 +1655,7 @@
         │   │   │               │   ├── flags: variable_call
         │   │   │               │   └── name: :a
         │   │   │               └── operator_loc: (72,6)-(72,8) = "**"
-        │   │   └── flags: keyword_splat
+        │   │   └── flags: contains_keyword_splat
         │   ├── closing_loc: (72,9)-(72,10) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅
@@ -2070,7 +2070,7 @@
         │   │   │               │   ├── flags: variable_call
         │   │   │               │   └── name: :foo
         │   │   │               └── operator_loc: (81,2)-(81,4) = "**"
-        │   │   └── flags: keyword_splat
+        │   │   └── flags: contains_keyword_splat
         │   ├── closing_loc: (81,7)-(81,8) = ")"
         │   ├── block: ∅
         │   ├── flags: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/since/32.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/since/32.txt
@@ -41,7 +41,7 @@
         │   │           │   │           └── @ AssocSplatNode (location: (2,16)-(2,18))
         │   │           │   │               ├── value: ∅
         │   │           │   │               └── operator_loc: (2,16)-(2,18) = "**"
-        │   │           │   └── flags: keyword_splat
+        │   │           │   └── flags: contains_keyword_splat
         │   │           ├── closing_loc: (2,18)-(2,19) = ")"
         │   │           ├── block: ∅
         │   │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/forwarded_argument_with_kwrestarg.txt
+++ b/test/prism/snapshots/whitequark/forwarded_argument_with_kwrestarg.txt
@@ -41,7 +41,7 @@
             │           │   │           └── @ AssocSplatNode (location: (1,37)-(1,39))
             │           │   │               ├── value: ∅
             │           │   │               └── operator_loc: (1,37)-(1,39) = "**"
-            │           │   └── flags: keyword_splat
+            │           │   └── flags: contains_keyword_splat
             │           ├── closing_loc: (1,39)-(1,40) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/forwarded_kwrestarg.txt
+++ b/test/prism/snapshots/whitequark/forwarded_kwrestarg.txt
@@ -36,7 +36,7 @@
             │           │   │           └── @ AssocSplatNode (location: (1,17)-(1,19))
             │           │   │               ├── value: ∅
             │           │   │               └── operator_loc: (1,17)-(1,19) = "**"
-            │           │   └── flags: keyword_splat
+            │           │   └── flags: contains_keyword_splat
             │           ├── closing_loc: (1,19)-(1,20) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/forwarded_kwrestarg_with_additional_kwarg.txt
+++ b/test/prism/snapshots/whitequark/forwarded_kwrestarg_with_additional_kwarg.txt
@@ -46,7 +46,7 @@
             │           │   │               ├── value:
             │           │   │               │   @ TrueNode (location: (1,31)-(1,35))
             │           │   │               └── operator_loc: ∅
-            │           │   └── flags: keyword_splat
+            │           │   └── flags: contains_keyword_splat
             │           ├── closing_loc: (1,35)-(1,36) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅

--- a/test/prism/snapshots/whitequark/kwoptarg_with_kwrestarg_and_forwarded_args.txt
+++ b/test/prism/snapshots/whitequark/kwoptarg_with_kwrestarg_and_forwarded_args.txt
@@ -41,7 +41,7 @@
             │           │   │           └── @ AssocSplatNode (location: (1,21)-(1,23))
             │           │   │               ├── value: ∅
             │           │   │               └── operator_loc: (1,21)-(1,23) = "**"
-            │           │   └── flags: keyword_splat
+            │           │   └── flags: contains_keyword_splat
             │           ├── closing_loc: (1,23)-(1,24) = ")"
             │           ├── block: ∅
             │           ├── flags: ∅


### PR DESCRIPTION
We need to do this change first on ruby/ruby before merging to ruby/prism to avoid breaking ruby/ruby CI