### PR TITLE
Set ASAN_OPTIONS=disable_coredump=0 for test_execopts_rlimit test

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -199,58 +199,67 @@ class TestProcess < Test::Unit::TestCase
 
     max = Process.getrlimit(:CORE).last
 
+    # When running under ASAN, we need to set disable_coredump=0 for this test; by default
+    # the ASAN runtime library sets RLIMIT_CORE to 0, "to avoid dumping a 16T+ core file", and
+    # that inteferes with this test.
+    asan_options = ENV['ASAN_OPTIONS'] || ''
+    asan_options  << ':' unless asan_options.empty?
+    env = {
+      'ASAN_OPTIONS' => "#{asan_options}disable_coredump=0"
+    }
+
     n = max
-    IO.popen([RUBY, "-e",
+    IO.popen([env, RUBY, "-e",
              "puts Process.getrlimit(:CORE)", :rlimit_core=>n]) {|io|
       assert_equal("#{n}\n#{n}\n", io.read)
     }
 
     n = 0
-    IO.popen([RUBY, "-e",
+    IO.popen([env, RUBY, "-e",
              "puts Process.getrlimit(:CORE)", :rlimit_core=>n]) {|io|
       assert_equal("#{n}\n#{n}\n", io.read)
     }
 
     n = max
-    IO.popen([RUBY, "-e",
+    IO.popen([env, RUBY, "-e",
              "puts Process.getrlimit(:CORE)", :rlimit_core=>[n]]) {|io|
       assert_equal("#{n}\n#{n}\n", io.read)
     }
 
     m, n = 0, max
-    IO.popen([RUBY, "-e",
+    IO.popen([env, RUBY, "-e",
              "puts Process.getrlimit(:CORE)", :rlimit_core=>[m,n]]) {|io|
       assert_equal("#{m}\n#{n}\n", io.read)
     }
 
     m, n = 0, 0
-    IO.popen([RUBY, "-e",
+    IO.popen([env, RUBY, "-e",
              "puts Process.getrlimit(:CORE)", :rlimit_core=>[m,n]]) {|io|
       assert_equal("#{m}\n#{n}\n", io.read)
     }
 
     n = max
-    IO.popen([RUBY, "-e",
+    IO.popen([env, RUBY, "-e",
       "puts Process.getrlimit(:CORE), Process.getrlimit(:CPU)",
       :rlimit_core=>n, :rlimit_cpu=>3600]) {|io|
       assert_equal("#{n}\n#{n}\n""3600\n3600\n", io.read)
     }
 
     assert_raise(ArgumentError) do
-      system(RUBY, '-e', 'exit',  'rlimit_bogus'.to_sym => 123)
+      system(env, RUBY, '-e', 'exit',  'rlimit_bogus'.to_sym => 123)
     end
-    assert_separately([],"#{<<~"begin;"}\n#{<<~'end;'}", 'rlimit_cpu'.to_sym => 3600)
+    assert_separately([env],"#{<<~"begin;"}\n#{<<~'end;'}", 'rlimit_cpu'.to_sym => 3600)
     BUG = "[ruby-core:82033] [Bug #13744]"
     begin;
       assert_equal([3600,3600], Process.getrlimit(:CPU), BUG)
     end;
 
     assert_raise_with_message(ArgumentError, /bogus/) do
-      system(RUBY, '-e', 'exit', :rlimit_bogus => 123)
+      system(env, RUBY, '-e', 'exit', :rlimit_bogus => 123)
     end
 
     assert_raise_with_message(ArgumentError, /rlimit_cpu/) {
-      system(RUBY, '-e', 'exit', "rlimit_cpu\0".to_sym => 3600)
+      system(env, RUBY, '-e', 'exit', "rlimit_cpu\0".to_sym => 3600)
     }
   end
 


### PR DESCRIPTION
By default, ASAN sets RLIMIT_CORE to zero, "to avoid dumping a 16T+ core file" on 64 bit systems. These tests are just asserting on the expected value of RLIMIT_CORE, not actually dumping core files, so it's fine to disable that behaviour of ASAN for this test.