### PR TITLE
[PRISM] Keyword arguments incorrectly passed as mutable

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1085,7 +1085,6 @@ pm_setup_args(pm_arguments_node_t *arguments_node, int *flags, struct rb_callinf
 
                 if (has_keyword_splat || has_splat) {
                     *flags |= VM_CALL_KW_SPLAT;
-                    *flags |= VM_CALL_KW_SPLAT_MUT;
 
                     has_keyword_splat = true;
 

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -2134,6 +2134,16 @@ end
     def test_KeywordRestParameterNode
       assert_prism_eval("def prism_test_keyword_rest_parameter_node(a, **b); end")
       assert_prism_eval("Object.tap { |**| }")
+
+      # Test that KeywordRestParameterNode creates a copy
+      assert_prism_eval(<<~RUBY)
+        hash = {}
+        o = Object.new
+        def o.foo(**a) = a[:foo] = 1
+
+        o.foo(**hash)
+        hash
+      RUBY
     end
 
     def test_NoKeywordsParameterNode


### PR DESCRIPTION
Fixes ruby/prism#2279.