### PR TITLE
Launchable: Fix a condition for bootstraptest

### DIFF
--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -63,7 +63,9 @@ runs:
         ${{
         (github.repository == 'ruby/ruby' ||
         (github.repository != 'ruby/ruby' && env.LAUNCHABLE_TOKEN)) &&
-        (inputs.test-task == 'check' || inputs.test-task == 'test-all')
+        (inputs.test-task == 'check' ||
+        inputs.test-task == 'test-all' ||
+        inputs.test-task == 'test')
         }}
 
     # Launchable CLI requires Python and Java.


### PR DESCRIPTION
Currently, Launchable does not record bootstraptests in RJIT. It's because a condition for enabling Launchable does not accept `test` command. This PR fixes it.

https://github.com/ruby/ruby/actions/runs/10297799338/job/28501605114#step:7:1