### PR TITLE
Fix wrong unreachable chunk remove when jump destination label is unremovable

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3054,7 +3054,6 @@ remove_unreachable_chunk(rb_iseq_t *iseq, LINK_ELEMENT *i)
                 break;
             }
             else if ((lab = find_destination((INSN *)i)) != 0) {
-                if (lab->unremovable) break;
                 unref_counts[lab->label_no]++;
             }
         }

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -813,6 +813,10 @@ class TestISeq < Test::Unit::TestCase
   end
 
   def test_unreachable_pattern_matching
+    assert_in_out_err([], "true or 1 in 1")
+  end
+
+  def test_unreachable_pattern_matching_in_if_condition
     assert_in_out_err([], "#{<<~"begin;"}\n#{<<~'end;'}", %w[1])
     begin;
       if true or {a: 0} in {a:}

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -814,6 +814,7 @@ class TestISeq < Test::Unit::TestCase
 
   def test_unreachable_pattern_matching
     assert_in_out_err([], "true or 1 in 1")
+    assert_in_out_err([], "true or (case 1; in 1; 1; in 2; 2; end)")
   end
 
   def test_unreachable_pattern_matching_in_if_condition


### PR DESCRIPTION
Fix `false && (1 in 1)` producing `argument stack underflow (-1)`
Fixes https://bugs.ruby-lang.org/issues/20651
Maybe related to https://github.com/ruby/ruby/pull/8381

Jump to unremovable label is not a sign of unreachable-end.

```
0001 putnil
0002 branchunless <L002>
0003 unreachable-start
0004 jump <L003> # jump to unremovable L003(because of refcnt) is removed now
0005 jump <L001> # I think jump to unremovable-flagged label can be removed too
<L001> [unremovable=1, refcnt=1] # but in that case, unremovable label is mostly(maybe always) inside unreachable chunk so remove is cancelled
0006 unreachable-end
<L002> [unremovable=0, refcnt=1]
<L003> [unremovable=0, refcnt=999]
```

These are the list of code that reaches `break;` removed in this pull request.
(Searched `**/*.rb` files and StringNode writen in `**/*.rb`)
```ruby
# spec/ruby/language/while_spec.rb
while ()
  a << :body_evaluated
end

# spec/ruby/language/while_spec.rb
i += 1 while ()

# test/prism/result/source_location_test.rb
case foo; in bar => baz; end

# test/ruby/test_iseq.rb
true or 1 in 1

# test/rubygems/test_gem_commands_exec_command.rb
# This is a valid ruby code
Building native extensions. This could take a while...
a-2
sometimes_used-2
with_platform-2
```

`true or 1 in 1` is fixed.
Result of `ruby --dump=insn -e "case foo; in bar => baz; end"` is changed a bit.
These two instructions began to remain in this pull request which was removed in `remove_unreachable_chunk`.
```
0017 putnil
0018 pop
```
I think this is a bugfix rather than a side effect because these two are not the only unreachable instructions followed by `jump`.
```
local table (size: 2, argc: 0 [opts: 0, rest: -1, post: 0, block: -1, kw: -1@-1, kwrest: -1])
[ 2] bar@0      [ 1] baz@1
0000 putnil                                                           (   1)[Li]
0001 putnil
0002 putobject                              false
0004 putnil
0005 putnil
0006 putself
0007 opt_send_without_block                 <calldata!mid:foo, argc:0, FCALL|VCALL|ARGS_SIMPLE>
0009 dup
0010 dup
0011 setlocal_WC_0                          bar@0
0013 setlocal_WC_0                          baz@1
0015 jump                                   65
0017 putnil                                 # REMAINS
0018 pop                                    # REMAINS
0019 putspecialobject                       1
0021 topn                                   4
0023 branchif                               41
0025 putobject                              NoMatchingPatternError
0027 putspecialobject                       1
0029 putobject                              "%p: %s"
0031 topn                                   4
0033 topn                                   7
0035 opt_send_without_block                 <calldata!mid:core#sprintf, argc:3, ARGS_SIMPLE>
0037 opt_send_without_block                 <calldata!mid:core#raise, argc:2, ARGS_SIMPLE>
0039 jump                                   61
0041 putobject                              NoMatchingPatternKeyError
0043 putspecialobject                       1
0045 putobject                              "%p: %s"
0047 topn                                   4
0049 topn                                   7
0051 opt_send_without_block                 <calldata!mid:core#sprintf, argc:3, ARGS_SIMPLE>
0053 topn                                   7
0055 topn                                   9
0057 opt_send_without_block                 <calldata!mid:new, argc:3, kw:[#<Symbol:0x000000000022a10c>,#<Symbol:0x000000000021610c>], KWARG>
0059 opt_send_without_block                 <calldata!mid:core#raise, argc:1, ARGS_SIMPLE>
0061 adjuststack                            7
0063 putnil
0064 leave
0065 adjuststack                            6
0067 putnil
0068 leave
```
