### PR TITLE
[Bug #20088] Fix to use target_os for cross compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -462,7 +462,7 @@ AC_SUBST(CC_VERSION_MESSAGE, $cc_version_message)
 
 RUBY_UNIVERSAL_ARCH
 AS_IF([test "$target_cpu" != "$host_cpu" -a "$GCC" = yes -a "${universal_binary:-no}" = no], [
-    RUBY_DEFAULT_ARCH("$target_cpu")
+    RUBY_DEFAULT_ARCH($target_cpu)
 ])
 host_os=$target_os
 host_vendor=$target_vendor

--- a/tool/m4/ruby_default_arch.m4
+++ b/tool/m4/ruby_default_arch.m4
@@ -10,10 +10,12 @@ AS_CASE([$1:"$host_cpu"],
     [[i[3-6]86]:x86_64], [ARCH_FLAG=-m32],
     [ppc64:ppc*],        [ARCH_FLAG=-m64],
     [ppc*:ppc64],        [ARCH_FLAG=-m32],
-    AS_CASE([$build_os],
-        [darwin*], [ARCH_FLAG="-arch "$1],
-        [ARCH_FLAG=-march=$1]
-    )
+    [
+    ARCH_FLAG=
+    for flag in "-arch "$1 -march=$1; do
+        _RUBY_TRY_CFLAGS([$]flag, [ARCH_FLAG="[$]flag"])
+        test x"$ARCH_FLAG" = x || break
+    done]
 )
-AC_MSG_RESULT([$ARCH_FLAG])
+AC_MSG_RESULT([${ARCH_FLAG:-'(none)'}])
 ])dnl

--- a/tool/m4/ruby_try_cflags.m4
+++ b/tool/m4/ruby_try_cflags.m4
@@ -6,14 +6,19 @@ m4_version_prereq([2.70], [], [
 m4_defun([AC_LANG_PROGRAM(C)], m4_bpatsubst(m4_defn([AC_LANG_PROGRAM(C)]), [main ()], [main (void)]))
 ])dnl
 dnl
-AC_DEFUN([RUBY_TRY_CFLAGS], [
-    AC_MSG_CHECKING([whether ]$1[ is accepted as CFLAGS])
+AC_DEFUN([_RUBY_TRY_CFLAGS], [
     RUBY_WERROR_FLAG([
     CFLAGS="[$]CFLAGS $1"
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[$4]], [[$5]])],
+	[$2], [$3])
+    ])dnl
+])dnl
+AC_DEFUN([RUBY_TRY_CFLAGS], [
+    AC_MSG_CHECKING([whether ]$1[ is accepted as CFLAGS])dnl
+    _RUBY_TRY_CFLAGS([$1],
 	[$2
 	AC_MSG_RESULT(yes)],
 	[$3
-	AC_MSG_RESULT(no)])
-    ])
+	AC_MSG_RESULT(no)],
+	[$4], [$5])
 ])dnl

--- a/tool/m4/ruby_universal_arch.m4
+++ b/tool/m4/ruby_universal_arch.m4
@@ -40,7 +40,7 @@ AS_IF([test ${target_archs+set}], [
 	    AS_IF([$CC $CFLAGS $ARCH_FLAG -o conftest conftest.c > /dev/null 2>&1], [
 		rm -fr conftest.*
 	    ], [test -z "$ARCH_FLAG"], [
-		RUBY_DEFAULT_ARCH("$target_archs")
+		RUBY_DEFAULT_ARCH($target_archs)
 	    ])
 	])
 	target_cpu=${target_archs}


### PR DESCRIPTION
Fix https://github.com/ruby/ruby/pull/9250#discussion_r1436342036