### PR TITLE
[Bug #20631] Workaround for macOS 15.0 fork crash

### DIFF
--- a/file.c
+++ b/file.c
@@ -310,8 +310,16 @@ rb_CFString_class_initialize_before_fork(void)
     const char small_str[] = "/";
     long len = sizeof(small_str) - 1;
     CFStringRef s;
-    CFMutableStringRef m = mutable_CFString_new(&s, small_str, len);
-    mutable_CFString_release(m, s);
+    /*
+     * Touch `CFStringCreateWithBytesNoCopy` *twice* because the implementation
+     * shipped with macOS 15.0 24A5331b does not return `NSTaggedPointerString`
+     * instance for the first call (totally not sure why). CoreFoundation
+     * shipped with macOS 15.1 does not have this issue.
+     */
+    for (int i = 0; i < 2; i++) {
+        CFMutableStringRef m = mutable_CFString_new(&s, small_str, len);
+        mutable_CFString_release(m, s);
+    }
 }
 # endif /* HAVE_WORKING_FORK */
 

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1874,8 +1874,6 @@ class TestProcess < Test::Unit::TestCase
     end
 
     def test_daemon_noclose
-      pend "macOS 15.0 is not working with this test" if macos?(15, 0)
-
       data = IO.popen("-", "r+") do |f|
         break f.read if f
         Process.daemon(false, true)


### PR DESCRIPTION
macOS 15.0 24A5331b seems to have a weird issue that `CFStringCreateWithBytesNoCopy` does not return `NSTaggedPointerString` instance for the first call. This issue is fixed in macOS 15.1 but we need to workaround it for macOS 15.0...

This is not an ideal solution and depends on implementation details too much, but we don't have resources to re-implement path string normalization for APFS/HFS+ without CoreFoundation, so just work around for now.

For PoC, the following snippet prints different results for macOS 15.0 and 15.1 beta 24B5055e

```c
// $ clang main.c -framework CoreFoundation
#include <CoreFoundation/CFString.h>
#include <stdio.h>

// Ref: https://github.com/apple-oss-distributions/objc4/blob/8701d5672d3fd3cd817aeb84db1077aafe1a1604/runtime/objc-internal.h#L446-L482
#if (TARGET_OS_OSX || TARGET_OS_MACCATALYST) && __x86_64__
# define _OBJC_TAG_MASK 1ULL
#else
# define _OBJC_TAG_MASK 0x8000000000000000ULL
#endif

#define _objc_isTaggedPointer(x) (((uintptr_t)(x)&_OBJC_TAG_MASK) != 0)

void checkTaggedPointer(const char *ptr, size_t len) {
  CFStringRef s = CFStringCreateWithBytesNoCopy(
      kCFAllocatorDefault, (const UInt8 *)ptr, len, kCFStringEncodingUTF8,
      FALSE, kCFAllocatorNull);
  printf("CFStringCreateWithBytesNoCopy(\"%s\") = %18p (tagged = %s)\n", ptr, s,
         _objc_isTaggedPointer(s) ? "YES" : "NO");
}

int main(int argc, char *argv[]) {
  checkTaggedPointer("/", 1);
  checkTaggedPointer("/", 1);
  return 0;
}

// macOS 15.0
// > CFStringCreateWithBytesNoCopy("/") =     0x600003459780 (tagged = NO)
// > CFStringCreateWithBytesNoCopy("/") = 0x945589177989a9d8 (tagged = YES)

// macOS 15.1 beta 24B5055e
// > CFStringCreateWithBytesNoCopy("/") = 0xb82f3d41355674ba (tagged = YES)
// > CFStringCreateWithBytesNoCopy("/") = 0xb82f3d41355674ba (tagged = YES)
```

https://bugs.ruby-lang.org/issues/20631