### PR TITLE
[PRISM] Fix compiler warnings about signedness

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -5676,7 +5676,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             // own arrays, followed by a newarray, and then continually
             // concat the arrays with the SplatNode nodes.
             const int max_new_array_size = 0x100;
-            const int min_tmp_array_size = 0x40;
+            const unsigned int min_tmp_array_size = 0x40;
 
             int new_array_size = 0;
             bool first_chunk = true;

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1360,7 +1360,7 @@ pm_compile_hash_elements(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
     // by newhash or hash merge). Double splat nodes should be merged using the
     // merge_kwd method call.
     const int max_stack_length = 0x100;
-    const int min_tmp_hash_length = 0x800;
+    const unsigned int min_tmp_hash_length = 0x800;
 
     int stack_length = 0;
     bool first_chunk = true;


### PR DESCRIPTION
Fixes:

```
prism_compile.c:1406:27: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
 1406 |                 if (count >= min_tmp_hash_length) {
      |                           ^~
prism_compile.c:5770:40: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
 5770 |                     if (tmp_array_size >= min_tmp_array_size) {
      |                                        ^~
```