### PR TITLE
Add RB_GC_GUARD for rb_str_to_parser_string

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -2082,7 +2082,9 @@ rb_parser_string_t *
 rb_str_to_parser_string(rb_parser_t *p, VALUE str)
 {
     /* Type check */
-    return rb_parser_encoding_string_new(p, RSTRING_PTR(str), RSTRING_LEN(str), rb_enc_get(str));
+    rb_parser_string_t *ret = rb_parser_encoding_string_new(p, RSTRING_PTR(str), RSTRING_LEN(str), rb_enc_get(str));
+    RB_GC_GUARD(str);
+    return ret;
 }
 #endif
 


### PR DESCRIPTION
I think this fixes the following random test failure that could not be fixed for a long time:

```
  1) Failure:
TestSymbol#test_inspect_under_gc_compact_stress [/home/chkbuild/chkbuild/tmp/build/20240522T003003Z/ruby/test/ruby/test_symbol.rb:126]:
<":testing"> expected but was
<":\"\\x00\\x00\\x00\\x00\\x00\\x00\\x00\"">.
```

The value passed to this function is the return value of `rb_id2str`, so it is never collected.  However, if auto_compact is enabled, the string may move and `RSTRING_PTR(str)` became invalid.

This change prevents the string from being moved by RB_GC_GUARD.