### PR TITLE
YJIT: Enhance the `String#<<` method substitution to handle integer codepoint values.

### DIFF
--- a/string.c
+++ b/string.c
@@ -12296,6 +12296,23 @@ rb_enc_interned_str_cstr(const char *ptr, rb_encoding *enc)
     return rb_enc_interned_str(ptr, strlen(ptr), enc);
 }
 
+#if USE_YJIT
+void
+rb_yjit_str_concat_codepoint(VALUE str, VALUE codepoint)
+{
+    if (RB_LIKELY(FIXNUM_P(codepoint)) && RB_LIKELY(ENCODING_GET_INLINED(str) == rb_ascii8bit_encindex())) {
+        ssize_t code = RB_NUM2SSIZE(codepoint);
+
+        if (RB_LIKELY(code >= 0 && code < 0xff)) {
+            rb_str_buf_cat_byte(str, (char) code);
+            return;
+        }
+    }
+
+    rb_str_concat(str, codepoint);
+}
+#endif
+
 void
 Init_String(void)
 {

--- a/string.c
+++ b/string.c
@@ -3375,8 +3375,7 @@ rb_str_buf_cat_byte(VALUE str, unsigned char byte)
     }
     else {
         // If there's not enough string_capacity, make a call into the general string concatenation function.
-        char buf[1] = {byte};
-        str_buf_cat(str, buf, 1);
+        str_buf_cat(str, (char *)&byte, 1);
     }
 
     // If the code range is already known, we can derive the resulting code range cheaply by looking at the byte we

--- a/string.c
+++ b/string.c
@@ -12300,7 +12300,7 @@ rb_enc_interned_str_cstr(const char *ptr, rb_encoding *enc)
 void
 rb_yjit_str_concat_codepoint(VALUE str, VALUE codepoint)
 {
-    if (RB_LIKELY(FIXNUM_P(codepoint)) && RB_LIKELY(ENCODING_GET_INLINED(str) == rb_ascii8bit_encindex())) {
+    if (RB_LIKELY(ENCODING_GET_INLINED(str) == rb_ascii8bit_encindex())) {
         ssize_t code = RB_NUM2SSIZE(codepoint);
 
         if (RB_LIKELY(code >= 0 && code < 0xff)) {

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -339,6 +339,7 @@ fn main() {
         .allowlist_function("rb_yjit_sendish_sp_pops")
         .allowlist_function("rb_yjit_invokeblock_sp_pops")
         .allowlist_function("rb_yjit_set_exception_return")
+        .allowlist_function("rb_yjit_str_concat_codepoint")
         .allowlist_type("robject_offsets")
         .allowlist_type("rstring_offsets")
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5770,10 +5770,9 @@ fn jit_rb_str_empty_p(
     return true;
 }
 
-// Codegen for rb_str_concat() -- *not* String#concat
-// Frequently strings are concatenated using "out_str << next_str".
-// This is common in Erb and similar templating languages.
-fn jit_rb_str_concat(
+// Codegen for rb_str_concat() with an integer argument -- *not* String#concat
+// Using strings as a byte buffer often includes appending byte values to the end of the string.
+fn jit_rb_str_concat_codepoint(
     jit: &mut JITState,
     asm: &mut Assembler,
     _ci: *const rb_callinfo,
@@ -5782,11 +5781,46 @@ fn jit_rb_str_concat(
     _argc: i32,
     _known_recv_class: Option<VALUE>,
 ) -> bool {
+    asm_comment!(asm, "String#<< with codepoint argument");
+
+    // Either of the string concatenation functions we call will reallocate the string to grow its
+    // capacity if necessary. In extremely rare cases (i.e., string exceeds `LONG_MAX` bytes),
+    // either of the called functions will raise an exception.
+    jit_prepare_non_leaf_call(jit, asm);
+
+    let codepoint = asm.stack_opnd(0);
+    let recv = asm.stack_opnd(1);
+
+    asm.ccall(rb_yjit_str_concat_codepoint as *const u8, vec![recv, codepoint]);
+
+    // The receiver is the return value, so we only need to pop the codepoint argument off the stack.
+    // We can reuse the receiver slot in the stack as the return value.
+    asm.stack_pop(1);
+
+    true
+}
+
+// Codegen for rb_str_concat() -- *not* String#concat
+// Frequently strings are concatenated using "out_str << next_str".
+// This is common in Erb and similar templating languages.
+fn jit_rb_str_concat(
+    jit: &mut JITState,
+    asm: &mut Assembler,
+    ci: *const rb_callinfo,
+    cme: *const rb_callable_method_entry_t,
+    block: Option<BlockHandler>,
+    argc: i32,
+    known_recv_class: Option<VALUE>,
+) -> bool {
     // The << operator can accept integer codepoints for characters
     // as the argument. We only specially optimise string arguments.
     // If the peeked-at compile time argument is something other than
     // a string, assume it won't be a string later either.
     let comptime_arg = jit.peek_at_stack(&asm.ctx, 0);
+    if unsafe { RB_TYPE_P(comptime_arg, RUBY_T_FIXNUM) } {
+        return jit_rb_str_concat_codepoint(jit, asm, ci, cme, block, argc, known_recv_class);
+    }
+
     if ! unsafe { RB_TYPE_P(comptime_arg, RUBY_T_STRING) } {
         return false;
     }
@@ -10227,7 +10261,7 @@ pub fn yjit_reg_method_codegen_fns() {
 }
 
 // Register a specialized codegen function for a particular method. Note that
-// the if the function returns true, the code it generates runs without a
+// if the function returns true, the code it generates runs without a
 // control frame and without interrupt checks. To avoid creating observable
 // behavior changes, the codegen function should only target simple code paths
 // that do not allocate and do not make method calls.

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -117,6 +117,7 @@ extern "C" {
         ci: *const rb_callinfo,
     ) -> *const rb_callable_method_entry_t;
     pub fn rb_hash_empty_p(hash: VALUE) -> VALUE;
+    pub fn rb_yjit_str_concat_codepoint(str: VALUE, codepoint: VALUE);
     pub fn rb_str_setbyte(str: VALUE, index: VALUE, value: VALUE) -> VALUE;
     pub fn rb_vm_splat_array(flag: VALUE, ary: VALUE) -> VALUE;
     pub fn rb_vm_concat_array(ary1: VALUE, ary2st: VALUE) -> VALUE;

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -453,6 +453,7 @@ make_counters! {
     guard_send_instance_of_class_mismatch,
     guard_send_interrupted,
     guard_send_not_fixnums,
+    guard_send_not_fixnum,
     guard_send_not_fixnum_or_flonum,
     guard_send_not_string,
     guard_send_respond_to_mid_mismatch,


### PR DESCRIPTION
This PR extends YJIT's method substitution for `String#<<` to handle integer codepoints as well. If the string is `ASCII-8BIT` and the codepoint is a byte value, YJIT will dispatch to `rb_str_buf_cat_byte` as a fast path for working with binary strings. Otherwise, it'll dispatch to the general `rb_str_concat` just as `vm_opt_ltlt` would.

`rb_str_buf_cat_byte` currently works with both `ASCII-8BIT` and `US-ASCII`, but this YJIT side only optimizes for `ASCII-8BIT`. It could be extended easily enough with an additional comparison. The encoding indices for a handful of encodings, including both `ASCII-8BIT` and `US-ASCII` are fixed and sequential, so we could also do a range check. For the time being, I've omitted the handling of `US-ASCII`. I'd like to get feedback on the simplified PR and extend it with `US-ASCII` handling if needed (which I'm also not convinced we do).

Please advise if the mechanism I'm using to handle polymorphic dispatch is incorrect. We already have `jit_rb_str_concat` as a method substitution for `String#<<`, but it deliberately only handled string arguments. I could have merged the two, but that struck me as being complicated. However, I also don't know if it's fine to call between methods like this. And, it ends up duplicating some of the type checks to ensure we dispatch to the correct type depending on what we see at compile time. I was unsure on how to handle the runtime guards, so please pay extra attention to that.