### PR TITLE
Skip Bootsnap and Zeitwerk in bundled gems warning

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -109,12 +109,7 @@ module Gem::BUNDLED_GEMS
     else
       return
     end
-    # Warning feature is not working correctly with Bootsnap.
-    # caller_locations returns:
-    #   lib/ruby/3.3.0+0/bundled_gems.rb:65:in `block (2 levels) in replace_require'
-    #   $GEM_HOME/gems/bootsnap-1.17.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'"
-    #   ...
-    return if caller_locations(2).find {|c| c&.path.match?(/bootsnap/) }
+
     return if WARNED[name]
     WARNED[name] = true
     if gem == true
@@ -134,11 +129,29 @@ module Gem::BUNDLED_GEMS
 
     if defined?(Bundler)
       msg += " Add #{gem} to your Gemfile or gemspec."
+
       # We detect the gem name from caller_locations. We need to skip 2 frames like:
       # lib/ruby/3.3.0+0/bundled_gems.rb:90:in `warning?'",
       # lib/ruby/3.3.0+0/bundler/rubygems_integration.rb:247:in `block (2 levels) in replace_require'",
-      location = caller_locations(3,1)[0]&.path
-      if File.file?(location) && !location.start_with?(Gem::BUNDLED_GEMS::LIBDIR)
+      #
+      # Additionally, we need to skip Bootsnap and Zeitwerk if present, these
+      # gems decorate Kernel#require, so they are not really the ones issuing
+      # the require call users should be warned about. Those are upwards.
+      frames_to_skip = 2
+      location = nil
+      Thread.each_caller_location do |cl|
+        if frames_to_skip >= 1
+          frames_to_skip -= 1
+          next
+        end
+
+        unless cl.path.match?(/bootsnap|zeitwerk/)
+          location = cl.path
+          break
+        end
+      end
+
+      if location && File.file?(location) && !location.start_with?(Gem::BUNDLED_GEMS::LIBDIR)
         caller_gem = nil
         Gem.path.each do |path|
           if location =~ %r{#{path}/gems/([\w\-\.]+)}


### PR DESCRIPTION
Bootsnap and Zeitwerk decorate `Kernel#require`.

The current logic in `bundled_gems.rb` produces warnings like this:

> Also contact author of zeitwerk-2.6.12 to add csv into its gemspec

which are not useful, since that `require` is just a proxy, the real one to be warned about is upwards. There have been several issues created in the Zeitwerk project due to this.

In this patch I propose to iterate over `caller_locations`, skipping references to `bootsnap` and `zeitwerk`. Hopefully, with this change, the warnings will point to the actual gem issuing the `require` call.

DISCLAIMER: I cannot build Ruby right now, I get

```
% ./autogen.sh      
Argument "/opt/homebrew/Cellar/autoconf/2.72/share/autoconf/build-..." isn't numeric in numeric ne (!=) at /opt/homebrew/bin/autoreconf line 383.
```

and was not able to test the patch, submitting optimistically!