### PR TITLE
Remove unneeded rb_parser_config_struct struct properties for Universal Parser

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -76,48 +76,6 @@
 #include "symbol.h"
 
 #ifndef RIPPER
-static void
-bignum_negate(VALUE b)
-{
-    BIGNUM_NEGATE(b);
-}
-
-static void
-rational_set_num(VALUE r, VALUE n)
-{
-    RATIONAL_SET_NUM(r, n);
-}
-
-static VALUE
-rational_get_num(VALUE obj)
-{
-    return RRATIONAL(obj)->num;
-}
-
-static void
-rcomplex_set_real(VALUE cmp, VALUE r)
-{
-    RCOMPLEX_SET_REAL(cmp, r);
-}
-
-static VALUE
-rcomplex_get_real(VALUE obj)
-{
-    return RCOMPLEX(obj)->real;
-}
-
-static void
-rcomplex_set_imag(VALUE cmp, VALUE i)
-{
-    RCOMPLEX_SET_IMAG(cmp, i);
-}
-
-static VALUE
-rcomplex_get_imag(VALUE obj)
-{
-    return RCOMPLEX(obj)->imag;
-}
-
 static bool
 hash_literal_key_p(VALUE k)
 {

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -195,52 +195,10 @@ static const rb_data_type_t ruby_parser_data_type = {
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 
-static void
-bignum_negate(VALUE b)
-{
-    BIGNUM_NEGATE(b);
-}
-
 static int
 is_ascii_string2(VALUE str)
 {
     return is_ascii_string(str);
-}
-
-static void
-rational_set_num(VALUE r, VALUE n)
-{
-    RATIONAL_SET_NUM(r, n);
-}
-
-static VALUE
-rational_get_num(VALUE obj)
-{
-    return RRATIONAL(obj)->num;
-}
-
-static void
-rcomplex_set_real(VALUE cmp, VALUE r)
-{
-    RCOMPLEX_SET_REAL(cmp, r);
-}
-
-static void
-rcomplex_set_imag(VALUE cmp, VALUE i)
-{
-    RCOMPLEX_SET_IMAG(cmp, i);
-}
-
-static VALUE
-rcomplex_get_real(VALUE obj)
-{
-    return RCOMPLEX(obj)->real;
-}
-
-static VALUE
-rcomplex_get_imag(VALUE obj)
-{
-    return RCOMPLEX(obj)->imag;
 }
 
 RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 6, 0)
@@ -517,18 +475,6 @@ nil_p(VALUE obj)
     return (int)NIL_P(obj);
 }
 
-static int
-flonum_p(VALUE obj)
-{
-    return (int)RB_FLONUM_P(obj);
-}
-
-static VALUE
-int2fix(long i)
-{
-    return INT2FIX(i);
-}
-
 static VALUE
 syntax_error_new(void)
 {
@@ -557,12 +503,6 @@ static VALUE
 default_rs(void)
 {
     return rb_default_rs;
-}
-
-static VALUE
-rational_raw1(VALUE x)
-{
-    return rb_rational_raw1(x);
 }
 
 static void *
@@ -762,30 +702,8 @@ rb_parser_config_initialize(rb_parser_config_t *config)
     config->hash_delete    = rb_hash_delete;
     config->ident_hash_new = rb_ident_hash_new;
 
-    config->int2fix = int2fix;
-
-    config->bignum_negate = bignum_negate;
-    config->big_norm      = rb_big_norm;
-    config->cstr_to_inum  = rb_cstr_to_inum;
-
-    config->float_new   = rb_float_new;
-    config->float_value = rb_float_value;
-
     config->num2int          = rb_num2int_inline;
-    config->int_positive_pow = rb_int_positive_pow;
     config->int2num          = rb_int2num_inline;
-    config->fix2long         = rb_fix2long;
-
-    config->rational_new     = rb_rational_new;
-    config->rational_raw1    = rational_raw1;
-    config->rational_set_num = rational_set_num;
-    config->rational_get_num = rational_get_num;
-
-    config->complex_raw       = rb_complex_raw;
-    config->rcomplex_set_real = rcomplex_set_real;
-    config->rcomplex_set_imag = rcomplex_set_imag;
-    config->rcomplex_get_real = rcomplex_get_real;
-    config->rcomplex_get_imag = rcomplex_get_imag;
 
     config->stderr_tty_p    = rb_stderr_tty_p;
     config->write_error_str = rb_write_error_str;
@@ -834,7 +752,6 @@ rb_parser_config_initialize(rb_parser_config_t *config)
     config->literal_cmp  = literal_cmp;
     config->literal_hash = literal_hash;
 
-    config->builtin_class_name = rb_builtin_class_name;
     config->syntax_error_append = syntax_error_append;
     config->raise = rb_raise;
     config->syntax_error_new = syntax_error_new;
@@ -876,7 +793,6 @@ rb_parser_config_initialize(rb_parser_config_t *config)
     config->undef_p = undef_p;
     config->rtest = rtest;
     config->nil_p = nil_p;
-    config->flonum_p = flonum_p;
     config->qnil  = Qnil;
     config->qtrue = Qtrue;
     config->qfalse = Qfalse;

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1303,36 +1303,9 @@ typedef struct rb_parser_config_struct {
     VALUE (*hash_lookup)(VALUE hash, VALUE key);
     VALUE (*ident_hash_new)(void);
 
-    /* Fixnum */
-    VALUE (*int2fix)(long i);
-
-    /* Bignum */
-    void (*bignum_negate)(VALUE b);
-    VALUE (*big_norm)(VALUE x);
-    VALUE (*cstr_to_inum)(const char *str, int base, int badcheck);
-
-    /* Float */
-    VALUE (*float_new)(double d);
-    double (*float_value)(VALUE v);
-
     /* Numeric */
     int (*num2int)(VALUE val);
-    VALUE (*int_positive_pow)(long x, unsigned long y);
     VALUE (*int2num)(int v);
-    long (*fix2long)(VALUE val);
-
-    /* Rational */
-    VALUE (*rational_new)(VALUE x, VALUE y);
-    VALUE (*rational_raw1)(VALUE x);
-    void (*rational_set_num)(VALUE r, VALUE n);
-    VALUE (*rational_get_num)(VALUE obj);
-
-    /* Complex */
-    VALUE (*complex_raw)(VALUE x, VALUE y);
-    void (*rcomplex_set_real)(VALUE cmp, VALUE r);
-    void (*rcomplex_set_imag)(VALUE cmp, VALUE i);
-    VALUE (*rcomplex_get_real)(VALUE obj);
-    VALUE (*rcomplex_get_imag)(VALUE obj);
 
     /* IO */
     int (*stderr_tty_p)(void);
@@ -1390,7 +1363,6 @@ typedef struct rb_parser_config_struct {
     parser_st_index_t (*literal_hash)(VALUE a);
 
     /* Error (Exception) */
-    const char *(*builtin_class_name)(VALUE x);
     RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 6, 0)
     VALUE (*syntax_error_append)(VALUE, VALUE, int, int, rb_encoding*, const char*, va_list);
     RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 2, 3)
@@ -1441,7 +1413,6 @@ typedef struct rb_parser_config_struct {
     int (*undef_p)(VALUE);
     int (*rtest)(VALUE obj);
     int (*nil_p)(VALUE obj);
-    int (*flonum_p)(VALUE obj);
     VALUE qnil;
     VALUE qtrue;
     VALUE qfalse;

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -217,41 +217,10 @@ struct rb_imemo_tmpbuf_struct {
 #define rb_hash_lookup    p->config->hash_lookup
 #define rb_ident_hash_new p->config->ident_hash_new
 
-#undef INT2FIX
-#define INT2FIX  p->config->int2fix
-#undef LONG2FIX
-#define LONG2FIX p->config->int2fix
-
-#define bignum_negate p->config->bignum_negate
-#define rb_big_norm   p->config->big_norm
-#define rb_cstr_to_inum p->config->cstr_to_inum
-
-#undef rb_float_new
-#define rb_float_new   p->config->float_new
-#undef RFLOAT_VALUE
-#define RFLOAT_VALUE   p->config->float_value
-#undef DBL2NUM
-#define DBL2NUM p->config->float_new
-
 #undef NUM2INT
 #define NUM2INT             p->config->num2int
-#define rb_int_positive_pow p->config->int_positive_pow
 #undef INT2NUM
 #define INT2NUM             p->config->int2num
-#undef FIX2LONG
-#define FIX2LONG            p->config->fix2long
-
-#define rb_rational_new  p->config->rational_new
-#undef rb_rational_raw1
-#define rb_rational_raw1 p->config->rational_raw1
-#define rational_set_num p->config->rational_set_num
-#define rational_get_num p->config->rational_get_num
-
-#define rb_complex_raw    p->config->complex_raw
-#define rcomplex_set_real p->config->rcomplex_set_real
-#define rcomplex_set_imag p->config->rcomplex_set_imag
-#define rcomplex_get_real p->config->rcomplex_get_real
-#define rcomplex_get_imag p->config->rcomplex_get_imag
 
 #define rb_stderr_tty_p    p->config->stderr_tty_p
 #define rb_write_error_str p->config->write_error_str
@@ -301,7 +270,6 @@ struct rb_imemo_tmpbuf_struct {
 #define literal_cmp  p->config->literal_cmp
 #define literal_hash p->config->literal_hash
 
-#define rb_builtin_class_name p->config->builtin_class_name
 #define rb_syntax_error_append p->config->syntax_error_append
 #define rb_raise p->config->raise
 #define syntax_error_new p->config->syntax_error_new
@@ -350,8 +318,6 @@ struct rb_imemo_tmpbuf_struct {
 #define RTEST p->config->rtest
 #undef NIL_P
 #define NIL_P p->config->nil_p
-#undef FLONUM_P
-#define FLONUM_P p->config->flonum_p
 #undef Qnil
 #define Qnil  p->config->qnil
 #undef Qtrue


### PR DESCRIPTION
In https://github.com/ruby/ruby/pull/9417, introduced Numeric Node's.
This made some rb_parser_config_struct struct properties that were needed in Universal Paser unnecessary, so they have been removed in this pull request.