### PR TITLE
Explicitly assert that redefined backquote method is called

### DIFF
--- a/bootstraptest/test_literal.rb
+++ b/bootstraptest/test_literal.rb
@@ -70,6 +70,7 @@ if /wasi/ !~ target_platform
   assert_equal "foo\n",           %q(`echo foo`)
   assert_equal "foo\n",           %q(s = "foo"; `echo #{s}`)
 end
+assert_equal "ECHO FOO",        %q(def `(s) s.upcase; end; `echo foo`)
 
 # regexp
 assert_equal '',                '//.source'

--- a/time.c
+++ b/time.c
@@ -2538,7 +2538,7 @@ parse_int(const char *ptr, const char *end, const char **endp, size_t *ndigits, 
 }
 
 static VALUE
-time_init_parse(rb_execution_context_t *ec, VALUE klass, VALUE str, VALUE zone, VALUE precision)
+time_init_parse(rb_execution_context_t *ec, VALUE time, VALUE str, VALUE zone, VALUE precision)
 {
     if (NIL_P(str = rb_check_string_type(str))) return Qnil;
     if (!rb_enc_str_asciicompat_p(str)) {
@@ -2660,7 +2660,7 @@ only_year:
         .sec  = (sec < 0)  ? 0 : sec,
         .subsecx = NIL_P(subsec) ? INT2FIX(0) : subsec,
     };
-    return time_init_vtm(klass, vtm, zone);
+    return time_init_vtm(time, vtm, zone);
 }
 
 static void

--- a/time.c
+++ b/time.c
@@ -1958,6 +1958,10 @@ rb_timespec_now(struct timespec *ts)
 #endif
 }
 
+/*
+ * Sets the current time information into _time_.
+ * Returns _time_.
+ */
 static VALUE
 time_init_now(rb_execution_context_t *ec, VALUE time, VALUE zone)
 {
@@ -2408,6 +2412,10 @@ vtm_day_wraparound(struct vtm *vtm)
 
 static VALUE time_init_vtm(VALUE time, struct vtm vtm, VALUE zone);
 
+/*
+ * Sets the broken-out time information into _time_.
+ * Returns _time_.
+ */
 static VALUE
 time_init_args(rb_execution_context_t *ec, VALUE time, VALUE year, VALUE mon, VALUE mday,
                VALUE hour, VALUE min, VALUE sec, VALUE zone)
@@ -2537,6 +2545,10 @@ parse_int(const char *ptr, const char *end, const char **endp, size_t *ndigits, 
     return rb_int_parse_cstr(ptr, len, (char **)endp, ndigits, 10, flags);
 }
 
+/*
+ * Parses _str_ and sets the broken-out time information into _time_.
+ * If _str_ is not a String, returns +nil+, otherwise returns _time_.
+ */
 static VALUE
 time_init_parse(rb_execution_context_t *ec, VALUE time, VALUE str, VALUE zone, VALUE precision)
 {


### PR DESCRIPTION
It has been used in some tests indirectly, but there was no direct test for redefinition in the toplevel.