### PR TITLE
Refactor parser compile functions

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -129,19 +129,6 @@ rb_ast_parse_file(VALUE path, VALUE keep_script_lines, VALUE error_tolerant, VAL
 }
 
 static VALUE
-lex_array(VALUE array, int index)
-{
-    VALUE str = rb_ary_entry(array, index);
-    if (!NIL_P(str)) {
-        StringValue(str);
-        if (!rb_enc_asciicompat(rb_enc_get(str))) {
-            rb_raise(rb_eArgError, "invalid source encoding");
-        }
-    }
-    return str;
-}
-
-static VALUE
 rb_ast_parse_array(VALUE array, VALUE keep_script_lines, VALUE error_tolerant, VALUE keep_tokens)
 {
     rb_ast_t *ast = 0;
@@ -151,7 +138,7 @@ rb_ast_parse_array(VALUE array, VALUE keep_script_lines, VALUE error_tolerant, V
     if (RTEST(keep_script_lines)) rb_parser_set_script_lines(vparser);
     if (RTEST(error_tolerant)) rb_parser_error_tolerant(vparser);
     if (RTEST(keep_tokens)) rb_parser_keep_tokens(vparser);
-    ast = rb_parser_compile_generic(vparser, lex_array, Qnil, array, 1);
+    ast = rb_parser_compile_array(vparser, Qnil, array, 1);
     return ast_parse_done(ast);
 }
 

--- a/common.mk
+++ b/common.mk
@@ -3316,6 +3316,7 @@ compile.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 compile.$(OBJEXT): $(top_srcdir)/internal/io.h
 compile.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 compile.$(OBJEXT): $(top_srcdir)/internal/object.h
+compile.$(OBJEXT): $(top_srcdir)/internal/parse.h
 compile.$(OBJEXT): $(top_srcdir)/internal/rational.h
 compile.$(OBJEXT): $(top_srcdir)/internal/re.h
 compile.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
@@ -7494,6 +7495,7 @@ goruby.$(OBJEXT): $(top_srcdir)/internal/fixnum.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/gc.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/numeric.h
+goruby.$(OBJEXT): $(top_srcdir)/internal/parse.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/rational.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
 goruby.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
@@ -10361,6 +10363,7 @@ miniinit.$(OBJEXT): $(top_srcdir)/internal/fixnum.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/gc.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/numeric.h
+miniinit.$(OBJEXT): $(top_srcdir)/internal/parse.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/rational.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
 miniinit.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
@@ -10820,6 +10823,7 @@ node_dump.$(OBJEXT): $(top_srcdir)/internal/gc.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/hash.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/numeric.h
+node_dump.$(OBJEXT): $(top_srcdir)/internal/parse.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/rational.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/ruby_parser.h
 node_dump.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h

--- a/ext/ripper/ripper_init.c.tmpl
+++ b/ext/ripper/ripper_init.c.tmpl
@@ -17,15 +17,40 @@
 
 ID id_warn, id_warning, id_gets, id_assoc;
 
+enum lex_type {
+    lex_type_str,
+    lex_type_io,
+    lex_type_generic,
+};
+
 struct ripper {
     rb_parser_t *p;
+    enum lex_type type;
+    union {
+       struct lex_pointer_string ptr_str;
+       VALUE val;
+    } data;
 };
 
 static void
 ripper_parser_mark2(void *ptr)
 {
     struct ripper *r = (struct ripper*)ptr;
-    if (r->p) ripper_parser_mark(r->p);
+    if (r->p) {
+        ripper_parser_mark(r->p);
+
+        switch (r->type) {
+            case lex_type_str:
+              rb_gc_mark(r->data.ptr_str.str);
+              break;
+            case lex_type_io:
+              rb_gc_mark(r->data.val);
+              break;
+            case lex_type_generic:
+              rb_gc_mark(r->data.val);
+              break;
+        }
+    }
 }
 
 static void
@@ -54,8 +79,9 @@ static const rb_data_type_t parser_data_type = {
 };
 
 static VALUE
-ripper_lex_get_generic(struct parser_params *p, VALUE src)
+ripper_lex_get_generic(struct parser_params *p, rb_parser_input_data input, int line_count)
 {
+    VALUE src = (VALUE)input;
     VALUE line = rb_funcallv_public(src, id_gets, 0, 0);
     if (!NIL_P(line) && !RB_TYPE_P(line, T_STRING)) {
         rb_raise(rb_eTypeError,
@@ -79,9 +105,16 @@ ripper_compile_error(struct parser_params *p, const char *fmt, ...)
 }
 
 static VALUE
-ripper_lex_io_get(struct parser_params *p, VALUE src)
+ripper_lex_io_get(struct parser_params *p, rb_parser_input_data input, int line_count)
 {
+    VALUE src = (VALUE)input;
     return rb_io_gets(src);
+}
+
+static VALUE
+ripper_lex_get_str(struct parser_params *p, rb_parser_input_data input, int line_count)
+{
+    return rb_parser_lex_get_str((struct lex_pointer_string *)input);
 }
 
 static VALUE
@@ -294,26 +327,38 @@ parser_dedent_string(VALUE self, VALUE input, VALUE width)
 static VALUE
 ripper_initialize(int argc, VALUE *argv, VALUE self)
 {
+    struct ripper *r;
     struct parser_params *p;
     VALUE src, fname, lineno;
-    VALUE (*gets)(struct parser_params*,VALUE);
-    VALUE input, sourcefile_string;
+    rb_parser_lex_gets_func *gets;
+    VALUE sourcefile_string;
     const char *sourcefile;
     int sourceline;
+    rb_parser_input_data input;
 
     p = ripper_parser_params(self, false);
+    TypedData_Get_Struct(self, struct ripper, &parser_data_type, r);
     rb_scan_args(argc, argv, "12", &src, &fname, &lineno);
     if (RB_TYPE_P(src, T_FILE)) {
         gets = ripper_lex_io_get;
+        r->type = lex_type_io;
+        r->data.val = src;
+        input = (rb_parser_input_data)src;
     }
     else if (rb_respond_to(src, id_gets)) {
         gets = ripper_lex_get_generic;
+        r->type = lex_type_generic;
+        r->data.val = src;
+        input = (rb_parser_input_data)src;
     }
     else {
         StringValue(src);
-        gets = rb_ruby_ripper_lex_get_str;
+        gets = ripper_lex_get_str;
+        r->type = lex_type_str;
+        r->data.ptr_str.str = src;
+        r->data.ptr_str.ptr = 0;
+        input = (rb_parser_input_data)&r->data.ptr_str;
     }
-    input = src;
     if (NIL_P(fname)) {
         fname = STR_NEW2("(ripper)");
         OBJ_FREEZE(fname);

--- a/internal/parse.h
+++ b/internal/parse.h
@@ -53,10 +53,9 @@ void rb_ruby_parser_set_options(rb_parser_t *p, int print, int loop, int chomp, 
 rb_parser_t *rb_ruby_parser_set_context(rb_parser_t *p, const struct rb_iseq_struct *base, int main);
 void rb_ruby_parser_set_script_lines(rb_parser_t *p);
 void rb_ruby_parser_error_tolerant(rb_parser_t *p);
-rb_ast_t* rb_ruby_parser_compile_file_path(rb_parser_t *p, VALUE fname, VALUE file, int start);
 void rb_ruby_parser_keep_tokens(rb_parser_t *p);
-rb_ast_t* rb_ruby_parser_compile_generic(rb_parser_t *p, VALUE (*lex_gets)(VALUE, int), VALUE fname, VALUE input, int start);
-rb_ast_t* rb_ruby_parser_compile_string_path(rb_parser_t *p, VALUE f, VALUE s, int line);
+typedef VALUE (rb_parser_lex_gets_func)(struct parser_params*, rb_parser_input_data, int);
+rb_ast_t *rb_parser_compile(rb_parser_t *p, rb_parser_lex_gets_func *gets, VALUE fname, rb_parser_input_data input, int line);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 
@@ -91,7 +90,7 @@ VALUE rb_ruby_parser_debug_output(rb_parser_t *p);
 void rb_ruby_parser_set_debug_output(rb_parser_t *p, VALUE output);
 VALUE rb_ruby_parser_parsing_thread(rb_parser_t *p);
 void rb_ruby_parser_set_parsing_thread(rb_parser_t *p, VALUE parsing_thread);
-void rb_ruby_parser_ripper_initialize(rb_parser_t *p, VALUE (*gets)(struct parser_params*,VALUE), VALUE input, VALUE sourcefile_string, const char *sourcefile, int sourceline);
+void rb_ruby_parser_ripper_initialize(rb_parser_t *p, rb_parser_lex_gets_func *gets, rb_parser_input_data input, VALUE sourcefile_string, const char *sourcefile, int sourceline);
 VALUE rb_ruby_parser_result(rb_parser_t *p);
 rb_encoding *rb_ruby_parser_enc(rb_parser_t *p);
 VALUE rb_ruby_parser_ruby_sourcefile_string(rb_parser_t *p);
@@ -99,7 +98,6 @@ int rb_ruby_parser_ruby_sourceline(rb_parser_t *p);
 int rb_ruby_parser_lex_state(rb_parser_t *p);
 void rb_ruby_ripper_parse0(rb_parser_t *p);
 int rb_ruby_ripper_dedent_string(rb_parser_t *p, VALUE string, int width);
-VALUE rb_ruby_ripper_lex_get_str(rb_parser_t *p, VALUE s);
 int rb_ruby_ripper_initialized_p(rb_parser_t *p);
 void rb_ruby_ripper_parser_initialize(rb_parser_t *p);
 long rb_ruby_ripper_column(rb_parser_t *p);

--- a/internal/ruby_parser.h
+++ b/internal/ruby_parser.h
@@ -5,9 +5,15 @@
 #include "internal/bignum.h"
 #include "internal/compilers.h"
 #include "internal/complex.h"
+#include "internal/parse.h"
 #include "internal/rational.h"
 #include "rubyparser.h"
 #include "vm.h"
+
+struct lex_pointer_string {
+    VALUE str;
+    long ptr;
+};
 
 RUBY_SYMBOL_EXPORT_BEGIN
 #ifdef UNIVERSAL_PARSER
@@ -19,6 +25,7 @@ VALUE rb_parser_new(void);
 rb_ast_t *rb_parser_compile_string_path(VALUE vparser, VALUE fname, VALUE src, int line);
 VALUE rb_str_new_parser_string(rb_parser_string_t *str);
 VALUE rb_str_new_mutable_parser_string(rb_parser_string_t *str);
+VALUE rb_parser_lex_get_str(struct lex_pointer_string *ptr_str);
 
 VALUE rb_node_str_string_val(const NODE *);
 VALUE rb_node_sym_string_val(const NODE *);
@@ -48,7 +55,8 @@ void rb_parser_keep_tokens(VALUE vparser);
 
 rb_ast_t *rb_parser_compile_string(VALUE, const char*, VALUE, int);
 rb_ast_t *rb_parser_compile_file_path(VALUE vparser, VALUE fname, VALUE input, int line);
-rb_ast_t *rb_parser_compile_generic(VALUE vparser, VALUE (*lex_gets)(VALUE, int), VALUE fname, VALUE input, int line);
+rb_ast_t *rb_parser_compile_generic(VALUE vparser, rb_parser_lex_gets_func *lex_gets, VALUE fname, VALUE input, int line);
+rb_ast_t *rb_parser_compile_array(VALUE vparser, VALUE fname, VALUE array, int start);
 
 enum lex_state_bits {
     EXPR_BEG_bit,		/* ignore newline, +/- is a sign. */

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -349,7 +349,6 @@ enc_mbc_to_codepoint(const char *p, const char *e, void *enc)
     return ONIGENC_MBC_TO_CODE((rb_encoding *)enc, up, ue);
 }
 
-VALUE rb_io_gets_internal(VALUE io);
 extern VALUE rb_eArgError;
 
 static const rb_parser_config_t rb_global_parser_config = {
@@ -396,8 +395,6 @@ static const rb_parser_config_t rb_global_parser_config = {
 
     .str_catf = rb_str_catf,
     .str_cat_cstr = rb_str_cat_cstr,
-    .str_subseq = rb_str_subseq,
-    .str_new_frozen = rb_str_new_frozen,
     .str_modify = rb_str_modify,
     .str_set_len = rb_str_set_len,
     .str_cat = rb_str_cat,
@@ -413,7 +410,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .rstring_ptr = RSTRING_PTR,
     .rstring_end = RSTRING_END,
     .rstring_len = RSTRING_LEN,
-    .filesystem_str_new_cstr = rb_filesystem_str_new_cstr,
     .obj_as_string = rb_obj_as_string,
 
     .int2num = rb_int2num_inline,
@@ -423,7 +419,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .io_write = rb_io_write,
     .io_flush = rb_io_flush,
     .io_puts = rb_io_puts,
-    .io_gets_internal = rb_io_gets_internal,
 
     .debug_output_stdout = rb_ractor_stdout,
     .debug_output_stderr = rb_ractor_stderr,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1289,8 +1289,6 @@ typedef struct rb_parser_config_struct {
     RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 2, 3)
     VALUE (*str_catf)(VALUE str, const char *format, ...);
     VALUE (*str_cat_cstr)(VALUE str, const char *ptr);
-    VALUE (*str_subseq)(VALUE str, long beg, long len);
-    VALUE (*str_new_frozen)(VALUE orig);
     void (*str_modify)(VALUE str);
     void (*str_set_len)(VALUE str, long len);
     VALUE (*str_cat)(VALUE str, const char *ptr, long len);
@@ -1308,7 +1306,6 @@ typedef struct rb_parser_config_struct {
     char *(*rstring_ptr)(VALUE str);
     char *(*rstring_end)(VALUE str);
     long (*rstring_len)(VALUE str);
-    VALUE (*filesystem_str_new_cstr)(const char *ptr);
     VALUE (*obj_as_string)(VALUE);
 
     /* Numeric */
@@ -1320,7 +1317,6 @@ typedef struct rb_parser_config_struct {
     VALUE (*io_write)(VALUE io, VALUE str);
     VALUE (*io_flush)(VALUE io);
     VALUE (*io_puts)(int argc, const VALUE *argv, VALUE out);
-    VALUE (*io_gets_internal)(VALUE io);
 
     /* IO (Ractor) */
     VALUE (*debug_output_stdout)(void);

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -73,6 +73,8 @@ enum rb_parser_shareability {
     rb_parser_shareable_everything,
 };
 
+typedef void* rb_parser_input_data;
+
 /*
  * AST Node
  */
@@ -1419,7 +1421,6 @@ typedef struct rb_parser_config_struct {
 
 RUBY_SYMBOL_EXPORT_BEGIN
 void rb_ruby_parser_free(void *ptr);
-rb_ast_t* rb_ruby_parser_compile_string(rb_parser_t *p, const char *f, VALUE s, int line);
 
 #ifdef UNIVERSAL_PARSER
 rb_parser_t *rb_ruby_parser_allocate(const rb_parser_config_t *config);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -119,8 +119,6 @@
 #define rb_str_catf                       p->config->str_catf
 #undef rb_str_cat_cstr
 #define rb_str_cat_cstr                   p->config->str_cat_cstr
-#define rb_str_subseq                     p->config->str_subseq
-#define rb_str_new_frozen                 p->config->str_new_frozen
 #define rb_str_modify                     p->config->str_modify
 #define rb_str_set_len                    p->config->str_set_len
 #define rb_str_cat                        p->config->str_cat
@@ -142,7 +140,6 @@
 #define RSTRING_END                       p->config->rstring_end
 #undef RSTRING_LEN
 #define RSTRING_LEN                       p->config->rstring_len
-#define rb_filesystem_str_new_cstr        p->config->filesystem_str_new_cstr
 #define rb_obj_as_string                  p->config->obj_as_string
 
 #undef INT2NUM
@@ -153,7 +150,6 @@
 #define rb_io_write        p->config->io_write
 #define rb_io_flush        p->config->io_flush
 #define rb_io_puts         p->config->io_puts
-#define rb_io_gets_internal p->config->io_gets_internal
 
 #define rb_ractor_stdout   p->config->debug_output_stdout
 #define rb_ractor_stderr   p->config->debug_output_stderr


### PR DESCRIPTION
Refactor parser compile functions to reduce the dependence
on ruby functions.
This commit includes these changes

1. Refactor `gets`, `input` and `gets_` of `parser_params`

Parser needs two different data structure to get next line, function (`gets`) and input data (`input`).
However `gets_` is used for both function (`call`) and input data (`ptr`).
`call` is used for managing general callback function when `rb_ruby_parser_compile_generic` is used.
`ptr` is used for managing the current pointer on String when `parser_compile_string` is used.
This commit changes parser to used only `gets` and `input` then removes `gets_`.

2. Move parser_compile functions and `gets` functions from parse.y to ruby_parser.c

This change reduces the dependence on ruby functions from parser.

3. Change ruby_parser and ripper to take care of `VALUE input` GC mark

Move the responsibility of calling `rb_gc_mark` for `VALUE input` from parser to ruby_parser and ripper.
`input` is arbitrary data pointer from the viewpoint of parser.

4. Introduce rb_parser_compile_array function

Caller of `rb_parser_compile_generic` needs to take care about GC because ruby_parser doesn’t know
about the detail of `lex_gets` and `input`.
Introduce `rb_parser_compile_array` to reduce the complexity of ast.c.