### PR TITLE
Allow dot3 in defs singleton

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -3426,7 +3426,6 @@ defn_head	: k_def def_name
 defs_head	: k_def singleton dot_or_colon
                     {
                         SET_LEX_STATE(EXPR_FNAME);
-                        p->ctxt.in_argdef = 1;
                     }
                   def_name
                     {
@@ -6746,8 +6745,14 @@ singleton	: var_ref
                         value_expr($1);
                         $$ = $1;
                     }
-                | '(' {SET_LEX_STATE(EXPR_BEG);} expr rparen
+                | '('
                     {
+                        SET_LEX_STATE(EXPR_BEG);
+                        p->ctxt.in_argdef = 0;
+                    }
+                  expr rparen
+                    {
+                        p->ctxt.in_argdef = 1;
                         NODE *expr = last_expr_node($3);
                         switch (nd_type(expr)) {
                           case NODE_STR:

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1968,6 +1968,8 @@ eom
     assert_valid_syntax("def foo b = 1, ...; bar(...); end")
     assert_valid_syntax("(def foo ...\n  bar(...)\nend)")
     assert_valid_syntax("(def foo ...; bar(...); end)")
+    assert_valid_syntax("def (1...).foo ...; bar(...); end")
+    assert_valid_syntax("def (tap{1...}).foo ...; bar(...); end")
     assert_valid_syntax('def ==(...) end')
     assert_valid_syntax('def [](...) end')
     assert_valid_syntax('def nil(...) end')


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/20766

Fix this code(syntax error) to be syntax ok
```ruby
def (tap{1...}).f; end
```

k_def sets `in_argdef = 1`
Change `in_argdef` to `0` while parsing singleton part

```
k_def     : keyword_def { p->ctxt.in_argdef = 1; }

singleton : '(' { p->ctxt.in_argdef = 0; }
            expr rparen { p->ctxt.in_argdef = 1; }
```

### Another approach that doesn't work
```
defn_head  : k_def def_name { p->ctxt.in_argdef = 1; }
defs_head  : k_def singleton dot_or_colon { p->ctxt.in_argdef = 1; }
```
This approach failed to parse `def f ...; end` because `k_def def_name { THIS PART }` is executed after scanning TDOT3
