### PR TITLE
YJIT: Add a specialized codegen function for `Class#superclass`.

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4816,3 +4816,19 @@ assert_equal "abc", %q{
   change_bytes(str, to_int_1, to_int_99)
   str
 }
+
+assert_equal '["raised", "Module", "Object"]', %q{
+  def foo(obj)
+    obj.superclass.name
+  end
+
+  ret = []
+
+  begin
+    foo(Class.allocate)
+  rescue TypeError
+    ret << 'raised'
+  end
+
+  ret += [foo(Class), foo(Class.new)]
+}

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -174,6 +174,7 @@ fn main() {
         .allowlist_var("rb_cThread")
         .allowlist_var("rb_cArray")
         .allowlist_var("rb_cHash")
+        .allowlist_var("rb_cClass")
 
         // From include/ruby/internal/fl_type.h
         .allowlist_type("ruby_fl_type")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -962,6 +962,7 @@ extern "C" {
     pub static mut rb_mKernel: VALUE;
     pub static mut rb_cBasicObject: VALUE;
     pub static mut rb_cArray: VALUE;
+    pub static mut rb_cClass: VALUE;
     pub static mut rb_cFalseClass: VALUE;
     pub static mut rb_cFloat: VALUE;
     pub static mut rb_cHash: VALUE;


### PR DESCRIPTION
Looking at results of running _yjit-bench_ on the _lobsters_ benchmark, `Class#superclass` ends up in the top 10 most frequent C calls. This PR optimizes those calls by adding a new specialized codegen function.