### PR TITLE
Remove expandarray/splatarray sequence peephole optimization

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3579,7 +3579,6 @@ iseq_peephole_optimize(rb_iseq_t *iseq, LINK_ELEMENT *list, const int do_tailcal
 
     if (IS_INSN_ID(iobj, newarray) ||
         IS_INSN_ID(iobj, duparray) ||
-        IS_INSN_ID(iobj, expandarray) ||
         IS_INSN_ID(iobj, concatarray) ||
         IS_INSN_ID(iobj, splatarray) ||
         0) {


### PR DESCRIPTION
newarray, duparray, concatarray, and splatarray always leave an array at the top of the stack.  expandarray does not, it takes an array from the top of the stack as input, and leaves individual elements on the stack.  I assume no Ruby code generates the expandarray/splatarray sequence, or it could break. The only use of expandarray outside the peephole optimizer is in the masgn code, and it does not appear to generate splatarray directly after expandarray.

The splatarray/splatarray peephole optimization is probably also wrong in the following case:

```
putobject  [1,2]
splatarray false
splatarray true
```

This instruction sequence should result in a duplicate of [1,2] at the top of the stack, but the peephole optimizer would remove the `splatarray true`, resulting in change that made [1,2] on top of the stack.  I'm not sure Ruby code can generate `splatarray false` followed by `splatarray true` (I could get it to generate chains of `splatarray true`), so maybe this has no effect.

newarray, duparray, and concatarray all result in newly allocated arrays at the top of the stack, so they shouldn't have an issue with removing either `splatarray true` or `splatarray false`.