### PR TITLE
[PRISM] Fix behavior of BlockParameters with only one parameter

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -847,6 +847,15 @@ module Prism
       assert_prism_eval("[].tap { _1 }")
 
       assert_prism_eval("[].each { |a,| }")
+
+      assert_prism_eval("[[]].map { |a| a }")
+      assert_prism_eval("[[]].map { |a| a }")
+      assert_prism_eval("[[]].map { |a, &block| a }")
+      assert_prism_eval("[[]].map { |a, &block| a }")
+      assert_prism_eval("[{}].map { |a,| }")
+      assert_prism_eval("[[]].map { |a,b=1| a }")
+      assert_prism_eval("[{}].map { |a,| }")
+      assert_prism_eval("[{}].map { |a| a }")
     end
 
     def test_ClassNode


### PR DESCRIPTION
This commit sets the ambiguous param flag if there is only one parameter on a block node. It also fixes a small bug with a trailing comma on params.