### PR TITLE
Run annocheck for libruby.so

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1668,7 +1668,7 @@ no-test-bundler-parallel:
 # architecture. It is designed to be independent of the host OS and the
 # architecture. The test-annocheck.sh requires docker or podman.
 test-annocheck: $(PROGRAM)
-	$(tooldir)/test-annocheck.sh $(PROGRAM)
+	$(tooldir)/test-annocheck.sh $(PROGRAM) $(LIBRUBY_SO)
 
 GEM = up
 sync-default-gems:

--- a/tool/annocheck/Dockerfile-copy
+++ b/tool/annocheck/Dockerfile-copy
@@ -2,6 +2,5 @@ FROM docker.io/fedora:latest
 ARG FILES
 
 RUN dnf -y install annobin-annocheck
-RUN mkdir /work
-COPY ${FILES} /work
+COPY ${FILES} /work/
 WORKDIR /work

--- a/tool/test-annocheck.sh
+++ b/tool/test-annocheck.sh
@@ -27,7 +27,8 @@ else
   # volume in container in container on GitHub Actions
   # <.github/workflows/compilers.yml>.
   TAG="${TAG}-copy"
-  "${DOCKER}" build --rm -t "${TAG}" --build-arg=FILES="${*}" -f ${TOOL_DIR}/annocheck/Dockerfile-copy .
+  sed -r "s/\\$\{FILES\}/${*}/" ${TOOL_DIR}/annocheck/Dockerfile-copy | \
+    "${DOCKER}" build --rm -t "${TAG}" --build-arg=FILES="${*}" -f - .
 fi
 
 "${DOCKER}" run --rm -t ${DOCKER_RUN_VOLUME_OPTS} "${TAG}" annocheck --verbose ${TEST_ANNOCHECK_OPTS-} "${@}"


### PR DESCRIPTION
When building with `--shared` option, most functionality is kept in `libruby.so`. Therefore also run annocheck for `libruby.so`. Testing `ruby` executable is almost pointless.