### PR TITLE
[Update classes.rb] Rename Kiev to Kyiv

### DIFF
--- a/spec/ruby/core/time/fixtures/classes.rb
+++ b/spec/ruby/core/time/fixtures/classes.rb
@@ -59,7 +59,7 @@ module TimeSpecs
   Zone = Struct.new(:std, :dst, :dst_range)
   Zones = {
     "Asia/Colombo" => Zone[Z[5*3600+30*60, "MMT"], nil, nil],
-    "Europe/Kiev" => Zone[Z[2*3600, "EET"], Z[3*3600, "EEST"], 4..10],
+    "Europe/Kyiv" => Zone[Z[2*3600, "EET"], Z[3*3600, "EEST"], 4..10],
     "PST" => Zone[Z[(-9*60*60), "PST"], nil, nil],
   }
 


### PR DESCRIPTION
Rename Kiev to Kyiv

The city name is listed as “Kiev,” which is the russian variant.

Resolutions of UN Conferences on the Standardization of Geographical Names recommend that countries cut back on using exonyms (traditional names) and prioritise national official names in publications, documents, and on maps, and that they use latinization systems adopted and recommended by the UN Group of Experts on Geographical Names (as submitted by the particular country) in transliterating foreign toponyms (from languages not based on the Latin alphabet).

For international use of Ukrainian geographical names, the Ukrainian Romanization system is used, as recommended by Resolution X/9 “Romanization of Ukrainian geographical names” of the X UN Conference on the Standardization of Geographical Names (New York, 2012).

At that Conference, “Toponymic Guidelines for Map and other Editors. Ukraine (for international use)” were also approved, setting out the spelling rules for Ukrainian geographical names and their rendering in Latin, and information about the administrative and territorial division of Ukraine (in Ukrainian and Latin), which is available on the website of the UN Group of Experts on Geographical Names (UNGEGN).

https://unstats.un.org/UNSD/geoinfo/UNGEGN/ungegnConf10.html