### PR TITLE
Update minitest and power_assert bundled gems

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -6,11 +6,8 @@
 # - revision: revision in repository-url to test
 #   if `revision` is not given, "v"+`version` or `version` will be used.
 
-# Waiting for https://github.com/minitest/minitest/pull/991
-minitest        5.22.3  https://github.com/Shopify/minitest b5f5202575894796e00109a8f8a5041b778991ee
-
-# Waiting for https://github.com/ruby/power_assert/pull/48
-power_assert    2.0.3   https://github.com/ruby/power_assert 78dd2ab3ccd93796d83c0b35b978c39bfabb938c
+minitest        5.22.3  https://github.com/minitest/minitest 287b35d60c8e19c11ba090efc6eeb225325a8520
+power_assert    2.0.3   https://github.com/ruby/power_assert 84e85124c5014a139af39161d484156cfe87a9ed
 rake            13.1.0  https://github.com/ruby/rake
 test-unit       3.6.2   https://github.com/test-unit/test-unit
 rexml           3.2.6   https://github.com/ruby/rexml


### PR DESCRIPTION
They were pointing to branches to be chilled string compatible. Both patches have been merged now.