### PR TITLE
Release GVL around system calls in dir.c

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -1264,7 +1264,7 @@ nogvl_fchdir(void *ptr)
 static void
 dir_fchdir(int fd)
 {
-    if (fchdir(fd) < 0)
+    if (IO_WITHOUT_GVL_INT(nogvl_fchdir, (void *)&fd) < 0)
         rb_sys_fail("fchdir");
 }
 

--- a/dir.c
+++ b/dir.c
@@ -1484,6 +1484,12 @@ check_dirname(VALUE dir)
 }
 
 #if defined(HAVE_CHROOT)
+static void *
+nogvl_chroot(void *dirname)
+{
+    return (void *)(VALUE)chroot((const char *)dirname);
+}
+
 /*
  * call-seq:
  *   Dir.chroot(dirpath) -> 0
@@ -1500,7 +1506,7 @@ static VALUE
 dir_s_chroot(VALUE dir, VALUE path)
 {
     path = check_dirname(path);
-    if (chroot(RSTRING_PTR(path)) == -1)
+    if (IO_WITHOUT_GVL_INT(nogvl_chroot, (void *)RSTRING_PTR(path)) == -1)
         rb_sys_fail_path(path);
 
     return INT2FIX(0);

--- a/dir.c
+++ b/dir.c
@@ -1062,7 +1062,7 @@ nogvl_chdir(void *ptr)
 static void
 dir_chdir0(VALUE path)
 {
-    if (chdir(RSTRING_PTR(path)) < 0)
+    if (IO_WITHOUT_GVL_INT(nogvl_chdir, (void*)RSTRING_PTR(path)) < 0)
         rb_sys_fail_path(path);
 }
 

--- a/dir.c
+++ b/dir.c
@@ -1673,8 +1673,8 @@ to_be_ignored(int e)
 }
 
 #ifdef _WIN32
-#define STAT(args)	nogvl_stat((void *)&(args))
-#define LSTAT(args)	nogvl_lstat((void *)&(args))
+#define STAT(args)	(int)(VALUE)nogvl_stat((void *)&(args))
+#define LSTAT(args)	(int)(VALUE)nogvl_lstat((void *)&(args))
 #else
 #define STAT(args)	IO_WITHOUT_GVL_INT(nogvl_stat, (void *)&(args))
 #define LSTAT(args)	IO_WITHOUT_GVL_INT(nogvl_lstat, (void *)&(args))

--- a/dir.c
+++ b/dir.c
@@ -509,7 +509,7 @@ nogvl_opendir(void *ptr)
 {
     const char *path = ptr;
 
-    return (void *)opendir(path);
+    return opendir(path);
 }
 
 static DIR *
@@ -591,7 +591,7 @@ dir_s_close(rb_execution_context_t *ec, VALUE klass, VALUE dir)
 static void *
 nogvl_fdopendir(void *fd)
 {
-    return (void *)fdopendir((int)(VALUE)fd);
+    return fdopendir((int)(VALUE)fd);
 }
 
 /*
@@ -620,7 +620,7 @@ dir_s_for_fd(VALUE klass, VALUE fd)
     struct dir_data *dp;
     VALUE dir = TypedData_Make_Struct(klass, struct dir_data, &dir_data_type, dp);
 
-    if (!(dp->dir = (DIR *)IO_WITHOUT_GVL(nogvl_fdopendir, (void *)(VALUE)NUM2INT(fd)))) {
+    if (!(dp->dir = IO_WITHOUT_GVL(nogvl_fdopendir, (void *)(VALUE)NUM2INT(fd)))) {
         rb_sys_fail("fdopendir");
         UNREACHABLE_RETURN(Qnil);
     }
@@ -767,11 +767,11 @@ fundamental_encoding_p(rb_encoding *enc)
 static void *
 nogvl_readdir(void *dir)
 {
-    return (void *)readdir((DIR *)dir);
+    return readdir(dir);
 }
 
-# define READDIR(dir, enc) (struct dirent *)IO_WITHOUT_GVL(nogvl_readdir, (void *)dir)
-# define READDIR_NOGVL(dir, enc) (struct dirent *)nogvl_readdir((void *)dir)
+# define READDIR(dir, enc) IO_WITHOUT_GVL(nogvl_readdir, (void *)(dir))
+# define READDIR_NOGVL(dir, enc) nogvl_readdir((dir))
 #endif
 
 /* safe to use without GVL */
@@ -1673,8 +1673,8 @@ to_be_ignored(int e)
 }
 
 #ifdef _WIN32
-#define STAT(args)	(int)(VALUE)nogvl_stat((void *)&(args))
-#define LSTAT(args)	(int)(VALUE)nogvl_lstat((void *)&(args))
+#define STAT(args)	(int)(VALUE)nogvl_stat(&(args))
+#define LSTAT(args)	(int)(VALUE)nogvl_lstat(&(args))
 #else
 #define STAT(args)	IO_WITHOUT_GVL_INT(nogvl_stat, (void *)&(args))
 #define LSTAT(args)	IO_WITHOUT_GVL_INT(nogvl_lstat, (void *)&(args))

--- a/file.c
+++ b/file.c
@@ -3690,6 +3690,14 @@ copy_home_path(VALUE result, const char *dir)
     return result;
 }
 
+#ifdef HAVE_PWD_H
+static void *
+nogvl_getpwnam(void *login)
+{
+    return (void *)getpwnam((const char *)login);
+}
+#endif
+
 VALUE
 rb_home_dir_of(VALUE user, VALUE result)
 {
@@ -3712,7 +3720,7 @@ rb_home_dir_of(VALUE user, VALUE result)
     }
 
 #ifdef HAVE_PWD_H
-    pwPtr = getpwnam(username);
+    pwPtr = (struct passwd *)IO_WITHOUT_GVL(nogvl_getpwnam, (void *)username);
 #else
     if (strcasecmp(username, getlogin()) == 0)
         dir = pwPtr = getenv("HOME");


### PR DESCRIPTION
This attempts to address the system calls mentioned in Bug #20587, with the exception of `getattrlist` and `fgetattrlist` (which seem to be Mac OS specific).

Releasing the GVL for readdir and stat caused problems on Windows, because these system calls are emulated on Windows, so this patch does not release the GVL on Windows.  I think any GVL releasing for Windows would need to happen in `win32/win32.c`.

While working on this, I noticed that `getpwnam` is called without releasing the GVL in `process.c` and `ext/etc/etc.c`.  If it makes sense to release the GVL for the `getpwnam` call in `Dir.home`, I think it makes sense to handle `getpwnam`, but that can be addressed later. Also, if `getpwnam` should release the GVL, `getpwuid`/`getgrgid`/`getgrnam` and similar methods should probably also release it.