### PR TITLE
[wasm] dln.c: Guard `dladdr` use in symbol incompatibility check

### DIFF
--- a/dln.c
+++ b/dln.c
@@ -272,13 +272,15 @@ rb_w32_check_imported(HMODULE ext, HMODULE mine)
 static bool
 dln_incompatible_func(void *handle, const char *funcname, void *const fp, const char **libname)
 {
-    Dl_info dli;
     void *ex = dlsym(handle, funcname);
     if (!ex) return false;
     if (ex == fp) return false;
+#  if defined(HAVE_DLADDR)
+    Dl_info dli;
     if (dladdr(ex, &dli)) {
         *libname = dli.dli_fname;
     }
+#  endif
     return true;
 }
 


### PR DESCRIPTION
wasi-libc recently added a family of `dl*` functions[^1], but it still doesn't have `dladdr` unlike other platforms. Guard the use of `dladdr` with `HAVE_DLADDR` to avoid build failure with the head version of wasi-libc.
The library name is used only for diagnostic purposes if it's not NULL, so it's safe to skip it.

This is a part of a patch series to support dynamic linking on WebAssembly.

[^1]: https://github.com/WebAssembly/wasi-libc/commit/b85d65528d6e17ae1874c6cc6a6a3ac02e83021a