### PR TITLE
[wasm] Use xmalloc/xfree for jmpbuf allocation to trigger GC properly

### DIFF
--- a/vm_core.h
+++ b/vm_core.h
@@ -913,13 +913,13 @@ typedef rb_jmpbuf_t *rb_vm_tag_jmpbuf_t;
 static inline void
 rb_vm_tag_jmpbuf_init(rb_vm_tag_jmpbuf_t *jmpbuf)
 {
-    *jmpbuf = malloc(sizeof(rb_jmpbuf_t));
+    *jmpbuf = ruby_xmalloc(sizeof(rb_jmpbuf_t));
 }
 
 static inline void
 rb_vm_tag_jmpbuf_deinit(const rb_vm_tag_jmpbuf_t *jmpbuf)
 {
-    free(*jmpbuf);
+    ruby_xfree(*jmpbuf);
 }
 #else
 typedef rb_jmpbuf_t rb_vm_tag_jmpbuf_t;


### PR DESCRIPTION
`rb_vm_tag_jmpbuf_{init,deinit}` are safe to raise exception since the given tag is not yet pushed to `ec->tag` or already popped from it at the time, so `ec->tag` is always valid and it's safe to raise exception when xmalloc fails.