### PR TITLE
Increase the default timeout in assert_darwin_vm_dump_works

### DIFF
--- a/test/ruby/test_vm_dump.rb
+++ b/test/ruby/test_vm_dump.rb
@@ -7,11 +7,11 @@ class TestVMDump < Test::Unit::TestCase
   def assert_darwin_vm_dump_works(args, timeout=nil)
     pend "macOS 15 beta is not working with this assertion" if /darwin/ =~ RUBY_PLATFORM && /15/ =~ `sw_vers -productVersion`
 
-    assert_in_out_err(args, "", [], /^\[IMPORTANT\]/, timeout: timeout || 60)
+    assert_in_out_err(args, "", [], /^\[IMPORTANT\]/, timeout: timeout || 1800)
   end
 
   def test_darwin_invalid_call
-    assert_darwin_vm_dump_works(['-r-test-/fatal', '-eBug.invalid_call(1)'], 180)
+    assert_darwin_vm_dump_works(['-r-test-/fatal', '-eBug.invalid_call(1)'])
   end
 
   def test_darwin_segv_in_syscall


### PR DESCRIPTION
`TestVMDump#test_darwin_invalid_call`, `TestVMDump#test_darwin_segv_in_syscall`, and `TestVMDump#test_darwin_invalid_access` are flaky tests according to Launchable. They mainly fail randomly on macOS. There are two possible causes here: the first possible cause is that executing tests is slow, and the second possible cause is that something hangs. To identify the causes, I have significantly increased the default timeout in this PR. 

**Note**:  This is temporary change, we'll decrease the timeout, later.

https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fruby%2Ftest_vm_dump.rb%23%23%23class%3DTestVMDump%23%23%23testcase%3Dtest_darwin_invalid_call?testSessionStatus=flake

https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fruby%2Ftest_vm_dump.rb%23%23%23class%3DTestVMDump%23%23%23testcase%3Dtest_darwin_segv_in_syscall?testSessionStatus=flake

https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fruby%2Ftest_vm_dump.rb%23%23%23class%3DTestVMDump%23%23%23testcase%3Dtest_darwin_invalid_access?testSessionStatus=flake