### PR TITLE
Use ruby_thread_set_pthread_native at boot

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -841,7 +841,7 @@ fiber_entry(struct coroutine_context * from, struct coroutine_context * to)
     rb_thread_t *thread = fiber->cont.saved_ec.thread_ptr;
 
 #ifdef COROUTINE_PTHREAD_CONTEXT
-    ruby_thread_set_native(thread);
+    ruby_thread_set_pthread_native(thread);
 #endif
 
     fiber_restore_thread(thread, fiber);

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -165,4 +165,6 @@ native_tls_set(native_tls_key_t key, void *ptr)
 RUBY_EXTERN native_tls_key_t ruby_current_ec_key;
 #endif
 
+bool ruby_thread_set_pthread_native(struct rb_thread_struct *th);
+
 #endif /* RUBY_THREAD_PTHREAD_H */


### PR DESCRIPTION
At boot, `th->ractor->threads.running_ec == th->ec` is true, so calling ruby_thread_set_native will cause an assertion error.

```
Assertion Failed: ractor_core.h:328:rb_ractor_set_current_ec_:ec == ((void*)0) || cr->threads.running_ec != ec

-- C level backtrace information -------------------------------------------
miniruby(rb_vm_bugreport+0xb60) [0x100290f20] vm_dump.c:1151
miniruby(rb_vm_bugreport) (null):0
miniruby(rb_assert_failure_detail+0xa4) [0x1003b533c] error.c:1168
miniruby(rb_assert_failure_detail+0x0) [0x1003b5298] error.c:1148
miniruby(rb_assert_failure) (null):0
miniruby(Init_native_thread.cold.1+0x0) [0x1003d3c24] ractor_core.h:328
miniruby(rb_ractor_set_current_ec_) (null):0
miniruby(ruby_thread_set_native.cold.1) thread_pthread.c:1624
miniruby(Init_native_thread+0x0) [0x100222380] ractor_core.h:328
miniruby(ruby_thread_set_native) (null):0
miniruby(fiber_entry+0x1c) [0x10008a1c4] cont.c:845
miniruby(coroutine_trampoline+0xa8) [0x1003a1d78] coroutine/pthread/Context.c:148
/usr/lib/system/libsystem_pthread.dylib(_pthread_start+0x88) [0x1911fef94]
```