### PR TITLE
[ruby/resolv] Support a :use_ipv6 option to Resolv#initialize

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -84,8 +84,8 @@ class Resolv
   ##
   # Creates a new Resolv using +resolvers+.
 
-  def initialize(resolvers=[Hosts.new, DNS.new])
-    @resolvers = resolvers
+  def initialize(resolvers=nil, use_ipv6: nil)
+    @resolvers = resolvers || [Hosts.new, DNS.new(DNS::Config.default_config_hash.merge(use_ipv6: use_ipv6))]
   end
 
   ##
@@ -410,6 +410,11 @@ class Resolv
     end
 
     def use_ipv6? # :nodoc:
+      use_ipv6 = @config.use_ipv6?
+      unless use_ipv6.nil?
+        return use_ipv6
+      end
+
       begin
         list = Socket.ip_address_list
       rescue NotImplementedError
@@ -1008,6 +1013,7 @@ class Resolv
         @mutex.synchronize {
           unless @initialized
             @nameserver_port = []
+            @use_ipv6 = nil
             @search = nil
             @ndots = 1
             case @config_info
@@ -1031,6 +1037,9 @@ class Resolv
             end
             if config_hash.include? :nameserver_port
               @nameserver_port = config_hash[:nameserver_port].map {|ns, port| [ns, (port || Port)] }
+            end
+            if config_hash.include? :use_ipv6
+              @use_ipv6 = config_hash[:use_ipv6]
             end
             @search = config_hash[:search] if config_hash.include? :search
             @ndots = config_hash[:ndots] if config_hash.include? :ndots
@@ -1086,6 +1095,10 @@ class Resolv
 
       def nameserver_port
         @nameserver_port
+      end
+
+      def use_ipv6?
+        @use_ipv6
       end
 
       def generate_candidates(name)


### PR DESCRIPTION
When set, supports returning IPv6 results even if there is no public IPv6 address for the system.

Implements [Feature #14922]

https://github.com/ruby/resolv/commit/09d141de38

The pull request was merged upstream, but the automerge to Ruby did not happen for this commit.