### PR TITLE
-l option of 7z is unknown switch with the `ubuntu-latest` for Ruby 3.1

### DIFF
--- a/tool/make-snapshot
+++ b/tool/make-snapshot
@@ -57,7 +57,7 @@ PACKAGES = {
 DEFAULT_PACKAGES = PACKAGES.keys - ["tar"]
 if !$no7z and system("7z", out: IO::NULL)
   PACKAGES["gzip"] = %w".tar.gz 7z a dummy -tgzip -mx -so"
-  PACKAGES["zip"]  = %w".zip    7z a -tzip -l -mx -mtc=off" << {out: IO::NULL}
+  PACKAGES["zip"]  = %w".zip    7z a -tzip -mx -mtc=off" << {out: IO::NULL}
 elsif gzip = ENV.delete("GZIP")
   PACKAGES["gzip"].concat(gzip.shellsplit)
 end


### PR DESCRIPTION
https://github.com/ruby/actions/actions/runs/11095032727/job/30823174026#step:3:349