### PR TITLE
[DOC] Remove Array#abbrev

### DIFF
--- a/array.c
+++ b/array.c
@@ -8692,7 +8692,6 @@ rb_ary_deconstruct(VALUE ary)
  *    - With string argument +field_separator+, a new string that is equivalent to
  *      <tt>join(field_separator)</tt>.
  *
- *  - #abbrev: Returns a hash of unambiguous abbreviations for elements.
  *  - #pack: Packs the elements into a binary sequence.
  *  - #sum: Returns a sum of elements according to either <tt>+</tt> or a given block.
  */


### PR DESCRIPTION
Doesn't seem to be in master any more. (Don't know what happened to it.)