### PR TITLE
Hash#inspect with colon style

### DIFF
--- a/bootstraptest/test_literal.rb
+++ b/bootstraptest/test_literal.rb
@@ -119,14 +119,14 @@ assert_equal '5',               'a = [1,2,3]; a[1] = 5; a[1]'
 assert_equal 'bar',             '[*:foo];:bar'
 assert_equal '[1, 2]',          'def nil.to_a; [2]; end; [1, *nil]'
 assert_equal '[1, 2]',          'def nil.to_a; [1, 2]; end; [*nil]'
-assert_equal '[0, 1, {2=>3}]',  '[0, *[1], 2=>3]', "[ruby-dev:31592]"
+assert_equal '[0, 1, {2 => 3}]', '[0, *[1], 2=>3]', "[ruby-dev:31592]"
 
 
 # hash
 assert_equal 'Hash',            '{}.class'
 assert_equal '{}',              '{}.inspect'
 assert_equal 'Hash',            '{1=>2}.class'
-assert_equal '{1=>2}',          '{1=>2}.inspect'
+assert_equal '{1 => 2}',        '{1=>2}.inspect'
 assert_equal '2',               'h = {1 => 2}; h[1]'
 assert_equal '0',               'h = {1 => 2}; h.delete(1); h.size'
 assert_equal '',                'h = {1 => 2}; h.delete(1); h[1]'

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -571,7 +571,7 @@ assert_equal '[RuntimeError, "ok", true]', %q{
 }
 
 # threads in a ractor will killed
-assert_equal '{:ok=>3}', %q{
+assert_equal '{ok: 3}', %q{
   Ractor.new Ractor.current do |main|
     q = Thread::Queue.new
     Thread.new do

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -1798,7 +1798,7 @@ assert_equal '{}', %q{
 }
 
 # test building hash with values
-assert_equal '{:foo=>:bar}', %q{
+assert_equal '{foo: :bar}', %q{
   def build_hash(val)
     { foo: val }
   end
@@ -3375,7 +3375,7 @@ assert_equal '[[1, 2, 3, 4]]', %q{
 }
 
 # cfunc kwargs
-assert_equal '{:foo=>123}', %q{
+assert_equal '{foo: 123}', %q{
   def foo(bar)
     bar.store(:value, foo: 123)
     bar[:value]
@@ -3386,7 +3386,7 @@ assert_equal '{:foo=>123}', %q{
 }
 
 # cfunc kwargs
-assert_equal '{:foo=>123}', %q{
+assert_equal '{foo: 123}', %q{
   def foo(bar)
     bar.replace(foo: 123)
   end
@@ -3396,7 +3396,7 @@ assert_equal '{:foo=>123}', %q{
 }
 
 # cfunc kwargs
-assert_equal '{:foo=>123, :bar=>456}', %q{
+assert_equal '{foo: 123, bar: 456}', %q{
   def foo(bar)
     bar.replace(foo: 123, bar: 456)
   end
@@ -3406,7 +3406,7 @@ assert_equal '{:foo=>123, :bar=>456}', %q{
 }
 
 # variadic cfunc kwargs
-assert_equal '{:foo=>123}', %q{
+assert_equal '{foo: 123}', %q{
   def foo(bar)
     bar.merge(foo: 123)
   end
@@ -3530,7 +3530,7 @@ assert_equal "true", %q{
 }
 
 # duphash
-assert_equal '{:foo=>123}', %q{
+assert_equal '{foo: 123}', %q{
   def foo
     {foo: 123}
   end
@@ -3540,7 +3540,7 @@ assert_equal '{:foo=>123}', %q{
 }
 
 # newhash
-assert_equal '{:foo=>2}', %q{
+assert_equal '{foo: 2}', %q{
   def foo
     {foo: 1+1}
   end
@@ -4349,7 +4349,7 @@ assert_equal "ArgumentError", %q{
 
 # Rest with block
 # Simplified code from railsbench
-assert_equal '[{"/a"=>"b", :as=>:c, :via=>:post}, [], nil]', %q{
+assert_equal '[{"/a" => "b", as: :c, via: :post}, [], nil]', %q{
   def match(path, *rest, &block)
     [path, rest, block]
   end
@@ -4610,7 +4610,7 @@ assert_equal '[nil, "yield"]', %q{
 }
 
 # splat with ruby2_keywords into rest parameter
-assert_equal '[[{:a=>1}], {}]', %q{
+assert_equal '[[{a: 1}], {}]', %q{
   ruby2_keywords def foo(*args) = args
 
   def bar(*args, **kw) = [args, kw]
@@ -4651,7 +4651,7 @@ assert_normal_exit %q{
 }
 
 # a kwrest case
-assert_equal '[1, 2, {:complete=>false}]', %q{
+assert_equal '[1, 2, {complete: false}]', %q{
   def rest(foo: 1, bar: 2, **kwrest)
     [foo, bar, kwrest]
   end
@@ -4710,7 +4710,7 @@ assert_equal '[[1, 2, 3], [0, 2, 3], [1, 2, 3], [2, 2, 3], [], [], [{}]]', %q{
 }
 
 # Class#new (arity=-1), splat, and ruby2_keywords
-assert_equal '[0, {1=>1}]', %q{
+assert_equal '[0, {1 => 1}]', %q{
   class KwInit
     attr_reader :init_args
     def initialize(x = 0, **kw)

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -20,7 +20,7 @@ matrix              0.4.2   https://github.com/ruby/matrix
 prime               0.1.2   https://github.com/ruby/prime
 rbs                 3.6.1   https://github.com/ruby/rbs
 typeprof            0.21.11 https://github.com/ruby/typeprof 167263ca3a634b61df0445f1a6b3e259a5d47f94
-debug               1.9.2   https://github.com/ruby/debug
+debug               1.9.2   https://github.com/ruby/debug 9c4279598e9e0376657b3813bf76a206f1f97beb
 racc                1.8.1   https://github.com/ruby/racc
 mutex_m             0.2.0   https://github.com/ruby/mutex_m
 getoptlong          0.2.1   https://github.com/ruby/getoptlong

--- a/lib/pp.rb
+++ b/lib/pp.rb
@@ -292,14 +292,35 @@ class PP < PrettyPrint
       }
     end
 
-    # A pretty print for a pair of Hash
-    def pp_hash_pair(k, v)
-      pp k
-      text '=>'
-      group(1) {
-        breakable ''
-        pp v
-      }
+    if RUBY_VERSION >= '3.4.'
+      # A pretty print for a pair of Hash
+      def pp_hash_pair(k, v)
+        if Symbol === k
+          sym_s = k.inspect
+          if sym_s[1].match?(/["$@!]/) || sym_s[-1].match?(/[%&*+\-\/<=>@\]^`|~]/)
+            text "#{k.to_s.inspect}:"
+          else
+            text "#{k}:"
+          end
+        else
+          pp k
+          text ' '
+          text '=>'
+        end
+        group(1) {
+          breakable
+          pp v
+        }
+      end
+    else
+      def pp_hash_pair(k, v)
+        pp k
+        text '=>'
+        group(1) {
+          breakable ''
+          pp v
+        }
+      end
     end
   end
 

--- a/spec/bundler/bundler/endpoint_specification_spec.rb
+++ b/spec/bundler/bundler/endpoint_specification_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Bundler::EndpointSpecification do
         expect { subject }.to raise_error(
           Bundler::GemspecError,
           a_string_including("There was an error parsing the metadata for the gem foo (1.0.0)").
-            and(a_string_including('The metadata was {"rubygems"=>">\n"}'))
+            and(a_string_including("The metadata was #{{ "rubygems" => ">\n" }.inspect}"))
         )
       end
     end

--- a/spec/bundler/install/gems/compact_index_spec.rb
+++ b/spec/bundler/install/gems/compact_index_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "compact index api" do
     bundle :install, verbose: true, artifice: "compact_index_checksum_mismatch"
     expect(out).to include("Fetching gem metadata from #{source_uri}")
     expect(out).to include("The checksum of /versions does not match the checksum provided by the server!")
-    expect(out).to include('Calculated checksums {"sha-256"=>"8KfZiM/fszVkqhP/m5s9lvE6M9xKu4I1bU4Izddp5Ms="} did not match expected {"sha-256"=>"ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0="}')
+    expect(out).to include("Calculated checksums #{{ "sha-256" => "8KfZiM/fszVkqhP/m5s9lvE6M9xKu4I1bU4Izddp5Ms=" }.inspect} did not match expected #{{ "sha-256" => "ungWv48Bz+pBQUDeXa4iI7ADYaOWF3qctBD/YfIAFa0=" }.inspect}")
     expect(the_bundle).to include_gems "myrack 1.0.0"
   end
 

--- a/spec/ruby/core/string/modulo_spec.rb
+++ b/spec/ruby/core/string/modulo_spec.rb
@@ -570,7 +570,7 @@ describe "String#%" do
     ("%1$p" % [10, 5]).should == "10"
     ("%-22p" % 10).should == "10                    "
     ("%*p" % [10, 10]).should == "        10"
-    ("%p" % {capture: 1}).should == "{:capture=>1}"
+    ("%p" % {capture: 1}).should == {capture: 1}.inspect
     ("%p" % "str").should == "\"str\""
   end
 

--- a/spec/ruby/language/pattern_matching_spec.rb
+++ b/spec/ruby/language/pattern_matching_spec.rb
@@ -232,11 +232,12 @@ describe "Pattern matching" do
       end
     }.should raise_error(NoMatchingPatternError, /\[0, 1\]/)
 
+    error_pattern = ruby_version_is("3.4") ? /\{a: 0, b: 1\}/ : /\{:a=>0, :b=>1\}/
     -> {
       case {a: 0, b: 1}
       in a: 1, b: 1
       end
-    }.should raise_error(NoMatchingPatternError, /\{:a=>0, :b=>1\}/)
+    }.should raise_error(NoMatchingPatternError, error_pattern)
   end
 
   it "raises NoMatchingPatternError if no pattern matches and evaluates the expression only once" do

--- a/spec/ruby/library/net-http/http/post_spec.rb
+++ b/spec/ruby/library/net-http/http/post_spec.rb
@@ -27,7 +27,7 @@ describe "Net::HTTP.post" do
 
   it "sends Content-Type: application/x-www-form-urlencoded by default" do
     response = Net::HTTP.post(URI("http://localhost:#{NetHTTPSpecs.port}/request/header"), "test=test")
-    response.body.should include('"Content-Type"=>"application/x-www-form-urlencoded"')
+    response.body.should include({ "Content-Type" => "application/x-www-form-urlencoded" }.inspect.delete("{}"))
   end
 
   it "does not support HTTP Basic Auth" do

--- a/spec/ruby/library/net-http/http/send_request_spec.rb
+++ b/spec/ruby/library/net-http/http/send_request_spec.rb
@@ -54,7 +54,7 @@ describe "Net::HTTP#send_request" do
 
       @methods.each do |method|
         response = @http.send_request(method, "/request/header", "test=test", "referer" => referer)
-        response.body.should include('"Referer"=>"' + referer + '"')
+        response.body.should include({ "Referer" => referer }.inspect.delete("{}"))
       end
     end
   end

--- a/spec/ruby/library/pp/pp_spec.rb
+++ b/spec/ruby/library/pp/pp_spec.rb
@@ -25,6 +25,6 @@ describe "PP.pp" do
     hash = { 'key' => 42 }
     -> {
       PP.pp hash
-    }.should output('{"key"=>42}' + "\n")
+    }.should output("#{hash.inspect}\n")
   end
 end

--- a/spec/ruby/optional/capi/string_spec.rb
+++ b/spec/ruby/optional/capi/string_spec.rb
@@ -1096,7 +1096,7 @@ end
     end
 
     it "tries to convert the passed argument to a string by calling #to_s" do
-      @s.rb_String({"bar" => "foo"}).should == '{"bar"=>"foo"}'
+      @s.rb_String({"bar" => "foo"}).should == {"bar" => "foo"}.to_s
     end
   end
 

--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -649,9 +649,9 @@ class TestCoverage < Test::Unit::TestCase
         end
 
         exp = [
-          "{:lines=>[1, 0, 0, nil, 0, nil, nil]}",
-          "{:lines=>[0, 1, 1, nil, 0, nil, nil]}",
-          "{:lines=>[0, 1, 0, nil, 1, nil, nil]}",
+          { lines: [1, 0, 0, nil, 0, nil, nil] }.inspect,
+          { lines: [0, 1, 1, nil, 0, nil, nil] }.inspect,
+          { lines: [0, 1, 0, nil, 1, nil, nil] }.inspect,
         ]
         assert_in_out_err(ARGV, <<-"end;", exp, [])
           Coverage.start(lines: true)
@@ -682,10 +682,10 @@ class TestCoverage < Test::Unit::TestCase
         end
 
         exp = [
-          "{:branches=>{[:if, 0, 2, 2, 6, 5]=>{[:then, 1, 3, 4, 3, 8]=>0, [:else, 2, 5, 4, 5, 12]=>0}}}",
-          "{:branches=>{[:if, 0, 2, 2, 6, 5]=>{[:then, 1, 3, 4, 3, 8]=>1, [:else, 2, 5, 4, 5, 12]=>0}}}",
-          "{:branches=>{[:if, 0, 2, 2, 6, 5]=>{[:then, 1, 3, 4, 3, 8]=>0, [:else, 2, 5, 4, 5, 12]=>1}}}",
-          "{:branches=>{[:if, 0, 2, 2, 6, 5]=>{[:then, 1, 3, 4, 3, 8]=>0, [:else, 2, 5, 4, 5, 12]=>1}}}",
+          { branches: { [:if, 0, 2, 2, 6, 5] => { [:then, 1, 3, 4, 3, 8] => 0, [:else, 2, 5, 4, 5, 12] => 0 } } }.inspect,
+          { branches: { [:if, 0, 2, 2, 6, 5] => { [:then, 1, 3, 4, 3, 8] => 1, [:else, 2, 5, 4, 5, 12] => 0 } } }.inspect,
+          { branches: { [:if, 0, 2, 2, 6, 5] => { [:then, 1, 3, 4, 3, 8] => 0, [:else, 2, 5, 4, 5, 12] => 1 } } }.inspect,
+          { branches: { [:if, 0, 2, 2, 6, 5] => { [:then, 1, 3, 4, 3, 8] => 0, [:else, 2, 5, 4, 5, 12] => 1 } } }.inspect,
         ]
         assert_in_out_err(ARGV, <<-"end;", exp, [])
           Coverage.start(branches: true)
@@ -718,10 +718,10 @@ class TestCoverage < Test::Unit::TestCase
         end
 
         exp = [
-          "{:methods=>{[Object, :foo, 1, 0, 7, 3]=>0}}",
-          "{:methods=>{[Object, :foo, 1, 0, 7, 3]=>1}}",
-          "{:methods=>{[Object, :foo, 1, 0, 7, 3]=>1}}",
-          "{:methods=>{[Object, :foo, 1, 0, 7, 3]=>1}}"
+          { methods: { [Object, :foo, 1, 0, 7, 3] => 0 } }.inspect,
+          { methods: { [Object, :foo, 1, 0, 7, 3] => 1 } }.inspect,
+          { methods: { [Object, :foo, 1, 0, 7, 3] => 1 } }.inspect,
+          { methods: { [Object, :foo, 1, 0, 7, 3] => 1 } }.inspect
         ]
         assert_in_out_err(ARGV, <<-"end;", exp, [])
           Coverage.start(methods: true)
@@ -754,10 +754,10 @@ class TestCoverage < Test::Unit::TestCase
         end
 
         exp = [
-          "{:oneshot_lines=>[1]}",
-          "{:oneshot_lines=>[2, 3]}",
-          "{:oneshot_lines=>[5]}",
-          "{:oneshot_lines=>[]}",
+          { oneshot_lines: [1] }.inspect,
+          { oneshot_lines: [2, 3] }.inspect,
+          { oneshot_lines: [5] }.inspect,
+          { oneshot_lines: [] }.inspect,
         ]
         assert_in_out_err(ARGV, <<-"end;", exp, [])
           Coverage.start(oneshot_lines: true)

--- a/test/error_highlight/test_error_highlight.rb
+++ b/test/error_highlight/test_error_highlight.rb
@@ -1241,7 +1241,7 @@ nil can't be coerced into Integer (TypeError)
     assert_error_message(NoMethodError, <<~END) do
 undefined method `time' for #{ ONE_RECV_MESSAGE }
 
-{:first_lineno=>#{ __LINE__ + 3 }, :first_column=>7, :last_lineno=>#{ __LINE__ + 3 }, :last_column=>12, :snippet=>"      1.time {}\\n"}
+#{{ first_lineno: __LINE__ + 3, first_column: 7, last_lineno: __LINE__ + 3, last_column: 12, snippet: "      1.time {}\n" }.inspect}
     END
 
       1.time {}

--- a/test/rdoc/test_rdoc_ri_driver.rb
+++ b/test/rdoc/test_rdoc_ri_driver.rb
@@ -54,10 +54,10 @@ class TestRDocRIDriver < RDoc::TestCase
       RDoc::RI::Driver.dump @store1.cache_path
     end
 
-    assert_match %r%:class_methods%,    out
-    assert_match %r%:modules%,          out
-    assert_match %r%:instance_methods%, out
-    assert_match %r%:ancestors%,        out
+    assert_match %r%:class_methods|class_methods:%,       out
+    assert_match %r%:modules|modules:%,                   out
+    assert_match %r%:instance_methods|instance_methods:%, out
+    assert_match %r%:ancestors|ancestors:%,               out
   end
 
   def test_add_also_in_empty

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -803,7 +803,7 @@ dummy
       "puts RubyVM::AbstractSyntaxTree.of(->{ 1 + 2 }, keep_script_lines: true).script_lines",
       "p SCRIPT_LINES__"
     ]
-    test_stdout = lines + ['{"-e"=>[]}']
+    test_stdout = lines + ['{"-e" => []}']
     assert_in_out_err(["-e", lines.join("\n")], "", test_stdout, [])
   end
 

--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -1128,11 +1128,11 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
     assert_raise(ArgumentError) {warn("test warning", uplevel: -1)}
     assert_in_out_err(["-e", "warn 'ok', uplevel: 1"], '', [], /warning:/)
     warning = capture_warning_warn {warn("test warning", {uplevel: 0})}
-    assert_match(/test warning.*{:uplevel=>0}/m, warning[0])
+    assert_match(/test warning.*{uplevel: 0}/m, warning[0])
     warning = capture_warning_warn {warn("test warning", **{uplevel: 0})}
     assert_equal("#{__FILE__}:#{__LINE__-1}: warning: test warning\n", warning[0])
     warning = capture_warning_warn {warn("test warning", {uplevel: 0}, **{})}
-    assert_equal("test warning\n{:uplevel=>0}\n", warning[0])
+    assert_equal("test warning\n{uplevel: 0}\n", warning[0])
     assert_raise(ArgumentError) {warn("test warning", foo: 1)}
   end
 

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -2295,7 +2295,7 @@ class TestHashOnly < Test::Unit::TestCase
     h = obj.h
 
     h[obj] = true
-    assert_equal '{0=>0, 1=>1, 2=>2, 3=>3, 4=>4, 5=>5, 6=>6, 7=>7, 8=>8, 9=>9, test=>true}', h.inspect
+    assert_equal '{0 => 0, 1 => 1, 2 => 2, 3 => 3, 4 => 4, 5 => 5, 6 => 6, 7 => 7, 8 => 8, 9 => 9, test => true}', h.inspect
   end
 
   def test_ar2st_delete
@@ -2309,7 +2309,7 @@ class TestHashOnly < Test::Unit::TestCase
 
     h[obj2] = true
     h.delete obj
-    assert_equal '{0=>0, 1=>1, 2=>2, 3=>3, 4=>4, 5=>5, 6=>6, 7=>7, 8=>8, 9=>9}', h.inspect
+    assert_equal '{0 => 0, 1 => 1, 2 => 2, 3 => 3, 4 => 4, 5 => 5, 6 => 6, 7 => 7, 8 => 8, 9 => 9}', h.inspect
   end
 
   def test_ar2st_lookup

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -869,6 +869,33 @@ class TestHash < Test::Unit::TestCase
     $, = nil
   end
 
+  def test_inspect
+    no_quote = '{a: 1, a!: 1, a?: 1}'
+    quote0 = '{"": 1}'
+    quote1 = '{"0": 1, "!": 1, "%": 1, "&": 1, "*": 1, "+": 1, "-": 1, "/": 1, "<": 1, ">": 1, "^": 1, "`": 1, "|": 1, "~": 1}'
+    quote2 = '{"@a": 1, "$a": 1, "+@": 1, "a=": 1, "[]": 1}'
+    quote3 = '{"a\"b": 1, "@@a": 1, "<=>": 1, "===": 1, "[]=": 1}'
+    assert_equal(no_quote, eval(no_quote).inspect)
+    assert_equal(quote0, eval(quote0).inspect)
+    assert_equal(quote1, eval(quote1).inspect)
+    assert_equal(quote2, eval(quote2).inspect)
+    assert_equal(quote3, eval(quote3).inspect)
+    begin
+      enc = Encoding.default_external
+      Encoding.default_external = Encoding::ASCII
+      utf8_ascii_hash = '{"\\u3042": 1}'
+      assert_equal(eval(utf8_ascii_hash).inspect, utf8_ascii_hash)
+      Encoding.default_external = Encoding::UTF_8
+      utf8_hash = "{\u3042: 1}"
+      assert_equal(eval(utf8_hash).inspect, utf8_hash)
+      Encoding.default_external = Encoding::Windows_31J
+      sjis_hash = "{\x87]: 1}".force_encoding('sjis')
+      assert_equal(eval(sjis_hash).inspect, sjis_hash)
+    ensure
+      Encoding.default_external = enc
+    end
+  end
+
   def test_update
     h1 = @cls[ 1 => 2, 2 => 3, 3 => 4 ]
     h2 = @cls[ 2 => 'two', 4 => 'four' ]

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -2863,7 +2863,7 @@ class TestKeywordArguments < Test::Unit::TestCase
   end
 
   def test_top_ruby2_keywords
-    assert_in_out_err([], <<-INPUT, ["[1, 2, 3]", "{:k=>1}"], [])
+    assert_in_out_err([], <<-INPUT, ["[1, 2, 3]", "{k: 1}"], [])
       def bar(*a, **kw)
         p a, kw
       end

--- a/test/ruby/test_pattern_matching.rb
+++ b/test/ruby/test_pattern_matching.rb
@@ -1664,7 +1664,7 @@ END
       raise a # suppress "unused variable: a" warning
     end
 
-    assert_raise_with_message(NoMatchingPatternKeyError, "{:a=>0}: key not found: :aa") do
+    assert_raise_with_message(NoMatchingPatternKeyError, "{a: 0}: key not found: :aa") do
       {a: 0} => {aa:}
       raise aa # suppress "unused variable: aa" warning
     rescue NoMatchingPatternKeyError => e
@@ -1673,7 +1673,7 @@ END
       raise e
     end
 
-    assert_raise_with_message(NoMatchingPatternKeyError, "{:a=>{:b=>0}}: key not found: :bb") do
+    assert_raise_with_message(NoMatchingPatternKeyError, "{a: {b: 0}}: key not found: :bb") do
       {a: {b: 0}} => {a: {bb:}}
       raise bb # suppress "unused variable: bb" warning
     rescue NoMatchingPatternKeyError => e
@@ -1682,15 +1682,15 @@ END
       raise e
     end
 
-    assert_raise_with_message(NoMatchingPatternError, "{:a=>0}: 1 === 0 does not return true") do
+    assert_raise_with_message(NoMatchingPatternError, "{a: 0}: 1 === 0 does not return true") do
       {a: 0} => {a: 1}
     end
 
-    assert_raise_with_message(NoMatchingPatternError, "{:a=>0}: {:a=>0} is not empty") do
+    assert_raise_with_message(NoMatchingPatternError, "{a: 0}: {a: 0} is not empty") do
       {a: 0} => {}
     end
 
-    assert_raise_with_message(NoMatchingPatternError, "[{:a=>0}]: rest of {:a=>0} is not empty") do
+    assert_raise_with_message(NoMatchingPatternError, "[{a: 0}]: rest of {a: 0} is not empty") do
       [{a: 0}] => [{**nil}]
     end
   end

--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -235,7 +235,7 @@ class TestSprintf < Test::Unit::TestCase
 
   def test_hash
     options = {:capture=>/\d+/}
-    assert_equal("with options {:capture=>/\\d+/}", sprintf("with options %p" % options))
+    assert_equal("with options #{options.inspect}", sprintf("with options %p" % options))
   end
 
   def test_inspect

--- a/test/rubygems/test_gem_dependency.rb
+++ b/test/rubygems/test_gem_dependency.rb
@@ -22,7 +22,7 @@ class TestGemDependency < Gem::TestCase
       Gem::Dependency.new "monkey" => "1.0"
     end
 
-    assert_equal 'dependency name must be a String, was {"monkey"=>"1.0"}',
+    assert_equal "dependency name must be a String, was #{{ "monkey" => "1.0" }.inspect}",
                  e.message
   end
 

--- a/test/rubygems/test_require.rb
+++ b/test/rubygems/test_require.rb
@@ -721,11 +721,11 @@ class TestGemRequire < Gem::TestCase
         _, err = capture_subprocess_io do
           system(*ruby_with_rubygems_in_load_path, "-w", "--disable=gems", "-C", dir, "main.rb")
         end
-        assert_match(/{:x=>1}\n{:y=>2}\n$/, err)
+        assert_match(/#{{ x: 1 }.inspect}\n#{{ y: 2 }.inspect}\n$/, err)
         _, err = capture_subprocess_io do
           system(*ruby_with_rubygems_in_load_path, "-w", "--enable=gems", "-C", dir, "main.rb")
         end
-        assert_match(/{:x=>1}\n{:y=>2}\n$/, err)
+        assert_match(/#{{ x: 1 }.inspect}\n#{{ y: 2 }.inspect}\n$/, err)
       end
     end
   end


### PR DESCRIPTION
Implements https://bugs.ruby-lang.org/issues/20433#note-7
Change Hash#inspect to use colon style if the key is a symbol.
When key is not a symbol, space is added around `=>`
```ruby
puts({a!: 1, "<=>" => 1, "a=": 1, 42 => 1}.inspect)
# => {a!: 1, "<=>" => 1, "a=": 1, 42 => 1}
# it was {:a!=>1, "<=>"=>1, :a==>1, 42=>1}
```



Symbol key that needs quote can be determined by this
```ruby
chars = (32..127).map(&:chr)+["☆"]-[*'b'..'z',*'B'..'Z',*'1'..'9']
(1..3).each do |n|
  symbols = chars.repeated_permutation(n).map(&:join).map(&:to_sym)
  # Found symbols that needs quote
  a = symbols.reject do |sym|
    k = sym.inspect[1..]
    begin;{sym=>1} == eval("{#{k}: 1}");rescue SyntaxError;false;end
  end
  # Determine logic
  b = symbols.select do |sym|
    s = sym.inspect
    s[1]=='@'||s[1]=='$'||s[1]=='!'||"%&*+-/<=>@]^`|~".include?(s[-1])
  end
  p a == b
end
```