### PR TITLE
Fix undefined behavior in String#append_as_bytes

### DIFF
--- a/string.c
+++ b/string.c
@@ -3763,9 +3763,7 @@ rb_str_append_as_bytes(int argc, VALUE *argv, VALUE str)
             break;
           }
           default:
-            UNREACHABLE;
-            RUBY_ASSERT("append_as_bytes arguments should have been validated");
-            break;
+            rb_bug("append_as_bytes arguments should have been validated");
         }
     }
 
@@ -3793,9 +3791,7 @@ rb_str_append_as_bytes(int argc, VALUE *argv, VALUE str)
                 break;
               }
               default:
-                UNREACHABLE;
-                RUBY_ASSERT("append_as_bytes arguments should have been validated");
-                break;
+                rb_bug("append_as_bytes arguments should have been validated");
             }
         }
         break;

--- a/string.c
+++ b/string.c
@@ -3790,6 +3790,7 @@ rb_str_append_as_bytes(int argc, VALUE *argv, VALUE str)
                 if (ENC_CODERANGE(obj) != ENC_CODERANGE_7BIT) {
                     goto clear_cr;
                 }
+                break;
               }
               default:
                 UNREACHABLE;


### PR DESCRIPTION
The UNREACHABLE macro calls __builtin_unreachable, which according to the [GCC docs](https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html#index-_005f_005fbuiltin_005funreachable):

> If control flow reaches the point of the __builtin_unreachable, the program is undefined.

But it can reach this point with the following script:

    "123".append_as_bytes("123")

This can crash on some platforms with a `Trace/BPT trap: 5`.