### PR TITLE
Setup ruby before setup directories

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -63,6 +63,11 @@ jobs:
         with:
           arch: ${{ matrix.arch }}
 
+      - uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # v1.172.0
+        with:
+          ruby-version: '3.0'
+          bundler: none
+
       - uses: ./.github/actions/setup/directories
         with:
           srcdir: src
@@ -71,11 +76,6 @@ jobs:
           dummy-files: ${{ matrix.test_task == 'check' }}
           # Set fetch-depth: 10 so that Launchable can receive commits information.
           fetch-depth: 10
-
-      - uses: ruby/setup-ruby@d4526a55538b775af234ba4af27118ed6f8f6677 # v1.172.0
-        with:
-          ruby-version: '3.0'
-          bundler: none
 
       - name: Run configure
         env:


### PR DESCRIPTION
When `makeup: true`, setup/directories also prepare auto generated source files, and requires baseruby.