### PR TITLE
Bundle rbs-3.5

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -18,7 +18,7 @@ net-pop         0.1.2   https://github.com/ruby/net-pop
 net-smtp        0.5.0   https://github.com/ruby/net-smtp
 matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
-rbs             3.5.0   https://github.com/ruby/rbs 88a72b8ca4a6a92b3f7615040d6622dd157f7148
+rbs             3.5.1.pre.1   https://github.com/ruby/rbs
 typeprof        0.21.11 https://github.com/ruby/typeprof b19a6416da3a05d57fadd6ffdadb382b6d236ca5
 debug           1.9.2   https://github.com/ruby/debug
 racc            1.8.0   https://github.com/ruby/racc

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -18,7 +18,7 @@ net-pop         0.1.2   https://github.com/ruby/net-pop
 net-smtp        0.5.0   https://github.com/ruby/net-smtp
 matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
-rbs             3.4.4   https://github.com/ruby/rbs ba7872795d5de04adb8ff500c0e6afdc81a041dd
+rbs             3.5.0   https://github.com/ruby/rbs 88a72b8ca4a6a92b3f7615040d6622dd157f7148
 typeprof        0.21.11 https://github.com/ruby/typeprof b19a6416da3a05d57fadd6ffdadb382b6d236ca5
 debug           1.9.2   https://github.com/ruby/debug
 racc            1.8.0   https://github.com/ruby/racc

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -18,7 +18,7 @@ net-pop         0.1.2   https://github.com/ruby/net-pop
 net-smtp        0.5.0   https://github.com/ruby/net-smtp
 matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
-rbs             3.5.1.pre.1   https://github.com/ruby/rbs
+rbs             3.5.1   https://github.com/ruby/rbs
 typeprof        0.21.11 https://github.com/ruby/typeprof b19a6416da3a05d57fadd6ffdadb382b6d236ca5
 debug           1.9.2   https://github.com/ruby/debug
 racc            1.8.0   https://github.com/ruby/racc


### PR DESCRIPTION
`rbs-3.5.0` has an issue that doesn't compile with c99 or c23. This PR is to bundle the fixed version `rbs-3.5.1`.