### PR TITLE
Update turbo_tests to 2.2.3 or higher

### DIFF
--- a/tool/bundler/dev_gems.rb
+++ b/tool/bundler/dev_gems.rb
@@ -7,7 +7,7 @@ gem "rake", "~> 13.1"
 gem "rb_sys"
 
 gem "webrick", "~> 1.6"
-gem "turbo_tests", "= 2.1.0"
+gem "turbo_tests", "~> 2.2.3"
 gem "parallel_tests", "< 3.9.0"
 gem "parallel", "~> 1.19"
 gem "rspec-core", "~> 3.12"


### PR DESCRIPTION
`commands/pristine_spec.rb` is passed successfully with the turbo_tests 2.2.3 because it removed the `json` dependency.

Related to https://github.com/ruby/ruby/pull/10496
