### PR TITLE
[PRISM] Account for ImplicitRestNode

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3308,13 +3308,10 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         PM_DUP_UNLESS_POPPED;
 
         pm_node_t *rest_expression = NULL;
-        if (multi_write_node->rest) {
-            RUBY_ASSERT(PM_NODE_TYPE_P(multi_write_node->rest, PM_SPLAT_NODE));
-
+        if (multi_write_node->rest && PM_NODE_TYPE_P(multi_write_node->rest, PM_SPLAT_NODE)) {
             pm_splat_node_t *rest_splat = ((pm_splat_node_t *)multi_write_node->rest);
             rest_expression = rest_splat->expression;
         }
-
 
         if (lefts->size) {
             ADD_INSN2(ret, &dummy_line_node, expandarray, INT2FIX(lefts->size), INT2FIX((int) (bool) (rights->size || rest_expression)));

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -435,6 +435,7 @@ module Prism
 
     def test_MultiWriteNode
       assert_prism_eval("foo, bar = [1, 2]")
+      assert_prism_eval("foo, = [1, 2]")
       assert_prism_eval("foo, *, bar = [1, 2]")
       assert_prism_eval("foo, bar = 1, 2")
       assert_prism_eval("foo, *, bar = 1, 2")
@@ -679,8 +680,9 @@ module Prism
       assert_prism_eval("for @i in [1,2] do; @i; end")
       assert_prism_eval("for $i in [1,2] do; $i; end")
 
-      # TODO: multiple assignment in ForNode index
-      #assert_prism_eval("for i, j in {a: 'b'} do; i; j; end")
+      assert_prism_eval("for foo, in  [1,2,3] do end")
+
+      assert_prism_eval("for i, j in {a: 'b'} do; i; j; end")
     end
 
     ############################################################################
@@ -734,6 +736,8 @@ module Prism
       assert_prism_eval("[1, 2, 3].each { |num| num }")
 
       assert_prism_eval("[].tap { _1 }")
+
+      assert_prism_eval("[].each { |a,| }")
     end
 
     def test_ClassNode


### PR DESCRIPTION
Prism introduced a new ImplicitRestNode. This adds tests for the ImplicitRestNode cases, and changes one assert which is no longer accurate.