### PR TITLE
Use bool to check ascii only in parse_ident

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -10647,13 +10647,13 @@ static enum yytokentype
 parse_ident(struct parser_params *p, int c, int cmd_state)
 {
     enum yytokentype result;
-    int mb = ENC_CODERANGE_7BIT;
+    bool is_ascii = true;
     const enum lex_state_e last_state = p->lex.state;
     ID ident;
     int enforce_keyword_end = 0;
 
     do {
-        if (!ISASCII(c)) mb = ENC_CODERANGE_UNKNOWN;
+        if (!ISASCII(c)) is_ascii = false;
         if (tokadd_mbchar(p, c) == -1) return 0;
         c = nextc(p);
     } while (parser_is_identchar(p));
@@ -10707,7 +10707,7 @@ parse_ident(struct parser_params *p, int c, int cmd_state)
     }
 #endif
 
-    if (mb == ENC_CODERANGE_7BIT && (!IS_lex_state(EXPR_DOT) || enforce_keyword_end)) {
+    if (is_ascii && (!IS_lex_state(EXPR_DOT) || enforce_keyword_end)) {
         const struct kwtable *kw;
 
         /* See if it is a reserved word.  */

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1344,8 +1344,6 @@ typedef struct rb_parser_config_struct {
     rb_encoding *(*enc_from_index)(int idx);
     VALUE (*enc_associate_index)(VALUE obj, int encindex);
     int (*enc_isspace)(OnigCodePoint c, rb_encoding *enc);
-    int enc_coderange_7bit;
-    int enc_coderange_unknown;
     rb_encoding *(*enc_compatible)(VALUE str1, VALUE str2);
     VALUE (*enc_from_encoding)(rb_encoding *enc);
     int (*encoding_get)(VALUE obj);
@@ -1430,6 +1428,8 @@ typedef struct rb_parser_config_struct {
     VALUE (*node_case_when_optimizable_literal)(const NODE *const node);
 
     /* For Ripper */
+    int enc_coderange_7bit;
+    int enc_coderange_unknown;
     VALUE (*static_id2sym)(ID id);
     long (*str_coderange_scan_restartable)(const char *s, const char *e, rb_encoding *enc, int *cr);
 } rb_parser_config_t;


### PR DESCRIPTION
No need to use ENC_CODERANGE to record ascii only or not.