### PR TITLE
[DOC] Enhance documentation for Array#zip

### DIFF
--- a/array.c
+++ b/array.c
@@ -4399,6 +4399,13 @@ take_items(VALUE obj, long n)
  *    d = a.zip(b, c)
  *    d # => [[:a0, :b0, :c0], [:a1, :b1, :c1], [:a2, :b2, :c2], [:a3, :b3, :c3]]
  *
+ *  If an argument is not an array, it extracts the values by calling #each:
+ *
+ *  a = [:a0, :a1, :a2, :a2]
+ *  b = 1..4
+ *  c = a.zip(b)
+ *  c # => [[:a0, 1], [:a1, 2], [:a2, 3], [:a2, 4]]
+ *
  *  When a block is given, calls the block with each of the sub-arrays (formed as above); returns +nil+:
  *
  *    a = [:a0, :a1, :a2, :a3]


### PR DESCRIPTION
This PR adds an example for `Array#zip` to accept a range object. It also mentions that `Array#zip` can accept an object that responds with `#each` and uses it to extract elements.

It is also covered in ruby/spec. https://github.com/the-spectator/ruby/blob/88d7838445ec84b1cc630ce3bd97bb71cd0aefd4/spec/ruby/core/array/zip_spec.rb#L31-L39