### PR TITLE
YJIT: Fix `Struct` accessors not firing tracing events

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4964,3 +4964,19 @@ assert_equal '[[true, false, false], [true, false, true], [true, :error, :error]
 
   results << test
 } unless rjit_enabled? # Not yet working on RJIT
+
+# test struct accessors fire c_call events
+assert_equal '[[:c_call, :x=], [:c_call, :x]]', %q{
+  c = Struct.new(:x)
+  obj = c.new
+
+  events = []
+  TracePoint.new(:c_call) do
+    events << [_1.event, _1.method_id]
+  end.enable do
+    obj.x = 100
+    obj.x
+  end
+
+  events
+}

--- a/lib/ruby_vm/rjit/insn_compiler.rb
+++ b/lib/ruby_vm/rjit/insn_compiler.rb
@@ -5461,6 +5461,12 @@ module RubyVM::RJIT
         return CantCompile
       end
 
+      if c_method_tracing_currently_enabled?
+        # Don't JIT if tracing c_call or c_return
+        asm.incr_counter(:send_cfunc_tracing)
+        return CantCompile
+      end
+
       off = cme.def.body.optimized.index
 
       recv_idx = argc # blockarg is not supported


### PR DESCRIPTION
- **YJIT: Fix `Struct` accessors not firing tracing events**
- **RJIT: YJIT: Fix `Struct` readers not firing tracing events**

Reading and writing to structs should fire `c_call` and `c_return`, but
YJIT wasn't correctly dropping those calls when tracing.
This has been missing since this functionality was added in 3081c83169c55ef7eead6222e49248e09232c22c,
but the added test only fails when ran in isolation with
`--yjit-call-threshold=1`. The test sometimes failed on CI.