### PR TITLE
When --parser=prism is set, use it for -c results

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -2327,7 +2327,7 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
     opt->sflag = process_sflag(opt->sflag);
     opt->xflag = 0;
 
-    if (dump & DUMP_BIT(syntax)) {
+    if (!(*rb_ruby_prism_ptr()) && dump & DUMP_BIT(syntax)) {
         printf("Syntax OK\n");
         dump &= ~DUMP_BIT(syntax);
         if (!dump) return Qtrue;
@@ -2429,6 +2429,10 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
                 ruby_opt_init(opt);
                 iseq = pm_iseq_new_main(&result.node, opt->script_name, path, vm_block_iseq(base_block), !(dump & DUMP_BIT(insns_without_opt)));
                 pm_parse_result_free(&result);
+                if (dump & DUMP_BIT(syntax)) {
+                    printf("Syntax OK\n");
+                    return Qtrue;
+                }
             }
             else {
                 pm_parse_result_free(&result);


### PR DESCRIPTION
before without error:

```
$ ./miniruby --parser=prism -c -e "puts :hi"
./miniruby: warning: The compiler based on the Prism parser is currently experimental and compatibility with the compiler based on parse.y is not yet complete. Please report any issues you find on the `ruby/prism` issue tracker.
Syntax OK
```

after without error:

```
$ ./miniruby --parser=prism -c -e "puts :hi"
./miniruby: warning: The compiler based on the Prism parser is currently experimental and compatibility with the compiler based on parse.y is not yet complete. Please report any issues you find on the `ruby/prism` issue tracker.
Syntax OK
```

☝️ These are the same and should stay the same.

before with error:

```
$ ./miniruby --parser=prism -c -e "puts :2hi"
./miniruby: warning: The compiler based on the Prism parser is currently experimental and compatibility with the compiler based on parse.y is not yet complete. Please report any issues you find on the `ruby/prism` issue tracker.
Syntax OK
```

☝️ This should print an error and doesn't.

after with error:

```
$ ./miniruby --parser=prism -c -e "puts :2hi"
./miniruby: warning: The compiler based on the Prism parser is currently experimental and compatibility with the compiler based on parse.y is not yet complete. Please report any issues you find on the `ruby/prism` issue tracker.
-e: syntax errors found (SyntaxError)
> 1 | puts :2hi
    |       ^ expected a newline or semicolon after the statement
    |       ^ invalid symbol
    |        ^ expected a newline or semicolon after the statement
```

prism issue: https://github.com/ruby/prism/issues/2338