### PR TITLE
Support NODE_ONCE for pattern matching

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -7259,6 +7259,7 @@ iseq_compile_pattern_each(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *c
       case NODE_COLON3:
       case NODE_BEGIN:
       case NODE_BLOCK:
+      case NODE_ONCE:
         CHECK(COMPILE(ret, "case in literal", node)); // (1)
         if (in_single_pattern) {
             ADD_INSN1(ret, line_node, dupn, INT2FIX(2));

--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -354,6 +354,14 @@ END
     end
 
     assert_block do
+      a = "abc"
+      case 'abc'
+      in /#{a}/o
+        true
+      end
+    end
+
+    assert_block do
       case 0
       in ->(i) { i == 0 }
         true


### PR DESCRIPTION
I saw this Issue and found that `NODE_ONCE` such as `/#{var}/o` are not supported by pattern matching.
https://github.com/rubocop/rubocop-performance/issues/438

So, add a simple test and modifying that `NODE_ONCE` can also be handled by pattern matching.