### PR TITLE
YJIT: Maintain MapToLocal that is just upgraded

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1947,6 +1947,9 @@ impl Context {
                         let mut new_type = self.get_local_type(idx);
                         new_type.upgrade(opnd_type);
                         self.set_local_type(idx, new_type);
+                        // Re-attach MapToLocal for this StackOpnd(idx). set_local_type() detaches
+                        // all MapToLocal mappings, including the one we're upgrading here.
+                        self.set_opnd_mapping(opnd, mapping);
                     }
                 }
             }
@@ -3579,6 +3582,14 @@ mod tests {
         assert!(top_type == Type::Fixnum);
 
         // TODO: write more tests for Context type diff
+    }
+
+    #[test]
+    fn context_upgrade_local() {
+        let mut asm = Assembler::new();
+        asm.stack_push_local(0);
+        asm.ctx.upgrade_opnd_type(StackOpnd(0), Type::Nil);
+        assert_eq!(Type::Nil, asm.ctx.get_opnd_type(StackOpnd(0)));
     }
 
     #[test]


### PR DESCRIPTION
10.5% of C calls on psych-load were `NilClass#!`. It's weird because `jit_guard_known_class` should upgrade the type to `Type::Nil` and `jit_rb_obj_not` should specialize it. 

I noticed `jit_guard_known_class` with `rb_cNilClass` failed to upgrade the type to `Type::Nil` when the operand being upgraded is `MapToLocal`. It was because `self.set_local_type` detaches all matching `MapToLocal` mappings from all temps, including the temp that is being upgraded. So this PR re-attaches the given temp to the local that is just upgraded.

This speeds up psych-load by 1%.

```
before: ruby 3.4.0dev (2024-02-07T21:26:14Z master 0e1f22ac7e) +YJIT [x86_64-linux]
after: ruby 3.4.0dev (2024-02-08T01:25:06Z yjit-local-upgrade 5033b4b921) +YJIT [x86_64-linux]

----------  -----------  ----------  ----------  ----------  -------------  ------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
psych-load  1918.5       0.2         1903.1      0.2         1.01           1.01
----------  -----------  ----------  ----------  ----------  -------------  ------------
```