### PR TITLE
Fix test: Relax test conditions to velify Socket::ResolutionError#error_code

### DIFF
--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -771,13 +771,10 @@ class TestSocket < Test::Unit::TestCase
   end
 
   def test_resolurion_error_error_code
-    # https://rubyci.s3.amazonaws.com/freebsd12/ruby-master/log/20231130T103002Z.fail.html.gz
-    omit if /freebsd/ =~ RUBY_PLATFORM
-
     begin
-      Socket.getaddrinfo("www.kame.net", 80, "AF_UNIX")
+      Socket.getaddrinfo("example.com", 80, "AF_UNIX")
     rescue => e
-      assert_equal(Socket::EAI_FAMILY, e.error_code)
+      assert_equal([Socket::EAI_FAMILY, Socket::EAI_FAIL].include?(e.error_code), true)
     end
   end
 

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -774,7 +774,7 @@ class TestSocket < Test::Unit::TestCase
     begin
       Socket.getaddrinfo("example.com", 80, "AF_UNIX")
     rescue => e
-      assert_equal([Socket::EAI_FAMILY, Socket::EAI_FAIL].include?(e.error_code), true)
+      assert_include([Socket::EAI_FAMILY, Socket::EAI_FAIL], e.error_code)
     end
   end
 


### PR DESCRIPTION
The test for Socket::ResolutionError#error_code fails in the FreeBSD environment with this test condition. Because Socket::ResolutionError#error_code returns Socket::EAI_FAIL instead of Socket::EAI_FAMILY.
ref: https://rubyci.s3.amazonaws.com/freebsd12/ruby-master/log/20231130T103002Z.fail.html.gz

This PR avoids the test failure by relaxing the condition.

Also changed the domain for testing to `example.com`.