### PR TITLE
Remove `rb_imemo_tmpbuf_t` from parser

### DIFF
--- a/ext/ripper/ripper_init.c.tmpl
+++ b/ext/ripper/ripper_init.c.tmpl
@@ -2,7 +2,6 @@
 #include "ruby/ruby.h"
 #include "ruby/encoding.h"
 #include "internal.h"
-#include "internal/imemo.h" /* needed by ruby_parser.h */
 #include "rubyparser.h"
 #define YYSTYPE_IS_DECLARED
 #include "parse.h"

--- a/internal/ruby_parser.h
+++ b/internal/ruby_parser.h
@@ -5,7 +5,6 @@
 #include "internal/bignum.h"
 #include "internal/compilers.h"
 #include "internal/complex.h"
-#include "internal/imemo.h"
 #include "internal/rational.h"
 #include "rubyparser.h"
 #include "vm.h"

--- a/node.h
+++ b/node.h
@@ -73,10 +73,6 @@ VALUE rb_parser_dump_tree(const NODE *node, int comment);
 const struct kwtable *rb_reserved_word(const char *, unsigned int);
 
 struct parser_params;
-void *rb_parser_malloc(struct parser_params *, size_t);
-void *rb_parser_realloc(struct parser_params *, void *, size_t);
-void *rb_parser_calloc(struct parser_params *, size_t, size_t);
-void rb_parser_free(struct parser_params *, void *);
 PRINTF_ARGS(void rb_parser_printf(struct parser_params *parser, const char *fmt, ...), 2, 3);
 VALUE rb_node_set_type(NODE *n, enum node_type t);
 

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -387,12 +387,6 @@ gc_guard(VALUE obj)
     RB_GC_GUARD(obj);
 }
 
-static rb_imemo_tmpbuf_t *
-tmpbuf_parser_heap(void *buf, rb_imemo_tmpbuf_t *old_heap, size_t cnt)
-{
-    return rb_imemo_tmpbuf_parser_heap(buf, old_heap, cnt);
-}
-
 static VALUE
 arg_error(void)
 {
@@ -462,7 +456,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .nonempty_memcpy = nonempty_memcpy,
     .xmalloc_mul_add = rb_xmalloc_mul_add,
 
-    .tmpbuf_parser_heap = tmpbuf_parser_heap,
     .ast_new = ast_new,
 
     .compile_callback = rb_suppress_tracing,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1241,7 +1241,6 @@ typedef struct rb_parser_config_struct {
     void *(*xmalloc_mul_add)(size_t x, size_t y, size_t z);
 
     /* imemo */
-    rb_imemo_tmpbuf_t *(*tmpbuf_parser_heap)(void *buf, rb_imemo_tmpbuf_t *old_heap, size_t cnt);
     rb_ast_t *(*ast_new)(VALUE nb);
 
     // VALUE rb_suppress_tracing(VALUE (*func)(VALUE), VALUE arg);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -61,16 +61,6 @@
 
 #define rb_encoding void
 
-#ifndef INTERNAL_IMEMO_H
-struct rb_imemo_tmpbuf_struct {
-    VALUE flags;
-    VALUE reserved;
-    VALUE *ptr; /* malloc'ed buffer */
-    struct rb_imemo_tmpbuf_struct *next; /* next imemo */
-    size_t cnt; /* buffer size in VALUE */
-};
-#endif
-
 #undef xmalloc
 #define xmalloc p->config->malloc
 #undef xcalloc
@@ -94,8 +84,6 @@ struct rb_imemo_tmpbuf_struct {
 #define MEMMOVE(p1,p2,type,n) (p->config->rb_memmove((p1), (p2), sizeof(type), (n)))
 #undef MEMCPY
 #define MEMCPY(p1,p2,type,n) (p->config->nonempty_memcpy((p1), (p2), sizeof(type), (n)))
-
-#define rb_imemo_tmpbuf_parser_heap p->config->tmpbuf_parser_heap
 
 #define compile_callback         p->config->compile_callback
 #define reg_named_capture_assign p->config->reg_named_capture_assign


### PR DESCRIPTION
No parser semantic value types are `VALUE` then no need to use imemo for managing semantic value stack anymore.