### PR TITLE
[PRISM] Use depth_offset for FOR Node

### DIFF
--- a/prism/parser.h
+++ b/prism/parser.h
@@ -475,13 +475,6 @@ typedef struct pm_scope {
      * about how many numbered parameters exist.
      */
     uint32_t numbered_parameters;
-
-    /**
-     * A transparent scope is a scope that cannot have locals set on itself.
-     * When a local is set on this scope, it will instead be set on the parent
-     * scope's local table.
-     */
-    bool transparent;
 } pm_scope_t;
 
 /**

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1375,6 +1375,7 @@ pm_scope_node_init(const pm_node_t *node, pm_scope_node_t *scope, pm_scope_node_
         case PM_FOR_NODE: {
             pm_for_node_t *cast = (pm_for_node_t *)node;
             scope->body = (pm_node_t *)cast->statements;
+            scope->local_depth_offset += 1;
             break;
         }
         case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE: {

--- a/test/prism/snapshots/for.txt
+++ b/test/prism/snapshots/for.txt
@@ -7,7 +7,7 @@
         │   ├── index:
         │   │   @ LocalVariableTargetNode (location: (1,4)-(1,5))
         │   │   ├── name: :i
-        │   │   └── depth: 1
+        │   │   └── depth: 0
         │   ├── collection:
         │   │   @ RangeNode (location: (1,9)-(1,14))
         │   │   ├── left:
@@ -23,7 +23,7 @@
         │   │   └── body: (length: 1)
         │   │       └── @ LocalVariableReadNode (location: (2,0)-(2,1))
         │   │           ├── name: :i
-        │   │           └── depth: 1
+        │   │           └── depth: 0
         │   ├── for_keyword_loc: (1,0)-(1,3) = "for"
         │   ├── in_keyword_loc: (1,6)-(1,8) = "in"
         │   ├── do_keyword_loc: ∅
@@ -32,7 +32,7 @@
         │   ├── index:
         │   │   @ LocalVariableTargetNode (location: (5,4)-(5,5))
         │   │   ├── name: :i
-        │   │   └── depth: 1
+        │   │   └── depth: 0
         │   ├── collection:
         │   │   @ RangeNode (location: (5,9)-(5,14))
         │   │   ├── left:
@@ -48,7 +48,7 @@
         │   │   └── body: (length: 1)
         │   │       └── @ LocalVariableReadNode (location: (5,16)-(5,17))
         │   │           ├── name: :i
-        │   │           └── depth: 1
+        │   │           └── depth: 0
         │   ├── for_keyword_loc: (5,0)-(5,3) = "for"
         │   ├── in_keyword_loc: (5,6)-(5,8) = "in"
         │   ├── do_keyword_loc: ∅
@@ -59,10 +59,10 @@
         │   │   ├── lefts: (length: 2)
         │   │   │   ├── @ LocalVariableTargetNode (location: (7,4)-(7,5))
         │   │   │   │   ├── name: :i
-        │   │   │   │   └── depth: 1
+        │   │   │   │   └── depth: 0
         │   │   │   └── @ LocalVariableTargetNode (location: (7,6)-(7,7))
         │   │   │       ├── name: :j
-        │   │   │       └── depth: 1
+        │   │   │       └── depth: 0
         │   │   ├── rest: ∅
         │   │   ├── rights: (length: 0)
         │   │   ├── lparen_loc: ∅
@@ -82,7 +82,7 @@
         │   │   └── body: (length: 1)
         │   │       └── @ LocalVariableReadNode (location: (8,0)-(8,1))
         │   │           ├── name: :i
-        │   │           └── depth: 1
+        │   │           └── depth: 0
         │   ├── for_keyword_loc: (7,0)-(7,3) = "for"
         │   ├── in_keyword_loc: (7,8)-(7,10) = "in"
         │   ├── do_keyword_loc: ∅
@@ -93,13 +93,13 @@
         │   │   ├── lefts: (length: 3)
         │   │   │   ├── @ LocalVariableTargetNode (location: (11,4)-(11,5))
         │   │   │   │   ├── name: :i
-        │   │   │   │   └── depth: 1
+        │   │   │   │   └── depth: 0
         │   │   │   ├── @ LocalVariableTargetNode (location: (11,6)-(11,7))
         │   │   │   │   ├── name: :j
-        │   │   │   │   └── depth: 1
+        │   │   │   │   └── depth: 0
         │   │   │   └── @ LocalVariableTargetNode (location: (11,8)-(11,9))
         │   │   │       ├── name: :k
-        │   │   │       └── depth: 1
+        │   │   │       └── depth: 0
         │   │   ├── rest: ∅
         │   │   ├── rights: (length: 0)
         │   │   ├── lparen_loc: ∅
@@ -119,7 +119,7 @@
         │   │   └── body: (length: 1)
         │   │       └── @ LocalVariableReadNode (location: (12,0)-(12,1))
         │   │           ├── name: :i
-        │   │           └── depth: 1
+        │   │           └── depth: 0
         │   ├── for_keyword_loc: (11,0)-(11,3) = "for"
         │   ├── in_keyword_loc: (11,10)-(11,12) = "in"
         │   ├── do_keyword_loc: ∅
@@ -128,7 +128,7 @@
         │   ├── index:
         │   │   @ LocalVariableTargetNode (location: (15,4)-(15,5))
         │   │   ├── name: :i
-        │   │   └── depth: 1
+        │   │   └── depth: 0
         │   ├── collection:
         │   │   @ RangeNode (location: (15,9)-(15,14))
         │   │   ├── left:
@@ -144,7 +144,7 @@
         │   │   └── body: (length: 1)
         │   │       └── @ LocalVariableReadNode (location: (16,0)-(16,1))
         │   │           ├── name: :i
-        │   │           └── depth: 1
+        │   │           └── depth: 0
         │   ├── for_keyword_loc: (15,0)-(15,3) = "for"
         │   ├── in_keyword_loc: (15,6)-(15,8) = "in"
         │   ├── do_keyword_loc: (15,15)-(15,17) = "do"
@@ -153,7 +153,7 @@
             ├── index:
             │   @ LocalVariableTargetNode (location: (19,4)-(19,5))
             │   ├── name: :i
-            │   └── depth: 1
+            │   └── depth: 0
             ├── collection:
             │   @ RangeNode (location: (19,9)-(19,14))
             │   ├── left:
@@ -169,7 +169,7 @@
             │   └── body: (length: 1)
             │       └── @ LocalVariableReadNode (location: (19,16)-(19,17))
             │           ├── name: :i
-            │           └── depth: 1
+            │           └── depth: 0
             ├── for_keyword_loc: (19,0)-(19,3) = "for"
             ├── in_keyword_loc: (19,6)-(19,8) = "in"
             ├── do_keyword_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/for.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/for.txt
@@ -16,7 +16,7 @@
         │   │   │       ├── index:
         │   │   │       │   @ LocalVariableTargetNode (location: (1,8)-(1,9))
         │   │   │       │   ├── name: :a
-        │   │   │       │   └── depth: 1
+        │   │   │       │   └── depth: 0
         │   │   │       ├── collection:
         │   │   │       │   @ CallNode (location: (1,13)-(1,16))
         │   │   │       │   ├── receiver: ∅
@@ -53,7 +53,7 @@
         │   ├── index:
         │   │   @ LocalVariableTargetNode (location: (4,4)-(4,5))
         │   │   ├── name: :a
-        │   │   └── depth: 1
+        │   │   └── depth: 0
         │   ├── collection:
         │   │   @ CallNode (location: (4,9)-(4,12))
         │   │   ├── receiver: ∅
@@ -88,14 +88,14 @@
         │   │   ├── lefts: (length: 1)
         │   │   │   └── @ LocalVariableTargetNode (location: (7,5)-(7,6))
         │   │   │       ├── name: :a
-        │   │   │       └── depth: 1
+        │   │   │       └── depth: 0
         │   │   ├── rest:
         │   │   │   @ SplatNode (location: (7,8)-(7,10))
         │   │   │   ├── operator_loc: (7,8)-(7,9) = "*"
         │   │   │   └── expression:
         │   │   │       @ LocalVariableTargetNode (location: (7,9)-(7,10))
         │   │   │       ├── name: :b
-        │   │   │       └── depth: 1
+        │   │   │       └── depth: 0
         │   │   ├── rights: (length: 0)
         │   │   ├── lparen_loc: (7,4)-(7,5) = "("
         │   │   └── rparen_loc: (7,10)-(7,11) = ")"
@@ -133,10 +133,10 @@
             │   ├── lefts: (length: 2)
             │   │   ├── @ LocalVariableTargetNode (location: (10,5)-(10,6))
             │   │   │   ├── name: :a
-            │   │   │   └── depth: 1
+            │   │   │   └── depth: 0
             │   │   └── @ LocalVariableTargetNode (location: (10,8)-(10,9))
             │   │       ├── name: :b
-            │   │       └── depth: 1
+            │   │       └── depth: 0
             │   ├── rest: ∅
             │   ├── rights: (length: 0)
             │   ├── lparen_loc: (10,4)-(10,5) = "("

--- a/test/prism/snapshots/whitequark/for.txt
+++ b/test/prism/snapshots/whitequark/for.txt
@@ -7,7 +7,7 @@
         │   ├── index:
         │   │   @ LocalVariableTargetNode (location: (1,4)-(1,5))
         │   │   ├── name: :a
-        │   │   └── depth: 1
+        │   │   └── depth: 0
         │   ├── collection:
         │   │   @ CallNode (location: (1,9)-(1,12))
         │   │   ├── receiver: ∅
@@ -33,7 +33,7 @@
         │   │           │   ├── arguments: (length: 1)
         │   │           │   │   └── @ LocalVariableReadNode (location: (1,18)-(1,19))
         │   │           │   │       ├── name: :a
-        │   │           │   │       └── depth: 1
+        │   │           │   │       └── depth: 0
         │   │           │   └── flags: ∅
         │   │           ├── closing_loc: ∅
         │   │           ├── block: ∅
@@ -46,7 +46,7 @@
             ├── index:
             │   @ LocalVariableTargetNode (location: (3,4)-(3,5))
             │   ├── name: :a
-            │   └── depth: 1
+            │   └── depth: 0
             ├── collection:
             │   @ CallNode (location: (3,9)-(3,12))
             │   ├── receiver: ∅
@@ -72,7 +72,7 @@
             │           │   ├── arguments: (length: 1)
             │           │   │   └── @ LocalVariableReadNode (location: (3,16)-(3,17))
             │           │   │       ├── name: :a
-            │           │   │       └── depth: 1
+            │           │   │       └── depth: 0
             │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅

--- a/test/prism/snapshots/whitequark/for_mlhs.txt
+++ b/test/prism/snapshots/whitequark/for_mlhs.txt
@@ -9,10 +9,10 @@
             │   ├── lefts: (length: 2)
             │   │   ├── @ LocalVariableTargetNode (location: (1,4)-(1,5))
             │   │   │   ├── name: :a
-            │   │   │   └── depth: 1
+            │   │   │   └── depth: 0
             │   │   └── @ LocalVariableTargetNode (location: (1,7)-(1,8))
             │   │       ├── name: :b
-            │   │       └── depth: 1
+            │   │       └── depth: 0
             │   ├── rest: ∅
             │   ├── rights: (length: 0)
             │   ├── lparen_loc: ∅
@@ -42,10 +42,10 @@
             │           │   ├── arguments: (length: 2)
             │           │   │   ├── @ LocalVariableReadNode (location: (1,19)-(1,20))
             │           │   │   │   ├── name: :a
-            │           │   │   │   └── depth: 1
+            │           │   │   │   └── depth: 0
             │           │   │   └── @ LocalVariableReadNode (location: (1,22)-(1,23))
             │           │   │       ├── name: :b
-            │           │   │       └── depth: 1
+            │           │   │       └── depth: 0
             │           │   └── flags: ∅
             │           ├── closing_loc: ∅
             │           ├── block: ∅


### PR DESCRIPTION
This PR removes the transparent scope node mechanism that we implemented inside Prism to deal with the local lookup offset caused by FOR node's pushing scopes and instead uses the depth_offset mechanism recently introduced inside the CRuby prism compiler.