### PR TITLE
put empty `rb_gc_force_recycle()`

### DIFF
--- a/include/ruby/internal/gc.h
+++ b/include/ruby/internal/gc.h
@@ -823,4 +823,7 @@ rb_obj_write(
     return a;
 }
 
+RBIMPL_ATTR_DEPRECATED(("Will be removed soon"))
+static inline void rb_gc_force_recycle(VALUE obj){}
+
 #endif /* RBIMPL_GC_H */


### PR DESCRIPTION
and declare it will be removed soon.

ddtrace is still referes the API and build was failed. See https://github.com/DataDog/dd-trace-rb/pull/3578

Maybe threre are only few users of this C-API now so we can remove it soon.