### PR TITLE
Don't check for dynamic symbol when reference updating

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -10179,9 +10179,7 @@ gc_update_object_references(rb_objspace_t *objspace, VALUE obj)
         break;
 
       case T_SYMBOL:
-        if (DYNAMIC_SYM_P((VALUE)any)) {
-            UPDATE_IF_MOVED(objspace, RSYMBOL(any)->fstr);
-        }
+        UPDATE_IF_MOVED(objspace, RSYMBOL(any)->fstr);
         break;
 
       case T_FLOAT:


### PR DESCRIPTION
All symbols in the GC are dynamic symbols, so we don't need to check it.