### PR TITLE
[Bug #20701] Add tests for mutable kwargs bug

### DIFF
--- a/test/ruby/test_call.rb
+++ b/test/ruby/test_call.rb
@@ -345,6 +345,18 @@ class TestCall < Test::Unit::TestCase
     assert_equal Hash, f(*[], **o).class
   end
 
+  def test_call_args_splat_with_pos_arg_kw_splat_is_not_mutable
+    o = Object.new
+    def o.foo(a, **h)= h[:splat_modified] = true
+
+    a = []
+    b = {splat_modified: false}
+
+    o.foo(*a, :x, **b)
+
+    assert_equal({splat_modified: false}, b)
+  end
+
   def test_kwsplat_block_order
     o = Object.new
     ary = []


### PR DESCRIPTION
Adds tests for for the case a splatted Hash is mutated inside a method, after is called with alongside a splatted array followed by a positional argument.

See: https://bugs.ruby-lang.org/issues/20701