### PR TITLE
Avoid hash allocation for certain proc calls

### DIFF
--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -2848,6 +2848,20 @@ class TestKeywordArguments < Test::Unit::TestCase
     assert_equal(1, process(:foo, bar: :baz))
   end
 
+  def test_ruby2_keywords_bug_20679
+    c = Class.new do
+       def self.get(_, _, h, &block)
+         h[1]
+       end
+
+      ruby2_keywords def get(*args, &block)
+        self.class.get(*args, &block)
+      end
+    end
+
+    assert_equal 2, c.new.get(true, {}, 1 => 2)
+  end
+
   def test_top_ruby2_keywords
     assert_in_out_err([], <<-INPUT, ["[1, 2, 3]", "{:k=>1}"], [])
       def bar(*a, **kw)

--- a/vm_args.c
+++ b/vm_args.c
@@ -767,8 +767,8 @@ setup_parameters_complex(rb_execution_context_t * const ec, const rb_iseq_t * co
                         keyword_hash = converted_keyword_hash;
                     }
                     else {
+                        locals[args->argc] = converted_keyword_hash;
                         args->argc += 1;
-                        locals[i] = converted_keyword_hash;
                         keyword_hash = Qnil;
                         kw_flag = 0;
                     }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2739,9 +2739,11 @@ vm_caller_setup_keyword_hash(const struct rb_callinfo *ci, VALUE keyword_hash)
             keyword_hash = rb_hash_dup(rb_to_hash_type(keyword_hash));
         }
     }
-    else if (!IS_ARGS_KW_SPLAT_MUT(ci)) {
+    else if (!IS_ARGS_KW_SPLAT_MUT(ci) && !RHASH_EMPTY_P(keyword_hash)) {
         /* Convert a hash keyword splat to a new hash unless
          * a mutable keyword splat was passed.
+         * Skip allocating new hash for empty keyword splat, as empty
+         * keyword splat will be ignored by both callers.
          */
         keyword_hash = rb_hash_dup(keyword_hash);
     }


### PR DESCRIPTION
Reapplies abc04e898b627ab37fa9dd5e330f239768778d8b, which was reverted at
d56470a27c5a8a2e7aee7a76cea445c2d29c0c59, with the addition of a bug fix and
test.

Fixes [Bug #20679]