### PR TITLE
Launchable: Fix the warning of pip

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@871daa956ca9ea99f3c3e30acb424b7960676734 # v5.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.x"
         if: steps.enable_launchable.outputs.enable_launchable
 
       - name: Set up Java
@@ -128,7 +128,9 @@ jobs:
       - name: Set up Launchable
         run: |
           set -x
-          pip install launchable
+          PATH=$PATH:$(python -msite --user-base)/bin
+          echo "PATH=$PATH" >> $GITHUB_ENV
+          pip install --user launchable
           launchable verify
           : # The build name cannot include a slash, so we replace the string here.
           github_ref="$(echo ${{ github.ref }} | sed 's/\//_/g')"


### PR DESCRIPTION
@nobu pointed out that the following warning is being output during the step that utilizes `actions/setup-python`. By updating the Python version from 3.10 to the latest version, we can resolve this warning. Additionally, Launchable [supports the latest version](https://www.launchableinc.com/docs/resources/cli-reference/). This update should not cause any problems.

```
[notice] A new release of pip is available: 23.0.1 -> 24.0
[notice] To update, run: python3.10 -m pip install --upgrade pip
```

https://github.com/ruby/ruby/actions/runs/8029119718/job/21935044360#step:10:66
