### PR TITLE
Make sure all machine stack marking also marks ASAN fake stacks

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -6410,7 +6410,7 @@ gc_mark_machine_stack_location_maybe(rb_objspace_t *objspace, VALUE obj)
     void *fake_frame_start;
     void *fake_frame_end;
     bool is_fake_frame = asan_get_fake_stack_extents(
-        ec->thread_ptr->asan_fake_stack_handle, obj,
+        ec->machine.asan_fake_stack_handle, obj,
         ec->machine.stack_start, ec->machine.stack_end,
         &fake_frame_start, &fake_frame_end
     );

--- a/thread.c
+++ b/thread.c
@@ -527,9 +527,6 @@ void
 ruby_thread_init_stack(rb_thread_t *th, void *local_in_parent_frame)
 {
     native_thread_init_stack(th, local_in_parent_frame);
-#ifdef RUBY_ASAN_ENABLED
-    th->asan_fake_stack_handle = asan_get_thread_fake_stack_handle();
-#endif
 }
 
 const VALUE *

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -2081,6 +2081,7 @@ native_thread_init_stack(rb_thread_t *th, void *local_in_parent_frame)
     rb_nativethread_id_t curr = pthread_self();
 #ifdef RUBY_ASAN_ENABLED
     local_in_parent_frame = asan_get_real_stack_addr(local_in_parent_frame);
+    th->ec->machine.asan_fake_stack_handle = asan_get_thread_fake_stack_handle();
 #endif
 
     if (!native_main_thread.id) {

--- a/vm.c
+++ b/vm.c
@@ -3399,10 +3399,7 @@ rb_execution_context_mark(const rb_execution_context_t *ec)
     if (ec->machine.stack_start && ec->machine.stack_end &&
         ec != GET_EC() /* marked for current ec at the first stage of marking */
         ) {
-        rb_gc_mark_machine_stack(ec);
-        rb_gc_mark_locations((VALUE *)&ec->machine.regs,
-                             (VALUE *)(&ec->machine.regs) +
-                             sizeof(ec->machine.regs) / (sizeof(VALUE)));
+        rb_gc_mark_machine_context(ec);
     }
 
     rb_gc_mark(ec->errinfo);

--- a/vm_core.h
+++ b/vm_core.h
@@ -1874,7 +1874,7 @@ void rb_vm_register_special_exception_str(enum ruby_special_exceptions sp, VALUE
 #define rb_vm_register_special_exception(sp, e, m) \
     rb_vm_register_special_exception_str(sp, e, rb_usascii_str_new_static((m), (long)rb_strlen_lit(m)))
 
-void rb_gc_mark_machine_stack(const rb_execution_context_t *ec);
+void rb_gc_mark_machine_context(const rb_execution_context_t *ec);
 
 void rb_vm_rewrite_cref(rb_cref_t *node, VALUE old_klass, VALUE new_klass, rb_cref_t **new_cref_ptr);
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -1044,6 +1044,10 @@ struct rb_execution_context_struct {
         VALUE *stack_end;
         size_t stack_maxsize;
         RUBY_ALIGNAS(SIZEOF_VALUE) jmp_buf regs;
+
+#ifdef RUBY_ASAN_ENABLED
+        void *asan_fake_stack_handle;
+#endif
     } machine;
 };
 
@@ -1164,11 +1168,6 @@ typedef struct rb_thread_struct {
     void **specific_storage;
 
     struct rb_ext_config ext_config;
-
-#ifdef RUBY_ASAN_ENABLED
-    void *asan_fake_stack_handle;
-#endif
-
 } rb_thread_t;
 
 static inline unsigned int


### PR DESCRIPTION
As per https://bugs.ruby-lang.org/issues/20310, ASAN requires that we perform some additional logic when marking the machine context (stack + registers) to also mark any values stored in an ASAN fake stack. The logic for doing this was already in `gc_mark_machine_stack_location_maybe`, (called by `mark_current_machine_context`), but that only applied to the current thread/fiber which actually performed the GC.

To fully support ASAN, we need to handle two more cases:
* Other threads which aren't performing the GC,
* Other fibers which aren't their thread's current fiber

Rather than duplicating this logic in `mark_current_machine_context`, I've tried to funnel all of these cases into one place in gc.c (which I called `rb_gc_mark_machine_context`). Fibers, when marked, call `rb_execution_context_mark`, and `rb_execution_context_mark` now calls `rb_gc_mark_machine_context`. No other code-paths should be performing marking of the machine stack other than `rb_gc_mark_machine_context` and `mark_current_machine_context` (the latter is a bit special because it needs to capture registers too).

I'm reasonably confident in the correctness of this patch, because without it I was frequently getting several tests in the test suite failing when run under ASAN, because of VALUEs on the machine stack getting collected; with this patch applied, I didn't get any such failures, so I think the right stacks are still getting marked at the right times. I also ran the suite on my machine with `VM_CHECK_MODE` and `RGENGC_CHECK_MODE` - also fine.

---

I ran a little bit of a benchmark to make sure this didn't make marking fibers dramatically less performant (https://gist.github.com/KJTsanaktsidis/2721d739668ddad343ded65de796d713); it seemed to show no difference

With this patch
```
ktsanaktsidis@fedora build % make TESTRUN_SCRIPT=fiber_bench.rb runruby
RUBY_ON_BUG='gdb -x ../.gdbinit -p' ./miniruby -I../lib -I. -I.ext/common  ../tool/runruby.rb --extout=.ext  -- --disable-gems  fiber_bench.rb 
  4.638099   0.419711   5.057810 (  5.084307)
```

Without this patch
```
ktsanaktsidis@fedora build % make TESTRUN_SCRIPT=fiber_bench.rb runruby
RUBY_ON_BUG='gdb -x ../.gdbinit -p' ./miniruby -I../lib -I. -I.ext/common  ../tool/runruby.rb --extout=.ext  -- --disable-gems  fiber_bench.rb 
  4.613809   0.447407   5.061216 (  5.077891)
```

---

https://bugs.ruby-lang.org/issues/20310 