### PR TITLE
Fix linting line end

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -2700,9 +2700,16 @@ load_file_internal(VALUE argp_v)
                 }
 
               start_read:
-                str += len - 1;
-                if (*str == '\n') *str-- = '\0';
-                if (*str == '\r') *str-- = '\0';
+                if (str[len-1] == '\n') {
+                    str[len-1] = '\0';
+                }
+                if (str[len-1] == '\r') {
+                    str[len-1] = '\0';
+                }
+                if (str[len-1] != '\0') {
+                    str += len - 1;
+                    str[len-1] = '\0';
+                }
                 /* ruby_engine should not contain a space */
                 if ((p = strstr(p, " -")) != 0) {
                     opt->warning = 0;


### PR DESCRIPTION
str is an array, but `*str` points to its beginning, that does not make sense and will never be true.

Fixes: 989a6f1ce8 ("ruby.c: simplify")

I am **not** sure that this patch is correct!

I came across this code while debugging the following crash:
create a file with the following line:
`#!ruby --enable`
and run:
`ruby file`
It crashes. This patch does not fix this crash, but I came across the changed code while debugging it...