### PR TITLE
Don't zero out existing coverage of eval'ed code.

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2487,7 +2487,8 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                         !(rb_get_coverage_mode() & COVERAGE_TARGET_ONESHOT_LINES)) {
                         int line = iobj->insn_info.line_no - 1;
                         if (line >= 0 && line < RARRAY_LEN(ISEQ_LINE_COVERAGE(iseq))) {
-                            RARRAY_ASET(ISEQ_LINE_COVERAGE(iseq), line, INT2FIX(0));
+                            if (RARRAY_AREF(ISEQ_LINE_COVERAGE(iseq), line) == Qnil)
+                                RARRAY_ASET(ISEQ_LINE_COVERAGE(iseq), line, INT2FIX(0));
                         }
                     }
                     if (ISEQ_BRANCH_COVERAGE(iseq) && (events & RUBY_EVENT_COVERAGE_BRANCH)) {

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -181,6 +181,18 @@ class TestCoverage < Test::Unit::TestCase
     end;
   end
 
+  def test_eval_coverage_repeated
+    assert_in_out_err(%w[-rcoverage], <<-"end;", ["[3]"], [])
+      Coverage.start(eval: true, lines: true)
+
+      3.times do
+        eval("Object.new", nil, "test.rb")
+      end
+
+      p Coverage.result["test.rb"][:lines]
+    end;
+  end
+
   def test_coverage_supported
     assert Coverage.supported?(:lines)
     assert Coverage.supported?(:oneshot_lines)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19857