### PR TITLE
[DOC] Fix a typo in globals.rdoc

### DIFF
--- a/doc/globals.rdoc
+++ b/doc/globals.rdoc
@@ -1,7 +1,7 @@
 = Pre-Defined Global Variables
 
 Some of the pre-defined global variables have synonyms
-that are available via module Engish.
+that are available via module English.
 For each of those, the \English synonym is given.
 
 To use the module:


### PR DESCRIPTION
Noticed this small type while reading the docs.