### PR TITLE
Fix macos bug deleting too many files

### DIFF
--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -493,9 +493,8 @@ clean-local::
 	  enc/encinit.c enc/encinit.$(OBJEXT) $(pkgconfig_DATA) \
 	  ruby-runner.$(OBJEXT) ruby-runner.h \
 	|| $(NULLCMD)
-	@$(RM) $(ALLOBJS:.$(OBJEXT)=.bc)
-	@$(RM) $(ALLOBJS:.$(OBJEXT)=.i)
-	@$(RM) $(ALLOBJS:.$(OBJEXT)=.s)
+	$(Q)find . ! -type d \( -name '*.bc' -o -name '*.[is]' \) -exec rm -f {} + || true
+
 
 distclean-local::
 	$(Q)$(RM) \


### PR DESCRIPTION
Since #10209 we've been noticing that on macos after running `make clean` the `coroutine/arm64/Context.S` file is missing, causing subsequent make calls to fail because `Context.S` is needed to build `Context.o`.

The reason this is happening is because macos is case-insensitive so the `.s` looks for `coroutine/arm64/Context.s` and finds `coroutine/arm64/Context.S` and deletes it. This does not happen on linux because the filesystem is case sensitive.

I attempted to use `find` because it is case sensitive regardless of filesystem, but it was a lot slower than `rm` since we can't pass multiple file names the same way to `find`.

Reverting this small part of #10209 fixes the issue for macos and it wasn't clear that those changes were strictly necessary for the rest of the PR.

cc/ @nobu as the author of #10209