### PR TITLE
Skip 3 specs when $HOME is not a valid directory

### DIFF
--- a/spec/ruby/core/dir/chdir_spec.rb
+++ b/spec/ruby/core/dir/chdir_spec.rb
@@ -19,14 +19,14 @@ describe "Dir.chdir" do
   end
 
   it "defaults to $HOME with no arguments" do
-    if ENV['HOME']
-      Dir.chdir
-      current_dir = Dir.pwd
+    skip "$HOME not valid directory" unless ENV['HOME'] && File.directory?(ENV['HOME'])
 
-      Dir.chdir(ENV['HOME'])
-      home = Dir.pwd
-      current_dir.should == home
-    end
+    Dir.chdir
+    current_dir = Dir.pwd
+
+    Dir.chdir(ENV['HOME'])
+    home = Dir.pwd
+    current_dir.should == home
   end
 
   it "changes to the specified directory" do
@@ -70,6 +70,8 @@ describe "Dir.chdir" do
   end
 
   it "defaults to the home directory when given a block but no argument" do
+    skip "$HOME not valid directory" unless ENV['HOME'] && File.directory?(ENV['HOME'])
+
     # Windows will return a path with forward slashes for ENV["HOME"] so we have
     # to compare the route representations returned by Dir.chdir.
     current_dir = ""

--- a/spec/ruby/core/dir/shared/exist.rb
+++ b/spec/ruby/core/dir/shared/exist.rb
@@ -34,6 +34,7 @@ describe :dir_exist, shared: true do
   end
 
   it "doesn't expand paths" do
+    skip "$HOME not valid directory" unless ENV['HOME'] && File.directory?(ENV['HOME'])
     Dir.send(@method, File.expand_path('~')).should be_true
     Dir.send(@method, '~').should be_false
   end


### PR DESCRIPTION
If $HOME isn't a valid directory, these specs fail, but I think it is better to skip in this case, as it does not indicate a bug.

This fixes specs when run in the OpenBSD port, which sets $HOME to an invalid directory to ensure that software's build system is not accidentally relying on it.