### PR TITLE
[PRISM] Fix keyword splat inside of array

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -702,6 +702,9 @@ module Prism
       assert_prism_eval("[-1, true, 0, *1..2, 3, 4, *5..6, 7, 8, *9..11]")
       assert_prism_eval("a = [1,2]; [0, *a, 3, 4, *5..6, 7, 8, *9..11]")
       assert_prism_eval("[[*1..2], 3, *4..5]")
+
+      # Test keyword splat inside of array
+      assert_prism_eval("[**{x: 'hello'}]")
     end
 
     def test_AssocNode


### PR DESCRIPTION
Fixes ruby/prism#2155.