### PR TITLE
Fixed fd leak at rubygems, net-http

### DIFF
--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -321,6 +321,7 @@ class TestNetHTTPSIdentityVerifyFailure < Test::Unit::TestCase
     @log_tester = lambda {|_| }
     ex = assert_raise(OpenSSL::SSL::SSLError){
       http.request_get("/") {|res| }
+      sleep 0.5
     }
     re_msg = /certificate verify failed|hostname \"#{HOST_IP}\" does not match/
     assert_match(re_msg, ex.message)

--- a/test/net/http/test_https_proxy.rb
+++ b/test/net/http/test_https_proxy.rb
@@ -56,38 +56,39 @@ class HTTPSProxyTest < Test::Unit::TestCase
       omit 'autoload problem. see [ruby-dev:45021][Bug #5786]'
     end
 
-    tcpserver = TCPServer.new("127.0.0.1", 0)
-    ctx = OpenSSL::SSL::SSLContext.new
-    ctx.key = OpenSSL::PKey.read(read_fixture("server.key"))
-    ctx.cert = OpenSSL::X509::Certificate.new(read_fixture("server.crt"))
-    serv = OpenSSL::SSL::SSLServer.new(tcpserver, ctx)
+    TCPServer.open("127.0.0.1", 0) {|tcpserver|
+      ctx = OpenSSL::SSL::SSLContext.new
+      ctx.key = OpenSSL::PKey.read(read_fixture("server.key"))
+      ctx.cert = OpenSSL::X509::Certificate.new(read_fixture("server.crt"))
+      serv = OpenSSL::SSL::SSLServer.new(tcpserver, ctx)
 
-    _, port, _, _ = serv.addr
-    client_thread = Thread.new {
-      proxy = Net::HTTP.Proxy("127.0.0.1", port, 'user', 'password', true)
-      http = proxy.new("foo.example.org", 8000)
-      http.use_ssl = true
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      begin
-        http.start
-      rescue EOFError
-      end
+      _, port, _, _ = serv.addr
+      client_thread = Thread.new {
+        proxy = Net::HTTP.Proxy("127.0.0.1", port, 'user', 'password', true)
+        http = proxy.new("foo.example.org", 8000)
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        begin
+          http.start
+        rescue EOFError
+        end
+      }
+      server_thread = Thread.new {
+        sock = serv.accept
+        begin
+          proxy_request = sock.gets("\r\n\r\n")
+          assert_equal(
+            "CONNECT foo.example.org:8000 HTTP/1.1\r\n" +
+            "Host: foo.example.org:8000\r\n" +
+            "Proxy-Authorization: Basic dXNlcjpwYXNzd29yZA==\r\n" +
+            "\r\n",
+            proxy_request,
+            "[ruby-core:96672]")
+        ensure
+          sock.close
+        end
+      }
+      assert_join_threads([client_thread, server_thread])
     }
-    server_thread = Thread.new {
-      sock = serv.accept
-      begin
-        proxy_request = sock.gets("\r\n\r\n")
-        assert_equal(
-          "CONNECT foo.example.org:8000 HTTP/1.1\r\n" +
-          "Host: foo.example.org:8000\r\n" +
-          "Proxy-Authorization: Basic dXNlcjpwYXNzd29yZA==\r\n" +
-          "\r\n",
-          proxy_request,
-          "[ruby-core:96672]")
-      ensure
-        sock.close
-      end
-    }
-    assert_join_threads([client_thread, server_thread])
   end
 end if defined?(OpenSSL)

--- a/test/net/http/utils.rb
+++ b/test/net/http/utils.rb
@@ -252,6 +252,7 @@ module TestNetHTTPUtils
   end
 
   def teardown
+    sleep 0.5 if @config['ssl_enable']
     if @server
       @server.shutdown
     end

--- a/test/open-uri/test_ssl.rb
+++ b/test/open-uri/test_ssl.rb
@@ -53,6 +53,7 @@ class TestOpenURISSL < Test::Unit::TestCase
     with_https(nil) {|srv, dr, url, server_thread, server_log|
       setup_validation(srv, dr)
       assert_raise(OpenSSL::SSL::SSLError) { URI.open("#{url}/data") {} }
+      sleep 0.5 unless RUBY_PLATFORM =~ /mswin|mingw/
     }
   end
 

--- a/test/open-uri/test_ssl.rb
+++ b/test/open-uri/test_ssl.rb
@@ -50,7 +50,7 @@ class TestOpenURISSL < Test::Unit::TestCase
   end
 
   def test_validation_failure
-    with_https(nil) {|srv, dr, url, server_thread, server_log|
+    with_https(nil) {|srv, dr, url|
       setup_validation(srv, dr)
       assert_raise(OpenSSL::SSL::SSLError) { URI.open("#{url}/data") {} }
       sleep 0.5 unless RUBY_PLATFORM =~ /mswin|mingw/

--- a/test/open-uri/utils.rb
+++ b/test/open-uri/utils.rb
@@ -363,6 +363,7 @@ module TestOpenURIUtils
       }
       begin
         yield srv, dr, url, cacert_filename, cacert_directory, proxy_host, proxy_port
+        sleep 1
       ensure
         proxy.shutdown
       end

--- a/test/open-uri/utils.rb
+++ b/test/open-uri/utils.rb
@@ -343,7 +343,7 @@ module TestOpenURIUtils
   def with_https_proxy(proxy_log_tester=lambda {|proxy_log, proxy_access_log| assert_equal([], proxy_log) })
     proxy_log = []
     proxy_access_log = []
-    with_https {|srv, dr, url, server_thread, server_log, threads|
+    with_https {|srv, dr, url|
       srv.instance_variable_get(:@server).setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
       cacert_filename = "#{dr}/cacert.pem"
       open(cacert_filename, "w") {|f| f << CA_CERT }
@@ -355,7 +355,7 @@ module TestOpenURIUtils
       proxy = SimpleHTTPProxyServer.new(proxy_host, 0, proxy_log, proxy_access_log)
       proxy_port = proxy.instance_variable_get(:@server).addr[1]
       proxy_thread = proxy.start
-      threads << Thread.new {
+      thread = Thread.new {
         proxy_thread.join
         if proxy_log_tester
           proxy_log_tester.call(proxy_log, proxy_access_log)
@@ -367,6 +367,7 @@ module TestOpenURIUtils
       ensure
         proxy.shutdown
       end
+      assert_join_threads([thread])
     }
   end
 
@@ -390,7 +391,7 @@ module TestOpenURIUtils
       }
       threads << Thread.new {
         begin
-          yield srv, dr, "https://#{host}:#{port}", server_thread, log, threads
+          yield srv, dr, "https://#{host}:#{port}"
         ensure
           srv.shutdown
         end

--- a/test/rubygems/test_gem_remote_fetcher_local_server.rb
+++ b/test/rubygems/test_gem_remote_fetcher_local_server.rb
@@ -90,10 +90,12 @@ gems:
 
     if @normal_server
       @normal_server.kill.join
+      @normal_server[:server].close
       @normal_server = nil
     end
     if @proxy_server
       @proxy_server.kill.join
+      @proxy_server[:server].close
       @proxy_server = nil
     end
 

--- a/test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb
+++ b/test/rubygems/test_gem_remote_fetcher_local_ssl_server.rb
@@ -143,6 +143,7 @@ PeIQQkFng2VVot/WAQbv3ePqWq07g1BBcwIBAg==
     end
     fetcher = Gem::RemoteFetcher.new
     yield fetcher
+    sleep 0.5 unless RUBY_PLATFORM =~ /mswin|mingw/
   ensure
     fetcher.close_all
     Gem.configuration = nil


### PR DESCRIPTION
I fixed like the followings:

```
Leaked file descriptor: HTTPSProxyTest#test_https_proxy_ssl_connection: 8 : #<TCPServer:fd 8, AF_INET, 127.0.0.1, 63104>
```