### PR TITLE
Enable native SOCKS support by default [Feature #20673]

### DIFF
--- a/ext/socket/extconf.rb
+++ b/ext/socket/extconf.rb
@@ -661,7 +661,7 @@ EOS
 
   $distcleanfiles << "constants.h" << "constdefs.*"
 
-  if enable_config("socks", ENV["SOCKS_SERVER"])
+  if enable_config("socks", true)
     if have_library("socks5", "SOCKSinit")
       $defs << "-DSOCKS5" << "-DSOCKS"
     elsif have_library("socksd", "Rconnect") || have_library("socks", "Rconnect")


### PR DESCRIPTION
Before:
Enable SOCKS support when `configure` with `--enable-socks` or `make` with `SOCKS_SERVER` environment variable.

After:
Enable SOCKS support when `configure` without `--disable-socks`.

Both:
Enabling SOCKS support needs socks library when `make`. (socks5, socksd, or socks)