### PR TITLE
[Backport 3.3] [Bug #20688] Fix use-after-free for WeakMap and WeakKeyMap

### DIFF
--- a/test/ruby/test_weakmap.rb
+++ b/test/ruby/test_weakmap.rb
@@ -258,4 +258,11 @@ class TestWeakMap < Test::Unit::TestCase
 
     assert_equal b, @wm[1]
   end
+
+  def test_use_after_free_bug_20688
+    assert_normal_exit(<<~RUBY)
+      weakmap = ObjectSpace::WeakMap.new
+      10_000.times { weakmap[Object.new] = Object.new }
+    RUBY
+  end
 end

--- a/weakmap.c
+++ b/weakmap.c
@@ -52,7 +52,7 @@ wmap_free_entry(VALUE *key, VALUE *val)
 }
 
 struct wmap_foreach_data {
-    void (*func)(struct weakmap_entry *, st_data_t);
+    int (*func)(struct weakmap_entry *, st_data_t);
     st_data_t arg;
 };
 
@@ -68,22 +68,22 @@ wmap_foreach_i(st_data_t key, st_data_t val, st_data_t arg)
         VALUE k = entry->key;
         VALUE v = entry->val;
 
-        data->func(entry, data->arg);
+        int ret = data->func(entry, data->arg);
 
         RB_GC_GUARD(k);
         RB_GC_GUARD(v);
+
+        return ret;
     }
     else {
         wmap_free_entry((VALUE *)key, (VALUE *)val);
 
         return ST_DELETE;
     }
-
-    return ST_CONTINUE;
 }
 
 static void
-wmap_foreach(struct weakmap *w, void (*func)(struct weakmap_entry *, st_data_t), st_data_t arg)
+wmap_foreach(struct weakmap *w, int (*func)(struct weakmap_entry *, st_data_t), st_data_t arg)
 {
     struct wmap_foreach_data foreach_data = {
         .func = func,
@@ -93,11 +93,13 @@ wmap_foreach(struct weakmap *w, void (*func)(struct weakmap_entry *, st_data_t),
     st_foreach(w->table, wmap_foreach_i, (st_data_t)&foreach_data);
 }
 
-static void
+static int
 wmap_mark_weak_table_i(struct weakmap_entry *entry, st_data_t _)
 {
     rb_gc_mark_weak(&entry->key);
     rb_gc_mark_weak(&entry->val);
+
+    return ST_CONTINUE;
 }
 
 static void
@@ -139,34 +141,24 @@ wmap_memsize(const void *ptr)
 }
 
 static int
-wmap_compact_table_i(st_data_t key, st_data_t val, st_data_t data)
+wmap_compact_table_i(struct weakmap_entry *entry, st_data_t data)
 {
     st_table *table = (st_table *)data;
 
-    VALUE key_obj = *(VALUE *)key;
-    VALUE val_obj = *(VALUE *)val;
+    VALUE new_key = rb_gc_location(entry->key);
 
-    if (wmap_live_p(key_obj) && wmap_live_p(val_obj)) {
-        VALUE new_key_obj = rb_gc_location(key_obj);
+    entry->val = rb_gc_location(entry->val);
 
-        *(VALUE *)val = rb_gc_location(val_obj);
+    /* If the key object moves, then we must reinsert because the hash is
+        * based on the pointer rather than the object itself. */
+    if (entry->key != new_key) {
+        entry->key = new_key;
 
-        /* If the key object moves, then we must reinsert because the hash is
-         * based on the pointer rather than the object itself. */
-        if (key_obj != new_key_obj) {
-            *(VALUE *)key = new_key_obj;
-
-            DURING_GC_COULD_MALLOC_REGION_START();
-            {
-                st_insert(table, key, val);
-            }
-            DURING_GC_COULD_MALLOC_REGION_END();
-
-            return ST_DELETE;
+        DURING_GC_COULD_MALLOC_REGION_START();
+        {
+            st_insert(table, (st_data_t)&entry->key, (st_data_t)&entry->val);
         }
-    }
-    else {
-        wmap_free_entry((VALUE *)key, (VALUE *)val);
+        DURING_GC_COULD_MALLOC_REGION_END();
 
         return ST_DELETE;
     }
@@ -180,7 +172,7 @@ wmap_compact(void *ptr)
     struct weakmap *w = ptr;
 
     if (w->table) {
-        st_foreach(w->table, wmap_compact_table_i, (st_data_t)w->table);
+        wmap_foreach(w, wmap_compact_table_i, (st_data_t)w->table);
     }
 }
 
@@ -232,7 +224,7 @@ wmap_inspect_append(VALUE str, VALUE obj)
     }
 }
 
-static void
+static int
 wmap_inspect_i(struct weakmap_entry *entry, st_data_t data)
 {
     VALUE str = (VALUE)data;
@@ -248,6 +240,8 @@ wmap_inspect_i(struct weakmap_entry *entry, st_data_t data)
     wmap_inspect_append(str, entry->key);
     rb_str_cat2(str, " => ");
     wmap_inspect_append(str, entry->val);
+
+    return ST_CONTINUE;
 }
 
 static VALUE
@@ -267,10 +261,12 @@ wmap_inspect(VALUE self)
     return str;
 }
 
-static void
+static int
 wmap_each_i(struct weakmap_entry *entry, st_data_t _)
 {
     rb_yield_values(2, entry->key, entry->val);
+
+    return ST_CONTINUE;
 }
 
 /*
@@ -292,10 +288,12 @@ wmap_each(VALUE self)
     return self;
 }
 
-static void
+static int
 wmap_each_key_i(struct weakmap_entry *entry, st_data_t _data)
 {
     rb_yield(entry->key);
+
+    return ST_CONTINUE;
 }
 
 /*
@@ -317,10 +315,12 @@ wmap_each_key(VALUE self)
     return self;
 }
 
-static void
+static int
 wmap_each_value_i(struct weakmap_entry *entry, st_data_t _data)
 {
     rb_yield(entry->val);
+
+    return ST_CONTINUE;
 }
 
 /*
@@ -342,12 +342,14 @@ wmap_each_value(VALUE self)
     return self;
 }
 
-static void
+static int
 wmap_keys_i(struct weakmap_entry *entry, st_data_t arg)
 {
     VALUE ary = (VALUE)arg;
 
     rb_ary_push(ary, entry->key);
+
+    return ST_CONTINUE;
 }
 
 /*
@@ -369,12 +371,14 @@ wmap_keys(VALUE self)
     return ary;
 }
 
-static void
+static int
 wmap_values_i(struct weakmap_entry *entry, st_data_t arg)
 {
     VALUE ary = (VALUE)arg;
 
     rb_ary_push(ary, entry->val);
+
+    return ST_CONTINUE;
 }
 
 /*

--- a/weakmap.c
+++ b/weakmap.c
@@ -30,6 +30,11 @@ struct weakmap {
     st_table *table;
 };
 
+struct weakmap_entry {
+    VALUE key;
+    VALUE val;
+};
+
 static bool
 wmap_live_p(VALUE obj)
 {
@@ -43,7 +48,7 @@ wmap_free_entry(VALUE *key, VALUE *val)
 
     /* We only need to free key because val is allocated beside key on in the
      * same malloc call. */
-    ruby_sized_xfree(key, sizeof(VALUE) * 2);
+    ruby_sized_xfree(key, sizeof(struct weakmap_entry));
 }
 
 static int
@@ -421,10 +426,10 @@ wmap_aset_replace(st_data_t *key, st_data_t *val, st_data_t new_key_ptr, int exi
         assert(*(VALUE *)*key == new_key);
     }
     else {
-        VALUE *pair = xmalloc(sizeof(VALUE) * 2);
+        struct weakmap_entry *entry = xmalloc(sizeof(struct weakmap_entry));
 
-        *key = (st_data_t)pair;
-        *val = (st_data_t)(pair + 1);
+        *key = (st_data_t)&entry->key;;
+        *val = (st_data_t)&entry->val;
     }
 
     *(VALUE *)*key = new_key;

--- a/weakmap.c
+++ b/weakmap.c
@@ -613,18 +613,24 @@ struct weakkeymap {
 };
 
 static int
-wkmap_mark_table_i(st_data_t key, st_data_t val_obj, st_data_t _)
+wkmap_mark_table_i(st_data_t key, st_data_t val_obj, st_data_t data)
 {
-    VALUE key_obj = *(VALUE *)key;
+    VALUE **dead_entry = (VALUE **)data;
+    if (dead_entry != NULL) {
+        ruby_sized_xfree(*dead_entry, sizeof(VALUE));
+        *dead_entry = NULL;
+    }
 
-    if (wmap_live_p(key_obj)) {
-        rb_gc_mark_weak((VALUE *)key);
+    VALUE *key_ptr = (VALUE *)key;
+
+    if (wmap_live_p(*key_ptr)) {
+        rb_gc_mark_weak(key_ptr);
         rb_gc_mark_movable((VALUE)val_obj);
 
         return ST_CONTINUE;
     }
     else {
-        ruby_sized_xfree((VALUE *)key, sizeof(VALUE));
+        *dead_entry = key_ptr;
 
         return ST_DELETE;
     }
@@ -635,7 +641,11 @@ wkmap_mark(void *ptr)
 {
     struct weakkeymap *w = ptr;
     if (w->table) {
-        st_foreach(w->table, wkmap_mark_table_i, (st_data_t)0);
+        VALUE *dead_entry = NULL;
+        st_foreach(w->table, wkmap_mark_table_i, (st_data_t)&dead_entry);
+        if (dead_entry != NULL) {
+            ruby_sized_xfree(dead_entry, sizeof(VALUE));
+        }
     }
 }
 
@@ -669,22 +679,28 @@ wkmap_memsize(const void *ptr)
 }
 
 static int
-wkmap_compact_table_i(st_data_t key, st_data_t val_obj, st_data_t _data, int _error)
+wkmap_compact_table_i(st_data_t key, st_data_t val_obj, st_data_t data, int _error)
 {
-    VALUE key_obj = *(VALUE *)key;
+    VALUE **dead_entry = (VALUE **)data;
+    if (dead_entry != NULL) {
+        ruby_sized_xfree(*dead_entry, sizeof(VALUE));
+        *dead_entry = NULL;
+    }
 
-    if (wmap_live_p(key_obj)) {
-        if (key_obj != rb_gc_location(key_obj) || val_obj != rb_gc_location(val_obj)) {
+    VALUE *key_ptr = (VALUE *)key;
+
+    if (wmap_live_p(*key_ptr)) {
+        if (*key_ptr != rb_gc_location(*key_ptr) || val_obj != rb_gc_location(val_obj)) {
             return ST_REPLACE;
         }
+
+        return ST_CONTINUE;
     }
     else {
-        ruby_sized_xfree((VALUE *)key, sizeof(VALUE));
+        *dead_entry = key_ptr;
 
         return ST_DELETE;
     }
-
-    return ST_CONTINUE;
 }
 
 static int
@@ -704,7 +720,11 @@ wkmap_compact(void *ptr)
     struct weakkeymap *w = ptr;
 
     if (w->table) {
-        st_foreach_with_replace(w->table, wkmap_compact_table_i, wkmap_compact_table_replace, (st_data_t)0);
+        VALUE *dead_entry = NULL;
+        st_foreach_with_replace(w->table, wkmap_compact_table_i, wkmap_compact_table_replace, (st_data_t)&dead_entry);
+        if (dead_entry != NULL) {
+            ruby_sized_xfree(dead_entry, sizeof(VALUE));
+        }
     }
 }
 

--- a/weakmap.c
+++ b/weakmap.c
@@ -192,8 +192,7 @@ wmap_allocate(VALUE klass)
 }
 
 struct wmap_foreach_data {
-    struct weakmap *w;
-    void (*func)(VALUE, VALUE, st_data_t);
+    void (*func)(struct weakmap_entry *, st_data_t);
     st_data_t arg;
 };
 
@@ -202,11 +201,17 @@ wmap_foreach_i(st_data_t key, st_data_t val, st_data_t arg)
 {
     struct wmap_foreach_data *data = (struct wmap_foreach_data *)arg;
 
-    VALUE key_obj = *(VALUE *)key;
-    VALUE val_obj = *(VALUE *)val;
+    struct weakmap_entry *entry = (struct weakmap_entry *)key;
+    RUBY_ASSERT(&entry->val == (VALUE *)val);
 
-    if (wmap_live_p(key_obj) && wmap_live_p(val_obj)) {
-        data->func(key_obj, val_obj, data->arg);
+    if (wmap_live_p(entry->key) && wmap_live_p(entry->val)) {
+        VALUE k = entry->key;
+        VALUE v = entry->val;
+
+        data->func(entry, data->arg);
+
+        RB_GC_GUARD(k);
+        RB_GC_GUARD(v);
     }
     else {
         wmap_free_entry((VALUE *)key, (VALUE *)val);
@@ -218,10 +223,9 @@ wmap_foreach_i(st_data_t key, st_data_t val, st_data_t arg)
 }
 
 static void
-wmap_foreach(struct weakmap *w, void (*func)(VALUE, VALUE, st_data_t), st_data_t arg)
+wmap_foreach(struct weakmap *w, void (*func)(struct weakmap_entry *, st_data_t), st_data_t arg)
 {
     struct wmap_foreach_data foreach_data = {
-        .w = w,
         .func = func,
         .arg = arg,
     };
@@ -241,7 +245,7 @@ wmap_inspect_append(VALUE str, VALUE obj)
 }
 
 static void
-wmap_inspect_i(VALUE key, VALUE val, st_data_t data)
+wmap_inspect_i(struct weakmap_entry *entry, st_data_t data)
 {
     VALUE str = (VALUE)data;
 
@@ -253,9 +257,9 @@ wmap_inspect_i(VALUE key, VALUE val, st_data_t data)
         RSTRING_PTR(str)[0] = '#';
     }
 
-    wmap_inspect_append(str, key);
+    wmap_inspect_append(str, entry->key);
     rb_str_cat2(str, " => ");
-    wmap_inspect_append(str, val);
+    wmap_inspect_append(str, entry->val);
 }
 
 static VALUE
@@ -276,9 +280,9 @@ wmap_inspect(VALUE self)
 }
 
 static void
-wmap_each_i(VALUE key, VALUE val, st_data_t _)
+wmap_each_i(struct weakmap_entry *entry, st_data_t _)
 {
-    rb_yield_values(2, key, val);
+    rb_yield_values(2, entry->key, entry->val);
 }
 
 /*
@@ -301,9 +305,9 @@ wmap_each(VALUE self)
 }
 
 static void
-wmap_each_key_i(VALUE key, VALUE _val, st_data_t _data)
+wmap_each_key_i(struct weakmap_entry *entry, st_data_t _data)
 {
-    rb_yield(key);
+    rb_yield(entry->key);
 }
 
 /*
@@ -326,9 +330,9 @@ wmap_each_key(VALUE self)
 }
 
 static void
-wmap_each_value_i(VALUE _key, VALUE val, st_data_t _data)
+wmap_each_value_i(struct weakmap_entry *entry, st_data_t _data)
 {
-    rb_yield(val);
+    rb_yield(entry->val);
 }
 
 /*
@@ -351,11 +355,11 @@ wmap_each_value(VALUE self)
 }
 
 static void
-wmap_keys_i(st_data_t key, st_data_t _, st_data_t arg)
+wmap_keys_i(struct weakmap_entry *entry, st_data_t arg)
 {
     VALUE ary = (VALUE)arg;
 
-    rb_ary_push(ary, key);
+    rb_ary_push(ary, entry->key);
 }
 
 /*
@@ -378,11 +382,11 @@ wmap_keys(VALUE self)
 }
 
 static void
-wmap_values_i(st_data_t key, st_data_t val, st_data_t arg)
+wmap_values_i(struct weakmap_entry *entry, st_data_t arg)
 {
     VALUE ary = (VALUE)arg;
 
-    rb_ary_push(ary, (VALUE)val);
+    rb_ary_push(ary, entry->val);
 }
 
 /*

--- a/weakmap.c
+++ b/weakmap.c
@@ -44,12 +44,19 @@ wmap_live_p(VALUE obj)
 struct wmap_foreach_data {
     int (*func)(struct weakmap_entry *, st_data_t);
     st_data_t arg;
+
+    struct weakmap_entry *dead_entry;
 };
 
 static int
 wmap_foreach_i(st_data_t key, st_data_t val, st_data_t arg)
 {
     struct wmap_foreach_data *data = (struct wmap_foreach_data *)arg;
+
+    if (data->dead_entry != NULL) {
+        ruby_sized_xfree(data->dead_entry, sizeof(struct weakmap_entry));
+        data->dead_entry = NULL;
+    }
 
     struct weakmap_entry *entry = (struct weakmap_entry *)key;
     RUBY_ASSERT(&entry->val == (VALUE *)val);
@@ -66,7 +73,11 @@ wmap_foreach_i(st_data_t key, st_data_t val, st_data_t arg)
         return ret;
     }
     else {
-        ruby_sized_xfree(entry, sizeof(struct weakmap_entry));
+        /* We cannot free the weakmap_entry here because the ST_DELETE could
+         * hash the key which would read the weakmap_entry and would cause a
+         * use-after-free. Instead, we store this entry and free it on the next
+         * iteration. */
+        data->dead_entry = entry;
 
         return ST_DELETE;
     }
@@ -78,9 +89,12 @@ wmap_foreach(struct weakmap *w, int (*func)(struct weakmap_entry *, st_data_t), 
     struct wmap_foreach_data foreach_data = {
         .func = func,
         .arg = arg,
+        .dead_entry = NULL,
     };
 
     st_foreach(w->table, wmap_foreach_i, (st_data_t)&foreach_data);
+
+    ruby_sized_xfree(foreach_data.dead_entry, sizeof(struct weakmap_entry));
 }
 
 static int

--- a/weakmap.c
+++ b/weakmap.c
@@ -51,23 +51,53 @@ wmap_free_entry(VALUE *key, VALUE *val)
     ruby_sized_xfree(key, sizeof(struct weakmap_entry));
 }
 
+struct wmap_foreach_data {
+    void (*func)(struct weakmap_entry *, st_data_t);
+    st_data_t arg;
+};
+
 static int
-wmap_mark_weak_table_i(st_data_t key, st_data_t val, st_data_t _)
+wmap_foreach_i(st_data_t key, st_data_t val, st_data_t arg)
 {
-    VALUE key_obj = *(VALUE *)key;
-    VALUE val_obj = *(VALUE *)val;
+    struct wmap_foreach_data *data = (struct wmap_foreach_data *)arg;
 
-    if (wmap_live_p(key_obj) && wmap_live_p(val_obj)) {
-        rb_gc_mark_weak((VALUE *)key);
-        rb_gc_mark_weak((VALUE *)val);
+    struct weakmap_entry *entry = (struct weakmap_entry *)key;
+    RUBY_ASSERT(&entry->val == (VALUE *)val);
 
-        return ST_CONTINUE;
+    if (wmap_live_p(entry->key) && wmap_live_p(entry->val)) {
+        VALUE k = entry->key;
+        VALUE v = entry->val;
+
+        data->func(entry, data->arg);
+
+        RB_GC_GUARD(k);
+        RB_GC_GUARD(v);
     }
     else {
         wmap_free_entry((VALUE *)key, (VALUE *)val);
 
         return ST_DELETE;
     }
+
+    return ST_CONTINUE;
+}
+
+static void
+wmap_foreach(struct weakmap *w, void (*func)(struct weakmap_entry *, st_data_t), st_data_t arg)
+{
+    struct wmap_foreach_data foreach_data = {
+        .func = func,
+        .arg = arg,
+    };
+
+    st_foreach(w->table, wmap_foreach_i, (st_data_t)&foreach_data);
+}
+
+static void
+wmap_mark_weak_table_i(struct weakmap_entry *entry, st_data_t _)
+{
+    rb_gc_mark_weak(&entry->key);
+    rb_gc_mark_weak(&entry->val);
 }
 
 static void
@@ -75,7 +105,7 @@ wmap_mark(void *ptr)
 {
     struct weakmap *w = ptr;
     if (w->table) {
-        st_foreach(w->table, wmap_mark_weak_table_i, (st_data_t)0);
+        wmap_foreach(w, wmap_mark_weak_table_i, (st_data_t)0);
     }
 }
 
@@ -189,48 +219,6 @@ wmap_allocate(VALUE klass)
     VALUE obj = TypedData_Make_Struct(klass, struct weakmap, &weakmap_type, w);
     w->table = st_init_table(&wmap_hash_type);
     return obj;
-}
-
-struct wmap_foreach_data {
-    void (*func)(struct weakmap_entry *, st_data_t);
-    st_data_t arg;
-};
-
-static int
-wmap_foreach_i(st_data_t key, st_data_t val, st_data_t arg)
-{
-    struct wmap_foreach_data *data = (struct wmap_foreach_data *)arg;
-
-    struct weakmap_entry *entry = (struct weakmap_entry *)key;
-    RUBY_ASSERT(&entry->val == (VALUE *)val);
-
-    if (wmap_live_p(entry->key) && wmap_live_p(entry->val)) {
-        VALUE k = entry->key;
-        VALUE v = entry->val;
-
-        data->func(entry, data->arg);
-
-        RB_GC_GUARD(k);
-        RB_GC_GUARD(v);
-    }
-    else {
-        wmap_free_entry((VALUE *)key, (VALUE *)val);
-
-        return ST_DELETE;
-    }
-
-    return ST_CONTINUE;
-}
-
-static void
-wmap_foreach(struct weakmap *w, void (*func)(struct weakmap_entry *, st_data_t), st_data_t arg)
-{
-    struct wmap_foreach_data foreach_data = {
-        .func = func,
-        .arg = arg,
-    };
-
-    st_foreach(w->table, wmap_foreach_i, (st_data_t)&foreach_data);
 }
 
 static VALUE


### PR DESCRIPTION
We cannot free the weakmap_entry before the ST_DELETE because it could hash the key which would read the weakmap_entry and would cause a use-after-free. Instead, we store the entry and free it on the next iteration.

For example, the following script triggers a use-after-free in Valgrind:

```ruby
weakmap = ObjectSpace::WeakMap.new
10_000.times { weakmap[Object.new] = Object.new }
```

```
==25795== Invalid read of size 8
==25795==    at 0x462297: wmap_cmp (weakmap.c:165)
==25795==    by 0x3A2B1C: find_table_bin_ind (st.c:930)
==25795==    by 0x3A5EAA: st_general_foreach (st.c:1599)
==25795==    by 0x3A5EAA: rb_st_foreach (st.c:1640)
==25795==    by 0x25C991: gc_mark_children (default.c:4870)
==25795==    by 0x25C991: gc_marks_wb_unprotected_objects_plane (default.c:5565)
==25795==    by 0x25C991: rgengc_rememberset_mark_plane (default.c:5557)
==25795==    by 0x25C991: rgengc_rememberset_mark (default.c:6233)
==25795==    by 0x25C991: gc_marks_start (default.c:6057)
==25795==    by 0x25C991: gc_marks (default.c:6077)
==25795==    by 0x25C991: gc_start (default.c:6723)
==25795==    by 0x260F96: heap_prepare (default.c:2282)
==25795==    by 0x260F96: heap_next_free_page (default.c:2489)
==25795==    by 0x260F96: newobj_cache_miss (default.c:2598)
==25795==    by 0x26197F: newobj_alloc (default.c:2622)
==25795==    by 0x26197F: rb_gc_impl_new_obj (default.c:2701)
==25795==    by 0x26197F: newobj_of (gc.c:890)
==25795==    by 0x26197F: rb_wb_protected_newobj_of (gc.c:917)
==25795==    by 0x2DEA88: rb_class_allocate_instance (object.c:131)
==25795==    by 0x2E3B18: class_call_alloc_func (object.c:2141)
==25795==    by 0x2E3B18: rb_class_alloc (object.c:2113)
==25795==    by 0x2E3B18: rb_class_new_instance_pass_kw (object.c:2172)
==25795==    by 0x429DDC: vm_call_cfunc_with_frame_ (vm_insnhelper.c:3786)
==25795==    by 0x44B08D: vm_sendish (vm_insnhelper.c:5953)
==25795==    by 0x44B08D: vm_exec_core (insns.def:898)
==25795==    by 0x43A7A4: rb_vm_exec (vm.c:2564)
==25795==    by 0x234914: rb_ec_exec_node (eval.c:281)
==25795==  Address 0x21603710 is 0 bytes inside a block of size 16 free'd
==25795==    at 0x4849B2C: free (vg_replace_malloc.c:989)
==25795==    by 0x249651: rb_gc_impl_free (default.c:8527)
==25795==    by 0x249651: rb_gc_impl_free (default.c:8508)
==25795==    by 0x249651: ruby_sized_xfree.constprop.0 (gc.c:4178)
==25795==    by 0x4626EC: ruby_sized_xfree_inlined (gc.h:277)
==25795==    by 0x4626EC: wmap_free_entry (weakmap.c:45)
==25795==    by 0x4626EC: wmap_mark_weak_table_i (weakmap.c:61)
==25795==    by 0x3A5CEF: apply_functor (st.c:1633)
==25795==    by 0x3A5CEF: st_general_foreach (st.c:1543)
==25795==    by 0x3A5CEF: rb_st_foreach (st.c:1640)
==25795==    by 0x25C991: gc_mark_children (default.c:4870)
==25795==    by 0x25C991: gc_marks_wb_unprotected_objects_plane (default.c:5565)
==25795==    by 0x25C991: rgengc_rememberset_mark_plane (default.c:5557)
==25795==    by 0x25C991: rgengc_rememberset_mark (default.c:6233)
==25795==    by 0x25C991: gc_marks_start (default.c:6057)
==25795==    by 0x25C991: gc_marks (default.c:6077)
==25795==    by 0x25C991: gc_start (default.c:6723)
==25795==    by 0x260F96: heap_prepare (default.c:2282)
==25795==    by 0x260F96: heap_next_free_page (default.c:2489)
==25795==    by 0x260F96: newobj_cache_miss (default.c:2598)
==25795==    by 0x26197F: newobj_alloc (default.c:2622)
==25795==    by 0x26197F: rb_gc_impl_new_obj (default.c:2701)
==25795==    by 0x26197F: newobj_of (gc.c:890)
==25795==    by 0x26197F: rb_wb_protected_newobj_of (gc.c:917)
==25795==    by 0x2DEA88: rb_class_allocate_instance (object.c:131)
==25795==    by 0x2E3B18: class_call_alloc_func (object.c:2141)
==25795==    by 0x2E3B18: rb_class_alloc (object.c:2113)
==25795==    by 0x2E3B18: rb_class_new_instance_pass_kw (object.c:2172)
==25795==    by 0x429DDC: vm_call_cfunc_with_frame_ (vm_insnhelper.c:3786)
==25795==    by 0x44B08D: vm_sendish (vm_insnhelper.c:5953)
==25795==    by 0x44B08D: vm_exec_core (insns.def:898)
==25795==    by 0x43A7A4: rb_vm_exec (vm.c:2564)
==25795==  Block was alloc'd at
==25795==    at 0x484680F: malloc (vg_replace_malloc.c:446)
==25795==    by 0x25CE9E: rb_gc_impl_malloc (default.c:8542)
==25795==    by 0x462A39: wmap_aset_replace (weakmap.c:423)
==25795==    by 0x3A5542: rb_st_update (st.c:1487)
==25795==    by 0x462B8E: wmap_aset (weakmap.c:452)
==25795==    by 0x429DDC: vm_call_cfunc_with_frame_ (vm_insnhelper.c:3786)
==25795==    by 0x44B08D: vm_sendish (vm_insnhelper.c:5953)
==25795==    by 0x44B08D: vm_exec_core (insns.def:898)
==25795==    by 0x43A7A4: rb_vm_exec (vm.c:2564)
==25795==    by 0x234914: rb_ec_exec_node (eval.c:281)
==25795==    by 0x2369B8: ruby_run_node (eval.c:319)
==25795==    by 0x15D675: rb_main (main.c:43)
==25795==    by 0x15D675: main (main.c:62)
```