### PR TITLE
YJIT: Fix a warning from nightly rust

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1000,7 +1000,7 @@ impl fmt::Debug for MutableBranchList {
         // SAFETY: the derived Clone for boxed slices does not mutate this Cell
         let branches = unsafe { self.0.ref_unchecked().clone() };
 
-        formatter.debug_list().entries(branches.into_iter()).finish()
+        formatter.debug_list().entries(branches.iter()).finish()
     }
 }
 


### PR DESCRIPTION
No plan about migrating to the 2024 edition yet (it's not even
available yet), but this is a simple enough suggestion so we can just
take it.

```
warning: this method call resolves to `<&Box<[T]> as IntoIterator>::into_iter` (due to backwards compatibility), but will resolve to `<Box<[T]> as IntoIterator>::into_iter` in Rust 2024
    --> ../yjit/src/core.rs:1003:49
     |
1003 |         formatter.debug_list().entries(branches.into_iter()).finish()
     |                                                 ^^^^^^^^^
     |
     = warning: this changes meaning in Rust 2024
     = note: `#[warn(boxed_slice_into_iter)]` on by default
help: use `.iter()` instead of `.into_iter()` to avoid ambiguity
     |
1003 |         formatter.debug_list().entries(branches.iter()).finish()
     |                                                 ~~~~
help: or use `IntoIterator::into_iter(..)` instead of `.into_iter()` to explicitly iterate by value
     |
1003 |         formatter.debug_list().entries(IntoIterator::into_iter(branches)).finish()
     |                                        ++++++++++++++++++++++++        ~
```
