### PR TITLE
Fix SEGV caused by `GC::Profiler.raw_data`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -13264,7 +13264,7 @@ gc_profile_record_get(VALUE _)
         gc_profile_record *record = &objspace->profile.records[i];
 
         prof = rb_hash_new();
-        rb_hash_aset(prof, ID2SYM(rb_intern("GC_FLAGS")), gc_info_decode(0, rb_hash_new(), record->flags));
+        rb_hash_aset(prof, ID2SYM(rb_intern("GC_FLAGS")), gc_info_decode(objspace, rb_hash_new(), record->flags));
         rb_hash_aset(prof, ID2SYM(rb_intern("GC_TIME")), DBL2NUM(record->gc_time));
         rb_hash_aset(prof, ID2SYM(rb_intern("GC_INVOKE_TIME")), DBL2NUM(record->gc_invoke_time));
         rb_hash_aset(prof, ID2SYM(rb_intern("HEAP_USE_SIZE")), SIZET2NUM(record->heap_use_size));

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -579,6 +579,14 @@ class TestGc < Test::Unit::TestCase
     RUBY
   end
 
+  def test_profiler_raw_data
+    GC::Profiler.enable
+    GC.start
+    assert GC::Profiler.raw_data
+  ensure
+    GC::Profiler.disable
+  end
+
   def test_profiler_total_time
     GC::Profiler.enable
     GC::Profiler.clear


### PR DESCRIPTION
```
# ./miniruby -v
ruby 3.3.0dev (2023-12-05T07:38:07Z master 8bdd28da74) [x86_64-linux]

# ./miniruby -e 'GC::Profiler.enable; GC.start; GC::Profiler.raw_data'
-e:1: [BUG] Segmentation fault at 0x00000000000005a8
ruby 3.3.0dev (2023-12-05T07:38:07Z master 8bdd28da74) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0003 p:---- s:0010 e:000009 CFUNC  :raw_data
c:0002 p:0014 s:0006 e:000005 EVAL   -e:1 [FINISH]
c:0001 p:0000 s:0003 E:000670 DUMMY  [FINISH]

-- Ruby level backtrace information ----------------------------------------
-e:1:in `<main>'
-e:1:in `raw_data'

-- Threading information ---------------------------------------------------
Total ractor count: 1
Ruby thread count for this ractor: 1

-- Machine register context ------------------------------------------------
 RIP: 0x000055555565f326 RBP: 0x0000000000000004 RSP: 0x00005554fffff010
 RAX: 0x0000000000000014 RBX: 0x000000000001a408 RCX: 0x0000000000000003
 RDX: 0x0000000000040000 RDI: 0x00005554ffffef28 RSI: 0x0000000000b3710c
  R8: 0x0000000000000000  R9: 0x00007fffe44dfe80 R10: 0x00005555557566d4
 R11: 0x000055555591b310 R12: 0x0000000000000000 R13: 0x00007fffe44dfe68
 R14: 0x000000000001a408 R15: 0x00005555558f20d8 EFL: 0x0000000000000202

-- C level backtrace information -------------------------------------------
/src/miniruby(rb_print_backtrace+0x14) [0x55555585eed1] /src/vm_dump.c:820
/src/miniruby(rb_vm_bugreport) /src/vm_dump.c:1151
/src/miniruby(rb_bug_for_fatal_signal+0xfc) [0x55555564462c] /src/error.c:1065
/src/miniruby(sigsegv+0x4d) [0x5555557a663d] /src/signal.c:920
/lib/x86_64-linux-gnu/libc.so.6(0x7fffffc9c520) [0x7fffffc9c520]
/src/miniruby(RB_INT2FIX+0x0) [0x55555565f326] /src/gc.c:11241
/src/miniruby(gc_info_decode) /src/gc.c:11241
/src/miniruby(gc_profile_record_get+0x9c) [0x55555566220c] /src/gc.c:13267
/src/miniruby(vm_cfp_consistent_p+0x0) [0x555555832ce4] /src/vm_insnhelper.c:3481
/src/miniruby(vm_call_cfunc_with_frame_) /src/vm_insnhelper.c:3483
/src/miniruby(vm_call_cfunc_with_frame) /src/vm_insnhelper.c:3509
/src/miniruby(vm_call_cfunc_other) /src/vm_insnhelper.c:3535
/src/miniruby(vm_sendish+0xa2) [0x555555850daf] /src/vm_insnhelper.c:5561
/src/miniruby(vm_exec_core) /src/insns.def:823
/src/miniruby(vm_exec_loop+0xa) [0x55555584168d] /src/vm.c:2501
/src/miniruby(rb_vm_exec) /src/vm.c:2477
/src/miniruby(rb_ec_exec_node+0xb5) [0x55555564cc75] /src/eval.c:287
/src/miniruby(ruby_run_node+0x4d) [0x55555564ec8d] /src/eval.c:328
/src/miniruby(rb_main+0x21) [0x55555558e207] ./main.c:39
/src/miniruby(main) ./main.c:58
/lib/x86_64-linux-gnu/libc.so.6(0x7fffffc83d90) [0x7fffffc83d90]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x7fffffc83e40]
[0x55555558e255]

-- Other runtime information -----------------------------------------------

* Loaded script: -e

* Loaded features:

    0 enumerator.so
    1 thread.rb
    2 fiber.so
    3 rational.so
    4 complex.so
    5 ruby2_keywords.rb

* Process memory map:

5554ff7ff000-5554ff800000 ---p 00000000 00:00 0 
5554ff800000-555500000000 rw-p 00000000 00:00 0 
555555554000-555555588000 r--p 00000000 00:2a 4048                       /host_virtiofs/Users/soutaro/Developer/ruby/miniruby
555555588000-5555558c9000 r-xp 00034000 00:2a 4048                       /host_virtiofs/Users/soutaro/Developer/ruby/miniruby
5555558c9000-555555a1a000 r--p 00375000 00:2a 4048                       /host_virtiofs/Users/soutaro/Developer/ruby/miniruby
555555a1a000-555555a27000 r--p 004c5000 00:2a 4048                       /host_virtiofs/Users/soutaro/Developer/ruby/miniruby
555555a27000-555555a28000 rw-p 004d2000 00:2a 4048                       /host_virtiofs/Users/soutaro/Developer/ruby/miniruby
555555a28000-555555c33000 rw-p 00000000 00:00 0 
7fffe27e2000-7fffe44d0000 r--s 00000000 00:2a 4048                       /host_virtiofs/Users/soutaro/Developer/ruby/miniruby
7fffe44d0000-7fffe4500000 rw-p 00000000 00:00 0 
7fffe4550000-7fffe4560000 rw-p 00000000 00:00 0 
7fffe46d2000-7fffe48f0000 r--s 00000000 fe:01 3805014                    /usr/lib/x86_64-linux-gnu/libc.so.6
7fffe48f0000-7fffe4910000 rw-p 00000000 00:00 0 
7fffe4940000-7fffe4943000 r--p 00000000 fe:01 3805039                    /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7fffe4943000-7fffe495a000 r-xp 00003000 fe:01 3805039                    /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7fffe495a000-7fffe495e000 r--p 0001a000 fe:01 3805039                    /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7fffe495e000-7fffe495f000 r--p 0001d000 fe:01 3805039                    /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7fffe495f000-7fffe4960000 rw-p 0001e000 fe:01 3805039                    /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7fffe4960000-7fffe4990000 rw-p 00000000 00:00 0 
7fffe49a0000-7fffe49d0000 rw-p 00000000 00:00 0 
7fffe49df000-7fffe49e0000 ---p 00000000 00:00 0 
7fffe49e0000-7fffe4a81000 rw-p 00000000 00:00 0 
7fffe4a81000-7fffe4a82000 ---p 00000000 00:00 0 
7fffe4a82000-7fffe4b23000 rw-p 00000000 00:00 0 
7fffe4b23000-7fffe4b24000 ---p 00000000 00:00 0 
7fffe4b24000-7fffe4bc5000 rw-p 00000000 00:00 0 
7fffe4bc5000-7fffe4bc6000 ---p 00000000 00:00 0 
7fffe4bc6000-7fffe4c67000 rw-p 00000000 00:00 0 
7fffe4c67000-7fffe4c68000 ---p 00000000 00:00 0 
7fffe4c68000-7fffe4d09000 rw-p 00000000 00:00 0 
7fffe4d09000-7fffe4d0a000 ---p 00000000 00:00 0 
7fffe4d0a000-7fffe4dab000 rw-p 00000000 00:00 0 
7fffe4dab000-7fffe4dac000 ---p 00000000 00:00 0 
7fffe4dac000-7fffe4e4d000 rw-p 00000000 00:00 0 
7fffe4e4d000-7fffe4e4e000 ---p 00000000 00:00 0 
7fffe4e4e000-7fffe4eef000 rw-p 00000000 00:00 0 
7fffe4eef000-7fffe4ef0000 ---p 00000000 00:00 0 
7fffe4ef0000-7fffe4f91000 rw-p 00000000 00:00 0 
7fffe4f91000-7fffe4f92000 ---p 00000000 00:00 0 
7fffe4f92000-7fffe5033000 rw-p 00000000 00:00 0 
7fffe5033000-7fffe5034000 ---p 00000000 00:00 0 
7fffe5034000-7fffe50d5000 rw-p 00000000 00:00 0 
7fffe50d5000-7fffe50d6000 ---p 00000000 00:00 0 
7fffe50d6000-7fffe5177000 rw-p 00000000 00:00 0 
7fffe5177000-7fffe5178000 ---p 00000000 00:00 0 
7fffe5178000-7fffe5219000 rw-p 00000000 00:00 0 
7fffe5219000-7fffe521a000 ---p 00000000 00:00 0 
7fffe521a000-7fffe52bb000 rw-p 00000000 00:00 0 
7fffe52bb000-7fffe52bc000 ---p 00000000 00:00 0 
7fffe52bc000-7fffe535d000 rw-p 00000000 00:00 0 
7fffe535d000-7fffe535e000 ---p 00000000 00:00 0 
7fffe535e000-7fffe53ff000 rw-p 00000000 00:00 0 
7fffe53ff000-7fffe5400000 ---p 00000000 00:00 0 
7fffe5400000-7fffe54a1000 rw-p 00000000 00:00 0 
7fffe54a1000-7fffe54a2000 ---p 00000000 00:00 0 
7fffe54a2000-7fffe5543000 rw-p 00000000 00:00 0 
7fffe5543000-7fffe5544000 ---p 00000000 00:00 0 
7fffe5544000-7fffe55e5000 rw-p 00000000 00:00 0 
7fffe55e5000-7fffe55e6000 ---p 00000000 00:00 0 
7fffe55e6000-7fffe5687000 rw-p 00000000 00:00 0 
7fffe5687000-7fffe5688000 ---p 00000000 00:00 0 
7fffe5688000-7fffe5729000 rw-p 00000000 00:00 0 
7fffe5729000-7fffe572a000 ---p 00000000 00:00 0 
7fffe572a000-7fffe57cb000 rw-p 00000000 00:00 0 
7fffe57cb000-7fffe57cc000 ---p 00000000 00:00 0 
7fffe57cc000-7fffe586d000 rw-p 00000000 00:00 0 
7fffe586d000-7fffe586e000 ---p 00000000 00:00 0 
7fffe586e000-7fffe590f000 rw-p 00000000 00:00 0 
7fffe590f000-7fffe5910000 ---p 00000000 00:00 0 
7fffe5910000-7fffe59b1000 rw-p 00000000 00:00 0 
7fffe59b1000-7fffe59b2000 ---p 00000000 00:00 0 
7fffe59b2000-7fffe5a53000 rw-p 00000000 00:00 0 
7fffe5a53000-7fffe5a54000 ---p 00000000 00:00 0 
7fffe5a54000-7fffe5af5000 rw-p 00000000 00:00 0 
7fffe5af5000-7fffe5af6000 ---p 00000000 00:00 0 
7fffe5af6000-7fffe5b97000 rw-p 00000000 00:00 0 
7fffe5b97000-7fffe5b98000 ---p 00000000 00:00 0 
7fffe5b98000-7fffe5c39000 rw-p 00000000 00:00 0 
7fffe5c39000-7fffe5c3a000 ---p 00000000 00:00 0 
7fffe5c3a000-7fffe5cdb000 rw-p 00000000 00:00 0 
7fffe5cdb000-7fffe5cdc000 ---p 00000000 00:00 0 
7fffe5cdc000-7fffe5d7d000 rw-p 00000000 00:00 0 
7fffe5d7d000-7fffe5d7e000 ---p 00000000 00:00 0 
7fffe5d7e000-7fffe5e1f000 rw-p 00000000 00:00 0 
7fffe5e1f000-7fffe5e20000 ---p 00000000 00:00 0 
7fffe5e20000-7fffe6670000 rw-p 00000000 00:00 0 
7fffe667f000-7fffffaf0000 rw-p 00000000 00:00 0 
7fffffaf9000-7fffffbfa000 rw-p 00000000 00:00 0 
7fffffbfa000-7fffffc01000 r--s 00000000 fe:01 3804982                    /usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache
7fffffc01000-7fffffc58000 r--p 00000000 fe:01 3804594                    /usr/lib/locale/C.utf8/LC_CTYPE
7fffffc58000-7fffffc5a000 rw-p 00000000 00:00 0 
7fffffc5a000-7fffffc82000 r--p 00000000 fe:01 3805014                    /usr/lib/x86_64-linux-gnu/libc.so.6
7fffffc82000-7fffffe17000 r-xp 00028000 fe:01 3805014                    /usr/lib/x86_64-linux-gnu/libc.so.6
7fffffe17000-7fffffe6f000 r--p 001bd000 fe:01 3805014                    /usr/lib/x86_64-linux-gnu/libc.so.6
7fffffe6f000-7fffffe73000 r--p 00214000 fe:01 3805014                    /usr/lib/x86_64-linux-gnu/libc.so.6
7fffffe73000-7fffffe75000 rw-p 00218000 fe:01 3805014                    /usr/lib/x86_64-linux-gnu/libc.so.6
7fffffe75000-7fffffe82000 rw-p 00000000 00:00 0 
7fffffe82000-7fffffe90000 r--p 00000000 fe:01 3805066                    /usr/lib/x86_64-linux-gnu/libm.so.6
7fffffe90000-7ffffff0c000 r-xp 0000e000 fe:01 3805066                    /usr/lib/x86_64-linux-gnu/libm.so.6
7ffffff0c000-7ffffff67000 r--p 0008a000 fe:01 3805066                    /usr/lib/x86_64-linux-gnu/libm.so.6
7ffffff67000-7ffffff68000 r--p 000e4000 fe:01 3805066                    /usr/lib/x86_64-linux-gnu/libm.so.6
7ffffff68000-7ffffff69000 rw-p 000e5000 fe:01 3805066                    /usr/lib/x86_64-linux-gnu/libm.so.6
7ffffff69000-7ffffff6b000 r--p 00000000 fe:01 3805023                    /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
7ffffff6b000-7ffffff7f000 r-xp 00002000 fe:01 3805023                    /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
7ffffff7f000-7ffffff98000 r--p 00016000 fe:01 3805023                    /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
7ffffff98000-7ffffff99000 ---p 0002f000 fe:01 3805023                    /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
7ffffff99000-7ffffff9a000 r--p 0002f000 fe:01 3805023                    /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
7ffffff9a000-7ffffff9b000 rw-p 00030000 fe:01 3805023                    /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
7ffffff9b000-7ffffffa5000 rw-p 00000000 00:00 0 
7ffffffa5000-7ffffffa7000 r--p 00000000 fe:01 3805145                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7ffffffa7000-7ffffffb8000 r-xp 00002000 fe:01 3805145                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7ffffffb8000-7ffffffbe000 r--p 00013000 fe:01 3805145                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7ffffffbe000-7ffffffbf000 ---p 00019000 fe:01 3805145                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7ffffffbf000-7ffffffc0000 r--p 00019000 fe:01 3805145                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7ffffffc0000-7ffffffc1000 rw-p 0001a000 fe:01 3805145                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7ffffffc4000-7ffffffc6000 r--p 00000000 fe:01 3804996                    /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7ffffffc6000-7fffffff0000 r-xp 00002000 fe:01 3804996                    /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7fffffff0000-7fffffffb000 r--p 0002c000 fe:01 3804996                    /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7fffffffb000-7fffffffc000 ---p 00000000 00:00 0 
7fffffffc000-7fffffffe000 r--p 00037000 fe:01 3804996                    /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7fffffffe000-800000000000 rw-p 00039000 fe:01 3804996                    /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
800000000000-800000023000 r--p 00000000 00:28 2                          /rosetta/rosetta
800000023000-800000080000 r-xp 00023000 00:28 2                          /rosetta/rosetta
800000080000-800000186000 rw-p 00080000 00:28 2                          /rosetta/rosetta
f00000000000-f00040000000 rw-p 00000000 00:00 0 
ffffabf17000-ffffabf9e000 rw-p 00000000 00:00 0 
ffffabf9e000-ffffabf9f000 ---p 00000000 00:00 0 
ffffabf9f000-ffffabfa3000 rw-p 00000000 00:00 0 
ffffabfa3000-ffffabfa4000 ---p 00000000 00:00 0 
ffffabfa4000-ffffac011000 rw-p 00000000 00:00 0 
ffffac011000-ffffac012000 ---p 00000000 00:00 0 
ffffac012000-ffffac016000 rw-p 00000000 00:00 0 
ffffac016000-ffffac017000 ---p 00000000 00:00 0 
ffffac017000-ffffac222000 rw-p 00000000 00:00 0 
ffffac222000-ffffb4222000 rwxp 00000000 00:00 0 
ffffb4222000-ffffb422a000 rw-p 00000000 00:00 0 
ffffb422a000-ffffb422c000 r--p 00000000 00:00 0                          [vvar]
ffffb422c000-ffffb422d000 r-xp 00000000 00:00 0                          [vdso]
ffffe2b7e000-ffffe2b9f000 rw-p 00000000 00:00 0                          [stack]


Aborted
```

