### PR TITLE
[PRISM] Don't increment argc for PM_ASSOC_SPLAT_NODE

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -982,7 +982,6 @@ pm_setup_args(pm_arguments_node_t *arguments_node, int *flags, struct rb_callinf
 
                   if (has_keyword_splat) {
                       int cur_hash_size = 0;
-                      orig_argc++;
 
                       bool new_hash_emitted = false;
                       for (size_t i = 0; i < len; i++) {
@@ -992,6 +991,7 @@ pm_setup_args(pm_arguments_node_t *arguments_node, int *flags, struct rb_callinf
 
                           switch (PM_NODE_TYPE(cur_node)) {
                             case PM_ASSOC_NODE: {
+                                orig_argc++;
                                 pm_assoc_node_t *assoc = (pm_assoc_node_t *)cur_node;
 
                                 PM_COMPILE_NOT_POPPED(assoc->key);

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1441,6 +1441,11 @@ module Prism
 
       assert_prism_eval("prism_test_call_node_splat(*[], 1, 2)")
 
+      assert_prism_eval(<<~RUBY)
+        def self.prism_test_call_node_splat_and_double_splat(a, b, **opts); end
+        prism_test_call_node_splat_and_double_splat(*[1], 2, **{})
+      RUBY
+
       assert_prism_eval(<<-CODE)
         class Foo
           def []=(a, b)


### PR DESCRIPTION
Fixes ruby/prism#2087.