### PR TITLE
Load default gems always with `test-bundled-gems`

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1563,7 +1563,7 @@ no-test-bundled-gems-prepare: no-test-bundled-gems-precheck
 yes-test-bundled-gems-prepare: yes-test-bundled-gems-precheck
 	$(ACTIONS_GROUP)
 	$(XRUBY) -C "$(srcdir)" bin/gem install --no-document \
-		--install-dir .bundle --conservative "hoe" "json-schema" "test-unit-rr" "ipaddr" "forwardable" "singleton" "ruby2_keywords"
+		--install-dir .bundle --conservative "hoe" "json-schema" "test-unit-rr"
 	$(ACTIONS_ENDGROUP)
 
 PREPARE_BUNDLED_GEMS = test-bundled-gems-prepare

--- a/spec/bundled_gems.mspec
+++ b/spec/bundled_gems.mspec
@@ -1,8 +1,6 @@
 load File.dirname(__FILE__) + '/default.mspec'
 
 class MSpecScript
-  gems = (get(:stdlibs).to_a & get(:bundled_gems).to_a).map{|gem| gem unless gem =~ /ftp/}.compact
-
-  set :library, gems
+  set :library, get(:stdlibs).to_a & get(:bundled_gems).to_a
   set :files, get(:library)
 end

--- a/tool/lib/bundled_gem.rb
+++ b/tool/lib/bundled_gem.rb
@@ -6,6 +6,15 @@ require 'rubygems/package'
 # unpack bundled gem files.
 
 module BundledGem
+  DEFAULT_GEMS_DEPENDENCIES = %w[
+    net-protocol # net-ftp
+    time # net-ftp
+    singleton # prime
+    ipaddr # rinda
+    forwardable # prime, rinda
+    ruby2_keywords # drb
+  ]
+
   module_function
 
   def unpack(file, *rest)
@@ -55,6 +64,9 @@ module BundledGem
     gem_dir = File.join(dir, "gems", target)
     yield gem_dir
     spec_dir = spec.extensions.empty? ? "specifications" : File.join("gems", target)
+    if spec.extensions.empty?
+      spec.dependencies.reject! {|dep| DEFAULT_GEMS_DEPENDENCIES.include?(dep.name)}
+    end
     File.binwrite(File.join(dir, spec_dir, "#{target}.gemspec"), spec.to_ruby)
     unless spec.extensions.empty?
       spec.dependencies.clear

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -1041,12 +1041,13 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
     next if /^\s*(?:#|$)/ =~ name
     next unless /^(\S+)\s+(\S+).*/ =~ name
     gem_name = "#$1-#$2"
-    # Try to find the gemspec file for C ext gems
-    # ex .bundle/gems/debug-1.7.1/debug-1.7.1.gemspec
-    # This gemspec keep the original dependencies
-    path = "#{srcdir}/.bundle/gems/#{gem_name}/#{gem_name}.gemspec"
+    # Try to find the gemspec file
+    path = "#{srcdir}/.bundle/gems/#{gem_name}/#{name}.gemspec"
     unless File.exist?(path)
-      path = "#{srcdir}/.bundle/specifications/#{gem_name}.gemspec"
+      # Try to find the gemspec file for C ext gems
+      # ex .bundle/gems/debug-1.7.1/debug-1.7.1.gemspec
+      # This gemspec keep the original dependencies
+      path = "#{srcdir}/.bundle/gems/#{gem_name}/#{gem_name}.gemspec"
       unless File.exist?(path)
          skipped[gem_name] = "gemspec not found"
          next

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -1040,17 +1040,22 @@ install?(:ext, :comm, :gem, :'bundled-gems') do
   File.foreach("#{srcdir}/gems/bundled_gems") do |name|
     next if /^\s*(?:#|$)/ =~ name
     next unless /^(\S+)\s+(\S+).*/ =~ name
+    gem = $1
     gem_name = "#$1-#$2"
-    # Try to find the gemspec file
-    path = "#{srcdir}/.bundle/gems/#{gem_name}/#{name}.gemspec"
+    # Try to find the original gemspec file
+    path = "#{srcdir}/.bundle/gems/#{gem_name}/#{gem}.gemspec"
     unless File.exist?(path)
       # Try to find the gemspec file for C ext gems
       # ex .bundle/gems/debug-1.7.1/debug-1.7.1.gemspec
       # This gemspec keep the original dependencies
       path = "#{srcdir}/.bundle/gems/#{gem_name}/#{gem_name}.gemspec"
       unless File.exist?(path)
-         skipped[gem_name] = "gemspec not found"
-         next
+          # Try to find the gemspec file for gems that hasn't own gemspec
+          path = "#{srcdir}/.bundle/specifications/#{gem_name}.gemspec"
+          unless File.exist?(path)
+            skipped[gem_name] = "gemspec not found"
+            next
+          end
       end
     end
     spec = load_gemspec(path, "#{srcdir}/.bundle/gems/#{gem_name}")


### PR DESCRIPTION
The current build system uses runtime dependencies from only `.bundle` directory.

We shouldn't install runtime dependencies from rubygems.org when `make test-bundled-gems` is invoked. Because we already have them as default gems. 