### PR TITLE
relax unused block warning for duck typing

### DIFF
--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -1692,5 +1692,19 @@ class TestMethod < Test::Unit::TestCase
       assert_match(/-:23: warning.+f5/, err.join)
       assert_match(/-:24: warning.+f6/, err.join)
     end
+
+    assert_in_out_err '-w', <<-'RUBY' do |_out, err, _status|
+      class C0
+        def f = yield
+      end
+
+      class C1 < C0
+        def f = nil
+      end
+
+      C1.new.f{} # do not warn on duck typing
+    RUBY
+      assert_equal 0, err.size, err.join("\n")
+    end
   end
 end

--- a/vm.c
+++ b/vm.c
@@ -4254,6 +4254,7 @@ Init_BareVM(void)
     vm->negative_cme_table = rb_id_table_create(16);
     vm->overloaded_cme_table = st_init_numtable();
     vm->constant_cache = rb_id_table_create(0);
+    vm->unused_block_warning_table = st_init_numtable();
 
     // setup main thread
     th->nt = ZALLOC(struct rb_native_thread);

--- a/vm_core.h
+++ b/vm_core.h
@@ -773,6 +773,7 @@ typedef struct rb_vm_struct {
     st_table *ci_table;
     struct rb_id_table *negative_cme_table;
     st_table *overloaded_cme_table; // cme -> overloaded_cme
+    st_table *unused_block_warning_table;
 
     // This id table contains a mapping from ID to ICs. It does this with ID
     // keys and nested st_tables as values. The nested tables have ICs as keys


### PR DESCRIPTION
if a method `foo` uses a block, other (unrelated) method `foo` can receives a block. So try to relax the unused block warning condition.

```ruby
      class C0
        def f = yield
      end

      class C1 < C0
        def f = nil
      end

      [C0, C1].f{ block } # do not warn
```