### PR TITLE
[Bug #20322] Fix rb_enc_interned_str_cstr null encoding

### DIFF
--- a/ext/-test-/string/fstring.c
+++ b/ext/-test-/string/fstring.c
@@ -19,13 +19,13 @@ bug_s_fstring_fake_str(VALUE self)
 VALUE
 bug_s_rb_enc_interned_str(VALUE self, VALUE encoding)
 {
-    return rb_enc_interned_str("foo", 3, RDATA(encoding)->data);
+    return rb_enc_interned_str("foo", 3, NIL_P(encoding) ? NULL : RDATA(encoding)->data);
 }
 
 VALUE
 bug_s_rb_enc_str_new(VALUE self, VALUE encoding)
 {
-    return rb_enc_str_new("foo", 3, RDATA(encoding)->data);
+    return rb_enc_str_new("foo", 3, NIL_P(encoding) ? NULL : RDATA(encoding)->data);
 }
 
 void

--- a/spec/ruby/optional/capi/ext/string_spec.c
+++ b/spec/ruby/optional/capi/ext/string_spec.c
@@ -573,7 +573,7 @@ static VALUE string_spec_rb_str_unlocktmp(VALUE self, VALUE str) {
 }
 
 static VALUE string_spec_rb_enc_interned_str_cstr(VALUE self, VALUE str, VALUE enc) {
-  rb_encoding *e = rb_to_encoding(enc);
+  rb_encoding *e = NIL_P(enc) ? 0 : rb_to_encoding(enc);
   return rb_enc_interned_str_cstr(RSTRING_PTR(str), e);
 }
 

--- a/spec/ruby/optional/capi/string_spec.rb
+++ b/spec/ruby/optional/capi/string_spec.rb
@@ -1236,6 +1236,14 @@ end
     it "returns the same string as String#-@" do
       @s.rb_enc_interned_str_cstr("hello", Encoding::UTF_8).should.equal?(-"hello")
     end
+
+    ruby_version_is "3.4" do
+      it "uses the default encoding if encoding is null" do
+        str = "hello"
+        val = @s.rb_enc_interned_str_cstr(str, nil)
+        val.encoding.should == Encoding::ASCII_8BIT
+      end
+    end
   end
 
   describe "rb_str_to_interned_str" do

--- a/spec/ruby/optional/capi/string_spec.rb
+++ b/spec/ruby/optional/capi/string_spec.rb
@@ -1237,7 +1237,7 @@ end
       @s.rb_enc_interned_str_cstr("hello", Encoding::UTF_8).should.equal?(-"hello")
     end
 
-    ruby_version_is "3.4" do
+    ruby_bug "#20322", ""..."3.4" do
       it "uses the default encoding if encoding is null" do
         str = "hello"
         val = @s.rb_enc_interned_str_cstr(str, nil)

--- a/string.c
+++ b/string.c
@@ -12122,7 +12122,7 @@ rb_interned_str_cstr(const char *ptr)
 VALUE
 rb_enc_interned_str(const char *ptr, long len, rb_encoding *enc)
 {
-    if (UNLIKELY(rb_enc_autoload_p(enc))) {
+    if (enc != NULL && UNLIKELY(rb_enc_autoload_p(enc))) {
         rb_enc_autoload(enc);
     }
 

--- a/test/-ext-/string/test_fstring.rb
+++ b/test/-ext-/string/test_fstring.rb
@@ -20,12 +20,20 @@ class Test_String_Fstring < Test::Unit::TestCase
     RUBY
   end
 
+  def test_rb_enc_interned_str_null_encoding
+    assert_equal Encoding::ASCII_8BIT, Bug::String.rb_enc_interned_str(nil).encoding
+  end
+
   def test_rb_enc_str_new_autoloaded_encoding
     assert_separately([], <<~RUBY)
       require '-test-/string'
       assert_include(Encoding::CESU_8.inspect, 'autoload')
       Bug::String.rb_enc_str_new(Encoding::CESU_8)
     RUBY
+  end
+
+  def test_rb_enc_str_new_null_encoding
+    assert_equal Encoding::ASCII_8BIT, Bug::String.rb_enc_str_new(nil).encoding
   end
 
   def test_instance_variable


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20322

While adding support for `rb_enc_interned_str_cstr` [in TruffleRuby](https://github.com/oracle/truffleruby/pull/3427), we noticed the documentation says that `enc` can be a null pointer: https://github.com/ruby/ruby/blob/93556d46203545bc2364b1c0dd1281ba098f3cc9/include/ruby/internal/encoding/string.h#L120

However, this currently causes a segmentation fault when it tries to [autoload the encoding](https://github.com/ruby/ruby/blob/93556d46203545bc2364b1c0dd1281ba098f3cc9/string.c#L12125-L12127) because it calls `rb_enc_mbmaxlen` which [expects a non-null encoding](https://github.com/ruby/ruby/blob/93556d46203545bc2364b1c0dd1281ba098f3cc9/include/ruby/internal/encoding/encoding.h#L448). This commit fixes the issue by checking for NULL before calling `rb_enc_autoload`.

I'm not sure how necessary the fix is, perhaps nobody has encountered this issue. Alternatively we could just remove the note about null pointers from the docs.