### PR TITLE
Make object ID faster by checking flags

### DIFF
--- a/gc/default.c
+++ b/gc/default.c
@@ -1683,13 +1683,17 @@ rb_gc_impl_object_id(void *objspace_ptr, VALUE obj)
     rb_objspace_t *objspace = objspace_ptr;
 
     unsigned int lev = rb_gc_vm_lock();
-    st_data_t val;
-    if (st_lookup(objspace->obj_to_id_tbl, (st_data_t)obj, &val)) {
-        GC_ASSERT(FL_TEST(obj, FL_SEEN_OBJ_ID));
-        id = (VALUE)val;
+    if (FL_TEST(obj, FL_SEEN_OBJ_ID)) {
+        st_data_t val;
+        if (st_lookup(objspace->obj_to_id_tbl, (st_data_t)obj, &val)) {
+            id = (VALUE)val;
+        }
+        else {
+            rb_bug("rb_gc_impl_object_id: FL_SEEN_OBJ_ID flag set but not found in table");
+        }
     }
     else {
-        GC_ASSERT(!FL_TEST(obj, FL_SEEN_OBJ_ID));
+        GC_ASSERT(!st_lookup(objspace->obj_to_id_tbl, (st_data_t)obj, NULL));
 
         id = ULL2NUM(objspace->next_object_id);
         objspace->next_object_id += OBJ_ID_INCREMENT;


### PR DESCRIPTION
We can improve object ID performance by checking the FL_SEEN_OBJ_ID flag instead of looking up in the table.