### PR TITLE
YJIT: Fix an unused field warning in `DumpDisasm`.

### DIFF
--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -125,6 +125,7 @@ pub enum DumpDisasm {
     // Dump to stdout
     Stdout,
     // Dump to "yjit_{pid}.log" file under the specified directory
+    #[cfg_attr(not(feature = "disasm"), allow(dead_code))]
     File(std::os::unix::io::RawFd),
 }
 


### PR DESCRIPTION
I see a warning about this field not being used in Rust 1.79.0.