### PR TITLE
YJIT: No need to set cfp->sp when setting escaped locals

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -521,6 +521,7 @@ vm_env_write_slowpath(const VALUE *ep, int index, VALUE v)
     RB_DEBUG_COUNTER_INC(lvar_set_slowpath);
 }
 
+// YJIT assumes this function never runs GC
 static inline void
 vm_env_write(const VALUE *ep, int index, VALUE v)
 {


### PR DESCRIPTION
While writing to the env object can add it to the remember set,
it shouldn't trigger a GC run.

---

Locally with a patch that scans the VM stack for left-over canaries, the canary from before this change was ending up on a different thread, for some reason. I'll need to dig deeper, but in any case, there is no need to `prepare_call` here.
