### PR TITLE
Reduce rb_enc_str_new function dependency for parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -78,12 +78,6 @@ is_notop_id2(ID id)
     return is_notop_id(id);
 }
 
-static VALUE
-enc_str_new(const char *ptr, long len, parser_encoding *enc)
-{
-    return rb_enc_str_new(ptr, len, enc);
-}
-
 static int
 enc_isalnum(OnigCodePoint c, parser_encoding *enc)
 {
@@ -369,7 +363,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .str_new = rb_str_new,
     .str_new_cstr = rb_str_new_cstr,
     .str_to_interned_str = rb_str_to_interned_str,
-    .enc_str_new = enc_str_new,
     .str_vcatf = rb_str_vcatf,
     .rb_sprintf = rb_sprintf,
     .rstring_ptr = RSTRING_PTR,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1225,7 +1225,6 @@ typedef struct rb_parser_config_struct {
     VALUE (*str_new)(const char *ptr, long len);
     VALUE (*str_new_cstr)(const char *ptr);
     VALUE (*str_to_interned_str)(VALUE);
-    VALUE (*enc_str_new)(const char *ptr, long len, rb_encoding *enc);
     RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 2, 0)
     VALUE (*str_vcatf)(VALUE str, const char *fmt, va_list ap);
     RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 1, 2)

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -121,7 +121,6 @@
 #undef rb_str_new_cstr
 #define rb_str_new_cstr                   p->config->str_new_cstr
 #define rb_str_to_interned_str            p->config->str_to_interned_str
-#define rb_enc_str_new                    p->config->enc_str_new
 #define rb_str_vcatf                      p->config->str_vcatf
 #define rb_sprintf                        p->config->rb_sprintf
 #undef RSTRING_PTR


### PR DESCRIPTION
Introduce `rb_str_new_encoding_parser_string` function and Reduce `rb_enc_str_new` function dependency for parser