### PR TITLE
Enable GC loading from a shared library

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -33,6 +33,8 @@ jobs:
             configure: '--disable-yjit'
           - test_task: check
             configure: '--enable-shared --enable-load-relative'
+          - test_task: check
+            configure: '--with-shared-gc'
           - test_task: test-bundler-parallel
           - test_task: test-bundled-gems
           - test_task: check

--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,7 @@ m4_include([tool/m4/ruby_replace_type.m4])dnl
 m4_include([tool/m4/ruby_require_funcs.m4])dnl
 m4_include([tool/m4/ruby_rm_recursive.m4])dnl
 m4_include([tool/m4/ruby_setjmp_type.m4])dnl
+m4_include([tool/m4/ruby_shared_gc.m4])dnl
 m4_include([tool/m4/ruby_stack_grow_direction.m4])dnl
 m4_include([tool/m4/ruby_thread.m4])dnl
 m4_include([tool/m4/ruby_try_cflags.m4])dnl
@@ -3750,6 +3751,7 @@ AS_IF([test x"$gcov" = xyes], [
 ])
 
 RUBY_SETJMP_TYPE
+RUBY_SHARED_GC
 }
 
 [begin]_group "installation section" && {
@@ -4656,6 +4658,7 @@ config_summary "target OS"           "$target_os"
 config_summary "compiler"            "$CC"
 config_summary "with thread"         "$THREAD_MODEL"
 config_summary "with coroutine"      "$coroutine_type"
+config_summary "with shared GC"      "$with_shared_gc"
 config_summary "enable shared libs"  "$ENABLE_SHARED"
 config_summary "dynamic library ext" "$DLEXT"
 config_summary "CFLAGS"              "$cflags"

--- a/dln.c
+++ b/dln.c
@@ -339,7 +339,7 @@ dln_disable_dlclose(void)
 #endif
 
 #if defined(_WIN32) || defined(USE_DLN_DLOPEN)
-static void *
+void *
 dln_open(const char *file)
 {
     static const char incompatible[] = "incompatible library version";
@@ -427,7 +427,7 @@ dln_open(const char *file)
     dln_loaderror("%s - %s", error, file);
 }
 
-static void *
+void *
 dln_sym(void *handle, const char *symbol)
 {
 #if defined(_WIN32)

--- a/dln.h
+++ b/dln.h
@@ -25,6 +25,7 @@ RUBY_SYMBOL_EXPORT_BEGIN
 char *dln_find_exe_r(const char*,const char*,char*,size_t DLN_FIND_EXTRA_ARG_DECL);
 char *dln_find_file_r(const char*,const char*,char*,size_t DLN_FIND_EXTRA_ARG_DECL);
 void *dln_load(const char*);
+void *dln_open(const char *file);
 void *dln_symbol(void*,const char*);
 
 RUBY_SYMBOL_EXPORT_END

--- a/dmydln.c
+++ b/dmydln.c
@@ -20,3 +20,13 @@ dln_symbol(void *handle, const char *symbol)
 
     UNREACHABLE_RETURN(NULL);
 }
+
+NORETURN(void *dln_open(const char*));
+void*
+dln_open(const char *library)
+{
+    rb_loaderror("this executable file can't load extension libraries");
+
+    UNREACHABLE_RETURN(NULL);
+}
+

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -16,6 +16,10 @@
 #include "ruby/ruby.h"          /* for rb_event_flag_t */
 #include "vm_core.h"            /* for GET_EC() */
 
+#ifndef USE_SHARED_GC
+# define USE_SHARED_GC 0
+#endif
+
 #if defined(__x86_64__) && !defined(_ILP32) && defined(__GNUC__)
 #define SET_MACHINE_STACK_END(p) __asm__ __volatile__ ("movq\t%%rsp, %0" : "=r" (*(p)))
 #elif defined(__i386) && defined(__GNUC__)

--- a/tool/m4/ruby_shared_gc.m4
+++ b/tool/m4/ruby_shared_gc.m4
@@ -1,0 +1,19 @@
+dnl -*- Autoconf -*-
+AC_DEFUN([RUBY_SHARED_GC],[
+AC_ARG_WITH(shared-gc,
+    AS_HELP_STRING([--with-shared-gc],
+    [Enable replacement of Ruby's GC from a shared library.]),
+    [with_shared_gc=$withval], [unset with_shared_gc]
+)
+
+AC_SUBST([with_shared_gc])
+AC_MSG_CHECKING([if Ruby is build with shared GC support])
+AS_IF([test "$with_shared_gc" = "yes"], [
+    AC_MSG_RESULT([yes])
+    AC_DEFINE([USE_SHARED_GC], [1])
+], [
+    AC_MSG_RESULT([no])
+    with_shared_gc="no"
+    AC_DEFINE([USE_SHARED_GC], [0])
+])
+])dnl

--- a/vm_core.h
+++ b/vm_core.h
@@ -106,6 +106,14 @@ extern int ruby_assert_critical_section_entered;
 
 #include "ruby/thread_native.h"
 
+#if USE_SHARED_GC
+typedef struct gc_function_map {
+    void *(*init)(void);
+} rb_gc_function_map_t;
+
+#define rb_gc_functions (GET_VM()->gc_functions_map)
+#endif
+
 /*
  * implementation selector of get_insn_info algorithm
  *   0: linear search
@@ -752,6 +760,9 @@ typedef struct rb_vm_struct {
     int coverage_mode;
 
     struct rb_objspace *objspace;
+#if USE_SHARED_GC
+    rb_gc_function_map_t *gc_functions_map;
+#endif
 
     rb_at_exit_list *at_exit;
 


### PR DESCRIPTION
This PR replaces https://github.com/ruby/ruby/pull/10302 as a method for dynamically loading a shared GC library. This new approach has been guided by feedback from @kateinoigakukun and @nobu 

The approach taken here is as follows:

- Enable this feature by configuring with `--with-shared-gc`
- When enabled, Ruby will check for the presence of the environment variable `RUBY_GC_LIBRARY_PATH`
- If that path exists and points to a valid shared object
  - Open the shared object (using `dln_open`), and map the `Init_GC` function to a function map
  - call `Init_GC` as part of `rb_objspace_alloc` when initialising the GC
- If that path does not point to a valid shared object
  - Degrade gracefully to initialising the existing Ruby objspace and GC
  
When Ruby is configured without the `--with-shared-gc` flag, no extra code is compiled and so existing behaviour is maintained without any performance penalty.

Enabling this feature, but not populating `RUBY_GC_LIBRARY_PATH` will incur a small performance penalty due to the overhead of using `getenv` to check for the environment variable.

The use of `dln.c` rather than using `dlopen` directly, should enable this feature to be supported on all platforms that support loading shared libraries, rather than the initial implementation, which explicitly only supported Linux and MacOS.