### PR TITLE
Debug LIBRUBY_RELATIVE on Windows

### DIFF
--- a/tool/mkconfig.rb
+++ b/tool/mkconfig.rb
@@ -20,7 +20,6 @@ mkconfig = File.basename($0)
 
 fast = {'prefix'=>true, 'ruby_install_name'=>true, 'INSTALL'=>true, 'EXEEXT'=>true}
 
-win32 = /mswin/ =~ arch
 universal = /universal.*darwin/ =~ arch
 v_fast = []
 v_others = []
@@ -107,7 +106,6 @@ File.foreach "config.status" do |line|
         end
       end
     end
-    eq = win32 && vars[name] ? '<< "\n"' : '='
     vars[name] = val
     if name == "configure_args"
       val.gsub!(/--with-out-ext/, "--without-ext")
@@ -135,7 +133,7 @@ File.foreach "config.status" do |line|
     when /^includedir$/
       val = '"$(SDKROOT)"'+val if /darwin/ =~ arch
     end
-    v = "  CONFIG[\"#{name}\"] #{eq} #{val}\n"
+    v = "  CONFIG[\"#{name}\"] = #{val}\n"
     if fast[name]
       v_fast << v
     else


### PR DESCRIPTION
I noticed that `RbConfig::CONFIG` does not have the `LIBRUBY_RELATIVE` key on `mswin`. The `rbinstall` script relies on that for deciding whether it needs to include a bash prolog in binstubs: https://github.com/ruby/ruby/blob/823f29a36edd25136999d5a649eaff5e4a41481c/tool/rbinstall.rb#L418-L426.

So I believe that's no working correctly on mswin because of that.

I wonder if this special code I'm removing here is what's breaking that.