### PR TITLE
Revert change of "mingw-ucrt" platform string

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4424,7 +4424,7 @@ AS_IF([test "${universal_binary-no}" = yes ], [
     AC_DEFINE_UNQUOTED(RUBY_PLATFORM, "universal." RUBY_PLATFORM_CPU "-" RUBY_PLATFORM_OS)
 ], [
     AS_IF([test "${target_os}-${rb_cv_msvcrt}" = "mingw32-ucrt" ], [
-        arch="${target_cpu}-${target_os}-ucrt"
+        arch="${target_cpu}-mingw-ucrt"
     ], [
         arch="${target_cpu}-${target_os}"
     ])


### PR DESCRIPTION
... of commit 00176cd40fe9f385231e9c20b956fc4a84d240b9 .

The reverted change was made only for constistency, as discussed in
  https://github.com/ruby/ruby/pull/11358#issuecomment-2282222369

But the platform string "mingw-ucrt" should not be changed. It is used as RUBY_PLATFORM and as the rubygems platform, so that there should be a good reason to change the name of an established platform. "mingw-ucrt" was introduced intentionally in commit 576b2e64cdc5ea42ad345dd3c1c215e006c06fca .

Related to #11358