### PR TITLE
[Feature #20187] Skip examples for bundled gems at Ruby 3.4

### DIFF
--- a/spec/default.mspec
+++ b/spec/default.mspec
@@ -4,6 +4,9 @@ if (opt = ENV["RUBYOPT"]) and (opt = opt.dup).sub!(/(?:\A|\s)-w(?=\z|\s)/, '')
   ENV["RUBYOPT"] = opt
 end
 
+# Disable to run for bundled gems
+ENV["GEM_SKIP"] = ENV["GEM_HOME"] = ENV["GEM_PATH"] = "".freeze
+
 # Enable leakcheckers by ruby/mspec
 ENV["CHECK_LEAKS"] ||= "true"
 

--- a/spec/ruby/core/integer/coerce_spec.rb
+++ b/spec/ruby/core/integer/coerce_spec.rb
@@ -1,104 +1,107 @@
 require_relative '../../spec_helper'
 
-require 'bigdecimal'
+ruby_version_is ""..."3.4" do
 
-describe "Integer#coerce" do
-  context "fixnum" do
-    describe "when given a Fixnum" do
-      it "returns an array containing two Fixnums" do
-        1.coerce(2).should == [2, 1]
-        1.coerce(2).map { |i| i.class }.should == [Integer, Integer]
+  require 'bigdecimal'
+
+  describe "Integer#coerce" do
+    context "fixnum" do
+      describe "when given a Fixnum" do
+        it "returns an array containing two Fixnums" do
+          1.coerce(2).should == [2, 1]
+          1.coerce(2).map { |i| i.class }.should == [Integer, Integer]
+        end
+      end
+
+      describe "when given a String" do
+        it "raises an ArgumentError when trying to coerce with a non-number String" do
+          -> { 1.coerce(":)") }.should raise_error(ArgumentError)
+        end
+
+        it "returns  an array containing two Floats" do
+          1.coerce("2").should == [2.0, 1.0]
+          1.coerce("-2").should == [-2.0, 1.0]
+        end
+      end
+
+      it "raises a TypeError when trying to coerce with nil" do
+        -> { 1.coerce(nil) }.should raise_error(TypeError)
+      end
+
+      it "tries to convert the given Object into a Float by using #to_f" do
+        (obj = mock('1.0')).should_receive(:to_f).and_return(1.0)
+        2.coerce(obj).should == [1.0, 2.0]
+
+        (obj = mock('0')).should_receive(:to_f).and_return('0')
+        -> { 2.coerce(obj).should == [1.0, 2.0] }.should raise_error(TypeError)
+      end
+
+      it "raises a TypeError when given an Object that does not respond to #to_f" do
+        -> { 1.coerce(mock('x'))  }.should raise_error(TypeError)
+        -> { 1.coerce(1..4)       }.should raise_error(TypeError)
+        -> { 1.coerce(:test)      }.should raise_error(TypeError)
       end
     end
 
-    describe "when given a String" do
-      it "raises an ArgumentError when trying to coerce with a non-number String" do
-        -> { 1.coerce(":)") }.should raise_error(ArgumentError)
+    context "bignum" do
+      it "coerces other to a Bignum and returns [other, self] when passed a Fixnum" do
+        a = bignum_value
+        ary = a.coerce(2)
+
+        ary[0].should be_kind_of(Integer)
+        ary[1].should be_kind_of(Integer)
+        ary.should == [2, a]
       end
 
-      it "returns  an array containing two Floats" do
-        1.coerce("2").should == [2.0, 1.0]
-        1.coerce("-2").should == [-2.0, 1.0]
+      it "returns [other, self] when passed a Bignum" do
+        a = bignum_value
+        b = bignum_value
+        ary = a.coerce(b)
+
+        ary[0].should be_kind_of(Integer)
+        ary[1].should be_kind_of(Integer)
+        ary.should == [b, a]
+      end
+
+      it "raises a TypeError when not passed a Fixnum or Bignum" do
+        a = bignum_value
+
+        -> { a.coerce(nil)         }.should raise_error(TypeError)
+        -> { a.coerce(mock('str')) }.should raise_error(TypeError)
+        -> { a.coerce(1..4)        }.should raise_error(TypeError)
+        -> { a.coerce(:test)       }.should raise_error(TypeError)
+      end
+
+      it "coerces both values to Floats and returns [other, self] when passed a Float" do
+        a = bignum_value
+        a.coerce(1.2).should == [1.2, a.to_f]
+      end
+
+      it "coerces both values to Floats and returns [other, self] when passed a String" do
+        a = bignum_value
+        a.coerce("123").should == [123.0, a.to_f]
+      end
+
+      it "calls #to_f to coerce other to a Float" do
+        b = mock("bignum value")
+        b.should_receive(:to_f).and_return(1.2)
+
+        a = bignum_value
+        ary = a.coerce(b)
+
+        ary.should == [1.2, a.to_f]
       end
     end
 
-    it "raises a TypeError when trying to coerce with nil" do
-      -> { 1.coerce(nil) }.should raise_error(TypeError)
+    context "bigdecimal" do
+      it "produces Floats" do
+        x, y = 3.coerce(BigDecimal("3.4"))
+        x.class.should == Float
+        x.should == 3.4
+        y.class.should == Float
+        y.should == 3.0
+      end
     end
 
-    it "tries to convert the given Object into a Float by using #to_f" do
-      (obj = mock('1.0')).should_receive(:to_f).and_return(1.0)
-      2.coerce(obj).should == [1.0, 2.0]
-
-      (obj = mock('0')).should_receive(:to_f).and_return('0')
-      -> { 2.coerce(obj).should == [1.0, 2.0] }.should raise_error(TypeError)
-    end
-
-    it "raises a TypeError when given an Object that does not respond to #to_f" do
-      -> { 1.coerce(mock('x'))  }.should raise_error(TypeError)
-      -> { 1.coerce(1..4)       }.should raise_error(TypeError)
-      -> { 1.coerce(:test)      }.should raise_error(TypeError)
-    end
   end
-
-  context "bignum" do
-    it "coerces other to a Bignum and returns [other, self] when passed a Fixnum" do
-      a = bignum_value
-      ary = a.coerce(2)
-
-      ary[0].should be_kind_of(Integer)
-      ary[1].should be_kind_of(Integer)
-      ary.should == [2, a]
-    end
-
-    it "returns [other, self] when passed a Bignum" do
-      a = bignum_value
-      b = bignum_value
-      ary = a.coerce(b)
-
-      ary[0].should be_kind_of(Integer)
-      ary[1].should be_kind_of(Integer)
-      ary.should == [b, a]
-    end
-
-    it "raises a TypeError when not passed a Fixnum or Bignum" do
-      a = bignum_value
-
-      -> { a.coerce(nil)         }.should raise_error(TypeError)
-      -> { a.coerce(mock('str')) }.should raise_error(TypeError)
-      -> { a.coerce(1..4)        }.should raise_error(TypeError)
-      -> { a.coerce(:test)       }.should raise_error(TypeError)
-    end
-
-    it "coerces both values to Floats and returns [other, self] when passed a Float" do
-      a = bignum_value
-      a.coerce(1.2).should == [1.2, a.to_f]
-    end
-
-    it "coerces both values to Floats and returns [other, self] when passed a String" do
-      a = bignum_value
-      a.coerce("123").should == [123.0, a.to_f]
-    end
-
-    it "calls #to_f to coerce other to a Float" do
-      b = mock("bignum value")
-      b.should_receive(:to_f).and_return(1.2)
-
-      a = bignum_value
-      ary = a.coerce(b)
-
-      ary.should == [1.2, a.to_f]
-    end
-  end
-
-  context "bigdecimal" do
-    it "produces Floats" do
-      x, y = 3.coerce(BigDecimal("3.4"))
-      x.class.should == Float
-      x.should == 3.4
-      y.class.should == Float
-      y.should == 3.0
-    end
-  end
-
 end

--- a/spec/ruby/core/rational/coerce_spec.rb
+++ b/spec/ruby/core/rational/coerce_spec.rb
@@ -1,6 +1,9 @@
 require_relative "../../spec_helper"
-require_relative '../../shared/rational/coerce'
 
-describe "Rational#coerce" do
-  it_behaves_like :rational_coerce, :coerce
+ruby_version_is ""..."3.4" do
+  require_relative '../../shared/rational/coerce'
+
+  describe "Rational#coerce" do
+    it_behaves_like :rational_coerce, :coerce
+  end
 end

--- a/spec/ruby/core/time/at_spec.rb
+++ b/spec/ruby/core/time/at_spec.rb
@@ -32,10 +32,12 @@ describe "Time.at" do
       t2.nsec.should == t.nsec
     end
 
-    describe "passed BigDecimal" do
-      it "doesn't round input value" do
-        require 'bigdecimal'
-        Time.at(BigDecimal('1.1')).to_f.should == 1.1
+    ruby_version_is ""..."3.4" do
+      describe "passed BigDecimal" do
+        it "doesn't round input value" do
+          require 'bigdecimal'
+          Time.at(BigDecimal('1.1')).to_f.should == 1.1
+        end
       end
     end
 

--- a/spec/ruby/library/abbrev/abbrev_spec.rb
+++ b/spec/ruby/library/abbrev/abbrev_spec.rb
@@ -1,31 +1,34 @@
 require_relative '../../spec_helper'
-require 'abbrev'
 
-#test both Abbrev.abbrev and Array#abbrev in
-#the same manner, as they're more or less aliases
-#of one another
+ruby_version_is ""..."3.4" do
+  require 'abbrev'
 
-[["Abbrev.abbrev", -> a { Abbrev.abbrev(a)}],
- ["Array#abbrev", -> a { a.abbrev}]
-].each do |(name, func)|
+  #test both Abbrev.abbrev and Array#abbrev in
+  #the same manner, as they're more or less aliases
+  #of one another
 
-  describe name do
-    it "returns a hash of all unambiguous abbreviations of the array of strings passed in" do
-      func.call(['ruby', 'rules']).should == {"rub" => "ruby",
-                                       "ruby" => "ruby",
-                                       "rul" => "rules",
-                                       "rule" => "rules",
-                                       "rules" => "rules"}
+  [["Abbrev.abbrev", -> a { Abbrev.abbrev(a)}],
+   ["Array#abbrev", -> a { a.abbrev}]
+  ].each do |(name, func)|
 
-      func.call(["car", "cone"]).should == {"ca" => "car",
-                                       "car" => "car",
-                                       "co" => "cone",
-                                       "con" => "cone",
-                                       "cone" => "cone"}
-    end
+    describe name do
+      it "returns a hash of all unambiguous abbreviations of the array of strings passed in" do
+        func.call(['ruby', 'rules']).should == {"rub" => "ruby",
+                                         "ruby" => "ruby",
+                                         "rul" => "rules",
+                                         "rule" => "rules",
+                                         "rules" => "rules"}
 
-    it "returns an empty hash when called on an empty array" do
-      func.call([]).should == {}
+        func.call(["car", "cone"]).should == {"ca" => "car",
+                                         "car" => "car",
+                                         "co" => "cone",
+                                         "con" => "cone",
+                                         "cone" => "cone"}
+      end
+
+      it "returns an empty hash when called on an empty array" do
+        func.call([]).should == {}
+      end
     end
   end
 end

--- a/spec/ruby/library/base64/decode64_spec.rb
+++ b/spec/ruby/library/base64/decode64_spec.rb
@@ -1,29 +1,32 @@
 require_relative '../../spec_helper'
 
-require 'base64'
+ruby_version_is ""..."3.4" do
 
-describe "Base64#decode64" do
-  it "returns the Base64-decoded version of the given string" do
-    Base64.decode64("U2VuZCByZWluZm9yY2VtZW50cw==\n").should == "Send reinforcements"
-  end
+  require 'base64'
 
-  it "returns the Base64-decoded version of the given shared string" do
-    Base64.decode64("base64: U2VuZCByZWluZm9yY2VtZW50cw==\n".split(" ").last).should == "Send reinforcements"
-  end
+  describe "Base64#decode64" do
+    it "returns the Base64-decoded version of the given string" do
+      Base64.decode64("U2VuZCByZWluZm9yY2VtZW50cw==\n").should == "Send reinforcements"
+    end
 
-  it "returns the Base64-decoded version of the given string with wrong padding" do
-    Base64.decode64("XU2VuZCByZWluZm9yY2VtZW50cw===").should == "]M\x95\xB9\x90\x81\xC9\x95\xA5\xB9\x99\xBD\xC9\x8D\x95\xB5\x95\xB9\xD1\xCC".b
-  end
+    it "returns the Base64-decoded version of the given shared string" do
+      Base64.decode64("base64: U2VuZCByZWluZm9yY2VtZW50cw==\n".split(" ").last).should == "Send reinforcements"
+    end
 
-  it "returns the Base64-decoded version of the given string that contains an invalid character" do
-    Base64.decode64("%3D").should == "\xDC".b
-  end
+    it "returns the Base64-decoded version of the given string with wrong padding" do
+      Base64.decode64("XU2VuZCByZWluZm9yY2VtZW50cw===").should == "]M\x95\xB9\x90\x81\xC9\x95\xA5\xB9\x99\xBD\xC9\x8D\x95\xB5\x95\xB9\xD1\xCC".b
+    end
 
-  it "returns a binary encoded string" do
-    Base64.decode64("SEk=").encoding.should == Encoding::BINARY
-  end
+    it "returns the Base64-decoded version of the given string that contains an invalid character" do
+      Base64.decode64("%3D").should == "\xDC".b
+    end
 
-  it "decodes without padding suffix ==" do
-    Base64.decode64("eyJrZXkiOnsibiI6InR0dCJ9fQ").should == "{\"key\":{\"n\":\"ttt\"}}"
+    it "returns a binary encoded string" do
+      Base64.decode64("SEk=").encoding.should == Encoding::BINARY
+    end
+
+    it "decodes without padding suffix ==" do
+      Base64.decode64("eyJrZXkiOnsibiI6InR0dCJ9fQ").should == "{\"key\":{\"n\":\"ttt\"}}"
+    end
   end
 end

--- a/spec/ruby/library/base64/encode64_spec.rb
+++ b/spec/ruby/library/base64/encode64_spec.rb
@@ -1,23 +1,26 @@
 require_relative '../../spec_helper'
 
-require 'base64'
+ruby_version_is ""..."3.4" do
 
-describe "Base64#encode64" do
-  it "returns the Base64-encoded version of the given string" do
-    Base64.encode64("Now is the time for all good coders\nto learn Ruby").should ==
-      "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g\nUnVieQ==\n"
-  end
+  require 'base64'
 
-  it "returns the Base64-encoded version of the given string" do
-    Base64.encode64('Send reinforcements').should == "U2VuZCByZWluZm9yY2VtZW50cw==\n"
-  end
+  describe "Base64#encode64" do
+    it "returns the Base64-encoded version of the given string" do
+      Base64.encode64("Now is the time for all good coders\nto learn Ruby").should ==
+        "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4g\nUnVieQ==\n"
+    end
 
-  it "returns the Base64-encoded version of the given shared string" do
-    Base64.encode64("Now is the time for all good coders\nto learn Ruby".split("\n").last).should ==
-      "dG8gbGVhcm4gUnVieQ==\n"
-  end
+    it "returns the Base64-encoded version of the given string" do
+      Base64.encode64('Send reinforcements').should == "U2VuZCByZWluZm9yY2VtZW50cw==\n"
+    end
 
-  it "returns a US_ASCII encoded string" do
-    Base64.encode64("HI").encoding.should == Encoding::US_ASCII
+    it "returns the Base64-encoded version of the given shared string" do
+      Base64.encode64("Now is the time for all good coders\nto learn Ruby".split("\n").last).should ==
+        "dG8gbGVhcm4gUnVieQ==\n"
+    end
+
+    it "returns a US_ASCII encoded string" do
+      Base64.encode64("HI").encoding.should == Encoding::US_ASCII
+    end
   end
 end

--- a/spec/ruby/library/base64/strict_decode64_spec.rb
+++ b/spec/ruby/library/base64/strict_decode64_spec.rb
@@ -1,41 +1,44 @@
 require_relative '../../spec_helper'
 
-require 'base64'
+ruby_version_is ""..."3.4" do
 
-describe "Base64#strict_decode64" do
-  it "returns the Base64-decoded version of the given string" do
-    Base64.strict_decode64("U2VuZCByZWluZm9yY2VtZW50cw==").should == "Send reinforcements"
-  end
+  require 'base64'
 
-  it "returns the Base64-decoded version of the given shared string" do
-    Base64.strict_decode64("base64: U2VuZCByZWluZm9yY2VtZW50cw==".split(" ").last).should == "Send reinforcements"
-  end
+  describe "Base64#strict_decode64" do
+    it "returns the Base64-decoded version of the given string" do
+      Base64.strict_decode64("U2VuZCByZWluZm9yY2VtZW50cw==").should == "Send reinforcements"
+    end
 
-  it "raises ArgumentError when the given string contains CR" do
-    -> do
-      Base64.strict_decode64("U2VuZCByZWluZm9yY2VtZW50cw==\r")
-    end.should raise_error(ArgumentError)
-  end
+    it "returns the Base64-decoded version of the given shared string" do
+      Base64.strict_decode64("base64: U2VuZCByZWluZm9yY2VtZW50cw==".split(" ").last).should == "Send reinforcements"
+    end
 
-  it "raises ArgumentError when the given string contains LF" do
-    -> do
-      Base64.strict_decode64("U2VuZCByZWluZm9yY2VtZW50cw==\n")
-    end.should raise_error(ArgumentError)
-  end
+    it "raises ArgumentError when the given string contains CR" do
+      -> do
+        Base64.strict_decode64("U2VuZCByZWluZm9yY2VtZW50cw==\r")
+      end.should raise_error(ArgumentError)
+    end
 
-  it "raises ArgumentError when the given string has wrong padding" do
-    -> do
-      Base64.strict_decode64("=U2VuZCByZWluZm9yY2VtZW50cw==")
-    end.should raise_error(ArgumentError)
-  end
+    it "raises ArgumentError when the given string contains LF" do
+      -> do
+        Base64.strict_decode64("U2VuZCByZWluZm9yY2VtZW50cw==\n")
+      end.should raise_error(ArgumentError)
+    end
 
-  it "raises ArgumentError when the given string contains an invalid character" do
-    -> do
-      Base64.strict_decode64("%3D")
-    end.should raise_error(ArgumentError)
-  end
+    it "raises ArgumentError when the given string has wrong padding" do
+      -> do
+        Base64.strict_decode64("=U2VuZCByZWluZm9yY2VtZW50cw==")
+      end.should raise_error(ArgumentError)
+    end
 
-  it "returns a binary encoded string" do
-    Base64.strict_decode64("SEk=").encoding.should == Encoding::BINARY
+    it "raises ArgumentError when the given string contains an invalid character" do
+      -> do
+        Base64.strict_decode64("%3D")
+      end.should raise_error(ArgumentError)
+    end
+
+    it "returns a binary encoded string" do
+      Base64.strict_decode64("SEk=").encoding.should == Encoding::BINARY
+    end
   end
 end

--- a/spec/ruby/library/base64/strict_encode64_spec.rb
+++ b/spec/ruby/library/base64/strict_encode64_spec.rb
@@ -1,19 +1,22 @@
 require_relative '../../spec_helper'
 
-require 'base64'
+ruby_version_is ""..."3.4" do
 
-describe "Base64#strict_encode64" do
-  it "returns the Base64-encoded version of the given string" do
-    Base64.strict_encode64("Now is the time for all good coders\nto learn Ruby").should ==
-      "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gUnVieQ=="
-  end
+  require 'base64'
 
-  it "returns the Base64-encoded version of the given shared string" do
-    Base64.strict_encode64("Now is the time for all good coders\nto learn Ruby".split("\n").last).should ==
-      "dG8gbGVhcm4gUnVieQ=="
-  end
+  describe "Base64#strict_encode64" do
+    it "returns the Base64-encoded version of the given string" do
+      Base64.strict_encode64("Now is the time for all good coders\nto learn Ruby").should ==
+        "Tm93IGlzIHRoZSB0aW1lIGZvciBhbGwgZ29vZCBjb2RlcnMKdG8gbGVhcm4gUnVieQ=="
+    end
 
-  it "returns a US_ASCII encoded string" do
-    Base64.strict_encode64("HI").encoding.should == Encoding::US_ASCII
+    it "returns the Base64-encoded version of the given shared string" do
+      Base64.strict_encode64("Now is the time for all good coders\nto learn Ruby".split("\n").last).should ==
+        "dG8gbGVhcm4gUnVieQ=="
+    end
+
+    it "returns a US_ASCII encoded string" do
+      Base64.strict_encode64("HI").encoding.should == Encoding::US_ASCII
+    end
   end
 end

--- a/spec/ruby/library/base64/urlsafe_decode64_spec.rb
+++ b/spec/ruby/library/base64/urlsafe_decode64_spec.rb
@@ -1,19 +1,22 @@
 require_relative '../../spec_helper'
 
-require 'base64'
+ruby_version_is ""..."3.4" do
 
-describe "Base64#urlsafe_decode64" do
-  it "uses '_' instead of '/'" do
-    decoded = Base64.urlsafe_decode64("V2hlcmUgYW0gST8gV2hvIGFtIEk_IEFtIEk_IEk_")
-    decoded.should == 'Where am I? Who am I? Am I? I?'
-  end
+  require 'base64'
 
-  it "uses '-' instead of '+'" do
-    decoded = Base64.urlsafe_decode64('IkJlaW5nIGRpc2ludGVncmF0ZWQgbWFrZXMgbWUgdmUtcnkgYW4tZ3J5ISIgPGh1ZmYsIGh1ZmY-')
-    decoded.should == '"Being disintegrated makes me ve-ry an-gry!" <huff, huff>'
-  end
+  describe "Base64#urlsafe_decode64" do
+    it "uses '_' instead of '/'" do
+      decoded = Base64.urlsafe_decode64("V2hlcmUgYW0gST8gV2hvIGFtIEk_IEFtIEk_IEk_")
+      decoded.should == 'Where am I? Who am I? Am I? I?'
+    end
 
-  it "does not require padding" do
-    Base64.urlsafe_decode64("MQ").should == "1"
+    it "uses '-' instead of '+'" do
+      decoded = Base64.urlsafe_decode64('IkJlaW5nIGRpc2ludGVncmF0ZWQgbWFrZXMgbWUgdmUtcnkgYW4tZ3J5ISIgPGh1ZmYsIGh1ZmY-')
+      decoded.should == '"Being disintegrated makes me ve-ry an-gry!" <huff, huff>'
+    end
+
+    it "does not require padding" do
+      Base64.urlsafe_decode64("MQ").should == "1"
+    end
   end
 end

--- a/spec/ruby/library/base64/urlsafe_encode64_spec.rb
+++ b/spec/ruby/library/base64/urlsafe_encode64_spec.rb
@@ -1,20 +1,23 @@
 require_relative '../../spec_helper'
 
-require 'base64'
+ruby_version_is ""..."3.4" do
 
-describe "Base64#urlsafe_encode64" do
-  it "uses '_' instead of '/'" do
-    encoded = Base64.urlsafe_encode64('Where am I? Who am I? Am I? I?')
-    encoded.should == "V2hlcmUgYW0gST8gV2hvIGFtIEk_IEFtIEk_IEk_"
-  end
+  require 'base64'
 
-  it "uses '-' instead of '+'" do
-    encoded = Base64.urlsafe_encode64('"Being disintegrated makes me ve-ry an-gry!" <huff, huff>')
-    encoded.should == 'IkJlaW5nIGRpc2ludGVncmF0ZWQgbWFrZXMgbWUgdmUtcnkgYW4tZ3J5ISIgPGh1ZmYsIGh1ZmY-'
-  end
+  describe "Base64#urlsafe_encode64" do
+    it "uses '_' instead of '/'" do
+      encoded = Base64.urlsafe_encode64('Where am I? Who am I? Am I? I?')
+      encoded.should == "V2hlcmUgYW0gST8gV2hvIGFtIEk_IEFtIEk_IEk_"
+    end
 
-  it "makes padding optional" do
-    Base64.urlsafe_encode64("1", padding: false).should == "MQ"
-    Base64.urlsafe_encode64("1").should == "MQ=="
+    it "uses '-' instead of '+'" do
+      encoded = Base64.urlsafe_encode64('"Being disintegrated makes me ve-ry an-gry!" <huff, huff>')
+      encoded.should == 'IkJlaW5nIGRpc2ludGVncmF0ZWQgbWFrZXMgbWUgdmUtcnkgYW4tZ3J5ISIgPGh1ZmYsIGh1ZmY-'
+    end
+
+    it "makes padding optional" do
+      Base64.urlsafe_encode64("1", padding: false).should == "MQ"
+      Base64.urlsafe_encode64("1").should == "MQ=="
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/BigDecimal_spec.rb
+++ b/spec/ruby/library/bigdecimal/BigDecimal_spec.rb
@@ -1,269 +1,272 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal" do
-  it "is not defined unless it is required" do
-    ruby_exe('puts Object.const_defined?(:BigDecimal)').should == "false\n"
-  end
-end
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-describe "Kernel#BigDecimal" do
-
-  it "creates a new object of class BigDecimal" do
-    BigDecimal("3.14159").should be_kind_of(BigDecimal)
-    (0..9).each {|i|
-      BigDecimal("1#{i}").should == 10 + i
-      BigDecimal("-1#{i}").should == -10 - i
-      BigDecimal("1E#{i}").should == 10**i
-      BigDecimal("1000000E-#{i}").should == 10**(6-i).to_f
-      # ^ to_f to avoid Rational type
-    }
-    (1..9).each {|i|
-      BigDecimal("100.#{i}").to_s.should =~ /\A0\.100#{i}E3\z/i
-      BigDecimal("-100.#{i}").to_s.should =~ /\A-0\.100#{i}E3\z/i
-    }
-  end
-
-  it "BigDecimal(Rational) with bigger-than-double numerator" do
-    rational = 99999999999999999999/100r
-    rational.numerator.should > 2**64
-    BigDecimal(rational, 100).to_s.should == "0.99999999999999999999e18"
-  end
-
-  it "accepts significant digits >= given precision" do
-    suppress_warning do
-      BigDecimal("3.1415923", 10).precs[1].should >= 10
+  describe "BigDecimal" do
+    it "is not defined unless it is required" do
+      ruby_exe('puts Object.const_defined?(:BigDecimal)').should == "false\n"
     end
   end
 
-  it "determines precision from initial value" do
-    pi_string = "3.14159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593014782083152134043"
-    suppress_warning {
-      BigDecimal(pi_string).precs[1]
-    }.should >= pi_string.size-1
-  end
+  describe "Kernel#BigDecimal" do
 
-  it "ignores leading and trailing whitespace" do
-    BigDecimal("  \t\n \r1234\t\r\n ").should == BigDecimal("1234")
-    BigDecimal("  \t\n \rNaN   \n").should.nan?
-    BigDecimal("  \t\n \rInfinity   \n").infinite?.should == 1
-    BigDecimal("  \t\n \r-Infinity   \n").infinite?.should == -1
-  end
-
-  it "coerces the value argument with #to_str" do
-    initial = mock("value")
-    initial.should_receive(:to_str).and_return("123")
-    BigDecimal(initial).should == BigDecimal("123")
-  end
-
-  it "does not ignores trailing garbage" do
-    -> { BigDecimal("123E45ruby") }.should raise_error(ArgumentError)
-    -> { BigDecimal("123x45") }.should raise_error(ArgumentError)
-    -> { BigDecimal("123.4%E5") }.should raise_error(ArgumentError)
-    -> { BigDecimal("1E2E3E4E5E") }.should raise_error(ArgumentError)
-  end
-
-  it "raises ArgumentError for invalid strings" do
-    -> { BigDecimal("ruby") }.should raise_error(ArgumentError)
-    -> { BigDecimal("  \t\n \r-\t\t\tInfinity   \n") }.should raise_error(ArgumentError)
-  end
-
-  it "allows omitting the integer part" do
-    BigDecimal(".123").should == BigDecimal("0.123")
-  end
-
-  it "process underscores as Float()" do
-    reference = BigDecimal("12345.67E89")
-
-    BigDecimal("12_345.67E89").should == reference
-    -> { BigDecimal("1_2_3_4_5_._6____7_E89") }.should raise_error(ArgumentError)
-    -> { BigDecimal("12345_.67E_8__9_") }.should raise_error(ArgumentError)
-  end
-
-  it "accepts NaN and [+-]Infinity" do
-    BigDecimal("NaN").should.nan?
-
-    pos_inf = BigDecimal("Infinity")
-    pos_inf.should_not.finite?
-    pos_inf.should > 0
-    pos_inf.should == BigDecimal("+Infinity")
-
-    neg_inf = BigDecimal("-Infinity")
-    neg_inf.should_not.finite?
-    neg_inf.should < 0
-  end
-
-  describe "with exception: false" do
-    it "returns nil for invalid strings" do
-      BigDecimal("invalid", exception: false).should be_nil
-      BigDecimal("0invalid", exception: false).should be_nil
-      BigDecimal("invalid0", exception: false).should be_nil
-      BigDecimal("0.", exception: false).should be_nil
-    end
-  end
-
-  describe "accepts NaN and [+-]Infinity as Float values" do
-    it "works without an explicit precision" do
-      BigDecimal(Float::NAN).should.nan?
-
-      pos_inf = BigDecimal(Float::INFINITY)
-      pos_inf.should_not.finite?
-      pos_inf.should > 0
-      pos_inf.should == BigDecimal("+Infinity")
-
-      neg_inf = BigDecimal(-Float::INFINITY)
-      neg_inf.should_not.finite?
-      neg_inf.should < 0
+    it "creates a new object of class BigDecimal" do
+      BigDecimal("3.14159").should be_kind_of(BigDecimal)
+      (0..9).each {|i|
+        BigDecimal("1#{i}").should == 10 + i
+        BigDecimal("-1#{i}").should == -10 - i
+        BigDecimal("1E#{i}").should == 10**i
+        BigDecimal("1000000E-#{i}").should == 10**(6-i).to_f
+        # ^ to_f to avoid Rational type
+      }
+      (1..9).each {|i|
+        BigDecimal("100.#{i}").to_s.should =~ /\A0\.100#{i}E3\z/i
+        BigDecimal("-100.#{i}").to_s.should =~ /\A-0\.100#{i}E3\z/i
+      }
     end
 
-    it "works with an explicit precision" do
-      BigDecimal(Float::NAN, Float::DIG).should.nan?
-
-      pos_inf = BigDecimal(Float::INFINITY, Float::DIG)
-      pos_inf.should_not.finite?
-      pos_inf.should > 0
-      pos_inf.should == BigDecimal("+Infinity")
-
-      neg_inf = BigDecimal(-Float::INFINITY, Float::DIG)
-      neg_inf.should_not.finite?
-      neg_inf.should < 0
+    it "BigDecimal(Rational) with bigger-than-double numerator" do
+      rational = 99999999999999999999/100r
+      rational.numerator.should > 2**64
+      BigDecimal(rational, 100).to_s.should == "0.99999999999999999999e18"
     end
-  end
 
-  it "allows for [eEdD] as exponent separator" do
-    reference = BigDecimal("12345.67E89")
-
-    BigDecimal("12345.67e89").should == reference
-    BigDecimal("12345.67E89").should == reference
-    BigDecimal("12345.67d89").should == reference
-    BigDecimal("12345.67D89").should == reference
-  end
-
-  it "allows for varying signs" do
-    reference = BigDecimal("123.456E1")
-
-    BigDecimal("+123.456E1").should == reference
-    BigDecimal("-123.456E1").should == -reference
-    BigDecimal("123.456E+1").should == reference
-    BigDecimal("12345.6E-1").should == reference
-    BigDecimal("+123.456E+1").should == reference
-    BigDecimal("+12345.6E-1").should == reference
-    BigDecimal("-123.456E+1").should == -reference
-    BigDecimal("-12345.6E-1").should == -reference
-  end
-
-  it "raises ArgumentError when Float is used without precision" do
-    -> { BigDecimal(1.0) }.should raise_error(ArgumentError)
-  end
-
-  it "returns appropriate BigDecimal zero for signed zero" do
-    BigDecimal(-0.0, Float::DIG).sign.should == -1
-    BigDecimal(0.0, Float::DIG).sign.should == 1
-  end
-
-  it "pre-coerces long integers" do
-    BigDecimal(3).add(1 << 50, 3).should == BigDecimal('0.113e16')
-  end
-
-  it "does not call to_s when calling inspect" do
-    value = BigDecimal('44.44')
-    value.to_s.should == '0.4444e2'
-    value.inspect.should == '0.4444e2'
-
-    ruby_exe( <<-'EOF').should == "cheese 0.4444e2"
-      require 'bigdecimal'
-      module BigDecimalOverride
-        def to_s; "cheese"; end
+    it "accepts significant digits >= given precision" do
+      suppress_warning do
+        BigDecimal("3.1415923", 10).precs[1].should >= 10
       end
-      BigDecimal.prepend BigDecimalOverride
+    end
+
+    it "determines precision from initial value" do
+      pi_string = "3.14159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593014782083152134043"
+      suppress_warning {
+        BigDecimal(pi_string).precs[1]
+      }.should >= pi_string.size-1
+    end
+
+    it "ignores leading and trailing whitespace" do
+      BigDecimal("  \t\n \r1234\t\r\n ").should == BigDecimal("1234")
+      BigDecimal("  \t\n \rNaN   \n").should.nan?
+      BigDecimal("  \t\n \rInfinity   \n").infinite?.should == 1
+      BigDecimal("  \t\n \r-Infinity   \n").infinite?.should == -1
+    end
+
+    it "coerces the value argument with #to_str" do
+      initial = mock("value")
+      initial.should_receive(:to_str).and_return("123")
+      BigDecimal(initial).should == BigDecimal("123")
+    end
+
+    it "does not ignores trailing garbage" do
+      -> { BigDecimal("123E45ruby") }.should raise_error(ArgumentError)
+      -> { BigDecimal("123x45") }.should raise_error(ArgumentError)
+      -> { BigDecimal("123.4%E5") }.should raise_error(ArgumentError)
+      -> { BigDecimal("1E2E3E4E5E") }.should raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError for invalid strings" do
+      -> { BigDecimal("ruby") }.should raise_error(ArgumentError)
+      -> { BigDecimal("  \t\n \r-\t\t\tInfinity   \n") }.should raise_error(ArgumentError)
+    end
+
+    it "allows omitting the integer part" do
+      BigDecimal(".123").should == BigDecimal("0.123")
+    end
+
+    it "process underscores as Float()" do
+      reference = BigDecimal("12345.67E89")
+
+      BigDecimal("12_345.67E89").should == reference
+      -> { BigDecimal("1_2_3_4_5_._6____7_E89") }.should raise_error(ArgumentError)
+      -> { BigDecimal("12345_.67E_8__9_") }.should raise_error(ArgumentError)
+    end
+
+    it "accepts NaN and [+-]Infinity" do
+      BigDecimal("NaN").should.nan?
+
+      pos_inf = BigDecimal("Infinity")
+      pos_inf.should_not.finite?
+      pos_inf.should > 0
+      pos_inf.should == BigDecimal("+Infinity")
+
+      neg_inf = BigDecimal("-Infinity")
+      neg_inf.should_not.finite?
+      neg_inf.should < 0
+    end
+
+    describe "with exception: false" do
+      it "returns nil for invalid strings" do
+        BigDecimal("invalid", exception: false).should be_nil
+        BigDecimal("0invalid", exception: false).should be_nil
+        BigDecimal("invalid0", exception: false).should be_nil
+        BigDecimal("0.", exception: false).should be_nil
+      end
+    end
+
+    describe "accepts NaN and [+-]Infinity as Float values" do
+      it "works without an explicit precision" do
+        BigDecimal(Float::NAN).should.nan?
+
+        pos_inf = BigDecimal(Float::INFINITY)
+        pos_inf.should_not.finite?
+        pos_inf.should > 0
+        pos_inf.should == BigDecimal("+Infinity")
+
+        neg_inf = BigDecimal(-Float::INFINITY)
+        neg_inf.should_not.finite?
+        neg_inf.should < 0
+      end
+
+      it "works with an explicit precision" do
+        BigDecimal(Float::NAN, Float::DIG).should.nan?
+
+        pos_inf = BigDecimal(Float::INFINITY, Float::DIG)
+        pos_inf.should_not.finite?
+        pos_inf.should > 0
+        pos_inf.should == BigDecimal("+Infinity")
+
+        neg_inf = BigDecimal(-Float::INFINITY, Float::DIG)
+        neg_inf.should_not.finite?
+        neg_inf.should < 0
+      end
+    end
+
+    it "allows for [eEdD] as exponent separator" do
+      reference = BigDecimal("12345.67E89")
+
+      BigDecimal("12345.67e89").should == reference
+      BigDecimal("12345.67E89").should == reference
+      BigDecimal("12345.67d89").should == reference
+      BigDecimal("12345.67D89").should == reference
+    end
+
+    it "allows for varying signs" do
+      reference = BigDecimal("123.456E1")
+
+      BigDecimal("+123.456E1").should == reference
+      BigDecimal("-123.456E1").should == -reference
+      BigDecimal("123.456E+1").should == reference
+      BigDecimal("12345.6E-1").should == reference
+      BigDecimal("+123.456E+1").should == reference
+      BigDecimal("+12345.6E-1").should == reference
+      BigDecimal("-123.456E+1").should == -reference
+      BigDecimal("-12345.6E-1").should == -reference
+    end
+
+    it "raises ArgumentError when Float is used without precision" do
+      -> { BigDecimal(1.0) }.should raise_error(ArgumentError)
+    end
+
+    it "returns appropriate BigDecimal zero for signed zero" do
+      BigDecimal(-0.0, Float::DIG).sign.should == -1
+      BigDecimal(0.0, Float::DIG).sign.should == 1
+    end
+
+    it "pre-coerces long integers" do
+      BigDecimal(3).add(1 << 50, 3).should == BigDecimal('0.113e16')
+    end
+
+    it "does not call to_s when calling inspect" do
       value = BigDecimal('44.44')
-      print "#{value.to_s} #{value.inspect}"
-    EOF
-  end
+      value.to_s.should == '0.4444e2'
+      value.inspect.should == '0.4444e2'
 
-  describe "when interacting with Rational" do
-    before :each do
-      @a = BigDecimal('166.666666666')
-      @b = Rational(500, 3)
-      @c = @a - @b
+      ruby_exe( <<-'EOF').should == "cheese 0.4444e2"
+        require 'bigdecimal'
+        module BigDecimalOverride
+          def to_s; "cheese"; end
+        end
+        BigDecimal.prepend BigDecimalOverride
+        value = BigDecimal('44.44')
+        print "#{value.to_s} #{value.inspect}"
+      EOF
     end
 
-    # Check the input is as we understand it
-
-    it "has the LHS print as expected" do
-      @a.to_s.should == "0.166666666666e3"
-      @a.to_f.to_s.should == "166.666666666"
-      Float(@a).to_s.should == "166.666666666"
-    end
-
-    it "has the RHS print as expected" do
-      @b.to_s.should == "500/3"
-      @b.to_f.to_s.should == "166.66666666666666"
-      Float(@b).to_s.should == "166.66666666666666"
-    end
-
-    it "has the expected precision on the LHS" do
-      suppress_warning { @a.precs[0] }.should == 18
-    end
-
-    it "has the expected maximum precision on the LHS" do
-      suppress_warning { @a.precs[1] }.should == 27
-    end
-
-    it "produces the expected result when done via Float" do
-      (Float(@a) - Float(@b)).to_s.should == "-6.666596163995564e-10"
-    end
-
-    it "produces the expected result when done via to_f" do
-      (@a.to_f - @b.to_f).to_s.should == "-6.666596163995564e-10"
-    end
-
-    # Check underlying methods work as we understand
-
-    it "BigDecimal precision is the number of digits rounded up to a multiple of nine" do
-      1.upto(100) do |n|
-        b = BigDecimal('4' * n)
-        precs, _ = suppress_warning { b.precs }
-        (precs >= 9).should be_true
-        (precs >= n).should be_true
-        (precs % 9).should == 0
+    describe "when interacting with Rational" do
+      before :each do
+        @a = BigDecimal('166.666666666')
+        @b = Rational(500, 3)
+        @c = @a - @b
       end
-      suppress_warning { BigDecimal('NaN').precs[0] }.should == 9
-    end
 
-    it "BigDecimal maximum precision is nine more than precision except for abnormals" do
-      1.upto(100) do |n|
-        b = BigDecimal('4' * n)
-        precs, max = suppress_warning { b.precs }
-        max.should == precs + 9
+      # Check the input is as we understand it
+
+      it "has the LHS print as expected" do
+        @a.to_s.should == "0.166666666666e3"
+        @a.to_f.to_s.should == "166.666666666"
+        Float(@a).to_s.should == "166.666666666"
       end
-      suppress_warning { BigDecimal('NaN').precs[1] }.should == 9
-    end
 
-    it "BigDecimal(Rational, 18) produces the result we expect" do
-      BigDecimal(@b, 18).to_s.should == "0.166666666666666667e3"
-    end
+      it "has the RHS print as expected" do
+        @b.to_s.should == "500/3"
+        @b.to_f.to_s.should == "166.66666666666666"
+        Float(@b).to_s.should == "166.66666666666666"
+      end
 
-    it "BigDecimal(Rational, BigDecimal.precs[0]) produces the result we expect" do
-      BigDecimal(@b, suppress_warning { @a.precs[0] }).to_s.should == "0.166666666666666667e3"
-    end
+      it "has the expected precision on the LHS" do
+        suppress_warning { @a.precs[0] }.should == 18
+      end
 
-    # Check the top-level expression works as we expect
+      it "has the expected maximum precision on the LHS" do
+        suppress_warning { @a.precs[1] }.should == 27
+      end
 
-    it "produces a BigDecimal" do
-      @c.class.should == BigDecimal
-    end
+      it "produces the expected result when done via Float" do
+        (Float(@a) - Float(@b)).to_s.should == "-6.666596163995564e-10"
+      end
 
-    it "produces the expected result" do
-      @c.should == BigDecimal("-0.666667e-9")
-      @c.to_s.should == "-0.666667e-9"
-    end
+      it "produces the expected result when done via to_f" do
+        (@a.to_f - @b.to_f).to_s.should == "-6.666596163995564e-10"
+      end
 
-    it "produces the correct class for other arithmetic operators" do
-      (@a + @b).class.should == BigDecimal
-      (@a * @b).class.should == BigDecimal
-      (@a / @b).class.should == BigDecimal
-      (@a % @b).class.should == BigDecimal
+      # Check underlying methods work as we understand
+
+      it "BigDecimal precision is the number of digits rounded up to a multiple of nine" do
+        1.upto(100) do |n|
+          b = BigDecimal('4' * n)
+          precs, _ = suppress_warning { b.precs }
+          (precs >= 9).should be_true
+          (precs >= n).should be_true
+          (precs % 9).should == 0
+        end
+        suppress_warning { BigDecimal('NaN').precs[0] }.should == 9
+      end
+
+      it "BigDecimal maximum precision is nine more than precision except for abnormals" do
+        1.upto(100) do |n|
+          b = BigDecimal('4' * n)
+          precs, max = suppress_warning { b.precs }
+          max.should == precs + 9
+        end
+        suppress_warning { BigDecimal('NaN').precs[1] }.should == 9
+      end
+
+      it "BigDecimal(Rational, 18) produces the result we expect" do
+        BigDecimal(@b, 18).to_s.should == "0.166666666666666667e3"
+      end
+
+      it "BigDecimal(Rational, BigDecimal.precs[0]) produces the result we expect" do
+        BigDecimal(@b, suppress_warning { @a.precs[0] }).to_s.should == "0.166666666666666667e3"
+      end
+
+      # Check the top-level expression works as we expect
+
+      it "produces a BigDecimal" do
+        @c.class.should == BigDecimal
+      end
+
+      it "produces the expected result" do
+        @c.should == BigDecimal("-0.666667e-9")
+        @c.to_s.should == "-0.666667e-9"
+      end
+
+      it "produces the correct class for other arithmetic operators" do
+        (@a + @b).class.should == BigDecimal
+        (@a * @b).class.should == BigDecimal
+        (@a / @b).class.should == BigDecimal
+        (@a % @b).class.should == BigDecimal
+      end
     end
   end
 end

--- a/spec/ruby/library/bigdecimal/abs_spec.rb
+++ b/spec/ruby/library/bigdecimal/abs_spec.rb
@@ -1,50 +1,53 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#abs" do
-  before :each do
-    @one = BigDecimal("1")
-    @zero = BigDecimal("0")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-    @two = BigDecimal("2")
-    @three = BigDecimal("3")
-    @mixed = BigDecimal("1.23456789")
-    @nan = BigDecimal("NaN")
-    @infinity = BigDecimal("Infinity")
-    @infinity_minus = BigDecimal("-Infinity")
-    @one_minus = BigDecimal("-1")
-    @frac_1 = BigDecimal("1E-99999")
-    @frac_2 = BigDecimal("0.9E-99999")
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
+
+  describe "BigDecimal#abs" do
+    before :each do
+      @one = BigDecimal("1")
+      @zero = BigDecimal("0")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
+      @two = BigDecimal("2")
+      @three = BigDecimal("3")
+      @mixed = BigDecimal("1.23456789")
+      @nan = BigDecimal("NaN")
+      @infinity = BigDecimal("Infinity")
+      @infinity_minus = BigDecimal("-Infinity")
+      @one_minus = BigDecimal("-1")
+      @frac_1 = BigDecimal("1E-99999")
+      @frac_2 = BigDecimal("0.9E-99999")
+    end
+
+    it "returns the absolute value" do
+      pos_int = BigDecimal("2E5555")
+      neg_int = BigDecimal("-2E5555")
+      pos_frac = BigDecimal("2E-9999")
+      neg_frac = BigDecimal("-2E-9999")
+
+      pos_int.abs.should == pos_int
+      neg_int.abs.should == pos_int
+      pos_frac.abs.should == pos_frac
+      neg_frac.abs.should == pos_frac
+      @one.abs.should == 1
+      @two.abs.should == 2
+      @three.abs.should == 3
+      @mixed.abs.should == @mixed
+      @one_minus.abs.should == @one
+    end
+
+    it "properly handles special values" do
+      @infinity.abs.should == @infinity
+      @infinity_minus.abs.should == @infinity
+      @nan.abs.should.nan? # have to do it this way, since == doesn't work on NaN
+      @zero.abs.should == 0
+      @zero.abs.sign.should == BigDecimal::SIGN_POSITIVE_ZERO
+      @zero_pos.abs.should == 0
+      @zero_pos.abs.sign.should == BigDecimal::SIGN_POSITIVE_ZERO
+      @zero_neg.abs.should == 0
+      @zero_neg.abs.sign.should == BigDecimal::SIGN_POSITIVE_ZERO
+    end
+
   end
-
-  it "returns the absolute value" do
-    pos_int = BigDecimal("2E5555")
-    neg_int = BigDecimal("-2E5555")
-    pos_frac = BigDecimal("2E-9999")
-    neg_frac = BigDecimal("-2E-9999")
-
-    pos_int.abs.should == pos_int
-    neg_int.abs.should == pos_int
-    pos_frac.abs.should == pos_frac
-    neg_frac.abs.should == pos_frac
-    @one.abs.should == 1
-    @two.abs.should == 2
-    @three.abs.should == 3
-    @mixed.abs.should == @mixed
-    @one_minus.abs.should == @one
-  end
-
-  it "properly handles special values" do
-    @infinity.abs.should == @infinity
-    @infinity_minus.abs.should == @infinity
-    @nan.abs.should.nan? # have to do it this way, since == doesn't work on NaN
-    @zero.abs.should == 0
-    @zero.abs.sign.should == BigDecimal::SIGN_POSITIVE_ZERO
-    @zero_pos.abs.should == 0
-    @zero_pos.abs.sign.should == BigDecimal::SIGN_POSITIVE_ZERO
-    @zero_neg.abs.should == 0
-    @zero_neg.abs.sign.should == BigDecimal::SIGN_POSITIVE_ZERO
-  end
-
 end

--- a/spec/ruby/library/bigdecimal/add_spec.rb
+++ b/spec/ruby/library/bigdecimal/add_spec.rb
@@ -1,193 +1,196 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
 
-require 'bigdecimal'
+ruby_version_is ""..."3.4" do
+  require_relative 'fixtures/classes'
 
-describe "BigDecimal#add" do
+  require 'bigdecimal'
 
-  before :each do
-    @one = BigDecimal("1")
-    @zero = BigDecimal("0")
-    @two = BigDecimal("2")
-    @three = BigDecimal("3")
-    @ten = BigDecimal("10")
-    @eleven = BigDecimal("11")
-    @nan = BigDecimal("NaN")
-    @infinity = BigDecimal("Infinity")
-    @infinity_minus = BigDecimal("-Infinity")
-    @one_minus = BigDecimal("-1")
-    @frac_1 = BigDecimal("1E-99999")
-    @frac_2 = BigDecimal("0.9E-99999")
-    @frac_3 = BigDecimal("12345E10")
-    @frac_4 = BigDecimal("98765E10")
-    @dot_ones = BigDecimal("0.1111111111")
-  end
+  describe "BigDecimal#add" do
 
-  it "returns a + b with given precision" do
-    # documentation states that precision is optional, but it ain't,
-    @two.add(@one, 1).should == @three
-    @one .add(@two, 1).should == @three
-    @one.add(@one_minus, 1).should == @zero
-    @ten.add(@one, 2).should == @eleven
-    @zero.add(@one, 1).should == @one
-    @frac_2.add(@frac_1, 10000).should == BigDecimal("1.9E-99999")
-    @frac_1.add(@frac_1, 10000).should == BigDecimal("2E-99999")
-    @frac_3.add(@frac_4, 0).should == BigDecimal("0.11111E16")
-    @frac_3.add(@frac_4, 1).should == BigDecimal("0.1E16")
-    @frac_3.add(@frac_4, 2).should == BigDecimal("0.11E16")
-    @frac_3.add(@frac_4, 3).should == BigDecimal("0.111E16")
-    @frac_3.add(@frac_4, 4).should == BigDecimal("0.1111E16")
-    @frac_3.add(@frac_4, 5).should == BigDecimal("0.11111E16")
-    @frac_3.add(@frac_4, 6).should == BigDecimal("0.11111E16")
-  end
-
-  it "returns a + [Fixnum value] with given precision" do
-    (1..10).each {|precision|
-      @dot_ones.add(0, precision).should == BigDecimal("0." + "1" * precision)
-    }
-    BigDecimal("0.88").add(0, 1).should == BigDecimal("0.9")
-  end
-
-  it "returns a + [Bignum value] with given precision" do
-    bignum = 10000000000000000000
-    (1..20).each {|precision|
-      @dot_ones.add(bignum, precision).should == BigDecimal("0.1E20")
-    }
-    (21..30).each {|precision|
-      @dot_ones.add(bignum, precision).should == BigDecimal(
-        "0.10000000000000000000" + "1" * (precision - 20) + "E20")
-    }
-  end
-
-#  TODO:
-#  https://blade.ruby-lang.org/ruby-core/17374
-#
-#  This doesn't work on MRI and looks like a bug to me:
-#  one can use BigDecimal + Float, but not Bigdecimal.add(Float)
-#
-#  it "returns a + [Float value] with given precision" do
-#    (1..10).each {|precision|
-#      @dot_ones.add(0.0, precision).should == BigDecimal("0." + "1" * precision)
-#    }
-#
-#    BigDecimal("0.88").add(0.0, 1).should == BigDecimal("0.9")
-#  end
-
-  describe "with Object" do
-    it "tries to coerce the other operand to self" do
-      object = mock("Object")
-      object.should_receive(:coerce).with(@frac_3).and_return([@frac_3, @frac_4])
-      @frac_3.add(object, 1).should == BigDecimal("0.1E16")
-    end
-  end
-
-  describe "with Rational" do
-    it "produces a BigDecimal" do
-      (@three + Rational(500, 2)).should == BigDecimal("0.253e3")
-    end
-  end
-
-  it "favors the precision specified in the second argument over the global limit" do
-    BigDecimalSpecs.with_limit(1) do
-      BigDecimal('0.888').add(@zero, 3).should == BigDecimal('0.888')
+    before :each do
+      @one = BigDecimal("1")
+      @zero = BigDecimal("0")
+      @two = BigDecimal("2")
+      @three = BigDecimal("3")
+      @ten = BigDecimal("10")
+      @eleven = BigDecimal("11")
+      @nan = BigDecimal("NaN")
+      @infinity = BigDecimal("Infinity")
+      @infinity_minus = BigDecimal("-Infinity")
+      @one_minus = BigDecimal("-1")
+      @frac_1 = BigDecimal("1E-99999")
+      @frac_2 = BigDecimal("0.9E-99999")
+      @frac_3 = BigDecimal("12345E10")
+      @frac_4 = BigDecimal("98765E10")
+      @dot_ones = BigDecimal("0.1111111111")
     end
 
-    BigDecimalSpecs.with_limit(2) do
-      BigDecimal('0.888').add(@zero, 1).should == BigDecimal('0.9')
+    it "returns a + b with given precision" do
+      # documentation states that precision is optional, but it ain't,
+      @two.add(@one, 1).should == @three
+      @one .add(@two, 1).should == @three
+      @one.add(@one_minus, 1).should == @zero
+      @ten.add(@one, 2).should == @eleven
+      @zero.add(@one, 1).should == @one
+      @frac_2.add(@frac_1, 10000).should == BigDecimal("1.9E-99999")
+      @frac_1.add(@frac_1, 10000).should == BigDecimal("2E-99999")
+      @frac_3.add(@frac_4, 0).should == BigDecimal("0.11111E16")
+      @frac_3.add(@frac_4, 1).should == BigDecimal("0.1E16")
+      @frac_3.add(@frac_4, 2).should == BigDecimal("0.11E16")
+      @frac_3.add(@frac_4, 3).should == BigDecimal("0.111E16")
+      @frac_3.add(@frac_4, 4).should == BigDecimal("0.1111E16")
+      @frac_3.add(@frac_4, 5).should == BigDecimal("0.11111E16")
+      @frac_3.add(@frac_4, 6).should == BigDecimal("0.11111E16")
     end
-  end
 
-  it "uses the current rounding mode if rounding is needed" do
-    BigDecimalSpecs.with_rounding(BigDecimal::ROUND_UP) do
-      BigDecimal('0.111').add(@zero, 1).should == BigDecimal('0.2')
-      BigDecimal('-0.111').add(@zero, 1).should == BigDecimal('-0.2')
+    it "returns a + [Fixnum value] with given precision" do
+      (1..10).each {|precision|
+        @dot_ones.add(0, precision).should == BigDecimal("0." + "1" * precision)
+      }
+      BigDecimal("0.88").add(0, 1).should == BigDecimal("0.9")
     end
-    BigDecimalSpecs.with_rounding(BigDecimal::ROUND_DOWN) do
-      BigDecimal('0.999').add(@zero, 1).should == BigDecimal('0.9')
-      BigDecimal('-0.999').add(@zero, 1).should == BigDecimal('-0.9')
+
+    it "returns a + [Bignum value] with given precision" do
+      bignum = 10000000000000000000
+      (1..20).each {|precision|
+        @dot_ones.add(bignum, precision).should == BigDecimal("0.1E20")
+      }
+      (21..30).each {|precision|
+        @dot_ones.add(bignum, precision).should == BigDecimal(
+          "0.10000000000000000000" + "1" * (precision - 20) + "E20")
+      }
     end
-    BigDecimalSpecs.with_rounding(BigDecimal::ROUND_HALF_UP) do
+
+  #  TODO:
+  #  https://blade.ruby-lang.org/ruby-core/17374
+  #
+  #  This doesn't work on MRI and looks like a bug to me:
+  #  one can use BigDecimal + Float, but not Bigdecimal.add(Float)
+  #
+  #  it "returns a + [Float value] with given precision" do
+  #    (1..10).each {|precision|
+  #      @dot_ones.add(0.0, precision).should == BigDecimal("0." + "1" * precision)
+  #    }
+  #
+  #    BigDecimal("0.88").add(0.0, 1).should == BigDecimal("0.9")
+  #  end
+
+    describe "with Object" do
+      it "tries to coerce the other operand to self" do
+        object = mock("Object")
+        object.should_receive(:coerce).with(@frac_3).and_return([@frac_3, @frac_4])
+        @frac_3.add(object, 1).should == BigDecimal("0.1E16")
+      end
+    end
+
+    describe "with Rational" do
+      it "produces a BigDecimal" do
+        (@three + Rational(500, 2)).should == BigDecimal("0.253e3")
+      end
+    end
+
+    it "favors the precision specified in the second argument over the global limit" do
+      BigDecimalSpecs.with_limit(1) do
+        BigDecimal('0.888').add(@zero, 3).should == BigDecimal('0.888')
+      end
+
+      BigDecimalSpecs.with_limit(2) do
+        BigDecimal('0.888').add(@zero, 1).should == BigDecimal('0.9')
+      end
+    end
+
+    it "uses the current rounding mode if rounding is needed" do
+      BigDecimalSpecs.with_rounding(BigDecimal::ROUND_UP) do
+        BigDecimal('0.111').add(@zero, 1).should == BigDecimal('0.2')
+        BigDecimal('-0.111').add(@zero, 1).should == BigDecimal('-0.2')
+      end
+      BigDecimalSpecs.with_rounding(BigDecimal::ROUND_DOWN) do
+        BigDecimal('0.999').add(@zero, 1).should == BigDecimal('0.9')
+        BigDecimal('-0.999').add(@zero, 1).should == BigDecimal('-0.9')
+      end
+      BigDecimalSpecs.with_rounding(BigDecimal::ROUND_HALF_UP) do
+        BigDecimal('0.85').add(@zero, 1).should == BigDecimal('0.9')
+        BigDecimal('-0.85').add(@zero, 1).should == BigDecimal('-0.9')
+      end
+      BigDecimalSpecs.with_rounding(BigDecimal::ROUND_HALF_DOWN) do
+        BigDecimal('0.85').add(@zero, 1).should == BigDecimal('0.8')
+        BigDecimal('-0.85').add(@zero, 1).should == BigDecimal('-0.8')
+      end
+      BigDecimalSpecs.with_rounding(BigDecimal::ROUND_HALF_EVEN) do
+        BigDecimal('0.75').add(@zero, 1).should == BigDecimal('0.8')
+        BigDecimal('0.85').add(@zero, 1).should == BigDecimal('0.8')
+        BigDecimal('-0.75').add(@zero, 1).should == BigDecimal('-0.8')
+        BigDecimal('-0.85').add(@zero, 1).should == BigDecimal('-0.8')
+      end
+      BigDecimalSpecs.with_rounding(BigDecimal::ROUND_CEILING) do
+        BigDecimal('0.85').add(@zero, 1).should == BigDecimal('0.9')
+        BigDecimal('-0.85').add(@zero, 1).should == BigDecimal('-0.8')
+      end
+      BigDecimalSpecs.with_rounding(BigDecimal::ROUND_FLOOR) do
+        BigDecimal('0.85').add(@zero, 1).should == BigDecimal('0.8')
+        BigDecimal('-0.85').add(@zero, 1).should == BigDecimal('-0.9')
+      end
+    end
+
+    it "uses the default ROUND_HALF_UP rounding if it wasn't explicitly changed" do
       BigDecimal('0.85').add(@zero, 1).should == BigDecimal('0.9')
       BigDecimal('-0.85').add(@zero, 1).should == BigDecimal('-0.9')
     end
-    BigDecimalSpecs.with_rounding(BigDecimal::ROUND_HALF_DOWN) do
-      BigDecimal('0.85').add(@zero, 1).should == BigDecimal('0.8')
-      BigDecimal('-0.85').add(@zero, 1).should == BigDecimal('-0.8')
+
+    it "returns NaN if NaN is involved" do
+      @one.add(@nan, 10000).should.nan?
+      @nan.add(@one, 1).should.nan?
     end
-    BigDecimalSpecs.with_rounding(BigDecimal::ROUND_HALF_EVEN) do
-      BigDecimal('0.75').add(@zero, 1).should == BigDecimal('0.8')
-      BigDecimal('0.85').add(@zero, 1).should == BigDecimal('0.8')
-      BigDecimal('-0.75').add(@zero, 1).should == BigDecimal('-0.8')
-      BigDecimal('-0.85').add(@zero, 1).should == BigDecimal('-0.8')
+
+    it "returns Infinity or -Infinity if these are involved" do
+      @zero.add(@infinity, 1).should == @infinity
+      @frac_2.add(@infinity, 1).should == @infinity
+      @one_minus.add(@infinity, 1).should == @infinity
+      @two.add(@infinity, 1).should == @infinity
+
+      @zero.add(@infinity_minus, 1).should == @infinity_minus
+      @frac_2.add(@infinity_minus, 1).should == @infinity_minus
+      @one_minus.add(@infinity_minus, 1).should == @infinity_minus
+      @two.add(@infinity_minus, 1).should == @infinity_minus
+
+      @infinity.add(@zero, 1).should == @infinity
+      @infinity.add(@frac_2, 1).should == @infinity
+      @infinity.add(@one_minus, 1).should == @infinity
+      @infinity.add(@two, 1).should == @infinity
+
+      @infinity_minus.add(@zero, 1).should == @infinity_minus
+      @infinity_minus.add(@frac_2, 1).should == @infinity_minus
+      @infinity_minus.add(@one_minus, 1).should == @infinity_minus
+      @infinity_minus.add(@two, 1).should == @infinity_minus
+
+      @infinity.add(@infinity, 10000).should == @infinity
+      @infinity_minus.add(@infinity_minus, 10000).should == @infinity_minus
     end
-    BigDecimalSpecs.with_rounding(BigDecimal::ROUND_CEILING) do
-      BigDecimal('0.85').add(@zero, 1).should == BigDecimal('0.9')
-      BigDecimal('-0.85').add(@zero, 1).should == BigDecimal('-0.8')
+
+    it "returns NaN if Infinity + (- Infinity)" do
+      @infinity.add(@infinity_minus, 10000).should.nan?
+      @infinity_minus.add(@infinity, 10000).should.nan?
     end
-    BigDecimalSpecs.with_rounding(BigDecimal::ROUND_FLOOR) do
-      BigDecimal('0.85').add(@zero, 1).should == BigDecimal('0.8')
-      BigDecimal('-0.85').add(@zero, 1).should == BigDecimal('-0.9')
+
+    it "raises TypeError when adds nil" do
+      -> {
+        @one.add(nil, 10)
+      }.should raise_error(TypeError)
+      -> {
+        @one.add(nil, 0)
+      }.should raise_error(TypeError)
     end
-  end
 
-  it "uses the default ROUND_HALF_UP rounding if it wasn't explicitly changed" do
-    BigDecimal('0.85').add(@zero, 1).should == BigDecimal('0.9')
-    BigDecimal('-0.85').add(@zero, 1).should == BigDecimal('-0.9')
-  end
+    it "raises TypeError when precision parameter is nil" do
+      -> {
+        @one.add(@one, nil)
+      }.should raise_error(TypeError)
+    end
 
-  it "returns NaN if NaN is involved" do
-    @one.add(@nan, 10000).should.nan?
-    @nan.add(@one, 1).should.nan?
-  end
-
-  it "returns Infinity or -Infinity if these are involved" do
-    @zero.add(@infinity, 1).should == @infinity
-    @frac_2.add(@infinity, 1).should == @infinity
-    @one_minus.add(@infinity, 1).should == @infinity
-    @two.add(@infinity, 1).should == @infinity
-
-    @zero.add(@infinity_minus, 1).should == @infinity_minus
-    @frac_2.add(@infinity_minus, 1).should == @infinity_minus
-    @one_minus.add(@infinity_minus, 1).should == @infinity_minus
-    @two.add(@infinity_minus, 1).should == @infinity_minus
-
-    @infinity.add(@zero, 1).should == @infinity
-    @infinity.add(@frac_2, 1).should == @infinity
-    @infinity.add(@one_minus, 1).should == @infinity
-    @infinity.add(@two, 1).should == @infinity
-
-    @infinity_minus.add(@zero, 1).should == @infinity_minus
-    @infinity_minus.add(@frac_2, 1).should == @infinity_minus
-    @infinity_minus.add(@one_minus, 1).should == @infinity_minus
-    @infinity_minus.add(@two, 1).should == @infinity_minus
-
-    @infinity.add(@infinity, 10000).should == @infinity
-    @infinity_minus.add(@infinity_minus, 10000).should == @infinity_minus
-  end
-
-  it "returns NaN if Infinity + (- Infinity)" do
-    @infinity.add(@infinity_minus, 10000).should.nan?
-    @infinity_minus.add(@infinity, 10000).should.nan?
-  end
-
-  it "raises TypeError when adds nil" do
-    -> {
-      @one.add(nil, 10)
-    }.should raise_error(TypeError)
-    -> {
-      @one.add(nil, 0)
-    }.should raise_error(TypeError)
-  end
-
-  it "raises TypeError when precision parameter is nil" do
-    -> {
-      @one.add(@one, nil)
-    }.should raise_error(TypeError)
-  end
-
-  it "raises ArgumentError when precision parameter is negative" do
-    -> {
-      @one.add(@one, -10)
-    }.should raise_error(ArgumentError)
+    it "raises ArgumentError when precision parameter is negative" do
+      -> {
+        @one.add(@one, -10)
+      }.should raise_error(ArgumentError)
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/case_compare_spec.rb
+++ b/spec/ruby/library/bigdecimal/case_compare_spec.rb
@@ -1,7 +1,10 @@
 require_relative '../../spec_helper'
-require_relative 'shared/eql'
+
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/eql'
 
 
-describe "BigDecimal#===" do
-  it_behaves_like :bigdecimal_eql, :===
+  describe "BigDecimal#===" do
+    it_behaves_like :bigdecimal_eql, :===
+  end
 end

--- a/spec/ruby/library/bigdecimal/ceil_spec.rb
+++ b/spec/ruby/library/bigdecimal/ceil_spec.rb
@@ -1,104 +1,107 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#ceil" do
-  before :each do
-    @zero = BigDecimal("0")
-    @one = BigDecimal("1")
-    @three = BigDecimal("3")
-    @four = BigDecimal("4")
-    @mixed = BigDecimal("1.23456789")
-    @mixed_big = BigDecimal("1.23456789E100")
-    @pos_int = BigDecimal("2E5555")
-    @neg_int = BigDecimal("-2E5555")
-    @pos_frac = BigDecimal("2E-9999")
-    @neg_frac = BigDecimal("-2E-9999")
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-    @infinity = BigDecimal("Infinity")
-    @infinity_neg = BigDecimal("-Infinity")
-    @nan = BigDecimal("NaN")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-  end
+  describe "BigDecimal#ceil" do
+    before :each do
+      @zero = BigDecimal("0")
+      @one = BigDecimal("1")
+      @three = BigDecimal("3")
+      @four = BigDecimal("4")
+      @mixed = BigDecimal("1.23456789")
+      @mixed_big = BigDecimal("1.23456789E100")
+      @pos_int = BigDecimal("2E5555")
+      @neg_int = BigDecimal("-2E5555")
+      @pos_frac = BigDecimal("2E-9999")
+      @neg_frac = BigDecimal("-2E-9999")
 
-  it "returns an Integer, if n is unspecified" do
-    @mixed.ceil.kind_of?(Integer).should == true
-  end
-
-  it "returns a BigDecimal, if n is specified" do
-    @pos_int.ceil(2).kind_of?(BigDecimal).should == true
-  end
-
-  it "returns the smallest integer greater or equal to self, if n is unspecified" do
-    @pos_int.ceil.should == @pos_int
-    @neg_int.ceil.should == @neg_int
-    @pos_frac.ceil.should == BigDecimal("1")
-    @neg_frac.ceil.should == @zero
-    @zero.ceil.should == 0
-    @zero_pos.ceil.should == @zero_pos
-    @zero_neg.ceil.should == @zero_neg
-
-
-    BigDecimal('2.3').ceil.should == 3
-    BigDecimal('2.5').ceil.should == 3
-    BigDecimal('2.9999').ceil.should == 3
-    BigDecimal('-2.3').ceil.should == -2
-    BigDecimal('-2.5').ceil.should == -2
-    BigDecimal('-2.9999').ceil.should == -2
-  end
-
-  it "raise exception, if self is special value" do
-    -> { @infinity.ceil }.should raise_error(FloatDomainError)
-    -> { @infinity_neg.ceil }.should raise_error(FloatDomainError)
-    -> { @nan.ceil }.should raise_error(FloatDomainError)
-  end
-
-  it "returns n digits right of the decimal point if given n > 0" do
-    @mixed.ceil(1).should == BigDecimal("1.3")
-    @mixed.ceil(5).should == BigDecimal("1.23457")
-
-    BigDecimal("-0.03").ceil(1).should == BigDecimal("0")
-    BigDecimal("0.03").ceil(1).should == BigDecimal("0.1")
-
-    BigDecimal("23.45").ceil(0).should == BigDecimal('24')
-    BigDecimal("23.45").ceil(1).should == BigDecimal('23.5')
-    BigDecimal("23.45").ceil(2).should == BigDecimal('23.45')
-
-    BigDecimal("-23.45").ceil(0).should == BigDecimal('-23')
-    BigDecimal("-23.45").ceil(1).should == BigDecimal('-23.4')
-    BigDecimal("-23.45").ceil(2).should == BigDecimal('-23.45')
-
-    BigDecimal("2E-10").ceil(0).should == @one
-    BigDecimal("2E-10").ceil(9).should == BigDecimal('1E-9')
-    BigDecimal("2E-10").ceil(10).should == BigDecimal('2E-10')
-    BigDecimal("2E-10").ceil(11).should == BigDecimal('2E-10')
-
-    (1..10).each do |n|
-      # 0.4, 0.34, 0.334, etc.
-      (@one.div(@three,20)).ceil(n).should == BigDecimal("0.#{'3'*(n-1)}4")
-      # 1.4, 1.34, 1.334, etc.
-      (@four.div(@three,20)).ceil(n).should == BigDecimal("1.#{'3'*(n-1)}4")
-      (BigDecimal('31').div(@three,20)).ceil(n).should == BigDecimal("10.#{'3'*(n-1)}4")
+      @infinity = BigDecimal("Infinity")
+      @infinity_neg = BigDecimal("-Infinity")
+      @nan = BigDecimal("NaN")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
     end
-    (1..10).each do |n|
-      # -0.4, -0.34, -0.334, etc.
-      (-@one.div(@three,20)).ceil(n).should == BigDecimal("-0.#{'3'* n}")
-    end
-    (1..10).each do |n|
-      (@three.div(@one,20)).ceil(n).should == @three
-    end
-    (1..10).each do |n|
-      (-@three.div(@one,20)).ceil(n).should == -@three
-    end
-  end
 
-  it "sets n digits left of the decimal point to 0, if given n < 0" do
-    BigDecimal("13345.234").ceil(-2).should == BigDecimal("13400.0")
-    @mixed_big.ceil(-99).should == BigDecimal("0.13E101")
-    @mixed_big.ceil(-100).should == BigDecimal("0.2E101")
-    @mixed_big.ceil(-95).should == BigDecimal("0.123457E101")
-    BigDecimal("1E10").ceil(-30).should == BigDecimal('1E30')
-    BigDecimal("-1E10").ceil(-30).should == @zero
-  end
+    it "returns an Integer, if n is unspecified" do
+      @mixed.ceil.kind_of?(Integer).should == true
+    end
 
+    it "returns a BigDecimal, if n is specified" do
+      @pos_int.ceil(2).kind_of?(BigDecimal).should == true
+    end
+
+    it "returns the smallest integer greater or equal to self, if n is unspecified" do
+      @pos_int.ceil.should == @pos_int
+      @neg_int.ceil.should == @neg_int
+      @pos_frac.ceil.should == BigDecimal("1")
+      @neg_frac.ceil.should == @zero
+      @zero.ceil.should == 0
+      @zero_pos.ceil.should == @zero_pos
+      @zero_neg.ceil.should == @zero_neg
+
+
+      BigDecimal('2.3').ceil.should == 3
+      BigDecimal('2.5').ceil.should == 3
+      BigDecimal('2.9999').ceil.should == 3
+      BigDecimal('-2.3').ceil.should == -2
+      BigDecimal('-2.5').ceil.should == -2
+      BigDecimal('-2.9999').ceil.should == -2
+    end
+
+    it "raise exception, if self is special value" do
+      -> { @infinity.ceil }.should raise_error(FloatDomainError)
+      -> { @infinity_neg.ceil }.should raise_error(FloatDomainError)
+      -> { @nan.ceil }.should raise_error(FloatDomainError)
+    end
+
+    it "returns n digits right of the decimal point if given n > 0" do
+      @mixed.ceil(1).should == BigDecimal("1.3")
+      @mixed.ceil(5).should == BigDecimal("1.23457")
+
+      BigDecimal("-0.03").ceil(1).should == BigDecimal("0")
+      BigDecimal("0.03").ceil(1).should == BigDecimal("0.1")
+
+      BigDecimal("23.45").ceil(0).should == BigDecimal('24')
+      BigDecimal("23.45").ceil(1).should == BigDecimal('23.5')
+      BigDecimal("23.45").ceil(2).should == BigDecimal('23.45')
+
+      BigDecimal("-23.45").ceil(0).should == BigDecimal('-23')
+      BigDecimal("-23.45").ceil(1).should == BigDecimal('-23.4')
+      BigDecimal("-23.45").ceil(2).should == BigDecimal('-23.45')
+
+      BigDecimal("2E-10").ceil(0).should == @one
+      BigDecimal("2E-10").ceil(9).should == BigDecimal('1E-9')
+      BigDecimal("2E-10").ceil(10).should == BigDecimal('2E-10')
+      BigDecimal("2E-10").ceil(11).should == BigDecimal('2E-10')
+
+      (1..10).each do |n|
+        # 0.4, 0.34, 0.334, etc.
+        (@one.div(@three,20)).ceil(n).should == BigDecimal("0.#{'3'*(n-1)}4")
+        # 1.4, 1.34, 1.334, etc.
+        (@four.div(@three,20)).ceil(n).should == BigDecimal("1.#{'3'*(n-1)}4")
+        (BigDecimal('31').div(@three,20)).ceil(n).should == BigDecimal("10.#{'3'*(n-1)}4")
+      end
+      (1..10).each do |n|
+        # -0.4, -0.34, -0.334, etc.
+        (-@one.div(@three,20)).ceil(n).should == BigDecimal("-0.#{'3'* n}")
+      end
+      (1..10).each do |n|
+        (@three.div(@one,20)).ceil(n).should == @three
+      end
+      (1..10).each do |n|
+        (-@three.div(@one,20)).ceil(n).should == -@three
+      end
+    end
+
+    it "sets n digits left of the decimal point to 0, if given n < 0" do
+      BigDecimal("13345.234").ceil(-2).should == BigDecimal("13400.0")
+      @mixed_big.ceil(-99).should == BigDecimal("0.13E101")
+      @mixed_big.ceil(-100).should == BigDecimal("0.2E101")
+      @mixed_big.ceil(-95).should == BigDecimal("0.123457E101")
+      BigDecimal("1E10").ceil(-30).should == BigDecimal('1E30')
+      BigDecimal("-1E10").ceil(-30).should == @zero
+    end
+
+  end
 end

--- a/spec/ruby/library/bigdecimal/clone_spec.rb
+++ b/spec/ruby/library/bigdecimal/clone_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../spec_helper'
-require_relative 'shared/clone'
 
-describe "BigDecimal#dup" do
-  it_behaves_like :bigdecimal_clone, :clone
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/clone'
+
+  describe "BigDecimal#dup" do
+    it_behaves_like :bigdecimal_clone, :clone
+  end
 end

--- a/spec/ruby/library/bigdecimal/coerce_spec.rb
+++ b/spec/ruby/library/bigdecimal/coerce_spec.rb
@@ -1,26 +1,29 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#coerce" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  it "returns [other, self] both as BigDecimal" do
-    one = BigDecimal("1.0")
-    five_point_28 = BigDecimal("5.28")
-    zero_minus = BigDecimal("-0.0")
-    some_value = 32434234234234234234
+  describe "BigDecimal#coerce" do
 
-    BigDecimal("1.2").coerce(1).should == [one, BigDecimal("1.2")]
-    five_point_28.coerce(1.0).should == [one, BigDecimal("5.28")]
-    one.coerce(one).should == [one, one]
-    one.coerce(2.5).should == [2.5, one]
-    BigDecimal("1").coerce(3.14).should == [3.14, one]
-    a, b = zero_minus.coerce(some_value)
-    a.should == BigDecimal(some_value.to_s)
-    b.should == zero_minus
-    a, b = one.coerce(some_value)
-    a.should == BigDecimal(some_value.to_s)
-    b.to_f.should be_close(1.0, TOLERANCE) # can we take out the to_f once BigDecimal#- is implemented?
-    b.should == one
+    it "returns [other, self] both as BigDecimal" do
+      one = BigDecimal("1.0")
+      five_point_28 = BigDecimal("5.28")
+      zero_minus = BigDecimal("-0.0")
+      some_value = 32434234234234234234
+
+      BigDecimal("1.2").coerce(1).should == [one, BigDecimal("1.2")]
+      five_point_28.coerce(1.0).should == [one, BigDecimal("5.28")]
+      one.coerce(one).should == [one, one]
+      one.coerce(2.5).should == [2.5, one]
+      BigDecimal("1").coerce(3.14).should == [3.14, one]
+      a, b = zero_minus.coerce(some_value)
+      a.should == BigDecimal(some_value.to_s)
+      b.should == zero_minus
+      a, b = one.coerce(some_value)
+      a.should == BigDecimal(some_value.to_s)
+      b.to_f.should be_close(1.0, TOLERANCE) # can we take out the to_f once BigDecimal#- is implemented?
+      b.should == one
+    end
+
   end
-
 end

--- a/spec/ruby/library/bigdecimal/comparison_spec.rb
+++ b/spec/ruby/library/bigdecimal/comparison_spec.rb
@@ -1,81 +1,84 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#<=>" do
-  before :each do
-    @zero = BigDecimal("0")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-    @mixed = BigDecimal("1.23456789")
-    @mixed_big = BigDecimal("1.23456789E100")
-    @pos_int = BigDecimal("2E5555")
-    @neg_int = BigDecimal("-2E5555")
-    @pos_frac = BigDecimal("2E-9999")
-    @neg_frac = BigDecimal("-2E-9999")
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-    @int_mock = mock('123')
-    class << @int_mock
-      def coerce(other)
-        return [other, BigDecimal('123')]
+  describe "BigDecimal#<=>" do
+    before :each do
+      @zero = BigDecimal("0")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
+      @mixed = BigDecimal("1.23456789")
+      @mixed_big = BigDecimal("1.23456789E100")
+      @pos_int = BigDecimal("2E5555")
+      @neg_int = BigDecimal("-2E5555")
+      @pos_frac = BigDecimal("2E-9999")
+      @neg_frac = BigDecimal("-2E-9999")
+
+      @int_mock = mock('123')
+      class << @int_mock
+        def coerce(other)
+          return [other, BigDecimal('123')]
+        end
+        def >=(other)
+          BigDecimal('123') >= other
+        end
       end
-      def >=(other)
-        BigDecimal('123') >= other
-      end
+
+      @values = [@mixed, @pos_int, @neg_int, @pos_frac, @neg_frac,
+        -2**32, -2**31, -2**30, -2**16, -2**8, -100, -10, -1,
+        @zero , 1, 2, 10, 2**8, 2**16, 2**32, @int_mock, @zero_pos, @zero_neg]
+
+      @infinity = BigDecimal("Infinity")
+      @infinity_neg = BigDecimal("-Infinity")
+      @nan = BigDecimal("NaN")
     end
 
-    @values = [@mixed, @pos_int, @neg_int, @pos_frac, @neg_frac,
-      -2**32, -2**31, -2**30, -2**16, -2**8, -100, -10, -1,
-      @zero , 1, 2, 10, 2**8, 2**16, 2**32, @int_mock, @zero_pos, @zero_neg]
 
-    @infinity = BigDecimal("Infinity")
-    @infinity_neg = BigDecimal("-Infinity")
-    @nan = BigDecimal("NaN")
-  end
+    it "returns 0 if a == b" do
+      (@pos_int <=> @pos_int).should == 0
+      (@neg_int <=> @neg_int).should == 0
+      (@pos_frac <=> @pos_frac).should == 0
+      (@neg_frac <=> @neg_frac).should == 0
+      (@zero <=> @zero).should == 0
+      (@infinity <=> @infinity).should == 0
+      (@infinity_neg <=> @infinity_neg).should == 0
+    end
 
+    it "returns 1 if a > b" do
+      (@pos_int <=> @neg_int).should == 1
+      (@pos_frac <=> @neg_frac).should == 1
+      (@pos_frac <=> @zero).should == 1
+      @values.each { |val|
+        (@infinity <=> val).should == 1
+      }
+    end
 
-  it "returns 0 if a == b" do
-    (@pos_int <=> @pos_int).should == 0
-    (@neg_int <=> @neg_int).should == 0
-    (@pos_frac <=> @pos_frac).should == 0
-    (@neg_frac <=> @neg_frac).should == 0
-    (@zero <=> @zero).should == 0
-    (@infinity <=> @infinity).should == 0
-    (@infinity_neg <=> @infinity_neg).should == 0
-  end
+    it "returns -1 if a < b" do
+      (@zero <=> @pos_frac).should == -1
+      (@neg_int <=> @pos_frac).should == -1
+      (@pos_frac <=> @pos_int).should == -1
+      @values.each { |val|
+        (@infinity_neg <=> val).should == -1
+      }
+    end
 
-  it "returns 1 if a > b" do
-    (@pos_int <=> @neg_int).should == 1
-    (@pos_frac <=> @neg_frac).should == 1
-    (@pos_frac <=> @zero).should == 1
-    @values.each { |val|
-      (@infinity <=> val).should == 1
-    }
-  end
+    it "returns nil if NaN is involved" do
+      @values += [@infinity, @infinity_neg, @nan]
+      @values << nil
+      @values << Object.new
+      @values.each { |val|
+        (@nan <=> val).should == nil
+      }
+    end
 
-  it "returns -1 if a < b" do
-    (@zero <=> @pos_frac).should == -1
-    (@neg_int <=> @pos_frac).should == -1
-    (@pos_frac <=> @pos_int).should == -1
-    @values.each { |val|
-      (@infinity_neg <=> val).should == -1
-    }
-  end
-
-  it "returns nil if NaN is involved" do
-    @values += [@infinity, @infinity_neg, @nan]
-    @values << nil
-    @values << Object.new
-    @values.each { |val|
-      (@nan <=> val).should == nil
-    }
-  end
-
-  it "returns nil if the argument is nil" do
-    (@zero <=> nil).should == nil
-    (@infinity <=> nil).should == nil
-    (@infinity_neg <=> nil).should == nil
-    (@mixed <=> nil).should == nil
-    (@pos_int <=> nil).should == nil
-    (@neg_frac <=> nil).should == nil
+    it "returns nil if the argument is nil" do
+      (@zero <=> nil).should == nil
+      (@infinity <=> nil).should == nil
+      (@infinity_neg <=> nil).should == nil
+      (@mixed <=> nil).should == nil
+      (@pos_int <=> nil).should == nil
+      (@neg_frac <=> nil).should == nil
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/constants_spec.rb
+++ b/spec/ruby/library/bigdecimal/constants_spec.rb
@@ -1,69 +1,72 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal constants" do
-  it "defines a VERSION value" do
-    BigDecimal.const_defined?(:VERSION).should be_true
-  end
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  it "has a BASE value" do
-    # The actual one is decided based on HAVE_INT64_T in MRI,
-    # which is hard to check here.
-    [10000, 1000000000].should include(BigDecimal::BASE)
-  end
+  describe "BigDecimal constants" do
+    it "defines a VERSION value" do
+      BigDecimal.const_defined?(:VERSION).should be_true
+    end
 
-  it "has a NaN value" do
-    BigDecimal::NAN.nan?.should be_true
-  end
+    it "has a BASE value" do
+      # The actual one is decided based on HAVE_INT64_T in MRI,
+      # which is hard to check here.
+      [10000, 1000000000].should include(BigDecimal::BASE)
+    end
 
-  it "has an INFINITY value" do
-    BigDecimal::INFINITY.infinite?.should == 1
-  end
+    it "has a NaN value" do
+      BigDecimal::NAN.nan?.should be_true
+    end
 
-  describe "exception-related constants" do
-    [
-      [:EXCEPTION_ALL, 0xff],
-      [:EXCEPTION_INFINITY, 0x01],
-      [:EXCEPTION_NaN, 0x02],
-      [:EXCEPTION_UNDERFLOW, 0x04],
-      [:EXCEPTION_OVERFLOW, 0x01],
-      [:EXCEPTION_ZERODIVIDE, 0x10]
-    ].each do |const, value|
-      it "has a #{const} value" do
-        BigDecimal.const_get(const).should == value
+    it "has an INFINITY value" do
+      BigDecimal::INFINITY.infinite?.should == 1
+    end
+
+    describe "exception-related constants" do
+      [
+        [:EXCEPTION_ALL, 0xff],
+        [:EXCEPTION_INFINITY, 0x01],
+        [:EXCEPTION_NaN, 0x02],
+        [:EXCEPTION_UNDERFLOW, 0x04],
+        [:EXCEPTION_OVERFLOW, 0x01],
+        [:EXCEPTION_ZERODIVIDE, 0x10]
+      ].each do |const, value|
+        it "has a #{const} value" do
+          BigDecimal.const_get(const).should == value
+        end
       end
     end
-  end
 
-  describe "rounding-related constants" do
-    [
-      [:ROUND_MODE, 0x100],
-      [:ROUND_UP, 1],
-      [:ROUND_DOWN, 2],
-      [:ROUND_HALF_UP, 3],
-      [:ROUND_HALF_DOWN, 4],
-      [:ROUND_CEILING, 5],
-      [:ROUND_FLOOR, 6],
-      [:ROUND_HALF_EVEN, 7]
-    ].each do |const, value|
-      it "has a #{const} value" do
-        BigDecimal.const_get(const).should == value
+    describe "rounding-related constants" do
+      [
+        [:ROUND_MODE, 0x100],
+        [:ROUND_UP, 1],
+        [:ROUND_DOWN, 2],
+        [:ROUND_HALF_UP, 3],
+        [:ROUND_HALF_DOWN, 4],
+        [:ROUND_CEILING, 5],
+        [:ROUND_FLOOR, 6],
+        [:ROUND_HALF_EVEN, 7]
+      ].each do |const, value|
+        it "has a #{const} value" do
+          BigDecimal.const_get(const).should == value
+        end
       end
     end
-  end
 
-  describe "sign-related constants" do
-    [
-      [:SIGN_NaN, 0],
-      [:SIGN_POSITIVE_ZERO, 1],
-      [:SIGN_NEGATIVE_ZERO, -1],
-      [:SIGN_POSITIVE_FINITE, 2],
-      [:SIGN_NEGATIVE_FINITE, -2],
-      [:SIGN_POSITIVE_INFINITE, 3],
-      [:SIGN_NEGATIVE_INFINITE, -3]
-    ].each do |const, value|
-      it "has a #{const} value" do
-        BigDecimal.const_get(const).should == value
+    describe "sign-related constants" do
+      [
+        [:SIGN_NaN, 0],
+        [:SIGN_POSITIVE_ZERO, 1],
+        [:SIGN_NEGATIVE_ZERO, -1],
+        [:SIGN_POSITIVE_FINITE, 2],
+        [:SIGN_NEGATIVE_FINITE, -2],
+        [:SIGN_POSITIVE_INFINITE, 3],
+        [:SIGN_NEGATIVE_INFINITE, -3]
+      ].each do |const, value|
+        it "has a #{const} value" do
+          BigDecimal.const_get(const).should == value
+        end
       end
     end
   end

--- a/spec/ruby/library/bigdecimal/div_spec.rb
+++ b/spec/ruby/library/bigdecimal/div_spec.rb
@@ -1,110 +1,113 @@
 require_relative '../../spec_helper'
-require_relative 'shared/quo'
-require 'bigdecimal'
 
-describe "BigDecimal#div with precision set to 0" do
-  # TODO: figure out if there is a better way to do these
-  # shared specs rather than sending [0]. See other specs
-  # that share :bigdecimal_quo.
-  it_behaves_like :bigdecimal_quo, :div, [0]
-end
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/quo'
+  require 'bigdecimal'
 
-describe "BigDecimal#div" do
-
-  before :each do
-    @one = BigDecimal("1")
-    @zero = BigDecimal("0")
-    @zero_plus = BigDecimal("+0")
-    @zero_minus = BigDecimal("-0")
-    @two = BigDecimal("2")
-    @three = BigDecimal("3")
-    @nan = BigDecimal("NaN")
-    @infinity = BigDecimal("Infinity")
-    @infinity_minus = BigDecimal("-Infinity")
-    @one_minus = BigDecimal("-1")
-    @frac_1 = BigDecimal("1E-99999")
-    @frac_2 = BigDecimal("0.9E-99999")
+  describe "BigDecimal#div with precision set to 0" do
+    # TODO: figure out if there is a better way to do these
+    # shared specs rather than sending [0]. See other specs
+    # that share :bigdecimal_quo.
+    it_behaves_like :bigdecimal_quo, :div, [0]
   end
 
-  it "returns a / b with optional precision" do
-    @two.div(@one).should == @two
-    @one.div(@two).should == @zero
-    # ^^ is this really intended for a class with arbitrary precision?
-    @one.div(@two, 1).should == BigDecimal("0.5")
-    @one.div(@one_minus).should == @one_minus
-    @one_minus.div(@one_minus).should == @one
-    @frac_2.div(@frac_1, 1).should == BigDecimal("0.9")
-    @frac_1.div(@frac_1).should == @one
+  describe "BigDecimal#div" do
 
-    res = "0." + "3" * 1000
-    (1..100).each { |idx|
-      @one.div(@three, idx).to_s("F").should == "0." + res[2, idx]
-    }
-  end
-
-  describe "with Object" do
-    it "tries to coerce the other operand to self" do
-      object = mock("Object")
-      object.should_receive(:coerce).with(@one).and_return([@one, @two])
-      @one.div(object).should == @zero
+    before :each do
+      @one = BigDecimal("1")
+      @zero = BigDecimal("0")
+      @zero_plus = BigDecimal("+0")
+      @zero_minus = BigDecimal("-0")
+      @two = BigDecimal("2")
+      @three = BigDecimal("3")
+      @nan = BigDecimal("NaN")
+      @infinity = BigDecimal("Infinity")
+      @infinity_minus = BigDecimal("-Infinity")
+      @one_minus = BigDecimal("-1")
+      @frac_1 = BigDecimal("1E-99999")
+      @frac_2 = BigDecimal("0.9E-99999")
     end
+
+    it "returns a / b with optional precision" do
+      @two.div(@one).should == @two
+      @one.div(@two).should == @zero
+      # ^^ is this really intended for a class with arbitrary precision?
+      @one.div(@two, 1).should == BigDecimal("0.5")
+      @one.div(@one_minus).should == @one_minus
+      @one_minus.div(@one_minus).should == @one
+      @frac_2.div(@frac_1, 1).should == BigDecimal("0.9")
+      @frac_1.div(@frac_1).should == @one
+
+      res = "0." + "3" * 1000
+      (1..100).each { |idx|
+        @one.div(@three, idx).to_s("F").should == "0." + res[2, idx]
+      }
+    end
+
+    describe "with Object" do
+      it "tries to coerce the other operand to self" do
+        object = mock("Object")
+        object.should_receive(:coerce).with(@one).and_return([@one, @two])
+        @one.div(object).should == @zero
+      end
+    end
+
+    it "raises FloatDomainError if NaN is involved" do
+      -> { @one.div(@nan) }.should raise_error(FloatDomainError)
+      -> { @nan.div(@one) }.should raise_error(FloatDomainError)
+      -> { @nan.div(@nan) }.should raise_error(FloatDomainError)
+    end
+
+    it "returns 0 if divided by Infinity and no precision given" do
+      @zero.div(@infinity).should == 0
+      @frac_2.div(@infinity).should == 0
+    end
+
+    it "returns 0 if divided by Infinity with given precision" do
+      @zero.div(@infinity, 0).should == 0
+      @frac_2.div(@infinity, 1).should == 0
+      @zero.div(@infinity, 100000).should == 0
+      @frac_2.div(@infinity, 100000).should == 0
+    end
+
+    it "raises ZeroDivisionError if divided by zero and no precision given" do
+      -> { @one.div(@zero) }.should raise_error(ZeroDivisionError)
+      -> { @one.div(@zero_plus) }.should raise_error(ZeroDivisionError)
+      -> { @one.div(@zero_minus) }.should raise_error(ZeroDivisionError)
+
+      -> { @zero.div(@zero) }.should raise_error(ZeroDivisionError)
+      -> { @zero_minus.div(@zero_plus) }.should raise_error(ZeroDivisionError)
+      -> { @zero_minus.div(@zero_minus) }.should raise_error(ZeroDivisionError)
+      -> { @zero_plus.div(@zero_minus) }.should raise_error(ZeroDivisionError)
+    end
+
+    it "returns NaN if zero is divided by zero" do
+      @zero.div(@zero, 0).should.nan?
+      @zero_minus.div(@zero_plus, 0).should.nan?
+      @zero_plus.div(@zero_minus, 0).should.nan?
+
+      @zero.div(@zero, 10).should.nan?
+      @zero_minus.div(@zero_plus, 10).should.nan?
+      @zero_plus.div(@zero_minus, 10).should.nan?
+    end
+
+    it "raises FloatDomainError if (+|-) Infinity divided by 1 and no precision given" do
+      -> { @infinity_minus.div(@one) }.should raise_error(FloatDomainError)
+      -> { @infinity.div(@one) }.should raise_error(FloatDomainError)
+      -> { @infinity_minus.div(@one_minus) }.should raise_error(FloatDomainError)
+    end
+
+    it "returns (+|-)Infinity if (+|-)Infinity by 1 and precision given" do
+      @infinity_minus.div(@one, 0).should == @infinity_minus
+      @infinity.div(@one, 0).should == @infinity
+      @infinity_minus.div(@one_minus, 0).should == @infinity
+    end
+
+    it "returns NaN if Infinity / ((+|-) Infinity)" do
+      @infinity.div(@infinity_minus, 100000).should.nan?
+      @infinity_minus.div(@infinity, 1).should.nan?
+    end
+
+
   end
-
-  it "raises FloatDomainError if NaN is involved" do
-    -> { @one.div(@nan) }.should raise_error(FloatDomainError)
-    -> { @nan.div(@one) }.should raise_error(FloatDomainError)
-    -> { @nan.div(@nan) }.should raise_error(FloatDomainError)
-  end
-
-  it "returns 0 if divided by Infinity and no precision given" do
-    @zero.div(@infinity).should == 0
-    @frac_2.div(@infinity).should == 0
-  end
-
-  it "returns 0 if divided by Infinity with given precision" do
-    @zero.div(@infinity, 0).should == 0
-    @frac_2.div(@infinity, 1).should == 0
-    @zero.div(@infinity, 100000).should == 0
-    @frac_2.div(@infinity, 100000).should == 0
-  end
-
-  it "raises ZeroDivisionError if divided by zero and no precision given" do
-    -> { @one.div(@zero) }.should raise_error(ZeroDivisionError)
-    -> { @one.div(@zero_plus) }.should raise_error(ZeroDivisionError)
-    -> { @one.div(@zero_minus) }.should raise_error(ZeroDivisionError)
-
-    -> { @zero.div(@zero) }.should raise_error(ZeroDivisionError)
-    -> { @zero_minus.div(@zero_plus) }.should raise_error(ZeroDivisionError)
-    -> { @zero_minus.div(@zero_minus) }.should raise_error(ZeroDivisionError)
-    -> { @zero_plus.div(@zero_minus) }.should raise_error(ZeroDivisionError)
-  end
-
-  it "returns NaN if zero is divided by zero" do
-    @zero.div(@zero, 0).should.nan?
-    @zero_minus.div(@zero_plus, 0).should.nan?
-    @zero_plus.div(@zero_minus, 0).should.nan?
-
-    @zero.div(@zero, 10).should.nan?
-    @zero_minus.div(@zero_plus, 10).should.nan?
-    @zero_plus.div(@zero_minus, 10).should.nan?
-  end
-
-  it "raises FloatDomainError if (+|-) Infinity divided by 1 and no precision given" do
-    -> { @infinity_minus.div(@one) }.should raise_error(FloatDomainError)
-    -> { @infinity.div(@one) }.should raise_error(FloatDomainError)
-    -> { @infinity_minus.div(@one_minus) }.should raise_error(FloatDomainError)
-  end
-
-  it "returns (+|-)Infinity if (+|-)Infinity by 1 and precision given" do
-    @infinity_minus.div(@one, 0).should == @infinity_minus
-    @infinity.div(@one, 0).should == @infinity
-    @infinity_minus.div(@one_minus, 0).should == @infinity
-  end
-
-  it "returns NaN if Infinity / ((+|-) Infinity)" do
-    @infinity.div(@infinity_minus, 100000).should.nan?
-    @infinity_minus.div(@infinity, 1).should.nan?
-  end
-
-
 end

--- a/spec/ruby/library/bigdecimal/divide_spec.rb
+++ b/spec/ruby/library/bigdecimal/divide_spec.rb
@@ -1,17 +1,20 @@
 require_relative '../../spec_helper'
-require_relative 'shared/quo'
-require 'bigdecimal'
 
-describe "BigDecimal#/" do
-  it_behaves_like :bigdecimal_quo, :/, []
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/quo'
+  require 'bigdecimal'
 
-  before :each do
-    @three = BigDecimal("3")
-  end
+  describe "BigDecimal#/" do
+    it_behaves_like :bigdecimal_quo, :/, []
 
-  describe "with Rational" do
-    it "produces a BigDecimal" do
-      (@three / Rational(500, 2)).should == BigDecimal("0.12e-1")
+    before :each do
+      @three = BigDecimal("3")
+    end
+
+    describe "with Rational" do
+      it "produces a BigDecimal" do
+        (@three / Rational(500, 2)).should == BigDecimal("0.12e-1")
+      end
     end
   end
 end

--- a/spec/ruby/library/bigdecimal/divmod_spec.rb
+++ b/spec/ruby/library/bigdecimal/divmod_spec.rb
@@ -1,180 +1,183 @@
 require_relative '../../spec_helper'
-require_relative 'shared/modulo'
-require 'bigdecimal'
 
-module DivmodSpecs
-  def self.check_both_nan(array)
-    array.length.should == 2
-    array[0].should.nan?
-    array[1].should.nan?
-  end
-  def self.check_both_bigdecimal(array)
-    array.length.should == 2
-    array[0].kind_of?(BigDecimal).should == true
-    array[1].kind_of?(BigDecimal).should == true
-  end
-end
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/modulo'
+  require 'bigdecimal'
 
-# TODO: figure out a way to do the shared specs with helpers instead
-# of spec'ing a method that does not really exist
-describe "BigDecimal#mod_part_of_divmod" do
-  # BigDecimal#divmod[1] behaves exactly like #modulo
-  before :all do
-    class BigDecimal
-      def mod_part_of_divmod(arg)
-        divmod(arg)[1]
-      end
-    end
-  end
-
-  after :all do
-    class BigDecimal
-      undef mod_part_of_divmod
-    end
-  end
-
-  it_behaves_like :bigdecimal_modulo, :mod_part_of_divmod
-
-  it "raises ZeroDivisionError if other is zero" do
-    bd5667 = BigDecimal("5667.19")
-
-    -> { bd5667.mod_part_of_divmod(0) }.should raise_error(ZeroDivisionError)
-    -> { bd5667.mod_part_of_divmod(BigDecimal("0")) }.should raise_error(ZeroDivisionError)
-    -> { @zero.mod_part_of_divmod(@zero) }.should raise_error(ZeroDivisionError)
-  end
-end
-
-describe "BigDecimal#divmod" do
-
-  before :each do
-    @a = BigDecimal("42.00000000000000000001")
-
-    @zero = BigDecimal("0")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-
-    @one = BigDecimal("1")
-    @mixed = BigDecimal("1.23456789")
-    @pos_int = BigDecimal("2E5555")
-    @neg_int = BigDecimal("-2E5555")
-    @pos_frac = BigDecimal("2E-9999")
-    @neg_frac = BigDecimal("-2E-9999")
-    @nan = BigDecimal("NaN")
-    @infinity = BigDecimal("Infinity")
-    @infinity_minus = BigDecimal("-Infinity")
-    @one_minus = BigDecimal("-1")
-    @frac_1 = BigDecimal("1E-99999")
-    @frac_2 = BigDecimal("0.9E-99999")
-
-    @special_vals = [@infinity, @infinity_minus, @nan]
-    @regular_vals = [
-      @one, @mixed, @pos_int, @neg_int, @pos_frac,
-      @neg_frac, @one_minus, @frac_1, @frac_2]
-    @zeroes = [@zero, @zero_pos, @zero_neg]
-  end
-
-  it "divides value, returns an array" do
-    res = @a.divmod(5)
-    res.kind_of?(Array).should == true
-  end
-
-  it "array contains quotient and modulus as BigDecimal" do
-    res = @a.divmod(5)
-    DivmodSpecs.check_both_bigdecimal(res)
-    res[0].should == BigDecimal('0.8E1')
-    res[1].should == BigDecimal('2.00000000000000000001')
-
-    BigDecimal('1').divmod(BigDecimal('2')).should == [0, 1]
-    BigDecimal('2').divmod(BigDecimal('1')).should == [2, 0]
-
-    BigDecimal('1').divmod(BigDecimal('-2')).should == [-1, -1]
-    BigDecimal('2').divmod(BigDecimal('-1')).should == [-2, 0]
-
-    BigDecimal('-1').divmod(BigDecimal('2')).should == [-1, 1]
-    BigDecimal('-2').divmod(BigDecimal('1')).should == [-2, 0]
-  end
-
-  it "can be reversed with * and +" do
-    # Example taken from BigDecimal documentation
-    a = BigDecimal("42")
-    b = BigDecimal("9")
-    q, m = a.divmod(b)
-    c = q * b + m
-    a.should == c
-
-    values = [@one, @one_minus, BigDecimal('2'), BigDecimal('-2'),
-      BigDecimal('5'), BigDecimal('-5'), BigDecimal('10'), BigDecimal('-10'),
-      BigDecimal('20'), BigDecimal('-20'), BigDecimal('100'), BigDecimal('-100'),
-      BigDecimal('1.23456789E10'), BigDecimal('-1.23456789E10')
-    ]
-
-    # TODO: file MRI bug:
-    # BigDecimal('1').divmod(BigDecimal('3E-9'))[0] #=> 0.3E9,
-    # but really should be 0.333333333E9
-    values << BigDecimal('1E-10')
-    values << BigDecimal('-1E-10')
-    values << BigDecimal('2E55')
-    values << BigDecimal('-2E55')
-    values << BigDecimal('2E-5555')
-    values << BigDecimal('-2E-5555')
-
-
-    values_and_zeroes = values + @zeroes
-    values_and_zeroes.each do |val1|
-      values.each do |val2|
-        res = val1.divmod(val2)
-        DivmodSpecs.check_both_bigdecimal(res)
-        res[0].should == ((val1/val2).floor)
-        res[1].should == (val1 - res[0] * val2)
-      end
-    end
-  end
-
-  it "returns an array of two NaNs if NaN is involved" do
-    (@special_vals + @regular_vals + @zeroes).each do |val|
-      DivmodSpecs.check_both_nan(val.divmod(@nan))
-      DivmodSpecs.check_both_nan(@nan.divmod(val))
-    end
-  end
-
-  it "raises ZeroDivisionError if the divisor is zero" do
-    (@special_vals + @regular_vals + @zeroes - [@nan]).each do |val|
-      @zeroes.each do |zero|
-        -> { val.divmod(zero) }.should raise_error(ZeroDivisionError)
-      end
-    end
-  end
-
-  it "returns an array of Infinity and NaN if the dividend is Infinity" do
-    @regular_vals.each do |val|
-      array = @infinity.divmod(val)
+  module DivmodSpecs
+    def self.check_both_nan(array)
       array.length.should == 2
-      array[0].infinite?.should == (val > 0 ? 1 : -1)
+      array[0].should.nan?
       array[1].should.nan?
     end
-  end
-
-  it "returns an array of zero and the dividend if the divisor is Infinity" do
-    @regular_vals.each do |val|
-      array = val.divmod(@infinity)
+    def self.check_both_bigdecimal(array)
       array.length.should == 2
-      array[0].should == @zero
-      array[1].should == val
+      array[0].kind_of?(BigDecimal).should == true
+      array[1].kind_of?(BigDecimal).should == true
     end
   end
 
-  it "returns an array of two zero if the dividend is zero" do
-    @zeroes.each do |zero|
-      @regular_vals.each do |val|
-        zero.divmod(val).should == [@zero, @zero]
+  # TODO: figure out a way to do the shared specs with helpers instead
+  # of spec'ing a method that does not really exist
+  describe "BigDecimal#mod_part_of_divmod" do
+    # BigDecimal#divmod[1] behaves exactly like #modulo
+    before :all do
+      class BigDecimal
+        def mod_part_of_divmod(arg)
+          divmod(arg)[1]
+        end
       end
     end
+
+    after :all do
+      class BigDecimal
+        undef mod_part_of_divmod
+      end
+    end
+
+    it_behaves_like :bigdecimal_modulo, :mod_part_of_divmod
+
+    it "raises ZeroDivisionError if other is zero" do
+      bd5667 = BigDecimal("5667.19")
+
+      -> { bd5667.mod_part_of_divmod(0) }.should raise_error(ZeroDivisionError)
+      -> { bd5667.mod_part_of_divmod(BigDecimal("0")) }.should raise_error(ZeroDivisionError)
+      -> { @zero.mod_part_of_divmod(@zero) }.should raise_error(ZeroDivisionError)
+    end
   end
 
-  it "raises TypeError if the argument cannot be coerced to BigDecimal" do
-    -> {
-      @one.divmod('1')
-    }.should raise_error(TypeError)
-  end
+  describe "BigDecimal#divmod" do
 
+    before :each do
+      @a = BigDecimal("42.00000000000000000001")
+
+      @zero = BigDecimal("0")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
+
+      @one = BigDecimal("1")
+      @mixed = BigDecimal("1.23456789")
+      @pos_int = BigDecimal("2E5555")
+      @neg_int = BigDecimal("-2E5555")
+      @pos_frac = BigDecimal("2E-9999")
+      @neg_frac = BigDecimal("-2E-9999")
+      @nan = BigDecimal("NaN")
+      @infinity = BigDecimal("Infinity")
+      @infinity_minus = BigDecimal("-Infinity")
+      @one_minus = BigDecimal("-1")
+      @frac_1 = BigDecimal("1E-99999")
+      @frac_2 = BigDecimal("0.9E-99999")
+
+      @special_vals = [@infinity, @infinity_minus, @nan]
+      @regular_vals = [
+        @one, @mixed, @pos_int, @neg_int, @pos_frac,
+        @neg_frac, @one_minus, @frac_1, @frac_2]
+      @zeroes = [@zero, @zero_pos, @zero_neg]
+    end
+
+    it "divides value, returns an array" do
+      res = @a.divmod(5)
+      res.kind_of?(Array).should == true
+    end
+
+    it "array contains quotient and modulus as BigDecimal" do
+      res = @a.divmod(5)
+      DivmodSpecs.check_both_bigdecimal(res)
+      res[0].should == BigDecimal('0.8E1')
+      res[1].should == BigDecimal('2.00000000000000000001')
+
+      BigDecimal('1').divmod(BigDecimal('2')).should == [0, 1]
+      BigDecimal('2').divmod(BigDecimal('1')).should == [2, 0]
+
+      BigDecimal('1').divmod(BigDecimal('-2')).should == [-1, -1]
+      BigDecimal('2').divmod(BigDecimal('-1')).should == [-2, 0]
+
+      BigDecimal('-1').divmod(BigDecimal('2')).should == [-1, 1]
+      BigDecimal('-2').divmod(BigDecimal('1')).should == [-2, 0]
+    end
+
+    it "can be reversed with * and +" do
+      # Example taken from BigDecimal documentation
+      a = BigDecimal("42")
+      b = BigDecimal("9")
+      q, m = a.divmod(b)
+      c = q * b + m
+      a.should == c
+
+      values = [@one, @one_minus, BigDecimal('2'), BigDecimal('-2'),
+        BigDecimal('5'), BigDecimal('-5'), BigDecimal('10'), BigDecimal('-10'),
+        BigDecimal('20'), BigDecimal('-20'), BigDecimal('100'), BigDecimal('-100'),
+        BigDecimal('1.23456789E10'), BigDecimal('-1.23456789E10')
+      ]
+
+      # TODO: file MRI bug:
+      # BigDecimal('1').divmod(BigDecimal('3E-9'))[0] #=> 0.3E9,
+      # but really should be 0.333333333E9
+      values << BigDecimal('1E-10')
+      values << BigDecimal('-1E-10')
+      values << BigDecimal('2E55')
+      values << BigDecimal('-2E55')
+      values << BigDecimal('2E-5555')
+      values << BigDecimal('-2E-5555')
+
+
+      values_and_zeroes = values + @zeroes
+      values_and_zeroes.each do |val1|
+        values.each do |val2|
+          res = val1.divmod(val2)
+          DivmodSpecs.check_both_bigdecimal(res)
+          res[0].should == ((val1/val2).floor)
+          res[1].should == (val1 - res[0] * val2)
+        end
+      end
+    end
+
+    it "returns an array of two NaNs if NaN is involved" do
+      (@special_vals + @regular_vals + @zeroes).each do |val|
+        DivmodSpecs.check_both_nan(val.divmod(@nan))
+        DivmodSpecs.check_both_nan(@nan.divmod(val))
+      end
+    end
+
+    it "raises ZeroDivisionError if the divisor is zero" do
+      (@special_vals + @regular_vals + @zeroes - [@nan]).each do |val|
+        @zeroes.each do |zero|
+          -> { val.divmod(zero) }.should raise_error(ZeroDivisionError)
+        end
+      end
+    end
+
+    it "returns an array of Infinity and NaN if the dividend is Infinity" do
+      @regular_vals.each do |val|
+        array = @infinity.divmod(val)
+        array.length.should == 2
+        array[0].infinite?.should == (val > 0 ? 1 : -1)
+        array[1].should.nan?
+      end
+    end
+
+    it "returns an array of zero and the dividend if the divisor is Infinity" do
+      @regular_vals.each do |val|
+        array = val.divmod(@infinity)
+        array.length.should == 2
+        array[0].should == @zero
+        array[1].should == val
+      end
+    end
+
+    it "returns an array of two zero if the dividend is zero" do
+      @zeroes.each do |zero|
+        @regular_vals.each do |val|
+          zero.divmod(val).should == [@zero, @zero]
+        end
+      end
+    end
+
+    it "raises TypeError if the argument cannot be coerced to BigDecimal" do
+      -> {
+        @one.divmod('1')
+      }.should raise_error(TypeError)
+    end
+
+  end
 end

--- a/spec/ruby/library/bigdecimal/double_fig_spec.rb
+++ b/spec/ruby/library/bigdecimal/double_fig_spec.rb
@@ -1,9 +1,12 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal.double_fig" do
-  # The result depends on the CPU and OS
-  it "returns the number of digits a Float number is allowed to have" do
-    BigDecimal.double_fig.should_not == nil
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
+
+  describe "BigDecimal.double_fig" do
+    # The result depends on the CPU and OS
+    it "returns the number of digits a Float number is allowed to have" do
+      BigDecimal.double_fig.should_not == nil
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/dup_spec.rb
+++ b/spec/ruby/library/bigdecimal/dup_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../spec_helper'
-require_relative 'shared/clone'
 
-describe "BigDecimal#dup" do
-  it_behaves_like :bigdecimal_clone, :dup
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/clone'
+
+  describe "BigDecimal#dup" do
+    it_behaves_like :bigdecimal_clone, :dup
+  end
 end

--- a/spec/ruby/library/bigdecimal/eql_spec.rb
+++ b/spec/ruby/library/bigdecimal/eql_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../spec_helper'
-require_relative 'shared/eql'
 
-describe "BigDecimal#eql?" do
-  it_behaves_like :bigdecimal_eql, :eql?
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/eql'
+
+  describe "BigDecimal#eql?" do
+    it_behaves_like :bigdecimal_eql, :eql?
+  end
 end

--- a/spec/ruby/library/bigdecimal/equal_value_spec.rb
+++ b/spec/ruby/library/bigdecimal/equal_value_spec.rb
@@ -1,7 +1,10 @@
 require_relative '../../spec_helper'
-require_relative 'shared/eql'
+
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/eql'
 
 
-describe "BigDecimal#==" do
-  it_behaves_like :bigdecimal_eql, :==
+  describe "BigDecimal#==" do
+    it_behaves_like :bigdecimal_eql, :==
+  end
 end

--- a/spec/ruby/library/bigdecimal/exponent_spec.rb
+++ b/spec/ruby/library/bigdecimal/exponent_spec.rb
@@ -1,27 +1,30 @@
 require_relative '../../spec_helper'
-require_relative 'shared/power'
-require 'bigdecimal'
 
-describe "BigDecimal#**" do
-  it_behaves_like :bigdecimal_power, :**
-end
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/power'
+  require 'bigdecimal'
 
-describe "BigDecimal#exponent" do
-
-  it "returns an Integer" do
-    BigDecimal("2E100000000").exponent.kind_of?(Integer).should == true
-    BigDecimal("2E-999").exponent.kind_of?(Integer).should == true
+  describe "BigDecimal#**" do
+    it_behaves_like :bigdecimal_power, :**
   end
 
-  it "is n if number can be represented as 0.xxx*10**n" do
-    BigDecimal("2E1000").exponent.should == 1001
-    BigDecimal("1234567E10").exponent.should == 17
-  end
+  describe "BigDecimal#exponent" do
 
-  it "returns 0 if self is 0" do
-    BigDecimal("0").exponent.should == 0
-    BigDecimal("+0").exponent.should == 0
-    BigDecimal("-0").exponent.should == 0
-  end
+    it "returns an Integer" do
+      BigDecimal("2E100000000").exponent.kind_of?(Integer).should == true
+      BigDecimal("2E-999").exponent.kind_of?(Integer).should == true
+    end
 
+    it "is n if number can be represented as 0.xxx*10**n" do
+      BigDecimal("2E1000").exponent.should == 1001
+      BigDecimal("1234567E10").exponent.should == 17
+    end
+
+    it "returns 0 if self is 0" do
+      BigDecimal("0").exponent.should == 0
+      BigDecimal("+0").exponent.should == 0
+      BigDecimal("-0").exponent.should == 0
+    end
+
+  end
 end

--- a/spec/ruby/library/bigdecimal/finite_spec.rb
+++ b/spec/ruby/library/bigdecimal/finite_spec.rb
@@ -1,34 +1,37 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#finite?" do
-  before :each do
-    @one = BigDecimal("1")
-    @zero = BigDecimal("0")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-    @two = BigDecimal("2")
-    @three = BigDecimal("3")
-    @nan = BigDecimal("NaN")
-    @infinity = BigDecimal("Infinity")
-    @infinity_minus = BigDecimal("-Infinity")
-    @one_minus = BigDecimal("-1")
-    @frac_1 = BigDecimal("1E-99999")
-    @frac_2 = BigDecimal("0.9E-99999")
-    @big = BigDecimal("2E40001")
-    @finite_vals = [@one, @zero, @zero_pos, @zero_neg, @two,
-      @three, @frac_1, @frac_2, @big, @one_minus]
-  end
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  it "is false if Infinity or NaN" do
-    @infinity.should_not.finite?
-    @infinity_minus.should_not.finite?
-    @nan.should_not.finite?
-  end
+  describe "BigDecimal#finite?" do
+    before :each do
+      @one = BigDecimal("1")
+      @zero = BigDecimal("0")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
+      @two = BigDecimal("2")
+      @three = BigDecimal("3")
+      @nan = BigDecimal("NaN")
+      @infinity = BigDecimal("Infinity")
+      @infinity_minus = BigDecimal("-Infinity")
+      @one_minus = BigDecimal("-1")
+      @frac_1 = BigDecimal("1E-99999")
+      @frac_2 = BigDecimal("0.9E-99999")
+      @big = BigDecimal("2E40001")
+      @finite_vals = [@one, @zero, @zero_pos, @zero_neg, @two,
+        @three, @frac_1, @frac_2, @big, @one_minus]
+    end
 
-  it "returns true for finite values" do
-    @finite_vals.each do |val|
-      val.should.finite?
+    it "is false if Infinity or NaN" do
+      @infinity.should_not.finite?
+      @infinity_minus.should_not.finite?
+      @nan.should_not.finite?
+    end
+
+    it "returns true for finite values" do
+      @finite_vals.each do |val|
+        val.should.finite?
+      end
     end
   end
 end

--- a/spec/ruby/library/bigdecimal/fix_spec.rb
+++ b/spec/ruby/library/bigdecimal/fix_spec.rb
@@ -1,57 +1,60 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#fix" do
-    before :each do
-      @zero = BigDecimal("0")
-      @mixed = BigDecimal("1.23456789")
-      @pos_int = BigDecimal("2E5555")
-      @neg_int = BigDecimal("-2E5555")
-      @pos_frac = BigDecimal("2E-9999")
-      @neg_frac = BigDecimal("-2E-9999")
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-      @infinity = BigDecimal("Infinity")
-      @infinity_neg = BigDecimal("-Infinity")
-      @nan = BigDecimal("NaN")
-      @zero_pos = BigDecimal("+0")
-      @zero_neg = BigDecimal("-0")
+  describe "BigDecimal#fix" do
+      before :each do
+        @zero = BigDecimal("0")
+        @mixed = BigDecimal("1.23456789")
+        @pos_int = BigDecimal("2E5555")
+        @neg_int = BigDecimal("-2E5555")
+        @pos_frac = BigDecimal("2E-9999")
+        @neg_frac = BigDecimal("-2E-9999")
+
+        @infinity = BigDecimal("Infinity")
+        @infinity_neg = BigDecimal("-Infinity")
+        @nan = BigDecimal("NaN")
+        @zero_pos = BigDecimal("+0")
+        @zero_neg = BigDecimal("-0")
+      end
+
+    it "returns a BigDecimal" do
+      BigDecimal("2E100000000").fix.kind_of?(BigDecimal).should == true
+      BigDecimal("2E-999").kind_of?(BigDecimal).should == true
     end
 
-  it "returns a BigDecimal" do
-    BigDecimal("2E100000000").fix.kind_of?(BigDecimal).should == true
-    BigDecimal("2E-999").kind_of?(BigDecimal).should == true
-  end
+    it "returns the integer part of the absolute value" do
+      a = BigDecimal("2E1000")
+      a.fix.should == a
+      b = BigDecimal("-2E1000")
+      b.fix.should == b
+      BigDecimal("0.123456789E5").fix.should == BigDecimal("0.12345E5")
+      BigDecimal("-0.123456789E5").fix.should == BigDecimal("-0.12345E5")
+    end
 
-  it "returns the integer part of the absolute value" do
-    a = BigDecimal("2E1000")
-    a.fix.should == a
-    b = BigDecimal("-2E1000")
-    b.fix.should == b
-    BigDecimal("0.123456789E5").fix.should == BigDecimal("0.12345E5")
-    BigDecimal("-0.123456789E5").fix.should == BigDecimal("-0.12345E5")
-  end
+    it "correctly handles special values" do
+      @infinity.fix.should == @infinity
+      @infinity_neg.fix.should == @infinity_neg
+      @nan.fix.should.nan?
+    end
 
-  it "correctly handles special values" do
-    @infinity.fix.should == @infinity
-    @infinity_neg.fix.should == @infinity_neg
-    @nan.fix.should.nan?
-  end
+    it "returns 0 if the absolute value is < 1" do
+      BigDecimal("0.99999").fix.should == 0
+      BigDecimal("-0.99999").fix.should == 0
+      BigDecimal("0.000000001").fix.should == 0
+      BigDecimal("-0.00000001").fix.should == 0
+      BigDecimal("-1000000").fix.should_not == 0
+      @zero.fix.should == 0
+      @zero_pos.fix.should == @zero_pos
+      @zero_neg.fix.should == @zero_neg
+    end
 
-  it "returns 0 if the absolute value is < 1" do
-    BigDecimal("0.99999").fix.should == 0
-    BigDecimal("-0.99999").fix.should == 0
-    BigDecimal("0.000000001").fix.should == 0
-    BigDecimal("-0.00000001").fix.should == 0
-    BigDecimal("-1000000").fix.should_not == 0
-    @zero.fix.should == 0
-    @zero_pos.fix.should == @zero_pos
-    @zero_neg.fix.should == @zero_neg
-  end
+    it "does not allow any arguments" do
+      -> {
+        @mixed.fix(10)
+      }.should raise_error(ArgumentError)
+    end
 
-  it "does not allow any arguments" do
-    -> {
-      @mixed.fix(10)
-    }.should raise_error(ArgumentError)
   end
-
 end

--- a/spec/ruby/library/bigdecimal/floor_spec.rb
+++ b/spec/ruby/library/bigdecimal/floor_spec.rb
@@ -1,100 +1,103 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#floor" do
-  before :each do
-    @one = BigDecimal("1")
-    @three = BigDecimal("3")
-    @four = BigDecimal("4")
-    @zero = BigDecimal("0")
-    @mixed = BigDecimal("1.23456789")
-    @mixed_big = BigDecimal("1.23456789E100")
-    @pos_int = BigDecimal("2E5555")
-    @neg_int = BigDecimal("-2E5555")
-    @pos_frac = BigDecimal("2E-9999")
-    @neg_frac = BigDecimal("-2E-9999")
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-    @infinity = BigDecimal("Infinity")
-    @infinity_neg = BigDecimal("-Infinity")
-    @nan = BigDecimal("NaN")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-  end
+  describe "BigDecimal#floor" do
+    before :each do
+      @one = BigDecimal("1")
+      @three = BigDecimal("3")
+      @four = BigDecimal("4")
+      @zero = BigDecimal("0")
+      @mixed = BigDecimal("1.23456789")
+      @mixed_big = BigDecimal("1.23456789E100")
+      @pos_int = BigDecimal("2E5555")
+      @neg_int = BigDecimal("-2E5555")
+      @pos_frac = BigDecimal("2E-9999")
+      @neg_frac = BigDecimal("-2E-9999")
 
-  it "returns the greatest integer smaller or equal to self" do
-    @pos_int.floor.should == @pos_int
-    @neg_int.floor.should == @neg_int
-    @pos_frac.floor.should == @zero
-    @neg_frac.floor.should == BigDecimal("-1")
-    @zero.floor.should == 0
-    @zero_pos.floor.should == @zero_pos
-    @zero_neg.floor.should == @zero_neg
-
-    BigDecimal('2.3').floor.should == 2
-    BigDecimal('2.5').floor.should == 2
-    BigDecimal('2.9999').floor.should == 2
-    BigDecimal('-2.3').floor.should == -3
-    BigDecimal('-2.5').floor.should == -3
-    BigDecimal('-2.9999').floor.should == -3
-    BigDecimal('0.8').floor.should == 0
-    BigDecimal('-0.8').floor.should == -1
-  end
-
-  it "raise exception, if self is special value" do
-    -> { @infinity.floor }.should raise_error(FloatDomainError)
-    -> { @infinity_neg.floor }.should raise_error(FloatDomainError)
-    -> { @nan.floor }.should raise_error(FloatDomainError)
-  end
-
-  it "returns n digits right of the decimal point if given n > 0" do
-    @mixed.floor(1).should == BigDecimal("1.2")
-    @mixed.floor(5).should == BigDecimal("1.23456")
-
-    BigDecimal("-0.03").floor(1).should == BigDecimal("-0.1")
-    BigDecimal("0.03").floor(1).should == BigDecimal("0")
-
-    BigDecimal("23.45").floor(0).should == BigDecimal('23')
-    BigDecimal("23.45").floor(1).should == BigDecimal('23.4')
-    BigDecimal("23.45").floor(2).should == BigDecimal('23.45')
-
-    BigDecimal("-23.45").floor(0).should == BigDecimal('-24')
-    BigDecimal("-23.45").floor(1).should == BigDecimal('-23.5')
-    BigDecimal("-23.45").floor(2).should == BigDecimal('-23.45')
-
-    BigDecimal("2E-10").floor(0).should == @zero
-    BigDecimal("2E-10").floor(9).should == @zero
-    BigDecimal("2E-10").floor(10).should == BigDecimal('2E-10')
-    BigDecimal("2E-10").floor(11).should == BigDecimal('2E-10')
-
-    (1..10).each do |n|
-      # 0.3, 0.33, 0.333, etc.
-      (@one.div(@three,20)).floor(n).should == BigDecimal("0.#{'3'*n}")
-      # 1.3, 1.33, 1.333, etc.
-      (@four.div(@three,20)).floor(n).should == BigDecimal("1.#{'3'*n}")
-      (BigDecimal('31').div(@three,20)).floor(n).should == BigDecimal("10.#{'3'*n}")
+      @infinity = BigDecimal("Infinity")
+      @infinity_neg = BigDecimal("-Infinity")
+      @nan = BigDecimal("NaN")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
     end
-    (1..10).each do |n|
-      # -0.4, -0.34, -0.334, etc.
-      (-@one.div(@three,20)).floor(n).should == BigDecimal("-0.#{'3'*(n-1)}4")
-    end
-    (1..10).each do |n|
-      (@three.div(@one,20)).floor(n).should == @three
-    end
-    (1..10).each do |n|
-      (-@three.div(@one,20)).floor(n).should == -@three
-    end
-  end
 
-  it "sets n digits left of the decimal point to 0, if given n < 0" do
-    BigDecimal("13345.234").floor(-2).should == BigDecimal("13300.0")
-    @mixed_big.floor(-99).should == BigDecimal("0.12E101")
-    @mixed_big.floor(-100).should == BigDecimal("0.1E101")
-    @mixed_big.floor(-95).should == BigDecimal("0.123456E101")
-    (1..10).each do |n|
-      BigDecimal('1.8').floor(-n).should == @zero
-    end
-    BigDecimal("1E10").floor(-30).should == @zero
-    BigDecimal("-1E10").floor(-30).should == BigDecimal('-1E30')
-  end
+    it "returns the greatest integer smaller or equal to self" do
+      @pos_int.floor.should == @pos_int
+      @neg_int.floor.should == @neg_int
+      @pos_frac.floor.should == @zero
+      @neg_frac.floor.should == BigDecimal("-1")
+      @zero.floor.should == 0
+      @zero_pos.floor.should == @zero_pos
+      @zero_neg.floor.should == @zero_neg
 
+      BigDecimal('2.3').floor.should == 2
+      BigDecimal('2.5').floor.should == 2
+      BigDecimal('2.9999').floor.should == 2
+      BigDecimal('-2.3').floor.should == -3
+      BigDecimal('-2.5').floor.should == -3
+      BigDecimal('-2.9999').floor.should == -3
+      BigDecimal('0.8').floor.should == 0
+      BigDecimal('-0.8').floor.should == -1
+    end
+
+    it "raise exception, if self is special value" do
+      -> { @infinity.floor }.should raise_error(FloatDomainError)
+      -> { @infinity_neg.floor }.should raise_error(FloatDomainError)
+      -> { @nan.floor }.should raise_error(FloatDomainError)
+    end
+
+    it "returns n digits right of the decimal point if given n > 0" do
+      @mixed.floor(1).should == BigDecimal("1.2")
+      @mixed.floor(5).should == BigDecimal("1.23456")
+
+      BigDecimal("-0.03").floor(1).should == BigDecimal("-0.1")
+      BigDecimal("0.03").floor(1).should == BigDecimal("0")
+
+      BigDecimal("23.45").floor(0).should == BigDecimal('23')
+      BigDecimal("23.45").floor(1).should == BigDecimal('23.4')
+      BigDecimal("23.45").floor(2).should == BigDecimal('23.45')
+
+      BigDecimal("-23.45").floor(0).should == BigDecimal('-24')
+      BigDecimal("-23.45").floor(1).should == BigDecimal('-23.5')
+      BigDecimal("-23.45").floor(2).should == BigDecimal('-23.45')
+
+      BigDecimal("2E-10").floor(0).should == @zero
+      BigDecimal("2E-10").floor(9).should == @zero
+      BigDecimal("2E-10").floor(10).should == BigDecimal('2E-10')
+      BigDecimal("2E-10").floor(11).should == BigDecimal('2E-10')
+
+      (1..10).each do |n|
+        # 0.3, 0.33, 0.333, etc.
+        (@one.div(@three,20)).floor(n).should == BigDecimal("0.#{'3'*n}")
+        # 1.3, 1.33, 1.333, etc.
+        (@four.div(@three,20)).floor(n).should == BigDecimal("1.#{'3'*n}")
+        (BigDecimal('31').div(@three,20)).floor(n).should == BigDecimal("10.#{'3'*n}")
+      end
+      (1..10).each do |n|
+        # -0.4, -0.34, -0.334, etc.
+        (-@one.div(@three,20)).floor(n).should == BigDecimal("-0.#{'3'*(n-1)}4")
+      end
+      (1..10).each do |n|
+        (@three.div(@one,20)).floor(n).should == @three
+      end
+      (1..10).each do |n|
+        (-@three.div(@one,20)).floor(n).should == -@three
+      end
+    end
+
+    it "sets n digits left of the decimal point to 0, if given n < 0" do
+      BigDecimal("13345.234").floor(-2).should == BigDecimal("13300.0")
+      @mixed_big.floor(-99).should == BigDecimal("0.12E101")
+      @mixed_big.floor(-100).should == BigDecimal("0.1E101")
+      @mixed_big.floor(-95).should == BigDecimal("0.123456E101")
+      (1..10).each do |n|
+        BigDecimal('1.8').floor(-n).should == @zero
+      end
+      BigDecimal("1E10").floor(-30).should == @zero
+      BigDecimal("-1E10").floor(-30).should == BigDecimal('-1E30')
+    end
+
+  end
 end

--- a/spec/ruby/library/bigdecimal/frac_spec.rb
+++ b/spec/ruby/library/bigdecimal/frac_spec.rb
@@ -1,48 +1,51 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#frac" do
-  before :each do
-    @zero = BigDecimal("0")
-    @mixed = BigDecimal("1.23456789")
-    @pos_int = BigDecimal("2E5555")
-    @neg_int = BigDecimal("-2E5555")
-    @pos_frac = BigDecimal("2E-9999")
-    @neg_frac = BigDecimal("-2E-9999")
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-    @infinity = BigDecimal("Infinity")
-    @infinity_neg = BigDecimal("-Infinity")
-    @nan = BigDecimal("NaN")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
+  describe "BigDecimal#frac" do
+    before :each do
+      @zero = BigDecimal("0")
+      @mixed = BigDecimal("1.23456789")
+      @pos_int = BigDecimal("2E5555")
+      @neg_int = BigDecimal("-2E5555")
+      @pos_frac = BigDecimal("2E-9999")
+      @neg_frac = BigDecimal("-2E-9999")
+
+      @infinity = BigDecimal("Infinity")
+      @infinity_neg = BigDecimal("-Infinity")
+      @nan = BigDecimal("NaN")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
+    end
+
+    it "returns a BigDecimal" do
+      @pos_int.frac.kind_of?(BigDecimal).should == true
+      @neg_int.frac.kind_of?(BigDecimal).should == true
+      @pos_frac.kind_of?(BigDecimal).should == true
+      @neg_frac.kind_of?(BigDecimal).should == true
+    end
+
+    it "returns the fractional part of the absolute value" do
+      @mixed.frac.should == BigDecimal("0.23456789")
+      @pos_frac.frac.should == @pos_frac
+      @neg_frac.frac.should == @neg_frac
+    end
+
+    it "returns 0 if the value is 0" do
+      @zero.frac.should == @zero
+    end
+
+    it "returns 0 if the value is an integer" do
+      @pos_int.frac.should == @zero
+      @neg_int.frac.should == @zero
+    end
+
+    it "correctly handles special values" do
+      @infinity.frac.should == @infinity
+      @infinity_neg.frac.should == @infinity_neg
+      @nan.frac.should.nan?
+    end
+
   end
-
-  it "returns a BigDecimal" do
-    @pos_int.frac.kind_of?(BigDecimal).should == true
-    @neg_int.frac.kind_of?(BigDecimal).should == true
-    @pos_frac.kind_of?(BigDecimal).should == true
-    @neg_frac.kind_of?(BigDecimal).should == true
-  end
-
-  it "returns the fractional part of the absolute value" do
-    @mixed.frac.should == BigDecimal("0.23456789")
-    @pos_frac.frac.should == @pos_frac
-    @neg_frac.frac.should == @neg_frac
-  end
-
-  it "returns 0 if the value is 0" do
-    @zero.frac.should == @zero
-  end
-
-  it "returns 0 if the value is an integer" do
-    @pos_int.frac.should == @zero
-    @neg_int.frac.should == @zero
-  end
-
-  it "correctly handles special values" do
-    @infinity.frac.should == @infinity
-    @infinity_neg.frac.should == @infinity_neg
-    @nan.frac.should.nan?
-  end
-
 end

--- a/spec/ruby/library/bigdecimal/gt_spec.rb
+++ b/spec/ruby/library/bigdecimal/gt_spec.rb
@@ -1,96 +1,99 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#>" do
-  before :each do
-    @zero = BigDecimal("0")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-    @mixed = BigDecimal("1.23456789")
-    @pos_int = BigDecimal("2E5555")
-    @neg_int = BigDecimal("-2E5555")
-    @pos_frac = BigDecimal("2E-9999")
-    @neg_frac = BigDecimal("-2E-9999")
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-    @int_mock = mock('123')
-    class << @int_mock
-      def coerce(other)
-        return [other, BigDecimal('123')]
+  describe "BigDecimal#>" do
+    before :each do
+      @zero = BigDecimal("0")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
+      @mixed = BigDecimal("1.23456789")
+      @pos_int = BigDecimal("2E5555")
+      @neg_int = BigDecimal("-2E5555")
+      @pos_frac = BigDecimal("2E-9999")
+      @neg_frac = BigDecimal("-2E-9999")
+
+      @int_mock = mock('123')
+      class << @int_mock
+        def coerce(other)
+          return [other, BigDecimal('123')]
+        end
+        def >(other)
+          BigDecimal('123') > other
+        end
       end
-      def >(other)
-        BigDecimal('123') > other
-      end
+
+      @values = [@mixed, @pos_int, @neg_int, @pos_frac, @neg_frac,
+        -2**32, -2**31, -2**30, -2**16, -2**8, -100, -10, -1,
+        @zero , 1, 2, 10, 10.5, 2**8, 2**16, 2**32, @int_mock, @zero_pos, @zero_neg]
+
+      @infinity = BigDecimal("Infinity")
+      @infinity_neg = BigDecimal("-Infinity")
+
+      @float_infinity = Float::INFINITY
+      @float_infinity_neg = -Float::INFINITY
+
+      @nan = BigDecimal("NaN")
     end
 
-    @values = [@mixed, @pos_int, @neg_int, @pos_frac, @neg_frac,
-      -2**32, -2**31, -2**30, -2**16, -2**8, -100, -10, -1,
-      @zero , 1, 2, 10, 10.5, 2**8, 2**16, 2**32, @int_mock, @zero_pos, @zero_neg]
+    it "returns true if a > b" do
+      one = BigDecimal("1")
+      two = BigDecimal("2")
 
-    @infinity = BigDecimal("Infinity")
-    @infinity_neg = BigDecimal("-Infinity")
+      frac_1 = BigDecimal("1E-99999")
+      frac_2 = BigDecimal("0.9E-99999")
+      (@zero > one).should == false
+      (two > @zero).should == true
+      (frac_2 > frac_1).should == false
 
-    @float_infinity = Float::INFINITY
-    @float_infinity_neg = -Float::INFINITY
+      (@neg_int > @pos_int).should == false
+      (@pos_int > @neg_int).should == true
+      (@neg_int > @pos_frac).should == false
+      (@pos_frac > @neg_int).should == true
+      (@zero > @zero_pos).should == false
+      (@zero > @zero_neg).should == false
+      (@zero_neg > @zero_pos).should == false
+      (@zero_pos > @zero_neg).should == false
+    end
 
-    @nan = BigDecimal("NaN")
-  end
+    it "properly handles infinity values" do
+      @values.each { |val|
+        (val > @infinity).should == false
+        (@infinity > val).should == true
+        (val > @infinity_neg).should == true
+        (@infinity_neg > val).should == false
+      }
+      (@infinity > @infinity).should == false
+      (@infinity_neg > @infinity_neg).should == false
+      (@infinity > @infinity_neg).should == true
+      (@infinity_neg > @infinity).should == false
+    end
 
-  it "returns true if a > b" do
-    one = BigDecimal("1")
-    two = BigDecimal("2")
+    it "properly handles Float infinity values" do
+      @values.each { |val|
+        (val > @float_infinity).should == false
+        (@float_infinity > val).should == true
+        (val > @float_infinity_neg).should == true
+        (@float_infinity_neg > val).should == false
+      }
+    end
 
-    frac_1 = BigDecimal("1E-99999")
-    frac_2 = BigDecimal("0.9E-99999")
-    (@zero > one).should == false
-    (two > @zero).should == true
-    (frac_2 > frac_1).should == false
+    it "properly handles NaN values" do
+      @values += [@infinity, @infinity_neg, @nan]
+      @values.each { |val|
+        (@nan > val).should == false
+        (val > @nan).should == false
+      }
+    end
 
-    (@neg_int > @pos_int).should == false
-    (@pos_int > @neg_int).should == true
-    (@neg_int > @pos_frac).should == false
-    (@pos_frac > @neg_int).should == true
-    (@zero > @zero_pos).should == false
-    (@zero > @zero_neg).should == false
-    (@zero_neg > @zero_pos).should == false
-    (@zero_pos > @zero_neg).should == false
-  end
-
-  it "properly handles infinity values" do
-    @values.each { |val|
-      (val > @infinity).should == false
-      (@infinity > val).should == true
-      (val > @infinity_neg).should == true
-      (@infinity_neg > val).should == false
-    }
-    (@infinity > @infinity).should == false
-    (@infinity_neg > @infinity_neg).should == false
-    (@infinity > @infinity_neg).should == true
-    (@infinity_neg > @infinity).should == false
-  end
-
-  it "properly handles Float infinity values" do
-    @values.each { |val|
-      (val > @float_infinity).should == false
-      (@float_infinity > val).should == true
-      (val > @float_infinity_neg).should == true
-      (@float_infinity_neg > val).should == false
-    }
-  end
-
-  it "properly handles NaN values" do
-    @values += [@infinity, @infinity_neg, @nan]
-    @values.each { |val|
-      (@nan > val).should == false
-      (val > @nan).should == false
-    }
-  end
-
-  it "raises an ArgumentError if the argument can't be coerced into a BigDecimal" do
-    -> {@zero         > nil }.should raise_error(ArgumentError)
-    -> {@infinity     > nil }.should raise_error(ArgumentError)
-    -> {@infinity_neg > nil }.should raise_error(ArgumentError)
-    -> {@mixed        > nil }.should raise_error(ArgumentError)
-    -> {@pos_int      > nil }.should raise_error(ArgumentError)
-    -> {@neg_frac     > nil }.should raise_error(ArgumentError)
+    it "raises an ArgumentError if the argument can't be coerced into a BigDecimal" do
+      -> {@zero         > nil }.should raise_error(ArgumentError)
+      -> {@infinity     > nil }.should raise_error(ArgumentError)
+      -> {@infinity_neg > nil }.should raise_error(ArgumentError)
+      -> {@mixed        > nil }.should raise_error(ArgumentError)
+      -> {@pos_int      > nil }.should raise_error(ArgumentError)
+      -> {@neg_frac     > nil }.should raise_error(ArgumentError)
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/gte_spec.rb
+++ b/spec/ruby/library/bigdecimal/gte_spec.rb
@@ -1,100 +1,103 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#>=" do
-  before :each do
-    @zero = BigDecimal("0")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-    @mixed = BigDecimal("1.23456789")
-    @pos_int = BigDecimal("2E5555")
-    @neg_int = BigDecimal("-2E5555")
-    @pos_frac = BigDecimal("2E-9999")
-    @neg_frac = BigDecimal("-2E-9999")
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-    @int_mock = mock('123')
-    class << @int_mock
-      def coerce(other)
-        return [other, BigDecimal('123')]
+  describe "BigDecimal#>=" do
+    before :each do
+      @zero = BigDecimal("0")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
+      @mixed = BigDecimal("1.23456789")
+      @pos_int = BigDecimal("2E5555")
+      @neg_int = BigDecimal("-2E5555")
+      @pos_frac = BigDecimal("2E-9999")
+      @neg_frac = BigDecimal("-2E-9999")
+
+      @int_mock = mock('123')
+      class << @int_mock
+        def coerce(other)
+          return [other, BigDecimal('123')]
+        end
+        def >=(other)
+          BigDecimal('123') >= other
+        end
       end
-      def >=(other)
-        BigDecimal('123') >= other
-      end
+
+      @values = [@mixed, @pos_int, @neg_int, @pos_frac, @neg_frac,
+        -2**32, -2**31, -2**30, -2**16, -2**8, -100, -10, -1,
+        @zero , 1, 2, 10, 10.5, 2**8, 2**16, 2**32, @int_mock, @zero_pos, @zero_neg]
+
+      @infinity = BigDecimal("Infinity")
+      @infinity_neg = BigDecimal("-Infinity")
+
+      @float_infinity = Float::INFINITY
+      @float_infinity_neg = -Float::INFINITY
+
+      @nan = BigDecimal("NaN")
     end
 
-    @values = [@mixed, @pos_int, @neg_int, @pos_frac, @neg_frac,
-      -2**32, -2**31, -2**30, -2**16, -2**8, -100, -10, -1,
-      @zero , 1, 2, 10, 10.5, 2**8, 2**16, 2**32, @int_mock, @zero_pos, @zero_neg]
+    it "returns true if a >= b" do
+      one = BigDecimal("1")
+      two = BigDecimal("2")
 
-    @infinity = BigDecimal("Infinity")
-    @infinity_neg = BigDecimal("-Infinity")
+      frac_1 = BigDecimal("1E-99999")
+      frac_2 = BigDecimal("0.9E-99999")
 
-    @float_infinity = Float::INFINITY
-    @float_infinity_neg = -Float::INFINITY
+      (@zero >= one).should == false
+      (two >= @zero).should == true
 
-    @nan = BigDecimal("NaN")
-  end
+      (frac_2 >= frac_1).should == false
+      (two >= two).should == true
+      (frac_1 >= frac_1).should == true
 
-  it "returns true if a >= b" do
-    one = BigDecimal("1")
-    two = BigDecimal("2")
+      (@neg_int >= @pos_int).should == false
+      (@pos_int >= @neg_int).should == true
+      (@neg_int >= @pos_frac).should == false
+      (@pos_frac >= @neg_int).should == true
+      (@zero >= @zero_pos).should == true
+      (@zero >= @zero_neg).should == true
+      (@zero_neg >= @zero_pos).should == true
+      (@zero_pos >= @zero_neg).should == true
+    end
 
-    frac_1 = BigDecimal("1E-99999")
-    frac_2 = BigDecimal("0.9E-99999")
+    it "properly handles infinity values" do
+      @values.each { |val|
+        (val >= @infinity).should == false
+        (@infinity >= val).should == true
+        (val >= @infinity_neg).should == true
+        (@infinity_neg >= val).should == false
+      }
+      (@infinity >= @infinity).should == true
+      (@infinity_neg >= @infinity_neg).should == true
+      (@infinity >= @infinity_neg).should == true
+      (@infinity_neg >= @infinity).should == false
+    end
 
-    (@zero >= one).should == false
-    (two >= @zero).should == true
+    it "properly handles Float infinity values" do
+      @values.each { |val|
+        (val >= @float_infinity).should == false
+        (@float_infinity >= val).should == true
+        (val >= @float_infinity_neg).should == true
+        (@float_infinity_neg >= val).should == false
+      }
+    end
 
-    (frac_2 >= frac_1).should == false
-    (two >= two).should == true
-    (frac_1 >= frac_1).should == true
+    it "properly handles NaN values" do
+      @values += [@infinity, @infinity_neg, @nan]
+      @values.each { |val|
+        (@nan >= val).should == false
+        (val >= @nan).should == false
+      }
+    end
 
-    (@neg_int >= @pos_int).should == false
-    (@pos_int >= @neg_int).should == true
-    (@neg_int >= @pos_frac).should == false
-    (@pos_frac >= @neg_int).should == true
-    (@zero >= @zero_pos).should == true
-    (@zero >= @zero_neg).should == true
-    (@zero_neg >= @zero_pos).should == true
-    (@zero_pos >= @zero_neg).should == true
-  end
-
-  it "properly handles infinity values" do
-    @values.each { |val|
-      (val >= @infinity).should == false
-      (@infinity >= val).should == true
-      (val >= @infinity_neg).should == true
-      (@infinity_neg >= val).should == false
-    }
-    (@infinity >= @infinity).should == true
-    (@infinity_neg >= @infinity_neg).should == true
-    (@infinity >= @infinity_neg).should == true
-    (@infinity_neg >= @infinity).should == false
-  end
-
-  it "properly handles Float infinity values" do
-    @values.each { |val|
-      (val >= @float_infinity).should == false
-      (@float_infinity >= val).should == true
-      (val >= @float_infinity_neg).should == true
-      (@float_infinity_neg >= val).should == false
-    }
-  end
-
-  it "properly handles NaN values" do
-    @values += [@infinity, @infinity_neg, @nan]
-    @values.each { |val|
-      (@nan >= val).should == false
-      (val >= @nan).should == false
-    }
-  end
-
-  it "returns nil if the argument is nil" do
-    -> {@zero         >= nil }.should raise_error(ArgumentError)
-    -> {@infinity     >= nil }.should raise_error(ArgumentError)
-    -> {@infinity_neg >= nil }.should raise_error(ArgumentError)
-    -> {@mixed        >= nil }.should raise_error(ArgumentError)
-    -> {@pos_int      >= nil }.should raise_error(ArgumentError)
-    -> {@neg_frac     >= nil }.should raise_error(ArgumentError)
+    it "returns nil if the argument is nil" do
+      -> {@zero         >= nil }.should raise_error(ArgumentError)
+      -> {@infinity     >= nil }.should raise_error(ArgumentError)
+      -> {@infinity_neg >= nil }.should raise_error(ArgumentError)
+      -> {@mixed        >= nil }.should raise_error(ArgumentError)
+      -> {@pos_int      >= nil }.should raise_error(ArgumentError)
+      -> {@neg_frac     >= nil }.should raise_error(ArgumentError)
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/hash_spec.rb
+++ b/spec/ruby/library/bigdecimal/hash_spec.rb
@@ -1,30 +1,33 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BidDecimal#hash" do
-  describe "two BigDecimal objects with the same value" do
-    it "should have the same hash for ordinary values" do
-      BigDecimal('1.2920').hash.should == BigDecimal('1.2920').hash
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
+
+  describe "BidDecimal#hash" do
+    describe "two BigDecimal objects with the same value" do
+      it "should have the same hash for ordinary values" do
+        BigDecimal('1.2920').hash.should == BigDecimal('1.2920').hash
+      end
+
+      it "should have the same hash for infinite values" do
+        BigDecimal("+Infinity").hash.should == BigDecimal("+Infinity").hash
+        BigDecimal("-Infinity").hash.should == BigDecimal("-Infinity").hash
+      end
+
+      it "should have the same hash for NaNs" do
+        BigDecimal("NaN").hash.should == BigDecimal("NaN").hash
+      end
+
+      it "should have the same hash for zero values" do
+        BigDecimal("+0").hash.should == BigDecimal("+0").hash
+        BigDecimal("-0").hash.should == BigDecimal("-0").hash
+      end
     end
 
-    it "should have the same hash for infinite values" do
-      BigDecimal("+Infinity").hash.should == BigDecimal("+Infinity").hash
-      BigDecimal("-Infinity").hash.should == BigDecimal("-Infinity").hash
-    end
-
-    it "should have the same hash for NaNs" do
-      BigDecimal("NaN").hash.should == BigDecimal("NaN").hash
-    end
-
-    it "should have the same hash for zero values" do
-      BigDecimal("+0").hash.should == BigDecimal("+0").hash
-      BigDecimal("-0").hash.should == BigDecimal("-0").hash
-    end
-  end
-
-  describe "two BigDecimal objects with numerically equal values" do
-    it "should have the same hash value" do
-      BigDecimal("1.2920").hash.should == BigDecimal("1.2920000").hash
+    describe "two BigDecimal objects with numerically equal values" do
+      it "should have the same hash value" do
+        BigDecimal("1.2920").hash.should == BigDecimal("1.2920000").hash
+      end
     end
   end
 end

--- a/spec/ruby/library/bigdecimal/infinite_spec.rb
+++ b/spec/ruby/library/bigdecimal/infinite_spec.rb
@@ -1,32 +1,35 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#infinite?" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  it "returns 1 if self is Infinity" do
-    BigDecimal("Infinity").infinite?.should == 1
+  describe "BigDecimal#infinite?" do
+
+    it "returns 1 if self is Infinity" do
+      BigDecimal("Infinity").infinite?.should == 1
+    end
+
+    it "returns -1 if self is -Infinity" do
+      BigDecimal("-Infinity").infinite?.should == -1
+    end
+
+    it "returns not true otherwise" do
+      e2_plus = BigDecimal("2E40001")
+      e3_minus = BigDecimal("3E-20001")
+      really_small_zero = BigDecimal("0E-200000000")
+      really_big_zero = BigDecimal("0E200000000000")
+      e3_minus.infinite?.should == nil
+      e2_plus.infinite?.should == nil
+      really_small_zero.infinite?.should == nil
+      really_big_zero.infinite?.should == nil
+      BigDecimal("0.000000000000000000000000").infinite?.should == nil
+    end
+
+    it "returns not true if self is NaN" do
+      # NaN is a special value which is neither finite nor infinite.
+      nan = BigDecimal("NaN")
+      nan.infinite?.should == nil
+    end
+
   end
-
-  it "returns -1 if self is -Infinity" do
-    BigDecimal("-Infinity").infinite?.should == -1
-  end
-
-  it "returns not true otherwise" do
-    e2_plus = BigDecimal("2E40001")
-    e3_minus = BigDecimal("3E-20001")
-    really_small_zero = BigDecimal("0E-200000000")
-    really_big_zero = BigDecimal("0E200000000000")
-    e3_minus.infinite?.should == nil
-    e2_plus.infinite?.should == nil
-    really_small_zero.infinite?.should == nil
-    really_big_zero.infinite?.should == nil
-    BigDecimal("0.000000000000000000000000").infinite?.should == nil
-  end
-
-  it "returns not true if self is NaN" do
-    # NaN is a special value which is neither finite nor infinite.
-    nan = BigDecimal("NaN")
-    nan.infinite?.should == nil
-  end
-
 end

--- a/spec/ruby/library/bigdecimal/inspect_spec.rb
+++ b/spec/ruby/library/bigdecimal/inspect_spec.rb
@@ -1,30 +1,33 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#inspect" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  before :each do
-    @bigdec = BigDecimal("1234.5678")
-  end
+  describe "BigDecimal#inspect" do
 
-  it "returns String" do
-    @bigdec.inspect.kind_of?(String).should == true
-  end
+    before :each do
+      @bigdec = BigDecimal("1234.5678")
+    end
 
-  it "looks like this" do
-    @bigdec.inspect.should == "0.12345678e4"
-  end
+    it "returns String" do
+      @bigdec.inspect.kind_of?(String).should == true
+    end
 
-  it "does not add an exponent for zero values" do
-    BigDecimal("0").inspect.should == "0.0"
-    BigDecimal("+0").inspect.should == "0.0"
-    BigDecimal("-0").inspect.should == "-0.0"
-  end
+    it "looks like this" do
+      @bigdec.inspect.should == "0.12345678e4"
+    end
 
-  it "properly cases non-finite values" do
-    BigDecimal("NaN").inspect.should == "NaN"
-    BigDecimal("Infinity").inspect.should == "Infinity"
-    BigDecimal("+Infinity").inspect.should == "Infinity"
-    BigDecimal("-Infinity").inspect.should == "-Infinity"
+    it "does not add an exponent for zero values" do
+      BigDecimal("0").inspect.should == "0.0"
+      BigDecimal("+0").inspect.should == "0.0"
+      BigDecimal("-0").inspect.should == "-0.0"
+    end
+
+    it "properly cases non-finite values" do
+      BigDecimal("NaN").inspect.should == "NaN"
+      BigDecimal("Infinity").inspect.should == "Infinity"
+      BigDecimal("+Infinity").inspect.should == "Infinity"
+      BigDecimal("-Infinity").inspect.should == "-Infinity"
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/limit_spec.rb
+++ b/spec/ruby/library/bigdecimal/limit_spec.rb
@@ -1,55 +1,58 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
-require 'bigdecimal'
 
-describe "BigDecimal.limit" do
-  it "returns the value before set if the passed argument is nil or is not specified" do
-    old = BigDecimal.limit
-    BigDecimal.limit.should == 0
-    BigDecimal.limit(10).should == 0
-    BigDecimal.limit.should == 10
-    BigDecimal.limit(old)
+ruby_version_is ""..."3.4" do
+  require_relative 'fixtures/classes'
+  require 'bigdecimal'
+
+  describe "BigDecimal.limit" do
+    it "returns the value before set if the passed argument is nil or is not specified" do
+      old = BigDecimal.limit
+      BigDecimal.limit.should == 0
+      BigDecimal.limit(10).should == 0
+      BigDecimal.limit.should == 10
+      BigDecimal.limit(old)
+    end
+
+    it "uses the global limit if no precision is specified" do
+      BigDecimalSpecs.with_limit(0) do
+        (BigDecimal('0.888') + BigDecimal('0')).should == BigDecimal('0.888')
+        (BigDecimal('0.888') - BigDecimal('0')).should == BigDecimal('0.888')
+        (BigDecimal('0.888') * BigDecimal('3')).should == BigDecimal('2.664')
+        (BigDecimal('0.888') / BigDecimal('3')).should == BigDecimal('0.296')
+      end
+
+      BigDecimalSpecs.with_limit(1) do
+        (BigDecimal('0.888') + BigDecimal('0')).should == BigDecimal('0.9')
+        (BigDecimal('0.888') - BigDecimal('0')).should == BigDecimal('0.9')
+        (BigDecimal('0.888') * BigDecimal('3')).should == BigDecimal('3')
+        (BigDecimal('0.888') / BigDecimal('3')).should == BigDecimal('0.3')
+      end
+
+      BigDecimalSpecs.with_limit(2) do
+        (BigDecimal('0.888') + BigDecimal('0')).should == BigDecimal('0.89')
+        (BigDecimal('0.888') - BigDecimal('0')).should == BigDecimal('0.89')
+        (BigDecimal('0.888') * BigDecimal('3')).should == BigDecimal('2.7')
+        (BigDecimal('0.888') / BigDecimal('3')).should == BigDecimal('0.30')
+      end
+    end
+
+    it "picks the specified precision over global limit" do
+      BigDecimalSpecs.with_limit(3) do
+        BigDecimal('0.888').add(BigDecimal('0'), 2).should == BigDecimal('0.89')
+        BigDecimal('0.888').sub(BigDecimal('0'), 2).should == BigDecimal('0.89')
+        BigDecimal('0.888').mult(BigDecimal('3'), 2).should == BigDecimal('2.7')
+        BigDecimal('0.888').div(BigDecimal('3'), 2).should == BigDecimal('0.30')
+      end
+    end
+
+    it "picks the global precision when limit 0 specified" do
+      BigDecimalSpecs.with_limit(3) do
+        BigDecimal('0.8888').add(BigDecimal('0'), 0).should == BigDecimal('0.889')
+        BigDecimal('0.8888').sub(BigDecimal('0'), 0).should == BigDecimal('0.889')
+        BigDecimal('0.888').mult(BigDecimal('3'), 0).should == BigDecimal('2.66')
+        BigDecimal('0.8888').div(BigDecimal('3'), 0).should == BigDecimal('0.296')
+      end
+    end
+
   end
-
-  it "uses the global limit if no precision is specified" do
-    BigDecimalSpecs.with_limit(0) do
-      (BigDecimal('0.888') + BigDecimal('0')).should == BigDecimal('0.888')
-      (BigDecimal('0.888') - BigDecimal('0')).should == BigDecimal('0.888')
-      (BigDecimal('0.888') * BigDecimal('3')).should == BigDecimal('2.664')
-      (BigDecimal('0.888') / BigDecimal('3')).should == BigDecimal('0.296')
-    end
-
-    BigDecimalSpecs.with_limit(1) do
-      (BigDecimal('0.888') + BigDecimal('0')).should == BigDecimal('0.9')
-      (BigDecimal('0.888') - BigDecimal('0')).should == BigDecimal('0.9')
-      (BigDecimal('0.888') * BigDecimal('3')).should == BigDecimal('3')
-      (BigDecimal('0.888') / BigDecimal('3')).should == BigDecimal('0.3')
-    end
-
-    BigDecimalSpecs.with_limit(2) do
-      (BigDecimal('0.888') + BigDecimal('0')).should == BigDecimal('0.89')
-      (BigDecimal('0.888') - BigDecimal('0')).should == BigDecimal('0.89')
-      (BigDecimal('0.888') * BigDecimal('3')).should == BigDecimal('2.7')
-      (BigDecimal('0.888') / BigDecimal('3')).should == BigDecimal('0.30')
-    end
-  end
-
-  it "picks the specified precision over global limit" do
-    BigDecimalSpecs.with_limit(3) do
-      BigDecimal('0.888').add(BigDecimal('0'), 2).should == BigDecimal('0.89')
-      BigDecimal('0.888').sub(BigDecimal('0'), 2).should == BigDecimal('0.89')
-      BigDecimal('0.888').mult(BigDecimal('3'), 2).should == BigDecimal('2.7')
-      BigDecimal('0.888').div(BigDecimal('3'), 2).should == BigDecimal('0.30')
-    end
-  end
-
-  it "picks the global precision when limit 0 specified" do
-    BigDecimalSpecs.with_limit(3) do
-      BigDecimal('0.8888').add(BigDecimal('0'), 0).should == BigDecimal('0.889')
-      BigDecimal('0.8888').sub(BigDecimal('0'), 0).should == BigDecimal('0.889')
-      BigDecimal('0.888').mult(BigDecimal('3'), 0).should == BigDecimal('2.66')
-      BigDecimal('0.8888').div(BigDecimal('3'), 0).should == BigDecimal('0.296')
-    end
-  end
-
 end

--- a/spec/ruby/library/bigdecimal/lt_spec.rb
+++ b/spec/ruby/library/bigdecimal/lt_spec.rb
@@ -1,94 +1,97 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#<" do
-  before :each do
-    @zero = BigDecimal("0")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-    @mixed = BigDecimal("1.23456789")
-    @pos_int = BigDecimal("2E5555")
-    @neg_int = BigDecimal("-2E5555")
-    @pos_frac = BigDecimal("2E-9999")
-    @neg_frac = BigDecimal("-2E-9999")
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-    @int_mock = mock('123')
-    class << @int_mock
-      def coerce(other)
-        return [other, BigDecimal('123')]
+  describe "BigDecimal#<" do
+    before :each do
+      @zero = BigDecimal("0")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
+      @mixed = BigDecimal("1.23456789")
+      @pos_int = BigDecimal("2E5555")
+      @neg_int = BigDecimal("-2E5555")
+      @pos_frac = BigDecimal("2E-9999")
+      @neg_frac = BigDecimal("-2E-9999")
+
+      @int_mock = mock('123')
+      class << @int_mock
+        def coerce(other)
+          return [other, BigDecimal('123')]
+        end
+        def <(other)
+          BigDecimal('123') < other
+        end
       end
-      def <(other)
-        BigDecimal('123') < other
-      end
+
+      @values = [@mixed, @pos_int, @neg_int, @pos_frac, @neg_frac,
+        -2**32, -2**31, -2**30, -2**16, -2**8, -100, -10, -1,
+        @zero , 1, 2, 10, 10.5, 2**8, 2**16, 2**32, @int_mock, @zero_pos, @zero_neg]
+
+      @infinity = BigDecimal("Infinity")
+      @infinity_neg = BigDecimal("-Infinity")
+
+      @float_infinity = Float::INFINITY
+      @float_infinity_neg = -Float::INFINITY
+
+      @nan = BigDecimal("NaN")
     end
 
-    @values = [@mixed, @pos_int, @neg_int, @pos_frac, @neg_frac,
-      -2**32, -2**31, -2**30, -2**16, -2**8, -100, -10, -1,
-      @zero , 1, 2, 10, 10.5, 2**8, 2**16, 2**32, @int_mock, @zero_pos, @zero_neg]
+    it "returns true if a < b" do
+      one = BigDecimal("1")
+      two = BigDecimal("2")
+      frac_1 = BigDecimal("1E-99999")
+      frac_2 = BigDecimal("0.9E-99999")
+      (@zero < one).should == true
+      (two < @zero).should == false
+      (frac_2 < frac_1).should == true
+      (@neg_int < @pos_int).should == true
+      (@pos_int < @neg_int).should == false
+      (@neg_int < @pos_frac).should == true
+      (@pos_frac < @neg_int).should == false
+      (@zero < @zero_pos).should == false
+      (@zero < @zero_neg).should == false
+      (@zero_neg < @zero_pos).should == false
+      (@zero_pos < @zero_neg).should == false
+    end
 
-    @infinity = BigDecimal("Infinity")
-    @infinity_neg = BigDecimal("-Infinity")
+    it "properly handles infinity values" do
+      @values.each { |val|
+        (val < @infinity).should == true
+        (@infinity < val).should == false
+        (val < @infinity_neg).should == false
+        (@infinity_neg < val).should == true
+      }
+      (@infinity < @infinity).should == false
+      (@infinity_neg < @infinity_neg).should == false
+      (@infinity < @infinity_neg).should == false
+      (@infinity_neg < @infinity).should == true
+    end
 
-    @float_infinity = Float::INFINITY
-    @float_infinity_neg = -Float::INFINITY
+    it "properly handles Float infinity values" do
+      @values.each { |val|
+        (val < @float_infinity).should == true
+        (@float_infinity < val).should == false
+        (val < @float_infinity_neg).should == false
+        (@float_infinity_neg < val).should == true
+      }
+    end
 
-    @nan = BigDecimal("NaN")
-  end
+    it "properly handles NaN values" do
+      @values += [@infinity, @infinity_neg, @nan]
+      @values.each { |val|
+        (@nan < val).should == false
+        (val < @nan).should == false
+      }
+    end
 
-  it "returns true if a < b" do
-    one = BigDecimal("1")
-    two = BigDecimal("2")
-    frac_1 = BigDecimal("1E-99999")
-    frac_2 = BigDecimal("0.9E-99999")
-    (@zero < one).should == true
-    (two < @zero).should == false
-    (frac_2 < frac_1).should == true
-    (@neg_int < @pos_int).should == true
-    (@pos_int < @neg_int).should == false
-    (@neg_int < @pos_frac).should == true
-    (@pos_frac < @neg_int).should == false
-    (@zero < @zero_pos).should == false
-    (@zero < @zero_neg).should == false
-    (@zero_neg < @zero_pos).should == false
-    (@zero_pos < @zero_neg).should == false
-  end
-
-  it "properly handles infinity values" do
-    @values.each { |val|
-      (val < @infinity).should == true
-      (@infinity < val).should == false
-      (val < @infinity_neg).should == false
-      (@infinity_neg < val).should == true
-    }
-    (@infinity < @infinity).should == false
-    (@infinity_neg < @infinity_neg).should == false
-    (@infinity < @infinity_neg).should == false
-    (@infinity_neg < @infinity).should == true
-  end
-
-  it "properly handles Float infinity values" do
-    @values.each { |val|
-      (val < @float_infinity).should == true
-      (@float_infinity < val).should == false
-      (val < @float_infinity_neg).should == false
-      (@float_infinity_neg < val).should == true
-    }
-  end
-
-  it "properly handles NaN values" do
-    @values += [@infinity, @infinity_neg, @nan]
-    @values.each { |val|
-      (@nan < val).should == false
-      (val < @nan).should == false
-    }
-  end
-
-  it "raises an ArgumentError if the argument can't be coerced into a BigDecimal" do
-    -> {@zero         < nil }.should raise_error(ArgumentError)
-    -> {@infinity     < nil }.should raise_error(ArgumentError)
-    -> {@infinity_neg < nil }.should raise_error(ArgumentError)
-    -> {@mixed        < nil }.should raise_error(ArgumentError)
-    -> {@pos_int      < nil }.should raise_error(ArgumentError)
-    -> {@neg_frac     < nil }.should raise_error(ArgumentError)
+    it "raises an ArgumentError if the argument can't be coerced into a BigDecimal" do
+      -> {@zero         < nil }.should raise_error(ArgumentError)
+      -> {@infinity     < nil }.should raise_error(ArgumentError)
+      -> {@infinity_neg < nil }.should raise_error(ArgumentError)
+      -> {@mixed        < nil }.should raise_error(ArgumentError)
+      -> {@pos_int      < nil }.should raise_error(ArgumentError)
+      -> {@neg_frac     < nil }.should raise_error(ArgumentError)
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/lte_spec.rb
+++ b/spec/ruby/library/bigdecimal/lte_spec.rb
@@ -1,100 +1,103 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#<=" do
-  before :each do
-    @zero = BigDecimal("0")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-    @mixed = BigDecimal("1.23456789")
-    @pos_int = BigDecimal("2E5555")
-    @neg_int = BigDecimal("-2E5555")
-    @pos_frac = BigDecimal("2E-9999")
-    @neg_frac = BigDecimal("-2E-9999")
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-    @int_mock = mock('123')
-    class << @int_mock
-      def coerce(other)
-        return [other, BigDecimal('123')]
+  describe "BigDecimal#<=" do
+    before :each do
+      @zero = BigDecimal("0")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
+      @mixed = BigDecimal("1.23456789")
+      @pos_int = BigDecimal("2E5555")
+      @neg_int = BigDecimal("-2E5555")
+      @pos_frac = BigDecimal("2E-9999")
+      @neg_frac = BigDecimal("-2E-9999")
+
+      @int_mock = mock('123')
+      class << @int_mock
+        def coerce(other)
+          return [other, BigDecimal('123')]
+        end
+        def <=(other)
+          BigDecimal('123') <= other
+        end
       end
-      def <=(other)
-        BigDecimal('123') <= other
-      end
+
+      @values = [@mixed, @pos_int, @neg_int, @pos_frac, @neg_frac,
+        -2**32, -2**31, -2**30, -2**16, -2**8, -100, -10, -1,
+        @zero , 1, 2, 10, 10.5, 2**8, 2**16, 2**32, @int_mock, @zero_pos, @zero_neg]
+
+      @infinity = BigDecimal("Infinity")
+      @infinity_neg = BigDecimal("-Infinity")
+
+      @float_infinity = Float::INFINITY
+      @float_infinity_neg = -Float::INFINITY
+
+      @nan = BigDecimal("NaN")
     end
 
-    @values = [@mixed, @pos_int, @neg_int, @pos_frac, @neg_frac,
-      -2**32, -2**31, -2**30, -2**16, -2**8, -100, -10, -1,
-      @zero , 1, 2, 10, 10.5, 2**8, 2**16, 2**32, @int_mock, @zero_pos, @zero_neg]
+    it "returns true if a <= b" do
+      one = BigDecimal("1")
+      two = BigDecimal("2")
 
-    @infinity = BigDecimal("Infinity")
-    @infinity_neg = BigDecimal("-Infinity")
+      frac_1 = BigDecimal("1E-99999")
+      frac_2 = BigDecimal("0.9E-99999")
 
-    @float_infinity = Float::INFINITY
-    @float_infinity_neg = -Float::INFINITY
+      (@zero <= one).should == true
+      (two <= @zero).should == false
 
-    @nan = BigDecimal("NaN")
-  end
+      (frac_2 <= frac_1).should == true
+      (two <= two).should == true
+      (frac_1 <= frac_1).should == true
 
-  it "returns true if a <= b" do
-    one = BigDecimal("1")
-    two = BigDecimal("2")
+      (@neg_int <= @pos_int).should == true
+      (@pos_int <= @neg_int).should == false
+      (@neg_int <= @pos_frac).should == true
+      (@pos_frac <= @neg_int).should == false
+      (@zero <= @zero_pos).should == true
+      (@zero <= @zero_neg).should == true
+      (@zero_neg <= @zero_pos).should == true
+      (@zero_pos <= @zero_neg).should == true
+    end
 
-    frac_1 = BigDecimal("1E-99999")
-    frac_2 = BigDecimal("0.9E-99999")
+    it "properly handles infinity values" do
+      @values.each { |val|
+        (val <= @infinity).should == true
+        (@infinity <= val).should == false
+        (val <= @infinity_neg).should == false
+        (@infinity_neg <= val).should == true
+      }
+      (@infinity <= @infinity).should == true
+      (@infinity_neg <= @infinity_neg).should == true
+      (@infinity <= @infinity_neg).should == false
+      (@infinity_neg <= @infinity).should == true
+    end
 
-    (@zero <= one).should == true
-    (two <= @zero).should == false
+    it "properly handles Float infinity values" do
+      @values.each { |val|
+        (val <= @float_infinity).should == true
+        (@float_infinity <= val).should == false
+        (val <= @float_infinity_neg).should == false
+        (@float_infinity_neg <= val).should == true
+      }
+    end
 
-    (frac_2 <= frac_1).should == true
-    (two <= two).should == true
-    (frac_1 <= frac_1).should == true
+    it "properly handles NaN values" do
+      @values += [@infinity, @infinity_neg, @nan]
+      @values.each { |val|
+        (@nan <= val).should == false
+        (val <= @nan).should == false
+      }
+    end
 
-    (@neg_int <= @pos_int).should == true
-    (@pos_int <= @neg_int).should == false
-    (@neg_int <= @pos_frac).should == true
-    (@pos_frac <= @neg_int).should == false
-    (@zero <= @zero_pos).should == true
-    (@zero <= @zero_neg).should == true
-    (@zero_neg <= @zero_pos).should == true
-    (@zero_pos <= @zero_neg).should == true
-  end
-
-  it "properly handles infinity values" do
-    @values.each { |val|
-      (val <= @infinity).should == true
-      (@infinity <= val).should == false
-      (val <= @infinity_neg).should == false
-      (@infinity_neg <= val).should == true
-    }
-    (@infinity <= @infinity).should == true
-    (@infinity_neg <= @infinity_neg).should == true
-    (@infinity <= @infinity_neg).should == false
-    (@infinity_neg <= @infinity).should == true
-  end
-
-  it "properly handles Float infinity values" do
-    @values.each { |val|
-      (val <= @float_infinity).should == true
-      (@float_infinity <= val).should == false
-      (val <= @float_infinity_neg).should == false
-      (@float_infinity_neg <= val).should == true
-    }
-  end
-
-  it "properly handles NaN values" do
-    @values += [@infinity, @infinity_neg, @nan]
-    @values.each { |val|
-      (@nan <= val).should == false
-      (val <= @nan).should == false
-    }
-  end
-
-  it "raises an ArgumentError if the argument can't be coerced into a BigDecimal" do
-    -> {@zero         <= nil }.should raise_error(ArgumentError)
-    -> {@infinity     <= nil }.should raise_error(ArgumentError)
-    -> {@infinity_neg <= nil }.should raise_error(ArgumentError)
-    -> {@mixed        <= nil }.should raise_error(ArgumentError)
-    -> {@pos_int      <= nil }.should raise_error(ArgumentError)
-    -> {@neg_frac     <= nil }.should raise_error(ArgumentError)
+    it "raises an ArgumentError if the argument can't be coerced into a BigDecimal" do
+      -> {@zero         <= nil }.should raise_error(ArgumentError)
+      -> {@infinity     <= nil }.should raise_error(ArgumentError)
+      -> {@infinity_neg <= nil }.should raise_error(ArgumentError)
+      -> {@mixed        <= nil }.should raise_error(ArgumentError)
+      -> {@pos_int      <= nil }.should raise_error(ArgumentError)
+      -> {@neg_frac     <= nil }.should raise_error(ArgumentError)
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/minus_spec.rb
+++ b/spec/ruby/library/bigdecimal/minus_spec.rb
@@ -1,66 +1,69 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#-" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  before :each do
-    @one = BigDecimal("1")
-    @zero = BigDecimal("0")
-    @two = BigDecimal("2")
-    @nan = BigDecimal("NaN")
-    @infinity = BigDecimal("Infinity")
-    @infinity_minus = BigDecimal("-Infinity")
-    @one_minus = BigDecimal("-1")
-    @frac_1 = BigDecimal("1E-99999")
-    @frac_2 = BigDecimal("0.9E-99999")
-  end
+  describe "BigDecimal#-" do
 
-  it "returns a - b" do
-    (@two - @one).should == @one
-    (@one - @two).should == @one_minus
-    (@one - @one_minus).should == @two
-    (@frac_2 - @frac_1).should == BigDecimal("-0.1E-99999")
-    (@two - @two).should == @zero
-    (@frac_1 - @frac_1).should == @zero
-    (BigDecimal('1.23456789') - BigDecimal('1.2')).should == BigDecimal("0.03456789")
-  end
-
-  it "returns NaN if NaN is involved" do
-    (@one - @nan).should.nan?
-    (@nan - @one).should.nan?
-    (@nan - @nan).should.nan?
-    (@nan - @infinity).should.nan?
-    (@nan - @infinity_minus).should.nan?
-    (@infinity - @nan).should.nan?
-    (@infinity_minus - @nan).should.nan?
-  end
-
-  it "returns NaN both operands are infinite with the same sign" do
-    (@infinity - @infinity).should.nan?
-    (@infinity_minus - @infinity_minus).should.nan?
-  end
-
-  it "returns Infinity or -Infinity if these are involved" do
-    (@infinity - @infinity_minus).should == @infinity
-    (@infinity_minus - @infinity).should == @infinity_minus
-
-    (@infinity - @zero).should == @infinity
-    (@infinity - @frac_2).should == @infinity
-    (@infinity - @two).should == @infinity
-    (@infinity - @one_minus).should == @infinity
-
-    (@zero - @infinity).should == @infinity_minus
-    (@frac_2 - @infinity).should == @infinity_minus
-    (@two - @infinity).should == @infinity_minus
-    (@one_minus - @infinity).should == @infinity_minus
-  end
-
-  describe "with Object" do
-    it "tries to coerce the other operand to self" do
-      object = mock("Object")
-      object.should_receive(:coerce).with(@one).and_return([@one, BigDecimal("42")])
-      (@one - object).should == BigDecimal("-41")
+    before :each do
+      @one = BigDecimal("1")
+      @zero = BigDecimal("0")
+      @two = BigDecimal("2")
+      @nan = BigDecimal("NaN")
+      @infinity = BigDecimal("Infinity")
+      @infinity_minus = BigDecimal("-Infinity")
+      @one_minus = BigDecimal("-1")
+      @frac_1 = BigDecimal("1E-99999")
+      @frac_2 = BigDecimal("0.9E-99999")
     end
-  end
 
+    it "returns a - b" do
+      (@two - @one).should == @one
+      (@one - @two).should == @one_minus
+      (@one - @one_minus).should == @two
+      (@frac_2 - @frac_1).should == BigDecimal("-0.1E-99999")
+      (@two - @two).should == @zero
+      (@frac_1 - @frac_1).should == @zero
+      (BigDecimal('1.23456789') - BigDecimal('1.2')).should == BigDecimal("0.03456789")
+    end
+
+    it "returns NaN if NaN is involved" do
+      (@one - @nan).should.nan?
+      (@nan - @one).should.nan?
+      (@nan - @nan).should.nan?
+      (@nan - @infinity).should.nan?
+      (@nan - @infinity_minus).should.nan?
+      (@infinity - @nan).should.nan?
+      (@infinity_minus - @nan).should.nan?
+    end
+
+    it "returns NaN both operands are infinite with the same sign" do
+      (@infinity - @infinity).should.nan?
+      (@infinity_minus - @infinity_minus).should.nan?
+    end
+
+    it "returns Infinity or -Infinity if these are involved" do
+      (@infinity - @infinity_minus).should == @infinity
+      (@infinity_minus - @infinity).should == @infinity_minus
+
+      (@infinity - @zero).should == @infinity
+      (@infinity - @frac_2).should == @infinity
+      (@infinity - @two).should == @infinity
+      (@infinity - @one_minus).should == @infinity
+
+      (@zero - @infinity).should == @infinity_minus
+      (@frac_2 - @infinity).should == @infinity_minus
+      (@two - @infinity).should == @infinity_minus
+      (@one_minus - @infinity).should == @infinity_minus
+    end
+
+    describe "with Object" do
+      it "tries to coerce the other operand to self" do
+        object = mock("Object")
+        object.should_receive(:coerce).with(@one).and_return([@one, BigDecimal("42")])
+        (@one - object).should == BigDecimal("-41")
+      end
+    end
+
+  end
 end

--- a/spec/ruby/library/bigdecimal/mode_spec.rb
+++ b/spec/ruby/library/bigdecimal/mode_spec.rb
@@ -1,36 +1,39 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal.mode" do
-  #the default value of BigDecimal exception constants is false
-  after :each do
-    BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
-    BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
-    BigDecimal.mode(BigDecimal::EXCEPTION_UNDERFLOW, false)
-    BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
-    BigDecimal.mode(BigDecimal::EXCEPTION_ZERODIVIDE, false)
-  end
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  it "returns the appropriate value and continue the computation if the flag is false" do
-    BigDecimal("NaN").add(BigDecimal("1"),0).should.nan?
-    BigDecimal("0").add(BigDecimal("Infinity"),0).should == BigDecimal("Infinity")
-    BigDecimal("1").quo(BigDecimal("0")).should == BigDecimal("Infinity")
-  end
+  describe "BigDecimal.mode" do
+    #the default value of BigDecimal exception constants is false
+    after :each do
+      BigDecimal.mode(BigDecimal::EXCEPTION_NaN, false)
+      BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, false)
+      BigDecimal.mode(BigDecimal::EXCEPTION_UNDERFLOW, false)
+      BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, false)
+      BigDecimal.mode(BigDecimal::EXCEPTION_ZERODIVIDE, false)
+    end
 
-  it "returns Infinity when too big" do
-    BigDecimal("1E11111111111111111111").should == BigDecimal("Infinity")
-    (BigDecimal("1E1000000000000000000")**10).should == BigDecimal("Infinity")
-  end
+    it "returns the appropriate value and continue the computation if the flag is false" do
+      BigDecimal("NaN").add(BigDecimal("1"),0).should.nan?
+      BigDecimal("0").add(BigDecimal("Infinity"),0).should == BigDecimal("Infinity")
+      BigDecimal("1").quo(BigDecimal("0")).should == BigDecimal("Infinity")
+    end
 
-  it "raise an exception if the flag is true" do
-    BigDecimal.mode(BigDecimal::EXCEPTION_NaN, true)
-    -> { BigDecimal("NaN").add(BigDecimal("1"),0) }.should raise_error(FloatDomainError)
-    BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, true)
-    -> { BigDecimal("0").add(BigDecimal("Infinity"),0) }.should raise_error(FloatDomainError)
-    BigDecimal.mode(BigDecimal::EXCEPTION_ZERODIVIDE, true)
-    -> { BigDecimal("1").quo(BigDecimal("0")) }.should raise_error(FloatDomainError)
-    BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, true)
-    -> { BigDecimal("1E11111111111111111111") }.should raise_error(FloatDomainError)
-    -> { (BigDecimal("1E1000000000000000000")**10) }.should raise_error(FloatDomainError)
+    it "returns Infinity when too big" do
+      BigDecimal("1E11111111111111111111").should == BigDecimal("Infinity")
+      (BigDecimal("1E1000000000000000000")**10).should == BigDecimal("Infinity")
+    end
+
+    it "raise an exception if the flag is true" do
+      BigDecimal.mode(BigDecimal::EXCEPTION_NaN, true)
+      -> { BigDecimal("NaN").add(BigDecimal("1"),0) }.should raise_error(FloatDomainError)
+      BigDecimal.mode(BigDecimal::EXCEPTION_INFINITY, true)
+      -> { BigDecimal("0").add(BigDecimal("Infinity"),0) }.should raise_error(FloatDomainError)
+      BigDecimal.mode(BigDecimal::EXCEPTION_ZERODIVIDE, true)
+      -> { BigDecimal("1").quo(BigDecimal("0")) }.should raise_error(FloatDomainError)
+      BigDecimal.mode(BigDecimal::EXCEPTION_OVERFLOW, true)
+      -> { BigDecimal("1E11111111111111111111") }.should raise_error(FloatDomainError)
+      -> { (BigDecimal("1E1000000000000000000")**10) }.should raise_error(FloatDomainError)
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/modulo_spec.rb
+++ b/spec/ruby/library/bigdecimal/modulo_spec.rb
@@ -1,12 +1,15 @@
 require_relative '../../spec_helper'
-require_relative 'shared/modulo'
 
-describe "BigDecimal#%" do
-  it_behaves_like :bigdecimal_modulo, :%
-  it_behaves_like :bigdecimal_modulo_zerodivisionerror, :%
-end
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/modulo'
 
-describe "BigDecimal#modulo" do
-  it_behaves_like :bigdecimal_modulo, :modulo
-  it_behaves_like :bigdecimal_modulo_zerodivisionerror, :modulo
+  describe "BigDecimal#%" do
+    it_behaves_like :bigdecimal_modulo, :%
+    it_behaves_like :bigdecimal_modulo_zerodivisionerror, :%
+  end
+
+  describe "BigDecimal#modulo" do
+    it_behaves_like :bigdecimal_modulo, :modulo
+    it_behaves_like :bigdecimal_modulo_zerodivisionerror, :modulo
+  end
 end

--- a/spec/ruby/library/bigdecimal/mult_spec.rb
+++ b/spec/ruby/library/bigdecimal/mult_spec.rb
@@ -1,32 +1,35 @@
 require_relative '../../spec_helper'
-require_relative 'shared/mult'
-require 'bigdecimal'
 
-describe "BigDecimal#mult" do
-  it_behaves_like :bigdecimal_mult, :mult, [10]
-end
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/mult'
+  require 'bigdecimal'
 
-describe "BigDecimal#mult" do
-  before :each do
-    @one = BigDecimal "1"
-    @e3_minus = BigDecimal("3E-20001")
-    @e3_plus = BigDecimal("3E20001")
-    @e = BigDecimal "1.00000000000000000000123456789"
-    @tolerance = @e.sub @one, 1000
-    @tolerance2 = BigDecimal "30001E-20005"
-
+  describe "BigDecimal#mult" do
+    it_behaves_like :bigdecimal_mult, :mult, [10]
   end
 
-  it "multiply self with other with (optional) precision" do
-    @e.mult(@one, 1).should be_close(@one, @tolerance)
-    @e3_minus.mult(@one, 1).should be_close(0, @tolerance2)
-  end
+  describe "BigDecimal#mult" do
+    before :each do
+      @one = BigDecimal "1"
+      @e3_minus = BigDecimal("3E-20001")
+      @e3_plus = BigDecimal("3E20001")
+      @e = BigDecimal "1.00000000000000000000123456789"
+      @tolerance = @e.sub @one, 1000
+      @tolerance2 = BigDecimal "30001E-20005"
 
-  describe "with Object" do
-    it "tries to coerce the other operand to self" do
-      object = mock("Object")
-      object.should_receive(:coerce).with(@e3_minus).and_return([@e3_minus, @e3_plus])
-      @e3_minus.mult(object, 1).should == BigDecimal("9")
+    end
+
+    it "multiply self with other with (optional) precision" do
+      @e.mult(@one, 1).should be_close(@one, @tolerance)
+      @e3_minus.mult(@one, 1).should be_close(0, @tolerance2)
+    end
+
+    describe "with Object" do
+      it "tries to coerce the other operand to self" do
+        object = mock("Object")
+        object.should_receive(:coerce).with(@e3_minus).and_return([@e3_minus, @e3_plus])
+        @e3_minus.mult(object, 1).should == BigDecimal("9")
+      end
     end
   end
 end

--- a/spec/ruby/library/bigdecimal/multiply_spec.rb
+++ b/spec/ruby/library/bigdecimal/multiply_spec.rb
@@ -1,41 +1,44 @@
 require_relative '../../spec_helper'
-require_relative 'shared/mult'
-require 'bigdecimal'
 
-describe "BigDecimal#*" do
-  it_behaves_like :bigdecimal_mult, :*, []
-end
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/mult'
+  require 'bigdecimal'
 
-describe "BigDecimal#*" do
-  before :each do
-    @three = BigDecimal("3")
-    @e3_minus = BigDecimal("3E-20001")
-    @e3_plus = BigDecimal("3E20001")
-    @e = BigDecimal("1.00000000000000000000123456789")
-    @one = BigDecimal("1")
+  describe "BigDecimal#*" do
+    it_behaves_like :bigdecimal_mult, :*, []
   end
 
-  it "multiply self with other" do
-    (@one * @one).should == @one
-    (@e3_minus * @e3_plus).should == BigDecimal("9")
-    # Can't do this till we implement **
-    # (@e3_minus * @e3_minus).should == @e3_minus ** 2
-    # So let's rewrite it as:
-    (@e3_minus * @e3_minus).should == BigDecimal("9E-40002")
-    (@e * @one).should == @e
-  end
-
-  describe "with Object" do
-    it "tries to coerce the other operand to self" do
-      object = mock("Object")
-      object.should_receive(:coerce).with(@e3_minus).and_return([@e3_minus, @e3_plus])
-      (@e3_minus * object).should == BigDecimal("9")
+  describe "BigDecimal#*" do
+    before :each do
+      @three = BigDecimal("3")
+      @e3_minus = BigDecimal("3E-20001")
+      @e3_plus = BigDecimal("3E20001")
+      @e = BigDecimal("1.00000000000000000000123456789")
+      @one = BigDecimal("1")
     end
-  end
 
-  describe "with Rational" do
-    it "produces a BigDecimal" do
-      (@three * Rational(500, 2)).should == BigDecimal("0.75e3")
+    it "multiply self with other" do
+      (@one * @one).should == @one
+      (@e3_minus * @e3_plus).should == BigDecimal("9")
+      # Can't do this till we implement **
+      # (@e3_minus * @e3_minus).should == @e3_minus ** 2
+      # So let's rewrite it as:
+      (@e3_minus * @e3_minus).should == BigDecimal("9E-40002")
+      (@e * @one).should == @e
+    end
+
+    describe "with Object" do
+      it "tries to coerce the other operand to self" do
+        object = mock("Object")
+        object.should_receive(:coerce).with(@e3_minus).and_return([@e3_minus, @e3_plus])
+        (@e3_minus * object).should == BigDecimal("9")
+      end
+    end
+
+    describe "with Rational" do
+      it "produces a BigDecimal" do
+        (@three * Rational(500, 2)).should == BigDecimal("0.75e3")
+      end
     end
   end
 end

--- a/spec/ruby/library/bigdecimal/nan_spec.rb
+++ b/spec/ruby/library/bigdecimal/nan_spec.rb
@@ -1,23 +1,26 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#nan?" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  it "returns true if self is not a number" do
-    BigDecimal("NaN").should.nan?
+  describe "BigDecimal#nan?" do
+
+    it "returns true if self is not a number" do
+      BigDecimal("NaN").should.nan?
+    end
+
+    it "returns false if self is not a NaN" do
+      BigDecimal("Infinity").should_not.nan?
+      BigDecimal("-Infinity").should_not.nan?
+      BigDecimal("0").should_not.nan?
+      BigDecimal("+0").should_not.nan?
+      BigDecimal("-0").should_not.nan?
+      BigDecimal("2E40001").should_not.nan?
+      BigDecimal("3E-20001").should_not.nan?
+      BigDecimal("0E-200000000").should_not.nan?
+      BigDecimal("0E200000000000").should_not.nan?
+      BigDecimal("0.000000000000000000000000").should_not.nan?
+    end
+
   end
-
-  it "returns false if self is not a NaN" do
-    BigDecimal("Infinity").should_not.nan?
-    BigDecimal("-Infinity").should_not.nan?
-    BigDecimal("0").should_not.nan?
-    BigDecimal("+0").should_not.nan?
-    BigDecimal("-0").should_not.nan?
-    BigDecimal("2E40001").should_not.nan?
-    BigDecimal("3E-20001").should_not.nan?
-    BigDecimal("0E-200000000").should_not.nan?
-    BigDecimal("0E200000000000").should_not.nan?
-    BigDecimal("0.000000000000000000000000").should_not.nan?
-  end
-
 end

--- a/spec/ruby/library/bigdecimal/nonzero_spec.rb
+++ b/spec/ruby/library/bigdecimal/nonzero_spec.rb
@@ -1,29 +1,32 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#nonzero?" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  it "returns self if self doesn't equal zero" do
-    # documentation says, it returns true. (04/10/08)
-    e2_plus = BigDecimal("2E40001")
-    e3_minus = BigDecimal("3E-20001")
-    infinity = BigDecimal("Infinity")
-    infinity_minus = BigDecimal("-Infinity")
-    nan = BigDecimal("NaN")
-    infinity.nonzero?.should equal(infinity)
-    infinity_minus.nonzero?.should equal(infinity_minus)
-    nan.nonzero?.should equal(nan)
-    e3_minus.nonzero?.should equal(e3_minus)
-    e2_plus.nonzero?.should equal(e2_plus)
+  describe "BigDecimal#nonzero?" do
+
+    it "returns self if self doesn't equal zero" do
+      # documentation says, it returns true. (04/10/08)
+      e2_plus = BigDecimal("2E40001")
+      e3_minus = BigDecimal("3E-20001")
+      infinity = BigDecimal("Infinity")
+      infinity_minus = BigDecimal("-Infinity")
+      nan = BigDecimal("NaN")
+      infinity.nonzero?.should equal(infinity)
+      infinity_minus.nonzero?.should equal(infinity_minus)
+      nan.nonzero?.should equal(nan)
+      e3_minus.nonzero?.should equal(e3_minus)
+      e2_plus.nonzero?.should equal(e2_plus)
+    end
+
+    it "returns nil otherwise" do
+      # documentation states, it should return false. (04/10/08)
+      really_small_zero = BigDecimal("0E-200000000")
+      really_big_zero = BigDecimal("0E200000000000")
+      really_small_zero.nonzero?.should == nil
+      really_big_zero.nonzero?.should == nil
+      BigDecimal("0.000000000000000000000000").nonzero?.should == nil
+    end
+
   end
-
-  it "returns nil otherwise" do
-    # documentation states, it should return false. (04/10/08)
-    really_small_zero = BigDecimal("0E-200000000")
-    really_big_zero = BigDecimal("0E200000000000")
-    really_small_zero.nonzero?.should == nil
-    really_big_zero.nonzero?.should == nil
-    BigDecimal("0.000000000000000000000000").nonzero?.should == nil
-  end
-
 end

--- a/spec/ruby/library/bigdecimal/plus_spec.rb
+++ b/spec/ruby/library/bigdecimal/plus_spec.rb
@@ -1,54 +1,57 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#+" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  before :each do
-    @one = BigDecimal("1")
-    @zero = BigDecimal("0")
-    @two = BigDecimal("2")
-    @three = BigDecimal("3")
-    @ten = BigDecimal("10")
-    @eleven = BigDecimal("11")
-    @nan = BigDecimal("NaN")
-    @infinity = BigDecimal("Infinity")
-    @infinity_minus = BigDecimal("-Infinity")
-    @one_minus = BigDecimal("-1")
-    @frac_1 = BigDecimal("1E-99999")
-    @frac_2 = BigDecimal("0.9E-99999")
-  end
+  describe "BigDecimal#+" do
 
-  it "returns a + b" do
-    (@two + @one).should == @three
-    (@one + @two).should == @three
-    (@one + @one_minus).should == @zero
-    (@zero + @one).should == @one
-    (@ten + @one).should == @eleven
-    (@frac_1 + @frac_2).should == BigDecimal("1.9E-99999")
-    (@frac_2 + @frac_1).should == BigDecimal("1.9E-99999")
-    (@frac_1 + @frac_1).should == BigDecimal("2E-99999")
-  end
+    before :each do
+      @one = BigDecimal("1")
+      @zero = BigDecimal("0")
+      @two = BigDecimal("2")
+      @three = BigDecimal("3")
+      @ten = BigDecimal("10")
+      @eleven = BigDecimal("11")
+      @nan = BigDecimal("NaN")
+      @infinity = BigDecimal("Infinity")
+      @infinity_minus = BigDecimal("-Infinity")
+      @one_minus = BigDecimal("-1")
+      @frac_1 = BigDecimal("1E-99999")
+      @frac_2 = BigDecimal("0.9E-99999")
+    end
 
-  it "returns NaN if NaN is involved" do
-    (@one + @nan).should.nan?
-    (@nan + @one).should.nan?
-  end
+    it "returns a + b" do
+      (@two + @one).should == @three
+      (@one + @two).should == @three
+      (@one + @one_minus).should == @zero
+      (@zero + @one).should == @one
+      (@ten + @one).should == @eleven
+      (@frac_1 + @frac_2).should == BigDecimal("1.9E-99999")
+      (@frac_2 + @frac_1).should == BigDecimal("1.9E-99999")
+      (@frac_1 + @frac_1).should == BigDecimal("2E-99999")
+    end
 
-  it "returns Infinity or -Infinity if these are involved" do
-    (@zero + @infinity).should == @infinity
-    (@frac_2 + @infinity).should == @infinity
-    (@two + @infinity_minus).should == @infinity_minus
-  end
+    it "returns NaN if NaN is involved" do
+      (@one + @nan).should.nan?
+      (@nan + @one).should.nan?
+    end
 
-  it "returns NaN if Infinity + (- Infinity)" do
-    (@infinity + @infinity_minus).should.nan?
-  end
+    it "returns Infinity or -Infinity if these are involved" do
+      (@zero + @infinity).should == @infinity
+      (@frac_2 + @infinity).should == @infinity
+      (@two + @infinity_minus).should == @infinity_minus
+    end
 
-  describe "with Object" do
-    it "tries to coerce the other operand to self" do
-      object = mock("Object")
-      object.should_receive(:coerce).with(@one).and_return([@one, BigDecimal("42")])
-      (@one + object).should == BigDecimal("43")
+    it "returns NaN if Infinity + (- Infinity)" do
+      (@infinity + @infinity_minus).should.nan?
+    end
+
+    describe "with Object" do
+      it "tries to coerce the other operand to self" do
+        object = mock("Object")
+        object.should_receive(:coerce).with(@one).and_return([@one, BigDecimal("42")])
+        (@one + object).should == BigDecimal("43")
+      end
     end
   end
 end

--- a/spec/ruby/library/bigdecimal/power_spec.rb
+++ b/spec/ruby/library/bigdecimal/power_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../spec_helper'
-require_relative 'shared/power'
 
-describe "BigDecimal#power" do
-  it_behaves_like :bigdecimal_power, :power
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/power'
+
+  describe "BigDecimal#power" do
+    it_behaves_like :bigdecimal_power, :power
+  end
 end

--- a/spec/ruby/library/bigdecimal/precs_spec.rb
+++ b/spec/ruby/library/bigdecimal/precs_spec.rb
@@ -1,54 +1,57 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#precs" do
-  before :each do
-    @infinity = BigDecimal("Infinity")
-    @infinity_neg = BigDecimal("-Infinity")
-    @nan = BigDecimal("NaN")
-    @zero = BigDecimal("0")
-    @zero_neg = BigDecimal("-0")
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-    @arr = [BigDecimal("2E40001"), BigDecimal("3E-20001"),\
-            @infinity, @infinity_neg, @nan, @zero, @zero_neg]
-    @precision = BigDecimal::BASE.to_s.length - 1
-  end
+  describe "BigDecimal#precs" do
+    before :each do
+      @infinity = BigDecimal("Infinity")
+      @infinity_neg = BigDecimal("-Infinity")
+      @nan = BigDecimal("NaN")
+      @zero = BigDecimal("0")
+      @zero_neg = BigDecimal("-0")
 
-  it "returns array of two values" do
-    suppress_warning do
-      @arr.each do |x|
-        x.precs.kind_of?(Array).should == true
-        x.precs.size.should == 2
+      @arr = [BigDecimal("2E40001"), BigDecimal("3E-20001"),\
+              @infinity, @infinity_neg, @nan, @zero, @zero_neg]
+      @precision = BigDecimal::BASE.to_s.length - 1
+    end
+
+    it "returns array of two values" do
+      suppress_warning do
+        @arr.each do |x|
+          x.precs.kind_of?(Array).should == true
+          x.precs.size.should == 2
+        end
       end
     end
-  end
 
-  it "returns Integers as array values" do
-    suppress_warning do
-      @arr.each do |x|
-        x.precs[0].kind_of?(Integer).should == true
-        x.precs[1].kind_of?(Integer).should == true
+    it "returns Integers as array values" do
+      suppress_warning do
+        @arr.each do |x|
+          x.precs[0].kind_of?(Integer).should == true
+          x.precs[1].kind_of?(Integer).should == true
+        end
       end
     end
-  end
 
-  it "returns the current value of significant digits as the first value" do
-    suppress_warning do
-      BigDecimal("3.14159").precs[0].should >= 6
-      BigDecimal('1').precs[0].should == BigDecimal('1' + '0' * 100).precs[0]
-      [@infinity, @infinity_neg, @nan, @zero, @zero_neg].each do |value|
-        value.precs[0].should <= @precision
+    it "returns the current value of significant digits as the first value" do
+      suppress_warning do
+        BigDecimal("3.14159").precs[0].should >= 6
+        BigDecimal('1').precs[0].should == BigDecimal('1' + '0' * 100).precs[0]
+        [@infinity, @infinity_neg, @nan, @zero, @zero_neg].each do |value|
+          value.precs[0].should <= @precision
+        end
       end
     end
-  end
 
-  it "returns the maximum number of significant digits as the second value" do
-    suppress_warning do
-      BigDecimal("3.14159").precs[1].should >= 6
-      BigDecimal('1').precs[1].should >= 1
-      BigDecimal('1' + '0' * 100).precs[1].should >= 101
-      [@infinity, @infinity_neg, @nan, @zero, @zero_neg].each do |value|
-        value.precs[1].should >= 1
+    it "returns the maximum number of significant digits as the second value" do
+      suppress_warning do
+        BigDecimal("3.14159").precs[1].should >= 6
+        BigDecimal('1').precs[1].should >= 1
+        BigDecimal('1' + '0' * 100).precs[1].should >= 101
+        [@infinity, @infinity_neg, @nan, @zero, @zero_neg].each do |value|
+          value.precs[1].should >= 1
+        end
       end
     end
   end

--- a/spec/ruby/library/bigdecimal/quo_spec.rb
+++ b/spec/ruby/library/bigdecimal/quo_spec.rb
@@ -1,12 +1,15 @@
 require_relative '../../spec_helper'
-require_relative 'shared/quo'
-require 'bigdecimal'
 
-describe "BigDecimal#quo" do
-  it_behaves_like :bigdecimal_quo, :quo, []
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/quo'
+  require 'bigdecimal'
 
-  it "returns NaN if NaN is involved" do
-    BigDecimal("1").quo(BigDecimal("NaN")).should.nan?
-    BigDecimal("NaN").quo(BigDecimal("1")).should.nan?
+  describe "BigDecimal#quo" do
+    it_behaves_like :bigdecimal_quo, :quo, []
+
+    it "returns NaN if NaN is involved" do
+      BigDecimal("1").quo(BigDecimal("NaN")).should.nan?
+      BigDecimal("NaN").quo(BigDecimal("1")).should.nan?
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/remainder_spec.rb
+++ b/spec/ruby/library/bigdecimal/remainder_spec.rb
@@ -1,94 +1,97 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#remainder" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  before :each do
-    @zero = BigDecimal("0")
-    @one = BigDecimal("1")
-    @three = BigDecimal("3")
-    @mixed = BigDecimal("1.23456789")
-    @pos_int = BigDecimal("2E5555")
-    @neg_int = BigDecimal("-2E5555")
-    @pos_frac = BigDecimal("2E-9999")
-    @neg_frac = BigDecimal("-2E-9999")
-    @nan = BigDecimal("NaN")
-    @infinity = BigDecimal("Infinity")
-    @infinity_minus = BigDecimal("-Infinity")
-    @one_minus = BigDecimal("-1")
-    @frac_1 = BigDecimal("1E-99999")
-    @frac_2 = BigDecimal("0.9E-99999")
-  end
+  describe "BigDecimal#remainder" do
 
-  it "it equals modulo, if both values are of same sign" do
-    BigDecimal('1234567890123456789012345679').remainder(BigDecimal('1')).should == @zero
-    BigDecimal('123456789').remainder(BigDecimal('333333333333333333333333333E-50')).should == BigDecimal('0.12233333333333333333345679E-24')
-
-    @mixed.remainder(@pos_frac).should == @mixed % @pos_frac
-    @pos_int.remainder(@pos_frac).should == @pos_int % @pos_frac
-    @neg_frac.remainder(@neg_int).should == @neg_frac % @neg_int
-    @neg_int.remainder(@neg_frac).should == @neg_int % @neg_frac
-  end
-
-  it "means self-arg*(self/arg).truncate" do
-    @mixed.remainder(@neg_frac).should == @mixed - @neg_frac * (@mixed / @neg_frac).truncate
-    @pos_int.remainder(@neg_frac).should == @pos_int - @neg_frac * (@pos_int / @neg_frac).truncate
-    @neg_frac.remainder(@pos_int).should == @neg_frac - @pos_int * (@neg_frac / @pos_int).truncate
-    @neg_int.remainder(@pos_frac).should == @neg_int - @pos_frac * (@neg_int / @pos_frac).truncate
-  end
-
-  it "returns NaN used with zero" do
-    @mixed.remainder(@zero).should.nan?
-    @zero.remainder(@zero).should.nan?
-  end
-
-  it "returns zero if used on zero" do
-    @zero.remainder(@mixed).should == @zero
-  end
-
-  it "returns NaN if NaN is involved" do
-    @nan.remainder(@nan).should.nan?
-    @nan.remainder(@one).should.nan?
-    @one.remainder(@nan).should.nan?
-    @infinity.remainder(@nan).should.nan?
-    @nan.remainder(@infinity).should.nan?
-  end
-
-  version_is BigDecimal::VERSION, ""..."3.1.4" do #ruby_version_is ""..."3.3" do
-    it "returns NaN if Infinity is involved" do
-      @infinity.remainder(@infinity).should.nan?
-      @infinity.remainder(@one).should.nan?
-      @infinity.remainder(@mixed).should.nan?
-      @infinity.remainder(@one_minus).should.nan?
-      @infinity.remainder(@frac_1).should.nan?
-      @one.remainder(@infinity).should.nan?
-
-      @infinity_minus.remainder(@infinity_minus).should.nan?
-      @infinity_minus.remainder(@one).should.nan?
-      @one.remainder(@infinity_minus).should.nan?
-      @frac_2.remainder(@infinity_minus).should.nan?
-
-      @infinity.remainder(@infinity_minus).should.nan?
-      @infinity_minus.remainder(@infinity).should.nan?
+    before :each do
+      @zero = BigDecimal("0")
+      @one = BigDecimal("1")
+      @three = BigDecimal("3")
+      @mixed = BigDecimal("1.23456789")
+      @pos_int = BigDecimal("2E5555")
+      @neg_int = BigDecimal("-2E5555")
+      @pos_frac = BigDecimal("2E-9999")
+      @neg_frac = BigDecimal("-2E-9999")
+      @nan = BigDecimal("NaN")
+      @infinity = BigDecimal("Infinity")
+      @infinity_minus = BigDecimal("-Infinity")
+      @one_minus = BigDecimal("-1")
+      @frac_1 = BigDecimal("1E-99999")
+      @frac_2 = BigDecimal("0.9E-99999")
     end
-  end
 
-  it "coerces arguments to BigDecimal if possible" do
-    @three.remainder(2).should == @one
-  end
+    it "it equals modulo, if both values are of same sign" do
+      BigDecimal('1234567890123456789012345679').remainder(BigDecimal('1')).should == @zero
+      BigDecimal('123456789').remainder(BigDecimal('333333333333333333333333333E-50')).should == BigDecimal('0.12233333333333333333345679E-24')
 
-  describe "with Object" do
-    it "tries to coerce the other operand to self" do
-      object = mock("Object")
-      object.should_receive(:coerce).with(@three).and_return([@three, 2])
-      @three.remainder(object).should == @one
+      @mixed.remainder(@pos_frac).should == @mixed % @pos_frac
+      @pos_int.remainder(@pos_frac).should == @pos_int % @pos_frac
+      @neg_frac.remainder(@neg_int).should == @neg_frac % @neg_int
+      @neg_int.remainder(@neg_frac).should == @neg_int % @neg_frac
     end
-  end
 
-  it "raises TypeError if the argument cannot be coerced to BigDecimal" do
-    -> {
-      @one.remainder('2')
-    }.should raise_error(TypeError)
-  end
+    it "means self-arg*(self/arg).truncate" do
+      @mixed.remainder(@neg_frac).should == @mixed - @neg_frac * (@mixed / @neg_frac).truncate
+      @pos_int.remainder(@neg_frac).should == @pos_int - @neg_frac * (@pos_int / @neg_frac).truncate
+      @neg_frac.remainder(@pos_int).should == @neg_frac - @pos_int * (@neg_frac / @pos_int).truncate
+      @neg_int.remainder(@pos_frac).should == @neg_int - @pos_frac * (@neg_int / @pos_frac).truncate
+    end
 
+    it "returns NaN used with zero" do
+      @mixed.remainder(@zero).should.nan?
+      @zero.remainder(@zero).should.nan?
+    end
+
+    it "returns zero if used on zero" do
+      @zero.remainder(@mixed).should == @zero
+    end
+
+    it "returns NaN if NaN is involved" do
+      @nan.remainder(@nan).should.nan?
+      @nan.remainder(@one).should.nan?
+      @one.remainder(@nan).should.nan?
+      @infinity.remainder(@nan).should.nan?
+      @nan.remainder(@infinity).should.nan?
+    end
+
+    version_is BigDecimal::VERSION, ""..."3.1.4" do #ruby_version_is ""..."3.3" do
+      it "returns NaN if Infinity is involved" do
+        @infinity.remainder(@infinity).should.nan?
+        @infinity.remainder(@one).should.nan?
+        @infinity.remainder(@mixed).should.nan?
+        @infinity.remainder(@one_minus).should.nan?
+        @infinity.remainder(@frac_1).should.nan?
+        @one.remainder(@infinity).should.nan?
+
+        @infinity_minus.remainder(@infinity_minus).should.nan?
+        @infinity_minus.remainder(@one).should.nan?
+        @one.remainder(@infinity_minus).should.nan?
+        @frac_2.remainder(@infinity_minus).should.nan?
+
+        @infinity.remainder(@infinity_minus).should.nan?
+        @infinity_minus.remainder(@infinity).should.nan?
+      end
+    end
+
+    it "coerces arguments to BigDecimal if possible" do
+      @three.remainder(2).should == @one
+    end
+
+    describe "with Object" do
+      it "tries to coerce the other operand to self" do
+        object = mock("Object")
+        object.should_receive(:coerce).with(@three).and_return([@three, 2])
+        @three.remainder(object).should == @one
+      end
+    end
+
+    it "raises TypeError if the argument cannot be coerced to BigDecimal" do
+      -> {
+        @one.remainder('2')
+      }.should raise_error(TypeError)
+    end
+
+  end
 end

--- a/spec/ruby/library/bigdecimal/round_spec.rb
+++ b/spec/ruby/library/bigdecimal/round_spec.rb
@@ -1,242 +1,245 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#round" do
-  before :each do
-    @one   = BigDecimal("1")
-    @two   = BigDecimal("2")
-    @three = BigDecimal("3")
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-    @neg_one   = BigDecimal("-1")
-    @neg_two   = BigDecimal("-2")
-    @neg_three = BigDecimal("-3")
+  describe "BigDecimal#round" do
+    before :each do
+      @one   = BigDecimal("1")
+      @two   = BigDecimal("2")
+      @three = BigDecimal("3")
 
-    @p1_50 = BigDecimal("1.50")
-    @p1_51 = BigDecimal("1.51")
-    @p1_49 = BigDecimal("1.49")
-    @n1_50 = BigDecimal("-1.50")
-    @n1_51 = BigDecimal("-1.51")
-    @n1_49 = BigDecimal("-1.49")
+      @neg_one   = BigDecimal("-1")
+      @neg_two   = BigDecimal("-2")
+      @neg_three = BigDecimal("-3")
 
-    @p2_50 = BigDecimal("2.50")
-    @p2_51 = BigDecimal("2.51")
-    @p2_49 = BigDecimal("2.49")
-    @n2_50 = BigDecimal("-2.50")
-    @n2_51 = BigDecimal("-2.51")
-    @n2_49 = BigDecimal("-2.49")
-  end
+      @p1_50 = BigDecimal("1.50")
+      @p1_51 = BigDecimal("1.51")
+      @p1_49 = BigDecimal("1.49")
+      @n1_50 = BigDecimal("-1.50")
+      @n1_51 = BigDecimal("-1.51")
+      @n1_49 = BigDecimal("-1.49")
 
-  after :each do
-    BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_HALF_UP)
-  end
+      @p2_50 = BigDecimal("2.50")
+      @p2_51 = BigDecimal("2.51")
+      @p2_49 = BigDecimal("2.49")
+      @n2_50 = BigDecimal("-2.50")
+      @n2_51 = BigDecimal("-2.51")
+      @n2_49 = BigDecimal("-2.49")
+    end
 
-  it "uses default rounding method unless given" do
-    @p1_50.round(0).should == @two
-    @p1_51.round(0).should == @two
-    @p1_49.round(0).should == @one
-    @n1_50.round(0).should == @neg_two
-    @n1_51.round(0).should == @neg_two
-    @n1_49.round(0).should == @neg_one
+    after :each do
+      BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_HALF_UP)
+    end
 
-    @p2_50.round(0).should == @three
-    @p2_51.round(0).should == @three
-    @p2_49.round(0).should == @two
-    @n2_50.round(0).should == @neg_three
-    @n2_51.round(0).should == @neg_three
-    @n2_49.round(0).should == @neg_two
+    it "uses default rounding method unless given" do
+      @p1_50.round(0).should == @two
+      @p1_51.round(0).should == @two
+      @p1_49.round(0).should == @one
+      @n1_50.round(0).should == @neg_two
+      @n1_51.round(0).should == @neg_two
+      @n1_49.round(0).should == @neg_one
 
-    BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_DOWN)
+      @p2_50.round(0).should == @three
+      @p2_51.round(0).should == @three
+      @p2_49.round(0).should == @two
+      @n2_50.round(0).should == @neg_three
+      @n2_51.round(0).should == @neg_three
+      @n2_49.round(0).should == @neg_two
 
-    @p1_50.round(0).should == @one
-    @p1_51.round(0).should == @one
-    @p1_49.round(0).should == @one
-    @n1_50.round(0).should == @neg_one
-    @n1_51.round(0).should == @neg_one
-    @n1_49.round(0).should == @neg_one
+      BigDecimal.mode(BigDecimal::ROUND_MODE, BigDecimal::ROUND_DOWN)
 
-    @p2_50.round(0).should == @two
-    @p2_51.round(0).should == @two
-    @p2_49.round(0).should == @two
-    @n2_50.round(0).should == @neg_two
-    @n2_51.round(0).should == @neg_two
-    @n2_49.round(0).should == @neg_two
-  end
+      @p1_50.round(0).should == @one
+      @p1_51.round(0).should == @one
+      @p1_49.round(0).should == @one
+      @n1_50.round(0).should == @neg_one
+      @n1_51.round(0).should == @neg_one
+      @n1_49.round(0).should == @neg_one
 
-  ["BigDecimal::ROUND_UP", ":up"].each do |way|
-    describe way do
-      it "rounds values away from zero" do
-        mode = eval(way)
+      @p2_50.round(0).should == @two
+      @p2_51.round(0).should == @two
+      @p2_49.round(0).should == @two
+      @n2_50.round(0).should == @neg_two
+      @n2_51.round(0).should == @neg_two
+      @n2_49.round(0).should == @neg_two
+    end
 
-        @p1_50.round(0, mode).should == @two
-        @p1_51.round(0, mode).should == @two
-        @p1_49.round(0, mode).should == @two
-        @n1_50.round(0, mode).should == @neg_two
-        @n1_51.round(0, mode).should == @neg_two
-        @n1_49.round(0, mode).should == @neg_two
+    ["BigDecimal::ROUND_UP", ":up"].each do |way|
+      describe way do
+        it "rounds values away from zero" do
+          mode = eval(way)
 
-        @p2_50.round(0, mode).should == @three
-        @p2_51.round(0, mode).should == @three
-        @p2_49.round(0, mode).should == @three
-        @n2_50.round(0, mode).should == @neg_three
-        @n2_51.round(0, mode).should == @neg_three
-        @n2_49.round(0, mode).should == @neg_three
+          @p1_50.round(0, mode).should == @two
+          @p1_51.round(0, mode).should == @two
+          @p1_49.round(0, mode).should == @two
+          @n1_50.round(0, mode).should == @neg_two
+          @n1_51.round(0, mode).should == @neg_two
+          @n1_49.round(0, mode).should == @neg_two
+
+          @p2_50.round(0, mode).should == @three
+          @p2_51.round(0, mode).should == @three
+          @p2_49.round(0, mode).should == @three
+          @n2_50.round(0, mode).should == @neg_three
+          @n2_51.round(0, mode).should == @neg_three
+          @n2_49.round(0, mode).should == @neg_three
+        end
       end
     end
-  end
 
-  ["BigDecimal::ROUND_DOWN", ":down", ":truncate"].each do |way|
-    describe way do
-      it "rounds values towards zero" do
-        mode = eval(way)
+    ["BigDecimal::ROUND_DOWN", ":down", ":truncate"].each do |way|
+      describe way do
+        it "rounds values towards zero" do
+          mode = eval(way)
 
-        @p1_50.round(0, mode).should == @one
-        @p1_51.round(0, mode).should == @one
-        @p1_49.round(0, mode).should == @one
-        @n1_50.round(0, mode).should == @neg_one
-        @n1_51.round(0, mode).should == @neg_one
-        @n1_49.round(0, mode).should == @neg_one
+          @p1_50.round(0, mode).should == @one
+          @p1_51.round(0, mode).should == @one
+          @p1_49.round(0, mode).should == @one
+          @n1_50.round(0, mode).should == @neg_one
+          @n1_51.round(0, mode).should == @neg_one
+          @n1_49.round(0, mode).should == @neg_one
 
-        @p2_50.round(0, mode).should == @two
-        @p2_51.round(0, mode).should == @two
-        @p2_49.round(0, mode).should == @two
-        @n2_50.round(0, mode).should == @neg_two
-        @n2_51.round(0, mode).should == @neg_two
-        @n2_49.round(0, mode).should == @neg_two
+          @p2_50.round(0, mode).should == @two
+          @p2_51.round(0, mode).should == @two
+          @p2_49.round(0, mode).should == @two
+          @n2_50.round(0, mode).should == @neg_two
+          @n2_51.round(0, mode).should == @neg_two
+          @n2_49.round(0, mode).should == @neg_two
+        end
       end
     end
-  end
 
-  ["BigDecimal::ROUND_HALF_UP", ":half_up", ":default"].each do |way|
-    describe way do
-      it "rounds values >= 5 up, otherwise down" do
-        mode = eval(way)
+    ["BigDecimal::ROUND_HALF_UP", ":half_up", ":default"].each do |way|
+      describe way do
+        it "rounds values >= 5 up, otherwise down" do
+          mode = eval(way)
 
-        @p1_50.round(0, mode).should == @two
-        @p1_51.round(0, mode).should == @two
-        @p1_49.round(0, mode).should == @one
-        @n1_50.round(0, mode).should == @neg_two
-        @n1_51.round(0, mode).should == @neg_two
-        @n1_49.round(0, mode).should == @neg_one
+          @p1_50.round(0, mode).should == @two
+          @p1_51.round(0, mode).should == @two
+          @p1_49.round(0, mode).should == @one
+          @n1_50.round(0, mode).should == @neg_two
+          @n1_51.round(0, mode).should == @neg_two
+          @n1_49.round(0, mode).should == @neg_one
 
-        @p2_50.round(0, mode).should == @three
-        @p2_51.round(0, mode).should == @three
-        @p2_49.round(0, mode).should == @two
-        @n2_50.round(0, mode).should == @neg_three
-        @n2_51.round(0, mode).should == @neg_three
-        @n2_49.round(0, mode).should == @neg_two
+          @p2_50.round(0, mode).should == @three
+          @p2_51.round(0, mode).should == @three
+          @p2_49.round(0, mode).should == @two
+          @n2_50.round(0, mode).should == @neg_three
+          @n2_51.round(0, mode).should == @neg_three
+          @n2_49.round(0, mode).should == @neg_two
+        end
       end
     end
-  end
 
-  ["BigDecimal::ROUND_HALF_DOWN", ":half_down"].each do |way|
-    describe way do
-      it "rounds values > 5 up, otherwise down" do
-        mode = eval(way)
+    ["BigDecimal::ROUND_HALF_DOWN", ":half_down"].each do |way|
+      describe way do
+        it "rounds values > 5 up, otherwise down" do
+          mode = eval(way)
 
-        @p1_50.round(0, mode).should == @one
-        @p1_51.round(0, mode).should == @two
-        @p1_49.round(0, mode).should == @one
-        @n1_50.round(0, mode).should == @neg_one
-        @n1_51.round(0, mode).should == @neg_two
-        @n1_49.round(0, mode).should == @neg_one
+          @p1_50.round(0, mode).should == @one
+          @p1_51.round(0, mode).should == @two
+          @p1_49.round(0, mode).should == @one
+          @n1_50.round(0, mode).should == @neg_one
+          @n1_51.round(0, mode).should == @neg_two
+          @n1_49.round(0, mode).should == @neg_one
 
-        @p2_50.round(0, mode).should == @two
-        @p2_51.round(0, mode).should == @three
-        @p2_49.round(0, mode).should == @two
-        @n2_50.round(0, mode).should == @neg_two
-        @n2_51.round(0, mode).should == @neg_three
-        @n2_49.round(0, mode).should == @neg_two
+          @p2_50.round(0, mode).should == @two
+          @p2_51.round(0, mode).should == @three
+          @p2_49.round(0, mode).should == @two
+          @n2_50.round(0, mode).should == @neg_two
+          @n2_51.round(0, mode).should == @neg_three
+          @n2_49.round(0, mode).should == @neg_two
+        end
       end
     end
-  end
 
-  ["BigDecimal::ROUND_CEILING", ":ceiling", ":ceil"].each do |way|
-    describe way do
-      it "rounds values towards +infinity" do
-        mode = eval(way)
+    ["BigDecimal::ROUND_CEILING", ":ceiling", ":ceil"].each do |way|
+      describe way do
+        it "rounds values towards +infinity" do
+          mode = eval(way)
 
-        @p1_50.round(0, mode).should == @two
-        @p1_51.round(0, mode).should == @two
-        @p1_49.round(0, mode).should == @two
-        @n1_50.round(0, mode).should == @neg_one
-        @n1_51.round(0, mode).should == @neg_one
-        @n1_49.round(0, mode).should == @neg_one
+          @p1_50.round(0, mode).should == @two
+          @p1_51.round(0, mode).should == @two
+          @p1_49.round(0, mode).should == @two
+          @n1_50.round(0, mode).should == @neg_one
+          @n1_51.round(0, mode).should == @neg_one
+          @n1_49.round(0, mode).should == @neg_one
 
-        @p2_50.round(0, mode).should == @three
-        @p2_51.round(0, mode).should == @three
-        @p2_49.round(0, mode).should == @three
-        @n2_50.round(0, mode).should == @neg_two
-        @n2_51.round(0, mode).should == @neg_two
-        @n2_49.round(0, mode).should == @neg_two
+          @p2_50.round(0, mode).should == @three
+          @p2_51.round(0, mode).should == @three
+          @p2_49.round(0, mode).should == @three
+          @n2_50.round(0, mode).should == @neg_two
+          @n2_51.round(0, mode).should == @neg_two
+          @n2_49.round(0, mode).should == @neg_two
+        end
       end
     end
-  end
 
-  ["BigDecimal::ROUND_FLOOR", ":floor"].each do |way|
-    describe way do
-      it "rounds values towards -infinity" do
-        mode = eval(way)
+    ["BigDecimal::ROUND_FLOOR", ":floor"].each do |way|
+      describe way do
+        it "rounds values towards -infinity" do
+          mode = eval(way)
 
-        @p1_50.round(0, mode).should == @one
-        @p1_51.round(0, mode).should == @one
-        @p1_49.round(0, mode).should == @one
-        @n1_50.round(0, mode).should == @neg_two
-        @n1_51.round(0, mode).should == @neg_two
-        @n1_49.round(0, mode).should == @neg_two
+          @p1_50.round(0, mode).should == @one
+          @p1_51.round(0, mode).should == @one
+          @p1_49.round(0, mode).should == @one
+          @n1_50.round(0, mode).should == @neg_two
+          @n1_51.round(0, mode).should == @neg_two
+          @n1_49.round(0, mode).should == @neg_two
 
-        @p2_50.round(0, mode).should == @two
-        @p2_51.round(0, mode).should == @two
-        @p2_49.round(0, mode).should == @two
-        @n2_50.round(0, mode).should == @neg_three
-        @n2_51.round(0, mode).should == @neg_three
-        @n2_49.round(0, mode).should == @neg_three
+          @p2_50.round(0, mode).should == @two
+          @p2_51.round(0, mode).should == @two
+          @p2_49.round(0, mode).should == @two
+          @n2_50.round(0, mode).should == @neg_three
+          @n2_51.round(0, mode).should == @neg_three
+          @n2_49.round(0, mode).should == @neg_three
+        end
       end
     end
-  end
 
-  ["BigDecimal::ROUND_HALF_EVEN", ":half_even", ":banker"].each do |way|
-    describe way do
-      it "rounds values > 5 up, < 5 down and == 5 towards even neighbor" do
-        mode = eval(way)
+    ["BigDecimal::ROUND_HALF_EVEN", ":half_even", ":banker"].each do |way|
+      describe way do
+        it "rounds values > 5 up, < 5 down and == 5 towards even neighbor" do
+          mode = eval(way)
 
-        @p1_50.round(0, mode).should == @two
-        @p1_51.round(0, mode).should == @two
-        @p1_49.round(0, mode).should == @one
-        @n1_50.round(0, mode).should == @neg_two
-        @n1_51.round(0, mode).should == @neg_two
-        @n1_49.round(0, mode).should == @neg_one
+          @p1_50.round(0, mode).should == @two
+          @p1_51.round(0, mode).should == @two
+          @p1_49.round(0, mode).should == @one
+          @n1_50.round(0, mode).should == @neg_two
+          @n1_51.round(0, mode).should == @neg_two
+          @n1_49.round(0, mode).should == @neg_one
 
-        @p2_50.round(0, mode).should == @two
-        @p2_51.round(0, mode).should == @three
-        @p2_49.round(0, mode).should == @two
-        @n2_50.round(0, mode).should == @neg_two
-        @n2_51.round(0, mode).should == @neg_three
-        @n2_49.round(0, mode).should == @neg_two
+          @p2_50.round(0, mode).should == @two
+          @p2_51.round(0, mode).should == @three
+          @p2_49.round(0, mode).should == @two
+          @n2_50.round(0, mode).should == @neg_two
+          @n2_51.round(0, mode).should == @neg_three
+          @n2_49.round(0, mode).should == @neg_two
+        end
       end
     end
-  end
 
-  it 'raise exception, if self is special value' do
-    -> { BigDecimal('NaN').round }.should raise_error(FloatDomainError)
-    -> { BigDecimal('Infinity').round }.should raise_error(FloatDomainError)
-    -> { BigDecimal('-Infinity').round }.should raise_error(FloatDomainError)
-  end
-
-  it 'do not raise exception, if self is special value and precision is given' do
-    -> { BigDecimal('NaN').round(2) }.should_not raise_error(FloatDomainError)
-    -> { BigDecimal('Infinity').round(2) }.should_not raise_error(FloatDomainError)
-    -> { BigDecimal('-Infinity').round(2) }.should_not raise_error(FloatDomainError)
-  end
-
-  version_is BigDecimal::VERSION, ''...'3.1.3' do #ruby_version_is ''...'3.2' do
-    it 'raise for a non-existent round mode' do
-      -> { @p1_50.round(0, :nonsense) }.should raise_error(ArgumentError, "invalid rounding mode")
+    it 'raise exception, if self is special value' do
+      -> { BigDecimal('NaN').round }.should raise_error(FloatDomainError)
+      -> { BigDecimal('Infinity').round }.should raise_error(FloatDomainError)
+      -> { BigDecimal('-Infinity').round }.should raise_error(FloatDomainError)
     end
-  end
 
-  version_is BigDecimal::VERSION, '3.1.3' do #ruby_version_is '3.2' do
-    it 'raise for a non-existent round mode' do
-      -> { @p1_50.round(0, :nonsense) }.should raise_error(ArgumentError, "invalid rounding mode (nonsense)")
+    it 'do not raise exception, if self is special value and precision is given' do
+      -> { BigDecimal('NaN').round(2) }.should_not raise_error(FloatDomainError)
+      -> { BigDecimal('Infinity').round(2) }.should_not raise_error(FloatDomainError)
+      -> { BigDecimal('-Infinity').round(2) }.should_not raise_error(FloatDomainError)
+    end
+
+    version_is BigDecimal::VERSION, ''...'3.1.3' do #ruby_version_is ''...'3.2' do
+      it 'raise for a non-existent round mode' do
+        -> { @p1_50.round(0, :nonsense) }.should raise_error(ArgumentError, "invalid rounding mode")
+      end
+    end
+
+    version_is BigDecimal::VERSION, '3.1.3' do #ruby_version_is '3.2' do
+      it 'raise for a non-existent round mode' do
+        -> { @p1_50.round(0, :nonsense) }.should raise_error(ArgumentError, "invalid rounding mode (nonsense)")
+      end
     end
   end
 end

--- a/spec/ruby/library/bigdecimal/sign_spec.rb
+++ b/spec/ruby/library/bigdecimal/sign_spec.rb
@@ -1,46 +1,49 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#sign" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  it "defines several constants for signs" do
-    # are these really correct?
-    BigDecimal::SIGN_POSITIVE_INFINITE.should == 3
-    BigDecimal::SIGN_NEGATIVE_INFINITE.should == -3
-    BigDecimal::SIGN_POSITIVE_ZERO.should == 1
-    BigDecimal::SIGN_NEGATIVE_ZERO.should == -1
-    BigDecimal::SIGN_POSITIVE_FINITE.should == 2
-    BigDecimal::SIGN_NEGATIVE_FINITE.should == -2
+  describe "BigDecimal#sign" do
+
+    it "defines several constants for signs" do
+      # are these really correct?
+      BigDecimal::SIGN_POSITIVE_INFINITE.should == 3
+      BigDecimal::SIGN_NEGATIVE_INFINITE.should == -3
+      BigDecimal::SIGN_POSITIVE_ZERO.should == 1
+      BigDecimal::SIGN_NEGATIVE_ZERO.should == -1
+      BigDecimal::SIGN_POSITIVE_FINITE.should == 2
+      BigDecimal::SIGN_NEGATIVE_FINITE.should == -2
+    end
+
+    it "returns positive value if BigDecimal greater than 0" do
+      BigDecimal("1").sign.should == BigDecimal::SIGN_POSITIVE_FINITE
+      BigDecimal("1E-20000000").sign.should == BigDecimal::SIGN_POSITIVE_FINITE
+      BigDecimal("1E200000000").sign.should == BigDecimal::SIGN_POSITIVE_FINITE
+      BigDecimal("Infinity").sign.should == BigDecimal::SIGN_POSITIVE_INFINITE
+    end
+
+    it "returns negative value if BigDecimal less than 0" do
+      BigDecimal("-1").sign.should == BigDecimal::SIGN_NEGATIVE_FINITE
+      BigDecimal("-1E-9990000").sign.should == BigDecimal::SIGN_NEGATIVE_FINITE
+      BigDecimal("-1E20000000").sign.should == BigDecimal::SIGN_NEGATIVE_FINITE
+      BigDecimal("-Infinity").sign.should == BigDecimal::SIGN_NEGATIVE_INFINITE
+    end
+
+    it "returns positive zero if BigDecimal equals positive zero" do
+      BigDecimal("0").sign.should == BigDecimal::SIGN_POSITIVE_ZERO
+      BigDecimal("0E-200000000").sign.should == BigDecimal::SIGN_POSITIVE_ZERO
+      BigDecimal("0E200000000").sign.should == BigDecimal::SIGN_POSITIVE_ZERO
+    end
+
+    it "returns negative zero if BigDecimal equals negative zero" do
+      BigDecimal("-0").sign.should == BigDecimal::SIGN_NEGATIVE_ZERO
+      BigDecimal("-0E-200000000").sign.should == BigDecimal::SIGN_NEGATIVE_ZERO
+      BigDecimal("-0E200000000").sign.should == BigDecimal::SIGN_NEGATIVE_ZERO
+    end
+
+    it "returns BigDecimal::SIGN_NaN if BigDecimal is NaN" do
+      BigDecimal("NaN").sign.should == BigDecimal::SIGN_NaN
+    end
+
   end
-
-  it "returns positive value if BigDecimal greater than 0" do
-    BigDecimal("1").sign.should == BigDecimal::SIGN_POSITIVE_FINITE
-    BigDecimal("1E-20000000").sign.should == BigDecimal::SIGN_POSITIVE_FINITE
-    BigDecimal("1E200000000").sign.should == BigDecimal::SIGN_POSITIVE_FINITE
-    BigDecimal("Infinity").sign.should == BigDecimal::SIGN_POSITIVE_INFINITE
-  end
-
-  it "returns negative value if BigDecimal less than 0" do
-    BigDecimal("-1").sign.should == BigDecimal::SIGN_NEGATIVE_FINITE
-    BigDecimal("-1E-9990000").sign.should == BigDecimal::SIGN_NEGATIVE_FINITE
-    BigDecimal("-1E20000000").sign.should == BigDecimal::SIGN_NEGATIVE_FINITE
-    BigDecimal("-Infinity").sign.should == BigDecimal::SIGN_NEGATIVE_INFINITE
-  end
-
-  it "returns positive zero if BigDecimal equals positive zero" do
-    BigDecimal("0").sign.should == BigDecimal::SIGN_POSITIVE_ZERO
-    BigDecimal("0E-200000000").sign.should == BigDecimal::SIGN_POSITIVE_ZERO
-    BigDecimal("0E200000000").sign.should == BigDecimal::SIGN_POSITIVE_ZERO
-  end
-
-  it "returns negative zero if BigDecimal equals negative zero" do
-    BigDecimal("-0").sign.should == BigDecimal::SIGN_NEGATIVE_ZERO
-    BigDecimal("-0E-200000000").sign.should == BigDecimal::SIGN_NEGATIVE_ZERO
-    BigDecimal("-0E200000000").sign.should == BigDecimal::SIGN_NEGATIVE_ZERO
-  end
-
-  it "returns BigDecimal::SIGN_NaN if BigDecimal is NaN" do
-    BigDecimal("NaN").sign.should == BigDecimal::SIGN_NaN
-  end
-
 end

--- a/spec/ruby/library/bigdecimal/split_spec.rb
+++ b/spec/ruby/library/bigdecimal/split_spec.rb
@@ -1,86 +1,89 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#split" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  before :each do
-    @arr = BigDecimal("0.314159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593014782083152134043E1").split
-    @arr_neg = BigDecimal("-0.314159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593014782083152134043E1").split
-    @digits = "922337203685477580810101333333333333333333333333333"
-    @arr_big = BigDecimal("00#{@digits}000").split
-    @arr_big_neg = BigDecimal("-00#{@digits}000").split
-    @huge = BigDecimal('100000000000000000000000000000000000000000001E90000000').split
+  describe "BigDecimal#split" do
 
-    @infinity = BigDecimal("Infinity")
-    @infinity_neg = BigDecimal("-Infinity")
-    @nan = BigDecimal("NaN")
-    @zero = BigDecimal("0")
-    @zero_neg = BigDecimal("-0")
+    before :each do
+      @arr = BigDecimal("0.314159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593014782083152134043E1").split
+      @arr_neg = BigDecimal("-0.314159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593014782083152134043E1").split
+      @digits = "922337203685477580810101333333333333333333333333333"
+      @arr_big = BigDecimal("00#{@digits}000").split
+      @arr_big_neg = BigDecimal("-00#{@digits}000").split
+      @huge = BigDecimal('100000000000000000000000000000000000000000001E90000000').split
+
+      @infinity = BigDecimal("Infinity")
+      @infinity_neg = BigDecimal("-Infinity")
+      @nan = BigDecimal("NaN")
+      @zero = BigDecimal("0")
+      @zero_neg = BigDecimal("-0")
+    end
+
+    it "splits BigDecimal in an array with four values" do
+      @arr.size.should == 4
+    end
+
+    it "first value: 1 for numbers > 0" do
+      @arr[0].should == 1
+      @arr_big[0].should == 1
+      @zero.split[0].should == 1
+      @huge[0].should == 1
+      BigDecimal("+0").split[0].should == 1
+      BigDecimal("1E400").split[0].should == 1
+      @infinity.split[0].should == 1
+    end
+
+    it "first value: -1 for numbers < 0" do
+      @arr_neg[0].should == -1
+      @arr_big_neg[0].should == -1
+      @zero_neg.split[0].should == -1
+      BigDecimal("-1E400").split[0].should == -1
+      @infinity_neg.split[0].should == -1
+    end
+
+    it "first value: 0 if BigDecimal is NaN" do
+      BigDecimal("NaN").split[0].should == 0
+    end
+
+    it "second value: a string with the significant digits" do
+      string = "314159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593014782083152134043"
+      @arr[1].should == string
+      @arr_big[1].should == @digits
+      @arr_big_neg[1].should == @digits
+      @huge[1].should == "100000000000000000000000000000000000000000001"
+      @infinity.split[1].should == @infinity.to_s
+      @nan.split[1].should == @nan.to_s
+      @infinity_neg.split[1].should == @infinity.to_s
+      @zero.split[1].should == "0"
+      BigDecimal("-0").split[1].should == "0"
+    end
+
+    it "third value: the base (currently always ten)" do
+     @arr[2].should == 10
+     @arr_neg[2].should == 10
+     @arr_big[2].should == 10
+     @arr_big_neg[2].should == 10
+     @huge[2].should == 10
+     @infinity.split[2].should == 10
+     @nan.split[2].should == 10
+     @infinity_neg.split[2].should == 10
+     @zero.split[2].should == 10
+     @zero_neg.split[2].should == 10
+    end
+
+    it "fourth value: the exponent" do
+      @arr[3].should == 1
+      @arr_neg[3].should == 1
+      @arr_big[3].should == 54
+      @arr_big_neg[3].should == 54
+      @huge[3].should == 90000045
+      @infinity.split[3].should == 0
+      @nan.split[3].should == 0
+      @infinity_neg.split[3].should == 0
+      @zero.split[3].should == 0
+      @zero_neg.split[3].should == 0
+    end
+
   end
-
-  it "splits BigDecimal in an array with four values" do
-    @arr.size.should == 4
-  end
-
-  it "first value: 1 for numbers > 0" do
-    @arr[0].should == 1
-    @arr_big[0].should == 1
-    @zero.split[0].should == 1
-    @huge[0].should == 1
-    BigDecimal("+0").split[0].should == 1
-    BigDecimal("1E400").split[0].should == 1
-    @infinity.split[0].should == 1
-  end
-
-  it "first value: -1 for numbers < 0" do
-    @arr_neg[0].should == -1
-    @arr_big_neg[0].should == -1
-    @zero_neg.split[0].should == -1
-    BigDecimal("-1E400").split[0].should == -1
-    @infinity_neg.split[0].should == -1
-  end
-
-  it "first value: 0 if BigDecimal is NaN" do
-    BigDecimal("NaN").split[0].should == 0
-  end
-
-  it "second value: a string with the significant digits" do
-    string = "314159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593014782083152134043"
-    @arr[1].should == string
-    @arr_big[1].should == @digits
-    @arr_big_neg[1].should == @digits
-    @huge[1].should == "100000000000000000000000000000000000000000001"
-    @infinity.split[1].should == @infinity.to_s
-    @nan.split[1].should == @nan.to_s
-    @infinity_neg.split[1].should == @infinity.to_s
-    @zero.split[1].should == "0"
-    BigDecimal("-0").split[1].should == "0"
-  end
-
-  it "third value: the base (currently always ten)" do
-   @arr[2].should == 10
-   @arr_neg[2].should == 10
-   @arr_big[2].should == 10
-   @arr_big_neg[2].should == 10
-   @huge[2].should == 10
-   @infinity.split[2].should == 10
-   @nan.split[2].should == 10
-   @infinity_neg.split[2].should == 10
-   @zero.split[2].should == 10
-   @zero_neg.split[2].should == 10
-  end
-
-  it "fourth value: the exponent" do
-    @arr[3].should == 1
-    @arr_neg[3].should == 1
-    @arr_big[3].should == 54
-    @arr_big_neg[3].should == 54
-    @huge[3].should == 90000045
-    @infinity.split[3].should == 0
-    @nan.split[3].should == 0
-    @infinity_neg.split[3].should == 0
-    @zero.split[3].should == 0
-    @zero_neg.split[3].should == 0
-  end
-
 end

--- a/spec/ruby/library/bigdecimal/sqrt_spec.rb
+++ b/spec/ruby/library/bigdecimal/sqrt_spec.rb
@@ -1,114 +1,117 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
-require 'bigdecimal'
 
-describe "BigDecimal#sqrt" do
-  before :each do
-    @one = BigDecimal("1")
-    @zero = BigDecimal("0")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-    @two = BigDecimal("2.0")
-    @three = BigDecimal("3.0")
-    @nan = BigDecimal("NaN")
-    @infinity = BigDecimal("Infinity")
-    @infinity_minus = BigDecimal("-Infinity")
-    @one_minus = BigDecimal("-1")
-    @frac_1 = BigDecimal("1E-99999")
-    @frac_2 = BigDecimal("0.9E-99999")
-  end
+ruby_version_is ""..."3.4" do
+  require_relative 'fixtures/classes'
+  require 'bigdecimal'
 
-  it "returns square root of 2 with desired precision" do
-    string = "1.41421356237309504880168872420969807856967187537694807317667973799073247846210703885038753432764157"
-    (1..99).each { |idx|
-      @two.sqrt(idx).should be_close(BigDecimal(string), BigDecimal("1E-#{idx-1}"))
-    }
-  end
-
-  it "returns square root of 3 with desired precision" do
-    sqrt_3 = "1.732050807568877293527446341505872366942805253810380628055806979451933016908800037081146186757248575"
-    (1..99).each { |idx|
-      @three.sqrt(idx).should be_close(BigDecimal(sqrt_3), BigDecimal("1E-#{idx-1}"))
-    }
-  end
-
-  it "returns square root of 121 with desired precision" do
-    BigDecimal('121').sqrt(5).should be_close(11, 0.00001)
-  end
-
-  platform_is_not wordsize: 32 do # fails on i686
-    it "returns square root of 0.9E-99999 with desired precision" do
-      @frac_2.sqrt(1).to_s.should =~ /\A0\.3E-49999\z/i
+  describe "BigDecimal#sqrt" do
+    before :each do
+      @one = BigDecimal("1")
+      @zero = BigDecimal("0")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
+      @two = BigDecimal("2.0")
+      @three = BigDecimal("3.0")
+      @nan = BigDecimal("NaN")
+      @infinity = BigDecimal("Infinity")
+      @infinity_minus = BigDecimal("-Infinity")
+      @one_minus = BigDecimal("-1")
+      @frac_1 = BigDecimal("1E-99999")
+      @frac_2 = BigDecimal("0.9E-99999")
     end
-  end
 
-  it "raises ArgumentError when no argument is given" do
-    -> {
-      @one.sqrt
-    }.should raise_error(ArgumentError)
-  end
+    it "returns square root of 2 with desired precision" do
+      string = "1.41421356237309504880168872420969807856967187537694807317667973799073247846210703885038753432764157"
+      (1..99).each { |idx|
+        @two.sqrt(idx).should be_close(BigDecimal(string), BigDecimal("1E-#{idx-1}"))
+      }
+    end
 
-  it "raises ArgumentError if a negative number is given" do
-    -> {
-      @one.sqrt(-1)
-    }.should raise_error(ArgumentError)
-  end
+    it "returns square root of 3 with desired precision" do
+      sqrt_3 = "1.732050807568877293527446341505872366942805253810380628055806979451933016908800037081146186757248575"
+      (1..99).each { |idx|
+        @three.sqrt(idx).should be_close(BigDecimal(sqrt_3), BigDecimal("1E-#{idx-1}"))
+      }
+    end
 
-  it "raises ArgumentError if 2 arguments are given" do
-    -> {
-      @one.sqrt(1, 1)
-    }.should raise_error(ArgumentError)
-  end
+    it "returns square root of 121 with desired precision" do
+      BigDecimal('121').sqrt(5).should be_close(11, 0.00001)
+    end
 
-  it "raises TypeError if nil is given" do
-    -> {
-      @one.sqrt(nil)
-    }.should raise_error(TypeError)
-  end
+    platform_is_not wordsize: 32 do # fails on i686
+      it "returns square root of 0.9E-99999 with desired precision" do
+        @frac_2.sqrt(1).to_s.should =~ /\A0\.3E-49999\z/i
+      end
+    end
 
-  it "raises TypeError if a string is given" do
-    -> {
-      @one.sqrt("stuff")
-    }.should raise_error(TypeError)
-  end
+    it "raises ArgumentError when no argument is given" do
+      -> {
+        @one.sqrt
+      }.should raise_error(ArgumentError)
+    end
 
-  it "raises TypeError if a plain Object is given" do
-    -> {
-      @one.sqrt(Object.new)
-    }.should raise_error(TypeError)
-  end
+    it "raises ArgumentError if a negative number is given" do
+      -> {
+        @one.sqrt(-1)
+      }.should raise_error(ArgumentError)
+    end
 
-  it "returns 1 if precision is 0 or 1" do
-    @one.sqrt(1).should == 1
-    @one.sqrt(0).should == 1
-  end
+    it "raises ArgumentError if 2 arguments are given" do
+      -> {
+        @one.sqrt(1, 1)
+      }.should raise_error(ArgumentError)
+    end
 
-  it "raises FloatDomainError on negative values" do
-    -> {
-      BigDecimal('-1').sqrt(10)
-    }.should raise_error(FloatDomainError)
-  end
+    it "raises TypeError if nil is given" do
+      -> {
+        @one.sqrt(nil)
+      }.should raise_error(TypeError)
+    end
 
-  it "returns positive infinity for infinity" do
-    @infinity.sqrt(1).should == @infinity
-  end
+    it "raises TypeError if a string is given" do
+      -> {
+        @one.sqrt("stuff")
+      }.should raise_error(TypeError)
+    end
 
-  it "raises FloatDomainError for negative infinity" do
-    -> {
-      @infinity_minus.sqrt(1)
-    }.should raise_error(FloatDomainError)
-  end
+    it "raises TypeError if a plain Object is given" do
+      -> {
+        @one.sqrt(Object.new)
+      }.should raise_error(TypeError)
+    end
 
-  it "raises FloatDomainError for NaN" do
-    -> {
-      @nan.sqrt(1)
-    }.should raise_error(FloatDomainError)
-  end
+    it "returns 1 if precision is 0 or 1" do
+      @one.sqrt(1).should == 1
+      @one.sqrt(0).should == 1
+    end
 
-  it "returns 0 for 0, +0.0 and -0.0" do
-    @zero.sqrt(1).should == 0
-    @zero_pos.sqrt(1).should == 0
-    @zero_neg.sqrt(1).should == 0
-  end
+    it "raises FloatDomainError on negative values" do
+      -> {
+        BigDecimal('-1').sqrt(10)
+      }.should raise_error(FloatDomainError)
+    end
 
+    it "returns positive infinity for infinity" do
+      @infinity.sqrt(1).should == @infinity
+    end
+
+    it "raises FloatDomainError for negative infinity" do
+      -> {
+        @infinity_minus.sqrt(1)
+      }.should raise_error(FloatDomainError)
+    end
+
+    it "raises FloatDomainError for NaN" do
+      -> {
+        @nan.sqrt(1)
+      }.should raise_error(FloatDomainError)
+    end
+
+    it "returns 0 for 0, +0.0 and -0.0" do
+      @zero.sqrt(1).should == 0
+      @zero_pos.sqrt(1).should == 0
+      @zero_neg.sqrt(1).should == 0
+    end
+
+  end
 end

--- a/spec/ruby/library/bigdecimal/sub_spec.rb
+++ b/spec/ruby/library/bigdecimal/sub_spec.rb
@@ -1,70 +1,73 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#sub" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  before :each do
-    @one = BigDecimal("1")
-    @zero = BigDecimal("0")
-    @two = BigDecimal("2")
-    @three = BigDecimal("3")
-    @nan = BigDecimal("NaN")
-    @infinity = BigDecimal("Infinity")
-    @infinity_minus = BigDecimal("-Infinity")
-    @one_minus = BigDecimal("-1")
-    @frac_1 = BigDecimal("1E-99999")
-    @frac_2 = BigDecimal("0.9E-99999")
-    @frac_3 = BigDecimal("12345E10")
-    @frac_4 = BigDecimal("98765E10")
-  end
+  describe "BigDecimal#sub" do
 
-  it "returns a - b with given precision" do
-    # documentation states, that precision is optional
-    # but implementation raises ArgumentError if not given.
-
-    @two.sub(@one, 1).should == @one
-    @one.sub(@two, 1).should == @one_minus
-    @one.sub(@one_minus, 1).should == @two
-    @frac_2.sub(@frac_1, 1000000).should == BigDecimal("-0.1E-99999")
-    @frac_2.sub(@frac_1, 1).should == BigDecimal("-0.1E-99999")
-    # the above two examples puzzle me.
-    in_arow_one = BigDecimal("1.23456789")
-    in_arow_two = BigDecimal("1.2345678")
-    in_arow_one.sub(in_arow_two, 10).should == BigDecimal("0.9E-7")
-    @two.sub(@two,1).should == @zero
-    @frac_1.sub(@frac_1, 1000000).should == @zero
-  end
-
-  describe "with Object" do
-    it "tries to coerce the other operand to self" do
-      object = mock("Object")
-      object.should_receive(:coerce).with(@frac_3).and_return([@frac_3, @frac_4])
-      @frac_3.sub(object, 1).should == BigDecimal("-0.9E15")
+    before :each do
+      @one = BigDecimal("1")
+      @zero = BigDecimal("0")
+      @two = BigDecimal("2")
+      @three = BigDecimal("3")
+      @nan = BigDecimal("NaN")
+      @infinity = BigDecimal("Infinity")
+      @infinity_minus = BigDecimal("-Infinity")
+      @one_minus = BigDecimal("-1")
+      @frac_1 = BigDecimal("1E-99999")
+      @frac_2 = BigDecimal("0.9E-99999")
+      @frac_3 = BigDecimal("12345E10")
+      @frac_4 = BigDecimal("98765E10")
     end
-  end
 
-  describe "with Rational" do
-    it "produces a BigDecimal" do
-      (@three - Rational(500, 2)).should == BigDecimal('-0.247e3')
+    it "returns a - b with given precision" do
+      # documentation states, that precision is optional
+      # but implementation raises ArgumentError if not given.
+
+      @two.sub(@one, 1).should == @one
+      @one.sub(@two, 1).should == @one_minus
+      @one.sub(@one_minus, 1).should == @two
+      @frac_2.sub(@frac_1, 1000000).should == BigDecimal("-0.1E-99999")
+      @frac_2.sub(@frac_1, 1).should == BigDecimal("-0.1E-99999")
+      # the above two examples puzzle me.
+      in_arow_one = BigDecimal("1.23456789")
+      in_arow_two = BigDecimal("1.2345678")
+      in_arow_one.sub(in_arow_two, 10).should == BigDecimal("0.9E-7")
+      @two.sub(@two,1).should == @zero
+      @frac_1.sub(@frac_1, 1000000).should == @zero
     end
-  end
 
-  it "returns NaN if NaN is involved" do
-    @one.sub(@nan, 1).should.nan?
-    @nan.sub(@one, 1).should.nan?
-  end
+    describe "with Object" do
+      it "tries to coerce the other operand to self" do
+        object = mock("Object")
+        object.should_receive(:coerce).with(@frac_3).and_return([@frac_3, @frac_4])
+        @frac_3.sub(object, 1).should == BigDecimal("-0.9E15")
+      end
+    end
 
-  it "returns NaN if both values are infinite with the same signs" do
-    @infinity.sub(@infinity, 1).should.nan?
-    @infinity_minus.sub(@infinity_minus, 1).should.nan?
-  end
+    describe "with Rational" do
+      it "produces a BigDecimal" do
+        (@three - Rational(500, 2)).should == BigDecimal('-0.247e3')
+      end
+    end
 
-  it "returns Infinity or -Infinity if these are involved" do
-    @infinity.sub(@infinity_minus, 1).should == @infinity
-    @infinity_minus.sub(@infinity, 1).should == @infinity_minus
-    @zero.sub(@infinity, 1).should == @infinity_minus
-    @frac_2.sub( @infinity, 1).should == @infinity_minus
-    @two.sub(@infinity, 1).should == @infinity_minus
-  end
+    it "returns NaN if NaN is involved" do
+      @one.sub(@nan, 1).should.nan?
+      @nan.sub(@one, 1).should.nan?
+    end
 
+    it "returns NaN if both values are infinite with the same signs" do
+      @infinity.sub(@infinity, 1).should.nan?
+      @infinity_minus.sub(@infinity_minus, 1).should.nan?
+    end
+
+    it "returns Infinity or -Infinity if these are involved" do
+      @infinity.sub(@infinity_minus, 1).should == @infinity
+      @infinity_minus.sub(@infinity, 1).should == @infinity_minus
+      @zero.sub(@infinity, 1).should == @infinity_minus
+      @frac_2.sub( @infinity, 1).should == @infinity_minus
+      @two.sub(@infinity, 1).should == @infinity_minus
+    end
+
+  end
 end

--- a/spec/ruby/library/bigdecimal/to_d_spec.rb
+++ b/spec/ruby/library/bigdecimal/to_d_spec.rb
@@ -1,10 +1,13 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
-require 'bigdecimal/util'
 
-describe "Float#to_d" do
-  it "returns appropriate BigDecimal zero for signed zero" do
-    -0.0.to_d.sign.should == -1
-    0.0.to_d.sign.should == 1
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
+  require 'bigdecimal/util'
+
+  describe "Float#to_d" do
+    it "returns appropriate BigDecimal zero for signed zero" do
+      -0.0.to_d.sign.should == -1
+      0.0.to_d.sign.should == 1
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/to_f_spec.rb
+++ b/spec/ruby/library/bigdecimal/to_f_spec.rb
@@ -1,54 +1,57 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#to_f" do
-  before :each do
-    @one = BigDecimal("1")
-    @zero = BigDecimal("0")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-    @two = BigDecimal("2")
-    @three = BigDecimal("3")
-    @nan = BigDecimal("NaN")
-    @infinity = BigDecimal("Infinity")
-    @infinity_minus = BigDecimal("-Infinity")
-    @one_minus = BigDecimal("-1")
-    @frac_1 = BigDecimal("1E-99999")
-    @frac_2 = BigDecimal("0.9E-99999")
-    @vals = [@one, @zero, @two, @three, @frac_1, @frac_2]
-    @spec_vals = [@zero_pos, @zero_neg, @nan, @infinity, @infinity_minus]
-  end
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  it "returns number of type float" do
-    BigDecimal("3.14159").to_f.should be_kind_of(Float)
-    @vals.each { |val| val.to_f.should be_kind_of(Float) }
-    @spec_vals.each { |val| val.to_f.should be_kind_of(Float) }
-  end
+  describe "BigDecimal#to_f" do
+    before :each do
+      @one = BigDecimal("1")
+      @zero = BigDecimal("0")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
+      @two = BigDecimal("2")
+      @three = BigDecimal("3")
+      @nan = BigDecimal("NaN")
+      @infinity = BigDecimal("Infinity")
+      @infinity_minus = BigDecimal("-Infinity")
+      @one_minus = BigDecimal("-1")
+      @frac_1 = BigDecimal("1E-99999")
+      @frac_2 = BigDecimal("0.9E-99999")
+      @vals = [@one, @zero, @two, @three, @frac_1, @frac_2]
+      @spec_vals = [@zero_pos, @zero_neg, @nan, @infinity, @infinity_minus]
+    end
 
-  it "rounds correctly to Float precision" do
-    bigdec = BigDecimal("3.141592653589793238462643383279502884197169399375")
-    bigdec.to_f.should be_close(3.14159265358979, TOLERANCE)
-    @one.to_f.should == 1.0
-    @two.to_f.should == 2.0
-    @three.to_f.should be_close(3.0, TOLERANCE)
-    @one_minus.to_f.should == -1.0
+    it "returns number of type float" do
+      BigDecimal("3.14159").to_f.should be_kind_of(Float)
+      @vals.each { |val| val.to_f.should be_kind_of(Float) }
+      @spec_vals.each { |val| val.to_f.should be_kind_of(Float) }
+    end
 
-    # regression test for [ruby-talk:338957]
-    BigDecimal("10.03").to_f.should == 10.03
-  end
+    it "rounds correctly to Float precision" do
+      bigdec = BigDecimal("3.141592653589793238462643383279502884197169399375")
+      bigdec.to_f.should be_close(3.14159265358979, TOLERANCE)
+      @one.to_f.should == 1.0
+      @two.to_f.should == 2.0
+      @three.to_f.should be_close(3.0, TOLERANCE)
+      @one_minus.to_f.should == -1.0
 
-  it "properly handles special values" do
-    @zero.to_f.should == 0
-    @zero.to_f.to_s.should == "0.0"
+      # regression test for [ruby-talk:338957]
+      BigDecimal("10.03").to_f.should == 10.03
+    end
 
-    @nan.to_f.should.nan?
+    it "properly handles special values" do
+      @zero.to_f.should == 0
+      @zero.to_f.to_s.should == "0.0"
 
-    @infinity.to_f.infinite?.should == 1
-    @infinity_minus.to_f.infinite?.should == -1
-  end
+      @nan.to_f.should.nan?
 
-  it "remembers negative zero when converted to float" do
-    @zero_neg.to_f.should == 0
-    @zero_neg.to_f.to_s.should == "-0.0"
+      @infinity.to_f.infinite?.should == 1
+      @infinity_minus.to_f.infinite?.should == -1
+    end
+
+    it "remembers negative zero when converted to float" do
+      @zero_neg.to_f.should == 0
+      @zero_neg.to_f.to_s.should == "-0.0"
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/to_i_spec.rb
+++ b/spec/ruby/library/bigdecimal/to_i_spec.rb
@@ -1,7 +1,10 @@
 require_relative '../../spec_helper'
-require_relative 'shared/to_int'
-require 'bigdecimal'
 
-describe "BigDecimal#to_i" do
-    it_behaves_like :bigdecimal_to_int, :to_i
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/to_int'
+  require 'bigdecimal'
+
+  describe "BigDecimal#to_i" do
+      it_behaves_like :bigdecimal_to_int, :to_i
+  end
 end

--- a/spec/ruby/library/bigdecimal/to_int_spec.rb
+++ b/spec/ruby/library/bigdecimal/to_int_spec.rb
@@ -1,8 +1,11 @@
 require_relative '../../spec_helper'
-require_relative 'shared/to_int'
-require 'bigdecimal'
+
+ruby_version_is ""..."3.4" do
+  require_relative 'shared/to_int'
+  require 'bigdecimal'
 
 
-describe "BigDecimal#to_int" do
-  it_behaves_like :bigdecimal_to_int, :to_int
+  describe "BigDecimal#to_int" do
+    it_behaves_like :bigdecimal_to_int, :to_int
+  end
 end

--- a/spec/ruby/library/bigdecimal/to_r_spec.rb
+++ b/spec/ruby/library/bigdecimal/to_r_spec.rb
@@ -1,28 +1,31 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#to_r" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  it "returns a Rational" do
-    BigDecimal("3.14159").to_r.should be_kind_of(Rational)
+  describe "BigDecimal#to_r" do
+
+    it "returns a Rational" do
+      BigDecimal("3.14159").to_r.should be_kind_of(Rational)
+    end
+
+    it "returns a Rational with bignum values" do
+      r = BigDecimal("3.141592653589793238462643").to_r
+      r.numerator.should eql(3141592653589793238462643)
+      r.denominator.should eql(1000000000000000000000000)
+    end
+
+    it "returns a Rational from a BigDecimal with an exponent" do
+      r = BigDecimal("1E2").to_r
+      r.numerator.should eql(100)
+      r.denominator.should eql(1)
+    end
+
+    it "returns a Rational from a negative BigDecimal with an exponent" do
+      r = BigDecimal("-1E2").to_r
+      r.numerator.should eql(-100)
+      r.denominator.should eql(1)
+    end
+
   end
-
-  it "returns a Rational with bignum values" do
-    r = BigDecimal("3.141592653589793238462643").to_r
-    r.numerator.should eql(3141592653589793238462643)
-    r.denominator.should eql(1000000000000000000000000)
-  end
-
-  it "returns a Rational from a BigDecimal with an exponent" do
-    r = BigDecimal("1E2").to_r
-    r.numerator.should eql(100)
-    r.denominator.should eql(1)
-  end
-
-  it "returns a Rational from a negative BigDecimal with an exponent" do
-    r = BigDecimal("-1E2").to_r
-    r.numerator.should eql(-100)
-    r.denominator.should eql(1)
-  end
-
 end

--- a/spec/ruby/library/bigdecimal/to_s_spec.rb
+++ b/spec/ruby/library/bigdecimal/to_s_spec.rb
@@ -1,100 +1,103 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#to_s" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  before :each do
-    @bigdec_str = "3.14159265358979323846264338327950288419716939937"
-    @bigneg_str = "-3.1415926535897932384626433832795028841971693993"
-    @bigdec = BigDecimal(@bigdec_str)
-    @bigneg = BigDecimal(@bigneg_str)
-    @internal = Encoding.default_internal
-  end
+  describe "BigDecimal#to_s" do
 
-  after :each do
-    Encoding.default_internal = @internal
-  end
-
-  it "return type is of class String" do
-    @bigdec.to_s.kind_of?(String).should == true
-    @bigneg.to_s.kind_of?(String).should == true
-  end
-
-  it "the default format looks like 0.xxxxenn" do
-    @bigdec.to_s.should =~ /^0\.[0-9]*e[0-9]*$/
-  end
-
-  it "does not add an exponent for zero values" do
-    BigDecimal("0").to_s.should == "0.0"
-    BigDecimal("+0").to_s.should == "0.0"
-    BigDecimal("-0").to_s.should == "-0.0"
-  end
-
-  it "takes an optional argument" do
-    -> {@bigdec.to_s("F")}.should_not raise_error()
-  end
-
-  it "starts with + if + is supplied and value is positive" do
-    @bigdec.to_s("+").should =~ /^\+.*/
-    @bigneg.to_s("+").should_not =~ /^\+.*/
-  end
-
-  it "inserts a space every n chars to fraction part, if integer n is supplied" do
-    re =\
-    /\A0\.314 159 265 358 979 323 846 264 338 327 950 288 419 716 939 937E1\z/i
-    @bigdec.to_s(3).should =~ re
-
-    str1 = '-123.45678 90123 45678 9'
-    BigDecimal("-123.45678901234567890").to_s('5F').should ==  str1
-    # trailing zeroes removed
-    BigDecimal("1.00000000000").to_s('1F').should == "1.0"
-    # 0 is treated as no spaces
-    BigDecimal("1.2345").to_s('0F').should == "1.2345"
-  end
-
-  version_is BigDecimal::VERSION, "3.1.5" do #ruby_version_is '3.3' do
-    it "inserts a space every n chars to integer part, if integer n is supplied" do
-      BigDecimal('1000010').to_s('5F').should == "10 00010.0"
+    before :each do
+      @bigdec_str = "3.14159265358979323846264338327950288419716939937"
+      @bigneg_str = "-3.1415926535897932384626433832795028841971693993"
+      @bigdec = BigDecimal(@bigdec_str)
+      @bigneg = BigDecimal(@bigneg_str)
+      @internal = Encoding.default_internal
     end
-  end
 
-  it "can return a leading space for values > 0" do
-    @bigdec.to_s(" F").should =~ /\ .*/
-    @bigneg.to_s(" F").should_not =~ /\ .*/
-  end
-
-  it "removes trailing spaces in floating point notation" do
-    BigDecimal('-123.45678901234567890').to_s('F').should == "-123.4567890123456789"
-    BigDecimal('1.2500').to_s('F').should == "1.25"
-    BigDecimal('0000.00000').to_s('F').should == "0.0"
-    BigDecimal('-00.000010000').to_s('F').should == "-0.00001"
-    BigDecimal("5.00000E-2").to_s("F").should == "0.05"
-
-    BigDecimal("500000").to_s("F").should == "500000.0"
-    BigDecimal("5E2").to_s("F").should == "500.0"
-    BigDecimal("-5E100").to_s("F").should == "-5" + "0" * 100 + ".0"
-  end
-
-  it "can use engineering notation" do
-    @bigdec.to_s("E").should =~ /^0\.[0-9]*E[0-9]*$/i
-  end
-
-  it "can use conventional floating point notation" do
-    %w[f F].each do |format_char|
-      @bigdec.to_s(format_char).should == @bigdec_str
-      @bigneg.to_s(format_char).should == @bigneg_str
-      str2 = "+123.45678901 23456789"
-      BigDecimal('123.45678901234567890').to_s("+8#{format_char}").should == str2
+    after :each do
+      Encoding.default_internal = @internal
     end
-  end
 
-  it "returns a String in US-ASCII encoding when Encoding.default_internal is nil" do
-    Encoding.default_internal = nil
-    BigDecimal('1.23').to_s.encoding.should equal(Encoding::US_ASCII)
-  end
+    it "return type is of class String" do
+      @bigdec.to_s.kind_of?(String).should == true
+      @bigneg.to_s.kind_of?(String).should == true
+    end
 
-  it "returns a String in US-ASCII encoding when Encoding.default_internal is not nil" do
-    Encoding.default_internal = Encoding::IBM437
-    BigDecimal('1.23').to_s.encoding.should equal(Encoding::US_ASCII)
+    it "the default format looks like 0.xxxxenn" do
+      @bigdec.to_s.should =~ /^0\.[0-9]*e[0-9]*$/
+    end
+
+    it "does not add an exponent for zero values" do
+      BigDecimal("0").to_s.should == "0.0"
+      BigDecimal("+0").to_s.should == "0.0"
+      BigDecimal("-0").to_s.should == "-0.0"
+    end
+
+    it "takes an optional argument" do
+      -> {@bigdec.to_s("F")}.should_not raise_error()
+    end
+
+    it "starts with + if + is supplied and value is positive" do
+      @bigdec.to_s("+").should =~ /^\+.*/
+      @bigneg.to_s("+").should_not =~ /^\+.*/
+    end
+
+    it "inserts a space every n chars to fraction part, if integer n is supplied" do
+      re =\
+      /\A0\.314 159 265 358 979 323 846 264 338 327 950 288 419 716 939 937E1\z/i
+      @bigdec.to_s(3).should =~ re
+
+      str1 = '-123.45678 90123 45678 9'
+      BigDecimal("-123.45678901234567890").to_s('5F').should ==  str1
+      # trailing zeroes removed
+      BigDecimal("1.00000000000").to_s('1F').should == "1.0"
+      # 0 is treated as no spaces
+      BigDecimal("1.2345").to_s('0F').should == "1.2345"
+    end
+
+    version_is BigDecimal::VERSION, "3.1.5" do #ruby_version_is '3.3' do
+      it "inserts a space every n chars to integer part, if integer n is supplied" do
+        BigDecimal('1000010').to_s('5F').should == "10 00010.0"
+      end
+    end
+
+    it "can return a leading space for values > 0" do
+      @bigdec.to_s(" F").should =~ /\ .*/
+      @bigneg.to_s(" F").should_not =~ /\ .*/
+    end
+
+    it "removes trailing spaces in floating point notation" do
+      BigDecimal('-123.45678901234567890').to_s('F').should == "-123.4567890123456789"
+      BigDecimal('1.2500').to_s('F').should == "1.25"
+      BigDecimal('0000.00000').to_s('F').should == "0.0"
+      BigDecimal('-00.000010000').to_s('F').should == "-0.00001"
+      BigDecimal("5.00000E-2").to_s("F").should == "0.05"
+
+      BigDecimal("500000").to_s("F").should == "500000.0"
+      BigDecimal("5E2").to_s("F").should == "500.0"
+      BigDecimal("-5E100").to_s("F").should == "-5" + "0" * 100 + ".0"
+    end
+
+    it "can use engineering notation" do
+      @bigdec.to_s("E").should =~ /^0\.[0-9]*E[0-9]*$/i
+    end
+
+    it "can use conventional floating point notation" do
+      %w[f F].each do |format_char|
+        @bigdec.to_s(format_char).should == @bigdec_str
+        @bigneg.to_s(format_char).should == @bigneg_str
+        str2 = "+123.45678901 23456789"
+        BigDecimal('123.45678901234567890').to_s("+8#{format_char}").should == str2
+      end
+    end
+
+    it "returns a String in US-ASCII encoding when Encoding.default_internal is nil" do
+      Encoding.default_internal = nil
+      BigDecimal('1.23').to_s.encoding.should equal(Encoding::US_ASCII)
+    end
+
+    it "returns a String in US-ASCII encoding when Encoding.default_internal is not nil" do
+      Encoding.default_internal = Encoding::IBM437
+      BigDecimal('1.23').to_s.encoding.should equal(Encoding::US_ASCII)
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/truncate_spec.rb
+++ b/spec/ruby/library/bigdecimal/truncate_spec.rb
@@ -1,81 +1,84 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#truncate" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  before :each do
-      @arr = ['3.14159', '8.7', "0.314159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593014782083152134043E1"]
-      @big = BigDecimal("123456.789")
-      @nan = BigDecimal('NaN')
-      @infinity = BigDecimal('Infinity')
-      @infinity_negative = BigDecimal('-Infinity')
-  end
+  describe "BigDecimal#truncate" do
 
-  it "returns value of type Integer." do
-    @arr.each do |x|
-      BigDecimal(x).truncate.kind_of?(Integer).should == true
+    before :each do
+        @arr = ['3.14159', '8.7', "0.314159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651328230664709384460955058223172535940812848111745028410270193852110555964462294895493038196442881097566593014782083152134043E1"]
+        @big = BigDecimal("123456.789")
+        @nan = BigDecimal('NaN')
+        @infinity = BigDecimal('Infinity')
+        @infinity_negative = BigDecimal('-Infinity')
     end
-  end
 
-  it "returns the integer part as a BigDecimal if no precision given" do
-    BigDecimal(@arr[0]).truncate.should == 3
-    BigDecimal(@arr[1]).truncate.should == 8
-    BigDecimal(@arr[2]).truncate.should == 3
-    BigDecimal('0').truncate.should == 0
-    BigDecimal('0.1').truncate.should == 0
-    BigDecimal('-0.1').truncate.should == 0
-    BigDecimal('1.5').truncate.should == 1
-    BigDecimal('-1.5').truncate.should == -1
-    BigDecimal('1E10').truncate.should == BigDecimal('1E10')
-    BigDecimal('-1E10').truncate.should == BigDecimal('-1E10')
-    BigDecimal('1.8888E10').truncate.should == BigDecimal('1.8888E10')
-    BigDecimal('-1E-1').truncate.should == 0
-  end
+    it "returns value of type Integer." do
+      @arr.each do |x|
+        BigDecimal(x).truncate.kind_of?(Integer).should == true
+      end
+    end
 
-  it "returns value of given precision otherwise" do
-    BigDecimal('-1.55').truncate(1).should == BigDecimal('-1.5')
-    BigDecimal('1.55').truncate(1).should == BigDecimal('1.5')
-    BigDecimal(@arr[0]).truncate(2).should == BigDecimal("3.14")
-    BigDecimal('123.456').truncate(2).should == BigDecimal("123.45")
-    BigDecimal('123.456789').truncate(4).should == BigDecimal("123.4567")
-    BigDecimal('0.456789').truncate(10).should == BigDecimal("0.456789")
-    BigDecimal('-1E-1').truncate(1).should == BigDecimal('-0.1')
-    BigDecimal('-1E-1').truncate(2).should == BigDecimal('-0.1E0')
-    BigDecimal('-1E-1').truncate.should == BigDecimal('0')
-    BigDecimal('-1E-1').truncate(0).should == BigDecimal('0')
-    BigDecimal('-1E-1').truncate(-1).should == BigDecimal('0')
-    BigDecimal('-1E-1').truncate(-2).should == BigDecimal('0')
+    it "returns the integer part as a BigDecimal if no precision given" do
+      BigDecimal(@arr[0]).truncate.should == 3
+      BigDecimal(@arr[1]).truncate.should == 8
+      BigDecimal(@arr[2]).truncate.should == 3
+      BigDecimal('0').truncate.should == 0
+      BigDecimal('0.1').truncate.should == 0
+      BigDecimal('-0.1').truncate.should == 0
+      BigDecimal('1.5').truncate.should == 1
+      BigDecimal('-1.5').truncate.should == -1
+      BigDecimal('1E10').truncate.should == BigDecimal('1E10')
+      BigDecimal('-1E10').truncate.should == BigDecimal('-1E10')
+      BigDecimal('1.8888E10').truncate.should == BigDecimal('1.8888E10')
+      BigDecimal('-1E-1').truncate.should == 0
+    end
 
-    BigDecimal(@arr[1]).truncate(1).should == BigDecimal("8.7")
-    BigDecimal(@arr[2]).truncate(100).should == BigDecimal(\
-      "3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679")
-  end
+    it "returns value of given precision otherwise" do
+      BigDecimal('-1.55').truncate(1).should == BigDecimal('-1.5')
+      BigDecimal('1.55').truncate(1).should == BigDecimal('1.5')
+      BigDecimal(@arr[0]).truncate(2).should == BigDecimal("3.14")
+      BigDecimal('123.456').truncate(2).should == BigDecimal("123.45")
+      BigDecimal('123.456789').truncate(4).should == BigDecimal("123.4567")
+      BigDecimal('0.456789').truncate(10).should == BigDecimal("0.456789")
+      BigDecimal('-1E-1').truncate(1).should == BigDecimal('-0.1')
+      BigDecimal('-1E-1').truncate(2).should == BigDecimal('-0.1E0')
+      BigDecimal('-1E-1').truncate.should == BigDecimal('0')
+      BigDecimal('-1E-1').truncate(0).should == BigDecimal('0')
+      BigDecimal('-1E-1').truncate(-1).should == BigDecimal('0')
+      BigDecimal('-1E-1').truncate(-2).should == BigDecimal('0')
 
-  it "sets n digits left of the decimal point to 0, if given n < 0" do
-    @big.truncate(-1).should == BigDecimal("123450.0")
-    @big.truncate(-2).should == BigDecimal("123400.0")
-    BigDecimal(@arr[2]).truncate(-1).should == 0
-  end
+      BigDecimal(@arr[1]).truncate(1).should == BigDecimal("8.7")
+      BigDecimal(@arr[2]).truncate(100).should == BigDecimal(\
+        "3.1415926535897932384626433832795028841971693993751058209749445923078164062862089986280348253421170679")
+    end
 
-  it "returns NaN if self is NaN" do
-    @nan.truncate(-1).should.nan?
-    @nan.truncate(+1).should.nan?
-    @nan.truncate(0).should.nan?
-  end
+    it "sets n digits left of the decimal point to 0, if given n < 0" do
+      @big.truncate(-1).should == BigDecimal("123450.0")
+      @big.truncate(-2).should == BigDecimal("123400.0")
+      BigDecimal(@arr[2]).truncate(-1).should == 0
+    end
 
-  it "returns Infinity if self is infinite" do
-    @infinity.truncate(-1).should == @infinity
-    @infinity.truncate(+1).should == @infinity
-    @infinity.truncate(0).should == @infinity
+    it "returns NaN if self is NaN" do
+      @nan.truncate(-1).should.nan?
+      @nan.truncate(+1).should.nan?
+      @nan.truncate(0).should.nan?
+    end
 
-    @infinity_negative.truncate(-1).should == @infinity_negative
-    @infinity_negative.truncate(+1).should == @infinity_negative
-    @infinity_negative.truncate(0).should == @infinity_negative
-  end
+    it "returns Infinity if self is infinite" do
+      @infinity.truncate(-1).should == @infinity
+      @infinity.truncate(+1).should == @infinity
+      @infinity.truncate(0).should == @infinity
 
-  it "returns the same value if self is special value" do
-    -> { @nan.truncate }.should raise_error(FloatDomainError)
-    -> { @infinity.truncate }.should raise_error(FloatDomainError)
-    -> { @infinity_negative.truncate }.should raise_error(FloatDomainError)
+      @infinity_negative.truncate(-1).should == @infinity_negative
+      @infinity_negative.truncate(+1).should == @infinity_negative
+      @infinity_negative.truncate(0).should == @infinity_negative
+    end
+
+    it "returns the same value if self is special value" do
+      -> { @nan.truncate }.should raise_error(FloatDomainError)
+      -> { @infinity.truncate }.should raise_error(FloatDomainError)
+      -> { @infinity_negative.truncate }.should raise_error(FloatDomainError)
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/uminus_spec.rb
+++ b/spec/ruby/library/bigdecimal/uminus_spec.rb
@@ -1,58 +1,61 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#-@" do
-  before :each do
-    @one = BigDecimal("1")
-    @zero = BigDecimal("0")
-    @zero_pos = BigDecimal("+0")
-    @zero_neg = BigDecimal("-0")
-    @nan = BigDecimal("NaN")
-    @infinity = BigDecimal("Infinity")
-    @infinity_minus = BigDecimal("-Infinity")
-    @one_minus = BigDecimal("-1")
-    @frac_1 = BigDecimal("1E-99999")
-    @frac_2 = BigDecimal("0.9E-99999")
-    @big = BigDecimal("333E99999")
-    @big_neg = BigDecimal("-333E99999")
-    @values = [@one, @zero, @zero_pos, @zero_neg, @infinity,
-      @infinity_minus, @one_minus, @frac_1, @frac_2, @big, @big_neg]
-  end
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  it "negates self" do
-    @one.send(:-@).should == @one_minus
-    @one_minus.send(:-@).should == @one
-    @frac_1.send(:-@).should == BigDecimal("-1E-99999")
-    @frac_2.send(:-@).should == BigDecimal("-0.9E-99999")
-    @big.send(:-@).should == @big_neg
-    @big_neg.send(:-@).should == @big
-    BigDecimal("2.221").send(:-@).should == BigDecimal("-2.221")
-    BigDecimal("2E10000").send(:-@).should == BigDecimal("-2E10000")
-    some_number = BigDecimal("2455999221.5512")
-    some_number_neg = BigDecimal("-2455999221.5512")
-    some_number.send(:-@).should == some_number_neg
-    (-BigDecimal("-5.5")).should == BigDecimal("5.5")
-    another_number = BigDecimal("-8.551551551551551551")
-    another_number_pos = BigDecimal("8.551551551551551551")
-    another_number.send(:-@).should == another_number_pos
-    @values.each do |val|
-      (val.send(:-@).send(:-@)).should == val
+  describe "BigDecimal#-@" do
+    before :each do
+      @one = BigDecimal("1")
+      @zero = BigDecimal("0")
+      @zero_pos = BigDecimal("+0")
+      @zero_neg = BigDecimal("-0")
+      @nan = BigDecimal("NaN")
+      @infinity = BigDecimal("Infinity")
+      @infinity_minus = BigDecimal("-Infinity")
+      @one_minus = BigDecimal("-1")
+      @frac_1 = BigDecimal("1E-99999")
+      @frac_2 = BigDecimal("0.9E-99999")
+      @big = BigDecimal("333E99999")
+      @big_neg = BigDecimal("-333E99999")
+      @values = [@one, @zero, @zero_pos, @zero_neg, @infinity,
+        @infinity_minus, @one_minus, @frac_1, @frac_2, @big, @big_neg]
     end
-  end
 
-  it "properly handles special values" do
-    @infinity.send(:-@).should == @infinity_minus
-    @infinity_minus.send(:-@).should == @infinity
-    @infinity.send(:-@).infinite?.should == -1
-    @infinity_minus.send(:-@).infinite?.should == 1
+    it "negates self" do
+      @one.send(:-@).should == @one_minus
+      @one_minus.send(:-@).should == @one
+      @frac_1.send(:-@).should == BigDecimal("-1E-99999")
+      @frac_2.send(:-@).should == BigDecimal("-0.9E-99999")
+      @big.send(:-@).should == @big_neg
+      @big_neg.send(:-@).should == @big
+      BigDecimal("2.221").send(:-@).should == BigDecimal("-2.221")
+      BigDecimal("2E10000").send(:-@).should == BigDecimal("-2E10000")
+      some_number = BigDecimal("2455999221.5512")
+      some_number_neg = BigDecimal("-2455999221.5512")
+      some_number.send(:-@).should == some_number_neg
+      (-BigDecimal("-5.5")).should == BigDecimal("5.5")
+      another_number = BigDecimal("-8.551551551551551551")
+      another_number_pos = BigDecimal("8.551551551551551551")
+      another_number.send(:-@).should == another_number_pos
+      @values.each do |val|
+        (val.send(:-@).send(:-@)).should == val
+      end
+    end
 
-    @zero.send(:-@).should == @zero
-    @zero.send(:-@).sign.should == -1
-    @zero_pos.send(:-@).should == @zero
-    @zero_pos.send(:-@).sign.should == -1
-    @zero_neg.send(:-@).should == @zero
-    @zero_neg.send(:-@).sign.should == 1
+    it "properly handles special values" do
+      @infinity.send(:-@).should == @infinity_minus
+      @infinity_minus.send(:-@).should == @infinity
+      @infinity.send(:-@).infinite?.should == -1
+      @infinity_minus.send(:-@).infinite?.should == 1
 
-    @nan.send(:-@).should.nan?
+      @zero.send(:-@).should == @zero
+      @zero.send(:-@).sign.should == -1
+      @zero_pos.send(:-@).should == @zero
+      @zero_pos.send(:-@).sign.should == -1
+      @zero_neg.send(:-@).should == @zero
+      @zero_neg.send(:-@).sign.should == 1
+
+      @nan.send(:-@).should.nan?
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/uplus_spec.rb
+++ b/spec/ruby/library/bigdecimal/uplus_spec.rb
@@ -1,17 +1,20 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#+@" do
-  it "returns the same value with same sign (twos complement)" do
-    first = BigDecimal("34.56")
-    first.send(:+@).should == first
-    second = BigDecimal("-34.56")
-    second.send(:+@).should == second
-    third = BigDecimal("0.0")
-    third.send(:+@).should == third
-    fourth = BigDecimal("2E1000000")
-    fourth.send(:+@).should == fourth
-    fifth = BigDecimal("123456789E-1000000")
-    fifth.send(:+@).should == fifth
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
+
+  describe "BigDecimal#+@" do
+    it "returns the same value with same sign (twos complement)" do
+      first = BigDecimal("34.56")
+      first.send(:+@).should == first
+      second = BigDecimal("-34.56")
+      second.send(:+@).should == second
+      third = BigDecimal("0.0")
+      third.send(:+@).should == third
+      fourth = BigDecimal("2E1000000")
+      fourth.send(:+@).should == fourth
+      fifth = BigDecimal("123456789E-1000000")
+      fifth.send(:+@).should == fifth
+    end
   end
 end

--- a/spec/ruby/library/bigdecimal/util_spec.rb
+++ b/spec/ruby/library/bigdecimal/util_spec.rb
@@ -1,40 +1,43 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
-require 'bigdecimal/util'
 
-describe "BigDecimal's util method definitions" do
-  describe "#to_d" do
-    it "should define #to_d on Integer" do
-      42.to_d.should == BigDecimal(42)
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
+  require 'bigdecimal/util'
+
+  describe "BigDecimal's util method definitions" do
+    describe "#to_d" do
+      it "should define #to_d on Integer" do
+        42.to_d.should == BigDecimal(42)
+      end
+
+      it "should define #to_d on Float" do
+        0.5.to_d.should == BigDecimal(0.5, Float::DIG)
+        1.234.to_d(2).should == BigDecimal(1.234, 2)
+      end
+
+      it "should define #to_d on String" do
+        "0.5".to_d.should == BigDecimal(0.5, Float::DIG)
+        "45.67 degrees".to_d.should == BigDecimal(45.67, Float::DIG)
+      end
+
+      it "should define #to_d on BigDecimal" do
+        bd = BigDecimal("3.14")
+        bd.to_d.should equal(bd)
+      end
+
+      it "should define #to_d on Rational" do
+        Rational(22, 7).to_d(3).should == BigDecimal(3.14, 3)
+      end
+
+      it "should define #to_d on nil" do
+        nil.to_d.should == BigDecimal(0)
+      end
     end
 
-    it "should define #to_d on Float" do
-      0.5.to_d.should == BigDecimal(0.5, Float::DIG)
-      1.234.to_d(2).should == BigDecimal(1.234, 2)
-    end
-
-    it "should define #to_d on String" do
-      "0.5".to_d.should == BigDecimal(0.5, Float::DIG)
-      "45.67 degrees".to_d.should == BigDecimal(45.67, Float::DIG)
-    end
-
-    it "should define #to_d on BigDecimal" do
-      bd = BigDecimal("3.14")
-      bd.to_d.should equal(bd)
-    end
-
-    it "should define #to_d on Rational" do
-      Rational(22, 7).to_d(3).should == BigDecimal(3.14, 3)
-    end
-
-    it "should define #to_d on nil" do
-      nil.to_d.should == BigDecimal(0)
-    end
-  end
-
-  describe "#to_digits" do
-    it "should define #to_digits on BigDecimal" do
-      BigDecimal("3.14").to_digits.should == "3.14"
+    describe "#to_digits" do
+      it "should define #to_digits on BigDecimal" do
+        BigDecimal("3.14").to_digits.should == "3.14"
+      end
     end
   end
 end

--- a/spec/ruby/library/bigdecimal/zero_spec.rb
+++ b/spec/ruby/library/bigdecimal/zero_spec.rb
@@ -1,27 +1,30 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#zero?" do
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
 
-  it "returns true if self does equal zero" do
-    really_small_zero = BigDecimal("0E-200000000")
-    really_big_zero = BigDecimal("0E200000000000")
-    really_small_zero.should.zero?
-    really_big_zero.should.zero?
-    BigDecimal("0.000000000000000000000000").should.zero?
-    BigDecimal("0").should.zero?
-    BigDecimal("0E0").should.zero?
-    BigDecimal("+0").should.zero?
-    BigDecimal("-0").should.zero?
+  describe "BigDecimal#zero?" do
+
+    it "returns true if self does equal zero" do
+      really_small_zero = BigDecimal("0E-200000000")
+      really_big_zero = BigDecimal("0E200000000000")
+      really_small_zero.should.zero?
+      really_big_zero.should.zero?
+      BigDecimal("0.000000000000000000000000").should.zero?
+      BigDecimal("0").should.zero?
+      BigDecimal("0E0").should.zero?
+      BigDecimal("+0").should.zero?
+      BigDecimal("-0").should.zero?
+    end
+
+    it "returns false otherwise" do
+      BigDecimal("0000000001").should_not.zero?
+      BigDecimal("2E40001").should_not.zero?
+      BigDecimal("3E-20001").should_not.zero?
+      BigDecimal("Infinity").should_not.zero?
+      BigDecimal("-Infinity").should_not.zero?
+      BigDecimal("NaN").should_not.zero?
+    end
+
   end
-
-  it "returns false otherwise" do
-    BigDecimal("0000000001").should_not.zero?
-    BigDecimal("2E40001").should_not.zero?
-    BigDecimal("3E-20001").should_not.zero?
-    BigDecimal("Infinity").should_not.zero?
-    BigDecimal("-Infinity").should_not.zero?
-    BigDecimal("NaN").should_not.zero?
-  end
-
 end

--- a/spec/ruby/library/bigmath/log_spec.rb
+++ b/spec/ruby/library/bigmath/log_spec.rb
@@ -1,10 +1,13 @@
 require_relative '../../spec_helper'
-require 'bigdecimal'
 
-describe "BigDecimal#log" do
-  it "handles high-precision Rational arguments" do
-    result = BigDecimal('0.22314354220170971436137296411949880462556361100856391620766259404746040597133837784E0')
-    r = Rational(1_234_567_890, 987_654_321)
-    BigMath.log(r, 50).should == result
+ruby_version_is ""..."3.4" do
+  require 'bigdecimal'
+
+  describe "BigDecimal#log" do
+    it "handles high-precision Rational arguments" do
+      result = BigDecimal('0.22314354220170971436137296411949880462556361100856391620766259404746040597133837784E0')
+      r = Rational(1_234_567_890, 987_654_321)
+      BigMath.log(r, 50).should == result
+    end
   end
 end

--- a/spec/ruby/library/csv/basicwriter/close_on_terminate_spec.rb
+++ b/spec/ruby/library/csv/basicwriter/close_on_terminate_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::BasicWriter#close_on_terminate" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::BasicWriter#close_on_terminate" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/basicwriter/initialize_spec.rb
+++ b/spec/ruby/library/csv/basicwriter/initialize_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::BasicWriter#initialize" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::BasicWriter#initialize" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/basicwriter/terminate_spec.rb
+++ b/spec/ruby/library/csv/basicwriter/terminate_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::BasicWriter#terminate" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::BasicWriter#terminate" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/cell/data_spec.rb
+++ b/spec/ruby/library/csv/cell/data_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::Cell#data" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::Cell#data" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/cell/initialize_spec.rb
+++ b/spec/ruby/library/csv/cell/initialize_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::Cell#initialize" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::Cell#initialize" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/foreach_spec.rb
+++ b/spec/ruby/library/csv/foreach_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../spec_helper'
-require 'csv'
 
-describe "CSV.foreach" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV.foreach" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/generate_line_spec.rb
+++ b/spec/ruby/library/csv/generate_line_spec.rb
@@ -1,30 +1,33 @@
 require_relative '../../spec_helper'
-require 'csv'
 
-describe "CSV.generate_line" do
+ruby_version_is ""..."3.4" do
+  require 'csv'
 
-  it "generates an empty string" do
-    result = CSV.generate_line([])
-    result.should == "\n"
-  end
+  describe "CSV.generate_line" do
 
-  it "generates the string 'foo,bar'" do
-    result = CSV.generate_line(["foo", "bar"])
-    result.should == "foo,bar\n"
-  end
+    it "generates an empty string" do
+      result = CSV.generate_line([])
+      result.should == "\n"
+    end
 
-  it "generates the string 'foo;bar'" do
-    result = CSV.generate_line(["foo", "bar"], col_sep: ?;)
-    result.should == "foo;bar\n"
-  end
+    it "generates the string 'foo,bar'" do
+      result = CSV.generate_line(["foo", "bar"])
+      result.should == "foo,bar\n"
+    end
 
-  it "generates the string 'foo,,bar'" do
-    result = CSV.generate_line(["foo", nil, "bar"])
-    result.should == "foo,,bar\n"
-  end
+    it "generates the string 'foo;bar'" do
+      result = CSV.generate_line(["foo", "bar"], col_sep: ?;)
+      result.should == "foo;bar\n"
+    end
 
-  it "generates the string 'foo;;bar'" do
-    result = CSV.generate_line(["foo", nil, "bar"], col_sep: ?;)
-    result.should == "foo;;bar\n"
+    it "generates the string 'foo,,bar'" do
+      result = CSV.generate_line(["foo", nil, "bar"])
+      result.should == "foo,,bar\n"
+    end
+
+    it "generates the string 'foo;;bar'" do
+      result = CSV.generate_line(["foo", nil, "bar"], col_sep: ?;)
+      result.should == "foo;;bar\n"
+    end
   end
 end

--- a/spec/ruby/library/csv/generate_row_spec.rb
+++ b/spec/ruby/library/csv/generate_row_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../spec_helper'
-require 'csv'
 
-describe "CSV.generate_row" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV.generate_row" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/generate_spec.rb
+++ b/spec/ruby/library/csv/generate_spec.rb
@@ -1,32 +1,35 @@
 require_relative '../../spec_helper'
-require 'csv'
-require 'tempfile'
 
-describe "CSV.generate" do
+ruby_version_is ""..."3.4" do
+  require 'csv'
+  require 'tempfile'
 
-  it "returns CSV string" do
-    csv_str = CSV.generate do |csv|
-      csv.add_row [1, 2, 3]
-      csv << [4, 5, 6]
+  describe "CSV.generate" do
+
+    it "returns CSV string" do
+      csv_str = CSV.generate do |csv|
+        csv.add_row [1, 2, 3]
+        csv << [4, 5, 6]
+      end
+      csv_str.should == "1,2,3\n4,5,6\n"
     end
-    csv_str.should == "1,2,3\n4,5,6\n"
-  end
 
-  it "accepts a col separator" do
-    csv_str = CSV.generate(col_sep: ";") do |csv|
-      csv.add_row [1, 2, 3]
-      csv << [4, 5, 6]
+    it "accepts a col separator" do
+      csv_str = CSV.generate(col_sep: ";") do |csv|
+        csv.add_row [1, 2, 3]
+        csv << [4, 5, 6]
+      end
+      csv_str.should == "1;2;3\n4;5;6\n"
     end
-    csv_str.should == "1;2;3\n4;5;6\n"
-  end
 
-  it "appends and returns the argument itself" do
-    str = ""
-    csv_str = CSV.generate(str) do |csv|
-      csv.add_row [1, 2, 3]
-      csv << [4, 5, 6]
+    it "appends and returns the argument itself" do
+      str = ""
+      csv_str = CSV.generate(str) do |csv|
+        csv.add_row [1, 2, 3]
+        csv << [4, 5, 6]
+      end
+      csv_str.should equal str
+      str.should == "1,2,3\n4,5,6\n"
     end
-    csv_str.should equal str
-    str.should == "1,2,3\n4,5,6\n"
   end
 end

--- a/spec/ruby/library/csv/iobuf/close_spec.rb
+++ b/spec/ruby/library/csv/iobuf/close_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::IOBuf#close" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::IOBuf#close" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/iobuf/initialize_spec.rb
+++ b/spec/ruby/library/csv/iobuf/initialize_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::IOBuf#initialize" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::IOBuf#initialize" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/iobuf/read_spec.rb
+++ b/spec/ruby/library/csv/iobuf/read_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::IOBuf#read" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::IOBuf#read" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/iobuf/terminate_spec.rb
+++ b/spec/ruby/library/csv/iobuf/terminate_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::IOBuf#terminate" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::IOBuf#terminate" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/ioreader/close_on_terminate_spec.rb
+++ b/spec/ruby/library/csv/ioreader/close_on_terminate_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::IOReader#close_on_terminate" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::IOReader#close_on_terminate" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/ioreader/get_row_spec.rb
+++ b/spec/ruby/library/csv/ioreader/get_row_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::IOReader#get_row" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::IOReader#get_row" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/ioreader/initialize_spec.rb
+++ b/spec/ruby/library/csv/ioreader/initialize_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::IOReader#initialize" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::IOReader#initialize" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/ioreader/terminate_spec.rb
+++ b/spec/ruby/library/csv/ioreader/terminate_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::IOReader#terminate" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::IOReader#terminate" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/liberal_parsing_spec.rb
+++ b/spec/ruby/library/csv/liberal_parsing_spec.rb
@@ -1,19 +1,22 @@
 require_relative '../../spec_helper'
-require 'csv'
 
-describe "CSV#liberal_parsing?" do
-  it "returns true if illegal input is handled" do
-    csv = CSV.new("", liberal_parsing: true)
-    csv.should.liberal_parsing?
-  end
+ruby_version_is ""..."3.4" do
+  require 'csv'
 
-  it "returns false if illegal input is not handled" do
-    csv = CSV.new("", liberal_parsing: false)
-    csv.should_not.liberal_parsing?
-  end
+  describe "CSV#liberal_parsing?" do
+    it "returns true if illegal input is handled" do
+      csv = CSV.new("", liberal_parsing: true)
+      csv.should.liberal_parsing?
+    end
 
-  it "returns false by default" do
-    csv = CSV.new("")
-    csv.should_not.liberal_parsing?
+    it "returns false if illegal input is not handled" do
+      csv = CSV.new("", liberal_parsing: false)
+      csv.should_not.liberal_parsing?
+    end
+
+    it "returns false by default" do
+      csv = CSV.new("")
+      csv.should_not.liberal_parsing?
+    end
   end
 end

--- a/spec/ruby/library/csv/open_spec.rb
+++ b/spec/ruby/library/csv/open_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../spec_helper'
-require 'csv'
 
-describe "CSV.open" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV.open" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/parse_spec.rb
+++ b/spec/ruby/library/csv/parse_spec.rb
@@ -1,93 +1,96 @@
 require_relative '../../spec_helper'
-require 'csv'
 
-describe "CSV.parse" do
+ruby_version_is ""..."3.4" do
+  require 'csv'
 
-  it "parses '' into []" do
-    result = CSV.parse ''
-    result.should be_kind_of(Array)
-    result.should == []
-  end
+  describe "CSV.parse" do
 
-  it "parses '\n' into [[]]" do
-    result = CSV.parse "\n"
-    result.should == [[]]
-  end
+    it "parses '' into []" do
+      result = CSV.parse ''
+      result.should be_kind_of(Array)
+      result.should == []
+    end
 
-  it "parses 'foo' into [['foo']]" do
-    result = CSV.parse 'foo'
-    result.should == [['foo']]
-  end
+    it "parses '\n' into [[]]" do
+      result = CSV.parse "\n"
+      result.should == [[]]
+    end
 
-  it "parses 'foo,bar,baz' into [['foo','bar','baz']]" do
-    result = CSV.parse 'foo,bar,baz'
-    result.should == [['foo','bar','baz']]
-  end
+    it "parses 'foo' into [['foo']]" do
+      result = CSV.parse 'foo'
+      result.should == [['foo']]
+    end
 
-  it "parses 'foo,baz' into [[foo,nil,baz]]" do
-    result = CSV.parse 'foo,,baz'
-    result.should == [['foo',nil,'baz']]
-  end
+    it "parses 'foo,bar,baz' into [['foo','bar','baz']]" do
+      result = CSV.parse 'foo,bar,baz'
+      result.should == [['foo','bar','baz']]
+    end
 
-  it "parses '\nfoo' into [[],['foo']]" do
-    result = CSV.parse "\nfoo"
-    result.should == [[],['foo']]
-  end
+    it "parses 'foo,baz' into [[foo,nil,baz]]" do
+      result = CSV.parse 'foo,,baz'
+      result.should == [['foo',nil,'baz']]
+    end
 
-  it "parses 'foo\n' into [['foo']]" do
-    result = CSV.parse "foo\n"
-    result.should == [['foo']]
-  end
+    it "parses '\nfoo' into [[],['foo']]" do
+      result = CSV.parse "\nfoo"
+      result.should == [[],['foo']]
+    end
 
-  it "parses 'foo\nbar' into [['foo'],['bar']]" do
-    result = CSV.parse "foo\nbar"
-    result.should == [['foo'],['bar']]
-  end
+    it "parses 'foo\n' into [['foo']]" do
+      result = CSV.parse "foo\n"
+      result.should == [['foo']]
+    end
 
-  it "parses 'foo,bar\nbaz,quz' into [['foo','bar'],['baz','quz']]" do
-    result = CSV.parse "foo,bar\nbaz,quz"
-    result.should == [['foo','bar'],['baz','quz']]
-  end
+    it "parses 'foo\nbar' into [['foo'],['bar']]" do
+      result = CSV.parse "foo\nbar"
+      result.should == [['foo'],['bar']]
+    end
 
-  it "parses 'foo,bar'\nbaz' into [['foo','bar'],['baz']]" do
-    result = CSV.parse "foo,bar\nbaz"
-    result.should == [['foo','bar'],['baz']]
-  end
+    it "parses 'foo,bar\nbaz,quz' into [['foo','bar'],['baz','quz']]" do
+      result = CSV.parse "foo,bar\nbaz,quz"
+      result.should == [['foo','bar'],['baz','quz']]
+    end
 
-  it "parses 'foo\nbar,baz' into [['foo'],['bar','baz']]" do
-    result = CSV.parse "foo\nbar,baz"
-    result.should == [['foo'],['bar','baz']]
-  end
+    it "parses 'foo,bar'\nbaz' into [['foo','bar'],['baz']]" do
+      result = CSV.parse "foo,bar\nbaz"
+      result.should == [['foo','bar'],['baz']]
+    end
 
-  it "parses '\n\nbar' into [[],[],'bar']]" do
-    result = CSV.parse "\n\nbar"
-    result.should == [[],[],['bar']]
-  end
+    it "parses 'foo\nbar,baz' into [['foo'],['bar','baz']]" do
+      result = CSV.parse "foo\nbar,baz"
+      result.should == [['foo'],['bar','baz']]
+    end
 
-  it "parses 'foo' into [['foo']] with a separator of ;" do
-    result = CSV.parse "foo", col_sep: ?;
-    result.should == [['foo']]
-  end
+    it "parses '\n\nbar' into [[],[],'bar']]" do
+      result = CSV.parse "\n\nbar"
+      result.should == [[],[],['bar']]
+    end
 
-  it "parses 'foo;bar' into [['foo','bar']] with a separator of ;" do
-    result = CSV.parse "foo;bar", col_sep: ?;
-    result.should == [['foo','bar']]
-  end
+    it "parses 'foo' into [['foo']] with a separator of ;" do
+      result = CSV.parse "foo", col_sep: ?;
+      result.should == [['foo']]
+    end
 
-  it "parses 'foo;bar\nbaz;quz' into [['foo','bar'],['baz','quz']] with a separator of ;" do
-    result = CSV.parse "foo;bar\nbaz;quz", col_sep: ?;
-    result.should == [['foo','bar'],['baz','quz']]
-  end
+    it "parses 'foo;bar' into [['foo','bar']] with a separator of ;" do
+      result = CSV.parse "foo;bar", col_sep: ?;
+      result.should == [['foo','bar']]
+    end
 
-  it "raises CSV::MalformedCSVError exception if input is illegal" do
-    -> {
-      CSV.parse('"quoted" field')
-    }.should raise_error(CSV::MalformedCSVError)
-  end
+    it "parses 'foo;bar\nbaz;quz' into [['foo','bar'],['baz','quz']] with a separator of ;" do
+      result = CSV.parse "foo;bar\nbaz;quz", col_sep: ?;
+      result.should == [['foo','bar'],['baz','quz']]
+    end
 
-  it "handles illegal input with the liberal_parsing option" do
-    illegal_input = '"Johnson, Dwayne",Dwayne "The Rock" Johnson'
-    result = CSV.parse(illegal_input, liberal_parsing: true)
-    result.should == [["Johnson, Dwayne", 'Dwayne "The Rock" Johnson']]
+    it "raises CSV::MalformedCSVError exception if input is illegal" do
+      -> {
+        CSV.parse('"quoted" field')
+      }.should raise_error(CSV::MalformedCSVError)
+    end
+
+    it "handles illegal input with the liberal_parsing option" do
+      illegal_input = '"Johnson, Dwayne",Dwayne "The Rock" Johnson'
+      result = CSV.parse(illegal_input, liberal_parsing: true)
+      result.should == [["Johnson, Dwayne", 'Dwayne "The Rock" Johnson']]
+    end
   end
 end

--- a/spec/ruby/library/csv/read_spec.rb
+++ b/spec/ruby/library/csv/read_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../spec_helper'
-require 'csv'
 
-describe "CSV.read" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV.read" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/readlines_spec.rb
+++ b/spec/ruby/library/csv/readlines_spec.rb
@@ -1,35 +1,38 @@
 require_relative '../../spec_helper'
-require 'csv'
 
-describe "CSV.readlines" do
-  it "needs to be reviewed for spec completeness"
-end
+ruby_version_is ""..."3.4" do
+  require 'csv'
 
-describe "CSV#readlines" do
-  it "returns an Array of Array containing each element in a one-line CSV file" do
-    file = CSV.new "a, b, c"
-    file.readlines.should == [["a", " b", " c"]]
+  describe "CSV.readlines" do
+    it "needs to be reviewed for spec completeness"
   end
 
-  it "returns an Array of Arrays containing each element in a multi-line CSV file" do
-    file = CSV.new "a, b, c\nd, e, f"
-    file.readlines.should == [["a", " b", " c"], ["d", " e", " f"]]
-  end
+  describe "CSV#readlines" do
+    it "returns an Array of Array containing each element in a one-line CSV file" do
+      file = CSV.new "a, b, c"
+      file.readlines.should == [["a", " b", " c"]]
+    end
 
-  it "returns nil for a missing value" do
-    file = CSV.new "a,, b, c"
-    file.readlines.should == [["a", nil, " b", " c"]]
-  end
+    it "returns an Array of Arrays containing each element in a multi-line CSV file" do
+      file = CSV.new "a, b, c\nd, e, f"
+      file.readlines.should == [["a", " b", " c"], ["d", " e", " f"]]
+    end
 
-  it "raises CSV::MalformedCSVError exception if input is illegal" do
-    csv = CSV.new('"quoted" field')
-    -> { csv.readlines }.should raise_error(CSV::MalformedCSVError)
-  end
+    it "returns nil for a missing value" do
+      file = CSV.new "a,, b, c"
+      file.readlines.should == [["a", nil, " b", " c"]]
+    end
 
-  it "handles illegal input with the liberal_parsing option" do
-    illegal_input = '"Johnson, Dwayne",Dwayne "The Rock" Johnson'
-    csv = CSV.new(illegal_input, liberal_parsing: true)
-    result = csv.readlines
-    result.should == [["Johnson, Dwayne", 'Dwayne "The Rock" Johnson']]
+    it "raises CSV::MalformedCSVError exception if input is illegal" do
+      csv = CSV.new('"quoted" field')
+      -> { csv.readlines }.should raise_error(CSV::MalformedCSVError)
+    end
+
+    it "handles illegal input with the liberal_parsing option" do
+      illegal_input = '"Johnson, Dwayne",Dwayne "The Rock" Johnson'
+      csv = CSV.new(illegal_input, liberal_parsing: true)
+      result = csv.readlines
+      result.should == [["Johnson, Dwayne", 'Dwayne "The Rock" Johnson']]
+    end
   end
 end

--- a/spec/ruby/library/csv/streambuf/add_buf_spec.rb
+++ b/spec/ruby/library/csv/streambuf/add_buf_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StreamBuf#add_buf" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StreamBuf#add_buf" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/streambuf/buf_size_spec.rb
+++ b/spec/ruby/library/csv/streambuf/buf_size_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StreamBuf#buf_size" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StreamBuf#buf_size" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/streambuf/drop_spec.rb
+++ b/spec/ruby/library/csv/streambuf/drop_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StreamBuf#drop" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StreamBuf#drop" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/streambuf/element_reference_spec.rb
+++ b/spec/ruby/library/csv/streambuf/element_reference_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StreamBuf#[]" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StreamBuf#[]" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/streambuf/get_spec.rb
+++ b/spec/ruby/library/csv/streambuf/get_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StreamBuf#get" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StreamBuf#get" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/streambuf/idx_is_eos_spec.rb
+++ b/spec/ruby/library/csv/streambuf/idx_is_eos_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StreamBuf#idx_is_eos?" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StreamBuf#idx_is_eos?" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/streambuf/initialize_spec.rb
+++ b/spec/ruby/library/csv/streambuf/initialize_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StreamBuf#initialize" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StreamBuf#initialize" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/streambuf/is_eos_spec.rb
+++ b/spec/ruby/library/csv/streambuf/is_eos_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StreamBuf#is_eos?" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StreamBuf#is_eos?" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/streambuf/read_spec.rb
+++ b/spec/ruby/library/csv/streambuf/read_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StreamBuf#read" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StreamBuf#read" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/streambuf/rel_buf_spec.rb
+++ b/spec/ruby/library/csv/streambuf/rel_buf_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StreamBuf#rel_buf" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StreamBuf#rel_buf" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/streambuf/terminate_spec.rb
+++ b/spec/ruby/library/csv/streambuf/terminate_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StreamBuf#terminate" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StreamBuf#terminate" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/stringreader/get_row_spec.rb
+++ b/spec/ruby/library/csv/stringreader/get_row_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StringReader#get_row" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StringReader#get_row" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/stringreader/initialize_spec.rb
+++ b/spec/ruby/library/csv/stringreader/initialize_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::StringReader#initialize" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::StringReader#initialize" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/writer/add_row_spec.rb
+++ b/spec/ruby/library/csv/writer/add_row_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::Writer#add_row" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::Writer#add_row" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/writer/append_spec.rb
+++ b/spec/ruby/library/csv/writer/append_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::Writer#<<" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::Writer#<<" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/writer/close_spec.rb
+++ b/spec/ruby/library/csv/writer/close_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::Writer#close" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::Writer#close" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/writer/create_spec.rb
+++ b/spec/ruby/library/csv/writer/create_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::Writer.create" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::Writer.create" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/writer/generate_spec.rb
+++ b/spec/ruby/library/csv/writer/generate_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::Writer.generate" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::Writer.generate" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/writer/initialize_spec.rb
+++ b/spec/ruby/library/csv/writer/initialize_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::Writer#initialize" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::Writer#initialize" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/csv/writer/terminate_spec.rb
+++ b/spec/ruby/library/csv/writer/terminate_spec.rb
@@ -1,6 +1,9 @@
 require_relative '../../../spec_helper'
-require 'csv'
 
-describe "CSV::Writer#terminate" do
-  it "needs to be reviewed for spec completeness"
+ruby_version_is ""..."3.4" do
+  require 'csv'
+
+  describe "CSV::Writer#terminate" do
+    it "needs to be reviewed for spec completeness"
+  end
 end

--- a/spec/ruby/library/getoptlong/each_option_spec.rb
+++ b/spec/ruby/library/getoptlong/each_option_spec.rb
@@ -1,7 +1,10 @@
 require_relative '../../spec_helper'
-require 'getoptlong'
-require_relative 'shared/each'
 
-describe "GetoptLong#each_option" do
-  it_behaves_like :getoptlong_each, :each_option
+ruby_version_is ""..."3.4" do
+  require 'getoptlong'
+  require_relative 'shared/each'
+
+  describe "GetoptLong#each_option" do
+    it_behaves_like :getoptlong_each, :each_option
+  end
 end

--- a/spec/ruby/library/getoptlong/each_spec.rb
+++ b/spec/ruby/library/getoptlong/each_spec.rb
@@ -1,7 +1,10 @@
 require_relative '../../spec_helper'
-require 'getoptlong'
-require_relative 'shared/each'
 
-describe "GetoptLong#each" do
-  it_behaves_like :getoptlong_each, :each
+ruby_version_is ""..."3.4" do
+  require 'getoptlong'
+  require_relative 'shared/each'
+
+  describe "GetoptLong#each" do
+    it_behaves_like :getoptlong_each, :each
+  end
 end

--- a/spec/ruby/library/getoptlong/error_message_spec.rb
+++ b/spec/ruby/library/getoptlong/error_message_spec.rb
@@ -1,23 +1,26 @@
 require_relative '../../spec_helper'
-require 'getoptlong'
 
-describe "GetoptLong#error_message" do
-  it "returns nil if no error occurred" do
-    opts = GetoptLong.new
-    opts.error_message.should == nil
-  end
+ruby_version_is ""..."3.4" do
+  require 'getoptlong'
 
-  it "returns the error message of the last error that occurred" do
-    argv [] do
+  describe "GetoptLong#error_message" do
+    it "returns nil if no error occurred" do
       opts = GetoptLong.new
-      opts.quiet = true
-      opts.get
-      -> {
-        opts.ordering = GetoptLong::PERMUTE
-      }.should raise_error(ArgumentError) { |e|
-        e.message.should == "argument error"
-        opts.error_message.should == "argument error"
-      }
+      opts.error_message.should == nil
+    end
+
+    it "returns the error message of the last error that occurred" do
+      argv [] do
+        opts = GetoptLong.new
+        opts.quiet = true
+        opts.get
+        -> {
+          opts.ordering = GetoptLong::PERMUTE
+        }.should raise_error(ArgumentError) { |e|
+          e.message.should == "argument error"
+          opts.error_message.should == "argument error"
+        }
+      end
     end
   end
 end

--- a/spec/ruby/library/getoptlong/get_option_spec.rb
+++ b/spec/ruby/library/getoptlong/get_option_spec.rb
@@ -1,7 +1,10 @@
 require_relative '../../spec_helper'
-require 'getoptlong'
-require_relative 'shared/get'
 
-describe "GetoptLong#get_option" do
-  it_behaves_like :getoptlong_get, :get_option
+ruby_version_is ""..."3.4" do
+  require 'getoptlong'
+  require_relative 'shared/get'
+
+  describe "GetoptLong#get_option" do
+    it_behaves_like :getoptlong_get, :get_option
+  end
 end

--- a/spec/ruby/library/getoptlong/get_spec.rb
+++ b/spec/ruby/library/getoptlong/get_spec.rb
@@ -1,7 +1,10 @@
 require_relative '../../spec_helper'
-require 'getoptlong'
-require_relative 'shared/get'
 
-describe "GetoptLong#get" do
-  it_behaves_like :getoptlong_get, :get
+ruby_version_is ""..."3.4" do
+  require 'getoptlong'
+  require_relative 'shared/get'
+
+  describe "GetoptLong#get" do
+    it_behaves_like :getoptlong_get, :get
+  end
 end

--- a/spec/ruby/library/getoptlong/initialize_spec.rb
+++ b/spec/ruby/library/getoptlong/initialize_spec.rb
@@ -1,28 +1,31 @@
 require_relative '../../spec_helper'
-require 'getoptlong'
 
-describe "GetoptLong#initialize" do
-  it "sets ordering to REQUIRE_ORDER if ENV['POSIXLY_CORRECT'] is set" do
-    begin
-      old_env_value = ENV["POSIXLY_CORRECT"]
-      ENV["POSIXLY_CORRECT"] = ""
+ruby_version_is ""..."3.4" do
+  require 'getoptlong'
 
-      opt = GetoptLong.new
-      opt.ordering.should == GetoptLong::REQUIRE_ORDER
-    ensure
-      ENV["POSIXLY_CORRECT"] = old_env_value
+  describe "GetoptLong#initialize" do
+    it "sets ordering to REQUIRE_ORDER if ENV['POSIXLY_CORRECT'] is set" do
+      begin
+        old_env_value = ENV["POSIXLY_CORRECT"]
+        ENV["POSIXLY_CORRECT"] = ""
+
+        opt = GetoptLong.new
+        opt.ordering.should == GetoptLong::REQUIRE_ORDER
+      ensure
+        ENV["POSIXLY_CORRECT"] = old_env_value
+      end
     end
-  end
 
-  it "sets ordering to PERMUTE if ENV['POSIXLY_CORRECT'] is not set" do
-    begin
-      old_env_value = ENV["POSIXLY_CORRECT"]
-      ENV["POSIXLY_CORRECT"] = nil
+    it "sets ordering to PERMUTE if ENV['POSIXLY_CORRECT'] is not set" do
+      begin
+        old_env_value = ENV["POSIXLY_CORRECT"]
+        ENV["POSIXLY_CORRECT"] = nil
 
-      opt = GetoptLong.new
-      opt.ordering.should == GetoptLong::PERMUTE
-    ensure
-      ENV["POSIXLY_CORRECT"] = old_env_value
+        opt = GetoptLong.new
+        opt.ordering.should == GetoptLong::PERMUTE
+      ensure
+        ENV["POSIXLY_CORRECT"] = old_env_value
+      end
     end
   end
 end

--- a/spec/ruby/library/getoptlong/ordering_spec.rb
+++ b/spec/ruby/library/getoptlong/ordering_spec.rb
@@ -1,38 +1,41 @@
 require_relative '../../spec_helper'
-require 'getoptlong'
 
-describe "GetoptLong#ordering=" do
-  it "raises an ArgumentError if called after processing has started" do
-    argv [ "--size", "10k", "--verbose" ] do
-      opts = GetoptLong.new([ '--size', GetoptLong::REQUIRED_ARGUMENT ],
-        [ '--verbose', GetoptLong::NO_ARGUMENT ])
-      opts.quiet = true
-      opts.get
+ruby_version_is ""..."3.4" do
+  require 'getoptlong'
+
+  describe "GetoptLong#ordering=" do
+    it "raises an ArgumentError if called after processing has started" do
+      argv [ "--size", "10k", "--verbose" ] do
+        opts = GetoptLong.new([ '--size', GetoptLong::REQUIRED_ARGUMENT ],
+          [ '--verbose', GetoptLong::NO_ARGUMENT ])
+        opts.quiet = true
+        opts.get
+
+        -> {
+          opts.ordering = GetoptLong::PERMUTE
+        }.should raise_error(ArgumentError)
+      end
+    end
+
+    it "raises an ArgumentError if given an invalid value" do
+      opts = GetoptLong.new
 
       -> {
-        opts.ordering = GetoptLong::PERMUTE
+        opts.ordering = 12345
       }.should raise_error(ArgumentError)
     end
-  end
 
-  it "raises an ArgumentError if given an invalid value" do
-    opts = GetoptLong.new
+    it "does not allow changing ordering to PERMUTE if ENV['POSIXLY_CORRECT'] is set" do
+      begin
+        old_env_value = ENV['POSIXLY_CORRECT']
+        ENV['POSIXLY_CORRECT'] = ""
 
-    -> {
-      opts.ordering = 12345
-    }.should raise_error(ArgumentError)
-  end
-
-  it "does not allow changing ordering to PERMUTE if ENV['POSIXLY_CORRECT'] is set" do
-    begin
-      old_env_value = ENV['POSIXLY_CORRECT']
-      ENV['POSIXLY_CORRECT'] = ""
-
-      opts = GetoptLong.new
-      opts.ordering = GetoptLong::PERMUTE
-      opts.ordering.should == GetoptLong::REQUIRE_ORDER
-    ensure
-      ENV['POSIXLY_CORRECT'] = old_env_value
+        opts = GetoptLong.new
+        opts.ordering = GetoptLong::PERMUTE
+        opts.ordering.should == GetoptLong::REQUIRE_ORDER
+      ensure
+        ENV['POSIXLY_CORRECT'] = old_env_value
+      end
     end
   end
 end

--- a/spec/ruby/library/getoptlong/set_options_spec.rb
+++ b/spec/ruby/library/getoptlong/set_options_spec.rb
@@ -1,98 +1,101 @@
 require_relative '../../spec_helper'
-require 'getoptlong'
 
-describe "GetoptLong#set_options" do
-  before :each do
-    @opts = GetoptLong.new
-  end
+ruby_version_is ""..."3.4" do
+  require 'getoptlong'
 
-  it "allows setting command line options" do
-    argv ["--size", "10k", "-v", "arg1", "arg2"] do
-      @opts.set_options(
-        ["--size", GetoptLong::REQUIRED_ARGUMENT],
-        ["--verbose", "-v", GetoptLong::NO_ARGUMENT]
-      )
-
-      @opts.get.should == ["--size", "10k"]
-      @opts.get.should == ["--verbose", ""]
-      @opts.get.should == nil
+  describe "GetoptLong#set_options" do
+    before :each do
+      @opts = GetoptLong.new
     end
-  end
 
-  it "discards previously defined command line options" do
-    argv ["--size", "10k", "-v", "arg1", "arg2"] do
-      @opts.set_options(
-        ["--size", GetoptLong::REQUIRED_ARGUMENT],
-        ["--verbose", "-v", GetoptLong::NO_ARGUMENT]
-      )
-
-      @opts.set_options(
-        ["-s", "--size", GetoptLong::REQUIRED_ARGUMENT],
-        ["-v", GetoptLong::NO_ARGUMENT]
-      )
-
-      @opts.get.should == ["-s", "10k"]
-      @opts.get.should == ["-v", ""]
-      @opts.get.should == nil
-    end
-  end
-
-  it "raises an ArgumentError if too many argument flags where given" do
-    argv [] do
-      -> {
-        @opts.set_options(["--size", GetoptLong::NO_ARGUMENT, GetoptLong::REQUIRED_ARGUMENT])
-      }.should raise_error(ArgumentError)
-    end
-  end
-
-  it "raises a RuntimeError if processing has already started" do
-    argv [] do
-      @opts.get
-      -> {
-        @opts.set_options()
-      }.should raise_error(RuntimeError)
-    end
-  end
-
-  it "raises an ArgumentError if no argument flag was given" do
-    argv [] do
-      -> {
-        @opts.set_options(["--size"])
-      }.should raise_error(ArgumentError)
-    end
-  end
-
-  it "raises an ArgumentError if one of the given arguments is not an Array" do
-    argv [] do
-      -> {
+    it "allows setting command line options" do
+      argv ["--size", "10k", "-v", "arg1", "arg2"] do
         @opts.set_options(
           ["--size", GetoptLong::REQUIRED_ARGUMENT],
-          "test")
-      }.should raise_error(ArgumentError)
+          ["--verbose", "-v", GetoptLong::NO_ARGUMENT]
+        )
+
+        @opts.get.should == ["--size", "10k"]
+        @opts.get.should == ["--verbose", ""]
+        @opts.get.should == nil
+      end
     end
-  end
 
-  it "raises an ArgumentError if the same option is given twice" do
-    argv [] do
-      -> {
+    it "discards previously defined command line options" do
+      argv ["--size", "10k", "-v", "arg1", "arg2"] do
         @opts.set_options(
-          ["--size", GetoptLong::NO_ARGUMENT],
-          ["--size", GetoptLong::OPTIONAL_ARGUMENT])
-      }.should raise_error(ArgumentError)
+          ["--size", GetoptLong::REQUIRED_ARGUMENT],
+          ["--verbose", "-v", GetoptLong::NO_ARGUMENT]
+        )
 
-      -> {
         @opts.set_options(
-          ["--size", GetoptLong::NO_ARGUMENT],
-          ["-s", "--size", GetoptLong::OPTIONAL_ARGUMENT])
-      }.should raise_error(ArgumentError)
+          ["-s", "--size", GetoptLong::REQUIRED_ARGUMENT],
+          ["-v", GetoptLong::NO_ARGUMENT]
+        )
+
+        @opts.get.should == ["-s", "10k"]
+        @opts.get.should == ["-v", ""]
+        @opts.get.should == nil
+      end
     end
-  end
 
-  it "raises an ArgumentError if the given option is invalid" do
-    argv [] do
-      -> {
-        @opts.set_options(["-size", GetoptLong::NO_ARGUMENT])
-      }.should raise_error(ArgumentError)
+    it "raises an ArgumentError if too many argument flags where given" do
+      argv [] do
+        -> {
+          @opts.set_options(["--size", GetoptLong::NO_ARGUMENT, GetoptLong::REQUIRED_ARGUMENT])
+        }.should raise_error(ArgumentError)
+      end
+    end
+
+    it "raises a RuntimeError if processing has already started" do
+      argv [] do
+        @opts.get
+        -> {
+          @opts.set_options()
+        }.should raise_error(RuntimeError)
+      end
+    end
+
+    it "raises an ArgumentError if no argument flag was given" do
+      argv [] do
+        -> {
+          @opts.set_options(["--size"])
+        }.should raise_error(ArgumentError)
+      end
+    end
+
+    it "raises an ArgumentError if one of the given arguments is not an Array" do
+      argv [] do
+        -> {
+          @opts.set_options(
+            ["--size", GetoptLong::REQUIRED_ARGUMENT],
+            "test")
+        }.should raise_error(ArgumentError)
+      end
+    end
+
+    it "raises an ArgumentError if the same option is given twice" do
+      argv [] do
+        -> {
+          @opts.set_options(
+            ["--size", GetoptLong::NO_ARGUMENT],
+            ["--size", GetoptLong::OPTIONAL_ARGUMENT])
+        }.should raise_error(ArgumentError)
+
+        -> {
+          @opts.set_options(
+            ["--size", GetoptLong::NO_ARGUMENT],
+            ["-s", "--size", GetoptLong::OPTIONAL_ARGUMENT])
+        }.should raise_error(ArgumentError)
+      end
+    end
+
+    it "raises an ArgumentError if the given option is invalid" do
+      argv [] do
+        -> {
+          @opts.set_options(["-size", GetoptLong::NO_ARGUMENT])
+        }.should raise_error(ArgumentError)
+      end
     end
   end
 end

--- a/spec/ruby/library/getoptlong/shared/each.rb
+++ b/spec/ruby/library/getoptlong/shared/each.rb
@@ -1,18 +1,20 @@
-describe :getoptlong_each, shared: true do
-  before :each do
-    @opts = GetoptLong.new(
-      [ '--size', '-s',             GetoptLong::REQUIRED_ARGUMENT ],
-      [ '--verbose', '-v',          GetoptLong::NO_ARGUMENT ],
-      [ '--query', '-q',            GetoptLong::NO_ARGUMENT ],
-      [ '--check', '--valid', '-c', GetoptLong::NO_ARGUMENT ]
-    )
-  end
+ruby_version_is ""..."3.4" do
+  describe :getoptlong_each, shared: true do
+    before :each do
+      @opts = GetoptLong.new(
+        [ '--size', '-s',             GetoptLong::REQUIRED_ARGUMENT ],
+        [ '--verbose', '-v',          GetoptLong::NO_ARGUMENT ],
+        [ '--query', '-q',            GetoptLong::NO_ARGUMENT ],
+        [ '--check', '--valid', '-c', GetoptLong::NO_ARGUMENT ]
+      )
+    end
 
-  it "passes each argument/value pair to the block" do
-    argv [ "--size", "10k", "-v", "-q", "a.txt", "b.txt" ] do
-      pairs = []
-      @opts.send(@method) { |arg, val| pairs << [ arg, val ] }
-      pairs.should == [ [ "--size", "10k" ], [ "--verbose", "" ], [ "--query", ""] ]
+    it "passes each argument/value pair to the block" do
+      argv [ "--size", "10k", "-v", "-q", "a.txt", "b.txt" ] do
+        pairs = []
+        @opts.send(@method) { |arg, val| pairs << [ arg, val ] }
+        pairs.should == [ [ "--size", "10k" ], [ "--verbose", "" ], [ "--query", ""] ]
+      end
     end
   end
 end

--- a/spec/ruby/library/getoptlong/shared/get.rb
+++ b/spec/ruby/library/getoptlong/shared/get.rb
@@ -1,62 +1,64 @@
-describe :getoptlong_get, shared: true do
-  before :each do
-    @opts = GetoptLong.new(
-      [ '--size', '-s',             GetoptLong::REQUIRED_ARGUMENT ],
-      [ '--verbose', '-v',          GetoptLong::NO_ARGUMENT ],
-      [ '--query', '-q',            GetoptLong::NO_ARGUMENT ],
-      [ '--check', '--valid', '-c', GetoptLong::NO_ARGUMENT ]
-    )
-    @opts.quiet = true # silence using $deferr
-  end
-
-  it "returns the next option name and its argument as an Array" do
-    argv [ "--size", "10k", "-v", "-q", "a.txt", "b.txt" ] do
-      @opts.send(@method).should == [ "--size", "10k" ]
-      @opts.send(@method).should == [ "--verbose", "" ]
-      @opts.send(@method).should == [ "--query", ""]
-      @opts.send(@method).should == nil
+ruby_version_is ""..."3.4" do
+  describe :getoptlong_get, shared: true do
+    before :each do
+      @opts = GetoptLong.new(
+        [ '--size', '-s',             GetoptLong::REQUIRED_ARGUMENT ],
+        [ '--verbose', '-v',          GetoptLong::NO_ARGUMENT ],
+        [ '--query', '-q',            GetoptLong::NO_ARGUMENT ],
+        [ '--check', '--valid', '-c', GetoptLong::NO_ARGUMENT ]
+      )
+      @opts.quiet = true # silence using $deferr
     end
-  end
 
-  it "shifts ARGV on each call" do
-    argv [ "--size", "10k", "-v", "-q", "a.txt", "b.txt" ] do
-      @opts.send(@method)
-      ARGV.should == [ "-v", "-q", "a.txt", "b.txt" ]
-
-      @opts.send(@method)
-      ARGV.should == [ "-q", "a.txt", "b.txt" ]
-
-      @opts.send(@method)
-      ARGV.should == [ "a.txt", "b.txt" ]
-
-      @opts.send(@method)
-      ARGV.should == [ "a.txt", "b.txt" ]
+    it "returns the next option name and its argument as an Array" do
+      argv [ "--size", "10k", "-v", "-q", "a.txt", "b.txt" ] do
+        @opts.send(@method).should == [ "--size", "10k" ]
+        @opts.send(@method).should == [ "--verbose", "" ]
+        @opts.send(@method).should == [ "--query", ""]
+        @opts.send(@method).should == nil
+      end
     end
-  end
 
-  it "terminates processing when encountering '--'" do
-    argv [ "--size", "10k", "--", "-v", "-q", "a.txt", "b.txt" ] do
-      @opts.send(@method)
-      ARGV.should == ["--", "-v", "-q", "a.txt", "b.txt"]
+    it "shifts ARGV on each call" do
+      argv [ "--size", "10k", "-v", "-q", "a.txt", "b.txt" ] do
+        @opts.send(@method)
+        ARGV.should == [ "-v", "-q", "a.txt", "b.txt" ]
 
-      @opts.send(@method)
-      ARGV.should ==  ["-v", "-q", "a.txt", "b.txt"]
+        @opts.send(@method)
+        ARGV.should == [ "-q", "a.txt", "b.txt" ]
 
-      @opts.send(@method)
-      ARGV.should ==  ["-v", "-q", "a.txt", "b.txt"]
+        @opts.send(@method)
+        ARGV.should == [ "a.txt", "b.txt" ]
+
+        @opts.send(@method)
+        ARGV.should == [ "a.txt", "b.txt" ]
+      end
     end
-  end
 
-  it "raises a if an argument was required, but none given" do
-    argv [ "--size" ] do
-      -> { @opts.send(@method) }.should raise_error(GetoptLong::MissingArgument)
+    it "terminates processing when encountering '--'" do
+      argv [ "--size", "10k", "--", "-v", "-q", "a.txt", "b.txt" ] do
+        @opts.send(@method)
+        ARGV.should == ["--", "-v", "-q", "a.txt", "b.txt"]
+
+        @opts.send(@method)
+        ARGV.should ==  ["-v", "-q", "a.txt", "b.txt"]
+
+        @opts.send(@method)
+        ARGV.should ==  ["-v", "-q", "a.txt", "b.txt"]
+      end
     end
-  end
 
-  # https://bugs.ruby-lang.org/issues/13858
-  it "returns multiline argument" do
-    argv [ "--size=\n10k\n" ] do
-      @opts.send(@method).should == [ "--size", "\n10k\n" ]
+    it "raises a if an argument was required, but none given" do
+      argv [ "--size" ] do
+        -> { @opts.send(@method) }.should raise_error(GetoptLong::MissingArgument)
+      end
+    end
+
+    # https://bugs.ruby-lang.org/issues/13858
+    it "returns multiline argument" do
+      argv [ "--size=\n10k\n" ] do
+        @opts.send(@method).should == [ "--size", "\n10k\n" ]
+      end
     end
   end
 end

--- a/spec/ruby/library/getoptlong/terminate_spec.rb
+++ b/spec/ruby/library/getoptlong/terminate_spec.rb
@@ -1,30 +1,33 @@
 require_relative '../../spec_helper'
-require 'getoptlong'
 
-describe "GetoptLong#terminate" do
-  before :each do
-    @opts = GetoptLong.new(
-      [ '--size', '-s',             GetoptLong::REQUIRED_ARGUMENT ],
-      [ '--verbose', '-v',          GetoptLong::NO_ARGUMENT ],
-      [ '--query', '-q',            GetoptLong::NO_ARGUMENT ],
-      [ '--check', '--valid', '-c', GetoptLong::NO_ARGUMENT ]
-    )
-  end
+ruby_version_is ""..."3.4" do
+  require 'getoptlong'
 
-  it "terminates option processing" do
-    argv [ "--size", "10k", "-v", "-q", "a.txt", "b.txt" ] do
-      @opts.get.should == [ "--size", "10k" ]
-      @opts.terminate
-      @opts.get.should == nil
+  describe "GetoptLong#terminate" do
+    before :each do
+      @opts = GetoptLong.new(
+        [ '--size', '-s',             GetoptLong::REQUIRED_ARGUMENT ],
+        [ '--verbose', '-v',          GetoptLong::NO_ARGUMENT ],
+        [ '--query', '-q',            GetoptLong::NO_ARGUMENT ],
+        [ '--check', '--valid', '-c', GetoptLong::NO_ARGUMENT ]
+      )
     end
-  end
 
-  it "returns self when option processing is terminated" do
-    @opts.terminate.should == @opts
-  end
+    it "terminates option processing" do
+      argv [ "--size", "10k", "-v", "-q", "a.txt", "b.txt" ] do
+        @opts.get.should == [ "--size", "10k" ]
+        @opts.terminate
+        @opts.get.should == nil
+      end
+    end
 
-  it "returns nil when option processing was already terminated" do
-    @opts.terminate
-    @opts.terminate.should == nil
+    it "returns self when option processing is terminated" do
+      @opts.terminate.should == @opts
+    end
+
+    it "returns nil when option processing was already terminated" do
+      @opts.terminate
+      @opts.terminate.should == nil
+    end
   end
 end

--- a/spec/ruby/library/getoptlong/terminated_spec.rb
+++ b/spec/ruby/library/getoptlong/terminated_spec.rb
@@ -1,17 +1,20 @@
 require_relative '../../spec_helper'
-require 'getoptlong'
 
-describe "GetoptLong#terminated?" do
-  it "returns true if option processing has terminated" do
-    argv [ "--size", "10k" ] do
-      opts = GetoptLong.new(["--size", GetoptLong::REQUIRED_ARGUMENT])
-      opts.should_not.terminated?
+ruby_version_is ""..."3.4" do
+  require 'getoptlong'
 
-      opts.get.should == ["--size", "10k"]
-      opts.should_not.terminated?
+  describe "GetoptLong#terminated?" do
+    it "returns true if option processing has terminated" do
+      argv [ "--size", "10k" ] do
+        opts = GetoptLong.new(["--size", GetoptLong::REQUIRED_ARGUMENT])
+        opts.should_not.terminated?
 
-      opts.get.should == nil
-      opts.should.terminated?
+        opts.get.should == ["--size", "10k"]
+        opts.should_not.terminated?
+
+        opts.get.should == nil
+        opts.should.terminated?
+      end
     end
   end
 end

--- a/spec/ruby/library/observer/add_observer_spec.rb
+++ b/spec/ruby/library/observer/add_observer_spec.rb
@@ -1,23 +1,26 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
 
-describe "Observer#add_observer" do
+ruby_version_is ""..."3.4" do
+  require_relative 'fixtures/classes'
 
-  before :each do
-    @observable = ObservableSpecs.new
-    @observer = ObserverCallbackSpecs.new
+  describe "Observer#add_observer" do
+
+    before :each do
+      @observable = ObservableSpecs.new
+      @observer = ObserverCallbackSpecs.new
+    end
+
+    it "adds the observer" do
+      @observer.value.should == nil
+      @observable.changed
+      @observable.notify_observers("test")
+      @observer.value.should == nil
+
+      @observable.add_observer(@observer)
+      @observable.changed
+      @observable.notify_observers("test2")
+      @observer.value.should == "test2"
+    end
+
   end
-
-  it "adds the observer" do
-    @observer.value.should == nil
-    @observable.changed
-    @observable.notify_observers("test")
-    @observer.value.should == nil
-
-    @observable.add_observer(@observer)
-    @observable.changed
-    @observable.notify_observers("test2")
-    @observer.value.should == "test2"
-  end
-
 end

--- a/spec/ruby/library/observer/count_observers_spec.rb
+++ b/spec/ruby/library/observer/count_observers_spec.rb
@@ -1,23 +1,26 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
 
-describe "Observer#count_observers" do
-  before :each do
-    @observable = ObservableSpecs.new
-    @observer   = ObserverCallbackSpecs.new
-    @observer2  = ObserverCallbackSpecs.new
-  end
+ruby_version_is ""..."3.4" do
+  require_relative 'fixtures/classes'
 
-  it "returns the number of observers" do
-    @observable.count_observers.should == 0
-    @observable.add_observer(@observer)
-    @observable.count_observers.should == 1
-    @observable.add_observer(@observer2)
-    @observable.count_observers.should == 2
-  end
+  describe "Observer#count_observers" do
+    before :each do
+      @observable = ObservableSpecs.new
+      @observer   = ObserverCallbackSpecs.new
+      @observer2  = ObserverCallbackSpecs.new
+    end
 
-  it "returns the number of unique observers" do
-    2.times { @observable.add_observer(@observer) }
-    @observable.count_observers.should == 1
+    it "returns the number of observers" do
+      @observable.count_observers.should == 0
+      @observable.add_observer(@observer)
+      @observable.count_observers.should == 1
+      @observable.add_observer(@observer2)
+      @observable.count_observers.should == 2
+    end
+
+    it "returns the number of unique observers" do
+      2.times { @observable.add_observer(@observer) }
+      @observable.count_observers.should == 1
+    end
   end
 end

--- a/spec/ruby/library/observer/delete_observer_spec.rb
+++ b/spec/ruby/library/observer/delete_observer_spec.rb
@@ -1,19 +1,22 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
 
-describe "Observer#delete_observer" do
-  before :each do
-    @observable = ObservableSpecs.new
-    @observer = ObserverCallbackSpecs.new
+ruby_version_is ""..."3.4" do
+  require_relative 'fixtures/classes'
+
+  describe "Observer#delete_observer" do
+    before :each do
+      @observable = ObservableSpecs.new
+      @observer = ObserverCallbackSpecs.new
+    end
+
+    it "deletes the observer" do
+      @observable.add_observer(@observer)
+      @observable.delete_observer(@observer)
+
+      @observable.changed
+      @observable.notify_observers("test")
+      @observer.value.should == nil
+    end
+
   end
-
-  it "deletes the observer" do
-    @observable.add_observer(@observer)
-    @observable.delete_observer(@observer)
-
-    @observable.changed
-    @observable.notify_observers("test")
-    @observer.value.should == nil
-  end
-
 end

--- a/spec/ruby/library/observer/delete_observers_spec.rb
+++ b/spec/ruby/library/observer/delete_observers_spec.rb
@@ -1,19 +1,22 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
 
-describe "Observer#delete_observers" do
-  before :each do
-    @observable = ObservableSpecs.new
-    @observer = ObserverCallbackSpecs.new
+ruby_version_is ""..."3.4" do
+  require_relative 'fixtures/classes'
+
+  describe "Observer#delete_observers" do
+    before :each do
+      @observable = ObservableSpecs.new
+      @observer = ObserverCallbackSpecs.new
+    end
+
+    it "deletes the observers" do
+      @observable.add_observer(@observer)
+      @observable.delete_observers
+
+      @observable.changed
+      @observable.notify_observers("test")
+      @observer.value.should == nil
+    end
+
   end
-
-  it "deletes the observers" do
-    @observable.add_observer(@observer)
-    @observable.delete_observers
-
-    @observable.changed
-    @observable.notify_observers("test")
-    @observer.value.should == nil
-  end
-
 end

--- a/spec/ruby/library/observer/fixtures/classes.rb
+++ b/spec/ruby/library/observer/fixtures/classes.rb
@@ -1,17 +1,19 @@
-require 'observer'
+ruby_version_is ""..."3.4" do
+  require 'observer'
 
-class ObserverCallbackSpecs
-  attr_reader :value
+  class ObserverCallbackSpecs
+    attr_reader :value
 
-  def initialize
-    @value = nil
+    def initialize
+      @value = nil
+    end
+
+    def update(value)
+      @value = value
+    end
   end
 
-  def update(value)
-    @value = value
+  class ObservableSpecs
+    include Observable
   end
-end
-
-class ObservableSpecs
-  include Observable
 end

--- a/spec/ruby/library/observer/notify_observers_spec.rb
+++ b/spec/ruby/library/observer/notify_observers_spec.rb
@@ -1,31 +1,34 @@
 require_relative '../../spec_helper'
-require_relative 'fixtures/classes'
 
-describe "Observer#notify_observers" do
+ruby_version_is ""..."3.4" do
+  require_relative 'fixtures/classes'
 
-  before :each do
-    @observable = ObservableSpecs.new
-    @observer = ObserverCallbackSpecs.new
-    @observable.add_observer(@observer)
+  describe "Observer#notify_observers" do
+
+    before :each do
+      @observable = ObservableSpecs.new
+      @observer = ObserverCallbackSpecs.new
+      @observable.add_observer(@observer)
+    end
+
+    it "must call changed before notifying observers" do
+      @observer.value.should == nil
+      @observable.notify_observers("test")
+      @observer.value.should == nil
+    end
+
+    it "verifies observer responds to update" do
+      -> {
+        @observable.add_observer(@observable)
+      }.should raise_error(NoMethodError)
+    end
+
+    it "receives the callback" do
+      @observer.value.should == nil
+      @observable.changed
+      @observable.notify_observers("test")
+      @observer.value.should == "test"
+    end
+
   end
-
-  it "must call changed before notifying observers" do
-    @observer.value.should == nil
-    @observable.notify_observers("test")
-    @observer.value.should == nil
-  end
-
-  it "verifies observer responds to update" do
-    -> {
-      @observable.add_observer(@observable)
-    }.should raise_error(NoMethodError)
-  end
-
-  it "receives the callback" do
-    @observer.value.should == nil
-    @observable.changed
-    @observable.notify_observers("test")
-    @observer.value.should == "test"
-  end
-
 end

--- a/spec/ruby/library/syslog/alert_spec.rb
+++ b/spec/ruby/library/syslog/alert_spec.rb
@@ -1,10 +1,13 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require_relative 'shared/log'
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.alert" do
-    it_behaves_like :syslog_log, :alert
+  platform_is_not :windows do
+    require_relative 'shared/log'
+    require 'syslog'
+
+    describe "Syslog.alert" do
+      it_behaves_like :syslog_log, :alert
+    end
   end
 end

--- a/spec/ruby/library/syslog/close_spec.rb
+++ b/spec/ruby/library/syslog/close_spec.rb
@@ -1,57 +1,60 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.close" do
-    platform_is_not :windows do
+  platform_is_not :windows do
+    require 'syslog'
 
-      before :each do
-        Syslog.opened?.should be_false
-      end
+    describe "Syslog.close" do
+      platform_is_not :windows do
 
-      after :each do
-        Syslog.opened?.should be_false
-      end
+        before :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "closes the log" do
-        Syslog.opened?.should be_false
-        Syslog.open
-        Syslog.opened?.should be_true
-        Syslog.close
-        Syslog.opened?.should be_false
-      end
+        after :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "raises a RuntimeError if the log's already closed" do
-        -> { Syslog.close }.should raise_error(RuntimeError)
-      end
+        it "closes the log" do
+          Syslog.opened?.should be_false
+          Syslog.open
+          Syslog.opened?.should be_true
+          Syslog.close
+          Syslog.opened?.should be_false
+        end
 
-      it "it does not work inside blocks" do
-        -> {
-          Syslog.open { |s| s.close }
-        }.should raise_error(RuntimeError)
-        Syslog.should_not.opened?
-      end
+        it "raises a RuntimeError if the log's already closed" do
+          -> { Syslog.close }.should raise_error(RuntimeError)
+        end
 
-      it "sets the identity to nil" do
-        Syslog.open("rubyspec")
-        Syslog.ident.should == "rubyspec"
-        Syslog.close
-        Syslog.ident.should be_nil
-      end
+        it "it does not work inside blocks" do
+          -> {
+            Syslog.open { |s| s.close }
+          }.should raise_error(RuntimeError)
+          Syslog.should_not.opened?
+        end
 
-      it "sets the options to nil" do
-        Syslog.open("rubyspec", Syslog::LOG_PID)
-        Syslog.options.should == Syslog::LOG_PID
-        Syslog.close
-        Syslog.options.should == nil
-      end
+        it "sets the identity to nil" do
+          Syslog.open("rubyspec")
+          Syslog.ident.should == "rubyspec"
+          Syslog.close
+          Syslog.ident.should be_nil
+        end
 
-      it "sets the facility to nil" do
-        Syslog.open
-        Syslog.facility.should == 8
-        Syslog.close
-        Syslog.facility.should == nil
+        it "sets the options to nil" do
+          Syslog.open("rubyspec", Syslog::LOG_PID)
+          Syslog.options.should == Syslog::LOG_PID
+          Syslog.close
+          Syslog.options.should == nil
+        end
+
+        it "sets the facility to nil" do
+          Syslog.open
+          Syslog.facility.should == 8
+          Syslog.close
+          Syslog.facility.should == nil
+        end
       end
     end
   end

--- a/spec/ruby/library/syslog/constants_spec.rb
+++ b/spec/ruby/library/syslog/constants_spec.rb
@@ -1,40 +1,43 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog::Constants" do
-    platform_is_not :windows, :solaris, :aix do
-      before :all do
-        @constants = %w(LOG_AUTHPRIV LOG_USER LOG_LOCAL2 LOG_NOTICE LOG_NDELAY
-                      LOG_SYSLOG LOG_ALERT LOG_FTP LOG_LOCAL5 LOG_ERR LOG_AUTH
-                      LOG_LOCAL1 LOG_ODELAY LOG_NEWS LOG_DAEMON LOG_LOCAL4
-                      LOG_CRIT LOG_INFO LOG_PERROR LOG_LOCAL0 LOG_CONS LOG_LPR
-                      LOG_LOCAL7 LOG_WARNING LOG_CRON LOG_LOCAL3 LOG_EMERG
-                      LOG_NOWAIT LOG_UUCP LOG_PID LOG_KERN LOG_MAIL LOG_LOCAL6
-                      LOG_DEBUG)
-      end
+  platform_is_not :windows do
+    require 'syslog'
 
-      it "includes the Syslog constants" do
-        @constants.each do |c|
-          Syslog::Constants.should have_constant(c)
+    describe "Syslog::Constants" do
+      platform_is_not :windows, :solaris, :aix do
+        before :all do
+          @constants = %w(LOG_AUTHPRIV LOG_USER LOG_LOCAL2 LOG_NOTICE LOG_NDELAY
+                        LOG_SYSLOG LOG_ALERT LOG_FTP LOG_LOCAL5 LOG_ERR LOG_AUTH
+                        LOG_LOCAL1 LOG_ODELAY LOG_NEWS LOG_DAEMON LOG_LOCAL4
+                        LOG_CRIT LOG_INFO LOG_PERROR LOG_LOCAL0 LOG_CONS LOG_LPR
+                        LOG_LOCAL7 LOG_WARNING LOG_CRON LOG_LOCAL3 LOG_EMERG
+                        LOG_NOWAIT LOG_UUCP LOG_PID LOG_KERN LOG_MAIL LOG_LOCAL6
+                        LOG_DEBUG)
+        end
+
+        it "includes the Syslog constants" do
+          @constants.each do |c|
+            Syslog::Constants.should have_constant(c)
+          end
         end
       end
-    end
 
-    # The masks are defined in <syslog.h>
+      # The masks are defined in <syslog.h>
 
-    describe "Syslog::Constants.LOG_MASK" do
-      it "returns the mask value for a priority" do
-        Syslog::Constants.LOG_MASK(Syslog::LOG_DEBUG).should == 128
-        Syslog::Constants.LOG_MASK(Syslog::LOG_WARNING).should == 16
+      describe "Syslog::Constants.LOG_MASK" do
+        it "returns the mask value for a priority" do
+          Syslog::Constants.LOG_MASK(Syslog::LOG_DEBUG).should == 128
+          Syslog::Constants.LOG_MASK(Syslog::LOG_WARNING).should == 16
+        end
       end
-    end
 
-    describe "Syslog::Constants.LOG_UPTO" do
-      it "returns a mask for the priorities up to a given argument" do
-        Syslog::Constants.LOG_UPTO(Syslog::LOG_ALERT).should == 3
-        Syslog::Constants.LOG_UPTO(Syslog::LOG_DEBUG).should == 255
+      describe "Syslog::Constants.LOG_UPTO" do
+        it "returns a mask for the priorities up to a given argument" do
+          Syslog::Constants.LOG_UPTO(Syslog::LOG_ALERT).should == 3
+          Syslog::Constants.LOG_UPTO(Syslog::LOG_DEBUG).should == 255
+        end
       end
     end
   end

--- a/spec/ruby/library/syslog/crit_spec.rb
+++ b/spec/ruby/library/syslog/crit_spec.rb
@@ -1,10 +1,13 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require_relative 'shared/log'
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.crit" do
-    it_behaves_like :syslog_log, :crit
+  platform_is_not :windows do
+    require_relative 'shared/log'
+    require 'syslog'
+
+    describe "Syslog.crit" do
+      it_behaves_like :syslog_log, :crit
+    end
   end
 end

--- a/spec/ruby/library/syslog/debug_spec.rb
+++ b/spec/ruby/library/syslog/debug_spec.rb
@@ -1,10 +1,13 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require_relative 'shared/log'
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.debug" do
-    it_behaves_like :syslog_log, :debug
+  platform_is_not :windows do
+    require_relative 'shared/log'
+    require 'syslog'
+
+    describe "Syslog.debug" do
+      it_behaves_like :syslog_log, :debug
+    end
   end
 end

--- a/spec/ruby/library/syslog/emerg_spec.rb
+++ b/spec/ruby/library/syslog/emerg_spec.rb
@@ -1,16 +1,19 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require_relative 'shared/log'
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.emerg" do
-    # Some way needs do be found to prevent this spec
-    # from causing output on all open terminals. If this
-    # is not possible, this spec may need a special guard
-    # that only runs when requested.
-    quarantine! do
-      it_behaves_like :syslog_log, :emerg
+  platform_is_not :windows do
+    require_relative 'shared/log'
+    require 'syslog'
+
+    describe "Syslog.emerg" do
+      # Some way needs do be found to prevent this spec
+      # from causing output on all open terminals. If this
+      # is not possible, this spec may need a special guard
+      # that only runs when requested.
+      quarantine! do
+        it_behaves_like :syslog_log, :emerg
+      end
     end
   end
 end

--- a/spec/ruby/library/syslog/err_spec.rb
+++ b/spec/ruby/library/syslog/err_spec.rb
@@ -1,10 +1,13 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require_relative 'shared/log'
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.err" do
-    it_behaves_like :syslog_log, :err
+  platform_is_not :windows do
+    require_relative 'shared/log'
+    require 'syslog'
+
+    describe "Syslog.err" do
+      it_behaves_like :syslog_log, :err
+    end
   end
 end

--- a/spec/ruby/library/syslog/facility_spec.rb
+++ b/spec/ruby/library/syslog/facility_spec.rb
@@ -1,47 +1,50 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.facility" do
-    platform_is_not :windows do
+  platform_is_not :windows do
+    require 'syslog'
 
-      before :each do
-        Syslog.opened?.should be_false
-      end
+    describe "Syslog.facility" do
+      platform_is_not :windows do
 
-      after :each do
-        Syslog.opened?.should be_false
-      end
+        before :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "returns the logging facility" do
-        Syslog.open("rubyspec", 3, Syslog::LOG_MAIL)
-        Syslog.facility.should == Syslog::LOG_MAIL
-        Syslog.close
-      end
+        after :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "returns nil if the log is closed" do
-        Syslog.opened?.should be_false
-        Syslog.facility.should == nil
-      end
+        it "returns the logging facility" do
+          Syslog.open("rubyspec", 3, Syslog::LOG_MAIL)
+          Syslog.facility.should == Syslog::LOG_MAIL
+          Syslog.close
+        end
 
-      it "defaults to LOG_USER" do
-        Syslog.open
-        Syslog.facility.should == Syslog::LOG_USER
-        Syslog.close
-      end
+        it "returns nil if the log is closed" do
+          Syslog.opened?.should be_false
+          Syslog.facility.should == nil
+        end
 
-      it "resets after each open call" do
-        Syslog.open
-        Syslog.facility.should == Syslog::LOG_USER
+        it "defaults to LOG_USER" do
+          Syslog.open
+          Syslog.facility.should == Syslog::LOG_USER
+          Syslog.close
+        end
 
-        Syslog.open!("rubyspec", 3, Syslog::LOG_MAIL)
-        Syslog.facility.should == Syslog::LOG_MAIL
-        Syslog.close
+        it "resets after each open call" do
+          Syslog.open
+          Syslog.facility.should == Syslog::LOG_USER
 
-        Syslog.open
-        Syslog.facility.should == Syslog::LOG_USER
-        Syslog.close
+          Syslog.open!("rubyspec", 3, Syslog::LOG_MAIL)
+          Syslog.facility.should == Syslog::LOG_MAIL
+          Syslog.close
+
+          Syslog.open
+          Syslog.facility.should == Syslog::LOG_USER
+          Syslog.close
+        end
       end
     end
   end

--- a/spec/ruby/library/syslog/ident_spec.rb
+++ b/spec/ruby/library/syslog/ident_spec.rb
@@ -1,34 +1,37 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.ident" do
-    platform_is_not :windows do
+  platform_is_not :windows do
+    require 'syslog'
 
-      before :each do
-        Syslog.opened?.should be_false
-      end
+    describe "Syslog.ident" do
+      platform_is_not :windows do
 
-      after :each do
-        Syslog.opened?.should be_false
-      end
+        before :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "returns the logging identity" do
-        Syslog.open("rubyspec")
-        Syslog.ident.should == "rubyspec"
-        Syslog.close
-      end
+        after :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "returns nil if the log is closed" do
-        Syslog.should_not.opened?
-        Syslog.ident.should == nil
-      end
+        it "returns the logging identity" do
+          Syslog.open("rubyspec")
+          Syslog.ident.should == "rubyspec"
+          Syslog.close
+        end
 
-      it "defaults to $0" do
-        Syslog.open
-        Syslog.ident.should == $0
-        Syslog.close
+        it "returns nil if the log is closed" do
+          Syslog.should_not.opened?
+          Syslog.ident.should == nil
+        end
+
+        it "defaults to $0" do
+          Syslog.open
+          Syslog.ident.should == $0
+          Syslog.close
+        end
       end
     end
   end

--- a/spec/ruby/library/syslog/info_spec.rb
+++ b/spec/ruby/library/syslog/info_spec.rb
@@ -1,10 +1,13 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require_relative 'shared/log'
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.info" do
-    it_behaves_like :syslog_log, :info
+  platform_is_not :windows do
+    require_relative 'shared/log'
+    require 'syslog'
+
+    describe "Syslog.info" do
+      it_behaves_like :syslog_log, :info
+    end
   end
 end

--- a/spec/ruby/library/syslog/inspect_spec.rb
+++ b/spec/ruby/library/syslog/inspect_spec.rb
@@ -1,38 +1,41 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.inspect" do
-    platform_is_not :windows do
+  platform_is_not :windows do
+    require 'syslog'
 
-      before :each do
-        Syslog.opened?.should be_false
-      end
+    describe "Syslog.inspect" do
+      platform_is_not :windows do
 
-      after :each do
-        Syslog.opened?.should be_false
-      end
+        before :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "returns a string a closed log" do
-        Syslog.inspect.should =~ /opened=false/
-      end
+        after :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "returns a string for an opened log" do
-        Syslog.open
-        Syslog.inspect.should =~ /opened=true.*/
-        Syslog.close
-      end
+        it "returns a string a closed log" do
+          Syslog.inspect.should =~ /opened=false/
+        end
 
-      it "includes the ident, options, facility and mask" do
-        Syslog.open("rubyspec", Syslog::LOG_PID, Syslog::LOG_USER)
-        inspect_str = Syslog.inspect.split ", "
-        inspect_str[0].should =~ /opened=true/
-        inspect_str[1].should == "ident=\"rubyspec\""
-        inspect_str[2].should == "options=#{Syslog::LOG_PID}"
-        inspect_str[3].should == "facility=#{Syslog::LOG_USER}"
-        inspect_str[4].should == "mask=255>"
-        Syslog.close
+        it "returns a string for an opened log" do
+          Syslog.open
+          Syslog.inspect.should =~ /opened=true.*/
+          Syslog.close
+        end
+
+        it "includes the ident, options, facility and mask" do
+          Syslog.open("rubyspec", Syslog::LOG_PID, Syslog::LOG_USER)
+          inspect_str = Syslog.inspect.split ", "
+          inspect_str[0].should =~ /opened=true/
+          inspect_str[1].should == "ident=\"rubyspec\""
+          inspect_str[2].should == "options=#{Syslog::LOG_PID}"
+          inspect_str[3].should == "facility=#{Syslog::LOG_USER}"
+          inspect_str[4].should == "mask=255>"
+          Syslog.close
+        end
       end
     end
   end

--- a/spec/ruby/library/syslog/instance_spec.rb
+++ b/spec/ruby/library/syslog/instance_spec.rb
@@ -1,12 +1,15 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.instance" do
-    platform_is_not :windows do
-      it "returns the module" do
-        Syslog.instance.should == Syslog
+  platform_is_not :windows do
+    require 'syslog'
+
+    describe "Syslog.instance" do
+      platform_is_not :windows do
+        it "returns the module" do
+          Syslog.instance.should == Syslog
+        end
       end
     end
   end

--- a/spec/ruby/library/syslog/log_spec.rb
+++ b/spec/ruby/library/syslog/log_spec.rb
@@ -1,55 +1,58 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.log" do
-    platform_is_not :windows, :darwin, :solaris, :aix, :android do
+  platform_is_not :windows do
+    require 'syslog'
 
-      before :each do
-        Syslog.opened?.should be_false
-      end
+    describe "Syslog.log" do
+      platform_is_not :windows, :darwin, :solaris, :aix, :android do
 
-      after :each do
-        Syslog.opened?.should be_false
-      end
-
-      it "receives a priority as first argument" do
-        -> {
-          Syslog.open("rubyspec", Syslog::LOG_PERROR) do |s|
-            s.log(Syslog::LOG_ALERT, "Hello")
-            s.log(Syslog::LOG_CRIT, "World")
-          end
-        }.should output_to_fd(/\Arubyspec(?::| \d+ - -) Hello\nrubyspec(?::| \d+ - -) World\n\z/, $stderr)
-      end
-
-      it "accepts undefined priorities" do
-        -> {
-          Syslog.open("rubyspec", Syslog::LOG_PERROR) do |s|
-            s.log(1337, "Hello")
-          end
-          # use a regex since it'll output unknown facility/priority messages
-        }.should output_to_fd(/rubyspec(?::| \d+ - -) Hello\n\z/, $stderr)
-      end
-
-      it "fails with TypeError on nil log messages" do
-        Syslog.open do |s|
-          -> { s.log(1, nil) }.should raise_error(TypeError)
+        before :each do
+          Syslog.opened?.should be_false
         end
-      end
 
-      it "fails if the log is closed" do
-        -> {
-          Syslog.log(Syslog::LOG_ALERT, "test")
-        }.should raise_error(RuntimeError)
-      end
+        after :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "accepts printf parameters" do
-        -> {
-          Syslog.open("rubyspec", Syslog::LOG_PERROR) do |s|
-            s.log(Syslog::LOG_ALERT, "%s x %d", "chunky bacon", 2)
+        it "receives a priority as first argument" do
+          -> {
+            Syslog.open("rubyspec", Syslog::LOG_PERROR) do |s|
+              s.log(Syslog::LOG_ALERT, "Hello")
+              s.log(Syslog::LOG_CRIT, "World")
+            end
+          }.should output_to_fd(/\Arubyspec(?::| \d+ - -) Hello\nrubyspec(?::| \d+ - -) World\n\z/, $stderr)
+        end
+
+        it "accepts undefined priorities" do
+          -> {
+            Syslog.open("rubyspec", Syslog::LOG_PERROR) do |s|
+              s.log(1337, "Hello")
+            end
+            # use a regex since it'll output unknown facility/priority messages
+          }.should output_to_fd(/rubyspec(?::| \d+ - -) Hello\n\z/, $stderr)
+        end
+
+        it "fails with TypeError on nil log messages" do
+          Syslog.open do |s|
+            -> { s.log(1, nil) }.should raise_error(TypeError)
           end
-        }.should output_to_fd(/rubyspec(?::| \d+ - -) chunky bacon x 2\n\z/, $stderr)
+        end
+
+        it "fails if the log is closed" do
+          -> {
+            Syslog.log(Syslog::LOG_ALERT, "test")
+          }.should raise_error(RuntimeError)
+        end
+
+        it "accepts printf parameters" do
+          -> {
+            Syslog.open("rubyspec", Syslog::LOG_PERROR) do |s|
+              s.log(Syslog::LOG_ALERT, "%s x %d", "chunky bacon", 2)
+            end
+          }.should output_to_fd(/rubyspec(?::| \d+ - -) chunky bacon x 2\n\z/, $stderr)
+        end
       end
     end
   end

--- a/spec/ruby/library/syslog/mask_spec.rb
+++ b/spec/ruby/library/syslog/mask_spec.rb
@@ -1,111 +1,114 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.mask" do
-    platform_is_not :windows do
+  platform_is_not :windows do
+    require 'syslog'
 
-      before :each do
-        Syslog.opened?.should be_false
-      end
+    describe "Syslog.mask" do
+      platform_is_not :windows do
 
-      after :each do
-        Syslog.opened?.should be_false
-        # make sure we return the mask to the default value
-        Syslog.open { |s| s.mask = 255 }
-      end
-
-      it "returns the log priority mask" do
-        Syslog.open("rubyspec") do
-          Syslog.mask.should == 255
-          Syslog.mask = 3
-          Syslog.mask.should == 3
-          Syslog.mask = 255
+        before :each do
+          Syslog.opened?.should be_false
         end
-      end
 
-      it "defaults to 255" do
-        Syslog.open do |s|
-          s.mask.should == 255
+        after :each do
+          Syslog.opened?.should be_false
+          # make sure we return the mask to the default value
+          Syslog.open { |s| s.mask = 255 }
         end
-      end
 
-      it "returns nil if the log is closed" do
-        Syslog.should_not.opened?
-        Syslog.mask.should == nil
-      end
-
-      platform_is :darwin do
-        it "resets if the log is reopened" do
-          Syslog.open
-          Syslog.mask.should == 255
-          Syslog.mask = 64
-
-          Syslog.reopen("rubyspec") do
+        it "returns the log priority mask" do
+          Syslog.open("rubyspec") do
             Syslog.mask.should == 255
-          end
-
-          Syslog.open do
-            Syslog.mask.should == 255
+            Syslog.mask = 3
+            Syslog.mask.should == 3
+            Syslog.mask = 255
           end
         end
-      end
 
-      platform_is_not :darwin do
-        it "persists if the log is reopened" do
-          Syslog.open
-          Syslog.mask.should == 255
-          Syslog.mask = 64
-
-          Syslog.reopen("rubyspec") do
-            Syslog.mask.should == 64
+        it "defaults to 255" do
+          Syslog.open do |s|
+            s.mask.should == 255
           end
+        end
 
-          Syslog.open do
-            Syslog.mask.should == 64
+        it "returns nil if the log is closed" do
+          Syslog.should_not.opened?
+          Syslog.mask.should == nil
+        end
+
+        platform_is :darwin do
+          it "resets if the log is reopened" do
+            Syslog.open
+            Syslog.mask.should == 255
+            Syslog.mask = 64
+
+            Syslog.reopen("rubyspec") do
+              Syslog.mask.should == 255
+            end
+
+            Syslog.open do
+              Syslog.mask.should == 255
+            end
+          end
+        end
+
+        platform_is_not :darwin do
+          it "persists if the log is reopened" do
+            Syslog.open
+            Syslog.mask.should == 255
+            Syslog.mask = 64
+
+            Syslog.reopen("rubyspec") do
+              Syslog.mask.should == 64
+            end
+
+            Syslog.open do
+              Syslog.mask.should == 64
+            end
           end
         end
       end
     end
-  end
 
-  describe "Syslog.mask=" do
-    platform_is_not :windows do
+    describe "Syslog.mask=" do
+      platform_is_not :windows do
 
-      before :each do
-        Syslog.opened?.should be_false
-      end
-
-      after :each do
-        Syslog.opened?.should be_false
-        # make sure we return the mask to the default value
-        Syslog.open { |s| s.mask = 255 }
-      end
-
-      it "sets the log priority mask" do
-        Syslog.open do
-          Syslog.mask = 64
-          Syslog.mask.should == 64
+        before :each do
+          Syslog.opened?.should be_false
         end
-      end
 
-      it "raises an error if the log is closed" do
-        -> { Syslog.mask = 1337 }.should raise_error(RuntimeError)
-      end
+        after :each do
+          Syslog.opened?.should be_false
+          # make sure we return the mask to the default value
+          Syslog.open { |s| s.mask = 255 }
+        end
 
-      it "only accepts numbers" do
-        Syslog.open do
+        it "sets the log priority mask" do
+          Syslog.open do
+            Syslog.mask = 64
+            Syslog.mask.should == 64
+          end
+        end
 
-          Syslog.mask = 1337
-          Syslog.mask.should == 1337
+        it "raises an error if the log is closed" do
+          -> { Syslog.mask = 1337 }.should raise_error(RuntimeError)
+        end
 
-          Syslog.mask = 3.1416
-          Syslog.mask.should == 3
+        it "only accepts numbers" do
+          Syslog.open do
 
-          -> { Syslog.mask = "oh hai" }.should raise_error(TypeError)
-          -> { Syslog.mask = "43" }.should raise_error(TypeError)
+            Syslog.mask = 1337
+            Syslog.mask.should == 1337
 
+            Syslog.mask = 3.1416
+            Syslog.mask.should == 3
+
+            -> { Syslog.mask = "oh hai" }.should raise_error(TypeError)
+            -> { Syslog.mask = "43" }.should raise_error(TypeError)
+
+          end
         end
       end
     end

--- a/spec/ruby/library/syslog/notice_spec.rb
+++ b/spec/ruby/library/syslog/notice_spec.rb
@@ -1,10 +1,13 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require_relative 'shared/log'
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.notice" do
-    it_behaves_like :syslog_log, :notice
+  platform_is_not :windows do
+    require_relative 'shared/log'
+    require 'syslog'
+
+    describe "Syslog.notice" do
+      it_behaves_like :syslog_log, :notice
+    end
   end
 end

--- a/spec/ruby/library/syslog/open_spec.rb
+++ b/spec/ruby/library/syslog/open_spec.rb
@@ -1,92 +1,95 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require_relative 'shared/reopen'
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.open" do
-    platform_is_not :windows do
+  platform_is_not :windows do
+    require_relative 'shared/reopen'
+    require 'syslog'
 
-      before :each do
-        Syslog.opened?.should be_false
-      end
+    describe "Syslog.open" do
+      platform_is_not :windows do
 
-      after :each do
-        Syslog.opened?.should be_false
-      end
+        before :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "returns the module" do
-        Syslog.open.should == Syslog
-        Syslog.close
-        Syslog.open("Test", 5, 9).should == Syslog
-        Syslog.close
-      end
+        after :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "receives an identity as first argument" do
-        Syslog.open("rubyspec")
-        Syslog.ident.should == "rubyspec"
-        Syslog.close
-      end
+        it "returns the module" do
+          Syslog.open.should == Syslog
+          Syslog.close
+          Syslog.open("Test", 5, 9).should == Syslog
+          Syslog.close
+        end
 
-      it "defaults the identity to $0" do
-        Syslog.open
-        Syslog.ident.should == $0
-        Syslog.close
-      end
+        it "receives an identity as first argument" do
+          Syslog.open("rubyspec")
+          Syslog.ident.should == "rubyspec"
+          Syslog.close
+        end
 
-      it "receives the logging options as second argument" do
-        Syslog.open("rubyspec", Syslog::LOG_PID)
-        Syslog.options.should == Syslog::LOG_PID
-        Syslog.close
-      end
+        it "defaults the identity to $0" do
+          Syslog.open
+          Syslog.ident.should == $0
+          Syslog.close
+        end
 
-      it "defaults the logging options to LOG_PID | LOG_CONS" do
-        Syslog.open
-        Syslog.options.should == Syslog::LOG_PID | Syslog::LOG_CONS
-        Syslog.close
-      end
+        it "receives the logging options as second argument" do
+          Syslog.open("rubyspec", Syslog::LOG_PID)
+          Syslog.options.should == Syslog::LOG_PID
+          Syslog.close
+        end
 
-      it "receives a facility as third argument" do
-        Syslog.open("rubyspec", Syslog::LOG_PID, 0)
-        Syslog.facility.should == 0
-        Syslog.close
-      end
+        it "defaults the logging options to LOG_PID | LOG_CONS" do
+          Syslog.open
+          Syslog.options.should == Syslog::LOG_PID | Syslog::LOG_CONS
+          Syslog.close
+        end
 
-      it "defaults the facility to LOG_USER" do
-        Syslog.open
-        Syslog.facility.should == Syslog::LOG_USER
-        Syslog.close
-      end
+        it "receives a facility as third argument" do
+          Syslog.open("rubyspec", Syslog::LOG_PID, 0)
+          Syslog.facility.should == 0
+          Syslog.close
+        end
 
-      it "receives a block and calls it with the module" do
-        Syslog.open("rubyspec", 3, 8) do |s|
-          s.should == Syslog
-          s.ident.should == "rubyspec"
-          s.options.should == 3
-          s.facility.should == Syslog::LOG_USER
+        it "defaults the facility to LOG_USER" do
+          Syslog.open
+          Syslog.facility.should == Syslog::LOG_USER
+          Syslog.close
+        end
+
+        it "receives a block and calls it with the module" do
+          Syslog.open("rubyspec", 3, 8) do |s|
+            s.should == Syslog
+            s.ident.should == "rubyspec"
+            s.options.should == 3
+            s.facility.should == Syslog::LOG_USER
+          end
+        end
+
+        it "closes the log if after it receives a block" do
+          Syslog.open{ }
+          Syslog.opened?.should be_false
+        end
+
+        it "raises an error if the log is opened" do
+          Syslog.open
+          -> {
+            Syslog.open
+          }.should raise_error(RuntimeError, /syslog already open/)
+          -> {
+            Syslog.close
+            Syslog.open
+          }.should_not raise_error
+          Syslog.close
         end
       end
-
-      it "closes the log if after it receives a block" do
-        Syslog.open{ }
-        Syslog.opened?.should be_false
-      end
-
-      it "raises an error if the log is opened" do
-        Syslog.open
-        -> {
-          Syslog.open
-        }.should raise_error(RuntimeError, /syslog already open/)
-        -> {
-          Syslog.close
-          Syslog.open
-        }.should_not raise_error
-        Syslog.close
-      end
     end
-  end
 
-  describe "Syslog.open!" do
-    it_behaves_like :syslog_reopen, :open!
+    describe "Syslog.open!" do
+      it_behaves_like :syslog_reopen, :open!
+    end
   end
 end

--- a/spec/ruby/library/syslog/opened_spec.rb
+++ b/spec/ruby/library/syslog/opened_spec.rb
@@ -1,38 +1,41 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.opened?" do
-    platform_is_not :windows do
+  platform_is_not :windows do
+    require 'syslog'
 
-      before :each do
-        Syslog.opened?.should be_false
-      end
+    describe "Syslog.opened?" do
+      platform_is_not :windows do
 
-      after :each do
-        Syslog.opened?.should be_false
-      end
-
-      it "returns true if the log is opened" do
-        Syslog.open
-        Syslog.opened?.should be_true
-        Syslog.close
-      end
-
-      it "returns false otherwise" do
-        Syslog.opened?.should be_false
-        Syslog.open
-        Syslog.close
-        Syslog.opened?.should be_false
-      end
-
-      it "works inside a block" do
-        Syslog.open do |s|
-          s.opened?.should be_true
-          Syslog.opened?.should be_true
+        before :each do
+          Syslog.opened?.should be_false
         end
-        Syslog.opened?.should be_false
+
+        after :each do
+          Syslog.opened?.should be_false
+        end
+
+        it "returns true if the log is opened" do
+          Syslog.open
+          Syslog.opened?.should be_true
+          Syslog.close
+        end
+
+        it "returns false otherwise" do
+          Syslog.opened?.should be_false
+          Syslog.open
+          Syslog.close
+          Syslog.opened?.should be_false
+        end
+
+        it "works inside a block" do
+          Syslog.open do |s|
+            s.opened?.should be_true
+            Syslog.opened?.should be_true
+          end
+          Syslog.opened?.should be_false
+        end
       end
     end
   end

--- a/spec/ruby/library/syslog/options_spec.rb
+++ b/spec/ruby/library/syslog/options_spec.rb
@@ -1,47 +1,50 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.options" do
-    platform_is_not :windows do
+  platform_is_not :windows do
+    require 'syslog'
 
-      before :each do
-        Syslog.opened?.should be_false
-      end
+    describe "Syslog.options" do
+      platform_is_not :windows do
 
-      after :each do
-        Syslog.opened?.should be_false
-      end
+        before :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "returns the logging options" do
-        Syslog.open("rubyspec", Syslog::LOG_PID)
-        Syslog.options.should == Syslog::LOG_PID
-        Syslog.close
-      end
+        after :each do
+          Syslog.opened?.should be_false
+        end
 
-      it "returns nil when the log is closed" do
-        Syslog.opened?.should be_false
-        Syslog.options.should == nil
-      end
+        it "returns the logging options" do
+          Syslog.open("rubyspec", Syslog::LOG_PID)
+          Syslog.options.should == Syslog::LOG_PID
+          Syslog.close
+        end
 
-      it "defaults to LOG_PID | LOG_CONS" do
-        Syslog.open
-        Syslog.options.should == Syslog::LOG_PID | Syslog::LOG_CONS
-        Syslog.close
-      end
+        it "returns nil when the log is closed" do
+          Syslog.opened?.should be_false
+          Syslog.options.should == nil
+        end
 
-      it "resets after each open call" do
-        Syslog.open
-        Syslog.options.should == Syslog::LOG_PID | Syslog::LOG_CONS
+        it "defaults to LOG_PID | LOG_CONS" do
+          Syslog.open
+          Syslog.options.should == Syslog::LOG_PID | Syslog::LOG_CONS
+          Syslog.close
+        end
 
-        Syslog.open!("rubyspec", Syslog::LOG_PID)
-        Syslog.options.should == Syslog::LOG_PID
-        Syslog.close
+        it "resets after each open call" do
+          Syslog.open
+          Syslog.options.should == Syslog::LOG_PID | Syslog::LOG_CONS
 
-        Syslog.open
-        Syslog.options.should == Syslog::LOG_PID | Syslog::LOG_CONS
-        Syslog.close
+          Syslog.open!("rubyspec", Syslog::LOG_PID)
+          Syslog.options.should == Syslog::LOG_PID
+          Syslog.close
+
+          Syslog.open
+          Syslog.options.should == Syslog::LOG_PID | Syslog::LOG_CONS
+          Syslog.close
+        end
       end
     end
   end

--- a/spec/ruby/library/syslog/reopen_spec.rb
+++ b/spec/ruby/library/syslog/reopen_spec.rb
@@ -1,10 +1,13 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require_relative 'shared/reopen'
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.reopen" do
-    it_behaves_like :syslog_reopen, :reopen
+  platform_is_not :windows do
+    require_relative 'shared/reopen'
+    require 'syslog'
+
+    describe "Syslog.reopen" do
+      it_behaves_like :syslog_reopen, :reopen
+    end
   end
 end

--- a/spec/ruby/library/syslog/shared/log.rb
+++ b/spec/ruby/library/syslog/shared/log.rb
@@ -1,39 +1,41 @@
-describe :syslog_log, shared: true do
-  platform_is_not :windows, :darwin, :solaris, :aix, :android do
-    before :each do
-      Syslog.opened?.should be_false
-    end
+ruby_version_is ""..."3.4" do
+  describe :syslog_log, shared: true do
+    platform_is_not :windows, :darwin, :solaris, :aix, :android do
+      before :each do
+        Syslog.opened?.should be_false
+      end
 
-    after :each do
-      Syslog.opened?.should be_false
-    end
+      after :each do
+        Syslog.opened?.should be_false
+      end
 
-    it "logs a message" do
-      -> {
-        Syslog.open("rubyspec", Syslog::LOG_PERROR) do
-          Syslog.send(@method, "Hello")
-        end
-      }.should output_to_fd(/\Arubyspec(?::| \d+ - -) Hello\n\z/, $stderr)
-    end
+      it "logs a message" do
+        -> {
+          Syslog.open("rubyspec", Syslog::LOG_PERROR) do
+            Syslog.send(@method, "Hello")
+          end
+        }.should output_to_fd(/\Arubyspec(?::| \d+ - -) Hello\n\z/, $stderr)
+      end
 
-    it "accepts sprintf arguments" do
-      -> {
-        Syslog.open("rubyspec", Syslog::LOG_PERROR) do
-          Syslog.send(@method, "Hello %s", "world")
-          Syslog.send(@method, "%d dogs", 2)
-        end
-      }.should output_to_fd(/\Arubyspec(?::| \d+ - -) Hello world\nrubyspec(?::| \d+ - -) 2 dogs\n\z/, $stderr)
-    end
+      it "accepts sprintf arguments" do
+        -> {
+          Syslog.open("rubyspec", Syslog::LOG_PERROR) do
+            Syslog.send(@method, "Hello %s", "world")
+            Syslog.send(@method, "%d dogs", 2)
+          end
+        }.should output_to_fd(/\Arubyspec(?::| \d+ - -) Hello world\nrubyspec(?::| \d+ - -) 2 dogs\n\z/, $stderr)
+      end
 
-    it "works as an alias for Syslog.log" do
-      level = Syslog.const_get "LOG_#{@method.to_s.upcase}"
-      -> {
-        Syslog.open("rubyspec", Syslog::LOG_PERROR) do
-          Syslog.send(@method, "Hello")
-          Syslog.log(level, "Hello")
-        end
-        # make sure the same thing is written to $stderr.
-      }.should output_to_fd(/\A(?:rubyspec(?::| \d+ - -) Hello\n){2}\z/, $stderr)
+      it "works as an alias for Syslog.log" do
+        level = Syslog.const_get "LOG_#{@method.to_s.upcase}"
+        -> {
+          Syslog.open("rubyspec", Syslog::LOG_PERROR) do
+            Syslog.send(@method, "Hello")
+            Syslog.log(level, "Hello")
+          end
+          # make sure the same thing is written to $stderr.
+        }.should output_to_fd(/\A(?:rubyspec(?::| \d+ - -) Hello\n){2}\z/, $stderr)
+      end
     end
   end
 end

--- a/spec/ruby/library/syslog/shared/reopen.rb
+++ b/spec/ruby/library/syslog/shared/reopen.rb
@@ -1,40 +1,42 @@
-describe :syslog_reopen, shared: true do
-  platform_is_not :windows do
-    before :each do
-      Syslog.opened?.should be_false
-    end
-
-    after :each do
-      Syslog.opened?.should be_false
-    end
-
-    it "reopens the log" do
-      Syslog.open
-      -> { Syslog.send(@method)}.should_not raise_error
-      Syslog.opened?.should be_true
-      Syslog.close
-    end
-
-    it "fails with RuntimeError if the log is closed" do
-      -> { Syslog.send(@method)}.should raise_error(RuntimeError)
-    end
-
-    it "receives the same parameters as Syslog.open" do
-      Syslog.open
-      Syslog.send(@method, "rubyspec", 3, 8) do |s|
-        s.should == Syslog
-        s.ident.should == "rubyspec"
-        s.options.should == 3
-        s.facility.should == Syslog::LOG_USER
-        s.opened?.should be_true
+ruby_version_is ""..."3.4" do
+  describe :syslog_reopen, shared: true do
+    platform_is_not :windows do
+      before :each do
+        Syslog.opened?.should be_false
       end
-      Syslog.opened?.should be_false
-    end
 
-    it "returns the module" do
-      Syslog.open
-      Syslog.send(@method).should == Syslog
-      Syslog.close
+      after :each do
+        Syslog.opened?.should be_false
+      end
+
+      it "reopens the log" do
+        Syslog.open
+        -> { Syslog.send(@method)}.should_not raise_error
+        Syslog.opened?.should be_true
+        Syslog.close
+      end
+
+      it "fails with RuntimeError if the log is closed" do
+        -> { Syslog.send(@method)}.should raise_error(RuntimeError)
+      end
+
+      it "receives the same parameters as Syslog.open" do
+        Syslog.open
+        Syslog.send(@method, "rubyspec", 3, 8) do |s|
+          s.should == Syslog
+          s.ident.should == "rubyspec"
+          s.options.should == 3
+          s.facility.should == Syslog::LOG_USER
+          s.opened?.should be_true
+        end
+        Syslog.opened?.should be_false
+      end
+
+      it "returns the module" do
+        Syslog.open
+        Syslog.send(@method).should == Syslog
+        Syslog.close
+      end
     end
   end
 end

--- a/spec/ruby/library/syslog/warning_spec.rb
+++ b/spec/ruby/library/syslog/warning_spec.rb
@@ -1,10 +1,13 @@
 require_relative '../../spec_helper'
 
-platform_is_not :windows do
-  require_relative 'shared/log'
-  require 'syslog'
+ruby_version_is ""..."3.4" do
 
-  describe "Syslog.warning" do
-    it_behaves_like :syslog_log, :warning
+  platform_is_not :windows do
+    require_relative 'shared/log'
+    require 'syslog'
+
+    describe "Syslog.warning" do
+      it_behaves_like :syslog_log, :warning
+    end
   end
 end


### PR DESCRIPTION
I added version guard to `ruby/spec` for Ruby 3.4 again.

https://github.com/ruby/spec/pull/1137 reverts all of commits and enable to run them again.

In background, maintaining bundled gems is out of scope ruby repository. We shouldn't keep their test code because they are not our responsibility. We only test them with `test-bundled-gems` for ruby Interpreter keep their support.

https://github.com/ruby/ruby/pull/6130 makes to load bundled gems on `test-spec`. But it's accidentally changes for `test-spec`.

Also see https://github.com/ruby/ruby/commit/5bf75c20a2098e626d0dd65708a35c46039c5310

