### PR TITLE
Fix off-by-one with RubyVM::Shape.exhaust_shapes

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -1062,7 +1062,7 @@ rb_shape_exhaust(int argc, VALUE *argv, VALUE self)
 {
     rb_check_arity(argc, 0, 1);
     int offset = argc == 1 ? NUM2INT(argv[0]) : 0;
-    GET_SHAPE_TREE()->next_shape_id = MAX_SHAPE_ID - offset;
+    GET_SHAPE_TREE()->next_shape_id = MAX_SHAPE_ID - offset + 1;
     return Qnil;
 }
 


### PR DESCRIPTION
Previously, the method left one shape available (MAX_SHAPE_ID) when
called without arguments.

With the method name and tests like `test_run_out_of_shape_for_object`, the method should make the next shape allocation fail.

cc @peterzhu2118 @byroot 
