### PR TITLE
[PRISM] Account for multiple anonymous locals

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1117,6 +1117,8 @@ module Prism
       assert_prism_eval("[].tap { _1 }")
 
       assert_prism_eval("[].each { |a,| }")
+      assert_prism_eval("[[1, 2, 3]].map { |_, _, a| a }")
+      assert_prism_eval("[[1, 2, 3]].map { |_, a| a }")
 
       assert_prism_eval("[[]].map { |a| a }")
       assert_prism_eval("[[]].map { |a| a }")


### PR DESCRIPTION
This commit adjusts the local table size to be consistent regardless of the number of anonymous locals.