### PR TITLE
objspace_dump.c: dump call cache ids with dump_append_id

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -366,8 +366,9 @@ dump_append_string_content(struct dump_config *dc, VALUE obj)
 static inline void
 dump_append_id(struct dump_config *dc, ID id)
 {
-    if (is_instance_id(id)) {
-        dump_append_string_value(dc, rb_sym2str(ID2SYM(id)));
+    VALUE str = rb_sym2str(ID2SYM(id));
+    if (RTEST(str)) {
+        dump_append_string_value(dc, str);
     }
     else {
         dump_append(dc, "\"ID_INTERNAL(");
@@ -443,7 +444,7 @@ dump_object(VALUE obj, struct dump_config *dc)
             mid = vm_ci_mid((const struct rb_callinfo *)obj);
             if (mid != 0) {
                 dump_append(dc, ", \"mid\":");
-                dump_append_string_value(dc, rb_id2str(mid));
+                dump_append_id(dc, mid);
             }
             break;
 
@@ -451,7 +452,7 @@ dump_object(VALUE obj, struct dump_config *dc)
             mid = vm_cc_cme((const struct rb_callcache *)obj)->called_id;
             if (mid != 0) {
                 dump_append(dc, ", \"called_id\":");
-                dump_append_string_value(dc, rb_id2str(mid));
+                dump_append_id(dc, mid);
 
                 VALUE klass = ((const struct rb_callcache *)obj)->klass;
                 if (klass != 0) {

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -563,7 +563,7 @@ class TestObjSpace < Test::Unit::TestCase
   end
 
   def test_dump_callinfo_includes_mid
-    assert_in_out_err(%w[-robjspace], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+    assert_in_out_err(%w[-robjspace --disable-gems], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
       begin;
         class Foo
           def foo
@@ -579,7 +579,7 @@ class TestObjSpace < Test::Unit::TestCase
       end;
       assert_empty error
       assert(output.count > 1)
-      assert_equal 1, output.count { |l| l.include?('"mid":"baz"') }
+      assert_includes output.grep(/"imemo_type":"callinfo"/).join("\n"), '"mid":"baz"'
     end
   end
 


### PR DESCRIPTION
Not all `ID` have an associated string.

Fixes a SEGFAULT in ObjectSpace.dump_all spec.

Followup: https://github.com/ruby/ruby/pull/8913

cc @jhawthorn @mame 