### PR TITLE
Fix Ripper memory allocation size when enabled Universal Parser

### DIFF
--- a/ext/ripper/ripper_init.c.tmpl
+++ b/ext/ripper/ripper_init.c.tmpl
@@ -94,7 +94,8 @@ ripper_s_allocate(VALUE klass)
                                        &parser_data_type, r);
 
 #ifdef UNIVERSAL_PARSER
-    r->p = rb_parser_params_allocate();
+    const rb_parser_config_t *config = rb_ruby_parser_config();
+    r->p = rb_ripper_parser_params_allocate(config);
 #else
     r->p = rb_ruby_ripper_parser_allocate();
 #endif

--- a/internal/parse.h
+++ b/internal/parse.h
@@ -105,6 +105,9 @@ long rb_ruby_ripper_column(rb_parser_t *p);
 long rb_ruby_ripper_token_len(rb_parser_t *p);
 rb_parser_string_t *rb_ruby_ripper_lex_lastline(rb_parser_t *p);
 VALUE rb_ruby_ripper_lex_state_name(struct parser_params *p, int state);
+#ifdef UNIVERSAL_PARSER
+rb_parser_t *rb_ripper_parser_params_allocate(const rb_parser_config_t *config);
+#endif
 struct parser_params *rb_ruby_ripper_parser_allocate(void);
 #endif
 

--- a/internal/ruby_parser.h
+++ b/internal/ruby_parser.h
@@ -12,6 +12,7 @@
 
 RUBY_SYMBOL_EXPORT_BEGIN
 #ifdef UNIVERSAL_PARSER
+const rb_parser_config_t *rb_ruby_parser_config(void);
 rb_parser_t *rb_parser_params_allocate(void);
 rb_parser_t *rb_parser_params_new(void);
 #endif

--- a/parse.y
+++ b/parse.y
@@ -16613,6 +16613,16 @@ rb_ruby_ripper_lex_state_name(struct parser_params *p, int state)
     return rb_parser_lex_state_name(p, (enum lex_state_e)state);
 }
 
+#ifdef UNIVERSAL_PARSER
+rb_parser_t *
+rb_ripper_parser_params_allocate(const rb_parser_config_t *config)
+{
+    rb_parser_t *p = (rb_parser_t *)config->calloc(1, sizeof(rb_parser_t));
+    p->config = config;
+    return p;
+}
+#endif
+
 struct parser_params*
 rb_ruby_ripper_parser_allocate(void)
 {

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -685,6 +685,12 @@ static const rb_parser_config_t rb_global_parser_config = {
     .str_coderange_scan_restartable = str_coderange_scan_restartable,
 };
 
+const rb_parser_config_t *
+rb_ruby_parser_config(void)
+{
+    return &rb_global_parser_config;
+}
+
 rb_parser_t *
 rb_parser_params_allocate(void)
 {


### PR DESCRIPTION
The size of `struct parser_params` is 8 bytes difference in `ripper_s_allocate` and `rb_ruby_parser_allocate` when the universal parser is enabled. This causes a situation where `*r->p` is not fully initialized in `ripper_s_allocate` as shown below.

```console
(gdb) p *r->p
$2 = {heap = 0x0, lval = 0x0, yylloc = 0x0, lex = {strterm = 0x0, gets = 0x0, input = 0, string_buffer = {head = 0x0, last = 0x0}, lastline = 0x0,
    nextline = 0x0, pbeg = 0x0, pcur = 0x0, pend = 0x0, ptok = 0x0, gets_ = {ptr = 0, call = 0x0}, state = EXPR_NONE, paren_nest = 0, lpar_beg = 0,
    brace_nest = 0}, cond_stack = 0, cmdarg_stack = 0, tokidx = 0, toksiz = 0, heredoc_end = 0, heredoc_indent = 0, heredoc_line_indent = 0,
  tokenbuf = 0x0, lvtbl = 0x0, pvtbl = 0x0, pktbl = 0x0, line_count = 0, ruby_sourceline = 0, ruby_sourcefile = 0x0, ruby_sourcefile_string = 0,
  enc = 0x0, token_info = 0x0, case_labels = 0, exits = 0x0, debug_buffer = 0, debug_output = 0, delayed = {token = 0, beg_line = 0, beg_col = 0,
    end_line = 0, end_col = 0}, cur_arg = 0, ast = 0x0, node_id = 0, max_numparam = 0, it_id = 0, ctxt = {in_defined = 0, in_kwarg = 0, in_argdef = 0,
    in_def = 0, in_class = 0, shareable_constant_value = shareable_none, in_rescue = before_rescue}, eval_tree_begin = 0x0, eval_tree = 0x0,
  parent_iseq = 0x0, config = 0x7ffff7f94ec0 <rb_global_parser_config>, frozen_string_literal = 0, command_start = 0, eofp = 0, ruby__end__seen = 0,
  debug = 0, has_shebang = 0, token_seen = 0, token_info_enabled = 0, error_p = 0, cr_seen = 0, value = 0, result = 0, parsing_thread = 0, s_value = 0,
  s_lvalue = 0, s_value_stack = 2097}
````

This seems to cause `double free or corruption (!prev)` and SEGV. So, fixing this by changing the location of the `const rb_parser_t *config` property in `struct parser_params` so that the same size is returned.