### PR TITLE
lib/bundled_gems.rb: dynamically ignore Kernel.require decorators

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -147,7 +147,7 @@ module Gem::BUNDLED_GEMS
           next
         end
 
-        unless cl.path.match?(/bootsnap|zeitwerk/)
+        if cl.base_label != "require"
           location = cl.path
           break
         end


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/10347

This avoid directly referencing bootsnap and zeitwerk, and also handle other gems that may decorate `require`.

@hsbt @fxn @jeremyevans 