### PR TITLE
[Universal parser] Fix -Wsuggest-attribute=format warnings

### DIFF
--- a/node.h
+++ b/node.h
@@ -15,8 +15,7 @@
 #include "rubyparser.h"
 #include "ruby/backward/2/attributes.h"
 
-typedef void (*bug_report_func)(const char *fmt, ...);
-
+typedef void (*bug_report_func)(const char *fmt, ...) RUBYPARSER_ATTRIBUTE_FORMAT(1, 2);
 typedef struct node_buffer_elem_struct {
     struct node_buffer_elem_struct *next;
     long len; /* Length of nodes */

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -34,6 +34,18 @@
 #endif
 #endif
 
+#if defined(__GNUC__)
+# if defined(__MINGW32__) || defined(__MINGW64__)
+#   define RUBYPARSER_ATTRIBUTE_FORMAT(string_index, argument_index) __attribute__((format(__MINGW_PRINTF_FORMAT, string_index, argument_index)))
+# else
+#   define RUBYPARSER_ATTRIBUTE_FORMAT(string_index, argument_index) __attribute__((format(printf, string_index, argument_index)))
+# endif
+#elif defined(__clang__)
+# define RUBYPARSER_ATTRIBUTE_FORMAT(string_index, argument_index) __attribute__((__format__(__printf__, string_index, argument_index)))
+#else
+# define RUBYPARSER_ATTRIBUTE_FORMAT(string_index, argument_index)
+#endif
+
 /*
  * Parser String
  */
@@ -1403,10 +1415,10 @@ typedef struct rb_parser_config_struct {
     int (*memcicmp)(const void *x, const void *y, long len);
 
     /* Error */
-    void (*compile_warn)(const char *file, int line, const char *fmt, ...);
-    void (*compile_warning)(const char *file, int line, const char *fmt, ...);
-    void (*bug)(const char *fmt, ...);
-    void (*fatal)(const char *fmt, ...);
+    void (*compile_warn)(const char *file, int line, const char *fmt, ...) RUBYPARSER_ATTRIBUTE_FORMAT(3, 4);
+    void (*compile_warning)(const char *file, int line, const char *fmt, ...) RUBYPARSER_ATTRIBUTE_FORMAT(3, 4);
+    void (*bug)(const char *fmt, ...) RUBYPARSER_ATTRIBUTE_FORMAT(1, 2);
+    void (*fatal)(const char *fmt, ...) RUBYPARSER_ATTRIBUTE_FORMAT(1, 2);
     VALUE (*verbose)(void);
     int *(*errno_ptr)(void);
 

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -35,7 +35,7 @@
 #endif
 
 #if defined(__GNUC__)
-# if defined(__MINGW32__) || defined(__MINGW64__)
+# if defined(__MINGW_PRINTF_FORMAT)
 #   define RUBYPARSER_ATTRIBUTE_FORMAT(string_index, argument_index) __attribute__((format(__MINGW_PRINTF_FORMAT, string_index, argument_index)))
 # else
 #   define RUBYPARSER_ATTRIBUTE_FORMAT(string_index, argument_index) __attribute__((format(printf, string_index, argument_index)))


### PR DESCRIPTION
Under a configuration including `cppflags=-DUNIVERSAL_PARSER`, the warnings listed below show at build time:

```
node.c:396:30: warning: initialization left-hand side might be a candidate for a format attribute [-Wsuggest-attribute=format]
  396 |     bug_report_func rb_bug = ast->node_buffer->config->bug;
      |                              ^~~
```

```
ruby_parser.c:655:21: warning: initialization left-hand side might be a candidate for a format attribute [-Wsuggest-attribute=format]
  655 |     .compile_warn = rb_compile_warn,
      |                     ^~~~~~~~~~~~~~~
ruby_parser.c:656:24: warning: initialization left-hand side might be a candidate for a format attribute [-Wsuggest-attribute=format]
  656 |     .compile_warning = rb_compile_warning,
      |                        ^~~~~~~~~~~~~~~~~~
ruby_parser.c:657:12: warning: initialization left-hand side might be a candidate for a format attribute [-Wsuggest-attribute=format]
  657 |     .bug = rb_bug,
      |            ^~~~~~
ruby_parser.c:658:14: warning: initialization left-hand side might be a candidate for a format attribute [-Wsuggest-attribute=format]
  658 |     .fatal = rb_fatal,
      |              ^~~~~~~~
```

To fix, this patch suggests adding `__attribute__((format(printf, n, m)))` to those function declarations.