### PR TITLE
[PRISM] Fix lambda start column number

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2502,6 +2502,13 @@ pm_scope_node_init(const pm_node_t *node, pm_scope_node_t *scope, pm_scope_node_
         scope->parameters = cast->parameters;
         scope->body = cast->body;
         scope->locals = cast->locals;
+
+        if (cast->parameters != NULL) {
+            scope->base.location.start = cast->parameters->location.start;
+        }
+        else {
+            scope->base.location.start = cast->operator_loc.end;
+        }
         break;
       }
       case PM_MODULE_NODE: {

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1838,6 +1838,15 @@ end
       assert_prism_eval("-> { to_s }.call")
     end
 
+    def test_LambdaNode_with_multiline_args
+      assert_prism_eval(<<-CODE)
+        -> (a,
+            b) {
+              a + b
+            }.call(1, 2)
+      CODE
+    end
+
     def test_ModuleNode
       assert_prism_eval("module M; end")
       assert_prism_eval("module M::N; end")


### PR DESCRIPTION
### Context

Given the source:
![source](https://github.com/ruby/ruby/assets/5512772/2d1a7b9d-5384-4cb2-8e48-9cb67a4574f8)

original parser builds block iseq with column `3` as the start location
![original_parser](https://github.com/ruby/ruby/assets/5512772/633a56c6-7b96-4e0d-bfe1-128c7dc313a2)

but PRISM uses lambda's start location instead
![bug_prism](https://github.com/ruby/ruby/assets/5512772/330ae4a2-b22c-4e10-ac00-9f89d802aba6)

### Solution

This PR fixes the issue by setting the block iseq start location based on the following logic:
- if lambda is defined with parameters - lambda start location is the parameters opening location
- if lambda is defined with no parameters - start location is the location of lambda operator's end

### Testing

The `test_LambdaNode_with_multiline_args` test I added **doesn't fail** even without the fix because it only compares `eval`s and not location data of generated iseqs but I wanted to keep it to have better coverage and more varieties of lambda definitions. I couldn't come up with a decent test to compare locations but would appreciate if anyone has suggestions on how to test it properly. Meanwhile I'm going to rely on manual verification as the change is low-risk:

![fixed_prism](https://github.com/ruby/ruby/assets/5512772/4e848159-f9b1-443f-adac-ae5c9444833f)
