### PR TITLE
Avoid reading unused lvars in Primitive.cexpr

### DIFF
--- a/bootstraptest/test_method.rb
+++ b/bootstraptest/test_method.rb
@@ -1190,3 +1190,12 @@ assert_equal 'DC', %q{
   test2 o1, [], block
   $result.join
 }
+
+assert_equal 'ok', %q{
+  def foo
+    binding
+    ["ok"].first
+  end
+  foo
+  foo
+}, '[Bug #20178]'


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20178

Previously on builds with optimizations disabled, we could end up with an out of bounds read trying to access a non-existent local variable in the compiled `Primitive.cexpr!`.

This occurred only when we had all of:

When we had all of:
* built with `-O0`
* Leaf builtin
* `Primitive.mandatory_only`
* "no args builtin", called by [vm_call_single_noarg_inline_builtin](https://github.com/ruby/ruby/pull/7486)
* The stack is escaped to the heap via binding or a proc


This is because `mk_builtin_loader` generated reads for all locals regardless of whether they were used and in the case we generated a mandatory_only iseq that would include more variables than were actually available.

On optimized builds, the invalid accesses would be optimized away, and this also was often unnoticed as the invalid access would just hit another part of the stack unless it had been escaped to the heap.

The fix here is imperfect, as this could have false positives, but since `Primitive.cexpr!` is only available within the cruby codebase itself that's probably fine as a proper fix would be much more challenging (the only false positives we found were in rjit.rb).

---

``` ruby
def foo
  binding
  [].first
end

foo
foo
```

```
=================================================================
==1542964==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x603000045fc8 at pc 0x55cb2958b7d0 bp 0x7ffcdc9f1f00 sp 0x7ffcdc9f1ef0
READ of size 8 at 0x603000045fc8 thread T0
    #0 0x55cb2958b7cf in rb_vm_lvar /home/jhawthorn/src/ruby/builtin.h:103
    #1 0x55cb295ab586 in builtin_inline_class_104 /home/jhawthorn/src/ruby/array.rbinc:14
    #2 0x55cb29b2243e in builtin_invoker0 /home/jhawthorn/src/ruby/vm_insnhelper.c:6724
    #3 0x55cb29b09556 in vm_call_single_noarg_inline_builtin /home/jhawthorn/src/ruby/vm_insnhelper.c:2931
    #4 0x55cb29b1d112 in vm_sendish /home/jhawthorn/src/ruby/vm_insnhelper.c:5581
    #5 0x55cb29b34533 in vm_exec_core /home/jhawthorn/src/ruby/insns.def:834
    #6 0x55cb29b6c9a3 in rb_vm_exec /home/jhawthorn/src/ruby/vm.c:2487
    #7 0x55cb29b6f338 in rb_iseq_eval_main /home/jhawthorn/src/ruby/vm.c:2753
    #8 0x55cb296f7188 in rb_ec_exec_node /home/jhawthorn/src/ruby/eval.c:287
    #9 0x55cb296f74e4 in ruby_run_node /home/jhawthorn/src/ruby/eval.c:328
    #10 0x55cb29587d51 in rb_main main.c:39
    #11 0x55cb29587eb1 in main main.c:58
    #12 0x7f3295558ccf  (/usr/lib/libc.so.6+0x27ccf) (BuildId: 8bfe03f6bf9b6a6e2591babd0bbc266837d8f658)
    #13 0x7f3295558d89 in __libc_start_main (/usr/lib/libc.so.6+0x27d89) (BuildId: 8bfe03f6bf9b6a6e2591babd0bbc266837d8f658)
    #14 0x55cb29587bb4 in _start (/home/jhawthorn/src/ruby/miniruby+0x1a7bb4) (BuildId: acaf2fc9526d3e1423a2fcbd072ee6aeb3e5c4c6)

0x603000045fc8 is located 8 bytes before 32-byte region [0x603000045fd0,0x603000045ff0)
allocated by thread T0 here:
    #0 0x7f32958e1359 in __interceptor_malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x55cb2975348a in objspace_xmalloc0 /home/jhawthorn/src/ruby/gc.c:12625
    #2 0x55cb29753940 in ruby_xmalloc2_body /home/jhawthorn/src/ruby/gc.c:12872
    #3 0x55cb29759643 in ruby_xmalloc2 /home/jhawthorn/src/ruby/gc.c:14473
    #4 0x55cb29b62b80 in vm_make_env_each /home/jhawthorn/src/ruby/vm.c:977
    #5 0x55cb29b62dc0 in vm_make_env_object /home/jhawthorn/src/ruby/vm.c:1010
    #6 0x55cb29b65271 in rb_vm_make_binding /home/jhawthorn/src/ruby/vm.c:1433
    #7 0x55cb298cbdb5 in rb_binding_new /home/jhawthorn/src/ruby/proc.c:347
    #8 0x55cb298cbdc8 in rb_f_binding /home/jhawthorn/src/ruby/proc.c:397
    #9 0x55cb29b0ca60 in ractor_safe_call_cfunc_0 /home/jhawthorn/src/ruby/vm_insnhelper.c:3306
    #10 0x55cb29b0eb89 in vm_call_cfunc_with_frame_ /home/jhawthorn/src/ruby/vm_insnhelper.c:3490
    #11 0x55cb29b0f149 in vm_call_cfunc_with_frame /home/jhawthorn/src/ruby/vm_insnhelper.c:3518
    #12 0x55cb29b1d112 in vm_sendish /home/jhawthorn/src/ruby/vm_insnhelper.c:5581
    #13 0x55cb29b34533 in vm_exec_core /home/jhawthorn/src/ruby/insns.def:834
    #14 0x55cb29b6c9a3 in rb_vm_exec /home/jhawthorn/src/ruby/vm.c:2487
    #15 0x55cb29b6f338 in rb_iseq_eval_main /home/jhawthorn/src/ruby/vm.c:2753
    #16 0x55cb296f7188 in rb_ec_exec_node /home/jhawthorn/src/ruby/eval.c:287
    #17 0x55cb296f74e4 in ruby_run_node /home/jhawthorn/src/ruby/eval.c:328
    #18 0x55cb29587d51 in rb_main main.c:39
    #19 0x55cb29587eb1 in main main.c:58
    #20 0x7f3295558ccf  (/usr/lib/libc.so.6+0x27ccf) (BuildId: 8bfe03f6bf9b6a6e2591babd0bbc266837d8f658)

SUMMARY: AddressSanitizer: heap-buffer-overflow /home/jhawthorn/src/ruby/builtin.h:103 in rb_vm_lvar
Shadow bytes around the buggy address:
  0x603000045d00: fd fd fd fa fa fa fd fd fd fa fa fa 00 00 00 00
  0x603000045d80: fa fa 00 00 04 fa fa fa fd fd fd fd fa fa 00 00
  0x603000045e00: 00 00 fa fa 00 00 00 fa fa fa 00 00 00 fa fa fa
  0x603000045e80: 00 00 00 fa fa fa 00 00 00 fa fa fa 00 00 00 00
  0x603000045f00: fa fa 00 00 00 00 fa fa 00 00 00 00 fa fa 00 00
=>0x603000045f80: 00 00 fa fa 00 00 00 00 fa[fa]00 00 00 00 fa fa
  0x603000046000: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x603000046080: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x603000046100: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x603000046180: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x603000046200: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==1542964==ABORTING
```