### PR TITLE
Update references to flori/json

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -2588,7 +2588,7 @@ float_arg(VALUE self)
  * - #as_json: Returns a serialized hash constructed from +self+.
  * - #to_json: Returns a JSON string representing +self+.
  *
- * These methods are provided by the {JSON gem}[https://github.com/flori/json]. To make these methods available:
+ * These methods are provided by the {JSON gem}[https://github.com/ruby/json]. To make these methods available:
  *
  *   require 'json/add/complex'
  *

--- a/doc/ChangeLog/ChangeLog-1.9.3
+++ b/doc/ChangeLog/ChangeLog-1.9.3
@@ -9012,7 +9012,7 @@ Thu Dec  2 01:24:39 2010  NARUSE, Yui  <naruse@ruby-lang.org>
 
 Thu Dec  2 01:02:03 2010  NARUSE, Yui  <naruse@ruby-lang.org>
 
-	* ext/json: Update github/flori/json from 1.4.2+ to
+	* ext/json: Update github/ruby/json from 1.4.2+ to
 	  e22b2f2bdfe6a9b0. this fixes some bugs.
 
 Thu Dec  2 00:05:44 2010  NARUSE, Yui  <naruse@ruby-lang.org>

--- a/doc/ChangeLog/ChangeLog-2.0.0
+++ b/doc/ChangeLog/ChangeLog-2.0.0
@@ -14426,7 +14426,7 @@ Tue May  8 02:34:26 2012  NARUSE, Yui  <naruse@ruby-lang.org>
 Mon May  7 21:19:17 2012  NARUSE, Yui  <naruse@ruby-lang.org>
 
 	* ext/json: Merge JSON 1.7.1.
-	 https://github.com/flori/json/commit/e5b9a9465c1159fae533bca320d950b772bcb4ac
+	 https://github.com/ruby/json/commit/e5b9a9465c1159fae533bca320d950b772bcb4ac
 
 Mon May  7 22:54:22 2012  Martin Bosslet  <Martin.Bosslet@googlemail.com>
 

--- a/doc/ChangeLog/ChangeLog-2.1.0
+++ b/doc/ChangeLog/ChangeLog-2.1.0
@@ -2167,7 +2167,7 @@ Wed Nov 20 11:46:38 2013  NARUSE, Yui  <naruse@ruby-lang.org>
 	* ext/json: merge JSON 1.8.1.
 	  https://github.com/nurse/json/compare/002ac2771ce32776b32ccd2d06e5604de6c36dcd...e09ffc0d7da25d0393873936c118c188c78dbac3
 	* Remove Rubinius exception since transcoding should be working now.
-	* Fix https://github.com/flori/json/issues/162 reported by Marc-Andre
+	* Fix https://github.com/ruby/json/issues/162 reported by Marc-Andre
 	  Lafortune <github_rocks@marc-andre.ca>. Thanks!
 	* Applied patches by Yui NARUSE <naruse@airemix.jp> to suppress
 	  warning with -Wchar-subscripts and better validate UTF-8 strings.
@@ -17913,7 +17913,7 @@ Tue Feb 12 12:02:35 2013  NARUSE, Yui  <naruse@ruby-lang.org>
 
 	* ext/json: merge JSON 1.7.7.
 	  This includes security fix. [CVE-2013-0269]
-	  https://github.com/flori/json/commit/d0a62f3ced7560daba2ad546d83f0479a5ae2cf2
+	  https://github.com/ruby/json/commit/d0a62f3ced7560daba2ad546d83f0479a5ae2cf2
 	  https://groups.google.com/d/topic/rubyonrails-security/4_YvCpLzL58/discussion
 
 Mon Feb 11 23:08:48 2013  Tanaka Akira  <akr@fsij.org>

--- a/doc/ChangeLog/ChangeLog-2.3.0
+++ b/doc/ChangeLog/ChangeLog-2.3.0
@@ -1211,7 +1211,7 @@ Sun Dec  6 08:39:05 2015  SHIBATA Hiroshi  <hsbt@ruby-lang.org>
 	  upstream changes.
 
 	  https://github.com/ruby/ruby/commit/4d059bf9f5f10f3d3088de49fc87e5555db7770d
-	  https://github.com/flori/json/commit/d4c99de78905d96c3f301f48b2c789943bb3f098
+	  https://github.com/ruby/json/commit/d4c99de78905d96c3f301f48b2c789943bb3f098
 
 	* ext/json/lib/json/version.rb: ditto.
 
@@ -10989,7 +10989,7 @@ Fri Feb 13 21:16:00 2015  Yusuke Endoh  <mame@tsg.ne.jp>
 
 Fri Feb 13 14:19:06 2015  SHIBATA Hiroshi  <shibata.hiroshi@gmail.com>
 
-	* ext/json: merge upstream from flori/json
+	* ext/json: merge upstream from ruby/json
 	  change usage of TypedData. [Feature #10739][ruby-core:67564]
 
 Thu Feb 12 18:34:01 2015  multisnow  <infinity.blick.winkel@gmail.com>
@@ -11556,7 +11556,7 @@ Tue Jan 13 21:08:22 2015  SHIBATA Hiroshi  <shibata.hiroshi@gmail.com>
 
 	* ext/json, test/json: merge JSON HEAD(259dee6)
 	  separate implementation of Typed_Data macro.
-	  https://github.com/flori/json/compare/v1.8.1...v1.8.2
+	  https://github.com/ruby/json/compare/v1.8.1...v1.8.2
 
 Tue Jan 13 14:16:35 2015  Nobuyoshi Nakada  <nobu@ruby-lang.org>
 
@@ -12009,7 +12009,7 @@ Mon Dec 29 10:37:27 2014  Thiago Lewin  <thiago_lewin@yahoo.com.br>
 Mon Dec 29 07:27:23 2014  SHIBATA Hiroshi  <shibata.hiroshi@gmail.com>
 
 	* ext/json, test/json: merge JSON HEAD(17fe8e7)
-	  https://github.com/flori/json/compare/v1.8.1...17fe8e7
+	  https://github.com/ruby/json/compare/v1.8.1...17fe8e7
 
 Sun Dec 28 23:49:37 2014  Michal Papis  <mpapis@gmail.com>
 

--- a/doc/ChangeLog/ChangeLog-2.4.0
+++ b/doc/ChangeLog/ChangeLog-2.4.0
@@ -2668,8 +2668,8 @@ Wed Jul  6 07:11:27 2016  Shugo Maeda  <shugo@ruby-lang.org>
 Tue Jul  5 20:49:30 2016  SHIBATA Hiroshi  <hsbt@ruby-lang.org>
 
 	* ext/json/*, test/json/*: Update json-2.0.1.
-	  Changes of 2.0.0: https://github.com/flori/json/blob/f679ebd0c69a94e3e70a897ac9a229f5779c2ee1/CHANGES.md#2015-09-11-200
-	  Changes of 2.0.1: https://github.com/flori/json/blob/f679ebd0c69a94e3e70a897ac9a229f5779c2ee1/CHANGES.md#2016-07-01-201
+	  Changes of 2.0.0: https://github.com/ruby/json/blob/f679ebd0c69a94e3e70a897ac9a229f5779c2ee1/CHANGES.md#2015-09-11-200
+	  Changes of 2.0.1: https://github.com/ruby/json/blob/f679ebd0c69a94e3e70a897ac9a229f5779c2ee1/CHANGES.md#2016-07-01-201
 	  [Feature #12542][ruby-dev:49706][fix GH-1395]
 
 Tue Jul  5 19:39:49 2016  Naohisa Goto  <ngotogenome@gmail.com>

--- a/doc/maintainers.md
+++ b/doc/maintainers.md
@@ -348,7 +348,7 @@ have commit right, others don't.
 #### ext/json
 * NARUSE, Yui (naruse)
 * Hiroshi SHIBATA (hsbt)
-* https://github.com/flori/json
+* https://github.com/ruby/json
 * https://rubygems.org/gems/json
 
 #### ext/openssl

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -27,7 +27,6 @@ class JSONParserTest < Test::Unit::TestCase
   end if defined?(Encoding::UTF_16)
 
   def test_error_message_encoding
-    # https://github.com/flori/json/actions/runs/6478148162/job/17589572890
     pend if RUBY_ENGINE == 'truffleruby'
 
     bug10705 = '[ruby-core:67386] [Bug #10705]'


### PR DESCRIPTION
Now that the repository was transfered, these links will become dead in a few months.