### PR TITLE
signal.c: Fix undefined `reset_sigmask` use on Emscripten

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -403,7 +403,7 @@ interrupt_init(int argc, VALUE *argv, VALUE self)
 }
 
 void rb_malloc_info_show_results(void); /* gc.c */
-#ifdef POSIX_SIGNAL
+#if defined(USE_SIGALTSTACK) || defined(_WIN32)
 static void reset_sigmask(int sig);
 #endif
 
@@ -416,7 +416,7 @@ ruby_default_signal(int sig)
     rb_malloc_info_show_results();
 
     signal(sig, SIG_DFL);
-#ifdef POSIX_SIGNAL
+#if defined(USE_SIGALTSTACK) || defined(_WIN32)
     reset_sigmask(sig);
 #endif
     raise(sig);


### PR DESCRIPTION
3c471149910d79745b50389c436f0ed2973e0d91 added a call to `reset_sigmask` but the guard condition didn't match with the condition used to define `reset_sigmask`.

It resulted build failure with Emscripten https://rubyci.s3.amazonaws.com/crossruby/crossruby-master-wasm32_emscripten/log/20231219T015418Z.fail.html.gz