### PR TITLE
Add some more nodes to defined

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1478,6 +1478,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_FLOAT_NODE:
       case PM_HASH_NODE:
       case PM_INTEGER_NODE:
+      case PM_INTERPOLATED_STRING_NODE:
       case PM_LAMBDA_NODE:
       case PM_OR_NODE:
       case PM_RANGE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1478,6 +1478,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_FLOAT_NODE:
       case PM_HASH_NODE:
       case PM_INTEGER_NODE:
+      case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE:
       case PM_INTERPOLATED_STRING_NODE:
       case PM_LAMBDA_NODE:
       case PM_OR_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1443,9 +1443,18 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
     enum defined_type dtype = DEFINED_NOT_DEFINED;
     switch (PM_NODE_TYPE(node)) {
       case PM_NIL_NODE:
-      case PM_PARENTHESES_NODE:
         dtype = DEFINED_NIL;
         break;
+      case PM_PARENTHESES_NODE: {
+          pm_parentheses_node_t *parentheses_node = (pm_parentheses_node_t *) node;
+
+          if (parentheses_node->body == NULL) {
+              dtype = DEFINED_NIL;
+          } else {
+              dtype = DEFINED_EXPR;
+          }
+          break;
+      }
       case PM_SELF_NODE:
         dtype = DEFINED_SELF;
         break;

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1486,6 +1486,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_REGULAR_EXPRESSION_NODE:
       case PM_STRING_NODE:
       case PM_SYMBOL_NODE:
+      case PM_X_STRING_NODE:
         dtype = DEFINED_EXPR;
         break;
       case PM_LOCAL_VARIABLE_READ_NODE:

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -158,6 +158,7 @@ module Prism
       assert_prism_eval("if defined? A; end")
 
       assert_prism_eval("defined?(())")
+      assert_prism_eval("defined?(('1'))")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -102,6 +102,7 @@ module Prism
       assert_prism_eval("defined? [1, 2, 3]")
       assert_prism_eval("defined?({ a: 1 })")
       assert_prism_eval("defined? 'str'")
+      assert_prism_eval('defined?("#{expr}")')
       assert_prism_eval("defined? :sym")
       assert_prism_eval("defined? /foo/")
       assert_prism_eval("defined? -> { 1 + 1 }")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -110,6 +110,17 @@ module Prism
       assert_prism_eval("defined? a && b")
       assert_prism_eval("defined? a || b")
 
+      assert_prism_eval("defined? %[1,2,3]")
+      assert_prism_eval("defined? %q[1,2,3]")
+      assert_prism_eval("defined? %Q[1,2,3]")
+      assert_prism_eval("defined? %r[1,2,3]")
+      assert_prism_eval("defined? %i[1,2,3]")
+      assert_prism_eval("defined? %I[1,2,3]")
+      assert_prism_eval("defined? %w[1,2,3]")
+      assert_prism_eval("defined? %W[1,2,3]")
+      assert_prism_eval("defined? %s[1,2,3]")
+      assert_prism_eval("defined? %x[1,2,3]")
+
       assert_prism_eval("defined? @a")
       assert_prism_eval("defined? $a")
       assert_prism_eval("defined? @@a")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -105,6 +105,7 @@ module Prism
       assert_prism_eval('defined?("#{expr}")')
       assert_prism_eval("defined? :sym")
       assert_prism_eval("defined? /foo/")
+      assert_prism_eval('defined?(/#{1}/)')
       assert_prism_eval("defined? -> { 1 + 1 }")
       assert_prism_eval("defined? a && b")
       assert_prism_eval("defined? a || b")


### PR DESCRIPTION
Adds the following missing nodes and tests for `defined?`:

* Fixes `PM_PARENTHESES_NODE` - the prior PR only accounted for an empty set of parens
* Adds `PM_INTERPOLATED_REGULAR_EXPRESSION_NODE`, `PM_INTERPOLATED_STRING_NODE`, and `PM_X_STRING_NODE` to `pm_compile_defined_expr0`.
* Adds tests for all these nodes and examples found in CRuby `defined?` tests.

cc/ @tenderlove