### PR TITLE
[PRISM] For stdin scripts, use locale encoding

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -2155,7 +2155,11 @@ prism_script(ruby_cmdline_options_t *opt, pm_parse_result_t *result)
 
     pm_options_t *options = &result->options;
     pm_options_line_set(options, 1);
+    const bool read_stdin = (strcmp(opt->script, "-") == 0);
 
+    if (read_stdin) {
+        pm_options_encoding_set(options, rb_enc_name(rb_locale_encoding()));
+    }
     if (opt->src.enc.name != 0) {
         pm_options_encoding_set(options, StringValueCStr(opt->src.enc.name));
     }
@@ -2163,7 +2167,7 @@ prism_script(ruby_cmdline_options_t *opt, pm_parse_result_t *result)
     uint8_t command_line = prism_script_command_line(opt);
     VALUE error;
 
-    if (strcmp(opt->script, "-") == 0) {
+    if (read_stdin) {
         pm_options_command_line_set(options, command_line);
         pm_options_filepath_set(options, "-");
         pm_options_shebang_callback_set(options, prism_script_shebang_callback, (void *) opt);


### PR DESCRIPTION
For example:

    $ echo 'p __ENCODING__' | LANG=C ruby
    #<Encoding:US-ASCII>

But, allow -K to override the source encoding.
Found by running spec/ruby/language/magic_comment_spec.rb with LANG=C.

https://github.com/ruby/prism/issues/3024
