### PR TITLE
YJIT: Fallback megamorphic opt_case_dispatch

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -323,8 +323,9 @@ module RubyVM::YJIT
         out.puts "num_send_x86_rel32:    " + format_number(13,  stats[:num_send_x86_rel32])
         out.puts "num_send_x86_reg:      " + format_number(13, stats[:num_send_x86_reg])
       end
-      out.puts "num_getivar_megamorphic: " + format_number(13, stats[:num_getivar_megamorphic])
-      out.puts "num_setivar_megamorphic: " + format_number(13, stats[:num_setivar_megamorphic])
+      out.puts "num_getivar_megamorphic: " + format_number(11, stats[:num_getivar_megamorphic])
+      out.puts "num_setivar_megamorphic: " + format_number(11, stats[:num_setivar_megamorphic])
+      out.puts "num_opt_case_megamorphic: " + format_number(10, stats[:num_opt_case_dispatch_megamorphic])
       out.puts "num_throw:             " + format_number(13, stats[:num_throw])
       out.puts "num_throw_break:       " + format_number_pct(13, stats[:num_throw_break], stats[:num_throw])
       out.puts "num_throw_retry:       " + format_number_pct(13, stats[:num_throw_retry], stats[:num_throw])

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -592,6 +592,7 @@ make_counters! {
 
     num_getivar_megamorphic,
     num_setivar_megamorphic,
+    num_opt_case_dispatch_megamorphic,
 
     num_throw,
     num_throw_break,


### PR DESCRIPTION
`opt_case_dispatch_megamorphic` accounts for 68% of exits on `rubocop`. This PR fixes it by falling back to compile subsequent instructions as is after 20 chains.

This speeds up `rubocop` by 3%.

```
before: ruby 3.4.0dev (2024-02-08T23:52:45Z master e2aa00ca66) +YJIT [x86_64-linux]
after: ruby 3.4.0dev (2024-02-08T23:53:29Z yjit-opt-case 2193dc2f13) +YJIT [x86_64-linux]

-------  -----------  ----------  ----------  ----------  -------------  ------------
bench    before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
rubocop  132.1        4.7         128.0       4.5         0.94           1.03
-------  -----------  ----------  ----------  ----------  -------------  ------------
```

This also speeds up `optcarrot --opt` by 17%, which people sometimes use when they compare their JIT against YJIT.

```bash
# before
ruby -v --yjit bin/optcarrot-bench --opt
ruby 3.4.0dev (2024-02-08T23:52:45Z master e2aa00ca66) +YJIT [x86_64-linux]
fps: 164.09038383764974

# after
$ ruby -v --yjit bin/optcarrot-bench --opt
ruby 3.4.0dev (2024-02-08T23:53:29Z yjit-opt-case 2193dc2f13) +YJIT [x86_64-linux]
fps: 192.09196646229304
```