### PR TITLE
Fix test_kwarg_eval_memory_leak

### DIFF
--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -1618,8 +1618,11 @@ class TestMethod < Test::Unit::TestCase
 
   def test_kwarg_eval_memory_leak
     assert_no_memory_leak([], "", <<~RUBY, rss: true, limit: 1.2)
+      obj = Object.new
+      def obj.test(**kwargs) = nil
+
       100_000.times do
-        eval("Hash.new(foo: 123)")
+        eval("obj.test(foo: 123)")
       end
     RUBY
   end


### PR DESCRIPTION
Hash.new no longer takes keyword arguments except for capacity, so we should just use a method that takes keyword arguments instead.