### PR TITLE
ci: Fixup for Playground CI workflow

### DIFF
--- a/.github/workflows/pr-playground.yml
+++ b/.github/workflows/pr-playground.yml
@@ -22,8 +22,7 @@ jobs:
       || (true
         && github.event_name == 'workflow_run'
         && github.event.workflow_run.conclusion == 'success'
-        && github.event.workflow_run.event == 'pull_request'
-      )
+        && github.event.workflow_run.event == 'pull_request')
       }}
     steps:
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -73,13 +72,11 @@ jobs:
               }
               // Workaround for https://github.com/orgs/community/discussions/25220
 
-              console.log(JSON.stringify(context.payload, null, 2));
               const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 run_id: context.payload.workflow_run.id,
               });
-              console.log(JSON.stringify(artifacts, null, 2));
               const artifact = artifacts.find(artifact => artifact.name == 'github-pr-info');
               if (!artifact) {
                 throw new Error('Cannot find github-pr-info.txt artifact');
@@ -99,12 +96,17 @@ jobs:
 
             const prNumber = await derivePRNumber();
 
-            console.log(`PR number: ${prNumber}`);
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: prNumber,
             });
+
+            core.info(`Checking if the PR ${prNumber} is labeled with Playground...`);
+            if (!pr.labels.some(label => label.name == 'Playground')) {
+              core.info(`The PR is not labeled with Playground.`);
+              return;
+            }
 
             core.info(`Checking if the build is successful for ${pr.head.ref} in ${pr.head.repo.owner.login}/${pr.head.repo.name}...`);
             const buildRun = await findSuccessfuBuildRun(pr);

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -163,12 +163,12 @@ jobs:
       # Workaround for https://github.com/orgs/community/discussions/25220
       - name: Save Pull Request number
         if: ${{ github.event_name == 'pull_request' }}
-        run: echo "${{ github.event.pull_request.number }}" >> ./github-pr-info.txt
+        run: echo "${{ github.event.pull_request.number }}" >> ${{ github.workspace }}/github-pr-info.txt
       - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         if: ${{ github.event_name == 'pull_request' }}
         with:
           name: github-pr-info
-          path: github-pr-info.txt
+          path: ${{ github.workspace }}/github-pr-info.txt
 
 defaults:
   run:


### PR DESCRIPTION
* Remove debugging code
* Fix path to github-pr-info.txt, which is used when labeled before build completes
* Add a check to skip the build if the build is completed but the PR is not labeled with Playground