### PR TITLE
[Feature #20306] Implement rb_free_at_exit_p

### DIFF
--- a/include/ruby/vm.h
+++ b/include/ruby/vm.h
@@ -49,6 +49,13 @@ int ruby_vm_destruct(ruby_vm_t *vm);
  */
 void ruby_vm_at_exit(void(*func)(ruby_vm_t *));
 
+/**
+ * Returns whether the Ruby VM will free all memory at shutdown.
+ *
+ * @return true if free-at-exit is enabled, false otherwise.
+ */
+bool ruby_free_at_exit_p(void);
+
 RBIMPL_SYMBOL_EXPORT_END()
 
 #endif /* RUBY_VM_H */

--- a/vm.c
+++ b/vm.c
@@ -4368,6 +4368,12 @@ rb_ruby_debug_ptr(void)
 
 bool rb_free_at_exit = false;
 
+bool
+ruby_free_at_exit_p(void)
+{
+    return rb_free_at_exit;
+}
+
 /* iseq.c */
 VALUE rb_insn_operand_intern(const rb_iseq_t *iseq,
                              VALUE insn, int op_no, VALUE op,


### PR DESCRIPTION
rb_free_at_exit_p is a way for extensions to determine whether they should free all memory at shutdown.