### PR TITLE
[PRISM] Fix multiple return with splat and splat+kwsplat

### DIFF
--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1486,6 +1486,13 @@ a
         end
         prism_test_return_node
       CODE
+
+      assert_prism_eval(<<-CODE)
+        def self.prism_test_return_node(*args, **kwargs)
+          return *args, *args, **kwargs
+        end
+        prism_test_return_node(1, foo: 0)
+      CODE
     end
 
     ############################################################################


### PR DESCRIPTION
Previously, `return *array, 1` didn't behave like `return [*array, 1]`
properly. Also, it crashed when splat and kwsplat is combined like in
`array = [*things, **hash]`.

Fix this by grouping `PM_ARGUMENTS_NODE` with `PM_ARRAY_NODE` handling and
combining splat and kwsplat handling.
