### PR TITLE
[Feature #20507] Allow compilation of C extensions with `-Wconversion`

### DIFF
--- a/ext/-test-/public_header_warnings/extconf.rb
+++ b/ext/-test-/public_header_warnings/extconf.rb
@@ -1,0 +1,23 @@
+#
+#  Under compilers with WERRORFLAG, MakeMakefile.try_compile treats warnings as errors, so we can
+#  use append_cflags to test whether the public header files emit warnings with certain flags turned
+#  on.
+#
+def check_append_cflags(flag, msg = nil)
+  msg ||= "flag #{flag} is not acceptable"
+  !$CFLAGS.include?(flag) or raise("flag #{flag} already present in $CFLAGS")
+  append_cflags(flag)
+  $CFLAGS.include?(flag) or raise(msg)
+end
+
+if %w[gcc clang].include?(RbConfig::CONFIG['CC'])
+  config_string("WERRORFLAG") or raise("expected WERRORFLAG to be defined")
+
+  # should be acceptable on all modern C compilers
+  check_append_cflags("-D_TEST_OK", "baseline compiler warning test failed")
+
+  # Feature #20507: Allow compilation of C extensions with -Wconversion
+  check_append_cflags("-Wconversion", "-Wconversion raising warnings in public headers")
+end
+
+create_makefile("-test-/public_header_warnings")

--- a/include/ruby/internal/arithmetic/long.h
+++ b/include/ruby/internal/arithmetic/long.h
@@ -114,11 +114,11 @@ RB_INT2FIX(long i)
 
     /* :NOTE: VALUE can be wider than long.  As j being unsigned, 2j+1 is fully
      * defined. Also it can be compiled into a single LEA instruction. */
-    const unsigned long j = i;
+    const unsigned long j = RBIMPL_CAST((unsigned long)i);
     const unsigned long k = (j << 1) + RUBY_FIXNUM_FLAG;
-    const long          l = k;
+    const long          l = RBIMPL_CAST((long)k);
     const SIGNED_VALUE  m = l; /* Sign extend */
-    const VALUE         n = m;
+    const VALUE         n = RBIMPL_CAST((VALUE)m);
 
     RBIMPL_ASSERT_OR_ASSUME(RB_FIXNUM_P(n));
     return n;
@@ -166,7 +166,7 @@ rbimpl_fix2long_by_idiv(VALUE x)
     /* :NOTE: VALUE  can be wider  than long.  (x-1)/2 never  overflows because
      * RB_FIXNUM_P(x)  holds.   Also it  has  no  portability issue  like  y>>1
      * below. */
-    const SIGNED_VALUE y = x - RUBY_FIXNUM_FLAG;
+    const SIGNED_VALUE y = RBIMPL_CAST((SIGNED_VALUE)(x - RUBY_FIXNUM_FLAG));
     const SIGNED_VALUE z = y / 2;
     const long         w = RBIMPL_CAST((long)z);
 
@@ -193,7 +193,7 @@ rbimpl_fix2long_by_shift(VALUE x)
 
     /* :NOTE: VALUE can be wider than long.  If right shift is arithmetic, this
      * is noticeably faster than above. */
-    const SIGNED_VALUE y = x;
+    const SIGNED_VALUE y = RBIMPL_CAST((SIGNED_VALUE)x);
     const SIGNED_VALUE z = y >> 1;
     const long         w = RBIMPL_CAST((long)z);
 
@@ -252,7 +252,7 @@ static inline unsigned long
 rb_fix2ulong(VALUE x)
 {
     RBIMPL_ASSERT_OR_ASSUME(RB_FIXNUM_P(x));
-    return rb_fix2long(x);
+    return RBIMPL_CAST((unsigned long)rb_fix2long(x));
 }
 
 /**
@@ -323,7 +323,7 @@ static inline VALUE
 rb_ulong2num_inline(unsigned long v)
 {
     if (RB_POSFIXABLE(v))
-        return RB_LONG2FIX(v);
+        return RB_LONG2FIX(RBIMPL_CAST((long)v));
     else
         return rb_uint2big(v);
 }

--- a/include/ruby/internal/arithmetic/long_long.h
+++ b/include/ruby/internal/arithmetic/long_long.h
@@ -127,7 +127,7 @@ static inline unsigned LONG_LONG
 rb_num2ull_inline(VALUE x)
 {
     if (RB_FIXNUM_P(x))
-        return RB_FIX2LONG(x);
+        return RBIMPL_CAST((unsigned LONG_LONG)RB_FIX2LONG(x));
     else
         return rb_num2ull(x);
 }

--- a/include/ruby/internal/arithmetic/st_data_t.h
+++ b/include/ruby/internal/arithmetic/st_data_t.h
@@ -58,7 +58,7 @@ RBIMPL_ATTR_ARTIFICIAL()
 static inline VALUE
 RB_ST2FIX(st_data_t i)
 {
-    SIGNED_VALUE x = i;
+    SIGNED_VALUE x = RBIMPL_CAST((SIGNED_VALUE)i);
 
     if (x >= 0) {
         x &= RUBY_FIXNUM_MAX;
@@ -69,7 +69,7 @@ RB_ST2FIX(st_data_t i)
 
     RBIMPL_ASSERT_OR_ASSUME(RB_FIXABLE(x));
     unsigned long y = RBIMPL_CAST((unsigned long)x);
-    return RB_LONG2FIX(y);
+    return RB_LONG2FIX(RBIMPL_CAST((long)y));
 }
 
 #endif /* RBIMPL_ARITHMETIC_ST_DATA_T_H */

--- a/include/ruby/internal/encoding/encoding.h
+++ b/include/ruby/internal/encoding/encoding.h
@@ -80,7 +80,7 @@ enum ruby_encoding_consts {
 static inline void
 RB_ENCODING_SET_INLINED(VALUE obj, int encindex)
 {
-    VALUE f = /* upcast */ encindex;
+    VALUE f = /* upcast */ RBIMPL_CAST((VALUE)encindex);
 
     f <<= RUBY_ENCODING_SHIFT;
     RB_FL_UNSET_RAW(obj, RUBY_ENCODING_MASK);

--- a/include/ruby/internal/memory.h
+++ b/include/ruby/internal/memory.h
@@ -643,7 +643,7 @@ rbimpl_size_mul_or_raise(size_t x, size_t y)
 static inline void *
 rb_alloc_tmp_buffer2(volatile VALUE *store, long count, size_t elsize)
 {
-    const size_t total_size = rbimpl_size_mul_or_raise(count, elsize);
+    const size_t total_size = rbimpl_size_mul_or_raise(RBIMPL_CAST((size_t)count), elsize);
     const size_t cnt = (total_size + sizeof(VALUE) - 1) / sizeof(VALUE);
     return rb_alloc_tmp_buffer_with_count(store, total_size, cnt);
 }

--- a/include/ruby/internal/special_consts.h
+++ b/include/ruby/internal/special_consts.h
@@ -156,7 +156,7 @@ RB_TEST(VALUE obj)
      *
      *  RTEST(v) can be 0 if and only if (v == Qfalse || v == Qnil).
      */
-    return obj & ~RUBY_Qnil;
+    return obj & RBIMPL_CAST((VALUE)~RUBY_Qnil);
 }
 
 RBIMPL_ATTR_CONST()
@@ -226,7 +226,7 @@ RB_NIL_OR_UNDEF_P(VALUE obj)
      *
      *  NIL_OR_UNDEF_P(v) can be true only when v is Qundef or Qnil.
      */
-    const VALUE mask = ~(RUBY_Qundef ^ RUBY_Qnil);
+    const VALUE mask = RBIMPL_CAST((VALUE)~(RUBY_Qundef ^ RUBY_Qnil));
     const VALUE common_bits = RUBY_Qundef & RUBY_Qnil;
     return (obj & mask) == common_bits;
 }


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20507

As a maintainer of several C extensions, I like to compile my code with some of the common [Warning Options](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html) to help maintain code quality and safety.

One of the options that is currently very difficult to use is `-Wsign-conversion`, because some of the Ruby public header files contain code that will generate warnings. So many warnings are printed when compiling against Ruby's header files that it's hard to see any warnings from my code.

As an example, compiling just one file in Nokogiri with this flag enabled will print:

```
.../include/ruby-3.4.0+0/ruby/internal/special_consts.h: In function ‘RB_TEST’:
.../include/ruby-3.4.0+0/ruby/internal/special_consts.h:159:16: warning: unsigned conversion from ‘int’ to ‘VALUE’ {aka ‘long unsigned int’} changes value from ‘-5’ to ‘18446744073709551611’ [-Wsign-conversion]
  159 |     return obj & ~RUBY_Qnil;
      |                ^
.../include/ruby-3.4.0+0/ruby/internal/special_consts.h: In function ‘RB_NIL_OR_UNDEF_P’:
.../include/ruby-3.4.0+0/ruby/internal/special_consts.h:229:24: warning: unsigned conversion from ‘int’ to ‘VALUE’ {aka ‘const long unsigned int’} changes value from ‘-33’ to ‘18446744073709551583’ [-Wsign-conversion]
  229 |     const VALUE mask = ~(RUBY_Qundef ^ RUBY_Qnil);
      |                        ^
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h: In function ‘RB_INT2FIX’:
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h:117:29: warning: conversion to ‘long unsigned int’ from ‘long int’ may change the sign of the result [-Wsign-conversion]
  117 |     const unsigned long j = i;
      |                             ^
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h:119:29: warning: conversion to ‘long int’ from ‘long unsigned int’ may change the sign of the result [-Wsign-conversion]
  119 |     const long          l = k;
      |                             ^
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h:121:29: warning: conversion to ‘VALUE’ {aka ‘const long unsigned int’} from ‘long int’ may change the sign of the result [-Wsign-conversion]
  121 |     const VALUE         n = m;
      |                             ^
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h: In function ‘rbimpl_fix2long_by_idiv’:
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h:169:28: warning: conversion to ‘long int’ from ‘VALUE’ {aka ‘long unsigned int’} may change the sign of the result [-Wsign-conversion]
  169 |     const SIGNED_VALUE y = x - RUBY_FIXNUM_FLAG;
      |                            ^
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h: In function ‘rbimpl_fix2long_by_shift’:
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h:196:28: warning: conversion to ‘long int’ from ‘VALUE’ {aka ‘long unsigned int’} may change the sign of the result [-Wsign-conversion]
  196 |     const SIGNED_VALUE y = x;
      |                            ^
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h: In function ‘rb_fix2ulong’:
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h:255:12: warning: conversion to ‘long unsigned int’ from ‘long int’ may change the sign of the result [-Wsign-conversion]
  255 |     return rb_fix2long(x);
      |            ^~~~~~~~~~~~~~
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h: In function ‘rb_ulong2num_inline’:
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h:326:28: warning: conversion to ‘long int’ from ‘long unsigned int’ may change the sign of the result [-Wsign-conversion]
  326 |         return RB_LONG2FIX(v);
      |                            ^
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long_long.h: In function ‘rb_num2ull_inline’:
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long.h:53:22: warning: conversion to ‘long long unsigned int’ from ‘long int’ may change the sign of the result [-Wsign-conversion]
   53 | #define RB_FIX2LONG  rb_fix2long          /**< @alias{rb_fix2long} */
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/long_long.h:130:16: note: in expansion of macro ‘RB_FIX2LONG’
  130 |         return RB_FIX2LONG(x);
      |                ^~~~~~~~~~~
In file included from .../include/ruby-3.4.0+0/ruby/internal/arithmetic.h:37:
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/st_data_t.h: In function ‘RB_ST2FIX’:
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/st_data_t.h:61:22: warning: conversion to ‘long int’ from ‘st_data_t’ {aka ‘long unsigned int’} may change the sign of the result [-Wsign-conversion]
   61 |     SIGNED_VALUE x = i;
      |                      ^
.../include/ruby-3.4.0+0/ruby/internal/arithmetic/st_data_t.h:72:24: warning: conversion to ‘long int’ from ‘long unsigned int’ may change the sign of the result [-Wsign-conversion]
   72 |     return RB_LONG2FIX(y);
      |                        ^
In file included from .../include/ruby-3.4.0+0/ruby/ruby.h:42:
.../include/ruby-3.4.0+0/ruby/internal/memory.h: In function ‘rb_alloc_tmp_buffer2’:
.../include/ruby-3.4.0+0/ruby/internal/memory.h:646:56: warning: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘long int’ may change the sign of the result [-Wsign-conversion]
  646 |     const size_t total_size = rbimpl_size_mul_or_raise(count, elsize);
      |                                                        ^~~~~
In file included from .../include/ruby-3.4.0+0/ruby/internal/encoding/ctype.h:27,
                 from .../include/ruby-3.4.0+0/ruby/encoding.h:22,
                 from ../../../../ext/nokogiri/nokogiri.h:79:
.../include/ruby-3.4.0+0/ruby/internal/encoding/encoding.h: In function ‘RB_ENCODING_SET_INLINED’:
.../include/ruby-3.4.0+0/ruby/internal/encoding/encoding.h:83:28: warning: conversion to ‘VALUE’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
   83 |     VALUE f = /* upcast */ encindex;
      |                            ^~~~~~~~
```

Compiling all 35 files in Nokogiri's C extension means these warnings are repeated another 34 times in a full build. This makes it difficult to see any conversion errors in my own code.

This pull request adds casts where there are intentional, known-safe integer conversions occurring that are triggering these warnings.

If merged, then C extension owners can add this to their `extconf.rb`:

```
append_cflags("-Wconversion")
```

and then any warnings generated are from the C extension code, and not from Ruby's header files.
