### PR TITLE
[ruby/optparse] Respect default values in block parameters

### DIFF
--- a/test/optparse/test_acceptable.rb
+++ b/test/optparse/test_acceptable.rb
@@ -8,6 +8,7 @@ class TestOptionParserAcceptable < TestOptionParser
     @opt.def_option("--integer VAL", Integer) { |v| @integer = v }
     @opt.def_option("--float VAL",   Float)   { |v| @float   = v }
     @opt.def_option("--numeric VAL", Numeric) { |v| @numeric = v }
+    @opt.def_option("--array VAL", Array) { |v| @array = v }
 
     @opt.def_option("--decimal-integer VAL",
                     OptionParser::DecimalInteger) { |i| @decimal_integer = i }
@@ -195,4 +196,8 @@ class TestOptionParserAcceptable < TestOptionParser
     end
   end
 
+  def test_array
+    assert_equal(%w"", no_error {@opt.parse!(%w"--array a,b,c")})
+    assert_equal(%w"a b c", @array)
+  end
 end

--- a/test/optparse/test_optarg.rb
+++ b/test/optparse/test_optarg.rb
@@ -9,6 +9,7 @@ class TestOptionParserOptArg < TestOptionParser
     @opt.def_option("--regexp[=REGEXP]", Regexp) {|x| @reopt = x}
     @opt.def_option "--with_underscore[=VAL]" do |x| @flag = x end
     @opt.def_option "--with-hyphen[=VAL]" do |x| @flag = x end
+    @opt.def_option("--fallback[=VAL]") do |x = "fallback"| @flag = x end
     @reopt = nil
   end
 
@@ -56,5 +57,12 @@ class TestOptionParserOptArg < TestOptionParser
     assert_equal("foo3", @flag)
     assert_equal(%w"", no_error {@opt.parse!(%w"--with_hyphen=foo4")})
     assert_equal("foo4", @flag)
+  end
+
+  def test_default_argument
+    assert_equal(%w"", no_error {@opt.parse!(%w"--fallback=val1")})
+    assert_equal("val1", @flag)
+    assert_equal(%w"", no_error {@opt.parse!(%w"--fallback")})
+    assert_equal("fallback", @flag)
   end
 end

--- a/test/optparse/test_optarg.rb
+++ b/test/optparse/test_optarg.rb
@@ -10,6 +10,7 @@ class TestOptionParserOptArg < TestOptionParser
     @opt.def_option "--with_underscore[=VAL]" do |x| @flag = x end
     @opt.def_option "--with-hyphen[=VAL]" do |x| @flag = x end
     @opt.def_option("--fallback[=VAL]") do |x = "fallback"| @flag = x end
+    @opt.def_option("--lambda[=VAL]", &->(x) {@flag = x})
     @reopt = nil
   end
 
@@ -64,5 +65,12 @@ class TestOptionParserOptArg < TestOptionParser
     assert_equal("val1", @flag)
     assert_equal(%w"", no_error {@opt.parse!(%w"--fallback")})
     assert_equal("fallback", @flag)
+  end
+
+  def test_lambda
+    assert_equal(%w"", no_error {@opt.parse!(%w"--lambda=lambda1")})
+    assert_equal("lambda1", @flag)
+    assert_equal(%w"", no_error {@opt.parse!(%w"--lambda")})
+    assert_equal(nil, @flag)
   end
 end

--- a/test/optparse/test_optparse.rb
+++ b/test/optparse/test_optparse.rb
@@ -73,10 +73,17 @@ class TestOptionParser < Test::Unit::TestCase
     @opt.def_option "-p", "--port=PORT", "port", Integer
     @opt.def_option "-v", "--verbose" do @verbose = true end
     @opt.def_option "-q", "--quiet" do @quiet = true end
+    @opt.def_option "-o", "--option [OPT]" do |opt| @option = opt end
     result = {}
     @opt.parse %w(--host localhost --port 8000 -v), into: result
     assert_equal({host: "localhost", port: 8000, verbose: true}, result)
     assert_equal(true, @verbose)
+    result = {}
+    @opt.parse %w(--option -q), into: result
+    assert_equal({quiet: true, option: nil}, result)
+    result = {}
+    @opt.parse %w(--option OPTION -v), into: result
+    assert_equal({verbose: true, option: "OPTION"}, result)
   end
 
   def test_require_exact

--- a/test/optparse/test_placearg.rb
+++ b/test/optparse/test_placearg.rb
@@ -13,6 +13,7 @@ class TestOptionParserPlaceArg < TestOptionParser
     @reopt = nil
     @opt.def_option "--with_underscore=VAL" do |x| @flag = x end
     @opt.def_option "--with-hyphen=VAL" do |x| @flag = x end
+    @opt.def_option("--fallback [VAL]") do |x = "fallback"| @flag = x end
   end
 
   def test_short
@@ -72,5 +73,14 @@ class TestOptionParserPlaceArg < TestOptionParser
     assert_nil(@topt)
     assert_equal(%w"te.rb", no_error('[ruby-dev:38333]') {@opt.parse!(%w"-T1 te.rb")})
     assert_equal(1, @topt)
+  end
+
+  def test_default_argument
+    assert_equal(%w"", no_error {@opt.parse!(%w"--fallback=val1")})
+    assert_equal("val1", @flag)
+    assert_equal(%w"", no_error {@opt.parse!(%w"--fallback val2")})
+    assert_equal("val2", @flag)
+    assert_equal(%w"", no_error {@opt.parse!(%w"--fallback")})
+    assert_equal("fallback", @flag)
   end
 end

--- a/test/optparse/test_placearg.rb
+++ b/test/optparse/test_placearg.rb
@@ -14,6 +14,7 @@ class TestOptionParserPlaceArg < TestOptionParser
     @opt.def_option "--with_underscore=VAL" do |x| @flag = x end
     @opt.def_option "--with-hyphen=VAL" do |x| @flag = x end
     @opt.def_option("--fallback [VAL]") do |x = "fallback"| @flag = x end
+    @opt.def_option("--lambda [VAL]", &->(x) {@flag = x})
   end
 
   def test_short
@@ -82,5 +83,14 @@ class TestOptionParserPlaceArg < TestOptionParser
     assert_equal("val2", @flag)
     assert_equal(%w"", no_error {@opt.parse!(%w"--fallback")})
     assert_equal("fallback", @flag)
+  end
+
+  def test_lambda
+    assert_equal(%w"", no_error {@opt.parse!(%w"--lambda=lambda1")})
+    assert_equal("lambda1", @flag)
+    assert_equal(%w"", no_error {@opt.parse!(%w"--lambda lambda2")})
+    assert_equal("lambda2", @flag)
+    assert_equal(%w"", no_error {@opt.parse!(%w"--lambda")})
+    assert_equal(nil, @flag)
   end
 end

--- a/test/optparse/test_reqarg.rb
+++ b/test/optparse/test_reqarg.rb
@@ -6,6 +6,7 @@ module TestOptionParserReqArg
     super
     @opt.def_option "--with_underscore=VAL" do |x| @flag = x end
     @opt.def_option "--with-hyphen=VAL" do |x| @flag = x end
+    @opt.def_option("--lambda=VAL", &->(x) {@flag = x})
   end
 
   class Def1 < TestOptionParser
@@ -79,6 +80,11 @@ module TestOptionParserReqArg
     assert_equal("foo3", @flag)
     assert_equal(%w"", no_error {@opt.parse!(%w"--with_hyphen foo4")})
     assert_equal("foo4", @flag)
+  end
+
+  def test_lambda
+    assert_equal(%w"", no_error {@opt.parse!(%w"--lambda=lambda1")})
+    assert_equal("lambda1", @flag)
   end
 
   class TestOptionParser::WithPattern < TestOptionParser


### PR DESCRIPTION
Fix https://github.com/ruby/optparse/pull/55

https://github.com/ruby/optparse/commit/e6be9b71d0