### PR TITLE
Launchable: Configure "os" flavor correctly in macos.yaml

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Set up Launchable
         uses: ./.github/actions/launchable/setup
         with:
-          os: ${{ matrix.os }}
+          os: ${{ matrix.os || (github.repository == 'ruby/ruby' && 'macos-arm-oss' || 'macos-14')}}
           test-opts: ${{ matrix.test_opts }}
           launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
           builddir: build


### PR DESCRIPTION
Upon seeing https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-sessions/2755303, I noticed that the "os" flavor has not been configured correctly in macos.yaml. This PR addresses it.