### PR TITLE
Change return value of `gets` function to be `rb_parser_string_t *` instead of `VALUE`

### DIFF
--- a/ext/ripper/ripper_init.c.tmpl
+++ b/ext/ripper/ripper_init.c.tmpl
@@ -78,17 +78,18 @@ static const rb_data_type_t parser_data_type = {
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 
-static VALUE
+static rb_parser_string_t *
 ripper_lex_get_generic(struct parser_params *p, rb_parser_input_data input, int line_count)
 {
     VALUE src = (VALUE)input;
     VALUE line = rb_funcallv_public(src, id_gets, 0, 0);
-    if (!NIL_P(line) && !RB_TYPE_P(line, T_STRING)) {
+    if (NIL_P(line)) return 0;
+    if (!RB_TYPE_P(line, T_STRING)) {
         rb_raise(rb_eTypeError,
                  "gets returned %"PRIsVALUE" (expected String or nil)",
                  rb_obj_class(line));
     }
-    return line;
+    return rb_str_to_parser_string(p, line);
 }
 
 void
@@ -104,17 +105,19 @@ ripper_compile_error(struct parser_params *p, const char *fmt, ...)
     ripper_error(p);
 }
 
-static VALUE
+static rb_parser_string_t *
 ripper_lex_io_get(struct parser_params *p, rb_parser_input_data input, int line_count)
 {
     VALUE src = (VALUE)input;
-    return rb_io_gets(src);
+    VALUE line = rb_io_gets(src);
+    if (NIL_P(line)) return 0;
+    return rb_str_to_parser_string(p, line);
 }
 
-static VALUE
+static rb_parser_string_t *
 ripper_lex_get_str(struct parser_params *p, rb_parser_input_data input, int line_count)
 {
-    return rb_parser_lex_get_str((struct lex_pointer_string *)input);
+    return rb_parser_lex_get_str(p, (struct lex_pointer_string *)input);
 }
 
 static VALUE

--- a/internal/parse.h
+++ b/internal/parse.h
@@ -54,7 +54,7 @@ rb_parser_t *rb_ruby_parser_set_context(rb_parser_t *p, const struct rb_iseq_str
 void rb_ruby_parser_set_script_lines(rb_parser_t *p);
 void rb_ruby_parser_error_tolerant(rb_parser_t *p);
 void rb_ruby_parser_keep_tokens(rb_parser_t *p);
-typedef VALUE (rb_parser_lex_gets_func)(struct parser_params*, rb_parser_input_data, int);
+typedef rb_parser_string_t*(rb_parser_lex_gets_func)(struct parser_params*, rb_parser_input_data, int);
 rb_ast_t *rb_parser_compile(rb_parser_t *p, rb_parser_lex_gets_func *gets, const char *fname_ptr, long fname_len, rb_encoding *fname_enc, rb_parser_input_data input, int line);
 
 RUBY_SYMBOL_EXPORT_BEGIN

--- a/internal/ruby_parser.h
+++ b/internal/ruby_parser.h
@@ -25,7 +25,7 @@ VALUE rb_parser_new(void);
 VALUE rb_parser_compile_string_path(VALUE vparser, VALUE fname, VALUE src, int line);
 VALUE rb_str_new_parser_string(rb_parser_string_t *str);
 VALUE rb_str_new_mutable_parser_string(rb_parser_string_t *str);
-VALUE rb_parser_lex_get_str(struct lex_pointer_string *ptr_str);
+rb_parser_string_t *rb_parser_lex_get_str(struct parser_params *p, struct lex_pointer_string *ptr_str);
 
 VALUE rb_node_str_string_val(const NODE *);
 VALUE rb_node_sym_string_val(const NODE *);


### PR DESCRIPTION
This change reduces parser's dependency on ruby object.