### PR TITLE
Revert "Direct access to `fptr->fd` should prefer to use the `internal/io.h`. (#11793)"

### DIFF
--- a/process.c
+++ b/process.c
@@ -15,8 +15,6 @@
 
 #include "ruby/fiber/scheduler.h"
 
-#include "internal/io.h"
-
 #include <ctype.h>
 #include <errno.h>
 #include <signal.h>
@@ -1963,7 +1961,7 @@ check_exec_redirect_fd(VALUE v, int iskey)
             goto wrong;
     }
     else if (!NIL_P(tmp = rb_io_check_io(v))) {
-        struct rb_io *fptr;
+        rb_io_t *fptr;
         GetOpenFile(tmp, fptr);
         if (fptr->tied_io_for_writing)
             rb_raise(rb_eArgError, "duplex IO redirection");


### PR DESCRIPTION
This reverts commit 6ea0dcc9781931129e77540097712f6196d49fde which was accidentally merged.