### PR TITLE
Specify `LAST_NODE` for `NODE_DEFINED`

### DIFF
--- a/node_dump.c
+++ b/node_dump.c
@@ -1048,6 +1048,7 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("defined? expression");
         ANN("format: defined?([nd_head])");
         ANN("example: defined?(foo)");
+        LAST_NODE;
         F_NODE(nd_head, RNODE_DEFINED, "expr");
         return;
 


### PR DESCRIPTION
For example:

```
defined?(1)
```

Before:

```
# @ NODE_SCOPE (id: 2, line: 1, location: (1,0)-(1,11))
# +- nd_tbl: (empty)
# +- nd_args:
# |   (null node)
# +- nd_body:
#     @ NODE_DEFINED (id: 1, line: 1, location: (1,0)-(1,11))*
#     +- nd_head:
#     |   @ NODE_INTEGER (id: 0, line: 1, location: (1,9)-(1,10))
#     |   +- val: 1
```

After:

```
# @ NODE_SCOPE (id: 2, line: 1, location: (1,0)-(1,11))
# +- nd_tbl: (empty)
# +- nd_args:
# |   (null node)
# +- nd_body:
#     @ NODE_DEFINED (id: 1, line: 1, location: (1,0)-(1,11))*
#     +- nd_head:
#         @ NODE_INTEGER (id: 0, line: 1, location: (1,9)-(1,10))
#         +- val: 1
```