### PR TITLE
Use `PRIuSIZE` instead of `%zu` for `size_t`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -213,7 +213,7 @@ rb_malloc_grow_capa(size_t current, size_t type_size)
     new_capacity -= malloc_offset;
     new_capacity /= type_size;
     if (current > new_capacity) {
-        rb_bug("rb_malloc_grow_capa: current_capacity=%zu, new_capacity=%zu, malloc_offset=%zu", current, new_capacity, malloc_offset);
+        rb_bug("rb_malloc_grow_capa: current_capacity=%"PRIuSIZE", new_capacity=%"PRIuSIZE", malloc_offset=%"PRIuSIZE"", current, new_capacity, malloc_offset);
     }
     RUBY_ASSERT(new_capacity > current);
     return new_capacity;
@@ -13963,7 +13963,7 @@ rb_raw_obj_info_buitin_type(char *const buff, const size_t buff_size, const VALU
             {
                 if (rb_shape_obj_too_complex(obj)) {
                     size_t hash_len = rb_st_table_size(ROBJECT_IV_HASH(obj));
-                    APPEND_F("(too_complex) len:%zu", hash_len);
+                    APPEND_F("(too_complex) len:%"PRIuSIZE"", hash_len);
                 }
                 else {
                     uint32_t len = ROBJECT_IV_CAPACITY(obj);

--- a/regexec.c
+++ b/regexec.c
@@ -4158,7 +4158,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 	  size_t length = (end - str) + 1;
 	  size_t num_match_cache_points = (size_t)msa->num_cache_points * length;
 #ifdef ONIG_DEBUG_MATCH_CACHE
-	  fprintf(stderr, "MATCH CACHE: #match cache points = %ld (length = %zu)\n", num_match_cache_points, length);
+	  fprintf(stderr, "MATCH CACHE: #match cache points = %"PRIuSIZE" (length = %"PRIuSIZE")\n", num_match_cache_points, length);
 #endif
 	  /* Overflow check */
 	  if (num_match_cache_points / length != (size_t)msa->num_cache_points) {


### PR DESCRIPTION
Since the 'z' modifier for `size_t` is specified in C99, but is not supported in VC2013, until we drop support for VC2013, we have to use `PRIuSIZE` instead.