### PR TITLE
Make rb_obj_free use rb_ary_freeze when the target is an Array

### DIFF
--- a/array.c
+++ b/array.c
@@ -652,7 +652,8 @@ rb_ary_freeze(VALUE ary)
         ary_shrink_capa(ary);
     }
 
-    return rb_obj_freeze(ary);
+    OBJ_FREEZE(ary);
+    return ary;
 }
 
 /* This can be used to take a snapshot of an array (with

--- a/object.c
+++ b/object.c
@@ -1317,6 +1317,11 @@ VALUE
 rb_obj_freeze(VALUE obj)
 {
     if (!OBJ_FROZEN(obj)) {
+        // If the target object is an array, we want to shrink it
+        if (RB_TYPE_P(obj, T_ARRAY)) {
+            return rb_ary_freeze(obj);
+        }
+
         OBJ_FREEZE(obj);
         if (SPECIAL_CONST_P(obj)) {
             rb_bug("special consts should be frozen.");


### PR DESCRIPTION
... and restore the assertions removed by 7542ae458a214ef7e160935555643265b6304ffd

@byroot @eileencodes 