### PR TITLE
Refactor VM root modules out

### DIFF
--- a/class.c
+++ b/class.c
@@ -810,7 +810,7 @@ boot_defclass(const char *name, VALUE super)
     ID id = rb_intern(name);
 
     rb_const_set((rb_cObject ? rb_cObject : obj), id, obj);
-    rb_vm_add_root_module(obj);
+    rb_gc_register_mark_object(obj);
     return obj;
 }
 
@@ -986,14 +986,14 @@ rb_define_class(const char *name, VALUE super)
         }
 
         /* Class may have been defined in Ruby and not pin-rooted */
-        rb_vm_add_root_module(klass);
+        rb_gc_register_mark_object(klass);
         return klass;
     }
     if (!super) {
         rb_raise(rb_eArgError, "no super class for '%s'", name);
     }
     klass = rb_define_class_id(id, super);
-    rb_vm_add_root_module(klass);
+    rb_gc_register_mark_object(klass);
     rb_const_set(rb_cObject, id, klass);
     rb_class_inherited(super, klass);
 
@@ -1043,7 +1043,7 @@ VALUE
 rb_define_class_id_under(VALUE outer, ID id, VALUE super)
 {
     VALUE klass = rb_define_class_id_under_no_pin(outer, id, super);
-    rb_vm_add_root_module(klass);
+    rb_gc_register_mark_object(klass);
     return klass;
 }
 
@@ -1097,11 +1097,11 @@ rb_define_module(const char *name)
                      name, rb_obj_class(module));
         }
         /* Module may have been defined in Ruby and not pin-rooted */
-        rb_vm_add_root_module(module);
+        rb_gc_register_mark_object(module);
         return module;
     }
     module = rb_module_new();
-    rb_vm_add_root_module(module);
+    rb_gc_register_mark_object(module);
     rb_const_set(rb_cObject, id, module);
 
     return module;

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -51,7 +51,6 @@ const void **rb_vm_get_insns_address_table(void);
 VALUE rb_source_location(int *pline);
 const char *rb_source_location_cstr(int *pline);
 void rb_vm_pop_cfunc_frame(void);
-int rb_vm_add_root_module(VALUE module);
 void rb_vm_check_redefinition_by_prepend(VALUE klass);
 int rb_vm_check_optimizable_mid(VALUE mid);
 VALUE rb_yield_refine_block(VALUE refinement, VALUE refinements);

--- a/struct.c
+++ b/struct.c
@@ -496,7 +496,7 @@ rb_struct_define(const char *name, ...)
     }
     else {
         st = new_struct(rb_str_new2(name), rb_cStruct);
-        rb_vm_add_root_module(st);
+        rb_gc_register_mark_object(st);
     }
     return setup_struct(st, ary);
 }
@@ -1705,7 +1705,7 @@ rb_data_define(VALUE super, ...)
     va_end(ar);
     if (!super) super = rb_cData;
     VALUE klass = setup_data(anonymous_struct(super), ary);
-    rb_vm_add_root_module(klass);
+    rb_gc_register_mark_object(klass);
     return klass;
 }
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -744,8 +744,6 @@ typedef struct rb_vm_struct {
     VALUE coverages, me2counter;
     int coverage_mode;
 
-    st_table * defined_module_hash;
-
     struct rb_objspace *objspace;
 
     rb_at_exit_list *at_exit;


### PR DESCRIPTION
This `st_table` is used to both mark and pin classes defined from the C API. But `vm->mark_object_ary` already does both much more efficiently.

Currently a Ruby process starts with 252 rooted classes, which uses `7224B` in an `st_table` or `2016B` in an `RArray`.

So a baseline of 5kB saved, but since `mark_object_ary` is preallocated with `1024` slots but only use `405` of them, it's a net `7kB` save.