### PR TITLE
Use real filename instead of `__FILE__`

### DIFF
--- a/debug_counter.h
+++ b/debug_counter.h
@@ -356,7 +356,7 @@ RB_DEBUG_COUNTER(load_path_is_not_realpath)
 
 enum rb_debug_counter_type {
 #define RB_DEBUG_COUNTER(name) RB_DEBUG_COUNTER_##name,
-#include __FILE__
+#include "debug_counter.h"
     RB_DEBUG_COUNTER_MAX
 #undef RB_DEBUG_COUNTER
 };


### PR DESCRIPTION
Compilation fails when `srcdir ! = builddir` and `-ffile-prefix-map` option is specified.

```
$ cd /home/xxx/src # HOME=/home/xxx
$ git clone https://github.com/ruby/ruby
$ cd ruby
$ ./autogen.sh
$ cd /tmp && mkdir ruby && cd ruby
$ CFLAGS=-ffile-prefix-map=${HOME}/src/ruby=/usr/src/debug/ruby ${HOME}/src/ruby/configure
$ make V=1
:
gcc -ffile-prefix-map=/home/xxx/src/ruby=/usr/src/debug/ruby  -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fno-strict-overflow -fvisibility=hidden -fexcess-precision=standard -DRUBY_EXPORT -fPIE -I. -I.ext/include/x86_64-linux -I/home/xxx/src/ruby/include -I/home/xxx/src/ruby -I/home/xxx/src/ruby/prism -I/home/xxx/src/ruby/enc/unicode/15.0.0      -o array.o -c /home/xxx/src/ruby/array.c
In file included from /home/xxx/src/ruby/array.c:14:
/home/xxx/src/ruby/debug_counter.h:359:10: fatal error: /usr/src/debug/ruby/debug_counter.h: No such file or directory
  359 | #include __FILE__
      |          ^~~~~~~~
compilation terminated.
make: *** [Makefile:450: array.o] Error 1
```

This commit reverts https://github.com/ruby/ruby/commit/1fd1fb2f2ce901133f1051c254fe61b468b23a50
