### PR TITLE
Spill fewer temps on iv writes

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2783,11 +2783,6 @@ fn gen_setinstancevariable(
             None => {
                 let (new_shape_id, needs_extension, ivar_index) = new_shape.unwrap();
                 if let Some((current_capacity, new_capacity)) = needs_extension {
-                    // We already spilled temps in the case the stack type is _not_ an immediate.
-                    // If it is an immediate, but we need to expand the object, then spill temps
-                    if stack_type.is_imm() {
-                        asm.spill_temps(); // for ccall
-                    }
                     // Generate the C call so that runtime code will increase
                     // the capacity and set the buffer.
                     asm_comment!(asm, "call rb_ensure_iv_list_size");

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2828,7 +2828,7 @@ fn gen_setinstancevariable(
         // If we know the stack value is an immediate, there's no need to
         // generate WB code.
         if !stack_type.is_imm() {
-            asm.spill_temps(); // for ccall
+            asm.spill_temps(); // for ccall (unconditionally spill them for RegTemps consistency)
             let skip_wb = asm.new_label("skip_wb");
             // If the value we're writing is an immediate, we don't need to WB
             asm.test(write_val, (RUBY_IMMEDIATE_MASK as u64).into());

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2750,7 +2750,6 @@ fn gen_setinstancevariable(
                 Opnd::const_ptr(ic as *const u8),
             ]
         );
-        asm.stack_pop(1); // Keep it on stack during ccall for GC
     } else {
         // Get the receiver
         let mut recv = asm.load(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_SELF));
@@ -2802,7 +2801,7 @@ fn gen_setinstancevariable(
                     recv = asm.load(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_SELF))
                 }
 
-                write_val = asm.stack_pop(1);
+                write_val = asm.stack_opnd(0);
                 gen_write_iv(asm, comptime_receiver, recv, ivar_index, write_val, needs_extension.is_some());
 
                 asm_comment!(asm, "write shape");
@@ -2820,7 +2819,7 @@ fn gen_setinstancevariable(
                 // the iv index by searching up the shape tree.  If we've
                 // made the transition already, then there's no reason to
                 // update the shape on the object.  Just set the IV.
-                write_val = asm.stack_pop(1);
+                write_val = asm.stack_opnd(0);
                 gen_write_iv(asm, comptime_receiver, recv, ivar_index, write_val, false);
             },
         }
@@ -2850,6 +2849,7 @@ fn gen_setinstancevariable(
             asm.write_label(skip_wb);
         }
     }
+    asm.stack_pop(1); // Keep it on stack during ccall for GC
 
     Some(KeepCompiling)
 }


### PR DESCRIPTION
Not all IV writes require calling a C function. If we don't need to execute a write barrier (IOW the written value is an immediate), and we don't need to expand the object to accommodate a new IV, we won't need to make a C call and we can avoid spilling temps.