### PR TITLE
Don't warn generally, only warn on specific code paths e.g. `map`.

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -699,8 +699,6 @@ io_flags_for_size(size_t size)
 VALUE
 rb_io_buffer_initialize(int argc, VALUE *argv, VALUE self)
 {
-    io_buffer_experimental();
-
     rb_check_arity(argc, 0, 2);
 
     struct rb_io_buffer *buffer = NULL;


### PR DESCRIPTION
`IO::Buffer` is now generally in use by external dependencies. Some parts of it are still marked as experimental, but the core interface as used by the fiber scheduler should not emit this warning.