### PR TITLE
Don't use assert_separately in Bug 20453 test

### DIFF
--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1828,14 +1828,11 @@ class TestRegexp < Test::Unit::TestCase
   end
 
   def test_bug_20453
-    assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
-    begin;
-      Regexp.timeout = 0.001
+    re = Regexp.new("^(a*)x$", timeout: 0.001)
 
-      assert_raise(Regexp::TimeoutError) do
-        /^(a*)x$/ =~ "a" * 1000000 + "x"
-      end
-    end;
+    assert_raise(Regexp::TimeoutError) do
+      re =~ "a" * 1000000 + "x"
+    end
   end
 
   def per_instance_redos_test(global_timeout, per_instance_timeout, expected_timeout)


### PR DESCRIPTION
https://github.com/ruby/ruby/pull/10630#discussion_r1579565056

The PR was merged before I had a chance to address this feedback. `assert_separately` is not necessary for this test if I don't use a global timeout.