### PR TITLE
[Universal parser] Improve AST structure

### DIFF
--- a/node.h
+++ b/node.h
@@ -39,9 +39,6 @@ struct node_buffer_struct {
     // - location info
     // Array, whose entry is array
     rb_parser_ary_t *tokens;
-#ifdef UNIVERSAL_PARSER
-    const rb_parser_config_t *config;
-#endif
 };
 
 RUBY_SYMBOL_EXPORT_BEGIN

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -758,9 +758,7 @@ static void
 ast_free(void *ptr)
 {
     rb_ast_t *ast = (rb_ast_t *)ptr;
-    if (ast) {
-        rb_ast_free(ast);
-    }
+    rb_ast_free(ast);
 }
 
 static const rb_data_type_t ast_data_type = {
@@ -777,7 +775,12 @@ static VALUE
 ast_alloc(void)
 {
     rb_ast_t *ast;
-    return TypedData_Make_Struct(0, rb_ast_t, &ast_data_type, ast);
+    VALUE vast = TypedData_Make_Struct(0, rb_ast_t, &ast_data_type, ast);
+#ifdef UNIVERSAL_PARSER
+    ast = (rb_ast_t *)DATA_PTR(vast);
+    ast->config = &rb_global_parser_config;
+#endif
+    return vast;
 }
 
 VALUE

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1209,6 +1209,10 @@ typedef struct RNode_ERROR {
 
 typedef struct node_buffer_struct node_buffer_t;
 
+#ifdef UNIVERSAL_PARSER
+typedef struct rb_parser_config_struct rb_parser_config_t;
+#endif
+
 typedef struct rb_ast_body_struct {
     const NODE *root;
     rb_parser_ary_t *script_lines;
@@ -1219,6 +1223,9 @@ typedef struct rb_ast_body_struct {
 typedef struct rb_ast_struct {
     node_buffer_t *node_buffer;
     rb_ast_body_t body;
+#ifdef UNIVERSAL_PARSER
+    const rb_parser_config_t *config;
+#endif
 } rb_ast_t;
 
 


### PR DESCRIPTION
This patch moves `ast->node_buffer->config` to `ast->config` aiming to improve readability of the source.

## Background

We could not add the `config` field to the `rb_ast_t *` before due to the five-word restriction of the IMEMO object. But it is now doable by merging https://github.com/ruby/ruby/pull/10618