### PR TITLE
[Fix] Support when nil is assigned to variable `name`

### DIFF
--- a/lib/ruby_vm/rjit/c_pointer.rb
+++ b/lib/ruby_vm/rjit/c_pointer.rb
@@ -338,7 +338,7 @@ module RubyVM::RJIT
 
     # Give a name to a dynamic CPointer class to see it on inspect
     def self.with_class_name(prefix, name, cache: false, &block)
-      return block.call if name.empty?
+      return block.call if !name.nil? && name.empty?
 
       # Use a cached result only if cache: true
       class_name = "#{prefix}_#{name}"


### PR DESCRIPTION
If we run the test `test/ruby/test_optimization.rb` in the following environment, it will fail.

* OS: Ubuntu 22.04
* Compiler: gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0

error log:
````
   1) Failure:
TestRubyOptimization#test_objtostring [/home/jinroq/dev/ruby/ruby/test/ruby/test_optimization.rb:938]:
assert_separately failed with error message
pid 3585101 exit 1
| /home/jinroq/dev/ruby/ruby/lib/ruby_vm/rjit/c_pointer.rb:343:in `with_class_name': undefined method `empty?' for nil (NoMethodError)
````