### PR TITLE
Ignore blocks to `Test::Unit::Assertions#pend` silently

### DIFF
--- a/tool/lib/test/unit/assertions.rb
+++ b/tool/lib/test/unit/assertions.rb
@@ -522,7 +522,7 @@ module Test
       # Skips the current test. Gets listed at the end of the run but
       # doesn't cause a failure exit code.
 
-      def pend msg = nil, bt = caller
+      def pend msg = nil, bt = caller, &_
         msg ||= "Skipped, no message given"
         @skip = true
         raise Test::Unit::PendedError, msg, bt


### PR DESCRIPTION
Although `pend` in test-unit gem expects the block does not pass if it is given, our `pend` should ignore the block silently as same as it just skips the test with no message by default.
Add an unused parameter, to suppress the warning for the block to be ignored.