### PR TITLE
'SPEC_TEMP_DIR` should not be world-writable

### DIFF
--- a/spec/ruby/library/find/fixtures/common.rb
+++ b/spec/ruby/library/find/fixtures/common.rb
@@ -71,13 +71,17 @@ module FindDirSpecs
   end
 
   def self.create_mock_dirs
+    tmp('') # make sure there is an tmpdir
     umask = File.umask 0
-    mock_dir_files.each do |name|
-      file = File.join mock_dir, name
-      mkdir_p File.dirname(file)
-      touch file
+    begin
+      mock_dir_files.each do |name|
+        file = File.join mock_dir, name
+        mkdir_p File.dirname(file)
+        touch file
+      end
+    ensure
+      File.umask umask
     end
-    File.umask umask
   end
 
   def self.delete_mock_dirs


### PR DESCRIPTION
`SPEC_TEMP_DIR` is not present until `tmp()` method is called on parallel run. In this case `tmp()` is called with `File.umask = 0`. This patch makes `SPEC_TEMP_DIR` before `File.umask = 0`.

To solve the issue essentially, I think `SPEC_TEMP_DIR` should be prepared at the beginning of parallel process.