### PR TITLE
Backport #20096 to Ruby 3.2

### DIFF
--- a/ext/win32/lib/win32/registry.rb
+++ b/ext/win32/lib/win32/registry.rb
@@ -740,14 +740,11 @@ For detail, see the MSDN[http://msdn.microsoft.com/library/en-us/sysinfo/base/pr
     # method returns.
     #
     def write(name, type, data)
-      termsize = 0
       case type
       when REG_SZ, REG_EXPAND_SZ
-        data = data.encode(WCHAR)
-        termsize = WCHAR_SIZE
+        data = data.encode(WCHAR) << WCHAR_NUL
       when REG_MULTI_SZ
         data = data.to_a.map {|s| s.encode(WCHAR)}.join(WCHAR_NUL) << WCHAR_NUL
-        termsize = WCHAR_SIZE
       when REG_BINARY, REG_NONE
         data = data.to_s
       when REG_DWORD
@@ -759,7 +756,7 @@ For detail, see the MSDN[http://msdn.microsoft.com/library/en-us/sysinfo/base/pr
       else
         raise TypeError, "Unsupported type #{Registry.type2name(type)}"
       end
-      API.SetValue(@hkey, name, type, data, data.bytesize + termsize)
+      API.SetValue(@hkey, name, type, data, data.bytesize)
     end
 
     #


### PR DESCRIPTION
Backports fix for https://bugs.ruby-lang.org/issues/20096 "Ruby 3.2.2 win32/registry: Junk appended to Windows Registry String Value"