### PR TITLE
[PRISM] Support UTF-8 symbols

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -216,6 +216,9 @@ parse_string_symbol(const pm_symbol_node_t *symbol, const pm_parser_t *parser)
     else if (symbol->base.flags & PM_SYMBOL_FLAGS_FORCED_BINARY_ENCODING) {
         encoding = "ASCII-8BIT";
     }
+    else if (symbol->base.flags & PM_SYMBOL_FLAGS_FORCED_US_ASCII_ENCODING) {
+        encoding = "US-ASCII";
+    }
     const uint8_t *start = pm_string_source(&symbol->unescaped);
     return parse_symbol(start, start + pm_string_length(&symbol->unescaped), encoding);
 }

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -209,7 +209,13 @@ parse_symbol(const uint8_t *start, const uint8_t *end, const char *encoding)
 static inline ID
 parse_string_symbol(const pm_symbol_node_t *symbol, const pm_parser_t *parser)
 {
-    const char *encoding = symbol->base.flags & PM_SYMBOL_FLAGS_FORCED_UTF8_ENCODING ? "UTF-8" : parser->encoding->name;
+    const char *encoding = parser->encoding->name;
+    if (symbol->base.flags & PM_SYMBOL_FLAGS_FORCED_UTF8_ENCODING) {
+        encoding = "UTF-8";
+    }
+    else if (symbol->base.flags & PM_SYMBOL_FLAGS_FORCED_BINARY_ENCODING) {
+        encoding = "ASCII-8BIT";
+    }
     const uint8_t *start = pm_string_source(&symbol->unescaped);
     return parse_symbol(start, start + pm_string_length(&symbol->unescaped), encoding);
 }

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -785,6 +785,12 @@ module Prism
         # -*- coding: us-ascii -*-
         :"\u{e9}"
       RUBY
+
+      # Test ASCII-8BIT symbol in a US-ASCII file
+      assert_prism_eval(<<~'RUBY', raw: true)
+        # -*- coding: us-ascii -*-
+        :"\xff"
+      RUBY
     end
 
     def test_XStringNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -779,6 +779,12 @@ module Prism
 
     def test_SymbolNode
       assert_prism_eval(":pit")
+
+      # Test UTF-8 symbol in a US-ASCII file
+      assert_prism_eval(<<~'RUBY', raw: true)
+        # -*- coding: us-ascii -*-
+        :"\u{e9}"
+      RUBY
     end
 
     def test_XStringNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -791,6 +791,12 @@ module Prism
         # -*- coding: us-ascii -*-
         :"\xff"
       RUBY
+
+      # Test US-ASCII symbol in a ASCII-8BIT file
+      assert_prism_eval(<<~'RUBY', raw: true)
+        # -*- coding: ascii-8bit -*-
+        :a
+      RUBY
     end
 
     def test_XStringNode


### PR DESCRIPTION
Fixes ruby/prism#2242.

Blocked by ruby/prism#2268.