### PR TITLE
[PRISM] Fix keywords arguments in IndexAndWriteNode

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -385,6 +385,15 @@ module Prism
         hash["key", &(Proc.new { _1.upcase })] &&= "value"
         hash
       CODE
+
+      # Test with keyword arguments
+      assert_prism_eval(<<~RUBY)
+        h = Object.new
+        def h.[](**b) = 0
+        def h.[]=(*a, **b); end
+
+        h[foo: 1] &&= 2
+      RUBY
     end
 
     def test_IndexOrWriteNode


### PR DESCRIPTION
Fixes ruby/prism#2233.