### PR TITLE
merge flags when the second one does not have a `-`

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -711,7 +711,13 @@ MSG
   # [+flags+] a C preprocessor flag as a +String+ or an +Array+ of them
   #
   def append_cppflags(flags, **opts)
-    Array(flags).each do |flag|
+    flags = Array(flags)
+    flags.each_with_index do |flag, i|
+      next_arg = flags[i + 1]
+      if next_arg && !next_arg.start_with?('-')
+        flag = "#{flag} #{next_arg}"
+        flags[i + 1] = nil
+      end
       if checking_for("whether #{flag} is accepted as CPPFLAGS") {
            try_cppflags(flag, **opts)
          }
@@ -1104,7 +1110,13 @@ SRC
   # [+flags+] a C compiler flag as a +String+ or an +Array+ of them
   #
   def append_cflags(flags, **opts)
-    Array(flags).each do |flag|
+    flags = Array(flags)
+    flags.each_with_index do |flag, i|
+      next_arg = flags[i + 1]
+      if next_arg && !next_arg.start_with?('-')
+        flag = "#{flag} #{next_arg}"
+        flags[i + 1] = nil
+      end
       if checking_for("whether #{flag} is accepted as CFLAGS") {
            try_cflags(flag, **opts)
          }


### PR DESCRIPTION
I ran into some problems with packages such as `nokogiri` and flags like `CFLAGS=-isystem /foo`.

The packages run something like `append_cflags(ENV["CFLAGS"].split) unless ENV["CFLAGS"].nil?`.

This fails because the `/foo` would be stripped as it is not a valid CFLAG alone.

That in turn leads to some compilation issues later. 

I never coded in Ruby, so I am sure this solution isn't really good. Maybe some one can come up with a better patch for this issue. The idea is to look at the next argument, and figure out if it does not start with a `-` to merge it with the previous one. 