### PR TITLE
Fix an off-by-one error of own memrchr implementation

### DIFF
--- a/string.c
+++ b/string.c
@@ -4525,9 +4525,9 @@ static void*
 memrchr(const char *search_str, int chr, long search_len)
 {
     const char *ptr = search_str + search_len;
-    do {
+    while (ptr > search_str) {
         if ((unsigned char)*(--ptr) == chr) return (void *)ptr;
-    } while (ptr >= search_str);
+    }
 
     return ((void *)0);
 }


### PR DESCRIPTION
and make it support `search_len == 0`, just for the case

Ref [Bug #20796]