### PR TITLE
Faster Integer.sqrt for large bignum

### DIFF
--- a/internal/numeric.h
+++ b/internal/numeric.h
@@ -86,6 +86,7 @@ VALUE rb_int_equal(VALUE x, VALUE y);
 VALUE rb_int_divmod(VALUE x, VALUE y);
 VALUE rb_int_and(VALUE x, VALUE y);
 VALUE rb_int_lshift(VALUE x, VALUE y);
+VALUE rb_int_rshift(VALUE x, VALUE y);
 VALUE rb_int_div(VALUE x, VALUE y);
 int rb_int_positive_p(VALUE num);
 int rb_int_negative_p(VALUE num);

--- a/numeric.c
+++ b/numeric.c
@@ -5169,7 +5169,7 @@ fix_rshift(long val, unsigned long i)
  *
  */
 
-static VALUE
+VALUE
 rb_int_rshift(VALUE x, VALUE y)
 {
     if (FIXNUM_P(x)) {


### PR DESCRIPTION
Improves execution time of `Integer.sqrt(10**1000000)` from 89.5sec to 3.13sec.
Combination with #10270, it only takes 0.449sec.

### Benchmark (measured in no GMP environment)

| code | master | this pull request | ratio |
| --- | --- | --- | --- |
| Integer.sqrt(10**20) | 0.000000197 sec | 0.000000212 sec | x0.93 |
| Integer.sqrt(10**100) | 0.000000856 sec | 0.00000133 sec | x0.64 (slower) |
| Integer.sqrt(10**1000) | 0.0000657 sec | 0.0000104 sec | x6.32 |
| Integer.sqrt(10**10000) | 0.00361 sec | 0.000381 sec | x9.48 |
| Integer.sqrt(10**100000) | 0.475 sec | 0.0264178 sec | x18.0 |

### Description of the change
Integer.sqrt was calculated by this form
```ruby
def sqrt(n)
  x = estimate_initial_sqrt(n)
  while x*x>n # Repeat Newton's method's step
    # This part is executed log2(n.bit_length) times with unnecessarily high precision, making the calculation slow.
    x = (x + n / x) / 2
  end
  x
end
```

Changed to
```ruby
def sqrt(n)
  shift = n.bit_length / 4
  x = Integer.sqrt(n >> (2 * shift)) << shift # If precision of initial x is high enough,
  x = (x + n / x) / 2 # Calculating this part only once is enough.
  while x*x > n
    # This part seems to be executed at most once.
    # We can use `if x*x>n` if this is proved. For safety, I think `while x*x>n` is better.
    x -= 1
  end
  x
end
```
