### PR TITLE
Revert rubygems tempdir check

### DIFF
--- a/test/rubygems/helper.rb
+++ b/test/rubygems/helper.rb
@@ -76,8 +76,6 @@ class Gem::TestCase < Test::Unit::TestCase
 
   attr_accessor :uri # :nodoc:
 
-  @@tempdirs = []
-
   def assert_activate(expected, *specs)
     specs.each do |spec|
       case spec
@@ -289,8 +287,7 @@ class Gem::TestCase < Test::Unit::TestCase
 
     FileUtils.mkdir_p @tmp
 
-    @tempdir = Dir.mktmpdir(method_name.to_s, @tmp)
-    @@tempdirs << @tempdir
+    @tempdir = Dir.mktmpdir("test_rubygems_", @tmp)
 
     ENV["GEM_VENDOR"] = nil
     ENV["GEMRC"] = nil
@@ -474,8 +471,6 @@ class Gem::TestCase < Test::Unit::TestCase
     end
 
     @back_ui.close
-
-    assert_empty @@tempdirs.select {|tempdir| File.exist?(tempdir) }
   end
 
   def credential_setup


### PR DESCRIPTION
This check was added to check if other tests still remain tempdir, and these tests do on Windows.

* `TestGemCommandsSetupCommand#test_destdir_flag_does_not_try_to_write_to_the_default_gem_home`
* `TestGemInstaller#test_install_build_root_when_gem_home_not_writable_does_not_fallback_to_user_install_inside_build_root`

Also some tests fail due to too long path names.