### PR TITLE
Make rb_check_frozen_inline() static inline again

### DIFF
--- a/error.c
+++ b/error.c
@@ -4001,13 +4001,7 @@ rb_error_frozen_object(VALUE frozen_obj)
 void
 rb_check_frozen(VALUE obj)
 {
-    if (RB_UNLIKELY(RB_OBJ_FROZEN(obj))) {
-        rb_error_frozen_object(obj);
-    }
-
-    if (RB_UNLIKELY(CHILLED_STRING_P(obj))) {
-        rb_str_modify(obj);
-    }
+    rb_check_frozen_inline(obj);
 }
 
 void


### PR DESCRIPTION
Since 730e3b2ce01915c4a98b79bb281b2c38a9ff1131
("Stop exposing `rb_str_chilled_p`"), we noticed a speed loss on a few
benchmarks that are string operations heavy. This is partially due to
routines no longer having the options to inline rb_check_frozen_inline()
in non-LTO builds. Make it an inlining candidate again to recover speed.

On the fannkuchredux benchmark, this patch gives a 1.15 speed-up with
YJIT and 1.03 without YJIT.

```
ruby-master: ruby 3.4.0dev (2024-07-19T15:45:31Z master e801fa5ce8) [x86_64-linux]
yjit-post: ruby 3.4.0dev (2024-07-19T19:56:00Z frozen 1d8e422723) [x86_64-linux]

-------------  ----------------  ----------  --------------  ----------  -----------------  ---------------------
bench          ruby-master (ms)  stddev (%)  yjit-post (ms)  stddev (%)  yjit-post 1st itr  ruby-master/yjit-post
fannkuchredux  2350.9            0.1         2283.6          0.1         1.03               1.03                 
-------------  ----------------  ----------  --------------  ----------  -----------------  ---------------------

ruby-master: ruby 3.4.0dev (2024-07-19T15:45:31Z master e801fa5ce8) +YJIT [x86_64-linux]
yjit-post: ruby 3.4.0dev (2024-07-19T19:56:00Z frozen 1d8e422723) +YJIT [x86_64-linux]

-------------  ----------------  ----------  --------------  ----------  -----------------  ---------------------
bench          ruby-master (ms)  stddev (%)  yjit-post (ms)  stddev (%)  yjit-post 1st itr  ruby-master/yjit-post
fannkuchredux  836.0             0.0         725.7           0.0         1.03               1.15                 
-------------  ----------------  ----------  --------------  ----------  -----------------  ---------------------
```

cc @byroot 
