### PR TITLE
Update duplicated 'when' clause warning message

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -13334,8 +13334,8 @@ check_literal_when(struct parser_params *p, NODE *arg, const YYLTYPE *loc)
     else {
         st_data_t line;
         if (st_lookup(p->case_labels, (st_data_t)arg, &line)) {
-            rb_warning1("duplicated 'when' clause with line %d is ignored",
-                        WARN_I((int)line));
+            rb_warning2("'when' clause on line %d duplicates 'when' clause on line %d and is ignored",
+                        WARN_I((int)nd_line(arg)), WARN_I((int)line));
             return;
         }
     }

--- a/prism/static_literals.h
+++ b/prism/static_literals.h
@@ -95,9 +95,10 @@ typedef struct {
  * @param start_line The line number that the parser starts on.
  * @param literals The set of static literals to add the node to.
  * @param node The node to add to the set.
+ * @param replace Whether to replace the previous node if one already exists.
  * @return A pointer to the node that is being overwritten, if there is one.
  */
-pm_node_t * pm_static_literals_add(const pm_newline_list_t *newline_list, int32_t start_line, pm_static_literals_t *literals, pm_node_t *node);
+pm_node_t * pm_static_literals_add(const pm_newline_list_t *newline_list, int32_t start_line, pm_static_literals_t *literals, pm_node_t *node, bool replace);
 
 /**
  * Free the internal memory associated with the given static literals set.

--- a/prism/templates/src/diagnostic.c.erb
+++ b/prism/templates/src/diagnostic.c.erb
@@ -368,7 +368,7 @@ static const pm_diagnostic_data_t diagnostic_messages[PM_DIAGNOSTIC_ID_MAX] = {
     [PM_WARN_COMPARISON_AFTER_COMPARISON]       = { "comparison '%.*s' after comparison", PM_WARNING_LEVEL_VERBOSE },
     [PM_WARN_DOT_DOT_DOT_EOL]                   = { "... at EOL, should be parenthesized?", PM_WARNING_LEVEL_DEFAULT },
     [PM_WARN_DUPLICATED_HASH_KEY]               = { "key %.*s is duplicated and overwritten on line %" PRIi32, PM_WARNING_LEVEL_DEFAULT },
-    [PM_WARN_DUPLICATED_WHEN_CLAUSE]            = { "duplicated 'when' clause with line %" PRIi32 " is ignored", PM_WARNING_LEVEL_VERBOSE },
+    [PM_WARN_DUPLICATED_WHEN_CLAUSE]            = { "'when' clause on line %" PRIi32 " duplicates 'when' clause on line %" PRIi32 " and is ignored", PM_WARNING_LEVEL_VERBOSE },
     [PM_WARN_EQUAL_IN_CONDITIONAL_3_3]          = { "found `= literal' in conditional, should be ==", PM_WARNING_LEVEL_DEFAULT },
     [PM_WARN_EQUAL_IN_CONDITIONAL]              = { "found '= literal' in conditional, should be ==", PM_WARNING_LEVEL_DEFAULT },
     [PM_WARN_END_IN_METHOD]                     = { "END in method; use at_exit", PM_WARNING_LEVEL_DEFAULT },

--- a/spec/ruby/language/case_spec.rb
+++ b/spec/ruby/language/case_spec.rb
@@ -416,17 +416,34 @@ describe "The 'case'-construct" do
     self.test(true).should == true
   end
 
-  it "warns if there are identical when clauses" do
-    -> {
-      eval <<~RUBY
-        case 1
-        when 2
-          :foo
-        when 2
-          :bar
-        end
-      RUBY
-    }.should complain(/warning: duplicated .when' clause with line \d+ is ignored/, verbose: true)
+  ruby_version_is ""..."3.4" do
+    it "warns if there are identical when clauses" do
+      -> {
+        eval <<~RUBY
+          case 1
+          when 2
+            :foo
+          when 2
+            :bar
+          end
+        RUBY
+      }.should complain(/warning: duplicated .when' clause with line \d+ is ignored/, verbose: true)
+    end
+  end
+
+  ruby_version_is "3.4" do
+    it "warns if there are identical when clauses" do
+      -> {
+        eval <<~RUBY
+          case 1
+          when 2
+            :foo
+          when 2
+            :bar
+          end
+        RUBY
+      }.should complain(/warning: 'when' clause on line \d+ duplicates 'when' clause on line \d+ and is ignored/, verbose: true)
+    end
   end
 end
 

--- a/test/.excludes-prism/TestSyntax.rb
+++ b/test/.excludes-prism/TestSyntax.rb
@@ -1,4 +1,3 @@
 exclude(:test_dedented_heredoc_continued_line, "https://bugs.ruby-lang.org/issues/20503")
-exclude(:test_duplicated_when, "https://bugs.ruby-lang.org/issues/20401")
 exclude(:test_optional_self_reference, "https://bugs.ruby-lang.org/issues/20478")
 exclude(:test_keyword_self_reference, "https://bugs.ruby-lang.org/issues/20478")

--- a/test/prism/warnings_test.rb
+++ b/test/prism/warnings_test.rb
@@ -65,7 +65,7 @@ module Prism
     end
 
     def test_duplicated_when_clause
-      assert_warning("case 1; when 1, 1; end", "clause with line")
+      assert_warning("case 1; when 1, 1; end", "when' clause")
     end
 
     def test_float_out_of_range

--- a/test/ripper/test_parser_events.rb
+++ b/test/ripper/test_parser_events.rb
@@ -1694,8 +1694,8 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
       else
       end
     STR
-    assert_match(/duplicated 'when' clause/, fmt)
-    assert_equal([3], args)
+    assert_match(/duplicates 'when' clause/, fmt)
+    assert_equal([4, 3], args)
   end
 
   def test_warn_duplicated_hash_keys

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -713,8 +713,8 @@ class TestSyntax < Test::Unit::TestCase
   end
 
   def test_duplicated_when
-    w = 'warning: duplicated \'when\' clause with line 3 is ignored'
-    assert_warning(/3: #{w}.+4: #{w}.+4: #{w}.+5: #{w}.+5: #{w}/m) {
+    w = ->(line) { "warning: 'when' clause on line #{line} duplicates 'when' clause on line 3 and is ignored" }
+    assert_warning(/#{w[3]}.+#{w[4]}.+#{w[4]}.+#{w[5]}.+#{w[5]}/m) {
       eval %q{
         case 1
         when 1, 1
@@ -723,7 +723,7 @@ class TestSyntax < Test::Unit::TestCase
         end
       }
     }
-    assert_warning(/#{w}/) {#/3: #{w}.+4: #{w}.+5: #{w}.+5: #{w}/m){
+    assert_warning(/#{w[3]}.+#{w[4]}.+#{w[5]}.+#{w[5]}/m) {
       a = a = 1
       eval %q{
         case 1
@@ -733,7 +733,7 @@ class TestSyntax < Test::Unit::TestCase
         end
       }
     }
-    assert_warning(/3: #{w}/m) {
+    assert_warning(/#{w[3]}/) {
       eval %q{
         case 1
         when __LINE__, __LINE__
@@ -742,7 +742,7 @@ class TestSyntax < Test::Unit::TestCase
         end
       }
     }
-    assert_warning(/3: #{w}/m) {
+    assert_warning(/#{w[3]}/) {
       eval %q{
         case 1
         when __FILE__, __FILE__
@@ -754,7 +754,7 @@ class TestSyntax < Test::Unit::TestCase
   end
 
   def test_duplicated_when_check_option
-    w = /duplicated \'when\' clause with line 3 is ignored/
+    w = /'when' clause on line 4 duplicates 'when' clause on line 3 and is ignored/
     assert_in_out_err(%[-wc], "#{<<~"begin;"}\n#{<<~'end;'}", ["Syntax OK"], w)
     begin;
       case 1


### PR DESCRIPTION
Previously for duplicated when clauses like:

1: case foo
2: when :bar
3: when :baz
4: when :bar
5: end

You would get a warning like:

```
warning: duplicated 'when' clause with line 2 is ignored
```

which is supposed to read as in:

"The 'when' clause at line 4 duplicates (conflicts) with (a 'when' clause at) line 2. This is ignored."

The issue is that it can be read as the clause on line 2 is ignored. This commit updates the warning message to instead say:

```
warning: 'when' clause on line 4 duplicates 'when' clause on line 2 and is ignored
```

This makes it clear which clause is begin duplicated and which clause is being ignored.

This commit fixes both parsers.