### PR TITLE
Set m_tbl right after allocation

### DIFF
--- a/internal/class.h
+++ b/internal/class.h
@@ -150,6 +150,13 @@ RCLASS_IV_COUNT(VALUE obj)
     }
 }
 
+static inline void
+RCLASS_SET_M_TBL(VALUE klass, struct rb_id_table *table)
+{
+    RUBY_ASSERT(!RB_OBJ_PROMOTED(klass));
+    RCLASS_M_TBL(klass) = table;
+}
+
 /* class.c */
 void rb_class_subclass_add(VALUE super, VALUE klass);
 void rb_class_remove_from_super_subclasses(VALUE);


### PR DESCRIPTION
We should set the m_tbl right after allocation before anything that can trigger GC to avoid clone_p from becoming old and needing to fire write barriers.

cc. @tenderlove 