### PR TITLE
Make String#chomp! raise ArgumentError for 2+ arguments if string is empty

### DIFF
--- a/string.c
+++ b/string.c
@@ -9689,7 +9689,7 @@ rb_str_chomp_bang(int argc, VALUE *argv, VALUE str)
 {
     VALUE rs;
     str_modifiable(str);
-    if (RSTRING_LEN(str) == 0) return Qnil;
+    if (RSTRING_LEN(str) == 0 && argc < 2) return Qnil;
     rs = chomp_rs(argc, argv);
     if (NIL_P(rs)) return Qnil;
     return rb_str_chomp_string(str, rs);

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -587,6 +587,8 @@ CODE
     assert_equal("foo", s.chomp!("\n"))
     s = "foo\r"
     assert_equal("foo", s.chomp!("\n"))
+
+    assert_raise(ArgumentError) {String.new.chomp!("", "")}
   ensure
     $/ = save
     $VERBOSE = verbose

--- a/tool/ln_sr.rb
+++ b/tool/ln_sr.rb
@@ -96,7 +96,7 @@ unless respond_to?(:ln_sr)
     while c = comp.shift
       if c == ".." and clean.last != ".." and !(fu_have_symlink? && File.symlink?(path))
         clean.pop
-        path.chomp!(%r((?<=\A|/)[^/]+/\z), "")
+        path.sub!(%r((?<=\A|/)[^/]+/\z), "")
       else
         clean << c
         path << c << "/"


### PR DESCRIPTION
`String#chomp!` returned `nil` without checking the number of passed arguments in this case.

Found by `tool/ln_sr.rb` passing multiple arguments to `chomp!`  I am guessing `sub!` was intended instead of `chomp!`, so this switches the method.