### PR TITLE
[PRISM] Refactor scope depth, and fix POST_EXECUTION_NODE

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1398,6 +1398,7 @@ pm_scope_node_init(const pm_node_t *node, pm_scope_node_t *scope, pm_scope_node_
         case PM_POST_EXECUTION_NODE: {
             pm_post_execution_node_t *cast = (pm_post_execution_node_t *) node;
             scope->body = (pm_node_t *) cast->statements;
+            scope->local_depth_offset += 2;
             break;
         }
         case PM_PROGRAM_NODE: {

--- a/prism_compile.h
+++ b/prism_compile.h
@@ -13,6 +13,11 @@ typedef struct pm_scope_node {
 
     ID *constants;
     st_table *index_lookup_table;
+
+    // Some locals are defined at higher scopes than they are used. We can use
+    // this offset to control which parent scopes local table we should be
+    // referencing from the current scope.
+    unsigned int local_depth_offset;
 } pm_scope_node_t;
 
 void pm_scope_node_init(const pm_node_t *node, pm_scope_node_t *scope, pm_scope_node_t *previous, pm_parser_t *parser);

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -737,6 +737,16 @@ module Prism
         end
         a + b + c
       CODE
+      assert_prism_eval(<<~CODE)
+        foo = 1
+        begin
+        ensure
+          begin
+          ensure
+            foo.nil?
+          end
+        end
+      CODE
     end
 
     def test_NextNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -883,6 +883,8 @@ module Prism
       assert_prism_eval("END { 1 }")
       assert_prism_eval("END { @b }; @b = 1")
       assert_prism_eval("END { @b; 0 }; @b = 1")
+      assert_prism_eval("foo = 1; END { foo.nil? }")
+      assert_prism_eval("foo = 1; END { END { foo.nil? }}")
     end
 
     def test_ProgramNode


### PR DESCRIPTION
This PR implements a slightly different approach to fix the local depth issues seen in ensure nodes and rescue nodes amongst others. Instead of passing a `depth` value by reference and then incrementing it every time we look up the scope tree, instead let's specify an offset directly inside the scope node itself - that way we can track offsets explicitly for nodes that need it.

This PR then uses this approach to fix the local lookup bug in POST_EXECUTION_NODES by providing the correct offset when creating the relevant scope node.

This fixes this code:

```
foo = 1
END { puts foo }
```