### PR TITLE
Improve behavioural consistency of unallocated (zero length) `IO::Buffer`.

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -854,11 +854,10 @@ io_buffer_get_bytes_for_writing(struct rb_io_buffer *buffer, void **base, size_t
     if (buffer->base) {
         *base = buffer->base;
         *size = buffer->size;
-
-        return;
+    } else {
+        *base = NULL;
+        *size = 0;
     }
-
-    rb_raise(rb_eIOBufferAllocationError, "The buffer is not allocated!");
 }
 
 void
@@ -880,11 +879,10 @@ io_buffer_get_bytes_for_reading(struct rb_io_buffer *buffer, const void **base, 
     if (buffer->base) {
         *base = buffer->base;
         *size = buffer->size;
-
-        return;
+    } else {
+        *base = NULL;
+        *size = 0;
     }
-
-    rb_raise(rb_eIOBufferAllocationError, "The buffer is not allocated!");
 }
 
 void

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -199,6 +199,14 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_positive buffer2 <=> buffer1
   end
 
+  def test_compare_zero_length
+    buffer1 = IO::Buffer.new(0)
+    buffer2 = IO::Buffer.new(1)
+
+    assert_negative buffer1 <=> buffer2
+    assert_positive buffer2 <=> buffer1
+  end
+
   def test_slice
     buffer = IO::Buffer.new(128)
     slice = buffer.slice(8, 32)
@@ -270,6 +278,14 @@ class TestIOBuffer < Test::Unit::TestCase
     end
   end
 
+  def test_zero_length_get_string
+    buffer = IO::Buffer.new.slice(0, 0)
+    assert_equal "", buffer.get_string
+
+    buffer = IO::Buffer.new(0)
+    assert_equal "", buffer.get_string
+  end
+
   # We check that values are correctly round tripped.
   RANGES = {
     :U8 => [0, 2**8-1],
@@ -316,6 +332,13 @@ class TestIOBuffer < Test::Unit::TestCase
     end
   end
 
+  def test_zero_length_get_set_values
+    buffer = IO::Buffer.new(0)
+
+    assert_equal [], buffer.get_values([], 0)
+    assert_equal 0, buffer.set_values([], 0, [])
+  end
+
   def test_values
     buffer = IO::Buffer.new(128)
 
@@ -340,11 +363,23 @@ class TestIOBuffer < Test::Unit::TestCase
     end
   end
 
+  def test_zero_length_each
+    buffer = IO::Buffer.new(0)
+
+    assert_equal [], buffer.each(:U8).to_a
+  end
+
   def test_each_byte
     string = "The quick brown fox jumped over the lazy dog."
     buffer = IO::Buffer.for(string)
 
     assert_equal string.bytes, buffer.each_byte.to_a
+  end
+
+  def test_zero_length_each_byte
+    buffer = IO::Buffer.new(0)
+
+    assert_equal [], buffer.each_byte.to_a
   end
 
   def test_clear


### PR DESCRIPTION
This makes the behaviour of `IO::Buffer.new(0)` and `IO::Buffer.new.slice(0, 0)` consistent.

Fixes https://bugs.ruby-lang.org/issues/19542 and https://bugs.ruby-lang.org/issues/18805.