### PR TITLE
respect `RUBY_TEST_SUBPROCESS_TIMEOUT_SCALE`

### DIFF
--- a/bootstraptest/runner.rb
+++ b/bootstraptest/runner.rb
@@ -163,6 +163,10 @@ def main
   BT.quiet = false
   BT.timeout = 180
   BT.timeout_scale = (defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled? ? 3 : 1) # for --jit-wait
+  if (ts = (ENV["RUBY_TEST_TIMEOUT_SCALE"] || ENV["RUBY_TEST_SUBPROCESS_TIMEOUT_SCALE"]).to_i) > 1
+    BT.timeout_scale *= ts
+  end
+
   # BT.wn = 1
   dir = nil
   quiet = false


### PR DESCRIPTION
GC benchmarks will spend long time with assertions so we need to respect `RUBY_TEST_SUBPROCESS_TIMEOUT_SCALE` environment variable.