### PR TITLE
Emit `warn` event for duplicated hash keys on ripper

### DIFF
--- a/internal/parse.h
+++ b/internal/parse.h
@@ -65,7 +65,6 @@ int rb_ruby_parser_end_seen_p(rb_parser_t *p);
 int rb_ruby_parser_set_yydebug(rb_parser_t *p, int flag);
 rb_parser_string_t *rb_str_to_parser_string(rb_parser_t *p, VALUE str);
 
-void rb_parser_warn_duplicate_keys(struct parser_params *p, NODE *hash);
 int rb_parser_dvar_defined_ref(struct parser_params*, ID, ID**);
 ID rb_parser_internal_id(struct parser_params*);
 int rb_parser_reg_fragment_check(struct parser_params*, rb_parser_string_t*, int);

--- a/test/ripper/test_parser_events.rb
+++ b/test/ripper/test_parser_events.rb
@@ -1686,6 +1686,12 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
     assert_equal([3], args)
   end
 
+  def test_warn_duplicated_hash_keys
+    fmt, *args = warn("{ a: 1, a: 2 }")
+    assert_match(/is duplicated and overwritten on line/, fmt)
+    assert_equal([:a, 1], args)
+  end
+
   def test_warn_cr_in_middle
     fmt = nil
     assert_warn("") {fmt, = warn("\r;")}


### PR DESCRIPTION
Need to use `rb_warn` macro instead of calling `rb_compile_warn` directly to emit `warn` event on ripper.