### PR TITLE
[PRISM] Fix bugs in compiling optional keyword parameters

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -4684,21 +4684,15 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                     pm_node_t *value = cast->value;
                     name = cast->name;
 
-                    switch PM_NODE_TYPE(value) {
-                      case PM_FALSE_NODE:
-                      case PM_FLOAT_NODE:
-                      case PM_INTEGER_NODE:
-                      case PM_IMAGINARY_NODE:
-                      case PM_NIL_NODE:
-                      case PM_RATIONAL_NODE:
-                      case PM_STRING_NODE:
-                      case PM_SYMBOL_NODE:
-                      case PM_TRUE_NODE:
+                    if (pm_static_literal_p(value) &&
+                            !(PM_NODE_TYPE_P(value, PM_ARRAY_NODE) ||
+                                PM_NODE_TYPE_P(value, PM_HASH_NODE) ||
+                                PM_NODE_TYPE_P(value, PM_RANGE_NODE))) {
+
                        rb_ary_push(default_values, pm_static_literal_value(value, scope_node, parser));
-                       break;
-                      default: {
+                    }
+                    else {
                         rb_ary_push(default_values, complex_mark);
-                      }
                     }
 
                     break;
@@ -4934,18 +4928,10 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                     pm_node_t *value = cast->value;
                     name = cast->name;
 
-                    switch PM_NODE_TYPE(value) {
-                      case PM_FALSE_NODE:
-                      case PM_FLOAT_NODE:
-                      case PM_INTEGER_NODE:
-                      case PM_IMAGINARY_NODE:
-                      case PM_NIL_NODE:
-                      case PM_RATIONAL_NODE:
-                      case PM_STRING_NODE:
-                      case PM_SYMBOL_NODE:
-                      case PM_TRUE_NODE:
-                        break;
-                      default: {
+                    if (!(pm_static_literal_p(value)) ||
+                            PM_NODE_TYPE_P(value, PM_ARRAY_NODE) ||
+                            PM_NODE_TYPE_P(value, PM_HASH_NODE) ||
+                            PM_NODE_TYPE_P(value, PM_RANGE_NODE)) {
                         LABEL *end_label = NEW_LABEL(nd_line(&dummy_line_node));
 
                         int index = pm_lookup_local_index(iseq, scope_node, name);
@@ -4956,8 +4942,8 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                         ADD_SETLOCAL(ret, &dummy_line_node, index, 0);
 
                         ADD_LABEL(ret, end_label);
-                      }
                     }
+                    break;
                   }
                   // def foo(a, (b, *c, d), e = 1, *f, g, (h, *i, j),  k:, l: 1, **m, &n)
                   //                                                   ^^

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1168,6 +1168,12 @@ module Prism
         end
         prism_test_def_node(10, b: 3)
       CODE
+      assert_prism_eval(<<-CODE)
+        def self.prism_test_def_node(a: [])
+          a
+        end
+        prism_test_def_node
+      CODE
 
       # block arguments
       assert_prism_eval("def self.prism_test_def_node(&block) block end; prism_test_def_node{}.class")


### PR DESCRIPTION
This PR fixes two bugs when compiling optional keyword parameters:
- It moves keyword parameter compilation to STEP 5 in the parameters sequence, where the rest of compilation happens. This is important because keyword parameter compilation relies on the value of body->param.keyword->bits_start which gets set in an earlier step
- It compiles array and hash values for keyword parameters, which it didn't previously

Closes https://github.com/ruby/prism/issues/2063
Closes https://github.com/ruby/prism/issues/2068
Closes https://github.com/ruby/prism/issues/2065