### PR TITLE
Only set shape id for CCs on attr_set + ivar

### DIFF
--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -348,7 +348,10 @@ vm_cc_new(VALUE klass,
         break;
     }
 
-    vm_cc_attr_index_initialize(cc, INVALID_SHAPE_ID);
+    if (cme->def->type == VM_METHOD_TYPE_ATTRSET || cme->def->type == VM_METHOD_TYPE_IVAR) {
+        vm_cc_attr_index_initialize(cc, INVALID_SHAPE_ID);
+    }
+
     RB_DEBUG_COUNTER_INC(cc_new);
     return cc;
 }


### PR DESCRIPTION
Only ivar reader and writer methods should need the shape ID set on the inline cache.  We shouldn't accidentally overwrite parts of the CC union when it's not necessary.