### PR TITLE
[Feature #20275] Remove extra backtrace entries for rescue and ensure

### DIFF
--- a/spec/ruby/language/ensure_spec.rb
+++ b/spec/ruby/language/ensure_spec.rb
@@ -328,4 +328,21 @@ describe "An ensure block inside 'do end' block" do
 
     result.should == :begin
   end
+
+  ruby_version_is "3.4" do
+    it "does not introduce extra backtrace entries" do
+      def foo
+        begin
+          raise "oops"
+        ensure
+          return caller(0, 2)
+        end
+      end
+      line = __LINE__
+      foo.should == [
+        "#{__FILE__}:#{line-3}:in 'foo'",
+        "#{__FILE__}:#{line+1}:in 'block (3 levels) in <top (required)>'"
+      ]
+    end
+  end
 end

--- a/spec/ruby/language/rescue_spec.rb
+++ b/spec/ruby/language/rescue_spec.rb
@@ -553,6 +553,23 @@ describe "The rescue keyword" do
     eval('1.+((1 rescue 1))').should == 2
   end
 
+  ruby_version_is "3.4" do
+    it "does not introduce extra backtrace entries" do
+      def foo
+        begin
+          raise "oops"
+        rescue
+          return caller(0, 2)
+        end
+      end
+      line = __LINE__
+      foo.should == [
+        "#{__FILE__}:#{line-3}:in 'foo'",
+        "#{__FILE__}:#{line+1}:in 'block (3 levels) in <top (required)>'"
+      ]
+    end
+  end
+
   describe "inline form" do
     it "can be inlined" do
       a = 1/0 rescue 1

--- a/test/ruby/test_backtrace.rb
+++ b/test/ruby/test_backtrace.rb
@@ -397,7 +397,6 @@ class TestBacktrace < Test::Unit::TestCase
     end;
 
     err = ["-:7:in 'Object#bar': bar! (RuntimeError)",
-           "\tfrom -:4:in 'Object#bar'",
            "\tfrom -:9:in '<main>'",
            "-:2:in 'Object#foo': foo! (RuntimeError)",
            "\tfrom -:5:in 'Object#bar'",


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20275