### PR TITLE
[Prism] Fix more method call argumnents

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1365,6 +1365,46 @@ module Prism
       CODE
     end
 
+    def test_trailing_keyword_method_params
+      # foo(1, b: 2, c: 3) # argc -> 3
+      assert_prism_eval("def self.foo(a, b:, c:); [a, b, c]; end; foo(1, b: 2, c: 3)")
+    end
+
+    def test_keyword_method_params_only
+      # foo(a: 1, b: 2) # argc -> 2
+      assert_prism_eval("def self.foo(a:, b:); [a, b]; end; foo(a: 1, b: 2)")
+    end
+
+    def test_keyword_method_params_with_splat
+      # foo(a: 1, **b) # argc -> 1
+      assert_prism_eval("def self.foo(a:, b:); [a, b]; end; b = { b: 2 }; foo(a: 1, **b)")
+    end
+
+    def test_positional_and_splat_keyword_method_params
+      # foo(a, **b) # argc -> 2
+      assert_prism_eval("def self.foo(a, b); [a, b]; end; b = { b: 2 }; foo(1, **b)")
+    end
+
+    def test_positional_and_splat_method_params
+      # foo(a, *b, c, *d, e) # argc -> 2
+      assert_prism_eval("def self.foo(a, b, c, d, e); [a, b, c, d, e]; end; b = [2]; d = [4]; foo(1, *b, 3, *d, 5)")
+    end
+
+    def test_positional_with_splat_and_splat_keyword_method_params
+      # foo(a, *b, c, *d, **e) # argc -> 3
+      assert_prism_eval("def self.foo(a, b, c, d, e); [a, b, c, d, e]; end; b = [2]; d = [4]; e = { e: 5 }; foo(1, *b, 3, *d, **e)")
+    end
+
+    def test_positional_with_splat_and_keyword_method_params
+      # foo(a, *b, c, *d, e:) # argc -> 3
+      assert_prism_eval("def self.foo(a, b, c, d, e:); [a, b, c, d, e]; end; b = [2]; d = [4]; foo(1, *b, 3, *d, e: 5)")
+    end
+
+    def test_leading_splat_and_keyword_method_params
+      # foo(*a, b:) # argc -> 2
+      assert_prism_eval("def self.foo(a, b:); [a, b]; end; a = [1]; foo(*a, b: 2)")
+    end
+
     def test_repeated_method_params
       assert_prism_eval("def self.foo(_a, _a); _a; end; foo(1, 2)")
     end


### PR DESCRIPTION
In #2087 it was noted that there was a bug in the number of arguments in `SplatNode` and `KeywordHashNode`. I looked into this with Aaron before the linked PR was merged and we found a bunch of cases that weren't working quite right. This PR aims to fix some of those cases, but there may be more.

A splat argument followed by a positional argument will concat the array until the end or unless the argument is a kwarg or splat kwarg. For example

```
foo(a, *b, c, *d, e)
```

Will have an `argc` of 2, because `b`, `c`, `d`, and `e` will be concatenated together.

```
foo(a, *b, c, *d, **e)
```

Will have an `argc` of 3, because `b`, `c`, and `d` will be concatenated together and `e` is a separate argument.