### PR TITLE
Avoid unnecessary writes in GC marking of ISEQ and imemo_env

### DIFF
--- a/imemo.c
+++ b/imemo.c
@@ -357,7 +357,9 @@ rb_imemo_mark_and_move(VALUE obj, bool reference_updating)
                 ((VALUE *)env->ep)[VM_ENV_DATA_INDEX_ENV] = rb_gc_location(env->ep[VM_ENV_DATA_INDEX_ENV]);
             }
             else {
-                VM_ENV_FLAGS_SET(env->ep, VM_ENV_FLAG_WB_REQUIRED);
+                if (!VM_ENV_FLAGS(env->ep, VM_ENV_FLAG_WB_REQUIRED)) {
+                    VM_ENV_FLAGS_SET(env->ep, VM_ENV_FLAG_WB_REQUIRED);
+                }
                 rb_gc_mark_movable( (VALUE)rb_vm_env_prev_env(env));
             }
         }

--- a/iseq.c
+++ b/iseq.c
@@ -346,7 +346,7 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
                 if (cc_is_active(cds[i].cc, reference_updating)) {
                     rb_gc_mark_and_move_ptr(&cds[i].cc);
                 }
-                else {
+                else if (cds[i].cc != rb_vm_empty_cc()) {
                     cds[i].cc = rb_vm_empty_cc();
                 }
             }


### PR DESCRIPTION
In my testing the ISEQ write is much more significant than the env one, but they make sense to fix together.

On iseq mark we check whether a callcache has been invalidated and if it has we replace it with the empty callcache, rb_vm_empty_cc(). However we also consider the empty callcache to not be active, and so previously would overwrite it with itself. Similarly when we mark imemo_env we set VM_ENV_FLAG_WB_REQUIRED whether or not it already was set.

These additional writes are problematic because even if they make no change they may force Copy-on-Write to occur on the memory page, increasing system memory use.


``` ruby
require "rails"
require "rails/all"

Process.warmup

puts RUBY_DESCRIPTION
Process.waitpid fork {
  puts "## Before"
  puts File.read("/proc/self/smaps_rollup")[/^Private_Dirty.*/]
  GC.start
  puts "## After"
  puts File.read("/proc/self/smaps_rollup")[/^Private_Dirty.*/]
}
```

**Before**

```
ruby 3.4.0preview1 (2024-05-16 master 9d69619623) [x86_64-linux]
## Before
Private_Dirty:       244 kB
## After
Private_Dirty:     16336 kB
```

**After**

```
$ ruby test_rails_cow.rb
ruby 3.4.0dev (2024-05-23T07:23:33Z master a5e782bfa9) [x86_64-linux]
## Before
Private_Dirty:       308 kB
## After
Private_Dirty:       676 kB
```

Improvement is likely less in real-world scenarios as forked processes will fill in the inline callcaches for some ISEQS, but I think it's not uncommon for these caches to stay empty forever.

Interestingly the iseq write seems to exist in Ruby 3.0, 3.1, 3.3, and 3.4.0-preview1, but not 3.2. The imemo_env write seems to occur in all previous versions I tested.

I found these using `perf record -c1 -e page-faults,page-faults:u -p $pid`, to see where page faults in the child process occur.

cc @matthewd
cc @byroot I bet this would help most under pitchfork where the iseq CCs are more likely to be filled in