### PR TITLE
YJIT: Support arity=-2 cfuncs

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4678,3 +4678,19 @@ assert_equal '[0, {1=>1}]', %q{
 
   test(KwInit, [Hash.ruby2_keywords_hash({1 => 1})])
 }
+
+# arity=-2 cfuncs
+assert_equal '["", "1/2", [0, [:ok, 1]]]', %q{
+  def test_cases(file, chain)
+    new_chain = chain.allocate # to call initialize directly
+    new_chain.send(:initialize, [0], ok: 1)
+
+    [
+      file.join,
+      file.join("1", "2"),
+      new_chain.to_a,
+    ]
+  end
+
+  test_cases(File, Enumerator::Chain)
+}

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -354,7 +354,7 @@ make_counters! {
     send_refined_method,
     send_private_not_fcall,
     send_cfunc_kw_splat_non_nil,
-    send_cfunc_ruby_array_varg,
+    send_cfunc_splat_neg2,
     send_cfunc_argc_mismatch,
     send_cfunc_block_arg,
     send_cfunc_toomany_args,


### PR DESCRIPTION
This type of cfuncs shows up as consume a lot of cycles in profiles of
the lobsters benchmark, even though in the stats they don't happen that
frequently. Might be a bug in the profiling, but these calls are not
too bad to support, so might as well do it.
