### PR TITLE
Reduce noise in object generation count tests

### DIFF
--- a/test/ruby/test_string_memory.rb
+++ b/test/ruby/test_string_memory.rb
@@ -25,6 +25,10 @@ class TestStringMemory < Test::Unit::TestCase
         instance.class,
         instance,
       ]
+    end.select do |path,|
+      # drop strings not created in this file
+      # (the parallel testing framework may create strings in a separate thread)
+      path == __FILE__
     end
   ensure
     GC.enable


### PR DESCRIPTION
The parallel testing framework may create strings in a separate thread.

```
    1) Failure:
  TestStringMemory#test_byteslice_prefix [D:/a/ruby/ruby/src/test/ruby/test_string_memory.rb:40]:
  One object allocation is expected, but allocated: [["D:/a/ruby/ruby/src/tool/lib/test/unit/parallel.rb", 42, String, "2240\x00\x00\x00\x00...
```
https://github.com/ruby/ruby/actions/runs/10222885396/job/28288271190?pr=11271#step:23:1026