### PR TITLE
YJIT: Fix getconstant exits after opt_ltlt fusion

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4813,6 +4813,15 @@ assert_equal [0x80000000000, 'a+', :ok].inspect, %q{
   tests
 }
 
+# test integer left shift fusion followed by opt_getconstant_path
+assert_equal '33', %q{
+  def test(a)
+    (a << 5) | (Object; a)
+  end
+
+  test(1)
+}
+
 # test String#stebyte with arguments that need conversion
 assert_equal "abc", %q{
   str = +"a00"


### PR DESCRIPTION
Follow-up to https://github.com/ruby/ruby/pull/10401

This PR fixes a crash on SFR. When `opt_ltlt` fusion returns `SkipNextInsn`, it updates `insn_idx` variable to skip the next instruction. When the next instruction is `opt_getconstant_path`, it calls `jump_to_next_insn` before `jit.insn_idx = insn_idx`. For that reason, `opt_getconstant_path` ends up exiting with a wrong PC, using an old `insn_idx`.

It also ends the block at `opt_ltlt` like other method calls. It's probably nice to share the successor block by ending the block like in case the receiver class varies. So we removed `SkipNextInsn` and just made a jump.