### PR TITLE
YJIT: print warning when disasm options used without a dev build

### DIFF
--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -245,7 +245,7 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
                         Err(err) => eprintln!("Failed to create {path}: {err}"),
                     }
                 }
-             }
+            }
         },
 
         ("dump-iseq-disasm", _) => unsafe {

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -228,21 +228,31 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
             _ => return None,
          },
 
-        ("dump-disasm", _) => match opt_val {
-            "" => unsafe { OPTIONS.dump_disasm = Some(DumpDisasm::Stdout) },
-            directory => {
-                let path = format!("{directory}/yjit_{}.log", std::process::id());
-                match File::options().create(true).append(true).open(&path) {
-                    Ok(_) => {
-                        eprintln!("YJIT disasm dump: {path}");
-                        unsafe { OPTIONS.dump_disasm = Some(DumpDisasm::File(path)) }
-                    }
-                    Err(err) => eprintln!("Failed to create {path}: {err}"),
-                }
+        ("dump-disasm", _) => {
+            if !cfg!(feature = "disasm") {
+                eprintln!("WARNING: the {} option is only available when YJIT is built in dev mode, i.e. ./configure --enable-yjit=dev", opt_name);
             }
-         },
+
+            match opt_val {
+                "" => unsafe { OPTIONS.dump_disasm = Some(DumpDisasm::Stdout) },
+                directory => {
+                    let path = format!("{directory}/yjit_{}.log", std::process::id());
+                    match File::options().create(true).append(true).open(&path) {
+                        Ok(_) => {
+                            eprintln!("YJIT disasm dump: {path}");
+                            unsafe { OPTIONS.dump_disasm = Some(DumpDisasm::File(path)) }
+                        }
+                        Err(err) => eprintln!("Failed to create {path}: {err}"),
+                    }
+                }
+             }
+        },
 
         ("dump-iseq-disasm", _) => unsafe {
+            if !cfg!(feature = "disasm") {
+                eprintln!("WARNING: the {} option is only available when YJIT is built in dev mode, i.e. ./configure --enable-yjit=dev", opt_name);
+            }
+
             OPTIONS.dump_iseq_disasm = Some(opt_val.to_string());
         },
 


### PR DESCRIPTION
I was confused for a few minutes the other way then --yjit-dump-disasm printed nothing, so I figured this would be useful for end-users (and future me).

The only question is, should we have this print a warning, or should we have it just error out? Might be more noticeable if it's an actual error, invalid argument error?