### PR TITLE
YJIT: Add stats option to RubyVM::YJIT.enable

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -1171,7 +1171,7 @@ VALUE rb_yjit_insns_compiled(rb_execution_context_t *ec, VALUE self, VALUE iseq)
 VALUE rb_yjit_code_gc(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_simulate_oom_bang(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_get_exit_locations(rb_execution_context_t *ec, VALUE self);
-VALUE rb_yjit_enable(rb_execution_context_t *ec, VALUE self);
+VALUE rb_yjit_enable(rb_execution_context_t *ec, VALUE self, VALUE gen_stats, VALUE print_stats);
 
 // Preprocessed yjit.rb generated during build
 #include "yjit.rbinc"

--- a/yjit.rb
+++ b/yjit.rb
@@ -29,8 +29,10 @@ module RubyVM::YJIT
   end
 
   # Enable \YJIT compilation.
-  def self.enable
-    Primitive.rb_yjit_enable
+  def self.enable(stats: false)
+    return false if enabled?
+    at_exit { print_and_dump_stats } if stats
+    Primitive.rb_yjit_enable(stats, stats != :quiet)
   end
 
   # If --yjit-trace-exits is enabled parse the hashes from
@@ -223,18 +225,21 @@ module RubyVM::YJIT
     Primitive.rb_yjit_simulate_oom_bang
   end
 
-  # Avoid calling a method here to not interfere with compilation tests
+  # Avoid calling a Ruby method here to not interfere with compilation tests
   if Primitive.rb_yjit_stats_enabled_p
-    at_exit do
+    at_exit { print_and_dump_stats }
+  end
+
+  class << self # :stopdoc:
+    private
+
+    # Print stats and dump exit locations
+    def print_and_dump_stats
       if Primitive.rb_yjit_print_stats_p
         _print_stats
       end
       _dump_locations
     end
-  end
-
-  class << self # :stopdoc:
-    private
 
     def _dump_locations # :nodoc:
       return unless trace_exit_locations_enabled?

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -249,9 +249,9 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         ("no-type-prop", "") => unsafe { OPTIONS.no_type_prop = true },
         ("stats", _) => match opt_val {
             "" => unsafe { OPTIONS.gen_stats = true },
-            "quiet" => {
-                unsafe { OPTIONS.gen_stats = true }
-                unsafe { OPTIONS.print_stats = false }
+            "quiet" => unsafe {
+                OPTIONS.gen_stats = true;
+                OPTIONS.print_stats = false;
             },
             _ => {
                 return None;

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -168,13 +168,13 @@ pub extern "C" fn rb_yjit_code_gc(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
 
 /// Enable YJIT compilation, returning true if YJIT was previously disabled
 #[no_mangle]
-pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
+pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE, gen_stats: VALUE, print_stats: VALUE) -> VALUE {
     with_vm_lock(src_loc!(), || {
-        if yjit_enabled_p() {
-            return Qfalse;
+        // Initialize and enable YJIT
+        unsafe {
+            OPTIONS.gen_stats = gen_stats.test();
+            OPTIONS.print_stats = print_stats.test();
         }
-
-        // Initialize and enable YJIT if currently disabled
         yjit_init();
 
         // Add "+YJIT" to RUBY_DESCRIPTION


### PR DESCRIPTION
`RubyVM::YJIT.enable` is useful not only for lazily enabling YJIT but also for enabling YJIT in a subset of workers in a server. 

Similarly to that, I want to enable YJIT stats only in part of workers so that I can monitor `ratio_in_yjit`, which is useful especially when the volume of traffic is very low and you use only one server. This could be also useful when you don't want to set up multiple clusters with different Ruby commands for that purpose.