### PR TITLE
Use xfree in hash_st_free

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1177,8 +1177,8 @@ hash_st_free(VALUE hash)
 
     st_table *tab = RHASH_ST_TABLE(hash);
 
-    free(tab->bins);
-    free(tab->entries);
+    xfree(tab->bins);
+    xfree(tab->entries);
 }
 
 static void


### PR DESCRIPTION
st.c redefines malloc and free to be ruby_xmalloc and ruby_xfree, so when this was copied into hash.c it ended up mismatching an xmalloc with a regular free, which ended up inflating oldmalloc_increase_bytes when hashes were freed by minor GC.

We found this by testing Ruby trunk in production, which showed a significant increase in major GC by cause of oldmalloc. After we were able to reproduce oldmalloc_increase_bytes increasing (semi-)consistently in a synthetic test. Finally I tracked down this location by enabling `CALC_EXACT_MALLOC_SIZE` and building with ASAN.

**Before:**

```
$ ./miniruby -e '10.times { 1000.times { (0..10).map{[_1,_1]}.to_h }; GC.start(full_mark: false); puts GC.stat(:oldmalloc_increase_bytes) }'
compiling hash.c
revision.h updated
linking miniruby
169728
562752
946752
1330752
1714752
2098752
2482752
2866752
3250752
3634752
```

**After**

```
$ ./miniruby -e '10.times { 1000.times { (0..10).map{[_1,_1]}.to_h }; GC.start(full_mark: false); puts GC.stat(:oldmalloc_increase_bytes) }'
make: 'miniruby' is up to date.
96
9120
9120
9120
9120
9120
9120
9120
9120
9120
```