### PR TITLE
Isolate architecture-dependent files in architecture-dependent locations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3555,7 +3555,7 @@ AS_CASE("$enable_shared", [yes], [
 	RUBY_APPEND_OPTIONS(LIBRUBY_DLDFLAGS, ['-Wl,-soname,$(LIBRUBY_SONAME)' "$LDFLAGS_OPTDIR"])
 	LIBRUBY_ALIASES='$(LIBRUBY_SONAME) lib$(RUBY_SO_NAME).$(SOEXT)'
 	AS_IF([test "$load_relative" = yes], [
-	    libprefix="'\$\${ORIGIN}/../${libdir_basename}'"
+	    libprefix="'\$\${ORIGIN}/../${multiarch+../../}${libdir_basename}'"
 	    LIBRUBY_RPATHFLAGS="-Wl,-rpath,${libprefix}"
 	    LIBRUBY_RELATIVE=yes
 	])
@@ -3567,7 +3567,7 @@ AS_CASE("$enable_shared", [yes], [
 	    LIBRUBY_SO="$LIBRUBY_SO.\$(TEENY)"
 	    LIBRUBY_ALIASES=''
 	], [test "$load_relative" = yes], [
-	    libprefix="'\$\$ORIGIN/../${libdir_basename}'"
+	    libprefix="'\$\$ORIGIN/../${multiarch+../../}${libdir_basename}'"
 	    LIBRUBY_RPATHFLAGS="-Wl,-rpath,${libprefix}"
 	    LIBRUBY_RELATIVE=yes
 	])
@@ -3591,7 +3591,7 @@ AS_CASE("$enable_shared", [yes], [
 	LIBRUBY_ALIASES='$(LIBRUBY_SONAME) lib$(RUBY_SO_NAME).$(SOEXT)'
 	RUBY_APPEND_OPTIONS(LIBRUBY_DLDFLAGS, ["${linker_flag}-h${linker_flag:+,}"'$(@F)'])
 	AS_IF([test "$load_relative" = yes], [
-	    libprefix="'\$\$ORIGIN/../${libdir_basename}'"
+	    libprefix="'\$\$ORIGIN/../${multiarch+../../}${libdir_basename}'"
 	    LIBRUBY_RPATHFLAGS="-R${libprefix}"
 	    LIBRUBY_RELATIVE=yes
 	], [
@@ -3608,7 +3608,7 @@ AS_CASE("$enable_shared", [yes], [
 	LIBRUBY_SONAME='$(LIBRUBY_SO)'
 	LIBRUBY_ALIASES='lib$(RUBY_INSTALL_NAME).$(SOEXT)'
 	AS_IF([test "$load_relative" = yes], [
-	    libprefix="@executable_path/../${libdir_basename}"
+	    libprefix="@executable_path/../${multiarch+../../}${libdir_basename}"
 	    LIBRUBY_RELATIVE=yes
 	])
 	LIBRUBY_DLDFLAGS="$LIBRUBY_DLDFLAGS -install_name ${libprefix}"'/$(LIBRUBY_SONAME)'

--- a/tool/lib/path.rb
+++ b/tool/lib/path.rb
@@ -1,0 +1,101 @@
+module Path
+  module_function
+
+  def clean(path)
+    path = "#{path}/".gsub(/(\A|\/)(?:\.\/)+/, '\1').tr_s('/', '/')
+    nil while path.sub!(/[^\/]+\/\.\.\//, '')
+    path
+  end
+
+  def relative(path, base)
+    path = clean(path)
+    base = clean(base)
+    path, base = [path, base].map{|s|s.split("/")}
+    until path.empty? or base.empty? or path[0] != base[0]
+      path.shift
+      base.shift
+    end
+    path, base = [path, base].map{|s|s.join("/")}
+    if base.empty?
+      path
+    elsif base.start_with?("../") or File.absolute_path?(base)
+      File.expand_path(path)
+    else
+      base.gsub!(/[^\/]+/, '..')
+      File.join(base, path)
+    end
+  end
+
+  def clean_link(src, dest)
+    begin
+      link = File.readlink(dest)
+    rescue
+    else
+      return if link == src
+      File.unlink(dest)
+    end
+    yield src, dest
+  end
+
+  # Extensions to FileUtils
+
+  module Mswin
+    def ln_safe(src, dest, *opt)
+      cmd = ["mklink", dest.tr("/", "\\"), src.tr("/", "\\")]
+      cmd[1, 0] = opt
+      return if system("cmd", "/c", *cmd)
+      # TODO: use RUNAS or something
+      puts cmd.join(" ")
+    end
+
+    def ln_dir_safe(src, dest)
+      ln_safe(src, dest, "/d")
+    end
+  end
+
+  module HardlinkExcutable
+    def ln_exe(src, dest)
+      ln(src, dest, force: true)
+    end
+  end
+
+  def ln_safe(src, dest)
+    ln_sf(src, dest)
+  rescue Errno::ENOENT
+    # Windows disallows to create broken symboic links, probably because
+    # it is a kind of reparse points.
+    raise if File.exist?(src)
+  end
+
+  alias ln_dir_safe ln_safe
+  alias ln_exe ln_safe
+
+  def ln_relative(src, dest, executable = false)
+    return if File.identical?(src, dest)
+    parent = File.dirname(dest)
+    File.directory?(parent) or mkdir_p(parent)
+    if executable
+      return (ln_exe(src, dest) if File.exist?(src))
+    end
+    clean_link(relative(src, parent), dest) {|s, d| ln_safe(s, d)}
+  end
+
+  def ln_dir_relative(src, dest)
+    return if File.identical?(src, dest)
+    parent = File.dirname(dest)
+    File.directory?(parent) or mkdir_p(parent)
+    clean_link(relative(src, parent), dest) {|s, d| ln_dir_safe(s, d)}
+  end
+
+  case (CROSS_COMPILING || RUBY_PLATFORM)
+  when /linux|darwin|solaris/
+    prepend HardlinkExcutable
+    extend HardlinkExcutable
+  when /mingw|mswin/
+    unless File.respond_to?(:symlink)
+      prepend Mswin
+      extend Mswin
+    end
+  else
+  end
+end

--- a/tool/mkrunnable.rb
+++ b/tool/mkrunnable.rb
@@ -34,18 +34,22 @@ vendordir = config["vendordir"]
 rubylibdir = config["rubylibdir"]
 rubyarchdir = config["rubyarchdir"]
 archdir = "#{extout}/#{arch}"
-[bindir, libdir, archdir].uniq.each do |dir|
+exedir = libdirname == "archlibdir" ? "#{config["libexecdir"]}/#{arch}/bin" : bindir
+[exedir, libdir, archdir].uniq.each do |dir|
   File.directory?(dir) or mkdir_p(dir)
+end
+unless exedir == bindir
+  ln_dir_relative(exedir, bindir)
 end
 
 exeext = config["EXEEXT"]
 ruby_install_name = config["ruby_install_name"]
 rubyw_install_name = config["rubyw_install_name"]
 goruby_install_name = "go" + ruby_install_name
-[ruby_install_name, rubyw_install_name, goruby_install_name].map do |ruby|
+[ruby_install_name, rubyw_install_name, goruby_install_name].each do |ruby|
   if ruby and !ruby.empty?
     ruby += exeext
-    ln_relative(ruby, "#{bindir}/#{ruby}", true)
+    ln_relative(ruby, "#{exedir}/#{ruby}", true)
   end
 end
 so = config["LIBRUBY_SO"]

--- a/tool/mkrunnable.rb
+++ b/tool/mkrunnable.rb
@@ -6,6 +6,7 @@
 
 require './rbconfig'
 require 'fileutils'
+require_relative 'lib/path'
 
 case ARGV[0]
 when "-n"
@@ -18,93 +19,7 @@ else
   include FileUtils
 end
 
-module Mswin
-  def ln_safe(src, dest, *opt)
-    cmd = ["mklink", dest.tr("/", "\\"), src.tr("/", "\\")]
-    cmd[1, 0] = opt
-    return if system("cmd", "/c", *cmd)
-    # TODO: use RUNAS or something
-    puts cmd.join(" ")
-  end
-
-  def ln_dir_safe(src, dest)
-    ln_safe(src, dest, "/d")
-  end
-end
-
-def clean_link(src, dest)
-  begin
-    link = File.readlink(dest)
-  rescue
-  else
-    return if link == src
-    File.unlink(dest)
-  end
-  yield src, dest
-end
-
-def ln_safe(src, dest)
-  ln_sf(src, dest)
-rescue Errno::ENOENT
-  # Windows disallows to create broken symboic links, probably because
-  # it is a kind of reparse points.
-  raise if File.exist?(src)
-end
-
-alias ln_dir_safe ln_safe
-
-case RUBY_PLATFORM
-when /linux|darwin|solaris/
-  def ln_exe(src, dest)
-    ln(src, dest, force: true)
-  end
-else
-  alias ln_exe ln_safe
-end
-
-if !File.respond_to?(:symlink) && /mingw|mswin/ =~ (CROSS_COMPILING || RUBY_PLATFORM)
-  extend Mswin
-end
-
-def clean_path(path)
-  path = "#{path}/".gsub(/(\A|\/)(?:\.\/)+/, '\1').tr_s('/', '/')
-  nil while path.sub!(/[^\/]+\/\.\.\//, '')
-  path
-end
-
-def relative_path_from(path, base)
-  path = clean_path(path)
-  base = clean_path(base)
-  path, base = [path, base].map{|s|s.split("/")}
-  until path.empty? or base.empty? or path[0] != base[0]
-    path.shift
-    base.shift
-  end
-  path, base = [path, base].map{|s|s.join("/")}
-  if /(\A|\/)\.\.\// =~ base
-    File.expand_path(path)
-  else
-    base.gsub!(/[^\/]+/, '..')
-    File.join(base, path)
-  end
-end
-
-def ln_relative(src, dest, executable = false)
-  return if File.identical?(src, dest)
-  parent = File.dirname(dest)
-  File.directory?(parent) or mkdir_p(parent)
-  if executable
-    return (ln_exe(src, dest) if File.exist?(src))
-  end
-  clean_link(relative_path_from(src, parent), dest) {|s, d| ln_safe(s, d)}
-end
-
-def ln_dir_relative(src, dest)
-  return if File.identical?(src, dest)
-  parent = File.dirname(dest)
-  File.directory?(parent) or mkdir_p(parent)
-  clean_link(relative_path_from(src, parent), dest) {|s, d| ln_dir_safe(s, d)}
-end
+include Path
 
 config = RbConfig::MAKEFILE_CONFIG.merge("prefix" => ".", "exec_prefix" => ".")
 config.each_value {|s| RbConfig.expand(s, config)}

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -448,6 +448,11 @@ install?(:local, :arch, :data) do
   if pc and File.file?(pc) and File.size?(pc)
     prepare "pkgconfig data", pkgconfigdir = File.join(libdir, "pkgconfig")
     install pc, pkgconfigdir, :mode => $data_mode
+    if (pkgconfig_base = CONFIG["libdir", true]) != libdir
+      prepare "pkgconfig data link", File.join(pkgconfig_base, "pkgconfig")
+      ln_sf(File.join("..", Path.relative(pkgconfigdir, pkgconfig_base), pc),
+            File.join(pkgconfig_base, "pkgconfig", pc))
+    end
   end
 end
 


### PR DESCRIPTION
Only when `--enable-multiarch` option is given.