### PR TITLE
[3.2 backport] compile.c: use putspecialobject for RubyVM::FrozenCore

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -9750,7 +9750,12 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const no
       case NODE_LIT:{
         debugp_param("lit", node->nd_lit);
         if (!popped) {
-            ADD_INSN1(ret, node, putobject, node->nd_lit);
+            if (UNLIKELY(node->nd_lit == rb_mRubyVMFrozenCore)) {
+                ADD_INSN1(ret, node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE)); // [Bug #20569]
+            }
+            else {
+                ADD_INSN1(ret, node, putobject, node->nd_lit);
+            }
             RB_OBJ_WRITTEN(iseq, Qundef, node->nd_lit);
         }
         break;

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -167,6 +167,14 @@ class TestISeq < Test::Unit::TestCase
     end
   end
 
+  def test_ractor_shareable_value_frozen_core
+    iseq = RubyVM::InstructionSequence.compile(<<~'RUBY')
+      # shareable_constant_value: literal
+      REGEX = /#{}/ # [Bug #20569]
+    RUBY
+    assert_includes iseq.to_binary, "REGEX".b
+  end
+
   def test_disasm_encoding
     src = "\u{3042} = 1; \u{3042}; \u{3043}"
     asm = compile(src).disasm


### PR DESCRIPTION
[Bug #20569]

`putobject RubyVM::FrozenCore`, is not serializable, we have to use `putspecialobject VM_SPECIAL_OBJECT_VMCORE`.

NB: In 3.2 it's the parser that generate a `NODE_LIT` for `RubyVM::FrozenCore` so the patch is quite different from the original targeting 3.4-dev: https://github.com/ruby/ruby/pull/10951
