### PR TITLE
[DOC] Fix autoload method formatting

### DIFF
--- a/load.c
+++ b/load.c
@@ -1451,9 +1451,9 @@ ruby_init_ext(const char *name, void (*init)(void))
  *     A.autoload(:B, "b")
  *     A::B.doit            # autoloads "b"
  *
- * If _const_ in _mod_ is defined as autoload, the file name to be
- * loaded is replaced with _filename_.  If _const_ is defined but not
- * as autoload, does nothing.
+ *  If _const_ in _mod_ is defined as autoload, the file name to be
+ *  loaded is replaced with _filename_.  If _const_ is defined but not
+ *  as autoload, does nothing.
  */
 
 static VALUE
@@ -1515,9 +1515,9 @@ rb_mod_autoload_p(int argc, VALUE *argv, VALUE mod)
  *
  *     autoload(:MyModule, "/usr/local/lib/modules/my_module.rb")
  *
- * If _const_ is defined as autoload, the file name to be loaded is
- * replaced with _filename_.  If _const_ is defined but not as
- * autoload, does nothing.
+ *  If _const_ is defined as autoload, the file name to be loaded is
+ *  replaced with _filename_.  If _const_ is defined but not as
+ *  autoload, does nothing.
  */
 
 static VALUE


### PR DESCRIPTION
Fixes `autoload` documentation
Before:
<img width="1099" alt="Screenshot 2024-09-15 at 22 55 26" src="https://github.com/user-attachments/assets/bbb4d217-1227-48b1-b9f0-a7d86586df72">
After
<img width="1109" alt="Screenshot 2024-09-15 at 22 58 24" src="https://github.com/user-attachments/assets/cfe572b4-6f46-4aa9-970a-8949e57bf6cc">
