### PR TITLE
Fixed a value specified for OPT_THREADED_CODE

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -147,9 +147,9 @@ jobs:
           - { name: disable-rubygems,     env: { append_configure: '--disable-rubygems' } }
           - { name: RUBY_DEVEL,           env: { append_configure: '--enable-devel' } }
 
+          - { name: OPT_THREADED_CODE=0,            env: { cppflags: '-DOPT_THREADED_CODE=0' } }
           - { name: OPT_THREADED_CODE=1,            env: { cppflags: '-DOPT_THREADED_CODE=1' } }
           - { name: OPT_THREADED_CODE=2,            env: { cppflags: '-DOPT_THREADED_CODE=2' } }
-          - { name: OPT_THREADED_CODE=3,            env: { cppflags: '-DOPT_THREADED_CODE=3' } }
 
           - { name: NDEBUG,                         env: { cppflags: '-DNDEBUG' } }
           - { name: RUBY_DEBUG,                     env: { cppflags: '-DRUBY_DEBUG' } }


### PR DESCRIPTION
Values defined for OPT_THREADED_CODE are [0,1,2](https://github.com/ruby/ruby/blob/master/vm_opts.h#L40-L42).

However, [1,2,3](https://github.com/ruby/ruby/blob/master/.github/workflows/compilers.yml#L150-L152) are set in workflow. Is this intentional?

It seems that case 3 does not exist, so 0 is specified instead.