### PR TITLE
Reduce `is_ascii_string` function dependency for parser

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -7694,15 +7694,20 @@ static VALUE
 parser_str_new(struct parser_params *p, const char *ptr, long len, rb_encoding *enc, int func, rb_encoding *enc0)
 {
     VALUE str;
+    rb_parser_string_t *pstr;
 
-    str = rb_enc_str_new(ptr, len, enc);
+    pstr = rb_parser_encoding_string_new(p, ptr, len, enc);
+    str = rb_str_new_mutable_parser_string(pstr);
+
     if (!(func & STR_FUNC_REGEXP) && rb_enc_asciicompat(enc)) {
-        if (is_ascii_string(str)) {
+        if (rb_parser_is_ascii_string(p, pstr)) {
         }
         else if (rb_is_usascii_enc((void *)enc0) && enc != rb_utf8_encoding()) {
             rb_enc_associate(str, rb_ascii8bit_encoding());
         }
     }
+
+    rb_parser_string_free(p, pstr);
 
     return str;
 }

--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -34,12 +34,6 @@
 
 #define parser_encoding const void
 
-static int
-is_ascii_string2(VALUE str)
-{
-    return is_ascii_string(str);
-}
-
 RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 6, 0)
 static VALUE
 syntax_error_append(VALUE exc, VALUE file, int line, int column,
@@ -375,7 +369,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .str_new = rb_str_new,
     .str_new_cstr = rb_str_new_cstr,
     .str_to_interned_str = rb_str_to_interned_str,
-    .is_ascii_string = is_ascii_string2,
     .enc_str_new = enc_str_new,
     .str_vcatf = rb_str_vcatf,
     .rb_sprintf = rb_sprintf,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1217,7 +1217,6 @@ typedef struct rb_parser_config_struct {
     VALUE (*str_new)(const char *ptr, long len);
     VALUE (*str_new_cstr)(const char *ptr);
     VALUE (*str_to_interned_str)(VALUE);
-    int (*is_ascii_string)(VALUE str);
     VALUE (*enc_str_new)(const char *ptr, long len, rb_encoding *enc);
     RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 2, 0)
     VALUE (*str_vcatf)(VALUE str, const char *fmt, va_list ap);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -121,7 +121,6 @@
 #undef rb_str_new_cstr
 #define rb_str_new_cstr                   p->config->str_new_cstr
 #define rb_str_to_interned_str            p->config->str_to_interned_str
-#define is_ascii_string                   p->config->is_ascii_string
 #define rb_enc_str_new                    p->config->enc_str_new
 #define rb_str_vcatf                      p->config->str_vcatf
 #define rb_sprintf                        p->config->rb_sprintf


### PR DESCRIPTION
Changed to use `rb_parser_is_ascii_string` function instead of `is_ascii_string` function