### PR TITLE
Allow waitpid(-1, Process::WNOHANG) to be woken if a waitpid(pid) is pending (3.1 backport)

### DIFF
--- a/process.c
+++ b/process.c
@@ -1292,7 +1292,7 @@ waitpid_wait(struct waitpid_state *w)
     if (w->ret) {
         if (w->ret == -1) w->errnum = errno;
     }
-    else if (w->options & WNOHANG) {
+    else if (w->options & WNOHANG && w->pid > 0) {
     }
     else {
         need_sleep = TRUE;

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -2638,7 +2638,7 @@ EOS
     end;
   end if Process.respond_to?(:_fork)
 
-  def test_concurrent_group_and_pid_wait
+  def _test_concurrent_group_and_pid_wait(nohang)
     # Use a pair of pipes that will make long_pid exit when this test exits, to avoid
     # leaking temp processes.
     long_rpipe, long_wpipe = IO.pipe
@@ -2662,8 +2662,23 @@ EOS
       Thread.pass until t1.stop?
       short_wpipe.close # Make short_pid exit
 
-      # The short pid has exited, so -1 should pick that up.
-      assert_equal short_pid, Process.waitpid(-1)
+      # The short pid has exited, so waitpid(-1) should pick that up.
+      exited_pid =
+        unless nohang
+          Process.waitpid(-1)
+        else
+          EnvUtil.timeout(5) do
+            loop do
+              pid = Process.waitpid(-1, Process::WNOHANG)
+
+              break pid if pid
+
+              sleep 0.1
+            end
+          end
+        end
+
+      assert_equal short_pid, exited_pid
 
       # Terminate t1 for the next phase of the test.
       t1.kill
@@ -2691,5 +2706,13 @@ EOS
     [t1, t2, t3].each { _1&.kill rescue nil }
     [t1, t2, t3].each { _1&.join rescue nil }
     [long_rpipe, long_wpipe, short_rpipe, short_wpipe].each { _1&.close rescue nil }
+  end if defined?(fork)
+
+  def test_concurrent_group_and_pid_wait
+    _test_concurrent_group_and_pid_wait(false)
+  end if defined?(fork)
+
+  def test_concurrent_group_and_pid_wait_nohang
+    _test_concurrent_group_and_pid_wait(true)
   end if defined?(fork)
 end


### PR DESCRIPTION
If two threads are running, with one calling waitpid(-1, Process::WNOHANG), and another calling waitpid($some_pid), and then $some_other_pid exits, we would expect the waitpid(-1, Process::WNOHANG) call to retrieve that exit status. However, it cannot actually do so until $some_pid _also_ exits.

This patch fixes the issue by ensuring that if -1 is specified with the WNOHANG flag, -1 gets added to the process group waits on SIGCHLD.

This is a similar issue to https://bugs.ruby-lang.org/issues/19837, except the WNOHANG flag is used.

Fixes [#20490](https://bugs.ruby-lang.org/issues/20490)