### PR TITLE
Decrease the timeout in assert_darwin_vm_dump_works

### DIFF
--- a/test/ruby/test_vm_dump.rb
+++ b/test/ruby/test_vm_dump.rb
@@ -7,7 +7,7 @@ class TestVMDump < Test::Unit::TestCase
   def assert_darwin_vm_dump_works(args, timeout=nil)
     pend "macOS 15 beta is not working with this assertion" if /darwin/ =~ RUBY_PLATFORM && /15/ =~ `sw_vers -productVersion`
 
-    assert_in_out_err(args, "", [], /^\[IMPORTANT\]/, timeout: timeout || 1800)
+    assert_in_out_err(args, "", [], /^\[IMPORTANT\]/, timeout: timeout || 300)
   end
 
   def test_darwin_invalid_call


### PR DESCRIPTION
I have significantly increased the timeout in https://github.com/ruby/ruby/pull/11373, then it seems to be that they're not failed randomly based on Launchable.

https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fruby%2Ftest_vm_dump.rb%23%23%23class%3DTestVMDump%23%23%23testcase%3Dtest_darwin_invalid_call?testSessionStatus=flake

=> Last failed at 2024-08-08 16:34:16 UTC

https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fruby%2Ftest_vm_dump.rb%23%23%23class%3DTestVMDump%23%23%23testcase%3Dtest_darwin_segv_in_syscall?testSessionStatus=flake

=> Last failed at 2024-08-13 05:07:19 UTC

https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fruby%2Ftest_vm_dump.rb%23%23%23class%3DTestVMDump%23%23%23testcase%3Dtest_darwin_invalid_access?testSessionStatus=flake

=> Last failed at 2024-08-13 21:10:51 UTC

From the above results, I believe that the cause of a failure is executing tests is just slow, not something hangs. Since I could identify the cause, I'm going to decrease the timeout. 

Here is the test durations for each test. Since I would like to set a significant timeout time, I'll set it to 5minutes.

`test_darwin_invalid_call` => { "minutes": 2, "milliseconds": 181 }
`test_darwin_segv_in_syscall` => { "minutes": 2, "seconds": 11, "milliseconds": 541 }
`test_darwin_invalid_access` => { "minutes": 2, "seconds": 12, "milliseconds": 830 }
