### PR TITLE
Fix RGENGC_FORCE_MAJOR_GC CI workflow

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -326,7 +326,7 @@ jobs:
       - { uses: './.github/actions/compilers', name: 'GC_PROFILE_MORE_DETAIL',         with: { cppflags: '-DGC_PROFILE_MORE_DETAIL' } }
       - { uses: './.github/actions/compilers', name: 'MALLOC_ALLOCATED_SIZE_CHECK',    with: { cppflags: '-DMALLOC_ALLOCATED_SIZE_CHECK' } }
       - { uses: './.github/actions/compilers', name: 'RGENGC_ESTIMATE_OLDMALLOC',      with: { cppflags: '-DRGENGC_ESTIMATE_OLDMALLOC' } }
-      # - { uses: './.github/actions/compilers', name: 'RGENGC_FORCE_MAJOR_GC',          with: { cppflags: '-DRGENGC_FORCE_MAJOR_GC' } }
+      - { uses: './.github/actions/compilers', name: 'RGENGC_FORCE_MAJOR_GC',          with: { cppflags: '-DRGENGC_FORCE_MAJOR_GC' } }
       - { uses: './.github/actions/compilers', name: 'RGENGC_OBJ_INFO',                with: { cppflags: '-DRGENGC_OBJ_INFO' } }
       - { uses: './.github/actions/compilers', name: 'RGENGC_PROFILE',                 with: { cppflags: '-DRGENGC_PROFILE' } }
       - { uses: './.github/actions/compilers', name: 'VM_DEBUG_BP_CHECK',              with: { cppflags: '-DVM_DEBUG_BP_CHECK' } }


### PR DESCRIPTION
Addresses https://bugs.ruby-lang.org/issues/20762

If we run with RGENGC_FORCE_MAJOR_GC, then all GC's will be major GC's. This means that any pages added to pooled pages will be unable to be allocated into until the next major GC. This frequently leaves the size pools with no allocatable pages, as there are no minor collections happening to sweep the pooled pages and add them back to the heap. 

We should take these "held" slots into account when deciding whether to allocate another page after a major or not.
