### PR TITLE
Fix fatal in shared GC

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -652,6 +652,8 @@ static rb_gc_function_map_t rb_gc_functions;
 
 # define RUBY_GC_LIBRARY "RUBY_GC_LIBRARY"
 
+# define fatal(...) do {fprintf(stderr, "" __VA_ARGS__); return;} while (0)
+
 static void
 ruby_external_gc_init(void)
 {
@@ -674,7 +676,7 @@ ruby_external_gc_init(void)
               case '.':
                 break;
               default:
-                rb_fatal("Only alphanumeric, dash, underscore, and period is allowed in "RUBY_GC_LIBRARY"");
+                fatal("Only alphanumeric, dash, underscore, and period is allowed in "RUBY_GC_LIBRARY"");
             }
         }
 
@@ -684,7 +686,7 @@ ruby_external_gc_init(void)
 
         handle = dlopen(gc_so_path, RTLD_LAZY | RTLD_GLOBAL);
         if (!handle) {
-            rb_fatal("ruby_external_gc_init: Shared library %s cannot be opened: %s", gc_so_path, dlerror());
+            fatal("ruby_external_gc_init: Shared library %s cannot be opened: %s", gc_so_path, dlerror());
         }
     }
 
@@ -694,7 +696,7 @@ ruby_external_gc_init(void)
     if (handle) { \
         gc_functions.name = dlsym(handle, "rb_gc_impl_" #name); \
         if (!gc_functions.name) { \
-            rb_fatal("ruby_external_gc_init: " #name " func not exported by library %s", gc_so_path); \
+            fatal("ruby_external_gc_init: " #name " func not exported by library %s", gc_so_path); \
         } \
     } \
     else { \


### PR DESCRIPTION
Ruby exception cannot work here.
Just show error messages then ignore the invalid library.