### PR TITLE
Use native_thread_init_stack on cygwin

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -2062,10 +2062,6 @@ native_thread_init_stack(rb_thread_t *th)
     return 0;
 }
 
-#ifndef __CYGWIN__
-#define USE_NATIVE_THREAD_INIT 1
-#endif
-
 struct nt_param {
     rb_vm_t *vm;
     struct rb_native_thread *nt;
@@ -2174,13 +2170,8 @@ native_thread_create_dedicated(rb_thread_t *th)
 static void
 call_thread_start_func_2(rb_thread_t *th)
 {
-#if defined USE_NATIVE_THREAD_INIT
     native_thread_init_stack(th);
     thread_start_func_2(th, th->ec->machine.stack_start);
-#else
-    VALUE stack_start;
-    thread_start_func_2(th, &stack_start);
-#endif
 }
 
 static void *


### PR DESCRIPTION
Ensure that native_thread_init_stack is also called on Cygwin.

ruby does not call native_thread_init_stack on Cygwin because the signal stack implementation in Cygwin at the time is half baked.
- https://github.com/ruby/ruby/commit/6957c6d9cf0b6a1e211c4b0175bc5474296f2031

But it seems that signal stack was also implemented on Cygwin in 2015.
- https://github.com/cygwin/cygwin/commit/22465796edbfd6f156ca2930f56b3345cc54b164

After applying this fix, `test_ractor.rb`, `test_thread.rb`, etc... which were causing segmentation faults now pass.

```
test_ractor.rb            FAIL 4/107
#1315 test_ractor.rb:1523:
     workers = (0...8).map do
       Ractor.new do
         loop do
           10_000.times.map { Object.new }
           Ractor.yield Time.now
         end
       end
     end

     1_000.times { idle_worker, tmp_reporter = Ractor.select(*workers) }
     "ok"
  #=> "" (expected "ok")
stderr output is not empty
   <internal:ractor>:644: [BUG] Segmentation fault at 0x0000000000000000
   ruby 3.3.0dev (2023-12-16T05:52:30Z master f535f53cd6) [x86_64-cygwin]

   -- Control frame information -----------------------------------------------
   c:0005 p:0003 s:0021 e:000020 METHOD <internal:ractor>:644
   c:0004 p:0016 s:0014 e:000013 BLOCK  bootstraptest.test_ractor.rb_1523_1315.rb:8
   c:0003 p:0018 s:0011 e:000010 METHOD <internal:kernel>:187
   c:0002 p:0004 s:0006 e:000005 BLOCK  bootstraptest.test_ractor.rb_1523_1315.rb:6 [FINISH]
   c:0001 p:---- s:0003 e:000002 DUMMY  [FINISH]

   -- Ruby level backtrace information ----------------------------------------
   bootstraptest.test_ractor.rb_1523_1315.rb:6:in `block (2 levels) in <main>'
   <internal:kernel>:187:in `loop'
   bootstraptest.test_ractor.rb_1523_1315.rb:8:in `block (3 levels) in <main>'
   <internal:ractor>:644:in `yield'

   -- Threading information ---------------------------------------------------
   Total ractor count: 9
   Ruby thread count for this ractor: 1

   -- Other runtime information -----------------------------------------------

   * Loaded script: bootstraptest.test_ractor.rb_1523_1315.rb

   * Loaded features:

       0 enumerator.so
       1 thread.rb
       2 fiber.so
       3 rational.so
       4 complex.so
       5 ruby2_keywords.rb
       6 /tmp/ruby/.ext/x86_64-cygwin/enc/encdb.so
       7 /tmp/ruby/.ext/x86_64-cygwin/enc/trans/transdb.so

test_thread.rb            /#<Thread:0x00006fffe5a84238 ./bootstraptest/runner.rb:449 run> terminated with exception (report_on_exception is true):
./bootstraptest/runner.rb:449:in `read': temporal unlocking already unlocked string (RuntimeError)
        from ./bootstraptest/runner.rb:449:in `block in with_stderr'
#1511 test_thread.rb:217: temporal unlocking already unlocked string  [ruby-dev:31371]
FAIL 1/50
:
:
:
```