### PR TITLE
[PRISM] Only intern constants upon compilation entry

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -1430,10 +1430,20 @@ iseqw_s_compile_prism_compile(pm_parser_t *parser, VALUE opt, rb_iseq_t *iseq, V
 
         pm_scope_node_t scope_node;
         pm_scope_node_init(node, &scope_node, NULL, parser);
+
+        ID *constants = calloc(parser->constant_pool.size, sizeof(ID));
+        rb_encoding *encoding = rb_enc_find(parser->encoding->name);
+        for (uint32_t index = 0; index < parser->constant_pool.size; index++) {
+            pm_constant_t *constant = &parser->constant_pool.constants[index];
+            constants[index] = rb_intern3((const char *) constant->start, constant->length, encoding);
+        }
+        scope_node.constants = constants;
+
         rb_iseq_compile_prism_node(iseq, &scope_node, parser);
 
         finish_iseq_build(iseq);
         pm_node_destroy(parser, node);
+        free(constants);
     }
 }
 

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6794,25 +6794,16 @@ rb_translate_prism(pm_parser_t *parser, rb_iseq_t *iseq, pm_scope_node_t *scope_
 {
     RUBY_ASSERT(ISEQ_COMPILE_DATA(iseq));
 
-    ID *constants = calloc(parser->constant_pool.size, sizeof(ID));
-    rb_encoding *encoding = rb_enc_find(parser->encoding->name);
-    for (uint32_t index = 0; index < parser->constant_pool.size; index++) {
-        pm_constant_t *constant = &parser->constant_pool.constants[index];
-        constants[index] = rb_intern3((const char *) constant->start, constant->length, encoding);
-    }
-
     st_table *index_lookup_table = st_init_numtable();
     pm_constant_id_list_t *locals = &scope_node->locals;
     for (size_t i = 0; i < locals->size; i++) {
         st_insert(index_lookup_table, locals->ids[i], i);
     }
-    scope_node->constants = constants;
     scope_node->index_lookup_table = index_lookup_table;
 
     pm_compile_node(iseq, (pm_node_t *)scope_node, ret, scope_node->base.location.start, false, (pm_scope_node_t *)scope_node);
     iseq_set_sequence(iseq, ret);
 
-    free(constants);
     return Qnil;
 }
 

--- a/tool/prism_btests
+++ b/tool/prism_btests
@@ -30,6 +30,6 @@
 # ../src/bootstraptest/test_ractor.rb
 # ../src/bootstraptest/test_syntax.rb
 # ../src/bootstraptest/test_yjit.rb
-# ../src/bootstraptest/test_yjit_30k_ifelse.rb
-# ../src/bootstraptest/test_yjit_30k_methods.rb
+../src/bootstraptest/test_yjit_30k_ifelse.rb
+../src/bootstraptest/test_yjit_30k_methods.rb
 # ../src/bootstraptest/test_yjit_rust_port.rb


### PR DESCRIPTION
Before this commit the Prism compiler would try to intern constants every time it re-entered. This pool of constants is "constant" (there is only one pool per parser instance), so we should do it only once: upon the top level entry to the compiler.

This change does just that: it populates the interned constants once.

Fixes: https://github.com/ruby/prism/issues/2152