### PR TITLE
Remove dead code

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -14941,9 +14941,6 @@ new_bodystmt(struct parser_params *p, NODE *head, NODE *rescue, NODE *rescue_els
         result = NEW_RESCUE(head, rescue, rescue_else, &rescue_loc);
         nd_set_line(result, rescue->nd_loc.beg_pos.lineno);
     }
-    else if (rescue_else) {
-        result = block_append(p, result, rescue_else);
-    }
     if (ensure) {
         result = NEW_ENSURE(result, ensure, loc);
     }


### PR DESCRIPTION
Since 140512d2225e6fd046ba1bdbcd1a27450f55c233, `else` without `rescue` has been a syntax error.