### PR TITLE
[DOC] Use www.rfc-editor.org for RFC text

### DIFF
--- a/doc/ChangeLog/ChangeLog-2.1.0
+++ b/doc/ChangeLog/ChangeLog-2.1.0
@@ -659,7 +659,7 @@ Mon Dec  9 02:10:32 2013  NARUSE, Yui  <naruse@ruby-lang.org>
 
 	* lib/net/http/responses.rb:
 	  Add `HTTPIMUsed`, as it is also supported by rack/rails.
-	  RFC - http://tools.ietf.org/html/rfc3229
+	  RFC - https://www.rfc-editor.org/rfc/rfc3229
 	  by Vipul A M <vipulnsward@gmail.com>
 	  https://github.com/ruby/ruby/pull/447 fix GH-447
 

--- a/doc/ChangeLog/ChangeLog-2.2.0
+++ b/doc/ChangeLog/ChangeLog-2.2.0
@@ -5648,7 +5648,7 @@ Wed Aug  6 04:16:05 2014  NARUSE, Yui  <naruse@ruby-lang.org>
 
 	* lib/net/http/requests.rb (Net::HTTP::Options::RESPONSE_HAS_BODY):
 	  OPTIONS requests may have response bodies. [Feature #8429]
-	  http://tools.ietf.org/html/rfc7231#section-4.3.7
+	  https://www.rfc-editor.org/rfc/rfc7231#section-4.3.7
 
 Wed Aug  6 03:18:04 2014  NARUSE, Yui  <naruse@ruby-lang.org>
 

--- a/doc/ChangeLog/ChangeLog-2.4.0
+++ b/doc/ChangeLog/ChangeLog-2.4.0
@@ -7356,7 +7356,7 @@ Thu Mar 17 11:51:48 2016  NARUSE, Yui  <naruse@ruby-lang.org>
 	  Note: CryptGenRandom function is PRNG and doesn't check its entropy,
 	  so it won't block. [Bug #12139]
 	  https://msdn.microsoft.com/ja-jp/library/windows/desktop/aa379942.aspx
-	  https://tools.ietf.org/html/rfc4086#section-7.1.3
+	  https://www.rfc-editor.org/rfc/rfc4086#section-7.1.3
 	  https://eprint.iacr.org/2007/419.pdf
 	  http://www.cs.huji.ac.il/~dolev/pubs/thesis/msc-thesis-leo.pdf
 

--- a/doc/csv/recipes/generating.rdoc
+++ b/doc/csv/recipes/generating.rdoc
@@ -163,7 +163,7 @@ This example defines and uses two custom write converters to strip and upcase ge
 === RFC 4180 Compliance
 
 By default, \CSV generates data that is compliant with
-{RFC 4180}[https://tools.ietf.org/html/rfc4180]
+{RFC 4180}[https://www.rfc-editor.org/rfc/rfc4180]
 with respect to:
 - Column separator.
 - Quote character.

--- a/doc/csv/recipes/parsing.rdoc
+++ b/doc/csv/recipes/parsing.rdoc
@@ -191,7 +191,7 @@ Output:
 === RFC 4180 Compliance
 
 By default, \CSV parses data that is compliant with
-{RFC 4180}[https://tools.ietf.org/html/rfc4180]
+{RFC 4180}[https://www.rfc-editor.org/rfc/rfc4180]
 with respect to:
 - Row separator.
 - Column separator.

--- a/doc/strftime_formatting.rdoc
+++ b/doc/strftime_formatting.rdoc
@@ -356,7 +356,7 @@ each based on an external standard.
 == HTTP Format
 
 The HTTP date format is based on
-{RFC 2616}[https://datatracker.ietf.org/doc/html/rfc2616],
+{RFC 2616}[https://www.rfc-editor.org/rfc/rfc2616],
 and treats dates in the format <tt>'%a, %d %b %Y %T GMT'</tt>:
 
   d = Date.new(2001, 2, 3) # => #<Date: 2001-02-03>
@@ -371,7 +371,7 @@ and treats dates in the format <tt>'%a, %d %b %Y %T GMT'</tt>:
 == RFC 3339 Format
 
 The RFC 3339 date format is based on
-{RFC 3339}[https://datatracker.ietf.org/doc/html/rfc3339]:
+{RFC 3339}[https://www.rfc-editor.org/rfc/rfc3339]:
 
   d = Date.new(2001, 2, 3) # => #<Date: 2001-02-03>
   # Return 3339-formatted string.
@@ -385,7 +385,7 @@ The RFC 3339 date format is based on
 == RFC 2822 Format
 
 The RFC 2822 date format is based on
-{RFC 2822}[https://datatracker.ietf.org/doc/html/rfc2822],
+{RFC 2822}[https://www.rfc-editor.org/rfc/rfc2822],
 and treats dates in the format <tt>'%a, %-d %b %Y %T %z'</tt>]:
 
   d = Date.new(2001, 2, 3) # => #<Date: 2001-02-03>

--- a/enc/ebcdic.h
+++ b/enc/ebcdic.h
@@ -7,5 +7,5 @@ ENC_ALIAS("ebcdic-cp-us", "IBM037");
  * hopefully the most widely used one.
  *
  * See http://www.iana.org/assignments/character-sets/character-sets.xhtml
- *     http://tools.ietf.org/html/rfc1345
+ *     https://www.rfc-editor.org/rfc/rfc1345
  */

--- a/ext/openssl/ossl_kdf.c
+++ b/ext/openssl/ossl_kdf.c
@@ -18,7 +18,7 @@ static VALUE mKDF, eKDF;
  * of _length_ bytes.
  *
  * For more information about PBKDF2, see RFC 2898 Section 5.2
- * (https://tools.ietf.org/html/rfc2898#section-5.2).
+ * (https://www.rfc-editor.org/rfc/rfc2898#section-5.2).
  *
  * === Parameters
  * pass       :: The password.
@@ -81,10 +81,10 @@ kdf_pbkdf2_hmac(int argc, VALUE *argv, VALUE self)
  * bcrypt.
  *
  * The keyword arguments _N_, _r_ and _p_ can be used to tune scrypt. RFC 7914
- * (published on 2016-08, https://tools.ietf.org/html/rfc7914#section-2) states
+ * (published on 2016-08, https://www.rfc-editor.org/rfc/rfc7914#section-2) states
  * that using values r=8 and p=1 appears to yield good results.
  *
- * See RFC 7914 (https://tools.ietf.org/html/rfc7914) for more information.
+ * See RFC 7914 (https://www.rfc-editor.org/rfc/rfc7914) for more information.
  *
  * === Parameters
  * pass   :: Passphrase.
@@ -147,7 +147,7 @@ kdf_scrypt(int argc, VALUE *argv, VALUE self)
  *    KDF.hkdf(ikm, salt:, info:, length:, hash:) -> String
  *
  * HMAC-based Extract-and-Expand Key Derivation Function (HKDF) as specified in
- * {RFC 5869}[https://tools.ietf.org/html/rfc5869].
+ * {RFC 5869}[https://www.rfc-editor.org/rfc/rfc5869].
  *
  * New in OpenSSL 1.1.0.
  *
@@ -165,7 +165,7 @@ kdf_scrypt(int argc, VALUE *argv, VALUE self)
  *   The hash function.
  *
  * === Example
- *   # The values from https://datatracker.ietf.org/doc/html/rfc5869#appendix-A.1
+ *   # The values from https://www.rfc-editor.org/rfc/rfc5869#appendix-A.1
  *   ikm = ["0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"].pack("H*")
  *   salt = ["000102030405060708090a0b0c"].pack("H*")
  *   info = ["f0f1f2f3f4f5f6f7f8f9"].pack("H*")

--- a/ext/openssl/ossl_ns_spki.c
+++ b/ext/openssl/ossl_ns_spki.c
@@ -365,8 +365,8 @@ ossl_spki_verify(VALUE self, VALUE key)
  *
  * OpenSSL::Netscape is a namespace for SPKI (Simple Public Key
  * Infrastructure) which implements Signed Public Key and Challenge.
- * See {RFC 2692}[http://tools.ietf.org/html/rfc2692] and {RFC
- * 2693}[http://tools.ietf.org/html/rfc2692] for details.
+ * See {RFC 2692}[https://www.rfc-editor.org/rfc/rfc2692] and {RFC
+ * 2693}[https://www.rfc-editor.org/rfc/rfc2692] for details.
  */
 
 /* Document-class: OpenSSL::Netscape::SPKIError

--- a/lib/random/formatter.rb
+++ b/lib/random/formatter.rb
@@ -165,7 +165,7 @@ module Random::Formatter
   #
   # The result contains 122 random bits (15.25 random bytes).
   #
-  # See RFC4122[https://datatracker.ietf.org/doc/html/rfc4122] for details of UUID.
+  # See RFC4122[https://www.rfc-editor.org/rfc/rfc4122] for details of UUID.
   #
   def uuid
     ary = random_bytes(16)

--- a/lib/uri.rb
+++ b/lib/uri.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: false
 # URI is a module providing classes to handle Uniform Resource Identifiers
-# (RFC2396[https://datatracker.ietf.org/doc/html/rfc2396]).
+# (RFC2396[https://www.rfc-editor.org/rfc/rfc2396]).
 #
 # == Features
 #
@@ -47,14 +47,14 @@
 # A good place to view an RFC spec is http://www.ietf.org/rfc.html.
 #
 # Here is a list of all related RFC's:
-# - RFC822[https://datatracker.ietf.org/doc/html/rfc822]
-# - RFC1738[https://datatracker.ietf.org/doc/html/rfc1738]
-# - RFC2255[https://datatracker.ietf.org/doc/html/rfc2255]
-# - RFC2368[https://datatracker.ietf.org/doc/html/rfc2368]
-# - RFC2373[https://datatracker.ietf.org/doc/html/rfc2373]
-# - RFC2396[https://datatracker.ietf.org/doc/html/rfc2396]
-# - RFC2732[https://datatracker.ietf.org/doc/html/rfc2732]
-# - RFC3986[https://datatracker.ietf.org/doc/html/rfc3986]
+# - RFC822[https://www.rfc-editor.org/rfc/rfc822]
+# - RFC1738[https://www.rfc-editor.org/rfc/rfc1738]
+# - RFC2255[https://www.rfc-editor.org/rfc/rfc2255]
+# - RFC2368[https://www.rfc-editor.org/rfc/rfc2368]
+# - RFC2373[https://www.rfc-editor.org/rfc/rfc2373]
+# - RFC2396[https://www.rfc-editor.org/rfc/rfc2396]
+# - RFC2732[https://www.rfc-editor.org/rfc/rfc2732]
+# - RFC3986[https://www.rfc-editor.org/rfc/rfc3986]
 #
 # == Class tree
 #

--- a/lib/uri/generic.rb
+++ b/lib/uri/generic.rb
@@ -945,7 +945,7 @@ module URI
     # == Description
     #
     # URI has components listed in order of decreasing significance from left to right,
-    # see RFC3986 https://tools.ietf.org/html/rfc3986 1.2.3.
+    # see RFC3986 https://www.rfc-editor.org/rfc/rfc3986 1.2.3.
     #
     # == Usage
     #

--- a/lib/uri/http.rb
+++ b/lib/uri/http.rb
@@ -85,7 +85,7 @@ module URI
     # == Description
     #
     # Returns the authority for an HTTP uri, as defined in
-    # https://datatracker.ietf.org/doc/html/rfc3986/#section-3.2.
+    # https://www.rfc-editor.org/rfc/rfc3986#section-3.2.
     #
     #
     # Example:
@@ -106,7 +106,7 @@ module URI
     # == Description
     #
     # Returns the origin for an HTTP uri, as defined in
-    # https://datatracker.ietf.org/doc/html/rfc6454.
+    # https://www.rfc-editor.org/rfc/rfc6454.
     #
     #
     # Example:

--- a/spec/bundler/bundler/digest_spec.rb
+++ b/spec/bundler/bundler/digest_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Bundler::Digest do
     it "is compatible with stdlib" do
       random_strings = ["foo", "skfjsdlkfjsdf", "3924m", "ldskfj"]
 
-      # https://datatracker.ietf.org/doc/html/rfc3174#section-7.3
+      # https://www.rfc-editor.org/rfc/rfc3174#section-7.3
       rfc3174_test_cases = ["abc", "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq", "a", "01234567" * 8]
 
       (random_strings + rfc3174_test_cases).each do |payload|

--- a/test/openssl/test_ssl.rb
+++ b/test/openssl/test_ssl.rb
@@ -691,7 +691,7 @@ class OpenSSL::TestSSL < OpenSSL::SSLTestCase
     assert_equal(true,  OpenSSL::SSL.verify_wildcard("xn--qdk4b9b", "xn--qdk4b9b"))
   end
 
-  # Comments in this test is excerpted from http://tools.ietf.org/html/rfc6125#page-27
+  # Comments in this test is excerpted from https://www.rfc-editor.org/rfc/rfc6125#page-27
   def test_post_connection_check_wildcard_san
     # case-insensitive ASCII comparison
     # RFC 6125, section 6.4.1

--- a/tool/lib/webrick/httprequest.rb
+++ b/tool/lib/webrick/httprequest.rb
@@ -402,7 +402,7 @@ module WEBrick
     # This method provides the metavariables defined by the revision 3
     # of "The WWW Common Gateway Interface Version 1.1"
     # To browse the current document of CGI Version 1.1, see below:
-    # http://tools.ietf.org/html/rfc3875
+    # https://www.rfc-editor.org/rfc/rfc3875
 
     def meta_vars
       meta = Hash.new


### PR DESCRIPTION
We use the following site for that now:

* https://tools.ietf.org/ or http
* https://datatracker.ietf.org or http

Today, IETF said the official site of RFC is www.rfc-editor.org.

FYI: https://authors.ietf.org/en/references-in-rfcxml

I replaced them to www.rfc-editor.org.