### PR TITLE
[DOC] Load options and parse files from srcdir

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -1,4 +1,7 @@
 ---
 page_dir: doc
+charset: UTF-8
+encoding: UTF-8
 main_page: README.md
 title: Documentation for Ruby development version
+visibility: :private

--- a/common.mk
+++ b/common.mk
@@ -64,14 +64,14 @@ LIBRUBY_EXTS  = ./.libruby-with-ext.time
 REVISION_H    = ./.revision.time
 PLATFORM_D    = $(TIMESTAMPDIR)/.$(PLATFORM_DIR).time
 ENC_TRANS_D   = $(TIMESTAMPDIR)/.enc-trans.time
-RDOC          = $(XRUBY) "$(srcdir)/libexec/rdoc" --root "$(srcdir)" --encoding=UTF-8 --all
+RDOC          = $(XRUBY) "$(tooldir)/rdoc-srcdir"
 RDOCOUT       = $(EXTOUT)/rdoc
 HTMLOUT       = $(EXTOUT)/html
 CAPIOUT       = doc/capi
 INSTALL_DOC_OPTS = --rdoc-output="$(RDOCOUT)" --html-output="$(HTMLOUT)"
-RDOC_GEN_OPTS = --page-dir "$(srcdir)/doc" --no-force-update \
+RDOC_GEN_OPTS = --no-force-update \
 	--title "Documentation for Ruby $(RUBY_API_VERSION)" \
-	--main README.md
+	$(empty)
 
 INITOBJS      = dmyext.$(OBJEXT) dmyenc.$(OBJEXT)
 NORMALMAINOBJ = main.$(OBJEXT)
@@ -662,11 +662,11 @@ post-install-dbg::
 
 rdoc: PHONY main srcs-doc
 	@echo Generating RDoc documentation
-	$(Q) $(RDOC) --ri --op "$(RDOCOUT)" $(RDOC_GEN_OPTS) $(RDOCFLAGS) "$(srcdir)"
+	$(Q) $(RDOC) --ri --op "$(RDOCOUT)" $(RDOC_GEN_OPTS) $(RDOCFLAGS) .
 
 html: PHONY main srcs-doc
 	@echo Generating RDoc HTML files
-	$(Q) $(RDOC) --op "$(HTMLOUT)" $(RDOC_GEN_OPTS) $(RDOCFLAGS) "$(srcdir)"
+	$(Q) $(RDOC) --op "$(HTMLOUT)" $(RDOC_GEN_OPTS) $(RDOCFLAGS) .
 
 rdoc-coverage: PHONY main srcs-doc
 	@echo Generating RDoc coverage report

--- a/tool/rdoc-srcdir
+++ b/tool/rdoc-srcdir
@@ -1,0 +1,20 @@
+#!ruby
+
+require 'rdoc/rdoc'
+
+# Make only the output directory relative to the invoked directory.
+invoked = Dir.pwd
+
+# Load options and parse files from srcdir.
+Dir.chdir(File.dirname(__dir__))
+
+options = RDoc::Options.load_options
+options.parse ARGV
+
+options.singleton_class.define_method(:finish) do
+  super()
+  @op_dir = File.expand_path(@op_dir, invoked)
+end
+
+# Do not hide errors when generating documents of Ruby itself.
+RDoc::RDoc.new.document options


### PR DESCRIPTION
RDoc options that do not change and can be written in `.rdoc_options` file are moved, so that they match when called without `make`.

Get rid of parsing the files in `page_dir` twice (as relative paths and absolute paths).