### PR TITLE
Suppress warnings in parser_set_encode function

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -9479,6 +9479,7 @@ parser_set_encode(struct parser_params *p, const char *name)
 {
     rb_encoding *enc;
     VALUE excargs[3];
+    int idx = 0;
 
     const char *wrong = 0;
     switch (*name) {
@@ -9488,7 +9489,7 @@ parser_set_encode(struct parser_params *p, const char *name)
       case 'l': case 'L': wrong = "locale"; break;
     }
     if (wrong && STRCASECMP(name, wrong) == 0) goto unknown;
-    int idx = rb_enc_find_index(name);
+    idx = rb_enc_find_index(name);
     if (idx < 0) {
       unknown:
         excargs[1] = rb_sprintf("unknown encoding name: %s", name);


### PR DESCRIPTION
Supress this warning.

```bash
generating parse.c
compiling parse.c
In file included from parse.y:38:
parse.y: In function ‘parser_set_encode’:
../ruby/universal_parser.c:252:33: warning: ‘idx’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  252 | #define rb_enc_from_index       p->config->enc_from_index
      |                                 ^
parse.y:9482:9: note: ‘idx’ was declared here
```