### PR TITLE
Re-initialize vm->ractor.sched.lock after fork

### DIFF
--- a/bootstraptest/test_fork.rb
+++ b/bootstraptest/test_fork.rb
@@ -75,3 +75,25 @@ assert_equal '[1, 2]', %q{
   end
 }, '[ruby-dev:44005] [Ruby 1.9 - Bug #4950]'
 
+assert_equal 'ok', %q{
+  def now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+  Thread.new do
+    loop { sleep 0.0001 }
+  end
+
+  10.times do
+    pid = fork{ exit!(0) }
+    deadline = now + 1
+    until Process.waitpid(pid, Process::WNOHANG)
+      if now > deadline
+        Process.kill(:KILL, pid)
+        raise "failed"
+      end
+      sleep 0.001
+    end
+  rescue NotImplementedError
+  end
+  :ok
+}, '[Bug #20670]'
+

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1556,6 +1556,7 @@ thread_sched_atfork(struct rb_thread_sched *sched)
     }
     vm->ractor.sched.running_cnt = 0;
 
+    rb_native_mutex_initialize(&vm->ractor.sched.lock);
     // rb_native_cond_destroy(&vm->ractor.sched.cond);
     rb_native_cond_initialize(&vm->ractor.sched.cond);
     rb_native_cond_initialize(&vm->ractor.sched.barrier_complete_cond);


### PR DESCRIPTION
Fixes #10889

We've been seeing an occasional failure in the Rails CI related to a test which forks and I managed to reduce it to the following reproduction.

``` ruby
Thread.new do
  loop { sleep 0.0001 }
end

1000.times do
  pid = fork{}
  Process.waitpid(pid)
rescue Exception
  Process.kill(:KILL, pid)
  raise
end
```

This hangs on Ruby 3.3 and HEAD (_fairly_ reliably), but completes always on Ruby 3.2

In a debugger it seems like the timer thread acquires `vm->ractor.sched.lock` in the parent process just as the process is forking. The child process then ends up stuck inside of `thread_sched_atfork` when trying to acquire the same lock.

---

I'm not completely sure this is the correct fix, but this makes the "atfork" initialization match the [same we do at VM init](https://github.com/ruby/ruby/blob/ebe94160c0292df60e2e6bf2ed52321e3adae902/thread_pthread.c#L1662).


https://bugs.ruby-lang.org/issues/20670

cc @ko1 @byroot 