### PR TITLE
rb_obj_setup: do not copy RUBY_FL_SEEN_OBJ_ID

### DIFF
--- a/object.c
+++ b/object.c
@@ -120,7 +120,7 @@ rb_obj_reveal(VALUE obj, VALUE klass)
 VALUE
 rb_obj_setup(VALUE obj, VALUE klass, VALUE type)
 {
-    VALUE ignored_flags = RUBY_FL_PROMOTED;
+    VALUE ignored_flags = RUBY_FL_PROMOTED | RUBY_FL_SEEN_OBJ_ID;
     RBASIC(obj)->flags = (type & ~ignored_flags) | (RBASIC(obj)->flags & ignored_flags);
     RBASIC_SET_CLASS(obj, klass);
     return obj;

--- a/test/ruby/test_clone.rb
+++ b/test/ruby/test_clone.rb
@@ -73,6 +73,13 @@ class TestClone < Test::Unit::TestCase
     assert_equal(cloned_obj.instance_variable_get(:@a), 1)
   end
 
+  def test_proc_obj_id_flag_reset
+    # [Bug #20250]
+    proc = Proc.new { }
+    proc.object_id
+    proc.clone.object_id # Would crash with RUBY_DEBUG=1
+  end
+
   def test_user_flags
     assert_separately([], <<-EOS)
       #


### PR DESCRIPTION
[[Bug #20250]](https://bugs.ruby-lang.org/issues/20250)

We're seting up a new instance, so it never had an associated object_id.