### PR TITLE
Use `__CET__` macro to enable IBT support.

### DIFF
--- a/coroutine/amd64/Context.S
+++ b/coroutine/amd64/Context.S
@@ -5,7 +5,7 @@
 ##  Copyright, 2018, by Samuel Williams.
 ##
 
-#if defined(__OpenBSD__)
+#if defined(__CET__)
 #include <cet.h>
 #endif
 
@@ -17,7 +17,7 @@
 .globl PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer)
 PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 
-#if defined(__OpenBSD__)
+#if defined(__CET__)
 	_CET_ENDBR
 #endif
 


### PR DESCRIPTION
According to the GCC documentation [[1]], the macro `__CET__` is dfined when `-fcf-protection` compiler option is used. Therefore use this macro to enable IBT support instead of special casing for `__OpenBSD__`.

[1]: https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fcf-protection