### PR TITLE
Expand Launchable into ubuntu workflow

### DIFF
--- a/.github/actions/launchable/record-test/action.yml
+++ b/.github/actions/launchable/record-test/action.yml
@@ -1,0 +1,33 @@
+name: Record tests in Launchable
+description: >-
+  Upload the test results to Launchable
+
+inputs:
+  os:
+    required: true
+    description: An operating system that CI runs on. This value is used in Launchable flavor.
+
+  report-path:
+    default: launchable_reports.json
+    required: true
+    description: A file path of the test report for uploading to Launchable
+
+  test-opts:
+    default: none
+    required: false
+    description: >-
+      Test options that determine how tests are run.
+      This value is used in the Launchable flavor.
+
+outputs: {} # nothing?
+
+runs:
+  using: composite
+
+  steps:
+    - name: Launchable - record tests
+      working-directory: ${{ inputs.builddir }}
+      shell: bash
+      run: |
+        test_opts="$(echo ${{ inputs.test-opts }} | sed 's/=/:/g' | sed 's/ //g')"
+        launchable record tests --flavor os=${{ inputs.os }} --flavor test_task=${{ matrix.test_task }} --flavor test_opts=${test_opts} raw ${{ inputs.report-path }}

--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -1,0 +1,84 @@
+name: Set up Launchable
+description: >-
+  Install the required dependencies and execute the necessary Launchable commands for test recording
+
+inputs:
+  report-path:
+    default: launchable_reports.json
+    required: true
+    description: The file path of the test report for uploading to Launchable
+
+  launchable-token:
+    required: false
+    description: >-
+      Launchable token is needed if you want to run Launchable on your forked repository.
+      See https://github.com/ruby/ruby/wiki/CI-Servers#launchable-ci for details.
+
+outputs:
+  enable-launchable:
+    description: "The boolean value indicating whether Launchable is enabled or not"
+    value: ${{ steps.enable-launchable.outputs.enable-launchable }}
+
+runs:
+  using: composite
+
+  steps:
+    - name: Enable Launchable conditionally
+      id: enable-launchable
+      run: echo "enable-launchable=true" >> $GITHUB_OUTPUT
+      shell: bash
+      if: >-
+        ${{
+        (github.repository == 'ruby/ruby' ||
+        (github.repository != 'ruby/ruby' && env.LAUNCHABLE_TOKEN)) &&
+        (matrix.test_task == 'check' || matrix.test_task == 'test-all')
+        }}
+
+    # Launchable CLI requires Python and Java.
+    # https://www.launchableinc.com/docs/resources/cli-reference/
+    - name: Set up Python
+      uses: actions/setup-python@871daa956ca9ea99f3c3e30acb424b7960676734 # v5.0.0
+      with:
+        python-version: "3.x"
+      if: steps.enable-launchable.outputs.enable-launchable
+
+    - name: Set up Java
+      uses: actions/setup-java@7a445ee88d4e23b52c33fdc7601e40278616c7f8 # v4.0.0
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+      if: steps.enable-launchable.outputs.enable-launchable
+
+    - name: Set environment variables for Launchable
+      shell: bash
+      run: |
+        : # GITHUB_PULL_REQUEST_URL are used for commenting test reports in Launchable Github App.
+        : # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/link.py#L42
+        echo "GITHUB_PULL_REQUEST_URL=${{ github.event.pull_request.html_url }}" >> $GITHUB_ENV
+        : # The following envs are necessary in Launchable tokenless authentication.
+        : # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/authentication.py#L20
+        echo "LAUNCHABLE_ORGANIZATION=${{ github.repository_owner }}" >> $GITHUB_ENV
+        echo "LAUNCHABLE_WORKSPACE=${{ github.event.repository.name }}" >> $GITHUB_ENV
+        : # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/authentication.py#L71
+        echo "GITHUB_PR_HEAD_SHA=${{ github.event.pull_request.head.sha || github.sha }}" >> $GITHUB_ENV
+        echo "LAUNCHABLE_TOKEN=${{ inputs.launchable-token }}" >> $GITHUB_ENV
+      if: steps.enable-launchable.outputs.enable-launchable
+
+    - name: Set up Launchable
+      shell: bash
+      run: |
+        set -x
+        PATH=$PATH:$(python -msite --user-base)/bin
+        echo "PATH=$PATH" >> $GITHUB_ENV
+        pip install --user launchable
+        launchable verify
+        : # The build name cannot include a slash, so we replace the string here.
+        github_ref="$(echo ${{ github.ref }} | sed 's/\//_/g')"
+        : # With the --name option, we need to configure a unique identifier for this build.
+        : # To avoid setting the same build name as the CI which runs on other branches, we use the branch name here.
+        : #
+        : # FIXME: Need to fix `WARNING: Failed to process a change to a file`.
+        : # https://github.com/launchableinc/cli/issues/786
+        launchable record build --name ${github_ref}_${GITHUB_PR_HEAD_SHA}
+        echo "TESTS=${TESTS} --launchable-test-reports=${{ inputs.report-path }}" >> $GITHUB_ENV
+      if: steps.enable-launchable.outputs.enable-launchable

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,21 +13,6 @@ on:
     # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
   merge_group:
 
-env:
-  # GITHUB_PULL_REQUEST_URL are used for commenting test reports in Launchable Github App.
-  # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/link.py#L42
-  GITHUB_PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
-  # The following envs are necessary in Launchable tokenless authentication.
-  # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/authentication.py#L20
-  LAUNCHABLE_ORGANIZATION: ${{ github.repository_owner }}
-  LAUNCHABLE_WORKSPACE: ${{ github.event.repository.name }}
-  # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/authentication.py#L71
-  GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-  # This secret setting is needed if you want to run Launchable on your forked
-  # repository.
-  # See https://github.com/ruby/ruby/wiki/CI-Servers#launchable-ci for details.
-  LAUNCHABLE_TOKEN: ${{ secrets.LAUNCHABLE_TOKEN }}
-
 concurrency:
   group: ${{ github.workflow }} / ${{ startsWith(github.event_name, 'pull') && github.ref_name || github.sha }}
   cancel-in-progress: ${{ startsWith(github.event_name, 'pull') }}
@@ -67,17 +52,6 @@ jobs:
       )}}
 
     steps:
-      - name: Enable Launchable conditionally
-        id: enable_launchable
-        run: echo "enable_launchable=true" >> $GITHUB_OUTPUT
-        working-directory:
-        if: >-
-          ${{
-          (github.repository == 'ruby/ruby' ||
-          (github.repository != 'ruby/ruby' && env.LAUNCHABLE_TOKEN)) &&
-          (matrix.test_task == 'check' || matrix.test_task == 'test-all')
-          }}
-
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           sparse-checkout-cone-mode: false
@@ -110,38 +84,11 @@ jobs:
           echo "TESTS=${TESTS}" >> $GITHUB_ENV
         if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
 
-      # Launchable CLI requires Python and Java
-      # https://www.launchableinc.com/docs/resources/cli-reference/
-      - name: Set up Python
-        uses: actions/setup-python@871daa956ca9ea99f3c3e30acb424b7960676734 # v5.0.0
-        with:
-          python-version: "3.x"
-        if: steps.enable_launchable.outputs.enable_launchable
-
-      - name: Set up Java
-        uses: actions/setup-java@7a445ee88d4e23b52c33fdc7601e40278616c7f8 # v4.0.0
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-        if: steps.enable_launchable.outputs.enable_launchable
-
       - name: Set up Launchable
-        run: |
-          set -x
-          PATH=$PATH:$(python -msite --user-base)/bin
-          echo "PATH=$PATH" >> $GITHUB_ENV
-          pip install --user launchable
-          launchable verify
-          : # The build name cannot include a slash, so we replace the string here.
-          github_ref="$(echo ${{ github.ref }} | sed 's/\//_/g')"
-          : # With the --name option, we need to configure a unique identifier for this build.
-          : # To avoid setting the same build name as the CI which runs on other branches, we use the branch name here.
-          : #
-          : # FIXME: Need to fix `WARNING: Failed to process a change to a file`.
-          : # https://github.com/launchableinc/cli/issues/786
-          launchable record build --name ${github_ref}_${GITHUB_PR_HEAD_SHA}
-          echo "TESTS=${TESTS} --launchable-test-reports=launchable_reports.json" >> $GITHUB_ENV
-        if: steps.enable_launchable.outputs.enable_launchable
+        id: enable-launchable
+        uses: ./.github/actions/launchable/setup
+        with:
+          launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
 
       - name: Set extra test options
         run: echo "TESTS=$TESTS ${{ matrix.test_opts }}" >> $GITHUB_ENV
@@ -166,9 +113,15 @@ jobs:
         if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
         continue-on-error: ${{ matrix.continue-on-skipped_tests || false }}
 
-      - name: Launchable - record tests
-        run: launchable record tests --flavor os=${{ matrix.os }} --flavor test_task=${{ matrix.test_task }} raw launchable_reports.json
-        if: ${{ always() && steps.enable_launchable.outputs.enable_launchable }}
+      - name: Record test results in Launchable
+        uses: ./.github/actions/launchable/record-test
+        with:
+          # We need to configure the `build` directory because
+          # this composite action is executed in the default working directory.
+          report-path: build/launchable_reports.json
+          os: ${{ matrix.os }}
+          test-opts: ${{ matrix.test_opts }}
+        if: ${{ always() && steps.enable-launchable.outputs.enable-launchable }}
 
       - uses: ./.github/actions/slack
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -95,6 +95,12 @@ jobs:
           echo "TESTS=${TESTS}" >> $GITHUB_ENV
         if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
 
+      - name: Set up Launchable
+        id: enable-launchable
+        uses: ./.github/actions/launchable/setup
+        with:
+          launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
+
       - name: make ${{ matrix.test_task }}
         run: >-
           $SETARCH make -s ${{ matrix.test_task }}
@@ -114,6 +120,16 @@ jobs:
           RUBY_TESTOPTS: '-v --tty=no'
         if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
         continue-on-error: ${{ matrix.continue-on-skipped_tests || false }}
+
+      - name: Record test results in Launchable
+        uses: ./.github/actions/launchable/record-test
+        with:
+          # We need to configure the `build` directory because
+          # this composite action is executed in the default working directory.
+          report-path: build/launchable_reports.json
+          os: ubuntu-20.04
+          test-opts: ${{ matrix.configure }}
+        if: ${{ always() && steps.enable-launchable.outputs.enable-launchable }}
 
       - uses: ./.github/actions/slack
         with:


### PR DESCRIPTION
Follow-up to https://github.com/ruby/ruby/pull/9777

Since the integration of Launchable into the macOS workflow has been completed in the previous PR, this PR extends the integration to the Ubuntu workflow as well. Along with this integration, I've also refactored some logic.
