### PR TITLE
Fix string value in hash literal being forced frozen

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -4903,7 +4903,7 @@ compile_array(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *node, int pop
 static inline int
 static_literal_node_pair_p(const NODE *node, const rb_iseq_t *iseq)
 {
-    return RNODE_LIST(node)->nd_head && static_literal_node_p(RNODE_LIST(node)->nd_head, iseq, true) && static_literal_node_p(RNODE_LIST(RNODE_LIST(node)->nd_next)->nd_head, iseq, true);
+    return RNODE_LIST(node)->nd_head && static_literal_node_p(RNODE_LIST(node)->nd_head, iseq, true) && static_literal_node_p(RNODE_LIST(RNODE_LIST(node)->nd_next)->nd_head, iseq, false);
 }
 
 static int

--- a/test/ruby/test_literal.rb
+++ b/test/ruby/test_literal.rb
@@ -184,6 +184,11 @@ class TestRubyLiteral < Test::Unit::TestCase
     list.each { |str| assert_predicate str, :frozen? }
   end
 
+  def test_string_in_hash_literal
+    hash = eval("# frozen-string-literal: false\n""{foo: 'foo'}")
+    assert_not_predicate(hash[:foo], :frozen?)
+  end
+
   if defined?(RubyVM::InstructionSequence.compile_option) and
     RubyVM::InstructionSequence.compile_option.key?(:debug_frozen_string_literal)
     def test_debug_frozen_string


### PR DESCRIPTION
We should pass `false` for `hash_key` for value nodes. Credits to
`@kddnewton` for noticing and bisecting.
