### PR TITLE
mingw.yml - fixup to use ucrt, logging

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -48,8 +48,9 @@ jobs:
       matrix:
         include:
           # To mitigate flakiness of MinGW CI, we test only one runtime that newer MSYS2 uses.
+          # Ruby 3.2 is the first Windows Ruby to use OpenSSL 3.x
           - msystem: 'UCRT64'
-            baseruby: '3.0'
+            baseruby: '3.2'
             test_task: 'check'
             test-all-opts: '--name=!/TestObjSpace#test_reachable_objects_during_iteration/'
       fail-fast: false
@@ -70,32 +71,28 @@ jobs:
         with:
           ruby-version: ${{ matrix.baseruby }}
 
-      - name: where check
+      - name: Misc system & package info
+        working-directory:
         run: |
           # show where
-          mv /c/Windows/System32/libcrypto-1_1-x64.dll /c/Windows/System32/libcrypto-1_1-x64.dll_
-          mv /c/Windows/System32/libssl-1_1-x64.dll    /c/Windows/System32/libssl-1_1-x64.dll_
           result=true
-          for e in gcc.exe ragel.exe make.exe libcrypto-1_1-x64.dll libssl-1_1-x64.dll; do
+          for e in gcc.exe ragel.exe make.exe libcrypto-3-x64.dll libssl-3-x64.dll; do
             echo ::group::$'\033[93m'$e$'\033[m'
             where $e || result=false
             echo ::endgroup::
           done
-          $result
-        working-directory:
-
-      - name: version check
-        run: |
           # show version
-          result=true
           for e in gcc ragel make "openssl version"; do
             case "$e" in *" "*) ;; *) e="$e --version";; esac
             echo ::group::$'\033[93m'$e$'\033[m'
             $e || result=false
             echo ::endgroup::
           done
+          # show packages
+          echo ::group::$'\033[93m'Packages$'\033[m'
+          pacman -Qs mingw-w64-ucrt-x86_64-* | sed -n "s,local/mingw-w64-ucrt-x86_64-,,p"
+          echo ::endgroup::
           $result
-        working-directory:
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:


### PR DESCRIPTION
The `mingw.yml` workflow uses `setup-ruby` to configure/install build tools, packages and the 'baseruby'.

`setup-ruby` is designed to work with most CI, where the tools & packages match the selected Ruby version.  Currently, the workflow's selected Ruby version is 3.0.

The publicly available Ruby 3.0 is a mingw Ruby that uses OpenSSL 1.1.1.  Since we want the head CI to use ucrt tools and packages, and also use OpenSSL 3.3.x, use Ruby 3.2 for the selected/base Ruby.

Additionally, there were two 'informational' steps, combine those into one, and add info as to the current packages installed.

`setup-ruby` could allow an input to specify the build type and OpenSSL version (defaulting to what the specified Ruby version uses), but there aren't a lot of use cases...