### PR TITLE
Stabilize TestObjSpace#test_dump_special_consts

### DIFF
--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -416,7 +416,7 @@ class TestObjSpace < Test::Unit::TestCase
     assert_equal('true', ObjectSpace.dump(true))
     assert_equal('false', ObjectSpace.dump(false))
     assert_equal('0', ObjectSpace.dump(0))
-    assert_equal('{"type":"SYMBOL", "value":"foo"}', ObjectSpace.dump(:foo))
+    assert_equal('{"type":"SYMBOL", "value":"test_dump_special_consts"}', ObjectSpace.dump(:test_dump_special_consts))
   end
 
   def test_dump_singleton_class


### PR DESCRIPTION
The test assumes `:foo` is a static symbol, but that is only true if a literal `:foo` was parsed before `"foo".to_sym` was evaled:

[Launchable report](https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fobjspace%2Ftest_objspace.rb%23class%3DTestObjSpace%23testcase%3Dtest_dump_special_consts?year-week=2024-W18&organizationId=ruby&workspaceId=ruby&testPathId=file%3Dtest%2Fobjspace%2Ftest_objspace.rb%23class%3DTestObjSpace%23testcase%3Dtest_dump_special_consts&tab=average-duration)

```ruby
require 'objspace'
foo_sym = "foo".to_sym
puts ObjectSpace.dump(eval(":foo"))
```

```
{"address":"0x100fb46d0", "type":"SYMBOL", "shape_id":10, "slot_size":40, "class":"0x100d3e9c8", "frozen":true, "bytesize":3, "value":"foo", "memsize":40, "flags":{"wb_protected":true, "marking":true, "marked":true}}
```

@nobu @mame 