### PR TITLE
[PRISM] Fix memory leak of ST table

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6862,6 +6862,8 @@ rb_translate_prism(pm_parser_t *parser, rb_iseq_t *iseq, pm_scope_node_t *scope_
     pm_compile_node(iseq, (pm_node_t *)scope_node, ret, scope_node->base.location.start, false, (pm_scope_node_t *)scope_node);
     iseq_set_sequence(iseq, ret);
 
+    st_free_table(index_lookup_table);
+
     return Qnil;
 }
 


### PR DESCRIPTION
This commit fixes a memory leak in rb_translate_prism because the ST table is never freed. There are still more memory leaks which still need to be fixed.

For example:

```ruby
10.times do
  100_000.times do
    RubyVM::InstructionSequence.compile_prism("")
  end

  puts `ps -o rss= -p #{$$}`
end
```

Before:

    34544
    57120
    79360
    102176
    123712
    146320
    168192
    190592
    212192
    234896

After:

    18336
    24592
    31488
    37648
    44592
    50944
    57280
    63632
    69904
    76160