### PR TITLE
YJIT: Optimize Integer#succ

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4347,3 +4347,8 @@ assert_equal '0', %q{
 
   entry
 }
+
+# Integer succ and overflow
+assert_equal '[2, 4611686018427387904]', %q{
+  [1.succ, 4611686018427387903.succ]
+}

--- a/yjit.rb
+++ b/yjit.rb
@@ -284,6 +284,7 @@ module RubyVM::YJIT
         opt_mod
         opt_mult
         opt_plus
+        opt_succ
         setlocal
       ].each do |insn|
         print_counters(stats, out: out, prefix: "#{insn}_", prompt: "#{insn} exit reasons:", optional: true)

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -444,6 +444,9 @@ make_counters! {
     opt_minus_overflow,
     opt_mult_overflow,
 
+    opt_succ_not_fixnum,
+    opt_succ_overflow,
+
     opt_mod_zero,
     opt_div_zero,
 


### PR DESCRIPTION
We use `Integer#succ` when we rewrite loop methods in Ruby (e.g. `Integer#times` and `Array#each`) because `opt_succ` (`i = i.succ`) is faster to dispatch on the interpreter than `putobject 1; opt_plus` (`i += 1`).

Since YJIT currently doesn't optimize `Integer#succ`, it's rather slower than `opt_plus`. This PR fixes this problem to improve the performance of `Array#each` when it's rewritten in Ruby.

This also speeds up `Integer#times` on YJIT.

```
$ benchmark-driver benchmark/loop_times.rb -v --chruby 'before::before --yjit-call-threshold=1;after::after --yjit-call-threshold=1'
before: ruby 3.4.0dev (2024-01-13T00:28:26Z master f7178045bb) +YJIT [x86_64-linux]
after: ruby 3.4.0dev (2024-01-13T01:11:20Z yjit-succ c27641f431) +YJIT [x86_64-linux]
Calculating -------------------------------------
                         before       after
          loop_times      8.963      21.565 i/s -       1.000 times in 0.111565s 0.046371s

Comparison:
                       loop_times
               after:        21.6 i/s
              before:         9.0 i/s - 2.41x  slower
```