### PR TITLE
[wasm] tool/m4/ruby_wasm_tools.m4: Add default value for OBJCOPY

### DIFF
--- a/tool/m4/ruby_wasm_tools.m4
+++ b/tool/m4/ruby_wasm_tools.m4
@@ -19,6 +19,7 @@ AC_DEFUN([RUBY_WASM_TOOLS],
         LD="${LD:-${WASI_SDK_PATH}/bin/clang}"
         AR="${AR:-${WASI_SDK_PATH}/bin/llvm-ar}"
         RANLIB="${RANLIB:-${WASI_SDK_PATH}/bin/llvm-ranlib}"
+        OBJCOPY="${OBJCOPY:-${WASI_SDK_PATH}/bin/llvm-objcopy}"
     ])
 ])
 ])dnl


### PR DESCRIPTION
The tool is used to build shared libraries but system installed tools usually don't support WebAssembly, so use WASI SDK's tools by default.