### PR TITLE
:bug: Fixes [Bug #20039](https://bugs.ruby-lang.org/issues/20039)

### DIFF
--- a/re.c
+++ b/re.c
@@ -3853,6 +3853,10 @@ reg_copy(VALUE copy, VALUE orig)
     RB_OBJ_WRITE(copy, &RREGEXP(copy)->src, RREGEXP(orig)->src);
     RREGEXP_PTR(copy)->timelimit = RREGEXP_PTR(orig)->timelimit;
     rb_enc_copy(copy, orig);
+
+    if (RB_FL_TEST(orig, KCODE_FIXED)) RB_FL_SET(copy, KCODE_FIXED);
+    if (RB_FL_TEST(orig, REG_ENCODING_NONE)) RB_FL_SET(copy, REG_ENCODING_NONE);
+
     return copy;
 }
 

--- a/re.c
+++ b/re.c
@@ -3853,9 +3853,7 @@ reg_copy(VALUE copy, VALUE orig)
     RB_OBJ_WRITE(copy, &RREGEXP(copy)->src, RREGEXP(orig)->src);
     RREGEXP_PTR(copy)->timelimit = RREGEXP_PTR(orig)->timelimit;
     rb_enc_copy(copy, orig);
-
-    if (RB_FL_TEST(orig, KCODE_FIXED)) RB_FL_SET(copy, KCODE_FIXED);
-    if (RB_FL_TEST(orig, REG_ENCODING_NONE)) RB_FL_SET(copy, REG_ENCODING_NONE);
+    FL_SET_RAW(copy, FL_TEST_RAW(orig, KCODE_FIXED|REG_ENCODING_NONE));
 
     return copy;
 }

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1936,6 +1936,16 @@ class TestRegexp < Test::Unit::TestCase
     assert_equal("123456789".match(/(?:x?\dx?){2,}/)[0], "123456789")
   end
 
+  def test_encoding_flags_are_preserved_when_initialized_with_another_regexp
+    re = Regexp.new("\u2018hello\u2019".encode("UTF-8"))
+    str = "".encode("US-ASCII")
+
+    assert_nothing_raised do
+      str.match?(re)
+      str.match?(Regexp.new(re))
+    end
+  end
+
   def test_bug_19537 # [Bug #19537]
     str = 'aac'
     re = '^([ab]{1,3})(a?)*$'


### PR DESCRIPTION
When a Regexp is initialized with another Regexp, we simply copy the properties from the original. However, the flags on the original were not being copied correctly. This caused an issue when the original had multibyte characters and was being compared with an ASCII string. Without the forced encoding flag (`KCODE_FIXED`) transferred on to the new Regexp, the comparison would fail. See the included test for an example.