### PR TITLE
Sync rdoc

### DIFF
--- a/lib/rdoc/generator/darkfish.rb
+++ b/lib/rdoc/generator/darkfish.rb
@@ -677,7 +677,6 @@ class RDoc::Generator::Darkfish
     return body if body =~ /<html/
 
     head_file = @template_dir + '_head.rhtml'
-    footer_file = @template_dir + '_footer.rhtml'
 
     <<-TEMPLATE
 <!DOCTYPE html>
@@ -687,8 +686,6 @@ class RDoc::Generator::Darkfish
 #{head_file.read}
 
 #{body}
-
-#{footer_file.read}
     TEMPLATE
   end
 

--- a/lib/rdoc/generator/template/darkfish/css/rdoc.css
+++ b/lib/rdoc/generator/template/darkfish/css/rdoc.css
@@ -24,7 +24,9 @@ body {
 
   /* Layout */
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  min-height: 100vh;
+  margin: 0;
 }
 
 body > :last-child {
@@ -209,16 +211,35 @@ nav {
   border-right: 1px solid #ccc;
   position: fixed;
   top: 0;
-  overflow: auto;
+  bottom: 0;
+  overflow: hidden;
   z-index: 10;
 
   /* Layout */
   width: var(--sidebar-width);
   min-height: 100vh;
   background: white;
+
+  display: flex;
+  flex-direction: column;
+}
+
+nav[hidden] {
+  display: none;
+}
+
+nav #project-metadata {
+  overflow: auto; /* Make the content scrollable */
+  flex: 1; /* Take up remaining space */
+}
+
+nav footer {
+  padding: 1em;
+  border-top: 1px solid #ccc;
 }
 
 main {
+  flex: 1;
   display: block;
   margin: 3em auto 1em;
   padding: 0 1em; /* Add padding to keep space between main content and sidebar/right side of the screen */
@@ -726,10 +747,6 @@ pre {
 #search-results pre {
   margin: 0.5em;
   font-family: "Source Code Pro", Monaco, monospace;
-}
-
-footer {
-  z-index: 20;
 }
 
 /* @end */

--- a/lib/rdoc/generator/template/darkfish/index.rhtml
+++ b/lib/rdoc/generator/template/darkfish/index.rhtml
@@ -12,6 +12,8 @@
     <%= render '_sidebar_pages.rhtml' %>
     <%= render '_sidebar_classes.rhtml' %>
   </div>
+
+  <%= render '_footer.rhtml' %>
 </nav>
 
 <main role="main">


### PR DESCRIPTION
This syncs the changes made in https://github.com/ruby/rdoc/pull/1152, which would improve the darkfish theme for `doc.ruby-lang.org`. [RDoc's doc](https://ruby.github.io/rdoc/) has adopted the change I think it works quite good now.

(For some reason the syncing for rdoc kept failing recently. I'd appreciate any pointers on how to debug the cause)