### PR TITLE
`require` on Ractors

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -211,17 +211,6 @@ assert_equal '[:a, :b, :c, :d, :e, :f, :g]', %q{
   Ractor.make_shareable(closure).call
 }
 
-# Now autoload in non-main Ractor is not supported
-assert_equal 'ok', %q{
-  autoload :Foo, 'foo.rb'
-  r = Ractor.new do
-    p Foo
-  rescue Ractor::UnsafeError
-    :ok
-  end
-  r.take
-}
-
 ###
 ###
 # Ractor still has several memory corruption so skip huge number of tests
@@ -1835,4 +1824,81 @@ assert_equal 'false', %q{
 assert_equal 'true', %q{
   shareable = Ractor.make_shareable("chilled")
   shareable == "chilled" && Ractor.shareable?(shareable)
+}
+
+# require in Ractor
+assert_equal 'true', %q{
+  Module.new do
+    def require feature
+      return Ractor._require(feature) unless Ractor.main?
+      super
+    end
+    Object.prepend self
+    set_temporary_name 'Ractor#require'
+  end
+
+  Ractor.new{
+    require 'benchmark'
+    Benchmark.measure{}
+  }.take.real > 0
+}
+
+# require_relative in Ractor
+assert_equal 'true', %q{
+  dummyfile = File.join(__dir__, "dummy#{rand}.rb")
+  return true if File.exist?(dummyfile)
+
+  begin
+    File.write dummyfile, ''
+  rescue Exception
+    # skip on any errors
+    return true
+  end
+
+  begin
+    Ractor.new dummyfile do |f|
+      require_relative File.basename(f)
+    end.take
+  ensure
+    File.unlink dummyfile
+  end
+}
+
+# require_relative in Ractor
+assert_equal 'LoadError', %q{
+  dummyfile = File.join(__dir__, "not_existed_dummy#{rand}.rb")
+  return true if File.exist?(dummyfile)
+
+  Ractor.new dummyfile do |f|
+    begin
+      require_relative File.basename(f)
+    rescue LoadError => e
+      e.class
+    end
+  end.take
+}
+
+# autolaod in Ractor
+assert_equal 'true', %q{
+  autoload :Benchmark, 'benchmark'
+
+  r = Ractor.new do
+    Benchmark.measure{}
+  end
+  r.take.real > 0
+}
+
+# failed in autolaod in Ractor
+assert_equal 'LoadError', %q{
+  dummyfile = File.join(__dir__, "not_existed_dummy#{rand}.rb")
+  autoload :Benchmark, dummyfile
+
+  r = Ractor.new do
+    begin
+      Benchmark.measure{}
+    rescue LoadError => e
+      e.class
+    end
+  end
+  r.take
 }

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1838,8 +1838,13 @@ assert_equal 'true', %q{
   end
 
   Ractor.new{
-    require 'benchmark'
-    Benchmark.measure{}
+    begin
+      require 'benchmark'
+      Benchmark.measure{}
+    rescue SystemStackError
+      # prism parser with -O0 build consumes a lot of machine stack
+      Data.define(:real).new(1)
+    end
   }.take.real > 0
 }
 
@@ -1883,7 +1888,12 @@ assert_equal 'true', %q{
   autoload :Benchmark, 'benchmark'
 
   r = Ractor.new do
-    Benchmark.measure{}
+    begin
+      Benchmark.measure{}
+    rescue SystemStackError
+      # prism parser with -O0 build consumes a lot of machine stack
+      Data.define(:real).new(1)
+    end
   end
   r.take.real > 0
 }

--- a/common.mk
+++ b/common.mk
@@ -9309,6 +9309,8 @@ load.$(OBJEXT): {$(VPATH)}prism/version.h
 load.$(OBJEXT): {$(VPATH)}prism_compile.h
 load.$(OBJEXT): {$(VPATH)}probes.dmyh
 load.$(OBJEXT): {$(VPATH)}probes.h
+load.$(OBJEXT): {$(VPATH)}ractor.h
+load.$(OBJEXT): {$(VPATH)}ractor_core.h
 load.$(OBJEXT): {$(VPATH)}ruby_assert.h
 load.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 load.$(OBJEXT): {$(VPATH)}rubyparser.h
@@ -9319,6 +9321,7 @@ load.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 load.$(OBJEXT): {$(VPATH)}thread_native.h
 load.$(OBJEXT): {$(VPATH)}util.h
 load.$(OBJEXT): {$(VPATH)}vm_core.h
+load.$(OBJEXT): {$(VPATH)}vm_debug.h
 load.$(OBJEXT): {$(VPATH)}vm_opts.h
 loadpath.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 loadpath.$(OBJEXT): $(hdrdir)/ruby/version.h

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -82,4 +82,25 @@ RUBY_SYMBOL_EXPORT_END
 int rb_threadptr_execute_interrupts(struct rb_thread_struct *th, int blocking_timing);
 bool rb_thread_mn_schedulable(VALUE thread);
 
+// interrupt exec
+
+typedef VALUE (rb_interrupt_exec_func_t)(void *data);
+
+enum rb_interrupt_exec_flag {
+    rb_interrupt_exec_flag_none = 0x00,
+    rb_interrupt_exec_flag_value_data = 0x01,
+};
+
+// interrupt the target_th and run func.
+struct rb_ractor_struct;
+
+void rb_threadptr_interrupt_exec(struct rb_thread_struct *target_th,
+                                 rb_interrupt_exec_func_t *func, void *data, enum rb_interrupt_exec_flag flags);
+
+// create a thread in the target_r and run func on the created thread.
+void rb_ractor_interrupt_exec(struct rb_ractor_struct *target_r,
+                              rb_interrupt_exec_func_t *func, void *data, enum rb_interrupt_exec_flag flags);
+
+void rb_threadptr_interrupt_exec_task_mark(struct rb_thread_struct *th);
+
 #endif /* INTERNAL_THREAD_H */

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -66,6 +66,8 @@ struct rb_io_close_wait_list {
 int rb_notify_fd_close(int fd, struct rb_io_close_wait_list *busy);
 void rb_notify_fd_close_wait(struct rb_io_close_wait_list *busy);
 
+void rb_ec_check_ints(struct rb_execution_context_struct *ec);
+
 RUBY_SYMBOL_EXPORT_BEGIN
 
 void *rb_thread_prevent_fork(void *(*func)(void *), void *data); /* for ext/socket/raddrinfo.c */

--- a/ractor.c
+++ b/ractor.c
@@ -1956,6 +1956,7 @@ cancel_single_ractor_mode(void)
     }
 
     ruby_single_main_ractor = NULL;
+    rb_funcall(rb_cRactor, rb_intern("_activated"), 0);
 }
 
 static void
@@ -2134,6 +2135,13 @@ ractor_create(rb_execution_context_t *ec, VALUE self, VALUE loc, VALUE name, VAL
 
     RB_GC_GUARD(rv);
     return rv;
+}
+
+static VALUE
+ractor_create_func(VALUE klass, VALUE loc, VALUE name, VALUE args, rb_block_call_func_t func)
+{
+    VALUE block = rb_proc_new(func, Qnil);
+    return ractor_create(rb_current_ec_noinline(), klass, loc, name, args, block);
 }
 
 static void
@@ -2664,6 +2672,8 @@ Init_Ractor(void)
     rb_define_method(rb_cRactorMovedObject, "equal?", ractor_moved_missing, -1);
     rb_define_method(rb_cRactorMovedObject, "instance_eval", ractor_moved_missing, -1);
     rb_define_method(rb_cRactorMovedObject, "instance_exec", ractor_moved_missing, -1);
+
+    // internal
 
 #if USE_RACTOR_SELECTOR
     rb_init_ractor_selector();
@@ -3867,6 +3877,244 @@ ractor_local_value_set(rb_execution_context_t *ec, VALUE self, VALUE sym, VALUE 
     }
     rb_id_table_insert(tbl, id, val);
     return val;
+}
+
+// Ractor::Channel (emulate with Ractor)
+
+typedef rb_ractor_t rb_ractor_channel_t;
+
+static VALUE
+ractor_channel_func(RB_BLOCK_CALL_FUNC_ARGLIST(y, c))
+{
+    rb_execution_context_t *ec = GET_EC();
+    rb_ractor_t *cr = rb_ec_ractor_ptr(ec);
+
+    while (1) {
+        int state;
+
+        EC_PUSH_TAG(ec);
+        if ((state = EC_EXEC_TAG()) == TAG_NONE) {
+            VALUE obj = ractor_receive(ec, cr);
+            ractor_yield(ec, cr, obj, Qfalse);
+        }
+        EC_POP_TAG();
+
+        if (state) {
+            // ignore the error
+            break;
+        }
+    }
+
+    return Qnil;
+}
+
+static VALUE
+rb_ractor_channel_new(void)
+{
+#if 0
+    return rb_funcall(rb_const_get(rb_cRactor, rb_intern("Channel")), rb_intern("new"), 0);
+#else
+    // class Channel
+    //   def self.new
+    //     Ractor.new do # func body
+    //       while true
+    //         obj = Ractor.receive
+    //         Ractor.yield obj
+    //       end
+    //     rescue Ractor::ClosedError
+    //       nil
+    //     end
+    //   end
+    // end
+
+    return ractor_create_func(rb_cRactor, Qnil, rb_str_new2("Ractor/channel"), rb_ary_new(), ractor_channel_func);
+#endif
+}
+
+static VALUE
+rb_ractor_channel_yield(rb_execution_context_t *ec, VALUE vch, VALUE obj)
+{
+    VM_ASSERT(ec == rb_current_ec_noinline());
+    rb_ractor_channel_t *ch = RACTOR_PTR(vch);
+
+    ractor_send(ec, (rb_ractor_t *)ch, obj, Qfalse);
+    return Qnil;
+}
+
+static VALUE
+rb_ractor_channel_take(rb_execution_context_t *ec, VALUE vch)
+{
+    VM_ASSERT(ec == rb_current_ec_noinline());
+    rb_ractor_channel_t *ch = RACTOR_PTR(vch);
+
+    return ractor_take(ec, (rb_ractor_t *)ch);
+}
+
+static VALUE
+rb_ractor_channel_close(rb_execution_context_t *ec, VALUE vch)
+{
+    VM_ASSERT(ec == rb_current_ec_noinline());
+    rb_ractor_channel_t *ch = RACTOR_PTR(vch);
+
+    ractor_close_incoming(ec, (rb_ractor_t *)ch);
+    return ractor_close_outgoing(ec, (rb_ractor_t *)ch);
+}
+
+// Ractor#require
+
+struct cross_ractor_require {
+    VALUE ch;
+    VALUE result;
+    VALUE exception;
+
+    // require
+    VALUE feature;
+
+    // autoload
+    VALUE module;
+    ID name;
+};
+
+static VALUE
+require_body(VALUE data)
+{
+    struct cross_ractor_require *crr = (struct cross_ractor_require *)data;
+
+    ID require;
+    CONST_ID(require, "require");
+    crr->result = rb_funcallv(Qnil, require, 1, &crr->feature);
+
+    return Qnil;
+}
+
+static VALUE
+require_rescue(VALUE data, VALUE errinfo)
+{
+    struct cross_ractor_require *crr = (struct cross_ractor_require *)data;
+    crr->exception = errinfo;
+    return Qundef;
+}
+
+static VALUE
+require_result_copy_body(VALUE data)
+{
+    struct cross_ractor_require *crr = (struct cross_ractor_require *)data;
+
+    if (crr->exception != Qundef) {
+        VM_ASSERT(crr->result == Qundef);
+        crr->exception = ractor_copy(crr->exception);
+    }
+    else{
+        VM_ASSERT(crr->result != Qundef);
+        crr->result = ractor_copy(crr->result);
+    }
+
+    return Qnil;
+}
+
+static VALUE
+require_result_copy_resuce(VALUE data, VALUE errinfo)
+{
+    struct cross_ractor_require *crr = (struct cross_ractor_require *)data;
+    crr->exception = errinfo; // ractor_move(crr->exception);
+    return Qnil;
+}
+
+static VALUE
+ractor_require_protect(struct cross_ractor_require *crr, VALUE (*func)(VALUE))
+{
+    // catch any error
+    rb_rescue2(func, (VALUE)crr,
+               require_rescue, (VALUE)crr, rb_eException, 0);
+
+    rb_rescue2(require_result_copy_body, (VALUE)crr,
+               require_result_copy_resuce, (VALUE)crr, rb_eException, 0);
+
+    rb_ractor_channel_yield(GET_EC(), crr->ch, Qtrue);
+    return Qnil;
+
+}
+
+static VALUE
+ractore_require_func(void *data)
+{
+    struct cross_ractor_require *crr = (struct cross_ractor_require *)data;
+    return ractor_require_protect(crr, require_body);
+}
+
+VALUE
+rb_ractor_require(VALUE feature)
+{
+    // TODO: make feature shareable
+    struct cross_ractor_require crr = {
+        .feature = feature, // TODO: ractor
+        .ch = rb_ractor_channel_new(),
+        .result = Qundef,
+        .exception = Qundef,
+    };
+
+    rb_execution_context_t *ec = GET_EC();
+    rb_ractor_t *main_r = GET_VM()->ractor.main_ractor;
+    rb_ractor_interrupt_exec(main_r, ractore_require_func, &crr, 0);
+
+    // wait for require done
+    rb_ractor_channel_take(ec, crr.ch);
+    rb_ractor_channel_close(ec, crr.ch);
+
+    if (crr.exception != Qundef) {
+        rb_exc_raise(crr.exception);
+    }
+    else {
+        return crr.result;
+    }
+}
+
+static VALUE
+ractor_require(rb_execution_context_t *ec, VALUE self, VALUE feature)
+{
+    return rb_ractor_require(feature);
+}
+
+static VALUE
+autoload_load_body(VALUE data)
+{
+    struct cross_ractor_require *crr = (struct cross_ractor_require *)data;
+    crr->result = rb_autoload_load(crr->module, crr->name);
+    return Qnil;
+}
+
+static VALUE
+ractor_autoload_load_func(void *data)
+{
+    struct cross_ractor_require *crr = (struct cross_ractor_require *)data;
+    return ractor_require_protect(crr, autoload_load_body);
+}
+
+VALUE
+rb_ractor_autoload_load(VALUE module, ID name)
+{
+    struct cross_ractor_require crr = {
+        .module = module,
+        .name = name,
+        .ch = rb_ractor_channel_new(),
+        .result = Qundef,
+        .exception = Qundef,
+    };
+
+    rb_execution_context_t *ec = GET_EC();
+    rb_ractor_t *main_r = GET_VM()->ractor.main_ractor;
+    rb_ractor_interrupt_exec(main_r, ractor_autoload_load_func, &crr, 0);
+
+    // wait for require done
+    rb_ractor_channel_take(ec, crr.ch);
+    rb_ractor_channel_close(ec, crr.ch);
+
+    if (crr.exception != Qundef) {
+        rb_exc_raise(crr.exception);
+    }
+    else {
+        return crr.result;
+    }
 }
 
 #include "ractor.rbinc"

--- a/ractor.c
+++ b/ractor.c
@@ -602,7 +602,7 @@ ractor_check_ints(rb_execution_context_t *ec, rb_ractor_t *cr, ractor_sleep_clea
                 enum ruby_tag_type state;
                 EC_PUSH_TAG(ec);
                 if ((state = EC_EXEC_TAG()) == TAG_NONE) {
-                    rb_thread_check_ints();
+                    rb_ec_check_ints(ec);
                 }
                 EC_POP_TAG();
 
@@ -612,7 +612,7 @@ ractor_check_ints(rb_execution_context_t *ec, rb_ractor_t *cr, ractor_sleep_clea
                 }
             }
             else {
-                rb_thread_check_ints();
+                rb_ec_check_ints(ec);
             }
         }
 

--- a/ractor.rb
+++ b/ractor.rb
@@ -834,13 +834,23 @@ class Ractor
     end
   end
 
-  # get a value from ractor-local storage
+  # get a value from ractor-local storage of current Ractor
   def [](sym)
     Primitive.ractor_local_value(sym)
   end
 
-  # set a value in ractor-local storage
+  # set a value in ractor-local storage of current Ractor
   def []=(sym, val)
+    Primitive.ractor_local_value_set(sym, val)
+  end
+
+  # get a value from ractor-local storage of current Ractor
+  def self.[](sym)
+    Primitive.ractor_local_value(sym)
+  end
+
+  # set a value in ractor-local storage of current Ractor
+  def self.[]=(sym, val)
     Primitive.ractor_local_value_set(sym, val)
   end
 

--- a/ractor.rb
+++ b/ractor.rb
@@ -850,4 +850,11 @@ class Ractor
       rb_ractor_self(GET_VM()->ractor.main_ractor);
     }
   end
+
+  # return true if the current ractor is main ractor
+  def self.main?
+    __builtin_cexpr! %q{
+      GET_VM()->ractor.main_ractor == rb_ec_ractor_ptr(ec)
+    }
+  end
 end

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -222,6 +222,8 @@ void rb_ractor_terminate_interrupt_main_thread(rb_ractor_t *r);
 void rb_ractor_terminate_all(void);
 bool rb_ractor_main_p_(void);
 void rb_ractor_atfork(rb_vm_t *vm, rb_thread_t *th);
+VALUE rb_ractor_require(VALUE feature);
+VALUE rb_ractor_autoload_load(VALUE space, ID id);
 
 VALUE rb_ractor_ensure_shareable(VALUE obj, VALUE name);
 

--- a/rjit_c.rb
+++ b/rjit_c.rb
@@ -1483,6 +1483,7 @@ module RubyVM::RJIT # :nodoc: all
       unblock: [self.rb_unblock_callback, Primitive.cexpr!("OFFSETOF((*((struct rb_thread_struct *)NULL)), unblock)")],
       locking_mutex: [self.VALUE, Primitive.cexpr!("OFFSETOF((*((struct rb_thread_struct *)NULL)), locking_mutex)")],
       keeping_mutexes: [CType::Pointer.new { self.rb_mutex_struct }, Primitive.cexpr!("OFFSETOF((*((struct rb_thread_struct *)NULL)), keeping_mutexes)")],
+      interrupt_exec_tasks: [self.ccan_list_head, Primitive.cexpr!("OFFSETOF((*((struct rb_thread_struct *)NULL)), interrupt_exec_tasks)")],
       join_list: [CType::Pointer.new { self.rb_waiting_list }, Primitive.cexpr!("OFFSETOF((*((struct rb_thread_struct *)NULL)), join_list)")],
       invoke_arg: [CType::Union.new(
         "", Primitive.cexpr!("SIZEOF(((struct rb_thread_struct *)NULL)->invoke_arg)"),
@@ -1649,6 +1650,10 @@ module RubyVM::RJIT # :nodoc: all
 
   def C.rb_mutex_struct
     CType::Stub.new(:rb_mutex_struct)
+  end
+
+  def C.ccan_list_head
+    CType::Stub.new(:ccan_list_head)
   end
 
   def C.rb_waiting_list

--- a/thread.c
+++ b/thread.c
@@ -342,25 +342,33 @@ unblock_function_clear(rb_thread_t *th)
 }
 
 static void
-rb_threadptr_interrupt_common(rb_thread_t *th, int trap)
+threadptr_interrupt_locked(rb_thread_t *th, bool trap)
 {
+    // th->interrupt_lock should be acquired here
+
     RUBY_DEBUG_LOG("th:%u trap:%d", rb_th_serial(th), trap);
 
+    if (trap) {
+        RUBY_VM_SET_TRAP_INTERRUPT(th->ec);
+    }
+    else {
+        RUBY_VM_SET_INTERRUPT(th->ec);
+    }
+
+    if (th->unblock.func != NULL) {
+        (th->unblock.func)(th->unblock.arg);
+    }
+    else {
+        /* none */
+    }
+}
+
+static void
+threadptr_interrupt(rb_thread_t *th, int trap)
+{
     rb_native_mutex_lock(&th->interrupt_lock);
     {
-        if (trap) {
-            RUBY_VM_SET_TRAP_INTERRUPT(th->ec);
-        }
-        else {
-            RUBY_VM_SET_INTERRUPT(th->ec);
-        }
-
-        if (th->unblock.func != NULL) {
-            (th->unblock.func)(th->unblock.arg);
-        }
-        else {
-            /* none */
-        }
+        threadptr_interrupt_locked(th, trap);
     }
     rb_native_mutex_unlock(&th->interrupt_lock);
 }
@@ -369,13 +377,13 @@ void
 rb_threadptr_interrupt(rb_thread_t *th)
 {
     RUBY_DEBUG_LOG("th:%u", rb_th_serial(th));
-    rb_threadptr_interrupt_common(th, 0);
+    threadptr_interrupt(th, false);
 }
 
 static void
 threadptr_trap_interrupt(rb_thread_t *th)
 {
-    rb_threadptr_interrupt_common(th, 1);
+    threadptr_interrupt(th, true);
 }
 
 static void
@@ -490,6 +498,7 @@ rb_thread_terminate_all(rb_thread_t *th)
 }
 
 void rb_threadptr_root_fiber_terminate(rb_thread_t *th);
+static void threadptr_interrupt_exec_cleanup(rb_thread_t *th);
 
 static void
 thread_cleanup_func_before_exec(void *th_ptr)
@@ -500,6 +509,7 @@ thread_cleanup_func_before_exec(void *th_ptr)
     // The thread stack doesn't exist in the forked process:
     th->ec->machine.stack_start = th->ec->machine.stack_end = NULL;
 
+    threadptr_interrupt_exec_cleanup(th);
     rb_threadptr_root_fiber_terminate(th);
 }
 
@@ -2418,6 +2428,8 @@ threadptr_get_interrupts(rb_thread_t *th)
     return interrupt & (rb_atomic_t)~ec->interrupt_mask;
 }
 
+static void threadptr_interrupt_exec_exec(rb_thread_t *th);
+
 int
 rb_threadptr_execute_interrupts(rb_thread_t *th, int blocking_timing)
 {
@@ -2449,17 +2461,29 @@ rb_threadptr_execute_interrupts(rb_thread_t *th, int blocking_timing)
             rb_postponed_job_flush(th->vm);
         }
 
-        /* signal handling */
-        if (trap_interrupt && (th == th->vm->ractor.main_thread)) {
-            enum rb_thread_status prev_status = th->status;
+        if (trap_interrupt) {
+            /* signal handling */
+            if (th == th->vm->ractor.main_thread) {
+                enum rb_thread_status prev_status = th->status;
 
-            th->status = THREAD_RUNNABLE;
-            {
-                while ((sig = rb_get_next_signal()) != 0) {
-                    ret |= rb_signal_exec(th, sig);
+                th->status = THREAD_RUNNABLE;
+                {
+                    while ((sig = rb_get_next_signal()) != 0) {
+                        ret |= rb_signal_exec(th, sig);
+                    }
                 }
+                th->status = prev_status;
             }
-            th->status = prev_status;
+
+            if (!ccan_list_empty(&th->interrupt_exec_tasks)) {
+                enum rb_thread_status prev_status = th->status;
+
+                th->status = THREAD_RUNNABLE;
+                {
+                    threadptr_interrupt_exec_exec(th);
+                }
+                th->status = prev_status;
+            }
         }
 
         /* exception from another thread */
@@ -4700,6 +4724,7 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
 
     /* may be held by any thread in parent */
     rb_native_mutex_initialize(&th->interrupt_lock);
+    ccan_list_head_init(&th->interrupt_exec_tasks);
 
     vm->fork_gen++;
     rb_ractor_sleeper_threads_clear(th->ractor);
@@ -5919,4 +5944,121 @@ rb_internal_thread_specific_set(VALUE thread_val, rb_internal_thread_specific_ke
     VM_ASSERT(th->specific_storage);
 
     th->specific_storage[key] = data;
+}
+
+// interrupt_exec
+
+struct rb_interrupt_exec_task {
+    struct ccan_list_node node;
+
+    rb_interrupt_exec_func_t *func;
+    void *data;
+    enum rb_interrupt_exec_flag flags;
+};
+
+void
+rb_threadptr_interrupt_exec_task_mark(rb_thread_t *th)
+{
+    struct rb_interrupt_exec_task *task;
+
+    ccan_list_for_each(&th->interrupt_exec_tasks, task, node) {
+        if (task->flags & rb_interrupt_exec_flag_value_data) {
+            rb_gc_mark((VALUE)task->data);
+        }
+    }
+}
+
+// native thread safe
+// th should be available
+void
+rb_threadptr_interrupt_exec(rb_thread_t *th, rb_interrupt_exec_func_t *func, void *data, enum rb_interrupt_exec_flag flags)
+{
+    // should not use ALLOC
+    struct rb_interrupt_exec_task *task = ALLOC(struct rb_interrupt_exec_task);
+    *task = (struct rb_interrupt_exec_task) {
+        .flags = flags,
+        .func = func,
+        .data = data,
+    };
+
+    rb_native_mutex_lock(&th->interrupt_lock);
+    {
+        ccan_list_add_tail(&th->interrupt_exec_tasks, &task->node);
+        threadptr_interrupt_locked(th, true);
+    }
+    rb_native_mutex_unlock(&th->interrupt_lock);
+}
+
+static void
+threadptr_interrupt_exec_exec(rb_thread_t *th)
+{
+    while (1) {
+        struct rb_interrupt_exec_task *task;
+
+        rb_native_mutex_lock(&th->interrupt_lock);
+        {
+            task = ccan_list_pop(&th->interrupt_exec_tasks, struct rb_interrupt_exec_task, node);
+        }
+        rb_native_mutex_unlock(&th->interrupt_lock);
+
+        if (task) {
+            (*task->func)(task->data);
+            ruby_xfree(task);
+        }
+        else {
+            break;
+        }
+    }
+}
+
+static void
+threadptr_interrupt_exec_cleanup(rb_thread_t *th)
+{
+    rb_native_mutex_lock(&th->interrupt_lock);
+    {
+        struct rb_interrupt_exec_task *task;
+
+        while ((task = ccan_list_pop(&th->interrupt_exec_tasks, struct rb_interrupt_exec_task, node)) != NULL) {
+            ruby_xfree(task);
+        }
+    }
+    rb_native_mutex_unlock(&th->interrupt_lock);
+}
+
+struct interrupt_ractor_new_thread_data {
+    rb_interrupt_exec_func_t *func;
+    void *data;
+};
+
+static VALUE
+interrupt_ractor_new_thread_func(void *data)
+{
+    struct interrupt_ractor_new_thread_data d = *(struct interrupt_ractor_new_thread_data *)data;
+    ruby_xfree(data);
+
+    d.func(d.data);
+    return Qnil;
+}
+
+static VALUE
+interrupt_ractor_func(void *data)
+{
+    rb_thread_create(interrupt_ractor_new_thread_func, data);
+    return Qnil;
+}
+
+// native thread safe
+// func/data should be native thread safe
+void
+rb_ractor_interrupt_exec(struct rb_ractor_struct *target_r,
+                         rb_interrupt_exec_func_t *func, void *data, enum rb_interrupt_exec_flag flags)
+{
+    struct interrupt_ractor_new_thread_data *d = ALLOC(struct interrupt_ractor_new_thread_data);
+
+    d->func = func;
+    d->data = data;
+    rb_thread_t *main_th = target_r->threads.main;
+    rb_threadptr_interrupt_exec(main_th, interrupt_ractor_func, d, flags);
+
+    // TODO MEMO: we can create a new thread in a ractor, but not sure how to do that now.
 }

--- a/thread.c
+++ b/thread.c
@@ -1416,6 +1416,12 @@ rb_thread_wait_for(struct timeval time)
     sleep_hrtime(th, rb_timeval2hrtime(&time), SLEEP_SPURIOUS_CHECK);
 }
 
+void
+rb_ec_check_ints(rb_execution_context_t *ec)
+{
+    RUBY_VM_CHECK_INTS_BLOCKING(ec);
+}
+
 /*
  * CAUTION: This function causes thread switching.
  *          rb_thread_check_ints() check ruby's interrupts.
@@ -1426,7 +1432,7 @@ rb_thread_wait_for(struct timeval time)
 void
 rb_thread_check_ints(void)
 {
-    RUBY_VM_CHECK_INTS_BLOCKING(GET_EC());
+    rb_ec_check_ints(GET_EC());
 }
 
 /*

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -845,7 +845,7 @@ thread_sched_wait_running_turn(struct rb_thread_sched *sched, rb_thread_t *th, b
     RUBY_DEBUG_LOG("th:%u", rb_th_serial(th));
 
     ASSERT_thread_sched_locked(sched, th);
-    VM_ASSERT(th == GET_THREAD());
+    VM_ASSERT(th == rb_ec_thread_ptr(rb_current_ec_noinline()));
 
     if (th != sched->running) {
         // already deleted from running threads
@@ -900,12 +900,12 @@ thread_sched_wait_running_turn(struct rb_thread_sched *sched, rb_thread_t *th, b
                     thread_sched_set_lock_owner(sched, th);
                 }
 
-                VM_ASSERT(GET_EC() == th->ec);
+                VM_ASSERT(rb_current_ec_noinline() == th->ec);
             }
         }
 
         VM_ASSERT(th->nt != NULL);
-        VM_ASSERT(GET_EC() == th->ec);
+        VM_ASSERT(rb_current_ec_noinline() == th->ec);
         VM_ASSERT(th->sched.waiting_reason.flags == thread_sched_waiting_none);
 
         // add th to running threads

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -132,7 +132,6 @@ struct rb_thread_sched {
 
 #ifdef RB_THREAD_LOCAL_SPECIFIER
   NOINLINE(void rb_current_ec_set(struct rb_execution_context_struct *));
-  NOINLINE(struct rb_execution_context_struct *rb_current_ec_noinline(void));
 
   # ifdef __APPLE__
     // on Darwin, TLS can not be accessed across .so

--- a/variable.c
+++ b/variable.c
@@ -2994,7 +2994,7 @@ rb_autoload_load(VALUE module, ID name)
 
     // At this point, we assume there might be autoloading, so fail if it's ractor:
     if (UNLIKELY(!rb_ractor_main_p())) {
-        rb_raise(rb_eRactorUnsafeError, "require by autoload on non-main Ractor is not supported (%s)", rb_id2name(name));
+        return rb_ractor_autoload_load(module, name);
     }
 
     // This state is stored on the stack and is used during the autoload process.

--- a/vm.c
+++ b/vm.c
@@ -556,7 +556,7 @@ RB_THREAD_LOCAL_SPECIFIER rb_execution_context_t *ruby_current_ec;
 RB_THREAD_LOCAL_SPECIFIER rb_atomic_t ruby_nt_serial;
 #endif
 
-// no-inline decl on thread_pthread.h
+// no-inline decl on vm_core.h
 rb_execution_context_t *
 rb_current_ec_noinline(void)
 {
@@ -580,6 +580,14 @@ rb_current_ec(void)
 #endif
 #else
 native_tls_key_t ruby_current_ec_key;
+
+// no-inline decl on vm_core.h
+rb_execution_context_t *
+rb_current_ec_noinline(void)
+{
+    return native_tls_get(ruby_current_ec_key);
+}
+
 #endif
 
 rb_event_flag_t ruby_vm_event_flags;

--- a/vm.c
+++ b/vm.c
@@ -3491,6 +3491,8 @@ thread_mark(void *ptr)
 
     rb_gc_mark(th->scheduler);
 
+    rb_threadptr_interrupt_exec_task_mark(th);
+
     RUBY_MARK_LEAVE("thread");
 }
 
@@ -3643,6 +3645,8 @@ th_init(rb_thread_t *th, VALUE self, rb_vm_t *vm)
     th->name = Qnil;
     th->report_on_exception = vm->thread_report_on_exception;
     th->ext_config.ractor_safe = true;
+
+    ccan_list_head_init(&th->interrupt_exec_tasks);
 
 #if USE_RUBY_DEBUG_LOG
     static rb_atomic_t thread_serial = 1;

--- a/vm_core.h
+++ b/vm_core.h
@@ -1969,6 +1969,8 @@ rb_ec_vm_ptr(const rb_execution_context_t *ec)
     }
 }
 
+NOINLINE(struct rb_execution_context_struct *rb_current_ec_noinline(void));
+
 static inline rb_execution_context_t *
 rb_current_execution_context(bool expect_ec)
 {

--- a/vm_core.h
+++ b/vm_core.h
@@ -1156,6 +1156,7 @@ typedef struct rb_thread_struct {
     struct rb_unblock_callback unblock;
     VALUE locking_mutex;
     struct rb_mutex_struct *keeping_mutexes;
+    struct ccan_list_head interrupt_exec_tasks;
 
     struct rb_waiting_list *join_list;
 

--- a/vm_sync.h
+++ b/vm_sync.h
@@ -21,9 +21,9 @@ void rb_vm_lock_body(LOCATION_ARGS);
 void rb_vm_unlock_body(LOCATION_ARGS);
 
 struct rb_ractor_struct;
-void rb_vm_lock_enter_body_cr(struct rb_ractor_struct *cr, unsigned int *lev APPEND_LOCATION_ARGS);
-void rb_vm_lock_enter_body_nb(unsigned int *lev APPEND_LOCATION_ARGS);
-void rb_vm_lock_enter_body(unsigned int *lev APPEND_LOCATION_ARGS);
+NOINLINE(void rb_vm_lock_enter_body_cr(struct rb_ractor_struct *cr, unsigned int *lev APPEND_LOCATION_ARGS));
+NOINLINE(void rb_vm_lock_enter_body_nb(unsigned int *lev APPEND_LOCATION_ARGS));
+NOINLINE(void rb_vm_lock_enter_body(unsigned int *lev APPEND_LOCATION_ARGS));
 void rb_vm_lock_leave_body(unsigned int *lev APPEND_LOCATION_ARGS);
 void rb_vm_barrier(void);
 


### PR DESCRIPTION
Some of required libraries need to run on main Ractor because of
setting constants with unshareable objects and so on.

So this patch allows `require` by running `require` on the main
ractor by `rb_ractor_interrupt_exec()` (which makes a thread in
the specified racotr and run passed C-func on the created thread).

If it failed, the exception object will be (copy) sent from the
main ractor to the caller ractor and raises on it. If the transfer
failed (maybe because the exception object is not copy-able), tell
the failure of transfering.

Same on `require_relative` and `autoload`.