### PR TITLE
[PRISM] Stop catch table entries being deleted by the optimiser

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2678,6 +2678,8 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
       case PM_FOR_NODE: {
         pm_for_node_t *for_node = (pm_for_node_t *)node;
 
+        ISEQ_COMPILE_DATA(iseq)->catch_except_p = true;
+
         const rb_iseq_t *child_iseq;
         const rb_iseq_t *prevblock = ISEQ_COMPILE_DATA(iseq)->current_block;
 
@@ -2700,15 +2702,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         ISEQ_COMPILE_DATA(iseq)->current_block = child_iseq;
         ADD_SEND_WITH_BLOCK(ret, &dummy_line_node, idEach, INT2FIX(0), child_iseq);
 
-        INSN *iobj;
-        LINK_ELEMENT *last_elem = LAST_ELEMENT(ret);
-        iobj = IS_INSN(last_elem) ? (INSN *)last_elem : (INSN *)get_prev_insn((INSN*)last_elem);
-        while (INSN_OF(iobj) != BIN(send) &&
-                INSN_OF(iobj) != BIN(invokesuper)) {
-            iobj = (INSN *)get_prev_insn(iobj);
-        }
-        ELEM_INSERT_NEXT(&iobj->link, (LINK_ELEMENT*)retry_end_l);
-
+        ADD_LABEL(ret, retry_end_l);
         PM_POP_IF_POPPED;
 
         ISEQ_COMPILE_DATA(iseq)->current_block = prevblock;
@@ -4328,6 +4322,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             ISEQ_COMPILE_DATA(iseq)->last_line = body->location.code_location.end_pos.lineno;
 
             /* wide range catch handler must put at last */
+            ISEQ_COMPILE_DATA(iseq)->catch_except_p = true;
             ADD_CATCH_ENTRY(CATCH_TYPE_REDO, start, end, NULL, start);
             ADD_CATCH_ENTRY(CATCH_TYPE_NEXT, start, end, NULL, end);
             break;

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -742,6 +742,7 @@ module Prism
     def test_BreakNode
       assert_prism_eval("while true; break; end")
       assert_prism_eval("while true; break 1; end")
+      assert_prism_eval("[].each { break }")
     end
 
     def test_EnsureNode


### PR DESCRIPTION
Fixes https://github.com/ruby/prism/issues/1987