### PR TITLE
Upload cores on macos GHA for debug

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -129,6 +129,36 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
         if: ${{ failure() }}
 
+      - name: Resolve job ID
+        id: job_id
+        uses: actions/github-script@main
+        env:
+          matrix: ${{ toJson(matrix) }}
+        with:
+          script: |
+            const { data: workflow_run } = await github.rest.actions.listJobsForWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            const matrix = JSON.parse(process.env.matrix);
+            const job_name = `${context.job}${matrix ? ` (${Object.values(matrix).join(", ")})` : ""}`;
+            return workflow_run.jobs.find((job) => job.name === job_name).id;
+
+      - name: upload /cores
+        run: |
+          ls -l /cores
+          CORES_TAR_GZ="cores-${{ github.run_id }}-${{ steps.job_id.outputs.result }}.tar.gz"
+          echo "test: $CORES_TAR_GZ"
+          if [ -n "$(ls /cores)" ]; then
+            tar czf /cores "$CORES_TAR_GZ"
+            aws s3 cp "$CORES_TAR_GZ" "s3://ruby-core-files/$CORES_TAR_GZ"
+          fi
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.RUBY_CORE_FILES_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.RUBY_CORE_FILES_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ap-northeast-1
+
   result:
     if: ${{ always() }}
     name: ${{ github.workflow }} result

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -70,6 +70,11 @@ jobs:
           # Set fetch-depth: 0 so that Launchable can receive commits information.
           fetch-depth: 10
 
+      - name: make sure that kern.coredump=1
+        run: |
+          sysctl -n kern.coredump
+          sudo sysctl -w kern.coredump=1
+
       - name: Run configure
         run: ../src/configure -C --disable-install-doc ${ruby_configure_args}
 


### PR DESCRIPTION
According to [Launchable](https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fruby%2Ftest_gc_compact.rb%23class%3DTestGCCompact%23testcase%3Dtest_moving_objects_between_size_pools?organizationId=ruby&workspaceId=ruby&testPathId=file%3Dtest%2Fruby%2Ftest_gc_compact.rb%23class%3DTestGCCompact%23testcase%3Dtest_moving_objects_between_size_pools&testSessionStatus=flake), there is a SEGV issue in macos, but we cannot debug it without core files. This change tries to upload core files on macos to S3.