### PR TITLE
RJIT: Just skip generating code for aarch64/arm64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3916,26 +3916,26 @@ AC_SUBST(CARGO_BUILD_ARGS)dnl for selecting Rust build profiles
 AC_SUBST(YJIT_LIBS)dnl for optionally building the Rust parts of YJIT
 AC_SUBST(YJIT_OBJ)dnl for optionally building the C parts of YJIT
 
-dnl Currently, RJIT only supports Unix x86_64 platforms.
+dnl RJIT supports only x86_64 platforms, but allows arm64/aarch64 for custom JITs.
 RJIT_TARGET_OK=no
 AS_IF([test "$cross_compiling" = no],
     AS_CASE(["$target_cpu-$target_os"],
         [*android*], [
             RJIT_TARGET_OK=no
         ],
-        [x86_64-darwin*], [
+        [arm64-darwin*|aarch64-darwin*|x86_64-darwin*], [
             RJIT_TARGET_OK=yes
         ],
-        [x86_64-*linux*], [
+        [arm64-*linux*|aarch64-*linux*|x86_64-*linux*], [
             RJIT_TARGET_OK=yes
         ],
-        [x86_64-*bsd*], [
+        [arm64-*bsd*|aarch64-*bsd*|x86_64-*bsd*], [
             RJIT_TARGET_OK=yes
         ]
     )
 )
 
-dnl Build RJIT on Unix x86_64 platforms or if --enable-rjit is specified.
+dnl Build RJIT on supported platforms or if --enable-rjit is specified.
 AC_ARG_ENABLE(rjit,
     AS_HELP_STRING([--enable-rjit],
     [enable pure-Ruby JIT compiler. enabled by default on Unix x86_64 platforms]),

--- a/lib/ruby_vm/rjit/compiler.rb
+++ b/lib/ruby_vm/rjit/compiler.rb
@@ -59,6 +59,7 @@ module RubyVM::RJIT
     # @param iseq `RubyVM::RJIT::CPointer::Struct_rb_iseq_t`
     # @param cfp `RubyVM::RJIT::CPointer::Struct_rb_control_frame_t`
     def compile(iseq, cfp)
+      return unless supported_platform?
       pc = cfp.pc.to_i
       jit = JITState.new(iseq:, cfp:)
       asm = Assembler.new
@@ -503,6 +504,13 @@ module RubyVM::RJIT
     def assert(cond)
       unless cond
         raise "'#{cond.inspect}' was not true"
+      end
+    end
+
+    def supported_platform?
+      return @supported_platform if defined?(@supported_platform)
+      @supported_platform = RUBY_PLATFORM.match?(/x86_64/).tap do |supported|
+        warn "warning: RJIT does not support #{RUBY_PLATFORM} yet" unless supported
       end
     end
   end


### PR DESCRIPTION
We merged https://github.com/ruby/ruby/pull/8222, but this resurrects automatic RJIT enablement on aarch64/arm64 as per @tenderlove's request.