### PR TITLE
Apply EnvUtil.apply_timeout_scale for TestFile#test_stat

### DIFF
--- a/test/ruby/test_file.rb
+++ b/test/ruby/test_file.rb
@@ -375,7 +375,7 @@ class TestFile < Test::Unit::TestCase
       sleep 2
       File.read(path)
 
-      delta = 1
+      delta = EnvUtil.apply_timeout_scale(1)
       stat = File.stat(path)
       assert_in_delta tb,   stat.birthtime.to_f, delta
       assert_in_delta t0+2, stat.mtime.to_f, delta


### PR DESCRIPTION
... to respect RUBY_TEST_TIMEOUT_SCALE. This test somehow fails frequently on macos-arm-oss with --repeat-count=2

https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fruby%2Ftest_file.rb%23%23%23class%3DTestFile%23%23%23testcase%3Dtest_stat?organizationId=ruby&workspaceId=ruby&testPathId=file%3Dtest%2Fruby%2Ftest_file.rb%23%23%23class%3DTestFile%23%23%23testcase%3Dtest_stat&testSessionStatus=flake