### PR TITLE
[DOC] Fix two minor typos on manual page

### DIFF
--- a/man/ruby.1
+++ b/man/ruby.1
@@ -101,10 +101,10 @@ different character encodings, without dependence on Unicode.
 .It Sy "Bignums"
 With built-in bignums, you can for example calculate factorial(400).
 .Pp
-.It Sy "Reflection and domain specific languages"
+.It Sy "Reflection and domain-specific languages"
 Class is also an instance of the Class class. Definition of classes and methods
 is an expression just as 1+1 is. So your programs can even write and modify programs.
-Thus you can write your application in your own programming language on top of Ruby.
+Thus, you can write your application in your own programming language on top of Ruby.
 .Pp
 .It Sy "Exception handling"
 As in Java(tm).
@@ -455,7 +455,7 @@ Enable compiler debug mode (same as
 .It Sy parsetree
 Print a textual representation of the Ruby AST for the program.
 .It Sy parsetree_with_comment
-Print a textual representation of the Ruby AST for the program, but with each node annoted with the associated Ruby source code.
+Print a textual representation of the Ruby AST for the program, but with each node annotated with the associated Ruby source code.
 .It Sy insns
 Print a list of disassembled bytecode instructions.
 .It Sy insns_without_opt


### PR DESCRIPTION
I suggest minor corrections for typos in this pull request, which I recently discovered while going through the man page.

The term domain-specific languages should be written using hyphens [1].

[1] Mernik, M., Heering, J., & Sloane, A. M. (2005). [When and how to develop domain-specific languages](https://dl.acm.org/doi/10.1145/1118890.1118892). ACM computing surveys (CSUR), 37(4), 316-344.