### PR TITLE
YJIT: Bump ec->cfp after setting cfp->jit_return

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -569,8 +569,9 @@ impl BranchGenFn {
             }
             BranchGenFn::JITReturn => {
                 asm_comment!(asm, "update cfp->jit_return");
+                let jit_return = RUBY_OFFSET_CFP_JIT_RETURN - RUBY_SIZEOF_CONTROL_FRAME as i32;
                 let raw_ptr = asm.lea_jump_target(target0);
-                asm.mov(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), raw_ptr);
+                asm.mov(Opnd::mem(64, CFP, jit_return), raw_ptr);
             }
         }
     }


### PR DESCRIPTION
There's a race condition that, when stackprof runs `rb_profile_frames()` on its signal handler, `ec->cfp` could be pointing to a JIT frame without `jit_return` because we set `cfp->jit_return` after bumping `ec->cfp`, which trips the safeguard added by https://github.com/ruby/ruby/pull/8415.

This PR reorders these operations to make it stackprof-safe. It also optimizes `lea` + `mov` into just `sub` for ISEQ calls.

### Before
```nas
  0x563bdb0260e2: lea rax, [r13 - 0x38]
  # switch to new CFP
  0x563bdb0260e6: mov r13, rax
  0x563bdb0260e9: mov qword ptr [r12 + 0x10], r13
  # update cfp->jit_return
  0x563bdb0260ee: movabs rax, 0x563bdb0280ca
  0x563bdb0260f8: mov qword ptr [r13 + 0x30], rax
```

### After
```nas                                                                                                              
  # update cfp->jit_return                                                                                                                                            
  0x55b192d380e2: movabs rax, 0x55b192d3a0ca                                                                                                                          
  0x55b192d380ec: mov qword ptr [r13 - 8], rax                                                                                                                        
  # switch to new CFP
  0x55b192d380f0: sub r13, 0x38                                                    
  0x55b192d380f4: mov qword ptr [r12 + 0x10], r13
```