### PR TITLE
Use configured `LD` for linking enc and ext libraries

### DIFF
--- a/enc/Makefile.in
+++ b/enc/Makefile.in
@@ -40,6 +40,7 @@ BUILTRUBY = $(topdir)/miniruby$(EXEEXT)
 
 empty =
 AR = @AR@
+LD = @LD@
 CC = @CC@
 ARFLAGS = @ARFLAGS@$(empty)
 RANLIB = @RANLIB@

--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -2149,6 +2149,7 @@ DLDFLAGS = $(ldflags) $(dldflags) $(ARCH_FLAG)
 LDSHARED = #{CONFIG['LDSHARED']}
 LDSHAREDXX = #{config_string('LDSHAREDXX') || '$(LDSHARED)'}
 AR = #{CONFIG['AR']}
+LD = #{CONFIG['LD']}
 EXEEXT = #{CONFIG['EXEEXT']}
 
 }


### PR DESCRIPTION
"AR" was well propagated to the enc.mk and mkmf, but "LD" was not. This caused the dynamic libraries to be linked with a linker found in the PATH, which could be different from the one used in the Ruby build process. This is especially important for cross-compilation, where the host linker may not be compatible with the target system. (e.g. WebAssembly)