### PR TITLE
Change the way embedded strings move across ractors

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -762,6 +762,18 @@ assert_equal '[0, 1]', %q{
   end
 }
 
+# move embedded string
+assert_equal '12345678'*3, %q{
+  r = Ractor.new do
+    str_in = receive
+    str_in # copy it back to main ractor
+  end
+
+  str_out = "12345678"*3 # is embedded
+  r.send(str_out, move: true)
+  r.take
+}
+
 # move with yield
 assert_equal 'hello', %q{
   r = Ractor.new do

--- a/ractor.c
+++ b/ractor.c
@@ -3336,7 +3336,6 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
       case T_STRING:
         rb_str_make_independent(obj);
         break;
-
       case T_OBJECT:
         {
             if (rb_shape_obj_too_complex(obj)) {
@@ -3520,7 +3519,13 @@ move_enter(VALUE obj, struct obj_traverse_replace_data *data)
         return traverse_skip;
     }
     else {
-        VALUE moved = rb_obj_alloc(RBASIC_CLASS(obj));
+        VALUE moved;
+        if (RB_TYPE_P(obj, T_STRING) && STR_EMBED_P(obj)) {
+            moved = rb_str_dup(obj);
+        }
+        else {
+            moved = rb_obj_alloc(RBASIC_CLASS(obj));
+        }
         rb_shape_set_shape(moved, rb_shape_get_shape(obj));
         data->replacement = moved;
         return traverse_cont;
@@ -3538,9 +3543,13 @@ move_leave(VALUE obj, struct obj_traverse_replace_data *data)
 
     dst->flags = (dst->flags & ~fl_users) | (src->flags & fl_users);
 
-    dst->v1 = src->v1;
-    dst->v2 = src->v2;
-    dst->v3 = src->v3;
+    if (RB_TYPE_P(v, T_STRING) && STR_EMBED_P(v)) {
+    }
+    else {
+        dst->v1 = src->v1;
+        dst->v2 = src->v2;
+        dst->v3 = src->v3;
+    }
 
     if (UNLIKELY(FL_TEST_RAW(obj, FL_EXIVAR))) {
         rb_replace_generic_ivar(v, obj);


### PR DESCRIPTION
When an embedded string was moved across ractors previously, parts of the embedded string would not appear correctly after 16 bytes. Now the string object is duplicated with `rb_str_dup` instead of relying on `rb_obj_alloc` and setting the generic RVALUE fields.

[Bug #20271]