### PR TITLE
Declare all jobs in matrix.include

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,10 +24,8 @@ jobs:
   make:
     strategy:
       matrix:
-        test_task: ['check']
-        test_opts: ['']
-        os: ['']
         include:
+          - test_task: check
           - test_task: test-all
             test_opts: --repeat-count=2
           - test_task: test-bundler-parallel

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,12 +24,9 @@ jobs:
   make:
     strategy:
       matrix:
-        test_task: [check]
-        arch: ['']
-        configure: ['cppflags=-DVM_CHECK_MODE']
-        os: ['']
-        # specifying other jobs with `include` to avoid redundant tests
         include:
+          - test_task: check
+            configure: 'cppflags=-DVM_CHECK_MODE'
           - test_task: check
             arch: i686
           - test_task: check


### PR DESCRIPTION
First of all, since we already have too many jobs, we don't want to use "matrix" jobs; we want to write down all test combinations to minimize the number of them instead of exhaustively testing every parameter combination.

Also, it seems like we don't need to use this weird syntax. I thought it was needed for formatting the job names and/or defining default values, but the job names look actually fine with this, and we could define default values when the variable is actually used (and it seems like our syntax actually didn't work as a default value correctly anyway).