### PR TITLE
automerge needs windows results

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -198,6 +198,16 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
         if: ${{ failure() }}
 
+  result:
+    if: ${{ always() }}
+    name: ${{ github.workflow }} result
+    runs-on: windows-latest
+    needs: [make]
+    steps:
+      - run: exit 1
+        working-directory:
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+
 defaults:
   run:
     working-directory: build


### PR DESCRIPTION
https://github.com/ruby/ruby/pull/11419 is merged with Windows failure. We should prevent that.