### PR TITLE
Add support for passing a block to `IO#readlines` and `IO.readlines`.

### DIFF
--- a/io.c
+++ b/io.c
@@ -4474,15 +4474,24 @@ rb_io_readlines(int argc, VALUE *argv, VALUE io)
 static VALUE
 io_readlines(const struct getline_arg *arg, VALUE io)
 {
-    VALUE line, ary;
+    VALUE line;
 
     if (arg->limit == 0)
         rb_raise(rb_eArgError, "invalid limit: 0 for readlines");
-    ary = rb_ary_new();
-    while (!NIL_P(line = rb_io_getline_1(arg->rs, arg->limit, arg->chomp, io))) {
-        rb_ary_push(ary, line);
+
+    // If a block is provided, yield lines.
+    if (rb_block_given_p()) {
+        while (!NIL_P(line = rb_io_getline_1(arg->rs, arg->limit, arg->chomp, io))) {
+            rb_yield(line);
+        }
+        return Qnil;
+    } else {
+        VALUE ary = rb_ary_new();
+        while (!NIL_P(line = rb_io_getline_1(arg->rs, arg->limit, arg->chomp, io))) {
+            rb_ary_push(ary, line);
+        }
+        return ary;
     }
-    return ary;
 }
 
 /*

--- a/spec/ruby/core/io/readlines_spec.rb
+++ b/spec/ruby/core/io/readlines_spec.rb
@@ -20,6 +20,16 @@ describe "IO#readlines" do
     -> { @io.readlines }.should raise_error(IOError)
   end
 
+  ruby_version_is "3.3" do
+    describe "when invoked with a block" do
+      it "yields each line to the block" do
+        lines = []
+        @io.readlines { |line| lines << line }
+        lines.should == IOSpecs.lines
+      end
+    end
+  end
+
   describe "when passed no arguments" do
     before :each do
       suppress_warning {@sep, $/ = $/, " "}
@@ -213,6 +223,14 @@ describe "IO.readlines" do
       -> {
         IO.readlines(cmd)
       }.should complain(/IO process creation with a leading '\|'/)
+    end
+
+    describe "when invoked with a block" do
+      it "yields each line to the block" do
+        lines = []
+        IO.readlines(@name) { |line| lines << line }
+        lines.should == IOSpecs.lines
+      end
     end
   end
 


### PR DESCRIPTION
`IO#readlines` can allocate memory proportional to the file size. This can be a problem. While `IO#each_line` exists, `IO#readlines` is convenient. So, let's extend `IO#readlines` and `IO.readlines` to accept a block, and yield one line at a time, to avoid memory usage issues when dealing with large files.

cc @youchan