### PR TITLE
Ensure fiber scheduler is woken up when close interrupts read

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -19,5 +19,5 @@ matrix          0.4.2   https://github.com/ruby/matrix
 prime           0.1.2   https://github.com/ruby/prime
 rbs             3.4.0   https://github.com/ruby/rbs
 typeprof        0.21.9  https://github.com/ruby/typeprof
-debug           1.9.1   https://github.com/ruby/debug
+debug           1.9.2   https://github.com/ruby/debug
 racc            1.7.3   https://github.com/ruby/racc

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -57,6 +57,7 @@ int rb_thread_wait_for_single_fd(int fd, int events, struct timeval * timeout);
 struct rb_io_close_wait_list {
     struct ccan_list_head pending_fd_users;
     VALUE closing_thread;
+    VALUE closing_fiber;
     VALUE wakeup_mutex;
 };
 int rb_notify_fd_close(int fd, struct rb_io_close_wait_list *busy);

--- a/test/fiber/test_io.rb
+++ b/test/fiber/test_io.rb
@@ -234,4 +234,47 @@ class TestFiberIO < Test::Unit::TestCase
 
     assert_equal "ok\n", result
   end
+
+  # Tests for https://bugs.ruby-lang.org/issues/20723 which would
+  # otherwise deadlock this test.
+  def test_close_while_reading_on_thread
+    # Windows has UNIXSocket, but only with VS 2019+
+    omit "UNIXSocket is not defined!" unless defined?(UNIXSocket)
+
+    i, o = Socket.pair(:UNIX, :STREAM)
+    if RUBY_PLATFORM=~/mswin|mingw/
+      i.nonblock = true
+      o.nonblock = true
+    end
+
+    message = nil
+
+    reading_thread = Thread.new do
+      Thread.current.report_on_exception = false
+      i.wait_readable
+    end
+
+    fs_thread = Thread.new do
+      # Wait until the reading thread is blocked on read:
+      Thread.pass until reading_thread.status == "sleep"
+
+      scheduler = Scheduler.new
+      Fiber.set_scheduler scheduler
+      Fiber.schedule do
+        i.close
+      end
+    end
+
+    assert_raise(IOError) { reading_thread.join }
+    refute_nil fs_thread.join(5), "expected thread to terminate within 5 seconds"
+
+    assert_predicate(i, :closed?)
+  ensure
+    fs_thread&.kill
+    fs_thread&.join rescue nil
+    reading_thread&.kill
+    reading_thread&.join rescue nil
+    i&.close
+    o&.close
+  end
 end


### PR DESCRIPTION
Backports https://bugs.ruby-lang.org/issues/20723 to Ruby 3.3