### PR TITLE
[PRISM] Fix memory leak in constants

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -10289,7 +10289,7 @@ pm_parse_process(pm_parse_result_t *result, pm_node_t *node)
     // Now set up the constant pool and intern all of the various constants into
     // their corresponding IDs.
     scope_node->parser = parser;
-    scope_node->constants = calloc(parser->constant_pool.size, sizeof(ID));
+    scope_node->constants = xcalloc(parser->constant_pool.size, sizeof(ID));
 
     for (uint32_t index = 0; index < parser->constant_pool.size; index++) {
         pm_constant_t *constant = &parser->constant_pool.constants[index];

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -9744,6 +9744,8 @@ pm_parse_result_free(pm_parse_result_t *result)
 {
     if (result->parsed) {
         pm_node_destroy(&result->parser, result->node.ast_node);
+
+        xfree(result->node.constants);
         pm_scope_node_destroy(&result->node);
     }
 


### PR DESCRIPTION
For example, the following code leaks:

```ruby
code = 1000.times.map { |i| "var#{i} = 1" }.join("\n")

10.times do
  1000.times do
    RubyVM::InstructionSequence.compile_prism(code)
  end

  puts `ps -o rss= -p #{$$}`
end
```

Before:

    70384
    88032
    103856
    115712
    125584
    132768
    144784
    152624
    165296
    180608

After:

    62368
    78784
    74512
    87712
    85072
    77728
    69424
    74992
    71264
    81440