### PR TITLE
s/SafeStringValue/StringValue/

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -3509,7 +3509,7 @@ dir_s_home(int argc, VALUE *argv, VALUE obj)
     rb_check_arity(argc, 0, 1);
     user = (argc > 0) ? argv[0] : Qnil;
     if (!NIL_P(user)) {
-        SafeStringValue(user);
+        StringValue(user);
         rb_must_asciicompat(user);
         u = StringValueCStr(user);
         if (*u) {

--- a/hash.c
+++ b/hash.c
@@ -4898,7 +4898,7 @@ static inline const char *
 env_name(volatile VALUE *s)
 {
     const char *name;
-    SafeStringValue(*s);
+    StringValue(*s);
     get_env_ptr(name, *s);
     return name;
 }
@@ -5375,8 +5375,8 @@ env_aset(VALUE nm, VALUE val)
         env_delete(nm);
         return Qnil;
     }
-    SafeStringValue(nm);
-    SafeStringValue(val);
+    StringValue(nm);
+    StringValue(val);
     /* nm can be modified in `val.to_str`, don't get `name` before
      * check for `val` */
     get_env_ptr(name, nm);
@@ -6239,7 +6239,7 @@ env_rassoc(VALUE dmy, VALUE obj)
 static VALUE
 env_key(VALUE dmy, VALUE value)
 {
-    SafeStringValue(value);
+    StringValue(value);
     VALUE str = Qnil;
 
     ENV_LOCK();

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -213,7 +213,7 @@ rb_imemo_tmpbuf_auto_free_pointer_new_from_an_RString(VALUE str)
     void *dst;
     size_t len;
 
-    SafeStringValue(str);
+    StringValue(str);
     /* create tmpbuf to keep the pointer before xmalloc */
     imemo = rb_imemo_tmpbuf_auto_free_pointer();
     tmpbuf = (rb_imemo_tmpbuf_t *)imemo;

--- a/io.c
+++ b/io.c
@@ -5121,7 +5121,7 @@ rb_io_ungetbyte(VALUE io, VALUE b)
         b = rb_str_new((const char *)&c, 1);
         break;
       default:
-        SafeStringValue(b);
+        StringValue(b);
     }
     io_ungetbyte(b, fptr);
     return Qnil;
@@ -5183,7 +5183,7 @@ rb_io_ungetc(VALUE io, VALUE c)
         c = rb_enc_uint_chr(NUM2UINT(c), io_read_encoding(fptr));
     }
     else {
-        SafeStringValue(c);
+        StringValue(c);
     }
     if (NEED_READCONV(fptr)) {
         SET_BINARY_MODE(fptr);
@@ -6834,7 +6834,7 @@ rb_io_extract_modeenc(VALUE *vmode_p, VALUE *vperm_p, VALUE opthash,
     else {
         const char *p;
 
-        SafeStringValue(vmode);
+        StringValue(vmode);
         p = StringValueCStr(vmode);
         fmode = rb_io_modestr_fmode(p);
         oflags = rb_io_fmode_oflags(fmode);
@@ -7943,7 +7943,7 @@ rb_io_popen(VALUE pname, VALUE pmode, VALUE env, VALUE opt)
         RB_GC_GUARD(tmp);
     }
     else {
-        SafeStringValue(pname);
+        StringValue(pname);
         execarg_obj = Qnil;
         if (!is_popen_fork(pname))
             execarg_obj = rb_execarg_new(1, &pname, TRUE, FALSE);
@@ -8148,7 +8148,7 @@ rb_io_s_sysopen(int argc, VALUE *argv, VALUE _)
     else if (!NIL_P(intmode = rb_check_to_integer(vmode, "to_int")))
         oflags = NUM2INT(intmode);
     else {
-        SafeStringValue(vmode);
+        StringValue(vmode);
         oflags = rb_io_modestr_oflags(StringValueCStr(vmode));
     }
     if (NIL_P(vperm)) perm = 0666;
@@ -10546,7 +10546,7 @@ rb_f_backquote(VALUE obj, VALUE str)
     VALUE result;
     rb_io_t *fptr;
 
-    SafeStringValue(str);
+    StringValue(str);
     rb_last_status_clear();
     port = pipe_open_s(str, "r", FMODE_READABLE|DEFAULT_TEXTMODE, NULL);
     if (NIL_P(port)) return rb_str_new(0,0);
@@ -11552,7 +11552,7 @@ rb_f_syscall(int argc, VALUE *argv, VALUE _)
         VALUE v = rb_check_string_type(argv[i]);
 
         if (!NIL_P(v)) {
-            SafeStringValue(v);
+            StringValue(v);
             rb_str_modify(v);
             arg[i] = (VALUE)StringValueCStr(v);
         }

--- a/process.c
+++ b/process.c
@@ -2482,12 +2482,12 @@ rb_check_argv(int argc, VALUE *argv)
         }
         prog = RARRAY_AREF(tmp, 0);
         argv[0] = RARRAY_AREF(tmp, 1);
-        SafeStringValue(prog);
+        StringValue(prog);
         StringValueCStr(prog);
         prog = rb_str_new_frozen(prog);
     }
     for (i = 0; i < argc; i++) {
-        SafeStringValue(argv[i]);
+        StringValue(argv[i]);
         argv[i] = rb_str_new_frozen(argv[i]);
         StringValueCStr(argv[i]);
     }

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1787,7 +1787,7 @@ rb_f_eval(int argc, const VALUE *argv, VALUE self)
     int line = 1;
 
     rb_scan_args(argc, argv, "13", &src, &scope, &vfile, &vline);
-    SafeStringValue(src);
+    StringValue(src);
     if (argc >= 3) {
         StringValue(vfile);
     }
@@ -1981,7 +1981,7 @@ static VALUE
 eval_under(VALUE self, int singleton, VALUE src, VALUE file, int line)
 {
     rb_cref_t *cref = vm_cref_push(GET_EC(), self, NULL, FALSE, singleton);
-    SafeStringValue(src);
+    StringValue(src);
 
     return eval_string_with_cref(self, src, cref, file, line);
 }
@@ -2000,7 +2000,7 @@ specific_eval(int argc, const VALUE *argv, VALUE self, int singleton, int kw_spl
 
         rb_check_arity(argc, 1, 3);
         code = argv[0];
-        SafeStringValue(code);
+        StringValue(code);
         if (argc > 2)
             line = NUM2INT(argv[2]);
         if (argc > 1) {


### PR DESCRIPTION
The macro `SafeStringValue()` became just `StringValue()` in c5c05460ac2:

```c
#define SafeStringValue(v) StringValue(v)
```

and [it is deprecated](https://github.com/ruby/ruby/blob/55b7121358e2bed9b90001405b651f57fafbeaad/include/ruby/internal/core/rstring.h#L91-L98) nowadays.

This patch replaces remaining macro usage. Some occurrences are left in `ext/stringio` and `ext/win32ole`, they should be fixed upstream.

The macro itself is not deleted, because it may be used in extensions.

/cc @jeremyevans