### PR TITLE
[DOC] Fix typo in GC documentation

### DIFF
--- a/gc.rb
+++ b/gc.rb
@@ -26,10 +26,10 @@ module GC
   # then marking will always be immediate, regardless of the value of
   # +immediate_mark+.
   #
-  # The +immedate_sweep+ keyword argument determines whether or not to defer
-  # sweeping (using lazy sweep). When set to +true+, sweeping is performed in
+  # The +immediate_sweep+ keyword argument determines whether or not to defer
+  # sweeping (using lazy sweep). When set to +false+, sweeping is performed in
   # steps that is interleaved with future Ruby code execution, so sweeping might
-  # not be completed during this method call. When set to +false+, sweeping is
+  # not be completed during this method call. When set to +true+, sweeping is
   # completed during the call to this method.
   #
   # Note: These keyword arguments are implementation and version dependent. They


### PR DESCRIPTION
The documentation for GC.start was incorrect. It said that the `immediate_sweep` keyword argument would defer sweeping when set to `true`, but it should have said that it would defer sweeping when set to `false`.

The commit will also fix the typo "immedate_sweep" to "immediate_sweep".

---

When I read:

> The immedate_sweep keyword argument determines whether or not to defer sweeping (using lazy sweep). When set to true, sweeping is performed in steps that is interleaved with future Ruby code execution, so sweeping might not be completed during this method call. When set to false, sweeping is completed during the call to this method.

It sounds like it will defer sweeping when set to true and do an immediate sweep when set to false. I think this must be incorrect. 

According to https://www.rubydoc.info/stdlib/core/2.1.6/ObjectSpace.garbage_collect it also sounds like it should be true here instead.