### PR TITLE
[Bug #20704] Win32: Fix chdir to non-ASCII path

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -559,6 +559,8 @@ translit_char_bin(char *p, int from, int to)
 #endif
 
 #ifdef _WIN32
+# undef chdir
+# define chdir rb_w32_uchdir
 # define UTF8_PATH 1
 #endif
 

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -237,7 +237,7 @@ class TestRubyOptions < Test::Unit::TestCase
 
   def test_kanji
     assert_in_out_err(%w(-KU), "p '\u3042'") do |r, e|
-      assert_equal("\"\u3042\"", r.join.force_encoding(Encoding::UTF_8))
+      assert_equal("\"\u3042\"", r.join('').force_encoding(Encoding::UTF_8))
     end
     line = '-eputs"\xc2\xa1".encoding'
     env = {'RUBYOPT' => nil}
@@ -362,8 +362,19 @@ class TestRubyOptions < Test::Unit::TestCase
 
     d = Dir.tmpdir
     assert_in_out_err(["-C", d, "-e", "puts Dir.pwd"]) do |r, e|
-      assert_file.identical?(r.join, d)
+      assert_file.identical?(r.join(''), d)
       assert_equal([], e)
+    end
+
+    Dir.mktmpdir(d) do |base|
+      # "test" in Japanese and N'Ko
+      test = base + "/\u{30c6 30b9 30c8}_\u{7e1 7ca 7dd 7cc 7df 7cd 7eb}"
+      Dir.mkdir(test)
+      assert_in_out_err(["-C", base, "-C", File.basename(test), "-e", "puts Dir.pwd"]) do |r, e|
+        assert_file.identical?(r.join(''), test)
+        assert_equal([], e)
+      end
+      Dir.rmdir(test)
     end
   end
 


### PR DESCRIPTION
On Windows, `chdir` in compilers' runtime libraries uses the active code page, but command line arguments in ruby are always UTF-8, since 33ea2646b98adb49ae2e1781753bf22d33729ac0.

[[Bug #20704]](https://bugs.ruby-lang.org/issues/20704)