### PR TITLE
Fix static linked extensions

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -110,7 +110,7 @@ jobs:
             shared: disable
             # check: true
 
-          - { name: ext/Setup }
+          - { name: ext/Setup, static-exts: 'etc,json/*,*/escape' }
 
 #         - { name: aarch64-linux-gnu,     crosshost: aarch64-linux-gnu, container: crossbuild-essential-arm64 }
 #         - { name: arm-linux-gnueabi,     crosshost: arm-linux-gnueabi }
@@ -258,9 +258,14 @@ jobs:
           }}
           --${{ matrix.entry.shared || 'enable' }}-shared
 
-      - name: Add to ext/Setup # statically link just the etc extension
-        run: mkdir ext && echo etc >> ext/Setup
-        if: ${{ matrix.entry.name == 'ext/Setup' }}
+      - name: Add to ext/Setup
+        run: |
+          mkdir ext
+          cd ext
+          for ext in {${{ matrix.entry.static-exts }}}/extconf.rb; do
+            echo ${ext%/extconf.rb}
+          done >> Setup
+        if: ${{ (matrix.entry.static-exts || '') != '' }}
 
       - run: make showflags
 

--- a/ext/extmk.rb
+++ b/ext/extmk.rb
@@ -132,6 +132,14 @@ def extract_makefile(makefile, keep = true)
   true
 end
 
+def create_makefile(target, srcprefix = nil)
+  if $static and target.include?("/")
+    base = File.basename(target)
+    $defs << "-DInit_#{base}=Init_#{target.tr('/', '_')}"
+  end
+  super
+end
+
 def extmake(target, basedir = 'ext', maybestatic = true)
   FileUtils.mkpath target unless File.directory?(target)
   begin
@@ -544,7 +552,13 @@ extend Module.new {
   end
 
   def create_makefile(*args, &block)
-    return super unless @gemname
+    unless @gemname
+      if $static and (target = args.first).include?("/")
+        base = File.basename(target)
+        $defs << "-DInit_#{base}=Init_#{target.tr('/', '_')}"
+      end
+      return super
+    end
     super(*args) do |conf|
       conf.find do |s|
         s.sub!(%r(^(srcdir *= *)\$\(top_srcdir\)/\.bundle/gems/[^/]+(?=/))) {

--- a/ext/extmk.rb
+++ b/ext/extmk.rb
@@ -104,7 +104,7 @@ def extract_makefile(makefile, keep = true)
     end
     return false
   end
-  srcs = Dir[File.join($srcdir, "*.{#{SRC_EXT.join(%q{,})}}")].map {|fn| File.basename(fn)}.sort
+  srcs = Dir[*SRC_EXT.map {|e| "*.#{e}"}, base: $srcdir].map {|fn| File.basename(fn)}.sort
   if !srcs.empty?
     old_srcs = m[/^ORIG_SRCS[ \t]*=[ \t](.*)/, 1] or return false
     (old_srcs.split - srcs).empty? or return false
@@ -507,10 +507,8 @@ cond = proc {|ext, *|
 }
 ($extension || %w[*]).each do |e|
   e = e.sub(/\A(?:\.\/)+/, '')
-  incl, excl = Dir.glob("#{ext_prefix}/#{e}/**/extconf.rb").collect {|d|
-    d = File.dirname(d)
-    d.slice!(0, ext_prefix.length + 1)
-    d
+  incl, excl = Dir.glob("#{e}/**/extconf.rb", base: "#$top_srcdir/#{ext_prefix}").collect {|d|
+    File.dirname(d)
   }.partition {|ext|
     with_config(ext, &cond)
   }
@@ -522,7 +520,7 @@ cond = proc {|ext, *|
     exts.delete_if {|d| File.fnmatch?("-*", d)}
   end
 end
-ext_prefix = ext_prefix[$top_srcdir.size+1..-2]
+ext_prefix.chomp!("/")
 
 @ext_prefix = ext_prefix
 @inplace = inplace

--- a/template/extinit.c.tmpl
+++ b/template/extinit.c.tmpl
@@ -1,5 +1,5 @@
 %# -*- C -*-
-% extinits = ARGV.map {|n| [n[%r[[^/.]+(?=\.[^/]*)?\z]], n]}
+% extinits = ARGV.map {|n| [n.tr('/', '_'), n]}
 #include "ruby/ruby.h"
 
 #define init(func, name) {	\


### PR DESCRIPTION
The extension library has each initialization function named "Init_" + basename. If multiple extensions have the same base name (such as cgi/escape and erb/escape), the same function will be registered for both names.

Also allow glob patterns in ext/Setup.