### PR TITLE
Clear coderange when rb_str_resize change size

### DIFF
--- a/ext/-test-/string/set_len.c
+++ b/ext/-test-/string/set_len.c
@@ -16,9 +16,17 @@ bug_str_append(VALUE str, VALUE addendum)
     return str;
 }
 
+static VALUE
+bug_str_resize(VALUE str, VALUE len)
+{
+    rb_str_resize(str, NUM2LONG(len));
+    return str;
+}
+
 void
 Init_string_set_len(VALUE klass)
 {
     rb_define_method(klass, "set_len", bug_str_set_len, 1);
     rb_define_method(klass, "append", bug_str_append, 1);
+    rb_define_method(klass, "resize", bug_str_resize, 1);
 }

--- a/string.c
+++ b/string.c
@@ -3111,8 +3111,7 @@ rb_str_resize(VALUE str, long len)
     long slen = RSTRING_LEN(str);
     const int termlen = TERM_LEN(str);
 
-    if ((slen > len && ENC_CODERANGE(str) != ENC_CODERANGE_7BIT) ||
-        (termlen > 1 && (slen % termlen == 0) != (len % termlen == 0))) {
+    if (slen > len || (termlen != 1 && slen < len)) {
         ENC_CODERANGE_CLEAR(str);
     }
 

--- a/string.c
+++ b/string.c
@@ -3109,14 +3109,15 @@ rb_str_resize(VALUE str, long len)
 
     int independent = str_independent(str);
     long slen = RSTRING_LEN(str);
+    const int termlen = TERM_LEN(str);
 
-    if (slen > len && ENC_CODERANGE(str) != ENC_CODERANGE_7BIT) {
+    if ((slen > len && ENC_CODERANGE(str) != ENC_CODERANGE_7BIT) ||
+        (termlen > 1 && (slen % termlen == 0) != (len % termlen == 0))) {
         ENC_CODERANGE_CLEAR(str);
     }
 
     {
         long capa;
-        const int termlen = TERM_LEN(str);
         if (STR_EMBED_P(str)) {
             if (len == slen) return str;
             if (str_embed_capa(str) >= len + termlen) {

--- a/test/-ext-/string/test_set_len.rb
+++ b/test/-ext-/string/test_set_len.rb
@@ -63,4 +63,22 @@ class Test_StrSetLen < Test::Unit::TestCase
     assert_not_predicate str, :ascii_only?
     assert_equal u, str
   end
+
+  def test_valid_encoding_after_resized
+    s = "\0\0".force_encoding(Encoding::UTF_16BE)
+    str = Bug::String.new(s)
+    assert_predicate str, :valid_encoding?
+    str.resize(1)
+    assert_not_predicate str, :valid_encoding?
+    str.resize(2)
+    assert_predicate str, :valid_encoding?
+    str.resize(3)
+    assert_not_predicate str, :valid_encoding?
+
+    s = "\xDB\x00\xDC\x00".force_encoding(Encoding::UTF_16BE)
+    str = Bug::String.new(s)
+    assert_predicate str, :valid_encoding?
+    str.resize(2)
+    assert_not_predicate str, :valid_encoding?
+  end
 end


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/20189

`rb_str_resize` was clearing coderange only when size shrinks
```c
if (slen > len && ENC_CODERANGE(str) != ENC_CODERANGE_7BIT) {
  ENC_CODERANGE_CLEAR(str);
}
```
But coderange should be cleared also when size is extended.

```
Example of coderange change with extend
"\x7f" (invalid utf16) → "\x7f\x00" (valid utf16)
"\x7f\x7f" (valid utf16) → "\x7f\x7f\x00" (invalid utf16)
```




Every existing encoding except utf16 utf32 does not end with `"\0"`.
```ruby
Encoding.list.select do |encoding|
  (0..0x10ffff).any? do |codepoint|
    bytes = codepoint.chr(encoding).bytes
    bytes != [0] && bytes.last == 0
  rescue
    false
  end
end
#=> [#<Encoding:UTF-16BE>, #<Encoding:UTF-16LE>, #<Encoding:UTF-32BE>, #<Encoding:UTF-32LE>]
```

Extending with \0 will change coderange only on these four encodings. These are the only encodings which is `TERM_LEN > 1`.
