### PR TITLE
respect `--error-output stderr` on parallel mode

### DIFF
--- a/spec/mspec/lib/mspec/runner/formatters/multi.rb
+++ b/spec/mspec/lib/mspec/runner/formatters/multi.rb
@@ -42,6 +42,6 @@ module MultiFormatter
   end
 
   def print_exception(exc, count)
-    print "\n#{count})\n#{exc}\n"
+    @err.print "\n#{count})\n#{exc}\n"
   end
 end


### PR DESCRIPTION
`MultiFormatter#print_exception` should respect `--error-output stderr`.