### PR TITLE
YJIT: Fix comment and counter in rb_yjit_invalidate_ep_is_bp()

### DIFF
--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -584,11 +584,10 @@ pub extern "C" fn rb_yjit_invalidate_ep_is_bp(iseq: IseqPtr) {
         let no_ep_escape_iseqs = &mut Invariants::get_instance().no_ep_escape_iseqs;
         match no_ep_escape_iseqs.get_mut(&iseq) {
             Some(blocks) => {
-                // Invalidate existing blocks and let jit.ep_is_bp()
-                // return true when they are compiled again
+                // Invalidate existing blocks and make jit.ep_is_bp() return false
                 for block in mem::take(blocks) {
                     invalidate_block_version(&block);
-                    incr_counter!(invalidate_no_singleton_class);
+                    incr_counter!(invalidate_ep_escape);
                 }
             }
             None => {

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -268,7 +268,7 @@ macro_rules! make_counters {
 
 /// The list of counters that are available without --yjit-stats.
 /// They are incremented only by `incr_counter!` and don't use `gen_counter_incr`.
-pub const DEFAULT_COUNTERS: [Counter; 16] = [
+pub const DEFAULT_COUNTERS: [Counter; 17] = [
     Counter::code_gc_count,
     Counter::compiled_iseq_entry,
     Counter::cold_iseq_entry,
@@ -286,6 +286,7 @@ pub const DEFAULT_COUNTERS: [Counter; 16] = [
     Counter::invalidate_constant_state_bump,
     Counter::invalidate_constant_ic_fill,
     Counter::invalidate_no_singleton_class,
+    Counter::invalidate_ep_escape,
 ];
 
 /// Macro to increase a counter by name and count
@@ -568,6 +569,7 @@ make_counters! {
     invalidate_constant_state_bump,
     invalidate_constant_ic_fill,
     invalidate_no_singleton_class,
+    invalidate_ep_escape,
 
     // Currently, it's out of the ordinary (might be impossible) for YJIT to leave gaps in
     // executable memory, so this should be 0.


### PR DESCRIPTION
`mem::take` substitutes an empty instance which makes `jit.ep_is_bp()`
return false.
