### PR TITLE
Use `rb_parser_string_t *` as `ruby_sourcefile_string`

### DIFF
--- a/internal/parse.h
+++ b/internal/parse.h
@@ -55,7 +55,7 @@ void rb_ruby_parser_set_script_lines(rb_parser_t *p);
 void rb_ruby_parser_error_tolerant(rb_parser_t *p);
 void rb_ruby_parser_keep_tokens(rb_parser_t *p);
 typedef VALUE (rb_parser_lex_gets_func)(struct parser_params*, rb_parser_input_data, int);
-rb_ast_t *rb_parser_compile(rb_parser_t *p, rb_parser_lex_gets_func *gets, VALUE fname, rb_parser_input_data input, int line);
+rb_ast_t *rb_parser_compile(rb_parser_t *p, rb_parser_lex_gets_func *gets, const char *fname_ptr, long fname_len, rb_encoding *fname_enc, rb_parser_input_data input, int line);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1338,6 +1338,7 @@ typedef struct rb_parser_config_struct {
     rb_encoding *(*ascii8bit_encoding)(void);
     int (*enc_codelen)(int c, rb_encoding *enc);
     int (*enc_mbcput)(unsigned int c, void *buf, rb_encoding *enc);
+    int (*enc_mbclen)(const char *p, const char *e, rb_encoding *enc);
     int (*enc_find_index)(const char *name);
     rb_encoding *(*enc_from_index)(int idx);
     int (*enc_isspace)(OnigCodePoint c, rb_encoding *enc);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -168,6 +168,7 @@
 #define rb_ascii8bit_encoding   p->config->ascii8bit_encoding
 #define rb_enc_codelen          p->config->enc_codelen
 #define rb_enc_mbcput           p->config->enc_mbcput
+#define rb_enc_mbclen           p->config->enc_mbclen
 #define rb_enc_find_index       p->config->enc_find_index
 #define rb_enc_from_index       p->config->enc_from_index
 #define rb_enc_isspace          p->config->enc_isspace


### PR DESCRIPTION
This reduces dependency on VALUE.