### PR TITLE
Skip under_gc_compact_stress on s390x

### DIFF
--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1703,6 +1703,7 @@ class TestArray < Test::Unit::TestCase
   end
 
   def test_slice_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress { assert_equal([1, 2, 3, 4, 5], (0..10).to_a[1, 5]) }
     EnvUtil.under_gc_compact_stress do
       a = [0, 1, 2, 3, 4, 5]

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -128,6 +128,7 @@ class TestEnumerator < Test::Unit::TestCase
   end
 
   def test_with_index_under_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       assert_equal([[1, 0], [2, 1], [3, 2]], @obj.to_enum(:foo, 1, 2, 3).with_index.to_a)
       assert_equal([[1, 5], [2, 6], [3, 7]], @obj.to_enum(:foo, 1, 2, 3).with_index(5).to_a)
@@ -863,6 +864,7 @@ class TestEnumerator < Test::Unit::TestCase
   end
 
   def test_lazy_chain_under_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       ea = (10..).lazy.select(&:even?).take(10)
       ed = (20..).lazy.select(&:odd?)

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -1468,6 +1468,7 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
   end
 
   def test_detailed_message_under_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       e = RuntimeError.new("foo\nbar\nbaz")
       assert_equal("foo (RuntimeError)\nbar\nbaz", e.detailed_message)

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -451,6 +451,7 @@ class TestMethod < Test::Unit::TestCase
   end
 
   def test_clone_under_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       o = Object.new
       def o.foo; :foo; end

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -73,6 +73,7 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_to_s_under_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       str = "abcd\u3042"
       [:UTF_16BE, :UTF_16LE, :UTF_32BE, :UTF_32LE].each do |es|
@@ -470,6 +471,7 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_inspect_under_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       assert_equal('/(?-mix:\\/)|/', Regexp.union(/\//, "").inspect)
     end
@@ -891,6 +893,7 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_match_under_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       m = /(?<foo>.)(?<n>[^aeiou])?(?<bar>.+)/.match("hoge\u3042")
       assert_equal("h", m.match(:foo))

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -909,6 +909,7 @@ CODE
   end
 
   def test_undump_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     a = S("Test") << 1 << 2 << 3 << 9 << 13 << 10
     EnvUtil.under_gc_compact_stress do
       assert_equal(a, S('"Test\\x01\\x02\\x03\\t\\r\\n"').undump)
@@ -1284,6 +1285,7 @@ CODE
   end
 
   def test_gsub_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress { assert_equal(S("h<e>ll<o>"), S("hello").gsub(/([aeiou])/, S('<\1>'))) }
   end
 
@@ -1331,6 +1333,7 @@ CODE
   end
 
   def test_gsub_bang_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       a = S("hello")
       a.gsub!(/([aeiou])/, S('<\1>'))
@@ -1672,6 +1675,7 @@ CODE
   end
 
   def test_scan_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress { assert_equal([["1a"], ["2b"], ["3c"]], S("1a2b3c").scan(/(\d.)/)) }
   end
 
@@ -2103,6 +2107,7 @@ CODE
   end
 
   def test_sub_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       m = /&(?<foo>.*?);/.match(S("aaa &amp; yyy"))
       assert_equal("amp", m["foo"])

--- a/test/ruby/test_symbol.rb
+++ b/test/ruby/test_symbol.rb
@@ -119,6 +119,7 @@ class TestSymbol < Test::Unit::TestCase
   end
 
   def test_inspect_under_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       assert_inspect_evaled(':testing')
     end

--- a/test/ruby/test_weakkeymap.rb
+++ b/test/ruby/test_weakkeymap.rb
@@ -124,6 +124,7 @@ class TestWeakKeyMap < Test::Unit::TestCase
   end
 
   def test_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress { ObjectSpace::WeakKeyMap.new }
   end
 

--- a/test/ruby/test_weakmap.rb
+++ b/test/ruby/test_weakmap.rb
@@ -238,6 +238,7 @@ class TestWeakMap < Test::Unit::TestCase
   end
 
   def test_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress { ObjectSpace::WeakMap.new }
   end
 

--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -251,6 +251,7 @@ module EnvUtil
   module_function :under_gc_stress
 
   def under_gc_compact_stress(val = :empty, &block)
+    raise "compaction doesn't work well on s390x. Omit the test in the caller." if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     auto_compact = GC.auto_compact
     GC.auto_compact = val
     under_gc_stress(&block)


### PR DESCRIPTION
It crashes like https://rubyci.s3.amazonaws.com/s390x/ruby-master/log/20240222T130005Z.fail.html.gz on RubyCI s390x very frequently. Travis s390x also fails very often (with no crash report), and I suspect it's also due to compaction crashes. 

We skip compaction tests on s390x https://github.com/ruby/ruby/pull/5077. Similarly, every `EnvUtil.under_gc_compact_stress` usage should be skipped on s390x.