### PR TITLE
Fix memory leak in parser for invalid syntax

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -7622,6 +7622,7 @@ yycompile0(VALUE arg)
     RUBY_DTRACE_PARSE_HOOK(END);
     p->debug_lines = 0;
 
+    xfree(p->lex.strterm);
     p->lex.strterm = 0;
     p->lex.pcur = p->lex.pbeg = p->lex.pend = 0;
     if (n || p->error_p) {


### PR DESCRIPTION
The strterm is leaked when there is invalid syntax.

For example:

    10.times do
      100_000.times do
        begin
          RubyVM::InstructionSequence.compile('private def foo = puts "Hello"')
        rescue SyntaxError
        end
      end

      puts `ps -o rss= -p #{$$}`
    end

Before:

    20384
    26256
    32592
    36720
    42016
    47888
    53248
    57456
    62928
    65936

After:

    16720
    17488
    17616
    17616
    17616
    17616
    17616
    17616
    17616
    16032