### PR TITLE
[Bug #20598] Fix corruption of internal encoding string

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -1788,7 +1788,7 @@ static int
 rb_enc_name_list_i(st_data_t name, st_data_t idx, st_data_t arg)
 {
     VALUE ary = (VALUE)arg;
-    VALUE str = rb_fstring_cstr((char *)name);
+    VALUE str = rb_interned_str_cstr((char *)name);
     rb_ary_push(ary, str);
     return ST_CONTINUE;
 }
@@ -1833,7 +1833,7 @@ rb_enc_aliases_enc_i(st_data_t name, st_data_t orig, st_data_t arg)
         str = rb_fstring_cstr(rb_enc_name(enc));
         rb_ary_store(ary, idx, str);
     }
-    key = rb_fstring_cstr((char *)name);
+    key = rb_interned_str_cstr((char *)name);
     rb_hash_aset(aliases, key, str);
     return ST_CONTINUE;
 }

--- a/test/ruby/test_m17n.rb
+++ b/test/ruby/test_m17n.rb
@@ -1722,14 +1722,20 @@ class TestM17N < Test::Unit::TestCase
   end
 
   def test_encoding_names_of_default_internal
-    # [Bug #20595]
-    assert_separately(%w(-W0), "#{<<~"begin;"}\n#{<<~"end;"}")
-    begin;
-      Encoding.default_internal = Encoding::ASCII_8BIT
-      names = Encoding.default_internal.names
-      Encoding.default_internal = nil
-      assert_include names, "int" + "ernal", "[Bug #20595]"
-    end;
+    # [Bug #20595] [Bug #20598]
+    [
+      "default_internal.names",
+      "name_list",
+      "aliases.keys"
+    ].each do |method|
+      assert_separately(%w(-W0), <<~RUBY)
+        exp_name = "int" + "ernal"
+        Encoding.default_internal = Encoding::ASCII_8BIT
+        name = Encoding.#{method}.find { |x| x == exp_name }
+        Encoding.default_internal = nil
+        assert_equal exp_name, name, "Encoding.#{method} [Bug #20595] [Bug #20598]"
+      RUBY
+    end
   end
 
   def test_greek_capital_gap


### PR DESCRIPTION
Just like [Bug #20595], Encoding#name_list and Encoding#aliases can have their strings corrupted when Encoding.default_internal is set to nil.