### PR TITLE
YJIT: add top C function call counts to `--yjit-stats`

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5419,8 +5419,7 @@ fn gen_send_cfunc(
 
     // Log the name of the method we're calling to,
     // note that we intentionally don't do this for inlined cfuncs
-    #[cfg(feature = "stats")]
-    {
+    if get_option!(gen_stats) {
         // TODO: extract code to get method name string into its own function
 
         // Assemble the method name string
@@ -7875,7 +7874,6 @@ fn gen_invokesuper_specialized(
             gen_send_iseq(jit, asm, ocb, iseq, ci, frame_type, None, cme, Some(block), ci_flags, argc, None)
         }
         VM_METHOD_TYPE_CFUNC => {
-            // FIXME: why do we put unknown comptime class here?
             gen_send_cfunc(jit, asm, ocb, ci, cme, Some(block), ptr::null(), ci_flags, argc)
         }
         _ => unreachable!(),

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5398,6 +5398,7 @@ fn gen_send_cfunc(
         return None;
     }
 
+    // Increment total cfunc send count
     gen_counter_incr(asm, Counter::num_send_cfunc);
 
     // Delegate to codegen for C methods if we have it.
@@ -5414,6 +5415,23 @@ fn gen_send_cfunc(
                 return Some(EndBlock);
             }
         }
+    }
+
+    // Log the name of the method we're calling to,
+    // note that we intentionally don't do this for inlined cfuncs
+    #[cfg(feature = "stats")]
+    {
+        // Assemble the method name string
+        let mid = unsafe { vm_ci_mid(ci) };
+        let class_name = unsafe { cstr_to_rust_string(rb_class2name(*recv_known_klass)) }.unwrap();
+        let method_name = unsafe { cstr_to_rust_string(rb_id2name(mid)) }.unwrap();
+        let name_str = format!("{}#{}", class_name, method_name);
+
+        // Get an index for this cfunc name
+        let cfunc_idx = get_cfunc_idx(&name_str);
+
+        // Increment the counter for this cfunc
+        asm.ccall(incr_cfunc_counter as *const u8, vec![cfunc_idx.into()]);
     }
 
     // Check for interrupts

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -6,6 +6,7 @@
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
+use std::collections::HashMap;
 
 use crate::codegen::CodegenGlobals;
 use crate::core::Context;
@@ -52,11 +53,12 @@ unsafe impl GlobalAlloc for StatsAlloc {
     }
 }
 
-
-
-use std::collections::HashMap;
+/// Mapping of C function name to integer indices
+/// This is accessed at compilation time only (protected by a lock)
 static mut CFUNC_NAME_TO_IDX: Option<HashMap<String, usize>> = None;
 
+/// Vector of call counts for each C function index
+/// This is modified (but not resized) by JITted code
 static mut CFUNC_CALL_COUNT: Option<Vec<u64>> = None;
 
 /// Assign an index to a given cfunc name string
@@ -102,12 +104,6 @@ pub extern "C" fn incr_cfunc_counter(idx: usize)
         cfunc_call_count[idx] += 1;
     }
 }
-
-
-
-
-
-
 
 // YJIT exit counts for each instruction type
 const VM_INSTRUCTION_SIZE_USIZE: usize = VM_INSTRUCTION_SIZE as usize;


### PR DESCRIPTION
My little pet project. Add top (uninlined) C function calls to `--yjit-stats`. This can reveal some easy optimization targets without needing to use a profiler.

Lobsters:
```
Top-20 most frequent C calls (31.3% of C calls):
                        Hash#fetch:    770,426 ( 9.4%)
                         Class#new:    366,541 ( 4.5%)
                        Array#each:    232,277 ( 2.8%)
                  Class#superclass:    160,770 ( 2.0%)
                        Array#any?:    117,291 ( 1.4%)
    Concurrent::Array#reverse_each:     97,111 ( 1.2%)
                     Regexp#match?:     78,375 ( 1.0%)
                         Hash#key?:     66,934 ( 0.8%)
                        Class#name:     66,534 ( 0.8%)
          SQLite3::Statement#done?:     61,089 ( 0.7%)
           SQLite3::Statement#step:     61,089 ( 0.7%)
                       Hash#empty?:     58,755 ( 0.7%)
                       Symbol#to_s:     57,037 ( 0.7%)
                     TrueClass#===:     56,353 ( 0.7%)
                         Object#!=:     56,066 ( 0.7%)
                      Array#reject:     55,639 ( 0.7%)
                    FalseClass#===:     54,948 ( 0.7%)
                          Hash#dup:     52,600 ( 0.6%)
                         Array#map:     52,183 ( 0.6%)
                    Array#include?:     45,110 ( 0.6%)

```

Here `Class#superclass` may be an easy optimization target, `TrueClass#===`, `Hash#empty?` and `Class#name` as well. Also surprised that we are still calling `Symbol#to_s`.

Optcarrot:
```
Top-20 most frequent C calls (20.5% of C calls):
             Integer#*:  2,643,814 ( 8.2%)
             Array#[]=:  1,540,322 ( 4.8%)
         Array#rotate!:  1,493,457 ( 4.6%)
            Integer#>>:    673,674 ( 2.1%)
            Array#size:    143,732 ( 0.4%)
             Integer#^:    109,241 ( 0.3%)
             Method#[]:     28,777 ( 0.1%)
          Fiber#resume:      5,443 ( 0.0%)
           Class#yield:      5,443 ( 0.0%)
            Array#each:      2,732 ( 0.0%)
     Integer#object_id:      2,029 ( 0.0%)
           Float#floor:      1,449 ( 0.0%)
       Array#object_id:      1,014 ( 0.0%)
           Array#uniq!:        995 ( 0.0%)
           Symbol#to_s:        612 ( 0.0%)
           Array#clear:        513 ( 0.0%)
    Symbol#start_with?:        397 ( 0.0%)
        Array#include?:        180 ( 0.0%)
               Float#/:        171 ( 0.0%)
               Float#-:        171 ( 0.0%)
```

On optcarrot, we already inline almost 80% of C function calls, which is very impressive and probably explains why we're so fast on that benchmark. The remaining top C functions still show many potential optimization targets, however. There is room to be even faster eventually.