### PR TITLE
GVL Instrumentation events are fired out of order on Ruby 3.3

### DIFF
--- a/test/-ext-/thread/test_instrumentation_api.rb
+++ b/test/-ext-/thread/test_instrumentation_api.rb
@@ -42,6 +42,17 @@ class TestThreadInstrumentation < Test::Unit::TestCase
     assert_join_counters(Bug::ThreadInstrumentation.local_counters)
   end
 
+  def test_order_of_events
+    expected_order = %w[started ready resumed suspended exited]
+    threads = threaded_cpu_work
+
+    assert_equal [false] * THREADS_COUNT, threads.map(&:status)
+    threads.each do |thread|
+      actual_order = Bug::ThreadInstrumentation.events_fired(thread)
+      assert_equal expected_order, actual_order
+    end
+  end
+
   def test_thread_instrumentation_fork_safe
     skip "No fork()" unless Process.respond_to?(:fork)
 


### PR DESCRIPTION
Right now this PR just provides an instrumentation spec to show what the behavior should be, and was in Ruby 3.2.

* The changes that came along with M:N threads have caused some issues with the GVL instrumentation api. The events are now fired out of order.

* This spec on ruby 3.2 would consistently record as %[started ready resumed suspended exited] per thread.

* On Ruby 3.3, it comes through as %w[ready resumed started exited suspended]

* With `RUBY_MN_THREADS=1` you get %w[ready started exited suspended]

```
make test-all TESTS="test/-ext-/thread/test_instrumentation_api.rb --name=TestThreadInstrumentation#test_order_of_events"
# => %w[ready resumed started exited suspended]

RUBY_MN_THREADS=1 make test-all TESTS="test/-ext-/thread/test_instrumentation_api.rb --name=TestThreadInstrumentation#test_order_of_events"
# => %w[ready started exited suspended]
```

@casperisfine 