### PR TITLE
Remove ruby objects from numeric node comparison

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -872,7 +872,7 @@ static VALUE
 rational_value(const char *node_val, int base, int seen_point)
 {
     VALUE lit;
-    char* val = strdup(node_val);
+    char *val = strdup(node_val);
     if (seen_point > 0) {
         int len = (int)(strlen(val));
         char *point = &val[seen_point];

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -11,6 +11,7 @@
 
 #define rb_encoding void
 #define OnigCodePoint unsigned int
+#define st_data_t parser_st_data_t
 #include "parser_st.h"
 #ifndef RUBY_RUBY_H
 #include "parser_value.h"
@@ -53,6 +54,10 @@ typedef struct rb_parser_string {
     /* Pointer to the contents of the string. */
     char *ptr;
 } rb_parser_string_t;
+
+typedef void free_func_t(void *ptr);
+typedef struct rb_parser_bignum rb_parser_bignum_t;
+void rb_parser_bigfree(free_func_t *func, rb_parser_bignum_t *big);
 
 /*
  * AST Node
@@ -195,6 +200,16 @@ typedef struct RNode {
     rb_code_location_t nd_loc;
     int node_id;
 } NODE;
+
+typedef void rb_node_hash_data;
+
+typedef struct RNode_hash_data {
+    st_data_t hash;
+    union {
+        rb_node_hash_data *ptr;
+        double d;
+    } data;
+} rb_node_hash_data_t;
 
 typedef struct RNode_SCOPE {
     NODE node;
@@ -645,7 +660,8 @@ typedef struct RNode_LIT {
 typedef struct RNode_INTEGER {
     NODE node;
 
-    char* val;
+    struct RNode_hash_data hash;
+    char *val;
     int minus;
     int base;
 } rb_node_integer_t;
@@ -653,14 +669,16 @@ typedef struct RNode_INTEGER {
 typedef struct RNode_FLOAT {
     NODE node;
 
-    char* val;
+    struct RNode_hash_data hash;
+    char *val;
     int minus;
 } rb_node_float_t;
 
 typedef struct RNode_RATIONAL {
     NODE node;
 
-    char* val;
+    struct RNode_hash_data hash;
+    char *val;
     int minus;
     int base;
     int seen_point;
@@ -675,7 +693,8 @@ enum rb_numeric_type {
 typedef struct RNode_IMAGINARY {
     NODE node;
 
-    char* val;
+    struct RNode_hash_data hash;
+    char *val;
     int minus;
     int base;
     int seen_point;
@@ -1014,6 +1033,8 @@ typedef struct RNode_FNDPTN {
 
 typedef struct RNode_LINE {
     NODE node;
+
+    struct RNode_hash_data hash;
 } rb_node_line_t;
 
 typedef struct RNode_FILE {

--- a/test/ruby/test_literal.rb
+++ b/test/ruby/test_literal.rb
@@ -508,6 +508,48 @@ class TestRubyLiteral < Test::Unit::TestCase
       assert_warning(/key #{Regexp.quote(eval(key).inspect)} is duplicated/) { eval("{#{key} => :bar, #{key} => :foo}") }
     end
 
+    # Integer
+    assert_warning(/key 1 is duplicated/) { eval("{1 => :bar, 0x1 => :foo}") }
+    assert_warning(/key 1 is duplicated/) { eval("{1 => :bar, 0b1 => :foo}") }
+    assert_warning(/key 1 is duplicated/) { eval("{1 => :bar, 0d1 => :foo}") }
+    assert_warning(/key 1 is duplicated/) { eval("{1 => :bar, 0o1 => :foo}") }
+    assert_warning(/key -1 is duplicated/) { eval("{-1 => :bar, -0x1 => :foo}") }
+    assert_warning(/key -1 is duplicated/) { eval("{-1 => :bar, -0b1 => :foo}") }
+    assert_warning(/key -1 is duplicated/) { eval("{-1 => :bar, -0d1 => :foo}") }
+    assert_warning(/key -1 is duplicated/) { eval("{-1 => :bar, -0o1 => :foo}") }
+    assert_warning("") { eval("{-1 => :bar,   1 => :foo}") }
+    assert_warning("") { eval("{-1 => :bar, 0x1 => :foo}") }
+    assert_warning("") { eval("{-1 => :bar, 0b1 => :foo}") }
+    assert_warning("") { eval("{-1 => :bar, 0d1 => :foo}") }
+    assert_warning("") { eval("{-1 => :bar, 0o1 => :foo}") }
+
+    # Float
+    assert_warning(/key 1234\.5 is duplicated/) { eval("{ 12.345e2 => :bar, 123.45e1 => :foo}") }
+    assert_warning(/key -1234\.5 is duplicated/) { eval("{ -12.345e2 => :bar, -123.45e1 => :foo}") }
+    assert_warning("") { eval("{ 12.345e2 => :bar, -123.45e1 => :foo}") }
+
+    # Rational
+    assert_warning(/key \(101\/100\) is duplicated/) { eval("{1.01r => :bar, 1.010r => :foo}") }
+    assert_warning(/key \(1\/1\) is duplicated/) { eval("{1.00r => :bar, 1.0r => :foo}") }
+    assert_warning(/key \(1\/1\) is duplicated/) { eval("{1.0r => :bar, 1r => :foo}") }
+    assert_warning(/key \(-101\/100\) is duplicated/) { eval("{-1.01r => :bar, -1.010r => :foo}") }
+    assert_warning(/key \(-1\/1\) is duplicated/) { eval("{-1.00r => :bar, -1.0r => :foo}") }
+    assert_warning(/key \(-1\/1\) is duplicated/) { eval("{-1.0r => :bar, -1r => :foo}") }
+    assert_warning("") { eval("{1.01r => :bar, -1.010r => :foo}") }
+    assert_warning("") { eval("{1.00r => :bar, -1.0r => :foo}") }
+    assert_warning("") { eval("{1.0r => :bar, -1r => :foo}") }
+
+    # Imaginary
+    assert_warning(/key \(0\+1i\) is duplicated/) { eval("{1i => :bar, 0x1i => :foo}") }
+    assert_warning(/key \(0\+1\.01i\) is duplicated/) { eval("{1.01i => :bar, 1.010i => :foo}") }
+    assert_warning(/key \(0\+\(101\/100\)\*i\) is duplicated/) { eval("{1.01ri => :bar, 1.010ri => :foo}") }
+    assert_warning(/key \(0-1i\) is duplicated/) { eval("{-1i => :bar, -0x1i => :foo}") }
+    assert_warning(/key \(0-1\.01i\) is duplicated/) { eval("{-1.01i => :bar, -1.010i => :foo}") }
+    assert_warning(/key \(0-\(101\/100\)\*i\) is duplicated/) { eval("{-1.01ri => :bar, -1.010ri => :foo}") }
+    assert_warning("") { eval("{1i => :bar, -0x1i => :foo}") }
+    assert_warning("") { eval("{1.01i => :bar, -1.010i => :foo}") }
+    assert_warning("") { eval("{1.01ri => :bar, -1.010ri => :foo}") }
+
     assert_warning(/key 1 is duplicated/) { eval("{__LINE__ => :bar, 1 => :foo}") }
     assert_warning(/key \"FILENAME\" is duplicated/) { eval("{__FILE__ => :bar, 'FILENAME' => :foo}", binding, "FILENAME") }
   end


### PR DESCRIPTION
Parser needs to compare nodes to warn duplicate keys in a hash, for example:

```
{1 => :a, 1 => :b}
# => test.rb:1: warning: key 1 is duplicated and overwritten on line 1
```

This commit stop using ruby objects for hash value calculation and node comparison.
Bignum is needed when comparing different radix numeric nodes.