### PR TITLE
Refactor `ary_heap_free_ptr` and remove `ary_heap_free`

### DIFF
--- a/array.c
+++ b/array.c
@@ -357,15 +357,9 @@ ary_heap_alloc_buffer(size_t capa)
 }
 
 static void
-ary_heap_free_ptr(VALUE ary, const VALUE *ptr, long size)
+ary_heap_free_ptr(const VALUE *ptr, long size)
 {
     ruby_sized_xfree((void *)ptr, size);
-}
-
-static void
-ary_heap_free(VALUE ary)
-{
-    ary_heap_free_ptr(ary, ARY_HEAP_PTR(ary), ARY_HEAP_SIZE(ary));
 }
 
 static size_t
@@ -391,7 +385,7 @@ rb_ary_make_embedded(VALUE ary)
 
         MEMCPY((void *)ARY_EMBED_PTR(ary), (void *)buf, VALUE, len);
 
-        ary_heap_free_ptr(ary, buf, len * sizeof(VALUE));
+        ary_heap_free_ptr(buf, len * sizeof(VALUE));
     }
 }
 
@@ -426,7 +420,7 @@ ary_resize_capa(VALUE ary, long capacity)
 
             if (len > capacity) len = capacity;
             MEMCPY((VALUE *)RARRAY(ary)->as.ary, ptr, VALUE, len);
-            ary_heap_free_ptr(ary, ptr, old_capa);
+            ary_heap_free_ptr(ptr, old_capa);
 
             FL_SET_EMBED(ary);
             ARY_SET_LEN(ary, len);
@@ -489,7 +483,7 @@ static void
 rb_ary_reset(VALUE ary)
 {
     if (ARY_OWNS_HEAP_P(ary)) {
-        ary_heap_free(ary);
+        ary_heap_free_ptr(ARY_HEAP_PTR(ary), ARY_HEAP_SIZE(ary));
     }
     else if (ARY_SHARED_P(ary)) {
         rb_ary_unshare(ary);
@@ -879,7 +873,7 @@ rb_ary_free(VALUE ary)
         }
 
         RB_DEBUG_COUNTER_INC(obj_ary_ptr);
-        ary_heap_free(ary);
+        ary_heap_free_ptr(ARY_HEAP_PTR(ary), ARY_HEAP_SIZE(ary));
     }
     else {
         RB_DEBUG_COUNTER_INC(obj_ary_embed);
@@ -3472,7 +3466,7 @@ rb_ary_sort_bang(VALUE ary)
                     rb_ary_unshare(ary);
                 }
                 else {
-                    ary_heap_free(ary);
+                    ary_heap_free_ptr(ARY_HEAP_PTR(ary), ARY_HEAP_SIZE(ary));
                 }
                 ARY_SET_PTR(ary, ARY_HEAP_PTR(tmp));
                 ARY_SET_HEAP_LEN(ary, len);


### PR DESCRIPTION
This PR does the following:

* `ary_heap_free_ptr` took an `ary` but it wasn't used for anything. The code that was using `ary` was removed in ruby/ruby#7942.
* since removing the `ary` argument, there's less value in having a separate function for `ary_heap_free`. I deleted it in favor of calling `ary_heap_free_ptr`.