### PR TITLE
Fix memory leak of `rb_ast_t` in parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -782,9 +782,10 @@ static const rb_data_type_t ast_data_type = {
 };
 
 static VALUE
-ast_alloc(rb_ast_t *ast)
+ast_alloc(void)
 {
-    VALUE vast = TypedData_Wrap_Struct(0, &ast_data_type, ast);
+    rb_ast_t *ast;
+    VALUE vast = TypedData_Make_Struct(0, rb_ast_t, &ast_data_type, ast);
 #ifdef UNIVERSAL_PARSER
     ast = (rb_ast_t *)DATA_PTR(vast);
     ast->config = &rb_global_parser_config;
@@ -796,9 +797,10 @@ VALUE
 rb_parser_compile_file_path(VALUE vparser, VALUE fname, VALUE file, int start)
 {
     struct ruby_parser *parser;
-    TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
+    VALUE vast = ast_alloc();
 
-    VALUE vast = ast_alloc(parser_compile_file_path(parser, fname, file, start));
+    TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
+    DATA_PTR(vast) = parser_compile_file_path(parser, fname, file, start);
     RB_GC_GUARD(vparser);
 
     return vast;
@@ -808,9 +810,10 @@ VALUE
 rb_parser_compile_array(VALUE vparser, VALUE fname, VALUE array, int start)
 {
     struct ruby_parser *parser;
-    TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
+    VALUE vast = ast_alloc();
 
-    VALUE vast = ast_alloc(parser_compile_array(parser, fname, array, start));
+    TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
+    DATA_PTR(vast) = parser_compile_array(parser, fname, array, start);
     RB_GC_GUARD(vparser);
 
     return vast;
@@ -820,9 +823,10 @@ VALUE
 rb_parser_compile_generic(VALUE vparser, rb_parser_lex_gets_func *lex_gets, VALUE fname, VALUE input, int start)
 {
     struct ruby_parser *parser;
-    TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
+    VALUE vast = ast_alloc();
 
-    VALUE vast = ast_alloc(parser_compile_generic(parser, lex_gets, fname, input, start));
+    TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
+    DATA_PTR(vast) = parser_compile_generic(parser, lex_gets, fname, input, start);
     RB_GC_GUARD(vparser);
 
     return vast;
@@ -832,9 +836,10 @@ VALUE
 rb_parser_compile_string(VALUE vparser, const char *f, VALUE s, int line)
 {
     struct ruby_parser *parser;
-    TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
+    VALUE vast = ast_alloc();
 
-    VALUE vast = ast_alloc(parser_compile_string(parser, f, s, line));
+    TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
+    DATA_PTR(vast) = parser_compile_string(parser, f, s, line);
     RB_GC_GUARD(vparser);
 
     return vast;
@@ -844,9 +849,10 @@ VALUE
 rb_parser_compile_string_path(VALUE vparser, VALUE f, VALUE s, int line)
 {
     struct ruby_parser *parser;
-    TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
+    VALUE vast = ast_alloc();
 
-    VALUE vast = ast_alloc(parser_compile_string_path(parser, f, s, line));
+    TypedData_Get_Struct(vparser, struct ruby_parser, &ruby_parser_data_type, parser);
+    DATA_PTR(vast) = parser_compile_string_path(parser, f, s, line);
     RB_GC_GUARD(vparser);
 
     return vast;
@@ -1136,8 +1142,8 @@ parser_aset_script_lines_for(VALUE path, rb_parser_ary_t *lines)
 VALUE
 rb_ruby_ast_new(const NODE *const root)
 {
-    rb_ast_t *ast = ruby_xcalloc(1, sizeof(rb_ast_t));
-    VALUE vast = ast_alloc(ast);
+    VALUE vast = ast_alloc();
+    rb_ast_t *ast = DATA_PTR(vast);
     ast->body = (rb_ast_body_t){
         .root = root,
         .frozen_string_literal = -1,

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -784,13 +784,7 @@ static const rb_data_type_t ast_data_type = {
 static VALUE
 ast_alloc(void)
 {
-    rb_ast_t *ast;
-    VALUE vast = TypedData_Make_Struct(0, rb_ast_t, &ast_data_type, ast);
-#ifdef UNIVERSAL_PARSER
-    ast = (rb_ast_t *)DATA_PTR(vast);
-    ast->config = &rb_global_parser_config;
-#endif
-    return vast;
+    return TypedData_Wrap_Struct(0, &ast_data_type, NULL);
 }
 
 VALUE
@@ -1142,8 +1136,11 @@ parser_aset_script_lines_for(VALUE path, rb_parser_ary_t *lines)
 VALUE
 rb_ruby_ast_new(const NODE *const root)
 {
-    VALUE vast = ast_alloc();
-    rb_ast_t *ast = DATA_PTR(vast);
+    rb_ast_t *ast;
+    VALUE vast = TypedData_Make_Struct(0, rb_ast_t, &ast_data_type, ast);
+#ifdef UNIVERSAL_PARSER
+    ast->config = &rb_global_parser_config;
+#endif
     ast->body = (rb_ast_body_t){
         .root = root,
         .frozen_string_literal = -1,


### PR DESCRIPTION
https://github.com/ruby/ruby/commit/e3bfd25bd2202a172d7709e9a2f7b65b523a132d approach is "Allocate then wrap". The approach is bad, because the "wrapping" itself can fail.
Avoid memory leak this PR

1. Change the first argument of `rb_iseq_new` functions to be `rb_ast_body_t *`
2. Do not allocate `rb_ast_t` for `VALUE vast` to avoid memory leak