### PR TITLE
[PRISM] Restructure parameters

### DIFF
--- a/prism_compile.h
+++ b/prism_compile.h
@@ -11,6 +11,14 @@ typedef struct pm_scope_node {
     pm_constant_id_list_t locals;
     pm_parser_t *parser;
 
+    // There are sometimes when we need to track
+    // hidden variables that we have put on
+    // the local table for the stack to use, so
+    // that we properly account for them when giving
+    // local indexes. We do this with the
+    // hidden_variable_count
+    int hidden_variable_count;
+
     ID *constants;
     st_table *index_lookup_table;
 

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -815,7 +815,17 @@ module Prism
       assert_prism_eval("def self.prism_test_def_node(x,y,z=7,*a) a end; prism_test_def_node(7,7).inspect")
       assert_prism_eval("def self.prism_test_def_node(x,y,z=7,zz=7,*a) a end; prism_test_def_node(7,7,7).inspect")
 
-      # block argument
+      # keyword arguments
+      assert_prism_eval("def self.prism_test_def_node(a: 1, b: 2, c: 4) a + b + c; end; prism_test_def_node(a: 2)")
+      assert_prism_eval("def self.prism_test_def_node(a: 1, b: 2, c: 4) a + b + c; end; prism_test_def_node(b: 3)")
+      assert_prism_eval(<<-CODE)
+        def self.prism_test_def_node(x = 1, y, a: 8, b: 2, c: 4)
+          a + b + c + x + y
+        end
+        prism_test_def_node(10, b: 3)
+      CODE
+
+      # block arguments
       assert_prism_eval("def self.prism_test_def_node(&block) block end; prism_test_def_node{}.class")
       assert_prism_eval("def self.prism_test_def_node(&block) block end; prism_test_def_node().inspect")
       assert_prism_eval("def self.prism_test_def_node(a,b=7,*c,&block) b end; prism_test_def_node(7,1).inspect")
@@ -846,6 +856,27 @@ module Prism
     def test_method_parameters
       assert_prism_eval(<<-CODE)
         def self.prism_test_method_parameters(a, b=1, *c, d:, e: 2, **f, &g)
+        end
+
+        method(:prism_test_method_parameters).parameters
+      CODE
+
+      assert_prism_eval(<<-CODE)
+        def self.prism_test_method_parameters(d:, e: 2, **f, &g)
+        end
+
+        method(:prism_test_method_parameters).parameters
+      CODE
+
+      assert_prism_eval(<<-CODE)
+        def self.prism_test_method_parameters(**f, &g)
+        end
+
+        method(:prism_test_method_parameters).parameters
+      CODE
+
+      assert_prism_eval(<<-CODE)
+        def self.prism_test_method_parameters(&g)
         end
 
         method(:prism_test_method_parameters).parameters


### PR DESCRIPTION
Prior to this commit, we weren't accounting for hidden variables on the locals table, so we would have inconsistencies on the stack. This commit fixes params, and introduces a hidden_variable_count on the scope, both of which fix parameters.