### PR TITLE
Report a TracePoint log when the TracePoint tests fail

### DIFF
--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -1373,9 +1373,11 @@ CODE
 
   def test_a_call
     events = []
+    log = []
     TracePoint.new(:a_call){|tp|
       next if !target_thread?
       events << tp.event
+      log << "| event:#{ tp.event } method_id:#{ tp.method_id } #{ tp.path }:#{ tp.lineno }"
     }.enable{
       [1].map{
         3
@@ -1391,14 +1393,16 @@ CODE
       :c_call,
       :call,
       :b_call,
-    ], events)
+    ], events, "TracePoint log:\n#{ log.join("\n") }\n")
   end
 
   def test_a_return
     events = []
+    log = []
     TracePoint.new(:a_return){|tp|
       next if !target_thread?
       events << tp.event
+      log << "| event:#{ tp.event } method_id:#{ tp.method_id } #{ tp.path }:#{ tp.lineno }"
     }.enable{
       [1].map{
         3
@@ -1414,7 +1418,7 @@ CODE
       :b_return,
       :return,
       :b_return
-    ], events)
+    ], events, "TracePoint log:\n#{ log.join("\n") }\n")
   end
 
   def test_const_missing


### PR DESCRIPTION
https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fruby%2Ftest_settracefunc.rb%23%23%23class%3DTestSetTraceFunc%23%23%23testcase%3Dtest_a_return?organizationId=ruby&workspaceId=ruby&testPathId=file%3Dtest%2Fruby%2Ftest_settracefunc.rb%23%23%23class%3DTestSetTraceFunc%23%23%23testcase%3Dtest_a_return&testSessionStatus=flake

```
Failure:
TestSetTraceFunc#test_a_return [/home/runner/work/ruby/ruby/src/test/ruby/test_settracefunc.rb:1410]:
<[:b_return, :c_return, :return, :b_return, :return, :b_return]> expected but was
<[:c_return,
 :return,
 :b_return,
 :c_return,
 :return,
 :b_return,
 :return,
 :b_return]>.
```