### PR TITLE
Make TestParallel#test_retry_workers consider RUBY_TEST_TIMEOUT_SCALE

### DIFF
--- a/tool/test/testunit/tests_for_parallel/slow_helper.rb
+++ b/tool/test/testunit/tests_for_parallel/slow_helper.rb
@@ -2,6 +2,7 @@ require 'test/unit'
 
 module TestSlowTimeout
   def test_slow
-    sleep (ENV['sec'] || 3).to_i if on_parallel_worker?
+    sleep_for = EnvUtil.apply_timeout_scale((ENV['sec'] || 3).to_i)
+    sleep sleep_for if on_parallel_worker?
   end
 end


### PR DESCRIPTION
This test currently fails if RUBY_TEST_TIMEOUT_SCALE is set, because the worker timeout is scaled out but the duration of the sleep does not; thus, the test-test-case does not timeout when it should.