### PR TITLE
YJIT: Let sp_opnd take the number of slots

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1793,8 +1793,8 @@ impl Context {
     }
 
     /// Get an operand for the adjusted stack pointer address
-    pub fn sp_opnd(&self, offset_bytes: i32) -> Opnd {
-        let offset = ((self.sp_offset as i32) * SIZEOF_VALUE_I32) + offset_bytes;
+    pub fn sp_opnd(&self, offset: i32) -> Opnd {
+        let offset = (self.sp_offset as i32 + offset) * SIZEOF_VALUE_I32;
         return Opnd::mem(64, SP, offset);
     }
 


### PR DESCRIPTION
This PR simplifies the interface of `ctx.sp_opnd()`.

For most of the time, `ctx.sp_opnd` takes `something * SIZEOF_VALUE`. It seems tedious to repeat `* SIZEOF_VALUE` everywhere. It needs to take the number of bytes when `RUBY_SIZEOF_CONTROL_FRAME` is used for stack overflow checks, but it's a multiple of `SIZEOF_VALUE` too. 

Statically asserting `RUBY_SIZEOF_CONTROL_FRAME % SIZEOF_VALUE == 0`, which seems like a fair assumption, we should be able to safely change the interface to take the number of `VALUE` slots.