### PR TITLE
Fix issues related Encoding with mswin platform

### DIFF
--- a/test/-ext-/string/test_fstring.rb
+++ b/test/-ext-/string/test_fstring.rb
@@ -15,16 +15,16 @@ class Test_String_Fstring < Test::Unit::TestCase
   def test_rb_enc_interned_str_autoloaded_encoding
     assert_separately([], <<~RUBY)
       require '-test-/string'
-      assert_include(Encoding::Windows_31J.inspect, 'autoload')
-      Bug::String.rb_enc_interned_str(Encoding::Windows_31J)
+      assert_include(Encoding::CESU_8.inspect, 'autoload')
+      Bug::String.rb_enc_interned_str(Encoding::CESU_8)
     RUBY
   end
 
   def test_rb_enc_str_new_autoloaded_encoding
     assert_separately([], <<~RUBY)
       require '-test-/string'
-      assert_include(Encoding::Windows_31J.inspect, 'autoload')
-      Bug::String.rb_enc_str_new(Encoding::Windows_31J)
+      assert_include(Encoding::CESU_8.inspect, 'autoload')
+      Bug::String.rb_enc_str_new(Encoding::CESU_8)
     RUBY
   end
 

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -2170,7 +2170,7 @@ EOS
       "c\u{1EE7}a",
     ].each do |arg|
       begin
-        arg = arg.encode(Encoding.find("locale"))
+        arg = arg.encode(Encoding.local_charmap)
       rescue
       else
         assert_in_out_err([], "#{<<-"begin;"}\n#{<<-"end;"}", [arg], [], bug12841)

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -366,18 +366,10 @@ class TestRubyOptions < Test::Unit::TestCase
     assert_in_out_err(%w(--encoding test_ruby_test_rubyoptions_foobarbazqux), "", [],
                       /unknown encoding name - test_ruby_test_rubyoptions_foobarbazqux \(RuntimeError\)/)
 
-    if /mswin|mingw|aix|android/ =~ RUBY_PLATFORM &&
-      (str = "\u3042".force_encoding(Encoding.find("external"))).valid_encoding?
-      # This result depends on locale because LANG=C doesn't affect locale
-      # on Windows.
-      # On AIX, the source encoding of stdin with LANG=C is ISO-8859-1,
-      # which allows \u3042.
-      out, err = [str], []
-    else
-      out, err = [], /invalid multibyte char/
-    end
-    assert_in_out_err(%w(-Eutf-8), "puts '\u3042'", out, err)
-    assert_in_out_err(%w(--encoding utf-8), "puts '\u3042'", out, err)
+    assert_in_out_err(%w(-Eutf-8), 'puts Encoding::default_external', ["UTF-8"])
+    assert_in_out_err(%w(-Ecesu-8), 'puts Encoding::default_external', ["CESU-8"])
+    assert_in_out_err(%w(--encoding utf-8), 'puts Encoding::default_external', ["UTF-8"])
+    assert_in_out_err(%w(--encoding cesu-8), 'puts Encoding::default_external', ["CESU-8"])
   end
 
   def test_syntax_check


### PR DESCRIPTION
Try to fix:

```
  1) Failure:
Test_String_Fstring#test_rb_enc_interned_str_autoloaded_encoding [C:/Users/hsbt/source/repos/ruby/ruby/test/-ext-/string/test_fstring.rb:18]:
Expected "#<Encoding:Windows-31J>" to include "autoload".

[  7/372] Test_String_Fstring#test_rb_enc_str_new_autoloaded_encoding = 0.26 s
  2) Failure:
Test_String_Fstring#test_rb_enc_str_new_autoloaded_encoding [C:/Users/hsbt/source/repos/ruby/ruby/test/-ext-/string/test_fstring.rb:26]:
Expected "#<Encoding:Windows-31J>" to include "autoload".

[180/372] TestRubyOptions#test_encoding = 0.11 s
  4) Failure:
TestRubyOptions#test_encoding [C:/Users/hsbt/source/repos/ruby/ruby/test/ruby/test_rubyoptions.rb:379]:
pid 16552 exit 1
| -:1: invalid multibyte char (Windows-31J)
| -: compile error (SyntaxError)
.

1. [1/2] Assertion for "stdout"
   | <["あ"]> expected but was
   | <[]>.

2. [2/2] Assertion for "stderr"
   | <[]> expected but was
   | <["-:1: invalid multibyte char (Windows-31J)", "-: compile error (SyntaxError)"]>.

[321/372] TestProcess#test_exec_nonascii = 0.06 s
  5) Failure:
TestProcess#test_exec_nonascii [C:/Users/hsbt/source/repos/ruby/ruby/test/ruby/test_process.rb:2176]:
[ruby-dev:49838] [Bug #12841]
pid 30816 exit 0.

1. [1/2] Assertion for "stdout"
   | <["\x{8D67}\x{8BCA}"]> expected but was
   | <["紅玉"]>.
```