### PR TITLE
Remove `enc_coderange_broken` field from `struct rb_parser_config_struct`

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -418,7 +418,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .enc_coderange_7bit = ENC_CODERANGE_7BIT,
     .enc_coderange_unknown = ENC_CODERANGE_UNKNOWN,
     .usascii_encoding = usascii_encoding,
-    .enc_coderange_broken = ENC_CODERANGE_BROKEN,
     .enc_mbminlen = enc_mbminlen,
     .enc_isascii = enc_isascii,
     .enc_mbc_to_codepoint = enc_mbc_to_codepoint,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1247,7 +1247,6 @@ typedef struct rb_parser_config_struct {
     rb_encoding *(*enc_from_index)(int idx);
     int (*enc_isspace)(OnigCodePoint c, rb_encoding *enc);
     rb_encoding *(*usascii_encoding)(void);
-    int enc_coderange_broken;
     int (*enc_mbminlen)(rb_encoding *enc);
     bool (*enc_isascii)(OnigCodePoint c, rb_encoding *enc);
     OnigCodePoint (*enc_mbc_to_codepoint)(const char *p, const char *e, rb_encoding *enc);


### PR DESCRIPTION
It has not been used since fcc55dc2261b4c61da711c10a5476d05d4391eca.