### PR TITLE
[Bug #20001] Fix GC issues with ASAN fake stacks (v2)

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -2000,6 +2000,7 @@ array.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 array.$(OBJEXT): $(top_srcdir)/internal/object.h
 array.$(OBJEXT): $(top_srcdir)/internal/proc.h
 array.$(OBJEXT): $(top_srcdir)/internal/rational.h
+array.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 array.$(OBJEXT): $(top_srcdir)/internal/serial.h
 array.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 array.$(OBJEXT): $(top_srcdir)/internal/variable.h
@@ -2213,6 +2214,7 @@ ast.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 ast.$(OBJEXT): $(top_srcdir)/internal/parse.h
 ast.$(OBJEXT): $(top_srcdir)/internal/rational.h
 ast.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
+ast.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 ast.$(OBJEXT): $(top_srcdir)/internal/serial.h
 ast.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 ast.$(OBJEXT): $(top_srcdir)/internal/symbol.h
@@ -2648,6 +2650,7 @@ builtin.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/gc.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+builtin.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/serial.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/variable.h
@@ -2877,6 +2880,7 @@ class.$(OBJEXT): $(top_srcdir)/internal/gc.h
 class.$(OBJEXT): $(top_srcdir)/internal/hash.h
 class.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 class.$(OBJEXT): $(top_srcdir)/internal/object.h
+class.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 class.$(OBJEXT): $(top_srcdir)/internal/serial.h
 class.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 class.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -3274,6 +3278,7 @@ compile.$(OBJEXT): $(top_srcdir)/internal/object.h
 compile.$(OBJEXT): $(top_srcdir)/internal/rational.h
 compile.$(OBJEXT): $(top_srcdir)/internal/re.h
 compile.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
+compile.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 compile.$(OBJEXT): $(top_srcdir)/internal/serial.h
 compile.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 compile.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -3527,6 +3532,7 @@ complex.$(OBJEXT): $(top_srcdir)/internal/math.h
 complex.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 complex.$(OBJEXT): $(top_srcdir)/internal/object.h
 complex.$(OBJEXT): $(top_srcdir)/internal/rational.h
+complex.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 complex.$(OBJEXT): $(top_srcdir)/internal/serial.h
 complex.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 complex.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -3971,6 +3977,7 @@ debug.$(OBJEXT): $(top_srcdir)/internal/class.h
 debug.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 debug.$(OBJEXT): $(top_srcdir)/internal/gc.h
 debug.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+debug.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 debug.$(OBJEXT): $(top_srcdir)/internal/serial.h
 debug.$(OBJEXT): $(top_srcdir)/internal/signal.h
 debug.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
@@ -4348,6 +4355,7 @@ dir.$(OBJEXT): $(top_srcdir)/internal/gc.h
 dir.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 dir.$(OBJEXT): $(top_srcdir)/internal/io.h
 dir.$(OBJEXT): $(top_srcdir)/internal/object.h
+dir.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 dir.$(OBJEXT): $(top_srcdir)/internal/serial.h
 dir.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 dir.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -6271,6 +6279,7 @@ enumerator.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 enumerator.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 enumerator.$(OBJEXT): $(top_srcdir)/internal/range.h
 enumerator.$(OBJEXT): $(top_srcdir)/internal/rational.h
+enumerator.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 enumerator.$(OBJEXT): $(top_srcdir)/internal/serial.h
 enumerator.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 enumerator.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -6483,6 +6492,7 @@ error.$(OBJEXT): $(top_srcdir)/internal/io.h
 error.$(OBJEXT): $(top_srcdir)/internal/load.h
 error.$(OBJEXT): $(top_srcdir)/internal/object.h
 error.$(OBJEXT): $(top_srcdir)/internal/process.h
+error.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 error.$(OBJEXT): $(top_srcdir)/internal/serial.h
 error.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 error.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -6699,6 +6709,7 @@ eval.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 eval.$(OBJEXT): $(top_srcdir)/internal/inits.h
 eval.$(OBJEXT): $(top_srcdir)/internal/io.h
 eval.$(OBJEXT): $(top_srcdir)/internal/object.h
+eval.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 eval.$(OBJEXT): $(top_srcdir)/internal/serial.h
 eval.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 eval.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -7434,6 +7445,7 @@ goruby.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/rational.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
+goruby.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/serial.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/variable.h
@@ -7670,6 +7682,7 @@ hash.$(OBJEXT): $(top_srcdir)/internal/hash.h
 hash.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 hash.$(OBJEXT): $(top_srcdir)/internal/object.h
 hash.$(OBJEXT): $(top_srcdir)/internal/proc.h
+hash.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 hash.$(OBJEXT): $(top_srcdir)/internal/serial.h
 hash.$(OBJEXT): $(top_srcdir)/internal/st.h
 hash.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
@@ -8082,6 +8095,7 @@ io.$(OBJEXT): $(top_srcdir)/internal/io.h
 io.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 io.$(OBJEXT): $(top_srcdir)/internal/object.h
 io.$(OBJEXT): $(top_srcdir)/internal/process.h
+io.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 io.$(OBJEXT): $(top_srcdir)/internal/serial.h
 io.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 io.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -8756,6 +8770,7 @@ load.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 load.$(OBJEXT): $(top_srcdir)/internal/parse.h
 load.$(OBJEXT): $(top_srcdir)/internal/rational.h
 load.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
+load.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 load.$(OBJEXT): $(top_srcdir)/internal/serial.h
 load.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 load.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -9485,6 +9500,7 @@ marshal.$(OBJEXT): $(top_srcdir)/internal/hash.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/object.h
+marshal.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/serial.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 marshal.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -9869,6 +9885,7 @@ memory_view.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 memory_view.$(OBJEXT): $(top_srcdir)/internal/gc.h
 memory_view.$(OBJEXT): $(top_srcdir)/internal/hash.h
 memory_view.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+memory_view.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 memory_view.$(OBJEXT): $(top_srcdir)/internal/serial.h
 memory_view.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 memory_view.$(OBJEXT): $(top_srcdir)/internal/variable.h
@@ -10080,6 +10097,7 @@ miniinit.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/rational.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
+miniinit.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/serial.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/variable.h
@@ -10328,6 +10346,7 @@ node.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 node.$(OBJEXT): $(top_srcdir)/internal/gc.h
 node.$(OBJEXT): $(top_srcdir)/internal/hash.h
 node.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+node.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 node.$(OBJEXT): $(top_srcdir)/internal/serial.h
 node.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 node.$(OBJEXT): $(top_srcdir)/internal/variable.h
@@ -10535,6 +10554,7 @@ node_dump.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/rational.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
+node_dump.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/serial.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/variable.h
@@ -10743,6 +10763,7 @@ numeric.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 numeric.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 numeric.$(OBJEXT): $(top_srcdir)/internal/object.h
 numeric.$(OBJEXT): $(top_srcdir)/internal/rational.h
+numeric.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 numeric.$(OBJEXT): $(top_srcdir)/internal/serial.h
 numeric.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 numeric.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -10956,6 +10977,7 @@ object.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 object.$(OBJEXT): $(top_srcdir)/internal/inits.h
 object.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 object.$(OBJEXT): $(top_srcdir)/internal/object.h
+object.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 object.$(OBJEXT): $(top_srcdir)/internal/serial.h
 object.$(OBJEXT): $(top_srcdir)/internal/st.h
 object.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
@@ -11170,6 +11192,7 @@ pack.$(OBJEXT): $(top_srcdir)/internal/bits.h
 pack.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 pack.$(OBJEXT): $(top_srcdir)/internal/gc.h
 pack.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+pack.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 pack.$(OBJEXT): $(top_srcdir)/internal/serial.h
 pack.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 pack.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -11389,6 +11412,7 @@ parse.$(OBJEXT): $(top_srcdir)/internal/parse.h
 parse.$(OBJEXT): $(top_srcdir)/internal/rational.h
 parse.$(OBJEXT): $(top_srcdir)/internal/re.h
 parse.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
+parse.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 parse.$(OBJEXT): $(top_srcdir)/internal/serial.h
 parse.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 parse.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -12641,6 +12665,7 @@ proc.$(OBJEXT): $(top_srcdir)/internal/gc.h
 proc.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 proc.$(OBJEXT): $(top_srcdir)/internal/object.h
 proc.$(OBJEXT): $(top_srcdir)/internal/proc.h
+proc.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 proc.$(OBJEXT): $(top_srcdir)/internal/serial.h
 proc.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 proc.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -12885,6 +12910,7 @@ process.$(OBJEXT): $(top_srcdir)/internal/io.h
 process.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 process.$(OBJEXT): $(top_srcdir)/internal/object.h
 process.$(OBJEXT): $(top_srcdir)/internal/process.h
+process.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 process.$(OBJEXT): $(top_srcdir)/internal/serial.h
 process.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 process.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -13107,6 +13133,7 @@ ractor.$(OBJEXT): $(top_srcdir)/internal/hash.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/rational.h
+ractor.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/serial.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -13729,6 +13756,7 @@ rational.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 rational.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 rational.$(OBJEXT): $(top_srcdir)/internal/object.h
 rational.$(OBJEXT): $(top_srcdir)/internal/rational.h
+rational.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 rational.$(OBJEXT): $(top_srcdir)/internal/serial.h
 rational.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 rational.$(OBJEXT): $(top_srcdir)/internal/variable.h
@@ -13935,6 +13963,7 @@ re.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 re.$(OBJEXT): $(top_srcdir)/internal/object.h
 re.$(OBJEXT): $(top_srcdir)/internal/ractor.h
 re.$(OBJEXT): $(top_srcdir)/internal/re.h
+re.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 re.$(OBJEXT): $(top_srcdir)/internal/serial.h
 re.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 re.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -15118,6 +15147,7 @@ rjit.$(OBJEXT): $(top_srcdir)/internal/gc.h
 rjit.$(OBJEXT): $(top_srcdir)/internal/hash.h
 rjit.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 rjit.$(OBJEXT): $(top_srcdir)/internal/process.h
+rjit.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 rjit.$(OBJEXT): $(top_srcdir)/internal/serial.h
 rjit.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 rjit.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -15647,6 +15677,7 @@ ruby.$(OBJEXT): $(top_srcdir)/internal/object.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/parse.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/rational.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
+ruby.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/serial.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 ruby.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -16067,6 +16098,7 @@ scheduler.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/gc.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+scheduler.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/serial.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 scheduler.$(OBJEXT): $(top_srcdir)/internal/thread.h
@@ -16431,6 +16463,7 @@ shape.$(OBJEXT): $(top_srcdir)/internal/error.h
 shape.$(OBJEXT): $(top_srcdir)/internal/gc.h
 shape.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 shape.$(OBJEXT): $(top_srcdir)/internal/object.h
+shape.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 shape.$(OBJEXT): $(top_srcdir)/internal/serial.h
 shape.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 shape.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -17647,6 +17680,7 @@ struct.$(OBJEXT): $(top_srcdir)/internal/hash.h
 struct.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 struct.$(OBJEXT): $(top_srcdir)/internal/object.h
 struct.$(OBJEXT): $(top_srcdir)/internal/proc.h
+struct.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 struct.$(OBJEXT): $(top_srcdir)/internal/serial.h
 struct.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 struct.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -17857,6 +17891,7 @@ symbol.$(OBJEXT): $(top_srcdir)/internal/gc.h
 symbol.$(OBJEXT): $(top_srcdir)/internal/hash.h
 symbol.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 symbol.$(OBJEXT): $(top_srcdir)/internal/object.h
+symbol.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 symbol.$(OBJEXT): $(top_srcdir)/internal/serial.h
 symbol.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 symbol.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -18078,6 +18113,7 @@ thread.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 thread.$(OBJEXT): $(top_srcdir)/internal/io.h
 thread.$(OBJEXT): $(top_srcdir)/internal/object.h
 thread.$(OBJEXT): $(top_srcdir)/internal/proc.h
+thread.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 thread.$(OBJEXT): $(top_srcdir)/internal/serial.h
 thread.$(OBJEXT): $(top_srcdir)/internal/signal.h
 thread.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
@@ -18331,6 +18367,7 @@ time.$(OBJEXT): $(top_srcdir)/internal/hash.h
 time.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 time.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 time.$(OBJEXT): $(top_srcdir)/internal/rational.h
+time.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 time.$(OBJEXT): $(top_srcdir)/internal/serial.h
 time.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 time.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -18894,6 +18931,7 @@ variable.$(OBJEXT): $(top_srcdir)/internal/hash.h
 variable.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 variable.$(OBJEXT): $(top_srcdir)/internal/object.h
 variable.$(OBJEXT): $(top_srcdir)/internal/re.h
+variable.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 variable.$(OBJEXT): $(top_srcdir)/internal/serial.h
 variable.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 variable.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -19106,6 +19144,7 @@ version.$(OBJEXT): $(top_srcdir)/internal/cmdlineopt.h
 version.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 version.$(OBJEXT): $(top_srcdir)/internal/gc.h
 version.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+version.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 version.$(OBJEXT): $(top_srcdir)/internal/serial.h
 version.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 version.$(OBJEXT): $(top_srcdir)/internal/variable.h
@@ -19594,6 +19633,7 @@ vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/error.h
 vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/gc.h
 vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/serial.h
 vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 vm_backtrace.$(OBJEXT): $(top_srcdir)/internal/string.h
@@ -19823,6 +19863,7 @@ vm_dump.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 vm_dump.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 vm_dump.$(OBJEXT): $(top_srcdir)/internal/gc.h
 vm_dump.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+vm_dump.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 vm_dump.$(OBJEXT): $(top_srcdir)/internal/serial.h
 vm_dump.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 vm_dump.$(OBJEXT): $(top_srcdir)/internal/variable.h
@@ -20051,6 +20092,7 @@ vm_sync.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/gc.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+vm_sync.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/serial.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 vm_sync.$(OBJEXT): $(top_srcdir)/internal/thread.h
@@ -20259,6 +20301,7 @@ vm_trace.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 vm_trace.$(OBJEXT): $(top_srcdir)/internal/gc.h
 vm_trace.$(OBJEXT): $(top_srcdir)/internal/hash.h
 vm_trace.$(OBJEXT): $(top_srcdir)/internal/imemo.h
+vm_trace.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 vm_trace.$(OBJEXT): $(top_srcdir)/internal/serial.h
 vm_trace.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
 vm_trace.$(OBJEXT): $(top_srcdir)/internal/symbol.h

--- a/eval.c
+++ b/eval.c
@@ -70,8 +70,6 @@ ruby_setup(void)
     if (GET_VM())
         return 0;
 
-    ruby_init_stack((void *)&state);
-
     /*
      * Disable THP early before mallocs happen because we want this to
      * affect as many future pages as possible for CoW-friendliness
@@ -115,7 +113,6 @@ ruby_options(int argc, char **argv)
     enum ruby_tag_type state;
     void *volatile iseq = 0;
 
-    ruby_init_stack((void *)&iseq);
     EC_PUSH_TAG(ec);
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
         SAVE_ROOT_JMPBUF(GET_THREAD(), iseq = ruby_process_options(argc, argv));
@@ -205,7 +202,6 @@ rb_ec_cleanup(rb_execution_context_t *ec, enum ruby_tag_type ex)
       step_0: step++;
         save_error = ec->errinfo;
         if (THROW_DATA_P(ec->errinfo)) ec->errinfo = Qnil;
-        ruby_init_stack(&message);
 
         /* exits with failure but silently when an exception raised
          * here */
@@ -324,14 +320,12 @@ ruby_run_node(void *n)
         rb_ec_cleanup(ec, (NIL_P(ec->errinfo) ? TAG_NONE : TAG_RAISE));
         return status;
     }
-    ruby_init_stack((void *)&status);
     return rb_ec_cleanup(ec, rb_ec_exec_node(ec, n));
 }
 
 int
 ruby_exec_node(void *n)
 {
-    ruby_init_stack((void *)&n);
     return rb_ec_exec_node(GET_EC(), n);
 }
 

--- a/ext/objspace/depend
+++ b/ext/objspace/depend
@@ -182,6 +182,7 @@ object_tracing.o: $(top_srcdir)/internal/basic_operators.h
 object_tracing.o: $(top_srcdir)/internal/compilers.h
 object_tracing.o: $(top_srcdir)/internal/gc.h
 object_tracing.o: $(top_srcdir)/internal/imemo.h
+object_tracing.o: $(top_srcdir)/internal/sanitizers.h
 object_tracing.o: $(top_srcdir)/internal/serial.h
 object_tracing.o: $(top_srcdir)/internal/static_assert.h
 object_tracing.o: $(top_srcdir)/internal/vm.h

--- a/ext/ripper/depend
+++ b/ext/ripper/depend
@@ -593,6 +593,7 @@ ripper.o: $(top_srcdir)/internal/parse.h
 ripper.o: $(top_srcdir)/internal/rational.h
 ripper.o: $(top_srcdir)/internal/re.h
 ripper.o: $(top_srcdir)/internal/ruby_parser.h
+ripper.o: $(top_srcdir)/internal/sanitizers.h
 ripper.o: $(top_srcdir)/internal/serial.h
 ripper.o: $(top_srcdir)/internal/static_assert.h
 ripper.o: $(top_srcdir)/internal/string.h

--- a/ext/socket/depend
+++ b/ext/socket/depend
@@ -199,6 +199,7 @@ ancdata.o: $(top_srcdir)/internal/error.h
 ancdata.o: $(top_srcdir)/internal/gc.h
 ancdata.o: $(top_srcdir)/internal/imemo.h
 ancdata.o: $(top_srcdir)/internal/io.h
+ancdata.o: $(top_srcdir)/internal/sanitizers.h
 ancdata.o: $(top_srcdir)/internal/serial.h
 ancdata.o: $(top_srcdir)/internal/static_assert.h
 ancdata.o: $(top_srcdir)/internal/string.h
@@ -408,6 +409,7 @@ basicsocket.o: $(top_srcdir)/internal/error.h
 basicsocket.o: $(top_srcdir)/internal/gc.h
 basicsocket.o: $(top_srcdir)/internal/imemo.h
 basicsocket.o: $(top_srcdir)/internal/io.h
+basicsocket.o: $(top_srcdir)/internal/sanitizers.h
 basicsocket.o: $(top_srcdir)/internal/serial.h
 basicsocket.o: $(top_srcdir)/internal/static_assert.h
 basicsocket.o: $(top_srcdir)/internal/string.h
@@ -617,6 +619,7 @@ constants.o: $(top_srcdir)/internal/error.h
 constants.o: $(top_srcdir)/internal/gc.h
 constants.o: $(top_srcdir)/internal/imemo.h
 constants.o: $(top_srcdir)/internal/io.h
+constants.o: $(top_srcdir)/internal/sanitizers.h
 constants.o: $(top_srcdir)/internal/serial.h
 constants.o: $(top_srcdir)/internal/static_assert.h
 constants.o: $(top_srcdir)/internal/string.h
@@ -827,6 +830,7 @@ ifaddr.o: $(top_srcdir)/internal/error.h
 ifaddr.o: $(top_srcdir)/internal/gc.h
 ifaddr.o: $(top_srcdir)/internal/imemo.h
 ifaddr.o: $(top_srcdir)/internal/io.h
+ifaddr.o: $(top_srcdir)/internal/sanitizers.h
 ifaddr.o: $(top_srcdir)/internal/serial.h
 ifaddr.o: $(top_srcdir)/internal/static_assert.h
 ifaddr.o: $(top_srcdir)/internal/string.h
@@ -1036,6 +1040,7 @@ init.o: $(top_srcdir)/internal/error.h
 init.o: $(top_srcdir)/internal/gc.h
 init.o: $(top_srcdir)/internal/imemo.h
 init.o: $(top_srcdir)/internal/io.h
+init.o: $(top_srcdir)/internal/sanitizers.h
 init.o: $(top_srcdir)/internal/serial.h
 init.o: $(top_srcdir)/internal/static_assert.h
 init.o: $(top_srcdir)/internal/string.h
@@ -1245,6 +1250,7 @@ ipsocket.o: $(top_srcdir)/internal/error.h
 ipsocket.o: $(top_srcdir)/internal/gc.h
 ipsocket.o: $(top_srcdir)/internal/imemo.h
 ipsocket.o: $(top_srcdir)/internal/io.h
+ipsocket.o: $(top_srcdir)/internal/sanitizers.h
 ipsocket.o: $(top_srcdir)/internal/serial.h
 ipsocket.o: $(top_srcdir)/internal/static_assert.h
 ipsocket.o: $(top_srcdir)/internal/string.h
@@ -1454,6 +1460,7 @@ option.o: $(top_srcdir)/internal/error.h
 option.o: $(top_srcdir)/internal/gc.h
 option.o: $(top_srcdir)/internal/imemo.h
 option.o: $(top_srcdir)/internal/io.h
+option.o: $(top_srcdir)/internal/sanitizers.h
 option.o: $(top_srcdir)/internal/serial.h
 option.o: $(top_srcdir)/internal/static_assert.h
 option.o: $(top_srcdir)/internal/string.h
@@ -1663,6 +1670,7 @@ raddrinfo.o: $(top_srcdir)/internal/error.h
 raddrinfo.o: $(top_srcdir)/internal/gc.h
 raddrinfo.o: $(top_srcdir)/internal/imemo.h
 raddrinfo.o: $(top_srcdir)/internal/io.h
+raddrinfo.o: $(top_srcdir)/internal/sanitizers.h
 raddrinfo.o: $(top_srcdir)/internal/serial.h
 raddrinfo.o: $(top_srcdir)/internal/static_assert.h
 raddrinfo.o: $(top_srcdir)/internal/string.h
@@ -1872,6 +1880,7 @@ socket.o: $(top_srcdir)/internal/error.h
 socket.o: $(top_srcdir)/internal/gc.h
 socket.o: $(top_srcdir)/internal/imemo.h
 socket.o: $(top_srcdir)/internal/io.h
+socket.o: $(top_srcdir)/internal/sanitizers.h
 socket.o: $(top_srcdir)/internal/serial.h
 socket.o: $(top_srcdir)/internal/static_assert.h
 socket.o: $(top_srcdir)/internal/string.h
@@ -2081,6 +2090,7 @@ sockssocket.o: $(top_srcdir)/internal/error.h
 sockssocket.o: $(top_srcdir)/internal/gc.h
 sockssocket.o: $(top_srcdir)/internal/imemo.h
 sockssocket.o: $(top_srcdir)/internal/io.h
+sockssocket.o: $(top_srcdir)/internal/sanitizers.h
 sockssocket.o: $(top_srcdir)/internal/serial.h
 sockssocket.o: $(top_srcdir)/internal/static_assert.h
 sockssocket.o: $(top_srcdir)/internal/string.h
@@ -2290,6 +2300,7 @@ tcpserver.o: $(top_srcdir)/internal/error.h
 tcpserver.o: $(top_srcdir)/internal/gc.h
 tcpserver.o: $(top_srcdir)/internal/imemo.h
 tcpserver.o: $(top_srcdir)/internal/io.h
+tcpserver.o: $(top_srcdir)/internal/sanitizers.h
 tcpserver.o: $(top_srcdir)/internal/serial.h
 tcpserver.o: $(top_srcdir)/internal/static_assert.h
 tcpserver.o: $(top_srcdir)/internal/string.h
@@ -2499,6 +2510,7 @@ tcpsocket.o: $(top_srcdir)/internal/error.h
 tcpsocket.o: $(top_srcdir)/internal/gc.h
 tcpsocket.o: $(top_srcdir)/internal/imemo.h
 tcpsocket.o: $(top_srcdir)/internal/io.h
+tcpsocket.o: $(top_srcdir)/internal/sanitizers.h
 tcpsocket.o: $(top_srcdir)/internal/serial.h
 tcpsocket.o: $(top_srcdir)/internal/static_assert.h
 tcpsocket.o: $(top_srcdir)/internal/string.h
@@ -2708,6 +2720,7 @@ udpsocket.o: $(top_srcdir)/internal/error.h
 udpsocket.o: $(top_srcdir)/internal/gc.h
 udpsocket.o: $(top_srcdir)/internal/imemo.h
 udpsocket.o: $(top_srcdir)/internal/io.h
+udpsocket.o: $(top_srcdir)/internal/sanitizers.h
 udpsocket.o: $(top_srcdir)/internal/serial.h
 udpsocket.o: $(top_srcdir)/internal/static_assert.h
 udpsocket.o: $(top_srcdir)/internal/string.h
@@ -2917,6 +2930,7 @@ unixserver.o: $(top_srcdir)/internal/error.h
 unixserver.o: $(top_srcdir)/internal/gc.h
 unixserver.o: $(top_srcdir)/internal/imemo.h
 unixserver.o: $(top_srcdir)/internal/io.h
+unixserver.o: $(top_srcdir)/internal/sanitizers.h
 unixserver.o: $(top_srcdir)/internal/serial.h
 unixserver.o: $(top_srcdir)/internal/static_assert.h
 unixserver.o: $(top_srcdir)/internal/string.h
@@ -3126,6 +3140,7 @@ unixsocket.o: $(top_srcdir)/internal/error.h
 unixsocket.o: $(top_srcdir)/internal/gc.h
 unixsocket.o: $(top_srcdir)/internal/imemo.h
 unixsocket.o: $(top_srcdir)/internal/io.h
+unixsocket.o: $(top_srcdir)/internal/sanitizers.h
 unixsocket.o: $(top_srcdir)/internal/serial.h
 unixsocket.o: $(top_srcdir)/internal/static_assert.h
 unixsocket.o: $(top_srcdir)/internal/string.h

--- a/include/ruby/internal/interpreter.h
+++ b/include/ruby/internal/interpreter.h
@@ -141,7 +141,7 @@ void ruby_show_copyright(void);
  *
  * @param[in]  addr  A pointer somewhere on the stack, near its bottom.
  */
-void ruby_init_stack(volatile VALUE *addr);
+void ruby_init_stack(void *addr);
 
 /**
  * Initializes the VM and builtin libraries.

--- a/internal/sanitizers.h
+++ b/internal/sanitizers.h
@@ -213,4 +213,68 @@ asan_get_real_stack_addr(void* slot)
     return addr ? addr : slot;
 }
 
+/*!
+ * Gets the current thread's fake stack handle, which can be passed into get_fake_stack_extents
+ *
+ * \retval An opaque value which can be passed to asan_get_fake_stack_extents
+ */
+static inline void *
+asan_get_thread_fake_stack_handle(void)
+{
+    return __asan_get_current_fake_stack();
+}
+
+/*!
+ * Checks if the given VALUE _actually_ represents a pointer to an ASAN fake stack.
+ *
+ * If the given slot _is_ actually a reference to an ASAN fake stack, and that fake stack
+ * contains the real values for the passed-in range of machine stack addresses, returns true
+ * and the range of the fake stack through the outparams.
+ *
+ * Otherwise, returns false, and sets the outparams to NULL.
+ *
+ * Note that this function expects "start" to be > "end" on downward-growing stack architectures;
+ *
+ * \param[in]  thread_fake_stack_handle  The asan fake stack reference for the thread we're scanning
+ * \param[in]  slot                      The value on the machine stack we want to inspect
+ * \param[in]  machine_stack_start       The extents of the real machine stack on which slot lives
+ * \param[in]  machine_stack_end         The extents of the real machine stack on which slot lives
+ * \param[out] fake_stack_start_out      The extents of the fake stack which contains real VALUEs
+ * \param[out] fake_stack_end_out        The extents of the fake stack which contains real VALUEs
+ * \return                               Whether slot is a pointer to a fake stack for the given machine stack range
+*/
+
+static inline bool
+asan_get_fake_stack_extents(void *thread_fake_stack_handle, VALUE slot,
+                            void *machine_stack_start, void *machine_stack_end,
+                            void **fake_stack_start_out, void **fake_stack_end_out)
+{
+    /* the ifdef is needed here to suppress a warning about fake_frame_{start/end} being
+       uninitialized if __asan_addr_is_in_fake_stack is an empty macro */
+#ifdef RUBY_ASAN_ENABLED
+    void *fake_frame_start;
+    void *fake_frame_end;
+    void *real_stack_frame = __asan_addr_is_in_fake_stack(
+        thread_fake_stack_handle, (void *)slot, &fake_frame_start, &fake_frame_end
+    );
+    if (real_stack_frame) {
+        bool in_range;
+#if STACK_GROW_DIRECTION < 0
+        in_range = machine_stack_start >= real_stack_frame && real_stack_frame >= machine_stack_end;
+#else
+        in_range = machine_stack_start <= real_stack_frame && real_stack_frame <= machine_stack_end;
+#endif
+        if (in_range) {
+            *fake_stack_start_out = fake_frame_start;
+            *fake_stack_end_out = fake_frame_end;
+            return true;
+        }
+    }
+#endif
+    *fake_stack_start_out = 0;
+    *fake_stack_end_out = 0;
+    return false;
+}
+
+
 #endif /* INTERNAL_SANITIZERS_H */

--- a/thread.c
+++ b/thread.c
@@ -525,6 +525,9 @@ void
 ruby_thread_init_stack(rb_thread_t *th, void *local_in_parent_frame)
 {
     native_thread_init_stack(th, local_in_parent_frame);
+#ifdef RUBY_ASAN_ENABLED
+    th->asan_fake_stack_handle = asan_get_thread_fake_stack_handle();
+#endif
 }
 
 const VALUE *

--- a/thread.c
+++ b/thread.c
@@ -522,9 +522,9 @@ static VALUE rb_threadptr_raise(rb_thread_t *, int, VALUE *);
 static VALUE rb_thread_to_s(VALUE thread);
 
 void
-ruby_thread_init_stack(rb_thread_t *th)
+ruby_thread_init_stack(rb_thread_t *th, void *local_in_parent_frame)
 {
-    native_thread_init_stack(th);
+    native_thread_init_stack(th, local_in_parent_frame);
 }
 
 const VALUE *

--- a/thread_none.c
+++ b/thread_none.c
@@ -139,13 +139,8 @@ ruby_mn_threads_params(void)
 {
 }
 
-void
-ruby_init_stack(volatile VALUE *addr)
-{
-}
-
 static int
-native_thread_init_stack(rb_thread_t *th)
+native_thread_init_stack(rb_thread_t *th, void *local_in_parent_frame)
 {
 #if defined(__wasm__) && !defined(__EMSCRIPTEN__)
     th->ec->machine.stack_start = (VALUE *)rb_wasm_stack_get_base();

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1962,9 +1962,8 @@ reserve_stack(volatile char *limit, size_t size)
 # define reserve_stack(limit, size) ((void)(limit), (void)(size))
 #endif
 
-#undef ruby_init_stack
-void
-ruby_init_stack(volatile VALUE *addr)
+static void
+native_thread_init_main_thread_stack(void *addr)
 {
     native_main_thread.id = pthread_self();
 
@@ -1987,7 +1986,7 @@ ruby_init_stack(volatile VALUE *addr)
     if (!native_main_thread.stack_start ||
         STACK_UPPER((VALUE *)(void *)&addr,
                     native_main_thread.stack_start > addr,
-                    native_main_thread.stack_start < addr)) {
+                    native_main_thread.stack_start < (VALUE *)addr)) {
         native_main_thread.stack_start = (VALUE *)addr;
     }
 #endif
@@ -2049,9 +2048,15 @@ ruby_init_stack(volatile VALUE *addr)
     {int err = (expr); if (err) {rb_bug_errno(#expr, err);}}
 
 static int
-native_thread_init_stack(rb_thread_t *th)
+native_thread_init_stack(rb_thread_t *th, void *local_in_parent_frame)
 {
     rb_nativethread_id_t curr = pthread_self();
+
+    if (!native_main_thread.id) {
+        /* This thread is the first thread, must be the main thread -
+         * configure the native_main_thread object */
+        native_thread_init_main_thread_stack(local_in_parent_frame);
+    }
 
     if (pthread_equal(curr, native_main_thread.id)) {
         th->ec->machine.stack_start = native_main_thread.stack_start;
@@ -2064,8 +2069,8 @@ native_thread_init_stack(rb_thread_t *th)
             size_t size;
 
             if (get_stack(&start, &size) == 0) {
-                uintptr_t diff = (uintptr_t)start - (uintptr_t)&curr;
-                th->ec->machine.stack_start = (VALUE *)&curr;
+                uintptr_t diff = (uintptr_t)start - (uintptr_t)local_in_parent_frame;
+                th->ec->machine.stack_start = (uintptr_t)local_in_parent_frame;
                 th->ec->machine.stack_maxsize = size - diff;
             }
         }
@@ -2185,8 +2190,19 @@ native_thread_create_dedicated(rb_thread_t *th)
 static void
 call_thread_start_func_2(rb_thread_t *th)
 {
-    native_thread_init_stack(th);
+    /* Capture the address of a local in this stack frame to mark the beginning of the
+       machine stack for this thread. This is required even if we can tell the real
+       stack beginning from the pthread API in native_thread_init_stack, because
+       glibc stores some of its own data on the stack before calling into user code
+       on a new thread, and replacing that data on fiber-switch would break it (see
+       bug #13887) */
+    VALUE stack_start = 0;
+    VALUE *stack_start_addr = &stack_start;
+    native_thread_init_stack(th, stack_start_addr);
     thread_start_func_2(th, th->ec->machine.stack_start);
+
+    /* Ensure that stack_start really was spilled to the stack */
+    RB_GC_GUARD(stack_start)
 }
 
 static void *

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -12,6 +12,7 @@
 #ifdef THREAD_SYSTEM_DEPENDENT_IMPLEMENTATION
 
 #include "internal/gc.h"
+#include "internal/sanitizers.h"
 #include "rjit.h"
 
 #ifdef HAVE_SYS_RESOURCE_H
@@ -1966,6 +1967,9 @@ static void
 native_thread_init_main_thread_stack(void *addr)
 {
     native_main_thread.id = pthread_self();
+#ifdef RUBY_ASAN_ENABLED
+    addr = asan_get_real_stack_addr((void *)addr);
+#endif
 
 #if MAINSTACKADDR_AVAILABLE
     if (native_main_thread.stack_maxsize) return;
@@ -2051,6 +2055,9 @@ static int
 native_thread_init_stack(rb_thread_t *th, void *local_in_parent_frame)
 {
     rb_nativethread_id_t curr = pthread_self();
+#ifdef RUBY_ASAN_ENABLED
+    local_in_parent_frame = asan_get_real_stack_addr(local_in_parent_frame);
+#endif
 
     if (!native_main_thread.id) {
         /* This thread is the first thread, must be the main thread -
@@ -2070,7 +2077,7 @@ native_thread_init_stack(rb_thread_t *th, void *local_in_parent_frame)
 
             if (get_stack(&start, &size) == 0) {
                 uintptr_t diff = (uintptr_t)start - (uintptr_t)local_in_parent_frame;
-                th->ec->machine.stack_start = (uintptr_t)local_in_parent_frame;
+                th->ec->machine.stack_start = local_in_parent_frame;
                 th->ec->machine.stack_maxsize = size - diff;
             }
         }
@@ -2197,12 +2204,10 @@ call_thread_start_func_2(rb_thread_t *th)
        on a new thread, and replacing that data on fiber-switch would break it (see
        bug #13887) */
     VALUE stack_start = 0;
-    VALUE *stack_start_addr = &stack_start;
+    VALUE *stack_start_addr = asan_get_real_stack_addr(&stack_start);
+
     native_thread_init_stack(th, stack_start_addr);
     thread_start_func_2(th, th->ec->machine.stack_start);
-
-    /* Ensure that stack_start really was spilled to the stack */
-    RB_GC_GUARD(stack_start)
 }
 
 static void *

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -11,6 +11,7 @@
 
 #ifdef THREAD_SYSTEM_DEPENDENT_IMPLEMENTATION
 
+#include "internal/sanitizers.h"
 #include <process.h>
 
 #define TIME_QUANTUM_USEC (10 * 1000)
@@ -592,7 +593,7 @@ COMPILER_WARNING_IGNORED(-Wmaybe-uninitialized)
 static inline SIZE_T
 query_memory_basic_info(PMEMORY_BASIC_INFORMATION mi, void *local_in_parent_frame)
 {
-    return VirtualQuery(local_in_parent_frame, mi, sizeof(*mi));
+    return VirtualQuery(asan_get_real_stack_addr(local_in_parent_frame), mi, sizeof(*mi));
 }
 COMPILER_WARNING_POP
 

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -581,10 +581,6 @@ rb_native_cond_destroy(rb_nativethread_cond_t *cond)
     /* */
 }
 
-void
-ruby_init_stack(volatile VALUE *addr)
-{
-}
 
 #define CHECK_ERR(expr) \
     {if (!(expr)) {rb_bug("err: %lu - %s", GetLastError(), #expr);}}
@@ -594,20 +590,20 @@ COMPILER_WARNING_PUSH
 COMPILER_WARNING_IGNORED(-Wmaybe-uninitialized)
 #endif
 static inline SIZE_T
-query_memory_basic_info(PMEMORY_BASIC_INFORMATION mi)
+query_memory_basic_info(PMEMORY_BASIC_INFORMATION mi, void *local_in_parent_frame)
 {
-    return VirtualQuery(mi, mi, sizeof(*mi));
+    return VirtualQuery(local_in_parent_frame, mi, sizeof(*mi));
 }
 COMPILER_WARNING_POP
 
 static void
-native_thread_init_stack(rb_thread_t *th)
+native_thread_init_stack(rb_thread_t *th, void *local_in_parent_frame)
 {
     MEMORY_BASIC_INFORMATION mi;
     char *base, *end;
     DWORD size, space;
 
-    CHECK_ERR(query_memory_basic_info(&mi));
+    CHECK_ERR(query_memory_basic_info(&mi, local_in_parent_frame));
     base = mi.AllocationBase;
     end = mi.BaseAddress;
     end += mi.RegionSize;
@@ -638,7 +634,7 @@ thread_start_func_1(void *th_ptr)
     rb_thread_t *th = th_ptr;
     volatile HANDLE thread_id = th->nt->thread_id;
 
-    native_thread_init_stack(th);
+    native_thread_init_stack(th, &th);
     th->nt->interrupt_event = CreateEvent(0, TRUE, FALSE, 0);
 
     /* run */

--- a/vm.c
+++ b/vm.c
@@ -54,6 +54,8 @@
 int ruby_assert_critical_section_entered = 0;
 #endif
 
+static void *native_main_thread_stack_top;
+
 VALUE rb_str_concat_literals(size_t, const VALUE*);
 
 VALUE vm_exec(rb_execution_context_t *);
@@ -4206,7 +4208,8 @@ Init_BareVM(void)
     th_init(th, 0, vm);
 
     rb_ractor_set_current_ec(th->ractor, th->ec);
-    ruby_thread_init_stack(th);
+    /* n.b. native_main_thread_stack_top is set by the INIT_STACK macro */
+    ruby_thread_init_stack(th, native_main_thread_stack_top);
 
     // setup ractor system
     rb_native_mutex_initialize(&vm->ractor.sync.lock);
@@ -4215,6 +4218,12 @@ Init_BareVM(void)
 #ifdef RUBY_THREAD_WIN32_H
     rb_native_cond_initialize(&vm->ractor.sync.barrier_cond);
 #endif
+}
+
+void
+ruby_init_stack(void *addr)
+{
+    native_main_thread_stack_top = addr;
 }
 
 #ifndef _WIN32

--- a/vm_core.h
+++ b/vm_core.h
@@ -94,6 +94,7 @@ extern int ruby_assert_critical_section_entered;
 #include "internal.h"
 #include "internal/array.h"
 #include "internal/basic_operators.h"
+#include "internal/sanitizers.h"
 #include "internal/serial.h"
 #include "internal/vm.h"
 #include "method.h"
@@ -1155,6 +1156,11 @@ typedef struct rb_thread_struct {
     void **specific_storage;
 
     struct rb_ext_config ext_config;
+
+#ifdef RUBY_ASAN_ENABLED
+    void *asan_fake_stack_handle;
+#endif
+
 } rb_thread_t;
 
 static inline unsigned int

--- a/vm_core.h
+++ b/vm_core.h
@@ -1842,7 +1842,7 @@ rb_control_frame_t *rb_vm_get_binding_creatable_next_cfp(const rb_execution_cont
 VALUE *rb_vm_svar_lep(const rb_execution_context_t *ec, const rb_control_frame_t *cfp);
 int rb_vm_get_sourceline(const rb_control_frame_t *);
 void rb_vm_stack_to_heap(rb_execution_context_t *ec);
-void ruby_thread_init_stack(rb_thread_t *th);
+void ruby_thread_init_stack(rb_thread_t *th, void *local_in_parent_frame);
 rb_thread_t * ruby_thread_from_native(void);
 int ruby_thread_set_native(rb_thread_t *th);
 int rb_vm_control_frame_id_and_class(const rb_control_frame_t *cfp, ID *idp, ID *called_idp, VALUE *klassp);


### PR DESCRIPTION
(this is https://github.com/ruby/ruby/pull/8903 again - I just accidently merged it too soon before)

----

This fixes some of the issues with ASAN I outlined in https://bugs.ruby-lang.org/issues/20001

With this merged, `make` now works on my machine with the following:

```
CC=clang ./configure cppflags="-fsanitize=address -fno-omit-frame-pointer" optflags=-O2 LDFLAGS="-fsanitize=address -fno-omit-frame-pointer" --prefix="$(realpath installed)"
ASAN_OPTIONS=use_sigaltstack=0:detect_leaks=0:abort_on_error=1 make
```

Without these fixes, I get crashes in various steps which use the built miniruby (e.g. parsing rdoc or runing extconf files) because `VALUE`'s on the machine stack are not getting properly marked (because they are instead living in ASAN fake stacks).

This seems to build fine with ASAN both enabled and disabled on linux/mac, and builds without asan on windows (i wasn't brave enough to try turning asan on with msvc heh).

[Bug #20001]