### PR TITLE
gems/bundled_gems - fix typeprof so it installs

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -19,7 +19,7 @@ net-smtp            0.5.0   https://github.com/ruby/net-smtp
 matrix              0.4.2   https://github.com/ruby/matrix
 prime               0.1.2   https://github.com/ruby/prime
 rbs                 3.6.1   https://github.com/ruby/rbs
-typeprof            0.21.11 https://github.com/ruby/typeprof 167263ca3a634b61df0445f1a6b3e259a5d47f94
+typeprof            0.30.0  https://github.com/ruby/typeprof 25faad1a7194cdbd1cd17b36c1da27985a2d62ac
 debug               1.9.2   https://github.com/ruby/debug 9c4279598e9e0376657b3813bf76a206f1f97beb
 racc                1.8.1   https://github.com/ruby/racc
 mutex_m             0.2.0   https://github.com/ruby/mutex_m


### PR DESCRIPTION
See https://github.com/ruby/ruby-dev-builder/actions/runs/11280388443/job/31373282203#step:19:357

Switch to most recent commit and current version