### PR TITLE
[PRISM] Fix TestTRICK#test_ksk_1

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -5792,6 +5792,8 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                         }
                     }
                     else {
+                        PM_COMPILE_NOT_POPPED(element);
+                        if (++new_array_size >= max_new_array_size) FLUSH_CHUNK;
                         static_literal = true;
                     }
                 } else {


### PR DESCRIPTION
If an array element is a static literal that does not result in a intermediate array, it still needs to be compiled normally.

Fixes https://github.com/ruby/prism/issues/3002