### PR TITLE
Suppress `-Wsign-compare` warning

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -10405,7 +10405,8 @@ pm_parse_process(pm_parse_result_t *result, pm_node_t *node, VALUE *script_lines
 
         for (size_t index = 0; index < parser->newline_list.size; index++) {
             size_t offset = parser->newline_list.offsets[index];
-            size_t length = index == parser->newline_list.size - 1 ? (parser->end - (parser->start + offset)) : (parser->newline_list.offsets[index + 1] - offset);
+            size_t length = index == parser->newline_list.size - 1 ?
+                (size_t)(parser->end - (parser->start + offset)) : (parser->newline_list.offsets[index + 1] - offset);
             rb_ary_push(*script_lines, rb_enc_str_new((const char *) parser->start + offset, length, scope_node->encoding));
         }
 


### PR DESCRIPTION
```
prism_compile.c: In function 'pm_parse_process':
prism_compile.c:10408:70: warning: operand of '?:' changes signedness from 'long long int' to 'size_t' {aka 'long long unsigned int'} due to unsignedness of other operand [-Wsign-compare]
10408 |             size_t length = index == parser->newline_list.size - 1 ? (parser->end - (parser->start + offset)) : (parser->newline_list.offsets[index + 1] - offset);
      |                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```