### PR TITLE
YJIT: Fix `cargo doc --document-private-items` warnings [ci skip]

### DIFF
--- a/yjit/src/asm/arm64/arg/bitmask_imm.rs
+++ b/yjit/src/asm/arm64/arg/bitmask_imm.rs
@@ -42,7 +42,7 @@ impl TryFrom<u64> for BitmaskImmediate {
     /// Attempt to convert a u64 into a BitmaskImmediate.
     ///
     /// The implementation here is largely based on this blog post:
-    /// https://dougallj.wordpress.com/2021/10/30/bit-twiddling-optimising-aarch64-logical-immediate-encoding-and-decoding/
+    /// <https://dougallj.wordpress.com/2021/10/30/bit-twiddling-optimising-aarch64-logical-immediate-encoding-and-decoding/>
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         if value == 0 || value == u64::MAX {
             return Err(());

--- a/yjit/src/asm/arm64/arg/sys_reg.rs
+++ b/yjit/src/asm/arm64/arg/sys_reg.rs
@@ -1,6 +1,6 @@
 /// The encoded representation of an A64 system register.
-/// https://developer.arm.com/documentation/ddi0601/2022-06/AArch64-Registers/
+/// <https://developer.arm.com/documentation/ddi0601/2022-06/AArch64-Registers/>
 pub enum SystemRegister {
-    /// https://developer.arm.com/documentation/ddi0601/2022-06/AArch64-Registers/NZCV--Condition-Flags?lang=en
+    /// <https://developer.arm.com/documentation/ddi0601/2022-06/AArch64-Registers/NZCV--Condition-Flags?lang=en>
     NZCV = 0b1_011_0100_0010_000
 }

--- a/yjit/src/asm/arm64/inst/atomic.rs
+++ b/yjit/src/asm/arm64/inst/atomic.rs
@@ -43,13 +43,13 @@ pub struct Atomic {
 
 impl Atomic {
     /// LDADDAL
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDADD--LDADDA--LDADDAL--LDADDL--Atomic-add-on-word-or-doubleword-in-memory-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDADD--LDADDA--LDADDAL--LDADDL--Atomic-add-on-word-or-doubleword-in-memory-?lang=en>
     pub fn ldaddal(rs: u8, rt: u8, rn: u8, num_bits: u8) -> Self {
         Self { rt, rn, rs, size: num_bits.into() }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en>
 const FAMILY: u32 = 0b0100;
 
 impl From<Atomic> for u32 {

--- a/yjit/src/asm/arm64/inst/branch.rs
+++ b/yjit/src/asm/arm64/inst/branch.rs
@@ -28,25 +28,25 @@ pub struct Branch {
 
 impl Branch {
     /// BR
-    /// https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/BR--Branch-to-Register-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/BR--Branch-to-Register-?lang=en>
     pub fn br(rn: u8) -> Self {
         Self { rn, op: Op::BR }
     }
 
     /// BLR
-    /// https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/BLR--Branch-with-Link-to-Register-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/BLR--Branch-with-Link-to-Register-?lang=en>
     pub fn blr(rn: u8) -> Self {
         Self { rn, op: Op::BLR }
     }
 
     /// RET
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/RET--Return-from-subroutine-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/RET--Return-from-subroutine-?lang=en>
     pub fn ret(rn: u8) -> Self {
         Self { rn, op: Op::RET }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en>
 const FAMILY: u32 = 0b101;
 
 impl From<Branch> for u32 {

--- a/yjit/src/asm/arm64/inst/branch_cond.rs
+++ b/yjit/src/asm/arm64/inst/branch_cond.rs
@@ -19,13 +19,13 @@ pub struct BranchCond {
 
 impl BranchCond {
     /// B.cond
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/B-cond--Branch-conditionally-
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/B-cond--Branch-conditionally->
     pub fn bcond(cond: u8, offset: InstructionOffset) -> Self {
         Self { cond, offset }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en>
 const FAMILY: u32 = 0b101;
 
 impl From<BranchCond> for u32 {

--- a/yjit/src/asm/arm64/inst/breakpoint.rs
+++ b/yjit/src/asm/arm64/inst/breakpoint.rs
@@ -13,13 +13,13 @@ pub struct Breakpoint {
 
 impl Breakpoint {
     /// BRK
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/BRK--Breakpoint-instruction-
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/BRK--Breakpoint-instruction->
     pub fn brk(imm16: u16) -> Self {
         Self { imm16 }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en#control
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en#control>
 const FAMILY: u32 = 0b101;
 
 impl From<Breakpoint> for u32 {

--- a/yjit/src/asm/arm64/inst/call.rs
+++ b/yjit/src/asm/arm64/inst/call.rs
@@ -29,19 +29,19 @@ pub struct Call {
 
 impl Call {
     /// B
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/B--Branch-
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/B--Branch->
     pub fn b(offset: InstructionOffset) -> Self {
         Self { offset, op: Op::Branch }
     }
 
     /// BL
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/BL--Branch-with-Link-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/BL--Branch-with-Link-?lang=en>
     pub fn bl(offset: InstructionOffset) -> Self {
         Self { offset, op: Op::BranchWithLink }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en>
 const FAMILY: u32 = 0b101;
 
 impl From<Call> for u32 {

--- a/yjit/src/asm/arm64/inst/conditional.rs
+++ b/yjit/src/asm/arm64/inst/conditional.rs
@@ -28,13 +28,13 @@ pub struct Conditional {
 
 impl Conditional {
     /// CSEL
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/CSEL--Conditional-Select-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/CSEL--Conditional-Select-?lang=en>
     pub fn csel(rd: u8, rn: u8, rm: u8, cond: u8, num_bits: u8) -> Self {
         Self { rd, rn, cond, rm, sf: num_bits.into() }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Register?lang=en#condsel
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Register?lang=en#condsel>
 const FAMILY: u32 = 0b101;
 
 impl From<Conditional> for u32 {

--- a/yjit/src/asm/arm64/inst/data_imm.rs
+++ b/yjit/src/asm/arm64/inst/data_imm.rs
@@ -44,37 +44,37 @@ pub struct DataImm {
 
 impl DataImm {
     /// ADD (immediate)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ADD--immediate---Add--immediate--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ADD--immediate---Add--immediate--?lang=en>
     pub fn add(rd: u8, rn: u8, imm: ShiftedImmediate, num_bits: u8) -> Self {
         Self { rd, rn, imm, s: S::LeaveFlags, op: Op::Add, sf: num_bits.into() }
     }
 
     /// ADDS (immediate, set flags)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ADDS--immediate---Add--immediate---setting-flags-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ADDS--immediate---Add--immediate---setting-flags-?lang=en>
     pub fn adds(rd: u8, rn: u8, imm: ShiftedImmediate, num_bits: u8) -> Self {
         Self { rd, rn, imm, s: S::UpdateFlags, op: Op::Add, sf: num_bits.into() }
     }
 
     /// CMP (immediate)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/CMP--immediate---Compare--immediate---an-alias-of-SUBS--immediate--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/CMP--immediate---Compare--immediate---an-alias-of-SUBS--immediate--?lang=en>
     pub fn cmp(rn: u8, imm: ShiftedImmediate, num_bits: u8) -> Self {
         Self::subs(31, rn, imm, num_bits)
     }
 
     /// SUB (immediate)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/SUB--immediate---Subtract--immediate--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/SUB--immediate---Subtract--immediate--?lang=en>
     pub fn sub(rd: u8, rn: u8, imm: ShiftedImmediate, num_bits: u8) -> Self {
         Self { rd, rn, imm, s: S::LeaveFlags, op: Op::Sub, sf: num_bits.into() }
     }
 
     /// SUBS (immediate, set flags)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/SUBS--immediate---Subtract--immediate---setting-flags-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/SUBS--immediate---Subtract--immediate---setting-flags-?lang=en>
     pub fn subs(rd: u8, rn: u8, imm: ShiftedImmediate, num_bits: u8) -> Self {
         Self { rd, rn, imm, s: S::UpdateFlags, op: Op::Sub, sf: num_bits.into() }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Immediate?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Immediate?lang=en>
 const FAMILY: u32 = 0b1000;
 
 impl From<DataImm> for u32 {

--- a/yjit/src/asm/arm64/inst/data_reg.rs
+++ b/yjit/src/asm/arm64/inst/data_reg.rs
@@ -57,7 +57,7 @@ pub struct DataReg {
 
 impl DataReg {
     /// ADD (shifted register)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ADD--shifted-register---Add--shifted-register--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ADD--shifted-register---Add--shifted-register--?lang=en>
     pub fn add(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
         Self {
             rd,
@@ -72,7 +72,7 @@ impl DataReg {
     }
 
     /// ADDS (shifted register, set flags)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ADDS--shifted-register---Add--shifted-register---setting-flags-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ADDS--shifted-register---Add--shifted-register---setting-flags-?lang=en>
     pub fn adds(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
         Self {
             rd,
@@ -87,13 +87,13 @@ impl DataReg {
     }
 
     /// CMP (shifted register)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/CMP--shifted-register---Compare--shifted-register---an-alias-of-SUBS--shifted-register--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/CMP--shifted-register---Compare--shifted-register---an-alias-of-SUBS--shifted-register--?lang=en>
     pub fn cmp(rn: u8, rm: u8, num_bits: u8) -> Self {
         Self::subs(31, rn, rm, num_bits)
     }
 
     /// SUB (shifted register)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/SUB--shifted-register---Subtract--shifted-register--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/SUB--shifted-register---Subtract--shifted-register--?lang=en>
     pub fn sub(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
         Self {
             rd,
@@ -108,7 +108,7 @@ impl DataReg {
     }
 
     /// SUBS (shifted register, set flags)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/SUBS--shifted-register---Subtract--shifted-register---setting-flags-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/SUBS--shifted-register---Subtract--shifted-register---setting-flags-?lang=en>
     pub fn subs(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
         Self {
             rd,
@@ -123,7 +123,7 @@ impl DataReg {
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Register?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Register?lang=en>
 const FAMILY: u32 = 0b0101;
 
 impl From<DataReg> for u32 {

--- a/yjit/src/asm/arm64/inst/halfword_imm.rs
+++ b/yjit/src/asm/arm64/inst/halfword_imm.rs
@@ -53,43 +53,43 @@ pub struct HalfwordImm {
 
 impl HalfwordImm {
     /// LDRH
-    /// https://developer.arm.com/documentation/ddi0602/2022-06/Base-Instructions/LDRH--immediate---Load-Register-Halfword--immediate--
+    /// <https://developer.arm.com/documentation/ddi0602/2022-06/Base-Instructions/LDRH--immediate---Load-Register-Halfword--immediate-->
     pub fn ldrh(rt: u8, rn: u8, imm12: i16) -> Self {
         Self { rt, rn, index: Index::None, imm: imm12, op: Op::Load }
     }
 
     /// LDRH (pre-index)
-    /// https://developer.arm.com/documentation/ddi0602/2022-06/Base-Instructions/LDRH--immediate---Load-Register-Halfword--immediate--
+    /// <https://developer.arm.com/documentation/ddi0602/2022-06/Base-Instructions/LDRH--immediate---Load-Register-Halfword--immediate-->
     pub fn ldrh_pre(rt: u8, rn: u8, imm9: i16) -> Self {
         Self { rt, rn, index: Index::PreIndex, imm: imm9, op: Op::Load }
     }
 
     /// LDRH (post-index)
-    /// https://developer.arm.com/documentation/ddi0602/2022-06/Base-Instructions/LDRH--immediate---Load-Register-Halfword--immediate--
+    /// <https://developer.arm.com/documentation/ddi0602/2022-06/Base-Instructions/LDRH--immediate---Load-Register-Halfword--immediate-->
     pub fn ldrh_post(rt: u8, rn: u8, imm9: i16) -> Self {
         Self { rt, rn, index: Index::PostIndex, imm: imm9, op: Op::Load }
     }
 
     /// STRH
-    /// https://developer.arm.com/documentation/ddi0602/2022-06/Base-Instructions/STRH--immediate---Store-Register-Halfword--immediate--
+    /// <https://developer.arm.com/documentation/ddi0602/2022-06/Base-Instructions/STRH--immediate---Store-Register-Halfword--immediate-->
     pub fn strh(rt: u8, rn: u8, imm12: i16) -> Self {
         Self { rt, rn, index: Index::None, imm: imm12, op: Op::Store }
     }
 
     /// STRH (pre-index)
-    /// https://developer.arm.com/documentation/ddi0602/2022-06/Base-Instructions/STRH--immediate---Store-Register-Halfword--immediate--
+    /// <https://developer.arm.com/documentation/ddi0602/2022-06/Base-Instructions/STRH--immediate---Store-Register-Halfword--immediate-->
     pub fn strh_pre(rt: u8, rn: u8, imm9: i16) -> Self {
         Self { rt, rn, index: Index::PreIndex, imm: imm9, op: Op::Store }
     }
 
     /// STRH (post-index)
-    /// https://developer.arm.com/documentation/ddi0602/2022-06/Base-Instructions/STRH--immediate---Store-Register-Halfword--immediate--
+    /// <https://developer.arm.com/documentation/ddi0602/2022-06/Base-Instructions/STRH--immediate---Store-Register-Halfword--immediate-->
     pub fn strh_post(rt: u8, rn: u8, imm9: i16) -> Self {
         Self { rt, rn, index: Index::PostIndex, imm: imm9, op: Op::Store }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en>
 const FAMILY: u32 = 0b111100;
 
 impl From<HalfwordImm> for u32 {

--- a/yjit/src/asm/arm64/inst/load_literal.rs
+++ b/yjit/src/asm/arm64/inst/load_literal.rs
@@ -40,13 +40,13 @@ pub struct LoadLiteral {
 
 impl LoadLiteral {
     /// LDR (load literal)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDR--literal---Load-Register--literal--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDR--literal---Load-Register--literal--?lang=en>
     pub fn ldr_literal(rt: u8, offset: InstructionOffset, num_bits: u8) -> Self {
         Self { rt, offset, opc: num_bits.into() }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en>
 const FAMILY: u32 = 0b0100;
 
 impl From<LoadLiteral> for u32 {

--- a/yjit/src/asm/arm64/inst/load_register.rs
+++ b/yjit/src/asm/arm64/inst/load_register.rs
@@ -61,13 +61,13 @@ pub struct LoadRegister {
 
 impl LoadRegister {
     /// LDR
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDR--register---Load-Register--register--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDR--register---Load-Register--register--?lang=en>
     pub fn ldr(rt: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
         Self { rt, rn, s: S::NoShift, option: Option::LSL, rm, size: num_bits.into() }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en>
 const FAMILY: u32 = 0b0100;
 
 impl From<LoadRegister> for u32 {

--- a/yjit/src/asm/arm64/inst/load_store.rs
+++ b/yjit/src/asm/arm64/inst/load_store.rs
@@ -66,67 +66,67 @@ pub struct LoadStore {
 
 impl LoadStore {
     /// LDR (immediate, post-index)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/LDR--immediate---Load-Register--immediate--
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/LDR--immediate---Load-Register--immediate-->
     pub fn ldr_post(rt: u8, rn: u8, imm9: i16, num_bits: u8) -> Self {
         Self { rt, rn, idx: Index::PostIndex, imm9, opc: Opc::LDR, size: num_bits.into() }
     }
 
     /// LDR (immediate, pre-index)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/LDR--immediate---Load-Register--immediate--
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/LDR--immediate---Load-Register--immediate-->
     pub fn ldr_pre(rt: u8, rn: u8, imm9: i16, num_bits: u8) -> Self {
         Self { rt, rn, idx: Index::PreIndex, imm9, opc: Opc::LDR, size: num_bits.into() }
     }
 
     /// LDUR (load register, unscaled)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDUR--Load-Register--unscaled--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDUR--Load-Register--unscaled--?lang=en>
     pub fn ldur(rt: u8, rn: u8, imm9: i16, num_bits: u8) -> Self {
         Self { rt, rn, idx: Index::None, imm9, opc: Opc::LDR, size: num_bits.into() }
     }
 
     /// LDURH Load Register Halfword (unscaled)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDURH--Load-Register-Halfword--unscaled--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDURH--Load-Register-Halfword--unscaled--?lang=en>
     pub fn ldurh(rt: u8, rn: u8, imm9: i16) -> Self {
         Self { rt, rn, idx: Index::None, imm9, opc: Opc::LDR, size: Size::Size16 }
     }
 
     /// LDURB (load register, byte, unscaled)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDURB--Load-Register-Byte--unscaled--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDURB--Load-Register-Byte--unscaled--?lang=en>
     pub fn ldurb(rt: u8, rn: u8, imm9: i16) -> Self {
         Self { rt, rn, idx: Index::None, imm9, opc: Opc::LDR, size: Size::Size8 }
     }
 
     /// LDURSW (load register, unscaled, signed)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDURSW--Load-Register-Signed-Word--unscaled--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDURSW--Load-Register-Signed-Word--unscaled--?lang=en>
     pub fn ldursw(rt: u8, rn: u8, imm9: i16) -> Self {
         Self { rt, rn, idx: Index::None, imm9, opc: Opc::LDURSW, size: Size::Size32 }
     }
 
     /// STR (immediate, post-index)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/STR--immediate---Store-Register--immediate--
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/STR--immediate---Store-Register--immediate-->
     pub fn str_post(rt: u8, rn: u8, imm9: i16, num_bits: u8) -> Self {
         Self { rt, rn, idx: Index::PostIndex, imm9, opc: Opc::STR, size: num_bits.into() }
     }
 
     /// STR (immediate, pre-index)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/STR--immediate---Store-Register--immediate--
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/STR--immediate---Store-Register--immediate-->
     pub fn str_pre(rt: u8, rn: u8, imm9: i16, num_bits: u8) -> Self {
         Self { rt, rn, idx: Index::PreIndex, imm9, opc: Opc::STR, size: num_bits.into() }
     }
 
     /// STUR (store register, unscaled)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/STUR--Store-Register--unscaled--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/STUR--Store-Register--unscaled--?lang=en>
     pub fn stur(rt: u8, rn: u8, imm9: i16, num_bits: u8) -> Self {
         Self { rt, rn, idx: Index::None, imm9, opc: Opc::STR, size: num_bits.into() }
     }
 
     /// STURH (store register, halfword, unscaled)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/STURH--Store-Register-Halfword--unscaled--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/STURH--Store-Register-Halfword--unscaled--?lang=en>
     pub fn sturh(rt: u8, rn: u8, imm9: i16) -> Self {
         Self { rt, rn, idx: Index::None, imm9, opc: Opc::STR, size: Size::Size16 }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en>
 const FAMILY: u32 = 0b0100;
 
 impl From<LoadStore> for u32 {

--- a/yjit/src/asm/arm64/inst/load_store_exclusive.rs
+++ b/yjit/src/asm/arm64/inst/load_store_exclusive.rs
@@ -52,19 +52,19 @@ pub struct LoadStoreExclusive {
 
 impl LoadStoreExclusive {
     /// LDAXR
-    /// https://developer.arm.com/documentation/ddi0602/2021-12/Base-Instructions/LDAXR--Load-Acquire-Exclusive-Register-
+    /// <https://developer.arm.com/documentation/ddi0602/2021-12/Base-Instructions/LDAXR--Load-Acquire-Exclusive-Register->
     pub fn ldaxr(rt: u8, rn: u8, num_bits: u8) -> Self {
         Self { rt, rn, rs: 31, op: Op::Load, size: num_bits.into() }
     }
 
     /// STLXR
-    /// https://developer.arm.com/documentation/ddi0602/2021-12/Base-Instructions/STLXR--Store-Release-Exclusive-Register-
+    /// <https://developer.arm.com/documentation/ddi0602/2021-12/Base-Instructions/STLXR--Store-Release-Exclusive-Register->
     pub fn stlxr(rs: u8, rt: u8, rn: u8, num_bits: u8) -> Self {
         Self { rt, rn, rs, op: Op::Store, size: num_bits.into() }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en>
 const FAMILY: u32 = 0b0100;
 
 impl From<LoadStoreExclusive> for u32 {

--- a/yjit/src/asm/arm64/inst/logical_imm.rs
+++ b/yjit/src/asm/arm64/inst/logical_imm.rs
@@ -44,43 +44,43 @@ pub struct LogicalImm {
 
 impl LogicalImm {
     /// AND (bitmask immediate)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/AND--immediate---Bitwise-AND--immediate--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/AND--immediate---Bitwise-AND--immediate--?lang=en>
     pub fn and(rd: u8, rn: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
         Self { rd, rn, imm, opc: Opc::And, sf: num_bits.into() }
     }
 
     /// ANDS (bitmask immediate)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ANDS--immediate---Bitwise-AND--immediate---setting-flags-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ANDS--immediate---Bitwise-AND--immediate---setting-flags-?lang=en>
     pub fn ands(rd: u8, rn: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
         Self { rd, rn, imm, opc: Opc::Ands, sf: num_bits.into() }
     }
 
     /// EOR (bitmask immediate)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/EOR--immediate---Bitwise-Exclusive-OR--immediate--
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/EOR--immediate---Bitwise-Exclusive-OR--immediate-->
     pub fn eor(rd: u8, rn: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
         Self { rd, rn, imm, opc: Opc::Eor, sf: num_bits.into() }
     }
 
     /// MOV (bitmask immediate)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/MOV--bitmask-immediate---Move--bitmask-immediate---an-alias-of-ORR--immediate--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/MOV--bitmask-immediate---Move--bitmask-immediate---an-alias-of-ORR--immediate--?lang=en>
     pub fn mov(rd: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
         Self { rd, rn: 0b11111, imm, opc: Opc::Orr, sf: num_bits.into() }
     }
 
     /// ORR (bitmask immediate)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORR--immediate---Bitwise-OR--immediate--
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORR--immediate---Bitwise-OR--immediate-->
     pub fn orr(rd: u8, rn: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
         Self { rd, rn, imm, opc: Opc::Orr, sf: num_bits.into() }
     }
 
     /// TST (bitmask immediate)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/TST--immediate---Test-bits--immediate---an-alias-of-ANDS--immediate--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/TST--immediate---Test-bits--immediate---an-alias-of-ANDS--immediate--?lang=en>
     pub fn tst(rn: u8, imm: BitmaskImmediate, num_bits: u8) -> Self {
         Self::ands(31, rn, imm, num_bits)
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Immediate?lang=en#log_imm
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Immediate?lang=en#log_imm>
 const FAMILY: u32 = 0b1001;
 
 impl From<LogicalImm> for u32 {

--- a/yjit/src/asm/arm64/inst/logical_reg.rs
+++ b/yjit/src/asm/arm64/inst/logical_reg.rs
@@ -70,55 +70,55 @@ pub struct LogicalReg {
 
 impl LogicalReg {
     /// AND (shifted register)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/AND--shifted-register---Bitwise-AND--shifted-register--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/AND--shifted-register---Bitwise-AND--shifted-register--?lang=en>
     pub fn and(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
         Self { rd, rn, imm6: 0, rm, n: N::No, shift: Shift::LSL, opc: Opc::And, sf: num_bits.into() }
     }
 
     /// ANDS (shifted register)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ANDS--shifted-register---Bitwise-AND--shifted-register---setting-flags-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/ANDS--shifted-register---Bitwise-AND--shifted-register---setting-flags-?lang=en>
     pub fn ands(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
         Self { rd, rn, imm6: 0, rm, n: N::No, shift: Shift::LSL, opc: Opc::Ands, sf: num_bits.into() }
     }
 
     /// EOR (shifted register)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/EOR--shifted-register---Bitwise-Exclusive-OR--shifted-register--
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/EOR--shifted-register---Bitwise-Exclusive-OR--shifted-register-->
     pub fn eor(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
         Self { rd, rn, imm6: 0, rm, n: N::No, shift: Shift::LSL, opc: Opc::Eor, sf: num_bits.into() }
     }
 
     /// MOV (register)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/MOV--register---Move--register---an-alias-of-ORR--shifted-register--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/MOV--register---Move--register---an-alias-of-ORR--shifted-register--?lang=en>
     pub fn mov(rd: u8, rm: u8, num_bits: u8) -> Self {
         Self { rd, rn: 0b11111, imm6: 0, rm, n: N::No, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
     }
 
     /// MVN (shifted register)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/MVN--Bitwise-NOT--an-alias-of-ORN--shifted-register--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/MVN--Bitwise-NOT--an-alias-of-ORN--shifted-register--?lang=en>
     pub fn mvn(rd: u8, rm: u8, num_bits: u8) -> Self {
         Self { rd, rn: 0b11111, imm6: 0, rm, n: N::Yes, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
     }
 
     /// ORN (shifted register)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORN--shifted-register---Bitwise-OR-NOT--shifted-register--
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORN--shifted-register---Bitwise-OR-NOT--shifted-register-->
     pub fn orn(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
         Self { rd, rn, imm6: 0, rm, n: N::Yes, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
     }
 
     /// ORR (shifted register)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORR--shifted-register---Bitwise-OR--shifted-register--
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ORR--shifted-register---Bitwise-OR--shifted-register-->
     pub fn orr(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
         Self { rd, rn, imm6: 0, rm, n: N::No, shift: Shift::LSL, opc: Opc::Orr, sf: num_bits.into() }
     }
 
     /// TST (shifted register)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/TST--shifted-register---Test--shifted-register---an-alias-of-ANDS--shifted-register--?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/TST--shifted-register---Test--shifted-register---an-alias-of-ANDS--shifted-register--?lang=en>
     pub fn tst(rn: u8, rm: u8, num_bits: u8) -> Self {
         Self { rd: 31, rn, imm6: 0, rm, n: N::No, shift: Shift::LSL, opc: Opc::Ands, sf: num_bits.into() }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Register?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Register?lang=en>
 const FAMILY: u32 = 0b0101;
 
 impl From<LogicalReg> for u32 {

--- a/yjit/src/asm/arm64/inst/madd.rs
+++ b/yjit/src/asm/arm64/inst/madd.rs
@@ -28,7 +28,7 @@ pub struct MAdd {
 
 impl MAdd {
     /// MUL
-    /// https://developer.arm.com/documentation/ddi0602/2023-06/Base-Instructions/MUL--Multiply--an-alias-of-MADD-
+    /// <https://developer.arm.com/documentation/ddi0602/2023-06/Base-Instructions/MUL--Multiply--an-alias-of-MADD->
     pub fn mul(rd: u8, rn: u8, rm: u8, num_bits: u8) -> Self {
         Self { rd, rn, ra: 0b11111, rm, sf: num_bits.into() }
     }

--- a/yjit/src/asm/arm64/inst/mov.rs
+++ b/yjit/src/asm/arm64/inst/mov.rs
@@ -56,19 +56,19 @@ pub struct Mov {
 
 impl Mov {
     /// MOVK
-    /// https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/MOVK--Move-wide-with-keep-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/MOVK--Move-wide-with-keep-?lang=en>
     pub fn movk(rd: u8, imm16: u16, hw: u8, num_bits: u8) -> Self {
         Self { rd, imm16, hw: hw.into(), op: Op::MOVK, sf: num_bits.into() }
     }
 
     /// MOVZ
-    /// https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/MOVZ--Move-wide-with-zero-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/MOVZ--Move-wide-with-zero-?lang=en>
     pub fn movz(rd: u8, imm16: u16, hw: u8, num_bits: u8) -> Self {
         Self { rd, imm16, hw: hw.into(), op: Op::MOVZ, sf: num_bits.into() }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Immediate?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Immediate?lang=en>
 const FAMILY: u32 = 0b1000;
 
 impl From<Mov> for u32 {

--- a/yjit/src/asm/arm64/inst/nop.rs
+++ b/yjit/src/asm/arm64/inst/nop.rs
@@ -10,7 +10,7 @@ pub struct Nop;
 
 impl Nop {
     /// NOP
-    /// https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/NOP--No-Operation-
+    /// <https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/NOP--No-Operation->
     pub fn nop() -> Self {
         Self {}
     }

--- a/yjit/src/asm/arm64/inst/pc_rel.rs
+++ b/yjit/src/asm/arm64/inst/pc_rel.rs
@@ -30,19 +30,19 @@ pub struct PCRelative {
 
 impl PCRelative {
     /// ADR
-    /// https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/ADR--Form-PC-relative-address-
+    /// <https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/ADR--Form-PC-relative-address->
     pub fn adr(rd: u8, imm: i32) -> Self {
         Self { rd, imm, op: Op::ADR }
     }
 
     /// ADRP
-    /// https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/ADRP--Form-PC-relative-address-to-4KB-page-
+    /// <https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/ADRP--Form-PC-relative-address-to-4KB-page->
     pub fn adrp(rd: u8, imm: i32) -> Self {
         Self { rd, imm: imm >> 12, op: Op::ADRP }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Immediate?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Immediate?lang=en>
 const FAMILY: u32 = 0b1000;
 
 impl From<PCRelative> for u32 {

--- a/yjit/src/asm/arm64/inst/reg_pair.rs
+++ b/yjit/src/asm/arm64/inst/reg_pair.rs
@@ -68,49 +68,49 @@ impl RegisterPair {
     }
 
     /// LDP (signed offset)
-    /// LDP <Xt1>, <Xt2>, [<Xn|SP>{, #<imm>}]
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDP--Load-Pair-of-Registers-?lang=en
+    /// `LDP <Xt1>, <Xt2>, [<Xn|SP>{, #<imm>}]`
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDP--Load-Pair-of-Registers-?lang=en>
     pub fn ldp(rt1: u8, rt2: u8, rn: u8, disp: i16, num_bits: u8) -> Self {
         Self::new(rt1, rt2, rn, disp, Index::LoadSignedOffset, num_bits)
     }
 
     /// LDP (pre-index)
-    /// LDP <Xt1>, <Xt2>, [<Xn|SP>, #<imm>]!
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDP--Load-Pair-of-Registers-?lang=en
+    /// `LDP <Xt1>, <Xt2>, [<Xn|SP>, #<imm>]!`
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDP--Load-Pair-of-Registers-?lang=en>
     pub fn ldp_pre(rt1: u8, rt2: u8, rn: u8, disp: i16, num_bits: u8) -> Self {
         Self::new(rt1, rt2, rn, disp, Index::LoadPreIndex, num_bits)
     }
 
     /// LDP (post-index)
-    /// LDP <Xt1>, <Xt2>, [<Xn|SP>], #<imm>
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDP--Load-Pair-of-Registers-?lang=en
+    /// `LDP <Xt1>, <Xt2>, [<Xn|SP>], #<imm>`
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/LDP--Load-Pair-of-Registers-?lang=en>
     pub fn ldp_post(rt1: u8, rt2: u8, rn: u8, disp: i16, num_bits: u8) -> Self {
         Self::new(rt1, rt2, rn, disp, Index::LoadPostIndex, num_bits)
     }
 
     /// STP (signed offset)
-    /// STP <Xt1>, <Xt2>, [<Xn|SP>{, #<imm>}]
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/STP--Store-Pair-of-Registers-?lang=en
+    /// `STP <Xt1>, <Xt2>, [<Xn|SP>{, #<imm>}]`
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/STP--Store-Pair-of-Registers-?lang=en>
     pub fn stp(rt1: u8, rt2: u8, rn: u8, disp: i16, num_bits: u8) -> Self {
         Self::new(rt1, rt2, rn, disp, Index::StoreSignedOffset, num_bits)
     }
 
     /// STP (pre-index)
-    /// STP <Xt1>, <Xt2>, [<Xn|SP>, #<imm>]!
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/STP--Store-Pair-of-Registers-?lang=en
+    /// `STP <Xt1>, <Xt2>, [<Xn|SP>, #<imm>]!`
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/STP--Store-Pair-of-Registers-?lang=en>
     pub fn stp_pre(rt1: u8, rt2: u8, rn: u8, disp: i16, num_bits: u8) -> Self {
         Self::new(rt1, rt2, rn, disp, Index::StorePreIndex, num_bits)
     }
 
     /// STP (post-index)
-    /// STP <Xt1>, <Xt2>, [<Xn|SP>], #<imm>
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/STP--Store-Pair-of-Registers-?lang=en
+    /// `STP <Xt1>, <Xt2>, [<Xn|SP>], #<imm>`
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/STP--Store-Pair-of-Registers-?lang=en>
     pub fn stp_post(rt1: u8, rt2: u8, rn: u8, disp: i16, num_bits: u8) -> Self {
         Self::new(rt1, rt2, rn, disp, Index::StorePostIndex, num_bits)
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Loads-and-Stores?lang=en>
 const FAMILY: u32 = 0b0100;
 
 impl From<RegisterPair> for u32 {

--- a/yjit/src/asm/arm64/inst/sbfm.rs
+++ b/yjit/src/asm/arm64/inst/sbfm.rs
@@ -32,7 +32,7 @@ pub struct SBFM {
 
 impl SBFM {
     /// ASR
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ASR--immediate---Arithmetic-Shift-Right--immediate---an-alias-of-SBFM-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/ASR--immediate---Arithmetic-Shift-Right--immediate---an-alias-of-SBFM-?lang=en>
     pub fn asr(rd: u8, rn: u8, shift: u8, num_bits: u8) -> Self {
         let (imms, n) = if num_bits == 64 {
             (0b111111, true)
@@ -44,13 +44,13 @@ impl SBFM {
     }
 
     /// SXTW
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/SXTW--Sign-Extend-Word--an-alias-of-SBFM-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/SXTW--Sign-Extend-Word--an-alias-of-SBFM-?lang=en>
     pub fn sxtw(rd: u8, rn: u8) -> Self {
         Self { rd, rn, immr: 0, imms: 31, n: true, sf: Sf::Sf64 }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Immediate?lang=en#bitfield
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Immediate?lang=en#bitfield>
 const FAMILY: u32 = 0b1001;
 
 impl From<SBFM> for u32 {

--- a/yjit/src/asm/arm64/inst/shift_imm.rs
+++ b/yjit/src/asm/arm64/inst/shift_imm.rs
@@ -38,13 +38,13 @@ pub struct ShiftImm {
 
 impl ShiftImm {
     /// LSL (immediate)
-    /// https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/LSL--immediate---Logical-Shift-Left--immediate---an-alias-of-UBFM-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/LSL--immediate---Logical-Shift-Left--immediate---an-alias-of-UBFM-?lang=en>
     pub fn lsl(rd: u8, rn: u8, shift: u8, num_bits: u8) -> Self {
         ShiftImm { rd, rn, shift, opc: Opc::LSL, sf: num_bits.into() }
     }
 
     /// LSR (immediate)
-    /// https://developer.arm.com/documentation/ddi0602/2021-12/Base-Instructions/LSR--immediate---Logical-Shift-Right--immediate---an-alias-of-UBFM-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0602/2021-12/Base-Instructions/LSR--immediate---Logical-Shift-Right--immediate---an-alias-of-UBFM-?lang=en>
     pub fn lsr(rd: u8, rn: u8, shift: u8, num_bits: u8) -> Self {
         ShiftImm { rd, rn, shift, opc: Opc::LSR, sf: num_bits.into() }
     }
@@ -85,7 +85,7 @@ impl ShiftImm {
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Immediate?lang=en#bitfield
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Data-Processing----Immediate?lang=en#bitfield>
 const FAMILY: u32 = 0b10011;
 
 impl From<ShiftImm> for u32 {

--- a/yjit/src/asm/arm64/inst/smulh.rs
+++ b/yjit/src/asm/arm64/inst/smulh.rs
@@ -22,7 +22,7 @@ pub struct SMulH {
 
 impl SMulH {
     /// SMULH
-    /// https://developer.arm.com/documentation/ddi0602/2023-06/Base-Instructions/SMULH--Signed-Multiply-High-
+    /// <https://developer.arm.com/documentation/ddi0602/2023-06/Base-Instructions/SMULH--Signed-Multiply-High->
     pub fn smulh(rd: u8, rn: u8, rm: u8) -> Self {
         Self { rd, rn, ra: 0b11111, rm }
     }

--- a/yjit/src/asm/arm64/inst/sys_reg.rs
+++ b/yjit/src/asm/arm64/inst/sys_reg.rs
@@ -32,19 +32,19 @@ pub struct SysReg {
 
 impl SysReg {
     /// MRS (register)
-    /// https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/MRS--Move-System-Register-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/MRS--Move-System-Register-?lang=en>
     pub fn mrs(rt: u8, systemreg: SystemRegister) -> Self {
         SysReg { rt, systemreg, l: L::MRS }
     }
 
     /// MSR (register)
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/MSR--register---Move-general-purpose-register-to-System-Register-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/MSR--register---Move-general-purpose-register-to-System-Register-?lang=en>
     pub fn msr(systemreg: SystemRegister, rt: u8) -> Self {
         SysReg { rt, systemreg, l: L::MSR }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en#systemmove
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en#systemmove>
 const FAMILY: u32 = 0b110101010001;
 
 impl From<SysReg> for u32 {

--- a/yjit/src/asm/arm64/inst/test_bit.rs
+++ b/yjit/src/asm/arm64/inst/test_bit.rs
@@ -60,19 +60,19 @@ pub struct TestBit {
 
 impl TestBit {
     /// TBNZ
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/TBNZ--Test-bit-and-Branch-if-Nonzero-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/TBNZ--Test-bit-and-Branch-if-Nonzero-?lang=en>
     pub fn tbnz(rt: u8, bit_num: u8, offset: i16) -> Self {
         Self { rt, imm14: offset, b40: bit_num & 0b11111, op: Op::TBNZ, b5: bit_num.into() }
     }
 
     /// TBZ
-    /// https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/TBZ--Test-bit-and-Branch-if-Zero-?lang=en
+    /// <https://developer.arm.com/documentation/ddi0596/2021-12/Base-Instructions/TBZ--Test-bit-and-Branch-if-Zero-?lang=en>
     pub fn tbz(rt: u8, bit_num: u8, offset: i16) -> Self {
         Self { rt, imm14: offset, b40: bit_num & 0b11111, op: Op::TBZ, b5: bit_num.into() }
     }
 }
 
-/// https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en
+/// <https://developer.arm.com/documentation/ddi0602/2022-03/Index-by-Encoding/Branches--Exception-Generating-and-System-instructions?lang=en>
 const FAMILY: u32 = 0b11011;
 
 impl From<TestBit> for u32 {

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -41,7 +41,7 @@ type InsnGenFn = fn(
 ) -> Option<CodegenStatus>;
 
 /// Ephemeral code generation state.
-/// Represents a [core::Block] while we build it.
+/// Represents a [crate::core::Block] while we build it.
 pub struct JITState<'a> {
     /// Instruction sequence for the compiling block
     pub iseq: IseqPtr,
@@ -1001,7 +1001,7 @@ pub fn gen_entry_chain_guard(
 /// Compile an interpreter entry block to be inserted into an iseq
 /// Returns None if compilation fails.
 /// If jit_exception is true, compile JIT code for handling exceptions.
-/// See [jit_compile_exception] for details.
+/// See jit_compile_exception() for details.
 pub fn gen_entry_prologue(
     cb: &mut CodeBlock,
     ocb: &mut OutlinedCb,

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -3055,7 +3055,7 @@ fn gen_block_series_body(
 /// Generate a block version that is an entry point inserted into an iseq
 /// NOTE: this function assumes that the VM lock has been taken
 /// If jit_exception is true, compile JIT code for handling exceptions.
-/// See [jit_compile_exception] for details.
+/// See jit_compile_exception() for details.
 pub fn gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exception: bool) -> Option<*const u8> {
     // Compute the current instruction index based on the current PC
     let cfp = unsafe { get_ec_cfp(ec) };
@@ -3149,7 +3149,7 @@ pub fn new_pending_entry() -> PendingEntryRef {
 
 c_callable! {
     /// Generated code calls this function with the SysV calling convention.
-    /// See [gen_call_entry_stub_hit].
+    /// See [gen_entry_stub].
     fn entry_stub_hit(entry_ptr: *const c_void, ec: EcPtr) -> *const u8 {
         with_compile_time(|| {
             with_vm_lock(src_loc!(), || {

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -768,17 +768,16 @@ mod manual_defs {
 pub use manual_defs::*;
 
 /// Interned ID values for Ruby symbols and method names.
-/// See [crate::cruby::ID] and usages outside of YJIT.
+/// See [type@crate::cruby::ID] and usages outside of YJIT.
 pub(crate) mod ids {
     use std::sync::atomic::AtomicU64;
     /// Globals to cache IDs on boot. Atomic to use with relaxed ordering
-    /// so reads can happen without `unsafe`. Initialization is done
-    /// single-threaded and release-acquire on [crate::yjit::YJIT_ENABLED]
-    /// makes sure we read the cached values after initialization is done.
+    /// so reads can happen without `unsafe`. Synchronization done through
+    /// the VM lock.
     macro_rules! def_ids {
         ($(name: $ident:ident content: $str:literal)*) => {
             $(
-                #[doc = concat!("[crate::cruby::ID] for `", stringify!($str), "`")]
+                #[doc = concat!("[type@crate::cruby::ID] for `", stringify!($str), "`")]
                 pub static $ident: AtomicU64 = AtomicU64::new(0);
             )*
 

--- a/yjit/src/utils.rs
+++ b/yjit/src/utils.rs
@@ -51,7 +51,7 @@ impl IntoUsize for u8 {
     }
 }
 
-/// The [Into<u64>] Rust does not provide.
+/// The `Into<u64>` Rust does not provide.
 /// Convert to u64 with assurance that the value is preserved.
 /// Currently, `usize::BITS == 64` holds for all platforms we support.
 pub(crate) trait IntoU64 {

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -114,7 +114,7 @@ fn rb_bug_panic_hook() {
 /// Called from C code to begin compiling a function
 /// NOTE: this should be wrapped in RB_VM_LOCK_ENTER(), rb_vm_barrier() on the C side
 /// If jit_exception is true, compile JIT code for handling exceptions.
-/// See [jit_compile_exception] for details.
+/// See jit_compile_exception() for details.
 #[no_mangle]
 pub extern "C" fn rb_yjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exception: bool) -> *const u8 {
     // Don't compile when there is insufficient native stack space


### PR DESCRIPTION
Mostly putting angle brackets around links to follow markdown syntax.
