### PR TITLE
Add NEWS entry for WeakMap#delete and `RUBY_CRASH_REPORT`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@ Note that each entry is kept to a minimum, see links for details.
   They are not displayed by default even in verbose mode.
   Turn them on with `-W:performance` or `Warning[:performance] = true`. [[Feature #19538]]
 
+* A new `RUBY_CRASH_REPORT` environment variable was introduced to allow
+  redirecting Ruby crash reports to a file or sub command. See the `BUG REPORT ENVIRONMENT`
+  section of the ruby manpage for further details. [[Feature #19790]]
+
 ## Core classes updates
 
 Note: We're only listing outstanding class updates.
@@ -46,16 +50,21 @@ Note: We're only listing outstanding class updates.
       The class use equality semantic to lookup keys like a regular hash,
       but it doesn't hold strong references on the keys. [[Feature #18498]]
 
+* ObjectSpace::WeakMap
+
+    * `ObjectSpace::WeakMap#delete` was added to eagerly clear weak map
+      entries. [[Feature #19561]]
+
 * Proc
     * Now Proc#dup and Proc#clone call `#initialize_dup` and `#initialize_clone`
       hooks respectively.  [[Feature #19362]]
 
-* Process.warmup
+* Process
 
-    * Notify the Ruby virtual machine that the boot sequence is finished,
+    * New `Process.warmup` method that notify the Ruby virtual machine that the boot sequence is finished,
       and that now is a good time to optimize the application. This is useful
-      for long running applications. The actual optimizations performed are entirely
-      implementation specific and may change in the future without notice. [[Feature #18885]]
+      for long-running applications. The actual optimizations performed are entirely
+      implementation-specific and may change in the future without notice. [[Feature #18885]]
 
 * Process::Status
 
@@ -315,3 +324,5 @@ changelog for details of the default gems or bundled gems.
 [Feature #19843]: https://bugs.ruby-lang.org/issues/19843
 [Bug #19868]:     https://bugs.ruby-lang.org/issues/19868
 [Feature #19965]: https://bugs.ruby-lang.org/issues/19965
+[Feature #19790]: https://bugs.ruby-lang.org/issues/19790
+[Feature #19561]: https://bugs.ruby-lang.org/issues/19561


### PR DESCRIPTION
I wasn't too sure where to put `RUBY_CRASH_REPORT`, it's not exactly a command line option but close enough.