### PR TITLE
Allow `foo(**nil, &block_arg)`

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -563,7 +563,12 @@ splatkw
 (VALUE obj, VALUE block)
 // attr bool leaf = false; /* has rb_to_hash_type() */
 {
-    obj = rb_to_hash_type(hash);
+    if (NIL_P(hash)) {
+        obj = Qnil;
+    }
+    else {
+        obj = rb_to_hash_type(hash);
+    }
 }
 
 /* put new Hash from n elements. n must be an even number. */

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -189,6 +189,7 @@ class TestKeywordArguments < Test::Unit::TestCase
     def self.a0; end
     assert_equal(nil, a0(**nil))
     assert_equal(nil, :a0.to_proc.call(self, **nil))
+    assert_equal(nil, a0(**nil, &:block))
 
     def self.o(x=1); x end
     assert_equal(1, o(**nil))


### PR DESCRIPTION
Previously, `**nil` by itself worked, but if you add a block argument,
it raised a conversion error. The presence of the block argument
shouldn't change how keyword splat works.

See: <https://bugs.ruby-lang.org/issues/20064>
