### PR TITLE
[Feature #20707] Fix negative UTC offset conversion

### DIFF
--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -1490,6 +1490,9 @@ class TestTime < Test::Unit::TestCase
         assert_equal("1960-12-31T23:00:00.123456Z", t.__send__(method, 6))
       end
 
+      t = get_t2000.getlocal("-09:30") # Pacific/Marquesas
+      assert_equal("1999-12-31T14:30:00-09:30", t.__send__(method))
+
       assert_equal("10000-01-01T00:00:00Z", Time.utc(10000).__send__(method))
       assert_equal("9999-01-01T00:00:00Z", Time.utc(9999).__send__(method))
       assert_equal("0001-01-01T00:00:00Z", Time.utc(1).__send__(method)) # 1 AD

--- a/time.c
+++ b/time.c
@@ -5285,13 +5285,15 @@ time_xmlschema(int argc, VALUE *argv, VALUE time)
     }
     else {
         long offset = NUM2LONG(rb_time_utc_offset(time));
+        *ptr++ = offset < 0 ? '-' : '+';
+        if (offset < 0) offset = -offset;
         int offset_hours = (int)(offset / 3600);
-        int offset_minutes = (int)((offset % 3600 / 60));
-        written = snprintf(ptr, sizeof("+ZH:ZM"), "%+03d:%02d", offset_hours, offset_minutes);
-        RUBY_ASSERT(written == sizeof("+ZH:ZM") - 1);
+        int offset_minutes = (int)(offset % 3600 / 60);
+        written = snprintf(ptr, sizeof("ZH:ZM"), "%02d:%02d", offset_hours, offset_minutes);
+        RUBY_ASSERT(written == sizeof("ZH:ZM") - 1, "%d[%.*s]", written, written, ptr);
         ptr += written;
     }
-    rb_str_set_len(str, ptr -start); // We could skip coderange scanning as we know it's full ASCII.
+    rb_str_set_len(str, ptr - start); // We could skip coderange scanning as we know it's full ASCII.
     return str;
 }
 


### PR DESCRIPTION
Negative UTC offset is obviously weird.

```ruby
Time.new(2000, 1,1, in:"utc").getlocal("-09:30").xmlschema #=> "1999-12-31T14:30:00-09:-3\u0000"
```

In short, get rid of division and modulo of negative integers.
