### PR TITLE
Do not modify provided argument splat when using ruby2_keywords with anonymous splat

### DIFF
--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -2809,6 +2809,24 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_raise(FrozenError) { c.send(:ruby2_keywords, :baz) }
   end
 
+  def test_anon_splat_ruby2_keywords
+    singleton_class.class_exec do
+      def bar(*a, **kw)
+        [a, kw]
+      end
+
+      ruby2_keywords def bar_anon(*)
+        bar(*)
+      end
+    end
+
+    a = [1, 2]
+    kw = {a: 1}
+    assert_equal([[1, 2], {a: 1}], bar_anon(*a, **kw))
+    assert_equal([1, 2], a)
+    assert_equal({a: 1}, kw)
+  end
+
   def test_top_ruby2_keywords
     assert_in_out_err([], <<-INPUT, ["[1, 2, 3]", "{:k=>1}"], [])
       def bar(*a, **kw)

--- a/vm_args.c
+++ b/vm_args.c
@@ -518,6 +518,7 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
                 given_argc == ISEQ_BODY(iseq)->param.lead_num + (kw_flag ? 2 : 1) &&
                 !ISEQ_BODY(iseq)->param.flags.has_opt &&
                 !ISEQ_BODY(iseq)->param.flags.has_post &&
+                !ISEQ_BODY(iseq)->param.flags.ruby2_keywords &&
                 (!kw_flag ||
                 !ISEQ_BODY(iseq)->param.flags.has_kw ||
                 !ISEQ_BODY(iseq)->param.flags.has_kwrest ||


### PR DESCRIPTION
Previously, this would push the provided keywords onto the argument splat.  Add ruby2_keywords to the list of other checks for whether it is safe for treating a given splat as mutable when the called method accepts an anonymous splat.