### PR TITLE
Document RbConfig::{SIZEOF,LIMITS}

### DIFF
--- a/template/limits.c.tmpl
+++ b/template/limits.c.tmpl
@@ -51,6 +51,20 @@
 # include <float.h>
 #endif
 
+/*
+ * Document-const: LIMITS
+ *
+ * A Hash with the bounds of numeric types available to the \C compiler
+ * used to build Ruby. To access this constant, first run
+ * <code>require 'rbconfig/sizeof'</code>.
+ *
+ *    require 'rbconfig/sizeof'
+ *    RUBY_PLATFORM # => "x64-mingw-ucrt"
+ *    RbConfig::LIMITS.fetch_values('FIXNUM_MAX', 'LONG_MAX')
+ *    # => [1073741823, 2147483647]
+ *
+ */
+
 void
 Init_limits(void)
 {

--- a/template/limits.c.tmpl
+++ b/template/limits.c.tmpl
@@ -55,7 +55,8 @@ void
 Init_limits(void)
 {
     VALUE h = rb_hash_new();
-    rb_define_const(rb_define_module("RbConfig"), "LIMITS", h);
+    VALUE mRbConfig = rb_define_module("RbConfig");
+    rb_define_const(mRbConfig, "LIMITS", h);
 
 #ifdef HAVE_LONG_LONG
 #ifndef ULLONG_MAX

--- a/template/sizes.c.tmpl
+++ b/template/sizes.c.tmpl
@@ -30,7 +30,8 @@ void
 Init_sizeof(void)
 {
     VALUE s = rb_hash_new();
-    rb_define_const(rb_define_module("RbConfig"), "SIZEOF", s);
+    VALUE mRbConfig = rb_define_module("RbConfig");
+    rb_define_const(mRbConfig, "SIZEOF", s);
 
 #define DEFINE(type, size) rb_hash_aset(s, rb_str_new_cstr(#type), INT2FIX(SIZEOF_##size))
 #define DEFINE_SIZE(type) rb_hash_aset(s, rb_str_new_cstr(#type), INT2FIX(sizeof(type)))

--- a/template/sizes.c.tmpl
+++ b/template/sizes.c.tmpl
@@ -25,6 +25,20 @@ conditions = {
 #endif
 
 % end
+
+/*
+ * Document-const: SIZEOF
+ *
+ * A Hash with the byte size of \C types available to the compiler
+ * used to build Ruby. To access this constant, first run
+ * <code>require 'rbconfig/sizeof'</code>.
+ *
+ *    require 'rbconfig/sizeof'
+ *    RUBY_PLATFORM                                  # => "x64-mingw-ucrt"
+ *    RbConfig::SIZEOF.fetch_values('long', 'void*') # => [4, 8]
+ *
+ */
+
 extern void Init_limits(void);
 void
 Init_sizeof(void)


### PR DESCRIPTION
I noticed that these constants from `rbconfig/sizeof` are completely undocumented while looking at #11130.

Rendered:
<img width="1118" alt="Screenshot 2024-07-12 at 19 55 19" src="https://github.com/user-attachments/assets/a124f9e2-f0da-4efa-a416-2f703f9adc48">


<img width="1129" alt="Screenshot 2024-07-12 at 19 40 03" src="https://github.com/user-attachments/assets/2bfac851-54bf-41fa-bfe9-60d5806fd4fe">
