### PR TITLE
Add ARGF native methods

### DIFF
--- a/io.c
+++ b/io.c
@@ -8557,6 +8557,12 @@ rb_io_printf(int argc, const VALUE *argv, VALUE out)
     return Qnil;
 }
 
+VALUE
+argf_printf(int argc, const VALUE *argv, VALUE out)
+{
+  rb_io_printf(argc, argv, out)
+}
+
 /*
  *  call-seq:
  *    printf(format_string, *objects)               -> nil
@@ -8704,6 +8710,12 @@ rb_io_print(int argc, const VALUE *argv, VALUE out)
     return Qnil;
 }
 
+VALUE
+argf_print(int argc, const VALUE *argv, VALUE out)
+{
+  rb_io_print(argc, argv, out)
+}
+
 /*
  *  call-seq:
  *    print(*objects) -> nil
@@ -8794,6 +8806,12 @@ rb_io_putc(VALUE io, VALUE ch)
     }
     rb_io_write(io, str);
     return ch;
+}
+
+static VALUE
+argf_putc(VALUE io, VALUE ch)
+{
+  rb_io_putc(io, ch)
 }
 
 #define forward(obj, id, argc, argv) \
@@ -8946,6 +8964,12 @@ rb_io_puts(int argc, const VALUE *argv, VALUE out)
     }
 
     return Qnil;
+}
+
+VALUE
+argf_puts(int argc, const VALUE *argv, VALUE out)
+{
+  rb_io_puts(argc, argv, out)
 }
 
 /*
@@ -15821,10 +15845,10 @@ Init_IO(void)
     rb_define_method(rb_cARGF, "binmode?", argf_binmode_p, 0);
 
     rb_define_method(rb_cARGF, "write", argf_write, 1);
-    rb_define_method(rb_cARGF, "print", rb_io_print, -1);
-    rb_define_method(rb_cARGF, "putc", rb_io_putc, 1);
-    rb_define_method(rb_cARGF, "puts", rb_io_puts, -1);
-    rb_define_method(rb_cARGF, "printf", rb_io_printf, -1);
+    rb_define_method(rb_cARGF, "print", argf_print, -1);
+    rb_define_method(rb_cARGF, "putc", argf_putc, 1);
+    rb_define_method(rb_cARGF, "puts", argf_puts, -1);
+    rb_define_method(rb_cARGF, "printf", argf_printf, -1);
 
     rb_define_method(rb_cARGF, "filename", argf_filename, 0);
     rb_define_method(rb_cARGF, "path", argf_filename, 0);

--- a/io.c
+++ b/io.c
@@ -8560,7 +8560,7 @@ rb_io_printf(int argc, const VALUE *argv, VALUE out)
 VALUE
 argf_printf(int argc, const VALUE *argv, VALUE out)
 {
-  rb_io_printf(argc, argv, out)
+  return rb_io_printf(argc, argv, out)
 }
 
 /*
@@ -8713,7 +8713,7 @@ rb_io_print(int argc, const VALUE *argv, VALUE out)
 VALUE
 argf_print(int argc, const VALUE *argv, VALUE out)
 {
-  rb_io_print(argc, argv, out)
+  return rb_io_print(argc, argv, out)
 }
 
 /*
@@ -8811,7 +8811,7 @@ rb_io_putc(VALUE io, VALUE ch)
 static VALUE
 argf_putc(VALUE io, VALUE ch)
 {
-  rb_io_putc(io, ch)
+  return rb_io_putc(io, ch)
 }
 
 #define forward(obj, id, argc, argv) \
@@ -8969,7 +8969,7 @@ rb_io_puts(int argc, const VALUE *argv, VALUE out)
 VALUE
 argf_puts(int argc, const VALUE *argv, VALUE out)
 {
-  rb_io_puts(argc, argv, out)
+  return rb_io_puts(argc, argv, out)
 }
 
 /*

--- a/io.c
+++ b/io.c
@@ -8557,7 +8557,7 @@ rb_io_printf(int argc, const VALUE *argv, VALUE out)
     return Qnil;
 }
 
-VALUE
+static VALUE
 argf_printf(int argc, const VALUE *argv, VALUE out)
 {
   return rb_io_printf(argc, argv, out);

--- a/io.c
+++ b/io.c
@@ -8710,7 +8710,7 @@ rb_io_print(int argc, const VALUE *argv, VALUE out)
     return Qnil;
 }
 
-VALUE
+static VALUE
 argf_print(int argc, const VALUE *argv, VALUE out)
 {
   return rb_io_print(argc, argv, out);
@@ -8966,7 +8966,7 @@ rb_io_puts(int argc, const VALUE *argv, VALUE out)
     return Qnil;
 }
 
-VALUE
+static VALUE
 argf_puts(int argc, const VALUE *argv, VALUE out)
 {
   return rb_io_puts(argc, argv, out);

--- a/io.c
+++ b/io.c
@@ -8560,7 +8560,7 @@ rb_io_printf(int argc, const VALUE *argv, VALUE out)
 VALUE
 argf_printf(int argc, const VALUE *argv, VALUE out)
 {
-  return rb_io_printf(argc, argv, out)
+  return rb_io_printf(argc, argv, out);
 }
 
 /*
@@ -8713,7 +8713,7 @@ rb_io_print(int argc, const VALUE *argv, VALUE out)
 VALUE
 argf_print(int argc, const VALUE *argv, VALUE out)
 {
-  return rb_io_print(argc, argv, out)
+  return rb_io_print(argc, argv, out);
 }
 
 /*
@@ -8811,7 +8811,7 @@ rb_io_putc(VALUE io, VALUE ch)
 static VALUE
 argf_putc(VALUE io, VALUE ch)
 {
-  return rb_io_putc(io, ch)
+  return rb_io_putc(io, ch);
 }
 
 #define forward(obj, id, argc, argv) \
@@ -8969,7 +8969,7 @@ rb_io_puts(int argc, const VALUE *argv, VALUE out)
 VALUE
 argf_puts(int argc, const VALUE *argv, VALUE out)
 {
-  return rb_io_puts(argc, argv, out)
+  return rb_io_puts(argc, argv, out);
 }
 
 /*


### PR DESCRIPTION
Adds native code for methods #putc, #puts, #print, #printf, which formerly called corresponding methods in class IO;  this meant that the doc for the methods in ARGF came from IO.

This change will mean that the methods in ARGF can have their own documentation (not yet added).

This is a draft b/c I don't know how to run the test with the modified C code.  @peterzhu2118, if you can test this and it's ok, I will add the documentation.