### PR TITLE
YJIT: Avoid leaks by skipping objects with a singleton class

### DIFF
--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -446,6 +446,7 @@ fn main() {
         .allowlist_function("rb_obj_is_proc")
         .allowlist_function("rb_vm_base_ptr")
         .allowlist_function("rb_ec_stack_check")
+        .allowlist_function("rb_vm_top_self")
 
         // We define VALUE manually, don't import it
         .blocklist_type("VALUE")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7321,6 +7321,17 @@ fn gen_send_general(
     assert_eq!(RUBY_T_CLASS, comptime_recv_klass.builtin_type(),
         "objects visible to ruby code should have a T_CLASS in their klass field");
 
+    // Don't compile calls through singleton classes to avoid retaining the receiver.
+    // Make an exception for class methods since classes tend to be retained anyways.
+    // Also compile calls on top_self to help tests.
+    if VALUE(0) != unsafe { FL_TEST(comptime_recv_klass, VALUE(RUBY_FL_SINGLETON as usize)) }
+        && comptime_recv != unsafe { rb_vm_top_self() }
+        && !unsafe { RB_TYPE_P(comptime_recv, RUBY_T_CLASS) }
+        && !unsafe { RB_TYPE_P(comptime_recv, RUBY_T_MODULE) } {
+        gen_counter_incr(asm, Counter::send_singleton_class);
+        return None;
+    }
+
     // Points to the receiver operand on the stack
     let recv = asm.stack_opnd(recv_idx);
     let recv_opnd: YARVOpnd = recv.into();
@@ -8091,6 +8102,12 @@ fn gen_invokesuper_specialized(
     let comptime_recv = jit.peek_at_stack(&asm.ctx, argc as isize);
     if unsafe { rb_obj_is_kind_of(comptime_recv, current_defined_class) } == VALUE(0) {
         gen_counter_incr(asm, Counter::invokesuper_defined_class_mismatch);
+        return None;
+    }
+
+    // Don't compile `super` on objects with singleton class to avoid retaining the receiver.
+    if VALUE(0) != unsafe { FL_TEST(comptime_recv.class_of(), VALUE(RUBY_FL_SINGLETON as usize)) } {
+        gen_counter_incr(asm, Counter::invokesuper_singleton_class);
         return None;
     }
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -974,6 +974,7 @@ extern "C" {
         n: ::std::os::raw::c_long,
         elts: *const VALUE,
     ) -> VALUE;
+    pub fn rb_vm_top_self() -> VALUE;
     pub static mut rb_vm_insns_count: u64;
     pub fn rb_method_entry_at(obj: VALUE, id: ID) -> *const rb_method_entry_t;
     pub fn rb_callable_method_entry(klass: VALUE, id: ID) -> *const rb_callable_method_entry_t;

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -300,6 +300,7 @@ make_counters! {
     // Method calls that fallback to dynamic dispatch
     send_keywords,
     send_kw_splat,
+    send_singleton_class,
     send_args_splat_super,
     send_iseq_zsuper,
     send_block_arg,
@@ -388,6 +389,7 @@ make_counters! {
     invokesuper_no_me,
     invokesuper_not_iseq_or_cfunc,
     invokesuper_refinement,
+    invokesuper_singleton_class,
 
     invokeblock_megamorphic,
     invokeblock_none,


### PR DESCRIPTION
For receiver with a singleton class, there are multiple vectors YJIT can
end up retaining the object. There is a path in jit_guard_known_klass()
that bakes the receiver into the code, and the object could also be kept
alive indirectly through a path starting at the CME object baked into
the code.

To avoid these leaks, avoid compiling calls on objects with a singleton
class.

See: https://github.com/Shopify/ruby/issues/552

There is little to no performance impact on headlining benchmarks:

```
yjit-pre: ruby 3.4.0dev (2024-01-23T19:00:05Z master 557b69e83b) +YJIT [x86_64-linux]
yjit-post: ruby 3.4.0dev (2024-01-23T23:05:17Z yjit-stop-singleto.. ab19268644) +YJIT [x86_64-linux]

--------------  -------------  ----------  --------------  ----------  -----------------  ------------------
bench           yjit-pre (ms)  stddev (%)  yjit-post (ms)  stddev (%)  yjit-post 1st itr  yjit-pre/yjit-post
activerecord    41.3           1.2         41.0            1.1         1.02               1.01              
chunky-png      627.4          0.5         637.1           0.7         0.99               0.98              
erubi-rails     1397.3         0.4         1439.6          0.4         0.97               0.97              
hexapdf         2112.7         1.9         2117.5          1.3         0.99               1.00              
liquid-c        56.8           1.4         57.1            1.4         1.00               1.00              
liquid-compile  57.3           2.0         57.3            1.5         1.00               1.00              
liquid-render   78.4           1.1         78.7            1.2         1.00               1.00              
lobsters        855.4          1.4         862.8           1.1         1.00               0.99              
mail            120.7          0.8         120.9           0.8         1.00               1.00              
psych-load      1807.1         0.1         1798.4          0.1         1.00               1.00              
railsbench      1726.0         0.3         1735.3          0.3         1.00               0.99              
rubocop         116.6          5.0         116.1           5.2         0.99               1.00              
ruby-lsp        116.8          3.6         114.7           3.5         0.97               1.02              
sequel          66.3           0.8         66.3            0.8         1.00               1.00              
--------------  -------------  ----------  --------------  ----------  -----------------  ------------------
```