### PR TITLE
[ruby/reline] Fix redisplay/insert_text called from pre_input_hook (backport)

### DIFF
--- a/lib/reline.rb
+++ b/lib/reline.rb
@@ -335,7 +335,11 @@ module Reline
       line_editor.prompt_proc = prompt_proc
       line_editor.auto_indent_proc = auto_indent_proc
       line_editor.dig_perfect_match_proc = dig_perfect_match_proc
+
+      # Readline calls pre_input_hook just after printing the first prompt.
+      line_editor.print_nomultiline_prompt
       pre_input_hook&.call
+
       unless Reline::IOGate == Reline::GeneralIO
         @dialog_proc_list.each_pair do |name_sym, d|
           line_editor.add_dialog_proc(name_sym, d.dialog_proc, d.context)
@@ -354,7 +358,7 @@ module Reline
             inputs.each do |key|
               if key.char == :bracketed_paste_start
                 text = io_gate.read_bracketed_paste
-                line_editor.insert_pasted_text(text)
+                line_editor.insert_multiline_text(text)
                 line_editor.scroll_into_view
               else
                 line_editor.update(key)
@@ -521,8 +525,8 @@ module Reline
   def_single_delegator :line_editor, :byte_pointer, :point
   def_single_delegator :line_editor, :byte_pointer=, :point=
 
-  def self.insert_text(*args, &block)
-    line_editor.insert_text(*args, &block)
+  def self.insert_text(text)
+    line_editor.insert_multiline_text(text)
     self
   end
 

--- a/lib/reline/line_editor.rb
+++ b/lib/reline/line_editor.rb
@@ -1343,7 +1343,7 @@ class Reline::LineEditor
     @confirm_multiline_termination_proc.(temp_buffer.join("\n") + "\n")
   end
 
-  def insert_pasted_text(text)
+  def insert_multiline_text(text)
     save_old_buffer
     pre = @buffer_of_lines[@line_index].byteslice(0, @byte_pointer)
     post = @buffer_of_lines[@line_index].byteslice(@byte_pointer..)

--- a/test/reline/yamatanooroti/test_rendering.rb
+++ b/test/reline/yamatanooroti/test_rendering.rb
@@ -1795,6 +1795,40 @@ begin
       EOC
     end
 
+    def test_pre_input_hook_with_redisplay
+      code = <<~'RUBY'
+        puts 'Multiline REPL.'
+        Reline.pre_input_hook = -> do
+          Reline.insert_text 'abc'
+          Reline.redisplay # Reline doesn't need this but Readline requires calling redisplay
+        end
+        Reline.readline('prompt> ')
+      RUBY
+      start_terminal(6, 30, ['ruby', "-I#{@pwd}/lib", '-rreline', '-e', code], startup_message: 'Multiline REPL.')
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        prompt> abc
+      EOC
+    end
+
+    def test_pre_input_hook_with_multiline_text_insert
+      # Frequently used pattern of pre_input_hook
+      code = <<~'RUBY'
+        puts 'Multiline REPL.'
+        Reline.pre_input_hook = -> do
+          Reline.insert_text "abc\nef"
+        end
+        Reline.readline('>')
+      RUBY
+      start_terminal(6, 30, ['ruby', "-I#{@pwd}/lib", '-rreline', '-e', code], startup_message: 'Multiline REPL.')
+      write("\C-ad")
+      assert_screen(<<~EOC)
+        Multiline REPL.
+        >abc
+        def
+      EOC
+    end
+
     def test_thread_safe
       start_terminal(6, 30, %W{ruby -I#{@pwd}/lib #{@pwd}/test/reline/yamatanooroti/multiline_repl --auto-indent}, startup_message: 'Multiline REPL.')
       write("[Thread.new{Reline.readline'>'},Thread.new{Reline.readmultiline('>'){true}}].map(&:join).size\n")


### PR DESCRIPTION
@tompng was kind enough to fix [a bug](https://bugs.ruby-lang.org/issues/20711) in master.
in hope of reducing work for the maintainers, i'm submitting his patch for the 3.3 branch, which is also affected.

commit description:

(https://github.com/ruby/reline/pull/742)

* Fix redisplay/insert_text called from pre_input_hook

* Rename insert_pasted_text to insert_multiline_text

It is now used from Reline.insert_text which is not inserting pasted text

https://github.com/ruby/reline/commit/694a540939