### PR TITLE
YJIT: Support empty splat and some block_arg calls to ivar getters

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -400,6 +400,7 @@ make_counters! {
 
     // Method calls that exit to the interpreter
     guard_send_block_arg_type,
+    guard_send_getter_splat_non_empty,
     guard_send_klass_megamorphic,
     guard_send_se_cf_overflow,
     guard_send_se_protected_check_failed,


### PR DESCRIPTION
These seem odd at first glance, but they're used with `...` calls with
`Module#delegate` from Active Support. These account for ~3% of fallback
reasons in the `lobsters` benchmark.
