### PR TITLE
[PRISM] Account for nil parent in Call{Operator,And,Or}PathWriteNodes

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2309,7 +2309,12 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         LABEL *lfin = NEW_LABEL(lineno);
 
         pm_constant_path_node_t *target = constant_path_and_write_node->target;
-        PM_COMPILE_NOT_POPPED(target->parent);
+        if (target->parent) {
+            PM_COMPILE_NOT_POPPED(target->parent);
+        }
+        else {
+            ADD_INSN1(ret, &dummy_line_node, putobject, rb_cObject);
+        }
 
         pm_constant_read_node_t *child = (pm_constant_read_node_t *)target->child;
         VALUE child_name = ID2SYM(pm_constant_id_lookup(scope_node, child->name));
@@ -2347,7 +2352,12 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         LABEL *lfin = NEW_LABEL(lineno);
 
         pm_constant_path_node_t *target = constant_path_or_write_node->target;
-        PM_COMPILE_NOT_POPPED(target->parent);
+        if (target->parent) {
+            PM_COMPILE_NOT_POPPED(target->parent);
+        }
+        else {
+            ADD_INSN1(ret, &dummy_line_node, putobject, rb_cObject);
+        }
 
         pm_constant_read_node_t *child = (pm_constant_read_node_t *)target->child;
         VALUE child_name = ID2SYM(pm_constant_id_lookup(scope_node, child->name));
@@ -2387,7 +2397,12 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         pm_constant_path_operator_write_node_t *constant_path_operator_write_node = (pm_constant_path_operator_write_node_t*) node;
 
         pm_constant_path_node_t *target = constant_path_operator_write_node->target;
-        PM_COMPILE_NOT_POPPED(target->parent);
+        if (target->parent) {
+            PM_COMPILE_NOT_POPPED(target->parent);
+        }
+        else {
+            ADD_INSN1(ret, &dummy_line_node, putobject, rb_cObject);
+        }
 
         PM_DUP;
         ADD_INSN1(ret, &dummy_line_node, putobject, Qtrue);

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -253,15 +253,18 @@ module Prism
     def test_ConstantPathAndWriteNode
       assert_prism_eval("Prism::CPAWN = 1; Prism::CPAWN &&= 2")
       assert_prism_eval("Prism::CPAWN &&= 1")
+      assert_prism_eval("::CPAWN = 1; ::CPAWN &&= 2")
     end
 
     def test_ConstantPathOrWriteNode
       assert_prism_eval("Prism::CPOrWN = nil; Prism::CPOrWN ||= 1")
       assert_prism_eval("Prism::CPOrWN ||= 1")
+      assert_prism_eval("::CPOrWN = nil; ::CPOrWN ||= 1")
     end
 
     def test_ConstantPathOperatorWriteNode
       assert_prism_eval("Prism::CPOWN = 0; Prism::CPOWN += 1")
+      assert_prism_eval("::CPOWN = 0; ::CPOWN += 1")
     end
 
     def test_GlobalVariableAndWriteNode


### PR DESCRIPTION
Prior to this commit, we were not accounting for the case of a nil parent in a CallXPathWriteNode, for example ::A ||= 1. This commit checks if the parent exists, and if not, uses Object as the inferred parent