### PR TITLE
[Misc #20661] Stop retrying tests in `make test-all` command by default

### DIFF
--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -298,7 +298,7 @@ module Test
 
         opts.separator "parallel test options:"
 
-        options[:retry] = true
+        options[:retry] = false
 
         opts.on '-j N', '--jobs N', /\A(t)?(\d+)\z/, "Allow run tests with N jobs at once" do |_, t, a|
           options[:testing] = true & t # For testing

--- a/tool/test/testunit/test_parallel.rb
+++ b/tool/test/testunit/test_parallel.rb
@@ -179,7 +179,7 @@ module TestParallel
     end
 
     def test_should_retry_failed_on_workers
-      spawn_runner
+      spawn_runner "--retry"
       buf = Timeout.timeout(TIMEOUT) {@test_out.read}
       assert_match(/^Retrying\.+$/,buf)
     end
@@ -206,14 +206,14 @@ module TestParallel
     end
 
     def test_hungup
-      spawn_runner "--worker-timeout=1", "test4test_hungup.rb"
+      spawn_runner "--worker-timeout=1", "--retry", "test4test_hungup.rb"
       buf = Timeout.timeout(TIMEOUT) {@test_out.read}
       assert_match(/^Retrying hung up testcases\.+$/, buf)
       assert_match(/^2 tests,.* 0 failures,/, buf)
     end
 
     def test_retry_workers
-      spawn_runner "--worker-timeout=1", "test4test_slow_0.rb", "test4test_slow_1.rb", jobs: "2"
+      spawn_runner "--worker-timeout=1", "--retry", "test4test_slow_0.rb", "test4test_slow_1.rb", jobs: "2"
       buf = Timeout.timeout(TIMEOUT) {@test_out.read}
       assert_match(/^Retrying hung up testcases\.+$/, buf)
       assert_match(/^2 tests,.* 0 failures,/, buf)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20661