### PR TITLE
Ensure `ibf_load_setup` is only passed String params

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -14214,6 +14214,8 @@ ibf_load_setup_bytes(struct ibf_load *load, VALUE loader_obj, const char *bytes,
 static void
 ibf_load_setup(struct ibf_load *load, VALUE loader_obj, VALUE str)
 {
+    StringValue(str);
+
     if (RSTRING_LENINT(str) < (int)sizeof(struct ibf_header)) {
         rb_raise(rb_eRuntimeError, "broken binary format");
     }

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -850,4 +850,11 @@ class TestISeq < Test::Unit::TestCase
       RubyVM::InstructionSequence.compile_prism(Object.new)
     end
   end
+
+  def test_load_from_binary_only_accepts_string_param
+    assert_raise(TypeError) do
+      var_0 = 0
+      RubyVM::InstructionSequence.load_from_binary(var_0)
+    end
+  end
 end


### PR DESCRIPTION
In cases where `RubyVM::InstructionSequence.load_from_binary()` is passed a param other than a String, we attempt to call the `RSTRING_LENINT` macro on it which can cause a segfault.

This commit adds a type check to raise a `TypeError` unless we are provided a String.

ex:
```ruby
var_0 = 0
RubyVM::InstructionSequence.load_from_binary(var_0)
```

```
test.rb:2: [BUG] Segmentation fault at 0x0000000000000011
ruby 3.4.0dev (2024-04-19T19:25:32Z master 23be6599a2) [x86_64-darwin23]

-- Crash Report log information --------------------------------------------
   See Crash Report log file in one of the following locations:
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
c:0003 p:---- s:0012 e:000011 CFUNC  :load_from_binary
c:0002 p:0009 s:0007 E:001ff8 EVAL   test.rb:2 [FINISH]
c:0001 p:0000 s:0003 E:000360 DUMMY  [FINISH]

-- Ruby level backtrace information ----------------------------------------
test.rb:2:in '<main>'
test.rb:2:in 'load_from_binary'

-- Threading information ---------------------------------------------------
Total ractor count: 1
Ruby thread count for this ractor: 1

-- Machine register context ------------------------------------------------
 rax: 0x000000010dd799f8 rbx: 0x000000010dd799f8 rcx: 0x0000000000000000
 rdx: 0x0000000000000000 rdi: 0x00007f8a3580b400 rsi: 0x0000000000000050
 rbp: 0x000000030d74fc90 rsp: 0x000000030d74fc60  r8: 0x0000000000000050
  r9: 0x0000000000000002 r10: 0x0000000000000004 r11: 0x00000000000000a0
 r12: 0x0000000055550083 r13: 0x00007f8a357054c0 r14: 0x000060000215c0a0
 r15: 0x0000000000000001 rip: 0x00000001047ba73f rfl: 0x0000000000000247

-- C level backtrace information -------------------------------------------
/Users/dave/src/github.com/ruby/build/ruby(rb_print_backtrace+0xf) [0x104a342a8] ../vm_dump.c:820
/Users/dave/src/github.com/ruby/build/ruby(rb_vm_bugreport) ../vm_dump.c:1151
/Users/dave/src/github.com/ruby/build/ruby(rb_vm_bugreport) (null):0
/Users/dave/src/github.com/ruby/build/ruby(rb_bug_for_fatal_signal+0x148) [0x104837c48] ../error.c:1087
/Users/dave/src/github.com/ruby/build/ruby(sigsegv+0x4d) [0x10497f68d] ../signal.c:929
/usr/lib/system/libsystem_platform.dylib(_sigtramp+0x1d) [0x7ff816602fdd]
/Users/dave/src/github.com/ruby/build/ruby(RSTRING_LEN+0x0) [0x1047ba73f] ../compile.c:14262
/Users/dave/src/github.com/ruby/build/ruby(RSTRING_LENINT) ../include/ruby/internal/core/rstring.h:470
/Users/dave/src/github.com/ruby/build/ruby(ibf_load_setup) ../compile.c:14217
/Users/dave/src/github.com/ruby/build/ruby(rb_iseq_ibf_load) ../compile.c:14264
/Users/dave/src/github.com/ruby/build/ruby(iseqw_s_load_from_binary+0xc) [0x1048a071c] ../iseq.c:4011
/Users/dave/src/github.com/ruby/build/ruby(vm_call_cfunc_with_frame_+0x132) [0x104a25c02] ../vm_insnhelper.c:3595
/Users/dave/src/github.com/ruby/build/ruby(vm_sendish+0xfd) [0x1049ff84d]
/Users/dave/src/github.com/ruby/build/ruby(vm_exec_core+0x3249) [0x104a04d19] ../insns.def:891
/Users/dave/src/github.com/ruby/build/ruby(rb_vm_exec+0x19f) [0x104a0008f] ../vm.c:2558
/Users/dave/src/github.com/ruby/build/ruby(rb_ec_exec_node+0x9e) [0x1048429de] ../eval.c:281
/Users/dave/src/github.com/ruby/build/ruby(ruby_run_node+0x42) [0x1048428f2] ../eval.c:319
/Users/dave/src/github.com/ruby/build/ruby(rb_main+0x1c) [0x104771c45] ../main.c:40
/Users/dave/src/github.com/ruby/build/ruby(main) ../main.c:59
```