### PR TITLE
Introduce `Kernel#not_nil!`

### DIFF
--- a/kernel.rb
+++ b/kernel.rb
@@ -71,6 +71,19 @@ module Kernel
 
   #
   #  call-seq:
+  #     obj.not_nil!
+  #
+  #  Raises a TypeError if <i>obj</i> is nil, returns <i>self</i> otherwise.
+  #
+  #     1.not_nil!   #=> 1
+  #     nil.not_nil!  #=> TypeError: Receiver of not_nil! is nil
+  #
+  def not_nil!
+    self
+  end
+
+  #
+  #  call-seq:
   #     obj.tap {|x| block }    -> obj
   #
   #  Yields self to the block, and then returns self.
@@ -134,6 +147,8 @@ module Kernel
     end
     yield(self)
   end
+
+  alias not_nil not_nil!
 
   #
   #  call-seq:

--- a/nilclass.rb
+++ b/nilclass.rb
@@ -1,6 +1,20 @@
 class NilClass
   #
   #  call-seq:
+  #     nil.not_nil!
+  #
+  #  Always raises a TypeError.
+  #
+  #     nil.not_nil!   #=> TypeError: Called `not_nil!` on nil
+  #
+  def not_nil!
+    raise TypeError, "Called `not_nil!` on nil"
+  end
+
+  alias not_nil then
+
+  #
+  #  call-seq:
   #     nil.to_i -> 0
   #
   #  Always returns zero.

--- a/spec/ruby/core/kernel/not_nil_spec.rb
+++ b/spec/ruby/core/kernel/not_nil_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../spec_helper'
+
+describe "Kernel#not_nil!" do
+  it "returns self" do
+    42.not_nil!.should == 42
+  end
+end
+
+describe "Kernel#not_nil" do
+  it "returns self" do
+    42.not_nil { "not 42" }.should == 42
+  end
+end

--- a/spec/ruby/core/nil/not_nil_spec.rb
+++ b/spec/ruby/core/nil/not_nil_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#not_nil!" do
+  it "raises a TypeError" do
+    -> { nil.not_nil! }.should raise_error(TypeError, "Called `not_nil!` on nil")
+  end
+end
+
+describe "NilClass#not_nil" do
+  it "returns the value of the block" do
+    nil.not_nil { 42 }.should == 42
+  end
+end

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -182,6 +182,16 @@ class TestObject < Test::Unit::TestCase
     assert_equal(true, nil.send(:!))
   end
 
+  def test_not_nil!
+    assert_equal(42, 42.not_nil!)
+    assert_raise(TypeError) { nil.not_nil! }
+  end
+
+  def test_not_nil
+    assert_equal(42, 42.not_nil { "not 42" })
+    assert_equal(42, nil.not_nil { 42 })
+  end
+
   def test_true_and
     assert_equal(true, true & true)
     assert_equal(true, true & 1)


### PR DESCRIPTION
This PR introduces 2 methods:

* `Kernel#not_nil!` which raises if `self` is nil and returns `self` otherwise
* `Kernel#not_nil` which allows the user to specify the return value with a block in case `self` is nil

This feature was discussed https://bugs.ruby-lang.org/issues/17326 and the general consensus seems to be that the method is useful and should be named `not_nil!`.

cc. @jez, @mame, @soutaro