### PR TITLE
[PRISM] Fix test spelling `RescueModifer` -> `RescueModifier`

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1197,7 +1197,7 @@ module Prism
       CODE
     end
 
-    def test_RescueModiferNode
+    def test_RescueModifierNode
       assert_prism_eval("1.nil? rescue false")
       assert_prism_eval("1.nil? rescue 1")
       assert_prism_eval("raise 'bang' rescue nil")


### PR DESCRIPTION
`RescueModifier` was spelled wrong. Not a big deal, but it meant I didn't immediately find the test when I was searching for it while working on implementing `defined?` nodes.

cc/ @kddnewton