### PR TITLE
Launchable: Correctly configure the missing "os" flavor in ubuntu.yaml

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Launchable
         uses: ./.github/actions/launchable/setup
         with:
-          os: ${{ matrix.os }}
+          os: ${{ matrix.os || 'ubuntu-22.04' }}
           test-opts: ${{ matrix.configure }}
           launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
           builddir: build


### PR DESCRIPTION
When seeing https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-sessions/2755303, I noticed that the "os" flavor has not been configured correctly in ubuntu.yaml. This PR addresses it.