### PR TITLE
.travis.yml: Allow failures for arm64 and arm32 cases temporarily.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,11 +113,11 @@ matrix:
     - <<: *arm32-linux
   allow_failures:
     # Allow failures for the unstable jobs.
-    # - name: arm64-linux
+    - name: arm64-linux
     - name: ppc64le-linux
     - name: s390x-linux
     # The 2nd arm64 pipeline may be unstable.
-    # - name: arm32-linux
+    - name: arm32-linux
   fast_finish: true
 
 before_script:


### PR DESCRIPTION
It's to avoid the failures by the infra issues in the term of the following maintenance.

There is a planned maintenance on March 6th 2024 between 8:00 and 12:00 UTC+0. The Travis service may be temporarily unavailable. https://bugs.ruby-lang.org/issues/20013#note-28