### PR TITLE
test_bignum: defined? returns String

### DIFF
--- a/test/ruby/test_bignum.rb
+++ b/test/ruby/test_bignum.rb
@@ -824,7 +824,7 @@ class TestBignum < Test::Unit::TestCase
 
   def test_gmp_version
     if RbConfig::CONFIG.fetch('configure_args').include?("'--with-gmp'")
-      assert_equal(true, defined?(Integer::GMP_VERSION))
+      assert_kind_of(String, Integer::GMP_VERSION)
     end
   end if ENV['GITHUB_WORKFLOW'] == 'Compilations'
 end


### PR DESCRIPTION
didn't verify the test is working properly due to mistaken auto-merge…

related https://github.com/ruby/ruby/pull/10876

bug: https://bugs.ruby-lang.org/issues/20515
follow-up: 22e4eeda6561693367fc7a00b92b90f46b09cabd
follow-up: https://github.com/ruby/ruby/pull/10875