### PR TITLE
[DOC] Cleanup docs for Kernel#then

### DIFF
--- a/kernel.rb
+++ b/kernel.rb
@@ -105,9 +105,9 @@ module Kernel
   #     require 'open-uri'
   #     require 'json'
   #
-  #     construct_url(arguments).
-  #       then {|url| URI(url).read }.
-  #       then {|response| JSON.parse(response) }
+  #     construct_url(arguments)
+  #       .then {|url| URI(url).read }
+  #       .then {|response| JSON.parse(response) }
   #
   #  When called without block, the method returns +Enumerator+,
   #  which can be used, for example, for conditional

--- a/kernel.rb
+++ b/kernel.rb
@@ -118,15 +118,6 @@ module Kernel
   #     # does not meet condition, drop value
   #     2.then.detect(&:odd?)            # => nil
   #
-  #  Good usage for +then+ is value piping in method chains:
-  #
-  #     require 'open-uri'
-  #     require 'json'
-  #
-  #     construct_url(arguments).
-  #       then {|url| URI(url).read }.
-  #       then {|response| JSON.parse(response) }
-  #
   def then
     Primitive.attr! :inline_block
     unless defined?(yield)


### PR DESCRIPTION
The docs for `Kernel#then` had the same example repeated twice, so I removed the second one.

I also cleaned up the style of the docs to be more consistent. Other methods like `#tap` have the dot at the start of the line when chaining, while `#then` had it at the end of the previous line.