### PR TITLE
[DOC] Refine timezones doc links

### DIFF
--- a/doc/_timezones.rdoc
+++ b/doc/_timezones.rdoc
@@ -1,5 +1,3 @@
-= Timezones
-
 == Timezone Specifiers
 
 Certain \Time methods accept arguments that specify timezones:
@@ -13,11 +11,11 @@ Certain \Time methods accept arguments that specify timezones:
 The value given with any of these must be one of the following
 (each detailed below):
 
-- {Hours/minutes offset}[rdoc-ref:timezones.rdoc@Hours-2FMinutes+Offsets].
-- {Single-letter offset}[rdoc-ref:timezones.rdoc@Single-Letter+Offsets].
-- {Integer offset}[rdoc-ref:timezones.rdoc@Integer+Offsets].
-- {Timezone object}[rdoc-ref:timezones.rdoc@Timezone+Objects].
-- {Timezone name}[rdoc-ref:timezones.rdoc@Timezone+Names].
+- {Hours/minutes offset}[rdoc-ref:Time@Hours-2FMinutes+Offsets].
+- {Single-letter offset}[rdoc-ref:Time@Single-Letter+Offsets].
+- {Integer offset}[rdoc-ref:Time@Integer+Offsets].
+- {Timezone object}[rdoc-ref:Time@Timezone+Objects].
+- {Timezone name}[rdoc-ref:Time@Timezone+Names].
 
 === Hours/Minutes Offsets
 

--- a/doc/_timezones.rdoc
+++ b/doc/_timezones.rdoc
@@ -1,6 +1,6 @@
 == Timezone Specifiers
 
-Certain \Time methods accept arguments that specify timezones:
+Certain +Time+ methods accept arguments that specify timezones:
 
 - Time.at: keyword argument +in:+.
 - Time.new: positional argument +zone+ or keyword argument +in:+.

--- a/time.c
+++ b/time.c
@@ -4075,7 +4075,7 @@ time_zonelocal(VALUE time, VALUE off)
  *    t.localtime("-09:00")               # => 2000-01-01 11:15:01 -0900
  *
  *  For forms of argument +zone+, see
- *  {Timezone Specifiers}[rdoc-ref:timezones.rdoc].
+ *  {Timezone Specifiers}[rdoc-ref:Time@Timezone+Specifiers].
  *
  */
 
@@ -4176,7 +4176,7 @@ time_fixoff(VALUE time)
  *    t.getlocal('+12:00')                  # => 2000-01-01 12:00:00 +1200
  *
  *  For forms of argument +zone+, see
- *  {Timezone Specifiers}[rdoc-ref:timezones.rdoc].
+ *  {Timezone Specifiers}[rdoc-ref:Time@Timezone+Specifiers].
  *
  */
 

--- a/time.c
+++ b/time.c
@@ -3584,7 +3584,7 @@ tmcmp(struct tm *a, struct tm *b)
  *   Time.utc(year, month = 1, mday = 1, hour = 0, min = 0, sec = 0, usec = 0) -> new_time
  *   Time.utc(sec, min, hour, mday, month, year, dummy, dummy, dummy, dummy) -> new_time
  *
- * Returns a new \Time object based the on given arguments,
+ * Returns a new +Time+ object based the on given arguments,
  * in the UTC timezone.
  *
  * With one to seven arguments given,
@@ -3662,7 +3662,7 @@ tmcmp(struct tm *a, struct tm *b)
  *   # => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
  *   Time.utc(*a) # => 0005-04-03 02:01:00 UTC
  *
- * This form is useful for creating a \Time object from a 10-element
+ * This form is useful for creating a +Time+ object from a 10-element
  * array returned by Time.to_a:
  *
  *   t = Time.new(2000, 1, 2, 3, 4, 5, 6) # => 2000-01-02 03:04:05 +000006
@@ -3693,7 +3693,7 @@ time_s_mkutc(int argc, VALUE *argv, VALUE klass)
  *   Time.local(year, month = 1, mday = 1, hour = 0, min = 0, sec = 0, usec = 0) -> new_time
  *   Time.local(sec, min, hour, mday, month, year, dummy, dummy, dummy, dummy) -> new_time
  *
- * Like Time.utc, except that the returned \Time object
+ * Like Time.utc, except that the returned +Time+ object
  * has the local timezone, not the UTC timezone:
  *
  *   # With seven arguments.
@@ -3922,7 +3922,7 @@ time_cmp(VALUE time1, VALUE time2)
  *   eql?(other_time)
  *
  * Returns +true+ if +self+ and +other_time+ are
- * both \Time objects with the exact same time value.
+ * both +Time+ objects with the exact same time value.
  */
 
 static VALUE
@@ -4062,13 +4062,13 @@ time_zonelocal(VALUE time, VALUE off)
  *  With no argument given:
  *
  *  - Returns +self+ if +self+ is a local time.
- *  - Otherwise returns a new \Time in the user's local timezone:
+ *  - Otherwise returns a new +Time+ in the user's local timezone:
  *
  *      t = Time.utc(2000, 1, 1, 20, 15, 1) # => 2000-01-01 20:15:01 UTC
  *      t.localtime                         # => 2000-01-01 14:15:01 -0600
  *
  *  With argument +zone+ given,
- *  returns the new \Time object created by converting
+ *  returns the new +Time+ object created by converting
  *  +self+ to the given time zone:
  *
  *    t = Time.utc(2000, 1, 1, 20, 15, 1) # => 2000-01-01 20:15:01 UTC
@@ -4102,7 +4102,7 @@ time_localtime_m(int argc, VALUE *argv, VALUE time)
  *    t.utc              # => 2000-01-01 06:00:00 UTC
  *    t.utc?             # => true
  *
- *  Related: Time#getutc (returns a new converted \Time object).
+ *  Related: Time#getutc (returns a new converted +Time+ object).
  */
 
 static VALUE
@@ -4167,7 +4167,7 @@ time_fixoff(VALUE time)
  *  call-seq:
  *    getlocal(zone = nil) -> new_time
  *
- *  Returns a new \Time object representing the value of +self+
+ *  Returns a new +Time+ object representing the value of +self+
  *  converted to a given timezone;
  *  if +zone+ is +nil+, the local timezone is used:
  *
@@ -4216,7 +4216,7 @@ time_getlocaltime(int argc, VALUE *argv, VALUE time)
  *  call-seq:
  *    getutc -> new_time
  *
- *  Returns a new \Time object representing the value of +self+
+ *  Returns a new +Time+ object representing the value of +self+
  *  converted to the UTC timezone:
  *
  *    local = Time.local(2000) # => 2000-01-01 00:00:00 -0600
@@ -4381,7 +4381,7 @@ time_add(const struct time_object *tobj, VALUE torig, VALUE offset, int sign)
  *  call-seq:
  *    self + numeric -> new_time
  *
- *  Returns a new \Time object whose value is the sum of the numeric value
+ *  Returns a new +Time+ object whose value is the sum of the numeric value
  *  of +self+ and the given +numeric+:
  *
  *    t = Time.new(2000) # => 2000-01-01 00:00:00 -0600
@@ -4409,7 +4409,7 @@ time_plus(VALUE time1, VALUE time2)
  *    self - other_time -> float
  *
  *  When +numeric+ is given,
- *  returns a new \Time object whose value is the difference
+ *  returns a new +Time+ object whose value is the difference
  *  of the numeric value of +self+ and +numeric+:
  *
  *    t = Time.new(2000) # => 2000-01-01 00:00:00 -0600
@@ -4459,7 +4459,7 @@ ndigits_denominator(VALUE ndigits)
  * call-seq:
  *   round(ndigits = 0) -> new_time
  *
- * Returns a new \Time object whose numeric value is that of +self+,
+ * Returns a new +Time+ object whose numeric value is that of +self+,
  * with its seconds value rounded to precision +ndigits+:
  *
  *   t = Time.utc(2010, 3, 30, 5, 43, 25.123456789r)
@@ -4508,7 +4508,7 @@ time_round(int argc, VALUE *argv, VALUE time)
  * call-seq:
  *   floor(ndigits = 0) -> new_time
  *
- * Returns a new \Time object whose numerical value
+ * Returns a new +Time+ object whose numerical value
  * is less than or equal to +self+ with its seconds
  * truncated to precision +ndigits+:
  *
@@ -4553,7 +4553,7 @@ time_floor(int argc, VALUE *argv, VALUE time)
  * call-seq:
  *   ceil(ndigits = 0)   -> new_time
  *
- * Returns a new \Time object whose numerical value
+ * Returns a new +Time+ object whose numerical value
  * is greater than or equal to +self+ with its seconds
  * truncated to precision +ndigits+:
  *
@@ -5015,7 +5015,7 @@ rb_time_utc_offset(VALUE time)
  *    #    [sec, min, hour, day, mon, year, wday, yday, dst?,   zone]
  *
  *  The returned array is suitable for use as an argument to Time.utc or Time.local
- *  to create a new \Time object.
+ *  to create a new +Time+ object.
  *
  */
 

--- a/timev.rb
+++ b/timev.rb
@@ -66,7 +66,7 @@
 #
 #   Time.new(2002, 10, 31, 2, 2, 2, "+02:00") #=> 2002-10-31 02:02:02 +0200
 #
-# Or {a timezone object}[rdoc-ref:timezones.rdoc@Timezone+Objects]:
+# Or {a timezone object}[rdoc-ref:Time@Timezone+Objects]:
 #
 #   zone = timezone("Europe/Athens")      # Eastern European Time, UTC+2
 #   Time.new(2002, 10, 31, 2, 2, 2, zone) #=> 2002-10-31 02:02:02 +0200
@@ -210,7 +210,9 @@
 # - #floor: Returns a new time with subseconds lowered to a floor.
 #
 # For the forms of argument +zone+, see
-# {Timezone Specifiers}[rdoc-ref:timezones.rdoc].
+# {Timezone Specifiers}[rdoc-ref:Time@Timezone+Specifiers].
+#
+# :include: doc/_timezones.rdoc
 class Time
   # Creates a new \Time object from the current system time.
   # This is the same as Time.new without arguments.
@@ -219,7 +221,7 @@ class Time
   #    Time.now(in: '+04:00') # => 2009-06-24 07:39:54 +0400
   #
   # For forms of argument +zone+, see
-  # {Timezone Specifiers}[rdoc-ref:timezones.rdoc].
+  # {Timezone Specifiers}[rdoc-ref:Time@Timezone+Specifiers].
   def self.now(in: nil)
     Primitive.time_s_now(Primitive.arg!(:in))
   end
@@ -277,7 +279,7 @@ class Time
   #   Time.at(secs, in: '-12:00') # => 2000-12-31 17:59:59 -1200
   #
   # For the forms of argument +zone+, see
-  # {Timezone Specifiers}[rdoc-ref:timezones.rdoc].
+  # {Timezone Specifiers}[rdoc-ref:Time@Timezone+Specifiers].
   #
   def self.at(time, subsec = false, unit = :microsecond, in: nil)
     if Primitive.mandatory_only?
@@ -371,7 +373,7 @@ class Time
   # When positional argument +zone+ or keyword argument +in:+ is given,
   # the new \Time object is in the specified timezone.
   # For the forms of argument +zone+, see
-  # {Timezone Specifiers}[rdoc-ref:timezones.rdoc]:
+  # {Timezone Specifiers}[rdoc-ref:Time@Timezone+Specifiers]:
   #
   #   Time.new(2000, 1, 1, 0, 0, 0, '+12:00')
   #   # => 2000-01-01 00:00:00 +1200

--- a/timev.rb
+++ b/timev.rb
@@ -1,4 +1,4 @@
-# A \Time object represents a date and time:
+# A +Time+ object represents a date and time:
 #
 #   Time.new(2000, 1, 1, 0, 0, 0) # => 2000-01-01 00:00:00 -0600
 #
@@ -41,7 +41,7 @@
 #
 # == \Time Resolution
 #
-# A \Time object derived from the system clock
+# A +Time+ object derived from the system clock
 # (for example, by method Time.now)
 # has the resolution supported by the system.
 #
@@ -49,7 +49,7 @@
 #
 # All of these examples were done using the EST timezone which is GMT-5.
 #
-# === Creating a New \Time Instance
+# === Creating a New +Time+ Instance
 #
 # You can create a new instance of Time with Time.new. This will use the
 # current system time. Time.now is an alias for this. You can also
@@ -81,7 +81,7 @@
 #
 #   Time.at(628232400) #=> 1989-11-28 00:00:00 -0500
 #
-# === Working with an Instance of \Time
+# === Working with an Instance of +Time+
 #
 # Once you have an instance of Time there is a multitude of things you can
 # do with it. Below are some examples. For all of the following examples, we
@@ -123,19 +123,19 @@
 #
 # == What's Here
 #
-# First, what's elsewhere. \Class \Time:
+# First, what's elsewhere. \Class +Time+:
 #
 # - Inherits from {class Object}[rdoc-ref:Object@What-27s+Here].
 # - Includes {module Comparable}[rdoc-ref:Comparable@What-27s+Here].
 #
-# Here, class \Time provides methods that are useful for:
+# Here, class +Time+ provides methods that are useful for:
 #
-# - {Creating \Time objects}[rdoc-ref:Time@Methods+for+Creating].
-# - {Fetching \Time values}[rdoc-ref:Time@Methods+for+Fetching].
-# - {Querying a \Time object}[rdoc-ref:Time@Methods+for+Querying].
-# - {Comparing \Time objects}[rdoc-ref:Time@Methods+for+Comparing].
-# - {Converting a \Time object}[rdoc-ref:Time@Methods+for+Converting].
-# - {Rounding a \Time}[rdoc-ref:Time@Methods+for+Rounding].
+# - {Creating +Time+ objects}[rdoc-ref:Time@Methods+for+Creating].
+# - {Fetching +Time+ values}[rdoc-ref:Time@Methods+for+Fetching].
+# - {Querying a +Time+ object}[rdoc-ref:Time@Methods+for+Querying].
+# - {Comparing +Time+ objects}[rdoc-ref:Time@Methods+for+Comparing].
+# - {Converting a +Time+ object}[rdoc-ref:Time@Methods+for+Converting].
+# - {Rounding a +Time+}[rdoc-ref:Time@Methods+for+Rounding].
 #
 # === Methods for Creating
 #
@@ -214,7 +214,7 @@
 #
 # :include: doc/_timezones.rdoc
 class Time
-  # Creates a new \Time object from the current system time.
+  # Creates a new +Time+ object from the current system time.
   # This is the same as Time.new without arguments.
   #
   #    Time.now               # => 2009-06-24 12:39:54 +0900
@@ -226,11 +226,11 @@ class Time
     Primitive.time_s_now(Primitive.arg!(:in))
   end
 
-  # Returns a new \Time object based on the given arguments.
+  # Returns a new +Time+ object based on the given arguments.
   #
   # Required argument +time+ may be either of:
   #
-  # - A \Time object, whose value is the basis for the returned time;
+  # - A +Time+ object, whose value is the basis for the returned time;
   #   also influenced by optional keyword argument +in:+ (see below).
   # - A numeric number of
   #   {Epoch seconds}[rdoc-ref:Time@Epoch+Seconds]
@@ -292,7 +292,7 @@ class Time
   # call-seq:
   #   Time.new(year = nil, mon = nil, mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil, precision: 9)
   #
-  # Returns a new \Time object based on the given arguments,
+  # Returns a new +Time+ object based on the given arguments,
   # by default in the local timezone.
   #
   # With no positional arguments, returns the value of Time.now:
@@ -300,7 +300,7 @@ class Time
   #   Time.new # => 2021-04-24 17:27:46.0512465 -0500
   #
   # With one string argument that represents a time, returns a new
-  # \Time object based on the given argument, in the local timezone.
+  # +Time+ object based on the given argument, in the local timezone.
   #
   #   Time.new('2000-12-31 23:59:59.5')              # => 2000-12-31 23:59:59.5 -0600
   #   Time.new('2000-12-31 23:59:59.5 +0900')        # => 2000-12-31 23:59:59.5 +0900
@@ -308,7 +308,7 @@ class Time
   #   Time.new('2000-12-31 23:59:59.5')              # => 2000-12-31 23:59:59.5 -0600
   #   Time.new('2000-12-31 23:59:59.56789', precision: 3) # => 2000-12-31 23:59:59.567 -0600
   #
-  # With one to six arguments, returns a new \Time object
+  # With one to six arguments, returns a new +Time+ object
   # based on the given arguments, in the local timezone.
   #
   #   Time.new(2000, 1, 2, 3, 4, 5) # => 2000-01-02 03:04:05 -0600
@@ -371,7 +371,7 @@ class Time
   #     Time.new(*a) # => 0000-01-01 00:00:00 -0600
   #
   # When positional argument +zone+ or keyword argument +in:+ is given,
-  # the new \Time object is in the specified timezone.
+  # the new +Time+ object is in the specified timezone.
   # For the forms of argument +zone+, see
   # {Timezone Specifiers}[rdoc-ref:Time@Timezone+Specifiers]:
   #
@@ -389,7 +389,7 @@ class Time
   #   Time.new('2000-01-01 00:00:00 +0100', in: '-0500').utc_offset  # => 3600
   #
   # - +precision+: maximum effective digits in sub-second part, default is 9.
-  #   More digits will be truncated, as other operations of \Time.
+  #   More digits will be truncated, as other operations of +Time+.
   #   Ignored unless the first argument is a string.
   #
   def initialize(year = (now = true), mon = (str = year; nil), mday = nil, hour = nil, min = nil, sec = nil, zone = nil,


### PR DESCRIPTION
- [[DOC] Include timezones document in timev.rb](https://github.com/ruby/ruby/pull/9106/commits/ae3e9f114c540e78f1166f67dfb3577966f21f7f) 
  So that it can be referred as a part of the document of `Time`.

- [[DOC] Markup class name Time as code](https://github.com/ruby/ruby/pull/9106/commits/092a17e7bd97525904c2874228a7febcaea74bf7)
  Simple capitalized word "time" and the class name `Time` should be distinguished.