### PR TITLE
[MinGW] Revert soname changes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1388,7 +1388,7 @@ AC_CHECK_HEADERS(sys/event.h)
 AC_CHECK_HEADERS(stdckdint.h)
 AC_CHECK_HEADERS(stdatomic.h)
 
-AS_CASE("$target_cpu", [x64|x86_64|i[3-6]86*], [
+AS_CASE("$target_cpu", [x64|x86_64|[i[3-6]86*]], [
   AC_CHECK_HEADERS(x86intrin.h)
 ])
 RUBY_UNIVERSAL_CHECK_HEADER([x86_64, i386], x86intrin.h)
@@ -3526,7 +3526,10 @@ AC_ARG_WITH(soname,
 	        RUBY_SO_NAME='$(RUBY_BASE_NAME)$(MAJOR)$(MINOR)0'
 	    ],
 	    [mingw*], [
-	        RUBY_SO_NAME="${target_cpu}-${rb_cv_msvcrt}"'-$(RUBY_BASE_NAME)$(MAJOR)$(MINOR)0'
+		RUBY_SO_NAME="${rb_cv_msvcrt}"'-$(RUBY_BASE_NAME)$(MAJOR)$(MINOR)0'
+		AS_IF([test x"${target_cpu}" != xi386 || test x"${rb_cv_msvcrt}" != xmsvcrt], [
+		    RUBY_SO_NAME="${target_cpu}-${RUBY_SO_NAME}"
+		])
 	    ],
 	    [RUBY_SO_NAME='$(RUBY_BASE_NAME)'])
 	])
@@ -4098,6 +4101,7 @@ enum {
 	[mingw*], [
 	    AS_IF([test x"$enable_shared" = xyes], [
 		LIBRUBY_SO='$(RUBY_SO_NAME)'.dll
+		LIBRUBY_SONAME=''
 		LIBRUBY_DLDFLAGS="${LIBRUBY_DLDFLAGS}"' $(RUBYDEF)'
 	    ])
 	    EXPORT_PREFIX=' '


### PR DESCRIPTION
- only i386-ucrt soname is changed to fix building on x86 clang
- fix detection of x86intrin.h on x86 system
- mingw does not have LIBRUBY_SONAME