### PR TITLE
Support keyword splatting nil

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,11 @@ Note that each entry is kept to a minimum, see links for details.
 
 * `it` is added to reference a block parameter. [[Feature #18980]]
 
+* Keyword splatting `nil` when calling methods is now supported.
+  `**nil` is treated similar to `**{}`, passing no keywords,
+  and not calling any conversion methods.
+  [[Bug #20064]]
+
 ## Core classes updates
 
 Note: We're only listing outstanding class updates.
@@ -57,3 +62,4 @@ See GitHub releases like [GitHub Releases of Logger](https://github.com/ruby/log
 ## JIT
 
 [Feature #18980]: https://bugs.ruby-lang.org/issues/18980
+[Bug #20064]: https://bugs.ruby-lang.org/issues/20064

--- a/compile.c
+++ b/compile.c
@@ -5079,6 +5079,7 @@ compile_hash(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int meth
                 int last_kw = !RNODE_LIST(RNODE_LIST(node)->nd_next)->nd_next; /* foo(  ..., **kw) */
                 int only_kw = last_kw && first_kw;            /* foo(1,2,3, **kw) */
 
+                empty_kw = empty_kw || nd_type_p(kw, NODE_NIL); /* foo(  ..., **nil, ...) */
                 if (empty_kw) {
                     if (only_kw && method_call_keywords) {
                         /* **{} appears at the only keyword argument in method call,

--- a/test/ruby/test_backtrace.rb
+++ b/test/ruby/test_backtrace.rb
@@ -378,7 +378,7 @@ class TestBacktrace < Test::Unit::TestCase
 
   def test_core_backtrace_hash_merge
     e = assert_raise(TypeError) do
-      {**nil}
+      {**1}
     end
     assert_not_match(/\Acore#/, e.backtrace_locations[0].base_label)
   end

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -194,6 +194,9 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal(1, o(**nil))
     assert_equal(2, o(2, **nil))
     assert_equal(1, o(*nil, **nil))
+    assert_equal(1, o(**nil, **nil))
+    assert_equal({a: 1}, o(a: 1, **nil))
+    assert_equal({a: 1}, o(**nil, a: 1))
 
     # symproc call
     assert_equal(1, :o.to_proc.call(self, **nil))
@@ -211,6 +214,10 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal([[], {}], skws(**nil))
     assert_equal([[1], {}], skws(1, **nil))
     assert_equal([[], {}], skws(*nil, **nil))
+
+    assert_equal({}, {**nil})
+    assert_equal({a: 1}, {a: 1, **nil})
+    assert_equal({a: 1}, {**nil, a: 1})
   end
 
   def test_lambda

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -182,6 +182,37 @@ class TestKeywordArguments < Test::Unit::TestCase
                   [:keyrest, :kw], [:block, :b]], method(:f9).parameters)
   end
 
+  def test_keyword_splat_nil
+    # cfunc call
+    assert_equal(nil, p(**nil))
+
+    def self.a0; end
+    assert_equal(nil, a0(**nil))
+    assert_equal(nil, :a0.to_proc.call(self, **nil))
+
+    def self.o(x=1); x end
+    assert_equal(1, o(**nil))
+    assert_equal(2, o(2, **nil))
+    assert_equal(1, o(*nil, **nil))
+
+    # symproc call
+    assert_equal(1, :o.to_proc.call(self, **nil))
+
+    def self.s(*a); a end
+    assert_equal([], s(**nil))
+    assert_equal([1], s(1, **nil))
+    assert_equal([], s(*nil, **nil))
+
+    def self.kws(**a); a end
+    assert_equal({}, kws(**nil))
+    assert_equal({}, kws(*nil, **nil))
+
+    def self.skws(*a, **kw); [a, kw] end
+    assert_equal([[], {}], skws(**nil))
+    assert_equal([[1], {}], skws(1, **nil))
+    assert_equal([[], {}], skws(*nil, **nil))
+  end
+
   def test_lambda
     f = ->(str: "foo", num: 424242) { [str, num] }
     assert_equal(["foo", 424242], f[])

--- a/vm.c
+++ b/vm.c
@@ -3666,7 +3666,9 @@ kwmerge_i(VALUE key, VALUE value, VALUE hash)
 static VALUE
 m_core_hash_merge_kwd(VALUE recv, VALUE hash, VALUE kw)
 {
-    REWIND_CFP(hash = core_hash_merge_kwd(hash, kw));
+    if (kw != Qnil) {
+        REWIND_CFP(hash = core_hash_merge_kwd(hash, kw));
+    }
     return hash;
 }
 

--- a/vm.c
+++ b/vm.c
@@ -3666,7 +3666,7 @@ kwmerge_i(VALUE key, VALUE value, VALUE hash)
 static VALUE
 m_core_hash_merge_kwd(VALUE recv, VALUE hash, VALUE kw)
 {
-    if (kw != Qnil) {
+    if (!NIL_P(kw)) {
         REWIND_CFP(hash = core_hash_merge_kwd(hash, kw));
     }
     return hash;

--- a/vm_args.c
+++ b/vm_args.c
@@ -434,6 +434,10 @@ fill_keys_values(st_data_t key, st_data_t val, st_data_t ptr)
 static inline int
 ignore_keyword_hash_p(VALUE keyword_hash, const rb_iseq_t * const iseq, unsigned int * kw_flag, VALUE * converted_keyword_hash)
 {
+    if (keyword_hash == Qnil) {
+        return 1;
+    }
+
     if (!RB_TYPE_P(keyword_hash, T_HASH)) {
         keyword_hash = rb_to_hash_type(keyword_hash);
     }


### PR DESCRIPTION
nil is treated similar to the empty hash in this case, passing no keywords and not calling any conversion methods.

Fixes [Bug #20064]