### PR TITLE
Use ppc64le coroutines on powerpc64-freebsd*

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2731,6 +2731,9 @@ AS_CASE([$coroutine_type], [yes|''], [
         [aarch64-freebsd*], [
             coroutine_type=arm64
         ],
+        [powerpc64-freebsd*], [
+            coroutine_type=ppc64le
+        ],
         [powerpc64le-freebsd*], [
             coroutine_type=ppc64le
         ],

--- a/configure.ac
+++ b/configure.ac
@@ -2731,6 +2731,9 @@ AS_CASE([$coroutine_type], [yes|''], [
         [aarch64-freebsd*], [
             coroutine_type=arm64
         ],
+        [powerpc64le-freebsd*], [
+            coroutine_type=ppc64le
+        ],
         [x86_64-netbsd*], [
             coroutine_type=amd64
         ],


### PR DESCRIPTION
Only one ractor-related test fails, but it also fails with ucontext.