### PR TITLE
[DOC] Specify unit for Benchmark.realtime

### DIFF
--- a/lib/benchmark.rb
+++ b/lib/benchmark.rb
@@ -307,6 +307,7 @@ module Benchmark
 
   #
   # Returns the elapsed real time used to execute the given block.
+  # The unit of time is seconds.
   #
   def realtime # :yield:
     r0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)


### PR DESCRIPTION
The documentation for `Benchmark.realtime` doesn't make it clear what unit is being used. I've updated the docs to specify that it uses seconds. The module level docs do mention that `Benchmark.measure` returns seconds, but it is easy to miss when looking at the method docs in isolation.

Rails has recently deprecated the `Benchmark.ms` monkeypatch (https://github.com/rails/rails/pull/52746), which means there might be more people using this in Rails app, and clarifying the unit here will make it less confusing to switch to this.