### PR TITLE
[Feature #120782] Introduction of Happy Eyeballs Version 2 (RFC8305) in TCPSocket.new

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -341,7 +341,7 @@ add_ts_to_tv(struct timeval tv, struct timespec ts)
 int
 is_infinity(struct timeval tv)
 {
-    // {-1, -1 } as infinity
+    // { -1, -1 } as infinity
     return tv.tv_sec == -1 || tv.tv_usec == -1;
 }
 
@@ -876,7 +876,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                     if (resolved_type_size > 0) {
                         resolved_type[resolved_type_size] = '\0';
 
-                        if (strcmp(resolved_type, IPV6_HOSTNAME_RESOLVED) == 0) { // IPv6解決
+                        if (strcmp(resolved_type, IPV6_HOSTNAME_RESOLVED) == 0) {
                             resolution_store.v6.ai = arg->getaddrinfo_entries[IPV6_ENTRY_POS]->ai;
                             resolution_store.v6.finished = true;
                             if (arg->getaddrinfo_entries[IPV6_ENTRY_POS]->err) {
@@ -892,7 +892,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                                 user_specified_resolv_timeout_at = NULL;
                                 break;
                             }
-                        } else if (strcmp(resolved_type, IPV4_HOSTNAME_RESOLVED) == 0) { // IPv4解決
+                        } else if (strcmp(resolved_type, IPV4_HOSTNAME_RESOLVED) == 0) {
                             resolution_store.v4.ai = arg->getaddrinfo_entries[IPV4_ENTRY_POS]->ai;
                             resolution_store.v4.finished = true;
 

--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -169,8 +169,927 @@ init_inetsock_internal(VALUE v)
     return io;
 }
 
+#ifndef FAST_FALLBACK_INIT_INETSOCK_IMPL
+#  if defined(HAVE_PTHREAD_CREATE) && defined(HAVE_PTHREAD_DETACH) && \
+     !defined(__MINGW32__) && !defined(__MINGW64__) && \
+     defined(F_SETFL) && defined(F_GETFL)
+#    include "ruby/thread_native.h"
+#    define FAST_FALLBACK_INIT_INETSOCK_IMPL 1
+#    define IPV6_ENTRY_POS 0
+#    define IPV4_ENTRY_POS 1
+#  else
+#    define FAST_FALLBACK_INIT_INETSOCK_IMPL 0
+#  endif
+#endif
+
+int
+is_specified_ip_address(const char *hostname)
+{
+    if (!hostname) return false;
+
+    struct in_addr ipv4addr;
+    struct in6_addr ipv6addr;
+
+    return (inet_pton(AF_INET6, hostname, &ipv6addr) == 1 ||
+            inet_pton(AF_INET, hostname, &ipv4addr) == 1);
+}
+
+struct fast_fallback_inetsock_arg
+{
+    VALUE sock;
+    struct {
+        VALUE host, serv;
+        struct rb_addrinfo *res;
+    } remote, local;
+    int type;
+    int fd;
+    VALUE resolv_timeout;
+    VALUE connect_timeout;
+
+    const char *hostp, *portp;
+    int *families;
+    int family_size;
+    int additional_flags;
+    int cancelled;
+    rb_nativethread_lock_t *lock;
+    struct fast_fallback_getaddrinfo_entry *getaddrinfo_entries[2];
+    struct fast_fallback_getaddrinfo_shared *getaddrinfo_shared;
+    int connection_attempt_fds_size;
+    int *connection_attempt_fds;
+    VALUE test_mode_settings;
+};
+
+static struct fast_fallback_getaddrinfo_shared *
+create_fast_fallback_getaddrinfo_shared()
+{
+    struct fast_fallback_getaddrinfo_shared *shared;
+    shared = (struct fast_fallback_getaddrinfo_shared *)calloc(1, sizeof(struct fast_fallback_getaddrinfo_shared));
+    return shared;
+}
+
+static struct fast_fallback_getaddrinfo_entry *
+allocate_fast_fallback_getaddrinfo_entry()
+{
+    struct fast_fallback_getaddrinfo_entry *entry;
+    entry = (struct fast_fallback_getaddrinfo_entry *)calloc(1, sizeof(struct fast_fallback_getaddrinfo_entry));
+    return entry;
+}
+
+static void
+allocate_fast_fallback_getaddrinfo_hints(struct addrinfo *hints, int family, int remote_addrinfo_hints, int additional_flags)
+{
+    MEMZERO(hints, struct addrinfo, 1);
+    hints->ai_family = family;
+    hints->ai_socktype = SOCK_STREAM;
+    hints->ai_protocol = IPPROTO_TCP;
+    hints->ai_flags = remote_addrinfo_hints;
+    hints->ai_flags |= additional_flags;
+}
+
+struct wait_fast_fallback_arg
+{
+    int status, nfds;
+    fd_set *readfds, *writefds;
+    struct timeval *delay;
+    int *cancelled;
+};
+
+static void *
+wait_fast_fallback(void *ptr)
+{
+    struct wait_fast_fallback_arg *arg = (struct wait_fast_fallback_arg *)ptr;
+    int status;
+    status = select(arg->nfds, arg->readfds, arg->writefds, NULL, arg->delay);
+    arg->status = status;
+    if (errno == EINTR) *arg->cancelled = true;
+    return 0;
+}
+
+static void
+cancel_fast_fallback(void *ptr)
+{
+    if (!ptr) return;
+
+    struct fast_fallback_getaddrinfo_shared *arg = (struct fast_fallback_getaddrinfo_shared *)ptr;
+
+    rb_nativethread_lock_lock(arg->lock);
+    {
+        *arg->cancelled = true;
+        write(arg->notify, SELECT_CANCELLED, strlen(SELECT_CANCELLED));
+    }
+    rb_nativethread_lock_unlock(arg->lock);
+}
+
+struct hostname_resolution_result
+{
+    struct addrinfo *ai;
+    int finished;
+    int succeed;
+};
+
+struct hostname_resolution_store
+{
+    struct hostname_resolution_result v6;
+    struct hostname_resolution_result v4;
+    int is_all_finised;
+};
+
+int
+any_addrinfos(struct hostname_resolution_store *resolution_store)
+{
+    return resolution_store->v6.ai || resolution_store->v4.ai;
+}
+
+struct timespec
+current_clocktime_ts()
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts;
+}
+
+void
+set_timeout_tv(struct timeval *tv, long ms, struct timespec from)
+{
+    long sec = ms / 1000;
+    long nsec = (ms % 1000) * 1000000;
+    long result_sec = from.tv_sec + sec;
+    long result_nsec = from.tv_nsec + nsec;
+
+    result_sec += result_nsec / 1000000000;
+    result_nsec = result_nsec % 1000000000;
+
+    tv->tv_sec = result_sec;
+    tv->tv_usec = (int)(result_nsec / 1000);
+}
+
+struct timeval
+add_ts_to_tv(struct timeval tv, struct timespec ts)
+{
+    long ts_usec = ts.tv_nsec / 1000;
+    tv.tv_sec += ts.tv_sec;
+    tv.tv_usec += ts_usec;
+
+    if (tv.tv_usec >= 1000000) {
+        tv.tv_sec += tv.tv_usec / 1000000;
+        tv.tv_usec = tv.tv_usec % 1000000;
+    }
+
+    return tv;
+}
+
+int
+is_infinity(struct timeval tv)
+{
+    // {-1, -1 } as infinity
+    return tv.tv_sec == -1 || tv.tv_usec == -1;
+}
+
+int
+is_timeout_tv(struct timeval *timeout_tv, struct timespec now) {
+    if (!timeout_tv) return false;
+    if (timeout_tv->tv_sec == -1 && timeout_tv->tv_usec == -1) return false;
+
+    struct timespec ts;
+    ts.tv_sec = timeout_tv->tv_sec;
+    ts.tv_nsec = timeout_tv->tv_usec * 1000;
+
+    if (now.tv_sec > ts.tv_sec) return true;
+    if (now.tv_sec == ts.tv_sec && now.tv_nsec >= ts.tv_nsec) return true;
+    return false;
+}
+
+struct timeval *
+select_expires_at(
+    struct hostname_resolution_store *resolution_store,
+    struct timeval *resolution_delay,
+    struct timeval *connection_attempt_delay,
+    struct timeval *user_specified_resolv_timeout_at,
+    struct timeval *user_specified_connect_timeout_at
+) {
+    if (any_addrinfos(resolution_store)) {
+        return resolution_delay ? resolution_delay : connection_attempt_delay;
+    }
+
+    struct timeval *timeout = NULL;
+
+    if (user_specified_resolv_timeout_at) {
+        if (is_infinity(*user_specified_resolv_timeout_at)) return NULL;
+        timeout = user_specified_resolv_timeout_at;
+    }
+
+    if (user_specified_connect_timeout_at) {
+        if (is_infinity(*user_specified_connect_timeout_at)) return NULL;
+        if (!timeout || timercmp(user_specified_connect_timeout_at, timeout, >)) {
+            return user_specified_connect_timeout_at;
+        }
+    }
+
+    return timeout;
+}
+
+struct timeval
+tv_to_timeout(struct timeval *ends_at, struct timespec now)
+{
+    struct timeval delay;
+    struct timespec expires_at;
+    expires_at.tv_sec = ends_at->tv_sec;
+    expires_at.tv_nsec = ends_at->tv_usec * 1000;
+
+    struct timespec diff;
+    diff.tv_sec = expires_at.tv_sec - now.tv_sec;
+
+    if (expires_at.tv_nsec >= now.tv_nsec) {
+        diff.tv_nsec = expires_at.tv_nsec - now.tv_nsec;
+    } else {
+        diff.tv_sec -= 1;
+        diff.tv_nsec = (1000000000 + expires_at.tv_nsec) - now.tv_nsec;
+    }
+
+    delay.tv_sec = diff.tv_sec;
+    delay.tv_usec = (int)diff.tv_nsec / 1000;
+
+    return delay;
+}
+
+struct addrinfo *
+pick_addrinfo(struct hostname_resolution_store *resolution_store, int last_family)
+{
+    int priority_on_v6[2] = { AF_INET6, AF_INET };
+    int priority_on_v4[2] = { AF_INET, AF_INET6 };
+    int *precedences = last_family == AF_INET6 ? priority_on_v4 : priority_on_v6;
+    struct addrinfo *selected_ai = NULL;
+
+    for (int i = 0; i < 2; i++) {
+        if (precedences[i] == AF_INET6) {
+            selected_ai = resolution_store->v6.ai;
+            if (selected_ai) {
+                resolution_store->v6.ai = selected_ai->ai_next;
+                break;
+            }
+        } else {
+            selected_ai = resolution_store->v4.ai;
+            if (selected_ai) {
+                resolution_store->v4.ai = selected_ai->ai_next;
+                break;
+            }
+        }
+    }
+    return selected_ai;
+}
+
+static void
+socket_nonblock_set(int fd)
+{
+    int flags = fcntl(fd, F_GETFL);
+
+    if (flags == -1) rb_sys_fail(0);
+    if ((flags & O_NONBLOCK) != 0) return;
+
+    flags |= O_NONBLOCK;
+
+    if (fcntl(fd, F_SETFL, flags) == -1) rb_sys_fail(0);
+    return;
+}
+
+static int
+in_progress_fds(const int *fds, int fds_size)
+{
+    for (int i = 0; i < fds_size; i++) {
+        if (fds[i] > 0) return true;
+    }
+    return false;
+}
+
+static VALUE
+init_fast_fallback_inetsock_internal(VALUE v)
+{
+    struct fast_fallback_inetsock_arg *arg = (void *)v;
+    VALUE resolv_timeout = arg->resolv_timeout;
+    VALUE connect_timeout = arg->connect_timeout;
+    VALUE test_mode_settings = arg->test_mode_settings;
+    struct addrinfo *remote_ai = NULL, *local_ai = NULL;
+    int fd = -1, connected_fd = -1, status = 0, local_status = 0;
+    int remote_addrinfo_hints = 0;
+    int last_error = 0;
+    const char *syscall = 0;
+
+    #ifdef HAVE_CONST_AI_ADDRCONFIG
+    remote_addrinfo_hints |= AI_ADDRCONFIG;
+    #endif
+
+    int family_size = arg->family_size;
+
+    struct fast_fallback_getaddrinfo_shared *getaddrinfo_shared = NULL;
+    pthread_t threads[family_size];
+    char resolved_type[2];
+    ssize_t resolved_type_size;
+    int hostname_resolution_waiter, hostname_resolution_notifier;
+    int pipefd[2];
+    fd_set readfds, writefds;
+
+    struct wait_fast_fallback_arg wait_arg;
+    struct timeval *ends_at = NULL;
+    struct timeval delay = (struct timeval){ -1, -1 };
+    wait_arg.nfds = 0;
+    wait_arg.writefds = NULL;
+    wait_arg.status = 0;
+
+    struct hostname_resolution_store resolution_store;
+    resolution_store.is_all_finised = false;
+    resolution_store.v6.ai = NULL;
+    resolution_store.v6.finished = false;
+    resolution_store.v4.ai = NULL;
+    resolution_store.v4.finished = false;
+
+    int last_family = 0;
+
+    int initial_capacity = 10;
+    int current_capacity = initial_capacity;
+    arg->connection_attempt_fds = (int *)malloc(initial_capacity * sizeof(int));
+    if (!arg->connection_attempt_fds) rb_syserr_fail(EAI_MEMORY, NULL);
+    arg->connection_attempt_fds_size = 0;
+
+    struct timeval resolution_delay_storage;
+    struct timeval *resolution_delay_expires_at = NULL;
+    struct timeval connection_attempt_delay_strage;
+    struct timeval *connection_attempt_delay_expires_at = NULL;
+    struct timeval user_specified_resolv_timeout_storage;
+    struct timeval *user_specified_resolv_timeout_at = NULL;
+    struct timeval user_specified_connect_timeout_storage;
+    struct timeval *user_specified_connect_timeout_at = NULL;
+    struct timespec now = current_clocktime_ts();
+
+    /* start of hostname resolution */
+    if (family_size == 1) {
+        int family = arg->families[0];
+        arg->remote.res = rsock_addrinfo(
+            arg->remote.host,
+            arg->remote.serv,
+            family,
+            SOCK_STREAM,
+            0
+        );
+
+        if (family == AF_INET6) {
+            resolution_store.v6.ai = arg->remote.res->ai;
+            resolution_store.v6.finished = true;
+            resolution_store.v4.finished = true;
+        } else if (family == AF_INET) {
+            resolution_store.v4.ai = arg->remote.res->ai;
+            resolution_store.v4.finished = true;
+            resolution_store.v6.finished = true;
+        }
+        resolution_store.is_all_finised = true;
+        wait_arg.readfds = NULL;
+    } else {
+        pipe(pipefd);
+        hostname_resolution_waiter = pipefd[0];
+        int waiter_flags = fcntl(hostname_resolution_waiter, F_GETFL, 0);
+        fcntl(hostname_resolution_waiter, F_SETFL, waiter_flags | O_NONBLOCK);
+        hostname_resolution_notifier = pipefd[1];
+        wait_arg.readfds = &readfds;
+
+        arg->getaddrinfo_shared = create_fast_fallback_getaddrinfo_shared();
+        if (!arg->getaddrinfo_shared) rb_syserr_fail(EAI_MEMORY, NULL);
+
+        arg->getaddrinfo_shared->lock = malloc(sizeof(rb_nativethread_lock_t));
+        if (!arg->getaddrinfo_shared->lock) rb_syserr_fail(EAI_MEMORY, NULL);
+        rb_nativethread_lock_initialize(arg->getaddrinfo_shared->lock);
+
+        getaddrinfo_shared = arg->getaddrinfo_shared;
+
+        getaddrinfo_shared->node = arg->hostp ? strdup(arg->hostp) : NULL;
+        getaddrinfo_shared->service = strdup(arg->portp);
+        getaddrinfo_shared->refcount = family_size + 1;
+        getaddrinfo_shared->notify = hostname_resolution_notifier;
+        getaddrinfo_shared->wait = hostname_resolution_waiter;
+        getaddrinfo_shared->connection_attempt_fds = arg->connection_attempt_fds;
+        getaddrinfo_shared->connection_attempt_fds_size = arg->connection_attempt_fds_size;
+        getaddrinfo_shared->cancelled = &arg->cancelled;
+        wait_arg.cancelled = &arg->cancelled;
+
+        for (int i = 0; i < arg->family_size; i++) {
+            arg->getaddrinfo_entries[i] = allocate_fast_fallback_getaddrinfo_entry();
+            if (!(arg->getaddrinfo_entries[i])) rb_syserr_fail(EAI_MEMORY, NULL);
+            arg->getaddrinfo_entries[i]->shared = arg->getaddrinfo_shared;
+        }
+
+        struct addrinfo getaddrinfo_hints[family_size];
+
+        for (int i = 0; i < family_size; i++) {
+            allocate_fast_fallback_getaddrinfo_hints(
+                &getaddrinfo_hints[i],
+                arg->families[i],
+                remote_addrinfo_hints,
+                arg->additional_flags
+            );
+
+            arg->getaddrinfo_entries[i]->hints = getaddrinfo_hints[i];
+            arg->getaddrinfo_entries[i]->ai = NULL;
+            arg->getaddrinfo_entries[i]->family = arg->families[i];
+            arg->getaddrinfo_entries[i]->refcount = 2;
+            arg->getaddrinfo_entries[i]->test_sleep_ms = 0;
+            arg->getaddrinfo_entries[i]->test_ecode = 0;
+
+            /* for testing HEv2 */
+            if (!NIL_P(test_mode_settings) && RB_TYPE_P(test_mode_settings, T_HASH)) {
+                const char *family_sym = arg->families[i] == AF_INET6 ? "ipv6" : "ipv4";
+
+                VALUE test_delay_setting = rb_hash_aref(test_mode_settings, ID2SYM(rb_intern("delay")));
+                if (!NIL_P(test_delay_setting)) {
+                    VALUE _test_delay_ms = rb_hash_aref(test_delay_setting, ID2SYM(rb_intern(family_sym)));
+                    long test_delay_ms = NIL_P(_test_delay_ms) ? 0 : _test_delay_ms;
+                    arg->getaddrinfo_entries[i]->test_sleep_ms = test_delay_ms;
+                }
+
+                VALUE test_fail_setting = rb_hash_aref(test_mode_settings, ID2SYM(rb_intern("error")));
+                if (!NIL_P(test_fail_setting)) {
+                    VALUE _test_fail_setting = rb_hash_aref(test_fail_setting, ID2SYM(rb_intern(family_sym)));
+                    if (!NIL_P(_test_fail_setting)) {
+                        VALUE error_obj = rb_funcall(_test_fail_setting, rb_intern("new"), 0);
+                        VALUE ecode = rb_funcall(error_obj, rb_intern("errno"), 0);
+                        arg->getaddrinfo_entries[i]->test_ecode = NUM2INT(ecode);
+                    }
+                }
+            }
+
+            if (do_pthread_create(&threads[i], do_fast_fallback_getaddrinfo, arg->getaddrinfo_entries[i]) != 0) {
+                last_error = EAI_AGAIN;
+                rsock_raise_resolution_error("getaddrinfo", last_error);
+            }
+            pthread_detach(threads[i]);
+        }
+
+        if (NIL_P(resolv_timeout)) {
+            user_specified_resolv_timeout_storage = (struct timeval){ -1, -1 };
+        } else {
+            struct timeval resolv_timeout_tv = rb_time_interval(resolv_timeout);
+            user_specified_resolv_timeout_storage = add_ts_to_tv(resolv_timeout_tv, now);
+        }
+        user_specified_resolv_timeout_at = &user_specified_resolv_timeout_storage;
+    }
+
+    int debug = false;
+    int count = 0;
+
+    while (true) {
+        count++;
+        if (debug) printf("[DEBUG] %d: ** Check for readying to connect **\n", count);
+        if (debug) printf("[DEBUG] %d: any_addrinfos %d\n", count, any_addrinfos(&resolution_store));
+        if (debug) printf("[DEBUG] %d: resolution_delay_expires_at %p\n", count, resolution_delay_expires_at);
+        if (debug) printf("[DEBUG] %d: connection_attempt_delay_expires_at %p\n", count, connection_attempt_delay_expires_at);
+        /* start of connection */
+        if (any_addrinfos(&resolution_store) &&
+            !resolution_delay_expires_at &&
+            !connection_attempt_delay_expires_at) {
+            if (debug) printf("[DEBUG] %d: ** Select addrinfo **\n", count);
+            while ((remote_ai = pick_addrinfo(&resolution_store, last_family))) {
+                fd = -1;
+                if (debug) printf("[DEBUG] %d: remote_ai %p\n", count, remote_ai);
+
+                #if !defined(INET6) && defined(AF_INET6)
+                if (remote_ai->ai_family == AF_INET6) {
+                    if (any_addrinfos(&resolution_store)) continue;
+                    if (!in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size)) break;
+                    if (resolution_store.is_all_finised) break;
+
+                    if (local_status < 0) {
+                        rsock_syserr_fail_host_port(last_error, syscall, arg->local.host, arg->local.serv);
+                    }
+                    rsock_syserr_fail_host_port(last_error, syscall, arg->remote.host, arg->remote.serv);
+                }
+                #endif
+
+                local_ai = NULL;
+
+                if (arg->local.res) {
+                    for (local_ai = arg->local.res->ai; local_ai; local_ai = local_ai->ai_next) {
+                        if (local_ai->ai_family == remote_ai->ai_family) break;
+                    }
+                    if (!local_ai) {
+                        if (any_addrinfos(&resolution_store)) continue;
+                        if (!in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size) &&
+                            resolution_store.is_all_finised) {
+                            /* Use a different family local address if no choice, this
+                             * will cause EAFNOSUPPORT. */
+                            last_error = EAFNOSUPPORT;
+                            rsock_syserr_fail_host_port(last_error, syscall, arg->local.host, arg->local.serv);
+                        }
+                    }
+                }
+
+                if (debug) printf("[DEBUG] %d: ** Create socket **\n", count);
+                status = rsock_socket(remote_ai->ai_family, remote_ai->ai_socktype, remote_ai->ai_protocol);
+                syscall = "socket(2)";
+                fd = status;
+                if (debug) printf("[DEBUG] %d: fd %d\n", count, fd);
+
+                if (fd < 0) {
+                    last_error = errno;
+                    fd = -1;
+
+                    if (any_addrinfos(&resolution_store) ||
+                        in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size) ||
+                        !resolution_store.is_all_finised) break;
+
+                    if (local_status < 0) {
+                        rsock_syserr_fail_host_port(last_error, syscall, arg->local.host, arg->local.serv);
+                    }
+                    rsock_syserr_fail_host_port(last_error, syscall, arg->remote.host, arg->remote.serv);
+                }
+
+                if (local_ai) {
+                    #if !defined(_WIN32) && !defined(__CYGWIN__)
+                    status = 1;
+                    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (char*)&status, (socklen_t)sizeof(status));
+                    #endif
+                    status = bind(fd, local_ai->ai_addr, local_ai->ai_addrlen);
+                    local_status = status;
+                    syscall = "bind(2)";
+
+                    if (status < 0) {
+                        last_error = errno;
+                        fd = -1;
+
+                        if (any_addrinfos(&resolution_store)) continue;
+                        if (in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size)) break;
+                        if (!resolution_store.is_all_finised) break;
+                        if (local_status < 0) {
+                           rsock_syserr_fail_host_port(last_error, syscall, arg->local.host, arg->local.serv);
+                        }
+                        rsock_syserr_fail_host_port(last_error, syscall, arg->remote.host, arg->remote.serv);
+                    }
+                }
+
+                if (debug) printf("[DEBUG] %d: ** Start to connect to %s **\n", count, (remote_ai->ai_family == 30) ? "IPv6" : "IPv4");
+                syscall = "connect(2)";
+
+                if (any_addrinfos(&resolution_store) ||
+                    in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size) ||
+                    !resolution_store.is_all_finised) {
+                    socket_nonblock_set(fd);
+                    status = connect(fd, remote_ai->ai_addr, remote_ai->ai_addrlen);
+                    last_family = remote_ai->ai_family;
+                } else {
+                    if (!NIL_P(connect_timeout)) {
+                        user_specified_connect_timeout_storage = rb_time_interval(connect_timeout);
+                        user_specified_connect_timeout_at = &user_specified_connect_timeout_storage;
+                    }
+
+                    struct timeval *timeout =
+                        (user_specified_connect_timeout_at && is_infinity(*user_specified_connect_timeout_at)) ?
+                        NULL : user_specified_connect_timeout_at;
+                    status = rsock_connect(fd, remote_ai->ai_addr, remote_ai->ai_addrlen, 0, timeout);
+                }
+
+                if (status == 0) {
+                    if (debug) printf("[DEBUG] %d: ** fd %d is connected successfully **\n", count, fd);
+                    connected_fd = fd;
+                    break;
+                }
+
+                if (errno == EINPROGRESS) {
+                    if (debug) printf("[DEBUG] %d: connection inprogress %d\n", count, fd);
+                    if (current_capacity == arg->connection_attempt_fds_size) {
+                        int new_capacity = current_capacity + initial_capacity;
+                        arg->connection_attempt_fds = (int*)realloc(arg->connection_attempt_fds, new_capacity * sizeof(int));
+                        if (!arg->connection_attempt_fds) rb_syserr_fail(EAI_MEMORY, NULL);
+                        current_capacity = new_capacity;
+                    }
+                    arg->connection_attempt_fds[arg->connection_attempt_fds_size] = fd;
+                    (arg->connection_attempt_fds_size)++;
+                    wait_arg.writefds = &writefds;
+
+                    set_timeout_tv(&connection_attempt_delay_strage, 250, now);
+                    connection_attempt_delay_expires_at = &connection_attempt_delay_strage;
+
+                    if (!any_addrinfos(&resolution_store)) {
+                        if (NIL_P(connect_timeout)) {
+                            user_specified_connect_timeout_storage = (struct timeval){ -1, -1 };
+                        } else {
+                            struct timeval connect_timeout_tv = rb_time_interval(connect_timeout);
+                            user_specified_connect_timeout_storage = add_ts_to_tv(connect_timeout_tv, now);
+                        }
+                        user_specified_connect_timeout_at = &user_specified_connect_timeout_storage;
+                    }
+
+                    if (debug) {
+                        printf("[DEBUG] %d: connection attempt fd size %d\n", count, arg->connection_attempt_fds_size);
+                        for (int i = 0; i < arg->connection_attempt_fds_size; i++) {
+                            printf("[DEBUG] %d: connection attempt fd %d\n", count, arg->connection_attempt_fds[i]);
+                        }
+                    }
+                    break;
+                }
+
+                if (debug) printf("[DEBUG] %d: connection failed\n", count);
+                last_error = errno;
+                close(fd);
+
+                if (any_addrinfos(&resolution_store)) continue;
+                if (in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size)) break;
+                if (!resolution_store.is_all_finised) break;
+
+                if (local_status < 0) {
+                    rsock_syserr_fail_host_port(last_error, syscall, arg->local.host, arg->local.serv);
+                }
+                rsock_syserr_fail_host_port(last_error, syscall, arg->remote.host, arg->remote.serv);
+            }
+        }
+
+        if (connected_fd >= 0) break;
+
+        if (debug) printf("[DEBUG] %d: resolution_delay_expires_at %p\n", count, resolution_delay_expires_at);
+        if (debug) printf("[DEBUG] %d: connection_attempt_delay_expires_at %p\n", count, connection_attempt_delay_expires_at);
+        if (debug) printf("[DEBUG] %d: user_specified_resolv_timeout_at %p\n", count, user_specified_resolv_timeout_at);
+        if (debug) printf("[DEBUG] %d: user_specified_connect_timeout_at %p\n", count, user_specified_connect_timeout_at);
+        ends_at = select_expires_at(
+            &resolution_store,
+            resolution_delay_expires_at,
+            connection_attempt_delay_expires_at,
+            user_specified_resolv_timeout_at,
+            user_specified_connect_timeout_at
+        );
+        if (ends_at) {
+            if (debug) printf("[DEBUG] %d: ends_at->tv_sec %ld\n", count, ends_at->tv_sec);
+            if (debug) printf("[DEBUG] %d: ends_at->tv_usec %d\n", count, ends_at->tv_usec);
+            delay = tv_to_timeout(ends_at, now);
+            wait_arg.delay = &delay;
+        } else {
+            wait_arg.delay = NULL;
+        }
+
+        if (debug) printf("[DEBUG] %d: ** Start to wait **\n", count);
+        if (arg->connection_attempt_fds_size) {
+            FD_ZERO(wait_arg.writefds);
+            int n = 0;
+            for (int i = 0; i < arg->connection_attempt_fds_size; i++) {
+                int cfd = arg->connection_attempt_fds[i];
+                if (cfd < 0) continue;
+                if (cfd > n) n = cfd;
+                FD_SET(cfd, wait_arg.writefds);
+            }
+            if (n > 0) n++;
+            wait_arg.nfds = n;
+        }
+
+        if (!resolution_store.is_all_finised) {
+            FD_ZERO(wait_arg.readfds);
+            FD_SET(hostname_resolution_waiter, wait_arg.readfds);
+            if ((hostname_resolution_waiter + 1) > wait_arg.nfds) {
+                wait_arg.nfds = hostname_resolution_waiter + 1;
+            }
+        }
+
+        rb_thread_call_without_gvl2(wait_fast_fallback, &wait_arg, cancel_fast_fallback, getaddrinfo_shared);
+        rb_thread_check_ints();
+
+        status = wait_arg.status;
+        syscall = "select(2)";
+        if (debug) printf("[DEBUG] %d: select(2) returned status %d\n", count, status);
+
+        now = current_clocktime_ts();
+        if (debug) printf("[DEBUG] %d: is_timeout_tv(resolution_delay_expires_at, now) %d\n", count, is_timeout_tv(resolution_delay_expires_at, now));
+        if (is_timeout_tv(resolution_delay_expires_at, now)) {
+            resolution_delay_expires_at = NULL;
+        }
+        if (debug) printf("[DEBUG] %d: is_timeout_tv(connection_attempt_delay_expires_at, now) %d\n", count, is_timeout_tv(connection_attempt_delay_expires_at, now));
+        if (is_timeout_tv(connection_attempt_delay_expires_at, now)) {
+            connection_attempt_delay_expires_at = NULL;
+        }
+
+        if (status < 0 && (errno && errno != EINTR)) rb_syserr_fail(errno, "select(2)");
+
+        if (status > 0) {
+            /* check for connection */
+            for (int i = 0; i < arg->connection_attempt_fds_size; i++) {
+                fd = arg->connection_attempt_fds[i];
+                if (fd < 0 || !FD_ISSET(fd, wait_arg.writefds)) continue;
+
+                int err;
+                socklen_t len = sizeof(err);
+
+                if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &len) == 0) {
+                    if (err == 0) {
+                        if (debug) printf("[DEBUG] %d: fd %d is connected successfully\n", count, fd);
+                        arg->connection_attempt_fds[i] = -1;
+                        connected_fd = fd;
+                        break;
+                    }
+
+                    if (debug) printf("[DEBUG] %d: fd %d is failed to connect\n", count, fd);
+                    errno = err;
+                    close(fd);
+                    arg->connection_attempt_fds[i] = -1;
+                    continue;
+                }
+            }
+
+            if (connected_fd >= 0) break;
+            last_error = errno;
+
+            if (any_addrinfos(&resolution_store) ||
+                in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size) ||
+                !resolution_store.is_all_finised) {
+                if (!in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size)) {
+                    user_specified_connect_timeout_at = NULL;
+                }
+            } else {
+                if (local_status < 0) {
+                    rsock_syserr_fail_host_port(last_error, syscall, arg->local.host, arg->local.serv);
+                }
+                rsock_syserr_fail_host_port(last_error, syscall, arg->remote.host, arg->remote.serv);
+            }
+
+            /* check for hostname resolution */
+            if (!resolution_store.is_all_finised && FD_ISSET(hostname_resolution_waiter, wait_arg.readfds)) {
+                if (debug) printf("[DEBUG] %d: ** Hostname resolution finished **\n", count);
+                while (true) {
+                    resolved_type_size = read(hostname_resolution_waiter, resolved_type, sizeof(resolved_type) - 1);
+
+                    if (resolved_type_size > 0) {
+                        resolved_type[resolved_type_size] = '\0';
+
+                        if (strcmp(resolved_type, IPV6_HOSTNAME_RESOLVED) == 0) { // IPv6解決
+                            if (debug) printf("[DEBUG] %d: ** Resolved IPv6 **\n", count);
+                            resolution_store.v6.ai = arg->getaddrinfo_entries[IPV6_ENTRY_POS]->ai;
+                            resolution_store.v6.finished = true;
+                            if (arg->getaddrinfo_entries[IPV6_ENTRY_POS]->err) {
+                                last_error = arg->getaddrinfo_entries[IPV6_ENTRY_POS]->err;
+                                resolution_store.v6.succeed = false;
+                            } else {
+                                resolution_store.v6.succeed = true;
+                            }
+                            if (resolution_store.v4.finished) {
+                                if (debug) printf("[DEBUG] %d: ** All hostname resolution is finished **\n", count);
+                                resolution_store.is_all_finised = true;
+                                wait_arg.readfds = NULL;
+                                resolution_delay_expires_at = NULL;
+                                user_specified_resolv_timeout_at = NULL;
+                                break;
+                            }
+                        } else if (strcmp(resolved_type, IPV4_HOSTNAME_RESOLVED) == 0) { // IPv4解決
+                            if (debug) printf("[DEBUG] %d: ** Resolved IPv4 **\n", count);
+                            resolution_store.v4.ai = arg->getaddrinfo_entries[IPV4_ENTRY_POS]->ai;
+                            resolution_store.v4.finished = true;
+
+                            if (arg->getaddrinfo_entries[IPV4_ENTRY_POS]->err) {
+                                last_error = arg->getaddrinfo_entries[IPV4_ENTRY_POS]->err;
+                                resolution_store.v4.succeed = false;
+                            } else {
+                                resolution_store.v4.succeed = true;
+                            }
+
+                            if (resolution_store.v6.finished) {
+                                if (debug) printf("[DEBUG] %d: ** All hostname resolution is finished **\n", count);
+                                resolution_store.is_all_finised = true;
+                                wait_arg.readfds = NULL;
+                                resolution_delay_expires_at = NULL;
+                                user_specified_resolv_timeout_at = NULL;
+                                break;
+                            }
+                        }
+                    } else if (resolved_type_size == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                        if (debug) printf("[DEBUG] %d: ** hostname_resolution_waiter is now empty **\n", count);
+                        errno = 0;
+                        break;
+                    } else {
+                        if (debug) printf("[DEBUG] %d: ** Hostname Resolution may be failed **\n", count);
+                        last_error = errno;
+                        if (!any_addrinfos(&resolution_store) &&
+                            !in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size) &&
+                            resolution_store.is_all_finised) {
+                            if (local_status < 0) {
+                                rsock_syserr_fail_host_port(last_error, syscall, arg->local.host, arg->local.serv);
+                            }
+                            rsock_syserr_fail_host_port(last_error, syscall, arg->remote.host, arg->remote.serv);
+                        }
+                    }
+
+                    if (!resolution_store.v6.finished && resolution_store.v4.succeed) {
+                        if (debug) printf("[DEBUG] %d: Resolution Delay is ready\n", count);
+                        set_timeout_tv(&resolution_delay_storage, 50, now);
+                        resolution_delay_expires_at = &resolution_delay_storage;
+                    }
+                }
+            }
+
+            status = wait_arg.status = 0;
+        }
+
+        if (debug) printf("[DEBUG] %d: ** Check for exiting **\n", count);
+        if (debug) printf("[DEBUG] %d: any_addrinfos %d\n", count, any_addrinfos(&resolution_store));
+        if (!any_addrinfos(&resolution_store)) {
+            if (debug) printf("[DEBUG] %d: in_progress_fds %d\n", count, in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size));
+            if (debug) printf("[DEBUG] %d: resolution_store.is_all_finised %d\n", count, resolution_store.is_all_finised);
+            if (!in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size) && resolution_store.is_all_finised) {
+                if (local_status < 0) {
+                    rsock_syserr_fail_host_port(last_error, syscall, arg->local.host, arg->local.serv);
+                }
+                rsock_syserr_fail_host_port(last_error, syscall, arg->remote.host, arg->remote.serv);
+            }
+
+            if (debug) printf("[DEBUG] %d: user_specified_resolv_timeout_at %p\n", count, user_specified_resolv_timeout_at);
+            if (debug) printf("[DEBUG] %d: is_timeout_tv(user_specified_resolv_timeout_at, now) %d\n", count, is_timeout_tv(user_specified_resolv_timeout_at, now));
+            if (debug) printf("[DEBUG] %d: user_specified_connect_timeout_at %p\n", count, user_specified_connect_timeout_at);
+            if (debug) printf("[DEBUG] %d: is_timeout_tv(user_specified_connect_timeout_at, now) %d\n", count, is_timeout_tv(user_specified_connect_timeout_at, now));
+            if ((is_timeout_tv(user_specified_resolv_timeout_at, now) || resolution_store.is_all_finised) &&
+                (is_timeout_tv(user_specified_connect_timeout_at, now) || !in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size))) {
+                VALUE errno_module = rb_const_get(rb_cObject, rb_intern("Errno"));
+                VALUE etimedout_error = rb_const_get(errno_module, rb_intern("ETIMEDOUT"));
+                rb_raise(etimedout_error, "user specified timeout");
+            }
+        }
+        if (debug && arg->connection_attempt_fds_size > 0) {
+            printf("[DEBUG] %d: connection attempt fds: ", count);
+            for(int i = 0; i < arg->connection_attempt_fds_size; i++) {
+                printf("arg->connection_attempt_fds[%d]=%d, ", i, arg->connection_attempt_fds[i]);
+            }
+            printf("\n");
+        }
+        if (debug) puts("------------");
+    }
+
+    /* create new instance */
+    return rsock_init_sock(arg->sock, connected_fd);
+}
+
+static VALUE
+fast_fallback_inetsock_cleanup(VALUE v)
+{
+    // int debug = true;
+    int debug = false;
+    struct fast_fallback_inetsock_arg *arg = (void *)v;
+    struct fast_fallback_getaddrinfo_shared *getaddrinfo_shared = arg->getaddrinfo_shared;
+
+    if (arg->remote.res) {
+        rb_freeaddrinfo(arg->remote.res);
+        arg->remote.res = 0;
+    }
+    if (arg->local.res) {
+        rb_freeaddrinfo(arg->local.res);
+        arg->local.res = 0;
+    }
+    if (arg->fd >= 0) {
+        close(arg->fd);
+    }
+
+    if (getaddrinfo_shared) {
+        int shared_need_free = 0;
+        int need_free[2] = { 0, 0 };
+
+        rb_nativethread_lock_lock(getaddrinfo_shared->lock);
+        {
+            for (int i = 0; i < arg->family_size; i++) {
+                if (arg->getaddrinfo_entries[i] && --(arg->getaddrinfo_entries[i]->refcount) == 0) {
+                    need_free[i] = 1;
+                }
+            }
+            if (--(getaddrinfo_shared->refcount) == 0) {
+                shared_need_free = 1;
+            }
+        }
+        rb_nativethread_lock_unlock(getaddrinfo_shared->lock);
+
+        for (int i = 0; i < arg->family_size; i++) {
+            if (need_free[i]) free_fast_fallback_getaddrinfo_entry(&arg->getaddrinfo_entries[i]);
+        }
+        if (shared_need_free) free_fast_fallback_getaddrinfo_shared(&getaddrinfo_shared);
+    }
+
+    int connection_attempt_fd;
+    int error = 0;
+    socklen_t len = sizeof(error);
+
+    for (int i = 0; i < arg->connection_attempt_fds_size; i++) {
+        connection_attempt_fd = arg->connection_attempt_fds[i];
+        if (debug) printf("fast_fallback_inetsock_cleanup: connection_attempt_fd %d\n", connection_attempt_fd);
+        if (connection_attempt_fd >= 0) {
+            getsockopt(connection_attempt_fd, SOL_SOCKET, SO_ERROR, &error, &len);
+            if (error == 0) {
+                if (debug) printf("fast_fallback_inetsock_cleanup: fd %d is shutdowned\n", connection_attempt_fd);
+                shutdown(connection_attempt_fd, SHUT_RDWR);
+            }
+            close(connection_attempt_fd);
+            if (debug) {
+                if (fcntl(connection_attempt_fd, F_GETFL) == -1 && errno == EBADF) {
+                    printf("fast_fallback_inetsock_cleanup: fd %d is closed\n", connection_attempt_fd);
+                }
+            }
+        }
+    }
+
+    if (arg->connection_attempt_fds) {
+        free(arg->connection_attempt_fds);
+        arg->connection_attempt_fds = NULL;
+    }
+
+    return Qnil;
+}
+
 VALUE
-rsock_init_inetsock(VALUE self, VALUE remote_host, VALUE remote_serv, VALUE local_host, VALUE local_serv, int type, VALUE resolv_timeout, VALUE connect_timeout)
+rsock_init_inetsock(VALUE sock, VALUE remote_host, VALUE remote_serv, VALUE local_host, VALUE local_serv, int type, VALUE resolv_timeout, VALUE connect_timeout, VALUE fast_fallback, VALUE test_mode_settings)
 {
     struct inetsock_arg arg;
     arg.self = self;
@@ -184,6 +1103,83 @@ rsock_init_inetsock(VALUE self, VALUE remote_host, VALUE remote_serv, VALUE loca
     arg.type = type;
     arg.resolv_timeout = resolv_timeout;
     arg.connect_timeout = connect_timeout;
+
+    if (type == INET_CLIENT && FAST_FALLBACK_INIT_INETSOCK_IMPL == 1 && RTEST(fast_fallback)) {
+        char *hostp, *portp;
+        char hbuf[NI_MAXHOST], pbuf[NI_MAXSERV];
+        int additional_flags = 0;
+        hostp = host_str(arg.remote.host, hbuf, sizeof(hbuf), &additional_flags);
+        portp = port_str(arg.remote.serv, pbuf, sizeof(pbuf), &additional_flags);
+
+        if (!is_specified_ip_address(hostp)) {
+            int target_families[2] = { 0, 0 };
+            int resolving_family_size = 0;
+
+            /*
+             * Maybe also accept a local address
+             */
+            if (!NIL_P(arg.local.host) || !NIL_P(arg.local.serv)) {
+                arg.local.res = rsock_addrinfo(
+                    arg.local.host,
+                    arg.local.serv,
+                    AF_UNSPEC,
+                    SOCK_STREAM,
+                    0
+                );
+
+                struct addrinfo *tmp_p = arg.local.res->ai;
+                for (tmp_p; tmp_p != NULL; tmp_p = tmp_p->ai_next) {
+                    if (target_families[0] == 0 && tmp_p->ai_family == AF_INET6) {
+                        target_families[0] = AF_INET6;
+                        resolving_family_size++;
+                    }
+                    if (target_families[1] == 0 && tmp_p->ai_family == AF_INET) {
+                        target_families[1] = AF_INET;
+                        resolving_family_size++;
+                    }
+                }
+            }  else {
+                resolving_family_size = 2;
+                target_families[0] = AF_INET6;
+                target_families[1] = AF_INET;
+            }
+
+            struct fast_fallback_inetsock_arg fast_fallback_arg;
+            memset(&fast_fallback_arg, 0, sizeof(fast_fallback_arg));
+
+            fast_fallback_arg.sock = arg.sock;
+            fast_fallback_arg.remote.host = arg.remote.host;
+            fast_fallback_arg.remote.serv = arg.remote.serv;
+            fast_fallback_arg.remote.res = arg.remote.res;
+            fast_fallback_arg.local.host = arg.local.host;
+            fast_fallback_arg.local.serv = arg.local.serv;
+            fast_fallback_arg.local.res = arg.local.res;
+            fast_fallback_arg.type = arg.type;
+            fast_fallback_arg.fd = arg.fd;
+            fast_fallback_arg.resolv_timeout = arg.resolv_timeout;
+            fast_fallback_arg.connect_timeout = arg.connect_timeout;
+            fast_fallback_arg.hostp = hostp;
+            fast_fallback_arg.portp = portp;
+            fast_fallback_arg.additional_flags = additional_flags;
+            fast_fallback_arg.cancelled = false;
+
+            int resolving_families[resolving_family_size];
+            int resolving_family_index = 0;
+            for (int i = 0; 2 > i; i++) {
+                if (target_families[i] != 0) {
+                    resolving_families[resolving_family_index] = target_families[i];
+                    resolving_family_index++;
+                }
+            }
+            fast_fallback_arg.families = resolving_families;
+            fast_fallback_arg.family_size = resolving_family_size;
+            fast_fallback_arg.test_mode_settings = test_mode_settings;
+
+            return rb_ensure(init_fast_fallback_inetsock_internal, (VALUE)&fast_fallback_arg,
+                             fast_fallback_inetsock_cleanup, (VALUE)&fast_fallback_arg);
+        }
+    }
+
     return rb_ensure(init_inetsock_internal, (VALUE)&arg,
                      inetsock_cleanup, (VALUE)&arg);
 }

--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -272,6 +272,28 @@ allocate_fast_fallback_getaddrinfo_hints(struct addrinfo *hints, int family, int
     hints->ai_flags |= additional_flags;
 }
 
+static int*
+allocate_connection_attempt_fds(int additional_capacity)
+{
+    int *fds = (int *)malloc(additional_capacity * sizeof(int));
+    if (!fds) rb_syserr_fail(errno, "malloc(3)");
+    for (int i = 0; i < additional_capacity; i++) fds[i] = -1;
+    return fds;
+}
+
+static int
+reallocate_connection_attempt_fds(int *fds, int current_capacity, int additional_capacity)
+{
+    int new_capacity = current_capacity + additional_capacity;
+
+    if (realloc(fds, new_capacity * sizeof(int)) == NULL) {
+        rb_syserr_fail(errno, "realloc(3)");
+    }
+
+    for (int i = current_capacity; i < new_capacity; i++) fds[i] = -1;
+    return new_capacity;
+}
+
 struct wait_fast_fallback_arg
 {
     int status, nfds;
@@ -493,12 +515,26 @@ socket_nonblock_set(int fd)
 }
 
 static int
-in_progress_fds(const int *fds, int fds_size)
+in_progress_fds(int fds_size)
 {
-    for (int i = 0; i < fds_size; i++) {
-        if (fds[i] > 0) return true;
+    return fds_size > 0;
+}
+
+static void
+remove_connection_attempt_fd(int *fds, int *fds_size, int removing_fd) {
+    int i, j;
+
+    for (i = 0; i < *fds_size; i++) {
+        if (fds[i] != removing_fd) continue;
+
+        for (j = i; j < *fds_size - 1; j++) {
+            fds[j] = fds[j + 1];
+        }
+
+        (*fds_size)--;
+        fds[*fds_size] = -1;
+        break;
     }
-    return false;
 }
 
 struct fast_fallback_error
@@ -551,10 +587,9 @@ init_fast_fallback_inetsock_internal(VALUE v)
 
     int last_family = 0;
 
-    int initial_capacity = 10;
-    int current_capacity = initial_capacity;
-    arg->connection_attempt_fds = (int *)malloc(initial_capacity * sizeof(int));
-    if (!arg->connection_attempt_fds) rb_syserr_fail(errno, "malloc(3)");
+    int additional_capacity = 10;
+    int current_capacity = additional_capacity;
+    arg->connection_attempt_fds = allocate_connection_attempt_fds(additional_capacity);
     arg->connection_attempt_fds_size = 0;
 
     struct timeval resolution_delay_storage;
@@ -604,8 +639,8 @@ init_fast_fallback_inetsock_internal(VALUE v)
         arg->getaddrinfo_shared = allocate_fast_fallback_getaddrinfo_shared();
         if (!arg->getaddrinfo_shared) rb_syserr_fail(errno, "calloc(3)");
 
-        arg->getaddrinfo_shared->lock = malloc(sizeof(rb_nativethread_lock_t));
-        if (!arg->getaddrinfo_shared->lock) rb_syserr_fail(errno, "malloc(3)");
+        arg->getaddrinfo_shared->lock = calloc(1, sizeof(rb_nativethread_lock_t));
+        if (!arg->getaddrinfo_shared->lock) rb_syserr_fail(errno, "calloc(3)");
         rb_nativethread_lock_initialize(arg->getaddrinfo_shared->lock);
 
         arg->getaddrinfo_shared->node = arg->hostp ? strdup(arg->hostp) : NULL;
@@ -686,7 +721,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                 #if !defined(INET6) && defined(AF_INET6)
                 if (remote_ai->ai_family == AF_INET6) {
                     if (any_addrinfos(&resolution_store)) continue;
-                    if (!in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size)) break;
+                    if (!in_progress_fds(arg->connection_attempt_fds_size)) break;
                     if (resolution_store.is_all_finised) break;
 
                     if (local_status < 0) {
@@ -712,7 +747,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                     }
                     if (!local_ai) {
                         if (any_addrinfos(&resolution_store)) continue;
-                        if (in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size)) break;
+                        if (in_progress_fds(arg->connection_attempt_fds_size)) break;
                         if (!resolution_store.is_all_finised) break;
 
                         /* Use a different family local address if no choice, this
@@ -729,7 +764,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                     last_error.ecode = errno;
 
                     if (any_addrinfos(&resolution_store)) continue;
-                    if (in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size)) break;
+                    if (in_progress_fds(arg->connection_attempt_fds_size)) break;
                     if (!resolution_store.is_all_finised) break;
 
                     if (local_status < 0) {
@@ -765,7 +800,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                         close(fd);
 
                         if (any_addrinfos(&resolution_store)) continue;
-                        if (in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size)) break;
+                        if (in_progress_fds(arg->connection_attempt_fds_size)) break;
                         if (!resolution_store.is_all_finised) break;
 
                         if (local_status < 0) {
@@ -786,7 +821,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                 syscall = "connect(2)";
 
                 if (any_addrinfos(&resolution_store) ||
-                    in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size) ||
+                    in_progress_fds(arg->connection_attempt_fds_size) ||
                     !resolution_store.is_all_finised) {
                     socket_nonblock_set(fd);
                     status = connect(fd, remote_ai->ai_addr, remote_ai->ai_addrlen);
@@ -811,13 +846,11 @@ init_fast_fallback_inetsock_internal(VALUE v)
 
                 if (errno == EINPROGRESS) {
                     if (current_capacity == arg->connection_attempt_fds_size) {
-                        int new_capacity = current_capacity + initial_capacity;
-                        arg->connection_attempt_fds = (int*)realloc(
+                        current_capacity = reallocate_connection_attempt_fds(
                             arg->connection_attempt_fds,
-                            new_capacity * sizeof(int)
+                            current_capacity,
+                            additional_capacity
                         );
-                        if (!arg->connection_attempt_fds) rb_syserr_fail(errno, "realloc(3)");
-                        current_capacity = new_capacity;
                     }
                     arg->connection_attempt_fds[arg->connection_attempt_fds_size] = fd;
                     (arg->connection_attempt_fds_size)++;
@@ -849,7 +882,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                 }
 
                 if (any_addrinfos(&resolution_store)) continue;
-                if (in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size)) break;
+                if (in_progress_fds(arg->connection_attempt_fds_size)) break;
                 if (!resolution_store.is_all_finised) break;
 
                 if (local_status < 0) {
@@ -894,6 +927,8 @@ init_fast_fallback_inetsock_internal(VALUE v)
             }
             if (n > 0) n++;
             wait_arg.nfds = n;
+        } else {
+            wait_arg.writefds = NULL;
         }
 
         FD_ZERO(wait_arg.readfds);
@@ -935,15 +970,23 @@ init_fast_fallback_inetsock_internal(VALUE v)
 
                 if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &len) == 0) {
                     if (err == 0) { /* success */
-                        arg->connection_attempt_fds[i] = -1;
+                        remove_connection_attempt_fd(
+                            arg->connection_attempt_fds,
+                            &arg->connection_attempt_fds_size,
+                            fd
+                        );
                         connected_fd = fd;
                         break;
-                    }
+                    };
 
                     /* fail */
                     errno = err;
                     close(fd);
-                    arg->connection_attempt_fds[i] = -1;
+                    remove_connection_attempt_fd(
+                        arg->connection_attempt_fds,
+                        &arg->connection_attempt_fds_size,
+                        fd
+                    );
                     continue;
                 }
             }
@@ -953,9 +996,9 @@ init_fast_fallback_inetsock_internal(VALUE v)
             last_error.ecode = errno;
 
             if (any_addrinfos(&resolution_store) ||
-                in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size) ||
+                in_progress_fds(arg->connection_attempt_fds_size) ||
                 !resolution_store.is_all_finised) {
-                if (!in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size)) {
+                if (!in_progress_fds(arg->connection_attempt_fds_size)) {
                     user_specified_connect_timeout_at = NULL;
                 }
             } else {
@@ -1044,7 +1087,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
         }
 
         if (!any_addrinfos(&resolution_store)) {
-            if (!in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size) &&
+            if (!in_progress_fds(arg->connection_attempt_fds_size) &&
                 resolution_store.is_all_finised) {
                 if (local_status < 0) {
                     host = arg->local.host;
@@ -1063,7 +1106,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
             if ((is_timeout_tv(user_specified_resolv_timeout_at, now) ||
                 resolution_store.is_all_finised) &&
                 (is_timeout_tv(user_specified_connect_timeout_at, now) ||
-                !in_progress_fds(arg->connection_attempt_fds, arg->connection_attempt_fds_size))) {
+                !in_progress_fds(arg->connection_attempt_fds_size))) {
                 VALUE errno_module = rb_const_get(rb_cObject, rb_intern("Errno"));
                 VALUE etimedout_error = rb_const_get(errno_module, rb_intern("ETIMEDOUT"));
                 rb_raise(etimedout_error, "user specified timeout");

--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -812,8 +812,8 @@ init_fast_fallback_inetsock_internal(VALUE v)
             user_specified_connect_timeout_at
         );
         if (ends_at) {
-            if (debug) printf("[DEBUG] %d: ends_at->tv_sec %ld\n", count, ends_at->tv_sec);
-            if (debug) printf("[DEBUG] %d: ends_at->tv_usec %d\n", count, ends_at->tv_usec);
+            if (debug) printf("[DEBUG] %d: ends_at->tv_sec %"PRI_TIMET_PREFIX"d\n", count, ends_at->tv_sec);
+            if (debug) printf("[DEBUG] %d: ends_at->tv_usec %d\n", count, (int)ends_at->tv_usec);
             delay = tv_to_timeout(ends_at, now);
             wait_arg.delay = &delay;
         } else {

--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -695,7 +695,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                 }
             }
 
-            if (do_pthread_create(&threads[i], do_fast_fallback_getaddrinfo, arg->getaddrinfo_entries[i]) != 0) {
+            if (raddrinfo_pthread_create(&threads[i], do_fast_fallback_getaddrinfo, arg->getaddrinfo_entries[i]) != 0) {
                 rsock_raise_resolution_error("getaddrinfo(3)", EAI_AGAIN);
             }
             pthread_detach(threads[i]);

--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -972,7 +972,8 @@ init_fast_fallback_inetsock_internal(VALUE v)
                         if (strcmp(resolved_type, IPV6_HOSTNAME_RESOLVED) == 0) {
                             resolution_store.v6.finished = true;
 
-                            if (arg->getaddrinfo_entries[IPV6_ENTRY_POS]->err) {
+                            if (arg->getaddrinfo_entries[IPV6_ENTRY_POS]->err &&
+                                arg->getaddrinfo_entries[IPV6_ENTRY_POS]->err != EAI_ADDRFAMILY) {
                                 last_error.type = RESOLUTION_ERROR;
                                 last_error.ecode = arg->getaddrinfo_entries[IPV6_ENTRY_POS]->err;
                                 syscall = "getaddrinfo(3)";

--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -880,12 +880,10 @@ init_fast_fallback_inetsock_internal(VALUE v)
             wait_arg.nfds = n;
         }
 
-        if (!resolution_store.is_all_finised) {
-            FD_ZERO(wait_arg.readfds);
-            FD_SET(hostname_resolution_waiter, wait_arg.readfds);
-            if ((hostname_resolution_waiter + 1) > wait_arg.nfds) {
-                wait_arg.nfds = hostname_resolution_waiter + 1;
-            }
+        FD_ZERO(wait_arg.readfds);
+        FD_SET(hostname_resolution_waiter, wait_arg.readfds);
+        if ((hostname_resolution_waiter + 1) > wait_arg.nfds) {
+            wait_arg.nfds = hostname_resolution_waiter + 1;
         }
 
         rb_thread_call_without_gvl2(
@@ -895,6 +893,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
             arg->getaddrinfo_shared
         );
         rb_thread_check_ints();
+        if (errno == EINTR || arg->cancelled) break;
 
         status = wait_arg.status;
         syscall = "select(2)";
@@ -983,7 +982,6 @@ init_fast_fallback_inetsock_internal(VALUE v)
                             }
                             if (resolution_store.v4.finished) {
                                 resolution_store.is_all_finised = true;
-                                wait_arg.readfds = NULL;
                                 resolution_delay_expires_at = NULL;
                                 user_specified_resolv_timeout_at = NULL;
                                 break;
@@ -1002,7 +1000,6 @@ init_fast_fallback_inetsock_internal(VALUE v)
 
                             if (resolution_store.v6.finished) {
                                 resolution_store.is_all_finised = true;
-                                wait_arg.readfds = NULL;
                                 resolution_delay_expires_at = NULL;
                                 user_specified_resolv_timeout_at = NULL;
                                 break;
@@ -1084,6 +1081,8 @@ init_fast_fallback_inetsock_internal(VALUE v)
             }
         }
     }
+
+    rb_thread_check_ints();
 
     /* create new instance */
     return rsock_init_sock(arg->sock, connected_fd);

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -469,7 +469,7 @@ cancel_getaddrinfo(void *ptr)
     rb_nativethread_lock_unlock(&arg->lock);
 }
 
-static int
+int
 do_pthread_create(pthread_t *th, void *(*start_routine) (void *), void *arg)
 {
     int limit = 3, ret;
@@ -822,7 +822,7 @@ str_is_number(const char *p)
     ((ptr)[0] == name[0] && \
      rb_strlen_lit(name) == (len) && memcmp(ptr, name, len) == 0)
 
-static char*
+char*
 host_str(VALUE host, char *hbuf, size_t hbuflen, int *flags_ptr)
 {
     if (NIL_P(host)) {
@@ -861,7 +861,7 @@ host_str(VALUE host, char *hbuf, size_t hbuflen, int *flags_ptr)
     }
 }
 
-static char*
+char*
 port_str(VALUE port, char *pbuf, size_t pbuflen, int *flags_ptr)
 {
     if (NIL_P(port)) {
@@ -3022,6 +3022,109 @@ rsock_io_socket_addrinfo(VALUE io, struct sockaddr *addr, socklen_t len)
     }
 
     UNREACHABLE_RETURN(Qnil);
+}
+
+void
+free_fast_fallback_getaddrinfo_shared(struct fast_fallback_getaddrinfo_shared **shared)
+{
+    free((*shared)->node);
+    (*shared)->node = NULL;
+    free((*shared)->service);
+    (*shared)->service = NULL;
+    close((*shared)->notify);
+    close((*shared)->wait);
+    rb_nativethread_lock_destroy((*shared)->lock);
+    free(*shared);
+    *shared = NULL;
+}
+
+void
+free_fast_fallback_getaddrinfo_entry(struct fast_fallback_getaddrinfo_entry **entry)
+{
+    if ((*entry)->ai) {
+        freeaddrinfo((*entry)->ai);
+        (*entry)->ai = NULL;
+    }
+    free(*entry);
+    *entry = NULL;
+}
+
+void *
+do_fast_fallback_getaddrinfo(void *ptr)
+{
+    int debug = false;
+    struct fast_fallback_getaddrinfo_entry *entry = (struct fast_fallback_getaddrinfo_entry *)ptr;
+    struct fast_fallback_getaddrinfo_shared *shared = entry->shared;
+    int err = 0, need_free = 0, shared_need_free = 0;
+
+    err = numeric_getaddrinfo(shared->node, shared->service, &entry->hints, &entry->ai);
+
+    if (debug) printf("do_fast_fallback_getaddrinfo %d starts to getaddrinfo \n", entry->family);
+
+    if (err != 0) {
+        err = getaddrinfo(shared->node, shared->service, &entry->hints, &entry->ai);
+       #ifdef __linux__
+       /* On Linux (mainly Ubuntu 13.04) /etc/nsswitch.conf has mdns4 and
+        * it cause getaddrinfo to return EAI_SYSTEM/ENOENT. [ruby-list:49420]
+        */
+       if (err == EAI_SYSTEM && errno == ENOENT)
+           err = EAI_NONAME;
+       #endif
+    }
+    if (debug) printf("do_fast_fallback_getaddrinfo %d finished to getaddrinfo\n", entry->family);
+
+    /* for testing HEv2 */
+    if (entry->test_sleep_ms > 0) {
+        struct timespec sleep_ts;
+        sleep_ts.tv_sec = entry->test_sleep_ms / 1000;
+        sleep_ts.tv_nsec = (entry->test_sleep_ms % 1000) * 1000000L;
+        if (sleep_ts.tv_nsec >= 1000000000L) {
+            sleep_ts.tv_sec += sleep_ts.tv_nsec / 1000000000L;
+            sleep_ts.tv_nsec = sleep_ts.tv_nsec % 1000000000L;
+        }
+        if (debug) printf("do_fast_fallback_getaddrinfo %d starts to nanosleep %ld:%ld\n", entry->family, sleep_ts.tv_sec, sleep_ts.tv_nsec);
+        nanosleep(&sleep_ts, NULL);
+        if (debug) printf("do_fast_fallback_getaddrinfo %d finished to nanosleep %ld:%ld\n", entry->family, sleep_ts.tv_sec, sleep_ts.tv_nsec);
+    }
+    if (entry->test_ecode > 0) {
+        err = entry->test_ecode;
+        if (entry->ai) {
+            freeaddrinfo(entry->ai);
+            entry->ai = NULL;
+        }
+        if (debug) printf("do_fast_fallback_getaddrinfo %d fail\n", entry->family);
+    }
+
+    rb_nativethread_lock_lock(shared->lock);
+    {
+        entry->err = err;
+        if (*shared->cancelled) {
+            if (entry->ai) {
+                freeaddrinfo(entry->ai);
+                entry->ai = NULL;
+            }
+        } else {
+            if (debug) printf("do_fast_fallback_getaddrinfo %d starts to write\n", entry->family);
+            if (entry->family == AF_INET6) {
+                write(shared->notify, IPV6_HOSTNAME_RESOLVED, strlen(IPV6_HOSTNAME_RESOLVED));
+            } else if (entry->family == AF_INET) {
+                write(shared->notify, IPV4_HOSTNAME_RESOLVED, strlen(IPV4_HOSTNAME_RESOLVED));
+            }
+            if (debug) printf("do_fast_fallback_getaddrinfo %d finished to write\n", entry->family);
+        }
+        if (--(entry->refcount) == 0) need_free = 1;
+        if (--(shared->refcount) == 0) shared_need_free = 1;
+    }
+    rb_nativethread_lock_unlock(shared->lock);
+
+    if (need_free && entry) {
+        free_fast_fallback_getaddrinfo_entry(&entry);
+    }
+    if (shared_need_free && shared) {
+        free_fast_fallback_getaddrinfo_shared(&shared);
+    }
+
+    return 0;
 }
 
 /*

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -3024,6 +3024,8 @@ rsock_io_socket_addrinfo(VALUE io, struct sockaddr *addr, socklen_t len)
     UNREACHABLE_RETURN(Qnil);
 }
 
+#if FAST_FALLBACK_INIT_INETSOCK_IMPL == 1
+
 void
 free_fast_fallback_getaddrinfo_shared(struct fast_fallback_getaddrinfo_shared **shared)
 {
@@ -3117,6 +3119,8 @@ do_fast_fallback_getaddrinfo(void *ptr)
 
     return 0;
 }
+
+#endif
 
 /*
  * Addrinfo class

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -3099,10 +3099,10 @@ do_fast_fallback_getaddrinfo(void *ptr)
                 entry->ai = NULL;
             }
         } else {
-            const char *notification = entry->family == AF_INET6 ?
+            const char notification = entry->family == AF_INET6 ?
             IPV6_HOSTNAME_RESOLVED : IPV4_HOSTNAME_RESOLVED;
 
-            if ((write(shared->notify, notification, strlen(notification))) < 0) {
+            if ((write(shared->notify, &notification, strlen(&notification))) < 0) {
                 entry->err = errno;
                 entry->has_syserr = true;
             }

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -3099,10 +3099,12 @@ do_fast_fallback_getaddrinfo(void *ptr)
                 entry->ai = NULL;
             }
         } else {
-            if (entry->family == AF_INET6) {
-                write(shared->notify, IPV6_HOSTNAME_RESOLVED, strlen(IPV6_HOSTNAME_RESOLVED));
-            } else if (entry->family == AF_INET) {
-                write(shared->notify, IPV4_HOSTNAME_RESOLVED, strlen(IPV4_HOSTNAME_RESOLVED));
+            const char *notification = entry->family == AF_INET6 ?
+            IPV6_HOSTNAME_RESOLVED : IPV4_HOSTNAME_RESOLVED;
+
+            if ((write(shared->notify, notification, strlen(notification))) < 0) {
+                entry->err = errno;
+                entry->has_syserr = true;
             }
         }
         if (--(entry->refcount) == 0) need_free = 1;

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -3082,7 +3082,7 @@ do_fast_fallback_getaddrinfo(void *ptr)
         }
         nanosleep(&sleep_ts, NULL);
     }
-    if (entry->test_ecode > 0) {
+    if (entry->test_ecode != 0) {
         err = entry->test_ecode;
         if (entry->ai) {
             freeaddrinfo(entry->ai);

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -470,7 +470,7 @@ cancel_getaddrinfo(void *ptr)
 }
 
 int
-do_pthread_create(pthread_t *th, void *(*start_routine) (void *), void *arg)
+raddrinfo_pthread_create(pthread_t *th, void *(*start_routine) (void *), void *arg)
 {
     int limit = 3, ret;
     do {
@@ -505,7 +505,7 @@ start:
     }
 
     pthread_t th;
-    if (do_pthread_create(&th, fork_safe_do_getaddrinfo, arg) != 0) {
+    if (raddrinfo_pthread_create(&th, fork_safe_do_getaddrinfo, arg) != 0) {
         int err = errno;
         free_getaddrinfo_arg(arg);
         errno = err;
@@ -726,7 +726,7 @@ start:
     }
 
     pthread_t th;
-    if (do_pthread_create(&th, do_getnameinfo, arg) != 0) {
+    if (raddrinfo_pthread_create(&th, do_getnameinfo, arg) != 0) {
         int err = errno;
         free_getnameinfo_arg(arg);
         errno = err;

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -425,8 +425,7 @@ char *port_str(VALUE port, char *pbuf, size_t pbuflen, int *flags_ptr);
 #    define IPV6_HOSTNAME_RESOLVED "1"
 #    define IPV4_HOSTNAME_RESOLVED "2"
 #    define SELECT_CANCELLED "3"
-#    define IPV6_ENTRY_POS 0
-#    define IPV4_ENTRY_POS 1
+
 struct fast_fallback_getaddrinfo_shared {
     int wait, notify, refcount, connection_attempt_fds_size;
     int *connection_attempt_fds, *cancelled;

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -426,7 +426,8 @@ char *port_str(VALUE port, char *pbuf, size_t pbuflen, int *flags_ptr);
 #    define IPV4_HOSTNAME_RESOLVED "2"
 #    define SELECT_CANCELLED "3"
 
-struct fast_fallback_getaddrinfo_shared {
+struct fast_fallback_getaddrinfo_shared
+{
     int wait, notify, refcount, connection_attempt_fds_size;
     int *connection_attempt_fds, *cancelled;
     char *node, *service;

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -445,7 +445,7 @@ struct fast_fallback_getaddrinfo_entry
     int test_ecode;
 };
 
-int do_pthread_create(pthread_t *th, void *(*start_routine) (void *), void *arg);
+int raddrinfo_pthread_create(pthread_t *th, void *(*start_routine) (void *), void *arg);
 void *do_fast_fallback_getaddrinfo(void *ptr);
 void free_fast_fallback_getaddrinfo_entry(struct fast_fallback_getaddrinfo_entry **entry);
 void free_fast_fallback_getaddrinfo_shared(struct fast_fallback_getaddrinfo_shared **shared);

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -422,9 +422,9 @@ char *port_str(VALUE port, char *pbuf, size_t pbuflen, int *flags_ptr);
 #  else
 #    include "ruby/thread_native.h"
 #    define FAST_FALLBACK_INIT_INETSOCK_IMPL 1
-#    define IPV6_HOSTNAME_RESOLVED "1"
-#    define IPV4_HOSTNAME_RESOLVED "2"
-#    define SELECT_CANCELLED "3"
+#    define IPV6_HOSTNAME_RESOLVED '1'
+#    define IPV4_HOSTNAME_RESOLVED '2'
+#    define SELECT_CANCELLED '3'
 
 struct fast_fallback_getaddrinfo_shared
 {

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -439,6 +439,7 @@ struct fast_fallback_getaddrinfo_entry
     struct addrinfo hints;
     struct addrinfo *ai;
     struct fast_fallback_getaddrinfo_shared *shared;
+    int has_syserr;
     long test_sleep_ms;
     int test_ecode;
 };

--- a/ext/socket/sockssocket.c
+++ b/ext/socket/sockssocket.c
@@ -34,7 +34,7 @@ socks_init(VALUE sock, VALUE host, VALUE port)
         init = 1;
     }
 
-    return rsock_init_inetsock(sock, host, port, Qnil, Qnil, INET_SOCKS, Qnil, Qnil);
+    return rsock_init_inetsock(sock, host, port, Qnil, Qnil, INET_SOCKS, Qnil, Qnil, Qfalse, Qnil);
 }
 
 #ifdef SOCKS5

--- a/ext/socket/tcpserver.c
+++ b/ext/socket/tcpserver.c
@@ -36,7 +36,7 @@ tcp_svr_init(int argc, VALUE *argv, VALUE sock)
     VALUE hostname, port;
 
     rb_scan_args(argc, argv, "011", &hostname, &port);
-    return rsock_init_inetsock(sock, hostname, port, Qnil, Qnil, INET_SERVER, Qnil, Qnil);
+    return rsock_init_inetsock(sock, hostname, port, Qnil, Qnil, INET_SERVER, Qnil, Qnil, Qfalse, Qnil);
 }
 
 /*

--- a/ext/socket/tcpsocket.c
+++ b/ext/socket/tcpsocket.c
@@ -12,13 +12,43 @@
 
 /*
  * call-seq:
- *    TCPSocket.new(remote_host, remote_port, local_host=nil, local_port=nil, connect_timeout: nil)
+ *    TCPSocket.new(remote_host, remote_port, local_host=nil, local_port=nil, resolv_timeout: nil, connect_timeout: nil, fast_fallback: true)
  *
  * Opens a TCP connection to +remote_host+ on +remote_port+.  If +local_host+
  * and +local_port+ are specified, then those parameters are used on the local
  * end to establish the connection.
  *
- * [:connect_timeout] specify the timeout in seconds.
+ * Starting from Ruby 3.4, this method operates according to the
+ * Happy Eyeballs Version 2 ({RFC 8305}[https://datatracker.ietf.org/doc/html/rfc8305])
+ * algorithm by default, except on Windows.
+ *
+ * To make it behave the same as in Ruby 3.3 and earlier,
+ * explicitly specify the option +fast_fallback:false+.
+ *
+ * Happy Eyeballs Version 2 is not provided on Windows,
+ * and it behaves the same as in Ruby 3.3 and earlier.
+ *
+ * [:resolv_timeout] Specifies the timeout in seconds from when the hostname resolution starts.
+ * [:connect_timeout] This method sequentially attempts connecting to all candidate destination addresses.<br>The +connect_timeout+ specifies the timeout in seconds from the start of the connection attempt to the last candidate.<br>By default, all connection attempts continue until the timeout occurs.<br>When +fast_fallback:false+ is explicitly specified,<br>a timeout is set for each connection attempt and any connection attempt that exceeds its timeout will be canceled.
+ * [:fast_fallback] Enables the Happy Eyeballs Version 2 algorithm (enabled by default).
+ *
+ * === Happy Eyeballs Version 2
+ * Happy Eyeballs Version 2 ({RFC 8305}[https://datatracker.ietf.org/doc/html/rfc8305])
+ * is an algorithm designed to improve client socket connectivity.<br>
+ * It aims for more reliable and efficient connections by performing hostname resolution
+ * and connection attempts in parallel, instead of serially.
+ *
+ * Starting from Ruby 3.4, this method operates as follows with this algorithm except on Windows:
+ *
+ * 1. Start resolving both IPv6 and IPv4 addresses concurrently.
+ * 2. Start connecting to the one of the addresses that are obtained first.<br>If IPv4 addresses are obtained first,
+ *    the method waits 50 ms for IPv6 name resolution to prioritize IPv6 connections.
+ * 3. After starting a connection attempt, wait 250 ms for the connection to be established.<br>
+ *    If no connection is established within this time, a new connection is started every 250 ms<br>
+ *    until a connection is  established or there are no more candidate addresses.<br>
+ *    (Although RFC 8305 strictly specifies sorting addresses,<br>
+ *    this method only alternates between IPv6 / IPv4 addresses due to the performance concerns)
+ * 4. Once a connection is established, all remaining connection attempts are canceled.
  */
 static VALUE
 tcp_init(int argc, VALUE *argv, VALUE sock)

--- a/ext/socket/tcpsocket.c
+++ b/ext/socket/tcpsocket.c
@@ -26,28 +26,35 @@ tcp_init(int argc, VALUE *argv, VALUE sock)
     VALUE remote_host, remote_serv;
     VALUE local_host, local_serv;
     VALUE opt;
-    static ID keyword_ids[2];
-    VALUE kwargs[2];
+    static ID keyword_ids[4];
+    VALUE kwargs[4];
     VALUE resolv_timeout = Qnil;
     VALUE connect_timeout = Qnil;
+    VALUE fast_fallback = Qtrue;
+    VALUE test_mode_settings = Qnil;
 
     if (!keyword_ids[0]) {
         CONST_ID(keyword_ids[0], "resolv_timeout");
         CONST_ID(keyword_ids[1], "connect_timeout");
+        CONST_ID(keyword_ids[2], "fast_fallback");
+        CONST_ID(keyword_ids[3], "test_mode_settings");
     }
 
     rb_scan_args(argc, argv, "22:", &remote_host, &remote_serv,
                         &local_host, &local_serv, &opt);
 
     if (!NIL_P(opt)) {
-        rb_get_kwargs(opt, keyword_ids, 0, 2, kwargs);
+        rb_get_kwargs(opt, keyword_ids, 0, 4, kwargs);
         if (kwargs[0] != Qundef) { resolv_timeout = kwargs[0]; }
         if (kwargs[1] != Qundef) { connect_timeout = kwargs[1]; }
+        if (kwargs[2] != Qundef) { fast_fallback = kwargs[2]; }
+        if (kwargs[3] != Qundef) { test_mode_settings = kwargs[3]; }
     }
 
     return rsock_init_inetsock(sock, remote_host, remote_serv,
                                local_host, local_serv, INET_CLIENT,
-                               resolv_timeout, connect_timeout);
+                               resolv_timeout, connect_timeout, fast_fallback,
+                               test_mode_settings);
 }
 
 static VALUE

--- a/test/socket/test_tcp.rb
+++ b/test/socket/test_tcp.rb
@@ -140,4 +140,208 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
       server_threads.each(&:join)
     end
   end
+
+  def test_initialize_v6_hostname_resolved_earlier
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      begin
+        server = TCPServer.new("::1", 0)
+      rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
+        exit
+      end
+
+      server_thread = Thread.new { server.accept }
+      port = server.addr[1]
+
+      socket = TCPSocket.new("localhost", port, test_mode_settings: { delay: { ipv4: 1000 } })
+      assert_true(socket.remote_address.ipv6?)
+      server_thread.value.close
+      server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_initialize_v4_hostname_resolved_earlier
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.addr[1]
+
+      server_thread = Thread.new { server.accept }
+      socket = TCPSocket.new("localhost", port, test_mode_settings: { delay: { ipv6: 1000 } })
+
+      assert_true(socket.remote_address.ipv4?)
+      server_thread.value.close
+      server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_initialize_v6_hostname_resolved_in_resolution_delay
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      begin
+        server = TCPServer.new("::1", 0)
+      rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
+        exit
+      end
+
+      port = server.addr[1]
+      delay_time = 25 # Socket::RESOLUTION_DELAY (private) is 50ms
+
+      server_thread = Thread.new { server.accept }
+      socket = TCPSocket.new("localhost", port, test_mode_settings: { delay: { ipv6: delay_time } })
+      assert_true(socket.remote_address.ipv6?)
+      server_thread.value.close
+      server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_initialize_v6_hostname_resolved_earlier_and_v6_server_is_not_listening
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      ipv4_address = "127.0.0.1"
+      ipv4_server = Socket.new(Socket::AF_INET, :STREAM)
+      ipv4_server.bind(Socket.pack_sockaddr_in(0, ipv4_address))
+      port = ipv4_server.connect_address.ip_port
+
+      ipv4_server_thread = Thread.new { ipv4_server.listen(1); ipv4_server.accept }
+      socket = TCPSocket.new("localhost", port, test_mode_settings: { delay: { ipv4: 10 } })
+      assert_equal(ipv4_address, socket.remote_address.ip_address)
+
+      accepted, _ = ipv4_server_thread.value
+      accepted.close
+      ipv4_server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_initialize_v6_hostname_resolved_later_and_v6_server_is_not_listening
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      ipv4_server = Socket.new(Socket::AF_INET, :STREAM)
+      ipv4_server.bind(Socket.pack_sockaddr_in(0, "127.0.0.1"))
+      port = ipv4_server.connect_address.ip_port
+
+      ipv4_server_thread = Thread.new { ipv4_server.listen(1); ipv4_server.accept }
+      socket = TCPSocket.new("localhost", port, test_mode_settings: { delay: { ipv6: 25 } })
+
+      assert_equal(
+        socket.remote_address.ipv4?,
+        true
+      )
+      accepted, _ = ipv4_server_thread.value
+      accepted.close
+      ipv4_server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_initialize_v6_hostname_resolution_failed_and_v4_hostname_resolution_is_success
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      server = TCPServer.new("127.0.0.1", 0)
+      port = server.addr[1]
+
+      server_thread = Thread.new { server.accept }
+      socket = TCPSocket.new("localhost", port, test_mode_settings: { delay: { ipv4: 10 }, error: { ipv6: Errno::EFAULT } })
+
+      assert_true(socket.remote_address.ipv4?)
+      server_thread.value.close
+      server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_initialize_resolv_timeout_with_connection_failure
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+    server = TCPServer.new("::1", 0)
+    port = server.connect_address.ip_port
+    server.close
+
+    begin;
+      assert_raise(Errno::ETIMEDOUT) do
+        TCPSocket.new("localhost", port, resolv_timeout: 0.01, test_mode_settings: { delay: { ipv4: 1000 } })
+      end
+    end;
+  end
+
+  def test_initialize_with_hostname_resolution_failure_after_connection_failure
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+    server = TCPServer.new("::1", 0)
+    port = server.connect_address.ip_port
+    server.close
+
+    begin;
+      assert_raise(Errno::EFAULT) do
+        TCPSocket.new("localhost", port, test_mode_settings: { delay: { ipv4: 100 }, error: { ipv4: Errno::EFAULT } })
+      end
+    end;
+  end
+
+  def test_initialize_v6_connected_socket_with_v6_address
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      begin
+        server = TCPServer.new("::1", 0)
+      rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
+        exit
+      end
+
+      server_thread = Thread.new { server.accept }
+      port = server.addr[1]
+
+      socket = TCPSocket.new("::1", port)
+      assert_true(socket.remote_address.ipv6?)
+      server_thread.value.close
+      server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_initialize_v4_connected_socket_with_v4_address
+    opts = %w[-rsocket -W1]
+    assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
+
+    begin;
+      server = TCPServer.new("127.0.0.1", 0)
+      server_thread = Thread.new { server.accept }
+      port = server.addr[1]
+
+      socket = TCPSocket.new("127.0.0.1", port)
+      assert_true(socket.remote_address.ipv4?)
+      server_thread.value.close
+      server.close
+      socket.close if socket && !socket.closed?
+    end;
+  end
+
+  def test_initialize_fast_fallback_is_false
+    server = TCPServer.new("127.0.0.1", 0)
+    _, port, = server.addr
+    server_thread = Thread.new { server.accept }
+    socket = TCPSocket.new("127.0.0.1", port, fast_fallback: false)
+
+    assert_true(socket.remote_address.ipv4?)
+    server_thread.value.close
+    server.close
+    socket.close if socket && !socket.closed?
+  end
 end if defined?(TCPSocket)

--- a/test/socket/test_tcp.rb
+++ b/test/socket/test_tcp.rb
@@ -142,6 +142,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_v6_hostname_resolved_earlier
+    return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
     opts = %w[-rsocket -W1]
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
 
@@ -164,6 +165,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_v4_hostname_resolved_earlier
+    return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
     opts = %w[-rsocket -W1]
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
 
@@ -182,6 +184,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_v6_hostname_resolved_in_resolution_delay
+    return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
     opts = %w[-rsocket -W1]
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
 
@@ -205,6 +208,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_v6_hostname_resolved_earlier_and_v6_server_is_not_listening
+    return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
     opts = %w[-rsocket -W1]
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
 
@@ -226,6 +230,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_v6_hostname_resolved_later_and_v6_server_is_not_listening
+    return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
     opts = %w[-rsocket -W1]
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
 
@@ -249,6 +254,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_v6_hostname_resolution_failed_and_v4_hostname_resolution_is_success
+    return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
     opts = %w[-rsocket -W1]
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
 
@@ -267,6 +273,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_resolv_timeout_with_connection_failure
+    return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
     opts = %w[-rsocket -W1]
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
     server = TCPServer.new("::1", 0)
@@ -281,6 +288,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_with_hostname_resolution_failure_after_connection_failure
+    return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
     opts = %w[-rsocket -W1]
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
     server = TCPServer.new("::1", 0)
@@ -295,6 +303,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_v6_connected_socket_with_v6_address
+    return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
     opts = %w[-rsocket -W1]
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
 
@@ -317,6 +326,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_v4_connected_socket_with_v4_address
+    return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
     opts = %w[-rsocket -W1]
     assert_separately opts, "#{<<-"begin;"}\n#{<<-'end;'}"
 
@@ -334,6 +344,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_fast_fallback_is_false
+    return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
     server = TCPServer.new("127.0.0.1", 0)
     _, port, = server.addr
     server_thread = Thread.new { server.accept }


### PR DESCRIPTION
This is an implementation of Happy Eyeballs version 2 (RFC 8305) in `TCPSocket.new`.
See https://bugs.ruby-lang.org/issues/20782

### Background
Prior to this implementation, I implemented Happy Eyeballs Version 2 (HEv2) for `Socket.tcp` in https://github.com/ruby/ruby/pull/9374. 
HEv2 is an algorithm defined in [RFC 8305](https://datatracker.ietf.org/doc/html/rfc8305), aimed at improving network connectivity. 
For more details on the specific cases that HEv2 helps, please refer to https://bugs.ruby-lang.org/issues/20108.

### Proposal & Outcome
This proposal implements the same HEv2 algorithm in `TCPSocket.new`.
Since `TCPSocket.new` is used more widely than `Socket.tcp`, this change is expected to broaden the impact of HEv2's benefits. 
Like `Socket.tcp`, I have also added `fast_fallback` keyword argument to `TCPSocket.new`. 
This option is set to true by default, enabling the HEv2 functionality. 
However, users can explicitly set it to false to disable HEv2 and use the previous behavior of `TCPSocket.new`.

It should be noted that HEv2 is enabled only in environments where pthreads are available.
This specification follows the approach taken in https://bugs.ruby-lang.org/issues/19965, where name resolution can be interrupted. 
(In environments where pthreads are not available, the `fast_fallback` option is ignored.)

### Performance
Below is the benchmark of 100 requests to `www.ruby-lang.org` with the fast_fallback option set to true and false, respectively. 
While there is a slight performance degradation when HEv2 is enabled, the degradation is smaller compared to that seen in `Socket.tcp` .

```ruby
require 'socket'
require 'benchmark'

hostname = "www.ruby-lang.org"
port = 80
n = 100

Benchmark.bmbm do |x|
  x.report("fast_fallback: true") do
    n.times { TCPSocket.new(hostname, port).close }
  end

  x.report("fast_fallback: false") do
    n.times { TCPSocket.new(hostname, port, fast_fallback: false).close }
  end
end
```

```
~/s/build ❯❯❯ ../install/bin/ruby ../ruby/test.rb
Rehearsal --------------------------------------------------------
fast_fallback: true    0.017588   0.097045   0.114633 (  1.460664)
fast_fallback: false   0.014033   0.078984   0.093017 (  1.413951)
----------------------------------------------- total: 0.207650sec

                           user     system      total        real
fast_fallback: true    0.020891   0.124054   0.144945 (  1.473816)
fast_fallback: false   0.018392   0.110852   0.129244 (  1.466014)
```