### PR TITLE
Fix wmap_compact from potentially corrupting ST table

### DIFF
--- a/weakmap.c
+++ b/weakmap.c
@@ -156,7 +156,7 @@ wmap_compact_table_i(struct weakmap_entry *entry, st_data_t data)
     entry->val = rb_gc_location(entry->val);
 
     /* If the key object moves, then we must reinsert because the hash is
-        * based on the pointer rather than the object itself. */
+     * based on the pointer rather than the object itself. */
     if (entry->key != new_key) {
         entry->key = new_key;
 


### PR DESCRIPTION
Since we hash by the address of the key in the WeakMap, we cannot change the key in the same entry because deleting the key could require hashing.

This commit changes it to allocate and insert a new entry if the key has moved.