### PR TITLE
YJIT: Add another regression test for empty splat

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4992,3 +4992,15 @@ assert_equal '1', %q{
   array.clear
   test_body(array)
 }
+
+# regression test for splatting empty array to cfunc
+assert_normal_exit %q{
+  def test_body(args) = Array(1, *args)
+
+  test_body([])
+  0x100.times do
+    array = Array.new(100)
+    array.clear
+    test_body(array)
+  end
+}


### PR DESCRIPTION
Follow-up for 6c8ae44a388e5c03b7db90376af3652007b574e8 ("YJIT: Fix out
of bounds access when splatting empty array"). This test crashes Ruby
3.3.2.
