### PR TITLE
array.c: Remove outdated assertions

### DIFF
--- a/array.c
+++ b/array.c
@@ -149,7 +149,6 @@ should_be_T_ARRAY(VALUE ary)
 #define ARY_SET_CAPA(ary, n) do { \
     RUBY_ASSERT(!ARY_EMBED_P(ary)); \
     RUBY_ASSERT(!ARY_SHARED_P(ary)); \
-    RUBY_ASSERT(!OBJ_FROZEN(ary)); \
     RARRAY(ary)->as.heap.aux.capa = (n); \
 } while (0)
 
@@ -370,7 +369,6 @@ ary_heap_free(VALUE ary)
 static size_t
 ary_heap_realloc(VALUE ary, size_t new_capa)
 {
-    RUBY_ASSERT(!OBJ_FROZEN(ary));
     SIZED_REALLOC_N(RARRAY(ary)->as.heap.ptr, VALUE, new_capa, ARY_HEAP_CAPA(ary));
     ary_verify(ary);
 

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -3493,6 +3493,17 @@ class TestArray < Test::Unit::TestCase
     assert_typed_equal(e, v, Complex, msg)
   end
 
+  def test_shrink_shared_array
+    assert_normal_exit(<<~'RUBY', '[Feature #20589]')
+      array = []
+      # Make sure the array is allocated
+      10.times { |i| array << i }
+      # Simulate a C extension using OBJ_FREEZE
+      Object.instance_method(:freeze).bind_call(array)
+      array.dup
+    RUBY
+  end
+
   def test_sum
     assert_int_equal(0, [].sum)
     assert_int_equal(3, [3].sum)


### PR DESCRIPTION
Following [Feature #20589] it can happen that we change the capacity of a frozen array, so these assertions no longer make sense.

Normally we don't hit them because `Array#freeze` shrinks the array, but if somehow the Array was frozen using `Object#freeze` then we may shrink it after it was frozen.

cc @eileencodes 