### PR TITLE
Remove a unused variable in i_print_name_entry

### DIFF
--- a/regparse.c
+++ b/regparse.c
@@ -478,7 +478,6 @@ typedef st_data_t HashDataType;   /* 1.6 st.h doesn't define st_data_t type */
 static int
 i_print_name_entry(HashDataType key_, HashDataType e_, HashDataType arg_)
 {
-  UChar* key = (UChar *)key_;
   NameEntry* e = (NameEntry *)e_;
   void* arg = (void *)arg_;
   int i;


### PR DESCRIPTION
A warning for this is shown when `ONIG_DEBUG_COMPILE` is enabled.