### PR TITLE
Make enc/ subdirectory in autoconf so gcc can write .o files there

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4603,6 +4603,9 @@ AC_CONFIG_FILES(Makefile:template/Makefile.in, [
     ]) && mv -f $tmpmk Makefile],
 [EXEEXT='$EXEEXT' MAKE='${MAKE-make}' gnumake='$gnumake' GIT='$GIT' YJIT_SUPPORT='$YJIT_SUPPORT'])
 
+dnl Make subdirectories where object files live, so that the compiler can write .o files to them
+AC_CONFIG_COMMANDS([enc], [mkdir -p enc])
+
 AC_ARG_WITH([ruby-pc],
 	    AS_HELP_STRING([--with-ruby-pc=FILENAME], [pc file basename]),
 	    [ruby_pc="$withval"],


### PR DESCRIPTION
The makefile has rules which build enc/ascii.o from enc/ascii.c, so that these "BUILTIN_ENCOBJS" can get compiled into miniruby _before_ the enc/Makefile is templated out. Unfortunately these rules don't create the enc/ directory, so unless something else does first, the compiler will fail at that point.

e.g.

```
gcc -DVM_CHECK_MODE=1 -O3 -fno-fast-math -ggdb3 -Wall -Wextra -Wdeprecated-declarations -Wdiv-by-zero -Wduplicated-cond -Wimplicit-function-declaration -Wimplicit-int -Wpointer-arith -Wwrite-strings -Wold-style-definition -Wimplicit-fallthrough=0 -Wmissing-noreturn -Wno-cast-function-type -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-packed-bitfield-compat -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wsuggest-attribute=format -Wsuggest-attribute=noreturn -Wunused-variable -Wmisleading-indentation -Wundef   -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fno-strict-overflow -fvisibility=hidden -fexcess-precision=standard -DRUBY_EXPORT -fPIE -I. -I.ext/include/x86_64-linux -I../include -I.. -I../prism -I../enc/unicode/15.0.0      -o enc/ascii.o -c ../enc/ascii.c
Assembler messages:
Fatal error: can't create enc/ascii.o: No such file or directory
```

Solution is to use autoconf (actually config.stauts) to make the directory before Make is run.

https://bugs.ruby-lang.org/issues/20241
[Bug #20241]