### PR TITLE
Fix compaction for generic ivars

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7254,7 +7254,7 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
     gc_mark_set_parent(objspace, obj);
 
     if (FL_TEST(obj, FL_EXIVAR)) {
-        rb_mark_and_update_generic_ivar(obj);
+        rb_mark_generic_ivar(obj);
     }
 
     switch (BUILTIN_TYPE(obj)) {
@@ -10248,6 +10248,12 @@ gc_ref_update_table_values_only(rb_objspace_t *objspace, st_table *tbl)
     }
 }
 
+void
+rb_gc_ref_update_table_values_only(st_table *tbl)
+{
+    gc_ref_update_table_values_only(&rb_objspace, tbl);
+}
+
 static void
 gc_update_table_refs(rb_objspace_t * objspace, st_table *tbl)
 {
@@ -10622,7 +10628,7 @@ gc_update_object_references(rb_objspace_t *objspace, VALUE obj)
     gc_report(4, objspace, "update-refs: %p ->\n", (void *)obj);
 
     if (FL_TEST(obj, FL_EXIVAR)) {
-        rb_mark_and_update_generic_ivar(obj);
+        rb_ref_update_generic_ivar(obj);
     }
 
     switch (BUILTIN_TYPE(obj)) {

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -250,6 +250,8 @@ void rb_gc_mark_and_move(VALUE *ptr);
 void rb_gc_mark_weak(VALUE *ptr);
 void rb_gc_remove_weak(VALUE parent_obj, VALUE *ptr);
 
+void rb_gc_ref_update_table_values_only(st_table *tbl);
+
 #define rb_gc_mark_and_move_ptr(ptr) do { \
     VALUE _obj = (VALUE)*(ptr); \
     rb_gc_mark_and_move(&_obj); \

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -53,7 +53,8 @@ void rb_evict_ivars_to_hash(VALUE obj);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* variable.c (export) */
-void rb_mark_and_update_generic_ivar(VALUE);
+void rb_mark_generic_ivar(VALUE obj);
+void rb_ref_update_generic_ivar(VALUE);
 void rb_mv_generic_ivar(VALUE src, VALUE dst);
 VALUE rb_const_missing(VALUE klass, VALUE name);
 int rb_class_ivar_set(VALUE klass, ID vid, VALUE value);


### PR DESCRIPTION
When generic instance variable has a shape, it is marked movable. If it it transitions to too complex, it needs to update references otherwise it may have incorrect references.

cc. @byroot @XrXr 