### PR TITLE
Enable Ruby to run on Windows with frozen string literals

### DIFF
--- a/ext/win32/lib/win32/registry.rb
+++ b/ext/win32/lib/win32/registry.rb
@@ -318,7 +318,7 @@ For detail, see the MSDN[http://msdn.microsoft.com/library/en-us/sysinfo/base/pr
         size = packdw(0)
         name = make_wstr(name)
         check RegQueryValueExW.call(hkey, name, 0, type, 0, size)
-        data = "\0".force_encoding('ASCII-8BIT') * unpackdw(size)
+        data = String.new("\0").force_encoding('ASCII-8BIT') * unpackdw(size)
         check RegQueryValueExW.call(hkey, name, 0, type, data, size)
         [ unpackdw(type), data[0, unpackdw(size)] ]
       end


### PR DESCRIPTION
I'm not sure if it's still advisable but I've been running Sonic Pi with frozen string literals for quite a few years now.

I'm in the process of updating to Ruby 3.3.1 and noticed things wouldn't start as this line in  registry.rb is modifying a string literal directly. This is easily fixed by using String.new.