### PR TITLE
Prevent fork from happening in known fork unsafe API

### DIFF
--- a/internal/thread.h
+++ b/internal/thread.h
@@ -46,6 +46,9 @@ VALUE rb_thread_shield_wait(VALUE self);
 VALUE rb_thread_shield_release(VALUE self);
 VALUE rb_thread_shield_destroy(VALUE self);
 int rb_thread_to_be_killed(VALUE thread);
+void rb_thread_acquire_fork_lock(void);
+void rb_thread_release_fork_lock(void);
+void rb_thread_reset_fork_lock(void);
 void rb_mutex_allow_trap(VALUE self, int val);
 VALUE rb_uninterruptible(VALUE (*b_proc)(VALUE), VALUE data);
 VALUE rb_mutex_owned_p(VALUE self);
@@ -63,6 +66,8 @@ int rb_notify_fd_close(int fd, struct rb_io_close_wait_list *busy);
 void rb_notify_fd_close_wait(struct rb_io_close_wait_list *busy);
 
 RUBY_SYMBOL_EXPORT_BEGIN
+
+void *rb_thread_prevent_fork(void *(*func)(void *), void *data); /* for ext/socket/raddrinfo.c */
 
 /* Temporary.  This API will be removed (renamed). */
 VALUE rb_thread_io_blocking_region(rb_blocking_function_t *func, void *data1, int fd);

--- a/process.c
+++ b/process.c
@@ -4227,12 +4227,17 @@ rb_fork_ruby(int *status)
         prefork();
 
         before_fork_ruby();
+        rb_thread_acquire_fork_lock();
         disable_child_handler_before_fork(&old);
 
         child.pid = pid = rb_fork();
         child.error = err = errno;
 
         disable_child_handler_fork_parent(&old); /* yes, bad name */
+        rb_thread_release_fork_lock();
+        if (pid == 0) {
+          rb_thread_reset_fork_lock();
+        }
         after_fork_ruby(pid);
 
         /* repeat while fork failed but retryable */

--- a/thread_none.c
+++ b/thread_none.c
@@ -326,4 +326,10 @@ rb_thread_lock_native_thread(void)
     return false;
 }
 
+void *
+rb_thread_prevent_fork(void *(*func)(void *), void *data)
+{
+    return func(data);
+}
+
 #endif /* THREAD_SYSTEM_DEPENDENT_IMPLEMENTATION */

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -1011,4 +1011,10 @@ rb_thread_lock_native_thread(void)
     return false;
 }
 
+void *
+rb_thread_prevent_fork(void *(*func)(void *), void *data)
+{
+    return func(data);
+}
+
 #endif /* THREAD_SYSTEM_DEPENDENT_IMPLEMENTATION */


### PR DESCRIPTION
[[Feature #20590]](https://bugs.ruby-lang.org/issues/20590)

For better of for worse, fork(2) remain the primary provider of parallelism in Ruby programs. Even though it's frowned uppon in many circles, and a lot of literature will simply state that only async-signal safe APIs are safe to use after `fork()`, in practice most APIs work well as long as you are careful about not forking while another thread is holding a pthread mutex.

One of the APIs that is known cause fork safety issues is `getaddrinfo`. If you fork while another thread is inside `getaddrinfo`, a mutex may be left locked in the child, with no way to unlock it.

I think we could reduce the impact of these problem by preventing in for the most notorious and common cases, by locking around `fork(2)` and known unsafe APIs with a read-write lock.

FYI: @mame @beauraF 