### PR TITLE
YJIT: Allow dev_nodebug to disasm release-mode code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3916,17 +3916,17 @@ AS_CASE(["${YJIT_SUPPORT}"],
     ],
     [dev], [
 	rb_rust_target_subdir=debug
-	CARGO_BUILD_ARGS='--features stats,disasm'
+	CARGO_BUILD_ARGS='--features disasm,runtime_assertions'
 	AC_DEFINE(RUBY_DEBUG, 1)
     ],
     [dev_nodebug], [
 	rb_rust_target_subdir=dev_nodebug
-	CARGO_BUILD_ARGS='--profile dev_nodebug --features stats,disasm'
+	CARGO_BUILD_ARGS='--profile dev_nodebug --features disasm'
 	AC_DEFINE(YJIT_STATS, 1)
     ],
     [stats], [
 	rb_rust_target_subdir=stats
-	CARGO_BUILD_ARGS='--profile stats --features stats'
+	CARGO_BUILD_ARGS='--profile stats'
 	AC_DEFINE(YJIT_STATS, 1)
     ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -3916,7 +3916,7 @@ AS_CASE(["${YJIT_SUPPORT}"],
     ],
     [dev], [
 	rb_rust_target_subdir=debug
-	CARGO_BUILD_ARGS='--features disasm,runtime_assertions'
+	CARGO_BUILD_ARGS='--features disasm,runtime_checks'
 	AC_DEFINE(RUBY_DEBUG, 1)
     ],
     [dev_nodebug], [

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -22,10 +22,11 @@ capstone = { version = "0.12.0", optional = true }
 [features]
 # Support --yjit-dump-disasm and RubyVM::YJIT.disasm using libcapstone.
 disasm = ["capstone"]
-# Modify generated code for assertions. This is managed separately
+# Modify generated code for assertions, e.g. and poison value in PC
+# for C method calls and stack canary. This is managed separately
 # from cfg!(debug_assertions) so that we can see disasm of the code
 # that would run in the release mode.
-runtime_assertions = []
+runtime_checks = []
 
 [profile.dev]
 opt-level = 0

--- a/yjit/Cargo.toml
+++ b/yjit/Cargo.toml
@@ -17,11 +17,15 @@ crate-type = ["staticlib"]
 # written rationale. Optional For development and testing purposes
 capstone = { version = "0.12.0", optional = true }
 
-[features]
 # NOTE: Development builds select a set of these via configure.ac
 # For debugging, `make V=1` shows exact cargo invocation.
+[features]
+# Support --yjit-dump-disasm and RubyVM::YJIT.disasm using libcapstone.
 disasm = ["capstone"]
-stats = []
+# Modify generated code for assertions. This is managed separately
+# from cfg!(debug_assertions) so that we can see disasm of the code
+# that would run in the release mode.
+runtime_assertions = []
 
 [profile.dev]
 opt-level = 0

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1759,7 +1759,7 @@ impl Assembler {
 
         // If the slot is already used, which is a valid optimization to avoid spills,
         // give up the verification.
-        let canary_opnd = if cfg!(debug_assertions) && self.leaf_ccall && opnds.iter().all(|opnd|
+        let canary_opnd = if cfg!(feature = "runtime_assertions") && self.leaf_ccall && opnds.iter().all(|opnd|
             opnd.get_reg_opnd() != canary_opnd.get_reg_opnd()
         ) {
             asm_comment!(self, "set stack canary");

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1759,7 +1759,7 @@ impl Assembler {
 
         // If the slot is already used, which is a valid optimization to avoid spills,
         // give up the verification.
-        let canary_opnd = if cfg!(feature = "runtime_assertions") && self.leaf_ccall && opnds.iter().all(|opnd|
+        let canary_opnd = if cfg!(feature = "runtime_checks") && self.leaf_ccall && opnds.iter().all(|opnd|
             opnd.get_reg_opnd() != canary_opnd.get_reg_opnd()
         ) {
             asm_comment!(self, "set stack canary");

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -8385,12 +8385,6 @@ fn gen_send_dynamic<F: Fn(&mut Assembler) -> Opnd>(
     // Save PC and SP to prepare for dynamic dispatch
     jit_prepare_non_leaf_call(jit, asm);
 
-    // Squash stack canary that might be left over from elsewhere
-    assert_eq!(false, asm.get_leaf_ccall());
-    if cfg!(debug_assertions) {
-        asm.store(asm.ctx.sp_opnd(0), 0.into());
-    }
-
     // Dispatch a method
     let ret = vm_sendish(asm);
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6587,7 +6587,7 @@ fn gen_send_cfunc(
         cme,
         recv,
         sp,
-        pc: if cfg!(debug_assertions) {
+        pc: if cfg!(feature = "runtime_assertions") {
             Some(!0) // Poison value. Helps to fail fast.
         } else {
             None     // Leave PC uninitialized as cfuncs shouldn't read it

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6587,7 +6587,7 @@ fn gen_send_cfunc(
         cme,
         recv,
         sp,
-        pc: if cfg!(feature = "runtime_assertions") {
+        pc: if cfg!(feature = "runtime_checks") {
             Some(!0) // Poison value. Helps to fail fast.
         } else {
             None     // Leave PC uninitialized as cfuncs shouldn't read it


### PR DESCRIPTION
* Add `runtime_assertions` feature to the cargo config
    * To check the quality of the generated code that would run in the release mode, I sometimes want to see the disasm of generated code without runtime assertions like "set stack canary".
    * Having this feature (separately from `cfg!(debug_assertions)`) allows `--enable-yjit=dev_nodebug` to disasm code without runtime assertions while enabling other compile-time assertions.
* Drop `stats` feature from cargo
    * This is no longer used. All stats implemented in YJIT's code are available in the release mode as well. I still left `--enable-yjit=stats` for the `YJIT_STATS` macro in C code.