### PR TITLE
Make value_type.h compatible with -Wconversion

### DIFF
--- a/include/ruby/internal/value_type.h
+++ b/include/ruby/internal/value_type.h
@@ -443,7 +443,7 @@ Check_Type(VALUE v, enum ruby_value_type t)
     }
 
   unexpected_type:
-    rb_unexpected_type(v, t);
+    rb_unexpected_type(v, RBIMPL_CAST((int)t));
 }
 
 #endif /* RBIMPL_VALUE_TYPE_H */


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/10843

[[Feature #20507]](https://bugs.ruby-lang.org/issues/20507)

This was missed from the initial commit.

```
../../.././include/ruby/internal/value_type.h:446:27: error: implicit conversion changes signedness: 'enum ruby_value_type' to 'int' [-Werror,-Wsign-conversion]
    rb_unexpected_type(v, t);
    ~~~~~~~~~~~~~~~~~~    ^
```

@flavorjones @nobu @shyouhei 