### PR TITLE
Accept floating point number strings without digit in fractional part

### DIFF
--- a/missing/dtoa.c
+++ b/missing/dtoa.c
@@ -1647,8 +1647,12 @@ break2:
     }
 #endif
     if (c == '.') {
-        if (!ISDIGIT(s[1]))
+        if (!ISDIGIT(s[1])) {
+            if (s[1] == 'e' || s[1] == 'E' || s[1] == '\0') {
+                c = *++s;
+            }
             goto dig_done;
+        }
         c = *++s;
         if (!nd) {
             for (; c == '0'; c = *++s)

--- a/spec/ruby/core/string/modulo_spec.rb
+++ b/spec/ruby/core/string/modulo_spec.rb
@@ -758,7 +758,6 @@ describe "String#%" do
       -> { format % "" }.should raise_error(ArgumentError)
       -> { format % "x" }.should raise_error(ArgumentError)
       -> { format % "." }.should raise_error(ArgumentError)
-      -> { format % "10." }.should raise_error(ArgumentError)
       -> { format % "5x" }.should raise_error(ArgumentError)
       -> { format % "0b1" }.should raise_error(ArgumentError)
       -> { format % "10e10.5" }.should raise_error(ArgumentError)
@@ -769,6 +768,19 @@ describe "String#%" do
       obj.should_receive(:to_f).and_return(5.0)
       (format % obj).should == (format % 5.0)
     end
+
+    ruby_version_is ""..."3.4" do
+      it "behaves as if calling Kernel#Float for #{format} arguments, when the passed argument does not respond to #to_ary and no fractional part floating point string" do
+        -> { format % "10." }.should raise_error(ArgumentError)
+      end
+    end
+
+    ruby_version_is "3.4" do
+      it "behaves as if calling Kernel#Float for #{format} arguments, when the passed argument does not respond to #to_ary and no fractional part floating point string" do
+        (format % "10.").should == (format % 10.0)
+      end
+    end
+
 
     it "behaves as if calling Kernel#Float for #{format} arguments, when the passed argument is hexadecimal string" do
       (format % "0xA").should == (format % 0xA)

--- a/test/ruby/test_float.rb
+++ b/test/ruby/test_float.rb
@@ -129,9 +129,16 @@ class TestFloat < Test::Unit::TestCase
     assert_in_delta(a, 0, Float::EPSILON)
     a = Float("-.0")
     assert_in_delta(a, 0, Float::EPSILON)
-    assert_raise(ArgumentError){Float("0.")}
-    assert_raise(ArgumentError){Float("+0.")}
-    assert_raise(ArgumentError){Float("-0.")}
+    a = Float("0.")
+    assert_in_delta(a, 0, Float::EPSILON)
+    a = Float("+0.")
+    assert_in_delta(a, 0, Float::EPSILON)
+    a = Float("-0.")
+    assert_in_delta(a, 0, Float::EPSILON)
+    a = Float("1.")
+    assert_in_delta(a, 1, Float::EPSILON)
+    a = Float("1.e+00")
+    assert_in_delta(a, 1, Float::EPSILON)
     assert_raise(ArgumentError){Float(".")}
     assert_raise(ArgumentError){Float("+")}
     assert_raise(ArgumentError){Float("+.")}
@@ -139,8 +146,6 @@ class TestFloat < Test::Unit::TestCase
     assert_raise(ArgumentError){Float("-.")}
     assert_raise(ArgumentError){Float("1e")}
     assert_raise(ArgumentError){Float("1__1")}
-    assert_raise(ArgumentError){Float("1.")}
-    assert_raise(ArgumentError){Float("1.e+00")}
     assert_raise(ArgumentError){Float("0x.1")}
     assert_raise(ArgumentError){Float("0x1.")}
     assert_raise(ArgumentError){Float("0x1.0")}


### PR DESCRIPTION
[Feature #20705]

String#to_f accepts "0." but didn't accept "0.E-9".

Kernel.#Float didn't accept both of "0." and "0.E-9".

Other systems such as Python, Node.js, PostgreSQL and MySQL accept "0." and "0.E-9" as valid floating point number strings. So Ruby also accepts them.