### PR TITLE
YJIT: Adjust the padding size of counts automatically

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -238,7 +238,7 @@ module RubyVM::YJIT
     private
 
     # Print stats and dump exit locations
-    def print_and_dump_stats
+    def print_and_dump_stats # :nodoc:
       if Primitive.rb_yjit_print_stats_p
         _print_stats
       end
@@ -395,8 +395,7 @@ module RubyVM::YJIT
 
       # Sort calls by decreasing frequency and keep the top N
       pairs = calls.map { |k,v| [k, v] }
-      pairs.sort_by! {|pair| pair[1] }
-      pairs.reverse!
+      pairs.sort_by! {|pair| -pair[1] }
       pairs = pairs[0...how_many]
 
       top_n_total = pairs.sum { |name, count| count }
@@ -405,9 +404,10 @@ module RubyVM::YJIT
 
       out.puts "Top-#{pairs.size} most frequent #{type} calls (#{"%.1f" % top_n_pct}% of #{type} calls):"
 
+      count_width = format_number(0, pairs[0][1]).length
       pairs.each do |name, count|
-        padded_count = format_number_pct(10, count, num_calls)
-        out.puts("#{padded_count}: #{name}")
+        padded_count = format_number_pct(count_width, count, num_calls)
+        out.puts("  #{padded_count}: #{name}")
       end
     end
 
@@ -429,10 +429,10 @@ module RubyVM::YJIT
 
         out.puts "Top-#{exits.size} most frequent exit ops (#{"%.1f" % top_n_exit_pct}% of exits):"
 
-        longest_insn_name_len = exits.max_by { |name, count| name.length }.first.length
+        count_width = format_number(0, exits[0][1]).length
         exits.each do |name, count|
-          padded_count = format_number_pct(10, count, total_exits)
-          out.puts("#{padded_count}: #{name}")
+          padded_count = format_number_pct(count_width, count, total_exits)
+          out.puts("  #{padded_count}: #{name}")
         end
       else
         out.puts "total_exits:           " + format_number(10, total_exits)
@@ -475,7 +475,7 @@ module RubyVM::YJIT
     end
 
     # Format large numbers with comma separators for readability
-    def format_number(pad, number)
+    def format_number(pad, number) # :nodoc:
       s = number.to_s
       i = s.index('.') || s.size
       s.insert(i -= 3, ',') while i > 3
@@ -483,7 +483,7 @@ module RubyVM::YJIT
     end
 
     # Format a number along with a percentage over a total value
-    def format_number_pct(pad, number, total)
+    def format_number_pct(pad, number, total) # :nodoc:
       padded_count = format_number(pad, number)
       percentage = number.fdiv(total) * 100
       formatted_pct = "%4.1f%%" % percentage


### PR DESCRIPTION
The format of https://github.com/ruby/ruby/pull/9906 was a bit off for some benchmarks and SFR that have large call counts, so this PR changes the padding size to be adjusted automatically.

I also did some minor refactoring and documentation fixes that I noticed.