### PR TITLE
Suppress a warning in `launchable record build` command

### DIFF
--- a/.github/actions/setup/directories/action.yml
+++ b/.github/actions/setup/directories/action.yml
@@ -44,6 +44,16 @@ inputs:
     description: >-
       If set to true, creates dummy files in build dir.
 
+  fetch-depth:
+    required: false
+    default: ''
+    description: The number of commits from the tip of the repository
+
+  filter:
+    required: false
+    default: ''
+    description: The number of commits from the tip of the repository
+
 outputs: {} # nothing?
 
 runs:
@@ -79,6 +89,8 @@ runs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: ${{ inputs.srcdir }}
+        fetch-depth: ${{ inputs.fetch-depth }}
+        filter: ${{ inputs.filter }}
 
     - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -58,6 +58,9 @@ jobs:
           sparse-checkout: /.github
           # Set fetch-depth: 0 so that Launchable can receive commits information.
           fetch-depth: 0
+          # When using sparse-checkout, Launchable issues a warning. To suppress it, set `filter: null`.
+          # https://www.launchableinc.com/docs/resources/troubleshooting/
+          filter: null
 
       - name: Install libraries
         uses: ./.github/actions/setup/macos
@@ -68,6 +71,8 @@ jobs:
           builddir: build
           makeup: true
           dummy-files: ${{ matrix.test_task == 'check' }}
+          fetch-depth: 10
+          filter: null
 
       - name: Run configure
         run: ../src/configure -C --disable-install-doc

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -58,6 +58,9 @@ jobs:
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: /.github
+          # When using sparse-checkout, Launchable issues a warning. To suppress it, set `filter: null`.
+          # https://www.launchableinc.com/docs/resources/troubleshooting/
+          filter: null
 
       - uses: ./.github/actions/setup/ubuntu
         with:
@@ -69,6 +72,8 @@ jobs:
           builddir: build
           makeup: true
           dummy-files: ${{ matrix.test_task == 'check' }}
+          fetch-depth: 10
+          filter: null
 
       - uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # v1.172.0
         with:


### PR DESCRIPTION
When executing the `launchable record build` command, a warning is issued, as shown here: [link to the warning](https://github.com/ruby/ruby/actions/runs/8029119718/job/21935044266#step:10:179). To suppress it, set `filter: null`. For more information, please refer to the [Launchable troubleshooting documentation](https://www.launchableinc.com/docs/resources/troubleshooting/).
