### PR TITLE
Fix flaky test test_stat_heap

### DIFF
--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -151,8 +151,13 @@ class TestGc < Test::Unit::TestCase
     GC.stat(stat)
 
     GC::INTERNAL_CONSTANTS[:SIZE_POOL_COUNT].times do |i|
-      GC.stat_heap(i, stat_heap)
-      GC.stat(stat)
+      begin
+        reenable_gc = !GC.disable
+        GC.stat_heap(i, stat_heap)
+        GC.stat(stat)
+      ensure
+        GC.enable if reenable_gc
+      end
 
       assert_equal GC::INTERNAL_CONSTANTS[:RVALUE_SIZE] * (2**i), stat_heap[:slot_size]
       assert_operator stat_heap[:heap_allocatable_pages], :<=, stat[:heap_allocatable_pages]


### PR DESCRIPTION
The test sometimes fails with:

    1) Failure:
    TestGc#test_stat_heap [/tmp/ruby/src/trunk-repeat50/test/ruby/test_gc.rb:169]:
    Expected 33434403 to be <= 33434354.