### PR TITLE
Remove unused shared GC configuration in GitHub Actions

### DIFF
--- a/.github/actions/compilers/entrypoint.sh
+++ b/.github/actions/compilers/entrypoint.sh
@@ -70,14 +70,6 @@ fi
 
 pushd ${builddir}
 
-case "${INPUT_APPEND_CONFIGURE}" in
-*--with-shared-gc*)
-    export RUBY_GC_LIBRARY='librubygc.default.so'
-    mkdir -p /home/runner/shared-gc
-    grouped make shared-gc SHARED_GC=default
-    ;;
-esac
-
 grouped make showflags
 grouped make all
 grouped make test


### PR DESCRIPTION
Shared GC CI is no longer running in the compilers workflow, so we can remove it from .github/actions/compilers/entrypoint.sh.