### PR TITLE
Set `CHECK_LEAKS` in spec/default.mspec

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -43,9 +43,6 @@ RUBYLIB       = $(PATH_SEPARATOR)
 RUBYOPT       = -
 RUN_OPTS      = --disable-gems
 
-# Enabld leakcheckers by ruby/mspec
-CHECK_LEAKS = true
-
 # GITPULLOPTIONS = --no-tags
 
 PRISM_SRCDIR = $(srcdir)/prism

--- a/spec/default.mspec
+++ b/spec/default.mspec
@@ -3,6 +3,10 @@ $VERBOSE = false
 if (opt = ENV["RUBYOPT"]) and (opt = opt.dup).sub!(/(?:\A|\s)-w(?=\z|\s)/, '')
   ENV["RUBYOPT"] = opt
 end
+
+# Enabld leakcheckers by ruby/mspec
+ENV["CHECK_LEAKS"] ||= "true"
+
 require "./rbconfig" unless defined?(RbConfig)
 require_relative "../tool/test-coverage" if ENV.key?("COVERAGE")
 load File.dirname(__FILE__) + '/ruby/default.mspec'


### PR DESCRIPTION
Because of `.NOEXPORT:` in template/Makefile.in, variables in common.mk will not be exported.