### PR TITLE
Bundle rbs-3.4.3

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -85,7 +85,7 @@ jobs:
         env:
           RUBY_TESTOPTS: '-q --tty=no'
           TESTS: ${{ matrix.test_task == 'check' && matrix.skipped_tests || '' }}
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'rbs,typeprof'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof'
           PRECHECK_BUNDLED_GEMS: 'no'
 
       - name: make skipped tests

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -99,7 +99,7 @@ jobs:
         env:
           RUBY_TESTOPTS: '-q --tty=no'
           TESTS: ${{ matrix.test_task == 'check' && matrix.skipped_tests || '' }}
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'rbs,typeprof'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof'
           PRECHECK_BUNDLED_GEMS: 'no'
 
       - name: make skipped tests

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -169,7 +169,7 @@ jobs:
         timeout-minutes: 60
         env:
           RUBY_TESTOPTS: '-q --tty=no'
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'rbs,typeprof'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof'
           PRECHECK_BUNDLED_GEMS: 'no'
           SYNTAX_SUGGEST_TIMEOUT: '5'
           YJIT_BINDGEN_DIFF_OPTS: '--exit-code'

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -17,7 +17,7 @@ net-pop         0.1.2   https://github.com/ruby/net-pop
 net-smtp        0.4.0.1 https://github.com/ruby/net-smtp
 matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
-rbs             3.4.2   https://github.com/ruby/rbs
+rbs             3.4.3   https://github.com/ruby/rbs
 typeprof        0.21.9  https://github.com/ruby/typeprof
 debug           1.9.1   https://github.com/ruby/debug 91fe870eeceb9ffbbc7f1bb4673f9e2f6a2c1f60
 racc            1.7.3   https://github.com/ruby/racc

--- a/tool/rbs_skip_tests
+++ b/tool/rbs_skip_tests
@@ -22,6 +22,8 @@ test_collection_install_frozen(RBS::CliTest) running tests without Bundler
 test_collection_install_gemspec(RBS::CliTest) running tests without Bundler
 test_collection_update(RBS::CliTest) running tests without Bundler
 
+test_loading_from_rbs_collection__gem_version_mismatch(RBS::EnvironmentLoaderTest) running test without rbs-amber testing gem
+
 test_defs(RBS::RbPrototypeTest) Numeric Nodes are added
 test_defs_return_type(RBS::RbPrototypeTest) Numeric Nodes are added
 test_defs_return_type_with_block(RBS::RbPrototypeTest) Numeric Nodes are added
@@ -46,6 +48,7 @@ test_parameter(RBS::RbiPrototypeTest) Symbol Node is added
 test_parameter_type_member_variance(RBS::RbiPrototypeTest) Symbol Node is added
 test_tuple(RBS::RbiPrototypeTest) Symbol Node is added
 test_untyped_block(RBS::RbiPrototypeTest) Symbol Node is added
+test_argument_forwarding(RBS::RbPrototypeTest) `...` args handling is changed
 
 test_TOPDIR(RbConfigSingletonTest) `TOPDIR` is `nil` during CI while RBS type is declared as `String`
 


### PR DESCRIPTION
Updating bundled rbs to 3.4.3 introduced a test failure.

* `test_loading_from_rbs_collection__gem_version_mismatch(RBS::EnvironmentLoaderTest)` is failing because it requires `rbs-amber` gem, which is generated during tests into Bundler context. Since the test is running without Bundler, it should be skipped. (This is a test case added in rbs-3.4.3, so it's a bug of rbs-3.4.3...)
* Another failure is `test_argument_forwarding(RBS::RbPrototypeTest)`, which is introduced during recent parser changes. So, I'm just moving the ignore from `TEST_BUNDLED_GEMS_ALLOW_FAILURES` to more fine grained `rbs_skip_tests`. We will enable the tests before Ruby 3.4 release, once the parser got stable enough.