### PR TITLE
Fix coding issue in prism_compile.c

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -8043,6 +8043,9 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             PUSH_GETLOCAL(ret, location, mult_local.index, mult_local.level);
             PUSH_INSN2(ret, location, invokesuperforward, new_callinfo(iseq, 0, 0, flag, NULL, block != NULL), block);
             if (popped) PUSH_INSN(ret, location, pop);
+            if (cast->block) {
+                ISEQ_COMPILE_DATA(iseq)->current_block = previous_block;
+            }
             return;
         }
 


### PR DESCRIPTION
Make sure to set back `ISEQ_COMPILE_DATA(iseq)->current_block` for forwarding super nodes with a block.

Fixes [Bug #20740]