### PR TITLE
Introduce `iniline_operation` rule

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -2908,6 +2908,9 @@ rb_parser_ary_free(rb_parser_t *p, rb_parser_ary_t *ary)
                 | keyword_variable
                 ;
 
+%rule %inline inline_operation : ident_or_const
+                               | tFID
+                               ;
 /*
  *	parameterizing rules
  */
@@ -3756,8 +3759,7 @@ cpath		: tCOLON3 cname
                     }
                 ;
 
-fname		: ident_or_const
-                | tFID
+fname		: inline_operation
                 | op
                     {
                         SET_LEX_STATE(EXPR_ENDFN);
@@ -6827,8 +6829,7 @@ assoc		: arg_value tASSOC arg_value
                     }
                 ;
 
-operation	: ident_or_const
-                | tFID
+operation	: inline_operation
                 ;
 
 operation2	: operation


### PR DESCRIPTION
`lrama` allow `%inline` directive, which may be add `inline_operation`.

```yacc
/*
 *	inlining rules
 */
%rule %inline inline_operation : tIDENTIFIER
                               | tCONSTANT
                               | tFID
                               ;
```

And it looks like can replace the same BNF pattern of `fname` and `operation` with `inline_operation`.

