### PR TITLE
Fix RegExp warning causing flaky Ripper failure

### DIFF
--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -2022,7 +2022,7 @@ class TestRegexp < Test::Unit::TestCase
 
   def test_bug_20212 # [Bug #20212]
     regex = Regexp.new(
-      /\A((?=.*?[a-z])(?!.*--)[a-z\d]+[a-z\d-]*[a-z\d]+).((?=.*?[a-z])(?!.*--)[a-z\d]+[a-z\d-]*[a-z\d]+).((?=.*?[a-z])(?!.*--)[a-zd]+[a-zd-]*[a-zd]+).((?=.*?[a-z])(?!.*--)[a-zd]+[a-zd-]*[a-zd]+)\Z/x
+      /\A((?=.*?[a-z])(?!.*--)[a-z\d]+[a-z\d-]*[a-z\d]+).((?=.*?[a-z])(?!.*--)[a-z\d]+[a-z\d-]*[a-z\d]+).((?=.*?[a-z])(?!.*--)[a-z]+[a-z-]*[a-z]+).((?=.*?[a-z])(?!.*--)[a-z]+[a-z-]*[a-z]+)\Z/x
     )
     string = "www.google.com"
     100.times.each { assert(regex.match?(string)) }


### PR DESCRIPTION
Sometimes this file get picked up and break Ripper tests:

    TestRipper::Generic#test_parse_files:test/ruby
    assert_separately failed with error message
    pid 63392 exit 0
    | test_regexp.rb:2025: warning: character class has duplicated range

https://github.com/ruby/ruby/actions/runs/7699956651/job/20982702553#step:12:103
