### PR TITLE
[PRISM] Frozen string literals should be fstrings

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6333,7 +6333,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             pm_string_node_t *cast = (pm_string_node_t *) node;
             VALUE value = parse_string_encoded(node, &cast->unescaped, parser);
             if (node->flags & PM_STRING_FLAGS_FROZEN) {
-                ADD_INSN1(ret, &dummy_line_node, putobject, rb_str_freeze(value));
+                ADD_INSN1(ret, &dummy_line_node, putobject, rb_fstring(value));
             }
             else {
                 ADD_INSN1(ret, &dummy_line_node, putstring, value);

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -638,14 +638,23 @@ module Prism
       assert_prism_eval('"pit"')
       assert_prism_eval('"a".frozen?')
 
-      frozen_source = <<-CODE
-      # frozen_string_literal: true
-      "a".frozen?
-      CODE
-      ruby_eval = RubyVM::InstructionSequence.compile(frozen_source).eval
-      prism_eval = RubyVM::InstructionSequence.compile_prism(frozen_source).eval
+      [
+        # Test that string literal is frozen
+        <<~RUBY,
+          # frozen_string_literal: true
+          "a".frozen?
+        RUBY
+        # Test that two string literals with the same contents are the same string
+        <<~RUBY,
+          # frozen_string_literal: true
+          "hello".equal?("hello")
+        RUBY
+      ].each do |src|
+        ruby_eval = RubyVM::InstructionSequence.compile(src).eval
+        prism_eval = RubyVM::InstructionSequence.compile_prism(src).eval
 
-      assert_equal ruby_eval, prism_eval
+        assert_equal ruby_eval, prism_eval, src
+      end
     end
 
     def test_SymbolNode


### PR DESCRIPTION
Frozen string literals should not just be frozen, but deduplicated as an fstring so that two string literals with the same contents are the exact same object.

Fixes ruby/prism#2095.