### PR TITLE
Fix default gemspec file list for extension gems

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -573,7 +573,12 @@ module RbInstall
           return [] if name.empty?
 
           feature = makefile[/^DLLIB[ \t]*=[ \t]*((?:.*\\\n)*.*)/, 1]
-          Array(feature.sub("$(TARGET)", name))
+          feature = feature.sub("$(TARGET)", name)
+
+          target_prefix = makefile[/^target_prefix[ \t]*=[ \t]*((?:.*\\\n)*.*)/, 1]
+          feature = File.join(target_prefix.delete_prefix("/"), feature) unless target_prefix.empty?
+
+          Array(feature)
         end
 
         def makefile_path

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -549,18 +549,36 @@ module RbInstall
       end
 
       def collect
-        ruby_libraries.sort
+        libraries.sort
       end
 
       class Ext < self
-        def ruby_libraries
+        def libraries
           # install ext only when it's configured
-          return [] unless File.exist?("#{makefile_dir}/Makefile")
+          return [] unless File.exist?(makefile_path)
 
-          Dir.glob("lib/**/*.rb", base: makefile_dir)
+          ruby_libraries + ext_libraries
         end
 
         private
+
+        def ruby_libraries
+          Dir.glob("**/*.rb", base: "#{makefile_dir}/lib")
+        end
+
+        def ext_libraries
+          makefile = File.read(makefile_path)
+
+          name = makefile[/^TARGET[ \t]*=[ \t]*((?:.*\\\n)*.*)/, 1]
+          return [] if name.empty?
+
+          feature = makefile[/^DLLIB[ \t]*=[ \t]*((?:.*\\\n)*.*)/, 1]
+          Array(feature.sub("$(TARGET)", name))
+        end
+
+        def makefile_path
+          "#{makefile_dir}/Makefile"
+        end
 
         def makefile_dir
           File.expand_path("#{$ext_build_dir}/#{relative_base}", srcdir)
@@ -568,7 +586,7 @@ module RbInstall
       end
 
       class Lib < self
-        def ruby_libraries
+        def libraries
           gemname = File.basename(gemspec, ".gemspec")
           base = relative_base || gemname
           # for lib/net/net-smtp.gemspec

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -549,24 +549,24 @@ module RbInstall
       end
 
       def collect
-        libraries.sort
+        requirable_features.sort
       end
 
       class Ext < self
-        def libraries
+        def requirable_features
           # install ext only when it's configured
           return [] unless File.exist?(makefile_path)
 
-          ruby_libraries + ext_libraries
+          ruby_features + ext_features
         end
 
         private
 
-        def ruby_libraries
+        def ruby_features
           Dir.glob("**/*.rb", base: "#{makefile_dir}/lib")
         end
 
-        def ext_libraries
+        def ext_features
           makefile = File.read(makefile_path)
 
           name = makefile[/^TARGET[ \t]*=[ \t]*((?:.*\\\n)*.*)/, 1]
@@ -586,24 +586,24 @@ module RbInstall
       end
 
       class Lib < self
-        def libraries
+        def requirable_features
           gemname = File.basename(gemspec, ".gemspec")
           base = relative_base || gemname
           # for lib/net/net-smtp.gemspec
           if m = /.*(?=-(.*)\z)/.match(gemname)
             base = File.join(base, *m.to_a.select {|n| !base.include?(n)})
           end
-          files = Dir.glob("lib/#{base}{.rb,/**/*.rb}", base: srcdir)
+          files = Dir.glob("#{base}{.rb,/**/*.rb}", base: "#{srcdir}/lib")
           if !relative_base and files.empty? # no files at the toplevel
             # pseudo gem like ruby2_keywords
-            files << "lib/#{gemname}.rb"
+            files << "#{gemname}.rb"
           end
 
           case gemname
           when "net-http"
-            files << "lib/net/https.rb"
+            files << "net/https.rb"
           when "optparse"
-            files << "lib/optionparser.rb"
+            files << "optionparser.rb"
           end
 
           files

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -553,12 +553,10 @@ module RbInstall
       end
 
       class Ext < self
-        def skip_install?(files)
-          # install ext only when it's configured
-          !File.exist?("#{makefile_dir}/Makefile")
-        end
-
         def ruby_libraries
+          # install ext only when it's configured
+          return [] unless File.exist?("#{makefile_dir}/Makefile")
+
           Dir.glob("lib/**/*.rb", base: makefile_dir)
         end
 
@@ -570,10 +568,6 @@ module RbInstall
       end
 
       class Lib < self
-        def skip_install?(files)
-          files.empty?
-        end
-
         def ruby_libraries
           gemname = File.basename(gemspec, ".gemspec")
           base = relative_base || gemname
@@ -763,7 +757,7 @@ def install_default_gem(dir, srcdir, bindir)
     spec = load_gemspec("#{base}/#{src}")
     file_collector = RbInstall::Specs::FileCollector.for(srcdir, dir, src)
     files = file_collector.collect
-    if file_collector.skip_install?(files)
+    if files.empty?
       next
     end
     spec.files = files

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -586,7 +586,11 @@ module RbInstall
         end
 
         def makefile_dir
-          File.expand_path("#{$ext_build_dir}/#{relative_base}", srcdir)
+          "#{root}/#{relative_base}"
+        end
+
+        def root
+          File.expand_path($ext_build_dir, srcdir)
         end
       end
 
@@ -598,7 +602,7 @@ module RbInstall
           if m = /.*(?=-(.*)\z)/.match(gemname)
             base = File.join(base, *m.to_a.select {|n| !base.include?(n)})
           end
-          files = Dir.glob("#{base}{.rb,/**/*.rb}", base: "#{srcdir}/lib")
+          files = Dir.glob("#{base}{.rb,/**/*.rb}", base: root)
           if !relative_base and files.empty? # no files at the toplevel
             # pseudo gem like ruby2_keywords
             files << "#{gemname}.rb"
@@ -612,6 +616,10 @@ module RbInstall
           end
 
           files
+        end
+
+        def root
+          "#{srcdir}/lib"
         end
       end
     end

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -555,11 +555,17 @@ module RbInstall
       class Ext < self
         def skip_install?(files)
           # install ext only when it's configured
-          !File.exist?("#{$ext_build_dir}/#{relative_base}/Makefile")
+          !File.exist?("#{makefile_dir}/Makefile")
         end
 
         def ruby_libraries
-          Dir.glob("lib/**/*.rb", base: "#{srcdir}/ext/#{relative_base}")
+          Dir.glob("lib/**/*.rb", base: makefile_dir)
+        end
+
+        private
+
+        def makefile_dir
+          File.expand_path("#{$ext_build_dir}/#{relative_base}", srcdir)
         end
       end
 


### PR DESCRIPTION
This is work to fix:

* https://github.com/rubygems/rubygems/issues/6207

and

* https://github.com/rubygems/rubygems/issues/7160
