### PR TITLE
extract-gems before nmake in Visual Studio workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -184,8 +184,6 @@ jobs:
       - run: nmake test
         timeout-minutes: 5
 
-      - run: nmake install
-
       - run: nmake test-spec
         timeout-minutes: 10
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -179,6 +179,10 @@ jobs:
 
       - run: nmake extract-extlibs
 
+      # On all other platforms, test-spec depending on extract-gems (in common.mk) is enough.
+      # But not for this Visual Studio workflow. So here we extract gems before building.
+      - run: nmake extract-gems
+
       - run: nmake
 
       - run: nmake test


### PR DESCRIPTION
* BTW this workflow is the only one doing extract-extlibs before building.
  It seems building with Visual Studio and nmake has significant differences.
* https://github.com/ruby/ruby/blob/master/doc/windows.md#how-to-compile-and-install mentions to `nmake up` which would also solve this.