### PR TITLE
[Bug #20725] Should not call compare on `nil`-endpoint

### DIFF
--- a/range.c
+++ b/range.c
@@ -2477,7 +2477,7 @@ range_overlap(VALUE range, VALUE other)
         /* if both begin values are equal, no more comparisons needed */
         if (rb_cmpint(cmp, self_beg, other_beg) == 0) return Qtrue;
     }
-    else if (NIL_P(self_beg) && NIL_P(other_beg)) {
+    else if (NIL_P(self_beg) && !NIL_P(self_end) && NIL_P(other_beg)) {
         VALUE cmp = rb_funcall(self_end, id_cmp, 1, other_end);
         return RBOOL(!NIL_P(cmp));
     }

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -1471,6 +1471,7 @@ class TestRange < Test::Unit::TestCase
     assert_operator((..3), :overlap?, (3..))
     assert_operator((nil..nil), :overlap?, (3..))
     assert_operator((nil...nil), :overlap?, (nil..))
+    assert_operator((nil..nil), :overlap?, (..3))
 
     assert_raise(TypeError) { (1..3).overlap?(1) }
 


### PR DESCRIPTION
It means unbounded, always inclusive of other ranges.

[[Bug #20725]](https://bugs.ruby-lang.org/issues/20725)