### PR TITLE
[PRISM] Correctly parse non-base 10 integers in Prism

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -78,8 +78,8 @@ pm_iseq_new_with_opt(pm_scope_node_t *scope_node, pm_parser_t *parser, VALUE nam
 static VALUE
 parse_integer(const pm_integer_node_t *node)
 {
-    const char *start = (const char *) node->base.location.start;
-    const char *end = (const char *) node->base.location.end;
+    char *start = (char *) node->base.location.start;
+    char *end = (char *) node->base.location.end;
 
     size_t length = end - start;
     int base = -10;
@@ -101,7 +101,7 @@ parse_integer(const pm_integer_node_t *node)
         rb_bug("Unexpected integer base");
     }
 
-    return rb_int_parse_cstr(start, length, NULL, NULL, base, RB_INT_PARSE_DEFAULT);
+    return rb_int_parse_cstr(start, length, &end, NULL, base, RB_INT_PARSE_DEFAULT);
 }
 
 static VALUE

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -34,6 +34,7 @@ module Prism
       assert_prism_eval("0b10")
       assert_prism_eval("0o10")
       assert_prism_eval("010")
+      assert_prism_eval("(0o00)")
     end
 
     def test_NilNode


### PR DESCRIPTION
This commit passes an `end` to rb_int_parse_cstr which allows us to correctly parse non-base 10 integers which are enclosed in parenthesis. Prior to this commit, we were getting a putobject nil when compiling `(0o0)` for example.