### PR TITLE
[YJIT] Fix block and splat handling when forwarding

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -5077,3 +5077,47 @@ assert_equal 'ok', <<~'RUBY'
 
   :ok
 RUBY
+
+assert_equal 'ok', <<~'RUBY'
+  class MyRelation
+    def callee(...)
+      :ok
+    end
+
+    def uncached(...)
+      callee(...)
+    end
+
+    def takes_block(&block)
+      # push blockhandler
+      uncached(&block) # CI1
+    end
+  end
+
+  relation = MyRelation.new
+  relation.takes_block { }
+RUBY
+
+assert_equal 'ok', <<~'RUBY'
+  def _exec_scope(...)
+    instance_exec(...)
+  end
+
+  def ok args, body
+    _exec_scope(*args, &body)
+  end
+
+  ok([], -> { "ok" })
+RUBY
+
+assert_equal 'ok', <<~'RUBY'
+  def _exec_scope(...)
+    instance_exec(...)
+  end
+
+  def ok args, body
+    _exec_scope(*args, &body)
+  end
+
+  ok(["ok"], ->(x) { x })
+RUBY


### PR DESCRIPTION
This commit fixes splat and block handling when calling in to a forwarding iseq.  In the case of a splat we need to avoid expanding the array to the stack.  We need to also ensure the CI write is flushed to the SP, otherwise it's possible for a block handler to clobber the CI

[ruby-core:118360]

This also fixes the problem in lobsters benchmark.