### PR TITLE
Kernel#warn: don't call `Warning.warn` unless the category is enabled

### DIFF
--- a/spec/ruby/core/warning/warn_spec.rb
+++ b/spec/ruby/core/warning/warn_spec.rb
@@ -121,6 +121,30 @@ describe "Warning.warn" do
     end
   end
 
+  ruby_bug '#19530', ''...'3.4' do
+    it "isn't called by Kernel.warn when category is :deprecated but Warning[:deprecated] is false" do
+      warn_deprecated = Warning[:deprecated]
+      begin
+        Warning[:deprecated] = false
+        Warning.should_not_receive(:warn)
+        Kernel.warn("foo", category: :deprecated)
+      ensure
+        Warning[:deprecated] = warn_deprecated
+      end
+    end
+
+    it "isn't called by Kernel.warn when category is :experimental but Warning[:experimental] is false" do
+      warn_experimental = Warning[:experimental]
+      begin
+        Warning[:experimental] = false
+        Warning.should_not_receive(:warn)
+        Kernel.warn("foo", category: :experimental)
+      ensure
+        Warning[:experimental] = warn_experimental
+      end
+    end
+  end
+
   it "prints the message when VERBOSE is false" do
     -> { Warning.warn("foo") }.should complain("foo")
   end

--- a/warning.rb
+++ b/warning.rb
@@ -47,7 +47,13 @@ module Kernel
   #                be removed in the future.
   # :experimental :: Used for experimental features that may change in
   #                  future releases.
+  # :performance  :: Used for warning about APIs or pattern that have
+  #                  negative performance impact
   def warn(*msgs, uplevel: nil, category: nil)
-    Primitive.rb_warn_m(msgs, uplevel, category)
+    if Primitive.cexpr!("NIL_P(category)")
+      Primitive.rb_warn_m(msgs, uplevel, nil)
+    elsif Warning[category = Primitive.cexpr!("rb_to_symbol_type(category)")]
+      Primitive.rb_warn_m(msgs, uplevel, category)
+    end
   end
 end


### PR DESCRIPTION
[[Bug #20573]](https://bugs.ruby-lang.org/issues/20573)

Followup: https://github.com/ruby/ruby/pull/10960

I believe `Kernel#warn` should behave in the same way than internal `rb_warning_* APIs

cc @tenderlove @jeremyevans 