### PR TITLE
No need to extract bundled gems before test-spec

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -983,7 +983,7 @@ $(RBCONFIG): $(tooldir)/mkconfig.rb config.status $(srcdir)/version.h $(srcdir)/
 test-rubyspec: test-spec
 yes-test-rubyspec: yes-test-spec
 
-yes-test-spec-precheck: yes-test-all-precheck yes-fake prepare-gems
+yes-test-spec-precheck: yes-test-all-precheck yes-fake
 
 test-spec: $(TEST_RUNNABLE)-test-spec
 yes-test-spec: yes-test-spec-precheck


### PR DESCRIPTION
* Since https://github.com/ruby/ruby/pull/9977