### PR TITLE
[Feature #20290] Add API for C extensions to free memory

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -7207,6 +7207,7 @@ gc.$(OBJEXT): $(top_srcdir)/internal/gc.h
 gc.$(OBJEXT): $(top_srcdir)/internal/hash.h
 gc.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 gc.$(OBJEXT): $(top_srcdir)/internal/io.h
+gc.$(OBJEXT): $(top_srcdir)/internal/load.h
 gc.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 gc.$(OBJEXT): $(top_srcdir)/internal/object.h
 gc.$(OBJEXT): $(top_srcdir)/internal/proc.h

--- a/configure.ac
+++ b/configure.ac
@@ -1738,7 +1738,7 @@ AS_IF([test "$GCC" = yes], [
 AC_CACHE_CHECK(for exported function attribute, rb_cv_func_exported, [
 rb_cv_func_exported=no
 RUBY_WERROR_FLAG([
-for mac in '__attribute__ ((__visibility__("default")))' '__declspec(dllexport)'; do
+for mac in '__declspec(dllexport)' '__attribute__ ((__visibility__("default")))'; do
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@define RUBY_FUNC_EXPORTED $mac extern
     RUBY_FUNC_EXPORTED void conftest_attribute_check(void);]], [[]])],
     [rb_cv_func_exported="$mac"; break])

--- a/dln.h
+++ b/dln.h
@@ -26,6 +26,7 @@ char *dln_find_exe_r(const char*,const char*,char*,size_t DLN_FIND_EXTRA_ARG_DEC
 char *dln_find_file_r(const char*,const char*,char*,size_t DLN_FIND_EXTRA_ARG_DECL);
 void *dln_load(const char*);
 void *dln_symbol(void*,const char*);
+void dln_unload(const char *file, void *handle);
 
 RUBY_SYMBOL_EXPORT_END
 

--- a/dmydln.c
+++ b/dmydln.c
@@ -20,3 +20,9 @@ dln_symbol(void *handle, const char *symbol)
 
     UNREACHABLE_RETURN(NULL);
 }
+
+NORETURN(void dln_unload(const char *file, void *handle));
+void dln_unload(const char *file, void *handle)
+{
+    rb_loaderror("this executable file can't load extension libraries");
+}

--- a/ext/-test-/load/destruct/destruct.c
+++ b/ext/-test-/load/destruct/destruct.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <ruby/ruby.h>
+
+void
+Init_destruct(void)
+{}
+
+RUBY_FUNC_EXPORTED void
+Destruct_destruct(void)
+{
+    printf("Calling Destruct_destruct\n");
+}

--- a/ext/-test-/load/destruct/extconf.rb
+++ b/ext/-test-/load/destruct/extconf.rb
@@ -1,0 +1,1 @@
+create_makefile("-test-/load/destruct")

--- a/include/ruby/internal/dllexport.h
+++ b/include/ruby/internal/dllexport.h
@@ -54,7 +54,11 @@
 #endif
 
 #ifndef RUBY_FUNC_EXPORTED
-# define RUBY_FUNC_EXPORTED /* void */
+# ifdef _WIN32
+#  define RUBY_FUNC_EXPORTED __declspec(dllexport)
+# else
+#  define RUBY_FUNC_EXPORTED /* void */
+# endif
 #endif
 
 /** @endcond */

--- a/internal/load.h
+++ b/internal/load.h
@@ -14,5 +14,6 @@
 VALUE rb_get_expanded_load_path(void);
 int rb_require_internal(VALUE fname);
 NORETURN(void rb_load_fail(VALUE, const char*));
+void rb_ext_call_destruct(void);
 
 #endif /* INTERNAL_LOAD_H */

--- a/load.c
+++ b/load.c
@@ -1580,6 +1580,20 @@ rb_ext_resolve_symbol(const char* fname, const char* symbol)
     return dln_symbol((void *)NUM2SVALUE(handle), symbol);
 }
 
+static int
+rb_ext_call_destruct_i(VALUE path, VALUE handle, VALUE _arg)
+{
+    dln_unload(RSTRING_PTR(path), (void *)NUM2SVALUE(handle));
+
+    return ST_CONTINUE;
+}
+
+void
+rb_ext_call_destruct(void)
+{
+    rb_hash_foreach(ruby_dln_libmap, rb_ext_call_destruct_i, 0);
+}
+
 void
 Init_load(void)
 {

--- a/parse.y
+++ b/parse.y
@@ -1616,7 +1616,7 @@ static void numparam_pop(struct parser_params *p, NODE *prev_inner);
 #define RE_OPTION_ARG_ENCODING_NONE 32
 
 #define yytnamerr(yyres, yystr) (YYSIZE_T)rb_yytnamerr(p, yyres, yystr)
-size_t rb_yytnamerr(struct parser_params *p, char *yyres, const char *yystr);
+RUBY_FUNC_EXPORTED size_t rb_yytnamerr(struct parser_params *p, char *yyres, const char *yystr);
 
 #define TOKEN2ID(tok) ( \
     tTOKEN_LOCAL_BEGIN<(tok)&&(tok)<tTOKEN_LOCAL_END ? TOKEN2LOCALID(tok) : \

--- a/prism/extension.h
+++ b/prism/extension.h
@@ -13,6 +13,6 @@ VALUE pm_ast_new(const pm_parser_t *parser, const pm_node_t *node, rb_encoding *
 
 void Init_prism_api_node(void);
 void Init_prism_pack(void);
-PRISM_EXPORTED_FUNCTION void Init_prism(void);
+RUBY_FUNC_EXPORTED void Init_prism(void);
 
 #endif

--- a/test/-ext-/load/test_destruct.rb
+++ b/test/-ext-/load/test_destruct.rb
@@ -1,0 +1,11 @@
+require "test/unit"
+
+class TestDestruct < Test::Unit::TestCase
+  def test_destruct_func_not_called
+    assert_in_out_err(["-r-test-/load/destruct"], "", [])
+  end
+
+  def test_destruct_func_called_when_free_on_exit
+    assert_in_out_err([{"RUBY_FREE_AT_EXIT" => "1"}, "-W0", "-r-test-/load/destruct"], "puts 'Running Ruby'", ["Running Ruby", "Calling Destruct_destruct"])
+  end
+end


### PR DESCRIPTION
[Ticket #19993](https://bugs.ruby-lang.org/issues/19993) added the new feature RUBY_FREE_AT_EXIT, which frees memory in Ruby at shutdown. This allowed tools like Valgrind, ASAN, and macOS leaks to find memory leaks in Ruby without a large number of false-positives outputted. However, this feature is not complete for C extensions, as they may also need to free their memory and there was no way to do so. This means that C extensions might not be able to directly use tools like Valgrind, ASAN, or macOS leaks to find memory leaks.

This ticket proposes an API for C extensions to free memory by defining a function called `Destruct_<extension name>` that is called during shutdown when RUBY_FREE_AT_EXIT is enabled. This name mirrors the `Init_<extension name>` API that already exists for extension initialization. However, unlike the `Init_<extension name>` function, `Destruct_<extension name>` is NOT mandatory for the C extension to implement so that we can preserve backwards compatibility.