### PR TITLE
Fallback every macos-arm-oss usage to macos-14

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,8 +39,7 @@ jobs:
       security-events: write # for github/codeql-action/autobuild to send a status report
     # CodeQL fails to run pull requests from dependabot due to missing write access to upload results.
     if: >-
-      ${{github.repository == 'ruby/ruby' &&
-      !(false
+      ${{!(false
       || contains(github.event.head_commit.message, '[DOC]')
       || contains(github.event.pull_request.title, '[DOC]')
       || contains(github.event.pull_request.labels.*.name, 'Documentation')
@@ -58,14 +57,14 @@ jobs:
             os: ubuntu-latest
           # ruby analysis used large memory. We need to use a larger runner.
           - language: ruby
-            os: macos-arm-oss
+            os: ${{ github.repository == 'ruby/ruby' && 'macos-arm-oss' || 'macos-14' }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Install libraries
-        if: ${{ matrix.os == 'macos-arm-oss' }}
+        if: ${{ contains(matrix.os, 'macos') }}
         uses: ./.github/actions/setup/macos
 
       - name: Install libraries

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -25,12 +25,15 @@ jobs:
     strategy:
       matrix:
         test_task: ['check']
-        os: ${{ fromJSON(format('["macos-12","macos-13"{0}]', (github.repository == 'ruby/ruby' && ',"macos-arm-oss"' || ''))) }}
+        os:
+          - macos-12
+          - macos-13
+          - ${{ github.repository == 'ruby/ruby' && 'macos-arm-oss' || 'macos-14' }}
         include:
           - test_task: test-all TESTS=--repeat-count=2
-            os: ${{ github.repository == 'ruby/ruby' && 'macos-arm-oss' || 'macos-13' }}
+            os: ${{ github.repository == 'ruby/ruby' && 'macos-arm-oss' || 'macos-14' }}
           - test_task: test-bundled-gems
-            os: ${{ github.repository == 'ruby/ruby' && 'macos-arm-oss' || 'macos-13' }}
+            os: ${{ github.repository == 'ruby/ruby' && 'macos-arm-oss' || 'macos-14' }}
       fail-fast: false
 
     env:

--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -24,11 +24,10 @@ jobs:
   cargo:
     name: cargo test
 
-    runs-on: macos-arm-oss
+    runs-on: ${{ github.repository == 'ruby/ruby' && 'macos-arm-oss' || 'macos-14' }}
 
     if: >-
-      ${{github.repository == 'ruby/ruby' &&
-      !(false
+      ${{!(false
       || contains(github.event.head_commit.message, '[DOC]')
       || contains(github.event.pull_request.title, '[DOC]')
       || contains(github.event.pull_request.labels.*.name, 'Documentation')


### PR DESCRIPTION
Now that [we have a publicly-available M1 macOS runner](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/), `macos-14`, we no longer need to skip the jobs using `macos-arm-oss` when `github.repository == 'ruby/ruby'`. `macos-arm-oss` is a larger runner, so we should still use it on ruby/ruby, and use `macos-14` otherwise.

### Note

* `macos-12` (`macos-latest`): 3 CPUs (Intel), 14GB RAM, darwin21 (Monterey)
* `macos-13`: 3 CPUs (Intel), 14GB RAM, darwin22 (Ventura)
* `macos-13-xlarge` (`macos-arm-oss`): 6 CPUs (M1), 14GB RAM, darwin22 (Ventura)
* `macos-14`: 3 CPUs (M1), 7GB RAM, darwin23 (Sonoma)

### References

* [Standard GitHub-hosted runners for Public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
* [macOS large runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners#about-macos-larger-runners)