### PR TITLE
Unmask signal before re-raising fatal signal

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -403,6 +403,9 @@ interrupt_init(int argc, VALUE *argv, VALUE self)
 }
 
 void rb_malloc_info_show_results(void); /* gc.c */
+#ifdef POSIX_SIGNAL
+static void reset_sigmask(int sig);
+#endif
 
 void
 ruby_default_signal(int sig)
@@ -413,6 +416,9 @@ ruby_default_signal(int sig)
     rb_malloc_info_show_results();
 
     signal(sig, SIG_DFL);
+#ifdef POSIX_SIGNAL
+    reset_sigmask(sig);
+#endif
     raise(sig);
 }
 


### PR DESCRIPTION
On Linux, while the signal handler runs, that signal is masked, so we
translated fatal signals to SIGABRT unintentionally. See signal(7).
It worked fine on macOS, though.

Before:

    $ ./miniruby -e 'Process.kill :SIGSEGV, Process.pid'
    <snip>
    Aborted (core dumped)

After:

    $ ./miniruby -e 'Process.kill :SIGSEGV, Process.pid'
    <snip>
    Segmentation fault (core dumped)

Follow-up for 1ac0afab4da "rb_bug_for_fatal_signal: exit with the right
signal".

cc: @byroot 
