### PR TITLE
Add test for RbConfig Ractor safety

### DIFF
--- a/template/sizes.c.tmpl
+++ b/template/sizes.c.tmpl
@@ -43,9 +43,6 @@ extern void Init_limits(void);
 void
 Init_sizeof(void)
 {
-#ifdef HAVE_RB_EXT_RACTOR_SAFE
-    rb_ext_ractor_safe(true);
-#endif
     VALUE s = rb_hash_new();
     VALUE mRbConfig = rb_define_module("RbConfig");
     rb_define_const(mRbConfig, "SIZEOF", s);

--- a/template/sizes.c.tmpl
+++ b/template/sizes.c.tmpl
@@ -43,6 +43,9 @@ extern void Init_limits(void);
 void
 Init_sizeof(void)
 {
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+    rb_ext_ractor_safe(true);
+#endif
     VALUE s = rb_hash_new();
     VALUE mRbConfig = rb_define_module("RbConfig");
     rb_define_const(mRbConfig, "SIZEOF", s);

--- a/test/test_rbconfig.rb
+++ b/test/test_rbconfig.rb
@@ -51,4 +51,21 @@ class TestRbConfig < Test::Unit::TestCase
       assert_match(/\$\(sitearch|\$\(rubysitearchprefix\)/, val, "#{key} #{bug7823}")
     end
   end
+
+  def test_limits_and_sizeof_access_in_ractor
+    if defined?(Ractor)
+      assert_separately(["-W0"], <<~'RUBY')
+        r = Ractor.new do
+          sizeof_int = RbConfig::SIZEOF["int"]
+          fixnum_max = RbConfig::LIMITS["FIXNUM_MAX"]
+          [sizeof_int, fixnum_max]
+        end
+
+        sizeof_int, fixnum_max = r.take
+
+        assert_kind_of Numeric, sizeof_int, "RbConfig::SIZEOF['int'] should be a Numeric"
+        assert_kind_of Numeric, fixnum_max, "RbConfig::LIMITS['FIXNUM_MAX'] should be a Numeric"
+      RUBY
+    end
+  end
 end

--- a/test/test_rbconfig.rb
+++ b/test/test_rbconfig.rb
@@ -53,19 +53,17 @@ class TestRbConfig < Test::Unit::TestCase
   end
 
   def test_limits_and_sizeof_access_in_ractor
-    if defined?(Ractor)
-      assert_separately(["-W0"], <<~'RUBY')
-        r = Ractor.new do
-          sizeof_int = RbConfig::SIZEOF["int"]
-          fixnum_max = RbConfig::LIMITS["FIXNUM_MAX"]
-          [sizeof_int, fixnum_max]
-        end
+    assert_separately(["-W0"], <<~'RUBY')
+      r = Ractor.new do
+        sizeof_int = RbConfig::SIZEOF["int"]
+        fixnum_max = RbConfig::LIMITS["FIXNUM_MAX"]
+        [sizeof_int, fixnum_max]
+      end
 
-        sizeof_int, fixnum_max = r.take
+      sizeof_int, fixnum_max = r.take
 
-        assert_kind_of Numeric, sizeof_int, "RbConfig::SIZEOF['int'] should be a Numeric"
-        assert_kind_of Numeric, fixnum_max, "RbConfig::LIMITS['FIXNUM_MAX'] should be a Numeric"
-      RUBY
-    end
-  end
+      assert_kind_of Integer, sizeof_int, "RbConfig::SIZEOF['int'] should be an Integer"
+      assert_kind_of Integer, fixnum_max, "RbConfig::LIMITS['FIXNUM_MAX'] should be an Integer"
+    RUBY
+  end if defined?(Ractor)
 end


### PR DESCRIPTION
In planning ahead to the near future when TruffleRuby can run C-extensions marked with `rb_ext_ractor_safe(true)` in parallel, and for when Ractors are no longer just experimental, I'm trying to get all commonly used C-extensions marked as `rb_ext_ractor_safe(true)`, would really appreciate it if you could take a look! 