### PR TITLE
Ignore -Wdangling-pointer in rb_gc_set_stack_end

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -4527,7 +4527,12 @@ void
 rb_gc_set_stack_end(VALUE **stack_end_p)
 {
     VALUE stack_end;
+COMPILER_WARNING_PUSH
+#if __has_warning("-Wdangling-pointer")
+COMPILER_WARNING_IGNORED(-Wdangling-pointer);
+#endif
     *stack_end_p = &stack_end;
+COMPILER_WARNING_POP
 }
 #endif
 


### PR DESCRIPTION
Fixes this compiler warning:

    thread.c:4530:18: warning: storing the address of local variable ‘stack_end’ in ‘*stack_end_p’ [-Wdangling-pointer=]
    4530 |     *stack_end_p = &stack_end;
          |     ~~~~~~~~~~~~~^~~~~~~~~~~~