### PR TITLE
Stop using rb_str_locktmp_ensure publicly

### DIFF
--- a/ext/socket/init.c
+++ b/ext/socket/init.c
@@ -204,7 +204,8 @@ rsock_s_recvfrom(VALUE socket, int argc, VALUE *argv, enum sock_recv_type from)
         rb_io_wait(fptr->self, RB_INT2NUM(RUBY_IO_READABLE), Qnil);
 #endif
 
-        slen = (long)rb_str_locktmp_ensure(str, recvfrom_locktmp, (VALUE)&arg);
+        rb_str_locktmp(str);
+        slen = (long)rb_ensure(recvfrom_locktmp, (VALUE)&arg, rb_str_unlocktmp, str);
 
         if (slen == 0 && !rsock_is_dgram(fptr)) {
             return Qnil;

--- a/string.c
+++ b/string.c
@@ -3098,7 +3098,7 @@ rb_str_unlocktmp(VALUE str)
     return str;
 }
 
-RUBY_FUNC_EXPORTED VALUE
+VALUE
 rb_str_locktmp_ensure(VALUE str, VALUE (*func)(VALUE), VALUE arg)
 {
     rb_str_locktmp(str);


### PR DESCRIPTION
rb_str_locktmp_ensure is a private API.