### PR TITLE
Simplify bitmap access macros

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1551,6 +1551,7 @@ tick(void)
 static int rgengc_remember(rb_objspace_t *objspace, VALUE obj);
 static void rgengc_mark_and_rememberset_clear(rb_objspace_t *objspace, rb_heap_t *heap);
 static void rgengc_rememberset_mark(rb_objspace_t *objspace, rb_heap_t *heap);
+static inline int RVALUE_MARKING(VALUE);
 static inline int RVALUE_MARKED(VALUE);
 
 static int
@@ -1590,7 +1591,7 @@ check_rvalue_consistency_force(const VALUE obj, int terminate)
             const int wb_unprotected_bit = RVALUE_WB_UNPROTECTED_BITMAP(obj) != 0;
             const int uncollectible_bit = RVALUE_UNCOLLECTIBLE_BITMAP(obj) != 0;
             const int mark_bit = RVALUE_MARKED(obj);
-            const int marking_bit = RVALUE_MARKING_BITMAP(obj) != 0;
+            const int marking_bit = RVALUE_MARKING(obj);
             const int remembered_bit = MARKED_IN_BITMAP(GET_HEAP_PAGE(obj)->remembered_bits, obj) != 0;
             const int age = RVALUE_AGE_GET((VALUE)obj);
 
@@ -8749,7 +8750,7 @@ rb_obj_gc_flags(VALUE obj, ID* flags, size_t max)
     if (RVALUE_WB_UNPROTECTED(obj) == 0 && n<max)                   flags[n++] = ID_wb_protected;
     if (RVALUE_OLD_P(obj) && n<max)                                 flags[n++] = ID_old;
     if (RVALUE_UNCOLLECTIBLE(obj) && n<max)                         flags[n++] = ID_uncollectible;
-    if (MARKED_IN_BITMAP(GET_HEAP_MARKING_BITS(obj), obj) && n<max) flags[n++] = ID_marking;
+    if (RVALUE_MARKING(obj) && n<max)                               flags[n++] = ID_marking;
     if (RVALUE_MARKED(obj) && n<max)                                flags[n++] = ID_marked;
     if (RVALUE_PINNED(obj) && n<max)                                flags[n++] = ID_pinned;
     return n;
@@ -13154,7 +13155,7 @@ rb_raw_obj_info_common(char *const buff, const size_t buff_size, const VALUE obj
                      C(RVALUE_UNCOLLECTIBLE_BITMAP(obj),  "L"),
                      C(RVALUE_MARKED(obj),                "M"),
                      C(RVALUE_PINNED(obj),                "P"),
-                     C(RVALUE_MARKING_BITMAP(obj),        "R"),
+                     C(RVALUE_MARKING(obj),               "R"),
                      C(RVALUE_WB_UNPROTECTED_BITMAP(obj), "U"),
                      C(rb_objspace_garbage_object_p(obj), "G"),
                      obj_type_name(obj));

--- a/gc.c
+++ b/gc.c
@@ -1551,6 +1551,7 @@ tick(void)
 static int rgengc_remember(rb_objspace_t *objspace, VALUE obj);
 static void rgengc_mark_and_rememberset_clear(rb_objspace_t *objspace, rb_heap_t *heap);
 static void rgengc_rememberset_mark(rb_objspace_t *objspace, rb_heap_t *heap);
+static inline int RVALUE_WB_UNPROTECTED(VALUE);
 static inline int RVALUE_MARKING(VALUE);
 static inline int RVALUE_MARKED(VALUE);
 
@@ -1588,7 +1589,7 @@ check_rvalue_consistency_force(const VALUE obj, int terminate)
             ;
         }
         else {
-            const int wb_unprotected_bit = RVALUE_WB_UNPROTECTED_BITMAP(obj) != 0;
+            const int wb_unprotected_bit = RVALUE_WB_UNPROTECTED(obj);
             const int uncollectible_bit = RVALUE_UNCOLLECTIBLE_BITMAP(obj) != 0;
             const int mark_bit = RVALUE_MARKED(obj);
             const int marking_bit = RVALUE_MARKING(obj);
@@ -13156,7 +13157,7 @@ rb_raw_obj_info_common(char *const buff, const size_t buff_size, const VALUE obj
                      C(RVALUE_MARKED(obj),                "M"),
                      C(RVALUE_PINNED(obj),                "P"),
                      C(RVALUE_MARKING(obj),               "R"),
-                     C(RVALUE_WB_UNPROTECTED_BITMAP(obj), "U"),
+                     C(RVALUE_WB_UNPROTECTED(obj),        "U"),
                      C(rb_objspace_garbage_object_p(obj), "G"),
                      obj_type_name(obj));
         }

--- a/gc.c
+++ b/gc.c
@@ -5783,7 +5783,7 @@ invalidate_moved_plane(rb_objspace_t *objspace, struct heap_page *page, uintptr_
                 VALUE object;
 
                 if (BUILTIN_TYPE(forwarding_object) == T_MOVED) {
-                    GC_ASSERT(MARKED_IN_BITMAP(GET_HEAP_PINNED_BITS(forwarding_object), forwarding_object));
+                    GC_ASSERT(RVALUE_PINNED(forwarding_object));
                     GC_ASSERT(!MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(forwarding_object), forwarding_object));
 
                     CLEAR_IN_BITMAP(GET_HEAP_PINNED_BITS(forwarding_object), forwarding_object);
@@ -6700,7 +6700,7 @@ gc_pin(rb_objspace_t *objspace, VALUE obj)
     GC_ASSERT(is_markable_object(obj));
     if (UNLIKELY(objspace->flags.during_compacting)) {
         if (LIKELY(during_gc)) {
-            if (!MARKED_IN_BITMAP(GET_HEAP_PINNED_BITS(obj), obj)) {
+            if (!RVALUE_PINNED(obj)) {
                 GC_ASSERT(GET_HEAP_PAGE(obj)->pinned_slots <= GET_HEAP_PAGE(obj)->total_slots);
                 GET_HEAP_PAGE(obj)->pinned_slots++;
                 MARK_IN_BITMAP(GET_HEAP_PINNED_BITS(obj), obj);
@@ -8750,7 +8750,7 @@ rb_obj_gc_flags(VALUE obj, ID* flags, size_t max)
     if (RVALUE_UNCOLLECTIBLE(obj) && n<max)                         flags[n++] = ID_uncollectible;
     if (MARKED_IN_BITMAP(GET_HEAP_MARKING_BITS(obj), obj) && n<max) flags[n++] = ID_marking;
     if (MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(obj), obj) && n<max)    flags[n++] = ID_marked;
-    if (MARKED_IN_BITMAP(GET_HEAP_PINNED_BITS(obj), obj) && n<max)  flags[n++] = ID_pinned;
+    if (RVALUE_PINNED(obj) && n<max)                                flags[n++] = ID_pinned;
     return n;
 }
 
@@ -13152,7 +13152,7 @@ rb_raw_obj_info_common(char *const buff, const size_t buff_size, const VALUE obj
                      (void *)obj, age,
                      C(RVALUE_UNCOLLECTIBLE_BITMAP(obj),  "L"),
                      C(RVALUE_MARK_BITMAP(obj),           "M"),
-                     C(RVALUE_PIN_BITMAP(obj),            "P"),
+                     C(RVALUE_PINNED(obj),                "P"),
                      C(RVALUE_MARKING_BITMAP(obj),        "R"),
                      C(RVALUE_WB_UNPROTECTED_BITMAP(obj), "U"),
                      C(rb_objspace_garbage_object_p(obj), "G"),
@@ -13505,7 +13505,7 @@ rb_gcdebug_print_obj_condition(VALUE obj)
     }
 
     fprintf(stderr, "marked?      : %s\n", MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(obj), obj) ? "true" : "false");
-    fprintf(stderr, "pinned?      : %s\n", MARKED_IN_BITMAP(GET_HEAP_PINNED_BITS(obj), obj) ? "true" : "false");
+    fprintf(stderr, "pinned?      : %s\n", RVALUE_PINNED(obj) ? "true" : "false");
     fprintf(stderr, "age?         : %d\n", RVALUE_AGE_GET(obj));
     fprintf(stderr, "old?         : %s\n", RVALUE_OLD_P(obj) ? "true" : "false");
     fprintf(stderr, "WB-protected?: %s\n", RVALUE_WB_UNPROTECTED(obj) ? "false" : "true");

--- a/gc.c
+++ b/gc.c
@@ -1551,6 +1551,7 @@ tick(void)
 static int rgengc_remember(rb_objspace_t *objspace, VALUE obj);
 static void rgengc_mark_and_rememberset_clear(rb_objspace_t *objspace, rb_heap_t *heap);
 static void rgengc_rememberset_mark(rb_objspace_t *objspace, rb_heap_t *heap);
+static inline int RVALUE_MARKED(VALUE);
 
 static int
 check_rvalue_consistency_force(const VALUE obj, int terminate)
@@ -1588,7 +1589,7 @@ check_rvalue_consistency_force(const VALUE obj, int terminate)
         else {
             const int wb_unprotected_bit = RVALUE_WB_UNPROTECTED_BITMAP(obj) != 0;
             const int uncollectible_bit = RVALUE_UNCOLLECTIBLE_BITMAP(obj) != 0;
-            const int mark_bit = RVALUE_MARK_BITMAP(obj) != 0;
+            const int mark_bit = RVALUE_MARKED(obj);
             const int marking_bit = RVALUE_MARKING_BITMAP(obj) != 0;
             const int remembered_bit = MARKED_IN_BITMAP(GET_HEAP_PAGE(obj)->remembered_bits, obj) != 0;
             const int age = RVALUE_AGE_GET((VALUE)obj);
@@ -4414,7 +4415,7 @@ static inline bool
 is_garbage_object(rb_objspace_t *objspace, VALUE ptr)
 {
     return is_lazy_sweeping(objspace) && GET_HEAP_PAGE(ptr)->flags.before_sweep &&
-        !MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(ptr), ptr);
+        !RVALUE_MARKED(ptr);
 }
 
 static inline bool
@@ -5028,7 +5029,7 @@ try_move(rb_objspace_t *objspace, rb_heap_t *heap, struct heap_page *free_page, 
     /* We should return true if either src is successfully moved, or src is
      * unmoveable. A false return will cause the sweeping cursor to be
      * incremented to the next page, and src will attempt to move again */
-    GC_ASSERT(MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(src), src));
+    GC_ASSERT(RVALUE_MARKED(src));
 
     asan_unlock_freelist(free_page);
     VALUE dest = (VALUE)free_page->freelist;
@@ -5784,7 +5785,7 @@ invalidate_moved_plane(rb_objspace_t *objspace, struct heap_page *page, uintptr_
 
                 if (BUILTIN_TYPE(forwarding_object) == T_MOVED) {
                     GC_ASSERT(RVALUE_PINNED(forwarding_object));
-                    GC_ASSERT(!MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(forwarding_object), forwarding_object));
+                    GC_ASSERT(!RVALUE_MARKED(forwarding_object));
 
                     CLEAR_IN_BITMAP(GET_HEAP_PINNED_BITS(forwarding_object), forwarding_object);
 
@@ -5807,7 +5808,7 @@ invalidate_moved_plane(rb_objspace_t *objspace, struct heap_page *page, uintptr_
                     orig_page->free_slots++;
                     heap_page_add_freeobj(objspace, orig_page, object);
 
-                    GC_ASSERT(MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(forwarding_object), forwarding_object));
+                    GC_ASSERT(RVALUE_MARKED(forwarding_object));
                     GC_ASSERT(BUILTIN_TYPE(forwarding_object) != T_MOVED);
                     GC_ASSERT(BUILTIN_TYPE(forwarding_object) != T_NONE);
                 }
@@ -7406,7 +7407,7 @@ gc_check_after_marks_i(st_data_t k, st_data_t v, st_data_t ptr)
     rb_objspace_t *objspace = (rb_objspace_t *)ptr;
 
     /* object should be marked or oldgen */
-    if (!MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(obj), obj)) {
+    if (!RVALUE_MARKED(obj)) {
         fprintf(stderr, "gc_check_after_marks_i: %s is not marked and not oldgen.\n", obj_info(obj));
         fprintf(stderr, "gc_check_after_marks_i: %p is referred from ", (void *)obj);
         reflist_dump(refs);
@@ -8749,7 +8750,7 @@ rb_obj_gc_flags(VALUE obj, ID* flags, size_t max)
     if (RVALUE_OLD_P(obj) && n<max)                                 flags[n++] = ID_old;
     if (RVALUE_UNCOLLECTIBLE(obj) && n<max)                         flags[n++] = ID_uncollectible;
     if (MARKED_IN_BITMAP(GET_HEAP_MARKING_BITS(obj), obj) && n<max) flags[n++] = ID_marking;
-    if (MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(obj), obj) && n<max)    flags[n++] = ID_marked;
+    if (RVALUE_MARKED(obj) && n<max)                                flags[n++] = ID_marked;
     if (RVALUE_PINNED(obj) && n<max)                                flags[n++] = ID_pinned;
     return n;
 }
@@ -9538,7 +9539,7 @@ gc_move(rb_objspace_t *objspace, VALUE scan, VALUE free, size_t src_slot_size, s
     gc_report(4, objspace, "Moving object: %p -> %p\n", (void*)scan, (void *)free);
 
     GC_ASSERT(BUILTIN_TYPE(scan) != T_NONE);
-    GC_ASSERT(!MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(free), free));
+    GC_ASSERT(!RVALUE_MARKED(free));
 
     GC_ASSERT(!RVALUE_MARKING((VALUE)src));
 
@@ -13151,7 +13152,7 @@ rb_raw_obj_info_common(char *const buff, const size_t buff_size, const VALUE obj
             APPEND_F("%p [%d%s%s%s%s%s%s] %s ",
                      (void *)obj, age,
                      C(RVALUE_UNCOLLECTIBLE_BITMAP(obj),  "L"),
-                     C(RVALUE_MARK_BITMAP(obj),           "M"),
+                     C(RVALUE_MARKED(obj),                "M"),
                      C(RVALUE_PINNED(obj),                "P"),
                      C(RVALUE_MARKING_BITMAP(obj),        "R"),
                      C(RVALUE_WB_UNPROTECTED_BITMAP(obj), "U"),
@@ -13504,7 +13505,7 @@ rb_gcdebug_print_obj_condition(VALUE obj)
         return;
     }
 
-    fprintf(stderr, "marked?      : %s\n", MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(obj), obj) ? "true" : "false");
+    fprintf(stderr, "marked?      : %s\n", RVALUE_MARKED(obj) ? "true" : "false");
     fprintf(stderr, "pinned?      : %s\n", RVALUE_PINNED(obj) ? "true" : "false");
     fprintf(stderr, "age?         : %d\n", RVALUE_AGE_GET(obj));
     fprintf(stderr, "old?         : %s\n", RVALUE_OLD_P(obj) ? "true" : "false");

--- a/gc.c
+++ b/gc.c
@@ -1552,6 +1552,7 @@ static int rgengc_remember(rb_objspace_t *objspace, VALUE obj);
 static void rgengc_mark_and_rememberset_clear(rb_objspace_t *objspace, rb_heap_t *heap);
 static void rgengc_rememberset_mark(rb_objspace_t *objspace, rb_heap_t *heap);
 static inline int RVALUE_WB_UNPROTECTED(VALUE);
+static inline int RVALUE_UNCOLLECTIBLE(VALUE);
 static inline int RVALUE_MARKING(VALUE);
 static inline int RVALUE_MARKED(VALUE);
 
@@ -1590,7 +1591,7 @@ check_rvalue_consistency_force(const VALUE obj, int terminate)
         }
         else {
             const int wb_unprotected_bit = RVALUE_WB_UNPROTECTED(obj);
-            const int uncollectible_bit = RVALUE_UNCOLLECTIBLE_BITMAP(obj) != 0;
+            const int uncollectible_bit = RVALUE_UNCOLLECTIBLE(obj) != 0;
             const int mark_bit = RVALUE_MARKED(obj);
             const int marking_bit = RVALUE_MARKING(obj);
             const int remembered_bit = MARKED_IN_BITMAP(GET_HEAP_PAGE(obj)->remembered_bits, obj) != 0;
@@ -13153,7 +13154,7 @@ rb_raw_obj_info_common(char *const buff, const size_t buff_size, const VALUE obj
         if (is_pointer_to_heap(&rb_objspace, (void *)obj)) {
             APPEND_F("%p [%d%s%s%s%s%s%s] %s ",
                      (void *)obj, age,
-                     C(RVALUE_UNCOLLECTIBLE_BITMAP(obj),  "L"),
+                     C(RVALUE_UNCOLLECTIBLE(obj),         "L"),
                      C(RVALUE_MARKED(obj),                "M"),
                      C(RVALUE_PINNED(obj),                "P"),
                      C(RVALUE_MARKING(obj),               "R"),


### PR DESCRIPTION
inline predicate functions `RVALUE_MARKED` `RVALUE_PINNED` etc have existed for many years, but are being used inconsistently in `gc.c` for access to the respective bitmap values.

Various patterns exist already, such as:

* `RVALUE_PINNED(obj)`
* `RVALUE_PIN_BITMAP(obj) != 0`
* `MARKED_IN_BITMAP(GET_HEAP_PINNED_BITS(obj), obj)`

This commit makes bitmap access a bit more consistent, preferring the inline functions of the form `RVALUE_PINNED` etc. It removes the `RVALUE_BIN_BITMAP` macro, in favour of inlining the bitmap access directly into the functions.

One side effect that this patch has is an increased number of calls to `check_rvalue_consistency`. This is useful for GC debugging, and has no impact on the performance of the final code due to the function being a no-op without `RGENGC_CHECK_MODE` that gets optimised away.

I have verified that replacing `MARKED_IN_BITMAP(GET_HEAP_PINNED_BITS(obj), obj)`, with a clal to `RVALUE_PINNED(obj)` does not change the emitted machine code by investigating `gc_mark_and_pin` before and after this change. Both branches are identical

```
~/git/ruby-2 master ≡
❯ objdump --demangle --disassemble-symbols=_gc_mark_and_pin gc.o

gc.o:   file format mach-o arm64

Disassembly of section __TEXT,__text:

0000000000002a0c <_gc_mark_and_pin>:
    2a0c: b40000c1      cbz     x1, 0x2a24 <_gc_mark_and_pin+0x18>
    2a10: 92400828      and     x8, x1, #0x7
    2a14: b5000088      cbnz    x8, 0x2a24 <_gc_mark_and_pin+0x18>
    2a18: 79402008      ldrh    w8, [x0, #16]
    2a1c: 37300068      tbnz    w8, #6, 0x2a28 <_gc_mark_and_pin+0x1c>
    2a20: 14000000      b       0x2a20 <_gc_mark_and_pin+0x14>
    2a24: d65f03c0      ret
    2a28: 362fffc8      tbz     w8, #5, 0x2a20 <_gc_mark_and_pin+0x14>
    2a2c: 9270bc28      and     x8, x1, #0xffffffffffff0000
    2a30: f9400109      ldr     x9, [x8]
    2a34: 91114128      add     x8, x9, #1104
    2a38: 12003c2a      and     w10, w1, #0xffff
    2a3c: 529999ab      mov     w11, #52429
    2a40: 1b0b7d4a      mul     w10, w10, w11
    2a44: 53157d4c      lsr     w12, w10, #21
    2a48: 531b7d4a      lsr     w10, w10, #27
    2a4c: f86a590b      ldr     x11, [x8, w10, uxtw #3]
    2a50: 5280002d      mov     w13, #1
    2a54: 9acc21ac      lsl     x12, x13, x12
    2a58: ea0c017f      tst     x11, x12
    2a5c: 54fffe21      b.ne    0x2a20 <_gc_mark_and_pin+0x14>
    2a60: 7940112d      ldrh    w13, [x9, #8]
    2a64: 110005ad      add     w13, w13, #1
    2a68: 7900112d      strh    w13, [x9, #8]
    2a6c: aa0c0169      orr     x9, x11, x12
    2a70: f82a7909      str     x9, [x8, x10, lsl #3]
    2a74: 14000000      b       0x2a74 <_gc_mark_and_pin+0x68>
```