### PR TITLE
 Integrate Launchable into mingw

### DIFF
--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -88,8 +88,7 @@ runs:
       working-directory: ${{ inputs.srcdir }}
       run: |
         set -x
-        PATH=$PATH:$(python -msite --user-base)/bin
-        echo "PATH=$PATH" >> $GITHUB_ENV
+        echo "$(python -msite --user-base)/bin" >> $GITHUB_PATH
         pip install --user launchable
         launchable verify || true
         : # The build name cannot include a slash, so we replace the string here.

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -107,6 +107,8 @@ jobs:
           srcdir: src
           builddir: build
           makeup: true
+          # Set fetch-depth: 10 so that Launchable can receive commits information.
+          fetch-depth: 10
 
       - name: configure
         run: >
@@ -119,6 +121,18 @@ jobs:
 
       - name: make install
         run: make DESTDIR=../install install-nodoc
+
+      - name: Set up Launchable
+        uses: ./.github/actions/launchable/setup
+        with:
+          os: windows-2022
+          # If we support new test task, we need to change this test-opts.
+          test-opts: --retry --job-status=normal --show-skip --timeout-scale=1.5
+            ${{ matrix.test-all-opts }}
+          launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
+          builddir: build
+          srcdir: src
+        continue-on-error: true
 
       - name: test
         timeout-minutes: 30
@@ -138,6 +152,7 @@ jobs:
           RUBY_TESTOPTS: >-
             --retry --job-status=normal --show-skip --timeout-scale=1.5
             ${{ matrix.test-all-opts }}
+            ${{ env.TESTS }}
           BUNDLER_VERSION:
         if: ${{ matrix.test_task == 'check' || matrix.test_task == 'test-all' || StartsWith(matrix.test_task, 'test/') }}
 


### PR DESCRIPTION
Recently, Launchable has been used for analyzing flaky tests. Kokubun-san asked me to integrate Launchable into mingw for analyzing flay tests in mingw, so I've created this PR to address it.

Examples for using Launchable:

https://github.com/ruby/ruby/pull/11025
https://github.com/ruby/ruby/pull/10749