### PR TITLE
Make the SHAPE_TOO_COMPLEX performance warning more actionable

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -733,9 +733,10 @@ rb_shape_get_next(rb_shape_t *shape, VALUE obj, ID id)
                 if (RCLASS_EXT(klass)->variation_count >= SHAPE_MAX_VARIATIONS) {
                     rb_category_warn(
                         RB_WARN_CATEGORY_PERFORMANCE,
-                        "Maximum shapes variations (%d) reached by %"PRIsVALUE", instance variables accesses will be slower.",
-                        SHAPE_MAX_VARIATIONS,
-                        rb_class_path(klass)
+                        "The class %"PRIsVALUE" reached %d shape variations, instance variables accesses will be slower and memory usage increased.\n"
+                        "It is recommended to define instance variable in a consistent order, for instance by eagerly defining them all in the `initialize` method.",
+                        rb_class_path(klass),
+                        SHAPE_MAX_VARIATIONS
                     );
                 }
             }

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -458,7 +458,7 @@ class TestObject < Test::Unit::TestCase
   end
 
   def test_max_shape_variation_with_performance_warnings
-    assert_in_out_err([], <<-INPUT, %w(), /Maximum shapes variations \(8\) reached by Foo, instance variables accesses will be slower\.$/)
+    assert_in_out_err([], <<-INPUT, %w(), /The class Foo reached 8 shape variations, instance variables accesses will be slower and memory usage increased/)
       $VERBOSE = false
       Warning[:performance] = true
 


### PR DESCRIPTION
As suggested by @mame, we should try to help users fix the issues without having to lookup the meaning of the warning.