### PR TITLE
Memory leak in parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -518,6 +518,7 @@ parser_free(void *ptr)
 {
     struct ruby_parser *parser = (struct ruby_parser*)ptr;
     rb_ruby_parser_free(parser->parser_params);
+    xfree(parser);
 }
 
 static size_t

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -763,10 +763,9 @@ static const rb_data_type_t ast_data_type = {
 };
 
 static VALUE
-ast_alloc(void)
+ast_alloc(rb_ast_t *ast)
 {
-    rb_ast_t *ast;
-    VALUE vast = TypedData_Make_Struct(0, rb_ast_t, &ast_data_type, ast);
+    VALUE vast = TypedData_Wrap_Struct(0, &ast_data_type, ast);
 #ifdef UNIVERSAL_PARSER
     ast = (rb_ast_t *)DATA_PTR(vast);
     ast->config = &rb_global_parser_config;
@@ -778,10 +777,9 @@ VALUE
 rb_parser_compile_file_path(VALUE vparser, VALUE fname, VALUE file, int start)
 {
     struct ruby_parser *parser;
-    VALUE vast = ast_alloc();
-
     TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
-    DATA_PTR(vast) = parser_compile_file_path(parser, fname, file, start);
+
+    VALUE vast = ast_alloc(parser_compile_file_path(parser, fname, file, start));
     RB_GC_GUARD(vparser);
 
     return vast;
@@ -791,10 +789,9 @@ VALUE
 rb_parser_compile_array(VALUE vparser, VALUE fname, VALUE array, int start)
 {
     struct ruby_parser *parser;
-    VALUE vast = ast_alloc();
-
     TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
-    DATA_PTR(vast) = parser_compile_array(parser, fname, array, start);
+
+    VALUE vast = ast_alloc(parser_compile_array(parser, fname, array, start));
     RB_GC_GUARD(vparser);
 
     return vast;
@@ -804,10 +801,9 @@ VALUE
 rb_parser_compile_generic(VALUE vparser, rb_parser_lex_gets_func *lex_gets, VALUE fname, VALUE input, int start)
 {
     struct ruby_parser *parser;
-    VALUE vast = ast_alloc();
-
     TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
-    DATA_PTR(vast) = parser_compile_generic(parser, lex_gets, fname, input, start);
+
+    VALUE vast = ast_alloc(parser_compile_generic(parser, lex_gets, fname, input, start));
     RB_GC_GUARD(vparser);
 
     return vast;
@@ -817,10 +813,9 @@ VALUE
 rb_parser_compile_string(VALUE vparser, const char *f, VALUE s, int line)
 {
     struct ruby_parser *parser;
-    VALUE vast = ast_alloc();
-
     TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
-    DATA_PTR(vast) = parser_compile_string(parser, f, s, line);
+
+    VALUE vast = ast_alloc(parser_compile_string(parser, f, s, line));
     RB_GC_GUARD(vparser);
 
     return vast;
@@ -830,10 +825,9 @@ VALUE
 rb_parser_compile_string_path(VALUE vparser, VALUE f, VALUE s, int line)
 {
     struct ruby_parser *parser;
-    VALUE vast = ast_alloc();
-
     TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
-    DATA_PTR(vast) = parser_compile_string_path(parser, f, s, line);
+
+    VALUE vast = ast_alloc(parser_compile_string_path(parser, f, s, line));
     RB_GC_GUARD(vparser);
 
     return vast;
@@ -1123,8 +1117,8 @@ parser_aset_script_lines_for(VALUE path, rb_parser_ary_t *lines)
 VALUE
 rb_ruby_ast_new(const NODE *const root)
 {
-    VALUE vast = ast_alloc();
-    rb_ast_t *ast = DATA_PTR(vast);
+    rb_ast_t *ast = ruby_xcalloc(1, sizeof(rb_ast_t));
+    VALUE vast = ast_alloc(ast);
     ast->body = (rb_ast_body_t){
         .root = root,
         .frozen_string_literal = -1,


### PR DESCRIPTION
For example:

```ruby
10.times do
  100_000.times do
    eval("")
  end

  puts `ps -o rss= -p #{$$}`
end
```

Before:

    19872
    26480
    32848
    39504
    45904
    52672
    59200
    65760
    72128
    78496

After:

    14320
    14320
    14320
    14320
    14320
    14320
    14320
    14336
    14336
    14336
