### PR TITLE
Make Struct memory leak test faster

### DIFF
--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -544,7 +544,7 @@ module TestStruct
 
       1_000.times(&code)
     PREP
-      300_000.times(&code)
+      50_000.times(&code)
     CODE
   end
 


### PR DESCRIPTION
[Bug #20311]

It times out on some platform, so we can reduce iterations. On my machine it completes in 250ms and RSS grows 8X.

cc @peterzhu2118 @ko1 