### PR TITLE
[PRISM] Support node id in Prism

### DIFF
--- a/prism/parser.h
+++ b/prism/parser.h
@@ -625,6 +625,13 @@ typedef uint32_t pm_state_stack_t;
  * it's considering.
  */
 struct pm_parser {
+    /**
+     * The current node identifier. This is used to assign unique identifiers to
+     * each node in the syntax tree. It is incremented each time a new node is
+     * created.
+     */
+    uint32_t node_id;
+
     /** The current state of the lexer. */
     pm_lex_state_t lex_state;
 

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -1885,6 +1885,7 @@ pm_alloc_node(PRISM_ATTRIBUTE_UNUSED pm_parser_t *parser, size_t size) {
 }
 
 #define PM_ALLOC_NODE(parser, type) (type *) pm_alloc_node(parser, sizeof(type))
+#define PM_ASSIGN_NODE_ID(parser) (++parser->node_id)
 
 /**
  * Allocate a new MissingNode node.
@@ -1892,7 +1893,13 @@ pm_alloc_node(PRISM_ATTRIBUTE_UNUSED pm_parser_t *parser, size_t size) {
 static pm_missing_node_t *
 pm_missing_node_create(pm_parser_t *parser, const uint8_t *start, const uint8_t *end) {
     pm_missing_node_t *node = PM_ALLOC_NODE(parser, pm_missing_node_t);
-    *node = (pm_missing_node_t) {{ .type = PM_MISSING_NODE, .location = { .start = start, .end = end } }};
+
+    *node = (pm_missing_node_t) {{
+        .type = PM_MISSING_NODE,
+        .id = PM_ASSIGN_NODE_ID(parser),
+        .location = { .start = start, .end = end }
+    }};
+
     return node;
 }
 
@@ -1907,6 +1914,7 @@ pm_alias_global_variable_node_create(pm_parser_t *parser, const pm_token_t *keyw
     *node = (pm_alias_global_variable_node_t) {
         {
             .type = PM_ALIAS_GLOBAL_VARIABLE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = old_name->location.end
@@ -1931,6 +1939,7 @@ pm_alias_method_node_create(pm_parser_t *parser, const pm_token_t *keyword, pm_n
     *node = (pm_alias_method_node_t) {
         {
             .type = PM_ALIAS_METHOD_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = old_name->location.end
@@ -1954,6 +1963,7 @@ pm_alternation_pattern_node_create(pm_parser_t *parser, pm_node_t *left, pm_node
     *node = (pm_alternation_pattern_node_t) {
         {
             .type = PM_ALTERNATION_PATTERN_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = left->location.start,
                 .end = right->location.end
@@ -1979,6 +1989,7 @@ pm_and_node_create(pm_parser_t *parser, pm_node_t *left, const pm_token_t *opera
     *node = (pm_and_node_t) {
         {
             .type = PM_AND_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = left->location.start,
                 .end = right->location.end
@@ -2002,6 +2013,7 @@ pm_arguments_node_create(pm_parser_t *parser) {
     *node = (pm_arguments_node_t) {
         {
             .type = PM_ARGUMENTS_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_NULL_VALUE(parser)
         },
         .arguments = { 0 }
@@ -2042,6 +2054,7 @@ pm_array_node_create(pm_parser_t *parser, const pm_token_t *opening) {
         {
             .type = PM_ARRAY_NODE,
             .flags = PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(opening)
         },
         .opening_loc = PM_OPTIONAL_LOCATION_TOKEN_VALUE(opening),
@@ -2104,6 +2117,7 @@ pm_array_pattern_node_node_list_create(pm_parser_t *parser, pm_node_list_t *node
     *node = (pm_array_pattern_node_t) {
         {
             .type = PM_ARRAY_PATTERN_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = nodes->nodes[0]->location.start,
                 .end = nodes->nodes[nodes->size - 1]->location.end
@@ -2146,6 +2160,7 @@ pm_array_pattern_node_rest_create(pm_parser_t *parser, pm_node_t *rest) {
     *node = (pm_array_pattern_node_t) {
         {
             .type = PM_ARRAY_PATTERN_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = rest->location,
         },
         .constant = NULL,
@@ -2170,6 +2185,7 @@ pm_array_pattern_node_constant_create(pm_parser_t *parser, pm_node_t *constant, 
     *node = (pm_array_pattern_node_t) {
         {
             .type = PM_ARRAY_PATTERN_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = constant->location.start,
                 .end = closing->end
@@ -2197,6 +2213,7 @@ pm_array_pattern_node_empty_create(pm_parser_t *parser, const pm_token_t *openin
     *node = (pm_array_pattern_node_t) {
         {
             .type = PM_ARRAY_PATTERN_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = opening->start,
                 .end = closing->end
@@ -2252,6 +2269,7 @@ pm_assoc_node_create(pm_parser_t *parser, pm_node_t *key, const pm_token_t *oper
         {
             .type = PM_ASSOC_NODE,
             .flags = flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = key->location.start,
                 .end = end
@@ -2276,6 +2294,7 @@ pm_assoc_splat_node_create(pm_parser_t *parser, pm_node_t *value, const pm_token
     *node = (pm_assoc_splat_node_t) {
         {
             .type = PM_ASSOC_SPLAT_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = operator->start,
                 .end = value == NULL ? operator->end : value->location.end
@@ -2299,6 +2318,7 @@ pm_back_reference_read_node_create(pm_parser_t *parser, const pm_token_t *name) 
     *node = (pm_back_reference_read_node_t) {
         {
             .type = PM_BACK_REFERENCE_READ_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(name),
         },
         .name = pm_parser_constant_id_token(parser, name)
@@ -2317,6 +2337,7 @@ pm_begin_node_create(pm_parser_t *parser, const pm_token_t *begin_keyword, pm_st
     *node = (pm_begin_node_t) {
         {
             .type = PM_BEGIN_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = begin_keyword->start,
                 .end = statements == NULL ? begin_keyword->end : statements->base.location.end
@@ -2382,6 +2403,7 @@ pm_block_argument_node_create(pm_parser_t *parser, const pm_token_t *operator, p
     *node = (pm_block_argument_node_t) {
         {
             .type = PM_BLOCK_ARGUMENT_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = operator->start,
                 .end = expression == NULL ? operator->end : expression->location.end
@@ -2404,6 +2426,7 @@ pm_block_node_create(pm_parser_t *parser, pm_constant_id_list_t *locals, const p
     *node = (pm_block_node_t) {
         {
             .type = PM_BLOCK_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = { .start = opening->start, .end = closing->end },
         },
         .locals = *locals,
@@ -2427,6 +2450,7 @@ pm_block_parameter_node_create(pm_parser_t *parser, const pm_token_t *name, cons
     *node = (pm_block_parameter_node_t) {
         {
             .type = PM_BLOCK_PARAMETER_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = operator->start,
                 .end = (name->type == PM_TOKEN_NOT_PROVIDED ? operator->end : name->end)
@@ -2468,6 +2492,7 @@ pm_block_parameters_node_create(pm_parser_t *parser, pm_parameters_node_t *param
     *node = (pm_block_parameters_node_t) {
         {
             .type = PM_BLOCK_PARAMETERS_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = start,
                 .end = end
@@ -2503,6 +2528,7 @@ pm_block_local_variable_node_create(pm_parser_t *parser, const pm_token_t *name)
     *node = (pm_block_local_variable_node_t) {
         {
             .type = PM_BLOCK_LOCAL_VARIABLE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(name),
         },
         .name = pm_parser_constant_id_token(parser, name)
@@ -2533,6 +2559,7 @@ pm_break_node_create(pm_parser_t *parser, const pm_token_t *keyword, pm_argument
     *node = (pm_break_node_t) {
         {
             .type = PM_BREAK_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = (arguments == NULL ? keyword->end : arguments->base.location.end)
@@ -2566,6 +2593,7 @@ pm_call_node_create(pm_parser_t *parser, pm_node_flags_t flags) {
         {
             .type = PM_CALL_NODE,
             .flags = flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_NULL_VALUE(parser),
         },
         .receiver = NULL,
@@ -2870,6 +2898,7 @@ pm_call_and_write_node_create(pm_parser_t *parser, pm_call_node_t *target, const
         {
             .type = PM_CALL_AND_WRITE_NODE,
             .flags = target->base.flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -2931,6 +2960,7 @@ pm_index_and_write_node_create(pm_parser_t *parser, pm_call_node_t *target, cons
         {
             .type = PM_INDEX_AND_WRITE_NODE,
             .flags = target->base.flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -2966,6 +2996,7 @@ pm_call_operator_write_node_create(pm_parser_t *parser, pm_call_node_t *target, 
         {
             .type = PM_CALL_OPERATOR_WRITE_NODE,
             .flags = target->base.flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3004,6 +3035,7 @@ pm_index_operator_write_node_create(pm_parser_t *parser, pm_call_node_t *target,
         {
             .type = PM_INDEX_OPERATOR_WRITE_NODE,
             .flags = target->base.flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3041,6 +3073,7 @@ pm_call_or_write_node_create(pm_parser_t *parser, pm_call_node_t *target, const 
         {
             .type = PM_CALL_OR_WRITE_NODE,
             .flags = target->base.flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3079,6 +3112,7 @@ pm_index_or_write_node_create(pm_parser_t *parser, pm_call_node_t *target, const
         {
             .type = PM_INDEX_OR_WRITE_NODE,
             .flags = target->base.flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3114,6 +3148,7 @@ pm_call_target_node_create(pm_parser_t *parser, pm_call_node_t *target) {
         {
             .type = PM_CALL_TARGET_NODE,
             .flags = target->base.flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = target->base.location
         },
         .receiver = target->receiver,
@@ -3145,6 +3180,7 @@ pm_index_target_node_create(pm_parser_t *parser, pm_call_node_t *target) {
         {
             .type = PM_INDEX_TARGET_NODE,
             .flags = flags | PM_CALL_NODE_FLAGS_ATTRIBUTE_WRITE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = target->base.location
         },
         .receiver = target->receiver,
@@ -3172,6 +3208,7 @@ pm_capture_pattern_node_create(pm_parser_t *parser, pm_node_t *value, pm_node_t 
     *node = (pm_capture_pattern_node_t) {
         {
             .type = PM_CAPTURE_PATTERN_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = value->location.start,
                 .end = target->location.end
@@ -3195,6 +3232,7 @@ pm_case_node_create(pm_parser_t *parser, const pm_token_t *case_keyword, pm_node
     *node = (pm_case_node_t) {
         {
             .type = PM_CASE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = case_keyword->start,
                 .end = end_keyword->end
@@ -3249,6 +3287,7 @@ pm_case_match_node_create(pm_parser_t *parser, const pm_token_t *case_keyword, p
     *node = (pm_case_match_node_t) {
         {
             .type = PM_CASE_MATCH_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = case_keyword->start,
                 .end = end_keyword->end
@@ -3303,7 +3342,11 @@ pm_class_node_create(pm_parser_t *parser, pm_constant_id_list_t *locals, const p
     *node = (pm_class_node_t) {
         {
             .type = PM_CLASS_NODE,
-            .location = { .start = class_keyword->start, .end = end_keyword->end },
+            .id = PM_ASSIGN_NODE_ID(parser),
+            .location = {
+                .start = class_keyword->start,
+                .end = end_keyword->end
+            }
         },
         .locals = *locals,
         .class_keyword_loc = PM_LOCATION_TOKEN_VALUE(class_keyword),
@@ -3329,6 +3372,7 @@ pm_class_variable_and_write_node_create(pm_parser_t *parser, pm_class_variable_r
     *node = (pm_class_variable_and_write_node_t) {
         {
             .type = PM_CLASS_VARIABLE_AND_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3353,6 +3397,7 @@ pm_class_variable_operator_write_node_create(pm_parser_t *parser, pm_class_varia
     *node = (pm_class_variable_operator_write_node_t) {
         {
             .type = PM_CLASS_VARIABLE_OPERATOR_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3379,6 +3424,7 @@ pm_class_variable_or_write_node_create(pm_parser_t *parser, pm_class_variable_re
     *node = (pm_class_variable_or_write_node_t) {
         {
             .type = PM_CLASS_VARIABLE_OR_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3404,6 +3450,7 @@ pm_class_variable_read_node_create(pm_parser_t *parser, const pm_token_t *token)
     *node = (pm_class_variable_read_node_t) {
         {
             .type = PM_CLASS_VARIABLE_READ_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token)
         },
         .name = pm_parser_constant_id_token(parser, token)
@@ -3437,10 +3484,11 @@ pm_class_variable_write_node_create(pm_parser_t *parser, pm_class_variable_read_
         {
             .type = PM_CLASS_VARIABLE_WRITE_NODE,
             .flags = pm_implicit_array_write_flags(value, PM_WRITE_NODE_FLAGS_IMPLICIT_ARRAY),
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = read_node->base.location.start,
                 .end = value->location.end
-            },
+            }
         },
         .name = read_node->name,
         .name_loc = PM_LOCATION_NODE_VALUE((pm_node_t *) read_node),
@@ -3462,6 +3510,7 @@ pm_constant_path_and_write_node_create(pm_parser_t *parser, pm_constant_path_nod
     *node = (pm_constant_path_and_write_node_t) {
         {
             .type = PM_CONSTANT_PATH_AND_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3485,6 +3534,7 @@ pm_constant_path_operator_write_node_create(pm_parser_t *parser, pm_constant_pat
     *node = (pm_constant_path_operator_write_node_t) {
         {
             .type = PM_CONSTANT_PATH_OPERATOR_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3510,6 +3560,7 @@ pm_constant_path_or_write_node_create(pm_parser_t *parser, pm_constant_path_node
     *node = (pm_constant_path_or_write_node_t) {
         {
             .type = PM_CONSTANT_PATH_OR_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3539,10 +3590,11 @@ pm_constant_path_node_create(pm_parser_t *parser, pm_node_t *parent, const pm_to
     *node = (pm_constant_path_node_t) {
         {
             .type = PM_CONSTANT_PATH_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = parent == NULL ? delimiter->start : parent->location.start,
                 .end = name_token->end
-            },
+            }
         },
         .parent = parent,
         .name = name,
@@ -3564,6 +3616,7 @@ pm_constant_path_write_node_create(pm_parser_t *parser, pm_constant_path_node_t 
         {
             .type = PM_CONSTANT_PATH_WRITE_NODE,
             .flags = pm_implicit_array_write_flags(value, PM_WRITE_NODE_FLAGS_IMPLICIT_ARRAY),
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3588,6 +3641,7 @@ pm_constant_and_write_node_create(pm_parser_t *parser, pm_constant_read_node_t *
     *node = (pm_constant_and_write_node_t) {
         {
             .type = PM_CONSTANT_AND_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3612,6 +3666,7 @@ pm_constant_operator_write_node_create(pm_parser_t *parser, pm_constant_read_nod
     *node = (pm_constant_operator_write_node_t) {
         {
             .type = PM_CONSTANT_OPERATOR_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3638,6 +3693,7 @@ pm_constant_or_write_node_create(pm_parser_t *parser, pm_constant_read_node_t *t
     *node = (pm_constant_or_write_node_t) {
         {
             .type = PM_CONSTANT_OR_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3663,6 +3719,7 @@ pm_constant_read_node_create(pm_parser_t *parser, const pm_token_t *name) {
     *node = (pm_constant_read_node_t) {
         {
             .type = PM_CONSTANT_READ_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(name)
         },
         .name = pm_parser_constant_id_token(parser, name)
@@ -3682,6 +3739,7 @@ pm_constant_write_node_create(pm_parser_t *parser, pm_constant_read_node_t *targ
         {
             .type = PM_CONSTANT_WRITE_NODE,
             .flags = pm_implicit_array_write_flags(value, PM_WRITE_NODE_FLAGS_IMPLICIT_ARRAY),
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -3886,6 +3944,7 @@ pm_def_node_create(
     *node = (pm_def_node_t) {
         {
             .type = PM_DEF_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = { .start = def_keyword->start, .end = end },
         },
         .name = name,
@@ -3915,6 +3974,7 @@ pm_defined_node_create(pm_parser_t *parser, const pm_token_t *lparen, pm_node_t 
     *node = (pm_defined_node_t) {
         {
             .type = PM_DEFINED_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword_loc->start,
                 .end = (rparen->type == PM_TOKEN_NOT_PROVIDED ? value->location.end : rparen->end)
@@ -3945,6 +4005,7 @@ pm_else_node_create(pm_parser_t *parser, const pm_token_t *else_keyword, pm_stat
     *node = (pm_else_node_t) {
         {
             .type = PM_ELSE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = else_keyword->start,
                 .end = end,
@@ -3968,6 +4029,7 @@ pm_embedded_statements_node_create(pm_parser_t *parser, const pm_token_t *openin
     *node = (pm_embedded_statements_node_t) {
         {
             .type = PM_EMBEDDED_STATEMENTS_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = opening->start,
                 .end = closing->end
@@ -3991,6 +4053,7 @@ pm_embedded_variable_node_create(pm_parser_t *parser, const pm_token_t *operator
     *node = (pm_embedded_variable_node_t) {
         {
             .type = PM_EMBEDDED_VARIABLE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = operator->start,
                 .end = variable->location.end
@@ -4013,6 +4076,7 @@ pm_ensure_node_create(pm_parser_t *parser, const pm_token_t *ensure_keyword, pm_
     *node = (pm_ensure_node_t) {
         {
             .type = PM_ENSURE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = ensure_keyword->start,
                 .end = end_keyword->end
@@ -4037,6 +4101,7 @@ pm_false_node_create(pm_parser_t *parser, const pm_token_t *token) {
     *node = (pm_false_node_t) {{
         .type = PM_FALSE_NODE,
         .flags = PM_NODE_FLAG_STATIC_LITERAL,
+        .id = PM_ASSIGN_NODE_ID(parser),
         .location = PM_LOCATION_TOKEN_VALUE(token)
     }};
 
@@ -4063,6 +4128,7 @@ pm_find_pattern_node_create(pm_parser_t *parser, pm_node_list_t *nodes) {
     *node = (pm_find_pattern_node_t) {
         {
             .type = PM_FIND_PATTERN_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = left->location.start,
                 .end = right->location.end,
@@ -4171,6 +4237,7 @@ pm_float_node_create(pm_parser_t *parser, const pm_token_t *token) {
         {
             .type = PM_FLOAT_NODE,
             .flags = PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token)
         },
         .value = pm_double_parse(parser, token)
@@ -4191,6 +4258,7 @@ pm_float_node_imaginary_create(pm_parser_t *parser, const pm_token_t *token) {
         {
             .type = PM_IMAGINARY_NODE,
             .flags = PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token)
         },
         .numeric = (pm_node_t *) pm_float_node_create(parser, &((pm_token_t) {
@@ -4215,6 +4283,7 @@ pm_float_node_rational_create(pm_parser_t *parser, const pm_token_t *token) {
         {
             .type = PM_RATIONAL_NODE,
             .flags = PM_INTEGER_BASE_FLAGS_DECIMAL | PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token)
         },
         .numerator = { 0 },
@@ -4268,6 +4337,7 @@ pm_float_node_rational_imaginary_create(pm_parser_t *parser, const pm_token_t *t
         {
             .type = PM_IMAGINARY_NODE,
             .flags = PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token)
         },
         .numeric = (pm_node_t *) pm_float_node_rational_create(parser, &((pm_token_t) {
@@ -4299,6 +4369,7 @@ pm_for_node_create(
     *node = (pm_for_node_t) {
         {
             .type = PM_FOR_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = for_keyword->start,
                 .end = end_keyword->end
@@ -4323,7 +4394,13 @@ static pm_forwarding_arguments_node_t *
 pm_forwarding_arguments_node_create(pm_parser_t *parser, const pm_token_t *token) {
     assert(token->type == PM_TOKEN_UDOT_DOT_DOT);
     pm_forwarding_arguments_node_t *node = PM_ALLOC_NODE(parser, pm_forwarding_arguments_node_t);
-    *node = (pm_forwarding_arguments_node_t) {{ .type = PM_FORWARDING_ARGUMENTS_NODE, .location = PM_LOCATION_TOKEN_VALUE(token) }};
+
+    *node = (pm_forwarding_arguments_node_t) {{
+        .type = PM_FORWARDING_ARGUMENTS_NODE,
+        .id = PM_ASSIGN_NODE_ID(parser),
+        .location = PM_LOCATION_TOKEN_VALUE(token)
+    }};
+
     return node;
 }
 
@@ -4334,7 +4411,13 @@ static pm_forwarding_parameter_node_t *
 pm_forwarding_parameter_node_create(pm_parser_t *parser, const pm_token_t *token) {
     assert(token->type == PM_TOKEN_UDOT_DOT_DOT);
     pm_forwarding_parameter_node_t *node = PM_ALLOC_NODE(parser, pm_forwarding_parameter_node_t);
-    *node = (pm_forwarding_parameter_node_t) {{ .type = PM_FORWARDING_PARAMETER_NODE, .location = PM_LOCATION_TOKEN_VALUE(token) }};
+
+    *node = (pm_forwarding_parameter_node_t) {{
+        .type = PM_FORWARDING_PARAMETER_NODE,
+        .id = PM_ASSIGN_NODE_ID(parser),
+        .location = PM_LOCATION_TOKEN_VALUE(token)
+    }};
+
     return node;
 }
 
@@ -4355,6 +4438,7 @@ pm_forwarding_super_node_create(pm_parser_t *parser, const pm_token_t *token, pm
     *node = (pm_forwarding_super_node_t) {
         {
             .type = PM_FORWARDING_SUPER_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = token->start,
                 .end = block != NULL ? block->base.location.end : token->end
@@ -4377,6 +4461,7 @@ pm_hash_pattern_node_empty_create(pm_parser_t *parser, const pm_token_t *opening
     *node = (pm_hash_pattern_node_t) {
         {
             .type = PM_HASH_PATTERN_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = opening->start,
                 .end = closing->end
@@ -4419,6 +4504,7 @@ pm_hash_pattern_node_node_list_create(pm_parser_t *parser, pm_node_list_t *eleme
     *node = (pm_hash_pattern_node_t) {
         {
             .type = PM_HASH_PATTERN_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = start,
                 .end = end
@@ -4470,6 +4556,7 @@ pm_global_variable_and_write_node_create(pm_parser_t *parser, pm_node_t *target,
     *node = (pm_global_variable_and_write_node_t) {
         {
             .type = PM_GLOBAL_VARIABLE_AND_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->location.start,
                 .end = value->location.end
@@ -4494,6 +4581,7 @@ pm_global_variable_operator_write_node_create(pm_parser_t *parser, pm_node_t *ta
     *node = (pm_global_variable_operator_write_node_t) {
         {
             .type = PM_GLOBAL_VARIABLE_OPERATOR_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->location.start,
                 .end = value->location.end
@@ -4520,6 +4608,7 @@ pm_global_variable_or_write_node_create(pm_parser_t *parser, pm_node_t *target, 
     *node = (pm_global_variable_or_write_node_t) {
         {
             .type = PM_GLOBAL_VARIABLE_OR_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->location.start,
                 .end = value->location.end
@@ -4544,6 +4633,7 @@ pm_global_variable_read_node_create(pm_parser_t *parser, const pm_token_t *name)
     *node = (pm_global_variable_read_node_t) {
         {
             .type = PM_GLOBAL_VARIABLE_READ_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(name),
         },
         .name = pm_parser_constant_id_token(parser, name)
@@ -4562,6 +4652,7 @@ pm_global_variable_read_node_synthesized_create(pm_parser_t *parser, pm_constant
     *node = (pm_global_variable_read_node_t) {
         {
             .type = PM_GLOBAL_VARIABLE_READ_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_NULL_VALUE(parser)
         },
         .name = name
@@ -4581,6 +4672,7 @@ pm_global_variable_write_node_create(pm_parser_t *parser, pm_node_t *target, con
         {
             .type = PM_GLOBAL_VARIABLE_WRITE_NODE,
             .flags = pm_implicit_array_write_flags(value, PM_WRITE_NODE_FLAGS_IMPLICIT_ARRAY),
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->location.start,
                 .end = value->location.end
@@ -4605,6 +4697,7 @@ pm_global_variable_write_node_synthesized_create(pm_parser_t *parser, pm_constan
     *node = (pm_global_variable_write_node_t) {
         {
             .type = PM_GLOBAL_VARIABLE_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_NULL_VALUE(parser)
         },
         .name = name,
@@ -4628,6 +4721,7 @@ pm_hash_node_create(pm_parser_t *parser, const pm_token_t *opening) {
         {
             .type = PM_HASH_NODE,
             .flags = PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(opening)
         },
         .opening_loc = PM_LOCATION_TOKEN_VALUE(opening),
@@ -4694,6 +4788,7 @@ pm_if_node_create(pm_parser_t *parser,
         {
             .type = PM_IF_NODE,
             .flags = PM_NODE_FLAG_NEWLINE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = if_keyword->start,
                 .end = end
@@ -4725,6 +4820,7 @@ pm_if_node_modifier_create(pm_parser_t *parser, pm_node_t *statement, const pm_t
         {
             .type = PM_IF_NODE,
             .flags = PM_NODE_FLAG_NEWLINE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = statement->location.start,
                 .end = predicate->location.end
@@ -4764,6 +4860,7 @@ pm_if_node_ternary_create(pm_parser_t *parser, pm_node_t *predicate, const pm_to
         {
             .type = PM_IF_NODE,
             .flags = PM_NODE_FLAG_NEWLINE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = predicate->location.start,
                 .end = false_expression->location.end,
@@ -4803,6 +4900,7 @@ pm_implicit_node_create(pm_parser_t *parser, pm_node_t *value) {
     *node = (pm_implicit_node_t) {
         {
             .type = PM_IMPLICIT_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = value->location
         },
         .value = value
@@ -4823,6 +4921,7 @@ pm_implicit_rest_node_create(pm_parser_t *parser, const pm_token_t *token) {
     *node = (pm_implicit_rest_node_t) {
         {
             .type = PM_IMPLICIT_REST_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token)
         }
     };
@@ -4842,6 +4941,7 @@ pm_integer_node_create(pm_parser_t *parser, pm_node_flags_t base, const pm_token
         {
             .type = PM_INTEGER_NODE,
             .flags = base | PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token)
         },
         .value = { 0 }
@@ -4873,6 +4973,7 @@ pm_integer_node_imaginary_create(pm_parser_t *parser, pm_node_flags_t base, cons
         {
             .type = PM_IMAGINARY_NODE,
             .flags = PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token)
         },
         .numeric = (pm_node_t *) pm_integer_node_create(parser, base, &((pm_token_t) {
@@ -4898,6 +4999,7 @@ pm_integer_node_rational_create(pm_parser_t *parser, pm_node_flags_t base, const
         {
             .type = PM_RATIONAL_NODE,
             .flags = base | PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token)
         },
         .numerator = { 0 },
@@ -4931,6 +5033,7 @@ pm_integer_node_rational_imaginary_create(pm_parser_t *parser, pm_node_flags_t b
         {
             .type = PM_IMAGINARY_NODE,
             .flags = PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token)
         },
         .numeric = (pm_node_t *) pm_integer_node_rational_create(parser, base, &((pm_token_t) {
@@ -4962,10 +5065,11 @@ pm_in_node_create(pm_parser_t *parser, pm_node_t *pattern, pm_statements_node_t 
     *node = (pm_in_node_t) {
         {
             .type = PM_IN_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = in_keyword->start,
                 .end = end
-            },
+            }
         },
         .pattern = pattern,
         .statements = statements,
@@ -4987,6 +5091,7 @@ pm_instance_variable_and_write_node_create(pm_parser_t *parser, pm_instance_vari
     *node = (pm_instance_variable_and_write_node_t) {
         {
             .type = PM_INSTANCE_VARIABLE_AND_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -5011,6 +5116,7 @@ pm_instance_variable_operator_write_node_create(pm_parser_t *parser, pm_instance
     *node = (pm_instance_variable_operator_write_node_t) {
         {
             .type = PM_INSTANCE_VARIABLE_OPERATOR_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -5037,6 +5143,7 @@ pm_instance_variable_or_write_node_create(pm_parser_t *parser, pm_instance_varia
     *node = (pm_instance_variable_or_write_node_t) {
         {
             .type = PM_INSTANCE_VARIABLE_OR_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -5062,6 +5169,7 @@ pm_instance_variable_read_node_create(pm_parser_t *parser, const pm_token_t *tok
     *node = (pm_instance_variable_read_node_t) {
         {
             .type = PM_INSTANCE_VARIABLE_READ_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token)
         },
         .name = pm_parser_constant_id_token(parser, token)
@@ -5081,6 +5189,7 @@ pm_instance_variable_write_node_create(pm_parser_t *parser, pm_instance_variable
         {
             .type = PM_INSTANCE_VARIABLE_WRITE_NODE,
             .flags = pm_implicit_array_write_flags(value, PM_WRITE_NODE_FLAGS_IMPLICIT_ARRAY),
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = read_node->base.location.start,
                 .end = value->location.end
@@ -5150,6 +5259,7 @@ pm_interpolated_regular_expression_node_create(pm_parser_t *parser, const pm_tok
         {
             .type = PM_INTERPOLATED_REGULAR_EXPRESSION_NODE,
             .flags = PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = opening->start,
                 .end = NULL,
@@ -5302,6 +5412,7 @@ pm_interpolated_string_node_create(pm_parser_t *parser, const pm_token_t *openin
         {
             .type = PM_INTERPOLATED_STRING_NODE,
             .flags = flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = opening->start,
                 .end = closing->end,
@@ -5358,6 +5469,7 @@ pm_interpolated_symbol_node_create(pm_parser_t *parser, const pm_token_t *openin
         {
             .type = PM_INTERPOLATED_SYMBOL_NODE,
             .flags = PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = opening->start,
                 .end = closing->end,
@@ -5388,6 +5500,7 @@ pm_interpolated_xstring_node_create(pm_parser_t *parser, const pm_token_t *openi
     *node = (pm_interpolated_x_string_node_t) {
         {
             .type = PM_INTERPOLATED_X_STRING_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = opening->start,
                 .end = closing->end
@@ -5423,6 +5536,7 @@ pm_it_local_variable_read_node_create(pm_parser_t *parser, const pm_token_t *nam
     *node = (pm_it_local_variable_read_node_t) {
         {
             .type = PM_IT_LOCAL_VARIABLE_READ_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(name)
         }
     };
@@ -5440,6 +5554,7 @@ pm_it_parameters_node_create(pm_parser_t *parser, const pm_token_t *opening, con
     *node = (pm_it_parameters_node_t) {
         {
             .type = PM_IT_PARAMETERS_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = opening->start,
                 .end = closing->end
@@ -5460,8 +5575,9 @@ pm_keyword_hash_node_create(pm_parser_t *parser) {
     *node = (pm_keyword_hash_node_t) {
         .base = {
             .type = PM_KEYWORD_HASH_NODE,
-            .location = PM_OPTIONAL_LOCATION_NOT_PROVIDED_VALUE,
-            .flags = PM_KEYWORD_HASH_NODE_FLAGS_SYMBOL_KEYS
+            .flags = PM_KEYWORD_HASH_NODE_FLAGS_SYMBOL_KEYS,
+            .id = PM_ASSIGN_NODE_ID(parser),
+            .location = PM_OPTIONAL_LOCATION_NOT_PROVIDED_VALUE
         },
         .elements = { 0 }
     };
@@ -5497,6 +5613,7 @@ pm_required_keyword_parameter_node_create(pm_parser_t *parser, const pm_token_t 
     *node = (pm_required_keyword_parameter_node_t) {
         {
             .type = PM_REQUIRED_KEYWORD_PARAMETER_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = name->start,
                 .end = name->end
@@ -5519,6 +5636,7 @@ pm_optional_keyword_parameter_node_create(pm_parser_t *parser, const pm_token_t 
     *node = (pm_optional_keyword_parameter_node_t) {
         {
             .type = PM_OPTIONAL_KEYWORD_PARAMETER_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = name->start,
                 .end = value->location.end
@@ -5542,6 +5660,7 @@ pm_keyword_rest_parameter_node_create(pm_parser_t *parser, const pm_token_t *ope
     *node = (pm_keyword_rest_parameter_node_t) {
         {
             .type = PM_KEYWORD_REST_PARAMETER_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = operator->start,
                 .end = (name->type == PM_TOKEN_NOT_PROVIDED ? operator->end : name->end)
@@ -5573,6 +5692,7 @@ pm_lambda_node_create(
     *node = (pm_lambda_node_t) {
         {
             .type = PM_LAMBDA_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = operator->start,
                 .end = closing->end
@@ -5601,6 +5721,7 @@ pm_local_variable_and_write_node_create(pm_parser_t *parser, pm_node_t *target, 
     *node = (pm_local_variable_and_write_node_t) {
         {
             .type = PM_LOCAL_VARIABLE_AND_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->location.start,
                 .end = value->location.end
@@ -5626,6 +5747,7 @@ pm_local_variable_operator_write_node_create(pm_parser_t *parser, pm_node_t *tar
     *node = (pm_local_variable_operator_write_node_t) {
         {
             .type = PM_LOCAL_VARIABLE_OPERATOR_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->location.start,
                 .end = value->location.end
@@ -5654,6 +5776,7 @@ pm_local_variable_or_write_node_create(pm_parser_t *parser, pm_node_t *target, c
     *node = (pm_local_variable_or_write_node_t) {
         {
             .type = PM_LOCAL_VARIABLE_OR_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->location.start,
                 .end = value->location.end
@@ -5681,6 +5804,7 @@ pm_local_variable_read_node_create_constant_id(pm_parser_t *parser, const pm_tok
     *node = (pm_local_variable_read_node_t) {
         {
             .type = PM_LOCAL_VARIABLE_READ_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(name)
         },
         .name = name_id,
@@ -5720,6 +5844,7 @@ pm_local_variable_write_node_create(pm_parser_t *parser, pm_constant_id_t name, 
         {
             .type = PM_LOCAL_VARIABLE_WRITE_NODE,
             .flags = pm_implicit_array_write_flags(value, PM_WRITE_NODE_FLAGS_IMPLICIT_ARRAY),
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = name_loc->start,
                 .end = value->location.end
@@ -5775,6 +5900,7 @@ pm_local_variable_target_node_create(pm_parser_t *parser, const pm_location_t *l
     *node = (pm_local_variable_target_node_t) {
         {
             .type = PM_LOCAL_VARIABLE_TARGET_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = *location
         },
         .name = name,
@@ -5796,6 +5922,7 @@ pm_match_predicate_node_create(pm_parser_t *parser, pm_node_t *value, pm_node_t 
     *node = (pm_match_predicate_node_t) {
         {
             .type = PM_MATCH_PREDICATE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = value->location.start,
                 .end = pattern->location.end
@@ -5821,6 +5948,7 @@ pm_match_required_node_create(pm_parser_t *parser, pm_node_t *value, pm_node_t *
     *node = (pm_match_required_node_t) {
         {
             .type = PM_MATCH_REQUIRED_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = value->location.start,
                 .end = pattern->location.end
@@ -5844,6 +5972,7 @@ pm_match_write_node_create(pm_parser_t *parser, pm_call_node_t *call) {
     *node = (pm_match_write_node_t) {
         {
             .type = PM_MATCH_WRITE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = call->base.location
         },
         .call = call,
@@ -5863,6 +5992,7 @@ pm_module_node_create(pm_parser_t *parser, pm_constant_id_list_t *locals, const 
     *node = (pm_module_node_t) {
         {
             .type = PM_MODULE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = module_keyword->start,
                 .end = end_keyword->end
@@ -5889,6 +6019,7 @@ pm_multi_target_node_create(pm_parser_t *parser) {
     *node = (pm_multi_target_node_t) {
         {
             .type = PM_MULTI_TARGET_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = { .start = NULL, .end = NULL }
         },
         .lefts = { 0 },
@@ -5964,6 +6095,7 @@ pm_multi_write_node_create(pm_parser_t *parser, pm_multi_target_node_t *target, 
         {
             .type = PM_MULTI_WRITE_NODE,
             .flags = pm_implicit_array_write_flags(value, PM_WRITE_NODE_FLAGS_IMPLICIT_ARRAY),
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = target->base.location.start,
                 .end = value->location.end
@@ -5996,6 +6128,7 @@ pm_next_node_create(pm_parser_t *parser, const pm_token_t *keyword, pm_arguments
     *node = (pm_next_node_t) {
         {
             .type = PM_NEXT_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = (arguments == NULL ? keyword->end : arguments->base.location.end)
@@ -6019,6 +6152,7 @@ pm_nil_node_create(pm_parser_t *parser, const pm_token_t *token) {
     *node = (pm_nil_node_t) {{
         .type = PM_NIL_NODE,
         .flags = PM_NODE_FLAG_STATIC_LITERAL,
+        .id = PM_ASSIGN_NODE_ID(parser),
         .location = PM_LOCATION_TOKEN_VALUE(token)
     }};
 
@@ -6037,6 +6171,7 @@ pm_no_keywords_parameter_node_create(pm_parser_t *parser, const pm_token_t *oper
     *node = (pm_no_keywords_parameter_node_t) {
         {
             .type = PM_NO_KEYWORDS_PARAMETER_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = operator->start,
                 .end = keyword->end
@@ -6059,6 +6194,7 @@ pm_numbered_parameters_node_create(pm_parser_t *parser, const pm_location_t *loc
     *node = (pm_numbered_parameters_node_t) {
         {
             .type = PM_NUMBERED_PARAMETERS_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = *location
         },
         .maximum = maximum
@@ -6124,6 +6260,7 @@ pm_numbered_reference_read_node_create(pm_parser_t *parser, const pm_token_t *na
     *node = (pm_numbered_reference_read_node_t) {
         {
             .type = PM_NUMBERED_REFERENCE_READ_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(name),
         },
         .number = pm_numbered_reference_read_node_number(parser, name)
@@ -6142,6 +6279,7 @@ pm_optional_parameter_node_create(pm_parser_t *parser, const pm_token_t *name, c
     *node = (pm_optional_parameter_node_t) {
         {
             .type = PM_OPTIONAL_PARAMETER_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = name->start,
                 .end = value->location.end
@@ -6168,6 +6306,7 @@ pm_or_node_create(pm_parser_t *parser, pm_node_t *left, const pm_token_t *operat
     *node = (pm_or_node_t) {
         {
             .type = PM_OR_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = left->location.start,
                 .end = right->location.end
@@ -6191,6 +6330,7 @@ pm_parameters_node_create(pm_parser_t *parser) {
     *node = (pm_parameters_node_t) {
         {
             .type = PM_PARAMETERS_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(&parser->current)
         },
         .rest = NULL,
@@ -6298,6 +6438,7 @@ pm_program_node_create(pm_parser_t *parser, pm_constant_id_list_t *locals, pm_st
     *node = (pm_program_node_t) {
         {
             .type = PM_PROGRAM_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = statements == NULL ? parser->start : statements->base.location.start,
                 .end = statements == NULL ? parser->end : statements->base.location.end
@@ -6320,6 +6461,7 @@ pm_parentheses_node_create(pm_parser_t *parser, const pm_token_t *opening, pm_no
     *node = (pm_parentheses_node_t) {
         {
             .type = PM_PARENTHESES_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = opening->start,
                 .end = closing->end
@@ -6343,6 +6485,7 @@ pm_pinned_expression_node_create(pm_parser_t *parser, pm_node_t *expression, con
     *node = (pm_pinned_expression_node_t) {
         {
             .type = PM_PINNED_EXPRESSION_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = operator->start,
                 .end = rparen->end
@@ -6367,6 +6510,7 @@ pm_pinned_variable_node_create(pm_parser_t *parser, const pm_token_t *operator, 
     *node = (pm_pinned_variable_node_t) {
         {
             .type = PM_PINNED_VARIABLE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = operator->start,
                 .end = variable->location.end
@@ -6389,6 +6533,7 @@ pm_post_execution_node_create(pm_parser_t *parser, const pm_token_t *keyword, co
     *node = (pm_post_execution_node_t) {
         {
             .type = PM_POST_EXECUTION_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = closing->end
@@ -6413,6 +6558,7 @@ pm_pre_execution_node_create(pm_parser_t *parser, const pm_token_t *keyword, con
     *node = (pm_pre_execution_node_t) {
         {
             .type = PM_PRE_EXECUTION_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = closing->end
@@ -6457,6 +6603,7 @@ pm_range_node_create(pm_parser_t *parser, pm_node_t *left, const pm_token_t *ope
         {
             .type = PM_RANGE_NODE,
             .flags = flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = (left == NULL ? operator->start : left->location.start),
                 .end = (right == NULL ? operator->end : right->location.end)
@@ -6478,7 +6625,12 @@ pm_redo_node_create(pm_parser_t *parser, const pm_token_t *token) {
     assert(token->type == PM_TOKEN_KEYWORD_REDO);
     pm_redo_node_t *node = PM_ALLOC_NODE(parser, pm_redo_node_t);
 
-    *node = (pm_redo_node_t) {{ .type = PM_REDO_NODE, .location = PM_LOCATION_TOKEN_VALUE(token) }};
+    *node = (pm_redo_node_t) {{
+        .type = PM_REDO_NODE,
+        .id = PM_ASSIGN_NODE_ID(parser),
+        .location = PM_LOCATION_TOKEN_VALUE(token)
+    }};
+
     return node;
 }
 
@@ -6494,6 +6646,7 @@ pm_regular_expression_node_create_unescaped(pm_parser_t *parser, const pm_token_
         {
             .type = PM_REGULAR_EXPRESSION_NODE,
             .flags = pm_regular_expression_flags_create(parser, closing) | PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = MIN(opening->start, closing->start),
                 .end = MAX(opening->end, closing->end)
@@ -6526,6 +6679,7 @@ pm_required_parameter_node_create(pm_parser_t *parser, const pm_token_t *token) 
     *node = (pm_required_parameter_node_t) {
         {
             .type = PM_REQUIRED_PARAMETER_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token)
         },
         .name = pm_parser_constant_id_token(parser, token)
@@ -6544,6 +6698,7 @@ pm_rescue_modifier_node_create(pm_parser_t *parser, pm_node_t *expression, const
     *node = (pm_rescue_modifier_node_t) {
         {
             .type = PM_RESCUE_MODIFIER_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = expression->location.start,
                 .end = rescue_expression->location.end
@@ -6567,6 +6722,7 @@ pm_rescue_node_create(pm_parser_t *parser, const pm_token_t *keyword) {
     *node = (pm_rescue_node_t) {
         {
             .type = PM_RESCUE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(keyword)
         },
         .keyword_loc = PM_LOCATION_TOKEN_VALUE(keyword),
@@ -6633,6 +6789,7 @@ pm_rest_parameter_node_create(pm_parser_t *parser, const pm_token_t *operator, c
     *node = (pm_rest_parameter_node_t) {
         {
             .type = PM_REST_PARAMETER_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = operator->start,
                 .end = (name->type == PM_TOKEN_NOT_PROVIDED ? operator->end : name->end)
@@ -6654,7 +6811,12 @@ pm_retry_node_create(pm_parser_t *parser, const pm_token_t *token) {
     assert(token->type == PM_TOKEN_KEYWORD_RETRY);
     pm_retry_node_t *node = PM_ALLOC_NODE(parser, pm_retry_node_t);
 
-    *node = (pm_retry_node_t) {{ .type = PM_RETRY_NODE, .location = PM_LOCATION_TOKEN_VALUE(token) }};
+    *node = (pm_retry_node_t) {{
+        .type = PM_RETRY_NODE,
+        .id = PM_ASSIGN_NODE_ID(parser),
+        .location = PM_LOCATION_TOKEN_VALUE(token)
+    }};
+
     return node;
 }
 
@@ -6668,7 +6830,7 @@ pm_return_node_create(pm_parser_t *parser, const pm_token_t *keyword, pm_argumen
     *node = (pm_return_node_t) {
         {
             .type = PM_RETURN_NODE,
-            .flags = 0,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = (arguments == NULL ? keyword->end : arguments->base.location.end)
@@ -6691,6 +6853,7 @@ pm_self_node_create(pm_parser_t *parser, const pm_token_t *token) {
 
     *node = (pm_self_node_t) {{
         .type = PM_SELF_NODE,
+        .id = PM_ASSIGN_NODE_ID(parser),
         .location = PM_LOCATION_TOKEN_VALUE(token)
     }};
 
@@ -6708,6 +6871,7 @@ pm_shareable_constant_node_create(pm_parser_t *parser, pm_node_t *write, pm_shar
         {
             .type = PM_SHAREABLE_CONSTANT_NODE,
             .flags = (pm_node_flags_t) value,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_NODE_VALUE(write)
         },
         .write = write
@@ -6726,6 +6890,7 @@ pm_singleton_class_node_create(pm_parser_t *parser, pm_constant_id_list_t *local
     *node = (pm_singleton_class_node_t) {
         {
             .type = PM_SINGLETON_CLASS_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = class_keyword->start,
                 .end = end_keyword->end
@@ -6753,6 +6918,7 @@ pm_source_encoding_node_create(pm_parser_t *parser, const pm_token_t *token) {
     *node = (pm_source_encoding_node_t) {{
         .type = PM_SOURCE_ENCODING_NODE,
         .flags = PM_NODE_FLAG_STATIC_LITERAL,
+        .id = PM_ASSIGN_NODE_ID(parser),
         .location = PM_LOCATION_TOKEN_VALUE(token)
     }};
 
@@ -6782,6 +6948,7 @@ pm_source_file_node_create(pm_parser_t *parser, const pm_token_t *file_keyword) 
         {
             .type = PM_SOURCE_FILE_NODE,
             .flags = flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(file_keyword),
         },
         .filepath = parser->filepath
@@ -6801,6 +6968,7 @@ pm_source_line_node_create(pm_parser_t *parser, const pm_token_t *token) {
     *node = (pm_source_line_node_t) {{
         .type = PM_SOURCE_LINE_NODE,
         .flags = PM_NODE_FLAG_STATIC_LITERAL,
+        .id = PM_ASSIGN_NODE_ID(parser),
         .location = PM_LOCATION_TOKEN_VALUE(token)
     }};
 
@@ -6817,6 +6985,7 @@ pm_splat_node_create(pm_parser_t *parser, const pm_token_t *operator, pm_node_t 
     *node = (pm_splat_node_t) {
         {
             .type = PM_SPLAT_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = operator->start,
                 .end = (expression == NULL ? operator->end : expression->location.end)
@@ -6839,6 +7008,7 @@ pm_statements_node_create(pm_parser_t *parser) {
     *node = (pm_statements_node_t) {
         {
             .type = PM_STATEMENTS_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_NULL_VALUE(parser)
         },
         .body = { 0 }
@@ -6936,6 +7106,7 @@ pm_string_node_create_unescaped(pm_parser_t *parser, const pm_token_t *opening, 
         {
             .type = PM_STRING_NODE,
             .flags = flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = (opening->type == PM_TOKEN_NOT_PROVIDED ? content->start : opening->start),
                 .end = (closing->type == PM_TOKEN_NOT_PROVIDED ? content->end : closing->end)
@@ -6985,6 +7156,7 @@ pm_super_node_create(pm_parser_t *parser, const pm_token_t *keyword, pm_argument
     *node = (pm_super_node_t) {
         {
             .type = PM_SUPER_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = end,
@@ -7222,6 +7394,7 @@ pm_symbol_node_create_unescaped(pm_parser_t *parser, const pm_token_t *opening, 
         {
             .type = PM_SYMBOL_NODE,
             .flags = PM_NODE_FLAG_STATIC_LITERAL | flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = (opening->type == PM_TOKEN_NOT_PROVIDED ? value->start : opening->start),
                 .end = (closing->type == PM_TOKEN_NOT_PROVIDED ? value->end : closing->end)
@@ -7303,6 +7476,7 @@ pm_symbol_node_synthesized_create(pm_parser_t *parser, const char *content) {
         {
             .type = PM_SYMBOL_NODE,
             .flags = PM_NODE_FLAG_STATIC_LITERAL | PM_SYMBOL_FLAGS_FORCED_US_ASCII_ENCODING,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_NULL_VALUE(parser)
         },
         .value_loc = PM_LOCATION_NULL_VALUE(parser),
@@ -7345,6 +7519,7 @@ pm_string_node_to_symbol_node(pm_parser_t *parser, pm_string_node_t *node, const
         {
             .type = PM_SYMBOL_NODE,
             .flags = PM_NODE_FLAG_STATIC_LITERAL,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = opening->start,
                 .end = closing->end
@@ -7388,6 +7563,7 @@ pm_symbol_node_to_string_node(pm_parser_t *parser, pm_symbol_node_t *node) {
         {
             .type = PM_STRING_NODE,
             .flags = flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = node->base.location
         },
         .opening_loc = node->opening_loc,
@@ -7415,6 +7591,7 @@ pm_true_node_create(pm_parser_t *parser, const pm_token_t *token) {
     *node = (pm_true_node_t) {{
         .type = PM_TRUE_NODE,
         .flags = PM_NODE_FLAG_STATIC_LITERAL,
+        .id = PM_ASSIGN_NODE_ID(parser),
         .location = PM_LOCATION_TOKEN_VALUE(token)
     }};
 
@@ -7431,6 +7608,7 @@ pm_true_node_synthesized_create(pm_parser_t *parser) {
     *node = (pm_true_node_t) {{
         .type = PM_TRUE_NODE,
         .flags = PM_NODE_FLAG_STATIC_LITERAL,
+        .id = PM_ASSIGN_NODE_ID(parser),
         .location = { .start = parser->start, .end = parser->end }
     }};
 
@@ -7448,6 +7626,7 @@ pm_undef_node_create(pm_parser_t *parser, const pm_token_t *token) {
     *node = (pm_undef_node_t) {
         {
             .type = PM_UNDEF_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_TOKEN_VALUE(token),
         },
         .keyword_loc = PM_LOCATION_TOKEN_VALUE(token),
@@ -7485,6 +7664,7 @@ pm_unless_node_create(pm_parser_t *parser, const pm_token_t *keyword, pm_node_t 
         {
             .type = PM_UNLESS_NODE,
             .flags = PM_NODE_FLAG_NEWLINE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = end
@@ -7516,6 +7696,7 @@ pm_unless_node_modifier_create(pm_parser_t *parser, pm_node_t *statement, const 
         {
             .type = PM_UNLESS_NODE,
             .flags = PM_NODE_FLAG_NEWLINE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = statement->location.start,
                 .end = predicate->location.end
@@ -7573,6 +7754,7 @@ pm_until_node_create(pm_parser_t *parser, const pm_token_t *keyword, const pm_to
         {
             .type = PM_UNTIL_NODE,
             .flags = flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = closing->end,
@@ -7600,10 +7782,11 @@ pm_until_node_modifier_create(pm_parser_t *parser, const pm_token_t *keyword, pm
         {
             .type = PM_UNTIL_NODE,
             .flags = flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = statements->base.location.start,
                 .end = predicate->location.end,
-            },
+            }
         },
         .keyword_loc = PM_LOCATION_TOKEN_VALUE(keyword),
         .closing_loc = PM_OPTIONAL_LOCATION_NOT_PROVIDED_VALUE,
@@ -7624,6 +7807,7 @@ pm_when_node_create(pm_parser_t *parser, const pm_token_t *keyword) {
     *node = (pm_when_node_t) {
         {
             .type = PM_WHEN_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = NULL
@@ -7680,6 +7864,7 @@ pm_while_node_create(pm_parser_t *parser, const pm_token_t *keyword, const pm_to
         {
             .type = PM_WHILE_NODE,
             .flags = flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = closing->end
@@ -7707,6 +7892,7 @@ pm_while_node_modifier_create(pm_parser_t *parser, const pm_token_t *keyword, pm
         {
             .type = PM_WHILE_NODE,
             .flags = flags,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = statements->base.location.start,
                 .end = predicate->location.end
@@ -7731,6 +7917,7 @@ pm_while_node_synthesized_create(pm_parser_t *parser, pm_node_t *predicate, pm_s
     *node = (pm_while_node_t) {
         {
             .type = PM_WHILE_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = PM_LOCATION_NULL_VALUE(parser)
         },
         .keyword_loc = PM_LOCATION_NULL_VALUE(parser),
@@ -7754,10 +7941,11 @@ pm_xstring_node_create_unescaped(pm_parser_t *parser, const pm_token_t *opening,
         {
             .type = PM_X_STRING_NODE,
             .flags = PM_STRING_FLAGS_FROZEN,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = opening->start,
                 .end = closing->end
-            },
+            }
         },
         .opening_loc = PM_LOCATION_TOKEN_VALUE(opening),
         .content_loc = PM_LOCATION_TOKEN_VALUE(content),
@@ -7797,6 +7985,7 @@ pm_yield_node_create(pm_parser_t *parser, const pm_token_t *keyword, const pm_lo
     *node = (pm_yield_node_t) {
         {
             .type = PM_YIELD_NODE,
+            .id = PM_ASSIGN_NODE_ID(parser),
             .location = {
                 .start = keyword->start,
                 .end = end
@@ -7812,6 +8001,7 @@ pm_yield_node_create(pm_parser_t *parser, const pm_token_t *keyword, const pm_lo
 }
 
 #undef PM_ALLOC_NODE
+#undef PM_ASSIGN_NODE_ID
 
 /**
  * Check if any of the currently visible scopes contain a local variable
@@ -21311,6 +21501,7 @@ pm_parser_init(pm_parser_t *parser, const uint8_t *source, size_t size, const pm
     assert(source != NULL);
 
     *parser = (pm_parser_t) {
+        .node_id = 0,
         .lex_state = PM_LEX_STATE_BEG,
         .enclosure_nesting = 0,
         .lambda_enclosure_nesting = -1,

--- a/prism/templates/include/prism/ast.h.erb
+++ b/prism/templates/include/prism/ast.h.erb
@@ -140,6 +140,13 @@ typedef struct pm_node {
     pm_node_flags_t flags;
 
     /**
+     * This is a unique identifier for the node in the tree. It is used for
+     * reproducable parses, such that we can keep around only an identifier and
+     * then reliably find it again on a subsequent parse.
+     */
+    uint32_t id;
+
+    /**
      * This is the location of the node in the source. It's a range of bytes
      * containing a start and an end.
      */

--- a/prism/templates/src/prettyprint.c.erb
+++ b/prism/templates/src/prettyprint.c.erb
@@ -36,7 +36,7 @@ prettyprint_node(pm_buffer_t *output_buffer, const pm_parser_t *parser, const pm
             <%- end -%>
             pm_buffer_append_string(output_buffer, "@ <%= node.name %> (location: ", <%= node.name.length + 14 %>);
             prettyprint_location(output_buffer, parser, &node->location);
-            pm_buffer_append_string(output_buffer, ")\n", 2);
+            pm_buffer_append_format(output_buffer, ", id: %" PRIu32 ")\n", node->id);
             <%- node.fields.each_with_index do |field, index| -%>
             <%- preadd = index == node.fields.length - 1 ? "    " : "|   " -%>
 

--- a/prism/util/pm_newline_list.c
+++ b/prism/util/pm_newline_list.c
@@ -55,6 +55,35 @@ pm_newline_list_append(pm_newline_list_t *list, const uint8_t *cursor) {
 }
 
 /**
+ * Returns the line of the given offset. If the offset is not in the list, the
+ * line of the closest offset less than the given offset is returned.
+ */
+int32_t
+pm_newline_list_line(const pm_newline_list_t *list, const uint8_t *cursor, int32_t start_line) {
+    assert(cursor >= list->start);
+    size_t offset = (size_t) (cursor - list->start);
+
+    size_t left = 0;
+    size_t right = list->size - 1;
+
+    while (left <= right) {
+        size_t mid = left + (right - left) / 2;
+
+        if (list->offsets[mid] == offset) {
+            return ((int32_t) mid) + start_line;
+        }
+
+        if (list->offsets[mid] < offset) {
+            left = mid + 1;
+        } else {
+            right = mid - 1;
+        }
+    }
+
+    return ((int32_t) left) + start_line - 1;
+}
+
+/**
  * Returns the line and column of the given offset. If the offset is not in the
  * list, the line and column of the closest offset less than the given offset
  * are returned.

--- a/prism/util/pm_newline_list.h
+++ b/prism/util/pm_newline_list.h
@@ -81,6 +81,12 @@ pm_newline_list_clear(pm_newline_list_t *list);
 bool pm_newline_list_append(pm_newline_list_t *list, const uint8_t *cursor);
 
 /**
+ * Returns the line of the given offset. If the offset is not in the list, the
+ * line of the closest offset less than the given offset is returned.
+ */
+int32_t pm_newline_list_line(const pm_newline_list_t *list, const uint8_t *cursor, int32_t start_line);
+
+/**
  * Returns the line and column of the given offset. If the offset is not in the
  * list, the line and column of the closest offset less than the given offset
  * are returned.

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1,7 +1,20 @@
 #include "prism.h"
 
+/**
+ * This compiler defines its own concept of the location of a node. We do this
+ * because we want to pair line information with node identifier so that we can
+ * have reproducable parses.
+ */
+typedef struct {
+    /** This is the line number of a node. */
+    int32_t line;
+
+    /** This is a unique identifier for the node. */
+    uint32_t node_id;
+} pm_node_location_t;
+
 /******************************************************************************/
-/* These macros operate on pm_line_column_t structs as opposed to NODE*s.     */
+/* These macros operate on pm_node_location_t structs as opposed to NODE*s.   */
 /******************************************************************************/
 
 #define PUSH_ADJUST(seq, location, label) \
@@ -11,16 +24,16 @@
     ADD_ELEM((seq), (LINK_ELEMENT *) new_adjust_body(iseq, (label), -1))
 
 #define PUSH_INSN(seq, location, insn) \
-    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).column, BIN(insn), 0))
+    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).node_id, BIN(insn), 0))
 
 #define PUSH_INSN1(seq, location, insn, op1) \
-    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).column, BIN(insn), 1, (VALUE)(op1)))
+    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).node_id, BIN(insn), 1, (VALUE)(op1)))
 
 #define PUSH_INSN2(seq, location, insn, op1, op2) \
-    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).column, BIN(insn), 2, (VALUE)(op1), (VALUE)(op2)))
+    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).node_id, BIN(insn), 2, (VALUE)(op1), (VALUE)(op2)))
 
 #define PUSH_INSN3(seq, location, insn, op1, op2, op3) \
-    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).column, BIN(insn), 3, (VALUE)(op1), (VALUE)(op2), (VALUE)(op3)))
+    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).node_id, BIN(insn), 3, (VALUE)(op1), (VALUE)(op2), (VALUE)(op3)))
 
 #define PUSH_INSNL(seq, location, insn, label) \
     (PUSH_INSN1(seq, location, insn, label), LABEL_REF(label))
@@ -29,7 +42,7 @@
     ADD_ELEM((seq), (LINK_ELEMENT *) (label))
 
 #define PUSH_SEND_R(seq, location, id, argc, block, flag, keywords) \
-    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_send(iseq, (int) (location).line, (int) (location).column, (id), (VALUE)(argc), (block), (VALUE)(flag), (keywords)))
+    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_send(iseq, (int) (location).line, (int) (location).node_id, (id), (VALUE)(argc), (block), (VALUE)(flag), (keywords)))
 
 #define PUSH_SEND(seq, location, id, argc) \
     PUSH_SEND_R((seq), location, (id), (argc), NULL, (VALUE)INT2FIX(0), NULL)
@@ -68,34 +81,34 @@
 /******************************************************************************/
 
 static void
-pm_iseq_add_getlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line_no, int column, int idx, int level)
+pm_iseq_add_getlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line, int node_id, int idx, int level)
 {
     if (iseq_local_block_param_p(iseq, idx, level)) {
-        ADD_ELEM(seq, (LINK_ELEMENT *) new_insn_body(iseq, line_no, column, BIN(getblockparam), 2, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level)));
+        ADD_ELEM(seq, (LINK_ELEMENT *) new_insn_body(iseq, line, node_id, BIN(getblockparam), 2, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level)));
     }
     else {
-        ADD_ELEM(seq, (LINK_ELEMENT *) new_insn_body(iseq, line_no, column, BIN(getlocal), 2, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level)));
+        ADD_ELEM(seq, (LINK_ELEMENT *) new_insn_body(iseq, line, node_id, BIN(getlocal), 2, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level)));
     }
     if (level > 0) access_outer_variables(iseq, level, iseq_lvar_id(iseq, idx, level), Qfalse);
 }
 
 static void
-pm_iseq_add_setlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line_no, int column, int idx, int level)
+pm_iseq_add_setlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line, int node_id, int idx, int level)
 {
     if (iseq_local_block_param_p(iseq, idx, level)) {
-        ADD_ELEM(seq, (LINK_ELEMENT *) new_insn_body(iseq, line_no, column, BIN(setblockparam), 2, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level)));
+        ADD_ELEM(seq, (LINK_ELEMENT *) new_insn_body(iseq, line, node_id, BIN(setblockparam), 2, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level)));
     }
     else {
-        ADD_ELEM(seq, (LINK_ELEMENT *) new_insn_body(iseq, line_no, column, BIN(setlocal), 2, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level)));
+        ADD_ELEM(seq, (LINK_ELEMENT *) new_insn_body(iseq, line, node_id, BIN(setlocal), 2, INT2FIX((idx) + VM_ENV_DATA_SIZE - 1), INT2FIX(level)));
     }
     if (level > 0) access_outer_variables(iseq, level, iseq_lvar_id(iseq, idx, level), Qtrue);
 }
 
 #define PUSH_GETLOCAL(seq, location, idx, level) \
-    pm_iseq_add_getlocal(iseq, (seq), (int) (location).line, (int) (location).column, (idx), (level))
+    pm_iseq_add_getlocal(iseq, (seq), (int) (location).line, (int) (location).node_id, (idx), (level))
 
 #define PUSH_SETLOCAL(seq, location, idx, level) \
-    pm_iseq_add_setlocal(iseq, (seq), (int) (location).line, (int) (location).column, (idx), (level))
+    pm_iseq_add_setlocal(iseq, (seq), (int) (location).line, (int) (location).node_id, (idx), (level))
 
 /******************************************************************************/
 /* These are helper macros for the compiler.                                  */
@@ -131,24 +144,25 @@ pm_iseq_add_setlocal(rb_iseq_t *iseq, LINK_ANCHOR *const seq, int line_no, int c
 #define PM_CONSTANT_MULT ((pm_constant_id_t)(idMULT | PM_SPECIAL_CONSTANT_FLAG))
 #define PM_CONSTANT_POW ((pm_constant_id_t)(idPow | PM_SPECIAL_CONSTANT_FLAG))
 
-#define PM_NODE_START_LINE_COLUMN(parser, node) \
-    pm_newline_list_line_column(&(parser)->newline_list, ((const pm_node_t *) (node))->location.start, (parser)->start_line)
+#define PM_NODE_START_LOCATION(parser, node) \
+    ((pm_node_location_t) { .line = pm_newline_list_line(&(parser)->newline_list, ((const pm_node_t *) (node))->location.start, (parser)->start_line), .node_id = ((const pm_node_t *) (node))->id })
 
-#define PM_NODE_END_LINE_COLUMN(parser, node) \
-    pm_newline_list_line_column(&(parser)->newline_list, ((const pm_node_t *) (node))->location.end, (parser)->start_line)
+#define PM_NODE_END_LOCATION(parser, node) \
+    ((pm_node_location_t) { .line = pm_newline_list_line(&(parser)->newline_list, ((const pm_node_t *) (node))->location.end, (parser)->start_line), .node_id = ((const pm_node_t *) (node))->id })
 
-#define PM_LOCATION_START_LINE_COLUMN(parser, location) \
-    pm_newline_list_line_column(&(parser)->newline_list, (location)->start, (parser)->start_line)
+#define PM_LOCATION_START_LOCATION(parser, location, id) \
+    ((pm_node_location_t) { .line = pm_newline_list_line(&(parser)->newline_list, (location)->start, (parser)->start_line), .node_id = id })
 
 static int
 pm_node_line_number(const pm_parser_t *parser, const pm_node_t *node)
 {
-    return (int) PM_NODE_START_LINE_COLUMN(parser, node).line;
+    return (int) pm_newline_list_line(&parser->newline_list, node->location.start, parser->start_line);
 }
 
 static int
-pm_location_line_number(const pm_parser_t *parser, const pm_location_t *location) {
-    return (int) PM_LOCATION_START_LINE_COLUMN(parser, location).line;
+pm_location_line_number(const pm_parser_t *parser, const pm_location_t *location)
+{
+    return (int) pm_newline_list_line(&parser->newline_list, location->start, parser->start_line);
 }
 
 /**
@@ -543,7 +557,7 @@ parse_regexp_concat(rb_iseq_t *iseq, const pm_scope_node_t *scope_node, const pm
 static void pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node);
 
 static int
-pm_interpolated_node_compile(rb_iseq_t *iseq, const pm_node_list_t *parts, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node, rb_encoding *implicit_regexp_encoding, rb_encoding *explicit_regexp_encoding)
+pm_interpolated_node_compile(rb_iseq_t *iseq, const pm_node_list_t *parts, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node, rb_encoding *implicit_regexp_encoding, rb_encoding *explicit_regexp_encoding)
 {
     int stack_size = 0;
     size_t parts_size = parts->size;
@@ -551,7 +565,7 @@ pm_interpolated_node_compile(rb_iseq_t *iseq, const pm_node_list_t *parts, const
 
     if (parts_size > 0) {
         VALUE current_string = Qnil;
-        pm_line_column_t current_location = *node_location;
+        pm_node_location_t current_location = *node_location;
 
         for (size_t index = 0; index < parts_size; index++) {
             const pm_node_t *part = parts->nodes[index];
@@ -572,7 +586,7 @@ pm_interpolated_node_compile(rb_iseq_t *iseq, const pm_node_list_t *parts, const
                 }
                 else {
                     current_string = string_value;
-                    if (index != 0) current_location = PM_NODE_END_LINE_COLUMN(scope_node->parser, part);
+                    if (index != 0) current_location = PM_NODE_END_LOCATION(scope_node->parser, part);
                 }
             }
             else {
@@ -599,7 +613,7 @@ pm_interpolated_node_compile(rb_iseq_t *iseq, const pm_node_list_t *parts, const
                     }
                     else {
                         current_string = string_value;
-                        current_location = PM_NODE_START_LINE_COLUMN(scope_node->parser, part);
+                        current_location = PM_NODE_START_LOCATION(scope_node->parser, part);
                     }
                 }
                 else {
@@ -627,7 +641,7 @@ pm_interpolated_node_compile(rb_iseq_t *iseq, const pm_node_list_t *parts, const
                     PUSH_INSN1(ret, current_location, putobject, rb_fstring(current_string));
                     PM_COMPILE_NOT_POPPED(part);
 
-                    const pm_line_column_t current_location = PM_NODE_START_LINE_COLUMN(scope_node->parser, part);
+                    const pm_node_location_t current_location = PM_NODE_START_LOCATION(scope_node->parser, part);
                     PUSH_INSN(ret, current_location, dup);
                     PUSH_INSN1(ret, current_location, objtostring, new_callinfo(iseq, idTo_s, 0, VM_CALL_FCALL | VM_CALL_ARGS_SIMPLE, NULL, FALSE));
                     PUSH_INSN(ret, current_location, anytostring);
@@ -660,7 +674,7 @@ pm_interpolated_node_compile(rb_iseq_t *iseq, const pm_node_list_t *parts, const
 }
 
 static void
-pm_compile_regexp_dynamic(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_list_t *parts, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_regexp_dynamic(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_list_t *parts, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
     rb_encoding *explicit_regexp_encoding = parse_regexp_encoding(scope_node, node);
     rb_encoding *implicit_regexp_encoding = explicit_regexp_encoding != NULL ? explicit_regexp_encoding : scope_node->encoding;
@@ -812,8 +826,8 @@ pm_static_literal_value(rb_iseq_t *iseq, const pm_node_t *node, const pm_scope_n
 static rb_code_location_t
 pm_code_location(const pm_scope_node_t *scope_node, const pm_node_t *node)
 {
-    const pm_line_column_t start_location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
-    const pm_line_column_t end_location = PM_NODE_END_LINE_COLUMN(scope_node->parser, node);
+    const pm_line_column_t start_location = pm_newline_list_line_column(&scope_node->parser->newline_list, node->location.start, scope_node->parser->start_line);
+    const pm_line_column_t end_location = pm_newline_list_line_column(&scope_node->parser->newline_list, node->location.end, scope_node->parser->start_line);
 
     return (rb_code_location_t) {
         .beg_pos = { .lineno = start_location.line, .column = start_location.column },
@@ -835,7 +849,7 @@ pm_compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const pm_no
 static void
 pm_compile_logical(rb_iseq_t *iseq, LINK_ANCHOR *const ret, pm_node_t *cond, LABEL *then_label, LABEL *else_label, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, cond);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, cond);
 
     DECL_ANCHOR(seq);
     INIT_ANCHOR(seq);
@@ -865,7 +879,7 @@ pm_compile_logical(rb_iseq_t *iseq, LINK_ANCHOR *const ret, pm_node_t *cond, LAB
 static void
 pm_compile_flip_flop_bound(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = { .line = ISEQ_BODY(iseq)->location.first_lineno, .column = -1 };
+    const pm_node_location_t location = { .line = ISEQ_BODY(iseq)->location.first_lineno, .node_id = -1 };
 
     if (PM_NODE_TYPE_P(node, PM_INTEGER_NODE)) {
         PM_COMPILE_NOT_POPPED(node);
@@ -881,7 +895,7 @@ pm_compile_flip_flop_bound(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *
 static void
 pm_compile_flip_flop(const pm_flip_flop_node_t *flip_flop_node, LABEL *else_label, LABEL *then_label, rb_iseq_t *iseq, const int lineno, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = { .line = ISEQ_BODY(iseq)->location.first_lineno, .column = -1 };
+    const pm_node_location_t location = { .line = ISEQ_BODY(iseq)->location.first_lineno, .node_id = -1 };
     LABEL *lend = NEW_LABEL(location.line);
 
     int again = !(flip_flop_node->base.flags & PM_RANGE_FLAGS_EXCLUDE_END);
@@ -920,12 +934,12 @@ pm_compile_flip_flop(const pm_flip_flop_node_t *flip_flop_node, LABEL *else_labe
     PUSH_INSNL(ret, location, jump, then_label);
 }
 
-static void pm_compile_defined_expr(rb_iseq_t *iseq, const pm_node_t *node, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node, bool in_condition);
+static void pm_compile_defined_expr(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node, bool in_condition);
 
 static void
 pm_compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const pm_node_t *cond, LABEL *then_label, LABEL *else_label, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, cond);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, cond);
 
 again:
     switch (PM_NODE_TYPE(cond)) {
@@ -980,9 +994,9 @@ again:
  * Compile an if or unless node.
  */
 static void
-pm_compile_conditional(rb_iseq_t *iseq, const pm_line_column_t *line_column, pm_node_type_t type, const pm_node_t *node, const pm_statements_node_t *statements, const pm_node_t *consequent, const pm_node_t *predicate, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_conditional(rb_iseq_t *iseq, const pm_node_location_t *node_location, pm_node_type_t type, const pm_node_t *node, const pm_statements_node_t *statements, const pm_node_t *consequent, const pm_node_t *predicate, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *line_column;
+    const pm_node_location_t location = *node_location;
     LABEL *then_label = NEW_LABEL(location.line);
     LABEL *else_label = NEW_LABEL(location.line);
     LABEL *end_label = NULL;
@@ -1021,7 +1035,7 @@ pm_compile_conditional(rb_iseq_t *iseq, const pm_line_column_t *line_column, pm_
                 if (statements != NULL) {
                     branch_location = pm_code_location(scope_node, (const pm_node_t *) statements);
                 } else if (type == PM_IF_NODE) {
-                    pm_line_column_t predicate_end = PM_NODE_END_LINE_COLUMN(scope_node->parser, predicate);
+                    pm_line_column_t predicate_end = pm_newline_list_line_column(&scope_node->parser->newline_list, predicate->location.end, scope_node->parser->start_line);
                     branch_location = (rb_code_location_t) {
                         .beg_pos = { .lineno = predicate_end.line, .column = predicate_end.column },
                         .end_pos = { .lineno = predicate_end.line, .column = predicate_end.column }
@@ -1084,9 +1098,9 @@ pm_compile_conditional(rb_iseq_t *iseq, const pm_line_column_t *line_column, pm_
  * Compile a while or until loop.
  */
 static void
-pm_compile_loop(rb_iseq_t *iseq, const pm_line_column_t *line_column, pm_node_flags_t flags, enum pm_node_type type, const pm_node_t *node, const pm_statements_node_t *statements, const pm_node_t *predicate, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_loop(rb_iseq_t *iseq, const pm_node_location_t *node_location, pm_node_flags_t flags, enum pm_node_type type, const pm_node_t *node, const pm_statements_node_t *statements, const pm_node_t *predicate, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *line_column;
+    const pm_node_location_t location = *node_location;
 
     LABEL *prev_start_label = ISEQ_COMPILE_DATA(iseq)->start_label;
     LABEL *prev_end_label = ISEQ_COMPILE_DATA(iseq)->end_label;
@@ -1219,7 +1233,7 @@ pm_new_child_iseq(rb_iseq_t *iseq, pm_scope_node_t *node, VALUE name, const rb_i
 }
 
 static int
-pm_compile_class_path(rb_iseq_t *iseq, const pm_node_t *node, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_class_path(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
     if (PM_NODE_TYPE_P(node, PM_CONSTANT_PATH_NODE)) {
         const pm_node_t *parent = ((const pm_constant_path_node_t *) node)->parent;
@@ -1247,9 +1261,9 @@ pm_compile_class_path(rb_iseq_t *iseq, const pm_node_t *node, const pm_line_colu
  * method calls that are followed by a ||= or &&= operator.
  */
 static void
-pm_compile_call_and_or_write_node(rb_iseq_t *iseq, bool and_node, const pm_node_t *receiver, const pm_node_t *value, pm_constant_id_t write_name, pm_constant_id_t read_name, bool safe_nav, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_call_and_or_write_node(rb_iseq_t *iseq, bool and_node, const pm_node_t *receiver, const pm_node_t *value, pm_constant_id_t write_name, pm_constant_id_t read_name, bool safe_nav, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
     LABEL *lfin = NEW_LABEL(location.line);
     LABEL *lcfin = NEW_LABEL(location.line);
     LABEL *lskip = NULL;
@@ -1305,7 +1319,7 @@ pm_compile_call_and_or_write_node(rb_iseq_t *iseq, bool and_node, const pm_node_
 static void
 pm_compile_hash_elements(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_list_t *elements, LINK_ANCHOR *const ret, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
 
     // If this element is not popped, then we need to create the hash on the
     // stack. Neighboring plain assoc nodes should be grouped together (either
@@ -1394,9 +1408,9 @@ pm_compile_hash_elements(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
 
 // This is details. Users should call pm_setup_args() instead.
 static int
-pm_setup_args_core(const pm_arguments_node_t *arguments_node, const pm_node_t *block, int *flags, const bool has_regular_blockarg, struct rb_callinfo_kwarg **kw_arg, rb_iseq_t *iseq, LINK_ANCHOR *const ret, pm_scope_node_t *scope_node, const pm_line_column_t *node_location)
+pm_setup_args_core(const pm_arguments_node_t *arguments_node, const pm_node_t *block, int *flags, const bool has_regular_blockarg, struct rb_callinfo_kwarg **kw_arg, rb_iseq_t *iseq, LINK_ANCHOR *const ret, pm_scope_node_t *scope_node, const pm_node_location_t *node_location)
 {
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
 
     int orig_argc = 0;
     bool has_splat = false;
@@ -1655,7 +1669,7 @@ pm_setup_args_core(const pm_arguments_node_t *arguments_node, const pm_node_t *b
 
 // Compile the argument parts of a call
 static int
-pm_setup_args(const pm_arguments_node_t *arguments_node, const pm_node_t *block, int *flags, struct rb_callinfo_kwarg **kw_arg, rb_iseq_t *iseq, LINK_ANCHOR *const ret, pm_scope_node_t *scope_node, const pm_line_column_t *node_location)
+pm_setup_args(const pm_arguments_node_t *arguments_node, const pm_node_t *block, int *flags, struct rb_callinfo_kwarg **kw_arg, rb_iseq_t *iseq, LINK_ANCHOR *const ret, pm_scope_node_t *scope_node, const pm_node_location_t *node_location)
 {
     if (block && PM_NODE_TYPE_P(block, PM_BLOCK_ARGUMENT_NODE)) {
         // We compile the `&block_arg` expression first and stitch it later
@@ -1701,9 +1715,9 @@ pm_setup_args(const pm_arguments_node_t *arguments_node, const pm_node_t *block,
  * and then calling the []= method with the result of the operator method.
  */
 static void
-pm_compile_index_operator_write_node(rb_iseq_t *iseq, const pm_index_operator_write_node_t *node, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_index_operator_write_node(rb_iseq_t *iseq, const pm_index_operator_write_node_t *node, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
     if (!popped) PUSH_INSN(ret, location, putnil);
 
     PM_COMPILE_NOT_POPPED(node->receiver);
@@ -1818,9 +1832,9 @@ pm_compile_index_operator_write_node(rb_iseq_t *iseq, const pm_index_operator_wr
  * []= method.
  */
 static void
-pm_compile_index_control_flow_write_node(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_t *receiver, const pm_arguments_node_t *arguments, const pm_node_t *block, const pm_node_t *value, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_index_control_flow_write_node(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_t *receiver, const pm_arguments_node_t *arguments, const pm_node_t *block, const pm_node_t *value, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
     if (!popped) PUSH_INSN(ret, location, putnil);
     PM_COMPILE_NOT_POPPED(receiver);
 
@@ -1961,7 +1975,7 @@ static int pm_compile_pattern(rb_iseq_t *iseq, pm_scope_node_t *scope_node, cons
 static int
 pm_compile_pattern_generic_error(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t *node, LINK_ANCHOR *const ret, VALUE message, unsigned int base_index)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
     LABEL *match_succeeded_label = NEW_LABEL(location.line);
 
     PUSH_INSN(ret, location, dup);
@@ -1991,7 +2005,7 @@ pm_compile_pattern_generic_error(rb_iseq_t *iseq, pm_scope_node_t *scope_node, c
 static int
 pm_compile_pattern_length_error(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t *node, LINK_ANCHOR *const ret, VALUE message, VALUE length, unsigned int base_index)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
     LABEL *match_succeeded_label = NEW_LABEL(location.line);
 
     PUSH_INSN(ret, location, dup);
@@ -2024,7 +2038,7 @@ pm_compile_pattern_length_error(rb_iseq_t *iseq, pm_scope_node_t *scope_node, co
 static int
 pm_compile_pattern_eqq_error(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t *node, LINK_ANCHOR *const ret, unsigned int base_index)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
     LABEL *match_succeeded_label = NEW_LABEL(location.line);
 
     PUSH_INSN(ret, location, dup);
@@ -2072,7 +2086,7 @@ pm_compile_pattern_match(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_
 static int
 pm_compile_pattern_deconstruct(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t *node, LINK_ANCHOR *const ret, LABEL *deconstruct_label, LABEL *match_failed_label, LABEL *deconstructed_label, LABEL *type_error_label, bool in_single_pattern, bool use_deconstructed_cache, unsigned int base_index)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
 
     if (use_deconstructed_cache) {
         PUSH_INSN1(ret, location, topn, INT2FIX(base_index + PM_PATTERN_BASE_INDEX_OFFSET_DECONSTRUCTED_CACHE));
@@ -2124,7 +2138,7 @@ pm_compile_pattern_deconstruct(rb_iseq_t *iseq, pm_scope_node_t *scope_node, con
 static int
 pm_compile_pattern_constant(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t *node, LINK_ANCHOR *const ret, LABEL *match_failed_label, bool in_single_pattern, unsigned int base_index)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
 
     PUSH_INSN(ret, location, dup);
     PM_COMPILE_NOT_POPPED(node);
@@ -2147,7 +2161,7 @@ pm_compile_pattern_constant(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const 
 static void
 pm_compile_pattern_error_handler(rb_iseq_t *iseq, const pm_scope_node_t *scope_node, const pm_node_t *node, LINK_ANCHOR *const ret, LABEL *done_label, bool popped)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
     LABEL *key_error_label = NEW_LABEL(location.line);
     LABEL *cleanup_label = NEW_LABEL(location.line);
 
@@ -2196,7 +2210,7 @@ pm_compile_pattern_error_handler(rb_iseq_t *iseq, const pm_scope_node_t *scope_n
 static int
 pm_compile_pattern(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t *node, LINK_ANCHOR *const ret, LABEL *matched_label, LABEL *unmatched_label, bool in_single_pattern, bool in_alternation_pattern, bool use_deconstructed_cache, unsigned int base_index)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
 
     switch (PM_NODE_TYPE(node)) {
       case PM_ARRAY_PATTERN_NODE: {
@@ -3038,7 +3052,7 @@ pm_iseq_builtin_function_name(const pm_scope_node_t *scope_node, const pm_node_t
 
 // Compile Primitive.attr! :leaf, ...
 static int
-pm_compile_builtin_attr(rb_iseq_t *iseq, const pm_scope_node_t *scope_node, const pm_arguments_node_t *arguments, const pm_line_column_t *node_location)
+pm_compile_builtin_attr(rb_iseq_t *iseq, const pm_scope_node_t *scope_node, const pm_arguments_node_t *arguments, const pm_node_location_t *node_location)
 {
     if (arguments == NULL) {
         COMPILE_ERROR(iseq, node_location->line, "attr!: no argument");
@@ -3074,7 +3088,7 @@ pm_compile_builtin_attr(rb_iseq_t *iseq, const pm_scope_node_t *scope_node, cons
 }
 
 static int
-pm_compile_builtin_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const pm_scope_node_t *scope_node, const pm_arguments_node_t *arguments, const pm_line_column_t *node_location, int popped)
+pm_compile_builtin_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const pm_scope_node_t *scope_node, const pm_arguments_node_t *arguments, const pm_node_location_t *node_location, int popped)
 {
     if (arguments == NULL) {
         COMPILE_ERROR(iseq, node_location->line, "arg!: no argument");
@@ -3104,7 +3118,7 @@ pm_compile_builtin_arg(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const pm_scope_n
 }
 
 static int
-pm_compile_builtin_mandatory_only_method(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_call_node_t *call_node, const pm_line_column_t *node_location)
+pm_compile_builtin_mandatory_only_method(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_call_node_t *call_node, const pm_node_location_t *node_location)
 {
     const pm_node_t *ast_node = scope_node->ast_node;
     if (!PM_NODE_TYPE_P(ast_node, PM_DEF_NODE)) {
@@ -3169,7 +3183,7 @@ pm_compile_builtin_mandatory_only_method(rb_iseq_t *iseq, pm_scope_node_t *scope
 }
 
 static int
-pm_compile_builtin_function_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, pm_scope_node_t *scope_node, const pm_call_node_t *call_node, const pm_line_column_t *node_location, int popped, const rb_iseq_t *parent_block, const char *builtin_func)
+pm_compile_builtin_function_call(rb_iseq_t *iseq, LINK_ANCHOR *const ret, pm_scope_node_t *scope_node, const pm_call_node_t *call_node, const pm_node_location_t *node_location, int popped, const rb_iseq_t *parent_block, const char *builtin_func)
 {
     const pm_arguments_node_t *arguments = call_node->arguments;
 
@@ -3270,14 +3284,14 @@ pm_compile_call(rb_iseq_t *iseq, const pm_call_node_t *call_node, LINK_ANCHOR *c
     const pm_location_t *message_loc = &call_node->message_loc;
     if (message_loc->start == NULL) message_loc = &call_node->base.location;
 
-    const pm_line_column_t location = PM_LOCATION_START_LINE_COLUMN(scope_node->parser, message_loc);
+    const pm_node_location_t location = PM_LOCATION_START_LOCATION(scope_node->parser, message_loc, call_node->base.id);
     LABEL *else_label = NEW_LABEL(location.line);
     LABEL *end_label = NEW_LABEL(location.line);
     LABEL *retry_end_l = NEW_LABEL(location.line);
 
     VALUE branches = Qfalse;
     rb_code_location_t code_location = { 0 };
-    int node_id = location.column;
+    int node_id = (int) call_node->base.id;
 
     if (PM_NODE_FLAG_P(call_node, PM_CALL_NODE_FLAGS_SAFE_NAVIGATION)) {
         if (PM_BRANCH_COVERAGE_P(iseq)) {
@@ -3291,7 +3305,7 @@ pm_compile_call(rb_iseq_t *iseq, const pm_call_node_t *call_node, LINK_ANCHOR *c
             end_cursor = (end_cursor == NULL || cursors[1] == NULL) ? cursors[1] : (end_cursor > cursors[1] ? end_cursor : cursors[1]);
             end_cursor = (end_cursor == NULL || cursors[2] == NULL) ? cursors[2] : (end_cursor > cursors[2] ? end_cursor : cursors[2]);
 
-            const pm_line_column_t start_location = PM_NODE_START_LINE_COLUMN(scope_node->parser, call_node);
+            const pm_line_column_t start_location = pm_newline_list_line_column(&scope_node->parser->newline_list, call_node->base.location.start, scope_node->parser->start_line);
             const pm_line_column_t end_location = pm_newline_list_line_column(&scope_node->parser->newline_list, end_cursor, scope_node->parser->start_line);
 
             code_location = (rb_code_location_t) {
@@ -3387,11 +3401,11 @@ pm_compile_call(rb_iseq_t *iseq, const pm_call_node_t *call_node, LINK_ANCHOR *c
 }
 
 static void
-pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node, bool in_condition, LABEL **lfinish, bool explicit_receiver)
+pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node, bool in_condition, LABEL **lfinish, bool explicit_receiver)
 {
     // in_condition is the same as compile.c's needstr
     enum defined_type dtype = DEFINED_NOT_DEFINED;
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
 
     switch (PM_NODE_TYPE(node)) {
       case PM_ARGUMENTS_NODE: {
@@ -3739,7 +3753,7 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, const pm_line_c
 }
 
 static void
-pm_defined_expr(rb_iseq_t *iseq, const pm_node_t *node, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node, bool in_condition, LABEL **lfinish, bool explicit_receiver)
+pm_defined_expr(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node, bool in_condition, LABEL **lfinish, bool explicit_receiver)
 {
     LINK_ELEMENT *lcur = ret->last;
     pm_compile_defined_expr0(iseq, node, node_location, ret, popped, scope_node, in_condition, lfinish, false);
@@ -3770,7 +3784,7 @@ pm_defined_expr(rb_iseq_t *iseq, const pm_node_t *node, const pm_line_column_t *
 }
 
 static void
-pm_compile_defined_expr(rb_iseq_t *iseq, const pm_node_t *node, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node, bool in_condition)
+pm_compile_defined_expr(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node, bool in_condition)
 {
     LABEL *lfinish[3];
     LINK_ELEMENT *last = ret->last;
@@ -3784,7 +3798,7 @@ pm_compile_defined_expr(rb_iseq_t *iseq, const pm_node_t *node, const pm_line_co
     }
 
     if (lfinish[1]) {
-        ELEM_INSERT_NEXT(last, &new_insn_body(iseq, node_location->line, node_location->column, BIN(putnil), 0)->link);
+        ELEM_INSERT_NEXT(last, &new_insn_body(iseq, node_location->line, node_location->node_id, BIN(putnil), 0)->link);
         PUSH_INSN(ret, *node_location, swap);
 
         if (lfinish[2]) PUSH_LABEL(ret, lfinish[2]);
@@ -3952,7 +3966,7 @@ pm_compile_destructured_param_locals(const pm_multi_target_node_t *node, st_tabl
 static inline void
 pm_compile_destructured_param_write(rb_iseq_t *iseq, const pm_required_parameter_node_t *node, LINK_ANCHOR *const ret, const pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
     pm_local_index_t index = pm_lookup_local_index(iseq, scope_node, node->name, 0);
     PUSH_SETLOCAL(ret, location, index.index, index.level);
 }
@@ -3968,7 +3982,7 @@ pm_compile_destructured_param_write(rb_iseq_t *iseq, const pm_required_parameter
 static void
 pm_compile_destructured_param_writes(rb_iseq_t *iseq, const pm_multi_target_node_t *node, LINK_ANCHOR *const ret, const pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
     bool has_rest = (node->rest && PM_NODE_TYPE_P(node->rest, PM_SPLAT_NODE) && (((const pm_splat_node_t *) node->rest)->expression) != NULL);
     bool has_rights = node->rights.size > 0;
 
@@ -4165,7 +4179,7 @@ pm_compile_multi_target_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR
 static void
 pm_compile_target_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const parents, LINK_ANCHOR *const writes, LINK_ANCHOR *const cleanup, pm_scope_node_t *scope_node, pm_multi_target_state_t *state)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
 
     switch (PM_NODE_TYPE(node)) {
       case PM_LOCAL_VARIABLE_TARGET_NODE: {
@@ -4396,7 +4410,7 @@ pm_compile_target_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *cons
 static void
 pm_compile_multi_target_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const parents, LINK_ANCHOR *const writes, LINK_ANCHOR *const cleanup, pm_scope_node_t *scope_node, pm_multi_target_state_t *state)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
     const pm_node_list_t *lefts;
     const pm_node_t *rest;
     const pm_node_list_t *rights;
@@ -4479,7 +4493,7 @@ pm_compile_multi_target_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR
 static void
 pm_compile_for_node_index(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
 
     switch (PM_NODE_TYPE(node)) {
       case PM_LOCAL_VARIABLE_TARGET_NODE: {
@@ -4567,7 +4581,7 @@ pm_compile_for_node_index(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *c
 }
 
 static void
-pm_compile_rescue(rb_iseq_t *iseq, const pm_begin_node_t *cast, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_rescue(rb_iseq_t *iseq, const pm_begin_node_t *cast, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
     const pm_parser_t *parser = scope_node->parser;
 
@@ -4618,11 +4632,11 @@ pm_compile_rescue(rb_iseq_t *iseq, const pm_begin_node_t *cast, const pm_line_co
 }
 
 static void
-pm_compile_ensure(rb_iseq_t *iseq, const pm_begin_node_t *cast, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_ensure(rb_iseq_t *iseq, const pm_begin_node_t *cast, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
     const pm_parser_t *parser = scope_node->parser;
     const pm_statements_node_t *statements = cast->ensure_clause->statements;
-    const pm_line_column_t location = statements != NULL ? PM_NODE_START_LINE_COLUMN(parser, statements) : *node_location;
+    const pm_node_location_t location = statements != NULL ? PM_NODE_START_LOCATION(parser, statements) : *node_location;
 
     LABEL *estart = NEW_LABEL(location.line);
     LABEL *eend = NEW_LABEL(location.line);
@@ -4741,9 +4755,9 @@ pm_opt_aset_with_p(const rb_iseq_t *iseq, const pm_call_node_t *node)
  * of the current iseq.
  */
 static void
-pm_compile_constant_read(rb_iseq_t *iseq, VALUE name, const pm_location_t *name_loc, LINK_ANCHOR *const ret, const pm_scope_node_t *scope_node)
+pm_compile_constant_read(rb_iseq_t *iseq, VALUE name, const pm_location_t *name_loc, uint32_t node_id, LINK_ANCHOR *const ret, const pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = PM_LOCATION_START_LINE_COLUMN(scope_node->parser, name_loc);
+    const pm_node_location_t location = PM_LOCATION_START_LOCATION(scope_node->parser, name_loc, node_id);
 
     if (ISEQ_COMPILE_DATA(iseq)->option->inline_const_cache) {
         ISEQ_BODY(iseq)->ic_size++;
@@ -4802,7 +4816,7 @@ pm_constant_path_parts(const pm_node_t *node, const pm_scope_node_t *scope_node)
 static void
 pm_compile_constant_path(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const prefix, LINK_ANCHOR *const body, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
 
     switch (PM_NODE_TYPE(node)) {
       case PM_CONSTANT_READ_NODE: {
@@ -4964,12 +4978,12 @@ pm_compile_shareable_constant_value(rb_iseq_t *iseq, const pm_node_t *node, cons
 {
     VALUE literal = pm_compile_shareable_constant_literal(iseq, node, scope_node);
     if (literal != Qundef) {
-        const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+        const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
         PUSH_INSN1(ret, location, putobject, literal);
         return;
     }
 
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(scope_node->parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, node);
     switch (PM_NODE_TYPE(node)) {
       case PM_ARRAY_NODE: {
         const pm_array_node_t *cast = (const pm_array_node_t *) node;
@@ -5055,9 +5069,9 @@ pm_compile_shareable_constant_value(rb_iseq_t *iseq, const pm_node_t *node, cons
  * not.
  */
 static void
-pm_compile_constant_write_node(rb_iseq_t *iseq, const pm_constant_write_node_t *node, const pm_node_flags_t shareability, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_constant_write_node(rb_iseq_t *iseq, const pm_constant_write_node_t *node, const pm_node_flags_t shareability, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
     ID name_id = pm_constant_id_lookup(scope_node, node->name);
 
     if (shareability != 0) {
@@ -5077,14 +5091,14 @@ pm_compile_constant_write_node(rb_iseq_t *iseq, const pm_constant_write_node_t *
  * or not.
  */
 static void
-pm_compile_constant_and_write_node(rb_iseq_t *iseq, const pm_constant_and_write_node_t *node, const pm_node_flags_t shareability, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_constant_and_write_node(rb_iseq_t *iseq, const pm_constant_and_write_node_t *node, const pm_node_flags_t shareability, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
 
     VALUE name = ID2SYM(pm_constant_id_lookup(scope_node, node->name));
     LABEL *end_label = NEW_LABEL(location.line);
 
-    pm_compile_constant_read(iseq, name, &node->name_loc, ret, scope_node);
+    pm_compile_constant_read(iseq, name, &node->name_loc, location.node_id, ret, scope_node);
     if (!popped) PUSH_INSN(ret, location, dup);
 
     PUSH_INSNL(ret, location, branchunless, end_label);
@@ -5108,9 +5122,9 @@ pm_compile_constant_and_write_node(rb_iseq_t *iseq, const pm_constant_and_write_
  * not.
  */
 static void
-pm_compile_constant_or_write_node(rb_iseq_t *iseq, const pm_constant_or_write_node_t *node, const pm_node_flags_t shareability, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_constant_or_write_node(rb_iseq_t *iseq, const pm_constant_or_write_node_t *node, const pm_node_flags_t shareability, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
     VALUE name = ID2SYM(pm_constant_id_lookup(scope_node, node->name));
 
     LABEL *set_label = NEW_LABEL(location.line);
@@ -5120,7 +5134,7 @@ pm_compile_constant_or_write_node(rb_iseq_t *iseq, const pm_constant_or_write_no
     PUSH_INSN3(ret, location, defined, INT2FIX(DEFINED_CONST), name, Qtrue);
     PUSH_INSNL(ret, location, branchunless, set_label);
 
-    pm_compile_constant_read(iseq, name, &node->name_loc, ret, scope_node);
+    pm_compile_constant_read(iseq, name, &node->name_loc, location.node_id, ret, scope_node);
     if (!popped) PUSH_INSN(ret, location, dup);
 
     PUSH_INSNL(ret, location, branchif, end_label);
@@ -5145,14 +5159,14 @@ pm_compile_constant_or_write_node(rb_iseq_t *iseq, const pm_constant_or_write_no
  * pragma or not.
  */
 static void
-pm_compile_constant_operator_write_node(rb_iseq_t *iseq, const pm_constant_operator_write_node_t *node, const pm_node_flags_t shareability, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_constant_operator_write_node(rb_iseq_t *iseq, const pm_constant_operator_write_node_t *node, const pm_node_flags_t shareability, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
 
     VALUE name = ID2SYM(pm_constant_id_lookup(scope_node, node->name));
     ID method_id = pm_constant_id_lookup(scope_node, node->binary_operator);
 
-    pm_compile_constant_read(iseq, name, &node->name_loc, ret, scope_node);
+    pm_compile_constant_read(iseq, name, &node->name_loc, location.node_id, ret, scope_node);
 
     if (shareability != 0) {
         pm_compile_shareable_constant_value(iseq, node->value, shareability, name, ret, scope_node, true);
@@ -5203,9 +5217,9 @@ pm_constant_path_path(const pm_constant_path_node_t *node, const pm_scope_node_t
  * or not.
  */
 static void
-pm_compile_constant_path_write_node(rb_iseq_t *iseq, const pm_constant_path_write_node_t *node, const pm_node_flags_t shareability, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_constant_path_write_node(rb_iseq_t *iseq, const pm_constant_path_write_node_t *node, const pm_node_flags_t shareability, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
     const pm_constant_path_node_t *target = node->target;
     VALUE name = ID2SYM(pm_constant_id_lookup(scope_node, target->name));
 
@@ -5237,9 +5251,9 @@ pm_compile_constant_path_write_node(rb_iseq_t *iseq, const pm_constant_path_writ
  * pragma or not.
  */
 static void
-pm_compile_constant_path_and_write_node(rb_iseq_t *iseq, const pm_constant_path_and_write_node_t *node, const pm_node_flags_t shareability, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_constant_path_and_write_node(rb_iseq_t *iseq, const pm_constant_path_and_write_node_t *node, const pm_node_flags_t shareability, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
     const pm_constant_path_node_t *target = node->target;
 
     VALUE name = ID2SYM(pm_constant_id_lookup(scope_node, target->name));
@@ -5288,9 +5302,9 @@ pm_compile_constant_path_and_write_node(rb_iseq_t *iseq, const pm_constant_path_
  * pragma or not.
  */
 static void
-pm_compile_constant_path_or_write_node(rb_iseq_t *iseq, const pm_constant_path_or_write_node_t *node, const pm_node_flags_t shareability, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_constant_path_or_write_node(rb_iseq_t *iseq, const pm_constant_path_or_write_node_t *node, const pm_node_flags_t shareability, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
     const pm_constant_path_node_t *target = node->target;
 
     VALUE name = ID2SYM(pm_constant_id_lookup(scope_node, target->name));
@@ -5345,9 +5359,9 @@ pm_compile_constant_path_or_write_node(rb_iseq_t *iseq, const pm_constant_path_o
  * ractor pragma or not.
  */
 static void
-pm_compile_constant_path_operator_write_node(rb_iseq_t *iseq, const pm_constant_path_operator_write_node_t *node, const pm_node_flags_t shareability, const pm_line_column_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
+pm_compile_constant_path_operator_write_node(rb_iseq_t *iseq, const pm_constant_path_operator_write_node_t *node, const pm_node_flags_t shareability, const pm_node_location_t *node_location, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
-    const pm_line_column_t location = *node_location;
+    const pm_node_location_t location = *node_location;
     const pm_constant_path_node_t *target = node->target;
 
     ID method_id = pm_constant_id_lookup(scope_node, node->binary_operator);
@@ -5396,7 +5410,7 @@ static void
 pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, bool popped, pm_scope_node_t *scope_node)
 {
     const pm_parser_t *parser = scope_node->parser;
-    const pm_line_column_t location = PM_NODE_START_LINE_COLUMN(parser, node);
+    const pm_node_location_t location = PM_NODE_START_LOCATION(parser, node);
     int lineno = (int) location.line;
 
     if (PM_NODE_TYPE_P(node, PM_RETURN_NODE) && PM_NODE_FLAG_P(node, PM_RETURN_NODE_FLAGS_REDUNDANT) && ((const pm_return_node_t *) node)->arguments == NULL) {
@@ -5410,7 +5424,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             // has a rescue clause, then the other parser considers it as
             // starting on the same line as the rescue, as opposed to the
             // location of the begin keyword. We replicate that behavior here.
-            lineno = (int) PM_NODE_START_LINE_COLUMN(parser, ((const pm_begin_node_t *) node)->rescue_clause).line;
+            lineno = (int) PM_NODE_START_LOCATION(parser, ((const pm_begin_node_t *) node)->rescue_clause).line;
         }
 
         if (PM_NODE_FLAG_P(node, PM_NODE_FLAG_NEWLINE) && ISEQ_COMPILE_DATA(iseq)->last_line != lineno) {
@@ -5770,7 +5784,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         const pm_location_t *message_loc = &cast->message_loc;
         if (message_loc->start == NULL) message_loc = &cast->base.location;
 
-        const pm_line_column_t location = PM_LOCATION_START_LINE_COLUMN(scope_node->parser, message_loc);
+        const pm_node_location_t location = PM_LOCATION_START_LOCATION(scope_node->parser, message_loc, cast->base.id);
         const char *builtin_func;
 
         if (UNLIKELY(iseq_has_builtin_function_table(iseq)) && (builtin_func = pm_iseq_builtin_function_name(scope_node, cast->receiver, method_id)) != NULL) {
@@ -5981,7 +5995,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                     const pm_node_t *condition = conditions->nodes[condition_index];
 
                     if (PM_NODE_TYPE_P(condition, PM_SPLAT_NODE)) {
-                        pm_line_column_t cond_location = PM_NODE_START_LINE_COLUMN(parser, condition);
+                        pm_node_location_t cond_location = PM_NODE_START_LOCATION(parser, condition);
                         PUSH_INSN(cond_seq, cond_location, putnil);
                         pm_compile_node(iseq, condition, cond_seq, false, scope_node);
                         PUSH_INSN1(cond_seq, cond_location, checkmatch, INT2FIX(VM_CHECKMATCH_TYPE_WHEN | VM_CHECKMATCH_ARRAY));
@@ -6060,7 +6074,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             // node instructions later.
             for (size_t clause_index = 0; clause_index < conditions->size; clause_index++) {
                 const pm_when_node_t *clause = (const pm_when_node_t *) conditions->nodes[clause_index];
-                pm_line_column_t clause_location = PM_NODE_START_LINE_COLUMN(parser, (const pm_node_t *) clause);
+                pm_node_location_t clause_location = PM_NODE_START_LOCATION(parser, (const pm_node_t *) clause);
 
                 const pm_node_list_t *conditions = &clause->conditions;
                 LABEL *label = NEW_LABEL(clause_location.line);
@@ -6070,7 +6084,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                 // jumps into the body if it matches.
                 for (size_t condition_index = 0; condition_index < conditions->size; condition_index++) {
                     const pm_node_t *condition = conditions->nodes[condition_index];
-                    const pm_line_column_t condition_location = PM_NODE_START_LINE_COLUMN(parser, condition);
+                    const pm_node_location_t condition_location = PM_NODE_START_LOCATION(parser, condition);
 
                     // If we haven't already abandoned the optimization, then
                     // we're going to try to compile the condition into the
@@ -6145,7 +6159,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             PUSH_LABEL(ret, else_label);
 
             if (cast->consequent != NULL) {
-                pm_line_column_t else_location = PM_NODE_START_LINE_COLUMN(parser, cast->consequent->statements != NULL ? ((const pm_node_t *) cast->consequent->statements) : ((const pm_node_t *) cast->consequent));
+                pm_node_location_t else_location = PM_NODE_START_LOCATION(parser, cast->consequent->statements != NULL ? ((const pm_node_t *) cast->consequent->statements) : ((const pm_node_t *) cast->consequent));
                 PUSH_INSN(ret, else_location, pop);
 
                 // Establish branch coverage for the else clause.
@@ -6245,8 +6259,8 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             RUBY_ASSERT(PM_NODE_TYPE_P(condition, PM_IN_NODE));
 
             const pm_in_node_t *in_node = (const pm_in_node_t *) condition;
-            const pm_line_column_t in_location = PM_NODE_START_LINE_COLUMN(parser, in_node);
-            const pm_line_column_t pattern_location = PM_NODE_START_LINE_COLUMN(parser, in_node->pattern);
+            const pm_node_location_t in_location = PM_NODE_START_LOCATION(parser, in_node);
+            const pm_node_location_t pattern_location = PM_NODE_START_LOCATION(parser, in_node->pattern);
 
             if (branch_id) {
                 PUSH_INSN(body_seq, in_location, putnil);
@@ -6523,7 +6537,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         const pm_constant_read_node_t *cast = (const pm_constant_read_node_t *) node;
         VALUE name = ID2SYM(pm_constant_id_lookup(scope_node, cast->name));
 
-        pm_compile_constant_read(iseq, name, &cast->base.location, ret, scope_node);
+        pm_compile_constant_read(iseq, name, &cast->base.location, cast->base.id, ret, scope_node);
         if (popped) PUSH_INSN(ret, location, pop);
 
         return;
@@ -9020,7 +9034,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
           case ISEQ_TYPE_BLOCK: {
             LABEL *start = ISEQ_COMPILE_DATA(iseq)->start_label = NEW_LABEL(0);
             LABEL *end = ISEQ_COMPILE_DATA(iseq)->end_label = NEW_LABEL(0);
-            const pm_line_column_t block_location = { .line = body->location.first_lineno, .column = -1 };
+            const pm_node_location_t block_location = { .line = body->location.first_lineno, .node_id = -1 };
 
             start->rescued = LABEL_RESCUE_BEG;
             end->rescued = LABEL_RESCUE_END;
@@ -9077,7 +9091,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             break;
           }
           case ISEQ_TYPE_ENSURE: {
-            const pm_line_column_t statements_location = (scope_node->body != NULL ? PM_NODE_START_LINE_COLUMN(scope_node->parser, scope_node->body) : location);
+            const pm_node_location_t statements_location = (scope_node->body != NULL ? PM_NODE_START_LOCATION(scope_node->parser, scope_node->body) : location);
             iseq_set_exception_local_table(iseq);
 
             if (scope_node->body != NULL) {
@@ -9139,13 +9153,13 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         }
 
         if (PM_NODE_TYPE_P(scope_node->ast_node, PM_CLASS_NODE) || PM_NODE_TYPE_P(scope_node->ast_node, PM_MODULE_NODE)) {
-            const pm_line_column_t end_location = PM_NODE_END_LINE_COLUMN(scope_node->parser, scope_node->ast_node);
+            const pm_node_location_t end_location = PM_NODE_END_LOCATION(scope_node->parser, scope_node->ast_node);
             ADD_TRACE(ret, RUBY_EVENT_END);
             ISEQ_COMPILE_DATA(iseq)->last_line = end_location.line;
         }
 
         if (!PM_NODE_TYPE_P(scope_node->ast_node, PM_ENSURE_NODE)) {
-            const pm_line_column_t location = { .line = ISEQ_COMPILE_DATA(iseq)->last_line, .column = -1 };
+            const pm_node_location_t location = { .line = ISEQ_COMPILE_DATA(iseq)->last_line, .node_id = -1 };
             PUSH_INSN(ret, location, leave);
         }
 

--- a/test/error_highlight/test_error_highlight.rb
+++ b/test/error_highlight/test_error_highlight.rb
@@ -5,13 +5,6 @@ require "did_you_mean"
 require "tempfile"
 
 class ErrorHighlightTest < Test::Unit::TestCase
-  # We can't revisit instruction sequences to find node ids if the prism
-  # compiler was used instead of the parse.y compiler. In that case, we'll omit
-  # some tests.
-  def self.compiling_with_prism?
-    RubyVM::InstructionSequence.compile("").to_a[4][:parser] == :prism
-  end
-
   class DummyFormatter
     def self.message_for(corrections)
       ""
@@ -876,27 +869,13 @@ uninitialized constant ErrorHighlightTest::NotDefined
     end
   end
 
-  if ErrorHighlight.const_get(:Spotter).const_get(:OPT_GETCONSTANT_PATH) && !compiling_with_prism?
-    def test_COLON2_5
-      # Unfortunately, we cannot identify which `NotDefined` caused the NameError
-      assert_error_message(NameError, <<~END) do
+  def test_COLON2_5
+    # Unfortunately, we cannot identify which `NotDefined` caused the NameError
+    assert_error_message(NameError, <<~END) do
 uninitialized constant ErrorHighlightTest::NotDefined
-      END
+    END
 
-        ErrorHighlightTest::NotDefined::NotDefined
-      end
-    end
-  else
-    def test_COLON2_5
-      assert_error_message(NameError, <<~END) do
-uninitialized constant ErrorHighlightTest::NotDefined
-
-        ErrorHighlightTest::NotDefined::NotDefined
-                          ^^^^^^^^^^^^
-      END
-
-        ErrorHighlightTest::NotDefined::NotDefined
-      end
+      ErrorHighlightTest::NotDefined::NotDefined
     end
   end
 
@@ -1342,7 +1321,11 @@ undefined method `foo' for #{ NIL_RECV_MESSAGE }
 
   def test_spot_with_node
     omit unless RubyVM::AbstractSyntaxTree.respond_to?(:node_id_for_backtrace_location)
-    omit if ErrorHighlightTest.compiling_with_prism?
+
+    # We can't revisit instruction sequences to find node ids if the prism
+    # compiler was used instead of the parse.y compiler. In that case, we'll
+    # omit this test.
+    omit if RubyVM::InstructionSequence.compile("").to_a[4][:parser] == :prism
 
     begin
       raise_name_error


### PR DESCRIPTION
This commit adds support for reproducable parses with node ids, like parse.y supports. Previously we attempted to replicate this functionality using line/column pairs, but this proved impossible to accomplish when attempting to support Rails' use of ErrorHighlight.spot because line numbers can differ between uncompiled and compiled versions of the source.

Unfortunately at the moment this is a CRuby-only API (Prism.of) but this could be extended to support other runtimes/tools if we begin exposing pm_node_t#id through some other mechanism.

Fortunately this doesn't actually end up taking up any more space on most 64-bit systems because we currently have a hole in `pm_node_t` on those systems, due to 32 bits worth of padding between the flags and the locations.