### PR TITLE
Annotate Symbol#to_s as leaf

### DIFF
--- a/string.c
+++ b/string.c
@@ -11693,17 +11693,6 @@ sym_inspect(VALUE sym)
     return str;
 }
 
-/*
- *  call-seq:
- *    to_s -> string
- *
- *  Returns a string representation of +self+ (not including the leading colon):
- *
- *    :foo.to_s # => "foo"
- *
- *  Related: Symbol#inspect, Symbol#name.
- */
-
 VALUE
 rb_sym_to_s(VALUE sym)
 {
@@ -12270,8 +12259,6 @@ Init_String(void)
     rb_define_method(rb_cSymbol, "==", sym_equal, 1);
     rb_define_method(rb_cSymbol, "===", sym_equal, 1);
     rb_define_method(rb_cSymbol, "inspect", sym_inspect, 0);
-    rb_define_method(rb_cSymbol, "to_s", rb_sym_to_s, 0);
-    rb_define_method(rb_cSymbol, "id2name", rb_sym_to_s, 0);
     rb_define_method(rb_cSymbol, "name", rb_sym2str, 0); /* in symbol.c */
     rb_define_method(rb_cSymbol, "to_proc", rb_sym_to_proc, 0); /* in proc.c */
     rb_define_method(rb_cSymbol, "succ", sym_succ, 0);

--- a/symbol.rb
+++ b/symbol.rb
@@ -1,5 +1,20 @@
 class Symbol
   # call-seq:
+  #   to_s -> string
+  #
+  # Returns a string representation of +self+ (not including the leading colon):
+  #
+  #   :foo.to_s # => "foo"
+  #
+  # Related: Symbol#inspect, Symbol#name.
+  def to_s
+    Primitive.attr! :leaf
+    Primitive.cexpr! 'rb_sym_to_s(self)'
+  end
+
+  alias id2name to_s
+
+  # call-seq:
   #   to_sym -> self
   #
   # Returns +self+.


### PR DESCRIPTION
A `leaf` annotation allows the interpreter and YJIT to call the method without pushing a frame.

It seems to speed up `railsbench` a little:

```
before: ruby 3.4.0dev (2024-01-30T19:59:53Z master c1f8d974a8) +YJIT [x86_64-linux]
after: ruby 3.4.0dev (2024-01-30T21:33:27Z symbol-to-s b49e185cb6) +YJIT [x86_64-linux]

----------  -----------  ----------  ----------  ----------  -------------  ------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
railsbench  2473.4       0.9         2455.6      0.6         0.99           1.01
----------  -----------  ----------  ----------  ----------  -------------  ------------
```