### PR TITLE
Delete unnecessary rubocop disable comment

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -65,7 +65,7 @@ module Gem::BUNDLED_GEMS
     [::Kernel.singleton_class, ::Kernel].each do |kernel_class|
       kernel_class.send(:alias_method, :no_warning_require, :require)
       kernel_class.send(:define_method, :require) do |name|
-        if message = ::Gem::BUNDLED_GEMS.warning?(name, specs: spec_names) # rubocop:disable Style/HashSyntax
+        if message = ::Gem::BUNDLED_GEMS.warning?(name, specs: spec_names)
           Kernel.warn message, uplevel: ::Gem::BUNDLED_GEMS.uplevel
         end
         kernel_class.send(:no_warning_require, name)


### PR DESCRIPTION
Delete rubocop disable comments that are no longer needed due to the changes made in below commit.
https://github.com/ruby/ruby/commit/83bdf127b8ddbb64c941bb9c467c686140b1696b
