### PR TITLE
Introduce `rb_io_blocking_region` which takes `struct rb_io` argument.

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -8601,6 +8601,7 @@ io_buffer.$(OBJEXT): $(top_srcdir)/internal/bits.h
 io_buffer.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 io_buffer.$(OBJEXT): $(top_srcdir)/internal/error.h
 io_buffer.$(OBJEXT): $(top_srcdir)/internal/fixnum.h
+io_buffer.$(OBJEXT): $(top_srcdir)/internal/io.h
 io_buffer.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 io_buffer.$(OBJEXT): $(top_srcdir)/internal/serial.h
 io_buffer.$(OBJEXT): $(top_srcdir)/internal/static_assert.h

--- a/file.c
+++ b/file.c
@@ -1145,14 +1145,14 @@ no_gvl_fstat(void *data)
 }
 
 static int
-fstat_without_gvl(int fd, struct stat *st)
+fstat_without_gvl(rb_io_t *fptr, struct stat *st)
 {
     no_gvl_stat_data data;
 
-    data.file.fd = fd;
+    data.file.fd = fptr->fd;
     data.st = st;
 
-    return (int)(VALUE)rb_thread_io_blocking_region(no_gvl_fstat, &data, fd);
+    return (int)rb_io_blocking_region(fptr, no_gvl_fstat, &data);
 }
 
 static void *
@@ -1224,12 +1224,12 @@ statx_without_gvl(const char *path, struct statx *stx, unsigned int mask)
 }
 
 static int
-fstatx_without_gvl(int fd, struct statx *stx, unsigned int mask)
+fstatx_without_gvl(rb_io_t *fptr, struct statx *stx, unsigned int mask)
 {
-    no_gvl_statx_data data = {stx, fd, "", AT_EMPTY_PATH, mask};
+    no_gvl_statx_data data = {stx, fptr->fd, "", AT_EMPTY_PATH, mask};
 
     /* call statx(2) with fd */
-    return (int)rb_thread_io_blocking_region(io_blocking_statx, &data, fd);
+    return (int)rb_io_blocking_region(fptr, io_blocking_statx, &data);
 }
 
 static int
@@ -1242,7 +1242,7 @@ rb_statx(VALUE file, struct statx *stx, unsigned int mask)
     if (!NIL_P(tmp)) {
         rb_io_t *fptr;
         GetOpenFile(tmp, fptr);
-        result = fstatx_without_gvl(fptr->fd, stx, mask);
+        result = fstatx_without_gvl(fptr, stx, mask);
         file = tmp;
     }
     else {
@@ -1283,7 +1283,7 @@ typedef struct statx statx_data;
 
 #elif defined(HAVE_STAT_BIRTHTIME)
 # define statx_without_gvl(path, st, mask) stat_without_gvl(path, st)
-# define fstatx_without_gvl(fd, st, mask) fstat_without_gvl(fd, st)
+# define fstatx_without_gvl(fptr, st, mask) fstat_without_gvl(fptr, st)
 # define statx_birthtime(st, fname) stat_birthtime(st)
 # define statx_has_birthtime(st) 1
 # define rb_statx(file, st, mask) rb_stat(file, st)
@@ -1303,7 +1303,7 @@ rb_stat(VALUE file, struct stat *st)
         rb_io_t *fptr;
 
         GetOpenFile(tmp, fptr);
-        result = fstat_without_gvl(fptr->fd, st);
+        result = fstat_without_gvl(fptr, st);
         file = tmp;
     }
     else {
@@ -2501,7 +2501,7 @@ rb_file_birthtime(VALUE obj)
     statx_data st;
 
     GetOpenFile(obj, fptr);
-    if (fstatx_without_gvl(fptr->fd, &st, STATX_BTIME) == -1) {
+    if (fstatx_without_gvl(fptr, &st, STATX_BTIME) == -1) {
         rb_sys_fail_path(fptr->pathv);
     }
     return statx_birthtime(&st, fptr->pathv);
@@ -5280,7 +5280,7 @@ rb_file_truncate(VALUE obj, VALUE len)
     }
     rb_io_flush_raw(obj, 0);
     fa.fd = fptr->fd;
-    if ((int)rb_thread_io_blocking_region(nogvl_ftruncate, &fa, fa.fd) < 0) {
+    if ((int)rb_io_blocking_region(fptr, nogvl_ftruncate, &fa) < 0) {
         rb_sys_fail_path(fptr->pathv);
     }
     return INT2FIX(0);
@@ -5380,7 +5380,7 @@ rb_file_flock(VALUE obj, VALUE operation)
     if (fptr->mode & FMODE_WRITABLE) {
         rb_io_flush_raw(obj, 0);
     }
-    while ((int)rb_thread_io_blocking_region(rb_thread_flock, op, fptr->fd) < 0) {
+    while ((int)rb_io_blocking_region(fptr, rb_thread_flock, op) < 0) {
         int e = errno;
         switch (e) {
           case EAGAIN:

--- a/internal/io.h
+++ b/internal/io.h
@@ -135,6 +135,9 @@ RUBY_SYMBOL_EXPORT_BEGIN
 void rb_maygvl_fd_fix_cloexec(int fd);
 int rb_gc_for_fd(int err);
 void rb_write_error_str(VALUE mesg);
+
+VALUE rb_io_blocking_region_events(struct rb_io *io, rb_blocking_function_t *function, void *argument, enum rb_io_event events);
+VALUE rb_io_blocking_region(struct rb_io *io, rb_blocking_function_t *function, void *argument);
 RUBY_SYMBOL_EXPORT_END
 
 #endif /* INTERNAL_IO_H */

--- a/internal/io.h
+++ b/internal/io.h
@@ -136,7 +136,7 @@ void rb_maygvl_fd_fix_cloexec(int fd);
 int rb_gc_for_fd(int err);
 void rb_write_error_str(VALUE mesg);
 
-VALUE rb_io_blocking_region_events(struct rb_io *io, rb_blocking_function_t *function, void *argument, enum rb_io_event events);
+VALUE rb_io_blocking_region_wait(struct rb_io *io, rb_blocking_function_t *function, void *argument, enum rb_io_event events);
 VALUE rb_io_blocking_region(struct rb_io *io, rb_blocking_function_t *function, void *argument);
 RUBY_SYMBOL_EXPORT_END
 

--- a/io.c
+++ b/io.c
@@ -222,6 +222,17 @@ static VALUE sym_HOLE;
 
 static VALUE prep_io(int fd, int fmode, VALUE klass, const char *path);
 
+VALUE
+rb_io_blocking_region_events(struct rb_io *io, rb_blocking_function_t *function, void *argument, enum rb_io_event events)
+{
+    return rb_thread_io_blocking_call(function, argument, io->fd, events);
+}
+
+VALUE rb_io_blocking_region(struct rb_io *io, rb_blocking_function_t *function, void *argument)
+{
+    return rb_io_blocking_region_events(io, function, argument, 0);
+}
+
 struct argf {
     VALUE filename, current_file;
     long last_lineno;		/* $. */


### PR DESCRIPTION
This is in preparation for changes to `struct rb_io`. Instead of passing `fd`, we should pass the `struct rb_io`, so that we have access to all the internals. This does not change any visible behaviour, but funnels all calls to `rb_thread_io_blocking_region` via this interface, which can be later modified to handle `IO#close` more effectively.

I will do a few parts of the core conversion in this PR, and then follow up with separate PRs for `ext/socket` etc.

See the previous work <https://github.com/ruby/ruby/pull/5384> for more details.