### PR TITLE
Fix ignored block warning in weakref

### DIFF
--- a/lib/weakref.rb
+++ b/lib/weakref.rb
@@ -41,7 +41,7 @@ class WeakRef < Delegator
     super
   end
 
-  def __getobj__ # :nodoc:
+  def __getobj__(&_) # :nodoc:
     @@__map[self] or defined?(@delegate_sd_obj) ? @delegate_sd_obj :
       Kernel::raise(RefError, "Invalid Reference - probably recycled", Kernel::caller(2))
   end


### PR DESCRIPTION
```
delegate.rb:84: warning: the passed block for 'WeakRef#__getobj__' defined at weakref.rb:44 may be ignored
```

FYI: @ko1 