### PR TITLE
[PRISM] Implement remaining nodes for `defined?` that use `expression`

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2546,6 +2546,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_KEYWORD_HASH_NODE:
       case PM_LAMBDA_NODE:
       case PM_MATCH_PREDICATE_NODE:
+      case PM_MATCH_WRITE_NODE:
       case PM_NEXT_NODE:
       case PM_OR_NODE:
       case PM_RANGE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2557,6 +2557,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_REGULAR_EXPRESSION_NODE:
       case PM_RETRY_NODE:
       case PM_RETURN_NODE:
+      case PM_SINGLETON_CLASS_NODE:
       case PM_SOURCE_ENCODING_NODE:
       case PM_SOURCE_FILE_NODE:
       case PM_SOURCE_LINE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2529,6 +2529,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_BEGIN_NODE:
       case PM_BREAK_NODE:
       case PM_CASE_NODE:
+      case PM_CASE_MATCH_NODE:
       case PM_DEFINED_NODE:
       case PM_FLOAT_NODE:
       case PM_HASH_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2552,6 +2552,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_NEXT_NODE:
       case PM_OR_NODE:
       case PM_RANGE_NODE:
+      case PM_RATIONAL_NODE:
       case PM_REDO_NODE:
       case PM_REGULAR_EXPRESSION_NODE:
       case PM_RETRY_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2534,6 +2534,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_DEF_NODE:
       case PM_DEFINED_NODE:
       case PM_FLOAT_NODE:
+      case PM_FOR_NODE:
       case PM_HASH_NODE:
       case PM_IMAGINARY_NODE:
       case PM_INTEGER_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2536,6 +2536,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_FLOAT_NODE:
       case PM_FOR_NODE:
       case PM_HASH_NODE:
+      case PM_IF_NODE:
       case PM_IMAGINARY_NODE:
       case PM_INTEGER_NODE:
       case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2548,6 +2548,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_MATCH_PREDICATE_NODE:
       case PM_MATCH_REQUIRED_NODE:
       case PM_MATCH_WRITE_NODE:
+      case PM_MODULE_NODE:
       case PM_NEXT_NODE:
       case PM_OR_NODE:
       case PM_RANGE_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2563,6 +2563,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_SOURCE_LINE_NODE:
       case PM_STRING_NODE:
       case PM_SYMBOL_NODE:
+      case PM_UNTIL_NODE:
       case PM_WHILE_NODE:
       case PM_X_STRING_NODE:
         dtype = DEFINED_EXPR;

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2530,6 +2530,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_BREAK_NODE:
       case PM_CASE_NODE:
       case PM_CASE_MATCH_NODE:
+      case PM_CLASS_NODE:
       case PM_DEFINED_NODE:
       case PM_FLOAT_NODE:
       case PM_HASH_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2563,6 +2563,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_SOURCE_LINE_NODE:
       case PM_STRING_NODE:
       case PM_SYMBOL_NODE:
+      case PM_UNLESS_NODE:
       case PM_UNTIL_NODE:
       case PM_WHILE_NODE:
       case PM_X_STRING_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2528,6 +2528,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_AND_NODE:
       case PM_BEGIN_NODE:
       case PM_BREAK_NODE:
+      case PM_CASE_NODE:
       case PM_DEFINED_NODE:
       case PM_FLOAT_NODE:
       case PM_HASH_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2563,6 +2563,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_SOURCE_LINE_NODE:
       case PM_STRING_NODE:
       case PM_SYMBOL_NODE:
+      case PM_WHILE_NODE:
       case PM_X_STRING_NODE:
         dtype = DEFINED_EXPR;
         break;

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2531,6 +2531,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_CASE_NODE:
       case PM_CASE_MATCH_NODE:
       case PM_CLASS_NODE:
+      case PM_DEF_NODE:
       case PM_DEFINED_NODE:
       case PM_FLOAT_NODE:
       case PM_HASH_NODE:

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2546,6 +2546,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *co
       case PM_KEYWORD_HASH_NODE:
       case PM_LAMBDA_NODE:
       case PM_MATCH_PREDICATE_NODE:
+      case PM_MATCH_REQUIRED_NODE:
       case PM_MATCH_WRITE_NODE:
       case PM_NEXT_NODE:
       case PM_OR_NODE:

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -262,6 +262,7 @@ module Prism
       assert_prism_eval("defined?(class << self; end)")
       assert_prism_eval("defined?(while a != 1; end)")
       assert_prism_eval("defined?(until a == 1; end)")
+      assert_prism_eval("defined?(unless true; 1; end)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -259,6 +259,7 @@ module Prism
       assert_prism_eval("defined?(1 => 1)")
       assert_prism_eval("defined?(module M; end)")
       assert_prism_eval("defined?(1.2r)")
+      assert_prism_eval("defined?(class << self; end)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -253,6 +253,7 @@ module Prism
       assert_prism_eval("defined?(case [1, 2, 3]; in [1, 2, 3]; 4; end)")
       assert_prism_eval("defined?(class PrismClassA; end)")
       assert_prism_eval("defined?(def prism_test_def_node; end)")
+      assert_prism_eval("defined?(for i in [1,2] do; i; end)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -257,6 +257,7 @@ module Prism
       assert_prism_eval("defined?(if true; 1; end)")
       assert_prism_eval("defined?(/(?<foo>bar)/ =~ 'barbar')")
       assert_prism_eval("defined?(1 => 1)")
+      assert_prism_eval("defined?(module M; end)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -258,6 +258,7 @@ module Prism
       assert_prism_eval("defined?(/(?<foo>bar)/ =~ 'barbar')")
       assert_prism_eval("defined?(1 => 1)")
       assert_prism_eval("defined?(module M; end)")
+      assert_prism_eval("defined?(1.2r)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -254,6 +254,7 @@ module Prism
       assert_prism_eval("defined?(class PrismClassA; end)")
       assert_prism_eval("defined?(def prism_test_def_node; end)")
       assert_prism_eval("defined?(for i in [1,2] do; i; end)")
+      assert_prism_eval("defined?(if true; 1; end)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -260,6 +260,7 @@ module Prism
       assert_prism_eval("defined?(module M; end)")
       assert_prism_eval("defined?(1.2r)")
       assert_prism_eval("defined?(class << self; end)")
+      assert_prism_eval("defined?(while a != 1; end)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -261,6 +261,7 @@ module Prism
       assert_prism_eval("defined?(1.2r)")
       assert_prism_eval("defined?(class << self; end)")
       assert_prism_eval("defined?(while a != 1; end)")
+      assert_prism_eval("defined?(until a == 1; end)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -252,6 +252,7 @@ module Prism
       assert_prism_eval("defined?(case :a; when :a; 1; else; 2; end)")
       assert_prism_eval("defined?(case [1, 2, 3]; in [1, 2, 3]; 4; end)")
       assert_prism_eval("defined?(class PrismClassA; end)")
+      assert_prism_eval("defined?(def prism_test_def_node; end)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -256,6 +256,7 @@ module Prism
       assert_prism_eval("defined?(for i in [1,2] do; i; end)")
       assert_prism_eval("defined?(if true; 1; end)")
       assert_prism_eval("defined?(/(?<foo>bar)/ =~ 'barbar')")
+      assert_prism_eval("defined?(1 => 1)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -248,6 +248,8 @@ module Prism
       assert_prism_eval("defined?([0][0] &&= 1)")
       assert_prism_eval("defined?([0][0] += 1)")
       assert_prism_eval("defined?([0][0] ||= 1)")
+
+      assert_prism_eval("defined?(case :a; when :a; 1; else; 2; end)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -251,6 +251,7 @@ module Prism
 
       assert_prism_eval("defined?(case :a; when :a; 1; else; 2; end)")
       assert_prism_eval("defined?(case [1, 2, 3]; in [1, 2, 3]; 4; end)")
+      assert_prism_eval("defined?(class PrismClassA; end)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -250,6 +250,7 @@ module Prism
       assert_prism_eval("defined?([0][0] ||= 1)")
 
       assert_prism_eval("defined?(case :a; when :a; 1; else; 2; end)")
+      assert_prism_eval("defined?(case [1, 2, 3]; in [1, 2, 3]; 4; end)")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -255,6 +255,7 @@ module Prism
       assert_prism_eval("defined?(def prism_test_def_node; end)")
       assert_prism_eval("defined?(for i in [1,2] do; i; end)")
       assert_prism_eval("defined?(if true; 1; end)")
+      assert_prism_eval("defined?(/(?<foo>bar)/ =~ 'barbar')")
     end
 
     def test_GlobalVariableReadNode


### PR DESCRIPTION
This PR implements the remaining nodes for `defined?`. All of them emit the `expression` instruction. Note that `MatchWriteNode` is slightly different as it also has a local table (see commit message for https://github.com/ruby/ruby/commit/b1473db423c695a47055b1d4eb937f928cba8598).

There are 4 nodes left in ruby/prism#2188 after this PR but I have determined all of them are not possible to call `defined?` on since they throw a `SyntaxError`. So this is the final PR for `defined?` to close ruby/prism#2188.

This PR implements the following nodes:

- `PM_UNTIL_NODE`
- `PM_WHILE_NODE`
- `PM_SINGLETON_CLASS_NODE`
- `PM_RATIONAL_NODE`
- `PM_MODULE_NODE`
- `PM_MATCH_REQUIRED_NODE`
- `PM_MATCH_WRITE_NODE`
- `PM_IF_NODE`
- `PM_FOR_NODE`
- `PM_DEF_NODE`
- `PM_CLASS_NODE`
- `PM_CASE_MATCH_NODE`
- `PM_CASE_NODE`

cc/ @kddnewton 