### PR TITLE
[Bug #20450] Remove rubyarchdir from bootsnap paths

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -101,8 +101,11 @@ module Gem::BUNDLED_GEMS
   def self.warning?(name, specs: nil)
     # name can be a feature name or a file path with String or Pathname
     feature = File.path(name)
-    # bootsnap expand `require "csv"` to `require "#{LIBDIR}/csv.rb"`
-    name = feature.delete_prefix(LIBDIR).chomp(".rb").tr("/", "-")
+    # bootsnap expands `require "csv"` to `require "#{LIBDIR}/csv.rb"`,
+    # and `require "syslog"` to `require "#{ARCHDIR}/syslog.so"`.
+    name = feature.delete_prefix(ARCHDIR)
+    name.delete_prefix!(LIBDIR)
+    name.tr!("/", "-")
     name.sub!(LIBEXT, "")
     return if specs.include?(name)
     _t, path = $:.resolve_feature_path(feature)

--- a/tool/test_for_warn_bundled_gems/test.sh
+++ b/tool/test_for_warn_bundled_gems/test.sh
@@ -32,6 +32,10 @@ echo "* Show warning with bootsnap"
 ruby test_warn_bootsnap.rb
 echo
 
+echo "* Show warning with bootsnap for gem with native extension"
+ruby test_warn_bootsnap_rubyarchdir_gem.rb
+echo
+
 echo "* Show warning with zeitwerk"
 ruby test_warn_zeitwerk.rb
 echo

--- a/tool/test_for_warn_bundled_gems/test_warn_bootsnap_rubyarchdir_gem.rb
+++ b/tool/test_for_warn_bundled_gems/test_warn_bootsnap_rubyarchdir_gem.rb
@@ -1,0 +1,11 @@
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "bootsnap", require: false
+end
+
+require 'bootsnap'
+Bootsnap.setup(cache_dir: 'tmp/cache')
+
+require 'syslog'


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20450

See also https://github.com/ruby/ruby/pull/10347#issuecomment-2073591775.