### PR TITLE
YJIT: Inline simple getlocal+leave iseqs

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4753,3 +4753,19 @@ assert_equal 'foo', %q{
   entry(false)
   entry(true)
 }
+
+assert_equal '[:ok, :ok, :ok]', %q{
+  def identity(x) = x
+  def foo(x, _) = x
+  def bar(_, _, _, _, x) = x
+
+  def tests
+    [
+      identity(:ok),
+      foo(:ok, 2),
+      bar(1, 2, 3, 4, :ok),
+    ]
+  end
+
+  tests
+}

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -711,6 +711,7 @@ mod manual_defs {
     pub const RUBY_FIXNUM_MAX: isize = RUBY_LONG_MAX / 2;
 
     // From vm_callinfo.h - uses calculation that seems to confuse bindgen
+    pub const VM_CALL_ARGS_SIMPLE: u32 = 1 << VM_CALL_ARGS_SIMPLE_bit;
     pub const VM_CALL_ARGS_SPLAT: u32 = 1 << VM_CALL_ARGS_SPLAT_bit;
     pub const VM_CALL_ARGS_BLOCKARG: u32 = 1 << VM_CALL_ARGS_BLOCKARG_bit;
     pub const VM_CALL_FCALL: u32 = 1 << VM_CALL_FCALL_bit;


### PR DESCRIPTION
This mainly targets things like `T.let()` from Sorbet, which is just an
identity function at runtime and only a hint for the static checker.
Only deal with simple caller and callees (no keywords and splat etc.).
