### PR TITLE
Use ubf list on cygwin

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -305,7 +305,7 @@ event_name(rb_event_flag_t event)
 
 static rb_serial_t current_fork_gen = 1; /* We can't use GET_VM()->fork_gen */
 
-#if defined(SIGVTALRM) && !defined(__CYGWIN__) && !defined(__EMSCRIPTEN__)
+#if defined(SIGVTALRM) && !defined(__EMSCRIPTEN__)
 #  define USE_UBF_LIST 1
 #endif
 


### PR DESCRIPTION
Use ubf list on cygwin as on other platforms.
This allows test_io to pass.

- https://bugs.ruby-lang.org/issues/4957
- https://bugs.ruby-lang.org/issues/5055
- https://bugs.ruby-lang.org/issues/7781
- https://bugs.ruby-lang.org/issues/15465
- https://bugs.ruby-lang.org/issues/17996

Cygwin appears to support SIGVTALRM.
- https://github.com/Alexpux/Cygwin/commit/8a0efa53e44919bcf5ccb1d3353618a82afdf8bc