### PR TITLE
[PRISM] Fix two mismatches between {x,}malloc and {,x}free

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -5030,7 +5030,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             }
         }
 
-        free(index_lookup_table);
+        st_free_table(index_lookup_table);
 
         if (!PM_NODE_TYPE_P(scope_node->ast_node, PM_ENSURE_NODE)) {
             ADD_INSN(ret, &dummy_line_node, leave);

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -4616,7 +4616,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             const VALUE default_values = rb_ary_hidden_new(1);
             const VALUE complex_mark = rb_str_tmp_new(0);
 
-            ID *ids = calloc(keywords_list->size, sizeof(ID));
+            ID *ids = xcalloc(keywords_list->size, sizeof(ID));
 
             for (size_t i = 0; i < keywords_list->size; i++, local_index++) {
                 pm_node_t *keyword_parameter_node = keywords_list->nodes[i];


### PR DESCRIPTION
Two mismatches in *alloc and *free:
* We need to use xcalloc on the iseq's ID table, as the iseq will be later freed using `xfree`
* We were calling `free` on an st_table without deallocating its internal buffers (and also we need to use xfree).

Co authored with @matthewd