### PR TITLE
Free pthread_attr after setting up the thread

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -511,6 +511,11 @@ start:
     }
     pthread_detach(th);
 
+    int r;
+    if ((r = pthread_attr_destroy(&attr)) != 0) {
+        rb_bug_errno("pthread_attr_destroy", r);
+    }
+
     rb_thread_call_without_gvl2(wait_getaddrinfo, arg, cancel_getaddrinfo, arg);
 
     int need_free = 0;
@@ -732,11 +737,16 @@ start:
 #endif
 
     pthread_t th;
-    if (do_pthread_create(&th, 0, do_getnameinfo, arg) != 0) {
+    if (do_pthread_create(&th, &attr, do_getnameinfo, arg) != 0) {
         free_getnameinfo_arg(arg);
         return EAI_AGAIN;
     }
     pthread_detach(th);
+
+    int r;
+    if ((r = pthread_attr_destroy(&attr)) != 0) {
+        rb_bug_errno("pthread_attr_destroy", r);
+    }
 
     rb_thread_call_without_gvl2(wait_getnameinfo, arg, cancel_getnameinfo, arg);
 


### PR DESCRIPTION
```
require 'socket'

10.times do
  10_000.times do
    IPSocket.getaddress("localhost")
  end

  puts `ps -o rss= -p #{$$}`
end
```

before:

```
26744
33400
39928
46328
53240
59640
66168
72696
79352
85880
```

after:

```
20864
20864
20864
20864
20864
20992
20992
20992
20992
21120
```

bug: https://bugs.ruby-lang.org/issues/20149