### PR TITLE
Enumerator should use a non-blocking fiber, change `rb_fiber_new` to be non-blocking by default.

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2382,7 +2382,7 @@ rb_fiber_initialize(int argc, VALUE* argv, VALUE self)
 VALUE
 rb_fiber_new_storage(rb_block_call_func_t func, VALUE obj, VALUE storage)
 {
-    return fiber_initialize(fiber_alloc(rb_cFiber), rb_proc_new(func, obj), rb_fiber_pool_default(Qnil), 1, storage);
+    return fiber_initialize(fiber_alloc(rb_cFiber), rb_proc_new(func, obj), rb_fiber_pool_default(Qnil), 0, storage);
 }
 
 VALUE

--- a/test/fiber/test_enumerator.rb
+++ b/test/fiber/test_enumerator.rb
@@ -42,4 +42,12 @@ class TestFiberEnumerator < Test::Unit::TestCase
     assert_predicate(i, :closed?)
     assert_predicate(o, :closed?)
   end
+
+  def enumerator_fiber_is_nonblocking
+    enumerator = Enumerator.new do |yielder|
+      yielder << Fiber.current.blocking?
+    end
+
+    assert_equal(false, enumerator.next)
+  end
 end


### PR DESCRIPTION
This re-applies <https://github.com/ruby/ruby/pull/10478> sans the `parse.h` change.