### PR TITLE
Reset `$.` before matching

### DIFF
--- a/spec/ruby/language/if_spec.rb
+++ b/spec/ruby/language/if_spec.rb
@@ -309,6 +309,7 @@ describe "The if expression" do
     it "warns when Integer literals are used instead of predicates" do
       -> {
         eval <<~RUBY
+          $. = 0
           10.times { |i| ScratchPad << i if 4..5 }
         RUBY
       }.should complain(/warning: integer literal in flip-flop/, verbose: true)


### PR DESCRIPTION
This is a global variable and may happen to be set to 4 elsewhere.

http://ci.rvm.jp/logfiles/brlog.trunk.20240403-054356#L1707
```
The if expression with a boolean range ('flip-flop' operator) warns when Integer literals are used instead of predicates FAILED
Expected [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] == []
to be truthy but was false
```