### PR TITLE
Fix return-type warning in compile.c

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -10310,6 +10310,8 @@ compile_shareable_constant_value(rb_iseq_t *iseq, LINK_ANCHOR *ret, enum rb_pars
             ADD_SEQ(ret, anchor);
         }
         return COMPILE_OK;
+      default:
+        rb_bug("unexpected rb_parser_shareability: %d", shareable);
     }
 }
 


### PR DESCRIPTION
This patch surppresses the warning below:

```console
compile.c:10314:1: warning: control reaches end of non-void function [-Wreturn-type]
10314 | }
      | ^
```