### PR TITLE
[wasm] Fix Asyncify loop exit condition for normal return

### DIFF
--- a/wasm/runtime.c
+++ b/wasm/runtime.c
@@ -19,6 +19,13 @@ int rb_wasm_rt_start(int (main)(int argc, char **argv), int argc, char **argv) {
       result = main(argc, argv);
     }
 
+    extern void *rb_asyncify_unwind_buf;
+    // Exit Asyncify loop if there is no unwound buffer, which
+    // means that main function has returned normally.
+    if (rb_asyncify_unwind_buf == NULL) {
+      break;
+    }
+
     // NOTE: it's important to call 'asyncify_stop_unwind' here instead in rb_wasm_handle_jmp_unwind
     // because unless that, Asyncify inserts another unwind check here and it unwinds to the root frame.
     asyncify_stop_unwind();


### PR DESCRIPTION
Stop calling `asyncify_stop_unwind` when the main function returns without any unwinding. In the era when Asyncify buffers were allocated on the stack, the `top` and `end` fields were remained in the stack space even after the main function returned, so buffer-overflow check in the `asyncify_stop_unwind` function passed. But now, the `top` and `end` fields are part of the jump buffer allocated on the heap and they are deallocated with `free` when the corresponding VM tag is popped. So, the buffer-overflow check in the `asyncify_stop_unwind` function failed when the main fuction returned without any unwinding, and we have to break the asyncify loop before calling `asyncify_stop_unwind`.

Related commit: https://github.com/ruby/ruby.wasm/commit/bc46b12b127e4b6625a100f373504ed5ea45ae66