### PR TITLE
YJIT: fix small bug causing jit_rb_int_rshift to side-exit

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4712,6 +4712,8 @@ fn jit_rb_int_lshift(
     }
 
     // Fallback to a C call if the shift amount varies
+    // This check is needed because the chain guard will side-exit
+    // if its max depth is reached
     if asm.ctx.get_chain_depth() > 0 {
         return false;
     }
@@ -4771,7 +4773,9 @@ fn jit_rb_int_rshift(
     }
 
     // Fallback to a C call if the shift amount varies
-    if asm.ctx.get_chain_depth() > 1 {
+    // This check is needed because the chain guard will side-exit
+    // if its max depth is reached
+    if asm.ctx.get_chain_depth() > 0 {
         return false;
     }
 


### PR DESCRIPTION
The nqueens benchmark was showing zero performance improvement because we immediately side-exited as soon as the shift amount changed. If the amount changes, we want to fall back to the C function call, not side-exit.

Before:
```
-------  -----------  ----------  ---------  ----------  ------------  -----------
bench    interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
nqueens  168.1        0.9         170.2      0.4         1.00          0.99       
-------  -----------  ----------  ---------  ----------  ------------  -----------
```

After:
```
-------  -----------  ----------  ---------  ----------  ------------  -----------
bench    interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
nqueens  169.5        0.4         43.1       0.9         0.99          3.93       
-------  -----------  ----------  ---------  ----------  ------------  -----------
```