### PR TITLE
[PRISM] Fix memory leak when compiling file

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -1477,23 +1477,26 @@ iseqw_s_compile_prism(int argc, VALUE *argv, VALUE self)
 
     pm_parser_t parser;
 
+    pm_string_t input;
     if (RB_TYPE_P(src, T_FILE)) {
         FilePathValue(src);
         file = rb_fstring(src); /* rb_io_t->pathv gets frozen anyways */
 
-        pm_string_t input;
         pm_string_mapped_init(&input, RSTRING_PTR(file));
-
-        pm_parser_init(&parser, pm_string_source(&input), pm_string_length(&input), &options);
     }
     else {
-        pm_parser_init(&parser, (const uint8_t *) RSTRING_PTR(src), RSTRING_LEN(src), &options);
+        input.source = (const uint8_t *)RSTRING_PTR(src);
+        input.length = RSTRING_LEN(src);
+        input.type = PM_STRING_SHARED;
     }
+
+    pm_parser_init(&parser, pm_string_source(&input), pm_string_length(&input), &options);
 
     rb_iseq_t *iseq = iseq_alloc();
     iseqw_s_compile_prism_compile(&parser, opt, iseq, file, path, start_line);
     pm_parser_free(&parser);
     pm_options_free(&options);
+    pm_string_free(&input);
 
     return iseqw_new(iseq);
 }


### PR DESCRIPTION
There is a memory leak when passing a file to
RubyVM::InstructionSequence.compile_prism because it does not free the mapped file.

For example:

```ruby
require "tempfile"

Tempfile.create(%w"test_iseq .rb") do |f|
  f.puts "name = 'Prism'; puts 'hello'"
  f.close

  10.times do
    1_000.times do
      RubyVM::InstructionSequence.compile_prism(f)
    end

    puts `ps -o rss= -p #{$$}`
  end
end
```

Before:

    27968
    44848
    61408
    77872
    94144
    110432
    126640
    142816
    159200
    175584

After:

    11504
    12144
    12592
    13072
    13488
    13664
    14064
    14368
    14704
    15168