### PR TITLE
Stop using `sigsetjmp` to hijack SIGCHLD handler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1072,7 +1072,6 @@ AS_CASE(["$target_os"],
 		AS_IF([test $gcc_major -eq 4 -a $gcc_minor -lt 3], [
 		    ac_cv_func___builtin_setjmp=no
 		])
-		with_setjmp_type=sigsetjmp # to hijack SIGCHLD handler
 		AC_CACHE_CHECK(for broken crypt with 8bit chars, rb_cv_broken_crypt,
 		    [AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>


### PR DESCRIPTION
It already has been dead code.
Follow up of 65d3eacc80bbefb29e5cd0f3f9661d886f2e4cee.