### PR TITLE
Allow Major GC's to be disabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,12 @@ Note that each entry is kept to a minimum, see links for details.
 * Keyword arguments are no longer allowed in index assignment
   (e.g. `a[0, kw: 1] = 2`).  [[Bug #20218]]
 
+* `GC.config` added to allow setting configuration variables on the Garbage
+  Collector [[Feature #20443]]
+
+* GC configuration parameter `rgengc_allow_full_mark` introduced. When `false`
+  GC will only mark young objects. Default is `true`. [[Feature #20443]]
+
 ## Core classes updates
 
 Note: We're only listing outstanding class updates.

--- a/common.mk
+++ b/common.mk
@@ -7511,8 +7511,10 @@ gc_impl.$(OBJEXT): $(top_srcdir)/gc/default.c
 gc_impl.$(OBJEXT): $(top_srcdir)/gc/gc_impl.h
 gc_impl.$(OBJEXT): $(top_srcdir)/internal/bits.h
 gc_impl.$(OBJEXT): $(top_srcdir)/internal/compilers.h
+gc_impl.$(OBJEXT): $(top_srcdir)/internal/hash.h
 gc_impl.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 gc_impl.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
+gc_impl.$(OBJEXT): $(top_srcdir)/internal/string.h
 gc_impl.$(OBJEXT): $(top_srcdir)/internal/warnings.h
 gc_impl.$(OBJEXT): {$(VPATH)}assert.h
 gc_impl.$(OBJEXT): {$(VPATH)}atomic.h
@@ -7530,6 +7532,7 @@ gc_impl.$(OBJEXT): {$(VPATH)}darray.h
 gc_impl.$(OBJEXT): {$(VPATH)}debug.h
 gc_impl.$(OBJEXT): {$(VPATH)}debug_counter.h
 gc_impl.$(OBJEXT): {$(VPATH)}defines.h
+gc_impl.$(OBJEXT): {$(VPATH)}encoding.h
 gc_impl.$(OBJEXT): {$(VPATH)}intern.h
 gc_impl.$(OBJEXT): {$(VPATH)}internal/abi.h
 gc_impl.$(OBJEXT): {$(VPATH)}internal/anyargs.h
@@ -7603,8 +7606,14 @@ gc_impl.$(OBJEXT): {$(VPATH)}internal/ctype.h
 gc_impl.$(OBJEXT): {$(VPATH)}internal/dllexport.h
 gc_impl.$(OBJEXT): {$(VPATH)}internal/dosish.h
 gc_impl.$(OBJEXT): {$(VPATH)}internal/encoding/coderange.h
+gc_impl.$(OBJEXT): {$(VPATH)}internal/encoding/ctype.h
 gc_impl.$(OBJEXT): {$(VPATH)}internal/encoding/encoding.h
+gc_impl.$(OBJEXT): {$(VPATH)}internal/encoding/pathname.h
+gc_impl.$(OBJEXT): {$(VPATH)}internal/encoding/re.h
+gc_impl.$(OBJEXT): {$(VPATH)}internal/encoding/sprintf.h
 gc_impl.$(OBJEXT): {$(VPATH)}internal/encoding/string.h
+gc_impl.$(OBJEXT): {$(VPATH)}internal/encoding/symbol.h
+gc_impl.$(OBJEXT): {$(VPATH)}internal/encoding/transcode.h
 gc_impl.$(OBJEXT): {$(VPATH)}internal/error.h
 gc_impl.$(OBJEXT): {$(VPATH)}internal/eval.h
 gc_impl.$(OBJEXT): {$(VPATH)}internal/event.h

--- a/gc.c
+++ b/gc.c
@@ -618,6 +618,8 @@ typedef struct gc_function_map {
     void (*gc_enable)(void *objspace_ptr);
     void (*gc_disable)(void *objspace_ptr, bool finish_current_gc);
     bool (*gc_enabled_p)(void *objspace_ptr);
+    VALUE (*config_get)(void *objpace_ptr);
+    VALUE (*config_set)(void *objspace_ptr, VALUE hash);
     void (*stress_set)(void *objspace_ptr, VALUE flag);
     VALUE (*stress_get)(void *objspace_ptr);
     // Object allocation
@@ -747,6 +749,8 @@ ruby_external_gc_init(void)
     load_external_gc_func(gc_enable);
     load_external_gc_func(gc_disable);
     load_external_gc_func(gc_enabled_p);
+    load_external_gc_func(config_set);
+    load_external_gc_func(config_get);
     load_external_gc_func(stress_set);
     load_external_gc_func(stress_get);
     // Object allocation
@@ -824,6 +828,8 @@ ruby_external_gc_init(void)
 # define rb_gc_impl_gc_enable rb_gc_functions.gc_enable
 # define rb_gc_impl_gc_disable rb_gc_functions.gc_disable
 # define rb_gc_impl_gc_enabled_p rb_gc_functions.gc_enabled_p
+# define rb_gc_impl_config_get rb_gc_functions.config_get
+# define rb_gc_impl_config_set rb_gc_functions.config_set
 # define rb_gc_impl_stress_set rb_gc_functions.stress_set
 # define rb_gc_impl_stress_get rb_gc_functions.stress_get
 // Object allocation
@@ -3565,6 +3571,18 @@ gc_stat_heap(rb_execution_context_t *ec, VALUE self, VALUE heap_name, VALUE arg)
     else {
         return arg;
     }
+}
+
+static VALUE
+gc_config_get(rb_execution_context_t *ec, VALUE self)
+{
+    return rb_gc_impl_config_get(rb_gc_get_objspace());
+}
+
+static VALUE
+gc_config_set(rb_execution_context_t *ec, VALUE self, VALUE hash)
+{
+    return rb_gc_impl_config_set(rb_gc_get_objspace(), hash);
 }
 
 static VALUE

--- a/gc.rb
+++ b/gc.rb
@@ -259,18 +259,50 @@ module GC
   #
   # Sets or gets information about the current GC config.
   #
-  # The contents of the hash are implementation specific and may change in
-  # the future without notice.
+  # Configuration parameters are GC implementation specific and may change
+  # without notice.
   #
-  # If the optional argument, hash, is given, it is overwritten and returned.
+  # This method can be called without parameters to retrieve the current config.
+  #
+  # This method can also be called with a +Hash+ argument to assign values to
+  # valid config keys. Config keys missing from the passed +Hash+ will be left
+  # unmodified.
+  #
+  # If a key/value pair is passed to this function that does not correspond to
+  # a valid config key for the GC implementation being used, no config will be
+  # updated, the key will be present in the returned Hash, and it's value will
+  # be +nil+. This is to facilitate easy migration between GC implementations.
+  #
+  # In both call-seqs the return value of <code>GC.config</code> will be a +Hash+
+  # containing the most recent full configuration. ie. All keys and values
+  # defined by the specific GC implementation being used. In the case of a
+  # config update, the return value will include the new values being updated.
   #
   # This method is only expected to work on CRuby.
   #
-  # The hash includes the following keys about the internal information in
-  # the \GC:
+  # Valid config keys for Ruby's default GC implementation are:
   #
-  # [slot_size]
-  #   The slot size of the heap in bytes.
+  # [rgengc_allow_full_mark]
+  #   Control whether the GC is allowed to run a full mark (young & old objects).
+  #
+  #   When +true+ GC interleaves major and minor collections. This is default. GC
+  #   will function as intended.
+  #
+  #   When +false+, the GC will never trigger a full marking cycle unless
+  #   explicitly requested by user code. Instead only a minor mark will run -
+  #   only young objects will be marked. When the heap space is exhausted, new
+  #   pages will be allocated immediately instead of running a full mark.
+  #
+  #   A flag will be set to notify that a full mark has been
+  #   requested. This flag is accessible using
+  #   <code>GC.latest_gc_info(:needs_major_by)</code>
+  #
+  #   The user can trigger a major collection at any time using
+  #   <code>GC.start(full_mark: true)</code>
+  #
+  #   When +false+. Young to Old object promotion is disabled. For performance
+  #   reasons it is recommended to warmup an application using +Process.warmup+
+  #   before setting this parameter to +false+.
   def self.config hash = nil
     return Primitive.gc_config_get unless hash
 

--- a/gc.rb
+++ b/gc.rb
@@ -254,6 +254,30 @@ module GC
   end
 
   # call-seq:
+  #     GC.config -> hash
+  #     GC.config(hash) -> hash
+  #
+  # Sets or gets information about the current GC config.
+  #
+  # The contents of the hash are implementation specific and may change in
+  # the future without notice.
+  #
+  # If the optional argument, hash, is given, it is overwritten and returned.
+  #
+  # This method is only expected to work on CRuby.
+  #
+  # The hash includes the following keys about the internal information in
+  # the \GC:
+  #
+  # [slot_size]
+  #   The slot size of the heap in bytes.
+  def self.config hash = nil
+    return Primitive.gc_config_get unless hash
+
+    Primitive.gc_config_set hash
+  end
+
+  # call-seq:
   #     GC.latest_gc_info -> hash
   #     GC.latest_gc_info(hash) -> hash
   #     GC.latest_gc_info(:major_by) -> :malloc

--- a/gc/default.c
+++ b/gc/default.c
@@ -12,7 +12,6 @@
 # include <sys/user.h>
 #endif
 
-#include "internal/string.h"
 #include "internal/hash.h"
 
 #include "ruby/ruby.h"
@@ -8081,7 +8080,7 @@ static int
 gc_config_set_key(st_data_t key, st_data_t value, st_data_t data)
 {
     rb_objspace_t *objspace = (rb_objspace_t *)data;
-    if (!strcmp(rb_str_to_cstr(rb_sym2str(key)), "rgengc_allow_full_mark")) {
+    if (rb_sym2id(key) == rb_intern("rgengc_allow_full_mark")) {
         gc_rest(objspace);
         gc_config_full_mark_set(RBOOL(value));
     }

--- a/gc/default.c
+++ b/gc/default.c
@@ -8072,7 +8072,7 @@ rb_gc_impl_config_get(void *objspace_ptr)
     rb_objspace_t *objspace = objspace_ptr;
     VALUE hash = rb_hash_new();
 
-    rb_hash_aset(hash, sym("full_mark"), RBOOL(gc_config_full_mark_val));
+    rb_hash_aset(hash, sym("rgengc_allow_full_mark"), RBOOL(gc_config_full_mark_val));
 
     return hash;
 }
@@ -8081,7 +8081,7 @@ static int
 gc_config_set_key(st_data_t key, st_data_t value, st_data_t data)
 {
     rb_objspace_t *objspace = (rb_objspace_t *)data;
-    if (!strcmp(rb_str_to_cstr(rb_sym2str(key)), "full_mark")) {
+    if (!strcmp(rb_str_to_cstr(rb_sym2str(key)), "rgengc_allow_full_mark")) {
         gc_rest(objspace);
         gc_config_full_mark_set(RBOOL(value));
     }

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -24,6 +24,8 @@ void rb_gc_impl_gc_disable(void *objspace_ptr, bool finish_current_gc);
 bool rb_gc_impl_gc_enabled_p(void *objspace_ptr);
 void rb_gc_impl_stress_set(void *objspace_ptr, VALUE flag);
 VALUE rb_gc_impl_stress_get(void *objspace_ptr);
+VALUE rb_gc_impl_config_get(void *objspace_ptr);
+VALUE rb_gc_impl_config_set(void *objspace_ptr, VALUE hash);
 // Object allocation
 VALUE rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, bool wb_protected, size_t alloc_size);
 size_t rb_gc_impl_obj_slot_size(VALUE obj);
@@ -76,5 +78,6 @@ bool rb_gc_impl_pointer_to_heap_p(void *objspace_ptr, const void *ptr);
 bool rb_gc_impl_garbage_object_p(void *objspace_ptr, VALUE obj);
 void rb_gc_impl_set_event_hook(void *objspace_ptr, const rb_event_flag_t event);
 void rb_gc_impl_copy_attributes(void *objspace_ptr, VALUE dest, VALUE obj);
+
 
 #endif

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -57,7 +57,7 @@ class TestGc < Test::Unit::TestCase
 
     config = GC.config
     assert_not_empty(config)
-    assert_true(config[:full_mark])
+    assert_true(config[:rgengc_allow_full_mark])
   end
 
   def test_gc_config_invalid_args
@@ -69,13 +69,13 @@ class TestGc < Test::Unit::TestCase
   def test_gc_config_setting_returns_updated_config_hash
     omit "unsupoported platform/GC" unless defined?(GC.config)
 
-    old_value = GC.config[:full_mark]
+    old_value = GC.config[:rgengc_allow_full_mark]
     assert_true(old_value)
 
-    new_value = GC.config(full_mark: false)[:full_mark]
+    new_value = GC.config(rgengc_allow_full_mark: false)[:rgengc_allow_full_mark]
     assert_false(new_value)
   ensure
-    GC.config(full_mark: true)
+    GC.config(rgengc_allow_full_mark: true)
     GC.start
   end
 
@@ -95,7 +95,7 @@ class TestGc < Test::Unit::TestCase
     GC.enable
     GC.start
 
-    GC.config(full_mark: false)
+    GC.config(rgengc_allow_full_mark: false)
     major_count = GC.stat[:major_gc_count]
     minor_count = GC.stat[:minor_gc_count]
 
@@ -109,7 +109,7 @@ class TestGc < Test::Unit::TestCase
     assert_operator(minor_count, :<=, GC.stat[:minor_gc_count])
     assert_nil(GC.start)
   ensure
-    GC.config(full_mark: true)
+    GC.config(rgengc_allow_full_mark: true)
     GC.start
   end
 


### PR DESCRIPTION
## Background

Ruby's GC running during Rails requests can have negative impacts on currently running requests, causing applications to have high tail-latency.

A technique to mitigate this high tail-latency is Out-of-band GC (OOBGC). This is basically where the application is run with GC disabled, and then GC is explicitly started after each request, or when no requests are in progress.

This can reduce the tail latency, but also introduces problems of its own. Long GC pauses after each request reduce throughput. This is more pronounced on threading servers like Puma because all the threads have to finish processing user requests and be "paused" before OOBGC can be triggered.

This throughput decrease happens for a couple of reasons:

1. There are few heuristics available for users to determine when GC should run, this means that in OOBGC scenarios, it's possible that major GC's are being run more than necessary.
2. The lack of any GC during a request means that lots of garbage objects have been created and not cleaned up, so the process is using more memory than it should - requiring major GC's run as part of OOBGC to do more work and therefore take more time.

This ticket attempts to address these issues by providing a way of disabling automatic major collections entirely, allowing the user to control exactly when they run, according to the heuristics exposed by the GC.

These ideas were originally proposed by @ko1 and @byroot in [this rails issue](https://github.com/rails/rails/issues/50449) 

Disabling GC major's would still allow minor GC's to run during the request, avoiding the ballooning memory usage caused by not running GC at all, and reducing the time that a major takes when we do run it, because the nursery objects have been cleaned up during the request already so there is less work for a major GC to do.

## Implementation

This feature provides a new method `GC.config` that configures internal GC configuration variables provided by an individual GC implementation.

Implemented in this PR is the option `full_mark`: a boolean value that will determine whether the Ruby GC is allowed to run a major collection while the process is running.

It has the following semantics:

This feature configures Ruby's GC to only run minor GC's. It's designed to give users relying on Out of Band GC complete control over when a major GC is run. Configuring `full_mark: false` does two main things:

* Never runs a Major GC. When the heap runs out of space during a minor and when a major would traditionally be run, instead we allocate more heap pages, and mark objspace as needing a major GC.
* Don't increment object ages. We don't promote objects during GC, this will cause every object to be scanned on every minor. This is an intentional trade-off between minor GC's doing more work every time, and potentially promoting objects that will then never be GC'd.

The intention behind not aging objects is that users of this feature should use a preforking web server, or some other method of pre-warming the oldgen (like Nakayoshi fork)before disabling Majors. That way most objects that are going to be old will have already been promoted.

This will interleave major and minor GC collections in exactly the same what that the Ruby GC runs in versions previously to this. This is the default behaviour.

* This new method has the following extra semantics:

  - `GC.config` with no arguments returns a hash of the keys of the currently configured GC
  - `GC.config` with a key pair (eg. `GC.config(full_mark: true)` sets the matching config key to the corresponding value and returns the entire known config hash, including the new values. If the key does not exist, `nil` is returned

* When a minor GC is run, Ruby sets an internal status flag to determine whether the next GC will be a major or a minor. When `full_mark: false` this flag is ignored and every GC will be a minor.

This status flag can be accessed at `GC.latest_gc_info(:needs_major_by)`. Any value other than `nil` means that the next collection would have been a major.

Thus it's possible to use this feature to check at a predetermined time, whether a major GC is necessary and run one if it is. eg. After a request has finished processing.

```ruby
  if GC.latest_gc_info(:needs_major_by)
    GC.start(full_mark: true)
  end
```

Because object aging is disabled when majors are disabled it is recommended to use this in conjunction with `Process.warmup`, which will prepare the heap by running a major GC, compacting the heap, and promoting every remaining object to old-gen. This ensures that minor GC's are running over the smallets possible set of young objects when `GC.disable_major` is true.

## Benchmarks

We ran some tests in production on Shopify's core monolith over a weekend and found that:

**Mean time spent in GC, as well as p99.9 and p99.99 GC times are all improved.**
<img width="935" alt="Screenshot 2024-04-22 at 16 41 49" src="https://github.com/ruby/ruby/assets/31869/6cff5b11-2e21-40c1-bb84-d994e0e1798d">

**p99 GC time is slightly higher.**
<img width="929" alt="Screenshot 2024-04-22 at 16 44 55" src="https://github.com/ruby/ruby/assets/31869/dc645cbe-9495-46f0-8485-24e790c42f32">

We're running far fewer OOBGC major GC's now that we have `GC.needs_major?` than we were before, and we believe that this is contributing to a slightly increased number of minor GC's. raising the p99 slightly.

**App response times are all improved**

We see a 9% reduction in average and p99 response times when compared against standard GC (4% p99.9 and p99.99).

<img width="1888" alt="Screenshot 2024-04-22 at 16 55 53" src="https://github.com/ruby/ruby/assets/31869/8a80c102-1564-4bc9-ba44-6e9a8b85f971">


This drops slightly to an 8% reduction in average and p99 response times when compared against standard OOBGC (3.59 p99.9 and 4% p99.99)

<img width="1893" alt="Screenshot 2024-04-22 at 16 56 10" src="https://github.com/ruby/ruby/assets/31869/1baef7ea-0155-4ff9-8ba4-a967b75749fe">




