### PR TITLE
[Feature #20624] Enhance `RubyVM::AbstractSyntaxTree::Node#locations`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,12 @@ Note: We're only listing outstanding class updates.
 
   * Range#size now raises TypeError if the range is not iterable. [[Misc #18984]]
 
+* RubyVM::AbstractSyntaxTree
+
+  * Add `RubyVM::AbstractSyntaxTree::Node#locations` method which returns location objects
+    associated with the AST node. [[Feature #20624]]
+  * Add `RubyVM::AbstractSyntaxTree::Location` class which holds location information. [[Feature #20624]]
+
 ## Stdlib updates
 
 * Tempfile
@@ -160,3 +166,4 @@ See GitHub releases like [GitHub Releases of Logger](https://github.com/ruby/log
 [Feature #20429]: https://bugs.ruby-lang.org/issues/20429
 [Feature #20443]: https://bugs.ruby-lang.org/issues/20443
 [Feature #20497]: https://bugs.ruby-lang.org/issues/20497
+[Feature #20624]: https://bugs.ruby-lang.org/issues/20624

--- a/ast.rb
+++ b/ast.rb
@@ -272,5 +272,62 @@ module RubyVM::AbstractSyntaxTree
         nil
       end
     end
+
+    #  call-seq:
+    #     node.locations -> array
+    #
+    #  Returns location objects associated with the AST node.
+    #  The returned array contains RubyVM::AbstractSyntaxTree::Location.
+    def locations
+      Primitive.ast_node_locations
+    end
+  end
+
+  # RubyVM::AbstractSyntaxTree::Location instances are created by
+  # RubyVM::AbstractSyntaxTree#locations.
+  #
+  # This class is MRI specific.
+  #
+  class Location
+
+    #  call-seq:
+    #     location.first_lineno -> integer
+    #
+    #  The line number in the source code where this AST's text began.
+    def first_lineno
+      Primitive.ast_location_first_lineno
+    end
+
+    #  call-seq:
+    #     location.first_column -> integer
+    #
+    #  The column number in the source code where this AST's text began.
+    def first_column
+      Primitive.ast_location_first_column
+    end
+
+    #  call-seq:
+    #     location.last_lineno -> integer
+    #
+    #  The line number in the source code where this AST's text ended.
+    def last_lineno
+      Primitive.ast_location_last_lineno
+    end
+
+    #  call-seq:
+    #     location.last_column -> integer
+    #
+    #  The column number in the source code where this AST's text ended.
+    def last_column
+      Primitive.ast_location_last_column
+    end
+
+    #  call-seq:
+    #     location.inspect -> string
+    #
+    #  Returns debugging information about this location as a string.
+    def inspect
+      Primitive.ast_location_inspect
+    end
   end
 end

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1297,6 +1297,13 @@ dummy
     end;
   end
 
+  def test_locations
+    node = RubyVM::AbstractSyntaxTree.parse("1 + 2")
+    locations = node.locations
+
+    assert_equal(RubyVM::AbstractSyntaxTree::Location, locations[0].class)
+  end
+
   private
 
   def assert_error_tolerant(src, expected, keep_tokens: false)
@@ -1315,5 +1322,17 @@ dummy
     PP.pp(node, str, 80)
     assert_equal(expected, str)
     node
+  end
+
+  class TestLocation < Test::Unit::TestCase
+    def test_lineno_and_column
+      node = RubyVM::AbstractSyntaxTree.parse("1 + 2")
+      location = node.locations[0]
+
+      assert_equal(1, location.first_lineno)
+      assert_equal(0, location.first_column)
+      assert_equal(1, location.last_lineno)
+      assert_equal(5, location.last_column)
+    end
   end
 end


### PR DESCRIPTION
This commit introduce `RubyVM::AbstractSyntaxTree::Node#locations` method and `RubyVM::AbstractSyntaxTree::Location` class.

Ruby AST node will hold multiple locations information. `RubyVM::AbstractSyntaxTree::Node#locations` provides a way to access these locations information.

`RubyVM::AbstractSyntaxTree::Location` is a class which holds these location information:

* `#first_lineno`
* `#first_column`
* `#last_lineno`
* `#last_column`