### PR TITLE
YJIT: Fix unused warnings

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -871,12 +871,6 @@ rb_yjit_fix_mod_fix(VALUE recv, VALUE obj)
     return rb_fix_mod_fix(recv, obj);
 }
 
-VALUE
-rb_yjit_fix_mul_fix(VALUE recv, VALUE obj)
-{
-    return rb_fix_mul_fix(recv, obj);
-}
-
 // Print the Ruby source location of some ISEQ for debugging purposes
 void
 rb_yjit_dump_iseq_loc(const rb_iseq_t *iseq, uint32_t insn_idx)

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -427,7 +427,6 @@ fn main() {
         .allowlist_function("rb_yarv_ary_entry_internal")
         .allowlist_function("rb_yjit_fix_div_fix")
         .allowlist_function("rb_yjit_fix_mod_fix")
-        .allowlist_function("rb_yjit_fix_mul_fix")
         .allowlist_function("rb_FL_TEST")
         .allowlist_function("rb_FL_TEST_RAW")
         .allowlist_function("rb_RB_TYPE_P")

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -139,7 +139,6 @@ extern "C" {
 
 // Renames
 pub use rb_insn_name as raw_insn_name;
-pub use rb_insn_len as raw_insn_len;
 pub use rb_get_ec_cfp as get_ec_cfp;
 pub use rb_get_cfp_iseq as get_cfp_iseq;
 pub use rb_get_cfp_pc as get_cfp_pc;
@@ -185,7 +184,6 @@ pub use rb_yarv_str_eql_internal as rb_str_eql_internal;
 pub use rb_yarv_ary_entry_internal as rb_ary_entry_internal;
 pub use rb_yjit_fix_div_fix as rb_fix_div_fix;
 pub use rb_yjit_fix_mod_fix as rb_fix_mod_fix;
-pub use rb_yjit_fix_mul_fix as rb_fix_mul_fix;
 pub use rb_FL_TEST as FL_TEST;
 pub use rb_FL_TEST_RAW as FL_TEST_RAW;
 pub use rb_RB_TYPE_P as RB_TYPE_P;
@@ -222,7 +220,7 @@ pub fn insn_len(opcode: usize) -> u32 {
 
     #[cfg(not(test))]
     unsafe {
-        raw_insn_len(VALUE(opcode)).try_into().unwrap()
+        rb_insn_len(VALUE(opcode)).try_into().unwrap()
     }
 }
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1121,7 +1121,6 @@ extern "C" {
     pub fn rb_yjit_rb_ary_subseq_length(ary: VALUE, beg: ::std::os::raw::c_long) -> VALUE;
     pub fn rb_yjit_fix_div_fix(recv: VALUE, obj: VALUE) -> VALUE;
     pub fn rb_yjit_fix_mod_fix(recv: VALUE, obj: VALUE) -> VALUE;
-    pub fn rb_yjit_fix_mul_fix(recv: VALUE, obj: VALUE) -> VALUE;
     pub fn rb_yjit_dump_iseq_loc(iseq: *const rb_iseq_t, insn_idx: u32);
     pub fn rb_FL_TEST(obj: VALUE, flags: VALUE) -> VALUE;
     pub fn rb_FL_TEST_RAW(obj: VALUE, flags: VALUE) -> VALUE;

--- a/yjit/src/lib.rs
+++ b/yjit/src/lib.rs
@@ -3,8 +3,7 @@
 #![allow(clippy::too_many_arguments)] // :shrug:
 #![allow(clippy::identity_op)] // Sometimes we do it for style
 
-
-mod asm;
+pub mod asm;
 mod backend;
 mod codegen;
 mod core;


### PR DESCRIPTION
```
warning: unused import: `condition::Condition`
  --> src/asm/arm64/arg/mod.rs:13:9
   |
13 | pub use condition::Condition;
   |         ^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: unused import: `rb_yjit_fix_mul_fix as rb_fix_mul_fix`
   --> src/cruby.rs:188:9
    |
188 | pub use rb_yjit_fix_mul_fix as rb_fix_mul_fix;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `rb_insn_len as raw_insn_len`
   --> src/cruby.rs:142:9
    |
142 | pub use rb_insn_len as raw_insn_len;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default
```

Make asm public so it stops warning about unused public stuff in there.


cc @nobu  https://github.com/ruby/ruby/pull/9467#issuecomment-1884195523