### PR TITLE
`ISeq#to_a` respects `use_block` status

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -11761,6 +11761,10 @@ rb_iseq_build_from_ary(rb_iseq_t *iseq, VALUE misc, VALUE locals, VALUE params,
         ISEQ_BODY(iseq)->param.flags.ambiguous_param0 = TRUE;
     }
 
+    if (Qtrue == rb_hash_aref(params, SYM(use_block))) {
+        ISEQ_BODY(iseq)->param.flags.use_block = TRUE;
+    }
+
     if (int_param(&i, params, SYM(kwrest))) {
         struct rb_iseq_param_keyword *keyword = (struct rb_iseq_param_keyword *)ISEQ_BODY(iseq)->param.keyword;
         if (keyword == NULL) {

--- a/iseq.c
+++ b/iseq.c
@@ -3200,6 +3200,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
         }
         if (iseq_body->param.flags.has_kwrest) rb_hash_aset(params, ID2SYM(rb_intern("kwrest")), INT2FIX(keyword->rest_start));
         if (iseq_body->param.flags.ambiguous_param0) rb_hash_aset(params, ID2SYM(rb_intern("ambiguous_param0")), Qtrue);
+        if (iseq_body->param.flags.use_block) rb_hash_aset(params, ID2SYM(rb_intern("use_block")), Qtrue);
     }
 
     /* body */

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -827,6 +827,18 @@ class TestISeq < Test::Unit::TestCase
     end
   end
 
+  def block_using_method
+    yield
+  end
+
+  def block_unused_method
+  end
+
+  def test_unused_param
+    assert_equal true, RubyVM::InstructionSequence.of(method(:block_using_method)).to_a.dig(11, :use_block)
+    assert_equal nil, RubyVM::InstructionSequence.of(method(:block_unused_method)).to_a.dig(11, :use_block)
+  end
+
   def test_compile_prism_with_invalid_object_type
     assert_raise(TypeError) do
       RubyVM::InstructionSequence.compile_prism(Object.new)


### PR DESCRIPTION
```ruby
b = RubyVM::InstructionSequence.compile('def f = yield; def g = nil').to_a
pp b

 #=>
 ...
 {:use_block=>true},
 ...
```