### PR TITLE
Tempfile.create_io implemented.

### DIFF
--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -513,7 +513,7 @@ end
 # this method fallbacks to create-and-unlink as on POSIX.
 #
 # Related: Tempfile.create.
-def Tempfile.create_io(basename="", tmpdir=nil, **options, &block)
+def Tempfile.create_io(basename="", tmpdir=nil, mode: 0, **options, &block)
   tmpio = nil
   if defined? File::TMPFILE # O_TMPFILE since Linux 3.11
     tmpfile_supported = true
@@ -528,7 +528,8 @@ def Tempfile.create_io(basename="", tmpdir=nil, **options, &block)
     end
   end
   if tmpio.nil?
-    tmpfile = Tempfile.create(basename, tmpdir, **options)
+    mode |= File::SHARE_DELETE
+    tmpfile = Tempfile.create(basename, tmpdir, mode: mode, **options)
     File.unlink(tmpfile.path)
     tmpfile.autoclose = false
     tmpio = IO.new(tmpfile.fileno, File::RDWR) # change File to IO to drop path.

--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -490,6 +490,12 @@ end
 #
 # Example:
 #
+#   Tempfile.create_io {|tmpio|
+#     tmpio.puts "foo"
+#     tmpio.rewind
+#     p tmpio.read              # => "foo\n"
+#   }
+#
 #   tmpio = Tempfile.create_io  # => #<IO:fd 5>
 #   tmpio.class                 # => IO
 #   tmpio.path                  # => nil

--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -392,9 +392,9 @@ end
 #   see {File Permissions}[rdoc-ref:File@File+Permissions].
 # - Mode is <tt>'w+'</tt> (read/write mode, positioned at the end).
 #
-# The temporary file removal depends on the keyword argument +unlink_first+ and
+# The temporary file removal depends on the keyword argument +anonymous+ and
 # whether a block is given or not.
-# See the description about the +unlink_first+ keyword argument later.
+# See the description about the +anonymous+ keyword argument later.
 #
 # Example:
 #
@@ -415,16 +415,16 @@ end
 #     File.exist?(f.path)   # => true
 #   }                       # The file is removed at block exit.
 #
-#   f = Tempfile.create(unlink_first: true)
-#   # The file is already removed because unlink_first
+#   f = Tempfile.create(anonymous: true)
+#   # The file is already removed because anonymous
 #   f.path                  # => "/tmp/"  (no filename since no file)
 #   f.puts "foo"
 #   f.rewind
 #   f.read                  # => "foo\n"
 #   f.close
 #
-#   Tempfile.create(unlink_first: true) {|f|
-#     # The file is already removed because unlink_first
+#   Tempfile.create(anonymous: true) {|f|
+#     # The file is already removed because anonymous
 #     f.path                # => "/tmp/"  (no filename since no file)
 #     f.puts "foo"
 #     f.rewind
@@ -454,21 +454,21 @@ end
 #   {File::Constants}[rdoc-ref:File::Constants].
 # - For +options+, see {Open Options}[rdoc-ref:IO@Open+Options].
 #
-# The keyword argument +unlink_first+ specifies when the file is removed.
+# The keyword argument +anonymous+ specifies when the file is removed.
 #
-# - +unlink_first=false+ (default) without a block: the file is not removed.
-# - +unlink_first=false+ (default) with a block: the file is removed after the block exits.
-# - +unlink_first=true+ without a block: the file is removed before returning.
-# - +unlink_first=true+ with a block: the file is removed before the block is called.
+# - +anonymous=false+ (default) without a block: the file is not removed.
+# - +anonymous=false+ (default) with a block: the file is removed after the block exits.
+# - +anonymous=true+ without a block: the file is removed before returning.
+# - +anonymous=true+ with a block: the file is removed before the block is called.
 #
-# In the first case (+unlink_first=false+ without a block),
+# In the first case (+anonymous=false+ without a block),
 # the file is not removed automatically.
 # It should be explicitly closed.
 # It can be used to rename to the desired filename.
 # If the file is not needed, it should be explicitly removed.
 #
 # The +File#path+ method of the created file object returns the temporary directory with a trailing slash
-# when +unlink_first+ is true.
+# when +anonymous+ is true.
 #
 # When a block is given, it creates the file as described above, passes it to the block,
 # and returns the block's value.
@@ -478,13 +478,13 @@ end
 #
 # Implementation note:
 #
-# The keyword argument +unlink_first=true+ is implemented using FILE_SHARE_DELETE on Windows.
+# The keyword argument +anonymous=true+ is implemented using FILE_SHARE_DELETE on Windows.
 # O_TMPFILE is used on Linux.
 #
 # Related: Tempfile.new.
 #
-def Tempfile.create(basename="", tmpdir=nil, mode: 0, unlink_first: false, **options, &block)
-  if unlink_first
+def Tempfile.create(basename="", tmpdir=nil, mode: 0, anonymous: false, **options, &block)
+  if anonymous
     create_without_file(basename, tmpdir, mode: mode, **options, &block)
   else
     create_with_file(basename, tmpdir, mode: mode, **options, &block)

--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -417,7 +417,7 @@ end
 #
 #   f = Tempfile.create(unlink_first: true)
 #   # The file is already removed because unlink_first
-#   f.path                  # => nil            (no path since no file)
+#   f.path                  # => "/tmp/"  (no filename since no file)
 #   f.puts "foo"
 #   f.rewind
 #   f.read                  # => "foo\n"
@@ -425,7 +425,7 @@ end
 #
 #   Tempfile.create(unlink_first: true) {|f|
 #     # The file is already removed because unlink_first
-#     f.path                # => nil            (no path since no file)
+#     f.path                # => "/tmp/"  (no filename since no file)
 #     f.puts "foo"
 #     f.rewind
 #     f.read                # => "foo\n"
@@ -467,7 +467,8 @@ end
 # It can be used to rename to the desired filename.
 # If the file is not needed, it should be explicitly removed.
 #
-# The +File#path+ method of the created file object returns nil when +unlink_first+ is true.
+# The +File#path+ method of the created file object returns the temporary directory with a trailing slash
+# when +unlink_first+ is true.
 #
 # When a block is given, it creates the file as described above, passes it to the block,
 # and returns the block's value.
@@ -536,10 +537,11 @@ private def create_without_file(basename="", tmpdir=nil, mode: 0, **options, &bl
     tmpfile = create_with_file(basename, tmpdir, mode: mode, **options)
     File.unlink(tmpfile.path)
   end
-  if tmpfile.path != nil
+  path = File.join(tmpdir, '')
+  if tmpfile.path != path
     # clear path.
     tmpfile.autoclose = false
-    tmpfile = File.new(tmpfile.fileno, mode: File::RDWR, path: nil)
+    tmpfile = File.new(tmpfile.fileno, mode: File::RDWR, path: path)
   end
   if block
     begin

--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -534,7 +534,7 @@ private def create_without_file(basename="", tmpdir=nil, mode: 0, **options, &bl
   if tmpfile.nil?
     mode |= File::SHARE_DELETE | File::BINARY # Windows needs them to unlink the opened file.
     tmpfile = create_with_file(basename, tmpdir, mode: mode, **options)
-    File.unlink(tmpfile.path) # Windows defers deleting the file until closing.
+    File.unlink(tmpfile.path)
   end
   if tmpfile.path != nil
     # clear path.

--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -539,7 +539,7 @@ private def create_without_file(basename="", tmpdir=nil, mode: 0, **options, &bl
   if tmpfile.path != nil
     # clear path.
     tmpfile.autoclose = false
-    tmpfile = File.new(tmpfile.fileno, path: nil)
+    tmpfile = File.new(tmpfile.fileno, 'w+', path: nil)
   end
   if block
     begin

--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -485,14 +485,14 @@ end
 #
 def Tempfile.create(basename="", tmpdir=nil, mode: 0, anonymous: false, **options, &block)
   if anonymous
-    create_without_file(basename, tmpdir, mode: mode, **options, &block)
+    create_anonymous(basename, tmpdir, mode: mode, **options, &block)
   else
-    create_with_file(basename, tmpdir, mode: mode, **options, &block)
+    create_with_filename(basename, tmpdir, mode: mode, **options, &block)
   end
 end
 
 class << Tempfile
-private def create_with_file(basename="", tmpdir=nil, mode: 0, **options)
+private def create_with_filename(basename="", tmpdir=nil, mode: 0, **options)
   tmpfile = nil
   Dir::Tmpname.create(basename, tmpdir, **options) do |tmpname, n, opts|
     mode |= File::RDWR|File::CREAT|File::EXCL
@@ -521,7 +521,7 @@ private def create_with_file(basename="", tmpdir=nil, mode: 0, **options)
   end
 end
 
-private def create_without_file(basename="", tmpdir=nil, mode: 0, **options, &block)
+private def create_anonymous(basename="", tmpdir=nil, mode: 0, **options, &block)
   tmpfile = nil
   tmpdir = Dir.tmpdir() if tmpdir.nil?
   if defined?(File::TMPFILE) # O_TMPFILE since Linux 3.11
@@ -534,7 +534,7 @@ private def create_without_file(basename="", tmpdir=nil, mode: 0, **options, &bl
   end
   if tmpfile.nil?
     mode |= File::SHARE_DELETE | File::BINARY # Windows needs them to unlink the opened file.
-    tmpfile = create_with_file(basename, tmpdir, mode: mode, **options)
+    tmpfile = create_with_filename(basename, tmpdir, mode: mode, **options)
     File.unlink(tmpfile.path)
   end
   path = File.join(tmpdir, '')

--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -490,6 +490,7 @@ end
 #   tmpio.puts "foo"
 #   tmpio.rewind
 #   tmpio.read                  # => "foo\n"
+#   tmpio.close
 #
 # Argument +basename+, +tmpdir+, keyword arguments +mode+ and +options+ are same as
 # Tempfile.create.

--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -539,7 +539,7 @@ private def create_without_file(basename="", tmpdir=nil, mode: 0, **options, &bl
   if tmpfile.path != nil
     # clear path.
     tmpfile.autoclose = false
-    tmpfile = File.new(tmpfile.fileno, 'w+', path: nil)
+    tmpfile = File.new(tmpfile.fileno, mode: File::RDWR, path: nil)
   end
   if block
     begin

--- a/lib/tempfile.rb
+++ b/lib/tempfile.rb
@@ -534,7 +534,7 @@ def Tempfile.create_io(basename="", tmpdir=nil, mode: 0, **options, &block)
     end
   end
   if tmpio.nil?
-    mode |= File::SHARE_DELETE
+    mode |= File::SHARE_DELETE | File::BINARY
     tmpfile = Tempfile.create(basename, tmpdir, mode: mode, **options)
     File.unlink(tmpfile.path)
     tmpfile.autoclose = false

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -426,7 +426,7 @@ puts Tempfile.new('foo').path
     end
   end
 
-  def test_create_unlink_without_block
+  def test_create_anonymous_without_block
     t = Tempfile.create(anonymous: true)
     assert_equal(File, t.class)
     assert_equal(0600, t.stat.mode & 0777) unless /mswin|mingw/ =~ RUBY_PLATFORM
@@ -438,7 +438,7 @@ puts Tempfile.new('foo').path
     t.close if t
   end
 
-  def test_create_unlink_with_block
+  def test_create_anonymous_with_block
     result = Tempfile.create(anonymous: true) {|t|
       assert_equal(File, t.class)
       assert_equal(0600, t.stat.mode & 0777) unless /mswin|mingw/ =~ RUBY_PLATFORM
@@ -450,7 +450,7 @@ puts Tempfile.new('foo').path
     assert_equal(:result, result)
   end
 
-  def test_create_unlink_removes_file
+  def test_create_anonymous_removes_file
     Dir.mktmpdir {|d|
       t = Tempfile.create("", d, anonymous: true)
       t.close
@@ -458,7 +458,7 @@ puts Tempfile.new('foo').path
     }
   end
 
-  def test_create_unlink_path
+  def test_create_anonymous_path
     Dir.mktmpdir {|d|
       begin
         t = Tempfile.create("", d, anonymous: true)
@@ -469,7 +469,7 @@ puts Tempfile.new('foo').path
     }
   end
 
-  def test_create_unlink_autoclose
+  def test_create_anonymous_autoclose
     Tempfile.create(anonymous: true) {|t|
       assert_equal(true, t.autoclose?)
     }

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -430,7 +430,7 @@ puts Tempfile.new('foo').path
     tmpio = Tempfile.create_io
     assert_equal(IO, tmpio.class)
     assert_equal(nil, tmpio.path)
-    assert_equal(0600, tmpio.stat.mode & 0777)
+    assert_equal(0600, tmpio.stat.mode & 0777) unless /mswin|mingw/ =~ RUBY_PLATFORM
     tmpio.puts "foo"
     tmpio.rewind
     assert_equal("foo\n", tmpio.read)
@@ -443,7 +443,7 @@ puts Tempfile.new('foo').path
     result = Tempfile.create_io {|tmpio|
       assert_equal(IO, tmpio.class)
       assert_equal(nil, tmpio.path)
-      assert_equal(0600, tmpio.stat.mode & 0777)
+      assert_equal(0600, tmpio.stat.mode & 0777) unless /mswin|mingw/ =~ RUBY_PLATFORM
       tmpio.puts "foo"
       tmpio.rewind
       assert_equal("foo\n", tmpio.read)

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -427,7 +427,7 @@ puts Tempfile.new('foo').path
   end
 
   def test_create_unlink_without_block
-    t = Tempfile.create(unlink_first: true)
+    t = Tempfile.create(anonymous: true)
     assert_equal(File, t.class)
     assert_equal(0600, t.stat.mode & 0777) unless /mswin|mingw/ =~ RUBY_PLATFORM
     t.puts "foo"
@@ -439,7 +439,7 @@ puts Tempfile.new('foo').path
   end
 
   def test_create_unlink_with_block
-    result = Tempfile.create(unlink_first: true) {|t|
+    result = Tempfile.create(anonymous: true) {|t|
       assert_equal(File, t.class)
       assert_equal(0600, t.stat.mode & 0777) unless /mswin|mingw/ =~ RUBY_PLATFORM
       t.puts "foo"
@@ -452,7 +452,7 @@ puts Tempfile.new('foo').path
 
   def test_create_unlink_removes_file
     Dir.mktmpdir {|d|
-      t = Tempfile.create("", d, unlink_first: true)
+      t = Tempfile.create("", d, anonymous: true)
       t.close
       assert_equal([], Dir.children(d))
     }
@@ -461,7 +461,7 @@ puts Tempfile.new('foo').path
   def test_create_unlink_path
     Dir.mktmpdir {|d|
       begin
-        t = Tempfile.create("", d, unlink_first: true)
+        t = Tempfile.create("", d, anonymous: true)
         assert_equal(File.join(d, ""), t.path)
       ensure
         t.close if t
@@ -470,7 +470,7 @@ puts Tempfile.new('foo').path
   end
 
   def test_create_unlink_autoclose
-    Tempfile.create(unlink_first: true) {|t|
+    Tempfile.create(anonymous: true) {|t|
       assert_equal(true, t.autoclose?)
     }
   end

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -453,16 +453,19 @@ puts Tempfile.new('foo').path
   def test_create_unlink_removes_file
     Dir.mktmpdir {|d|
       t = Tempfile.create("", d, unlink_first: true)
-      t.close # The temporary file may exists until here on Windows.
+      t.close
       assert_equal([], Dir.children(d))
     }
   end
 
   def test_create_unlink_path
     Dir.mktmpdir {|d|
-      t = Tempfile.create("", d, unlink_first: true)
-      assert_equal(nil, t.path)
-      t.close
+      begin
+        t = Tempfile.create("", d, unlink_first: true)
+        assert_equal(File.join(d, ""), t.path)
+      ensure
+        t.close if t
+      end
     }
   end
 

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -416,7 +416,6 @@ puts Tempfile.new('foo').path
     end
   end
 
-
   def assert_mktmpdir_traversal
     Dir.mktmpdir do |target|
       target = target.chomp('/') + '/'

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -416,6 +416,7 @@ puts Tempfile.new('foo').path
     end
   end
 
+
   def assert_mktmpdir_traversal
     Dir.mktmpdir do |target|
       target = target.chomp('/') + '/'
@@ -424,5 +425,17 @@ puts Tempfile.new('foo').path
       actual = yield traversal_path
       assert_not_send([File.absolute_path(actual), :start_with?, target])
     end
+  end
+
+  def test_create_io
+    tmpio = Tempfile.create_io
+    assert_equal(IO, tmpio.class)
+    assert_equal(nil, tmpio.path)
+    assert_equal(0600, tmpio.stat.mode & 0777)
+    tmpio.puts "foo"
+    tmpio.rewind
+    assert_equal("foo\n", tmpio.read)
+  ensure
+    tmpio.close if tmpio
   end
 end

--- a/test/test_tempfile.rb
+++ b/test/test_tempfile.rb
@@ -454,7 +454,7 @@ puts Tempfile.new('foo').path
 
   def test_create_io_removes_file
     Dir.mktmpdir {|d|
-      tmpio = Tempfile.create_io(nil, d)
+      tmpio = Tempfile.create_io("", d)
       tmpio.close # The temporary file may exists until here on Windows.
       assert_equal([], Dir.children(d))
     }


### PR DESCRIPTION
Tempfile.create_io creates an unnamed file.

It is implemented using Tempfile.create and unlink. It try to use O_TMPFILE available since Linux 3.11.