### PR TITLE
rb_str_hash(): Avoid UB with making misaligned pointer

### DIFF
--- a/string.c
+++ b/string.c
@@ -376,9 +376,8 @@ str_precompute_hash(VALUE str)
     RUBY_ASSERT(free_bytes >= sizeof(st_index_t));
 #endif
 
-    typedef struct {char bytes[sizeof(st_index_t)];} unaligned_index;
-    union {st_index_t i; unaligned_index b;} u = {.i = str_do_hash(str)};
-    *(unaligned_index *)(RSTRING_END(str) + TERM_LEN(str)) = u.b;
+    st_index_t hash = str_do_hash(str);
+    memcpy(RSTRING_END(str) + TERM_LEN(str), &hash, sizeof(hash));
 
     FL_SET(str, STR_PRECOMPUTED_HASH);
 

--- a/string.c
+++ b/string.c
@@ -3735,8 +3735,8 @@ st_index_t
 rb_str_hash(VALUE str)
 {
     if (FL_TEST_RAW(str, STR_PRECOMPUTED_HASH)) {
-        typedef struct {char bytes[sizeof(st_index_t)];} unaligned_index;
-        st_index_t precomputed_hash = ((union {st_index_t i; unaligned_index b;} *)(RSTRING_END(str) + TERM_LEN(str)))->i;
+        st_index_t precomputed_hash;
+        memcpy(&precomputed_hash, RSTRING_END(str) + TERM_LEN(str), sizeof(precomputed_hash));
 
         RUBY_ASSERT(precomputed_hash == str_do_hash(str));
         return precomputed_hash;


### PR DESCRIPTION
Previously, on common platforms, this code made a pointer to a union of
8 byte alignment out of a char pointer that is not guaranteed to satisfy
the alignment requirement. That is undefined behavior according
to [C99 6.3.2.3p7](https://port70.net/~nsz/c/c99/n1256.html#6.3.2.3p7).

Use memcpy() to do the unaligned read instead.

cc @byroot 
