### PR TITLE
YJIT: reduce default exec mem size to 48MiB

### DIFF
--- a/doc/yjit/yjit.md
+++ b/doc/yjit/yjit.md
@@ -165,7 +165,7 @@ The machine code generated for a given method can be printed by adding `puts Rub
 YJIT supports all command-line options supported by upstream CRuby, but also adds a few YJIT-specific options:
 
 - `--yjit`: enable YJIT (disabled by default)
-- `--yjit-exec-mem-size=N`: size of the executable memory block to allocate, in MiB (default 64 MiB)
+- `--yjit-exec-mem-size=N`: size of the executable memory block to allocate, in MiB (default 48 MiB)
 - `--yjit-call-threshold=N`: number of calls after which YJIT begins to compile a function.
   It defaults to 30, and it's then increased to 120 when the number of ISEQs in the process reaches 40,000.
 - `--yjit-cold-threshold=N`: number of global calls after which an ISEQ is considered cold and not

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -81,7 +81,7 @@ pub struct Options {
 
 // Initialize the options to default values
 pub static mut OPTIONS: Options = Options {
-    exec_mem_size: 64 * 1024 * 1024,
+    exec_mem_size: 48 * 1024 * 1024,
     no_type_prop: false,
     max_versions: 4,
     num_temp_regs: 5,
@@ -101,7 +101,7 @@ pub static mut OPTIONS: Options = Options {
 
 /// YJIT option descriptions for `ruby --help`.
 static YJIT_OPTIONS: [(&str, &str); 9] = [
-    ("--yjit-exec-mem-size=num",           "Size of executable memory block in MiB (default: 64)"),
+    ("--yjit-exec-mem-size=num",           "Size of executable memory block in MiB (default: 48)"),
     ("--yjit-call-threshold=num",          "Number of calls to trigger JIT"),
     ("--yjit-cold-threshold=num",          "Global calls after which ISEQs not compiled (default: 200K)"),
     ("--yjit-stats",                       "Enable collecting YJIT statistics"),


### PR DESCRIPTION
Based on user feedback from @jhawthorn and others. Better for small and memory-constrained deployments.

NOTE: This commit should be included in the next Ruby 3.3.x point release. @xrxr should we tag someone specific?