### PR TITLE
Refactor run_finalizer to not directly push tags to the EC

### DIFF
--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -176,6 +176,19 @@ End
     end;
   end
 
+  def test_exception_in_warning_in_finalizer
+    assert_in_out_err([], "#{<<~"begin;"}\n#{<<~'end;'}", %w(ok), [])
+    begin;
+      module Warning
+        def warn(str) = raise
+      end
+
+      obj = Object.new
+      ObjectSpace.define_finalizer(obj) { raise }
+      ObjectSpace.define_finalizer(obj) { puts "ok" }
+    end;
+  end
+
   def test_finalizer_thread_raise
     GC.disable
     fzer = proc do |id|


### PR DESCRIPTION
This commit refactors run_finalizer to use rb_protect rather than directly pushing and popping tags to the EC.