### PR TITLE
[Feature #20476] Add an Enumerator#eager that returns `self`

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -1217,6 +1217,19 @@ append_method(VALUE obj, VALUE str, ID default_method, VALUE default_args)
 }
 
 /*
+ *  call-seq:
+ *     enumerator.eager -> enumerator
+ *
+ *  Returns self.
+ */
+
+static VALUE
+enumerator_eager(VALUE obj)
+{
+    return obj;
+}
+
+/*
  * call-seq:
  *   e.inspect  -> string
  *
@@ -4478,6 +4491,7 @@ InitVM_Enumerator(void)
     rb_define_method(rb_cEnumerator, "inspect", enumerator_inspect, 0);
     rb_define_method(rb_cEnumerator, "size", enumerator_size, 0);
     rb_define_method(rb_cEnumerator, "+", enumerator_plus, 1);
+    rb_define_method(rb_mEnumerable, "eager", enumerator_eager, 0);
     rb_define_method(rb_mEnumerable, "chain", enum_chain, -1);
 
     /* Lazy */

--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -102,6 +102,10 @@ class TestEnumerable < Test::Unit::TestCase
     end
   end
 
+  def test_eager
+    assert_equal(@obj, @obj.eager)
+  end
+
   def test_find
     assert_equal(2, @obj.find {|x| x % 2 == 0 })
     assert_equal(nil, @obj.find {|x| false })


### PR DESCRIPTION
This PR adds an Enumerator#eager that returns `self` to mirror Enumerator::Lazy#lazy, which also returns `self`.

https://bugs.ruby-lang.org/issues/20476