### PR TITLE
Sync power_assert version field in `gems/bundled_gems`

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -7,7 +7,7 @@
 #   if `revision` is not given, "v"+`version` or `version` will be used.
 
 minitest        5.22.3  https://github.com/minitest/minitest 287b35d60c8e19c11ba090efc6eeb225325a8520
-power_assert    2.0.3   https://github.com/ruby/power_assert 84e85124c5014a139af39161d484156cfe87a9ed
+power_assert    2.0.4dev https://github.com/ruby/power_assert 84e85124c5014a139af39161d484156cfe87a9ed
 rake            13.1.0  https://github.com/ruby/rake
 test-unit       3.6.2   https://github.com/test-unit/test-unit
 rexml           3.2.6   https://github.com/ruby/rexml


### PR DESCRIPTION
`power_assert` gem suffixes the version number with `dev` when it is not released yet. Out of sync version number in `gems/bundled_gems` confuses `tool/rbinstall.rb` and results in not installing the gem.