### PR TITLE
Fix compilation for platforms without pthread

### DIFF
--- a/ext/-test-/thread/lock_native_thread/lock_native_thread.c
+++ b/ext/-test-/thread/lock_native_thread/lock_native_thread.c
@@ -42,6 +42,7 @@ Init_lock_native_thread(void)
 }
 
 #else // HAVE_PTHREAD_H
+void
 Init_lock_native_thread(void)
 {
     // do nothing


### PR DESCRIPTION
Found when compiling ruby for windows-arm64 using msys2

Missing return type for function Init_lock_native_thread

```
lock_native_thread.c:45:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
   45 | Init_lock_native_thread(void)
      | ^
      | int
```