### PR TITLE
YJIT: Use a special breakpoint address if one isn't explicitly supplied in order to support natural line stepping.

### DIFF
--- a/yjit/src/asm/arm64/mod.rs
+++ b/yjit/src/asm/arm64/mod.rs
@@ -257,7 +257,7 @@ pub fn br(cb: &mut CodeBlock, rn: A64Opnd) {
 /// BRK - create a breakpoint
 pub fn brk(cb: &mut CodeBlock, imm16: A64Opnd) {
     let bytes: [u8; 4] = match imm16 {
-        A64Opnd::None => Breakpoint::brk(0).into(),
+        A64Opnd::None => Breakpoint::brk(0xf000).into(),
         A64Opnd::UImm(imm16) => {
             assert!(uimm_fits_bits(imm16, 16), "The immediate operand must be 16 bits or less.");
             Breakpoint::brk(imm16 as u16).into()


### PR DESCRIPTION
ARM64 will not increment the program counter (PC) upon hitting a breakpoint instruction. Consequently, stepping through code with a debugger ends up looping back to the breakpoint instruction. LLDB has a special breakpoint address of 0xf000 that will increment the PC and allow the debugger to work as expected. This change makes it possible to debug YJIT generated code on ARM64.

More details at: https://discourse.llvm.org/t/stepping-over-a-brk-instruction-on-arm64/69766/8