### PR TITLE
[DOC] More on Array#fill

### DIFF
--- a/array.c
+++ b/array.c
@@ -4711,7 +4711,7 @@ rb_ary_clear(VALUE ary)
  *    ['a', 'b', 'c', 'd'].fill('-', 3, 2)          # => ["a", "b", "c", "-", "-"]
  *    ['a', 'b', 'c', 'd'].fill(3, 2) {|e| e.to_s } # => ["a", "b", "c", "3", "4"]
  *
- *    # Extends with nils and specified values if necessary.
+ *    # Fills with nils if necessary.
  *    ['a', 'b', 'c', 'd'].fill('-', 6, 2)          # => ["a", "b", "c", "d", nil, nil, "-", "-"]
  *    ['a', 'b', 'c', 'd'].fill(6, 2) {|e| e.to_s } # => ["a", "b", "c", "d", nil, nil, "6", "7"]
  *
@@ -4735,7 +4735,7 @@ rb_ary_clear(VALUE ary)
  *    +nil+ means "all the rest."
  *
  *  With argument +object+ given,
- *  that one object is the sole replacement value:
+ *  that one object is used for all replacements:
  *
  *    o = Object.new           # => #<Object:0x0000014e7bff7600>
  *    a = ['a', 'b', 'c', 'd'] # => ["a", "b", "c", "d"]
@@ -4745,7 +4745,7 @@ rb_ary_clear(VALUE ary)
  *  With a block given, the block is called once for each element to be replaced;
  *  the value passed to the block is the _index_ of the element to be replaced
  *  (not the element itself);
- *  the block's return value is the element's replacement:
+ *  the block's return value replaces the element:
  *
  *    a = ['a', 'b', 'c', 'd']               # => ["a", "b", "c", "d"]
  *    a.fill(1, 2) {|element| element.to_s } # => ["a", "1", "2", "d"]
@@ -4753,7 +4753,7 @@ rb_ary_clear(VALUE ary)
  *  For arguments +start+ and +count+:
  *
  *  - If +start+ is non-negative,
- *    replaces +count+ elements from offset +start+ through the end:
+ *    replaces +count+ elements beginning at offset +start+:
  *
  *      ['a', 'b', 'c', 'd'].fill('-', 0, 2) # => ["-", "-", "c", "d"]
  *      ['a', 'b', 'c', 'd'].fill('-', 1, 2) # => ["a", "-", "-", "d"]
@@ -4832,7 +4832,7 @@ rb_ary_clear(VALUE ary)
  *      ['a', 'b', 'c', 'd'].fill('-', 1..2)          # => ["a", "-", "-", "d"]
  *      ['a', 'b', 'c', 'd'].fill(1..2) {|e| e.to_s } # => ["a", "1", "2", "d"]
  *
- *    If +end+ is smaller than +begin+, no elements are replaced:
+ *    If +end+ is smaller than +begin+, replaces no elements:
  *
  *      ['a', 'b', 'c', 'd'].fill('-', 2..1)          # => ["a", "b", "c", "d"]
  *      ['a', 'b', 'c', 'd'].fill(2..1) {|e| e.to_s } # => ["a", "b", "c", "d"]
@@ -4849,8 +4849,11 @@ rb_ary_clear(VALUE ary)
  *
  *  - If the +end+ value is excluded (see Range#exclude_end?), omits the last replacement:
  *
- *      ['a', 'b', 'c', 'd'].fill('-', 1...2)          # => ["a", "-", "c", "d"]
- *      ['a', 'b', 'c', 'd'].fill(1...2) {|e| e.to_s } # => ["a", "1", "c", "d"]
+ *      ['a', 'b', 'c', 'd'].fill('-', 1...2)  # => ["a", "-", "c", "d"]
+ *      ['a', 'b', 'c', 'd'].fill('-', 1...-2) # => ["a", "-", "c", "d"]
+ *
+ *      ['a', 'b', 'c', 'd'].fill(1...2) {|e| e.to_s }  # => ["a", "1", "c", "d"]
+ *      ['a', 'b', 'c', 'd'].fill(1...-2) {|e| e.to_s } # => ["a", "1", "c", "d"]
  *
  *  - If the range is endless (see {Endless Ranges}[rdoc-ref:Range@Endless+Ranges]),
  *    replaces elements to the end of +self+:

--- a/array.c
+++ b/array.c
@@ -4692,198 +4692,199 @@ rb_ary_clear(VALUE ary)
 
 /*
  *  call-seq:
- *    array.fill(obj) -> self
- *    array.fill(obj, start) -> self
- *    array.fill(obj, start, length) -> self
- *    array.fill(obj, range) -> self
- *    array.fill {|index| ... } -> self
- *    array.fill(start) {|index| ... } -> self
- *    array.fill(start, length) {|index| ... } -> self
- *    array.fill(range) {|index| ... } -> self
+ *    fill(object) -> self
+ *    fill(object, start) -> self
+ *    fill(object, start, length) -> self
+ *    fill(object, range) -> self
+ *    fill {|index| ... } -> self
+ *    fill(start) {|index| ... } -> self
+ *    fill(start, length) {|index| ... } -> self
+ *    fill(range) {|index| ... } -> self
  *
  *  Replaces specified elements in +self+ with specified objects; returns +self+.
  *
- *  With argument +obj+ and no block given, replaces all elements with that one object:
+ *  Note: many examples here initialize arrays using a Range of characters:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a # => ["a", "b", "c", "d"]
- *    a.fill(:X) # => [:X, :X, :X, :X]
+ *    a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
  *
- *  With arguments +obj+ and Integer +start+, and no block given,
- *  replaces elements based on the given start.
+ *  <b>With No Block Given</b>
  *
- *  If +start+ is in range (<tt>0 <= start < array.size</tt>),
- *  replaces all elements from offset +start+ through the end:
+ *  With no block given, argument +object+ is required,
+ *  and its value may be any object.
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, 2) # => ["a", "b", :X, :X]
+ *  With the single argument +object+, replaces all elements with that one object:
  *
- *  If +start+ is too large (<tt>start >= array.size</tt>), does nothing:
+ *    a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *    a.fill('-')         # => ["-", "-", "-", "-"]
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, 4) # => ["a", "b", "c", "d"]
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, 5) # => ["a", "b", "c", "d"]
+ *  With argument +object+ and integer argument +start+,
+ *  replaces elements based on the given +start+:
  *
- *  If +start+ is negative, counts from the end (starting index is <tt>start + array.size</tt>):
+ *  - If +start+ is in range (<tt>0 <= start < array.size</tt>),
+ *    replaces all elements from offset +start+ through the end:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, -2) # => ["a", "b", :X, :X]
+ *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *      a.fill('-', 2)      # => ["a", "b", "-", "-"]
  *
- *  If +start+ is too small (less than and far from zero), replaces all elements:
+ *   - If +start+ is too large (<tt>start >= array.size</tt>), does nothing:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, -6) # => [:X, :X, :X, :X]
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, -50) # => [:X, :X, :X, :X]
+ *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *      a.fill('-', 4)      # => ["a", "b", "c", "d"]
  *
- *  With arguments +obj+, Integer +start+, and Integer +length+, and no block given,
- *  replaces elements based on the given +start+ and +length+.
+ *  - If +start+ is negative, counts from the end (starting index is <tt>start + array.size</tt>):
  *
- *  If +start+ is in range, replaces +length+ elements beginning at offset +start+:
+ *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *      a.fill('-', -3)     # => ["a", "-", "-", "-"]
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, 1, 1) # => ["a", :X, "c", "d"]
+ *  - If +start+ is too small (less than and far from zero), replaces all elements:
  *
- *  If +start+ is negative, counts from the end:
+ *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *      a.fill('-', -9)     # => ["-", "-", "-", "-"]
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, -2, 1) # => ["a", "b", :X, "d"]
+ *  With argument +object+ and integer arguments +start+ and +length+,
+ *  replaces elements based on the given +start+ and +length+:
  *
- *  If +start+ is large (<tt>start >= array.size</tt>), extends +self+ with +nil+:
+ *  - If +start+ is in range, replaces +length+ elements beginning at offset +start+:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, 5, 0) # => ["a", "b", "c", "d", nil]
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, 5, 2) # => ["a", "b", "c", "d", nil, :X, :X]
+ *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *      a.fill('-', 1, 2)   # => ["a", "-", "-", "d"]
  *
- *  If +length+ is zero or negative, replaces no elements:
+ *  - If +start+ is negative, counts from the end:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, 1, 0) # => ["a", "b", "c", "d"]
- *    a.fill(:X, 1, -1) # => ["a", "b", "c", "d"]
+ *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *      a.fill('-', -3, 2)  # => ["a", "-", "-", "d"]
  *
- *  With arguments +obj+ and Range +range+, and no block given,
- *  replaces elements based on the given range.
+ *  - If +start+ is large (<tt>start >= array.size</tt>), extends +self+ with +nil+:
  *
- *  If the range is positive and ascending (<tt>0 < range.begin <= range.end</tt>),
- *  replaces elements from <tt>range.begin</tt> to <tt>range.end</tt>:
+ *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *      a.fill('-', 6, 2)   # => ["a", "b", "c", "d", nil, nil, "-", "-"]
+ *      # Extends even if length is zero.
+ *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *      a.fill('-', 6, 0)   # => ["a", "b", "c", "d", nil, nil]
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, (1..1)) # => ["a", :X, "c", "d"]
+ *  - If +length+ is zero or negative, replaces no elements:
  *
- *  If <tt>range.first</tt> is negative, replaces no elements:
+ *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *      a.fill('-', 2, 0)   # => ["a", "b", "c", "d"]
+ *      a.fill('-', 2, -1)  # => ["a", "b", "c", "d"]
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, (-1..1)) # => ["a", "b", "c", "d"]
+ *  With argument +object+ and Range argument +range+,
+ *  replaces elements based on the given range:
  *
- *  If <tt>range.last</tt> is negative, counts from the end:
+ *  - If the range is positive and ascending (<tt>0 < range.begin <= range.end</tt>),
+ *    replaces elements from <tt>range.begin</tt> to <tt>range.end</tt>:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, (0..-2)) # => [:X, :X, :X, "d"]
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, (1..-2)) # => ["a", :X, :X, "d"]
+ *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *      a.fill('-', (1..2)) # => ["a", "-", "-", "d"]
  *
- *  If <tt>range.last</tt> and <tt>range.last</tt> are both negative,
- *  both count from the end of the array:
+ *  - If <tt>range.first</tt> is negative, replaces no elements:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, (-1..-1)) # => ["a", "b", "c", :X]
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(:X, (-2..-2)) # => ["a", "b", :X, "d"]
+ *      a = ('a'..'d').to_a  # => ["a", "b", "c", "d"]
+ *      a.fill('-', (-1..2)) # => ["a", "b", "c", "d"]
  *
- *  With no arguments and a block given, calls the block with each index;
+ *  - If <tt>range.last</tt> is negative, counts from the end:
+ *
+ *      a = ('a'..'d').to_a  # => ["a", "b", "c", "d"]
+ *      a.fill('-', (1..-2)) # => ["a", "-", "-", "d"]
+ *
+ *  - If <tt>range.last</tt> and <tt>range.last</tt> are both negative,
+ *    both count from the end of the array:
+ *
+ *      a = ('a'..'d').to_a   # => ["a", "b", "c", "d"]
+ *      a.fill('-', (-3..-2)) # => ["a", "-", "-", "d"]
+ *
+ *  <b>With a Block Given</b>
+ *
+ *  With no argument, calls the block with each index;
  *  replaces the corresponding element with the block's return value:
  *
- *    a = ['a', 'b', 'c', 'd']
+ *    a = ('a'..'d').to_a               # => ["a", "b", "c", "d"]
  *    a.fill { |index| "new_#{index}" } # => ["new_0", "new_1", "new_2", "new_3"]
  *
- *  With argument +start+ and a block given, calls the block with each index
+ *  With integer argument +start+ given, calls the block with each index
  *  from offset +start+ to the end; replaces the corresponding element
- *  with the block's return value.
+ *  with the block's return value:
  *
- *  If start is in range (<tt>0 <= start < array.size</tt>),
- *  replaces from offset +start+ to the end:
+ *  - If start is in range (<tt>0 <= start < array.size</tt>),
+ *    replaces from offset +start+ to the end:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(1) { |index| "new_#{index}" } # => ["a", "new_1", "new_2", "new_3"]
+ *      a = ('a'..'d').to_a                  # => ["a", "b", "c", "d"]
+ *      a.fill(2) { |index| "new_#{index}" } # => ["a", "b", "new_2", "new_3"]
  *
- *  If +start+ is too large(<tt>start >= array.size</tt>), does nothing:
+ *  - If +start+ is too large(<tt>start >= array.size</tt>), does nothing:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(4) { |index| fail 'Cannot happen' } # => ["a", "b", "c", "d"]
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(4) { |index| fail 'Cannot happen' } # => ["a", "b", "c", "d"]
+ *      a = ('a'..'d').to_a                        # => ["a", "b", "c", "d"]
+ *      a.fill(4) { |index| fail 'Cannot happen' } # => ["a", "b", "c", "d"]
  *
- *  If +start+ is negative, counts from the end:
+ *  - If +start+ is negative, counts from the end:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(-2) { |index| "new_#{index}" } # => ["a", "b", "new_2", "new_3"]
+ *      a = ('a'..'d').to_a                   # => ["a", "b", "c", "d"]
+ *      a.fill(-2) { |index| "new_#{index}" } # => ["a", "b", "new_2", "new_3"]
  *
- *  If start is too small (<tt>start <= -array.size</tt>, replaces all elements:
+ *  - If start is too small (<tt>start <= - array.size</tt>, replaces all elements:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(-6) { |index| "new_#{index}" } # => ["new_0", "new_1", "new_2", "new_3"]
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(-50) { |index| "new_#{index}" } # => ["new_0", "new_1", "new_2", "new_3"]
+ *      a = ('a'..'d').to_a                   # => ["a", "b", "c", "d"]
+ *      a.fill(-4) { |index| "new_#{index}" } # => ["new_0", "new_1", "new_2", "new_3"]
  *
- *  With arguments +start+ and +length+, and a block given,
+ *  With integer arguments +start+ and +length+,
  *  calls the block for each index specified by start length;
- *  replaces the corresponding element with the block's return value.
+ *  replaces the corresponding element with the block's return value:
  *
- *  If +start+ is in range, replaces +length+ elements beginning at offset +start+:
+ *  - If +start+ is in range, replaces +length+ elements beginning at offset +start+:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(1, 1) { |index| "new_#{index}" } # => ["a", "new_1", "c", "d"]
+ *      a = ('a'..'d').to_a                     # => ["a", "b", "c", "d"]
+ *      a.fill(1, 2) { |index| "new_#{index}" } # => ["a", "new_1", "new_2", "d"]
  *
- *  If start is negative, counts from the end:
+ *  - If +start+ is negative, counts from the end:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(-2, 1) { |index| "new_#{index}" } # => ["a", "b", "new_2", "d"]
+ *      a = ('a'..'d').to_a                      # => ["a", "b", "c", "d"]
+ *      a.fill(-3, 2) { |index| "new_#{index}" } # => ["a", "new_1", "new_2", "d"]
  *
- *  If +start+ is large (<tt>start >= array.size</tt>), extends +self+ with +nil+:
+ *  - If +start+ is large (<tt>start >= array.size</tt>), extends +self+ with +nil+:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(5, 0) { |index| "new_#{index}" } # => ["a", "b", "c", "d", nil]
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(5, 2) { |index| "new_#{index}" } # => ["a", "b", "c", "d", nil, "new_5", "new_6"]
+ *      a = ('a'..'d').to_a                     # => ["a", "b", "c", "d"]
+ *      a.fill(5, 2) { |index| "new_#{index}" } # => ["a", "b", "c", "d", nil, "new_5", "new_6"]
+ *      # Extends even if length is zero.
+ *      a = ('a'..'d').to_a                     # => ["a", "b", "c", "d"]
+ *      a.fill(5, 0) { |index| "new_#{index}" } # => ["a", "b", "c", "d", nil]
  *
- *  If +length+ is zero or less, replaces no elements:
+ *  - If +length+ is zero or less, replaces no elements:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(1, 0) { |index| "new_#{index}" } # => ["a", "b", "c", "d"]
- *    a.fill(1, -1) { |index| "new_#{index}" } # => ["a", "b", "c", "d"]
+ *      a = ('a'..'d').to_a                      # => ["a", "b", "c", "d"]
+ *      a.fill(1, 0) { |index| "new_#{index}" }  # => ["a", "b", "c", "d"]
+ *      a.fill(1, -1) { |index| "new_#{index}" } # => ["a", "b", "c", "d"]
  *
- *  With arguments +obj+ and +range+, and a block given,
+ *  With Range argument +range+ given,
  *  calls the block with each index in the given range;
- *  replaces the corresponding element with the block's return value.
+ *  replaces the corresponding element with the block's return value:
  *
- *  If the range is positive and ascending (<tt>range 0 < range.begin <= range.end</tt>,
- *  replaces elements from <tt>range.begin</tt> to <tt>range.end</tt>:
+ *  - If the range is positive and ascending (<tt>range 0 < range.begin <= range.end</tt>,
+ *    replaces elements from <tt>range.begin</tt> to <tt>range.end</tt>:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(1..1) { |index| "new_#{index}" } # => ["a", "new_1", "c", "d"]
+ *      a = ('a'..'d').to_a                     # => ["a", "b", "c", "d"]
+ *      a.fill(1..1) { |index| "new_#{index}" } # => ["a", "new_1", "c", "d"]
  *
- *  If +range.first+ is negative, does nothing:
+ *  - If +range.first+ is negative, does nothing:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(-1..1) { |index| fail 'Cannot happen' } # => ["a", "b", "c", "d"]
+ *      a = ('a'..'d').to_a                            # => ["a", "b", "c", "d"]
+ *      a.fill(-1..1) { |index| fail 'Cannot happen' } # => ["a", "b", "c", "d"]
  *
- *  If <tt>range.last</tt> is negative, counts from the end:
+ *  - If <tt>range.last</tt> is negative, counts from the end:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(0..-2) { |index| "new_#{index}" } # => ["new_0", "new_1", "new_2", "d"]
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(1..-2) { |index| "new_#{index}" } # => ["a", "new_1", "new_2", "d"]
+ *      a = ('a'..'d').to_a                      # => ["a", "b", "c", "d"]
+ *      a.fill(0..-2) { |index| "new_#{index}" } # => ["new_0", "new_1", "new_2", "d"]
+ *      a = ('a'..'d').to_a                      # => ["a", "b", "c", "d"]
+ *      a.fill(1..-2) { |index| "new_#{index}" } # => ["a", "new_1", "new_2", "d"]
  *
- *  If <tt>range.first</tt> and <tt>range.last</tt> are both negative,
- *  both count from the end:
+ *  - If <tt>range.first</tt> and <tt>range.last</tt> are both negative,
+ *    both count from the end:
  *
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(-1..-1) { |index| "new_#{index}" } # => ["a", "b", "c", "new_3"]
- *    a = ['a', 'b', 'c', 'd']
- *    a.fill(-2..-2) { |index| "new_#{index}" } # => ["a", "b", "new_2", "d"]
+ *      a = ('a'..'d').to_a                       # => ["a", "b", "c", "d"]
+ *      a.fill(-1..-1) { |index| "new_#{index}" } # => ["a", "b", "c", "new_3"]
+ *      a = ('a'..'d').to_a                       # => ["a", "b", "c", "d"]
+ *      a.fill(-2..-2) { |index| "new_#{index}" } # => ["a", "b", "new_2", "d"]
  *
+ *  Related: see {Methods for Assigning}[rdoc-ref:Array@Methods+for+Assigning].
  */
 
 static VALUE

--- a/array.c
+++ b/array.c
@@ -4783,7 +4783,7 @@ rb_ary_clear(VALUE ary)
  *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
  *      a.fill('-', 4)      # => ["a", "b", "c", "d"]
  *
- *  - If +start+ is negative, counts from the end (starting index is <tt>start + array.size</tt>):
+ *  - If +start+ is negative, counts from the end (starting index is <tt>start + self.size</tt>):
  *
  *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
  *      a.fill('-', -3)     # => ["a", "-", "-", "-"]

--- a/array.c
+++ b/array.c
@@ -4806,7 +4806,7 @@ rb_ary_clear(VALUE ary)
  *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
  *      a.fill('-', -3, 2)  # => ["a", "-", "-", "d"]
  *
- *  - If +start+ is large (<tt>start >= array.size</tt>), extends +self+ with +nil+:
+ *  - If +start+ is large (<tt>start >= self.size</tt>), extends +self+ with +nil+:
  *
  *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
  *      a.fill('-', 6, 2)   # => ["a", "b", "c", "d", nil, nil, "-", "-"]

--- a/array.c
+++ b/array.c
@@ -4703,15 +4703,21 @@ rb_ary_clear(VALUE ary)
  *
  *  In brief:
  *
- *    ['a', 'b', 'c', 'd'].fill('-', 1, 2)  # => ["a", "-", "-", "d"]
- *    ['a', 'b', 'c', 'd'].fill('-', 3, 2)  # => ["a", "b", "c", "-", "-"]
- *    ['a', 'b', 'c', 'd'].fill('-', 6, 2)  # => ["a", "b", "c", "d", nil, nil, "-", "-"]
- *    ['a', 'b', 'c', 'd'].fill('-', -4, 3) # => ["-", "-", "-", "d"]
+ *    # Non-negative start.
+ *    ['a', 'b', 'c', 'd'].fill('-', 1, 2)          # => ["a", "-", "-", "d"]
+ *    ['a', 'b', 'c', 'd'].fill(1, 2) {|e| e.to_s } # => ["a", "1", "2", "d"]
  *
- *    ['a', 'b', 'c', 'd'].fill(1, 2) {|e| e.to_s }  # => ["a", "1", "2", "d"]
- *    ['a', 'b', 'c', 'd'].fill(3, 2) {|e| e.to_s }  # => ["a", "b", "c", "3", "4"]
- *    ['a', 'b', 'c', 'd'].fill(6, 2) {|e| e.to_s }  # => ["a", "b", "c", "d", nil, nil, "6", "7"]
- *    ['a', 'b', 'c', 'd'].fill(-4, 3) {|e| e.to_s } # => ["0", "1", "2", "d"]
+ *    # Extended with specified values.
+ *    ['a', 'b', 'c', 'd'].fill('-', 3, 2)          # => ["a", "b", "c", "-", "-"]
+ *    ['a', 'b', 'c', 'd'].fill(3, 2) {|e| e.to_s } # => ["a", "b", "c", "3", "4"]
+ *
+ *    # Extended with nils and specified values.
+ *    ['a', 'b', 'c', 'd'].fill('-', 6, 2)          # => ["a", "b", "c", "d", nil, nil, "-", "-"]
+ *    ['a', 'b', 'c', 'd'].fill(6, 2) {|e| e.to_s } # => ["a", "b", "c", "d", nil, nil, "6", "7"]
+ *
+ *    # Negative start; counts backwards from the end.
+ *    ['a', 'b', 'c', 'd'].fill('-', -3, 3)          # => ["a", "-", "-", "-"]
+ *    ['a', 'b', 'c', 'd'].fill(-3, 3) {|e| e.to_s } # => ["a", "1", "2", "3"]
  *
  *  When arguments +start+ and +count+ are given,
  *  they select the elements of +self+ to be replaced;

--- a/array.c
+++ b/array.c
@@ -4762,14 +4762,6 @@ rb_ary_clear(VALUE ary)
  *      ['a', 'b', 'c', 'd'].fill(5, 2) {|e| e.to_s } # => ["a", "b", "c", "d", nil, "5", "6"]
  *      ['a', 'b', 'c', 'd'].fill(6, 2) {|e| e.to_s } # => ["a", "b", "c", "d", nil, nil, "6", "7"]
  *
- *    Extends +self+ if <tt>start + count</tt> is greater than <tt>self.size</tt>:
- *
- *      ['a', 'b', 'c', 'd'].fill('-', 2, 3) # => ["a", "b", "-", "-", "-"]
- *      ['a', 'b', 'c', 'd'].fill('-', 2, 4) # => ["a", "b", "-", "-", "-", "-"]
- *
- *      ['a', 'b', 'c', 'd'].fill(2, 3) {|e| e.to_s } # => ["a", "b", "2", "3", "4"]
- *      ['a', 'b', 'c', 'd'].fill(2, 4) {|e| e.to_s } # => ["a", "b", "2", "3", "4", "5"]
- *
  *    Does nothing if +count+ is non-positive:
  *
  *      ['a', 'b', 'c', 'd'].fill('-', 2, 0)    # => ["a", "b", "c", "d"]

--- a/array.c
+++ b/array.c
@@ -4772,7 +4772,7 @@ rb_ary_clear(VALUE ary)
  *  With argument +object+ and numeric argument +start+,
  *  replaces elements based on the given +start+:
  *
- *  - If +start+ is in range (<tt>0 <= start < array.size</tt>),
+ *  - If +start+ is in range (<tt>0 <= start < self.size</tt>),
  *    replaces all elements from offset +start+ through the end:
  *
  *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]

--- a/array.c
+++ b/array.c
@@ -4788,7 +4788,7 @@ rb_ary_clear(VALUE ary)
  *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
  *      a.fill('-', -3)     # => ["a", "-", "-", "-"]
  *
- *  - If +start+ is too small (less than and far from zero), replaces all elements:
+ *  - If +start+ is too small (<tt>start <= -self.size</tt>), replaces all elements:
  *
  *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
  *      a.fill('-', -9)     # => ["-", "-", "-", "-"]

--- a/array.c
+++ b/array.c
@@ -4701,11 +4701,60 @@ rb_ary_clear(VALUE ary)
  *    fill(start, length) {|index| ... } -> self
  *    fill(range) {|index| ... } -> self
  *
- *  Replaces specified elements in +self+ with specified objects; returns +self+.
+ *  Replaces specified elements in +self+ with specified objects;
+ *  always returns +self+ (never a new array).
  *
- *  Note: many examples here initialize arrays using a Range of characters:
+ *  Note: many examples here use this array, derived from a Range of characters:
  *
- *    a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *    ('a'..'d').to_a # => ["a", "b", "c", "d"]
+ *
+ *  In brief:
+ *
+ *    # Argument object.
+ *    ('a'..'d').to_a.fill('-') # => ["-", "-", "-", "-"]
+ *
+ *    # Arguments object and start.
+ *    ('a'..'d').to_a.fill('-', 2)  # => ["a", "b", "-", "-"]
+ *    ('a'..'d').to_a.fill('-', 4)  # => ["a", "b", "c", "d"]
+ *    ('a'..'d').to_a.fill('-', -2) # => ["a", "b", "-", "-"]
+ *    ('a'..'d').to_a.fill('-', -9) # => ["-", "-", "-", "-"]
+ *
+ *    # Arguments object, start, and length.
+ *    ('a'..'d').to_a.fill('-', 1, 2)  # => ["a", "-", "-", "d"]
+ *    ('a'..'d').to_a.fill('-', -3, 2) # => ["a", "-", "-", "d"]
+ *    ('a'..'d').to_a.fill('-', 6, 2)  # => ["a", "b", "c", "d", nil, nil, "-", "-"]
+ *    ('a'..'d').to_a.fill('-', 6, 0)  # => ["a", "b", "c", "d", nil, nil]
+ *
+ *    # Arguments object and range.
+ *    ('a'..'d').to_a.fill('-', (1..2))   # => ["a", "-", "-", "d"]
+ *    ('a'..'d').to_a.fill('-', (-1..2))  # => ["a", "b", "c", "d"]
+ *    ('a'..'d').to_a.fill('-', (1..-2))  # => ["a", "-", "-", "d"]
+ *    ('a'..'d').to_a.fill('-', (-3..-2)) # => ["a", "-", "-", "d"]
+ *
+ *    # No argument, with a block.
+ *    ('a'..'d').to_a.fill  { |index| "new_#{index}" } # => ["new_0", "new_1", "new_2", "new_3"]
+ *
+ *    # Argument start, with a block.
+ *    ('a'..'d').to_a.fill(2)  { |index| "new_#{index}" }      # => ["a", "b", "new_2", "new_3"]
+ *    ('a'..'d').to_a.fill(4) { |index| fail 'Cannot happen' } # => ["a", "b", "c", "d"]
+ *    ('a'..'d').to_a.fill(-2) { |index| "new_#{index}" }      # => ["a", "b", "new_2", "new_3"]
+ *    ('a'..'d').to_a.fill(-4) { |index| "new_#{index}" }      # => ["new_0", "new_1", "new_2", "new_3"]
+ *
+ *    # Arguments start and length, with a block.
+ *    ('a'..'d').to_a.fill(1, 2) { |index| "new_#{index}" }  # => ["a", "new_1", "new_2", "d"]
+ *    ('a'..'d').to_a.fill(-3, 2) { |index| "new_#{index}" } # => ["a", "new_1", "new_2", "d"]
+ *    ('a'..'d').to_a.fill(5, 2) { |index| "new_#{index}" }  # => ["a", "b", "c", "d", nil, "new_5", "new_6"]
+ *    ('a'..'d').to_a.fill(5, 0) { |index| "new_#{index}" }  # => ["a", "b", "c", "d", nil]
+ *    ('a'..'d').to_a.fill(1, 0) { |index| "new_#{index}" }  # => ["a", "b", "c", "d"]
+ *    ('a'..'d').to_a.fill(1, -1) { |index| "new_#{index}" } # => ["a", "b", "c", "d"]
+ *
+ *    # Argument range, with a block.
+ *    ('a'..'d').to_a.fill(1..1) { |index| "new_#{index}" }        # => ["a", "new_1", "c", "d"]
+ *    ('a'..'d').to_a.fill(-1..1) { |index| fail 'Cannot happen' } # => ["a", "b", "c", "d"]
+ *    ('a'..'d').to_a.fill(0..-2) { |index| "new_#{index}" }       # => ["new_0", "new_1", "new_2", "d"]
+ *    ('a'..'d').to_a.fill(1..-2) { |index| "new_#{index}" }       # => ["a", "new_1", "new_2", "d"]
+ *    ('a'..'d').to_a.fill(-1..-1) { |index| "new_#{index}" }      # => ["a", "b", "c", "new_3"]
+ *    ('a'..'d').to_a.fill(-2..-2) { |index| "new_#{index}" }      # => ["a", "b", "new_2", "d"]
  *
  *  <b>With No Block Given</b>
  *

--- a/array.c
+++ b/array.c
@@ -4857,13 +4857,13 @@ rb_ary_clear(VALUE ary)
  *  from offset +start+ to the end; replaces the corresponding element
  *  with the block's return value:
  *
- *  - If start is in range (<tt>0 <= start < array.size</tt>),
+ *  - If start is in range (<tt>0 <= start < self.size</tt>),
  *    replaces from offset +start+ to the end:
  *
  *      a = ('a'..'d').to_a                  # => ["a", "b", "c", "d"]
  *      a.fill(2) { |index| "new_#{index}" } # => ["a", "b", "new_2", "new_3"]
  *
- *  - If +start+ is too large(<tt>start >= array.size</tt>), does nothing:
+ *  - If +start+ is too large(<tt>start >= self.size</tt>), does nothing:
  *
  *      a = ('a'..'d').to_a                        # => ["a", "b", "c", "d"]
  *      a.fill(4) { |index| fail 'Cannot happen' } # => ["a", "b", "c", "d"]
@@ -4873,7 +4873,7 @@ rb_ary_clear(VALUE ary)
  *      a = ('a'..'d').to_a                   # => ["a", "b", "c", "d"]
  *      a.fill(-2) { |index| "new_#{index}" } # => ["a", "b", "new_2", "new_3"]
  *
- *  - If start is too small (<tt>start <= - array.size</tt>, replaces all elements:
+ *  - If start is too small (<tt>start <= - self.size</tt>, replaces all elements:
  *
  *      a = ('a'..'d').to_a                   # => ["a", "b", "c", "d"]
  *      a.fill(-4) { |index| "new_#{index}" } # => ["new_0", "new_1", "new_2", "new_3"]
@@ -4892,7 +4892,7 @@ rb_ary_clear(VALUE ary)
  *      a = ('a'..'d').to_a                      # => ["a", "b", "c", "d"]
  *      a.fill(-3, 2) { |index| "new_#{index}" } # => ["a", "new_1", "new_2", "d"]
  *
- *  - If +start+ is large (<tt>start >= array.size</tt>), extends +self+ with +nil+:
+ *  - If +start+ is large (<tt>start >= self.size</tt>), extends +self+ with +nil+:
  *
  *      a = ('a'..'d').to_a                     # => ["a", "b", "c", "d"]
  *      a.fill(5, 2) { |index| "new_#{index}" } # => ["a", "b", "c", "d", nil, "new_5", "new_6"]
@@ -5097,7 +5097,7 @@ rb_ary_concat(VALUE x, VALUE y)
  *    a * 3 # => ["x", "y", "x", "y", "x", "y"]
  *
  *  When string argument +string_separator+ is given,
- *  equivalent to <tt>array.join(string_separator)</tt>:
+ *  equivalent to <tt>self.join(string_separator)</tt>:
  *
  *    [0, [0, 1], {foo: 0}] * ', ' # => "0, 0, 1, {:foo=>0}"
  *

--- a/array.c
+++ b/array.c
@@ -4708,6 +4708,9 @@ rb_ary_clear(VALUE ary)
  *
  *    ('a'..'d').to_a # => ["a", "b", "c", "d"]
  *
+ *  In all cases, numeric arguments +start+ and +length+ must be
+ *  {integer-convertible objects}[rdoc-ref:implicit_conversion.rdoc@Integer-Convertible+Objects].
+ *
  *  In brief:
  *
  *    # Argument object.
@@ -4766,7 +4769,7 @@ rb_ary_clear(VALUE ary)
  *    a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
  *    a.fill('-')         # => ["-", "-", "-", "-"]
  *
- *  With argument +object+ and integer argument +start+,
+ *  With argument +object+ and numeric argument +start+,
  *  replaces elements based on the given +start+:
  *
  *  - If +start+ is in range (<tt>0 <= start < array.size</tt>),
@@ -4790,7 +4793,7 @@ rb_ary_clear(VALUE ary)
  *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
  *      a.fill('-', -9)     # => ["-", "-", "-", "-"]
  *
- *  With argument +object+ and integer arguments +start+ and +length+,
+ *  With argument +object+ and numeric arguments +start+ and +length+,
  *  replaces elements based on the given +start+ and +length+:
  *
  *  - If +start+ is in range, replaces +length+ elements beginning at offset +start+:
@@ -4850,7 +4853,7 @@ rb_ary_clear(VALUE ary)
  *    a = ('a'..'d').to_a               # => ["a", "b", "c", "d"]
  *    a.fill { |index| "new_#{index}" } # => ["new_0", "new_1", "new_2", "new_3"]
  *
- *  With integer argument +start+ given, calls the block with each index
+ *  With numeric argument +start+, calls the block with each index
  *  from offset +start+ to the end; replaces the corresponding element
  *  with the block's return value:
  *
@@ -4875,7 +4878,7 @@ rb_ary_clear(VALUE ary)
  *      a = ('a'..'d').to_a                   # => ["a", "b", "c", "d"]
  *      a.fill(-4) { |index| "new_#{index}" } # => ["new_0", "new_1", "new_2", "new_3"]
  *
- *  With integer arguments +start+ and +length+,
+ *  With numeric arguments +start+ and +length+,
  *  calls the block for each index specified by start length;
  *  replaces the corresponding element with the block's return value:
  *

--- a/array.c
+++ b/array.c
@@ -4701,6 +4701,18 @@ rb_ary_clear(VALUE ary)
  *  may add elements to +self+;
  *  always returns +self+ (never a new array).
  *
+ *  In brief:
+ *
+ *    ['a', 'b', 'c', 'd'].fill('-', 1, 2)  # => ["a", "-", "-", "d"]
+ *    ['a', 'b', 'c', 'd'].fill('-', 3, 2)  # => ["a", "b", "c", "-", "-"]
+ *    ['a', 'b', 'c', 'd'].fill('-', 6, 2)  # => ["a", "b", "c", "d", nil, nil, "-", "-"]
+ *    ['a', 'b', 'c', 'd'].fill('-', -4, 3) # => ["-", "-", "-", "d"]
+ *
+ *    ['a', 'b', 'c', 'd'].fill(1, 2) {|e| e.to_s }  # => ["a", "1", "2", "d"]
+ *    ['a', 'b', 'c', 'd'].fill(3, 2) {|e| e.to_s }  # => ["a", "b", "c", "3", "4"]
+ *    ['a', 'b', 'c', 'd'].fill(6, 2) {|e| e.to_s }  # => ["a", "b", "c", "d", nil, nil, "6", "7"]
+ *    ['a', 'b', 'c', 'd'].fill(-4, 3) {|e| e.to_s } # => ["0", "1", "2", "d"]
+ *
  *  When arguments +start+ and +count+ are given,
  *  they select the elements of +self+ to be replaced;
  *  each must be an

--- a/array.c
+++ b/array.c
@@ -4693,8 +4693,8 @@ rb_ary_clear(VALUE ary)
 /*
  *  call-seq:
  *    fill(object, start = nil, count = nil) -> new_array
- *    fill(start = nil, count = nil) {|element| ... } -> new_array
  *    fill(object, range) -> new_array
+ *    fill(start = nil, count = nil) {|element| ... } -> new_array
  *    fill(range) {|element| ... } -> new_array
  *
  *  Replaces selected elements in +self+;

--- a/array.c
+++ b/array.c
@@ -4707,11 +4707,17 @@ rb_ary_clear(VALUE ary)
  *  {integer-convertible object}[rdoc-ref:implicit_conversion.rdoc@Integer-Convertible+Objects]
  *  (or +nil+):
  *
- *  - +start+ is the zero-based offset of the first element to be replaced;
- *    +nil+ means zero;
+ *  - +start+ specifies the zero-based offset of the first element to be replaced:
+ *
+ *    - If +start+ is non-negative, the effective start is +start+.
+ *    - If +start+ is +nil+, the effective start is zero.
+ *    - If +start+ is negative, counts backwards from the end of self;
+ *      the effective start is <tt>self.size + start</tt>.
+ *
  *  - +count+ is the number of consecutive elements to be replaced;
  *    +nil+ means "all the rest."
- *  - If <tt>start + count</tt> is greater than <tt>self.size</tt>, elements are appended.
+ *  - If the effective start plus +count+ is greater than <tt>self.size</tt>,
+ *    elements are appended.
  *
  *  If argument +object+ is given,
  *  that one object is the sole replacement value:

--- a/array.c
+++ b/array.c
@@ -4778,7 +4778,7 @@ rb_ary_clear(VALUE ary)
  *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
  *      a.fill('-', 2)      # => ["a", "b", "-", "-"]
  *
- *   - If +start+ is too large (<tt>start >= array.size</tt>), does nothing:
+ *   - If +start+ is too large (<tt>start >= self.size</tt>), does nothing:
  *
  *      a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
  *      a.fill('-', 4)      # => ["a", "b", "c", "d"]


### PR DESCRIPTION
- Uses idiom `('a'..'d').to_a` to create example arrays.
- Revises examples to (more often) vertically align elements before/after call:
  ```
  a = ('a'..'d').to_a # => ["a", "b", "c", "d"]
  a.fill('-', 1, 2)   # => ["a", "-", "-", "d"]
  ```
- Revises examples to make changed elements more obvious: `'a'` replaced by `'-'` instead of by `:X`.
- Makes emphatic separation (via pseudo-headings) between no-block and block discussions.
- Adds "In brief" section;  it's long, but only about 20% as long as the rest of the discussion.  With any luck, an experienced Rubyist's question will be answered there.
- Notes that numeric arguments `start` and `length` must be integer-convertible objects.

