### PR TITLE
Sync IRB `241e061` and fix IRB binding spec

### DIFF
--- a/lib/irb.rb
+++ b/lib/irb.rb
@@ -311,7 +311,9 @@ require_relative "irb/pager"
 # ### Input Method
 #
 # The IRB input method determines how command input is to be read; by default,
-# the input method for a session is IRB::RelineInputMethod.
+# the input method for a session is IRB::RelineInputMethod. Unless the
+# value of the TERM environment variable is 'dumb', in which case the
+# most simplistic input method is used.
 #
 # You can set the input method by:
 #
@@ -329,7 +331,8 @@ require_relative "irb/pager"
 #         IRB::ReadlineInputMethod.
 #     *   `--nosingleline` or `--multiline` sets the input method to
 #         IRB::RelineInputMethod.
-#
+#     *   `--nosingleline` together with `--nomultiline` sets the
+#         input to IRB::StdioInputMethod.
 #
 #
 # Method `conf.use_multiline?` and its synonym `conf.use_reline` return:

--- a/lib/irb/context.rb
+++ b/lib/irb/context.rb
@@ -85,7 +85,7 @@ module IRB
         @io = nil
         case use_multiline?
         when nil
-          if STDIN.tty? && IRB.conf[:PROMPT_MODE] != :INF_RUBY && !use_singleline?
+          if term_interactive? && IRB.conf[:PROMPT_MODE] != :INF_RUBY && !use_singleline?
             # Both of multiline mode and singleline mode aren't specified.
             @io = RelineInputMethod.new(build_completor)
           else
@@ -99,7 +99,7 @@ module IRB
         unless @io
           case use_singleline?
           when nil
-            if (defined?(ReadlineInputMethod) && STDIN.tty? &&
+            if (defined?(ReadlineInputMethod) && term_interactive? &&
                 IRB.conf[:PROMPT_MODE] != :INF_RUBY)
               @io = ReadlineInputMethod.new
             else
@@ -149,6 +149,11 @@ module IRB
 
       @user_aliases = IRB.conf[:COMMAND_ALIASES].dup
       @command_aliases = @user_aliases.merge(KEYWORD_ALIASES)
+    end
+
+    private def term_interactive?
+      return true if ENV['TEST_IRB_FORCE_INTERACTIVE']
+      STDIN.tty? && ENV['TERM'] != 'dumb'
     end
 
     # because all input will eventually be evaluated as Ruby code,

--- a/spec/ruby/core/binding/irb_spec.rb
+++ b/spec/ruby/core/binding/irb_spec.rb
@@ -10,7 +10,7 @@ describe "Binding#irb" do
       IO.popen([envs, *ruby_exe, irb_fixture, chdir: dir], "r+") do |pipe|
         pipe.puts "a ** 2"
         pipe.puts "exit"
-        pipe.readlines.map(&:chomp)
+        pipe.readlines.map(&:chomp).reject(&:empty?)
       end
     end
 

--- a/test/irb/helper.rb
+++ b/test/irb/helper.rb
@@ -121,7 +121,9 @@ module TestIRB
       @envs["XDG_CONFIG_HOME"] ||= tmp_dir
       @envs["IRBRC"] = nil unless @envs.key?("IRBRC")
 
-      PTY.spawn(@envs.merge("TERM" => "dumb"), *cmd) do |read, write, pid|
+      envs_for_spawn = @envs.merge('TERM' => 'dumb', 'TEST_IRB_FORCE_INTERACTIVE' => 'true')
+
+      PTY.spawn(envs_for_spawn, *cmd) do |read, write, pid|
         Timeout.timeout(TIMEOUT_SEC) do
           while line = safe_gets(read)
             lines << line


### PR DESCRIPTION
1. https://github.com/ruby/irb/commit/241e06173fd68b8e827aafc72a5113ee566c40fa was missed from auto-syncing, so we need to do that manually.
2. The specs are failing because of the additonal newlines https://github.com/ruby/irb/commit/acf3c1816ec7374cd375737711eab390132507fa introduced. IMO that test doesn't need to tightly follow each output format change of IRB. So I made it reject empty output.