### PR TITLE
Update net test cert fixture

### DIFF
--- a/test/net/fixtures/cacert.pem
+++ b/test/net/fixtures/cacert.pem
@@ -1,24 +1,82 @@
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            23:47:84:0c:27:d1:e9:46:8b:b1:7e:a4:eb:aa:3b:e7:8c:35:47:ff
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = JP, ST = Shimane, L = Matz-e city, O = Ruby Core Team, CN = Ruby Test CA, emailAddress = security@ruby-lang.org
+        Validity
+            Not Before: Jan  1 11:02:41 2024 GMT
+            Not After : Dec 30 11:02:41 2028 GMT
+        Subject: C = JP, ST = Shimane, L = Matz-e city, O = Ruby Core Team, CN = Ruby Test CA, emailAddress = security@ruby-lang.org
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:e8:da:9c:01:2e:2b:10:ec:49:cd:5e:07:13:07:
+                    9c:70:9e:c6:74:bc:13:c2:e1:6f:c6:82:fd:e3:48:
+                    e0:2c:a5:68:c7:9e:42:de:60:54:65:e6:6a:14:57:
+                    7a:30:d0:cc:b5:b6:d9:c3:d2:df:c9:25:97:54:67:
+                    cf:f6:be:5e:cb:8b:ee:03:c5:e1:e2:f9:e7:f7:d1:
+                    0c:47:f0:b8:da:33:5a:ad:41:ad:e7:b5:a2:7b:b7:
+                    bf:30:da:60:f8:e3:54:a2:bc:3a:fd:1b:74:d9:dc:
+                    74:42:e9:29:be:df:ac:b4:4f:eb:32:f4:06:f1:e1:
+                    8c:4b:a8:8b:fb:29:e7:b1:bf:1d:01:ee:73:0f:f9:
+                    40:dc:d5:15:79:d9:c6:73:d0:c0:dd:cb:e4:da:19:
+                    47:80:c6:14:04:72:fd:9a:7c:8f:11:82:76:49:04:
+                    79:cc:f2:5c:31:22:95:13:3e:5d:40:a6:4d:e0:a3:
+                    02:26:7d:52:3b:bb:ed:65:a1:0f:ed:6b:b0:3c:d4:
+                    de:61:15:5e:d3:dd:68:09:9f:4a:57:a5:c2:a9:6d:
+                    86:92:c5:f4:a4:d4:b7:13:3b:52:63:24:05:e2:cc:
+                    e3:8a:3c:d4:35:34:2b:10:bb:58:72:e7:e1:8d:1d:
+                    74:8c:61:16:20:3d:d0:1c:4e:8f:6e:fd:fe:64:10:
+                    4f:41
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Subject Key Identifier: 
+                ED:28:C2:7E:AB:4B:C8:E8:FE:55:6D:66:95:31:1C:2D:60:F9:02:36
+            X509v3 Authority Key Identifier: 
+                ED:28:C2:7E:AB:4B:C8:E8:FE:55:6D:66:95:31:1C:2D:60:F9:02:36
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        1f:33:d1:7a:75:b6:ce:0d:1e:6e:4b:16:f5:6b:d1:53:68:33:
+        30:ee:5a:b6:f2:7f:1c:99:23:44:a8:ae:6e:23:49:44:2b:72:
+        be:5c:86:e7:55:25:44:47:21:19:3c:09:97:55:73:3b:de:d1:
+        e7:a4:ac:4c:b0:03:06:12:0a:0d:32:b2:a6:a0:28:3a:30:b1:
+        b5:3c:5b:8c:35:31:77:9f:fd:be:1c:34:54:c9:60:4f:32:39:
+        02:a7:94:56:8b:7f:46:ec:70:1e:f0:4f:de:2c:b7:19:b2:0d:
+        02:05:5c:e5:d4:48:eb:a3:c3:f2:fc:73:19:ba:17:cd:39:f6:
+        ab:99:7c:dc:d3:58:c2:8c:ae:78:5d:d9:2e:24:9d:04:67:a5:
+        11:8e:d9:b6:fd:f8:15:99:0c:c7:01:e7:07:74:92:d8:9f:22:
+        5b:cc:2e:e7:bd:e3:0a:b9:2e:c2:59:11:75:6f:40:43:fc:04:
+        8f:b9:10:48:01:d0:9e:ec:a5:ca:c9:4f:a3:92:5e:65:0e:c1:
+        df:8b:d6:44:a2:53:7a:b2:ed:86:ca:34:4f:b4:66:d6:3d:03:
+        60:a4:05:1f:8b:d8:24:93:2a:a1:f6:87:d2:78:23:b7:f2:b8:
+        77:7a:02:4b:2b:a7:b3:10:1a:17:5c:8e:1f:49:a0:5b:bb:ca:
+        03:2c:4b:29
 -----BEGIN CERTIFICATE-----
-MIID7TCCAtWgAwIBAgIJAIltvxrFAuSnMA0GCSqGSIb3DQEBCwUAMIGMMQswCQYD
-VQQGEwJKUDEQMA4GA1UECAwHU2hpbWFuZTEUMBIGA1UEBwwLTWF0ei1lIGNpdHkx
-FzAVBgNVBAoMDlJ1YnkgQ29yZSBUZWFtMRUwEwYDVQQDDAxSdWJ5IFRlc3QgQ0Ex
-JTAjBgkqhkiG9w0BCQEWFnNlY3VyaXR5QHJ1YnktbGFuZy5vcmcwHhcNMTkwMTAy
-MDI1ODI4WhcNMjQwMTAxMDI1ODI4WjCBjDELMAkGA1UEBhMCSlAxEDAOBgNVBAgM
-B1NoaW1hbmUxFDASBgNVBAcMC01hdHotZSBjaXR5MRcwFQYDVQQKDA5SdWJ5IENv
-cmUgVGVhbTEVMBMGA1UEAwwMUnVieSBUZXN0IENBMSUwIwYJKoZIhvcNAQkBFhZz
-ZWN1cml0eUBydWJ5LWxhbmcub3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
-CgKCAQEAznlbjRVhz1NlutHVrhcGnK8W0qug2ujKXv1njSC4U6nJF6py7I9EeehV
-SaKePyv+I9z3K1LnfUHOtUbdwdKC77yN66A6q2aqzu5q09/NSykcZGOIF0GuItYI
-3nvW3IqBddff2ffsyR+9pBjfb5AIPP08WowF9q4s1eGULwZc4w2B8PFhtxYANd7d
-BvGLXFlcufv9tDtzyRi4t7eqxCRJkZQIZNZ6DHHIJrNxejOILfHLarI12yk8VK6L
-2LG4WgGqyeePiRyd1o1MbuiAFYqAwpXNUbRKg5NaZGwBHZk8UZ+uFKt1QMBURO5R
-WFy1c349jbWszTqFyL4Lnbg9HhAowQIDAQABo1AwTjAdBgNVHQ4EFgQU9tEiKdU9
-I9derQyc5nWPnc34nVMwHwYDVR0jBBgwFoAU9tEiKdU9I9derQyc5nWPnc34nVMw
-DAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAxj7F/u3C3fgq24N7hGRA
-of7ClFQxGmo/IGT0AISzW3HiVYiFaikKhbO1NwD9aBpD8Zwe62sCqMh8jGV/b0+q
-aOORnWYNy2R6r9FkASAglmdF6xn3bhgGD5ls4pCvcG9FynGnGc24g6MrjFNrBYUS
-2iIZsg36i0IJswo/Dy6HLphCms2BMCD3DeWtfjePUiTmQHJo6HsQIKP/u4N4Fvee
-uMBInei2M4VU74fLXbmKl1F9AEX7JDP3BKSZG19Ch5pnUo4uXM1uNTGsi07P4Y0s
-K44+SKBC0bYEFbDK0eQWMrX3kIhkPxyIWhxdq9/NqPYjShuSEAhA6CSpmRg0pqc+
-mA==
+MIID+zCCAuOgAwIBAgIUI0eEDCfR6UaLsX6k66o754w1R/8wDQYJKoZIhvcNAQEL
+BQAwgYwxCzAJBgNVBAYTAkpQMRAwDgYDVQQIDAdTaGltYW5lMRQwEgYDVQQHDAtN
+YXR6LWUgY2l0eTEXMBUGA1UECgwOUnVieSBDb3JlIFRlYW0xFTATBgNVBAMMDFJ1
+YnkgVGVzdCBDQTElMCMGCSqGSIb3DQEJARYWc2VjdXJpdHlAcnVieS1sYW5nLm9y
+ZzAeFw0yNDAxMDExMTAyNDFaFw0yODEyMzAxMTAyNDFaMIGMMQswCQYDVQQGEwJK
+UDEQMA4GA1UECAwHU2hpbWFuZTEUMBIGA1UEBwwLTWF0ei1lIGNpdHkxFzAVBgNV
+BAoMDlJ1YnkgQ29yZSBUZWFtMRUwEwYDVQQDDAxSdWJ5IFRlc3QgQ0ExJTAjBgkq
+hkiG9w0BCQEWFnNlY3VyaXR5QHJ1YnktbGFuZy5vcmcwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQDo2pwBLisQ7EnNXgcTB5xwnsZ0vBPC4W/Ggv3jSOAs
+pWjHnkLeYFRl5moUV3ow0My1ttnD0t/JJZdUZ8/2vl7Li+4DxeHi+ef30QxH8Lja
+M1qtQa3ntaJ7t78w2mD441SivDr9G3TZ3HRC6Sm+36y0T+sy9Abx4YxLqIv7Keex
+vx0B7nMP+UDc1RV52cZz0MDdy+TaGUeAxhQEcv2afI8RgnZJBHnM8lwxIpUTPl1A
+pk3gowImfVI7u+1loQ/ta7A81N5hFV7T3WgJn0pXpcKpbYaSxfSk1LcTO1JjJAXi
+zOOKPNQ1NCsQu1hy5+GNHXSMYRYgPdAcTo9u/f5kEE9BAgMBAAGjUzBRMB0GA1Ud
+DgQWBBTtKMJ+q0vI6P5VbWaVMRwtYPkCNjAfBgNVHSMEGDAWgBTtKMJ+q0vI6P5V
+bWaVMRwtYPkCNjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAf
+M9F6dbbODR5uSxb1a9FTaDMw7lq28n8cmSNEqK5uI0lEK3K+XIbnVSVERyEZPAmX
+VXM73tHnpKxMsAMGEgoNMrKmoCg6MLG1PFuMNTF3n/2+HDRUyWBPMjkCp5RWi39G
+7HAe8E/eLLcZsg0CBVzl1Ejro8Py/HMZuhfNOfarmXzc01jCjK54XdkuJJ0EZ6UR
+jtm2/fgVmQzHAecHdJLYnyJbzC7nveMKuS7CWRF1b0BD/ASPuRBIAdCe7KXKyU+j
+kl5lDsHfi9ZEolN6su2GyjRPtGbWPQNgpAUfi9gkkyqh9ofSeCO38rh3egJLK6ez
+EBoXXI4fSaBbu8oDLEsp
 -----END CERTIFICATE-----

--- a/test/net/fixtures/server.crt
+++ b/test/net/fixtures/server.crt
@@ -1,13 +1,13 @@
 Certificate:
     Data:
-        Version: 3 (0x2)
-        Serial Number: 2 (0x2)
-    Signature Algorithm: sha256WithRSAEncryption
-        Issuer: C=JP, ST=Shimane, L=Matz-e city, O=Ruby Core Team, CN=Ruby Test CA/emailAddress=security@ruby-lang.org
+        Version: 1 (0x0)
+        Serial Number: 0 (0x0)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = JP, ST = Shimane, L = Matz-e city, O = Ruby Core Team, CN = Ruby Test CA, emailAddress = security@ruby-lang.org
         Validity
-            Not Before: Jan  2 03:27:13 2019 GMT
-            Not After : Jan  1 03:27:13 2024 GMT
-        Subject: C=JP, ST=Shimane, O=Ruby Core Team, OU=Ruby Test, CN=localhost
+            Not Before: Jan  1 11:02:41 2024 GMT
+            Not After : Dec 30 11:02:41 2028 GMT
+        Subject: C = JP, ST = Shimane, O = Ruby Core Team, OU = Ruby Test, CN = localhost
         Subject Public Key Info:
             Public Key Algorithm: rsaEncryption
                 Public-Key: (2048 bit)
@@ -31,52 +31,41 @@ Certificate:
                     74:8c:61:16:20:3d:d0:1c:4e:8f:6e:fd:fe:64:10:
                     4f:41
                 Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Basic Constraints: 
-                CA:FALSE
-            Netscape Comment: 
-                OpenSSL Generated Certificate
-            X509v3 Subject Key Identifier: 
-                ED:28:C2:7E:AB:4B:C8:E8:FE:55:6D:66:95:31:1C:2D:60:F9:02:36
-            X509v3 Authority Key Identifier: 
-                keyid:F6:D1:22:29:D5:3D:23:D7:5E:AD:0C:9C:E6:75:8F:9D:CD:F8:9D:53
-
     Signature Algorithm: sha256WithRSAEncryption
-         1d:b8:c5:8b:72:41:20:65:ad:27:6f:15:63:06:26:12:8d:9c:
-         ad:ca:f4:db:97:b4:90:cb:ff:35:94:bb:2a:a7:a1:ab:1e:35:
-         2d:a5:3f:c9:24:b0:1a:58:89:75:3e:81:0a:2c:4f:98:f9:51:
-         fb:c0:a3:09:d0:0a:9b:e7:a2:b7:c3:60:40:c8:f4:6d:b2:6a:
-         56:12:17:4c:00:24:31:df:9c:60:ae:b1:68:54:a9:e6:b5:4a:
-         04:e6:92:05:86:d9:5a:dc:96:30:a5:58:de:14:99:0f:e5:15:
-         89:3e:9b:eb:80:e3:bd:83:c3:ea:33:35:4b:3e:2f:d3:0d:64:
-         93:67:7f:8d:f5:3f:0c:27:bc:37:5a:cc:d6:47:16:af:5a:62:
-         d2:da:51:f8:74:06:6b:24:ad:28:68:08:98:37:7d:ed:0e:ab:
-         1e:82:61:05:d0:ba:75:a0:ab:21:b0:9a:fd:2b:54:86:1d:0d:
-         1f:c2:d4:77:1f:72:26:5e:ad:8a:9f:09:36:6d:44:be:74:c2:
-         5a:3e:ff:5c:9d:75:d6:38:7b:c5:39:f9:44:6e:a1:d1:8e:ff:
-         63:db:c4:bb:c6:91:92:ca:5c:60:9b:1d:eb:0a:de:08:ee:bf:
-         da:76:03:65:62:29:8b:f8:7f:c7:86:73:1e:f6:1f:2d:89:69:
-         fd:be:bd:6e
+    Signature Value:
+        36:63:a3:6f:e6:4d:ff:a9:43:81:8d:9d:84:42:83:57:c9:e0:
+        c6:0a:41:f5:ea:95:de:fa:65:77:e9:c6:33:b9:bb:65:f8:75:
+        cc:23:fb:78:96:20:c6:72:ec:69:5f:5c:a5:b6:78:f6:6a:0e:
+        84:7c:8b:d4:78:a4:29:f3:fa:ce:b8:d4:17:92:ca:cb:17:b5:
+        52:6d:bc:db:f3:f1:60:dd:dd:23:c5:f2:a3:8d:db:18:27:9a:
+        a4:5c:1f:1e:2c:62:6d:78:6a:a2:54:a6:8d:02:97:15:00:87:
+        af:fb:c8:f1:8f:24:c2:2b:19:33:0b:c9:3c:5e:7d:6e:4f:aa:
+        c1:d8:29:88:e2:43:33:0f:51:cd:12:1c:cd:95:47:6e:a9:ab:
+        10:aa:d8:34:04:3f:ee:be:ab:54:f9:e5:e5:09:f9:10:b8:3b:
+        ab:22:77:74:8e:95:ec:98:1b:1d:28:30:f7:51:62:a0:98:6e:
+        8e:80:09:9c:34:e9:48:4b:33:db:66:98:e5:67:13:b9:9d:42:
+        c3:45:a9:8b:ba:12:5a:1a:14:d3:21:dc:b7:c6:2b:11:7a:3e:
+        90:1f:42:3e:aa:68:55:a3:dd:07:12:89:9a:a0:2a:9d:9e:51:
+        7d:4c:98:71:b5:bf:c2:fb:80:c3:18:02:ea:a3:0b:8d:6a:bb:
+        c7:67:a3:f7
 -----BEGIN CERTIFICATE-----
-MIID4zCCAsugAwIBAgIBAjANBgkqhkiG9w0BAQsFADCBjDELMAkGA1UEBhMCSlAx
-EDAOBgNVBAgMB1NoaW1hbmUxFDASBgNVBAcMC01hdHotZSBjaXR5MRcwFQYDVQQK
-DA5SdWJ5IENvcmUgVGVhbTEVMBMGA1UEAwwMUnVieSBUZXN0IENBMSUwIwYJKoZI
-hvcNAQkBFhZzZWN1cml0eUBydWJ5LWxhbmcub3JnMB4XDTE5MDEwMjAzMjcxM1oX
-DTI0MDEwMTAzMjcxM1owYDELMAkGA1UEBhMCSlAxEDAOBgNVBAgMB1NoaW1hbmUx
-FzAVBgNVBAoMDlJ1YnkgQ29yZSBUZWFtMRIwEAYDVQQLDAlSdWJ5IFRlc3QxEjAQ
-BgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
-AOjanAEuKxDsSc1eBxMHnHCexnS8E8Lhb8aC/eNI4CylaMeeQt5gVGXmahRXejDQ
-zLW22cPS38kll1Rnz/a+XsuL7gPF4eL55/fRDEfwuNozWq1Bree1onu3vzDaYPjj
-VKK8Ov0bdNncdELpKb7frLRP6zL0BvHhjEuoi/sp57G/HQHucw/5QNzVFXnZxnPQ
-wN3L5NoZR4DGFARy/Zp8jxGCdkkEeczyXDEilRM+XUCmTeCjAiZ9Uju77WWhD+1r
-sDzU3mEVXtPdaAmfSlelwqlthpLF9KTUtxM7UmMkBeLM44o81DU0KxC7WHLn4Y0d
-dIxhFiA90BxOj279/mQQT0ECAwEAAaN7MHkwCQYDVR0TBAIwADAsBglghkgBhvhC
-AQ0EHxYdT3BlblNTTCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwHQYDVR0OBBYEFO0o
-wn6rS8jo/lVtZpUxHC1g+QI2MB8GA1UdIwQYMBaAFPbRIinVPSPXXq0MnOZ1j53N
-+J1TMA0GCSqGSIb3DQEBCwUAA4IBAQAduMWLckEgZa0nbxVjBiYSjZytyvTbl7SQ
-y/81lLsqp6GrHjUtpT/JJLAaWIl1PoEKLE+Y+VH7wKMJ0Aqb56K3w2BAyPRtsmpW
-EhdMACQx35xgrrFoVKnmtUoE5pIFhtla3JYwpVjeFJkP5RWJPpvrgOO9g8PqMzVL
-Pi/TDWSTZ3+N9T8MJ7w3WszWRxavWmLS2lH4dAZrJK0oaAiYN33tDqsegmEF0Lp1
-oKshsJr9K1SGHQ0fwtR3H3ImXq2Knwk2bUS+dMJaPv9cnXXWOHvFOflEbqHRjv9j
-28S7xpGSylxgmx3rCt4I7r/adgNlYimL+H/HhnMe9h8tiWn9vr1u
+MIIDYTCCAkkCAQAwDQYJKoZIhvcNAQELBQAwgYwxCzAJBgNVBAYTAkpQMRAwDgYD
+VQQIDAdTaGltYW5lMRQwEgYDVQQHDAtNYXR6LWUgY2l0eTEXMBUGA1UECgwOUnVi
+eSBDb3JlIFRlYW0xFTATBgNVBAMMDFJ1YnkgVGVzdCBDQTElMCMGCSqGSIb3DQEJ
+ARYWc2VjdXJpdHlAcnVieS1sYW5nLm9yZzAeFw0yNDAxMDExMTAyNDFaFw0yODEy
+MzAxMTAyNDFaMGAxCzAJBgNVBAYTAkpQMRAwDgYDVQQIDAdTaGltYW5lMRcwFQYD
+VQQKDA5SdWJ5IENvcmUgVGVhbTESMBAGA1UECwwJUnVieSBUZXN0MRIwEAYDVQQD
+DAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDo2pwB
+LisQ7EnNXgcTB5xwnsZ0vBPC4W/Ggv3jSOAspWjHnkLeYFRl5moUV3ow0My1ttnD
+0t/JJZdUZ8/2vl7Li+4DxeHi+ef30QxH8LjaM1qtQa3ntaJ7t78w2mD441SivDr9
+G3TZ3HRC6Sm+36y0T+sy9Abx4YxLqIv7Keexvx0B7nMP+UDc1RV52cZz0MDdy+Ta
+GUeAxhQEcv2afI8RgnZJBHnM8lwxIpUTPl1Apk3gowImfVI7u+1loQ/ta7A81N5h
+FV7T3WgJn0pXpcKpbYaSxfSk1LcTO1JjJAXizOOKPNQ1NCsQu1hy5+GNHXSMYRYg
+PdAcTo9u/f5kEE9BAgMBAAEwDQYJKoZIhvcNAQELBQADggEBADZjo2/mTf+pQ4GN
+nYRCg1fJ4MYKQfXqld76ZXfpxjO5u2X4dcwj+3iWIMZy7GlfXKW2ePZqDoR8i9R4
+pCnz+s641BeSyssXtVJtvNvz8WDd3SPF8qON2xgnmqRcHx4sYm14aqJUpo0ClxUA
+h6/7yPGPJMIrGTMLyTxefW5PqsHYKYjiQzMPUc0SHM2VR26pqxCq2DQEP+6+q1T5
+5eUJ+RC4O6sid3SOleyYGx0oMPdRYqCYbo6ACZw06UhLM9tmmOVnE7mdQsNFqYu6
+EloaFNMh3LfGKxF6PpAfQj6qaFWj3QcSiZqgKp2eUX1MmHG1v8L7gMMYAuqjC41q
+u8dno/c=
 -----END CERTIFICATE-----


### PR DESCRIPTION
Some net test fail to cert limit.
So, update to cert in this pull request.

```bash
sh@DESKTOP-L0NI312:~/rubydev/ruby/test/net/fixtures$ openssl x509 -noout -dates -in cacert.pem
notBefore=Jan  2 02:58:28 2019 GMT
notAfter=Jan  1 02:58:28 2024 GMT
sh@DESKTOP-L0NI312:~/rubydev/ruby/test/net/fixtures$ make regen_certs
touch server.key
make server.crt
make[1]: Entering directory '/home/sh/rubydev/ruby/test/net/fixtures'
openssl req -new -key server.key -out server.csr -text -subj "/C=JP/ST=Shimane/O=Ruby Core Team/OU=Ruby Test/CN=localhost"
openssl req -new -x509 -days 1825 -key server.key -out cacert.pem -text -subj "/C=JP/ST=Shimane/L=Matz-e city/O=Ruby Core Team/CN=Ruby Test CA/emailAddress=security@ruby-lang.org"
openssl x509 -days 1825 -CA cacert.pem -CAkey server.key -set_serial 00 -in server.csr -req -text -out server.crt
Certificate request self-signature ok
subject=C = JP, ST = Shimane, O = Ruby Core Team, OU = Ruby Test, CN = localhost
rm server.csr
make[1]: Leaving directory '/home/sh/rubydev/ruby/test/net/fixtures'
sh@DESKTOP-L0NI312:~/rubydev/ruby/test/net/fixtures$ openssl x509 -noout -dates -in cacert.pem
notBefore=Jan  1 11:02:41 2024 GMT
notAfter=Dec 30 11:02:41 2028 GMT
```