### PR TITLE
windows-arm64 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2667,6 +2667,9 @@ AS_CASE([$coroutine_type], [yes|''], [
         [*86-mingw*], [
             coroutine_type=win32
         ],
+        [aarch64-mingw*], [
+            coroutine_type=arm64
+        ],
         [arm*-linux*], [
             coroutine_type=arm32
         ],

--- a/configure.ac
+++ b/configure.ac
@@ -512,6 +512,9 @@ AS_CASE(["$target_os"],
 ],
 [hiuxmpp*], [AC_DEFINE(__HIUX_MPP__)])    # by TOYODA Eizi <toyoda@npd.kishou.go.jp>
 
+USE_LLVM_WINDRES=no
+windres_version=`windres --version | grep LLVM`
+test -z "$windres_version" || USE_LLVM_WINDRES=yes
 
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
@@ -4245,6 +4248,7 @@ AC_SUBST(MINIOBJS)
 AC_SUBST(THREAD_MODEL)
 AC_SUBST(COROUTINE_TYPE, ${coroutine_type})
 AC_SUBST(PLATFORM_DIR)
+AC_SUBST(USE_LLVM_WINDRES)
 
 firstmf=`echo $FIRSTMAKEFILE | sed 's/:.*//'`
 firsttmpl=`echo $FIRSTMAKEFILE | sed 's/.*://'`

--- a/cygwin/GNUmakefile.in
+++ b/cygwin/GNUmakefile.in
@@ -3,9 +3,14 @@ gnumake = yes
 include Makefile
 
 DLLWRAP = @DLLWRAP@ --target=$(target_os) --driver-name="$(CC)"
-windres-cpp := $(CPP) -xc
-windres-cpp := --preprocessor=$(firstword $(windres-cpp)) \
-	$(addprefix --preprocessor-arg=,$(wordlist 2,$(words $(windres-cpp)),$(windres-cpp)))
+ifeq (@USE_LLVM_WINDRES@,yes) # USE_LLVM_WINDRES
+	# llvm-windres fails when preprocessor options are added
+	windres-cpp :=
+else
+	windres-cpp := $(CPP) -xc
+	windres-cpp := --preprocessor=$(firstword $(windres-cpp)) \
+		$(addprefix --preprocessor-arg=,$(wordlist 2,$(words $(windres-cpp)),$(windres-cpp)))
+endif
 WINDRES = @WINDRES@ $(windres-cpp) -DRC_INVOKED
 STRIP = @STRIP@
 

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -753,6 +753,14 @@ dump_thread(void *arg)
                     frame.AddrFrame.Offset = context.Rbp;
                     frame.AddrStack.Mode = AddrModeFlat;
                     frame.AddrStack.Offset = context.Rsp;
+#elif defined(__aarch64__)
+                    mac = IMAGE_FILE_MACHINE_ARM64;
+                    frame.AddrPC.Mode = AddrModeFlat;
+                    frame.AddrPC.Offset = context.Pc;
+                    frame.AddrFrame.Mode = AddrModeFlat;
+                    frame.AddrFrame.Offset = context.Fp;
+                    frame.AddrStack.Mode = AddrModeFlat;
+                    frame.AddrStack.Offset = context.Sp;
 #else	/* i386 */
                     mac = IMAGE_FILE_MACHINE_I386;
                     frame.AddrPC.Mode = AddrModeFlat;

--- a/win32/mkexports.rb
+++ b/win32/mkexports.rb
@@ -151,7 +151,7 @@ class Exports::Cygwin < Exports
   end
 
   def each_line(objs, &block)
-    IO.foreach("|#{self.class.nm} --extern --defined #{objs.join(' ')}", &block)
+    IO.foreach("|#{self.class.nm} --extern-only --defined-only #{objs.join(' ')}", &block)
   end
 
   def each_export(objs)

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -2615,8 +2615,72 @@ set_pioinfo_extra(void)
      * * https://bugs.ruby-lang.org/issues/18605
      */
     char *p = (char*)get_proc_address(UCRTBASE, "_isatty", NULL);
-    char *pend = p;
     /* _osfile(fh) & FDEV */
+
+#ifdef _M_ARM64
+#define IS_INSN(pc, name) ((*(pc) & name##_mask) == name##_id)
+    const int max_num_inst = 500;
+    uint32_t *start = (uint32_t*)p;
+    uint32_t *end_limit = (start + max_num_inst);
+    uint32_t *pc = start;
+
+    if (!p) {
+        fprintf(stderr, "_isatty proc not found in " UCRTBASE "\n");
+        _exit(1);
+    }
+
+    /* end of function */
+    const uint32_t ret_id = 0xd65f0000;
+    const uint32_t ret_mask = 0xfffffc1f;
+    for(; pc < end_limit; pc++) {
+        if (IS_INSN(pc, ret)) {
+            break;
+        }
+    }
+    if (pc == end_limit) {
+        fprintf(stderr, "end of _isatty not found in " UCRTBASE "\n");
+        _exit(1);
+    }
+
+    /* pioinfo instruction mark */
+    const uint32_t adrp_id = 0x90000000;
+    const uint32_t adrp_mask = 0x9f000000;
+    const uint32_t add_id = 0x11000000;
+    const uint32_t add_mask = 0x3fc00000;
+    for(; pc > start; pc--) {
+        if (IS_INSN(pc, adrp) && IS_INSN(pc + 1, add)) {
+            break;
+        }
+    }
+    if(pc == start) {
+        fprintf(stderr, "pioinfo mark not found in " UCRTBASE "\n");
+        _exit(1);
+    }
+
+    /* We now point to instructions that load address of __pioinfo:
+     * adrp	x8, 0x1801d8000
+     * add	x8, x8, #0xdb0
+     * https://devblogs.microsoft.com/oldnewthing/20220809-00/?p=106955
+     * The last adrp/add sequence before ret is what we are looking for.
+     */
+    const uint32_t adrp_insn = *pc;
+    const uint32_t adrp_immhi = (adrp_insn & 0x00ffffe0) >> 5;
+    const uint32_t adrp_immlo = (adrp_insn & 0x60000000) >> (5 + 19 + 5);
+    /* imm = immhi:immlo:Zeros(12), 64 */
+    const uint64_t adrp_imm = ((adrp_immhi << 2) | adrp_immlo) << 12;
+    /* base = PC64<63:12>:Zeros(12) */
+    const uint64_t adrp_base = (uint64_t)pc & 0xfffffffffffff000;
+
+    const uint32_t add_insn = *(pc + 1);
+    const uint32_t add_sh = (add_insn & 0x400000) >> (12 + 5 + 5);
+    /* case sh of
+      when '0' imm = ZeroExtend(imm12, datasize);
+      when '1' imm = ZeroExtend(imm12:Zeros(12), datasize); */
+    const uint64_t add_imm = ((add_insn & 0x3ffc00) >> (5 + 5)) << (add_sh ? 12 : 0);
+
+    __pioinfo = (ioinfo**)(adrp_base + adrp_imm + add_imm);
+#else /* _M_ARM64 */
+    char *pend = p;
 
 # ifdef _WIN64
     int32_t rel;
@@ -2667,7 +2731,8 @@ set_pioinfo_extra(void)
 #else
     __pioinfo = *(ioinfo***)(p);
 #endif
-#endif
+#endif /* _M_ARM64 */
+#endif /* RUBY_MSVCRT_VERSION */
     int fd;
 
     fd = _open("NUL", O_RDONLY);


### PR DESCRIPTION
This series allows to build and run Ruby natively on windows-arm64.

It contains fixes for build system (some of them taken from [MSYS2 Ruby package](https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-ruby)).
Most of the work is detection of `__pioinfo` pointer, which was the blocking step. Details are available in commit message. This was tested on windows-arm64 11 retail build (**not** insiders).

You can find a build log [here](https://gitlab.com/Linaro/windowsonarm/packages/ruby/-/jobs/5594478181), that uses this [script](https://gitlab.com/Linaro/windowsonarm/packages/ruby/-/blob/master/build_ruby.sh?ref_type=heads) from an MSYS2 clangarm64 shell. 

I'm not sure if Ruby community accepts a serie of patches, or if several PR are needed. Let me know.
Note: This is an effort part of my work at [Linaro](https://www.linaro.org/windows-on-arm/).