### PR TITLE
Fix memory leak reported with YJIT

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -1156,12 +1156,6 @@ struct yjit_root_struct {
     bool unused; // empty structs are not legal in C99
 };
 
-static void
-yjit_root_free(void *ptr)
-{
-    // Do nothing. The root lives as long as the process.
-}
-
 static size_t
 yjit_root_memsize(const void *ptr)
 {
@@ -1176,7 +1170,7 @@ void rb_yjit_root_update_references(void *ptr); // in Rust
 // TODO: make this write barrier protected
 static const rb_data_type_t yjit_root_type = {
     "yjit_root",
-    {rb_yjit_root_mark, yjit_root_free, yjit_root_memsize, rb_yjit_root_update_references},
+    {rb_yjit_root_mark, RUBY_DEFAULT_FREE, yjit_root_memsize, rb_yjit_root_update_references},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 


### PR DESCRIPTION
The following memory leak gets reported with RUBY_FREE_AT_EXIT and YJIT enabled because the memory for yjit_root is never freed.

    STACK OF 1 INSTANCE OF 'ROOT LEAK: <calloc in rb_gc_impl_calloc>':
    11  dyld                                  0x18067e0e0 start + 2360
    10  miniruby                              0x1024b67d8 main + 100  main.c:62
    9   miniruby                              0x10256e0ec ruby_options + 156  eval.c:117
    8   miniruby                              0x102681164 ruby_process_options + 5140  ruby.c:3097
    7   miniruby                              0x10256f7dc rb_ensure + 180  eval.c:0
    6   miniruby                              0x102681c64 load_file_internal + 996  ruby.c:2685
    5   miniruby                              0x102682368 ruby_opt_init + 380  ruby.c:1817
    4   miniruby                              0x102848e38 yjit::yjit::yjit_init::h3cea491822b80cef + 360  yjit.rs:84
    3   miniruby                              0x10278f7d4 rb_yjit_init_gc_hooks + 28  yjit.c:1273
    2   miniruby                              0x10258a228 rb_data_typed_object_zalloc + 132  gc.c:989
    1   miniruby                              0x102586d88 rb_gc_impl_calloc + 148  default.c:8517
    0   libsystem_malloc.dylib                0x180840cac _malloc_zone_calloc_instrumented_or_legacy + 128