### PR TITLE
[PRISM] Fix encoding of interpolated strings

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -712,6 +712,16 @@ module Prism
 
         ("a""#{1}""b").frozen?
       CODE
+
+      # Test encoding of interpolated strings
+      assert_prism_eval(<<~'RUBY')
+        "#{"foo"}s".encoding
+      RUBY
+      assert_prism_eval(<<~'RUBY')
+        a = "foo"
+        b = "#{a}" << "Bar"
+        [a, b, b.encoding]
+      RUBY
     end
 
     def test_InterpolatedSymbolNode


### PR DESCRIPTION
Fixes ruby/prism#2313.