### PR TITLE
Set `SCRIPT_LINES__` outside of parser

### DIFF
--- a/internal/ruby_parser.h
+++ b/internal/ruby_parser.h
@@ -46,7 +46,6 @@ VALUE rb_parser_end_seen_p(VALUE);
 VALUE rb_parser_encoding(VALUE);
 VALUE rb_parser_set_yydebug(VALUE, VALUE);
 VALUE rb_parser_build_script_lines_from(rb_parser_ary_t *script_lines);
-void rb_parser_aset_script_lines_for(VALUE path, rb_parser_ary_t *script_lines);
 void rb_parser_set_options(VALUE, int, int, int, int);
 VALUE rb_parser_load_file(VALUE parser, VALUE name);
 void rb_parser_set_script_lines(VALUE vparser);

--- a/parse.y
+++ b/parse.y
@@ -7722,7 +7722,6 @@ yycompile0(VALUE arg)
     n = yyparse(p);
     RUBY_DTRACE_PARSE_HOOK(END);
 
-    rb_parser_aset_script_lines_for(p->ruby_sourcefile_string, p->debug_lines);
     p->debug_lines = 0;
 
     xfree(p->lex.strterm);


### PR DESCRIPTION
Parser should not depend on functions defiend on "ruby_parser.c".