### PR TITLE
compile.c: don't allocate empty default values list

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1985,7 +1985,7 @@ iseq_set_arguments_keywords(rb_iseq_t *iseq, LINK_ANCHOR *const optargs,
     keyword->required_num = rkw;
     keyword->table = &body->local_table[keyword->bits_start - keyword->num];
 
-    {
+    if (RARRAY_LEN(default_values)) {
         VALUE *dvs = ALLOC_N(VALUE, RARRAY_LEN(default_values));
 
         for (i = 0; i < RARRAY_LEN(default_values); i++) {
@@ -12769,7 +12769,7 @@ ibf_load_param_keyword(const struct ibf_load *load, ibf_offset_t param_keyword_o
         struct rb_iseq_param_keyword *kw = IBF_R(param_keyword_offset, struct rb_iseq_param_keyword, 1);
         ID *ids = IBF_R(kw->table, ID, kw->num);
         int dv_num = kw->num - kw->required_num;
-        VALUE *dvs = IBF_R(kw->default_values, VALUE, dv_num);
+        VALUE *dvs = dv_num ? IBF_R(kw->default_values, VALUE, dv_num) : NULL;
         int i;
 
         for (i=0; i<kw->num; i++) {

--- a/iseq.c
+++ b/iseq.c
@@ -194,7 +194,9 @@ rb_iseq_free(const rb_iseq_t *iseq)
         if (body->param.keyword != NULL) {
             if (body->param.keyword->table != &body->local_table[body->param.keyword->bits_start - body->param.keyword->num])
                 ruby_xfree((void *)body->param.keyword->table);
-            ruby_xfree((void *)body->param.keyword->default_values);
+            if (body->param.keyword->default_values) {
+                ruby_xfree((void *)body->param.keyword->default_values);
+            }
             ruby_xfree((void *)body->param.keyword);
         }
         compile_data_free(ISEQ_COMPILE_DATA(iseq));

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -8889,18 +8889,20 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             keyword->bits_start = local_index;
             keyword->table = ids;
 
-            VALUE *dvs = ALLOC_N(VALUE, RARRAY_LEN(default_values));
+            if (RARRAY_LEN(default_values)) {
+                VALUE *dvs = ALLOC_N(VALUE, RARRAY_LEN(default_values));
 
-            for (int i = 0; i < RARRAY_LEN(default_values); i++) {
-                VALUE dv = RARRAY_AREF(default_values, i);
-                if (dv == complex_mark) dv = Qundef;
-                if (!SPECIAL_CONST_P(dv)) {
-                    RB_OBJ_WRITTEN(iseq, Qundef, dv);
+                for (int i = 0; i < RARRAY_LEN(default_values); i++) {
+                    VALUE dv = RARRAY_AREF(default_values, i);
+                    if (dv == complex_mark) dv = Qundef;
+                    if (!SPECIAL_CONST_P(dv)) {
+                        RB_OBJ_WRITTEN(iseq, Qundef, dv);
+                    }
+                    dvs[i] = dv;
                 }
-                dvs[i] = dv;
-            }
 
-            keyword->default_values = dvs;
+                keyword->default_values = dvs;
+            }
 
             // Hidden local for keyword arguments
             ID local = rb_make_temporary_id(local_index);


### PR DESCRIPTION
This just waste memory.