### PR TITLE
YJIT: rb_str_concat_literals is not leaf

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3064,8 +3064,8 @@ fn gen_concatstrings(
 ) -> Option<CodegenStatus> {
     let n = jit.get_arg(0).as_usize();
 
-    // Save the PC and SP because we are allocating
-    jit_prepare_call_with_gc(jit, asm);
+    // rb_str_concat_literals may raise Encoding::CompatibilityError
+    jit_prepare_non_leaf_call(jit, asm);
 
     let values_ptr = asm.lea(asm.ctx.sp_opnd(-(SIZEOF_VALUE_I32 * n as i32)));
 


### PR DESCRIPTION
As indicated by `attr bool leaf = false;` in insns.def, `rb_str_concat_literals` (`concatstrings` instruction) is not leaf. This PR fixes the setup to prepare for arbitrary method calls.

```
  -- C level backtrace information -------------------------------------------
  /Users/runner/work/ruby/ruby/build/ruby(rb_vm_bugreport+0xb60) [0x1050a6d5c] ../src/vm_dump.c:1151
  /Users/runner/work/ruby/ruby/build/ruby(rb_vm_bugreport) (null):0
  /Users/runner/work/ruby/ruby/build/ruby(rb_bug_without_die+0xf0) [0x104ebf048] ../src/error.c:1042
  /Users/runner/work/ruby/ruby/build/ruby(rb_bug+0x1c) [0x10549d400] ../src/error.c:1050
  /Users/runner/work/ruby/ruby/build/ruby(rb_vm_push_frame_fname.cold.1+0x0) [0x1054c160c] ../src/vm_insnhelper.c:281
  /Users/runner/work/ruby/ruby/build/ruby(rb_vm_check_canary.cold.1) (null):0
  /Users/runner/work/ruby/ruby/build/ruby(rb_vm_stack_canary+0x0) [0x10506fa38] ../src/vm_insnhelper.c:258
  /Users/runner/work/ruby/ruby/build/ruby(rb_vm_check_canary) (null):0
  /Users/runner/work/ruby/ruby/build/ruby(vm_push_frame+0x18c) [0x10506fd0c] ../src/vm_insnhelper.c:374
  /Users/runner/work/ruby/ruby/build/ruby(vm_call0_cfunc_with_frame+0x8c) [0x10509df00] ../src/vm_eval.c:167
  /Users/runner/work/ruby/ruby/build/ruby(vm_call0_cfunc) ../src/vm_eval.c:187
  /Users/runner/work/ruby/ruby/build/ruby(vm_call0_body) ../src/vm_eval.c:233
  /Users/runner/work/ruby/ruby/build/ruby(vm_call0_cc+0x120) [0x1050815f8] ../src/vm_eval.c:110
  /Users/runner/work/ruby/ruby/build/ruby(rb_call0+0x314) [0x10509ec5c]
  /Users/runner/work/ruby/ruby/build/ruby(rb_class_new_instance+0x50) [0x104f5c154] ../src/object.c:2184
  /Users/runner/work/ruby/ruby/build/ruby(rb_exc_new_str+0x40) [0x104ebfd50] ../src/error.c:1413
  /Users/runner/work/ruby/ruby/build/ruby(rb_vraise+0x28) [0x104ec33a4] ../src/error.c:3474
  /Users/runner/work/ruby/ruby/build/ruby(rb_warning_category_update+0x0) [0x104ebe24c] ../src/error.c:3482
  /Users/runner/work/ruby/ruby/build/ruby(rb_raise) (null):0
  /Users/runner/work/ruby/ruby/build/ruby(rb_str_buf_cat_ascii+0x0) [0x105012e7c] ../src/string.c:3364
  /Users/runner/work/ruby/ruby/build/ruby(rb_enc_cr_str_buf_cat) (null):0
  /Users/runner/work/ruby/ruby/build/ruby(RB_BUILTIN_TYPE+0x0) [0x105013150] ../src/string.c:3426
  /Users/runner/work/ruby/ruby/build/ruby(rbimpl_RB_TYPE_P_fastpath) ../src/include/ruby/internal/value_type.h:351
  /Users/runner/work/ruby/ruby/build/ruby(RB_FL_ABLE) ../src/include/ruby/internal/fl_type.h:449
  /Users/runner/work/ruby/ruby/build/ruby(RB_FL_UNSET_RAW) ../src/include/ruby/internal/fl_type.h:668
  /Users/runner/work/ruby/ruby/build/ruby(RB_ENC_CODERANGE_SET) ../src/include/ruby/internal/encoding/coderange.h:131
  /Users/runner/work/ruby/ruby/build/ruby(rb_str_buf_append) ../src/string.c:3429
  /Users/runner/work/ruby/ruby/build/ruby(rb_str_concat_literals+0x214) [0x10501358c] ../src/string.c:3459
```

https://github.com/ruby/ruby/actions/runs/7981888849/job/21794443595