### PR TITLE
rb_bug_for_fatal_signal: exit with the right signal

### DIFF
--- a/error.c
+++ b/error.c
@@ -1066,6 +1066,7 @@ rb_bug_for_fatal_signal(ruby_sighandler_t default_sighandler, int sig, const voi
 
     if (default_sighandler) default_sighandler(sig);
 
+    ruby_default_signal(sig);
     die();
 }
 


### PR DESCRIPTION
`die()` calls `abort()` which always exit as if `SIGABRT` was received.

This isn't very friendly with systems that automatically collect crashes as the `%s` parameter will be changed.