### PR TITLE
Make sure to always use the right `warn` in `bundled_gems.rb`

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -66,7 +66,7 @@ module Gem::BUNDLED_GEMS
       kernel_class.send(:alias_method, :no_warning_require, :require)
       kernel_class.send(:define_method, :require) do |name|
         if message = ::Gem::BUNDLED_GEMS.warning?(name, specs: spec_names) # rubocop:disable Style/HashSyntax
-          warn message, :uplevel => 1
+          Kernel.warn message, :uplevel => 1
         end
         kernel_class.send(:no_warning_require, name)
       end

--- a/tool/test_for_warn_bundled_gems/test.sh
+++ b/tool/test_for_warn_bundled_gems/test.sh
@@ -51,3 +51,7 @@ echo
 echo "* Don't show warning bigdecimal/util when bigdecimal on Gemfile"
 ruby test_no_warn_sub_feature.rb
 echo
+
+echo "* Show warning when warn is not the standard one in the current scope"
+ruby test_warn_redefined.rb
+echo

--- a/tool/test_for_warn_bundled_gems/test_warn_redefined.rb
+++ b/tool/test_for_warn_bundled_gems/test_warn_redefined.rb
@@ -1,0 +1,18 @@
+module My
+  def warn(msg)
+  end
+
+  def my
+    require "bundler/inline"
+
+    gemfile do
+      source "https://rubygems.org"
+    end
+
+    require "csv"
+  end
+
+  extend self
+end
+
+My.my


### PR DESCRIPTION
Depending on scope, we may end up not calling the right `warn` method. I guess an explicit receiver can fix such case?

Fixes https://github.com/rubygems/rubygems/issues/7914.