### PR TITLE
Lenient call with gvl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -342,6 +342,12 @@ The following bundled gems are updated.
       `IO` objects share the same file descriptor, closing one does not affect
       the other. [[Feature #18455]]
 
+* GVL
+
+    * `rb_thread_call_with_gvl` now works with or without the GVL.
+      This allows gems to avoid checking `ruby_thread_has_gvl_p`.
+      Please still be diligent about the GVL. [[Feature #20750]]
+
 * Set
 
     * A C API for `Set` has been added. The following methods are supported:
@@ -402,6 +408,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 [Feature #19908]: https://bugs.ruby-lang.org/issues/19908
 [Feature #20610]: https://bugs.ruby-lang.org/issues/20610
 [Feature #20724]: https://bugs.ruby-lang.org/issues/20724
+[Feature #20750]: https://bugs.ruby-lang.org/issues/20750
 [Feature #20884]: https://bugs.ruby-lang.org/issues/20884
 [Feature #20925]: https://bugs.ruby-lang.org/issues/20925
 [Feature #20971]: https://bugs.ruby-lang.org/issues/20971

--- a/gc.c
+++ b/gc.c
@@ -5063,11 +5063,7 @@ gc_raise(VALUE exc, const char *fmt, ...)
         exc, fmt, &ap,
     };
 
-    if (ruby_thread_has_gvl_p()) {
-        gc_vraise(&argv);
-        UNREACHABLE;
-    }
-    else if (ruby_native_thread_p()) {
+    if (ruby_native_thread_p()) {
         rb_thread_call_with_gvl(gc_vraise, &argv);
         UNREACHABLE;
     }

--- a/thread.c
+++ b/thread.c
@@ -2042,6 +2042,9 @@ rb_thread_io_blocking_region(struct rb_io *io, rb_blocking_function_t *func, voi
  *       created as Ruby thread (created by Thread.new or so).  In other
  *       words, this function *DOES NOT* associate or convert a NON-Ruby
  *       thread to a Ruby thread.
+ *
+ * NOTE: If this thread has already acquired the GVL, then the method call
+ *       is performed without acquiring or releasing the GVL (from Ruby 4.0).
  */
 void *
 rb_thread_call_with_gvl(void *(*func)(void *), void *data1)
@@ -2065,7 +2068,8 @@ rb_thread_call_with_gvl(void *(*func)(void *), void *data1)
     prev_unblock = th->unblock;
 
     if (brb == 0) {
-        rb_bug("rb_thread_call_with_gvl: called by a thread which has GVL.");
+        /* the GVL is already acquired, call method directly */
+        return (*func)(data1);
     }
 
     blocking_region_end(th, brb);


### PR DESCRIPTION
Alternative to #11619

This is part of https://bugs.ruby-lang.org/issues/20750

Before
----

Calling `rb_thread_call_with_gvl` when the GVL is acquired throws an error.

After
---

Calling `rb_thread_call_with_gvl` when the GVL is acquired graciously continues.


Sorry, I do not know if we want a larger or smaller change.
So I kept as 2 commits.
