### PR TITLE
YJIT: Fix canary crash with Array#<<

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5929,8 +5929,10 @@ fn jit_rb_ary_push(
 ) -> bool {
     asm_comment!(asm, "Array#<<");
 
-    // rb_ary_push allocates memory for buffer extension
-    jit_prepare_call_with_gc(jit, asm);
+    // rb_ary_push allocates memory for buffer extension and can raise FrozenError
+    // Not using a lazy frame here since the interpreter also has a truncated
+    // stack trace from opt_ltlt.
+    jit_prepare_non_leaf_call(jit, asm);
 
     let item_opnd = asm.stack_opnd(0);
     let ary_opnd = asm.stack_opnd(1);


### PR DESCRIPTION
Previously, we got "We are killing the stack canary set by opt_ltlt"
from `$./miniruby --yjit-call-threshold=1 -e 'a = [].freeze; a << 1'`

Found by running ruby-spec with yjit-call-threshold=1.
