### PR TITLE
[Bug #20688] Fix use-after-free for WeakMap and WeakKeyMap

### DIFF
--- a/test/ruby/test_weakmap.rb
+++ b/test/ruby/test_weakmap.rb
@@ -258,4 +258,11 @@ class TestWeakMap < Test::Unit::TestCase
 
     assert_equal b, @wm[1]
   end
+
+  def test_use_after_free_bug_20688
+    assert_normal_exit(<<~RUBY)
+      weakmap = ObjectSpace::WeakMap.new
+      10_000.times { weakmap[Object.new] = Object.new }
+    RUBY
+  end
 end

--- a/weakmap.c
+++ b/weakmap.c
@@ -29,6 +29,11 @@ struct weakmap {
     st_table *table;
 };
 
+struct weakmap_entry {
+    VALUE key;
+    VALUE val;
+};
+
 static bool
 wmap_live_p(VALUE obj)
 {
@@ -42,7 +47,7 @@ wmap_free_entry(VALUE *key, VALUE *val)
 
     /* We only need to free key because val is allocated beside key on in the
      * same malloc call. */
-    ruby_sized_xfree(key, sizeof(VALUE) * 2);
+    ruby_sized_xfree(key, sizeof(struct weakmap_entry));
 }
 
 static int
@@ -418,10 +423,10 @@ wmap_aset_replace(st_data_t *key, st_data_t *val, st_data_t new_key_ptr, int exi
         RUBY_ASSERT(*(VALUE *)*key == new_key);
     }
     else {
-        VALUE *pair = xmalloc(sizeof(VALUE) * 2);
+        struct weakmap_entry *entry = xmalloc(sizeof(struct weakmap_entry));
 
-        *key = (st_data_t)pair;
-        *val = (st_data_t)(pair + 1);
+        *key = (st_data_t)&entry->key;;
+        *val = (st_data_t)&entry->val;
     }
 
     *(VALUE *)*key = new_key;

--- a/weakmap.c
+++ b/weakmap.c
@@ -40,16 +40,6 @@ wmap_live_p(VALUE obj)
     return !UNDEF_P(obj);
 }
 
-static void
-wmap_free_entry(VALUE *key, VALUE *val)
-{
-    RUBY_ASSERT(key + 1 == val);
-
-    /* We only need to free key because val is allocated beside key on in the
-     * same malloc call. */
-    ruby_sized_xfree(key, sizeof(struct weakmap_entry));
-}
-
 struct wmap_foreach_data {
     int (*func)(struct weakmap_entry *, st_data_t);
     st_data_t arg;
@@ -75,7 +65,7 @@ wmap_foreach_i(st_data_t key, st_data_t val, st_data_t arg)
         return ret;
     }
     else {
-        wmap_free_entry((VALUE *)key, (VALUE *)val);
+        ruby_sized_xfree(entry, sizeof(struct weakmap_entry));
 
         return ST_DELETE;
     }
@@ -113,7 +103,10 @@ wmap_mark(void *ptr)
 static int
 wmap_free_table_i(st_data_t key, st_data_t val, st_data_t arg)
 {
-    wmap_free_entry((VALUE *)key, (VALUE *)val);
+    struct weakmap_entry *entry = (struct weakmap_entry *)key;
+    RUBY_ASSERT(&entry->val == (VALUE *)val);
+    ruby_sized_xfree(entry, sizeof(struct weakmap_entry));
+
     return ST_CONTINUE;
 }
 
@@ -533,7 +526,8 @@ wmap_delete(VALUE self, VALUE key)
         rb_gc_remove_weak(self, (VALUE *)orig_key_data);
         rb_gc_remove_weak(self, (VALUE *)orig_val_data);
 
-        wmap_free_entry((VALUE *)orig_key_data, (VALUE *)orig_val_data);
+        struct weakmap_entry *entry = (struct weakmap_entry *)orig_key_data;
+        ruby_sized_xfree(entry, sizeof(struct weakmap_entry));
 
         if (wmap_live_p(orig_val)) {
             return orig_val;


### PR DESCRIPTION
We cannot free the weakmap_entry before the ST_DELETE because it could hash the key which would read the weakmap_entry and would cause a use-after-free. Instead, we store the entry and free it on the next iteration.

For example, the following script triggers a use-after-free in Valgrind:

```ruby
weakmap = ObjectSpace::WeakMap.new
10_000.times { weakmap[Object.new] = Object.new }
```

```
==25795== Invalid read of size 8
==25795==    at 0x462297: wmap_cmp (weakmap.c:165)
==25795==    by 0x3A2B1C: find_table_bin_ind (st.c:930)
==25795==    by 0x3A5EAA: st_general_foreach (st.c:1599)
==25795==    by 0x3A5EAA: rb_st_foreach (st.c:1640)
==25795==    by 0x25C991: gc_mark_children (default.c:4870)
==25795==    by 0x25C991: gc_marks_wb_unprotected_objects_plane (default.c:5565)
==25795==    by 0x25C991: rgengc_rememberset_mark_plane (default.c:5557)
==25795==    by 0x25C991: rgengc_rememberset_mark (default.c:6233)
==25795==    by 0x25C991: gc_marks_start (default.c:6057)
==25795==    by 0x25C991: gc_marks (default.c:6077)
==25795==    by 0x25C991: gc_start (default.c:6723)
==25795==    by 0x260F96: heap_prepare (default.c:2282)
==25795==    by 0x260F96: heap_next_free_page (default.c:2489)
==25795==    by 0x260F96: newobj_cache_miss (default.c:2598)
==25795==    by 0x26197F: newobj_alloc (default.c:2622)
==25795==    by 0x26197F: rb_gc_impl_new_obj (default.c:2701)
==25795==    by 0x26197F: newobj_of (gc.c:890)
==25795==    by 0x26197F: rb_wb_protected_newobj_of (gc.c:917)
==25795==    by 0x2DEA88: rb_class_allocate_instance (object.c:131)
==25795==    by 0x2E3B18: class_call_alloc_func (object.c:2141)
==25795==    by 0x2E3B18: rb_class_alloc (object.c:2113)
==25795==    by 0x2E3B18: rb_class_new_instance_pass_kw (object.c:2172)
==25795==    by 0x429DDC: vm_call_cfunc_with_frame_ (vm_insnhelper.c:3786)
==25795==    by 0x44B08D: vm_sendish (vm_insnhelper.c:5953)
==25795==    by 0x44B08D: vm_exec_core (insns.def:898)
==25795==    by 0x43A7A4: rb_vm_exec (vm.c:2564)
==25795==    by 0x234914: rb_ec_exec_node (eval.c:281)
==25795==  Address 0x21603710 is 0 bytes inside a block of size 16 free'd
==25795==    at 0x4849B2C: free (vg_replace_malloc.c:989)
==25795==    by 0x249651: rb_gc_impl_free (default.c:8527)
==25795==    by 0x249651: rb_gc_impl_free (default.c:8508)
==25795==    by 0x249651: ruby_sized_xfree.constprop.0 (gc.c:4178)
==25795==    by 0x4626EC: ruby_sized_xfree_inlined (gc.h:277)
==25795==    by 0x4626EC: wmap_free_entry (weakmap.c:45)
==25795==    by 0x4626EC: wmap_mark_weak_table_i (weakmap.c:61)
==25795==    by 0x3A5CEF: apply_functor (st.c:1633)
==25795==    by 0x3A5CEF: st_general_foreach (st.c:1543)
==25795==    by 0x3A5CEF: rb_st_foreach (st.c:1640)
==25795==    by 0x25C991: gc_mark_children (default.c:4870)
==25795==    by 0x25C991: gc_marks_wb_unprotected_objects_plane (default.c:5565)
==25795==    by 0x25C991: rgengc_rememberset_mark_plane (default.c:5557)
==25795==    by 0x25C991: rgengc_rememberset_mark (default.c:6233)
==25795==    by 0x25C991: gc_marks_start (default.c:6057)
==25795==    by 0x25C991: gc_marks (default.c:6077)
==25795==    by 0x25C991: gc_start (default.c:6723)
==25795==    by 0x260F96: heap_prepare (default.c:2282)
==25795==    by 0x260F96: heap_next_free_page (default.c:2489)
==25795==    by 0x260F96: newobj_cache_miss (default.c:2598)
==25795==    by 0x26197F: newobj_alloc (default.c:2622)
==25795==    by 0x26197F: rb_gc_impl_new_obj (default.c:2701)
==25795==    by 0x26197F: newobj_of (gc.c:890)
==25795==    by 0x26197F: rb_wb_protected_newobj_of (gc.c:917)
==25795==    by 0x2DEA88: rb_class_allocate_instance (object.c:131)
==25795==    by 0x2E3B18: class_call_alloc_func (object.c:2141)
==25795==    by 0x2E3B18: rb_class_alloc (object.c:2113)
==25795==    by 0x2E3B18: rb_class_new_instance_pass_kw (object.c:2172)
==25795==    by 0x429DDC: vm_call_cfunc_with_frame_ (vm_insnhelper.c:3786)
==25795==    by 0x44B08D: vm_sendish (vm_insnhelper.c:5953)
==25795==    by 0x44B08D: vm_exec_core (insns.def:898)
==25795==    by 0x43A7A4: rb_vm_exec (vm.c:2564)
==25795==  Block was alloc'd at
==25795==    at 0x484680F: malloc (vg_replace_malloc.c:446)
==25795==    by 0x25CE9E: rb_gc_impl_malloc (default.c:8542)
==25795==    by 0x462A39: wmap_aset_replace (weakmap.c:423)
==25795==    by 0x3A5542: rb_st_update (st.c:1487)
==25795==    by 0x462B8E: wmap_aset (weakmap.c:452)
==25795==    by 0x429DDC: vm_call_cfunc_with_frame_ (vm_insnhelper.c:3786)
==25795==    by 0x44B08D: vm_sendish (vm_insnhelper.c:5953)
==25795==    by 0x44B08D: vm_exec_core (insns.def:898)
==25795==    by 0x43A7A4: rb_vm_exec (vm.c:2564)
==25795==    by 0x234914: rb_ec_exec_node (eval.c:281)
==25795==    by 0x2369B8: ruby_run_node (eval.c:319)
==25795==    by 0x15D675: rb_main (main.c:43)
==25795==    by 0x15D675: main (main.c:62)
```