### PR TITLE
[pty] Fix `ptsname_r` fallback

### DIFF
--- a/ext/pty/extconf.rb
+++ b/ext/pty/extconf.rb
@@ -13,11 +13,13 @@ if /mswin|mingw|bccwin/ !~ RUBY_PLATFORM
     have_header("util.h") # OpenBSD openpty
     util = have_library("util", "openpty")
   end
-  if have_func("posix_openpt") or
+  openpt = have_func("posix_openpt")
+  if openpt
+    have_func("ptsname_r") or have_func("ptsname")
+  end
+  if openpt
       (util or have_func("openpty")) or
       have_func("_getpty") or
-      have_func("ptsname_r") or
-      have_func("ptsname") or
       have_func("ioctl")
     create_makefile('pty')
   end

--- a/ext/pty/pty.c
+++ b/ext/pty/pty.c
@@ -256,7 +256,7 @@ establishShell(int argc, VALUE *argv, struct pty_info *info,
     RB_GC_GUARD(carg.execarg_obj);
 }
 
-#if defined(HAVE_PTSNAME) && !defined(HAVE_PTSNAME_R)
+#if (defined(HAVE_POSIX_OPENPT) || defined(HAVE_PTSNAME)) && !defined(HAVE_PTSNAME_R)
 /* glibc only, not obsolete interface on Tru64 or HP-UX */
 static int
 ptsname_r(int fd, char *buf, size_t buflen)


### PR DESCRIPTION
If `posix_openpt` is available, also `ptsname` should be available.