### PR TITLE
Fix test of GVL instrumentation on Ractor sleeping

### DIFF
--- a/test/-ext-/thread/test_instrumentation_api.rb
+++ b/test/-ext-/thread/test_instrumentation_api.rb
@@ -172,6 +172,7 @@ class TestThreadInstrumentation < Test::Unit::TestCase
           sleep 0.1
           Thread.current
         }.take
+        sleep 0.1
       end
 
       timeline = timeline_for(thread, full_timeline)


### PR DESCRIPTION
It seems that the Ractor sleep GVL event arrives very slightly after the value becomes available and other threads wake (which makes sense) so we need a little additional time to ensure we end up in a consisteny state.