### PR TITLE
Allow gdb to search source path for required files

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1344,4 +1344,4 @@ define print_flags
   printf "RUBY_FL_USER18      : %s\n", ((struct RBasic*)($arg0))->flags & RUBY_FL_USER18 ? "1" : "0"
 end
 
-source misc/gdb.py
+source -s misc/gdb.py


### PR DESCRIPTION
When doing out-of-source builds I often end up wanting to use gdb from inside a build directory.

Currently if I do that the `.gdbinit` in the ruby source directory is not read.

Attempting to manually load the `.gdbinit` from the Ruby source directory errors because of hard coded file-paths that assume we're running gdb from inside the source tree.

Adding the `-s` flag to the `source` command when loading relative files signals to gdb to search in the source search path for the required file, rather than just the current directory.

This allows me to use a custom `.gdbinit` from my build directory that sets the correct source directory and then loads the Ruby `.gdbinit`.

```
dir ../src
source ../src/.gdbinit
```