### PR TITLE
Make sure to wait for the thread to exit in TestProcess#test_wait_and_sigchild

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1732,15 +1732,20 @@ class TestProcess < Test::Unit::TestCase
         sig_w.write('?')
       end
       pid = nil
+      th = nil
       IO.pipe do |r, w|
         pid = fork { r.read(1); exit }
-        Thread.start {
+        th = Thread.start {
           Thread.current.report_on_exception = false
           raise
         }
         w.puts
       end
       Process.wait pid
+      begin
+        th.join
+      rescue Exception
+      end
       assert_send [sig_r, :wait_readable, 5], 'self-pipe not readable'
     end
     if defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled? # checking -DRJIT_FORCE_ENABLE. It may trigger extra SIGCHLD.


### PR DESCRIPTION
When I debugged the flaky test which is `TestProcess#test_wait_and_sigchild`, I found the following backtrace. It's hard to identify the cause of failing in this case since we cannot find which process was frozen. That's why I changed the test code so that we can make sure to wait for the thread to exit in this PR.

```
2024-08-09T07:21:20.4002401Z -- Ruby level backtrace information ----------------------------------------

2024-08-09T07:21:20.4003793Z /home/runner/work/ruby/ruby/src/tool/lib/test/unit/parallel.rb:221:in '<main>'
2024-08-09T07:21:20.4005295Z /home/runner/work/ruby/ruby/src/tool/lib/test/unit/parallel.rb:122:in 'run'
2024-08-09T07:21:20.4006852Z /home/runner/work/ruby/ruby/src/tool/lib/test/unit/parallel.rb:23:in '_run_suites'
2024-08-09T07:21:20.4008380Z /home/runner/work/ruby/ruby/src/tool/lib/test/unit/parallel.rb:23:in 'map'
2024-08-09T07:21:20.4009965Z /home/runner/work/ruby/ruby/src/tool/lib/test/unit/parallel.rb:24:in 'block in _run_suites'
2024-08-09T07:21:20.4010946Z /home/runner/work/ruby/ruby/src/tool/lib/test/unit/parallel.rb:52:in '_run_suite'
2024-08-09T07:21:20.4011750Z /home/runner/work/ruby/ruby/src/tool/lib/test/unit.rb:1361:in '_run_suite'
2024-08-09T07:21:20.4012487Z /home/runner/work/ruby/ruby/src/tool/lib/test/unit.rb:1657:in '_run_suite'
2024-08-09T07:21:20.4013200Z /home/runner/work/ruby/ruby/src/tool/lib/test/unit.rb:1657:in 'map'
2024-08-09T07:21:20.4013948Z /home/runner/work/ruby/ruby/src/tool/lib/test/unit.rb:1670:in 'block in _run_suite'
2024-08-09T07:21:20.4014961Z /home/runner/work/ruby/ruby/src/tool/lib/test/unit/testcase.rb:183:in 'run'
2024-08-09T07:21:20.4015551Z <internal:array>:53:in 'each'
2024-08-09T07:21:20.4016151Z /home/runner/work/ruby/ruby/src/tool/lib/test/unit/testcase.rb:185:in 'block in run'
2024-08-09T07:21:20.4016956Z /home/runner/work/ruby/ruby/src/test/ruby/test_process.rb:16:in 'teardown'
2024-08-09T07:21:20.4017688Z /home/runner/work/ruby/ruby/src/test/ruby/test_process.rb:16:in 'waitall'
```

https://github.com/ruby/ruby/actions/runs/10313609523/job/28550665934?pr=11323#step:14:15250