### PR TITLE
ruby_3_2 - [CI] windows.yml - use MSYS2 bison instead of Chocolatey

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,9 +51,7 @@ jobs:
         id: setup-msys2
         with:
           update: true
-          install: >-
-            patch
-        if: ${{ env.OS_VER != 'windows-2019' }}
+          install: bison patch
       - name: patch path
         shell: msys2 {0}
         run: echo PATCH=$(cygpath -wa $(command -v patch)) >> $GITHUB_ENV
@@ -75,19 +73,6 @@ jobs:
       - name: Install libraries with vcpkg
         run: |
           vcpkg --triplet x64-windows install libffi libyaml openssl readline zlib
-      - uses: actions/cache@c17f4bf4666a8001b1a45c09eb7a485c41aa64c3 # v3.2.0
-        with:
-          path: C:\Users\runneradmin\AppData\Local\Temp\chocolatey
-          key: ${{ runner.os }}-chocolatey-${{ env.OS_VER }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-chocolatey-${{ env.OS_VER }}-
-            ${{ runner.os }}-chocolatey-
-      - name: Install libraries with chocolatey
-        run: |
-          # Using Choco-Install for retries, but it doesn't detect failures properly
-          # if you pass multiple package names in a single command.
-          Choco-Install -PackageName winflexbison3
-        shell: pwsh
       - name: git config
         run: |
           git config --global core.autocrlf false
@@ -104,7 +89,9 @@ jobs:
       - name: setup env
         # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
         # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302
+        # msys2/setup-msys2 installs MSYS2 to D:/a/_temp/msys64/usr/bin
         run: |
+          set Path=D:/a/_temp/msys64/usr/bin;%Path%
           set VS=${{ matrix.vs }}
           set VCVARS=${{ matrix.vcvars }}
           if not "%VCVARS%" == "" goto :vcset
@@ -137,7 +124,7 @@ jobs:
       - run: nmake extract-extlibs
       - run: nmake
         env:
-          YACC: win_bison
+          YACC: bison.exe
       - run: nmake test
         timeout-minutes: 5
       - run: nmake test-spec


### PR DESCRIPTION
Fixes current failures