### PR TITLE
Fix --debug=gc_stress flag

### DIFF
--- a/debug.c
+++ b/debug.c
@@ -185,9 +185,9 @@ ruby_env_debug_option(const char *str, int len, void *arg)
     int ov;
     size_t retlen;
     unsigned long n;
+#define NAME_MATCH(name) (len == sizeof(name) - 1 && strncmp(str, (name), len) == 0)
 #define SET_WHEN(name, var, val) do {	    \
-        if (len == sizeof(name) - 1 &&	    \
-            strncmp(str, (name), len) == 0) { \
+        if (NAME_MATCH(name)) { \
             (var) = (val);		    \
             return 1;			    \
         }				    \
@@ -221,7 +221,10 @@ ruby_env_debug_option(const char *str, int len, void *arg)
 #define SET_WHEN_UINT(name, vals, num, req) \
     if (NAME_MATCH_VALUE(name)) SET_UINT_LIST(name, vals, num);
 
-    SET_WHEN("gc_stress", *ruby_initial_gc_stress_ptr, Qtrue);
+    if (NAME_MATCH("gc_stress")) {
+        rb_gc_stress_set(Qtrue);
+        return 1;
+    }
     SET_WHEN("core", ruby_enable_coredump, 1);
     SET_WHEN("ci", ruby_on_ci, 1);
     if (NAME_MATCH_VALUE("rgengc")) {

--- a/gc.c
+++ b/gc.c
@@ -439,8 +439,6 @@ typedef struct {
     size_t oldmalloc_limit_min;
     size_t oldmalloc_limit_max;
     double oldmalloc_limit_growth_factor;
-
-    VALUE gc_stress;
 } ruby_gc_params_t;
 
 static ruby_gc_params_t gc_params = {
@@ -462,8 +460,6 @@ static ruby_gc_params_t gc_params = {
     GC_OLDMALLOC_LIMIT_MIN,
     GC_OLDMALLOC_LIMIT_MAX,
     GC_OLDMALLOC_LIMIT_GROWTH_FACTOR,
-
-    FALSE,
 };
 
 /* GC_DEBUG:
@@ -1135,10 +1131,6 @@ RVALUE_AGE_SET(VALUE obj, int age)
     if (unless_objspace_vm) objspace = unless_objspace_vm->objspace; \
     else /* return; or objspace will be warned uninitialized */
 
-#define ruby_initial_gc_stress	gc_params.gc_stress
-
-VALUE *ruby_initial_gc_stress_ptr = &ruby_initial_gc_stress;
-
 #define malloc_limit		objspace->malloc_params.limit
 #define malloc_increase 	objspace->malloc_params.increase
 #define malloc_allocated_size 	objspace->malloc_params.allocated_size
@@ -1389,7 +1381,6 @@ NO_SANITIZE("memory", static inline int is_pointer_to_heap(rb_objspace_t *objspa
 static size_t obj_memsize_of(VALUE obj, int use_all_types);
 static void gc_verify_internal_consistency(rb_objspace_t *objspace);
 
-static void gc_stress_set(rb_objspace_t *objspace, VALUE flag);
 static VALUE gc_disable_no_rest(rb_objspace_t *);
 
 static double getrusage_time(void);
@@ -3550,14 +3541,6 @@ Init_heap(void)
 
     objspace->profile.invoke_time = getrusage_time();
     finalizer_table = st_init_numtable();
-}
-
-void
-Init_gc_stress(void)
-{
-    rb_objspace_t *objspace = &rb_objspace;
-
-    gc_stress_set(objspace, ruby_initial_gc_stress);
 }
 
 typedef int each_obj_callback(void *, void *, size_t, void *);
@@ -11151,9 +11134,11 @@ gc_stress_get(rb_execution_context_t *ec, VALUE self)
     return ruby_gc_stress_mode;
 }
 
-static void
-gc_stress_set(rb_objspace_t *objspace, VALUE flag)
+void
+rb_gc_stress_set(VALUE flag)
 {
+    rb_objspace_t *objspace = &rb_objspace;
+
     objspace->flags.gc_stressful = RTEST(flag);
     objspace->gc_stress_mode = flag;
 }
@@ -11161,8 +11146,8 @@ gc_stress_set(rb_objspace_t *objspace, VALUE flag)
 static VALUE
 gc_stress_set_m(rb_execution_context_t *ec, VALUE self, VALUE flag)
 {
-    rb_objspace_t *objspace = &rb_objspace;
-    gc_stress_set(objspace, flag);
+
+    rb_gc_stress_set(flag);
     return flag;
 }
 

--- a/inits.c
+++ b/inits.c
@@ -73,7 +73,6 @@ rb_call_inits(void)
     CALL(vm_trace);
     CALL(vm_stack_canary);
     CALL(ast);
-    CALL(gc_stress);
     CALL(shape);
     CALL(Prism);
 

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -189,7 +189,6 @@ typedef struct ractor_newobj_cache {
 } rb_ractor_newobj_cache_t;
 
 /* gc.c */
-extern VALUE *ruby_initial_gc_stress_ptr;
 extern int ruby_disable_gc;
 RUBY_ATTR_MALLOC void *ruby_mimmalloc(size_t size);
 void ruby_mimfree(void *ptr);
@@ -223,6 +222,8 @@ void rb_gc_mark_weak(VALUE *ptr);
 void rb_gc_remove_weak(VALUE parent_obj, VALUE *ptr);
 
 void rb_gc_ref_update_table_values_only(st_table *tbl);
+
+void rb_gc_stress_set(VALUE flag);
 
 #define rb_gc_mark_and_move_ptr(ptr) do { \
     VALUE _obj = (VALUE)*(ptr); \


### PR DESCRIPTION
ruby_env_debug_option gets called after Init_gc_stress, so the --debug=gc_stress flag never works.