### PR TITLE
RUBY_FREE_AT_EXIT fixes

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2587,12 +2587,12 @@ rb_threadptr_root_fiber_release(rb_thread_t *th)
         /* ignore. A root fiber object will free th->ec */
     }
     else {
-        rb_execution_context_t *ec = GET_EC();
+        rb_execution_context_t *ec = rb_current_execution_context(false);
 
         VM_ASSERT(th->ec->fiber_ptr->cont.type == FIBER_CONTEXT);
         VM_ASSERT(th->ec->fiber_ptr->cont.self == 0);
 
-        if (th->ec == ec) {
+        if (ec && th->ec == ec) {
             rb_ractor_set_current_ec(th->ractor, NULL);
         }
         fiber_free(th->ec->fiber_ptr);

--- a/vm.c
+++ b/vm.c
@@ -2994,7 +2994,6 @@ ruby_vm_destruct(rb_vm_t *vm)
         rb_thread_t *th = vm->ractor.main_thread;
         VALUE *stack = th->ec->vm_stack;
         if (rb_free_at_exit) {
-            rb_free_default_rand_key();
             rb_free_encoded_insn_data();
             rb_free_global_enc_table();
             rb_free_loaded_builtin_table();
@@ -3056,6 +3055,7 @@ ruby_vm_destruct(rb_vm_t *vm)
             if (rb_free_at_exit) {
                 rb_objspace_free_objects(objspace);
                 rb_free_generic_iv_tbl_();
+                rb_free_default_rand_key();
                 if (th) {
                     xfree(stack);
                     ruby_mimfree(th);

--- a/vm.c
+++ b/vm.c
@@ -3056,7 +3056,8 @@ ruby_vm_destruct(rb_vm_t *vm)
                 rb_objspace_free_objects(objspace);
                 rb_free_generic_iv_tbl_();
                 rb_free_default_rand_key();
-                if (th) {
+                if (th && vm->fork_gen == 0) {
+                    /* If we have forked, main_thread may not be the initial thread */
                     xfree(stack);
                     ruby_mimfree(th);
                 }

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -82,7 +82,7 @@ rb_hook_list_mark_and_update(rb_hook_list_t *hooks)
     }
 }
 
-static void clean_hooks(const rb_execution_context_t *ec, rb_hook_list_t *list);
+static void clean_hooks(rb_hook_list_t *list);
 
 void
 rb_hook_list_free(rb_hook_list_t *hooks)
@@ -90,7 +90,7 @@ rb_hook_list_free(rb_hook_list_t *hooks)
     hooks->need_clean = true;
 
     if (hooks->running == 0) {
-        clean_hooks(GET_EC(), hooks);
+        clean_hooks(hooks);
     }
 }
 
@@ -223,7 +223,7 @@ rb_add_event_hook2(rb_event_hook_func_t func, rb_event_flag_t events, VALUE data
 }
 
 static void
-clean_hooks(const rb_execution_context_t *ec, rb_hook_list_t *list)
+clean_hooks(rb_hook_list_t *list)
 {
     rb_event_hook_t *hook, **nextp = &list->hooks;
     rb_event_flag_t prev_events = list->events;
@@ -257,11 +257,11 @@ clean_hooks(const rb_execution_context_t *ec, rb_hook_list_t *list)
 }
 
 static void
-clean_hooks_check(const rb_execution_context_t *ec, rb_hook_list_t *list)
+clean_hooks_check(rb_hook_list_t *list)
 {
     if (UNLIKELY(list->need_clean)) {
         if (list->running == 0) {
-            clean_hooks(ec, list);
+            clean_hooks(list);
         }
     }
 }
@@ -289,7 +289,7 @@ remove_event_hook(const rb_execution_context_t *ec, const rb_thread_t *filter_th
         hook = hook->next;
     }
 
-    clean_hooks_check(ec, list);
+    clean_hooks_check(list);
     return ret;
 }
 
@@ -373,7 +373,7 @@ static void
 exec_hooks_postcheck(const rb_execution_context_t *ec, rb_hook_list_t *list)
 {
     list->running--;
-    clean_hooks_check(ec, list);
+    clean_hooks_check(list);
 }
 
 static void


### PR DESCRIPTION
This fixes a couple errors which could occur when RUBY_FREE_AT_EXIT=1 is enabled. These fixes aren't perfect, but I think fixes which avoided more leaks and never caused errors would be more complex and would be dangerous to merge so close to 3.3's release. (I'd like to investigate this more next year and maybe we can backport the fixes For 3.3.1)

First, during VM destruction EC seems to be NULL, this avoids two cases we were always calling `GET_EC()` at that time (one we just didn't need and the other I added an if case for it being NULL). This fixes an error which always occurred when Ruby was built in debug.

Fixes `RUBY_FREE_AT_EXIT=1 ./miniruby -e ''`

Next, we need to move the freeing of `default_rand_key` after the freeing of Ractors in `rb_objspace_free_objects`, as that will iterate over over the local storage keys so the memory needs to be freed later to avoid a use-after-free.

Fixes `RUBY_FREE_AT_EXIT=1 ./miniruby -e rand`

Lastly when we forked for a Thread we would end up double-freeing the main thread's stack, because the *main thread* was no longer the *initial thread* from `Init_BareVM`. The new Thread's stack was freed naturally in `rb_objspace_free_objects`

Fixes `RUBY_FREE_AT_EXIT=1 ./miniruby -e 'Thread.new { fork { } }.join; Process.waitpid'`

With these changes `RUBY_FREE_AT_EXIT=1 make btest` works with RUBY_DEBUG and ASAN enabled (other than a few Ractor tests which detect false positives).

cc @HParker @peterzhu2118 