### PR TITLE
Fix warnings on wasi

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -146,7 +146,7 @@ static int rb_threadptr_pending_interrupt_empty_p(const rb_thread_t *th);
 static const char *thread_status_name(rb_thread_t *th, int detail);
 static int hrtime_update_expire(rb_hrtime_t *, const rb_hrtime_t);
 NORETURN(static void async_bug_fd(const char *mesg, int errno_arg, int fd));
-static int consume_communication_pipe(int fd);
+MAYBE_UNUSED(static int consume_communication_pipe(int fd));
 
 static volatile int system_working = 1;
 static rb_internal_thread_specific_key_t specific_key_count;
@@ -259,6 +259,9 @@ timeout_prepare(rb_hrtime_t **to, rb_hrtime_t *rel, rb_hrtime_t *end,
 }
 
 MAYBE_UNUSED(NOINLINE(static int thread_start_func_2(rb_thread_t *th, VALUE *stack_start)));
+MAYBE_UNUSED(static void rb_thread_sched_destroy(struct rb_thread_sched *sched));
+MAYBE_UNUSED(static bool th_has_dedicated_nt(const rb_thread_t *th));
+MAYBE_UNUSED(static int waitfd_to_waiting_flag(int wfd_event));
 
 #include THREAD_IMPL_SRC
 

--- a/thread.c
+++ b/thread.c
@@ -259,7 +259,6 @@ timeout_prepare(rb_hrtime_t **to, rb_hrtime_t *rel, rb_hrtime_t *end,
 }
 
 MAYBE_UNUSED(NOINLINE(static int thread_start_func_2(rb_thread_t *th, VALUE *stack_start)));
-MAYBE_UNUSED(static void rb_thread_sched_destroy(struct rb_thread_sched *sched));
 MAYBE_UNUSED(static bool th_has_dedicated_nt(const rb_thread_t *th));
 MAYBE_UNUSED(static int waitfd_to_waiting_flag(int wfd_event));
 

--- a/thread_none.c
+++ b/thread_none.c
@@ -46,10 +46,12 @@ rb_thread_sched_init(struct rb_thread_sched *sched, bool atfork)
 {
 }
 
+#if 0
 static void
 rb_thread_sched_destroy(struct rb_thread_sched *sched)
 {
 }
+#endif
 
 // Do nothing for mutex guard
 void

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -155,6 +155,7 @@ rb_thread_sched_init(struct rb_thread_sched *sched, bool atfork)
     sched->lock = w32_mutex_create();
 }
 
+#if 0
 // per-ractor
 void
 rb_thread_sched_destroy(struct rb_thread_sched *sched)
@@ -162,6 +163,7 @@ rb_thread_sched_destroy(struct rb_thread_sched *sched)
     if (GVL_DEBUG) fprintf(stderr, "sched destroy\n");
     CloseHandle(sched->lock);
 }
+#endif
 
 rb_thread_t *
 ruby_thread_from_native(void)

--- a/time.c
+++ b/time.c
@@ -2346,7 +2346,7 @@ zone_timelocal(VALUE zone, VALUE time)
     struct time_object *tobj = RTYPEDDATA_GET_DATA(time);
     wideval_t t, s;
 
-    split_second(tobj->timew, &t, &s);
+    wdivmod(tobj->timew, WINT2FIXWV(TIME_SCALE), &t, &s);
     tm = tm_from_time(rb_cTimeTM, time);
     utc = rb_check_funcall(zone, id_local_to_utc, 1, &tm);
     if (UNDEF_P(utc)) return 0;


### PR DESCRIPTION
```
../src/thread.c:4565:1: warning: unused function 'consume_communication_pipe' [-Wunused-function]
consume_communication_pipe(int fd)
^
In file included from ../src/thread.c:263:
../src/thread_none.c:50:1: warning: unused function 'rb_thread_sched_destroy' [-Wunused-function]
rb_thread_sched_destroy(struct rb_thread_sched *sched)
^
../src/thread_none.c:275:1: warning: unused function 'th_has_dedicated_nt' [-Wunused-function]
th_has_dedicated_nt(const rb_thread_t *th)
^
../src/thread.c:1664:1: warning: unused function 'waitfd_to_waiting_flag' [-Wunused-function]
waitfd_to_waiting_flag(int wfd_event)
^
../src/time.c:2349:35: warning: incompatible pointer types passing 'wideval_t *' (aka 'unsigned long long *') to parameter of type 'VALUE *' (aka 'unsigned long *') [-Wincompatible-pointer-types]
    split_second(tobj->timew, &t, &s);
                                  ^~
../src/time.c:616:58: note: passing argument to parameter 'subsecx_p' here
split_second(wideval_t timew, wideval_t *timew_p, VALUE *subsecx_p)
                                                         ^
```