### PR TITLE
Fix bug at fork on FreeBSD

### DIFF
--- a/process.c
+++ b/process.c
@@ -4234,7 +4234,13 @@ rb_fork_ruby(int *status)
         child.error = err = errno;
 
         disable_child_handler_fork_parent(&old); /* yes, bad name */
-        rb_thread_release_fork_lock();
+        if (
+#if defined(__FreeBSD__)
+            pid != 0 &&
+#endif
+            true) {
+            rb_thread_release_fork_lock();
+        }
         if (pid == 0) {
             rb_thread_reset_fork_lock();
         }


### PR DESCRIPTION
The main thread in a forked process appears not to own the read-write lock.

```
   bootstraptest.test_fork.rb_1_284.rb:6: [BUG] pthread_rwlock_unlock: Operation not permitted (EPERM)
   ruby 3.4.0dev (2024-09-13T05:35:25Z master 5894202365) +PRISM [x86_64-freebsd13.3]
   
   -- Control frame information -----------------------------------------------
   c:0003 p:---- s:0012 e:000011 CFUNC  :fork
   c:0002 p:0024 s:0008 E:001038 EVAL   bootstraptest.test_fork.rb_1_284.rb:6 [FINISH]
   c:0001 p:0000 s:0003 E:000500 DUMMY  [FINISH]
   
   -- Ruby level backtrace information ----------------------------------------
   bootstraptest.test_fork.rb_1_284.rb:6:in '<main>'
   bootstraptest.test_fork.rb_1_284.rb:6:in 'fork'
```