### PR TITLE
Update exception message in string_for_symbol

### DIFF
--- a/spec/ruby/core/thread/thread_variable_get_spec.rb
+++ b/spec/ruby/core/thread/thread_variable_get_spec.rb
@@ -43,18 +43,18 @@ describe "Thread#thread_variable_get" do
 
   it "raises a TypeError if the key is neither Symbol nor String when thread variables are already set" do
     @t.thread_variable_set(:a, 49)
-    -> { @t.thread_variable_get(123) }.should raise_error(TypeError, "123 is not a symbol")
+    -> { @t.thread_variable_get(123) }.should raise_error(TypeError, /123 is not a symbol/)
   end
 
   ruby_version_is '3.4' do
     it "raises a TypeError if the key is neither Symbol nor String when no thread variables are set" do
-      -> { @t.thread_variable_get(123) }.should raise_error(TypeError, "123 is not a symbol")
+      -> { @t.thread_variable_get(123) }.should raise_error(TypeError, /123 is not a symbol/)
     end
 
     it "raises a TypeError if the key is neither Symbol nor String without calling #to_sym" do
       key = mock('key')
       key.should_not_receive(:to_sym)
-      -> { @t.thread_variable_get(key) }.should raise_error(TypeError, "#{key.inspect} is not a symbol")
+      -> { @t.thread_variable_get(key) }.should raise_error(TypeError, /#{Regexp.escape(key.inspect)} is not a symbol/)
     end
   end
 end

--- a/spec/ruby/core/thread/thread_variable_set_spec.rb
+++ b/spec/ruby/core/thread/thread_variable_set_spec.rb
@@ -51,12 +51,12 @@ describe "Thread#thread_variable_set" do
   end
 
   it "raises a TypeError if the key is neither Symbol nor String, nor responds to #to_str" do
-    -> { @t.thread_variable_set(123, 1) }.should raise_error(TypeError, '123 is not a symbol')
+    -> { @t.thread_variable_set(123, 1) }.should raise_error(TypeError, /123 is not a symbol/)
   end
 
   it "does not try to convert the key with #to_sym" do
     key = mock('key')
     key.should_not_receive(:to_sym)
-    -> { @t.thread_variable_set(key, 42) }.should raise_error(TypeError, "#{key.inspect} is not a symbol")
+    -> { @t.thread_variable_set(key, 42) }.should raise_error(TypeError, /#{Regexp.quote(key.inspect)} is not a symbol/)
   end
 end

--- a/spec/ruby/core/thread/thread_variable_spec.rb
+++ b/spec/ruby/core/thread/thread_variable_spec.rb
@@ -43,18 +43,18 @@ describe "Thread#thread_variable?" do
 
   it "raises a TypeError if the key is neither Symbol nor String when thread variables are already set" do
     @t.thread_variable_set(:a, 49)
-    -> { @t.thread_variable?(123) }.should raise_error(TypeError, "123 is not a symbol")
+    -> { @t.thread_variable?(123) }.should raise_error(TypeError, /123 is not a symbol/)
   end
 
   ruby_version_is '3.4' do
     it "raises a TypeError if the key is neither Symbol nor String when no thread variables are set" do
-      -> { @t.thread_variable?(123) }.should raise_error(TypeError, "123 is not a symbol")
+      -> { @t.thread_variable?(123) }.should raise_error(TypeError, /123 is not a symbol/)
     end
 
     it "raises a TypeError if the key is neither Symbol nor String without calling #to_sym" do
       key = mock('key')
       key.should_not_receive(:to_sym)
-      -> { @t.thread_variable?(key) }.should raise_error(TypeError, "#{key.inspect} is not a symbol")
+      -> { @t.thread_variable?(key) }.should raise_error(TypeError, /#{Regexp.escape(key.inspect)} is not a symbol/)
     end
   end
 end

--- a/string.c
+++ b/string.c
@@ -12398,7 +12398,7 @@ string_for_symbol(VALUE name)
     if (!RB_TYPE_P(name, T_STRING)) {
         VALUE tmp = rb_check_string_type(name);
         if (NIL_P(tmp)) {
-            rb_raise(rb_eTypeError, "%+"PRIsVALUE" is not a symbol",
+            rb_raise(rb_eTypeError, "%+"PRIsVALUE" is not a symbol nor a string",
                      name);
         }
         name = tmp;


### PR DESCRIPTION
This is a static function only called in two places (rb_to_id and rb_to_symbol), and in both places, both symbols and strings are allowed.  This makes the error message consistent with rb_check_id and rb_check_symbol.

Fixes [Bug #20607]