### PR TITLE
Revert "Resize arrays in `rb_ary_freeze` and use it for freezing arrays"

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -769,7 +769,7 @@ ast_node_all_tokens(rb_execution_context_t *ec, VALUE self)
         token = rb_ary_new_from_args(4, INT2FIX(parser_token->id), ID2SYM(rb_intern(parser_token->type_name)), str, loc);
         rb_ary_push(all_tokens, token);
     }
-    rb_ary_freeze(all_tokens);
+    rb_obj_freeze(all_tokens);
 
     return all_tokens;
 }

--- a/compile.c
+++ b/compile.c
@@ -4840,7 +4840,7 @@ static_literal_value(const NODE *node, rb_iseq_t *iseq)
         if (ISEQ_COMPILE_DATA(iseq)->option->debug_frozen_string_literal || RTEST(ruby_debug)) {
             VALUE debug_info = rb_ary_new_from_args(2, rb_iseq_path(iseq), INT2FIX((int)nd_line(node)));
             VALUE lit = rb_str_dup(get_string_value(node));
-            rb_ivar_set(lit, id_debug_created_info, rb_ary_freeze(debug_info));
+            rb_ivar_set(lit, id_debug_created_info, rb_obj_freeze(debug_info));
             return rb_str_freeze(lit);
         }
         else {
@@ -10752,7 +10752,7 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const no
                 if (ISEQ_COMPILE_DATA(iseq)->option->debug_frozen_string_literal || RTEST(ruby_debug)) {
                     VALUE debug_info = rb_ary_new_from_args(2, rb_iseq_path(iseq), INT2FIX(line));
                     lit = rb_str_dup(lit);
-                    rb_ivar_set(lit, id_debug_created_info, rb_ary_freeze(debug_info));
+                    rb_ivar_set(lit, id_debug_created_info, rb_obj_freeze(debug_info));
                     lit = rb_str_freeze(lit);
                 }
                 ADD_INSN1(ret, node, putobject, lit);
@@ -11321,7 +11321,7 @@ rb_insns_name_array(void)
     for (i = 0; i < VM_INSTRUCTION_SIZE; i++) {
         rb_ary_push(ary, rb_fstring_cstr(insn_name(i)));
     }
-    return rb_ary_freeze(ary);
+    return rb_obj_freeze(ary);
 }
 
 static LABEL *
@@ -13709,7 +13709,7 @@ ibf_load_object_array(const struct ibf_load *load, const struct ibf_object_heade
         rb_ary_push(ary, ibf_load_object(load, index));
     }
 
-    if (header->frozen) rb_ary_freeze(ary);
+    if (header->frozen) rb_obj_freeze(ary);
 
     return ary;
 }

--- a/enumerator.c
+++ b/enumerator.c
@@ -3181,7 +3181,7 @@ enum_chain_initialize(VALUE obj, VALUE enums)
 
     if (!ptr) rb_raise(rb_eArgError, "unallocated chain");
 
-    ptr->enums = rb_ary_freeze(enums);
+    ptr->enums = rb_obj_freeze(enums);
     ptr->pos = -1;
 
     return obj;
@@ -3509,7 +3509,7 @@ enum_product_initialize(int argc, VALUE *argv, VALUE obj)
 
     if (!ptr) rb_raise(rb_eArgError, "unallocated product");
 
-    ptr->enums = rb_ary_freeze(enums);
+    ptr->enums = rb_obj_freeze(enums);
 
     return obj;
 }

--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -57,7 +57,7 @@ static VALUE sym_hour, sym_min, sym_sec, sym_sec_fraction, sym_zone;
 #define f_add3(x,y,z) f_add(f_add(x, y), z)
 #define f_sub3(x,y,z) f_sub(f_sub(x, y), z)
 
-#define f_frozen_ary(...) rb_ary_freeze(rb_ary_new3(__VA_ARGS__))
+#define f_frozen_ary(...) rb_obj_freeze(rb_ary_new3(__VA_ARGS__))
 
 static VALUE date_initialize(int argc, VALUE *argv, VALUE self);
 static VALUE datetime_initialize(int argc, VALUE *argv, VALUE self);
@@ -9466,7 +9466,7 @@ mk_ary_of_str(long len, const char *a[])
 	}
 	rb_ary_push(o, e);
     }
-    rb_ary_freeze(o);
+    rb_obj_freeze(o);
     return o;
 }
 

--- a/iseq.c
+++ b/iseq.c
@@ -521,7 +521,7 @@ rb_iseq_pathobj_new(VALUE path, VALUE realpath)
     else {
         if (!NIL_P(realpath)) realpath = rb_fstring(realpath);
         pathobj = rb_ary_new_from_args(2, rb_fstring(path), realpath);
-        rb_ary_freeze(pathobj);
+        rb_obj_freeze(pathobj);
     }
     return pathobj;
 }

--- a/load.c
+++ b/load.c
@@ -104,7 +104,7 @@ rb_construct_expanded_load_path(rb_vm_t *vm, enum expand_type type, int *has_rel
         if (NIL_P(expanded_path)) expanded_path = as_str;
         rb_ary_push(ary, rb_fstring(expanded_path));
     }
-    rb_ary_freeze(ary);
+    rb_obj_freeze(ary);
     vm->expanded_load_path = ary;
     rb_ary_replace(vm->load_path_snapshot, vm->load_path);
 }

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -299,7 +299,7 @@ parse_static_literal_string(rb_iseq_t *iseq, const pm_scope_node_t *scope_node, 
         int line_number = pm_node_line_number(scope_node->parser, node);
         VALUE debug_info = rb_ary_new_from_args(2, rb_iseq_path(iseq), INT2FIX(line_number));
         value = rb_str_dup(value);
-        rb_ivar_set(value, id_debug_created_info, rb_ary_freeze(debug_info));
+        rb_ivar_set(value, id_debug_created_info, rb_obj_freeze(debug_info));
         rb_str_freeze(value);
     }
 
@@ -693,7 +693,7 @@ pm_static_literal_string(rb_iseq_t *iseq, VALUE string, int line_number)
 {
     if (ISEQ_COMPILE_DATA(iseq)->option->debug_frozen_string_literal || RTEST(ruby_debug)) {
         VALUE debug_info = rb_ary_new_from_args(2, rb_iseq_path(iseq), INT2FIX(line_number));
-        rb_ivar_set(string, id_debug_created_info, rb_ary_freeze(debug_info));
+        rb_ivar_set(string, id_debug_created_info, rb_obj_freeze(debug_info));
         return rb_str_freeze(string);
     }
     else {


### PR DESCRIPTION
This reverts commit d25b74b32cbce4fcaed503f124fa8e7d721f18bf.

Caused failures in Shopify's CI after upgrade. Looking into the issue but need to revert for now because I'm off the next few days.

Revert of #11030

cc/ @byroot 