### PR TITLE
Ignore the result of pthread_kill in ubf_wakeup_thread

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -2569,10 +2569,7 @@ ubf_wakeup_thread(rb_thread_t *th)
 {
     RUBY_DEBUG_LOG("th:%u thread_id:%p", rb_th_serial(th), (void *)th->nt->thread_id);
 
-    int r = pthread_kill(th->nt->thread_id, SIGVTALRM);
-    if (r != 0) {
-        rb_bug_errno("pthread_kill", r);
-    }
+    pthread_kill(th->nt->thread_id, SIGVTALRM);
 }
 
 static void


### PR DESCRIPTION
After an upgrade to Ruby 3.3.0, I experienced reproducible production crashes of the form:

[BUG] pthread_kill: No such process (ESRCH)

This is the only pthread_kill call in Ruby. The result of pthread_kill was previously ignored in Ruby 3.2 and below. Checking the result was added in be1bbd5b7d40ad863ab35097765d3754726bbd54 (MaNy).

I have not yet been able to create a minimal self-contained example, but it should be safe to remove the checks.