### PR TITLE
Correctly handle `MAP_FAILED` in `Init_default_shapes`.

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -1232,6 +1232,11 @@ Init_default_shapes(void)
 #ifdef HAVE_MMAP
     rb_shape_tree_ptr->shape_cache = (redblack_node_t *)mmap(NULL, rb_size_mul_or_raise(REDBLACK_CACHE_SIZE, sizeof(redblack_node_t), rb_eRuntimeError),
                          PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+
+    if (rb_shape_tree_ptr->shape_cache == MAP_FAILED) {
+        rb_shape_tree_ptr->shape_cache = NULL;
+    }
+
     rb_shape_tree_ptr->cache_size = 0;
 
     // If mmap fails, then give up on the redblack tree cache.


### PR DESCRIPTION
(Still waiting for bugs.ruby-lang.org issue to show up).

On low-memory systems (< ~400MB RAM+Swap), `Init_default_shapes` will fail and cause Ruby to segfault later.

Even something as simple as `ruby -e "puts 123"` will fail.

The latter `mmap` tries to allocate 384MB as a cache. This fails with `MAP_FAILED` and later this pointer is derefenced causing a segfault.

A better strategy should probably be used, e.g.

- Prefer dynamic allocation instead of mmap, OR
- If `mmap` fails, half the size of the cache and try again.

The latter approach might be problematic if the fixed cache size causes other (later) allocations to fail. I think that we should be extremely careful about allocating a large chunk of memory like this.