### PR TITLE
Set RUBY_TEST_TIMEOUT_SCALE=3 for --repeat-count=2 test

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -102,7 +102,9 @@ jobs:
         continue-on-error: true
 
       - name: Set extra test options
-        run: echo "TESTS=$TESTS ${{ matrix.test_opts }}" >> $GITHUB_ENV
+        run: |
+          echo "TESTS=$TESTS ${{ matrix.test_opts }}" >> $GITHUB_ENV
+          echo "RUBY_TEST_TIMEOUT_SCALE=3" >> $GITHUB_ENV # With --repeat-count=2, flaky test by timeout occurs frequently for some reason
         if: matrix.test_opts
 
       - name: make ${{ matrix.test_task }}


### PR DESCRIPTION
With --repeat-count=2, timing-related test seems to fail frequently. I'm not sure of the cause, but I want to reduce the errors by setting RUBY_TEST_TIMEOUT_SCALE.