### PR TITLE
Builtin index by line number

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -46,7 +46,6 @@ rb_load_with_builtin_functions(const char *feature_name, const struct rb_builtin
     rb_vm_t *vm = GET_VM();
     if (vm->builtin_function_table != NULL) rb_bug("vm->builtin_function_table should be NULL.");
     vm->builtin_function_table = table;
-    vm->builtin_inline_index = 0;
     const rb_iseq_t *iseq = rb_iseq_ibf_load_bytes((const char *)bin, size);
     ASSUME(iseq); // otherwise an exception should have raised
     vm->builtin_function_table = NULL;

--- a/compile.c
+++ b/compile.c
@@ -8786,7 +8786,6 @@ compile_builtin_function_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NOD
             }
             else if (strcmp("cinit!", builtin_func) == 0) {
                 // ignore
-                GET_VM()->builtin_inline_index++;
                 return COMPILE_OK;
             }
             else if (strcmp("attr!", builtin_func) == 0) {
@@ -8814,10 +8813,7 @@ compile_builtin_function_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NOD
                 return COMPILE_NG;
             }
 
-            if (GET_VM()->builtin_inline_index == INT_MAX) {
-                rb_bug("builtin inline function index overflow:%s", builtin_func);
-            }
-            int inline_index = GET_VM()->builtin_inline_index++;
+            int inline_index = nd_line(node);
             snprintf(inline_func, sizeof(inline_func), BUILTIN_INLINE_PREFIX "%d", inline_index);
             builtin_func = inline_func;
             args_node = NULL;

--- a/mini_builtin.c
+++ b/mini_builtin.c
@@ -27,7 +27,6 @@ builtin_iseq_load(const char *feature_name, const struct rb_builtin_function *ta
                  feature_name);
     }
     vm->builtin_function_table = table;
-    vm->builtin_inline_index = 0;
     static const rb_compile_option_t optimization = {
         TRUE, /* unsigned int inline_const_cache; */
         TRUE, /* unsigned int peephole_optimization; */

--- a/rjit_c.rb
+++ b/rjit_c.rb
@@ -1541,11 +1541,13 @@ module RubyVM::RJIT # :nodoc: all
   end
 
   def C.VALUE
-    @VALUE ||= CType::Immediate.find(Primitive.cexpr!("SIZEOF(VALUE)"), Primitive.cexpr!("SIGNED_TYPE_P(VALUE)"))
+    @VALUE ||= CType::Immediate.find(Primitive.cexpr!("SIZEOF(VALUE)"),
+      Primitive.cexpr!("SIGNED_TYPE_P(VALUE)"))
   end
 
   def C.shape_id_t
-    @shape_id_t ||= CType::Immediate.find(Primitive.cexpr!("SIZEOF(shape_id_t)"), Primitive.cexpr!("SIGNED_TYPE_P(shape_id_t)"))
+    @shape_id_t ||= CType::Immediate.find(Primitive.cexpr!("SIZEOF(shape_id_t)"),
+      Primitive.cexpr!("SIGNED_TYPE_P(shape_id_t)"))
   end
 
   def C.rb_id_table

--- a/tool/mk_builtin_loader.rb
+++ b/tool/mk_builtin_loader.rb
@@ -166,7 +166,7 @@ def collect_builtin base, tree, name, bs, inlines, locals = nil
           when 'cstmt'
             text = inline_text argc, args.first
 
-            func_name = "_bi#{inlines.size}"
+            func_name = "_bi#{lineno}"
             cfunc_name = make_cfunc_name(inlines, name, lineno)
             inlines[cfunc_name] = [lineno, text, locals, func_name]
             argc -= 1
@@ -174,7 +174,7 @@ def collect_builtin base, tree, name, bs, inlines, locals = nil
             text = inline_text argc, args.first
             code = "return #{text};"
 
-            func_name = "_bi#{inlines.size}"
+            func_name = "_bi#{lineno}"
             cfunc_name = make_cfunc_name(inlines, name, lineno)
 
             locals = [] if $1 == 'cconst'

--- a/tool/rjit/bindgen.rb
+++ b/tool/rjit/bindgen.rb
@@ -183,7 +183,8 @@ class BindingGenerator
         raise "Non-immediate type is given to dynamic_types: #{type}"
       end
       println "  def C.#{type}"
-      println "    @#{type} ||= CType::Immediate.find(Primitive.cexpr!(\"SIZEOF(#{type})\"), Primitive.cexpr!(\"SIGNED_TYPE_P(#{type})\"))"
+      println "    @#{type} ||= CType::Immediate.find(Primitive.cexpr!(\"SIZEOF(#{type})\"),"
+      println "      Primitive.cexpr!(\"SIGNED_TYPE_P(#{type})\"))"
       println "  end"
       println
     end

--- a/vm_core.h
+++ b/vm_core.h
@@ -747,7 +747,6 @@ typedef struct rb_vm_struct {
     st_table *frozen_strings;
 
     const struct rb_builtin_function *builtin_function_table;
-    int builtin_inline_index;
 
     struct rb_id_table *negative_cme_table;
     st_table *overloaded_cme_table; // cme -> overloaded_cme


### PR DESCRIPTION
The order of iseq may differ from the order of tokens, typically `while`/`until` conditions are put after the body.

These orders can match by using line numbers as builtin-indexes, but at the same time, it introduces the restriction that multiple `cexpr!` and `cstmt!` cannot appear in the same line.

Another possible idea is to use `RubyVM::AbstractSyntaxTree` and `node_id` instead of ripper, with making BASERUBY 3.1 or later.

Separated from #9576