### PR TITLE
Don't warn about missing libyaml if error was a version conflict

### DIFF
--- a/lib/yaml.rb
+++ b/lib/yaml.rb
@@ -2,7 +2,12 @@
 
 begin
   require 'psych'
-rescue LoadError
+rescue LoadError => ex
+  # Skip warning message concerning missing yaml dependency as LoadError wasn't
+  # triggered due to a missing dependency but because of a conflicting version
+  # which was already activated.
+  raise if ex.message.match?(/already activated/)
+
   case RUBY_ENGINE
   when 'jruby'
     warn "The Psych YAML extension failed to load.\n" \


### PR DESCRIPTION
The error triggered when loading psych may not be due to a missing library but an already activated version of psych which is now conflicting.

Hide the missing dependency warning to prevent any sort of confusion.