### PR TITLE
Emit warning for other method redefinition types

### DIFF
--- a/vm_method.c
+++ b/vm_method.c
@@ -1058,7 +1058,7 @@ rb_method_entry_make(VALUE klass, ID mid, VALUE defined_class, rb_method_visibil
     }
     /* check mid */
     if (mid == object_id || mid == id__send__) {
-        if (type == VM_METHOD_TYPE_ISEQ && search_method(klass, mid, 0)) {
+        if (type != VM_METHOD_TYPE_CFUNC && search_method(klass, mid, 0)) {
             rb_warn("redefining '%s' may cause serious problems", rb_id2name(mid));
         }
     }


### PR DESCRIPTION
This commit ensures warnings about `object_id` and `__send__` method redefinitions are emitted for other method types such as aliases, procs, and attr readers—anything except C functions.

Redefining `object_id` is quite an easy mistake to make because it's a really useful generic name, and it can happen dynamically. For example in ActiveRecord if a table has a column named `object_id` then the model class will have a dynamically generated `#object_id` getter method. Warning when `object_id` is redefined via meta-programming will help language users avoid this issue.

I'm still new to the internals of Ruby so it would be great if someone could sense check that this warning should apply to each of these types (except `VM_METHOD_TYPE_CFUNC`). If not, then I could update the PR to warn only for a specific subset of types. https://github.com/ruby/ruby/blob/de50c4bd42099a70b06bfa6a7f9fa9a2532a93df/method.h#L110-L121