### PR TITLE
YJIT: Support splat with C methods with -1 arity

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4634,3 +4634,27 @@ assert_equal '[1, 1, 1]', %q{
   empty = []
   [1.abs(*empty), 1.abs(**nil), 1.bit_length(*empty, **nil)]
 }
+
+# splat into C methods with -1 arity
+assert_equal '[[1, 2, 3], [0, 2, 3], [1, 2, 3], [2, 2, 3], [], [], [{}]]', %q{
+  class Foo < Array
+    def push(args) = super(1, *args)
+  end
+
+  def test_cfunc_vargs_splat(sub_instance, array_class, empty_kw_hash)
+    splat = [2, 3]
+    kw_splat = [empty_kw_hash]
+    [
+      sub_instance.push(splat),
+      array_class[0, *splat, **nil],
+      array_class[1, *splat, &nil],
+      array_class[2, *splat, **nil, &nil],
+      array_class.send(:[], *kw_splat),
+      # kw_splat disables keywords hash handling
+      array_class[*kw_splat],
+      array_class[*kw_splat, **nil],
+    ]
+  end
+
+  test_cfunc_vargs_splat(Foo.new, Array, Hash.ruby2_keywords_hash({}))
+}

--- a/yjit.c
+++ b/yjit.c
@@ -894,7 +894,7 @@ rb_yjit_ruby2_keywords_splat_p(VALUE obj)
 VALUE
 rb_yjit_splat_varg_checks(VALUE *sp, VALUE splat_array, rb_control_frame_t *cfp)
 {
-    if (!RB_TYPE_P(splat_array, T_ARRAY)) return Qfalse;
+    // We inserted a T_ARRAY guard before this call
     long len = RARRAY_LEN(splat_array);
 
     // Large splat arrays need a separate allocation

--- a/yjit.c
+++ b/yjit.c
@@ -890,6 +890,51 @@ rb_yjit_ruby2_keywords_splat_p(VALUE obj)
     return FL_TEST_RAW(last, RHASH_PASS_AS_KEYWORDS);
 }
 
+// Checks to establish preconditions for rb_yjit_splat_varg_cfunc()
+VALUE
+rb_yjit_splat_varg_checks(VALUE *sp, VALUE splat_array, rb_control_frame_t *cfp)
+{
+    if (!RB_TYPE_P(splat_array, T_ARRAY)) return Qfalse;
+    long len = RARRAY_LEN(splat_array);
+
+    // Large splat arrays need a separate allocation
+    if (len < 0 || len > VM_ARGC_STACK_MAX) return Qfalse;
+
+    // Would we overflow if we put the contents of the array onto the stack?
+    if (sp + len > (VALUE *)(cfp - 2)) return Qfalse;
+
+    return Qtrue;
+}
+
+// Push array elements to the stack for a C method that has a variable number
+// of parameters. Returns the number of arguments the splat array contributes.
+int
+rb_yjit_splat_varg_cfunc(VALUE *stack_splat_array, bool sole_splat)
+{
+    VALUE splat_array = *stack_splat_array;
+    int len;
+
+    // We already checked that length fits in `int`
+    RUBY_ASSERT(RB_TYPE_P(splat_array, T_ARRAY));
+    len = (int)RARRAY_LEN(splat_array);
+
+    // If this is a splat call without any keyword arguments, exclude the
+    // ruby2_keywords hash if it's empty
+    if (sole_splat && len > 0) {
+        VALUE last_hash = RARRAY_AREF(splat_array, len - 1);
+        if (RB_TYPE_P(last_hash, T_HASH) &&
+                FL_TEST_RAW(last_hash, RHASH_PASS_AS_KEYWORDS) &&
+                RHASH_EMPTY_P(last_hash)) {
+            len--;
+        }
+    }
+
+    // Push the contents of the array onto the stack
+    MEMCPY(stack_splat_array, RARRAY_CONST_PTR(splat_array), VALUE, len);
+
+    return len;
+}
+
 // Print the Ruby source location of some ISEQ for debugging purposes
 void
 rb_yjit_dump_iseq_loc(const rb_iseq_t *iseq, uint32_t insn_idx)

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -460,6 +460,8 @@ fn main() {
         .allowlist_function("rb_vm_base_ptr")
         .allowlist_function("rb_ec_stack_check")
         .allowlist_function("rb_vm_top_self")
+        .allowlist_function("rb_yjit_splat_varg_checks")
+        .allowlist_function("rb_yjit_splat_varg_cfunc")
 
         // We define VALUE manually, don't import it
         .blocklist_type("VALUE")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6217,9 +6217,11 @@ fn gen_send_cfunc(
 
     // Guard for variable length splat call before any modifications to the stack
     if variable_splat {
+        let splat_array = asm.stack_opnd(i32::from(kw_splat) + i32::from(block_arg));
+        guard_object_is_array(asm, splat_array, splat_array.into(), Counter::guard_send_splat_not_array);
+
         asm_comment!(asm, "guard variable length splat call servicable");
         let sp = asm.ctx.sp_opnd(0);
-        let splat_array = asm.stack_opnd(i32::from(kw_splat) + i32::from(block_arg));
         let proceed = asm.ccall(rb_yjit_splat_varg_checks as _, vec![sp, splat_array, CFP]);
         asm.cmp(proceed, Qfalse.into());
         asm.je(Target::side_exit(Counter::guard_send_cfunc_bad_splat_vargs));

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1194,6 +1194,15 @@ extern "C" {
     pub fn rb_yjit_fix_div_fix(recv: VALUE, obj: VALUE) -> VALUE;
     pub fn rb_yjit_fix_mod_fix(recv: VALUE, obj: VALUE) -> VALUE;
     pub fn rb_yjit_ruby2_keywords_splat_p(obj: VALUE) -> usize;
+    pub fn rb_yjit_splat_varg_checks(
+        sp: *mut VALUE,
+        splat_array: VALUE,
+        cfp: *mut rb_control_frame_t,
+    ) -> VALUE;
+    pub fn rb_yjit_splat_varg_cfunc(
+        stack_splat_array: *mut VALUE,
+        sole_splat: bool,
+    ) -> ::std::os::raw::c_int;
     pub fn rb_yjit_dump_iseq_loc(iseq: *const rb_iseq_t, insn_idx: u32);
     pub fn rb_yjit_iseq_inspect(iseq: *const rb_iseq_t) -> *mut ::std::os::raw::c_char;
     pub fn rb_FL_TEST(obj: VALUE, flags: VALUE) -> VALUE;

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -386,7 +386,6 @@ make_counters! {
     send_args_splat_aref,
     send_args_splat_aset,
     send_args_splat_opt_call,
-    send_args_splat_cfunc_var_args,
     send_iseq_splat_arity_error,
     send_splat_too_long,
     send_send_wrong_args,
@@ -443,6 +442,8 @@ make_counters! {
     guard_send_not_fixnum_or_flonum,
     guard_send_not_string,
     guard_send_respond_to_mid_mismatch,
+
+    guard_send_cfunc_bad_splat_vargs,
 
     guard_invokesuper_me_changed,
 


### PR DESCRIPTION
Usually we deal with splats by speculating that they're of a specific
size. In this case, the C method takes a pointer and a length, so
we can support changing sizes just fine.

On lobsters:

```
num_send_dynamic:            727,218 ( 2.6%)
num_send_dynamic:            684,529 ( 2.5%)
```