### PR TITLE
ripper: Fix excess `compile_error` at simple backref op_asgn

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -1448,7 +1448,9 @@ static NODE *assignable(struct parser_params*,ID,NODE*,const YYLTYPE*);
 static NODE *aryset(struct parser_params*,NODE*,NODE*,const YYLTYPE*);
 static NODE *attrset(struct parser_params*,NODE*,ID,ID,const YYLTYPE*);
 
+#ifndef RIPPER
 static void rb_backref_error(struct parser_params*,NODE*);
+#endif
 static NODE *node_assign(struct parser_params*,NODE*,NODE*,struct lex_context,const YYLTYPE*);
 
 static NODE *new_op_assign(struct parser_params *p, NODE *lhs, ID op, NODE *rhs, struct lex_context, const YYLTYPE *loc);
@@ -3875,10 +3877,10 @@ arg		: lhs '=' lex_ctxt arg_rhs
                     }
                 | backref tOP_ASGN lex_ctxt arg_rhs
                     {
-                        rb_backref_error(p, $1);
                     /*%%%*/
-                        $$ = NEW_ERROR(&@$);
+                        rb_backref_error(p, $1);
                     /*% %*/
+                        $$ = NEW_ERROR(&@$);
                     /*% ripper[error]: backref_error(p, $1, opassign!(var_field!($:1), $:2, $:4)) %*/
                     }
                 | arg tDOT2 arg
@@ -6114,8 +6116,6 @@ qsym_list	: /* none */
 string_contents : /* none */
                     {
                         $$ = 0;
-                    /*%%%*/
-                    /*% %*/
                     /*% ripper: string_content! %*/
                     }
                 | string_contents string_content
@@ -13671,6 +13671,7 @@ attrset(struct parser_params *p, NODE *recv, ID atype, ID id, const YYLTYPE *loc
     return NEW_ATTRASGN(recv, id, 0, loc);
 }
 
+#ifndef RIPPER
 static void
 rb_backref_error(struct parser_params *p, NODE *node)
 {
@@ -13683,6 +13684,7 @@ rb_backref_error(struct parser_params *p, NODE *node)
         break;
     }
 }
+#endif
 
 #ifdef RIPPER
 static VALUE

--- a/test/ripper/test_parser_events.rb
+++ b/test/ripper/test_parser_events.rb
@@ -267,28 +267,28 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
   end
 
   def test_assign_error_backref
-    thru_assign_error = false
+    errors = []
     result =
-      parse('$& = 1', :on_assign_error) {thru_assign_error = true}
-    assert_equal true, thru_assign_error
+      parse('$& = 1', %i[on_assign_error compile_error]) {|e, *| errors << e}
+    assert_equal %i[on_assign_error], errors
     assert_equal '[assign(assign_error(var_field($&)),1)]', result
 
-    thru_assign_error = false
+    errors = []
     result =
-      parse('$&, _ = 1', :on_assign_error) {thru_assign_error = true}
-    assert_equal true, thru_assign_error
+      parse('$&, _ = 1', %i[on_assign_error compile_error]) {|e, *| errors << e}
+    assert_equal %i[on_assign_error], errors
     assert_equal '[massign([assign_error(var_field($&)),var_field(_)],1)]', result
 
-    thru_assign_error = false
+    errors = []
     result =
-      parse('$& += 1', :on_assign_error) {thru_assign_error = true}
-    assert_equal true, thru_assign_error
+      parse('$& += 1', %i[on_assign_error compile_error]) {|e, *| errors << e}
+    assert_equal %i[on_assign_error], errors
     assert_equal '[assign_error(opassign(var_field($&),+=,1))]', result
 
-    thru_assign_error = false
+    errors = []
     result =
-      parse('$& += cmd 1, 2', :on_assign_error) {thru_assign_error = true}
-    assert_equal true, thru_assign_error
+      parse('$& += cmd 1, 2', %i[on_assign_error compile_error]) {|e, *| errors << e}
+    assert_equal %i[on_assign_error], errors
     assert_equal '[assign_error(opassign(var_field($&),+=,command(cmd,[1,2])))]', result
   end
 


### PR DESCRIPTION
Fix up 89cfc1520717257073012ec07105c551e4b8af7c.