### PR TITLE
[Bug #20714] Handle optional dependencies for `bundled_gems.rb`

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -126,6 +126,11 @@ module Gem::BUNDLED_GEMS
   end
 
   def self.warning?(name, specs: nil)
+    # If a dependency is loaded with $VERBOSE set to nil, let the next require
+    # warn instead to handle optional dependencies. Example:
+    # https://github.com/ruby/reline/blob/v0.5.9/lib/reline/terminfo.rb#L1-L15
+    return false if $VERBOSE == nil
+
     # name can be a feature name or a file path with String or Pathname
     feature = File.path(name)
 

--- a/tool/test_for_warn_bundled_gems/test.sh
+++ b/tool/test_for_warn_bundled_gems/test.sh
@@ -28,6 +28,10 @@ echo "* Show warning when bundle exec with -r option"
 bundle exec ruby -rostruct -e ''
 echo
 
+echo "* Show warning after require with \$VERBOSE = nil for optional dependencies"
+bundle exec ruby test_warn_bundle_exec_optional_dependency.rb
+echo
+
 echo "* Show warning with bootsnap"
 ruby test_warn_bootsnap.rb
 echo

--- a/tool/test_for_warn_bundled_gems/test_warn_bundle_exec_optional_dependency.rb
+++ b/tool/test_for_warn_bundled_gems/test_warn_bundle_exec_optional_dependency.rb
@@ -1,0 +1,9 @@
+begin
+  verbose, $VERBOSE = $VERBOSE, nil
+  require "base64"
+rescue LoadError
+ensure
+  $VERBOSE = verbose
+end
+
+require "base64"


### PR DESCRIPTION
[[Bug #20714]](https://bugs.ruby-lang.org/issues/20714)

Imagine the the second `require 'base64'` originates from a different gem. This should still warn, the library that does `$VERBOSE = nil` before the require is already prepared.

With this patch, the following will be printed where previously there was no output at all:
```
test_warn_bundle_exec_optional_dependency.rb:9: warning: base64 was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add base64 to your Gemfile or gemspec to silence this warning.
```