### PR TITLE
Prefer `sa_handler` to `sa_sigaction` in Wasm

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -597,7 +597,7 @@ ruby_signal(int signum, sighandler_t handler)
 #endif
 
     sigemptyset(&sigact.sa_mask);
-#ifdef USE_SIGALTSTACK
+#if defined(USE_SIGALTSTACK) && !defined(__wasm__)
     if (handler == SIG_IGN || handler == SIG_DFL) {
         sigact.sa_handler = handler;
         sigact.sa_flags = 0;


### PR DESCRIPTION
Previously the code assigns `handler` function pointer, which accepts one argument, to `sigact.sa_sigaction`, which accepts three argument. This mismatch is not allowed in Wasm.

I don't see the reason to use `sa_sigaction` here, so this change assigns to `sa_handler`, which accepts one argument, in Wasm.