### PR TITLE
Get the error codes as Socket::EAI_XXX when `getaddrinfo` and `getnameinfo` fail

### DIFF
--- a/ext/socket/init.c
+++ b/ext/socket/init.c
@@ -38,7 +38,7 @@ static VALUE sym_wait_readable;
 static ID id_error_code;
 
 void
-rsock_raise_socket_error(const char *reason, int error)
+rsock_raise_resolution_error(const char *reason, int error)
 {
 #ifdef EAI_SYSTEM
     int e;

--- a/ext/socket/init.c
+++ b/ext/socket/init.c
@@ -50,10 +50,14 @@ rsock_raise_socket_error(const char *reason, int error)
     VALUE msg = rb_sprintf("%s: ", reason);
     if (!enc) enc = rb_default_internal_encoding();
     rb_str_concat(msg, rb_w32_conv_from_wchar(gai_strerrorW(error), enc));
-    rb_exc_raise(rb_exc_new_str(rb_eSocket, msg));
 #else
-    rb_raise(rb_eSocket, "%s: %s", reason, gai_strerror(error));
+    VALUE msg = rb_sprintf("%s: %s", reason, gai_strerror(error));
 #endif
+
+    StringValue(msg);
+    VALUE self = rb_class_new_instance(1, &msg, rb_eResolution);
+    rb_ivar_set(self, id_error_code, INT2NUM(error));
+    rb_exc_raise(self);
 }
 
 #if defined __APPLE__

--- a/ext/socket/init.c
+++ b/ext/socket/init.c
@@ -27,6 +27,7 @@ VALUE rb_cSocket;
 VALUE rb_cAddrinfo;
 
 VALUE rb_eSocket;
+VALUE rb_eResolution;
 
 #ifdef SOCKS
 VALUE rb_cSOCKSSocket;
@@ -34,6 +35,7 @@ VALUE rb_cSOCKSSocket;
 
 int rsock_do_not_reverse_lookup = 1;
 static VALUE sym_wait_readable;
+static ID id_error_code;
 
 void
 rsock_raise_socket_error(const char *reason, int error)
@@ -772,6 +774,12 @@ rsock_getfamily(rb_io_t *fptr)
     return ss.addr.sa_family;
 }
 
+static VALUE
+sock_resolv_error_code(VALUE self)
+{
+  return rb_attr_get(self, id_error_code);
+}
+
 void
 rsock_init_socket_init(void)
 {
@@ -779,6 +787,8 @@ rsock_init_socket_init(void)
      * SocketError is the error class for socket.
      */
     rb_eSocket = rb_define_class("SocketError", rb_eStandardError);
+    rb_eResolution = rb_define_class_under(rb_cSocket, "ResolutionError", rb_eSocket);
+    rb_define_method(rb_eResolution, "error_code", sock_resolv_error_code, 0);
     rsock_init_ipsocket();
     rsock_init_tcpsocket();
     rsock_init_tcpserver();
@@ -791,6 +801,8 @@ rsock_init_socket_init(void)
     rsock_init_addrinfo();
     rsock_init_sockifaddr();
     rsock_init_socket_constants();
+
+    id_error_code = rb_intern_const("error_code");
 
 #undef rb_intern
     sym_wait_readable = ID2SYM(rb_intern("wait_readable"));

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -766,7 +766,7 @@ make_ipaddr0(struct sockaddr *addr, socklen_t addrlen, char *buf, size_t buflen)
 
     error = rb_getnameinfo(addr, addrlen, buf, buflen, NULL, 0, NI_NUMERICHOST);
     if (error) {
-        rsock_raise_socket_error("getnameinfo", error);
+        rsock_raise_resolution_error("getnameinfo", error);
     }
 }
 
@@ -975,7 +975,7 @@ rsock_getaddrinfo(VALUE host, VALUE port, struct addrinfo *hints, int socktype_h
         if (hostp && hostp[strlen(hostp)-1] == '\n') {
             rb_raise(rb_eSocket, "newline at the end of hostname");
         }
-        rsock_raise_socket_error("getaddrinfo", error);
+        rsock_raise_resolution_error("getaddrinfo", error);
     }
 
     return res;
@@ -1034,7 +1034,7 @@ rsock_ipaddr(struct sockaddr *sockaddr, socklen_t sockaddrlen, int norevlookup)
     error = rb_getnameinfo(sockaddr, sockaddrlen, hbuf, sizeof(hbuf),
                            pbuf, sizeof(pbuf), NI_NUMERICHOST | NI_NUMERICSERV);
     if (error) {
-        rsock_raise_socket_error("getnameinfo", error);
+        rsock_raise_resolution_error("getnameinfo", error);
     }
     addr2 = rb_str_new2(hbuf);
     if (addr1 == Qnil) {
@@ -1672,7 +1672,7 @@ rsock_inspect_sockaddr(struct sockaddr *sockaddr_arg, socklen_t socklen, VALUE r
                                        hbuf, (socklen_t)sizeof(hbuf), NULL, 0,
                                        NI_NUMERICHOST|NI_NUMERICSERV);
                 if (error) {
-                    rsock_raise_socket_error("getnameinfo", error);
+                    rsock_raise_resolution_error("getnameinfo", error);
                 }
                 if (addr->sin6_port == 0) {
                     rb_str_cat2(ret, hbuf);
@@ -2040,7 +2040,7 @@ addrinfo_mdump(VALUE self)
                                hbuf, (socklen_t)sizeof(hbuf), pbuf, (socklen_t)sizeof(pbuf),
                                NI_NUMERICHOST|NI_NUMERICSERV);
         if (error) {
-            rsock_raise_socket_error("getnameinfo", error);
+            rsock_raise_resolution_error("getnameinfo", error);
         }
         sockaddr = rb_assoc_new(rb_str_new_cstr(hbuf), rb_str_new_cstr(pbuf));
         break;
@@ -2386,7 +2386,7 @@ addrinfo_getnameinfo(int argc, VALUE *argv, VALUE self)
                            hbuf, (socklen_t)sizeof(hbuf), pbuf, (socklen_t)sizeof(pbuf),
                            flags);
     if (error) {
-        rsock_raise_socket_error("getnameinfo", error);
+        rsock_raise_resolution_error("getnameinfo", error);
     }
 
     return rb_assoc_new(rb_str_new2(hbuf), rb_str_new2(pbuf));

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -308,7 +308,7 @@ VALUE rsock_sockaddr_string_value_with_addrinfo(volatile VALUE *v, VALUE *ai_ret
 
 VALUE rb_check_sockaddr_string_type(VALUE);
 
-NORETURN(void rsock_raise_socket_error(const char *, int));
+NORETURN(void rsock_raise_resolution_error(const char *, int));
 
 int rsock_family_arg(VALUE domain);
 int rsock_socktype_arg(VALUE type);

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -285,6 +285,7 @@ extern VALUE rb_cAddrinfo;
 extern VALUE rb_cSockOpt;
 
 extern VALUE rb_eSocket;
+extern VALUE rb_eResolution;
 
 #ifdef SOCKS
 extern VALUE rb_cSOCKSSocket;

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -1313,7 +1313,7 @@ sock_s_getnameinfo(int argc, VALUE *argv, VALUE _)
     saved_errno = errno;
     if (res) rb_freeaddrinfo(res);
     errno = saved_errno;
-    rsock_raise_socket_error("getnameinfo", error);
+    rsock_raise_resolution_error("getnameinfo", error);
 
     UNREACHABLE_RETURN(Qnil);
 }

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -11,7 +11,7 @@ rake            13.1.0  https://github.com/ruby/rake
 test-unit       3.6.1   https://github.com/test-unit/test-unit
 rexml           3.2.6   https://github.com/ruby/rexml
 rss             0.3.0   https://github.com/ruby/rss
-net-ftp         0.2.0   https://github.com/ruby/net-ftp
+net-ftp         0.2.0   https://github.com/ruby/net-ftp 54a9c289048c17e5037ea806e8d7896093f75263
 net-imap        0.4.6   https://github.com/ruby/net-imap
 net-pop         0.1.2   https://github.com/ruby/net-pop
 net-smtp        0.4.0   https://github.com/ruby/net-smtp

--- a/spec/ruby/library/socket/socket/getnameinfo_spec.rb
+++ b/spec/ruby/library/socket/socket/getnameinfo_spec.rb
@@ -70,7 +70,7 @@ describe 'Socket.getnameinfo' do
 
     it 'raises SocketError or TypeError when using an invalid String' do
       -> { Socket.getnameinfo('cats') }.should raise_error(Exception) { |e|
-        [SocketError, TypeError].should include(e.class)
+        (e.is_a?(SocketError) || e.is_a?(TypeError)).should == true
       }
     end
 

--- a/test/fiber/test_address_resolve.rb
+++ b/test/fiber/test_address_resolve.rb
@@ -179,7 +179,7 @@ class TestAddressResolve < Test::Unit::TestCase
       Fiber.set_scheduler scheduler
 
       Fiber.schedule do
-        assert_raise(SocketError) {
+        assert_raise(Socket::ResolutionError) {
           Addrinfo.getaddrinfo("non-existing-domain.abc", nil)
         }
       end

--- a/test/socket/test_addrinfo.rb
+++ b/test/socket/test_addrinfo.rb
@@ -103,7 +103,7 @@ class TestSocketAddrinfo < Test::Unit::TestCase
   end
 
   def test_error_message
-    e = assert_raise_with_message(SocketError, /getaddrinfo/) do
+    e = assert_raise_with_message(Socket::ResolutionError, /getaddrinfo/) do
       Addrinfo.ip("...")
     end
     m = e.message
@@ -357,7 +357,7 @@ class TestSocketAddrinfo < Test::Unit::TestCase
     ai = Addrinfo.unix("/testdir/sock").family_addrinfo("/testdir/sock2")
     assert_equal("/testdir/sock2", ai.unix_path)
     assert_equal(Socket::SOCK_STREAM, ai.socktype)
-    assert_raise(SocketError) { Addrinfo.tcp("0.0.0.0", 4649).family_addrinfo("::1", 80) }
+    assert_raise(Socket::ResolutionError) { Addrinfo.tcp("0.0.0.0", 4649).family_addrinfo("::1", 80) }
   end
 
   def random_port

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -91,20 +91,20 @@ class TestSocket < Test::Unit::TestCase
 
   def test_getaddrinfo
     # This should not send a DNS query because AF_UNIX.
-    assert_raise(SocketError) { Socket.getaddrinfo("www.kame.net", 80, "AF_UNIX") }
+    assert_raise(Socket::ResolutionError) { Socket.getaddrinfo("www.kame.net", 80, "AF_UNIX") }
   end
 
   def test_getaddrinfo_raises_no_errors_on_port_argument_of_0 # [ruby-core:29427]
     assert_nothing_raised('[ruby-core:29427]'){ Socket.getaddrinfo('localhost', 0, Socket::AF_INET, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME) }
     assert_nothing_raised('[ruby-core:29427]'){ Socket.getaddrinfo('localhost', '0', Socket::AF_INET, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME) }
     assert_nothing_raised('[ruby-core:29427]'){ Socket.getaddrinfo('localhost', '00', Socket::AF_INET, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME) }
-    assert_raise(SocketError, '[ruby-core:29427]'){ Socket.getaddrinfo(nil, nil, Socket::AF_INET, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME) }
+    assert_raise(Socket::ResolutionError, '[ruby-core:29427]'){ Socket.getaddrinfo(nil, nil, Socket::AF_INET, Socket::SOCK_STREAM, nil, Socket::AI_CANONNAME) }
     assert_nothing_raised('[ruby-core:29427]'){ TCPServer.open('localhost', 0) {} }
   end
 
 
   def test_getnameinfo
-    assert_raise(SocketError) { Socket.getnameinfo(["AF_UNIX", 80, "0.0.0.0"]) }
+    assert_raise(Socket::ResolutionError) { Socket.getnameinfo(["AF_UNIX", 80, "0.0.0.0"]) }
     assert_raise(ArgumentError) {Socket.getnameinfo(["AF_INET", "http\0", "example.net"])}
     assert_raise(ArgumentError) {Socket.getnameinfo(["AF_INET", "http", "example.net\0"])}
   end
@@ -768,6 +768,14 @@ class TestSocket < Test::Unit::TestCase
   ensure
     s1.close
     s2.close
+  end
+
+  def test_resolurion_error_error_code
+    begin
+      Socket.getaddrinfo("www.kame.net", 80, "AF_UNIX")
+    rescue => e
+      assert_equal(e.error_code, Socket::EAI_FAMILY)
+    end
   end
 
 end if defined?(Socket)


### PR DESCRIPTION
This PR allows getting the error codes as `Socket::EAI_XXX` when `getaddrinfo` and `getnameinfo` fail.

### The purpose of this PR
This PR is necessary to implement Happy Eyeballs version 2 (RFC 8305) in `Socket.tcp`.
In HEv2, `EAI_ADDRFAMILY` and `EAI_AGAIN` obtained during name resolution should be ignored. However, there is currently no way to ask `SocketError` for errors returned by `getaddrinfo`, so I opened this PR.

### Changes
- Added `Socket::ResolutionError` as a subclass of `SocketError`
- Added an attribute of Socket::ResolutionError to get error code via `#error_code
- Replaced `SocketError` (`rb_eSocket`) with `Socket::ResolutionError` (`rb_eResolutionError`)  in `rsock_raise_socket_error` because this function is only called when `getaddrinfo` and `getnameinfo` fail
- Renamed `rsock_raise_socket_error` to `rock_raise_resolution_error` for the same reason

### Note
Socket::ResolutionError is a subclass of SocketError, so it does not affect `rescue SocketError` in source codes.