### PR TITLE
Refactor frozen_string_literal check during compilation

### DIFF
--- a/bootstraptest/runner.rb
+++ b/bootstraptest/runner.rb
@@ -548,7 +548,7 @@ class Assertion < Struct.new(:src, :path, :lineno, :proc)
     end
   end
 
-  def make_srcfile(frozen_string_literal: true)
+  def make_srcfile(frozen_string_literal: nil)
     filename = "bootstraptest.#{self.path}_#{self.lineno}_#{self.id}.rb"
     File.open(filename, 'w') {|f|
       f.puts "#frozen_string_literal:#{frozen_string_literal}" unless frozen_string_literal.nil?

--- a/bootstraptest/test_eval.rb
+++ b/bootstraptest/test_eval.rb
@@ -364,3 +364,34 @@ assert_normal_exit %q{
   end
 }, 'check escaping the internal value th->base_block'
 
+assert_equal "false", <<~RUBY, "literal strings are mutable", "--disable-frozen-string-literal"
+  eval("'test'").frozen?
+RUBY
+
+assert_equal "false", <<~RUBY, "literal strings are mutable", "--disable-frozen-string-literal", frozen_string_literal: true
+  eval("'test'").frozen?
+RUBY
+
+assert_equal "true", <<~RUBY, "literal strings are frozen", "--enable-frozen-string-literal"
+  eval("'test'").frozen?
+RUBY
+
+assert_equal "true", <<~RUBY, "literal strings are frozen", "--enable-frozen-string-literal", frozen_string_literal: false
+  eval("'test'").frozen?
+RUBY
+
+assert_equal "false", <<~RUBY, "__FILE__ is mutable", "--disable-frozen-string-literal"
+  eval("__FILE__").frozen?
+RUBY
+
+assert_equal "false", <<~RUBY, "__FILE__ is mutable", "--disable-frozen-string-literal", frozen_string_literal: true
+  eval("__FILE__").frozen?
+RUBY
+
+assert_equal "true", <<~RUBY, "__FILE__ is frozen", "--enable-frozen-string-literal"
+  eval("__FILE__").frozen?
+RUBY
+
+assert_equal "true", <<~RUBY, "__FILE__ is frozen", "--enable-frozen-string-literal", frozen_string_literal: false
+  eval("__FILE__").frozen?
+RUBY

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1421,7 +1421,7 @@ assert_equal '[false, false, true, true]', %q{
 }
 
 # TracePoint with normal Proc should be Ractor local
-assert_equal '[7, 11]', %q{
+assert_equal '[6, 10]', %q{
   rs = []
   TracePoint.new(:line){|tp| rs << tp.lineno if tp.path == __FILE__}.enable do
     Ractor.new{ # line 5

--- a/bootstraptest/test_syntax.rb
+++ b/bootstraptest/test_syntax.rb
@@ -904,3 +904,35 @@ assert_normal_exit %q{
     Class
   end
 }, '[ruby-core:30293]'
+
+assert_equal "false", <<~RUBY, "literal strings are mutable", "--disable-frozen-string-literal"
+  'test'.frozen?
+RUBY
+
+assert_equal "true", <<~RUBY, "literal strings are frozen", "--disable-frozen-string-literal", frozen_string_literal: true
+  'test'.frozen?
+RUBY
+
+assert_equal "true", <<~RUBY, "literal strings are frozen", "--enable-frozen-string-literal"
+  'test'.frozen?
+RUBY
+
+assert_equal "false", <<~RUBY, "literal strings are mutable", "--enable-frozen-string-literal", frozen_string_literal: false
+  'test'.frozen?
+RUBY
+
+assert_equal "false", <<~RUBY, "__FILE__ is mutable", "--disable-frozen-string-literal"
+  __FILE__.frozen?
+RUBY
+
+assert_equal "true", <<~RUBY, "__FILE__ is frozen", "--disable-frozen-string-literal", frozen_string_literal: true
+  __FILE__.frozen?
+RUBY
+
+assert_equal "true", <<~RUBY, "__FILE__ is frozen", "--enable-frozen-string-literal"
+  __FILE__.frozen?
+RUBY
+
+assert_equal "false", <<~RUBY, "__FILE__ is mutable", "--enable-frozen-string-literal", frozen_string_literal: false
+  __FILE__.frozen?
+RUBY

--- a/iseq.c
+++ b/iseq.c
@@ -733,6 +733,12 @@ static rb_compile_option_t COMPILE_OPTION_DEFAULT = {
 
 static const rb_compile_option_t COMPILE_OPTION_FALSE = {0};
 
+int
+rb_iseq_opt_frozen_string_literal(void)
+{
+    return COMPILE_OPTION_DEFAULT.frozen_string_literal;
+}
+
 static void
 set_compile_option_from_hash(rb_compile_option_t *option, VALUE opt)
 {
@@ -1241,6 +1247,8 @@ pm_iseq_compile_with_option(VALUE src, VALUE file, VALUE realpath, VALUE line, V
 
     pm_parse_result_t result = { 0 };
     pm_options_line_set(&result.options, NUM2INT(line));
+
+    pm_options_frozen_string_literal_set(&result.options, option.frozen_string_literal);
 
     VALUE error;
     if (RB_TYPE_P(src, T_FILE)) {

--- a/iseq.h
+++ b/iseq.h
@@ -172,6 +172,7 @@ void rb_iseq_init_trace(rb_iseq_t *iseq);
 int rb_iseq_add_local_tracepoint_recursively(const rb_iseq_t *iseq, rb_event_flag_t turnon_events, VALUE tpval, unsigned int target_line, bool target_bmethod);
 int rb_iseq_remove_local_tracepoint_recursively(const rb_iseq_t *iseq, VALUE tpval);
 const rb_iseq_t *rb_iseq_load_iseq(VALUE fname);
+int rb_iseq_opt_frozen_string_literal(void);
 
 #if VM_INSN_INFO_TABLE_IMPL == 2
 unsigned int *rb_iseq_insns_info_decode_positions(const struct rb_iseq_constant_body *body);

--- a/ruby.c
+++ b/ruby.c
@@ -2116,6 +2116,8 @@ prism_script(ruby_cmdline_options_t *opt, pm_parse_result_t *result)
     pm_options_t *options = &result->options;
     pm_options_line_set(options, 1);
 
+    pm_options_frozen_string_literal_set(&result->options, rb_iseq_opt_frozen_string_literal());
+
     uint8_t command_line = 0;
     if (opt->do_split) command_line |= PM_OPTIONS_COMMAND_LINE_A;
     if (opt->do_line) command_line |= PM_OPTIONS_COMMAND_LINE_L;

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1663,6 +1663,8 @@ pm_eval_make_iseq(VALUE src, VALUE fname, int line,
     pm_parse_result_t result = { 0 };
     pm_options_line_set(&result.options, line);
 
+    pm_options_frozen_string_literal_set(&result.options, rb_iseq_opt_frozen_string_literal());
+
     // Cout scopes, one for each parent iseq, plus one for our local scope
     int scopes_count = 0;
     do {


### PR DESCRIPTION
In preparation for https://bugs.ruby-lang.org/issues/20205.

The `frozen_string_literal` compilation option will no longer be a boolean but a tri-state: `on/off/default`.

~~Blocked on https://github.com/ruby/prism/pull/2603 (cc @kddnewton)~~

Also fix a few discrepancies with how prism compiler handle these options.