### PR TITLE
[Bug #20784] Fix incomplete character syntax followed by EOF

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -10118,7 +10118,7 @@ parse_qmark(struct parser_params *p, int space_seen)
             enc = rb_utf8_encoding();
             tokadd_utf8(p, &enc, -1, 0, 0);
         }
-        else if (!ISASCII(c = peekc(p))) {
+        else if (!ISASCII(c = peekc(p)) && c != -1) {
             nextc(p);
             if (tokadd_mbchar(p, c) == -1) return 0;
         }

--- a/test/ripper/test_scanner_events.rb
+++ b/test/ripper/test_scanner_events.rb
@@ -952,6 +952,10 @@ class TestRipper::ScannerEvents < Test::Unit::TestCase
                  scan('CHAR', "?\\u{41}")
 
     err = nil
+    assert_equal [], scan('CHAR', '?\\') {|*e| err = e}
+    assert_equal([:on_parse_error, "Invalid escape character syntax", "?\\"], err)
+
+    err = nil
     assert_equal [], scan('CHAR', '?\\M ') {|*e| err = e}
     assert_equal([:on_parse_error, "Invalid escape character syntax", "?\\M "], err)
 


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20784
Fix `?\` followed by EOF bug that parses `p ?\` as `p `