### PR TITLE
YJIT: Add some object validity assertions

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7097,6 +7097,8 @@ fn gen_send_general(
     let recv_idx = argc + if flags & VM_CALL_ARGS_BLOCKARG != 0 { 1 } else { 0 };
     let comptime_recv = jit.peek_at_stack(&asm.ctx, recv_idx as isize);
     let comptime_recv_klass = comptime_recv.class_of();
+    assert_eq!(RUBY_T_CLASS, comptime_recv_klass.builtin_type(),
+        "objects visible to ruby code should have a T_CLASS in their klass field");
 
     // Points to the receiver operand on the stack
     let recv = asm.stack_opnd(recv_idx);

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -140,7 +140,6 @@ extern "C" {
 // Renames
 pub use rb_insn_name as raw_insn_name;
 pub use rb_insn_len as raw_insn_len;
-pub use rb_yarv_class_of as CLASS_OF;
 pub use rb_get_ec_cfp as get_ec_cfp;
 pub use rb_get_cfp_iseq as get_cfp_iseq;
 pub use rb_get_cfp_pc as get_cfp_pc;
@@ -406,7 +405,13 @@ impl VALUE {
     }
 
     pub fn class_of(self) -> VALUE {
-        unsafe { CLASS_OF(self) }
+        if !self.special_const_p() {
+            let builtin_type = self.builtin_type();
+            assert_ne!(builtin_type, RUBY_T_NONE, "YJIT should only see live objects");
+            assert_ne!(builtin_type, RUBY_T_MOVED, "YJIT should only see live objects");
+        }
+
+        unsafe { rb_yarv_class_of(self) }
     }
 
     pub fn is_frozen(self) -> bool {


### PR DESCRIPTION
We've seen quite a few compaction bugs lately, and these assertions should give clearer symptoms. We only call class_of() on objects that the Ruby code can see.