### PR TITLE
YJIT: Optimize putobject+opt_ltlt for integers

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4769,3 +4769,20 @@ assert_equal '[:ok, :ok, :ok]', %q{
 
   tests
 }
+
+# test integer left shift with constant rhs
+assert_equal [0x80000000000, 'a+', :ok].inspect, %q{
+  def shift(val) = val << 43
+
+  def tests
+    int = shift(1)
+    str = shift("a")
+
+    Integer.define_method(:<<) { |_| :ok }
+    redef = shift(1)
+
+    [int, str, redef]
+  end
+
+  tests
+}


### PR DESCRIPTION
In `jit_rb_int_lshift()`, we guard against the right hand side changing
since we want to avoid generating variable length shifts. When control
reaches a putobject and `opt_ltlt` pair, though, we know that the right
hand side never changes.

This commit detects this situation and substitutes an implementation
that does not guard against the right hand side changing, saving that
work.

Deleted some putobject Rust tests since they aren't that valuable and
cause linking issues.

Nice boost to `optcarrot` and `protoboeuf`:
```
yjit-pre: ruby 3.4.0dev (2024-03-28T19:30:38Z master 8780059c38) +YJIT [arm64-darwin23]
yjit-post: ruby 3.4.0dev (2024-03-28T19:46:08Z yjit-fused-ltlt 811aa3eb6b) +YJIT [arm64-darwin23]

----------  -------------  ----------  --------------  ----------  -----------------  ------------------
bench       yjit-pre (ms)  stddev (%)  yjit-post (ms)  stddev (%)  yjit-post 1st itr  yjit-pre/yjit-post
optcarrot   915.8          0.7         838.2           0.8         1.09               1.09              
protoboeuf  29.6           12.6        26.5            2.5         1.05               1.12              
----------  -------------  ----------  --------------  ----------  -----------------  ------------------
```