### PR TITLE
Improve base time of assert_linear_performance

### DIFF
--- a/tool/lib/core_assertions.rb
+++ b/tool/lib/core_assertions.rb
@@ -825,7 +825,7 @@ eom
         end
         times.compact!
         tmin, tmax = times.minmax
-        tbase = 10 ** Math.log10(tmax * ([(tmax / tmin), 2].max ** 2)).ceil
+        tbase = 10 * tmax * [(tmax / tmin) ** 2 / 4, 1].max
         info = "(tmin: #{tmin}, tmax: #{tmax}, tbase: #{tbase})"
 
         seq.each do |i|

--- a/tool/lib/core_assertions.rb
+++ b/tool/lib/core_assertions.rb
@@ -825,6 +825,8 @@ eom
         end
         times.compact!
         tmin, tmax = times.minmax
+
+        # safe_factor * tmax * rehearsal_time_variance_factor(equals to 1 when variance is small)
         tbase = 10 * tmax * [(tmax / tmin) ** 2 / 4, 1].max
         info = "(tmin: #{tmin}, tmax: #{tmax}, tbase: #{tbase})"
 


### PR DESCRIPTION
Base time of linear performance assertion was using this calculation.
```ruby
tbase = 10 ** Math.log10(t).ceil
```
There is a 10x gap. When rehearsal time exceeds some threshold, tbase becomes 10x large.
It can potentially make the assertion loose and also flaky.
```ruby
T = 0.0024 # n=100000 fails
T = 0.0025 # n=400000 passes
def test_linear_performance_quadratic
  assert_linear_performance([10000, 50000, 100000, 150000, 200000, 400000], rehearsal: 10) do |n|
    t = T * (n / 10000.0) ** 2
    t2 = Process.clock_gettime(:CLOCK_THREAD_CPUTIME_ID) + t
    1 while Process.clock_gettime(:CLOCK_THREAD_CPUTIME_ID) < t2
  end
end
```
Note that test in ruby/rexml uses `seq = [10000, 50000, 100000, 150000, 200000]`

I think this pull request makes the assertion more strict and also less flaky.
```ruby
10 ** Math.log10(tmax * ([(tmax / tmin), 2].max ** 2)).ceil
# ↓ remove ceil that makes 10x gap
10 ** (Math.log10(tmax * ([(tmax / tmin), 2].max ** 2)) + 0.5)
# ↓
3.16 * tmax * ([(tmax / tmin), 2].max ** 2)
# ↓
12.65 * tmax * [(tmax / tmin) ** 2 / 4, 1].max
# ↓ round safe_factor to 10
10 * tmax * [(tmax / tmin) ** 2 / 4, 1].max
# safe_factor * tmax * variance_factor
# variance_factor == 1 when variance of rehearsal time is small
```