### PR TITLE
YJIT: Add compilation log

### DIFF
--- a/doc/yjit/yjit.md
+++ b/doc/yjit/yjit.md
@@ -166,10 +166,10 @@ You can dump statistics about compilation and execution by running YJIT with the
 ./miniruby --yjit-stats myscript.rb
 ```
 
-You can see what YJIT has compiled by running YJIT with the `--yjit-compilation-log` command-line option:
+You can see what YJIT has compiled by running YJIT with the `--yjit-log` command-line option:
 
 ```sh
-./miniruby --yjit-compilation-log myscript.rb
+./miniruby --yjit-log myscript.rb
 ```
 
 The machine code generated for a given method can be printed by adding `puts RubyVM::YJIT.disasm(method(:method_name))` to a Ruby script. Note that no code will be generated if the method is not compiled.
@@ -187,8 +187,8 @@ YJIT supports all command-line options supported by upstream CRuby, but also add
   compiled, lower values mean less code is compiled (default 200K)
 - `--yjit-stats`: print statistics after the execution of a program (incurs a run-time cost)
 - `--yjit-stats=quiet`: gather statistics while running a program but don't print them. Stats are accessible through `RubyVM::YJIT.runtime_stats`. (incurs a run-time cost)
-- `--yjit-compilation-log[=file|dir]`: log all compilation events to the specified file or directory. If no name is supplied, the last 1024 log entries will be printed to stderr when the application exits.
-- `--yjit-compilation-log=quiet`: gather a circular buffer of recent YJIT compilations. The compilation log entries are accessible through `RubyVM::YJIT.compilation_log` and old entries will be discarded if the buffer is not drained quickly. (incurs a run-time cost)
+- `--yjit-log[=file|dir]`: log all compilation events to the specified file or directory. If no name is supplied, the last 1024 log entries will be printed to stderr when the application exits.
+- `--yjit-log=quiet`: gather a circular buffer of recent YJIT compilations. The compilation log entries are accessible through `RubyVM::YJIT.log` and old entries will be discarded if the buffer is not drained quickly. (incurs a run-time cost)
 - `--yjit-disable`: disable YJIT despite other `--yjit*` flags for lazily enabling it with `RubyVM::YJIT.enable`
 - `--yjit-code-gc`: enable code GC (disabled by default as of Ruby 3.3).
   It will cause all machine code to be discarded when the executable memory size limit is hit, meaning JIT compilation will then start over.

--- a/doc/yjit/yjit.md
+++ b/doc/yjit/yjit.md
@@ -166,6 +166,12 @@ You can dump statistics about compilation and execution by running YJIT with the
 ./miniruby --yjit-stats myscript.rb
 ```
 
+You can see what YJIT has compiled by running YJIT with the `--yjit-compilation-log` command-line option:
+
+```sh
+./miniruby --yjit-compilation-log myscript.rb
+```
+
 The machine code generated for a given method can be printed by adding `puts RubyVM::YJIT.disasm(method(:method_name))` to a Ruby script. Note that no code will be generated if the method is not compiled.
 
 <h3 id="command-line-options">Command-Line Options</h3>
@@ -181,6 +187,8 @@ YJIT supports all command-line options supported by upstream CRuby, but also add
   compiled, lower values mean less code is compiled (default 200K)
 - `--yjit-stats`: print statistics after the execution of a program (incurs a run-time cost)
 - `--yjit-stats=quiet`: gather statistics while running a program but don't print them. Stats are accessible through `RubyVM::YJIT.runtime_stats`. (incurs a run-time cost)
+- `--yjit-compilation-log`: print a log of all compiled methods to the console.
+- `--yjit-compilation-log=quiet`: gather a circular buffer of recent YJIT compilations. The compilation log entries are accessible through `RubyVM::YJIT.compilation_log` and old entries will be discarded if the buffer is not drained quickly. (incurs a run-time cost)
 - `--yjit-disable`: disable YJIT despite other `--yjit*` flags for lazily enabling it with `RubyVM::YJIT.enable`
 - `--yjit-code-gc`: enable code GC (disabled by default as of Ruby 3.3).
   It will cause all machine code to be discarded when the executable memory size limit is hit, meaning JIT compilation will then start over.

--- a/doc/yjit/yjit.md
+++ b/doc/yjit/yjit.md
@@ -187,7 +187,7 @@ YJIT supports all command-line options supported by upstream CRuby, but also add
   compiled, lower values mean less code is compiled (default 200K)
 - `--yjit-stats`: print statistics after the execution of a program (incurs a run-time cost)
 - `--yjit-stats=quiet`: gather statistics while running a program but don't print them. Stats are accessible through `RubyVM::YJIT.runtime_stats`. (incurs a run-time cost)
-- `--yjit-compilation-log`: print a log of all compiled methods to the console.
+- `--yjit-compilation-log[=file|dir]`: log all compilation events to the specified file or directory. If no name is supplied, the last 1024 log entries will be printed to stderr when the application exits.
 - `--yjit-compilation-log=quiet`: gather a circular buffer of recent YJIT compilations. The compilation log entries are accessible through `RubyVM::YJIT.compilation_log` and old entries will be discarded if the buffer is not drained quickly. (incurs a run-time cost)
 - `--yjit-disable`: disable YJIT despite other `--yjit*` flags for lazily enabling it with `RubyVM::YJIT.enable`
 - `--yjit-code-gc`: enable code GC (disabled by default as of Ruby 3.3).

--- a/yjit.c
+++ b/yjit.c
@@ -1236,7 +1236,7 @@ VALUE rb_yjit_insns_compiled(rb_execution_context_t *ec, VALUE self, VALUE iseq)
 VALUE rb_yjit_code_gc(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_simulate_oom_bang(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_get_exit_locations(rb_execution_context_t *ec, VALUE self);
-VALUE rb_yjit_enable(rb_execution_context_t *ec, VALUE self, VALUE gen_stats, VALUE print_stats);
+VALUE rb_yjit_enable(rb_execution_context_t *ec, VALUE self, VALUE gen_stats, VALUE print_stats, VALUE gen_compilation_log, VALUE print_compilation_log);
 
 // Preprocessed yjit.rb generated during build
 #include "yjit.rbinc"

--- a/yjit.c
+++ b/yjit.c
@@ -1231,6 +1231,7 @@ VALUE rb_yjit_print_compilation_log_p(rb_execution_context_t *c, VALUE self);
 VALUE rb_yjit_trace_exit_locations_enabled_p(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self, VALUE key);
 VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self);
+VALUE rb_yjit_get_compilation_log(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_disasm_iseq(rb_execution_context_t *ec, VALUE self, VALUE iseq);
 VALUE rb_yjit_insns_compiled(rb_execution_context_t *ec, VALUE self, VALUE iseq);
 VALUE rb_yjit_code_gc(rb_execution_context_t *ec, VALUE self);

--- a/yjit.c
+++ b/yjit.c
@@ -1226,6 +1226,8 @@ rb_yjit_set_exception_return(rb_control_frame_t *cfp, void *leave_exit, void *le
 // Primitives used by yjit.rb
 VALUE rb_yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_print_stats_p(rb_execution_context_t *ec, VALUE self);
+VALUE rb_yjit_compilation_log_enabled_p(rb_execution_context_t *c, VALUE self);
+VALUE rb_yjit_print_compilation_log_p(rb_execution_context_t *c, VALUE self);
 VALUE rb_yjit_trace_exit_locations_enabled_p(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self, VALUE key);
 VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self);

--- a/yjit.c
+++ b/yjit.c
@@ -1226,12 +1226,12 @@ rb_yjit_set_exception_return(rb_control_frame_t *cfp, void *leave_exit, void *le
 // Primitives used by yjit.rb
 VALUE rb_yjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_print_stats_p(rb_execution_context_t *ec, VALUE self);
-VALUE rb_yjit_compilation_log_enabled_p(rb_execution_context_t *c, VALUE self);
-VALUE rb_yjit_print_compilation_log_p(rb_execution_context_t *c, VALUE self);
+VALUE rb_yjit_log_enabled_p(rb_execution_context_t *c, VALUE self);
+VALUE rb_yjit_print_log_p(rb_execution_context_t *c, VALUE self);
 VALUE rb_yjit_trace_exit_locations_enabled_p(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_get_stats(rb_execution_context_t *ec, VALUE self, VALUE key);
 VALUE rb_yjit_reset_stats_bang(rb_execution_context_t *ec, VALUE self);
-VALUE rb_yjit_get_compilation_log(rb_execution_context_t *ec, VALUE self);
+VALUE rb_yjit_get_log(rb_execution_context_t *ec, VALUE self);
 VALUE rb_yjit_disasm_iseq(rb_execution_context_t *ec, VALUE self, VALUE iseq);
 VALUE rb_yjit_insns_compiled(rb_execution_context_t *ec, VALUE self, VALUE iseq);
 VALUE rb_yjit_code_gc(rb_execution_context_t *ec, VALUE self);

--- a/yjit.rb
+++ b/yjit.rb
@@ -18,9 +18,9 @@ module RubyVM::YJIT
     Primitive.rb_yjit_stats_enabled_p
   end
 
-  # Check if `--yjit-compilation-log` is used.
-  def self.compilation_log_enabled?
-    Primitive.rb_yjit_compilation_log_enabled_p
+  # Check if `--yjit-log` is used.
+  def self.log_enabled?
+    Primitive.rb_yjit_log_enabled_p
   end
 
   # Check if rb_yjit_trace_exit_locations_enabled_p is enabled.
@@ -41,14 +41,14 @@ module RubyVM::YJIT
   # * `true`: Enable stats. Print stats at exit.
   # * `:quiet`: Enable stats. Do not print stats at exit.
   #
-  # `compilation_log`:
-  # * `false`: Don't enable the compilation log.
-  # * `true`: Enable the compilation log. Print compilation log at exit.
-  # * `:quiet`: Enable the compilation log. Do not print compilation log at exit.
-  def self.enable(stats: false, compilation_log: false)
+  # `log`:
+  # * `false`: Don't enable the log.
+  # * `true`: Enable the log. Print log at exit.
+  # * `:quiet`: Enable the log. Do not print log at exit.
+  def self.enable(stats: false, log: false)
     return false if enabled?
     at_exit { print_and_dump_stats } if stats
-    Primitive.rb_yjit_enable(stats, stats != :quiet, compilation_log, compilation_log != :quiet)
+    Primitive.rb_yjit_enable(stats, stats != :quiet, log, log != :quiet)
   end
 
   # If --yjit-trace-exits is enabled parse the hashes from
@@ -185,12 +185,12 @@ module RubyVM::YJIT
     strio.string
   end
 
-  # Return an array of compilation log entries.
+  # Return an array of log entries.
   # Return `nil` when option is not passed or unavailable.
-  def self.compilation_log
-    return nil unless compilation_log_enabled?
+  def self.log
+    return nil unless log_enabled?
 
-    Primitive.rb_yjit_get_compilation_log.map do |timestamp, path|
+    Primitive.rb_yjit_get_log.map do |timestamp, path|
       [Time.at(timestamp), path]
     end
   end

--- a/yjit.rb
+++ b/yjit.rb
@@ -186,6 +186,12 @@ module RubyVM::YJIT
     strio.string
   end
 
+  # Return an array of compilation log entries.
+  # Return `nil` when option is not passed or unavailable.
+  def self.compilation_log
+    Primitive.rb_yjit_get_compilation_log
+  end
+
   # Produce disassembly for an iseq. This requires a `--enable-yjit=dev` build.
   def self.disasm(iseq) # :nodoc:
     # If a method or proc is passed in, get its iseq

--- a/yjit.rb
+++ b/yjit.rb
@@ -191,8 +191,8 @@ module RubyVM::YJIT
   def self.compilation_log
     return nil unless compilation_log_enabled?
 
-    Primitive.rb_yjit_get_compilation_log.map do |path, timestamp|
-      [path, Time.at(timestamp)]
+    Primitive.rb_yjit_get_compilation_log.map do |timestamp, path|
+      [Time.at(timestamp), path]
     end
   end
 

--- a/yjit.rb
+++ b/yjit.rb
@@ -18,6 +18,11 @@ module RubyVM::YJIT
     Primitive.rb_yjit_stats_enabled_p
   end
 
+  # Check if `--yjit-compilation-log` is used.
+  def self.compilation_log_enabled?
+    Primitive.rb_yjit_compilation_log_enabled_p
+  end
+
   # Check if rb_yjit_trace_exit_locations_enabled_p is enabled.
   def self.trace_exit_locations_enabled? # :nodoc:
     Primitive.rb_yjit_trace_exit_locations_enabled_p
@@ -223,6 +228,10 @@ module RubyVM::YJIT
   # Avoid calling a Ruby method here to not interfere with compilation tests
   if Primitive.rb_yjit_stats_enabled_p
     at_exit { print_and_dump_stats }
+  end
+
+  if Primitive.rb_yjit_compilation_log_enabled_p
+    at_exit { $stderr.puts("***YJIT: Printing YJIT compilation log on exit***") if Primitive.rb_yjit_print_compilation_log_p }
   end
 
   class << self

--- a/yjit.rb
+++ b/yjit.rb
@@ -263,7 +263,10 @@ module RubyVM::YJIT
     # Print the compilation log
     def print_compilation_log # :nodoc:
       if Primitive.rb_yjit_print_compilation_log_p
-        $stderr.puts("***YJIT: Printing YJIT compilation log on exit***")
+        RubyVM::YJIT.compilation_log.each do |iseq_path, timestamp|
+          t = Time.at(timestamp)
+          $stderr.puts "%15.6f: %s" % [t.to_f, iseq_path]
+        end
       end
     end
 

--- a/yjit.rb
+++ b/yjit.rb
@@ -48,7 +48,6 @@ module RubyVM::YJIT
   def self.enable(stats: false, compilation_log: false)
     return false if enabled?
     at_exit { print_and_dump_stats } if stats
-    at_exit { print_compilation_log } if compilation_log
     Primitive.rb_yjit_enable(stats, stats != :quiet, compilation_log, compilation_log != :quiet)
   end
 
@@ -248,10 +247,6 @@ module RubyVM::YJIT
     at_exit { print_and_dump_stats }
   end
 
-  if Primitive.rb_yjit_compilation_log_enabled_p
-    at_exit { print_compilation_log }
-  end
-
   class << self
     # :stopdoc:
     private
@@ -262,16 +257,6 @@ module RubyVM::YJIT
         _print_stats
       end
       _dump_locations
-    end
-
-    # Print the compilation log
-    def print_compilation_log # :nodoc:
-      if Primitive.rb_yjit_print_compilation_log_p
-        $stderr.puts "***YJIT: Printing YJIT compilation log on exit***"
-        RubyVM::YJIT.compilation_log.each do |iseq_path, timestamp|
-          $stderr.puts "%15.6f: %s" % [timestamp.to_f, iseq_path]
-        end
-      end
     end
 
     def _dump_locations # :nodoc:

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6597,9 +6597,6 @@ fn gen_send_cfunc(
                 perf_call!("gen_send_cfunc: ", known_cfunc_codegen(jit, asm, ci, cme, block, argc, recv_known_class))
             };
 
-            let method_id = unsafe { (*cme).called_id };
-            CompilationLog::add_cfunc(recv_known_class, method_id);
-
             if cfunc_codegen {
                 assert_eq!(expected_stack_after, asm.ctx.get_stack_size() as i32);
                 gen_counter_incr(jit, asm, Counter::num_send_cfunc_inline);
@@ -9108,7 +9105,7 @@ fn get_class_name(class: Option<VALUE>) -> String {
 }
 
 /// Assemble "{class_name}#{method_name}" from a class pointer and a method ID
-pub fn get_method_name(class: Option<VALUE>, mid: u64) -> String {
+fn get_method_name(class: Option<VALUE>, mid: u64) -> String {
     let class_name = get_class_name(class);
     let method_name = if mid != 0 {
         unsafe { cstr_to_rust_string(rb_id2name(mid)) }
@@ -9119,7 +9116,7 @@ pub fn get_method_name(class: Option<VALUE>, mid: u64) -> String {
 }
 
 /// Assemble "{label}@{iseq_path}:{lineno}" (iseq_inspect() format) from an ISEQ
-pub fn get_iseq_name(iseq: IseqPtr) -> String {
+fn get_iseq_name(iseq: IseqPtr) -> String {
     let c_string = unsafe { rb_yjit_iseq_inspect(iseq) };
     let string = unsafe { CStr::from_ptr(c_string) }.to_str()
         .unwrap_or_else(|_| "not UTF-8").to_string();

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -9113,7 +9113,7 @@ fn get_method_name(class: Option<VALUE>, mid: u64) -> String {
 }
 
 /// Assemble "{label}@{iseq_path}:{lineno}" (iseq_inspect() format) from an ISEQ
-fn get_iseq_name(iseq: IseqPtr) -> String {
+pub fn get_iseq_name(iseq: IseqPtr) -> String {
     let c_string = unsafe { rb_yjit_iseq_inspect(iseq) };
     let string = unsafe { CStr::from_ptr(c_string) }.to_str()
         .unwrap_or_else(|_| "not UTF-8").to_string();

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -458,6 +458,7 @@ macro_rules! perf_call {
 }
 
 use crate::codegen::JCCKinds::*;
+use crate::compilation_log::CompilationLog;
 
 #[allow(non_camel_case_types, unused)]
 pub enum JCCKinds {
@@ -6594,6 +6595,9 @@ fn gen_send_cfunc(
                 perf_call!("gen_send_cfunc: ", known_cfunc_codegen(jit, asm, ci, cme, block, argc, recv_known_class))
             };
 
+            let method_id = unsafe { (*cme).called_id };
+            CompilationLog::add_cfunc(recv_known_class, method_id);
+
             if cfunc_codegen {
                 assert_eq!(expected_stack_after, asm.ctx.get_stack_size() as i32);
                 gen_counter_incr(jit, asm, Counter::num_send_cfunc_inline);
@@ -9102,7 +9106,7 @@ fn get_class_name(class: Option<VALUE>) -> String {
 }
 
 /// Assemble "{class_name}#{method_name}" from a class pointer and a method ID
-fn get_method_name(class: Option<VALUE>, mid: u64) -> String {
+pub fn get_method_name(class: Option<VALUE>, mid: u64) -> String {
     let class_name = get_class_name(class);
     let method_name = if mid != 0 {
         unsafe { cstr_to_rust_string(rb_id2name(mid)) }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -458,7 +458,7 @@ macro_rules! perf_call {
 }
 
 use crate::codegen::JCCKinds::*;
-use crate::compilation_log::CompilationLog;
+use crate::log::Log;
 
 #[allow(non_camel_case_types, unused)]
 pub enum JCCKinds {
@@ -1224,7 +1224,7 @@ pub fn gen_single_block(
         asm_comment!(asm, "reg_mapping: {:?}", asm.ctx.get_reg_mapping());
     }
 
-    CompilationLog::add_block_with_chain_depth(blockid, asm.ctx.get_chain_depth());
+    Log::add_block_with_chain_depth(blockid, asm.ctx.get_chain_depth());
 
     // Mark the start of an ISEQ for --yjit-perf
     jit_perf_symbol_push!(jit, &mut asm, &get_iseq_name(iseq), PerfMap::ISEQ);

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -1224,6 +1224,8 @@ pub fn gen_single_block(
         asm_comment!(asm, "reg_mapping: {:?}", asm.ctx.get_reg_mapping());
     }
 
+    CompilationLog::add_block_with_chain_depth(blockid, asm.ctx.get_chain_depth());
+
     // Mark the start of an ISEQ for --yjit-perf
     jit_perf_symbol_push!(jit, &mut asm, &get_iseq_name(iseq), PerfMap::ISEQ);
 

--- a/yjit/src/compilation_log.rs
+++ b/yjit/src/compilation_log.rs
@@ -1,0 +1,25 @@
+use crate::cruby::{EcPtr, Qfalse, Qtrue, VALUE};
+use crate::options::*;
+use crate::yjit::yjit_enabled_p;
+
+/// Primitive called in yjit.rb
+/// Check if compilation log generation is enabled
+#[no_mangle]
+pub extern "C" fn rb_yjit_compilation_log_enabled_p(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
+    if get_option!(gen_compilation_log) {
+        return Qtrue;
+    } else {
+        return Qfalse;
+    }
+}
+
+/// Primitive called in yjit.rb
+/// Check if the compilation log should print at exit
+#[no_mangle]
+pub extern "C" fn rb_yjit_print_compilation_log_p(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
+    if yjit_enabled_p() && get_option!(print_compilation_log) {
+        return Qtrue;
+    } else {
+        return Qfalse;
+    }
+}

--- a/yjit/src/compilation_log.rs
+++ b/yjit/src/compilation_log.rs
@@ -1,4 +1,7 @@
-use crate::cruby::{EcPtr, Qfalse, Qtrue, VALUE};
+#![allow(dead_code)]
+
+use crate::core::BlockId;
+use crate::cruby::*;
 use crate::options::*;
 use crate::yjit::yjit_enabled_p;
 
@@ -22,4 +25,11 @@ pub extern "C" fn rb_yjit_print_compilation_log_p(_ec: EcPtr, _ruby_self: VALUE)
     } else {
         return Qfalse;
     }
+}
+
+/// Primitive called in yjit.rb.
+/// Export all YJIT compilation log entries as a Ruby array.
+#[no_mangle]
+pub extern "C" fn rb_yjit_get_compilation_log(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
+    with_vm_lock(src_loc!(), || unsafe { rb_ary_new_capa(0) })
 }

--- a/yjit/src/compilation_log.rs
+++ b/yjit/src/compilation_log.rs
@@ -1,9 +1,141 @@
-#![allow(dead_code)]
-
 use crate::core::BlockId;
 use crate::cruby::*;
 use crate::options::*;
 use crate::yjit::yjit_enabled_p;
+
+use std::os::raw::c_long;
+
+#[derive(Copy, Clone)]
+pub struct CompilationLogEntry {
+    /// The compiled block.
+    pub block_id: BlockId,
+
+    /// The time when the block was compiled.
+    pub timestamp: f64,
+}
+
+pub type CompilationLog = CircularBuffer<CompilationLogEntry, 1024>;
+static mut COMPILATION_LOG : Option<CompilationLog> = None;
+
+impl CompilationLog {
+    pub fn init() {
+        unsafe {
+            COMPILATION_LOG = Some(CompilationLog::new());
+        }
+    }
+
+    pub fn get_instance() -> &'static mut CompilationLog {
+        unsafe {
+            COMPILATION_LOG.as_mut().unwrap()
+        }
+    }
+
+    pub fn has_instance() -> bool {
+        unsafe {
+            COMPILATION_LOG.as_mut().is_some()
+        }
+    }
+
+    pub fn add_entry(block_id: BlockId) {
+        if !Self::has_instance() {
+            return;
+        }
+
+        Self::get_instance().push(CompilationLogEntry {
+            block_id: block_id,
+            timestamp: std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs_f64()
+        });
+    }
+
+    pub fn clear() {
+        unsafe {
+            COMPILATION_LOG.as_mut().unwrap().reset()
+        }
+    }
+}
+
+pub struct CircularBuffer<T, const N: usize> {
+    buffer: [Option<T>; N],
+    head: usize,
+    tail: usize,
+    size: usize
+}
+
+impl<T: Copy, const N: usize> CircularBuffer<T, N> {
+    pub fn new() -> Self {
+        Self {
+            buffer: [None; N],
+            head: 0,
+            tail: 0,
+            size: 0
+        }
+    }
+
+    pub fn push(&mut self, value: T) {
+        self.buffer[self.head] = Some(value);
+        self.head = (self.head + 1) % N;
+        if self.size == N {
+            self.tail = (self.tail + 1) % N;
+        } else {
+            self.size += 1;
+        }
+    }
+
+    pub fn pop(&mut self) -> Option<T> {
+        if self.size == 0 {
+            return None;
+        }
+
+        let value = self.buffer[self.tail].take();
+        self.tail = (self.tail + 1) % N;
+        self.size -= 1;
+        value
+    }
+
+    pub fn len(&self) -> usize {
+        self.size
+    }
+
+    pub fn iter(&self) -> CircularBufferIterator<T, N> {
+        CircularBufferIterator {
+            buffer: self,
+            current: 0,
+            count: 0,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.head = 0;
+        self.tail = 0;
+        self.size = 0;
+    }
+}
+
+pub struct CircularBufferIterator<'a, T: Copy, const N: usize> {
+    buffer: &'a CircularBuffer<T, N>,
+    current: usize,
+    count: usize,
+}
+
+impl<'a, T: Copy, const N: usize> Iterator for CircularBufferIterator<'a, T, N> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.count >= self.buffer.size {
+            return None;
+        }
+
+        let index = (self.buffer.tail + self.current) % N;
+        let item = self.buffer.buffer[index];
+        self.current = (self.current + 1) % N;
+        self.count += 1;
+
+        item
+    }
+}
+
+
+//===========================================================================
 
 /// Primitive called in yjit.rb
 /// Check if compilation log generation is enabled
@@ -31,5 +163,27 @@ pub extern "C" fn rb_yjit_print_compilation_log_p(_ec: EcPtr, _ruby_self: VALUE)
 /// Export all YJIT compilation log entries as a Ruby array.
 #[no_mangle]
 pub extern "C" fn rb_yjit_get_compilation_log(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
-    with_vm_lock(src_loc!(), || unsafe { rb_ary_new_capa(0) })
+    with_vm_lock(src_loc!(), || rb_yjit_get_compilation_log_array())
+}
+
+fn rb_yjit_get_compilation_log_array() -> VALUE {
+    if !yjit_enabled_p() {
+        return Qnil;
+    }
+
+    let log = CompilationLog::get_instance();
+    let array = unsafe { rb_ary_new_capa(log.len() as c_long) };
+
+    for entry in log.iter() {
+        unsafe {
+            let entry_array = rb_ary_new_capa(2);
+            rb_ary_push(entry_array, entry.block_id.iseq_name());
+            rb_ary_push(entry_array, rb_float_new(entry.timestamp));
+            rb_ary_push(array, entry_array);
+        }
+    }
+
+    CompilationLog::clear();
+
+    return array;
 }

--- a/yjit/src/compilation_log.rs
+++ b/yjit/src/compilation_log.rs
@@ -230,8 +230,8 @@ fn rb_yjit_get_compilation_log_array() -> VALUE {
     for entry in log.iter() {
         unsafe {
             let entry_array = rb_ary_new_capa(2);
-            rb_ary_push(entry_array, entry.payload.to_string().into());
             rb_ary_push(entry_array, rb_float_new(entry.timestamp));
+            rb_ary_push(entry_array, entry.payload.to_string().into());
             rb_ary_push(array, entry_array);
         }
     }

--- a/yjit/src/compilation_log.rs
+++ b/yjit/src/compilation_log.rs
@@ -86,21 +86,18 @@ impl CompilationLog {
             payload
         };
 
-        match print_compilation_log {
-            Some(CompilationLogOutput::File(fd)) => {
-                use std::os::unix::io::{FromRawFd, IntoRawFd};
-                use std::io::Write;
+        if let Some(CompilationLogOutput::File(fd)) = print_compilation_log {
+            use std::os::unix::io::{FromRawFd, IntoRawFd};
+            use std::io::Write;
 
-                // Write with the fd opened during boot
-                let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
-                writeln!(file, "{}", entry).unwrap();
-                file.flush().unwrap();
-                file.into_raw_fd(); // keep the fd open
-            },
-            _ => {
-                Self::get_instance().push(entry);
-            }
+            // Write with the fd opened during boot
+            let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
+            writeln!(file, "{}", entry).unwrap();
+            file.flush().unwrap();
+            file.into_raw_fd(); // keep the fd open
         }
+
+        Self::get_instance().push(entry);
     }
 
     pub fn clear() {

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1763,7 +1763,7 @@ pub struct IseqPayload {
     // Basic block versions
     pub version_map: VersionMap,
 
-    // Indexes of code pages used by this this ISEQ
+    // Indexes of code pages used by this ISEQ
     pub pages: HashSet<usize>,
 
     // List of ISEQ entry codes

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -28,7 +28,6 @@ use std::ptr;
 use ptr::NonNull;
 use YARVOpnd::*;
 use TempMapping::*;
-use crate::compilation_log::CompilationLog;
 use crate::invariants::*;
 
 // Maximum number of temp value types or registers we keep track of
@@ -3049,10 +3048,6 @@ impl BlockId {
     pub fn dump_src_loc(&self) {
         unsafe { rb_yjit_dump_iseq_loc(self.iseq, self.idx as u32) }
     }
-
-    pub fn iseq_name(&self) -> String {
-        get_iseq_name(self.iseq)
-    }
 }
 
 /// See [gen_block_series_body]. This simply counts compilation failures.
@@ -3233,8 +3228,6 @@ pub fn gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exception: bool) -> Option<
 
     // Count the number of entry points we compile
     incr_counter!(compiled_iseq_entry);
-
-    CompilationLog::add_entry_point(blockid);
 
     // Compilation successful and block not empty
     code_ptr.map(|ptr| ptr.raw_ptr(cb))

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -3234,7 +3234,7 @@ pub fn gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exception: bool) -> Option<
     // Count the number of entry points we compile
     incr_counter!(compiled_iseq_entry);
 
-    CompilationLog::add_entry(blockid);
+    CompilationLog::add_iseq(blockid);
 
     // Compilation successful and block not empty
     code_ptr.map(|ptr| ptr.raw_ptr(cb))

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -28,6 +28,7 @@ use std::ptr;
 use ptr::NonNull;
 use YARVOpnd::*;
 use TempMapping::*;
+use crate::compilation_log::CompilationLog;
 use crate::invariants::*;
 
 // Maximum number of temp value types or registers we keep track of
@@ -3048,6 +3049,11 @@ impl BlockId {
     pub fn dump_src_loc(&self) {
         unsafe { rb_yjit_dump_iseq_loc(self.iseq, self.idx as u32) }
     }
+
+    pub fn iseq_name(&self) -> VALUE {
+        let path = get_iseq_name(self.iseq);
+        rust_str_to_ruby(&path)
+    }
 }
 
 /// See [gen_block_series_body]. This simply counts compilation failures.
@@ -3228,6 +3234,8 @@ pub fn gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exception: bool) -> Option<
 
     // Count the number of entry points we compile
     incr_counter!(compiled_iseq_entry);
+
+    CompilationLog::add_entry(blockid);
 
     // Compilation successful and block not empty
     code_ptr.map(|ptr| ptr.raw_ptr(cb))

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -3050,9 +3050,8 @@ impl BlockId {
         unsafe { rb_yjit_dump_iseq_loc(self.iseq, self.idx as u32) }
     }
 
-    pub fn iseq_name(&self) -> VALUE {
-        let path = get_iseq_name(self.iseq);
-        rust_str_to_ruby(&path)
+    pub fn iseq_name(&self) -> String {
+        get_iseq_name(self.iseq)
     }
 }
 

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -3234,7 +3234,7 @@ pub fn gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exception: bool) -> Option<
     // Count the number of entry points we compile
     incr_counter!(compiled_iseq_entry);
 
-    CompilationLog::add_iseq(blockid);
+    CompilationLog::add_entry_point(blockid);
 
     // Compilation successful and block not empty
     code_ptr.map(|ptr| ptr.raw_ptr(cb))

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -564,6 +564,18 @@ impl From<*const rb_callable_method_entry_t> for VALUE {
     }
 }
 
+impl From<&str> for VALUE {
+    fn from(value: &str) -> Self {
+        rust_str_to_ruby(value)
+    }
+}
+
+impl From<String> for VALUE {
+    fn from(value: String) -> Self {
+        rust_str_to_ruby(&value)
+    }
+}
+
 impl From<VALUE> for u64 {
     fn from(value: VALUE) -> Self {
         let VALUE(uimm) = value;
@@ -595,7 +607,6 @@ impl From<VALUE> for u16 {
 }
 
 /// Produce a Ruby string from a Rust string slice
-#[cfg(feature = "disasm")]
 pub fn rust_str_to_ruby(str: &str) -> VALUE {
     unsafe { rb_utf8_str_new(str.as_ptr() as *const _, str.len() as i64) }
 }

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -84,6 +84,7 @@
 
 use std::convert::From;
 use std::ffi::{CString, CStr};
+use std::fmt::{Debug, Formatter};
 use std::os::raw::{c_char, c_int, c_uint};
 use std::panic::{catch_unwind, UnwindSafe};
 
@@ -623,6 +624,12 @@ pub fn cstr_to_rust_string(c_char_ptr: *const c_char) -> Option<String> {
 pub struct SourceLocation {
     pub file: &'static CStr,
     pub line: c_int,
+}
+
+impl Debug for SourceLocation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{}:{}", self.file.to_string_lossy(), self.line))
+    }
 }
 
 /// Make a [SourceLocation] at the current spot.

--- a/yjit/src/lib.rs
+++ b/yjit/src/lib.rs
@@ -15,4 +15,4 @@ mod stats;
 mod utils;
 mod yjit;
 mod virtualmem;
-mod compilation_log;
+mod log;

--- a/yjit/src/lib.rs
+++ b/yjit/src/lib.rs
@@ -15,3 +15,4 @@ mod stats;
 mod utils;
 mod yjit;
 mod virtualmem;
+mod compilation_log;

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -82,6 +82,12 @@ pub struct Options {
 
     /// Enable writing /tmp/perf-{pid}.map for Linux perf
     pub perf_map: Option<PerfMap>,
+
+    // Log compilations
+    pub gen_compilation_log: bool,
+
+    // Print compilation log on exit (when gen_compilation_log is also true)
+    pub print_compilation_log: bool,
 }
 
 // Initialize the options to default values
@@ -103,6 +109,8 @@ pub static mut OPTIONS: Options = Options {
     frame_pointer: false,
     code_gc: false,
     perf_map: None,
+    gen_compilation_log: false,
+    print_compilation_log: true,
 };
 
 /// YJIT option descriptions for `ruby --help`.
@@ -113,6 +121,7 @@ pub const YJIT_OPTIONS: &'static [(&str, &str)] = &[
     ("--yjit-call-threshold=num",          "Number of calls to trigger JIT."),
     ("--yjit-cold-threshold=num",          "Global calls after which ISEQs not compiled (default: 200K)."),
     ("--yjit-stats",                       "Enable collecting YJIT statistics."),
+    ("--yjit-compilation-log",             "Enable logging of YJIT's compilation activity."),
     ("--yjit-disable",                     "Disable YJIT for lazily enabling it with RubyVM::YJIT.enable."),
     ("--yjit-code-gc",                     "Run code GC when the code size reaches the limit."),
     ("--yjit-perf",                        "Enable frame pointers and perf profiling."),
@@ -306,6 +315,15 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
                 OPTIONS.gen_stats = true;
                 OPTIONS.print_stats = false;
             },
+            _ => {
+                return None;
+            }
+        },
+        ("compilation-log", _) => match opt_val {
+            "" => unsafe {
+                OPTIONS.gen_compilation_log = true;
+                OPTIONS.print_compilation_log = true;
+            }
             _ => {
                 return None;
             }

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -179,6 +179,7 @@ macro_rules! get_option_ref {
     };
 }
 pub(crate) use get_option_ref;
+use crate::compilation_log::CompilationLog;
 
 /// Expected to receive what comes after the third dash in "--yjit-*".
 /// Empty string means user passed only "--yjit". C code rejects when
@@ -323,6 +324,7 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
             "" => unsafe {
                 OPTIONS.gen_compilation_log = true;
                 OPTIONS.print_compilation_log = true;
+                CompilationLog::init();
             }
             _ => {
                 return None;

--- a/yjit/src/options.rs
+++ b/yjit/src/options.rs
@@ -331,6 +331,10 @@ pub fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
                 OPTIONS.compilation_log = Some(CompilationLogOutput::Stderr);
                 CompilationLog::init();
             },
+            "quiet" => unsafe {
+                OPTIONS.compilation_log = Some(CompilationLogOutput::MemoryOnly);
+                CompilationLog::init();
+            },
             arg_value => {
                 let log_file_path = if std::path::Path::new(arg_value).is_dir() {
                     format!("{arg_value}/yjit_compilation_{}.log", std::process::id())

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -8,6 +8,7 @@ use crate::stats::incr_counter;
 use crate::stats::with_compile_time;
 
 use std::os::raw;
+use crate::compilation_log::CompilationLog;
 
 /// Is YJIT on? The interpreter uses this variable to decide whether to trigger
 /// compilation. See jit_exec() and jit_compile().
@@ -181,6 +182,7 @@ pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE, gen_stats: VALUE
             unsafe {
                 OPTIONS.gen_compilation_log = gen_compilation_log.test();
                 OPTIONS.print_compilation_log = print_compilation_log.test();
+                CompilationLog::init();
             }
         }
 

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -180,12 +180,10 @@ pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE, gen_stats: VALUE
 
         if gen_compilation_log.test() {
             unsafe {
-                OPTIONS.gen_compilation_log = gen_compilation_log.test();
-
                 if print_compilation_log.test() {
-                    OPTIONS.print_compilation_log = Some(CompilationLogOutput::Stderr);
+                    OPTIONS.compilation_log = Some(CompilationLogOutput::Stderr);
                 } else {
-                    OPTIONS.print_compilation_log = None;
+                    OPTIONS.compilation_log = Some(CompilationLogOutput::MemoryOnly);
                 }
 
                 CompilationLog::init();

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -167,7 +167,7 @@ pub extern "C" fn rb_yjit_code_gc(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
 
 /// Enable YJIT compilation, returning true if YJIT was previously disabled
 #[no_mangle]
-pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE, gen_stats: VALUE, print_stats: VALUE) -> VALUE {
+pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE, gen_stats: VALUE, print_stats: VALUE, gen_compilation_log: VALUE, print_compilation_log: VALUE) -> VALUE {
     with_vm_lock(src_loc!(), || {
         // Initialize and enable YJIT
         if gen_stats.test() {
@@ -176,6 +176,14 @@ pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE, gen_stats: VALUE
                 OPTIONS.print_stats = print_stats.test();
             }
         }
+
+        if gen_compilation_log.test() {
+            unsafe {
+                OPTIONS.gen_compilation_log = gen_compilation_log.test();
+                OPTIONS.print_compilation_log = print_compilation_log.test();
+            }
+        }
+
         yjit_init();
 
         // Add "+YJIT" to RUBY_DESCRIPTION

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -181,7 +181,13 @@ pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE, gen_stats: VALUE
         if gen_compilation_log.test() {
             unsafe {
                 OPTIONS.gen_compilation_log = gen_compilation_log.test();
-                OPTIONS.print_compilation_log = print_compilation_log.test();
+
+                if print_compilation_log.test() {
+                    OPTIONS.print_compilation_log = Some(CompilationLogOutput::Stderr);
+                } else {
+                    OPTIONS.print_compilation_log = None;
+                }
+
                 CompilationLog::init();
             }
         }

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -8,7 +8,7 @@ use crate::stats::incr_counter;
 use crate::stats::with_compile_time;
 
 use std::os::raw;
-use crate::compilation_log::CompilationLog;
+use crate::log::Log;
 
 /// Is YJIT on? The interpreter uses this variable to decide whether to trigger
 /// compilation. See jit_exec() and jit_compile().
@@ -168,7 +168,7 @@ pub extern "C" fn rb_yjit_code_gc(_ec: EcPtr, _ruby_self: VALUE) -> VALUE {
 
 /// Enable YJIT compilation, returning true if YJIT was previously disabled
 #[no_mangle]
-pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE, gen_stats: VALUE, print_stats: VALUE, gen_compilation_log: VALUE, print_compilation_log: VALUE) -> VALUE {
+pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE, gen_stats: VALUE, print_stats: VALUE, gen_log: VALUE, print_log: VALUE) -> VALUE {
     with_vm_lock(src_loc!(), || {
         // Initialize and enable YJIT
         if gen_stats.test() {
@@ -178,15 +178,15 @@ pub extern "C" fn rb_yjit_enable(_ec: EcPtr, _ruby_self: VALUE, gen_stats: VALUE
             }
         }
 
-        if gen_compilation_log.test() {
+        if gen_log.test() {
             unsafe {
-                if print_compilation_log.test() {
-                    OPTIONS.compilation_log = Some(CompilationLogOutput::Stderr);
+                if print_log.test() {
+                    OPTIONS.log = Some(LogOutput::Stderr);
                 } else {
-                    OPTIONS.compilation_log = Some(CompilationLogOutput::MemoryOnly);
+                    OPTIONS.log = Some(LogOutput::MemoryOnly);
                 }
 
-                CompilationLog::init();
+                Log::init();
             }
         }
 


### PR DESCRIPTION
This PR introduces a new compilation log to help gain insights into how YJIT is optimizing an application. Finding the correct amount information to display for a given context is a bit hard. Some folks may want an entire log while others are only interested in the most recent events. This PR tries to strike a balance by offering a few different operating modes.

# Command-Line Flag

This PR introduces the `--yjit-compilation-log` flag, which functions like a hybrid of `--yjit-stats` and `--yjit-dump-disasm`. The presence of an optional argument will dictate where the compilation log is written.

## No Argument

~`--yjit-compilation-log` without an argument will print the compilation log to `$stderr` when the application exits. Events are buffered until the application exit in order to avoid mixing messages up with other output from the application. To constrain the total amount of memory used, a circular buffer is used to store the logged events. Only the entries present in the buffer at the time the application exits will be printed.~

`--yjit-compilation-log` without an argument will print the compilation log to `$stderr` as events occur. It will be logically equivalent to running with `--yjit-compilation-log=/dev/stderr`, just without file truncation. Events will still be collected in the internal circular buffer for programmatic access.

## Directory Argument

The `--yjit-compilation-log` flag can take an optional argument pointing at a directory (e.g., `--yjit-compilation-log=$PWD`). In this case, it functions very similarly to `--yjit-dump-disasm`: a new file named `yjit_compilation_$PID.log` will be created in the specified directory and all compilation events will be logged to that file. In this way, one directory can capture output from multiple processes. NB: the directory must exist when starting Ruby, otherwise the argument will be treated as if it were a file name (see below).

Unlike the case where output is sent to `$stderr`, all events will be written to the file as they occur. The circular buffer will still be populated in the event you wish to work with the log in memory (accessible via `RubyVM::YJIT.compilation_log`).

## File Argument

The `--yjit-compilation-log` flag can take an optional argument pointing at a file (e.g., `--yjit-compilation-log=my_compilation.log`). This works very similarly to the directory argument case, except instead of a file name being generated, it will use the one supplied.

The file will be created when the process starts. If the file already exists, it will be truncated. This supports a nice workflow whereby you can re-run the same `ruby` invocation repeatedly and avoid mixing results for multiple runs. Moreover, since the file is truncated rather than re-created, you can `tail -f my_compilation.log` without having to restart the `tail` command each time you re-run `ruby`.

# Programmatically Control

In addition to the command-line flag, you can enable or disable the compilation log via `RubyVM::YJIT.enable` and the `compilation_log` keyword argument. It is designed to function similarly to the programmatic control of YJIT's runtime stats. Principally, it accepts three values:

* `false`: Don't enable the compilation log (more of a placeholder since you can't call this method again to disable)
* `true`: Enable the compilation log and print it to `$stderr` at exit
* `:quiet`: Enable the compilation log, but do not write or print it

NB: There is not an option to enable the log and write to a file. If you want to operate in that mode you should supply the `--yjit-compilation-log` argument.

# Programmatic Access

## Check if Enabled

You can check if the YJIT compilation log is currently enabled with `RubyVM::YJIT.compilation_log_enabled?`.

## Reading the Log

The last _N=1024_ compilation log entries are accessible via `RubyVM::YJIT.compilation_log`. The output has the type `Array[Tuple[Time, String]]`, providing the log is enabled. If it is not, the value will be `nil` to help differentiate from a log where no compilation has occurred yet (i.e., an empty array) . The log is automatically cleared when accessed so subsequent reads will be guaranteed to contain new events.
