### PR TITLE
Fix ractor move of unshareable frozen objects

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -752,6 +752,17 @@ assert_equal '[0, 1]', %q{
   end
 }
 
+# unshareable frozen objects should still be frozen in new ractor after move
+assert_equal 'true', %q{
+r = Ractor.new do
+  obj = receive
+  { frozen: obj.frozen? }
+end
+obj = [Object.new].freeze
+r.send(obj, move: true)
+r.take[:frozen]
+}
+
 # move with yield
 assert_equal 'hello', %q{
   r = Ractor.new do

--- a/ractor.c
+++ b/ractor.c
@@ -3581,6 +3581,10 @@ move_leave(VALUE obj, struct obj_traverse_replace_data *data)
         rb_replace_generic_ivar(v, obj);
     }
 
+    if (OBJ_FROZEN(obj)) {
+        OBJ_FREEZE(v);
+    }
+
     // TODO: generic_ivar
 
     ractor_moved_bang(obj);


### PR DESCRIPTION
These objects didn't retain their frozen status after the move

Bug [#19408]