### PR TITLE
Do not truncate strings inefficiently

### DIFF
--- a/lib/cgi/core.rb
+++ b/lib/cgi/core.rb
@@ -530,7 +530,7 @@ class CGI
             if head && buf.size > boundary_size
               len = buf.size - boundary_size
               body.print(buf[0, len])
-              buf[0, len] = ''
+              buf = buf[len, buf.size]
             end
             c = stdin.read(bufsize < content_length ? bufsize : content_length)
             raise EOFError.new("bad content body") if c.nil? || c.empty?

--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -989,7 +989,7 @@ SRC
       f = nil
       Dir.glob(files) do |fx|
         f = fx
-        f[0..len] = "" if len
+        f = f[len, f.size] if len
         case File.basename(f)
         when *$NONINSTALLFILES
           next

--- a/lib/rubygems/safe_marshal/visitors/to_ruby.rb
+++ b/lib/rubygems/safe_marshal/visitors/to_ruby.rb
@@ -109,7 +109,7 @@ module Gem::SafeMarshal
               marshal_string.concat(k.size + 5)
               marshal_string.concat(k.to_s)
               dumped = Marshal.dump(v)
-              dumped[0, 2] = ""
+              dumped = dumped[2, dumped.size]
               marshal_string.concat(dumped)
             end
 

--- a/sample/drb/http0.rb
+++ b/sample/drb/http0.rb
@@ -14,7 +14,7 @@ module DRb
         begin
           return @buf[0,n]
         ensure
-          @buf[0,n] = ''
+          @buf = @buf[n, @buf.size]
         end
       end
 


### PR DESCRIPTION
Hey folks,
as I demonstrated in [this blog post](http://blog.mattstuchlik.com/2024/01/31/sneaky-one-liner.html), truncating string with `s[0, x] = ''` seems to lead to unnecessary memory copying. I've identified couple places in Ruby where this pattern is being used and this PR replaces it with the more efficient pattern.

If this look like something you might be interested in merging let me know if I need to do anything else here, it's my first PR against Ruby.

Related PR against this same issue in openssl: https://github.com/ruby/openssl/pull/706