### PR TITLE
YJIT: x64: Remove register shuffle with `opt_and` and friends

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3827,7 +3827,7 @@ fn gen_opt_and(
 
         // Push the output on the stack
         let dst = asm.stack_push(Type::Fixnum);
-        asm.store(dst, val);
+        asm.mov(dst, val);
 
         Some(KeepCompiling)
     } else {
@@ -3867,7 +3867,7 @@ fn gen_opt_or(
 
         // Push the output on the stack
         let dst = asm.stack_push(Type::Fixnum);
-        asm.store(dst, val);
+        asm.mov(dst, val);
 
         Some(KeepCompiling)
     } else {
@@ -3909,7 +3909,7 @@ fn gen_opt_minus(
 
         // Push the output on the stack
         let dst = asm.stack_push(Type::Fixnum);
-        asm.store(dst, val);
+        asm.mov(dst, val);
 
         Some(KeepCompiling)
     } else {


### PR DESCRIPTION
This is best understood by looking at the change to the output:

```diff
  # Insn: 0002 opt_and (stack_size: 2)
  - mov rax, rsi
  - and rax, rdi
  - mov rsi, rax
  + and rsi, rdi
```

It's a bit awkward to match against due to how stack operands are
lowered, but hey, it's nice to save the 2 unnecessary MOVs.
