### PR TITLE
Add more assertions in `test_uplus_minus`

### DIFF
--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -3356,7 +3356,11 @@ CODE
     assert_same(str, +str)
     assert_not_same(str, -str)
 
+    require 'objspace'
+
     str = "bar".freeze
+    assert_includes ObjectSpace.dump(str), '"fstring":true'
+
     assert_predicate(str, :frozen?)
     assert_not_predicate(+str, :frozen?)
     assert_predicate(-str, :frozen?)
@@ -3364,8 +3368,8 @@ CODE
     assert_not_same(str, +str)
     assert_same(str, -str)
 
-    bar = %w(b a r).join('')
-    assert_same(str, -bar, "uminus deduplicates [Feature #13077]")
+    bar = -%w(b a r).join('')
+    assert_same(str, bar, "uminus deduplicates [Feature #13077] #{ObjectSpace.dump(bar)}")
   end
 
   def test_uminus_frozen


### PR DESCRIPTION
Not along after 1b830740ba8371c4bcfdfc6eb2cb7e0ae81a84e0 CI started to rarely fail this test:

```
TestString#test_uplus_minus: Test::Unit::AssertionFailedError: uminus deduplicates [Feature #13077].
  1) Failure:
TestString#test_uplus_minus [/tmp/ruby/src/trunk/test/ruby/test_string.rb:3368]:
```

It's unclear what is going on, but one possibility is that `"bar".freeze` might no longer compile correctly.

Another possibility is that another test redefine `String#freeze`, causing `opt_str_freeze` to no longer return an `fstring`.