### PR TITLE
[Backport bugfix for #20633 to 3.2] Fix the condition for `atomic_signal_fence`

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -405,7 +405,7 @@ vm_push_frame(rb_execution_context_t *ec,
     This is a no-op in all cases we've looked at (https://godbolt.org/z/3oxd1446K), but should guarantee it for all
     future/untested compilers/platforms. */
 
-    #ifdef HAVE_DECL_ATOMIC_SIGNAL_FENCE
+    #if defined HAVE_DECL_ATOMIC_SIGNAL_FENCE && HAVE_DECL_ATOMIC_SIGNAL_FENCE
     atomic_signal_fence(memory_order_seq_cst);
     #endif
 


### PR DESCRIPTION
`AC_CHECK_DECLS` defines `HAVE_DECL_SYMBOL` to 1 if declared, 0 otherwise, not undefined.

This was fixed in master in https://github.com/ruby/ruby/commit/7472fff7f1b5296fbfcde0e2b7411a1d87781f3f but since the original change was backported to 3.2 in https://github.com/ruby/ruby/pull/11090, I'm opening this PR to backport the fix.