### PR TITLE
[PRISM] Correct depth offset for block local vars

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1354,6 +1354,7 @@ pm_scope_node_init(const pm_node_t *node, pm_scope_node_t *scope, pm_scope_node_
             }
             scope->body = cast->body;
             scope->locals = cast->locals;
+            scope->local_depth_offset = 0;
             break;
         }
         case PM_CLASS_NODE: {

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -786,6 +786,23 @@ module Prism
           end
         end
       CODE
+      assert_prism_eval(<<~CODE)
+        def test
+        ensure
+          {}.each do |key, value|
+            {}[key] = value
+          end
+        end
+      CODE
+      assert_prism_eval(<<~CODE)
+        def test
+          a = 1
+        ensure
+          {}.each do |key, value|
+            {}[key] = a
+          end
+        end
+      CODE
     end
 
     def test_NextNode
@@ -921,6 +938,15 @@ module Prism
         a + b + c
       CODE
       assert_prism_eval("begin; rescue; end")
+
+      assert_prism_eval(<<~CODE)
+        begin
+        rescue
+          args.each do |key, value|
+            tmp[key] = 1
+          end
+        end
+      CODE
     end
 
     def test_RescueModiferNode


### PR DESCRIPTION
Blocks should always look at their own local table first, even when defined inside an ensure/rescue or something else that uses depth offset. We can ignore the depth offset if we're doing local lookups inside a block