### PR TITLE
Reject encodings determined at runtime as source code encodings

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -9477,11 +9477,20 @@ parser_encode_length(struct parser_params *p, const char *name, long len)
 static void
 parser_set_encode(struct parser_params *p, const char *name)
 {
-    int idx = rb_enc_find_index(name);
     rb_encoding *enc;
     VALUE excargs[3];
 
+    const char *wrong = 0;
+    switch (*name) {
+      case 'e': case 'E': wrong = "external"; break;
+      case 'i': case 'I': wrong = "internal"; break;
+      case 'f': case 'F': wrong = "filesystem"; break;
+      case 'l': case 'L': wrong = "locale"; break;
+    }
+    if (wrong && STRCASECMP(name, wrong) == 0) goto unknown;
+    int idx = rb_enc_find_index(name);
     if (idx < 0) {
+      unknown:
         excargs[1] = rb_sprintf("unknown encoding name: %s", name);
       error:
         excargs[0] = rb_eArgError;

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -767,6 +767,34 @@ x = __ENCODING__
       END
     end
     assert_equal(__ENCODING__, x)
+
+    assert_raise(ArgumentError) do
+      EnvUtil.with_default_external(Encoding::US_ASCII) {eval <<-END, nil, __FILE__, __LINE__+1}
+# coding = external
+x = __ENCODING__
+      END
+    end
+
+    assert_raise(ArgumentError) do
+      EnvUtil.with_default_internal(Encoding::US_ASCII) {eval <<-END, nil, __FILE__, __LINE__+1}
+# coding = internal
+x = __ENCODING__
+      END
+    end
+
+    assert_raise(ArgumentError) do
+      eval <<-END, nil, __FILE__, __LINE__+1
+# coding = filesystem
+x = __ENCODING__
+      END
+    end
+
+    assert_raise(ArgumentError) do
+      eval <<-END, nil, __FILE__, __LINE__+1
+# coding = locale
+x = __ENCODING__
+      END
+    end
   end
 
   def test_utf8_bom


### PR DESCRIPTION
The encodings determined at runtime are affected by the runtime environment, such as the OS and locale, while the file contents are not.