### PR TITLE
[PRISM] Add handling of implicit hash arguments

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1329,6 +1329,16 @@ module Prism
         end
         foo(1)
       CODE
+
+      assert_prism_eval(<<-CODE)
+        def self.prism_opt_var_trail_hash(a = nil, *b, c, **d); end
+        prism_opt_var_trail_hash("a")
+        prism_opt_var_trail_hash("a", c: 1)
+        prism_opt_var_trail_hash("a", "b")
+        prism_opt_var_trail_hash("a", "b", "c")
+        prism_opt_var_trail_hash("a", "b", "c", c: 1)
+        prism_opt_var_trail_hash("a", "b", "c", "c" => 0, c: 1)
+      CODE
     end
 
     def test_CallAndWriteNode


### PR DESCRIPTION
Arguments that are passed as a hash need special consideration since in certain case they are not treated as keyword arguments. For example, if a call is passing `"a" => 1` as an argument, this will be turned into an implicit hash argument and not a keyword argument.

The existing compiler checks to see if all hash nodes can be treated as keyword arguments. If they can, then it will treat them as keyword arguments. If not, then it will treat them as implicit hash arguments.

This commit implements the same logic inside the Prism compiler.

Fixes https://github.com/ruby/prism/issues/1894