### PR TITLE
[PRISM] Implement forwarding of args on ForwardingSuperNode

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -4448,9 +4448,16 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
                 pm_constant_id_t name = ((pm_rest_parameter_node_t *)parameters_node->rest)->name;
                 if (name) {
+                    // def foo(a, (b, *c, d), e = 1, *f, g, (h, *i, j),  k:, l: 1, **m, &n)
+                    //                               ^^
                     pm_insert_local_index(name, local_index, index_lookup_table, local_table_for_iseq, scope_node);
-                    local_index++;
                 }
+                else {
+                    // def foo(a, (b, *c, d), e = 1, *, g, (h, *i, j),  k:, l: 1, **m, &n)
+                    //                               ^
+                    local_table_for_iseq->ids[local_index] = idMULT;
+                }
+                local_index++;
             }
         }
 

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1543,6 +1543,22 @@ module Prism
     def test_ForwardingSuperNode
       assert_prism_eval("class Forwarding; def to_s; super; end; end")
       assert_prism_eval("class Forwarding; def eval(code); super { code }; end; end")
+      assert_prism_eval(<<-CODE)
+        class A
+          def initialize(a, b)
+          end
+        end
+
+        class B < A
+          attr_reader :res
+          def initialize(a, b, *)
+            super
+            @res = [a, b]
+          end
+        end
+
+        B.new(1, 2).res
+      CODE
     end
 
     def test_KeywordHashNode


### PR DESCRIPTION
Prior to this commit, we were not actually emitting the correct iseqs for the forwarded args on ForwardingSuperNodes. This commit implements that logic, largely copying what was already done in CRuby and using the information we've stored on the local iseq about parameters to compute the relevant values to forward.

Closes https://github.com/ruby/prism/issues/2048