### PR TITLE
Add tool/missing-baseruby.bat, used when BASERUBY not available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,7 +89,7 @@ AS_IF([test "$HAVE_BASERUBY" != no -a "`RUBYOPT=- $BASERUBY --disable=gems -e 'p
 ])
 AS_IF([test "$HAVE_BASERUBY" = no], [
     AS_IF([test "$cross_compiling" = yes], [AC_MSG_ERROR([executable host ruby is required for cross-compiling])])
-    BASERUBY="echo executable host ruby is required.  use --with-baseruby option.; false"
+    BASERUBY=$srcdir/tool/missing-baseruby.bat
 ])
 AC_SUBST(BASERUBY)
 AC_SUBST(HAVE_BASERUBY)

--- a/tool/missing-baseruby.bat
+++ b/tool/missing-baseruby.bat
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "executable host ruby is required.  use --with-baseruby option."
+exit 1

--- a/tool/missing-baseruby.bat
+++ b/tool/missing-baseruby.bat
@@ -1,3 +1,5 @@
-#!/bin/sh
+: "
+@echo off
+: "
 echo "executable host ruby is required.  use --with-baseruby option."
 exit 1

--- a/tool/missing-baseruby.bat
+++ b/tool/missing-baseruby.bat
@@ -1,5 +1,5 @@
 : "
 @echo off
 : "
-echo "executable host ruby is required.  use --with-baseruby option."
+echo executable host ruby is required.  use --with-baseruby option.
 exit 1


### PR DESCRIPTION
Previously, the embedded semicolon in BASERUBY if BASERUBY is not available breaks tarball builds without BASERUBY when using OpenBSD make, due to the inability to escape MFLAGS correctly. This moves the same BASERUBY code into a separate file, avoiding the MFLAGS quoting issue.

BASERUBY must be passed to build-ext because it is required by ripper since the introduction of lrama.

Fixes [Bug #19683]