### PR TITLE
[PRISM] Fix for s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,6 @@ env:
       # on s390x CPU architecture.
       # https://github.com/madler/zlib/pull/410
       - DFLTCC=0
-      - TESTS="--exclude=ruby/test_compile_prism.rb --exclude=ruby/test_iseq.rb"
   - &arm32-linux
     name: arm32-linux
     arch: arm64
@@ -135,7 +134,7 @@ before_script:
 
 script:
   - $SETARCH make -s test
-  - ../tool/travis_wait.sh $SETARCH make -s test-all RUBYOPT="-w" TESTS="$TESTS"
+  - ../tool/travis_wait.sh $SETARCH make -s test-all RUBYOPT="-w"
   - $SETARCH make -s test-spec
 
 # We want to be notified when something happens.

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2817,7 +2817,7 @@ static int
 pm_local_table_insert_func(st_data_t *key, st_data_t *value, st_data_t arg, int existing)
 {
     if (!existing) {
-        pm_constant_id_t constant_id = *(pm_constant_id_t *)key;
+        pm_constant_id_t constant_id = (pm_constant_id_t)*key;
         struct pm_local_table_insert_ctx * ctx = (struct pm_local_table_insert_ctx *)arg;
 
         pm_scope_node_t *scope_node = ctx->scope_node;
@@ -2827,7 +2827,7 @@ pm_local_table_insert_func(st_data_t *key, st_data_t *value, st_data_t arg, int 
         ID local = pm_constant_id_lookup(scope_node, constant_id);
         local_table_for_iseq->ids[local_index] = local;
 
-        *value = local_index;
+        *value = (st_data_t)local_index;
 
         ctx->local_index++;
     }
@@ -2842,7 +2842,7 @@ pm_insert_local_index(pm_constant_id_t constant_id, int local_index, st_table *i
 
     ID local = pm_constant_id_lookup(scope_node, constant_id);
     local_table_for_iseq->ids[local_index] = local;
-    st_insert(index_lookup_table, constant_id, local_index);
+    st_insert(index_lookup_table, (st_data_t)constant_id, local_index);
 }
 
 /**
@@ -6544,7 +6544,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                     // def foo(a, (b, *c, d), e = 1, *, g, (h, *i, j),  k:, l: 1, **m, &n)
                     //                               ^
                     local_table_for_iseq->ids[local_index] = PM_CONSTANT_MULT;
-                    st_insert(index_lookup_table, PM_CONSTANT_MULT, local_index);
+                    st_insert(index_lookup_table, (st_data_t)PM_CONSTANT_MULT, local_index);
                 }
                 local_index++;
             }
@@ -6727,7 +6727,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                     }
                     else {
                         local_table_for_iseq->ids[local_index] = PM_CONSTANT_POW;
-                        st_insert(index_lookup_table, PM_CONSTANT_POW, local_index);
+                        st_insert(index_lookup_table, (st_data_t)PM_CONSTANT_POW, local_index);
                     }
                     local_index++;
                     break;
@@ -6738,17 +6738,17 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                     body->param.rest_start = local_index;
                     body->param.flags.has_rest = true;
                     local_table_for_iseq->ids[local_index] = PM_CONSTANT_MULT;
-                    st_insert(index_lookup_table, PM_CONSTANT_MULT, local_index);
+                    st_insert(index_lookup_table, (st_data_t)PM_CONSTANT_MULT, local_index);
                     local_index++;
 
                     body->param.block_start = local_index;
                     body->param.flags.has_block = true;
                     local_table_for_iseq->ids[local_index] = PM_CONSTANT_AND;
-                    st_insert(index_lookup_table, PM_CONSTANT_AND, local_index);
+                    st_insert(index_lookup_table, (st_data_t)PM_CONSTANT_AND, local_index);
                     local_index++;
 
                     local_table_for_iseq->ids[local_index] = PM_CONSTANT_DOT3;
-                    st_insert(index_lookup_table, PM_CONSTANT_DOT3, local_index);
+                    st_insert(index_lookup_table, (st_data_t)PM_CONSTANT_DOT3, local_index);
                     local_index++;
                     break;
                   }
@@ -6768,7 +6768,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
                 if (name == 0) {
                     local_table_for_iseq->ids[local_index] = PM_CONSTANT_AND;
-                    st_insert(index_lookup_table, PM_CONSTANT_AND, local_index);
+                    st_insert(index_lookup_table, (st_data_t)PM_CONSTANT_AND, local_index);
                 }
                 else {
                     if (PM_NODE_FLAG_P(parameters_node->block, PM_PARAMETER_FLAGS_REPEATED_PARAMETER)) {
@@ -6867,7 +6867,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                     ctx.local_table_for_iseq = local_table_for_iseq;
                     ctx.local_index = local_index;
 
-                    st_update(index_lookup_table, constant_id, pm_local_table_insert_func, (st_data_t)&ctx);
+                    st_update(index_lookup_table, (st_data_t)constant_id, pm_local_table_insert_func, (st_data_t)&ctx);
 
                     local_index = ctx.local_index;
                 }


### PR DESCRIPTION
On s390x, a long is 8 bytes. st_data_t is an unsigned long but pm_constant_id_t is a 4 byte integer. We need to cast it to st_data_t when passing it to ST functions.