### PR TITLE
[DOC] Layout fix for Float#to_s

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -1039,6 +1039,8 @@ rb_float_new_in_heap(double d)
 }
 
 /*
+ *  :markup: markdown
+ *
  *  call-seq:
  *    to_s -> string
  *
@@ -1052,11 +1054,13 @@ rb_float_new_in_heap(double d)
  *  - '-Infinity'.
  *  - 'NaN' (indicating not-a-number).
  *
- *    3.14.to_s         # => "3.14"
- *    (10.1**50).to_s   # => "1.644631821843879e+50"
- *    (10.1**500).to_s  # => "Infinity"
- *    (-10.1**500).to_s # => "-Infinity"
- *    (0.0/0.0).to_s    # => "NaN"
+ *  ```
+ *  3.14.to_s         # => "3.14"
+ *  (10.1**50).to_s   # => "1.644631821843879e+50"
+ *  (10.1**500).to_s  # => "Infinity"
+ *  (-10.1**500).to_s # => "-Infinity"
+ *  (0.0/0.0).to_s    # => "NaN"
+ *  ```
  *
  */
 


### PR DESCRIPTION
The parser gets confused with the enumeration followed by a code snippet, which uses the sam indentation as a continuation of the enumeration. The chosen solution has been copied from the docs of Float#floor.

Example of current layout: https://ruby-doc.org/3.3.5/Float.html#method-i-to_s