### PR TITLE
Fix Exception#detailed_message for GC compaction

### DIFF
--- a/error.c
+++ b/error.c
@@ -1662,7 +1662,7 @@ exc_detailed_message(int argc, VALUE *argv, VALUE exc)
 
     VALUE highlight = check_highlight_keyword(opt, 0);
 
-    extern VALUE rb_decorate_message(const VALUE eclass, const VALUE emesg, int highlight);
+    extern VALUE rb_decorate_message(const VALUE eclass, VALUE emesg, int highlight);
 
     return rb_decorate_message(CLASS_OF(exc), rb_get_message(exc), RTEST(highlight));
 }

--- a/eval_error.c
+++ b/eval_error.c
@@ -125,7 +125,7 @@ print_errinfo(const VALUE eclass, const VALUE errat, const VALUE emesg, const VA
 }
 
 VALUE
-rb_decorate_message(const VALUE eclass, const VALUE emesg, int highlight)
+rb_decorate_message(const VALUE eclass, VALUE emesg, int highlight)
 {
     const char *einfo = "";
     long elen = 0;
@@ -209,6 +209,8 @@ rb_decorate_message(const VALUE eclass, const VALUE emesg, int highlight)
             }
         }
     }
+
+    RB_GC_GUARD(emesg);
 
     return str;
 }

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -1459,6 +1459,14 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
     assert_equal("\e[1mRuntimeError (\e[1;4mRuntimeError\e[m\e[1m)\e[m", e.detailed_message(highlight: true))
   end
 
+  def test_detailed_message_under_gc_compact_stress
+    EnvUtil.under_gc_compact_stress do
+      e = RuntimeError.new("foo\nbar\nbaz")
+      assert_equal("foo (RuntimeError)\nbar\nbaz", e.detailed_message)
+      assert_equal("\e[1mfoo (\e[1;4mRuntimeError\e[m\e[1m)\e[m\n\e[1mbar\e[m\n\e[1mbaz\e[m", e.detailed_message(highlight: true))
+    end
+  end
+
   def test_full_message_with_custom_detailed_message
     e = RuntimeError.new("message")
     opt_ = nil


### PR DESCRIPTION
Before this commit, the test fails with RGENGC_CHECK_MODE enabled:

    TestException#test_detailed_message_under_gc_compact_stress [test/ruby/test_exception.rb:1466]:
    <"\e[1mfoo (\e[1;4mRuntimeError\e[m\e[1m)\e[m\n" +
    "\e[1mbar\e[m\n" +
    "\e[1mbaz\e[m"> expected but was
    <"\e[1mfoo (\e[1;4mRuntimeError\e[m\e[1m)\e[m\n" +
    "\e[1m\x00\x00\x00\x00\x00\x00\x00\e[m">.