### PR TITLE
Remove "simple" flag from forwarded ICs

### DIFF
--- a/bootstraptest/test_method.rb
+++ b/bootstraptest/test_method.rb
@@ -1374,3 +1374,24 @@ assert_equal 'ok', %q{
   foo(:foo, b: :ok)
   foo(*["foo"], b: :ok)
 }
+
+assert_equal 'ok', %q{
+  Thing = Struct.new(:value)
+
+  Obj = Thing.new("ok")
+
+  def delegate(...)
+    Obj.value(...)
+  end
+
+  def no_args
+    delegate
+  end
+
+  def splat_args(*args)
+    delegate(*args)
+  end
+
+  no_args
+  splat_args
+}

--- a/vm_args.c
+++ b/vm_args.c
@@ -1177,7 +1177,7 @@ vm_caller_setup_fwd_args(const rb_execution_context_t *ec, rb_control_frame_t *r
 
     *adjusted_ci = VM_CI_ON_STACK(
             site_mid,
-            (caller_flag | (site_flag & (VM_CALL_FCALL | VM_CALL_FORWARDING))),
+            ((caller_flag & ~VM_CALL_ARGS_SIMPLE) | (site_flag & (VM_CALL_FCALL | VM_CALL_FORWARDING))),
             site_argc + caller_argc,
             kw
             );


### PR DESCRIPTION
I don't think we should ever consider forwarded IC's to be "simple". Previously, the "simple" flag would be copied to the derived IC and this happened to cause struct set / get iseqs to write an invalid CC fastpath:

  https://github.com/tenderlove/ruby/blob/f45eb3dcb9c7d849064cb802953f37e1cf9f3996/vm_insnhelper.c#L4726-L4729

[Bug #20799]