### PR TITLE
YJIT: Fix crash with autosplat + lead and optional parameters

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,8 @@
+# regression test for autosplat into optional parameter
+assert_equal "[0, 1]", %q{
+  [0].yield_self { |a, opt = 1| [a, 1] }
+}
+
 # regression test for send stack shifting
 assert_normal_exit %q{
   def foo(a, b)

--- a/lib/ruby_vm/rjit/insn_compiler.rb
+++ b/lib/ruby_vm/rjit/insn_compiler.rb
@@ -4576,7 +4576,7 @@ module RubyVM::RJIT
         # The block_arg0_splat implementation cannot deal with optional parameters.
         # This is a setup_parameters_complex() situation and interacts with the
         # starting position of the callee.
-        if opt_num > 1
+        if opt_num > 0
           asm.incr_counter(:invokeblock_iseq_arg0_optional)
           return CantCompile
         end

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6251,7 +6251,7 @@ fn gen_send_iseq(
         // The block_arg0_splat implementation cannot deal with optional parameters.
         // This is a setup_parameters_complex() situation and interacts with the
         // starting position of the callee.
-        if opt_num > 1 {
+        if opt_num > 0 {
             gen_counter_incr(asm, Counter::invokeblock_iseq_arg0_optional);
             return None;
         }


### PR DESCRIPTION
Previously, when yielding into a block with auto array expansion that
has both lead and optional parameters, we crashed. We need to reject all
cases of optional parameters, not just ones that trigger autosplat.

Replicate fix in RJIT since it's simple.
