### PR TITLE
Use ENDBR instruction in amd64 coroutine on OpenBSD

### DIFF
--- a/coroutine/amd64/Context.S
+++ b/coroutine/amd64/Context.S
@@ -5,6 +5,10 @@
 ##  Copyright, 2018, by Samuel Williams.
 ##
 
+#if defined(__OpenBSD__)
+#include <cet.h>
+#endif
+
 #define TOKEN_PASTE(x,y) x##y
 #define PREFIXED_SYMBOL(prefix,name) TOKEN_PASTE(prefix,name)
 
@@ -12,6 +16,10 @@
 
 .globl PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer)
 PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
+
+#if defined(__OpenBSD__)
+	_CET_ENDBR
+#endif
 
 	# Make space on the stack for 6 registers:
 	subq $48, %rsp


### PR DESCRIPTION
When running on newer Intel processors supporting the feature, OpenBSD enforces indirect branch tracking.  Without this endbr64 instruction, jumps to the coroutine_transfer function result in SIGILL on OpenBSD/amd64 when using such processors.

The OpenBSD Ruby ports have been using a patch similar to this for the past two months.

From some research, cet.h has been supported by GCC for about 6 years and LLVM for about 4 years.