### PR TITLE
`defined?(@ivar)` with Ractors should check more

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1086,6 +1086,20 @@ assert_equal '333', %q{
   a + b + c + d + e + f
 }
 
+assert_equal '["instance-variable", "instance-variable", nil]', %q{
+  class C
+    @iv1 = ""
+    @iv2 = 42
+    def self.iv1 = defined?(@iv1) # "instance-variable"
+    def self.iv2 = defined?(@iv2) # "instance-variable"
+    def self.iv3 = defined?(@iv3) # nil
+  end
+
+  Ractor.new{
+    [C.iv1, C.iv2, C.iv3]
+  }.take
+}
+
 # moved objects have their shape properly set to original object's shape
 assert_equal '1234', %q{
 class Obj

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1252,7 +1252,13 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
                 // and modules. So we can skip locking.
                 // Second, other ractors need to check the shareability of the
                 // values returned from the class ivars.
-                goto general_path;
+
+                if (default_value == Qundef) { // defined?
+                    return rb_ivar_defined(obj, id) ? Qtrue : Qundef;
+                }
+                else {
+                    goto general_path;
+                }
             }
 
             ivar_list = RCLASS_IVPTR(obj);


### PR DESCRIPTION
It is not allowed to get instance variables from an object if
1. the object is shareable
2. and the instance variable refers to an unshareable object

```ruby
R = Ractor.new{}
R.instance_variable_set(:@iv, [])
Ractor.new{ p R.instance_variable_get(:@iv) }.take
```

```ruby
class C
  @iv = []
  def self.iv = @iv
end
Ractor.new{ p C.iv }.take
```

So that returning `nil` for `defined?(@iv)` on this kind of situation is reasonable.

```ruby
class C
  @iv1 = []
  def self.iv1 = defined?(@iv1)

  @iv2 = 42
  def self.iv2 = defined?(@iv2)
end
Ractor.new{
  p C.iv1 #=> nil
  p C.iv2 #=> "instance-variable" because @iv2 is shareable object.
}.take
```