### PR TITLE
Skip test_session_reuse_but_expire with OpenSSL 3.3

### DIFF
--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -168,6 +168,7 @@ class TestNetHTTPS < Test::Unit::TestCase
     # FIXME: The new_session_cb is known broken for clients in OpenSSL 1.1.0h.
     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 1.1.0h')
     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.2.')
+    omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.3.')
 
     http = Net::HTTP.new(HOST, config("port"))
     http.use_ssl = true


### PR DESCRIPTION
OpenSSL 3.3.0 9 Apr 2024 is also broken.