### PR TITLE
Perform an actual access check in Dir.tmpdir for writability

### DIFF
--- a/lib/tmpdir.rb
+++ b/lib/tmpdir.rb
@@ -36,7 +36,7 @@ class Dir
       case
       when !stat.directory?
         warn "#{name} is not a directory: #{dir}"
-      when !stat.writable?
+      when !File.writable?(dir)
         warn "#{name} is not writable: #{dir}"
       when stat.world_writable? && !stat.sticky?
         warn "#{name} is world-writable: #{dir}"


### PR DESCRIPTION
At the moment, this code is looking at the stat output to determine if a temp directory can be written to. However, just because the stat bits say that a directory is writable, does not make it so; and, likewise, the operating system may in fact grant access to paths that the stat bits and process UID say should be inaccessible.

These systems include:

* Posix ACL's
* Linux's capabilities like CAP_DAC_OVERRIDE
* Linux Security Modules like SELinux or AppArmor
* Syscall filters like Linux's seccomp
* Granular capability systems like FreeBSD's Capsicum
* OpenBSD's pledge and unveil
* Windows too has a rich ACL system for controlling filesystem access

The best thing to do is simply to try and access the path with `File.writable?` and let the operating system tell us if the path can be accessed.