### PR TITLE
[DOC] [ci-skip] Shorter example for `Module#instance_method`

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -2138,29 +2138,29 @@ rb_obj_singleton_method(VALUE obj, VALUE vid)
  *
  *  Returns an +UnboundMethod+ representing the given
  *  instance method in _mod_.
+ *  See +UnboundMethod+ about how to utilize it
  *
- *     class Interpreter
- *       def do_a() print "there, "; end
- *       def do_d() print "Hello ";  end
- *       def do_e() print "!\n";     end
- *       def do_v() print "Dave";    end
- *       Dispatcher = {
- *         "a" => instance_method(:do_a),
- *         "d" => instance_method(:do_d),
- *         "e" => instance_method(:do_e),
- *         "v" => instance_method(:do_v)
- *       }
- *       def interpret(string)
- *         string.each_char {|b| Dispatcher[b].bind(self).call }
- *       end
- *     end
+ *    class Person
+ *      def initialize(name)
+ *        @name = name
+ *      end
  *
- *     interpreter = Interpreter.new
- *     interpreter.interpret('dave')
+ *      def hi
+ *        puts "Hi, I'm #{@name}!"
+ *      end
+ *    end
+ *
+ *     dave = Person.new('Dave')
+ *     thomas = Person.new('Thomas')
+ *
+ *     hi = Person.instance_method(:hi)
+ *     hi.bind_call(dave)
+ *     hi.bind_call(thomas)
  *
  *  <em>produces:</em>
  *
- *     Hello there, Dave!
+ *     Hi, I'm Dave!
+ *     Hi, I'm Thomas!
  */
 
 static VALUE


### PR DESCRIPTION
The previous example code was too complex and includes extra logics that's not relevant to its main usage: `bind`.
The new example code focuses on `bind_call` so that readers can understand how it works more easily.