### PR TITLE
[Prism] Implement missing `defined?` nodes that use `assignment`

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2648,6 +2648,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
 
       case PM_INDEX_AND_WRITE_NODE:
       case PM_INDEX_OPERATOR_WRITE_NODE:
+      case PM_INDEX_OR_WRITE_NODE:
 
       case PM_INSTANCE_VARIABLE_WRITE_NODE:
       case PM_INSTANCE_VARIABLE_OPERATOR_WRITE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2634,6 +2634,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_CONSTANT_PATH_AND_WRITE_NODE:
       case PM_CONSTANT_PATH_OPERATOR_WRITE_NODE:
       case PM_CONSTANT_PATH_OR_WRITE_NODE:
+      case PM_CONSTANT_PATH_WRITE_NODE:
 
       case PM_GLOBAL_VARIABLE_WRITE_NODE:
       case PM_GLOBAL_VARIABLE_OPERATOR_WRITE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2624,6 +2624,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
         return;
       case PM_CALL_AND_WRITE_NODE:
       case PM_CALL_OPERATOR_WRITE_NODE:
+      case PM_CALL_OR_WRITE_NODE:
 
       case PM_CONSTANT_WRITE_NODE:
       case PM_CONSTANT_OPERATOR_WRITE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2631,6 +2631,8 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_CONSTANT_AND_WRITE_NODE:
       case PM_CONSTANT_OR_WRITE_NODE:
 
+      case PM_CONSTANT_PATH_AND_WRITE_NODE:
+
       case PM_GLOBAL_VARIABLE_WRITE_NODE:
       case PM_GLOBAL_VARIABLE_OPERATOR_WRITE_NODE:
       case PM_GLOBAL_VARIABLE_AND_WRITE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2632,6 +2632,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_CONSTANT_OR_WRITE_NODE:
 
       case PM_CONSTANT_PATH_AND_WRITE_NODE:
+      case PM_CONSTANT_PATH_OPERATOR_WRITE_NODE:
 
       case PM_GLOBAL_VARIABLE_WRITE_NODE:
       case PM_GLOBAL_VARIABLE_OPERATOR_WRITE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2647,6 +2647,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_CLASS_VARIABLE_OR_WRITE_NODE:
 
       case PM_INDEX_AND_WRITE_NODE:
+      case PM_INDEX_OPERATOR_WRITE_NODE:
 
       case PM_INSTANCE_VARIABLE_WRITE_NODE:
       case PM_INSTANCE_VARIABLE_OPERATOR_WRITE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2623,6 +2623,8 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
                   PUSH_VAL(DEFINED_ZSUPER));
         return;
       case PM_CALL_AND_WRITE_NODE:
+      case PM_CALL_OPERATOR_WRITE_NODE:
+
       case PM_CONSTANT_WRITE_NODE:
       case PM_CONSTANT_OPERATOR_WRITE_NODE:
       case PM_CONSTANT_AND_WRITE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2633,6 +2633,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
 
       case PM_CONSTANT_PATH_AND_WRITE_NODE:
       case PM_CONSTANT_PATH_OPERATOR_WRITE_NODE:
+      case PM_CONSTANT_PATH_OR_WRITE_NODE:
 
       case PM_GLOBAL_VARIABLE_WRITE_NODE:
       case PM_GLOBAL_VARIABLE_OPERATOR_WRITE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2622,6 +2622,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
         ADD_INSN3(ret, &dummy_line_node, defined, INT2FIX(DEFINED_ZSUPER), 0,
                   PUSH_VAL(DEFINED_ZSUPER));
         return;
+      case PM_CALL_AND_WRITE_NODE:
       case PM_CONSTANT_WRITE_NODE:
       case PM_CONSTANT_OPERATOR_WRITE_NODE:
       case PM_CONSTANT_AND_WRITE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2646,6 +2646,8 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_CLASS_VARIABLE_AND_WRITE_NODE:
       case PM_CLASS_VARIABLE_OR_WRITE_NODE:
 
+      case PM_INDEX_AND_WRITE_NODE:
+
       case PM_INSTANCE_VARIABLE_WRITE_NODE:
       case PM_INSTANCE_VARIABLE_OPERATOR_WRITE_NODE:
       case PM_INSTANCE_VARIABLE_AND_WRITE_NODE:

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -241,6 +241,7 @@ module Prism
       assert_prism_eval("defined?(PrismTestSubclass.test_call_and_write_node &&= 1)")
       assert_prism_eval("defined?(PrismTestSubclass.test_call_operator_write_node += 1)")
       assert_prism_eval("defined?(PrismTestSubclass.test_call_or_write_node ||= 1)")
+      assert_prism_eval("defined?(Prism::CPAWN &&= 1)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -242,6 +242,7 @@ module Prism
       assert_prism_eval("defined?(PrismTestSubclass.test_call_operator_write_node += 1)")
       assert_prism_eval("defined?(PrismTestSubclass.test_call_or_write_node ||= 1)")
       assert_prism_eval("defined?(Prism::CPAWN &&= 1)")
+      assert_prism_eval("defined?(Prism::CPOWN += 1)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -244,6 +244,7 @@ module Prism
       assert_prism_eval("defined?(Prism::CPAWN &&= 1)")
       assert_prism_eval("defined?(Prism::CPOWN += 1)")
       assert_prism_eval("defined?(Prism::CPOrWN ||= 1)")
+      assert_prism_eval("defined?(Prism::CPWN = 1)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -247,6 +247,7 @@ module Prism
       assert_prism_eval("defined?(Prism::CPWN = 1)")
       assert_prism_eval("defined?([0][0] &&= 1)")
       assert_prism_eval("defined?([0][0] += 1)")
+      assert_prism_eval("defined?([0][0] ||= 1)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -246,6 +246,7 @@ module Prism
       assert_prism_eval("defined?(Prism::CPOrWN ||= 1)")
       assert_prism_eval("defined?(Prism::CPWN = 1)")
       assert_prism_eval("defined?([0][0] &&= 1)")
+      assert_prism_eval("defined?([0][0] += 1)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -237,6 +237,8 @@ module Prism
       assert_prism_eval("defined?(defined?(a))")
       assert_prism_eval('defined?(:"#{1}")')
       assert_prism_eval("defined?(`echo #{1}`)")
+
+      assert_prism_eval("defined?(PrismTestSubclass.test_call_and_write_node &&= 1)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -239,6 +239,7 @@ module Prism
       assert_prism_eval("defined?(`echo #{1}`)")
 
       assert_prism_eval("defined?(PrismTestSubclass.test_call_and_write_node &&= 1)")
+      assert_prism_eval("defined?(PrismTestSubclass.test_call_operator_write_node += 1)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -245,6 +245,7 @@ module Prism
       assert_prism_eval("defined?(Prism::CPOWN += 1)")
       assert_prism_eval("defined?(Prism::CPOrWN ||= 1)")
       assert_prism_eval("defined?(Prism::CPWN = 1)")
+      assert_prism_eval("defined?([0][0] &&= 1)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -243,6 +243,7 @@ module Prism
       assert_prism_eval("defined?(PrismTestSubclass.test_call_or_write_node ||= 1)")
       assert_prism_eval("defined?(Prism::CPAWN &&= 1)")
       assert_prism_eval("defined?(Prism::CPOWN += 1)")
+      assert_prism_eval("defined?(Prism::CPOrWN ||= 1)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -240,6 +240,7 @@ module Prism
 
       assert_prism_eval("defined?(PrismTestSubclass.test_call_and_write_node &&= 1)")
       assert_prism_eval("defined?(PrismTestSubclass.test_call_operator_write_node += 1)")
+      assert_prism_eval("defined?(PrismTestSubclass.test_call_or_write_node ||= 1)")
     end
 
     def test_GlobalVariableReadNode


### PR DESCRIPTION
This PR implements all the nodes for `defined?` that return `assignment` for the instructions. This is part 2 of #2188. Each node is it's own commit. The PR implements the following nodes for `defined?`

- `PM_INDEX_OPERATOR_WRITE_NODE`
- `PM_INDEX_AND_WRITE_NODE`
- `PM_CONSTANT_PATH_WRITE_NODE`
- `PM_CONSTANT_PATH_OR_WRITE_NODE`
- `PM_CONSTANT_PATH_OPERATOR_WRITE_NODE`
- `PM_CONSTANT_PATH_AND_WRITE_NODE`
- `PM_CALL_OR_WRITE_NODE`
- `PM_CALL_OPERATOR_WRITE_NODE`
- `PM_CALL_AND_WRITE_NODE`

The instructions for all of these look like this:

```
"********* Ruby *************"
== disasm: #<ISeq:<compiled>@<compiled>:1 (1,0)-(59,58)>
0000 putobject                              "assignment"              (  59)[Li]
0002 leave
"********* PRISM *************"
== disasm: #<ISeq:<compiled>@<compiled>:58 (58,0)-(58,58)>
0000 putobject                              "assignment"              (  58)[Li]
0002 leave
```

cc/ @kddnewton 