### PR TITLE
Free a buffer allocated by realpath

### DIFF
--- a/file.c
+++ b/file.c
@@ -4582,7 +4582,7 @@ rb_check_realpath_internal(VALUE basedir, VALUE path, rb_encoding *origenc, enum
         rb_sys_fail_path(unresolved_path);
     }
     resolved = ospath_new(resolved_ptr, strlen(resolved_ptr), rb_filesystem_encoding());
-# if defined(NEEDS_REALPATH_BUFFER) && NEEDS_REALPATH_BUFFER
+# if !(defined(NEEDS_REALPATH_BUFFER) && NEEDS_REALPATH_BUFFER)
     free(resolved_ptr);
 # endif
 


### PR DESCRIPTION
8350b48cfa7d344d9e2dc9748c26607c1b89d7df introduced a memory leak bug.

Will fix [Bug #20773]
`loop { File.realpath("foo") }` caused memory leak.