### PR TITLE
[PRISM] Compiler cleanup

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -4622,15 +4622,17 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         return;
       }
       case PM_BLOCK_ARGUMENT_NODE: {
-        pm_block_argument_node_t *cast = (pm_block_argument_node_t *) node;
+        // foo(&bar)
+        //     ^^^^
+        const pm_block_argument_node_t *cast = (const pm_block_argument_node_t *) node;
 
-        if (cast->expression) {
+        if (cast->expression != NULL) {
             PM_COMPILE(cast->expression);
         }
         else {
             // If there's no expression, this must be block forwarding.
             pm_local_index_t local_index = pm_lookup_local_index(iseq, scope_node, PM_CONSTANT_AND, 0);
-            ADD_INSN2(ret, &dummy_line_node, getblockparamproxy, INT2FIX(local_index.index + VM_ENV_DATA_SIZE - 1), INT2FIX(local_index.level));
+            PUSH_INSN2(ret, location, getblockparamproxy, INT2FIX(local_index.index + VM_ENV_DATA_SIZE - 1), INT2FIX(local_index.level));
         }
         return;
       }

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -292,9 +292,9 @@ pm_optimizable_range_item_p(pm_node_t *node)
 static void pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node);
 
 static int
-pm_interpolated_node_compile(const pm_node_list_t *parts, rb_iseq_t *iseq, NODE dummy_line_node, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_interpolated_node_compile(rb_iseq_t *iseq, const pm_node_list_t *parts, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    int number_of_items_pushed = 0;
+    int stack_size = 0;
     size_t parts_size = parts->size;
 
     if (parts_size > 0) {
@@ -304,8 +304,8 @@ pm_interpolated_node_compile(const pm_node_list_t *parts, rb_iseq_t *iseq, NODE 
             const pm_node_t *part = parts->nodes[index];
 
             if (PM_NODE_TYPE_P(part, PM_STRING_NODE)) {
-                const pm_string_node_t *string_node = (const pm_string_node_t *)part;
-                VALUE string_value = parse_string_encoded(scope_node, (pm_node_t *)string_node, &string_node->unescaped);
+                const pm_string_node_t *string_node = (const pm_string_node_t *) part;
+                VALUE string_value = parse_string_encoded(scope_node, (const pm_node_t *) string_node, &string_node->unescaped);
 
                 if (RTEST(current_string)) {
                     current_string = rb_str_concat(current_string, string_value);
@@ -314,10 +314,12 @@ pm_interpolated_node_compile(const pm_node_list_t *parts, rb_iseq_t *iseq, NODE 
                     current_string = string_value;
                 }
             }
-            else if (PM_NODE_TYPE_P(part, PM_EMBEDDED_STATEMENTS_NODE) &&
-                    ((const pm_embedded_statements_node_t *) part)->statements != NULL &&
-                    ((const pm_embedded_statements_node_t *) part)->statements->body.size == 1 &&
-                    PM_NODE_TYPE_P(((const pm_embedded_statements_node_t *) part)->statements->body.nodes[0], PM_STRING_NODE)) {
+            else if (
+                PM_NODE_TYPE_P(part, PM_EMBEDDED_STATEMENTS_NODE) &&
+                ((const pm_embedded_statements_node_t *) part)->statements != NULL &&
+                ((const pm_embedded_statements_node_t *) part)->statements->body.size == 1 &&
+                PM_NODE_TYPE_P(((const pm_embedded_statements_node_t *) part)->statements->body.nodes[0], PM_STRING_NODE)
+            ) {
                 const pm_string_node_t *string_node = (const pm_string_node_t *) ((const pm_embedded_statements_node_t *) part)->statements->body.nodes[0];
                 VALUE string_value = parse_string_encoded(scope_node, (pm_node_t *)string_node, &string_node->unescaped);
 
@@ -333,32 +335,30 @@ pm_interpolated_node_compile(const pm_node_list_t *parts, rb_iseq_t *iseq, NODE 
                     current_string = rb_enc_str_new(NULL, 0, scope_node->encoding);
                 }
 
-                ADD_INSN1(ret, &dummy_line_node, putobject, rb_fstring(current_string));
+                PUSH_INSN1(ret, *node_location, putobject, rb_fstring(current_string));
+                PM_COMPILE_NOT_POPPED(part);
+                PUSH_INSN(ret, *node_location, dup);
+                PUSH_INSN1(ret, *node_location, objtostring, new_callinfo(iseq, idTo_s, 0, VM_CALL_FCALL | VM_CALL_ARGS_SIMPLE , NULL, FALSE));
+                PUSH_INSN(ret, *node_location, anytostring);
 
                 current_string = Qnil;
-                number_of_items_pushed++;
-
-                PM_COMPILE_NOT_POPPED(part);
-                PM_DUP;
-                ADD_INSN1(ret, &dummy_line_node, objtostring, new_callinfo(iseq, idTo_s, 0, VM_CALL_FCALL | VM_CALL_ARGS_SIMPLE , NULL, FALSE));
-                ADD_INSN(ret, &dummy_line_node, anytostring);
-
-                number_of_items_pushed++;
+                stack_size += 2;
             }
         }
 
         if (RTEST(current_string)) {
             current_string = rb_fstring(current_string);
-            ADD_INSN1(ret, &dummy_line_node, putobject, current_string);
+            PUSH_INSN1(ret, *node_location, putobject, current_string);
+
             current_string = Qnil;
-            number_of_items_pushed++;
+            stack_size++;
         }
     }
     else {
-        PM_PUTNIL;
+        PUSH_INSN(ret, *node_location, putnil);
     }
 
-    return number_of_items_pushed;
+    return stack_size;
 }
 
 static VALUE
@@ -523,8 +523,7 @@ parse_regexp_concat(rb_iseq_t *iseq, const pm_scope_node_t *scope_node, const pm
 static void
 pm_compile_regexp_dynamic(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_list_t *parts, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    NODE dummy_line_node = generate_dummy_line_node(node_location->line, node_location->column);
-    int length = pm_interpolated_node_compile(parts, iseq, dummy_line_node, ret, popped, scope_node);
+    int length = pm_interpolated_node_compile(iseq, parts, node_location, ret, popped, scope_node);
     PUSH_INSN2(ret, *node_location, toregexp, INT2FIX(parse_regexp_flags(node) & 0xFF), INT2FIX(length));
 }
 
@@ -6217,7 +6216,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         }
         else {
             const pm_interpolated_string_node_t *cast = (const pm_interpolated_string_node_t *) node;
-            int length = pm_interpolated_node_compile(&cast->parts, iseq, dummy_line_node, ret, popped, scope_node);
+            int length = pm_interpolated_node_compile(iseq, &cast->parts, &location, ret, popped, scope_node);
 
             if (length > 1) PUSH_INSN1(ret, location, concatstrings, INT2FIX(length));
             if (popped) PUSH_INSN(ret, location, pop);
@@ -6229,7 +6228,6 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         // :"foo #{bar}"
         // ^^^^^^^^^^^^^
         const pm_interpolated_symbol_node_t *cast = (const pm_interpolated_symbol_node_t *) node;
-        int length;
 
         if (PM_NODE_FLAG_P(node, PM_NODE_FLAG_STATIC_LITERAL)) {
             if (!popped) {
@@ -6238,7 +6236,8 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             }
         }
         else {
-            if ((length = pm_interpolated_node_compile(&cast->parts, iseq, dummy_line_node, ret, popped, scope_node)) > 1) {
+            int length = pm_interpolated_node_compile(iseq, &cast->parts, &location, ret, popped, scope_node);
+            if (length > 1) {
                 PUSH_INSN1(ret, location, concatstrings, INT2FIX(length));
             }
 
@@ -6253,16 +6252,18 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         return;
       }
       case PM_INTERPOLATED_X_STRING_NODE: {
-        pm_interpolated_x_string_node_t *interp_x_string_node = (pm_interpolated_x_string_node_t *) node;
-        PM_PUTSELF;
-        int number_of_items_pushed = pm_interpolated_node_compile(&interp_x_string_node->parts, iseq, dummy_line_node, ret, false, scope_node);
+        // `foo #{bar}`
+        // ^^^^^^^^^^^^
+        const pm_interpolated_x_string_node_t *cast = (const pm_interpolated_x_string_node_t *) node;
 
-        if (number_of_items_pushed > 1) {
-            ADD_INSN1(ret, &dummy_line_node, concatstrings, INT2FIX(number_of_items_pushed));
-        }
+        PUSH_INSN(ret, location, putself);
 
-        ADD_SEND_WITH_FLAG(ret, &dummy_line_node, idBackquote, INT2NUM(1), INT2FIX(VM_CALL_FCALL | VM_CALL_ARGS_SIMPLE));
-        PM_POP_IF_POPPED;
+        int length = pm_interpolated_node_compile(iseq, &cast->parts, &location, ret, false, scope_node);
+        if (length > 1) PUSH_INSN1(ret, location, concatstrings, INT2FIX(length));
+
+        PUSH_SEND_WITH_FLAG(ret, location, idBackquote, INT2NUM(1), INT2FIX(VM_CALL_FCALL | VM_CALL_ARGS_SIMPLE));
+        if (popped) PUSH_INSN(ret, location, pop);
+
         return;
       }
       case PM_KEYWORD_HASH_NODE: {

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6673,51 +6673,55 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         return;
       }
       case PM_NEXT_NODE: {
-        pm_next_node_t *next_node = (pm_next_node_t *) node;
+        // next
+        // ^^^^
+        //
+        // next foo
+        // ^^^^^^^^
+        const pm_next_node_t *cast = (const pm_next_node_t *) node;
 
         if (ISEQ_COMPILE_DATA(iseq)->redo_label != 0 && can_add_ensure_iseq(iseq)) {
             LABEL *splabel = NEW_LABEL(0);
+            PUSH_LABEL(ret, splabel);
 
-            ADD_LABEL(ret, splabel);
-
-            if (next_node->arguments) {
-                PM_COMPILE_NOT_POPPED((pm_node_t *)next_node->arguments);
+            if (cast->arguments) {
+                PM_COMPILE_NOT_POPPED((const pm_node_t *) cast->arguments);
             }
             else {
-                PM_PUTNIL;
+                PUSH_INSN(ret, location, putnil);
             }
             pm_add_ensure_iseq(ret, iseq, 0, scope_node);
 
-            ADD_ADJUST(ret, &dummy_line_node, ISEQ_COMPILE_DATA(iseq)->redo_label);
-            ADD_INSNL(ret, &dummy_line_node, jump, ISEQ_COMPILE_DATA(iseq)->start_label);
+            PUSH_ADJUST(ret, location, ISEQ_COMPILE_DATA(iseq)->redo_label);
+            PUSH_INSNL(ret, location, jump, ISEQ_COMPILE_DATA(iseq)->start_label);
 
-            ADD_ADJUST_RESTORE(ret, splabel);
-            PM_PUTNIL_UNLESS_POPPED;
+            PUSH_ADJUST_RESTORE(ret, splabel);
+            if (!popped) PUSH_INSN(ret, location, putnil);
         }
         else if (ISEQ_COMPILE_DATA(iseq)->end_label && can_add_ensure_iseq(iseq)) {
             LABEL *splabel = NEW_LABEL(0);
 
-            ADD_LABEL(ret, splabel);
-            ADD_ADJUST(ret, &dummy_line_node, ISEQ_COMPILE_DATA(iseq)->start_label);
+            PUSH_LABEL(ret, splabel);
+            PUSH_ADJUST(ret, location, ISEQ_COMPILE_DATA(iseq)->start_label);
 
-            if (next_node->arguments) {
-                PM_COMPILE_NOT_POPPED((pm_node_t *)next_node->arguments);
+            if (cast->arguments != NULL) {
+                PM_COMPILE_NOT_POPPED((const pm_node_t *) cast->arguments);
             }
             else {
-                PM_PUTNIL;
+                PUSH_INSN(ret, location, putnil);
             }
 
             pm_add_ensure_iseq(ret, iseq, 0, scope_node);
-            ADD_INSNL(ret, &dummy_line_node, jump, ISEQ_COMPILE_DATA(iseq)->end_label);
-            ADD_ADJUST_RESTORE(ret, splabel);
+            PUSH_INSNL(ret, location, jump, ISEQ_COMPILE_DATA(iseq)->end_label);
+            PUSH_ADJUST_RESTORE(ret, splabel);
             splabel->unremovable = FALSE;
 
-            PM_PUTNIL_UNLESS_POPPED;
+            if (!popped) PUSH_INSN(ret, location, putnil);
         }
         else {
             const rb_iseq_t *ip = iseq;
-
             unsigned long throw_flag = 0;
+
             while (ip) {
                 if (!ISEQ_COMPILE_DATA(ip)) {
                     ip = 0;
@@ -6740,15 +6744,15 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                 ip = ISEQ_BODY(ip)->parent_iseq;
             }
             if (ip != 0) {
-                if (next_node->arguments) {
-                    PM_COMPILE_NOT_POPPED((pm_node_t *)next_node->arguments);
+                if (cast->arguments) {
+                    PM_COMPILE_NOT_POPPED((const pm_node_t *) cast->arguments);
                 }
                 else {
-                    PM_PUTNIL;
+                    PUSH_INSN(ret, location, putnil);
                 }
-                ADD_INSN1(ret, &dummy_line_node, throw, INT2FIX(throw_flag | TAG_NEXT));
 
-                PM_POP_IF_POPPED;
+                PUSH_INSN1(ret, location, throw, INT2FIX(throw_flag | TAG_NEXT));
+                if (popped) PUSH_INSN(ret, location, pop);
             }
             else {
                 rb_raise(rb_eArgError, "Invalid next");

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -5461,7 +5461,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
         pm_compile_constant_read(iseq, name, &cast->base.location, ret, scope_node);
         if (popped) PUSH_INSN(ret, location, pop);
-    
+
         return;
       }
       case PM_CONSTANT_AND_WRITE_NODE: {
@@ -5839,7 +5839,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                 PUSH_INSN1(args, location, putobject, ID2SYM(id));
                 PUSH_GETLOCAL(args, location, idx, depth);
             }
-        
+
             PUSH_SEND(args, location, id_core_hash_merge_ptr, INT2FIX(i * 2 + 1));
             flag |= VM_CALL_KW_SPLAT| VM_CALL_KW_SPLAT_MUT;
         }


### PR DESCRIPTION
* Consistently define how to fetch line/column values.
* Reduce dependency on compile.c.
* Stop causing so much struct copying.
* Do not use any dummy nodes.