### PR TITLE
Remove `rb_grantpt` function

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2099,7 +2099,6 @@ AC_CHECK_FUNCS(gettimeofday)		# for making ac_cv_func_gettimeofday
 AC_CHECK_FUNCS(getuid)
 AC_CHECK_FUNCS(getuidx)
 AC_CHECK_FUNCS(gmtime_r)
-AC_CHECK_FUNCS(grantpt)
 AC_CHECK_FUNCS(initgroups)
 AC_CHECK_FUNCS(ioctl)
 AC_CHECK_FUNCS(isfinite)

--- a/ext/pty/pty.c
+++ b/ext/pty/pty.c
@@ -258,13 +258,19 @@ get_device_once(int *master, int *slave, char SlaveName[DEVICELEN], int nomesg, 
     /* Unix98 PTY */
     int masterfd = -1, slavefd = -1;
     char *slavedevice;
+    struct sigaction dfl, old;
+
+    dfl.sa_handler = SIG_DFL;
+    dfl.sa_flags = 0;
+    sigemptyset(&dfl.sa_mask);
 
 #if defined(__sun) || defined(__OpenBSD__) || (defined(__FreeBSD__) && __FreeBSD_version < 902000)
     /* workaround for Solaris 10: grantpt() doesn't work if FD_CLOEXEC is set.  [ruby-dev:44688] */
     /* FreeBSD 9.2 or later supports O_CLOEXEC
      * http://www.freebsd.org/cgi/query-pr.cgi?pr=162374 */
     if ((masterfd = posix_openpt(O_RDWR|O_NOCTTY)) == -1) goto error;
-    if (rb_grantpt(masterfd) == -1) goto error;
+    if (sigaction(SIGCHLD, &dfl, &old) == -1) goto error;
+    if (grantpt(masterfd) == -1) goto grantpt_error;
     rb_fd_fix_cloexec(masterfd);
 #else
     {
@@ -278,8 +284,10 @@ get_device_once(int *master, int *slave, char SlaveName[DEVICELEN], int nomesg, 
         if ((masterfd = posix_openpt(flags)) == -1) goto error;
     }
     rb_fd_fix_cloexec(masterfd);
-    if (rb_grantpt(masterfd) == -1) goto error;
+    if (sigaction(SIGCHLD, &dfl, &old) == -1) goto error;
+    if (grantpt(masterfd) == -1) goto grantpt_error;
 #endif
+    if (sigaction(SIGCHLD, &old, NULL) == -1) goto error;
     if (unlockpt(masterfd) == -1) goto error;
     if ((slavedevice = ptsname(masterfd)) == NULL) goto error;
     if (no_mesg(slavedevice, nomesg) == -1) goto error;
@@ -297,6 +305,8 @@ get_device_once(int *master, int *slave, char SlaveName[DEVICELEN], int nomesg, 
     strlcpy(SlaveName, slavedevice, DEVICELEN);
     return 0;
 
+  grantpt_error:
+    sigaction(SIGCHLD, &old, NULL);
   error:
     if (slavefd != -1) close(slavefd);
     if (masterfd != -1) close(masterfd);
@@ -348,17 +358,21 @@ get_device_once(int *master, int *slave, char SlaveName[DEVICELEN], int nomesg, 
 
     extern char *ptsname(int);
     extern int unlockpt(int);
+    extern int grantpt(int);
 
 #if defined(__sun)
     /* workaround for Solaris 10: grantpt() doesn't work if FD_CLOEXEC is set.  [ruby-dev:44688] */
     if((masterfd = open("/dev/ptmx", O_RDWR, 0)) == -1) goto error;
-    if(rb_grantpt(masterfd) == -1) goto error;
+    s = signal(SIGCHLD, SIG_DFL);
+    if(grantpt(masterfd) == -1) goto error;
     rb_fd_fix_cloexec(masterfd);
 #else
     if((masterfd = rb_cloexec_open("/dev/ptmx", O_RDWR, 0)) == -1) goto error;
     rb_update_max_fd(masterfd);
-    if(rb_grantpt(masterfd) == -1) goto error;
+    s = signal(SIGCHLD, SIG_DFL);
+    if(grantpt(masterfd) == -1) goto error;
 #endif
+    signal(SIGCHLD, s);
     if(unlockpt(masterfd) == -1) goto error;
     if((slavedevice = ptsname(masterfd)) == NULL) goto error;
     if (no_mesg(slavedevice, nomesg) == -1) goto error;

--- a/internal/signal.h
+++ b/internal/signal.h
@@ -19,7 +19,6 @@ void (*ruby_posix_signal(int, void (*)(int)))(int);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* signal.c (export) */
-int rb_grantpt(int fd);
 RUBY_SYMBOL_EXPORT_END
 
 #endif /* INTERNAL_SIGNAL_H */

--- a/signal.c
+++ b/signal.c
@@ -1548,21 +1548,3 @@ Init_signal(void)
 
     rb_enable_interrupt();
 }
-
-#if defined(HAVE_GRANTPT)
-extern int grantpt(int);
-#else
-static int
-fake_grantfd(int masterfd)
-{
-    errno = ENOSYS;
-    return -1;
-}
-#define grantpt(fd) fake_grantfd(fd)
-#endif
-
-int
-rb_grantpt(int masterfd)
-{
-    return grantpt(masterfd);
-}


### PR DESCRIPTION
This function is only for pty library, and It does nothing other than just call grantpt(3) since ruby/ruby#7527.