### PR TITLE
Use native Windows commands instead of msys2

### DIFF
--- a/.github/workflows/spec_guards.yml
+++ b/.github/workflows/spec_guards.yml
@@ -43,7 +43,7 @@ jobs:
           - ruby-3.0
           - ruby-3.1
           - ruby-3.2
-          - ruby-3.3
+          # - ruby-3.3
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/spec/ruby/core/file/atime_spec.rb
+++ b/spec/ruby/core/file/atime_spec.rb
@@ -27,6 +27,9 @@ describe "File.atime" do
         else
           File.atime(__FILE__).usec.should == 0
         end
+      rescue Errno::ENOENT => e
+        # Native Windows don't have stat command.
+        skip e.message
       end
     end
   end

--- a/spec/ruby/core/file/ctime_spec.rb
+++ b/spec/ruby/core/file/ctime_spec.rb
@@ -22,6 +22,9 @@ describe "File.ctime" do
       else
         File.ctime(__FILE__).usec.should == 0
       end
+    rescue Errno::ENOENT => e
+      # Windows don't have stat command.
+      skip e.message
     end
   end
 

--- a/spec/ruby/core/file/mtime_spec.rb
+++ b/spec/ruby/core/file/mtime_spec.rb
@@ -26,6 +26,9 @@ describe "File.mtime" do
         else
           File.mtime(__FILE__).usec.should == 0
         end
+      rescue Errno::ENOENT => e
+        # Windows don't have stat command.
+        skip e.message
       end
     end
   end

--- a/spec/ruby/core/io/close_read_spec.rb
+++ b/spec/ruby/core/io/close_read_spec.rb
@@ -4,7 +4,8 @@ require_relative 'fixtures/classes'
 describe "IO#close_read" do
 
   before :each do
-    @io = IO.popen 'cat', "r+"
+    cmd = platform_is(:windows) ? 'rem' : 'cat'
+    @io = IO.popen cmd, "r+"
     @path = tmp('io.close.txt')
   end
 

--- a/spec/ruby/core/io/close_write_spec.rb
+++ b/spec/ruby/core/io/close_write_spec.rb
@@ -3,7 +3,8 @@ require_relative 'fixtures/classes'
 
 describe "IO#close_write" do
   before :each do
-    @io = IO.popen 'cat', 'r+'
+    cmd = platform_is(:windows) ? 'rem' : 'cat'
+    @io = IO.popen cmd, 'r+'
     @path = tmp('io.close.txt')
   end
 
@@ -48,12 +49,15 @@ describe "IO#close_write" do
     io.should.closed?
   end
 
-  it "flushes and closes the write stream" do
-    @io.puts '12345'
+  # Windows didn't have command like cat
+  platform_is_not :windows do
+    it "flushes and closes the write stream" do
+      @io.puts '12345'
 
-    @io.close_write
+      @io.close_write
 
-    @io.read.should == "12345\n"
+      @io.read.should == "12345\n"
+    end
   end
 
   it "does nothing on closed stream" do

--- a/spec/ruby/core/io/lineno_spec.rb
+++ b/spec/ruby/core/io/lineno_spec.rb
@@ -26,7 +26,8 @@ describe "IO#lineno" do
   end
 
   it "raises an IOError on a duplexed stream with the read side closed" do
-    IO.popen('cat', 'r+') do |p|
+    cmd = platform_is(:windows) ? 'rem' : 'cat'
+    IO.popen(cmd, 'r+') do |p|
       p.close_read
       -> { p.lineno }.should raise_error(IOError)
     end
@@ -70,7 +71,8 @@ describe "IO#lineno=" do
   end
 
   it "raises an IOError on a duplexed stream with the read side closed" do
-    IO.popen('cat', 'r+') do |p|
+    cmd = platform_is(:windows) ? 'rem' : 'cat'
+    IO.popen(cmd, 'r+') do |p|
       p.close_read
       -> { p.lineno = 0 }.should raise_error(IOError)
     end

--- a/spec/ruby/core/io/stat_spec.rb
+++ b/spec/ruby/core/io/stat_spec.rb
@@ -3,7 +3,8 @@ require_relative 'fixtures/classes'
 
 describe "IO#stat" do
   before :each do
-    @io = IO.popen 'cat', "r+"
+    cmd = platform_is(:windows) ? 'rem' : 'cat'
+    @io = IO.popen cmd, "r+"
   end
 
   after :each do

--- a/spec/ruby/core/kernel/require_spec.rb
+++ b/spec/ruby/core/kernel/require_spec.rb
@@ -26,7 +26,7 @@ describe "Kernel#require" do
     features = out.lines.map { |line| File.basename(line.chomp, '.*') }
 
     # Ignore CRuby internals
-    features -= %w[encdb transdb windows_1252]
+    features -= %w[encdb transdb windows_1252 windows_31j]
     features.reject! { |feature| feature.end_with?('-fake') }
 
     features.sort.should == provided.sort

--- a/spec/ruby/core/process/waitpid_spec.rb
+++ b/spec/ruby/core/process/waitpid_spec.rb
@@ -2,7 +2,8 @@ require_relative '../../spec_helper'
 
 describe "Process.waitpid" do
   it "returns nil when the process has not yet completed and WNOHANG is specified" do
-    pid = spawn("sleep 5")
+    cmd = platform_is(:windows) ? "timeout" : "sleep"
+    pid = spawn("#{cmd} 5")
     begin
       Process.waitpid(pid, Process::WNOHANG).should == nil
       Process.kill("KILL", pid)


### PR DESCRIPTION
cat, sleep, stat is only provided msys, not native Windows. We should replace them for `mswin` environment.

