### PR TITLE
Check current file on TracePoint

### DIFF
--- a/spec/ruby/core/tracepoint/inspect_spec.rb
+++ b/spec/ruby/core/tracepoint/inspect_spec.rb
@@ -24,6 +24,8 @@ describe 'TracePoint#inspect' do
     line = nil
     TracePoint.new(:line) { |tp|
       next unless TracePointSpec.target_thread?
+      next unless tp.path == __FILE__
+
       inspect ||= tp.inspect
     }.enable do
       line = __LINE__
@@ -37,6 +39,8 @@ describe 'TracePoint#inspect' do
     line = nil
     TracePoint.new(:call) { |tp|
       next unless TracePointSpec.target_thread?
+      next unless tp.path == __FILE__
+
       inspect ||= tp.inspect
     }.enable do
       line = __LINE__ + 1
@@ -52,6 +56,8 @@ describe 'TracePoint#inspect' do
     line = nil
     TracePoint.new(:return) { |tp|
       next unless TracePointSpec.target_thread?
+      next unless tp.path == __FILE__
+
       inspect ||= tp.inspect
     }.enable do
       line = __LINE__ + 4
@@ -69,6 +75,8 @@ describe 'TracePoint#inspect' do
     inspect = nil
     tracepoint = TracePoint.new(:c_call) { |tp|
       next unless TracePointSpec.target_thread?
+      next unless tp.path == __FILE__
+
       inspect ||= tp.inspect
     }
     line = __LINE__ + 2
@@ -84,6 +92,8 @@ describe 'TracePoint#inspect' do
     line = nil
     TracePoint.new(:class) { |tp|
       next unless TracePointSpec.target_thread?
+      next unless tp.path == __FILE__
+
       inspect ||= tp.inspect
     }.enable do
       line = __LINE__ + 1
@@ -100,6 +110,7 @@ describe 'TracePoint#inspect' do
     thread_inspection = nil
     TracePoint.new(:thread_begin) { |tp|
       next unless Thread.current == thread
+
       inspect ||= tp.inspect
     }.enable(target_thread: nil) do
       thread = Thread.new {}
@@ -116,6 +127,7 @@ describe 'TracePoint#inspect' do
     thread_inspection = nil
     TracePoint.new(:thread_end) { |tp|
       next unless Thread.current == thread
+
       inspect ||= tp.inspect
     }.enable(target_thread: nil) do
       thread = Thread.new {}


### PR DESCRIPTION
```
1)
TracePoint#inspect returns a String showing the event, method, path and line for a :call event FAILED
Expected "#<TracePoint:call 'call' /tmp/ruby/src/trunk/spec/ruby/core/objectspace/define_finalizer_spec.rb:33>" =~ /\A#<TracePoint:call [`']trace_point_spec_test_call' \/tmp\/ruby\/src\/trunk\/spec\/ruby\/core\/tracepoint\/inspect_spec.rb:43>\z/
to be truthy but was nil
```

This kind of failures comes because of finaizers.
So check the current file or not.