### PR TITLE
Don't mark empty singleton cc's

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -292,6 +292,10 @@ static bool
 cc_is_active(const struct rb_callcache *cc, bool reference_updating)
 {
     if (cc) {
+        if (cc == rb_vm_empty_cc() || rb_vm_empty_cc_for_super()) {
+            return false;
+        }
+
         if (reference_updating) {
             cc = (const struct rb_callcache *)rb_gc_location((VALUE)cc);
         }


### PR DESCRIPTION
These cc's aren't managed by the garbage collector so we shouldn't try to mark and move them.