### PR TITLE
[PRISM] Fix test_compile_prism_with_file

### DIFF
--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -805,10 +805,7 @@ class TestISeq < Test::Unit::TestCase
       f.close
 
       assert_nothing_raised(TypeError) do
-        begin
-          RubyVM::InstructionSequence.compile_prism(f.path)
-        rescue SyntaxError
-        end
+        RubyVM::InstructionSequence.compile_prism(f)
       end
     end
   end


### PR DESCRIPTION
The test should be testing RubyVM::InstructionSequence.compile_prism with a file but it is instead passing the file path (which is a string) which raises a SyntaxError because it is not Ruby syntax.