### PR TITLE
More on auto-link

### DIFF
--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -173,14 +173,10 @@ Code that is a simple string should include the quote marks.
 In general, \RDoc's auto-linking should not be suppressed.
 For example, we should write `Array`, not `\Array`.
 
-We might consider whether to suppress when:
+Suppress when:
 
 - The word in question does not refer to a Ruby entity
   (e.g., some uses of _Class_ or _English_).
-- The reference is to the current class document
-  (e.g., _Array_ in the documentation for class `Array`).
-- The same reference is repeated many times
-  (e.g., _RDoc_ on this page).
 - The reference is to a class or module that users
   usually don't deal with, including these:
 

--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -178,7 +178,9 @@ However, suppress when the word in question:
 - Does not refer to a Ruby entity
   (e.g., some uses of _Class_ or _English_).
 - Refers to the current document
-  (e.g., _Array_ in the documentation for class `Array`).
+  (e.g., _Array_ in the documentation for class `Array`);
+  in that case, the word should be forced to
+  [monofont](rdoc-ref:RDoc::MarkupReference@Monofont).
 
 Most often, the name of a class, module, or method
 will be auto-linked:

--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -173,19 +173,11 @@ Code that is a simple string should include the quote marks.
 In general, \RDoc's auto-linking should not be suppressed.
 For example, we should write `Array`, not `\Array`.
 
-Suppress when:
-
-- The word in question does not refer to a Ruby entity
-  (e.g., some uses of _Class_ or _English_).
-- The reference is to a class or module that users
-  usually don't deal with, including these:
-
-    - \Class.
-    - \Method.
-    - \Module.
+However, suppress when the word in question does not refer to a Ruby entity
+(e.g., some uses of _Class_ or _English_).
 
 Most often, the name of a class, module, or method
-will be autolinked:
+will be auto-linked:
 
 - Array.
 - Enumerable.

--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -172,7 +172,6 @@ Code that is a simple string should include the quote marks.
 
 In general, \RDoc's auto-linking should not be suppressed.
 For example, we should write `Array`, not `\Array`.
-
 However, suppress when the word in question does not refer to a Ruby entity
 (e.g., some uses of _Class_ or _English_).
 

--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -171,9 +171,14 @@ Code that is a simple string should include the quote marks.
 ### Auto-Linking
 
 In general, \RDoc's auto-linking should not be suppressed.
-For example, we should write `Array`, not `\Array`.
-However, suppress when the word in question does not refer to a Ruby entity
-(e.g., some uses of _Class_ or _English_).
+For example, we should write `Array`, not `\Array`
+
+However, suppress when the word in question:
+
+- Does not refer to a Ruby entity
+  (e.g., some uses of _Class_ or _English_).
+- Refers to the current document
+  (e.g., _Array_ in the documentation for class `Array`).
 
 Most often, the name of a class, module, or method
 will be auto-linked:

--- a/doc/contributing/documentation_guide.md
+++ b/doc/contributing/documentation_guide.md
@@ -171,7 +171,7 @@ Code that is a simple string should include the quote marks.
 ### Auto-Linking
 
 In general, \RDoc's auto-linking should not be suppressed.
-For example, we should write `Array`, not `\Array`
+For example, we should write `Array`, not `\Array`.
 
 However, suppress when the word in question:
 


### PR DESCRIPTION
@nobu [suggests](https://github.com/ruby/ruby/pull/9842#discussion_r1481348817) that a reference to a class such as `IO` (even the local one) should be `+IO+` (to force monofont), not `\IO` (plain text).  In my view, if it's not plain text, it may as well be auto-linked (`IO`), since both forced monofont and auto-linking cause both the font and the background color to be changed.

Therefore I propose allowing auto-linking in almost all cases.

This proposed change does not imply that current docs should be revised for this purpose, but only that additions or revisions should consider this.