### PR TITLE
Use include instead of equal assertion.

### DIFF
--- a/spec/ruby/core/binding/irb_spec.rb
+++ b/spec/ruby/core/binding/irb_spec.rb
@@ -11,6 +11,8 @@ describe "Binding#irb" do
       pipe.readlines.map(&:chomp)
     end
 
-    out[-3..-1].should == ["a ** 2", "100", "exit"]
+    [out[-3..-1], ["a ** 2", "100", "exit"]].transpose.each do |actual, expected|
+      actual.should include(expected)
+    end
   end
 end


### PR DESCRIPTION
irb will load multiple rc files now. If developer have their rcfile on home directory or etc, equal assertion will fail with custom prompt.