### PR TITLE
[Bug #20680] `ensure` block is always void context

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -3005,7 +3005,7 @@ program		:  {
 
 top_compstmt	: top_stmts terms?
                     {
-                        $$ = void_stmts(p, $1);
+                        void_stmts(p, $$ = $1);
                     }
                 ;
 
@@ -3082,7 +3082,7 @@ bodystmt	: compstmt[body]
 
 compstmt	: stmts terms?
                     {
-                        $$ = void_stmts(p, $1);
+                        void_stmts(p, $$ = $1);
                     }
                 ;
 
@@ -5994,10 +5994,11 @@ exc_var		: tASSOC lhs
                 | none
                 ;
 
-opt_ensure	: k_ensure compstmt
+opt_ensure	: k_ensure stmts terms?
                     {
                         p->ctxt.in_rescue = $1.in_rescue;
                         $$ = $2;
+                        void_expr(p, void_stmts(p, $$));
                     /*% ripper: ensure!($:2) %*/
                     }
                 | none
@@ -14038,6 +14039,7 @@ void_expr(struct parser_params *p, NODE *node)
     }
 }
 
+/* warns useless use of block and returns the last statement node */
 static NODE *
 void_stmts(struct parser_params *p, NODE *node)
 {
@@ -14050,7 +14052,7 @@ void_stmts(struct parser_params *p, NODE *node)
         void_expr(p, RNODE_BLOCK(node)->nd_head);
         node = RNODE_BLOCK(node)->nd_next;
     }
-    return n;
+    return RNODE_BLOCK(node)->nd_head;
 }
 
 static NODE *

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -273,7 +273,7 @@ class TestAst < Test::Unit::TestCase
     assert_parse("def m; defined?(retry); end")
     assert_parse("!begin defined?(retry); end")
     assert_parse("begin rescue; else; defined?(retry); end")
-    assert_parse("begin rescue; ensure; defined?(retry); end")
+    assert_parse("begin rescue; ensure; p defined?(retry); end")
     assert_parse("END {defined?(retry)}")
     assert_parse("begin rescue; END {defined?(retry)}; end")
     assert_parse("!defined? retry")
@@ -281,7 +281,7 @@ class TestAst < Test::Unit::TestCase
     assert_parse("def m; defined? retry; end")
     assert_parse("!begin defined? retry; end")
     assert_parse("begin rescue; else; defined? retry; end")
-    assert_parse("begin rescue; ensure; defined? retry; end")
+    assert_parse("begin rescue; ensure; p defined? retry; end")
     assert_parse("END {defined? retry}")
     assert_parse("begin rescue; END {defined? retry}; end")
 

--- a/test/ruby/test_parse.rb
+++ b/test/ruby/test_parse.rb
@@ -952,6 +952,7 @@ x = __ENCODING__
     assert_nil assert_warning(useless_use) {eval("true; nil")}
     assert_nil assert_warning(useless_use) {eval("false; nil")}
     assert_nil assert_warning(useless_use) {eval("defined?(1); nil")}
+    assert_nil assert_warning(useless_use) {eval("begin; ensure; x; end")}
     assert_equal 1, x
 
     assert_syntax_error("1; next; 2", /Invalid next/)


### PR DESCRIPTION
[[Bug #20680]](https://bugs.ruby-lang.org/issues/20680)