### PR TITLE
Fix error when default gem is loaded from `-r` option

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -108,7 +108,7 @@ module Gem::BUNDLED_GEMS
     _t, path = $:.resolve_feature_path(feature)
     if gem = find_gem(path)
       return if specs.include?(gem)
-      caller = caller_locations(3, 3).find {|c| c&.absolute_path}
+      caller = caller_locations(3, 3)&.find {|c| c&.absolute_path}
       return if find_gem(caller&.absolute_path)
     elsif SINCE[name] && !path
       gem = true


### PR DESCRIPTION
This patch fixes an error when a default gem that will be migrated to a bundled gem is loaded from `-r` option.

Problem
===

`bundle exec ruby -rostruct -e ''` unexpectedly raises the following error:

```console
$ ruby -v
ruby 3.4.0dev (2024-04-08T02:39:00Z master 6f7e8e278f) [arm64-darwin21]
$ bundle init && bundle install
$ bundle exec ruby -rostruct -e ''
/Users/kuwabara.masataka/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:111:in 'Gem::BUNDLED_GEMS.warning?': undefined method 'find' for nil (NoMethodError)

      caller = caller_locations(3, 3).find {|c| c&.absolute_path}
                                     ^^^^^
        from /Users/kuwabara.masataka/.rbenv/versions/trunk/lib/ruby/3.4.0+0/bundled_gems.rb:75:in 'block (2 levels) in Kernel#replace_require'
```

Solution
===

This patch uses a safe navigation operator to fix this problem. By this change, the command will show the warning message correctly.

```console
$ bundle exec ruby -rostruct -e ''
warning: ostruct was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add ostruct to your Gemfile or gemspec.
```