### PR TITLE
Skip tests of RDoc related feature

### DIFF
--- a/lib/rubygems/commands/setup_command.rb
+++ b/lib/rubygems/commands/setup_command.rb
@@ -336,6 +336,8 @@ By default, this RubyGems will install gem as:
 
       require_relative "../rdoc"
 
+      return false unless defined?(Gem::RDoc)
+
       fake_spec = Gem::Specification.new "rubygems", Gem::VERSION
       def fake_spec.full_gem_path
         File.expand_path "../../..", __dir__

--- a/test/irb/test_command.rb
+++ b/test/irb/test_command.rb
@@ -765,7 +765,7 @@ module TestIRB
     ensure
       # this is the only way to reset the redefined method without coupling the test with its implementation
       EnvUtil.suppress_warning { load "irb/command/help.rb" }
-    end
+    end if defined?(RDoc)
 
     def test_show_doc_without_rdoc
       _, err = without_rdoc do

--- a/test/irb/test_input_method.rb
+++ b/test/irb/test_input_method.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: false
 
 require "irb"
-require "rdoc"
+begin
+  require "rdoc"
+rescue LoadError
+end
 require_relative "helper"
 
 module TestIRB
@@ -188,4 +191,4 @@ module TestIRB
       File.exist?(RDoc::RI::Paths::BASE)
     end
   end
-end
+end if defined?(RDoc)

--- a/test/rubygems/test_gem_commands_install_command.rb
+++ b/test/rubygems/test_gem_commands_install_command.rb
@@ -667,7 +667,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
 
     assert_path_exist File.join(a2.doc_dir, "ri")
     assert_path_exist File.join(a2.doc_dir, "rdoc")
-  end
+  end if defined?(Gem::RDoc)
 
   def test_execute_rdoc_with_path
     specs = spec_fetcher do |fetcher|
@@ -703,7 +703,7 @@ ERROR:  Possible alternatives: non_existent_with_hint
     wait_for_child_process_to_exit
 
     assert_path_exist "whatever/doc/a-2", "documentation not installed"
-  end
+  end if defined?(Gem::RDoc)
 
   def test_execute_saves_build_args
     specs = spec_fetcher do |fetcher|

--- a/test/rubygems/test_gem_commands_update_command.rb
+++ b/test/rubygems/test_gem_commands_update_command.rb
@@ -506,7 +506,7 @@ class TestGemCommandsUpdateCommand < Gem::TestCase
     a2 = @specs["a-2"]
 
     assert_path_exist File.join(a2.doc_dir, "rdoc")
-  end
+  end if defined?(Gem::RDoc)
 
   def test_execute_named
     spec_fetcher do |fetcher|

--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -134,4 +134,4 @@ class TestGemRDoc < Gem::TestCase
       FileUtils.rm_r @a.doc_dir
     end
   end
-end
+end if defined?(Gem::RDoc)


### PR DESCRIPTION
I have a plan to extract RDoc as bundled gems at Ruby 3.5. We should make related feature optional in Ruby repo.