### PR TITLE
Update unmerged RBS to debug `EBADF` error

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -17,7 +17,7 @@ net-pop         0.1.2   https://github.com/ruby/net-pop
 net-smtp        0.4.0.1 https://github.com/ruby/net-smtp
 matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
-rbs             3.4.4   https://github.com/ruby/rbs 0637ef60e13d5ded71d69d5238dbffcaae3d3740
+rbs             3.4.4   https://github.com/ruby/rbs 61b412bc7ba00519e7d6d08450bd384990d94ea2
 typeprof        0.21.11 https://github.com/ruby/typeprof
 debug           1.9.1   https://github.com/ruby/debug 2d602636d99114d55a32fedd652c9c704446a749
 racc            1.7.3   https://github.com/ruby/racc


### PR DESCRIPTION
You can find the bundled commit at https://github.com/ruby/rbs/pull/1758.

We confirmed having `sysopen` calls in `FileTest_test` caused `EBADF` errors ([link](https://github.com/ruby/ruby/actions/runs/8308709399/job/22739307637#step:11:381)). Now getting remove the `sysopen` calls iin `FileTest_test` but get `sysopen` calls in other tests back.