### PR TITLE
free ractors with ractor_free

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4607,7 +4607,7 @@ rb_objspace_free_objects(rb_objspace_t *objspace)
             VALUE vp = (VALUE)p;
             switch (BUILTIN_TYPE(vp)) {
               case T_DATA: {
-                if (rb_obj_is_mutex(vp) || rb_obj_is_thread(vp)) {
+                if (rb_obj_is_mutex(vp) || rb_obj_is_thread(vp) || rb_obj_is_main_ractor(vp)) {
                     obj_free(objspace, vp);
                 }
                 break;

--- a/vm.c
+++ b/vm.c
@@ -3006,9 +3006,6 @@ ruby_vm_destruct(rb_vm_t *vm)
             rb_free_warning();
             rb_free_rb_global_tbl();
             rb_free_loaded_features_index(vm);
-            rb_ractor_t *r = vm->ractor.main_ractor;
-            xfree(r->sync.recv_queue.baskets);
-            xfree(r->sync.takers_queue.baskets);
 
             rb_id_table_free(vm->negative_cme_table);
             st_free_table(vm->overloaded_cme_table);
@@ -3060,7 +3057,6 @@ ruby_vm_destruct(rb_vm_t *vm)
                 rb_objspace_free_objects(objspace);
                 rb_free_generic_iv_tbl_();
                 if (th) {
-                    xfree(th->ractor);
                     xfree(stack);
                     ruby_mimfree(th);
                 }


### PR DESCRIPTION
Previously with RUBY_FREE_ON_EXIT, ractors where being xfree-ed which is incorrect since they are not xmalloced. Instead we can free ractors with ractor free during shutdown. This change only effects main ractor freeing when RUBY_FREE_ON_EXIT is set.

CC: @peterzhu2118 