### PR TITLE
Add ruby_mimcalloc

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -2569,11 +2569,10 @@ rb_fiber_start(rb_fiber_t *fiber)
 void
 rb_threadptr_root_fiber_setup(rb_thread_t *th)
 {
-    rb_fiber_t *fiber = ruby_mimmalloc(sizeof(rb_fiber_t));
+    rb_fiber_t *fiber = ruby_mimcalloc(1, sizeof(rb_fiber_t));
     if (!fiber) {
         rb_bug("%s", strerror(errno)); /* ... is it possible to call rb_bug here? */
     }
-    MEMZERO(fiber, rb_fiber_t, 1);
     fiber->cont.type = FIBER_CONTEXT;
     fiber->cont.saved_ec.fiber_ptr = fiber;
     fiber->cont.saved_ec.thread_ptr = th;

--- a/gc.c
+++ b/gc.c
@@ -12355,6 +12355,34 @@ ruby_mimmalloc(size_t size)
     return mem;
 }
 
+void *
+ruby_mimcalloc(size_t num, size_t size)
+{
+    void *mem;
+#if CALC_EXACT_MALLOC_SIZE
+    size += sizeof(struct malloc_obj_info);
+#endif
+    mem = calloc(num, size);
+#if CALC_EXACT_MALLOC_SIZE
+    if (!mem) {
+        return NULL;
+    }
+    else
+    /* set 0 for consistency of allocated_size/allocations */
+    {
+        struct malloc_obj_info *info = mem;
+        info->size = 0;
+#if USE_GC_MALLOC_OBJ_INFO_DETAILS
+        info->gen = 0;
+        info->file = NULL;
+        info->line = 0;
+#endif
+        mem = info + 1;
+    }
+#endif
+    return mem;
+}
+
 void
 ruby_mimfree(void *ptr)
 {

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -193,6 +193,7 @@ typedef struct ractor_newobj_cache {
 /* gc.c */
 extern int ruby_disable_gc;
 RUBY_ATTR_MALLOC void *ruby_mimmalloc(size_t size);
+RUBY_ATTR_MALLOC void *ruby_mimcalloc(size_t num, size_t size);
 void ruby_mimfree(void *ptr);
 void rb_gc_prepare_heap(void);
 void rb_objspace_set_event_hook(const rb_event_flag_t event);

--- a/ractor.c
+++ b/ractor.c
@@ -2012,12 +2012,11 @@ ractor_alloc(VALUE klass)
 rb_ractor_t *
 rb_ractor_main_alloc(void)
 {
-    rb_ractor_t *r = ruby_mimmalloc(sizeof(rb_ractor_t));
+    rb_ractor_t *r = ruby_mimcalloc(1, sizeof(rb_ractor_t));
     if (r == NULL) {
         fprintf(stderr, "[FATAL] failed to allocate memory for main ractor\n");
         exit(EXIT_FAILURE);
     }
-    MEMZERO(r, rb_ractor_t, 1);
     r->pub.id = ++ractor_last_id;
     r->loc = Qnil;
     r->name = Qnil;

--- a/shape.c
+++ b/shape.c
@@ -1213,8 +1213,7 @@ rb_shape_find_by_id(VALUE mod, VALUE id)
 void
 Init_default_shapes(void)
 {
-    rb_shape_tree_t *st = ruby_mimmalloc(sizeof(rb_shape_tree_t));
-    memset(st, 0, sizeof(rb_shape_tree_t));
+    rb_shape_tree_t *st = ruby_mimcalloc(1, sizeof(rb_shape_tree_t));
     rb_shape_tree_ptr = st;
 
 #ifdef HAVE_MMAP

--- a/vm.c
+++ b/vm.c
@@ -3301,7 +3301,6 @@ vm_default_params_setup(rb_vm_t *vm)
 static void
 vm_init2(rb_vm_t *vm)
 {
-    MEMZERO(vm, rb_vm_t, 1);
     rb_vm_living_threads_init(vm);
     vm->thread_report_on_exception = 1;
     vm->src_encoding_index = -1;
@@ -4237,15 +4236,14 @@ void
 Init_BareVM(void)
 {
     /* VM bootstrap: phase 1 */
-    rb_vm_t * vm = ruby_mimmalloc(sizeof(*vm));
-    rb_thread_t * th = ruby_mimmalloc(sizeof(*th));
+    rb_vm_t *vm = ruby_mimcalloc(1, sizeof(*vm));
+    rb_thread_t *th = ruby_mimcalloc(1, sizeof(*th));
     if (!vm || !th) {
         fputs("[FATAL] failed to allocate memory\n", stderr);
         exit(EXIT_FAILURE);
     }
 
     // setup the VM
-    MEMZERO(th, rb_thread_t, 1);
     vm_init2(vm);
 
     rb_vm_postponed_job_queue_init(vm);


### PR DESCRIPTION
Many places call ruby_mimmalloc then MEMZERO. This can be reduced by using ruby_mimcalloc instead.