### PR TITLE
[Bug #20649] Allow `nil` as 2nd argument of `assign_error`

### DIFF
--- a/ext/ripper/lib/ripper/lexer.rb
+++ b/ext/ripper/lib/ripper/lexer.rb
@@ -242,7 +242,12 @@ class Ripper
     end
 
     def on_error2(mesg, elem)
-      @errors.push Elem.new(elem.pos, __callee__, elem.tok, elem.state, mesg)
+      if elem
+        elem = Elem.new(elem.pos, __callee__, elem.tok, elem.state, mesg)
+      else
+        elem = Elem.new([lineno(), column()], __callee__, token(), state(), mesg)
+      end
+      @errors.push elem
     end
     PARSER_EVENTS.grep(/_error\z/) do |e|
       arity = PARSER_EVENT_TABLE.fetch(e)

--- a/test/ripper/test_scanner_events.rb
+++ b/test/ripper/test_scanner_events.rb
@@ -53,6 +53,8 @@ class TestRipper::ScannerEvents < Test::Unit::TestCase
                  Ripper.tokenize("1  .foo\n")
     assert_equal ["1", "\n", "  ", ".", "foo", "\n"],
                  Ripper.tokenize("1\n  .foo\n")
+    assert_equal ["def", " ", "f", ";", " ", "(", "x", ")", "::", "A", " ", "="],
+                 Ripper.tokenize("def f; (x)::A =")
   end
 
   def test_lex


### PR DESCRIPTION
Fallback to the last token element in that case, for the backward compatibilities.

https://bugs.ruby-lang.org/issues/20649