### PR TITLE
YJIT: Let RubyVM::YJIT.enable respect --yjit-stats

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -67,7 +67,19 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
-  def test_yjit_enable_stats
+  def test_yjit_enable_stats_false
+    assert_separately(["--yjit-disable", "--yjit-stats"], <<~RUBY, ignore_stderr: true)
+      assert_false RubyVM::YJIT.enabled?
+      assert_nil RubyVM::YJIT.runtime_stats
+
+      RubyVM::YJIT.enable
+
+      assert_true RubyVM::YJIT.enabled?
+      assert_true RubyVM::YJIT.runtime_stats[:all_stats]
+    RUBY
+  end
+
+  def test_yjit_enable_stats_true
     args = []
     args << "--disable=yjit" if RubyVM::YJIT.enabled?
     assert_separately(args, <<~RUBY, ignore_stderr: true)

--- a/yjit.rb
+++ b/yjit.rb
@@ -28,7 +28,11 @@ module RubyVM::YJIT
     Primitive.rb_yjit_reset_stats_bang
   end
 
-  # Enable \YJIT compilation.
+  # Enable \YJIT compilation. `stats` option decides whether to enable \YJIT stats or not.
+  #
+  # * `false`: Disable stats.
+  # * `true`: Enable stats. Print stats at exit.
+  # * `:quiet`: Enable stats. Do not print stats at exit.
   def self.enable(stats: false)
     return false if enabled?
     at_exit { print_and_dump_stats } if stats

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -171,9 +171,11 @@ pub extern "C" fn rb_yjit_code_gc(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
 pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE, gen_stats: VALUE, print_stats: VALUE) -> VALUE {
     with_vm_lock(src_loc!(), || {
         // Initialize and enable YJIT
-        unsafe {
-            OPTIONS.gen_stats = gen_stats.test();
-            OPTIONS.print_stats = print_stats.test();
+        if gen_stats.test() {
+            unsafe {
+                OPTIONS.gen_stats = gen_stats.test();
+                OPTIONS.print_stats = print_stats.test();
+            }
         }
         yjit_init();
 


### PR DESCRIPTION
As of adding `RubyVM::YJIT.enable` https://github.com/ruby/ruby/pull/8705, it respected `--yjit-stats` and it was the intended behavior. https://github.com/ruby/ruby/pull/9297 accidentally changed it to ignore `--yjit-stats`.

This PR lets `RubyVM::YJIT.enable` (no `stats` option) respect whether `--yjit-stats` is given or not. I also added a documentation about `stats` option.

---

I'll request a backport to ruby_3_3 once merged.