### PR TITLE
Avoid a hash allocation when keyword splatting empty hash when calling ruby2_keywords method

### DIFF
--- a/test/ruby/test_allocation.rb
+++ b/test/ruby/test_allocation.rb
@@ -273,7 +273,7 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(0, 1, "keyword(**hash1, **empty_hash#{block})")
         check_allocations(1, 0, "keyword(*empty_array, *empty_array, **empty_hash#{block})")
 
-        check_allocations(1, 0, "keyword(*r2k_empty_array#{block})")
+        check_allocations(0, 0, "keyword(*r2k_empty_array#{block})")
         check_allocations(1, 1, "keyword(*r2k_array#{block})")
 
         check_allocations(0, 1, "keyword(*empty_array, a: 2, **empty_hash#{block})")
@@ -379,7 +379,7 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "required_and_keyword(*array1, *empty_array, a: 2, **empty_hash#{block})")
         check_allocations(1, 1, "required_and_keyword(*array1, *empty_array, **hash1, **empty_hash#{block})")
 
-        check_allocations(1, 0, "required_and_keyword(*r2k_empty_array1#{block})")
+        check_allocations(0, 0, "required_and_keyword(*r2k_empty_array1#{block})")
         check_allocations(1, 1, "required_and_keyword(*r2k_array1#{block})")
 
         # Currently allocates 1 array unnecessarily due to splatarray true
@@ -724,7 +724,7 @@ class TestAllocation < Test::Unit::TestCase
         check_allocations(1, 1, "r2k(1, **empty_hash, a: 2#{block})")
 
         check_allocations(1, 0, "r2k(1, **nil#{block})")
-        check_allocations(1, 1, "r2k(1, **empty_hash#{block})")
+        check_allocations(1, 0, "r2k(1, **empty_hash#{block})")
         check_allocations(1, 1, "r2k(1, **hash1#{block})")
         check_allocations(1, 1, "r2k(1, *empty_array, **hash1#{block})")
         check_allocations(1, 1, "r2k(1, **hash1, **empty_hash#{block})")
@@ -732,17 +732,17 @@ class TestAllocation < Test::Unit::TestCase
 
         check_allocations(1, 0, "r2k(1, *empty_array#{block})")
         check_allocations(1, 1, "r2k(1, **hash1, **empty_hash#{block})")
-        check_allocations(1, 1, "r2k(1, *empty_array, *empty_array, **empty_hash#{block})")
+        check_allocations(1, 0, "r2k(1, *empty_array, *empty_array, **empty_hash#{block})")
 
         check_allocations(1, 1, "r2k(*array1, a: 2#{block})")
 
         check_allocations(1, 0, "r2k(*array1, **nill#{block})")
-        check_allocations(1, 1, "r2k(*array1, **empty_hash#{block})")
+        check_allocations(1, 0, "r2k(*array1, **empty_hash#{block})")
         check_allocations(1, 1, "r2k(*array1, **hash1#{block})")
         check_allocations(1, 1, "r2k(*array1, *empty_array, **hash1#{block})")
 
         check_allocations(1, 0, "r2k(*array1, *empty_array#{block})")
-        check_allocations(1, 1, "r2k(*array1, *empty_array, **empty_hash#{block})")
+        check_allocations(1, 0, "r2k(*array1, *empty_array, **empty_hash#{block})")
 
         check_allocations(1, 1, "r2k(*array1, *empty_array, a: 2, **empty_hash#{block})")
         check_allocations(1, 1, "r2k(*array1, *empty_array, **hash1, **empty_hash#{block})")


### PR DESCRIPTION
Treat this similar to keyword splatting nil, using goto ignore. However, keep previous behavior if the method accepts a keyword splat, to avoid double hash allocation.

This also can avoid an array allocation when calling a method that doesn't have any splat parameters but supports literal keyword parameters, because ignore_keyword_hash_p was not ignoring the keyword hash in that case.

This change doesn't remove the empty ruby2_keywords hash from the array, which caused an assertion failure if the method being called accepted keywords in some cases.  Modify the assertion to handle this case.  An alternative approach would add a flag to the args struct so the args_argc calculation could handle this case and report the correct argc, but such an approach would likely be slower.