### PR TITLE
string.c: avoid costly encoding checks in str_ensure_byte_pos when possible

### DIFF
--- a/string.c
+++ b/string.c
@@ -6563,7 +6563,6 @@ rb_str_bytesplice(int argc, VALUE *argv, VALUE str)
 {
     long beg, len, vbeg, vlen;
     VALUE val;
-    rb_encoding *enc;
     int cr;
 
     rb_check_arity(argc, 2, 5);
@@ -6608,10 +6607,13 @@ rb_str_bytesplice(int argc, VALUE *argv, VALUE str)
     }
     str_check_beg_len(str, &beg, &len);
     str_check_beg_len(val, &vbeg, &vlen);
-    enc = rb_enc_check(str, val);
     str_modify_keep_cr(str);
+
+    if (RB_UNLIKELY(ENCODING_GET_INLINED(str) != ENCODING_GET_INLINED(val))) {
+        rb_enc_associate(str, rb_enc_check(str, val));
+    }
+
     rb_str_update_1(str, beg, len, val, vbeg, vlen);
-    rb_enc_associate(str, enc);
     cr = ENC_CODERANGE_AND(ENC_CODERANGE(str), ENC_CODERANGE(val));
     if (cr != ENC_CODERANGE_BROKEN)
         ENC_CODERANGE_SET(str, cr);


### PR DESCRIPTION
Profiling shows byteslice spend quite a bit of time ensuring character boundaries. The costly part is to fetch the `rb_encoding`, which we can avoid most of the time when the encoding and coderange combinaison indicate that we're only dealing with single bytes.

Before:
<img width="927" alt="Capture d’écran 2024-08-08 à 11 15 47" src="https://github.com/user-attachments/assets/81452fd4-4cd6-46c5-a46e-cd11a89fc6f6">

After:
<img width="866" alt="Capture d’écran 2024-08-08 à 11 16 00" src="https://github.com/user-attachments/assets/bbf07549-9ef3-47ad-92a1-ae16f5988c96">

There is likely a few other places where this fast path could be used.