### PR TITLE
[Bug #20062] Fixed numbered parameter syntax error

### DIFF
--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1767,6 +1767,7 @@ eom
 
     assert_valid_syntax("proc {def foo(_);end;_1}")
     assert_valid_syntax("p { [_1 **2] }")
+    assert_valid_syntax("proc {_1;def foo();end;_1}")
   end
 
   def test_it


### PR DESCRIPTION
At the method definition, the local scope that saves the context of the numbered parameters needs to be pushed before saving.

https://bugs.ruby-lang.org/issues/20062