### PR TITLE
[DOC] Fix doc for `refinements`

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -1547,7 +1547,7 @@ mod_using(VALUE self, VALUE module)
  *  call-seq:
  *     refinements -> array
  *
- *  Returns an array of modules defined within the receiver.
+ *  Returns an array of +Refinement+ defined within the receiver.
  *
  *     module A
  *       refine Integer do


### PR DESCRIPTION
The current doc is partially wrong since `refinements` method returns an array of `Refinement` class, not `Module`.
I'm not sure if it's right to link to `Refinement`, but it has some documentation so it should be useful.
https://docs.ruby-lang.org/en/3.2/Refinement.html