### PR TITLE
Make rbconfig/sizeof keys as literals

### DIFF
--- a/template/limits.c.tmpl
+++ b/template/limits.c.tmpl
@@ -82,7 +82,7 @@ Init_limits(void)
 #define MAX2NUM(name) ULONG2NUM(name ## _MAX)
 #define MIN2NUM(name)  LONG2NUM(name ## _MIN)
 #endif
-#define DEFINE(k, v) rb_hash_aset(h, rb_str_new_cstr(#k), v)
+#define DEFINE(k, v) rb_hash_aset(h, rb_str_new_lit(#k), v)
 
 % limits.each do |type|
 #ifdef <%= type %>_MAX

--- a/template/sizes.c.tmpl
+++ b/template/sizes.c.tmpl
@@ -47,8 +47,8 @@ Init_sizeof(void)
     VALUE mRbConfig = rb_define_module("RbConfig");
     rb_define_const(mRbConfig, "SIZEOF", s);
 
-#define DEFINE(type, size) rb_hash_aset(s, rb_str_new_cstr(#type), INT2FIX(SIZEOF_##size))
-#define DEFINE_SIZE(type) rb_hash_aset(s, rb_str_new_cstr(#type), INT2FIX(sizeof(type)))
+#define DEFINE(type, size) rb_hash_aset(s, rb_str_new_lit(#type), INT2FIX(SIZEOF_##size))
+#define DEFINE_SIZE(type) rb_hash_aset(s, rb_str_new_lit(#type), INT2FIX(sizeof(type)))
 
 % types.each do |type|
 %   if sizes[type]


### PR DESCRIPTION
These keys are made from string literals, and used only as keys of hashes.