### PR TITLE
Move --repeat-count=2 job to macos-arm-oss

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,6 +32,9 @@ jobs:
         test_task: ['check']
         configure: ['']
         os: ${{ fromJSON(format('["macos-11","macos-12"{0}]', (github.repository == 'ruby/ruby' && ',"macos-arm-oss"' || ''))) }}
+        include:
+          - test_task: test-all TESTS=--repeat-count=2
+            os: ${{ github.repository == 'ruby/ruby' && 'macos-arm-oss' || 'macos-12' }}
       fail-fast: false
 
     env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -40,7 +40,6 @@ jobs:
             configure: '--disable-yjit'
           - test_task: check
             configure: '--enable-shared --enable-load-relative'
-          - test_task: test-all TESTS=--repeat-count=2
           - test_task: test-bundler-parallel
           - test_task: test-bundled-gems
       fail-fast: false


### PR DESCRIPTION
This is by far the slowest job out of all required status checks.

`macos-arm-oss` is a very fast machine. If we're only interested in `--repeat-count=2` safety, it should be okay to test this on `macos-arm-oss` instead.