### PR TITLE
omit dns test failure with mingw

### DIFF
--- a/test/resolv/test_dns.rb
+++ b/test/resolv/test_dns.rb
@@ -89,7 +89,7 @@ class TestResolvDNS < Test::Unit::TestCase
             u = nil
             retry
           end
-          raise
+          omit "Could not find a free port after 10 retries"
         end
 
         # If we get to this point, we have a valid t & u socket


### PR DESCRIPTION
mingw environment can't bind free port with 10 times. We should omit it instead of test failure.

```
 1) Error:
  TestResolvDNS#test_multiple_servers_with_timeout_and_truncated_tcp_fallback:
  Errno::EACCES: Permission denied - bind(2) for "127.0.0.1" port 59677
      D:/a/ruby/ruby/src/test/resolv/test_dns.rb:78:in 'TCPServer#initialize'
      D:/a/ruby/ruby/src/test/resolv/test_dns.rb:78:in 'TCPServer.new'
      D:/a/ruby/ruby/src/test/resolv/test_dns.rb:78:in 'TestResolvDNS#with_udp_and_tcp'
      D:/a/ruby/ruby/src/test/resolv/test_dns.rb:711:in 'TestResolvDNS#test_multiple_servers_with_timeout_and_truncated_tcp_fallback'

    2) Error:
  TestResolvDNS#test_query_ipv4_address_truncated_tcp_fallback:
  Errno::EACCES: Permission denied - bind(2) for "127.0.0.1" port 59689
      D:/a/ruby/ruby/src/test/resolv/test_dns.rb:78:in 'TCPServer#initialize'
      D:/a/ruby/ruby/src/test/resolv/test_dns.rb:78:in 'TCPServer.new'
      D:/a/ruby/ruby/src/test/resolv/test_dns.rb:78:in 'TestResolvDNS#with_udp_and_tcp'
      D:/a/ruby/ruby/src/test/resolv/test_dns.rb:223:in 'TestResolvDNS#test_query_ipv4_address_truncated_tcp_fallback'
```