### PR TITLE
Dump annotations on RubyVM::ISeq.disasm

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -2526,6 +2526,15 @@ rb_iseq_disasm_recursive(const rb_iseq_t *iseq, VALUE indent)
         rb_str_modify_expand(str, header_minlen - l);
         memset(RSTRING_END(str), '=', header_minlen - l);
     }
+    if (iseq->body->builtin_attrs) {
+#define disasm_builtin_attr(str, iseq, attr) \
+        if (iseq->body->builtin_attrs & BUILTIN_ATTR_ ## attr) { \
+            rb_str_cat2(str, " " #attr); \
+        }
+        disasm_builtin_attr(str, iseq, LEAF);
+        disasm_builtin_attr(str, iseq, SINGLE_NOARG_LEAF);
+        disasm_builtin_attr(str, iseq, INLINE_BLOCK);
+    }
     rb_str_cat2(str, "\n");
 
     /* show catch table information */


### PR DESCRIPTION
Make it easier to check what annotations an ISEQ has. SINGLE_NOARG_LEAF is added automatically, so it's hard to be sure about the annotation by just reading code. It's also unclear to me what happens to it with Primitive.mandatory_only?, but this at least explains that LEAF annotation is not added to the non-mandatory_only ISEQ.

The information is added to the place where `(catch: false)` used to be annotated. We dropped the metadata along with MJIT in Ruby 3.3. It's probably nice to have ISEQ-level metadata like that there.