### PR TITLE
[PRISM] move rb_ruby_prism_ptr out of prism/prism

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -8881,6 +8881,7 @@ load.$(OBJEXT): {$(VPATH)}onigmo.h
 load.$(OBJEXT): {$(VPATH)}oniguruma.h
 load.$(OBJEXT): {$(VPATH)}prism/ast.h
 load.$(OBJEXT): {$(VPATH)}prism/version.h
+load.$(OBJEXT): {$(VPATH)}prism_compile.h
 load.$(OBJEXT): {$(VPATH)}probes.dmyh
 load.$(OBJEXT): {$(VPATH)}probes.h
 load.$(OBJEXT): {$(VPATH)}ruby_assert.h

--- a/load.c
+++ b/load.c
@@ -16,7 +16,7 @@
 #include "probes.h"
 #include "darray.h"
 #include "ruby/encoding.h"
-#include "prism/prism.h"
+#include "prism_compile.h"
 #include "ruby/util.h"
 
 static VALUE ruby_dln_librefs;

--- a/prism/prism.h
+++ b/prism/prism.h
@@ -42,17 +42,6 @@
  */
 PRISM_EXPORTED_FUNCTION const char * pm_version(void);
 
-
-/**
- * @private
- *
- * This is used to decide of the prism parser should be used.
- *
- * @retval  true       Use Prism to parse files
- * @retval  false      Use standard parser
- */
-bool *rb_ruby_prism_ptr(void);
-
 /**
  * Initialize a parser with the given start and end pointers.
  *

--- a/prism_compile.h
+++ b/prism_compile.h
@@ -29,3 +29,4 @@ typedef struct pm_scope_node {
 } pm_scope_node_t;
 
 void pm_scope_node_init(const pm_node_t *node, pm_scope_node_t *scope, pm_scope_node_t *previous, pm_parser_t *parser);
+bool *rb_ruby_prism_ptr(void);


### PR DESCRIPTION
This moves rb_ruby_prism_ptr out of prism/prism.h where i mistakenly put it.