### PR TITLE
Spec test update for bug #20280

### DIFF
--- a/spec/ruby/language/symbol_spec.rb
+++ b/spec/ruby/language/symbol_spec.rb
@@ -97,11 +97,11 @@ describe "A Symbol literal" do
   end
 
   ruby_bug "#20280", ""..."3.4" do
-    it "raises an SyntaxError at parse time when Symbol with invalid bytes" do
+    it "raises an EncodingError at parse time when Symbol with invalid bytes" do
       ScratchPad.record []
       -> {
         eval 'ScratchPad << 1; :"\xC3"'
-      }.should raise_error(SyntaxError, /invalid symbol/)
+      }.should raise_error(EncodingError, /invalid symbol/)
       ScratchPad.recorded.should == []
     end
   end


### PR DESCRIPTION
Fix spec test for raising error at parse time when Symbol with invalid bytes from SyntaxError to EncodingError which was part of https://bugs.ruby-lang.org/issues/20280