### PR TITLE
Assume VM locked in rb_mark_generic_ivar

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -1107,9 +1107,9 @@ gen_ivtbl_resize(struct gen_ivtbl *old, uint32_t n)
 void
 rb_mark_generic_ivar(VALUE obj)
 {
-    struct gen_ivtbl *ivtbl;
-
-    if (rb_gen_ivtbl_get(obj, 0, &ivtbl)) {
+    st_data_t data;
+    if (st_lookup(generic_ivtbl_no_ractor_check(obj), (st_data_t)obj, &data)) {
+        struct gen_ivtbl *ivtbl = (struct gen_ivtbl *)data;
         if (rb_shape_obj_too_complex(obj)) {
             rb_mark_tbl_no_pin(ivtbl->as.complex.table);
         }


### PR DESCRIPTION
rb_gen_ivtbl_get locks the VM, but the VM must be locked during marking so we can directly read from the generic_ivtbl without locking the VM.