### PR TITLE
windows.yml - fixup vcpkg code, list packages

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -115,7 +115,12 @@ jobs:
 
       - name: Install libraries with vcpkg
         run: |
-          vcpkg --triplet x64-windows install gmp libffi libyaml openssl zlib
+          set pkgs=gmp libffi libyaml openssl zlib
+          vcpkg --triplet x64-windows install %pkgs%
+          vcpkg --triplet x64-windows upgrade %pkgs% --no-dry-run
+
+      - name: List vcpkg libraries
+        run: vcpkg list
 
       - name: Install libraries with scoop
         run: |


### PR DESCRIPTION
Correctly updates the vcpkg library packages, adds a step 'List vcpkg libraries' that lists all packages and their versions.  This can be helpful if a library package update is suspected of causing a CI failure.

Note that the file `vcpkg.json` was added to the repo, but the workflow was never updated to work with it.  So, it only works with a local installation when used properly.

Note that Windows Rubies 3.2.4 and 3.3.3 are using OpenSSL 3.3.z and zlib 1.3.1.  They are both MSYS2 ucrt64 builds.

Packages will be updated as required, based on the vcpkg version included in the GHA runner image.