### PR TITLE
[3.3 backport] Re-initialize vm->ractor.sched.lock after fork

### DIFF
--- a/bootstraptest/test_fork.rb
+++ b/bootstraptest/test_fork.rb
@@ -75,3 +75,25 @@ assert_equal '[1, 2]', %q{
   end
 }, '[ruby-dev:44005] [Ruby 1.9 - Bug #4950]'
 
+assert_equal 'ok', %q{
+  def now = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+  Thread.new do
+    loop { sleep 0.0001 }
+  end
+
+  10.times do
+    pid = fork{ exit!(0) }
+    deadline = now + 1
+    until Process.waitpid(pid, Process::WNOHANG)
+      if now > deadline
+        Process.kill(:KILL, pid)
+        raise "failed"
+      end
+      sleep 0.001
+    end
+  rescue NotImplementedError
+  end
+  :ok
+}, '[Bug #20670]'
+

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1530,6 +1530,7 @@ thread_sched_atfork(struct rb_thread_sched *sched)
     }
     vm->ractor.sched.running_cnt = 0;
 
+    rb_native_mutex_initialize(&vm->ractor.sched.lock);
     // rb_native_cond_destroy(&vm->ractor.sched.cond);
     rb_native_cond_initialize(&vm->ractor.sched.cond);
     rb_native_cond_initialize(&vm->ractor.sched.barrier_complete_cond);


### PR DESCRIPTION
Backport of https://github.com/ruby/ruby/pull/11356 to Ruby 3.3.x

https://bugs.ruby-lang.org/issues/20670


