### PR TITLE
Fix Regexp#inspect for GC compaction

### DIFF
--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -469,6 +469,12 @@ class TestRegexp < Test::Unit::TestCase
     assert_equal('/\/\xF1\xF2\xF3/i', /\/#{s}/i.inspect)
   end
 
+  def test_inspect_under_gc_compact_stress
+    EnvUtil.under_gc_compact_stress do
+      assert_equal('/(?-mix:\\/)|/', Regexp.union(/\//, "").inspect)
+    end
+  end
+
   def test_char_to_option
     assert_equal("BAR", "FOOBARBAZ"[/b../i])
     assert_equal("bar", "foobarbaz"[/  b  .  .  /x])


### PR DESCRIPTION
rb_reg_desc was not safe for GC compaction because it took in the C string and length but not the backing String object so it get moved during compaction. This commit changes rb_reg_desc to use the string from the Regexp object.

The test fails when RGENGC_CHECK_MODE is turned on:

    TestRegexp#test_inspect_under_gc_compact_stress [test/ruby/test_regexp.rb:474]:
    <"(?-mix:\\/)|"> expected but was
    <"/\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00/">.