### PR TITLE
.travis.yml: Update jaruga's email.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,6 +148,6 @@ notifications:
     on_failure: always
   email:
     recipients:
-      - jaruga@ruby-lang.org
+      - jun.aruga@gmail.com
     on_success: never
     on_failure: always


### PR DESCRIPTION
I cannot receive Travis's notification via jaruga@ruby-lang.org, while another committer with their @ruby-lang.org email can receive the notification. The issue is my ruby-lang.org email address specific. So far we haven't seen the root cause even with the Travis support's help.

Because of that, I change the email address to my personal email address.