### PR TITLE
do not show unused block on `send`

### DIFF
--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -1645,15 +1645,15 @@ class TestMethod < Test::Unit::TestCase
     assert_in_out_err '-w', <<-'RUBY' do |_out, err, _status|
       def foo = nil
       foo{}          # warn
-      send(:foo){}   # warn
+      send(:foo){}   # don't warn because it uses send
       b = Proc.new{}
       foo(&b)        # warn
     RUBY
-      assert_equal 3, err.size
-      err = err.join
-      assert_match(/-:2: warning/, err)
-      assert_match(/-:3: warning/, err)
-      assert_match(/-:5: warning/, err)
+      errstr = err.join("\n")
+      assert_equal 2, err.size, errstr
+
+      assert_match(/-:2: warning/, errstr)
+      assert_match(/-:5: warning/, errstr)
     end
 
     assert_in_out_err '-w', <<-'RUBY' do |_out, err, _status|

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3090,7 +3090,7 @@ vm_callee_setup_arg(rb_execution_context_t *ec, struct rb_calling_info *calling,
 
     if (UNLIKELY(!ISEQ_BODY(iseq)->param.flags.use_block &&
                  calling->block_handler != VM_BLOCK_HANDLER_NONE &&
-                 !(vm_ci_flag(calling->cd->ci) & VM_CALL_SUPER))) {
+                 !(vm_ci_flag(calling->cd->ci) & (VM_CALL_OPT_SEND | VM_CALL_SUPER)))) {
         warn_unused_block(vm_cc_cme(cc), iseq, (void *)ec->cfp->pc);
     }
 


### PR DESCRIPTION
Some case it is difficult to know the calling method uses a block or not with `send` on a general framework. So this patch stops showing unused block warning on `send`.

example with test/unit:

```ruby
require 'test/unit'

class T < Test::Unit::TestCase
  def setup
  end

  def test_foo = nil
end
```

=> /home/ko1/ruby/install/master/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.2/lib/test/unit/fixture.rb:284: warning: the block passed to 'priority_setup' defined at /home/ko1/ruby/install/master/lib/ruby/gems/3.4.0+0/gems/test-unit-3.6.2/lib/test/unit/priority.rb:183 may be ignored

because test/unit can call any setup method (`priority_setup` in this case) with a block.

Maybe we can show the warning again when we provide a way to recognize the calling method uses a block or not.