### PR TITLE
YJIT: Relax `--yjit-verify-ctx` after singleton class creation

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4830,6 +4830,20 @@ assert_equal "abc", %q{
   str
 }
 
+# test --yjit-verify-ctx for arrays with a singleton class
+assert_equal "ok", %q{
+  class Array
+    def foo
+      self.singleton_class.define_method(:first) { :ok }
+      first
+    end
+  end
+
+  def test = [].foo
+
+  test
+}
+
 assert_equal '["raised", "Module", "Object"]', %q{
   def foo(obj)
     obj.superclass.name

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -53,11 +53,11 @@ pub enum Type {
     ImmSymbol,
 
     TString, // An object with the T_STRING flag set, possibly an rb_cString
-    CString, // An un-subclassed string of type rb_cString (can have instance vars in some cases)
+    CString, // An object that at one point had its class field equal rb_cString (creating a singleton class changes it)
     TArray, // An object with the T_ARRAY flag set, possibly an rb_cArray
-    CArray, // An un-subclassed array of type rb_cArray (can have instance vars in some cases)
+    CArray, // An object that at one point had its class field equal rb_cArray (creating a singleton class changes it)
     THash, // An object with the T_HASH flag set, possibly an rb_cHash
-    CHash, // An un-subclassed hash of type rb_cHash (can have instance vars in some cases)
+    CHash, // An object that at one point had its class field equal rb_cHash (creating a singleton class changes it)
 
     BlockParamProxy, // A special sentinel value indicating the block parameter should be read from
                      // the current surrounding cfp


### PR DESCRIPTION
Types like `Type::CString` really only assert that at one point the object had
its class field equal to `String`. Once a singleton class is created for any
strings, the type makes no assertion about any class field anymore, and becomes
the same as `Type::TString`.

Previously, the `--yjit-verify-ctx` option wasn't allowing objects of these
kind that have have singleton classes to pass verification even though the code
generators handle it just fine.

Found through `ruby/spec`.

---

This stops short of changing the actual type propagation logic, which should be fine but seems scary (and hard to explain).
