### PR TITLE
`Exception#set_backtrace` accept arrays of `Backtrace::Location`

### DIFF
--- a/error.c
+++ b/error.c
@@ -1839,7 +1839,7 @@ static VALUE
 rb_check_backtrace(VALUE bt)
 {
     long i;
-    static const char err[] = "backtrace must be Array of String";
+    static const char err[] = "backtrace must be an Array of String or an Array of Thread::Backtrace::Location";
 
     if (!NIL_P(bt)) {
         if (RB_TYPE_P(bt, T_STRING)) return rb_ary_new3(1, bt);
@@ -1870,7 +1870,15 @@ rb_check_backtrace(VALUE bt)
 static VALUE
 exc_set_backtrace(VALUE exc, VALUE bt)
 {
-    return rb_ivar_set(exc, id_bt, rb_check_backtrace(bt));
+    VALUE btobj = rb_location_ary_to_backtrace(bt);
+    if (RTEST(btobj)) {
+        rb_ivar_set(exc, id_bt, btobj);
+        rb_ivar_set(exc, id_bt_locations, btobj);
+        return bt;
+    }
+    else {
+        return rb_ivar_set(exc, id_bt, rb_check_backtrace(bt));
+    }
 }
 
 VALUE

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -114,6 +114,7 @@ void rb_backtrace_print_as_bugreport(FILE*);
 int rb_backtrace_p(VALUE obj);
 VALUE rb_backtrace_to_str_ary(VALUE obj);
 VALUE rb_backtrace_to_location_ary(VALUE obj);
+VALUE rb_location_ary_to_backtrace(VALUE ary);
 void rb_backtrace_each(VALUE (*iter)(VALUE recv, VALUE str), VALUE output);
 int rb_frame_info_p(VALUE obj);
 int rb_get_node_id_from_frame_info(VALUE obj);

--- a/spec/ruby/core/exception/set_backtrace_spec.rb
+++ b/spec/ruby/core/exception/set_backtrace_spec.rb
@@ -11,9 +11,37 @@ describe "Exception#set_backtrace" do
   it "allows the user to set the backtrace from a rescued exception" do
     bt  = ExceptionSpecs::Backtrace.backtrace
     err = RuntimeError.new
+    err.backtrace.should == nil
+    err.backtrace_locations.should == nil
 
     err.set_backtrace bt
+
     err.backtrace.should == bt
+    err.backtrace_locations.should == nil
+  end
+
+  ruby_version_is "3.4" do
+    it "allows the user to set backtrace locations from a rescued exception" do
+      bt_locations = ExceptionSpecs::Backtrace.backtrace_locations
+      err = RuntimeError.new
+      err.backtrace.should == nil
+      err.backtrace_locations.should == nil
+
+      err.set_backtrace bt_locations
+
+      err.backtrace_locations.size.should == bt_locations.size
+      err.backtrace_locations.each_with_index do |loc, index|
+        other_loc = bt_locations[index]
+
+        loc.path.should == other_loc.path
+        loc.label.should == other_loc.label
+        loc.base_label.should == other_loc.base_label
+        loc.lineno.should == other_loc.lineno
+        loc.absolute_path.should == other_loc.absolute_path
+        loc.to_s.should == other_loc.to_s
+      end
+      err.backtrace.size.should == err.backtrace_locations.size
+    end
   end
 
   it "accepts an empty Array" do

--- a/spec/ruby/shared/kernel/raise.rb
+++ b/spec/ruby/shared/kernel/raise.rb
@@ -146,4 +146,12 @@ describe :kernel_raise, shared: true do
       @object.raise(ArgumentError, "message", caller)
     end.should raise_error(ArgumentError, "message")
   end
+
+  ruby_version_is "3.4" do
+    it "allows Exception, message, and backtrace_locations parameters" do
+      -> do
+        @object.raise(ArgumentError, "message", caller_locations)
+      end.should raise_error(ArgumentError, "message")
+    end
+  end
 end


### PR DESCRIPTION
[[Feature #13557]](https://bugs.ruby-lang.org/issues/13557)

Setting the backtrace with an array of strings is lossy. The resulting exception will return nil on `#backtrace_locations`.

By accepting an array of `Backtrace::Location` instance, we can rebuild a `Backtrace` instance and have a fully functioning Exception.

~~NOTE: Exception's instance variables `id_bt` and `id_bt_locations` are a bit inconsistent right now and would deserve a cleanup.~~