### PR TITLE
Use echo command in mswin platform

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -724,11 +724,7 @@ module Prism
 
     def test_InterpolatedXStringNode
       assert_prism_eval('`echo #{1}`')
-      if /mswin|ucrt/ =~ RUBY_PLATFORM
-        assert_prism_eval('`echo #{"100"}`')
-      else
-        assert_prism_eval('`printf #{"100"}`')
-      end
+      assert_prism_eval('`echo #{"100"}`')
     end
 
     def test_MatchLastLineNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -724,7 +724,11 @@ module Prism
 
     def test_InterpolatedXStringNode
       assert_prism_eval('`echo #{1}`')
-      assert_prism_eval('`printf #{"100"}`')
+      if /mswin|ucrt/ =~ RUBY_PLATFORM
+        assert_prism_eval('`echo #{"100"}`')
+      else
+        assert_prism_eval('`printf #{"100"}`')
+      end
     end
 
     def test_MatchLastLineNode


### PR DESCRIPTION
@kddnewton `test_InterpolatedXStringNode` is failed with mswin platform because `printf` is not provided on native windows console.

```
  1) Error:
Prism::TestCompilePrism#test_InterpolatedXStringNode:
Errno::ENOENT: No such file or directory - printf 100
    <compiled>:2:in ``'
    <compiled>:2:in `<class:TestCompilePrism>'
    <compiled>:1:in `<compiled>'
    C:/Users/hsbt/source/repos/ruby/ruby/test/ruby/test_compile_prism.rb:2439:in `eval'
    C:/Users/hsbt/source/repos/ruby/ruby/test/ruby/test_compile_prism.rb:2439:in `compare_eval'
    C:/Users/hsbt/source/repos/ruby/ruby/test/ruby/test_compile_prism.rb:2453:in `assert_prism_eval'
    C:/Users/hsbt/source/repos/ruby/ruby/test/ruby/test_compile_prism.rb:712:in `test_InterpolatedXStringNode'
```

I'm not sure why it doesn't use `echo` command same as first assertion.