### PR TITLE
YJIT: Avoid register allocation conflict with a higher stack_idx

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4273,3 +4273,21 @@ assert_normal_exit %q{
   Foo.class_eval "def initialize() #{ivars} end"
   Foo.new
 }
+
+assert_equal '0', %q{
+  def spill
+    1.to_i # not inlined
+  end
+
+  def inline(_stack1, _stack2, _stack3, _stack4, _stack5)
+    0 # inlined
+  end
+
+  def entry
+    # RegTemps is 00111110 prior to the #inline call.
+    # Its return value goes to stack_idx=0, which conflicts with stack_idx=5.
+    inline(spill, 2, 3, 4, 5)
+  end
+
+  entry
+}


### PR DESCRIPTION
`RegTemps::conflicts_with` currently checks if it conflicts with indexes lower than the argument stack_idx. Therefore it does not detect a conflict with indexes higher than the argument stack_idx. While it works fine in most cases, it leads to a wrong allocation in the scenario demonstrated in this test_yjit script.

This PR fixes it to check both lower indexes and higher indexes than the argument stack_idx.