### PR TITLE
[YJIT] Don't expand kwargs on forwarding

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -5121,3 +5121,23 @@ assert_equal 'ok', <<~'RUBY'
 
   ok(["ok"], ->(x) { x })
 RUBY
+
+assert_equal 'ok', <<~'RUBY'
+def baz(a, b)
+  a + b
+end
+
+def bar(...)
+  baz(...)
+end
+
+def foo(a, ...)
+  bar(a, ...)
+end
+
+def test
+  foo("o", "k")
+end
+
+test
+RUBY

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6962,7 +6962,6 @@ fn gen_send_iseq(
     let iseq_has_rest = unsafe { get_iseq_flags_has_rest(iseq) };
     let iseq_has_block_param = unsafe { get_iseq_flags_has_block(iseq) };
     let arg_setup_block = captured_opnd.is_some(); // arg_setup_type: arg_setup_block (invokeblock)
-    let kw_splat = flags & VM_CALL_KW_SPLAT != 0;
 
     // Is this iseq tagged as "forwardable"? Iseqs that take `...` as a
     // parameter are tagged as forwardable (e.g. `def foo(...); end`)
@@ -6975,6 +6974,7 @@ fn gen_send_iseq(
     //
     // `def foo(...); end; foo(*blah)`
     let splat_call = (flags & VM_CALL_ARGS_SPLAT != 0) && !forwarding;
+    let kw_splat = (flags & VM_CALL_KW_SPLAT != 0) && !forwarding;
 
     // For computing offsets to callee locals
     let num_params = unsafe { get_iseq_body_param_size(iseq) as i32 };


### PR DESCRIPTION
Similarly to splat arrays, we shouldn't expand splat kwargs.

[ruby-core:118401]