### PR TITLE
Add RB_GC_GUARD for operands in PUSH_INSN

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2785,8 +2785,8 @@ pm_compile_pattern(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t
             PUSH_INSN(ret, location, putnil);
         }
         else {
+            rb_obj_hide(keys);
             PUSH_INSN1(ret, location, duparray, keys);
-            RB_OBJ_WRITTEN(iseq, Qundef, rb_obj_hide(keys));
         }
         PUSH_SEND(ret, location, rb_intern("deconstruct_keys"), INT2FIX(1));
 
@@ -7676,7 +7676,6 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         }
 
         PUSH_INSN3(ret, location, defineclass, ID2SYM(class_id), class_iseq, INT2FIX(flags));
-        RB_OBJ_WRITTEN(iseq, Qundef, (VALUE)class_iseq);
 
         if (popped) PUSH_INSN(ret, location, pop);
         return;
@@ -7894,7 +7893,6 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         else {
             PUSH_INSN2(ret, location, definemethod, ID2SYM(method_name), method_iseq);
         }
-        RB_OBJ_WRITTEN(iseq, Qundef, (VALUE) method_iseq);
 
         if (!popped) {
             PUSH_INSN1(ret, location, putobject, ID2SYM(method_name));
@@ -8300,7 +8298,6 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
                 else {
                     VALUE value = pm_static_literal_value(iseq, node, scope_node);
                     PUSH_INSN1(ret, location, duphash, value);
-                    RB_OBJ_WRITTEN(iseq, Qundef, value);
                 }
             }
         }
@@ -8641,7 +8638,6 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         VALUE argc = INT2FIX(0);
         PUSH_INSN1(ret, location, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
         PUSH_CALL_WITH_BLOCK(ret, location, idLambda, argc, block);
-        RB_OBJ_WRITTEN(iseq, Qundef, (VALUE) block);
 
         if (popped) PUSH_INSN(ret, location, pop);
         return;
@@ -8944,7 +8940,6 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         const int flags = VM_DEFINECLASS_TYPE_MODULE | pm_compile_class_path(iseq, cast->constant_path, &location, ret, false, scope_node);
         PUSH_INSN(ret, location, putnil);
         PUSH_INSN3(ret, location, defineclass, ID2SYM(module_id), module_iseq, INT2FIX(flags));
-        RB_OBJ_WRITTEN(iseq, Qundef, (VALUE) module_iseq);
 
         if (popped) PUSH_INSN(ret, location, pop);
         return;
@@ -9217,7 +9212,6 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
 
         int is_index = ISEQ_BODY(iseq)->ise_size++;
         PUSH_INSN2(ret, location, once, child_iseq, INT2FIX(is_index));
-        RB_OBJ_WRITTEN(iseq, Qundef, (VALUE) child_iseq);
         if (popped) PUSH_INSN(ret, location, pop);
 
         ISEQ_COMPILE_DATA(iseq)->current_block = prevblock;
@@ -9619,7 +9613,6 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
         PUSH_INSN3(ret, location, defineclass, ID2SYM(singletonclass), child_iseq, INT2FIX(VM_DEFINECLASS_TYPE_SINGLETON_CLASS));
 
         if (popped) PUSH_INSN(ret, location, pop);
-        RB_OBJ_WRITTEN(iseq, Qundef, (VALUE) child_iseq);
 
         return;
       }

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -26,17 +26,34 @@ typedef struct {
 #define PUSH_INSN(seq, location, insn) \
     ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).node_id, BIN(insn), 0))
 
-#define PUSH_INSN1(seq, location, insn, op1) \
-    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).node_id, BIN(insn), 1, (VALUE)(op1)))
+#define PUSH_INSN1(seq, location, insn, op1) do { \
+    VALUE push_insn_op1 = (VALUE)(op1); \
+    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).node_id, BIN(insn), 1, push_insn_op1)); \
+    RB_GC_GUARD(push_insn_op1); \
+} while (0)
 
-#define PUSH_INSN2(seq, location, insn, op1, op2) \
-    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).node_id, BIN(insn), 2, (VALUE)(op1), (VALUE)(op2)))
+#define PUSH_INSN2(seq, location, insn, op1, op2) do { \
+    VALUE push_insn_op1 = (VALUE)(op1); \
+    VALUE push_insn_op2 = (VALUE)(op2); \
+    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).node_id, BIN(insn), 2, push_insn_op1, push_insn_op2)); \
+    RB_GC_GUARD(push_insn_op1); \
+    RB_GC_GUARD(push_insn_op2); \
+} while (0)
 
-#define PUSH_INSN3(seq, location, insn, op1, op2, op3) \
-    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).node_id, BIN(insn), 3, (VALUE)(op1), (VALUE)(op2), (VALUE)(op3)))
+#define PUSH_INSN3(seq, location, insn, op1, op2, op3) do { \
+    VALUE push_insn_op1 = (VALUE)(op1); \
+    VALUE push_insn_op2 = (VALUE)(op2); \
+    VALUE push_insn_op3 = (VALUE)(op3); \
+    ADD_ELEM((seq), (LINK_ELEMENT *) new_insn_body(iseq, (int) (location).line, (int) (location).node_id, BIN(insn), 3, push_insn_op1, push_insn_op2, push_insn_op3)); \
+    RB_GC_GUARD(push_insn_op1); \
+    RB_GC_GUARD(push_insn_op2); \
+    RB_GC_GUARD(push_insn_op3); \
+} while (0)
 
-#define PUSH_INSNL(seq, location, insn, label) \
-    (PUSH_INSN1(seq, location, insn, label), LABEL_REF(label))
+#define PUSH_INSNL(seq, location, insn, label) do { \
+    PUSH_INSN1(seq, location, insn, label); \
+    LABEL_REF(label); \
+} while (0)
 
 #define PUSH_LABEL(seq, label) \
     ADD_ELEM((seq), (LINK_ELEMENT *) (label))


### PR DESCRIPTION
In the ASAN CI, there is sometimes a use-after-poison in the objtostring instruction. This suggests that there is a T_NONE in the stack.

http://ci.rvm.jp/logfiles/brlog.trunk_asan.20240920-082802

My hypothesis is that the in the parse.y compiler, there are unnecessary RB_OBJ_WRITTEN write barriers after the putobject instructions, which ensures that the objects are on the stack. These write barriers are unnecessary because new_insn_core guarantees that all objects in the operands have write barriers applied.

When we call new_insn_core, it allocates an INSN, which could trigger GC. If the objects are not on the stack, the objects could be swept before the INSN is attached to the iseq.

This commit changes the PUSH_INSN to ensure that the objects remains on the stack until the INSN is attached to the iseq.