### PR TITLE
[PRISM] Fix crash with empty ensure blocks

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3279,14 +3279,16 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                     PM_PUTNIL_UNLESS_POPPED;
                 }
             }
+
             ADD_LABEL(ret, eend);
+            ADD_LABEL(ret, econt);
+
             if (!popped) {
                 PM_NOP;
             }
             pm_statements_node_t *statements = begin_node->ensure_clause->statements;
             if (statements) {
                 PM_COMPILE((pm_node_t *)statements);
-                ADD_LABEL(ret, econt);
                 PM_POP_UNLESS_POPPED;
             }
 

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -961,6 +961,22 @@ module Prism
         end
         prism_test_ensure_node
       CODE
+
+      # Test empty ensure block
+      assert_prism_eval(<<~RUBY)
+        res = []
+
+        begin
+          begin
+            raise
+          ensure
+          end
+        rescue
+          res << "rescue"
+        end
+
+        res
+      RUBY
     end
 
     def test_NextNode


### PR DESCRIPTION
Fixes ruby/prism#2179.