### PR TITLE
[DOC] Add `$;` to the list of deprecated global variables

### DIFF
--- a/doc/globals.rdoc
+++ b/doc/globals.rdoc
@@ -101,14 +101,6 @@ English - <tt>$INPUT_RECORD_SEPARATOR</tt>, <tt>$RS</tt>.
 
 Aliased as <tt>$-0</tt>.
 
-=== <tt>$;</tt> (Input Field Separator)
-
-An input field separator, initially +nil+.
-
-English - <tt>$FIELD_SEPARATOR</tt>, <tt>$FS</tt>.
-
-Aliased as <tt>$-F</tt>.
-
 === <tt>$\\</tt> (Output Record Separator)
 
 An output record separator, initially +nil+.
@@ -284,6 +276,8 @@ Whether command-line option <tt>-p</tt> was given; read-only.
 === <tt>$=</tt>
 
 === <tt>$,</tt>
+
+=== <tt>$;</tt>
 
 = Pre-Defined Global Constants
 


### PR DESCRIPTION
# Motivation

I noticed the [latest globals RDoc Documentation](https://ruby-doc.org/3.3.4/globals_rdoc.html) didn't include the information that `$;` is deprecated, while the [3.2.5 documentation](https://ruby-doc.org/3.2.5/globals_rdoc.html) mentioned that it would be deprecated.

The newer documentation has a _Deprecated_ section that includes `$=`, no longer effective, and `$,`, still effective. Both `$,` and `$;` show deprecation warnings when used, so either both should be described in the documentation, including a note that they're deprecated and will be removed in the future, or both should be included in the _Deprecated_ section.

# Changes

This PR removes the `$;` from the documentation, moving it to the _Deprecated_ section.