### PR TITLE
[Bug #20277] Remove stale `String` test conditionals

### DIFF
--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -9,9 +9,6 @@ class TestString < Test::Unit::TestCase
 
   def initialize(*args)
     @cls = String
-    @aref_re_nth = true
-    @aref_re_silent = false
-    @aref_slicebang_silent = true
     super
   end
 
@@ -146,14 +143,12 @@ CODE
     assert_equal(nil,      S("FooBar")[S("xyzzy")])
     assert_equal(nil,      S("FooBar")[S("plugh")])
 
-    if @aref_re_nth
-      assert_equal(S("Foo"), S("FooBar")[/([A-Z]..)([A-Z]..)/, 1])
-      assert_equal(S("Bar"), S("FooBar")[/([A-Z]..)([A-Z]..)/, 2])
-      assert_equal(nil,      S("FooBar")[/([A-Z]..)([A-Z]..)/, 3])
-      assert_equal(S("Bar"), S("FooBar")[/([A-Z]..)([A-Z]..)/, -1])
-      assert_equal(S("Foo"), S("FooBar")[/([A-Z]..)([A-Z]..)/, -2])
-      assert_equal(nil,      S("FooBar")[/([A-Z]..)([A-Z]..)/, -3])
-    end
+    assert_equal(S("Foo"), S("FooBar")[/([A-Z]..)([A-Z]..)/, 1])
+    assert_equal(S("Bar"), S("FooBar")[/([A-Z]..)([A-Z]..)/, 2])
+    assert_equal(nil,      S("FooBar")[/([A-Z]..)([A-Z]..)/, 3])
+    assert_equal(S("Bar"), S("FooBar")[/([A-Z]..)([A-Z]..)/, -1])
+    assert_equal(S("Foo"), S("FooBar")[/([A-Z]..)([A-Z]..)/, -2])
+    assert_equal(nil,      S("FooBar")[/([A-Z]..)([A-Z]..)/, -3])
 
     o = Object.new
     def o.to_int; 2; end
@@ -199,24 +194,17 @@ CODE
     assert_equal(S("BarBar"), s)
     s[/..r$/] = S("Foo")
     assert_equal(S("BarFoo"), s)
-    if @aref_re_silent
-      s[/xyzzy/] = S("None")
-      assert_equal(S("BarFoo"), s)
-    else
-      assert_raise(IndexError) { s[/xyzzy/] = S("None") }
-    end
-    if @aref_re_nth
-      s[/([A-Z]..)([A-Z]..)/, 1] = S("Foo")
-      assert_equal(S("FooFoo"), s)
-      s[/([A-Z]..)([A-Z]..)/, 2] = S("Bar")
-      assert_equal(S("FooBar"), s)
-      assert_raise(IndexError) { s[/([A-Z]..)([A-Z]..)/, 3] = "None" }
-      s[/([A-Z]..)([A-Z]..)/, -1] = S("Foo")
-      assert_equal(S("FooFoo"), s)
-      s[/([A-Z]..)([A-Z]..)/, -2] = S("Bar")
-      assert_equal(S("BarFoo"), s)
-      assert_raise(IndexError) { s[/([A-Z]..)([A-Z]..)/, -3] = "None" }
-    end
+    assert_raise(IndexError) { s[/xyzzy/] = S("None") }
+    s[/([A-Z]..)([A-Z]..)/, 1] = S("Foo")
+    assert_equal(S("FooFoo"), s)
+    s[/([A-Z]..)([A-Z]..)/, 2] = S("Bar")
+    assert_equal(S("FooBar"), s)
+    assert_raise(IndexError) { s[/([A-Z]..)([A-Z]..)/, 3] = "None" }
+    s[/([A-Z]..)([A-Z]..)/, -1] = S("Foo")
+    assert_equal(S("FooFoo"), s)
+    s[/([A-Z]..)([A-Z]..)/, -2] = S("Bar")
+    assert_equal(S("BarFoo"), s)
+    assert_raise(IndexError) { s[/([A-Z]..)([A-Z]..)/, -3] = "None" }
 
     s = S("FooBar")
     s[S("Foo")] = S("Bar")
@@ -1728,20 +1716,11 @@ CODE
     assert_equal(S("FooBa"), a)
 
     a = S("FooBar")
-    if @aref_slicebang_silent
-      assert_nil( a.slice!(6) )
-      assert_nil( a.slice!(6r) )
-    else
-      assert_raise(IndexError) { a.slice!(6) }
-      assert_raise(IndexError) { a.slice!(6r) }
-    end
+    assert_nil(a.slice!(6))
+    assert_nil(a.slice!(6r))
     assert_equal(S("FooBar"), a)
 
-    if @aref_slicebang_silent
-      assert_nil( a.slice!(-7) )
-    else
-      assert_raise(IndexError) { a.slice!(-7) }
-    end
+    assert_nil(a.slice!(-7))
     assert_equal(S("FooBar"), a)
 
     a = S("FooBar")
@@ -1753,17 +1732,9 @@ CODE
     assert_equal(S("Foo"), a)
 
     a=S("FooBar")
-    if @aref_slicebang_silent
     assert_nil(a.slice!(7,2))      # Maybe should be six?
-    else
-    assert_raise(IndexError) {a.slice!(7,2)}     # Maybe should be six?
-    end
     assert_equal(S("FooBar"), a)
-    if @aref_slicebang_silent
     assert_nil(a.slice!(-7,10))
-    else
-    assert_raise(IndexError) {a.slice!(-7,10)}
-    end
     assert_equal(S("FooBar"), a)
 
     a=S("FooBar")
@@ -1775,17 +1746,9 @@ CODE
     assert_equal(S("Foo"), a)
 
     a=S("FooBar")
-    if @aref_slicebang_silent
     assert_equal(S(""), a.slice!(6..2))
-    else
-    assert_raise(RangeError) {a.slice!(6..2)}
-    end
     assert_equal(S("FooBar"), a)
-    if @aref_slicebang_silent
     assert_nil(a.slice!(-10..-7))
-    else
-    assert_raise(RangeError) {a.slice!(-10..-7)}
-    end
     assert_equal(S("FooBar"), a)
 
     a=S("FooBar")
@@ -1797,17 +1760,9 @@ CODE
     assert_equal(S("Foo"), a)
 
     a=S("FooBar")
-    if @aref_slicebang_silent
-      assert_nil(a.slice!(/xyzzy/))
-    else
-      assert_raise(IndexError) {a.slice!(/xyzzy/)}
-    end
+    assert_nil(a.slice!(/xyzzy/))
     assert_equal(S("FooBar"), a)
-    if @aref_slicebang_silent
-      assert_nil(a.slice!(/plugh/))
-    else
-      assert_raise(IndexError) {a.slice!(/plugh/)}
-    end
+    assert_nil(a.slice!(/plugh/))
     assert_equal(S("FooBar"), a)
 
     a=S("FooBar")


### PR DESCRIPTION
These instance variables for conditional execution have remained unchanged for nearly twenty years, since YARV merger. It is questionable whether these behaviors can be changed anymore.

https://bugs.ruby-lang.org/issues/20277