### PR TITLE
[DOC] Doc for field processing

### DIFF
--- a/doc/.document
+++ b/doc/.document
@@ -9,3 +9,4 @@ rdoc
 regexp
 rjit
 yjit
+command_line

--- a/doc/command_line/field_processing.md
+++ b/doc/command_line/field_processing.md
@@ -7,17 +7,14 @@ the invoked Ruby program can process input line-by-line.
 
 ### About the Examples
 
-Examples here assume that this code (creating file `desiderata.txt`)
-has been executed:
+Examples here assume that file `desiderata.txt` exists:
 
 ```
-text = <<EOT
+$ cat desiderata.txt
 Go placidly amid the noise and the haste,
 and remember what peace there may be in silence.
 As far as possible, without surrender,
 be on good terms with all persons.
-EOT
-File.write('desiderata.txt', text)
 ```
 
 The examples also use command-line option `-e`,
@@ -77,7 +74,9 @@ $ ruby -an -e 'p $F' desiderata.txt
 ["be", "on", "good", "terms", "with", "all", "persons."]
 ```
 
-The default field separator used for the splitting is the input field separator `$;`.
+For the splitting,
+the default record separator is `$/`,
+and the default field separator  is `$;`.
 
 ### Option `-F`
 

--- a/doc/command_line/field_processing.md
+++ b/doc/command_line/field_processing.md
@@ -24,7 +24,7 @@ The examples also use command-line option `-e`,
 which passes the Ruby code to be executed on the command line itself:
 
 ```sh
-$ ruby -e "puts 'Hello, World.'"
+$ ruby -e 'puts "Hello, World."'
 ```
 
 ## Option `-n`
@@ -38,11 +38,10 @@ end
 ```
 
 Note that `gets` reads the next line and sets global variable `$_`
-to the last read line;
-note also that character `'$'` must be escaped as `'\$'`:
+to the last read line:
 
 ```sh
-$ ruby -n -e "puts \$_" desiderata.txt
+$ ruby -n -e 'puts $_' desiderata.txt
 Go placidly amid the noise and the haste,
 and remember what peace there may be in silence.
 As far as possible, without surrender,
@@ -54,7 +53,7 @@ be on good terms with all persons.
 Option `-p` is like option `-n`, but also prints each line:
 
 ```sh
-$ ruby -p -e "puts \$_.size" desiderata.txt
+$ ruby -p -e 'puts $_.size' desiderata.txt
 42
 Go placidly amid the noise and the haste,
 49
@@ -71,7 +70,7 @@ Option `-a`, when given with either of options `-n` or `-p`,
 splits the string at `$_` into an array of strings at `$F`:
 
 ```sh
-$ ruby -an -e "p \$F" desiderata.txt
+$ ruby -an -e 'p $F' desiderata.txt
 ["Go", "placidly", "amid", "the", "noise", "and", "the", "haste,"]
 ["and", "remember", "what", "peace", "there", "may", "be", "in", "silence."]
 ["As", "far", "as", "possible,", "without", "surrender,"]
@@ -86,12 +85,15 @@ Option `-F`, when given with option `-a`,
 specifies that its argument is to be the input field separator to be used for splitting:
 
 ```sh
-$ ruby -an -Fs -e "p \$F" desiderata.txt
+$ ruby -an -Fs -e 'p $F' desiderata.txt
 ["Go placidly amid the noi", "e and the ha", "te,\n"]
 ["and remember what peace there may be in ", "ilence.\n"]
 ["A", " far a", " po", "", "ible, without ", "urrender,\n"]
 ["be on good term", " with all per", "on", ".\n"]
 ```
+
+The argument may be a regular expression;
+see String#split.
 
 ## Option `-l`
 
@@ -106,7 +108,7 @@ modifies line-ending processing by:
 Without option `-l` (unchopped):
 
 ```sh
-$ ruby -n -e "p \$_" desiderata.txt
+$ ruby -n -e 'p $_' desiderata.txt
 "Go placidly amid the noise and the haste,\n"
 "and remember what peace there may be in silence.\n"
 "As far as possible, without surrender,\n"
@@ -116,7 +118,7 @@ $ ruby -n -e "p \$_" desiderata.txt
 With option `-l' (chopped):
 
 ```sh
-$ ruby -ln -e "p \$_" desiderata.txt
+$ ruby -ln -e 'p $_' desiderata.txt
 "Go placidly amid the noise and the haste,"
 "and remember what peace there may be in silence."
 "As far as possible, without surrender,"

--- a/doc/command_line/field_processing.md
+++ b/doc/command_line/field_processing.md
@@ -1,11 +1,11 @@
-# Field Processing
+## Field Processing
 
 Ruby supports <i>field processing</i>.
 
 This means that when certain command-line options are given,
 the invoked Ruby program can process input line-by-line.
 
-## About the Examples
+### About the Examples
 
 Examples here assume that this code (creating file `desiderata.txt`)
 has been executed:
@@ -27,7 +27,7 @@ which passes the Ruby code to be executed on the command line itself:
 $ ruby -e 'puts "Hello, World."'
 ```
 
-## Option `-n`
+### Option `-n`
 
 Option `-n` runs your program in a Kernel#gets loop:
 
@@ -48,7 +48,7 @@ As far as possible, without surrender,
 be on good terms with all persons.
 ```
 
-## Option `-p`
+### Option `-p`
 
 Option `-p` is like option `-n`, but also prints each line:
 
@@ -64,7 +64,7 @@ As far as possible, without surrender,
 be on good terms with all persons.
 ```
 
-## Option `-a`
+### Option `-a`
 
 Option `-a`, when given with either of options `-n` or `-p`,
 splits the string at `$_` into an array of strings at `$F`:
@@ -79,7 +79,7 @@ $ ruby -an -e 'p $F' desiderata.txt
 
 The default field separator used for the splitting is the input field separator `$;`.
 
-## Option `-F`
+### Option `-F`
 
 Option `-F`, when given with option `-a`,
 specifies that its argument is to be the input field separator to be used for splitting:
@@ -95,7 +95,7 @@ $ ruby -an -Fs -e 'p $F' desiderata.txt
 The argument may be a regular expression;
 see String#split.
 
-## Option `-l`
+### Option `-l`
 
 Option `-l`, when given with option `-n` or `-p`,
 modifies line-ending processing by:

--- a/doc/command_line/field_processing.md
+++ b/doc/command_line/field_processing.md
@@ -91,8 +91,15 @@ $ ruby -an -Fs -e 'p $F' desiderata.txt
 ["be on good term", " with all per", "on", ".\n"]
 ```
 
-The argument may be a regular expression;
-see String#split.
+The argument may be a regular expression:
+
+```
+$ ruby -an -F'[.,]\s*' -e 'p $F' desiderata.txt
+["Go placidly amid the noise and the haste"]
+["and remember what peace there may be in silence"]
+["As far as possible", "without surrender"]
+["be on good terms with all persons"]
+```
 
 ### Option `-l`
 

--- a/doc/command_line/field_processing.md
+++ b/doc/command_line/field_processing.md
@@ -1,0 +1,94 @@
+# Field Processing
+
+Ruby supports <i>field processing</i>.
+
+This means that when certain command-line options are given,
+the invoked Ruby program can process input line-by-line.
+
+## About the Examples
+
+Examples here assume that this code (creating file `desiderata.txt`)
+has been executed:
+
+```
+text = <<EOT
+Go placidly amid the noise and the haste,
+and remember what peace there may be in silence.
+As far as possible, without surrender,
+be on good terms with all persons.
+EOT
+File.write('desiderata.txt', text)
+```
+
+The examples also use command-line option `-e`,
+which passes the Ruby code to be executed on the command line itself:
+
+```sh
+$ ruby -e "puts 'Hello, World.'"
+```
+
+## Option `-n`
+
+Option `-n` runs your program in a Kernel#gets loop:
+
+```
+while gets
+  # Your Ruby code.
+end
+```
+
+Note that `gets` reads the next line and sets global variable `$_`
+to the last read line;
+note also that character `'$'` must be escaped as `'\$'`:
+
+```sh
+$ ruby -n -e "puts \$_" desiderata.txt
+Go placidly amid the noise and the haste,
+and remember what peace there may be in silence.
+As far as possible, without surrender,
+be on good terms with all persons.
+```
+
+## Option `-p`
+
+Option `-p` is like option `-n`, but also prints each line:
+
+```sh
+$ ruby -p -e "puts \$_.size" desiderata.txt
+42
+Go placidly amid the noise and the haste,
+49
+and remember what peace there may be in silence.
+39
+As far as possible, without surrender,
+35
+be on good terms with all persons.
+```
+
+## Option `-a`
+
+Option `-a`, when given with either of options `-n` or `-p`,
+splits the string at `$_` into an array of strings at `$F`:
+
+```sh
+$ ruby -an -e "p \$F" desiderata.txt
+["Go", "placidly", "amid", "the", "noise", "and", "the", "haste,"]
+["and", "remember", "what", "peace", "there", "may", "be", "in", "silence."]
+["As", "far", "as", "possible,", "without", "surrender,"]
+["be", "on", "good", "terms", "with", "all", "persons."]
+```
+
+The default field separator used for the splitting is the input field separator `$;`.
+
+## Option `-F`
+
+Option `-F`, when given with option `-a`,
+specifies that its argument is to be the input field separator to be used for splitting:
+
+```sh
+$ ruby -an -Fs -e "p \$F" desiderata.txt
+["Go placidly amid the noi", "e and the ha", "te,\n"]
+["and remember what peace there may be in ", "ilence.\n"]
+["A", " far a", " po", "", "ible, without ", "urrender,\n"]
+["be on good term", " with all per", "on", ".\n"]
+```

--- a/doc/command_line/field_processing.md
+++ b/doc/command_line/field_processing.md
@@ -92,3 +92,33 @@ $ ruby -an -Fs -e "p \$F" desiderata.txt
 ["A", " far a", " po", "", "ible, without ", "urrender,\n"]
 ["be on good term", " with all per", "on", ".\n"]
 ```
+
+## Option `-l`
+
+Option `-l`, when given with option `-n` or `-p`,
+modifies line-ending processing by:
+
+- Setting global variable output record separator `$\`
+  input record separator `$/`;
+  this affects line-oriented output (such a that from Kernel#puts).
+- Calling String#chop! on each line read.
+
+Without option `-l` (unchopped):
+
+```sh
+$ ruby -n -e "p \$_" desiderata.txt
+"Go placidly amid the noise and the haste,\n"
+"and remember what peace there may be in silence.\n"
+"As far as possible, without surrender,\n"
+"be on good terms with all persons.\n"
+```
+
+With option `-l' (chopped):
+
+```sh
+$ ruby -ln -e "p \$_" desiderata.txt
+"Go placidly amid the noise and the haste,"
+"and remember what peace there may be in silence."
+"As far as possible, without surrender,"
+"be on good terms with all persons."
+```


### PR DESCRIPTION
Documents command-line options `-n`, `-p`, `-a`, and `-F`, each affecting field processing.

I've put the new file into directory `doc/command_line/` (instead of `doc/`) because I'm planning more files documenting more CLI options.  These may eventually be gathered into an inclusive `doc/command_line_options.md`.