### PR TITLE
Fix coderange of invalid_encoding_string.<<(ord)

### DIFF
--- a/string.c
+++ b/string.c
@@ -3522,8 +3522,12 @@ rb_str_concat(VALUE str1, VALUE str2)
         }
         rb_str_resize(str1, pos+len);
         memcpy(RSTRING_PTR(str1) + pos, buf, len);
-        if (cr == ENC_CODERANGE_7BIT && code > 127)
+        if (cr == ENC_CODERANGE_7BIT && code > 127) {
             cr = ENC_CODERANGE_VALID;
+        }
+        else if (cr == ENC_CODERANGE_BROKEN) {
+            cr = ENC_CODERANGE_UNKNOWN;
+        }
         ENC_CODERANGE_SET(str1, cr);
     }
     return str1;

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -301,6 +301,9 @@ CODE
     assert_raise(RangeError, bug) {S("a".force_encoding(Encoding::UTF_8)) << -1}
     assert_raise(RangeError, bug) {S("a".force_encoding(Encoding::UTF_8)) << 0x81308130}
     assert_nothing_raised {S("a".force_encoding(Encoding::GB18030)) << 0x81308130}
+
+    s = "\x95".force_encoding(Encoding::SJIS).tap(&:valid_encoding?)
+    assert_predicate(s << 0x5c, :valid_encoding?)
   end
 
   def test_MATCH # '=~'


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/20190

In some encoding, appending valid encoding character can change coderange from invalid to valid, so ENC_CODERANGE_BROKEN should be cleared.

Example: `"表".encode('sjis')` is `"\x95\x5C"`, `"\\"` is `"\x5C"`
`"\x95".force_encoding('sjis')<<0x5C` should be a valid encoding string.
