### PR TITLE
Use GC.respond_to?(:compact) in bootstraptest/test_yjit.rb

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -123,7 +123,7 @@ assert_equal '[:ae, :ae]', %q{
 
 # regression test for GC marking stubs in invalidated code
 assert_normal_exit %q{
-  skip true unless defined?(GC.compact)
+  skip true unless GC.respond_to?(:compact)
   garbage = Array.new(10_000) { [] } # create garbage to cause iseq movement
   eval(<<~RUBY)
   def foo(n, garbage)
@@ -158,7 +158,7 @@ assert_equal '0', "0.abs(&nil)"
 
 # regression test for invokeblock iseq guard
 assert_equal 'ok', %q{
-  skip :ok unless defined?(GC.compact)
+  skip :ok unless GC.respond_to?(:compact)
   def foo = yield
   10.times do |i|
     ret = eval("foo { #{i} }")
@@ -1230,7 +1230,7 @@ assert_equal 'special', %q{
 
 # Test that object references in generated code get marked and moved
 assert_equal "good", %q{
-  skip :good unless defined?(GC.compact)
+  skip :good unless GC.respond_to?(:compact)
   def bar
     "good"
   end
@@ -2351,7 +2351,7 @@ assert_equal '123', %q{
 
 # Test EP == BP invalidation with moving ISEQs
 assert_equal 'ok', %q{
-  skip :ok unless defined?(GC.compact)
+  skip :ok unless GC.respond_to?(:compact)
   def entry
     ok = proc { :ok } # set #entry as an EP-escaping ISEQ
     [nil].reverse_each do # avoid exiting the JIT frame on the constant


### PR DESCRIPTION
defined?(GC.compact) will always return true even when compaction is not supported. We should use GC.respond_to?(:compact) instead.