### PR TITLE
YJIT: Allow non-leaf calls on opt_* insns

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -2009,11 +2009,11 @@ impl Assembler {
         out
     }
 
-    /// Verify the leafness of the given block if leaf_ccall is true.
-    pub fn with_leaf_ccall<F, R>(&mut self, leaf_ccall: bool, mut block: F) -> R
+    /// Verify the leafness of the given block
+    pub fn with_leaf_ccall<F, R>(&mut self, mut block: F) -> R
     where F: FnMut(&mut Self) -> R {
         let old_leaf_ccall = self.leaf_ccall;
-        self.leaf_ccall = leaf_ccall;
+        self.leaf_ccall = true;
         let ret = block(self);
         self.leaf_ccall = old_leaf_ccall;
         ret

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1580,11 +1580,6 @@ impl Assembler
     pub fn expect_leaf_ccall(&mut self) {
         self.leaf_ccall = true;
     }
-
-    /// Undo expect_leaf_ccall() as an exception.
-    pub fn allow_non_leaf_ccall(&mut self) {
-        self.leaf_ccall = false;
-    }
 }
 
 /// A struct that allows iterating through an assembler's instructions and
@@ -2014,11 +2009,11 @@ impl Assembler {
         out
     }
 
-    /// Verify the leafness of the given block
-    pub fn with_leaf_ccall<F, R>(&mut self, mut block: F) -> R
+    /// Verify the leafness of the given block if leaf_ccall is true.
+    pub fn with_leaf_ccall<F, R>(&mut self, leaf_ccall: bool, mut block: F) -> R
     where F: FnMut(&mut Self) -> R {
         let old_leaf_ccall = self.leaf_ccall;
-        self.leaf_ccall = true;
+        self.leaf_ccall = leaf_ccall;
         let ret = block(self);
         self.leaf_ccall = old_leaf_ccall;
         ret

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -298,6 +298,16 @@ impl JITState {
             }
         }
     }
+
+    /// Return true if we're compiling a send-like instruction, not an opt_* instruction.
+    pub fn on_send_insn(&self) -> bool {
+        match unsafe { rb_iseq_opcode_at_pc(self.iseq, self.pc) } as u32 {
+            YARVINSN_send |
+            YARVINSN_opt_send_without_block |
+            YARVINSN_invokesuper => true,
+            _ => false,
+        }
+    }
 }
 
 /// Macro to call jit.perf_symbol_push() without evaluating arguments when
@@ -5525,10 +5535,9 @@ fn jit_rb_str_concat(
     guard_object_is_string(asm, asm.stack_opnd(0), StackOpnd(0), Counter::guard_send_not_string);
 
     // Guard buffers from GC since rb_str_buf_append may allocate.
-    jit_prepare_non_leaf_call(jit, asm);
     // rb_str_buf_append may raise Encoding::CompatibilityError, but we accept compromised
     // backtraces on this method since the interpreter does the same thing on opt_ltlt.
-    asm.allow_non_leaf_ccall();
+    jit_prepare_non_leaf_call(jit, asm);
     asm.spill_temps(); // For ccall. Unconditionally spill them for RegTemps consistency.
 
     let concat_arg = asm.stack_pop(1);
@@ -6088,7 +6097,9 @@ fn gen_send_cfunc(
         let expected_stack_after = asm.ctx.get_stack_size() as i32 - argc;
         if let Some(known_cfunc_codegen) = lookup_cfunc_codegen(unsafe { (*cme).def }) {
             // We don't push a frame for specialized cfunc codegen, so the generated code must be leaf.
-            if asm.with_leaf_ccall(|asm|
+            // However, the interpreter doesn't push a frame on opt_* instruction either, so we allow
+            // non-send instructions to break this rule as an exception.
+            if asm.with_leaf_ccall(jit.on_send_insn(), |asm|
                 perf_call!("gen_send_cfunc: ", known_cfunc_codegen(jit, asm, ocb, ci, cme, block, argc, recv_known_class))
             ) {
                 assert_eq!(expected_stack_after, asm.ctx.get_stack_size() as i32);

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -300,7 +300,7 @@ impl JITState {
     }
 
     /// Return true if we're compiling a send-like instruction, not an opt_* instruction.
-    pub fn on_send_insn(&self) -> bool {
+    pub fn is_sendish(&self) -> bool {
         match unsafe { rb_iseq_opcode_at_pc(self.iseq, self.pc) } as u32 {
             YARVINSN_send |
             YARVINSN_opt_send_without_block |
@@ -6099,7 +6099,7 @@ fn gen_send_cfunc(
             // We don't push a frame for specialized cfunc codegen, so the generated code must be leaf.
             // However, the interpreter doesn't push a frame on opt_* instruction either, so we allow
             // non-send instructions to break this rule as an exception.
-            if asm.with_leaf_ccall(jit.on_send_insn(), |asm|
+            if asm.with_leaf_ccall(jit.is_sendish(), |asm|
                 perf_call!("gen_send_cfunc: ", known_cfunc_codegen(jit, asm, ocb, ci, cme, block, argc, recv_known_class))
             ) {
                 assert_eq!(expected_stack_after, asm.ctx.get_stack_size() as i32);


### PR DESCRIPTION
Follow-up on https://github.com/ruby/ruby/pull/10002

We allowed `jit_rb_str_concat` to make a non-leaf call as an exception because the interpreter skips pushing a frame too. This PR refactors https://github.com/ruby/ruby/pull/10002 to encode the rule in the `with_leaf_ccall()` call instead of reversing it in cfunc codegen.

I was going to clarify that by moving the implementation to `gen_opt_ltlt` using `BOP`, which would limit the optimization to `rb_cString`, but I want the optimization to be applied to all `T_STRING`s because Rails defines subclasses of `String`.