### PR TITLE
Use main_thread->ec from rb_vm_main_ractor_ec

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -305,7 +305,7 @@ changelog for details of the default gems or bundled gems.
     * added: `rb_postponed_job_preregister()`
     * added: `rb_postponed_job_trigger()`
     * deprecated: `rb_postponed_job_register()` (and semantic change. see below)
-    * deprecated: `rb_postponed_job_register_once()`
+    * deprecated: `rb_postponed_job_register_one()`
   * The postponed job APIs have been changed to address some rare crashes.
     To solve the issue, we introduced new two APIs and deprecated current APIs.
     The semantics of these functions have also changed slightly; `rb_postponed_job_register`

--- a/include/ruby/debug.h
+++ b/include/ruby/debug.h
@@ -643,11 +643,11 @@ VALUE rb_tracearg_object(rb_trace_arg_t *trace_arg);
  * racing with Ruby's internal use of them. These two functions are still present,
  * but are marked as deprecated and have slightly changed semantics:
  *
- * * rb_postponed_job_register now works like rb_postponed_job_register_once i.e.
+ * * rb_postponed_job_register now works like rb_postponed_job_register_one i.e.
  *   `func` will only be executed at most one time each time Ruby checks for
  *   interrupts, no matter how many times it is registered
  * * They are also called with the last `data` to be registered, not the first
- *   (which is how rb_postponed_job_register_once previously worked)
+ *   (which is how rb_postponed_job_register_one previously worked)
  */
 
 

--- a/ractor.c
+++ b/ractor.c
@@ -2481,7 +2481,7 @@ rb_ractor_terminate_all(void)
 rb_execution_context_t *
 rb_vm_main_ractor_ec(rb_vm_t *vm)
 {
-    return vm->ractor.main_ractor->threads.running_ec;
+    return vm->ractor.main_thread->ec;
 }
 
 static VALUE


### PR DESCRIPTION
`rb_vm_main_ractor_ec` was introduced to allow `rb_postponed_job_*` to work when fired on non-Ruby threads, which have no EC set, and that is its only use.

When `RUBY_MN_THREADS=1` is set `ractor->threads.running_ec` is `NULL` when the shared thread is sleeping. This instead grabs the EC directly from the main thread which seems to always be set.

With this change StackProf works with `RUBY_MN_THREADS=1` set (this should fix https://github.com/tmm1/stackprof/issues/221)

Fixes [[Bug #20016]](https://bugs.ruby-lang.org/issues/20016)

cc @byroot @ko1 @KJTsanaktsidis @tenderlove 