### PR TITLE
Revert "Migrate auto_request_review back to CODEOWNERS"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,0 @@
-# YJIT sources and tests
-yjit*      @ruby/yjit
-yjit/**/*  @ruby/yjit
-doc/yjit/* @ruby/yjit
-bootstraptest/test_yjit* @ruby/yjit
-test/ruby/test_yjit*     @ruby/yjit
-yjit/src/cruby_bindings.inc.rs

--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -1,0 +1,13 @@
+files:
+  'yjit*': [team:yjit]
+  'yjit/**/*': [team:yjit]
+  'yjit/src/cruby_bindings.inc.rs': []
+  'doc/yjit/*': [team:yjit]
+  'bootstraptest/test_yjit*': [team:yjit]
+  'test/ruby/test_yjit*': [team:yjit]
+options:
+  ignore_draft: true
+  # This currently doesn't work as intended. We want to skip reviews when only
+  # cruby_bingings.inc.rs is modified, but this skips reviews even when other
+  # yjit files are modified as well. To be enabled after fixing the behavior.
+  #last_files_match_only: true

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,0 +1,19 @@
+name: Auto Request Review
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  auto-request-review:
+    name: Auto Request Review
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'ruby/ruby' && github.base_ref == 'master' }}
+    steps:
+      - name: Request review based on files changes and/or groups the author belongs to
+        uses: necojackarc/auto-request-review@e89da1a8cd7c8c16d9de9c6e763290b6b0e3d424 # v0.13.0
+        with:
+          # scope: public_repo
+          token: ${{ secrets.MATZBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts ruby/ruby#10133

We will have a couple of new YJIT team members who don't have a commit access. To enable sending review requests to them, we'll need to switch it back to auto-request-review.