### PR TITLE
Reapply "mkmf.rb: Define missing `POSTLINK` variable in generated Makefile

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -2148,6 +2148,7 @@ ARCH_FLAG = #{$ARCH_FLAG}
 DLDFLAGS = $(ldflags) $(dldflags) $(ARCH_FLAG)
 LDSHARED = #{CONFIG['LDSHARED']}
 LDSHAREDXX = #{config_string('LDSHAREDXX') || '$(LDSHARED)'}
+POSTLINK = #{config_string('POSTLINK', RbConfig::CONFIG)}
 AR = #{CONFIG['AR']}
 LD = #{CONFIG['LD']}
 EXEEXT = #{CONFIG['EXEEXT']}


### PR DESCRIPTION
This reverts commit 0ae0a0c1c3bb01d118c5a924d731a2b3e9774105.