### PR TITLE
RubyVM::InstructionSequence.of Thread::Backtrace::Location

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -3029,7 +3029,10 @@ iseqw_s_of(VALUE klass, VALUE body)
 {
     const rb_iseq_t *iseq = NULL;
 
-    if (rb_obj_is_proc(body)) {
+    if (rb_frame_info_p(body)) {
+        iseq = rb_get_iseq_from_frame_info(body);
+    }
+    else if (rb_obj_is_proc(body)) {
         iseq = vm_proc_iseq(body);
 
         if (!rb_obj_is_iseq((VALUE)iseq)) {

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -726,18 +726,24 @@ class TestISeq < Test::Unit::TestCase
   end
 
   def test_iseq_of
-    [proc{},
-     method(:test_iseq_of),
-     RubyVM::InstructionSequence.compile("p 1", __FILE__)].each{|src|
+    [
+      proc{},
+      method(:test_iseq_of),
+      RubyVM::InstructionSequence.compile("p 1", __FILE__),
+      begin; raise "error"; rescue => error; error.backtrace_locations[0]; end
+    ].each{|src|
       iseq = RubyVM::InstructionSequence.of(src)
       assert_equal __FILE__, iseq.path
     }
   end
 
   def test_iseq_of_twice_for_same_code
-    [proc{},
-     method(:test_iseq_of_twice_for_same_code),
-     RubyVM::InstructionSequence.compile("p 1")].each{|src|
+    [
+      proc{},
+      method(:test_iseq_of_twice_for_same_code),
+      RubyVM::InstructionSequence.compile("p 1"),
+      begin; raise "error"; rescue => error; error.backtrace_locations[0]; end
+    ].each{|src|
       iseq1 = RubyVM::InstructionSequence.of(src)
       iseq2 = RubyVM::InstructionSequence.of(src)
 


### PR DESCRIPTION
This would be useful for debugging.