### PR TITLE
YJIT: expandarray for non-arrays

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2509,7 +2509,7 @@ assert_equal '[1, 2]', %q{
 
   expandarray_redefined_nilclass
   expandarray_redefined_nilclass
-}
+} unless rjit_enabled?
 
 assert_equal '[1, 2, nil]', %q{
   def expandarray_rhs_too_small

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2494,6 +2494,23 @@ assert_equal '[:not_array, nil, nil]', %q{
   expandarray_not_array(obj)
 }
 
+assert_equal '[1, 2]', %q{
+  class NilClass
+    private
+    def to_ary
+      [1, 2]
+    end
+  end
+
+  def expandarray_redefined_nilclass
+    a, b = nil
+    [a, b]
+  end
+
+  expandarray_redefined_nilclass
+  expandarray_redefined_nilclass
+}
+
 assert_equal '[1, 2, nil]', %q{
   def expandarray_rhs_too_small
     a, b, c = [1, 2]

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1637,18 +1637,6 @@ fn gen_expandarray(
 
     let array_opnd = asm.stack_opnd(0);
 
-    // If the array operand is nil, just push on nils
-    if asm.ctx.get_opnd_type(array_opnd.into()) == Type::Nil {
-        asm.stack_pop(1); // pop after using the type info
-        // special case for a, b = nil pattern
-        // push N nils onto the stack
-        for _ in 0..num {
-            let push_opnd = asm.stack_push(Type::Nil);
-            asm.mov(push_opnd, Qnil.into());
-        }
-        return Some(KeepCompiling);
-    }
-
     // Defer compilation so we can specialize on a runtime `self`
     if !jit.at_current_insn() {
         defer_compilation(jit, asm, ocb);
@@ -1657,10 +1645,51 @@ fn gen_expandarray(
 
     let comptime_recv = jit.peek_at_stack(&asm.ctx, 0);
 
-    // If the comptime receiver is not an array, bail
-    if comptime_recv.class_of() != unsafe { rb_cArray } {
-        gen_counter_incr(asm, Counter::expandarray_comptime_not_array);
-        return None;
+    // If the comptime receiver is not an array
+    if !unsafe { RB_TYPE_P(comptime_recv, RUBY_T_ARRAY) } {
+        // at compile time, ensure to_ary is not defined
+        let target_cme = unsafe { rb_callable_method_entry_or_negative(comptime_recv.class_of(), ID!(to_ary)) };
+        let cme_def_type = unsafe { get_cme_def_type(target_cme) };
+
+        if cme_def_type != VM_METHOD_TYPE_UNDEF {
+            // if to_ary is defined, return can't compile so to_ary can be called
+            return None;
+        }
+
+        // invalidate compile block if to_ary is later defined
+        jit.assume_method_lookup_stable(asm, ocb, target_cme);
+
+        jit_guard_known_klass(
+            jit,
+            asm,
+            ocb,
+            comptime_recv.class_of(),
+            array_opnd,
+            array_opnd.into(),
+            comptime_recv,
+            SEND_MAX_DEPTH,
+            Counter::expandarray_not_array,
+        );
+
+        let opnd = asm.stack_pop(1); // pop after using the type info
+
+        // If we don't actually want any values, then just keep going
+        if num == 0 {
+            return Some(KeepCompiling);
+        }
+
+        // load opnd to avoid a race because we are also pushing onto the stack
+        let opnd = asm.load(opnd);
+
+        for _ in 1..num {
+            let push_opnd = asm.stack_push(Type::Nil);
+            asm.mov(push_opnd, Qnil.into());
+        }
+
+        let push_opnd = asm.stack_push(Type::Unknown);
+        asm.mov(push_opnd, opnd);
+
+        return Some(KeepCompiling);
     }
 
     // Get the compile-time array length

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1651,8 +1651,9 @@ fn gen_expandarray(
         let target_cme = unsafe { rb_callable_method_entry_or_negative(comptime_recv.class_of(), ID!(to_ary)) };
         let cme_def_type = unsafe { get_cme_def_type(target_cme) };
 
+        // if to_ary is defined, return can't compile so to_ary can be called
         if cme_def_type != VM_METHOD_TYPE_UNDEF {
-            // if to_ary is defined, return can't compile so to_ary can be called
+            gen_counter_incr(asm, Counter::expandarray_to_ary);
             return None;
         }
 

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -781,6 +781,7 @@ pub(crate) mod ids {
         name: max                content: b"max"
         name: hash               content: b"hash"
         name: respond_to_missing content: b"respond_to_missing?"
+        name: to_ary             content: b"to_ary"
     }
 }
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -469,7 +469,7 @@ make_counters! {
     expandarray_splat,
     expandarray_postarg,
     expandarray_not_array,
-    expandarray_comptime_not_array,
+    expandarray_to_ary,
     expandarray_chain_max_depth,
 
     // getblockparam


### PR DESCRIPTION
This PR updates the `expandarray` instruction for YJIT. 

`expandarray` is an instruction that appears for array decomposition or multiple assignment. 

Most commonly, `expandarray` will be encountered when assigning multiple variables at once from array, 
example - 

```ruby 
a, b, c = [1, 2, 3]
```

But it can often appear with non-arrays, when assigning multiple variables to a single value. It is common enough to see `expandarray` on a single `nil` that `gen_expandarray` previously had a special case if the operand was `nil`, but this is potentially incorrect because `to_ary` can be redefined on `NilClass`.

This PR updates the non-array case by bailing if `to_ary` is defined on a non-array operand. Otherwise, we push `nil`s to fill the unset values, then push the original operand, which also helps get rid of side exits from a pattern like:

```ruby
def some_method
   if ok
      true
   else 
      [false, err]
   end
end

value, err = some_method
```

This pattern was one of the most commonly seen side-exits for GitHub benchmarks.

Quick benchmark:

```bash
% time ./miniruby --disable-gems --yjit -e '10_000_000.times { a,b = 1 }'
./miniruby --disable-gems --yjit -e '10_000_000.times { a,b = 1 }'  0.35s user 0.02s system 61% cpu 0.594 total

% time ruby --disable-gems --yjit -e '10_000_000.times { a,b = 1 }'      
ruby --disable-gems --yjit -e '10_000_000.times { a,b = 1 }'  1.01s user 0.03s system 95% cpu 1.098 total
```



