### PR TITLE
Suppress warning in parser_compile when enabling Universal Parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -674,7 +674,7 @@ parser_compile(rb_parser_t *p, rb_parser_lex_gets_func *gets, VALUE fname, rb_pa
         enc = rb_enc_get(fname);
     }
 
-    ast = rb_parser_compile(p, gets, ptr, len, enc, input, line);
+    ast = rb_parser_compile(p, gets, ptr, len, (void *)enc, input, line);
     parser_aset_script_lines_for(fname, ast->body.script_lines);
     return ast;
 }


### PR DESCRIPTION
These warning is output when enabled Universal Parser.
This pull request was supress these warning.

```console
compiling ../ruby/ruby_parser.c
../ruby/ruby_parser.c: In function ‘parser_compile’:
../ruby/ruby_parser.c:677:48: warning: passing argument 5 of ‘rb_parser_compile’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifier]
  677 |     ast = rb_parser_compile(p, gets, ptr, len, enc, input, line);
      |                                                ^~~
In file included from ../ruby/ruby_parser.c:3:
../ruby/internal/parse.h:58:128: note: expected ‘void *’ but argument is of type ‘const rb_encoding *’ {aka ‘const struct OnigEncodingTypeST *’}
   58 | rb_ast_t *rb_parser_compile(rb_parser_t *p, rb_parser_lex_gets_func *gets, const char *fname_ptr, long fname_len, rb_encoding *fname_enc, rb_parser_input_data input, int line);
      |                                                                                                                                ^
../ruby/ruby_parser.c: At top level:
cc1: note: unrecognized command-line option ‘-Wno-self-assign’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-parentheses-equality’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-constant-logical-operand’ may have been intended to silence earlier diagnostics


```