### PR TITLE
Free all remaining objects in rb_objspace_free_objects

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3810,7 +3810,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
             RB_DEBUG_COUNTER_INC(obj_imemo_constcache);
             break;
         }
-        return TRUE;
+        break;
 
       default:
         rb_bug("gc_sweep(): unknown data type 0x%x(%p) 0x%"PRIxVALUE,
@@ -3822,6 +3822,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
         return FALSE;
     }
     else {
+        RBASIC(obj)->flags = 0;
         return TRUE;
     }
 }
@@ -4618,16 +4619,11 @@ rb_objspace_free_objects(rb_objspace_t *objspace)
         for (; p < pend; p += stride) {
             VALUE vp = (VALUE)p;
             switch (BUILTIN_TYPE(vp)) {
-              case T_DATA: {
-                if (rb_obj_is_mutex(vp) || rb_obj_is_thread(vp) || rb_obj_is_main_ractor(vp)) {
-                    obj_free(objspace, vp);
-                }
-                break;
-              }
-              case T_ARRAY:
-                obj_free(objspace, vp);
+              case T_NONE:
+              case T_SYMBOL:
                 break;
               default:
+                obj_free(objspace, vp);
                 break;
             }
         }


### PR DESCRIPTION
rb_objspace_call_finalizer didn't free fibers and neither did rb_objspace_free_objects, which caused fibers to be reported as leaked when using RUBY_FREE_AT_EXIT. This commit changes rb_objspace_free_objects to free all remaining Ruby objects.