### PR TITLE
Fix shared GC with -DRUBY_DEBUG

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -13472,6 +13472,7 @@ ractor.$(OBJEXT): $(top_srcdir)/internal/gc.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/hash.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/numeric.h
+ractor.$(OBJEXT): $(top_srcdir)/internal/ractor.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/rational.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/serial.h

--- a/common.mk
+++ b/common.mk
@@ -1914,7 +1914,7 @@ shared-gc: probes.h
 	fi
 	$(ECHO) generating $(shared_gc_dir)librubygc.$(SHARED_GC).$(SOEXT)
 	$(Q) $(MAKEDIRS) $(shared_gc_dir)
-	$(Q) $(LDSHARED) -I$(srcdir)/include -I$(srcdir) -I$(arch_hdrdir) $(XDLDFLAGS) $(cflags) -DBUILDING_SHARED_GC -fPIC -o $(shared_gc_dir)librubygc.$(SHARED_GC).$(SOEXT) $(srcdir)/gc/$(SHARED_GC).c
+	$(Q) $(LDSHARED) -I$(srcdir)/include -I$(srcdir) -I$(arch_hdrdir) $(XDLDFLAGS) $(CFLAGS) $(CPPFLAGS) -DBUILDING_SHARED_GC -fPIC -o $(shared_gc_dir)librubygc.$(SHARED_GC).$(SOEXT) $(srcdir)/gc/$(SHARED_GC).c
 
 help: PHONY
 	$(MESSAGE_BEGIN) \

--- a/internal/ractor.h
+++ b/internal/ractor.h
@@ -3,4 +3,8 @@
 
 void rb_ractor_ensure_main_ractor(const char *msg);
 
+RUBY_SYMBOL_EXPORT_BEGIN
+void rb_ractor_setup_belonging(VALUE obj);
+RUBY_SYMBOL_EXPORT_END
+
 #endif /* INTERNAL_RACTOR_H */

--- a/ractor.c
+++ b/ractor.c
@@ -12,6 +12,7 @@
 #include "internal/error.h"
 #include "internal/gc.h"
 #include "internal/hash.h"
+#include "internal/ractor.h"
 #include "internal/rational.h"
 #include "internal/struct.h"
 #include "internal/thread.h"


### PR DESCRIPTION
RUBY_DEBUG enables ractor assertions, which sets up some space at the end of each RVALUE to store the associated ractor ID. We need to make sure the function that does this is visible to shared GC libraries.