### PR TITLE
Mingw32-x86: Use ATOMIC_PTR functions to avoid compiler warnings due to incompatible types

### DIFF
--- a/random.c
+++ b/random.c
@@ -576,7 +576,7 @@ static void
 release_crypt(void *p)
 {
     HCRYPTPROV *ptr = p;
-    HCRYPTPROV prov = (HCRYPTPROV)ATOMIC_SIZE_EXCHANGE(*ptr, INVALID_HCRYPTPROV);
+    HCRYPTPROV prov = (HCRYPTPROV)ATOMIC_PTR_EXCHANGE(*((char *)ptr), (char *)INVALID_HCRYPTPROV);
     if (prov && prov != INVALID_HCRYPTPROV) {
         CryptReleaseContext(prov, 0);
     }
@@ -591,7 +591,7 @@ fill_random_bytes_crypt(void *seed, size_t size)
         if (!CryptAcquireContext(&prov, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT)) {
             prov = INVALID_HCRYPTPROV;
         }
-        old_prov = (HCRYPTPROV)ATOMIC_SIZE_CAS(perm_prov, 0, prov);
+        old_prov = (HCRYPTPROV)ATOMIC_PTR_CAS(*((char *)&perm_prov), 0, (char *)prov);
         if (LIKELY(!old_prov)) { /* no other threads acquired */
             if (prov != INVALID_HCRYPTPROV) {
 #undef RUBY_UNTYPED_DATA_WARNING


### PR DESCRIPTION
HCRYPTPROV can be casted to pointer without warning but not to size_t.

Avoids the following warning/error:
```
../snapshot-master/random.c: In function 'fill_random_bytes_crypt': ../snapshot-master/include/ruby/atomic.h:246:28: error: passing argument 1 of 'rbimpl_atomic_size_cas' from incompatible pointer type [-Wincompatible-pointer-types]
  246 |     rbimpl_atomic_size_cas(&(var), (oldval), (newval))
      |                            ^~~~~~
      |                            |
      |                            HCRYPTPROV * {aka long unsigned int *}
../snapshot-master/ruby_atomic.h:16:46: note: in expansion of macro 'RUBY_ATOMIC_SIZE_CAS'
   16 | #define ATOMIC_SIZE_CAS(var, oldval, newval) RUBY_ATOMIC_SIZE_CAS(var, oldval, newval)
      |                                              ^~~~~~~~~~~~~~~~~~~~
../snapshot-master/random.c:594:32: note: in expansion of macro 'ATOMIC_SIZE_CAS'
  594 |         old_prov = (HCRYPTPROV)ATOMIC_SIZE_CAS(perm_prov, 0, prov);
      |                                ^~~~~~~~~~~~~~~
../snapshot-master/include/ruby/atomic.h:853:41: note: expected 'volatile size_t *' {aka 'volatile unsigned int *'} but argument is of type 'HCRYPTPROV *' {aka 'long unsigned int *'}
  853 | rbimpl_atomic_size_cas(volatile size_t *ptr, size_t oldval, size_t newval)
      |                        ~~~~~~~~~~~~~~~~~^~~
```