### PR TITLE
Handle case of Bootsnap

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -102,6 +102,8 @@ module Gem::BUNDLED_GEMS
     else
       return
     end
+    # Warning feature is not working correctly with Bootsnap
+    return if caller_locations(2,1)[0]&.path.match?(/bootsnap/)
     return if WARNED[name]
     WARNED[name] = true
     if gem == true

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -102,8 +102,12 @@ module Gem::BUNDLED_GEMS
     else
       return
     end
-    # Warning feature is not working correctly with Bootsnap
-    return if caller_locations(2,1)[0]&.path.match?(/bootsnap/)
+    # Warning feature is not working correctly with Bootsnap.
+    # caller_locations returns:
+    #   lib/ruby/3.3.0+0/bundled_gems.rb:65:in `block (2 levels) in replace_require'
+    #   $GEM_HOME/gems/bootsnap-1.17.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'"
+    #   ...
+    return if caller_locations(2).find {|c| c&.path.match?(/bootsnap/) }
     return if WARNED[name]
     WARNED[name] = true
     if gem == true


### PR DESCRIPTION
[Bug #20060]

https://bugs.ruby-lang.org/issues/20060

Bootsnap always use `LIBPATH` for the default gems. So, We can't detect default gems.