### PR TITLE
[PRISM] Implement more `defined?` nodes

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1466,12 +1466,14 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
         break;
       case PM_ARRAY_NODE: {
         pm_array_node_t *array_node = (pm_array_node_t *) node;
-        for (size_t index = 0; index < array_node->elements.size; index++) {
-          pm_compile_defined_expr0(iseq, array_node->elements.nodes[index], ret, src, popped, scope_node, dummy_line_node, lineno, true, lfinish);
-          if (!lfinish[1]) {
-            lfinish[1] = NEW_LABEL(lineno);
-          }
-          ADD_INSNL(ret, &dummy_line_node, branchunless, lfinish[1]);
+        if (!(array_node->base.flags & PM_ARRAY_NODE_FLAGS_CONTAINS_SPLAT)) {
+            for (size_t index = 0; index < array_node->elements.size; index++) {
+              pm_compile_defined_expr0(iseq, array_node->elements.nodes[index], ret, src, popped, scope_node, dummy_line_node, lineno, true, lfinish);
+              if (!lfinish[1]) {
+                lfinish[1] = NEW_LABEL(lineno);
+              }
+              ADD_INSNL(ret, &dummy_line_node, branchunless, lfinish[1]);
+            }
         }
       }
       case PM_AND_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1485,6 +1485,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_INTERPOLATED_STRING_NODE:
       case PM_KEYWORD_HASH_NODE:
       case PM_LAMBDA_NODE:
+      case PM_MATCH_PREDICATE_NODE:
       case PM_OR_NODE:
       case PM_RANGE_NODE:
       case PM_REGULAR_EXPRESSION_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1487,6 +1487,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_REGULAR_EXPRESSION_NODE:
       case PM_SOURCE_ENCODING_NODE:
       case PM_SOURCE_FILE_NODE:
+      case PM_SOURCE_LINE_NODE:
       case PM_STRING_NODE:
       case PM_SYMBOL_NODE:
       case PM_X_STRING_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1477,6 +1477,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_AND_NODE:
       case PM_FLOAT_NODE:
       case PM_HASH_NODE:
+      case PM_IMAGINARY_NODE:
       case PM_INTEGER_NODE:
       case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE:
       case PM_INTERPOLATED_STRING_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1485,6 +1485,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_OR_NODE:
       case PM_RANGE_NODE:
       case PM_REGULAR_EXPRESSION_NODE:
+      case PM_SOURCE_ENCODING_NODE:
       case PM_STRING_NODE:
       case PM_SYMBOL_NODE:
       case PM_X_STRING_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1486,6 +1486,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_RANGE_NODE:
       case PM_REGULAR_EXPRESSION_NODE:
       case PM_SOURCE_ENCODING_NODE:
+      case PM_SOURCE_FILE_NODE:
       case PM_STRING_NODE:
       case PM_SYMBOL_NODE:
       case PM_X_STRING_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1483,6 +1483,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_INTEGER_NODE:
       case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE:
       case PM_INTERPOLATED_STRING_NODE:
+      case PM_KEYWORD_HASH_NODE:
       case PM_LAMBDA_NODE:
       case PM_OR_NODE:
       case PM_RANGE_NODE:

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -112,6 +112,7 @@ module Prism
       assert_prism_eval("defined? a || b")
       assert_prism_eval("defined? __ENCODING__")
       assert_prism_eval("defined? __FILE__")
+      assert_prism_eval("defined? __LINE__")
 
       assert_prism_eval("defined? %[1,2,3]")
       assert_prism_eval("defined? %q[1,2,3]")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -128,6 +128,7 @@ module Prism
       assert_prism_eval("defined? [*b]")
       assert_prism_eval("defined? [[*1..2], 3, *4..5]")
       assert_prism_eval("defined? [a: [:b, :c]]")
+      assert_prism_eval("defined? 1 in 1")
 
       assert_prism_eval("defined? @a")
       assert_prism_eval("defined? $a")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -110,6 +110,7 @@ module Prism
       assert_prism_eval("defined? -> { 1 + 1 }")
       assert_prism_eval("defined? a && b")
       assert_prism_eval("defined? a || b")
+      assert_prism_eval("defined? __ENCODING__")
 
       assert_prism_eval("defined? %[1,2,3]")
       assert_prism_eval("defined? %q[1,2,3]")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -111,6 +111,7 @@ module Prism
       assert_prism_eval("defined? a && b")
       assert_prism_eval("defined? a || b")
       assert_prism_eval("defined? __ENCODING__")
+      assert_prism_eval("defined? __FILE__")
 
       assert_prism_eval("defined? %[1,2,3]")
       assert_prism_eval("defined? %q[1,2,3]")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -125,6 +125,9 @@ module Prism
       assert_prism_eval("defined? %s[1,2,3]")
       assert_prism_eval("defined? %x[1,2,3]")
 
+      assert_prism_eval("defined? [*b]")
+      assert_prism_eval("defined? [[*1..2], 3, *4..5]")
+
       assert_prism_eval("defined? @a")
       assert_prism_eval("defined? $a")
       assert_prism_eval("defined? @@a")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -127,6 +127,7 @@ module Prism
 
       assert_prism_eval("defined? [*b]")
       assert_prism_eval("defined? [[*1..2], 3, *4..5]")
+      assert_prism_eval("defined? [a: [:b, :c]]")
 
       assert_prism_eval("defined? @a")
       assert_prism_eval("defined? $a")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -96,6 +96,7 @@ module Prism
       assert_prism_eval("defined? true")
       assert_prism_eval("defined? false")
       assert_prism_eval("defined? 1")
+      assert_prism_eval("defined? 1i")
       assert_prism_eval("defined? 1.0")
       assert_prism_eval("defined? 1..2")
       assert_prism_eval("defined? [A, B, C]")


### PR DESCRIPTION
Implements the following nodes for `defined?`:

* `PM_IMAGINARY_NODE`
* `PM_KEYWORD_HASH_NODE`
* `PM_MATCH_PREDICATE_NODE`
* `PM_SOURCE_ENCODING_NODE`
* `PM_SOURCE_FILE_NODE`
* `PM_SOURCE_LINE_NODE`
* `PM_SPLAT_NODE`

For arrays with splats in them, the upstream parser will ignore the rest of the elements and return `expression`. See [commit](https://github.com/ruby/ruby/commit/34f13f7bd818900806fe5c5d760a12925496b6a0). 

Each commit includes the Ruby code and instructions produced. For `PM_KEYWORD_HASH_NODE` I've included the instructions with and without optimizations.

I went through every example test for the prism compiler and checked how that code behaves with `defined?`. Other than the ones that return `PM_CALL_NODE`, I think this is all the nodes I can come up with.