### PR TITLE
Launchable: Fix Python package path

### DIFF
--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -96,12 +96,19 @@ runs:
         echo "LAUNCHABLE_TOKEN=${{ inputs.launchable-token }}" >> $GITHUB_ENV
       if: steps.enable-launchable.outputs.enable-launchable
 
+    - name: Set up path
+      shell: bash
+      working-directory: ${{ inputs.srcdir }}
+      # Since updated PATH variable will be available in only subsequent actions, we need to add the path beforehand.
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+      run: echo "$(python -msite --user-base)/bin" >> $GITHUB_PATH
+      if: startsWith(inputs.os, 'macos')
+
     - name: Set up Launchable
       shell: bash
       working-directory: ${{ inputs.srcdir }}
       run: |
         set -x
-        echo "$(python -msite --user-base)/bin" >> $GITHUB_PATH
         pip install --user launchable
         launchable verify || true
         : # The build name cannot include a slash, so we replace the string here.


### PR DESCRIPTION
Currently, executing Launchable CLI command is always failed on Mac OS environments such as https://github.com/ruby/ruby/actions/runs/9965995344/job/27537304248#step:10:213. The reason is because the way of using `$GITHUB_PATH` is wrong. In this document, updated PATH variable will be available in only subsequent actions, not the current action. So, I've updated it.

> Prepends a directory to the system PATH variable and automatically makes it available to all subsequent actions in the current job; the currently running action cannot access the updated path variable. To see the currently defined paths for your job, you can use echo "$PATH" in a step or an action.

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path