### PR TITLE
Make expandarray compaction safe

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -498,10 +498,11 @@ expandarray
 (rb_num_t num, rb_num_t flag)
 (..., VALUE ary)
 (...)
+// attr bool handles_sp = true;
 // attr bool leaf = false; /* has rb_check_array_type() */
 // attr rb_snum_t sp_inc = (rb_snum_t)num - 1 + (flag & 1 ? 1 : 0);
 {
-    vm_expandarray(GET_SP(), ary, num, (int)flag);
+    vm_expandarray(GET_CFP(), ary, num, (int)flag);
 }
 
 /* concat two arrays */


### PR DESCRIPTION
The expandarray instruction can allocate an array, which can trigger a GC compaction. However, since it does not increment the sp until the end of the instruction, the objects it places on the stack are not marked or reference updated by the GC, which can cause the objects to move which leaves broken or incorrect objects on the stack.

This commit changes the instruction to be handles_sp so the sp is incremented inside of the instruction right after the object is written on the stack.