### PR TITLE
Don't verify during gc_enter when gc is disabled.

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -9297,7 +9297,7 @@ gc_enter(rb_objspace_t *objspace, enum gc_enter_event event, unsigned int *lock_
 
     gc_enter_count(event);
     if (UNLIKELY(during_gc != 0)) rb_bug("during_gc != 0");
-    if (RGENGC_CHECK_MODE >= 3) gc_verify_internal_consistency(objspace);
+    if (RGENGC_CHECK_MODE >= 3 && (dont_gc_val() == 0)) gc_verify_internal_consistency(objspace);
 
     during_gc = TRUE;
     RUBY_DEBUG_LOG("%s (%s)",gc_enter_event_cstr(event), gc_current_status(objspace));


### PR DESCRIPTION
`RGENGC_CHECK_MODE >=3` fails with an inconsistency in the old object count during ec_finalization.

This is due to inconsistency introduced to the object graph using `T_DATA` finalizers.

This is explained in commit https://github.com/ruby/ruby/commit/79df14c04b452411b9d17e26a398e491bca1a811 which disabled gc during finalization to work around this.

```
    /* prohibit GC because force T_DATA finalizers can break an object graph consistency */
    dont_gc_on()
```

This object graph inconsistency also seems to break `RGENGC_CHECK_MODE >= 3`, when it attempt to verify the object age relationships during finalization at VM shutdown (gc_enter is called during finalization).

This commit stops the internal consistency check during gc_enter only when RGENGC_CHECK_MODE >= 3 and when gc is disabled.

This fixes `make btest` with `-DRGENGC_CHECK_MODE=3`