### PR TITLE
[Bug #20510] Do not count optional hash argument for `IO.new`

### DIFF
--- a/test/ruby/test_file.rb
+++ b/test/ruby/test_file.rb
@@ -460,6 +460,39 @@ class TestFile < Test::Unit::TestCase
     end
   end
 
+  def test_initialize
+    Dir.mktmpdir(__method__.to_s) do |tmpdir|
+      path = File.join(tmpdir, "foo")
+
+      assert_raise(Errno::ENOENT) {File.new(path)}
+      f = File.new(path, "w")
+      f.write("FOO\n")
+      f.close
+      f = File.new(path)
+      data = f.read
+      f.close
+      assert_equal("FOO\n", data)
+
+      f = File.new(path, File::WRONLY)
+      f.write("BAR\n")
+      f.close
+      f = File.new(path, File::RDONLY)
+      data = f.read
+      f.close
+      assert_equal("BAR\n", data)
+
+      data = File.open(path) {|file|
+        File.new(file.fileno, mode: File::RDONLY, autoclose: false).read
+      }
+      assert_equal("BAR\n", data)
+
+      data = File.open(path) {|file|
+        File.new(file.fileno, File::RDONLY, autoclose: false).read
+      }
+      assert_equal("BAR\n", data)
+    end
+  end
+
   def test_file_open_newline_option
     Dir.mktmpdir(__method__.to_s) do |tmpdir|
       path = File.join(tmpdir, "foo")

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2929,6 +2929,15 @@ class TestIO < Test::Unit::TestCase
       f.close
 
       assert_equal("FOO\n", File.read(t.path))
+
+      fd = IO.sysopen(t.path)
+      %w[w r+ w+ a+].each do |mode|
+        assert_raise(Errno::EINVAL, "#{mode} [ruby-dev:38571]") {IO.new(fd, mode)}
+      end
+      f = IO.new(fd, "r")
+      data = f.read
+      f.close
+      assert_equal("FOO\n", data)
     }
   end
 


### PR DESCRIPTION
Since `IO.new` accepts one or two positional arguments except for the optional hash argument, exclude the optional hash argument from the check for delegation to `IO.new`.