### PR TITLE
Handle Qnil in `check_method_entry`

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -707,6 +707,7 @@ static rb_callable_method_entry_t *
 check_method_entry(VALUE obj, int can_be_svar)
 {
     if (obj == Qfalse) return NULL;
+    if (obj == Qnil) return NULL;
 
 #if VM_CHECK_MODE > 0
     if (!RB_TYPE_P(obj, T_IMEMO)) rb_bug("check_method_entry: unknown type: %s", rb_obj_info(obj));


### PR DESCRIPTION
I don't know if it's legit for IMEMO to be `Qnil`

```
0  imemo_type (imemo=4) at internal/imemo.h:156
1  check_method_entry (can_be_svar=1, obj=4) at /tmp/ruby-build/ruby-3.3.0-a57186b9d1b0db3a88e5e9082347903b109f7d0e/vm_insnhelper.c:715
2  rb_vm_frame_method_entry (cfp=cfp@entry=0x7ec43117e5b0) at /tmp/ruby-build/ruby-3.3.0-a57186b9d1b0db3a88e5e9082347903b109f7d0e/vm_insnhelper.c:743
3  0x00005c8b9f55963c in control_frame_dump (ec=ec@entry=0x7ec43107c2d0, cfp=cfp@entry=0x7ec43117e5b0, errout=errout@entry=0x7ec326110a00) at vm_dump.c:63
4  0x00005c8b9f55a7b2 in rb_vmdebug_stack_dump_raw (errout=<optimized out>, cfp=0x7ec43117e5b0, ec=<optimized out>) at vm_dump.c:235
5  rb_vmdebug_stack_dump_raw (errout=0x7ec326110a00, cfp=<optimized out>, ec=0x7ec43107c2d0) at vm_dump.c:209
6  rb_vm_bugreport (ctx=ctx@entry=0x7ec4307342c0, errout=errout@entry=0x7ec326110a00) at vm_dump.c:1133
```