### PR TITLE
Bump the required BASERUBY version to 3.0

### DIFF
--- a/.github/workflows/annocheck.yml
+++ b/.github/workflows/annocheck.yml
@@ -72,6 +72,11 @@ jobs:
           builddir: build
           makeup: true
 
+      - uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        with:
+          ruby-version: '3.0'
+          bundler: none
+
       # Minimal flags to pass the check.
       # -g0 disables backtraces when SEGV.  Do not set that.
       - name: Run configure

--- a/.github/workflows/baseruby.yml
+++ b/.github/workflows/baseruby.yml
@@ -43,7 +43,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - ruby-2.7
           - ruby-3.0
           - ruby-3.1
           - ruby-3.2

--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -53,6 +53,11 @@ jobs:
 
       - uses: ./.github/actions/setup/directories
 
+      - uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        with:
+          ruby-version: '3.0'
+          bundler: none
+
       - name: Run configure
         run: ./configure -C --disable-install-doc --disable-rubygems --with-gcc 'optflags=-O0' 'debugflags=-save-temps=obj -g'
 

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -49,7 +49,7 @@ jobs:
         include:
           # To mitigate flakiness of MinGW CI, we test only one runtime that newer MSYS2 uses.
           - msystem: 'UCRT64'
-            baseruby: '2.7'
+            baseruby: '3.0'
             test_task: 'check'
             test-all-opts: '--name=!/TestObjSpace#test_reachable_objects_during_iteration/'
       fail-fast: false

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -70,6 +70,11 @@ jobs:
           makeup: true
           dummy-files: ${{ matrix.test_task == 'check' }}
 
+      - uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        with:
+          ruby-version: '3.0'
+          bundler: none
+
       - name: Run configure
         env:
           arch: ${{ matrix.arch }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -98,6 +98,11 @@ jobs:
         run: |
           echo "WASI_SDK_PATH=/opt/wasi-sdk" >> $GITHUB_ENV
 
+      - uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        with:
+          ruby-version: '3.0'
+          bundler: none
+
       - name: Build baseruby
         run: |
           set -ex

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -91,7 +91,7 @@ jobs:
 
       - uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
         with:
-          ruby-version: '2.7'
+          ruby-version: '3.0'
           bundler: none
           windows-toolchain: none
 

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -141,6 +141,11 @@ jobs:
         if: ${{ matrix.rust_version }}
         run: rustup install ${{ matrix.rust_version }} --profile minimal
 
+      - uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        with:
+          ruby-version: '3.0'
+          bundler: none
+
       - name: Run configure
         run: ../src/configure -C --disable-install-doc --prefix=$(pwd)/install ${{ matrix.configure }}
 

--- a/configure.ac
+++ b/configure.ac
@@ -75,8 +75,8 @@ AC_ARG_WITH(baseruby,
 	[
 		AC_PATH_PROG([BASERUBY], [ruby], [false])
 	])
-# BASERUBY must be >= 2.7.0. Note that `"2.7.0" > "2.7"` is true.
-AS_IF([test "$HAVE_BASERUBY" != no -a "`RUBYOPT=- $BASERUBY --disable=gems -e 'print 42 if RUBY_VERSION > "2.7"' 2>/dev/null`" = 42], [
+# BASERUBY must be >= 3.0.0. Note that `"3.0.0" > "3.0"` is true.
+AS_IF([test "$HAVE_BASERUBY" != no -a "`RUBYOPT=- $BASERUBY --disable=gems -e 'print true if RUBY_VERSION > "3.0"' 2>/dev/null`" = true], [
     AS_CASE(["$build_os"], [mingw*], [
         # Can MSys shell run a command with a drive letter?
         RUBYOPT=- `cygpath -ma "$BASERUBY"` --disable=gems -e exit 2>/dev/null || HAVE_BASERUBY=no

--- a/rjit_c.rb
+++ b/rjit_c.rb
@@ -451,69 +451,22 @@ module RubyVM::RJIT # :nodoc: all
   C::VM_METHOD_TYPE_ZSUPER = Primitive.cexpr! %q{ SIZET2NUM(VM_METHOD_TYPE_ZSUPER) }
   C::VM_SPECIAL_OBJECT_VMCORE = Primitive.cexpr! %q{ SIZET2NUM(VM_SPECIAL_OBJECT_VMCORE) }
 
-  def C.block_type_iseq
-    Primitive.cexpr! %q{ SIZET2NUM(block_type_iseq) }
-  end
-
-  def C.idRespond_to_missing
-    Primitive.cexpr! %q{ SIZET2NUM(idRespond_to_missing) }
-  end
-
-  def C.imemo_callinfo
-    Primitive.cexpr! %q{ SIZET2NUM(imemo_callinfo) }
-  end
-
-  def C.imemo_iseq
-    Primitive.cexpr! %q{ SIZET2NUM(imemo_iseq) }
-  end
-
-  def C.rb_block_param_proxy
-    Primitive.cexpr! %q{ SIZET2NUM(rb_block_param_proxy) }
-  end
-
-  def C.rb_cArray
-    Primitive.cexpr! %q{ SIZET2NUM(rb_cArray) }
-  end
-
-  def C.rb_cFalseClass
-    Primitive.cexpr! %q{ SIZET2NUM(rb_cFalseClass) }
-  end
-
-  def C.rb_cFloat
-    Primitive.cexpr! %q{ SIZET2NUM(rb_cFloat) }
-  end
-
-  def C.rb_cInteger
-    Primitive.cexpr! %q{ SIZET2NUM(rb_cInteger) }
-  end
-
-  def C.rb_cNilClass
-    Primitive.cexpr! %q{ SIZET2NUM(rb_cNilClass) }
-  end
-
-  def C.rb_cString
-    Primitive.cexpr! %q{ SIZET2NUM(rb_cString) }
-  end
-
-  def C.rb_cSymbol
-    Primitive.cexpr! %q{ SIZET2NUM(rb_cSymbol) }
-  end
-
-  def C.rb_cTrueClass
-    Primitive.cexpr! %q{ SIZET2NUM(rb_cTrueClass) }
-  end
-
-  def C.rb_mRubyVMFrozenCore
-    Primitive.cexpr! %q{ SIZET2NUM(rb_mRubyVMFrozenCore) }
-  end
-
-  def C.rb_rjit_global_events
-    Primitive.cexpr! %q{ SIZET2NUM(rb_rjit_global_events) }
-  end
-
-  def C.rb_vm_insns_count
-    Primitive.cexpr! %q{ SIZET2NUM(rb_vm_insns_count) }
-  end
+  def C.block_type_iseq = Primitive.cexpr!(%q{ SIZET2NUM(block_type_iseq) })
+  def C.idRespond_to_missing = Primitive.cexpr!(%q{ SIZET2NUM(idRespond_to_missing) })
+  def C.imemo_callinfo = Primitive.cexpr!(%q{ SIZET2NUM(imemo_callinfo) })
+  def C.imemo_iseq = Primitive.cexpr!(%q{ SIZET2NUM(imemo_iseq) })
+  def C.rb_block_param_proxy = Primitive.cexpr!(%q{ SIZET2NUM(rb_block_param_proxy) })
+  def C.rb_cArray = Primitive.cexpr!(%q{ SIZET2NUM(rb_cArray) })
+  def C.rb_cFalseClass = Primitive.cexpr!(%q{ SIZET2NUM(rb_cFalseClass) })
+  def C.rb_cFloat = Primitive.cexpr!(%q{ SIZET2NUM(rb_cFloat) })
+  def C.rb_cInteger = Primitive.cexpr!(%q{ SIZET2NUM(rb_cInteger) })
+  def C.rb_cNilClass = Primitive.cexpr!(%q{ SIZET2NUM(rb_cNilClass) })
+  def C.rb_cString = Primitive.cexpr!(%q{ SIZET2NUM(rb_cString) })
+  def C.rb_cSymbol = Primitive.cexpr!(%q{ SIZET2NUM(rb_cSymbol) })
+  def C.rb_cTrueClass = Primitive.cexpr!(%q{ SIZET2NUM(rb_cTrueClass) })
+  def C.rb_mRubyVMFrozenCore = Primitive.cexpr!(%q{ SIZET2NUM(rb_mRubyVMFrozenCore) })
+  def C.rb_rjit_global_events = Primitive.cexpr!(%q{ SIZET2NUM(rb_rjit_global_events) })
+  def C.rb_vm_insns_count = Primitive.cexpr!(%q{ SIZET2NUM(rb_vm_insns_count) })
 
   def C.rb_ary_clear
     Primitive.cexpr! %q{ SIZET2NUM((size_t)rb_ary_clear) }

--- a/tool/rjit/bindgen.rb
+++ b/tool/rjit/bindgen.rb
@@ -141,12 +141,10 @@ class BindingGenerator
     # Define variables
     @values.each do |type, values|
       values.each do |value|
-        println "  def C.#{value}"
-        println "    Primitive.cexpr! %q{ #{type}2NUM(#{value}) }"
-        println "  end"
-        println
+        println "  def C.#{value} = Primitive.cexpr!(%q{ #{type}2NUM(#{value}) })"
       end
     end
+    println
 
     # Define function pointers
     @funcs.each do |func|


### PR DESCRIPTION
[[Misc #16671]](https://bugs.ruby-lang.org/issues/16671)

[Matz decided](https://bugs.ruby-lang.org/issues/16671#note-10) that the latest version of Debian should determine the required BASERUBY version. We also consider the latest stable Ubuntu release. 

* Debian 12 (bookworm): Ruby 3.1
* Ubuntu 22.04 (Jammy): Ruby 3.0

We've agreed to bump the BASERUBY version to Ruby 3.0 at [DevMeeting-2023-01-19](https://github.com/ruby/dev-meeting-log/blob/master/2023/DevMeeting-2023-01-19.md#misc-16671-baseruby-version-policy-hsbt). Also note that Ruby 2.7 is EOL.