### PR TITLE
Include more debug information in test_uplus_minus

### DIFF
--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -3369,7 +3369,7 @@ CODE
     assert_same(str, -str)
 
     bar = -%w(b a r).join('')
-    assert_same(str, bar, "uminus deduplicates [Feature #13077] #{ObjectSpace.dump(bar)}")
+    assert_same(str, bar, "uminus deduplicates [Feature #13077] str: #{ObjectSpace.dump(str)} bar: #{ObjectSpace.dump(bar)}")
   end
 
   def test_uminus_frozen


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/10529

It failed again with:

```
TestString#test_uplus_minus: Test::Unit::AssertionFailedError: uminus deduplicates [Feature #13077] {"address":"0x7ff89bd140e8", "type":"STRING", "shape_id":1, "slot_size":40, "class":"0x7ff89cdeec60", "frozen":true, "embedded":true, "fstring":true, "bytesize":3, "value":"bar", "encoding":"UTF-8", "coderange":"7bit", "memsize":40, "flags":{"wb_protected":true}}
  1) Failure:
TestString#test_uplus_minus [/tmp/ruby/src/trunk/test/ruby/test_string.rb:3372]:
uminus deduplicates [Feature #13077] {"address":"0x7fe2c6106160", "type":"STRING", "shape_id":1, "slot_size":40, "class":"0x7fe2c761ec50", "frozen":true, "embedded":true, "fstring":true, "bytesize":3, "value":"bar", "encoding":"UTF-8", "coderange":"7bit", "memsize":40, "flags":{"wb_protected":true}}
```

Which suggest both `bar` and `str` are `fstring`, have same content, but are two distinct objects, which is weird.