### PR TITLE
[Bug #20524] win32: Suppress GMP warning

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -30,9 +30,6 @@
 # define USE_GMP 0
 #endif
 #endif
-#if USE_GMP
-# include <gmp.h>
-#endif
 
 #include "id.h"
 #include "internal.h"
@@ -47,6 +44,15 @@
 #include "ruby/thread.h"
 #include "ruby/util.h"
 #include "ruby_assert.h"
+
+#if USE_GMP
+RBIMPL_WARNING_PUSH()
+# ifdef _MSC_VER
+RBIMPL_WARNING_IGNORED(4146) /* for mpn_neg() */
+# endif
+# include <gmp.h>
+RBIMPL_WARNING_POP()
+#endif
 
 static const bool debug_integer_pack = (
 #ifdef DEBUG_INTEGER_PACK

--- a/rational.c
+++ b/rational.c
@@ -22,9 +22,6 @@
 # define USE_GMP 0
 #endif
 #endif
-#if USE_GMP
-#include <gmp.h>
-#endif
 
 #include "id.h"
 #include "internal.h"
@@ -35,6 +32,15 @@
 #include "internal/object.h"
 #include "internal/rational.h"
 #include "ruby_assert.h"
+
+#if USE_GMP
+RBIMPL_WARNING_PUSH()
+# ifdef _MSC_VER
+RBIMPL_WARNING_IGNORED(4146) /* for mpn_neg() */
+# endif
+# include <gmp.h>
+RBIMPL_WARNING_POP()
+#endif
 
 #define ZERO INT2FIX(0)
 #define ONE INT2FIX(1)


### PR DESCRIPTION
```
C:\vcpkg\installed\x64-windows\include\gmp.h(2237): warning C4146: unary minus operator applied to unsigned type, result still unsigned
```