### PR TITLE
Fix `SSL_read: unexpected eof while reading` issues

### DIFF
--- a/ext/openssl/lib/openssl/ssl.rb
+++ b/ext/openssl/lib/openssl/ssl.rb
@@ -28,6 +28,7 @@ module OpenSSL
           opts = OpenSSL::SSL::OP_ALL
           opts &= ~OpenSSL::SSL::OP_DONT_INSERT_EMPTY_FRAGMENTS
           opts |= OpenSSL::SSL::OP_NO_COMPRESSION
+          opts |= OpenSSL::SSL::OP_IGNORE_UNEXPECTED_EOF
           opts
         }.call
       }


### PR DESCRIPTION
Ignore unexpected shutdown of TLS connections. After updating to ssl 3.0 some requests may fail with unexpected eof while reading issue. 