### PR TITLE
[PRISM] Do not optimize safe navigation method calls

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -4136,6 +4136,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             pm_compile_call(iseq, call_node, ret, popped, scope_node, method_id, start);
         }
         else if ((method_id == idUMinus || method_id == idFreeze) &&
+                !PM_NODE_FLAG_P(call_node, PM_CALL_NODE_FLAGS_SAFE_NAVIGATION) &&
                 PM_NODE_TYPE_P(call_node->receiver, PM_STRING_NODE) &&
                 call_node->arguments == NULL &&
                 call_node->block == NULL &&

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -4149,7 +4149,9 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                 ADD_INSN2(ret, &dummy_line_node, opt_str_freeze, str, new_callinfo(iseq, idFreeze, 0, 0, NULL, FALSE));
             }
         }
-        else if (method_id == idAREF && call_node->arguments &&
+        else if (method_id == idAREF &&
+                !PM_NODE_FLAG_P(call_node, PM_CALL_NODE_FLAGS_SAFE_NAVIGATION) &&
+                call_node->arguments &&
                 PM_NODE_TYPE_P((pm_node_t *)call_node->arguments, PM_ARGUMENTS_NODE) &&
                 ((pm_arguments_node_t *)call_node->arguments)->arguments.size == 1 &&
                 PM_NODE_TYPE_P(((pm_arguments_node_t *)call_node->arguments)->arguments.nodes[0], PM_STRING_NODE) &&


### PR DESCRIPTION
From: https://github.com/ruby/ruby/pull/9820