### PR TITLE
security.rdoc: fix YAML security documentation

### DIFF
--- a/doc/security.rdoc
+++ b/doc/security.rdoc
@@ -37,7 +37,7 @@ programs for configuration and database persistence of Ruby object trees.
 
 Similar to +Marshal+, it is able to deserialize into arbitrary Ruby classes.
 For example, the following YAML data will create an +ERB+ object when
-deserialized:
+deserialized, using the `unsafe_load` method:
 
   !ruby/object:ERB
   src: puts `uname`


### PR DESCRIPTION
Since https://github.com/ruby/ruby/commit/fbb4e3f96c10de2240f2d87eac19cf6f62f65fea `YAML` does not unmarshal arbitrary ruby objects.