### PR TITLE
Add test cases for duplicated `when\' clause warnings

### DIFF
--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -717,6 +717,24 @@ WARN
         end
       }
     }
+    assert_warning(/3: #{w}.+4: #{w}.+4: #{w}.+5: #{w}.+5: #{w}/m) {
+      eval %q{
+        case 1
+        when __LINE__, __LINE__
+        when 3, 3
+        when 3, 3
+        end
+      }
+    }
+    assert_warning(/3: #{w}.+4: #{w}.+4: #{w}.+5: #{w}.+5: #{w}/m) {
+      eval %q{
+        case 1
+        when __FILE__, __FILE__
+        when "filename", "filename"
+        when "filename", "filename"
+        end
+      }, binding, "filename"
+    }
   end
 
   def test_duplicated_when_check_option


### PR DESCRIPTION
Add test cases for `__LINE__` and `__FILE__` because they were managed by NODE_LIT and NODE_STR but changed to be managed by dedicated NODE now.