### PR TITLE
Show where mutated chilled strings were allocated

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4726,7 +4726,7 @@ assert_equal '[0, {1 => 1}]', %q{
 }
 
 # Chilled string setivar trigger warning
-assert_equal 'literal string will be frozen in the future', %q{
+assert_match(/literal string will be frozen in the future/, %q{
   Warning[:deprecated] = true
   $VERBOSE = true
   $warning = "no-warning"
@@ -4754,7 +4754,7 @@ assert_equal 'literal string will be frozen in the future', %q{
 
   setivar!("chilled") # Emit warning
   $warning
-}
+})
 
 # arity=-2 cfuncs
 assert_equal '["", "1/2", [0, [:ok, 1]]]', %q{

--- a/internal/string.h
+++ b/internal/string.h
@@ -57,6 +57,10 @@ VALUE rb_str_upto_each(VALUE, VALUE, int, int (*each)(VALUE, VALUE), VALUE);
 size_t rb_str_size_as_embedded(VALUE);
 bool rb_str_reembeddable_p(VALUE);
 VALUE rb_str_upto_endless_each(VALUE, int (*each)(VALUE, VALUE), VALUE);
+VALUE rb_str_with_debug_created_info(VALUE, VALUE, int);
+
+/* error.c */
+void rb_warn_unchilled(VALUE str);
 
 static inline bool STR_EMBED_P(VALUE str);
 static inline bool STR_SHARED_P(VALUE str);
@@ -124,7 +128,7 @@ static inline void
 CHILLED_STRING_MUTATED(VALUE str)
 {
     FL_UNSET_RAW(str, STR_CHILLED);
-    rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "literal string will be frozen in the future");
+    rb_warn_unchilled(str);
 }
 
 static inline void

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -319,10 +319,7 @@ parse_static_literal_string(rb_iseq_t *iseq, const pm_scope_node_t *scope_node, 
 
     if (ISEQ_COMPILE_DATA(iseq)->option->debug_frozen_string_literal || RTEST(ruby_debug)) {
         int line_number = pm_node_line_number(scope_node->parser, node);
-        VALUE debug_info = rb_ary_new_from_args(2, rb_iseq_path(iseq), INT2FIX(line_number));
-        value = rb_str_dup(value);
-        rb_ivar_set(value, id_debug_created_info, rb_ary_freeze(debug_info));
-        rb_str_freeze(value);
+        value = rb_str_with_debug_created_info(value, rb_iseq_path(iseq), line_number);
     }
 
     return value;
@@ -726,9 +723,7 @@ static VALUE
 pm_static_literal_string(rb_iseq_t *iseq, VALUE string, int line_number)
 {
     if (ISEQ_COMPILE_DATA(iseq)->option->debug_frozen_string_literal || RTEST(ruby_debug)) {
-        VALUE debug_info = rb_ary_new_from_args(2, rb_iseq_path(iseq), INT2FIX(line_number));
-        rb_ivar_set(string, id_debug_created_info, rb_ary_freeze(debug_info));
-        return rb_str_freeze(string);
+        return rb_str_with_debug_created_info(string, rb_iseq_path(iseq), line_number);
     }
     else {
         return rb_fstring(string);

--- a/spec/ruby/command_line/fixtures/debug_info.rb
+++ b/spec/ruby/command_line/fixtures/debug_info.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 a = 'string'
 b = a
 c = b

--- a/spec/ruby/command_line/frozen_strings_spec.rb
+++ b/spec/ruby/command_line/frozen_strings_spec.rb
@@ -57,9 +57,18 @@ end
 
 describe "The --debug flag produces" do
   it "debugging info on attempted frozen string modification" do
-    error_str = ruby_exe(fixture(__FILE__, 'debug_info.rb'), options: '--debug',  args: "2>&1")
+    error_str = ruby_exe(fixture(__FILE__, 'debug_info.rb'), options: '--enable-frozen-string-literal --debug',  args: "2>&1")
     error_str.should include("can't modify frozen String")
     error_str.should include("created at")
-    error_str.should include("command_line/fixtures/debug_info.rb:2")
+    error_str.should include("command_line/fixtures/debug_info.rb:1")
+  end
+
+  guard -> { ruby_version_is "3.4" and !"test".frozen? } do
+    it "debugging info on mutating chilled string" do
+      error_str = ruby_exe(fixture(__FILE__, 'debug_info.rb'), options: '-w --debug',  args: "2>&1")
+      error_str.should include("literal string will be frozen in the future")
+      error_str.should include("the string was created here")
+      error_str.should include("command_line/fixtures/debug_info.rb:1")
+    end
   end
 end

--- a/string.c
+++ b/string.c
@@ -1811,41 +1811,9 @@ ec_str_alloc_heap(struct rb_execution_context_struct *ec, VALUE klass)
 }
 
 static inline VALUE
-str_duplicate_setup(VALUE klass, VALUE str, VALUE dup)
+str_duplicate_setup_encoding(VALUE str, VALUE dup, VALUE flags)
 {
-    const VALUE flag_mask =
-        ENC_CODERANGE_MASK | ENCODING_MASK |
-        FL_FREEZE
-        ;
-    VALUE flags = FL_TEST_RAW(str, flag_mask);
     int encidx = 0;
-    if (STR_EMBED_P(str)) {
-        long len = RSTRING_LEN(str);
-
-        RUBY_ASSERT(STR_EMBED_P(dup));
-        RUBY_ASSERT(str_embed_capa(dup) >= len + 1);
-        MEMCPY(RSTRING(dup)->as.embed.ary, RSTRING(str)->as.embed.ary, char, len + 1);
-    }
-    else {
-        VALUE root = str;
-        if (FL_TEST_RAW(str, STR_SHARED)) {
-            root = RSTRING(str)->as.heap.aux.shared;
-        }
-        else if (UNLIKELY(!(flags & FL_FREEZE))) {
-            root = str = str_new_frozen(klass, str);
-            flags = FL_TEST_RAW(str, flag_mask);
-        }
-        RUBY_ASSERT(!STR_SHARED_P(root));
-        RUBY_ASSERT(RB_OBJ_FROZEN_RAW(root));
-
-        RSTRING(dup)->as.heap.ptr = RSTRING_PTR(str);
-        FL_SET(root, STR_SHARED_ROOT);
-        RB_OBJ_WRITE(dup, &RSTRING(dup)->as.heap.aux.shared, root);
-        flags |= RSTRING_NOEMBED | STR_SHARED;
-    }
-
-    STR_SET_LEN(dup, RSTRING_LEN(str));
-
     if ((flags & ENCODING_MASK) == (ENCODING_INLINE_MAX<<ENCODING_SHIFT)) {
         encidx = rb_enc_get_index(str);
         flags &= ~ENCODING_MASK;
@@ -1855,18 +1823,54 @@ str_duplicate_setup(VALUE klass, VALUE str, VALUE dup)
     return dup;
 }
 
+static const VALUE flag_mask = ENC_CODERANGE_MASK | ENCODING_MASK | FL_FREEZE;
+
 static inline VALUE
-ec_str_duplicate(struct rb_execution_context_struct *ec, VALUE klass, VALUE str)
+str_duplicate_setup_embed(VALUE klass, VALUE str, VALUE dup)
 {
-    VALUE dup;
+    VALUE flags = FL_TEST_RAW(str, flag_mask);
+    long len = RSTRING_LEN(str);
+
+    RUBY_ASSERT(STR_EMBED_P(dup));
+    RUBY_ASSERT(str_embed_capa(dup) >= len + 1);
+    MEMCPY(RSTRING(dup)->as.embed.ary, RSTRING(str)->as.embed.ary, char, len + 1);
+    STR_SET_LEN(dup, RSTRING_LEN(str));
+    return str_duplicate_setup_encoding(str, dup, flags);
+}
+
+static inline VALUE
+str_duplicate_setup_heap(VALUE klass, VALUE str, VALUE dup)
+{
+    VALUE flags = FL_TEST_RAW(str, flag_mask);
+    VALUE root = str;
+    if (FL_TEST_RAW(str, STR_SHARED)) {
+        root = RSTRING(str)->as.heap.aux.shared;
+    }
+    else if (UNLIKELY(!(flags & FL_FREEZE))) {
+        root = str = str_new_frozen(klass, str);
+        flags = FL_TEST_RAW(str, flag_mask);
+    }
+    RUBY_ASSERT(!STR_SHARED_P(root));
+    RUBY_ASSERT(RB_OBJ_FROZEN_RAW(root));
+
+    RSTRING(dup)->as.heap.ptr = RSTRING_PTR(str);
+    FL_SET(root, STR_SHARED_ROOT);
+    RB_OBJ_WRITE(dup, &RSTRING(dup)->as.heap.aux.shared, root);
+    flags |= RSTRING_NOEMBED | STR_SHARED;
+
+    STR_SET_LEN(dup, RSTRING_LEN(str));
+    return str_duplicate_setup_encoding(str, dup, flags);
+}
+
+static inline VALUE
+str_duplicate_setup(VALUE klass, VALUE str, VALUE dup)
+{
     if (STR_EMBED_P(str)) {
-        dup = ec_str_alloc_embed(ec, klass, RSTRING_LEN(str) + TERM_LEN(str));
+        return str_duplicate_setup_embed(klass, str, dup);
     }
     else {
-        dup = ec_str_alloc_heap(ec, klass);
+        return str_duplicate_setup_heap(klass, str, dup);
     }
-
-    return str_duplicate_setup(klass, str, dup);
 }
 
 static inline VALUE
@@ -1912,11 +1916,30 @@ VALUE
 rb_ec_str_resurrect(struct rb_execution_context_struct *ec, VALUE str, bool chilled)
 {
     RUBY_DTRACE_CREATE_HOOK(STRING, RSTRING_LEN(str));
-    VALUE new_str = ec_str_duplicate(ec, rb_cString, str);
+    VALUE new_str, klass = rb_cString;
+
+    if (!(chilled && RTEST(rb_ivar_defined(str, id_debug_created_info))) && STR_EMBED_P(str)) {
+        new_str = ec_str_alloc_embed(ec, klass, RSTRING_LEN(str) + TERM_LEN(str));
+        str_duplicate_setup_embed(klass, str, new_str);
+    }
+    else {
+        new_str = ec_str_alloc_heap(ec, klass);
+        str_duplicate_setup_heap(klass, str, new_str);
+    }
     if (chilled) {
         STR_CHILL_RAW(new_str);
     }
     return new_str;
+}
+
+VALUE
+rb_str_with_debug_created_info(VALUE str, VALUE path, int line)
+{
+    VALUE debug_info = rb_ary_new_from_args(2, path, INT2FIX(line));
+    if (OBJ_FROZEN_RAW(str)) str = rb_str_dup(str);
+    rb_ivar_set(str, id_debug_created_info, rb_ary_freeze(debug_info));
+    STR_CHILL_RAW(str);
+    return rb_str_freeze(str);
 }
 
 /*

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -1262,9 +1262,8 @@ class TestRubyOptions < Test::Unit::TestCase
     code = <<~RUBY
       "foo" << "bar"
     RUBY
-    warning = ["-:1: warning: literal string will be frozen in the future"]
-    assert_in_out_err(["-W:deprecated"], code, [], warning)
-    assert_in_out_err(["-W:deprecated", "--debug-frozen-string-literal"], code, [], warning)
+    assert_in_out_err(["-W:deprecated"], code, [], ["-:1: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)"])
+    assert_in_out_err(["-W:deprecated", "--debug-frozen-string-literal"], code, [], ["-:1: warning: literal string will be frozen in the future", "-:1: info: the string was created here"])
     assert_in_out_err(["-W:deprecated", "--disable-frozen-string-literal", "--debug-frozen-string-literal"], code, [], [])
     assert_in_out_err(["-W:deprecated", "--enable-frozen-string-literal", "--debug-frozen-string-literal"], code, [], ["-:1:in '<main>': can't modify frozen String: \"foo\", created at -:1 (FrozenError)"])
   end


### PR DESCRIPTION
[[Feature #20205]](https://bugs.ruby-lang.org/issues/20205)

The warning now suggests running with `--debug-frozen-string-literal`:

```
test.rb:3: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```

When using `--debug-frozen-string-literal`, the location where the string was created is shown:

```
test.rb:3: warning: literal string will be frozen in the future
test.rb:1: the string was created here
```

When resurrecting strings and debug mode is not enabled, the overhead is a simple `FL_TEST_RAW`. When mutating chilled strings and deprecation warnings are not enabled, the overhead is a simple warning category enabled check.