### PR TITLE
[Feature #20233] Support pkgconf on windows

### DIFF
--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -1168,6 +1168,7 @@ s,@top_srcdir@,$(srcdir),;t t
 s,@try_header@,try_compile,;t t
 s,@ruby_pc@,$(ruby_pc),;t t
 s,@RJIT_SUPPORT@,$(RJIT_SUPPORT),;t t
+s,@PKG_CONFIG@,$(PKG_CONFIG),;t t
 <<KEEP
 
 !if "$(HAVE_BASERUBY)" != "yes" || "$(CROSS_COMPILING)" == "yes"


### PR DESCRIPTION
1. Store the `PKG_CONFIG` variable in Makefile.sub (or try to get it from the ENV var PKG_CONFIG in mkmf.rb)
2. Try to use --msvc-syntax, with a fallback to replacing -Lxxx with -libpath:xxx. --msvc-syntax has been in pkgconf since 1.4.0 (released 7 years ago). pkg-config (freedesktop), does not support it, hence the fallback.
3. The `try_ldflags` passes these `ldflags` as the `opt` parameter to the `link_command`, not as `ldflags`. Unix systems are forgiving in that regard, MSVC is not: as a result as passing them as `opt`, they (specifically the `/libpath:xxx` ones) end up passed before the `-link` command to `cl.exe` and it throws because it ignores it and therefore can't find the lib.

```
cl : Command line warning D9002 : ignoring unknown option '-libpath:C:/Users/julien/.conan2/p/libff3726d89a6255c/p/lib'
```

Context: I am trying to make a [conan](https://conan.io/) recipe (the C++ package manager) for ruby, and realized pkgconf was not working on windows and that's why I couldn't link fiddle to libffi.