### PR TITLE
[PRISM] Fix error handling in `pm_parse_prism`

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -7811,7 +7811,13 @@ VALUE
 pm_parse_file(pm_parse_result_t *result, VALUE filepath)
 {
     if (!pm_string_mapped_init(&result->input, RSTRING_PTR(filepath))) {
-        return rb_exc_new3(rb_eRuntimeError, rb_sprintf("Failed to map file: %s", RSTRING_PTR(filepath)));
+#ifdef _WIN32
+        int e = rb_w32_map_errno(GetLastError());
+#else
+        int e = errno;
+#endif
+
+        return rb_syserr_new(e, RSTRING_PTR(filepath));
     }
 
     VALUE error = pm_parse_input(result, filepath);

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -2678,6 +2678,22 @@ end
       assert_prism_eval(":però")
     end
 
+    def test_parse_file
+      assert_nothing_raised do
+        RubyVM::InstructionSequence.compile_file_prism(__FILE__)
+      end
+
+      error = assert_raise Errno::ENOENT do
+        RubyVM::InstructionSequence.compile_file_prism("idontexist.rb")
+      end
+
+      assert_equal "No such file or directory - idontexist.rb", error.message
+
+      assert_raise TypeError do
+        RubyVM::InstructionSequence.compile_file_prism(nil)
+      end
+    end
+
     private
 
     def compare_eval(source, raw:)


### PR DESCRIPTION
Following changes made in ruby/prism#2365 this implements error handling for when `pm_string_mapped_init` returns `false`.

Related: ruby/prism#2207