### PR TITLE
Avoid underflow of rb_yjit_live_iseq_count

### DIFF
--- a/bootstraptest/test_eval.rb
+++ b/bootstraptest/test_eval.rb
@@ -227,6 +227,16 @@ assert_equal %q{[10, main]}, %q{
   }, '[ruby-dev:31372]'
 end
 
+assert_normal_exit %{
+  $stderr = STDOUT
+  5000.times do
+    begin
+      eval "0 rescue break"
+    rescue SyntaxError
+    end
+  end
+}
+
 assert_normal_exit %q{
   $stderr = STDOUT
   class Foo

--- a/iseq.c
+++ b/iseq.c
@@ -167,8 +167,10 @@ rb_iseq_free(const rb_iseq_t *iseq)
         rb_rjit_free_iseq(iseq); /* Notify RJIT */
 #if USE_YJIT
         rb_yjit_iseq_free(body->yjit_payload);
-        RUBY_ASSERT(rb_yjit_live_iseq_count > 0);
-        rb_yjit_live_iseq_count--;
+        if (FL_TEST_RAW((VALUE)iseq, ISEQ_TRANSLATED)) {
+            RUBY_ASSERT(rb_yjit_live_iseq_count > 0);
+            rb_yjit_live_iseq_count--;
+        }
 #endif
         ruby_xfree((void *)body->iseq_encoded);
         ruby_xfree((void *)body->insns_info.body);


### PR DESCRIPTION
This value is only incremented when `rb_iseq_translate_threaded_code` is called, which doesn't happen for iseqs which result in a syntax error.

This is easy to hit by running a debug build with `RUBY_FREE_AT_EXIT=1`, but any build and options could underflow this value by running enough evals.

cc @ruby/yjit 