### PR TITLE
Test setup-ruby 3.1 on macos-arm-oss

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -63,6 +63,11 @@ jobs:
           makeup: true
           dummy-files: ${{ matrix.test_task == 'check' }}
 
+      - uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+        with:
+          ruby-version: '3.1'
+          bundler: none
+
       - name: Run configure
         run: ../src/configure -C --disable-install-doc ${{ matrix.configure }}
 


### PR DESCRIPTION
It's not supposed to have cached Ruby 3.1, so I want to see what happens there.