### PR TITLE
Shrink capa from OBJ_FREEZE for arrays

### DIFF
--- a/array.c
+++ b/array.c
@@ -450,6 +450,14 @@ ary_shrink_capa(VALUE ary)
     ary_verify(ary);
 }
 
+void
+rb_ary_shrink_capa(VALUE ary)
+{
+    if (!ARY_EMBED_P(ary) && !ARY_SHARED_P(ary) && !ARY_SHARED_ROOT_P(ary)) {
+        ary_shrink_capa(ary);
+    }
+}
+
 static void
 ary_double_capa(VALUE ary, long min)
 {
@@ -647,9 +655,7 @@ rb_ary_freeze(VALUE ary)
 
     if (OBJ_FROZEN(ary)) return ary;
 
-    if (!ARY_EMBED_P(ary) && !ARY_SHARED_P(ary) && !ARY_SHARED_ROOT_P(ary)) {
-        ary_shrink_capa(ary);
-    }
+    rb_ary_shrink_capa(ary);
 
     return rb_obj_freeze(ary);
 }

--- a/internal/array.h
+++ b/internal/array.h
@@ -45,6 +45,7 @@ VALUE rb_ary_tmp_new_from_values(VALUE, long, const VALUE *);
 VALUE rb_check_to_array(VALUE ary);
 VALUE rb_ary_behead(VALUE, long);
 VALUE rb_ary_aref1(VALUE ary, VALUE i);
+void rb_ary_shrink_capa(VALUE ary);
 
 struct rb_execution_context_struct;
 VALUE rb_ec_ary_new_from_values(struct rb_execution_context_struct *ec, long n, const VALUE *elts);

--- a/variable.c
+++ b/variable.c
@@ -1812,13 +1812,19 @@ rb_shape_set_shape_id(VALUE obj, shape_id_t shape_id)
  *
  * @param[out]  x  Object in question.
  */
-void rb_obj_freeze_inline(VALUE x)
+void
+rb_obj_freeze_inline(VALUE x)
 {
     if (RB_FL_ABLE(x)) {
-        RB_FL_SET_RAW(x, RUBY_FL_FREEZE);
-        if (TYPE(x) == T_STRING) {
+        switch (BUILTIN_TYPE(x)) {
+          case T_STRING:
             RB_FL_UNSET_RAW(x, FL_USER3); // STR_CHILLED
+            break;
+          case T_ARRAY:
+            rb_ary_shrink_capa(x);
+            break;
         }
+        RB_FL_SET_RAW(x, RUBY_FL_FREEZE);
 
         rb_shape_t * next_shape = rb_shape_transition_shape_frozen(x);
 


### PR DESCRIPTION
When we freeze an array ensure that the capacity is shrunk first. We're already doing type checking in `OBJ_FREEZE` for `T_STRING` so this shouldn't impact performance.

Some gems like JSON call `OBJ_FREEZE` so they don't go through `rb_obj_freeze` or `rb_ary_freeze`, and instead use `rb_obj_freeze_inline`.

Followup to #11124

cc/ @tenderlove @byroot @mame 