### PR TITLE
Add RB_DEFAULT_PARSER preprocessor macro

### DIFF
--- a/internal/parse.h
+++ b/internal/parse.h
@@ -12,6 +12,13 @@
 #include "rubyparser.h"
 #include "internal/static_assert.h"
 
+// The default parser to use for Ruby code.
+// 0: parse.y
+// 1: Prism
+#ifndef RB_DEFAULT_PARSER
+#define RB_DEFAULT_PARSER 0
+#endif
+
 #ifdef UNIVERSAL_PARSER
 #define rb_encoding const void
 #endif

--- a/ruby.c
+++ b/ruby.c
@@ -1428,10 +1428,10 @@ proc_long_options(ruby_cmdline_options_t *opt, const char *s, long argc, char **
     }
     else if (is_option_with_arg("parser", Qfalse, Qtrue)) {
         if (strcmp("prism", s) == 0) {
-            (*rb_ruby_prism_ptr()) = true;
+            *rb_ruby_prism_ptr() = true;
         }
         else if (strcmp("parse.y", s) == 0) {
-            // default behavior
+            *rb_ruby_prism_ptr() = false;
         }
         else {
             rb_raise(rb_eRuntimeError, "unknown parser %s", s);
@@ -3113,8 +3113,6 @@ ruby_process_options(int argc, char **argv)
     ruby_cmdline_options_t opt;
     VALUE iseq;
     const char *script_name = (argc > 0 && argv[0]) ? argv[0] : ruby_engine;
-
-    (*rb_ruby_prism_ptr()) = false;
 
     if (!origarg.argv || origarg.argc <= 0) {
         origarg.argc = argc;

--- a/vm.c
+++ b/vm.c
@@ -4456,7 +4456,7 @@ rb_ruby_verbose_ptr(void)
     return &cr->verbose;
 }
 
-static bool prism;
+static bool prism = (RB_DEFAULT_PARSER == 1);
 
 bool *
 rb_ruby_prism_ptr(void)


### PR DESCRIPTION
This way there is one place to change for switching the default, and allows for building the same commit with different cppflags.