### PR TITLE
[Bug #20307] Fix `Hash#update` to make frozen copy of string keys

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3890,18 +3890,9 @@ rb_hash_invert(VALUE hash)
 }
 
 static int
-rb_hash_update_callback(st_data_t *key, st_data_t *value, struct update_arg *arg, int existing)
-{
-    *value = arg->arg;
-    return ST_CONTINUE;
-}
-
-NOINSERT_UPDATE_CALLBACK(rb_hash_update_callback)
-
-static int
 rb_hash_update_i(VALUE key, VALUE value, VALUE hash)
 {
-    RHASH_UPDATE(hash, key, rb_hash_update_callback, value);
+    rb_hash_aset(hash, key, value);
     return ST_CONTINUE;
 }
 
@@ -3912,6 +3903,9 @@ rb_hash_update_block_callback(st_data_t *key, st_data_t *value, struct update_ar
 
     if (existing) {
         newvalue = (st_data_t)rb_yield_values(3, (VALUE)*key, (VALUE)*value, (VALUE)newvalue);
+    }
+    else if (RHASH_STRING_KEY_P(arg->hash, *key) && !RB_OBJ_FROZEN(*key)) {
+        *key = rb_hash_key_str(*key);
     }
     *value = newvalue;
     return ST_CONTINUE;

--- a/hash.c
+++ b/hash.c
@@ -379,6 +379,7 @@ const struct st_hash_type rb_hashtype_ident = {
 };
 
 #define RHASH_IDENTHASH_P(hash) (RHASH_TYPE(hash) == &identhash)
+#define RHASH_STRING_KEY_P(hash, key) (!RHASH_IDENTHASH_P(hash) && (rb_obj_class(key) == rb_cString))
 
 typedef st_index_t st_hash_t;
 
@@ -2942,7 +2943,7 @@ rb_hash_aset(VALUE hash, VALUE key, VALUE val)
 
     rb_hash_modify(hash);
 
-    if (RHASH_IDENTHASH_P(hash) || rb_obj_class(key) != rb_cString) {
+    if (!RHASH_STRING_KEY_P(hash, key)) {
         RHASH_UPDATE_ITER(hash, iter_p, key, hash_aset, val);
     }
     else {

--- a/hash.c
+++ b/hash.c
@@ -378,6 +378,8 @@ const struct st_hash_type rb_hashtype_ident = {
     rb_ident_hash,
 };
 
+#define RHASH_IDENTHASH_P(hash) (RHASH_TYPE(hash) == &identhash)
+
 typedef st_index_t st_hash_t;
 
 /*
@@ -2940,7 +2942,7 @@ rb_hash_aset(VALUE hash, VALUE key, VALUE val)
 
     rb_hash_modify(hash);
 
-    if (RHASH_TYPE(hash) == &identhash || rb_obj_class(key) != rb_cString) {
+    if (RHASH_IDENTHASH_P(hash) || rb_obj_class(key) != rb_cString) {
         RHASH_UPDATE_ITER(hash, iter_p, key, hash_aset, val);
     }
     else {
@@ -4146,7 +4148,7 @@ rb_hash_assoc(VALUE hash, VALUE key)
 
     if (RHASH_EMPTY_P(hash)) return Qnil;
 
-    if (RHASH_ST_TABLE_P(hash) && RHASH_ST_TABLE(hash)->type != &identhash) {
+    if (RHASH_ST_TABLE_P(hash) && !RHASH_IDENTHASH_P(hash)) {
         VALUE value = Qundef;
         st_table assoctable = *RHASH_ST_TABLE(hash);
         assoctable.type = &(struct st_hash_type){
@@ -4423,7 +4425,7 @@ rb_hash_compare_by_id(VALUE hash)
 VALUE
 rb_hash_compare_by_id_p(VALUE hash)
 {
-    return RBOOL(RHASH_ST_TABLE_P(hash) && RHASH_ST_TABLE(hash)->type == &identhash);
+    return RBOOL(RHASH_IDENTHASH_P(hash));
 }
 
 VALUE

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1268,6 +1268,15 @@ class TestHash < Test::Unit::TestCase
     assert_equal(@cls[a: 10, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10], h)
   end
 
+  def test_update_on_identhash
+    key = +'a'
+    i = @cls[].compare_by_identity
+    i[key] = 0
+    h = @cls[].update(i)
+    key.upcase!
+    assert_equal(0, h.fetch('a'))
+  end
+
   def test_merge
     h1 = @cls[1=>2, 3=>4]
     h2 = {1=>3, 5=>7}
@@ -1290,10 +1299,10 @@ class TestHash < Test::Unit::TestCase
     expected[7] = 8
     h2 = h.merge(7=>8)
     assert_equal(expected, h2)
-    assert_equal(true, h2.compare_by_identity?)
+    assert_predicate(h2, :compare_by_identity?)
     h2 = h.merge({})
     assert_equal(h, h2)
-    assert_equal(true, h2.compare_by_identity?)
+    assert_predicate(h2, :compare_by_identity?)
 
     h = @cls[]
     h.compare_by_identity
@@ -1301,10 +1310,10 @@ class TestHash < Test::Unit::TestCase
     h1.compare_by_identity
     h2 = h.merge(7=>8)
     assert_equal(h1, h2)
-    assert_equal(true, h2.compare_by_identity?)
+    assert_predicate(h2, :compare_by_identity?)
     h2 = h.merge({})
     assert_equal(h, h2)
-    assert_equal(true, h2.compare_by_identity?)
+    assert_predicate(h2, :compare_by_identity?)
   end
 
   def test_merge!


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20307