### PR TITLE
Fix issue in compile.c with a short-circuit if/unless `defined?` condition

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3307,7 +3307,7 @@ pm_scope_node_destroy(pm_scope_node_t *scope_node)
  * Normally, "send" instruction is at the last. However, qcall under branch
  * coverage measurement adds some instructions after the "send".
  *
- * Note that "invokesuper" appears instead of "send".
+ * Note that "invokesuper", "invokesuperforward" appears instead of "send".
  */
 static void
 pm_compile_retry_end_label(rb_iseq_t *iseq, LINK_ANCHOR *const ret, LABEL *retry_end_l)
@@ -8151,8 +8151,9 @@ pm_compile_super_node(rb_iseq_t *iseq, const pm_super_node_t *node, const pm_nod
             PUSH_INSN2(ret, *location, invokesuper, callinfo, current_block);
         }
 
-        pm_compile_retry_end_label(iseq, ret, retry_end_l);
     }
+
+    pm_compile_retry_end_label(iseq, ret, retry_end_l);
 
     if (popped) PUSH_INSN(ret, *location, pop);
     ISEQ_COMPILE_DATA(iseq)->current_block = previous_block;

--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -165,6 +165,11 @@ module EnvUtil
     }
 
     args = [args] if args.kind_of?(String)
+    # use the same parser as current ruby
+    if args.none? { |arg| arg.start_with?("--parser=") }
+      current_parser = RUBY_DESCRIPTION =~ /prism/i ? "prism" : "parse.y"
+      args = ["--parser=#{current_parser}"] + args
+    end
     pid = spawn(child_env, *precommand, rubybin, *args, opt)
     in_c.close
     out_c&.close


### PR DESCRIPTION
This caused an issue when `defined?` was in the `if` condition. Its instructions weren't appended to the instruction sequence even though it was compiled if a known logical short-circuit happened before the `defined?`. The catch table (`defined?` compilation produces a catch table) was still on the iseq even though the instructions weren't there. This caused faulty exception handling in the method. The solution is to no longer add the catch table entry when compiling `defined?` in this case.

This shouldn't touch much code, it's only for cases like the following, which can occur during debugging:

  if false && defined?(Some::CONSTANT)
    "more code..."
  end