### PR TITLE
Fix flaky TestWeakMap#test_inspect_garbage

### DIFF
--- a/test/ruby/test_weakmap.rb
+++ b/test/ruby/test_weakmap.rb
@@ -78,7 +78,7 @@ class TestWeakMap < Test::Unit::TestCase
       @wm[i] = Object.new
       @wm.inspect
     end
-    assert_match(/\A\#<#{@wm.class.name}:[^:]++:(?:\s\d+\s=>\s\#<(?:Object|collected):[^:<>]*+>(?:,|>\z))+/,
+    assert_match(/\A\#<#{@wm.class.name}:0x[\da-f]+(?::(?: \d+ => \#<(?:Object|collected):0x[\da-f]+>,?)+)?>\z/,
                  @wm.inspect)
   end
 


### PR DESCRIPTION
If a GC is ran before the assert_match, then the WeakMap would be empty and would not have any objects, so the regular expression match would fail. This changes the regular expression to work even if the WeakMap is empty.