### PR TITLE
Launchable: Remove unused code

### DIFF
--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -38,11 +38,6 @@ inputs:
       Directory to (re-)checkout source codes. Launchable retrives the commit information
       from the directory.
 
-outputs:
-  enable-launchable:
-    description: "The boolean value indicating whether Launchable is enabled or not"
-    value: ${{ steps.enable-launchable.outputs.enable-launchable }}
-
 runs:
   using: composite
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -90,7 +90,6 @@ jobs:
         if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
 
       - name: Set up Launchable
-        id: enable-launchable
         uses: ./.github/actions/launchable/setup
         with:
           os: ${{ matrix.os }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -107,7 +107,6 @@ jobs:
         if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
 
       - name: Set up Launchable
-        id: enable-launchable
         uses: ./.github/actions/launchable/setup
         with:
           os: ${{ matrix.os }}


### PR DESCRIPTION
Follow-up fix to https://github.com/ruby/ruby/pull/10207.

We don't need jobs.<job_id>.outputs in .github/actions/launchable/setup/action.yml.