### PR TITLE
Fix determing if option inside magic comments requires an arguement

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -1375,7 +1375,7 @@ proc_long_options(ruby_cmdline_options_t *opt, const char *s, long argc, char **
 # define is_option_with_arg(name, allow_hyphen, allow_envopt)           \
     is_option_with_optarg(name, allow_hyphen, allow_envopt, Qtrue, Qtrue)
 # define is_option_with_optarg(name, allow_hyphen, allow_envopt, needs_arg, next_arg) \
-    (strncmp((name), s, n = sizeof(name) - 1) == 0 && is_option_end(s[n], (allow_hyphen)) && \
+    (strncmp((name), s, n = sizeof(name) - 1) == 0 && (s[n]) && is_option_end(s[n], (allow_hyphen)) && \
      (s[n] != '-' || s[n+1]) ?                                          \
      (check_envopt(name, (allow_envopt)), s += n,                       \
       need_argument(name, s, needs_arg, next_arg), 1) : 0)


### PR DESCRIPTION
Test:
```
$ echo '#!ruby -0 --disable' > file.rb
$ ruby file.rb
```
Ruby crashed with segmentation fault, because `is_option_with_arg("disable", Qtrue, Qtrue)` in ruby.c:1399 (per tree of commit 7b6731b1bb7c8fab72580f92450eea6e4cc3d943) returned true, while it must return false.

But
```
$ ruby -0 --disable
```
does not crash, `is_option_with_arg("disable", Qtrue, Qtrue)` in ruby.c:1399 correctly returns false.

I suspect that a good fix must be done somewhere else, but I cannot understand the difference between two cases described above, so just adding a check.

Not sure that this patch does not break anything.