### PR TITLE
Move encoding object conversion outside of parser

### DIFF
--- a/ext/ripper/ripper_init.c.tmpl
+++ b/ext/ripper/ripper_init.c.tmpl
@@ -188,7 +188,7 @@ ripper_parser_encoding(VALUE vparser)
 {
     struct parser_params *p = ripper_parser_params(vparser, false);
 
-    return rb_ruby_parser_encoding(p);
+    return rb_enc_from_encoding(rb_ruby_parser_encoding(p));
 }
 
 /*

--- a/internal/parse.h
+++ b/internal/parse.h
@@ -59,7 +59,7 @@ rb_ast_t *rb_parser_compile(rb_parser_t *p, rb_parser_lex_gets_func *gets, VALUE
 
 RUBY_SYMBOL_EXPORT_BEGIN
 
-VALUE rb_ruby_parser_encoding(rb_parser_t *p);
+rb_encoding *rb_ruby_parser_encoding(rb_parser_t *p);
 int rb_ruby_parser_end_seen_p(rb_parser_t *p);
 int rb_ruby_parser_set_yydebug(rb_parser_t *p, int flag);
 rb_parser_string_t *rb_str_to_parser_string(rb_parser_t *p, VALUE str);

--- a/parse.y
+++ b/parse.y
@@ -15953,10 +15953,10 @@ rb_ruby_parser_keep_tokens(rb_parser_t *p)
     p->tokens = rb_parser_ary_new_capa_for_ast_token(p, 10);
 }
 
-VALUE
+rb_encoding *
 rb_ruby_parser_encoding(rb_parser_t *p)
 {
-    return rb_enc_from_encoding(p->enc);
+    return p->enc;
 }
 
 int

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -184,12 +184,6 @@ intern3(const char *name, long len, void *enc)
     return rb_intern3(name, len, (rb_encoding *)enc);
 }
 
-static VALUE
-enc_from_encoding(void *enc)
-{
-    return rb_enc_from_encoding((rb_encoding *)enc);
-}
-
 static int
 encoding_is_ascii8bit(VALUE obj)
 {
@@ -436,7 +430,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .enc_isspace = enc_isspace,
     .enc_coderange_7bit = ENC_CODERANGE_7BIT,
     .enc_coderange_unknown = ENC_CODERANGE_UNKNOWN,
-    .enc_from_encoding = enc_from_encoding,
     .encoding_is_ascii8bit = encoding_is_ascii8bit,
     .usascii_encoding = usascii_encoding,
     .enc_coderange_broken = ENC_CODERANGE_BROKEN,

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -827,7 +827,7 @@ rb_parser_encoding(VALUE vparser)
     struct ruby_parser *parser;
 
     TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
-    return rb_ruby_parser_encoding(parser->parser_params);
+    return rb_enc_from_encoding(rb_ruby_parser_encoding(parser->parser_params));
 }
 
 VALUE

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1340,7 +1340,6 @@ typedef struct rb_parser_config_struct {
     int (*enc_find_index)(const char *name);
     rb_encoding *(*enc_from_index)(int idx);
     int (*enc_isspace)(OnigCodePoint c, rb_encoding *enc);
-    VALUE (*enc_from_encoding)(rb_encoding *enc);
     int (*encoding_is_ascii8bit)(VALUE obj);
     rb_encoding *(*usascii_encoding)(void);
     int enc_coderange_broken;

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -173,7 +173,6 @@
 #define rb_enc_isspace          p->config->enc_isspace
 #define ENC_CODERANGE_7BIT      p->config->enc_coderange_7bit
 #define ENC_CODERANGE_UNKNOWN   p->config->enc_coderange_unknown
-#define rb_enc_from_encoding    p->config->enc_from_encoding
 #define ENCODING_IS_ASCII8BIT   p->config->encoding_is_ascii8bit
 #define rb_usascii_encoding     p->config->usascii_encoding
 


### PR DESCRIPTION
Reduce the parser's dependence on `VALUE` and `rb_enc_from_encoding`.