### PR TITLE
ci: Add arm64/v8 configuration to GitHub Actions

### DIFF
--- a/.github/actions/setup/ubuntu/action.yml
+++ b/.github/actions/setup/ubuntu/action.yml
@@ -11,6 +11,12 @@ inputs:
     description: >-
       Architecture.  Because we run this on a GitHub-hosted runner
       acceptable value for this input is very limited.
+  docker_platform:
+    required: false
+    default: ''
+    description: >-
+      Docker platform.  This is used to run QEMU on a GitHub-hosted
+      runner.
 
 outputs:
   arch:
@@ -24,7 +30,29 @@ runs:
   using: composite
 
   steps:
+    - name: set SETARCH for QEMU
+      if: ${{ inputs.docker_platform != '' }}
+      shell: bash
+      run: |
+        CONTAINER_NAME="ruby-ci-ubuntu-$GITHUB_RUN_ID"
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        docker run -dit -v "$PWD:$PWD" -w "$PWD" \
+          --name "$CONTAINER_NAME" \
+          --platform=${{ inputs.docker_platform }} \
+          ubuntu:20.04
+
+        SETARCH="${{ github.workspace }}/setarch"
+        echo '#!/bin/sh'                                    >> $SETARCH
+        echo "exec docker exec \\"                          >> $SETARCH
+        echo "  --env DEBIAN_FRONTEND=\$DEBIAN_FRONTEND \\" >> $SETARCH
+        echo "  --env GNUMAKEFLAGS=\$GNUMAKEFLAGS \\"       >> $SETARCH
+        echo "  --workdir \$PWD $CONTAINER_NAME \$@"        >> $SETARCH
+        chmod +x $SETARCH
+
+        echo "SETARCH=${SETARCH}" >> "$GITHUB_ENV"
+
     - name: set SETARCH
+      if: ${{ inputs.docker_platform == '' }}
       shell: bash
       run: echo "SETARCH=${setarch}" >> "$GITHUB_ENV"
       env:
@@ -39,15 +67,18 @@ runs:
 
     - name: apt-get
       shell: bash
+      # Run `apt-get` on the guest machine if we use QEMU. Otherwise install
+      # the target arch packages on the host machine.
       env:
-        arch: ${{ inputs.arch && format(':{0}', steps.uname.outputs.dpkg) || '' }}
+        arch: ${{ (inputs.arch && inputs.docker_platform == '') && format(':{0}', steps.uname.outputs.dpkg) || '' }}
+        shell: ${{ inputs.docker_platform != '' && env.SETARCH || 'sudo' }}
       run: |
         set -x
         ${arch:+sudo dpkg --add-architecture ${arch#:}}
-        sudo apt-get update -qq || :
-        sudo apt-get install --no-install-recommends -qq -y -o=Dpkg::Use-Pty=0 \
+        ${shell} apt-get update -qq || :
+        ${shell} apt-get install --no-install-recommends -qq -y -o=Dpkg::Use-Pty=0 \
         ${arch:+cross}build-essential${arch/:/-} \
         libssl-dev${arch} libyaml-dev${arch} libreadline6-dev${arch} \
         zlib1g-dev${arch} libncurses5-dev${arch} libffi-dev${arch} \
         autoconf ruby
-        sudo apt-get install -qq -y pkg-config${arch} || :
+        ${shell} apt-get install -qq -y pkg-config${arch} || :

--- a/.github/actions/setup/ubuntu/action.yml
+++ b/.github/actions/setup/ubuntu/action.yml
@@ -34,7 +34,7 @@ runs:
       if: ${{ inputs.use_docker == 'true' && runner.os == 'macOS' }}
       shell: bash
       run: |
-        brew install docker
+        brew install docker colima
         colima start
 
     - name: set SETARCH (docker)

--- a/.github/actions/setup/ubuntu/action.yml
+++ b/.github/actions/setup/ubuntu/action.yml
@@ -11,9 +11,9 @@ inputs:
     description: >-
       Architecture.  Because we run this on a GitHub-hosted runner
       acceptable value for this input is very limited.
-  docker_platform:
+  use_docker:
     required: false
-    default: ''
+    default: 'false'
     description: >-
       Docker platform.  This is used to run QEMU on a GitHub-hosted
       runner.
@@ -30,15 +30,20 @@ runs:
   using: composite
 
   steps:
-    - name: set SETARCH for QEMU
-      if: ${{ inputs.docker_platform != '' }}
+    - name: install Docker
+      if: ${{ inputs.use_docker == 'true' && runner.os == 'macOS' }}
+      shell: bash
+      run: |
+        brew install docker
+        colima start
+
+    - name: set SETARCH (docker)
+      if: ${{ inputs.use_docker == 'true' }}
       shell: bash
       run: |
         CONTAINER_NAME="ruby-ci-ubuntu-$GITHUB_RUN_ID"
-        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         docker run -dit -v "$PWD:$PWD" -w "$PWD" \
           --name "$CONTAINER_NAME" \
-          --platform=${{ inputs.docker_platform }} \
           ubuntu:20.04
 
         SETARCH="${{ github.workspace }}/setarch"
@@ -52,7 +57,7 @@ runs:
         echo "SETARCH=${SETARCH}" >> "$GITHUB_ENV"
 
     - name: set SETARCH
-      if: ${{ inputs.docker_platform == '' }}
+      if: ${{ inputs.use_docker != 'true' }}
       shell: bash
       run: echo "SETARCH=${setarch}" >> "$GITHUB_ENV"
       env:
@@ -67,11 +72,11 @@ runs:
 
     - name: apt-get
       shell: bash
-      # Run `apt-get` on the guest machine if we use QEMU. Otherwise install
-      # the target arch packages on the host machine.
+      # Run `apt-get` on the guest machine if we use a guest machine. Otherwise
+      # install the target arch packages on the host machine.
       env:
-        arch: ${{ (inputs.arch && inputs.docker_platform == '') && format(':{0}', steps.uname.outputs.dpkg) || '' }}
-        shell: ${{ inputs.docker_platform != '' && env.SETARCH || 'sudo' }}
+        arch: ${{ (inputs.arch && inputs.use_docker != 'true') && format(':{0}', steps.uname.outputs.dpkg) || '' }}
+        shell: ${{ inputs.use_docker == 'true' && env.SETARCH || 'sudo' }}
       run: |
         set -x
         ${arch:+sudo dpkg --add-architecture ${arch#:}}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,8 +11,6 @@ on:
   pull_request:
     # Do not use paths-ignore for required status checks
     # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
-  workflow_dispatch:
-
   merge_group:
     paths-ignore:
       - 'doc/**'
@@ -48,14 +46,11 @@ jobs:
             { test_task: 'test-bundler-parallel' },
             { test_task: 'test-bundled-gems' },
           ]
-          require 'json'
-          event = JSON.parse(File.read(ENV['GITHUB_EVENT_PATH']))
-
-          # Run slow jobs only for master branch and manual trigger
-          if (ENV['GITHUB_EVENT_NAME'] == 'push' && ENV['GITHUB_REF'] == 'refs/heads/master') ||
-             (ENV['GITHUB_EVENT_NAME'] == 'workflow_dispatch')
-            matrix << { test_task: 'test', arch: 'arm64', docker_platform: 'linux/arm64/v8' }
+          # Add arm64 macos runner only for ruby/ruby
+          if ENV['GITHUB_REPOSITORY'] == 'ruby/ruby'
+            matrix << { test_task: 'test', arch: 'arm64', runner: 'macos-arm-oss', use_docker: 'true' }
           end
+          require 'json'
           File.write(ENV['GITHUB_OUTPUT'], "matrix-include=#{JSON.dump(matrix)}")
 
   make:
@@ -64,7 +59,6 @@ jobs:
       matrix:
         test_task: [check]
         arch: ['']
-        docker_platform: ['']
         configure: ['cppflags=-DVM_CHECK_MODE']
         # specifying other jobs with `include` to avoid redundant tests
         include: ${{ fromJson(needs.build-matrix.outputs.matrix-include) }}
@@ -74,7 +68,7 @@ jobs:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
       RUBY_DEBUG: ci
 
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.runner || 'ubuntu-20.04' }}
 
     if: >-
       ${{!(false
@@ -93,7 +87,7 @@ jobs:
       - uses: ./.github/actions/setup/ubuntu
         with:
           arch: ${{ matrix.arch }}
-          docker_platform: ${{ matrix.docker_platform }}
+          use_docker: ${{ matrix.use_docker }}
 
       - uses: ./.github/actions/setup/directories
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,6 +11,8 @@ on:
   pull_request:
     # Do not use paths-ignore for required status checks
     # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+  workflow_dispatch:
+
   merge_group:
     paths-ignore:
       - 'doc/**'
@@ -28,22 +30,44 @@ permissions:
   contents: read
 
 jobs:
+  build-matrix:
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix-include: ${{ steps.generate.outputs.matrix-include }}
+
+    steps:
+      - name: Generate matrix entries
+        shell: ruby {0}
+        id: generate
+        working-directory: ${{ github.workspace }}
+        run: |
+          matrix = [
+            { test_task: 'check', arch: 'i686' },
+            { test_task: 'check', configure: '--disable-yjit' },
+            { test_task: 'check', configure: '--enable-shared --enable-load-relative' },
+            { test_task: 'test-bundler-parallel' },
+            { test_task: 'test-bundled-gems' },
+          ]
+          require 'json'
+          event = JSON.parse(File.read(ENV['GITHUB_EVENT_PATH']))
+
+          # Run slow jobs only for master branch and manual trigger
+          if (ENV['GITHUB_EVENT_NAME'] == 'push' && ENV['GITHUB_REF'] == 'refs/heads/master') ||
+             (ENV['GITHUB_EVENT_NAME'] == 'workflow_dispatch')
+            matrix << { test_task: 'test', arch: 'arm64', docker_platform: 'linux/arm64/v8' }
+          end
+          File.write(ENV['GITHUB_OUTPUT'], "matrix-include=#{JSON.dump(matrix)}")
+
   make:
+    needs: [build-matrix]
     strategy:
       matrix:
         test_task: [check]
         arch: ['']
+        docker_platform: ['']
         configure: ['cppflags=-DVM_CHECK_MODE']
         # specifying other jobs with `include` to avoid redundant tests
-        include:
-          - test_task: check
-            arch: i686
-          - test_task: check
-            configure: '--disable-yjit'
-          - test_task: check
-            configure: '--enable-shared --enable-load-relative'
-          - test_task: test-bundler-parallel
-          - test_task: test-bundled-gems
+        include: ${{ fromJson(needs.build-matrix.outputs.matrix-include) }}
       fail-fast: false
 
     env:
@@ -69,6 +93,7 @@ jobs:
       - uses: ./.github/actions/setup/ubuntu
         with:
           arch: ${{ matrix.arch }}
+          docker_platform: ${{ matrix.docker_platform }}
 
       - uses: ./.github/actions/setup/directories
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -40,11 +40,11 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           matrix = [
-            { test_task: 'check', arch: 'i686' },
-            { test_task: 'check', configure: '--disable-yjit' },
-            { test_task: 'check', configure: '--enable-shared --enable-load-relative' },
-            { test_task: 'test-bundler-parallel' },
-            { test_task: 'test-bundled-gems' },
+            # { test_task: 'check', arch: 'i686' },
+            # { test_task: 'check', configure: '--disable-yjit' },
+            # { test_task: 'check', configure: '--enable-shared --enable-load-relative' },
+            # { test_task: 'test-bundler-parallel' },
+            # { test_task: 'test-bundled-gems' },
           ]
           # Add arm64 macos runner only for ruby/ruby
           if ENV['GITHUB_REPOSITORY'] == 'ruby/ruby'
@@ -79,6 +79,7 @@ jobs:
       )}}
 
     steps:
+      - uses: mxschmitt/action-tmate@v3
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
To verify some arm64/v8 specific code like PAC/BTI. Since the QEMU emulation is slow, it's only triggered when pushed to master branch and manually triggered. Also some of bootstrap Ractor tests are failing, so use `make test` as a smoke test for now.