### PR TITLE
Fix the return value of `Integer#downto` called with a block

### DIFF
--- a/numeric.rb
+++ b/numeric.rb
@@ -243,7 +243,7 @@ class Integer
 
   # call-seq:
   #   downto(limit) {|i| ... } -> self
-  #   downto(limit)            ->  enumerator
+  #   downto(limit)            -> enumerator
   #
   # Calls the given block with each integer value from +self+ down to +limit+;
   # returns +self+:
@@ -268,6 +268,7 @@ class Integer
       yield from
       from = from.pred
     end
+    self
   end
 
   #  call-seq:

--- a/test/ruby/test_integer.rb
+++ b/test/ruby/test_integer.rb
@@ -282,31 +282,31 @@ class TestInteger < Test::Unit::TestCase
 
   def test_upto
     a = []
-    1.upto(3) {|x| a << x }
+    assert_equal(1, 1.upto(3) {|x| a << x })
     assert_equal([1, 2, 3], a)
 
     a = []
-    1.upto(0) {|x| a << x }
+    assert_equal(1, 1.upto(0) {|x| a << x })
     assert_equal([], a)
 
     y = 2**30 - 1
     a = []
-    y.upto(y+2) {|x| a << x }
+    assert_equal(y, y.upto(y+2) {|x| a << x })
     assert_equal([y, y+1, y+2], a)
   end
 
   def test_downto
     a = []
-    -1.downto(-3) {|x| a << x }
+    assert_equal(-1, -1.downto(-3) {|x| a << x })
     assert_equal([-1, -2, -3], a)
 
     a = []
-    1.downto(2) {|x| a << x }
+    assert_equal(1, 1.downto(2) {|x| a << x })
     assert_equal([], a)
 
     y = -(2**30)
     a = []
-    y.downto(y-2) {|x| a << x }
+    assert_equal(y, y.downto(y-2) {|x| a << x })
     assert_equal([y, y-1, y-2], a)
   end
 


### PR DESCRIPTION
As the document states, it should return `self`, not `nil`.
Fix up of f4b313f7338f5fbe37f73aae29f70aeb474f7f5b.