### PR TITLE
Use RB_SPECIAL_CONST_P instead of rb_special_const_p

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4398,7 +4398,7 @@ is_live_object(rb_objspace_t *objspace, VALUE ptr)
 static inline int
 is_markable_object(VALUE obj)
 {
-    if (rb_special_const_p(obj)) return FALSE; /* special const is not markable */
+    if (RB_SPECIAL_CONST_P(obj)) return FALSE; /* special const is not markable */
     check_rvalue_consistency(obj);
     return TRUE;
 }

--- a/marshal.c
+++ b/marshal.c
@@ -1889,7 +1889,7 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE extmod, int typ
                 goto type_hash;
             }
             v = r_object_for(arg, partial, 0, extmod, type);
-            if (rb_special_const_p(v) || RB_TYPE_P(v, T_OBJECT) || RB_TYPE_P(v, T_CLASS)) {
+            if (RB_SPECIAL_CONST_P(v) || RB_TYPE_P(v, T_OBJECT) || RB_TYPE_P(v, T_CLASS)) {
                 goto format_error;
             }
             if (RB_TYPE_P(v, T_MODULE) || !RTEST(rb_class_inherited_p(c, RBASIC(v)->klass))) {

--- a/vm.c
+++ b/vm.c
@@ -2922,7 +2922,7 @@ rb_vm_each_stack_value(void *ptr, void (*cb)(VALUE, void*), void *ctx)
                         VALUE *p = ec->vm_stack;
                         VALUE *sp = ec->cfp->sp;
                         while (p < sp) {
-                            if (!rb_special_const_p(*p)) {
+                            if (!RB_SPECIAL_CONST_P(*p)) {
                                 cb(*p, ctx);
                             }
                             p++;


### PR DESCRIPTION
rb_special_const_p returns a VALUE (Qtrue or Qfalse), so we shouldn't assume that Qfalse is 0. We should instead use RB_SPECIAL_CONST_P.