### PR TITLE
Add an internal event hook for JIT side_exits

### DIFF
--- a/include/ruby/internal/event.h
+++ b/include/ruby/internal/event.h
@@ -89,7 +89,7 @@
  */
 #define RUBY_INTERNAL_EVENT_SWITCH          0x040000 /**< Thread switched. */
 #define RUBY_EVENT_SWITCH                   0x040000 /**< @old{RUBY_INTERNAL_EVENT_SWITCH} */
-                                         /* 0x080000 */
+#define RUBY_INTERNAL_EVENT_JIT_SIDE_EXIT   0x080000 /**< RJIT/YJIT side exit. */
 #define RUBY_INTERNAL_EVENT_NEWOBJ          0x100000 /**< Object allocated. */
 #define RUBY_INTERNAL_EVENT_FREEOBJ         0x200000 /**< Object swept. */
 #define RUBY_INTERNAL_EVENT_GC_START        0x400000 /**< GC started. */

--- a/vm.c
+++ b/vm.c
@@ -458,7 +458,11 @@ jit_exec(rb_execution_context_t *ec)
     rb_jit_func_t func = jit_compile(ec);
     if (func) {
         // Call the JIT code
-        return func(ec, ec->cfp);
+        VALUE val = func(ec, ec->cfp);
+        if (val == Qundef) {
+            EXEC_EVENT_HOOK(ec, RUBY_INTERNAL_EVENT_JIT_SIDE_EXIT, ec->cfp->self, 0, 0, 0, Qundef);
+        }
+        return val;
     }
     else {
         return Qundef;

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -179,6 +179,9 @@ default:                        \
     if (val == Qundef && (func = jit_compile(ec))) { \
         val = func(ec, ec->cfp); \
         RESTORE_REGS(); /* fix cfp for tailcall */ \
+        if (val == Qundef) { \
+            EXEC_EVENT_HOOK(ec, RUBY_INTERNAL_EVENT_JIT_SIDE_EXIT, ec->cfp->self, 0, 0, 0, Qundef); \
+        } \
         if (ec->tag->state) THROW_EXCEPTION(val); \
     } \
 } while (0)


### PR DESCRIPTION
This adds the ability for an extension to trace side exits from YJIT/RJIT on demand. This allows, for example, gathering the same type of data as ``.

I believe this will be very low overhead as we only need to check in the case we are already side-exiting (the C compiler should be able to combine the `val == Qundef` check with an existing one) and when not hooked into `EXEC_EVENT_HOOK` is a simple bit test.

I've prototyped this in vernier https://github.com/jhawthorn/vernier/pull/24 but would happily add the same functionality to `stackprof` or a standlone gem as well so that it's widely available.

(TODO: I'll run benchmarks to verify no increase in overhead)