### PR TITLE
str_independent: add a fastpath with a single flag check

### DIFF
--- a/string.c
+++ b/string.c
@@ -880,7 +880,7 @@ str_capacity(VALUE str, const int termlen)
     if (STR_EMBED_P(str)) {
         return str_embed_capa(str) - termlen;
     }
-    else if (FL_TEST(str, STR_SHARED|STR_NOFREE)) {
+    else if (FL_ANY_RAW(str, STR_SHARED|STR_NOFREE)) {
         return RSTRING(str)->len;
     }
     else {


### PR DESCRIPTION
If we assume that most strings we modify are not frozen and are independent, then we can optimize this case by replacing multiple flag checks by a single mask check.

Profiled on top of: https://github.com/ruby/ruby/pull/11337

Before:

<img width="693" alt="Capture d’écran 2024-08-08 à 12 19 12" src="https://github.com/user-attachments/assets/eb49d5bb-5347-4698-b33c-b4c403b096c2">

After:

<img width="692" alt="Capture d’écran 2024-08-08 à 12 20 00" src="https://github.com/user-attachments/assets/2c552585-c9ae-4432-bacf-540cd3dbfe9d">

We can see:

  - `str_modify_keep_cr` `1.3%` -> `0.5%`
  - `rb_str_modify` `1.2%` -> `0.2%` (outside screenshot)

