### PR TITLE
Delay the array allocation of multiple arguments for Enumerable#find, #any?, etc.

### DIFF
--- a/include/ruby/internal/scan_args.h
+++ b/include/ruby/internal/scan_args.h
@@ -75,7 +75,7 @@
  * Pass keywords if current method is called with keywords, useful for argument
  * delegation
  */
-#define RB_PASS_CALLED_KEYWORDS rb_keyword_given_p()
+#define RB_PASS_CALLED_KEYWORDS !!rb_keyword_given_p()
 
 /** @} */
 

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -87,6 +87,7 @@ struct vm_ifunc {
     const void *data;
     struct vm_ifunc_argc argc;
 };
+#define IFUNC_YIELD_OPTIMIZABLE IMEMO_FL_USER0
 
 struct rb_imemo_tmpbuf_struct {
     VALUE flags;

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -77,6 +77,8 @@ VALUE rb_lambda_call(VALUE obj, ID mid, int argc, const VALUE *argv,
                      rb_block_call_func_t bl_proc, int min_argc, int max_argc,
                      VALUE data2);
 void rb_check_stack_overflow(void);
+#define RB_BLOCK_NO_USE_PACKED_ARGS 2
+VALUE rb_block_call2(VALUE obj, ID mid, int argc, const VALUE *argv, rb_block_call_func_t bl_proc, VALUE data2, long flags);
 
 #if USE_YJIT
 /* vm_exec.c */

--- a/proc.c
+++ b/proc.c
@@ -1159,6 +1159,12 @@ rb_block_pair_yield_optimizable(void)
             return min > 1;
         }
 
+      case block_handler_type_ifunc:
+        {
+            const struct vm_ifunc *ifunc = block.as.captured.code.ifunc;
+            if (ifunc->flags & IFUNC_YIELD_OPTIMIZABLE) return 1;
+        }
+
       default:
         return min > 1;
     }


### PR DESCRIPTION
```
def allocated_now = GC.stat(:total_allocated_objects)

dummy_hash = 100_000.times.each_with_index.to_h
before_allocs = allocated_now
dummy_hash.find {|k, v| false }
puts "Allocated #{allocated_now - before_allocs}"
# before this patch: Allocated 100005
# after this patch:  Allocated 5
```

[[Bug #20608]](https://bugs.ruby-lang.org/issues/20608)