### PR TITLE
Suppress warning for fd leak

### DIFF
--- a/test/resolv/test_dns.rb
+++ b/test/resolv/test_dns.rb
@@ -758,7 +758,7 @@ class TestResolvDNS < Test::Unit::TestCase
           u1.send(msg[0...512], 0, client_address, client_port)
         end
 
-        tcp_server1_thread = Thread.new { t1.accept }
+        tcp_server1_thread = Thread.new { t1.accept; t1.close }
 
         tcp_server2_thread = Thread.new do
           ct = t2.accept


### PR DESCRIPTION
```
Leaked file descriptor: TestResolvDNS#test_multiple_servers_with_timeout_and_truncated_tcp_fallback: 15 : #<TCPSocket:fd 15, AF_INET, 127.0.0.1, 61633>
```