### PR TITLE
Make test_nested_timeouts less flaky

### DIFF
--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -66,7 +66,7 @@ class TestTimeout < Test::Unit::TestCase
     a = nil
     assert_raise(Timeout::Error) do
       Timeout.timeout(0.1) {
-        Timeout.timeout(1) {
+        Timeout.timeout(30) {
           nil while true
         }
         a = 1
@@ -84,7 +84,7 @@ class TestTimeout < Test::Unit::TestCase
   def test_nested_timeout_error_identity
     begin
       Timeout.timeout(0.1, MyNewErrorOuter) {
-        Timeout.timeout(1, MyNewErrorInner) {
+        Timeout.timeout(30, MyNewErrorInner) {
           nil while true
         }
       }


### PR DESCRIPTION
This test randomly fails due to the bug reported in [Bug #20314], where the two timeouts are too close so that they can expire at the same time.

As a workaround, this change increases the time difference between timeouts. This will reduce the probability of simultaneous expirations and lower flakiness.