### PR TITLE
Support `IO#timeout` for `rsock_connect`.

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -55,13 +55,6 @@ init_inetsock_internal(VALUE v)
     int family = AF_UNSPEC;
     const char *syscall = 0;
     VALUE connect_timeout = arg->connect_timeout;
-    struct timeval tv_storage;
-    struct timeval *tv = NULL;
-
-    if (!NIL_P(connect_timeout)) {
-        tv_storage = rb_time_interval(connect_timeout);
-        tv = &tv_storage;
-    }
 
     arg->remote.res = rsock_addrinfo(arg->remote.host, arg->remote.serv,
                                      family, SOCK_STREAM,
@@ -130,7 +123,7 @@ init_inetsock_internal(VALUE v)
             }
 
             if (status >= 0) {
-                status = rsock_connect(io, res->ai_addr, res->ai_addrlen, (type == INET_SOCKS), tv);
+                status = rsock_connect(io, res->ai_addr, res->ai_addrlen, (type == INET_SOCKS), connect_timeout);
                 syscall = "connect(2)";
             }
         }

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -379,7 +379,7 @@ VALUE rsock_s_recvfrom_nonblock(VALUE sock, VALUE len, VALUE flg, VALUE str,
                                 VALUE ex, enum sock_recv_type from);
 VALUE rsock_s_recvfrom(VALUE sock, int argc, VALUE *argv, enum sock_recv_type from);
 
-int rsock_connect(VALUE self, const struct sockaddr *sockaddr, int len, int socks, struct timeval *timeout);
+int rsock_connect(VALUE self, const struct sockaddr *sockaddr, int len, int socks, VALUE timeout);
 
 VALUE rsock_s_accept(VALUE klass, VALUE io, struct sockaddr *sockaddr, socklen_t *len);
 VALUE rsock_s_accept_nonblock(VALUE klass, VALUE ex, rb_io_t *fptr,

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -387,16 +387,15 @@ rsock_sock_s_socketpair(int argc, VALUE *argv, VALUE klass)
  * * connect function in Microsoft's Winsock functions reference
  */
 static VALUE
-sock_connect(VALUE sock, VALUE addr)
+sock_connect(VALUE self, VALUE addr)
 {
     VALUE rai;
-    rb_io_t *fptr;
 
     SockAddrStringValueWithAddrinfo(addr, rai);
     addr = rb_str_new4(addr);
-    GetOpenFile(sock, fptr);
 
-    int result = rsock_connect(sock, (struct sockaddr*)RSTRING_PTR(addr), RSTRING_SOCKLEN(addr), 0, NULL);
+    int result = rsock_connect(self, (struct sockaddr*)RSTRING_PTR(addr), RSTRING_SOCKLEN(addr), 0, RUBY_IO_TIMEOUT_DEFAULT);
+
     if (result < 0) {
         rsock_sys_fail_raddrinfo_or_sockaddr("connect(2)", addr, rai);
     }

--- a/ext/socket/udpsocket.c
+++ b/ext/socket/udpsocket.c
@@ -56,7 +56,7 @@ udp_connect_internal(VALUE v)
     struct addrinfo *res;
 
     for (res = arg->res->ai; res; res = res->ai_next) {
-        if (rsock_connect(arg->io, res->ai_addr, res->ai_addrlen, 0, NULL) >= 0) {
+        if (rsock_connect(arg->io, res->ai_addr, res->ai_addrlen, 0, RUBY_IO_TIMEOUT_DEFAULT) >= 0) {
             return Qtrue;
         }
     }

--- a/ext/socket/unixsocket.c
+++ b/ext/socket/unixsocket.c
@@ -21,7 +21,7 @@ static VALUE
 unixsock_connect_internal(VALUE a)
 {
     struct unixsock_arg *arg = (struct unixsock_arg *)a;
-    return (VALUE)rsock_connect(arg->io, (struct sockaddr*)arg->sockaddr, arg->sockaddrlen, 0, NULL);
+    return (VALUE)rsock_connect(arg->io, (struct sockaddr*)arg->sockaddr, arg->sockaddrlen, 0, RUBY_IO_TIMEOUT_DEFAULT);
 }
 
 static VALUE

--- a/spec/ruby/library/socket/socket/connect_spec.rb
+++ b/spec/ruby/library/socket/socket/connect_spec.rb
@@ -53,4 +53,18 @@ describe 'Socket#connect' do
       end
     end
   end
+
+  ruby_version_is "3.4" do
+    it "fails with timeout" do
+      # TEST-NET-1 IP address are reserved for documentation and example purposes.
+      address = Socket.pack_sockaddr_in(1, "192.0.2.1")
+
+      client = Socket.new(Socket::AF_INET, Socket::SOCK_STREAM)
+      client.timeout = 0
+
+      -> {
+        client.connect(address)
+      }.should raise_error(IO::TimeoutError)
+    end
+  end
 end


### PR DESCRIPTION
Introduce support for general `IO#timeout` to `rsock_connect`:

```ruby
# Simple connect example:

require 'socket'

socket = Socket.new(:INET, :STREAM)
socket.timeout = 1
remote_addr = Socket.pack_sockaddr_in(80, '192.168.1.200') # Doesn't exist.
socket.connect(remote_addr) # raises IO::TimeoutError
```

See <https://github.com/socketry/async-http/issues/184> for more details/context. For reference, this builds on the previous changes: https://github.com/ruby/ruby/commits/master/?author=ioquatix&since=2024-10-04&until=2024-10-11