### PR TITLE
[Bug #20789] Fix an invalid syntax error when `->a=1...{}`

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -11043,7 +11043,7 @@ parser_yylex(struct parser_params *p)
         SET_LEX_STATE(EXPR_BEG);
         if ((c = nextc(p)) == '.') {
             if ((c = nextc(p)) == '.') {
-                if (p->ctxt.in_argdef || IS_LABEL_POSSIBLE() || lambda_beginning_p()) {
+                if (p->ctxt.in_argdef || IS_LABEL_POSSIBLE()) {
                     SET_LEX_STATE(EXPR_ENDARG);
                     return tBDOT3;
                 }

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1975,6 +1975,7 @@ eom
     assert_valid_syntax('def nil(...) end')
     assert_valid_syntax('def true(...) end')
     assert_valid_syntax('def false(...) end')
+    assert_valid_syntax('->a=1...{}')
     unexpected = /unexpected \.{3}/
     assert_syntax_error('iter do |...| end', /unexpected/)
     assert_syntax_error('iter {|...|}', /unexpected/)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20789