### PR TITLE
Load external GC using command line argument

### DIFF
--- a/main.c
+++ b/main.c
@@ -32,10 +32,15 @@
 # undef RUBY_DEBUG_ENV
 #endif
 
+void ruby_load_external_gc_from_argv(int argc, char **argv);
+
 static int
 rb_main(int argc, char **argv)
 {
     RUBY_INIT_STACK;
+#if USE_SHARED_GC
+    ruby_load_external_gc_from_argv(argc, argv);
+#endif
     ruby_init();
     return ruby_run_node(ruby_options(argc, argv));
 }

--- a/ruby.c
+++ b/ruby.c
@@ -1436,6 +1436,16 @@ proc_long_options(ruby_cmdline_options_t *opt, const char *s, long argc, char **
         set_source_encoding_once(opt, s, 0);
     }
 #endif
+#if defined(USE_SHARED_GC) && USE_SHARED_GC
+    else if (is_option_with_arg("gc-library", Qfalse, Qfalse)) {
+        // no-op
+        // Handled by ruby_load_external_gc_from_argv
+
+        if (!dln_supported_p()) {
+            rb_warn("--gc-library is ignored because this executable file can't load extension libraries");
+        }
+    }
+#endif
     else if (strcmp("version", s) == 0) {
         if (envopt) goto noenvopt_long;
         opt->dump |= DUMP_BIT(version);

--- a/vm_core.h
+++ b/vm_core.h
@@ -106,14 +106,6 @@ extern int ruby_assert_critical_section_entered;
 
 #include "ruby/thread_native.h"
 
-#if USE_SHARED_GC
-typedef struct gc_function_map {
-    void *(*objspace_alloc)(void);
-} rb_gc_function_map_t;
-
-#define rb_gc_functions (&GET_VM()->gc_functions_map)
-#endif
-
 /*
  * implementation selector of get_insn_info algorithm
  *   0: linear search
@@ -761,9 +753,6 @@ typedef struct rb_vm_struct {
     int coverage_mode;
 
     struct rb_objspace *objspace;
-#if USE_SHARED_GC
-    rb_gc_function_map_t gc_functions_map;
-#endif
 
     rb_at_exit_list *at_exit;
 


### PR DESCRIPTION
This commit changes the external GC to be loaded with the `--gc-library` command line argument instead of the RUBY_GC_LIBRARY_PATH environment variable because @nobu pointed out that loading binaries using environment variables can pose a security risk.