### PR TITLE
Use noinline version of accessing current ec

### DIFF
--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -134,7 +134,7 @@ struct rb_thread_sched {
 
   # ifdef __APPLE__
     // on Darwin, TLS can not be accessed across .so
-    struct rb_execution_context_struct *rb_current_ec(void);
+    NOINLINE(struct rb_execution_context_struct *rb_current_ec(void));
   # else
     RUBY_EXTERN RB_THREAD_LOCAL_SPECIFIER struct rb_execution_context_struct *ruby_current_ec;
 


### PR DESCRIPTION
On universal.arm64e-darwin22 with clang 15.0.0 (I didn't check details yet) accessing `ruby_current_ec` directly causes assertion violation `VM_ASSERT(ec == rb_current_ec_noinline())` on `rb_current_execution_context()`, maybe because TLS accessing issue.