### PR TITLE
Automated release package publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,9 @@ jobs:
 
       - name: Convert tag name to dot from underscore
         run: |
-            # vX_Y_Z to X.Y.Z
-            echo "RUBY_VERSION=$(echo ${{ github.ref }} | sed 's/v\([0-9]*\)_\([0-9]*\)_\([0-9]*\)/\1.\2.\3/')" >> $GITHUB_ENV
+            # Convert refs/tags/vX_Y_Z to X.Y.Z
+            echo "RUBY_VERSION=$(echo ${{ github.ref }} | sed -e 's/refs\/tags\/v//;s/_/./g')" >> $GITHUB_ENV
+
       - name: Build and push Docker images
         run: |
           curl -L -X POST \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish Ruby packages
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set latest flag for Ruby 3.3
+        if: contains(github.ref, 'v3_3')
+        run: |
+          echo "LATEST=true" >> $GITHUB_ENV
+
+      - name: Convert tag name to dot from underscore
+        run: |
+            # vX_Y_Z to X.Y.Z
+            echo "RUBY_VERSION=$(echo ${{ github.ref }} | sed 's/v\([0-9]*\)_\([0-9]*\)_\([0-9]*\)/\1.\2.\3/')" >> $GITHUB_ENV
+      - name: Build and push Docker images
+        run: |
+          curl -L -X POST \
+            -H "Authorization: Bearer ${{ secrets.MATZBOT_GITHUB_WORKFLOW_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/ruby/docker-images/dispatches \
+            -d '{"event_type": "build", "client_payload": {"ruby_version": "${{ env.RUBY_VERSION }}", "arch": "amd64", "latest": "${{ env.LATEST }}"}}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish Ruby packages
+name: Start release workflow
 on:
   push:
     tags:
@@ -8,16 +8,6 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - name: Set latest flag for Ruby 3.3
-        if: contains(github.ref, 'v3_3')
-        run: |
-          echo "LATEST=true" >> $GITHUB_ENV
-
-      - name: Convert tag name to dot from underscore
-        run: |
-            # Convert refs/tags/vX_Y_Z to X.Y.Z
-            echo "RUBY_VERSION=$(echo ${{ github.ref }} | sed -e 's/refs\/tags\/v//;s/_/./g')" >> $GITHUB_ENV
-
       - name: Build release package
         run: |
           curl -L -X POST \
@@ -26,12 +16,3 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/ruby/actions/dispatches \
             -d '{"event_type": "${{ github.ref }}"}'
-
-      - name: Build and push Docker images
-        run: |
-          curl -L -X POST \
-            -H "Authorization: Bearer ${{ secrets.MATZBOT_GITHUB_WORKFLOW_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/ruby/docker-images/dispatches \
-            -d '{"event_type": "build", "client_payload": {"ruby_version": "${{ env.RUBY_VERSION }}", "arch": "amd64", "latest": "${{ env.LATEST }}"}}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,15 @@ jobs:
             # Convert refs/tags/vX_Y_Z to X.Y.Z
             echo "RUBY_VERSION=$(echo ${{ github.ref }} | sed -e 's/refs\/tags\/v//;s/_/./g')" >> $GITHUB_ENV
 
+      - name: Build release package
+        run: |
+          curl -L -X POST \
+            -H "Authorization: Bearer ${{ secrets.MATZBOT_GITHUB_WORKFLOW_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/ruby/actions/dispatches \
+            -d '{"event_type": "${{ github.ref }}"}'
+
       - name: Build and push Docker images
         run: |
           curl -L -X POST \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,15 @@ jobs:
       # TODO
       # - name: Create a release on GitHub
 
+      - name: Update versions index
+        run: |
+          curl -L -X POST \
+            -H "Authorization: Bearer ${{ secrets.MATZBOT_GITHUB_WORKFLOW_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/ruby/actions/dispatches \
+            -d '{"event_type": "update_index"}'
+
       - name: Set latest flag for Ruby 3.3
         if: contains(${{ env.RUBY_VERSION }}, '3.3.')
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,3 +53,12 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/ruby/docker-images/dispatches \
             -d '{"event_type": "build", "client_payload": {"ruby_version": "${{ env.RUBY_VERSION }}", "arch": "amd64", "latest": "${{ env.LATEST }}"}}'
+
+      - name: Build snapcraft packages
+        run: |
+          curl -L -X POST \
+            -H "Authorization: Bearer ${{ secrets.MATZBOT_GITHUB_WORKFLOW_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/ruby/snap.ruby/dispatches \
+            -d '{"event_type": "build", "client_payload": {"ruby_version": "${{ env.RUBY_VERSION }}"}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Publish Ruby packages
+
+on:
+  repository_dispatch:
+    types:
+      - release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Copy draft package `/tmp` to `/pub` directory
+        run: tool/release.sh ${{ github.event.client_payload.version }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.FTP_R_L_O_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.FTP_R_L_O_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-west-2
+
+      # TODO
+      # - name: Create a release on GitHub
+
+      - name: Set latest flag for Ruby 3.3
+        if: contains(${{ github.event.client_payload.version }}, '3.3.')
+        run: |
+          echo "LATEST=true" >> $GITHUB_ENV
+
+      - name: Build and push Docker images
+        run: |
+          curl -L -X POST \
+            -H "Authorization: Bearer ${{ secrets.MATZBOT_GITHUB_WORKFLOW_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/ruby/docker-images/dispatches \
+            -d '{"event_type": "build", "client_payload": {"ruby_version": "${{ github.event.client_payload.version }}", "arch": "amd64", "latest": "${{ env.LATEST }}"}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   repository_dispatch:
     types:
       - release
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of the Ruby package to release'
+        required: true
+        default: '3.3.4'
 
 jobs:
   release:
@@ -11,8 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Store Ruby version
+        run: |
+          echo "RUBY_VERSION=${{ github.event.client_payload.version || github.event.inputs.version }}" >> $GITHUB_ENV
+
       - name: Copy draft package `/tmp` to `/pub` directory
-        run: tool/release.sh ${{ github.event.client_payload.version }}
+        run: tool/release.sh ${{ env.RUBY_VERSION }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.FTP_R_L_O_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.FTP_R_L_O_AWS_SECRET_ACCESS_KEY }}
@@ -22,7 +32,7 @@ jobs:
       # - name: Create a release on GitHub
 
       - name: Set latest flag for Ruby 3.3
-        if: contains(${{ github.event.client_payload.version }}, '3.3.')
+        if: contains(${{ env.RUBY_VERSION }}, '3.3.')
         run: |
           echo "LATEST=true" >> $GITHUB_ENV
 
@@ -33,4 +43,4 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/ruby/docker-images/dispatches \
-            -d '{"event_type": "build", "client_payload": {"ruby_version": "${{ github.event.client_payload.version }}", "arch": "amd64", "latest": "${{ env.LATEST }}"}}'
+            -d '{"event_type": "build", "client_payload": {"ruby_version": "${{ env.RUBY_VERSION }}", "arch": "amd64", "latest": "${{ env.LATEST }}"}}'


### PR DESCRIPTION
We should reduce amount of time for release workflow.

I would like to connect some of current release workflow. This PR makes the following chain:

1. The maintainer tagged like `v3_3_5` in this repo.
2. `publish.yml` (new) notify `draft-release.yml` at `ruby/actions`
3. <del>https://github.com/ruby/actions/pull/73 notify `release.yml` (new) at this repo when the all of tests are passed.</del>
4.  The maintainer confirm draft packages. After that, they can invoke `release.yml` with `workflow_dispatch`.
5. `release.yml` trigger `tool/release.sh` with modified name like `3.3.5` from 1st step.
6. `release.yml` trigger `update_index` at `ruby/actions`.
7. `release.yml` also trigger `ruby/docker-images` with `3.3.5`

@k0kubun @nagachika How about this? I have bit of concerns about reproducible build. If we invoke `draft-release.yml` after release work, It will update the current release package. I'm not sure `draft-release.yml` always build same package anytime.