### PR TITLE
[DOC] RDoc for Complex

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -821,11 +821,11 @@ rb_complex_uminus(VALUE self)
  *
  * Returns the sum of +self+ and +numeric+:
  *
- *   Complex(2, 3)  + Complex(2, 3)  # => (4+6i)
- *   Complex(900)   + Complex(1)     # => (901+0i)
- *   Complex(-2, 9) + Complex(-9, 2) # => (-11+11i)
- *   Complex(9, 8)  + 4              # => (13+8i)
- *   Complex(20, 9) + 9.8            # => (29.8+9i)
+ *   Complex.rect(2, 3)  + Complex.rect(2, 3)  # => (4+6i)
+ *   Complex.rect(900)   + Complex.rect(1)     # => (901+0i)
+ *   Complex.rect(-2, 9) + Complex.rect(-9, 2) # => (-11+11i)
+ *   Complex.rect(9, 8)  + 4                   # => (13+8i)
+ *   Complex.rect(20, 9) + 9.8                 # => (29.8+9i)
  *
  */
 VALUE
@@ -856,11 +856,11 @@ rb_complex_plus(VALUE self, VALUE other)
  *
  * Returns the difference of +self+ and +numeric+:
  *
- *   Complex(2, 3)  - Complex(2, 3)  # => (0+0i)
- *   Complex(900)   - Complex(1)     # => (899+0i)
- *   Complex(-2, 9) - Complex(-9, 2) # => (7+7i)
- *   Complex(9, 8)  - 4              # => (5+8i)
- *   Complex(20, 9) - 9.8            # => (10.2+9i)
+ *   Complex.rect(2, 3)  - Complex.rect(2, 3)  # => (0+0i)
+ *   Complex.rect(900)   - Complex.rect(1)     # => (899+0i)
+ *   Complex.rect(-2, 9) - Complex.rect(-9, 2) # => (7+7i)
+ *   Complex.rect(9, 8)  - 4                   # => (5+8i)
+ *   Complex.rect(20, 9) - 9.8                 # => (10.2+9i)
  *
  */
 VALUE
@@ -917,11 +917,11 @@ comp_mul(VALUE areal, VALUE aimag, VALUE breal, VALUE bimag, VALUE *real, VALUE 
  *
  * Returns the product of +self+ and +numeric+:
  *
- *   Complex(2, 3)  * Complex(2, 3)  # => (-5+12i)
- *   Complex(900)   * Complex(1)     # => (900+0i)
- *   Complex(-2, 9) * Complex(-9, 2) # => (0-85i)
- *   Complex(9, 8)  * 4              # => (36+32i)
- *   Complex(20, 9) * 9.8            # => (196.0+88.2i)
+ *   Complex.rect(2, 3)  * Complex.rect(2, 3)  # => (-5+12i)
+ *   Complex.rect(900)   * Complex.rect(1)     # => (900+0i)
+ *   Complex.rect(-2, 9) * Complex.rect(-9, 2) # => (0-85i)
+ *   Complex.rect(9, 8)  * 4                   # => (36+32i)
+ *   Complex.rect(20, 9) * 9.8                 # => (196.0+88.2i)
  *
  */
 VALUE
@@ -993,11 +993,11 @@ f_divide(VALUE self, VALUE other,
  *
  * Returns the quotient of +self+ and +numeric+:
  *
- *   Complex(2, 3)  / Complex(2, 3)  # => ((1/1)+(0/1)*i)
- *   Complex(900)   / Complex(1)     # => ((900/1)+(0/1)*i)
- *   Complex(-2, 9) / Complex(-9, 2) # => ((36/85)-(77/85)*i)
- *   Complex(9, 8)  / 4              # => ((9/4)+(2/1)*i)
- *   Complex(20, 9) / 9.8            # => (2.0408163265306123+0.9183673469387754i)
+ *   Complex.rect(2, 3)  / Complex.rect(2, 3)  # => (1+0i)
+ *   Complex.rect(900)   / Complex.rect(1)     # => (900+0i)
+ *   Complex.rect(-2, 9) / Complex.rect(-9, 2) # => ((36/85)-(77/85)*i)
+ *   Complex.rect(9, 8)  / 4                   # => ((9/4)+2i)
+ *   Complex.rect(20, 9) / 9.8                 # => (2.0408163265306123+0.9183673469387754i)
  *
  */
 VALUE
@@ -1012,9 +1012,9 @@ rb_complex_div(VALUE self, VALUE other)
  * call-seq:
  *   fdiv(numeric) -> new_complex
  *
- * Returns <tt>Complex(self.real/numeric, self.imag/numeric)</tt>:
+ * Returns <tt>Complex.rect(self.real/numeric, self.imag/numeric)</tt>:
  *
- *   Complex(11, 22).fdiv(3) # => (3.6666666666666665+7.333333333333333i)
+ *   Complex.rect(11, 22).fdiv(3) # => (3.6666666666666665+7.333333333333333i)
  *
  */
 static VALUE
@@ -1218,7 +1218,7 @@ rb_complex_pow(VALUE self, VALUE other)
  * Returns +true+ if <tt>self.real == object.real</tt>
  * and <tt>self.imag == object.imag</tt>:
  *
- *   Complex(2, 3)  == Complex(2.0, 3.0)      # => true
+ *   Complex.rect(2, 3)  == Complex.rect(2.0, 3.0) # => true
  *
  */
 static VALUE
@@ -1260,12 +1260,12 @@ nucomp_real_p(VALUE self)
  *
  * Examples:
  *
- *   Complex(2) <=> 3             # => -1
- *   Complex(2) <=> 2             # => 0
- *   Complex(2) <=> 1             # => 1
- *   Complex(2, 1) <=> 1          # => nil # self.imag not zero.
- *   Complex(1) <=> Complex(1, 1) # => nil # object.imag not zero.
- *   Complex(1) <=> 'Foo'         # => nil # object.imag not defined.
+ *   Complex.rect(2) <=> 3                  # => -1
+ *   Complex.rect(2) <=> 2                  # => 0
+ *   Complex.rect(2) <=> 1                  # => 1
+ *   Complex.rect(2, 1) <=> 1               # => nil # self.imag not zero.
+ *   Complex.rect(1) <=> Complex.rect(1, 1) # => nil # object.imag not zero.
+ *   Complex.rect(1) <=> 'Foo'              # => nil # object.imag not defined.
  *
  */
 static VALUE
@@ -1500,13 +1500,13 @@ nucomp_denominator(VALUE self)
  * {lowest common denominator}[https://en.wikipedia.org/wiki/Lowest_common_denominator]
  * of the two:
  *
- *   c = Complex(Rational(2, 3), Rational(3, 4)) # => ((2/3)+(3/4)*i)
- *   c.numerator                                 # => (8+9i)
+ *   c = Complex.rect(Rational(2, 3), Rational(3, 4)) # => ((2/3)+(3/4)*i)
+ *   c.numerator                                      # => (8+9i)
  *
  * In this example, the lowest common denominator of the two parts is 12;
  * the two converted parts may be thought of as \Rational(8, 12) and \Rational(9, 12),
  * whose numerators, respectively, are 8 and 9;
- * so the returned value of <tt>c.numerator</tt> is <tt>Complex(8, 9)</tt>.
+ * so the returned value of <tt>c.numerator</tt> is <tt>Complex.rect(8, 9)</tt>.
  *
  * Related: Complex#denominator.
  */
@@ -1550,7 +1550,7 @@ rb_complex_hash(VALUE self)
  * Two \Complex objects created from the same values will have the same hash value
  * (and will compare using #eql?):
  *
- *   Complex(1, 2).hash == Complex(1, 2).hash # => true
+ *   Complex.rect(1, 2).hash == Complex.rect(1, 2).hash # => true
  *
  */
 static VALUE
@@ -1664,8 +1664,8 @@ nucomp_inspect(VALUE self)
  * Returns +true+ if both <tt>self.real.finite?</tt> and <tt>self.imag.finite?</tt>
  * are true, +false+ otherwise:
  *
- *   Complex(1, 1).finite?               # => true
- *   Complex(Float::INFINITY, 0).finite? # => false
+ *   Complex.rect(1, 1).finite?               # => true
+ *   Complex.rect(Float::INFINITY, 0).finite? # => false
  *
  * Related: Numeric#finite?, Float#finite?.
  */
@@ -1684,8 +1684,8 @@ rb_complex_finite_p(VALUE self)
  * Returns +1+ if either <tt>self.real.infinite?</tt> or <tt>self.imag.infinite?</tt>
  * is true, +nil+ otherwise:
  *
- *   Complex(Float::INFINITY, 0).infinite? # => 1
- *   Complex(1, 1).infinite?               # => nil
+ *   Complex.rect(Float::INFINITY, 0).infinite? # => 1
+ *   Complex.rect(1, 1).infinite?               # => nil
  *
  * Related: Numeric#infinite?, Float#infinite?.
  */
@@ -1789,8 +1789,8 @@ rb_dbl_complex_new(double real, double imag)
  *
  * Returns the value of <tt>self.real</tt> as an Integer, if possible:
  *
- *   Complex(1, 0).to_i              # => 1
- *   Complex(1, Rational(0, 1)).to_i # => 1
+ *   Complex.rect(1, 0).to_i              # => 1
+ *   Complex.rect(1, Rational(0, 1)).to_i # => 1
  *
  * Raises RangeError if <tt>self.imag</tt> is not exactly zero
  * (either <tt>Integer(0)</tt> or <tt>Rational(0, _n_)</tt>).
@@ -1813,8 +1813,8 @@ nucomp_to_i(VALUE self)
  *
  * Returns the value of <tt>self.real</tt> as a Float, if possible:
  *
- *   Complex(1, 0).to_f              # => 1.0
- *   Complex(1, Rational(0, 1)).to_f # => 1.0
+ *   Complex.rect(1, 0).to_f              # => 1.0
+ *   Complex.rect(1, Rational(0, 1)).to_f # => 1.0
  *
  * Raises RangeError if <tt>self.imag</tt> is not exactly zero
  * (either <tt>Integer(0)</tt> or <tt>Rational(0, _n_)</tt>).
@@ -1837,8 +1837,8 @@ nucomp_to_f(VALUE self)
  *
  * Returns the value of <tt>self.real</tt> as a Rational, if possible:
  *
- *   Complex(1, 0).to_r              # => (1/1)
- *   Complex(1, Rational(0, 1)).to_r # => (1/1)
+ *   Complex.rect(1, 0).to_r              # => (1/1)
+ *   Complex.rect(1, Rational(0, 1)).to_r # => (1/1)
  *
  * Raises RangeError if <tt>self.imag</tt> is not exactly zero
  * (either <tt>Integer(0)</tt> or <tt>Rational(0, _n_)</tt>).
@@ -1867,25 +1867,25 @@ nucomp_to_r(VALUE self)
  * With no argument +epsilon+ given, returns a \Rational object
  * whose value is exactly equal to that of <tt>self.real.rationalize</tt>:
  *
- *   Complex(1, 0).rationalize              # => (1/1)
- *   Complex(1, Rational(0, 1)).rationalize # => (1/1)
- *   Complex(3.14159, 0).rationalize        # => (314159/100000)
+ *   Complex.rect(1, 0).rationalize              # => (1/1)
+ *   Complex.rect(1, Rational(0, 1)).rationalize # => (1/1)
+ *   Complex.rect(3.14159, 0).rationalize        # => (314159/100000)
  *
  * With argument +epsilon+ given, returns a \Rational object
  * whose value is exactly or approximately equal to that of <tt>self.real</tt>
  * to the given precision:
  *
- *   Complex(3.14159, 0).rationalize(0.1)          # => (16/5)
- *   Complex(3.14159, 0).rationalize(0.01)         # => (22/7)
- *   Complex(3.14159, 0).rationalize(0.001)        # => (201/64)
- *   Complex(3.14159, 0).rationalize(0.0001)       # => (333/106)
- *   Complex(3.14159, 0).rationalize(0.00001)      # => (355/113)
- *   Complex(3.14159, 0).rationalize(0.000001)     # => (7433/2366)
- *   Complex(3.14159, 0).rationalize(0.0000001)    # => (9208/2931)
- *   Complex(3.14159, 0).rationalize(0.00000001)   # => (47460/15107)
- *   Complex(3.14159, 0).rationalize(0.000000001)  # => (76149/24239)
- *   Complex(3.14159, 0).rationalize(0.0000000001) # => (314159/100000)
- *   Complex(3.14159, 0).rationalize(0.0)          # => (3537115888337719/1125899906842624)
+ *   Complex.rect(3.14159, 0).rationalize(0.1)          # => (16/5)
+ *   Complex.rect(3.14159, 0).rationalize(0.01)         # => (22/7)
+ *   Complex.rect(3.14159, 0).rationalize(0.001)        # => (201/64)
+ *   Complex.rect(3.14159, 0).rationalize(0.0001)       # => (333/106)
+ *   Complex.rect(3.14159, 0).rationalize(0.00001)      # => (355/113)
+ *   Complex.rect(3.14159, 0).rationalize(0.000001)     # => (7433/2366)
+ *   Complex.rect(3.14159, 0).rationalize(0.0000001)    # => (9208/2931)
+ *   Complex.rect(3.14159, 0).rationalize(0.00000001)   # => (47460/15107)
+ *   Complex.rect(3.14159, 0).rationalize(0.000000001)  # => (76149/24239)
+ *   Complex.rect(3.14159, 0).rationalize(0.0000000001) # => (314159/100000)
+ *   Complex.rect(3.14159, 0).rationalize(0.0)          # => (3537115888337719/1125899906842624)
  *
  * Related: Complex#to_r.
  */
@@ -2627,7 +2627,7 @@ Init_Complex(void)
 
     /*
      * Equivalent
-     * to <tt>Complex(0, 1)</tt>:
+     * to <tt>Complex.rect(0, 1)</tt>:
      *
      *   Complex::I # => (0+1i)
      *


### PR DESCRIPTION
Prefer explicit `Complex.rect` to `Complex`.