### PR TITLE
Set node_id to -1 in add_adjust_info

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2465,6 +2465,7 @@ add_adjust_info(struct iseq_insn_info_entry *insns_info, unsigned int *positions
                 int insns_info_index, int code_index, const ADJUST *adjust)
 {
     insns_info[insns_info_index].line_no    = adjust->line_no;
+    insns_info[insns_info_index].node_id    = -1;
     insns_info[insns_info_index].events     = 0;
     positions[insns_info_index]             = code_index;
     return TRUE;


### PR DESCRIPTION
add_adjust_info will increment the insns_info_index, so we need to set the node_id to -1 to prevent a "Conditional jump or move depends on uninitialised value" in Valgrind.