### PR TITLE
compile.c: use rb_enc_interned_str to reduce allocations

### DIFF
--- a/internal/ruby_parser.h
+++ b/internal/ruby_parser.h
@@ -19,6 +19,7 @@ VALUE rb_parser_set_context(VALUE, const struct rb_iseq_struct *, int);
 VALUE rb_parser_new(void);
 rb_ast_t *rb_parser_compile_string_path(VALUE vparser, VALUE fname, VALUE src, int line);
 VALUE rb_str_new_parser_string(rb_parser_string_t *str);
+VALUE rb_str_new_mutable_parser_string(rb_parser_string_t *str);
 
 VALUE rb_node_str_string_val(const NODE *);
 VALUE rb_node_sym_string_val(const NODE *);

--- a/parse.y
+++ b/parse.y
@@ -7959,7 +7959,7 @@ nextline(struct parser_params *p, int set_encoding)
         }
 #ifndef RIPPER
         if (p->debug_lines) {
-            VALUE v = rb_str_new_parser_string(str);
+            VALUE v = rb_str_new_mutable_parser_string(str);
             if (set_encoding) rb_enc_associate(v, p->enc);
             rb_ary_push(p->debug_lines, v);
         }

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -742,6 +742,14 @@ rb_parser_set_yydebug(VALUE vparser, VALUE flag)
 VALUE
 rb_str_new_parser_string(rb_parser_string_t *str)
 {
+    VALUE string = rb_enc_interned_str(str->ptr, str->len, str->enc);
+    rb_enc_str_coderange(string);
+    return string;
+}
+
+VALUE
+rb_str_new_mutable_parser_string(rb_parser_string_t *str)
+{
     return rb_enc_str_new(str->ptr, str->len, str->enc);
 }
 

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -1006,7 +1006,7 @@ class TestShapes < Test::Unit::TestCase
   end
 
   def test_freezing_and_cloning_string
-    str = "str".freeze
+    str = ("str" + "str").freeze
     str2 = str.clone(freeze: true)
     assert_predicate(str2, :frozen?)
     assert_shape_equal(RubyVM::Shape.of(str), RubyVM::Shape.of(str2))


### PR DESCRIPTION
The `rb_fstring(rb_enc_str_new())` pattern is inneficient because:

- It passes a mutable string to `rb_fstring` so if it has to be interned it will first be duped.
- It an equivalent interned string already exists, we allocated the string for nothing.

With `rb_enc_interned_str` we either directly get the pre-existing string with 0 allocations, or efficiently directly intern the one we create without first duping it.