### PR TITLE
[Bug #19877] Assign captures for direct regexp literal only

### DIFF
--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -1060,20 +1060,19 @@ x = __ENCODING__
   end
 
   def test_named_capture_in_block
-    [
+    all_assertions_foreach(nil,
       '(/(?<a>.*)/)',
       '(;/(?<a>.*)/)',
       '(%s();/(?<a>.*)/)',
       '(%w();/(?<a>.*)/)',
       '(1; (2; 3; (4; /(?<a>.*)/)))',
       '(1+1; /(?<a>.*)/)',
-    ].each do |code|
+    ) do |code, pass|
       token = Random.bytes(4).unpack1("H*")
-      begin
-        $VERBOSE, verbose_bak = nil, $VERBOSE
+      if pass
         assert_equal(token, eval("#{code} =~ #{token.dump}; a"))
-      ensure
-        $VERBOSE = verbose_bak
+      else
+        assert_nil(eval("#{code} =~ #{token.dump}; defined?(a)"), code)
       end
     end
   end


### PR DESCRIPTION
Literals that are simply enclosed in parentheses are also considered non-direct.