### PR TITLE
clear `sched->lock_onwer` at fork

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1129,6 +1129,11 @@ void
 rb_thread_sched_init(struct rb_thread_sched *sched, bool atfork)
 {
     rb_native_mutex_initialize(&sched->lock_);
+
+#if VM_CHECK_MODE
+    sched->lock_owner = NULL;
+#endif
+
     ccan_list_head_init(&sched->readyq);
     sched->readyq_cnt = 0;
 


### PR DESCRIPTION
`sched->lock_owner` can be non-NULL at fork because the timer thread can acquire the lock while forking. `lock_owner` information is for debugging, so we only need to clear it at fork.

I hope this patch fixes the following assertion failure:
```
thread_pthread.c:354:thread_sched_lock_:sched->lock_owner == NULL
```