### PR TITLE
[PRISM] Clean up calls to rb_bug and rb_raise within Prism

### DIFF
--- a/prism/prism.h
+++ b/prism/prism.h
@@ -260,7 +260,7 @@ PRISM_EXPORTED_FUNCTION const char * pm_token_type_to_str(pm_token_type_t token_
  *     pm_buffer_t buffer = { 0 };
  *
  *     pm_prettyprint(&buffer, &parser, root);
- *     printf("*.s%\n", (int) buffer.length, buffer.value);
+ *     printf("%*.s\n", (int) buffer.length, buffer.value);
  *
  *     pm_buffer_free(&buffer);
  *     pm_node_destroy(&parser, root);


### PR DESCRIPTION
prism_compile.c has been inconsistent about when it calls rb_bug and rb_raise. This commit cleans up those calls in anticipation of the Ruby 3.3 release