### PR TITLE
Reset the test internal counter for two consecutive runs

### DIFF
--- a/ext/-test-/ensure_and_callcc/ensure_and_callcc.c
+++ b/ext/-test-/ensure_and_callcc/ensure_and_callcc.c
@@ -40,11 +40,19 @@ ensure_called(VALUE self)
     return rb_iv_get(rb_mEnsureAndCallcc, "@ensure_called");
 }
 
+static VALUE
+reset(VALUE self)
+{
+    rb_iv_set(rb_mEnsureAndCallcc, "@ensure_called", INT2FIX(0));
+    return Qnil;
+}
+
 void
 Init_ensure_and_callcc(void)
 {
     rb_mEnsureAndCallcc = rb_define_module("EnsureAndCallcc");
     rb_iv_set(rb_mEnsureAndCallcc, "@ensure_called", INT2FIX(0));
+    rb_define_singleton_method(rb_mEnsureAndCallcc, "reset", reset, 0);
     rb_define_singleton_method(rb_mEnsureAndCallcc, "ensure_called", ensure_called, 0);
     rb_define_singleton_method(rb_mEnsureAndCallcc, "require_with_ensure", require_with_ensure, 1);
 }

--- a/test/-ext-/test_ensure_and_callcc.rb
+++ b/test/-ext-/test_ensure_and_callcc.rb
@@ -23,6 +23,7 @@ class TestEnsureAndCallcc < Test::Unit::TestCase
   def test_bug20655_extension_using_rb_ensure
     need_continuation
     require '-test-/ensure_and_callcc'
+    EnsureAndCallcc.reset
     assert_equal(0, EnsureAndCallcc.ensure_called)
     EnsureAndCallcc.require_with_ensure(File.join(__dir__, 'required'))
     assert_equal(1, EnsureAndCallcc.ensure_called,


### PR DESCRIPTION
The test `test/-ext-/test_ensure_and_callcc.rb` fails when it runs with the `--repeat-count=2` option.
This change is to fix the issue by resetting the internal counter in the test case.