### PR TITLE
[DOC] Small edits in rbasic.h

### DIFF
--- a/include/ruby/internal/core/rbasic.h
+++ b/include/ruby/internal/core/rbasic.h
@@ -63,8 +63,8 @@ RUBY_ALIGNAS(SIZEOF_VALUE)
 RBasic {
 
     /**
-     * Per-object  flags.  Each  Ruby  object has its own  characteristics apart
-     * from its class.  For instance, whether an object  is frozen or not is not
+     * Per-object flags.   Each Ruby object  has its own  characteristics apart
+     * from its class.  For instance, whether an object is frozen or not is not
      * controlled by its class.  This is where such properties are stored.
      *
      * @see enum ::ruby_fl_type

--- a/include/ruby/internal/core/rbasic.h
+++ b/include/ruby/internal/core/rbasic.h
@@ -56,22 +56,20 @@ enum ruby_rvalue_flags {
 };
 
 /**
- * Ruby's object's,  base components.  Every  single ruby objects have  them in
- * common.
+ * Ruby object's base components. All Ruby objects have them in common.
  */
 struct
 RUBY_ALIGNAS(SIZEOF_VALUE)
 RBasic {
 
     /**
-     * Per-object  flags.  Each  ruby  objects have  their own  characteristics
-     * apart from their  classes.  For instance whether an object  is frozen or
-     * not is not  controlled by its class.  This is  where such properties are
-     * stored.
+     * Per-object  flags.  Each  Ruby  object has its own  characteristics apart
+     * from its class.  For instance, whether an object  is frozen or not is not
+     * controlled by its class.  This is where such properties are stored.
      *
      * @see enum ::ruby_fl_type
      *
-     * @note  This is ::VALUE rather than  an enum for alignment purpose.  Back
+     * @note  This is ::VALUE rather than  an enum for alignment purposes.  Back
      *        in the 1990s there were no such thing like `_Alignas` in C.
      */
     VALUE flags;
@@ -79,10 +77,10 @@ RBasic {
     /**
      * Class of an object.  Every object has its class.  Also, everything is an
      * object  in Ruby.   This means  classes are  also objects.   Classes have
-     * their own classes,  classes of classes have their classes,  too ...  and
-     * it recursively continues forever.
+     * their own classes,  classes  of classes have their classes too,  and  it
+     * recursively continues forever.
      *
-     * Also note the `const` qualifier.  In  ruby an object cannot "change" its
+     * Also note the `const` qualifier.  In Ruby, an object cannot "change" its
      * class.
      */
     const VALUE klass;


### PR DESCRIPTION
I leveraged a pass reading `rbasic.h` to fix a few minor things. Mostly English usage, and ruby -> Ruby when referring to the language.

For example, in the sentence

> Every  single ruby objects have  them in common.

"objects" and "have" do not agree with the "Every single".

In this file, comments are justified. Also, there are two spaces after periods. The patch preserves this.