### PR TITLE
[ruby/securerandom] adding SecureRandom.nummeric

### DIFF
--- a/lib/random/formatter.rb
+++ b/lib/random/formatter.rb
@@ -370,4 +370,35 @@ module Random::Formatter
     n = 16 if n.nil?
     choose(chars, n)
   end
+
+  # The default character list for #numeric.
+  NUMERIC = [*'0'..'9']
+
+  # Generate a random numeric string.
+  #
+  # The argument _n_ specifies the length, in characters, of the numeric
+  # string to be generated.
+  # The argument _chars_ specifies the character list which the result is
+  # consist of.
+  #
+  # If _n_ is not specified or is nil, 16 is assumed.
+  # It may be larger in the future.
+  #
+  # The result may contain 0-9, unless _chars_ is specified.
+  #
+  #   require 'random/formatter'
+  #
+  #   Random.numeric     #=> "0115469885704937"
+  #   # or
+  #   prng = Random.new
+  #   prng.numeric(10) #=> "3461790852"
+  #
+  #   Random.numeric(4, chars: [*"0".."5"]) #=> "2152"
+  #   # or
+  #   prng = Random.new
+  #   prng.numeric(10, chars: [*"0".."5"]) #=> "2152"
+  def numeric(n = nil, chars: NUMERIC)
+    n = 16 if n.nil?
+    choose(chars, n)
+  end
 end

--- a/test/ruby/test_random_formatter.rb
+++ b/test/ruby/test_random_formatter.rb
@@ -136,6 +136,27 @@ module Random::Formatter
           assert_equal(n, an.length)
         end
       end
+
+      def test_numeric
+        65.times do |n|
+          an = @it.numeric(n)
+          assert_match(/\A[0-9]*\z/, an)
+          assert_equal(n, an.length)
+        end
+      end
+
+      def test_numeric_chars
+        [
+          [[*"0".."9"], /\A\d*\z/],
+          [[*"0".."4"], /\A[0-4]*\z/],
+        ].each do |chars, pattern|
+          10.times do |n|
+            an = @it.numeric(n, chars: chars)
+            assert_match(pattern, an)
+            assert_equal(n, an.length)
+          end
+        end
+      end
     end
 
     def assert_in_range(range, result, mesg = nil)


### PR DESCRIPTION
At the moment if you want a random string out of numbers you need to write:
```ruby
.alphanumeric(10, chars: [*'0'..'9'])
```
which this change you can simply write:
```ruby
.numeric(10)
```