### PR TITLE
[Backport 3.3] [Bug #20085] Use consistent default options for `-mbranch-protection`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -830,7 +830,10 @@ AS_IF([test "$GCC" = yes], [
 	AS_FOR(option, opt, [-mbranch-protection=pac-ret -msign-return-address=all], [
             RUBY_TRY_CFLAGS(option, [branch_protection=yes], [branch_protection=no])
             AS_IF([test "x$branch_protection" = xyes], [
+                # C compiler and assembler must be consistent for -mbranch-protection
+                # since they both check `__ARM_FEATURE_PAC_DEFAULT` definition.
                 RUBY_APPEND_OPTION(XCFLAGS, option)
+                RUBY_APPEND_OPTION(ASFLAGS, option)
                 break
             ])
         ])


### PR DESCRIPTION
Cherry-pick 02973b78f499acc28c714a082c82a846314a911f to fix a regression in 3.3.0 release https://bugs.ruby-lang.org/issues/20085

- Short description: Fiber on aarch64 with PAC support on Linux was broken in 3.3.0. The patch fixes the issue by adjusting compiler options.
- Scope: Only aarch64 with PAC support on Linux (like aarch64 Linux container on M1 Mac)
- Testing: Unfortunately, we don't have a CI node that affects the issue. The community and I tested the patch manually on such environments.

---

We need to use the same options for both C compiler and assembler when `-mbranch-protection` is guessed by configure. Otherwise, `coroutine/arm64/Context.{h,S}` will use incompatible PAC strategies.
