### PR TITLE
readline: Make arm32 platform regex broader

### DIFF
--- a/test/readline/test_readline.rb
+++ b/test/readline/test_readline.rb
@@ -497,7 +497,7 @@ module BasetestReadline
     omit if /i[3-6]86-linux/ =~ RUBY_PLATFORM
 
     # Skip arm32-linux (Travis CI).
-    omit "Skip arm32-linux" if /armv.+l-linux/ =~ RUBY_PLATFORM
+    omit "Skip arm32-linux" if /armv[0-9+][a-z]-linux/ =~ RUBY_PLATFORM
 
     if defined?(TestReadline) && self.class == TestReadline
       use = "use_ext_readline"


### PR DESCRIPTION
This needs to be broader to match all arm32 variants.  E.g. `armv7a-linux-eabihf`, `armv6j-linux-eabihf`

Fixes: aefc98891c42024039f19ef45bdfe93fbc590b7c