### PR TITLE
[DOC] rewrite inject doc

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -956,7 +956,7 @@ ary_inject_op(VALUE ary, VALUE init, VALUE op)
  *
  *  <b>Second Shortcut: a Reducer function</b>
  *
- *  A _reducer function_ is a function that takes a partial result and the next value,
+ *  A <i>reducer function</i> is a function that takes a partial result and the next value,
  *  returning the next partial result. The block that is given to +inject+ is a reducer.
  *
  *  You can also write a reducer as a function and pass the name of that function

--- a/enum.c
+++ b/enum.c
@@ -886,7 +886,7 @@ ary_inject_op(VALUE ary, VALUE init, VALUE op)
  *
  *  as being
  *
- *      fn(d, fn(c, fn(b, fn(i, a))))
+ *      fn(fn(fn(fn(i, a), b), c), d)
  *
  *  In a way the +inject+ function _injects_ the function
  *  between the elements of the enumerable.

--- a/enum.c
+++ b/enum.c
@@ -891,7 +891,7 @@ ary_inject_op(VALUE ary, VALUE init, VALUE op)
  *  In a way the +inject+ function _injects_ the function
  *  between the elements of the enumerable.
  *
- *  `inject` is aliased as `reduce`. You use it when you want to
+ *  +inject+ is aliased as +reduce+. You use it when you want to
  *  _reduce_ a collection to a single value.
  *
  *  <b>The Calling Sequences</b>

--- a/enum.c
+++ b/enum.c
@@ -952,7 +952,7 @@ ary_inject_op(VALUE ary, VALUE init, VALUE op)
  *               "com"=>15, ...
  *
  *  Note that the last line of the block is just the word +counts+. This ensures the
- *  return value of the block is the result taht's being calculated.
+ *  return value of the block is the result that's being calculated.
  *
  *  <b>Second Shortcut: a Reducer function</b>
  *


### PR DESCRIPTION
I was reading the RDoc for `Enumerable#inject` and I felt it needed some love.

It was just plain wrong in places. But it also (I think) missed the whole point of `inject`/`reduce`. The examples were almost all `[1,2,3].inject(:+)` style, which is only a trivial subset of the real-world power of `reduce`.

Feel free to ignore this, or to change anything you don't like. I feel better for having done it :)