### PR TITLE
Fix some warnings

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -98,6 +98,15 @@ redblack_find(redblack_node_t * tree, ID key)
     }
 }
 
+static inline rb_shape_t *
+redblack_value(redblack_node_t * node)
+{
+    // Color is stored in the bottom bit of the shape pointer
+    // Mask away the bit so we get the actual pointer back
+    return (rb_shape_t *)((uintptr_t)node->value & (((uintptr_t)-1) - 1));
+}
+
+#ifdef HAVE_MMAP
 static inline char
 redblack_color(redblack_node_t * node)
 {
@@ -110,15 +119,6 @@ redblack_red_p(redblack_node_t * node)
     return redblack_color(node) == RED;
 }
 
-static inline rb_shape_t *
-redblack_value(redblack_node_t * node)
-{
-    // Color is stored in the bottom bit of the shape pointer
-    // Mask away the bit so we get the actual pointer back
-    return (rb_shape_t *)((uintptr_t)node->value & (((uintptr_t)-1) - 1));
-}
-
-#ifdef HAVE_MMAP
 static redblack_id_t
 redblack_id_for(redblack_node_t * node)
 {

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -589,7 +589,7 @@ rb_native_cond_destroy(rb_nativethread_cond_t *cond)
     {if (!(expr)) {rb_bug("err: %lu - %s", GetLastError(), #expr);}}
 
 COMPILER_WARNING_PUSH
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
 COMPILER_WARNING_IGNORED(-Wmaybe-uninitialized)
 #endif
 static inline SIZE_T

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -589,7 +589,7 @@ rb_native_cond_destroy(rb_nativethread_cond_t *cond)
     {if (!(expr)) {rb_bug("err: %lu - %s", GetLastError(), #expr);}}
 
 COMPILER_WARNING_PUSH
-#if defined(__GNUC__) && !defined(__clang__)
+#if __has_warning("-Wmaybe-uninitialized")
 COMPILER_WARNING_IGNORED(-Wmaybe-uninitialized)
 #endif
 static inline SIZE_T


### PR DESCRIPTION
this fix silenced the warnings on Clang environment..
```
2024-08-13T12:19:18.1148051Z ../ruby-3.3.4/thread_win32.c:596:1: warning: unknown warning group '-Wmaybe-uninitialized', ignored [-Wunknown-warning-option]
2024-08-13T12:19:18.1149531Z   596 | COMPILER_WARNING_IGNORED(-Wmaybe-uninitialized)
2024-08-13T12:19:18.1150332Z       | ^
2024-08-13T12:19:18.1151373Z ../ruby-3.3.4/internal/warnings.h:15:40: note: expanded from macro 'COMPILER_WARNING_IGNORED'
2024-08-13T12:19:18.1152810Z    15 | #define COMPILER_WARNING_IGNORED(flag) RBIMPL_WARNING_IGNORED(flag)
2024-08-13T12:19:18.1153871Z       |                                        ^
2024-08-13T12:19:18.1155469Z ../ruby-3.3.4/include/ruby/internal/warning_push.h:103:39: note: expanded from macro 'RBIMPL_WARNING_IGNORED'
2024-08-13T12:19:18.1157527Z   103 | # define RBIMPL_WARNING_IGNORED(flag) RBIMPL_WARNING_PRAGMA2(ignored, flag)
2024-08-13T12:19:18.1158652Z       |                                       ^
2024-08-13T12:19:18.1160160Z ../ruby-3.3.4/include/ruby/internal/warning_push.h:99:39: note: expanded from macro 'RBIMPL_WARNING_PRAGMA2'
2024-08-13T12:19:18.1161828Z    99 | # define RBIMPL_WARNING_PRAGMA2(x, y) RBIMPL_WARNING_PRAGMA1(x # y)
2024-08-13T12:19:18.1162850Z       |                                       ^
2024-08-13T12:19:18.1164344Z ../ruby-3.3.4/include/ruby/internal/warning_push.h:98:39: note: expanded from macro 'RBIMPL_WARNING_PRAGMA1'
2024-08-13T12:19:18.1166112Z    98 | # define RBIMPL_WARNING_PRAGMA1(x)    RBIMPL_WARNING_PRAGMA0(clang diagnostic x)
2024-08-13T12:19:18.1167238Z       |                                       ^
2024-08-13T12:19:18.1168755Z ../ruby-3.3.4/include/ruby/internal/warning_push.h:97:39: note: expanded from macro 'RBIMPL_WARNING_PRAGMA0'
2024-08-13T12:19:18.1170277Z    97 | # define RBIMPL_WARNING_PRAGMA0(x)    _Pragma(# x)
2024-08-13T12:19:18.1171163Z       |                                       ^
2024-08-13T12:19:18.1172036Z <scratch space>:185:27: note: expanded from here
2024-08-13T12:19:18.1173156Z   185 |  clang diagnostic ignored "-Wmaybe-uninitialized"
```

and the second one..
```
2024-08-13T12:19:14.0194648Z ../ruby-3.3.4/shape.c:285:1: warning: unused function 'redblack_insert' [-Wunused-function]
2024-08-13T12:19:14.0195952Z   285 | redblack_insert(redblack_node_t * tree, ID key, rb_shape_t * value)
2024-08-13T12:19:14.0196894Z       | ^~~~~~~~~~~~~~~
2024-08-13T12:19:14.0197500Z 1 warning generated.
```