### PR TITLE
Fix TestPatternMatching#test_deconstruct_keys test

### DIFF
--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -1331,7 +1331,7 @@ END
     end
 
     assert_block do
-      case {}
+      case C.new({})
       in {}
         C.keys == nil
       end


### PR DESCRIPTION
Before the change `C.keys` returned keys captured in some previous test case that by chance captures `nil` value what made this test passed successfully. Now `C.keys` returns keys captured in this test case.