### PR TITLE
YJIT: Try splitting getlocal/setlocal blocks

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2265,6 +2265,12 @@ fn gen_getlocal_generic(
     ep_offset: u32,
     level: u32,
 ) -> Option<CodegenStatus> {
+    // Start the block with this instruction for EP-escape invalidation
+    if level == 0 && !jit.at_current_insn() {
+        defer_compilation(jit, asm, ocb);
+        return Some(EndBlock);
+    }
+
     let local_opnd = if level == 0 && jit.assume_no_ep_escape(asm, ocb) {
         // Load the local using SP register
         asm.ctx.ep_opnd(-(ep_offset as i32))
@@ -2326,6 +2332,12 @@ fn gen_setlocal_generic(
     ep_offset: u32,
     level: u32,
 ) -> Option<CodegenStatus> {
+    // Start the block with this instruction for EP-escape invalidation
+    if level == 0 && !jit.at_current_insn() {
+        defer_compilation(jit, asm, ocb);
+        return Some(EndBlock);
+    }
+
     let value_type = asm.ctx.get_opnd_type(StackOpnd(0));
 
     // Fallback because of write barrier


### PR DESCRIPTION
After the take-2 PR https://github.com/ruby/ruby/pull/10607, the same symptom ([timeout](https://github.com/ruby/ruby/actions/runs/8839441222/job/24272812243), [nil on stack](https://github.com/ruby/ruby/actions/runs/8851651227/job/24308678802)) has unfortunately happened.

I have a suspicion that the block needs to start with getlocal/setlocal to invalidate them right away. While we isolate send-ish instructions to invalidate them, some unexpected instructions might trigger the invalidation in the same block.

I'll keep investigating this, but I'd like to leave this code in master so that the CI can tell if this theory is relevant.