### PR TITLE
Update warning flags before dump

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -1739,6 +1739,8 @@ Init_extra_exts(void)
 static void
 ruby_opt_init(ruby_cmdline_options_t *opt)
 {
+    rb_warning_category_update(opt->warn.mask, opt->warn.set);
+
     if (opt->dump & dump_exit_bits) return;
 
     if (FEATURE_SET_P(opt->features, gems)) {
@@ -1753,8 +1755,6 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
             rb_define_module("SyntaxSuggest");
         }
     }
-
-    rb_warning_category_update(opt->warn.mask, opt->warn.set);
 
     /* [Feature #19785] Warning for removed GC environment variable.
      * Remove this in Ruby 3.4. */

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -296,6 +296,8 @@ class TestRubyOptions < Test::Unit::TestCase
     warning = /compiler based on the Prism parser is currently experimental/
 
     assert_in_out_err(%w(--parser=prism -e) + ["puts :hi"], "", %w(hi), warning)
+    assert_in_out_err(%w(--parser=prism -W:no-experimental -e) + ["puts :hi"], "", %w(hi), [])
+    assert_in_out_err(%w(--parser=prism -W:no-experimental --dump=parsetree -e :hi), "", /"hi"/, [])
 
     assert_in_out_err(%w(--parser=parse.y -e) + ["puts :hi"], "", %w(hi), [])
     assert_norun_with_rflag('--parser=parse.y', '--version', "")


### PR DESCRIPTION
No warning when `ruby --parser=prism -W:no-experimental` but prism with `--dump` option is still warned.