### PR TITLE
Reduce array allocations during method calling in some additional cases

### DIFF
--- a/benchmark/vm_super_splat_calls.yml
+++ b/benchmark/vm_super_splat_calls.yml
@@ -1,0 +1,25 @@
+prelude: |
+  @a = [1].freeze
+  @ea = [].freeze
+  @kw = {y: 1}.freeze
+  @b = lambda{}
+  extend(Module.new{def arg_splat(x=0, y: 0) end})
+  extend(Module.new{def arg_splat_block(x=0, y: 0) end})
+  extend(Module.new{def splat_kw_splat(x=0, y: 0) end})
+  extend(Module.new{def splat_kw_splat_block(x=0, y: 0) end})
+  extend(Module.new{def splat_kw(x=0, y: 0) end})
+  extend(Module.new{def splat_kw_block(x=0, y: 0) end})
+
+  extend(Module.new{def arg_splat; super(1, *@ea) end})
+  extend(Module.new{def arg_splat_block; super(1, *@ea, &@b) end})
+  extend(Module.new{def splat_kw_splat; super(*@a, **@kw) end})
+  extend(Module.new{def splat_kw_splat_block; super(*@a, **@kw, &@b) end})
+  extend(Module.new{def splat_kw; super(*@a, y: 1) end})
+  extend(Module.new{def splat_kw_block; super(*@a, y: 1, &@b) end})
+benchmark:
+  arg_splat: "arg_splat"
+  arg_splat_block: "arg_splat_block"
+  splat_kw_splat: "splat_kw_splat"
+  splat_kw_splat_block: "splat_kw_splat_block"
+  splat_kw: "splat_kw"
+  splat_kw_block: "splat_kw_block"

--- a/benchmark/vm_zsuper_splat_calls.yml
+++ b/benchmark/vm_zsuper_splat_calls.yml
@@ -1,0 +1,28 @@
+prelude: |
+  a = [1].freeze
+  ea = [].freeze
+  kw = {y: 1}.freeze
+  b = lambda{}
+  extend(Module.new{def arg_splat(x=0, y: 0) end})
+  extend(Module.new{def arg_splat_block(x=0, y: 0) end})
+  extend(Module.new{def arg_splat_post(x=0, y: 0) end})
+  extend(Module.new{def splat_kw_splat(x=0, y: 0) end})
+  extend(Module.new{def splat_kw_splat_block(x=0, y: 0) end})
+  extend(Module.new{def splat_kw(x=0, y: 0) end})
+  extend(Module.new{def splat_kw_block(x=0, y: 0) end})
+
+  extend(Module.new{def arg_splat(x, *a) super end})
+  extend(Module.new{def arg_splat_block(x, *a, &b) super end})
+  extend(Module.new{def arg_splat_post(*a, x) super end})
+  extend(Module.new{def splat_kw_splat(*a, **kw) super end})
+  extend(Module.new{def splat_kw_splat_block(*a, **kw, &b) super end})
+  extend(Module.new{def splat_kw(*a, y: 1) super end})
+  extend(Module.new{def splat_kw_block(*a, y: 1, &b) super end})
+benchmark:
+  arg_splat: "arg_splat(1, *ea)"
+  arg_splat_block: "arg_splat_block(1, *ea, &b)"
+  arg_splat_post: "arg_splat_post(1, *ea, &b)"
+  splat_kw_splat: "splat_kw_splat(*a, **kw)"
+  splat_kw_splat_block: "splat_kw_splat_block(*a, **kw, &b)"
+  splat_kw: "splat_kw(*a, y: 1)"
+  splat_kw_block: "splat_kw_block(*a, y: 1, &b)"

--- a/compile.c
+++ b/compile.c
@@ -3192,6 +3192,10 @@ optimize_args_splat_no_copy(rb_iseq_t *iseq, INSN *insn, LINK_ELEMENT *niobj,
                                  unsigned int set_flags, unsigned int unset_flags)
 {
     LINK_ELEMENT *iobj = (LINK_ELEMENT *)insn;
+    if ((set_flags & VM_CALL_ARGS_BLOCKARG) && (set_flags & VM_CALL_KW_SPLAT) &&
+            IS_NEXT_INSN_ID(niobj, splatkw)) {
+        niobj = niobj->next;
+    }
     if (!IS_NEXT_INSN_ID(niobj, send) && !IS_NEXT_INSN_ID(niobj, invokesuper)) {
         return false;
     }

--- a/compile.c
+++ b/compile.c
@@ -3192,7 +3192,7 @@ optimize_args_splat_no_copy(rb_iseq_t *iseq, INSN *insn, LINK_ELEMENT *niobj,
                                  unsigned int set_flags, unsigned int unset_flags)
 {
     LINK_ELEMENT *iobj = (LINK_ELEMENT *)insn;
-    if (!IS_NEXT_INSN_ID(niobj, send)) {
+    if (!IS_NEXT_INSN_ID(niobj, send) && !IS_NEXT_INSN_ID(niobj, invokesuper)) {
         return false;
     }
     niobj = niobj->next;

--- a/compile.c
+++ b/compile.c
@@ -9520,7 +9520,7 @@ compile_super(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
             /* rest argument */
             int idx = local_body->local_table_size - local_body->param.rest_start;
             ADD_GETLOCAL(args, node, idx, lvar_level);
-            ADD_INSN1(args, node, splatarray, Qfalse);
+            ADD_INSN1(args, node, splatarray, local_body->param.flags.has_post ? Qtrue : Qfalse);
 
             argc = local_body->param.rest_start + 1;
             flag |= VM_CALL_ARGS_SPLAT;
@@ -9529,6 +9529,7 @@ compile_super(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
             /* post arguments */
             int post_len = local_body->param.post_num;
             int post_start = local_body->param.post_start;
+            flag |= VM_CALL_ARGS_SPLAT_MUT;
 
             if (local_body->param.flags.has_rest) {
                 int j;
@@ -9536,8 +9537,7 @@ compile_super(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
                     int idx = local_body->local_table_size - (post_start + j);
                     ADD_GETLOCAL(args, node, idx, lvar_level);
                 }
-                ADD_INSN1(args, node, newarray, INT2FIX(j));
-                ADD_INSN (args, node, concatarray);
+                ADD_INSN1(args, node, pushtoarray, INT2FIX(j));
                 /* argc is settled at above */
             }
             else {

--- a/compile.c
+++ b/compile.c
@@ -9520,7 +9520,7 @@ compile_super(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
             /* rest argument */
             int idx = local_body->local_table_size - local_body->param.rest_start;
             ADD_GETLOCAL(args, node, idx, lvar_level);
-            ADD_INSN1(args, node, splatarray, local_body->param.flags.has_post ? Qtrue : Qfalse);
+            ADD_INSN1(args, node, splatarray, RBOOL(local_body->param.flags.has_post));
 
             argc = local_body->param.rest_start + 1;
             flag |= VM_CALL_ARGS_SPLAT;
@@ -9529,7 +9529,6 @@ compile_super(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
             /* post arguments */
             int post_len = local_body->param.post_num;
             int post_start = local_body->param.post_start;
-            flag |= VM_CALL_ARGS_SPLAT_MUT;
 
             if (local_body->param.flags.has_rest) {
                 int j;
@@ -9538,6 +9537,7 @@ compile_super(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
                     ADD_GETLOCAL(args, node, idx, lvar_level);
                 }
                 ADD_INSN1(args, node, pushtoarray, INT2FIX(j));
+                flag |= VM_CALL_ARGS_SPLAT_MUT;
                 /* argc is settled at above */
             }
             else {


### PR DESCRIPTION
This reduces unnecessary array allocations for the following types of calls:

```ruby
    super(arg, *ary)
    super(arg, *ary, &block)
    super(*ary, **kw)
    super(*ary, **kw, &block)
    super(*ary, kw: 1)
    super(*ary, kw: 1, &block)
    super(...)

    f(*ary, **kw, &block)
    f(...)

    def f(*ary, post_arg)
      super
    end
```

The ` f(*ary, **kw, &block)` case was previously optimized before Ruby 3.3 was released, but the optimization no longer took effect after the introduction of the splatkw VM instruction.  This also resulted in `f(...)` not being fully optimized, after the recent switch to operate as `f(*, **, &)`.