### PR TITLE
Ignore _odr_asan symbols in leaked-globals

### DIFF
--- a/tool/leaked-globals
+++ b/tool/leaked-globals
@@ -88,6 +88,7 @@ Pipe.new(NM + ARGV).each do |line|
   next unless n.sub!(/^#{SYMBOL_PREFIX}/o, "")
   next if n.include?(".")
   next if !so and n.start_with?("___asan_")
+  next if !so and n.start_with?("__odr_asan_")
   case n
   when /\A(?:Init_|InitVM_|pm_|[Oo]nig|dln_|coroutine_)/
     next


### PR DESCRIPTION
ASAN includes these to detect violations of the ODR rule.

[Bug #20221]