### PR TITLE
YJIT: Add a counter for invokebuiltin exits

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -271,6 +271,7 @@ module RubyVM::YJIT
         branchunless
         definedivar
         expandarray
+        invokebuiltin
         jump
         leave
         objtostring

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -8786,6 +8786,7 @@ fn gen_invokebuiltin(
 
     // ec, self, and arguments
     if bf_argc + 2 > C_ARG_OPNDS.len() {
+        incr_counter!(invokebuiltin_too_many_args);
         return None;
     }
 
@@ -8825,6 +8826,7 @@ fn gen_opt_invokebuiltin_delegate(
 
     // ec, self, and arguments
     if bf_argc + 2 > (C_ARG_OPNDS.len() as i32) {
+        incr_counter!(invokebuiltin_too_many_args);
         return None;
     }
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -468,6 +468,8 @@ make_counters! {
 
     setlocal_wb_required,
 
+    invokebuiltin_too_many_args,
+
     opt_plus_overflow,
     opt_minus_overflow,
     opt_mult_overflow,


### PR DESCRIPTION
SFR has some exits on `opt_invokebuiltin_delegate`. This exit seems like the only reason for that instruction, but I'd like to double-check it using this counter.