### PR TITLE
Remove dependency on fiddle from test/ruby

### DIFF
--- a/ext/-test-/thread/id/extconf.rb
+++ b/ext/-test-/thread/id/extconf.rb
@@ -1,0 +1,3 @@
+if have_func("gettid")
+  create_makefile("-test-/thread/id")
+end

--- a/ext/-test-/thread/id/id.c
+++ b/ext/-test-/thread/id/id.c
@@ -1,0 +1,15 @@
+#include <ruby.h>
+
+static VALUE
+bug_gettid(VALUE self)
+{
+    pid_t tid = gettid();
+    return PIDT2NUM(tid);
+}
+
+void
+Init_id(void)
+{
+    VALUE klass = rb_define_module_under(rb_define_module("Bug"), "ThreadID");
+    rb_define_module_function(klass, "gettid", bug_gettid, 0);
+}


### PR DESCRIPTION
From https://github.com/nobu/ruby/tree/test-without-fiddle