### PR TITLE
GC guard catch_table_ary

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1595,6 +1595,8 @@ iseq_insert_nop_between_end_and_cont(rb_iseq_t *iseq)
             }
         }
     }
+
+    RB_GC_GUARD(catch_table_ary);
 }
 
 static int


### PR DESCRIPTION
Using RARRAY_CONST_PTR can cause the array object to not exist on the stack, which could cause it to be GC'd or be moved by GC compaction. This can cause RARRAY_CONST_PTR to point to the incorrect location if the array is embedded and moved by GC compaction.

Fixes ruby/prism#2444.