### PR TITLE
[Prism] Implement paren node for `defined?`

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1442,10 +1442,10 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
     // in_condition is the same as compile.c's needstr
     enum defined_type dtype = DEFINED_NOT_DEFINED;
     switch (PM_NODE_TYPE(node)) {
-      case PM_NIL_NODE: {
+      case PM_NIL_NODE:
+      case PM_PARENTHESES_NODE:
         dtype = DEFINED_NIL;
         break;
-      }
       case PM_SELF_NODE:
         dtype = DEFINED_SELF;
         break;

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -150,6 +150,8 @@ module Prism
       assert_prism_eval("x = 1; defined? x ||= 1")
 
       assert_prism_eval("if defined? A; end")
+
+      assert_prism_eval("defined?(())")
     end
 
     def test_GlobalVariableReadNode


### PR DESCRIPTION
Implements and adds a test for passing a parentheses node to `defined?`.

cc/ @tenderlove 