### PR TITLE
[Bug #20719] Float argument must be ASCII compatible

### DIFF
--- a/object.c
+++ b/object.c
@@ -3400,7 +3400,7 @@ rb_f_integer(rb_execution_context_t *ec, VALUE obj, VALUE arg, VALUE base, VALUE
 }
 
 static double
-rb_cstr_to_dbl_raise(const char *p, int badcheck, int raise, int *error)
+rb_cstr_to_dbl_raise(const char *p, rb_encoding *enc, int badcheck, int raise, int *error)
 {
     const char *q;
     char *end;
@@ -3411,6 +3411,7 @@ rb_cstr_to_dbl_raise(const char *p, int badcheck, int raise, int *error)
 #define OutOfRange() ((end - p > max_width) ? \
                       (w = max_width, ellipsis = "...") : \
                       (w = (int)(end - p), ellipsis = ""))
+    /* p...end has been parsed with strtod, should be ASCII-only */
 
     if (!p) return 0.0;
     q = p;
@@ -3506,7 +3507,8 @@ rb_cstr_to_dbl_raise(const char *p, int badcheck, int raise, int *error)
 
   bad:
     if (raise) {
-        rb_invalid_str(q, "Float()");
+        VALUE s = rb_enc_str_new_cstr(q, enc);
+        rb_raise(rb_eArgError, "invalid value for Float(): %+"PRIsVALUE, s);
         UNREACHABLE_RETURN(nan(""));
     }
     else {
@@ -3518,7 +3520,7 @@ rb_cstr_to_dbl_raise(const char *p, int badcheck, int raise, int *error)
 double
 rb_cstr_to_dbl(const char *p, int badcheck)
 {
-    return rb_cstr_to_dbl_raise(p, badcheck, TRUE, NULL);
+    return rb_cstr_to_dbl_raise(p, NULL, badcheck, TRUE, NULL);
 }
 
 static double
@@ -3549,9 +3551,11 @@ rb_str_to_dbl_raise(VALUE str, int badcheck, int raise, int *error)
             s = p;
         }
     }
-    ret = rb_cstr_to_dbl_raise(s, badcheck, raise, error);
+    ret = rb_cstr_to_dbl_raise(s, rb_enc_get(str), badcheck, raise, error);
     if (v)
         ALLOCV_END(v);
+    else
+        RB_GC_GUARD(str);
     return ret;
 }
 

--- a/object.c
+++ b/object.c
@@ -3530,6 +3530,7 @@ rb_str_to_dbl_raise(VALUE str, int badcheck, int raise, int *error)
     VALUE v = 0;
 
     StringValue(str);
+    rb_must_asciicompat(str);
     s = RSTRING_PTR(str);
     len = RSTRING_LEN(str);
     if (s) {

--- a/test/ruby/test_float.rb
+++ b/test/ruby/test_float.rb
@@ -850,6 +850,12 @@ class TestFloat < Test::Unit::TestCase
     o = Object.new
     def o.to_f; inf = Float::INFINITY; inf/inf; end
     assert_predicate(Float(o), :nan?)
+
+    assert_raise(Encoding::CompatibilityError) {Float("0".encode("utf-16be"))}
+    assert_raise(Encoding::CompatibilityError) {Float("0".encode("utf-16le"))}
+    assert_raise(Encoding::CompatibilityError) {Float("0".encode("utf-32be"))}
+    assert_raise(Encoding::CompatibilityError) {Float("0".encode("utf-32le"))}
+    assert_raise(Encoding::CompatibilityError) {Float("0".encode("iso-2022-jp"))}
   end
 
   def test_invalid_str

--- a/test/ruby/test_float.rb
+++ b/test/ruby/test_float.rb
@@ -856,6 +856,8 @@ class TestFloat < Test::Unit::TestCase
     assert_raise(Encoding::CompatibilityError) {Float("0".encode("utf-32be"))}
     assert_raise(Encoding::CompatibilityError) {Float("0".encode("utf-32le"))}
     assert_raise(Encoding::CompatibilityError) {Float("0".encode("iso-2022-jp"))}
+
+    assert_raise_with_message(ArgumentError, /\u{1f4a1}/) {Float("\u{1f4a1}")}
   end
 
   def test_invalid_str


### PR DESCRIPTION
Also preserve encoding in exception message.