### PR TITLE
Move RUBY_INTERNAL_EVENT_FREEOBJ into GC implementation

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1087,8 +1087,6 @@ rb_gc_obj_free(void *objspace, VALUE obj)
 {
     RB_DEBUG_COUNTER_INC(obj_free);
 
-    rb_gc_event_hook(obj, RUBY_INTERNAL_EVENT_FREEOBJ);
-
     switch (BUILTIN_TYPE(obj)) {
       case T_NIL:
       case T_FIXNUM:

--- a/gc/default.c
+++ b/gc/default.c
@@ -3568,6 +3568,8 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
 #undef CHECK
 #endif
 
+                rb_gc_event_hook(vp, RUBY_INTERNAL_EVENT_FREEOBJ);
+
                 bool has_object_id = FL_TEST(vp, FL_SEEN_OBJ_ID);
                 if (rb_gc_obj_free(objspace, vp)) {
                     if (has_object_id) {


### PR DESCRIPTION
Instead of calling rb_gc_event_hook inside of rb_gc_obj_free, it should be up to the GC implementation to call the event.