### PR TITLE
YJIT: add specialized codegen for fixnum XOR

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1,3 +1,6 @@
+# To run the tests in this file only, with YJIT enabled:
+# make btest BTESTS=bootstraptest/test_yjit.rb RUN_OPTS="--yjit-call-threshold=1"
+
 # regression test for popping before side exit
 assert_equal "ok", %q{
   def foo(a, *) = a
@@ -4449,6 +4452,11 @@ assert_equal '[2, 4611686018427387904]', %q{
 # Integer right shift
 assert_equal '[0, 1, -4]', %q{
   [0 >> 1, 2 >> 1, -7 >> 1]
+}
+
+# Integer XOR
+assert_equal '[0, 0, 4]', %q{
+  [0 ^ 0, 1 ^ 1, 7 ^ 3]
 }
 
 assert_equal '[nil, "yield"]', %q{


### PR DESCRIPTION
Big speedup!

Before:
```
--------  -----------  ----------  ---------  ----------  ------------  -----------
bench     interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
ruby-xor  982.2        0.2         123.8      0.6         7.46          7.93       
--------  -----------  ----------  ---------  ----------  ------------  -----------
```

After:
```
--------  -----------  ----------  ---------  ----------  ------------  -----------
bench     interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
ruby-xor  993.2        0.3         109.4      0.5         8.44          9.08       
--------  -----------  ----------  ---------  ----------  ------------  -----------
```

Top C calls:
```
Top-8 most frequent C calls (19.9% of C calls):
        String#setbyte:  6,498,050 (19.6%)
            String#dup:     99,971 ( 0.3%)
           Symbol#to_s:        445 ( 0.0%)
```

I will look at adding some specialized codegen for `String#setbyte` next.