### PR TITLE
YJIT: No need to RESTORE_REG now that we reject tailcalls

### DIFF
--- a/vm_exec.h
+++ b/vm_exec.h
@@ -179,7 +179,6 @@ default:                        \
     /* don't run tailcalls since that breaks FINISH */ \
     if (val == Qundef && GET_CFP() != ec->cfp && (func = jit_compile(ec))) { \
         val = func(ec, ec->cfp); \
-        RESTORE_REGS(); /* fix cfp for tailcall */ \
         if (ec->tag->state) THROW_EXCEPTION(val); \
     } \
 } while (0)


### PR DESCRIPTION
Thanks to Kokubun for noticing.

Follow-up: b0711b1cf152afad0a480ee2f9bedd142a0d24ac
