### PR TITLE
Remove unnecessary assignment to ast->body.line_count

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -1481,16 +1481,6 @@ rb_binding_add_dynavars(VALUE bindval, rb_binding_t *bind, int dyncount, const I
     tmp_node.nd_args = 0;
 
     VALUE vast = rb_ruby_ast_new(RNODE(&tmp_node));
-    {   /*
-         * TODO:
-         * Assigning -1 to line_count is to maintain the previous code.
-         * However, the author of this patch guesses this code is no longer necessary.
-         * We will try to remove this code in the next commit which is atomically
-         * revertable if the author is wrong.
-         */
-        rb_ast_t *ast = (rb_ast_t *)DATA_PTR(vast);
-        ast->body.line_count = -1;
-    }
 
     if (base_iseq) {
         iseq = rb_iseq_new(vast, ISEQ_BODY(base_iseq)->location.label, path, realpath, base_iseq, ISEQ_TYPE_EVAL);


### PR DESCRIPTION
This patch removes a code that assigns `-1` to `ast->body.line_count` because, at least as of now, it looks not necessary.
I made this commit atomically revertable if I was wrong.

## Relevant commits

- The preparation for this PR: https://github.com/ruby/ruby/pull/10655/files#diff-2af2e7f2e1c28da5e9d99ad117cba1c4dabd8b0bc3081da88e414c55c6aa9549R1484-R1493
- The original commit that introduced the assignment: https://github.com/ruby/ruby/commit/d65f7458bc8b4fa4404c41713cfa1ece5260fc8a