### PR TITLE
Fix ec assertion with using pthread

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1620,7 +1620,7 @@ ruby_thread_set_native(rb_thread_t *th)
 
     // setup TLS
 
-    if (th && th->ec) {
+    if (th && th->ec && th->ec != th->ractor->threads.running_ec) {
         rb_ractor_set_current_ec(th->ractor, th->ec);
     }
 #ifdef RB_THREAD_LOCAL_SPECIFIER


### PR DESCRIPTION
When RUBY_DEBUG is enabled, the following script causes an assertion failure:

    Fiber.new(&Object.method(:class_eval)).resume("foo")

The assertion failure is:

    Assertion Failed: ractor_core.h:328:rb_ractor_set_current_ec_:ec == ((void*)0) || cr->threads.running_ec != ec

    -- C level backtrace information -------------------------------------------
    miniruby(rb_vm_bugreport+0xb60) [0x100290f20] vm_dump.c:1151
    miniruby(rb_vm_bugreport) (null):0
    miniruby(rb_assert_failure_detail+0xa4) [0x1003b533c] error.c:1168
    miniruby(rb_assert_failure_detail+0x0) [0x1003b5298] error.c:1148
    miniruby(rb_assert_failure) (null):0
    miniruby(Init_native_thread.cold.1+0x0) [0x1003d3c24] ractor_core.h:328
    miniruby(rb_ractor_set_current_ec_) (null):0
    miniruby(ruby_thread_set_native.cold.1) thread_pthread.c:1624
    miniruby(Init_native_thread+0x0) [0x100222380] ractor_core.h:328
    miniruby(ruby_thread_set_native) (null):0
    miniruby(fiber_entry+0x1c) [0x10008a1c4] cont.c:845
    miniruby(coroutine_trampoline+0xa8) [0x1003a1d78] coroutine/pthread/Context.c:148
    /usr/lib/system/libsystem_pthread.dylib(_pthread_start+0x88) [0x1911fef94]