### PR TITLE
[Feature #20335] `Thread.each_caller_location` arguments

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -143,18 +143,8 @@ module Gem::BUNDLED_GEMS
       # Additionally, we need to skip Bootsnap and Zeitwerk if present, these
       # gems decorate Kernel#require, so they are not really the ones issuing
       # the require call users should be warned about. Those are upwards.
-      frames_to_skip = 2
-      location = nil
-      Thread.each_caller_location do |cl|
-        if frames_to_skip >= 1
-          frames_to_skip -= 1
-          next
-        end
-
-        if cl.base_label != "require"
-          location = cl.path
-          break
-        end
+      location = Thread.each_caller_location(2) do |cl|
+        break cl.path unless cl.base_label == "require"
       end
 
       if location && File.file?(location) && !location.start_with?(Gem::BUNDLED_GEMS::LIBDIR)

--- a/spec/ruby/core/thread/each_caller_location_spec.rb
+++ b/spec/ruby/core/thread/each_caller_location_spec.rb
@@ -40,10 +40,10 @@ describe "Thread.each_caller_location" do
       }.should raise_error(LocalJumpError, "no block given")
     end
 
-    it "doesn't accept positional and keyword arguments" do
+    it "doesn't accept keyword arguments" do
       -> {
         Thread.each_caller_location(12, foo: 10) {}
-      }.should raise_error(ArgumentError, "wrong number of arguments (given 2, expected 0)")
+      }.should raise_error(ArgumentError);
     end
   end
 end

--- a/spec/ruby/optional/capi/spec_helper.rb
+++ b/spec/ruby/optional/capi/spec_helper.rb
@@ -33,12 +33,6 @@ def compile_extension(name)
   ruby_header = "#{rubyhdrdir}/ruby.h"
   abi_header = "#{rubyhdrdir}/ruby/internal/abi.h"
 
-  if RbConfig::CONFIG["ENABLE_SHARED"] == "yes"
-    # below is defined since 2.1, except for mswin, and maybe other platforms
-    libdirname = RbConfig::CONFIG.fetch 'libdirname', 'libdir'
-    libruby = "#{RbConfig::CONFIG[libdirname]}/#{RbConfig::CONFIG['LIBRUBY']}"
-  end
-
   begin
     mtime = File.mtime(lib)
   rescue Errno::ENOENT
@@ -49,7 +43,6 @@ def compile_extension(name)
     when mtime <= File.mtime("#{spec_ext_dir}/#{ext}.c")
     when mtime <= File.mtime(ruby_header)
     when (mtime <= File.mtime(abi_header) rescue nil)
-    when libruby && mtime <= File.mtime(libruby)
     else
       return lib # up-to-date
     end

--- a/test/ruby/test_backtrace.rb
+++ b/test/ruby/test_backtrace.rb
@@ -155,6 +155,10 @@ class TestBacktrace < Test::Unit::TestCase
   end
 
   def test_each_backtrace_location
+    assert_nil(Thread.each_caller_location {})
+
+    assert_raise(LocalJumpError) {Thread.each_caller_location}
+
     i = 0
     cl = caller_locations(1, 1)[0]; ecl = Thread.each_caller_location{|x| i+=1; break x if i == 1}
     assert_equal(cl.to_s, ecl.to_s)
@@ -181,6 +185,10 @@ class TestBacktrace < Test::Unit::TestCase
     assert_raise(StopIteration) {
       ecl.next
     }
+
+    ary = []
+    cl = caller_locations(1, 2); Thread.each_caller_location(1, 2) {|x| ary << x}
+    assert_equal(cl.map(&:to_s), ary.map(&:to_s))
   end
 
   def test_caller_locations_first_label


### PR DESCRIPTION
Accecpt the same arguments as `caller` and `caller_locations`.