### PR TITLE
Test `rb_ext_resolve_symbol` without Windows .def files

### DIFF
--- a/ext/-test-/load/resolve_symbol_target/resolve_symbol_target.def
+++ b/ext/-test-/load/resolve_symbol_target/resolve_symbol_target.def
@@ -1,4 +1,0 @@
-LIBRARY resolve_symbol_target
-EXPORTS
-  Init_resolve_symbol_target
-  rst_any_method

--- a/ext/-test-/load/stringify_target/stringify_target.def
+++ b/ext/-test-/load/stringify_target/stringify_target.def
@@ -1,4 +1,0 @@
-LIBRARY stringify_target
-EXPORTS
-  Init_stringify_target
-  stt_any_method


### PR DESCRIPTION
Now it works since 906a86e4de71061dca0558a6bd6e0b355776dfb1.
And `.def` files are not processed by the preprocessor, it is not possible to select symbols by conditions (e.g., ruby version).