### PR TITLE
Make ensure first lineno the first line of the ensure

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -8343,7 +8343,7 @@ compile_resbody(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node,
 static int
 compile_ensure(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, int popped)
 {
-    const int line = nd_line(node);
+    const int line = nd_line(RNODE_ENSURE(node)->nd_ensr);
     const NODE *line_node = node;
     DECL_ANCHOR(ensr);
     const rb_iseq_t *ensure = NEW_CHILD_ISEQ(RNODE_ENSURE(node)->nd_ensr,

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -469,7 +469,7 @@ class TestISeq < Test::Unit::TestCase
                   ["<class:C>@1",
                     ["bar@10", ["block in bar@11",
                             ["block (2 levels) in bar@12"]]],
-                    ["foo@2", ["ensure in foo@2"],
+                    ["foo@2", ["ensure in foo@7"],
                               ["rescue in foo@4"]]],
                   ["<class:D>@17"]]
 
@@ -502,7 +502,7 @@ class TestISeq < Test::Unit::TestCase
                                   [4, :line],
                                   [7, :line],
                                   [9, :return]]],
-                       [["ensure in foo@2", [[7, :line]]]],
+                       [["ensure in foo@7", [[7, :line]]]],
                        [["rescue in foo@4", [[5, :line],
                                              [5, :rescue]]]]]],
                    [["<class:D>@17", [[17, :class],


### PR DESCRIPTION
Previously, ensure ISEQs took their first line number from the line number coming from the AST. However, if this is coming from an empty `begin`..`end` inside of a method, this can be all of the way back to the method declaration. Instead, this commit changes it to be the first line number of the ensure block itself.

The first_lineno field is only accessible through manual ISEQ compilation or through tracepoint. Either way, this will be more accurate for targeting going forward, and more consistent with `rescue`.