### PR TITLE
String#bytesplice optimizations

### DIFF
--- a/string.c
+++ b/string.c
@@ -4254,12 +4254,14 @@ rb_str_index_m(int argc, VALUE *argv, VALUE str)
 static void
 str_ensure_byte_pos(VALUE str, long pos)
 {
-    const char *s = RSTRING_PTR(str);
-    const char *e = RSTRING_END(str);
-    const char *p = s + pos;
-    if (!at_char_boundary(s, p, e, rb_enc_get(str))) {
-        rb_raise(rb_eIndexError,
-                 "offset %ld does not land on character boundary", pos);
+    if (!single_byte_optimizable(str)) {
+        const char *s = RSTRING_PTR(str);
+        const char *e = RSTRING_END(str);
+        const char *p = s + pos;
+        if (!at_char_boundary(s, p, e, rb_enc_get(str))) {
+            rb_raise(rb_eIndexError,
+                     "offset %ld does not land on character boundary", pos);
+        }
     }
 }
 

--- a/string.c
+++ b/string.c
@@ -6571,7 +6571,6 @@ rb_str_bytesplice(int argc, VALUE *argv, VALUE str)
 {
     long beg, len, vbeg, vlen;
     VALUE val;
-    rb_encoding *enc;
     int cr;
 
     rb_check_arity(argc, 2, 5);
@@ -6616,10 +6615,13 @@ rb_str_bytesplice(int argc, VALUE *argv, VALUE str)
     }
     str_check_beg_len(str, &beg, &len);
     str_check_beg_len(val, &vbeg, &vlen);
-    enc = rb_enc_check(str, val);
     str_modify_keep_cr(str);
+
+    if (RB_UNLIKELY(ENCODING_GET_INLINED(str) != ENCODING_GET_INLINED(val))) {
+        rb_enc_associate(str, rb_enc_check(str, val));
+    }
+
     rb_str_update_1(str, beg, len, val, vbeg, vlen);
-    rb_enc_associate(str, enc);
     cr = ENC_CODERANGE_AND(ENC_CODERANGE(str), ENC_CODERANGE(val));
     if (cr != ENC_CODERANGE_BROKEN)
         ENC_CODERANGE_SET(str, cr);


### PR DESCRIPTION
Profiling shows byteslice spend quite a bit of time ensuring character boundaries. The costly part is to fetch the `rb_encoding`, which we can avoid most of the time when the encoding and coderange combinaison indicate that we're only dealing with single bytes.

Before:
<img width="927" alt="Capture d’écran 2024-08-08 à 11 15 47" src="https://github.com/user-attachments/assets/81452fd4-4cd6-46c5-a46e-cd11a89fc6f6">

After:

<img width="906" alt="Capture d’écran 2024-08-08 à 11 51 04" src="https://github.com/user-attachments/assets/7a1ac610-410f-4fe7-9b70-65ca6ac34dde">


Fix https://github.com/ruby/ruby/pull/11337

This is an alternate version that improve `single_byte_optimizable` instead of introducing a new function just for `str_ensure_byte_pos` as suggested by @nirvdrum.