### PR TITLE
Introduce NODE_ENCODING

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -706,6 +706,8 @@ node_children(rb_ast_t *ast, const NODE *node)
         return rb_ary_new_from_args(1, rb_node_line_lineno_val(node));
       case NODE_FILE:
         return rb_ary_new_from_args(1, rb_node_file_path_val(node));
+      case NODE_ENCODING:
+        return rb_ary_new_from_args(1, rb_node_encoding_val(node));
       case NODE_ERROR:
         return rb_ary_new_from_node_args(ast, 0);
       case NODE_ARGS_AUX:

--- a/compile.c
+++ b/compile.c
@@ -1960,6 +1960,9 @@ iseq_set_arguments_keywords(rb_iseq_t *iseq, LINK_ANCHOR *const optargs,
               case NODE_IMAGINARY:
                 dv = rb_node_imaginary_literal_val(val_node);
                 break;
+              case NODE_ENCODING:
+                dv = rb_node_encoding_val(val_node);
+                break;
               case NODE_NIL:
                 dv = Qnil;
                 break;
@@ -4512,6 +4515,7 @@ compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *ret, const NODE *cond,
       case NODE_SYM:
       case NODE_LINE:
       case NODE_FILE:
+      case NODE_ENCODING:
       case NODE_INTEGER:    /* NODE_INTEGER is always true */
       case NODE_FLOAT:      /* NODE_FLOAT is always true */
       case NODE_RATIONAL:   /* NODE_RATIONAL is always true */
@@ -4722,6 +4726,7 @@ static_literal_node_p(const NODE *node, const rb_iseq_t *iseq, bool hash_key)
       case NODE_LIT:
       case NODE_SYM:
       case NODE_LINE:
+      case NODE_ENCODING:
       case NODE_INTEGER:
       case NODE_FLOAT:
       case NODE_RATIONAL:
@@ -4760,6 +4765,8 @@ static_literal_value(const NODE *node, rb_iseq_t *iseq)
         return rb_node_sym_string_val(node);
       case NODE_LINE:
         return rb_node_line_lineno_val(node);
+      case NODE_ENCODING:
+        return rb_node_encoding_val(node);
       case NODE_FILE:
       case NODE_STR:
         if (ISEQ_COMPILE_DATA(iseq)->option->debug_frozen_string_literal || RTEST(ruby_debug)) {
@@ -5790,6 +5797,7 @@ defined_expr0(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
       case NODE_SYM:
       case NODE_LINE:
       case NODE_FILE:
+      case NODE_ENCODING:
       case NODE_INTEGER:
       case NODE_FLOAT:
       case NODE_RATIONAL:
@@ -7221,6 +7229,7 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
       case NODE_RATIONAL:
       case NODE_IMAGINARY:
       case NODE_FILE:
+      case NODE_ENCODING:
       case NODE_STR:
       case NODE_XSTR:
       case NODE_DSTR:
@@ -10270,6 +10279,12 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const no
       case NODE_LINE:{
         if (!popped) {
             ADD_INSN1(ret, node, putobject, rb_node_line_lineno_val(node));
+        }
+        break;
+      }
+      case NODE_ENCODING:{
+        if (!popped) {
+            ADD_INSN1(ret, node, putobject, rb_node_encoding_val(node));
         }
         break;
       }

--- a/internal/ruby_parser.h
+++ b/internal/ruby_parser.h
@@ -79,6 +79,7 @@ RUBY_SYMBOL_EXPORT_END
 VALUE rb_node_sym_string_val(const NODE *);
 VALUE rb_node_line_lineno_val(const NODE *);
 VALUE rb_node_file_path_val(const NODE *);
+VALUE rb_node_encoding_val(const NODE *);
 
 VALUE rb_node_integer_literal_val(const NODE *);
 VALUE rb_node_float_literal_val(const NODE *);

--- a/node_dump.c
+++ b/node_dump.c
@@ -1149,6 +1149,13 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         F_VALUE(path, rb_node_file_path_val(node), "path");
         return;
 
+      case NODE_ENCODING:
+        ANN("encoding");
+        ANN("format: [enc]");
+        ANN("example: __ENCODING__");
+        F_VALUE(enc, rb_node_encoding_val(node), "enc");
+        break;
+
       case NODE_ERROR:
         ANN("Broken input recovered by Error Tolerant mode");
         return;

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -1008,3 +1008,9 @@ rb_node_file_path_val(const NODE *node)
 {
     return rb_str_new_parser_string(RNODE_FILE(node)->path);
 }
+
+VALUE
+rb_node_encoding_val(const NODE *node)
+{
+    return rb_enc_from_encoding(RNODE_ENCODING(node)->enc);
+}

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -160,6 +160,7 @@ enum node_type {
     NODE_ERROR,
     NODE_LINE,
     NODE_FILE,
+    NODE_ENCODING,
     NODE_RIPPER,
     NODE_RIPPER_VALUES,
     NODE_LAST
@@ -1005,6 +1006,11 @@ typedef struct RNode_FILE {
     struct rb_parser_string *path;
 } rb_node_file_t;
 
+typedef struct RNode_ENCODING {
+    NODE node;
+    rb_encoding *enc;
+} rb_node_encoding_t;
+
 typedef struct RNode_ERROR {
     NODE node;
 } rb_node_error_t;
@@ -1121,6 +1127,7 @@ typedef struct RNode_ERROR {
 #define RNODE_FNDPTN(node) ((struct RNode_FNDPTN *)(node))
 #define RNODE_LINE(node) ((struct RNode_LINE *)(node))
 #define RNODE_FILE(node) ((struct RNode_FILE *)(node))
+#define RNODE_ENCODING(node) ((struct RNode_ENCODING *)(node))
 
 #ifdef RIPPER
 typedef struct RNode_RIPPER {


### PR DESCRIPTION
`__ENCODING__ `was managed by `NODE_LIT` with Encoding object. 

Introduce `NODE_ENCODING` for
1. `__ENCODING__` is detectable from AST Node.
2. Reduce dependency Ruby object for parse.y