### PR TITLE
Merge two `node_buffer_list_t` fields into one

### DIFF
--- a/node.c
+++ b/node.c
@@ -39,7 +39,7 @@ init_node_buffer_elem(node_buffer_elem_t *nbe, size_t allocated, void *xmalloc(s
 }
 
 static void
-init_node_buffer_list(node_buffer_list_t * nb, node_buffer_elem_t *head, void *xmalloc(size_t))
+init_node_buffer_list(node_buffer_list_t *nb, node_buffer_elem_t *head, void *xmalloc(size_t))
 {
     init_node_buffer_elem(head, NODE_BUF_DEFAULT_SIZE, xmalloc);
     nb->head = nb->last = head;
@@ -60,14 +60,13 @@ rb_node_buffer_new(void)
 #endif
 {
     const size_t bucket_size = offsetof(node_buffer_elem_t, buf) + NODE_BUF_DEFAULT_SIZE;
-    const size_t alloc_size = sizeof(node_buffer_t) + (bucket_size * 2);
+    const size_t alloc_size = sizeof(node_buffer_t) + (bucket_size);
     STATIC_ASSERT(
         integer_overflow,
         offsetof(node_buffer_elem_t, buf) + NODE_BUF_DEFAULT_SIZE
-        > sizeof(node_buffer_t) + 2 * sizeof(node_buffer_elem_t));
+        > sizeof(node_buffer_t) + sizeof(node_buffer_elem_t));
     node_buffer_t *nb = ruby_xmalloc(alloc_size);
-    init_node_buffer_list(&nb->unmarkable, (node_buffer_elem_t*)&nb[1], ruby_xmalloc);
-    init_node_buffer_list(&nb->markable, (node_buffer_elem_t*)((size_t)nb->unmarkable.head + bucket_size), ruby_xmalloc);
+    init_node_buffer_list(&nb->buffer_list, (node_buffer_elem_t*)&nb[1], ruby_xmalloc);
     nb->local_tables = 0;
     nb->tokens = 0;
 #ifdef UNIVERSAL_PARSER
@@ -249,9 +248,8 @@ rb_node_buffer_free(rb_ast_t *ast, node_buffer_t *nb)
     if (ast->node_buffer && ast->node_buffer->tokens) {
         parser_tokens_free(ast, ast->node_buffer->tokens);
     }
-    iterate_node_values(ast, &nb->unmarkable, free_ast_value, NULL);
-    node_buffer_list_free(ast, &nb->unmarkable);
-    node_buffer_list_free(ast, &nb->markable);
+    iterate_node_values(ast, &nb->buffer_list, free_ast_value, NULL);
+    node_buffer_list_free(ast, &nb->buffer_list);
     struct rb_ast_local_table_link *local_table = nb->local_tables;
     while (local_table) {
         struct rb_ast_local_table_link *next_table = local_table->next;
@@ -288,6 +286,15 @@ ast_newnode_in_bucket(rb_ast_t *ast, node_buffer_list_t *nb, size_t size, size_t
     return ptr;
 }
 
+NODE *
+rb_ast_newnode(rb_ast_t *ast, enum node_type type, size_t size, size_t alignment)
+{
+    node_buffer_t *nb = ast->node_buffer;
+    node_buffer_list_t *bucket = &nb->buffer_list;
+    return ast_newnode_in_bucket(ast, bucket, size, alignment);
+}
+
+#if RUBY_DEBUG
 RBIMPL_ATTR_PURE()
 static bool
 nodetype_markable_p(enum node_type type)
@@ -295,16 +302,6 @@ nodetype_markable_p(enum node_type type)
     return false;
 }
 
-NODE *
-rb_ast_newnode(rb_ast_t *ast, enum node_type type, size_t size, size_t alignment)
-{
-    node_buffer_t *nb = ast->node_buffer;
-    node_buffer_list_t *bucket =
-        (nodetype_markable_p(type) ? &nb->markable : &nb->unmarkable);
-    return ast_newnode_in_bucket(ast, bucket, size, alignment);
-}
-
-#if RUBY_DEBUG
 void
 rb_ast_node_type_change(NODE *n, enum node_type type)
 {
@@ -421,8 +418,7 @@ rb_ast_memsize(const rb_ast_t *ast)
 
     if (nb) {
         size += sizeof(node_buffer_t);
-        size += buffer_list_size(&nb->unmarkable);
-        size += buffer_list_size(&nb->markable);
+        size += buffer_list_size(&nb->buffer_list);
     }
     return size;
 }

--- a/node.c
+++ b/node.c
@@ -294,25 +294,6 @@ rb_ast_newnode(rb_ast_t *ast, enum node_type type, size_t size, size_t alignment
     return ast_newnode_in_bucket(ast, bucket, size, alignment);
 }
 
-#if RUBY_DEBUG
-RBIMPL_ATTR_PURE()
-static bool
-nodetype_markable_p(enum node_type type)
-{
-    return false;
-}
-
-void
-rb_ast_node_type_change(NODE *n, enum node_type type)
-{
-    enum node_type old_type = nd_type(n);
-    if (nodetype_markable_p(old_type) != nodetype_markable_p(type)) {
-        rb_bug("node type changed: %s -> %s",
-               ruby_node_name(old_type), ruby_node_name(type));
-    }
-}
-#endif
-
 rb_ast_id_table_t *
 rb_ast_new_local_table(rb_ast_t *ast, int size)
 {
@@ -432,8 +413,5 @@ rb_ast_dispose(rb_ast_t *ast)
 VALUE
 rb_node_set_type(NODE *n, enum node_type t)
 {
-#if RUBY_DEBUG
-    rb_ast_node_type_change(n, t);
-#endif
     return nd_init_type(n, t);
 }

--- a/node.h
+++ b/node.h
@@ -53,9 +53,6 @@ rb_ast_t *rb_ast_new(void);
 #endif
 size_t rb_ast_memsize(const rb_ast_t*);
 void rb_ast_dispose(rb_ast_t*);
-#if RUBY_DEBUG
-void rb_ast_node_type_change(NODE *n, enum node_type type);
-#endif
 const char *ruby_node_name(int node);
 void rb_node_init(NODE *n, enum node_type type);
 

--- a/node.h
+++ b/node.h
@@ -31,8 +31,7 @@ typedef struct {
 } node_buffer_list_t;
 
 struct node_buffer_struct {
-    node_buffer_list_t unmarkable;
-    node_buffer_list_t markable;
+    node_buffer_list_t buffer_list;
     struct rb_ast_local_table_link *local_tables;
     // - id (sequence number)
     // - token_type


### PR DESCRIPTION
All types of Node are managed by `node_buffer_list_t unmarkable`
therefore merge them into `node_buffer_list_t buffer_list`.