### PR TITLE
YJIT: Allow popping before falling back

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4527,3 +4527,14 @@ assert_equal '[1, 2]', %q{
   arr = [1]
   foo(*arr, 2)
 }
+
+# pop before fallback
+assert_normal_exit %q{
+  class Foo
+    attr_reader :foo
+
+    def try = foo(0, &nil)
+  end
+
+  Foo.new.try
+}

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7516,6 +7516,10 @@ fn gen_send_dynamic<F: Fn(&mut Assembler) -> Opnd>(
         return None;
     }
 
+    // Rewind stack_size using ctx.with_stack_size to allow stack_size changes
+    // before you return None.
+    asm.ctx = asm.ctx.with_stack_size(jit.stack_size_for_pc);
+
     // Save PC and SP to prepare for dynamic dispatch
     jit_prepare_non_leaf_call(jit, asm);
 


### PR DESCRIPTION
Popping but not generating any code before returning `None` was allowed
before fallbacks were introduced so this is restoring that support in
the same way. The included test used to trip an assert due to popping
too much.
