### PR TITLE
Don't set stack end in rb_gc_mark_roots

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2462,7 +2462,6 @@ rb_gc_mark_roots(void *objspace, const char **categoryp)
     rb_gc_impl_objspace_mark(objspace);
 
     MARK_CHECKPOINT("vm");
-    SET_STACK_END;
     rb_vm_mark(vm);
     if (vm->self) rb_gc_impl_mark(objspace, vm->self);
 


### PR DESCRIPTION
We don't need to set the stack end in rb_gc_mark_roots because it is already set in mark_current_machine_context.