### PR TITLE
.travis.yml: Drop s390x temporarily.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,9 @@ matrix:
   include:
     - <<: *arm64-linux
     - <<: *ppc64le-linux
-    - <<: *s390x-linux
+    # FIXME: The job fails with exceeding the maximum time limit 50 minutes.
+    # https://bugs.ruby-lang.org/issues/20013#note-13
+    # - <<: *s390x-linux
     # FIXME: lib/rubygems/util.rb:104 glob_files_in_dir -
     # <internal:dir>:411:in glob: File name too long - (Errno::ENAMETOOLONG)
     # https://github.com/rubygems/rubygems/issues/7132


### PR DESCRIPTION
The s390x pipelines are timeout (50 minutes) on both master and ruby_3_3 branches. Drop it temporarily.

https://app.travis-ci.com/github/ruby/ruby/builds/268617296
https://app.travis-ci.com/github/ruby/ruby/builds/268615249
