### PR TITLE
Specify `use_ipv6` option for `test_query_ipv4_duplicate_responses`.

### DIFF
--- a/lib/resolv.rb
+++ b/lib/resolv.rb
@@ -403,6 +403,8 @@ class Resolv
     end
 
     def use_ipv6? # :nodoc:
+      @config.lazy_initialize unless @config.instance_variable_get(:@initialized)
+
       use_ipv6 = @config.use_ipv6?
       unless use_ipv6.nil?
         return use_ipv6

--- a/test/resolv/test_dns.rb
+++ b/test/resolv/test_dns.rb
@@ -382,7 +382,7 @@ class TestResolvDNS < Test::Unit::TestCase
       _, server_port, _, server_address = u.addr
       begin
         client_thread = Thread.new {
-          Resolv::DNS.open(:nameserver_port => [[server_address, server_port]], :search => ['bad1.com', 'bad2.com', 'good.com'], ndots: 5) {|dns|
+          Resolv::DNS.open(:nameserver_port => [[server_address, server_port]], :search => ['bad1.com', 'bad2.com', 'good.com'], ndots: 5, use_ipv6: false) {|dns|
             dns.getaddress("example")
           }
         }


### PR DESCRIPTION
That test failing with ipv6 environments. We should investigate that root cause later.