### PR TITLE
Fix sign-conversion warning

### DIFF
--- a/ext/-test-/public_header_warnings/extconf.rb
+++ b/ext/-test-/public_header_warnings/extconf.rb
@@ -5,9 +5,14 @@
 #
 def check_append_cflags(flag, msg = nil)
   msg ||= "flag #{flag} is not acceptable"
-  !$CFLAGS.include?(flag) or raise("flag #{flag} already present in $CFLAGS")
+  if $CFLAGS.include?(flag)
+    raise("flag #{flag} already present in $CFLAGS")
+  end
   append_cflags(flag)
-  $CFLAGS.include?(flag) or raise(msg)
+  unless $CFLAGS.include?(flag)
+    system("cat mkmf.log")
+    raise(msg)
+  end
 end
 
 if %w[gcc clang].include?(RbConfig::CONFIG['CC'])

--- a/include/ruby/internal/special_consts.h
+++ b/include/ruby/internal/special_consts.h
@@ -346,7 +346,7 @@ RBIMPL_ATTR_CONSTEXPR(CXX11)
 static inline VALUE
 rb_special_const_p(VALUE obj)
 {
-    return RB_SPECIAL_CONST_P(obj) * RUBY_Qtrue;
+    return (unsigned int)RB_SPECIAL_CONST_P(obj) * RUBY_Qtrue;
 }
 
 /**


### PR DESCRIPTION
```
../../.././include/ruby/internal/special_consts.h:349:36: error: conversion to ‘VALUE’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Werror=sign-conversion]
  349 |     return RB_SPECIAL_CONST_P(obj) * RUBY_Qtrue;
      |            ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
```
