### PR TITLE
Alias Float#magnitude to abs

### DIFF
--- a/numeric.rb
+++ b/numeric.rb
@@ -328,10 +328,7 @@ class Float
     Primitive.cexpr! 'rb_float_abs(self)'
   end
 
-  def magnitude
-    Primitive.attr! :leaf
-    Primitive.cexpr! 'rb_float_abs(self)'
-  end
+  alias magnitude abs
 
   # call-seq:
   #   -float -> float


### PR DESCRIPTION
The `Float#magnitude` method has no docs, but has the same implementation as `Float#abs`. By aliasing, we get the benefit of linking to the other method in the API docs.

We already alias the method to `abs` for `Integer` in the same file.

### Screenshots

Before:

<img width="389" alt="Screenshot 2024-10-01 at 11 07 28 PM" src="https://github.com/user-attachments/assets/bcefd561-bc2f-4db5-9b5b-ab7223092930">

After:

<img width="311" alt="Screenshot 2024-10-01 at 11 07 07 PM" src="https://github.com/user-attachments/assets/d29a24fc-2422-4956-abde-b4566271e4f3">
