### PR TITLE
[Bug #20592] Fix segfault when sending NULL to freeaddrinfo

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -278,7 +278,7 @@ void
 rb_freeaddrinfo(struct rb_addrinfo *ai)
 {
     if (!ai->allocated_by_malloc)
-        freeaddrinfo(ai->ai);
+        if (ai->ai) freeaddrinfo(ai->ai);
     else {
         struct addrinfo *ai1, *ai2;
         ai1 = ai->ai;
@@ -423,7 +423,7 @@ do_getaddrinfo(void *ptr)
         arg->err = err;
         arg->gai_errno = gai_errno;
         if (arg->cancelled) {
-            freeaddrinfo(arg->ai);
+            if (arg->ai) freeaddrinfo(arg->ai);
         }
         else {
             arg->done = 1;


### PR DESCRIPTION
On alpine freeaddrinfo does not accept NULL pointer, and it gives a segfault.

Use case: interrupt Addrinfo which would end with an error