### PR TITLE
Prefer to use `Fiber#transfer` in scheduler implementation.

### DIFF
--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -27,7 +27,9 @@ class Scheduler
     Warning[:experimental] = experimental
   end
 
-  def initialize
+  def initialize(fiber = Fiber.current)
+    @fiber = fiber
+
     @readable = {}
     @writable = {}
     @waiting = {}
@@ -44,6 +46,10 @@ class Scheduler
   attr :readable
   attr :writable
   attr :waiting
+
+  def transfer
+    @fiber.transfer
+  end
 
   def next_timeout
     _fiber, timeout = @waiting.min_by{|key, value| value}
@@ -88,7 +94,7 @@ class Scheduler
       end
 
       selected.each do |fiber, events|
-        fiber.resume(events)
+        fiber.transfer(events)
       end
 
       if @waiting.any?
@@ -98,7 +104,7 @@ class Scheduler
         waiting.each do |fiber, timeout|
           if fiber.alive?
             if timeout <= time
-              fiber.resume
+              fiber.transfer
             else
               @waiting[fiber] = timeout
             end
@@ -114,7 +120,7 @@ class Scheduler
         end
 
         ready.each do |fiber|
-          fiber.resume
+          fiber.transfer
         end
       end
     end
@@ -217,7 +223,7 @@ class Scheduler
       @waiting[fiber] = current_time + duration
     end
 
-    Fiber.yield
+    @fiber.transfer
   ensure
     @waiting.delete(fiber) if duration
     @readable.delete(io) if readable
@@ -254,7 +260,7 @@ class Scheduler
     if timeout
       @waiting[fiber] = current_time + timeout
       begin
-        Fiber.yield
+        @fiber.transfer
       ensure
         # Remove from @waiting in the case #unblock was called before the timeout expired:
         @waiting.delete(fiber)
@@ -262,7 +268,7 @@ class Scheduler
     else
       @blocking[fiber] = true
       begin
-        Fiber.yield
+        @fiber.transfer
       ensure
         @blocking.delete(fiber)
       end
@@ -290,7 +296,7 @@ class Scheduler
   def fiber(&block)
     fiber = Fiber.new(blocking: false, &block)
 
-    fiber.resume
+    fiber.transfer
 
     return fiber
   end

--- a/test/fiber/test_mutex.rb
+++ b/test/fiber/test_mutex.rb
@@ -207,7 +207,7 @@ class TestFiberMutex < Test::Unit::TestCase
       Fiber.schedule do
         mutex.synchronize do
           puts 'in synchronize'
-          Fiber.yield
+          scheduler.transfer
         end
       end
 


### PR DESCRIPTION
See <https://github.com/ruby/ruby/pull/2002> for context.

Previous attempt <https://github.com/ruby/ruby/pull/3746>.