### PR TITLE
[Bug #20595] Fix corruption of encoding name string

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -1291,7 +1291,7 @@ enc_names_i(st_data_t name, st_data_t idx, st_data_t args)
     VALUE *arg = (VALUE *)args;
 
     if ((int)idx == (int)arg[0]) {
-        VALUE str = rb_fstring_cstr((char *)name);
+        VALUE str = rb_interned_str_cstr((char *)name);
         rb_ary_push(arg[1], str);
     }
     return ST_CONTINUE;

--- a/test/ruby/test_m17n.rb
+++ b/test/ruby/test_m17n.rb
@@ -1721,6 +1721,17 @@ class TestM17N < Test::Unit::TestCase
     assert_equal(e("[\"\xB4\xC1\xBB\xFA\"]"), s, bug11787)
   end
 
+  def test_encoding_names_of_default_internal
+    # [Bug #20595]
+    assert_separately(%w(-W0), "#{<<~"begin;"}\n#{<<~"end;"}")
+    begin;
+      Encoding.default_internal = Encoding::ASCII_8BIT
+      names = Encoding.default_internal.names
+      Encoding.default_internal = nil
+      assert_include names, "int" + "ernal", "[Bug #20595]"
+    end;
+  end
+
   def test_greek_capital_gap
     bug12204 = '[ruby-core:74478] [Bug #12204] GREEK CAPITAL RHO and SIGMA'
     assert_equal("\u03A3", "\u03A1".succ, bug12204)


### PR DESCRIPTION
enc_set_default_encoding will free the C string if the encoding is nil, but the C string can be used by the encoding name string. This will cause the encoding name string to be corrupted.

Consider the following code:

    Encoding.default_internal = Encoding::ASCII_8BIT
    names = Encoding.default_internal.names
    p names
    Encoding.default_internal = nil
    p names

It outputs:

    ["ASCII-8BIT", "BINARY", "internal"]
    ["ASCII-8BIT", "BINARY", "\x00\x00\x00\x00\x00\x00\x00\x00"]