### PR TITLE
Fix memory leak in Ripper for indented heredocs

### DIFF
--- a/ext/ripper/ripper_init.c.tmpl
+++ b/ext/ripper/ripper_init.c.tmpl
@@ -260,6 +260,7 @@ ripper_parser_dedent_string(struct parser_params *p, VALUE string, int width)
     str = rb_str_to_parser_string(p, string);
     col = rb_ruby_ripper_dedent_string(p, str, width);
     rb_str_replace(string, rb_str_new_parser_string(str));
+    rb_parser_string_free(p, str);
     return col;
 }
 

--- a/internal/parse.h
+++ b/internal/parse.h
@@ -70,6 +70,7 @@ rb_encoding *rb_ruby_parser_encoding(rb_parser_t *p);
 int rb_ruby_parser_end_seen_p(rb_parser_t *p);
 int rb_ruby_parser_set_yydebug(rb_parser_t *p, int flag);
 rb_parser_string_t *rb_str_to_parser_string(rb_parser_t *p, VALUE str);
+void rb_parser_string_free(rb_parser_t *p, rb_parser_string_t *str);
 
 int rb_parser_dvar_defined_ref(struct parser_params*, ID, ID**);
 ID rb_parser_internal_id(struct parser_params*);

--- a/parse.y
+++ b/parse.y
@@ -764,8 +764,6 @@ string_buffer_append(struct parser_params *p, rb_parser_string_t *str)
     buf->last->buf[buf->last->used++] = str;
 }
 
-static void rb_parser_string_free(rb_parser_t *p, rb_parser_string_t *str);
-
 static void
 string_buffer_free(struct parser_params *p)
 {
@@ -2048,15 +2046,15 @@ rb_str_to_parser_string(rb_parser_t *p, VALUE str)
     RB_GC_GUARD(str);
     return ret;
 }
-#endif
 
-static void
+void
 rb_parser_string_free(rb_parser_t *p, rb_parser_string_t *str)
 {
     if (!str) return;
     xfree(PARSER_STRING_PTR(str));
     xfree(str);
 }
+#endif
 
 static st_index_t
 rb_parser_str_hash(rb_parser_string_t *str)


### PR DESCRIPTION
The allocated parser string is never freed, which causes a memory leak.

The following code leaks memory:

    Ripper.sexp_raw(DATA.read)

    __END__
    <<~EOF
      a
        #{1}
      a
    EOF