### PR TITLE
No longer needs `sigsetjmp`

### DIFF
--- a/tool/m4/ruby_check_builtin_setjmp.m4
+++ b/tool/m4/ruby_check_builtin_setjmp.m4
@@ -20,7 +20,7 @@ AC_CACHE_CHECK(for __builtin_setjmp, ac_cv_func___builtin_setjmp,
 	    void (*volatile f)(void) = t;
 	    if (!jump()) printf("%d\n", f != 0);
 	    ]])],
-	    [ac_cv_func___builtin_setjmp="yes with cast ($cast)"])
+	    [ac_cv_func___builtin_setjmp="yes${cast:+ with cast ($cast)}"])
 	])
 	test "$ac_cv_func___builtin_setjmp" = no || break
     done])

--- a/tool/m4/ruby_setjmp_type.m4
+++ b/tool/m4/ruby_setjmp_type.m4
@@ -3,18 +3,15 @@ AC_DEFUN([RUBY_SETJMP_TYPE], [
 RUBY_CHECK_BUILTIN_SETJMP
 RUBY_CHECK_SETJMP(_setjmpex, [], [@%:@include <setjmpex.h>])
 RUBY_CHECK_SETJMP(_setjmp)
-RUBY_CHECK_SETJMP(sigsetjmp, [sigjmp_buf])
 AC_MSG_CHECKING(for setjmp type)
 setjmp_suffix=
-unset setjmp_sigmask
 AC_ARG_WITH(setjmp-type,
-	AS_HELP_STRING([--with-setjmp-type], [select setjmp type]),
+    AS_HELP_STRING([--with-setjmp-type], [select setjmp type]),
 	[
 	AS_CASE([$withval],
 	[__builtin_setjmp], [setjmp=__builtin_setjmp],
 	[_setjmp], [ setjmp_prefix=_],
-	[sigsetjmp,*], [ setjmp_prefix=sig setjmp_sigmask=`expr "$withval" : 'sigsetjmp\(,.*\)'`],
-	[sigsetjmp], [ setjmp_prefix=sig],
+	[sigsetjmp*], [ AC_MSG_WARN(No longer use sigsetjmp; use setjmp instead); setjmp_prefix=],
 	[setjmp], [ setjmp_prefix=],
 	[setjmpex], [ setjmp_prefix= setjmp_suffix=ex],
 	[''], [ unset setjmp_prefix],
@@ -34,19 +31,13 @@ AS_IF([test ${setjmp_prefix+set}], [
 ], [test "$ac_cv_func__setjmp" = yes], [
     setjmp_prefix=_
     setjmp_suffix=
-], [test "$ac_cv_func_sigsetjmp" = yes], [
-    AS_CASE([$target_os],[solaris*|cygwin*],[setjmp_prefix=],[setjmp_prefix=sig])
-    setjmp_suffix=
 ], [
     setjmp_prefix=
     setjmp_suffix=
 ])
-AS_IF([test x$setjmp_prefix:$setjmp_sigmask = xsig:], [
-    setjmp_sigmask=,0
-])
-AC_MSG_RESULT(${setjmp_prefix}setjmp${setjmp_suffix}${setjmp_cast:+\($setjmp_cast\)}${setjmp_sigmask})
-AC_DEFINE_UNQUOTED([RUBY_SETJMP(env)], [${setjmp_prefix}setjmp${setjmp_suffix}($setjmp_cast(env)${setjmp_sigmask})])
+AC_MSG_RESULT(${setjmp_prefix}setjmp${setjmp_suffix}${setjmp_cast:+\($setjmp_cast\)})
+AC_DEFINE_UNQUOTED([RUBY_SETJMP(env)], [${setjmp_prefix}setjmp${setjmp_suffix}($setjmp_cast(env))])
 AC_DEFINE_UNQUOTED([RUBY_LONGJMP(env,val)], [${setjmp_prefix}longjmp($setjmp_cast(env),val)])
-AS_IF([test "(" "$GCC" != yes ")" -o x$setjmp_prefix != x__builtin_], AC_DEFINE_UNQUOTED(RUBY_JMP_BUF, ${setjmp_sigmask+${setjmp_prefix}}jmp_buf))
+AS_CASE(["$GCC:$setjmp_prefix"], [yes:__builtin_], [], AC_DEFINE_UNQUOTED(RUBY_JMP_BUF, jmp_buf))
 AS_IF([test x$setjmp_suffix = xex], [AC_DEFINE_UNQUOTED(RUBY_USE_SETJMPEX, 1)])
 ])dnl


### PR DESCRIPTION
Since signal handlers just set flag and return now, `sigsetjmp` and `siglongjmp` will not be needed.