### PR TITLE
Speed up chunkypng benchmark

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -1771,7 +1771,7 @@ VALUE
 rb_thread_io_blocking_call(rb_blocking_function_t *func, void *data1, int fd, int events)
 {
     rb_execution_context_t *volatile ec = GET_EC();
-    rb_thread_t * volatile th = rb_ec_thread_ptr(ec);
+    rb_thread_t *volatile th = rb_ec_thread_ptr(ec);
 
     RUBY_DEBUG_LOG("th:%u fd:%d ev:%d", rb_th_serial(th), fd, events);
 

--- a/thread.c
+++ b/thread.c
@@ -1771,7 +1771,7 @@ VALUE
 rb_thread_io_blocking_call(rb_blocking_function_t *func, void *data1, int fd, int events)
 {
     rb_execution_context_t *volatile ec = GET_EC();
-    rb_thread_t *th = rb_ec_thread_ptr(ec);
+    rb_thread_t * volatile th = rb_ec_thread_ptr(ec);
 
     RUBY_DEBUG_LOG("th:%u fd:%d ev:%d", rb_th_serial(th), fd, events);
 


### PR DESCRIPTION
Since d037c5196a14c03e72746ccdf0437b5dd4f80a69 we're seeing a slowdown in ChunkyPNG benchmarks in YJIT bench. This patch addresses the slowdown. Making the thread volatile speeds up the benchmark by 2 or 3% on my machine.

```
before: ruby 3.4.0dev (2024-07-02T18:48:43Z master b2b8306b46) [x86_64-linux]
after: ruby 3.4.0dev (2024-07-02T20:07:44Z speed-chunkypng 418334dba9) [x86_64-linux]

----------  -----------  ----------  ----------  ----------  -------------  ------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
chunky-png  1000.2       0.1         980.6       0.1         1.02           1.02
----------  -----------  ----------  ----------  ----------  -------------  ------------
Legend:
- after 1st itr: ratio of before/after time for the first benchmarking iteration.
- before/after: ratio of before/after time. Higher is better for after. Above 1 represents a speedup.

Output:
./data/output_015.csv
```

cc @k0kubun @maximecb 