### PR TITLE
fix incorrect warning.

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -9372,6 +9372,8 @@ compile_super(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
 
     INIT_ANCHOR(args);
     ISEQ_COMPILE_DATA(iseq)->current_block = NULL;
+    ISEQ_BODY(ISEQ_BODY(iseq)->local_iseq)->param.flags.use_block = 1;
+
     if (type == NODE_SUPER) {
         VALUE vargc = setup_args(iseq, args, RNODE_SUPER(node)->nd_args, &flag, &keywords);
         CHECK(!NIL_P(vargc));
@@ -9382,8 +9384,6 @@ compile_super(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, i
     }
     else {
         /* NODE_ZSUPER */
-        ISEQ_BODY(ISEQ_BODY(iseq)->local_iseq)->param.flags.use_block = 1;
-
         int i;
         const rb_iseq_t *liseq = body->local_iseq;
         const struct rb_iseq_constant_body *const local_body = ISEQ_BODY(liseq);

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -1666,20 +1666,25 @@ class TestMethod < Test::Unit::TestCase
         def foo = nil
         def bar = nil
         def baz = nil
+        def qux = nil
       end
 
       class C1 < C0
         def foo = super
         def bar = super()
         def baz(&_) = super(&_)
+        def qux = super(&nil)
       end
 
       C1.new.foo{} # no warning
-      C1.new.bar{} # warning
+      C1.new.bar{} # no warning
       C1.new.baz{} # no warning
+      # C1.new.qux{} # TODO: warning line:16 but not supported yet.
     RUBY
-      assert_equal 1, err.size
-      assert_match(/-:14: warning.+bar/, err.join)
+      assert_equal 0, err.size
+      # TODO
+      # assert_equal 1, err.size
+      # assert_match(/-:16: warning.+qux/, err.join)
     end
   end
 end


### PR DESCRIPTION
`super()` (not zsuper) passes the passed block and it can be used.

```ruby
class C0
  def foo; yield; end
end

class C1 < C0
  def foo; super(); end
end

C1.new.foo{p :block} #=> :block
```