### PR TITLE
Add RB_GC_GUARD for ast_value

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -971,7 +971,7 @@ iseq_translate(rb_iseq_t *iseq)
 }
 
 rb_iseq_t *
-rb_iseq_new_with_opt(const VALUE ast_value, VALUE name, VALUE path, VALUE realpath,
+rb_iseq_new_with_opt(VALUE ast_value, VALUE name, VALUE path, VALUE realpath,
                      int first_lineno, const rb_iseq_t *parent, int isolated_depth,
                      enum rb_iseq_type type, const rb_compile_option_t *option,
                      VALUE script_lines)
@@ -1004,6 +1004,7 @@ rb_iseq_new_with_opt(const VALUE ast_value, VALUE name, VALUE path, VALUE realpa
 
     rb_iseq_compile_node(iseq, node);
     finish_iseq_build(iseq);
+    RB_GC_GUARD(ast_value);
 
     return iseq_translate(iseq);
 }

--- a/vm_core.h
+++ b/vm_core.h
@@ -1203,7 +1203,7 @@ rb_iseq_t *rb_iseq_new         (const VALUE ast_value, VALUE name, VALUE path, V
 rb_iseq_t *rb_iseq_new_top     (const VALUE ast_value, VALUE name, VALUE path, VALUE realpath,                   const rb_iseq_t *parent);
 rb_iseq_t *rb_iseq_new_main    (const VALUE ast_value,             VALUE path, VALUE realpath,                   const rb_iseq_t *parent, int opt);
 rb_iseq_t *rb_iseq_new_eval    (const VALUE ast_value, VALUE name, VALUE path, VALUE realpath, int first_lineno, const rb_iseq_t *parent, int isolated_depth);
-rb_iseq_t *rb_iseq_new_with_opt(const VALUE ast_value, VALUE name, VALUE path, VALUE realpath, int first_lineno, const rb_iseq_t *parent, int isolated_depth,
+rb_iseq_t *rb_iseq_new_with_opt(      VALUE ast_value, VALUE name, VALUE path, VALUE realpath, int first_lineno, const rb_iseq_t *parent, int isolated_depth,
                                 enum rb_iseq_type, const rb_compile_option_t*,
                                 VALUE script_lines);
 


### PR DESCRIPTION
I think this change fixes the following assertion failure:

```
[BUG] unexpected rb_parser_ary_data_type (2114076960) for script lines
```

It seems that `ast_value` is collected then `rb_parser_build_script_lines_from` touches invalid memory address.
This change prevents `ast_value` from being collected by RB_GC_GUARD.