### PR TITLE
[PRISM] Fix crash in compile_prism

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -1485,6 +1485,7 @@ iseqw_s_compile_prism(int argc, VALUE *argv, VALUE self)
         pm_string_mapped_init(&input, RSTRING_PTR(file));
     }
     else {
+        Check_Type(src, T_STRING);
         input.source = (const uint8_t *)RSTRING_PTR(src);
         input.length = RSTRING_LEN(src);
         input.type = PM_STRING_SHARED;

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -809,4 +809,10 @@ class TestISeq < Test::Unit::TestCase
       end
     end
   end
+
+  def test_compile_prism_with_invalid_object_type
+    assert_raise(TypeError) do
+      RubyVM::InstructionSequence.compile_prism(Object.new)
+    end
+  end
 end


### PR DESCRIPTION
If the argument is not a file or a string, it assumes it's a string which will crash because RSTRING_PTR and RSTRING_LEN assumes it's a string.