### PR TITLE
Increase timeout in `test_darwin_invalid_call` method

### DIFF
--- a/test/ruby/test_vm_dump.rb
+++ b/test/ruby/test_vm_dump.rb
@@ -4,14 +4,14 @@ require 'test/unit'
 return unless /darwin/ =~ RUBY_PLATFORM
 
 class TestVMDump < Test::Unit::TestCase
-  def assert_darwin_vm_dump_works(args)
+  def assert_darwin_vm_dump_works(args, timeout=nil)
     pend "macOS 15 beta is not working with this assertion" if /darwin/ =~ RUBY_PLATFORM && /15/ =~ `sw_vers -productVersion`
 
-    assert_in_out_err(args, "", [], /^\[IMPORTANT\]/, timeout: 60)
+    assert_in_out_err(args, "", [], /^\[IMPORTANT\]/, timeout: timeout || 60)
   end
 
   def test_darwin_invalid_call
-    assert_darwin_vm_dump_works(['-r-test-/fatal', '-eBug.invalid_call(1)'])
+    assert_darwin_vm_dump_works(['-r-test-/fatal', '-eBug.invalid_call(1)'], 180)
   end
 
   def test_darwin_segv_in_syscall


### PR DESCRIPTION
`TestVMDump#test_darwin_invalid_call` method is one of flaky tests in our CI environment. Here is the example. 

```
Error:
TestVMDump#test_darwin_invalid_call:
Test::Unit::ProxyError: execution of Test::Unit::CoreAssertions#assert_in_out_err expired timeout (10 sec)
pid 24224 killed by SIGBUS (signal 10) (core dumped)
| 
| -e:1: [BUG] Bus Error at 0x0000000000000001
| ruby 3.4.0dev (2024-06-23T06:59:37Z master acce96647d) [arm64-darwin22]
| 
| -- Crash Report log information --------------------------------------------
|    See Crash Report log file in one of the following locations:
|      * ~/Library/Logs/DiagnosticReports
|      * /Library/Logs/DiagnosticReports
|    for more details.
| Don't forget to include the above Crash Report log file in bug rep
...
```

That's why we extend the timeout in https://github.com/ruby/ruby/commit/3a323c6b12dbe6b450b6c9bac14de0eb06773a44. Then, looks like it had been fixed. 

However, it still appears based on [Launchable](https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fruby%2Ftest_vm_dump.rb%23%23%23class%3DTestVMDump%23%23%23testcase%3Dtest_darwin_invalid_call?testSessionStatus=flake). So, I increased the timeout in this PR.
