### PR TITLE
Correct free_on_exit env var to free_at_exit

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4699,7 +4699,7 @@ rb_objspace_call_finalizer(rb_objspace_t *objspace)
               case T_NONE:
                 break;
               default:
-                if (rb_free_on_exit) {
+                if (rb_free_at_exit) {
                     obj_free(objspace, vp);
                 }
                 break;

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -83,7 +83,7 @@ void rb_check_stack_overflow(void);
 extern uint64_t rb_vm_insns_count;
 #endif
 
-extern bool rb_free_on_exit;
+extern bool rb_free_at_exit;
 
 /* miniinit.c and builtin.c */
 void rb_free_loaded_builtin_table(void);

--- a/ruby.c
+++ b/ruby.c
@@ -1770,9 +1770,9 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
                            "environment variables RUBY_GC_HEAP_%d_INIT_SLOTS");
     }
 
-    if (getenv("RUBY_FREE_ON_EXIT")) {
-        rb_warn("Free on exit is experimental and may be unstable");
-        rb_free_on_exit = true;
+    if (getenv("RUBY_FREE_AT_EXIT")) {
+        rb_warn("Free at exit is experimental and may be unstable");
+        rb_free_at_exit = true;
     }
 
 #if USE_RJIT

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -1241,9 +1241,9 @@ class TestRubyOptions < Test::Unit::TestCase
     assert_in_out_err([IO::NULL], success: true)
   end
 
-  def test_free_on_exit_env_var
-    env = {"RUBY_FREE_ON_EXIT"=>"1"}
+  def test_free_at_exit_env_var
+    env = {"RUBY_FREE_AT_EXIT"=>"1"}
     assert_ruby_status([env, "-e;"])
-    assert_in_out_err([env, "-W"], "", [], /Free on exit is experimental and may be unstable/)
+    assert_in_out_err([env, "-W"], "", [], /Free at exit is experimental and may be unstable/)
   end
 end

--- a/vm.c
+++ b/vm.c
@@ -2993,7 +2993,7 @@ ruby_vm_destruct(rb_vm_t *vm)
     if (vm) {
         rb_thread_t *th = vm->ractor.main_thread;
         VALUE *stack = th->ec->vm_stack;
-        if (rb_free_on_exit) {
+        if (rb_free_at_exit) {
             rb_free_default_rand_key();
             rb_free_encoded_insn_data();
             rb_free_global_enc_table();
@@ -3053,7 +3053,7 @@ ruby_vm_destruct(rb_vm_t *vm)
         }
         RB_ALTSTACK_FREE(vm->main_altstack);
         if (objspace) {
-            if (rb_free_on_exit) {
+            if (rb_free_at_exit) {
                 rb_objspace_free_objects(objspace);
                 rb_free_generic_iv_tbl_();
                 if (th) {
@@ -4273,7 +4273,7 @@ rb_ruby_debug_ptr(void)
     return &cr->debug;
 }
 
-bool rb_free_on_exit = false;
+bool rb_free_at_exit = false;
 
 /* iseq.c */
 VALUE rb_insn_operand_intern(const rb_iseq_t *iseq,


### PR DESCRIPTION
Fixes the incorrect name introduced in: https://github.com/ruby/ruby/pull/8868