### PR TITLE
[PRISM] Fix fallthrough for PM_ENSURE_NODE

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -4236,6 +4236,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             PM_COMPILE((pm_node_t *)ensure_node->statements);
         }
         ADD_LABEL(ret, end);
+        return;
       }
       case PM_ELSE_NODE: {
           pm_else_node_t *cast = (pm_else_node_t *)node;

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -931,6 +931,21 @@ module Prism
         end
         a
       CODE
+
+      # Test that ensure block only evaluated once
+      assert_prism_eval(<<~RUBY)
+        res = []
+        begin
+          begin
+            raise
+          ensure
+            res << $!.to_s
+          end
+        rescue
+          res
+        end
+      RUBY
+
       assert_prism_eval(<<-CODE)
         a = 1
         begin


### PR DESCRIPTION
This caused it to fall into PM_ELSE_NODE which caused ensure nodes to be compiled twice.

Fixes ruby/prism#2176.