### PR TITLE
Support `GC.auto_compact = :empty` on debug builds

### DIFF
--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -245,9 +245,9 @@ module EnvUtil
   end
   module_function :under_gc_stress
 
-  def under_gc_compact_stress(&block)
+  def under_gc_compact_stress(val = :empty, &block)
     auto_compact = GC.auto_compact
-    GC.auto_compact = true
+    GC.auto_compact = val
     under_gc_stress(&block)
   ensure
     GC.auto_compact = auto_compact


### PR DESCRIPTION
This commit adds `GC.auto_compact = :empty` which will run auto-compaction sorting pages by empty slots so the most amount of objects will be moved. This will make it easier to write tests for auto-compaction.

cc. @tenderlove 