### PR TITLE
Fix Symbol#inspect for GC compaction

### DIFF
--- a/string.c
+++ b/string.c
@@ -11630,10 +11630,15 @@ sym_inspect(VALUE sym)
     }
     else {
         rb_encoding *enc = STR_ENC_GET(str);
-        RSTRING_GETMEM(str, ptr, len);
+
+        VALUE orig_str = str;
+        RSTRING_GETMEM(orig_str, ptr, len);
+
         str = rb_enc_str_new(0, len + 1, enc);
         dest = RSTRING_PTR(str);
         memcpy(dest + 1, ptr, len);
+
+        RB_GC_GUARD(orig_str);
     }
     dest[0] = ':';
     return str;

--- a/test/ruby/test_symbol.rb
+++ b/test/ruby/test_symbol.rb
@@ -118,6 +118,12 @@ class TestSymbol < Test::Unit::TestCase
     end
   end
 
+  def test_inspect_under_gc_compact_stress
+    EnvUtil.under_gc_compact_stress do
+      assert_inspect_evaled(':testing')
+    end
+  end
+
   def test_name
     assert_equal("foo", :foo.name)
     assert_same(:foo.name, :foo.name)


### PR DESCRIPTION
The test fails when RGENGC_CHECK_MODE is turned on:

    1) Failure:
    TestSymbol#test_inspect_under_gc_compact_stress [test/ruby/test_symbol.rb:123]:
    <":testing"> expected but was
    <":\x00\x00\x00\x00\x00\x00\x00">.