### PR TITLE
This single change fixes every MN test on macos...

### DIFF
--- a/io.c
+++ b/io.c
@@ -1286,7 +1286,7 @@ rb_io_read_memory(rb_io_t *fptr, void *buf, size_t count)
         iis.timeout = &timeout_storage;
     }
 
-    return (ssize_t)rb_thread_io_blocking_call(internal_read_func, &iis, fptr->fd, RB_WAITFD_IN);
+    return (ssize_t)rb_thread_io_blocking_call(internal_read_func, &iis, fptr->fd, RB_WAITFD_IN | RB_WAITFD_OUT);
 }
 
 static ssize_t


### PR DESCRIPTION
No way that's right, as in truly _fixing_ it. But it's curious that they start working. Maybe it just triggers them to switch to native threads, which is the opposite of the intended affect. But here's a commit to test it out anyways

Related to https://bugs.ruby-lang.org/issues/20076