### PR TITLE
YJIT: Support concattoarray and pushtoarray

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4459,3 +4459,17 @@ assert_equal '[[{:a=>1}], {}]', %q{
 
   body
 }
+
+# concatarray
+assert_equal '[1, 2]', %q{
+  def foo(a, b) = [a, b]
+  arr = [2]
+  foo(*[1], *arr)
+}
+
+# pushtoarray
+assert_equal '[1, 2]', %q{
+  def foo(a, b) = [a, b]
+  arr = [1]
+  foo(*arr, 2)
+}

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5237,6 +5237,12 @@ rb_vm_concat_array(VALUE ary1, VALUE ary2st)
     return vm_concat_array(ary1, ary2st);
 }
 
+VALUE
+rb_vm_concat_to_array(VALUE ary1, VALUE ary2st)
+{
+    return vm_concat_to_array(ary1, ary2st);
+}
+
 static VALUE
 vm_splat_array(VALUE flag, VALUE ary)
 {

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -133,6 +133,7 @@ fn main() {
         .allowlist_function("rb_ary_new_capa")
         .allowlist_function("rb_ary_store")
         .allowlist_function("rb_ary_resurrect")
+        .allowlist_function("rb_ary_cat")
         .allowlist_function("rb_ary_clear")
         .allowlist_function("rb_ary_dup")
         .allowlist_function("rb_ary_push")

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -114,6 +114,7 @@ pub use autogened::*;
 extern "C" {
     pub fn rb_vm_splat_array(flag: VALUE, ary: VALUE) -> VALUE;
     pub fn rb_vm_concat_array(ary1: VALUE, ary2st: VALUE) -> VALUE;
+    pub fn rb_vm_concat_to_array(ary1: VALUE, ary2st: VALUE) -> VALUE;
     pub fn rb_vm_defined(
         ec: EcPtr,
         reg_cfp: CfpPtr,

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -936,6 +936,7 @@ extern "C" {
     pub fn rb_ary_store(ary: VALUE, key: ::std::os::raw::c_long, val: VALUE);
     pub fn rb_ary_dup(ary: VALUE) -> VALUE;
     pub fn rb_ary_resurrect(ary: VALUE) -> VALUE;
+    pub fn rb_ary_cat(ary: VALUE, train: *const VALUE, len: ::std::os::raw::c_long) -> VALUE;
     pub fn rb_ary_push(ary: VALUE, elem: VALUE) -> VALUE;
     pub fn rb_ary_clear(ary: VALUE) -> VALUE;
     pub fn rb_hash_new() -> VALUE;


### PR DESCRIPTION
This PR adds support for `concatarray` and `pushtoarray` instructions added in https://github.com/ruby/ruby/pull/9247 so that `railsbench` will not exit on those instructions.