### PR TITLE
Remove uneeded Universal Parser properties

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -358,12 +358,6 @@ syntax_error_new(void)
     return rb_class_new_instance(0, 0, rb_eSyntaxError);
 }
 
-static int
-obj_frozen(VALUE obj)
-{
-    return (int)RB_OBJ_FROZEN(obj);
-}
-
 static VALUE
 obj_write(VALUE old, VALUE *slot, VALUE young)
 {
@@ -511,7 +505,6 @@ static const rb_parser_config_t rb_global_parser_config = {
 
     .obj_freeze = rb_obj_freeze,
     .obj_hide = rb_obj_hide,
-    .obj_frozen = obj_frozen,
     .type_p = type_p,
     .obj_freeze_raw = OBJ_FREEZE_RAW,
 
@@ -523,17 +516,13 @@ static const rb_parser_config_t rb_global_parser_config = {
     .ary_new = rb_ary_new,
     .ary_push = rb_ary_push,
     .ary_new_from_args = rb_ary_new_from_args,
-    .ary_pop = rb_ary_pop,
-    .ary_last = rb_ary_last,
     .ary_unshift = rb_ary_unshift,
     .ary_new2 = rb_ary_new2,
-    .ary_entry = rb_ary_entry,
     .ary_clear = rb_ary_clear,
     .ary_modify = rb_ary_modify,
     .array_len = rb_array_len,
     .array_aref = RARRAY_AREF,
 
-    .sym_intern_ascii_cstr = rb_sym_intern_ascii_cstr,
     .make_temporary_id = rb_make_temporary_id,
     .is_local_id = is_local_id2,
     .is_attrset_id = is_attrset_id2,
@@ -546,7 +535,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .intern_str = rb_intern_str,
     .is_notop_id = is_notop_id2,
     .enc_symname_type = enc_symname_type,
-    .str_intern = rb_str_intern,
     .id2name = rb_id2name,
     .id2str = rb_id2str,
     .id2sym = rb_id2sym,
@@ -555,7 +543,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .str_catf = rb_str_catf,
     .str_cat_cstr = rb_str_cat_cstr,
     .str_subseq = rb_str_subseq,
-    .str_dup = rb_str_dup,
     .str_new_frozen = rb_str_new_frozen,
     .str_buf_new = rb_str_buf_new,
     .str_buf_cat = rb_str_buf_cat,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1234,7 +1234,6 @@ typedef struct rb_parser_config_struct {
     /* Object */
     VALUE (*obj_freeze)(VALUE obj);
     VALUE (*obj_hide)(VALUE obj);
-    int (*obj_frozen)(VALUE obj);
     int (*type_p)(VALUE, int);
     void (*obj_freeze_raw)(VALUE obj);
 
@@ -1248,18 +1247,14 @@ typedef struct rb_parser_config_struct {
     VALUE (*ary_new)(void);
     VALUE (*ary_push)(VALUE ary, VALUE elem);
     VALUE (*ary_new_from_args)(long n, ...);
-    VALUE (*ary_pop)(VALUE ary);
-    VALUE (*ary_last)(int argc, const VALUE *argv, VALUE ary);
     VALUE (*ary_unshift)(VALUE ary, VALUE item);
     VALUE (*ary_new2)(long capa); // ary_new_capa
-    VALUE (*ary_entry)(VALUE ary, long offset);
     VALUE (*ary_clear)(VALUE ary);
     void (*ary_modify)(VALUE ary);
     long (*array_len)(VALUE a);
     VALUE (*array_aref)(VALUE, long);
 
     /* Symbol */
-    VALUE (*sym_intern_ascii_cstr)(const char *ptr);
     ID (*make_temporary_id)(size_t n);
     int (*is_local_id)(ID);
     int (*is_attrset_id)(ID);
@@ -1272,7 +1267,6 @@ typedef struct rb_parser_config_struct {
     ID (*intern_str)(VALUE str);
     int (*is_notop_id)(ID);
     int (*enc_symname_type)(const char *name, long len, rb_encoding *enc, unsigned int allowed_attrset);
-    VALUE (*str_intern)(VALUE str);
     const char *(*id2name)(ID id);
     VALUE (*id2str)(ID id);
     VALUE (*id2sym)(ID x);
@@ -1283,7 +1277,6 @@ typedef struct rb_parser_config_struct {
     VALUE (*str_catf)(VALUE str, const char *format, ...);
     VALUE (*str_cat_cstr)(VALUE str, const char *ptr);
     VALUE (*str_subseq)(VALUE str, long beg, long len);
-    VALUE (*str_dup)(VALUE str);
     VALUE (*str_new_frozen)(VALUE orig);
     VALUE (*str_buf_new)(long capa);
     VALUE (*str_buf_cat)(VALUE, const char*, long);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -115,13 +115,9 @@ struct rb_imemo_tmpbuf_struct {
 
 #define compile_callback         p->config->compile_callback
 #define reg_named_capture_assign p->config->reg_named_capture_assign
-#define script_lines_defined     p->config->script_lines_defined
-#define script_lines_get         p->config->script_lines_get
 
 #define rb_obj_freeze p->config->obj_freeze
 #define rb_obj_hide p->config->obj_hide
-#undef RB_OBJ_FROZEN
-#define RB_OBJ_FROZEN p->config->obj_frozen
 #undef RB_TYPE_P
 #define RB_TYPE_P p->config->type_p
 #undef OBJ_FREEZE_RAW
@@ -138,20 +134,15 @@ struct rb_imemo_tmpbuf_struct {
 #define rb_ary_push          p->config->ary_push
 #undef rb_ary_new_from_args
 #define rb_ary_new_from_args p->config->ary_new_from_args
-#define rb_ary_pop           p->config->ary_pop
-#define rb_ary_last          p->config->ary_last
 #define rb_ary_unshift       p->config->ary_unshift
 #undef rb_ary_new2
 #define rb_ary_new2          p->config->ary_new2
-#define rb_ary_entry         p->config->ary_entry
 #define rb_ary_clear         p->config->ary_clear
 #define rb_ary_modify        p->config->ary_modify
 #undef RARRAY_LEN
 #define RARRAY_LEN           p->config->array_len
 #define RARRAY_AREF          p->config->array_aref
 
-#undef rb_sym_intern_ascii_cstr
-#define rb_sym_intern_ascii_cstr p->config->sym_intern_ascii_cstr
 #define rb_make_temporary_id     p->config->make_temporary_id
 #define is_local_id              p->config->is_local_id
 #define is_attrset_id            p->config->is_attrset_id
@@ -165,10 +156,8 @@ struct rb_imemo_tmpbuf_struct {
 #define rb_intern_str            p->config->intern_str
 #define is_notop_id              p->config->is_notop_id
 #define rb_enc_symname_type      p->config->enc_symname_type
-#define rb_str_intern            p->config->str_intern
 #define rb_id2name               p->config->id2name
 #define rb_id2str                p->config->id2str
-#define rb_id2sym                p->config->id2sym
 #undef ID2SYM
 #define ID2SYM                   p->config->id2sym
 #undef SYM2ID
@@ -178,7 +167,6 @@ struct rb_imemo_tmpbuf_struct {
 #undef rb_str_cat_cstr
 #define rb_str_cat_cstr                   p->config->str_cat_cstr
 #define rb_str_subseq                     p->config->str_subseq
-#define rb_str_dup                        p->config->str_dup
 #define rb_str_new_frozen                 p->config->str_new_frozen
 #define rb_str_buf_new                    p->config->str_buf_new
 #undef rb_str_buf_cat
@@ -262,7 +250,6 @@ struct rb_imemo_tmpbuf_struct {
 
 #define rb_ractor_make_shareable p->config->ractor_make_shareable
 
-#define ruby_vm_keep_script_lines p->config->vm_keep_script_lines()
 #define rb_local_defined          p->config->local_defined
 #define rb_dvar_defined           p->config->dvar_defined
 
@@ -333,7 +320,6 @@ struct rb_imemo_tmpbuf_struct {
 #define SPECIAL_CONST_P p->config->special_const_p
 #undef BUILTIN_TYPE
 #define BUILTIN_TYPE p->config->builtin_type
-#define ruby_snprintf p->config->snprintf
 
 #define rb_node_case_when_optimizable_literal p->config->node_case_when_optimizable_literal
 


### PR DESCRIPTION
Some Universal Parser properties are not currently used by parse.y, etc. and can be removed.