### PR TITLE
Check existance of `SPEC_TEMP_DIR`

### DIFF
--- a/spec/mspec/lib/mspec/helpers/tmp.rb
+++ b/spec/mspec/lib/mspec/helpers/tmp.rb
@@ -12,6 +12,11 @@ else
 end
 SPEC_TEMP_DIR = spec_temp_dir
 
+# to debug
+if File.exist?(SPEC_TEMP_DIR)
+  STDERR.puts File.stat(SPEC_TEMP_DIR).inspect
+end
+
 SPEC_TEMP_UNIQUIFIER = +"0"
 
 at_exit do


### PR DESCRIPTION
Sometimes there are weird failure like:

```
1)
Dir.mktmpdir when passed a block yields the path to the passed block ERROR
ArgumentError: parent directory is world writable but not sticky: /tmp/rubytest.wlu5cs_11
/tmp/ruby/src/trunk/lib/tmpdir.rb:113:in 'Dir.mktmpdir'
/tmp/ruby/src/trunk/spec/ruby/library/tmpdir/dir/mktmpdir_spec.rb:39:in 'block (2 levels) in <top (required)>'
```

and this is because of existance of `SPEC_TEMP_DIR`.

`mktmpdir_spec.rb` introduces the mock method for `Dir.tmpdir` to return `SPEC_TEMP_DIR` without checking the world-writable bit, so the scenario may be:

1. make a `SPEC_TEMP_DIR` "foo_2" (`_2` is from parallel test)
2. make "foo_2" world-writable
3. rubyspec process left it because of some trouble
4. another rubyspec process use "foo_2" accidentally
5. ``mktmpdir_spec.rb` specs fails with world-writable check

To confirm the scenario, I inserted the existance check of `SPEC_TEMP_DIR`.