### PR TITLE
YJIT: add codegen for String#setbyte

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -2046,6 +2046,14 @@ assert_equal '[97, :nil, 97, :nil, :raised]', %q{
   [getbyte("a", 0), getbyte("a", 1), getbyte("a", -1), getbyte("a", -2), getbyte("a", "a")]
 } unless rjit_enabled? # Not yet working on RJIT
 
+# Basic test for setbyte
+assert_equal 'AoZ', %q{
+  s = "foo"
+  s.setbyte(0, 65)
+  s.setbyte(-1, 90)
+  s
+}
+
 # Test << operator on string subclass
 assert_equal 'abab', %q{
   class MyString < String; end

--- a/string.c
+++ b/string.c
@@ -6124,7 +6124,7 @@ rb_str_getbyte(VALUE str, VALUE index)
  *
  *  Related: String#getbyte.
  */
-static VALUE
+VALUE
 rb_str_setbyte(VALUE str, VALUE index, VALUE value)
 {
     long pos = NUM2LONG(index);


### PR DESCRIPTION
Before:
```
--------  -----------  ----------  ---------  ----------  ------------  -----------
bench     interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
ruby-xor  987.2        0.1         109.3      0.3         8.38          9.04       
--------  -----------  ----------  ---------  ----------  ------------  -----------
```

After:
```
--------  -----------  ----------  ---------  ----------  ------------  -----------
bench     interp (ms)  stddev (%)  yjit (ms)  stddev (%)  yjit 1st itr  interp/yjit
ruby-xor  991.8        0.6         99.6       0.4         9.25          9.96       
--------  -----------  ----------  ---------  ----------  ------------  -----------
```