### PR TITLE
Prism 2188 missing defined nodes 1

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2480,6 +2480,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_RANGE_NODE:
       case PM_REDO_NODE:
       case PM_REGULAR_EXPRESSION_NODE:
+      case PM_RETRY_NODE:
       case PM_RETURN_NODE:
       case PM_SOURCE_ENCODING_NODE:
       case PM_SOURCE_FILE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2470,6 +2470,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_INTEGER_NODE:
       case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE:
       case PM_INTERPOLATED_STRING_NODE:
+      case PM_INTERPOLATED_SYMBOL_NODE:
       case PM_KEYWORD_HASH_NODE:
       case PM_LAMBDA_NODE:
       case PM_MATCH_PREDICATE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2462,6 +2462,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
           }
       }
       case PM_AND_NODE:
+      case PM_BREAK_NODE:
       case PM_FLOAT_NODE:
       case PM_HASH_NODE:
       case PM_IMAGINARY_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2471,6 +2471,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE:
       case PM_INTERPOLATED_STRING_NODE:
       case PM_INTERPOLATED_SYMBOL_NODE:
+      case PM_INTERPOLATED_X_STRING_NODE:
       case PM_KEYWORD_HASH_NODE:
       case PM_LAMBDA_NODE:
       case PM_MATCH_PREDICATE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2462,6 +2462,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
           }
       }
       case PM_AND_NODE:
+      case PM_BEGIN_NODE:
       case PM_BREAK_NODE:
       case PM_DEFINED_NODE:
       case PM_FLOAT_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2471,6 +2471,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_KEYWORD_HASH_NODE:
       case PM_LAMBDA_NODE:
       case PM_MATCH_PREDICATE_NODE:
+      case PM_NEXT_NODE:
       case PM_OR_NODE:
       case PM_RANGE_NODE:
       case PM_REGULAR_EXPRESSION_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2463,6 +2463,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       }
       case PM_AND_NODE:
       case PM_BREAK_NODE:
+      case PM_DEFINED_NODE:
       case PM_FLOAT_NODE:
       case PM_HASH_NODE:
       case PM_IMAGINARY_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2480,6 +2480,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_RANGE_NODE:
       case PM_REDO_NODE:
       case PM_REGULAR_EXPRESSION_NODE:
+      case PM_RETURN_NODE:
       case PM_SOURCE_ENCODING_NODE:
       case PM_SOURCE_FILE_NODE:
       case PM_SOURCE_LINE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2478,6 +2478,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_NEXT_NODE:
       case PM_OR_NODE:
       case PM_RANGE_NODE:
+      case PM_REDO_NODE:
       case PM_REGULAR_EXPRESSION_NODE:
       case PM_SOURCE_ENCODING_NODE:
       case PM_SOURCE_FILE_NODE:

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -223,6 +223,7 @@ module Prism
       assert_prism_eval("defined?(break)")
       assert_prism_eval("defined?(defined?(a))")
       assert_prism_eval('defined?(:"#{1}")')
+      assert_prism_eval("defined?(`echo #{1}`)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -222,6 +222,7 @@ module Prism
       assert_prism_eval("defined?(next)")
       assert_prism_eval("defined?(break)")
       assert_prism_eval("defined?(defined?(a))")
+      assert_prism_eval('defined?(:"#{1}")')
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -221,6 +221,7 @@ module Prism
 
       assert_prism_eval("defined?(next)")
       assert_prism_eval("defined?(break)")
+      assert_prism_eval("defined?(defined?(a))")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -218,6 +218,8 @@ module Prism
 
         defined?(PrismDefinedNode.new.m1)
       RUBY
+
+      assert_prism_eval("defined?(next)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -222,8 +222,15 @@ module Prism
       assert_prism_eval("defined?(next)")
       assert_prism_eval("defined?(break)")
       assert_prism_eval("defined?(redo)")
-      assert_prism_eval("defined?(return)")
       assert_prism_eval("defined?(retry)")
+
+      assert_prism_eval(<<~RUBY)
+        class PrismDefinedReturnNode
+          def self.m1; defined?(return) end
+        end
+
+        PrismDefinedReturnNode.m1
+      RUBY
 
       assert_prism_eval("defined?(begin; 1; end)")
 

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -221,6 +221,7 @@ module Prism
 
       assert_prism_eval("defined?(next)")
       assert_prism_eval("defined?(break)")
+      assert_prism_eval("defined?(redo)")
       assert_prism_eval("defined?(defined?(a))")
       assert_prism_eval('defined?(:"#{1}")')
       assert_prism_eval("defined?(`echo #{1}`)")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -220,6 +220,7 @@ module Prism
       RUBY
 
       assert_prism_eval("defined?(next)")
+      assert_prism_eval("defined?(break)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -223,6 +223,8 @@ module Prism
       assert_prism_eval("defined?(break)")
       assert_prism_eval("defined?(redo)")
       assert_prism_eval("defined?(return)")
+      assert_prism_eval("defined?(retry)")
+
       assert_prism_eval("defined?(defined?(a))")
       assert_prism_eval('defined?(:"#{1}")')
       assert_prism_eval("defined?(`echo #{1}`)")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -222,6 +222,7 @@ module Prism
       assert_prism_eval("defined?(next)")
       assert_prism_eval("defined?(break)")
       assert_prism_eval("defined?(redo)")
+      assert_prism_eval("defined?(return)")
       assert_prism_eval("defined?(defined?(a))")
       assert_prism_eval('defined?(:"#{1}")')
       assert_prism_eval("defined?(`echo #{1}`)")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -225,6 +225,8 @@ module Prism
       assert_prism_eval("defined?(return)")
       assert_prism_eval("defined?(retry)")
 
+      assert_prism_eval("defined?(begin; 1; end)")
+
       assert_prism_eval("defined?(defined?(a))")
       assert_prism_eval('defined?(:"#{1}")')
       assert_prism_eval("defined?(`echo #{1}`)")


### PR DESCRIPTION
This PR implements the following nodes for `defined?`

* `PM_BEGIN_NODE`
* `PM_RETRY_NODE`
* `PM_RETURN_NODE`
* `PM_REDO_NODE`
* `PM_INTERPOLATED_X_STRING_NODE`
* `PM_INTERPOLATED_SYMBOL_NODE`
* `PM_DEFINED_NODE`
* `PM_BREAK_NODE`
* `PM_NEXT_NODE`

Instructions for all of these look like the following:


```
"********* Ruby *************"
== disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(59,15)>
0000 putobject                              "expression"              (  59)[Li]
0002 leave
"********* PRISM *************"
== disasm: #<ISeq:<compiled>@<compiled>:58 (58,0)-(58,15)>
0000 putobject                              "expression"              (  58)[Li]
0002 leave
```

Related to ruby/prism#2188 - I'm going to open PRs for the missing `defined?` nodes in batches as I finish them.