### PR TITLE
Fix flaky TestSetTraceFunc#test_remove_in_trace by filtering trace events

### DIFF
--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -456,6 +456,9 @@ class TestSetTraceFunc < Test::Unit::TestCase
     bug3921 = '[ruby-dev:42350]'
     ok = false
     func = lambda{|e, f, l, i, b, k|
+      # In parallel testing, unexpected events like IO operations may be traced,
+      # so we filter out events here.
+      next unless f == __FILE__
       set_trace_func(nil)
       ok = eval("self", b)
     }


### PR DESCRIPTION
According to Lauchable, TestSetTraceFunc#test_remove_in_trace is one of flaky tests. 

![Screenshot 2024-08-13 at 19 39 35](https://github.com/user-attachments/assets/5894631a-9ed6-47f0-b09b-9a887a27d480)

https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fruby%2Ftest_settracefunc.rb%23%23%23class%3DTestSetTraceFunc%23%23%23testcase%3Dtest_remove_in_trace?testSessionStatus=fail

Here is the log when failing it.

```
TestSetTraceFunc#test_remove_in_trace [/home/runner/work/ruby/ruby/src/test/ruby/test_settracefunc.rb:464]:
  [ruby-dev:42350].
  <#<TestSetTraceFunc:0x00007f8afc35fa00
   @__gc_disabled__=false,
   @__io__=nil,
   @__name__=:test_remove_in_trace,
   @__passed__=nil,
   @__runner_options__=
    {:job_status=>nil,
     :retry=>false,
     :hide_skip=>true,
     :failed_output=>#<IO:<STDOUT>>,
     :repeat_count=>nil,
     :excludes=>["../src/test/.excludes"],
     :seed=>16542,
     :ruby=>
      ["./miniruby",
       "-I../src/lib",
       "-I.",
       "-I.ext/common",
       "../src/tool/runruby.rb",
       "--extout=.ext",
       "--",
       "--disable-gems"],
     :filter=>/\A(?=.*)(?!.*(?-mix:memory_leak))/},
   @_assertions=1,
   @original_compile_option=
    {:inline_const_cache=>true,
     :peephole_optimization=>true,
     :tailcall_optimization=>false,
     :specialized_instruction=>true,
     :operands_unification=>true,
     :instructions_unification=>false,
     :debug_frozen_string_literal=>false,
     :coverage_enabled=>true,
     :debug_level=>0,
     :frozen_string_literal=>nil},
   @target_thread=#<Thread:0x00007f8b10d3a7f0 run>,
   @tracepoint_captured_singlethread=false,
   @tracepoint_captured_stat=[[#<RubyVM:0x00007f8b10d3a818>, 0, 0]]>> expected but was
  <#<Tempfile::Closer:0x00007f8af5048df0
   @tmpfile=
    #<File:/tmp/rubytest.0spm3a/parse_include20240813-1425674-kkx1k1.rd (closed)>>>.
```

Based on investigation, the test was failed when unexpected instance was set in `ok` variable because unexpected events like Tempfile::Closer was traced. Here is the log when outputting the log. The former event, "e: c-return, f: /home/runner/work/ruby/ruby/src/test/ruby/test_settracefunc.rb..." is expected event, but the latter one is not. Thus, I modified test code so that we can filter out unexpected trace events.

```
e: c-return, f: /home/runner/work/ruby/ruby/src/test/ruby/test_settracefunc.rb, l: 464, i: set_trace_func, b: , k: Kernel
...
e: call, f: /home/runner/work/ruby/ruby/src/lib/tempfile.rb, l: 371, i: call, b: #<Binding:0xe7eabe28>, k: Tempfile::Closer
```

https://github.com/ruby/ruby/actions/runs/10365091706/job/28691604883?pr=11323#step:12:19393
