### PR TITLE
[Bug #20653] Fix memory leak in String#start_with? when regexp times out

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -5575,8 +5575,7 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
 
 timeout:
   MATCH_ARG_FREE(msa);
-  onig_region_free(region, false);
-  HANDLE_REG_TIMEOUT_IN_MATCH_AT;
+  return ONIGERR_TIMEOUT;
 }
 
 extern OnigPosition

--- a/regint.h
+++ b/regint.h
@@ -163,9 +163,6 @@
     rb_thread_check_ints(); \
   } \
 } while(0)
-# define HANDLE_REG_TIMEOUT_IN_MATCH_AT do { \
-  rb_reg_raise_timeout(); \
-} while (0)
 # define onig_st_init_table                  st_init_table
 # define onig_st_init_table_with_size        st_init_table_with_size
 # define onig_st_init_numtable               st_init_numtable
@@ -1002,7 +999,6 @@ extern int onig_st_insert_strend(hash_table_type* table, const UChar* str_key, c
 extern size_t onig_memsize(const regex_t *reg);
 extern size_t onig_region_memsize(const struct re_registers *regs);
 bool rb_reg_timeout_p(regex_t *reg, void *end_time);
-NORETURN(void rb_reg_raise_timeout(void));
 #endif
 
 RUBY_SYMBOL_EXPORT_END

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1971,6 +1971,22 @@ CODE
     assert_nil($&)
   end
 
+  def test_start_with_timeout_memory_leak
+    assert_no_memory_leak([], "#{<<~"begin;"}", "#{<<~'end;'}", "[Bug #20653]", rss: true)
+      regex = Regexp.new("^#{"(a*)" * 10_000}x$", timeout: 0.000001)
+      str = "a" * 1_000_000 + "x"
+
+      code = proc do
+        str.start_with?(regex)
+      rescue
+      end
+
+      10.times(&code)
+    begin;
+      1_000.times(&code)
+    end;
+  end
+
   def test_strip
     assert_equal(S("x"), S("      x        ").strip)
     assert_equal(S("x"), S(" \n\r\t     x  \t\r\n\n      ").strip)


### PR DESCRIPTION
This commit refactors how Onigmo handles timeout. Instead of raising a timeout error, onig_search will return a ONIGERR_TIMEOUT which the caller can free memory, and then raise a timeout error.

This fixes a memory leak in String#start_with when the regexp times out. For example:

```ruby
regex = Regexp.new("^#{"(a*)" * 10_000}x$", timeout: 0.000001)
str = "a" * 1000000 + "x"

10.times do
  100.times do
    str.start_with?(regex)
  rescue
  end

  puts `ps -o rss= -p #{$$}`
end
```

Before:

```
33216
51936
71152
81728
97152
103248
120384
133392
133520
133616
```

After:

```
14912
15376
15824
15824
16128
16128
16144
16144
16160
16160
```