### PR TITLE
Remove unused timeout in parsey CI.

### DIFF
--- a/.github/workflows/parsey.yml
+++ b/.github/workflows/parsey.yml
@@ -75,7 +75,6 @@ jobs:
 
       - name: make ${{ matrix.test_task }}
         run: make -s ${{ matrix.test_task }} RUN_OPTS="$RUN_OPTS" SPECOPTS="$SPECOPTS"
-        timeout-minutes: ${{ matrix.timeout }}
         env:
           RUBY_TESTOPTS: ${{ matrix.testopts }}
           EXCLUDES: '../src/test/.excludes-parsey'


### PR DESCRIPTION
This is unset and has no fallback. it's causing an error in the CI output

```
Error: An error occurred when attempting to determine the step timeout.
Error: The template is not valid. .github/workflows/parsey.yml (Line: 78, Col: 26): Unexpected value ''
```