### PR TITLE
Add allocation tests for ruby2_keywords

### DIFF
--- a/test/ruby/test_allocation.rb
+++ b/test/ruby/test_allocation.rb
@@ -100,7 +100,7 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(0, 1, "none(**empty_hash, **empty_hash#{block})")
         check_allocations(1, 1, "none(*empty_array, *empty_array, **empty_hash, **empty_hash#{block})")
 
-        check_allocations(#{block.empty?} ? 0 : 1, 0, "none(*r2k_empty_array#{block})")
+        check_allocations(0, 0, "none(*r2k_empty_array#{block})")
       RUBY
     end
 
@@ -120,7 +120,7 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(0, 1, "required(**hash1, **empty_hash#{block})")
         check_allocations(1, 0, "required(*array1, *empty_array, **empty_hash#{block})")
 
-        check_allocations(#{block.empty?} ? 0 : 1, 0, "required(*r2k_empty_array1#{block})")
+        check_allocations(0, 0, "required(*r2k_empty_array1#{block})")
         check_allocations(0, 1, "required(*r2k_array#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true
@@ -144,8 +144,8 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(0, 1, "optional(**hash1, **empty_hash#{block})")
         check_allocations(1, 0, "optional(*array1, *empty_array, **empty_hash#{block})")
 
-        check_allocations(#{block.empty?} ? 0 : 1, 0, "optional(*r2k_empty_array#{block})")
-        check_allocations(#{block.empty?} ? 0 : 1, 0, "optional(*r2k_empty_array1#{block})")
+        check_allocations(0, 0, "optional(*r2k_empty_array#{block})")
+        check_allocations(0, 0, "optional(*r2k_empty_array1#{block})")
         check_allocations(0, 1, "optional(*r2k_array#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true

--- a/test/ruby/test_allocation.rb
+++ b/test/ruby/test_allocation.rb
@@ -100,7 +100,7 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(0, 1, "none(**empty_hash, **empty_hash#{block})")
         check_allocations(1, 1, "none(*empty_array, *empty_array, **empty_hash, **empty_hash#{block})")
 
-        check_allocations(#{block.empty?} ? 0 : 1, #{block.empty?} ? 0 : 1, "none(*r2k_empty_array#{block})")
+        check_allocations(#{block.empty?} ? 0 : 1, 0, "none(*r2k_empty_array#{block})")
       RUBY
     end
 
@@ -120,7 +120,7 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(0, 1, "required(**hash1, **empty_hash#{block})")
         check_allocations(1, 0, "required(*array1, *empty_array, **empty_hash#{block})")
 
-        check_allocations(#{block.empty?} ? 0 : 1, #{block.empty?} ? 0 : 1, "required(*r2k_empty_array1#{block})")
+        check_allocations(#{block.empty?} ? 0 : 1, 0, "required(*r2k_empty_array1#{block})")
         check_allocations(0, 1, "required(*r2k_array#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true
@@ -144,8 +144,8 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(0, 1, "optional(**hash1, **empty_hash#{block})")
         check_allocations(1, 0, "optional(*array1, *empty_array, **empty_hash#{block})")
 
-        check_allocations(#{block.empty?} ? 0 : 1, #{block.empty?} ? 0 : 1, "optional(*r2k_empty_array#{block})")
-        check_allocations(#{block.empty?} ? 0 : 1, #{block.empty?} ? 0 : 1, "optional(*r2k_empty_array1#{block})")
+        check_allocations(#{block.empty?} ? 0 : 1, 0, "optional(*r2k_empty_array#{block})")
+        check_allocations(#{block.empty?} ? 0 : 1, 0, "optional(*r2k_empty_array1#{block})")
         check_allocations(0, 1, "optional(*r2k_array#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true
@@ -180,8 +180,8 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 0, "splat(*array1, *empty_array, **empty_hash#{block})")
         check_allocations(1, 1, "splat(*empty_array, **hash1, **empty_hash#{block})")
 
-        check_allocations(1, 1, "splat(*r2k_empty_array#{block})")
-        check_allocations(1, 1, "splat(*r2k_empty_array1#{block})")
+        check_allocations(1, 0, "splat(*r2k_empty_array#{block})")
+        check_allocations(1, 0, "splat(*r2k_empty_array1#{block})")
         check_allocations(1, 1, "splat(*r2k_array#{block})")
         check_allocations(1, 1, "splat(*r2k_array1#{block})")
       RUBY
@@ -214,7 +214,7 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 0, "req_splat(*array1, *empty_array, **empty_hash#{block})")
         check_allocations(1, 1, "req_splat(*empty_array, **hash1, **empty_hash#{block})")
 
-        check_allocations(1, 1, "req_splat(*r2k_empty_array1#{block})")
+        check_allocations(1, 0, "req_splat(*r2k_empty_array1#{block})")
         check_allocations(1, 1, "req_splat(*r2k_array#{block})")
         check_allocations(1, 1, "req_splat(*r2k_array1#{block})")
       RUBY
@@ -247,7 +247,7 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 0, "splat_post(*array1, *empty_array, **empty_hash#{block})")
         check_allocations(1, 1, "splat_post(*empty_array, **hash1, **empty_hash#{block})")
 
-        check_allocations(1, 1, "splat_post(*r2k_empty_array1#{block})")
+        check_allocations(1, 0, "splat_post(*r2k_empty_array1#{block})")
         check_allocations(1, 1, "splat_post(*r2k_array#{block})")
         check_allocations(1, 1, "splat_post(*r2k_array1#{block})")
       RUBY
@@ -277,7 +277,7 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(0, 1, "keyword(**hash1, **empty_hash#{block})")
         check_allocations(1, 0, "keyword(*empty_array, *empty_array, **empty_hash#{block})")
 
-        check_allocations(1, 1, "keyword(*r2k_empty_array#{block})")
+        check_allocations(1, 0, "keyword(*r2k_empty_array#{block})")
         check_allocations(1, 1, "keyword(*r2k_array#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true
@@ -385,7 +385,7 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "required_and_keyword(*array1, *empty_array, a: 2, **empty_hash#{block})")
         check_allocations(1, 1, "required_and_keyword(*array1, *empty_array, **hash1, **empty_hash#{block})")
 
-        check_allocations(1, 1, "required_and_keyword(*r2k_empty_array1#{block})")
+        check_allocations(1, 0, "required_and_keyword(*r2k_empty_array1#{block})")
         check_allocations(1, 1, "required_and_keyword(*r2k_array1#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true
@@ -436,9 +436,9 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "splat_and_keyword(*array1, **hash1, **empty_hash#{block})")
         check_allocations(1, 0, "splat_and_keyword(*array1, **nil#{block})")
 
-        check_allocations(1, 1, "splat_and_keyword(*r2k_empty_array#{block})")
+        check_allocations(1, 0, "splat_and_keyword(*r2k_empty_array#{block})")
         check_allocations(1, 1, "splat_and_keyword(*r2k_array#{block})")
-        check_allocations(1, 1, "splat_and_keyword(*r2k_empty_array1#{block})")
+        check_allocations(1, 0, "splat_and_keyword(*r2k_empty_array1#{block})")
         check_allocations(1, 1, "splat_and_keyword(*r2k_array1#{block})")
       RUBY
     end
@@ -758,11 +758,11 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "r2k(*array1, **hash1, **empty_hash#{block})")
         check_allocations(1, 0, "r2k(*array1, **nil#{block})")
 
-        check_allocations(1, 1, "r2k(*r2k_empty_array#{block})")
+        check_allocations(1, 0, "r2k(*r2k_empty_array#{block})")
         check_allocations(1, 1, "r2k(*r2k_array#{block})")
         unless defined?(RubyVM::YJIT.enabled?) && RubyVM::YJIT.enabled?
           # YJIT may or may not allocate depending on arch?
-          check_allocations(1, 1, "r2k(*r2k_empty_array1#{block})")
+          check_allocations(1, 0, "r2k(*r2k_empty_array1#{block})")
           check_allocations(1, 1, "r2k(*r2k_array1#{block})")
         end
       RUBY

--- a/test/ruby/test_allocation.rb
+++ b/test/ruby/test_allocation.rb
@@ -25,6 +25,10 @@ class TestAllocation < Test::Unit::TestCase
           empty_array = empty_array = []
           empty_hash = empty_hash = {}
           array1 = array1 = [1]
+          r2k_array = r2k_array = [Hash.ruby2_keywords_hash(a: 3)]
+          r2k_array1 = r2k_array1 = [1, Hash.ruby2_keywords_hash(a: 3)]
+          r2k_empty_array = r2k_empty_array = [Hash.ruby2_keywords_hash({})]
+          r2k_empty_array1 = r2k_empty_array1 = [1, Hash.ruby2_keywords_hash({})]
           hash1 = hash1 = {a: 2}
           nill = nill = nil
           block = block = lambda{}
@@ -95,6 +99,8 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 0, "none(*empty_array, *empty_array#{block})")
         check_allocations(0, 1, "none(**empty_hash, **empty_hash#{block})")
         check_allocations(1, 1, "none(*empty_array, *empty_array, **empty_hash, **empty_hash#{block})")
+
+        check_allocations(#{block.empty?} ? 0 : 1, #{block.empty?} ? 0 : 1, "none(*r2k_empty_array#{block})")
       RUBY
     end
 
@@ -113,6 +119,9 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 0, "required(*array1, *empty_array#{block})")
         check_allocations(0, 1, "required(**hash1, **empty_hash#{block})")
         check_allocations(1, 0, "required(*array1, *empty_array, **empty_hash#{block})")
+
+        check_allocations(#{block.empty?} ? 0 : 1, #{block.empty?} ? 0 : 1, "required(*r2k_empty_array1#{block})")
+        check_allocations(0, 1, "required(*r2k_array#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true
         check_allocations(1, 1, "required(*empty_array, **hash1, **empty_hash#{block})")
@@ -134,6 +143,10 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 0, "optional(*array1, *empty_array#{block})")
         check_allocations(0, 1, "optional(**hash1, **empty_hash#{block})")
         check_allocations(1, 0, "optional(*array1, *empty_array, **empty_hash#{block})")
+
+        check_allocations(#{block.empty?} ? 0 : 1, #{block.empty?} ? 0 : 1, "optional(*r2k_empty_array#{block})")
+        check_allocations(#{block.empty?} ? 0 : 1, #{block.empty?} ? 0 : 1, "optional(*r2k_empty_array1#{block})")
+        check_allocations(0, 1, "optional(*r2k_array#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true
         check_allocations(1, 1, "optional(*empty_array, **hash1, **empty_hash#{block})")
@@ -166,6 +179,11 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "splat(**hash1, **empty_hash#{block})")
         check_allocations(1, 0, "splat(*array1, *empty_array, **empty_hash#{block})")
         check_allocations(1, 1, "splat(*empty_array, **hash1, **empty_hash#{block})")
+
+        check_allocations(1, 1, "splat(*r2k_empty_array#{block})")
+        check_allocations(1, 1, "splat(*r2k_empty_array1#{block})")
+        check_allocations(1, 1, "splat(*r2k_array#{block})")
+        check_allocations(1, 1, "splat(*r2k_array1#{block})")
       RUBY
     end
 
@@ -195,6 +213,10 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "req_splat(**hash1, **empty_hash#{block})")
         check_allocations(1, 0, "req_splat(*array1, *empty_array, **empty_hash#{block})")
         check_allocations(1, 1, "req_splat(*empty_array, **hash1, **empty_hash#{block})")
+
+        check_allocations(1, 1, "req_splat(*r2k_empty_array1#{block})")
+        check_allocations(1, 1, "req_splat(*r2k_array#{block})")
+        check_allocations(1, 1, "req_splat(*r2k_array1#{block})")
       RUBY
     end
 
@@ -224,6 +246,10 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "splat_post(**hash1, **empty_hash#{block})")
         check_allocations(1, 0, "splat_post(*array1, *empty_array, **empty_hash#{block})")
         check_allocations(1, 1, "splat_post(*empty_array, **hash1, **empty_hash#{block})")
+
+        check_allocations(1, 1, "splat_post(*r2k_empty_array1#{block})")
+        check_allocations(1, 1, "splat_post(*r2k_array#{block})")
+        check_allocations(1, 1, "splat_post(*r2k_array1#{block})")
       RUBY
     end
 
@@ -250,6 +276,9 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(0, 0, "keyword(*empty_array#{block})")
         check_allocations(0, 1, "keyword(**hash1, **empty_hash#{block})")
         check_allocations(1, 0, "keyword(*empty_array, *empty_array, **empty_hash#{block})")
+
+        check_allocations(1, 1, "keyword(*r2k_empty_array#{block})")
+        check_allocations(1, 1, "keyword(*r2k_array#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true
         check_allocations(1, 1, "keyword(*empty_array, a: 2, **empty_hash#{block})")
@@ -281,6 +310,9 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(0, 1, "keyword_splat(**hash1, **empty_hash#{block})")
         check_allocations(1, 1, "keyword_splat(*empty_array, *empty_array, **empty_hash#{block})")
 
+        check_allocations(1, 1, "keyword_splat(*r2k_empty_array#{block})")
+        check_allocations(1, 1, "keyword_splat(*r2k_array#{block})")
+
         # Currently allocates 1 array unnecessarily due to splatarray true
         check_allocations(1, 1, "keyword_splat(*empty_array, a: 2, **empty_hash#{block})")
         check_allocations(1, 1, "keyword_splat(*empty_array, **hash1, **empty_hash#{block})")
@@ -310,6 +342,9 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(0, 1, "keyword_and_keyword_splat(*empty_array#{block})")
         check_allocations(0, 1, "keyword_and_keyword_splat(**hash1, **empty_hash#{block})")
         check_allocations(1, 1, "keyword_and_keyword_splat(*empty_array, *empty_array, **empty_hash#{block})")
+
+        check_allocations(1, 1, "keyword_and_keyword_splat(*r2k_empty_array#{block})")
+        check_allocations(1, 1, "keyword_and_keyword_splat(*r2k_array#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true
         check_allocations(1, 1, "keyword_and_keyword_splat(*empty_array, a: 2, **empty_hash#{block})")
@@ -349,6 +384,9 @@ class TestAllocation < Test::Unit::TestCase
 
         check_allocations(1, 1, "required_and_keyword(*array1, *empty_array, a: 2, **empty_hash#{block})")
         check_allocations(1, 1, "required_and_keyword(*array1, *empty_array, **hash1, **empty_hash#{block})")
+
+        check_allocations(1, 1, "required_and_keyword(*r2k_empty_array1#{block})")
+        check_allocations(1, 1, "required_and_keyword(*r2k_array1#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true
         check_allocations(1, 1, "required_and_keyword(1, *empty_array, a: 2, **empty_hash#{block})")
@@ -397,6 +435,11 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "splat_and_keyword(*array1, **empty_hash, a: 2#{block})")
         check_allocations(1, 1, "splat_and_keyword(*array1, **hash1, **empty_hash#{block})")
         check_allocations(1, 0, "splat_and_keyword(*array1, **nil#{block})")
+
+        check_allocations(1, 1, "splat_and_keyword(*r2k_empty_array#{block})")
+        check_allocations(1, 1, "splat_and_keyword(*r2k_array#{block})")
+        check_allocations(1, 1, "splat_and_keyword(*r2k_empty_array1#{block})")
+        check_allocations(1, 1, "splat_and_keyword(*r2k_array1#{block})")
       RUBY
     end
 
@@ -432,6 +475,9 @@ class TestAllocation < Test::Unit::TestCase
 
         check_allocations(1, 1, "required_and_keyword_splat(*array1, *empty_array, a: 2, **empty_hash#{block})")
         check_allocations(1, 1, "required_and_keyword_splat(*array1, *empty_array, **hash1, **empty_hash#{block})")
+
+        check_allocations(1, 1, "required_and_keyword_splat(*r2k_empty_array1#{block})")
+        check_allocations(1, 1, "required_and_keyword_splat(*r2k_array1#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true
         check_allocations(1, 1, "required_and_keyword_splat(1, *empty_array, a: 2, **empty_hash#{block})")
@@ -480,6 +526,11 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "splat_and_keyword_splat(*array1, **empty_hash, a: 2#{block})")
         check_allocations(1, 1, "splat_and_keyword_splat(*array1, **hash1, **empty_hash#{block})")
         check_allocations(1, 1, "splat_and_keyword_splat(*array1, **nil#{block})")
+
+        check_allocations(1, 1, "splat_and_keyword_splat(*r2k_empty_array#{block})")
+        check_allocations(1, 1, "splat_and_keyword_splat(*r2k_array#{block})")
+        check_allocations(1, 1, "splat_and_keyword_splat(*r2k_empty_array1#{block})")
+        check_allocations(1, 1, "splat_and_keyword_splat(*r2k_array1#{block})")
       RUBY
     end
 
@@ -521,6 +572,11 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "anon_splat_and_anon_keyword_splat(*array1, **empty_hash, a: 2#{block})")
         check_allocations(1, 1, "anon_splat_and_anon_keyword_splat(*array1, **hash1, **empty_hash#{block})")
         check_allocations(1, 0, "anon_splat_and_anon_keyword_splat(*array1, **nil#{block})")
+
+        check_allocations(1, 1, "anon_splat_and_anon_keyword_splat(*r2k_empty_array#{block})")
+        check_allocations(1, 1, "anon_splat_and_anon_keyword_splat(*r2k_array#{block})")
+        check_allocations(1, 1, "anon_splat_and_anon_keyword_splat(*r2k_empty_array1#{block})")
+        check_allocations(1, 1, "anon_splat_and_anon_keyword_splat(*r2k_array1#{block})")
       RUBY
     end
 
@@ -562,6 +618,11 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "anon_splat_and_anon_keyword_splat(*array1, **empty_hash, a: 2#{block})")
         check_allocations(1, 1, "anon_splat_and_anon_keyword_splat(*array1, **hash1, **empty_hash#{block})")
         check_allocations(1, 0, "anon_splat_and_anon_keyword_splat(*array1, **nil#{block})")
+
+        check_allocations(1, 1, "anon_splat_and_anon_keyword_splat(*r2k_empty_array#{block})")
+        check_allocations(1, 1, "anon_splat_and_anon_keyword_splat(*r2k_array#{block})")
+        check_allocations(1, 1, "anon_splat_and_anon_keyword_splat(*r2k_empty_array1#{block})")
+        check_allocations(1, 1, "anon_splat_and_anon_keyword_splat(*r2k_array1#{block})")
       RUBY
     end
 
@@ -603,6 +664,11 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "argument_forwarding(*array1, **empty_hash, a: 2#{block})")
         check_allocations(1, 1, "argument_forwarding(*array1, **hash1, **empty_hash#{block})")
         check_allocations(1, 0, "argument_forwarding(*array1, **nil#{block})")
+
+        check_allocations(1, 1, "argument_forwarding(*r2k_empty_array#{block})")
+        check_allocations(1, 1, "argument_forwarding(*r2k_array#{block})")
+        check_allocations(1, 1, "argument_forwarding(*r2k_empty_array1#{block})")
+        check_allocations(1, 1, "argument_forwarding(*r2k_array1#{block})")
       RUBY
     end
 
@@ -644,6 +710,61 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "argument_forwarding(*array1, **empty_hash, a: 2#{block})")
         check_allocations(1, 1, "argument_forwarding(*array1, **hash1, **empty_hash#{block})")
         check_allocations(1, 0, "argument_forwarding(*array1, **nil#{block})")
+
+        check_allocations(1, 1, "argument_forwarding(*r2k_empty_array#{block})")
+        check_allocations(1, 1, "argument_forwarding(*r2k_array#{block})")
+        check_allocations(1, 1, "argument_forwarding(*r2k_empty_array1#{block})")
+        check_allocations(1, 1, "argument_forwarding(*r2k_array1#{block})")
+      RUBY
+    end
+
+    def test_ruby2_keywords
+      check_allocations(<<~RUBY)
+        def self.r2k(*a#{block}); end
+        singleton_class.send(:ruby2_keywords, :r2k)
+
+        check_allocations(1, 1, "r2k(1, a: 2#{block})")
+        check_allocations(1, 1, "r2k(1, *empty_array, a: 2#{block})")
+        check_allocations(1, 1, "r2k(1, a:2, **empty_hash#{block})")
+        check_allocations(1, 1, "r2k(1, **empty_hash, a: 2#{block})")
+
+        check_allocations(1, 0, "r2k(1, **nil#{block})")
+        check_allocations(1, 1, "r2k(1, **empty_hash#{block})")
+        check_allocations(1, 1, "r2k(1, **hash1#{block})")
+        check_allocations(1, 1, "r2k(1, *empty_array, **hash1#{block})")
+        check_allocations(1, 1, "r2k(1, **hash1, **empty_hash#{block})")
+        check_allocations(1, 1, "r2k(1, **empty_hash, **hash1#{block})")
+
+        check_allocations(1, 0, "r2k(1, *empty_array#{block})")
+        check_allocations(1, 1, "r2k(1, **hash1, **empty_hash#{block})")
+        check_allocations(1, 1, "r2k(1, *empty_array, *empty_array, **empty_hash#{block})")
+
+        check_allocations(1, 1, "r2k(*array1, a: 2#{block})")
+
+        check_allocations(1, 0, "r2k(*array1, **nill#{block})")
+        check_allocations(1, 1, "r2k(*array1, **empty_hash#{block})")
+        check_allocations(1, 1, "r2k(*array1, **hash1#{block})")
+        check_allocations(1, 1, "r2k(*array1, *empty_array, **hash1#{block})")
+
+        check_allocations(1, 0, "r2k(*array1, *empty_array#{block})")
+        check_allocations(1, 1, "r2k(*array1, *empty_array, **empty_hash#{block})")
+
+        check_allocations(1, 1, "r2k(*array1, *empty_array, a: 2, **empty_hash#{block})")
+        check_allocations(1, 1, "r2k(*array1, *empty_array, **hash1, **empty_hash#{block})")
+
+        check_allocations(1, 1, "r2k(1, *empty_array, a: 2, **empty_hash#{block})")
+        check_allocations(1, 1, "r2k(1, *empty_array, **hash1, **empty_hash#{block})")
+        check_allocations(1, 1, "r2k(*array1, **empty_hash, a: 2#{block})")
+        check_allocations(1, 1, "r2k(*array1, **hash1, **empty_hash#{block})")
+        check_allocations(1, 0, "r2k(*array1, **nil#{block})")
+
+        check_allocations(1, 1, "r2k(*r2k_empty_array#{block})")
+        check_allocations(1, 1, "r2k(*r2k_array#{block})")
+        unless defined?(RubyVM::YJIT.enabled?) && RubyVM::YJIT.enabled?
+          # YJIT may or may not allocate depending on arch?
+          check_allocations(1, 1, "r2k(*r2k_empty_array1#{block})")
+          check_allocations(1, 1, "r2k(*r2k_array1#{block})")
+        end
       RUBY
     end
 

--- a/vm_args.c
+++ b/vm_args.c
@@ -684,7 +684,9 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
             if (RB_TYPE_P(rest_last, T_HASH) && FL_TEST_RAW(rest_last, RHASH_PASS_AS_KEYWORDS)) {
                 // def f(**kw); a = [..., kw]; g(*a)
                 splat_flagged_keyword_hash = rest_last;
-                rest_last = rb_hash_dup(rest_last);
+                if (!RHASH_EMPTY_P(rest_last) || (ISEQ_BODY(iseq)->param.flags.has_kwrest)) {
+                    rest_last = rb_hash_dup(rest_last);
+                }
                 kw_flag |= VM_CALL_KW_SPLAT | VM_CALL_KW_SPLAT_MUT;
 
                 // Unset rest_dupped set by anon_rest as we may need to modify splat in this case

--- a/vm_args.c
+++ b/vm_args.c
@@ -693,8 +693,11 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
                 args->rest_dupped = false;
 
                 if (ignore_keyword_hash_p(rest_last, iseq, &kw_flag, &converted_keyword_hash)) {
-                    arg_rest_dup(args);
-                    rb_ary_pop(args->rest);
+                    if (ISEQ_BODY(iseq)->param.flags.has_rest || arg_setup_type != arg_setup_method) {
+                        // Only duplicate/modify splat array if it will be used
+                        arg_rest_dup(args);
+                        rb_ary_pop(args->rest);
+                    }
                     given_argc--;
                     kw_flag &= ~(VM_CALL_KW_SPLAT | VM_CALL_KW_SPLAT_MUT);
                 }


### PR DESCRIPTION
This tests ruby2_keywords flagged methods, as well as passing ruby2_keywords flagged hashes to other methods.

Some of the behavior here is questionable, such as allocating different numbers of objects depending on whether a block is passed or whether YJIT is enabled. I think there are likely ways to eliminate allocations in certain cases.  However, this gives us a baseline and shows us where it is possible to make improvements.