### PR TITLE
Introduce NODE_SYM to manage symbol literal

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -581,6 +581,8 @@ node_children(rb_ast_t *ast, const NODE *node)
             }
             return rb_ary_new_from_args(3, RNODE_DSTR(node)->nd_lit, head, next);
         }
+      case NODE_SYM:
+        return rb_ary_new_from_args(1, rb_node_sym_string_val(node));
       case NODE_EVSTR:
         return rb_ary_new_from_node_args(ast, 1, RNODE_EVSTR(node)->nd_body);
       case NODE_ARGSCAT:

--- a/internal/ruby_parser.h
+++ b/internal/ruby_parser.h
@@ -71,6 +71,7 @@ enum lex_state_e {
     EXPR_NONE = 0
 };
 
+VALUE rb_node_sym_string_val(const NODE *);
 VALUE rb_node_line_lineno_val(const NODE *);
 VALUE rb_node_file_path_val(const NODE *);
 

--- a/node.c
+++ b/node.c
@@ -179,6 +179,9 @@ static void
 free_ast_value(rb_ast_t *ast, void *ctx, NODE *node)
 {
     switch (nd_type(node)) {
+      case NODE_SYM:
+        parser_string_free(ast, RNODE_SYM(node)->string);
+        break;
       case NODE_FILE:
         parser_string_free(ast, RNODE_FILE(node)->path);
         break;

--- a/node_dump.c
+++ b/node_dump.c
@@ -784,6 +784,13 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         F_NODE(nd_next->nd_next, RNODE_DSTR, "tailing strings");
         return;
 
+      case NODE_SYM:
+        ANN("symbol literal");
+        ANN("format: [string]");
+        ANN("example: :foo");
+        F_VALUE(string, rb_node_sym_string_val(node), "string");
+        return;
+
       case NODE_EVSTR:
         ANN("interpolation expression");
         ANN("format: \"..#{ [nd_body] }..\"");

--- a/parse.y
+++ b/parse.y
@@ -86,6 +86,7 @@ hash_literal_key_p(VALUE k)
           case NODE_FLOAT:
           case NODE_RATIONAL:
           case NODE_IMAGINARY:
+          case NODE_SYM:
           case NODE_LINE:
           case NODE_FILE:
             return true;
@@ -195,6 +196,9 @@ node_cdhash_cmp(VALUE val, VALUE lit)
         else if (type_lit == NODE_IMAGINARY) {
             return node_imaginary_cmp(RNODE_IMAGINARY(node_val), RNODE_IMAGINARY(node_lit));
         }
+        else if (type_lit == NODE_SYM) {
+            return rb_parser_string_hash_cmp(RNODE_SYM(node_val)->string, RNODE_SYM(node_lit)->string);
+        }
         else if (type_lit == NODE_LINE) {
             return node_val->nd_loc.beg_pos.lineno != node_lit->nd_loc.beg_pos.lineno;
         }
@@ -234,6 +238,8 @@ node_cdhash_hash(VALUE a)
           case NODE_IMAGINARY:
             val = rb_node_imaginary_literal_val(node);
             return rb_complex_hash(val);
+          case NODE_SYM:
+            return rb_node_sym_string_val(node);
           case NODE_LINE:
             /* Same with NODE_INTEGER FIXNUM case */
             return INT2FIX(node->nd_loc.beg_pos.lineno);
@@ -1071,6 +1077,7 @@ static rb_node_false_t *rb_node_false_new(struct parser_params *p, const YYLTYPE
 static rb_node_errinfo_t *rb_node_errinfo_new(struct parser_params *p, const YYLTYPE *loc);
 static rb_node_defined_t *rb_node_defined_new(struct parser_params *p, NODE *nd_head, const YYLTYPE *loc);
 static rb_node_postexe_t *rb_node_postexe_new(struct parser_params *p, NODE *nd_body, const YYLTYPE *loc);
+static rb_node_sym_t *rb_node_sym_new(struct parser_params *p, VALUE str, const YYLTYPE *loc);
 static rb_node_dsym_t *rb_node_dsym_new(struct parser_params *p, VALUE nd_lit, long nd_alen, NODE *nd_next, const YYLTYPE *loc);
 static rb_node_attrasgn_t *rb_node_attrasgn_new(struct parser_params *p, NODE *nd_recv, ID nd_mid, NODE *nd_args, const YYLTYPE *loc);
 static rb_node_lambda_t *rb_node_lambda_new(struct parser_params *p, rb_node_args_t *nd_args, NODE *nd_body, const YYLTYPE *loc);
@@ -1178,6 +1185,7 @@ static rb_node_error_t *rb_node_error_new(struct parser_params *p, const YYLTYPE
 #define NEW_ERRINFO(loc) (NODE *)rb_node_errinfo_new(p,loc)
 #define NEW_DEFINED(e,loc) (NODE *)rb_node_defined_new(p,e,loc)
 #define NEW_POSTEXE(b,loc) (NODE *)rb_node_postexe_new(p,b,loc)
+#define NEW_SYM(str,loc) (NODE *)rb_node_sym_new(p,str,loc)
 #define NEW_DSYM(s,l,n,loc) (NODE *)rb_node_dsym_new(p,s,l,n,loc)
 #define NEW_ATTRASGN(r,m,a,loc) (NODE *)rb_node_attrasgn_new(p,r,m,a,loc)
 #define NEW_LAMBDA(a,b,loc) (NODE *)rb_node_lambda_new(p,a,b,loc)
@@ -3417,7 +3425,7 @@ fname		: tIDENTIFIER
 fitem		: fname
                     {
                     /*%%%*/
-                        $$ = NEW_LIT(ID2SYM($1), &@$);
+                        $$ = NEW_SYM(rb_id2str($1), &@$);
                     /*% %*/
                     /*% ripper: symbol_literal!($1) %*/
                     }
@@ -5613,7 +5621,7 @@ p_kw		: p_kw_label p_expr
                     {
                         error_duplicate_pattern_key(p, get_id($1), &@1);
                     /*%%%*/
-                        $$ = list_append(p, NEW_LIST(NEW_LIT(ID2SYM($1), &@1), &@$), $2);
+                        $$ = list_append(p, NEW_LIST(NEW_SYM(rb_id2str($1), &@1), &@$), $2);
                     /*% %*/
                     /*% ripper: rb_ary_new_from_args(2, get_value($1), get_value($2)) %*/
                     }
@@ -5625,7 +5633,7 @@ p_kw		: p_kw_label p_expr
                         }
                         error_duplicate_pattern_variable(p, get_id($1), &@1);
                     /*%%%*/
-                        $$ = list_append(p, NEW_LIST(NEW_LIT(ID2SYM($1), &@$), &@$), assignable(p, $1, 0, &@$));
+                        $$ = list_append(p, NEW_LIST(NEW_SYM(rb_id2str($1), &@$), &@$), assignable(p, $1, 0, &@$));
                     /*% %*/
                     /*% ripper: rb_ary_new_from_args(2, get_value(assignable(p, $1)), Qnil) %*/
                     }
@@ -5638,7 +5646,7 @@ p_kw_label	: tLABEL
                     /*%%%*/
                         if (!$2 || nd_type_p($2, NODE_STR)) {
                             NODE *node = dsym_node(p, $2, &loc);
-                            $$ = SYM2ID(RNODE_LIT(node)->nd_lit);
+                            $$ = rb_sym2id(rb_node_sym_string_val(node));
                         }
                     /*%
                         if (ripper_is_node_yylval(p, $2) && RNODE_RIPPER($2)->nd_cval) {
@@ -5650,7 +5658,7 @@ p_kw_label	: tLABEL
                     %*/
                         else {
                             yyerror1(&loc, "symbol literal with interpolation is not allowed");
-                            $$ = 0;
+                            $$ = rb_intern_str(STR_NEW0());
                         }
                     }
                 ;
@@ -6217,7 +6225,15 @@ ssym		: tSYMBEG sym
                     {
                         SET_LEX_STATE(EXPR_END);
                     /*%%%*/
-                        $$ = NEW_LIT(ID2SYM($2), &@$);
+                        VALUE str = rb_id2str($2);
+                        /*
+                         * TODO:
+                         *   set_yylval_noname sets invalid id to yylval.
+                         *   This branch can be removed once yylval is changed to
+                         *   hold lexed string.
+                         */
+                        if (!str) str = STR_NEW0();
+                        $$ = NEW_SYM(str, &@$);
                     /*% %*/
                     /*% ripper: symbol_literal!(symbol!($2)) %*/
                     }
@@ -6818,6 +6834,7 @@ singleton	: var_ref
                           case NODE_DXSTR:
                           case NODE_DREGX:
                           case NODE_LIT:
+                          case NODE_SYM:
                           case NODE_LINE:
                           case NODE_FILE:
                           case NODE_INTEGER:
@@ -6884,7 +6901,7 @@ assoc		: arg_value tASSOC arg_value
                 | tLABEL arg_value
                     {
                     /*%%%*/
-                        $$ = list_append(p, NEW_LIST(NEW_LIT(ID2SYM($1), &@1), &@$), $2);
+                        $$ = list_append(p, NEW_LIST(NEW_SYM(rb_id2str($1), &@1), &@$), $2);
                     /*% %*/
                     /*% ripper: assoc_new!($1, $2) %*/
                     }
@@ -6893,7 +6910,7 @@ assoc		: arg_value tASSOC arg_value
                     /*%%%*/
                         NODE *val = gettable(p, $1, &@$);
                         if (!val) val = NEW_ERROR(&@$);
-                        $$ = list_append(p, NEW_LIST(NEW_LIT(ID2SYM($1), &@1), &@$), val);
+                        $$ = list_append(p, NEW_LIST(NEW_SYM(rb_id2str($1), &@1), &@$), val);
                     /*% %*/
                     /*% ripper: assoc_new!($1, Qnil) %*/
                     }
@@ -12175,6 +12192,15 @@ rb_node_dxstr_new(struct parser_params *p, VALUE nd_lit, long nd_alen, NODE *nd_
     return n;
 }
 
+static rb_node_sym_t *
+rb_node_sym_new(struct parser_params *p, VALUE str, const YYLTYPE *loc)
+{
+    rb_node_sym_t *n = NODE_NEWNODE(NODE_SYM, rb_node_sym_t, loc);
+    n->string = rb_str_to_parser_encoding_string(p, str);
+
+    return n;
+}
+
 static rb_node_dsym_t *
 rb_node_dsym_new(struct parser_params *p, VALUE nd_lit, long nd_alen, NODE *nd_next, const YYLTYPE *loc)
 {
@@ -13189,8 +13215,7 @@ symbol_append(struct parser_params *p, NODE *symbols, NODE *symbol)
         nd_set_type(symbol, NODE_DSYM);
         break;
       case NODE_STR:
-        nd_set_type(symbol, NODE_LIT);
-        RB_OBJ_WRITTEN(p->ast, Qnil, RNODE_LIT(symbol)->nd_lit = rb_str_intern(RNODE_LIT(symbol)->nd_lit));
+        symbol = NEW_SYM(RNODE_LIT(symbol)->nd_lit, &RNODE(symbol)->nd_loc);
         break;
       default:
         compile_error(p, "unexpected node as symbol: %s", parser_node_name(type));
@@ -13922,6 +13947,8 @@ shareable_literal_value(struct parser_params *p, NODE *node)
         return Qfalse;
       case NODE_NIL:
         return Qnil;
+      case NODE_SYM:
+        return rb_node_sym_string_val(node);
       case NODE_LINE:
         return rb_node_line_lineno_val(node);
       case NODE_INTEGER:
@@ -13958,6 +13985,7 @@ shareable_literal_constant(struct parser_params *p, enum shareability shareable,
       case NODE_FALSE:
       case NODE_NIL:
       case NODE_LIT:
+      case NODE_SYM:
       case NODE_LINE:
       case NODE_INTEGER:
       case NODE_FLOAT:
@@ -14276,6 +14304,7 @@ void_expr(struct parser_params *p, NODE *node)
         useless = "a constant";
         break;
       case NODE_LIT:
+      case NODE_SYM:
       case NODE_LINE:
       case NODE_FILE:
       case NODE_INTEGER:
@@ -14419,6 +14448,7 @@ is_static_content(NODE *node)
             if (!is_static_content(RNODE_LIST(node)->nd_head)) return 0;
         } while ((node = RNODE_LIST(node)->nd_next) != 0);
       case NODE_LIT:
+      case NODE_SYM:
       case NODE_LINE:
       case NODE_FILE:
       case NODE_INTEGER:
@@ -14543,6 +14573,7 @@ cond0(struct parser_params *p, NODE *node, enum cond_type type, const YYLTYPE *l
         else if (nd_type_p(node, NODE_DOT3)) nd_set_type(node, NODE_FLIP3);
         break;
 
+      case NODE_SYM:
       case NODE_DSYM:
       warn_symbol:
         SWITCH_BY_COND_TYPE(type, warning, "symbol ");
@@ -14907,7 +14938,7 @@ dsym_node(struct parser_params *p, NODE *node, const YYLTYPE *loc)
     VALUE lit;
 
     if (!node) {
-        return NEW_LIT(ID2SYM(idNULL), loc);
+        return NEW_SYM(STR_NEW0(), loc);
     }
 
     switch (nd_type(node)) {
@@ -14917,9 +14948,7 @@ dsym_node(struct parser_params *p, NODE *node, const YYLTYPE *loc)
         break;
       case NODE_STR:
         lit = RNODE_STR(node)->nd_lit;
-        RB_OBJ_WRITTEN(p->ast, Qnil, RNODE_STR(node)->nd_lit = ID2SYM(rb_intern_str(lit)));
-        nd_set_type(node, NODE_LIT);
-        nd_set_loc(node, loc);
+        node = NEW_SYM(lit, loc);
         break;
       default:
         node = NEW_DSYM(Qnil, 1, NEW_LIST(node, loc), loc);
@@ -14938,6 +14967,7 @@ nd_type_st_key_enable_p(NODE *node)
       case NODE_RATIONAL:
       case NODE_IMAGINARY:
       case NODE_STR:
+      case NODE_SYM:
       case NODE_LINE:
       case NODE_FILE:
         return true;
@@ -14958,6 +14988,7 @@ nd_st_key(struct parser_params *p, NODE *node)
       case NODE_FLOAT:
       case NODE_RATIONAL:
       case NODE_IMAGINARY:
+      case NODE_SYM:
       case NODE_LINE:
       case NODE_FILE:
         return (VALUE)node;
@@ -14983,6 +15014,8 @@ nd_st_key_val(struct parser_params *p, NODE *node)
         return rb_node_rational_literal_val(node);
       case NODE_IMAGINARY:
         return rb_node_imaginary_literal_val(node);
+      case NODE_SYM:
+        return rb_node_sym_string_val(node);
       case NODE_LINE:
         return rb_node_line_lineno_val(node);
       case NODE_FILE:
@@ -15727,7 +15760,7 @@ rb_reg_named_capture_assign_iter_impl(struct parser_params *p, const char *s, lo
     if (len < MAX_WORD_LENGTH && rb_reserved_word(s, (int)len)) {
         if (!lvar_defined(p, var)) return ST_CONTINUE;
     }
-    node = node_assign(p, assignable(p, var, 0, loc), NEW_LIT(ID2SYM(var), loc), NO_LEX_CTXT, loc);
+    node = node_assign(p, assignable(p, var, 0, loc), NEW_SYM(rb_id2str(var), loc), NO_LEX_CTXT, loc);
     succ = *succ_block;
     if (!succ) succ = NEW_ERROR(loc);
     succ = block_append(p, succ, node);
@@ -15819,7 +15852,7 @@ parser_append_options(struct parser_params *p, NODE *node)
             node = block_append(p, split, node);
         }
         if (p->do_chomp) {
-            NODE *chomp = NEW_LIT(ID2SYM(rb_intern("chomp")), LOC);
+            NODE *chomp = NEW_SYM(rb_str_new_cstr("chomp"), LOC);
             chomp = list_append(p, NEW_LIST(chomp, LOC), NEW_TRUE(LOC));
             irs = list_append(p, irs, NEW_HASH(chomp, LOC));
         }

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -965,6 +965,13 @@ rb_parser_set_yydebug(VALUE vparser, VALUE flag)
 #endif
 
 VALUE
+rb_node_sym_string_val(const NODE *node)
+{
+    rb_parser_string_t *str = RNODE_SYM(node)->string;
+    return ID2SYM(rb_intern3(str->ptr, str->len, str->enc));
+}
+
+VALUE
 rb_node_line_lineno_val(const NODE *node)
 {
     return INT2FIX(node->nd_loc.beg_pos.lineno);

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -150,6 +150,7 @@ enum node_type {
     NODE_ERRINFO,
     NODE_DEFINED,
     NODE_POSTEXE,
+    NODE_SYM,
     NODE_DSYM,
     NODE_ATTRASGN,
     NODE_LAMBDA,
@@ -940,6 +941,12 @@ typedef struct RNode_POSTEXE {
     struct RNode *nd_body;
 } rb_node_postexe_t;
 
+typedef struct RNode_SYM {
+    NODE node;
+
+    struct rb_parser_string *string;
+} rb_node_sym_t;
+
 typedef struct RNode_DSYM {
     NODE node;
 
@@ -1105,6 +1112,7 @@ typedef struct RNode_ERROR {
 #define RNODE_ERRINFO(node) ((struct RNode_ERRINFO *)(node))
 #define RNODE_DEFINED(node) ((struct RNode_DEFINED *)(node))
 #define RNODE_POSTEXE(node) ((struct RNode_POSTEXE *)(node))
+#define RNODE_SYM(node) ((struct RNode_SYM *)(node))
 #define RNODE_DSYM(node) ((struct RNode_DSYM *)(node))
 #define RNODE_ATTRASGN(node) ((struct RNode_ATTRASGN *)(node))
 #define RNODE_LAMBDA(node) ((struct RNode_LAMBDA *)(node))

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1013,7 +1013,7 @@ dummy
                 const: nil
                 kw:
                   (HASH@2:4-2:13
-                     (LIST@2:4-2:13 (LIT@2:4-2:6 :a) (CONST@2:7-2:13 :String) nil))
+                     (LIST@2:4-2:13 (SYM@2:4-2:6 :a) (CONST@2:7-2:13 :String) nil))
                 kwrest: nil) (BEGIN@2:14-2:14 nil) nil)))
     EXP
   end

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -568,12 +568,14 @@ class TestRubyOptions < Test::Unit::TestCase
       t.puts "if a = {}; end"
       t.puts "if a = {1=>2}; end"
       t.puts "if a = {3=>a}; end"
+      t.puts "if a = :sym; end"
       t.flush
       err = ["#{t.path}:1:#{warning}",
              "#{t.path}:2:#{warning}",
              "#{t.path}:3:#{warning}",
              "#{t.path}:5:#{warning}",
              "#{t.path}:6:#{warning}",
+             "#{t.path}:8:#{warning}",
             ]
       feature4299 = '[ruby-dev:43083]'
       assert_in_out_err(["-w", t.path], "", [], err, feature4299)

--- a/tool/rbs_skip_tests
+++ b/tool/rbs_skip_tests
@@ -22,13 +22,30 @@ test_collection_install_frozen(RBS::CliTest) running tests without Bundler
 test_collection_install_gemspec(RBS::CliTest) running tests without Bundler
 test_collection_update(RBS::CliTest) running tests without Bundler
 
-test_defs(RBS::RbPrototypeTest)
-test_defs_return_type(RBS::RbPrototypeTest)
-test_defs_return_type_with_block(RBS::RbPrototypeTest)
-test_defs_return_type_with_if(RBS::RbPrototypeTest)
-test_endless_method_definition(RBS::RbPrototypeTest)
-test_literal_to_type(RBS::RbPrototypeTest)
-test_literal_types(RBS::RbPrototypeTest)
+test_defs(RBS::RbPrototypeTest) Numeric Nodes are added
+test_defs_return_type(RBS::RbPrototypeTest) Numeric Nodes are added
+test_defs_return_type_with_block(RBS::RbPrototypeTest) Numeric Nodes are added
+test_defs_return_type_with_if(RBS::RbPrototypeTest) Numeric Nodes are added
+test_endless_method_definition(RBS::RbPrototypeTest) Numeric Nodes are added
+test_literal_to_type(RBS::RbPrototypeTest) Numeric Nodes are added
+test_literal_types(RBS::RbPrototypeTest) Numeric Nodes are added
+test_accessibility(RBS::RbPrototypeTest) Symbol Node is added
+test_aliases(RBS::RbPrototypeTest) Symbol Node is added
+test_comments(RBS::RbPrototypeTest) Symbol Node is added
+test_const(RBS::RbPrototypeTest) Symbol Node is added
+test_meta_programming(RBS::RbPrototypeTest) Symbol Node is added
+test_module_function(RBS::RbPrototypeTest) Symbol Node is added
+test_all(RBS::RbiPrototypeTest) Symbol Node is added
+test_block_args(RBS::RbiPrototypeTest) Symbol Node is added
+test_implicit_block(RBS::RbiPrototypeTest) Symbol Node is added
+test_non_parameter_type_member(RBS::RbiPrototypeTest) Symbol Node is added
+test_noreturn(RBS::RbiPrototypeTest) Symbol Node is added
+test_optional_block(RBS::RbiPrototypeTest) Symbol Node is added
+test_overloading(RBS::RbiPrototypeTest) Symbol Node is added
+test_parameter(RBS::RbiPrototypeTest) Symbol Node is added
+test_parameter_type_member_variance(RBS::RbiPrototypeTest) Symbol Node is added
+test_tuple(RBS::RbiPrototypeTest) Symbol Node is added
+test_untyped_block(RBS::RbiPrototypeTest) Symbol Node is added
 
 test_TOPDIR(RbConfigSingletonTest) `TOPDIR` is `nil` during CI while RBS type is declared as `String`
 


### PR DESCRIPTION
`:sym` was managed by `NODE_LIT` with `Symbol` object. This commit introduces `NODE_SYM` so that

1. Symbol literal is detectable from AST Node
2. Reduce dependency on ruby object