### PR TITLE
Harden the ObjectSpace.memsize_of spec

### DIFF
--- a/spec/ruby/library/objectspace/memsize_of_spec.rb
+++ b/spec/ruby/library/objectspace/memsize_of_spec.rb
@@ -13,7 +13,7 @@ describe "ObjectSpace.memsize_of" do
   end
 
   it "returns 0 for literal Symbols" do
-    ObjectSpace.memsize_of(:abc).should == 0
+    ObjectSpace.memsize_of(:object_space_memsize_spec_static_sym).should == 0
   end
 
   it "returns a positive Integer for an Object" do


### PR DESCRIPTION
[[Bug #20803]](https://bugs.ruby-lang.org/issues/20803)

`abc` is used a lot across the ruby spec suite, if another test runs before this spec is loaded and create this symbol dynamically (`"abc".to_sym`) the spec will fail.

So it's preferable to use a symbol name that is very unlikely to be used elsewhere to avoid flakes.

cc @MSP-Greg 