### PR TITLE
[PRISM] Respect string encoding override in array literals

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -405,7 +405,7 @@ pm_static_literal_value(const pm_node_t *node, const pm_scope_node_t *scope_node
         return INT2FIX(source_line);
       }
       case PM_STRING_NODE:
-        return parse_string(&((pm_string_node_t *) node)->unescaped, parser);
+        return parse_string_encoded(node, &((pm_string_node_t *)node)->unescaped, parser);
       case PM_SYMBOL_NODE:
         return ID2SYM(parse_string_symbol((pm_symbol_node_t *)node, parser));
       case PM_TRUE_NODE:

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -834,6 +834,13 @@ module Prism
 
       # Test keyword splat inside of array
       assert_prism_eval("[**{x: 'hello'}]")
+
+      # Test UTF-8 string array literal in a US-ASCII file
+      assert_prism_eval(<<~'RUBY', raw: true)
+        # -*- coding: us-ascii -*-
+        # frozen_string_literal: true
+        %W"\u{1f44b} \u{1f409}"
+      RUBY
     end
 
     def test_AssocNode


### PR DESCRIPTION
Fixes `TestZlibGzipReader#test_gets2`.
