### PR TITLE
Disable callcc when ASAN is enabled

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -1775,6 +1775,13 @@ rb_callcc(VALUE self)
         return rb_yield(val);
     }
 }
+#ifdef RUBY_ASAN_ENABLED
+/* callcc can't possibly work with ASAN; see bug #20273. Also this function
+ * definition below avoids a "defined and not used" warning. */
+MAYBE_UNUSED(static void notusing_callcc(void)) { rb_callcc(Qnil); }
+# define rb_callcc rb_f_notimplement
+#endif
+
 
 static VALUE
 make_passing_arg(int argc, const VALUE *argv)

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -3561,6 +3561,7 @@ class TestArray < Test::Unit::TestCase
     unless respond_to?(:callcc, true)
       EnvUtil.suppress_warning {require 'continuation'}
     end
+    omit 'requires callcc support' unless respond_to?(:callcc, true)
   end
 end
 

--- a/test/ruby/test_beginendblock.rb
+++ b/test/ruby/test_beginendblock.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: false
 require 'test/unit'
+EnvUtil.suppress_warning {require 'continuation'}
 
 class TestBeginEndBlock < Test::Unit::TestCase
   DIR = File.dirname(File.expand_path(__FILE__))
@@ -131,6 +132,8 @@ class TestBeginEndBlock < Test::Unit::TestCase
   end
 
   def test_callcc_at_exit
+    omit 'requires callcc support' unless respond_to?(:callcc)
+
     bug9110 = '[ruby-core:58329][Bug #9110]'
     assert_ruby_status([], "#{<<~"begin;"}\n#{<<~'end;'}", bug9110)
     begin;

--- a/test/ruby/test_continuation.rb
+++ b/test/ruby/test_continuation.rb
@@ -4,6 +4,10 @@ EnvUtil.suppress_warning {require 'continuation'}
 require 'fiber'
 
 class TestContinuation < Test::Unit::TestCase
+  def setup
+    omit 'requires callcc support' unless respond_to?(:callcc)
+  end
+
   def test_create
     assert_equal(:ok, callcc{:ok})
     assert_equal(:ok, callcc{|c| c.call :ok})

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -843,6 +843,8 @@ class TestEnumerable < Test::Unit::TestCase
   end
 
   def test_callcc
+    omit 'requires callcc support' unless respond_to?(:callcc)
+
     assert_raise(RuntimeError) do
       c = nil
       @obj.sort_by {|x| callcc {|c2| c ||= c2 }; x }

--- a/test/ruby/test_fiber.rb
+++ b/test/ruby/test_fiber.rb
@@ -82,12 +82,14 @@ class TestFiber < Test::Unit::TestCase
       f.resume
       f.resume
     }
-    assert_raise(RuntimeError){
-      Fiber.new{
-        @c = callcc{|c| @c = c}
-      }.resume
-      @c.call # cross fiber callcc
-    }
+    if respond_to?(:callcc)
+      assert_raise(RuntimeError){
+        Fiber.new{
+          @c = callcc{|c| @c = c}
+        }.resume
+        @c.call # cross fiber callcc
+      }
+    end
     assert_raise(RuntimeError){
       Fiber.new{
         raise

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1359,6 +1359,8 @@ class TestHash < Test::Unit::TestCase
   end
 
   def test_callcc
+    omit 'requires callcc support' unless respond_to?(:callcc)
+
     h = @cls[1=>2]
     c = nil
     f = false
@@ -1379,6 +1381,8 @@ class TestHash < Test::Unit::TestCase
   end
 
   def test_callcc_iter_level
+    omit 'requires callcc support' unless respond_to?(:callcc)
+
     bug9105 = '[ruby-dev:47803] [Bug #9105]'
     h = @cls[1=>2, 3=>4]
     c = nil
@@ -1397,6 +1401,8 @@ class TestHash < Test::Unit::TestCase
   end
 
   def test_callcc_escape
+    omit 'requires callcc support' unless respond_to?(:callcc)
+
     bug9105 = '[ruby-dev:47803] [Bug #9105]'
     assert_nothing_raised(RuntimeError, bug9105) do
       h=@cls[]
@@ -1411,6 +1417,8 @@ class TestHash < Test::Unit::TestCase
   end
 
   def test_callcc_reenter
+    omit 'requires callcc support' unless respond_to?(:callcc)
+
     bug9105 = '[ruby-dev:47803] [Bug #9105]'
     assert_nothing_raised(RuntimeError, bug9105) do
       h = @cls[1=>2,3=>4]

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -609,6 +609,8 @@ class TestMarshal < Test::Unit::TestCase
 
   def test_continuation
     EnvUtil.suppress_warning {require "continuation"}
+    omit 'requires callcc support' unless respond_to?(:callcc)
+
     c = Bug9523.new
     assert_raise_with_message(RuntimeError, /Marshal\.dump reentered at marshal_dump/) do
       Marshal.dump(c)

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: false
 require 'test/unit'
+EnvUtil.suppress_warning {require 'continuation'}
 
 class TestSetTraceFunc < Test::Unit::TestCase
   def setup
@@ -1258,15 +1259,17 @@ CODE
       end
     }
     assert_normal_exit src % %q{obj.zip({}) {}}, bug7774
-    assert_normal_exit src % %q{
-      require 'continuation'
-      begin
-        c = nil
-        obj.sort_by {|x| callcc {|c2| c ||= c2 }; x }
-        c.call
-      rescue RuntimeError
-      end
-    }, bug7774
+    if respond_to?(:callcc)
+      assert_normal_exit src % %q{
+        require 'continuation'
+        begin
+          c = nil
+          obj.sort_by {|x| callcc {|c2| c ||= c2 }; x }
+          c.call
+        rescue RuntimeError
+        end
+      }, bug7774
+    end
 
     # TracePoint
     tp_b = nil


### PR DESCRIPTION
callcc's implementation is fundamentally incompatible with ASAN. Since callcc is deprecated and almost never used, it's probably OK to disable callcc when ruby is compiled with ASAN.

This PR adds an autoconf test to detect when we're building with ASAN, and uses this to either define `RUBY_CALLCC_ENABLED` or not. Obviously the define defaults to on.

I also moved a lot of the `cont.c` code around so that all of the callcc implementation could be guarded by a single ifdef.

[Bug #20273]