### PR TITLE
Refactor `parse_isalnum` and `parse_isxdigit` to use macro

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -274,7 +274,7 @@ parse_isdigit(int c)
 static inline int
 parse_isalnum(int c)
 {
-    return parse_isalpha(c) || parse_isdigit(c);
+    return ISALPHA(c) || ISDIGIT(c);
 }
 
 #undef ISALNUM
@@ -283,7 +283,7 @@ parse_isalnum(int c)
 static inline int
 parse_isxdigit(int c)
 {
-    return parse_isdigit(c) || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f');
+    return ISDIGIT(c) || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f');
 }
 
 #undef ISXDIGIT


### PR DESCRIPTION
This PR is refactor `parse_isalnum` and `parse_isxdigit` to use macro.
