### PR TITLE
[PRISM] Fix memory leak in iseq

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6947,7 +6947,6 @@ rb_translate_prism(pm_parser_t *parser, rb_iseq_t *iseq, pm_scope_node_t *scope_
     scope_node->index_lookup_table = index_lookup_table;
 
     pm_compile_node(iseq, (pm_node_t *)scope_node, ret, scope_node->base.location.start, false, (pm_scope_node_t *)scope_node);
-    iseq_set_sequence(iseq, ret);
 
     st_free_table(index_lookup_table);
 


### PR DESCRIPTION
rb_iseq_compile_prism_node calls both rb_translate_prism and iseq_setup. Both of these functions call iseq_set_sequence. This means that the first iseq_set_sequence will leak because the iseq will be overwritten.

For example:

```ruby
10.times do
  100_000.times do
    RubyVM::InstructionSequence.compile_prism("")
  end

  puts `ps -o rss= -p #{$$}`
end
```

Before:

    20528
    27328
    33840
    40208
    46400
    52960
    59168
    65600
    71888
    78352

After:

    13696
    13712
    13712
    13712
    13712
    14352
    14352
    14992
    14992
    14992