### PR TITLE
Fix broken `make test-tool` with Windows

### DIFF
--- a/tool/lib/test/unit.rb
+++ b/tool/lib/test/unit.rb
@@ -415,8 +415,9 @@ module Test
         end
 
         def kill
-          Process.kill(:SEGV, @pid)
-          warn "worker #{to_s} does not respond; SIGSEGV is sent"
+          signal = RUBY_PLATFORM =~ /mswin|mingw/ ? :KILL : :SEGV
+          Process.kill(signal, @pid)
+          warn "worker #{to_s} does not respond; #{signal} is sent"
         rescue Errno::ESRCH
         end
 


### PR DESCRIPTION
We should use `:KILL` with Windows platform.

```
[ 14/191] TestParallel::TestParallel#test_hungup = 11.02 s
  1) Failure:
TestParallel::TestParallel#test_hungup [C:/Users/hsbt/DevDrive/github.com/ruby/ruby/tool/test/testunit/test_parallel.rb:211]:
Expected /^Retrying hung up testcases\.+$/ to match "Run options: \n" +
"  --seed=35582\n" +
"  --ruby\n" +
"  \".\\\\ruby.exe -I../../ruby/lib -I.ext/x64-mswin64_140 -I. ../../ruby/tool/runruby.rb --extout=.ext -- --disable-gems\"\n" +
"  -j\n" +
"  t1\n" +
"  --worker-timeout=1\n" +
"\n" +
"# Running tests:\n" +
"\n" +
"[1/1] 50340=test4test_hungup.\n" +
"C:/Users/hsbt/DevDrive/github.com/ruby/ruby/tool/lib/test/unit.rb:418:in 'Process.kill': Invalid argument (Errno::EINVAL)\n" +
```