### PR TITLE
Implement String#append_bytes(String)

### DIFF
--- a/internal/string.h
+++ b/internal/string.h
@@ -77,6 +77,7 @@ VALUE rb_fstring_new(const char *ptr, long len);
 VALUE rb_obj_as_string_result(VALUE str, VALUE obj);
 VALUE rb_str_opt_plus(VALUE x, VALUE y);
 VALUE rb_str_concat_literals(size_t num, const VALUE *strary);
+VALUE rb_str_append_bytes(VALUE str1, VALUE str2);
 VALUE rb_str_eql(VALUE str1, VALUE str2);
 VALUE rb_id_quote_unprintable(ID);
 VALUE rb_sym_proc_call(ID mid, int argc, const VALUE *argv, int kw_splat, VALUE passed_proc);

--- a/spec/ruby/core/string/append_bytes_spec.rb
+++ b/spec/ruby/core/string/append_bytes_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../../spec_helper'
+
+describe "String#append_bytes" do
+  ruby_version_is "3.4" do
+    it "allows creating broken strings" do
+      str = +"hello"
+      str.append_bytes("\xE2\x82")
+      str.valid_encoding?.should == false
+
+      str.append_bytes("\xAC")
+      str.valid_encoding?.should == true
+
+      str = "abc".encode(Encoding::UTF_32LE)
+      str.append_bytes("def")
+      str.encoding.should == Encoding::UTF_32LE
+      str.valid_encoding?.should == false
+    end
+
+    it "never changes the receiver encoding" do
+      str = "".b
+      str.append_bytes("€")
+      str.encoding.should == Encoding::BINARY
+    end
+
+    it "only accepts strings, and doesn't attempt to cast with #to_str" do
+      to_str = mock("to_str")
+      to_str.should_not_receive(:to_str)
+
+      str = +"hello"
+      -> { str.append_bytes(to_str) }.should raise_error(TypeError, "wrong argument type MockObject (expected String)")
+    end
+  end
+end

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -3630,6 +3630,55 @@ CODE
     assert_bytesplice_raise(ArgumentError, S("hello"), 0..-1, "bye", 0, 3)
   end
 
+  def test_append_bytes_into_binary
+    buf = S("".b)
+    assert_equal Encoding::BINARY, buf.encoding
+
+    buf.append_bytes(S("hello"))
+    assert_equal "hello".b, buf
+    assert_equal Encoding::BINARY, buf.encoding
+
+    buf.append_bytes(S("こんにちは"))
+    assert_equal S("helloこんにちは".b), buf
+    assert_equal Encoding::BINARY, buf.encoding
+  end
+
+  def test_append_bytes_into_utf8
+    buf = S("")
+    assert_equal Encoding::UTF_8, buf.encoding
+
+    buf.append_bytes(S("hello"))
+    assert_equal S("hello"), buf
+    assert_equal Encoding::UTF_8, buf.encoding
+    assert_predicate buf, :ascii_only?
+    assert_predicate buf, :valid_encoding?
+
+    buf.append_bytes(S("こんにちは"))
+    assert_equal S("helloこんにちは"), buf
+    assert_equal Encoding::UTF_8, buf.encoding
+    refute_predicate buf, :ascii_only?
+    assert_predicate buf, :valid_encoding?
+
+    buf.append_bytes(S("\xE2\x82".b))
+    assert_equal S("helloこんにちは\xE2\x82"), buf
+    assert_equal Encoding::UTF_8, buf.encoding
+    refute_predicate buf, :valid_encoding?
+
+    buf.append_bytes(S("\xAC".b))
+    assert_equal S("helloこんにちは€"), buf
+    assert_equal Encoding::UTF_8, buf.encoding
+    assert_predicate buf, :valid_encoding?
+  end
+
+  def test_append_bytes_into_utf32
+    buf = S("abc".encode(Encoding::UTF_32LE))
+    assert_equal Encoding::UTF_32LE, buf.encoding
+
+    buf.append_bytes("def")
+    assert_equal Encoding::UTF_32LE, buf.encoding
+    refute_predicate buf, :valid_encoding?
+  end
+
   def test_chilled_string
     chilled_string = eval('"chilled"')
 

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -228,6 +228,7 @@ fn main() {
         .allowlist_function("rb_str_concat_literals")
         .allowlist_function("rb_obj_as_string_result")
         .allowlist_function("rb_str_byte_substr")
+        .allowlist_function("rb_str_append_bytes")
 
         // From include/ruby/internal/intern/parse.h
         .allowlist_function("rb_backref_get")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1085,6 +1085,7 @@ extern "C" {
     pub fn rb_str_byte_substr(str_: VALUE, beg: VALUE, len: VALUE) -> VALUE;
     pub fn rb_obj_as_string_result(str_: VALUE, obj: VALUE) -> VALUE;
     pub fn rb_str_concat_literals(num: usize, strary: *const VALUE) -> VALUE;
+    pub fn rb_str_append_bytes(str1: VALUE, str2: VALUE) -> VALUE;
     pub fn rb_ec_str_resurrect(
         ec: *mut rb_execution_context_struct,
         str_: VALUE,


### PR DESCRIPTION
[Feature #20594]

A handy method to construct a string out of multiple chunks.

Contrary to `String#concat`, it only takes a single argument and doesn't do any encoding negociation. The string content is appended, and the receiver encoding is preserved.

It's the caller responsibility to check for `String#valid_encoding?` in cases where it's needed.

cc @nirvdrum 