### PR TITLE
YJIT: Support opt_invokebuiltin_delegate for leaf builtin

### DIFF
--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1600,6 +1600,19 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_leaf_builtin
+    assert_compiles(code_gc_helpers + <<~'RUBY', exits: :any, result: 1)
+      before = RubyVM::YJIT.runtime_stats[:num_send_iseq_leaf]
+      return 1 if before.nil?
+
+      def entry = self.class
+      entry
+
+      after = RubyVM::YJIT.runtime_stats[:num_send_iseq_leaf]
+      after - before
+    RUBY
+  end
+
   private
 
   def code_gc_helpers

--- a/yjit.c
+++ b/yjit.c
@@ -739,15 +739,17 @@ rb_yjit_iseq_builtin_attrs(const rb_iseq_t *iseq)
     return iseq->body->builtin_attrs;
 }
 
-// If true, the iseq has only opt_invokebuiltin_delegate_leave and leave insns.
+// If true, the iseq has only opt_invokebuiltin_delegate(_leave) and leave insns.
 static bool
 invokebuiltin_delegate_leave_p(const rb_iseq_t *iseq)
 {
-    unsigned int invokebuiltin_len = insn_len(BIN(opt_invokebuiltin_delegate_leave));
-    unsigned int leave_len = insn_len(BIN(leave));
-    return iseq->body->iseq_size == (invokebuiltin_len + leave_len) &&
-        rb_vm_insn_addr2opcode((void *)iseq->body->iseq_encoded[0]) == BIN(opt_invokebuiltin_delegate_leave) &&
-        rb_vm_insn_addr2opcode((void *)iseq->body->iseq_encoded[invokebuiltin_len]) == BIN(leave);
+    int insn1 = rb_vm_insn_addr2opcode((void *)iseq->body->iseq_encoded[0]);
+    if ((int)iseq->body->iseq_size != insn_len(insn1) + insn_len(BIN(leave))) {
+        return false;
+    }
+    int insn2 = rb_vm_insn_addr2opcode((void *)iseq->body->iseq_encoded[insn_len(insn1)]);
+    return (insn1 == BIN(opt_invokebuiltin_delegate) || insn1 == BIN(opt_invokebuiltin_delegate_leave)) &&
+            insn2 == BIN(leave);
 }
 
 // Return an rb_builtin_function if the iseq contains only that builtin function.


### PR DESCRIPTION
Methods like `Kernel#class` have an ISEQ like `opt_invokebuiltin_delegate_leave` + `leave` in local environments. On SFR and Core, however, it turns into `opt_invokebuiltin_delegate` + `leave` for some reason. While we're still investigating why it happens, these ISEQs work in the same way whether we fix it or not.

This PR lets `rb_yjit_builtin_function` extract a builtin function whether the first instruction is `opt_invokebuiltin_delegate_leave` or `opt_invokebuiltin_delegate`.

On SFR, `Kernel#class` is 2.0% of all ISEQ calls, `Symbol#to_s` is 1.1%, `Integer#zero?` is 0.6%, and `Array#last` is 0.5%. So this PR should inline 4.2% or more ISEQ calls on SFR.