### PR TITLE
Remove empty keyword splat in array after positional splat

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -10444,11 +10444,18 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const no
             const NODE *body_node = RNODE_ARGSPUSH(node)->nd_body;
             if (static_literal_node_p(body_node, iseq, false)) {
                 ADD_INSN1(ret, body_node, putobject, static_literal_value(body_node, iseq));
+                ADD_INSN1(ret, node, pushtoarray, INT2FIX(1));
             }
             else {
                 CHECK(COMPILE_(ret, "array element", body_node, FALSE));
+                if (keyword_node_p(body_node)) {
+                    ADD_INSN1(ret, node, newarraykwsplat, INT2FIX(1));
+                    ADD_INSN(ret, node, concattoarray);
+                }
+                else {
+                    ADD_INSN1(ret, node, pushtoarray, INT2FIX(1));
+                }
             }
-            ADD_INSN1(ret, node, pushtoarray, INT2FIX(1));
         }
         break;
       }

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -264,6 +264,41 @@ class TestSyntax < Test::Unit::TestCase
     assert_equal([h, {:a=>2}], [h, **h, **{}, a: 2])
   end
 
+  def test_array_splat_kwsplat_hash
+    a = []
+    kw = {}
+    h = {a: 1}
+    assert_equal([], [*a, **{}])
+    assert_equal([], [*a, **kw])
+    assert_equal([h], [*a, **h])
+    assert_equal([{}], [*a, {}])
+    assert_equal([kw], [*a, kw])
+    assert_equal([h], [*a, h])
+
+    assert_equal([1], [1, *a, **{}])
+    assert_equal([1], [1, *a, **kw])
+    assert_equal([1, h], [1, *a, **h])
+    assert_equal([1, {}], [1, *a, {}])
+    assert_equal([1, kw], [1, *a, kw])
+    assert_equal([1, h], [1, *a, h])
+
+    assert_equal([], [*a, **kw, **kw])
+    assert_equal([], [*a, **kw, **{}, **kw])
+    assert_equal([1], [1, *a, **kw, **{}, **kw])
+
+    assert_equal([{}], [*a, {}, *a, **kw, **kw])
+    assert_equal([kw], [*a, kw, *a, **kw, **kw])
+    assert_equal([h], [*a, h, *a, **kw, **kw])
+    assert_equal([h, h], [*a, h, *a, **kw, **kw, **h])
+
+    assert_equal([h, {:a=>2}], [*a, h, *a, **{}, **h, a: 2])
+    assert_equal([h, h], [*a, h, *a, **{}, a: 2, **h])
+    assert_equal([h, h], [*a, h, *a, a: 2, **{}, **h])
+    assert_equal([h, h], [*a, h, *a, a: 2, **h, **{}])
+    assert_equal([h, {:a=>2}], [*a, h, *a, **h, a: 2, **{}])
+    assert_equal([h, {:a=>2}], [*a, h, *a, **h, **{}, a: 2])
+  end
+
   def test_normal_argument
     assert_valid_syntax('def foo(x) end')
     assert_syntax_error('def foo(X) end', /constant/)


### PR DESCRIPTION
Previously, this wasn't removed, because compile_array_1 was missing the newarraykwsplat instruction that compile_array uses.

Fixes [Bug #20180]