### PR TITLE
YJIT: Add --yjit-disable to help and reorder it

### DIFF
--- a/doc/yjit/yjit.md
+++ b/doc/yjit/yjit.md
@@ -165,15 +165,17 @@ The machine code generated for a given method can be printed by adding `puts Rub
 YJIT supports all command-line options supported by upstream CRuby, but also adds a few YJIT-specific options:
 
 - `--yjit`: enable YJIT (disabled by default)
+- `--yjit-exec-mem-size=N`: size of the executable memory block to allocate, in MiB (default 64 MiB)
 - `--yjit-call-threshold=N`: number of calls after which YJIT begins to compile a function (default 30)
 - `--yjit-cold-threshold=N`: number of global calls after which an ISEQ is considered cold and not
-compiled, lower values mean less code is compiled (default 200K)
-- `--yjit-exec-mem-size=N`: size of the executable memory block to allocate, in MiB (default 64 MiB)
-- `--yjit-code-gc`: enable code GC (disabled by default as of Ruby 3.3)
+  compiled, lower values mean less code is compiled (default 200K)
 - `--yjit-stats`: print statistics after the execution of a program (incurs a run-time cost)
 - `--yjit-stats=quiet`: gather statistics while running a program but don't print them. Stats are accessible through `RubyVM::YJIT.runtime_stats`. (incurs a run-time cost)
+- `--yjit-disable`: disable YJIT despite other `--yjit*` flags for lazily enabling it with `RubyVM::YJIT.enable`
+- `--yjit-code-gc`: enable code GC (disabled by default as of Ruby 3.3)
+- `--yjit-perf`: enable frame pointers and profiling with the `perf` tool
 - `--yjit-trace-exits`: produce a Marshal dump of backtraces from specific exits. Automatically enables `--yjit-stats`
-- `--yjit-perf`: Enable frame pointers and profiling with the `perf` tool
+- `--yjit-trace-exits-sample-rate=N`: trace exit locations only every Nth occurrence
 
 Note that there is also an environment variable `RUBY_YJIT_ENABLE` which can be used to enable YJIT.
 This can be useful for some deployment scripts where specifying an extra command-line option to Ruby is not practical.

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -100,15 +100,16 @@ pub static mut OPTIONS: Options = Options {
 };
 
 /// YJIT option descriptions for `ruby --help`.
-static YJIT_OPTIONS: [(&str, &str); 8] = [
-    ("--yjit-stats",                    "Enable collecting YJIT statistics"),
-    ("--yjit-trace-exits",              "Record Ruby source location when exiting from generated code"),
-    ("--yjit-trace-exits-sample-rate",  "Trace exit locations only every Nth occurrence"),
-    ("--yjit-exec-mem-size=num",        "Size of executable memory block in MiB (default: 64)"),
-    ("--yjit-code-gc",                  "Run code GC when the code size reaches the limit"),
-    ("--yjit-call-threshold=num",       "Number of calls to trigger JIT"),
-    ("--yjit-cold-threshold=num",       "Global call after which ISEQs not compiled (default: 200K)"),
-    ("--yjit-perf",                     "Enable frame pointers and perf profiling"),
+static YJIT_OPTIONS: [(&str, &str); 9] = [
+    ("--yjit-exec-mem-size=num",           "Size of executable memory block in MiB (default: 64)"),
+    ("--yjit-call-threshold=num",          "Number of calls to trigger JIT"),
+    ("--yjit-cold-threshold=num",          "Global calls after which ISEQs not compiled (default: 200K)"),
+    ("--yjit-stats",                       "Enable collecting YJIT statistics"),
+    ("--yjit-disable",                     "Disable YJIT for lazily enabling it with RubyVM::YJIT.enable"),
+    ("--yjit-code-gc",                     "Run code GC when the code size reaches the limit"),
+    ("--yjit-perf",                        "Enable frame pointers and perf profiling"),
+    ("--yjit-trace-exits",                 "Record Ruby source location when exiting from generated code"),
+    ("--yjit-trace-exits-sample-rate=num", "Trace exit locations only every Nth occurrence"),
 ];
 
 #[derive(Clone, PartialEq, Eq, Debug)]


### PR DESCRIPTION
* Add missing `--yjit-disable` to help
* Fix `s/--yjit-trace-exits-sample-rate/--yjit-trace-exits-sample-rate=num/` in help
* Reorder options in help:
  * Major tuning options first, stats second, memory optimization-related stuff third, and profiling at last.
* Make yjit.md consistent with help