### PR TITLE
Remove use of symbols and arrays when freeing global table

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4316,13 +4316,8 @@ rb_objspace_free_objects_i(VALUE obj, void *data)
 {
     rb_objspace_t *objspace = (rb_objspace_t *)data;
 
-    switch (BUILTIN_TYPE(obj)) {
-      case T_NONE:
-      case T_SYMBOL:
-        break;
-      default:
+    if (BUILTIN_TYPE(obj) != T_NONE) {
         obj_free(objspace, obj);
-        break;
     }
 }
 
@@ -4350,8 +4345,6 @@ rb_objspace_call_finalizer_i(VALUE obj, void *data)
       case T_FILE:
         obj_free(objspace, obj);
         break;
-      case T_SYMBOL:
-      case T_ARRAY:
       case T_NONE:
         break;
       default:

--- a/variable.c
+++ b/variable.c
@@ -451,7 +451,7 @@ struct rb_global_entry {
 };
 
 static enum rb_id_table_iterator_result
-free_global_entry_i(ID key, VALUE val, void *arg)
+free_global_entry_i(VALUE val, void *arg)
 {
     struct rb_global_entry *entry = (struct rb_global_entry *)val;
     if (entry->var->counter == 1) {
@@ -467,7 +467,7 @@ free_global_entry_i(ID key, VALUE val, void *arg)
 void
 rb_free_rb_global_tbl(void)
 {
-    rb_id_table_foreach(rb_global_tbl, free_global_entry_i, 0);
+    rb_id_table_foreach_values(rb_global_tbl, free_global_entry_i, 0);
     rb_id_table_free(rb_global_tbl);
 }
 


### PR DESCRIPTION
This removes the use of symbol and array objects when freeing the global table so we can now free symbols and arrays earlier.