### PR TITLE
Introduce NODE_FILE

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -694,6 +694,8 @@ node_children(rb_ast_t *ast, const NODE *node)
         }
       case NODE_LINE:
         return rb_ary_new_from_args(1, rb_node_line_lineno_val(node));
+      case NODE_FILE:
+        return rb_ary_new_from_args(1, rb_node_file_path_val(node));
       case NODE_ERROR:
         return rb_ary_new_from_node_args(ast, 0);
       case NODE_ARGS_AUX:

--- a/common.mk
+++ b/common.mk
@@ -10495,6 +10495,7 @@ node_dump.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/gc.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/hash.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+node_dump.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/serial.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/variable.h

--- a/internal/ruby_parser.h
+++ b/internal/ruby_parser.h
@@ -68,4 +68,5 @@ enum lex_state_e {
 };
 
 VALUE rb_node_line_lineno_val(const NODE *);
+VALUE rb_node_file_path_val(const NODE *);
 #endif /* INTERNAL_RUBY_PARSE_H */

--- a/misc/lldb_rb/utils.py
+++ b/misc/lldb_rb/utils.py
@@ -457,6 +457,8 @@ class RbInspector(LLDBInterface):
                     self._append_expression("*(struct RNode_ERROR *) %0#x" % val.GetValueAsUnsigned())
                 elif nd_type == self.ruby_globals["NODE_LINE"]:
                     self._append_expression("*(struct RNode_LINE *) %0#x" % val.GetValueAsUnsigned())
+                elif nd_type == self.ruby_globals["NODE_FILE"]:
+                    self._append_expression("*(struct RNode_FILE *) %0#x" % val.GetValueAsUnsigned())
                 elif nd_type == self.ruby_globals["NODE_RIPPER"]:
                     self._append_expression("*(struct RNode_RIPPER *) %0#x" % val.GetValueAsUnsigned())
                 elif nd_type == self.ruby_globals["NODE_RIPPER_VALUES"]:

--- a/node.c
+++ b/node.c
@@ -170,9 +170,18 @@ struct rb_ast_local_table_link {
 };
 
 static void
+parser_string_free(rb_ast_t *ast, rb_parser_string_t *str)
+{
+    xfree(str);
+}
+
+static void
 free_ast_value(rb_ast_t *ast, void *ctx, NODE *node)
 {
     switch (nd_type(node)) {
+      case NODE_FILE:
+        parser_string_free(ast, RNODE_FILE(node)->path);
+        break;
       default:
         break;
     }

--- a/node_dump.c
+++ b/node_dump.c
@@ -11,6 +11,7 @@
 
 #include "internal.h"
 #include "internal/hash.h"
+#include "internal/ruby_parser.h"
 #include "internal/variable.h"
 #include "ruby/ruby.h"
 #include "vm_core.h"
@@ -64,6 +65,7 @@
 #define F_INT(name, type, ann)	    SIMPLE_FIELD1(#name, ann) A_INT(type(node)->name)
 #define F_LONG(name, type, ann)	    SIMPLE_FIELD1(#name, ann) A_LONG(type(node)->name)
 #define F_LIT(name, type, ann)	    SIMPLE_FIELD1(#name, ann) A_LIT(type(node)->name)
+#define F_VALUE(name, val, ann)     SIMPLE_FIELD1(#name, ann) A_LIT(val)
 #define F_MSG(name, ann, desc)	    SIMPLE_FIELD1(#name, ann) A(desc)
 
 #define F_NODE(name, type, ann) \
@@ -1103,6 +1105,13 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("line");
         ANN("format: [lineno]");
         ANN("example: __LINE__");
+        return;
+
+      case NODE_FILE:
+        ANN("line");
+        ANN("format: [path]");
+        ANN("example: __FILE__");
+        F_VALUE(path, rb_node_file_path_val(node), "path");
         return;
 
       case NODE_ERROR:

--- a/parse.y
+++ b/parse.y
@@ -954,6 +954,7 @@ static rb_node_aryptn_t *rb_node_aryptn_new(struct parser_params *p, NODE *pre_a
 static rb_node_hshptn_t *rb_node_hshptn_new(struct parser_params *p, NODE *nd_pconst, NODE *nd_pkwargs, NODE *nd_pkwrestarg, const YYLTYPE *loc);
 static rb_node_fndptn_t *rb_node_fndptn_new(struct parser_params *p, NODE *pre_rest_arg, NODE *args, NODE *post_rest_arg, const YYLTYPE *loc);
 static rb_node_line_t *rb_node_line_new(struct parser_params *p, const YYLTYPE *loc);
+static rb_node_file_t *rb_node_file_new(struct parser_params *p, VALUE str, const YYLTYPE *loc);
 static rb_node_error_t *rb_node_error_new(struct parser_params *p, const YYLTYPE *loc);
 
 #define NEW_SCOPE(a,b,loc) (NODE *)rb_node_scope_new(p,a,b,loc)
@@ -1056,6 +1057,7 @@ static rb_node_error_t *rb_node_error_new(struct parser_params *p, const YYLTYPE
 #define NEW_HSHPTN(c,kw,kwrest,loc) (NODE *)rb_node_hshptn_new(p,c,kw,kwrest,loc)
 #define NEW_FNDPTN(pre,a,post,loc) (NODE *)rb_node_fndptn_new(p,pre,a,post,loc)
 #define NEW_LINE(loc) (NODE *)rb_node_line_new(p,loc)
+#define NEW_FILE(str,loc) (NODE *)rb_node_file_new(p,str,loc)
 #define NEW_ERROR(loc) (NODE *)rb_node_error_new(p,loc)
 
 #endif
@@ -1909,6 +1911,56 @@ get_nd_args(struct parser_params *p, NODE *node)
         compile_error(p, "unexpected node: %s", parser_node_name(nd_type(node)));
         return 0;
     }
+}
+#endif
+
+#ifndef RIPPER
+static rb_parser_string_t *
+rb_parser_string_new(rb_parser_t *p, const char *ptr, long len)
+{
+    size_t size;
+    rb_parser_string_t *str;
+
+    if (len < 0) {
+        rb_bug("negative string size (or size too big): %ld", len);
+    }
+
+    size = offsetof(rb_parser_string_t, ptr) + len + 1;
+    str = xcalloc(1, size);
+
+    if (ptr) {
+        memcpy(str->ptr, ptr, len);
+    }
+    str->len = len;
+    str->ptr[len] = '\0';
+    return str;
+}
+
+static rb_parser_string_t *
+rb_parser_encoding_string_new(rb_parser_t *p, const char *ptr, long len, rb_encoding *enc)
+{
+    rb_parser_string_t *str = rb_parser_string_new(p, ptr, len);
+    str->enc = enc;
+    return str;
+}
+
+long
+rb_parser_string_length(rb_parser_string_t *str)
+{
+    return str->len;
+}
+
+char *
+rb_parser_string_pointer(rb_parser_string_t *str)
+{
+    return str->ptr;
+}
+
+static rb_parser_string_t *
+rb_str_to_parser_encoding_string(rb_parser_t *p, VALUE str)
+{
+    /* Type check */
+    return rb_parser_encoding_string_new(p, RSTRING_PTR(str), RSTRING_LEN(str), rb_enc_get(str));
 }
 #endif
 %}
@@ -6599,6 +6651,7 @@ singleton	: var_ref
                           case NODE_DREGX:
                           case NODE_LIT:
                           case NODE_LINE:
+                          case NODE_FILE:
                           case NODE_DSYM:
                           case NODE_LIST:
                           case NODE_ZLIST:
@@ -12186,6 +12239,15 @@ rb_node_line_new(struct parser_params *p, const YYLTYPE *loc)
     return n;
 }
 
+static rb_node_file_t *
+rb_node_file_new(struct parser_params *p, VALUE str, const YYLTYPE *loc)
+{
+    rb_node_file_t *n = NODE_NEWNODE(NODE_FILE, rb_node_file_t, loc);
+    n->path = rb_str_to_parser_encoding_string(p, str);
+
+    return n;
+}
+
 static rb_node_cdecl_t *
 rb_node_cdecl_new(struct parser_params *p, ID nd_vid, NODE *nd_value, NODE *nd_else, const YYLTYPE *loc)
 {
@@ -12786,10 +12848,7 @@ gettable(struct parser_params *p, ID id, const YYLTYPE *loc)
             VALUE file = p->ruby_sourcefile_string;
             if (NIL_P(file))
                 file = rb_str_new(0, 0);
-            else
-                file = rb_str_dup(file);
-            node = NEW_STR(file, loc);
-            RB_OBJ_WRITTEN(p->ast, Qnil, file);
+            node = NEW_FILE(file, loc);
         }
         return node;
       case keyword__LINE__:
@@ -13691,6 +13750,12 @@ shareable_literal_constant(struct parser_params *p, enum shareability shareable,
         RB_OBJ_WRITE(p->ast, &RNODE_LIT(value)->nd_lit, lit);
         return value;
 
+      case NODE_FILE:
+        lit = rb_fstring(rb_node_file_path_val(value));
+        value = NEW_LIT(lit, loc);
+        RB_OBJ_WRITTEN(p->ast, Qnil, RNODE_LIT(value)->nd_lit);
+        return value;
+
       case NODE_ZLIST:
         lit = rb_ary_new();
         OBJ_FREEZE_RAW(lit);
@@ -13985,6 +14050,7 @@ void_expr(struct parser_params *p, NODE *node)
         break;
       case NODE_LIT:
       case NODE_LINE:
+      case NODE_FILE:
       case NODE_STR:
       case NODE_DSTR:
       case NODE_DREGX:
@@ -14123,6 +14189,7 @@ is_static_content(NODE *node)
         } while ((node = RNODE_LIST(node)->nd_next) != 0);
       case NODE_LIT:
       case NODE_LINE:
+      case NODE_FILE:
       case NODE_STR:
       case NODE_NIL:
       case NODE_TRUE:
@@ -14208,6 +14275,7 @@ cond0(struct parser_params *p, NODE *node, enum cond_type type, const YYLTYPE *l
       case NODE_DSTR:
       case NODE_EVSTR:
       case NODE_STR:
+      case NODE_FILE:
         SWITCH_BY_COND_TYPE(type, warn, "string ");
         break;
 

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -4,12 +4,6 @@
 
 #include "rubyparser.h"
 
-VALUE
-rb_node_line_lineno_val(const NODE *node)
-{
-    return INT2FIX(node->nd_loc.beg_pos.lineno);
-}
-
 #ifdef UNIVERSAL_PARSER
 
 #include "internal.h"
@@ -920,3 +914,16 @@ rb_parser_set_yydebug(VALUE vparser, VALUE flag)
     return flag;
 }
 #endif
+
+VALUE
+rb_node_line_lineno_val(const NODE *node)
+{
+    return INT2FIX(node->nd_loc.beg_pos.lineno);
+}
+
+VALUE
+rb_node_file_path_val(const NODE *node)
+{
+    rb_parser_string_t *str = RNODE_FILE(node)->path;
+    return rb_enc_str_new(str->ptr, str->len, str->enc);
+}

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -22,6 +22,29 @@
 
 #endif
 
+#ifndef FLEX_ARY_LEN
+/* From internal/compilers.h */
+/* A macro for defining a flexible array, like: VALUE ary[FLEX_ARY_LEN]; */
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+# define FLEX_ARY_LEN   /* VALUE ary[]; */
+#elif defined(__GNUC__) && !defined(__STRICT_ANSI__)
+# define FLEX_ARY_LEN 0 /* VALUE ary[0]; */
+#else
+# define FLEX_ARY_LEN 1 /* VALUE ary[1]; */
+#endif
+#endif
+
+/*
+ * Parser String
+ */
+typedef struct rb_parser_string {
+    rb_encoding *enc;
+    /* Length of the string, not including terminating NUL character. */
+    long len;
+    /* Pointer to the contents of the string. */
+    char ptr[FLEX_ARY_LEN];
+} rb_parser_string_t;
+
 /*
  * AST Node
  */
@@ -131,22 +154,11 @@ enum node_type {
     NODE_FNDPTN,
     NODE_ERROR,
     NODE_LINE,
+    NODE_FILE,
     NODE_RIPPER,
     NODE_RIPPER_VALUES,
     NODE_LAST
 };
-
-#ifndef FLEX_ARY_LEN
-/* From internal/compilers.h */
-/* A macro for defining a flexible array, like: VALUE ary[FLEX_ARY_LEN]; */
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
-# define FLEX_ARY_LEN   /* VALUE ary[]; */
-#elif defined(__GNUC__) && !defined(__STRICT_ANSI__)
-# define FLEX_ARY_LEN 0 /* VALUE ary[0]; */
-#else
-# define FLEX_ARY_LEN 1 /* VALUE ary[1]; */
-#endif
-#endif
 
 typedef struct rb_ast_id_table {
     int size;
@@ -936,6 +948,12 @@ typedef struct RNode_LINE {
     NODE node;
 } rb_node_line_t;
 
+typedef struct RNode_FILE {
+    NODE node;
+
+    struct rb_parser_string *path;
+} rb_node_file_t;
+
 typedef struct RNode_ERROR {
     NODE node;
 } rb_node_error_t;
@@ -1046,6 +1064,7 @@ typedef struct RNode_ERROR {
 #define RNODE_HSHPTN(node) ((struct RNode_HSHPTN *)(node))
 #define RNODE_FNDPTN(node) ((struct RNode_FNDPTN *)(node))
 #define RNODE_LINE(node) ((struct RNode_LINE *)(node))
+#define RNODE_FILE(node) ((struct RNode_FILE *)(node))
 
 #ifdef RIPPER
 typedef struct RNode_RIPPER {
@@ -1406,6 +1425,10 @@ void rb_ruby_parser_config_free(rb_parser_config_t *config);
 rb_parser_t *rb_ruby_parser_allocate(rb_parser_config_t *config);
 rb_parser_t *rb_ruby_parser_new(rb_parser_config_t *config);
 #endif
+
+long rb_parser_string_length(rb_parser_string_t *str);
+char *rb_parser_string_pointer(rb_parser_string_t *str);
+
 RUBY_SYMBOL_EXPORT_END
 
 #endif /* RUBY_RUBYPARSER_H */

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -582,8 +582,10 @@ class TestRubyOptions < Test::Unit::TestCase
       t.rewind
       t.truncate(0)
       t.puts "if a = __LINE__; end"
+      t.puts "if a = __FILE__; end"
       t.flush
       err = ["#{t.path}:1:#{warning}",
+             "#{t.path}:2:#{warning}",
             ]
       assert_in_out_err(["-w", t.path], "", [], err)
       assert_in_out_err(["-wr", t.path, "-e", ""], "", [], err)

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1210,6 +1210,9 @@ eom
     assert_warn(/string literal in condition/) do
       eval('1 if ""')
     end
+    assert_warning(/string literal in condition/) do
+      eval('1 if __FILE__')
+    end
     assert_warn(/regex literal in condition/) do
       eval('1 if //')
     end


### PR DESCRIPTION
`__FILE__` was managed by `NODE_STR` with `String` object. This commit introduces `NODE_FILE` and `struct rb_parser_string` so that

1. `__FILE__` is detectable from AST Node
2. Reduce dependency ruby object