### PR TITLE
CI: Run annocheck for libruby.so

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1666,8 +1666,8 @@ no-test-bundler-parallel:
 # The annocheck supports ELF format binaries compiled for any OS and for any
 # architecture. It is designed to be independent of the host OS and the
 # architecture. The test-annocheck.sh requires docker or podman.
-test-annocheck: $(PROGRAM)
-	$(tooldir)/test-annocheck.sh $(PROGRAM)
+test-annocheck: $(PROGRAM) $(LIBRUBY_SO)
+	$(tooldir)/test-annocheck.sh $(PROGRAM) $(LIBRUBY_SO)
 
 GEM = up
 sync-default-gems:

--- a/tool/annocheck/Dockerfile-copy
+++ b/tool/annocheck/Dockerfile-copy
@@ -1,7 +1,6 @@
 FROM docker.io/fedora:latest
-ARG FILES
+ARG IN_DIR
 
 RUN dnf -y install annobin-annocheck
-RUN mkdir /work
-COPY ${FILES} /work
+COPY ${IN_DIR} /work
 WORKDIR /work

--- a/tool/test-annocheck.sh
+++ b/tool/test-annocheck.sh
@@ -14,7 +14,7 @@ set -x
 
 DOCKER="$(command -v docker || command -v podman)"
 TAG=ruby-fedora-annocheck
-TOOL_DIR=$(dirname "${0}")
+TOOL_DIR="$(dirname "${0}")"
 TMP_DIR="tmp/annocheck"
 DOCKER_RUN_VOLUME_OPTS=
 

--- a/tool/test-annocheck.sh
+++ b/tool/test-annocheck.sh
@@ -15,6 +15,7 @@ set -x
 DOCKER="$(command -v docker || command -v podman)"
 TAG=ruby-fedora-annocheck
 TOOL_DIR=$(dirname "${0}")
+TMP_DIR="tmp/annocheck"
 DOCKER_RUN_VOLUME_OPTS=
 
 if [ -z "${CI-}" ]; then
@@ -27,7 +28,13 @@ else
   # volume in container in container on GitHub Actions
   # <.github/workflows/compilers.yml>.
   TAG="${TAG}-copy"
-  "${DOCKER}" build --rm -t "${TAG}" --build-arg=FILES="${*}" -f ${TOOL_DIR}/annocheck/Dockerfile-copy .
+  rm -rf "${TMP_DIR}"
+  mkdir -p "${TMP_DIR}"
+  for file in "${@}"; do
+    cp -p "${file}" "${TMP_DIR}"
+  done
+  "${DOCKER}" build --rm -t "${TAG}" --build-arg=IN_DIR="${TMP_DIR}" -f ${TOOL_DIR}/annocheck/Dockerfile-copy .
+  rm -rf "${TMP_DIR}"
 fi
 
 "${DOCKER}" run --rm -t ${DOCKER_RUN_VOLUME_OPTS} "${TAG}" annocheck --verbose ${TEST_ANNOCHECK_OPTS-} "${@}"


### PR DESCRIPTION
This PR is a rework for the https://github.com/ruby/ruby/pull/11123. I tested in my forked repository, and confirmed the test-annocheck case passing properly testing both `ruby` and `libruby.so`. Below is the CI log.

https://github.com/junaruga/ruby/actions/runs/10284090286/job/28459376922#step:10:106

---

When building with the `--shared` option, most functionality is kept in `libruby.so`. Therefore also run annocheck for `libruby.so`.

Use `ARG IN_DIR` to propagate multiple files into the container instead of `ARG FILES` in the `Dockerfile-copy`. Because the `COPY` syntax in Dockerfile doesn't support copying the multiple files.
https://stackoverflow.com/questions/61599384/specify-multiple-files-in-arg-to-copy-in-dockerfile

Co-authored-by: Vít Ondruch <vondruch@redhat.com>