### PR TITLE
Fix moving embedded arrays across ractors

### DIFF
--- a/array.c
+++ b/array.c
@@ -741,6 +741,12 @@ rb_ary_new_capa(long capa)
 }
 
 VALUE
+rb_ary_new_capa_with_klass(VALUE klass, long capa)
+{
+    return ary_new(klass, capa);
+}
+
+VALUE
 rb_ary_new(void)
 {
     return rb_ary_new_capa(0);

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1121,6 +1121,20 @@ values = r.take
 values.join
 }
 
+# send embedded array with move: true
+assert_equal 'true', %q{
+r = Ractor.new {
+  inner_ary = receive
+  { equal: (inner_ary == ["",{},2,3,4,5,6]) }
+}
+ary = ["",{},2,3,4,5,6]
+r.send(ary, move: true)
+r_values = r.take
+[
+  r_values[:equal],
+].join(',')
+}
+
 # cvar in shareable-objects are not allowed to access from non-main Ractor
 assert_equal 'can not access class variables from non-main Ractors', %q{
   class C

--- a/include/ruby/internal/intern/array.h
+++ b/include/ruby/internal/intern/array.h
@@ -89,6 +89,11 @@ VALUE rb_ary_new(void);
 VALUE rb_ary_new_capa(long capa);
 
 /**
+ * Identical to rb_ary_new_capa(), except it additionally specifies a klass
+ */
+VALUE rb_ary_new_capa_with_klass(VALUE klass, long capa);
+
+/**
  * Constructs an array from the passed objects.
  *
  * @param[in]  n    Number of passed objects.


### PR DESCRIPTION
The array values must be copied to the new embedded array's space.

[Bug #20255]