### PR TITLE
Address feedback on previous postponed job PR

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -277,6 +277,18 @@ changelog for details of the default gems or bundled gems.
 
 ## C API updates
 
+* `rb_postponed_job` changes
+
+    The postponed job APIs have been changed to address some rare crashes.
+    There are two new methods for managing postponed jobs; `rb_postponed_job_preregister`
+    and `rb_postponed_job_trigger`. These APIs replace `rb_postponed_job_register`
+    and `rb_postponed_job_register_once`, which are now marked as deprecated.
+    The semantics of these functions have also changed slightly; `rb_postponed_job_register`
+    now behaves like the `once` variant in that multiple calls with the same
+    `func` might be coalesced into a single execution of the `func`
+
+    [[Feature #20057]]
+
 ## Implementation improvements
 
 * `defined?(@ivar)` is optimized with Object Shapes.
@@ -409,3 +421,4 @@ changelog for details of the default gems or bundled gems.
 [Feature #19843]: https://bugs.ruby-lang.org/issues/19843
 [Bug #19868]:     https://bugs.ruby-lang.org/issues/19868
 [Feature #19965]: https://bugs.ruby-lang.org/issues/19965
+[Feature #20057]: https://bugs.ruby-lang.org/issues/20057

--- a/ext/-test-/tracepoint/gc_hook.c
+++ b/ext/-test-/tracepoint/gc_hook.c
@@ -2,11 +2,6 @@
 #include "ruby/debug.h"
 
 static int invoking; /* TODO: should not be global variable */
-static VALUE gc_start_proc;
-static VALUE gc_end_proc;
-static rb_postponed_job_handle_t invoking_proc_pjob;
-static bool pjob_execute_gc_start_proc_p;
-static bool pjob_execute_gc_end_proc_p;
 
 static VALUE
 invoke_proc_ensure(VALUE _)
@@ -22,35 +17,25 @@ invoke_proc_begin(VALUE proc)
 }
 
 static void
-invoke_proc(void *unused)
+invoke_proc(void *data)
 {
-    if (pjob_execute_gc_start_proc_p) {
-        pjob_execute_gc_start_proc_p = false;
-        invoking += 1;
-        rb_ensure(invoke_proc_begin, gc_start_proc, invoke_proc_ensure, 0);
-    }
-    if (pjob_execute_gc_end_proc_p) {
-        pjob_execute_gc_end_proc_p = false;
-        invoking += 1;
-        rb_ensure(invoke_proc_begin, gc_end_proc, invoke_proc_ensure, 0);
-    }
+    VALUE proc = (VALUE)data;
+    invoking += 1;
+    rb_ensure(invoke_proc_begin, proc, invoke_proc_ensure, 0);
 }
 
 static void
 gc_start_end_i(VALUE tpval, void *data)
 {
-    rb_trace_arg_t *tparg = rb_tracearg_from_tracepoint(tpval);
     if (0) {
+        rb_trace_arg_t *tparg = rb_tracearg_from_tracepoint(tpval);
         fprintf(stderr, "trace: %s\n", rb_tracearg_event_flag(tparg) == RUBY_INTERNAL_EVENT_GC_START ? "gc_start" : "gc_end");
     }
 
     if (invoking == 0) {
-        if (rb_tracearg_event_flag(tparg) == RUBY_INTERNAL_EVENT_GC_START) {
-            pjob_execute_gc_start_proc_p = true;
-        } else {
-            pjob_execute_gc_end_proc_p = true;
-        }
-        rb_postponed_job_trigger(invoking_proc_pjob);
+        /* will overwrite the existing handle with new data on the second and subsequent call */
+        rb_postponed_job_handle_t h = rb_postponed_job_preregister(0, invoke_proc, data);
+        rb_postponed_job_trigger(h);
     }
 }
 
@@ -71,13 +56,8 @@ set_gc_hook(VALUE module, VALUE proc, rb_event_flag_t event, const char *tp_str,
         if (!rb_obj_is_proc(proc)) {
             rb_raise(rb_eTypeError, "trace_func needs to be Proc");
         }
-        if (event == RUBY_INTERNAL_EVENT_GC_START) {
-            gc_start_proc = proc;
-        } else {
-            gc_end_proc = proc;
-        }
 
-        tpval = rb_tracepoint_new(0, event, gc_start_end_i, 0);
+        tpval = rb_tracepoint_new(0, event, gc_start_end_i, (void *)proc);
         rb_ivar_set(module, tp_key, tpval);
         rb_tracepoint_enable(tpval);
     }
@@ -104,10 +84,4 @@ Init_gc_hook(VALUE module)
 {
     rb_define_module_function(module, "after_gc_start_hook=", set_after_gc_start, 1);
     rb_define_module_function(module, "after_gc_exit_hook=", start_after_gc_exit, 1);
-    rb_gc_register_address(&gc_start_proc);
-    rb_gc_register_address(&gc_end_proc);
-    invoking_proc_pjob = rb_postponed_job_preregister(0, invoke_proc, NULL);
-    if (invoking_proc_pjob == POSTPONED_JOB_HANDLE_INVALID) {
-        rb_raise(rb_eStandardError, "could not preregister invoke_proc");
-    }
 }

--- a/test/-ext-/postponed_job/test_postponed_job.rb
+++ b/test/-ext-/postponed_job/test_postponed_job.rb
@@ -25,6 +25,14 @@ class TestPostponed_job < Test::Unit::TestCase
     RUBY
   end
 
+  def test_multiple_preregistration_with_new_data
+    assert_separately([], __FILE__, __LINE__, <<-'RUBY')
+      require '-test-/postponed_job'
+      values = Bug.postponed_job_preregister_calls_with_last_argument
+      # i.e. the callback is called with the last argument it was preregistered with
+      assert_equal [3, 4], values
+    RUBY
+  end
 
   def test_legacy_register
     assert_separately([], __FILE__, __LINE__, <<-'RUBY')

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -1678,16 +1678,16 @@ rb_workqueue_register(unsigned flags, rb_postponed_job_func_t func, void *data)
     return TRUE;
 }
 
-#define PJOB_PREREG_TABLE_SIZE              (sizeof(rb_atomic_t) * CHAR_BIT)
+#define PJOB_TABLE_SIZE              (sizeof(rb_atomic_t) * CHAR_BIT)
 /* pre-registered jobs table, for async-safe jobs */
 typedef struct rb_postponed_job_queue {
     struct {
         rb_postponed_job_func_t func;
         void *data;
-    } prereg_table[PJOB_PREREG_TABLE_SIZE];
+    } table[PJOB_TABLE_SIZE];
     /* Bits in this are set when the corresponding entry in prereg_table has non-zero
      * triggered_count; i.e. somebody called rb_postponed_job_trigger */
-    rb_atomic_t prereg_triggered_bitset;
+    rb_atomic_t triggered_bitset;
 } rb_postponed_job_queues_t;
 
 void
@@ -1696,8 +1696,8 @@ rb_vm_postponed_job_queue_init(rb_vm_t *vm)
     /* use mimmalloc; postponed job registration is a dependency of objspace, so this gets
      * called _VERY_ early inside Init_BareVM */
     rb_postponed_job_queues_t *pjq = ruby_mimmalloc(sizeof(rb_postponed_job_queues_t));
-    pjq->prereg_triggered_bitset = 0;
-    memset(pjq->prereg_table, 0, sizeof(pjq->prereg_table));
+    pjq->triggered_bitset = 0;
+    memset(pjq->table, 0, sizeof(pjq->table));
     vm->postponed_job_queue = pjq;
 }
 
@@ -1716,7 +1716,7 @@ rb_vm_postponed_job_atfork(void)
     rb_postponed_job_queues_t *pjq = vm->postponed_job_queue;
     /* make sure we set the interrupt flag on _this_ thread if we carried any pjobs over
      * from the other side of the fork */
-    if (pjq->prereg_triggered_bitset) {
+    if (pjq->triggered_bitset) {
         RUBY_VM_SET_POSTPONED_JOB_INTERRUPT(get_valid_ec(vm));
     }
 
@@ -1753,15 +1753,15 @@ rb_postponed_job_preregister(unsigned int flags, rb_postponed_job_func_t func, v
      * func, however, the data may get mixed up between them. */
 
     rb_postponed_job_queues_t *pjq = GET_VM()->postponed_job_queue;
-    for (unsigned int i = 0; i < PJOB_PREREG_TABLE_SIZE; i++) {
+    for (unsigned int i = 0; i < PJOB_TABLE_SIZE; i++) {
         /* Try and set this slot to equal `func` */
-        rb_postponed_job_func_t existing_func = (rb_postponed_job_func_t)RUBY_ATOMIC_PTR_CAS(pjq->prereg_table[i], NULL, (void *)func);
+        rb_postponed_job_func_t existing_func = (rb_postponed_job_func_t)RUBY_ATOMIC_PTR_CAS(pjq->table[i], NULL, (void *)func);
         if (existing_func == NULL || existing_func == func) {
             /* Either this slot was NULL, and we set it to func, or, this slot was already equal to func.
              * In either case, clobber the data with our data. Note that concurrent calls to
              * rb_postponed_job_register with the same func & different data will result in either of the
              * datas being written */
-            RUBY_ATOMIC_PTR_EXCHANGE(pjq->prereg_table[i].data, data);
+            RUBY_ATOMIC_PTR_EXCHANGE(pjq->table[i].data, data);
             return (rb_postponed_job_handle_t)i;
         } else {
             /* Try the next slot if this one already has a func in it */
@@ -1779,7 +1779,7 @@ rb_postponed_job_trigger(rb_postponed_job_handle_t h)
     rb_vm_t *vm = GET_VM();
     rb_postponed_job_queues_t *pjq = vm->postponed_job_queue;
 
-    RUBY_ATOMIC_OR(pjq->prereg_triggered_bitset, (((rb_atomic_t)1UL) << h));
+    RUBY_ATOMIC_OR(pjq->triggered_bitset, (((rb_atomic_t)1UL) << h));
     RUBY_VM_SET_POSTPONED_JOB_INTERRUPT(get_valid_ec(vm));
 }
 
@@ -1826,7 +1826,7 @@ rb_postponed_job_flush(rb_vm_t *vm)
     ccan_list_append_list(&tmp, &vm->workqueue);
     rb_nativethread_lock_unlock(&vm->workqueue_lock);
 
-    rb_atomic_t prereg_triggered_bits = RUBY_ATOMIC_EXCHANGE(pjq->prereg_triggered_bitset, 0);
+    rb_atomic_t triggered_bits = RUBY_ATOMIC_EXCHANGE(pjq->triggered_bitset, 0);
 
     ec->errinfo = Qnil;
     /* mask POSTPONED_JOB dispatch */
@@ -1835,11 +1835,11 @@ rb_postponed_job_flush(rb_vm_t *vm)
         EC_PUSH_TAG(ec);
         if (EC_EXEC_TAG() == TAG_NONE) {
             /* execute postponed jobs */
-            while (prereg_triggered_bits) {
-                unsigned int i = bit_length(prereg_triggered_bits) - 1;
-                prereg_triggered_bits ^= ((1UL) << i); /* toggle ith bit off */
-                rb_postponed_job_func_t func = pjq->prereg_table[i].func;
-                void *data = pjq->prereg_table[i].data;
+            while (triggered_bits) {
+                unsigned int i = bit_length(triggered_bits) - 1;
+                triggered_bits ^= ((1UL) << i); /* toggle ith bit off */
+                rb_postponed_job_func_t func = pjq->table[i].func;
+                void *data = pjq->table[i].data;
                 (func)(data);
             }
 
@@ -1870,8 +1870,8 @@ rb_postponed_job_flush(rb_vm_t *vm)
     }
     /* likewise with any remaining-to-be-executed bits of the preregistered postponed
      * job table */
-    if (prereg_triggered_bits) {
-        RUBY_ATOMIC_OR(pjq->prereg_triggered_bitset, prereg_triggered_bits);
+    if (triggered_bits) {
+        RUBY_ATOMIC_OR(pjq->triggered_bitset, triggered_bits);
         RUBY_VM_SET_POSTPONED_JOB_INTERRUPT(GET_EC());
     }
 }


### PR DESCRIPTION
This PR just has some minor fixes in response to feedback in https://github.com/ruby/ruby/pull/8949

* Doc enhancements
* Refactor some local variable names
* Revert the changes to the tracepoint tests (they are unnescessary with the semantics of `rb_postponed_job_preregister` we finally settled on)
* Added a test case to assert that multiple calls to preregister updates the stored data.