### PR TITLE
Allow Errno::EACCES when testing connection timeout

### DIFF
--- a/test/socket/test_tcp.rb
+++ b/test/socket/test_tcp.rb
@@ -70,7 +70,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_connect_timeout
-    assert_raise(IO::TimeoutError, Errno::ENETUNREACH) do
+    assert_raise(IO::TimeoutError, Errno::ENETUNREACH, Errno::EACCES) do
       TCPSocket.new("192.0.2.1", 80, connect_timeout: 0)
     end
   end


### PR DESCRIPTION
Some packaging systems that include support for running tests, such as OpenBSD's, do not allow outbound network connections during testing for security reasons. EACCES is the error raised by OpenBSD in this case.