### PR TITLE
Rename thread_profile_frames() to profile_thread_frames()

### DIFF
--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1574,7 +1574,7 @@ rb_debug_inspector_backtrace_locations(const rb_debug_inspector_t *dc)
 }
 
 static int
-thread_profile_frames(rb_execution_context_t *ec, int start, int limit, VALUE *buff, int *lines)
+profile_thread_frames(rb_execution_context_t *ec, int start, int limit, VALUE *buff, int *lines)
 {
     int i;
     const rb_control_frame_t *cfp = ec->cfp, *end_cfp = RUBY_VM_END_CONTROL_FRAME(ec);
@@ -1649,14 +1649,14 @@ rb_profile_frames(int start, int limit, VALUE *buff, int *lines)
         return 0;
     }
 
-    return thread_profile_frames(ec, start, limit, buff, lines);
+    return profile_thread_frames(ec, start, limit, buff, lines);
 }
 
 int
 rb_profile_thread_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines)
 {
     rb_thread_t *th = rb_thread_ptr(thread);
-    return thread_profile_frames(th->ec, start, limit, buff, lines);
+    return profile_thread_frames(th->ec, start, limit, buff, lines);
 }
 
 static const rb_iseq_t *


### PR DESCRIPTION
Match the word order in rb_profile_thread_frames().

rb_profile_thread_frames() was named rb_thread_profile_frames() in the original proposal, but it was renamed to its current name through discussion. The internal implementation should match its name too.