### PR TITLE
Resolve a warning in `launchable record build` command

### DIFF
--- a/.github/actions/launchable/record-test/action.yml
+++ b/.github/actions/launchable/record-test/action.yml
@@ -19,6 +19,13 @@ inputs:
       Test options that determine how tests are run.
       This value is used in the Launchable flavor.
 
+  srcdir:
+    required: false
+    default: ${{ github.workspace }}
+    description: >-
+      Directory to (re-)checkout source codes. Launchable retrives the commit information
+      from the directory.
+
 outputs: {} # nothing?
 
 runs:
@@ -26,7 +33,7 @@ runs:
 
   steps:
     - name: Launchable - record tests
-      working-directory: ${{ inputs.builddir }}
+      working-directory: ${{ inputs.srcdir }}
       shell: bash
       run: |
         test_opts="$(echo ${{ inputs.test-opts }} | sed 's/=/:/g' | sed 's/ //g')"

--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -14,6 +14,13 @@ inputs:
       Launchable token is needed if you want to run Launchable on your forked repository.
       See https://github.com/ruby/ruby/wiki/CI-Servers#launchable-ci for details.
 
+  srcdir:
+    required: false
+    default: ${{ github.workspace }}
+    description: >-
+      Directory to (re-)checkout source codes. Launchable retrives the commit information
+      from the directory.
+
 outputs:
   enable-launchable:
     description: "The boolean value indicating whether Launchable is enabled or not"
@@ -66,6 +73,7 @@ runs:
 
     - name: Set up Launchable
       shell: bash
+      working-directory: ${{ inputs.srcdir }}
       run: |
         set -x
         PATH=$PATH:$(python -msite --user-base)/bin

--- a/.github/actions/setup/directories/action.yml
+++ b/.github/actions/setup/directories/action.yml
@@ -44,6 +44,11 @@ inputs:
     description: >-
       If set to true, creates dummy files in build dir.
 
+  fetch-depth:
+    required: false
+    default: '1'
+    description: The depth of commit history fetched from the remote repository
+
 outputs: {} # nothing?
 
 runs:
@@ -79,6 +84,7 @@ runs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: ${{ inputs.srcdir }}
+        fetch-depth: ${{ inputs.fetch-depth }}
 
     - uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -56,8 +56,6 @@ jobs:
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: /.github
-          # Set fetch-depth: 0 so that Launchable can receive commits information.
-          fetch-depth: 0
 
       - name: Install libraries
         uses: ./.github/actions/setup/macos
@@ -68,6 +66,8 @@ jobs:
           builddir: build
           makeup: true
           dummy-files: ${{ matrix.test_task == 'check' }}
+          # Set fetch-depth: 0 so that Launchable can receive commits information.
+          fetch-depth: 10
 
       - name: Run configure
         run: ../src/configure -C --disable-install-doc
@@ -89,6 +89,7 @@ jobs:
         uses: ./.github/actions/launchable/setup
         with:
           launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
+          srcdir: src
 
       - name: Set extra test options
         run: echo "TESTS=$TESTS ${{ matrix.test_opts }}" >> $GITHUB_ENV
@@ -118,9 +119,10 @@ jobs:
         with:
           # We need to configure the `build` directory because
           # this composite action is executed in the default working directory.
-          report-path: build/launchable_reports.json
+          report-path: ../build/launchable_reports.json
           os: ${{ matrix.os }}
           test-opts: ${{ matrix.test_opts }}
+          srcdir: src
         if: ${{ always() && steps.enable-launchable.outputs.enable-launchable }}
 
       - uses: ./.github/actions/slack

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -69,6 +69,8 @@ jobs:
           builddir: build
           makeup: true
           dummy-files: ${{ matrix.test_task == 'check' }}
+          # Set fetch-depth: 10 so that Launchable can receive commits information.
+          fetch-depth: 10
 
       - uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # v1.172.0
         with:
@@ -100,6 +102,7 @@ jobs:
         uses: ./.github/actions/launchable/setup
         with:
           launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
+          srcdir: src
 
       - name: make ${{ matrix.test_task }}
         run: >-
@@ -126,9 +129,10 @@ jobs:
         with:
           # We need to configure the `build` directory because
           # this composite action is executed in the default working directory.
-          report-path: build/launchable_reports.json
+          report-path: ../build/launchable_reports.json
           os: ubuntu-20.04
           test-opts: ${{ matrix.configure }}
+          srcdir: src
         if: ${{ always() && steps.enable-launchable.outputs.enable-launchable }}
 
       - uses: ./.github/actions/slack


### PR DESCRIPTION
When executing the `launchable record build` command, a warning is issued, as shown here: [link to the warning](https://github.com/ruby/ruby/actions/runs/8029119718/job/21935044266#step:10:179). This warning occurs because Blob objects cannot be retrieved in the cloned repository when using sparse checkout, resulting in a "blob-less" clone. You can find more information about this behavior [here](https://github.com/actions/checkout/blob/b32f140b0c872d58512e0a66172253c302617b90/src/git-source-provider.ts#L166).

In the ruby/ruby repository, the source code is cloned into the `src/` directory without employing sparse checkout. Therefore, by executing the `launchable record build` command in the `src/` directory, we can resolve the warning.
