### PR TITLE
Lock turbo_tests to 2.1.0 provisionally

### DIFF
--- a/tool/bundler/dev_gems.rb
+++ b/tool/bundler/dev_gems.rb
@@ -7,7 +7,7 @@ gem "rake", "~> 13.1"
 gem "rb_sys"
 
 gem "webrick", "~> 1.6"
-gem "turbo_tests", "~> 2.1"
+gem "turbo_tests", "= 2.1.0"
 gem "parallel_tests", "< 3.9.0"
 gem "parallel", "~> 1.19"
 gem "rspec-core", "~> 3.12"


### PR DESCRIPTION
turbo_tests 2.1.1 adds json to its dependency and the current bundler does not take the standard library json and fails to build as a gem before the installation.