### PR TITLE
skip a test on non-UTF-8 locale

### DIFF
--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -297,7 +297,10 @@ class TestRubyOptions < Test::Unit::TestCase
 
     assert_in_out_err(%w(--parser=prism -e) + ["puts :hi"], "", %w(hi), warning)
     assert_in_out_err(%w(--parser=prism -W:no-experimental -e) + ["puts :hi"], "", %w(hi), [])
-    assert_in_out_err(%w(--parser=prism -W:no-experimental --dump=parsetree -e :hi), "", /"hi"/, [])
+
+    if Encoding.locale_charmap == 'UTF-8'
+      assert_in_out_err(%w(--parser=prism -W:no-experimental --dump=parsetree -e :hi), "", /"hi"/, [])
+    end
 
     assert_in_out_err(%w(--parser=parse.y -e) + ["puts :hi"], "", %w(hi), [])
     assert_norun_with_rflag('--parser=parse.y', '--version', "")


### PR DESCRIPTION
`ruby --parser=prism -W:no-experimental --dump=parsetree -e :hi` prints non-ASCII char(s) so the following test with non UTF-8 locale fails.

```
$ LANG=C make test-all TESTS='-n /parser/ ruby/rubyoptions' -o encs -o exts
Run options:
  --seed=32323
  "--ruby=./miniruby -I/home/ko1/ruby/src/master/lib -I. -I.ext/common  /home/ko1/ruby/src/master/tool/runruby.rb --extout=.ext  -- --disable-gems"
  --excludes-dir=/home/ko1/ruby/src/master/test/.excludes
  --name=!/memory_leak/
  -n
  /parser/

[1/1] TestRubyOptions#test_parser_flag = 0.04 s
  1) Failure:
TestRubyOptions#test_parser_flag [/home/ko1/ruby/src/master/test/ruby/test_rubyoptions.rb:300]:
pid 135869 exit 0.

1. [1/2] Assertion for "stdout"
   | invalid byte sequence in US-ASCII.

Finished tests in 0.044362s, 22.5416 tests/s, 225.4157 assertions/s.
1 tests, 10 assertions, 1 failures, 0 errors, 0 skips

ruby -v: ruby 3.4.0dev (2024-02-20T17:13:36Z master c0e5de9567) [x86_64-linux]
make: *** [uncommon.mk:945: yes-test-all] Error 1
```

Now simply skip the test if the locale is not UTF-8. (I'm not familiar with encodings so please fix it if needed)