### PR TITLE
Fix `--debug-frozen-string-literal` to not apply `--disable-frozen-string-literal`

### DIFF
--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -1233,6 +1233,17 @@ class TestRubyOptions < Test::Unit::TestCase
     end
   end
 
+  def test_frozen_string_literal_debug_chilled_strings
+    code = <<~RUBY
+      "foo" << "bar"
+    RUBY
+    warning = ["-:1: warning: literal string will be frozen in the future"]
+    assert_in_out_err(["-W:deprecated"], code, [], warning)
+    assert_in_out_err(["-W:deprecated", "--debug-frozen-string-literal"], code, [], warning)
+    assert_in_out_err(["-W:deprecated", "--disable-frozen-string-literal", "--debug-frozen-string-literal"], code, [], [])
+    assert_in_out_err(["-W:deprecated", "--enable-frozen-string-literal", "--debug-frozen-string-literal"], code, [], ["-:1:in '<main>': can't modify frozen String: \"foo\", created at -:1 (FrozenError)"])
+  end
+
   def test___dir__encoding
     lang = {"LC_ALL"=>ENV["LC_ALL"]||ENV["LANG"]}
     with_tmpchdir do


### PR DESCRIPTION
[Feature #20205]

This was an undesired side effect. Now that this value is a triplet, we can't assume it's disabled by default.