### PR TITLE
Make YJIT a GC root rather than an object

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -7503,6 +7503,7 @@ gc.$(OBJEXT): {$(VPATH)}vm_core.h
 gc.$(OBJEXT): {$(VPATH)}vm_debug.h
 gc.$(OBJEXT): {$(VPATH)}vm_opts.h
 gc.$(OBJEXT): {$(VPATH)}vm_sync.h
+gc.$(OBJEXT): {$(VPATH)}yjit.h
 goruby.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
 goruby.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h
 goruby.$(OBJEXT): $(CCAN_DIR)/list/list.h

--- a/yjit.c
+++ b/yjit.c
@@ -1156,24 +1156,6 @@ struct yjit_root_struct {
     bool unused; // empty structs are not legal in C99
 };
 
-static size_t
-yjit_root_memsize(const void *ptr)
-{
-    // Count off-gc-heap allocation size of the dependency table
-    return 0; // TODO: more accurate accounting
-}
-
-void rb_yjit_root_mark(void *ptr); // in Rust
-void rb_yjit_root_update_references(void *ptr); // in Rust
-
-// Custom type for interacting with the GC
-// TODO: make this write barrier protected
-static const rb_data_type_t yjit_root_type = {
-    "yjit_root",
-    {rb_yjit_root_mark, RUBY_DEFAULT_FREE, yjit_root_memsize, rb_yjit_root_update_references},
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
-};
-
 // For dealing with refinements
 void
 rb_yjit_invalidate_all_method_lookup_assumptions(void)
@@ -1256,12 +1238,3 @@ VALUE rb_yjit_enable(rb_execution_context_t *ec, VALUE self, VALUE gen_stats, VA
 
 // Preprocessed yjit.rb generated during build
 #include "yjit.rbinc"
-
-// Initialize the GC hooks
-void
-rb_yjit_init_gc_hooks(void)
-{
-    struct yjit_root_struct *root;
-    VALUE yjit_root = TypedData_Make_Struct(0, struct yjit_root_struct, &yjit_root_type, root);
-    rb_vm_register_global_object(yjit_root);
-}

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -345,7 +345,7 @@ pub extern "C" fn rb_yjit_constant_state_changed(id: ID) {
 /// Callback for marking GC objects inside [Invariants].
 /// See `struct yjijt_root_struct` in C.
 #[no_mangle]
-pub extern "C" fn rb_yjit_root_mark(_: *mut c_void) {
+pub extern "C" fn rb_yjit_root_mark() {
     // Call rb_gc_mark on exit location's raw_samples to
     // wrap frames in a GC allocated object. This needs to be called
     // at the same time as root mark.
@@ -374,7 +374,7 @@ pub extern "C" fn rb_yjit_root_mark(_: *mut c_void) {
 }
 
 #[no_mangle]
-pub extern "C" fn rb_yjit_root_update_references(_: *mut c_void) {
+pub extern "C" fn rb_yjit_root_update_references() {
     if unsafe { INVARIANTS.is_none() } {
         return;
     }

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -75,12 +75,6 @@ fn yjit_init() {
         let _ = std::fs::remove_file(&perf_map);
         println!("YJIT perf map: {perf_map}");
     }
-
-    // Initialize the GC hooks. Do this at last as some code depend on Rust initialization.
-    extern "C" {
-        fn rb_yjit_init_gc_hooks();
-    }
-    unsafe { rb_yjit_init_gc_hooks() }
 }
 
 /// At the moment, we abort in all cases we panic.


### PR DESCRIPTION
YJIT currently uses the YJIT root object to mark objects during GC and update references during compaction. This object otherwise serves no purpose.

This commit changes it YJIT to be step when marking the GC root. This saves some memory from being allocated from the system and the GC.