### PR TITLE
[PRISM] Increase test-bundler-parallel to 40 minutes

### DIFF
--- a/.github/workflows/prism.yml
+++ b/.github/workflows/prism.yml
@@ -51,7 +51,7 @@ jobs:
           - test_task: test-bundler-parallel
             run_opts: '--parser=prism'
             testopts: '-v --tty=no'
-            timeout: 30
+            timeout: 40
           - test_task: test-bundled-gems
             run_opts: '--parser=prism'
             testopts: '-v --tty=no'


### PR DESCRIPTION
It's timing out frequently recently, so increasing the timeout should fix it.