### PR TITLE
Clean up after rubygems test

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -957,12 +957,16 @@ PRECHECK_TEST_ALL = yes-test-all-precheck
 test-all: $(TEST_RUNNABLE)-test-all
 yes-test-all: $(PRECHECK_TEST_ALL)
 	$(ACTIONS_GROUP)
-	$(gnumake_recursive)$(Q)$(exec) $(RUNRUBY) "$(TESTSDIR)/runner.rb" --ruby="$(RUNRUBY)" \
+	$(gnumake_recursive)$(Q)$(exec) $(RUNRUBY) -r$(tooldir)/lib/_tmpdir \
+	"$(TESTSDIR)/runner.rb" --ruby="$(RUNRUBY)" \
 	$(TEST_EXCLUDES) $(TESTOPTS) $(TESTS)
 	$(ACTIONS_ENDGROUP)
 TESTS_BUILD = mkmf
 no-test-all: PHONY
-	$(gnumake_recursive)$(MINIRUBY) -I"$(srcdir)/lib" "$(TESTSDIR)/runner.rb" $(TESTOPTS) $(TESTS_BUILD)
+	$(ACTIONS_GROUP)
+	$(gnumake_recursive)$(MINIRUBY) -I"$(srcdir)/lib" -r$(tooldir)/lib/_tmpdir \
+	"$(TESTSDIR)/runner.rb" $(TESTOPTS) $(TESTS_BUILD)
+	$(ACTIONS_ENDGROUP)
 
 test-almost: test-all
 yes-test-almost: yes-test-all
@@ -1004,7 +1008,7 @@ test-spec: $(TEST_RUNNABLE)-test-spec
 yes-test-spec: yes-test-spec-precheck
 	$(ACTIONS_GROUP)
 	$(gnumake_recursive)$(Q) \
-	$(RUNRUBY) -r./$(arch)-fake -r$(tooldir)/rubyspec_temp \
+	$(RUNRUBY) -r./$(arch)-fake -r$(tooldir)/lib/_tmpdir \
 		$(srcdir)/spec/mspec/bin/mspec run -B $(srcdir)/spec/default.mspec $(MSPECOPT) $(SPECOPTS)
 	$(ACTIONS_ENDGROUP)
 no-test-spec:
@@ -1013,7 +1017,7 @@ test-prism-spec: $(TEST_RUNNABLE)-test-prism-spec
 yes-test-prism-spec: yes-test-spec-precheck
 	$(ACTIONS_GROUP)
 	$(gnumake_recursive)$(Q) \
-	$(RUNRUBY) -r./$(arch)-fake -r$(tooldir)/rubyspec_temp \
+	$(RUNRUBY) -r./$(arch)-fake -r$(tooldir)/lib/_tmpdir \
 		$(srcdir)/spec/mspec/bin/mspec run -B $(srcdir)/spec/default.mspec -B $(srcdir)/spec/prism.mspec $(MSPECOPT) $(SPECOPTS)
 	$(ACTIONS_ENDGROUP)
 no-test-prism-spec:
@@ -1606,7 +1610,7 @@ test-bundled-gems-spec: $(TEST_RUNNABLE)-test-bundled-gems-spec
 yes-test-bundled-gems-spec: yes-test-spec-precheck $(PREPARE_BUNDLED_GEMS)
 	$(ACTIONS_GROUP)
 	$(gnumake_recursive)$(Q) \
-	$(RUNRUBY) -r./$(arch)-fake -r$(tooldir)/rubyspec_temp \
+	$(RUNRUBY) -r./$(arch)-fake -r$(tooldir)/lib/_tmpdir \
 		$(srcdir)/spec/mspec/bin/mspec run -B $(srcdir)/spec/bundled_gems.mspec $(MSPECOPT) $(SPECOPTS)
 	$(ACTIONS_ENDGROUP)
 no-test-bundled-gems-spec:

--- a/tool/lib/_tmpdir.rb
+++ b/tool/lib/_tmpdir.rb
@@ -13,7 +13,41 @@ end
 pid = $$
 END {
   if pid == $$
-    FileUtils.rm_rf(tmpdir)
+    begin
+      Dir.rmdir(tmpdir)
+    rescue Errno::ENOENT
+    rescue Errno::ENOTEMPTY
+      require_relative "colorize"
+      colorize = Colorize.new
+      mode_inspect = ->(m, s) {
+        [
+          (m & 0o4 == 0 ? ?- : ?r),
+          (m & 0o2 == 0 ? ?- : ?w),
+          (m & 0o1 == 0 ? (s ? s.upcase : ?-) : (s || ?x)),
+        ]
+      }
+      filecolor = ->(st) {
+        st.directory? ? "bold;blue" : st.link? ? "bold;cyan" : st.executable? ? "bold;green" : nil
+      }
+      warn colorize.notice("Children under ")+colorize.fail(tmpdir)+":"
+      Dir.children(tmpdir).each do |child|
+        path = File.join(tmpdir, child)
+        st = File.lstat(path)
+        m = st.mode
+        m = [
+          (st.file? ? ?- : st.ftype[0]),
+          mode_inspect[m >> 6, (?s unless m & 04000 == 0)],
+          mode_inspect[m >> 3, (?s unless m & 02000 == 0)],
+          mode_inspect[m,      (?t unless m & 01000 == 0)],
+        ].join("")
+        warn [
+          " ", m, st.nlink, st.size, st.mtime,
+          colorize.decorate(child,  filecolor[st]),
+          (["->", colorize.cyan(File.readlink(path))] if st.symlink?),
+        ].compact.join(" ")
+      end
+      FileUtils.rm_rf(tmpdir)
+    end
   end
 }
 

--- a/tool/lib/_tmpdir.rb
+++ b/tool/lib/_tmpdir.rb
@@ -1,14 +1,20 @@
 require "tmpdir"
 require "fileutils"
 
-template = "rubyspec_temp."
-if (tmpdir = Dir.mktmpdir(template)).size > 80
+template = "rubytest."
+if (tmpdir = Dir.mktmpdir(template)).size > 50
   # On macOS, the default TMPDIR is very long, inspite of UNIX socket
   # path length is limited.
   Dir.rmdir(tmpdir)
   tmpdir = Dir.mktmpdir(template, "/tmp")
 end
 # warn "tmpdir(#{tmpdir.size}) = #{tmpdir}"
-END {FileUtils.rm_rf(tmpdir)}
 
-ENV["TMPDIR"] = ENV["SPEC_TEMP_DIR"] = tmpdir
+pid = $$
+END {
+  if pid == $$
+    FileUtils.rm_rf(tmpdir)
+  end
+}
+
+ENV["TMPDIR"] = ENV["SPEC_TEMP_DIR"] = ENV["GEM_TEST_TMPDIR"] = tmpdir

--- a/tool/rubyspec_temp.rb
+++ b/tool/rubyspec_temp.rb
@@ -1,11 +1,12 @@
 require "tmpdir"
 require "fileutils"
 
-if (tmpdir = Dir.mktmpdir("rubyspec_temp.")).size > 80
+template = "rubyspec_temp."
+if (tmpdir = Dir.mktmpdir(template)).size > 80
   # On macOS, the default TMPDIR is very long, inspite of UNIX socket
   # path length is limited.
   Dir.rmdir(tmpdir)
-  tmpdir = Dir.mktmpdir("rubyspec_temp.", "/tmp")
+  tmpdir = Dir.mktmpdir(template, "/tmp")
 end
 # warn "tmpdir(#{tmpdir.size}) = #{tmpdir}"
 END {FileUtils.rm_rf(tmpdir)}


### PR DESCRIPTION
It is known that `gem rebuild` leaves temporary directories for now.
https://github.com/rubygems/rubygems/pull/4913#issuecomment-2060098606