### PR TITLE
Use 3.3.0 explicitly for Rubyspec Version Guards Check

### DIFF
--- a/.github/workflows/spec_guards.yml
+++ b/.github/workflows/spec_guards.yml
@@ -43,7 +43,7 @@ jobs:
           - ruby-3.0
           - ruby-3.1
           - ruby-3.2
-          - ruby-3.3
+          - 3.3.0 # TODO: ruby-3.3 returns 3.3.0-preview2 now.
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
https://github.com/ruby/ruby/actions/runs/7484732410/job/20372022839?pr=9481

`ruby/setup-ruby` returns `3.3.0-preview2` with `ruby-3.3`.