### PR TITLE
Avoid using `else` for `peek_at` function in prism/prism.c

### DIFF
--- a/prism/prism.c
+++ b/prism/prism.c
@@ -7078,9 +7078,8 @@ static inline uint8_t
 peek_at(pm_parser_t *parser, const uint8_t *cursor) {
     if (cursor < parser->end) {
         return *cursor;
-    } else {
-        return '\0';
     }
+    return '\0';
 }
 
 /**


### PR DESCRIPTION
I was reading `prism/prism.c` and found out this situation.

This allows to avoid using `else` since the `if` branch has a return statement. This case occurred in the `peek_at` function in `prism/prism.c`.