### PR TITLE
YJIT: Optimize defined?(yield)

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4357,3 +4357,9 @@ assert_equal '[2, 4611686018427387904]', %q{
 assert_equal '[0, 1, -4]', %q{
   [0 >> 1, 2 >> 1, -7 >> 1]
 }
+
+# Integer right shift
+assert_equal '[nil, "yield"]', %q{
+  def defined_yield = defined?(yield)
+  [defined_yield, defined_yield {}]
+}

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4358,7 +4358,6 @@ assert_equal '[0, 1, -4]', %q{
   [0 >> 1, 2 >> 1, -7 >> 1]
 }
 
-# Integer right shift
 assert_equal '[nil, "yield"]', %q{
   def defined_yield = defined?(yield)
   [defined_yield, defined_yield {}]

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -348,6 +348,7 @@ fn main() {
         .allowlist_function("rb_iseqw_to_iseq")
         .allowlist_function("rb_iseq_label")
         .allowlist_function("rb_iseq_line_no")
+        .allowlist_type("defined_type")
 
         // From builtin.h
         .allowlist_type("rb_builtin_function.*")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2655,31 +2655,41 @@ fn gen_defined(
     let obj = jit.get_arg(1);
     let pushval = jit.get_arg(2);
 
-    // Save the PC and SP because the callee may allocate
-    // Note that this modifies REG_SP, which is why we do it first
-    jit_prepare_routine_call(jit, asm);
+    match op_type as u32 {
+        DEFINED_YIELD => {
+            asm.stack_pop(1); // v operand is not used
+            let out_opnd = asm.stack_push(Type::Unknown); // nil or "yield"
 
-    // Get the operands from the stack
-    let v_opnd = asm.stack_opnd(0);
+            get_block_given(jit, asm, out_opnd, pushval.into(), Qnil.into());
+        }
+        _ => {
+            // Save the PC and SP because the callee may allocate
+            // Note that this modifies REG_SP, which is why we do it first
+            jit_prepare_routine_call(jit, asm);
 
-    // Call vm_defined(ec, reg_cfp, op_type, obj, v)
-    let def_result = asm.ccall(rb_vm_defined as *const u8, vec![EC, CFP, op_type.into(), obj.into(), v_opnd]);
-    asm.stack_pop(1); // Keep it on stack during ccall for GC
+            // Get the operands from the stack
+            let v_opnd = asm.stack_opnd(0);
 
-    // if (vm_defined(ec, GET_CFP(), op_type, obj, v)) {
-    //  val = pushval;
-    // }
-    asm.test(def_result, Opnd::UImm(255));
-    let out_value = asm.csel_nz(pushval.into(), Qnil.into());
+            // Call vm_defined(ec, reg_cfp, op_type, obj, v)
+            let def_result = asm.ccall(rb_vm_defined as *const u8, vec![EC, CFP, op_type.into(), obj.into(), v_opnd]);
+            asm.stack_pop(1); // Keep it on stack during ccall for GC
 
-    // Push the return value onto the stack
-    let out_type = if pushval.special_const_p() {
-        Type::UnknownImm
-    } else {
-        Type::Unknown
-    };
-    let stack_ret = asm.stack_push(out_type);
-    asm.mov(stack_ret, out_value);
+            // if (vm_defined(ec, GET_CFP(), op_type, obj, v)) {
+            //  val = pushval;
+            // }
+            asm.test(def_result, Opnd::UImm(255));
+            let out_value = asm.csel_nz(pushval.into(), Qnil.into());
+
+            // Push the return value onto the stack
+            let out_type = if pushval.special_const_p() {
+                Type::UnknownImm
+            } else {
+                Type::Unknown
+            };
+            let stack_ret = asm.stack_push(out_type);
+            asm.mov(stack_ret, out_value);
+        }
+    }
 
     Some(KeepCompiling)
 }
@@ -5265,6 +5275,21 @@ fn jit_rb_f_block_given_p(
     _argc: i32,
     _known_recv_class: *const VALUE,
 ) -> bool {
+    asm.stack_pop(1);
+    let out_opnd = asm.stack_push(Type::UnknownImm);
+
+    get_block_given(jit, asm, out_opnd, Qtrue.into(), Qfalse.into());
+
+    true
+}
+
+fn get_block_given(
+    jit: &mut JITState,
+    asm: &mut Assembler,
+    out_opnd: Opnd,
+    true_opnd: Opnd,
+    false_opnd: Opnd,
+) {
     asm_comment!(asm, "block_given?");
 
     // Same as rb_vm_frame_block_handler
@@ -5273,15 +5298,10 @@ fn jit_rb_f_block_given_p(
         Opnd::mem(64, ep_opnd, SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL)
     );
 
-    asm.stack_pop(1);
-    let out_opnd = asm.stack_push(Type::UnknownImm);
-
     // Return `block_handler != VM_BLOCK_HANDLER_NONE`
     asm.cmp(block_handler, VM_BLOCK_HANDLER_NONE.into());
-    let block_given = asm.csel_ne(Qtrue.into(), Qfalse.into());
+    let block_given = asm.csel_ne(true_opnd, false_opnd);
     asm.mov(out_opnd, block_given);
-
-    true
 }
 
 fn jit_thread_s_current(

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2660,7 +2660,7 @@ fn gen_defined(
             asm.stack_pop(1); // v operand is not used
             let out_opnd = asm.stack_push(Type::Unknown); // nil or "yield"
 
-            get_block_given(jit, asm, out_opnd, pushval.into(), Qnil.into());
+            gen_block_given(jit, asm, out_opnd, pushval.into(), Qnil.into());
         }
         _ => {
             // Save the PC and SP because the callee may allocate
@@ -5278,12 +5278,12 @@ fn jit_rb_f_block_given_p(
     asm.stack_pop(1);
     let out_opnd = asm.stack_push(Type::UnknownImm);
 
-    get_block_given(jit, asm, out_opnd, Qtrue.into(), Qfalse.into());
+    gen_block_given(jit, asm, out_opnd, Qtrue.into(), Qfalse.into());
 
     true
 }
 
-fn get_block_given(
+fn gen_block_given(
     jit: &mut JITState,
     asm: &mut Assembler,
     out_opnd: Opnd,

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -874,6 +874,25 @@ pub type ruby_vminsn_type = u32;
 pub type rb_iseq_callback = ::std::option::Option<
     unsafe extern "C" fn(arg1: *const rb_iseq_t, arg2: *mut ::std::os::raw::c_void),
 >;
+pub const DEFINED_NOT_DEFINED: defined_type = 0;
+pub const DEFINED_NIL: defined_type = 1;
+pub const DEFINED_IVAR: defined_type = 2;
+pub const DEFINED_LVAR: defined_type = 3;
+pub const DEFINED_GVAR: defined_type = 4;
+pub const DEFINED_CVAR: defined_type = 5;
+pub const DEFINED_CONST: defined_type = 6;
+pub const DEFINED_METHOD: defined_type = 7;
+pub const DEFINED_YIELD: defined_type = 8;
+pub const DEFINED_ZSUPER: defined_type = 9;
+pub const DEFINED_SELF: defined_type = 10;
+pub const DEFINED_TRUE: defined_type = 11;
+pub const DEFINED_FALSE: defined_type = 12;
+pub const DEFINED_ASGN: defined_type = 13;
+pub const DEFINED_EXPR: defined_type = 14;
+pub const DEFINED_REF: defined_type = 15;
+pub const DEFINED_FUNC: defined_type = 16;
+pub const DEFINED_CONST_FROM: defined_type = 17;
+pub type defined_type = u32;
 pub const ROBJECT_OFFSET_AS_HEAP_IVPTR: robject_offsets = 16;
 pub const ROBJECT_OFFSET_AS_HEAP_IV_INDEX_TBL: robject_offsets = 24;
 pub const ROBJECT_OFFSET_AS_ARY: robject_offsets = 16;


### PR DESCRIPTION
This PR optimizes `defined` instruction for the `DEFINED_YIELD` case, which is used by `defined?(yield)`.

It has been raised as an idea to use `defined?(yield)` instead of `block_given?` when we rewrite a C method in Ruby so that it will not be impacted by method redefinition.

Matz didn't ask for tolerating such redefinition, so we don't need to do it for compatibility. However, it could be still useful for performance when we rewrite C methods in Ruby since `defined?(yield)` is not a method call unlike `block_given?`, so it's faster on the interpreter.

Even for YJIT, `defined` instruction is more preferable because you don't need to split blocks for `defer_compilation` (smaller memory overhead) or add a guard for the receiver (faster).

Since we're interested in removing C -> Ruby calls, we would naturally rewrite methods that check `block_given?`. To make it easier for us to merge such changes, being able to use this optimization for the interpreter performance seems useful.

## Example code

### block_given? 

```asm
  # Insn: 0001 opt_send_without_block (stack_size: 1)
  # call to Object#block_given?
  # guard known object with singleton class
  0x559640a680bf: movabs rax, 0x7f9f7f6ace00
  0x559640a680c9: cmp rsi, rax
  0x559640a680cc: jne 0x559640a6a0aa
  # block_given?
  0x559640a680d2: mov rax, qword ptr [r13 + 0x20]
  0x559640a680d6: mov rax, qword ptr [rax - 8]
  0x559640a680da: test rax, rax
  0x559640a680dd: mov eax, 0x14
  0x559640a680e2: mov ecx, 0
  0x559640a680e7: cmove rax, rcx
  0x559640a680eb: mov rsi, rax
```

### defined?(yield)

```asm
  # Insn: 0001 defined (stack_size: 1)
  # block_given?
  0x559640a6805d: mov rax, qword ptr [r13 + 0x20]
  0x559640a68061: mov rax, qword ptr [rax - 8]
  0x559640a68065: test rax, rax
  0x559640a68068: movabs rax, 0x7f9f7f671940
  0x559640a68072: mov rax, rax
  0x559640a68075: mov ecx, 4
  0x559640a6807a: cmove rax, rcx
  0x559640a6807e: mov rsi, rax
```