### PR TITLE
Manage required baseruby version in one place

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,10 +75,8 @@ AC_ARG_WITH(baseruby,
 	[
 		AC_PATH_PROG([BASERUBY], [ruby], [false])
 	])
-required_baseruby_version=`${tooldir}/missing-baseruby.bat 2>&1 | sed '/.* BASERUBY must be /!d;s///;s/^Ruby *//;s/ .*//'`
-required_baseruby_version=${required_baseruby_version%.0} # Note that `"x.y.0" > "x.y"` is true.
 AS_IF([test "$HAVE_BASERUBY" != no], [
-    HAVE_BASERUBY="`RUBYOPT=- $BASERUBY --disable=gems -e 'print :yes if RUBY_VERSION > "'$required_baseruby_version'"' 2>/dev/null`"
+    RUBYOPT=- $BASERUBY --disable=gems "${tooldir}/missing-baseruby.bat" || HAVE_BASERUBY=no
 ])
 AS_IF([test "${HAVE_BASERUBY:=no}" != no], [
     AS_CASE(["$build_os"], [mingw*], [

--- a/tool/missing-baseruby.bat
+++ b/tool/missing-baseruby.bat
@@ -1,12 +1,14 @@
-: "
+:"" == "
 @echo off || (
   :warn
     echo>&2.%~1
   goto :eof
   :abort
     exit /b 1
+)||(
+:)"||(
+  s = %^#
 )
-: "
 : ; call() { local call=${1#:}; shift; $call "$@"; }
 : ; warn() { echo "$1" >&2; }
 : ; abort () { exit 1; }
@@ -14,3 +16,4 @@
 call :warn "executable host ruby is required.  use --with-baseruby option."
 call :warn "Note that BASERUBY must be Ruby 3.0.0 or later."
 call :abort
+: || (:^; abort if RUBY_VERSION < s[%r"warn .*Ruby ([\d.]+)(?:\.0)?",1])

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -11,13 +11,15 @@ PATH_SEPARATOR = ;
 TZ =				# skip timezone tests
 PWD = $(MAKEDIR)
 empty =
+tooldir = $(srcdir)/tool
 
 !ifndef MFLAGS
 MFLAGS=-l
 !endif
 
 !if "$(BASERUBY)" == ""
-! if [for %I in (ruby.exe) do @echo BASERUBY = %~s$$PATH:I > baseruby.mk]
+! if [ruby $(tooldir)/missing-baseruby.bat 2> nul]
+! else if [for %I in (ruby.exe) do @echo BASERUBY = %~s$$PATH:I > baseruby.mk]
 ! else
 !   include baseruby.mk
 ! endif
@@ -27,7 +29,7 @@ MFLAGS=-l
 BASERUBY =
 !endif
 !if "$(BASERUBY)" == ""
-BASERUBY = echo executable host ruby is required.  use --with-baseruby option.^& exit 1
+BASERUBY = $(tooldir:/=\)\missing-baseruby.bat
 HAVE_BASERUBY = no
 !else
 HAVE_BASERUBY = yes
@@ -485,7 +487,6 @@ EXTOBJS = dmyext.$(OBJEXT)
 arch_hdrdir = $(EXTOUT)/include/$(arch)
 top_srcdir = $(srcdir)
 hdrdir = $(srcdir)/include
-tooldir = $(srcdir)/tool
 VPATH = $(arch_hdrdir)/ruby;$(hdrdir)/ruby;$(srcdir);$(srcdir)/missing;$(win_srcdir)
 
 !ifndef GIT

--- a/win32/setup.mak
+++ b/win32/setup.mak
@@ -66,6 +66,7 @@ RJIT_SUPPORT = $(RJIT_SUPPORT)
 # TOOLS
 <<
 !if defined(BASERUBY)
+	$(BASERUBY:/=\) "$(srcdir)/tool/missing-baseruby.bat"
 	@echo BASERUBY = $(BASERUBY:/=\)>> $(MAKEFILE)
 !endif
 !if "$(RUBY_DEVEL)" == "yes"


### PR DESCRIPTION
Add a Ruby script mode to `tool/missing-baseruby.bat` that checks if `RUBY_VERSION` meets the required version.
This will enable similar checks on mswin as well.