### PR TITLE
Remove unnecessary semantic actions

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -3190,9 +3190,6 @@ stmts		: none
                 ;
 
 stmt_or_begin	: stmt
-                    {
-                        $$ = $1;
-                    }
                 | keyword_BEGIN
                     {
                         yyerror1(&@1, "BEGIN is permitted only at toplevel");
@@ -4034,9 +4031,6 @@ arg		: asgn(lhs, arg_rhs)
                     }
                 | def_endless_method(endless_arg)
                 | primary
-                    {
-                        $$ = $1;
-                    }
                 ;
 
 endless_arg	: arg %prec modifier_rescue
@@ -4097,9 +4091,6 @@ arg_value	: value_expr(arg)
 
 aref_args	: none
                 | args trailer
-                    {
-                        $$ = $1;
-                    }
                 | args ',' assocs trailer
                     {
                         $$ = $3 ? arg_append(p, $1, new_hash(p, $3, &@3), &@$) : $1;
@@ -4163,9 +4154,6 @@ opt_paren_args	: none
 opt_call_args	: none
                 | call_args
                 | args ','
-                    {
-                        $$ = $1;
-                    }
                 | args ',' assocs ','
                     {
                         $$ = $3 ? arg_append(p, $1, new_hash(p, $3, &@3), &@$) : $1;
@@ -5632,9 +5620,6 @@ p_args		: p_expr
                 ;
 
 p_args_head	: p_arg ','
-                    {
-                        $$ = $1;
-                    }
                 | p_args_head p_arg ','
                     {
                         $$ = list_concat($1, $2);


### PR DESCRIPTION
If you don’t specify an action for a rule, Lrama supplies a default: `$$ = $1`.