### PR TITLE
Disregard si_addr for fatal signals sent from other processes

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -872,9 +872,9 @@ check_stack_overflow(int sig, const void *addr)
 # else
 #   define FAULT_ADDRESS info->si_addr
 #   ifdef USE_UCONTEXT_REG
-#     define CHECK_STACK_OVERFLOW() check_stack_overflow(sig, (uintptr_t)FAULT_ADDRESS, ctx)
+#     define CHECK_STACK_OVERFLOW() (info->si_pid ? (void)0 : check_stack_overflow(sig, (uintptr_t)FAULT_ADDRESS, ctx))
 #   else
-#     define CHECK_STACK_OVERFLOW() check_stack_overflow(sig, FAULT_ADDRESS)
+#     define CHECK_STACK_OVERFLOW() (info->si_pid ? (void)0 : check_stack_overflow(sig, FAULT_ADDRESS))
 #   endif
 #   define MESSAGE_FAULT_ADDRESS " at %p", FAULT_ADDRESS
 # endif


### PR DESCRIPTION
Previously, when another process sends a fatal signals such as SIGBUS to Ruby, we could mis-interpret it as a stack overflow Ruby itself generated. When the si_pid field is set on the signal, we shouldn't check the si_addr field to check for stack overflow.

> Signals sent with kill(2) and sigqueue(3) fill in si_pid and si_uid.