### PR TITLE
Fix comment for VM_CALL_ARGS_SIMPLE

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1439,14 +1439,14 @@ new_callinfo(rb_iseq_t *iseq, ID mid, int argc, unsigned int flag, struct rb_cal
 {
     VM_ASSERT(argc >= 0);
 
-    if (!(flag & (VM_CALL_ARGS_SPLAT | VM_CALL_ARGS_BLOCKARG | VM_CALL_KW_SPLAT | VM_CALL_FORWARDING)) &&
-        kw_arg == NULL && !has_blockiseq) {
-        flag |= VM_CALL_ARGS_SIMPLE;
-    }
-
     if (kw_arg) {
         flag |= VM_CALL_KWARG;
         argc += kw_arg->keyword_len;
+    }
+
+    if (!(flag & (VM_CALL_ARGS_SPLAT | VM_CALL_ARGS_BLOCKARG | VM_CALL_KWARG | VM_CALL_KW_SPLAT | VM_CALL_FORWARDING))
+        && !has_blockiseq) {
+        flag |= VM_CALL_ARGS_SIMPLE;
     }
 
     ISEQ_BODY(iseq)->ci_size++;

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -12,12 +12,13 @@
 #include "internal/class.h"
 #include "shape.h"
 
-enum vm_call_flag_bits {
+enum vm_call_flag_bits
+{
     VM_CALL_ARGS_SPLAT_bit,     // m(*args)
     VM_CALL_ARGS_BLOCKARG_bit,  // m(&block)
     VM_CALL_FCALL_bit,          // m(args)   # receiver is self
     VM_CALL_VCALL_bit,          // m         # method call that looks like a local variable
-    VM_CALL_ARGS_SIMPLE_bit,    // (ci->flag & (SPLAT|BLOCKARG)) && blockiseq == NULL && ci->kw_arg == NULL
+    VM_CALL_ARGS_SIMPLE_bit,    // !(ci->flag & (SPLAT|BLOCKARG|KWARG|KW_SPLAT|FORWARDING)) && !has_block_iseq
     VM_CALL_KWARG_bit,          // has kwarg
     VM_CALL_KW_SPLAT_bit,       // m(**opts)
     VM_CALL_TAILCALL_bit,       // located at tail position

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -12,8 +12,7 @@
 #include "internal/class.h"
 #include "shape.h"
 
-enum vm_call_flag_bits
-{
+enum vm_call_flag_bits {
     VM_CALL_ARGS_SPLAT_bit,     // m(*args)
     VM_CALL_ARGS_BLOCKARG_bit,  // m(&block)
     VM_CALL_FCALL_bit,          // m(args)   # receiver is self


### PR DESCRIPTION
The comment for that field did not match its actual value. This corrects it. In the process, it changes the "set-site" slightly so it matches that new comment (_no change to functionality, just readability_).