### PR TITLE
[Prism] Fix cvar or assignment instructions

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2552,6 +2552,13 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         pm_class_variable_or_write_node_t *class_variable_or_write_node = (pm_class_variable_or_write_node_t*) node;
 
         LABEL *end_label = NEW_LABEL(lineno);
+        LABEL *start_label = NEW_LABEL(lineno);
+
+        ADD_INSN(ret, &dummy_line_node, putnil);
+        ADD_INSN3(ret, &dummy_line_node, defined, INT2FIX(DEFINED_CVAR),
+                ID2SYM(pm_constant_id_lookup(scope_node, class_variable_or_write_node->name)), Qtrue);
+
+        ADD_INSNL(ret, &dummy_line_node, branchunless, start_label);
 
         ID class_variable_name_id = pm_constant_id_lookup(scope_node, class_variable_or_write_node->name);
         VALUE class_variable_name_val = ID2SYM(class_variable_name_id);
@@ -2565,6 +2572,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         ADD_INSNL(ret, &dummy_line_node, branchif, end_label);
 
         PM_POP_UNLESS_POPPED;
+        ADD_LABEL(ret, start_label);
 
         PM_COMPILE_NOT_POPPED(class_variable_or_write_node->value);
 


### PR DESCRIPTION
The instructions for `PM_CLASS_VARIABLE_OR_WRITE_NODE` were incorrect as they were missing a `putnil`, a `defined`, and a `branchunless`.

I verified this is fixed via the instructions and running the following: `RUBY_ISEQ_DUMP_DEBUG=prism make test/csv/interface/test_read_write.rb`.

These new instructions can't go in the defined function because `defined?(@@fop ||= 1)` should return "assignment" not "class variable".

Instructions before:

```
"********* Ruby *************"
== disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(30,11)>
0000 putnil                                                           (  30)[Li]
0001 defined                                class variable, :@@foo, true
0005 branchunless                           14
0007 getclassvariable                       :@@foo, <is:0>
0010 dup
0011 branchif                               20
0013 pop
0014 putobject                              1
0016 dup
0017 setclassvariable                       :@@foo, <is:0>
0020 leave

"********* PRISM *************"
== disasm: #<ISeq:<compiled>@<compiled>:29 (29,0)-(29,11)>
0000 getclassvariable                       :@@foo, <is:0>            (  29)[Li]
0003 dup
0004 branchif                               13
0006 pop
0007 putobject                              1
0009 dup
0010 setclassvariable                       :@@foo, <is:0>
0013 leave
```

Instructions after:

```
"********* Ruby *************"
== disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(30,11)>
0000 putnil                                                           (  30)[Li]
0001 defined                                class variable, :@@foo, true
0005 branchunless                           14
0007 getclassvariable                       :@@foo, <is:0>
0010 dup
0011 branchif                               20
0013 pop
0014 putobject                              1
0016 dup
0017 setclassvariable                       :@@foo, <is:0>
0020 leave

"********* PRISM *************"
== disasm: #<ISeq:<compiled>@<compiled>:29 (29,0)-(29,11)>
0000 putnil                                                           (  29)[Li]
0001 defined                                class variable, :@@foo, true
0005 branchunless                           14
0007 getclassvariable                       :@@foo, <is:0>
0010 dup
0011 branchif                               20
0013 pop
0014 putobject                              1
0016 dup
0017 setclassvariable                       :@@foo, <is:0>
0020 leave
```

Fixes ruby/prism#2064

cc/ @jemmaissroff @tenderlove @kddnewton 