### PR TITLE
[DOC] Tweak for ENV doc

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -7305,7 +7305,7 @@ Init_Hash(void)
      * - ENV.replace replaces \ENV with a new collection of entries.
      * - ENV.clear empties \ENV.
      *
-     * == What's Here
+     * === What's Here
      *
      * First, what's elsewhere. \Class \ENV:
      *
@@ -7321,7 +7321,7 @@ Init_Hash(void)
      * - {Converting}[rdoc-ref:ENV@Methods+for+Converting]
      * - {And more ....}[rdoc-ref:ENV@More+Methods]
      *
-     * === Methods for Querying
+     * ==== Methods for Querying
      *
      * - ::[]: Returns the value for the given environment variable name if it exists:
      * - ::empty?: Returns whether \ENV is empty.
@@ -7332,7 +7332,7 @@ Init_Hash(void)
      * - ::size, ::length: Returns the number of entries.
      * - ::value?: Returns whether any entry has the given value.
      *
-     * === Methods for Assigning
+     * ==== Methods for Assigning
      *
      * - ::[]=, ::store: Creates, updates, or deletes the named environment variable.
      * - ::clear: Removes every environment variable; returns \ENV:
@@ -7340,7 +7340,7 @@ Init_Hash(void)
      * - ::replace: Replaces the entire content of the \ENV
      *   with the name/value pairs in the given hash.
      *
-     * === Methods for Deleting
+     * ==== Methods for Deleting
      *
      * - ::delete: Deletes the named environment variable name if it exists.
      * - ::delete_if: Deletes entries selected by the block.
@@ -7349,13 +7349,13 @@ Init_Hash(void)
      * - ::select!, ::filter!: Deletes entries selected by the block.
      * - ::shift: Removes and returns the first entry.
      *
-     * === Methods for Iterating
+     * ==== Methods for Iterating
      *
      * - ::each, ::each_pair: Calls the block with each name/value pair.
      * - ::each_key: Calls the block with each name.
      * - ::each_value: Calls the block with each value.
      *
-     * === Methods for Converting
+     * ==== Methods for Converting
      *
      * - ::assoc: Returns a 2-element array containing the name and value
      *   of the named environment variable if it exists:
@@ -7378,7 +7378,7 @@ Init_Hash(void)
      * - ::values: Returns all values as an array.
      * - ::values_at: Returns an array of the values for the given name.
      *
-     * === More Methods
+     * ==== More Methods
      *
      * - ::dup: Raises an exception.
      * - ::freeze: Raises an exception.


### PR DESCRIPTION
Rationalize heading levels to make left TOC work correctly;  What's Here and its subsections were omitted.