### PR TITLE
YJIT: Refactor recv_known_class to Option

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4492,7 +4492,7 @@ fn jit_rb_obj_not(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     let recv_opnd = asm.ctx.get_opnd_type(StackOpnd(0));
 
@@ -4527,7 +4527,7 @@ fn jit_rb_true(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     asm_comment!(asm, "nil? == true");
     asm.stack_pop(1);
@@ -4545,7 +4545,7 @@ fn jit_rb_false(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     asm_comment!(asm, "nil? == false");
     asm.stack_pop(1);
@@ -4563,14 +4563,14 @@ fn jit_rb_kernel_is_a(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     argc: i32,
-    known_recv_class: *const VALUE,
+    known_recv_class: Option<VALUE>,
 ) -> bool {
     if argc != 1 {
         return false;
     }
 
     // If this is a super call we might not know the class
-    if known_recv_class.is_null() {
+    if known_recv_class.is_none() {
         return false;
     }
 
@@ -4616,14 +4616,14 @@ fn jit_rb_kernel_instance_of(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     argc: i32,
-    known_recv_class: *const VALUE,
+    known_recv_class: Option<VALUE>,
 ) -> bool {
     if argc != 1 {
         return false;
     }
 
     // If this is a super call we might not know the class
-    if known_recv_class.is_null() {
+    if known_recv_class.is_none() {
         return false;
     }
 
@@ -4681,7 +4681,7 @@ fn jit_rb_mod_eqq(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     if argc != 1 {
         return false;
@@ -4715,7 +4715,7 @@ fn jit_rb_obj_equal(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     asm_comment!(asm, "equal?");
     let obj1 = asm.stack_pop(1);
@@ -4739,7 +4739,7 @@ fn jit_rb_obj_not_equal(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     gen_equality_specialized(jit, asm, ocb, false) == Some(true)
 }
@@ -4753,7 +4753,7 @@ fn jit_rb_int_equal(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     // Check that both operands are fixnums
     guard_two_fixnums(jit, asm, ocb);
@@ -4778,7 +4778,7 @@ fn jit_rb_int_succ(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     // Guard the receiver is fixnum
     let recv_type = asm.ctx.get_opnd_type(StackOpnd(0));
@@ -4808,7 +4808,7 @@ fn jit_rb_int_div(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     if asm.ctx.two_fixnums_on_stack(jit) != Some(true) {
         return false;
@@ -4842,7 +4842,7 @@ fn jit_rb_int_lshift(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     if asm.ctx.two_fixnums_on_stack(jit) != Some(true) {
         return false;
@@ -4907,7 +4907,7 @@ fn jit_rb_int_rshift(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     if asm.ctx.two_fixnums_on_stack(jit) != Some(true) {
         return false;
@@ -4960,7 +4960,7 @@ fn jit_rb_int_xor(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     if asm.ctx.two_fixnums_on_stack(jit) != Some(true) {
         return false;
@@ -4987,7 +4987,7 @@ fn jit_rb_int_aref(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     if argc != 1 {
         return false;
@@ -5016,7 +5016,7 @@ fn jit_rb_float_plus(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     // Guard obj is Fixnum or Flonum to avoid rb_funcall on rb_num_coerce_bin
     let comptime_obj = jit.peek_at_stack(&asm.ctx, 0);
@@ -5060,7 +5060,7 @@ fn jit_rb_float_minus(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     // Guard obj is Fixnum or Flonum to avoid rb_funcall on rb_num_coerce_bin
     let comptime_obj = jit.peek_at_stack(&asm.ctx, 0);
@@ -5104,7 +5104,7 @@ fn jit_rb_float_mul(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     // Guard obj is Fixnum or Flonum to avoid rb_funcall on rb_num_coerce_bin
     let comptime_obj = jit.peek_at_stack(&asm.ctx, 0);
@@ -5148,7 +5148,7 @@ fn jit_rb_float_div(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     // Guard obj is Fixnum or Flonum to avoid rb_funcall on rb_num_coerce_bin
     let comptime_obj = jit.peek_at_stack(&asm.ctx, 0);
@@ -5193,7 +5193,7 @@ fn jit_rb_str_uplus(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool
 {
     if argc != 0 {
@@ -5237,7 +5237,7 @@ fn jit_rb_str_length(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     asm_comment!(asm, "String#length");
     extern "C" {
@@ -5264,7 +5264,7 @@ fn jit_rb_str_bytesize(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     asm_comment!(asm, "String#bytesize");
 
@@ -5296,7 +5296,7 @@ fn jit_rb_str_getbyte(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     asm_comment!(asm, "String#getbyte");
     extern "C" {
@@ -5329,9 +5329,9 @@ fn jit_rb_str_to_s(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    known_recv_class: *const VALUE,
+    known_recv_class: Option<VALUE>,
 ) -> bool {
-    if !known_recv_class.is_null() && unsafe { *known_recv_class == rb_cString } {
+    if unsafe { known_recv_class == Some(rb_cString) } {
         asm_comment!(asm, "to_s on plain string");
         // The method returns the receiver, which is already on the stack.
         // No stack movement.
@@ -5349,7 +5349,7 @@ fn jit_rb_str_empty_p(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     let recv_opnd = asm.stack_pop(1);
 
@@ -5379,7 +5379,7 @@ fn jit_rb_str_concat(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     // The << operator can accept integer codepoints for characters
     // as the argument. We only specially optimise string arguments.
@@ -5450,7 +5450,7 @@ fn jit_rb_ary_empty_p(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     let array_opnd = asm.stack_pop(1);
     let array_reg = asm.load(array_opnd);
@@ -5474,7 +5474,7 @@ fn jit_rb_ary_length(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     let array_opnd = asm.stack_pop(1);
     let array_reg = asm.load(array_opnd);
@@ -5498,7 +5498,7 @@ fn jit_rb_ary_push(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     asm_comment!(asm, "Array#<<");
 
@@ -5524,7 +5524,7 @@ fn jit_rb_hash_empty_p(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     asm_comment!(asm, "Hash#empty?");
 
@@ -5544,18 +5544,17 @@ fn jit_obj_respond_to(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     argc: i32,
-    known_recv_class: *const VALUE,
+    known_recv_class: Option<VALUE>,
 ) -> bool {
     // respond_to(:sym) or respond_to(:sym, true)
     if argc != 1 && argc != 2 {
         return false;
     }
 
-    if known_recv_class.is_null() {
-        return false;
-    }
-
-    let recv_class = unsafe { *known_recv_class };
+    let recv_class = match known_recv_class {
+        Some(class) => class,
+        None => return false,
+    };
 
     // Get the method_id from compile time. We will later add a guard against it.
     let mid_sym = jit.peek_at_stack(&asm.ctx, (argc - 1) as isize);
@@ -5651,7 +5650,7 @@ fn jit_rb_f_block_given_p(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     asm.stack_pop(1);
     let out_opnd = asm.stack_push(Type::UnknownImm);
@@ -5690,7 +5689,7 @@ fn jit_thread_s_current(
     _cme: *const rb_callable_method_entry_t,
     _block: Option<BlockHandler>,
     _argc: i32,
-    _known_recv_class: *const VALUE,
+    _known_recv_class: Option<VALUE>,
 ) -> bool {
     asm_comment!(asm, "Thread.current");
     asm.stack_pop(1);
@@ -5904,7 +5903,7 @@ fn gen_send_cfunc(
     ci: *const rb_callinfo,
     cme: *const rb_callable_method_entry_t,
     block: Option<BlockHandler>,
-    recv_known_klass: *const VALUE,
+    recv_known_class: Option<VALUE>,
     flags: u32,
     argc: i32,
 ) -> Option<CodegenStatus> {
@@ -5950,7 +5949,7 @@ fn gen_send_cfunc(
         let codegen_p = lookup_cfunc_codegen(unsafe { (*cme).def });
         let expected_stack_after = asm.ctx.get_stack_size() as i32 - argc;
         if let Some(known_cfunc_codegen) = codegen_p {
-            if known_cfunc_codegen(jit, asm, ocb, ci, cme, block, argc, recv_known_klass) {
+            if known_cfunc_codegen(jit, asm, ocb, ci, cme, block, argc, recv_known_class) {
                 assert_eq!(expected_stack_after, asm.ctx.get_stack_size() as i32);
                 gen_counter_incr(asm, Counter::num_send_cfunc_inline);
                 // cfunc codegen generated code. Terminate the block so
@@ -5968,8 +5967,8 @@ fn gen_send_cfunc(
 
         // Assemble the method name string
         let mid = unsafe { vm_ci_mid(ci) };
-        let class_name = if recv_known_klass != ptr::null() {
-            unsafe { cstr_to_rust_string(rb_class2name(*recv_known_klass)) }.unwrap()
+        let class_name = if let Some(class) = recv_known_class {
+            unsafe { cstr_to_rust_string(rb_class2name(class)) }.unwrap()
         } else {
             "Unknown".to_string()
         };
@@ -7726,7 +7725,7 @@ fn gen_send_general(
                     ci,
                     cme,
                     block,
-                    &comptime_recv_klass,
+                    Some(comptime_recv_klass),
                     flags,
                     argc,
                 );
@@ -8463,7 +8462,7 @@ fn gen_invokesuper_specialized(
             gen_send_iseq(jit, asm, ocb, iseq, ci, frame_type, None, cme, Some(block), ci_flags, argc, None)
         }
         VM_METHOD_TYPE_CFUNC => {
-            gen_send_cfunc(jit, asm, ocb, ci, cme, Some(block), ptr::null(), ci_flags, argc)
+            gen_send_cfunc(jit, asm, ocb, ci, cme, Some(block), None, ci_flags, argc)
         }
         _ => unreachable!(),
     }
@@ -9328,7 +9327,7 @@ fn get_gen_fn(opcode: VALUE) -> Option<InsnGenFn> {
 }
 
 // Return true when the codegen function generates code.
-// known_recv_klass is non-NULL when the caller has used jit_guard_known_klass().
+// known_recv_class has Some value when the caller has used jit_guard_known_klass().
 // See yjit_reg_method().
 type MethodGenFn = fn(
     jit: &mut JITState,
@@ -9338,7 +9337,7 @@ type MethodGenFn = fn(
     cme: *const rb_callable_method_entry_t,
     block: Option<BlockHandler>,
     argc: i32,
-    known_recv_class: *const VALUE,
+    known_recv_class: Option<VALUE>,
 ) -> bool;
 
 /// Methods for generating code for hardcoded (usually C) methods


### PR DESCRIPTION
`MethodGenFn` uses a pointer to a class pointer for expressing an optional value. This PR refactors it to use `Option<VALUE>`.