### PR TITLE
[PRISM] Fix ElseNode within CaseNode

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2255,9 +2255,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             PM_POP;
 
             if (case_node->consequent) {
-                if (!popped || !PM_NODE_TYPE_P(((pm_node_t *)case_node->consequent), PM_ELSE_NODE)) {
-                    PM_COMPILE_NOT_POPPED((pm_node_t *)case_node->consequent);
-                }
+                 PM_COMPILE((pm_node_t *)case_node->consequent);
             }
             else {
                 PM_PUTNIL_UNLESS_POPPED;
@@ -2759,7 +2757,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
               PM_COMPILE((pm_node_t *)cast->statements);
           }
           else {
-              PM_PUTNIL;
+              PM_PUTNIL_UNLESS_POPPED;
           }
           return;
       }

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -701,6 +701,17 @@ module Prism
       assert_prism_eval("case; when :a, :b; 1; else; 2 end")
       assert_prism_eval("case :a; when :b; else; end")
       assert_prism_eval("b = 1; case :a; when b; else; end")
+      assert_prism_eval(<<-CODE)
+        def self.prism_test_case_node
+          case :a
+          when :b
+          else
+            return 2
+          end
+          1
+        end
+        prism_test_case_node
+      CODE
     end
 
     def test_ElseNode


### PR DESCRIPTION
The logic within the consequent for the CaseNodes in popped cases was incorrect as it wouldn't emit consequent instructions for a popped CaseNode. This commit fixes that.

Closes https://github.com/ruby/prism/issues/2013