### PR TITLE
Fix memory leak reported in main ractor when RUBY_FREE_AT_EXIT

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -249,7 +249,12 @@ ractor_free(void *ptr)
     ractor_local_storage_free(r);
     rb_hook_list_free(&r->pub.hooks);
 
-    RUBY_ASSERT(rb_free_at_exit || r->newobj_cache == NULL);
+    if (r->newobj_cache) {
+        RUBY_ASSERT(r == ruby_single_main_ractor);
+
+        rb_gc_ractor_cache_free(r->newobj_cache);
+        r->newobj_cache = NULL;
+    }
 
     ruby_xfree(r);
 }


### PR DESCRIPTION
```
STACK OF 1 INSTANCE OF 'ROOT LEAK: <calloc in rb_ractor_main_alloc>':
6   dyld                                  0x1840e20e0 start + 2360
5   miniruby                              0x1006796c8 main + 88  main.c:62
4   miniruby                              0x10072f4a4 ruby_init + 16  eval.c:99
3   miniruby                              0x10072f328 ruby_setup + 104  eval.c:81
2   miniruby                              0x1008d08c0 Init_BareVM + 508  vm.c:4276
1   miniruby                              0x1007f8944 rb_ractor_main_alloc + 76  ractor.c:2034
0   libsystem_malloc.dylib                0x1842a4cac _malloc_zone_calloc_instrumented_or_legacy + 128
====
    1 (96 bytes) ROOT LEAK: <calloc in rb_ractor_main_alloc 0x1347075d0> [96]
```