### PR TITLE
Don't add `+YJIT` to `RUBY_DESCRIPTION` until it's actually enabled

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -2302,7 +2302,8 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
 #endif
 #if USE_YJIT
     if (FEATURE_SET_P(opt->features, yjit)) {
-        opt->yjit = true; // set opt->yjit for Init_ruby_description() and calling rb_yjit_init()
+        bool rb_yjit_option_disable(void);
+        opt->yjit = !rb_yjit_option_disable(); // set opt->yjit for Init_ruby_description() and calling rb_yjit_init()
     }
 #endif
 

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -56,14 +56,26 @@ class TestYJIT < Test::Unit::TestCase
   def test_yjit_enable
     args = []
     args << "--disable=yjit" if RubyVM::YJIT.enabled?
-    assert_separately(args, <<~RUBY)
-      assert_false RubyVM::YJIT.enabled?
-      assert_false RUBY_DESCRIPTION.include?("+YJIT")
+    assert_separately(args, <<~'RUBY')
+      refute_predicate RubyVM::YJIT, :enabled?
+      refute_includes RUBY_DESCRIPTION, "+YJIT"
 
       RubyVM::YJIT.enable
 
-      assert_true RubyVM::YJIT.enabled?
-      assert_true RUBY_DESCRIPTION.include?("+YJIT")
+      assert_predicate RubyVM::YJIT, :enabled?
+      assert_includes RUBY_DESCRIPTION, "+YJIT"
+    RUBY
+  end
+
+  def test_yjit_disable
+    assert_separately(["--yjit", "--yjit-disable"], <<~'RUBY')
+      refute_predicate RubyVM::YJIT, :enabled?
+      refute_includes RUBY_DESCRIPTION, "+YJIT"
+
+      RubyVM::YJIT.enable
+
+      assert_predicate RubyVM::YJIT, :enabled?
+      assert_includes RUBY_DESCRIPTION, "+YJIT"
     RUBY
   end
 

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -22,6 +22,11 @@ pub extern "C" fn rb_yjit_parse_option(str_ptr: *const raw::c_char) -> bool {
     return parse_option(str_ptr).is_some();
 }
 
+#[no_mangle]
+pub extern "C" fn rb_yjit_option_disable() -> bool {
+    return get_option!(disable);
+}
+
 /// Like rb_yjit_enabled_p, but for Rust code.
 pub fn yjit_enabled_p() -> bool {
     unsafe { rb_yjit_enabled_p }
@@ -34,7 +39,7 @@ pub extern "C" fn rb_yjit_init(yjit_enabled: bool) {
     yjit_reg_method_codegen_fns();
 
     // If --yjit-disable, yjit_init() will not be called until RubyVM::YJIT.enable.
-    if yjit_enabled && !get_option!(disable) {
+    if yjit_enabled {
         yjit_init();
     }
 }


### PR DESCRIPTION
If you start Ruby with `--yjit-disable`, the `+YJIT` shouldn't be added until `RubyVM::YJIT.enable` is actually called. Otherwise it's confusing in crash reports etc.