### PR TITLE
Add a ruby_bug spec for String#index clearing $~

### DIFF
--- a/spec/ruby/core/string/index_spec.rb
+++ b/spec/ruby/core/string/index_spec.rb
@@ -231,6 +231,17 @@ describe "String#index with Regexp" do
     $~.should == nil
   end
 
+  ruby_bug "#20421", ""..."3.3" do
+    it "always clear $~" do
+      "a".index(/a/)
+      $~.should_not == nil
+
+      string = "blablabla"
+      string.index(/bla/, string.length + 1)
+      $~.should == nil
+    end
+  end
+
   it "starts the search at the given offset" do
     "blablabla".index(/.{0}/, 5).should == 5
     "blablabla".index(/.{1}/, 5).should == 5


### PR DESCRIPTION
[[Bug #20421]](https://bugs.ruby-lang.org/issues/20421)

The bug was fixed in Ruby 3.3 via 9dcdffb8bf8a3654fd78bf1a58b30c8e13888a7a

@eregon 