### PR TITLE
Don't clear out flags in rb_gc_obj_free

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1314,7 +1314,6 @@ rb_gc_obj_free(void *objspace, VALUE obj)
         return FALSE;
     }
     else {
-        RBASIC(obj)->flags = 0;
         return TRUE;
     }
 }

--- a/gc/default.c
+++ b/gc/default.c
@@ -3030,7 +3030,9 @@ rb_gc_impl_shutdown_free_objects(void *objspace_ptr)
             VALUE vp = (VALUE)p;
             asan_unpoisoning_object(vp) {
                 if (RB_BUILTIN_TYPE(vp) != T_NONE) {
-                    rb_gc_obj_free(objspace, vp);
+                    if (rb_gc_obj_free(objspace, vp)) {
+                        RBASIC(vp)->flags = 0;
+                    }
                 }
             }
         }
@@ -3102,7 +3104,9 @@ rb_gc_impl_shutdown_call_finalizer(void *objspace_ptr)
             VALUE vp = (VALUE)p;
             asan_unpoisoning_object(vp) {
                 if (rb_gc_shutdown_call_finalizer_p(vp)) {
-                    rb_gc_obj_free(objspace, vp);
+                    if (rb_gc_obj_free(objspace, vp)) {
+                        RBASIC(vp)->flags = 0;
+                    }
                 }
             }
         }


### PR DESCRIPTION
If there's a crash after rb_gc_obj_free, it's hard to debug because the flags have been cleared out already.