### PR TITLE
Fix next inside block argument stack underflow

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -3070,8 +3070,7 @@ remove_unreachable_chunk(rb_iseq_t *iseq, LINK_ELEMENT *i)
             /* do nothing */
         }
         else if (IS_ADJUST(i)) {
-            LABEL *dest = ((ADJUST *)i)->label;
-            if (dest && dest->unremovable) return 0;
+            return 0;
         }
         end = i;
     } while ((i = i->next) != 0);
@@ -8205,7 +8204,6 @@ compile_next(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
         add_ensure_iseq(ret, iseq, 0);
         ADD_INSNL(ret, line_node, jump, ISEQ_COMPILE_DATA(iseq)->end_label);
         ADD_ADJUST_RESTORE(ret, splabel);
-        splabel->unremovable = FALSE;
 
         if (!popped) {
             ADD_INSN(ret, line_node, putnil);

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -828,6 +828,27 @@ class TestISeq < Test::Unit::TestCase
     end;
   end
 
+  def test_unreachable_next_in_block
+    bug20344 = '[ruby-core:117210] [Bug #20344]'
+    assert_nothing_raised(SyntaxError, bug20344) do
+      compile(<<~RUBY)
+        proc do
+          next
+
+          case nil
+          when "a"
+            next
+          when "b"
+          when "c"
+            proc {}
+          end
+
+          next
+        end
+      RUBY
+    end
+  end
+
   def test_loading_kwargs_memory_leak
     assert_no_memory_leak([], "#{<<~"begin;"}", "#{<<~'end;'}", rss: true)
     a = RubyVM::InstructionSequence.compile("foo(bar: :baz)").to_binary


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/20344
This code produces `argument stack underflow (-1) (SyntaxError)` 
```ruby
proc do
  next

  case nil
  when "a"
    next
  when "b"
  when "c"
    proc {}
  end

  next
end
```

## Reason of the bug
Removable and `refcnt > unref_count` label is treated as an unreachable chunk end mark in remove_unreachable_chunk.
`compile_next` adds an adjust and a removable label. This is making remove_unreachable_chunk removing wrong chunk.

```ruby
-- raw disasm--------
   trace: 100
   0000 nop                                                              (   1)
 <L000> [sp: 0, unremovable: 1, refcnt: 6]
   trace: 1
 <L002> [sp: 0, unremovable: 0, refcnt: 1]
   adjust: [label: 0]
   0001 putnil                                                           (   2)
   0002 leave                                                            (  13)

# UNREACHABLE CHUNK START
# need to remove all to the bottom or give up removing

 <L006> [sp: 1, unremovable: 0, refcnt: 1] # Removable referenced label, wrongly treated as removable chunk end mark
   adjust: [label: 0]
   0003 putnil                                                           (   6)
   0004 leave                                                            (  13)
   adjust: [label: 6] # Removable label referenced from here
   0005 jump                 <L003>                                      (   5)
   0007 pop                                                              (   7)
   0008 jump                 <L003>                                      (   7)
*  0010 pop                                                              (   8)
   trace: 1
 <L009> [sp: -1, unremovable: 1, refcnt: 1]
   0011 putself                                                          (   9)
   0012 send                 <calldata:proc, 0>, nil                     (   9)
 <L010> [sp: -1, unremovable: 0, refcnt: 2]
   0015 pop                                                              (   9)
 <L003> [sp: 1, unremovable: 0, refcnt: 2]
   trace: 1
 <L011> [sp: -1, unremovable: 0, refcnt: 1]
   adjust: [label: 0]
   0016 putnil                                                           (  12)
   0017 leave                                                            (  13)
 <L001> [sp: -1, unremovable: 0, refcnt: 3]
   trace: 200
   0018 leave                                                            (  13)
---------------------
-: -:8: argument stack underflow (-1) (SyntaxError)
```



