### PR TITLE
Implement equality for CI comparison when CC searching

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -9984,9 +9984,6 @@ update_cc_tbl_i(VALUE ccs_ptr, void *data)
     }
 
     for (int i=0; i<ccs->len; i++) {
-        if (gc_object_moved_p(objspace, (VALUE)ccs->entries[i].ci)) {
-            ccs->entries[i].ci = (struct rb_callinfo *)rb_gc_location((VALUE)ccs->entries[i].ci);
-        }
         if (gc_object_moved_p(objspace, (VALUE)ccs->entries[i].cc)) {
             ccs->entries[i].cc = (struct rb_callcache *)rb_gc_location((VALUE)ccs->entries[i].cc);
         }

--- a/imemo.c
+++ b/imemo.c
@@ -196,7 +196,6 @@ cc_table_mark_i(ID id, VALUE ccs_ptr, void *data)
             VM_ASSERT((VALUE)data == ccs->entries[i].cc->klass);
             VM_ASSERT(vm_cc_check_cme(ccs->entries[i].cc, ccs->cme));
 
-            rb_gc_mark_movable((VALUE)ccs->entries[i].ci);
             rb_gc_mark_movable((VALUE)ccs->entries[i].cc);
         }
         return ID_TABLE_CONTINUE;

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -575,7 +575,8 @@ struct rb_class_cc_entries {
     int len;
     const struct rb_callable_method_entry_struct *cme;
     struct rb_class_cc_entries_entry {
-        const struct rb_callinfo *ci;
+        unsigned int argc;
+        unsigned int flag;
         const struct rb_callcache *cc;
     } *entries;
 };

--- a/vm_method.c
+++ b/vm_method.c
@@ -31,7 +31,6 @@ vm_ccs_dump_i(ID mid, VALUE val, void *data)
     rp(ccs->cme);
 
     for (int i=0; i<ccs->len; i++) {
-        fprintf(stderr, "  | [%d]\t", i); vm_ci_dump(ccs->entries[i].ci);
         rp_m(           "  |   \t", ccs->entries[i].cc);
     }
 


### PR DESCRIPTION
When we're searching for CCs, compare the argc and flags for CI rather than comparing pointers.  This means we don't need to store a reference to the CI, and it also naturally "de-duplicates" CC objects.

We can observe the effect with the following code:

```ruby
require "objspace"

hash = {}

p ObjectSpace.memsize_of(Hash)

eval ("a".."zzz").map { |key|
  "hash.merge(:#{key} => 1)"
}.join("; ")

p ObjectSpace.memsize_of(Hash)
```

On master:

```
$ ruby -v test.rb
ruby 3.4.0dev (2024-04-15T16:21:41Z master d019b3baec) [arm64-darwin23]
test.rb:3: warning: assigned but unused variable - hash
3424
527736
```

On this branch:

```
$ make runruby
compiling vm.c
linking miniruby
builtin_binary.inc updated
compiling builtin.c
linking static-library libruby.3.4-static.a
ln -sf ../../rbconfig.rb .ext/arm64-darwin23/rbconfig.rb
linking ruby
ld: warning: ignoring duplicate libraries: '-ldl', '-lobjc', '-lpthread'
RUBY_ON_BUG='gdb -x ./.gdbinit -p' ./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems  ./test.rb
2240
2368
```