### PR TITLE
Fix TODO in `hash.c` concerning `pair` values.

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -856,14 +856,7 @@ ar_general_foreach(VALUE hash, st_foreach_check_callback_func *func, st_update_c
                 return 0;
               case ST_REPLACE:
                 if (replace) {
-                    VALUE key = pair->key;
-                    VALUE val = pair->val;
-                    retval = (*replace)(&key, &val, arg, TRUE);
-
-                    // TODO: pair should be same as pair before.
-                    ar_table_pair *pair = RHASH_AR_TABLE_REF(hash, i);
-                    pair->key = key;
-                    pair->val = val;
+                    retval = (*replace)(&pair->key, &pair->val, arg, TRUE);
                 }
                 break;
               case ST_DELETE:


### PR DESCRIPTION
[st_update_callback_func](https://github.com/ruby/ruby/blob/55335eab80d763fb11d621c041d23aaf8f4857c6/include/ruby/st.h#L133) takes pointers for `key` and `val` for their first arguments:

```h
typedef int st_update_callback_func(st_data_t *key, st_data_t *value, st_data_t arg, int existing);
```

Although these were being passed here, this invocation was altering the values:

```c
VALUE key = pair->key;
VALUE val = pair->val;
retval = (*replace)(&key, &val, arg, TRUE);
```

Passing the pointer for the struct member directly ensures the value doesn't get altered.