### PR TITLE
Fix dllimport warnings

### DIFF
--- a/ext/-test-/load/resolve_symbol_target/resolve_symbol_target.h
+++ b/ext/-test-/load/resolve_symbol_target/resolve_symbol_target.h
@@ -1,4 +1,4 @@
 #include <ruby.h>
 #include "ruby/internal/dllexport.h"
 
-RUBY_EXTERN VALUE rst_any_method(VALUE);
+RUBY_FUNC_EXPORTED VALUE rst_any_method(VALUE);

--- a/ext/-test-/load/stringify_target/stringify_target.h
+++ b/ext/-test-/load/stringify_target/stringify_target.h
@@ -1,4 +1,4 @@
 #include <ruby.h>
 #include "ruby/internal/dllexport.h"
 
-RUBY_EXTERN VALUE stt_any_method(VALUE);
+RUBY_FUNC_EXPORTED VALUE stt_any_method(VALUE);


### PR DESCRIPTION
From Visual C:
```
../../../../../src/ext/-test-/load/resolve_symbol_target/resolve_symbol_target.c(5): warning C4273: 'rst_any_method': inconsistent dll linkage
D:\a\ruby\ruby\src\ext\-test-\load\resolve_symbol_target\resolve_symbol_target.h(4): note: see previous definition of 'rst_any_method'
../../../../../src/ext/-test-/load/stringify_target/stringify_target.c(5): warning C4273: 'stt_any_method': inconsistent dll linkage
D:\a\ruby\ruby\src\ext\-test-\load\stringify_target\stringify_target.h(4): note: see previous definition of 'stt_any_method'
```

From MinGW gcc:
```
../../../../../src/ext/-test-/load/resolve_symbol_target/resolve_symbol_target.c:5:1: warning: 'rst_any_method' redeclared without dllimport attribute: previous dllimport ignored [-Wattributes]
compiling ../../../../../src/ext/-test-/marshal/compat/usrcompat.c
    5 | rst_any_method(VALUE klass)
      | ^~~~~~~~~~~~~~
../../../../../src/ext/-test-/load/stringify_target/stringify_target.c:5:1: warning: 'stt_any_method' redeclared without dllimport attribute: previous dllimport ignored [-Wattributes]
    5 | stt_any_method(VALUE klass)
      | ^~~~~~~~~~~~~~
```