### PR TITLE
[Bug #20737] We don't warn target gems for Ruby 3.5

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -26,12 +26,6 @@ module Gem::BUNDLED_GEMS
     "resolv-replace" => "3.4.0",
     "rinda" => "3.4.0",
     "syslog" => "3.4.0",
-    "ostruct" => "3.5.0",
-    "pstore" => "3.5.0",
-    "rdoc" => "3.5.0",
-    "win32ole" => "3.5.0",
-    "fiddle" => "3.5.0",
-    "logger" => "3.5.0",
   }.freeze
 
   SINCE_FAST_PATH = SINCE.transform_keys { |g| g.sub(/\A.*\-/, "") }.freeze


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20737