### PR TITLE
`RUBY_TRY_UNUSED_BLOCK_WARNING_STRICT`

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2006,8 +2006,11 @@ iseq_set_use_block(rb_iseq_t *iseq)
         body->param.flags.use_block = 1;
 
         rb_vm_t *vm = GET_VM();
-        st_data_t key = (st_data_t)rb_intern_str(body->location.label); // String -> ID
-        st_insert(vm->unused_block_warning_table, key, 1);
+
+        if (!vm->unused_block_warning_strict) {
+            st_data_t key = (st_data_t)rb_intern_str(body->location.label); // String -> ID
+            st_insert(vm->unused_block_warning_table, key, 1);
+        }
     }
 }
 

--- a/vm.c
+++ b/vm.c
@@ -4261,6 +4261,12 @@ Init_BareVM(void)
     vm->constant_cache = rb_id_table_create(0);
     vm->unused_block_warning_table = st_init_numtable();
 
+    // TODO: remove before Ruby 3.4.0 release
+    const char *s = getenv("RUBY_TRY_UNUSED_BLOCK_WARNING_STRICT");
+    if (s && strcmp(s, "1") == 0) {
+        vm->unused_block_warning_strict = true;
+    }
+
     // setup main thread
     th->nt = ZALLOC(struct rb_native_thread);
     th->vm = vm;

--- a/vm_core.h
+++ b/vm_core.h
@@ -774,6 +774,7 @@ typedef struct rb_vm_struct {
     struct rb_id_table *negative_cme_table;
     st_table *overloaded_cme_table; // cme -> overloaded_cme
     st_table *unused_block_warning_table;
+    bool unused_block_warning_strict;
 
     // This id table contains a mapping from ID to ICs. It does this with ID
     // keys and nested st_tables as values. The nested tables have ICs as keys

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2973,6 +2973,7 @@ warn_unused_block(const rb_callable_method_entry_t *cme, const rb_iseq_t *iseq, 
 {
     rb_vm_t *vm = GET_VM();
     st_table *dup_check_table = vm->unused_block_warning_table;
+    st_data_t key;
 
     union {
         VALUE v;
@@ -2984,14 +2985,17 @@ warn_unused_block(const rb_callable_method_entry_t *cme, const rb_iseq_t *iseq, 
     };
 
     // relax check
-    st_data_t key = (st_data_t)cme->def->original_id;
+    if (!vm->unused_block_warning_strict) {
+        key = (st_data_t)cme->def->original_id;
 
-    if (st_lookup(dup_check_table, key, NULL)) {
-        return;
+        if (st_lookup(dup_check_table, key, NULL)) {
+            return;
+        }
     }
 
     // strict check
     // make unique key from pc and me->def pointer
+    key = 0;
     for (int i=0; i<SIZEOF_VALUE; i++) {
         // fprintf(stderr, "k1:%3d k2:%3d\n", k1.b[i], k2.b[SIZEOF_VALUE-1-i]);
         key |= (st_data_t)(k1.b[i] ^ k2.b[SIZEOF_VALUE-1-i]) << (8 * i);


### PR DESCRIPTION
`RUBY_TRY_UNUSED_BLOCK_WARNING_STRICT=1 ruby ...` will enable strict check for unused block warning.

(== reverting e9d7478dedbd2b57530bc17efe8a9db9b8b2f280)

This option is only for trial to compare the results so the envname is not considered well.
Should be removed before Ruby 3.4.0 release.