### PR TITLE
[Bug #20327] Do not count subsecond to calculate UTC offset

### DIFF
--- a/test/ruby/test_time_tz.rb
+++ b/test/ruby/test_time_tz.rb
@@ -695,6 +695,13 @@ module TestTimeTZ::WithTZ
     assert_equal(t.dst?, t2.dst?)
   end
 
+  def subtest_fractional_second(time_class, tz, tzarg, tzname, abbr, utc_offset)
+    t = time_class.new(2024, 1, 1, 23, 59, 59.9r, tzarg)
+    assert_equal(utc_offset[t.dst? ? 1 : 0], t.utc_offset)
+    t = time_class.new(2024, 7, 1, 23, 59, 59.9r, tzarg)
+    assert_equal(utc_offset[t.dst? ? 1 : 0], t.utc_offset)
+  end
+
   def test_invalid_zone
     make_timezone("INVALID", "INV", 0)
   rescue => e
@@ -719,6 +726,7 @@ module TestTimeTZ::WithTZ
     "Asia/Tokyo" => ["JST", +9*3600],
     "America/Los_Angeles" => ["PST", -8*3600, "PDT", -7*3600],
     "Africa/Ndjamena" => ["WAT", +1*3600],
+    "Etc/UTC" => ["UTC", 0],
   }
 
   def make_timezone(tzname, abbr, utc_offset, abbr2 = nil, utc_offset2 = nil)

--- a/time.c
+++ b/time.c
@@ -2346,7 +2346,7 @@ zone_timelocal(VALUE zone, VALUE time)
     struct time_object *tobj = RTYPEDDATA_GET_DATA(time);
     wideval_t t, s;
 
-    t = rb_time_unmagnify(tobj->timew);
+    split_second(tobj->timew, &t, &s);
     tm = tm_from_time(rb_cTimeTM, time);
     utc = rb_check_funcall(zone, id_local_to_utc, 1, &tm);
     if (UNDEF_P(utc)) return 0;


### PR DESCRIPTION
Assume that there will never be any time zones with UTC offsets that are subseconds.
Historically, UTC offset has only been used down to the second.