### PR TITLE
Return an Iterator Instead of a Vector in `addrs_to_pages` Method

### DIFF
--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -432,7 +432,7 @@ impl CodeBlock {
     }
 
     /// Convert an address range to memory page indexes against a num_pages()-sized array.
-    pub fn addrs_to_pages(&self, start_addr: CodePtr, end_addr: CodePtr) -> Vec<usize> {
+    pub fn addrs_to_pages(&self, start_addr: CodePtr, end_addr: CodePtr) -> impl Iterator<Item = usize> {
         let mem_start = self.mem_block.borrow().start_ptr().raw_addr(self);
         let mem_end = self.mem_block.borrow().mapped_end_ptr().raw_addr(self);
         assert!(mem_start <= start_addr.raw_addr(self));
@@ -441,12 +441,12 @@ impl CodeBlock {
 
         // Ignore empty code ranges
         if start_addr == end_addr {
-            return vec![];
+            return (0..0).into_iter();
         }
 
         let start_page = (start_addr.raw_addr(self) - mem_start) / self.page_size;
-        let end_page = (end_addr.raw_addr(self) - mem_start - 1) / self.page_size;
-        (start_page..=end_page).collect() // TODO: consider returning an iterator
+        let end_page = (end_addr.raw_addr(self) - mem_start - 1) / self.page_size + 1;
+        (start_page..end_page).into_iter()
     }
 
     /// Get a (possibly dangling) direct pointer to the current write position

--- a/yjit/src/asm/mod.rs
+++ b/yjit/src/asm/mod.rs
@@ -445,8 +445,8 @@ impl CodeBlock {
         }
 
         let start_page = (start_addr.raw_addr(self) - mem_start) / self.page_size;
-        let end_page = (end_addr.raw_addr(self) - mem_start - 1) / self.page_size + 1;
-        (start_page..end_page).into_iter()
+        let end_page = (end_addr.raw_addr(self) - mem_start - 1) / self.page_size;
+        (start_page..end_page + 1).into_iter()
     }
 
     /// Get a (possibly dangling) direct pointer to the current write position

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -10563,7 +10563,7 @@ impl CodegenGlobals {
         let cfunc_exit_code = gen_full_cfunc_return(&mut ocb).unwrap();
 
         let ocb_end_addr = ocb.unwrap().get_write_ptr();
-        let ocb_pages = ocb.unwrap().addrs_to_pages(ocb_start_addr, ocb_end_addr);
+        let ocb_pages = ocb.unwrap().addrs_to_pages(ocb_start_addr, ocb_end_addr).collect();
 
         // Mark all code memory as executable
         cb.mark_all_executable();


### PR DESCRIPTION
This pull request changes the `addrs_to_pages` method to return an iterator instead of a `Vec<usize>`. This modification reduces unnecessary allocations.