### PR TITLE
Look for test.rb in the working directory

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -319,7 +319,7 @@ TEST_EXCLUDES = --excludes-dir=$(TESTSDIR)/.excludes --name=!/memory_leak/
 TESTWORKDIR   = testwork
 TESTOPTS      = $(RUBY_TESTOPTS)
 
-TESTRUN_SCRIPT = $(srcdir)/test.rb
+TESTRUN_SCRIPT = ./test.rb
 
 COMPILE_PRELUDE = $(tooldir)/generic_erb.rb $(srcdir)/template/prelude.c.tmpl \
 	$(tooldir)/ruby_vm/helpers/c_escape.rb


### PR DESCRIPTION
The `test.rb` script used by `make run` etc is explicitly located in the `$srcdir` - the location of the Ruby source code.

The [Building Ruby](https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html) documentation recommends using out-of-source builds.

Requiring `test.rb` to be located in the source directory prevents me from having multiple build directories, with a distinct `test.rb` per build, instead forcing pollution of the source directory.

I propose looking for `test.rb` in the current working directory. This will maintain compatibility with in-source builds, and provide extra flexibility for those of us using out-of-source builds.

There will be a small one time impact for Ruby committers, who will have to move their existing `test.rb` files into their build directories.