### PR TITLE
Remove VALUE from `struct rb_strterm_struct`

### DIFF
--- a/internal/parse.h
+++ b/internal/parse.h
@@ -18,8 +18,6 @@
 
 struct rb_iseq_struct;          /* in vm_core.h */
 
-#define STRTERM_HEREDOC IMEMO_FL_USER0
-
 /* structs for managing terminator of string literal and heredocment */
 typedef struct rb_strterm_literal_struct {
     long nest;
@@ -40,7 +38,7 @@ typedef struct rb_strterm_heredoc_struct {
 #define HERETERM_LENGTH_MAX UINT_MAX
 
 typedef struct rb_strterm_struct {
-    VALUE flags;
+    bool heredoc;
     union {
         rb_strterm_literal_t literal;
         rb_strterm_heredoc_t heredoc;

--- a/parse.y
+++ b/parse.y
@@ -7923,7 +7923,7 @@ parser_str_new(struct parser_params *p, const char *ptr, long len, rb_encoding *
 static int
 strterm_is_heredoc(rb_strterm_t *strterm)
 {
-    return strterm->flags & STRTERM_HEREDOC;
+    return strterm->heredoc;
 }
 
 static rb_strterm_t *
@@ -7940,7 +7940,7 @@ static rb_strterm_t *
 new_heredoc(struct parser_params *p)
 {
     rb_strterm_t *strterm = ZALLOC(rb_strterm_t);
-    strterm->flags |= STRTERM_HEREDOC;
+    strterm->heredoc = true;
     return strterm;
 }
 


### PR DESCRIPTION
In the past, it was imemo. However a075c55 changed it. Therefore no need to use `VALUE` for the first field.