### PR TITLE
[20656] Import Hash#except! from Active Support

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2659,6 +2659,33 @@ rb_hash_slice(int argc, VALUE *argv, VALUE hash)
 
 /*
  *  call-seq:
+ *     hsh.except!(*keys) -> a_hash
+ *
+ *  Returns +self+ excluding entries for the given +keys+:
+ *     h = { a: 100, b: 200, c: 300 }
+ *     h.except(:a)          #=> {:b=>200, :c=>300}
+ *
+ *  Any given +keys+ that are not found are ignored.
+ */
+
+static VALUE
+rb_hash_except_bang(int argc, VALUE *argv, VALUE hash)
+{
+    int i;
+    VALUE key;
+
+    rb_hash_modify_check(hash);
+
+    for (i = 0; i < argc; i++) {
+        key = argv[i];
+        rb_hash_delete_entry(hash, key);
+    }
+
+    return hash;
+}
+
+/*
+ *  call-seq:
  *     hsh.except(*keys) -> a_hash
  *
  *  Returns a new +Hash+ excluding entries for the given +keys+:
@@ -7176,6 +7203,7 @@ Init_Hash(void)
     rb_define_method(rb_cHash, "reject", rb_hash_reject, 0);
     rb_define_method(rb_cHash, "reject!", rb_hash_reject_bang, 0);
     rb_define_method(rb_cHash, "slice", rb_hash_slice, -1);
+    rb_define_method(rb_cHash, "except!", rb_hash_except_bang, -1);
     rb_define_method(rb_cHash, "except", rb_hash_except, -1);
     rb_define_method(rb_cHash, "clear", rb_hash_clear, 0);
     rb_define_method(rb_cHash, "invert", rb_hash_invert, 0);

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1096,6 +1096,22 @@ class TestHash < Test::Unit::TestCase
     assert_equal({}, {}.except)
   end
 
+  def test_except!
+    h = @cls[1=>2,3=>4,5=>6]
+    h.except!(1, 3)
+    assert_equal({5=>6}, h)
+
+    h = @cls[1=>2,3=>4,5=>6]
+    h.except!(7)
+    assert_equal({1=>2,3=>4,5=>6}, h)
+
+    h = @cls[1=>2,3=>4,5=>6]
+    h.except!
+    assert_equal({1=>2,3=>4,5=>6}, h)
+
+    assert_equal({}, {}.except!)
+  end
+
   def test_except_on_identhash
     h = @cls[1=>2,3=>4,5=>6]
     h.compare_by_identity


### PR DESCRIPTION
Fixes [#20656](https://bugs.ruby-lang.org/issues/20656).

Implementation: https://bugs.ruby-lang.org/issues/8499#note-30