### PR TITLE
Remove excess allocation for kwsplat to kw call

### DIFF
--- a/vm_args.c
+++ b/vm_args.c
@@ -725,8 +725,9 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
                 kw_flag &= ~(VM_CALL_KW_SPLAT | VM_CALL_KW_SPLAT_MUT);
             }
             else {
-                if (!(kw_flag & VM_CALL_KW_SPLAT_MUT)) {
+                if (!(kw_flag & VM_CALL_KW_SPLAT_MUT) && !ISEQ_BODY(iseq)->param.flags.has_kw) {
                     converted_keyword_hash = rb_hash_dup(converted_keyword_hash);
+                    kw_flag |= VM_CALL_KW_SPLAT_MUT;
                 }
 
                 if (last_arg != converted_keyword_hash) {


### PR DESCRIPTION
Previously, calls like the following duplicated the kwsplat hash
unnecessarily:

```ruby
def foo(a:) = a
hash = {a: 10}
foo(**hash)
```

This is due to the fix in ca204a20231. Since it targets when the callee
has no keyword parameters, skip duplicating when the method takes
keywords.
