### PR TITLE
do not call `check_rvalue_consistency` here

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -9545,7 +9545,7 @@ gc_move(rb_objspace_t *objspace, VALUE scan, VALUE free, size_t src_slot_size, s
     gc_report(4, objspace, "Moving object: %p -> %p\n", (void*)scan, (void *)free);
 
     GC_ASSERT(BUILTIN_TYPE(scan) != T_NONE);
-    GC_ASSERT(!RVALUE_MARKED(free));
+    GC_ASSERT(!MARKED_IN_BITMAP(GET_HEAP_MARK_BITS(free), free));
 
     GC_ASSERT(!RVALUE_MARKING((VALUE)src));
 


### PR DESCRIPTION
in `free` is not valid object and should not call
`check_rvalue_consistency`.

http://ci.rvm.jp/results/trunk-gc-asserts@ruby-sp2-docker/5152088
```

   -- C level backtrace information -------------------------------------------
   /tmp/ruby/build/trunk-gc-asserts/miniruby(rb_print_backtrace+0x14) [0x55ca0284d9a1] /tmp/ruby/src/trunk-gc-asserts/vm_dump.c:820
   /tmp/ruby/build/trunk-gc-asserts/miniruby(rb_vm_bugreport) /tmp/ruby/src/trunk-gc-asserts/vm_dump.c:1151
   /tmp/ruby/build/trunk-gc-asserts/miniruby(bug_report_end+0x0) [0x55ca0263ad6e] /tmp/ruby/src/trunk-gc-asserts/error.c:1085
   /tmp/ruby/build/trunk-gc-asserts/miniruby(rb_bug_without_die) /tmp/ruby/src/trunk-gc-asserts/error.c:1085
   /tmp/ruby/build/trunk-gc-asserts/miniruby(die+0x0) [0x55ca02561267] /tmp/ruby/src/trunk-gc-asserts/error.c:1093
   /tmp/ruby/build/trunk-gc-asserts/miniruby(rb_bug) /tmp/ruby/src/trunk-gc-asserts/error.c:1095
   /tmp/ruby/build/trunk-gc-asserts/miniruby(rb_gc_size_allocatable_p+0x0) [0x55ca02561c43] /tmp/ruby/src/trunk-gc-asserts/gc.c:4801
   /tmp/ruby/build/trunk-gc-asserts/miniruby(obj_memsize_of+0xa) [0x55ca0265ed25] /tmp/ruby/src/trunk-gc-asserts/gc.c:4688
   /tmp/ruby/build/trunk-gc-asserts/miniruby(check_rvalue_consistency_force) /tmp/ruby/src/trunk-gc-asserts/gc.c:1652
   /tmp/ruby/build/trunk-gc-asserts/miniruby(check_rvalue_consistency+0x10) [0x55ca02661b69] /tmp/ruby/src/trunk-gc-asserts/gc.c:1714
   /tmp/ruby/build/trunk-gc-asserts/miniruby(RVALUE_MARKED) /tmp/ruby/src/trunk-gc-asserts/gc.c:1550
   /tmp/ruby/build/trunk-gc-asserts/miniruby(gc_move) /tmp/ruby/src/trunk-gc-asserts/gc.c:9548
   /tmp/ruby/build/trunk-gc-asserts/miniruby(RB_SPECIAL_CONST_P+0x0) [0x55ca026622d2] /tmp/ruby/src/trunk-gc-asserts/gc.c:5064
   /tmp/ruby/build/trunk-gc-asserts/miniruby(is_markable_object) /tmp/ruby/src/trunk-gc-asserts/gc.c:4445
   /tmp/ruby/build/trunk-gc-asserts/miniruby(gc_pin) /tmp/ruby/src/trunk-gc-asserts/gc.c:6707
   /tmp/ruby/build/trunk-gc-asserts/miniruby(try_move) /tmp/ruby/src/trunk-gc-asserts/gc.c:5065
   /tmp/ruby/build/trunk-gc-asserts/miniruby(gc_compact_move) /tmp/ruby/src/trunk-gc-asserts/gc.c:8158
   /tmp/ruby/build/trunk-gc-asserts/miniruby(gc_compact_plane) /tmp/ruby/src/trunk-gc-asserts/gc.c:8209
   /tmp/ruby/build/trunk-gc-asserts/miniruby(gc_compact_page+0x1d) [0x55ca02668e95] /tmp/ruby/src/trunk-gc-asserts/gc.c:8239
   /tmp/ruby/build/trunk-gc-asserts/miniruby(gc_sweep_compact) /tmp/ruby/src/trunk-gc-asserts/gc.c:8291
   /tmp/ruby/build/trunk-gc-asserts/miniruby(gc_sweep) /tmp/ruby/src/trunk-gc-asserts/gc.c:5900
   /tmp/ruby/build/trunk-gc-asserts/miniruby(gc_start+0xd1b) [0x55ca0266bfcb] /tmp/ruby/src/trunk-gc-asserts/gc.c:9088
   /tmp/ruby/build/trunk-gc-asserts/miniruby(rb_multi_ractor_p+0x0) [0x55ca0266ed78] /tmp/ruby/src/trunk-gc-asserts/gc.c:8968
   /tmp/ruby/build/trunk-gc-asserts/miniruby(rb_vm_lock_leave) /tmp/ruby/src/trunk-gc-asserts/vm_sync.h:92
   /tmp/ruby/build/trunk-gc-asserts/miniruby(garbage_collect) /tmp/ruby/src/trunk-gc-asserts/gc.c:8970
   /tmp/ruby/build/trunk-gc-asserts/miniruby(gc_start_internal) /tmp/ruby/src/trunk-gc-asserts/gc.c:9418
   /tmp/ruby/build/trunk-gc-asserts/miniruby(gc_compact) /tmp/ruby/src/trunk-gc-asserts/gc.c:10488
   /tmp/ruby/build/trunk-gc-asserts/miniruby(vm_cfp_consistent_p+0x0) [0x55ca0281cb64] /tmp/ruby/src/trunk-gc-asserts/vm_insnhelper.c:359
```