### PR TITLE
[DOC] Stop discouraging the use of Array#each

### DIFF
--- a/doc/yjit/yjit.md
+++ b/doc/yjit/yjit.md
@@ -268,8 +268,6 @@ This section contains tips on writing Ruby code that will run as fast as possibl
   - Avoid classes that wrap objects if you can
   - Avoid methods that just call another method, trivial one-liner methods
 - Try to write code so that the same variables always have the same type
-- Use `while` loops if you can, instead of C methods like `Array#each`
-  - This is not idiomatic Ruby, but could help in hot methods
 - CRuby method calls are costly. Avoid things such as methods that only return a value from a hash or return a constant.
 
 You can also use the `--yjit-stats` command-line option to see which bytecodes cause YJIT to exit, and refactor your code to avoid using these instructions in the hottest methods of your code.


### PR DESCRIPTION
Given https://github.com/ruby/ruby/pull/9622 and https://github.com/ruby/ruby/pull/9533, you shouldn't need to rewrite `Array#each` with a while loop, which is no longer a C method.

It still helps other ones like `Array#map`. However, it should be on us to optimize the ones that are used frequently in Ruby 3.4, and ones that are not frequently used shouldn't matter. So I think this should be dropped from the Ruby 3.4 document.