### PR TITLE
Mark iseq keyword default values during compilation

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -354,11 +354,13 @@ rb_iseq_mark_and_move(rb_iseq_t *iseq, bool reference_updating)
             }
         }
 
-        if (body->param.flags.has_kw && ISEQ_COMPILE_DATA(iseq) == NULL) {
+        if (body->param.flags.has_kw && body->param.keyword != NULL) {
             const struct rb_iseq_param_keyword *const keyword = body->param.keyword;
 
-            for (int j = 0, i = keyword->required_num; i < keyword->num; i++, j++) {
-                rb_gc_mark_and_move(&keyword->default_values[j]);
+            if (keyword->default_values != NULL) {
+                for (int j = 0, i = keyword->required_num; i < keyword->num; i++, j++) {
+                    rb_gc_mark_and_move(&keyword->default_values[j]);
+                }
             }
         }
 


### PR DESCRIPTION
During compilation, we write keyword default values into the iseq, so we should mark it to ensure it does not get GC'd.

This might fix issues on ASAN like
http://ci.rvm.jp/logfiles/brlog.trunk_asan.20240927-194923

    ==805257==ERROR: AddressSanitizer: use-after-poison on address 0x7b7e5e3e2828 at pc 0x5e09ac4822f8 bp 0x7ffde56b0140 sp 0x7ffde56b0138
    READ of size 8 at 0x7b7e5e3e2828 thread T0
    #0 0x5e09ac4822f7 in RB_BUILTIN_TYPE include/ruby/internal/value_type.h:191:30
    #1 0x5e09ac4822f7 in rbimpl_RB_TYPE_P_fastpath include/ruby/internal/value_type.h:352:19
    #2 0x5e09ac4822f7 in gc_mark gc/default.c:4488:9
    #3 0x5e09ac51011e in rb_iseq_mark_and_move iseq.c:361:17
    #4 0x5e09ac4b85c4 in rb_imemo_mark_and_move imemo.c:386:9
    #5 0x5e09ac467544 in rb_gc_mark_children gc.c:2508:9
    #6 0x5e09ac482c24 in gc_mark_children gc/default.c:4673:5
    #7 0x5e09ac482c24 in gc_mark_stacked_objects gc/default.c:4694:9
    #8 0x5e09ac482c24 in gc_mark_stacked_objects_all gc/default.c:4732:12
    #9 0x5e09ac48c7f9 in gc_marks_rest gc/default.c:5755:9
    #10 0x5e09ac48c7f9 in gc_marks gc/default.c:5870:9
    #11 0x5e09ac48c7f9 in gc_start gc/default.c:6517:13