### PR TITLE
[PRISM] Fix memory leak in case nodes

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3502,7 +3502,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
         pm_node_list_t conditions = case_node->conditions;
 
-        LABEL **conditions_labels = (LABEL **)ALLOC_N(VALUE, conditions.size + 1);
+        LABEL **conditions_labels = (LABEL **)ALLOCA_N(VALUE, conditions.size + 1);
         LABEL *label;
 
         for (size_t i = 0; i < conditions.size; i++) {


### PR DESCRIPTION
The temporary array conditions_labels is heap allocated and never freed. We can use alloca instead to stack allocate it so that we don't need to manually free it.

For example:

```ruby
code = "case; #{100.times.map { "when #{it}; " }.join}; end"

10.times do
  10_000.times do
    RubyVM::InstructionSequence.compile_prism(code)
  end

  puts `ps -o rss= -p #{$$}`
end
```

Before:

    21376
    30304
    38800
    47184
    55456
    64192
    72288
    80400
    89040
    97104

After:

    13088
    13632
    13760
    14016
    14688
    14992
    15120
    15232
    15744
    15744