### PR TITLE
Change `enum rb_parser_ary_data_type` default value to 1 for easy debug

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -2512,6 +2512,7 @@ parser_ary_new_capa(rb_parser_t *p, long len)
         rb_bug("negative array size (or size too big): %ld", len);
     }
     rb_parser_ary_t *ary = xcalloc(1, sizeof(rb_parser_ary_t));
+    ary->data_type = 0;
     ary->len = 0;
     ary->capa = len;
     if (0 < len) {

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -224,7 +224,7 @@ typedef struct rb_parser_ast_token {
 typedef void* rb_parser_ary_data;
 
 enum rb_parser_ary_data_type {
-    PARSER_ARY_DATA_AST_TOKEN,
+    PARSER_ARY_DATA_AST_TOKEN = 1,
     PARSER_ARY_DATA_SCRIPT_LINE
 };
 


### PR DESCRIPTION
We face `[BUG] unexpected rb_parser_ary_data_type (0) for script lines` on master branch recently.
This commit changes `enum rb_parser_ary_data_type` to start with `1` and `0` to be invalid then it makes clear `rb_parser_ary_data_type (0)` is not intentional.