### PR TITLE
Fixes [Bug #20449]

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -2218,7 +2218,7 @@ lhs		: user_variable
 		    /*%%%*/
 			$$ = attrset(p, $1, idCOLON2, $3, &@$);
 		    /*% %*/
-		    /*% ripper: field!($1, idCOLON2, $3) %*/
+		    /*% ripper: field!($1, $2, $3) %*/
 		    }
 		| primary_value call_op tCONSTANT
 		    {

--- a/test/ripper/test_parser_events.rb
+++ b/test/ripper/test_parser_events.rb
@@ -474,8 +474,8 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
       end
     end
 
-    parser = DummyParser.new("a::b").extend(hook)
-    assert_equal '[call(vcall((ident: "a")),(method: (op: "::")),(ident: "b"))]', parser.parse.to_s
+    assert_equal '[call(vcall((ident: "a")),(method: (op: "::")),(ident: "b"))]', DummyParser.new("a::b").extend(hook).parse.to_s
+    assert_equal '[assign(field(vcall((ident: "a")),(op: "::"),(ident: "b")),1)]', DummyParser.new("a::b = 1").extend(hook).parse.to_s
   end
 
   def test_excessed_comma


### PR DESCRIPTION
Bisecting between 3.1.4 and 3.1.5 showed that https://bugs.ruby-lang.org/issues/20449 was introduced here https://github.com/ruby/ruby/commit/4153e807c55ec0fc234969ae08a01c1e0c8ed167

As far as I can tell, this issue only affect Ruby 3.1.5