### PR TITLE
Call  method when a timeout occurs while waiting for the worker's response

### DIFF
--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -533,6 +533,8 @@ module Test
         closed = [] if cond
         @workers.reject! do |worker|
           next unless cond&.call(worker)
+          # Since `record` method is not called when a timeout occurs while waiting for the worker's response, we need to call `record` method here.
+          record(fake_class(worker.current[0]), worker.current[1], 0, @worker_timeout, Timeout::Error.new, worker.real_file) if cond
           begin
             Timeout.timeout(5) do
               worker.quit(cond ? :timeout : :normal)


### PR DESCRIPTION
Currently, Launchable cannot capture the timeout error of waiting for worker's response (Link: https://github.com/ruby/ruby/actions/runs/10240923674/job/28328470385?pr=11271#step:30:4). It's because `record` method is not called in this case. I've added the process of calling `record` method before killing the worker in this PR.
