### PR TITLE
[Bug #20697] Parse `r` suffix at Rational

### DIFF
--- a/rational.c
+++ b/rational.c
@@ -2304,6 +2304,12 @@ islettere(int c)
     return (c == 'e' || c == 'E');
 }
 
+inline static int
+isletterr(int c)
+{
+    return (c == 'r' || c == 'R');
+}
+
 static VALUE
 negate_num(VALUE num)
 {
@@ -2353,7 +2359,13 @@ read_num(const char **s, const char *const end, VALUE *num, VALUE *nexp)
         ok = 1;
     }
 
-    if (ok && *s + 1 < end && islettere(**s)) {
+    if (!ok || *s >= end) {
+        /* failed or finish */
+    }
+    else if (isletterr(**s)) {
+        (*s)++;
+    }
+    else if (*s + 1 < end && islettere(**s)) {
         (*s)++;
         expsign = read_sign(s, end);
         exp = rb_int_parse_cstr(*s, end-*s, &e, NULL,

--- a/test/ruby/test_rational.rb
+++ b/test/ruby/test_rational.rb
@@ -65,7 +65,7 @@ class Rational_Test < Test::Unit::TestCase
     assert_instance_of(String, c.to_s)
   end
 
-  def test_conv
+  def test_conv_integer
     c = Rational(0,1)
     assert_equal(Rational(0,1), c)
 
@@ -94,6 +94,11 @@ class Rational_Test < Test::Unit::TestCase
     c = Rational(Rational(1,2),Rational(1,2))
     assert_equal(Rational(1), c)
 
+    assert_equal(Rational(3),Rational(3))
+    assert_equal(Rational(1),Rational(3,3))
+  end
+
+  def test_conv_complex
     c = Rational(Complex(1,2),2)
     assert_equal(Complex(Rational(1,2),1), c)
 
@@ -102,11 +107,21 @@ class Rational_Test < Test::Unit::TestCase
 
     c = Rational(Complex(1,2),Complex(1,2))
     assert_equal(Rational(1), c)
+  end
 
-    assert_equal(Rational(3),Rational(3))
-    assert_equal(Rational(1),Rational(3,3))
+  def test_conv_float
     assert_equal(3.3.to_r,Rational(3.3))
     assert_equal(1,Rational(3.3,3.3))
+
+    if (0.0/0).nan?
+      assert_raise(FloatDomainError){Rational(0.0/0)}
+    end
+    if (1.0/0).infinite?
+      assert_raise(FloatDomainError){Rational(1.0/0)}
+    end
+  end
+
+  def test_conv_string
     assert_equal(Rational(3),Rational('3'))
     assert_equal(Rational(1),Rational('3.0','3.0'))
     assert_equal(Rational(1),Rational('3/3','3/3'))
@@ -115,6 +130,9 @@ class Rational_Test < Test::Unit::TestCase
     assert_equal(Rational(111, 10), Rational('1.11e1'))
     assert_equal(Rational(111, 100), Rational('1.11e0'))
     assert_equal(Rational(111, 1000), Rational('1.11e-1'))
+  end
+
+  def test_conv_error
     assert_raise(TypeError){Rational(nil)}
     assert_raise(ArgumentError){Rational('')}
 
@@ -131,7 +149,9 @@ class Rational_Test < Test::Unit::TestCase
     assert_raise(TypeError){Rational(Object.new)}
     assert_raise(TypeError){Rational(Object.new, Object.new)}
     assert_raise(TypeError){Rational(1, Object.new)}
+  end
 
+  def test_conv_coerce
     bug12485 = '[ruby-core:75995] [Bug #12485]'
     o = Object.new
     def o.to_int; 1; end
@@ -162,13 +182,6 @@ class Rational_Test < Test::Unit::TestCase
 
     assert_raise(ArgumentError){Rational()}
     assert_raise(ArgumentError){Rational(1,2,3)}
-
-    if (0.0/0).nan?
-      assert_raise(FloatDomainError){Rational(0.0/0)}
-    end
-    if (1.0/0).infinite?
-      assert_raise(FloatDomainError){Rational(1.0/0)}
-    end
 
     bug16518 = "[ruby-core:96942] [Bug #16518]"
     cls = Class.new(Numeric) do

--- a/test/ruby/test_rational.rb
+++ b/test/ruby/test_rational.rb
@@ -130,6 +130,7 @@ class Rational_Test < Test::Unit::TestCase
     assert_equal(Rational(111, 10), Rational('1.11e1'))
     assert_equal(Rational(111, 100), Rational('1.11e0'))
     assert_equal(Rational(111, 1000), Rational('1.11e-1'))
+    assert_equal(Rational(5, 4), Rational('3.0r','2.4R'))
   end
 
   def test_conv_error
@@ -842,6 +843,10 @@ class Rational_Test < Test::Unit::TestCase
     ng[5, 3, '5/3x']
 
     ng[5, 1, '5/-3']
+
+    ok[30, 24, '3.0r/2.4R']
+    ng[30, 24, '3.0r/2.4re1']
+    ng[30, 240, '3.0r/2.4e1r']
   end
 
   def test_parse_zero_denominator


### PR DESCRIPTION
[[Bug #20697]](https://bugs.ruby-lang.org/issues/20697)