### PR TITLE
Handle default prism parser in test_rubyoptions

### DIFF
--- a/test/-ext-/bug_reporter/test_bug_reporter.rb
+++ b/test/-ext-/bug_reporter/test_bug_reporter.rb
@@ -8,7 +8,8 @@ class TestBugReporter < Test::Unit::TestCase
     pend "macOS 15 beta is not working with this test" if /darwin/ =~ RUBY_PLATFORM && /15/ =~ `sw_vers -productVersion`
 
     omit "flaky with RJIT" if JITSupport.rjit_enabled?
-    description = RUBY_DESCRIPTION.sub(/\+PRISM /, '')
+    description = RUBY_DESCRIPTION
+    description = description.sub(/\+PRISM /, '') unless EnvUtil.invoke_ruby(["-v"], "", true, false)[0].include?("+PRISM")
     description = description.sub(/\+RJIT /, '') unless JITSupport.rjit_force_enabled?
     expected_stderr = [
       :*,

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -13,7 +13,12 @@ class TestRubyOptions < Test::Unit::TestCase
   # Here we're defining our own RUBY_DESCRIPTION without "+PRISM". We do this
   # here so that the various tests that reference RUBY_DESCRIPTION don't have to
   # worry about it. The flag itself is tested in its own test.
-  RUBY_DESCRIPTION = ::RUBY_DESCRIPTION.sub(/\+PRISM /, '')
+  RUBY_DESCRIPTION =
+    if EnvUtil.invoke_ruby(["-v"], "", true, false)[0].include?("+PRISM")
+      ::RUBY_DESCRIPTION
+    else
+      ::RUBY_DESCRIPTION.sub(/\+PRISM /, '')
+    end
 
   NO_JIT_DESCRIPTION =
     if rjit_enabled?
@@ -163,14 +168,14 @@ class TestRubyOptions < Test::Unit::TestCase
       /^jruby #{q[RUBY_ENGINE_VERSION]} \(#{q[RUBY_VERSION]}\).*? \[#{
         q[RbConfig::CONFIG["host_os"]]}-#{q[RbConfig::CONFIG["host_cpu"]]}\]$/
     else
-      /^ruby #{q[RUBY_VERSION]}(?:[p ]|dev|rc).*? \[#{q[RUBY_PLATFORM]}\]$/
+      /^ruby #{q[RUBY_VERSION]}(?:[p ]|dev|rc).*? (\+PRISM )?\[#{q[RUBY_PLATFORM]}\]$/
     end
   private_constant :VERSION_PATTERN
 
   VERSION_PATTERN_WITH_RJIT =
     case RUBY_ENGINE
     when 'ruby'
-      /^ruby #{q[RUBY_VERSION]}(?:[p ]|dev|rc).*? \+RJIT (\+MN )?\[#{q[RUBY_PLATFORM]}\]$/
+      /^ruby #{q[RUBY_VERSION]}(?:[p ]|dev|rc).*? \+RJIT (\+MN )?(\+PRISM )?\[#{q[RUBY_PLATFORM]}\]$/
     else
       VERSION_PATTERN
     end

--- a/version.c
+++ b/version.c
@@ -150,7 +150,8 @@ define_ruby_description(const char *const jit_opt)
         sizeof(ruby_description)
         + rb_strlen_lit(YJIT_DESCRIPTION)
         + rb_strlen_lit(" +MN")
-        ];
+        + rb_strlen_lit(" +PRISM")
+    ];
 
     const char *const threads_opt = ruby_mn_threads_enabled ? " +MN" : "";
     const char *const parser_opt = (*rb_ruby_prism_ptr()) ? " +PRISM" : "";


### PR DESCRIPTION
When `--parser=prism` is the default, some assertions against `RUBY_DESCRIPTION` need to change.