### PR TITLE
Extend timeout of TestGCCompect#test_moving_objects_between_size_pools

### DIFF
--- a/test/ruby/test_gc_compact.rb
+++ b/test/ruby/test_gc_compact.rb
@@ -332,7 +332,7 @@ class TestGCCompact < Test::Unit::TestCase
   def test_moving_objects_between_size_pools
     omit if GC::INTERNAL_CONSTANTS[:SIZE_POOL_COUNT] == 1
 
-    assert_separately(%w[-robjspace], "#{<<~"begin;"}\n#{<<~"end;"}", timeout: 10, signal: :SEGV)
+    assert_separately(%w[-robjspace], "#{<<~"begin;"}\n#{<<~"end;"}", timeout: 60, signal: :SEGV)
     begin;
       class Foo
         def add_ivars


### PR DESCRIPTION
It is too flaky on macOS GitHub Actions