### PR TITLE
YJIT: print msg to stderr when RubyVM::YJIT.disasm not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,7 @@ lcov*.info
 
 # /coroutine/
 !/coroutine/**/*.s
+!/coroutine/**/*.S
 
 # /enc/trans/
 /enc/trans/*.c

--- a/yjit.rb
+++ b/yjit.rb
@@ -201,20 +201,27 @@ module RubyVM::YJIT
     # If a method or proc is passed in, get its iseq
     iseq = RubyVM::InstructionSequence.of(iseq)
 
-    if self.enabled?
-      disasm_str = Primitive.rb_yjit_disasm_iseq(iseq)
-
-      if !disasm_str
-        $stderr.puts("YJIT disasm is only available when YJIT is built in dev mode, i.e.:\n")
-        $stderr.puts("./configure --enable-yjit=dev (see doc/yjit/yjit.md)\n")
-      else
-        # Produce the disassembly string
-        # Include the YARV iseq disasm in the string for additional context
-        iseq.disasm + "\n" + disasm_str
-      end
-    else
-      iseq.disasm
+    if !self.enabled?
+      warn(
+        "YJIT needs to be enabled to produce disasm output, e.g.\n" +
+        "ruby --yjit-call-threshold=1 my_script.rb (see doc/yjit/yjit.md)"
+      )
+      return nil
     end
+
+    disasm_str = Primitive.rb_yjit_disasm_iseq(iseq)
+
+    if !disasm_str
+      warn(
+        "YJIT disasm is only available when YJIT is built in dev mode, i.e.\n" +
+        "./configure --enable-yjit=dev (see doc/yjit/yjit.md)\n"
+      )
+      return nil
+    end
+
+    # Produce the disassembly string
+    # Include the YARV iseq disasm in the string for additional context
+    iseq.disasm + "\n" + disasm_str
   end
 
   # Produce a list of instructions compiled by YJIT for an iseq

--- a/yjit.rb
+++ b/yjit.rb
@@ -202,9 +202,16 @@ module RubyVM::YJIT
     iseq = RubyVM::InstructionSequence.of(iseq)
 
     if self.enabled?
-      # Produce the disassembly string
-      # Include the YARV iseq disasm in the string for additional context
-      iseq.disasm + "\n" + Primitive.rb_yjit_disasm_iseq(iseq)
+      disasm_str = Primitive.rb_yjit_disasm_iseq(iseq)
+
+      if !disasm_str
+        $stderr.puts("YJIT disasm is only available when YJIT is built in dev mode, i.e.:\n")
+        $stderr.puts("./configure --enable-yjit (see doc/yjit/yjit.md)\n")
+      else
+        # Produce the disassembly string
+        # Include the YARV iseq disasm in the string for additional context
+        iseq.disasm + "\n" + disasm_str
+      end
     else
       iseq.disasm
     end

--- a/yjit.rb
+++ b/yjit.rb
@@ -206,7 +206,7 @@ module RubyVM::YJIT
 
       if !disasm_str
         $stderr.puts("YJIT disasm is only available when YJIT is built in dev mode, i.e.:\n")
-        $stderr.puts("./configure --enable-yjit (see doc/yjit/yjit.md)\n")
+        $stderr.puts("./configure --enable-yjit=dev (see doc/yjit/yjit.md)\n")
       else
         # Produce the disassembly string
         # Include the YARV iseq disasm in the string for additional context


### PR DESCRIPTION
Print a more useful error message when people try to use this feature without YJIT dev.

Previously, this cryptic error message would be printed when trying to use disasm without dev mode:
```
irb(main):001> RubyVM::YJIT.disasm(MyThing.instance_method(:call))
<internal:yjit>:203:in `+': no implicit conversion of nil into String (TypeError)
	from <internal:yjit>:203:in `disasm'
	from /home/samuel/Projects/socketry/console/test.rb(irb):1:in `<main>'
	from <internal:kernel>:187:in `loop'
	from <internal:prelude>:5:in `irb'
	from ./test.rb:16:in `<main>'
```

Also fix an issue with .gitignore file on macOS