### PR TITLE
reinitialize the sched lock on `thread_atfork`

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1555,6 +1555,7 @@ thread_sched_atfork(struct rb_thread_sched *sched)
     }
     vm->ractor.sched.running_cnt = 0;
 
+    rb_native_mutex_initialize(&vm->ractor.sched.lock);
     // rb_native_cond_destroy(&vm->ractor.sched.cond);
     rb_native_cond_initialize(&vm->ractor.sched.cond);
     rb_native_cond_initialize(&vm->ractor.sched.barrier_complete_cond);


### PR DESCRIPTION
We are seeing intermittent hangs in various tests at Stripe when using Ruby 3.3.1 that involve subprocesses: one process is stuck waiting for a child process to complete, while the child process is stuck waiting for `vm->ractor.sched.lock`.  Inspecting the lock on x86-64 Linux says that the lock is being held by the parent process -- but the parent process's threads are all nowhere near the critical section that this lock is protecting, i.e. the parent process is not actually holding the lock.  The tests in question are all using the `subprocess` gem, but we believe the below scenario is applicable to any use of `fork`, including much of `Open3` in the standard library.

We think what must have happened is:

1. Some thread T2 in the parent process calls `fork` from Ruby.
1. Some thread T1 in the parent process locks `vm->ractor.sched.lock`
1. T2 calls `fork(2)`.
1. The child process starts, but only with a copy of T2; T1 only exists in the parent process.
1. The child process eventually tries to lock `vm->ractor.sched.lock` and discovers that the parent process is holding onto the lock.
1. The parent process eventually resumes T1 to unlock `vm->ractor.sched.lock`.
1. The child process is stuck waiting forever, because nothing in it exists to unlock `vm->ractor.sched.lock`.

To address the above problem, we re-initialize the mutex in `thread_atfork` so the child process starts with a clean slate.  This is undefined behavior according to pthreads, but so is re-initializing the condition variables and barrier here.  I don't think this makes things any worse. 😅 

We've done some limited testing with this patch on our internal CI and it appears to make the hangs go away (none of the affected tests hang in a handful of runs, whereas at least one of them would fail with high probability on any given run before).  We plan on doing wider testing with it starting next week.