### PR TITLE
Fix use-after-move in Symbol#inspect

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -7358,8 +7358,10 @@ gc_mark_children(rb_objspace_t *objspace, VALUE obj)
       case T_FLOAT:
       case T_BIGNUM:
       case T_SYMBOL:
-        /* Not immediates, but does not have references and singleton
-         * class */
+        /* Not immediates, but does not have references and singleton class.
+         *
+         * RSYMBOL(obj)->fstr intentionally not marked. See log for 96815f1e
+         * ("symbol.c: remove rb_gc_mark_symbols()") */
         return;
 
       case T_NIL:

--- a/string.c
+++ b/string.c
@@ -11740,11 +11740,13 @@ sym_inspect(VALUE sym)
     }
     else {
         rb_encoding *enc = STR_ENC_GET(str);
-
         VALUE orig_str = str;
-        RSTRING_GETMEM(orig_str, ptr, len);
 
+        len = RSTRING_LEN(orig_str);
         str = rb_enc_str_new(0, len + 1, enc);
+
+        // Get data pointer after allocation
+        ptr = RSTRING_PTR(orig_str);
         dest = RSTRING_PTR(str);
         memcpy(dest + 1, ptr, len);
 


### PR DESCRIPTION
The allocation could re-embed `orig_str` and invalidate the data
pointer from RSTRING_GETMEM() if the string is embedded.

Found on CI, where the test introduced in https://github.com/ruby/ruby/commit/7002e776944ddfd362cea253d18d02bc250fe9f7 ("Fix
Symbol#inspect for GC compaction") recently failed.

See: <https://github.com/ruby/ruby/actions/runs/7880657560/job/21503019659>

cc @peterzhu2118 