### PR TITLE
Improve method_missing method documentation

### DIFF
--- a/vm_eval.c
+++ b/vm_eval.c
@@ -904,7 +904,7 @@ NORETURN(static void raise_method_missing(rb_execution_context_t *ec, int argc, 
 
 /*
  *  call-seq:
- *     obj.method_missing(symbol [, *args] )   -> result
+ *     obj.method_missing(symbol [, *args, **kwargs, &block] )   -> result
  *
  *  Invoked by Ruby when <i>obj</i> is sent a message it cannot handle.
  *  <i>symbol</i> is the symbol for the method called, and <i>args</i>
@@ -924,12 +924,12 @@ NORETURN(static void raise_method_missing(rb_execution_context_t *ec, int argc, 
  *         # ...
  *       end
  *
- *       def method_missing(symbol, *args)
+ *       def method_missing(symbol, ...)
  *         str = symbol.id2name
  *         begin
  *           roman_to_int(str)
  *         rescue
- *           super(symbol, *args)
+ *           super
  *         end
  *       end
  *     end


### PR DESCRIPTION
This enhances the documentation of method_missing by documenting some additional behavior.

First it enhances the description to make it clear you can also pass in kwargs and a block.

Then it simplifies the example by relying on a Ruby 3.0 feature to pass in ... instead of individual arguments. The super call without braces and arguments means it inherits them all, regardless of method definition.