### PR TITLE
Revert ".travis.yml: Drop s390x temporarily."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,9 +106,7 @@ matrix:
   include:
     - <<: *arm64-linux
     - <<: *ppc64le-linux
-    # FIXME: The job fails with exceeding the maximum time limit 50 minutes.
-    # https://bugs.ruby-lang.org/issues/20013#note-13
-    # - <<: *s390x-linux
+    - <<: *s390x-linux
     # FIXME: lib/rubygems/util.rb:104 glob_files_in_dir -
     # <internal:dir>:411:in glob: File name too long - (Errno::ENAMETOOLONG)
     # https://github.com/rubygems/rubygems/issues/7132


### PR DESCRIPTION
This reverts commit 7ded31d36dc78c1495b03a45ec1a3235fdd81f1e.

I was told from Travis CI support that their infra team has deployed a fix for the issue we encountered with the s390x Build environment. One issue is that ppc64le/s390x pipelines takes more time than arm64 pipelines.

* https://app.travis-ci.com/github/junaruga/ruby/builds/268627677
* https://app.travis-ci.com/github/junaruga/ruby/builds/268629163
* https://app.travis-ci.com/github/junaruga/ruby/builds/268630063

In my impression, the slow issue might happen today.

1. https://app.travis-ci.com/github/ruby/ruby/builds/268626565
  ppc64le: 18 mins 17 secs
2. https://app.travis-ci.com/github/ruby/ruby/builds/268627983
  ppc64le: 28 mins 45 secs

And the current latest master: https://app.travis-ci.com/github/ruby/ruby/builds/268630667


