### PR TITLE
[DOC] clarify situation for Ractor#send of T_DATA objects.

### DIFF
--- a/doc/ractor.md
+++ b/doc/ractor.md
@@ -204,8 +204,8 @@ For message sending and receiving, there are two types of APIs: push type and pu
   * When a Ractor is terminated, the Ractor's ports are closed.
 * There are 3 ways to send an object as a message
   * (1) Send a reference: Sending a shareable object, send only a reference to the object (fast)
-  * (2) Copy an object: Sending an unshareable object by copying an object deeply (slow). Note that you can not send an object which does not support deep copy. Some `T_DATA` objects are not supported.
-  * (3) Move an object: Sending an unshareable object reference with a membership. Sender Ractor can not access moved objects anymore (raise an exception) after moving it. Current implementation makes new object as a moved object for receiver Ractor and copies references of sending object to moved object.
+  * (2) Copy an object: Sending an unshareable object by copying an object deeply (slow). Note that you can not send an object which does not support deep copy. Some `T_DATA` objects (objects whose class is defined in a C extension, such as `StringIO`) are not supported.
+  * (3) Move an object: Sending an unshareable object reference with a membership. Sender Ractor can not access moved objects anymore (raise an exception) after moving it. Current implementation makes new object as a moved object for receiver Ractor and copies references of sending object to moved object. `T_DATA` objects are not supported.
   * You can choose "Copy" and "Move" by the `move:` keyword, `Ractor#send(obj, move: true/false)` and `Ractor.yield(obj, move: true/false)` (default is `false` (COPY)).
 
 ### Sending/Receiving ports


### PR DESCRIPTION
For copying, use language like "some" T_DATA objects not supported. This is because objects like Time are supported, they don't refer to other objects so it's okay.

For `send(obj, move: true)`, it's currently not supported to move any T_DATA objects.

Fix [Bug #20078]