### PR TITLE
Rewrite #test_redefinition_mismatch to use a dedicated test class

### DIFF
--- a/ext/-test-/class/init.c
+++ b/ext/-test-/class/init.c
@@ -7,5 +7,6 @@ Init_class(void)
 {
     VALUE mBug = rb_define_module("Bug");
     VALUE mod = rb_define_module_under(mBug, "Class");
+    rb_define_class_under(mod, "TestClassDefinedInC", rb_cObject);
     TEST_INIT_FUNCS(init);
 }

--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -721,9 +721,13 @@ class TestClass < Test::Unit::TestCase
 
     assert_separately([], "#{<<~"begin;"}\n#{<<~"end;"}")
     begin;
-      Date = (class C\u{1f5ff}; self; end).new
+      module Bug
+        module Class
+          TestClassDefinedInC = (class C\u{1f5ff}; self; end).new
+        end
+      end
       assert_raise_with_message(TypeError, /C\u{1f5ff}/) {
-        require 'date'
+        require '-test-/class'
       }
     end;
   end


### PR DESCRIPTION
This test is checking what happens if you try and define a class in a C extension where that constant is already not a class. It was doing this by overriding ::Date and then trying to require 'date. The issue with this is that if we ever add 'date' as a dependency for the test runner, this test will break because the test runner files get implicitly required in an `assert_separately` block.

Better use an explicit class for this purpose which can't be accidentally required elsewhere.

(The reason I ran into this is because I've patched the test runner to emit XML test reports for my Jenkins server, and that requires `date`).