### PR TITLE
Don't clear pending interrupts in the parent process.

### DIFF
--- a/process.c
+++ b/process.c
@@ -1682,7 +1682,6 @@ before_fork_ruby(void)
 static void
 after_fork_ruby(rb_pid_t pid)
 {
-    rb_threadptr_pending_interrupt_clear(GET_THREAD());
     if (pid == 0) {
         // child
         clear_pid_cache();

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -2828,4 +2828,25 @@ EOS
     [t1, t2, t3].each { _1&.join rescue nil }
     [long_rpipe, long_wpipe, short_rpipe, short_wpipe].each { _1&.close rescue nil }
   end if defined?(fork)
+
+  def test_handle_interrupt_with_fork
+    Thread.handle_interrupt(RuntimeError => :never) do
+      Thread.current.raise(RuntimeError, "Queued error")
+
+      assert_predicate Thread, :pending_interrupt?
+
+      pid = Process.fork do
+        if Thread.pending_interrupt?
+          exit 1
+        end
+      end
+
+      _, status = Process.waitpid2(pid)
+      assert_predicate status, :success?
+
+      assert_predicate Thread, :pending_interrupt?
+    end
+  rescue RuntimeError
+    # Ignore.
+  end if defined?(fork)
 end

--- a/thread.c
+++ b/thread.c
@@ -4725,6 +4725,7 @@ void
 rb_thread_atfork(void)
 {
     rb_thread_t *th = GET_THREAD();
+    rb_threadptr_pending_interrupt_clear(th);
     rb_thread_atfork_internal(th, terminate_atfork_i);
     th->join_list = NULL;
     rb_fiber_atfork(th);


### PR DESCRIPTION
While experimenting with `Thread.handle_interrupt`, I found this bug with `Process.fork`.

Essentially, `Process.fork` will clear any pending interrupts... in the child process AND the parent process. I believe it should only clear pending interrupts in the child process and NOT the parent process.

See <https://bugs.ruby-lang.org/issues/20393> for more context.