### PR TITLE
YJIT: record `num_send_cfunc` stat

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -304,9 +304,8 @@ module RubyVM::YJIT
       out.puts "num_send_dynamic:      " + format_number_pct(13, stats[:num_send_dynamic], stats[:num_send])
       out.puts "num_send_inline:       " + format_number_pct(13, stats[:num_send_inline], stats[:num_send])
       out.puts "num_send_leaf_builtin: " + format_number_pct(13, stats[:num_send_leaf_builtin], stats[:num_send])
-
       out.puts "num_send_cfunc:        " + format_number_pct(13, stats[:num_send_cfunc], stats[:num_send])
-      out.puts "num_send_known_cfunc:  " + format_number_pct(13, stats[:num_send_known_cfunc], stats[:num_send_cfunc])
+      out.puts "num_send_cfunc_inline: " + format_number_pct(13, stats[:num_send_cfunc_inline], stats[:num_send_cfunc])
       if stats[:num_send_x86_rel32] != 0 || stats[:num_send_x86_reg] != 0
         out.puts "num_send_x86_rel32:    " + format_number(13,  stats[:num_send_x86_rel32])
         out.puts "num_send_x86_reg:      " + format_number(13, stats[:num_send_x86_reg])

--- a/yjit.rb
+++ b/yjit.rb
@@ -304,7 +304,9 @@ module RubyVM::YJIT
       out.puts "num_send_dynamic:      " + format_number_pct(13, stats[:num_send_dynamic], stats[:num_send])
       out.puts "num_send_inline:       " + format_number_pct(13, stats[:num_send_inline], stats[:num_send])
       out.puts "num_send_leaf_builtin: " + format_number_pct(13, stats[:num_send_leaf_builtin], stats[:num_send])
-      out.puts "num_send_known_cfunc:  " + format_number_pct(13, stats[:num_send_known_cfunc], stats[:num_send])
+
+      out.puts "num_send_cfunc:        " + format_number_pct(13, stats[:num_send_cfunc], stats[:num_send])
+      out.puts "num_send_known_cfunc:  " + format_number_pct(13, stats[:num_send_known_cfunc], stats[:num_send_cfunc])
       if stats[:num_send_x86_rel32] != 0 || stats[:num_send_x86_reg] != 0
         out.puts "num_send_x86_rel32:    " + format_number(13,  stats[:num_send_x86_rel32])
         out.puts "num_send_x86_reg:      " + format_number(13, stats[:num_send_x86_reg])

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5407,7 +5407,7 @@ fn gen_send_cfunc(
         if let Some(known_cfunc_codegen) = codegen_p {
             if known_cfunc_codegen(jit, asm, ocb, ci, cme, block, argc, recv_known_klass) {
                 assert_eq!(expected_stack_after, asm.ctx.get_stack_size() as i32);
-                gen_counter_incr(asm, Counter::num_send_known_cfunc);
+                gen_counter_incr(asm, Counter::num_send_cfunc_inline);
                 // cfunc codegen generated code. Terminate the block so
                 // there isn't multiple calls in the same block.
                 jump_to_next_insn(jit, asm, ocb);

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5398,6 +5398,8 @@ fn gen_send_cfunc(
         return None;
     }
 
+    gen_counter_incr(asm, Counter::num_send_cfunc);
+
     // Delegate to codegen for C methods if we have it.
     if kw_arg.is_null() && flags & VM_CALL_OPT_SEND == 0 && flags & VM_CALL_ARGS_SPLAT == 0 && (cfunc_argc == -1 || argc == cfunc_argc) {
         let codegen_p = lookup_cfunc_codegen(unsafe { (*cme).def });
@@ -5432,7 +5434,6 @@ fn gen_send_cfunc(
     } else {
         argc - kw_arg_num + 1
     };
-
 
     // If the argument count doesn't match
     if cfunc_argc >= 0 && cfunc_argc != passed_argc && flags & VM_CALL_ARGS_SPLAT == 0 {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -482,6 +482,7 @@ make_counters! {
     num_send_dynamic,
     num_send_inline,
     num_send_leaf_builtin,
+    num_send_cfunc,
     num_send_known_cfunc,
 
     num_getivar_megamorphic,

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -483,7 +483,7 @@ make_counters! {
     num_send_inline,
     num_send_leaf_builtin,
     num_send_cfunc,
-    num_send_known_cfunc,
+    num_send_cfunc_inline,
 
     num_getivar_megamorphic,
     num_setivar_megamorphic,


### PR DESCRIPTION
Also report `num_send_known_cfunc` as percentage of `num_send_cfunc`.

The results are interesting, for example for lobsters:
```
num_send:                 26,760,083
num_send_known_class:        582,989 ( 2.2%)
num_send_polymorphic:      3,753,785 (14.0%)
num_send_megamorphic:        254,507 ( 1.0%)
num_send_dynamic:            746,039 ( 2.8%)
num_send_inline:             238,076 ( 0.9%)
num_send_leaf_builtin:       283,907 ( 1.1%)
num_send_cfunc:            8,191,737 (30.6%)
num_send_known_cfunc:      3,679,959 (44.9%)
```

We can see that we're actually inlining a pretty big chunk of the total C function calls we're generating.