### PR TITLE
Remove outdated documentation information from `Set.to_a`

### DIFF
--- a/lib/set.rb
+++ b/lib/set.rb
@@ -335,7 +335,7 @@ class Set
     end
   end
 
-  # Converts the set to an array.  The order of elements is uncertain.
+  # Converts the set to an array.
   #
   #     Set[1, 2].to_a                    #=> [1, 2]
   #     Set[1, 'c', :s].to_a              #=> [1, "c", :s]


### PR DESCRIPTION
Just removing the note _"The order of elements is uncertain."_  from the documentation.

This information is no longer true since ruby 1.9, when hashes started having its elements iterated in order of their respective insertion.

The methods `delete_if` and `keep if` in this same class even go on the length of ensure the *subclasses won't break the enumeration order*.