### PR TITLE
[PRISM] Fix crash in anonymous block with forwarding arguments

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6617,8 +6617,8 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
                     body->param.block_start = local_index;
                     body->param.flags.has_block = true;
-                    local = idAnd;
-                    local_table_for_iseq->ids[local_index] = local;
+                    local_table_for_iseq->ids[local_index] = PM_CONSTANT_AND;
+                    st_insert(index_lookup_table, PM_CONSTANT_AND, local_index);
                     local_index++;
 
                     local = idDot3;

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1713,11 +1713,20 @@ end
     def test_BlockArgumentNode
       assert_prism_eval("1.then(&:to_s)")
 
-      # Test forwarding with no name
+      # Test anonymous block forwarding
       assert_prism_eval(<<~RUBY)
         o = Object.new
         def o.foo(&) = yield
         def o.bar(&) = foo(&)
+
+        o.bar { :ok }
+      RUBY
+
+      # Test anonymous block forwarding from argument forwarding
+      assert_prism_eval(<<~RUBY)
+        o = Object.new
+        def o.foo = yield
+        def o.bar(...) = foo(&)
 
         o.bar { :ok }
       RUBY


### PR DESCRIPTION
Fixes ruby/prism#2262.