### PR TITLE
Fix memory leak reported in ripper tests

### DIFF
--- a/test/ripper/test_parser_events.rb
+++ b/test/ripper/test_parser_events.rb
@@ -22,12 +22,18 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
   end
 
   def compile_error(str)
-    parse(str, :compile_error) {|e, msg| return msg}
+    ret = nil
+    parse(str, :compile_error) { |e, msg| ret = msg }
+    ret
   end
 
   def warning(str)
-    tree = parse(str, :warning) {|e, *args| return args}
-    if block_given?
+    ret = nil
+    tree = parse(str, :warning) { |e, *args| ret = args }
+
+    if ret
+      ret
+    elsif block_given?
       yield tree
     else
       assert(false, "warning expected")
@@ -35,8 +41,12 @@ class TestRipper::ParserEvents < Test::Unit::TestCase
   end
 
   def warn(str)
-    tree = parse(str, :warn) {|e, *args| return args}
-    if block_given?
+    ret = nil
+    tree = parse(str, :warn) { |e, *args| ret = args }
+
+    if ret
+      ret
+    elsif block_given?
       yield tree
     else
       assert(false, "warning expected")

--- a/test/ripper/test_scanner_events.rb
+++ b/test/ripper/test_scanner_events.rb
@@ -1013,7 +1013,8 @@ class TestRipper::ScannerEvents < Test::Unit::TestCase
 
   def test_error_token
     src = "{a:,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n""hello}"
-    err = scan('parse_error', src) {|*e| break e}
+    err = nil
+    scan('parse_error', src) {|*e| err = e}
     assert_equal "", err[2]
   end
 end if ripper_test


### PR DESCRIPTION
There's memory leaks reported in ripper tests because it returns out of the Ripper#compile_error, Ripper#warn, Ripper#warning methods, so the parsing is abruptly terminated and cannot clean up.