### PR TITLE
Make OBJ_ID_INCREMENT == RUBY_IMMEDIATE_MASK + 1

### DIFF
--- a/gc/default.c
+++ b/gc/default.c
@@ -1629,7 +1629,7 @@ object_id_hash(st_data_t n)
     return FIX2LONG(rb_hash((VALUE)n));
 }
 
-#define OBJ_ID_INCREMENT (BASE_SLOT_SIZE)
+#define OBJ_ID_INCREMENT (RUBY_IMMEDIATE_MASK + 1)
 #define OBJ_ID_INITIAL (OBJ_ID_INCREMENT)
 
 static const struct st_hash_type object_id_hash_type = {


### PR DESCRIPTION
All the non-GC objects (i.e. immediates) have addresses such that `obj % RUBY_IMMEDIATE_MASK != 0` (except for `Qfalse`, which is 0). We can define `OBJ_ID_INCREMENT` as `RUBY_IMMEDIATE_MASK + 1` which should guarantee that GC objects never have conflicting object IDs with immediates.