### PR TITLE
Try to upload core file on macos GitHub Actions

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -74,6 +74,7 @@ jobs:
         run: |
           sysctl -n kern.coredump
           sudo sysctl -w kern.coredump=1
+          sudo chmod -R +rwx /cores/
 
       - name: Run configure
         run: ../src/configure -C --disable-install-doc ${ruby_configure_args}
@@ -115,6 +116,7 @@ jobs:
 
       - name: make skipped tests
         run: |
+          ulimit -c unlimited
           make -s test-all TESTS="${TESTS//-n!\//-n/}"
         env:
           GNUMAKEFLAGS: ''


### PR DESCRIPTION
A core dump occurred, but failed to capture the core file. https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-sessions/2935062?tab=retried-tests

Looks like a core file was not created. I am not unsure why, so make sure that the /cores directory is writable and try `ulimit` command.