### PR TITLE
Fix String#sub for GC compaction

### DIFF
--- a/string.c
+++ b/string.c
@@ -5816,6 +5816,8 @@ rb_str_sub_bang(int argc, VALUE *argv, VALUE str)
         TERM_FILL(&RSTRING_PTR(str)[len], TERM_LEN(str));
         ENC_CODERANGE_SET(str, cr);
 
+        RB_GC_GUARD(match);
+
         return str;
     }
     return Qnil;

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -2081,6 +2081,15 @@ CODE
     }
   end
 
+  def test_sub_gc_compact_stress
+    EnvUtil.under_gc_compact_stress do
+      m = /&(?<foo>.*?);/.match(S("aaa &amp; yyy"))
+      assert_equal("amp", m["foo"])
+
+      assert_equal("aaa [amp] yyy", S("aaa &amp; yyy").sub(/&(?<foo>.*?);/, S('[\k<foo>]')))
+    end
+  end
+
   def test_sub!
     a = S("hello")
     b = a.dup


### PR DESCRIPTION
The test fails when RGENGC_CHECK_MODE is turned on:

    TestString#test_sub_gc_compact_stress = 9.42 s
    1) Failure:
    TestString#test_sub_gc_compact_stress [test/ruby/test_string.rb:2089]:
    <"aaa [amp] yyy"> expected but was
    <"aaa [] yyy">.