### PR TITLE
Don't allow T_NIL in gc_is_moveable_obj

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -9468,7 +9468,6 @@ gc_is_moveable_obj(rb_objspace_t *objspace, VALUE obj)
 
     switch (BUILTIN_TYPE(obj)) {
       case T_NONE:
-      case T_NIL:
       case T_MOVED:
       case T_ZOMBIE:
         return FALSE;


### PR DESCRIPTION
gc_is_moveable_obj is only given GC managed objects, and T_NIL cannot be a GC managed type.