### PR TITLE
[Prism] Use `putnil` for nil kwargs, not `putobject {}`

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1475,7 +1475,7 @@ pm_compile_hash_elements(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
                     // This is only done for method calls and not for literal
                     // hashes, because literal hashes should always result in a
                     // new hash.
-                    PUSH_INSN1(ret, location, putobject, rb_hash_new());
+                    PUSH_INSN(ret, location, putnil);
                 }
                 else if (first_element) {
                     // **{} appears as the first keyword argument, so it may be


### PR DESCRIPTION
This addresses one of the issues in the `test_kw_splat_nil` failure, but doesn't make the test pass because of other changes that need to be made to Prism directly.

One issue was when we have the following code Prism was using `putobject` with an empty hash whereas the parse.y parser used `putnil`.

```ruby
:ok.itself(**nil)
```

Before:

```
0000 putobject                              :ok                       (   1)[Li]
0002 putobject                              {}
0004 opt_send_without_block                 <calldata!mid:itself, argc:1, KW_SPLAT>
0006 leave
```

After:

```
== disasm: #<ISeq:<main>@test2.rb:1 (1,0)-(1,17)>
0000 putobject                              :ok                       (   1)[Li]
0002 putnil
0003 opt_send_without_block                 <calldata!mid:itself, argc:1, KW_SPLAT>
0005 leave
```

Related to ruby/prism#2935.

cc/ @kddnewton 