### PR TITLE
YJIT: Avoid doubly splitting Opnd::Value on CSel

### DIFF
--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -271,7 +271,11 @@ impl Assembler
                                 *truthy = asm.load(*truthy);
                             }
                         },
-                        Opnd::UImm(_) | Opnd::Imm(_) | Opnd::Value(_) => {
+                        Opnd::UImm(_) | Opnd::Imm(_) => {
+                            *truthy = asm.load(*truthy);
+                        },
+                        // Opnd::Value could have already been split
+                        Opnd::Value(_) if !matches!(truthy, Opnd::InsnOut { .. }) => {
                             *truthy = asm.load(*truthy);
                         },
                         _ => {}
@@ -1268,6 +1272,24 @@ mod tests {
             0x5: mov eax, 4
             0xa: cmovg rax, qword ptr [rbx]
             0xe: mov qword ptr [rbx], rax
+        "});
+    }
+
+    #[test]
+    fn test_csel_split() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let stack_top = Opnd::mem(64, SP, 0);
+        let elem_opnd = asm.csel_ne(VALUE(0x7f22c88d1930).into(), Qnil.into());
+        asm.mov(stack_top, elem_opnd);
+
+        asm.compile_with_num_regs(&mut cb, 3);
+
+        assert_disasm!(cb, "48b830198dc8227f0000b904000000480f44c1488903", {"
+            0x0: movabs rax, 0x7f22c88d1930
+            0xa: mov ecx, 4
+            0xf: cmove rax, rcx
+            0x13: mov qword ptr [rbx], rax
         "});
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ruby/ruby/pull/9599#issuecomment-1900676539

Every `Opnd::Value` operand is split before insn-specific split [here](https://github.com/ruby/ruby/blob/740f0b52e051d6fd022bf4b9eeab078c841b49a2/yjit/src/backend/x86_64/mod.rs#L156). `CSel`-specific split could split an `Opnd::Value` operand again since it's looking at `unmapped_opnds[0]`.

### Before
```nas
  # Insn: 0001 defined (stack_size: 1)
  # block_given?
  0x55b0bcda705d: mov rax, qword ptr [r13 + 0x20]
  0x55b0bcda7061: mov rax, qword ptr [rax - 8]
  0x55b0bcda7065: test rax, rax
  0x55b0bcda7068: movabs rax, 0x7f9dfee51930
  0x55b0bcda7072: mov rax, rax
  0x55b0bcda7075: mov ecx, 4
  0x55b0bcda707a: cmove rax, rcx
  0x55b0bcda707e: mov rsi, rax
```

### After
```nas
  # Insn: 0001 defined (stack_size: 1)
  # block_given?
  0x55a18b4c505d: mov rax, qword ptr [r13 + 0x20]
  0x55a18b4c5061: mov rax, qword ptr [rax - 8]
  0x55a18b4c5065: test rax, rax
  0x55a18b4c5068: movabs rax, 0x7f64811d1950
  0x55a18b4c5072: mov ecx, 4
  0x55a18b4c5077: cmove rax, rcx
  0x55a18b4c507b: mov rsi, rax
```