### PR TITLE
Don't wait in `io_binwrite_string` if not necessary.

### DIFF
--- a/io.c
+++ b/io.c
@@ -1800,13 +1800,11 @@ io_binwrite_string(VALUE arg)
         // Write as much as possible:
         ssize_t result = io_binwrite_string_internal(p->fptr, ptr, remaining);
 
-        // If only the internal buffer is written, result will be zero [bytes of given data written]. This means we
-        // should try again.
         if (result == 0) {
-            errno = EWOULDBLOCK;
+            // If only the internal buffer is written, result will be zero [bytes of given data written]. This means we
+            // should try again immediately.
         }
-
-        if (result > 0) {
+        else if (result > 0) {
             if ((size_t)result == remaining) break;
             ptr += result;
             remaining -= result;


### PR DESCRIPTION
Indirectly responsible for <https://github.com/socketry/async/issues/301>.

Writing to a buffered IO can result in the entire internal buffer being flushed, which causes `io_binwrite_string_internal` to return 0. In that case, we were setting `errno = EAGAIN`. This causes `rb_io_maybe_wait_writable` to be invoked, however we should immediately retry `io_binwrite_string_internal` instead, which is what this proposal implements.

The reason why calling `rb_io_maybe_wait_writable` is a bad idea in general, is that not all IO can go via this mechanism - in other words, `kqueue` does not support `kevent("/dev/null", writable)` and returns errno=22 `EINVAL`. The same applies to some kinds of pipes, TTYs, etc.