### PR TITLE
YJIT: limit size of call count stats dict

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -821,7 +821,7 @@ fn rb_yjit_gen_stats_dict(context: bool) -> VALUE {
 
                 // Cap the number of counts reported to avoid
                 // bloating log files, etc.
-                pairs = pairs[0..20].to_vec();
+                pairs.truncate(20);
 
                 // Add the pairs to the dict
                 for (name, call_count) in pairs {


### PR DESCRIPTION
Someone reported two weeks ago that logs were getting bloated because the ISEQ and C call count dicts were huge, since they include all of the call sites. I wrote code on the Rust size to limit the size of the dict to avoid this problem. The size limit is hardcoded at 20, but I figure this is probably fine?