### PR TITLE
Also export CC for dtrace's benefit as well

### DIFF
--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -480,7 +480,7 @@ probes.$(OBJEXT): $(srcdir)/probes.d $(DTRACE_REBUILD:yes=probes.stamp)
 	@$(ECHO) processing probes in object files
 	@# n.b. the dtrace script looks at the $CFLAGS environment variable to decide
 	@# how to assemble probes.o; so we need to actually _export_ $(CFLAGS)
-	$(Q) CFLAGS="$(CFLAGS) $(XCFLAGS) $(CPPFLAGS)" $(DTRACE) -G -C $(INCFLAGS) -s $(srcdir)/probes.d -o $@ $(DTRACE_REBUILD_OBJS)
+	$(Q) CC="$(CC)" CFLAGS="$(CFLAGS) $(XCFLAGS) $(CPPFLAGS)" $(DTRACE) -G -C $(INCFLAGS) -s $(srcdir)/probes.d -o $@ $(DTRACE_REBUILD_OBJS)
 
 # DTrace static library hacks described here:
 # https://marc.info/?l=opensolaris-dtrace-discuss&m=114761203110734&w=4


### PR DESCRIPTION
The CFLAGS might contain flags that only work with the specified CC