### PR TITLE
[DOC] [Bug #20761] Update docs of `AbstractSyntaxTree.of` for prism

### DIFF
--- a/ast.rb
+++ b/ast.rb
@@ -92,6 +92,10 @@ module RubyVM::AbstractSyntaxTree
   #     RubyVM::AbstractSyntaxTree.of(method(:hello))
   #     # => #<RubyVM::AbstractSyntaxTree::Node:SCOPE@1:0-3:3>
   #
+  #   Note that this only works with nodes compiled by <tt>parse.y</tt> and starting with Ruby 3.4,
+  #   <tt>prism</tt> is the default compiler. For related functionality for nodes compiled by <tt>prism</tt>,
+  #   see RubyVM::InstructionSequence::of.
+  #
   #   See ::parse for explanation of keyword argument meaning and usage.
   def self.of body, keep_script_lines: RubyVM.keep_script_lines, error_tolerant: false, keep_tokens: false
     Primitive.ast_s_of body, keep_script_lines, error_tolerant, keep_tokens


### PR DESCRIPTION
In https://github.com/ruby/ruby/pull/9934 this was made to raise if compiled with prism. This updates documentation.

~I have also replaced the parser gem recommendation at the toplevel with prism itself.~ Already done in https://github.com/ruby/ruby/commit/b873787a42e4ec23dab3dbc5dded95c4804472d2