### PR TITLE
Fix GC_ASSERT for gc.c and gc/default.c

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -51,8 +51,6 @@
 # include <malloc.h>
 #endif
 
-# define GC_ASSERT
-
 /* MALLOC_HEADERS_END */
 
 #ifdef HAVE_SYS_TIME_H

--- a/gc/default.c
+++ b/gc/default.c
@@ -248,11 +248,6 @@ int ruby_rgengc_debug;
 # define RGENGC_CHECK_MODE  0
 #endif
 
-#ifndef GC_ASSERT
-// Note: using RUBY_ASSERT_WHEN() extend a macro in expr (info by nobu).
-# define GC_ASSERT(expr) RUBY_ASSERT_MESG_WHEN(RGENGC_CHECK_MODE > 0, expr, #expr)
-#endif
-
 /* RGENGC_PROFILE
  * 0: disable RGenGC profiling
  * 1: enable profiling for basic information

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -51,6 +51,10 @@ void rb_ractor_finish_marking(void);
 // -------------------Private section begin------------------------
 // Functions in this section are private to the default GC and gc.c
 
+#ifndef GC_ASSERT
+# define GC_ASSERT(expr) RUBY_ASSERT_MESG_WHEN(RGENGC_CHECK_MODE > 0, expr, #expr)
+#endif
+
 static int
 hash_foreach_replace_value(st_data_t key, st_data_t value, st_data_t argp, int error)
 {


### PR DESCRIPTION
gc.c mistakenly defined GC_ASSERT as blank, which caused it to be a no-op. This caused all assertions in gc.c and gc/default.c to not do anything. This commit fixes it by moving the definition of GC_ASSERT to gc/gc.h.