### PR TITLE
Fix shellwords spec

### DIFF
--- a/.github/workflows/spec_guards.yml
+++ b/.github/workflows/spec_guards.yml
@@ -43,7 +43,7 @@ jobs:
           - ruby-3.0
           - ruby-3.1
           - ruby-3.2
-          # - ruby-3.3
+          - ruby-3.3
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/spec/ruby/library/shellwords/shellwords_spec.rb
+++ b/spec/ruby/library/shellwords/shellwords_spec.rb
@@ -1,34 +1,33 @@
 require_relative '../../spec_helper'
 require 'shellwords'
-include Shellwords
 
 describe "Shellwords#shellwords" do
   it "honors quoted strings" do
-    shellwords('a "b b" a').should == ['a', 'b b', 'a']
+    Shellwords.shellwords('a "b b" a').should == ['a', 'b b', 'a']
   end
 
   it "honors escaped double quotes" do
-    shellwords('a "\"b\" c" d').should == ['a', '"b" c', 'd']
+    Shellwords.shellwords('a "\"b\" c" d').should == ['a', '"b" c', 'd']
   end
 
   it "honors escaped single quotes" do
-    shellwords("a \"'b' c\" d").should == ['a', "'b' c", 'd']
+    Shellwords.shellwords("a \"'b' c\" d").should == ['a', "'b' c", 'd']
   end
 
   it "honors escaped spaces" do
-    shellwords('a b\ c d').should == ['a', 'b c', 'd']
+    Shellwords.shellwords('a b\ c d').should == ['a', 'b c', 'd']
   end
 
   it "raises ArgumentError when double quoted strings are misquoted" do
-    -> { shellwords('a "b c d e') }.should raise_error(ArgumentError)
+    -> { Shellwords.shellwords('a "b c d e') }.should raise_error(ArgumentError)
   end
 
   it "raises ArgumentError when single quoted strings are misquoted" do
-    -> { shellwords("a 'b c d e") }.should raise_error(ArgumentError)
+    -> { Shellwords.shellwords("a 'b c d e") }.should raise_error(ArgumentError)
   end
 
   # https://bugs.ruby-lang.org/issues/10055
   it "matches POSIX sh behavior for backslashes within double quoted strings" do
-    shellsplit('printf "%s\n"').should == ['printf', '%s\n']
+    Shellwords.shellsplit('printf "%s\n"').should == ['printf', '%s\n']
   end
 end


### PR DESCRIPTION
`Shellwords::VERSION` is visible as `::VERSION`.