### PR TITLE
Document that String#sub! and String#gsub! return nil if no replacement occured

### DIFF
--- a/string.c
+++ b/string.c
@@ -6092,8 +6092,8 @@ rb_pat_search(VALUE pat, VALUE str, long pos, int set_backref_str)
  *    sub!(pattern, replacement)   -> self or nil
  *    sub!(pattern) {|match| ... } -> self or nil
  *
- *  Returns +self+ with only the first occurrence
- *  (not all occurrences) of the given +pattern+ replaced.
+ *  Replaces the first occurrence (not all occurrences) of the given +pattern+
+ *  on +self+; returns +self+ if a replacement occurred, +nil+ otherwise.
  *
  *  See {Substitution Methods}[rdoc-ref:String@Substitution+Methods].
  *

--- a/string.rb
+++ b/string.rb
@@ -29,9 +29,11 @@
 #  These methods perform substitutions:
 #
 #  - String#sub: One substitution (or none); returns a new string.
-#  - String#sub!: One substitution (or none); returns +self+.
+#  - String#sub!: One substitution (or none); returns +self+ if any changes,
+#    +nil+ otherwise.
 #  - String#gsub: Zero or more substitutions; returns a new string.
-#  - String#gsub!: Zero or more substitutions; returns +self+.
+#  - String#gsub!: Zero or more substitutions; returns +self+ if any changes,
+#    +nil+ otherwise.
 #
 #  Each of these methods takes:
 #


### PR DESCRIPTION
The current (quite short) documentation was previously changed in #5060 / ae2359f602bb467ca755eef02d73d361d35eaed7 where the description of the return values was removed. It appears the previous documentation got lost during the review of #5060.