### PR TITLE
YJIT: Local variable register allocation

### DIFF
--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -381,7 +381,7 @@ impl Assembler
         }
 
         let live_ranges: Vec<usize> = take(&mut self.live_ranges);
-        let mut asm_local = Assembler::new_with_label_names(take(&mut self.label_names), take(&mut self.side_exits));
+        let mut asm_local = Assembler::new_with_label_names(take(&mut self.label_names), take(&mut self.side_exits), self.local_size);
         let asm = &mut asm_local;
         let mut iterator = self.into_draining_iter();
 

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -381,7 +381,7 @@ impl Assembler
         }
 
         let live_ranges: Vec<usize> = take(&mut self.live_ranges);
-        let mut asm_local = Assembler::new_with_label_names(take(&mut self.label_names), take(&mut self.side_exits), self.local_size);
+        let mut asm_local = Assembler::new_with_label_names(take(&mut self.label_names), take(&mut self.side_exits), self.num_locals);
         let asm = &mut asm_local;
         let mut iterator = self.into_draining_iter();
 

--- a/yjit/src/backend/arm64/mod.rs
+++ b/yjit/src/backend/arm64/mod.rs
@@ -1383,7 +1383,7 @@ mod tests {
     use crate::disasm::*;
 
     fn setup_asm() -> (Assembler, CodeBlock) {
-        (Assembler::new(), CodeBlock::new_dummy(1024))
+        (Assembler::new(0), CodeBlock::new_dummy(1024))
     }
 
     #[test]
@@ -1682,7 +1682,7 @@ mod tests {
     #[test]
     fn test_bcond_straddling_code_pages() {
         const LANDING_PAGE: usize = 65;
-        let mut asm = Assembler::new();
+        let mut asm = Assembler::new(0);
         let mut cb = CodeBlock::new_dummy_with_freed_pages(vec![0, LANDING_PAGE]);
 
         // Skip to near the end of the page. Room for two instructions.

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -6,7 +6,7 @@ use crate::codegen::{gen_counted_exit, gen_outlined_exit};
 use crate::cruby::{vm_stack_canary, SIZEOF_VALUE_I32, VALUE, VM_ENV_DATA_SIZE};
 use crate::virtualmem::CodePtr;
 use crate::asm::{CodeBlock, OutlinedCb};
-use crate::core::{Context, RegMapping, RegMappings, MAX_REG_MAPPINGS};
+use crate::core::{Context, RegOpnd, RegMapping, MAX_REG_OPNDS};
 use crate::options::*;
 use crate::stats::*;
 
@@ -81,8 +81,8 @@ pub enum Opnd
         local_size: Option<u32>,
         /// ctx.sp_offset when this operand is made. Used with idx for Opnd::Mem.
         sp_offset: i8,
-        /// ctx.reg_mappings when this operand is read. Used for register allocation.
-        reg_mappings: Option<RegMappings>
+        /// ctx.reg_mapping when this operand is read. Used for register allocation.
+        reg_mapping: Option<RegMapping>
     },
 
     // Low-level operands, for lowering
@@ -174,7 +174,7 @@ impl Opnd
             Opnd::Reg(reg) => Some(Opnd::Reg(reg.with_num_bits(num_bits))),
             Opnd::Mem(Mem { base, disp, .. }) => Some(Opnd::Mem(Mem { base, disp, num_bits })),
             Opnd::InsnOut { idx, .. } => Some(Opnd::InsnOut { idx, num_bits }),
-            Opnd::Stack { idx, stack_size, local_size, sp_offset, reg_mappings, .. } => Some(Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, reg_mappings }),
+            Opnd::Stack { idx, stack_size, local_size, sp_offset, reg_mapping, .. } => Some(Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, reg_mapping }),
             _ => None,
         }
     }
@@ -230,22 +230,22 @@ impl Opnd
     }
 
     /// Convert Opnd::Stack into RegMapping
-    pub fn reg_mapping(&self) -> RegMapping {
+    pub fn reg_mapping(&self) -> RegOpnd {
         self.get_reg_mapping().unwrap()
     }
 
     /// Convert an operand into RegMapping if it's Opnd::Stack
-    pub fn get_reg_mapping(&self) -> Option<RegMapping> {
+    pub fn get_reg_mapping(&self) -> Option<RegOpnd> {
         match *self {
             Opnd::Stack { idx, stack_size, local_size, .. } => Some(
                 if let Some(local_size) = local_size {
                     let last_idx = stack_size as i32 + VM_ENV_DATA_SIZE as i32 - 1;
                     assert!(last_idx <= idx, "Local index {} must be >= last local index {}", idx, last_idx);
                     assert!(idx <= last_idx + local_size as i32, "Local index {} must be < last local index {} + local size {}", idx, last_idx, local_size);
-                    RegMapping::Local((last_idx + local_size as i32 - idx) as u8)
+                    RegOpnd::Local((last_idx + local_size as i32 - idx) as u8)
                 } else {
                     assert!(idx < stack_size as i32);
-                    RegMapping::Stack((stack_size as i32 - idx - 1) as u8)
+                    RegOpnd::Stack((stack_size as i32 - idx - 1) as u8)
                 }
             ),
             _ => None,
@@ -974,7 +974,7 @@ pub struct SideExitContext {
     /// Context fields used by get_generic_ctx()
     pub stack_size: u8,
     pub sp_offset: i8,
-    pub reg_mappings: RegMappings,
+    pub reg_mapping: RegMapping,
     pub is_return_landing: bool,
     pub is_deferred: bool,
 }
@@ -986,7 +986,7 @@ impl SideExitContext {
             pc,
             stack_size: ctx.get_stack_size(),
             sp_offset: ctx.get_sp_offset(),
-            reg_mappings: ctx.get_reg_mappings(),
+            reg_mapping: ctx.get_reg_mapping(),
             is_return_landing: ctx.is_return_landing(),
             is_deferred: ctx.is_deferred(),
         };
@@ -1002,7 +1002,7 @@ impl SideExitContext {
         let mut ctx = Context::default();
         ctx.set_stack_size(self.stack_size);
         ctx.set_sp_offset(self.sp_offset);
-        ctx.set_reg_mappings(self.reg_mappings);
+        ctx.set_reg_mapping(self.reg_mapping);
         if self.is_return_landing {
             ctx.set_as_return_landing();
         }
@@ -1110,8 +1110,8 @@ impl Assembler
                     assert!(idx < self.insns.len());
                     self.live_ranges[idx] = insn_idx;
                 }
-                // Set current ctx.reg_mappings to Opnd::Stack.
-                Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, reg_mappings: None } => {
+                // Set current ctx.reg_mapping to Opnd::Stack.
+                Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, reg_mapping: None } => {
                     assert_eq!(
                         self.ctx.get_stack_size() as i16 - self.ctx.get_sp_offset() as i16,
                         stack_size as i16 - sp_offset as i16,
@@ -1124,7 +1124,7 @@ impl Assembler
                         stack_size,
                         local_size,
                         sp_offset,
-                        reg_mappings: Some(self.ctx.get_reg_mappings()),
+                        reg_mapping: Some(self.ctx.get_reg_mapping()),
                     };
                 }
                 _ => {}
@@ -1196,8 +1196,8 @@ impl Assembler
         }
 
         match opnd {
-            Opnd::Stack { reg_mappings, .. } => {
-                if let Some(reg_idx) = reg_mappings.unwrap().get_reg(opnd.reg_mapping()) {
+            Opnd::Stack { reg_mapping, .. } => {
+                if let Some(reg_idx) = reg_mapping.unwrap().get_reg(opnd.reg_mapping()) {
                     reg_opnd(opnd, reg_idx)
                 } else {
                     mem_opnd(opnd)
@@ -1208,11 +1208,11 @@ impl Assembler
     }
 
     /// Allocate a register to a stack temp if available.
-    pub fn alloc_reg(&mut self, mapping: RegMapping) {
+    pub fn alloc_reg(&mut self, mapping: RegOpnd) {
         // Allocate a register if there's no conflict.
-        let mut reg_mappings = self.ctx.get_reg_mappings();
-        if reg_mappings.alloc_reg(mapping) {
-            self.set_reg_mappings(reg_mappings);
+        let mut reg_mapping = self.ctx.get_reg_mapping();
+        if reg_mapping.alloc_reg(mapping) {
+            self.set_reg_mapping(reg_mapping);
         }
     }
 
@@ -1226,55 +1226,55 @@ impl Assembler
     /// Spill all live stack temps from registers to the stack
     pub fn spill_temps(&mut self) {
         // Forget registers above the stack top
-        let mut reg_mappings = self.ctx.get_reg_mappings();
-        for stack_idx in self.ctx.get_stack_size()..MAX_REG_MAPPINGS {
-            reg_mappings.dealloc_reg(RegMapping::Stack(stack_idx));
+        let mut reg_mapping = self.ctx.get_reg_mapping();
+        for stack_idx in self.ctx.get_stack_size()..MAX_REG_OPNDS {
+            reg_mapping.dealloc_reg(RegOpnd::Stack(stack_idx));
         }
-        self.set_reg_mappings(reg_mappings);
+        self.set_reg_mapping(reg_mapping);
 
         // Spill live stack temps
-        if self.ctx.get_reg_mappings() != RegMappings::default() {
-            asm_comment!(self, "spill_temps: {:?} -> {:?}", self.ctx.get_reg_mappings(), RegMappings::default());
+        if self.ctx.get_reg_mapping() != RegMapping::default() {
+            asm_comment!(self, "spill_temps: {:?} -> {:?}", self.ctx.get_reg_mapping(), RegMapping::default());
 
             // Spill stack temps
-            for stack_idx in 0..u8::min(MAX_REG_MAPPINGS, self.ctx.get_stack_size()) {
-                if reg_mappings.dealloc_reg(RegMapping::Stack(stack_idx)) {
+            for stack_idx in 0..u8::min(MAX_REG_OPNDS, self.ctx.get_stack_size()) {
+                if reg_mapping.dealloc_reg(RegOpnd::Stack(stack_idx)) {
                     let idx = self.ctx.get_stack_size() - 1 - stack_idx;
                     self.spill_temp(self.stack_opnd(idx.into()));
                 }
             }
 
             // Spill locals
-            for local_idx in 0..MAX_REG_MAPPINGS {
-                if reg_mappings.dealloc_reg(RegMapping::Local(local_idx)) {
+            for local_idx in 0..MAX_REG_OPNDS {
+                if reg_mapping.dealloc_reg(RegOpnd::Local(local_idx)) {
                     let first_local_ep_offset = self.local_size.unwrap() + VM_ENV_DATA_SIZE - 1;
                     let ep_offset = first_local_ep_offset - local_idx as u32;
                     self.spill_temp(self.local_opnd(ep_offset));
                 }
             }
 
-            self.ctx.set_reg_mappings(reg_mappings);
+            self.ctx.set_reg_mapping(reg_mapping);
         }
 
         // Every stack temp should have been spilled
-        assert_eq!(self.ctx.get_reg_mappings(), RegMappings::default());
+        assert_eq!(self.ctx.get_reg_mapping(), RegMapping::default());
     }
 
     /// Spill a stack temp from a register to the stack
     fn spill_temp(&mut self, opnd: Opnd) {
-        assert_ne!(self.ctx.get_reg_mappings().get_reg(opnd.reg_mapping()), None);
+        assert_ne!(self.ctx.get_reg_mapping().get_reg(opnd.reg_mapping()), None);
 
         // Use different RegMappings for dest and src operands
-        let reg_mappings = self.ctx.get_reg_mappings();
-        let mut mem_mappings = reg_mappings;
+        let reg_mapping = self.ctx.get_reg_mapping();
+        let mut mem_mappings = reg_mapping;
         mem_mappings.dealloc_reg(opnd.reg_mapping());
 
         // Move the stack operand from a register to memory
         match opnd {
             Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, .. } => {
                 self.mov(
-                    Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, reg_mappings: Some(mem_mappings) },
-                    Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, reg_mappings: Some(reg_mappings) },
+                    Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, reg_mapping: Some(mem_mappings) },
+                    Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, reg_mapping: Some(reg_mapping) },
                 );
             }
             _ => unreachable!(),
@@ -1283,10 +1283,10 @@ impl Assembler
     }
 
     /// Update which stack temps are in a register
-    pub fn set_reg_mappings(&mut self, reg_mappings: RegMappings) {
-        if self.ctx.get_reg_mappings() != reg_mappings {
-            asm_comment!(self, "reg_mappings: {:?} -> {:?}", self.ctx.get_reg_mappings(), reg_mappings);
-            self.ctx.set_reg_mappings(reg_mappings);
+    pub fn set_reg_mapping(&mut self, reg_mapping: RegMapping) {
+        if self.ctx.get_reg_mapping() != reg_mapping {
+            asm_comment!(self, "reg_mapping: {:?} -> {:?}", self.ctx.get_reg_mapping(), reg_mapping);
+            self.ctx.set_reg_mapping(reg_mapping);
         }
     }
 
@@ -1707,16 +1707,16 @@ impl Assembler {
         // Let vm_check_canary() assert this ccall's leafness if leaf_ccall is set
         let canary_opnd = self.set_stack_canary(&opnds);
 
-        let old_temps = self.ctx.get_reg_mappings(); // with registers
+        let old_temps = self.ctx.get_reg_mapping(); // with registers
         // Spill stack temp registers since they are caller-saved registers.
         // Note that this doesn't spill stack temps that are already popped
         // but may still be used in the C arguments.
         self.spill_temps();
-        let new_temps = self.ctx.get_reg_mappings(); // all spilled
+        let new_temps = self.ctx.get_reg_mapping(); // all spilled
 
         // Temporarily manipulate RegMappings so that we can use registers
         // to pass stack operands that are already spilled above.
-        self.ctx.set_reg_mappings(old_temps);
+        self.ctx.set_reg_mapping(old_temps);
 
         // Call a C function
         let out = self.next_opnd_out(Opnd::match_num_bits(&opnds));
@@ -1724,7 +1724,7 @@ impl Assembler {
 
         // Registers in old_temps may be clobbered by the above C call,
         // so rollback the manipulated RegMappings to a spilled version.
-        self.ctx.set_reg_mappings(new_temps);
+        self.ctx.set_reg_mapping(new_temps);
 
         // Clear the canary after use
         if let Some(canary_opnd) = canary_opnd {
@@ -1773,7 +1773,7 @@ impl Assembler {
 
         // Re-enable ccall's RegMappings assertion disabled by cpush_all.
         // cpush_all + cpop_all preserve all stack temp registers, so it's safe.
-        self.set_reg_mappings(self.ctx.get_reg_mappings());
+        self.set_reg_mapping(self.ctx.get_reg_mapping());
     }
 
     pub fn cpop_into(&mut self, opnd: Opnd) {
@@ -1791,7 +1791,7 @@ impl Assembler {
         // Temps will be marked back as being in registers by cpop_all.
         // We assume that cpush_all + cpop_all are used for C functions in utils.rs
         // that don't require spill_temps for GC.
-        self.set_reg_mappings(RegMappings::default());
+        self.set_reg_mapping(RegMapping::default());
     }
 
     pub fn cret(&mut self, opnd: Opnd) {

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1223,8 +1223,8 @@ impl Assembler
         self.ctx.clear_local_types();
     }
 
-    /// Spill all live stack temps from registers to the stack
-    pub fn spill_temps(&mut self) {
+    /// Spill all live registers to the stack
+    pub fn spill_regs(&mut self) {
         // Forget registers above the stack top
         let mut reg_mapping = self.ctx.get_reg_mapping();
         for stack_idx in self.ctx.get_stack_size()..MAX_REG_OPNDS {
@@ -1711,7 +1711,7 @@ impl Assembler {
         // Spill stack temp registers since they are caller-saved registers.
         // Note that this doesn't spill stack temps that are already popped
         // but may still be used in the C arguments.
-        self.spill_temps();
+        self.spill_regs();
         let new_temps = self.ctx.get_reg_mapping(); // all spilled
 
         // Temporarily manipulate RegMappings so that we can use registers

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -230,12 +230,12 @@ impl Opnd
     }
 
     /// Convert Opnd::Stack into RegMapping
-    pub fn reg_mapping(&self) -> RegOpnd {
-        self.get_reg_mapping().unwrap()
+    pub fn reg_opnd(&self) -> RegOpnd {
+        self.get_reg_opnd().unwrap()
     }
 
     /// Convert an operand into RegMapping if it's Opnd::Stack
-    pub fn get_reg_mapping(&self) -> Option<RegOpnd> {
+    pub fn get_reg_opnd(&self) -> Option<RegOpnd> {
         match *self {
             Opnd::Stack { idx, stack_size, num_locals, .. } => Some(
                 if let Some(num_locals) = num_locals {
@@ -1215,7 +1215,7 @@ impl Assembler
 
         match opnd {
             Opnd::Stack { reg_mapping, .. } => {
-                if let Some(reg_idx) = reg_mapping.unwrap().get_reg(opnd.reg_mapping()) {
+                if let Some(reg_idx) = reg_mapping.unwrap().get_reg(opnd.reg_opnd()) {
                     reg_opnd(opnd, reg_idx)
                 } else {
                     mem_opnd(opnd)
@@ -1280,12 +1280,12 @@ impl Assembler
 
     /// Spill a stack temp from a register to the stack
     fn spill_temp(&mut self, opnd: Opnd) {
-        assert_ne!(self.ctx.get_reg_mapping().get_reg(opnd.reg_mapping()), None);
+        assert_ne!(self.ctx.get_reg_mapping().get_reg(opnd.reg_opnd()), None);
 
         // Use different RegMappings for dest and src operands
         let reg_mapping = self.ctx.get_reg_mapping();
         let mut mem_mappings = reg_mapping;
-        mem_mappings.dealloc_reg(opnd.reg_mapping());
+        mem_mappings.dealloc_reg(opnd.reg_opnd());
 
         // Move the stack operand from a register to memory
         match opnd {
@@ -1760,7 +1760,7 @@ impl Assembler {
         // If the slot is already used, which is a valid optimization to avoid spills,
         // give up the verification.
         let canary_opnd = if cfg!(debug_assertions) && self.leaf_ccall && opnds.iter().all(|opnd|
-            opnd.get_reg_mapping() != canary_opnd.get_reg_mapping()
+            opnd.get_reg_opnd() != canary_opnd.get_reg_opnd()
         ) {
             asm_comment!(self, "set stack canary");
             self.mov(canary_opnd, vm_stack_canary().into());

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1086,7 +1086,7 @@ impl Assembler
     }
 
     /// Get the list of registers that can be used for stack temps.
-    pub fn get_temp_regs() -> &'static [Reg] {
+    pub fn get_temp_regs2() -> &'static [Reg] {
         let num_regs = get_option!(num_temp_regs);
         &TEMP_REGS[0..num_regs]
     }
@@ -1204,7 +1204,7 @@ impl Assembler
 
         // Convert Opnd::Stack to Opnd::Reg
         fn reg_opnd(opnd: &Opnd, reg_idx: usize) -> Opnd {
-            let regs = Assembler::get_temp_regs();
+            let regs = Assembler::get_temp_regs2();
             if let Opnd::Stack { num_bits, .. } = *opnd {
                 incr_counter!(temp_reg_opnd);
                 Opnd::Reg(regs[reg_idx]).with_num_bits(num_bits).unwrap()

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 use std::fmt;
 use std::convert::From;
 use std::mem::take;
-use crate::codegen::{gen_outlined_exit, gen_counted_exit};
-use crate::cruby::{vm_stack_canary, SIZEOF_VALUE_I32, VALUE};
+use crate::codegen::{gen_counted_exit, gen_outlined_exit};
+use crate::cruby::{vm_stack_canary, SIZEOF_VALUE_I32, VALUE, VM_ENV_DATA_SIZE};
 use crate::virtualmem::CodePtr;
 use crate::asm::{CodeBlock, OutlinedCb};
-use crate::core::{Context, RegTemps, MAX_REG_TEMPS};
+use crate::core::{Context, RegTemp, RegTemps, MAX_REG_TEMPS};
 use crate::options::*;
 use crate::stats::*;
 
@@ -77,6 +77,8 @@ pub enum Opnd
         num_bits: u8,
         /// ctx.stack_size when this operand is made. Used with idx for Opnd::Reg.
         stack_size: u8,
+        /// The number of local variables in the current ISEQ. Used only for locals.
+        local_size: Option<u32>,
         /// ctx.sp_offset when this operand is made. Used with idx for Opnd::Mem.
         sp_offset: i8,
         /// ctx.reg_temps when this operand is read. Used for register allocation.
@@ -172,7 +174,7 @@ impl Opnd
             Opnd::Reg(reg) => Some(Opnd::Reg(reg.with_num_bits(num_bits))),
             Opnd::Mem(Mem { base, disp, .. }) => Some(Opnd::Mem(Mem { base, disp, num_bits })),
             Opnd::InsnOut { idx, .. } => Some(Opnd::InsnOut { idx, num_bits }),
-            Opnd::Stack { idx, stack_size, sp_offset, reg_temps, .. } => Some(Opnd::Stack { idx, num_bits, stack_size, sp_offset, reg_temps }),
+            Opnd::Stack { idx, stack_size, local_size, sp_offset, reg_temps, .. } => Some(Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, reg_temps }),
             _ => None,
         }
     }
@@ -227,28 +229,26 @@ impl Opnd
         Self::match_num_bits_iter(opnds.iter())
     }
 
-    /// Calculate Opnd::Stack's index from the stack bottom.
-    pub fn stack_idx(&self) -> u8 {
-        self.get_stack_idx().unwrap()
+    /// Convert Opnd::Stack into RegTemp
+    pub fn reg_temp(&self) -> RegTemp {
+        self.get_reg_temp().unwrap()
     }
 
-    /// Calculate Opnd::Stack's index from the stack bottom if it's Opnd::Stack.
-    pub fn get_stack_idx(&self) -> Option<u8> {
-        match self {
-            Opnd::Stack { idx, stack_size, .. } => {
-                Some((*stack_size as isize - *idx as isize - 1) as u8)
-            },
-            _ => None
-        }
-    }
-
-    /// Get the index for stack temp registers.
-    pub fn reg_idx(&self) -> usize {
-        match self {
-            Opnd::Stack { .. } => {
-                self.stack_idx() as usize % get_option!(num_temp_regs)
-            },
-            _ => unreachable!(),
+    /// Convert an operand into RegTemp if it's Opnd::Stack
+    pub fn get_reg_temp(&self) -> Option<RegTemp> {
+        match *self {
+            Opnd::Stack { idx, stack_size, local_size, .. } => Some(
+                if let Some(local_size) = local_size {
+                    let last_idx = stack_size as i32 + VM_ENV_DATA_SIZE as i32 - 1;
+                    assert!(last_idx <= idx, "Local index {} must be >= last local index {}", idx, last_idx);
+                    assert!(idx <= last_idx + local_size as i32, "Local index {} must be < last local index {} + local size {}", idx, last_idx, local_size);
+                    RegTemp::Local((last_idx + local_size as i32 - idx) as u8)
+                } else {
+                    assert!(idx < stack_size as i32);
+                    RegTemp::Stack((stack_size as i32 - idx - 1) as u8)
+                }
+            ),
+            _ => None,
         }
     }
 }
@@ -1031,6 +1031,10 @@ pub struct Assembler {
     /// Context for generating the current insn
     pub ctx: Context,
 
+    /// The current ISEQ's local table size. asm.local_opnd() uses this, and it's
+    /// sometimes hard to pass this value, e.g. asm.spill_temps() in asm.ccall().
+    pub local_size: Option<u32>,
+
     /// Side exit caches for each SideExitContext
     pub(super) side_exits: HashMap<SideExitContext, CodePtr>,
 
@@ -1047,15 +1051,20 @@ pub struct Assembler {
 impl Assembler
 {
     pub fn new() -> Self {
-        Self::new_with_label_names(Vec::default(), HashMap::default())
+        Self::new_with_label_names(Vec::default(), HashMap::default(), None)
     }
 
-    pub fn new_with_label_names(label_names: Vec<String>, side_exits: HashMap<SideExitContext, CodePtr>) -> Self {
+    pub fn new_with_label_names(
+        label_names: Vec<String>,
+        side_exits: HashMap<SideExitContext, CodePtr>,
+        local_size: Option<u32>
+    ) -> Self {
         Self {
             insns: Vec::with_capacity(ASSEMBLER_INSNS_CAPACITY),
             live_ranges: Vec::with_capacity(ASSEMBLER_INSNS_CAPACITY),
             label_names,
             ctx: Context::default(),
+            local_size,
             side_exits,
             side_exit_pc: None,
             side_exit_stack_size: None,
@@ -1090,30 +1099,31 @@ impl Assembler
 
         let mut opnd_iter = insn.opnd_iter_mut();
         while let Some(opnd) = opnd_iter.next() {
-            match opnd {
+            match *opnd {
                 // If we find any InsnOut from previous instructions, we're going to update
                 // the live range of the previous instruction to point to this one.
                 Opnd::InsnOut { idx, .. } => {
-                    assert!(*idx < self.insns.len());
-                    self.live_ranges[*idx] = insn_idx;
+                    assert!(idx < self.insns.len());
+                    self.live_ranges[idx] = insn_idx;
                 }
                 Opnd::Mem(Mem { base: MemBase::InsnOut(idx), .. }) => {
-                    assert!(*idx < self.insns.len());
-                    self.live_ranges[*idx] = insn_idx;
+                    assert!(idx < self.insns.len());
+                    self.live_ranges[idx] = insn_idx;
                 }
                 // Set current ctx.reg_temps to Opnd::Stack.
-                Opnd::Stack { idx, num_bits, stack_size, sp_offset, reg_temps: None } => {
+                Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, reg_temps: None } => {
                     assert_eq!(
                         self.ctx.get_stack_size() as i16 - self.ctx.get_sp_offset() as i16,
-                        *stack_size as i16 - *sp_offset as i16,
+                        stack_size as i16 - sp_offset as i16,
                         "Opnd::Stack (stack_size: {}, sp_offset: {}) expects a different SP position from asm.ctx (stack_size: {}, sp_offset: {})",
-                        *stack_size, *sp_offset, self.ctx.get_stack_size(), self.ctx.get_sp_offset(),
+                        stack_size, sp_offset, self.ctx.get_stack_size(), self.ctx.get_sp_offset(),
                     );
                     *opnd = Opnd::Stack {
-                        idx: *idx,
-                        num_bits: *num_bits,
-                        stack_size: *stack_size,
-                        sp_offset: *sp_offset,
+                        idx,
+                        num_bits,
+                        stack_size,
+                        local_size,
+                        sp_offset,
                         reg_temps: Some(self.ctx.get_reg_temps()),
                     };
                 }
@@ -1141,7 +1151,7 @@ impl Assembler
         // Get a cached side exit
         let side_exit = match self.side_exits.get(&side_exit_context) {
             None => {
-                let exit_code = gen_outlined_exit(side_exit_context.pc, &side_exit_context.get_ctx(), ocb)?;
+                let exit_code = gen_outlined_exit(side_exit_context.pc, self.local_size.unwrap(), &side_exit_context.get_ctx(), ocb)?;
                 self.side_exits.insert(*side_exit_context, exit_code);
                 exit_code
             }
@@ -1175,11 +1185,11 @@ impl Assembler
         }
 
         // Convert Opnd::Stack to Opnd::Reg
-        fn reg_opnd(opnd: &Opnd) -> Opnd {
+        fn reg_opnd(opnd: &Opnd, reg_idx: usize) -> Opnd {
             let regs = Assembler::get_temp_regs();
             if let Opnd::Stack { num_bits, .. } = *opnd {
                 incr_counter!(temp_reg_opnd);
-                Opnd::Reg(regs[opnd.reg_idx()]).with_num_bits(num_bits).unwrap()
+                Opnd::Reg(regs[reg_idx]).with_num_bits(num_bits).unwrap()
             } else {
                 unreachable!()
             }
@@ -1187,8 +1197,8 @@ impl Assembler
 
         match opnd {
             Opnd::Stack { reg_temps, .. } => {
-                if opnd.stack_idx() < MAX_REG_TEMPS && reg_temps.unwrap().get(opnd.stack_idx()) {
-                    reg_opnd(opnd)
+                if let Some(reg_idx) = reg_temps.unwrap().get_reg(opnd.reg_temp()) {
+                    reg_opnd(opnd, reg_idx)
                 } else {
                     mem_opnd(opnd)
                 }
@@ -1198,17 +1208,10 @@ impl Assembler
     }
 
     /// Allocate a register to a stack temp if available.
-    pub fn alloc_temp_reg(&mut self, stack_idx: u8) {
-        if get_option!(num_temp_regs) == 0 {
-            return;
-        }
-
+    pub fn alloc_temp_reg(&mut self, reg_temp: RegTemp) {
         // Allocate a register if there's no conflict.
         let mut reg_temps = self.ctx.get_reg_temps();
-        if reg_temps.conflicts_with(stack_idx) {
-            assert!(!reg_temps.get(stack_idx));
-        } else {
-            reg_temps.set(stack_idx, true);
+        if reg_temps.alloc_reg(reg_temp) {
             self.set_reg_temps(reg_temps);
         }
     }
@@ -1225,20 +1228,31 @@ impl Assembler
         // Forget registers above the stack top
         let mut reg_temps = self.ctx.get_reg_temps();
         for stack_idx in self.ctx.get_stack_size()..MAX_REG_TEMPS {
-            reg_temps.set(stack_idx, false);
+            reg_temps.dealloc_reg(RegTemp::Stack(stack_idx));
         }
         self.set_reg_temps(reg_temps);
 
         // Spill live stack temps
         if self.ctx.get_reg_temps() != RegTemps::default() {
-            asm_comment!(self, "spill_temps: {:08b} -> {:08b}", self.ctx.get_reg_temps().as_u8(), RegTemps::default().as_u8());
+            asm_comment!(self, "spill_temps: {:?} -> {:?}", self.ctx.get_reg_temps(), RegTemps::default());
+
+            // Spill stack temps
             for stack_idx in 0..u8::min(MAX_REG_TEMPS, self.ctx.get_stack_size()) {
-                if self.ctx.get_reg_temps().get(stack_idx) {
+                if reg_temps.dealloc_reg(RegTemp::Stack(stack_idx)) {
                     let idx = self.ctx.get_stack_size() - 1 - stack_idx;
                     self.spill_temp(self.stack_opnd(idx.into()));
-                    reg_temps.set(stack_idx, false);
                 }
             }
+
+            // Spill locals
+            for local_idx in 0..MAX_REG_TEMPS {
+                if reg_temps.dealloc_reg(RegTemp::Local(local_idx)) {
+                    let first_local_ep_offset = self.local_size.unwrap() + VM_ENV_DATA_SIZE - 1;
+                    let ep_offset = first_local_ep_offset - local_idx as u32;
+                    self.spill_temp(self.local_opnd(ep_offset));
+                }
+            }
+
             self.ctx.set_reg_temps(reg_temps);
         }
 
@@ -1248,19 +1262,19 @@ impl Assembler
 
     /// Spill a stack temp from a register to the stack
     fn spill_temp(&mut self, opnd: Opnd) {
-        assert!(self.ctx.get_reg_temps().get(opnd.stack_idx()));
+        assert_ne!(self.ctx.get_reg_temps().get_reg(opnd.reg_temp()), None);
 
         // Use different RegTemps for dest and src operands
         let reg_temps = self.ctx.get_reg_temps();
         let mut mem_temps = reg_temps;
-        mem_temps.set(opnd.stack_idx(), false);
+        mem_temps.dealloc_reg(opnd.reg_temp());
 
         // Move the stack operand from a register to memory
         match opnd {
-            Opnd::Stack { idx, num_bits, stack_size, sp_offset, .. } => {
+            Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, .. } => {
                 self.mov(
-                    Opnd::Stack { idx, num_bits, stack_size, sp_offset, reg_temps: Some(mem_temps) },
-                    Opnd::Stack { idx, num_bits, stack_size, sp_offset, reg_temps: Some(reg_temps) },
+                    Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, reg_temps: Some(mem_temps) },
+                    Opnd::Stack { idx, num_bits, stack_size, local_size, sp_offset, reg_temps: Some(reg_temps) },
                 );
             }
             _ => unreachable!(),
@@ -1271,18 +1285,8 @@ impl Assembler
     /// Update which stack temps are in a register
     pub fn set_reg_temps(&mut self, reg_temps: RegTemps) {
         if self.ctx.get_reg_temps() != reg_temps {
-            asm_comment!(self, "reg_temps: {:08b} -> {:08b}", self.ctx.get_reg_temps().as_u8(), reg_temps.as_u8());
+            asm_comment!(self, "reg_temps: {:?} -> {:?}", self.ctx.get_reg_temps(), reg_temps);
             self.ctx.set_reg_temps(reg_temps);
-            self.verify_reg_temps();
-        }
-    }
-
-    /// Assert there's no conflict in stack temp register allocation
-    fn verify_reg_temps(&self) {
-        for stack_idx in 0..MAX_REG_TEMPS {
-            if self.ctx.get_reg_temps().get(stack_idx) {
-                assert!(!self.ctx.get_reg_temps().conflicts_with(stack_idx));
-            }
         }
     }
 
@@ -1411,7 +1415,7 @@ impl Assembler
         let live_ranges: Vec<usize> = take(&mut self.live_ranges);
         // shifted_live_ranges is indexed by mapped indexes in insn operands.
         let mut shifted_live_ranges: Vec<usize> = live_ranges.clone();
-        let mut asm = Assembler::new_with_label_names(take(&mut self.label_names), take(&mut self.side_exits));
+        let mut asm = Assembler::new_with_label_names(take(&mut self.label_names), take(&mut self.side_exits), self.local_size);
         let mut iterator = self.into_draining_iter();
 
         while let Some((index, mut insn)) = iterator.next_mapped() {
@@ -1738,7 +1742,7 @@ impl Assembler {
         // If the slot is already used, which is a valid optimization to avoid spills,
         // give up the verification.
         let canary_opnd = if cfg!(debug_assertions) && self.leaf_ccall && opnds.iter().all(|opnd|
-            opnd.get_stack_idx() != canary_opnd.get_stack_idx()
+            opnd.get_reg_temp() != canary_opnd.get_reg_temp()
         ) {
             asm_comment!(self, "set stack canary");
             self.mov(canary_opnd, vm_stack_canary().into());

--- a/yjit/src/backend/tests.rs
+++ b/yjit/src/backend/tests.rs
@@ -1,19 +1,19 @@
 #![cfg(test)]
-use crate::asm::{CodeBlock};
+use crate::asm::CodeBlock;
 use crate::backend::ir::*;
 use crate::cruby::*;
 use crate::utils::c_callable;
 
 #[test]
 fn test_add() {
-    let mut asm = Assembler::new();
+    let mut asm = Assembler::new(0);
     let out = asm.add(SP, Opnd::UImm(1));
     let _ = asm.add(out, Opnd::UImm(2));
 }
 
 #[test]
 fn test_alloc_regs() {
-    let mut asm = Assembler::new();
+    let mut asm = Assembler::new(0);
 
     // Get the first output that we're going to reuse later.
     let out1 = asm.add(EC, Opnd::UImm(1));
@@ -62,7 +62,7 @@ fn test_alloc_regs() {
 
 fn setup_asm() -> (Assembler, CodeBlock) {
     return (
-        Assembler::new(),
+        Assembler::new(0),
         CodeBlock::new_dummy(1024)
     );
 }
@@ -194,7 +194,7 @@ fn test_c_call()
 
 #[test]
 fn test_alloc_ccall_regs() {
-    let mut asm = Assembler::new();
+    let mut asm = Assembler::new(0);
     let out1 = asm.ccall(0 as *const u8, vec![]);
     let out2 = asm.ccall(0 as *const u8, vec![out1]);
     asm.mov(EC, out2);
@@ -283,8 +283,7 @@ fn test_bake_string() {
 
 #[test]
 fn test_draining_iterator() {
-
-    let mut asm = Assembler::new();
+    let mut asm = Assembler::new(0);
 
     let _ = asm.load(Opnd::None);
     asm.store(Opnd::None, Opnd::None);
@@ -315,7 +314,7 @@ fn test_cmp_8_bit() {
 fn test_no_pos_marker_callback_when_compile_fails() {
     // When compilation fails (e.g. when out of memory), the code written out is malformed.
     // We don't want to invoke the pos_marker callbacks with positions of malformed code.
-    let mut asm = Assembler::new();
+    let mut asm = Assembler::new(0);
 
     // Markers around code to exhaust memory limit
     let fail_if_called = |_code_ptr, _cb: &_| panic!("pos_marker callback should not be called");

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -79,7 +79,7 @@ impl From<&Opnd> for X86Opnd {
     }
 }
 
-/// List of registers that can be used for stack temps.
+/// List of registers that can be used for stack temps and locals.
 pub static TEMP_REGS: [Reg; 5] = [RSI_REG, RDI_REG, R8_REG, R9_REG, R10_REG];
 
 impl Assembler

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -112,7 +112,7 @@ impl Assembler
     fn x86_split(mut self) -> Assembler
     {
         let live_ranges: Vec<usize> = take(&mut self.live_ranges);
-        let mut asm = Assembler::new_with_label_names(take(&mut self.label_names), take(&mut self.side_exits));
+        let mut asm = Assembler::new_with_label_names(take(&mut self.label_names), take(&mut self.side_exits), self.local_size);
         let mut iterator = self.into_draining_iter();
 
         while let Some((index, mut insn)) = iterator.next_unmapped() {

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -112,7 +112,7 @@ impl Assembler
     fn x86_split(mut self) -> Assembler
     {
         let live_ranges: Vec<usize> = take(&mut self.live_ranges);
-        let mut asm = Assembler::new_with_label_names(take(&mut self.label_names), take(&mut self.side_exits), self.local_size);
+        let mut asm = Assembler::new_with_label_names(take(&mut self.label_names), take(&mut self.side_exits), self.num_locals);
         let mut iterator = self.into_draining_iter();
 
         while let Some((index, mut insn)) = iterator.next_unmapped() {

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -895,14 +895,14 @@ impl Assembler
 
 #[cfg(test)]
 mod tests {
-    use crate::disasm::{assert_disasm};
+    use crate::disasm::assert_disasm;
     #[cfg(feature = "disasm")]
     use crate::disasm::{unindent, disasm_addr_range};
 
     use super::*;
 
     fn setup_asm() -> (Assembler, CodeBlock) {
-        (Assembler::new(), CodeBlock::new_dummy(1024))
+        (Assembler::new(0), CodeBlock::new_dummy(1024))
     }
 
     #[test]

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -651,7 +651,7 @@ fn verify_ctx(jit: &JITState, ctx: &Context) {
     }
 
     // Verify stack operand types
-    let top_idx = cmp::min(ctx.get_stack_size(), MAX_TEMP_TYPES as u8);
+    let top_idx = cmp::min(ctx.get_stack_size(), MAX_CTX_TEMPS as u8);
     for i in 0..top_idx {
         let learned_mapping = ctx.get_opnd_mapping(StackOpnd(i));
         let learned_type = ctx.get_opnd_type(StackOpnd(i));
@@ -698,7 +698,7 @@ fn verify_ctx(jit: &JITState, ctx: &Context) {
 
     // Verify local variable types
     let local_table_size = unsafe { get_iseq_body_local_table_size(jit.iseq) };
-    let top_idx: usize = cmp::min(local_table_size as usize, MAX_TEMP_TYPES);
+    let top_idx: usize = cmp::min(local_table_size as usize, MAX_CTX_TEMPS);
     for i in 0..top_idx {
         let learned_type = ctx.get_local_type(i);
         let learned_type = relax_type_with_singleton_class_assumption(learned_type);
@@ -1238,7 +1238,7 @@ pub fn gen_single_block(
 
         // stack_pop doesn't immediately deallocate a register for stack temps,
         // but it's safe to do so at this instruction boundary.
-        for stack_idx in asm.ctx.get_stack_size()..MAX_REG_OPNDS {
+        for stack_idx in asm.ctx.get_stack_size()..MAX_CTX_TEMPS as u8 {
             asm.ctx.dealloc_reg(RegOpnd::Stack(stack_idx));
         }
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2368,7 +2368,7 @@ fn gen_setlocal_generic(
         let local_opnd = asm.local_opnd(ep_offset);
 
         // Allocate a register to the new local operand
-        asm.alloc_reg(local_opnd.reg_mapping());
+        asm.alloc_reg(local_opnd.reg_opnd());
         (flags_opnd, local_opnd)
     } else {
         // Load flags and the local for the level
@@ -7510,7 +7510,7 @@ fn gen_send_iseq(
         };
         // Store rest param to memory to avoid register shuffle as
         // we won't be reading it for the remainder of the block.
-        asm.ctx.dealloc_reg(rest_param.reg_mapping());
+        asm.ctx.dealloc_reg(rest_param.reg_opnd());
         asm.store(rest_param, rest_param_array);
     }
 
@@ -7609,7 +7609,7 @@ fn gen_send_iseq(
         // Write the CI in to the stack and ensure that it actually gets
         // flushed to memory
         let ci_opnd = asm.stack_opnd(-1);
-        asm.ctx.dealloc_reg(ci_opnd.reg_mapping());
+        asm.ctx.dealloc_reg(ci_opnd.reg_opnd());
         asm.mov(ci_opnd, VALUE(ci as usize).into());
     }
 
@@ -7975,7 +7975,7 @@ fn gen_iseq_kw_call(
             kwargs_order[kwrest_idx] = 0;
         }
         // Put kwrest straight into memory, since we might pop it later
-        asm.ctx.dealloc_reg(stack_kwrest.reg_mapping());
+        asm.ctx.dealloc_reg(stack_kwrest.reg_opnd());
         asm.mov(stack_kwrest, kwrest);
         if stack_kwrest_idx >= 0 {
             asm.ctx.set_opnd_mapping(stack_kwrest.into(), TempMapping::map_to_stack(kwrest_type));
@@ -8073,7 +8073,7 @@ fn gen_iseq_kw_call(
     if let Some(kwrest_type) = kwrest_type {
         let kwrest = asm.stack_push(kwrest_type);
         // We put the kwrest parameter in memory earlier
-        asm.ctx.dealloc_reg(kwrest.reg_mapping());
+        asm.ctx.dealloc_reg(kwrest.reg_opnd());
         argc += 1;
     }
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -814,7 +814,7 @@ pub fn gen_outlined_exit(exit_pc: *mut VALUE, local_size: u32, ctx: &Context, oc
     let mut asm = Assembler::new();
     asm.ctx = *ctx;
     asm.local_size = Some(local_size);
-    asm.set_reg_mappings(ctx.get_reg_mappings());
+    asm.set_reg_mapping(ctx.get_reg_mapping());
 
     gen_exit(exit_pc, &mut asm);
 
@@ -1195,7 +1195,7 @@ pub fn gen_single_block(
         let blockid_idx = blockid.idx;
         let chain_depth = if asm.ctx.get_chain_depth() > 0 { format!("(chain_depth: {})", asm.ctx.get_chain_depth()) } else { "".to_string() };
         asm_comment!(asm, "Block: {} {}", iseq_get_location(blockid.iseq, blockid_idx), chain_depth);
-        asm_comment!(asm, "reg_mappings: {:?}", asm.ctx.get_reg_mappings());
+        asm_comment!(asm, "reg_mapping: {:?}", asm.ctx.get_reg_mapping());
     }
 
     // Mark the start of an ISEQ for --yjit-perf
@@ -1240,8 +1240,8 @@ pub fn gen_single_block(
 
         // stack_pop doesn't immediately deallocate a register for stack temps,
         // but it's safe to do so at this instruction boundary.
-        for stack_idx in asm.ctx.get_stack_size()..MAX_REG_MAPPINGS {
-            asm.ctx.dealloc_reg(RegMapping::Stack(stack_idx));
+        for stack_idx in asm.ctx.get_stack_size()..MAX_REG_OPNDS {
+            asm.ctx.dealloc_reg(RegOpnd::Stack(stack_idx));
         }
 
         // If previous instruction requested to record the boundary
@@ -1810,7 +1810,7 @@ fn gen_splatkw(
         asm.mov(stack_ret, hash);
         asm.stack_push(block_type);
         // Leave block_opnd spilled by ccall as is
-        asm.ctx.dealloc_reg(RegMapping::Stack(asm.ctx.get_stack_size() - 1));
+        asm.ctx.dealloc_reg(RegOpnd::Stack(asm.ctx.get_stack_size() - 1));
     }
 
     Some(KeepCompiling)
@@ -10545,7 +10545,7 @@ mod tests {
 
         assert_eq!(status, Some(KeepCompiling));
         let mut default = Context::default();
-        default.set_reg_mappings(context.get_reg_mappings());
+        default.set_reg_mapping(context.get_reg_mapping());
         assert_eq!(context.diff(&default), TypeDiff::Compatible(0));
     }
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -531,7 +531,7 @@ pub struct Context {
     // This represents how far the JIT's SP is from the "real" SP
     sp_offset: i8,
 
-    /// Bitmap of which stack temps are in a register
+    /// Which stack temps or locals are in a register
     reg_temps: RegTemps,
 
     /// Fields packed into u8
@@ -1019,7 +1019,7 @@ impl Context {
             bits.push_u8(self.sp_offset as u8);
         }
 
-        // Which stack temps are in a register
+        // Which stack temps or locals are in a register
         for &temp in self.reg_temps.0.iter() {
             if let Some(temp) = temp {
                 bits.push_u1(1); // Some
@@ -1116,7 +1116,7 @@ impl Context {
             ctx.sp_offset = bits.read_u8(&mut idx) as i8;
         }
 
-        // Which stack temps are in a register
+        // Which stack temps or locals are in a register
         for index in 0..MAX_TEMP_REGS {
             if bits.read_u1(&mut idx) == 1 { // Some
                 let temp = if bits.read_u1(&mut idx) == 0 { // RegTemp::Stack

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -3701,7 +3701,7 @@ fn gen_branch_stub(
     }
 
     // Spill temps to the VM stack as well for jit.peek_at_stack()
-    asm.spill_temps();
+    asm.spill_regs();
 
     // Set up the arguments unique to this stub for:
     //

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -2996,7 +2996,7 @@ impl Assembler {
             idx,
             num_bits: 64,
             stack_size: self.ctx.stack_size,
-            local_size: None, // not needed for stack temps
+            num_locals: None, // not needed for stack temps
             sp_offset: self.ctx.sp_offset,
             reg_mapping: None, // push_insn will set this
         }
@@ -3009,7 +3009,7 @@ impl Assembler {
             idx,
             num_bits: 64,
             stack_size: self.ctx.stack_size,
-            local_size: Some(self.local_size.unwrap()), // this must exist for locals
+            num_locals: Some(self.num_locals.unwrap()), // this must exist for locals
             sp_offset: self.ctx.sp_offset,
             reg_mapping: None, // push_insn will set this
         }
@@ -3684,7 +3684,7 @@ fn gen_branch_stub(
 
     let mut asm = Assembler::new();
     asm.ctx = Context::decode(ctx);
-    asm.local_size = Some(unsafe { get_iseq_body_local_table_size(iseq) });
+    asm.num_locals = Some(unsafe { get_iseq_body_local_table_size(iseq) });
     asm.set_reg_mapping(asm.ctx.reg_mapping);
     asm_comment!(asm, "branch stub hit");
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -431,14 +431,14 @@ pub enum RegOpnd {
 pub struct RegMapping([Option<RegOpnd>; MAX_MAPPED_REGS]);
 
 impl RegMapping {
-    /// Return the index of the register for a given stack value if allocated.
+    /// Return the index of the register for a given operand if allocated.
     pub fn get_reg(&self, opnd: RegOpnd) -> Option<usize> {
         self.0.iter().enumerate()
             .find(|(_, &reg_opnd)| reg_opnd == Some(opnd))
             .map(|(reg_idx, _)| reg_idx)
     }
 
-    /// Allocate a register for a given stack value if available.
+    /// Allocate a register for a given operand if available.
     /// Return true if self is updated.
     pub fn alloc_reg(&mut self, opnd: RegOpnd) -> bool {
         // If a given opnd already has a register, skip allocation.
@@ -463,7 +463,7 @@ impl RegMapping {
         false
     }
 
-    /// Deallocate a register for a given stack value if in use.
+    /// Deallocate a register for a given operand if in use.
     /// Return true if self is updated.
     pub fn dealloc_reg(&mut self, opnd: RegOpnd) -> bool {
         for reg_opnd in self.0.iter_mut() {
@@ -481,7 +481,7 @@ impl RegMapping {
             return None;
         }
 
-        // If the default index for the stack value is available, use that to minimize
+        // If the default index for the operand is available, use that to minimize
         // discrepancies among Contexts.
         let default_idx = match opnd {
             RegOpnd::Stack(stack_idx) => stack_idx.as_usize() % MAX_MAPPED_REGS,

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -424,9 +424,11 @@ pub enum RegOpnd {
     Local(u8),
 }
 
-/// RegMappings manages a set of registers used for temporary values on the stack.
+/// RegMappings manages a set of registers used for stack temps and locals.
 /// Each element of the array represents each of the registers.
-/// If an element is Some, the temporary value uses a register.
+/// If an element is Some, the stack temp or the local uses a register.
+///
+/// Note that Opnd::InsnOut uses a separate set of registers at the moment.
 #[derive(Copy, Clone, Default, Eq, Hash, PartialEq)]
 pub struct RegMapping([Option<RegOpnd>; MAX_MAPPED_REGS]);
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -2926,7 +2926,7 @@ impl Assembler {
 
         // Allocate a register to the new stack operand
         let stack_opnd = self.stack_opnd(0);
-        self.alloc_reg(stack_opnd.reg_mapping());
+        self.alloc_reg(stack_opnd.reg_opnd());
 
         stack_opnd
     }

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -683,7 +683,7 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all() {
             cb.set_write_ptr(patch.inline_patch_pos);
             cb.set_dropped_bytes(false);
             cb.without_page_end_reserve(|cb| {
-                let mut asm = crate::backend::ir::Assembler::new();
+                let mut asm = crate::backend::ir::Assembler::new_without_iseq();
                 asm.jmp(patch.outlined_target_pos.as_side_exit());
                 if asm.compile(cb, None).is_none() {
                     panic!("Failed to apply patch at {:?}", patch.inline_patch_pos);

--- a/yjit/src/utils.rs
+++ b/yjit/src/utils.rs
@@ -273,7 +273,7 @@ mod tests {
 
     #[test]
     fn test_print_int() {
-        let mut asm = Assembler::new();
+        let mut asm = Assembler::new_without_iseq();
         let mut cb = CodeBlock::new_dummy(1024);
 
         print_int(&mut asm, Opnd::Imm(42));
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn test_print_str() {
-        let mut asm = Assembler::new();
+        let mut asm = Assembler::new_without_iseq();
         let mut cb = CodeBlock::new_dummy(1024);
 
         print_str(&mut asm, "Hello, world!");


### PR DESCRIPTION
This PR introduces a register allocator for local variables. This PR contains the following changes for it:

* Migrate `Context::reg_temps` from `u8` to `[Option<RegTemp>; 5]`
    * `RegTemp` is either `RegTemp::Stack(u8)` or `RegTemp::Local(u8)`.
    * The encoder uses 1-5 bits for each of the 5 registers. 1 bit for `Option`, 1 bit for enum variant, and 3 bits for index.
* `Opnd::Stack` can now be assigned to any register while it still defaults to `stack_idx % 5` (register bias)
    * When the register at `stack_idx % 5` is already used, it uses an unused register with the smallest index.
* Allocate a register for a local variable on setivar
    * Convert local variable access from `Opnd::Mem` to `Opnd::Stack`
    * It defaults to the register at `4 - (local_idx % 5)`. If it's taken, it uses an unused register with the largest index.

## Out of Scope

Method arguments are local variables but they aren't set by `setivar`, so it's not supported in this PR. 

I'm thinking of working on that next, but I think the current optimization should be merged separately to keep the patches simple and to allow benchmarking them independently.

## Benchmark

It gives 1-2% speedup to some benchmarks. `railsbench` specifically seems to consistently show a 2% speedup.

```
before: ruby 3.4.0dev (2024-07-09T17:22:29Z master 6f6aff56b1) +YJIT [x86_64-linux]
after: ruby 3.4.0dev (2024-07-12T09:13:23Z yjit-local-regs 1ad043bd3e) +YJIT [x86_64-linux]

--------------  -----------  ----------  ----------  ----------  -------------  ------------
bench           before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
activerecord    302.0        0.2         302.2       0.4         1.00           1.00
chunky-png      487.5        0.1         486.1       0.2         0.99           1.00
erubi-rails     1275.5       0.1         1259.9      0.1         1.01           1.01
hexapdf         1876.7       2.5         1869.0      1.3         0.98           1.00
liquid-c        76.5         0.7         75.4        0.5         0.96           1.01
liquid-compile  75.7         0.5         74.7        0.9         0.90           1.01
liquid-render   98.8         0.3         97.8        0.5         0.96           1.01
lobsters        985.5        1.6         979.9       1.4         0.97           1.01
mail            155.9        0.4         155.6       0.5         0.95           1.00
psych-load      1803.7       0.1         1826.4      0.1         0.99           0.99
railsbench      2505.3       0.7         2457.8      0.8         0.99           1.02
rubocop         130.5        6.6         131.1       7.1         0.94           1.00
ruby-lsp        145.3        0.9         143.6       1.0         0.93           1.01
sequel          92.6         0.6         92.7        0.4         0.99           1.00
--------------  -----------  ----------  ----------  ----------  -------------  ------------
Legend:
- after 1st itr: ratio of before/after time for the first benchmarking iteration.
- before/after: ratio of before/after time. Higher is better for after. Above 1 represents a speedup.

Output:
./data/output_1343.csv
```

## Memory Usage

The current master always uses 8 bits for a `reg_temps`. This PR uses 5-25 bits. So, on average, `bytes_per_context` is increased. However, it doesn't seem to have a significant impact on overall `yjit_alloc_size`, thanks to context caching.

With 25 itrs on lobsters, 

### Before

```
yjit_alloc_size:          27,728,430
context_data_bytes:          341,320
context_cache_bytes:          16,384
num_contexts_encoded:        192,683
bytes_per_context:              1.77
context_cache_hit_rate:      141,224 (73.3%)
```

### After

```
yjit_alloc_size:          27,608,015
context_data_bytes:          390,787
context_cache_bytes:          20,480
num_contexts_encoded:        191,803
bytes_per_context:              2.04
context_cache_hit_rate:      136,528 (71.2%)
```