### PR TITLE
Fix freeing invalid pointer

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3717,7 +3717,7 @@ pm_multi_target_state_update(pm_multi_target_state_t *state)
         previous = current;
         current = current->next;
 
-        free(previous);
+        xfree(previous);
     }
 }
 


### PR DESCRIPTION
Pointers allocated with `ruby_xmalloc` (`ALLOC` macro) must be freed with `ruby_xfree`.
