### PR TITLE
Use index for referring to symbols in `args` rule instead of named references

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -4043,9 +4043,9 @@ args		: arg_value
                 | args ',' arg_splat
                     {
                     /*%%%*/
-                        $$ = rest_arg_append(p, $args, $arg_splat, &@$);
+                        $$ = rest_arg_append(p, $1, $3, &@$);
                     /*% %*/
-                    /*% ripper: args_add_star!($args, $arg_splat) %*/
+                    /*% ripper: args_add_star!($1, $3) %*/
                     }
                 ;
 


### PR DESCRIPTION
In `args: args ',' arg_splat`, `args` is not unique name. Currently the associated rule is interpreted as
`$$ = rest_arg_append(p, $$, $3, &@$);`.
The action works as expected because `$$` is initialized with `$1` before each action is executed.
However it's misleading then change to use index.