### PR TITLE
[Bug #20279] [DOC] Update for `BasicObject`

### DIFF
--- a/object.c
+++ b/object.c
@@ -4093,7 +4093,7 @@ rb_f_loop_size(VALUE self, VALUE args, VALUE eobj)
  *      end
  *
  *      def respond_to_missing?(name, include_private = false)
- *        DELEGATE.include?(name) or super
+ *        DELEGATE.include?(name)
  *      end
  *    end
  *


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20279

The current implementation raises on the call to super.

I got surprised by this recently myself. This does what https://bugs.ruby-lang.org/issues/20279#note-5 suggests and just removes the `super` call. This actually makes the example work.

```rb
class MyObjectSystem < BasicObject
  DELEGATE = [:puts, :p]

  def method_missing(name, *args, &block)
    return super unless DELEGATE.include? name
    ::Kernel.send(name, *args, &block)
  end

  def respond_to_missing?(name, include_private = false)
    DELEGATE.include?(name) or super
  end
end

MyObjectSystem.new.puts("abc")
# abc
# => nil

MyObjectSystem.new.raise(StandardError)
# `method_missing': undefined method `raise' for #<MyObjectSystem:0x00007f48f2ee50b0> (NoMethodError)
```