### PR TITLE
Further fix the GVL instrumentation API

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -799,6 +799,7 @@ thread_sched_to_ready_common(struct rb_thread_sched *sched, rb_thread_t *th, boo
 
     VM_ASSERT(sched->running != th);
     VM_ASSERT(!thread_sched_readyq_contain_p(sched, th));
+    RB_INTERNAL_THREAD_HOOK(RUBY_INTERNAL_THREAD_EVENT_READY, th);
 
     if (sched->running == NULL) {
         thread_sched_set_running(sched, th);
@@ -807,8 +808,6 @@ thread_sched_to_ready_common(struct rb_thread_sched *sched, rb_thread_t *th, boo
     else {
         thread_sched_enq(sched, th);
     }
-
-    RB_INTERNAL_THREAD_HOOK(RUBY_INTERNAL_THREAD_EVENT_READY, th);
 }
 
 // waiting -> ready
@@ -1068,7 +1067,6 @@ ubf_waiting(void *ptr)
             // not sleeping yet.
         }
         else {
-            RB_INTERNAL_THREAD_HOOK(RUBY_INTERNAL_THREAD_EVENT_SUSPENDED, th);
             thread_sched_to_ready_common(sched, th, true, false);
         }
     }
@@ -1085,6 +1083,8 @@ thread_sched_to_waiting_until_wakeup(struct rb_thread_sched *sched, rb_thread_t 
 
     RB_VM_SAVE_MACHINE_CONTEXT(th);
     setup_ubf(th, ubf_waiting, (void *)th);
+
+    RB_INTERNAL_THREAD_HOOK(RUBY_INTERNAL_THREAD_EVENT_SUSPENDED, th);
 
     thread_sched_lock(sched, th);
     {


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/9029

[Bug #20019]

Some events still weren't triggered from the right place.

The test suite was also improved a bit more.

cc @jpcamara @jhawthorn, hopefully third time the charm?

I also manually checked that the full timeline makes sense in the CPU preemption case, but I'm not sure if I should actually turn it into assertions as I'm worried it may be flaky. Thoughts?

```
TestThreadInstrumentation#test_muti_thread_timeline
thread-0: started              
thread-0: ready
thread-1: started
thread-1: ready
thread-2: started
thread-2: ready
main    : suspended
main    : ready
thread-0: resumed
thread-0: suspended
thread-0: ready
thread-1: resumed
thread-1: suspended
thread-1: ready
thread-2: resumed
thread-2: suspended
thread-2: ready
main    : resumed
main    : suspended
main    : ready
thread-0: resumed
thread-0: suspended
thread-0: ready
thread-1: resumed
thread-1: suspended
thread-1: ready
thread-2: resumed
thread-2: suspended
thread-2: ready
main    : resumed
main    : suspended
main    : ready
thread-0: resumed
thread-0: suspended
thread-0: ready
thread-1: resumed
thread-1: suspended
thread-1: ready
thread-2: resumed
thread-2: suspended
thread-2: ready
main    : resumed
main    : suspended
thread-0: resumed
main    : ready
thread-0: suspended
thread-0: exited
thread-1: resumed
thread-1: suspended
thread-1: exited
thread-2: resumed
thread-2: suspended
thread-2: exited
main    : resumed
```
