### PR TITLE
Do not fail `launchable verify` command

### DIFF
--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -96,7 +96,7 @@ runs:
         PATH=$PATH:$(python -msite --user-base)/bin
         echo "PATH=$PATH" >> $GITHUB_ENV
         pip install --user launchable
-        launchable verify
+        launchable verify || true
         : # The build name cannot include a slash, so we replace the string here.
         github_ref="${{ github.ref }}"
         github_ref="${github_ref//\//_}"


### PR DESCRIPTION
To ensure the smooth operation of the CI process, the Launchable CLI is designed not to terminate abnormally. In other words, the status code of the Launchable CLI should always be 0. However, the `launchable verify` command is an exception, as it serves to notify whether the setup was successful or not. Since the setup process in ruby/ruby has been completed, it's unnecessary to check if `launchable verify` is successful. Therefore, we can execute the following command:

```
launchable verify || true
```

This approach is recommended in the Launchable documentation.

> Therefore, we recommend you keep launchable verify || true in a recognizable spot in your CI process. This way, when you suspect a problem in Launchable, you can check the output of this command as a starting point.
https://www.launchableinc.com/docs/resources/cli-reference/

