### PR TITLE
merge revision(s) c7ce2f537f96ab2cf2f5fc2982d6147866ff5340: [Backport #20304]

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -1543,7 +1543,14 @@ enc_set_default_encoding(struct default_encoding *def, VALUE encoding, const cha
         if (NIL_P(encoding)) {
             def->index = -1;
             def->enc = 0;
-            st_insert(enc_table->names, (st_data_t)strdup(name),
+            char *name_dup = strdup(name);
+
+            st_data_t existing_name = (st_data_t)name_dup;
+            if (st_delete(enc_table->names, &existing_name, NULL)) {
+                xfree((void *)existing_name);
+            }
+
+            st_insert(enc_table->names, (st_data_t)name_dup,
                       (st_data_t)UNSPECIFIED_ENCODING);
         }
         else {


### PR DESCRIPTION
Fix memory leak in setting encodings

There is a memory leak in Encoding.default_external= and
Encoding.default_internal= because the duplicated name is not freed
when overwriting.

    10.times do
      1_000_000.times do
        Encoding.default_internal = nil
      end

      puts `ps -o rss= -p #{$$}`
    end

Before:

     25664
     41504
     57360
     73232
     89168
    105056
    120944
    136816
    152720
    168576

After:

    9648
    9648
    9648
    9680
    9680
    9680
    9680
    9680
    9680
    9680
