### PR TITLE
Test_SyncDefaultGems: Fail when editor run

### DIFF
--- a/tool/test/test_sync_default_gems.rb
+++ b/tool/test/test_sync_default_gems.rb
@@ -175,13 +175,13 @@ module Test_SyncDefaultGems
       result = nil
       out = capture_process_output_to([STDOUT, STDERR]) do
         Dir.chdir("src") do
-          if editor
-            editor, ENV["GIT_EDITOR"] = ENV["GIT_EDITOR"], editor
-            edit = true
-          end
+          orig_editor = ENV["GIT_EDITOR"]
+          ENV["GIT_EDITOR"] = editor || 'false'
+          edit = true if editor
+
           result = SyncDefaultGems.sync_default_gems_with_commits(@target, commits, edit: edit)
         ensure
-          ENV["GIT_EDITOR"] = editor if edit
+          ENV["GIT_EDITOR"] = orig_editor
         end
       end
       assert_equal(success, result, out)


### PR DESCRIPTION
When something went wrong and git launches editor, and a editor chosen was terminal-based, a test run unnoticeably hangs.

As we intend editors not to be ran with --no-edit, GIT_EDITOR should be defaulted to `false` so let Git command fails when it attempts to start a editor. This allows catching such unintentional behaviour in test suite.

(Note: Prior to Git v2.32.0, git cherry-pick --no-edit doesn't work for conflict resolution. https://github.com/git/git/commit/39edfd5cbc4d168db19ec1bc867d78ec7211ec39
 i.e. Ubuntu 20.04 focal and Debian Bullseye)