### PR TITLE
C API docs tweaks related to freezing

### DIFF
--- a/include/ruby/internal/fl_type.h
+++ b/include/ruby/internal/fl_type.h
@@ -906,6 +906,14 @@ RB_OBJ_FROZEN(VALUE obj)
 }
 
 RUBY_SYMBOL_EXPORT_BEGIN
+/**
+ * Prevents further modifications to the given object.  ::rb_eFrozenError shall
+ * be raised if modification is attempted.
+ *
+ * @param[out]  x               Object in question.
+ * @exception   rb_eNoMemError  Failed   to   allocate memory  for  the  frozen
+ *                              representation of the object.
+ */
 void rb_obj_freeze_inline(VALUE obj);
 RUBY_SYMBOL_EXPORT_END
 

--- a/include/ruby/internal/intern/array.h
+++ b/include/ruby/internal/intern/array.h
@@ -144,7 +144,13 @@ void rb_ary_free(VALUE ary);
  */
 void rb_ary_modify(VALUE ary);
 
-/** @alias{rb_obj_freeze} */
+/**
+ * Freeze an array, preventing further modifications. The underlying  buffer may
+ * be shrunk before freezing to conserve memory.
+ *
+ * @param[out]  obj  Object assumed to be an array to freeze.
+ * @see         RB_OBJ_FREEZE()
+ */
 VALUE rb_ary_freeze(VALUE obj);
 
 RBIMPL_ATTR_PURE()

--- a/variable.c
+++ b/variable.c
@@ -1806,12 +1806,6 @@ rb_shape_set_shape_id(VALUE obj, shape_id_t shape_id)
     return true;
 }
 
-/**
- * Prevents further modifications to the given object.  ::rb_eFrozenError shall
- * be raised if modification is attempted.
- *
- * @param[out]  x  Object in question.
- */
 void rb_obj_freeze_inline(VALUE x)
 {
     if (RB_FL_ABLE(x)) {


### PR DESCRIPTION
- **[DOC] No more is rb_ary_freeze() an alias of rb_obj_freeze()**
- **[DOC] Note that rb_obj_freeze_inline() can raise NoMemoryError**
