### PR TITLE
YJIT: Fix insufficient type guards

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1658,7 +1658,7 @@ fn guard_object_is_array(
     asm.cmp(flags_opnd, (RUBY_T_ARRAY as u64).into());
     asm.jne(Target::side_exit(counter));
 
-    if Type::UnknownHeap.diff(object_type) != TypeDiff::Incompatible {
+    if Type::TArray.diff(object_type) != TypeDiff::Incompatible {
         asm.ctx.upgrade_opnd_type(object_opnd, Type::TArray);
     }
 }
@@ -1690,7 +1690,7 @@ fn guard_object_is_hash(
     asm.cmp(flags_opnd, (RUBY_T_HASH as u64).into());
     asm.jne(Target::side_exit(counter));
 
-    if Type::UnknownHeap.diff(object_type) != TypeDiff::Incompatible {
+    if Type::THash.diff(object_type) != TypeDiff::Incompatible {
         asm.ctx.upgrade_opnd_type(object_opnd, Type::THash);
     }
 }
@@ -1722,7 +1722,7 @@ fn guard_object_is_string(
     asm.cmp(flags_reg, Opnd::UImm(RUBY_T_STRING as u64));
     asm.jne(Target::side_exit(counter));
 
-    if Type::UnknownHeap.diff(object_type) != TypeDiff::Incompatible {
+    if Type::TString.diff(object_type) != TypeDiff::Incompatible {
         asm.ctx.upgrade_opnd_type(object_opnd, Type::TString);
     }
 }


### PR DESCRIPTION
I think we copied `Type::UnknownHeap.diff(object_type)` from `guard_object_is_heap`, but the guarded type should match the one it's being upgraded to.