### PR TITLE
Ignore retguard symbols when looking for leaked symbols

### DIFF
--- a/tool/leaked-globals
+++ b/tool/leaked-globals
@@ -89,6 +89,7 @@ Pipe.new(NM + ARGV).each do |line|
   next if n.include?(".")
   next if !so and n.start_with?("___asan_")
   next if !so and n.start_with?("__odr_asan_")
+  next if !so and n.start_with?("__retguard_")
   case n
   when /\A(?:Init_|InitVM_|pm_|[Oo]nig|dln_|coroutine_)/
     next


### PR DESCRIPTION
retguard symbols are added on OpenBSD as part of stack protection. They should be ignored by the leaked symbols checker, just as we ignore asan symbols.