### PR TITLE
[PRISM] Account for RescueNodes with no statements

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3658,9 +3658,14 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             ADD_GETLOCAL(ret, &dummy_line_node, LVAR_ERRINFO, 0);
             PM_COMPILE((pm_node_t *)rescue_node->reference);
         }
+
         if (rescue_node->statements) {
             PM_COMPILE((pm_node_t *)rescue_node->statements);
         }
+        else {
+            PM_PUTNIL;
+        }
+
         ADD_INSN(ret, &dummy_line_node, leave);
         ADD_LABEL(ret, rescue_end);
 

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -794,6 +794,12 @@ module Prism
       CODE
       assert_prism_eval(<<~CODE)
         begin
+          raise StandardError
+        rescue StandardError => e
+        end
+      CODE
+      assert_prism_eval(<<~CODE)
+        begin
           1
         rescue StandardError => e
           e


### PR DESCRIPTION
We need a PUTNIL if a RescueNode has no statements.