### PR TITLE
Make `const_source_location` return the real constant as soon as defined

### DIFF
--- a/spec/ruby/core/module/autoload_spec.rb
+++ b/spec/ruby/core/module/autoload_spec.rb
@@ -407,6 +407,8 @@ describe "Module#autoload" do
     before :each do
       @path = fixture(__FILE__, "autoload_during_autoload_after_define.rb")
       ModuleSpecs::Autoload.autoload :DuringAutoloadAfterDefine, @path
+      @autoload_location = [__FILE__, __LINE__ - 1]
+      @const_location = [@path, 2]
       @remove << :DuringAutoloadAfterDefine
       raise unless ModuleSpecs::Autoload.autoload?(:DuringAutoloadAfterDefine) == @path
     end
@@ -437,6 +439,15 @@ describe "Module#autoload" do
         ModuleSpecs::Autoload.autoload?(:DuringAutoloadAfterDefine)
       }
       results.should == [@path, nil, @path, nil]
+    end
+
+    ruby_bug("#20188", ""..."3.4") do
+      it "returns the real constant location in autoload thread and returns the autoload location in other threads for Module#const_source_location" do
+        results = check_before_during_thread_after(:DuringAutoloadAfterDefine) {
+          ModuleSpecs::Autoload.const_source_location(:DuringAutoloadAfterDefine)
+        }
+        results.should == [@autoload_location, @const_location, @autoload_location, @const_location]
+      end
     end
   end
 

--- a/spec/ruby/core/module/const_source_location_spec.rb
+++ b/spec/ruby/core/module/const_source_location_spec.rb
@@ -233,5 +233,17 @@ describe "Module#const_source_location" do
       line = ConstantSpecs::CONST_LOCATION
       ConstantSpecs.const_source_location('CONST_LOCATION').should == [file, line]
     end
+
+    ruby_bug("#20188", ""..."3.4") do
+      it 'returns the real constant location as soon as it is defined' do
+        file = fixture(__FILE__, 'autoload_const_source_location.rb')
+        ConstantSpecs.autoload :ConstSource, file
+        autoload_location = [__FILE__, __LINE__ - 1]
+
+        ConstantSpecs.const_source_location(:ConstSource).should == autoload_location
+        ConstantSpecs::ConstSource::LOCATION.should == ConstantSpecs.const_source_location(:ConstSource)
+        ConstantSpecs::BEFORE_DEFINE_LOCATION.should == autoload_location
+      end
+    end
   end
 end

--- a/spec/ruby/core/module/fixtures/autoload_const_source_location.rb
+++ b/spec/ruby/core/module/fixtures/autoload_const_source_location.rb
@@ -1,0 +1,6 @@
+module ConstantSpecs
+  BEFORE_DEFINE_LOCATION = const_source_location(:ConstSource)
+  module ConstSource
+    LOCATION = Object.const_source_location(name)
+  end
+end

--- a/variable.c
+++ b/variable.c
@@ -3183,6 +3183,19 @@ rb_const_location_from(VALUE klass, ID id, int exclude, int recurse, int visibil
             if (exclude && klass == rb_cObject) {
                 goto not_found;
             }
+
+            if (UNDEF_P(ce->value)) { // autoload
+                VALUE autoload_const_value = autoload_data(klass, id);
+                if (RTEST(autoload_const_value)) {
+                    struct autoload_const *autoload_const;
+                    struct autoload_data *autoload_data = get_autoload_data(autoload_const_value, &autoload_const);
+
+                    if (!UNDEF_P(autoload_const->value) && RTEST(rb_mutex_owned_p(autoload_data->mutex))) {
+                        return rb_assoc_new(autoload_const->file, INT2NUM(autoload_const->line));
+                    }
+                }
+            }
+
             if (NIL_P(ce->file)) return rb_ary_new();
             return rb_assoc_new(ce->file, INT2NUM(ce->line));
         }


### PR DESCRIPTION
[[Bug #20188]](https://bugs.ruby-lang.org/issues/20188)

Ref: https://github.com/fxn/zeitwerk/issues/281#issuecomment-1893228355

Previously, it would only return the real constant location once the
autoload was fully completed.