### PR TITLE
Enable redefinition check for rbinc methods

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -1787,7 +1787,12 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
 
     Init_ext(); /* load statically linked extensions before rubygems */
     Init_extra_exts();
+
+    GET_VM()->running = 0;
     rb_call_builtin_inits();
+    GET_VM()->running = 1;
+    memset(ruby_vm_redefined_flag, 0, sizeof(ruby_vm_redefined_flag));
+
     ruby_init_prelude();
 
     // Initialize JITs after prelude because JITing prelude is typically not optimal.

--- a/vm_method.c
+++ b/vm_method.c
@@ -522,6 +522,8 @@ rb_method_definition_set(const rb_method_entry_t *me, rb_method_definition_t *de
     rb_method_definition_release(me->def);
     *(rb_method_definition_t **)&me->def = method_definition_addref(def, METHOD_ENTRY_COMPLEMENTED(me));
 
+    if (!ruby_running) add_opt_method_entry(me);
+
     if (opts != NULL) {
         switch (def->type) {
           case VM_METHOD_TYPE_ISEQ:


### PR DESCRIPTION
This is just a cherry pick of @nobu's commit.

This commit allows us to detect redefinition (BOP checking) for methods that have been defined in `.rbinc` files. Previously, we could only detect method redefinition for C methods.