### PR TITLE
.travis.yml: Drop s390x temporarily.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,8 @@ matrix:
   include:
     - <<: *arm64-linux
     - <<: *ppc64le-linux
-    - <<: *s390x-linux
+    # The s390x builds are not starting.
+    # - <<: *s390x-linux
     # FIXME: lib/rubygems/util.rb:104 glob_files_in_dir -
     # <internal:dir>:411:in glob: File name too long - (Errno::ENAMETOOLONG)
     # https://github.com/rubygems/rubygems/issues/7132
@@ -113,7 +114,6 @@ matrix:
     # Allow failures for the unstable jobs.
     # - name: arm64-linux
     # - name: ppc64le-linux
-    # The s390x build is sometimes not starting.
     - name: s390x-linux
     # The 2nd arm64 pipeline may be unstable.
     # - name: arm32-linux


### PR DESCRIPTION
The builds are not starting.

You can check the Travis status on the ticket,
<https://bugs.ruby-lang.org/issues/20013>.