### PR TITLE
We don't use tracked_files in before(:suite). It breaks with release package

### DIFF
--- a/spec/bundler/support/path.rb
+++ b/spec/bundler/support/path.rb
@@ -80,7 +80,7 @@ module Spec
     end
 
     def shipped_files
-      @shipped_files ||= ruby_core? ? tracked_files : loaded_gemspec.files
+      @shipped_files ||= ruby_core? ? (loaded_gemspec.files - ["exe/bundle", "exe/bundler"] + ["libexec/bundle", "libexec/bundler"]) : loaded_gemspec.files
     end
 
     def lib_tracked_files

--- a/spec/bundler/support/path.rb
+++ b/spec/bundler/support/path.rb
@@ -80,7 +80,7 @@ module Spec
     end
 
     def shipped_files
-      @shipped_files ||= ruby_core? ? (loaded_gemspec.files - ["exe/bundle", "exe/bundler"] + ["libexec/bundle", "libexec/bundler"]) : loaded_gemspec.files
+      @shipped_files ||= ruby_core? ? loaded_gemspec.files.map{|f| f.gsub(/^exe\//, "libexec/")} : loaded_gemspec.files
     end
 
     def lib_tracked_files


### PR DESCRIPTION
https://github.com/rubygems/rubygems/issues/7297