### PR TITLE
Time#strftime: grow the buffer faster

### DIFF
--- a/benchmark/time_strftime.yml
+++ b/benchmark/time_strftime.yml
@@ -1,0 +1,7 @@
+prelude: |
+  # frozen_string_literal: true
+  time = Time.now
+benchmark:
+  - time.strftime("%FT%T")     # 19B
+  - time.strftime("%FT%T.%3N") # 23B
+  - time.strftime("%FT%T.%6N") # 26B

--- a/strftime.c
+++ b/strftime.c
@@ -171,7 +171,9 @@ resize_buffer(VALUE ftime, char *s, const char **start, const char **endp,
 	      ptrdiff_t n, size_t maxsize)
 {
 	size_t len = s - *start;
-	size_t nlen = len + n * 2;
+	size_t need = len + n * 2;
+	size_t nlen = rb_str_capacity(ftime);
+	while (nlen < need) nlen <<= 1;
 
 	if (nlen < len || nlen > maxsize) {
 		return 0;


### PR DESCRIPTION
Use a classic doubling of capacity rather than only adding twice as much capacity as is already known to be needed.

```
compare-ruby: ruby 3.4.0dev (2024-09-04T09:21:53Z opt-strftime-2 ae98d19cf9) +YJIT [arm64-darwin23]
built-ruby: ruby 3.4.0dev (2024-09-04T11:46:02Z opt-strftime-growth 586263d6fb) +YJIT [arm64-darwin23]
warming up...
# Iteration per second (i/s)

|                            |compare-ruby|built-ruby|
|:---------------------------|-----------:|---------:|
|time.strftime("%FT%T")      |      1.754M|    1.889M|
|                            |           -|     1.08x|
|time.strftime("%FT%T.%3N")  |      1.508M|    1.749M|
|                            |           -|     1.16x|
|time.strftime("%FT%T.%6N")  |      1.488M|    1.756M|
|                            |           -|     1.18x|
```