### PR TITLE
YJIT: Simplify code page switching logic, remove an assert

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -136,6 +136,10 @@ impl CodeBlock {
         };
         cb.page_end_reserve = cb.jmp_ptr_bytes();
         cb.write_pos = cb.page_start();
+
+        #[cfg(not(test))]
+        assert_eq!(0, mem_size % page_size, "partially in-bounds code pages should be impossible");
+
         cb
     }
 


### PR DESCRIPTION
We have received a report of `assert!( !cb.has_dropped_bytes())` in
set_page() failing. The only explanation for this seems to be memory
allocation failing in write_byte(). The if condition implies that
`current_write_pos < dst_pos < mem_size`, which rules out failing to
encode the relative jump. The has_capacity() assert above not tripping
implies that we were in a place in the page where write_byte() did
attempt to write the byte and potentially made a syscall in the process.

Remove the assert, since memory allocation could fail. Also, return
failure if the destination is outside of the code region to detect that
out-of-memory situation quicker.


Also: `YJIT: Assert code pages are not partially in-bounds`

ref: https://github.com/Shopify/ruby/issues/548