### PR TITLE
[DOC] rb_ary_s_create

### DIFF
--- a/array.c
+++ b/array.c
@@ -1159,11 +1159,11 @@ rb_ary_initialize(int argc, VALUE *argv, VALUE ary)
 }
 
 /*
- * Returns a new array populated with the given objects.
+ * Returns a new +Array+ object, populated with the given objects:
  *
- *   Array.[]( 1, 'a', /^A/)  # => [1, "a", /^A/]
- *   Array[ 1, 'a', /^A/ ]    # => [1, "a", /^A/]
- *   [ 1, 'a', /^A/ ]         # => [1, "a", /^A/]
+ *   Array.[]( 1, 'a', /^A/) # => [1, "a", /^A/]
+ *   Array.[]                # => []
+ *
  */
 
 static VALUE

--- a/array.c
+++ b/array.c
@@ -1161,8 +1161,9 @@ rb_ary_initialize(int argc, VALUE *argv, VALUE ary)
 /*
  * Returns a new +Array+ object, populated with the given objects:
  *
- *   Array.[]( 1, 'a', /^A/) # => [1, "a", /^A/]
- *   Array.[]                # => []
+ *   Array[1, 'a', /^A/]    # => [1, "a", /^A/]
+ *   Array[]                # => []
+ *   Array.[](1, 'a', /^A/) # => [1, "a", /^A/]
  *
  */
 


### PR DESCRIPTION
Tune up Array::[].  Removes two examples that don't actually call Array::[].