### PR TITLE
YJIT: Squash canary before falling back

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -8006,6 +8006,12 @@ fn gen_send_dynamic<F: Fn(&mut Assembler) -> Opnd>(
     // Save PC and SP to prepare for dynamic dispatch
     jit_prepare_non_leaf_call(jit, asm);
 
+    // Squash stack canary that might be left over from elsewhere
+    assert_eq!(false, asm.get_leaf_ccall());
+    if cfg!(debug_assertions) {
+        asm.store(asm.ctx.sp_opnd(0), 0.into());
+    }
+
     // Dispatch a method
     let ret = vm_sendish(asm);
 


### PR DESCRIPTION
Recent flaky canary-related CI failures have all happened while trying
to fall back. It's unclear what is leaving the canary on the stack and
causing gen_send_dynamic() to falsely assume that it should be leaf,
and this patch isn't going to help us find the source. One source I
found is Array#<< with a frozen array, but it's unclear if that's what's
causing the CI failures. I'm somewhat afraid to add a canary check to
rb_longjmp() since that might introduce more flaky failures, and maybe
ones unrelated to YJIT.

See: https://github.com/ruby/ruby/actions/runs/8083502532/job/22086714152
See: https://github.com/ruby/ruby/actions/runs/8066858522/job/22035963315
