### PR TITLE
CI: Fix the no such file or directory error with the working directory.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -105,6 +105,7 @@ jobs:
     needs: [make]
     steps:
       - run: exit 1
+        working-directory:
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
 
 defaults:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -118,6 +118,7 @@ jobs:
     needs: [make]
     steps:
       - run: exit 1
+        working-directory:
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
 
 defaults:

--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -138,6 +138,7 @@ jobs:
     needs: [make]
     steps:
       - run: exit 1
+        working-directory:
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
 
 defaults:

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -189,6 +189,7 @@ jobs:
     needs: [make]
     steps:
       - run: exit 1
+        working-directory:
         if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
 
 defaults:


### PR DESCRIPTION
This PR is to fix the following error that I faced on my forked repository.

Fix the error with the working directory in the result job in some GitHub Actions YAML files. I hit this error on my forked repository below.

https://github.com/junaruga/ruby/actions/runs/7921897724/job/21628462038?pr=2#step:2:11
```
Error: An error occurred trying to start process '/bin/bash' with working directory '/Users/runner/work/ruby/ruby/build'. No such file or directory
```

By this PR, the `exit 1` fails as expected without the working directory error message.

https://github.com/junaruga/ruby/actions/runs/7923651044/job/21633890880?pr=2#step:2:11

```
Error: Process completed with exit code 1.
```
