### PR TITLE
[PRISM] Support block parameters with no name

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6632,8 +6632,10 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                 body->param.flags.has_block = true;
 
                 pm_constant_id_t name = ((pm_block_parameter_node_t *)parameters_node->block)->name;
-                pm_insert_local_index(name, local_index, index_lookup_table, local_table_for_iseq, scope_node);
-                local_index++;
+                if (name != 0) {
+                    pm_insert_local_index(name, local_index, index_lookup_table, local_table_for_iseq, scope_node);
+                    local_index++;
+                }
             }
         }
 

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1690,6 +1690,15 @@ end
 
     def test_BlockArgumentNode
       assert_prism_eval("1.then(&:to_s)")
+
+      # Test forwarding with no name
+      assert_prism_eval(<<~RUBY)
+        o = Object.new
+        def o.foo(&) = yield
+        def o.bar(&) = foo(&)
+
+        o.bar { :ok }
+      RUBY
     end
 
     def test_BlockLocalVariableNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -2055,6 +2055,10 @@ end
     def test_BlockParameterNode
       assert_prism_eval("def prism_test_block_parameter_node(&bar) end")
       assert_prism_eval("->(b, c=1, *d, e, &f){}")
+
+      # Test BlockParameterNode with no name
+      assert_prism_eval("->(&){}")
+      assert_prism_eval("def prism_test_block_parameter_node(&); end")
     end
 
     def test_BlockParametersNode


### PR DESCRIPTION
Fixes ruby/prism#2249.