### PR TITLE
Don't skip test_inspect_under_gc_compact_stress

### DIFF
--- a/test/ruby/test_symbol.rb
+++ b/test/ruby/test_symbol.rb
@@ -120,8 +120,7 @@ class TestSymbol < Test::Unit::TestCase
 
   def test_inspect_under_gc_compact_stress
     omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
-    omit "very flaky on many platforms, more so with YJIT enabled" if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
-    omit "very flaky on many platforms, more so with RJIT enabled" if defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled?
+
     EnvUtil.under_gc_compact_stress do
       assert_inspect_evaled(':testing')
     end


### PR DESCRIPTION
Commit 1471a16 seems to have fixed this flaky test, so we don't need to skip it for YJIT or RJIT anymore.