### PR TITLE
YJIT: Prefer an overloaded cme if available

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2032,7 +2032,7 @@ vm_ccs_verify(struct rb_class_cc_entries *ccs, ID mid, VALUE klass)
 }
 #endif
 
-static const rb_callable_method_entry_t *check_overloaded_cme(const rb_callable_method_entry_t *cme, const struct rb_callinfo * const ci);
+const rb_callable_method_entry_t *rb_check_overloaded_cme(const rb_callable_method_entry_t *cme, const struct rb_callinfo * const ci);
 
 static const struct rb_callcache *
 vm_search_cc(const VALUE klass, const struct rb_callinfo * const ci)
@@ -2118,7 +2118,7 @@ vm_search_cc(const VALUE klass, const struct rb_callinfo * const ci)
         }
     }
 
-    cme = check_overloaded_cme(cme, ci);
+    cme = rb_check_overloaded_cme(cme, ci);
 
     const struct rb_callcache *cc = vm_cc_new(klass, cme, vm_call_general, cc_type_normal);
     vm_ccs_push(klass, ccs, ci, cc);

--- a/vm_method.c
+++ b/vm_method.c
@@ -1063,8 +1063,8 @@ get_overloaded_cme(const rb_callable_method_entry_t *cme)
     }
 }
 
-static const rb_callable_method_entry_t *
-check_overloaded_cme(const rb_callable_method_entry_t *cme, const struct rb_callinfo * const ci)
+const rb_callable_method_entry_t *
+rb_check_overloaded_cme(const rb_callable_method_entry_t *cme, const struct rb_callinfo * const ci)
 {
     if (UNLIKELY(cme->def->iseq_overload) &&
         (vm_ci_flag(ci) & (VM_CALL_ARGS_SIMPLE)) &&

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7679,6 +7679,10 @@ fn gen_send_general(
         return None;
     }
 
+    // Load an overloaded cme if applicable. See vm_search_cc().
+    // It allows you to use a faster ISEQ if possible.
+    cme = unsafe { rb_check_overloaded_cme(cme, ci) };
+
     let visi = unsafe { METHOD_ENTRY_VISI(cme) };
     match visi {
         METHOD_VISI_PUBLIC => {

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -112,6 +112,10 @@ pub use autogened::*;
 // Use bindgen for functions that are defined in headers or in yjit.c.
 #[cfg_attr(test, allow(unused))] // We don't link against C code when testing
 extern "C" {
+    pub fn rb_check_overloaded_cme(
+        me: *const rb_callable_method_entry_t,
+        ci: *const rb_callinfo,
+    ) -> *const rb_callable_method_entry_t;
     pub fn rb_hash_empty_p(hash: VALUE) -> VALUE;
     pub fn rb_vm_splat_array(flag: VALUE, ary: VALUE) -> VALUE;
     pub fn rb_vm_concat_array(ary1: VALUE, ary2st: VALUE) -> VALUE;


### PR DESCRIPTION
This PR adds support for overloaded cme. It allows `Array#first` and `Array#last` to be considered leaf.

Since https://github.com/ruby/ruby/pull/5112, ISEQs can be overloaded. `Array#first` and `Array#last` are one of such examples (https://github.com/ruby/ruby/pull/7486), and they are leaf only in the overloaded version.

It speeds up `rubykon` by 3%, which calls `Array#first` fairly frequently:

```
before: ruby 3.4.0dev (2024-02-10T00:23:17Z master ea91ab696e) +YJIT [x86_64-linux]
after: ruby 3.4.0dev (2024-02-10T01:13:04Z yjit-mandatory dae393743e) +YJIT [x86_64-linux]

-------  -----------  ----------  ----------  ----------  -------------  ------------
bench    before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
rubykon  8022.2       1.2         7818.6      1.0         1.02           1.03
-------  -----------  ----------  ----------  ----------  -------------  ------------
```