### PR TITLE
We don't need to check if the ci is markable anymore

### DIFF
--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -240,21 +240,6 @@ vm_ci_new_runtime_(ID mid, unsigned int flag, unsigned int argc, const struct rb
 
 #define VM_CALLINFO_NOT_UNDER_GC IMEMO_FL_USER0
 
-static inline bool
-vm_ci_markable(const struct rb_callinfo *ci)
-{
-    if (! ci) {
-        return false; /* or true? This is Qfalse... */
-    }
-    else if (vm_ci_packed_p(ci)) {
-        return true;
-    }
-    else {
-        VM_ASSERT(IMEMO_TYPE_P(ci, imemo_callinfo));
-        return ! FL_ANY_RAW((VALUE)ci, VM_CALLINFO_NOT_UNDER_GC);
-    }
-}
-
 #define VM_CI_ON_STACK(mid_, flags_, argc_, kwarg_) \
     (struct rb_callinfo) {                          \
         .flags = T_IMEMO |                          \

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3036,7 +3036,6 @@ vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling,
 {
     const struct rb_callinfo *ci = calling->cd->ci;
     const struct rb_callcache *cc = calling->cc;
-    bool cacheable_ci = vm_ci_markable(ci);
 
     if (UNLIKELY(!ISEQ_BODY(iseq)->param.flags.use_block &&
                  calling->block_handler != VM_BLOCK_HANDLER_NONE &&
@@ -3057,7 +3056,7 @@ vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling,
             VM_ASSERT(ci == calling->cd->ci);
             VM_ASSERT(cc == calling->cc);
 
-            if (cacheable_ci && vm_call_iseq_optimizable_p(ci, cc)) {
+            if (vm_call_iseq_optimizable_p(ci, cc)) {
                 if ((iseq->body->builtin_attrs & BUILTIN_ATTR_SINGLE_NOARG_LEAF) &&
                     !(ruby_vm_event_flags & (RUBY_EVENT_C_CALL | RUBY_EVENT_C_RETURN))) {
                     VM_ASSERT(iseq->body->builtin_attrs & BUILTIN_ATTR_LEAF);
@@ -3087,12 +3086,12 @@ vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling,
             if (LIKELY(!(vm_ci_flag(ci) & VM_CALL_TAILCALL))) {
                 CC_SET_FASTPATH(cc, vm_call_iseq_setup_normal_opt_start,
                                 !IS_ARGS_SPLAT(ci) && !IS_ARGS_KEYWORD(ci) &&
-                                cacheable_ci && vm_call_cacheable(ci, cc));
+                                vm_call_cacheable(ci, cc));
             }
             else {
                 CC_SET_FASTPATH(cc, vm_call_iseq_setup_tailcall_opt_start,
                                 !IS_ARGS_SPLAT(ci) && !IS_ARGS_KEYWORD(ci) &&
-                                cacheable_ci && vm_call_cacheable(ci, cc));
+                                vm_call_cacheable(ci, cc));
             }
 
             /* initialize opt vars for self-references */
@@ -3120,7 +3119,7 @@ vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling,
                     args_setup_kw_parameters(ec, iseq, ci_kws, ci_kw_len, ci_keywords, klocals);
 
                     CC_SET_FASTPATH(cc, vm_call_iseq_setup_kwparm_kwarg,
-                                    cacheable_ci && vm_call_cacheable(ci, cc));
+                                    vm_call_cacheable(ci, cc));
 
                     return 0;
                 }
@@ -3133,7 +3132,7 @@ vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling,
                 if (klocals[kw_param->num] == INT2FIX(0)) {
                     /* copy from default_values */
                     CC_SET_FASTPATH(cc, vm_call_iseq_setup_kwparm_nokwarg,
-                                    cacheable_ci && vm_call_cacheable(ci, cc));
+                                    vm_call_cacheable(ci, cc));
                 }
 
                 return 0;

--- a/vm_method.c
+++ b/vm_method.c
@@ -427,7 +427,6 @@ rb_vm_ci_lookup(ID mid, unsigned int flag, unsigned int argc, const struct rb_ca
     RB_VM_LOCK_LEAVE();
 
     VM_ASSERT(ci);
-    VM_ASSERT(vm_ci_markable(ci));
 
     return ci;
 }


### PR DESCRIPTION
It doesn't matter if CI's are stack allocated or not.