### PR TITLE
Use max_cpu when RUBY_MAX_CPU given

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1685,8 +1685,11 @@ ruby_mn_threads_params(void)
     const int default_max_cpu = 8; // TODO: CPU num?
     int max_cpu = default_max_cpu;
 
-    if (USE_MN_THREADS && max_cpu_cstr && (max_cpu = atoi(max_cpu_cstr)) > 0) {
-        max_cpu = default_max_cpu;
+    if (USE_MN_THREADS && max_cpu_cstr)  {
+        int given_max_cpu = atoi(max_cpu_cstr);
+        if (given_max_cpu > 0) {
+            max_cpu = given_max_cpu;
+        }
     }
 
     vm->ractor.sched.max_cpu = max_cpu;


### PR DESCRIPTION
Happy new year!!

From Ruby 3.3.0, M:N Thread introduced, and users can set how many CPU can be used for it via `RUBY_MAX_CPU`.

When user gives max cpu num for M:N thread via `RUBY_MAX_CPU` env, however, current implementation set value to `max_cpu` and overwrite it with `default_max_cpu`.
I think which is weird, and expected behavior is like this diff, set given max cpu num.
How do you think @ko1 ? Am I misunderstanding something? 🤔 

Confirmed on custom build with this patch, and I noticed RUBY_MAX_CPU=1 make process unreachable, do we ignore if 1 given?