### PR TITLE
[PRISM] Fix segv with regex once flag

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1437,6 +1437,7 @@ pm_scope_node_init(const pm_node_t *node, pm_scope_node_t *scope, pm_scope_node_
         case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE: {
             RUBY_ASSERT(node->flags & PM_REGULAR_EXPRESSION_FLAGS_ONCE);
             scope->body = (pm_node_t *)node;
+            scope->local_depth_offset += 1;
             break;
         }
         case PM_LAMBDA_NODE: {

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -601,6 +601,7 @@ module Prism
       assert_prism_eval('/pit/ne')
 
       assert_prism_eval('2.times.map { /#{1}/o }')
+      assert_prism_eval('2.times.map { foo = 1; /#{foo}/o }')
     end
 
     def test_StringNode


### PR DESCRIPTION
When you have an interpolated regex with a `once` flag and local variable is outside the block created by the `once` flag, Prism would see a segv. This is because it was not taking the depth into account.

To fix this, we need to add 1 to the `local_depth_offset` on the `scope`.

Fixes: ruby/prism#2047

cc/ @jemmaissroff @tenderlove 