### PR TITLE
YJIT: String#getbyte codegen

### DIFF
--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -722,6 +722,9 @@ mod manual_defs {
     pub const RUBY_OFFSET_RSTRUCT_AS_HEAP_PTR: i32 = 24; // struct RStruct, subfield "as.heap.ptr"
     pub const RUBY_OFFSET_RSTRUCT_AS_ARY: i32 = 16; // struct RStruct, subfield "as.ary"
 
+    pub const RUBY_OFFSET_RSTRING_AS_HEAP_PTR: i32 = 24; // struct RString, subfield "as.heap.ptr"
+    pub const RUBY_OFFSET_RSTRING_AS_ARY: i32 = 24; // struct RString, subfield "as.embed.ary"
+
     // Constants from rb_control_frame_t vm_core.h
     pub const RUBY_OFFSET_CFP_PC: i32 = 0;
     pub const RUBY_OFFSET_CFP_SP: i32 = 8;

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -546,15 +546,9 @@ make_counters! {
 
     objtostring_not_string,
 
-
-
     getbyte_idx_not_fixnum,
     getbyte_idx_negative,
     getbyte_idx_out_of_bounds,
-
-
-
-
 
     splatkw_not_hash,
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -546,6 +546,16 @@ make_counters! {
 
     objtostring_not_string,
 
+
+
+    getbyte_idx_not_fixnum,
+    getbyte_idx_negative,
+    getbyte_idx_out_of_bounds,
+
+
+
+
+
     splatkw_not_hash,
 
     binding_allocations,


### PR DESCRIPTION
Right now we seem to be missing a load with zero extension instruction to make this work.