### PR TITLE
Include `undef` keyword into UNDEF NODE location

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -3155,6 +3155,7 @@ stmt		: keyword_alias fitem {SET_LEX_STATE(EXPR_FNAME|EXPR_FITEM);} fitem
                     }
                 | keyword_undef undef_list
                     {
+                        nd_set_first_loc($2, @1.beg_pos);
                         $$ = $2;
                     /*% ripper: undef!($:2) %*/
                     }


### PR DESCRIPTION
For example:

```
undef a, b
```

Before:

```
@ NODE_UNDEF (id: 1, line: 1, location: (1,6)-(1,10))*
```

After:

```
@ NODE_UNDEF (id: 1, line: 1, location: (1,0)-(1,10))*
```