### PR TITLE
Allow RUBY_GC_LIBRARY_PATH to be set in miniruby

### DIFF
--- a/dln.c
+++ b/dln.c
@@ -76,6 +76,12 @@ void *xrealloc();
 # include <unistd.h>
 #endif
 
+bool
+dln_supported_p(void)
+{
+    return true;
+}
+
 #ifndef dln_loaderror
 static void
 dln_loaderror(const char *format, ...)

--- a/dln.h
+++ b/dln.h
@@ -22,6 +22,7 @@ RUBY_SYMBOL_EXPORT_BEGIN
 #define DLN_FIND_EXTRA_ARG_DECL
 #endif
 
+bool dln_supported_p(void);
 char *dln_find_exe_r(const char*,const char*,char*,size_t DLN_FIND_EXTRA_ARG_DECL);
 char *dln_find_file_r(const char*,const char*,char*,size_t DLN_FIND_EXTRA_ARG_DECL);
 void *dln_load(const char*);

--- a/dmydln.c
+++ b/dmydln.c
@@ -3,6 +3,12 @@
 
 #include "ruby/ruby.h"
 
+bool
+dln_supported_p(void)
+{
+    return false;
+}
+
 NORETURN(void *dln_load(const char *));
 void*
 dln_load(const char *file)

--- a/gc.c
+++ b/gc.c
@@ -1887,12 +1887,14 @@ static void *rb_gc_impl_objspace_alloc(void);
 #if USE_SHARED_GC
 # include "dln.h"
 
+# define RUBY_GC_LIBRARY_PATH "RUBY_GC_LIBRARY_PATH"
+
 void
 ruby_external_gc_init()
 {
-    char *gc_so_path = getenv("RUBY_GC_LIBRARY_PATH");
+    char *gc_so_path = getenv(RUBY_GC_LIBRARY_PATH);
     void *handle = NULL;
-    if (gc_so_path) {
+    if (gc_so_path && dln_supported_p()) {
         char error[1024];
         handle = dln_open(gc_so_path, error, sizeof(error));
         if (!handle) {
@@ -13657,6 +13659,12 @@ rb_gcdebug_remove_stress_to_class(int argc, VALUE *argv, VALUE self)
 void
 Init_GC(void)
 {
+#if USE_SHARED_GC
+    if (getenv(RUBY_GC_LIBRARY_PATH) != NULL && !dln_supported_p()) {
+        rb_warn(RUBY_GC_LIBRARY_PATH " is ignored because this executable file can't load extension libraries");
+    }
+#endif
+
 #undef rb_intern
     malloc_offset = gc_compute_malloc_offset();
 


### PR DESCRIPTION
miniruby is used by tool/runruby.rb, so we need to ensure we don't rb_bug when RUBY_GC_LIBRARY_PATH is set so we can run tests using the make commands. This commit changes it to warn instead.