### PR TITLE
Module#remove_const: cleanup vm->defined_module_hash

### DIFF
--- a/array.c
+++ b/array.c
@@ -8577,7 +8577,8 @@ rb_ary_deconstruct(VALUE ary)
 void
 Init_Array(void)
 {
-    rb_cArray  = rb_define_class("Array", rb_cObject);
+    rb_global_variable(&rb_cArray);
+    rb_cArray = rb_define_class("Array", rb_cObject);
     rb_include_module(rb_cArray, rb_mEnumerable);
 
     rb_define_alloc_func(rb_cArray, empty_ary_alloc);

--- a/ast.c
+++ b/ast.c
@@ -815,7 +815,9 @@ ast_node_script_lines(rb_execution_context_t *ec, VALUE self)
 void
 Init_ast(void)
 {
+    rb_global_variable(&rb_mAST);
     rb_mAST = rb_define_module_under(rb_cRubyVM, "AbstractSyntaxTree");
+    rb_global_variable(&rb_cNode);
     rb_cNode = rb_define_class_under(rb_mAST, "Node", rb_cObject);
     rb_undef_alloc_func(rb_cNode);
 }

--- a/class.c
+++ b/class.c
@@ -890,16 +890,21 @@ refinement_import_methods(int argc, VALUE *argv, VALUE refinement)
 void
 Init_class_hierarchy(void)
 {
+    rb_global_variable(&rb_cBasicObject);
     rb_cBasicObject = boot_defclass("BasicObject", 0);
+    rb_global_variable(&rb_cObject);
     rb_cObject = boot_defclass("Object", rb_cBasicObject);
     rb_gc_register_mark_object(rb_cObject);
 
     /* resolve class name ASAP for order-independence */
     rb_set_class_path_string(rb_cObject, rb_cObject, rb_fstring_lit("Object"));
 
+    rb_global_variable(&rb_cModule);
     rb_cModule = boot_defclass("Module", rb_cObject);
-    rb_cClass =  boot_defclass("Class",  rb_cModule);
-    rb_cRefinement =  boot_defclass("Refinement",  rb_cModule);
+    rb_global_variable(&rb_cClass);
+    rb_cClass = boot_defclass("Class",  rb_cModule);
+    rb_global_variable(&rb_cRefinement);
+    rb_cRefinement = boot_defclass("Refinement",  rb_cModule);
 
 #if 0 /* for RDoc */
     // we pretend it to be public, otherwise RDoc will ignore it

--- a/compar.c
+++ b/compar.c
@@ -312,6 +312,7 @@ cmp_clamp(int argc, VALUE *argv, VALUE x)
 void
 Init_Comparable(void)
 {
+    rb_global_variable(&rb_mComparable);
     rb_mComparable = rb_define_module("Comparable");
     rb_define_method(rb_mComparable, "==", cmp_equal, 1);
     rb_define_method(rb_mComparable, ">", cmp_gt, 1);

--- a/complex.c
+++ b/complex.c
@@ -2597,7 +2597,6 @@ float_arg(VALUE self)
 void
 Init_Complex(void)
 {
-    VALUE compat;
     id_abs = rb_intern_const("abs");
     id_arg = rb_intern_const("arg");
     id_denominator = rb_intern_const("denominator");
@@ -2610,6 +2609,7 @@ Init_Complex(void)
     id_rationalize = rb_intern_const("rationalize");
     id_PI = rb_intern_const("PI");
 
+    rb_global_variable(&rb_cComplex);
     rb_cComplex = rb_define_class("Complex", rb_cNumeric);
 
     rb_define_alloc_func(rb_cComplex, nucomp_s_alloc);
@@ -2684,7 +2684,7 @@ Init_Complex(void)
 
     rb_define_private_method(rb_cComplex, "marshal_dump", nucomp_marshal_dump, 0);
     /* :nodoc: */
-    compat = rb_define_class_under(rb_cComplex, "compatible", rb_cObject);
+    VALUE compat = rb_define_class_under(rb_cComplex, "compatible", rb_cObject);
     rb_define_private_method(compat, "marshal_load", nucomp_marshal_load, 1);
     rb_marshal_define_compat(rb_cComplex, compat, nucomp_dumper, nucomp_loader);
 

--- a/cont.c
+++ b/cont.c
@@ -3477,8 +3477,11 @@ Init_Cont(void)
         }
     }
 
+    rb_global_variable(&rb_cFiber);
     rb_cFiber = rb_define_class("Fiber", rb_cObject);
     rb_define_alloc_func(rb_cFiber, fiber_alloc);
+
+    rb_global_variable(&rb_eFiberError);
     rb_eFiberError = rb_define_class("FiberError", rb_eStandardError);
     rb_define_singleton_method(rb_cFiber, "yield", rb_fiber_s_yield, -1);
     rb_define_singleton_method(rb_cFiber, "current", rb_fiber_s_current, 0);
@@ -3508,6 +3511,7 @@ Init_Cont(void)
     rb_define_singleton_method(rb_cFiber, "schedule", rb_fiber_s_schedule, -1);
 
 #ifdef RB_EXPERIMENTAL_FIBER_POOL
+    rb_global_variable(&rb_cFiberPool);
     rb_cFiberPool = rb_define_class_under(rb_cFiber, "Pool", rb_cObject);
     rb_define_alloc_func(rb_cFiberPool, fiber_pool_alloc);
     rb_define_method(rb_cFiberPool, "initialize", rb_fiber_pool_initialize, -1);
@@ -3521,6 +3525,7 @@ RUBY_SYMBOL_EXPORT_BEGIN
 void
 ruby_Init_Continuation_body(void)
 {
+    rb_global_variable(&rb_cContinuation);
     rb_cContinuation = rb_define_class("Continuation", rb_cObject);
     rb_undef_alloc_func(rb_cContinuation);
     rb_undef_method(CLASS_OF(rb_cContinuation), "new");

--- a/enum.c
+++ b/enum.c
@@ -5058,6 +5058,7 @@ enum_compact(VALUE obj)
 void
 Init_Enumerable(void)
 {
+    rb_global_variable(&rb_mEnumerable);
     rb_mEnumerable = rb_define_module("Enumerable");
 
     rb_define_method(rb_mEnumerable, "to_a", enum_to_a, -1);

--- a/enumerator.c
+++ b/enumerator.c
@@ -4449,6 +4449,7 @@ InitVM_Enumerator(void)
     rb_define_method(rb_mKernel, "to_enum", obj_to_enum, -1);
     rb_define_method(rb_mKernel, "enum_for", obj_to_enum, -1);
 
+    rb_global_variable(&rb_cEnumerator);
     rb_cEnumerator = rb_define_class("Enumerator", rb_cObject);
     rb_include_module(rb_cEnumerator, rb_mEnumerable);
 
@@ -4472,6 +4473,7 @@ InitVM_Enumerator(void)
     rb_define_method(rb_mEnumerable, "chain", enum_chain, -1);
 
     /* Lazy */
+    rb_global_variable(&rb_cLazy);
     rb_cLazy = rb_define_class_under(rb_cEnumerator, "Lazy", rb_cEnumerator);
     rb_define_method(rb_mEnumerable, "lazy", enumerable_lazy, 0);
 
@@ -4578,6 +4580,7 @@ InitVM_Enumerator(void)
     rb_define_method(rb_eStopIteration, "result", stop_result, 0);
 
     /* Generator */
+    rb_global_variable(&rb_cGenerator);
     rb_cGenerator = rb_define_class_under(rb_cEnumerator, "Generator", rb_cObject);
     rb_include_module(rb_cGenerator, rb_mEnumerable);
     rb_define_alloc_func(rb_cGenerator, generator_allocate);
@@ -4586,6 +4589,7 @@ InitVM_Enumerator(void)
     rb_define_method(rb_cGenerator, "each", generator_each, -1);
 
     /* Yielder */
+    rb_global_variable(&rb_cYielder);
     rb_cYielder = rb_define_class_under(rb_cEnumerator, "Yielder", rb_cObject);
     rb_define_alloc_func(rb_cYielder, yielder_allocate);
     rb_define_method(rb_cYielder, "initialize", yielder_initialize, 0);
@@ -4594,12 +4598,14 @@ InitVM_Enumerator(void)
     rb_define_method(rb_cYielder, "to_proc", yielder_to_proc, 0);
 
     /* Producer */
+    rb_global_variable(&rb_cEnumProducer);
     rb_cEnumProducer = rb_define_class_under(rb_cEnumerator, "Producer", rb_cObject);
     rb_define_alloc_func(rb_cEnumProducer, producer_allocate);
     rb_define_method(rb_cEnumProducer, "each", producer_each, 0);
     rb_define_singleton_method(rb_cEnumerator, "produce", enumerator_s_produce, -1);
 
     /* Chain */
+    rb_global_variable(&rb_cEnumChain);
     rb_cEnumChain = rb_define_class_under(rb_cEnumerator, "Chain", rb_cEnumerator);
     rb_define_alloc_func(rb_cEnumChain, enum_chain_allocate);
     rb_define_method(rb_cEnumChain, "initialize", enum_chain_initialize, -2);
@@ -4615,6 +4621,7 @@ InitVM_Enumerator(void)
     rb_undef_method(rb_cEnumChain, "peek_values");
 
     /* Product */
+    rb_global_variable(&rb_cEnumProduct);
     rb_cEnumProduct = rb_define_class_under(rb_cEnumerator, "Product", rb_cEnumerator);
     rb_define_alloc_func(rb_cEnumProduct, enum_product_allocate);
     rb_define_method(rb_cEnumProduct, "initialize", enum_product_initialize, -1);
@@ -4631,6 +4638,7 @@ InitVM_Enumerator(void)
     rb_define_singleton_method(rb_cEnumerator, "product", enumerator_s_product, -1);
 
     /* ArithmeticSequence */
+    rb_global_variable(&rb_cArithSeq);
     rb_cArithSeq = rb_define_class_under(rb_cEnumerator, "ArithmeticSequence", rb_cEnumerator);
     rb_undef_alloc_func(rb_cArithSeq);
     rb_undef_method(CLASS_OF(rb_cArithSeq), "new");

--- a/error.c
+++ b/error.c
@@ -3316,7 +3316,8 @@ exception_loader(VALUE exc, VALUE obj)
 void
 Init_Exception(void)
 {
-    rb_eException   = rb_define_class("Exception", rb_cObject);
+    rb_global_variable(&rb_eException);
+    rb_eException = rb_define_class("Exception", rb_cObject);
     rb_define_alloc_func(rb_eException, exception_alloc);
     rb_marshal_define_compat(rb_eException, rb_eException, exception_dumper, exception_loader);
     rb_define_singleton_method(rb_eException, "exception", rb_class_new_instance, -1);
@@ -3334,26 +3335,46 @@ Init_Exception(void)
     rb_define_method(rb_eException, "set_backtrace", exc_set_backtrace, 1);
     rb_define_method(rb_eException, "cause", exc_cause, 0);
 
+    rb_global_variable(&rb_eSystemExit);
     rb_eSystemExit  = rb_define_class("SystemExit", rb_eException);
     rb_define_method(rb_eSystemExit, "initialize", exit_initialize, -1);
     rb_define_method(rb_eSystemExit, "status", exit_status, 0);
     rb_define_method(rb_eSystemExit, "success?", exit_success_p, 0);
 
-    rb_eFatal  	    = rb_define_class("fatal", rb_eException);
-    rb_eSignal      = rb_define_class("SignalException", rb_eException);
-    rb_eInterrupt   = rb_define_class("Interrupt", rb_eSignal);
+    rb_global_variable(&rb_eFatal);
+    rb_eFatal = rb_define_class("fatal", rb_eException);
 
+    rb_global_variable(&rb_eSignal);
+    rb_eSignal = rb_define_class("SignalException", rb_eException);
+
+    rb_global_variable(&rb_eInterrupt);
+    rb_eInterrupt = rb_define_class("Interrupt", rb_eSignal);
+
+    rb_global_variable(&rb_eStandardError);
     rb_eStandardError = rb_define_class("StandardError", rb_eException);
-    rb_eTypeError     = rb_define_class("TypeError", rb_eStandardError);
-    rb_eArgError      = rb_define_class("ArgumentError", rb_eStandardError);
-    rb_eIndexError    = rb_define_class("IndexError", rb_eStandardError);
-    rb_eKeyError      = rb_define_class("KeyError", rb_eIndexError);
+
+    rb_global_variable(&rb_eTypeError);
+    rb_eTypeError = rb_define_class("TypeError", rb_eStandardError);
+
+    rb_global_variable(&rb_eArgError);
+    rb_eArgError = rb_define_class("ArgumentError", rb_eStandardError);
+
+    rb_global_variable(&rb_eIndexError);
+    rb_eIndexError = rb_define_class("IndexError", rb_eStandardError);
+
+    rb_global_variable(&rb_eKeyError);
+    rb_eKeyError = rb_define_class("KeyError", rb_eIndexError);
     rb_define_method(rb_eKeyError, "initialize", key_err_initialize, -1);
     rb_define_method(rb_eKeyError, "receiver", key_err_receiver, 0);
     rb_define_method(rb_eKeyError, "key", key_err_key, 0);
-    rb_eRangeError    = rb_define_class("RangeError", rb_eStandardError);
 
+    rb_global_variable(&rb_eRangeError);
+    rb_eRangeError = rb_define_class("RangeError", rb_eStandardError);
+
+    rb_global_variable(&rb_eScriptError);
     rb_eScriptError = rb_define_class("ScriptError", rb_eException);
+
+    rb_global_variable(&rb_eSyntaxError);
     rb_eSyntaxError = rb_define_class("SyntaxError", rb_eScriptError);
     rb_define_method(rb_eSyntaxError, "initialize", syntax_error_initialize, -1);
 
@@ -3364,17 +3385,22 @@ Init_Exception(void)
     /* the path failed to parse */
     rb_attr(rb_eSyntaxError, path, TRUE, FALSE, FALSE);
 
-    rb_eLoadError   = rb_define_class("LoadError", rb_eScriptError);
+    rb_global_variable(&rb_eLoadError);
+    rb_eLoadError = rb_define_class("LoadError", rb_eScriptError);
     /* the path failed to load */
     rb_attr(rb_eLoadError, path, TRUE, FALSE, FALSE);
 
+    rb_global_variable(&rb_eNotImpError);
     rb_eNotImpError = rb_define_class("NotImplementedError", rb_eScriptError);
 
-    rb_eNameError     = rb_define_class("NameError", rb_eStandardError);
+    rb_global_variable(&rb_eNameError);
+    rb_eNameError = rb_define_class("NameError", rb_eStandardError);
     rb_define_method(rb_eNameError, "initialize", name_err_initialize, -1);
     rb_define_method(rb_eNameError, "name", name_err_name, 0);
     rb_define_method(rb_eNameError, "receiver", name_err_receiver, 0);
     rb_define_method(rb_eNameError, "local_variables", name_err_local_variables, 0);
+
+    rb_global_variable(&rb_cNameErrorMesg);
     rb_cNameErrorMesg = rb_define_class_under(rb_eNameError, "message", rb_cObject);
     rb_define_alloc_func(rb_cNameErrorMesg, name_err_mesg_alloc);
     rb_define_method(rb_cNameErrorMesg, "initialize_copy", name_err_mesg_init_copy, 1);
@@ -3382,33 +3408,53 @@ Init_Exception(void)
     rb_define_method(rb_cNameErrorMesg, "to_str", name_err_mesg_to_str, 0);
     rb_define_method(rb_cNameErrorMesg, "_dump", name_err_mesg_dump, 1);
     rb_define_singleton_method(rb_cNameErrorMesg, "_load", name_err_mesg_load, 1);
+
+    rb_global_variable(&rb_eNoMethodError);
     rb_eNoMethodError = rb_define_class("NoMethodError", rb_eNameError);
     rb_define_method(rb_eNoMethodError, "initialize", nometh_err_initialize, -1);
     rb_define_method(rb_eNoMethodError, "args", nometh_err_args, 0);
     rb_define_method(rb_eNoMethodError, "private_call?", nometh_err_private_call_p, 0);
 
+    rb_global_variable(&rb_eRuntimeError);
     rb_eRuntimeError = rb_define_class("RuntimeError", rb_eStandardError);
+
+    rb_global_variable(&rb_eFrozenError);
     rb_eFrozenError = rb_define_class("FrozenError", rb_eRuntimeError);
     rb_define_method(rb_eFrozenError, "initialize", frozen_err_initialize, -1);
     rb_define_method(rb_eFrozenError, "receiver", frozen_err_receiver, 0);
+
+    rb_global_variable(&rb_eSecurityError);
     rb_eSecurityError = rb_define_class("SecurityError", rb_eException);
+
+    rb_global_variable(&rb_eNoMemError);
     rb_eNoMemError = rb_define_class("NoMemoryError", rb_eException);
+
+    rb_global_variable(&rb_eEncodingError);
     rb_eEncodingError = rb_define_class("EncodingError", rb_eStandardError);
+
+    rb_global_variable(&rb_eEncCompatError);
     rb_eEncCompatError = rb_define_class_under(rb_cEncoding, "CompatibilityError", rb_eEncodingError);
+
+    rb_global_variable(&rb_eNoMatchingPatternError);
     rb_eNoMatchingPatternError = rb_define_class("NoMatchingPatternError", rb_eStandardError);
+
+    rb_global_variable(&rb_eNoMatchingPatternKeyError);
     rb_eNoMatchingPatternKeyError = rb_define_class("NoMatchingPatternKeyError", rb_eNoMatchingPatternError);
     rb_define_method(rb_eNoMatchingPatternKeyError, "initialize", no_matching_pattern_key_err_initialize, -1);
     rb_define_method(rb_eNoMatchingPatternKeyError, "matchee", no_matching_pattern_key_err_matchee, 0);
     rb_define_method(rb_eNoMatchingPatternKeyError, "key", no_matching_pattern_key_err_key, 0);
 
     syserr_tbl = st_init_numtable();
+    rb_global_variable(&rb_eSystemCallError);
     rb_eSystemCallError = rb_define_class("SystemCallError", rb_eStandardError);
     rb_define_method(rb_eSystemCallError, "initialize", syserr_initialize, -1);
     rb_define_method(rb_eSystemCallError, "errno", syserr_errno, 0);
     rb_define_singleton_method(rb_eSystemCallError, "===", syserr_eqq, 1);
 
+    rb_global_variable(&rb_mErrno);
     rb_mErrno = rb_define_module("Errno");
 
+    rb_global_variable(&rb_mWarning);
     rb_mWarning = rb_define_module("Warning");
     rb_define_singleton_method(rb_mWarning, "[]", rb_warning_s_aref, 1);
     rb_define_singleton_method(rb_mWarning, "[]=", rb_warning_s_aset, 2);
@@ -3416,6 +3462,7 @@ Init_Exception(void)
     rb_extend_object(rb_mWarning, rb_mWarning);
 
     /* :nodoc: */
+    rb_global_variable(&rb_cWarningBuffer);
     rb_cWarningBuffer = rb_define_class_under(rb_mWarning, "buffer", rb_cString);
     rb_define_method(rb_cWarningBuffer, "write", warning_write, -1);
 

--- a/file.c
+++ b/file.c
@@ -7345,7 +7345,10 @@ Init_File(void)
 
     VALUE separator;
 
+    rb_global_variable(&rb_mFileTest);
     rb_mFileTest = rb_define_module("FileTest");
+
+    rb_global_variable(&rb_cFile);
     rb_cFile = rb_define_class("File", rb_cIO);
 
     define_filetest_function("directory?", rb_file_directory_p, 1);
@@ -7447,6 +7450,7 @@ Init_File(void)
 
     rb_define_method(rb_cFile, "flock", rb_file_flock, 1);
 
+    rb_global_variable(&rb_mFConst);
     /*
      * Document-module: File::Constants
      *
@@ -7848,6 +7852,7 @@ Init_File(void)
 
     rb_define_global_function("test", rb_f_test, -1);
 
+    rb_global_variable(&rb_cStat);
     rb_cStat = rb_define_class_under(rb_cFile, "Stat", rb_cObject);
     rb_define_alloc_func(rb_cStat,  rb_stat_s_alloc);
     rb_define_method(rb_cStat, "initialize", rb_stat_init, 1);

--- a/gc.c
+++ b/gc.c
@@ -3284,6 +3284,7 @@ obj_free(rb_objspace_t *objspace, VALUE obj)
         break;
       case T_MODULE:
       case T_CLASS:
+        rb_vm_remove_root_module(obj);
         rb_id_table_free(RCLASS_M_TBL(obj));
         rb_cc_table_free(obj);
         if (rb_shape_obj_too_complex(obj)) {
@@ -6284,6 +6285,12 @@ rb_mark_set(st_table *tbl)
     mark_set(&rb_objspace, tbl);
 }
 
+void
+rb_pin_set_no_mark(st_table *tbl)
+{
+    mark_set(&rb_objspace, tbl);
+}
+
 static int
 mark_keyvalue(st_data_t key, st_data_t value, st_data_t data)
 {
@@ -6708,6 +6715,12 @@ void
 rb_gc_mark_movable(VALUE ptr)
 {
     gc_mark(&rb_objspace, ptr);
+}
+
+void
+rb_gc_pin_no_mark(VALUE ptr)
+{
+    gc_pin(&rb_objspace, ptr);
 }
 
 void

--- a/gc.c
+++ b/gc.c
@@ -13686,6 +13686,7 @@ Init_GC(void)
     VALUE rb_mProfiler;
     VALUE gc_constants;
 
+    rb_global_variable(&rb_mGC);
     rb_mGC = rb_define_module("GC");
 
     gc_constants = rb_hash_new();
@@ -13716,6 +13717,7 @@ Init_GC(void)
     rb_define_singleton_method(rb_mProfiler, "report", gc_profile_report, -1);
     rb_define_singleton_method(rb_mProfiler, "total_time", gc_profile_total_time, 0);
 
+    rb_global_variable(&rb_mObjSpace);
     rb_mObjSpace = rb_define_module("ObjectSpace");
 
     rb_define_module_function(rb_mObjSpace, "each_object", os_each_obj, -1);

--- a/hash.c
+++ b/hash.c
@@ -7130,6 +7130,7 @@ Init_Hash(void)
     id_flatten_bang = rb_intern_const("flatten!");
     id_hash_iter_lev = rb_make_internal_id();
 
+    rb_global_variable(&rb_cHash);
     rb_cHash = rb_define_class("Hash", rb_cObject);
 
     rb_include_module(rb_cHash, rb_mEnumerable);

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -247,6 +247,7 @@ void rb_gc_mark_and_move(VALUE *ptr);
 
 void rb_gc_mark_weak(VALUE *ptr);
 void rb_gc_remove_weak(VALUE parent_obj, VALUE *ptr);
+void rb_gc_pin_no_mark(VALUE);
 
 void rb_gc_ref_update_table_values_only(st_table *tbl);
 

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -52,6 +52,7 @@ VALUE rb_source_location(int *pline);
 const char *rb_source_location_cstr(int *pline);
 void rb_vm_pop_cfunc_frame(void);
 int rb_vm_add_root_module(VALUE module);
+int rb_vm_remove_root_module(VALUE module);
 void rb_vm_check_redefinition_by_prepend(VALUE klass);
 int rb_vm_check_optimizable_mid(VALUE mid);
 VALUE rb_yield_refine_block(VALUE refinement, VALUE refinements);

--- a/io.c
+++ b/io.c
@@ -15530,7 +15530,10 @@ Init_IO(void)
     cygwin_internal(CW_PERFILE, pf);
 #endif
 
+    rb_global_variable(&rb_eIOError);
     rb_eIOError = rb_define_class("IOError", rb_eStandardError);
+
+    rb_global_variable(&rb_eEOFError);
     rb_eEOFError = rb_define_class("EOFError", rb_eIOError);
 
     id_write = rb_intern_const("write");
@@ -15559,10 +15562,12 @@ Init_IO(void)
     rb_define_global_function("p", rb_f_p, -1);
     rb_define_method(rb_mKernel, "display", rb_obj_display, -1);
 
+    rb_global_variable(&rb_cIO);
     rb_cIO = rb_define_class("IO", rb_cObject);
     rb_include_module(rb_cIO, rb_mEnumerable);
 
     /* Can be raised by IO operations when IO#timeout= is set. */
+    rb_global_variable(&rb_eIOTimeoutError);
     rb_eIOTimeoutError = rb_define_class_under(rb_cIO, "TimeoutError", rb_eIOError);
 
     /* Readable event mask for IO#wait. */
@@ -15573,13 +15578,17 @@ Init_IO(void)
     rb_define_const(rb_cIO, "PRIORITY", INT2NUM(RUBY_IO_PRIORITY));
 
     /* exception to wait for reading. see IO.select. */
+    rb_global_variable(&rb_mWaitReadable);
     rb_mWaitReadable = rb_define_module_under(rb_cIO, "WaitReadable");
     /* exception to wait for writing. see IO.select. */
+    rb_global_variable(&rb_mWaitWritable);
     rb_mWaitWritable = rb_define_module_under(rb_cIO, "WaitWritable");
     /* exception to wait for reading by EAGAIN. see IO.select. */
+    rb_global_variable(&rb_eEAGAINWaitReadable);
     rb_eEAGAINWaitReadable = rb_define_class_under(rb_cIO, "EAGAINWaitReadable", rb_eEAGAIN);
     rb_include_module(rb_eEAGAINWaitReadable, rb_mWaitReadable);
     /* exception to wait for writing by EAGAIN. see IO.select. */
+    rb_global_variable(&rb_eEAGAINWaitWritable);
     rb_eEAGAINWaitWritable = rb_define_class_under(rb_cIO, "EAGAINWaitWritable", rb_eEAGAIN);
     rb_include_module(rb_eEAGAINWaitWritable, rb_mWaitWritable);
 #if EAGAIN == EWOULDBLOCK
@@ -15591,16 +15600,20 @@ Init_IO(void)
     rb_define_const(rb_cIO, "EWOULDBLOCKWaitWritable", rb_eEAGAINWaitWritable);
 #else
     /* exception to wait for reading by EWOULDBLOCK. see IO.select. */
+    rb_global_variable(&rb_eEWOULDBLOCKWaitReadable);
     rb_eEWOULDBLOCKWaitReadable = rb_define_class_under(rb_cIO, "EWOULDBLOCKWaitReadable", rb_eEWOULDBLOCK);
     rb_include_module(rb_eEWOULDBLOCKWaitReadable, rb_mWaitReadable);
     /* exception to wait for writing by EWOULDBLOCK. see IO.select. */
+    rb_global_variable(&rb_eEWOULDBLOCKWaitWritable);
     rb_eEWOULDBLOCKWaitWritable = rb_define_class_under(rb_cIO, "EWOULDBLOCKWaitWritable", rb_eEWOULDBLOCK);
     rb_include_module(rb_eEWOULDBLOCKWaitWritable, rb_mWaitWritable);
 #endif
     /* exception to wait for reading by EINPROGRESS. see IO.select. */
+    rb_global_variable(&rb_eEINPROGRESSWaitReadable);
     rb_eEINPROGRESSWaitReadable = rb_define_class_under(rb_cIO, "EINPROGRESSWaitReadable", rb_eEINPROGRESS);
     rb_include_module(rb_eEINPROGRESSWaitReadable, rb_mWaitReadable);
     /* exception to wait for writing by EINPROGRESS. see IO.select. */
+    rb_global_variable(&rb_eEINPROGRESSWaitWritable);
     rb_eEINPROGRESSWaitWritable = rb_define_class_under(rb_cIO, "EINPROGRESSWaitWritable", rb_eEINPROGRESS);
     rb_include_module(rb_eEINPROGRESSWaitWritable, rb_mWaitWritable);
 
@@ -15783,6 +15796,7 @@ Init_IO(void)
     rb_cARGF = rb_define_class("ARGF", rb_cObject);
 #endif
 
+    rb_global_variable(&rb_cARGF);
     rb_cARGF = rb_class_new(rb_cObject);
     rb_set_class_path(rb_cARGF, rb_cObject, "ARGF.class");
     rb_define_alloc_func(rb_cARGF, argf_alloc);

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3620,21 +3620,27 @@ io_buffer_not_inplace(VALUE self)
 void
 Init_IO_Buffer(void)
 {
+    rb_global_variable(&rb_cIOBuffer);
     rb_cIOBuffer = rb_define_class_under(rb_cIO, "Buffer", rb_cObject);
 
     /* Raised when an operation would resize or re-allocate a locked buffer. */
+    rb_global_variable(&rb_eIOBufferLockedError);
     rb_eIOBufferLockedError = rb_define_class_under(rb_cIOBuffer, "LockedError", rb_eRuntimeError);
 
     /* Raised when the buffer cannot be allocated for some reason, or you try to use a buffer that's not allocated. */
+    rb_global_variable(&rb_eIOBufferAllocationError);
     rb_eIOBufferAllocationError = rb_define_class_under(rb_cIOBuffer, "AllocationError", rb_eRuntimeError);
 
     /* Raised when you try to write to a read-only buffer, or resize an external buffer. */
+    rb_global_variable(&rb_eIOBufferAccessError);
     rb_eIOBufferAccessError = rb_define_class_under(rb_cIOBuffer, "AccessError", rb_eRuntimeError);
 
     /* Raised if you try to access a buffer slice which no longer references a valid memory range of the underlying source. */
+    rb_global_variable(&rb_eIOBufferInvalidatedError);
     rb_eIOBufferInvalidatedError = rb_define_class_under(rb_cIOBuffer, "InvalidatedError", rb_eRuntimeError);
 
     /* Raised if the mask given to a binary operation is invalid, e.g. zero length or overlaps the target buffer. */
+    rb_global_variable(&rb_eIOBufferMaskError);
     rb_eIOBufferMaskError = rb_define_class_under(rb_cIOBuffer, "MaskError", rb_eArgError);
 
     rb_define_alloc_func(rb_cIOBuffer, rb_io_buffer_type_allocate);

--- a/iseq.c
+++ b/iseq.c
@@ -4160,6 +4160,7 @@ void
 Init_ISeq(void)
 {
     /* declare ::RubyVM::InstructionSequence */
+    rb_global_variable(&rb_cISeq);
     rb_cISeq = rb_define_class_under(rb_cRubyVM, "InstructionSequence", rb_cObject);
     rb_undef_alloc_func(rb_cISeq);
     rb_define_method(rb_cISeq, "inspect", iseqw_inspect, 0);

--- a/math.c
+++ b/math.c
@@ -1090,7 +1090,10 @@ exp1(sqrt)
 void
 InitVM_Math(void)
 {
+    rb_global_variable(&rb_mMath);
     rb_mMath = rb_define_module("Math");
+
+    rb_global_variable(&rb_eMathDomainError);
     rb_eMathDomainError = rb_define_class_under(rb_mMath, "DomainError", rb_eStandardError);
 
     /*  Definition of the mathematical constant PI as a Float number. */

--- a/numeric.c
+++ b/numeric.c
@@ -6160,8 +6160,13 @@ Init_Numeric(void)
     id_to = rb_intern_const("to");
     id_by = rb_intern_const("by");
 
+    rb_global_variable(&rb_eZeroDivError);
     rb_eZeroDivError = rb_define_class("ZeroDivisionError", rb_eStandardError);
+
+    rb_global_variable(&rb_eFloatDomainError);
     rb_eFloatDomainError = rb_define_class("FloatDomainError", rb_eRangeError);
+
+    rb_global_variable(&rb_cNumeric);
     rb_cNumeric = rb_define_class("Numeric", rb_cObject);
 
     rb_define_method(rb_cNumeric, "singleton_method_added", num_sadded, 1);
@@ -6196,6 +6201,7 @@ Init_Numeric(void)
     rb_define_method(rb_cNumeric, "positive?", num_positive_p, 0);
     rb_define_method(rb_cNumeric, "negative?", num_negative_p, 0);
 
+    rb_global_variable(&rb_cInteger);
     rb_cInteger = rb_define_class("Integer", rb_cNumeric);
     rb_undef_alloc_func(rb_cInteger);
     rb_undef_method(CLASS_OF(rb_cInteger), "new");
@@ -6265,6 +6271,7 @@ Init_Numeric(void)
         rb_gc_register_mark_object(rb_fix_to_s_static[i]);
     }
 
+    rb_global_variable(&rb_cFloat);
     rb_cFloat  = rb_define_class("Float", rb_cNumeric);
 
     rb_undef_alloc_func(rb_cFloat);

--- a/object.c
+++ b/object.c
@@ -4396,6 +4396,7 @@ InitVM_Object(void)
      * - #warn: Issue a warning based on the given messages and options.
      *
      */
+    rb_global_variable(&rb_mKernel);
     rb_mKernel = rb_define_module("Kernel");
     rb_include_module(rb_cObject, rb_mKernel);
     rb_define_private_method(rb_cClass, "inherited", rb_obj_class_inherited, 1);
@@ -4450,8 +4451,10 @@ InitVM_Object(void)
 
     rb_global_variable(&rb_cNilClass);
     rb_cNilClass = rb_define_class("NilClass", rb_cObject);
+
+    rb_global_variable(&rb_cNilClass);
     rb_cNilClass_to_s = rb_fstring_enc_lit("", rb_usascii_encoding());
-    rb_gc_register_mark_object(rb_cNilClass_to_s);
+    rb_global_variable(&rb_cNilClass_to_s);
     rb_define_method(rb_cNilClass, "to_s", rb_nil_to_s, 0);
     rb_define_method(rb_cNilClass, "to_a", nil_to_a, 0);
     rb_define_method(rb_cNilClass, "to_h", nil_to_h, 0);

--- a/object.c
+++ b/object.c
@@ -4448,6 +4448,7 @@ InitVM_Object(void)
     rb_define_global_function("Array", rb_f_array, 1);
     rb_define_global_function("Hash", rb_f_hash, 1);
 
+    rb_global_variable(&rb_cNilClass);
     rb_cNilClass = rb_define_class("NilClass", rb_cObject);
     rb_cNilClass_to_s = rb_fstring_enc_lit("", rb_usascii_encoding());
     rb_gc_register_mark_object(rb_cNilClass_to_s);
@@ -4534,6 +4535,7 @@ InitVM_Object(void)
     rb_undef_method(rb_cClass, "append_features");
     rb_undef_method(rb_cClass, "prepend_features");
 
+    rb_global_variable(&rb_cTrueClass);
     rb_cTrueClass = rb_define_class("TrueClass", rb_cObject);
     rb_cTrueClass_to_s = rb_fstring_enc_lit("true", rb_usascii_encoding());
     rb_gc_register_mark_object(rb_cTrueClass_to_s);
@@ -4546,6 +4548,7 @@ InitVM_Object(void)
     rb_undef_alloc_func(rb_cTrueClass);
     rb_undef_method(CLASS_OF(rb_cTrueClass), "new");
 
+    rb_global_variable(&rb_cFalseClass);
     rb_cFalseClass = rb_define_class("FalseClass", rb_cObject);
     rb_cFalseClass_to_s = rb_fstring_enc_lit("false", rb_usascii_encoding());
     rb_gc_register_mark_object(rb_cFalseClass_to_s);

--- a/proc.c
+++ b/proc.c
@@ -4242,6 +4242,7 @@ Init_Proc(void)
 {
 #undef rb_intern
     /* Proc */
+    rb_global_variable(&rb_cProc);
     rb_cProc = rb_define_class("Proc", rb_cObject);
     rb_undef_alloc_func(rb_cProc);
     rb_define_singleton_method(rb_cProc, "new", rb_proc_s_new, -1);
@@ -4278,10 +4279,12 @@ Init_Proc(void)
     // rb_define_method(rb_cProc, "isolate", rb_proc_isolate, 0); is not accepted.
 
     /* Exceptions */
+    rb_global_variable(&rb_eLocalJumpError);
     rb_eLocalJumpError = rb_define_class("LocalJumpError", rb_eStandardError);
     rb_define_method(rb_eLocalJumpError, "exit_value", localjump_xvalue, 0);
     rb_define_method(rb_eLocalJumpError, "reason", localjump_reason, 0);
 
+    rb_global_variable(&rb_eSysStackError);
     rb_eSysStackError = rb_define_class("SystemStackError", rb_eException);
     rb_vm_register_special_exception(ruby_error_sysstack, rb_eSysStackError, "stack level too deep");
 
@@ -4290,6 +4293,7 @@ Init_Proc(void)
     rb_define_global_function("lambda", f_lambda, 0);
 
     /* Method */
+    rb_global_variable(&rb_cMethod);
     rb_cMethod = rb_define_class("Method", rb_cObject);
     rb_undef_alloc_func(rb_cMethod);
     rb_undef_method(CLASS_OF(rb_cMethod), "new");
@@ -4321,6 +4325,7 @@ Init_Proc(void)
     rb_define_method(rb_mKernel, "singleton_method", rb_obj_singleton_method, 1);
 
     /* UnboundMethod */
+    rb_global_variable(&rb_cUnboundMethod);
     rb_cUnboundMethod = rb_define_class("UnboundMethod", rb_cObject);
     rb_undef_alloc_func(rb_cUnboundMethod);
     rb_undef_method(CLASS_OF(rb_cUnboundMethod), "new");
@@ -4391,6 +4396,7 @@ Init_Proc(void)
 void
 Init_Binding(void)
 {
+    rb_global_variable(&rb_cBinding);
     rb_cBinding = rb_define_class("Binding", rb_cObject);
     rb_undef_alloc_func(rb_cBinding);
     rb_undef_method(CLASS_OF(rb_cBinding), "new");

--- a/process.c
+++ b/process.c
@@ -9205,6 +9205,7 @@ InitVM_process(void)
     rb_define_global_function("exit", f_exit, -1);
     rb_define_global_function("abort", f_abort, -1);
 
+    rb_global_variable(&rb_mProcess);
     rb_mProcess = rb_define_module("Process");
 
 #ifdef WNOHANG
@@ -9240,11 +9241,13 @@ InitVM_process(void)
     rb_define_module_function(rb_mProcess, "detach", proc_detach, 1);
 
     /* :nodoc: */
+    rb_global_variable(&rb_cWaiter);
     rb_cWaiter = rb_define_class_under(rb_mProcess, "Waiter", rb_cThread);
     rb_undef_alloc_func(rb_cWaiter);
     rb_undef_method(CLASS_OF(rb_cWaiter), "new");
     rb_define_method(rb_cWaiter, "pid", detach_process_pid, 0);
 
+    rb_global_variable(&rb_cProcessStatus);
     rb_cProcessStatus = rb_define_class_under(rb_mProcess, "Status", rb_cObject);
     rb_define_alloc_func(rb_cProcessStatus, rb_process_status_allocate);
     rb_undef_method(CLASS_OF(rb_cProcessStatus), "new");

--- a/ractor.c
+++ b/ractor.c
@@ -2517,6 +2517,7 @@ RUBY_SYMBOL_EXPORT_END
 void
 rb_init_ractor_selector(void)
 {
+    rb_global_variable(&rb_cRactorSelector);
     rb_cRactorSelector = rb_define_class_under(rb_cRactor, "Selector", rb_cObject);
     rb_undef_alloc_func(rb_cRactorSelector);
 
@@ -2625,16 +2626,29 @@ rb_init_ractor_selector(void)
 void
 Init_Ractor(void)
 {
+    rb_global_variable(&rb_cRactor);
     rb_cRactor = rb_define_class("Ractor", rb_cObject);
     rb_undef_alloc_func(rb_cRactor);
 
-    rb_eRactorError          = rb_define_class_under(rb_cRactor, "Error", rb_eRuntimeError);
-    rb_eRactorIsolationError = rb_define_class_under(rb_cRactor, "IsolationError", rb_eRactorError);
-    rb_eRactorRemoteError    = rb_define_class_under(rb_cRactor, "RemoteError", rb_eRactorError);
-    rb_eRactorMovedError     = rb_define_class_under(rb_cRactor, "MovedError",  rb_eRactorError);
-    rb_eRactorClosedError    = rb_define_class_under(rb_cRactor, "ClosedError", rb_eStopIteration);
-    rb_eRactorUnsafeError    = rb_define_class_under(rb_cRactor, "UnsafeError", rb_eRactorError);
+    rb_global_variable(&rb_eRactorError);
+    rb_eRactorError = rb_define_class_under(rb_cRactor, "Error", rb_eRuntimeError);
 
+    rb_global_variable(&rb_eRactorIsolationError);
+    rb_eRactorIsolationError = rb_define_class_under(rb_cRactor, "IsolationError", rb_eRactorError);
+
+    rb_global_variable(&rb_eRactorRemoteError);
+    rb_eRactorRemoteError = rb_define_class_under(rb_cRactor, "RemoteError", rb_eRactorError);
+
+    rb_global_variable(&rb_eRactorMovedError);
+    rb_eRactorMovedError = rb_define_class_under(rb_cRactor, "MovedError",  rb_eRactorError);
+
+    rb_global_variable(&rb_eRactorClosedError);
+    rb_eRactorClosedError = rb_define_class_under(rb_cRactor, "ClosedError", rb_eStopIteration);
+
+    rb_global_variable(&rb_eRactorUnsafeError);
+    rb_eRactorUnsafeError = rb_define_class_under(rb_cRactor, "UnsafeError", rb_eRactorError);
+
+    rb_global_variable(&rb_cRactorMovedObject);
     rb_cRactorMovedObject = rb_define_class_under(rb_cRactor, "MovedObject", rb_cBasicObject);
     rb_undef_alloc_func(rb_cRactorMovedObject);
     rb_define_method(rb_cRactorMovedObject, "method_missing", ractor_moved_missing, -1);

--- a/random.c
+++ b/random.c
@@ -1825,6 +1825,7 @@ InitVM_Random(void)
 
     base = rb_define_class_id(id_base, rb_cObject);
     rb_undef_alloc_func(base);
+    rb_global_variable(&rb_cRandom);
     rb_cRandom = rb_define_class("Random", base);
     rb_const_set(rb_cRandom, id_base, base);
     rb_define_alloc_func(rb_cRandom, random_alloc);

--- a/rational.c
+++ b/rational.c
@@ -2750,12 +2750,12 @@ nurat_s_convert(int argc, VALUE *argv, VALUE klass)
 void
 Init_Rational(void)
 {
-    VALUE compat;
     id_abs = rb_intern_const("abs");
     id_integer_p = rb_intern_const("integer?");
     id_i_num = rb_intern_const("@numerator");
     id_i_den = rb_intern_const("@denominator");
 
+    rb_global_variable(&rb_cRational);
     rb_cRational = rb_define_class("Rational", rb_cNumeric);
 
     rb_define_alloc_func(rb_cRational, nurat_s_alloc);
@@ -2803,7 +2803,7 @@ Init_Rational(void)
 
     rb_define_private_method(rb_cRational, "marshal_dump", nurat_marshal_dump, 0);
     /* :nodoc: */
-    compat = rb_define_class_under(rb_cRational, "compatible", rb_cObject);
+    VALUE compat = rb_define_class_under(rb_cRational, "compatible", rb_cObject);
     rb_define_private_method(compat, "marshal_load", nurat_marshal_load, 1);
     rb_marshal_define_compat(rb_cRational, compat, nurat_dumper, nurat_loader);
 

--- a/re.c
+++ b/re.c
@@ -4762,6 +4762,7 @@ rb_reg_timeout_get(VALUE re)
 void
 Init_Regexp(void)
 {
+    rb_global_variable(&rb_eRegexpError);
     rb_eRegexpError = rb_define_class("RegexpError", rb_eStandardError);
 
     onigenc_set_default_encoding(ONIG_ENCODING_ASCII);
@@ -4782,6 +4783,7 @@ Init_Regexp(void)
 
     rb_define_virtual_variable("$=", ignorecase_getter, ignorecase_setter);
 
+    rb_global_variable(&rb_cRegexp);
     rb_cRegexp = rb_define_class("Regexp", rb_cObject);
     rb_define_alloc_func(rb_cRegexp, rb_reg_s_alloc);
     rb_define_singleton_method(rb_cRegexp, "compile", rb_class_new_instance_pass_kw, -1);
@@ -4813,6 +4815,7 @@ Init_Regexp(void)
     rb_define_method(rb_cRegexp, "named_captures", rb_reg_named_captures, 0);
     rb_define_method(rb_cRegexp, "timeout", rb_reg_timeout_get, 0);
 
+    rb_global_variable(&rb_eRegexpTimeoutError);
     rb_eRegexpTimeoutError = rb_define_class_under(rb_cRegexp, "TimeoutError", rb_eRegexpError);
     rb_define_singleton_method(rb_cRegexp, "timeout", rb_reg_s_timeout_get, 0);
     rb_define_singleton_method(rb_cRegexp, "timeout=", rb_reg_s_timeout_set, 1);
@@ -4830,7 +4833,8 @@ Init_Regexp(void)
 
     rb_global_variable(&reg_cache);
 
-    rb_cMatch  = rb_define_class("MatchData", rb_cObject);
+    rb_global_variable(&rb_cMatch);
+    rb_cMatch = rb_define_class("MatchData", rb_cObject);
     rb_define_alloc_func(rb_cMatch, match_alloc);
     rb_undef_method(CLASS_OF(rb_cMatch), "new");
     rb_undef_method(CLASS_OF(rb_cMatch), "allocate");

--- a/string.c
+++ b/string.c
@@ -12139,7 +12139,8 @@ rb_enc_interned_str_cstr(const char *ptr, rb_encoding *enc)
 void
 Init_String(void)
 {
-    rb_cString  = rb_define_class("String", rb_cObject);
+    rb_global_variable(&rb_cString);
+    rb_cString = rb_define_class("String", rb_cObject);
     RUBY_ASSERT(rb_vm_fstring_table());
     st_foreach(rb_vm_fstring_table(), fstring_set_class_i, rb_cString);
     rb_include_module(rb_cString, rb_mComparable);
@@ -12295,6 +12296,7 @@ Init_String(void)
     rb_define_method(rb_cString, "ascii_only?", rb_str_is_ascii_only_p, 0);
 
     /* define UnicodeNormalize module here so that we don't have to look it up */
+    rb_global_variable(&mUnicodeNormalize);
     mUnicodeNormalize          = rb_define_module("UnicodeNormalize");
     id_normalize               = rb_intern_const("normalize");
     id_normalized_p            = rb_intern_const("normalized?");
@@ -12308,6 +12310,7 @@ Init_String(void)
     rb_define_hooked_variable("$-F", &rb_fs, 0, rb_fs_setter);
     rb_gc_register_address(&rb_fs);
 
+    rb_global_variable(&rb_cSymbol);
     rb_cSymbol = rb_define_class("Symbol", rb_cObject);
     rb_include_module(rb_cSymbol, rb_mComparable);
     rb_undef_alloc_func(rb_cSymbol);

--- a/struct.c
+++ b/struct.c
@@ -2164,6 +2164,7 @@ rb_data_inspect(VALUE s)
 void
 InitVM_Struct(void)
 {
+    rb_global_variable(&rb_cStruct);
     rb_cStruct = rb_define_class("Struct", rb_cObject);
     rb_include_module(rb_cStruct, rb_mEnumerable);
 
@@ -2203,6 +2204,7 @@ InitVM_Struct(void)
     rb_define_method(rb_cStruct, "deconstruct", rb_struct_to_a, 0);
     rb_define_method(rb_cStruct, "deconstruct_keys", rb_struct_deconstruct_keys, 1);
 
+    rb_global_variable(&rb_cData);
     rb_cData = rb_define_class("Data", rb_cObject);
 
     rb_undef_method(CLASS_OF(rb_cData), "new");

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -3300,6 +3300,32 @@ class TestModule < Test::Unit::TestCase
     CODE
   end
 
+  def test_rooted_module_leak
+    # [Bug #20311]
+    assert_no_memory_leak([], <<~PREP, <<~CODE, rss: true)
+      code = proc do
+        Struct.new("A")
+        Struct.send(:remove_const, :A)
+      end
+
+      1_000.times(&code)
+    PREP
+      300_000.times(&code)
+    CODE
+
+    assert_no_memory_leak([], <<~PREP, <<~CODE, rss: true)
+      $VERBOSE = nil
+      code = proc do
+        Struct.new("A")
+        Struct.send(:const_set, :A, nil)
+      end
+
+      1_000.times(&code)
+    PREP
+      300_000.times(&code)
+    CODE
+  end
+
   def test_complemented_method_entry_memory_leak
     # [Bug #19894] [Bug #19896]
     assert_no_memory_leak([], <<~PREP, <<~CODE, rss: true)

--- a/thread.c
+++ b/thread.c
@@ -5384,7 +5384,6 @@ Init_Thread_Mutex(void)
 void
 Init_Thread(void)
 {
-    VALUE cThGroup;
     rb_thread_t *th = GET_THREAD();
 
     sym_never = ID2SYM(rb_intern_const("never"));
@@ -5451,7 +5450,7 @@ Init_Thread(void)
     rb_vm_register_special_exception(ruby_error_stream_closed, rb_eIOError,
                                      "stream closed in another thread");
 
-    cThGroup = rb_define_class("ThreadGroup", rb_cObject);
+    VALUE cThGroup = rb_define_class("ThreadGroup", rb_cObject);
     rb_define_alloc_func(cThGroup, thgroup_s_alloc);
     rb_define_method(cThGroup, "list", thgroup_list, 0);
     rb_define_method(cThGroup, "enclose", thgroup_enclose, 0);
@@ -5463,6 +5462,7 @@ Init_Thread(void)
         rb_define_const(cThGroup, "Default", th->thgroup);
     }
 
+    rb_global_variable(&rb_eThreadError);
     rb_eThreadError = rb_define_class("ThreadError", rb_eStandardError);
 
     /* init thread core */

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -1598,13 +1598,21 @@ Init_thread_sync(void)
 {
 #undef rb_intern
 #if defined(TEACH_RDOC) && TEACH_RDOC == 42
+    rb_global_variable(&rb_cMutex);
     rb_cMutex = rb_define_class_under(rb_cThread, "Mutex", rb_cObject);
+
+    rb_global_variable(&rb_cConditionVariable);
     rb_cConditionVariable = rb_define_class_under(rb_cThread, "ConditionVariable", rb_cObject);
+
+    rb_global_variable(&rb_cQueue);
     rb_cQueue = rb_define_class_under(rb_cThread, "Queue", rb_cObject);
+
+    rb_global_variable(&rb_cSizedQueue);
     rb_cSizedQueue = rb_define_class_under(rb_cThread, "SizedQueue", rb_cObject);
 #endif
 
 #define DEFINE_CLASS(name, super) \
+    rb_global_variable(&rb_c##name); \
     rb_c##name = define_thread_class(rb_cThread, rb_intern(#name), rb_c##super)
 
     /* Mutex */
@@ -1623,6 +1631,7 @@ Init_thread_sync(void)
     DEFINE_CLASS(Queue, Object);
     rb_define_alloc_func(rb_cQueue, queue_alloc);
 
+    rb_global_variable(&rb_eClosedQueueError);
     rb_eClosedQueueError = rb_define_class("ClosedQueueError", rb_eStopIteration);
 
     rb_define_method(rb_cQueue, "initialize", rb_queue_initialize, -1);

--- a/time.c
+++ b/time.c
@@ -5777,6 +5777,7 @@ Init_Time(void)
     str_empty = rb_fstring_lit("");
     rb_gc_register_mark_object(str_empty);
 
+    rb_global_variable(&rb_cTime);
     rb_cTime = rb_define_class("Time", rb_cObject);
     VALUE scTime = rb_singleton_class(rb_cTime);
     rb_include_module(rb_cTime, rb_mComparable);

--- a/variable.c
+++ b/variable.c
@@ -3272,6 +3272,10 @@ rb_const_remove(VALUE mod, ID id)
         autoload_delete(mod, id);
         val = Qnil;
     }
+    else if (RB_TYPE_P(val, T_CLASS) || RB_TYPE_P(val, T_MODULE)) {
+        // The module may have beed pinned by `rb_vm_add_root_module` because defined from C
+        rb_vm_remove_root_module(val);
+    }
 
     ruby_xfree(ce);
 
@@ -3670,6 +3674,11 @@ const_tbl_update(struct autoload_const *ac, int autoload_force)
             if (!NIL_P(ce->file) && ce->line) {
                 rb_compile_warn(RSTRING_PTR(ce->file), ce->line,
                                 "previous definition of %"PRIsVALUE" was here", name);
+            }
+
+            if (RB_TYPE_P(ce->value, T_CLASS) || RB_TYPE_P(ce->value, T_MODULE)) {
+                // The module may have beed pinned by `rb_vm_add_root_module` because defined from C
+                rb_vm_remove_root_module(ce->value);
             }
         }
         rb_clear_constant_cache_for_id(id);

--- a/variable.c
+++ b/variable.c
@@ -3274,7 +3274,7 @@ rb_const_remove(VALUE mod, ID id)
     }
     else if (RB_TYPE_P(val, T_CLASS) || RB_TYPE_P(val, T_MODULE)) {
         // The module may have beed pinned by `rb_vm_add_root_module` because defined from C
-        rb_vm_remove_root_module(val);
+        // rb_vm_remove_root_module(val);
     }
 
     ruby_xfree(ce);
@@ -3678,7 +3678,7 @@ const_tbl_update(struct autoload_const *ac, int autoload_force)
 
             if (RB_TYPE_P(ce->value, T_CLASS) || RB_TYPE_P(ce->value, T_MODULE)) {
                 // The module may have beed pinned by `rb_vm_add_root_module` because defined from C
-                rb_vm_remove_root_module(ce->value);
+                // rb_vm_remove_root_module(ce->value);
             }
         }
         rb_clear_constant_cache_for_id(id);

--- a/vm.c
+++ b/vm.c
@@ -3933,6 +3933,7 @@ Init_VM(void)
      * prototyping, and research.  Normal users must not use it.
      * This module is not portable between Ruby implementations.
      */
+    rb_global_variable(&rb_cRubyVM);
     rb_cRubyVM = rb_define_class("RubyVM", rb_cObject);
     rb_undef_alloc_func(rb_cRubyVM);
     rb_undef_method(CLASS_OF(rb_cRubyVM), "new");
@@ -4128,6 +4129,7 @@ Init_VM(void)
      * 	on some platforms.
      *
      */
+    rb_global_variable(&rb_cThread);
     rb_cThread = rb_define_class("Thread", rb_cObject);
     rb_undef_alloc_func(rb_cThread);
 

--- a/vm.c
+++ b/vm.c
@@ -3039,32 +3039,14 @@ rb_vm_register_special_exception_str(enum ruby_special_exceptions sp, VALUE cls,
     rb_gc_register_mark_object(exc);
 }
 
-static int
-vm_add_root_module_i(st_data_t *key, st_data_t *val, st_data_t _arg, int existing)
-{
-    (*val)++;
-    return ST_CONTINUE;
-}
-
 int
 rb_vm_add_root_module(VALUE module)
 {
     rb_vm_t *vm = GET_VM();
 
-    st_update(vm->defined_module_hash, (st_data_t)module, vm_add_root_module_i, (st_data_t)0);
+    st_insert(vm->defined_module_hash, (st_data_t)module, (st_data_t)Qtrue);
 
     return TRUE;
-}
-
-
-static int
-vm_remove_root_module_i(st_data_t *key, st_data_t *val, st_data_t _arg, int existing)
-{
-    (*val)--;
-    if (*val <= 0) {
-        return ST_DELETE;
-    }
-    return ST_CONTINUE;
 }
 
 int
@@ -3076,7 +3058,7 @@ rb_vm_remove_root_module(VALUE module)
 
     rb_vm_t *vm = GET_VM();
 
-    st_update(vm->defined_module_hash, (st_data_t)module, vm_remove_root_module_i, (st_data_t)0);
+    st_delete(vm->defined_module_hash, (st_data_t *)&module, NULL);
 
     return TRUE;
 }

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -2695,6 +2695,7 @@ Init_vm_eval(void)
     rb_define_method(rb_cModule, "module_eval", rb_mod_module_eval_internal, -1);
     rb_define_method(rb_cModule, "class_eval", rb_mod_module_eval_internal, -1);
 
+    rb_global_variable(&rb_eUncaughtThrow);
     rb_eUncaughtThrow = rb_define_class("UncaughtThrowError", rb_eArgError);
     rb_define_method(rb_eUncaughtThrow, "initialize", uncaught_throw_init, -1);
     rb_define_method(rb_eUncaughtThrow, "tag", uncaught_throw_tag, 0);

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -1622,6 +1622,7 @@ Init_vm_trace(void)
     rb_define_method(rb_cThread, "set_trace_func", thread_set_trace_func_m, 1);
     rb_define_method(rb_cThread, "add_trace_func", thread_add_trace_func_m, 1);
 
+    rb_global_variable(&rb_cTracePoint);
     rb_cTracePoint = rb_define_class("TracePoint", rb_cObject);
     rb_undef_alloc_func(rb_cTracePoint);
 }


### PR DESCRIPTION
[[Bug #20311]](https://bugs.ruby-lang.org/issues/20311)

All module and classes defined from C are stored in this table to ensure they are pinned and won't be moved by the compactor.

However this means we need to remove them from it whenever a constant referencing them is removed.

But since a same class or module may be referenced under multiple names, we have to do some ref counting.