### PR TITLE
YJIT: Support inlining putself

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4513,6 +4513,10 @@ assert_equal 'true', %q{
   def entry = yield
   entry { true }
 }
+assert_equal 'sym', %q{
+  def entry = :sym.to_sym
+  entry
+}
 
 assert_normal_exit %q{
   ivars = 1024.times.map { |i| "@iv_#{i} = #{i}\n" }.join


### PR DESCRIPTION
This PR extends https://github.com/ruby/ruby/pull/8855 a little and adds `putself` support to ISEQ inlining.

`Symbol#to_sym`, which is just `putself` + `leave`, is the method that is most frequently called on production SFR, accounting for 14% of all ISEQ calls. While we're planning on implementing a proper inlining later, I think there's a value in removing this bottleneck right away before we get to work on the full inlining implementation.

Because it leaves the receiver as is, this implementation generates no code (besides a known class guard if needed) for such method calls. Here's an example code for `:sym.to_sym`:

```asm
  # Block: <main>@-e:1
  # reg_temps: 00000001
  # Insn: 0002 opt_send_without_block (stack_size: 1)
  # call to Symbol#to_sym
  # inlined simple ISEQ
  # gen_direct_jmp: fallthrough
  0x562131f8a027: nop dword ptr [rax + rax]
```