### PR TITLE
[DOC] Doc fixes

### DIFF
--- a/file.c
+++ b/file.c
@@ -5326,16 +5326,12 @@ rb_thread_flock(void *data)
  *  Returns `false` if `File::LOCK_NB` is specified and the operation would have blocked;
  *  otherwise returns `0`.
  *
- *  <br>
- *
  *  | Constant        | Lock         | Effect
- *  |-----------------|--------------|-------------------------------------------------------------------
- *  | +File::LOCK_EX+ | Exclusive    | Only one process may hold an exclusive lock for +self+ at a time.
- *  | +File::LOCK_NB+ | Non-blocking | No blocking; may be combined with +File::LOCK_SH+ or +File::LOCK_EX+ using the bitwise OR operator <tt>\|</tt>.
- *  | +File::LOCK_SH+ | Shared       | Multiple processes may each hold a shared lock for +self+ at the same time.
- *  | +File::LOCK_UN+ | Unlock       | Remove an existing lock held by this process.
- *
- *  <br>
+ *  |-----------------|--------------|-----------------------------------------------------------------------------------------------------------------|
+ *  | +File::LOCK_EX+ | Exclusive    | Only one process may hold an exclusive lock for +self+ at a time.                                               |
+ *  | +File::LOCK_NB+ | Non-blocking | No blocking; may be combined with +File::LOCK_SH+ or +File::LOCK_EX+ using the bitwise OR operator <tt>\|</tt>. |
+ *  | +File::LOCK_SH+ | Shared       | Multiple processes may each hold a shared lock for +self+ at the same time.                                     |
+ *  | +File::LOCK_UN+ | Unlock       | Remove an existing lock held by this process.                                                                   |
  *
  *  Example:
  *

--- a/numeric.c
+++ b/numeric.c
@@ -5805,8 +5805,6 @@ int_floor(int argc, VALUE* argv, VALUE num)
  *      | -4      | 10000       | 10000              |
  *      | -5      | 100000      | 100000             |
  *
- *      <br>
- *
  *      Examples with negative `self`:
  *
  *      | ndigits | Granularity | -1234.ceil(ndigits) |
@@ -5816,8 +5814,6 @@ int_floor(int argc, VALUE* argv, VALUE num)
  *      | -3      | 1000        | -1000               |
  *      | -4      | 10000       | 0                   |
  *      | -5      | 100000      | 0                   |
- *
- *      <br>
  *
  *  Related: Integer#floor.
  */


### PR DESCRIPTION
Removed `<br>` snippets (HTML is said to foul the RI renderings).  Added proper terminations to adjoining table rows.