### PR TITLE
build: fix crossruby build by handling empty `ac_abs_builddir`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3501,7 +3501,7 @@ done
 
 BTESTRUBY='$(MINIRUBY)'
 AS_IF([test x"$cross_compiling" = xyes], [
-  test x"$MINIRUBY" = x && MINIRUBY="${RUBY-$BASERUBY} -I$ac_abs_builddir "-r'$(arch)-fake'
+  test x"$MINIRUBY" = x && MINIRUBY="${RUBY-$BASERUBY} -I${ac_abs_builddir-.} "-r'$(arch)-fake'
   XRUBY_LIBDIR=`${RUBY-$BASERUBY} -rrbconfig -e ['puts RbConfig::CONFIG["libdir"]']`
   XRUBY_RUBYLIBDIR=`${RUBY-$BASERUBY} -rrbconfig -e ['puts RbConfig::CONFIG["rubylibdir"]']`
   XRUBY_RUBYHDRDIR=`${RUBY-$BASERUBY} -rrbconfig -e ['puts RbConfig::CONFIG["rubyhdrdir"]']`


### PR DESCRIPTION
`ac_abs_builddir` can be empty when the build is top-level (not subdirs, and Ruby is usually the case). In such case, the MINIRUBY is expanded to `$RUBY -I -r'$(arch)-fake'`, which interprets `-r$(arch)-fake` as an argument to `-I` option. This led to:
- Not loading the fake config file
- Then not setting `CROSS_COMPILING` constant during extmk.rb execution
- Then misusing cross-compiled `./miniruby` instead of baseruby to generate files used in exts.

```
generating eventids1.c from ../.././parse.y
gmake[2]: ../../miniruby: No such file or directory
gmake[2]: *** [Makefile:362: eventids1.c] Error 127
gmake[2]: Leaving directory '/home/chkbuild/chkbuild/tmp/build/20240622T021304Z/ruby/ext/ripper'
gmake[1]: *** [exts.mk:100: ext/ripper/static] Error 2
gmake[1]: Leaving directory '/home/chkbuild/chkbuild/tmp/build/20240622T021304Z/ruby'
gmake: *** [uncommon.mk:416: build-ext] Error 2
```
https://rubyci.s3.amazonaws.com/crossruby/crossruby-master-wasm32_wasi/log/20240622T042000Z.fail.html.gz

This commit fixes the issue by handling the empty `ac_abs_builddir` case properly.