### PR TITLE
[PRISM] Support repeated required parameter names.

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1299,6 +1299,10 @@ module Prism
       CODE
     end
 
+    def test_repeated_method_params
+      assert_prism_eval("def self.foo(_a, _a); _a; end; foo(1, 2)")
+    end
+
     def test_method_parameters
       assert_prism_eval(<<-CODE)
         def self.prism_test_method_parameters(a, b=1, *c, d:, e: 2, **f, &g)


### PR DESCRIPTION
Fixes: https://github.com/ruby/prism/issues/2062

This patch only fixes positional parameters, we still need to fix the other cases spelled out in test/prism/fixtures/repeat_parameters.txt