### PR TITLE
RJIT: Fixed and/or reg+disp32 operations

### DIFF
--- a/bootstraptest/test_rjit.rb
+++ b/bootstraptest/test_rjit.rb
@@ -29,6 +29,28 @@ assert_equal 'bar', %q{
   bar(Struct.new(:bar).new(:bar))
 }
 
+# AND with offset  DISP32
+assert_equal '2', %q{
+  def foo
+    a = 6;
+    b = {a: 1, b: 1, c: 1, d: 1, e: 1,  f: 1, g: 1, h: a&3}
+    b[:h]
+  end
+
+  foo
+}
+
+# OR with offset DISP32
+assert_equal '6', %q{
+  def foo
+    a = 4;
+    b = {a: 1, b: 1, c: 1, d: 1, e: 1,  f: 1, g: 1, h: a|2}
+    b[:h]
+  end
+
+  foo
+}
+
 # kwargs default w/ checkkeyword + locals (which shouldn't overwrite unspecified_bits)
 assert_equal '1', %q{
   def foo(bar: 1.to_s)

--- a/lib/ruby_vm/rjit/assembler.rb
+++ b/lib/ruby_vm/rjit/assembler.rb
@@ -152,6 +152,16 @@ module RubyVM::RJIT
           mod_rm: ModRM[mod: Mod01, reg: dst_reg, rm: src_reg],
           disp: imm8(src_disp),
         )
+        # AND r64, r/m64 (Mod 10: [reg]+disp32)
+        in [R64 => dst_reg, QwordPtr[R64 => src_reg, IMM32 => src_disp]]
+          # REX.W + 23 /r
+          # RM: Operand 1: ModRM:reg (r, w), Operand 2: ModRM:r/m (r)
+          insn(
+            prefix: REX_W,
+            opcode: 0x23,
+            mod_rm: ModRM[mod: Mod10, reg: dst_reg, rm: src_reg],
+            disp: imm32(src_disp),
+            )
       end
     end
 
@@ -736,6 +746,16 @@ module RubyVM::RJIT
           mod_rm: ModRM[mod: Mod01, reg: dst_reg, rm: src_reg],
           disp: imm8(src_disp),
         )
+        # OR r64, r/m64 (Mod 10: [reg]+disp32)
+        in [R64 => dst_reg, QwordPtr[R64 => src_reg, IMM32 => src_disp]]
+          # REX.W + 0B /r
+          # RM: Operand 1: ModRM:reg (r, w), Operand 2: ModRM:r/m (r)
+          insn(
+            prefix: REX_W,
+            opcode: 0x0b,
+            mod_rm: ModRM[mod: Mod10, reg: dst_reg, rm: src_reg],
+            disp: imm32(src_disp),
+            )
       end
     end
 


### PR DESCRIPTION
This patch append RJIT codes and fixes errors:

```bash
ruby --rjit --rjit-call-threshold=1 -e "a=3; puts({a: 1, b: 1, c: 1, d: 1, e: 1,  f: 1, g: 1, h: a&1})"
```
ruby-3.4.0-preview1/lib/ruby/3.4.0+0/ruby_vm/rjit/assembler.rb:124:in 'RubyVM::RJIT::Assembler#and': [:rax, [:rbx, 136]] (NoMatchingPatternError)

and
```bash
ruby --rjit --rjit-call-threshold=1 -e "a=2; puts({a: 1, b: 1, c: 1, d: 1, e: 1,  f: 1, g: 1, h: a|1})"
```
ruby-3.4.0-preview1/lib/ruby/3.4.0+0/ruby_vm/rjit/assembler.rb:708:in 'RubyVM::RJIT::Assembler#or': [:rax, [:rbx, 136]] (NoMatchingPatternError)

Unfortunate, I didn't understand how append tests for this. Please help who know.