### PR TITLE
Free `data` of `struct rb_parser_ary` in `rb_parser_ary_free`

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -2598,6 +2598,7 @@ rb_parser_ary_free(rb_parser_t *p, rb_parser_ary_t *ary)
         break;
     }
 # undef foreach_ary
+    xfree(ary->data);
     xfree(ary);
 }
 


### PR DESCRIPTION
For example:

    10.times do
      100_000.times do
        RubyVM::AbstractSyntaxTree.parse("x = 1 + 2 +", keep_tokens: true)
      rescue SyntaxError
      end

      puts `ps -o rss= -p #{$$}`
    end

Before:

    28944
    44816
    60720
    76496
    92336
   108160
   123968
   139808
   155648
   171408

After:

    11984
    12704
    12816
    12832
    13072
    13088
    13088
    13136
    13136
    13152