### PR TITLE
YJIT: implement call fuzzer script

### DIFF
--- a/misc/call_fuzzer.rb
+++ b/misc/call_fuzzer.rb
@@ -1,0 +1,159 @@
+require 'optparse'
+require 'set'
+
+# Number of iterations to test
+num_iters = 10_000
+
+# Parse the command-line options
+OptionParser.new do |opts|
+  opts.on("--num_iters=N") do |n|
+    num_iters = n.to_i
+  end
+end.parse!
+
+def gen_random_method()
+  # Choose how many positional arguments to use, and how many are optional
+  num_pargs = rand(10)
+  opt_parg_idx = rand(num_pargs)
+  num_opt_pargs = rand( num_pargs + 1 - opt_parg_idx)
+  pargs = []
+  num_pargs.times { |i| pargs.push("p#{i}") }
+  opt_pargs = pargs[opt_parg_idx...opt_parg_idx + num_opt_pargs]
+
+  # Choose how many kwargs to use, and how many are optional
+  num_kwargs = rand(10)
+  num_opt_kwargs = rand(num_kwargs + 1)
+  kwargs = []
+  num_kwargs.times { |i| kwargs.push("k#{i}") }
+  opt_kwargs = kwargs.sample(num_opt_kwargs)
+
+  # Choose whether to have a block argument and splats or not
+  block_arg = rand() < 0.5
+  has_rest = num_opt_pargs == 0 && rand() < 0.5
+  has_kwrest = rand() < 0.5
+
+  # Generate a method definitions
+  m_str = "def m("
+
+  pargs.each_with_index do |name, i|
+    if !m_str.end_with?("(")
+      m_str += ", "
+    end
+    m_str += "#{name}"
+
+    # If this has a default value
+    if opt_pargs.include?(name)
+      m_str += " = #{i}"
+    end
+  end
+
+  if has_rest
+    if !m_str.end_with?("(")
+      m_str += ", "
+    end
+    m_str += "*rest"
+  end
+
+  kwargs.each_with_index do |name, i|
+    if !m_str.end_with?("(")
+      m_str += ", "
+    end
+    m_str += "#{name}:"
+
+    # If this has a default value
+    if opt_kwargs.include?(name)
+      m_str += " #{i}"
+    end
+  end
+
+  if has_kwrest
+    if !m_str.end_with?("(")
+      m_str += ", "
+    end
+    m_str += "**kwrest"
+  end
+
+  if block_arg
+    if !m_str.end_with?("(")
+      m_str += ", "
+    end
+    m_str += "&block"
+  end
+
+  m_str += ")\n"
+  if block_arg
+    m_str += "if block; block.call; end\n"
+  end
+  m_str += "if block_given?; yield; end\n"
+  m_str += "777\n"
+  m_str += "end"
+
+  # Generate a random call to the method
+  c_str = "m("
+
+  pargs.each_with_index do |name, i|
+    if !c_str.end_with?("(")
+      c_str += ", "
+    end
+
+    c_str += "#{i}"
+
+    # TODO: don't always pass optional positional args
+  end
+
+  kwargs.each_with_index do |name, i|
+    # Don't always pass optional kwargs
+    if opt_kwargs.include?(name) && rand() < 0.5
+      next
+    end
+
+    if !c_str.end_with?("(")
+      c_str += ", "
+    end
+
+    c_str += "#{name}: #{i}"
+  end
+
+  c_str += ")"
+
+  # Randomly pass a block or not
+  if rand() < 0.5
+    c_str += " { 1 }"
+  end
+
+  [m_str, c_str]
+end
+
+iseqs_compiled_start = RubyVM::YJIT.runtime_stats[:compiled_iseq_entry]
+
+num_iters.times do |i|
+  puts "Iteration #{i}"
+
+  m_str, c_str = gen_random_method()
+
+  eval("class Foo; end")
+
+  f = Foo.new()
+
+  # Define the method on f
+  puts "Defining"
+  p m_str
+  f.instance_eval(m_str)
+
+  puts "Calling"
+  c_str = "f.#{c_str}"
+  p c_str
+  r = eval(c_str)
+  p r
+
+  if r != 777
+    raise "incorrect return value"
+  end
+
+  puts ""
+end
+
+iseqs_compiled_end = RubyVM::YJIT.runtime_stats[:compiled_iseq_entry]
+if iseqs_compiled_end - iseqs_compiled_start < num_iters
+  raise "YJIT did not compile enough ISEQs"
+end

--- a/misc/call_fuzzer.sh
+++ b/misc/call_fuzzer.sh
@@ -1,0 +1,6 @@
+# TODO: we may want to test other call thresholds?
+ruby --yjit-call-threshold=1 misc/call_fuzzer.rb
+
+# TODO: we may also want to test with --verify-ctx?
+# Could the call_fuzzer ruby script call itself with different options?
+# May want to have a separate runner script


### PR DESCRIPTION
Attempt to detect bugs in YJIT call implementation.

This is very basic at this point and so I'll make it a draft PR, but would like some suggestions on where to go next @XrXr 

I was thinking I could compute the sum and/or product of the arguments to make sure that the generated methods produce the result we expect, signifying that arguments were passed correctly. I could also pass things like strings or objects that require heap pointers, to make sure that we track types correctly.

I'll try to make it as dynamic as possible, and add more tricky edge cases (suggestions welcome), but somewhat afraid that this script will become complicated and hard to follow fairly quickly 😅 

Another potential approach to this would be to fuzz by concatenating random tokens, and then forking both a CRuby interpreter and a YJIT process, and checking that the output from both is the same. This is more inefficient in terms of compute and time 

Sample output:
```
Iteration 9991
Defining
"def m(p0 = 0, p1 = 1, p2 = 2, p3 = 3, p4 = 4, p5 = 5, p6 = 6, p7 = 7, p8 = 8, k0: 0, k1:, k2: 2, k3:, k4: 4, k5: 5, k6: 6, k7: 7, k8:, **kwrest)\nif block_given?; yield; end\n777\nend"
Calling
"f.m(0, 1, 2, 3, 4, 5, 6, 7, 8, k0: 0, k1: 1, k2: 2, k3: 3, k4: 4, k7: 7, k8: 8)"
777

Iteration 9992
Defining
"def m(p0, p1 = 1, p2 = 2, k0:, k1:, k2:, k3:)\nif block_given?; yield; end\n777\nend"
Calling
"f.m(0, 1, 2, k0: 0, k1: 1, k2: 2, k3: 3)"
777

Iteration 9993
Defining
"def m(p0 = 0, k0: 0, k1: 1, k2: 2, k3: 3, k4: 4, k5: 5, k6: 6)\nif block_given?; yield; end\n777\nend"
Calling
"f.m(0, k0: 0, k1: 1, k2: 2, k5: 5, k6: 6) { 1 }"
777

Iteration 9994
Defining
"def m(p0, k0: 0, k1:, k2:, k3:, k4:, &block)\nif block; block.call; end\nif block_given?; yield; end\n777\nend"
Calling
"f.m(0, k0: 0, k1: 1, k2: 2, k3: 3, k4: 4)"
777

Iteration 9995
Defining
"def m(p0, p1, *rest, k0: 0, k1: 1, k2:, k3: 3, k4: 4, **kwrest)\nif block_given?; yield; end\n777\nend"
Calling
"f.m(0, 1, k1: 1, k2: 2) { 1 }"
777

Iteration 9996
Defining
"def m(p0 = 0, &block)\nif block; block.call; end\nif block_given?; yield; end\n777\nend"
Calling
"f.m(0)"
777

Iteration 9997
Defining
"def m(k0:, k1: 1, k2:, k3: 3, k4:, k5:, k6: 6, k7:, k8:)\nif block_given?; yield; end\n777\nend"
Calling
"f.m(k0: 0, k2: 2, k4: 4, k5: 5, k7: 7, k8: 8)"
777

Iteration 9998
Defining
"def m(p0, p1, p2, p3, p4, k0:, **kwrest, &block)\nif block; block.call; end\nif block_given?; yield; end\n777\nend"
Calling
"f.m(0, 1, 2, 3, 4, k0: 0)"
777

Iteration 9999
Defining
"def m(p0, p1, p2, p3 = 3, p4 = 4, p5, p6, p7, k0:, k1:, k2:, k3:, k4:, k5:, k6:, k7:, k8:)\nif block_given?; yield; end\n777\nend"
Calling
"f.m(0, 1, 2, 3, 4, 5, 6, 7, k0: 0, k1: 1, k2: 2, k3: 3, k4: 4, k5: 5, k6: 6, k7: 7, k8: 8) { 1 }"
777
```