### PR TITLE
Fix yjit bootstrap tests

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -157,7 +157,7 @@ assert_equal '0', "0.abs(&nil)"
 
 # regression test for invokeblock iseq guard
 assert_equal 'ok', %q{
-  return :ok unless defined?(GC.compact)
+  skip :ok unless defined?(GC.compact)
   def foo = yield
   10.times do |i|
     ret = eval("foo { #{i} }")

--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -123,6 +123,7 @@ assert_equal '[:ae, :ae]', %q{
 
 # regression test for GC marking stubs in invalidated code
 assert_normal_exit %q{
+  skip true unless defined?(GC.compact)
   garbage = Array.new(10_000) { [] } # create garbage to cause iseq movement
   eval(<<~RUBY)
   def foo(n, garbage)
@@ -1229,6 +1230,7 @@ assert_equal 'special', %q{
 
 # Test that object references in generated code get marked and moved
 assert_equal "good", %q{
+  skip :good unless defined?(GC.compact)
   def bar
     "good"
   end
@@ -2321,6 +2323,7 @@ assert_equal '123', %q{
 
 # Test EP == BP invalidation with moving ISEQs
 assert_equal 'ok', %q{
+  skip :ok unless defined?(GC.compact)
   def entry
     ok = proc { :ok } # set #entry as an EP-escaping ISEQ
     [nil].reverse_each do # avoid exiting the JIT frame on the constant


### PR DESCRIPTION
This PR fixes some guards in the yjit bootstrap tests that cause errors on platforms that don't implement GC compaction.