### PR TITLE
proc.c: get rid of `CLONESETUP`

### DIFF
--- a/internal/object.h
+++ b/internal/object.h
@@ -16,6 +16,8 @@ VALUE rb_class_search_ancestor(VALUE klass, VALUE super);
 NORETURN(void rb_undefined_alloc(VALUE klass));
 double rb_num_to_dbl(VALUE val);
 VALUE rb_obj_dig(int argc, VALUE *argv, VALUE self, VALUE notfound);
+VALUE rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze);
+VALUE rb_obj_dup_setup(VALUE obj, VALUE dup);
 VALUE rb_immutable_obj_clone(int, VALUE *, VALUE);
 VALUE rb_check_convert_type_with_id(VALUE,int,const char*,ID);
 int rb_bool_expected(VALUE, const char *, int raise);

--- a/object.c
+++ b/object.c
@@ -454,15 +454,12 @@ immutable_obj_clone(VALUE obj, VALUE kwfreeze)
     return obj;
 }
 
-static VALUE
-mutable_obj_clone(VALUE obj, VALUE kwfreeze)
+VALUE
+rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze)
 {
-    VALUE clone, singleton;
     VALUE argv[2];
 
-    clone = rb_obj_alloc(rb_obj_class(obj));
-
-    singleton = rb_singleton_class_clone_and_attach(obj, clone);
+    VALUE singleton = rb_singleton_class_clone_and_attach(obj, clone);
     RBASIC_SET_CLASS(clone, singleton);
     if (FL_TEST(singleton, FL_SINGLETON)) {
         rb_singleton_class_attached(singleton, clone);
@@ -529,11 +526,27 @@ mutable_obj_clone(VALUE obj, VALUE kwfreeze)
     return clone;
 }
 
+static VALUE
+mutable_obj_clone(VALUE obj, VALUE kwfreeze)
+{
+    VALUE clone = rb_obj_alloc(rb_obj_class(obj));
+    return rb_obj_clone_setup(obj, clone, kwfreeze);
+}
+
 VALUE
 rb_obj_clone(VALUE obj)
 {
     if (special_object_p(obj)) return obj;
     return mutable_obj_clone(obj, Qnil);
+}
+
+VALUE
+rb_obj_dup_setup(VALUE obj, VALUE dup)
+{
+    init_copy(dup, obj);
+    rb_funcall(dup, id_init_dup, 1, obj);
+
+    return dup;
 }
 
 /*
@@ -584,10 +597,7 @@ rb_obj_dup(VALUE obj)
         return obj;
     }
     dup = rb_obj_alloc(rb_obj_class(obj));
-    init_copy(dup, obj);
-    rb_funcall(dup, id_init_dup, 1, obj);
-
-    return dup;
+    return rb_obj_dup_setup(obj, dup);
 }
 
 /*

--- a/spec/ruby/core/binding/clone_spec.rb
+++ b/spec/ruby/core/binding/clone_spec.rb
@@ -4,4 +4,10 @@ require_relative 'shared/clone'
 
 describe "Binding#clone" do
   it_behaves_like :binding_clone, :clone
+
+  it "preserves frozen status" do
+    bind = binding.freeze
+    bind.frozen?.should == true
+    bind.clone.frozen?.should == true
+  end
 end

--- a/spec/ruby/core/binding/dup_spec.rb
+++ b/spec/ruby/core/binding/dup_spec.rb
@@ -4,4 +4,10 @@ require_relative 'shared/clone'
 
 describe "Binding#dup" do
   it_behaves_like :binding_clone, :dup
+
+  it "resets frozen status" do
+    bind = binding.freeze
+    bind.frozen?.should == true
+    bind.dup.frozen?.should == false
+  end
 end

--- a/spec/ruby/core/binding/shared/clone.rb
+++ b/spec/ruby/core/binding/shared/clone.rb
@@ -31,4 +31,26 @@ describe :binding_clone, shared: true do
       b2.local_variable_defined?(:x).should == false
     end
   end
+
+  ruby_version_is "3.4" do
+    it "copies instance variables" do
+      @b1.instance_variable_set(:@ivar, 1)
+      cl = @b1.send(@method)
+      cl.instance_variables.should == [:@ivar]
+    end
+
+    it "copies the finalizer" do
+      code = <<-RUBY
+        obj = binding
+
+        ObjectSpace.define_finalizer(obj, Proc.new { STDOUT.write "finalized\n" })
+
+        obj.clone
+
+        exit 0
+      RUBY
+
+      ruby_exe(code).lines.sort.should == ["finalized\n", "finalized\n"]
+    end
+  end
 end

--- a/spec/ruby/core/method/clone_spec.rb
+++ b/spec/ruby/core/method/clone_spec.rb
@@ -1,14 +1,13 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
+require_relative 'shared/dup'
 
 describe "Method#clone" do
-  it "returns a copy of the method" do
-    m1 = MethodSpecs::Methods.new.method(:foo)
-    m2 = m1.clone
+  it_behaves_like :method_dup, :clone
 
-    m1.should == m2
-    m1.should_not equal(m2)
-
-    m1.call.should == m2.call
+  it "preserves frozen status" do
+    method = Object.new.method(:method)
+    method.freeze
+    method.frozen?.should == true
+    method.clone.frozen?.should == true
   end
 end

--- a/spec/ruby/core/method/dup_spec.rb
+++ b/spec/ruby/core/method/dup_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+require_relative 'shared/dup'
+
+describe "Method#dup" do
+  ruby_version_is "3.4" do
+    it_behaves_like :method_dup, :dup
+
+    it "resets frozen status" do
+      method = Object.new.method(:method)
+      method.freeze
+      method.frozen?.should == true
+      method.dup.frozen?.should == false
+    end
+  end
+end

--- a/spec/ruby/core/method/shared/dup.rb
+++ b/spec/ruby/core/method/shared/dup.rb
@@ -1,32 +1,23 @@
-describe :proc_dup, shared: true do
+describe :method_dup, shared: true do
   it "returns a copy of self" do
-    a = -> { "hello" }
+    a = Object.new.method(:method)
     b = a.send(@method)
 
+    a.should == b
     a.should_not equal(b)
-
-    a.call.should == b.call
-  end
-
-  ruby_version_is "3.2" do
-    it "returns an instance of subclass" do
-      cl = Class.new(Proc)
-
-      cl.new{}.send(@method).class.should == cl
-    end
   end
 
   ruby_version_is "3.4" do
     it "copies instance variables" do
-      proc = -> { "hello" }
-      proc.instance_variable_set(:@ivar, 1)
-      cl = proc.send(@method)
+      method = Object.new.method(:method)
+      method.instance_variable_set(:@ivar, 1)
+      cl = method.send(@method)
       cl.instance_variables.should == [:@ivar]
     end
 
     it "copies the finalizer" do
       code = <<-RUBY
-        obj = Proc.new { }
+        obj = Object.new.method(:method)
 
         ObjectSpace.define_finalizer(obj, Proc.new { STDOUT.write "finalized\n" })
 

--- a/spec/ruby/core/proc/clone_spec.rb
+++ b/spec/ruby/core/proc/clone_spec.rb
@@ -3,4 +3,13 @@ require_relative 'shared/dup'
 
 describe "Proc#clone" do
   it_behaves_like :proc_dup, :clone
+
+  ruby_bug "cloning a frozen proc is broken on Ruby 3.3", "3.3"..."3.4" do
+    it "preserves frozen status" do
+      proc = Proc.new { }
+      proc.freeze
+      proc.frozen?.should == true
+      proc.clone.frozen?.should == true
+    end
+  end
 end

--- a/spec/ruby/core/proc/dup_spec.rb
+++ b/spec/ruby/core/proc/dup_spec.rb
@@ -3,4 +3,11 @@ require_relative 'shared/dup'
 
 describe "Proc#dup" do
   it_behaves_like :proc_dup, :dup
+
+  it "resets frozen status" do
+    proc = Proc.new { }
+    proc.freeze
+    proc.frozen?.should == true
+    proc.dup.frozen?.should == false
+  end
 end

--- a/spec/ruby/core/unboundmethod/clone_spec.rb
+++ b/spec/ruby/core/unboundmethod/clone_spec.rb
@@ -1,12 +1,13 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
+require_relative 'shared/dup'
 
 describe "UnboundMethod#clone" do
-  it "returns a copy of the UnboundMethod" do
-    um1 = UnboundMethodSpecs::Methods.instance_method(:foo)
-    um2 = um1.clone
+  it_behaves_like :unboundmethod_dup, :clone
 
-    (um1 == um2).should == true
-    um1.bind(UnboundMethodSpecs::Methods.new).call.should == um2.bind(UnboundMethodSpecs::Methods.new).call
+  it "preserves frozen status" do
+    method = Class.instance_method(:instance_method)
+    method.freeze
+    method.frozen?.should == true
+    method.clone.frozen?.should == true
   end
 end

--- a/spec/ruby/core/unboundmethod/dup_spec.rb
+++ b/spec/ruby/core/unboundmethod/dup_spec.rb
@@ -1,0 +1,15 @@
+require_relative '../../spec_helper'
+require_relative 'shared/dup'
+
+describe "UnboundMethod#dup" do
+  ruby_version_is "3.4" do
+    it_behaves_like :unboundmethod_dup, :dup
+
+    it "resets frozen status" do
+      method = Class.instance_method(:instance_method)
+      method.freeze
+      method.frozen?.should == true
+      method.dup.frozen?.should == false
+    end
+  end
+end

--- a/spec/ruby/core/unboundmethod/shared/dup.rb
+++ b/spec/ruby/core/unboundmethod/shared/dup.rb
@@ -1,32 +1,23 @@
-describe :proc_dup, shared: true do
+describe :unboundmethod_dup, shared: true do
   it "returns a copy of self" do
-    a = -> { "hello" }
+    a = Class.instance_method(:instance_method)
     b = a.send(@method)
 
+    a.should == b
     a.should_not equal(b)
-
-    a.call.should == b.call
-  end
-
-  ruby_version_is "3.2" do
-    it "returns an instance of subclass" do
-      cl = Class.new(Proc)
-
-      cl.new{}.send(@method).class.should == cl
-    end
   end
 
   ruby_version_is "3.4" do
     it "copies instance variables" do
-      proc = -> { "hello" }
-      proc.instance_variable_set(:@ivar, 1)
-      cl = proc.send(@method)
+      method = Class.instance_method(:instance_method)
+      method.instance_variable_set(:@ivar, 1)
+      cl = method.send(@method)
       cl.instance_variables.should == [:@ivar]
     end
 
     it "copies the finalizer" do
       code = <<-RUBY
-        obj = Proc.new { }
+        obj = Class.instance_method(:instance_method)
 
         ObjectSpace.define_finalizer(obj, Proc.new { STDOUT.write "finalized\n" })
 


### PR DESCRIPTION
[[Bug #20253]](https://bugs.ruby-lang.org/issues/20253)

All the way down to Ruby 1.9, `Proc`, `Method`, `UnboundMethod` and `Binding` always had their own specific clone and dup routine.

This caused various discrepancies with how other objects behave on `dup` and `clone. [Bug #20250], [Bug #20253].

This commit get rid of `CLONESETUP` and use the the same codepath as all other types, so ensure consistency.

NB: It's still not accepting the `freeze` keyword argument on `clone`.

cc @peterzhu2118 