### PR TITLE
Fix `String#index` to clear MatchData when a regexp is passed

### DIFF
--- a/spec/ruby/core/string/byteindex_spec.rb
+++ b/spec/ruby/core/string/byteindex_spec.rb
@@ -1,0 +1,16 @@
+# -*- encoding: utf-8 -*-
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "String#byteindex with Regexp" do
+  ruby_version_is "3.2" do
+    it "always clear $~" do
+      "a".byteindex(/a/)
+      $~.should_not == nil
+
+      string = "blablabla"
+      string.byteindex(/bla/, string.bytesize + 1)
+      $~.should == nil
+    end
+  end
+end

--- a/spec/ruby/core/string/index_spec.rb
+++ b/spec/ruby/core/string/index_spec.rb
@@ -224,6 +224,17 @@ describe "String#index with Regexp" do
     $~.should == nil
   end
 
+  ruby_bug "#20421", ""..."3.2" do
+    it "always clear $~" do
+      "a".index(/a/)
+      $~.should_not == nil
+
+      string = "blablabla"
+      string.index(/bla/, string.length + 1)
+      $~.should == nil
+    end
+  end
+
   it "starts the search at the given offset" do
     "blablabla".index(/.{0}/, 5).should == 5
     "blablabla".index(/.{1}/, 5).should == 5

--- a/spec/ruby/core/string/rindex_spec.rb
+++ b/spec/ruby/core/string/rindex_spec.rb
@@ -265,6 +265,15 @@ describe "String#rindex with Regexp" do
     $~.should == nil
   end
 
+  it "always clear $~" do
+    "a".rindex(/a/)
+    $~.should_not == nil
+
+    string = "blablabla"
+    string.rindex(/bla/, -(string.length + 1))
+    $~.should == nil
+  end
+
   it "starts the search at the given offset" do
     "blablabla".rindex(/.{0}/, 5).should == 5
     "blablabla".rindex(/.{1}/, 5).should == 5

--- a/string.c
+++ b/string.c
@@ -3993,8 +3993,10 @@ rb_str_index_m(int argc, VALUE *argv, VALUE str)
     }
 
     if (RB_TYPE_P(sub, T_REGEXP)) {
-        if (pos > str_strlen(str, NULL))
+        if (pos > str_strlen(str, NULL)) {
+            rb_backref_set(Qnil);
             return Qnil;
+        }
         pos = str_offset(RSTRING_PTR(str), RSTRING_END(str), pos,
                          rb_enc_check(str, sub), single_byte_optimizable(str));
 


### PR DESCRIPTION
[[Bug #20421]](https://bugs.ruby-lang.org/issues/20421)

The bug was fixed in Ruby 3.3 via 9dcdffb8bf8a3654fd78bf1a58b30c8e13888a7a