### PR TITLE
Implement SUPER NODE locations

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -846,6 +846,12 @@ node_locations(VALUE ast_value, const NODE *node)
         return rb_ary_new_from_args(2,
                                     location_new(nd_code_loc(node)),
                                     location_new(&RNODE_SPLAT(node)->operator_loc));
+      case NODE_SUPER:
+        return rb_ary_new_from_args(4,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_SUPER(node)->keyword_loc),
+                                    location_new(&RNODE_SUPER(node)->lparen_loc),
+                                    location_new(&RNODE_SUPER(node)->rparen_loc));
       case NODE_UNDEF:
         return rb_ary_new_from_args(2,
                                     location_new(nd_code_loc(node)),

--- a/node_dump.c
+++ b/node_dump.c
@@ -646,8 +646,11 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("super invocation");
         ANN("format: super [nd_args]");
         ANN("example: super 1");
-        LAST_NODE;
         F_NODE(nd_args, RNODE_SUPER, "arguments");
+        F_LOC(keyword_loc, RNODE_SUPER);
+        F_LOC(lparen_loc, RNODE_SUPER);
+        LAST_NODE;
+        F_LOC(rparen_loc, RNODE_SUPER);
         return;
 
       case NODE_ZSUPER:

--- a/parse.y
+++ b/parse.y
@@ -1094,7 +1094,7 @@ static rb_node_opcall_t *rb_node_opcall_new(struct parser_params *p, NODE *nd_re
 static rb_node_fcall_t *rb_node_fcall_new(struct parser_params *p, ID nd_mid, NODE *nd_args, const YYLTYPE *loc);
 static rb_node_vcall_t *rb_node_vcall_new(struct parser_params *p, ID nd_mid, const YYLTYPE *loc);
 static rb_node_qcall_t *rb_node_qcall_new(struct parser_params *p, NODE *nd_recv, ID nd_mid, NODE *nd_args, const YYLTYPE *loc);
-static rb_node_super_t *rb_node_super_new(struct parser_params *p, NODE *nd_args, const YYLTYPE *loc);
+static rb_node_super_t *rb_node_super_new(struct parser_params *p, NODE *nd_args, const YYLTYPE *loc, const YYLTYPE *keyword_loc, const YYLTYPE *lparen_loc, const YYLTYPE *rparen_loc);
 static rb_node_zsuper_t * rb_node_zsuper_new(struct parser_params *p, const YYLTYPE *loc);
 static rb_node_list_t *rb_node_list_new(struct parser_params *p, NODE *nd_head, const YYLTYPE *loc);
 static rb_node_list_t *rb_node_list_new2(struct parser_params *p, NODE *nd_head, long nd_alen, NODE *nd_next, const YYLTYPE *loc);
@@ -1202,7 +1202,7 @@ static rb_node_error_t *rb_node_error_new(struct parser_params *p, const YYLTYPE
 #define NEW_FCALL(m,a,loc) rb_node_fcall_new(p,m,a,loc)
 #define NEW_VCALL(m,loc) (NODE *)rb_node_vcall_new(p,m,loc)
 #define NEW_QCALL0(r,m,a,loc) (NODE *)rb_node_qcall_new(p,r,m,a,loc)
-#define NEW_SUPER(a,loc) (NODE *)rb_node_super_new(p,a,loc)
+#define NEW_SUPER(a,loc,k_loc,l_loc,r_loc) (NODE *)rb_node_super_new(p,a,loc,k_loc,l_loc,r_loc)
 #define NEW_ZSUPER(loc) (NODE *)rb_node_zsuper_new(p,loc)
 #define NEW_LIST(a,loc) (NODE *)rb_node_list_new(p,a,loc)
 #define NEW_LIST2(h,l,n,loc) (NODE *)rb_node_list_new2(p,h,l,n,loc)
@@ -3509,7 +3509,7 @@ command		: fcall command_args       %prec tLOWEST
                    }
                 | keyword_super command_args
                     {
-                        $$ = NEW_SUPER($2, &@$);
+                        $$ = NEW_SUPER($2, &@$, &@1, &NULL_LOC, &NULL_LOC);
                         fixpos($$, $2);
                     /*% ripper: super!($:2) %*/
                     }
@@ -5327,7 +5327,12 @@ method_call	: fcall paren_args
                     }
                 | keyword_super paren_args
                     {
-                        $$ = NEW_SUPER($2, &@$);
+                        rb_code_location_t lparen_loc = @2;
+                        rb_code_location_t rparen_loc = @2;
+                        lparen_loc.end_pos.column = lparen_loc.beg_pos.column + 1;
+                        rparen_loc.beg_pos.column = rparen_loc.end_pos.column - 1;
+
+                        $$ = NEW_SUPER($2, &@$, &@1, &lparen_loc, &rparen_loc);
                     /*% ripper: super!($:2) %*/
                     }
                 | keyword_super
@@ -11760,10 +11765,14 @@ rb_node_false_new(struct parser_params *p, const YYLTYPE *loc)
 }
 
 static rb_node_super_t *
-rb_node_super_new(struct parser_params *p, NODE *nd_args, const YYLTYPE *loc)
+rb_node_super_new(struct parser_params *p, NODE *nd_args, const YYLTYPE *loc,
+                  const YYLTYPE *keyword_loc, const YYLTYPE *lparen_loc, const YYLTYPE *rparen_loc)
 {
     rb_node_super_t *n = NODE_NEWNODE(NODE_SUPER, rb_node_super_t, loc);
     n->nd_args = nd_args;
+    n->keyword_loc = *keyword_loc;
+    n->lparen_loc = *lparen_loc;
+    n->rparen_loc = *rparen_loc;
 
     return n;
 }

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -541,6 +541,9 @@ typedef struct RNode_SUPER {
     NODE node;
 
     struct RNode *nd_args;
+    rb_code_location_t keyword_loc;
+    rb_code_location_t lparen_loc;
+    rb_code_location_t rparen_loc;
 } rb_node_super_t;
 
 typedef struct RNode_ZSUPER {

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1456,6 +1456,14 @@ dummy
       assert_locations(node.children[-1].children[1].children[0].children[0].locations, [[1, 13, 1, 15], [1, 13, 1, 14]])
     end
 
+    def test_super_locations
+      node = ast_parse("super 1")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 7], [1, 0, 1, 5], nil, nil])
+
+      node = ast_parse("super(1)")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 8], [1, 0, 1, 5], [1, 5, 1, 6], [1, 7, 1, 8]])
+    end
+
     def test_unless_locations
       node = ast_parse("unless cond then 1 else 2 end")
       assert_locations(node.children[-1].locations, [[1, 0, 1, 29], [1, 0, 1, 6], [1, 12, 1, 16], [1, 26, 1, 29]])


### PR DESCRIPTION
The following Location information has been added This is the information required for parse.y to be a universal parser:

```
❯ ruby --parser=prism --dump=parsetree -e "super 1"                   
@ ProgramNode (location: (1,0)-(1,7))
+-- locals: []
+-- statements:
    @ StatementsNode (location: (1,0)-(1,7))
    +-- body: (length: 1)
        +-- @ SuperNode (location: (1,0)-(1,7))
            +-- keyword_loc: (1,0)-(1,5) = "super"
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- lparen_loc: nil
            +-- arguments:
            |   @ ArgumentsNode (location: (1,6)-(1,7))
            |   +-- ArgumentsNodeFlags: nil
            |   +-- arguments: (length: 1)
            |       +-- @ IntegerNode (location: (1,6)-(1,7))
            |           +-- IntegerBaseFlags: decimal
            |           +-- value: 1
            +-- rparen_loc: nil
            +-- block: nil
```