### PR TITLE
Use xfree for IO::Buffer

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -262,7 +262,7 @@ rb_io_buffer_type_free(void *_buffer)
 
     io_buffer_free(buffer);
 
-    free(buffer);
+    xfree(buffer);
 }
 
 size_t


### PR DESCRIPTION
Since IO::Buffer is allocated using TypedData_Make_Struct, it must use xfree to free the buffer otherwise it will cause more major GC to run.

Example:

```ruby
10.times do
  1_000_000.times { IO::Buffer.new(0) }

  puts "oldmalloc_increase_bytes: #{GC.stat(:oldmalloc_increase_bytes)}, major_gc_count: #{GC.stat(:major_gc_count)}"
end
```

Before:

```
oldmalloc_increase_bytes: 14904176, major_gc_count: 3
oldmalloc_increase_bytes: 2399424, major_gc_count: 5
oldmalloc_increase_bytes: 5204640, major_gc_count: 6
oldmalloc_increase_bytes: 2199936, major_gc_count: 7
oldmalloc_increase_bytes: 34199936, major_gc_count: 7
oldmalloc_increase_bytes: 24223360, major_gc_count: 8
oldmalloc_increase_bytes: 5967616, major_gc_count: 9
oldmalloc_increase_bytes: 37967616, major_gc_count: 9
oldmalloc_increase_bytes: 9689792, major_gc_count: 10
oldmalloc_increase_bytes: 41689792, major_gc_count: 10
```

After:

```
oldmalloc_increase_bytes: 117392, major_gc_count: 2
oldmalloc_increase_bytes: 26128, major_gc_count: 2
oldmalloc_increase_bytes: 71600, major_gc_count: 2
oldmalloc_increase_bytes: 117072, major_gc_count: 2
oldmalloc_increase_bytes: 17296, major_gc_count: 2
oldmalloc_increase_bytes: 62768, major_gc_count: 2
oldmalloc_increase_bytes: 108240, major_gc_count: 2
oldmalloc_increase_bytes: 153712, major_gc_count: 2
oldmalloc_increase_bytes: 53936, major_gc_count: 2
oldmalloc_increase_bytes: 99408, major_gc_count: 2
```