### PR TITLE
Remove null checks for xfree

### DIFF
--- a/ext/-test-/memory_view/memory_view.c
+++ b/ext/-test-/memory_view/memory_view.c
@@ -313,8 +313,8 @@ mdview_get_memory_view(VALUE obj, rb_memory_view_t *view, int flags)
 static bool
 mdview_release_memory_view(VALUE obj, rb_memory_view_t *view)
 {
-    if (view->shape) xfree((void *)view->shape);
-    if (view->strides) xfree((void *)view->strides);
+    xfree((void *)view->shape);
+    xfree((void *)view->strides);
 
     return true;
 }

--- a/gc.c
+++ b/gc.c
@@ -3579,7 +3579,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
         if (rb_shape_obj_too_complex(obj)) {
             st_free_table((st_table *)RCLASS_IVPTR(obj));
         }
-        else if (RCLASS_IVPTR(obj)) {
+        else {
             xfree(RCLASS_IVPTR(obj));
         }
 
@@ -3674,8 +3674,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
             }
 #endif
             onig_region_free(&rm->regs, 0);
-            if (rm->char_offset)
-                xfree(rm->char_offset);
+            xfree(rm->char_offset);
 
             RB_DEBUG_COUNTER_INC(obj_match_ptr);
         }

--- a/iseq.c
+++ b/iseq.c
@@ -182,10 +182,7 @@ rb_iseq_free(const rb_iseq_t *iseq)
         if (LIKELY(body->local_table != rb_iseq_shared_exc_local_tbl))
             ruby_xfree((void *)body->local_table);
         ruby_xfree((void *)body->is_entries);
-
-        if (body->call_data) {
-            ruby_xfree(body->call_data);
-        }
+        ruby_xfree(body->call_data);
         ruby_xfree((void *)body->catch_table);
         ruby_xfree((void *)body->param.opt_table);
         if (ISEQ_MBITS_BUFLEN(body->iseq_size) > 1 && body->mark_bits.list) {

--- a/iseq.h
+++ b/iseq.h
@@ -66,9 +66,7 @@ ISEQ_ORIGINAL_ISEQ_CLEAR(const rb_iseq_t *iseq)
 {
     void *ptr = ISEQ_BODY(iseq)->variable.original_iseq;
     ISEQ_BODY(iseq)->variable.original_iseq = NULL;
-    if (ptr) {
-        ruby_xfree(ptr);
-    }
+    ruby_xfree(ptr);
 }
 
 static inline VALUE *

--- a/marshal.c
+++ b/marshal.c
@@ -2294,10 +2294,8 @@ r_object(struct load_arg *arg)
 static void
 clear_load_arg(struct load_arg *arg)
 {
-    if (arg->buf) {
-        xfree(arg->buf);
-        arg->buf = 0;
-    }
+    xfree(arg->buf);
+    arg->buf = NULL;
     arg->buflen = 0;
     arg->offset = 0;
     arg->readable = 0;

--- a/memory_view.c
+++ b/memory_view.c
@@ -845,9 +845,7 @@ rb_memory_view_release(rb_memory_view_t* view)
         if (rv) {
             unregister_exported_object(view->obj);
             view->obj = Qnil;
-            if (view->item_desc.components) {
-                xfree((void *)view->item_desc.components);
-            }
+            xfree((void *)view->item_desc.components);
         }
         return rv;
     }

--- a/regcomp.c
+++ b/regcomp.c
@@ -5496,10 +5496,8 @@ clear_optimize_info(regex_t* reg)
   reg->sub_anchor    = 0;
   reg->exact_end     = (UChar* )NULL;
   reg->threshold_len = 0;
-  if (IS_NOT_NULL(reg->exact)) {
-    xfree(reg->exact);
-    reg->exact = (UChar* )NULL;
-  }
+  xfree(reg->exact);
+  reg->exact = (UChar* )NULL;
 }
 
 #ifdef ONIG_DEBUG

--- a/regparse.c
+++ b/regparse.c
@@ -763,10 +763,9 @@ names_clear(regex_t* reg)
 	e->back_refs = (int* )NULL;
       }
     }
-    if (IS_NOT_NULL(t->e)) {
-      xfree(t->e);
-      t->e = NULL;
-    }
+
+    xfree(t->e);
+    t->e = NULL;
     t->num = 0;
   }
   return 0;

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -2306,10 +2306,8 @@ rb_threadptr_sched_free(rb_thread_t *th)
         // TODO: how to free nt and nt->altstack?
     }
 
-    if (th->sched.context) {
-        ruby_xfree(th->sched.context);
-        VM_ASSERT((th->sched.context = NULL) == NULL);
-    }
+    ruby_xfree(th->sched.context);
+    VM_ASSERT((th->sched.context = NULL) == NULL);
 #else
     ruby_xfree(th->sched.context_stack);
     native_thread_destroy(th->nt);

--- a/variable.c
+++ b/variable.c
@@ -1459,9 +1459,7 @@ rb_obj_convert_to_too_complex(VALUE obj, st_table *table)
         RB_VM_LOCK_LEAVE();
     }
 
-    if (old_ivptr) {
-        xfree(old_ivptr);
-    }
+    xfree(old_ivptr);
 }
 
 void

--- a/vm.c
+++ b/vm.c
@@ -3441,9 +3441,7 @@ thread_free(void *ptr)
         rb_bug("thread_free: keeping_mutexes must be NULL (%p:%p)", (void *)th, (void *)th->keeping_mutexes);
     }
 
-    if (th->specific_storage) {
-        ruby_xfree(th->specific_storage);
-    }
+    ruby_xfree(th->specific_storage);
 
     rb_threadptr_root_fiber_release(th);
 


### PR DESCRIPTION
xfree can handle null values, so we don't need to check it.