### PR TITLE
Use spaces around => in Hash#inspect for symbol keys that would generate invalid syntax

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3440,6 +3440,7 @@ static int
 inspect_i(VALUE key, VALUE value, VALUE str)
 {
     VALUE str2;
+    bool spaces = false;
 
     str2 = rb_inspect(key);
     if (RSTRING_LEN(str) > 1) {
@@ -3449,7 +3450,18 @@ inspect_i(VALUE key, VALUE value, VALUE str)
         rb_enc_copy(str, str2);
     }
     rb_str_buf_append(str, str2);
-    rb_str_buf_cat_ascii(str, "=>");
+    if (RB_SYMBOL_P(key)) {
+        switch (*(RSTRING_PTR(str) + RSTRING_LEN(str) - 1)) {
+          case '!':
+          case '?':
+          case '*':
+          case '=':
+          case '<':
+            spaces = true;
+          /* no default */
+        }
+    }
+    rb_str_buf_cat_ascii(str, spaces ? " => " : "=>");
     str2 = rb_inspect(value);
     rb_str_buf_append(str, str2);
 

--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -295,7 +295,12 @@ class PP < PrettyPrint
     # A pretty print for a pair of Hash
     def pp_hash_pair(k, v)
       pp k
-      text '=>'
+      if Symbol === k && k.match?(/[!?*=<]\z/)
+        sep = ' => '
+      else
+        sep = '=>'
+      end
+      text sep
       group(1) {
         breakable ''
         pp v

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -869,6 +869,19 @@ class TestHash < Test::Unit::TestCase
     $, = nil
   end
 
+  def test_inspect_eval_symbol_bug_20433
+    [:a!, :a?, :*, :==, :<].each do |key|
+      h = {key => 1}
+      assert_equal(h, eval(h.inspect), "eval(#{h.inspect.inspect}) != #{h.inspect}")
+    end
+
+    assert_equal("{:a! => 1}", { :a! => 1 }.inspect)
+    assert_equal("{:a? => 1}", { :a? => 1 }.inspect)
+    assert_equal("{:* => 1}", { :* => 1 }.inspect)
+    assert_equal("{:== => 1}", { :== => 1 }.inspect)
+    assert_equal("{:< => 1}", { :< => 1 }.inspect)
+  end
+
   def test_update
     h1 = @cls[ 1 => 2, 2 => 3, 3 => 4 ]
     h2 = @cls[ 2 => 'two', 4 => 'four' ]

--- a/test/test_pp.rb
+++ b/test/test_pp.rb
@@ -16,6 +16,19 @@ class PPTest < Test::Unit::TestCase
     assert_equal("[0,\n 1,\n 2,\n 3]\n", PP.pp([0,1,2,3], ''.dup, 11))
   end
 
+  def test_hash_eval_symbol_bug_20433
+    [:a!, :a?, :*, :==, :<].each do |key|
+      h = {key => 1}
+      assert_equal(h, eval(PP.pp(h, ''.dup)), "eval(PP.pp(#{h.inspect})) != #{h.inspect}")
+    end
+
+    assert_equal("{:a! => 1}\n", PP.pp({ :a! => 1 }, ''.dup))
+    assert_equal("{:a? => 1}\n", PP.pp({ :a? => 1 }, ''.dup))
+    assert_equal("{:* => 1}\n", PP.pp({ :* => 1 }, ''.dup))
+    assert_equal("{:== => 1}\n", PP.pp({ :== => 1 }, ''.dup))
+    assert_equal("{:< => 1}\n", PP.pp({ :< => 1 }, ''.dup))
+  end
+
   OverriddenStruct = Struct.new("OverriddenStruct", :members, :class)
   def test_struct_override_members # [ruby-core:7865]
     a = OverriddenStruct.new(1,2)


### PR DESCRIPTION
Also use spaces around => in PP.pp for hashes with symbol keys that would generate invalid syntax.

Fixes [Bug #20433]