### PR TITLE
Add Marshal::MarshalError, and subclasses

### DIFF
--- a/marshal.c
+++ b/marshal.c
@@ -116,6 +116,10 @@ static ID s_encoding_short, s_ruby2_keywords_flag;
 #define name_s_encoding_short "E"
 #define name_s_ruby2_keywords_flag "K"
 
+VALUE rb_eMarshalError;
+VALUE rb_eMarshalExceedDepthLimitError;
+VALUE rb_eMarshalDataTooShortError;
+
 typedef struct {
     VALUE newclass;
     VALUE oldclass;
@@ -819,7 +823,7 @@ w_object(VALUE obj, struct dump_arg *arg, int limit)
     VALUE encname = Qnil;
 
     if (limit == 0) {
-        rb_raise(rb_eArgError, "exceed depth limit");
+        rb_raise(rb_eMarshalExceedDepthLimitError, "exceed depth limit");
     }
 
     if (NIL_P(obj)) {
@@ -1285,7 +1289,7 @@ NORETURN(static void too_short(void));
 static void
 too_short(void)
 {
-    rb_raise(rb_eArgError, "marshal data too short");
+    rb_raise(rb_eMarshalDataTooShortError, "marshal data too short");
 }
 
 static st_index_t
@@ -2505,6 +2509,13 @@ Init_marshal(void)
     rb_define_const(rb_mMarshal, "MAJOR_VERSION", INT2FIX(MARSHAL_MAJOR));
     /* minor version */
     rb_define_const(rb_mMarshal, "MINOR_VERSION", INT2FIX(MARSHAL_MINOR));
+
+    /* A base class for errors raised by Marshal. */
+    rb_eMarshalError = rb_define_class_under(rb_mMarshal, "MarshalError", rb_eArgError);
+    /* Raised when the depth limit is exceeded. */
+    rb_eMarshalExceedDepthLimitError = rb_define_class_under(rb_mMarshal, "ExceedDepthLimitError", rb_eMarshalError);
+    /* Raised when the loaded data is too short. */
+    rb_eMarshalDataTooShortError = rb_define_class_under(rb_mMarshal, "DataTooShortError", rb_eMarshalError);
 }
 
 static int


### PR DESCRIPTION
These are all ArgumentError subclasses, named and turned into their own classes, for ease of use.

See https://bugs.ruby-lang.org/issues/20669

EDIT: TODO, just use 1 class.

<details>

```
  Failed tests:
  JSONCommonInterfaceTest#test_dump: Test::Unit::AssertionFailedError: [ArgumentError] exception expected, not #<Marshal::ExceedDepthLimitError: exceed depth limit>.
  TestMarshal#test_too_long_string: Test::Unit::AssertionFailedError: [ruby-dev:32054].
  TestMarshal#test_limit: Test::Unit::AssertionFailedError: [ArgumentError] exception expected, not #<Marshal::ExceedDepthLimitError: exceed depth limit>.
  TestMarshal#test_continuation: Test::Unit::PendedError: requires callcc support
  
  Retrying...
  
    1) Failure:
  JSONCommonInterfaceTest#test_dump [/Users/runner/work/ruby/ruby/src/test/json/json_common_interface_test.rb:106]:
  [ArgumentError] exception expected, not #<Marshal::ExceedDepthLimitError: exceed depth limit>.
  
    2) Failure:
  TestMarshal#test_too_long_string [/Users/runner/work/ruby/ruby/src/test/ruby/test_marshal.rb:118]:
  [ruby-dev:32054].
  [ArgumentError] exception expected, not #<Marshal::DataTooShortError: marshal data too short>.
  
    3) Failure:
  TestMarshal#test_limit [/Users/runner/work/ruby/ruby/src/test/ruby/test_marshal.rb:156]:
  [ArgumentError] exception expected, not #<Marshal::ExceedDepthLimitError: exceed depth limit>.

```

<summary>TODO</summary>

</details>