### PR TITLE
test_uplus_minus: Use a different string literal

### DIFF
--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -3358,7 +3358,7 @@ CODE
 
     require 'objspace'
 
-    str = "bar".freeze
+    str = "test_uplus_minus_str".freeze
     assert_includes ObjectSpace.dump(str), '"fstring":true'
 
     assert_predicate(str, :frozen?)
@@ -3368,7 +3368,7 @@ CODE
     assert_not_same(str, +str)
     assert_same(str, -str)
 
-    bar = -%w(b a r).join('')
+    bar = -%w(test uplus minus str).join('_')
     assert_same(str, bar, "uminus deduplicates [Feature #13077] str: #{ObjectSpace.dump(str)} bar: #{ObjectSpace.dump(bar)}")
   end
 


### PR DESCRIPTION
This test fail relatively frequently and it's unclear what is happening.

```
str: {"address":"0x7fbdeb26d4e0", "type":"STRING", "shape_id":1, "slot_size":40, "class":"0x7fbdd1e0ec50", "frozen":true, "embedded":true, "fstring":true, "bytesize":3, "value":"bar", "encoding":"UTF-8", "coderange":"7bit", "memsize":40, "flags":{"wb_protected":true, "old":true, "uncollectible":true, "marked":true}}
bar: {"address":"0x7fbdd0a8b138", "type":"STRING", "shape_id":1, "slot_size":40, "class":"0x7fbdd1e0ec50", "frozen":true, "embedded":true, "fstring":true, "bytesize":3, "value":"bar", "encoding":"UTF-8", "coderange":"7bit", "memsize":40, "flags":{"wb_protected":true}}
```

The `"bar".freeze` literal correctly put an old-gen fstring on the stack. But `-%w(b a r).join('')` returns a young-gen fstring, which suggest it somehow failed to find the old one in the `frozen_strings` table.

This could be caused by another test corrupting the table, or corrupting the `"bar"` fstring.

By using a different literal value we can learn whether the bug is specific to `"bar"` (used in many tests) or more general.