### PR TITLE
Make rb_profile_frames return 0 for NULL ec

### DIFF
--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1641,7 +1641,14 @@ thread_profile_frames(rb_execution_context_t *ec, int start, int limit, VALUE *b
 int
 rb_profile_frames(int start, int limit, VALUE *buff, int *lines)
 {
-    rb_execution_context_t *ec = GET_EC();
+    rb_execution_context_t *ec = rb_current_execution_context(false);
+
+    // If there is no EC, we may be attempting to profile a non-Ruby thread or a
+    // M:N shared native thread which has no active Ruby thread.
+    if (!ec) {
+        return 0;
+    }
+
     return thread_profile_frames(ec, start, limit, buff, lines);
 }
 


### PR DESCRIPTION
When using M:N threads, EC is set to NULL in the shared native thread when nothing is scheduled. This previously caused a segfault when we try to examine the EC.

Returning 0 instead means we may miss profiling information, but a profiler relying on this isn't thread aware anyways, and observing that "nothing" is running is probably correct.

This is necessary for stackprof because it assumes that `rb_profile_frames` is async-signal-safe (the API doesn't guarantee this ). [Vernier](https://github.com/jhawthorn/vernier) works fine without this since it uses the GVL instrumentation to detect suspended threads and doesn't attempt to profile them.

I think this change is safe to merge pre-3.3 (I'll merge it tomorrow if nobody objects), since it only changes a case which otherwise would segfault.

Fixes [[Bug #20017]](https://bugs.ruby-lang.org/issues/20017)

cc @byroot @ko1 @tenderlove 