### PR TITLE
Change UNDEF Node structure

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -334,6 +334,24 @@ dump_array(VALUE ast_value, const struct RNode_LIST *node)
 }
 
 static VALUE
+dump_parser_array(VALUE ast_value, rb_parser_ary_t *p_ary)
+{
+    VALUE ary;
+
+    if (p_ary->data_type != PARSER_ARY_DATA_NODE) {
+        rb_bug("unexpected rb_parser_ary_data_type: %d", p_ary->data_type);
+    }
+
+    ary = rb_ary_new();
+
+    for (long i = 0; i < p_ary->len; i++) {
+        rb_ary_push(ary, NEW_CHILD(ast_value, p_ary->data[i]));
+    }
+
+    return ary;
+}
+
+static VALUE
 var_name(ID id)
 {
     if (!id) return Qnil;
@@ -577,7 +595,7 @@ node_children(VALUE ast_value, const NODE *node)
       case NODE_VALIAS:
         return rb_ary_new_from_args(2, ID2SYM(RNODE_VALIAS(node)->nd_alias), ID2SYM(RNODE_VALIAS(node)->nd_orig));
       case NODE_UNDEF:
-        return rb_ary_new_from_node_args(ast_value, 1, RNODE_UNDEF(node)->nd_undef);
+        return rb_ary_new_from_args(1, dump_parser_array(ast_value, RNODE_UNDEF(node)->nd_undefs));
       case NODE_CLASS:
         return rb_ary_new_from_node_args(ast_value, 3, RNODE_CLASS(node)->nd_cpath, RNODE_CLASS(node)->nd_super, RNODE_CLASS(node)->nd_body);
       case NODE_MODULE:

--- a/compile.c
+++ b/compile.c
@@ -11016,10 +11016,18 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const no
         break;
       }
       case NODE_UNDEF:{
-        ADD_INSN1(ret, node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
-        ADD_INSN1(ret, node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_CBASE));
-        CHECK(COMPILE(ret, "undef arg", RNODE_UNDEF(node)->nd_undef));
-        ADD_SEND(ret, node, id_core_undef_method, INT2FIX(2));
+        const rb_parser_ary_t *ary = RNODE_UNDEF(node)->nd_undefs;
+
+        for (long i = 0; i < ary->len; i++) {
+            ADD_INSN1(ret, node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
+            ADD_INSN1(ret, node, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_CBASE));
+            CHECK(COMPILE(ret, "undef arg", ary->data[i]));
+            ADD_SEND(ret, node, id_core_undef_method, INT2FIX(2));
+
+            if (i < ary->len - 1) {
+                ADD_INSN(ret, node, pop);
+            }
+        }
 
         if (popped) {
             ADD_INSN(ret, node, pop);

--- a/node.c
+++ b/node.c
@@ -163,6 +163,14 @@ parser_tokens_free(rb_ast_t *ast, rb_parser_ary_t *tokens)
 }
 
 static void
+parser_nodes_free(rb_ast_t *ast, rb_parser_ary_t *nodes)
+{
+    /* Do nothing for nodes because nodes are freed when rb_ast_t is freed */
+    xfree(nodes->data);
+    xfree(nodes);
+}
+
+static void
 free_ast_value(rb_ast_t *ast, void *ctx, NODE *node)
 {
     switch (nd_type(node)) {
@@ -205,6 +213,9 @@ free_ast_value(rb_ast_t *ast, void *ctx, NODE *node)
         break;
       case NODE_IMAGINARY:
         xfree(RNODE_IMAGINARY(node)->val);
+        break;
+      case NODE_UNDEF:
+        parser_nodes_free(ast, RNODE_UNDEF(node)->nd_undefs);
         break;
       default:
         break;

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -225,7 +225,8 @@ typedef void* rb_parser_ary_data;
 
 enum rb_parser_ary_data_type {
     PARSER_ARY_DATA_AST_TOKEN = 1,
-    PARSER_ARY_DATA_SCRIPT_LINE
+    PARSER_ARY_DATA_SCRIPT_LINE,
+    PARSER_ARY_DATA_NODE
 };
 
 typedef struct rb_parser_ary {
@@ -885,7 +886,7 @@ typedef struct RNode_VALIAS {
 typedef struct RNode_UNDEF {
     NODE node;
 
-    struct RNode *nd_undef;
+    rb_parser_ary_t *nd_undefs;
 } rb_node_undef_t;
 
 typedef struct RNode_CLASS {


### PR DESCRIPTION
Change UNDEF Node to hold their items to keep the original grammar structure.

For example:

```
undef a, b
```

Before:

```
@ NODE_BLOCK (id: 4, line: 1, location: (1,6)-(1,10))*
+- nd_head (1):
|   @ NODE_UNDEF (id: 1, line: 1, location: (1,6)-(1,7))
|   +- nd_undef:
|       @ NODE_SYM (id: 0, line: 1, location: (1,6)-(1,7))
|       +- string: :a
+- nd_head (2):
    @ NODE_UNDEF (id: 3, line: 1, location: (1,9)-(1,10))
    +- nd_undef:
        @ NODE_SYM (id: 2, line: 1, location: (1,9)-(1,10))
        +- string: :b
```

After:

```
@ NODE_UNDEF (id: 1, line: 1, location: (1,6)-(1,10))*
+- nd_undefs:
    +- length: 2
    +- element (0):
    |   @ NODE_SYM (id: 0, line: 1, location: (1,6)-(1,7))
    |   +- string: :a
    +- element (1):
        @ NODE_SYM (id: 2, line: 1, location: (1,9)-(1,10))
        +- string: :b
```