### PR TITLE
Don't shrink array in `ary_make_shared`

### DIFF
--- a/array.c
+++ b/array.c
@@ -149,6 +149,7 @@ should_be_T_ARRAY(VALUE ary)
 #define ARY_SET_CAPA(ary, n) do { \
     RUBY_ASSERT(!ARY_EMBED_P(ary)); \
     RUBY_ASSERT(!ARY_SHARED_P(ary)); \
+    RUBY_ASSERT(!OBJ_FROZEN(ary)); \
     RARRAY(ary)->as.heap.aux.capa = (n); \
 } while (0)
 
@@ -369,6 +370,7 @@ ary_heap_free(VALUE ary)
 static size_t
 ary_heap_realloc(VALUE ary, size_t new_capa)
 {
+    RUBY_ASSERT(!OBJ_FROZEN(ary));
     SIZED_REALLOC_N(RARRAY(ary)->as.heap.ptr, VALUE, new_capa, ARY_HEAP_CAPA(ary));
     ary_verify(ary);
 
@@ -926,9 +928,6 @@ ary_make_shared(VALUE ary)
         return ary;
     }
     else if (OBJ_FROZEN(ary)) {
-        if (!ARY_EMBED_P(ary)) {
-            ary_shrink_capa(ary);
-        }
         return ary;
     }
     else {


### PR DESCRIPTION
This change adds back the assertions removed in #11092 and removes the call to `ary_shrink_capa` from `ary_make_shared` when the array is frozen.

cc/ @peterzhu2118 @tenderlove 