### PR TITLE
Make defined? for op asgn expressions to constants use "assignment"

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -5951,6 +5951,7 @@ defined_expr0(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
       case NODE_IASGN:
       case NODE_CDECL:
       case NODE_CVASGN:
+      case NODE_OP_CDECL:
         expr_type = DEFINED_ASGN;
         break;
     }

--- a/test/ruby/test_defined.rb
+++ b/test/ruby/test_defined.rb
@@ -127,6 +127,18 @@ class TestDefined < Test::Unit::TestCase
     assert_equal nil, defined?($2)
   end
 
+  def test_defined_assignment
+    assert_equal("assignment", defined?(a = 1))
+    assert_equal("assignment", defined?(a += 1))
+    assert_equal("assignment", defined?(a &&= 1))
+    assert_equal("assignment", eval('defined?(A = 1)'))
+    assert_equal("assignment", eval('defined?(A += 1)'))
+    assert_equal("assignment", eval('defined?(A &&= 1)'))
+    assert_equal("assignment", eval('defined?(A::B = 1)'))
+    assert_equal("assignment", eval('defined?(A::B += 1)'))
+    assert_equal("assignment", eval('defined?(A::B &&= 1)'))
+  end
+
   def test_defined_literal
     assert_equal("nil", defined?(nil))
     assert_equal("true", defined?(true))


### PR DESCRIPTION
Previously, it used "expression", as that was the default.  However, op asgn expressions to constants use the NODE_OP_CDECL, so recognize that node type as assignement.

Fixes [Bug #20111]