### PR TITLE
Use free with ruby_dtoa

### DIFF
--- a/marshal.c
+++ b/marshal.c
@@ -466,7 +466,7 @@ w_float(double d, struct dump_arg *arg)
             memcpy(buf + len, p, digs);
             len += digs;
         }
-        xfree(p);
+        free(p);
         w_bytes(buf, len, arg);
     }
 }

--- a/numeric.c
+++ b/numeric.c
@@ -1078,7 +1078,7 @@ flo_to_s(VALUE flt)
     s = sign ? rb_usascii_str_new_cstr("-") : rb_usascii_str_new(0, 0);
     if ((digs = (int)(e - p)) >= (int)sizeof(buf)) digs = (int)sizeof(buf) - 1;
     memcpy(buf, p, digs);
-    xfree(p);
+    free(p);
     if (decpt > 0) {
         if (decpt < digs) {
             memmove(buf + decpt + 1, buf + decpt, digs - decpt);

--- a/vsnprintf.c
+++ b/vsnprintf.c
@@ -1255,8 +1255,8 @@ cvt(double value, int ndigits, int flags, char *sign, int *decpt, int ch, int *l
 	}
 	buf[0] = 0; /* rve - digits may be 0 */
 	memcpy(buf, digits, rve - digits);
-	xfree(digits);
 	rve = buf + (rve - digits);
+	free(digits);
 	digits = buf;
 	if (flags & ALT) {	/* Print trailing zeros */
 		bp = digits + ndigits;


### PR DESCRIPTION
In ae0ceafb0c0d05cc80623b525070255e3abb34ef `ruby_dtoa` was switched to use `malloc` instead of `xmalloc`, which means that consumers should be using free instead of `xfree`. Otherwise we will artificially shrink `oldmalloc_increase_bytes`.

I found this while investigating #9150

cc @nobu I'm not 100% sure this is the best approach or if we should `#define MALLOC xmalloc` in `util.c` ?

**Before:**

```
$ ./miniruby -e '10.times { 1000.times { 0.0.to_s }; GC.start(full_mark: false); puts GC.stat(:oldmalloc_increase_bytes) }'
10376
832
0
0
0
0
0
0
0
0
```

**After:**

```
$ ./miniruby -e '10.times { 1000.times { 0.0.to_s }; GC.start(full_mark: false); puts GC.stat(:oldmalloc_increase_bytes) }'
18376
8832
8832
8832
8832
8832
8832
8832
8832
8832
```