### PR TITLE
Use `File.open` instead of `IO.sysopen` (backport to 3.5)

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -18,7 +18,7 @@ net-pop         0.1.2   https://github.com/ruby/net-pop
 net-smtp        0.5.0   https://github.com/ruby/net-smtp
 matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
-rbs             3.5.1   https://github.com/ruby/rbs 084a930dbfb1cd53e3efaa9e43d84cd104e511ff
+rbs             3.5.1   https://github.com/ruby/rbs 97e12999b14dc36e374ed30a03fca58af62dfd90
 typeprof        0.21.11 https://github.com/ruby/typeprof b19a6416da3a05d57fadd6ffdadb382b6d236ca5
 debug           1.9.2   https://github.com/ruby/debug
 racc            1.8.0   https://github.com/ruby/racc


### PR DESCRIPTION
#11060 bundled rbs based on 3.6 branch, and caused some compilation issue.

This PR bundles [rbs based on 3.5](https://github.com/ruby/rbs/pull/1913). 