### PR TITLE
Use fprintf for error message when loading external GC

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1893,10 +1893,11 @@ ruby_external_gc_init()
     char *gc_so_path = getenv("RUBY_GC_LIBRARY_PATH");
     void *handle = NULL;
     if (gc_so_path) {
-        char error[128];
+        char error[1024];
         handle = dln_open(gc_so_path, error, sizeof(error));
         if (!handle) {
-            rb_bug("ruby_external_gc_init: Shared library %s cannot be opened (%s)", gc_so_path, error);
+            fprintf(stderr, "%s", error);
+            rb_bug("ruby_external_gc_init: Shared library %s cannot be opened", gc_so_path);
         }
     }
 


### PR DESCRIPTION
The error message is often long, so using a small buffer could cause it to be truncated. rb_bug also has a 256 byte message buffer, so it could also be truncated.