### PR TITLE
Allow waitpid(-1, Process::WNOHANG) to be woken if a waitpid(pid) is pending (3.2 backport)

### DIFF
--- a/process.c
+++ b/process.c
@@ -1290,7 +1290,7 @@ waitpid_wait(struct waitpid_state *w)
     if (w->ret) {
         if (w->ret == -1) w->errnum = errno;
     }
-    else if (w->options & WNOHANG) {
+    else if (w->options & WNOHANG && w->pid > 0) {
     }
     else {
         need_sleep = TRUE;


### PR DESCRIPTION
If two threads are running, with one calling waitpid(-1, Process::WNOHANG), and another calling waitpid($some_pid), and then $some_other_pid exits, we would expect the waitpid(-1, Process::WNOHANG) call to retrieve that exit status. However, it cannot actually do so until $some_pid _also_ exits.

This patch fixes the issue by ensuring that if -1 is specified with the WNOHANG flag, -1 gets added to the process group waits on SIGCHLD.

This is a similar issue to https://bugs.ruby-lang.org/issues/19837, except the WNOHANG flag is used.

Fixes [#20490](https://bugs.ruby-lang.org/issues/20490)