### PR TITLE
Crash instead of raising with Check_Type() in RBIMPL_ASSERT_TYPE()

### DIFF
--- a/include/ruby/internal/value_type.h
+++ b/include/ruby/internal/value_type.h
@@ -96,11 +96,7 @@
 #define RB_TYPE_P         RB_TYPE_P
 #define Check_Type        Check_Type
 
-#if !RUBY_DEBUG
-# define RBIMPL_ASSERT_TYPE(v, t) RBIMPL_ASSERT_OR_ASSUME(RB_TYPE_P((v), (t)))
-#else
-# define RBIMPL_ASSERT_TYPE Check_Type
-#endif
+#define RBIMPL_ASSERT_TYPE(v, t) RBIMPL_ASSERT_OR_ASSUME(RB_TYPE_P((v), (t)))
 /** @endcond */
 
 /** @old{rb_type} */


### PR DESCRIPTION
Previously, RBIMPL_ASSERT_TYPE() used Check_Type() only in RUBY_DEBUG builds.
It raised TypeError, but only in debug builds. For people testing
type mismatch using debug builds looking for a Ruby exception, this hid
a bug -- the code is missing a type check in non-debug builds that most
people consume.

Also, Check_Type() can obscure the true cause of error in debug mode.
When type check fails because the object is corrupt, instead of crashing
with a clear type assertion message, it can crash while trying to
construct an exception object to raise. You can see this for example in
<https://github.com/ruby/ruby/actions/runs/9489999591/job/26152506434?pr=10985>,
where RB_ENCODING_GET() is used on a corrupt object, but the crash
happens later and says "Assertion Failed:
../src/vm_method.c:1477:callable_method_entry_or_negative".
RBIMPL_ASSERT_TYPE() should assert right away.

RBIMPL_ASSERT_OR_ASSUME() asserts when RUBY_DEBUG and assumes in release
builds, as desired.

This should help investigate flaky CI failures that show up as TypeError
from `Kernel#require`, e.g.
"'Kernel#require': wrong argument type false (expected String) (TypeError)".

Same CI failure examples:
 - https://github.com/ruby/ruby/actions/runs/9034787861/job/24828147431
 - https://github.com/ruby/ruby/actions/runs/9418303667/job/25945492440
 - https://github.com/ruby/ruby/actions/runs/9505650952/job/26201031314

The failure occurs with and without use of YJIT.
