### PR TITLE
[Bug #20457] Do not remove final return node

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -14298,7 +14298,7 @@ reduce_nodes(struct parser_params *p, NODE **body)
      (reduce_nodes(p, &type(node)->n1), body = &type(node)->n2, 1))
 
     while (node) {
-        int newline = (int)(nd_fl_newline(node));
+        int newline = (int)nd_fl_newline(node);
         switch (nd_type(node)) {
           end:
           case NODE_NIL:

--- a/parse.y
+++ b/parse.y
@@ -14304,10 +14304,6 @@ reduce_nodes(struct parser_params *p, NODE **body)
           case NODE_NIL:
             *body = 0;
             return;
-          case NODE_RETURN:
-            *body = node = RNODE_RETURN(node)->nd_stts;
-            if (newline && node) nd_set_fl_newline(node);
-            continue;
           case NODE_BEGIN:
             *body = node = RNODE_BEGIN(node)->nd_body;
             if (newline && node) nd_set_fl_newline(node);

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1197,9 +1197,9 @@ typedef struct RNode_ERROR {
 #define NODE_TYPESHIFT 8
 #define NODE_TYPEMASK  (((VALUE)0x7f)<<NODE_TYPESHIFT)
 
-#define nd_fl_newline(n) (n)->flags & NODE_FL_NEWLINE
-#define nd_set_fl_newline(n) (n)->flags |= NODE_FL_NEWLINE
-#define nd_unset_fl_newline(n) (n)->flags &= ~NODE_FL_NEWLINE
+#define nd_fl_newline(n) ((n)->flags & NODE_FL_NEWLINE)
+#define nd_set_fl_newline(n) ((n)->flags |= NODE_FL_NEWLINE)
+#define nd_unset_fl_newline(n) ((n)->flags &= ~NODE_FL_NEWLINE)
 
 #define nd_type(n) ((int) ((RNODE(n)->flags & NODE_TYPEMASK)>>NODE_TYPESHIFT))
 #define nd_set_type(n,t) \

--- a/spec/ruby/core/tracepoint/inspect_spec.rb
+++ b/spec/ruby/core/tracepoint/inspect_spec.rb
@@ -61,6 +61,7 @@ describe 'TracePoint#inspect' do
       end
       trace_point_spec_test_return
     end
+    ruby_version_is("3.4") { line -= 1 }
 
     inspect.should =~ /\A#<TracePoint:return [`']trace_point_spec_test_return'#{@path_prefix}#{__FILE__}:#{line}>\z/
   end

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -696,6 +696,37 @@ class TestAst < Test::Unit::TestCase
     assert_equal(:a, args.children[rest])
   end
 
+  def test_return
+    assert_ast_eqaul(<<~STR, <<~EXP)
+      def m(a)
+        return a
+      end
+    STR
+      (SCOPE@1:0-3:3
+       tbl: []
+       args: nil
+       body:
+         (DEFN@1:0-3:3
+          mid: :m
+          body:
+            (SCOPE@1:0-3:3
+             tbl: [:a]
+             args:
+               (ARGS@1:6-1:7
+                pre_num: 1
+                pre_init: nil
+                opt: nil
+                first_post: nil
+                post_num: 0
+                post_init: nil
+                rest: nil
+                kw: nil
+                kwrest: nil
+                block: nil)
+             body: (RETURN@2:2-2:10 (LVAR@2:9-2:10 :a)))))
+    EXP
+  end
+
   def test_keep_script_lines_for_parse
     node = RubyVM::AbstractSyntaxTree.parse(<<~END, keep_script_lines: true)
 1.times do
@@ -1239,9 +1270,13 @@ dummy
   end
 
   def assert_error_tolerant(src, expected, keep_tokens: false)
+    assert_ast_eqaul(src, expected, error_tolerant: true, keep_tokens: keep_tokens)
+  end
+
+  def assert_ast_eqaul(src, expected, **options)
     begin
       verbose_bak, $VERBOSE = $VERBOSE, false
-      node = RubyVM::AbstractSyntaxTree.parse(src, error_tolerant: true, keep_tokens: keep_tokens)
+      node = RubyVM::AbstractSyntaxTree.parse(src, **options)
     ensure
       $VERBOSE = verbose_bak
     end

--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -232,7 +232,9 @@ class TestSetTraceFunc < Test::Unit::TestCase
                  events.shift)
     assert_equal(["line", 5, :meth_return, self.class],
                  events.shift)
-    assert_equal(["return", 7, :meth_return, self.class],
+    assert_equal(["line", 6, :meth_return, self.class],
+                 events.shift)
+    assert_equal(["return", 6, :meth_return, self.class],
                  events.shift)
     assert_equal(["line", 10, :test_return, self.class],
                  events.shift)
@@ -271,7 +273,7 @@ class TestSetTraceFunc < Test::Unit::TestCase
                  events.shift)
     assert_equal(["line", 6, :meth_return2, self.class],
                  events.shift)
-    assert_equal(["return", 7, :meth_return2, self.class],
+    assert_equal(["return", 6, :meth_return2, self.class],
                  events.shift)
     assert_equal(["line", 9, :test_return2, self.class],
                  events.shift)


### PR DESCRIPTION
This was an optimization for versions prior to 1.9 that traverse the AST at runtime.