### PR TITLE
YJIT: Check when gen_branch() fails

### DIFF
--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -561,6 +561,7 @@ make_counters! {
     compiled_branch_count,
     compile_time_ns,
     compilation_failure,
+    abandoned_block_count,
     block_next_count,
     defer_count,
     defer_empty_count,


### PR DESCRIPTION
We got some core dumps in the wild where a PendingBranch had everything
as None, which caused a panic unwrapping in
PendingBranch::into_branch(). This happened while compiling a
`branchif`.

It seems that the only way this can happen is when
yjit::core::gen_branch() fails, but not due to OOM. We wouldn't have
reach into_branch() when OOM, and the only way to not leave markers that
would've set the branch's start_addr to some value in gen_branch() is
for set_target() to fail, causing an early return.

Unfortunately, it's hard to tell the exact sequence of events that led
to this situation, but regardless, the core dumps show us that we
should check for errors in gen_branch().

Because gen_branch() is used deep in the stack during compilation (e.g.
guard_known_class() -> jit_chain_guard() -> gen_branch()), it'd be bad
for compile speed to propagate the error everywhere, not to mention the
massive patch required. Opt for a flag checked at the end of
compilation.
