### PR TITLE
Add assertions to verify the correctness of the shape tree

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -654,12 +654,19 @@ rb_shape_get_next_iv_shape(rb_shape_t* shape, ID id)
 }
 
 rb_shape_t *
-rb_shape_get_next(rb_shape_t* shape, VALUE obj, ID id)
+rb_shape_get_next(rb_shape_t *shape, VALUE obj, ID id)
 {
     RUBY_ASSERT(!is_instance_id(id) || RTEST(rb_sym2str(ID2SYM(id))));
     if (UNLIKELY(shape->type == SHAPE_OBJ_TOO_COMPLEX)) {
         return shape;
     }
+
+#if RUBY_DEBUG
+    attr_index_t index;
+    if (rb_shape_get_iv_index(shape, id, &index)) {
+        rb_bug("rb_shape_get_next: trying to create ivar that already exists at index %u", index);
+    }
+#endif
 
     bool allow_new_shape = true;
 


### PR DESCRIPTION
We're still seeing flaky failures in the i686 CI about shape issues. This commit adds assertions to verify the correctness of the shape tree.

Example failure: https://github.com/ruby/ruby/actions/runs/6983912138/job/19005844648

```
Assertion Failed: ../src/variable.c:1663:rb_obj_copy_ivs_to_hash_table_i:!st_lookup((st_table *)arg, (st_data_t)key, NULL)
  ruby 3.3.0dev (2023-11-24T18:29:04Z master 269c705f93) [i686-linux-gnu]
```

cc. @byroot 