### PR TITLE
Tidy up mitigation property notes in aarch64/x86_64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -489,7 +489,6 @@ AC_CACHE_CHECK([for $AR flags], [rb_cv_arflags], [
 	[rb_cv_arflags=rcD], [rb_cv_arflags=rcu])
 ])
 AC_SUBST(ARFLAGS, ["$rb_cv_arflags "])
-AC_SUBST(ASFLAGS)
 
 AS_CASE(["$target_os"],
 [cygwin*|msys*|mingw*], [

--- a/configure.ac
+++ b/configure.ac
@@ -1006,58 +1006,6 @@ AC_SUBST(incflags, "$INCFLAGS")
 test -z "${ac_env_CFLAGS_set}" -a -n "${cflags+set}" && eval CFLAGS="\"$cflags $ARCH_FLAG\""
 test -z "${ac_env_CXXFLAGS_set}" -a -n "${cxxflags+set}" && eval CXXFLAGS="\"$cxxflags $ARCH_FLAG\""
 
-# The lines above expand out the $cflags/$optflags/$debugflags/$hardenflags variables into the
-# CFLAGS variable. So, at this point, we have a $CFLAGS var with the actual compiler flags we're
-# going to use.
-# That means this is the right time to check what branch protection flags are going to be in use
-# and define appropriate macros for use in Context.S based on this
-AS_CASE(["$target_cpu"], [aarch64], [
-    AC_CACHE_CHECK([whether __ARM_FEATURE_BTI_DEFAULT is defined],
-        rb_cv_aarch64_bti_enabled,
-        AC_COMPILE_IFELSE(
-            [AC_LANG_PROGRAM([[
-                @%:@ifndef __ARM_FEATURE_BTI_DEFAULT
-                @%:@error "__ARM_FEATURE_BTI_DEFAULT not defined"
-                @%:@endif
-            ]])],
-        [rb_cv_aarch64_bti_enabled=yes],
-        [rb_cv_aarch64_bti_enabled=no])
-    )
-    AS_IF([test "$rb_cv_aarch64_bti_enabled" = yes],
-          AC_DEFINE(RUBY_AARCH64_BTI_ENABLED, 1))
-    AC_CACHE_CHECK([whether __ARM_FEATURE_PAC_DEFAULT is defined],
-        rb_cv_aarch64_pac_enabled,
-        AC_COMPILE_IFELSE(
-            [AC_LANG_PROGRAM([[
-                @%:@ifndef __ARM_FEATURE_PAC_DEFAULT
-                @%:@error "__ARM_FEATURE_PAC_DEFAULT not defined"
-                @%:@endif
-            ]])],
-        [rb_cv_aarch64_pac_enabled=yes],
-        [rb_cv_aarch64_pac_enabled=no])
-    )
-    AS_IF([test "$rb_cv_aarch64_pac_enabled" = yes],
-          AC_DEFINE(RUBY_AARCH64_PAC_ENABLED, 1))
-    # Context.S will only ever sign its return address with the A-key; it doesn't support
-    # the B-key at the moment.
-    AS_IF([test "$rb_cv_aarch64_pac_enabled" = yes], [
-        AC_CACHE_CHECK([whether __ARM_FEATURE_PAC_DEFAULT specifies the b-key bit 0x02],
-            rb_cv_aarch64_pac_b_key,
-            AC_COMPILE_IFELSE(
-                [AC_LANG_PROGRAM([[
-                    @%:@ifdef __ARM_FEATURE_PAC_DEFAULT
-                    @%:@if __ARM_FEATURE_PAC_DEFAULT & 0x02
-                    @%:@error "__ARM_FEATURE_PAC_DEFAULT specifies B key"
-                    @%:@endif
-                    @%:@endif
-                ]])],
-            [rb_cv_aarch64_pac_b_key=no],
-            [rb_cv_aarch64_pac_b_key=yes])
-        )
-        AS_IF([test "$rb_cv_aarch64_pac_b_key" = yes],
-            AC_MSG_ERROR(-mbranch-protection flag specified b-key but Ruby's Context.S does not support this yet.))
-    ])
-])
 
 AC_CACHE_CHECK([whether compiler has statement and declarations in expressions],
   rb_cv_have_stmt_and_decl_in_expr,

--- a/coroutine/amd64/Context.S
+++ b/coroutine/amd64/Context.S
@@ -5,9 +5,9 @@
 ##  Copyright, 2018, by Samuel Williams.
 ##
 
-#if defined(__CET__)
-#include <cet.h>
-#endif
+/* Important - do _not_ include <cet.h> in this file; doing so will
+ * cause an incorrect .note.gnu.property section to be emitted. We have
+ * one at the bottom of this file */
 
 #define TOKEN_PASTE(x,y) x##y
 #define PREFIXED_SYMBOL(prefix,name) TOKEN_PASTE(prefix,name)
@@ -17,8 +17,9 @@
 .globl PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer)
 PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 
-#if defined(__CET__)
-	_CET_ENDBR
+#if defined(__CET__) && (__CET__ & 0x01) != 0
+        /* IBT landing pad */
+        endbr64
 #endif
 
 	# Make space on the stack for 6 registers:
@@ -58,3 +59,28 @@ PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 #if (defined(__linux__) || defined(__FreeBSD__)) && defined(__ELF__)
 .section .note.GNU-stack,"",%progbits
 #endif
+
+#if defined(__CET__) && (__CET__ & 0x01) != 0
+# define IBT_FLAG 0x01
+#else
+# define IBT_FLAG 0x00
+#endif
+
+/* We do _NOT_ support CET shadow-stack. Do _not_ add the property for
+ * this to the Context.o object. If you require CET shadow-stack support,
+ * for now, consider building with --with-coroutine=ucontext */
+#define SHSTK_FLAG 0x00
+
+.pushsection .note.gnu.property, "a"
+.p2align 3
+.long 0x4        /* Name size ("GNU\0") */
+.long 0x10       /* Descriptor size */
+.long 0x5        /* Type: NT_GNU_PROPERTY_TYPE_0 */
+.asciz "GNU"     /* Name */
+# Begin descriptor
+.long 0xc0000002 /* Property type: GNU_PROPERTY_X86_FEATURE_1_AND */
+.long 0x4        /* Property size */
+.long (IBT_FLAG | SHSTK_FLAG)
+.long 0x0        /* 8-byte alignment padding */
+/* End descriptor */
+.popsection

--- a/coroutine/arm64/Context.S
+++ b/coroutine/arm64/Context.S
@@ -5,8 +5,6 @@
 ##  Copyright, 2018, by Samuel Williams.
 ##
 
-#include "ruby/config.h"
-
 #define TOKEN_PASTE(x,y) x##y
 #define PREFIXED_SYMBOL(prefix,name) TOKEN_PASTE(prefix,name)
 
@@ -20,6 +18,10 @@
 .align 2
 #endif
 
+#if defined(__ARM_FEATURE_PAC_DEFAULT) && (__ARM_FEATURE_PAC_DEFAULT & 0x02) != 0
+# error "-mbranch-protection flag specified b-key but Context.S does not support this"
+#endif
+
 ## NOTE(PAC): Use we HINT mnemonics instead of PAC mnemonics to
 ## keep compatibility with those assemblers that don't support PAC.
 ##
@@ -29,10 +31,10 @@
 .global PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer)
 PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 
-#if defined(RUBY_AARCH64_PAC_ENABLED)
+#if defined(__ARM_FEATURE_PAC_DEFAULT) && (__ARM_FEATURE_PAC_DEFAULT != 0)
 	# paciasp (it also acts as BTI landing pad, so no need to insert BTI also)
 	hint #25
-#elif defined(RUBY_AARCH64_BTI_ENABLED)
+#elif defined(__ARM_FEATURE_BTI_DEFAULT) && (__ARM_FEATURE_BTI_DEFAULT != 0)
 	# For the case PAC is not enabled but BTI is.
 	# bti c
 	hint #34
@@ -75,7 +77,7 @@ PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 	# Pop stack frame
 	add sp, sp, 0xa0
 
-#if defined(RUBY_AARCH64_PAC_ENABLED)
+#if defined(__ARM_FEATURE_PAC_DEFAULT) && (__ARM_FEATURE_PAC_DEFAULT != 0)
 	# autiasp: Authenticate x30 (LR) with SP and key A
 	hint #29
 #endif
@@ -87,18 +89,18 @@ PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 .section .note.GNU-stack,"",%progbits
 #endif
 
-#if defined(RUBY_AARCH64_BTI_ENABLED) || defined(RUBY_AARCH64_PAC_ENABLED)
+#if (defined(__ARM_FEATURE_BTI_DEFAULT) && __ARM_FEATURE_BTI_DEFAULT != 0) || (defined(____ARM_FEATURE_PAC_DEFAULT) && __ARM_FEATURE_PAC_DEFAULT != 0)
 /*  See "ELF for the Arm 64-bit Architecture (AArch64)"
     https://github.com/ARM-software/abi-aa/blob/2023Q3/aaelf64/aaelf64.rst#program-property */
 #  define GNU_PROPERTY_AARCH64_FEATURE_1_BTI (1<<0)
 #  define GNU_PROPERTY_AARCH64_FEATURE_1_PAC (1<<1)
 
-#  if defined(RUBY_AARCH64_BTI_ENABLED)
+#  if defined(__ARM_FEATURE_BTI_DEFAULT) && __ARM_FEATURE_BTI_DEFAULT != 0
 #    define BTI_FLAG GNU_PROPERTY_AARCH64_FEATURE_1_BTI
 #  else
 #    define BTI_FLAG 0
 #  endif
-#  if defined(RUBY_AARCH64_PAC_ENABLED)
+#  if defined(__ARM_FEATURE_PAC_DEFAULT) && __ARM_FEATURE_PAC_DEFAULT != 0
 #    define PAC_FLAG GNU_PROPERTY_AARCH64_FEATURE_1_PAC
 #  else
 #    define PAC_FLAG 0

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -478,8 +478,9 @@ probes.stamp: $(DTRACE_REBUILD_OBJS)
 
 probes.$(OBJEXT): $(srcdir)/probes.d $(DTRACE_REBUILD:yes=probes.stamp)
 	@$(ECHO) processing probes in object files
-	$(Q) $(RM) $@
-	$(Q) $(DTRACE) -G -C $(INCFLAGS) -s $(srcdir)/probes.d -o $@ $(DTRACE_REBUILD_OBJS)
+	@# n.b. the dtrace script looks at the $CFLAGS environment variable to decide
+	@# how to assemble probes.o; so we need to actually _export_ $(CFLAGS)
+	$(Q) CFLAGS="$(CFLAGS) $(XCFLAGS) $(CPPFLAGS)" $(DTRACE) -G -C $(INCFLAGS) -s $(srcdir)/probes.d -o $@ $(DTRACE_REBUILD_OBJS)
 
 # DTrace static library hacks described here:
 # https://marc.info/?l=opensolaris-dtrace-discuss&m=114761203110734&w=4

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -225,7 +225,6 @@ AR            = @AR@
 ARFLAGS       = @ARFLAGS@$(empty)
 RANLIB        = @RANLIB@
 AS            = @AS@
-ASFLAGS       = @ASFLAGS@ $(ARCH_FLAG) $(INCFLAGS)
 IFCHANGE      = $(SHELL) $(tooldir)/ifchange
 OBJDUMP       = @OBJDUMP@
 OBJCOPY       = @OBJCOPY@
@@ -449,7 +448,7 @@ $(srcdir)/enc/jis/props.h: enc/jis/props.kwd
 
 .$(ASMEXT).$(OBJEXT):
 	@$(ECHO) assembling $<
-	$(Q) $(CC) $(ASFLAGS) -DSYMBOL_PREFIX=$(SYMBOL_PREFIX) -o $@ -c $<
+	$(Q) $(CC) $(CFLAGS) $(XCFLAGS) $(CPPFLAGS) $(COUTFLAG)$@ -DSYMBOL_PREFIX=$(SYMBOL_PREFIX) -c $<
 
 .c.$(ASMEXT):
 	@$(ECHO) translating $<


### PR DESCRIPTION
This PR does a few related things to try and make sure that Ruby is correctly declaring in its assembly files which compiler mitigations are supported and which are not.

1. In line with the discussion in https://bugs.ruby-lang.org/issues/20601, this passes CFLAGS to the assembling stage instead of ASFLAGS. This makes sense because we don't actually invoke `as` to do assembly, but rather `cc`.
2. A consequence of this is that macros like `__CET__` and `__ARM_FEATURE_PAC_DEFAULT` get defined by the compiler driver if the relevant mitigation flags `-fcf-protectoin` or `-mbranch-protectoin` are in CFLAGS. This means we don't need to the autoconf checks to export our own version of these macros.
3. I noticed that the `probes.o` file doesn't get marked as supporting Intel IBT/SHSTK, even though it of course does (because it doesn't even have any code!). This can be fixed by making sure CFLAGS are passed to the dtrace invocation through the environment
4. The inclusion of `<cet.h>` in amd64/Context.S makes the built Ruby declare itelf as supporting CET's SHSTK (shadow-stack) feature, even though it doesn't! We could perhaps implement this, but in the meanwhile we should correctly declare that IBT but NOT SHSTK is supported.

(If anybody was wondering why we don't crash when using fibers on amd64 right now, it's because even if you compile with `-fcf-protectoin`, glibc won't actually enable the shadow stack feature at runtime by default. If you set the env var `GLIBC_TUNABLES=glibc.cpu.hwcaps=SHSTK` though, it does, and then it does indeed crash when trying to resume a fiber).