### PR TITLE
rb_profile_thread_frames: Immediately return if passed thread is dead

### DIFF
--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1790,6 +1790,12 @@ int
 rb_profile_thread_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines)
 {
     rb_thread_t *th = rb_thread_ptr(thread);
+
+    // If the threads is already in the KILLED state, there are no frames to capture.
+    if (th->status == THREAD_KILLED) {
+        return 0;
+    }
+
     return thread_profile_frames(th->ec, start, limit, buff, lines);
 }
 


### PR DESCRIPTION
Accept completed Threads as rb_profile_thread_frames' first argument.

Currently, the caller needs to check if the Thread is complete before calling rb_profile_thread_frames(). This requires an extra rb_funcall to `Thread#status` and also has a possibility of a race condition (the Thread could quit between the Thread#status check and the rb_profile_thread_frames() call).