### PR TITLE
[DOC] Small fixes for documentation rendering

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -3272,18 +3272,18 @@ rb_fiber_m_raise(int argc, VALUE *argv, VALUE self)
  *  call-seq:
  *     fiber.kill -> nil
  *
- *  Terminates +fiber+ by raising an uncatchable exception.
- *  It only terminates the given Fiber and no other Fiber, returning +nil+ to
- *  another Fiber if that Fiber was calling +fiber.resume+ or +fiber.transfer+.
+ *  Terminates the fiber by raising an uncatchable exception.
+ *  It only terminates the given fiber and no other fiber, returning +nil+ to
+ *  another fiber if that fiber was calling #resume or #transfer.
  *
- *  +Fiber#kill+ only interrupts another Fiber when it is in +Fiber.yield+.
- *  If called on the current Fiber then it raises that exception at the +Fiber#kill+ call site.
+ *  <tt>Fiber#kill</tt> only interrupts another fiber when it is in Fiber.yield.
+ *  If called on the current fiber then it raises that exception at the <tt>Fiber#kill</tt> call site.
  *
  *  If the fiber has not been started, transition directly to the terminated state.
  *
  *  If the fiber is already terminated, does nothing.
  *
- *  Raises +FiberError+ if called on a Fiber belonging to another +Thread+.
+ *  Raises FiberError if called on a fiber belonging to another thread.
  */
 static VALUE
 rb_fiber_m_kill(VALUE self)

--- a/dir.c
+++ b/dir.c
@@ -1322,7 +1322,7 @@ dir_s_fchdir(VALUE klass, VALUE fd_value)
  *   Dir.pwd # => "/"
  *   dir = Dir.new('example')
  *   dir.chdir
- *   dir.pwd # => "/example"
+ *   Dir.pwd # => "/example"
  *
  */
 static VALUE

--- a/error.c
+++ b/error.c
@@ -291,11 +291,11 @@ rb_warning_s_warn(int argc, VALUE *argv, VALUE mod)
  *
  *  Changing the behavior of Warning.warn is useful to customize how warnings are
  *  handled by Ruby, for instance by filtering some warnings, and/or outputting
- *  warnings somewhere other than $stderr.
+ *  warnings somewhere other than <tt>$stderr</tt>.
  *
  *  If you want to change the behavior of Warning.warn you should use
- *  +Warning.extend(MyNewModuleWithWarnMethod)+ and you can use `super`
- *  to get the default behavior of printing the warning to $stderr.
+ *  <tt>Warning.extend(MyNewModuleWithWarnMethod)</tt> and you can use +super+
+ *  to get the default behavior of printing the warning to <tt>$stderr</tt>.
  *
  *  Example:
  *    module MyWarningFilter
@@ -312,7 +312,7 @@ rb_warning_s_warn(int argc, VALUE *argv, VALUE mod)
  *  You should never redefine Warning#warn (the instance method), as that will
  *  then no longer provide a way to use the default behavior.
  *
- *  The +warning+ gem provides convenient ways to customize Warning.warn.
+ *  The warning[https://rubygems.org/gems/warning] gem provides convenient ways to customize Warning.warn.
  */
 
 static VALUE

--- a/range.c
+++ b/range.c
@@ -2394,14 +2394,14 @@ empty_region_p(VALUE beg, VALUE end, int excl)
  *  This method assumes that there is no minimum value because
  *  Ruby lacks a standard method for determining minimum values.
  *  This assumption is invalid.
- *  For example, there is no value smaller than +-Float::INFINITY+,
- *  making +(...-Float::INFINITY)+ an empty set.
- *  Consequently, +(...-Float::INFINITY)+ has no elements in common with itself,
- *  yet +(...-Float::INFINITY).overlap?((...-Float::INFINITY))+ returns
- *  true due to this assumption.
- *  In general, if +r = (...minimum); r.overlap?(r)+ returns +true+,
+ *  For example, there is no value smaller than <tt>-Float::INFINITY</tt>,
+ *  making <tt>(...-Float::INFINITY)</tt> an empty set.
+ *  Consequently, <tt>(...-Float::INFINITY)</tt> has no elements in common with itself,
+ *  yet <tt>(...-Float::INFINITY).overlap?((...-Float::INFINITY))<tt> returns
+ *  +true+ due to this assumption.
+ *  In general, if <tt>r = (...minimum); r.overlap?(r)</tt> returns +true+,
  *  where +minimum+ is a value that no value is smaller than.
- *  Such values include +-Float::INFINITY+, +[]+, +""+, and
+ *  Such values include <tt>-Float::INFINITY</tt>, <tt>[]</tt>, <tt>""</tt>, and
  *  classes without subclasses.
  *
  *  Related: Range#cover?.


### PR DESCRIPTION
Mostly for newly introduced features, mostly just fixing RDoc's incorrect treatment of `+`:

* [Fiber#kill](https://docs.ruby-lang.org/en/master/Fiber.html#method-i-kill): rendering glitches with `+`, downcasing some `Fiber` word instances to have less links/monospace (like other methods around do);
* [Range#overlap?](https://docs.ruby-lang.org/en/master/Range.html#method-i-overlap-3F): rendering glitches with `+`;
* [Warning](https://docs.ruby-lang.org/en/master/Warning.html) (module docs): rendering glitches with `+`, a link to `warning` gem;
* [Dir#chdir](https://docs.ruby-lang.org/en/master/Dir.html#method-i-chdir): typo in the example code.