### PR TITLE
Add a fudge factor to the GC compaction move up/down tests

### DIFF
--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -313,7 +313,7 @@ class TestGCCompact < Test::Unit::TestCase
 
     assert_separately(%w[-robjspace], "#{<<~"begin;"}\n#{<<~"end;"}", timeout: 10, signal: :SEGV)
     begin;
-      ARY_COUNT = 500
+      ARY_COUNT = 50000
 
       GC.verify_compaction_references(expand_heap: true, toward: :empty)
 
@@ -325,7 +325,7 @@ class TestGCCompact < Test::Unit::TestCase
       }.resume
 
       stats = GC.verify_compaction_references(expand_heap: true, toward: :empty)
-      assert_operator(stats.dig(:moved_down, :T_ARRAY) || 0, :>=, ARY_COUNT)
+      assert_operator(stats.dig(:moved_down, :T_ARRAY) || 0, :>=, ARY_COUNT - 10)
       refute_empty($arys.keep_if { |o| ObjectSpace.dump(o).include?('"embedded":true') })
     end;
   end
@@ -335,7 +335,7 @@ class TestGCCompact < Test::Unit::TestCase
 
     assert_separately(%w[-robjspace], "#{<<~"begin;"}\n#{<<~"end;"}", timeout: 10, signal: :SEGV)
     begin;
-      ARY_COUNT = 500
+      ARY_COUNT = 50000
 
       GC.verify_compaction_references(expand_heap: true, toward: :empty)
 
@@ -349,7 +349,7 @@ class TestGCCompact < Test::Unit::TestCase
       }.resume
 
       stats = GC.verify_compaction_references(expand_heap: true, toward: :empty)
-      assert_operator(stats.dig(:moved_up, :T_ARRAY) || 0, :>=, ARY_COUNT)
+      assert_operator(stats.dig(:moved_up, :T_ARRAY) || 0, :>=, ARY_COUNT - 10)
       refute_empty($arys.keep_if { |o| ObjectSpace.dump(o).include?('"embedded":true') })
     end;
   end
@@ -367,7 +367,7 @@ class TestGCCompact < Test::Unit::TestCase
         end
       end
 
-      OBJ_COUNT = 500
+      OBJ_COUNT = 50000
 
       GC.verify_compaction_references(expand_heap: true, toward: :empty)
 
@@ -381,7 +381,7 @@ class TestGCCompact < Test::Unit::TestCase
 
       stats = GC.verify_compaction_references(expand_heap: true, toward: :empty)
 
-      assert_operator(stats.dig(:moved_up, :T_OBJECT) || 0, :>=, OBJ_COUNT)
+      assert_operator(stats.dig(:moved_up, :T_OBJECT) || 0, :>=, OBJ_COUNT - 10)
       refute_empty($ary.keep_if { |o| ObjectSpace.dump(o).include?('"embedded":true') })
     end;
   end
@@ -402,7 +402,7 @@ class TestGCCompact < Test::Unit::TestCase
 
       stats = GC.verify_compaction_references(expand_heap: true, toward: :empty)
 
-      assert_operator(stats[:moved_up][:T_STRING], :>=, STR_COUNT)
+      assert_operator(stats[:moved_up][:T_STRING], :>=, STR_COUNT - 10)
       refute_empty($ary.keep_if { |o| ObjectSpace.dump(o).include?('"embedded":true') })
     end;
   end
@@ -422,7 +422,7 @@ class TestGCCompact < Test::Unit::TestCase
 
       stats = GC.verify_compaction_references(expand_heap: true, toward: :empty)
 
-      assert_operator(stats[:moved_down][:T_STRING], :>=, STR_COUNT)
+      assert_operator(stats[:moved_down][:T_STRING], :>=, STR_COUNT - 10)
       refute_empty($ary.keep_if { |o| ObjectSpace.dump(o).include?('"embedded":true') })
     end;
   end
@@ -446,7 +446,7 @@ class TestGCCompact < Test::Unit::TestCase
 
       stats = GC.verify_compaction_references(expand_heap: true, toward: :empty)
 
-      assert_operator(stats[:moved_down][:T_HASH], :>=, HASH_COUNT)
+      assert_operator(stats[:moved_down][:T_HASH], :>=, HASH_COUNT - 10)
     end;
   end
 


### PR DESCRIPTION
There seems to be another manifestation of bug #20021, where some of the compaction tests are failing on i686 for unrelated PR's because of fake "live" references to moved objects on the machine stack.

We _could_ solve this by counting how many objects are pinned during compaction, but doing that involves pushing down the mark & pin bitset merge into gc_compact_plane and out of gc_compact_page, which I thought was pretty ugly.

Now that we've solved bug #20022 though, we're able to compact arbitrarily many objects with GC.verify_compaction_references, so the number of objects we're moving is now 50,000 instead of 500. Since that's now much larger than the number of objects likely to be pinned, I think it's safe enough to just add a fudge-factor to the tests.

Any _other_ change in GC.verify_compaction_references that breaks compaction is now highly likely to break the assertion by more than 10 objects, since it's operating on so many more in the first place.

[Bug #20021]