### PR TITLE
maximum showing line number on btest failure

### DIFF
--- a/bootstraptest/runner.rb
+++ b/bootstraptest/runner.rb
@@ -749,6 +749,8 @@ end
 
 def pretty(src, desc, result)
   src = src.sub(/\A\s*\n/, '')
+  lines = src.lines
+  src = lines[0..20].join + "(...snip)\n" if lines.size > 20
   (/\n/ =~ src ? "\n#{adjust_indent(src)}" : src) + "  #=> #{desc}"
 end
 


### PR DESCRIPTION
Some tests in btest uses long src for btest and it is harmful to check the results. This patch introducing the limitation how many lines of code is shown on failure.