### PR TITLE
[Bug #20295] Fix SEGV when parsing invalid regexp

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -13017,10 +13017,12 @@ match_op(struct parser_params *p, NODE *node1, NODE *node2, const YYLTYPE *op_lo
           case NODE_REGX:
             {
                 const VALUE lit = rb_node_regx_string_val(n);
-                NODE *match = NEW_MATCH2(node1, node2, loc);
-                RNODE_MATCH2(match)->nd_args = reg_named_capture_assign(p, lit, loc);
-                nd_set_line(match, line);
-                return match;
+                if (!NIL_P(lit)) {
+                    NODE *match = NEW_MATCH2(node1, node2, loc);
+                    RNODE_MATCH2(match)->nd_args = reg_named_capture_assign(p, lit, loc);
+                    nd_set_line(match, line);
+                    return match;
+                }
             }
         }
     }

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1034,6 +1034,14 @@ eom
     assert_not_match(/end-of-input/, e.message)
   end
 
+  def test_invalid_regexp
+    bug20295 = '[ruby-core:116913] [Bug #20295]'
+
+    assert_syntax_error("/[/=~s", /premature end of char-class/, bug20295)
+    assert_syntax_error("/(?<>)/=~s", /group name is empty/, bug20295)
+    assert_syntax_error("/(?<a>[)/=~s", /premature end of char-class/, bug20295)
+  end
+
   def test_lineno_operation_brace_block
     expected = __LINE__ + 1
     actual = caller_lineno\


### PR DESCRIPTION
Fix https://bugs.ruby-lang.org/issues/20295