### PR TITLE
Remove unused functions from `struct rb_parser_config_struct`

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -298,12 +298,6 @@ rbool(VALUE v)
 }
 
 static int
-undef_p(VALUE v)
-{
-    return RB_UNDEF_P(v);
-}
-
-static int
 rtest(VALUE obj)
 {
     return (int)RB_TEST(obj);
@@ -355,18 +349,6 @@ static int *
 rb_errno_ptr2(void)
 {
     return rb_errno_ptr();
-}
-
-static int
-fixnum_p(VALUE obj)
-{
-    return (int)RB_FIXNUM_P(obj);
-}
-
-static int
-symbol_p(VALUE obj)
-{
-    return (int)RB_SYMBOL_P(obj);
 }
 
 static void *
@@ -447,9 +429,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .compile_callback = rb_suppress_tracing,
     .reg_named_capture_assign = reg_named_capture_assign,
 
-    .fixnum_p = fixnum_p,
-    .symbol_p = symbol_p,
-
     .attr_get = rb_attr_get,
 
     .ary_new = rb_ary_new,
@@ -457,7 +436,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .ary_new_from_args = rb_ary_new_from_args,
     .ary_unshift = rb_ary_unshift,
     .ary_new2 = rb_ary_new2,
-    .ary_clear = rb_ary_clear,
     .ary_modify = rb_ary_modify,
     .array_len = rb_array_len,
     .array_aref = RARRAY_AREF,
@@ -586,7 +564,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .strtod = ruby_strtod,
 
     .rbool = rbool,
-    .undef_p = undef_p,
     .rtest = rtest,
     .nil_p = nil_p,
     .qnil = Qnil,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1248,9 +1248,6 @@ typedef struct rb_parser_config_struct {
     VALUE (*compile_callback)(VALUE (*func)(VALUE), VALUE arg);
     NODE *(*reg_named_capture_assign)(struct parser_params* p, VALUE regexp, const rb_code_location_t *loc);
 
-    int (*fixnum_p)(VALUE);
-    int (*symbol_p)(VALUE);
-
     /* Variable */
     VALUE (*attr_get)(VALUE obj, ID id);
 
@@ -1260,7 +1257,6 @@ typedef struct rb_parser_config_struct {
     VALUE (*ary_new_from_args)(long n, ...);
     VALUE (*ary_unshift)(VALUE ary, VALUE item);
     VALUE (*ary_new2)(long capa); // ary_new_capa
-    VALUE (*ary_clear)(VALUE ary);
     void (*ary_modify)(VALUE ary);
     long (*array_len)(VALUE a);
     VALUE (*array_aref)(VALUE, long);
@@ -1409,7 +1405,6 @@ typedef struct rb_parser_config_struct {
 
     /* Misc */
     VALUE (*rbool)(VALUE);
-    int (*undef_p)(VALUE);
     int (*rtest)(VALUE obj);
     int (*nil_p)(VALUE obj);
     VALUE qnil;

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -88,11 +88,6 @@
 #define compile_callback         p->config->compile_callback
 #define reg_named_capture_assign p->config->reg_named_capture_assign
 
-#undef FIXNUM_P
-#define FIXNUM_P p->config->fixnum_p
-#undef SYMBOL_P
-#define SYMBOL_P p->config->symbol_p
-
 #define rb_attr_get p->config->attr_get
 
 #define rb_ary_new           p->config->ary_new
@@ -102,7 +97,6 @@
 #define rb_ary_unshift       p->config->ary_unshift
 #undef rb_ary_new2
 #define rb_ary_new2          p->config->ary_new2
-#define rb_ary_clear         p->config->ary_clear
 #define rb_ary_modify        p->config->ary_modify
 #undef RARRAY_LEN
 #define RARRAY_LEN           p->config->array_len
@@ -245,8 +239,6 @@
 
 #undef RBOOL
 #define RBOOL p->config->rbool
-#undef UNDEF_P
-#define UNDEF_P p->config->undef_p
 #undef RTEST
 #define RTEST p->config->rtest
 #undef NIL_P


### PR DESCRIPTION
These functions have been not used since f057741c5dd6fdc25926c2f16fc6e936eeec5fd1 and 799e854897856e431c03a5122252358e2c57aff2