### PR TITLE
We need to load builtins so that they work

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -2410,6 +2410,7 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
             }
 
             iseq = rb_iseq_new_main_prism(&input, &options, path);
+            ruby_opt_init(opt);
 
             pm_string_free(&input);
             pm_options_free(&options);


### PR DESCRIPTION
Before this commit no methods defined in Ruby were being loaded. For example `class` or `tap` methods would not exist.

I think this plugs a leak in the current implementation but we should probably revisit how Prism is integrated in to the Ruby boot process.

cc @eightbitraptor 