### PR TITLE
Suppress warnings in `time_init_parse` function

### DIFF
--- a/time.c
+++ b/time.c
@@ -2647,11 +2647,11 @@ time_init_parse(rb_execution_context_t *ec, VALUE time, VALUE str, VALUE zone, V
     }
     if (!NIL_P(subsec)) {
         /* subseconds is the last using ndigits */
-        if (ndigits < TIME_SCALE_NUMDIGITS) {
+        if (ndigits < (size_t)TIME_SCALE_NUMDIGITS) {
             VALUE mul = rb_int_positive_pow(10, TIME_SCALE_NUMDIGITS - ndigits);
             subsec = rb_int_mul(subsec, mul);
         }
-        else if (ndigits > TIME_SCALE_NUMDIGITS) {
+        else if (ndigits > (size_t)TIME_SCALE_NUMDIGITS) {
             VALUE num = rb_int_positive_pow(10, ndigits - TIME_SCALE_NUMDIGITS);
             subsec = rb_rational_new(subsec, num);
         }


### PR DESCRIPTION
When building Ruby on Ubuntu 22.04 and GCC 11.4.0, the following warning appeared. And this change has suppressed warning.

```
compiling ../ruby/time.c
../ruby/time.c: In function ‘time_init_parse’:
../ruby/time.c:2650:21: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
 2650 |         if (ndigits < TIME_SCALE_NUMDIGITS) {
      |                     ^
../ruby/time.c:2654:26: warning: comparison of integer expressions of different signedness: ‘size_t’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
 2654 |         else if (ndigits > TIME_SCALE_NUMDIGITS) {
      |
```