### PR TITLE
Fix typo in example code for `String#encode` method

### DIFF
--- a/doc/encodings.rdoc
+++ b/doc/encodings.rdoc
@@ -419,7 +419,7 @@ These keyword-value pairs specify encoding options:
 
     hash = {"\u3042" => 'xyzzy'}
     hash.default = 'XYZZY'
-    s.encode('ASCII', fallback: h) # => "xyzzyfooXYZZY"
+    s.encode('ASCII', fallback: hash) # => "xyzzyfooXYZZY"
 
     def (fallback = "U+%.4X").escape(x)
       self % x.unpack("U")


### PR DESCRIPTION
The example code in the documentation for the `String#encode` method has a typo in the `fallback` option. The example code uses `h` as the fallback option, but it should use `hash` instead to match the variable name in the example code.