### PR TITLE
YJIT: add context cache hits stat

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -390,10 +390,11 @@ module RubyVM::YJIT
       out.puts "yjit_alloc_size:       " + format_number(13, stats[:yjit_alloc_size]) if stats.key?(:yjit_alloc_size)
 
       bytes_per_context = stats[:context_data_bytes].fdiv(stats[:num_contexts_encoded])
-      out.puts "context_cache_bytes:   " + format_number(13, stats[:context_cache_bytes])
       out.puts "context_data_bytes:    " + format_number(13, stats[:context_data_bytes])
+      out.puts "context_cache_bytes:   " + format_number(13, stats[:context_cache_bytes])
       out.puts "num_contexts_encoded:  " + format_number(13, stats[:num_contexts_encoded])
       out.puts "bytes_per_context:     " + ("%13.2f" % bytes_per_context)
+      out.puts "context_cache_hit_rate:" + format_number_pct(13, stats[:context_cache_hits], stats[:num_contexts_encoded])
 
       out.puts "live_page_count:       " + format_number(13, stats[:live_page_count])
       out.puts "freed_page_count:      " + format_number(13, stats[:freed_page_count])

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -858,10 +858,12 @@ impl Context {
         incr_counter!(num_contexts_encoded);
 
         if *self == Context::default() {
+            incr_counter!(context_cache_hits);
             return 0;
         }
 
         if let Some(idx) = Self::cache_get(self) {
+            incr_counter!(context_cache_hits);
             debug_assert!(Self::decode(idx) == *self);
             return idx;
         }

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -266,7 +266,7 @@ macro_rules! make_counters {
 
 /// The list of counters that are available without --yjit-stats.
 /// They are incremented only by `incr_counter!` and don't use `gen_counter_incr`.
-pub const DEFAULT_COUNTERS: [Counter; 18] = [
+pub const DEFAULT_COUNTERS: [Counter; 19] = [
     Counter::code_gc_count,
     Counter::compiled_iseq_entry,
     Counter::cold_iseq_entry,
@@ -277,6 +277,7 @@ pub const DEFAULT_COUNTERS: [Counter; 18] = [
     Counter::compile_time_ns,
     Counter::max_inline_versions,
     Counter::num_contexts_encoded,
+    Counter::context_cache_hits,
 
     Counter::invalidation_count,
     Counter::invalidate_method_lookup,
@@ -611,6 +612,9 @@ make_counters! {
     temp_reg_opnd,
     temp_mem_opnd,
     temp_spill,
+
+    context_cache_hits,
+    context_cache_misses,
 }
 
 //===========================================================================

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -614,7 +614,6 @@ make_counters! {
     temp_spill,
 
     context_cache_hits,
-    context_cache_misses,
 }
 
 //===========================================================================


### PR DESCRIPTION
This stat should make more sense when it comes to interpreting the effectiveness of the cache on large deployed apps.