### PR TITLE
Fix memory leak when parsing invalid pattern matching

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -16070,6 +16070,11 @@ rb_ruby_parser_free(void *ptr)
         }
     }
     string_buffer_free(p);
+
+    if (p->pvtbl) {
+        st_free_table(p->pvtbl);
+    }
+
     xfree(ptr);
 }
 


### PR DESCRIPTION
If the pattern matching is invalid, then the pvtbl would get leaked. For example:

```ruby
10.times do
  100_000.times do
    eval(<<~RUBY)
      case {a: 1}
      in {"a" => 1}
      end
    RUBY
  rescue SyntaxError
  end

  puts `ps -o rss= -p #{$$}`
end
```

Before:

    28096
    44768
    61472
    78512
    94992
    111504
    128096
    144528
    161008
    177472

After:

    14096
    14112
    14112
    14176
    14208
    14240
    14240
    14240
    14240
    14240