### PR TITLE
Optimize `String#<<` with a single byte argument

### DIFF
--- a/string.c
+++ b/string.c
@@ -3346,6 +3346,58 @@ rb_str_cat_cstr(VALUE str, const char *ptr)
     return rb_str_buf_cat(str, ptr, strlen(ptr));
 }
 
+static void
+rb_str_buf_cat_byte(VALUE str, unsigned char byte)
+{
+    RUBY_ASSERT(RB_ENCODING_GET_INLINED(str) == ENCINDEX_ASCII_8BIT);
+
+    // We can't write directly to shared strings without impacting others, so we must make the string independent.
+    if (UNLIKELY(!str_independent(str))) {
+        str_make_independent(str);
+    }
+
+    long string_length = -1;
+    const int null_terminator_length = 1;
+    char *sptr;
+    RSTRING_GETMEM(str, sptr, string_length);
+
+    // Ensure the resulting string wouldn't be too long.
+    if (UNLIKELY(string_length > LONG_MAX - 1)) {
+        rb_raise(rb_eArgError, "string sizes too big");
+    }
+
+    long string_capacity = str_capacity(str, null_terminator_length);
+
+    // Get the code range before any modifications since those might clear the code range.
+    int cr = ENC_CODERANGE(str);
+
+    // Check if the string has spare string_capacity to write the new byte.
+    if (LIKELY(string_capacity >= string_length + 1)) {
+        // In fast path we can write the new byte and note the string's new length.
+        sptr[string_length] = byte;
+        STR_SET_LEN(str, string_length + 1);
+        TERM_FILL(sptr + string_length + 1, null_terminator_length);
+    }
+    else {
+        // If there's not enough string_capacity, make a call into the general string concatenation function.
+        char buf[1] = {byte};
+        str_buf_cat(str, buf, 1);
+    }
+
+    // If the code range is already known, we can derive the resulting code range cheaply by looking at the byte we
+    // just appended. If the code range is unknown, but the string was empty, then we can also derive the code range
+    // by looking at the byte we just appended. Otherwise, we'd have to scan the bytes to determine the code range so
+    // we leave it as unknown. It cannot be broken for binary strings so we don't need to handle that option.
+    if (cr == ENC_CODERANGE_7BIT || string_length == 0) {
+        if (ISASCII(byte)) {
+            ENC_CODERANGE_SET(str, ENC_CODERANGE_7BIT);
+        }
+        else {
+            ENC_CODERANGE_SET(str, ENC_CODERANGE_VALID);
+        }
+    }
+}
+
 RUBY_ALIAS_FUNCTION(rb_str_buf_cat(VALUE str, const char *ptr, long len), rb_str_cat, (str, ptr, len))
 RUBY_ALIAS_FUNCTION(rb_str_buf_cat2(VALUE str, const char *ptr), rb_str_cat_cstr, (str, ptr))
 RUBY_ALIAS_FUNCTION(rb_str_cat2(VALUE str, const char *ptr), rb_str_cat_cstr, (str, ptr))
@@ -3634,7 +3686,11 @@ rb_str_concat(VALUE str1, VALUE str2)
     }
 
     encidx = rb_ascii8bit_appendable_encoding_index(enc, code);
-    if (encidx >= 0) {
+
+    if (encidx == ENCINDEX_ASCII_8BIT) {
+        rb_str_buf_cat_byte(str1, (unsigned char)code);
+    }
+    else if (encidx >= 0) {
         char buf[1];
         buf[0] = (char)code;
         rb_str_cat(str1, buf, 1);


### PR DESCRIPTION
Since Ruby lacks a binary array data type, we must use strings with an `ASCII-8BIT` encoding to efficiently work with binary data. Previously, we added the ability to set the initial capacity of a string withe `String.new(capacity:)`. However, filling those bytes can be rather inefficient. If we want to append a single byte, we cannot use `String#setbyte` because that performs bounds-checking based on the current string length. So, we have to resort to `String#<<`, but that method does an extensive set of checks to ensure the string being appended is compatible.

CRuby currently has a specialized path for when the value being appended is a codepoint. It will wrap the int value up into a `char buf[1]` and then dispatch as if `String#<<` were called with a string argument.

This PR speeds up the case where we know we have a binary string and we're appending byte values. We still must perform bounds checks and set the string length, but if there's capacity in the string we can now directly write to that byte location.

Initially, I focused on speeding up byte appends to string's with an `ASCII-8BIT` encoding. Byte-oriented operations on binary strings is a fairly common use case. In a second commit I extended the code a little bit to handle byte appends to US-ASCII strings. Ruby will promote a US-ASCII string to ASCII-8BIT if a non-ASCII byte value is seen. If this isn't warranted we can easily drop the second commit.

I think we could extend this further and optimize ASCII codepoint writes in all ASCII-compatible encodings. I could see that being useful for single-character appends to UTF-8 strings. I have not yet done that work. If it's interesting, I'm happy to do it. However, I have some concerns that querying an encoding for its ASCII-compatibility setting would slow down the binary string use case. Since this PR focuses on only two specific encodings we can use the encoding index directly without having to do any operations on the encoding object.

I've run the `string_concat` benchmarks, comparing _master_ (0a6b1a4d9de583ebfd305ab1b297be1cea7bdc2f) against this PR. There seems to be no significant impact on those benchmarks. However, in additional benchmarks there is a noticeable improvement. For example:

```ruby
eval "def concat(str); " +
  50000.times.map { "str << 15" }.join("; ") + "; end"

def run_benchmark count
  i = 0
  while i < count
    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
    yield
    ms = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
    puts "itr ##{i}: #{(ms * 1000).to_i}ms"
    i += 1
  end
end

run_benchmark(25) do
  250.times do
    str = "".b
    concat str
  end
end
```

| Ruby | Avg. Execution |
|--------|--------|
| _master_ (0a6b1a4d9de583ebfd305ab1b297be1cea7bdc2f) | 240 ms |
| PR #10968 | 220 ms |

If the benchmark is changed to call a method that requires the code range the performance is much larger. As a contrived example, changing the `"str << 15"` line above to `"str << 15; str.ascii_only?"` so the benchmark looks like:

```ruby
eval "def concat(str); " +
  50000.times.map { "str << 15; str.ascii_only?" }.join("; ") + "; end"

def run_benchmark count
  i = 0
  while i < count
    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
    yield
    ms = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
    puts "itr ##{i}: #{(ms * 1000).to_i}ms"
    i += 1
  end
end

run_benchmark(25) do
  250.times do
    str = "".b
    concat str
  end
end
```

| Ruby | Avg. Execution |
|--------|--------|
| _master_ (0a6b1a4d9de583ebfd305ab1b297be1cea7bdc2f) | 13259 ms |
| PR #10968 | 400 ms |

Here, the performance difference is largely attributable to the preservation of the code range. In `rb_str_buf_cat_byte` we can cheaply derive the string's code range after the byte append. Normally in string concatenation, CRuby must conservatively clear the code range. While calling `str.ascii_only?` on each iteration of a loop is a pathological case, it is reasonable to expect code that may call a `String` method that requires the code range. Clearing the code range means a linear scan through the string to compute the new code range. Granted, there are fewer cases where the code range is needed for `ASCII-8BIT` than for other encodings given it is also single-byte optimizable. Regardless, not having to clear the code range reduces the number of surprise performance hits.