### PR TITLE
Fix -Wmaybe-uninitialized on Complex#**

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -1065,6 +1065,8 @@ complex_pow_for_special_angle(VALUE self, VALUE other)
     else if (f_eqeq_p(dat->real, f_negate(dat->imag))) {
         x = dat->imag;
         dir = 3;
+    } else {
+        dir = 0;
     }
 
     if (UNDEF_P(x)) return x;


### PR DESCRIPTION
http://ci.rvm.jp/results/trunk-asserts-nopara@ruby-sp2-docker/4960977

```
/tmp/ruby/src/trunk-asserts-nopara/complex.c: In function 'complex_pow_for_special_angle':
--
  | /tmp/ruby/src/trunk-asserts-nopara/complex.c:1074:13: warning: 'dir' may be used uninitialized in this function [-Wmaybe-uninitialized]
  | 1074 \|         dir += 4;
  | \|         ~~~~^~~~
```

ref: https://github.com/ruby/ruby/pull/8931