### PR TITLE
Windows - vcpkg.json - remove "builtin-baseline", use current runner version

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,5 @@
     "libyaml",
     "openssl",
     "zlib"
-  ],
-  "builtin-baseline": "53bef8994c541b6561884a8395ea35715ece75db"
+  ]
 }


### PR DESCRIPTION
Currently, "builtin-baseline" in the vcpkg.json file locks the vcpkg repo to commit 53bef8994c541b6561884a8395ea35715ece75db, which is from 12-Jan-2024.

The PR changes the packages to be installed from the vcpkg 'release' used in the current GHA runner.

Below are the packages installed before and after this PR.  Note the updates to OpenSSL ande zlib.

CURRENT
libffi-3.4.4#1
libyaml-0.2.5#4
openssl-3.1.1
readline-0#4
zlib-1.2.13

AFTER PR
libffi-3.4.6
libyaml-0.2.5#4
openssl-3.3.0#1
readline-0#5
readline-win32-5.0#8
zlib-1.3.1
