### PR TITLE
Rewrite Numeric#dup and Numeric#+@ in Ruby

### DIFF
--- a/numeric.c
+++ b/numeric.c
@@ -552,39 +552,6 @@ num_clone(int argc, VALUE *argv, VALUE x)
 # define num_clone rb_immutable_obj_clone
 #endif
 
-#if 0
-/*
- *  call-seq:
- *    dup -> self
- *
- *  Returns +self+.
- *
- *  Related: Numeric#clone.
- *
- */
-static VALUE
-num_dup(VALUE x)
-{
-    return x;
-}
-#else
-# define num_dup num_uplus
-#endif
-
-/*
- *  call-seq:
- *    +self -> self
- *
- *  Returns +self+.
- *
- */
-
-static VALUE
-num_uplus(VALUE num)
-{
-    return num;
-}
-
 /*
  *  call-seq:
  *    i -> complex
@@ -6322,10 +6289,8 @@ Init_Numeric(void)
     rb_include_module(rb_cNumeric, rb_mComparable);
     rb_define_method(rb_cNumeric, "coerce", num_coerce, 1);
     rb_define_method(rb_cNumeric, "clone", num_clone, -1);
-    rb_define_method(rb_cNumeric, "dup", num_dup, 0);
 
     rb_define_method(rb_cNumeric, "i", num_imaginary, 0);
-    rb_define_method(rb_cNumeric, "+@", num_uplus, 0);
     rb_define_method(rb_cNumeric, "-@", num_uminus, 0);
     rb_define_method(rb_cNumeric, "<=>", num_cmp, 1);
     rb_define_method(rb_cNumeric, "eql?", num_eql, 1);

--- a/numeric.rb
+++ b/numeric.rb
@@ -1,4 +1,14 @@
 class Numeric
+  #  call-seq:
+  #    dup -> self
+  #
+  #  Returns +self+.
+  #
+  #  Related: Numeric#clone.
+  #
+  def dup
+    self
+  end
 
   #  call-seq:
   #    real? -> true or false
@@ -70,6 +80,15 @@ class Numeric
   end
 
   alias conj conjugate
+
+  #  call-seq:
+  #    +self -> self
+  #
+  #  Returns +self+.
+  #
+  def +@
+    self
+  end
 end
 
 class Integer

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6347,21 +6347,6 @@ fn jit_thread_s_current(
     true
 }
 
-fn jit_numeric_dup(
-    _jit: &mut JITState,
-    _asm: &mut Assembler,
-    _ci: *const rb_callinfo,
-    _cme: *const rb_callable_method_entry_t,
-    _block: Option<BlockHandler>,
-    _argc: i32,
-    _known_recv_class: Option<VALUE>,
-) -> bool {
-    // Numeric#dup has arity=0 and is the identity function.
-    // Our caller already did argument count check, so this is
-    // no-op to return the receiver that is already on the stack.
-    true
-}
-
 /// Specialization for rb_obj_dup() (Kernel#dup)
 fn jit_rb_obj_dup(
     _jit: &mut JITState,
@@ -10459,8 +10444,6 @@ pub fn yjit_reg_method_codegen_fns() {
         reg_method_codegen(rb_cFloat, "-", jit_rb_float_minus);
         reg_method_codegen(rb_cFloat, "*", jit_rb_float_mul);
         reg_method_codegen(rb_cFloat, "/", jit_rb_float_div);
-
-        reg_method_codegen(rb_cNumeric, "dup", jit_numeric_dup);
 
         reg_method_codegen(rb_cString, "empty?", jit_rb_str_empty_p);
         reg_method_codegen(rb_cString, "to_s", jit_rb_str_to_s);


### PR DESCRIPTION
Related to https://github.com/ruby/ruby/pull/11926

YJIT can already inline such simple Ruby methods. We shouldn't need to duplicate the implementation in Rust.