### PR TITLE
Calling into a C func shouldn't fast path when forwarding

### DIFF
--- a/bootstraptest/test_method.rb
+++ b/bootstraptest/test_method.rb
@@ -1344,3 +1344,18 @@ assert_equal 'ok', %q{
 
   C.new.foo
 }
+
+assert_equal 'ok', %q{
+  class C
+    def initialize(a)
+    end
+  end
+
+  def foo(...)
+    C.new(...)
+    :ok
+  end
+
+  foo(*["bar"])
+  foo("baz")
+}

--- a/bootstraptest/test_method.rb
+++ b/bootstraptest/test_method.rb
@@ -1359,3 +1359,18 @@ assert_equal 'ok', %q{
   foo(*["bar"])
   foo("baz")
 }
+
+assert_equal 'ok', %q{
+  class C
+    def foo(b:)
+      b
+    end
+  end
+
+  def foo(...)
+    C.new.send(...)
+  end
+
+  foo(:foo, b: :ok)
+  foo(*["foo"], b: :ok)
+}

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4363,10 +4363,10 @@ vm_call_opt_send(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct
     const struct rb_callinfo *ci = calling->cd->ci;
     int flags = vm_ci_flag(ci);
 
-    if (UNLIKELY(!(flags & VM_CALL_ARGS_SIMPLE) &&
+    if (UNLIKELY((flags & VM_CALL_FORWARDING) || (!(flags & VM_CALL_ARGS_SIMPLE) &&
         ((calling->argc == 1 && (flags & (VM_CALL_ARGS_SPLAT | VM_CALL_KW_SPLAT))) ||
          (calling->argc == 2 && (flags & VM_CALL_ARGS_SPLAT) && (flags & VM_CALL_KW_SPLAT)) ||
-         ((flags & VM_CALL_KWARG) && (vm_ci_kwarg(ci)->keyword_len == calling->argc))))) {
+         ((flags & VM_CALL_KWARG) && (vm_ci_kwarg(ci)->keyword_len == calling->argc)))))) {
         CC_SET_FASTPATH(calling->cc, vm_call_opt_send_complex, TRUE);
         return vm_call_opt_send_complex(ec, reg_cfp, calling);
     }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3907,7 +3907,7 @@ vm_call_cfunc(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, struct rb
     const struct rb_callinfo *ci = calling->cd->ci;
     RB_DEBUG_COUNTER_INC(ccf_cfunc);
 
-    if (IS_ARGS_SPLAT(ci)) {
+    if (IS_ARGS_SPLAT(ci) && !(vm_ci_flag(ci) & VM_CALL_FORWARDING)) {
         if (!IS_ARGS_KW_SPLAT(ci) && vm_ci_argc(ci) == 1) {
             // f(*a)
             CC_SET_FASTPATH(calling->cc, vm_call_cfunc_only_splat, TRUE);


### PR DESCRIPTION
When we forward calls to C functions if the callsite is a forwarding site it might not always be a splat, so we can't use the fast path.

Fixes:

[ruby-core:118418]