### PR TITLE
[DOC] More on links 

### DIFF
--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -205,7 +205,7 @@ When writing an explicit link, follow these guidelines.
 
 #### +rdoc-ref+ Scheme
 
-Use the +rdoc-ref+ scheme for:
+Prefer the +rdoc-ref+ scheme for:
 
 - A link in core documentation to other core documentation.
 - A link in core documentation to documentation in a standard library package.

--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -205,14 +205,14 @@ When writing an explicit link, follow these guidelines.
 
 #### +rdoc-ref+ Scheme
 
-Prefer the +rdoc-ref+ scheme for:
+Use the +rdoc-ref+ scheme for:
 
 - A link in core documentation to other core documentation.
 - A link in core documentation to documentation in a standard library package.
 - A link in a standard library package to other documentation in that same
   standard library package.
 
-See section "+rdoc-ref+ Scheme" in {Links}[https://docs.ruby-lang.org/en/master/RDoc/MarkupReference.html#class-RDoc::MarkupReference-label-Links].
+See section "+rdoc-ref+ Scheme" in {Links}[rdoc-ref:RDoc::MarkupReference@Links].
 
 #### URL-Based Link
 

--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -199,6 +199,36 @@ will be autolinked:
 If not, or if you suppress autolinking, consider forcing
 [monofont](rdoc-ref:RDoc::MarkupReference@Monofont).
 
+### Explicit Links
+
+When writing an explicit link, follow these guidelines.
+
+#### +rdoc-ref+ Scheme
+
+Use the +rdoc-ref+ scheme for:
+
+- A link in core documentation to other core documentation.
+- A link in core documentation to documentation in a standard library package.
+- A link in a standard library package to other documentation in that same
+  standard library package.
+
+See section "+rdoc-ref+ Scheme" in {Links}[https://docs.ruby-lang.org/en/master/RDoc/MarkupReference.html#class-RDoc::MarkupReference-label-Links].
+
+#### URL-Based Link
+
+Use a full URL-based link for:
+
+- A link in standard library documentation to documentation in the core.
+- A link in standard library documentation to documentation in a different
+  standard library package.
+
+Doing so ensures that the link will valid even when the package documentation
+is built independently (separately from the core documentation).
+
+The link should lead to a target in https://docs.ruby-lang.org/en/master/.
+
+Also use a full URL-based link for a link to an off-site document.
+
 ### Variable Names
 
 The name of a variable (as specified in its call-seq) should be marked up as


### PR DESCRIPTION
Replaces https://github.com/ruby/ruby/pull/9011, which I fouled up.