### PR TITLE
Enumerator should use a non-blocking fiber.

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2382,7 +2382,7 @@ rb_fiber_initialize(int argc, VALUE* argv, VALUE self)
 VALUE
 rb_fiber_new_storage(rb_block_call_func_t func, VALUE obj, VALUE storage)
 {
-    return fiber_initialize(fiber_alloc(rb_cFiber), rb_proc_new(func, obj), rb_fiber_pool_default(Qnil), 1, storage);
+    return fiber_initialize(fiber_alloc(rb_cFiber), rb_proc_new(func, obj), rb_fiber_pool_default(Qnil), 0, storage);
 }
 
 VALUE

--- a/internal/parse.h
+++ b/internal/parse.h
@@ -68,6 +68,7 @@ rb_parser_string_t *rb_str_to_parser_string(rb_parser_t *p, VALUE str);
 void rb_parser_warn_duplicate_keys(struct parser_params *p, NODE *hash);
 int rb_parser_dvar_defined_ref(struct parser_params*, ID, ID**);
 ID rb_parser_internal_id(struct parser_params*);
+VALUE rb_parser_node_case_when_optimizable_literal(struct parser_params *p, const NODE *const node);
 int rb_parser_reg_fragment_check(struct parser_params*, rb_parser_string_t*, int);
 int rb_reg_named_capture_assign_iter_impl(struct parser_params *p, const char *s, long len, rb_encoding *enc, NODE **succ_block, const rb_code_location_t *loc);
 int rb_parser_local_defined(struct parser_params *p, ID id, const struct rb_iseq_struct *iseq);

--- a/test/fiber/test_enumerator.rb
+++ b/test/fiber/test_enumerator.rb
@@ -42,4 +42,12 @@ class TestFiberEnumerator < Test::Unit::TestCase
     assert_predicate(i, :closed?)
     assert_predicate(o, :closed?)
   end
+
+  def enumerator_fiber_is_nonblocking
+    enumerator = Enumerator.new do |yielder|
+      yielder << Fiber.current.blocking?
+    end
+
+    assert_equal(false, enumerator.next)
+  end
 end


### PR DESCRIPTION
Some usage of `Enumerator` can be problematic in the event loop, e.g. calling `sleep`.

See <https://github.com/ruby/ruby/pull/2002> for background context.

This PR allows the fiber scheduler to transfer on blocking operations within an Enumerator's block.