### PR TITLE
Specialize String#byteslice(a, b)

### DIFF
--- a/internal/string.h
+++ b/internal/string.h
@@ -45,6 +45,7 @@ void rb_str_make_independent(VALUE str);
 int rb_enc_str_coderange_scan(VALUE str, rb_encoding *enc);
 int rb_ascii8bit_appendable_encoding_index(rb_encoding *enc, unsigned int code);
 VALUE rb_str_include(VALUE str, VALUE arg);
+VALUE rb_str_byte_substr(VALUE str, VALUE beg, VALUE len);
 
 static inline bool STR_EMBED_P(VALUE str);
 static inline bool STR_SHARED_P(VALUE str);

--- a/string.c
+++ b/string.c
@@ -6274,6 +6274,12 @@ str_byte_substr(VALUE str, long beg, long len, int empty)
     return str2;
 }
 
+VALUE
+rb_str_byte_substr(VALUE str, VALUE beg, VALUE len)
+{
+    return str_byte_substr(str, NUM2LONG(beg), NUM2LONG(len), TRUE);
+}
+
 static VALUE
 str_byte_aref(VALUE str, VALUE indx)
 {

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -224,6 +224,7 @@ fn main() {
         .allowlist_function("rb_ec_str_resurrect")
         .allowlist_function("rb_str_concat_literals")
         .allowlist_function("rb_obj_as_string_result")
+        .allowlist_function("rb_str_byte_substr")
 
         // From include/ruby/internal/intern/parse.h
         .allowlist_function("rb_backref_get")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5329,7 +5329,6 @@ fn jit_rb_str_byteslice(
     let ret_opnd = asm.ccall(rb_str_byte_substr as *const u8, vec![recv, beg, len]);
     asm.stack_pop(3);
 
-    // Can either return a FIXNUM or nil
     let out_opnd = asm.stack_push(Type::TString);
     asm.mov(out_opnd, ret_opnd);
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1049,6 +1049,7 @@ extern "C" {
     pub fn rb_gvar_set(arg1: ID, arg2: VALUE) -> VALUE;
     pub fn rb_ensure_iv_list_size(obj: VALUE, len: u32, newsize: u32);
     pub fn rb_vm_barrier();
+    pub fn rb_str_byte_substr(str_: VALUE, beg: VALUE, len: VALUE) -> VALUE;
     pub fn rb_obj_as_string_result(str_: VALUE, obj: VALUE) -> VALUE;
     pub fn rb_str_concat_literals(num: usize, strary: *const VALUE) -> VALUE;
     pub fn rb_ec_str_resurrect(ec: *mut rb_execution_context_struct, str_: VALUE) -> VALUE;


### PR DESCRIPTION
This adds a specialization for String#byteslice when there are two parameters.

This makes our protobuf parser go from 5.84x slower to 5.33x slower

```
Comparison:
decode upstream (53738 bytes):     7228.5 i/s
decode protobuff (53738 bytes):     1236.8 i/s - 5.84x  slower

Comparison:
decode upstream (53738 bytes):     7024.8 i/s
decode protobuff (53738 bytes):     1318.5 i/s - 5.33x  slower
```