### PR TITLE
YJIT: Report invalidation counts in non-stats mode

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -245,7 +245,7 @@ macro_rules! make_counters {
 
 /// The list of counters that are available without --yjit-stats.
 /// They are incremented only by `incr_counter!` and don't use `gen_counter_incr`.
-pub const DEFAULT_COUNTERS: [Counter; 9] = [
+pub const DEFAULT_COUNTERS: [Counter; 15] = [
     Counter::code_gc_count,
     Counter::compiled_iseq_entry,
     Counter::cold_iseq_entry,
@@ -255,6 +255,13 @@ pub const DEFAULT_COUNTERS: [Counter; 9] = [
     Counter::compiled_branch_count,
     Counter::compile_time_ns,
     Counter::max_inline_versions,
+
+    Counter::invalidation_count,
+    Counter::invalidate_method_lookup,
+    Counter::invalidate_bop_redefined,
+    Counter::invalidate_ractor_spawn,
+    Counter::invalidate_constant_state_bump,
+    Counter::invalidate_constant_ic_fill,
 ];
 
 /// Macro to increase a counter by name and count


### PR DESCRIPTION
The `invalidation_count` and `invalidate_*` counters are all incremented using `incr_counter!` without a guard on stats mode, so they can be made always available.

This could be to helpful in investigating where, how often, and what types of invalidations are occurring in a production system.