### PR TITLE
[DOC] Fix granularity calculation

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -5722,7 +5722,7 @@ int_round(int argc, VALUE* argv, VALUE num)
  *  - When `self` is non-zero and `ndigits` is negative,
  *    returns a value based on a computed granularity:
  *
- *      - The granularity is <tt>ndigits.abs * 10</tt>.
+ *      - The granularity is <tt>10 ** ndigits.abs</tt>.
  *      - The returned value is the largest multiple of the granularity
  *        that is less than or equal to `self`.
  *
@@ -5791,7 +5791,7 @@ int_floor(int argc, VALUE* argv, VALUE num)
  *  - When `self` is non-zero and `ndigits` is negative,
  *    returns a value based on a computed granularity:
  *
- *      - The granularity is <tt>ndigits.abs * 10</tt>.
+ *      - The granularity is <tt>10 ** ndigits.abs</tt>.
  *      - The returned value is the smallest multiple of the granularity
  *        that is greater than or equal to `self`.
  *

--- a/numeric.c
+++ b/numeric.c
@@ -5722,7 +5722,7 @@ int_round(int argc, VALUE* argv, VALUE num)
  *  - When `self` is non-zero and `ndigits` is negative,
  *    returns a value based on a computed granularity:
  *
- *      - The granularity is <tt>10 ** ndigits.abs</tt>.
+ *      - The granularity is `10 ** ndigits.abs`.
  *      - The returned value is the largest multiple of the granularity
  *        that is less than or equal to `self`.
  *
@@ -5791,7 +5791,7 @@ int_floor(int argc, VALUE* argv, VALUE num)
  *  - When `self` is non-zero and `ndigits` is negative,
  *    returns a value based on a computed granularity:
  *
- *      - The granularity is <tt>10 ** ndigits.abs</tt>.
+ *      - The granularity is `10 ** ndigits.abs`.
  *      - The returned value is the smallest multiple of the granularity
  *        that is greater than or equal to `self`.
  *


### PR DESCRIPTION
The granularity is calculated as `10 ** ndigits.abs` rather than `ndigits.abs * 10`. For example, if `ndigits` is `-2`, it should be `10 ** 2 == 100` rather than `2 * 10 == 20`.