### PR TITLE
[PRISM] Handle stack and local table sizes for repeated params

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6418,7 +6418,11 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                   case PM_REQUIRED_PARAMETER_NODE: {
                     pm_required_parameter_node_t * param = (pm_required_parameter_node_t *)required;
 
-                    if (!PM_NODE_FLAG_P(required, PM_PARAMETER_FLAGS_REPEATED_PARAMETER)) {
+                    if (PM_NODE_FLAG_P(required, PM_PARAMETER_FLAGS_REPEATED_PARAMETER)) {
+                        ID local = pm_constant_id_lookup(scope_node, param->name);
+                        local_table_for_iseq->ids[local_index] = local;
+                    }
+                    else {
                         pm_insert_local_index(param->name, local_index, index_lookup_table, local_table_for_iseq, scope_node);
                     }
                     break;

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6359,7 +6359,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                 // additional anonymous local not represented in the locals table
                 // We want to account for this in our table size
                 pm_node_t *required = posts_list->nodes[i];
-                if (PM_NODE_TYPE_P(required, PM_MULTI_TARGET_NODE)) {
+                if (PM_NODE_TYPE_P(required, PM_MULTI_TARGET_NODE) || PM_NODE_FLAG_P(required, PM_PARAMETER_FLAGS_REPEATED_PARAMETER)) {
                     table_size++;
                 }
             }
@@ -6528,8 +6528,14 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                   //                                   ^
                   case PM_REQUIRED_PARAMETER_NODE: {
                     pm_required_parameter_node_t * param = (pm_required_parameter_node_t *)post_node;
+                    if (PM_NODE_FLAG_P(param, PM_PARAMETER_FLAGS_REPEATED_PARAMETER)) {
+                        ID local = pm_constant_id_lookup(scope_node, param->name);
+                        local_table_for_iseq->ids[local_index] = local;
+                    }
+                    else {
 
-                    pm_insert_local_index(param->name, local_index, index_lookup_table, local_table_for_iseq, scope_node);
+                        pm_insert_local_index(param->name, local_index, index_lookup_table, local_table_for_iseq, scope_node);
+                    }
                     break;
                   }
                   default: {

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6365,6 +6365,15 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             }
         }
 
+        if (keywords_list && keywords_list->size) {
+            for (size_t i = 0; i < keywords_list->size; i++) {
+                pm_node_t *keyword_parameter_node = keywords_list->nodes[i];
+                if (PM_NODE_FLAG_P(keyword_parameter_node, PM_PARAMETER_FLAGS_REPEATED_PARAMETER)) {
+                    table_size++;
+                }
+            }
+        }
+
         if (block_param_keyword_rest) {
             table_size++;
         }
@@ -6570,7 +6579,13 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                     name = ((pm_required_keyword_parameter_node_t *)keyword_parameter_node)->name;
                     keyword->required_num++;
                     ID local = pm_constant_id_lookup(scope_node, name);
-                    pm_insert_local_index(name, local_index, index_lookup_table, local_table_for_iseq, scope_node);
+
+                    if (PM_NODE_FLAG_P(keyword_parameter_node, PM_PARAMETER_FLAGS_REPEATED_PARAMETER)) {
+                        local_table_for_iseq->ids[local_index] = local;
+                    }
+                    else {
+                        pm_insert_local_index(name, local_index, index_lookup_table, local_table_for_iseq, scope_node);
+                    }
                     local_index++;
                     ids[kw_index++] = local;
                 }
@@ -6600,7 +6615,12 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                     }
 
                     ID local = pm_constant_id_lookup(scope_node, name);
-                    pm_insert_local_index(name, local_index, index_lookup_table, local_table_for_iseq, scope_node);
+                    if (PM_NODE_FLAG_P(keyword_parameter_node, PM_PARAMETER_FLAGS_REPEATED_PARAMETER)) {
+                        local_table_for_iseq->ids[local_index] = local;
+                    }
+                    else {
+                        pm_insert_local_index(name, local_index, index_lookup_table, local_table_for_iseq, scope_node);
+                    }
                     ids[kw_index++] = local;
                     local_index++;
                 }

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6345,11 +6345,19 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         // table size to take it in to account.
         // def m(foo, *, bar)
         //            ^
-        if (parameters_node && parameters_node->rest) {
-            if (!(PM_NODE_TYPE_P(parameters_node->rest, PM_IMPLICIT_REST_NODE))) {
-                if (!((pm_rest_parameter_node_t *)parameters_node->rest)->name || PM_NODE_FLAG_P(parameters_node->rest, PM_PARAMETER_FLAGS_REPEATED_PARAMETER)) {
-                    table_size++;
+        if (parameters_node) {
+            if (parameters_node->rest) {
+                if (!(PM_NODE_TYPE_P(parameters_node->rest, PM_IMPLICIT_REST_NODE))) {
+                    if (!((pm_rest_parameter_node_t *)parameters_node->rest)->name || PM_NODE_FLAG_P(parameters_node->rest, PM_PARAMETER_FLAGS_REPEATED_PARAMETER)) {
+                        table_size++;
+                    }
                 }
+            }
+
+            // def underscore_parameters(_, **_); _; end
+            //                              ^^^
+            if (parameters_node->keyword_rest && PM_NODE_FLAG_P(parameters_node->keyword_rest, PM_PARAMETER_FLAGS_REPEATED_PARAMETER)) {
+                table_size++;
             }
         }
 
@@ -6678,7 +6686,13 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
                     pm_constant_id_t constant_id = kw_rest_node->name;
                     if (constant_id) {
-                        pm_insert_local_index(constant_id, local_index, index_lookup_table, local_table_for_iseq, scope_node);
+                        if (PM_NODE_FLAG_P(kw_rest_node, PM_PARAMETER_FLAGS_REPEATED_PARAMETER)) {
+                            ID local = pm_constant_id_lookup(scope_node, constant_id);
+                            local_table_for_iseq->ids[local_index] = local;
+                        }
+                        else {
+                            pm_insert_local_index(constant_id, local_index, index_lookup_table, local_table_for_iseq, scope_node);
+                        }
                     }
                     else {
                         local_table_for_iseq->ids[local_index] = PM_CONSTANT_POW;

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1545,6 +1545,10 @@ a
       CODE
     end
 
+    def test_repeated_required_post_underscore
+      assert_prism_eval("def self.m(_, _, *_, _); _; end; method(:m).parameters")
+    end
+
     def test_repeated_splat_underscore
       assert_prism_eval("def self.m(_, _, _ = 1, _ = 2, *_); end; method(:m).parameters")
     end

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1545,6 +1545,10 @@ a
       CODE
     end
 
+    def test_repeated_block_underscore
+      assert_prism_eval("def self.m(_, **_, &_); _; end; method(:m).parameters")
+    end
+
     def test_repeated_kw_rest_underscore
       assert_prism_eval("def self.m(_, **_); _; end; method(:m).parameters")
     end

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1545,6 +1545,10 @@ a
       CODE
     end
 
+    def test_repeated_optional_underscore
+      assert_prism_eval("def self.m(a, _, _, _ = 1, _ = 2, b); end; method(:m).parameters")
+    end
+
     def test_repeated_required_underscore
       assert_prism_eval("def self.m(a, _, _, b); end; method(:m).parameters")
     end

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1545,6 +1545,11 @@ a
       CODE
     end
 
+    def test_repeated_required_keyword_underscore
+      assert_prism_eval("def self.m(_, _, *_, _, _:); _; end; method(:m).parameters")
+      assert_prism_eval("def self.m(_, _, *_, _, _:, _: 2); _; end; method(:m).parameters")
+    end
+
     def test_repeated_required_post_underscore
       assert_prism_eval("def self.m(_, _, *_, _); _; end; method(:m).parameters")
     end

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1545,6 +1545,10 @@ a
       CODE
     end
 
+    def test_repeated_required_underscore
+      assert_prism_eval("def self.m(a, _, _, b); end; method(:m).parameters")
+    end
+
     def test_locals_in_parameters
       assert_prism_eval("def self.m(a = b = c = 1); [a, b, c]; end; self.m")
     end

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1545,6 +1545,10 @@ a
       CODE
     end
 
+    def test_repeated_kw_rest_underscore
+      assert_prism_eval("def self.m(_, **_); _; end; method(:m).parameters")
+    end
+
     def test_repeated_required_keyword_underscore
       assert_prism_eval("def self.m(_, _, *_, _, _:); _; end; method(:m).parameters")
       assert_prism_eval("def self.m(_, _, *_, _, _:, _: 2); _; end; method(:m).parameters")

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1545,6 +1545,10 @@ a
       CODE
     end
 
+    def test_repeated_splat_underscore
+      assert_prism_eval("def self.m(_, _, _ = 1, _ = 2, *_); end; method(:m).parameters")
+    end
+
     def test_repeated_optional_underscore
       assert_prism_eval("def self.m(a, _, _, _ = 1, _ = 2, b); end; method(:m).parameters")
     end


### PR DESCRIPTION
This is a big patch, but we tried to split the commits for each type of repeated `_` in a method definition.

Fixes: https://github.com/ruby/prism/issues/2252