### PR TITLE
Revert ".travis.yml: Allow failures for arm64 and arm32 cases temporarily."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,11 +113,11 @@ matrix:
     - <<: *arm32-linux
   allow_failures:
     # Allow failures for the unstable jobs.
-    - name: arm64-linux
+    # - name: arm64-linux
     - name: ppc64le-linux
     - name: s390x-linux
     # The 2nd arm64 pipeline may be unstable.
-    - name: arm32-linux
+    # - name: arm32-linux
   fast_finish: true
 
 before_script:


### PR DESCRIPTION
This reverts commit 23dc7aa2c5a104e73563134a595124804379f049.

It seems that the planned maintenance was finished. https://bugs.ruby-lang.org/issues/20013#note-28