### PR TITLE
[BACKPORT] Don't call `Warning.warn` unless the category is enabled

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -589,6 +589,8 @@ assert_equal 'string', %q{
 
 # Check that exceptions work when getting global variable
 assert_equal 'rescued', %q{
+  Warning[:deprecated] = true
+
   module Warning
     def warn(message)
       raise

--- a/error.c
+++ b/error.c
@@ -432,7 +432,7 @@ rb_warn(const char *fmt, ...)
 void
 rb_category_warn(rb_warning_category_t category, const char *fmt, ...)
 {
-    if (!NIL_P(ruby_verbose)) {
+    if (!NIL_P(ruby_verbose) && rb_warning_category_enabled_p(category)) {
         with_warning_string(mesg, 0, fmt) {
             rb_warn_category(mesg, rb_warning_category_to_name(category));
         }
@@ -464,7 +464,7 @@ rb_warning(const char *fmt, ...)
 void
 rb_category_warning(rb_warning_category_t category, const char *fmt, ...)
 {
-    if (RTEST(ruby_verbose)) {
+    if (RTEST(ruby_verbose) && rb_warning_category_enabled_p(category)) {
         with_warning_string(mesg, 0, fmt) {
             rb_warn_category(mesg, rb_warning_category_to_name(category));
         }


### PR DESCRIPTION
The warning category should be enabled if we want to call `Warning.warn`.

This commit speeds up the following benchmark:

```ruby
eval "def test; " +
  1000.times.map { "'  '.chomp!" }.join(";") + "; end"

def run_benchmark count
  i = 0
  while i < count
    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
    yield
    ms = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
    puts "itr ##{i}: #{(ms * 1000).to_i}ms"
    i += 1
  end
end

run_benchmark(25) do
  250.times do
    test
  end
end
```

On `master` this runs at about 92ms per iteration. With this patch, it is 7ms per iteration.

[Bug #20573]