### PR TITLE
Skip Warning.[] spec if mspec is passing warning options

### DIFF
--- a/spec/prism.mspec
+++ b/spec/prism.mspec
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-# This is turned off because when we run with --parser=prism we explicitly turn
-# off experimental warnings to make sure the output is consistent.
-MSpec.register(:exclude, "Warning.[] returns default values for categories :deprecated and :experimental")
-
 ## Language
 MSpec.register(:exclude, "Hash literal raises a SyntaxError at parse time when Symbol key with invalid bytes")
 MSpec.register(:exclude, "Hash literal raises a SyntaxError at parse time when Symbol key with invalid bytes and 'key: value' syntax used")

--- a/spec/ruby/core/warning/element_reference_spec.rb
+++ b/spec/ruby/core/warning/element_reference_spec.rb
@@ -2,6 +2,10 @@ require_relative '../../spec_helper'
 
 describe "Warning.[]" do
   it "returns default values for categories :deprecated and :experimental" do
+    # If any warning options were set on the Ruby that will be executed, then
+    # it's possible this test will fail. In this case we will skip this test.
+    skip if ruby_exe.any? { |opt| opt.start_with?("-W") }
+
     ruby_exe('p [Warning[:deprecated], Warning[:experimental]]').chomp.should == "[false, true]"
     ruby_exe('p [Warning[:deprecated], Warning[:experimental]]', options: "-w").chomp.should == "[true, true]"
   end


### PR DESCRIPTION
@eregon is this alright?

In order to run the specs we run with `-T -W:no-experimental`, which causes this spec to fail. So I wanted to skip that spec if warning options were passed on the command line. Eventually the warning should go away with the prism compiler, so we'll go back to passing this without skipping (and can remove this line).