### PR TITLE
[PRISM] Add a test with a non-static-literal hash key

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -659,6 +659,7 @@ module Prism
       assert_prism_eval("{ to_s: }")
       assert_prism_eval("{ Prism: }")
       assert_prism_eval("[ Prism: [:b, :c]]")
+      assert_prism_eval("{ [] => 1}")
     end
 
     def test_ImplicitNode


### PR DESCRIPTION
This new test file makes sure the Prism compiler works properly by deoptimizing in the cases where hash keys are not static literals.

Related to: https://github.com/ruby/prism/issues/2015