### PR TITLE
[wasm-pic] Remove --pass-arg=asyncify-ignore-imports from POSTLINK

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1267,7 +1267,7 @@ main()
 [wasi*],[	LIBS="-lm -lwasi-emulated-mman -lwasi-emulated-signal -lwasi-emulated-getpid -lwasi-emulated-process-clocks $LIBS"
 		RUBY_APPEND_OPTIONS(CFLAGS, -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID -D_WASI_EMULATED_PROCESS_CLOCKS)
 		RUBY_APPEND_OPTIONS(CPPFLAGS, -D_WASI_EMULATED_SIGNAL -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_GETPID -D_WASI_EMULATED_PROCESS_CLOCKS)
-		POSTLINK="\$(WASMOPT) --asyncify \$(wasmoptflags) --pass-arg=asyncify-ignore-imports -o \$@ \$@${POSTLINK:+; $POSTLINK}"
+		POSTLINK="\$(WASMOPT) --asyncify \$(wasmoptflags) -o \$@ \$@${POSTLINK:+; $POSTLINK}"
 		# wasi-libc's sys/socket.h is not compatible with -std=gnu99,
 		# so re-declare shutdown in include/ruby/missing.h
 		ac_cv_func_shutdown=no


### PR DESCRIPTION
Before PIC era, we could assume that the stack is not unwound by imported functions since all imported functions are WASI syscalls and they don't use Asyncify at all. However, PIC binary can import functions from other modules and we cannot guarantee that they won't unwind the stack. Passing `--pass-arg=asyncify-ignore-imports` as optimization is now builder's responsibility. 