### PR TITLE
.travis.yml: Add lscpu command to see the details of the CPU.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,6 +121,7 @@ matrix:
   fast_finish: true
 
 before_script:
+  - lscpu
   - ./autogen.sh
   - mkdir build
   - cd build


### PR DESCRIPTION
The `lscpu` command is useful to see the details of the used CPU. Especially it's useful when we want to align our SSH servers with the CI environment, and ensure what parts are different.
