### PR TITLE
Refactor init_copy gc attributes

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -8691,11 +8691,12 @@ rb_gc_writebarrier_remember(VALUE obj)
 }
 
 void
-rb_copy_wb_protected_attribute(VALUE dest, VALUE obj)
+rb_gc_copy_attributes(VALUE dest, VALUE obj)
 {
     if (RVALUE_WB_UNPROTECTED(obj)) {
         rb_gc_writebarrier_unprotect(dest);
     }
+    rb_gc_copy_finalizer(dest, obj);
 }
 
 size_t

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -197,7 +197,7 @@ void rb_objspace_set_event_hook(const rb_event_flag_t event);
 VALUE rb_objspace_gc_enable(struct rb_objspace *);
 VALUE rb_objspace_gc_disable(struct rb_objspace *);
 void ruby_gc_set_params(void);
-void rb_copy_wb_protected_attribute(VALUE dest, VALUE obj);
+void rb_gc_copy_attributes(VALUE dest, VALUE obj);
 size_t rb_size_mul_or_raise(size_t, size_t, VALUE); /* used in compile.c */
 size_t rb_size_mul_add_or_raise(size_t, size_t, size_t, VALUE); /* used in iseq.h */
 size_t rb_malloc_grow_capa(size_t current_capacity, size_t type_size);

--- a/object.c
+++ b/object.c
@@ -396,10 +396,8 @@ init_copy(VALUE dest, VALUE obj)
     RBASIC(dest)->flags &= ~(T_MASK|FL_EXIVAR);
     // Copies the shape id from obj to dest
     RBASIC(dest)->flags |= RBASIC(obj)->flags & (T_MASK|FL_EXIVAR);
-    rb_copy_wb_protected_attribute(dest, obj);
+    rb_gc_copy_attributes(dest, obj);
     rb_copy_generic_ivar(dest, obj);
-    rb_gc_copy_finalizer(dest, obj);
-
     if (RB_TYPE_P(obj, T_OBJECT)) {
         rb_obj_copy_ivar(dest, obj);
     }


### PR DESCRIPTION
This PR moves `rb_copy_wb_protected_attribute` and `rb_gc_copy_finalizer` into a single function called `rb_gc_copy_attributes` to be called by `init_copy`. This reduces the surface area of the GC API.