### PR TITLE
.travis.yml: Allow failures for ppc64le and s390x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,8 +114,8 @@ matrix:
   allow_failures:
     # Allow failures for the unstable jobs.
     # - name: arm64-linux
-    # - name: ppc64le-linux
-    # - name: s390x-linux
+    - name: ppc64le-linux
+    - name: s390x-linux
     # The 2nd arm64 pipeline may be unstable.
     # - name: arm32-linux
   fast_finish: true


### PR DESCRIPTION
Because Travis ppc64le/s390x are unstable.

ppc64le:
* https://app.travis-ci.com/github/ruby/ruby/builds/269211469
* https://app.travis-ci.com/github/ruby/ruby/builds/269204073

s390x:
* https://app.travis-ci.com/github/ruby/ruby/builds/269201221