### PR TITLE
Introduced rb_node_const_decl_val function

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -16081,6 +16081,7 @@ ruby_parser.$(OBJEXT): {$(VPATH)}internal/variable.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 ruby_parser.$(OBJEXT): {$(VPATH)}missing.h
+ruby_parser.$(OBJEXT): {$(VPATH)}node.h
 ruby_parser.$(OBJEXT): {$(VPATH)}onigmo.h
 ruby_parser.$(OBJEXT): {$(VPATH)}oniguruma.h
 ruby_parser.$(OBJEXT): {$(VPATH)}ruby_assert.h

--- a/internal/ruby_parser.h
+++ b/internal/ruby_parser.h
@@ -80,6 +80,7 @@ VALUE rb_node_sym_string_val(const NODE *);
 VALUE rb_node_line_lineno_val(const NODE *);
 VALUE rb_node_file_path_val(const NODE *);
 VALUE rb_node_encoding_val(const NODE *);
+VALUE rb_node_const_decl_val(const NODE *node);
 
 VALUE rb_node_integer_literal_val(const NODE *);
 VALUE rb_node_float_literal_val(const NODE *);

--- a/parse.y
+++ b/parse.y
@@ -13991,31 +13991,7 @@ const_decl_path(struct parser_params *p, NODE **dest)
     NODE *n = *dest;
     if (!nd_type_p(n, NODE_CALL)) {
         const YYLTYPE *loc = &n->nd_loc;
-        VALUE path;
-        if (RNODE_CDECL(n)->nd_vid) {
-             path = rb_id2str(RNODE_CDECL(n)->nd_vid);
-        }
-        else {
-            n = RNODE_CDECL(n)->nd_else;
-            path = rb_ary_new();
-            for (; n && nd_type_p(n, NODE_COLON2); n = RNODE_COLON2(n)->nd_head) {
-                rb_ary_push(path, rb_id2str(RNODE_COLON2(n)->nd_mid));
-            }
-            if (n && nd_type_p(n, NODE_CONST)) {
-                // Const::Name
-                rb_ary_push(path, rb_id2str(RNODE_CONST(n)->nd_vid));
-            }
-            else if (n && nd_type_p(n, NODE_COLON3)) {
-                // ::Const::Name
-                rb_ary_push(path, rb_str_new(0, 0));
-            }
-            else {
-                // expression::Name
-                rb_ary_push(path, rb_str_new_cstr("..."));
-            }
-            path = rb_ary_join(rb_ary_reverse(path), rb_str_new_cstr("::"));
-            path = rb_fstring(path);
-        }
+        VALUE path = rb_node_const_decl_val(n);
         *dest = n = NEW_LIT(path, loc);
         RB_OBJ_WRITTEN(p->ast, Qnil, RNODE_LIT(n)->nd_lit);
     }

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1243,8 +1243,6 @@ typedef struct rb_parser_config_struct {
     VALUE (*ary_unshift)(VALUE ary, VALUE item);
     VALUE (*ary_new2)(long capa); // ary_new_capa
     VALUE (*ary_entry)(VALUE ary, long offset);
-    VALUE (*ary_join)(VALUE ary, VALUE sep);
-    VALUE (*ary_reverse)(VALUE ary);
     VALUE (*ary_clear)(VALUE ary);
     void (*ary_modify)(VALUE ary);
     long (*array_len)(VALUE a);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -144,8 +144,6 @@ struct rb_imemo_tmpbuf_struct {
 #undef rb_ary_new2
 #define rb_ary_new2          p->config->ary_new2
 #define rb_ary_entry         p->config->ary_entry
-#define rb_ary_join          p->config->ary_join
-#define rb_ary_reverse       p->config->ary_reverse
 #define rb_ary_clear         p->config->ary_clear
 #define rb_ary_modify        p->config->ary_modify
 #undef RARRAY_LEN


### PR DESCRIPTION
Introduce `rb_node_const_decl_val` function to allow `rb_ary_join` and `rb_ary_reverse` functions to be removed from Universal Parser.