### PR TITLE
[DOC] Fix typos in ObjectSpace::WeakMap docs

### DIFF
--- a/weakmap.c
+++ b/weakmap.c
@@ -1019,7 +1019,7 @@ wkmap_inspect(VALUE self)
  *     val1 = Object.new
  *     m[key1] = val1
  *
- *     key2 = "foo"
+ *     key2 = "bar"
  *     val2 = Object.new
  *     m[key2] = val2
  *


### PR DESCRIPTION
The value of variable key2 should be "bar". This way, when nil is assigned to val1 and garbage collection occurs, the output of m.keys will then be ["bar"].