### PR TITLE
Remove `ast_new` field from `struct rb_parser_config_struct`

### DIFF
--- a/node.c
+++ b/node.c
@@ -301,8 +301,9 @@ rb_ast_t *
 rb_ast_new(const rb_parser_config_t *config)
 {
     node_buffer_t *nb = rb_node_buffer_new(config);
-    rb_ast_t *ast = config->ast_new(nb);
+    rb_ast_t *ast = (rb_ast_t *)config->calloc(1, sizeof(rb_ast_t));
     ast->config = config;
+    ast->node_buffer = nb;
     return ast;
 }
 #else

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -292,14 +292,6 @@ arg_error(void)
     return rb_eArgError;
 }
 
-static rb_ast_t *
-ast_new(node_buffer_t *nb)
-{
-    rb_ast_t *ast = ruby_xcalloc(1, sizeof(rb_ast_t));
-    ast->node_buffer = nb;
-    return ast;
-}
-
 static VALUE
 static_id2sym(ID id)
 {
@@ -347,8 +339,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .rb_memmove = memmove2,
     .nonempty_memcpy = nonempty_memcpy,
     .xmalloc_mul_add = rb_xmalloc_mul_add,
-
-    .ast_new = ast_new,
 
     .compile_callback = rb_suppress_tracing,
     .reg_named_capture_assign = reg_named_capture_assign,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1255,8 +1255,6 @@ typedef struct rb_parser_config_struct {
     void *(*nonempty_memcpy)(void *dest, const void *src, size_t t, size_t n);
     void *(*xmalloc_mul_add)(size_t x, size_t y, size_t z);
 
-    rb_ast_t *(*ast_new)(node_buffer_t *nb);
-
     // VALUE rb_suppress_tracing(VALUE (*func)(VALUE), VALUE arg);
     VALUE (*compile_callback)(VALUE (*func)(VALUE), VALUE arg);
     NODE *(*reg_named_capture_assign)(struct parser_params* p, VALUE regexp, const rb_code_location_t *loc);


### PR DESCRIPTION
`ast_new` can be embedded into `rb_ast_new`.