### PR TITLE
Enable LeakChecker for RJIT previously disabled for MJIT

### DIFF
--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -1761,9 +1761,7 @@ module Test
           puts if @verbose
           $stdout.flush
 
-          unless defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled? # compiler process is wrongly considered as leak
-            leakchecker.check("#{inst.class}\##{inst.__name__}")
-          end
+          leakchecker.check("#{inst.class}\##{inst.__name__}")
 
           _end_method(inst)
 


### PR DESCRIPTION
RJIT doesn't spawn subprocesses so there should now be no need to
special case it.
