### PR TITLE
Add branch prediction annotations for object allocation

### DIFF
--- a/gc/default.c
+++ b/gc/default.c
@@ -2450,7 +2450,7 @@ ractor_cache_allocate_slot(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *ca
     rb_ractor_newobj_size_pool_cache_t *size_pool_cache = &cache->size_pool_caches[size_pool_idx];
     struct free_slot *p = size_pool_cache->freelist;
 
-    if (is_incremental_marking(objspace)) {
+    if (RB_UNLIKELY(is_incremental_marking(objspace))) {
         // Not allowed to allocate without running an incremental marking step
         if (cache->incremental_mark_step_allocated_slots >= INCREMENTAL_MARK_STEP_ALLOCATIONS) {
             return Qfalse;
@@ -2461,7 +2461,7 @@ ractor_cache_allocate_slot(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *ca
         }
     }
 
-    if (p) {
+    if (RB_LIKELY(p)) {
         VALUE obj = (VALUE)p;
         MAYBE_UNUSED(const size_t) stride = size_pool_slot_size(size_pool_idx);
         size_pool_cache->freelist = p->next;


### PR DESCRIPTION
<https://speed.yjit.org> alerted us that compared to 98eeadc93298b2f178d400d99f3921e3663369b6, `master` is noticeably slower. Part of that is because object allocation got slower. Testing the following script, `master` takes about 1.15 times as long as the 98eeadc93298b2f178d400d99f3921e3663369b6 baseline.

```ruby
i = 0
while i < 10_000_000
  Object.new
  i = i.succ
end
```

We figured out the interpreter loop is responsible for 0.05 of that, which we need to investigate separately. This PR improves the ratio to 1.1.

~~@peterzhu2118 added the atomic increment to avoid some concurrency issue with Ractors, though, which is why this PR is draft.~~ ref #11233 