### PR TITLE
Remove `rb_bug` after COMPILE_ERROR

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -5406,7 +5406,6 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             }
 
             COMPILE_ERROR(ERROR_ARGS "Invalid break");
-            rb_bug("Invalid break");
         }
         return;
       }


### PR DESCRIPTION
Fix test failures since 7afc16aa48beb093b06eb978bc430f90dd771690.
Why crash after reported compile error properly.