### PR TITLE
Remove pointer check in vm_ccs_free

### DIFF
--- a/imemo.c
+++ b/imemo.c
@@ -457,7 +457,7 @@ vm_ccs_free(struct rb_class_cc_entries *ccs, int alive, VALUE klass)
             if (!alive) {
                 void *ptr = asan_unpoison_object_temporary((VALUE)cc);
                 // ccs can be free'ed.
-                if (rb_gc_is_ptr_to_obj(cc) &&
+                if (rb_objspace_markable_object_p((VALUE)cc) &&
                     IMEMO_TYPE_P(cc, imemo_callcache) &&
                     cc->klass == klass) {
                     // OK. maybe target cc.


### PR DESCRIPTION
We don't need to check that the object is pointer to the GC heap in vm_ccs_free because it is called during sweeping, which does not free pages so it can never point to an object that is not on the GC heap.