### PR TITLE
[DOC] Fix invalid documentation for `reachable_objects_from`

### DIFF
--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -623,7 +623,7 @@ collect_values(st_data_t key, st_data_t value, st_data_t data)
  *
  *  With this method, you can find memory leaks.
  *
- *  This method is only expected to work except with C Ruby.
+ *  This method is only expected to work with C Ruby.
  *
  *  Example:
  *    ObjectSpace.reachable_objects_from(['a', 'b', 'c'])


### PR DESCRIPTION
Previous documentation is stating the opposite (that the method won't work for CRuby).