### PR TITLE
Skip assert_no_memory_leak when ASAN is enabled

### DIFF
--- a/ext/-test-/asan/asan.c
+++ b/ext/-test-/asan/asan.c
@@ -1,0 +1,24 @@
+#include "ruby/ruby.h"
+
+static VALUE
+asan_enabled_p(VALUE self)
+{
+#if defined(__has_feature)
+    /* clang uses __has_feature for determining asan */
+    return __has_feature(address_sanitizer) ? Qtrue : Qfalse;
+#elif defined(__SANITIZE_ADDRESS__)
+    /* GCC sets __SANITIZE_ADDRESS__ for determining asan */
+    return Qtrue;
+#else
+    return Qfalse;
+#endif
+}
+
+void
+Init_asan(void)
+{
+    VALUE m = rb_define_module("Test");
+    VALUE c = rb_define_class_under(m, "ASAN", rb_cObject);
+    rb_define_singleton_method(c, "enabled?", asan_enabled_p, 0);
+}
+

--- a/ext/-test-/asan/extconf.rb
+++ b/ext/-test-/asan/extconf.rb
@@ -1,0 +1,2 @@
+require 'mkmf'
+create_makefile('-test-/asan')

--- a/tool/lib/core_assertions.rb
+++ b/tool/lib/core_assertions.rb
@@ -74,6 +74,11 @@ module Test
     module CoreAssertions
       require_relative 'envutil'
       require 'pp'
+      begin
+        require '-test-/asan'
+      rescue LoadError
+      end
+
       nil.pretty_inspect
 
       def mu_pp(obj) #:nodoc:
@@ -152,6 +157,9 @@ module Test
         pend 'assert_no_memory_leak may consider RJIT memory usage as leak' if defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled?
         # For previous versions which implemented MJIT
         pend 'assert_no_memory_leak may consider MJIT memory usage as leak' if defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
+        # ASAN has the same problem - its shadow memory greatly increases memory usage
+        # (plus asan has better ways to detect memory leaks than this assertion)
+        pend 'assert_no_memory_leak may consider ASAN memory usage as leak' if defined?(Test::ASAN) && Test::ASAN.enabled?
 
         require_relative 'memory_status'
         raise Test::Unit::PendedError, "unsupported platform" unless defined?(Memory::Status)


### PR DESCRIPTION
ASAN greatly increases the memory footprint of Ruby, so these static thresholds are not appropriate. There's no real need to run these tests under ASAN.

[Bug #20274]