### PR TITLE
Supress type cast warning from `long int` to `VALUE` in parse.y

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -224,7 +224,7 @@ node_cdhash_hash(VALUE a)
         switch (type) {
           case NODE_INTEGER:
             val = rb_node_integer_literal_val(node);
-            return (FIXNUM_P(val) ? val : FIX2LONG(rb_big_hash(val)));
+            return (FIXNUM_P(val) ? val : (VALUE)FIX2LONG(rb_big_hash(val)));
           case NODE_FLOAT:
             val = rb_node_float_literal_val(node);
             return rb_dbl_long_hash(RFLOAT_VALUE(val));


### PR DESCRIPTION
#9407 has caused a warning message.

```
In file included from ./include/ruby/internal/arithmetic/int.h:26,
                 from ./include/ruby/internal/arithmetic/char.h:23,
                 from ./include/ruby/internal/arithmetic.h:24,
                 from ./include/ruby/ruby.h:28,
                 from internal.h:31,
                 from parse.y:49:
parse.y: In function ‘node_cdhash_hash’:
./include/ruby/internal/arithmetic/long.h:53:22: warning: operand of ‘?:’ changes signedness from ‘long int’ to ‘VALUE’ {aka ‘long unsigned int’} due to unsignedness of other operand [-Wsign-compare]
   53 | #define RB_FIX2LONG  rb_fix2long          /**< @alias{rb_fix2long} */
./include/ruby/internal/arithmetic/long.h:46:22: note: in expansion of macro ‘RB_FIX2LONG’
   46 | #define FIX2LONG     RB_FIX2LONG          /**< @old{RB_FIX2LONG} */
      |                      ^~~~~~~~~~~
parse.y:227:43: note: in expansion of macro ‘FIX2LONG’
  227 |             return (FIXNUM_P(val) ? val : FIX2LONG(rb_big_hash(val)));
      |                                           ^~~~~~~~
parse.y: At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
```

I fixed it with typecasting, but is it as expected?