### PR TITLE
Fix how Prism parses encoding from shebang args (`#!`)

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -2121,12 +2121,24 @@ prism_script_shebang_callback(pm_options_t *options, const uint8_t *source, size
     memcpy(switches, source, length);
     switches[length] = '\0';
 
+    int no_src_enc = !opt->src.enc.name;
+    int no_ext_enc = !opt->ext.enc.name;
+    int no_int_enc = !opt->intern.enc.name;
+
     moreswitches(switches, opt, 0);
     free(switches);
 
     pm_options_command_line_set(options, prism_script_command_line(opt));
-    if (opt->ext.enc.name != 0) {
+
+    if (no_src_enc && opt->src.enc.name) {
+        opt->src.enc.index = opt_enc_index(opt->src.enc.name);
         pm_options_encoding_set(options, StringValueCStr(opt->ext.enc.name));
+    }
+    if (no_ext_enc && opt->ext.enc.name) {
+        opt->ext.enc.index = opt_enc_index(opt->ext.enc.name);
+    }
+    if (no_int_enc && opt->intern.enc.name) {
+        opt->intern.enc.index = opt_enc_index(opt->intern.enc.name);
     }
 }
 


### PR DESCRIPTION
Fix the first of the two assertion failures here:

```ruby
TestRubyOptions#test_shebang [/Users/alex/src/github.com/Ruby/ruby/test/ruby/test_rubyoptions.rb:514]:
pid 49518 exit 0.

1. [1/2] Assertion for "stdout"
   | <["\"あ\""]> expected but was
   | <["\"\\u3042\""]>.

2. [2/2] Assertion for "stderr"
   | Expected /shebang line ending with \\r/ to match "".

Finished tests in 0.030572s, 32.7097 tests/s, 359.8064 assertions/s.
1 tests, 11 assertions, 1 failures, 0 errors, 0 skips

ruby -v: ruby 3.4.0dev (2024-08-22T14:01:55Z master 56a34b5af5) +PRISM [arm64-darwin23]
make: *** [yes-test-all] Error 1
```

(The latter was fixed in https://github.com/ruby/prism/pull/3007)

Fixes https://github.com/ruby/prism/issues/2996