### PR TITLE
A fix for bundled_gems + bootsnap error

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -85,7 +85,7 @@ module Gem::BUNDLED_GEMS
     else
       return
     end
-    EXACT[n] or PREFIXED[n = n[%r[\A[^/]+(?=/)]]] && n
+    (EXACT[n] or PREFIXED[n = n[%r[\A[^/]+(?=/)]]]) && n
   end
 
   def self.warning?(name, specs: nil)


### PR DESCRIPTION
[Bug #20060]
I think I found a simple fix for https://bugs.ruby-lang.org/issues/20060.

The root cause of this error seems to me that [this line](https://github.com/ruby/ruby/blob/0f1c7e3bcb2ee0cb38d228ba0d23f52ceef5623c/lib/bundled_gems.rb#L88) was returning `true` instead of the matched gem name in some cases (thus, bootsnap is in fact not at all related). Changing this line to always return the gem name should fix the error.