### PR TITLE
Changed initialization position of local variable `idx`

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -9487,8 +9487,8 @@ parser_set_encode(struct parser_params *p, const char *name)
       case 'f': case 'F': wrong = "filesystem"; break;
       case 'l': case 'L': wrong = "locale"; break;
     }
-    if (wrong && STRCASECMP(name, wrong) == 0) goto unknown;
     int idx = rb_enc_find_index(name);
+    if (wrong && STRCASECMP(name, wrong) == 0) goto unknown;
     if (idx < 0) {
       unknown:
         excargs[1] = rb_sprintf("unknown encoding name: %s", name);


### PR DESCRIPTION
When `if (wrong && STRCASECMP(name, wrong) == 0) goto unknown;`  is executed, local variable `idx` is not initialized.
Therefore, gcc(ver. 11.4.0) outputs warning messages like the one below.

```
parse.y: In function ‘parser_set_encode’:
universal_parser.c:252:33: warning: ‘idx’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  252 | #define rb_enc_from_index       p->config->enc_from_index
      |                                 ^
parse.y:9491:9: note: ‘idx’ was declared here
 9491 |     int idx = rb_enc_find_index(name);
      |         ^~~
parse.y: At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics
```