### PR TITLE
Don't check for dynamic symbol in gc_is_moveable_obj

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -9473,7 +9473,7 @@ gc_is_moveable_obj(rb_objspace_t *objspace, VALUE obj)
       case T_ZOMBIE:
         return FALSE;
       case T_SYMBOL:
-        if (DYNAMIC_SYM_P(obj) && (RSYMBOL(obj)->id & ~ID_SCOPE_MASK)) {
+        if (RSYMBOL(obj)->id & ~ID_SCOPE_MASK) {
             return FALSE;
         }
         /* fall through */


### PR DESCRIPTION
All GC managed symbols are dynamic symbols so we don't need to check it.