### PR TITLE
Fix [Bug #20098]: set counter value for {n,m} repetition correctly

### DIFF
--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1987,6 +1987,14 @@ class TestRegexp < Test::Unit::TestCase
     end
   end
 
+  def test_bug_20098 # [Bug #20098]
+    assert /a((.|.)|bc){,4}z/.match? 'abcbcbcbcz'
+    assert /a(b+?c*){4,5}z/.match? 'abbbccbbbccbcbcz'
+    assert /a(b+?(.|.)){2,3}z/.match? 'abbbcbbbcbbbcz'
+    assert /a(b*?(.|.)[bc]){2,5}z/.match? 'abcbbbcbcccbcz'
+    assert /^(?:.+){2,4}?b|b/.match? "aaaabaa"
+  end
+
   def test_linear_time_p
     assert_send [Regexp, :linear_time?, /a/]
     assert_send [Regexp, :linear_time?, 'a']


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20098