### PR TITLE
Fix parameter types for rb_ivar_foreach() callbacks

### DIFF
--- a/error.c
+++ b/error.c
@@ -3248,9 +3248,9 @@ exception_dumper(VALUE exc)
 }
 
 static int
-ivar_copy_i(st_data_t key, st_data_t val, st_data_t exc)
+ivar_copy_i(ID key, VALUE val, st_data_t exc)
 {
-    rb_ivar_set((VALUE) exc, (ID) key, (VALUE) val);
+    rb_ivar_set((VALUE)exc, key, val);
     return ST_CONTINUE;
 }
 

--- a/marshal.c
+++ b/marshal.c
@@ -610,10 +610,8 @@ struct w_ivar_arg {
 };
 
 static int
-w_obj_each(st_data_t key, st_data_t val, st_data_t a)
+w_obj_each(ID id, VALUE value, st_data_t a)
 {
-    ID id = (ID)key;
-    VALUE value = (VALUE)val;
     struct w_ivar_arg *ivarg = (struct w_ivar_arg *)a;
     struct dump_call_arg *arg = ivarg->dump;
 
@@ -635,9 +633,8 @@ w_obj_each(st_data_t key, st_data_t val, st_data_t a)
 }
 
 static int
-obj_count_ivars(st_data_t key, st_data_t val, st_data_t a)
+obj_count_ivars(ID id, VALUE val, st_data_t a)
 {
-    ID id = (ID)key;
     if (!to_be_skipped_id(id) && UNLIKELY(!++*(st_index_t *)a)) {
         rb_raise(rb_eRuntimeError, "too many instance variables");
     }
@@ -1683,10 +1680,9 @@ r_leave(VALUE v, struct load_arg *arg, bool partial)
 }
 
 static int
-copy_ivar_i(st_data_t key, st_data_t val, st_data_t arg)
+copy_ivar_i(ID vid, VALUE value, st_data_t arg)
 {
-    VALUE obj = (VALUE)arg, value = (VALUE)val;
-    ID vid = (ID)key;
+    VALUE obj = (VALUE)arg;
 
     if (!rb_ivar_defined(obj, vid))
         rb_ivar_set(obj, vid, value);

--- a/object.c
+++ b/object.c
@@ -702,10 +702,8 @@ rb_inspect(VALUE obj)
 }
 
 static int
-inspect_i(st_data_t k, st_data_t v, st_data_t a)
+inspect_i(ID id, VALUE value, st_data_t a)
 {
-    ID id = (ID)k;
-    VALUE value = (VALUE)v;
     VALUE str = (VALUE)a;
 
     /* need not to show internal data */

--- a/variable.c
+++ b/variable.c
@@ -2127,9 +2127,8 @@ rb_ivar_count(VALUE obj)
 }
 
 static int
-ivar_i(st_data_t k, st_data_t v, st_data_t a)
+ivar_i(ID key, VALUE v, st_data_t a)
 {
-    ID key = (ID)k;
     VALUE ary = (VALUE)a;
 
     if (rb_is_instance_id(key)) {
@@ -3999,9 +3998,8 @@ rb_define_class_variable(VALUE klass, const char *name, VALUE val)
 }
 
 static int
-cv_i(st_data_t k, st_data_t v, st_data_t a)
+cv_i(ID key, VALUE v, st_data_t a)
 {
-    ID key = (ID)k;
     st_table *tbl = (st_table *)a;
 
     if (rb_is_class_id(key)) {
@@ -4216,9 +4214,9 @@ rb_class_ivar_set(VALUE obj, ID id, VALUE val)
 }
 
 static int
-tbl_copy_i(st_data_t key, st_data_t val, st_data_t dest)
+tbl_copy_i(ID key, VALUE val, st_data_t dest)
 {
-    rb_class_ivar_set(dest, key, val);
+    rb_class_ivar_set((VALUE)dest, key, val);
 
     return ST_CONTINUE;
 }


### PR DESCRIPTION
For this public API, the callback is declared to take
`(ID, VALUE, st_data_t)`, but it so happens that using
`(st_data_t, st_data_t, st_data_t)` also
type checks, because the underlying type is identical.
Use it as declared and get rid of some casts.
