### PR TITLE
Fix issues with Ractor#send with move option for Array/Hash/Struct

### DIFF
--- a/array.c
+++ b/array.c
@@ -392,6 +392,21 @@ rb_ary_make_embedded(VALUE ary)
     }
 }
 
+void rb_ary_unembed(VALUE ary)
+{
+    if (ARY_EMBED_P(ary)) {
+        long len = ARY_EMBED_LEN(ary);
+        long capacity = ARY_CAPA(ary);
+        VALUE *ptr = ary_heap_alloc(capacity);
+
+        MEMCPY(ptr, ARY_EMBED_PTR(ary), VALUE, len);
+        FL_UNSET_EMBED(ary);
+        ARY_SET_PTR(ary, ptr);
+        ARY_SET_HEAP_LEN(ary, len);
+        ARY_SET_CAPA(ary, capacity);
+    }
+}
+
 static void
 ary_resize_capa(VALUE ary, long capacity)
 {

--- a/gc.c
+++ b/gc.c
@@ -3473,6 +3473,25 @@ obj_free_object_id(rb_objspace_t *objspace, VALUE obj)
     }
 }
 
+void rb_obj_switch_obj_id(VALUE src, VALUE dst)
+{
+    st_data_t id;
+    rb_objspace_t *objspace = &rb_objspace;
+    if (!FL_TEST(src, FL_SEEN_OBJ_ID)) {
+        return;
+    }
+    RB_VM_LOCK_ENTER();
+    {
+        if (st_lookup(objspace->obj_to_id_tbl, (st_data_t)src, &id)) {
+            st_insert(objspace->obj_to_id_tbl, (st_data_t)dst, id);
+            st_insert(objspace->id_to_obj_tbl, id, (st_data_t)dst);
+            FL_UNSET(src, FL_SEEN_OBJ_ID);
+            FL_SET(dst, FL_SEEN_OBJ_ID);
+        }
+    }
+    RB_VM_LOCK_LEAVE();
+}
+
 static bool
 rb_data_free(rb_objspace_t *objspace, VALUE obj)
 {

--- a/hash.c
+++ b/hash.c
@@ -3895,7 +3895,7 @@ rb_hash_update_callback(st_data_t *key, st_data_t *value, struct update_arg *arg
 
 NOINSERT_UPDATE_CALLBACK(rb_hash_update_callback)
 
-static int
+int
 rb_hash_update_i(VALUE key, VALUE value, VALUE hash)
 {
     RHASH_UPDATE(hash, key, rb_hash_update_callback, value);

--- a/internal/array.h
+++ b/internal/array.h
@@ -37,6 +37,7 @@ size_t rb_ary_size_as_embedded(VALUE ary);
 void rb_ary_make_embedded(VALUE ary);
 bool rb_ary_embeddable_p(VALUE ary);
 VALUE rb_ary_diff(VALUE ary1, VALUE ary2);
+void rb_ary_unembed(VALUE ary);
 
 static inline VALUE rb_ary_entry_internal(VALUE ary, long offset);
 static inline bool ARY_PTR_USING_P(VALUE ary);

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -278,6 +278,7 @@ void rb_objspace_each_objects_without_setup(
 size_t rb_gc_obj_slot_size(VALUE obj);
 
 VALUE rb_gc_disable_no_rest(void);
+void rb_obj_switch_obj_id(VALUE src, VALUE dst);
 
 
 /* gc.c (export) */

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -100,6 +100,8 @@ static inline st_table *RHASH_ST_TABLE(VALUE h);
 static inline size_t RHASH_ST_SIZE(VALUE h);
 static inline void RHASH_ST_CLEAR(VALUE h);
 
+int rb_hash_update_i(VALUE key, VALUE value, VALUE hash);
+
 RUBY_SYMBOL_EXPORT_BEGIN
 /* hash.c (export) */
 VALUE rb_hash_delete_entry(VALUE hash, VALUE key);


### PR DESCRIPTION
Array/Hash/Struct were not being moved properly. If arrays were embedded they weren't being moved. Hashes were not being updated properly and write barriers were not being fired on newly moved object. Structs fields were not being set properly.

Also fix issue where moved object_id was different from original object's object id.

Fixes [Bug #20165]