### PR TITLE
YJIT: Fix calling leaf builtins with empty splat and kw_splat

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4576,3 +4576,9 @@ assert_equal 'ok', %q{
 
   splat_nil_kw_splat([:ok])
 }
+
+# empty splat and kwsplat into leaf builtins
+assert_equal '[1, 1, 1]', %q{
+  empty = []
+  [1.abs(*empty), 1.abs(**nil), 1.bit_length(*empty, **nil)]
+}

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4559,15 +4559,6 @@ assert_equal '[1, []]', %q{
   call_site([1])
 }
 
-# splat+kw_splat+opt+rest
-assert_equal '[1, []]', %q{
-  def opt_rest(a = 0, *rest) = [a, rest]
-
-  def call_site(args) = opt_rest(*args, **nil)
-
-  call_site([1])
-}
-
 # splat and nil kw_splat
 assert_equal 'ok', %q{
   def identity(x) = x

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6713,7 +6713,8 @@ fn gen_send_iseq(
     let builtin_func_raw = unsafe { rb_yjit_builtin_function(iseq) };
     let builtin_func = if builtin_func_raw.is_null() { None } else { Some(builtin_func_raw) };
     let opt_send_call = flags & VM_CALL_OPT_SEND != 0; // .send call is not currently supported for builtins
-    if let (None, Some(builtin_info), true, false) = (block, builtin_func, builtin_attrs & BUILTIN_ATTR_LEAF != 0, opt_send_call) {
+    if let (None, Some(builtin_info), true, false, None | Some(0)) =
+           (block, builtin_func, builtin_attrs & BUILTIN_ATTR_LEAF != 0, opt_send_call, splat_array_length) {
         let builtin_argc = unsafe { (*builtin_info).argc };
         if builtin_argc + 1 < (C_ARG_OPNDS.len() as i32) {
             // We pop the block arg without using it because:
@@ -6725,6 +6726,16 @@ fn gen_send_iseq(
                     gen_counter_incr(asm, Counter::send_iseq_leaf_builtin_block_arg_block_param);
                     return None;
                 }
+                asm.stack_pop(1);
+            }
+
+            // Pop empty kw_splat hash which passes nothing (exit_if_kwsplat_non_nil())
+            if kw_splat {
+                asm.stack_pop(1);
+            }
+
+            // Pop empty splat array which passes nothing
+            if let Some(0) = splat_array_length {
                 asm.stack_pop(1);
             }
 


### PR DESCRIPTION
- YJIT: Fix calling leaf builtins with empty splat and kw_splat
Fixes cases like https://github.com/ruby/ruby/actions/runs/7977363890/job/21780095289#step:13:104
- YJIT: Remove duplicate test
