### PR TITLE
Bump the required BASERUBY version to 2.7

### DIFF
--- a/.github/workflows/baseruby.yml
+++ b/.github/workflows/baseruby.yml
@@ -50,9 +50,7 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - ruby-2.5
-#         - ruby-2.6
-#         - ruby-2.7
+          - ruby-2.7
           - ruby-3.0
           - ruby-3.1
           - ruby-3.2

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -59,7 +59,7 @@ jobs:
         include:
           # To mitigate flakiness of MinGW CI, we test only one runtime that newer MSYS2 uses.
           - msystem: 'UCRT64'
-            base_ruby: head
+            baseruby: '2.7'
             test_task: 'check'
             test-all-opts: '--name=!/TestObjSpace#test_reachable_objects_during_iteration/'
       fail-fast: false
@@ -76,7 +76,7 @@ jobs:
       - name: Set up Ruby & MSYS2
         uses: ruby/setup-ruby@360dc864d5da99d54fcb8e9148c14a84b90d3e88 # v1.165.1
         with:
-          ruby-version: ${{ matrix.base_ruby }}
+          ruby-version: ${{ matrix.baseruby }}
 
       - name: where check
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,10 +96,6 @@ jobs:
             ${{ steps.find-tools.outputs.needs }}
         if: ${{ steps.find-tools.outputs.needs != '' }}
 
-      - uses: ruby/setup-ruby@360dc864d5da99d54fcb8e9148c14a84b90d3e88 # v1.165.1
-        with:
-          ruby-version: '2.7'
-
       - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         with:
           path: C:\vcpkg\downloads
@@ -137,6 +133,7 @@ jobs:
           builddir: build
 
       - name: setup env
+        # Available Ruby versions: https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md#ruby
         # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
         # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302
         run: |
@@ -150,9 +147,13 @@ jobs:
           set TEMP=%USERPROFILE%\AppData\Local\Temp
           set MAKEFLAGS=l
           set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul
+          set PATH=C:\hostedtoolcache\windows\Ruby\2.7.8\x64\bin;%PATH%
           set | C:\msys64\usr\bin\sort > new.env
           C:\msys64\usr\bin\comm -13 old.env new.env >> %GITHUB_ENV%
           del *.env
+
+      - name: baseruby version
+        run: ruby -v
 
       - name: compiler version
         run: cl

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,6 +96,10 @@ jobs:
             ${{ steps.find-tools.outputs.needs }}
         if: ${{ steps.find-tools.outputs.needs != '' }}
 
+      - uses: ruby/setup-ruby@360dc864d5da99d54fcb8e9148c14a84b90d3e88 # v1.165.1
+        with:
+          ruby-version: '2.7'
+
       - uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
         with:
           path: C:\vcpkg\downloads

--- a/configure.ac
+++ b/configure.ac
@@ -75,8 +75,8 @@ AC_ARG_WITH(baseruby,
 	[
 		AC_PATH_PROG([BASERUBY], [ruby], [false])
 	])
-# BASERUBY must be >= 2.5.0. Note that `"2.5.0" > "2.5"` is true.
-AS_IF([test "$HAVE_BASERUBY" != no -a "`RUBYOPT=- $BASERUBY --disable=gems -e 'print 42 if RUBY_VERSION > "2.5"' 2>/dev/null`" = 42], [
+# BASERUBY must be >= 2.7.0. Note that `"2.7.0" > "2.7"` is true.
+AS_IF([test "$HAVE_BASERUBY" != no -a "`RUBYOPT=- $BASERUBY --disable=gems -e 'print 42 if RUBY_VERSION > "2.7"' 2>/dev/null`" = 42], [
     AS_CASE(["$build_os"], [mingw*], [
         # Can MSys shell run a command with a drive letter?
         RUBYOPT=- `cygpath -ma "$BASERUBY"` --disable=gems -e exit 2>/dev/null || HAVE_BASERUBY=no


### PR DESCRIPTION
[[Misc #16671]](https://bugs.ruby-lang.org/issues/16671)

We gave up on Ruby 2.7 at https://github.com/ruby/ruby/pull/7504, but we no longer have AppVeyor or use bionic for ruby-ci-image. Since windows-2019 has Ruby 2.7 in Cached Tools https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md, we can use it through ruby/setup-ruby.

It means that we can now bump the required BASERUBY version to 2.7.