### PR TITLE
Remove SizedQueue#freeze

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -1652,7 +1652,6 @@ Init_thread_sync(void)
     rb_define_method(rb_cSizedQueue, "clear", rb_szqueue_clear, 0);
     rb_define_method(rb_cSizedQueue, "length", rb_szqueue_length, 0);
     rb_define_method(rb_cSizedQueue, "num_waiting", rb_szqueue_num_waiting, 0);
-    rb_define_method(rb_cSizedQueue, "freeze", rb_queue_freeze, 0);
     rb_define_alias(rb_cSizedQueue, "size", "length");
 
     /* CVar */


### PR DESCRIPTION
Queue#freeze uses the same C function, so SizedQueue#freeze can use that via normal method lookup.

Not sure why I added the method to both classes. Maybe I didn't realize SizedQueue inherited from Queue at the time.