### PR TITLE
Unpoison page->freelist before trying to assert on it

### DIFF
--- a/internal/sanitizers.h
+++ b/internal/sanitizers.h
@@ -206,6 +206,35 @@ asan_poison_object_restore(VALUE obj, void *ptr)
     return NULL;
 }
 
+#define asan_unpoisoning_object(obj) \
+    for (void *poisoned = asan_unpoison_object_temporary(obj), \
+              *unpoisoning = &poisoned; /* flag to loop just once */ \
+         unpoisoning; \
+         unpoisoning = asan_poison_object_restore(obj, poisoned))
+
+
+static inline void *
+asan_unpoison_memory_region_temporary(void *ptr, size_t len)
+{
+    void *poisoned_ptr = __asan_region_is_poisoned(ptr, len);
+    asan_unpoison_memory_region(ptr, len, false);
+    return poisoned_ptr;
+}
+
+static inline void *
+asan_poison_memory_region_restore(void *ptr, size_t len, void *poisoned_ptr)
+{
+    if (poisoned_ptr) {
+        asan_poison_memory_region(ptr, len);
+    }
+    return NULL;
+}
+
+#define asan_unpoisoning_memory_region(ptr, len) \
+    for (void *poisoned = asan_unpoison_memory_region_temporary(ptr, len), \
+              *unpoisoning = &poisoned; /* flag to loop just once */ \
+         unpoisoning; \
+         unpoisoning = asan_poison_memory_region_restore(ptr, len, poisoned))
 
 /**
  * Checks if the given pointer is on an ASAN fake stack. If so, it returns the


### PR DESCRIPTION
Otherwise trying to deref the pointer can cause an ASAN crash, even though the only reason we're dereferencing it is so that we can assert on it.

This causes ASAN crashes when building with both VM_CHECK_MODE and ASAN - e.g. https://ruby-rr-ci.kjtsanaktsidis.id.au/jenkins/job/ruby_ci-rr-asan/789/testReport/test-all/TestGCCompact/TestGCCompact_test_moving_arrays_down_size_pools/