### PR TITLE
retry on cancelling of `getaddrinfo`

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -510,7 +510,7 @@ start:
             if (err == 0) *ai = arg->ai;
         }
         else if (arg->cancelled) {
-            err = EAI_AGAIN;
+            retry = 1;
         }
         else {
             // If already interrupted, rb_thread_call_without_gvl2 may return without calling wait_getaddrinfo.
@@ -731,7 +731,7 @@ start:
         }
     }
     else if (arg->cancelled) {
-        err = EAI_AGAIN;
+        retry = 1;
     }
     else {
         // If already interrupted, rb_thread_call_without_gvl2 may return without calling wait_getnameinfo.


### PR DESCRIPTION
When the registerred unblock function is called, it should retry the cancelled blocking function if possible after checkints.

For example, `SIGCHLD` can cancel this method, but it should not raise any exception if there is no trap handlers.

The following is repro-code:

```ruby
require 'socket'
PN = 10_000

1000000.times{
  p _1
  PN.times{
    fork{
      sleep rand(0.3)
    }
  }
  i = 0
  while i<PN
    cpid = Process.wait -1, Process::WNOHANG
    if cpid
      # p [i, cpid]
      i += 1
    end

    begin
      TCPServer.new(nil, 0).close
    rescue
      p $!
      exit!
    end
  end
}
```