### PR TITLE
fix rb_memsearch() document

### DIFF
--- a/include/ruby/internal/encoding/string.h
+++ b/include/ruby/internal/encoding/string.h
@@ -307,13 +307,13 @@ RBIMPL_ATTR_NONNULL(())
 /**
  * Looks for the passed string in the passed buffer.
  *
- * @param[in]  x          Buffer that potentially includes `y`.
+ * @param[in]  x          Query string.
  * @param[in]  m          Number of bytes of `x`.
- * @param[in]  y          Query string.
+ * @param[in]  y          Buffer that potentially includes `x`.
  * @param[in]  n          Number of bytes of `y`.
  * @param[in]  enc        Encoding of both `x` and `y`.
  * @retval     -1         Not found.
- * @retval     otherwise  Found index in `x`.
+ * @retval     otherwise  Found index in `y`.
  * @note       This API can match at a non-character-boundary.
  */
 long rb_memsearch(const void *x, long m, const void *y, long n, rb_encoding *enc);


### PR DESCRIPTION
## Why?
The explanation of x and y is reversed.

https://github.com/ruby/ruby/blob/ddbd64400199fd408d23c85f9fb0d7f742ecf9e1/re.c#L251-L256
