### PR TITLE
Don't create empty string for interpolation

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -643,12 +643,15 @@ pm_interpolated_node_compile(rb_iseq_t *iseq, const pm_node_list_t *parts, const
                             encoding = scope_node->encoding;
                         }
 
-                        current_string = rb_enc_str_new(NULL, 0, encoding);
+                        if (parts_size == 1) {
+                            current_string = rb_enc_str_new(NULL, 0, encoding);
+                        }
                     }
 
-                    {
+                    if (RTEST(current_string)) {
                         VALUE operand = rb_fstring(current_string);
                         PUSH_INSN1(ret, current_location, putobject, operand);
+                        stack_size++;
                     }
 
                     PM_COMPILE_NOT_POPPED(part);
@@ -664,7 +667,7 @@ pm_interpolated_node_compile(rb_iseq_t *iseq, const pm_node_list_t *parts, const
                     PUSH_INSN(ret, current_location, anytostring);
 
                     current_string = Qnil;
-                    stack_size += 2;
+                    stack_size++;
                 }
             }
         }


### PR DESCRIPTION
We don't need to create an empty string for interpolation unless it is the only element.

For example:

    "#{hello} world"

Before:

    0000 putobject                              ""                        (   1)[Li]
    0002 putself
    0003 opt_send_without_block                 <calldata!mid:hello, argc:0, FCALL|VCALL|ARGS_SIMPLE>
    0005 dup
    0006 objtostring                            <calldata!mid:to_s, argc:0, FCALL|ARGS_SIMPLE>
    0008 anytostring
    0009 putobject                              " world"
    0011 concatstrings                          3
    0013 leave

After:

    0000 putself                                                          (   1)[Li]
    0001 opt_send_without_block                 <calldata!mid:hello, argc:0, FCALL|VCALL|ARGS_SIMPLE>
    0003 dup
    0004 objtostring                            <calldata!mid:to_s, argc:0, FCALL|ARGS_SIMPLE>
    0006 anytostring
    0007 putobject                              " world"
    0009 concatstrings                          2
    0011 leave