### PR TITLE
[Bug #20677] Don't emit ELF notes for coroutines on non-ELF platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -839,7 +839,7 @@ AS_IF([test "$GCC" = yes], [
     ])
 
     # aarch64 branch protection
-    AS_CASE(["$target_cpu"], [aarch64], [
+    AS_CASE(["$target_cpu"], [aarch64|arm64], [
 	AS_FOR(option, opt, [-mbranch-protection=pac-ret -msign-return-address=all], [
             # Try these flags in the _prepended_ position - i.e. we want to try building a program
             # with CFLAGS="-mbranch-protection=pac-ret $CFLAGS". If the builder has provided different

--- a/coroutine/amd64/Context.S
+++ b/coroutine/amd64/Context.S
@@ -60,6 +60,8 @@ PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 .section .note.GNU-stack,"",%progbits
 #endif
 
+#if defined(__ELF__)
+
 #if defined(__CET__) && (__CET__ & 0x01) != 0
 # define IBT_FLAG 0x01
 #else
@@ -84,3 +86,4 @@ PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 .long 0x0        /* 8-byte alignment padding */
 /* End descriptor */
 .popsection
+#endif

--- a/coroutine/arm64/Context.S
+++ b/coroutine/arm64/Context.S
@@ -90,6 +90,7 @@ PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 #endif
 
 #if (defined(__ARM_FEATURE_BTI_DEFAULT) && __ARM_FEATURE_BTI_DEFAULT != 0) || (defined(__ARM_FEATURE_PAC_DEFAULT) && __ARM_FEATURE_PAC_DEFAULT != 0)
+#if defined(__ELF__)
 /*  See "ELF for the Arm 64-bit Architecture (AArch64)"
     https://github.com/ARM-software/abi-aa/blob/2023Q3/aaelf64/aaelf64.rst#program-property */
 #  define GNU_PROPERTY_AARCH64_FEATURE_1_BTI (1<<0)
@@ -121,4 +122,5 @@ PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
   .long 0x0        /* 8-byte alignment padding */
   # End descriptor
   .popsection
+#endif
 #endif

--- a/coroutine/arm64/Context.S
+++ b/coroutine/arm64/Context.S
@@ -89,7 +89,7 @@ PREFIXED_SYMBOL(SYMBOL_PREFIX,coroutine_transfer):
 .section .note.GNU-stack,"",%progbits
 #endif
 
-#if (defined(__ARM_FEATURE_BTI_DEFAULT) && __ARM_FEATURE_BTI_DEFAULT != 0) || (defined(____ARM_FEATURE_PAC_DEFAULT) && __ARM_FEATURE_PAC_DEFAULT != 0)
+#if (defined(__ARM_FEATURE_BTI_DEFAULT) && __ARM_FEATURE_BTI_DEFAULT != 0) || (defined(__ARM_FEATURE_PAC_DEFAULT) && __ARM_FEATURE_PAC_DEFAULT != 0)
 /*  See "ELF for the Arm 64-bit Architecture (AArch64)"
     https://github.com/ARM-software/abi-aa/blob/2023Q3/aaelf64/aaelf64.rst#program-property */
 #  define GNU_PROPERTY_AARCH64_FEATURE_1_BTI (1<<0)


### PR DESCRIPTION
Three commits in this one:

* Stop emitting ELF notes on non-ELF platforms, like MacOS. They don't actually _do_ anything and only really have a platform-defined meaning on Linux.
* There was a typo in one of the macros for generating the ELF notes on aarch64.
* The configure check for pac-ret was only looking for `aarch64`, not `arm64`, so it wasn't auto-enabling on MacOS. Fixed that.
