### PR TITLE
mustermann depends on URI::RFC2396_PARSER behavior

### DIFF
--- a/spec/bundler/install/gems/dependency_api_fallback_spec.rb
+++ b/spec/bundler/install/gems/dependency_api_fallback_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe "gemcutter's dependency API" do
 
       require_relative "../../support/artifice/endpoint_timeout"
 
+      # mustermann depends on URI::RFC2396_PARSER behavior
+      URI.parser = URI::RFC2396_PARSER if URI.respond_to?(:parser=)
+
       @t = Thread.new do
         server = Rack::Server.start(app: EndpointTimeout,
                                     Host: "0.0.0.0",
@@ -31,6 +34,8 @@ RSpec.describe "gemcutter's dependency API" do
       Artifice.deactivate
       @t.kill
       @t.join
+
+      URI.parser = URI::DEFAULT_PARSER if URI.respond_to?(:parser=)
     end
 
     it "times out and falls back on the modern index" do


### PR DESCRIPTION
It's part of dependencies for Sinatra. we should fix mustermann before final release of Ruby 3.4