### PR TITLE
[PRISM] Provide runtime flag for prism in iseq

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -253,6 +253,11 @@ ast_s_of(rb_execution_context_t *ec, VALUE module, VALUE body, VALUE keep_script
     if (!iseq) {
         return Qnil;
     }
+
+    if (ISEQ_BODY(iseq)->prism) {
+        rb_raise(rb_eRuntimeError, "cannot get AST for ISEQ compiled by prism");
+    }
+
     lines = ISEQ_BODY(iseq)->variable.script_lines;
 
     VALUE path = rb_iseq_path(iseq);

--- a/compile.c
+++ b/compile.c
@@ -12740,6 +12740,7 @@ ibf_dump_iseq_each(struct ibf_dump *dump, const rb_iseq_t *iseq)
     ibf_dump_write_small_value(dump, body->ci_size);
     ibf_dump_write_small_value(dump, body->stack_max);
     ibf_dump_write_small_value(dump, body->builtin_attrs);
+    ibf_dump_write_small_value(dump, body->prism ? 1 : 0);
 
 #undef IBF_BODY_OFFSET
 
@@ -12852,6 +12853,7 @@ ibf_load_iseq_each(struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t offset)
     const unsigned int ci_size = (unsigned int)ibf_load_small_value(load, &reading_pos);
     const unsigned int stack_max = (unsigned int)ibf_load_small_value(load, &reading_pos);
     const unsigned int builtin_attrs = (unsigned int)ibf_load_small_value(load, &reading_pos);
+    const bool prism = (bool)ibf_load_small_value(load, &reading_pos);
 
     // setup fname and dummy frame
     VALUE path = ibf_load_object(load, location_pathobj_index);
@@ -12926,6 +12928,7 @@ ibf_load_iseq_each(struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t offset)
     load_body->location.code_location.end_pos.lineno = location_code_location_end_pos_lineno;
     load_body->location.code_location.end_pos.column = location_code_location_end_pos_column;
     load_body->builtin_attrs = builtin_attrs;
+    load_body->prism = prism;
 
     load_body->ivc_size             = ivc_size;
     load_body->icvarc_size          = icvarc_size;

--- a/iseq.c
+++ b/iseq.c
@@ -999,6 +999,8 @@ pm_iseq_new_with_opt(pm_scope_node_t *node, VALUE name, VALUE path, VALUE realpa
                      enum rb_iseq_type type, const rb_compile_option_t *option)
 {
     rb_iseq_t *iseq = iseq_alloc();
+    ISEQ_BODY(iseq)->prism = true;
+
     if (!option) option = &COMPILE_OPTION_DEFAULT;
 
     pm_location_t *location = &node->base.location;
@@ -1140,6 +1142,10 @@ iseq_load(VALUE data, const rb_iseq_t *parent, VALUE opt)
         tmp_loc.beg_pos.column = NUM2INT(rb_ary_entry(code_location, 1));
         tmp_loc.end_pos.lineno = NUM2INT(rb_ary_entry(code_location, 2));
         tmp_loc.end_pos.column = NUM2INT(rb_ary_entry(code_location, 3));
+    }
+
+    if (RTEST(rb_hash_aref(misc, ID2SYM(rb_intern("prism"))))) {
+        ISEQ_BODY(iseq)->prism = true;
     }
 
     make_compile_option(&option, opt);
@@ -3374,6 +3380,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
 #ifdef USE_ISEQ_NODE_ID
     rb_hash_aset(misc, ID2SYM(rb_intern("node_ids")), node_ids);
 #endif
+    rb_hash_aset(misc, ID2SYM(rb_intern("prism")), iseq_body->prism ? Qtrue : Qfalse);
 
     /*
      * [:magic, :major_version, :minor_version, :format_type, :misc,

--- a/rjit_c.rb
+++ b/rjit_c.rb
@@ -1121,6 +1121,7 @@ module RubyVM::RJIT # :nodoc: all
       ci_size: [CType::Immediate.parse("unsigned int"), Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_constant_body *)NULL)), ci_size)")],
       stack_max: [CType::Immediate.parse("unsigned int"), Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_constant_body *)NULL)), stack_max)")],
       builtin_attrs: [CType::Immediate.parse("unsigned int"), Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_constant_body *)NULL)), builtin_attrs)")],
+      prism: [self._Bool, Primitive.cexpr!("OFFSETOF((*((struct rb_iseq_constant_body *)NULL)), prism)")],
       mark_bits: [CType::Union.new(
         "", Primitive.cexpr!("SIZEOF(((struct rb_iseq_constant_body *)NULL)->mark_bits)"),
         list: CType::Pointer.new { self.iseq_bits_t },
@@ -1569,6 +1570,10 @@ module RubyVM::RJIT # :nodoc: all
     CType::Stub.new(:rb_snum_t)
   end
 
+  def C._Bool
+    CType::Bool.new
+  end
+
   def C.iseq_bits_t
     CType::Stub.new(:iseq_bits_t)
   end
@@ -1595,10 +1600,6 @@ module RubyVM::RJIT # :nodoc: all
 
   def C.rb_method_refined_t
     CType::Stub.new(:rb_method_refined_t)
-  end
-
-  def C._Bool
-    CType::Bool.new
   end
 
   def C.redblack_node_t

--- a/vm_core.h
+++ b/vm_core.h
@@ -496,6 +496,8 @@ struct rb_iseq_constant_body {
 
     unsigned int builtin_attrs; // Union of rb_builtin_attr
 
+    bool prism; // ISEQ was generated from prism compiler
+
     union {
         iseq_bits_t * list; /* Find references for GC */
         iseq_bits_t single;


### PR DESCRIPTION
The reason we want this is that we want to store prism-specific node ids in the iseq in order to support error highlight. So we need to be able to map from the compiler that produced the iseq to the node ids that are contained in the iseq.

This adds a single bool to `rb_iseq_constant_body` and adds `:prism` to the `misc` hash in the serialized array form of an iseq.

Note that this PR includes https://github.com/ruby/error_highlight/pull/41.