### PR TITLE
YJIT: Fallback Integer#<< if a shift amount varies

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -288,7 +288,7 @@ module RubyVM::YJIT
       ].each do |insn|
         print_counters(stats, out: out, prefix: "#{insn}_", prompt: "#{insn} exit reasons:", optional: true)
       end
-      print_counters(stats, out: out, prefix: 'lshift_', prompt: 'left shift (ltlt) exit reasons: ')
+      print_counters(stats, out: out, prefix: 'lshift_', prompt: 'left shift (opt_ltlt) exit reasons: ')
       print_counters(stats, out: out, prefix: 'invalidate_', prompt: 'invalidation reasons: ')
     end
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4637,17 +4637,28 @@ fn jit_rb_int_lshift(
 
     // Untag the fixnum shift amount
     let shift_amt = comptime_shift.as_isize() >> 1;
-
     if shift_amt > 63 || shift_amt < 0 {
+        return false;
+    }
+
+    // Fallback to a C call if the shift amount varies
+    if asm.ctx.get_chain_depth() > 0 {
         return false;
     }
 
     let rhs = asm.stack_pop(1);
     let lhs = asm.stack_pop(1);
 
-    // Guard on the shift value we speculated on
+    // Guard on the shift amount we speculated on
     asm.cmp(rhs, comptime_shift.into());
-    asm.jne(Target::side_exit(Counter::lshift_amt_changed));
+    jit_chain_guard(
+        JCC_JNE,
+        jit,
+        asm,
+        ocb,
+        1,
+        Counter::lshift_amount_changed,
+    );
 
     let in_val = asm.sub(lhs, 1.into());
     let shift_opnd = Opnd::UImm(shift_amt as u64);

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4642,7 +4642,7 @@ fn jit_rb_int_lshift(
     }
 
     // Fallback to a C call if the shift amount varies
-    if asm.ctx.get_chain_depth() > 0 {
+    if asm.ctx.get_chain_depth() > 1 {
         return false;
     }
 
@@ -4656,7 +4656,7 @@ fn jit_rb_int_lshift(
         jit,
         asm,
         ocb,
-        1,
+        2, // defer_compilation increments chain_depth
         Counter::lshift_amount_changed,
     );
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -447,7 +447,7 @@ make_counters! {
     opt_mod_zero,
     opt_div_zero,
 
-    lshift_amt_changed,
+    lshift_amount_changed,
     lshift_overflow,
 
     opt_aref_argc_not_one,


### PR DESCRIPTION
* Chain-guard `Integer#<<` once and fallback to a C call if a shift amount varies.
* Rename an exit reason `amt_changed` to `amount_changed` since the name seemed a bit cryptic.

On `nqueens` https://github.com/Shopify/yjit-bench/pull/260 with `--yjit-call-threshold=1`, this change pushes `ratio_in_yjit` from 0.0% to 99.9% and makes it 3.60x faster.

```
before: ruby 3.4.0dev (2024-01-05T16:51:37Z master 4d03140009) +YJIT [x86_64-linux]
after: ruby 3.4.0dev (2024-01-08T17:07:08Z yjit-ltlt 43edc3419f) +YJIT [x86_64-linux]

-------  -----------  ----------  ----------  ----------  -------------  ------------
bench    before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
nqueens  581.8        0.7         161.8       0.1         3.55           3.60
-------  -----------  ----------  ----------  ----------  -------------  ------------
```