### PR TITLE
Introduction of Happy Eyeballs Version 2 (RFC8305) in Socket.tcp

### DIFF
--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -703,7 +703,12 @@ class Socket < BasicSocket
           family_name, res = hostname_resolution_queue.get
 
           if res.is_a? Exception
-            last_error = res unless (res.is_a?(Socket::ResolutionError)) && (res.error_code == Socket::EAI_ADDRFAMILY)
+            unless (Socket.const_defined?(:EAI_ADDRFAMILY)) &&
+                (res.is_a?(Socket::ResolutionError)) &&
+                (res.error_code == Socket::EAI_ADDRFAMILY)
+              last_error = res
+            end
+
             if hostname_resolution_retry_count.zero?
               state = :failure
               break

--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -614,6 +614,9 @@ class Socket < BasicSocket
   HOSTNAME_RESOLUTION_QUEUE_UPDATED = 0
   private_constant :HOSTNAME_RESOLUTION_QUEUE_UPDATED
 
+  IPV6_ADRESS_FORMAT = /(?i)(?:(?:[0-9A-F]{1,4}:){7}(?:[0-9A-F]{1,4}|:)|(?:[0-9A-F]{1,4}:){6}(?:[0-9A-F]{1,4}::[0-9A-F]{1,4}|:(?:[0-9A-F]{1,4}:){1,5}[0-9A-F]{1,4}|:)|(?:[0-9A-F]{1,4}:){5}(?::[0-9A-F]{1,4}::[0-9A-F]{1,4}|:(?:[0-9A-F]{1,4}:){1,4}[0-9A-F]{1,4}|:)|(?:[0-9A-F]{1,4}:){4}(?::[0-9A-F]{1,4}::[0-9A-F]{1,4}|:(?:[0-9A-F]{1,4}:){1,3}[0-9A-F]{1,4}|:)|(?:[0-9A-F]{1,4}:){3}(?::[0-9A-F]{1,4}::[0-9A-F]{1,4}|:(?:[0-9A-F]{1,4}:){1,2}[0-9A-F]{1,4}|:)|(?:[0-9A-F]{1,4}:){2}(?::[0-9A-F]{1,4}::[0-9A-F]{1,4}|:(?:[0-9A-F]{1,4}:)[0-9A-F]{1,4}|:)|(?:[0-9A-F]{1,4}:){1}(?::[0-9A-F]{1,4}::[0-9A-F]{1,4}|::(?:[0-9A-F]{1,4}:){1,5}[0-9A-F]{1,4}|:)|::(?:[0-9A-F]{1,4}::[0-9A-F]{1,4}|:(?:[0-9A-F]{1,4}:){1,6}[0-9A-F]{1,4}|:))(?:%.+)?/
+  private_constant :IPV6_ADRESS_FORMAT
+
   @tcp_fast_fallback = true
 
   class << self
@@ -938,7 +941,7 @@ class Socket < BasicSocket
   end
 
   def self.specified_family_name_and_next_state(hostname)
-    if    hostname.match?(/:/)                             then [:ipv6, :v6c]
+    if    hostname.match?(IPV6_ADRESS_FORMAT)              then [:ipv6, :v6c]
     elsif hostname.match?(/^([0-9]{1,3}\.){3}[0-9]{1,3}$/) then [:ipv4, :v4c]
     end
   end

--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -599,6 +599,23 @@ class Socket < BasicSocket
     __accept_nonblock(exception)
   end
 
+  RESOLUTION_DELAY = 0.05
+  private_constant :RESOLUTION_DELAY
+
+  PATIENTLY_RESOLUTION_DELAY = 3
+  private_constant :PATIENTLY_RESOLUTION_DELAY
+
+  CONNECTION_ATTEMPT_DELAY = 0.25
+  private_constant :CONNECTION_ATTEMPT_DELAY
+
+  ADDRESS_FAMILIES = {
+    ipv6: Socket::AF_INET6,
+    ipv4: Socket::AF_INET
+  }.freeze
+  private_constant :ADDRESS_FAMILIES
+
+  HOSTNAME_RESOLUTION_QUEUE_UPDATED = 0
+  private_constant :HOSTNAME_RESOLUTION_QUEUE_UPDATED
   # :call-seq:
   #   Socket.tcp(host, port, local_host=nil, local_port=nil, [opts]) {|socket| ... }
   #   Socket.tcp(host, port, local_host=nil, local_port=nil, [opts])
@@ -626,39 +643,228 @@ class Socket < BasicSocket
   #   }
   #
   def self.tcp(host, port, local_host = nil, local_port = nil, connect_timeout: nil, resolv_timeout: nil) # :yield: socket
+    # Happy Eyeballs' states
+    # - :start
+    # - :v6c
+    # - :v4w
+    # - :v4c
+    # - :v46c
+    # - :v46w
+    # - :success
+    # - :failure
+    # - :timeout
+
+    hostname_resolution_threads = []
+    wait_for_hostname_resolution_patiently = false
+    selectable_addrinfos = SelectableAddrinfos.new
+    connecting_sockets = ConnectingSockets.new
+    connection_attempt_delay_expires_at = nil
+    connection_attempt_started_at = nil
+    state = :start
+    connected_socket = nil
     last_error = nil
-    ret = nil
 
-    local_addr_list = nil
-    if local_host != nil || local_port != nil
-      local_addr_list = Addrinfo.getaddrinfo(local_host, local_port, nil, :STREAM, nil)
+    if local_host && local_port
+      local_addrinfos = Addrinfo.getaddrinfo(local_host, local_port, nil, :STREAM, nil)
+      resolving_family_names = local_addrinfos.map { |lai| ADDRESS_FAMILIES.key(lai.afamily) }
+    else
+      local_addrinfos = []
+      resolving_family_names = ADDRESS_FAMILIES.keys
     end
 
-    Addrinfo.foreach(host, port, nil, :STREAM, timeout: resolv_timeout) {|ai|
-      if local_addr_list
-        local_addr = local_addr_list.find {|local_ai| local_ai.afamily == ai.afamily }
-        next unless local_addr
-      else
-        local_addr = nil
-      end
-      begin
-        sock = local_addr ?
-          ai.connect_from(local_addr, timeout: connect_timeout) :
-          ai.connect(timeout: connect_timeout)
-      rescue SystemCallError
-        last_error = $!
+    hostname_resolution_queue = HostnameResolutionQueue.new(resolving_family_names.size)
+
+    ret = loop do
+      case state
+      when :start
+        hostname_resolution_started_at = current_clocktime
+        hostname_resolution_args = [host, port, hostname_resolution_queue]
+
+        hostname_resolution_threads.concat(
+          resolving_family_names.map { |family|
+            thread_args = [family, *hostname_resolution_args]
+            thread = Thread.new(*thread_args) { |*thread_args| hostname_resolution(*thread_args) }
+            Thread.pass
+            thread
+          }
+        )
+
+        hostname_resolution_retry_count = resolving_family_names.size - 1
+
+        while hostname_resolution_retry_count >= 0
+          remaining = resolv_timeout ? second_to_timeout(hostname_resolution_started_at + resolv_timeout) : nil
+          hostname_resolved, _, = IO.select([hostname_resolution_queue.rpipe], nil, nil, remaining)
+
+          unless hostname_resolved
+            state = :timeout
+            break
+          end
+
+          family_name, res = hostname_resolution_queue.get
+
+          if res.is_a? Exception
+            last_error = res unless (res.is_a?(Socket::ResolutionError)) && (res.error_code == Socket::EAI_ADDRFAMILY)
+            if hostname_resolution_retry_count.zero?
+              state = :failure
+              break
+            end
+            hostname_resolution_retry_count -= 1
+          else
+            state = case family_name
+                    when :ipv6 then :v6c
+                    when :ipv4 then hostname_resolution_queue.rpipe.closed? ? :v4c : :v4w
+                    end
+            selectable_addrinfos.add(family_name, res)
+            last_error = nil
+            break
+          end
+        end
+
         next
-      end
-      ret = sock
-      break
-    }
-    unless ret
-      if last_error
+      when :v4w
+        ipv6_resolved, _, = IO.select([hostname_resolution_queue.rpipe], nil, nil, RESOLUTION_DELAY)
+
+        if ipv6_resolved
+          family_name, res = hostname_resolution_queue.get
+          selectable_addrinfos.add(family_name, res) unless res.is_a? Exception
+          state = :v46c
+        else
+          state = :v4c
+        end
+
+        next
+      when :v4c, :v6c, :v46c
+        connection_attempt_started_at = current_clocktime unless connection_attempt_started_at
+        addrinfo = selectable_addrinfos.get
+        socket = Socket.new(addrinfo.pfamily, addrinfo.socktype, addrinfo.protocol)
+
+        if local_addrinfos.any?
+          local_addrinfo = local_addrinfos.find { |lai| lai.afamily == addrinfo.afamily }
+
+          if local_addrinfo.nil?
+            if selectable_addrinfos.empty? && connecting_sockets.empty? && hostname_resolution_queue.empty?
+              if !hostname_resolution_queue.rpipe.closed? && !wait_for_hostname_resolution_patiently
+                wait_for_hostname_resolution_patiently = true
+                connection_attempt_delay_expires_at = current_clocktime + PATIENTLY_RESOLUTION_DELAY
+                state = :v46w
+              else
+                last_error = SocketError.new 'no appropriate local address'
+                state = :failure
+              end
+            elsif selectable_addrinfos.any?
+              # Try other Addrinfo in next loop
+            else
+              # Wait for connection to be established or hostname resolution in next loop
+              connection_attempt_delay_expires_at = nil
+              state = :v46w
+            end
+            next
+          end
+
+          socket.bind(local_addrinfo)
+        end
+
+        connection_attempt_delay_expires_at = current_clocktime + CONNECTION_ATTEMPT_DELAY
+
+        begin
+          case socket.connect_nonblock(addrinfo, exception: false)
+          when 0
+            connected_socket = socket
+            state = :success
+          when :wait_writable
+            connecting_sockets.add(socket, addrinfo)
+            state = :v46w
+          end
+        rescue SystemCallError => e
+          last_error = e
+          socket.close unless socket.closed?
+
+          if selectable_addrinfos.empty? && connecting_sockets.empty? && hostname_resolution_queue.empty?
+            if !hostname_resolution_queue.rpipe.closed? && !wait_for_hostname_resolution_patiently
+              wait_for_hostname_resolution_patiently = true
+              connection_attempt_delay_expires_at = current_clocktime + PATIENTLY_RESOLUTION_DELAY
+              state = :v46w
+            else
+              state = :failure
+            end
+          elsif selectable_addrinfos.any?
+            # Try other Addrinfo in next loop
+          else
+            # Wait for connection to be established or hostname resolution in next loop
+            connection_attempt_delay_expires_at = nil
+            state = :v46w
+          end
+        end
+
+        next
+      when :v46w
+        if connect_timeout && second_to_timeout(connection_attempt_started_at + connect_timeout).zero?
+          state = :timeout
+          next
+        end
+
+        remaining = second_to_timeout(connection_attempt_delay_expires_at)
+        rpipe = hostname_resolution_queue.rpipe.closed? ? nil : [hostname_resolution_queue.rpipe]
+        hostname_resolved, connectable_sockets, = IO.select(rpipe, connecting_sockets.all, nil, remaining)
+
+        if connectable_sockets&.any?
+          while (connectable_socket = connectable_sockets.pop)
+            if (sockopt = connectable_socket.getsockopt(Socket::SOL_SOCKET, Socket::SO_ERROR)).int.zero?
+              connected_socket = connectable_socket
+              connecting_sockets.delete connectable_socket
+              connectable_sockets.each do |other_connectable_socket|
+                other_connectable_socket.close unless other_connectable_socket.closed?
+              end
+              state = :success
+              break
+            else
+              failed_ai = connecting_sockets.delete connectable_socket
+              inspected_ip_address = failed_ai.ipv6? ? "[#{failed_ai.ip_address}]" : failed_ai.ip_address
+              last_error = SystemCallError.new("connect(2) for #{inspected_ip_address}:#{failed_ai.ip_port}", sockopt.int)
+              connectable_socket.close unless connectable_socket.closed?
+
+              next if connectable_sockets.any?
+
+              if selectable_addrinfos.empty? && connecting_sockets.empty? && hostname_resolution_queue.empty?
+                if !hostname_resolution_queue.rpipe.closed? && !wait_for_hostname_resolution_patiently
+                  wait_for_hostname_resolution_patiently = true
+                  connection_attempt_delay_expires_at = current_clocktime + PATIENTLY_RESOLUTION_DELAY
+                else
+                  state = :failure
+                end
+              elsif selectable_addrinfos.any?
+                # Wait for connection attempt delay timeout in next loop
+              else
+                # Wait for connection to be established or hostname resolution in next loop
+                connection_attempt_delay_expires_at = nil
+              end
+            end
+          end
+        elsif hostname_resolved&.any?
+          family_name, res = hostname_resolution_queue.get
+          selectable_addrinfos.add(family_name, res) unless res.is_a? Exception
+          connection_attempt_delay_expires_at = nil if wait_for_hostname_resolution_patiently
+          state = :v46w
+        else
+          if selectable_addrinfos.empty? && connecting_sockets.empty? && hostname_resolution_queue.empty?
+            state = :failure
+          elsif selectable_addrinfos.any?
+            state = :v46c
+          else
+            connection_attempt_delay_expires_at = nil
+          end
+        end
+
+        next
+      when :success
+        break connected_socket
+      when :failure
         raise last_error
-      else
-        raise SocketError, "no appropriate local address"
+      when :timeout
+        raise Errno::ETIMEDOUT, 'user specified timeout'
       end
     end
+
     if block_given?
       begin
         yield ret
@@ -668,7 +874,161 @@ class Socket < BasicSocket
     else
       ret
     end
+  ensure
+    hostname_resolution_threads.each do |thread|
+      thread&.exit
+    end
+
+    hostname_resolution_queue.close_all
+
+    connecting_sockets.each do |connecting_socket|
+      connecting_socket.close unless connecting_socket.closed?
+    end
   end
+
+  def self.hostname_resolution(family, host, port, hostname_resolution_queue)
+    begin
+      resolved_addrinfos = Addrinfo.getaddrinfo(host, port, ADDRESS_FAMILIES[family], :STREAM)
+      hostname_resolution_queue.add_resolved(family, resolved_addrinfos)
+    rescue => e
+      hostname_resolution_queue.add_error(family, e)
+    end
+  end
+  private_class_method :hostname_resolution
+
+  def self.second_to_timeout(ends_at)
+    return 0 unless ends_at
+
+    remaining = (ends_at - current_clocktime)
+    remaining.negative? ? 0 : remaining
+  end
+  private_class_method :second_to_timeout
+
+  def self.current_clocktime
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+  private_class_method :current_clocktime
+
+  class SelectableAddrinfos
+    PRIORITY_ON_V6 = [:ipv6, :ipv4]
+    PRIORITY_ON_V4 = [:ipv4, :ipv6]
+
+    def initialize
+      @addrinfo_dict = {}
+      @last_family = nil
+    end
+
+    def add(family_name, addrinfos)
+      @addrinfo_dict[family_name] = addrinfos
+    end
+
+    def get
+      return nil if empty?
+
+      precedences = case @last_family
+                    when :ipv4, nil then PRIORITY_ON_V6
+                    when :ipv6      then PRIORITY_ON_V4
+                    end
+
+      precedences.each do |family_name|
+        addrinfo = @addrinfo_dict[family_name]&.shift
+        next unless addrinfo
+
+        @last_family = family_name
+        return addrinfo
+      end
+    end
+
+    def empty?
+      @addrinfo_dict.all? { |_, addrinfos| addrinfos.empty? }
+    end
+
+    def any?
+      !empty?
+    end
+  end
+  private_constant :SelectableAddrinfos
+
+  class HostnameResolutionQueue
+    attr_reader :rpipe
+
+    def initialize(size)
+      @size = size
+      @taken_count = 0
+      @rpipe, @wpipe = IO.pipe
+      @queue = Queue.new
+      @mutex = Mutex.new
+    end
+
+    def add_resolved(family, resolved_addrinfos)
+      @mutex.synchronize do
+        @queue.push [family, resolved_addrinfos]
+        @wpipe.putc HOSTNAME_RESOLUTION_QUEUE_UPDATED
+      end
+    end
+
+    def add_error(family, error)
+      @mutex.synchronize do
+        @queue.push [family, error]
+        @wpipe.putc HOSTNAME_RESOLUTION_QUEUE_UPDATED
+      end
+    end
+
+    def get
+      return nil if @queue.empty?
+
+      res = nil
+
+      @mutex.synchronize do
+        @rpipe.getbyte
+        res = @queue.pop
+      end
+
+      @taken_count += 1
+      close_all if @taken_count == @size
+      res
+    end
+
+    def empty?
+      @queue.empty?
+    end
+
+    def close_all
+      @queue.close unless @queue.closed?
+      @rpipe.close unless @rpipe.closed?
+      @wpipe.close unless @wpipe.closed?
+    end
+  end
+  private_constant :HostnameResolutionQueue
+
+  class ConnectingSockets
+    def initialize
+      @socket_dict = {}
+    end
+
+    def all
+      @socket_dict.keys
+    end
+
+    def add(socket, addrinfo)
+      @socket_dict[socket] = addrinfo
+    end
+
+    def delete(socket)
+      @socket_dict.delete socket
+    end
+
+    def empty?
+      @socket_dict.empty?
+    end
+
+    def each
+      @socket_dict.keys.each do |socket|
+        yield socket
+      end
+    end
+  end
+  private_constant :ConnectingSockets
 
   # :stopdoc:
   def self.ip_sockets_port0(ai_list, reuseaddr)

--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -621,24 +621,7 @@ class Socket < BasicSocket
 
   class << self
     attr_accessor :tcp_fast_fallback
-
-    def initialize_socket
-      @local_ip_address_list = Socket.ip_address_list
-      @has_public_ipv4_addr = false
-      @has_public_ipv6_addr = false
-      @local_ip_address_list.each do |ai|
-        if ai.ipv6?
-          next if @has_public_ipv6_addr
-          @has_public_ipv6_addr = true unless (ai.ipv6_loopback? || ai.ipv6_multicast? || ai.ipv6_linklocal?)
-        else
-          next if @has_public_ipv4_addr
-          @has_public_ipv4_addr = true unless (ai.ipv4_loopback? || ai.ipv4_multicast? || ai.ip_address.start_with?("169.254"))
-        end
-      end
-    end
   end
-
-  self.initialize_socket
 
   # :call-seq:
   #   Socket.tcp(host, port, local_host=nil, local_port=nil, [opts]) {|socket| ... }
@@ -699,15 +682,7 @@ class Socket < BasicSocket
     ret = loop do
       case state
       when :start
-        specified_family_name, next_state =
-          (host && specified_family_name_and_next_state(host)) ||
-          ((host == "localhost" || host.nil?) &&
-           @local_ip_address_list.none?(&:ipv6_loopback?) ? [:ipv4, :v4c] : nil ) ||
-          ((host != "localhost" && !host.nil?) &&
-           (if @has_public_ipv4_addr && @has_public_ipv6_addr then nil
-            elsif @has_public_ipv4_addr then [:ipv4, :v4c]
-            elsif @has_public_ipv6_addr then [:ipv6, :v6c]
-            end))
+        specified_family_name, next_state = host && specified_family_name_and_next_state(host)
 
         if local_host && local_port
           specified_family_name, next_state = specified_family_name_and_next_state(local_host) unless specified_family_name

--- a/ext/socket/mkconstants.rb
+++ b/ext/socket/mkconstants.rb
@@ -669,6 +669,7 @@ SO_SETFIB       nil     Set the associated routing table for the socket (FreeBSD
 SO_RTABLE               nil     Set the routing table for this socket (OpenBSD)
 SO_INCOMING_CPU         nil     Receive the cpu attached to the socket (Linux 3.19)
 SO_INCOMING_NAPI_ID     nil     Receive the napi ID attached to a RX queue (Linux 4.12)
+SO_CONNECT_TIME         nil     Returns the number of seconds a socket has been connected. This option is only valid for connection-oriented protocols (Windows)
 
 SOPRI_INTERACTIVE	nil	Interactive socket priority
 SOPRI_NORMAL	nil	Normal socket priority

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -35,6 +35,7 @@
 #ifdef _WIN32
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
+#  include <mswsock.h>
 #  include <iphlpapi.h>
 #  if defined(_MSC_VER)
 #    undef HAVE_TYPE_STRUCT_SOCKADDR_DL

--- a/include/ruby/win32.h
+++ b/include/ruby/win32.h
@@ -35,6 +35,7 @@ extern "C++" {			/* template without extern "C++" */
 #endif
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <mswsock.h>
 #if !defined(_MSC_VER) || _MSC_VER >= 1400
 #include <iphlpapi.h>
 #endif

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -783,6 +783,10 @@ class TestSocket < Test::Unit::TestCase
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
 
     begin;
+      exit if Socket.ip_address_list.none? do |ai|
+        ai.ipv6? && (!ai.ipv6_loopback? && !ai.ipv6_multicast? && !ai.ipv6_linklocal?)
+      end
+
       begin
         server = TCPServer.new("::1", 0)
       rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
@@ -836,6 +840,10 @@ class TestSocket < Test::Unit::TestCase
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
 
     begin;
+      exit if Socket.ip_address_list.none? do |ai|
+        ai.ipv6? && (!ai.ipv6_loopback? && !ai.ipv6_multicast? && !ai.ipv6_linklocal?)
+      end
+
       begin
         server = TCPServer.new("::1", 0)
       rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
@@ -894,8 +902,17 @@ class TestSocket < Test::Unit::TestCase
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
 
     begin;
-      Addrinfo.define_singleton_method(:getaddrinfo) { |*_| sleep }
-      port = TCPServer.new("localhost", 0).addr[1]
+      Addrinfo.define_singleton_method(:getaddrinfo) { |*_|
+        if Socket.ip_address_list.none? { |ai|
+          ai.ipv6? && (!ai.ipv6_loopback? && !ai.ipv6_multicast? && !ai.ipv6_linklocal?)
+        }
+          raise Errno::ETIMEDOUT
+        else
+          sleep
+        end
+      }
+
+      port = TCPServer.new("127.0.0.1", 0).addr[1]
 
       assert_raise(Errno::ETIMEDOUT) do
         Socket.tcp("localhost", port, resolv_timeout: 0.01)
@@ -908,18 +925,13 @@ class TestSocket < Test::Unit::TestCase
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
 
     begin;
-      begin
-        server = TCPServer.new("::1", 0)
-      rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
-        exit
-      end
-
+      server = TCPServer.new("127.0.0.1", 0)
       port = server.addr[1]
 
       Addrinfo.define_singleton_method(:getaddrinfo) do |_, _, family, *_|
         case family
-        when Socket::AF_INET6 then [Addrinfo.tcp("::1", port)]
-        when Socket::AF_INET then sleep(0.001); raise SocketError
+        when Socket::AF_INET6 then sleep(0.01); raise SocketError
+        when Socket::AF_INET then [Addrinfo.tcp("127.0.0.1", port)]
         end
       end
 
@@ -955,4 +967,42 @@ class TestSocket < Test::Unit::TestCase
     end;
   end
 
+  def test_tcp_socket_v6_address_passed
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      begin
+        server = TCPServer.new("::1", 0)
+      rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
+        exit
+      end
+
+      _, port, = server.addr
+
+      Addrinfo.define_singleton_method(:getaddrinfo) do |*_|
+        [Addrinfo.tcp("::1", port)]
+      end
+
+      server_thread = Thread.new { server.accept }
+      socket = Socket.tcp("::1", port)
+
+      assert_true(socket.remote_address.ipv6?)
+      server_thread.value.close
+      server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_tcp_socket_fast_fallback_is_false
+    server = TCPServer.new("127.0.0.1", 0)
+    _, port, = server.addr
+    server_thread = Thread.new { server.accept }
+    socket = Socket.tcp("127.0.0.1", port, fast_fallback: false)
+
+    assert_true(socket.remote_address.ipv4?)
+    server_thread.value.close
+    server.close
+    socket.close if socket && !socket.closed?
+  end
 end if defined?(Socket)

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -778,4 +778,181 @@ class TestSocket < Test::Unit::TestCase
     end
   end
 
+  def test_tcp_socket_v6_hostname_resolved_earlier
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      begin
+        server = TCPServer.new("::1", 0)
+      rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
+        exit
+      end
+
+      server_thread = Thread.new { server.accept }
+      port = server.addr[1]
+
+      Addrinfo.define_singleton_method(:getaddrinfo) do |_, _, family, *_|
+        case family
+        when Socket::AF_INET6 then [Addrinfo.tcp("::1", port)]
+        when Socket::AF_INET then sleep(10); [Addrinfo.tcp("127.0.0.1", port)]
+        end
+      end
+
+      socket = Socket.tcp("localhost", port)
+      assert_true(socket.remote_address.ipv6?)
+      server_thread.value.close
+      server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_tcp_socket_v4_hostname_resolved_earlier
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.addr[1]
+
+      Addrinfo.define_singleton_method(:getaddrinfo) do |_, _, family, *_|
+        case family
+        when Socket::AF_INET6 then sleep(10); [Addrinfo.tcp("::1", port)]
+        when Socket::AF_INET then [Addrinfo.tcp("127.0.0.1", port)]
+        end
+      end
+
+      server_thread = Thread.new { server.accept }
+      socket = Socket.tcp("localhost", port)
+      assert_true(socket.remote_address.ipv4?)
+      server_thread.value.close
+      server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_tcp_socket_v6_hostname_resolved_in_resolution_delay
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      begin
+        server = TCPServer.new("::1", 0)
+      rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
+        exit
+      end
+
+      port = server.addr[1]
+      delay_time = 0.025 # Socket::RESOLUTION_DELAY (private) is 0.05
+
+      Addrinfo.define_singleton_method(:getaddrinfo) do |_, _, family, *_|
+        case family
+        when Socket::AF_INET6 then sleep(delay_time); [Addrinfo.tcp("::1", port)]
+        when Socket::AF_INET then [Addrinfo.tcp("127.0.0.1", port)]
+        end
+      end
+
+      server_thread = Thread.new { server.accept }
+      socket = Socket.tcp("localhost", port)
+      assert_true(socket.remote_address.ipv6?)
+      server_thread.value.close
+      server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_tcp_socket_v6_hostname_resolved_earlier_and_v6_server_is_not_listening
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      ipv4_address = "127.0.0.1"
+      ipv4_server = Socket.new(Socket::AF_INET, :STREAM)
+      ipv4_server.bind(Socket.pack_sockaddr_in(0, ipv4_address))
+      port = ipv4_server.connect_address.ip_port
+
+      Addrinfo.define_singleton_method(:getaddrinfo) do |_, _, family, *_|
+        case family
+        when Socket::AF_INET6 then [Addrinfo.tcp("::1", port)]
+        when Socket::AF_INET then sleep(0.001); [Addrinfo.tcp(ipv4_address, port)]
+        end
+      end
+
+      ipv4_server_thread = Thread.new { ipv4_server.listen(1); ipv4_server.accept }
+      socket = Socket.tcp("localhost", port)
+      assert_equal(ipv4_address, socket.remote_address.ip_address)
+
+      accepted, _ = ipv4_server_thread.value
+      accepted.close
+      ipv4_server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_tcp_socket_resolv_timeout
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      Addrinfo.define_singleton_method(:getaddrinfo) { |*_| sleep }
+      port = TCPServer.new("localhost", 0).addr[1]
+
+      assert_raise(Errno::ETIMEDOUT) do
+        Socket.tcp("localhost", port, resolv_timeout: 0.01)
+      end
+    end;
+  end
+
+  def test_tcp_socket_one_hostname_resolution_succeeded_at_least
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      begin
+        server = TCPServer.new("::1", 0)
+      rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
+        exit
+      end
+
+      port = server.addr[1]
+
+      Addrinfo.define_singleton_method(:getaddrinfo) do |_, _, family, *_|
+        case family
+        when Socket::AF_INET6 then [Addrinfo.tcp("::1", port)]
+        when Socket::AF_INET then sleep(0.001); raise SocketError
+        end
+      end
+
+      server_thread = Thread.new { server.accept }
+      socket = nil
+
+      assert_nothing_raised do
+        socket = Socket.tcp("localhost", port)
+      end
+
+      server_thread.value.close
+      server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_tcp_socket_all_hostname_resolution_failed
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      Addrinfo.define_singleton_method(:getaddrinfo) do |_, _, family, *_|
+        case family
+        when Socket::AF_INET6 then raise SocketError
+        when Socket::AF_INET then sleep(0.001); raise SocketError, "Last hostname resolution error"
+        end
+      end
+      port = TCPServer.new("localhost", 0).addr[1]
+
+      assert_raise_with_message(SocketError, "Last hostname resolution error") do
+        Socket.tcp("localhost", port)
+      end
+    end;
+  end
+
 end if defined?(Socket)


### PR DESCRIPTION
This is an implementation of Happy Eyeballs version 2 (RFC 8305) in Socket.tcp.

### Background
Currently, `Socket.tcp` synchronously resolves names and makes connection attempts with `Addrinfo::foreach.`
This implementation has the following two problems.

1. In hostname resolution, the program stops until the DNS server responds to all DNS queries.
2. In a connection attempt, while an IP address is trying to connect to the destination host and is taking time, the program stops, and other resolved IP addresses cannot try to connect.

### Proposal
"Happy Eyeballs" ([RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305)) is an algorithm to solve this kind of problem. It avoids delays to the user whenever possible and also uses IPv6 preferentially.
I implemented it into `Socket.tcp` by using `Addrinfo.getaddrinfo` in each thread spawned per address family to resolve the hostname asynchronously, and using `Socket::connect_nonblock` to try to connect with multiple addrinfo in parallel. 

### Outcome

This change eliminates a fatal defect in the following cases.

#### Case 1. One of the A or AAAA DNS queries does not return

```ruby
require 'socket'

class Addrinfo
  class << self
    # Current Socket.tcp depends on foreach
    def foreach(nodename, service, family=nil, socktype=nil, protocol=nil, flags=nil, timeout: nil, &block)
      getaddrinfo(nodename, service, Socket::AF_INET6, socktype, protocol, flags, timeout: timeout)
        .concat(getaddrinfo(nodename, service, Socket::AF_INET, socktype, protocol, flags, timeout: timeout))
        .each(&block)
    end

    def getaddrinfo(_, _, family, *_)
      case family
      when Socket::AF_INET6 then sleep
      when Socket::AF_INET then [Addrinfo.tcp("127.0.0.1", 4567)]
      end
    end
  end
end

Socket.tcp("localhost", 4567)
```

Because the current `Socket.tcp` cannot resolve IPv6 names, the program stops in this case. It cannot start to connect with IPv4 address.
Though `Socket.tcp` with HEv2 can promptly start a connection attempt with IPv4 address in this case.

#### Case 2. Server does not promptly return ack for syn of either IPv4 / IPv6 address family

```ruby
require 'socket'

fork do
  socket = Socket.new(Socket::AF_INET6, :STREAM)
  socket.setsockopt(:SOCKET, :REUSEADDR, true)
  socket.bind(Socket.pack_sockaddr_in(4567, '::1'))
  sleep
  socket.listen(1)
  connection, _ = socket.accept
  connection.close
  socket.close
end

fork do
  socket = Socket.new(Socket::AF_INET, :STREAM)
  socket.setsockopt(:SOCKET, :REUSEADDR, true)
  socket.bind(Socket.pack_sockaddr_in(4567, '127.0.0.1'))
  socket.listen(1)
  connection, _ = socket.accept
  connection.close
  socket.close
end

Socket.tcp("localhost", 4567)
```

The current `Socket.tcp` tries to connect serially, so when its first name resolves an IPv6 address and initiates a connection to an IPv6 server, this server does not return an ACK, and the program stops.
Though `Socket.tcp` with HEv2 starts to connect sequentially and in parallel so a connection can be established promptly at the socket that attempted to connect to the IPv4 server.

In exchange, the performance of `Socket.tcp` with HEv2 will be degraded.

```
100.times { Socket.tcp("www.ruby-lang.org", 80) }
# Socket.tcp (Before) 0.123809
# Socket.tcp (After)  0.246387
```

This is due to the addition of the creation of IO objects, Thread objects, etc., and calls to `IO::select` in the implementation.