### PR TITLE
RB_OBJ_FREEZE_RAW: Set the object shape

### DIFF
--- a/class.c
+++ b/class.c
@@ -2273,7 +2273,7 @@ rb_freeze_singleton_class(VALUE x)
         VALUE klass = RBASIC_CLASS(x);
         if (klass && // no class when hidden from ObjectSpace
             FL_TEST(klass, (FL_SINGLETON|FL_FREEZE)) == FL_SINGLETON) {
-            OBJ_FREEZE_RAW(klass);
+            OBJ_FREEZE(klass);
         }
     }
 }

--- a/compile.c
+++ b/compile.c
@@ -10009,7 +10009,7 @@ compile_shareable_literal_constant(rb_iseq_t *iseq, LINK_ANCHOR *ret, enum rb_pa
 
       case NODE_ZLIST:{
         VALUE lit = rb_ary_new();
-        OBJ_FREEZE_RAW(lit);
+        OBJ_FREEZE(lit);
         ADD_INSN1(ret, node, putobject, lit);
         RB_OBJ_WRITTEN(iseq, Qundef, lit);
         *value_p = lit;

--- a/complex.c
+++ b/complex.c
@@ -397,7 +397,7 @@ nucomp_s_new_internal(VALUE klass, VALUE real, VALUE imag)
 
     RCOMPLEX_SET_REAL(obj, real);
     RCOMPLEX_SET_IMAG(obj, imag);
-    OBJ_FREEZE_RAW((VALUE)obj);
+    OBJ_FREEZE((VALUE)obj);
 
     return (VALUE)obj;
 }
@@ -1717,7 +1717,7 @@ nucomp_loader(VALUE self, VALUE a)
 
     RCOMPLEX_SET_REAL(dat, rb_ivar_get(a, id_i_real));
     RCOMPLEX_SET_IMAG(dat, rb_ivar_get(a, id_i_imag));
-    OBJ_FREEZE_RAW(self);
+    OBJ_FREEZE(self);
 
     return self;
 }

--- a/include/ruby/internal/fl_type.h
+++ b/include/ruby/internal/fl_type.h
@@ -905,6 +905,10 @@ RB_OBJ_FROZEN(VALUE obj)
     }
 }
 
+RUBY_SYMBOL_EXPORT_BEGIN
+void rb_obj_freeze_inline(VALUE obj);
+RUBY_SYMBOL_EXPORT_END
+
 RBIMPL_ATTR_ARTIFICIAL()
 /**
  * This is an  implementation detail of RB_OBJ_FREEZE().  3rd  parties need not
@@ -915,14 +919,7 @@ RBIMPL_ATTR_ARTIFICIAL()
 static inline void
 RB_OBJ_FREEZE_RAW(VALUE obj)
 {
-    RB_FL_SET_RAW(obj, RUBY_FL_FREEZE);
-    if (TYPE(obj) == T_STRING) {
-        RB_FL_UNSET_RAW(obj, FL_USER3); // STR_CHILLED
-    }
+    rb_obj_freeze_inline(obj);
 }
-
-RUBY_SYMBOL_EXPORT_BEGIN
-void rb_obj_freeze_inline(VALUE obj);
-RUBY_SYMBOL_EXPORT_END
 
 #endif /* RBIMPL_FL_TYPE_H */

--- a/rational.c
+++ b/rational.c
@@ -418,7 +418,7 @@ nurat_s_new_internal(VALUE klass, VALUE num, VALUE den)
 
     RATIONAL_SET_NUM((VALUE)obj, num);
     RATIONAL_SET_DEN((VALUE)obj, den);
-    OBJ_FREEZE_RAW((VALUE)obj);
+    OBJ_FREEZE((VALUE)obj);
 
     return (VALUE)obj;
 }
@@ -1847,7 +1847,7 @@ nurat_loader(VALUE self, VALUE a)
     nurat_canonicalize(&num, &den);
     RATIONAL_SET_NUM((VALUE)dat, num);
     RATIONAL_SET_DEN((VALUE)dat, den);
-    OBJ_FREEZE_RAW(self);
+    OBJ_FREEZE(self);
 
     return self;
 }

--- a/ruby.c
+++ b/ruby.c
@@ -706,11 +706,11 @@ ruby_init_loadpath(void)
             p -= bindir_len;
             archlibdir = rb_str_subseq(sopath, 0, p - libpath);
             rb_str_cat_cstr(archlibdir, libdir);
-            OBJ_FREEZE_RAW(archlibdir);
+            OBJ_FREEZE(archlibdir);
         }
         else if (p - libpath >= libdir_len && !strncmp(p - libdir_len, libdir, libdir_len)) {
             archlibdir = rb_str_subseq(sopath, 0, (p2 ? p2 : p) - libpath);
-            OBJ_FREEZE_RAW(archlibdir);
+            OBJ_FREEZE(archlibdir);
             p -= libdir_len;
         }
 #ifdef ENABLE_MULTIARCH
@@ -741,7 +741,7 @@ ruby_init_loadpath(void)
 #endif
     rb_gc_register_address(&ruby_prefix_path);
     ruby_prefix_path = PREFIX_PATH();
-    OBJ_FREEZE_RAW(ruby_prefix_path);
+    OBJ_FREEZE(ruby_prefix_path);
     if (!archlibdir) archlibdir = ruby_prefix_path;
     rb_gc_register_address(&ruby_archlibdir_path);
     ruby_archlibdir_path = archlibdir;

--- a/string.c
+++ b/string.c
@@ -379,7 +379,7 @@ fstr_update_callback(st_data_t *key, st_data_t *value, st_data_t data, int exist
                                      RSTRING(str)->len,
                                      ENCODING_GET(str));
             }
-            OBJ_FREEZE_RAW(str);
+            OBJ_FREEZE(str);
         }
         else {
             if (!OBJ_FROZEN(str) || CHILLED_STRING_P(str)) {
@@ -415,7 +415,7 @@ rb_fstring(VALUE str)
     bare = BARE_STRING_P(str);
     if (!bare) {
         if (STR_EMBED_P(str)) {
-            OBJ_FREEZE_RAW(str);
+            OBJ_FREEZE(str);
             return str;
         }
 
@@ -432,7 +432,7 @@ rb_fstring(VALUE str)
 
     if (!bare) {
         str_replace_shared_without_enc(str, fstr);
-        OBJ_FREEZE_RAW(str);
+        OBJ_FREEZE(str);
         return str;
     }
     return fstr;

--- a/struct.c
+++ b/struct.c
@@ -136,7 +136,7 @@ struct_set_members(VALUE klass, VALUE /* frozen hidden array */ members)
                 j = struct_member_pos_probe(j, mask);
             }
         }
-        OBJ_FREEZE_RAW(back);
+        OBJ_FREEZE(back);
     }
     rb_ivar_set(klass, id_members, members);
     rb_ivar_set(klass, id_back_members, back);
@@ -422,7 +422,7 @@ struct_make_members_list(va_list ar)
     }
     ary = rb_hash_keys(list);
     RBASIC_CLEAR_CLASS(ary);
-    OBJ_FREEZE_RAW(ary);
+    OBJ_FREEZE(ary);
     return ary;
 }
 
@@ -682,7 +682,7 @@ rb_struct_s_def(int argc, VALUE *argv, VALUE klass)
     }
     rest = rb_hash_keys(rest);
     RBASIC_CLEAR_CLASS(rest);
-    OBJ_FREEZE_RAW(rest);
+    OBJ_FREEZE(rest);
     if (NIL_P(name)) {
         st = anonymous_struct(klass);
     }
@@ -794,7 +794,7 @@ VALUE
 rb_struct_initialize(VALUE self, VALUE values)
 {
     rb_struct_initialize_m(RARRAY_LENINT(values), RARRAY_CONST_PTR(values), self);
-    if (rb_obj_is_kind_of(self, rb_cData)) OBJ_FREEZE_RAW(self);
+    if (rb_obj_is_kind_of(self, rb_cData)) OBJ_FREEZE(self);
     RB_GC_GUARD(values);
     return Qnil;
 }
@@ -1685,7 +1685,7 @@ rb_data_s_def(int argc, VALUE *argv, VALUE klass)
     }
     rest = rb_hash_keys(rest);
     RBASIC_CLEAR_CLASS(rest);
-    OBJ_FREEZE_RAW(rest);
+    OBJ_FREEZE(rest);
     data_class = anonymous_struct(klass);
     setup_data(data_class, rest);
     if (rb_block_given_p()) {
@@ -1802,7 +1802,7 @@ rb_data_initialize_m(int argc, const VALUE *argv, VALUE self)
     rb_hash_foreach(argv[0], struct_hash_set_i, (VALUE)&arg);
     // Freeze early before potentially raising, so that we don't leave an
     // unfrozen copy on the heap, which could get exposed via ObjectSpace.
-    OBJ_FREEZE_RAW(self);
+    OBJ_FREEZE(self);
     if (arg.unknown_keywords != Qnil) {
         rb_exc_raise(rb_keyword_error_new("unknown", arg.unknown_keywords));
     }
@@ -1814,7 +1814,7 @@ static VALUE
 rb_data_init_copy(VALUE copy, VALUE s)
 {
     copy = rb_struct_init_copy(copy, s);
-    RB_OBJ_FREEZE_RAW(copy);
+    RB_OBJ_FREEZE(copy);
     return copy;
 }
 

--- a/thread.c
+++ b/thread.c
@@ -2281,7 +2281,7 @@ rb_thread_s_handle_interrupt(VALUE self, VALUE mask_arg)
         mask = mask_arg;
     }
     else if (RB_TYPE_P(mask, T_HASH)) {
-        OBJ_FREEZE_RAW(mask);
+        OBJ_FREEZE(mask);
     }
 
     rb_ary_push(th->pending_interrupt_mask_stack, mask);
@@ -5846,7 +5846,7 @@ rb_uninterruptible(VALUE (*b_proc)(VALUE), VALUE data)
     rb_thread_t *cur_th = GET_THREAD();
 
     rb_hash_aset(interrupt_mask, rb_cObject, sym_never);
-    OBJ_FREEZE_RAW(interrupt_mask);
+    OBJ_FREEZE(interrupt_mask);
     rb_ary_push(cur_th->pending_interrupt_mask_stack, interrupt_mask);
 
     VALUE ret = rb_ensure(b_proc, data, uninterruptible_exit, Qnil);

--- a/variable.c
+++ b/variable.c
@@ -1815,7 +1815,10 @@ rb_shape_set_shape_id(VALUE obj, shape_id_t shape_id)
 void rb_obj_freeze_inline(VALUE x)
 {
     if (RB_FL_ABLE(x)) {
-        RB_OBJ_FREEZE_RAW(x);
+        RB_FL_SET_RAW(x, RUBY_FL_FREEZE);
+        if (TYPE(x) == T_STRING) {
+            RB_FL_UNSET_RAW(x, FL_USER3); // STR_CHILLED
+        }
 
         rb_shape_t * next_shape = rb_shape_transition_shape_frozen(x);
 

--- a/vm_args.c
+++ b/vm_args.c
@@ -1021,7 +1021,7 @@ vm_caller_setup_arg_block(const rb_execution_context_t *ec, rb_control_frame_t *
                     VALUE callback_arg = rb_ary_hidden_new(2);
                     rb_ary_push(callback_arg, block_code);
                     rb_ary_push(callback_arg, ref);
-                    OBJ_FREEZE_RAW(callback_arg);
+                    OBJ_FREEZE(callback_arg);
                     func = rb_func_lambda_new(refine_sym_proc_call, callback_arg, 1, UNLIMITED_ARGUMENTS);
                     rb_hash_aset(ref, block_code, func);
                 }


### PR DESCRIPTION
`_RAW` variants are supposed to skip checking if the object is an `RBasic` or immediate.

But that's not what it's doing here, it only set the frozen flag, but skip changing the shape. I have to proof of this causing a bug, but I don't think it's a good idea to have two distinct functions for this.

This change is related to the investigation on the currently flaky test:

```
uminus deduplicates [Feature #13077]
str: {"address":"0x7fa4c81055a8", "type":"STRING", "shape_id":0, "slot_size":40, "class":"0x7fa4c94eec40", "frozen":true, "embedded":true, "fstring":true, "bytesize":3, "value":"bar", "encoding":"UTF-8", "coderange":"7bit", "memsize":40, "flags":{"wb_protected":true, "old":true, "uncollectible":true, "marked":true}}
bar: {"address":"0x7fa4c82c8b88", "type":"STRING", "shape_id":1, "slot_size":40, "class":"0x7fa4c94eec40", "frozen":true, "embedded":true, "fstring":true, "bytesize":3, "value":"bar", "encoding":"UTF-8", "coderange":"7bit", "memsize":40, "flags":{"wb_protected":true}}
```

One of the two `fstring` still has the default shape even though it's frozen. I can't say this will fix the test, but it doesn't hurt to eliminate this possibility.
