### PR TITLE
extmk.rb: define Gem.target_rbconfig not to break `Gem::Platform.local`

### DIFF
--- a/ext/extmk.rb
+++ b/ext/extmk.rb
@@ -2,7 +2,13 @@
 # -*- mode: ruby; coding: us-ascii -*-
 # frozen_string_literal: false
 
-module Gem; end # only needs Gem::Platform
+module Gem
+  # Used by Gem::Platform.local
+  def self.target_rbconfig
+    RbConfig::CONFIG
+  end
+end
+# only needs Gem::Platform
 require 'rubygems/platform'
 
 # :stopdoc:


### PR DESCRIPTION
Fix https://github.com/ruby/ruby/actions/runs/9557130718/job/26343688358

```
*** Following extensions are not compiled:
bigdecimal-3.1.8/ext/bigdecimal:
	Could not be configured. It will not be installed.
	/Users/runner/work/ruby/ruby/src/lib/rubygems/platform.rb:18: undefined method 'target_rbconfig' for module Gem
	Check .bundle/gems/bigdecimal-3.1.8/ext/bigdecimal/mkmf.log for more details.
```