### PR TITLE
YJIT: add missing jge comparison instruction

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -1135,6 +1135,9 @@ impl Assembler
                 Insn::Jg(target) => {
                     emit_conditional_jump::<{Condition::GT}>(cb, compile_side_exit(*target, self, ocb)?);
                 },
+                Insn::Jge(target) => {
+                    emit_conditional_jump::<{Condition::GE}>(cb, compile_side_exit(*target, self, ocb)?);
+                },
                 Insn::Jbe(target) => {
                     emit_conditional_jump::<{Condition::LS}>(cb, compile_side_exit(*target, self, ocb)?);
                 },

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -423,6 +423,9 @@ pub enum Insn {
     /// Jump if greater
     Jg(Target),
 
+    /// Jump if greater or equal
+    Jge(Target),
+
     // Unconditional jump to a branch target
     Jmp(Target),
 
@@ -532,6 +535,7 @@ impl Insn {
             Insn::Je(target) |
             Insn::Jl(target) |
             Insn::Jg(target) |
+            Insn::Jge(target) |
             Insn::Jmp(target) |
             Insn::Jne(target) |
             Insn::Jnz(target) |
@@ -578,6 +582,7 @@ impl Insn {
             Insn::Je(_) => "Je",
             Insn::Jl(_) => "Jl",
             Insn::Jg(_) => "Jg",
+            Insn::Jge(_) => "Jge",
             Insn::Jmp(_) => "Jmp",
             Insn::JmpOpnd(_) => "JmpOpnd",
             Insn::Jne(_) => "Jne",
@@ -682,6 +687,7 @@ impl Insn {
             Insn::Je(target) |
             Insn::Jl(target) |
             Insn::Jg(target) |
+            Insn::Jge(target) |
             Insn::Jmp(target) |
             Insn::Jne(target) |
             Insn::Jnz(target) |
@@ -733,6 +739,7 @@ impl<'a> Iterator for InsnOpndIterator<'a> {
             Insn::Je(_) |
             Insn::Jl(_) |
             Insn::Jg(_) |
+            Insn::Jge(_) |
             Insn::Jmp(_) |
             Insn::Jne(_) |
             Insn::Jnz(_) |
@@ -834,6 +841,7 @@ impl<'a> InsnOpndMutIterator<'a> {
             Insn::Je(_) |
             Insn::Jl(_) |
             Insn::Jg(_) |
+            Insn::Jge(_) |
             Insn::Jmp(_) |
             Insn::Jne(_) |
             Insn::Jnz(_) |
@@ -1803,6 +1811,11 @@ impl Assembler {
     #[allow(dead_code)]
     pub fn jg(&mut self, target: Target) {
         self.push_insn(Insn::Jg(target));
+    }
+
+    #[allow(dead_code)]
+    pub fn jge(&mut self, target: Target) {
+        self.push_insn(Insn::Jge(target));
     }
 
     pub fn jmp(&mut self, target: Target) {

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -730,6 +730,14 @@ impl Assembler
                     }
                 },
 
+                Insn::Jge(target) => {
+                    match compile_side_exit(*target, self, ocb)? {
+                        Target::CodePtr(code_ptr) | Target::SideExitPtr(code_ptr) => jge_ptr(cb, code_ptr),
+                        Target::Label(label_idx) => jge_label(cb, label_idx),
+                        Target::SideExit { .. } => unreachable!("Target::SideExit should have been compiled by compile_side_exit"),
+                    }
+                },
+
                 Insn::Jbe(target) => {
                     match compile_side_exit(*target, self, ocb)? {
                         Target::CodePtr(code_ptr) | Target::SideExitPtr(code_ptr) => jbe_ptr(cb, code_ptr),


### PR DESCRIPTION
I ran into this while trying to implement setbyte, was surprised to find out we hadn't implemented it yet.