### PR TITLE
Clear all refined CCs on reopening refinement mod

### DIFF
--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -1606,18 +1606,35 @@ class TestRefinement < Test::Unit::TestCase
       end
 
       using R
+      def m
+        C.new.m
+      end
+
       assert_equal(:foo, C.new.m)
+      assert_equal(:foo, m)
 
       module R
         refine C do
+
+          assert_equal(:foo, C.new.m)
+          assert_equal(:foo, m)
+
           alias m m
+
+          assert_equal(:foo, C.new.m)
+          assert_equal(:foo, m)
+
           def m
             :bar
           end
+
+          assert_equal(:bar, C.new.m, "[ruby-core:71423] [Bug #11672]")
+          assert_equal(:bar, m, "[Bug #20285]")
         end
       end
 
       assert_equal(:bar, C.new.m, "[ruby-core:71423] [Bug #11672]")
+      assert_equal(:bar, m, "[Bug #20285]")
     end;
   end
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -301,6 +301,7 @@ rb_clear_method_cache(VALUE klass_or_module, ID mid)
             VALUE refined_class = rb_refinement_module_get_refined_class(module);
             rb_clear_method_cache(refined_class, mid);
             rb_class_foreach_subclass(refined_class, clear_iclass_method_cache_by_id_for_refinements, mid);
+            rb_clear_all_refinement_method_cache();
         }
         rb_class_foreach_subclass(module, clear_iclass_method_cache_by_id, mid);
     }


### PR DESCRIPTION
In cfd7729ce7a31c8b6ec5dd0e99c67b2932de4732 we started using inline caches for refinements. However, we weren't clearing inline caches when defined on a reopened refinement module.

Fixes [[Bug #20246]](https://bugs.ruby-lang.org/issues/20285)