### PR TITLE
Fix incomplete switch statement in imemo_memsize

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3060,6 +3060,9 @@ imemo_memsize(VALUE obj)
       case imemo_ast:
         size += rb_ast_memsize(&RANY(obj)->as.imemo.ast);
         break;
+      case imemo_callcache:
+      case imemo_callinfo:
+      case imemo_constcache:
       case imemo_cref:
       case imemo_svar:
       case imemo_throw_data:
@@ -3068,7 +3071,7 @@ imemo_memsize(VALUE obj)
       case imemo_parser_strterm:
         break;
       default:
-        /* unreachable */
+        rb_bug("unreachable");
         break;
     }
     return size;


### PR DESCRIPTION
The switch statement is not exhaustive, meaning the "unreachable" comment was not correct. This commit fixes it by making the list exhaustive and adding an rb_bug in the default case.