### PR TITLE
Load iseq hidden variables as 0

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -11865,7 +11865,7 @@ ibf_load_id(const struct ibf_load *load, const ID id_index)
     VALUE sym = ibf_load_object(load, id_index);
     if (rb_type_p(sym, T_FIXNUM)) {
         /* Load hidden local variables as indexes */
-        return NUM2LONG(sym);
+        return NUM2ULONG(sym);
     }
     return rb_sym2id(sym);
 }

--- a/compile.c
+++ b/compile.c
@@ -11863,7 +11863,7 @@ ibf_load_id(const struct ibf_load *load, const ID id_index)
         return 0;
     }
     VALUE sym = ibf_load_object(load, id_index);
-    if (rb_type_p(sym, T_FIXNUM)) {
+    if (FIXNUM_P(sym) || RB_BIGNUM_TYPE_P(sym)) {
         /* Load hidden local variables as indexes */
         return NUM2ULONG(sym);
     }

--- a/compile.c
+++ b/compile.c
@@ -11863,7 +11863,7 @@ ibf_load_id(const struct ibf_load *load, const ID id_index)
         return 0;
     }
     VALUE sym = ibf_load_object(load, id_index);
-    if (FIXNUM_P(sym) || RB_BIGNUM_TYPE_P(sym)) {
+    if (rb_integer_type_p(sym)) {
         /* Load hidden local variables as indexes */
         return NUM2ULONG(sym);
     }

--- a/compile.c
+++ b/compile.c
@@ -11865,7 +11865,7 @@ ibf_load_id(const struct ibf_load *load, const ID id_index)
     VALUE sym = ibf_load_object(load, id_index);
     if (rb_type_p(sym, T_FIXNUM)) {
         /* Load hidden local variables as indexes */
-        return FIX2INT(sym);
+        return NUM2LONG(sym);
     }
     return rb_sym2id(sym);
 }
@@ -12393,7 +12393,7 @@ ibf_dump_local_table(struct ibf_dump *dump, const rb_iseq_t *iseq)
         VALUE v = ibf_dump_id(dump, body->local_table[i]);
         if (v == 0) {
             /* Dump hidden local variables as indexes, so load_from_binary will work with them */
-            v = ibf_dump_object(dump, ULONG2NUM(size-i+1));
+            v = ibf_dump_object(dump, ULONG2NUM(body->local_table[i]));
         }
         table[i] = v;
     }


### PR DESCRIPTION
This fixes test failures when running tests with
RUBY_ISEQ_DUMP_DEBUG=to_binary.