### PR TITLE
YJIT: Skip pushing a frame for Hash#empty?

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3015,7 +3015,7 @@ rb_hash_size_num(VALUE hash)
  *    {foo: 0, bar: 1, baz: 2}.empty? # => false
  */
 
-static VALUE
+VALUE
 rb_hash_empty_p(VALUE hash)
 {
     return RBOOL(RHASH_EMPTY_P(hash));

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -107,11 +107,12 @@ pub use autogened::*;
 // TODO: For #defines that affect memory layout, we need to check for them
 // on build and fail if they're wrong. e.g. USE_FLONUM *must* be true.
 
-// These are functions we expose from vm_insnhelper.c, not in any header.
+// These are functions we expose from C files, not in any header.
 // Parsing it would result in a lot of duplicate definitions.
 // Use bindgen for functions that are defined in headers or in yjit.c.
 #[cfg_attr(test, allow(unused))] // We don't link against C code when testing
 extern "C" {
+    pub fn rb_hash_empty_p(hash: VALUE) -> VALUE;
     pub fn rb_vm_splat_array(flag: VALUE, ary: VALUE) -> VALUE;
     pub fn rb_vm_concat_array(ary1: VALUE, ary2st: VALUE) -> VALUE;
     pub fn rb_vm_concat_to_array(ary1: VALUE, ary2st: VALUE) -> VALUE;


### PR DESCRIPTION
Like `opt_empty_p` does, this PR skips pushing a frame for `Hash#empty?`. It consists of 11.5% of C calls on psych-load.

This speeds up `psych-load` by 1%.

```
before: ruby 3.4.0dev (2024-02-07T21:26:14Z master 0e1f22ac7e) +YJIT [x86_64-linux]
after: ruby 3.4.0dev (2024-02-07T21:26:14Z master 0e1f22ac7e) +YJIT [x86_64-linux]

----------  -----------  ----------  ----------  ----------  -------------  ------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
psych-load  1927.3       0.1         1901.3      0.0         1.01           1.01
----------  -----------  ----------  ----------  ----------  -------------  ------------
```