### PR TITLE
YJIT: implement variable-length context encoding scheme

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -1245,7 +1245,7 @@ rb_yjit_set_exception_return(rb_control_frame_t *cfp, void *leave_exit, void *le
 VALUE rb_yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_print_stats_p(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_trace_exit_locations_enabled_p(rb_execution_context_t *ec, VALUE self);
-VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self, VALUE context);
+VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_disasm_iseq(rb_execution_context_t *ec, VALUE self, VALUE iseq);
 VALUE rb_yjit_insns_compiled(rb_execution_context_t *ec, VALUE self, VALUE iseq);

--- a/yjit.rb
+++ b/yjit.rb
@@ -390,6 +390,12 @@ module RubyVM::YJIT
       out.puts "yjit_alloc_size:       " + format_number(13, stats[:yjit_alloc_size]) if stats.key?(:yjit_alloc_size)
       out.puts "live_context_size:     " + format_number(13, stats[:live_context_size])
       out.puts "live_context_count:    " + format_number(13, stats[:live_context_count])
+
+      bytes_per_context = stats[:context_data_bytes].fdiv(stats[:num_contexts_encoded])
+      out.puts "context_data_bytes:    " + format_number(13, stats[:context_data_bytes])
+      out.puts "num_contexts_encoded:  " + format_number(13, stats[:num_contexts_encoded])
+      out.puts "bytes_per_context:     " + ("%13.2f" % bytes_per_context)
+
       out.puts "live_page_count:       " + format_number(13, stats[:live_page_count])
       out.puts "freed_page_count:      " + format_number(13, stats[:freed_page_count])
       out.puts "code_gc_count:         " + format_number(13, stats[:code_gc_count])

--- a/yjit.rb
+++ b/yjit.rb
@@ -155,8 +155,8 @@ module RubyVM::YJIT
 
   # Return a hash for statistics generated for the `--yjit-stats` command line option.
   # Return `nil` when option is not passed or unavailable.
-  def self.runtime_stats(context: false)
-    stats = Primitive.rb_yjit_get_stats(context)
+  def self.runtime_stats()
+    stats = Primitive.rb_yjit_get_stats()
     return stats if stats.nil?
 
     stats[:object_shape_count] = Primitive.object_shape_count
@@ -313,7 +313,7 @@ module RubyVM::YJIT
 
     # Format and print out counters
     def _print_stats(out: $stderr) # :nodoc:
-      stats = runtime_stats(context: true)
+      stats = runtime_stats()
       return unless Primitive.rb_yjit_stats_enabled_p
 
       out.puts("***YJIT: Printing YJIT statistics on exit***")
@@ -388,8 +388,6 @@ module RubyVM::YJIT
 
       out.puts "freed_code_size:       " + format_number(13, stats[:freed_code_size])
       out.puts "yjit_alloc_size:       " + format_number(13, stats[:yjit_alloc_size]) if stats.key?(:yjit_alloc_size)
-      out.puts "live_context_size:     " + format_number(13, stats[:live_context_size])
-      out.puts "live_context_count:    " + format_number(13, stats[:live_context_count])
 
       bytes_per_context = stats[:context_data_bytes].fdiv(stats[:num_contexts_encoded])
       out.puts "context_data_bytes:    " + format_number(13, stats[:context_data_bytes])

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -10333,6 +10333,7 @@ fn yjit_reg_method(klass: VALUE, mid_str: &str, gen_fn: MethodGenFn) {
 
 /// Global state needed for code generation
 pub struct CodegenGlobals {
+    /// Flat vector of bits to store compressed context data
     context_data: BitVector,
 
     /// Inline code block (fast path)

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5789,7 +5789,7 @@ fn jit_rb_str_getbyte(
         RUBY_OFFSET_RSTRING_LEN as i32,
     );
 
-    // Exit if the indes is out of bounds
+    // Exit if the index is out of bounds
     asm.cmp(idx, str_len_opnd);
     asm.jge(Target::side_exit(Counter::getbyte_idx_out_of_bounds));
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -10333,6 +10333,8 @@ fn yjit_reg_method(klass: VALUE, mid_str: &str, gen_fn: MethodGenFn) {
 
 /// Global state needed for code generation
 pub struct CodegenGlobals {
+    context_data: BitVector,
+
     /// Inline code block (fast path)
     inline_cb: CodeBlock,
 
@@ -10448,6 +10450,7 @@ impl CodegenGlobals {
         ocb.unwrap().mark_all_executable();
 
         let codegen_globals = CodegenGlobals {
+            context_data: BitVector::new(),
             inline_cb: cb,
             outlined_cb: ocb,
             leave_exit_code,
@@ -10474,6 +10477,11 @@ impl CodegenGlobals {
 
     pub fn has_instance() -> bool {
         unsafe { CODEGEN_GLOBALS.as_mut().is_some() }
+    }
+
+    /// Get a mutable reference to the context data
+    pub fn get_context_data() -> &'static mut BitVector {
+        &mut CodegenGlobals::get_instance().context_data
     }
 
     /// Get a mutable reference to the inline code block

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -458,8 +458,11 @@ const CHAIN_DEPTH_MASK: u8   = 0b00111111; // 63
 /// There are a lot of context objects so we try to keep the size small.
 #[derive(Copy, Clone, Default, Eq, Hash, PartialEq, Debug)]
 pub struct Context {
+    // FIXME: decoded_from breaks == on contexts
+    /*
     // Offset at which this context was previously encoded (zero if not)
     decoded_from: u32,
+    */
 
     // Number of values currently on the temporary stack
     stack_size: u8,
@@ -849,10 +852,12 @@ impl Context {
             return 0;
         }
 
+        /*
         // If this context was previously decoded and was not changed since
         if self.decoded_from != 0 && Self::decode(self.decoded_from) == *self {
             return self.decoded_from;
         }
+        */
 
         // If this context was recently encoded (cache check)
         unsafe {
@@ -889,10 +894,10 @@ impl Context {
         };
 
         let context_data = CodegenGlobals::get_context_data();
-        let mut ctx = Self::decode_from(context_data, start_idx as usize);
+        let ctx = Self::decode_from(context_data, start_idx as usize);
 
         // Keep track of the fact that this context was previously encoded
-        ctx.decoded_from = start_idx;
+        //ctx.decoded_from = start_idx;
 
         ctx
     }

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -499,8 +499,7 @@ pub struct Context {
 }
 
 #[derive(Clone)]
-pub struct BitVector
-{
+pub struct BitVector {
     // Flat vector of bytes to write into
     bytes: Vec<u8>,
 
@@ -508,10 +507,8 @@ pub struct BitVector
     num_bits: usize,
 }
 
-impl BitVector
-{
-    pub fn new() -> Self
-    {
+impl BitVector {
+    pub fn new() -> Self {
         Self {
             bytes: Vec::with_capacity(4096),
             num_bits: 0,
@@ -519,21 +516,18 @@ impl BitVector
     }
 
     #[allow(unused)]
-    pub fn num_bits(&self) -> usize
-    {
+    pub fn num_bits(&self) -> usize {
         self.num_bits
     }
 
     // Total number of bytes taken
     #[allow(unused)]
-    pub fn num_bytes(&self) -> usize
-    {
+    pub fn num_bytes(&self) -> usize {
         (self.num_bits / 8) + if (self.num_bits % 8) != 0 { 1 } else { 0 }
     }
 
     // Write/append an unsigned integer value
-    fn push_uint(&mut self, mut val: u64, mut num_bits: usize)
-    {
+    fn push_uint(&mut self, mut val: u64, mut num_bits: usize) {
         assert!(num_bits <= 64);
 
         // Mask out bits above the number of bits requested
@@ -580,45 +574,38 @@ impl BitVector
         }
     }
 
-    fn push_u8(&mut self, val: u8)
-    {
+    fn push_u8(&mut self, val: u8) {
         self.push_uint(val as u64, 8);
     }
 
-    fn push_u4(&mut self, val: u8)
-    {
+    fn push_u4(&mut self, val: u8) {
         assert!(val < 16);
         self.push_uint(val as u64, 4);
     }
 
-    fn push_u3(&mut self, val: u8)
-    {
+    fn push_u3(&mut self, val: u8) {
         assert!(val < 8);
         self.push_uint(val as u64, 3);
     }
 
-    fn push_u2(&mut self, val: u8)
-    {
+    fn push_u2(&mut self, val: u8) {
         assert!(val < 4);
         self.push_uint(val as u64, 2);
     }
 
-    fn push_u1(&mut self, val: u8)
-    {
+    fn push_u1(&mut self, val: u8) {
         assert!(val < 2);
         self.push_uint(val as u64, 1);
     }
 
     // Push a context encoding opcode
-    fn push_op(&mut self, op: CtxOp)
-    {
+    fn push_op(&mut self, op: CtxOp) {
         self.push_u4(op as u8);
     }
 
     // Read a uint value at a given bit index
     // The bit index is incremented after the value is read
-    fn read_uint(&self, bit_idx: &mut usize, mut num_bits: usize) -> u64
-    {
+    fn read_uint(&self, bit_idx: &mut usize, mut num_bits: usize) -> u64 {
         let start_bit_idx = *bit_idx;
         let mut cur_idx = *bit_idx;
 
@@ -652,41 +639,33 @@ impl BitVector
         out_bits
     }
 
-    fn read_u8(&self, bit_idx: &mut usize) -> u8
-    {
+    fn read_u8(&self, bit_idx: &mut usize) -> u8 {
         self.read_uint(bit_idx, 8) as u8
     }
 
-    fn read_u4(&self, bit_idx: &mut usize) -> u8
-    {
+    fn read_u4(&self, bit_idx: &mut usize) -> u8 {
         self.read_uint(bit_idx, 4) as u8
     }
 
-    fn read_u3(&self, bit_idx: &mut usize) -> u8
-    {
+    fn read_u3(&self, bit_idx: &mut usize) -> u8 {
         self.read_uint(bit_idx, 3) as u8
     }
 
-    fn read_u2(&self, bit_idx: &mut usize) -> u8
-    {
+    fn read_u2(&self, bit_idx: &mut usize) -> u8 {
         self.read_uint(bit_idx, 2) as u8
     }
 
-    fn read_u1(&self, bit_idx: &mut usize) -> u8
-    {
+    fn read_u1(&self, bit_idx: &mut usize) -> u8 {
         self.read_uint(bit_idx, 1) as u8
     }
 
-    fn read_op(&self, bit_idx: &mut usize) -> CtxOp
-    {
+    fn read_op(&self, bit_idx: &mut usize) -> CtxOp {
         unsafe { std::mem::transmute(self.read_u4(bit_idx)) }
     }
 }
 
-impl fmt::Debug for BitVector
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
-    {
+impl fmt::Debug for BitVector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // We print the higher bytes first
         for (idx, byte) in self.bytes.iter().enumerate().rev() {
             write!(f, "{:08b}", byte)?;
@@ -766,7 +745,6 @@ mod bitvector_tests {
 
     #[test]
     fn write_read_u32_max_64b() {
-
         let mut arr = BitVector::new();
         arr.push_uint(0xFF_FF_FF_FF, 64);
         assert!(arr.read_uint(&mut 0, 64) == 0xFF_FF_FF_FF);
@@ -830,8 +808,7 @@ mod bitvector_tests {
 // Context encoding opcodes (4 bits)
 #[derive(Debug, Copy, Clone)]
 #[repr(u8)]
-enum CtxOp
-{
+enum CtxOp {
     // Self type (4 bits)
     SetSelfType = 0,
 
@@ -862,10 +839,8 @@ enum CtxOp
 // We can experiment with varying the size of this cache
 static mut LAST_CTX_ENCODED: Option<(Context, u32)> = None;
 
-impl Context
-{
-    pub fn encode(&self) -> u32
-    {
+impl Context {
+    pub fn encode(&self) -> u32 {
         incr_counter!(num_contexts_encoded);
 
         if *self == Context::default() {
@@ -900,8 +875,7 @@ impl Context
         idx
     }
 
-    pub fn decode(start_idx: u32) -> Context
-    {
+    pub fn decode(start_idx: u32) -> Context {
         if start_idx == 0 {
             return Context::default();
         };
@@ -911,8 +885,7 @@ impl Context
     }
 
     // Encode into a compressed context representation in a bit vector
-    fn encode_into(&self, bits: &mut BitVector) -> usize
-    {
+    fn encode_into(&self, bits: &mut BitVector) -> usize {
         let start_idx = bits.num_bits();
 
         // NOTE: this value is often zero or falls within
@@ -926,8 +899,7 @@ impl Context
             // One single bit to signify a compact stack_size/sp_offset encoding
             bits.push_u1(1);
             bits.push_u2(self.stack_size);
-        } else
-        {
+        } else {
             // Full stack size encoding
             bits.push_u1(0);
 
@@ -1006,8 +978,7 @@ impl Context
     }
 
     // Decode a compressed context representation from a bit vector
-    fn decode_from(bits: &BitVector, start_idx: usize) -> Context
-    {
+    fn decode_from(bits: &BitVector, start_idx: usize) -> Context {
         let mut ctx = Context::default();
 
         let mut idx = start_idx;
@@ -1016,8 +987,7 @@ impl Context
         if bits.read_u1(&mut idx) == 1 {
             ctx.stack_size = bits.read_u2(&mut idx);
             ctx.sp_offset = ctx.stack_size as i8;
-        } else
-        {
+        } else {
             ctx.stack_size = bits.read_u8(&mut idx);
             ctx.sp_offset = bits.read_u8(&mut idx) as i8;
         }
@@ -1028,8 +998,7 @@ impl Context
         // chain_depth_and_flags: u8
         ctx.chain_depth_and_flags = bits.read_u8(&mut idx);
 
-        loop
-        {
+        loop {
             //println!("reading op");
             let op = bits.read_op(&mut idx);
             //println!("got op {:?}", op);

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1650,15 +1650,6 @@ pub fn for_each_iseq<F: FnMut(IseqPtr)>(mut callback: F) {
     unsafe { rb_yjit_for_each_iseq(Some(callback_wrapper), (&mut data) as *mut _ as *mut c_void) };
 }
 
-/// Iterate over all ISEQ payloads
-pub fn for_each_iseq_payload<F: FnMut(&IseqPayload)>(mut callback: F) {
-    for_each_iseq(|iseq| {
-        if let Some(iseq_payload) = get_iseq_payload(iseq) {
-            callback(iseq_payload);
-        }
-    });
-}
-
 /// Iterate over all on-stack ISEQs
 pub fn for_each_on_stack_iseq<F: FnMut(IseqPtr)>(mut callback: F) {
     unsafe extern "C" fn callback_wrapper(iseq: IseqPtr, data: *mut c_void) {

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -867,6 +867,17 @@ impl Context
 
         bits
     }
+
+    // Decode a compressed context representation
+    pub fn decode(bits: &BitVector, start_idx: usize) -> Context
+    {
+
+
+
+
+
+        todo!();
+    }
 }
 
 
@@ -2018,6 +2029,11 @@ impl JITState {
         // Test the variable-length context encoding logic
         {
             let ctx = self.get_starting_ctx();
+
+            if ctx == Context::default() {
+                println!("trying to encode default context");
+            }
+
             let bits = ctx.encode();
             let num_bytes = bits.num_bytes();
             //println!("num_bytes={}", num_bytes);
@@ -2042,7 +2058,6 @@ impl JITState {
             }
         }
         */
-
 
 
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -894,6 +894,9 @@ impl Context
             LAST_CTX_ENCODED = Some((*self, idx));
         }
 
+        // In debug mode, check that the round-trip decoding always matches
+        debug_assert!(Self::decode(idx) == *self);
+
         idx
     }
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -498,15 +498,13 @@ pub struct Context {
     inline_block: u64,
 }
 
-
-
-
-
-
 #[derive(Clone)]
 pub struct BitVector
 {
+    // Flat vector of bytes to write into
     bytes: Vec<u8>,
+
+    // Number of bits taken out of bytes allocated
     num_bits: usize,
 }
 
@@ -533,7 +531,7 @@ impl BitVector
         (self.num_bits / 8) + if (self.num_bits % 8) != 0 { 1 } else { 0 }
     }
 
-    // Write and append an unsigned integer
+    // Write/append an unsigned integer value
     fn push_uint(&mut self, mut val: u64, mut num_bits: usize)
     {
         assert!(num_bits <= 64);
@@ -611,7 +609,7 @@ impl BitVector
     }
 
     // Read a uint value at a given bit index
-    // The bit index will is incremented after the value is read
+    // The bit index is incremented after the value is read
     fn read_uint(&self, bit_idx: &mut usize, mut num_bits: usize) -> u64
     {
         let start_bit_idx = *bit_idx;
@@ -853,6 +851,8 @@ enum CtxOp
 }
 
 // Cache of the last context encoded
+// Empirically this saves a few percent of memory
+// We can experiment with varying the size of this cache
 static mut LAST_CTX_ENCODED: Option<(Context, u32)> = None;
 
 impl Context

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -2122,7 +2122,7 @@ unsafe fn add_block_version(blockref: BlockRef, cb: &CodeBlock) {
     let block = unsafe { blockref.as_ref() };
 
     // Function entry blocks must have stack size 0
-    //assert!(!(block.iseq_range.start == 0 && block.ctx.stack_size > 0));
+    debug_assert!(!(block.iseq_range.start == 0 && Context::decode(block.ctx).stack_size > 0));
 
     let version_list = get_or_create_version_list(block.get_blockid());
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -500,13 +500,13 @@ pub struct Context {
 
 
 
-struct BitArray
+struct BitVector
 {
     bytes: Vec<u8>,
     num_bits: usize,
 }
 
-impl BitArray
+impl BitVector
 {
     fn new() -> Self
     {
@@ -592,20 +592,40 @@ impl BitArray
 
 }
 
+impl fmt::Debug for BitVector
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result
+    {
+        // We print the higher bytes first
+        for (idx, byte) in self.bytes.iter().enumerate().rev() {
+            write!(f, "{:08b}", byte)?;
+
+            // Insert a separator between each byte
+            if idx > 0 {
+                write!(f, "|")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+
+
 #[cfg(test)]
-mod bitarray_tests {
+mod bitvector_tests {
     use super::*;
 
     #[test]
     fn write_3() {
-        let mut arr = BitArray::new();
+        let mut arr = BitVector::new();
         arr.push_uint(3, 2);
         assert!(arr.read_uint_at(0, 2) == 3);
     }
 
     #[test]
     fn write_11() {
-        let mut arr = BitArray::new();
+        let mut arr = BitVector::new();
         arr.push_uint(1, 1);
         arr.push_uint(1, 1);
         assert!(arr.read_uint_at(0, 2) == 3);
@@ -613,35 +633,32 @@ mod bitarray_tests {
 
     #[test]
     fn write_ff_0() {
-        let mut arr = BitArray::new();
+        let mut arr = BitVector::new();
         arr.push_uint(0xFF, 8);
         assert!(arr.read_uint_at(0, 8) == 0xFF);
     }
 
 
-
-
-    // FIXME: broken
-    /*
     #[test]
     fn write_ff_3() {
         // Write 0xFF at bit index 3
-        let mut arr = BitArray::new();
+        let mut arr = BitVector::new();
         arr.push_uint(0, 3);
         arr.push_uint(0xFF, 8);
 
-        dbg!(arr.read_uint(3, 8));
+        dbg!(&arr);
 
-        assert!(arr.read_uint(3, 8) == 0xFF);
+        dbg!(arr.read_uint_at(3, 8));
+
+        assert!(arr.read_uint_at(3, 8) == 0xFF);
     }
-    */
 
 
 
     /*
     #[test]
     fn write_11_overlap() {
-        let mut arr = BitArray::new();
+        let mut arr = BitVector::new();
         arr.write_uint(0, 7);
         arr.write_uint(3, 2);
         arr.write_uint(1, 1);

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -659,11 +659,15 @@ mod bitvector_tests {
         assert!(arr.read_uint_at(3, 8) == 0xFF);
     }
 
-
-
-
-
-
+    #[test]
+    fn write_ff_sandwich() {
+        // Write 0xFF sandwhiched between zeros
+        let mut arr = BitVector::new();
+        arr.push_uint(0, 3);
+        arr.push_uint(0xFF, 8);
+        arr.push_uint(0, 3);
+        assert!(arr.read_uint_at(3, 8) == 0xFF);
+    }
 }
 
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -852,16 +852,17 @@ enum CtxOp
 
 impl Context
 {
-    pub fn encode(&self) -> usize
+    pub fn encode(&self) -> u32
     {
         let context_data = CodegenGlobals::get_context_data();
-        self.encode_into(context_data)
+        let idx = self.encode_into(context_data);
+        idx.try_into().unwrap()
     }
 
-    pub fn decode(&self, start_idx: usize) -> Context
+    pub fn decode(&self, start_idx: u32) -> Context
     {
         let context_data = CodegenGlobals::get_context_data();
-        Self::decode_from(context_data, start_idx)
+        Self::decode_from(context_data, start_idx as usize)
     }
 
     // Encode into a compressed context representation in a bit vector

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -576,16 +576,19 @@ impl BitVector
 
         // While we have bits left to read
         while num_bits > 0 {
-            assert!(bit_idx % 8 == 0);
-            let byte = self.bytes[bit_idx / 8];
-            let bits_in_byte = (byte as usize) & ((1 << num_bits) - 1);
-
             let num_bits_in_byte = std::cmp::min(num_bits, 8);
+            assert!(bit_idx % 8 == 0);
+            let byte = self.bytes[bit_idx / 8] as usize;
+
+            let bits_in_byte = byte & ((1 << num_bits) - 1);
+            out_bits |= bits_in_byte << (bit_idx - start_bit_idx);
+
+            // Move to the next byte/offset
             bit_idx += num_bits_in_byte;
             num_bits -= num_bits_in_byte;
-
-            out_bits |= bits_in_byte << (bit_idx - start_bit_idx);
         }
+
+        dbg!(out_bits);
 
         out_bits
     }
@@ -610,8 +613,6 @@ impl fmt::Debug for BitVector
     }
 }
 
-
-
 #[cfg(test)]
 mod bitvector_tests {
     use super::*;
@@ -632,12 +633,22 @@ mod bitvector_tests {
     }
 
     #[test]
+    fn write_11_overlap() {
+        let mut arr = BitVector::new();
+        arr.push_uint(0, 7);
+        arr.push_uint(3, 2);
+        arr.push_uint(1, 1);
+
+        //dbg!(arr.read_uint(7, 2));
+        assert!(arr.read_uint_at(7, 2) == 3);
+    }
+
+    #[test]
     fn write_ff_0() {
         let mut arr = BitVector::new();
         arr.push_uint(0xFF, 8);
         assert!(arr.read_uint_at(0, 8) == 0xFF);
     }
-
 
     #[test]
     fn write_ff_3() {
@@ -645,28 +656,12 @@ mod bitvector_tests {
         let mut arr = BitVector::new();
         arr.push_uint(0, 3);
         arr.push_uint(0xFF, 8);
-
-        dbg!(&arr);
-
-        dbg!(arr.read_uint_at(3, 8));
-
         assert!(arr.read_uint_at(3, 8) == 0xFF);
     }
 
 
 
-    /*
-    #[test]
-    fn write_11_overlap() {
-        let mut arr = BitVector::new();
-        arr.write_uint(0, 7);
-        arr.write_uint(3, 2);
-        arr.write_uint(1, 1);
 
-        dbg!(arr.read_uint(7, 2));
-        assert!(arr.read_uint(7, 2) == 3);
-    }
-    */
 
 
 }

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -522,8 +522,8 @@ impl BitArray
         (self.num_bits / 8) + if (self.num_bits % 8) != 0 { 1 } else { 0 }
     }
 
-    // Write and append a uint
-    fn write_uint(&mut self, mut val: usize, mut num_bits: usize)
+    // Write and append an unsigned integer
+    fn push_uint(&mut self, mut val: usize, mut num_bits: usize)
     {
         // Mask out bits above the number of bits requested
         let val_bits = val & ((1 << num_bits) - 1);
@@ -599,22 +599,22 @@ mod bitarray_tests {
     #[test]
     fn write_3() {
         let mut arr = BitArray::new();
-        arr.write_uint(3, 2);
+        arr.push_uint(3, 2);
         assert!(arr.read_uint_at(0, 2) == 3);
     }
 
     #[test]
     fn write_11() {
         let mut arr = BitArray::new();
-        arr.write_uint(1, 1);
-        arr.write_uint(1, 1);
+        arr.push_uint(1, 1);
+        arr.push_uint(1, 1);
         assert!(arr.read_uint_at(0, 2) == 3);
     }
 
     #[test]
     fn write_ff_0() {
         let mut arr = BitArray::new();
-        arr.write_uint(0xFF, 8);
+        arr.push_uint(0xFF, 8);
         assert!(arr.read_uint_at(0, 8) == 0xFF);
     }
 
@@ -627,8 +627,8 @@ mod bitarray_tests {
     fn write_ff_3() {
         // Write 0xFF at bit index 3
         let mut arr = BitArray::new();
-        arr.write_uint(0, 3);
-        arr.write_uint(0xFF, 8);
+        arr.push_uint(0, 3);
+        arr.push_uint(0xFF, 8);
 
         dbg!(arr.read_uint(3, 8));
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -562,6 +562,13 @@ impl BitVector
 
         // While we have bits left to encode
         while num_bits > 0 {
+            // Grow with a 1.2x growth factor instead of 2x
+            assert!(self.num_bits % 8 == 0);
+            let num_bytes = self.num_bits / 8;
+            if num_bytes == self.bytes.capacity() {
+                self.bytes.reserve_exact(self.bytes.len() / 5);
+            }
+
             let bits = val & 0xFF;
             let bits: u8 = bits.try_into().unwrap();
             self.bytes.push(bits);

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -852,8 +852,20 @@ enum CtxOp
 
 impl Context
 {
+    pub fn encode(&self) -> usize
+    {
+        let context_data = CodegenGlobals::get_context_data();
+        self.encode_into(context_data)
+    }
+
+    pub fn decode(&self, start_idx: usize) -> Context
+    {
+        let context_data = CodegenGlobals::get_context_data();
+        Self::decode_from(context_data, start_idx)
+    }
+
     // Encode into a compressed context representation in a bit vector
-    pub fn encode_into(&self, bits: &mut BitVector) -> usize
+    fn encode_into(&self, bits: &mut BitVector) -> usize
     {
         let start_idx = bits.num_bits();
 
@@ -948,7 +960,7 @@ impl Context
     }
 
     // Decode a compressed context representation from a bit vector
-    pub fn decode_from(bits: &BitVector, start_idx: usize) -> Context
+    fn decode_from(bits: &BitVector, start_idx: usize) -> Context
     {
         let mut ctx = Context::default();
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -522,6 +522,7 @@ impl BitArray
         (self.num_bits / 8) + if (self.num_bits % 8) != 0 { 1 } else { 0 }
     }
 
+    // Write and append a uint
     fn write_uint(&mut self, mut val: usize, mut num_bits: usize)
     {
         // Mask out bits above the number of bits requested
@@ -558,7 +559,8 @@ impl BitArray
         }
     }
 
-    fn read_uint(&self, start_bit_idx: usize, mut num_bits: usize) -> usize
+    // Read a uint value at a given bit index
+    fn read_uint_at(&self, start_bit_idx: usize, mut num_bits: usize) -> usize
     {
         let mut bit_idx = start_bit_idx;
 
@@ -598,7 +600,7 @@ mod bitarray_tests {
     fn write_3() {
         let mut arr = BitArray::new();
         arr.write_uint(3, 2);
-        assert!(arr.read_uint(0, 2) == 3);
+        assert!(arr.read_uint_at(0, 2) == 3);
     }
 
     #[test]
@@ -606,8 +608,33 @@ mod bitarray_tests {
         let mut arr = BitArray::new();
         arr.write_uint(1, 1);
         arr.write_uint(1, 1);
-        assert!(arr.read_uint(0, 2) == 3);
+        assert!(arr.read_uint_at(0, 2) == 3);
     }
+
+    #[test]
+    fn write_ff_0() {
+        let mut arr = BitArray::new();
+        arr.write_uint(0xFF, 8);
+        assert!(arr.read_uint_at(0, 8) == 0xFF);
+    }
+
+
+
+
+    // FIXME: broken
+    /*
+    #[test]
+    fn write_ff_3() {
+        // Write 0xFF at bit index 3
+        let mut arr = BitArray::new();
+        arr.write_uint(0, 3);
+        arr.write_uint(0xFF, 8);
+
+        dbg!(arr.read_uint(3, 8));
+
+        assert!(arr.read_uint(3, 8) == 0xFF);
+    }
+    */
 
 
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -515,17 +515,19 @@ impl BitVector
     pub fn new() -> Self
     {
         Self {
-            bytes: Vec::with_capacity(64),
+            bytes: Vec::with_capacity(4096),
             num_bits: 0,
         }
     }
 
+    #[allow(unused)]
     pub fn num_bits(&self) -> usize
     {
         self.num_bits
     }
 
     // Total number of bytes taken
+    #[allow(unused)]
     pub fn num_bytes(&self) -> usize
     {
         (self.num_bits / 8) + if (self.num_bits % 8) != 0 { 1 } else { 0 }

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -520,6 +520,11 @@ impl BitVector
         }
     }
 
+    fn num_bits(&self) -> usize
+    {
+        self.num_bits
+    }
+
     // Total number of bytes taken
     fn num_bytes(&self) -> usize
     {
@@ -737,8 +742,11 @@ mod bitvector_tests {
 
     #[test]
     fn encode_default() {
+        let mut bits = BitVector::new();
         let ctx = Context::default();
-        let bits = ctx.encode();
+        let start_idx = ctx.encode(&mut bits);
+        assert!(start_idx == 0);
+        assert!(bits.num_bits() > 0);
         assert!(bits.num_bytes() > 0);
     }
 }
@@ -774,9 +782,9 @@ enum CtxOp
 
 impl Context
 {
-    pub fn encode(&self) -> BitVector
+    pub fn encode(&self, bits: &mut BitVector) -> usize
     {
-        let mut bits = BitVector::new();
+        let start_idx = bits.num_bits();
 
         // NOTE: this value is often zero or falls within
         // a small range, so could be compressed
@@ -865,7 +873,7 @@ impl Context
         // or store num ops at the beginning?
         bits.push_op(CtxOp::EndOfCode);
 
-        bits
+        start_idx
     }
 
     // Decode a compressed context representation

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -754,6 +754,7 @@ fn rb_yjit_gen_stats_dict(context: bool) -> VALUE {
             hash_aset_usize!(hash, "live_context_size", live_context_count * context_size);
         }
 
+        // How many bytes we are using to store context data
         let context_data = CodegenGlobals::get_context_data();
         hash_aset_usize!(hash, "context_data_bytes", context_data.num_bytes());
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -557,6 +557,7 @@ make_counters! {
     branch_insn_count,
     branch_known_count,
     max_inline_versions,
+    num_contexts_encoded,
 
     freed_iseq_count,
 
@@ -752,6 +753,9 @@ fn rb_yjit_gen_stats_dict(context: bool) -> VALUE {
             hash_aset_usize!(hash, "live_context_count", live_context_count);
             hash_aset_usize!(hash, "live_context_size", live_context_count * context_size);
         }
+
+        let context_data = CodegenGlobals::get_context_data();
+        hash_aset_usize!(hash, "context_data_bytes", context_data.num_bytes());
 
         // VM instructions count
         hash_aset_usize!(hash, "vm_insns_count", rb_vm_insns_count as usize);

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -10,8 +10,6 @@ use std::time::Instant;
 use std::collections::HashMap;
 
 use crate::codegen::CodegenGlobals;
-use crate::core::Context;
-use crate::core::for_each_iseq_payload;
 use crate::cruby::*;
 use crate::options::*;
 use crate::yjit::yjit_enabled_p;
@@ -642,8 +640,8 @@ pub extern "C" fn rb_yjit_print_stats_p(_ec: EcPtr, _ruby_self: VALUE) -> VALUE 
 /// Primitive called in yjit.rb.
 /// Export all YJIT statistics as a Ruby hash.
 #[no_mangle]
-pub extern "C" fn rb_yjit_get_stats(_ec: EcPtr, _ruby_self: VALUE, context: VALUE) -> VALUE {
-    with_vm_lock(src_loc!(), || rb_yjit_gen_stats_dict(context == Qtrue))
+pub extern "C" fn rb_yjit_get_stats(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
+    with_vm_lock(src_loc!(), || rb_yjit_gen_stats_dict())
 }
 
 /// Primitive called in yjit.rb
@@ -702,7 +700,7 @@ pub extern "C" fn rb_yjit_incr_counter(counter_name: *const std::os::raw::c_char
 }
 
 /// Export all YJIT statistics as a Ruby hash.
-fn rb_yjit_gen_stats_dict(context: bool) -> VALUE {
+fn rb_yjit_gen_stats_dict() -> VALUE {
     // If YJIT is not enabled, return Qnil
     if !yjit_enabled_p() {
         return Qnil;
@@ -744,15 +742,6 @@ fn rb_yjit_gen_stats_dict(context: bool) -> VALUE {
 
         // Rust global allocations in bytes
         hash_aset_usize!(hash, "yjit_alloc_size", GLOBAL_ALLOCATOR.alloc_size.load(Ordering::SeqCst));
-
-        // `context` is true at RubyVM::YJIT._print_stats for --yjit-stats. It's false by default
-        // for RubyVM::YJIT.runtime_stats because counting all Contexts could be expensive.
-        if context {
-            let live_context_count = get_live_context_count();
-            let context_size = std::mem::size_of::<Context>();
-            hash_aset_usize!(hash, "live_context_count", live_context_count);
-            hash_aset_usize!(hash, "live_context_size", live_context_count * context_size);
-        }
 
         // How many bytes we are using to store context data
         let context_data = CodegenGlobals::get_context_data();
@@ -849,21 +838,6 @@ fn rb_yjit_gen_stats_dict(context: bool) -> VALUE {
     }
 
     hash
-}
-
-fn get_live_context_count() -> usize {
-    let mut count = 0;
-    for_each_iseq_payload(|iseq_payload| {
-        for blocks in iseq_payload.version_map.iter() {
-            for block in blocks.iter() {
-                count += unsafe { block.as_ref() }.get_ctx_count();
-            }
-        }
-        for block in iseq_payload.dead_blocks.iter() {
-            count += unsafe { block.as_ref() }.get_ctx_count();
-        }
-    });
-    count
 }
 
 /// Record the backtrace when a YJIT exit occurs. This functionality requires


### PR DESCRIPTION
This PR implements a scheme where `Context` objects are stored into a flat vector of bits, using a variable-length encoding scheme. This is essentially a simple ad-hoc compression scheme.

I wrote a method `Context::encode()` that encodes the information from the current context into a vector of bits. There is also a corresponding `Context::decode()` method. The compressed contexts are referred to using a `u32` which is a bit index into the flat `BitVector` that stores contexts.

The encoding is not particularly clever or anything. It could probably be optimized to be more compact. The main space saving feature is that if we don't know the type of a stack temp or local, we don't write anything. We can also avoid writing the inline block pointer when it's null. This alone seems to be potentially very effective in terms of space savings. Some values are currently always written at the beginning (i.e. stack size, sp offset). Type information is written using a system of 4-bit opcodes and variable-length instructions, with a special "end of encoding" opcode. 

There are two further space-saving optimizations. Offset 0 in the bit vector is reserved for the default context, and there is also a simple cache of the last context encoded. These save a few percent more memory.

I added some stats as well to compute the average number of bytes per context. Those values look quite good:

```
lobsters:
  context_data_bytes:          648,388
  num_contexts_encoded:        134,125
  bytes_per_context:              4.83

railsbench:
  context_data_bytes:          385,321
  num_contexts_encoded:         78,865
  bytes_per_context:              4.89

liquid-render:
  context_data_bytes:           86,032
  num_contexts_encoded:         17,311
  bytes_per_context:              4.97
```

The impact on `yjit_alloc_size` is not as clear cut and amazing as I would like it to be:
```
masters:
  lobsters:
    yjit_alloc_size:          20,651,810

  railsbench:
    yjit_alloc_size:           9,887,827

  liquid-render:
    yjit_alloc_size:           2,595,099

var-len:
  lobsters:
    yjit_alloc_size:          20,164,574

  railsbench:
    yjit_alloc_size:           9,640,691

  liquid-render:
    yjit_alloc_size:           2,624,275
```

We seem to save a little bit of space on the larger benchmarks but no space on others. One challenge is that the Rust allocator may have size classes like Ruby's allocator. So shrinking objects does not immediately translate into a visible reduction on memory usage. Another potential issue it that apparently Rust's `Vec` uses a 2x growth rate, which could waste significant space. I think I may be able to fix that issue by using a manually allocated slice of bytes and a 1.2x growth rate instead.

A third possible source of overhead is that it's possible that I'm encoding-decoding and re-encoding contexts in places where it's not really necessary. I would appreciate your help in reviewing this PR to identify such cases if there are any. Ideally, if we've encoded a context, we want to avoid decoding an re-encoding it again, because that could allocate more memory when it isn't necessary.