### PR TITLE
Remove rb_str_cat for parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -371,7 +371,6 @@ static const rb_parser_config_t rb_global_parser_config = {
 
     .str_catf = rb_str_catf,
     .str_cat_cstr = rb_str_cat_cstr,
-    .str_cat = rb_str_cat,
     .str_resize = rb_str_resize,
     .str_new = rb_str_new,
     .str_new_cstr = rb_str_new_cstr,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1211,7 +1211,6 @@ typedef struct rb_parser_config_struct {
     RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 2, 3)
     VALUE (*str_catf)(VALUE str, const char *format, ...);
     VALUE (*str_cat_cstr)(VALUE str, const char *ptr);
-    VALUE (*str_cat)(VALUE str, const char *ptr, long len);
     VALUE (*str_resize)(VALUE str, long len);
     VALUE (*str_new)(const char *ptr, long len);
     VALUE (*str_new_cstr)(const char *ptr);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -115,7 +115,6 @@
 #define rb_str_catf                       p->config->str_catf
 #undef rb_str_cat_cstr
 #define rb_str_cat_cstr                   p->config->str_cat_cstr
-#define rb_str_cat                        p->config->str_cat
 #define rb_str_resize                     p->config->str_resize
 #undef rb_str_new
 #define rb_str_new                        p->config->str_new


### PR DESCRIPTION
rb_str_cat function was not used by the parser and could be removed.