### PR TITLE
[wasm-pic] Add `LDSHARED` definition for WASI platform

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3157,6 +3157,7 @@ AC_SUBST(EXTOBJS)
 	[hiuxmpp], [	: ${LDSHARED='$(LD) -r'}],
 	[atheos*], [	: ${LDSHARED='$(CC) -shared'}
 			rb_cv_dlopen=yes],
+	[wasi*], [	: ${LDSHARED='$(LD) -shared -Xlinker --export-dynamic'}],
 	[	: ${LDSHARED='$(LD)'}])
     AC_MSG_RESULT($rb_cv_dlopen)
 }


### PR DESCRIPTION
We are going to add dynamic linking support for WASI platform. The `LDSHARED` definition is used to link shared libraries for building ruby binaries and extensions.