### PR TITLE
Specify Kernel#autoload? uses current namespace

### DIFF
--- a/load.c
+++ b/load.c
@@ -1532,7 +1532,7 @@ rb_f_autoload(VALUE obj, VALUE sym, VALUE file)
  *     autoload?(name, inherit=true)   -> String or nil
  *
  *  Returns _filename_ to be loaded if _name_ is registered as
- *  +autoload+ in the current namespae or one of its ancestors.
+ *  +autoload+ in the current namespace or one of its ancestors.
  *
  *     autoload(:B, "b")
  *     autoload?(:B)            #=> "b"

--- a/load.c
+++ b/load.c
@@ -1532,10 +1532,22 @@ rb_f_autoload(VALUE obj, VALUE sym, VALUE file)
  *     autoload?(name, inherit=true)   -> String or nil
  *
  *  Returns _filename_ to be loaded if _name_ is registered as
- *  +autoload+.
+ *  +autoload+ in the current namespae or one of its ancestors.
  *
  *     autoload(:B, "b")
  *     autoload?(:B)            #=> "b"
+ *
+ *     module C
+ *       autoload(:D, "d")
+ *       autoload?(:D)          #=> "d"
+ *       autoload?(:B)          #=> nil
+ *     end
+ *
+ *     class E
+ *       autoload(:F, "f")
+ *       autoload?(:F)          #=> "f"
+ *       autoload?(:B)          #=> "b"
+ *     end
  */
 
 static VALUE


### PR DESCRIPTION
Related to https://bugs.ruby-lang.org/issues/20411

Because `Kernel#autoload?` uses the current namespace, it can lead to potentially confusing results. We should make it clearer that modules count as separate namespaces to lookup in.

cc @jeremyevans 