### PR TITLE
Fix installation failure of rss at ruby_3_2

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -4,7 +4,7 @@ power_assert    2.0.3   https://github.com/ruby/power_assert
 rake            13.0.6  https://github.com/ruby/rake
 test-unit       3.5.7   https://github.com/test-unit/test-unit
 rexml           3.3.2   https://github.com/ruby/rexml
-rss             0.2.9   https://github.com/ruby/rss
+rss             0.3.1   https://github.com/ruby/rss
 net-ftp         0.2.1   https://github.com/ruby/net-ftp
 net-imap        0.3.4.1   https://github.com/ruby/net-imap
 net-pop         0.1.2   https://github.com/ruby/net-pop


### PR DESCRIPTION
Fixed https://github.com/ruby/actions/actions/runs/10272052433/job/28423580297#step:21:1233

It caused with https://github.com/ruby/rss/commit/71a105ee089e010e2e128524b5e185aab479e46d#diff-a38772b74bf0bf3fe7973fe3a525e3bfa2d1daf39ddf64a803ddae08622a27b6L15