### PR TITLE
YJIT: fix bug in top cfunc logging in `--yjit-stats`

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -375,7 +375,7 @@ module RubyVM::YJIT
 
     def print_sorted_cfunc_calls(stats, out:, how_many: 20, left_pad: 4) # :nodoc:
       calls = stats[:cfunc_calls]
-      if calls.size == 0
+      if calls.empty?
         return
       end
 

--- a/yjit.rb
+++ b/yjit.rb
@@ -375,7 +375,9 @@ module RubyVM::YJIT
 
     def print_sorted_cfunc_calls(stats, out:, how_many: 20, left_pad: 4) # :nodoc:
       calls = stats[:cfunc_calls]
-      #puts calls
+      if calls.size == 0
+        return
+      end
 
       # Total number of cfunc calls
       num_send_cfunc = stats[:num_send_cfunc]

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -743,9 +743,10 @@ fn rb_yjit_gen_stats_dict(context: bool) -> VALUE {
         }
 
         // Create a hash for the cfunc call counts
+        let calls_hash = rb_hash_new();
+        rb_hash_aset(hash, rust_str_to_sym("cfunc_calls"), calls_hash);
         if let Some(cfunc_name_to_idx) = CFUNC_NAME_TO_IDX.as_mut() {
             let call_counts = CFUNC_CALL_COUNT.as_mut().unwrap();
-            let calls_hash = rb_hash_new();
 
             for (name, idx) in cfunc_name_to_idx {
                 let count = call_counts[*idx];
@@ -755,8 +756,6 @@ fn rb_yjit_gen_stats_dict(context: bool) -> VALUE {
                 let value = VALUE::fixnum_from_usize(count as usize);
                 rb_hash_aset(calls_hash, key, value);
             }
-
-            rb_hash_aset(hash, rust_str_to_sym("cfunc_calls"), calls_hash);
         }
     }
 


### PR DESCRIPTION
Correctly handle case where there are no cfunc calls