### PR TITLE
Remove rb_ary_new for parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -341,7 +341,6 @@ static const rb_parser_config_t rb_global_parser_config = {
 
     .attr_get = rb_attr_get,
 
-    .ary_new = rb_ary_new,
     .ary_push = rb_ary_push,
     .ary_new_from_args = rb_ary_new_from_args,
     .ary_unshift = rb_ary_unshift,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1193,7 +1193,6 @@ typedef struct rb_parser_config_struct {
     VALUE (*attr_get)(VALUE obj, ID id);
 
     /* Array */
-    VALUE (*ary_new)(void);
     VALUE (*ary_push)(VALUE ary, VALUE elem);
     VALUE (*ary_new_from_args)(long n, ...);
     VALUE (*ary_unshift)(VALUE ary, VALUE item);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -86,7 +86,6 @@
 
 #define rb_attr_get p->config->attr_get
 
-#define rb_ary_new           p->config->ary_new
 #define rb_ary_push          p->config->ary_push
 #undef rb_ary_new_from_args
 #define rb_ary_new_from_args p->config->ary_new_from_args


### PR DESCRIPTION
rb_ary_new function was not used by the parser and could be removed.