### PR TITLE
Fix nil error with KNOWNBUGS.rb

### DIFF
--- a/bootstraptest/runner.rb
+++ b/bootstraptest/runner.rb
@@ -6,7 +6,6 @@
 # Never use optparse in this file.
 # Never use test/unit in this file.
 # Never use Ruby extensions in this file.
-# Maintain Ruby 1.8 compatibility for now
 
 $start_time = Time.now
 
@@ -428,7 +427,7 @@ class Assertion < Struct.new(:src, :path, :lineno, :proc)
   def initialize(*args)
     super
     self.class.add self
-    @category = self.path.match(/test_(.+)\.rb/)[1]
+    @category = self.path.match(/test_(.+)\.rb/)&.[](1)
   end
 
   def call

--- a/bootstraptest/runner.rb
+++ b/bootstraptest/runner.rb
@@ -427,7 +427,7 @@ class Assertion < Struct.new(:src, :path, :lineno, :proc)
   def initialize(*args)
     super
     self.class.add self
-    @category = self.path.match(/test_(.+)\.rb/)&.[](1)
+    @category = self.path[/\Atest_(.+)\.rb\z/, 1]
   end
 
   def call


### PR DESCRIPTION
Previously, `make test-knownbugs` crashed with `NoMethodError` due to the failed regex match if there is a test case in it.

The note about 1.8 compatibility is probably bogus as we require a way more recent BASERUBY now.