### PR TITLE
Fix double free when `getcwd` does not allocate buffer

### DIFF
--- a/util.c
+++ b/util.c
@@ -564,7 +564,7 @@ ruby_getcwd(void)
         rb_imemo_tmpbuf_set_ptr(guard, buf);
         buf = xrealloc(buf, size);
     }
-    rb_free_tmp_buffer(&guard);
+    rb_imemo_tmpbuf_set_ptr(guard, NULL);
     return buf;
 }
 


### PR DESCRIPTION
Do not free the result at normal return from `ruby_getcwd`.