### PR TITLE
[PRISM] Fix compiling rescue + ensure

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1506,6 +1506,22 @@ a
       CODE
     end
 
+    def test_rescue_with_ensure
+      assert_prism_eval(<<-CODE)
+begin
+  begin
+    raise "a"
+  rescue
+    raise "b"
+  ensure
+    raise "c"
+  end
+rescue => e
+  e.message
+end
+      CODE
+    end
+
     def test_required_kwarg_ordering
       assert_prism_eval("def self.foo(a: 1, b:); [a, b]; end; foo(b: 2)")
     end

--- a/tool/prism_btests
+++ b/tool/prism_btests
@@ -28,7 +28,7 @@
 ../src/bootstraptest/test_yjit_30k_ifelse.rb
 ../src/bootstraptest/test_yjit_30k_methods.rb
 ../src/bootstraptest/test_yjit_rust_port.rb
-# ../src/bootstraptest/test_exception.rb
+../src/bootstraptest/test_exception.rb
 # ../src/bootstraptest/test_insns.rb
 # ../src/bootstraptest/test_method.rb
 # ../src/bootstraptest/test_ractor.rb


### PR DESCRIPTION
When we're compiling begin / rescue / ensure nodes, we need to "wrap" the code in the begin statements correctly.  The wrapping is like this: (ensure code (rescue code (begin code)))

This patch pulls the each leg in to its own function, then calls the appropriate wrapping function depending on whether there are ensure / rescue legs.

Fixes: https://github.com/ruby/prism/issues/2221