### PR TITLE
Loading/testing rb_ext_resolve_symbol in different processes for multiple runs

### DIFF
--- a/test/-ext-/load/test_resolve_symbol.rb
+++ b/test/-ext-/load/test_resolve_symbol.rb
@@ -3,22 +3,25 @@ require 'test/unit'
 
 class Test_Load_ResolveSymbol < Test::Unit::TestCase
   def test_load_resolve_symbol_resolver
-    feature = "Feature #20005"
-    assert_raise(LoadError, "resolve_symbol_target is not loaded") {
-      require '-test-/load/resolve_symbol_resolver'
-    }
-    require '-test-/load/resolve_symbol_target'
-    assert_nothing_raised(LoadError, "#{feature} resolver can be loaded") {
-      require '-test-/load/resolve_symbol_resolver'
-    }
-    assert_not_nil ResolveSymbolResolver
-    assert_equal "from target", ResolveSymbolResolver.any_method
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      feature = "Feature #20005"
+      assert_raise(LoadError, "resolve_symbol_target is not loaded") {
+        require '-test-/load/resolve_symbol_resolver'
+      }
+      require '-test-/load/resolve_symbol_target'
+      assert_nothing_raised(LoadError, "#{feature} resolver can be loaded") {
+        require '-test-/load/resolve_symbol_resolver'
+      }
+      assert_not_nil ResolveSymbolResolver
+      assert_equal "from target", ResolveSymbolResolver.any_method
 
-    assert_raise(LoadError, "tries to resolve missing feature name, and it should raise LoadError") {
-      ResolveSymbolResolver.try_resolve_fname
-    }
-    assert_raise(LoadError, "tries to resolve missing symbol name, and it should raise LoadError") {
-      ResolveSymbolResolver.try_resolve_sname
-    }
+      assert_raise(LoadError, "tries to resolve missing feature name, and it should raise LoadError") {
+        ResolveSymbolResolver.try_resolve_fname
+      }
+      assert_raise(LoadError, "tries to resolve missing symbol name, and it should raise LoadError") {
+        ResolveSymbolResolver.try_resolve_sname
+      }
+    end;
   end
 end


### PR DESCRIPTION
To fix the CI failure: http://ci.rvm.jp/logfiles/brlog.trunk-repeat50.20231215-054006#L2470

This tests passed on my laptop with:
> $ make test-all RUBYOPT=-w TESTOPTS="--stderr-on-failure" TESTS="../test/-ext-/load/test_*.rb --repeat-count=2"