### PR TITLE
Merge URI-0.12.3 for Ruby 3.2

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -19,6 +19,8 @@ module URI
   Parser = RFC2396_Parser
   RFC3986_PARSER = RFC3986_Parser.new
   Ractor.make_shareable(RFC3986_PARSER) if defined?(Ractor)
+  RFC2396_PARSER = RFC2396_Parser.new
+  Ractor.make_shareable(RFC2396_PARSER) if defined?(Ractor)
 
   # URI::Parser.new
   DEFAULT_PARSER = Parser.new

--- a/lib/uri/version.rb
+++ b/lib/uri/version.rb
@@ -1,6 +1,6 @@
 module URI
   # :stopdoc:
-  VERSION_CODE = '001202'.freeze
+  VERSION_CODE = '001203'.freeze
   VERSION = VERSION_CODE.scan(/../).collect{|n| n.to_i}.join('.').freeze
   # :startdoc:
 end


### PR DESCRIPTION
For https://github.com/ruby/uri/issues/118.

Ruby 3.4 will deprecate some methods like `RFC3986_PARSER.escape`. We should add `RFC2396_PARSER` constant for that migration with old Ruby version.