### PR TITLE
Do not set Enumerator::Lazy#zip to use packed format

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -2400,7 +2400,6 @@ lazy_zip_func(VALUE proc_entry, struct MEMO *result, VALUE memos, long memo_inde
         rb_ary_push(ary, v);
     }
     LAZY_MEMO_SET_VALUE(result, ary);
-    LAZY_MEMO_SET_PACKED(result);
     return result;
 }
 

--- a/test/ruby/test_lazy_enumerator.rb
+++ b/test/ruby/test_lazy_enumerator.rb
@@ -489,6 +489,10 @@ EOS
     assert_equal [1, 2, 3], enum.map { |x| x / 2 }
   end
 
+  def test_lazy_zip_map_yield_arity_bug_20623
+    assert_equal([[1, 2]], [1].lazy.zip([2].lazy).map { |x| x }.force)
+  end
+
   def test_lazy_to_enum
     lazy = [1, 2, 3].lazy
     def lazy.foo(*args)


### PR DESCRIPTION
Enumerator#zip yields a single array, not multiple arguments, so Enumerator::Lazy#zip should do the same.