### PR TITLE
Experiment: Optimize `strftime`

### DIFF
--- a/benchmark/time_strftime.yml
+++ b/benchmark/time_strftime.yml
@@ -1,0 +1,5 @@
+prelude: |
+  # frozen_string_literal: true
+  time = Time.now
+benchmark:
+  - time.strftime("%FT%T.%6N")

--- a/benchmark/time_strftime.yml
+++ b/benchmark/time_strftime.yml
@@ -2,4 +2,6 @@ prelude: |
   # frozen_string_literal: true
   time = Time.now
 benchmark:
-  - time.strftime("%FT%T.%6N")
+  - time.strftime("%FT%T")     # 19B
+  - time.strftime("%FT%T.%3N") # 23B
+  - time.strftime("%FT%T.%6N") # 26B

--- a/internal/string.h
+++ b/internal/string.h
@@ -51,6 +51,7 @@ int rb_enc_str_coderange_scan(VALUE str, rb_encoding *enc);
 int rb_ascii8bit_appendable_encoding_index(rb_encoding *enc, unsigned int code);
 VALUE rb_str_include(VALUE str, VALUE arg);
 VALUE rb_str_byte_substr(VALUE str, VALUE beg, VALUE len);
+long rb_str_ensure_capa_for(VALUE str, long len);
 
 static inline bool STR_EMBED_P(VALUE str);
 static inline bool STR_SHARED_P(VALUE str);

--- a/internal/string.h
+++ b/internal/string.h
@@ -52,6 +52,7 @@ int rb_ascii8bit_appendable_encoding_index(rb_encoding *enc, unsigned int code);
 VALUE rb_str_include(VALUE str, VALUE arg);
 VALUE rb_str_byte_substr(VALUE str, VALUE beg, VALUE len);
 long rb_str_ensure_capa_for(VALUE str, long len);
+void rb_str_raw_set_len(VALUE str, long len);
 
 static inline bool STR_EMBED_P(VALUE str);
 static inline bool STR_SHARED_P(VALUE str);

--- a/strftime.c
+++ b/strftime.c
@@ -177,7 +177,7 @@ resize_buffer(VALUE ftime, char *s, const char **start, const char **endp,
 		return 0;
 	}
 
-	rb_str_set_len(ftime, len);
+	rb_str_raw_set_len(ftime, len);
     long capa = rb_str_ensure_capa_for(ftime, n);
 	s = RSTRING_PTR(ftime);
 	*endp = s + capa;
@@ -312,7 +312,7 @@ rb_strftime_with_timespec(VALUE ftime, const char *format, size_t format_len,
 			precision = FMT_PRECISION(def_prec); \
 			len = s - start; \
 			NEEDS(precision); \
-			rb_str_set_len(ftime, len); \
+			rb_str_raw_set_len(ftime, len); \
 			rb_str_catf(ftime, FMT_PADDING(fmt, def_pad), \
 				    precision, (val)); \
 			RSTRING_GETMEM(ftime, s, len); \
@@ -322,7 +322,7 @@ rb_strftime_with_timespec(VALUE ftime, const char *format, size_t format_len,
 #define STRFTIME(fmt) \
 		do { \
 			len = s - start; \
-			rb_str_set_len(ftime, len); \
+			rb_str_raw_set_len(ftime, len); \
 			if (!rb_strftime_with_timespec(ftime, (fmt), rb_strlen_lit(fmt), \
 						       enc, time, vtm, timev, ts, gmt, maxsize)) \
 				return 0; \
@@ -356,7 +356,7 @@ rb_strftime_with_timespec(VALUE ftime, const char *format, size_t format_len,
 				tmp = format_value(tmp, base); \
 				i = RSTRING_LEN(tmp); \
 				FILL_PADDING(i); \
-				rb_str_set_len(ftime, s-start); \
+				rb_str_raw_set_len(ftime, s-start); \
 				rb_str_append(ftime, tmp); \
 				RSTRING_GETMEM(ftime, s, len); \
 				endp = (start = s) + rb_str_capacity(ftime); \
@@ -909,7 +909,7 @@ rb_strftime_with_timespec(VALUE ftime, const char *format, size_t format_len,
 		return 0;
 	}
 	len = s - start;
-	rb_str_set_len(ftime, len);
+	rb_str_raw_set_len(ftime, len);
 	rb_str_resize(ftime, len);
 	return ftime;
 

--- a/strftime.c
+++ b/strftime.c
@@ -172,18 +172,15 @@ resize_buffer(VALUE ftime, char *s, const char **start, const char **endp,
 {
 	size_t len = s - *start;
 	size_t nlen = len + n * 2;
-	size_t capa = rb_str_capacity(ftime);
-	if (nlen < capa * 2) {
-	    nlen = capa * 2;
-	}
 
 	if (nlen < len || nlen > maxsize) {
 		return 0;
 	}
+
 	rb_str_set_len(ftime, len);
-	rb_str_modify_expand(ftime, nlen-len);
+    long capa = rb_str_ensure_capa_for(ftime, n);
 	s = RSTRING_PTR(ftime);
-	*endp = s + nlen;
+	*endp = s + capa;
 	*start = s;
 	return s += len;
 }

--- a/strftime.c
+++ b/strftime.c
@@ -172,6 +172,10 @@ resize_buffer(VALUE ftime, char *s, const char **start, const char **endp,
 {
 	size_t len = s - *start;
 	size_t nlen = len + n * 2;
+	size_t capa = rb_str_capacity(ftime);
+	if (nlen < capa * 2) {
+	    nlen = capa * 2;
+	}
 
 	if (nlen < len || nlen > maxsize) {
 		return 0;

--- a/string.c
+++ b/string.c
@@ -3194,6 +3194,18 @@ rb_str_locktmp_ensure(VALUE str, VALUE (*func)(VALUE), VALUE arg)
 }
 
 void
+rb_str_raw_set_len(VALUE str, long len)
+{
+    const int termlen = TERM_LEN(str);
+
+    RUBY_ASSERT(!STR_SHARED_P(str));
+    RUBY_ASSERT(!(len > (long)str_capacity(str, termlen) || len < 0), "probable buffer overflow");
+    STR_SET_LEN(str, len);
+    TERM_FILL(&RSTRING_PTR(str)[len], termlen);
+    ENC_CODERANGE_CLEAR(str);
+}
+
+void
 rb_str_set_len(VALUE str, long len)
 {
     long capa;


### PR DESCRIPTION
`Time#strftime` is a hotspot for applications that do a lot of JSON serialization, typical API endpoint etc. They generally contains quite a bit of dates and `Time#iso8601` and its variant are just a `strftime` call. 

![image](https://github.com/user-attachments/assets/79a4dd11-6f9a-401b-a55c-5f27ea55efde)


![image](https://github.com/user-attachments/assets/b400c1df-0f5b-4a62-9a80-b6f69cb6c6c1)


Looking at profiles, I found a few ideas, e.g. the logic to grow the string capacity seem to try to minimize the final string capacity, by using a more agressive growing strategy we can make the method roughtly 20% faster.

Then it calls a lot into `rb_str_set_len` after having written past the string terminator. That function does a lot of checks, so by using a simplified function we can optimize a bit further.

But then I can't really see a path to really get more:

```
compare-ruby: ruby 3.4.0dev (2024-08-29T13:11:40Z master 6b08a50a62) +YJIT [arm64-darwin23]
built-ruby: ruby 3.4.0dev (2024-08-30T08:52:31Z opt-strftime 32bfb1cb7f) +YJIT [arm64-darwin23]
warming up...
# Iteration per second (i/s)

|                            |compare-ruby|built-ruby|
|:---------------------------|-----------:|---------:|
|time.strftime("%FT%T")      |      1.757M|    2.165M|
|                            |           -|     1.23x|
|time.strftime("%FT%T.%3N")  |      1.529M|    2.007M|
|                            |           -|     1.31x|
|time.strftime("%FT%T.%6N")  |      1.471M|    2.004M|
|                            |           -|     1.36x|
```

Now most of the time is in `ruby_vfprintf`, which perhaps could be improved too as it repeatedly check if the string is modifiable and have enough capacity, but it's becoming hairy:

<img width="891" alt="Capture d’écran 2024-08-30 à 11 16 12" src="https://github.com/user-attachments/assets/32b81567-8ac5-4307-aba6-1ac3b06a1e7b">

<img width="1080" alt="Capture d’écran 2024-08-30 à 11 17 44" src="https://github.com/user-attachments/assets/9da654b0-1640-4764-b1f8-2c3aaabdf905">

I think one avenue could be to open a feature request to make `xmlschema/iso8601` a core method, which would allow to implement it without using any `printf` like implementation, which would allow to know upfront the necessary string size.

I'm tempted to experiment with a gem that does a native implementation of `iso8601`, so see that the upper performance cap is like. 

FYI @ianks 