### PR TITLE
`rb_enc_compile_warn` and `rb_enc_compile_warning` are printf format

### DIFF
--- a/internal/error.h
+++ b/internal/error.h
@@ -142,6 +142,8 @@ VALUE rb_syntax_error_append(VALUE, VALUE, int, int, rb_encoding*, const char*, 
 PRINTF_ARGS(void rb_enc_warn(rb_encoding *enc, const char *fmt, ...), 2, 3);
 PRINTF_ARGS(void rb_sys_enc_warning(rb_encoding *enc, const char *fmt, ...), 2, 3);
 PRINTF_ARGS(void rb_syserr_enc_warning(int err, rb_encoding *enc, const char *fmt, ...), 3, 4);
+PRINTF_ARGS(void rb_enc_compile_warning(rb_encoding *enc, const char *file, int line, const char *fmt, ...), 4, 5);
+PRINTF_ARGS(void rb_enc_compile_warn(rb_encoding *enc, const char *file, int line, const char *fmt, ...), 4, 5);
 rb_warning_category_t rb_warning_category_from_name(VALUE category);
 bool rb_warning_category_enabled_p(rb_warning_category_t category);
 VALUE rb_name_err_new(VALUE mesg, VALUE recv, VALUE method);

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -9280,9 +9280,6 @@ pm_parse_process_error(const pm_parse_result_t *result)
     return error;
 }
 
-void rb_enc_compile_warning(rb_encoding *enc, const char *file, int line, const char *fmt, ...);
-void rb_enc_compile_warn(rb_encoding *enc, const char *file, int line, const char *fmt, ...);
-
 /**
  * Parse the parse result and raise a Ruby error if there are any syntax errors.
  * It returns an error if one should be raised. It is assumed that the parse


### PR DESCRIPTION
```
../src/error.c: In function ‘rb_enc_compile_warn’:
../src/error.c:410:9: warning: function ‘rb_enc_compile_warn’ might be a candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
  410 |         with_warn_vsprintf(enc, file, line, fmt) {
      |         ^~~~~~~~~~~~~~~~~~
../src/error.c: In function ‘rb_enc_compile_warning’:
../src/error.c:432:9: warning: function ‘rb_enc_compile_warning’ might be a candidate for ‘gnu_printf’ format attribute [-Wsuggest-attribute=format]
  432 |         with_warn_vsprintf(enc, file, line, fmt) {
      |         ^~~~~~~~~~~~~~~~~~
```