### PR TITLE
Free rb_native_thread of main thread

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -3029,6 +3029,11 @@ ruby_vm_destruct(rb_vm_t *vm)
             st_free_table(vm->defined_module_hash);
 
             rb_id_table_free(vm->constant_cache);
+
+            if (th) {
+                xfree(th->nt);
+                th->nt = NULL;
+            }
         }
         else {
             if (th) {


### PR DESCRIPTION
The rb_native_thread gets reported as a memory leak by the macOS leaks tool:

    $ RUBY_FREE_AT_EXIT=1 leaks -q --atExit -- ./miniruby -e ""
    STACK OF 1 INSTANCE OF 'ROOT LEAK: <calloc in ruby_xcalloc_body>':
    6   dyld                                  0x1818a90e0 start + 2360
    5   miniruby                              0x104730128 main + 88  main.c:58
    4   miniruby                              0x1047d7710 ruby_init + 16  eval.c:102
    3   miniruby                              0x1047d757c ruby_setup + 112  eval.c:83
    2   miniruby                              0x104977278 Init_BareVM + 524  vm.c:4193
    1   miniruby                              0x1047f2478 ruby_xcalloc_body + 176  gc.c:12878
    0   libsystem_malloc.dylib                0x181a67b78 _malloc_zone_calloc_instrumented_or_legacy + 100
    ====
        1 (176 bytes) ROOT LEAK: <calloc in ruby_xcalloc_body 0x126604780> [176]

cc. @HParker 