### PR TITLE
Fix empty hash instruction

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -7164,9 +7164,16 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             // is popped, then we know we don't need to do anything since it's
             // statically known.
             if (!popped) {
-                VALUE value = pm_static_literal_value(iseq, node, scope_node);
-                PUSH_INSN1(ret, location, duphash, value);
-                RB_OBJ_WRITTEN(iseq, Qundef, value);
+                const pm_hash_node_t *cast = (const pm_hash_node_t *) node;
+
+                if (cast->elements.size == 0) {
+                    PUSH_INSN1(ret, location, newhash, INT2FIX(0));
+                }
+                else {
+                    VALUE value = pm_static_literal_value(iseq, node, scope_node);
+                    PUSH_INSN1(ret, location, duphash, value);
+                    RB_OBJ_WRITTEN(iseq, Qundef, value);
+                }
             }
         }
         else {


### PR DESCRIPTION
When we have an empty hash the iseq should have a `newhash` but instead had a `duphash`. To fix, return `Qnil` if the `hash` elements are empty, use `newhash` in that case, otherwise `duphash`.

Before:

```
== disasm: #<ISeq:<main>@test2.rb:1 (1,0)-(1,2)>
0000 duphash                                {}                        (   1)[Li]
0002 leave
```

After:

```
== disasm: #<ISeq:<main>@test2.rb:1 (1,0)-(1,2)>
0000 newhash                                0                         (   1)[Li]
0002 leave
```

Fixes the test `TestYJIT#test_compile_newhash`. Related to ruby/prism#2935

cc/ @kddnewton 