### PR TITLE
Backport [ruby/net-http] Skip test_session_reuse_but_expire with OpenSSL 3.3

### DIFF
--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -168,6 +168,7 @@ class TestNetHTTPS < Test::Unit::TestCase
     # FIXME: The new_session_cb is known broken for clients in OpenSSL 1.1.0h.
     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 1.1.0h')
     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.2.')
+    omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.3.')
 
     http = Net::HTTP.new(HOST, config("port"))
     http.use_ssl = true

--- a/test/openssl/test_asn1.rb
+++ b/test/openssl/test_asn1.rb
@@ -406,10 +406,6 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
     rescue OpenSSL::ASN1::ASN1Error
       pend "No negative time_t support?"
     end
-    # Seconds is omitted. LibreSSL 3.6.0 requires it
-    return if libressl?
-    decode_test B(%w{ 17 0B }) + "1609082343Z".b,
-      OpenSSL::ASN1::UTCTime.new(Time.utc(2016, 9, 8, 23, 43, 0))
     # not implemented
     # decode_test B(%w{ 17 11 }) + "500908234339+0930".b,
     #   OpenSSL::ASN1::UTCTime.new(Time.new(1950, 9, 8, 23, 43, 39, "+09:30"))
@@ -428,10 +424,6 @@ class  OpenSSL::TestASN1 < OpenSSL::TestCase
       OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 29))
     encode_decode_test B(%w{ 18 0F }) + "99990908234339Z".b,
       OpenSSL::ASN1::GeneralizedTime.new(Time.utc(9999, 9, 8, 23, 43, 39))
-    # LibreSSL 3.6.0 requires the seconds element
-    return if libressl?
-    decode_test B(%w{ 18 0D }) + "201612081934Z".b,
-      OpenSSL::ASN1::GeneralizedTime.new(Time.utc(2016, 12, 8, 19, 34, 0))
     # not implemented
     # decode_test B(%w{ 18 13 }) + "20161208193439+0930".b,
     #   OpenSSL::ASN1::GeneralizedTime.new(Time.new(2016, 12, 8, 19, 34, 39, "+09:30"))


### PR DESCRIPTION
picked from https://github.com/ruby/net-http/commit/ab525c956d