### PR TITLE
Avoid deprecation warnings in TestString

### DIFF
--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -3629,6 +3629,9 @@ CODE
   end
 
   def test_chilled_string_setivar
+    deprecated = Warning[:deprecated]
+    Warning[:deprecated] = false
+
     String.class_eval <<~RUBY, __FILE__, __LINE__ + 1
       def setivar!
         @ivar = 42
@@ -3641,6 +3644,8 @@ CODE
     ensure
       String.undef_method(:setivar!)
     end
+  ensure
+    Warning[:deprecated] = deprecated
   end
 
   private


### PR DESCRIPTION
Fixes:

```
"make yes-test-all TESTOPTS='--stderr-on-failure' TESTS='-j16'" exit with 0.
/tmp/ruby/src/trunk/test/ruby/test_string.rb:3634: warning: literal string will be frozen in the future
/tmp/ruby/src/trunk/test/ruby/test_string.rb:3634: warning: literal string will be frozen in the future
```
