### PR TITLE
Remove setaffinity of pthread for getaddrinfo

### DIFF
--- a/ext/socket/extconf.rb
+++ b/ext/socket/extconf.rb
@@ -706,8 +706,6 @@ SRC
 
   have_func("pthread_create")
   have_func("pthread_detach")
-  have_func("pthread_attr_setaffinity_np")
-  have_func("sched_getcpu")
 
   $VPATH << '$(topdir)' << '$(top_srcdir)'
   create_makefile("socket")


### PR DESCRIPTION
It looks like `sched_getcpu(3)` returns a strange number on some (virtual?) environments.

I decided to remove the setaffinity mechanism because the performance does not appear to degrade on a quick benchmark even if removed.

[Bug #20172]