### PR TITLE
Use RJIT for make test-spec

### DIFF
--- a/.github/workflows/rjit.yml
+++ b/.github/workflows/rjit.yml
@@ -95,11 +95,12 @@ jobs:
 
       - name: make test-spec
         run: |
-          $SETARCH make -s test-spec RUN_OPTS="$RUN_OPTS"
+          $SETARCH make -s test-spec RUN_OPTS="$RUN_OPTS" SPECOPTS="$SPECOPTS"
         timeout-minutes: 10
         env:
           GNUMAKEFLAGS: ''
           RUN_OPTS: ${{ matrix.run_opts }}
+          SPECOPTS: '-T --rjit-call-threshold=1'
 
       - uses: ./.github/actions/slack
         with:


### PR DESCRIPTION
Previously only the test runner was using RJIT. This switches the Ruby that is being tested to use RJIT. cc @k0kubun 

I just noticed this because of prism trying to run the specs.