### PR TITLE
Remove unused functions from struct rb_parser_config_struct

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -385,7 +385,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .is_ascii_string = is_ascii_string2,
     .enc_str_new = enc_str_new,
     .str_vcatf = rb_str_vcatf,
-    .string_value_cstr = rb_string_value_cstr,
     .rb_sprintf = rb_sprintf,
     .rstring_ptr = RSTRING_PTR,
     .rstring_end = RSTRING_END,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1301,7 +1301,6 @@ typedef struct rb_parser_config_struct {
     VALUE (*enc_str_new)(const char *ptr, long len, rb_encoding *enc);
     RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 2, 0)
     VALUE (*str_vcatf)(VALUE str, const char *fmt, va_list ap);
-    char *(*string_value_cstr)(volatile VALUE *ptr);
     RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 1, 2)
     VALUE (*rb_sprintf)(const char *format, ...);
     char *(*rstring_ptr)(VALUE str);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -131,8 +131,6 @@
 #define is_ascii_string                   p->config->is_ascii_string
 #define rb_enc_str_new                    p->config->enc_str_new
 #define rb_str_vcatf                      p->config->str_vcatf
-#undef StringValueCStr
-#define StringValueCStr(v)                p->config->string_value_cstr(&(v))
 #define rb_sprintf                        p->config->rb_sprintf
 #undef RSTRING_PTR
 #define RSTRING_PTR                       p->config->rstring_ptr


### PR DESCRIPTION
StringValueCStr has not used in parse.y