### PR TITLE
Refactor live and garbage obj check

### DIFF
--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -577,7 +577,7 @@ reachable_object_from_i(VALUE obj, void *data_ptr)
     VALUE key = obj;
     VALUE val = obj;
 
-    if (rb_objspace_markable_object_p(obj)) {
+    if (!rb_objspace_garbage_object_p(obj)) {
         if (NIL_P(rb_hash_lookup(data->refs, key))) {
             rb_hash_aset(data->refs, key, Qtrue);
 
@@ -643,7 +643,7 @@ collect_values(st_data_t key, st_data_t value, st_data_t data)
 static VALUE
 reachable_objects_from(VALUE self, VALUE obj)
 {
-    if (rb_objspace_markable_object_p(obj)) {
+    if (!rb_objspace_garbage_object_p(obj)) {
         struct rof_data data;
 
         if (rb_typeddata_is_kind_of(obj, &iow_data_type)) {
@@ -690,7 +690,7 @@ reachable_object_from_root_i(const char *category, VALUE obj, void *ptr)
         rb_hash_aset(data->categories, category_str, category_objects);
     }
 
-    if (rb_objspace_markable_object_p(obj) &&
+    if (!rb_objspace_garbage_object_p(obj) &&
         obj != data->categories &&
         obj != data->last_category_objects) {
         if (rb_objspace_internal_object_p(obj)) {

--- a/imemo.c
+++ b/imemo.c
@@ -215,7 +215,7 @@ rb_cc_table_mark(VALUE klass)
 static bool
 moved_or_living_object_strictly_p(VALUE obj)
 {
-    return obj && (rb_objspace_markable_object_p(obj) || BUILTIN_TYPE(obj) == T_MOVED);
+    return obj && (!rb_objspace_garbage_object_p(obj) || BUILTIN_TYPE(obj) == T_MOVED);
 }
 
 static void
@@ -455,7 +455,7 @@ vm_ccs_free(struct rb_class_cc_entries *ccs, int alive, VALUE klass)
             if (!alive) {
                 void *ptr = asan_unpoison_object_temporary((VALUE)cc);
                 // ccs can be free'ed.
-                if (rb_objspace_markable_object_p((VALUE)cc) &&
+                if (!rb_objspace_garbage_object_p((VALUE)cc) &&
                     IMEMO_TYPE_P(cc, imemo_callcache) &&
                     cc->klass == klass) {
                     // OK. maybe target cc.

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -213,7 +213,6 @@ void rb_gc_ractor_newobj_cache_clear(rb_ractor_newobj_cache_t *newobj_cache);
 bool rb_gc_size_allocatable_p(size_t size);
 size_t *rb_gc_size_pool_sizes(void);
 size_t rb_gc_size_pool_id_for_size(size_t size);
-int rb_objspace_garbage_object_p(VALUE obj);
 bool rb_gc_is_ptr_to_obj(const void *ptr);
 
 void rb_gc_mark_and_move(VALUE *ptr);
@@ -235,7 +234,7 @@ RUBY_SYMBOL_EXPORT_BEGIN
 /* exports for objspace module */
 void rb_objspace_reachable_objects_from(VALUE obj, void (func)(VALUE, void *), void *data);
 void rb_objspace_reachable_objects_from_root(void (func)(const char *category, VALUE, void *), void *data);
-int rb_objspace_markable_object_p(VALUE obj);
+int rb_objspace_garbage_object_p(VALUE obj);
 int rb_objspace_internal_object_p(VALUE obj);
 
 void rb_objspace_each_objects(

--- a/yjit.c
+++ b/yjit.c
@@ -1041,7 +1041,7 @@ rb_yjit_multi_ractor_p(void)
 void
 rb_assert_iseq_handle(VALUE handle)
 {
-    RUBY_ASSERT_ALWAYS(rb_objspace_markable_object_p(handle));
+    RUBY_ASSERT_ALWAYS(!rb_objspace_garbage_object_p(handle));
     RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(handle, imemo_iseq));
 }
 
@@ -1054,7 +1054,7 @@ rb_IMEMO_TYPE_P(VALUE imemo, enum imemo_type imemo_type)
 void
 rb_assert_cme_handle(VALUE handle)
 {
-    RUBY_ASSERT_ALWAYS(rb_objspace_markable_object_p(handle));
+    RUBY_ASSERT_ALWAYS(!rb_objspace_garbage_object_p(handle));
     RUBY_ASSERT_ALWAYS(IMEMO_TYPE_P(handle, imemo_ment));
 }
 


### PR DESCRIPTION
This PR moves the code for `is_live_object` into `is_garbage_object` because they are opposite of one another. It also replaces calls to `is_live_object` and `rb_objspace_markable_object_p` with `!is_garbage_object` and `!rb_objspace_garbage_object_p` respectively.

This refactor reduces the surface area of the GC API.