### PR TITLE
[DOC] Fix and improve array slicing example in range.c

### DIFF
--- a/range.c
+++ b/range.c
@@ -2438,8 +2438,8 @@ range_overlap(VALUE range, VALUE other)
  * A beginless range may be used to slice an array:
  *
  *  a = [1, 2, 3, 4]
- *  r = (..2) # => nil...2
- *  a[r]      # => [1, 2]
+ *  r = (...2) # => nil...2
+ *  a[r]       # => [1, 2]
  *
  * \Method +each+ for a beginless range raises an exception.
  *

--- a/range.c
+++ b/range.c
@@ -2438,8 +2438,10 @@ range_overlap(VALUE range, VALUE other)
  * A beginless range may be used to slice an array:
  *
  *  a = [1, 2, 3, 4]
+ *  # Include the third array element in the slice
  *  r = (..2)  # => nil..2
  *  a[r]       # => [1, 2, 3]
+ *  # Exclude the third array element from the slice
  *  r = (...2) # => nil...2
  *  a[r]       # => [1, 2]
  *

--- a/range.c
+++ b/range.c
@@ -2438,6 +2438,8 @@ range_overlap(VALUE range, VALUE other)
  * A beginless range may be used to slice an array:
  *
  *  a = [1, 2, 3, 4]
+ *  r = (..2)  # => nil..2
+ *  a[r]       # => [1, 2, 3]
  *  r = (...2) # => nil...2
  *  a[r]       # => [1, 2]
  *


### PR DESCRIPTION
Hi!

I found one small typo in the [Range docs](https://docs.ruby-lang.org/en/3.3/Range.html#class-Range-label-Beginless+Ranges): in the example of the beginless range used for array slicing, `..` range literal was used (`r = (..2)`) while the `...` literal was expected (`# => nil...2`).

Dear people from _The Ruby Language Discord Server_ helped me to orientate, and @zenspider suggested to include as well an example for the array slice with the beginless range using the `..` range literal. I took the liberty and added two comments as well, to make crystal clear what the `..` and `...` range literals do when used for array slicing as beginless range.

I progressively committed all the above-mentioned changes, so please do tell me if some of them should go, and I will squash approved ones into one commit ready for merge.

Oh, and this is my first serious PR ever, so bear with me. :blush: 