### PR TITLE
Replace assert with RUBY_ASSERT

### DIFF
--- a/array.c
+++ b/array.c
@@ -77,47 +77,47 @@ should_be_T_ARRAY(VALUE ary)
     return RB_TYPE_P(ary, T_ARRAY);
 }
 
-#define ARY_HEAP_PTR(a) (assert(!ARY_EMBED_P(a)), RARRAY(a)->as.heap.ptr)
-#define ARY_HEAP_LEN(a) (assert(!ARY_EMBED_P(a)), RARRAY(a)->as.heap.len)
-#define ARY_HEAP_CAPA(a) (assert(!ARY_EMBED_P(a)), assert(!ARY_SHARED_ROOT_P(a)), \
+#define ARY_HEAP_PTR(a) (RUBY_ASSERT(!ARY_EMBED_P(a)), RARRAY(a)->as.heap.ptr)
+#define ARY_HEAP_LEN(a) (RUBY_ASSERT(!ARY_EMBED_P(a)), RARRAY(a)->as.heap.len)
+#define ARY_HEAP_CAPA(a) (RUBY_ASSERT(!ARY_EMBED_P(a)), RUBY_ASSERT(!ARY_SHARED_ROOT_P(a)), \
                           RARRAY(a)->as.heap.aux.capa)
 
-#define ARY_EMBED_PTR(a) (assert(ARY_EMBED_P(a)), RARRAY(a)->as.ary)
+#define ARY_EMBED_PTR(a) (RUBY_ASSERT(ARY_EMBED_P(a)), RARRAY(a)->as.ary)
 #define ARY_EMBED_LEN(a) \
-    (assert(ARY_EMBED_P(a)), \
+    (RUBY_ASSERT(ARY_EMBED_P(a)), \
      (long)((RBASIC(a)->flags >> RARRAY_EMBED_LEN_SHIFT) & \
          (RARRAY_EMBED_LEN_MASK >> RARRAY_EMBED_LEN_SHIFT)))
-#define ARY_HEAP_SIZE(a) (assert(!ARY_EMBED_P(a)), assert(ARY_OWNS_HEAP_P(a)), ARY_CAPA(a) * sizeof(VALUE))
+#define ARY_HEAP_SIZE(a) (RUBY_ASSERT(!ARY_EMBED_P(a)), RUBY_ASSERT(ARY_OWNS_HEAP_P(a)), ARY_CAPA(a) * sizeof(VALUE))
 
-#define ARY_OWNS_HEAP_P(a) (assert(should_be_T_ARRAY((VALUE)(a))), \
+#define ARY_OWNS_HEAP_P(a) (RUBY_ASSERT(should_be_T_ARRAY((VALUE)(a))), \
                             !FL_TEST_RAW((a), RARRAY_SHARED_FLAG|RARRAY_EMBED_FLAG))
 
 #define FL_SET_EMBED(a) do { \
-    assert(!ARY_SHARED_P(a)); \
+    RUBY_ASSERT(!ARY_SHARED_P(a)); \
     FL_SET((a), RARRAY_EMBED_FLAG); \
     ary_verify(a); \
 } while (0)
 
 #define FL_UNSET_EMBED(ary) FL_UNSET((ary), RARRAY_EMBED_FLAG|RARRAY_EMBED_LEN_MASK)
 #define FL_SET_SHARED(ary) do { \
-    assert(!ARY_EMBED_P(ary)); \
+    RUBY_ASSERT(!ARY_EMBED_P(ary)); \
     FL_SET((ary), RARRAY_SHARED_FLAG); \
 } while (0)
 #define FL_UNSET_SHARED(ary) FL_UNSET((ary), RARRAY_SHARED_FLAG)
 
 #define ARY_SET_PTR(ary, p) do { \
-    assert(!ARY_EMBED_P(ary)); \
-    assert(!OBJ_FROZEN(ary)); \
+    RUBY_ASSERT(!ARY_EMBED_P(ary)); \
+    RUBY_ASSERT(!OBJ_FROZEN(ary)); \
     RARRAY(ary)->as.heap.ptr = (p); \
 } while (0)
 #define ARY_SET_EMBED_LEN(ary, n) do { \
     long tmp_n = (n); \
-    assert(ARY_EMBED_P(ary)); \
+    RUBY_ASSERT(ARY_EMBED_P(ary)); \
     RBASIC(ary)->flags &= ~RARRAY_EMBED_LEN_MASK; \
     RBASIC(ary)->flags |= (tmp_n) << RARRAY_EMBED_LEN_SHIFT; \
 } while (0)
 #define ARY_SET_HEAP_LEN(ary, n) do { \
-    assert(!ARY_EMBED_P(ary)); \
+    RUBY_ASSERT(!ARY_EMBED_P(ary)); \
     RARRAY(ary)->as.heap.len = (n); \
 } while (0)
 #define ARY_SET_LEN(ary, n) do { \
@@ -127,15 +127,15 @@ should_be_T_ARRAY(VALUE ary)
     else { \
         ARY_SET_HEAP_LEN((ary), (n)); \
     } \
-    assert(RARRAY_LEN(ary) == (n)); \
+    RUBY_ASSERT(RARRAY_LEN(ary) == (n)); \
 } while (0)
 #define ARY_INCREASE_PTR(ary, n) do  { \
-    assert(!ARY_EMBED_P(ary)); \
-    assert(!OBJ_FROZEN(ary)); \
+    RUBY_ASSERT(!ARY_EMBED_P(ary)); \
+    RUBY_ASSERT(!OBJ_FROZEN(ary)); \
     RARRAY(ary)->as.heap.ptr += (n); \
 } while (0)
 #define ARY_INCREASE_LEN(ary, n) do  { \
-    assert(!OBJ_FROZEN(ary)); \
+    RUBY_ASSERT(!OBJ_FROZEN(ary)); \
     if (ARY_EMBED_P(ary)) { \
         ARY_SET_EMBED_LEN((ary), RARRAY_LEN(ary)+(n)); \
     } \
@@ -147,30 +147,30 @@ should_be_T_ARRAY(VALUE ary)
 #define ARY_CAPA(ary) (ARY_EMBED_P(ary) ? ary_embed_capa(ary) : \
                        ARY_SHARED_ROOT_P(ary) ? RARRAY_LEN(ary) : ARY_HEAP_CAPA(ary))
 #define ARY_SET_CAPA(ary, n) do { \
-    assert(!ARY_EMBED_P(ary)); \
-    assert(!ARY_SHARED_P(ary)); \
-    assert(!OBJ_FROZEN(ary)); \
+    RUBY_ASSERT(!ARY_EMBED_P(ary)); \
+    RUBY_ASSERT(!ARY_SHARED_P(ary)); \
+    RUBY_ASSERT(!OBJ_FROZEN(ary)); \
     RARRAY(ary)->as.heap.aux.capa = (n); \
 } while (0)
 
 #define ARY_SHARED_ROOT_OCCUPIED(ary) (!OBJ_FROZEN(ary) && ARY_SHARED_ROOT_REFCNT(ary) == 1)
 #define ARY_SET_SHARED_ROOT_REFCNT(ary, value) do { \
-    assert(ARY_SHARED_ROOT_P(ary)); \
-    assert(!OBJ_FROZEN(ary)); \
-    assert((value) >= 0); \
+    RUBY_ASSERT(ARY_SHARED_ROOT_P(ary)); \
+    RUBY_ASSERT(!OBJ_FROZEN(ary)); \
+    RUBY_ASSERT((value) >= 0); \
     RARRAY(ary)->as.heap.aux.capa = (value); \
 } while (0)
 #define FL_SET_SHARED_ROOT(ary) do { \
-    assert(!OBJ_FROZEN(ary)); \
-    assert(!ARY_EMBED_P(ary)); \
+    RUBY_ASSERT(!OBJ_FROZEN(ary)); \
+    RUBY_ASSERT(!ARY_EMBED_P(ary)); \
     FL_SET((ary), RARRAY_SHARED_ROOT_FLAG); \
 } while (0)
 
 static inline void
 ARY_SET(VALUE a, long i, VALUE v)
 {
-    assert(!ARY_SHARED_P(a));
-    assert(!OBJ_FROZEN(a));
+    RUBY_ASSERT(!ARY_SHARED_P(a));
+    RUBY_ASSERT(!OBJ_FROZEN(a));
 
     RARRAY_ASET(a, i, v);
 }
@@ -180,7 +180,7 @@ static long
 ary_embed_capa(VALUE ary)
 {
     size_t size = rb_gc_obj_slot_size(ary) - offsetof(struct RArray, as.ary);
-    assert(size % sizeof(VALUE) == 0);
+    RUBY_ASSERT(size % sizeof(VALUE) == 0);
     return size / sizeof(VALUE);
 }
 
@@ -234,20 +234,20 @@ rb_ary_size_as_embedded(VALUE ary)
 static VALUE
 ary_verify_(VALUE ary, const char *file, int line)
 {
-    assert(RB_TYPE_P(ary, T_ARRAY));
+    RUBY_ASSERT(RB_TYPE_P(ary, T_ARRAY));
 
     if (ARY_SHARED_P(ary)) {
         VALUE root = ARY_SHARED_ROOT(ary);
         const VALUE *ptr = ARY_HEAP_PTR(ary);
         const VALUE *root_ptr = RARRAY_CONST_PTR(root);
         long len = ARY_HEAP_LEN(ary), root_len = RARRAY_LEN(root);
-        assert(ARY_SHARED_ROOT_P(root) || OBJ_FROZEN(root));
-        assert(root_ptr <= ptr && ptr + len <= root_ptr + root_len);
+        RUBY_ASSERT(ARY_SHARED_ROOT_P(root) || OBJ_FROZEN(root));
+        RUBY_ASSERT(root_ptr <= ptr && ptr + len <= root_ptr + root_len);
         ary_verify(root);
     }
     else if (ARY_EMBED_P(ary)) {
-        assert(!ARY_SHARED_P(ary));
-        assert(RARRAY_LEN(ary) <= ary_embed_capa(ary));
+        RUBY_ASSERT(!ARY_SHARED_P(ary));
+        RUBY_ASSERT(RARRAY_LEN(ary) <= ary_embed_capa(ary));
     }
     else {
         const VALUE *ptr = RARRAY_CONST_PTR(ary);
@@ -325,7 +325,7 @@ ary_memfill(VALUE ary, long beg, long size, VALUE val)
 static void
 ary_memcpy0(VALUE ary, long beg, long argc, const VALUE *argv, VALUE buff_owner_ary)
 {
-    assert(!ARY_SHARED_P(buff_owner_ary));
+    RUBY_ASSERT(!ARY_SHARED_P(buff_owner_ary));
 
     if (argc > (int)(128/sizeof(VALUE)) /* is magic number (cache line size) */) {
         rb_gc_writebarrier_remember(buff_owner_ary);
@@ -379,7 +379,7 @@ ary_heap_realloc(VALUE ary, size_t new_capa)
 void
 rb_ary_make_embedded(VALUE ary)
 {
-    assert(rb_ary_embeddable_p(ary));
+    RUBY_ASSERT(rb_ary_embeddable_p(ary));
     if (!ARY_EMBED_P(ary)) {
         const VALUE *buf = ARY_HEAP_PTR(ary);
         long len = ARY_HEAP_LEN(ary);
@@ -396,9 +396,9 @@ rb_ary_make_embedded(VALUE ary)
 static void
 ary_resize_capa(VALUE ary, long capacity)
 {
-    assert(RARRAY_LEN(ary) <= capacity);
-    assert(!OBJ_FROZEN(ary));
-    assert(!ARY_SHARED_P(ary));
+    RUBY_ASSERT(RARRAY_LEN(ary) <= capacity);
+    RUBY_ASSERT(!OBJ_FROZEN(ary));
+    RUBY_ASSERT(!ARY_SHARED_P(ary));
 
     if (capacity > ary_embed_capa(ary)) {
         size_t new_capa = capacity;
@@ -439,8 +439,8 @@ ary_shrink_capa(VALUE ary)
 {
     long capacity = ARY_HEAP_LEN(ary);
     long old_capa = ARY_HEAP_CAPA(ary);
-    assert(!ARY_SHARED_P(ary));
-    assert(old_capa >= capacity);
+    RUBY_ASSERT(!ARY_SHARED_P(ary));
+    RUBY_ASSERT(old_capa >= capacity);
     if (old_capa > capacity) ary_heap_realloc(ary, capacity);
 
     ary_verify(ary);
@@ -499,7 +499,7 @@ rb_ary_increment_share(VALUE shared_root)
 {
     if (!OBJ_FROZEN(shared_root)) {
         long num = ARY_SHARED_ROOT_REFCNT(shared_root);
-        assert(num >= 0);
+        RUBY_ASSERT(num >= 0);
         ARY_SET_SHARED_ROOT_REFCNT(shared_root, num + 1);
     }
     return shared_root;
@@ -508,9 +508,9 @@ rb_ary_increment_share(VALUE shared_root)
 static void
 rb_ary_set_shared(VALUE ary, VALUE shared_root)
 {
-    assert(!ARY_EMBED_P(ary));
-    assert(!OBJ_FROZEN(ary));
-    assert(ARY_SHARED_ROOT_P(shared_root) || OBJ_FROZEN(shared_root));
+    RUBY_ASSERT(!ARY_EMBED_P(ary));
+    RUBY_ASSERT(!OBJ_FROZEN(ary));
+    RUBY_ASSERT(ARY_SHARED_ROOT_P(shared_root) || OBJ_FROZEN(shared_root));
 
     rb_ary_increment_share(shared_root);
     FL_SET_SHARED(ary);
@@ -665,7 +665,7 @@ static VALUE
 ary_alloc_embed(VALUE klass, long capa)
 {
     size_t size = ary_embed_size(capa);
-    assert(rb_gc_size_allocatable_p(size));
+    RUBY_ASSERT(rb_gc_size_allocatable_p(size));
     NEWOBJ_OF(ary, struct RArray, klass,
                      T_ARRAY | RARRAY_EMBED_FLAG | (RGENGC_WB_PROTECTED_ARRAY ? FL_WB_PROTECTED : 0),
                      size, 0);
@@ -712,7 +712,7 @@ ary_new(VALUE klass, long capa)
     else {
         ary = ary_alloc_heap(klass);
         ARY_SET_CAPA(ary, capa);
-        assert(!ARY_EMBED_P(ary));
+        RUBY_ASSERT(!ARY_EMBED_P(ary));
 
         ARY_SET_PTR(ary, ary_heap_alloc(capa));
         ARY_SET_HEAP_LEN(ary, 0);
@@ -776,7 +776,7 @@ static VALUE
 ec_ary_alloc_embed(rb_execution_context_t *ec, VALUE klass, long capa)
 {
     size_t size = ary_embed_size(capa);
-    assert(rb_gc_size_allocatable_p(size));
+    RUBY_ASSERT(rb_gc_size_allocatable_p(size));
     NEWOBJ_OF(ary, struct RArray, klass,
             T_ARRAY | RARRAY_EMBED_FLAG | (RGENGC_WB_PROTECTED_ARRAY ? FL_WB_PROTECTED : 0),
             size, ec);
@@ -816,7 +816,7 @@ ec_ary_new(rb_execution_context_t *ec, VALUE klass, long capa)
     else {
         ary = ec_ary_alloc_heap(ec, klass);
         ARY_SET_CAPA(ary, capa);
-        assert(!ARY_EMBED_P(ary));
+        RUBY_ASSERT(!ARY_EMBED_P(ary));
 
         ARY_SET_PTR(ary, ary_heap_alloc(capa));
         ARY_SET_HEAP_LEN(ary, 0);
@@ -948,7 +948,7 @@ ary_make_substitution(VALUE ary)
 
     if (ary_embeddable_p(len)) {
         VALUE subst = rb_ary_new_capa(len);
-        assert(ARY_EMBED_P(subst));
+        RUBY_ASSERT(ARY_EMBED_P(subst));
 
         ary_memcpy(subst, 0, len, RARRAY_CONST_PTR(ary));
         ARY_SET_EMBED_LEN(subst, len);
@@ -1091,8 +1091,8 @@ rb_ary_initialize(int argc, VALUE *argv, VALUE ary)
     rb_ary_modify(ary);
     if (argc == 0) {
         rb_ary_reset(ary);
-        assert(ARY_EMBED_P(ary));
-        assert(ARY_EMBED_LEN(ary) == 0);
+        RUBY_ASSERT(ARY_EMBED_P(ary));
+        RUBY_ASSERT(ARY_EMBED_LEN(ary) == 0);
         if (rb_block_given_p()) {
             rb_warning("given block not used");
         }
@@ -1189,9 +1189,9 @@ rb_ary_store(VALUE ary, long idx, VALUE val)
 static VALUE
 ary_make_partial(VALUE ary, VALUE klass, long offset, long len)
 {
-    assert(offset >= 0);
-    assert(len >= 0);
-    assert(offset+len <= RARRAY_LEN(ary));
+    RUBY_ASSERT(offset >= 0);
+    RUBY_ASSERT(len >= 0);
+    RUBY_ASSERT(offset+len <= RARRAY_LEN(ary));
 
     VALUE result = ary_alloc_heap(klass);
     size_t embed_capa = ary_embed_capa(result);
@@ -1225,10 +1225,10 @@ ary_make_partial(VALUE ary, VALUE klass, long offset, long len)
 static VALUE
 ary_make_partial_step(VALUE ary, VALUE klass, long offset, long len, long step)
 {
-    assert(offset >= 0);
-    assert(len >= 0);
-    assert(offset+len <= RARRAY_LEN(ary));
-    assert(step != 0);
+    RUBY_ASSERT(offset >= 0);
+    RUBY_ASSERT(len >= 0);
+    RUBY_ASSERT(offset+len <= RARRAY_LEN(ary));
+    RUBY_ASSERT(step != 0);
 
     const long orig_len = len;
 
@@ -1563,7 +1563,7 @@ make_room_for_unshift(VALUE ary, const VALUE *head, VALUE *sharedp, int argc, lo
         head = sharedp + argc + room;
     }
     ARY_SET_PTR(ary, head - argc);
-    assert(ARY_SHARED_ROOT_OCCUPIED(ARY_SHARED_ROOT(ary)));
+    RUBY_ASSERT(ARY_SHARED_ROOT_OCCUPIED(ARY_SHARED_ROOT(ary)));
 
     ary_verify(ary);
     return ARY_SHARED_ROOT(ary);
@@ -3340,7 +3340,7 @@ VALUE
 rb_ary_sort_bang(VALUE ary)
 {
     rb_ary_modify(ary);
-    assert(!ARY_SHARED_P(ary));
+    RUBY_ASSERT(!ARY_SHARED_P(ary));
     if (RARRAY_LEN(ary) > 1) {
         VALUE tmp = ary_make_substitution(ary); /* only ary refers tmp */
         struct ary_sort_data data;
@@ -3367,7 +3367,7 @@ rb_ary_sort_bang(VALUE ary)
                 ARY_SET_CAPA(ary, RARRAY_LEN(tmp));
             }
             else {
-                assert(!ARY_SHARED_P(tmp));
+                RUBY_ASSERT(!ARY_SHARED_P(tmp));
                 if (ARY_EMBED_P(ary)) {
                     FL_UNSET_EMBED(ary);
                 }
@@ -4513,7 +4513,7 @@ rb_ary_replace(VALUE copy, VALUE orig)
 
     /* orig has enough space to embed the contents of orig. */
     if (RARRAY_LEN(orig) <= ary_embed_capa(copy)) {
-        assert(ARY_EMBED_P(copy));
+        RUBY_ASSERT(ARY_EMBED_P(copy));
         ary_memcpy(copy, 0, RARRAY_LEN(orig), RARRAY_CONST_PTR(orig));
         ARY_SET_EMBED_LEN(copy, RARRAY_LEN(orig));
     }

--- a/bignum.c
+++ b/bignum.c
@@ -349,7 +349,7 @@ maxpow_in_bdigit_dbl(int base, int *exp_ret)
     BDIGIT_DBL maxpow;
     int exponent;
 
-    assert(2 <= base && base <= 36);
+    RUBY_ASSERT(2 <= base && base <= 36);
 
     {
 #if SIZEOF_BDIGIT_DBL == 2
@@ -381,7 +381,7 @@ maxpow_in_bdigit_dbl(int base, int *exp_ret)
 static inline BDIGIT_DBL
 bary2bdigitdbl(const BDIGIT *ds, size_t n)
 {
-    assert(n <= 2);
+    RUBY_ASSERT(n <= 2);
 
     if (n == 2)
         return ds[0] | BIGUP(ds[1]);
@@ -393,7 +393,7 @@ bary2bdigitdbl(const BDIGIT *ds, size_t n)
 static inline void
 bdigitdbl2bary(BDIGIT *ds, size_t n, BDIGIT_DBL num)
 {
-    assert(n == 2);
+    RUBY_ASSERT(n == 2);
 
     ds[0] = BIGLO(num);
     ds[1] = (BDIGIT)BIGDN(num);
@@ -424,7 +424,7 @@ bary_small_lshift(BDIGIT *zds, const BDIGIT *xds, size_t n, int shift)
 {
     size_t i;
     BDIGIT_DBL num = 0;
-    assert(0 <= shift && shift < BITSPERDIG);
+    RUBY_ASSERT(0 <= shift && shift < BITSPERDIG);
 
     for (i=0; i<n; i++) {
         num = num | (BDIGIT_DBL)*xds++ << shift;
@@ -440,7 +440,7 @@ bary_small_rshift(BDIGIT *zds, const BDIGIT *xds, size_t n, int shift, BDIGIT hi
     size_t i;
     BDIGIT_DBL num = 0;
 
-    assert(0 <= shift && shift < BITSPERDIG);
+    RUBY_ASSERT(0 <= shift && shift < BITSPERDIG);
 
     num = BIGUP(higher_bdigit);
     for (i = 0; i < n; i++) {
@@ -1060,8 +1060,8 @@ integer_unpack_num_bdigits(size_t numwords, size_t wordsize, size_t nails, int *
         if (debug_integer_pack) {
             int nlp_bits1;
             size_t num_bdigits1 = integer_unpack_num_bdigits_generic(numwords, wordsize, nails, &nlp_bits1);
-            assert(num_bdigits == num_bdigits1);
-            assert(*nlp_bits_ret == nlp_bits1);
+            RUBY_ASSERT(num_bdigits == num_bdigits1);
+            RUBY_ASSERT(*nlp_bits_ret == nlp_bits1);
             (void)num_bdigits1;
         }
     }
@@ -1271,7 +1271,7 @@ bary_unpack_internal(BDIGIT *bdigits, size_t num_bdigits, const void *words, siz
         }
         if (dd)
             *dp++ = (BDIGIT)dd;
-        assert(dp <= de);
+        RUBY_ASSERT(dp <= de);
         while (dp < de)
             *dp++ = 0;
 #undef PUSH_BITS
@@ -1330,7 +1330,7 @@ bary_unpack(BDIGIT *bdigits, size_t num_bdigits, const void *words, size_t numwo
 
     num_bdigits0 = integer_unpack_num_bdigits(numwords, wordsize, nails, &nlp_bits);
 
-    assert(num_bdigits0 <= num_bdigits);
+    RUBY_ASSERT(num_bdigits0 <= num_bdigits);
 
     sign = bary_unpack_internal(bdigits, num_bdigits0, words, numwords, wordsize, nails, flags, nlp_bits);
 
@@ -1349,8 +1349,8 @@ bary_subb(BDIGIT *zds, size_t zn, const BDIGIT *xds, size_t xn, const BDIGIT *yd
     size_t i;
     size_t sn;
 
-    assert(xn <= zn);
-    assert(yn <= zn);
+    RUBY_ASSERT(xn <= zn);
+    RUBY_ASSERT(yn <= zn);
 
     sn = xn < yn ? xn : yn;
 
@@ -1411,8 +1411,8 @@ bary_addc(BDIGIT *zds, size_t zn, const BDIGIT *xds, size_t xn, const BDIGIT *yd
     BDIGIT_DBL num;
     size_t i;
 
-    assert(xn <= zn);
-    assert(yn <= zn);
+    RUBY_ASSERT(xn <= zn);
+    RUBY_ASSERT(yn <= zn);
 
     if (xn > yn) {
         const BDIGIT *tds;
@@ -1476,7 +1476,7 @@ bary_mul_single(BDIGIT *zds, size_t zn, BDIGIT x, BDIGIT y)
 {
     BDIGIT_DBL n;
 
-    assert(2 <= zn);
+    RUBY_ASSERT(2 <= zn);
 
     n = (BDIGIT_DBL)x * y;
     bdigitdbl2bary(zds, 2, n);
@@ -1490,7 +1490,7 @@ bary_muladd_1xN(BDIGIT *zds, size_t zn, BDIGIT x, const BDIGIT *yds, size_t yn)
     BDIGIT_DBL dd;
     size_t j;
 
-    assert(zn > yn);
+    RUBY_ASSERT(zn > yn);
 
     if (x == 0)
         return 0;
@@ -1525,7 +1525,7 @@ bigdivrem_mulsub(BDIGIT *zds, size_t zn, BDIGIT x, const BDIGIT *yds, size_t yn)
     BDIGIT_DBL t2;
     BDIGIT_DBL_SIGNED num;
 
-    assert(zn == yn + 1);
+    RUBY_ASSERT(zn == yn + 1);
 
     num = 0;
     t2 = 0;
@@ -1550,7 +1550,7 @@ bary_mulsub_1xN(BDIGIT *zds, size_t zn, BDIGIT x, const BDIGIT *yds, size_t yn)
 {
     BDIGIT_DBL_SIGNED num;
 
-    assert(zn == yn + 1);
+    RUBY_ASSERT(zn == yn + 1);
 
     num = bigdivrem_mulsub(zds, zn, x, yds, yn);
     zds[yn] = BIGLO(num);
@@ -1564,7 +1564,7 @@ bary_mul_normal(BDIGIT *zds, size_t zn, const BDIGIT *xds, size_t xn, const BDIG
 {
     size_t i;
 
-    assert(xn + yn <= zn);
+    RUBY_ASSERT(xn + yn <= zn);
 
     BDIGITS_ZERO(zds, zn);
     for (i = 0; i < xn; i++) {
@@ -1595,7 +1595,7 @@ bary_sq_fast(BDIGIT *zds, size_t zn, const BDIGIT *xds, size_t xn)
     BDIGIT vl;
     int vh;
 
-    assert(xn * 2 <= zn);
+    RUBY_ASSERT(xn * 2 <= zn);
 
     BDIGITS_ZERO(zds, zn);
 
@@ -1667,9 +1667,9 @@ bary_mul_balance_with_mulfunc(BDIGIT *const zds, const size_t zn,
     VALUE work = 0;
     size_t n;
 
-    assert(xn + yn <= zn);
-    assert(xn <= yn);
-    assert(!KARATSUBA_BALANCED(xn, yn) || !TOOM3_BALANCED(xn, yn));
+    RUBY_ASSERT(xn + yn <= zn);
+    RUBY_ASSERT(xn <= yn);
+    RUBY_ASSERT(!KARATSUBA_BALANCED(xn, yn) || !TOOM3_BALANCED(xn, yn));
 
     BDIGITS_ZERO(zds, xn);
 
@@ -1751,9 +1751,9 @@ bary_mul_karatsuba(BDIGIT *zds, size_t zn, const BDIGIT *xds, size_t xn, const B
     const BDIGIT *xds0, *xds1, *yds0, *yds1;
     BDIGIT *zds0, *zds1, *zds2, *zds3;
 
-    assert(xn + yn <= zn);
-    assert(xn <= yn);
-    assert(yn < 2 * xn);
+    RUBY_ASSERT(xn + yn <= zn);
+    RUBY_ASSERT(xn <= yn);
+    RUBY_ASSERT(yn < 2 * xn);
 
     sq = xds == yds && xn == yn;
 
@@ -1768,7 +1768,7 @@ bary_mul_karatsuba(BDIGIT *zds, size_t zn, const BDIGIT *xds, size_t xn, const B
 
     n = yn / 2;
 
-    assert(n < xn);
+    RUBY_ASSERT(n < xn);
 
     if (wn < n) {
         /* This function itself needs only n BDIGITs for work area.
@@ -1889,7 +1889,7 @@ bary_mul_karatsuba(BDIGIT *zds, size_t zn, const BDIGIT *xds, size_t xn, const B
         for (x = 0, i = xn-1; 0 <= i; i--) { x <<= SIZEOF_BDIGIT*CHAR_BIT; x |= xds[i]; }
         for (y = 0, i = yn-1; 0 <= i; i--) { y <<= SIZEOF_BDIGIT*CHAR_BIT; y |= yds[i]; }
         for (z = 0, i = zn-1; 0 <= i; i--) { z <<= SIZEOF_BDIGIT*CHAR_BIT; z |= zds[i]; }
-        assert(z == x * y);
+        RUBY_ASSERT(z == x * y);
     }
     */
 
@@ -1957,11 +1957,11 @@ bary_mul_toom3(BDIGIT *zds, size_t zn, const BDIGIT *xds, size_t xn, const BDIGI
 
     int sq = xds == yds && xn == yn;
 
-    assert(xn <= yn);  /* assume y >= x */
-    assert(xn + yn <= zn);
+    RUBY_ASSERT(xn <= yn);  /* assume y >= x */
+    RUBY_ASSERT(xn + yn <= zn);
 
     n = (yn + 2) / 3;
-    assert(2*n < xn);
+    RUBY_ASSERT(2*n < xn);
 
     wnc = 0;
 
@@ -2148,19 +2148,19 @@ bary_mul_toom3(BDIGIT *zds, size_t zn, const BDIGIT *xds, size_t xn, const BDIGI
     /* z(1) : t1 <- u1 * v1 */
     bary_mul_toom3_start(t1ds, t1n, u1ds, u1n, v1ds, v1n, wds, wn);
     t1p = u1p == v1p;
-    assert(t1ds[t1n-1] == 0);
+    RUBY_ASSERT(t1ds[t1n-1] == 0);
     t1n--;
 
     /* z(-1) : t2 <- u2 * v2 */
     bary_mul_toom3_start(t2ds, t2n, u2ds, u2n, v2ds, v2n, wds, wn);
     t2p = u2p == v2p;
-    assert(t2ds[t2n-1] == 0);
+    RUBY_ASSERT(t2ds[t2n-1] == 0);
     t2n--;
 
     /* z(-2) : t3 <- u3 * v3 */
     bary_mul_toom3_start(t3ds, t3n, u3ds, u3n, v3ds, v3n, wds, wn);
     t3p = u3p == v3p;
-    assert(t3ds[t3n-1] == 0);
+    RUBY_ASSERT(t3ds[t3n-1] == 0);
     t3n--;
 
     /* z(inf) : t4 <- x2 * y2 */
@@ -2336,7 +2336,7 @@ bary_mul_gmp(BDIGIT *zds, size_t zn, const BDIGIT *xds, size_t xn, const BDIGIT 
     mpz_t x, y, z;
     size_t count;
 
-    assert(xn + yn <= zn);
+    RUBY_ASSERT(xn + yn <= zn);
 
     mpz_init(x);
     mpz_init(y);
@@ -2371,7 +2371,7 @@ rb_big_mul_gmp(VALUE x, VALUE y)
 static void
 bary_short_mul(BDIGIT *zds, size_t zn, const BDIGIT *xds, size_t xn, const BDIGIT *yds, size_t yn)
 {
-    assert(xn + yn <= zn);
+    RUBY_ASSERT(xn + yn <= zn);
 
     if (xn == 1 && yn == 1) {
         bary_mul_single(zds, zn, xds[0], yds[0]);
@@ -2407,7 +2407,7 @@ bary_mul_precheck(BDIGIT **zdsp, size_t *znp, const BDIGIT **xdsp, size_t *xnp, 
     const BDIGIT *yds = *ydsp;
     size_t yn = *ynp;
 
-    assert(xn + yn <= zn);
+    RUBY_ASSERT(xn + yn <= zn);
 
     nlsz = 0;
 
@@ -2456,7 +2456,7 @@ bary_mul_precheck(BDIGIT **zdsp, size_t *znp, const BDIGIT **xdsp, size_t *xnp, 
         tds = xds; xds = yds; yds = tds;
         tn = xn; xn = yn; yn = tn;
     }
-    assert(xn <= yn);
+    RUBY_ASSERT(xn <= yn);
 
     if (xn <= 1) {
         if (xn == 0) {
@@ -2639,8 +2639,8 @@ rb_big_stop(void *ptr)
 static BDIGIT
 bigdivrem_single1(BDIGIT *qds, const BDIGIT *xds, size_t xn, BDIGIT x_higher_bdigit, BDIGIT y)
 {
-    assert(0 < xn);
-    assert(x_higher_bdigit < y);
+    RUBY_ASSERT(0 < xn);
+    RUBY_ASSERT(x_higher_bdigit < y);
     if (POW2_P(y)) {
         BDIGIT r;
         r = xds[0] & (y-1);
@@ -2672,9 +2672,9 @@ bigdivrem_restoring(BDIGIT *zds, size_t zn, BDIGIT *yds, size_t yn)
     struct big_div_struct bds;
     size_t ynzero;
 
-    assert(yn < zn);
-    assert(BDIGIT_MSB(yds[yn-1]));
-    assert(zds[zn-1] < yds[yn-1]);
+    RUBY_ASSERT(yn < zn);
+    RUBY_ASSERT(BDIGIT_MSB(yds[yn-1]));
+    RUBY_ASSERT(zds[zn-1] < yds[yn-1]);
 
     for (ynzero = 0; !yds[ynzero]; ynzero++);
 
@@ -2713,9 +2713,9 @@ bary_divmod_normal(BDIGIT *qds, size_t qn, BDIGIT *rds, size_t rn, const BDIGIT 
     size_t zn;
     VALUE tmpyz = 0;
 
-    assert(yn < xn || (xn == yn && yds[yn - 1] <= xds[xn - 1]));
-    assert(qds ? (xn - yn + 1) <= qn : 1);
-    assert(rds ? yn <= rn : 1);
+    RUBY_ASSERT(yn < xn || (xn == yn && yds[yn - 1] <= xds[xn - 1]));
+    RUBY_ASSERT(qds ? (xn - yn + 1) <= qn : 1);
+    RUBY_ASSERT(rds ? yn <= rn : 1);
 
     zn = xn + BIGDIVREM_EXTRA_WORDS;
 
@@ -2807,10 +2807,10 @@ bary_divmod_gmp(BDIGIT *qds, size_t qn, BDIGIT *rds, size_t rn, const BDIGIT *xd
     mpz_t x, y, q, r;
     size_t count;
 
-    assert(yn < xn || (xn == yn && yds[yn - 1] <= xds[xn - 1]));
-    assert(qds ? (xn - yn + 1) <= qn : 1);
-    assert(rds ? yn <= rn : 1);
-    assert(qds || rds);
+    RUBY_ASSERT(yn < xn || (xn == yn && yds[yn - 1] <= xds[xn - 1]));
+    RUBY_ASSERT(qds ? (xn - yn + 1) <= qn : 1);
+    RUBY_ASSERT(rds ? yn <= rn : 1);
+    RUBY_ASSERT(qds || rds);
 
     mpz_init(x);
     mpz_init(y);
@@ -2896,8 +2896,8 @@ bary_divmod_branch(BDIGIT *qds, size_t qn, BDIGIT *rds, size_t rn, const BDIGIT 
 static void
 bary_divmod(BDIGIT *qds, size_t qn, BDIGIT *rds, size_t rn, const BDIGIT *xds, size_t xn, const BDIGIT *yds, size_t yn)
 {
-    assert(xn <= qn);
-    assert(yn <= rn);
+    RUBY_ASSERT(xn <= qn);
+    RUBY_ASSERT(yn <= rn);
 
     BARY_TRUNC(yds, yn);
     if (yn == 0)
@@ -3432,8 +3432,8 @@ rb_absint_numwords(VALUE val, size_t word_numbits, size_t *nlz_bits_ret)
         if (debug_integer_pack) {
             size_t numwords0, nlz_bits0;
             numwords0 = absint_numwords_generic(numbytes, nlz_bits_in_msbyte, word_numbits, &nlz_bits0);
-            assert(numwords0 == numwords);
-            assert(nlz_bits0 == nlz_bits);
+            RUBY_ASSERT(numwords0 == numwords);
+            RUBY_ASSERT(nlz_bits0 == nlz_bits);
             (void)numwords0;
         }
     }
@@ -3848,7 +3848,7 @@ str2big_poweroftwo(
     if (numbits) {
         *dp++ = BIGLO(dd);
     }
-    assert((size_t)(dp - BDIGITS(z)) == num_bdigits);
+    RUBY_ASSERT((size_t)(dp - BDIGITS(z)) == num_bdigits);
 
     return z;
 }
@@ -3891,7 +3891,7 @@ str2big_normal(
             }
             break;
         }
-        assert(blen <= num_bdigits);
+        RUBY_ASSERT(blen <= num_bdigits);
     }
 
     return z;
@@ -3949,7 +3949,7 @@ str2big_karatsuba(
             current_base = 1;
         }
     }
-    assert(i == num_bdigits);
+    RUBY_ASSERT(i == num_bdigits);
     for (unit = 2; unit < num_bdigits; unit *= 2) {
         for (i = 0; i < num_bdigits; i += unit*2) {
             if (2*unit <= num_bdigits - i) {
@@ -4094,8 +4094,8 @@ rb_int_parse_cstr(const char *str, ssize_t len, char **endp, size_t *ndigits,
         len -= (n); \
     } while (0)
 #define ASSERT_LEN() do {\
-        assert(len != 0); \
-        if (len0 >= 0) assert(s + len0 == str + len); \
+        RUBY_ASSERT(len != 0); \
+        if (len0 >= 0) RUBY_ASSERT(s + len0 == str + len); \
     } while (0)
 
     if (!str) {
@@ -4640,8 +4640,8 @@ big_shift2(VALUE x, int lshift_p, VALUE y)
     size_t shift_numdigits;
     int shift_numbits;
 
-    assert(POW2_P(CHAR_BIT));
-    assert(POW2_P(BITSPERDIG));
+    RUBY_ASSERT(POW2_P(CHAR_BIT));
+    RUBY_ASSERT(POW2_P(BITSPERDIG));
 
     if (BIGZEROP(x))
         return INT2FIX(0);
@@ -4764,7 +4764,7 @@ big2str_2bdigits(struct big2str_struct *b2s, BDIGIT *xds, size_t xn, size_t tail
     int beginning = !b2s->ptr;
     size_t len = 0;
 
-    assert(xn <= 2);
+    RUBY_ASSERT(xn <= 2);
     num = bary2bdigitdbl(xds, xn);
 
     if (beginning) {
@@ -4892,7 +4892,7 @@ big2str_karatsuba(struct big2str_struct *b2s, BDIGIT *xds, size_t xn, size_t wn,
             /* bigdivrem_restoring will modify y.
              * So use temporary buffer.  */
             tds = xds + qn;
-            assert(qn + bn <= xn + wn);
+            RUBY_ASSERT(qn + bn <= xn + wn);
             bary_small_lshift(tds, bds, bn, shift);
             xds[xn] = bary_small_lshift(xds, xds, xn, shift);
         }
@@ -4910,7 +4910,7 @@ big2str_karatsuba(struct big2str_struct *b2s, BDIGIT *xds, size_t xn, size_t wn,
         }
 
         BARY_TRUNC(qds, qn);
-        assert(qn <= bn);
+        RUBY_ASSERT(qn <= bn);
         big2str_karatsuba(b2s, qds, qn, xn+wn - (rn+qn), lower_power_level, lower_numdigits+taillen);
         BARY_TRUNC(rds, rn);
         big2str_karatsuba(b2s, rds, rn, xn+wn - rn, lower_power_level, taillen);
@@ -4985,7 +4985,7 @@ big2str_generic(VALUE x, int base)
         power_level++;
         power = power_cache_get_power(base, power_level, NULL);
     }
-    assert(power_level != MAX_BASE36_POWER_TABLE_ENTRIES);
+    RUBY_ASSERT(power_level != MAX_BASE36_POWER_TABLE_ENTRIES);
 
     if ((size_t)BIGNUM_LEN(power) <= xn) {
         /*
@@ -5660,7 +5660,7 @@ bigsub_int(VALUE x, long y0)
     zds = BDIGITS(z);
 
 #if SIZEOF_BDIGIT >= SIZEOF_LONG
-    assert(xn == zn);
+    RUBY_ASSERT(xn == zn);
     num = (BDIGIT_DBL_SIGNED)xds[0] - y;
     if (xn == 1 && num < 0) {
         BIGNUM_NEGATE(z);
@@ -5723,7 +5723,7 @@ bigsub_int(VALUE x, long y0)
     goto finish;
 
   finish:
-    assert(num == 0 || num == -1);
+    RUBY_ASSERT(num == 0 || num == -1);
     if (num < 0) {
         get2comp(z);
         BIGNUM_NEGATE(z);
@@ -7001,7 +7001,7 @@ int_pow_tmp3(VALUE x, VALUE y, VALUE m, int nega_flg)
     if (FIXNUM_P(y)) {
        y = rb_int2big(FIX2LONG(y));
     }
-    assert(RB_BIGNUM_TYPE_P(m));
+    RUBY_ASSERT(RB_BIGNUM_TYPE_P(m));
     xn = BIGNUM_LEN(x);
     yn = BIGNUM_LEN(y);
     mn = BIGNUM_LEN(m);

--- a/compile.c
+++ b/compile.c
@@ -2063,7 +2063,7 @@ iseq_set_arguments(rb_iseq_t *iseq, LINK_ANCHOR *const optargs, const NODE *cons
             body->param.rest_start = arg_size++;
             body->param.flags.has_rest = TRUE;
             if (rest_id == '*') body->param.flags.anon_rest = TRUE;
-            assert(body->param.rest_start != -1);
+            RUBY_ASSERT(body->param.rest_start != -1);
         }
 
         if (args->first_post_arg) {
@@ -2683,7 +2683,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                       case TS_CALLDATA:
                         {
                             const struct rb_callinfo *source_ci = (const struct rb_callinfo *)operands[j];
-                            assert(ISEQ_COMPILE_DATA(iseq)->ci_index <= body->ci_size);
+                            RUBY_ASSERT(ISEQ_COMPILE_DATA(iseq)->ci_index <= body->ci_size);
                             struct rb_call_data *cd = &body->call_data[ISEQ_COMPILE_DATA(iseq)->ci_index++];
                             cd->ci = source_ci;
                             cd->cc = vm_cc_empty();
@@ -4626,7 +4626,7 @@ compile_keyword_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
             const NODE *key_node = RNODE_LIST(node)->nd_head;
             seen_nodes++;
 
-            assert(nd_type_p(node, NODE_LIST));
+            RUBY_ASSERT(nd_type_p(node, NODE_LIST));
             if (key_node && nd_type_p(key_node, NODE_LIT) && SYMBOL_P(RNODE_LIT(key_node)->nd_lit)) {
                 /* can be keywords */
             }
@@ -4676,7 +4676,7 @@ compile_keyword_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
                 }
                 NO_CHECK(COMPILE_(ret, "keyword values", val_node, popped));
             }
-            assert(j == len);
+            RUBY_ASSERT(j == len);
             return TRUE;
         }
     }
@@ -5942,7 +5942,7 @@ defined_expr0(rb_iseq_t *iseq, LINK_ANCHOR *const ret,
         break;
     }
 
-    assert(expr_type != DEFINED_NOT_DEFINED);
+    RUBY_ASSERT(expr_type != DEFINED_NOT_DEFINED);
 
     if (needstr != Qfalse) {
         VALUE str = rb_iseq_defined_string(expr_type);
@@ -6084,7 +6084,7 @@ can_add_ensure_iseq(const rb_iseq_t *iseq)
 static void
 add_ensure_iseq(LINK_ANCHOR *const ret, rb_iseq_t *iseq, int is_return)
 {
-    assert(can_add_ensure_iseq(iseq));
+    RUBY_ASSERT(can_add_ensure_iseq(iseq));
 
     struct iseq_compile_data_ensure_node_stack *enlp =
         ISEQ_COMPILE_DATA(iseq)->ensure_node_stack;
@@ -9547,7 +9547,7 @@ compile_super(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
             if (local_body->param.flags.has_kwrest) {
                 int idx = local_body->local_table_size - local_kwd->rest_start;
                 ADD_GETLOCAL(args, node, idx, lvar_level);
-                assert(local_kwd->num > 0);
+                RUBY_ASSERT(local_kwd->num > 0);
                 ADD_SEND (args, node, rb_intern("dup"), INT2FIX(0));
             }
             else {
@@ -12035,7 +12035,7 @@ ibf_dump_code(struct ibf_dump *dump, const rb_iseq_t *iseq)
             ibf_dump_write_small_value(dump, wv);
           skip_wv:;
         }
-        assert(insn_len(insn) == op_index+1);
+        RUBY_ASSERT(insn_len(insn) == op_index+1);
     }
 
     return offset;
@@ -12200,8 +12200,8 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
         }
     }
 
-    assert(code_index == iseq_size);
-    assert(reading_pos == bytecode_offset + bytecode_size);
+    RUBY_ASSERT(code_index == iseq_size);
+    RUBY_ASSERT(reading_pos == bytecode_offset + bytecode_size);
     return code;
 }
 
@@ -12611,7 +12611,7 @@ ibf_load_outer_variables(const struct ibf_load * load, ibf_offset_t outer_variab
 static ibf_offset_t
 ibf_dump_iseq_each(struct ibf_dump *dump, const rb_iseq_t *iseq)
 {
-    assert(dump->current_buffer == &dump->global_buffer);
+    RUBY_ASSERT(dump->current_buffer == &dump->global_buffer);
 
     unsigned int *positions;
 

--- a/complex.c
+++ b/complex.c
@@ -411,15 +411,15 @@ nucomp_s_alloc(VALUE klass)
 inline static VALUE
 f_complex_new_bang1(VALUE klass, VALUE x)
 {
-    assert(!RB_TYPE_P(x, T_COMPLEX));
+    RUBY_ASSERT(!RB_TYPE_P(x, T_COMPLEX));
     return nucomp_s_new_internal(klass, x, ZERO);
 }
 
 inline static VALUE
 f_complex_new_bang2(VALUE klass, VALUE x, VALUE y)
 {
-    assert(!RB_TYPE_P(x, T_COMPLEX));
-    assert(!RB_TYPE_P(y, T_COMPLEX));
+    RUBY_ASSERT(!RB_TYPE_P(x, T_COMPLEX));
+    RUBY_ASSERT(!RB_TYPE_P(y, T_COMPLEX));
     return nucomp_s_new_internal(klass, x, y);
 }
 
@@ -432,7 +432,7 @@ nucomp_real_check(VALUE num)
         !RB_TYPE_P(num, T_RATIONAL)) {
         if (RB_TYPE_P(num, T_COMPLEX) && nucomp_real_p(num)) {
             VALUE real = RCOMPLEX(num)->real;
-            assert(!RB_TYPE_P(real, T_COMPLEX));
+            RUBY_ASSERT(!RB_TYPE_P(real, T_COMPLEX));
             return real;
         }
         if (!k_numeric_p(num) || !f_real_p(num))

--- a/darray.h
+++ b/darray.h
@@ -196,7 +196,7 @@ rb_darray_resize_capa_impl(void *ptr_to_ary, size_t new_capa, size_t header_size
         new_ary->size = 0;
     }
 
-    assert(new_ary->size <= new_capa);
+    RUBY_ASSERT(new_ary->size <= new_capa);
 
     new_ary->capa = new_capa;
 

--- a/enum.c
+++ b/enum.c
@@ -4538,7 +4538,7 @@ struct enum_sum_memo {
 static void
 sum_iter_normalize_memo(struct enum_sum_memo *memo)
 {
-    assert(FIXABLE(memo->n));
+    RUBY_ASSERT(FIXABLE(memo->n));
     memo->v = rb_fix_plus(LONG2FIX(memo->n), memo->v);
     memo->n = 0;
 
@@ -4640,7 +4640,7 @@ sum_iter_Kahan_Babuska(VALUE i, struct enum_sum_memo *memo)
 static void
 sum_iter(VALUE i, struct enum_sum_memo *memo)
 {
-    assert(memo != NULL);
+    RUBY_ASSERT(memo != NULL);
     if (memo->block_given) {
         i = rb_yield(i);
     }
@@ -4691,8 +4691,8 @@ hash_sum_i(VALUE key, VALUE value, VALUE arg)
 static void
 hash_sum(VALUE hash, struct enum_sum_memo *memo)
 {
-    assert(RB_TYPE_P(hash, T_HASH));
-    assert(memo != NULL);
+    RUBY_ASSERT(RB_TYPE_P(hash, T_HASH));
+    RUBY_ASSERT(memo != NULL);
 
     rb_hash_foreach(hash, hash_sum_i, (VALUE)memo);
 }

--- a/id_table.c
+++ b/id_table.c
@@ -150,7 +150,7 @@ hash_table_raw_insert(struct rb_id_table *tbl, id_key_t key, VALUE val)
     int mask = tbl->capa - 1;
     int ix = key & mask;
     int d = 1;
-    assert(key != 0);
+    RUBY_ASSERT(key != 0);
     while (ITEM_KEY_ISSET(tbl, ix)) {
         ITEM_SET_COLLIDED(tbl, ix);
         ix = (ix + d) & mask;
@@ -276,7 +276,7 @@ rb_id_table_foreach(struct rb_id_table *tbl, rb_id_table_foreach_func_t *func, v
         if (ITEM_KEY_ISSET(tbl, i)) {
             const id_key_t key = ITEM_GET_KEY(tbl, i);
             enum rb_id_table_iterator_result ret = (*func)(key2id(key), tbl->items[i].val, data);
-            assert(key != 0);
+            RUBY_ASSERT(key != 0);
 
             if (ret == ID_TABLE_DELETE)
                 hash_delete_index(tbl, i);

--- a/load.c
+++ b/load.c
@@ -253,9 +253,9 @@ features_index_add_single_callback(st_data_t *key, st_data_t *value, st_data_t r
             rb_darray_set(feature_indexes, top^0, FIX2LONG(this_feature_index));
             rb_darray_set(feature_indexes, top^1, FIX2LONG(offset));
 
-            assert(rb_darray_size(feature_indexes) == 2);
+            RUBY_ASSERT(rb_darray_size(feature_indexes) == 2);
             // assert feature_indexes does not look like a special const
-            assert(!SPECIAL_CONST_P((VALUE)feature_indexes));
+            RUBY_ASSERT(!SPECIAL_CONST_P((VALUE)feature_indexes));
 
             *value = (st_data_t)feature_indexes;
         }

--- a/numeric.c
+++ b/numeric.c
@@ -836,7 +836,7 @@ int_zero_p(VALUE num)
     if (FIXNUM_P(num)) {
         return FIXNUM_ZERO_P(num);
     }
-    assert(RB_BIGNUM_TYPE_P(num));
+    RUBY_ASSERT(RB_BIGNUM_TYPE_P(num));
     return rb_bigzero_p(num);
 }
 
@@ -3574,7 +3574,7 @@ rb_int_odd_p(VALUE num)
         return RBOOL(num & 2);
     }
     else {
-        assert(RB_BIGNUM_TYPE_P(num));
+        RUBY_ASSERT(RB_BIGNUM_TYPE_P(num));
         return rb_big_odd_p(num);
     }
 }
@@ -3586,7 +3586,7 @@ int_even_p(VALUE num)
         return RBOOL((num & 2) == 0);
     }
     else {
-        assert(RB_BIGNUM_TYPE_P(num));
+        RUBY_ASSERT(RB_BIGNUM_TYPE_P(num));
         return rb_big_even_p(num);
     }
 }
@@ -3843,7 +3843,7 @@ rb_int_uminus(VALUE num)
         return fix_uminus(num);
     }
     else {
-        assert(RB_BIGNUM_TYPE_P(num));
+        RUBY_ASSERT(RB_BIGNUM_TYPE_P(num));
         return rb_big_uminus(num);
     }
 }
@@ -4359,7 +4359,7 @@ int_remainder(VALUE x, VALUE y)
     if (FIXNUM_P(x)) {
         if (FIXNUM_P(y)) {
             VALUE z = fix_mod(x, y);
-            assert(FIXNUM_P(z));
+            RUBY_ASSERT(FIXNUM_P(z));
             if (z != INT2FIX(0) && (SIGNED_VALUE)(x ^ y) < 0)
                 z = fix_minus(z, y);
             return z;
@@ -5444,7 +5444,7 @@ rb_fix_digits(VALUE fix, long base)
     VALUE digits;
     long x = FIX2LONG(fix);
 
-    assert(x >= 0);
+    RUBY_ASSERT(x >= 0);
 
     if (base < 2)
         rb_raise(rb_eArgError, "invalid radix %ld", base);
@@ -5467,7 +5467,7 @@ rb_int_digits_bigbase(VALUE num, VALUE base)
 {
     VALUE digits, bases;
 
-    assert(!rb_num_negative_p(num));
+    RUBY_ASSERT(!rb_num_negative_p(num));
 
     if (RB_BIGNUM_TYPE_P(base))
         base = rb_big_norm(base);

--- a/range.c
+++ b/range.c
@@ -1266,11 +1266,11 @@ rb_int_range_last(int argc, VALUE *argv, VALUE range)
     int x;
     long n;
 
-    assert(argc > 0);
+    RUBY_ASSERT(argc > 0);
 
     b = RANGE_BEG(range);
     e = RANGE_END(range);
-    assert(RB_INTEGER_TYPE_P(b) && RB_INTEGER_TYPE_P(e));
+    RUBY_ASSERT(RB_INTEGER_TYPE_P(b) && RB_INTEGER_TYPE_P(e));
 
     x = EXCL(range);
 

--- a/rational.c
+++ b/rational.c
@@ -389,8 +389,8 @@ f_gcd(VALUE x, VALUE y)
 {
     VALUE r = f_gcd_orig(x, y);
     if (f_nonzero_p(r)) {
-        assert(f_zero_p(f_mod(x, r)));
-        assert(f_zero_p(f_mod(y, r)));
+        RUBY_ASSERT(f_zero_p(f_mod(x, r)));
+        RUBY_ASSERT(f_zero_p(f_mod(y, r)));
     }
     return r;
 }
@@ -456,8 +456,8 @@ nurat_int_value(VALUE num)
 static void
 nurat_canonicalize(VALUE *num, VALUE *den)
 {
-    assert(num); assert(RB_INTEGER_TYPE_P(*num));
-    assert(den); assert(RB_INTEGER_TYPE_P(*den));
+    RUBY_ASSERT(num); RUBY_ASSERT(RB_INTEGER_TYPE_P(*num));
+    RUBY_ASSERT(den); RUBY_ASSERT(RB_INTEGER_TYPE_P(*den));
     if (INT_NEGATIVE_P(*den)) {
         *num = rb_int_uminus(*num);
         *den = rb_int_uminus(*den);
@@ -497,16 +497,16 @@ nurat_s_canonicalize_internal_no_reduce(VALUE klass, VALUE num, VALUE den)
 inline static VALUE
 f_rational_new2(VALUE klass, VALUE x, VALUE y)
 {
-    assert(!k_rational_p(x));
-    assert(!k_rational_p(y));
+    RUBY_ASSERT(!k_rational_p(x));
+    RUBY_ASSERT(!k_rational_p(y));
     return nurat_s_canonicalize_internal(klass, x, y);
 }
 
 inline static VALUE
 f_rational_new_no_reduce2(VALUE klass, VALUE x, VALUE y)
 {
-    assert(!k_rational_p(x));
-    assert(!k_rational_p(y));
+    RUBY_ASSERT(!k_rational_p(x));
+    RUBY_ASSERT(!k_rational_p(y));
     return nurat_s_canonicalize_internal_no_reduce(klass, x, y);
 }
 
@@ -610,7 +610,7 @@ nurat_denominator(VALUE self)
 VALUE
 rb_rational_uminus(VALUE self)
 {
-    const int unused = (assert(RB_TYPE_P(self, T_RATIONAL)), 0);
+    const int unused = (RUBY_ASSERT(RB_TYPE_P(self, T_RATIONAL)), 0);
     get_dat1(self);
     (void)unused;
     return f_rational_new2(CLASS_OF(self), rb_int_uminus(dat->num), dat->den);
@@ -646,7 +646,7 @@ inline static VALUE
 f_imul(long x, long y)
 {
     VALUE r = f_imul_orig(x, y);
-    assert(f_eqeq_p(r, f_mul(LONG2NUM(x), LONG2NUM(y))));
+    RUBY_ASSERT(f_eqeq_p(r, f_mul(LONG2NUM(x), LONG2NUM(y))));
     return r;
 }
 #endif
@@ -795,7 +795,7 @@ f_muldiv(VALUE self, VALUE anum, VALUE aden, VALUE bnum, VALUE bden, int k)
 {
     VALUE num, den;
 
-    assert(RB_TYPE_P(self, T_RATIONAL));
+    RUBY_ASSERT(RB_TYPE_P(self, T_RATIONAL));
 
     /* Integer#** can return Rational with Float right now */
     if (RB_FLOAT_TYPE_P(anum) || RB_FLOAT_TYPE_P(aden) ||
@@ -806,10 +806,10 @@ f_muldiv(VALUE self, VALUE anum, VALUE aden, VALUE bnum, VALUE bden, int k)
         return DBL2NUM(x);
     }
 
-    assert(RB_INTEGER_TYPE_P(anum));
-    assert(RB_INTEGER_TYPE_P(aden));
-    assert(RB_INTEGER_TYPE_P(bnum));
-    assert(RB_INTEGER_TYPE_P(bden));
+    RUBY_ASSERT(RB_INTEGER_TYPE_P(anum));
+    RUBY_ASSERT(RB_INTEGER_TYPE_P(aden));
+    RUBY_ASSERT(RB_INTEGER_TYPE_P(bnum));
+    RUBY_ASSERT(RB_INTEGER_TYPE_P(bden));
 
     if (k == '/') {
         VALUE t;
@@ -2559,7 +2559,7 @@ nurat_convert(VALUE klass, VALUE numv, VALUE denv, int raise)
     VALUE a1 = numv, a2 = denv;
     int state;
 
-    assert(!UNDEF_P(a1));
+    RUBY_ASSERT(!UNDEF_P(a1));
 
     if (NIL_P(a1) || NIL_P(a2)) {
         if (!raise) return Qnil;

--- a/string.c
+++ b/string.c
@@ -155,7 +155,7 @@ str_enc_fastpath(VALUE str)
         }\
     }\
     else {\
-        assert(!FL_TEST((str), STR_SHARED)); \
+        RUBY_ASSERT(!FL_TEST((str), STR_SHARED)); \
         SIZED_REALLOC_N(RSTRING(str)->as.heap.ptr, char, \
                         (size_t)(capacity) + (termlen), STR_HEAP_SIZE(str)); \
         RSTRING(str)->as.heap.aux.capa = (capacity);\
@@ -164,8 +164,8 @@ str_enc_fastpath(VALUE str)
 
 #define STR_SET_SHARED(str, shared_str) do { \
     if (!FL_TEST(str, STR_FAKESTR)) { \
-        assert(RSTRING_PTR(shared_str) <= RSTRING_PTR(str)); \
-        assert(RSTRING_PTR(str) <= RSTRING_PTR(shared_str) + RSTRING_LEN(shared_str)); \
+        RUBY_ASSERT(RSTRING_PTR(shared_str) <= RSTRING_PTR(str)); \
+        RUBY_ASSERT(RSTRING_PTR(str) <= RSTRING_PTR(shared_str) + RSTRING_LEN(shared_str)); \
         RB_OBJ_WRITE((str), &RSTRING(str)->as.heap.aux.shared, (shared_str)); \
         FL_SET((str), STR_SHARED); \
         FL_SET((shared_str), STR_SHARED_ROOT); \
@@ -370,7 +370,7 @@ fstr_update_callback(st_data_t *key, st_data_t *value, st_data_t data, int exist
             if (STR_SHARED_P(str)) { /* str should not be shared */
                 /* shared substring  */
                 str_make_independent(str);
-                assert(OBJ_FROZEN(str));
+                RUBY_ASSERT(OBJ_FROZEN(str));
             }
             if (!BARE_STRING_P(str)) {
                 str = str_new_frozen(rb_cString, str);
@@ -403,7 +403,7 @@ rb_fstring(VALUE str)
         }
 
         if (FL_TEST_RAW(str, STR_SHARED_ROOT | STR_SHARED) == STR_SHARED_ROOT) {
-            assert(OBJ_FROZEN(str));
+            RUBY_ASSERT(OBJ_FROZEN(str));
             return str;
         }
     }
@@ -437,10 +437,11 @@ register_fstring(VALUE str, bool copy)
     }
     RB_VM_LOCK_LEAVE();
 
-    assert(OBJ_FROZEN(args.fstr));
-    assert(!FL_TEST_RAW(args.fstr, STR_FAKESTR));
-    assert(!FL_TEST_RAW(args.fstr, FL_EXIVAR));
-    assert(RBASIC_CLASS(args.fstr) == rb_cString);
+    RUBY_ASSERT(OBJ_FROZEN(args.fstr));
+    RUBY_ASSERT(!FL_TEST_RAW(args.fstr, STR_FAKESTR));
+    RUBY_ASSERT(!FL_TEST_RAW(args.fstr, FL_EXIVAR));
+    RUBY_ASSERT(RBASIC_CLASS(args.fstr) == rb_cString);
+
     return args.fstr;
 }
 
@@ -829,8 +830,8 @@ static inline VALUE
 str_alloc_embed(VALUE klass, size_t capa)
 {
     size_t size = rb_str_embed_size(capa);
-    assert(size > 0);
-    assert(rb_gc_size_allocatable_p(size));
+    RUBY_ASSERT(size > 0);
+    RUBY_ASSERT(rb_gc_size_allocatable_p(size));
 
     NEWOBJ_OF(str, struct RString, klass,
             T_STRING | (RGENGC_WB_PROTECTED_STRING ? FL_WB_PROTECTED : 0), size, 0);
@@ -1280,7 +1281,8 @@ str_replace_shared_without_enc(VALUE str2, VALUE str)
             root = rb_str_new_frozen(str);
             RSTRING_GETMEM(root, ptr, len);
         }
-        assert(OBJ_FROZEN(root));
+        RUBY_ASSERT(OBJ_FROZEN(root));
+
         if (!STR_EMBED_P(str2) && !FL_TEST_RAW(str2, STR_SHARED|STR_NOFREE)) {
             if (FL_TEST_RAW(str2, STR_SHARED_ROOT)) {
                 rb_fatal("about to free a possible shared root");
@@ -1384,21 +1386,21 @@ rb_str_tmp_frozen_release(VALUE orig, VALUE tmp)
         return;
 
     if (STR_EMBED_P(tmp)) {
-        assert(OBJ_FROZEN_RAW(tmp));
+        RUBY_ASSERT(OBJ_FROZEN_RAW(tmp));
     }
     else if (FL_TEST_RAW(orig, STR_SHARED) &&
             !FL_TEST_RAW(orig, STR_TMPLOCK|RUBY_FL_FREEZE)) {
         VALUE shared = RSTRING(orig)->as.heap.aux.shared;
 
         if (shared == tmp && !FL_TEST_RAW(tmp, STR_BORROWED)) {
-            assert(RSTRING(orig)->as.heap.ptr == RSTRING(tmp)->as.heap.ptr);
-            assert(RSTRING_LEN(orig) == RSTRING_LEN(tmp));
+            RUBY_ASSERT(RSTRING(orig)->as.heap.ptr == RSTRING(tmp)->as.heap.ptr);
+            RUBY_ASSERT(RSTRING_LEN(orig) == RSTRING_LEN(tmp));
 
             /* Unshare orig since the root (tmp) only has this one child. */
             FL_UNSET_RAW(orig, STR_SHARED);
             RSTRING(orig)->as.heap.aux.capa = RSTRING(tmp)->as.heap.aux.capa;
             RBASIC(orig)->flags |= RBASIC(tmp)->flags & STR_NOFREE;
-            assert(OBJ_FROZEN_RAW(tmp));
+            RUBY_ASSERT(OBJ_FROZEN_RAW(tmp));
 
             /* Make tmp embedded and empty so it is safe for sweeping. */
             STR_SET_EMBED(tmp);
@@ -1416,8 +1418,8 @@ str_new_frozen(VALUE klass, VALUE orig)
 static VALUE
 heap_str_make_shared(VALUE klass, VALUE orig)
 {
-    assert(!STR_EMBED_P(orig));
-    assert(!STR_SHARED_P(orig));
+    RUBY_ASSERT(!STR_EMBED_P(orig));
+    RUBY_ASSERT(!STR_SHARED_P(orig));
 
     VALUE str = str_alloc_heap(klass);
     STR_SET_LEN(str, RSTRING_LEN(orig));
@@ -1441,23 +1443,23 @@ str_new_frozen_buffer(VALUE klass, VALUE orig, int copy_encoding)
 
     if (STR_EMBED_P(orig) || STR_EMBEDDABLE_P(len, termlen)) {
         str = str_new0(klass, RSTRING_PTR(orig), len, termlen);
-        assert(STR_EMBED_P(str));
+        RUBY_ASSERT(STR_EMBED_P(str));
     }
     else {
         if (FL_TEST_RAW(orig, STR_SHARED)) {
             VALUE shared = RSTRING(orig)->as.heap.aux.shared;
             long ofs = RSTRING(orig)->as.heap.ptr - RSTRING_PTR(shared);
             long rest = RSTRING_LEN(shared) - ofs - RSTRING_LEN(orig);
-            assert(ofs >= 0);
-            assert(rest >= 0);
-            assert(ofs + rest <= RSTRING_LEN(shared));
-            assert(OBJ_FROZEN(shared));
+            RUBY_ASSERT(ofs >= 0);
+            RUBY_ASSERT(rest >= 0);
+            RUBY_ASSERT(ofs + rest <= RSTRING_LEN(shared));
+            RUBY_ASSERT(OBJ_FROZEN(shared));
 
             if ((ofs > 0) || (rest > 0) ||
                 (klass != RBASIC(shared)->klass) ||
                 ENCODING_GET(shared) != ENCODING_GET(orig)) {
                 str = str_new_shared(klass, shared);
-                assert(!STR_EMBED_P(str));
+                RUBY_ASSERT(!STR_EMBED_P(str));
                 RSTRING(str)->as.heap.ptr += ofs;
                 STR_SET_LEN(str, RSTRING_LEN(str) - (ofs + rest));
             }
@@ -1610,9 +1612,9 @@ str_shared_replace(VALUE str, VALUE str2)
     }
     else {
         if (STR_EMBED_P(str2)) {
-            assert(!FL_TEST(str2, STR_SHARED));
+            RUBY_ASSERT(!FL_TEST(str2, STR_SHARED));
             long len = RSTRING_LEN(str2);
-            assert(len + termlen <= str_embed_capa(str2));
+            RUBY_ASSERT(len + termlen <= str_embed_capa(str2));
 
             char *new_ptr = ALLOC_N(char, len + termlen);
             memcpy(new_ptr, RSTRING(str2)->as.embed.ary, len + termlen);
@@ -1671,7 +1673,7 @@ str_replace(VALUE str, VALUE str2)
     len = RSTRING_LEN(str2);
     if (STR_SHARED_P(str2)) {
         VALUE shared = RSTRING(str2)->as.heap.aux.shared;
-        assert(OBJ_FROZEN(shared));
+        RUBY_ASSERT(OBJ_FROZEN(shared));
         STR_SET_NOEMBED(str);
         STR_SET_LEN(str, len);
         RSTRING(str)->as.heap.ptr = RSTRING_PTR(str2);
@@ -1689,8 +1691,8 @@ static inline VALUE
 ec_str_alloc_embed(struct rb_execution_context_struct *ec, VALUE klass, size_t capa)
 {
     size_t size = rb_str_embed_size(capa);
-    assert(size > 0);
-    assert(rb_gc_size_allocatable_p(size));
+    RUBY_ASSERT(size > 0);
+    RUBY_ASSERT(rb_gc_size_allocatable_p(size));
 
     NEWOBJ_OF(str, struct RString, klass,
             T_STRING | (RGENGC_WB_PROTECTED_STRING ? FL_WB_PROTECTED : 0), size, ec);
@@ -1719,8 +1721,8 @@ str_duplicate_setup(VALUE klass, VALUE str, VALUE dup)
     if (STR_EMBED_P(str)) {
         long len = RSTRING_LEN(str);
 
-        assert(STR_EMBED_P(dup));
-        assert(str_embed_capa(dup) >= len + 1);
+        RUBY_ASSERT(STR_EMBED_P(dup));
+        RUBY_ASSERT(str_embed_capa(dup) >= len + 1);
         MEMCPY(RSTRING(dup)->as.embed.ary, RSTRING(str)->as.embed.ary, char, len + 1);
     }
     else {
@@ -1732,8 +1734,8 @@ str_duplicate_setup(VALUE klass, VALUE str, VALUE dup)
             root = str = str_new_frozen(klass, str);
             flags = FL_TEST_RAW(str, flag_mask);
         }
-        assert(!STR_SHARED_P(root));
-        assert(RB_OBJ_FROZEN_RAW(root));
+        RUBY_ASSERT(!STR_SHARED_P(root));
+        RUBY_ASSERT(RB_OBJ_FROZEN_RAW(root));
 
         RSTRING(dup)->as.heap.ptr = RSTRING_PTR(str);
         FL_SET(root, STR_SHARED_ROOT);
@@ -1862,7 +1864,7 @@ rb_str_init(int argc, VALUE *argv, VALUE str)
             str_modifiable(str);
             if (STR_EMBED_P(str)) { /* make noembed always */
                 char *new_ptr = ALLOC_N(char, (size_t)capa + termlen);
-                assert(RSTRING_LEN(str) + 1 <= str_embed_capa(str));
+                RUBY_ASSERT(RSTRING_LEN(str) + 1 <= str_embed_capa(str));
                 memcpy(new_ptr, RSTRING(str)->as.embed.ary, RSTRING_LEN(str) + 1);
                 RSTRING(str)->as.heap.ptr = new_ptr;
             }
@@ -2291,8 +2293,8 @@ rb_str_plus(VALUE str1, VALUE str2)
 VALUE
 rb_str_opt_plus(VALUE str1, VALUE str2)
 {
-    assert(RBASIC_CLASS(str1) == rb_cString);
-    assert(RBASIC_CLASS(str2) == rb_cString);
+    RUBY_ASSERT(RBASIC_CLASS(str1) == rb_cString);
+    RUBY_ASSERT(RBASIC_CLASS(str2) == rb_cString);
     long len1, len2;
     MAYBE_UNUSED(char) *ptr1, *ptr2;
     RSTRING_GETMEM(str1, ptr1, len1);
@@ -2608,7 +2610,7 @@ rb_str_change_terminator_length(VALUE str, const int oldtermlen, const int terml
     long capa = str_capacity(str, oldtermlen) + oldtermlen;
     long len = RSTRING_LEN(str);
 
-    assert(capa >= len);
+    RUBY_ASSERT(capa >= len);
     if (capa - len < termlen) {
         rb_check_lockedtmp(str);
         str_make_independent_expand(str, len, 0L, termlen);
@@ -2620,7 +2622,7 @@ rb_str_change_terminator_length(VALUE str, const int oldtermlen, const int terml
     else {
         if (!STR_EMBED_P(str)) {
             /* modify capa instead of realloc */
-            assert(!FL_TEST((str), STR_SHARED));
+            RUBY_ASSERT(!FL_TEST((str), STR_SHARED));
             RSTRING(str)->as.heap.aux.capa = capa - termlen;
         }
         if (termlen > oldtermlen) {
@@ -2853,9 +2855,9 @@ str_subseq(VALUE str, long beg, long len)
 {
     VALUE str2;
 
-    assert(beg >= 0);
-    assert(len >= 0);
-    assert(beg+len <= RSTRING_LEN(str));
+    RUBY_ASSERT(beg >= 0);
+    RUBY_ASSERT(len >= 0);
+    RUBY_ASSERT(beg+len <= RSTRING_LEN(str));
 
     const int termlen = TERM_LEN(str);
     if (!SHARABLE_SUBSTRING_P(beg, len, RSTRING_LEN(str))) {
@@ -2876,7 +2878,7 @@ str_subseq(VALUE str, long beg, long len)
     }
     else {
         str_replace_shared(str2, str);
-        assert(!STR_EMBED_P(str2));
+        RUBY_ASSERT(!STR_EMBED_P(str2));
         ENC_CODERANGE_CLEAR(str2);
         RSTRING(str2)->as.heap.ptr += beg;
         if (RSTRING_LEN(str2) > len) {
@@ -5393,8 +5395,9 @@ rb_str_update(VALUE str, long beg, long len, VALUE val)
     if (beg < 0) {
         beg += slen;
     }
-    assert(beg >= 0);
-    assert(beg <= slen);
+    RUBY_ASSERT(beg >= 0);
+    RUBY_ASSERT(beg <= slen);
+
     if (len > slen - beg) {
         len = slen - beg;
     }
@@ -6348,8 +6351,9 @@ str_check_beg_len(VALUE str, long *beg, long *len)
     if (*beg < 0) {
         *beg += slen;
     }
-    assert(*beg >= 0);
-    assert(*beg <= slen);
+    RUBY_ASSERT(*beg >= 0);
+    RUBY_ASSERT(*beg <= slen);
+
     if (*len > slen - *beg) {
         *len = slen - *beg;
     }
@@ -12118,7 +12122,7 @@ void
 Init_String(void)
 {
     rb_cString  = rb_define_class("String", rb_cObject);
-    assert(rb_vm_fstring_table());
+    RUBY_ASSERT(rb_vm_fstring_table());
     st_foreach(rb_vm_fstring_table(), fstring_set_class_i, rb_cString);
     rb_include_module(rb_cString, rb_mComparable);
     rb_define_alloc_func(rb_cString, empty_str_alloc);

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -854,7 +854,7 @@ raise_closed_queue_error(VALUE self)
 static VALUE
 queue_closed_result(VALUE self, struct rb_queue *q)
 {
-    assert(queue_length(self, q) == 0);
+    RUBY_ASSERT(queue_length(self, q) == 0);
     return Qnil;
 }
 
@@ -1081,8 +1081,8 @@ queue_do_pop(VALUE self, struct rb_queue *q, int should_block, VALUE timeout)
         else {
             rb_execution_context_t *ec = GET_EC();
 
-            assert(RARRAY_LEN(q->que) == 0);
-            assert(queue_closed_p(self) == 0);
+            RUBY_ASSERT(RARRAY_LEN(q->que) == 0);
+            RUBY_ASSERT(queue_closed_p(self) == 0);
 
             struct queue_waiter queue_waiter = {
                 .w = {.self = self, .th = ec->thread_ptr, .fiber = nonblocking_fiber(ec->fiber_ptr)},

--- a/weakmap.c
+++ b/weakmap.c
@@ -39,7 +39,7 @@ wmap_live_p(VALUE obj)
 static void
 wmap_free_entry(VALUE *key, VALUE *val)
 {
-    assert(key + 1 == val);
+    RUBY_ASSERT(key + 1 == val);
 
     /* We only need to free key because val is allocated beside key on in the
      * same malloc call. */
@@ -418,7 +418,7 @@ wmap_aset_replace(st_data_t *key, st_data_t *val, st_data_t new_key_ptr, int exi
     VALUE new_val = *(((VALUE *)new_key_ptr) + 1);
 
     if (existing) {
-        assert(*(VALUE *)*key == new_key);
+        RUBY_ASSERT(*(VALUE *)*key == new_key);
     }
     else {
         VALUE *pair = xmalloc(sizeof(VALUE) * 2);
@@ -462,7 +462,7 @@ wmap_aset(VALUE self, VALUE key, VALUE val)
 static VALUE
 wmap_lookup(VALUE self, VALUE key)
 {
-    assert(wmap_live_p(key));
+    RUBY_ASSERT(wmap_live_p(key));
 
     struct weakmap *w;
     TypedData_Get_Struct(self, struct weakmap, &weakmap_type, w);
@@ -681,7 +681,7 @@ wkmap_compact_table_i(st_data_t key, st_data_t val_obj, st_data_t _data, int _er
 static int
 wkmap_compact_table_replace(st_data_t *key_ptr, st_data_t *val_ptr, st_data_t _data, int existing)
 {
-    assert(existing);
+    RUBY_ASSERT(existing);
 
     *(VALUE *)*key_ptr = rb_gc_location(*(VALUE *)*key_ptr);
     *val_ptr = (st_data_t)rb_gc_location((VALUE)*val_ptr);
@@ -729,7 +729,7 @@ static st_index_t
 wkmap_hash(st_data_t n)
 {
     VALUE obj = *(VALUE *)n;
-    assert(wmap_live_p(obj));
+    RUBY_ASSERT(wmap_live_p(obj));
 
     return rb_any_hash(obj);
 }


### PR DESCRIPTION
assert does not print the bug report, only the file and line number of the assertion that failed. RUBY_ASSERT prints the full bug report, which makes it much easier to debug.