### PR TITLE
Fixed return values for some node types in nd_st_key function

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -14966,13 +14966,19 @@ nd_st_key(struct parser_params *p, NODE *node)
       case NODE_STR:
         return RNODE_STR(node)->nd_lit;
       case NODE_INTEGER:
+        return rb_node_integer_literal_val(node);
       case NODE_FLOAT:
+        return rb_node_float_literal_val(node);
       case NODE_RATIONAL:
+        return rb_node_rational_literal_val(node);
       case NODE_IMAGINARY:
+        return rb_node_imaginary_literal_val(node);
       case NODE_SYM:
+        return rb_node_sym_string_val(node);
       case NODE_LINE:
+        return rb_node_line_lineno_val(node);
       case NODE_FILE:
-        return (VALUE)node;
+        return rb_node_file_path_val(node);
       default:
         rb_bug("unexpected node: %s", ruby_node_name(nd_type(node)));
         UNREACHABLE_RETURN(0);


### PR DESCRIPTION
TestRubyLiteral#test_hash_duplicated_key failed in my environment.
So fixed return  values for some node types, and passed TestRubyLiteral#test_hash_duplicated_key.

<summary>Test failure log<summary>
<details>

```bash
Run options:
  --seed=15527
  "--ruby=./miniruby -I../ruby/lib -I. -I.ext/common  ../ruby/tool/runruby.rb --extout=.ext  -- --disable-gems"
  --excludes-dir=../ruby/test/.excludes
  --name=!/memory_leak/
  --exclude=rubygems/test_gem_package_task\.rb

# Running tests:

[19/29] TestRubyLiteral#test_hash_duplicated_key = 0.00 s
  1) Failure:
TestRubyLiteral#test_hash_duplicated_key [/home/sh/rubydev/ruby/test/ruby/test_literal.rb:488]:
duplicated literal key.

1. [ 3/11] Assertion for "1000"
   | expected: /key 1000 is duplicated/
   | actual: "".

2. [ 4/11] Assertion for "1.0"
   | expected: /key 1\.0 is duplicated/
   | actual: "".

3. [ 5/11] Assertion for "1_000_000_000_000_000_000_000"
   | expected: /key 1000000000000000000000 is duplicated/
   | actual: "".

4. [ 6/11] Assertion for "1.0r"
   | expected: /key \(1\/1\) is duplicated/
   | actual: "".

5. [ 7/11] Assertion for "1.0i"
   | expected: /key \(0\+1\.0i\) is duplicated/
   | actual: "".

6. [ 8/11] Assertion for "1.72723e-77"
   | expected: /key 1\.72723e\-77 is duplicated/
   | actual: "".

7. [10/11] Assertion for "__LINE__"
   | expected: /key 1 is duplicated/
   | actual: "".

8. [11/11] Assertion for "__FILE__"
   | expected: /key "\(eval\ at\ \/home\/sh\/rubydev\/ruby\/test\/ruby\/test_literal\.rb:502\)" is duplicated/
   | actual: "".

Finished tests in 0.504680s, 57.4621 tests/s, 33714.4031 assertions/s.
29 tests, 17015 assertions, 1 failures, 0 errors, 0 skips
```

</details>


<summary>My environment<summary>
<details>

```bash
sh@DESKTOP-L0NI312:~/rubydev/ruby$ gcc --version
gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

sh@DESKTOP-L0NI312:~/rubydev/ruby$ cat /etc/issue
Ubuntu 22.04.3 LTS \n \l
```

</details>