### PR TITLE
[PRISM] Fix keyword hash handling in method calls

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1446,6 +1446,18 @@ module Prism
       CODE
 
       assert_prism_eval(<<-CODE)
+        def self.foo(*args, **kwargs) = [args, kwargs]
+
+        [
+          foo(2 => 3),
+          foo([] => 42),
+          foo(a: 42, b: 61),
+          foo(1, 2, 3, a: 42, "b" => 61),
+          foo(:a => 42, :b => 61),
+        ]
+      CODE
+
+      assert_prism_eval(<<-CODE)
         class PrivateMethod
           def initialize
             self.instance_var


### PR DESCRIPTION
* Start using the renamed `PM_KEYWORD_HASH_NODE_FLAGS_SYMBOL_KEYS` flag to check if all keys of the keyword hash node are symbols. Ref: https://github.com/ruby/prism/pull/2069
* For arguments passed as a hash, start marking them as `KW_SPLAT_MUT` only if the number of entries in the hash is greater than 1 (which is what the old compiler used to do).

Also added a test case that would have failed previously. 