### PR TITLE
Fix a variable name

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -8129,7 +8129,7 @@ escaped_control_code(int c)
 }
 
 #define WARN_SPACE_CHAR(c, prefix) \
-    rb_warn1("invalid character syntax; use "prefix"\\%c", WARN_I(c2))
+    rb_warn1("invalid character syntax; use "prefix"\\%c", WARN_I(c))
 
 static int
 tokadd_codepoint(struct parser_params *p, rb_encoding **encp,


### PR DESCRIPTION
The first argument of `WARN_SPACE_CHAR` is always `c2` in caller side, so `c` equals to `c2`.