### PR TITLE
[PRISM] Field renaming

### DIFF
--- a/lib/prism/desugar_compiler.rb
+++ b/lib/prism/desugar_compiler.rb
@@ -60,7 +60,7 @@ module Prism
           location: node.location,
           body: [public_send(read_class, location: node.name_loc, **arguments)]
         ),
-        consequent: else_node(
+        subsequent: else_node(
           location: node.location,
           else_keyword_loc: node.operator_loc,
           statements: statements_node(

--- a/lib/prism/translation/parser/compiler.rb
+++ b/lib/prism/translation/parser/compiler.rb
@@ -181,7 +181,7 @@ module Prism
           if (rescue_clause = node.rescue_clause)
             begin
               find_start_offset = (rescue_clause.reference&.location || rescue_clause.exceptions.last&.location || rescue_clause.keyword_loc).end_offset
-              find_end_offset = (rescue_clause.statements&.location&.start_offset || rescue_clause.consequent&.location&.start_offset || (find_start_offset + 1))
+              find_end_offset = (rescue_clause.statements&.location&.start_offset || rescue_clause.subsequent&.location&.start_offset || (find_start_offset + 1))
 
               rescue_bodies << builder.rescue_body(
                 token(rescue_clause.keyword_loc),
@@ -191,7 +191,7 @@ module Prism
                 srange_find(find_start_offset, find_end_offset, [";"]),
                 visit(rescue_clause.statements)
               )
-            end until (rescue_clause = rescue_clause.consequent).nil?
+            end until (rescue_clause = rescue_clause.subsequent).nil?
           end
 
           begin_body =
@@ -410,8 +410,8 @@ module Prism
             token(node.case_keyword_loc),
             visit(node.predicate),
             visit_all(node.conditions),
-            token(node.consequent&.else_keyword_loc),
-            visit(node.consequent),
+            token(node.else_clause&.else_keyword_loc),
+            visit(node.else_clause),
             token(node.end_keyword_loc)
           )
         end
@@ -423,8 +423,8 @@ module Prism
             token(node.case_keyword_loc),
             visit(node.predicate),
             visit_all(node.conditions),
-            token(node.consequent&.else_keyword_loc),
-            visit(node.consequent),
+            token(node.else_clause&.else_keyword_loc),
+            visit(node.else_clause),
             token(node.end_keyword_loc)
           )
         end
@@ -858,8 +858,8 @@ module Prism
               visit(node.predicate),
               token(node.then_keyword_loc),
               visit(node.statements),
-              token(node.consequent.else_keyword_loc),
-              visit(node.consequent)
+              token(node.subsequent.else_keyword_loc),
+              visit(node.subsequent)
             )
           elsif node.if_keyword_loc.start_offset == node.location.start_offset
             builder.condition(
@@ -868,16 +868,16 @@ module Prism
               if node.then_keyword_loc
                 token(node.then_keyword_loc)
               else
-                srange_find(node.predicate.location.end_offset, (node.statements&.location || node.consequent&.location || node.end_keyword_loc).start_offset, [";"])
+                srange_find(node.predicate.location.end_offset, (node.statements&.location || node.subsequent&.location || node.end_keyword_loc).start_offset, [";"])
               end,
               visit(node.statements),
-              case node.consequent
+              case node.subsequent
               when IfNode
-                token(node.consequent.if_keyword_loc)
+                token(node.subsequent.if_keyword_loc)
               when ElseNode
-                token(node.consequent.else_keyword_loc)
+                token(node.subsequent.else_keyword_loc)
               end,
-              visit(node.consequent),
+              visit(node.subsequent),
               if node.if_keyword != "elsif"
                 token(node.end_keyword_loc)
               end
@@ -885,7 +885,7 @@ module Prism
           else
             builder.condition_mod(
               visit(node.statements),
-              visit(node.consequent),
+              visit(node.subsequent),
               token(node.if_keyword_loc),
               visit(node.predicate)
             )
@@ -1784,16 +1784,16 @@ module Prism
               if node.then_keyword_loc
                 token(node.then_keyword_loc)
               else
-                srange_find(node.predicate.location.end_offset, (node.statements&.location || node.consequent&.location || node.end_keyword_loc).start_offset, [";"])
+                srange_find(node.predicate.location.end_offset, (node.statements&.location || node.else_clause&.location || node.end_keyword_loc).start_offset, [";"])
               end,
-              visit(node.consequent),
-              token(node.consequent&.else_keyword_loc),
+              visit(node.else_clause),
+              token(node.else_clause&.else_keyword_loc),
               visit(node.statements),
               token(node.end_keyword_loc)
             )
           else
             builder.condition_mod(
-              visit(node.consequent),
+              visit(node.else_clause),
               visit(node.statements),
               token(node.keyword_loc),
               visit(node.predicate)

--- a/lib/prism/translation/ripper.rb
+++ b/lib/prism/translation/ripper.rb
@@ -1273,8 +1273,8 @@ module Prism
       def visit_case_node(node)
         predicate = visit(node.predicate)
         clauses =
-          node.conditions.reverse_each.inject(visit(node.consequent)) do |consequent, condition|
-            on_when(*visit(condition), consequent)
+          node.conditions.reverse_each.inject(visit(node.else_clause)) do |current, condition|
+            on_when(*visit(condition), current)
           end
 
         bounds(node.location)
@@ -1286,8 +1286,8 @@ module Prism
       def visit_case_match_node(node)
         predicate = visit(node.predicate)
         clauses =
-          node.conditions.reverse_each.inject(visit(node.consequent)) do |consequent, condition|
-            on_in(*visit(condition), consequent)
+          node.conditions.reverse_each.inject(visit(node.else_clause)) do |current, condition|
+            on_in(*visit(condition), current)
           end
 
         bounds(node.location)
@@ -1908,7 +1908,7 @@ module Prism
         if node.then_keyword == "?"
           predicate = visit(node.predicate)
           truthy = visit(node.statements.body.first)
-          falsy = visit(node.consequent.statements.body.first)
+          falsy = visit(node.subsequent.statements.body.first)
 
           bounds(node.location)
           on_ifop(predicate, truthy, falsy)
@@ -1921,13 +1921,13 @@ module Prism
             else
               visit(node.statements)
             end
-          consequent = visit(node.consequent)
+          subsequent = visit(node.subsequent)
 
           bounds(node.location)
           if node.if_keyword == "if"
-            on_if(predicate, statements, consequent)
+            on_if(predicate, statements, subsequent)
           else
-            on_elsif(predicate, statements, consequent)
+            on_elsif(predicate, statements, subsequent)
           end
         else
           statements = visit(node.statements.body.first)
@@ -1960,7 +1960,7 @@ module Prism
       # ^^^^^^^^^^^^^^^^^^^^^
       def visit_in_node(node)
         # This is a special case where we're not going to call on_in directly
-        # because we don't have access to the consequent. Instead, we'll return
+        # because we don't have access to the subsequent. Instead, we'll return
         # the component parts and let the parent node handle it.
         pattern = visit_pattern_node(node.pattern)
         statements =
@@ -2808,10 +2808,10 @@ module Prism
             visit(node.statements)
           end
 
-        consequent = visit(node.consequent)
+        subsequent = visit(node.subsequent)
 
         bounds(node.location)
-        on_rescue(exceptions, reference, statements, consequent)
+        on_rescue(exceptions, reference, statements, subsequent)
       end
 
       # def foo(*bar); end
@@ -3132,10 +3132,10 @@ module Prism
             else
               visit(node.statements)
             end
-          consequent = visit(node.consequent)
+          else_clause = visit(node.else_clause)
 
           bounds(node.location)
-          on_unless(predicate, statements, consequent)
+          on_unless(predicate, statements, else_clause)
         else
           statements = visit(node.statements.body.first)
           predicate = visit(node.predicate)
@@ -3176,7 +3176,7 @@ module Prism
       #           ^^^^^^^^^^^^^
       def visit_when_node(node)
         # This is a special case where we're not going to call on_when directly
-        # because we don't have access to the consequent. Instead, we'll return
+        # because we don't have access to the subsequent. Instead, we'll return
         # the component parts and let the parent node handle it.
         conditions = visit_arguments(node.conditions)
         statements =

--- a/lib/prism/translation/ruby_parser.rb
+++ b/lib/prism/translation/ruby_parser.rb
@@ -147,7 +147,7 @@ module Prism
             end
 
             current = node.rescue_clause
-            until (current = current.consequent).nil?
+            until (current = current.subsequent).nil?
               result << visit(current)
             end
           end
@@ -347,13 +347,13 @@ module Prism
         # case foo; when bar; end
         # ^^^^^^^^^^^^^^^^^^^^^^^
         def visit_case_node(node)
-          s(node, :case, visit(node.predicate)).concat(visit_all(node.conditions)) << visit(node.consequent)
+          s(node, :case, visit(node.predicate)).concat(visit_all(node.conditions)) << visit(node.else_clause)
         end
 
         # case foo; in bar; end
         # ^^^^^^^^^^^^^^^^^^^^^
         def visit_case_match_node(node)
-          s(node, :case, visit(node.predicate)).concat(visit_all(node.conditions)) << visit(node.consequent)
+          s(node, :case, visit(node.predicate)).concat(visit_all(node.conditions)) << visit(node.else_clause)
         end
 
         # class Foo; end
@@ -700,7 +700,7 @@ module Prism
         # foo ? bar : baz
         # ^^^^^^^^^^^^^^^
         def visit_if_node(node)
-          s(node, :if, visit(node.predicate), visit(node.statements), visit(node.consequent))
+          s(node, :if, visit(node.predicate), visit(node.statements), visit(node.subsequent))
         end
 
         # 1i
@@ -1470,7 +1470,7 @@ module Prism
         # bar unless foo
         # ^^^^^^^^^^^^^^
         def visit_unless_node(node)
-          s(node, :if, visit(node.predicate), visit(node.consequent), visit(node.statements))
+          s(node, :if, visit(node.predicate), visit(node.else_clause), visit(node.statements))
         end
 
         # until foo; bar end

--- a/prism/config.yml
+++ b/prism/config.yml
@@ -1310,7 +1310,7 @@ nodes:
         type: node?
       - name: conditions
         type: node[]
-      - name: consequent
+      - name: else_clause
         type: node?
         kind: ElseNode
       - name: case_keyword_loc
@@ -1330,7 +1330,7 @@ nodes:
         type: node?
       - name: conditions
         type: node[]
-      - name: consequent
+      - name: else_clause
         type: node?
         kind: ElseNode
       - name: case_keyword_loc
@@ -2187,7 +2187,7 @@ nodes:
                 baz
                 ^^^
               end
-      - name: consequent
+      - name: subsequent
         type: node?
         kind:
           - ElseNode
@@ -3448,7 +3448,7 @@ nodes:
       - name: statements
         type: node?
         kind: StatementsNode
-      - name: consequent
+      - name: subsequent
         type: node?
         kind: RescueNode
     comment: |
@@ -3703,7 +3703,7 @@ nodes:
 
               unless cond then bar end
                                ^^^
-      - name: consequent
+      - name: else_clause
         type: node?
         kind: ElseNode
         comment: |

--- a/test/prism/result/source_location_test.rb
+++ b/test/prism/result/source_location_test.rb
@@ -315,8 +315,8 @@ module Prism
     end
 
     def test_ElseNode
-      assert_location(ElseNode, "if foo; bar; else; baz; end", 13...27, &:consequent)
-      assert_location(ElseNode, "foo ? bar : baz", 10...15, &:consequent)
+      assert_location(ElseNode, "if foo; bar; else; baz; end", 13...27, &:subsequent)
+      assert_location(ElseNode, "foo ? bar : baz", 10...15, &:subsequent)
     end
 
     def test_EmbeddedStatementsNode
@@ -758,7 +758,7 @@ module Prism
       end
       RUBY
       assert_location(RescueNode, code, 13...50) { |node| node.rescue_clause }
-      assert_location(RescueNode, code, 30...50) { |node| node.rescue_clause.consequent }
+      assert_location(RescueNode, code, 30...50) { |node| node.rescue_clause.subsequent }
     end
 
     def test_RescueModifierNode
@@ -827,8 +827,8 @@ module Prism
       assert_location(StatementsNode, "if foo; bar; end", 8...11, &:statements)
       assert_location(StatementsNode, "foo if bar", 0...3, &:statements)
 
-      assert_location(StatementsNode, "if foo; foo; elsif bar; bar; end", 24...27) { |node| node.consequent.statements }
-      assert_location(StatementsNode, "if foo; foo; else; bar; end", 19...22) { |node| node.consequent.statements }
+      assert_location(StatementsNode, "if foo; foo; elsif bar; bar; end", 24...27) { |node| node.subsequent.statements }
+      assert_location(StatementsNode, "if foo; foo; else; bar; end", 19...22) { |node| node.subsequent.statements }
 
       assert_location(StatementsNode, "unless foo; bar; end", 12...15, &:statements)
       assert_location(StatementsNode, "foo unless bar", 0...3, &:statements)

--- a/test/prism/snapshots/arrays.txt
+++ b/test/prism/snapshots/arrays.txt
@@ -1802,7 +1802,7 @@
         │   │   │   │   ├── closing_loc: (120,23)-(120,24) = "]"
         │   │   │   │   └── block: ∅
         │   │   │   ├── statements: ∅
-        │   │   │   └── consequent: ∅
+        │   │   │   └── subsequent: ∅
         │   │   ├── else_clause: ∅
         │   │   ├── ensure_clause: ∅
         │   │   └── end_keyword_loc: (120,26)-(120,29) = "end"
@@ -1873,7 +1873,7 @@
             │   │   │   ├── closing_loc: (122,26)-(122,27) = "]"
             │   │   │   └── block: ∅
             │   │   ├── statements: ∅
-            │   │   └── consequent: ∅
+            │   │   └── subsequent: ∅
             │   ├── else_clause: ∅
             │   ├── ensure_clause: ∅
             │   └── end_keyword_loc: (122,29)-(122,32) = "end"

--- a/test/prism/snapshots/begin_rescue.txt
+++ b/test/prism/snapshots/begin_rescue.txt
@@ -43,7 +43,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause:
         │   │   @ ElseNode (location: (1,21)-(1,33))
         │   │   ├── flags: ∅
@@ -103,7 +103,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause:
         │   │   @ ElseNode (location: (3,21)-(3,36))
         │   │   ├── flags: ∅
@@ -265,7 +265,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent:
+        │   │   └── subsequent:
         │   │       @ RescueNode (location: (20,0)-(23,1))
         │   │       ├── flags: ∅
         │   │       ├── keyword_loc: (20,0)-(20,6) = "rescue"
@@ -286,7 +286,7 @@
         │   │       │           ├── arguments: ∅
         │   │       │           ├── closing_loc: ∅
         │   │       │           └── block: ∅
-        │   │       └── consequent:
+        │   │       └── subsequent:
         │   │           @ RescueNode (location: (22,0)-(23,1))
         │   │           ├── flags: ∅
         │   │           ├── keyword_loc: (22,0)-(22,6) = "rescue"
@@ -307,7 +307,7 @@
         │   │           │           ├── arguments: ∅
         │   │           │           ├── closing_loc: ∅
         │   │           │           └── block: ∅
-        │   │           └── consequent: ∅
+        │   │           └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (24,0)-(24,3) = "end"
@@ -356,7 +356,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent:
+        │   │   └── subsequent:
         │   │       @ RescueNode (location: (30,0)-(31,3))
         │   │       ├── flags: ∅
         │   │       ├── keyword_loc: (30,0)-(30,6) = "rescue"
@@ -387,7 +387,7 @@
         │   │       │           ├── arguments: ∅
         │   │       │           ├── closing_loc: ∅
         │   │       │           └── block: ∅
-        │   │       └── consequent: ∅
+        │   │       └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (32,0)-(32,3) = "end"
@@ -436,7 +436,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause:
         │   │   @ EnsureNode (location: (38,0)-(40,3))
@@ -502,7 +502,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (48,0)-(48,3) = "end"
@@ -544,7 +544,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (50,17)-(50,20) = "end"
@@ -586,7 +586,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (54,2)-(54,5) = "end"
@@ -631,7 +631,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (60,0)-(60,3) = "end"
@@ -679,7 +679,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (66,0)-(66,3) = "end"
@@ -731,7 +731,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (72,0)-(72,3) = "end"
@@ -780,7 +780,7 @@
             │   │           ├── arguments: ∅
             │   │           ├── closing_loc: ∅
             │   │           └── block: ∅
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause: ∅
             ├── ensure_clause: ∅
             └── end_keyword_loc: (78,0)-(78,3) = "end"

--- a/test/prism/snapshots/blocks.txt
+++ b/test/prism/snapshots/blocks.txt
@@ -409,7 +409,7 @@
         │       │   │   ├── operator_loc: ∅
         │       │   │   ├── reference: ∅
         │       │   │   ├── statements: ∅
-        │       │   │   └── consequent: ∅
+        │       │   │   └── subsequent: ∅
         │       │   ├── else_clause: ∅
         │       │   ├── ensure_clause: ∅
         │       │   └── end_keyword_loc: (22,0)-(22,3) = "end"

--- a/test/prism/snapshots/case.txt
+++ b/test/prism/snapshots/case.txt
@@ -27,7 +27,7 @@
         │   │       │       └── unescaped: "hi"
         │   │       ├── then_keyword_loc: ∅
         │   │       └── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (1,0)-(1,4) = "case"
         │   └── end_keyword_loc: (3,0)-(3,3) = "end"
         ├── @ CaseNode (location: (5,0)-(5,58))
@@ -96,7 +96,7 @@
         │   │                   │           └── unescaped: "bye"
         │   │                   ├── closing_loc: ∅
         │   │                   └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (5,0)-(5,4) = "case"
         │   └── end_keyword_loc: (5,55)-(5,58) = "end"
         ├── @ CaseNode (location: (7,0)-(7,20))
@@ -123,7 +123,7 @@
         │   │       │           └── block: ∅
         │   │       ├── then_keyword_loc: ∅
         │   │       └── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (7,0)-(7,4) = "case"
         │   └── end_keyword_loc: (7,17)-(7,20) = "end"
         ├── @ CaseNode (location: (9,0)-(13,3))
@@ -148,7 +148,7 @@
         │   │       │       └── unescaped: "hi"
         │   │       ├── then_keyword_loc: ∅
         │   │       └── statements: ∅
-        │   ├── consequent:
+        │   ├── else_clause:
         │   │   @ ElseNode (location: (11,0)-(13,3))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (11,0)-(11,4) = "else"
@@ -191,7 +191,7 @@
         │   │       │       └── name: :BazBonk
         │   │       ├── then_keyword_loc: ∅
         │   │       └── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (15,0)-(15,4) = "case"
         │   └── end_keyword_loc: (15,33)-(15,36) = "end"
         ├── @ CaseNode (location: (17,0)-(19,3))
@@ -237,7 +237,7 @@
         │   │       │       └── block: ∅
         │   │       ├── then_keyword_loc: ∅
         │   │       └── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (17,0)-(17,4) = "case"
         │   └── end_keyword_loc: (19,0)-(19,3) = "end"
         ├── @ CaseNode (location: (21,0)-(25,3))
@@ -260,7 +260,7 @@
         │   │       │       └── block: ∅
         │   │       ├── then_keyword_loc: ∅
         │   │       └── statements: ∅
-        │   ├── consequent:
+        │   ├── else_clause:
         │   │   @ ElseNode (location: (23,0)-(25,3))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (23,0)-(23,4) = "else"
@@ -294,7 +294,7 @@
         │   │       │       └── unescaped: "b"
         │   │       ├── then_keyword_loc: ∅
         │   │       └── statements: ∅
-        │   ├── consequent:
+        │   ├── else_clause:
         │   │   @ ElseNode (location: (29,5)-(30,6))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (29,5)-(29,9) = "else"
@@ -315,7 +315,7 @@
         │   │       │       └── value: 1
         │   │       ├── then_keyword_loc: ∅
         │   │       └── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (32,0)-(32,4) = "case"
         │   └── end_keyword_loc: (32,22)-(32,25) = "end"
         ├── @ CaseNode (location: (34,0)-(36,3))
@@ -342,7 +342,7 @@
         │   │       │       └── value: 3
         │   │       ├── then_keyword_loc: ∅
         │   │       └── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (34,0)-(34,4) = "case"
         │   └── end_keyword_loc: (36,0)-(36,3) = "end"
         ├── @ CaseNode (location: (38,0)-(38,24))
@@ -369,7 +369,7 @@
         │   │       │       └── value: 3
         │   │       ├── then_keyword_loc: ∅
         │   │       └── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (38,0)-(38,4) = "case"
         │   └── end_keyword_loc: (38,21)-(38,24) = "end"
         ├── @ CaseMatchNode (location: (40,0)-(42,3))
@@ -396,7 +396,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (41,0)-(41,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (40,0)-(40,4) = "case"
         │   └── end_keyword_loc: (42,0)-(42,3) = "end"
         ├── @ CaseMatchNode (location: (44,0)-(44,22))
@@ -423,7 +423,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (44,13)-(44,15) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (44,0)-(44,4) = "case"
         │   └── end_keyword_loc: (44,19)-(44,22) = "end"
         ├── @ CaseMatchNode (location: (46,0)-(49,3))
@@ -481,7 +481,7 @@
         │   │       │   │           ├── flags: newline
         │   │       │   │           ├── name: :b
         │   │       │   │           └── depth: 0
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements:
         │   │       │   @ StatementsNode (location: (48,2)-(48,3))
@@ -499,7 +499,7 @@
         │   │       │           └── block: ∅
         │   │       ├── in_loc: (47,0)-(47,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (46,0)-(46,4) = "case"
         │   └── end_keyword_loc: (49,0)-(49,3) = "end"
         └── @ CallNode (location: (51,0)-(55,3))
@@ -547,7 +547,7 @@
                 │           │       ├── statements: ∅
                 │           │       ├── in_loc: (53,2)-(53,4) = "in"
                 │           │       └── then_loc: ∅
-                │           ├── consequent: ∅
+                │           ├── else_clause: ∅
                 │           ├── case_keyword_loc: (52,2)-(52,6) = "case"
                 │           └── end_keyword_loc: (54,2)-(54,5) = "end"
                 ├── opening_loc: (51,7)-(51,9) = "do"

--- a/test/prism/snapshots/classes.txt
+++ b/test/prism/snapshots/classes.txt
@@ -80,7 +80,7 @@
         │   │   │   ├── operator_loc: ∅
         │   │   │   ├── reference: ∅
         │   │   │   ├── statements: ∅
-        │   │   │   └── consequent: ∅
+        │   │   │   └── subsequent: ∅
         │   │   ├── else_clause:
         │   │   │   @ ElseNode (location: (5,17)-(5,29))
         │   │   │   ├── flags: ∅
@@ -227,7 +227,7 @@
         │   │           │   │   ├── operator_loc: ∅
         │   │           │   │   ├── reference: ∅
         │   │           │   │   ├── statements: ∅
-        │   │           │   │   └── consequent: ∅
+        │   │           │   │   └── subsequent: ∅
         │   │           │   ├── else_clause:
         │   │           │   │   @ ElseNode (location: (16,32)-(16,44))
         │   │           │   │   ├── flags: ∅

--- a/test/prism/snapshots/command_method_call.txt
+++ b/test/prism/snapshots/command_method_call.txt
@@ -91,7 +91,7 @@
         │   │           │           └── value: 1
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: ∅
         ├── @ UnlessNode (location: (7,0)-(7,18))
         │   ├── flags: newline
@@ -134,7 +134,7 @@
         │   │           │           └── value: 1
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   └── end_keyword_loc: ∅
         ├── @ WhileNode (location: (9,0)-(9,17))
         │   ├── flags: newline

--- a/test/prism/snapshots/endless_range_in_conditional.txt
+++ b/test/prism/snapshots/endless_range_in_conditional.txt
@@ -22,7 +22,7 @@
         │   │   └── operator_loc: (1,4)-(1,6) = ".."
         │   ├── then_keyword_loc: ∅
         │   ├── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (1,10)-(1,13) = "end"
         ├── @ IfNode (location: (2,0)-(2,12))
         │   ├── flags: newline
@@ -38,7 +38,7 @@
         │   │   └── operator_loc: (2,3)-(2,5) = ".."
         │   ├── then_keyword_loc: ∅
         │   ├── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (2,9)-(2,12) = "end"
         └── @ IfNode (location: (3,0)-(3,12))
             ├── flags: newline
@@ -54,5 +54,5 @@
             │   └── operator_loc: (3,4)-(3,6) = ".."
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (3,9)-(3,12) = "end"

--- a/test/prism/snapshots/if.txt
+++ b/test/prism/snapshots/if.txt
@@ -19,7 +19,7 @@
         │   │       └── @ IntegerNode (location: (1,9)-(1,10))
         │   │           ├── flags: newline, static_literal, decimal
         │   │           └── value: 1
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (1,12)-(1,15) = "end"
         ├── @ IfNode (location: (3,0)-(4,12))
         │   ├── flags: newline
@@ -35,7 +35,7 @@
         │   │       └── @ IntegerNode (location: (4,0)-(4,1))
         │   │           ├── flags: newline, static_literal, decimal
         │   │           └── value: 1
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (4,2)-(4,12))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (4,2)-(4,6) = "else"
@@ -61,7 +61,7 @@
         │   │   └── body: (length: 1)
         │   │       └── @ TrueNode (location: (6,13)-(6,17))
         │   │           └── flags: newline, static_literal
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ IfNode (location: (6,18)-(6,73))
         │   │   ├── flags: newline
         │   │   ├── if_keyword_loc: (6,18)-(6,23) = "elsif"
@@ -75,7 +75,7 @@
         │   │   │   └── body: (length: 1)
         │   │   │       └── @ FalseNode (location: (6,35)-(6,40))
         │   │   │           └── flags: newline, static_literal
-        │   │   ├── consequent:
+        │   │   ├── subsequent:
         │   │   │   @ IfNode (location: (6,41)-(6,73))
         │   │   │   ├── flags: newline
         │   │   │   ├── if_keyword_loc: (6,41)-(6,46) = "elsif"
@@ -89,7 +89,7 @@
         │   │   │   │   └── body: (length: 1)
         │   │   │   │       └── @ NilNode (location: (6,56)-(6,59))
         │   │   │   │           └── flags: newline, static_literal
-        │   │   │   ├── consequent:
+        │   │   │   ├── subsequent:
         │   │   │   │   @ ElseNode (location: (6,60)-(6,73))
         │   │   │   │   ├── flags: ∅
         │   │   │   │   ├── else_keyword_loc: (6,60)-(6,64) = "else"
@@ -117,7 +117,7 @@
         │   │       └── @ IntegerNode (location: (8,0)-(8,1))
         │   │           ├── flags: newline, static_literal, decimal
         │   │           └── value: 1
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: ∅
         ├── @ CallNode (location: (10,0)-(10,21))
         │   ├── flags: newline, ignore_visibility
@@ -152,7 +152,7 @@
         │       │           │           ├── flags: newline
         │       │           │           ├── arguments: ∅
         │       │           │           └── keyword_loc: (10,6)-(10,11) = "break"
-        │       │           ├── consequent: ∅
+        │       │           ├── subsequent: ∅
         │       │           └── end_keyword_loc: ∅
         │       ├── opening_loc: (10,4)-(10,5) = "{"
         │       └── closing_loc: (10,20)-(10,21) = "}"
@@ -189,7 +189,7 @@
         │       │           │           ├── flags: newline
         │       │           │           ├── arguments: ∅
         │       │           │           └── keyword_loc: (12,6)-(12,10) = "next"
-        │       │           ├── consequent: ∅
+        │       │           ├── subsequent: ∅
         │       │           └── end_keyword_loc: ∅
         │       ├── opening_loc: (12,4)-(12,5) = "{"
         │       └── closing_loc: (12,19)-(12,20) = "}"
@@ -208,7 +208,7 @@
         │   │           ├── flags: newline
         │   │           ├── keyword_loc: (14,0)-(14,6) = "return"
         │   │           └── arguments: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: ∅
         ├── @ CallNode (location: (16,0)-(16,38))
         │   ├── flags: newline, ignore_visibility
@@ -257,7 +257,7 @@
         │       │           │           │           ├── flags: static_literal, decimal
         │       │           │           │           └── value: 42
         │       │           │           └── keyword_loc: (16,24)-(16,29) = "break"
-        │       │           ├── consequent: ∅
+        │       │           ├── subsequent: ∅
         │       │           └── end_keyword_loc: (16,33)-(16,36) = "end"
         │       ├── opening_loc: (16,4)-(16,5) = "{"
         │       └── closing_loc: (16,37)-(16,38) = "}"
@@ -290,7 +290,7 @@
         │   │           ├── arguments: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (20,0)-(20,3) = "end"
         ├── @ IfNode (location: (22,0)-(22,11))
         │   ├── flags: newline
@@ -340,9 +340,9 @@
         │   │           │           ├── arguments: ∅
         │   │           │           ├── closing_loc: ∅
         │   │           │           └── block: ∅
-        │   │           ├── consequent: ∅
+        │   │           ├── subsequent: ∅
         │   │           └── end_keyword_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: ∅
         ├── @ IfNode (location: (24,0)-(27,3))
         │   ├── flags: newline
@@ -395,7 +395,7 @@
         │   │           │                   └── operator_loc: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (26,0)-(27,3))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (26,0)-(26,4) = "else"
@@ -426,7 +426,7 @@
         │   │   └── operator_loc: (29,8)-(29,10) = "in"
         │   ├── then_keyword_loc: ∅
         │   ├── statements: ∅
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ IfNode (location: (30,0)-(31,3))
         │   │   ├── flags: newline
         │   │   ├── if_keyword_loc: (30,0)-(30,5) = "elsif"
@@ -451,7 +451,7 @@
         │   │   │   └── operator_loc: (30,11)-(30,13) = "in"
         │   │   ├── then_keyword_loc: ∅
         │   │   ├── statements: ∅
-        │   │   ├── consequent: ∅
+        │   │   ├── subsequent: ∅
         │   │   └── end_keyword_loc: (31,0)-(31,3) = "end"
         │   └── end_keyword_loc: (31,0)-(31,3) = "end"
         └── @ IfNode (location: (33,0)-(42,3))
@@ -508,7 +508,7 @@
             │               ├── body: ∅
             │               ├── opening_loc: (34,9)-(34,11) = "do"
             │               └── closing_loc: (35,2)-(35,5) = "end"
-            ├── consequent:
+            ├── subsequent:
             │   @ IfNode (location: (36,0)-(42,3))
             │   ├── flags: newline
             │   ├── if_keyword_loc: (36,0)-(36,5) = "elsif"
@@ -563,7 +563,7 @@
             │   │               ├── body: ∅
             │   │               ├── opening_loc: (37,9)-(37,11) = "do"
             │   │               └── closing_loc: (38,2)-(38,5) = "end"
-            │   ├── consequent:
+            │   ├── subsequent:
             │   │   @ ElseNode (location: (39,0)-(42,3))
             │   │   ├── flags: ∅
             │   │   ├── else_keyword_loc: (39,0)-(39,4) = "else"

--- a/test/prism/snapshots/keywords.txt
+++ b/test/prism/snapshots/keywords.txt
@@ -44,7 +44,7 @@
         │   │   │   └── body: (length: 1)
         │   │   │       └── @ RetryNode (location: (3,15)-(3,20))
         │   │   │           └── flags: newline
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (3,22)-(3,25) = "end"

--- a/test/prism/snapshots/method_calls.txt
+++ b/test/prism/snapshots/method_calls.txt
@@ -727,7 +727,7 @@
         │   │           │           └── unescaped: "b"
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: ∅
         ├── @ CallNode (location: (53,0)-(56,1))
         │   ├── flags: newline, ignore_visibility
@@ -2047,7 +2047,7 @@
         │   │           │               │           └── depth: 0
         │   │           │               ├── opening_loc: (121,8)-(121,10) = "do"
         │   │           │               └── closing_loc: (123,4)-(123,7) = "end"
-        │   │           ├── consequent: ∅
+        │   │           ├── subsequent: ∅
         │   │           └── end_keyword_loc: (124,2)-(124,5) = "end"
         │   ├── closing_loc: ∅
         │   └── block: ∅

--- a/test/prism/snapshots/methods.txt
+++ b/test/prism/snapshots/methods.txt
@@ -717,7 +717,7 @@
         │   │   │   ├── operator_loc: ∅
         │   │   │   ├── reference: ∅
         │   │   │   ├── statements: ∅
-        │   │   │   └── consequent: ∅
+        │   │   │   └── subsequent: ∅
         │   │   ├── else_clause:
         │   │   │   @ ElseNode (location: (77,15)-(77,27))
         │   │   │   ├── flags: ∅
@@ -901,7 +901,7 @@
         │   │       │   │                       ├── value_loc: (99,8)-(99,10) = "hi"
         │   │       │   │                       ├── closing_loc: ∅
         │   │       │   │                       └── unescaped: "hi"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       └── @ SymbolNode (location: (100,0)-(100,4))
         │   │           ├── flags: newline, static_literal, forced_us_ascii_encoding

--- a/test/prism/snapshots/modules.txt
+++ b/test/prism/snapshots/modules.txt
@@ -122,7 +122,7 @@
         │   │   │   ├── operator_loc: ∅
         │   │   │   ├── reference: ∅
         │   │   │   ├── statements: ∅
-        │   │   │   └── consequent: ∅
+        │   │   │   └── subsequent: ∅
         │   │   ├── else_clause: ∅
         │   │   ├── ensure_clause: ∅
         │   │   └── end_keyword_loc: (9,16)-(9,19) = "end"

--- a/test/prism/snapshots/patterns.txt
+++ b/test/prism/snapshots/patterns.txt
@@ -3226,7 +3226,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (135,10)-(135,12) = "in"
         │   │       └── then_loc: (135,17)-(135,21) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (135,0)-(135,4) = "case"
         │   └── end_keyword_loc: (135,22)-(135,25) = "end"
         ├── @ CaseMatchNode (location: (136,0)-(136,23))
@@ -3252,7 +3252,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (136,10)-(136,12) = "in"
         │   │       └── then_loc: (136,15)-(136,19) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (136,0)-(136,4) = "case"
         │   └── end_keyword_loc: (136,20)-(136,23) = "end"
         ├── @ CaseMatchNode (location: (137,0)-(137,25))
@@ -3278,7 +3278,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (137,10)-(137,12) = "in"
         │   │       └── then_loc: (137,17)-(137,21) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (137,0)-(137,4) = "case"
         │   └── end_keyword_loc: (137,22)-(137,25) = "end"
         ├── @ CaseMatchNode (location: (138,0)-(138,24))
@@ -3307,7 +3307,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (138,10)-(138,12) = "in"
         │   │       └── then_loc: (138,16)-(138,20) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (138,0)-(138,4) = "case"
         │   └── end_keyword_loc: (138,21)-(138,24) = "end"
         ├── @ CaseMatchNode (location: (139,0)-(139,24))
@@ -3334,7 +3334,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (139,10)-(139,12) = "in"
         │   │       └── then_loc: (139,16)-(139,20) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (139,0)-(139,4) = "case"
         │   └── end_keyword_loc: (139,21)-(139,24) = "end"
         ├── @ CaseMatchNode (location: (140,0)-(140,26))
@@ -3363,7 +3363,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (140,10)-(140,12) = "in"
         │   │       └── then_loc: (140,18)-(140,22) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (140,0)-(140,4) = "case"
         │   └── end_keyword_loc: (140,23)-(140,26) = "end"
         ├── @ CaseMatchNode (location: (141,0)-(141,29))
@@ -3392,7 +3392,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (141,10)-(141,12) = "in"
         │   │       └── then_loc: (141,21)-(141,25) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (141,0)-(141,4) = "case"
         │   └── end_keyword_loc: (141,26)-(141,29) = "end"
         ├── @ CaseMatchNode (location: (142,0)-(142,28))
@@ -3421,7 +3421,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (142,10)-(142,12) = "in"
         │   │       └── then_loc: (142,20)-(142,24) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (142,0)-(142,4) = "case"
         │   └── end_keyword_loc: (142,25)-(142,28) = "end"
         ├── @ CaseMatchNode (location: (143,0)-(143,27))
@@ -3450,7 +3450,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (143,10)-(143,12) = "in"
         │   │       └── then_loc: (143,19)-(143,23) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (143,0)-(143,4) = "case"
         │   └── end_keyword_loc: (143,24)-(143,27) = "end"
         ├── @ CaseMatchNode (location: (144,0)-(144,27))
@@ -3479,7 +3479,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (144,10)-(144,12) = "in"
         │   │       └── then_loc: (144,19)-(144,23) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (144,0)-(144,4) = "case"
         │   └── end_keyword_loc: (144,24)-(144,27) = "end"
         ├── @ CaseMatchNode (location: (145,0)-(145,29))
@@ -3508,7 +3508,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (145,10)-(145,12) = "in"
         │   │       └── then_loc: (145,21)-(145,25) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (145,0)-(145,4) = "case"
         │   └── end_keyword_loc: (145,26)-(145,29) = "end"
         ├── @ CaseMatchNode (location: (146,0)-(146,29))
@@ -3542,7 +3542,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (146,10)-(146,12) = "in"
         │   │       └── then_loc: (146,21)-(146,25) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (146,0)-(146,4) = "case"
         │   └── end_keyword_loc: (146,26)-(146,29) = "end"
         ├── @ CaseMatchNode (location: (147,0)-(147,29))
@@ -3576,7 +3576,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (147,10)-(147,12) = "in"
         │   │       └── then_loc: (147,21)-(147,25) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (147,0)-(147,4) = "case"
         │   └── end_keyword_loc: (147,26)-(147,29) = "end"
         ├── @ CaseMatchNode (location: (148,0)-(148,29))
@@ -3610,7 +3610,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (148,10)-(148,12) = "in"
         │   │       └── then_loc: (148,21)-(148,25) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (148,0)-(148,4) = "case"
         │   └── end_keyword_loc: (148,26)-(148,29) = "end"
         ├── @ CaseMatchNode (location: (149,0)-(149,29))
@@ -3644,7 +3644,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (149,10)-(149,12) = "in"
         │   │       └── then_loc: (149,21)-(149,25) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (149,0)-(149,4) = "case"
         │   └── end_keyword_loc: (149,26)-(149,29) = "end"
         ├── @ CaseMatchNode (location: (150,0)-(150,29))
@@ -3673,7 +3673,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (150,10)-(150,12) = "in"
         │   │       └── then_loc: (150,21)-(150,25) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (150,0)-(150,4) = "case"
         │   └── end_keyword_loc: (150,26)-(150,29) = "end"
         ├── @ CaseMatchNode (location: (151,0)-(151,29))
@@ -3702,7 +3702,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (151,10)-(151,12) = "in"
         │   │       └── then_loc: (151,21)-(151,25) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (151,0)-(151,4) = "case"
         │   └── end_keyword_loc: (151,26)-(151,29) = "end"
         ├── @ CaseMatchNode (location: (152,0)-(152,27))
@@ -3731,7 +3731,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (152,10)-(152,12) = "in"
         │   │       └── then_loc: (152,19)-(152,23) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (152,0)-(152,4) = "case"
         │   └── end_keyword_loc: (152,24)-(152,27) = "end"
         ├── @ CaseMatchNode (location: (153,0)-(153,25))
@@ -3756,7 +3756,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (153,10)-(153,12) = "in"
         │   │       └── then_loc: (153,17)-(153,21) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (153,0)-(153,4) = "case"
         │   └── end_keyword_loc: (153,22)-(153,25) = "end"
         ├── @ CaseMatchNode (location: (154,0)-(154,26))
@@ -3781,7 +3781,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (154,10)-(154,12) = "in"
         │   │       └── then_loc: (154,18)-(154,22) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (154,0)-(154,4) = "case"
         │   └── end_keyword_loc: (154,23)-(154,26) = "end"
         ├── @ CaseMatchNode (location: (155,0)-(155,26))
@@ -3806,7 +3806,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (155,10)-(155,12) = "in"
         │   │       └── then_loc: (155,18)-(155,22) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (155,0)-(155,4) = "case"
         │   └── end_keyword_loc: (155,23)-(155,26) = "end"
         ├── @ CaseMatchNode (location: (156,0)-(156,27))
@@ -3831,7 +3831,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (156,10)-(156,12) = "in"
         │   │       └── then_loc: (156,19)-(156,23) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (156,0)-(156,4) = "case"
         │   └── end_keyword_loc: (156,24)-(156,27) = "end"
         ├── @ CaseMatchNode (location: (157,0)-(157,30))
@@ -3857,7 +3857,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (157,10)-(157,12) = "in"
         │   │       └── then_loc: (157,22)-(157,26) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (157,0)-(157,4) = "case"
         │   └── end_keyword_loc: (157,27)-(157,30) = "end"
         ├── @ CaseMatchNode (location: (158,0)-(158,30))
@@ -3882,7 +3882,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (158,10)-(158,12) = "in"
         │   │       └── then_loc: (158,22)-(158,26) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (158,0)-(158,4) = "case"
         │   └── end_keyword_loc: (158,27)-(158,30) = "end"
         ├── @ CaseMatchNode (location: (159,0)-(159,34))
@@ -3907,7 +3907,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (159,10)-(159,12) = "in"
         │   │       └── then_loc: (159,26)-(159,30) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (159,0)-(159,4) = "case"
         │   └── end_keyword_loc: (159,31)-(159,34) = "end"
         ├── @ CaseMatchNode (location: (160,0)-(160,32))
@@ -3945,7 +3945,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (160,10)-(160,12) = "in"
         │   │       └── then_loc: (160,24)-(160,28) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (160,0)-(160,4) = "case"
         │   └── end_keyword_loc: (160,29)-(160,32) = "end"
         ├── @ CaseMatchNode (location: (162,0)-(162,32))
@@ -3982,12 +3982,12 @@
         │   │       │   │           ├── flags: newline
         │   │       │   │           ├── name: :bar
         │   │       │   │           └── depth: 0
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (162,10)-(162,12) = "in"
         │   │       └── then_loc: (162,24)-(162,28) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (162,0)-(162,4) = "case"
         │   └── end_keyword_loc: (162,29)-(162,32) = "end"
         ├── @ CaseMatchNode (location: (163,0)-(163,30))
@@ -4023,12 +4023,12 @@
         │   │       │   │       └── @ IntegerNode (location: (163,13)-(163,14))
         │   │       │   │           ├── flags: newline, static_literal, decimal
         │   │       │   │           └── value: 1
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (163,10)-(163,12) = "in"
         │   │       └── then_loc: (163,22)-(163,26) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (163,0)-(163,4) = "case"
         │   └── end_keyword_loc: (163,27)-(163,30) = "end"
         ├── @ CaseMatchNode (location: (164,0)-(164,32))
@@ -4064,12 +4064,12 @@
         │   │       │   │       └── @ FloatNode (location: (164,13)-(164,16))
         │   │       │   │           ├── flags: newline, static_literal
         │   │       │   │           └── value: 1.0
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (164,10)-(164,12) = "in"
         │   │       └── then_loc: (164,24)-(164,28) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (164,0)-(164,4) = "case"
         │   └── end_keyword_loc: (164,29)-(164,32) = "end"
         ├── @ CaseMatchNode (location: (165,0)-(165,31))
@@ -4108,12 +4108,12 @@
         │   │       │   │               @ IntegerNode (location: (165,13)-(165,14))
         │   │       │   │               ├── flags: static_literal, decimal
         │   │       │   │               └── value: 1
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (165,10)-(165,12) = "in"
         │   │       └── then_loc: (165,23)-(165,27) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (165,0)-(165,4) = "case"
         │   └── end_keyword_loc: (165,28)-(165,31) = "end"
         ├── @ CaseMatchNode (location: (166,0)-(166,31))
@@ -4150,12 +4150,12 @@
         │   │       │   │           ├── flags: newline, static_literal, decimal
         │   │       │   │           ├── numerator: 1
         │   │       │   │           └── denominator: 1
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (166,10)-(166,12) = "in"
         │   │       └── then_loc: (166,23)-(166,27) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (166,0)-(166,4) = "case"
         │   └── end_keyword_loc: (166,28)-(166,31) = "end"
         ├── @ CaseMatchNode (location: (167,0)-(167,33))
@@ -4194,12 +4194,12 @@
         │   │       │   │           ├── value_loc: (167,14)-(167,17) = "foo"
         │   │       │   │           ├── closing_loc: ∅
         │   │       │   │           └── unescaped: "foo"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (167,10)-(167,12) = "in"
         │   │       └── then_loc: (167,25)-(167,29) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (167,0)-(167,4) = "case"
         │   └── end_keyword_loc: (167,30)-(167,33) = "end"
         ├── @ CaseMatchNode (location: (168,0)-(168,36))
@@ -4238,12 +4238,12 @@
         │   │       │   │           ├── value_loc: (168,16)-(168,19) = "foo"
         │   │       │   │           ├── closing_loc: (168,19)-(168,20) = "]"
         │   │       │   │           └── unescaped: "foo"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (168,10)-(168,12) = "in"
         │   │       └── then_loc: (168,28)-(168,32) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (168,0)-(168,4) = "case"
         │   └── end_keyword_loc: (168,33)-(168,36) = "end"
         ├── @ CaseMatchNode (location: (169,0)-(169,35))
@@ -4282,12 +4282,12 @@
         │   │       │   │           ├── value_loc: (169,15)-(169,18) = "foo"
         │   │       │   │           ├── closing_loc: (169,18)-(169,19) = "\""
         │   │       │   │           └── unescaped: "foo"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (169,10)-(169,12) = "in"
         │   │       └── then_loc: (169,27)-(169,31) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (169,0)-(169,4) = "case"
         │   └── end_keyword_loc: (169,32)-(169,35) = "end"
         ├── @ CaseMatchNode (location: (170,0)-(170,34))
@@ -4326,12 +4326,12 @@
         │   │       │   │           ├── content_loc: (170,14)-(170,17) = "foo"
         │   │       │   │           ├── closing_loc: (170,17)-(170,18) = "/"
         │   │       │   │           └── unescaped: "foo"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (170,10)-(170,12) = "in"
         │   │       └── then_loc: (170,26)-(170,30) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (170,0)-(170,4) = "case"
         │   └── end_keyword_loc: (170,31)-(170,34) = "end"
         ├── @ CaseMatchNode (location: (171,0)-(171,34))
@@ -4370,12 +4370,12 @@
         │   │       │   │           ├── content_loc: (171,14)-(171,17) = "foo"
         │   │       │   │           ├── closing_loc: (171,17)-(171,18) = "`"
         │   │       │   │           └── unescaped: "foo"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (171,10)-(171,12) = "in"
         │   │       └── then_loc: (171,26)-(171,30) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (171,0)-(171,4) = "case"
         │   └── end_keyword_loc: (171,31)-(171,34) = "end"
         ├── @ CaseMatchNode (location: (172,0)-(172,36))
@@ -4414,12 +4414,12 @@
         │   │       │   │           ├── content_loc: (172,16)-(172,19) = "foo"
         │   │       │   │           ├── closing_loc: (172,19)-(172,20) = "]"
         │   │       │   │           └── unescaped: "foo"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (172,10)-(172,12) = "in"
         │   │       └── then_loc: (172,28)-(172,32) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (172,0)-(172,4) = "case"
         │   └── end_keyword_loc: (172,33)-(172,36) = "end"
         ├── @ CaseMatchNode (location: (173,0)-(173,36))
@@ -4463,12 +4463,12 @@
         │   │       │   │           │       └── unescaped: "foo"
         │   │       │   │           ├── opening_loc: (173,13)-(173,16) = "%i["
         │   │       │   │           └── closing_loc: (173,19)-(173,20) = "]"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (173,10)-(173,12) = "in"
         │   │       └── then_loc: (173,28)-(173,32) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (173,0)-(173,4) = "case"
         │   └── end_keyword_loc: (173,33)-(173,36) = "end"
         ├── @ CaseMatchNode (location: (174,0)-(174,36))
@@ -4512,12 +4512,12 @@
         │   │       │   │           │       └── unescaped: "foo"
         │   │       │   │           ├── opening_loc: (174,13)-(174,16) = "%I["
         │   │       │   │           └── closing_loc: (174,19)-(174,20) = "]"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (174,10)-(174,12) = "in"
         │   │       └── then_loc: (174,28)-(174,32) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (174,0)-(174,4) = "case"
         │   └── end_keyword_loc: (174,33)-(174,36) = "end"
         ├── @ CaseMatchNode (location: (175,0)-(175,36))
@@ -4561,12 +4561,12 @@
         │   │       │   │           │       └── unescaped: "foo"
         │   │       │   │           ├── opening_loc: (175,13)-(175,16) = "%w["
         │   │       │   │           └── closing_loc: (175,19)-(175,20) = "]"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (175,10)-(175,12) = "in"
         │   │       └── then_loc: (175,28)-(175,32) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (175,0)-(175,4) = "case"
         │   └── end_keyword_loc: (175,33)-(175,36) = "end"
         ├── @ CaseMatchNode (location: (176,0)-(176,36))
@@ -4610,12 +4610,12 @@
         │   │       │   │           │       └── unescaped: "foo"
         │   │       │   │           ├── opening_loc: (176,13)-(176,16) = "%W["
         │   │       │   │           └── closing_loc: (176,19)-(176,20) = "]"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (176,10)-(176,12) = "in"
         │   │       └── then_loc: (176,28)-(176,32) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (176,0)-(176,4) = "case"
         │   └── end_keyword_loc: (176,33)-(176,36) = "end"
         ├── @ CaseMatchNode (location: (177,0)-(177,36))
@@ -4654,12 +4654,12 @@
         │   │       │   │           ├── content_loc: (177,16)-(177,19) = "foo"
         │   │       │   │           ├── closing_loc: (177,19)-(177,20) = "]"
         │   │       │   │           └── unescaped: "foo"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (177,10)-(177,12) = "in"
         │   │       └── then_loc: (177,28)-(177,32) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (177,0)-(177,4) = "case"
         │   └── end_keyword_loc: (177,33)-(177,36) = "end"
         ├── @ CaseMatchNode (location: (178,0)-(178,36))
@@ -4698,12 +4698,12 @@
         │   │       │   │           ├── content_loc: (178,16)-(178,19) = "foo"
         │   │       │   │           ├── closing_loc: (178,19)-(178,20) = "]"
         │   │       │   │           └── unescaped: "foo"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (178,10)-(178,12) = "in"
         │   │       └── then_loc: (178,28)-(178,32) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (178,0)-(178,4) = "case"
         │   └── end_keyword_loc: (178,33)-(178,36) = "end"
         ├── @ CaseMatchNode (location: (179,0)-(179,34))
@@ -4742,12 +4742,12 @@
         │   │       │   │           ├── content_loc: (179,14)-(179,17) = "foo"
         │   │       │   │           ├── closing_loc: (179,17)-(179,18) = "\""
         │   │       │   │           └── unescaped: "foo"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (179,10)-(179,12) = "in"
         │   │       └── then_loc: (179,26)-(179,30) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (179,0)-(179,4) = "case"
         │   └── end_keyword_loc: (179,31)-(179,34) = "end"
         ├── @ CaseMatchNode (location: (180,0)-(180,32))
@@ -4782,12 +4782,12 @@
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ NilNode (location: (180,13)-(180,16))
         │   │       │   │           └── flags: newline, static_literal
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (180,10)-(180,12) = "in"
         │   │       └── then_loc: (180,24)-(180,28) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (180,0)-(180,4) = "case"
         │   └── end_keyword_loc: (180,29)-(180,32) = "end"
         ├── @ CaseMatchNode (location: (181,0)-(181,33))
@@ -4822,12 +4822,12 @@
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ SelfNode (location: (181,13)-(181,17))
         │   │       │   │           └── flags: newline
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (181,10)-(181,12) = "in"
         │   │       └── then_loc: (181,25)-(181,29) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (181,0)-(181,4) = "case"
         │   └── end_keyword_loc: (181,30)-(181,33) = "end"
         ├── @ CaseMatchNode (location: (182,0)-(182,33))
@@ -4862,12 +4862,12 @@
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ TrueNode (location: (182,13)-(182,17))
         │   │       │   │           └── flags: newline, static_literal
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (182,10)-(182,12) = "in"
         │   │       └── then_loc: (182,25)-(182,29) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (182,0)-(182,4) = "case"
         │   └── end_keyword_loc: (182,30)-(182,33) = "end"
         ├── @ CaseMatchNode (location: (183,0)-(183,34))
@@ -4902,12 +4902,12 @@
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ FalseNode (location: (183,13)-(183,18))
         │   │       │   │           └── flags: newline, static_literal
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (183,10)-(183,12) = "in"
         │   │       └── then_loc: (183,26)-(183,30) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (183,0)-(183,4) = "case"
         │   └── end_keyword_loc: (183,31)-(183,34) = "end"
         ├── @ CaseMatchNode (location: (184,0)-(184,37))
@@ -4943,12 +4943,12 @@
         │   │       │   │       └── @ SourceFileNode (location: (184,13)-(184,21))
         │   │       │   │           ├── flags: newline
         │   │       │   │           └── filepath: "patterns.txt"
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (184,10)-(184,12) = "in"
         │   │       └── then_loc: (184,29)-(184,33) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (184,0)-(184,4) = "case"
         │   └── end_keyword_loc: (184,34)-(184,37) = "end"
         ├── @ CaseMatchNode (location: (185,0)-(185,37))
@@ -4983,12 +4983,12 @@
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ SourceLineNode (location: (185,13)-(185,21))
         │   │       │   │           └── flags: newline, static_literal
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (185,10)-(185,12) = "in"
         │   │       └── then_loc: (185,29)-(185,33) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (185,0)-(185,4) = "case"
         │   └── end_keyword_loc: (185,34)-(185,37) = "end"
         ├── @ CaseMatchNode (location: (186,0)-(186,41))
@@ -5023,12 +5023,12 @@
         │   │       │   │   └── body: (length: 1)
         │   │       │   │       └── @ SourceEncodingNode (location: (186,13)-(186,25))
         │   │       │   │           └── flags: newline, static_literal
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (186,10)-(186,12) = "in"
         │   │       └── then_loc: (186,33)-(186,37) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (186,0)-(186,4) = "case"
         │   └── end_keyword_loc: (186,38)-(186,41) = "end"
         ├── @ CaseMatchNode (location: (187,0)-(187,39))
@@ -5076,12 +5076,12 @@
         │   │       │   │                       ├── flags: newline
         │   │       │   │                       ├── name: :bar
         │   │       │   │                       └── depth: 1
-        │   │       │   ├── consequent: ∅
+        │   │       │   ├── subsequent: ∅
         │   │       │   └── end_keyword_loc: ∅
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (187,10)-(187,12) = "in"
         │   │       └── then_loc: (187,31)-(187,35) = "then"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (187,0)-(187,4) = "case"
         │   └── end_keyword_loc: (187,36)-(187,39) = "end"
         ├── @ IfNode (location: (189,0)-(190,3))
@@ -5113,7 +5113,7 @@
         │   │   └── operator_loc: (189,5)-(189,7) = "in"
         │   ├── then_keyword_loc: ∅
         │   ├── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (190,0)-(190,3) = "end"
         ├── @ MatchRequiredNode (location: (192,0)-(194,1))
         │   ├── flags: newline
@@ -5497,7 +5497,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (219,9)-(219,11) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (219,0)-(219,4) = "case"
         │   └── end_keyword_loc: (219,22)-(219,25) = "end"
         └── @ CaseMatchNode (location: (220,0)-(220,31))
@@ -5565,6 +5565,6 @@
             │       ├── statements: ∅
             │       ├── in_loc: (220,9)-(220,11) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (220,0)-(220,4) = "case"
             └── end_keyword_loc: (220,28)-(220,31) = "end"

--- a/test/prism/snapshots/procs.txt
+++ b/test/prism/snapshots/procs.txt
@@ -88,7 +88,7 @@
         │       │   ├── operator_loc: ∅
         │       │   ├── reference: ∅
         │       │   ├── statements: ∅
-        │       │   └── consequent: ∅
+        │       │   └── subsequent: ∅
         │       ├── else_clause:
         │       │   @ ElseNode (location: (9,0)-(10,6))
         │       │   ├── flags: ∅

--- a/test/prism/snapshots/rescue.txt
+++ b/test/prism/snapshots/rescue.txt
@@ -166,7 +166,7 @@
         │       │       └── @ IntegerNode (location: (14,17)-(14,18))
         │       │           ├── flags: newline, static_literal, decimal
         │       │           └── value: 1
-        │       ├── consequent:
+        │       ├── subsequent:
         │       │   @ ElseNode (location: (14,19)-(14,22))
         │       │   ├── flags: ∅
         │       │   ├── else_keyword_loc: (14,19)-(14,20) = ":"
@@ -218,7 +218,7 @@
         │   │   ├── operator_loc: ∅
         │   │   ├── reference: ∅
         │   │   ├── statements: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (16,21)-(16,24) = "end"
@@ -363,7 +363,7 @@
         │   │           ├── arguments: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (24,0)-(24,3) = "end"
         ├── @ DefNode (location: (26,0)-(26,44))
         │   ├── flags: newline
@@ -467,7 +467,7 @@
         │   │   │   ├── operator_loc: ∅
         │   │   │   ├── reference: ∅
         │   │   │   ├── statements: ∅
-        │   │   │   └── consequent: ∅
+        │   │   │   └── subsequent: ∅
         │   │   ├── else_clause: ∅
         │   │   ├── ensure_clause: ∅
         │   │   └── end_keyword_loc: (31,0)-(31,3) = "end"
@@ -510,7 +510,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   ├── consequent: ∅
+        │   │   ├── subsequent: ∅
         │   │   └── end_keyword_loc: ∅
         │   ├── keyword_loc: (33,11)-(33,17) = "rescue"
         │   └── rescue_expression:

--- a/test/prism/snapshots/seattlerb/begin_rescue_else_ensure_bodies.txt
+++ b/test/prism/snapshots/seattlerb/begin_rescue_else_ensure_bodies.txt
@@ -29,7 +29,7 @@
             │   │       └── @ IntegerNode (location: (4,2)-(4,3))
             │   │           ├── flags: newline, static_literal, decimal
             │   │           └── value: 2
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause:
             │   @ ElseNode (location: (5,0)-(7,6))
             │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/begin_rescue_else_ensure_no_bodies.txt
+++ b/test/prism/snapshots/seattlerb/begin_rescue_else_ensure_no_bodies.txt
@@ -17,7 +17,7 @@
             │   ├── operator_loc: ∅
             │   ├── reference: ∅
             │   ├── statements: ∅
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause:
             │   @ ElseNode (location: (5,0)-(7,6))
             │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/begin_rescue_ensure_no_bodies.txt
+++ b/test/prism/snapshots/seattlerb/begin_rescue_ensure_no_bodies.txt
@@ -17,7 +17,7 @@
             │   ├── operator_loc: ∅
             │   ├── reference: ∅
             │   ├── statements: ∅
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause: ∅
             ├── ensure_clause:
             │   @ EnsureNode (location: (3,0)-(4,3))

--- a/test/prism/snapshots/seattlerb/bug191.txt
+++ b/test/prism/snapshots/seattlerb/bug191.txt
@@ -30,7 +30,7 @@
         │   │           ├── content_loc: (1,5)-(1,5) = ""
         │   │           ├── closing_loc: (1,5)-(1,6) = "\""
         │   │           └── unescaped: ""
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (1,6)-(1,9))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (1,6)-(1,7) = ":"
@@ -75,7 +75,7 @@
             │           ├── content_loc: (3,5)-(3,5) = ""
             │           ├── closing_loc: (3,5)-(3,6) = "'"
             │           └── unescaped: ""
-            ├── consequent:
+            ├── subsequent:
             │   @ ElseNode (location: (3,6)-(3,9))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (3,6)-(3,7) = ":"

--- a/test/prism/snapshots/seattlerb/bug_case_when_regexp.txt
+++ b/test/prism/snapshots/seattlerb/bug_case_when_regexp.txt
@@ -27,6 +27,6 @@
             │       │       └── unescaped: "x"
             │       ├── then_keyword_loc: (1,18)-(1,22) = "then"
             │       └── statements: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (1,23)-(1,26) = "end"

--- a/test/prism/snapshots/seattlerb/bug_comma.txt
+++ b/test/prism/snapshots/seattlerb/bug_comma.txt
@@ -40,5 +40,5 @@
             │   └── block: ∅
             ├── then_keyword_loc: (1,16)-(1,20) = "then"
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (1,21)-(1,24) = "end"

--- a/test/prism/snapshots/seattlerb/bug_cond_pct.txt
+++ b/test/prism/snapshots/seattlerb/bug_cond_pct.txt
@@ -21,6 +21,6 @@
             │       │       └── unescaped: "blahblah"
             │       ├── then_keyword_loc: ∅
             │       └── statements: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (1,25)-(1,28) = "end"

--- a/test/prism/snapshots/seattlerb/call_assoc_new_if_multiline.txt
+++ b/test/prism/snapshots/seattlerb/call_assoc_new_if_multiline.txt
@@ -47,7 +47,7 @@
             │                   │   │       └── @ IntegerNode (location: (2,0)-(2,1))
             │                   │   │           ├── flags: newline, static_literal, decimal
             │                   │   │           └── value: 1
-            │                   │   ├── consequent:
+            │                   │   ├── subsequent:
             │                   │   │   @ ElseNode (location: (3,0)-(5,3))
             │                   │   │   ├── flags: ∅
             │                   │   │   ├── else_keyword_loc: (3,0)-(3,4) = "else"

--- a/test/prism/snapshots/seattlerb/case_in.txt
+++ b/test/prism/snapshots/seattlerb/case_in.txt
@@ -46,7 +46,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (2,0)-(2,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (1,0)-(1,4) = "case"
         │   └── end_keyword_loc: (3,0)-(3,3) = "end"
         ├── @ CaseMatchNode (location: (5,0)-(7,3))
@@ -82,7 +82,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (6,0)-(6,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (5,0)-(5,4) = "case"
         │   └── end_keyword_loc: (7,0)-(7,3) = "end"
         ├── @ CaseMatchNode (location: (9,0)-(11,3))
@@ -118,7 +118,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (10,0)-(10,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (9,0)-(9,4) = "case"
         │   └── end_keyword_loc: (11,0)-(11,3) = "end"
         ├── @ CaseMatchNode (location: (13,0)-(15,3))
@@ -154,7 +154,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (14,0)-(14,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (13,0)-(13,4) = "case"
         │   └── end_keyword_loc: (15,0)-(15,3) = "end"
         ├── @ CaseMatchNode (location: (17,0)-(19,3))
@@ -190,7 +190,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (18,0)-(18,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (17,0)-(17,4) = "case"
         │   └── end_keyword_loc: (19,0)-(19,3) = "end"
         ├── @ CaseMatchNode (location: (21,0)-(23,3))
@@ -222,7 +222,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (22,0)-(22,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (21,0)-(21,4) = "case"
         │   └── end_keyword_loc: (23,0)-(23,3) = "end"
         ├── @ CaseMatchNode (location: (25,0)-(27,3))
@@ -254,7 +254,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (26,0)-(26,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (25,0)-(25,4) = "case"
         │   └── end_keyword_loc: (27,0)-(27,3) = "end"
         ├── @ CaseMatchNode (location: (29,0)-(31,3))
@@ -286,7 +286,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (30,0)-(30,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (29,0)-(29,4) = "case"
         │   └── end_keyword_loc: (31,0)-(31,3) = "end"
         ├── @ CaseMatchNode (location: (33,0)-(35,3))
@@ -321,7 +321,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (34,0)-(34,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (33,0)-(33,4) = "case"
         │   └── end_keyword_loc: (35,0)-(35,3) = "end"
         ├── @ CaseMatchNode (location: (37,0)-(39,3))
@@ -348,7 +348,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (38,0)-(38,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (37,0)-(37,4) = "case"
         │   └── end_keyword_loc: (39,0)-(39,3) = "end"
         ├── @ CaseMatchNode (location: (41,0)-(43,3))
@@ -378,7 +378,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (42,0)-(42,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (41,0)-(41,4) = "case"
         │   └── end_keyword_loc: (43,0)-(43,3) = "end"
         ├── @ CaseMatchNode (location: (45,0)-(47,3))
@@ -403,7 +403,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (46,0)-(46,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (45,0)-(45,4) = "case"
         │   └── end_keyword_loc: (47,0)-(47,3) = "end"
         ├── @ CaseMatchNode (location: (49,0)-(51,3))
@@ -450,7 +450,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (50,0)-(50,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (49,0)-(49,4) = "case"
         │   └── end_keyword_loc: (51,0)-(51,3) = "end"
         ├── @ CaseMatchNode (location: (53,0)-(55,3))
@@ -497,7 +497,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (54,0)-(54,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (53,0)-(53,4) = "case"
         │   └── end_keyword_loc: (55,0)-(55,3) = "end"
         ├── @ CaseMatchNode (location: (57,0)-(59,3))
@@ -527,7 +527,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (58,0)-(58,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (57,0)-(57,4) = "case"
         │   └── end_keyword_loc: (59,0)-(59,3) = "end"
         ├── @ CaseMatchNode (location: (61,0)-(63,3))
@@ -577,7 +577,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (62,0)-(62,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (61,0)-(61,4) = "case"
         │   └── end_keyword_loc: (63,0)-(63,3) = "end"
         ├── @ CaseMatchNode (location: (65,0)-(67,3))
@@ -627,7 +627,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (66,0)-(66,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (65,0)-(65,4) = "case"
         │   └── end_keyword_loc: (67,0)-(67,3) = "end"
         ├── @ CaseMatchNode (location: (69,0)-(71,3))
@@ -689,7 +689,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (70,0)-(70,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (69,0)-(69,4) = "case"
         │   └── end_keyword_loc: (71,0)-(71,3) = "end"
         ├── @ CaseMatchNode (location: (73,0)-(75,3))
@@ -754,7 +754,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (74,0)-(74,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (73,0)-(73,4) = "case"
         │   └── end_keyword_loc: (75,0)-(75,3) = "end"
         ├── @ CaseMatchNode (location: (77,0)-(79,3))
@@ -791,7 +791,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (78,0)-(78,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (77,0)-(77,4) = "case"
         │   └── end_keyword_loc: (79,0)-(79,3) = "end"
         ├── @ CaseMatchNode (location: (81,0)-(83,3))
@@ -858,7 +858,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (82,0)-(82,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (81,0)-(81,4) = "case"
         │   └── end_keyword_loc: (83,0)-(83,3) = "end"
         ├── @ CaseMatchNode (location: (85,0)-(87,3))
@@ -885,7 +885,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (86,0)-(86,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (85,0)-(85,4) = "case"
         │   └── end_keyword_loc: (87,0)-(87,3) = "end"
         ├── @ CaseMatchNode (location: (89,0)-(91,3))
@@ -928,7 +928,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (90,0)-(90,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (89,0)-(89,4) = "case"
         │   └── end_keyword_loc: (91,0)-(91,3) = "end"
         ├── @ CaseMatchNode (location: (93,0)-(95,3))
@@ -976,7 +976,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (94,0)-(94,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (93,0)-(93,4) = "case"
         │   └── end_keyword_loc: (95,0)-(95,3) = "end"
         ├── @ CaseMatchNode (location: (97,0)-(99,3))
@@ -1001,7 +1001,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (98,0)-(98,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (97,0)-(97,4) = "case"
         │   └── end_keyword_loc: (99,0)-(99,3) = "end"
         ├── @ CaseMatchNode (location: (101,0)-(103,3))
@@ -1034,7 +1034,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (102,0)-(102,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (101,0)-(101,4) = "case"
         │   └── end_keyword_loc: (103,0)-(103,3) = "end"
         ├── @ CaseMatchNode (location: (105,0)-(107,3))
@@ -1078,7 +1078,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (106,0)-(106,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (105,0)-(105,4) = "case"
         │   └── end_keyword_loc: (107,0)-(107,3) = "end"
         └── @ CaseMatchNode (location: (109,0)-(111,3))
@@ -1104,6 +1104,6 @@
             │       ├── statements: ∅
             │       ├── in_loc: (110,0)-(110,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (109,0)-(109,4) = "case"
             └── end_keyword_loc: (111,0)-(111,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_31.txt
+++ b/test/prism/snapshots/seattlerb/case_in_31.txt
@@ -52,6 +52,6 @@
             │       │           └── unescaped: "d"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_37.txt
+++ b/test/prism/snapshots/seattlerb/case_in_37.txt
@@ -63,6 +63,6 @@
             │       │           └── unescaped: "c"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_42.txt
+++ b/test/prism/snapshots/seattlerb/case_in_42.txt
@@ -48,6 +48,6 @@
             │       │           └── flags: newline, static_literal
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: (2,10)-(2,14) = "then"
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (3,0)-(3,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_42_2.txt
+++ b/test/prism/snapshots/seattlerb/case_in_42_2.txt
@@ -45,6 +45,6 @@
             │       │           └── flags: newline, static_literal
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: (2,12)-(2,16) = "then"
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (3,0)-(3,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_47.txt
+++ b/test/prism/snapshots/seattlerb/case_in_47.txt
@@ -54,6 +54,6 @@
             │       │           └── unescaped: "d"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_67.txt
+++ b/test/prism/snapshots/seattlerb/case_in_67.txt
@@ -34,6 +34,6 @@
             │       │           └── flags: newline, static_literal
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: (2,7)-(2,11) = "then"
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (3,0)-(3,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_86.txt
+++ b/test/prism/snapshots/seattlerb/case_in_86.txt
@@ -55,6 +55,6 @@
             │       │           └── flags: newline, static_literal
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: (2,17)-(2,21) = "then"
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (3,0)-(3,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_86_2.txt
+++ b/test/prism/snapshots/seattlerb/case_in_86_2.txt
@@ -55,6 +55,6 @@
             │       │           └── flags: newline, static_literal
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: (2,17)-(2,21) = "then"
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (3,0)-(3,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_array_pat_const.txt
+++ b/test/prism/snapshots/seattlerb/case_in_array_pat_const.txt
@@ -45,6 +45,6 @@
             │       │           └── unescaped: "d"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_array_pat_const2.txt
+++ b/test/prism/snapshots/seattlerb/case_in_array_pat_const2.txt
@@ -51,6 +51,6 @@
             │       │           └── unescaped: "e"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_array_pat_paren_assign.txt
+++ b/test/prism/snapshots/seattlerb/case_in_array_pat_paren_assign.txt
@@ -53,6 +53,6 @@
             │       │           └── unescaped: "d"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_const.txt
+++ b/test/prism/snapshots/seattlerb/case_in_const.txt
@@ -30,6 +30,6 @@
             │       │           └── unescaped: "b"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_else.txt
+++ b/test/prism/snapshots/seattlerb/case_in_else.txt
@@ -30,7 +30,7 @@
             │       │           └── unescaped: "b"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent:
+            ├── else_clause:
             │   @ ElseNode (location: (4,0)-(6,3))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (4,0)-(4,4) = "else"

--- a/test/prism/snapshots/seattlerb/case_in_find.txt
+++ b/test/prism/snapshots/seattlerb/case_in_find.txt
@@ -51,6 +51,6 @@
             │       ├── statements: ∅
             │       ├── in_loc: (2,2)-(2,4) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (3,0)-(3,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_find_array.txt
+++ b/test/prism/snapshots/seattlerb/case_in_find_array.txt
@@ -47,6 +47,6 @@
             │       ├── statements: ∅
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (3,0)-(3,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat.txt
@@ -71,6 +71,6 @@
             │       │           └── unescaped: "f"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: (2,22)-(2,26) = "then"
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_assign.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_assign.txt
@@ -95,6 +95,6 @@
             │       │           └── unescaped: "g"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: (2,35)-(2,39) = "then"
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_paren_assign.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_paren_assign.txt
@@ -54,6 +54,6 @@
             │       │           └── unescaped: "d"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_paren_true.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_paren_true.txt
@@ -50,6 +50,6 @@
             │       │           └── unescaped: "c"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: (2,11)-(2,15) = "then"
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_rest.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_rest.txt
@@ -60,6 +60,6 @@
             │       │           └── unescaped: "d"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: (2,16)-(2,20) = "then"
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (3,0)-(3,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_hash_pat_rest_solo.txt
+++ b/test/prism/snapshots/seattlerb/case_in_hash_pat_rest_solo.txt
@@ -45,6 +45,6 @@
             │       │           └── unescaped: "d"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: (2,10)-(2,14) = "then"
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (3,0)-(3,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_if_unless_post_mod.txt
+++ b/test/prism/snapshots/seattlerb/case_in_if_unless_post_mod.txt
@@ -32,7 +32,7 @@
             │   │   │   │       └── @ ConstantReadNode (location: (2,3)-(2,4))
             │   │   │   │           ├── flags: newline
             │   │   │   │           └── name: :A
-            │   │   │   ├── consequent: ∅
+            │   │   │   ├── subsequent: ∅
             │   │   │   └── end_keyword_loc: ∅
             │   │   ├── statements:
             │   │   │   @ StatementsNode (location: (3,2)-(3,4))
@@ -63,7 +63,7 @@
             │       │   │       └── @ ConstantReadNode (location: (4,3)-(4,4))
             │       │   │           ├── flags: newline
             │       │   │           └── name: :D
-            │       │   ├── consequent: ∅
+            │       │   ├── else_clause: ∅
             │       │   └── end_keyword_loc: ∅
             │       ├── statements:
             │       │   @ StatementsNode (location: (5,2)-(5,4))
@@ -77,6 +77,6 @@
             │       │           └── unescaped: "E"
             │       ├── in_loc: (4,0)-(4,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (6,0)-(6,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_multiple.txt
+++ b/test/prism/snapshots/seattlerb/case_in_multiple.txt
@@ -63,6 +63,6 @@
             │       │           └── unescaped: "F"
             │       ├── in_loc: (4,0)-(4,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (6,0)-(6,3) = "end"

--- a/test/prism/snapshots/seattlerb/case_in_or.txt
+++ b/test/prism/snapshots/seattlerb/case_in_or.txt
@@ -41,6 +41,6 @@
             │       │           └── unescaped: "d"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/cond_unary_minus.txt
+++ b/test/prism/snapshots/seattlerb/cond_unary_minus.txt
@@ -14,5 +14,5 @@
             │   └── value: -1
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (1,7)-(1,10) = "end"

--- a/test/prism/snapshots/seattlerb/defn_oneliner_rescue.txt
+++ b/test/prism/snapshots/seattlerb/defn_oneliner_rescue.txt
@@ -61,7 +61,7 @@
         │   │   │   │   └── body: (length: 1)
         │   │   │   │       └── @ NilNode (location: (4,2)-(4,5))
         │   │   │   │           └── flags: newline, static_literal
-        │   │   │   └── consequent: ∅
+        │   │   │   └── subsequent: ∅
         │   │   ├── else_clause: ∅
         │   │   ├── ensure_clause: ∅
         │   │   └── end_keyword_loc: (5,0)-(5,3) = "end"

--- a/test/prism/snapshots/seattlerb/defs_oneliner_rescue.txt
+++ b/test/prism/snapshots/seattlerb/defs_oneliner_rescue.txt
@@ -63,7 +63,7 @@
         │   │   │   │   └── body: (length: 1)
         │   │   │   │       └── @ NilNode (location: (4,2)-(4,5))
         │   │   │   │           └── flags: newline, static_literal
-        │   │   │   └── consequent: ∅
+        │   │   │   └── subsequent: ∅
         │   │   ├── else_clause: ∅
         │   │   ├── ensure_clause: ∅
         │   │   └── end_keyword_loc: (5,0)-(5,3) = "end"

--- a/test/prism/snapshots/seattlerb/difficult1_line_numbers.txt
+++ b/test/prism/snapshots/seattlerb/difficult1_line_numbers.txt
@@ -268,5 +268,5 @@
             │           │           └── value: 7
             │           ├── closing_loc: (11,10)-(11,11) = ")"
             │           └── block: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (12,0)-(12,3) = "end"

--- a/test/prism/snapshots/seattlerb/difficult1_line_numbers2.txt
+++ b/test/prism/snapshots/seattlerb/difficult1_line_numbers2.txt
@@ -72,7 +72,7 @@
         │   │           │   ├── flags: static_literal, decimal
         │   │           │   └── value: 1
         │   │           └── operator_loc: (5,4)-(5,5) = "="
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (6,0)-(6,3) = "end"
         └── @ CallNode (location: (7,0)-(7,1))
             ├── flags: newline, variable_call, ignore_visibility

--- a/test/prism/snapshots/seattlerb/difficult2_.txt
+++ b/test/prism/snapshots/seattlerb/difficult2_.txt
@@ -36,7 +36,7 @@
         │   │           │           └── unescaped: ""
         │   │           ├── closing_loc: (1,8)-(1,9) = ")"
         │   │           └── block: ∅
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (1,10)-(1,13))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (1,10)-(1,11) = ":"

--- a/test/prism/snapshots/seattlerb/difficult3_4.txt
+++ b/test/prism/snapshots/seattlerb/difficult3_4.txt
@@ -32,7 +32,7 @@
             │   │   └── body: (length: 1)
             │   │       └── @ TrueNode (location: (1,6)-(1,10))
             │   │           └── flags: newline, static_literal
-            │   ├── consequent:
+            │   ├── subsequent:
             │   │   @ ElseNode (location: (1,10)-(1,17))
             │   │   ├── flags: ∅
             │   │   ├── else_keyword_loc: (1,10)-(1,11) = ":"

--- a/test/prism/snapshots/seattlerb/difficult7_.txt
+++ b/test/prism/snapshots/seattlerb/difficult7_.txt
@@ -66,7 +66,7 @@
             │   │   │       │           │           ├── arguments: ∅
             │   │   │       │           │           ├── closing_loc: (2,26)-(2,27) = ")"
             │   │   │       │           │           └── block: ∅
-            │   │   │       │           ├── consequent:
+            │   │   │       │           ├── subsequent:
             │   │   │       │           │   @ ElseNode (location: (2,28)-(2,31))
             │   │   │       │           │   ├── flags: ∅
             │   │   │       │           │   ├── else_keyword_loc: (2,28)-(2,29) = ":"

--- a/test/prism/snapshots/seattlerb/flip2_env_lvar.txt
+++ b/test/prism/snapshots/seattlerb/flip2_env_lvar.txt
@@ -36,5 +36,5 @@
             │   └── operator_loc: (1,4)-(1,6) = ".."
             ├── then_keyword_loc: (1,8)-(1,12) = "then"
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (1,13)-(1,16) = "end"

--- a/test/prism/snapshots/seattlerb/float_with_if_modifier.txt
+++ b/test/prism/snapshots/seattlerb/float_with_if_modifier.txt
@@ -19,5 +19,5 @@
             │       └── @ FloatNode (location: (1,0)-(1,3))
             │           ├── flags: newline, static_literal
             │           └── value: 1.0
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: ∅

--- a/test/prism/snapshots/seattlerb/if_elsif.txt
+++ b/test/prism/snapshots/seattlerb/if_elsif.txt
@@ -14,7 +14,7 @@
             │   └── value: 1
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent:
+            ├── subsequent:
             │   @ IfNode (location: (1,6)-(1,18))
             │   ├── flags: newline
             │   ├── if_keyword_loc: (1,6)-(1,11) = "elsif"
@@ -24,6 +24,6 @@
             │   │   └── value: 2
             │   ├── then_keyword_loc: ∅
             │   ├── statements: ∅
-            │   ├── consequent: ∅
+            │   ├── subsequent: ∅
             │   └── end_keyword_loc: (1,15)-(1,18) = "end"
             └── end_keyword_loc: (1,15)-(1,18) = "end"

--- a/test/prism/snapshots/seattlerb/if_symbol.txt
+++ b/test/prism/snapshots/seattlerb/if_symbol.txt
@@ -30,5 +30,5 @@
             │   └── block: ∅
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (1,9)-(1,12) = "end"

--- a/test/prism/snapshots/seattlerb/integer_with_if_modifier.txt
+++ b/test/prism/snapshots/seattlerb/integer_with_if_modifier.txt
@@ -19,5 +19,5 @@
             │       └── @ IntegerNode (location: (1,0)-(1,5))
             │           ├── flags: newline, static_literal, decimal
             │           └── value: 1234
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: ∅

--- a/test/prism/snapshots/seattlerb/parse_if_not_canonical.txt
+++ b/test/prism/snapshots/seattlerb/parse_if_not_canonical.txt
@@ -50,7 +50,7 @@
             │           ├── content_loc: (1,22)-(1,25) = "foo"
             │           ├── closing_loc: (1,25)-(1,26) = "'"
             │           └── unescaped: "foo"
-            ├── consequent:
+            ├── subsequent:
             │   @ ElseNode (location: (1,27)-(2,3))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (1,27)-(1,31) = "else"

--- a/test/prism/snapshots/seattlerb/parse_if_not_noncanonical.txt
+++ b/test/prism/snapshots/seattlerb/parse_if_not_noncanonical.txt
@@ -50,7 +50,7 @@
             │           ├── content_loc: (1,22)-(1,25) = "foo"
             │           ├── closing_loc: (1,25)-(1,26) = "'"
             │           └── unescaped: "foo"
-            ├── consequent:
+            ├── subsequent:
             │   @ ElseNode (location: (1,27)-(2,3))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (1,27)-(1,31) = "else"

--- a/test/prism/snapshots/seattlerb/parse_line_rescue.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_rescue.txt
@@ -43,7 +43,7 @@
             │   │           ├── arguments: ∅
             │   │           ├── closing_loc: ∅
             │   │           └── block: ∅
-            │   └── consequent:
+            │   └── subsequent:
             │       @ RescueNode (location: (5,0)-(6,3))
             │       ├── flags: ∅
             │       ├── keyword_loc: (5,0)-(5,6) = "rescue"
@@ -64,7 +64,7 @@
             │       │           ├── arguments: ∅
             │       │           ├── closing_loc: ∅
             │       │           └── block: ∅
-            │       └── consequent: ∅
+            │       └── subsequent: ∅
             ├── else_clause: ∅
             ├── ensure_clause: ∅
             └── end_keyword_loc: (7,0)-(7,3) = "end"

--- a/test/prism/snapshots/seattlerb/parse_line_return.txt
+++ b/test/prism/snapshots/seattlerb/parse_line_return.txt
@@ -36,7 +36,7 @@
             │           │                   └── @ IntegerNode (location: (3,17)-(3,19))
             │           │                       ├── flags: static_literal, decimal
             │           │                       └── value: 42
-            │           ├── consequent: ∅
+            │           ├── subsequent: ∅
             │           └── end_keyword_loc: (4,8)-(4,11) = "end"
             ├── locals: []
             ├── def_keyword_loc: (1,6)-(1,9) = "def"

--- a/test/prism/snapshots/seattlerb/parse_pattern_019.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_019.txt
@@ -34,6 +34,6 @@
             │       │           └── flags: newline, static_literal
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/parse_pattern_044.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_044.txt
@@ -41,6 +41,6 @@
             │       │           └── flags: newline, static_literal
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/parse_pattern_051.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_051.txt
@@ -50,6 +50,6 @@
             │       │           └── flags: newline, static_literal
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/parse_pattern_058.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_058.txt
@@ -83,6 +83,6 @@
             │       │           └── closing_loc: (3,10)-(3,11) = "]"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/parse_pattern_058_2.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_058_2.txt
@@ -75,6 +75,6 @@
             │       │           └── closing_loc: (3,4)-(3,5) = "]"
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/parse_pattern_069.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_069.txt
@@ -51,6 +51,6 @@
             │       │           └── value: 1
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/parse_pattern_076.txt
+++ b/test/prism/snapshots/seattlerb/parse_pattern_076.txt
@@ -64,6 +64,6 @@
             │       │           └── flags: newline, static_literal
             │       ├── in_loc: (2,0)-(2,2) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/rescue_do_end_no_raise.txt
+++ b/test/prism/snapshots/seattlerb/rescue_do_end_no_raise.txt
@@ -50,7 +50,7 @@
                 │   │   │           ├── value_loc: (4,3)-(4,9) = "rescue"
                 │   │   │           ├── closing_loc: ∅
                 │   │   │           └── unescaped: "rescue"
-                │   │   └── consequent: ∅
+                │   │   └── subsequent: ∅
                 │   ├── else_clause:
                 │   │   @ ElseNode (location: (5,0)-(7,6))
                 │   │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/rescue_do_end_rescued.txt
+++ b/test/prism/snapshots/seattlerb/rescue_do_end_rescued.txt
@@ -54,7 +54,7 @@
                 │   │   │           ├── value_loc: (4,3)-(4,9) = "rescue"
                 │   │   │           ├── closing_loc: ∅
                 │   │   │           └── unescaped: "rescue"
-                │   │   └── consequent: ∅
+                │   │   └── subsequent: ∅
                 │   ├── else_clause:
                 │   │   @ ElseNode (location: (5,0)-(7,6))
                 │   │   ├── flags: ∅

--- a/test/prism/snapshots/seattlerb/rescue_in_block.txt
+++ b/test/prism/snapshots/seattlerb/rescue_in_block.txt
@@ -45,7 +45,7 @@
                 │   │   │           ├── arguments: ∅
                 │   │   │           ├── closing_loc: ∅
                 │   │   │           └── block: ∅
-                │   │   └── consequent: ∅
+                │   │   └── subsequent: ∅
                 │   ├── else_clause: ∅
                 │   ├── ensure_clause: ∅
                 │   └── end_keyword_loc: (4,0)-(4,3) = "end"

--- a/test/prism/snapshots/seattlerb/str_interp_ternary_or_label.txt
+++ b/test/prism/snapshots/seattlerb/str_interp_ternary_or_label.txt
@@ -93,7 +93,7 @@
             │       │           │           │           └── unescaped: ""
             │       │           │           ├── closing_loc: ∅
             │       │           │           └── block: ∅
-            │       │           ├── consequent:
+            │       │           ├── subsequent:
             │       │           │   @ ElseNode (location: (1,17)-(1,21))
             │       │           │   ├── flags: ∅
             │       │           │   ├── else_keyword_loc: (1,17)-(1,18) = ":"

--- a/test/prism/snapshots/seattlerb/when_splat.txt
+++ b/test/prism/snapshots/seattlerb/when_splat.txt
@@ -39,6 +39,6 @@
             │       │           └── block: ∅
             │       ├── then_keyword_loc: (1,16)-(1,20) = "then"
             │       └── statements: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (1,22)-(1,25) = "end"

--- a/test/prism/snapshots/ternary_operator.txt
+++ b/test/prism/snapshots/ternary_operator.txt
@@ -34,7 +34,7 @@
         │   │           ├── arguments: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (1,6)-(1,9))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (1,6)-(1,7) = ":"
@@ -89,7 +89,7 @@
         │   │           │   └── block: ∅
         │   │           ├── rparen_loc: ∅
         │   │           └── keyword_loc: (3,4)-(3,12) = "defined?"
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (3,15)-(3,27))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (3,15)-(3,16) = ":"
@@ -136,7 +136,7 @@
         │   │   └── body: (length: 1)
         │   │       └── @ TrueNode (location: (5,7)-(5,11))
         │   │           └── flags: newline, static_literal
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (5,11)-(5,15))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (5,11)-(5,12) = ":"
@@ -169,7 +169,7 @@
         │   │   └── body: (length: 1)
         │   │       └── @ FalseNode (location: (7,7)-(7,12))
         │   │           └── flags: newline, static_literal
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (7,12)-(7,16))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (7,12)-(7,13) = ":"
@@ -202,7 +202,7 @@
         │   │   └── body: (length: 1)
         │   │       └── @ NilNode (location: (9,7)-(9,10))
         │   │           └── flags: newline, static_literal
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (9,10)-(9,14))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (9,10)-(9,11) = ":"
@@ -235,7 +235,7 @@
         │   │   └── body: (length: 1)
         │   │       └── @ NilNode (location: (11,3)-(11,6))
         │   │           └── flags: newline, static_literal
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (11,6)-(11,10))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (11,6)-(11,7) = ":"
@@ -276,7 +276,7 @@
         │   │           ├── arguments: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (13,8)-(13,14))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (13,8)-(13,9) = ":"
@@ -325,7 +325,7 @@
             │           │   ├── flags: static_literal, decimal
             │           │   └── value: 2
             │           └── operator_loc: (15,8)-(15,9) = "="
-            ├── consequent:
+            ├── subsequent:
             │   @ ElseNode (location: (15,10)-(15,12))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (15,10)-(15,11) = ":"

--- a/test/prism/snapshots/unless.txt
+++ b/test/prism/snapshots/unless.txt
@@ -19,7 +19,7 @@
         │   │       └── @ IntegerNode (location: (1,13)-(1,14))
         │   │           ├── flags: newline, static_literal, decimal
         │   │           └── value: 1
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   └── end_keyword_loc: (1,16)-(1,19) = "end"
         ├── @ UnlessNode (location: (3,0)-(4,12))
         │   ├── flags: newline
@@ -35,7 +35,7 @@
         │   │       └── @ IntegerNode (location: (4,0)-(4,1))
         │   │           ├── flags: newline, static_literal, decimal
         │   │           └── value: 1
-        │   ├── consequent:
+        │   ├── else_clause:
         │   │   @ ElseNode (location: (4,2)-(4,12))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (4,2)-(4,6) = "else"
@@ -62,7 +62,7 @@
         │   │       └── @ IntegerNode (location: (6,0)-(6,1))
         │   │           ├── flags: newline, static_literal, decimal
         │   │           └── value: 1
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   └── end_keyword_loc: ∅
         ├── @ CallNode (location: (8,0)-(8,25))
         │   ├── flags: newline, ignore_visibility
@@ -97,7 +97,7 @@
         │       │           │           ├── flags: newline
         │       │           │           ├── arguments: ∅
         │       │           │           └── keyword_loc: (8,6)-(8,11) = "break"
-        │       │           ├── consequent: ∅
+        │       │           ├── else_clause: ∅
         │       │           └── end_keyword_loc: ∅
         │       ├── opening_loc: (8,4)-(8,5) = "{"
         │       └── closing_loc: (8,24)-(8,25) = "}"
@@ -134,7 +134,7 @@
         │       │           │           ├── flags: newline
         │       │           │           ├── arguments: ∅
         │       │           │           └── keyword_loc: (10,6)-(10,10) = "next"
-        │       │           ├── consequent: ∅
+        │       │           ├── else_clause: ∅
         │       │           └── end_keyword_loc: ∅
         │       ├── opening_loc: (10,4)-(10,5) = "{"
         │       └── closing_loc: (10,23)-(10,24) = "}"
@@ -153,7 +153,7 @@
         │   │           ├── flags: newline
         │   │           ├── keyword_loc: (12,0)-(12,6) = "return"
         │   │           └── arguments: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   └── end_keyword_loc: ∅
         └── @ UnlessNode (location: (14,0)-(14,22))
             ├── flags: newline
@@ -199,5 +199,5 @@
             │           │           └── unescaped: "b"
             │           ├── closing_loc: ∅
             │           └── block: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             └── end_keyword_loc: ∅

--- a/test/prism/snapshots/unparser/corpus/literal/block.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/block.txt
@@ -942,7 +942,7 @@
         │       │   │   │   ├── name: :e
         │       │   │   │   └── depth: 0
         │       │   │   ├── statements: ∅
-        │       │   │   └── consequent: ∅
+        │       │   │   └── subsequent: ∅
         │       │   ├── else_clause: ∅
         │       │   ├── ensure_clause: ∅
         │       │   └── end_keyword_loc: (51,0)-(51,3) = "end"
@@ -1002,7 +1002,7 @@
         │       │   │   │           ├── flags: newline
         │       │   │   │           ├── name: :bar
         │       │   │   │           └── depth: 0
-        │       │   │   └── consequent: ∅
+        │       │   │   └── subsequent: ∅
         │       │   ├── else_clause: ∅
         │       │   ├── ensure_clause: ∅
         │       │   └── end_keyword_loc: (56,0)-(56,3) = "end"
@@ -1078,7 +1078,7 @@
         │       │   │   │           ├── arguments: ∅
         │       │   │   │           ├── closing_loc: ∅
         │       │   │   │           └── block: ∅
-        │       │   │   └── consequent: ∅
+        │       │   │   └── subsequent: ∅
         │       │   ├── else_clause: ∅
         │       │   ├── ensure_clause: ∅
         │       │   └── end_keyword_loc: (61,0)-(61,3) = "end"
@@ -1158,7 +1158,7 @@
         │       │   │   │           ├── arguments: ∅
         │       │   │   │           ├── closing_loc: ∅
         │       │   │   │           └── block: ∅
-        │       │   │   └── consequent: ∅
+        │       │   │   └── subsequent: ∅
         │       │   ├── else_clause: ∅
         │       │   ├── ensure_clause: ∅
         │       │   └── end_keyword_loc: (66,0)-(66,3) = "end"
@@ -1231,7 +1231,7 @@
         │       │   │   │           ├── arguments: ∅
         │       │   │   │           ├── closing_loc: ∅
         │       │   │   │           └── block: ∅
-        │       │   │   └── consequent: ∅
+        │       │   │   └── subsequent: ∅
         │       │   ├── else_clause: ∅
         │       │   ├── ensure_clause: ∅
         │       │   └── end_keyword_loc: (71,0)-(71,3) = "end"
@@ -1280,7 +1280,7 @@
         │       │   │   ├── operator_loc: ∅
         │       │   │   ├── reference: ∅
         │       │   │   ├── statements: ∅
-        │       │   │   └── consequent: ∅
+        │       │   │   └── subsequent: ∅
         │       │   ├── else_clause: ∅
         │       │   ├── ensure_clause: ∅
         │       │   └── end_keyword_loc: (75,0)-(75,3) = "end"
@@ -1326,7 +1326,7 @@
         │       │   │   ├── operator_loc: ∅
         │       │   │   ├── reference: ∅
         │       │   │   ├── statements: ∅
-        │       │   │   └── consequent: ∅
+        │       │   │   └── subsequent: ∅
         │       │   ├── else_clause:
         │       │   │   @ ElseNode (location: (79,0)-(81,3))
         │       │   │   ├── flags: ∅
@@ -1421,7 +1421,7 @@
         │       │   │   │           ├── arguments: ∅
         │       │   │   │           ├── closing_loc: ∅
         │       │   │   │           └── block: ∅
-        │       │   │   └── consequent: ∅
+        │       │   │   └── subsequent: ∅
         │       │   ├── else_clause: ∅
         │       │   ├── ensure_clause: ∅
         │       │   └── end_keyword_loc: (86,0)-(86,3) = "end"
@@ -1484,7 +1484,7 @@
         │       │   │   ├── operator_loc: ∅
         │       │   │   ├── reference: ∅
         │       │   │   ├── statements: ∅
-        │       │   │   └── consequent: ∅
+        │       │   │   └── subsequent: ∅
         │       │   ├── else_clause: ∅
         │       │   ├── ensure_clause:
         │       │   │   @ EnsureNode (location: (92,0)-(93,3))

--- a/test/prism/snapshots/unparser/corpus/literal/case.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/case.txt
@@ -67,7 +67,7 @@
         │   │                   ├── arguments: ∅
         │   │                   ├── closing_loc: ∅
         │   │                   └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (1,0)-(1,4) = "case"
         │   └── end_keyword_loc: (6,0)-(6,3) = "end"
         ├── @ CaseNode (location: (7,0)-(11,3))
@@ -129,7 +129,7 @@
         │   │                   ├── arguments: ∅
         │   │                   ├── closing_loc: ∅
         │   │                   └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (7,0)-(7,4) = "case"
         │   └── end_keyword_loc: (11,0)-(11,3) = "end"
         ├── @ CaseNode (location: (12,0)-(17,3))
@@ -204,7 +204,7 @@
         │   │                   ├── arguments: ∅
         │   │                   ├── closing_loc: ∅
         │   │                   └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (12,0)-(12,4) = "case"
         │   └── end_keyword_loc: (17,0)-(17,3) = "end"
         ├── @ CaseNode (location: (18,0)-(21,3))
@@ -256,7 +256,7 @@
         │   │                   ├── value_loc: (20,3)-(20,8) = "other"
         │   │                   ├── closing_loc: ∅
         │   │                   └── unescaped: "other"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (18,0)-(18,4) = "case"
         │   └── end_keyword_loc: (21,0)-(21,3) = "end"
         ├── @ CaseNode (location: (22,0)-(25,3))
@@ -302,7 +302,7 @@
         │   │                   ├── value_loc: (24,3)-(24,8) = "value"
         │   │                   ├── closing_loc: ∅
         │   │                   └── unescaped: "value"
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (22,0)-(22,4) = "case"
         │   └── end_keyword_loc: (25,0)-(25,3) = "end"
         ├── @ CaseNode (location: (26,0)-(31,3))
@@ -348,7 +348,7 @@
         │   │                   ├── arguments: ∅
         │   │                   ├── closing_loc: ∅
         │   │                   └── block: ∅
-        │   ├── consequent:
+        │   ├── else_clause:
         │   │   @ ElseNode (location: (29,0)-(31,3))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (29,0)-(29,4) = "else"
@@ -422,7 +422,7 @@
         │   │       │           └── block: ∅
         │   │       ├── then_keyword_loc: ∅
         │   │       └── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (32,0)-(32,4) = "case"
         │   └── end_keyword_loc: (34,0)-(34,3) = "end"
         └── @ CaseNode (location: (35,0)-(37,3))
@@ -475,6 +475,6 @@
             │       │           └── block: ∅
             │       ├── then_keyword_loc: ∅
             │       └── statements: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (35,0)-(35,4) = "case"
             └── end_keyword_loc: (37,0)-(37,3) = "end"

--- a/test/prism/snapshots/unparser/corpus/literal/def.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/def.txt
@@ -50,7 +50,7 @@
         │   │   │   │           ├── arguments: ∅
         │   │   │   │           ├── closing_loc: ∅
         │   │   │   │           └── block: ∅
-        │   │   │   └── consequent: ∅
+        │   │   │   └── subsequent: ∅
         │   │   ├── else_clause:
         │   │   │   @ ElseNode (location: (5,0)-(7,6))
         │   │   │   ├── flags: ∅
@@ -157,7 +157,7 @@
         │   │   │   │           ├── arguments: ∅
         │   │   │   │           ├── closing_loc: ∅
         │   │   │   │           └── block: ∅
-        │   │   │   └── consequent: ∅
+        │   │   │   └── subsequent: ∅
         │   │   ├── else_clause:
         │   │   │   @ ElseNode (location: (15,0)-(17,6))
         │   │   │   ├── flags: ∅
@@ -321,7 +321,7 @@
         │   │   │   │           ├── arguments: ∅
         │   │   │   │           ├── closing_loc: ∅
         │   │   │   │           └── block: ∅
-        │   │   │   └── consequent: ∅
+        │   │   │   └── subsequent: ∅
         │   │   ├── else_clause: ∅
         │   │   ├── ensure_clause:
         │   │   │   @ EnsureNode (location: (35,0)-(37,3))
@@ -448,7 +448,7 @@
         │   │   │   │           ├── arguments: ∅
         │   │   │   │           ├── closing_loc: ∅
         │   │   │   │           └── block: ∅
-        │   │   │   └── consequent: ∅
+        │   │   │   └── subsequent: ∅
         │   │   ├── else_clause: ∅
         │   │   ├── ensure_clause: ∅
         │   │   └── end_keyword_loc: (49,0)-(49,3) = "end"

--- a/test/prism/snapshots/unparser/corpus/literal/dstr.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/dstr.txt
@@ -32,7 +32,7 @@
         │   │           │       ├── closing_loc: ∅
         │   │           │       └── unescaped: "a"
         │   │           └── closing_loc: (2,7)-(2,8) = "\""
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (3,0)-(3,3) = "end"
         ├── @ IfNode (location: (4,0)-(11,3))
         │   ├── flags: newline
@@ -77,7 +77,7 @@
         │   │           ├── arguments: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (11,0)-(11,3) = "end"
         ├── @ InterpolatedStringNode (location: (12,0)-(12,10))
         │   ├── flags: newline
@@ -264,7 +264,7 @@
         │   │                       │       ├── closing_loc: ∅
         │   │                       │       └── unescaped: "\n"
         │   │                       └── closing_loc: (29,0)-(30,0) = "  HEREDOC\n"
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (30,0)-(30,3) = "end"
         ├── @ CallNode (location: (31,0)-(31,15))
         │   ├── flags: newline, ignore_visibility

--- a/test/prism/snapshots/unparser/corpus/literal/flipflop.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/flipflop.txt
@@ -105,7 +105,7 @@
         │   │           ├── arguments: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (3,0)-(3,3) = "end"
         ├── @ IfNode (location: (4,0)-(6,3))
         │   ├── flags: newline
@@ -207,7 +207,7 @@
         │   │           ├── arguments: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (6,0)-(6,3) = "end"
         ├── @ IfNode (location: (7,0)-(8,3))
         │   ├── flags: newline
@@ -230,7 +230,7 @@
         │   │   └── operator_loc: (7,3)-(7,5) = ".."
         │   ├── then_keyword_loc: ∅
         │   ├── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (8,0)-(8,3) = "end"
         └── @ IfNode (location: (9,0)-(10,3))
             ├── flags: newline
@@ -253,5 +253,5 @@
             │   └── operator_loc: (9,6)-(9,8) = ".."
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (10,0)-(10,3) = "end"

--- a/test/prism/snapshots/unparser/corpus/literal/if.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/if.txt
@@ -30,7 +30,7 @@
         │   │           ├── arguments: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (3,0)-(3,3) = "end"
         ├── @ IfNode (location: (4,0)-(6,3))
         │   ├── flags: newline
@@ -47,7 +47,7 @@
         │   │       └── @ IntegerNode (location: (5,2)-(5,3))
         │   │           ├── flags: newline, static_literal, decimal
         │   │           └── value: 9
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (6,0)-(6,3) = "end"
         ├── @ IfNode (location: (7,0)-(11,3))
         │   ├── flags: newline
@@ -64,7 +64,7 @@
         │   │       └── @ IntegerNode (location: (8,2)-(8,3))
         │   │           ├── flags: newline, static_literal, decimal
         │   │           └── value: 5
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (9,0)-(11,3))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (9,0)-(9,4) = "else"
@@ -91,7 +91,7 @@
         │   │   └── body: (length: 1)
         │   │       └── @ NilNode (location: (13,2)-(13,5))
         │   │           └── flags: newline, static_literal
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   └── end_keyword_loc: (14,0)-(14,3) = "end"
         ├── @ UnlessNode (location: (15,0)-(17,3))
         │   ├── flags: newline
@@ -108,7 +108,7 @@
         │   │       └── @ IntegerNode (location: (16,2)-(16,3))
         │   │           ├── flags: newline, static_literal, decimal
         │   │           └── value: 9
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   └── end_keyword_loc: (17,0)-(17,3) = "end"
         ├── @ IfNode (location: (18,0)-(19,3))
         │   ├── flags: newline
@@ -126,7 +126,7 @@
         │   │   └── block: ∅
         │   ├── then_keyword_loc: ∅
         │   ├── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (19,0)-(19,3) = "end"
         ├── @ ModuleNode (location: (21,0)-(23,3))
         │   ├── flags: newline
@@ -170,7 +170,7 @@
         │   │           │           │   ├── closing_loc: ∅
         │   │           │           │   └── block: ∅
         │   │           │           └── operator_loc: (22,6)-(22,7) = "="
-        │   │           ├── consequent: ∅
+        │   │           ├── subsequent: ∅
         │   │           └── end_keyword_loc: ∅
         │   ├── end_keyword_loc: (23,0)-(23,3) = "end"
         │   └── name: :A
@@ -216,7 +216,7 @@
         │   │           │           │   ├── closing_loc: ∅
         │   │           │           │   └── block: ∅
         │   │           │           └── operator_loc: (26,6)-(26,7) = "="
-        │   │           ├── consequent: ∅
+        │   │           ├── else_clause: ∅
         │   │           └── end_keyword_loc: ∅
         │   ├── end_keyword_loc: (27,0)-(27,3) = "end"
         │   └── name: :B
@@ -256,7 +256,7 @@
         │   │           │   ├── closing_loc: ∅
         │   │           │   └── block: ∅
         │   │           └── operator_loc: (29,6)-(29,7) = "="
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   └── end_keyword_loc: (30,0)-(30,3) = "end"
         └── @ IfNode (location: (31,0)-(36,3))
             ├── flags: newline
@@ -326,5 +326,5 @@
             │           ├── flags: newline
             │           ├── name: :foo
             │           └── depth: 0
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (36,0)-(36,3) = "end"

--- a/test/prism/snapshots/unparser/corpus/literal/kwbegin.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/kwbegin.txt
@@ -17,7 +17,7 @@
         │   │   ├── operator_loc: ∅
         │   │   ├── reference: ∅
         │   │   ├── statements: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (3,0)-(3,3) = "end"
@@ -93,7 +93,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (17,0)-(17,3) = "end"
@@ -145,7 +145,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (24,0)-(24,3) = "end"
@@ -164,7 +164,7 @@
         │   │   ├── operator_loc: ∅
         │   │   ├── reference: ∅
         │   │   ├── statements: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (28,0)-(28,3) = "end"
@@ -187,7 +187,7 @@
         │   │   │   ├── name: :foo
         │   │   │   └── depth: 0
         │   │   ├── statements: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (32,0)-(32,3) = "end"
@@ -232,7 +232,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent:
+        │   │   └── subsequent:
         │   │       @ RescueNode (location: (38,0)-(39,3))
         │   │       ├── flags: ∅
         │   │       ├── keyword_loc: (38,0)-(38,6) = "rescue"
@@ -256,7 +256,7 @@
         │   │       │           ├── arguments: ∅
         │   │       │           ├── closing_loc: ∅
         │   │       │           └── block: ∅
-        │   │       └── consequent: ∅
+        │   │       └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause:
         │   │   @ EnsureNode (location: (40,0)-(42,3))
@@ -314,7 +314,7 @@
         │   │           │   ├── operator_loc: ∅
         │   │           │   ├── reference: ∅
         │   │           │   ├── statements: ∅
-        │   │           │   └── consequent: ∅
+        │   │           │   └── subsequent: ∅
         │   │           ├── else_clause: ∅
         │   │           ├── ensure_clause: ∅
         │   │           └── end_keyword_loc: (49,2)-(49,5) = "end"
@@ -349,7 +349,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (53,0)-(53,3) = "end"
@@ -409,7 +409,7 @@
         │   │   ├── operator_loc: ∅
         │   │   ├── reference: ∅
         │   │   ├── statements: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (58,0)-(58,3) = "end"
@@ -443,7 +443,7 @@
         │   │   │           ├── flags: newline
         │   │   │           ├── name: :bar
         │   │   │           └── depth: 0
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (64,0)-(64,3) = "end"
@@ -483,7 +483,7 @@
         │   │   │           ├── flags: newline
         │   │   │           ├── name: :bar
         │   │   │           └── depth: 0
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (70,0)-(70,3) = "end"
@@ -534,7 +534,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (76,0)-(76,3) = "end"

--- a/test/prism/snapshots/unparser/corpus/literal/pattern.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/pattern.txt
@@ -179,7 +179,7 @@
         │   │   │   │   │           ├── rest: ∅
         │   │   │   │   │           ├── opening_loc: (10,3)-(10,4) = "{"
         │   │   │   │   │           └── closing_loc: (10,4)-(10,5) = "}"
-        │   │   │   │   ├── consequent: ∅
+        │   │   │   │   ├── subsequent: ∅
         │   │   │   │   └── end_keyword_loc: ∅
         │   │   │   ├── statements:
         │   │   │   │   @ StatementsNode (location: (11,2)-(11,6))
@@ -425,7 +425,7 @@
         │   │       │           └── flags: newline, static_literal
         │   │       ├── in_loc: (29,0)-(29,2) = "in"
         │   │       └── then_loc: (29,5)-(29,9) = "then"
-        │   ├── consequent:
+        │   ├── else_clause:
         │   │   @ ElseNode (location: (31,0)-(33,3))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (31,0)-(31,4) = "else"
@@ -486,7 +486,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (35,0)-(35,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (34,0)-(34,4) = "case"
         │   └── end_keyword_loc: (36,0)-(36,3) = "end"
         ├── @ CaseMatchNode (location: (37,0)-(40,3))
@@ -512,7 +512,7 @@
         │   │       ├── statements: ∅
         │   │       ├── in_loc: (38,0)-(38,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent:
+        │   ├── else_clause:
         │   │   @ ElseNode (location: (39,0)-(40,3))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (39,0)-(39,4) = "else"

--- a/test/prism/snapshots/unparser/corpus/literal/send.txt
+++ b/test/prism/snapshots/unparser/corpus/literal/send.txt
@@ -158,7 +158,7 @@
         │   │   │   ├── operator_loc: ∅
         │   │   │   ├── reference: ∅
         │   │   │   ├── statements: ∅
-        │   │   │   └── consequent: ∅
+        │   │   │   └── subsequent: ∅
         │   │   ├── else_clause: ∅
         │   │   ├── ensure_clause: ∅
         │   │   └── end_keyword_loc: (15,0)-(15,3) = "end"
@@ -220,7 +220,7 @@
         │   │   │       │       └── block: ∅
         │   │   │       ├── then_keyword_loc: ∅
         │   │   │       └── statements: ∅
-        │   │   ├── consequent: ∅
+        │   │   ├── else_clause: ∅
         │   │   ├── case_keyword_loc: (16,0)-(16,4) = "case"
         │   │   └── end_keyword_loc: (19,0)-(19,3) = "end"
         │   ├── call_operator_loc: (19,3)-(19,4) = "."
@@ -263,7 +263,7 @@
         │   │   │       │       └── block: ∅
         │   │   │       ├── then_keyword_loc: ∅
         │   │   │       └── statements: ∅
-        │   │   ├── consequent: ∅
+        │   │   ├── else_clause: ∅
         │   │   ├── case_keyword_loc: (20,0)-(20,4) = "case"
         │   │   └── end_keyword_loc: (22,0)-(22,3) = "end"
         │   ├── call_operator_loc: (22,3)-(22,4) = "."
@@ -441,7 +441,7 @@
         │   │   │   └── block: ∅
         │   │   ├── then_keyword_loc: ∅
         │   │   ├── statements: ∅
-        │   │   ├── consequent: ∅
+        │   │   ├── subsequent: ∅
         │   │   └── end_keyword_loc: (36,0)-(36,3) = "end"
         │   ├── call_operator_loc: (36,3)-(36,4) = "."
         │   ├── name: :baz

--- a/test/prism/snapshots/unparser/corpus/semantic/and.txt
+++ b/test/prism/snapshots/unparser/corpus/semantic/and.txt
@@ -176,7 +176,7 @@
         │   │   └── operator_loc: (4,9)-(4,11) = "or"
         │   ├── then_keyword_loc: ∅
         │   ├── statements: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (5,0)-(5,3) = "end"
         └── @ IfNode (location: (7,0)-(8,3))
             ├── flags: newline
@@ -239,5 +239,5 @@
             │   └── operator_loc: (7,9)-(7,12) = "and"
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (8,0)-(8,3) = "end"

--- a/test/prism/snapshots/unparser/corpus/semantic/block.txt
+++ b/test/prism/snapshots/unparser/corpus/semantic/block.txt
@@ -49,7 +49,7 @@
         │       │   │   ├── operator_loc: ∅
         │       │   │   ├── reference: ∅
         │       │   │   ├── statements: ∅
-        │       │   │   └── consequent: ∅
+        │       │   │   └── subsequent: ∅
         │       │   ├── else_clause: ∅
         │       │   ├── ensure_clause: ∅
         │       │   └── end_keyword_loc: (6,0)-(6,3) = "end"

--- a/test/prism/snapshots/unparser/corpus/semantic/dstr.txt
+++ b/test/prism/snapshots/unparser/corpus/semantic/dstr.txt
@@ -262,7 +262,7 @@
         │   │           │       ├── closing_loc: ∅
         │   │           │       └── unescaped: "\n"
         │   │           └── closing_loc: (80,0)-(81,0) = "  DOC\n"
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (81,0)-(81,3) = "end"
         ├── @ IfNode (location: (83,0)-(87,3))
         │   ├── flags: newline
@@ -297,7 +297,7 @@
         │   │           │       ├── closing_loc: ∅
         │   │           │       └── unescaped: "\n"
         │   │           └── closing_loc: (86,0)-(87,0) = "  DOC\n"
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (87,0)-(87,3) = "end"
         ├── @ IfNode (location: (89,0)-(93,3))
         │   ├── flags: newline
@@ -326,7 +326,7 @@
         │   │           │       ├── closing_loc: ∅
         │   │           │       └── unescaped: "a\n"
         │   │           └── closing_loc: (92,0)-(93,0) = "  DOC\n"
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (93,0)-(93,3) = "end"
         ├── @ IfNode (location: (95,0)-(101,3))
         │   ├── flags: newline
@@ -345,7 +345,7 @@
         │   │           ├── content_loc: (97,0)-(100,0) = "   a\n\n   b\n"
         │   │           ├── closing_loc: (100,0)-(101,0) = "  DOC\n"
         │   │           └── unescaped: "   a\n\n   b\n"
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (101,0)-(101,3) = "end"
         ├── @ InterpolatedStringNode (location: (103,0)-(103,6))
         │   ├── flags: newline

--- a/test/prism/snapshots/unparser/corpus/semantic/kwbegin.txt
+++ b/test/prism/snapshots/unparser/corpus/semantic/kwbegin.txt
@@ -17,7 +17,7 @@
         │   │   ├── operator_loc: ∅
         │   │   ├── reference: ∅
         │   │   ├── statements: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (3,0)-(3,3) = "end"
@@ -33,7 +33,7 @@
         │   │   ├── operator_loc: ∅
         │   │   ├── reference: ∅
         │   │   ├── statements: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause:
         │   │   @ ElseNode (location: (7,0)-(8,3))
         │   │   ├── flags: ∅
@@ -101,7 +101,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (18,0)-(18,3) = "end"
@@ -153,7 +153,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (25,0)-(25,3) = "end"
@@ -172,7 +172,7 @@
         │   │   ├── operator_loc: ∅
         │   │   ├── reference: ∅
         │   │   ├── statements: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause:
         │   │   @ ElseNode (location: (29,0)-(30,3))
         │   │   ├── flags: ∅
@@ -196,7 +196,7 @@
         │   │   ├── operator_loc: ∅
         │   │   ├── reference: ∅
         │   │   ├── statements: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause:
         │   │   @ ElseNode (location: (32,17)-(32,26))
         │   │   ├── flags: ∅
@@ -246,7 +246,7 @@
             │   │           ├── arguments: ∅
             │   │           ├── closing_loc: ∅
             │   │           └── block: ∅
-            │   └── consequent:
+            │   └── subsequent:
             │       @ RescueNode (location: (38,0)-(39,3))
             │       ├── flags: ∅
             │       ├── keyword_loc: (38,0)-(38,6) = "rescue"
@@ -270,7 +270,7 @@
             │       │           ├── arguments: ∅
             │       │           ├── closing_loc: ∅
             │       │           └── block: ∅
-            │       └── consequent: ∅
+            │       └── subsequent: ∅
             ├── else_clause: ∅
             ├── ensure_clause:
             │   @ EnsureNode (location: (40,0)-(42,3))

--- a/test/prism/snapshots/whitequark/ambiuous_quoted_label_in_ternary_operator.txt
+++ b/test/prism/snapshots/whitequark/ambiuous_quoted_label_in_ternary_operator.txt
@@ -53,7 +53,7 @@
             │           │           └── unescaped: ""
             │           ├── closing_loc: ∅
             │           └── block: ∅
-            ├── consequent:
+            ├── subsequent:
             │   @ ElseNode (location: (1,10)-(1,15))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (1,10)-(1,11) = ":"

--- a/test/prism/snapshots/whitequark/bug_rescue_empty_else.txt
+++ b/test/prism/snapshots/whitequark/bug_rescue_empty_else.txt
@@ -20,7 +20,7 @@
             │   ├── operator_loc: ∅
             │   ├── reference: ∅
             │   ├── statements: ∅
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause:
             │   @ ElseNode (location: (1,25)-(1,34))
             │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/case_cond.txt
+++ b/test/prism/snapshots/whitequark/case_cond.txt
@@ -34,6 +34,6 @@
             │                   ├── content_loc: (1,17)-(1,20) = "foo"
             │                   ├── closing_loc: (1,20)-(1,21) = "'"
             │                   └── unescaped: "foo"
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (1,23)-(1,26) = "end"

--- a/test/prism/snapshots/whitequark/case_cond_else.txt
+++ b/test/prism/snapshots/whitequark/case_cond_else.txt
@@ -34,7 +34,7 @@
             │                   ├── content_loc: (1,17)-(1,20) = "foo"
             │                   ├── closing_loc: (1,20)-(1,21) = "'"
             │                   └── unescaped: "foo"
-            ├── consequent:
+            ├── else_clause:
             │   @ ElseNode (location: (1,23)-(1,38))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (1,23)-(1,27) = "else"

--- a/test/prism/snapshots/whitequark/case_expr.txt
+++ b/test/prism/snapshots/whitequark/case_expr.txt
@@ -44,6 +44,6 @@
             │                   ├── arguments: ∅
             │                   ├── closing_loc: ∅
             │                   └── block: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (1,27)-(1,30) = "end"

--- a/test/prism/snapshots/whitequark/case_expr_else.txt
+++ b/test/prism/snapshots/whitequark/case_expr_else.txt
@@ -44,7 +44,7 @@
             │                   ├── arguments: ∅
             │                   ├── closing_loc: ∅
             │                   └── block: ∅
-            ├── consequent:
+            ├── else_clause:
             │   @ ElseNode (location: (1,27)-(1,40))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (1,27)-(1,31) = "else"

--- a/test/prism/snapshots/whitequark/cond_begin.txt
+++ b/test/prism/snapshots/whitequark/cond_begin.txt
@@ -42,5 +42,5 @@
             │           ├── arguments: ∅
             │           ├── closing_loc: ∅
             │           └── block: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (1,15)-(1,18) = "end"

--- a/test/prism/snapshots/whitequark/cond_begin_masgn.txt
+++ b/test/prism/snapshots/whitequark/cond_begin_masgn.txt
@@ -56,5 +56,5 @@
             │   └── closing_loc: (1,19)-(1,20) = ")"
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (1,22)-(1,25) = "end"

--- a/test/prism/snapshots/whitequark/cond_eflipflop.txt
+++ b/test/prism/snapshots/whitequark/cond_eflipflop.txt
@@ -79,5 +79,5 @@
             │   └── operator_loc: (3,6)-(3,9) = "..."
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (3,14)-(3,17) = "end"

--- a/test/prism/snapshots/whitequark/cond_eflipflop_with_beginless_range.txt
+++ b/test/prism/snapshots/whitequark/cond_eflipflop_with_beginless_range.txt
@@ -26,5 +26,5 @@
             │   └── operator_loc: (1,3)-(1,6) = "..."
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (1,11)-(1,14) = "end"

--- a/test/prism/snapshots/whitequark/cond_eflipflop_with_endless_range.txt
+++ b/test/prism/snapshots/whitequark/cond_eflipflop_with_endless_range.txt
@@ -26,5 +26,5 @@
             │   └── operator_loc: (1,6)-(1,9) = "..."
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (1,11)-(1,14) = "end"

--- a/test/prism/snapshots/whitequark/cond_iflipflop.txt
+++ b/test/prism/snapshots/whitequark/cond_iflipflop.txt
@@ -79,5 +79,5 @@
             │   └── operator_loc: (3,6)-(3,8) = ".."
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (3,13)-(3,16) = "end"

--- a/test/prism/snapshots/whitequark/cond_iflipflop_with_beginless_range.txt
+++ b/test/prism/snapshots/whitequark/cond_iflipflop_with_beginless_range.txt
@@ -26,5 +26,5 @@
             │   └── operator_loc: (1,3)-(1,5) = ".."
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (1,10)-(1,13) = "end"

--- a/test/prism/snapshots/whitequark/cond_iflipflop_with_endless_range.txt
+++ b/test/prism/snapshots/whitequark/cond_iflipflop_with_endless_range.txt
@@ -26,5 +26,5 @@
             │   └── operator_loc: (1,6)-(1,8) = ".."
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (1,10)-(1,13) = "end"

--- a/test/prism/snapshots/whitequark/cond_match_current_line.txt
+++ b/test/prism/snapshots/whitequark/cond_match_current_line.txt
@@ -33,5 +33,5 @@
             │   └── unescaped: "wat"
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (3,10)-(3,13) = "end"

--- a/test/prism/snapshots/whitequark/hash_label_end.txt
+++ b/test/prism/snapshots/whitequark/hash_label_end.txt
@@ -41,7 +41,7 @@
         │   │           │           ├── content_loc: (1,7)-(1,8) = "a"
         │   │           │           ├── closing_loc: (1,8)-(1,9) = "\""
         │   │           │           └── unescaped: "a"
-        │   │           ├── consequent:
+        │   │           ├── subsequent:
         │   │           │   @ ElseNode (location: (1,9)-(1,11))
         │   │           │   ├── flags: ∅
         │   │           │   ├── else_keyword_loc: (1,9)-(1,10) = ":"

--- a/test/prism/snapshots/whitequark/if.txt
+++ b/test/prism/snapshots/whitequark/if.txt
@@ -34,7 +34,7 @@
         │   │           ├── arguments: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── subsequent: ∅
         │   └── end_keyword_loc: (1,17)-(1,20) = "end"
         └── @ IfNode (location: (3,0)-(3,16))
             ├── flags: newline
@@ -65,5 +65,5 @@
             │           ├── arguments: ∅
             │           ├── closing_loc: ∅
             │           └── block: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (3,13)-(3,16) = "end"

--- a/test/prism/snapshots/whitequark/if_else.txt
+++ b/test/prism/snapshots/whitequark/if_else.txt
@@ -34,7 +34,7 @@
         │   │           ├── arguments: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (1,17)-(1,30))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (1,17)-(1,21) = "else"
@@ -83,7 +83,7 @@
             │           ├── arguments: ∅
             │           ├── closing_loc: ∅
             │           └── block: ∅
-            ├── consequent:
+            ├── subsequent:
             │   @ ElseNode (location: (3,13)-(3,26))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (3,13)-(3,17) = "else"

--- a/test/prism/snapshots/whitequark/if_elsif.txt
+++ b/test/prism/snapshots/whitequark/if_elsif.txt
@@ -34,7 +34,7 @@
             │           ├── arguments: ∅
             │           ├── closing_loc: ∅
             │           └── block: ∅
-            ├── consequent:
+            ├── subsequent:
             │   @ IfNode (location: (1,13)-(1,38))
             │   ├── flags: newline
             │   ├── if_keyword_loc: (1,13)-(1,18) = "elsif"
@@ -57,7 +57,7 @@
             │   │       └── @ IntegerNode (location: (1,24)-(1,25))
             │   │           ├── flags: newline, static_literal, decimal
             │   │           └── value: 1
-            │   ├── consequent:
+            │   ├── subsequent:
             │   │   @ ElseNode (location: (1,27)-(1,38))
             │   │   ├── flags: ∅
             │   │   ├── else_keyword_loc: (1,27)-(1,31) = "else"

--- a/test/prism/snapshots/whitequark/if_masgn__24.txt
+++ b/test/prism/snapshots/whitequark/if_masgn__24.txt
@@ -46,5 +46,5 @@
             │   └── closing_loc: (1,14)-(1,15) = ")"
             ├── then_keyword_loc: ∅
             ├── statements: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (1,17)-(1,20) = "end"

--- a/test/prism/snapshots/whitequark/if_mod.txt
+++ b/test/prism/snapshots/whitequark/if_mod.txt
@@ -34,5 +34,5 @@
             │           ├── arguments: ∅
             │           ├── closing_loc: ∅
             │           └── block: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: ∅

--- a/test/prism/snapshots/whitequark/if_nl_then.txt
+++ b/test/prism/snapshots/whitequark/if_nl_then.txt
@@ -34,5 +34,5 @@
             │           ├── arguments: ∅
             │           ├── closing_loc: ∅
             │           └── block: ∅
-            ├── consequent: ∅
+            ├── subsequent: ∅
             └── end_keyword_loc: (2,9)-(2,12) = "end"

--- a/test/prism/snapshots/whitequark/newline_in_hash_argument.txt
+++ b/test/prism/snapshots/whitequark/newline_in_hash_argument.txt
@@ -97,7 +97,7 @@
         │   │       │           └── flags: newline, static_literal
         │   │       ├── in_loc: (5,0)-(5,2) = "in"
         │   │       └── then_loc: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   ├── case_keyword_loc: (1,0)-(1,4) = "case"
         │   └── end_keyword_loc: (8,0)-(8,3) = "end"
         ├── @ CallNode (location: (10,0)-(11,1))

--- a/test/prism/snapshots/whitequark/pattern_matching__FILE__LINE_literals.txt
+++ b/test/prism/snapshots/whitequark/pattern_matching__FILE__LINE_literals.txt
@@ -58,6 +58,6 @@
             │       ├── statements: ∅
             │       ├── in_loc: (2,10)-(2,12) = "in"
             │       └── then_loc: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,8)-(1,12) = "case"
             └── end_keyword_loc: (3,8)-(3,11) = "end"

--- a/test/prism/snapshots/whitequark/pattern_matching_blank_else.txt
+++ b/test/prism/snapshots/whitequark/pattern_matching_blank_else.txt
@@ -27,7 +27,7 @@
             │       │           └── value: 3
             │       ├── in_loc: (1,8)-(1,10) = "in"
             │       └── then_loc: ∅
-            ├── consequent:
+            ├── else_clause:
             │   @ ElseNode (location: (1,17)-(1,26))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (1,17)-(1,21) = "else"

--- a/test/prism/snapshots/whitequark/pattern_matching_else.txt
+++ b/test/prism/snapshots/whitequark/pattern_matching_else.txt
@@ -27,7 +27,7 @@
             │       │           └── value: 3
             │       ├── in_loc: (1,8)-(1,10) = "in"
             │       └── then_loc: ∅
-            ├── consequent:
+            ├── else_clause:
             │   @ ElseNode (location: (1,17)-(1,29))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (1,17)-(1,21) = "else"

--- a/test/prism/snapshots/whitequark/resbody_list.txt
+++ b/test/prism/snapshots/whitequark/resbody_list.txt
@@ -46,7 +46,7 @@
             │   │           ├── arguments: ∅
             │   │           ├── closing_loc: ∅
             │   │           └── block: ∅
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause: ∅
             ├── ensure_clause: ∅
             └── end_keyword_loc: (1,36)-(1,39) = "end"

--- a/test/prism/snapshots/whitequark/resbody_list_mrhs.txt
+++ b/test/prism/snapshots/whitequark/resbody_list_mrhs.txt
@@ -56,7 +56,7 @@
             │   │           ├── arguments: ∅
             │   │           ├── closing_loc: ∅
             │   │           └── block: ∅
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause: ∅
             ├── ensure_clause: ∅
             └── end_keyword_loc: (1,41)-(1,44) = "end"

--- a/test/prism/snapshots/whitequark/resbody_list_var.txt
+++ b/test/prism/snapshots/whitequark/resbody_list_var.txt
@@ -57,7 +57,7 @@
             │   │           ├── arguments: ∅
             │   │           ├── closing_loc: ∅
             │   │           └── block: ∅
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause: ∅
             ├── ensure_clause: ∅
             └── end_keyword_loc: (1,36)-(1,39) = "end"

--- a/test/prism/snapshots/whitequark/resbody_var.txt
+++ b/test/prism/snapshots/whitequark/resbody_var.txt
@@ -46,7 +46,7 @@
         │   │   │           ├── arguments: ∅
         │   │   │           ├── closing_loc: ∅
         │   │   │           └── block: ∅
-        │   │   └── consequent: ∅
+        │   │   └── subsequent: ∅
         │   ├── else_clause: ∅
         │   ├── ensure_clause: ∅
         │   └── end_keyword_loc: (1,33)-(1,36) = "end"
@@ -92,7 +92,7 @@
             │   │           ├── arguments: ∅
             │   │           ├── closing_loc: ∅
             │   │           └── block: ∅
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause: ∅
             ├── ensure_clause: ∅
             └── end_keyword_loc: (3,32)-(3,35) = "end"

--- a/test/prism/snapshots/whitequark/rescue.txt
+++ b/test/prism/snapshots/whitequark/rescue.txt
@@ -43,7 +43,7 @@
             │   │           ├── arguments: ∅
             │   │           ├── closing_loc: ∅
             │   │           └── block: ∅
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause: ∅
             ├── ensure_clause: ∅
             └── end_keyword_loc: (1,26)-(1,29) = "end"

--- a/test/prism/snapshots/whitequark/rescue_else.txt
+++ b/test/prism/snapshots/whitequark/rescue_else.txt
@@ -43,7 +43,7 @@
             │   │           ├── arguments: ∅
             │   │           ├── closing_loc: ∅
             │   │           └── block: ∅
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause:
             │   @ ElseNode (location: (1,26)-(1,40))
             │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/rescue_else_ensure.txt
+++ b/test/prism/snapshots/whitequark/rescue_else_ensure.txt
@@ -43,7 +43,7 @@
             │   │           ├── arguments: ∅
             │   │           ├── closing_loc: ∅
             │   │           └── block: ∅
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause:
             │   @ ElseNode (location: (1,26)-(1,42))
             │   ├── flags: ∅

--- a/test/prism/snapshots/whitequark/rescue_ensure.txt
+++ b/test/prism/snapshots/whitequark/rescue_ensure.txt
@@ -43,7 +43,7 @@
             │   │           ├── arguments: ∅
             │   │           ├── closing_loc: ∅
             │   │           └── block: ∅
-            │   └── consequent: ∅
+            │   └── subsequent: ∅
             ├── else_clause: ∅
             ├── ensure_clause:
             │   @ EnsureNode (location: (1,26)-(1,42))

--- a/test/prism/snapshots/whitequark/rescue_in_lambda_block.txt
+++ b/test/prism/snapshots/whitequark/rescue_in_lambda_block.txt
@@ -25,7 +25,7 @@
                 │   ├── operator_loc: ∅
                 │   ├── reference: ∅
                 │   ├── statements: ∅
-                │   └── consequent: ∅
+                │   └── subsequent: ∅
                 ├── else_clause: ∅
                 ├── ensure_clause: ∅
                 └── end_keyword_loc: (1,14)-(1,17) = "end"

--- a/test/prism/snapshots/whitequark/rescue_without_begin_end.txt
+++ b/test/prism/snapshots/whitequark/rescue_without_begin_end.txt
@@ -58,7 +58,7 @@
                 │   │   │           ├── arguments: ∅
                 │   │   │           ├── closing_loc: ∅
                 │   │   │           └── block: ∅
-                │   │   └── consequent: ∅
+                │   │   └── subsequent: ∅
                 │   ├── else_clause: ∅
                 │   ├── ensure_clause: ∅
                 │   └── end_keyword_loc: (1,27)-(1,30) = "end"

--- a/test/prism/snapshots/whitequark/ruby_bug_10279.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_10279.txt
@@ -33,7 +33,7 @@
             │       │   │       └── @ IntegerNode (location: (1,17)-(1,19))
             │       │   │           ├── flags: newline, static_literal, decimal
             │       │   │           └── value: 42
-            │       │   ├── consequent: ∅
+            │       │   ├── subsequent: ∅
             │       │   └── end_keyword_loc: (1,20)-(1,23) = "end"
             │       └── operator_loc: ∅
             └── closing_loc: (1,23)-(1,24) = "}"

--- a/test/prism/snapshots/whitequark/ruby_bug_10653.txt
+++ b/test/prism/snapshots/whitequark/ruby_bug_10653.txt
@@ -33,7 +33,7 @@
         │   │               ├── body: ∅
         │   │               ├── opening_loc: (1,14)-(1,16) = "do"
         │   │               └── closing_loc: (1,17)-(1,20) = "end"
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (1,21)-(1,33))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (1,21)-(1,22) = ":"
@@ -88,7 +88,7 @@
         │   │               ├── body: ∅
         │   │               ├── opening_loc: (3,14)-(3,15) = "{"
         │   │               └── closing_loc: (3,15)-(3,16) = "}"
-        │   ├── consequent:
+        │   ├── subsequent:
         │   │   @ ElseNode (location: (3,17)-(3,25))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (3,17)-(3,18) = ":"
@@ -184,7 +184,7 @@
             │               │           └── block: ∅
             │               ├── opening_loc: (5,13)-(5,15) = "do"
             │               └── closing_loc: (5,24)-(5,27) = "end"
-            ├── consequent:
+            ├── subsequent:
             │   @ ElseNode (location: (5,28)-(5,31))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (5,28)-(5,29) = ":"

--- a/test/prism/snapshots/whitequark/ternary.txt
+++ b/test/prism/snapshots/whitequark/ternary.txt
@@ -27,7 +27,7 @@
             │       └── @ IntegerNode (location: (1,6)-(1,7))
             │           ├── flags: newline, static_literal, decimal
             │           └── value: 1
-            ├── consequent:
+            ├── subsequent:
             │   @ ElseNode (location: (1,8)-(1,11))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (1,8)-(1,9) = ":"

--- a/test/prism/snapshots/whitequark/ternary_ambiguous_symbol.txt
+++ b/test/prism/snapshots/whitequark/ternary_ambiguous_symbol.txt
@@ -46,7 +46,7 @@
             │           ├── flags: newline
             │           ├── name: :t
             │           └── depth: 0
-            ├── consequent:
+            ├── subsequent:
             │   @ ElseNode (location: (1,11)-(1,13))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (1,11)-(1,12) = ":"

--- a/test/prism/snapshots/whitequark/unless.txt
+++ b/test/prism/snapshots/whitequark/unless.txt
@@ -34,7 +34,7 @@
         │   │           ├── arguments: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent: ∅
+        │   ├── else_clause: ∅
         │   └── end_keyword_loc: (1,21)-(1,24) = "end"
         └── @ UnlessNode (location: (3,0)-(3,20))
             ├── flags: newline
@@ -65,5 +65,5 @@
             │           ├── arguments: ∅
             │           ├── closing_loc: ∅
             │           └── block: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             └── end_keyword_loc: (3,17)-(3,20) = "end"

--- a/test/prism/snapshots/whitequark/unless_else.txt
+++ b/test/prism/snapshots/whitequark/unless_else.txt
@@ -34,7 +34,7 @@
         │   │           ├── arguments: ∅
         │   │           ├── closing_loc: ∅
         │   │           └── block: ∅
-        │   ├── consequent:
+        │   ├── else_clause:
         │   │   @ ElseNode (location: (1,21)-(1,34))
         │   │   ├── flags: ∅
         │   │   ├── else_keyword_loc: (1,21)-(1,25) = "else"
@@ -83,7 +83,7 @@
             │           ├── arguments: ∅
             │           ├── closing_loc: ∅
             │           └── block: ∅
-            ├── consequent:
+            ├── else_clause:
             │   @ ElseNode (location: (3,17)-(3,30))
             │   ├── flags: ∅
             │   ├── else_keyword_loc: (3,17)-(3,21) = "else"

--- a/test/prism/snapshots/whitequark/unless_mod.txt
+++ b/test/prism/snapshots/whitequark/unless_mod.txt
@@ -34,5 +34,5 @@
             │           ├── arguments: ∅
             │           ├── closing_loc: ∅
             │           └── block: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             └── end_keyword_loc: ∅

--- a/test/prism/snapshots/whitequark/when_multi.txt
+++ b/test/prism/snapshots/whitequark/when_multi.txt
@@ -50,6 +50,6 @@
             │                   ├── arguments: ∅
             │                   ├── closing_loc: ∅
             │                   └── block: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (1,34)-(1,37) = "end"

--- a/test/prism/snapshots/whitequark/when_splat.txt
+++ b/test/prism/snapshots/whitequark/when_splat.txt
@@ -75,6 +75,6 @@
             │       │           └── block: ∅
             │       ├── then_keyword_loc: ∅
             │       └── statements: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (1,40)-(1,43) = "end"

--- a/test/prism/snapshots/whitequark/when_then.txt
+++ b/test/prism/snapshots/whitequark/when_then.txt
@@ -44,6 +44,6 @@
             │                   ├── arguments: ∅
             │                   ├── closing_loc: ∅
             │                   └── block: ∅
-            ├── consequent: ∅
+            ├── else_clause: ∅
             ├── case_keyword_loc: (1,0)-(1,4) = "case"
             └── end_keyword_loc: (1,31)-(1,34) = "end"


### PR DESCRIPTION
Rename some fields that do not quite make sense.

* CaseMatchNode#consequent -> CaseMatchNode#else_clause
* CaseNode#consequent -> CaseNode#else_clause
* IfNode#consequent -> IfNode#subsequent
* RescueNode#consequent -> RescueNode#subsequent
* UnlessNode#consequent -> UnlessNode#else_clause