### PR TITLE
YJIT: Fuse `opt_eq`, `opt_lt`, and `branchunless` for fixnums

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -364,6 +364,7 @@ module RubyVM::YJIT
 
       out.puts "branch_insn_count:     " + format_number(13, stats[:branch_insn_count])
       out.puts "branch_known_count:    " + format_number_pct(13, stats[:branch_known_count], stats[:branch_insn_count])
+      out.puts "branch_fused_count:    " + format_number_pct(13, stats[:branch_fused_count], stats[:branch_insn_count])
 
       out.puts "freed_iseq_count:      " + format_number(13, stats[:freed_iseq_count])
       out.puts "invalidation_count:    " + format_number(13, stats[:invalidation_count])

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -529,6 +529,7 @@ pub enum BranchGenFn {
     JBEToTarget0,
     JBToTarget0,
     JOMulToTarget0,
+    JGEToTarget0,
     JITReturn,
 }
 
@@ -573,6 +574,7 @@ impl BranchGenFn {
                     asm.jmp(target0);
                 }
             }
+            BranchGenFn::JGEToTarget0 => asm.jge(target0),
             BranchGenFn::JNZToTarget0 => {
                 asm.jnz(target0)
             }
@@ -608,6 +610,7 @@ impl BranchGenFn {
             BranchGenFn::JBEToTarget0 |
             BranchGenFn::JBToTarget0 |
             BranchGenFn::JOMulToTarget0 |
+            BranchGenFn::JGEToTarget0 |
             BranchGenFn::JITReturn => BranchShape::Default,
         }
     }
@@ -630,6 +633,7 @@ impl BranchGenFn {
             BranchGenFn::JBEToTarget0 |
             BranchGenFn::JBToTarget0 |
             BranchGenFn::JOMulToTarget0 |
+            BranchGenFn::JGEToTarget0 |
             BranchGenFn::JITReturn => {
                 assert_eq!(new_shape, BranchShape::Default);
             }

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -555,6 +555,7 @@ make_counters! {
     defer_empty_count,
     branch_insn_count,
     branch_known_count,
+    branch_fused_count,
     max_inline_versions,
 
     freed_iseq_count,


### PR DESCRIPTION
This targets the instruction pair that usually result from code like
`if a == b` or `if a < b`.

Fusing the two makes it so we don't need to use csel and then test the
result:

```diff
-# Insn: 0007 opt_eq
+# Insn: 0007 opt_eq (stack_size: 3)
 cmp x9, x10
-mov x11, #0x14
-mov x12, #0
-csel x11, x11, x12, eq
-mov x9, x11
-# Insn: 0009 branchunless
-tst x9, #-5
-b.eq #0x1092ee174
+b.ne #0x10457a174
 nop
-b #0x1092ee1a8
+# gen_direct_jmp: fallthrough
```

By using gen_direct_jmp() for when the branch is not taken, the fusion
also reduces one stub for each fused branch, saving some code size.


```
yjit-pre: ruby 3.4.0dev (2024-04-04T20:59:08Z master 440c63df31) +YJIT [x86_64-linux]
yjit-post: ruby 3.4.0dev (2024-04-09T21:33:39Z yjit-fused-branch e92320519a) +YJIT [x86_64-linux]

----------  -------------  ----------  --------------  ----------  -----------------  ------------------
bench       yjit-pre (ms)  stddev (%)  yjit-post (ms)  stddev (%)  yjit-post 1st itr  yjit-pre/yjit-post
optcarrot   1954.5         0.6         1953.4          0.7         1.00               1.00              
protoboeuf  50.5           1.1         49.2            1.1         1.07               1.03              
activerecord    36.0           1.2         36.3            1.3         0.98               0.99              
chunky-png      615.0          0.4         639.9           0.6         0.96               0.96              
erubi-rails     931.1          0.3         937.2           0.2         0.98               0.99              
hexapdf         1913.2         1.3         1933.0          2.6         0.98               0.99              
liquid-c        56.4           1.4         56.3            1.4         1.00               1.00              
liquid-compile  57.7           1.9         57.2            1.8         0.99               1.01              
liquid-render   76.8           1.3         76.8            1.3         0.99               1.00              
lobsters        860.5          1.3         859.8           1.1         1.06               1.00              
mail            120.4          0.8         120.4           0.7         1.00               1.00              
psych-load      1616.7         0.1         1617.0          0.1         1.00               1.00              
railsbench      1959.9         0.1         1952.9          0.1         1.00               1.00              
rubocop         109.6          5.0         109.5           5.0         1.00               1.00              
ruby-lsp        95.6           2.4         93.9            2.4         1.01               1.02              
sequel          66.5           0.8         66.3            0.7         0.99               1.00              
--------------  -------------  ----------  --------------  ----------  -----------------  ------------------