### PR TITLE
GC guard current_string in the putobject instruction

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -646,7 +646,9 @@ pm_interpolated_node_compile(rb_iseq_t *iseq, const pm_node_list_t *parts, const
                         current_string = rb_enc_str_new(NULL, 0, encoding);
                     }
 
-                    PUSH_INSN1(ret, current_location, putobject, rb_fstring(current_string));
+                    current_string = rb_fstring(current_string);
+                    PUSH_INSN1(ret, current_location, putobject, current_string);
+                    RB_GC_GUARD(current_string);
                     PM_COMPILE_NOT_POPPED(part);
 
                     const pm_node_location_t current_location = PM_NODE_START_LOCATION(scope_node->parser, part);


### PR DESCRIPTION
This is a band-aid solution for #11655 that only applies the fix for the putobject instruction before the objtostring instruction.

This should help fix the use-after-poison in the ASAN CI.

http://ci.rvm.jp/logfiles/brlog.trunk_asan.20240920-082802