### PR TITLE
Make assertions allow incremental GC when disabled

### DIFF
--- a/gc/default.c
+++ b/gc/default.c
@@ -4182,7 +4182,7 @@ gc_sweep_rest(rb_objspace_t *objspace)
 static void
 gc_sweep_continue(rb_objspace_t *objspace, rb_size_pool_t *sweep_size_pool, rb_heap_t *heap)
 {
-    GC_ASSERT(dont_gc_val() == FALSE);
+    GC_ASSERT(dont_gc_val() == FALSE || objspace->profile.latest_gc_info & GPR_FLAG_METHOD);
     if (!GC_ENABLE_LAZY_SWEEP) return;
 
     gc_sweeping_enter(objspace);
@@ -5985,7 +5985,7 @@ gc_marks_step(rb_objspace_t *objspace, size_t slots)
 static bool
 gc_marks_continue(rb_objspace_t *objspace, rb_size_pool_t *size_pool, rb_heap_t *heap)
 {
-    GC_ASSERT(dont_gc_val() == FALSE);
+    GC_ASSERT(dont_gc_val() == FALSE || objspace->profile.latest_gc_info & GPR_FLAG_METHOD);
     bool marking_finished = true;
 
     gc_marking_enter(objspace);

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -856,6 +856,16 @@ class TestGc < Test::Unit::TestCase
     ensure
       GC.enable unless disabled
     end
+
+    begin
+      disabled = GC.disable
+      c = GC.count
+      GC.start(immediate_mark: false, immediate_sweep: false)
+      10_000.times { Object.new }
+      assert_equal 1, GC.count - c
+    ensure
+      GC.enable unless disabled
+    end
   end
 
   def test_vm_object


### PR DESCRIPTION
When assertions are enabled, the following code triggers an assertion error:

```ruby
GC.disable
GC.start(immediate_mark: false, immediate_sweep: false)

10_000_000.times { Object.new }
```

This is because the GC.start ignores that the GC is disabled and will start incremental marking and lazy sweeping. But the assertions in gc_marks_continue and gc_sweep_continue assert that GC is not disabled.

This commit changes it for the assertion to pass if the GC was triggered from a method.