### PR TITLE
Ensure that exiting thread invokes end-of-life behaviour.

### DIFF
--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -2874,4 +2874,52 @@ CODE
     assert err.kind_of?(RuntimeError)
     assert_equal err.message.to_i + 3, line
   end
+
+  def test_tracepoint_thread_begin
+    target_thread = nil
+
+    trace = TracePoint.new(:thread_begin) do |tp|
+      target_thread = tp.self
+    end
+
+    trace.enable(target_thread: nil) do
+      Thread.new{}.join
+    end
+
+    assert_kind_of(Thread, target_thread)
+  end
+
+  def test_tracepoint_thread_end
+    target_thread = nil
+
+    trace = TracePoint.new(:thread_end) do |tp|
+      target_thread = tp.self
+    end
+
+    trace.enable(target_thread: nil) do
+      Thread.new{}.join
+    end
+
+    assert_kind_of(Thread, target_thread)
+  end
+
+  def test_tracepoint_thread_end_with_exception
+    target_thread = nil
+
+    trace = TracePoint.new(:thread_end) do |tp|
+      target_thread = tp.self
+    end
+
+    trace.enable(target_thread: nil) do
+      thread = Thread.new do
+        Thread.current.report_on_exception = false
+        raise
+      end
+
+      # Ignore the exception raised by the thread:
+      thread.join rescue nil
+    end
+
+    assert_kind_of(Thread, target_thread)
+  end
 end

--- a/thread.c
+++ b/thread.c
@@ -601,54 +601,31 @@ thread_do_start_proc(rb_thread_t *th)
     }
 }
 
-static void
+static VALUE
 thread_do_start(rb_thread_t *th)
 {
     native_set_thread_name(th);
     VALUE result = Qundef;
 
-    rb_execution_context_t *ec = th->ec;
-    int state;
+    switch (th->invoke_type) {
+      case thread_invoke_type_proc:
+        result = thread_do_start_proc(th);
+        break;
 
-    EXEC_EVENT_HOOK(ec, RUBY_EVENT_THREAD_BEGIN, th->self, 0, 0, 0, Qundef);
+      case thread_invoke_type_ractor_proc:
+        result = thread_do_start_proc(th);
+        rb_ractor_atexit(th->ec, result);
+        break;
 
-    EC_PUSH_TAG(ec);
-    if ((state = EC_EXEC_TAG()) == TAG_NONE) {
-        switch (th->invoke_type) {
-        case thread_invoke_type_proc:
-            result = thread_do_start_proc(th);
-            break;
+      case thread_invoke_type_func:
+        result = (*th->invoke_arg.func.func)(th->invoke_arg.func.arg);
+        break;
 
-        case thread_invoke_type_ractor_proc:
-            result = thread_do_start_proc(th);
-            rb_ractor_atexit(th->ec, result);
-            break;
-
-        case thread_invoke_type_func:
-            result = (*th->invoke_arg.func.func)(th->invoke_arg.func.arg);
-            break;
-
-        case thread_invoke_type_none:
-            rb_bug("unreachable");
-        }
+      case thread_invoke_type_none:
+        rb_bug("unreachable");
     }
 
-    EC_POP_TAG();
-    VALUE errinfo = ec->errinfo;
-
-    if (!NIL_P(errinfo) && !RB_TYPE_P(errinfo, T_OBJECT)) {
-        ec->errinfo = Qnil;
-    }
-
-    rb_fiber_scheduler_set(Qnil);
-    EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_THREAD_END, th->self, 0, 0, 0, Qundef);
-
-    ec->errinfo = errinfo;
-
-    if (state)
-        EC_JUMP_TAG(ec, state);
-
-    th->value = result;
+    return result;
 }
 
 void rb_ec_clear_current_thread_trace_func(const rb_execution_context_t *ec);
@@ -679,12 +656,31 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     // Ensure that we are not joinable.
     VM_ASSERT(UNDEF_P(th->value));
 
+    int rb_fiber_scheduler_set_invoked = 0, event_thread_end_hooked = 0;
+    VALUE result = Qundef;
+
     EC_PUSH_TAG(th->ec);
 
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
-        SAVE_ROOT_JMPBUF(th, thread_do_start(th));
+        EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_THREAD_BEGIN, th->self, 0, 0, 0, Qundef);
+
+        SAVE_ROOT_JMPBUF(th, result = thread_do_start(th));
     }
-    else {
+
+    if (!rb_fiber_scheduler_set_invoked) {
+        rb_fiber_scheduler_set(Qnil);
+        rb_fiber_scheduler_set_invoked = 1;
+    }
+
+    if (!event_thread_end_hooked) {
+        EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_THREAD_END, th->self, 0, 0, 0, Qundef);
+        event_thread_end_hooked = 1;
+    }
+
+    if (state == TAG_NONE) {
+        // This must be set AFTER doing all user-level code. At this point, the thread is effectively finished and calls to `Thread#join` will succeed.
+        th->value = result;
+    } else {
         errinfo = th->ec->errinfo;
 
         VALUE exc = rb_vm_make_jump_tag_but_local_jump(state, Qundef);

--- a/thread.c
+++ b/thread.c
@@ -656,7 +656,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     // Ensure that we are not joinable.
     VM_ASSERT(UNDEF_P(th->value));
 
-    int rb_fiber_scheduler_set_invoked = 0, event_thread_end_hooked = 0;
+    int fiber_scheduler_closed = 0, event_thread_end_hooked = 0;
     VALUE result = Qundef;
 
     EC_PUSH_TAG(th->ec);
@@ -667,8 +667,8 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
         SAVE_ROOT_JMPBUF(th, result = thread_do_start(th));
     }
 
-    if (!rb_fiber_scheduler_set_invoked) {
-        rb_fiber_scheduler_set_invoked = 1;
+    if (!fiber_scheduler_closed) {
+        fiber_scheduler_closed = 1;
         rb_fiber_scheduler_set(Qnil);
     }
 

--- a/thread.c
+++ b/thread.c
@@ -668,13 +668,13 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     }
 
     if (!rb_fiber_scheduler_set_invoked) {
-        rb_fiber_scheduler_set(Qnil);
         rb_fiber_scheduler_set_invoked = 1;
+        rb_fiber_scheduler_set(Qnil);
     }
 
     if (!event_thread_end_hooked) {
-        EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_THREAD_END, th->self, 0, 0, 0, Qundef);
         event_thread_end_hooked = 1;
+        EXEC_EVENT_HOOK(th->ec, RUBY_EVENT_THREAD_END, th->self, 0, 0, 0, Qundef);
     }
 
     if (state == TAG_NONE) {


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20286