### PR TITLE
Show what objects were actually allocated on allocation count tests

### DIFF
--- a/test/ruby/test_string_memory.rb
+++ b/test/ruby/test_string_memory.rb
@@ -30,7 +30,7 @@ class TestStringMemory < Test::Unit::TestCase
       string.byteslice(0, 50_000)
     end
 
-    assert_equal 1, allocations.size
+    assert_equal 1, allocations.size, "One object allocation is expected, but allocated: #{ allocations.inspect }"
   end
 
   def test_byteslice_postfix
@@ -40,7 +40,7 @@ class TestStringMemory < Test::Unit::TestCase
       string.byteslice(50_000, 100_000)
     end
 
-    assert_equal 1, allocations.size
+    assert_equal 1, allocations.size, "One object allocation is expected, but allocated: #{ allocations.inspect }"
   end
 
   def test_byteslice_postfix_twice
@@ -50,6 +50,6 @@ class TestStringMemory < Test::Unit::TestCase
       string.byteslice(50_000, 100_000).byteslice(25_000, 50_000)
     end
 
-    assert_equal 2, allocations.size
+    assert_equal 2, allocations.size, "Two object allocations are expected, but allocated: #{ allocations.inspect }"
   end
 end


### PR DESCRIPTION
According to Launchable, these tests fail randomly

```
Failure:
TestStringMemory#test_byteslice_prefix [D:/a/ruby/ruby/src/test/ruby/test_string_memory.rb:33]:
<1> expected but was
<2>.
```

https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fruby%2Ftest_string_memory.rb%23%23%23class%3DTestStringMemory%23%23%23testcase%3Dtest_byteslice_prefix?testSessionStatus=flake