### PR TITLE
Optimize allocations in `Hash#compare_by_identity`

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -4377,13 +4377,16 @@ rb_hash_compare_by_id(VALUE hash)
     if (hash_iterating_p(hash)) {
         rb_raise(rb_eRuntimeError, "compare_by_identity during iteration");
     }
-    ar_force_convert_table(hash, __FILE__, __LINE__);
-    HASH_ASSERT(RHASH_ST_TABLE_P(hash));
 
     if (RHASH_TABLE_EMPTY_P(hash)) {
         // Fast path: There's nothing to rehash, so we don't need a `tmp` table.
+        // We're most likely an AR table, so this will need an allocation.
+        ar_force_convert_table(hash, __FILE__, __LINE__);
+        HASH_ASSERT(RHASH_ST_TABLE_P(hash));
+
         RHASH_ST_TABLE(hash)->type = &identhash;
-    } else {
+    }
+    else {
         // Slow path: Need to rehash the members of `self` into a new
         // `tmp` table using the new `identhash` compare/hash functions.
         tmp = hash_alloc(0);
@@ -4391,8 +4394,10 @@ rb_hash_compare_by_id(VALUE hash)
         identtable = RHASH_ST_TABLE(tmp);
 
         rb_hash_foreach(hash, rb_hash_rehash_i, (VALUE)tmp);
-
         rb_hash_free(hash);
+
+        // We know for sure `identtable` is an st table,
+        // so we can skip `ar_force_convert_table` here.
         RHASH_ST_TABLE_SET(hash, identtable);
         RHASH_ST_CLEAR(tmp);
     }


### PR DESCRIPTION
* If `self` is an empty Hash, then we don't need to allocate the `tmp` Hash (since there's nothing to re-hash).
* If `self` is non-empty, then we don't need to bother with `ar_force_convert_table`. We're going to discard that table and replace it with the new `identtable` st table that we're stealing out of `tmp`.

So in either case, we get one less allocation.

This simple micro-benchmark clocks it as ~1.7x faster than before:

```
Comparison:
 After: {}.compare_by_identity: 13725103.3 i/s
Before: {}.compare_by_identity:  8085211.5 i/s - 1.70x  slower
```

Oddly, the difference is even larger (~1.85x) if you `GC.disable` (though this "same-ish: difference falls within error" conclusion seems pretty wrong...):

```
Comparison:
 After: {}.compare_by_identity:  9306969.8 i/s
Before: {}.compare_by_identity:  5036135.4 i/s - same-ish: difference falls within error
```

<details><summary><code>benchmark.rb</code></summary>

```ruby
#!/usr/bin/ruby

require "benchmark/ips"

# GC.disable

Benchmark.ips do |x|
  x.report("Before: {}.compare_by_identity") do |times|
    i = 0
    while (i += 1) < times
      {}.compare_by_identity
    end
  end
  
  x.compare!
  x.hold!("compare_by_identity.json")
  
  x.report(" After: {}.compare_by_identity") do |times|
    i = 0
    while (i += 1) < times
      {}.compare_by_identity
    end
  end
  
  x.compare!
end
```

</p>
</details> 
