### PR TITLE
Use ruby to suppress a warning message by cmd.exe

### DIFF
--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -2543,7 +2543,7 @@ class TestIO < Test::Unit::TestCase
     end
     assert_raise(Errno::ESPIPE) do
       assert_deprecated_warning(/IO process creation with a leading '\|'/) do # https://bugs.ruby-lang.org/issues/19630
-        IO.read("|echo foo", 1, 1)
+        IO.read("|#{EnvUtil.rubybin} -e 'puts :foo'", 1, 1)
       end
     end
   end


### PR DESCRIPTION
It is expected that reading from command with offset fails by ESPIPE and the pipe will be closed immediately.
While this causes the child process to terminate by SIGPIPE usually, cmd.exe yields the message bellow.

```
The process tried to write to a nonexistent pipe.
```