### PR TITLE
Added bootstrap job for release workflow for Ruby 3.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,18 @@
+name: Start release workflow
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build release package
+        run: |
+          curl -L -X POST \
+            -H "Authorization: Bearer ${{ secrets.MATZBOT_GITHUB_WORKFLOW_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/ruby/actions/dispatches \
+            -d '{"event_type": "${{ github.ref }}"}'


### PR DESCRIPTION
We need to enable this bootstrap workflow each branches because `git tag` event only notify that branch.