### PR TITLE
[PRISM] Use block opening line as `source_location` line of lambda

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -5564,9 +5564,14 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         return;
       }
       case PM_LAMBDA_NODE: {
+        const pm_lambda_node_t *cast = (const pm_lambda_node_t *) node;
+
         pm_scope_node_t next_scope_node;
         pm_scope_node_init(node, &next_scope_node, scope_node, parser);
-        const rb_iseq_t *block = NEW_CHILD_ISEQ(&next_scope_node, make_name_for_block(iseq), ISEQ_TYPE_BLOCK, lineno);
+
+        int opening_lineno = (int) pm_newline_list_line_column(&parser->newline_list, cast->opening_loc.start).line;
+
+        const rb_iseq_t *block = NEW_CHILD_ISEQ(&next_scope_node, make_name_for_block(iseq), ISEQ_TYPE_BLOCK, opening_lineno);
         pm_scope_node_destroy(&next_scope_node);
 
         VALUE argc = INT2FIX(0);


### PR DESCRIPTION
Fixes https://github.com/ruby/prism/issues/2312

There are several prism tests failing related to the `source_location` for lambda returning line of the operator (`->`) while original parser execution results in `source_location` line pointing to the block opening location (`{` or `do`)

This commit changes `PM_LAMBDA_NODE` compilation case to use block opening location instead of the whole node (operator) opening location to get the line number to build block iseq 