### PR TITLE
Allow symbols used for scopes to move

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -9519,10 +9519,6 @@ gc_is_moveable_obj(rb_objspace_t *objspace, VALUE obj)
       case T_ZOMBIE:
         return FALSE;
       case T_SYMBOL:
-        if (RSYMBOL(obj)->id & ~ID_SCOPE_MASK) {
-            return FALSE;
-        }
-        /* fall through */
       case T_STRING:
       case T_OBJECT:
       case T_FLOAT:


### PR DESCRIPTION
This commit allows symbols used for instance variables, global variables, constants, class names to be moved by GC compaction.

For example:

```ruby
require "objspace"

Object.const_set("Hello".to_sym, 1)
sym = "Hello".to_sym

puts ObjectSpace.dump(sym)
GC.verify_compaction_references(expand_heap: true, toward: :empty)
puts ObjectSpace.dump(sym)
```

Before:

    {"address":"0x101274ac8", "type":"SYMBOL", ... }
    {"address":"0x101274ac8", "type":"SYMBOL", ... }

After:

    {"address":"0x101544a78", "type":"SYMBOL", ... }
    {"address":"0x1015d7f80", "type":"SYMBOL", ... }