### PR TITLE
.travis.yml: Add s390x again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,8 +104,7 @@ matrix:
   include:
     - <<: *arm64-linux
     - <<: *ppc64le-linux
-    # The s390x builds are not starting.
-    # - <<: *s390x-linux
+    - <<: *s390x-linux
     # FIXME: lib/rubygems/util.rb:104 glob_files_in_dir -
     # <internal:dir>:411:in glob: File name too long - (Errno::ENAMETOOLONG)
     # https://github.com/rubygems/rubygems/issues/7132
@@ -114,7 +113,7 @@ matrix:
     # Allow failures for the unstable jobs.
     # - name: arm64-linux
     # - name: ppc64le-linux
-    - name: s390x-linux
+    # - name: s390x-linux
     # The 2nd arm64 pipeline may be unstable.
     # - name: arm32-linux
   fast_finish: true


### PR DESCRIPTION
As Travis CI IBM z pipeine is operational again, I will add s390x again to check the case. Though Travis s390x infra team is still investigating the root cause. https://www.traviscistatus.com/

Please revert this commit or comment on the
<https://bugs.ruby-lang.org/issues/20013>, when you see the s390x builds are not starting again.

Sorry for inconvenience.