### PR TITLE
[PRISM] Define and use a pm_add_ensure_iseq

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -847,6 +847,15 @@ module Prism
           end
         end
       CODE
+      assert_prism_eval(<<-CODE)
+        def self.prism_test_ensure_node
+          begin
+          ensure
+          end
+          return
+        end
+        prism_test_ensure_node
+      CODE
     end
 
     def test_NextNode


### PR DESCRIPTION
Prior to this commit, we were using `add_ensure_iseq` which compiled a node as if it was a CRuby node. This commit defines `pm_add_ensure_iseq` which compiles the Prism node appropriately.