### PR TITLE
[PRISM] Fix splat assigns with no lefties

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -5108,12 +5108,10 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                 PM_NODE_TYPE_P(cast->rest, PM_SPLAT_NODE) &&
                 (((pm_splat_node_t *)cast->rest)->expression));
 
-        if (cast->lefts.size) {
-            int flag = (int) (bool) cast->rights.size || has_rest_expression;
-            ADD_INSN2(ret, &dummy_line_node, expandarray, INT2FIX(cast->lefts.size), INT2FIX(flag));
-            for (size_t index = 0; index < cast->lefts.size; index++) {
-                PM_COMPILE_NOT_POPPED(cast->lefts.nodes[index]);
-            }
+        int flag = (int) (bool) cast->rights.size || has_rest_expression;
+        ADD_INSN2(ret, &dummy_line_node, expandarray, INT2FIX(cast->lefts.size), INT2FIX(flag));
+        for (size_t index = 0; index < cast->lefts.size; index++) {
+            PM_COMPILE_NOT_POPPED(cast->lefts.nodes[index]);
         }
 
         if (has_rest_expression) {

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1314,6 +1314,10 @@ module Prism
       assert_prism_eval("def self.foo(_a, _a); _a; end; foo(1, 2)")
     end
 
+    def test_splat_params_with_no_lefties
+      assert_prism_eval("def self.foo(v, (*)); v; end; foo(1, [2, 3, 4])")
+    end
+
     def test_method_parameters
       assert_prism_eval(<<-CODE)
         def self.prism_test_method_parameters(a, b=1, *c, d:, e: 2, **f, &g)

--- a/tool/prism_btests
+++ b/tool/prism_btests
@@ -20,7 +20,7 @@
 ../src/bootstraptest/test_string.rb
 ../src/bootstraptest/test_struct.rb
 ../src/bootstraptest/test_thread.rb
-# ../src/bootstraptest/test_block.rb
+../src/bootstraptest/test_block.rb
 # ../src/bootstraptest/test_exception.rb
 # ../src/bootstraptest/test_flow.rb
 # ../src/bootstraptest/test_insns.rb


### PR DESCRIPTION
We still need to emit an expand array even if there's no "left side" variables

Fixes: https://github.com/ruby/prism/issues/2153