### PR TITLE
Remove deprecated function rb_gc_force_recycle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -101,7 +101,8 @@ See GitHub releases like [GitHub Releases of Logger](https://github.com/ruby/log
 
 ## C API updates
 
-* `rb_newobj` and `rb_newobj_of` (and corresponding macros `RB_NEWOBJ`, `RB_NEWOBJ_OF`, `NEWOBJ`, `NEWOBJ_OF`) have been removed [[Feature #20265]].
+* `rb_newobj` and `rb_newobj_of` (and corresponding macros `RB_NEWOBJ`, `RB_NEWOBJ_OF`, `NEWOBJ`, `NEWOBJ_OF`) have been removed. [[Feature #20265]]
+* Removed deprecated function `rb_gc_force_recycle`. [[Feature #18290]]
 
 ## Implementation improvements
 
@@ -111,6 +112,7 @@ See GitHub releases like [GitHub Releases of Logger](https://github.com/ruby/log
 
 [Feature #13557]: https://bugs.ruby-lang.org/issues/13557
 [Feature #16495]: https://bugs.ruby-lang.org/issues/16495
+[Feature #18290]: https://bugs.ruby-lang.org/issues/18290
 [Feature #18980]: https://bugs.ruby-lang.org/issues/18980
 [Feature #19117]: https://bugs.ruby-lang.org/issues/19117
 [Bug #19918]:     https://bugs.ruby-lang.org/issues/19918

--- a/gc.c
+++ b/gc.c
@@ -8752,12 +8752,6 @@ rb_gc_ractor_newobj_cache_clear(rb_ractor_newobj_cache_t *newobj_cache)
 }
 
 void
-rb_gc_force_recycle(VALUE obj)
-{
-    /* no-op */
-}
-
-void
 rb_gc_register_mark_object(VALUE obj)
 {
     if (!is_pointer_to_heap(&rb_objspace, (void *)obj))

--- a/include/ruby/internal/gc.h
+++ b/include/ruby/internal/gc.h
@@ -210,22 +210,6 @@ void rb_gc_mark_movable(VALUE obj);
 VALUE rb_gc_location(VALUE obj);
 
 /**
- * Asserts  that the  passed  object is  no longer  needed.   Such objects  are
- * reclaimed sooner or later so this  function is not mandatory.  But sometimes
- * you can know  from your application knowledge that an  object is surely dead
- * at some point.  Calling this as a hint can be a polite way.
- *
- * @param[out]  obj  Object, dead.
- * @pre         `obj` have never been passed to this function before.
- * @post        `obj` could be invalidated.
- * @warning     It  is a  failure  to pass  an object  multiple  times to  this
- *              function.
- * @deprecated  This is now a no-op function.
- */
-RBIMPL_ATTR_DEPRECATED(("this is now a no-op function"))
-void rb_gc_force_recycle(VALUE obj);
-
-/**
  * Triggers a GC process.  This was the only  GC entry point that we had at the
  * beginning.  Over time our GC evolved.  Now what this function does is just a
  * very  simplified  variation  of  the  entire GC  algorithms.   A  series  of


### PR DESCRIPTION
This function has been deprecated since Ruby 3.1, so we should remove it for Ruby 3.4.