### PR TITLE
Normalize bundler bindir

### DIFF
--- a/lib/bundler/bundler.gemspec
+++ b/lib/bundler/bundler.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   # include the gemspec itself because warbler breaks w/o it
   s.files += %w[lib/bundler/bundler.gemspec]
 
-  s.bindir        = "libexec"
+  s.bindir        = "exe"
   s.executables   = %w[bundle bundler]
   s.require_paths = ["lib"]
 end

--- a/spec/bundler/quality_spec.rb
+++ b/spec/bundler/quality_spec.rb
@@ -191,9 +191,10 @@ RSpec.describe "The library itself" do
   end
 
   it "ships the correct set of files" do
-    git_list = git_ls_files(ruby_core? ? "lib/bundler lib/bundler.rb libexec/bundle*" : "lib exe CHANGELOG.md LICENSE.md README.md bundler.gemspec")
+    git_list = tracked_files.reject {|f| f.start_with?("spec/") }
 
     gem_list = loaded_gemspec.files
+    gem_list.map! {|f| f.sub(%r{\Aexe/}, "libexec/") } if ruby_core?
 
     expect(git_list).to match_array(gem_list)
   end

--- a/spec/bundler/support/helpers.rb
+++ b/spec/bundler/support/helpers.rb
@@ -330,7 +330,9 @@ module Spec
 
       begin
         shipped_files.each do |shipped_file|
-          target_shipped_file = build_path + shipped_file
+          target_shipped_file = shipped_file
+          target_shipped_file = shipped_file.sub(/\Alibexec/, "exe") if ruby_core?
+          target_shipped_file = build_path + target_shipped_file
           target_shipped_dir = File.dirname(target_shipped_file)
           FileUtils.mkdir_p target_shipped_dir unless File.directory?(target_shipped_dir)
           FileUtils.cp shipped_file, target_shipped_file, preserve: true

--- a/spec/bundler/support/path.rb
+++ b/spec/bundler/support/path.rb
@@ -80,7 +80,7 @@ module Spec
     end
 
     def shipped_files
-      @shipped_files ||= loaded_gemspec.files
+      @shipped_files ||= ruby_core? ? tracked_files : loaded_gemspec.files
     end
 
     def lib_tracked_files
@@ -268,7 +268,7 @@ module Spec
     end
 
     def tracked_files_glob
-      ruby_core? ? "lib/bundler lib/bundler.rb spec/bundler man/bundle*" : ""
+      ruby_core? ? "libexec/bundle* lib/bundler lib/bundler.rb spec/bundler man/bundle*" : "lib exe spec CHANGELOG.md LICENSE.md README.md bundler.gemspec"
     end
 
     def lib_tracked_files_glob

--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -149,7 +149,7 @@ module SyncDefaultGems
       gemspec_content = File.readlines("#{upstream}/bundler/bundler.gemspec").map do |line|
         next if line =~ /LICENSE\.md/
 
-        line.gsub("bundler.gemspec", "lib/bundler/bundler.gemspec").gsub('"exe"', '"libexec"')
+        line.gsub("bundler.gemspec", "lib/bundler/bundler.gemspec")
       end.compact.join
       File.write("lib/bundler/bundler.gemspec", gemspec_content)
 


### PR DESCRIPTION
This makes bundler consistent with all other gems, and makes the default installation of Bundler in the release package look like any other bundler installation.

Before (on preview3, for example), Bundler executable is installed at:

lib/ruby/gems/3.3.0+0/gems/bundler-2.5.0.dev/libexec/bundle

Now it's installed in the standard location:

lib/ruby/gems/3.3.0+0/gems/bundler-2.5.0.dev/exe/bundle

I'm working on adding a Ruby 3.3 build matrix to Bundler at https://github.com/rubygems/rubygems/pull/7233 and I believe this should fix some failures.