### PR TITLE
[PRISM] Check keyword parameters correctly

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6751,6 +6751,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         //********STEP 5************
         // Goal: compile anything that needed to be compiled
         if (keywords_list && keywords_list->size) {
+            size_t optional_index = 0;
             for (size_t i = 0; i < keywords_list->size; i++, local_index++) {
                 pm_node_t *keyword_parameter_node = keywords_list->nodes[i];
                 pm_constant_id_t name;
@@ -6772,13 +6773,14 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
                         pm_local_index_t index = pm_lookup_local_index(iseq, scope_node, name, 0);
                         int kw_bits_idx = table_size - body->param.keyword->bits_start;
-                        ADD_INSN2(ret, &dummy_line_node, checkkeyword, INT2FIX(kw_bits_idx + VM_ENV_DATA_SIZE - 1), INT2FIX(i));
+                        ADD_INSN2(ret, &dummy_line_node, checkkeyword, INT2FIX(kw_bits_idx + VM_ENV_DATA_SIZE - 1), INT2FIX(optional_index));
                         ADD_INSNL(ret, &dummy_line_node, branchif, end_label);
                         PM_COMPILE(value);
                         ADD_SETLOCAL(ret, &dummy_line_node, index.index, index.level);
 
                         ADD_LABEL(ret, end_label);
                     }
+                    optional_index++;
                     break;
                   }
                   // def foo(a, (b, *c, d), e = 1, *f, g, (h, *i, j),  k:, l: 1, **m, &n)

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1515,6 +1515,11 @@ a
       CODE
     end
 
+    def test_complex_default_params
+      assert_prism_eval("def self.foo(a:, b: '2'.to_i); [a, b]; end; foo(a: 1)")
+      assert_prism_eval("def self.foo(a:, b: 2, c: '3'.to_i); [a, b, c]; end; foo(a: 1)")
+    end
+
     def test_rescue_with_ensure
       assert_prism_eval(<<-CODE)
 begin

--- a/tool/prism_btests
+++ b/tool/prism_btests
@@ -31,5 +31,5 @@
 ../src/bootstraptest/test_exception.rb
 ../src/bootstraptest/test_insns.rb
 ../src/bootstraptest/test_ractor.rb
-# ../src/bootstraptest/test_method.rb
+../src/bootstraptest/test_method.rb
 # ../src/bootstraptest/test_yjit.rb


### PR DESCRIPTION
We weren't checking the right offsets when compiling methods with keyword parameters that had complex code.

Fixes: https://github.com/ruby/prism/issues/2228