### PR TITLE
Use rb_id_table_foreach_values for marking CC table

### DIFF
--- a/imemo.c
+++ b/imemo.c
@@ -179,11 +179,17 @@ rb_imemo_memsize(VALUE obj)
  * ========================================================================= */
 
 static enum rb_id_table_iterator_result
-cc_table_mark_i(ID id, VALUE ccs_ptr, void *data)
+cc_table_mark_i(VALUE ccs_ptr, void *data)
 {
     struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_ptr;
     VM_ASSERT(vm_ccs_p(ccs));
-    VM_ASSERT(id == ccs->cme->called_id);
+#if VM_CHECK_MODE > 0
+    VALUE klass = (VALUE)data;
+
+    VALUE lookup_val;
+    VM_ASSERT(rb_id_table_lookup(RCLASS_CC_TBL(klass), ccs->cme->called_id, &lookup_val));
+    VM_ASSERT(lookup_val == ccs_ptr);
+#endif
 
     if (METHOD_ENTRY_INVALIDATED(ccs->cme)) {
         rb_vm_ccs_free(ccs);
@@ -193,7 +199,7 @@ cc_table_mark_i(ID id, VALUE ccs_ptr, void *data)
         rb_gc_mark_movable((VALUE)ccs->cme);
 
         for (int i=0; i<ccs->len; i++) {
-            VM_ASSERT((VALUE)data == ccs->entries[i].cc->klass);
+            VM_ASSERT(klass == ccs->entries[i].cc->klass);
             VM_ASSERT(vm_cc_check_cme(ccs->entries[i].cc, ccs->cme));
 
             rb_gc_mark_movable((VALUE)ccs->entries[i].cc);
@@ -207,7 +213,7 @@ rb_cc_table_mark(VALUE klass)
 {
     struct rb_id_table *cc_tbl = RCLASS_CC_TBL(klass);
     if (cc_tbl) {
-        rb_id_table_foreach(cc_tbl, cc_table_mark_i, (void *)klass);
+        rb_id_table_foreach_values(cc_tbl, cc_table_mark_i, (void *)klass);
     }
 }
 


### PR DESCRIPTION
We don't use the key, so we can speed it up by not needing to convert the key to ID in the iterator.