### PR TITLE
Remove unnecessary macros and functions for Universal Parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -264,18 +264,6 @@ enc_from_encoding(void *enc)
 }
 
 static int
-encoding_get(VALUE obj)
-{
-    return ENCODING_GET(obj);
-}
-
-static void
-encoding_set(VALUE obj, int encindex)
-{
-    ENCODING_SET(obj, encindex);
-}
-
-static int
 encoding_is_ascii8bit(VALUE obj)
 {
     return ENCODING_IS_ASCII8BIT(obj);
@@ -603,8 +591,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .ascii8bit_encoding = ascii8bit_encoding,
     .enc_codelen = enc_codelen,
     .enc_mbcput = enc_mbcput,
-    .char_to_option_kcode = rb_char_to_option_kcode,
-    .ascii8bit_encindex = rb_ascii8bit_encindex,
     .enc_find_index = rb_enc_find_index,
     .enc_from_index = enc_from_index,
     .enc_associate_index = rb_enc_associate_index,
@@ -613,8 +599,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .enc_coderange_unknown = ENC_CODERANGE_UNKNOWN,
     .enc_compatible = enc_compatible,
     .enc_from_encoding = enc_from_encoding,
-    .encoding_get = encoding_get,
-    .encoding_set = encoding_set,
     .encoding_is_ascii8bit = encoding_is_ascii8bit,
     .usascii_encoding = usascii_encoding,
     .enc_coderange_broken = ENC_CODERANGE_BROKEN,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1356,16 +1356,12 @@ typedef struct rb_parser_config_struct {
     rb_encoding *(*ascii8bit_encoding)(void);
     int (*enc_codelen)(int c, rb_encoding *enc);
     int (*enc_mbcput)(unsigned int c, void *buf, rb_encoding *enc);
-    int (*char_to_option_kcode)(int c, int *option, int *kcode);
-    int (*ascii8bit_encindex)(void);
     int (*enc_find_index)(const char *name);
     rb_encoding *(*enc_from_index)(int idx);
     VALUE (*enc_associate_index)(VALUE obj, int encindex);
     int (*enc_isspace)(OnigCodePoint c, rb_encoding *enc);
     rb_encoding *(*enc_compatible)(VALUE str1, VALUE str2);
     VALUE (*enc_from_encoding)(rb_encoding *enc);
-    int (*encoding_get)(VALUE obj);
-    void (*encoding_set)(VALUE obj, int encindex);
     int (*encoding_is_ascii8bit)(VALUE obj);
     rb_encoding *(*usascii_encoding)(void);
     int enc_coderange_broken;

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -211,8 +211,6 @@ struct rb_imemo_tmpbuf_struct {
 #define rb_ascii8bit_encoding   p->config->ascii8bit_encoding
 #define rb_enc_codelen          p->config->enc_codelen
 #define rb_enc_mbcput           p->config->enc_mbcput
-#define rb_char_to_option_kcode p->config->char_to_option_kcode
-#define rb_ascii8bit_encindex   p->config->ascii8bit_encindex
 #define rb_enc_find_index       p->config->enc_find_index
 #define rb_enc_from_index       p->config->enc_from_index
 #define rb_enc_associate_index  p->config->enc_associate_index
@@ -221,8 +219,6 @@ struct rb_imemo_tmpbuf_struct {
 #define ENC_CODERANGE_UNKNOWN   p->config->enc_coderange_unknown
 #define rb_enc_compatible       p->config->enc_compatible
 #define rb_enc_from_encoding    p->config->enc_from_encoding
-#define ENCODING_GET            p->config->encoding_get
-#define ENCODING_SET            p->config->encoding_set
 #define ENCODING_IS_ASCII8BIT   p->config->encoding_is_ascii8bit
 #define rb_usascii_encoding     p->config->usascii_encoding
 


### PR DESCRIPTION
Remove not used universal parser macros and functions

Some macros and functions for Universal Parser that have not been used since e7ab5d891c3272e72caef6879e90ad8ae4e13dea commit.