### PR TITLE
ObjectSpace.dump_all: Add an option to not dump string content

### DIFF
--- a/ext/objspace/lib/objspace.rb
+++ b/ext/objspace/lib/objspace.rb
@@ -81,7 +81,7 @@ module ObjectSpace
   # This is an experimental method and is subject to change.
   # In particular, the function signature and output format are
   # not guaranteed to be compatible in future versions of ruby.
-  def dump_all(output: :file, full: false, since: nil, shapes: true)
+  def dump_all(output: :file, full: false, since: nil, shapes: true, string_value: true)
     out = case output
     when :file, nil
       require 'tempfile'
@@ -97,7 +97,7 @@ module ObjectSpace
     end
 
     shapes = 0 if shapes == true
-    ret = _dump_all(out, full, since, shapes)
+    ret = _dump_all(out, full, since, shapes, string_value)
     return nil if output == :stdout
     ret
   end

--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -46,7 +46,8 @@ struct dump_config {
     size_t cur_obj_references;
     unsigned int roots: 1;
     unsigned int full_heap: 1;
-    unsigned int partial_dump;
+    unsigned int partial_dump: 1;
+    unsigned int dump_string_value: 1;
     size_t since;
     size_t shapes_since;
     unsigned long buffer_len;
@@ -340,7 +341,7 @@ dump_string_ascii_only(const char *str, long size)
 }
 
 static void
-dump_append_string_content(struct dump_config *dc, VALUE obj)
+dump_append_string_content(struct dump_config *dc, VALUE obj, bool dump_value)
 {
     dump_append(dc, ", \"bytesize\":");
     dump_append_ld(dc, RSTRING_LEN(obj));
@@ -349,7 +350,7 @@ dump_append_string_content(struct dump_config *dc, VALUE obj)
         dump_append_sizet(dc, rb_str_capacity(obj));
     }
 
-    if (RSTRING_LEN(obj) && rb_enc_asciicompat(rb_enc_from_index(ENCODING_GET(obj)))) {
+    if (dump_value && RSTRING_LEN(obj) && rb_enc_asciicompat(rb_enc_from_index(ENCODING_GET(obj)))) {
         int cr = ENC_CODERANGE(obj);
         if (cr == RUBY_ENC_CODERANGE_UNKNOWN) {
             if (dump_string_ascii_only(RSTRING_PTR(obj), RSTRING_LEN(obj))) {
@@ -468,7 +469,7 @@ dump_object(VALUE obj, struct dump_config *dc)
         break;
 
       case T_SYMBOL:
-        dump_append_string_content(dc, rb_sym2str(obj));
+        dump_append_string_content(dc, rb_sym2str(obj), true);
         break;
 
       case T_STRING:
@@ -481,7 +482,7 @@ dump_object(VALUE obj, struct dump_config *dc)
         if (STR_SHARED_P(obj))
             dump_append(dc, ", \"shared\":true");
         else
-            dump_append_string_content(dc, obj);
+            dump_append_string_content(dc, obj, dc->dump_string_value);
 
         if (!ENCODING_IS_ASCII8BIT(obj)) {
             dump_append(dc, ", \"encoding\":\"");
@@ -695,7 +696,7 @@ root_obj_i(const char *category, VALUE obj, void *data)
 }
 
 static void
-dump_output(struct dump_config *dc, VALUE output, VALUE full, VALUE since, VALUE shapes)
+dump_output(struct dump_config *dc, VALUE output, VALUE full, VALUE since, VALUE shapes, VALUE string_value)
 {
 
     dc->full_heap = 0;
@@ -723,6 +724,7 @@ dump_output(struct dump_config *dc, VALUE output, VALUE full, VALUE since, VALUE
     }
 
     dc->shapes_since = RTEST(shapes) ? NUM2SIZET(shapes) : 0;
+    dc->dump_string_value = string_value == Qfalse ? 0 : 1;
 }
 
 static VALUE
@@ -748,7 +750,7 @@ objspace_dump(VALUE os, VALUE obj, VALUE output)
         dc.cur_page_slot_size = rb_gc_obj_slot_size(obj);
     }
 
-    dump_output(&dc, output, Qnil, Qnil, Qnil);
+    dump_output(&dc, output, Qnil, Qnil, Qnil, Qnil);
 
     dump_object(obj, &dc);
 
@@ -815,10 +817,10 @@ shape_i(rb_shape_t *shape, void *data)
 
 /* :nodoc: */
 static VALUE
-objspace_dump_all(VALUE os, VALUE output, VALUE full, VALUE since, VALUE shapes)
+objspace_dump_all(VALUE os, VALUE output, VALUE full, VALUE since, VALUE shapes, VALUE string_value)
 {
     struct dump_config dc = {0,};
-    dump_output(&dc, output, full, since, shapes);
+    dump_output(&dc, output, full, since, shapes, string_value);
 
     if (!dc.partial_dump || dc.since == 0) {
         /* dump roots */
@@ -841,7 +843,7 @@ static VALUE
 objspace_dump_shapes(VALUE os, VALUE output, VALUE shapes)
 {
     struct dump_config dc = {0,};
-    dump_output(&dc, output, Qfalse, Qnil, shapes);
+    dump_output(&dc, output, Qfalse, Qnil, shapes, Qnil);
 
     if (RTEST(shapes)) {
         rb_shape_each_shape(shape_i, &dc);
@@ -858,7 +860,7 @@ Init_objspace_dump(VALUE rb_mObjSpace)
 #endif
 
     rb_define_module_function(rb_mObjSpace, "_dump", objspace_dump, 2);
-    rb_define_module_function(rb_mObjSpace, "_dump_all", objspace_dump_all, 4);
+    rb_define_module_function(rb_mObjSpace, "_dump_all", objspace_dump_all, 5);
     rb_define_module_function(rb_mObjSpace, "_dump_shapes", objspace_dump_shapes, 2);
 
     /* force create static IDs */

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -479,6 +479,36 @@ class TestObjSpace < Test::Unit::TestCase
     end
   end
 
+  def test_dump_no_string_value
+    assert_in_out_err(%w[-robjspace], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+      begin;
+        SECRET = "super-s3cr37"
+        def dump_my_heap_please
+          ObjectSpace.dump_all(output: :stdout, full: true)
+        end
+
+        p dump_my_heap_please
+      end;
+      assert_equal 'nil', output.pop
+      heap = output.find_all { |l| JSON.parse(l)['value'] == "super-s3cr37" }
+      assert_operator heap.length, :>, 0
+    end
+
+    assert_in_out_err(%w[-robjspace], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
+      begin;
+        SECRET = "super-s3cr37"
+        def dump_my_heap_please
+          ObjectSpace.dump_all(output: :stdout, full: true, string_value: false)
+        end
+
+        p dump_my_heap_please
+      end;
+      assert_equal 'nil', output.pop
+      heap = output.find_all { |l| JSON.parse(l)['value'] == "super-s3cr37" }
+      assert_equal 0, heap.length
+    end
+  end
+
   def test_dump_all_single_generation
     assert_in_out_err(%w[-robjspace], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
       begin;


### PR DESCRIPTION
`ObjectSpace.dump_all` is a very useful method to debug memory leaks and such, hence is frequently needed in production. But since all the 7bit strings content is included in the dump, it inccur the risk of leaking personal or secret data.

In many case the strings content isn't that helpful and is just making the dump much bigger for no good reason.

cc @zzak 