### PR TITLE
[PRISM] Fix ReturnNodes

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -948,6 +948,14 @@ module Prism
 
     def test_ReturnNode
       assert_prism_eval("def return_node; return 1; end")
+      assert_prism_eval(<<-CODE)
+        def self.prism_test_return_node
+          [1].each do |e|
+            return true
+          end
+        end
+        prism_test_return_node
+      CODE
     end
 
     ############################################################################


### PR DESCRIPTION
This code is almost exactly the same (fixed variable names) as what exists already in compile.c

Closes [1988](https://github.com/ruby/prism/issues/1988)