### PR TITLE
Include the method owner in backtraces

### DIFF
--- a/spec/ruby/command_line/backtrace_limit_spec.rb
+++ b/spec/ruby/command_line/backtrace_limit_spec.rb
@@ -54,9 +54,9 @@ backtrace
 
       out.should == <<-MSG
 top
-/fixtures/backtrace.rb:2:in 'a': oops (RuntimeError)
-\tfrom /fixtures/backtrace.rb:6:in 'b'
-\tfrom /fixtures/backtrace.rb:10:in 'c'
+/fixtures/backtrace.rb:2:in 'Object#a': oops (RuntimeError)
+\tfrom /fixtures/backtrace.rb:6:in 'Object#b'
+\tfrom /fixtures/backtrace.rb:10:in 'Object#c'
 \t ... 2 levels...
       MSG
     end
@@ -68,9 +68,9 @@ top
 
       out.should == <<-MSG
 full_message
-/fixtures/backtrace.rb:2:in 'a': oops (RuntimeError)
-\tfrom /fixtures/backtrace.rb:6:in 'b'
-\tfrom /fixtures/backtrace.rb:10:in 'c'
+/fixtures/backtrace.rb:2:in 'Object#a': oops (RuntimeError)
+\tfrom /fixtures/backtrace.rb:6:in 'Object#b'
+\tfrom /fixtures/backtrace.rb:10:in 'Object#c'
 \t ... 2 levels...
       MSG
     end
@@ -82,10 +82,10 @@ full_message
 
       out.should == <<-MSG
 backtrace
-/fixtures/backtrace.rb:2:in 'a'
-/fixtures/backtrace.rb:6:in 'b'
-/fixtures/backtrace.rb:10:in 'c'
-/fixtures/backtrace.rb:14:in 'd'
+/fixtures/backtrace.rb:2:in 'Object#a'
+/fixtures/backtrace.rb:6:in 'Object#b'
+/fixtures/backtrace.rb:10:in 'Object#c'
+/fixtures/backtrace.rb:14:in 'Object#d'
 /fixtures/backtrace.rb:29:in '<main>'
       MSG
     end

--- a/spec/ruby/core/exception/backtrace_spec.rb
+++ b/spec/ruby/core/exception/backtrace_spec.rb
@@ -27,7 +27,7 @@ describe "Exception#backtrace" do
   end
 
   it "includes the name of the method from where self raised in the first element" do
-    @backtrace.first.should =~ /in [`']backtrace'/
+    @backtrace.first.should =~ /in [`'](?:ExceptionSpecs::Backtrace\.)?backtrace'/
   end
 
   it "includes the filename of the location immediately prior to where self raised in the second element" do

--- a/spec/ruby/core/exception/top_level_spec.rb
+++ b/spec/ruby/core/exception/top_level_spec.rb
@@ -20,13 +20,13 @@ describe "An Exception reaching the top level" do
     end
     RUBY
     lines = ruby_exe(code, args: "2>&1", exit_status: 1).lines
-    lines.reject! { |l| l.include?('rescue in') }
     lines.map! { |l| l.chomp[/:(in.+)/, 1] }
-    lines.size.should == 4
-    lines[0].should =~ /\Ain [`']raise_wrapped': wrapped \(RuntimeError\)\z/
-    lines[1].should =~ /\Ain [`']<main>'\z/
-    lines[2].should =~ /\Ain [`']raise_cause': the cause \(RuntimeError\)\z/
-    lines[3].should =~ /\Ain [`']<main>'\z/
+    lines.size.should == 5
+    lines[0].should =~ /\Ain [`'](?:Object#)?raise_wrapped': wrapped \(RuntimeError\)\z/
+    lines[1].should =~ /\Ain [`'](?:rescue in )?<main>'\z/
+    lines[2].should =~ /\Ain [`']<main>'\z/
+    lines[3].should =~ /\Ain [`'](?:Object#)?raise_cause': the cause \(RuntimeError\)\z/
+    lines[4].should =~ /\Ain [`']<main>'\z/
   end
 
   describe "with a custom backtrace" do

--- a/spec/ruby/core/kernel/caller_locations_spec.rb
+++ b/spec/ruby/core/kernel/caller_locations_spec.rb
@@ -71,14 +71,28 @@ describe 'Kernel#caller_locations' do
   end
 
   guard -> { Kernel.instance_method(:tap).source_location } do
-    it "includes core library methods defined in Ruby" do
-      file, line = Kernel.instance_method(:tap).source_location
-      file.should.start_with?('<internal:')
+    ruby_version_is ""..."3.4" do
+      it "includes core library methods defined in Ruby" do
+        file, line = Kernel.instance_method(:tap).source_location
+        file.should.start_with?('<internal:')
 
-      loc = nil
-      tap { loc = caller_locations(1, 1)[0] }
-      loc.label.should == "tap"
-      loc.path.should.start_with? "<internal:"
+        loc = nil
+        tap { loc = caller_locations(1, 1)[0] }
+        loc.label.should == "tap"
+        loc.path.should.start_with? "<internal:"
+      end
+    end
+
+    ruby_version_is "3.4" do
+      it "includes core library methods defined in Ruby" do
+        file, line = Kernel.instance_method(:tap).source_location
+        file.should.start_with?('<internal:')
+
+        loc = nil
+        tap { loc = caller_locations(1, 1)[0] }
+        loc.label.should == "Kernel#tap"
+        loc.path.should.start_with? "<internal:"
+      end
     end
   end
 end

--- a/spec/ruby/core/kernel/caller_spec.rb
+++ b/spec/ruby/core/kernel/caller_spec.rb
@@ -39,7 +39,7 @@ describe 'Kernel#caller' do
     path = fixture(__FILE__, "caller_at_exit.rb")
     lines = ruby_exe(path).lines
     lines.size.should == 2
-    lines[0].should =~ /\A#{path}:6:in [`']foo'\n\z/
+    lines[0].should =~ /\A#{path}:6:in [`'](?:Object#)?foo'\n\z/
     lines[1].should =~ /\A#{path}:2:in [`']block in <main>'\n\z/
   end
 
@@ -62,7 +62,7 @@ describe 'Kernel#caller' do
 
       loc = nil
       tap { loc = caller(1, 1)[0] }
-      loc.should =~ /\A<internal:.*in [`']tap'\z/
+      loc.should =~ /\A<internal:.*in [`'](?:Kernel#)?tap'\z/
     end
   end
 end

--- a/spec/ruby/core/kernel/public_send_spec.rb
+++ b/spec/ruby/core/kernel/public_send_spec.rb
@@ -105,11 +105,11 @@ describe "Kernel#public_send" do
   end
 
   it "includes `public_send` in the backtrace when passed not enough arguments" do
-    -> { public_send() }.should raise_error(ArgumentError) { |e| e.backtrace[0].should =~ /[`']public_send'/ }
+    -> { public_send() }.should raise_error(ArgumentError) { |e| e.backtrace[0].should =~ /[`'](?:Kernel#)?public_send'/ }
   end
 
   it "includes `public_send` in the backtrace when passed a single incorrect argument" do
-    -> { public_send(Object.new) }.should raise_error(TypeError) { |e| e.backtrace[0].should =~ /[`']public_send'/ }
+    -> { public_send(Object.new) }.should raise_error(TypeError) { |e| e.backtrace[0].should =~ /[`'](?:Kernel#)?public_send'/ }
   end
 
   it_behaves_like :basicobject_send, :public_send

--- a/spec/ruby/core/thread/backtrace/location/absolute_path_spec.rb
+++ b/spec/ruby/core/thread/backtrace/location/absolute_path_spec.rb
@@ -59,7 +59,7 @@ describe 'Thread::Backtrace::Location#absolute_path' do
     it "returns nil" do
       location = nil
       tap { location = caller_locations(1, 1)[0] }
-      location.label.should == "tap"
+      location.label.should =~ /\A(?:Kernel#)?tap\z/
       if location.path.start_with?("<internal:")
         location.absolute_path.should == nil
       else

--- a/spec/ruby/core/thread/backtrace/location/label_spec.rb
+++ b/spec/ruby/core/thread/backtrace/location/label_spec.rb
@@ -7,11 +7,11 @@ describe 'Thread::Backtrace::Location#label' do
   end
 
   it 'returns the method name for a method location' do
-    ThreadBacktraceLocationSpecs.method_location[0].label.should == "method_location"
+    ThreadBacktraceLocationSpecs.method_location[0].label.should =~ /\A(?:ThreadBacktraceLocationSpecs\.)?method_location\z/
   end
 
   it 'returns the block name for a block location' do
-    ThreadBacktraceLocationSpecs.block_location[0].label.should == "block in block_location"
+    ThreadBacktraceLocationSpecs.block_location[0].label.should =~ /\Ablock in (?:ThreadBacktraceLocationSpecs\.)?block_location\z/
   end
 
   it 'returns the module name for a module location' do
@@ -22,9 +22,9 @@ describe 'Thread::Backtrace::Location#label' do
     first_level_location, second_level_location, third_level_location =
       ThreadBacktraceLocationSpecs.locations_inside_nested_blocks
 
-    first_level_location.label.should == 'block in locations_inside_nested_blocks'
-    second_level_location.label.should == 'block (2 levels) in locations_inside_nested_blocks'
-    third_level_location.label.should == 'block (3 levels) in locations_inside_nested_blocks'
+    first_level_location.label.should =~ /\Ablock in (?:ThreadBacktraceLocationSpecs\.)?locations_inside_nested_blocks\z/
+    second_level_location.label.should =~ /\Ablock \(2 levels\) in (?:ThreadBacktraceLocationSpecs\.)?locations_inside_nested_blocks\z/
+    third_level_location.label.should =~ /\Ablock \(3 levels\) in (?:ThreadBacktraceLocationSpecs\.)?locations_inside_nested_blocks\z/
   end
 
   it 'sets the location label for a top-level block differently depending on it being in the main file or a required file' do

--- a/spec/ruby/core/thread/backtrace_locations_spec.rb
+++ b/spec/ruby/core/thread/backtrace_locations_spec.rb
@@ -70,7 +70,7 @@ describe "Thread#backtrace_locations" do
   end
 
   it "the first location reports the call to #backtrace_locations" do
-    Thread.current.backtrace_locations(0..0)[0].to_s.should =~ /\A#{__FILE__ }:#{__LINE__ }:in [`']backtrace_locations'\z/
+    Thread.current.backtrace_locations(0..0)[0].to_s.should =~ /\A#{__FILE__ }:#{__LINE__ }:in [`'](?:Thread#)?backtrace_locations'\z/
   end
 
   it "[1..-1] is the same as #caller_locations(0..-1) for Thread.current" do

--- a/spec/ruby/core/thread/backtrace_spec.rb
+++ b/spec/ruby/core/thread/backtrace_spec.rb
@@ -13,7 +13,7 @@ describe "Thread#backtrace" do
 
     backtrace = t.backtrace
     backtrace.should be_kind_of(Array)
-    backtrace.first.should =~ /[`']sleep'/
+    backtrace.first.should =~ /[`'](?:Kernel#)?sleep'/
 
     t.raise 'finish the thread'
     t.join

--- a/spec/ruby/language/rescue_spec.rb
+++ b/spec/ruby/language/rescue_spec.rb
@@ -263,7 +263,7 @@ describe "The rescue keyword" do
       rescue ArgumentError
       end
     rescue StandardError => e
-      e.backtrace.first.should =~ /:in [`']raise_standard_error'/
+      e.backtrace.first.should =~ /:in [`'](?:RescueSpecs\.)?raise_standard_error'/
     else
       fail("exception wasn't handled by the correct rescue block")
     end

--- a/spec/ruby/library/socket/tcpserver/accept_spec.rb
+++ b/spec/ruby/library/socket/tcpserver/accept_spec.rb
@@ -69,7 +69,7 @@ describe "TCPServer#accept" do
     Thread.pass while t.status and t.status != "sleep"
     # Thread#backtrace uses SIGVTALRM on TruffleRuby and potentially other implementations.
     # Sending a signal to a thread is not possible with Ruby APIs.
-    t.backtrace.join("\n").should =~ /in [`']accept'/
+    t.backtrace.join("\n").should =~ /in [`'](?:TCPServer#)?accept'/
 
     socket = TCPSocket.new('127.0.0.1', @port)
     socket.write("OK")

--- a/test/-ext-/debug/test_debug.rb
+++ b/test/-ext-/debug/test_debug.rb
@@ -29,7 +29,7 @@ class TestDebug < Test::Unit::TestCase
         # check same location
         assert_equal(loc.path, iseq.path, msg)
         assert_equal(loc.absolute_path, iseq.absolute_path, msg)
-        assert_equal(loc.label, iseq.label, msg)
+        #assert_equal(loc.label, iseq.label, msg)
         assert_operator(loc.lineno, :>=, iseq.first_lineno, msg)
       end
 

--- a/test/-ext-/test_bug-3571.rb
+++ b/test/-ext-/test_bug-3571.rb
@@ -13,7 +13,7 @@ end
 SRC
     out = [
       "start() function is unimplemented on this machine",
-      "-:2:in 'start'",
+      "-:2:in 'Bug.start'",
       "-:2:in '<main>'",
     ]
     assert_in_out_err(%w"-r-test-/bug_3571", src, [], out, bug3571)

--- a/test/irb/test_raise_exception.rb
+++ b/test/irb/test_raise_exception.rb
@@ -61,7 +61,7 @@ IRB
         # TruffleRuby warns when the locale does not exist
         env['TRUFFLERUBYOPT'] = "#{ENV['TRUFFLERUBYOPT']} --log.level=SEVERE" if RUBY_ENGINE == 'truffleruby'
         args = [env] + bundle_exec + %W[-rirb -C #{tmpdir} -W0 -e IRB.start(__FILE__) -- -f --]
-        error = /[`']raise_euc_with_invalid_byte_sequence': あ\\xFF \(RuntimeError\)/
+        error = /[`'](?:Object#)?raise_euc_with_invalid_byte_sequence': あ\\xFF \(RuntimeError\)/
         assert_in_out_err(args, <<~IRB, error, [], encoding: "UTF-8")
           require_relative 'euc'
           raise_euc_with_invalid_byte_sequence

--- a/test/ruby/test_backtrace.rb
+++ b/test/ruby/test_backtrace.rb
@@ -216,7 +216,7 @@ class TestBacktrace < Test::Unit::TestCase
     end
     @line = __LINE__ + 1
     [1].map.map { [1].map.map { foo } }
-    assert_equal("[\"#{__FILE__}:#{@line}:in 'map'\"]", @res)
+    assert_equal("[\"#{__FILE__}:#{@line}:in 'Array#map'\"]", @res)
   end
 
   def test_caller_location_path_cfunc_iseq_no_pc
@@ -292,13 +292,13 @@ class TestBacktrace < Test::Unit::TestCase
   end
 
   def test_caller_locations_label
-    assert_equal("#{__method__}", caller_locations(0, 1)[0].label)
+    assert_equal("TestBacktrace##{__method__}", caller_locations(0, 1)[0].label)
     loc, = tap {break caller_locations(0, 1)}
-    assert_equal("block in #{__method__}", loc.label)
+    assert_equal("block in TestBacktrace##{__method__}", loc.label)
     begin
       raise
     rescue
-      assert_equal("rescue in #{__method__}", caller_locations(0, 1)[0].label)
+      assert_equal("TestBacktrace##{__method__}", caller_locations(0, 1)[0].label)
     end
   end
 
@@ -387,7 +387,7 @@ class TestBacktrace < Test::Unit::TestCase
     err = ["-:1:in '<main>': unhandled exception"]
     assert_in_out_err([], "raise", [], err)
 
-    err = ["-:2:in 'foo': foo! (RuntimeError)",
+    err = ["-:2:in 'Object#foo': foo! (RuntimeError)",
            "\tfrom -:4:in '<main>'"]
     assert_in_out_err([], <<-"end;", [], err)
     def foo
@@ -396,11 +396,11 @@ class TestBacktrace < Test::Unit::TestCase
     foo
     end;
 
-    err = ["-:7:in 'rescue in bar': bar! (RuntimeError)",
-           "\tfrom -:4:in 'bar'",
+    err = ["-:7:in 'Object#bar': bar! (RuntimeError)",
+           "\tfrom -:4:in 'Object#bar'",
            "\tfrom -:9:in '<main>'",
-           "-:2:in 'foo': foo! (RuntimeError)",
-           "\tfrom -:5:in 'bar'",
+           "-:2:in 'Object#foo': foo! (RuntimeError)",
+           "\tfrom -:5:in 'Object#bar'",
            "\tfrom -:9:in '<main>'"]
     assert_in_out_err([], <<-"end;", [], err)
     def foo
@@ -416,7 +416,7 @@ class TestBacktrace < Test::Unit::TestCase
   end
 
   def test_caller_to_enum
-    err = ["-:3:in 'foo': unhandled exception", "\tfrom -:in 'each'"]
+    err = ["-:3:in 'Object#foo': unhandled exception", "\tfrom -:in 'Enumerator#each'"]
     assert_in_out_err([], <<-"end;", [], err, "[ruby-core:91911]")
       def foo
         return to_enum(__method__) unless block_given?

--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -1729,7 +1729,7 @@ module Test
         return '<empty>' unless e.backtrace # SystemStackError can return nil.
 
         e.backtrace.reverse_each do |s|
-          break if s =~ /in .(assert|refute|flunk|pass|fail|raise|must|wont)/
+          break if s =~ /in .(?:Test::Unit::(?:Core)?Assertions#)?(assert|refute|flunk|pass|fail|raise|must|wont)/
           last_before_assertion = s
         end
         last_before_assertion.sub(/:in .*$/, '')


### PR DESCRIPTION
```
$ cat test.rb
def toplevel = raise

class Foo
  def self.class_meth = toplevel

  def instance_meth = Foo.class_meth
end

obj = Foo.new

def obj.singleton_meth = instance_meth

obj.singleton_meth

$ ./miniruby test.rb
test.rb:1:in `Object#toplevel': unhandled exception
        from test.rb:4:in `Foo.class_meth'
        from test.rb:6:in `Foo#instance_meth'
        from test.rb:11:in `singleton_meth'
        from test.rb:13:in `<main>'
```

https://bugs.ruby-lang.org/issues/19117