### PR TITLE
Follow removed conflict files

### DIFF
--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -544,6 +544,8 @@ module SyncDefaultGems
         end
         if editor
           system([editor, conflict].join(' '))
+          conflict.delete_if {|f| !File.exist?(f)}
+          return true if conflict.empty?
           return system(*%w"git add --", *conflict)
         end
       end


### PR DESCRIPTION
After editing a conflict, continue without removed files.

ruby/rdoc@e4c9034 conflicts at lib/rdoc/markdown.kpeg.