### PR TITLE
Add missing RB_GC_GUARDs related to DATA_PTR

### DIFF
--- a/array.c
+++ b/array.c
@@ -6643,6 +6643,7 @@ ary_sample(rb_execution_context_t *ec, VALUE ary, VALUE randgen, VALUE nv, VALUE
         });
         DATA_PTR(vmemo) = 0;
         st_free_table(memo);
+        RB_GC_GUARD(vmemo);
     }
     else {
         result = rb_ary_dup(ary);

--- a/compile.c
+++ b/compile.c
@@ -11318,6 +11318,7 @@ iseq_build_from_ary_body(rb_iseq_t *iseq, LINK_ANCHOR *const anchor,
         }
     }
     DATA_PTR(labels_wrapper) = 0;
+    RB_GC_GUARD(labels_wrapper);
     validate_labels(iseq, labels_table);
     if (!ret) return ret;
     return iseq_setup(iseq, anchor);

--- a/string.c
+++ b/string.c
@@ -1148,6 +1148,7 @@ str_cat_conv_enc_opts(VALUE newstr, long ofs, const char *ptr, long len,
         rb_str_resize(newstr, olen);
     }
     DATA_PTR(econv_wrapper) = 0;
+    RB_GC_GUARD(econv_wrapper);
     rb_econv_close(ec);
     switch (ret) {
       case econv_finished:


### PR DESCRIPTION
I discovered the problem in `compile.c` from a failing TestIseqLoad#test_stressful_roundtrip test with ASAN enabled. The other two changes in array.c and string.c I found by auditing similar usages of DATA_PTR in the codebase.

[Bug #20402]