### PR TITLE
Fix test failure of daily package CI

### DIFF
--- a/spec/bundler/cache/git_spec.rb
+++ b/spec/bundler/cache/git_spec.rb
@@ -294,6 +294,8 @@ RSpec.describe "bundle cache with git" do
     FileUtils.mkdir_p bundled_app("vendor/cache")
     FileUtils.cp_r git_path, bundled_app("vendor/cache/foo-1.0-#{path_revision}")
     FileUtils.rm_rf bundled_app("vendor/cache/foo-1.0-#{path_revision}/.git")
+    # bundle install with git repo needs to be run under the git environment.
+    Dir.chdir(bundled_app) { system(*%W[git init --quiet]) }
 
     bundle :install, env: { "BUNDLE_DEPLOYMENT" => "true", "BUNDLE_CACHE_ALL" => "true" }
   end


### PR DESCRIPTION
Fix https://github.com/ruby/actions/actions/runs/10513692214/job/29130044376#step:19:3550

```
       Git error: command `git rev-parse --is-bare-repository` in directory /home/runner/work/actions/actions/snapshot-master/tmp/1.7/bundled_app/vendor/cache/foo-1.0-f18431e82ed6 has failed.
       fatal: not a git repository (or any of the parent directories): .git
```

This failure is only happened under that tar package.