### PR TITLE
Travis reenable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ env:
   global:
     - NPROC="$(nproc)"
     - JOBS="-j${NPROC}"
-    # SETARCH are overridden when necessary. See below.
-    - SETARCH=
     # https://github.com/travis-ci/travis-build/blob/e411371dda21430a60f61b8f3f57943d2fe4d344/lib/travis/build/bash/travis_apt_get_options.bash#L7
     - travis_apt_get_options='--allow-downgrades --allow-remove-essential --allow-change-held-packages'
     - travis_apt_get_options="-yq --no-install-suggests --no-install-recommends $travis_apt_get_options"
@@ -72,52 +70,17 @@ env:
       # on s390x CPU architecture.
       # https://github.com/madler/zlib/pull/410
       - DFLTCC=0
-  - &arm32-linux
-    name: arm32-linux
-    arch: arm64
-    # https://packages.ubuntu.com/jammy/crossbuild-essential-armhf
-    compiler: arm-linux-gnueabihf-gcc
-    env:
-      - SETARCH='setarch linux32 --verbose --32bit'
-      # Still keep the -O1 for only arm32, while we want to test with the
-      # default optflags -O3.
-      # Because bootstraptest/test_ractor.rb fails with segfualt with the
-      # default -O3.
-      # https://bugs.ruby-lang.org/issues/19981
-      - optflags=-O1
-    before_install:
-      - sudo dpkg --add-architecture armhf
-      - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
-      - >-
-        tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
-        crossbuild-essential-armhf
-        libc6:armhf
-        libstdc++-10-dev:armhf
-        libffi-dev:armhf
-        libncurses-dev:armhf
-        libncursesw5-dev:armhf
-        libreadline-dev:armhf
-        libssl-dev:armhf
-        libyaml-dev:armhf
-        linux-libc-dev:armhf
-        zlib1g-dev:armhf
 
 matrix:
   include:
     - <<: *arm64-linux
     - <<: *ppc64le-linux
     - <<: *s390x-linux
-    # FIXME: lib/rubygems/util.rb:104 glob_files_in_dir -
-    # <internal:dir>:411:in glob: File name too long - (Errno::ENAMETOOLONG)
-    # https://github.com/rubygems/rubygems/issues/7132
-    - <<: *arm32-linux
   allow_failures:
     # The arm64 is very slow to start the jobs.
     - name: arm64-linux
     - name: ppc64le-linux
     - name: s390x-linux
-    # The arm64 is very slow to start the jobs.
-    - name: arm32-linux
   fast_finish: true
 
 before_script:
@@ -125,18 +88,18 @@ before_script:
   - ./autogen.sh
   - mkdir build
   - cd build
-  - $SETARCH ../configure -C --disable-install-doc --prefix=$(pwd)/install
-  - $SETARCH make -s $JOBS
+  - ../configure -C --disable-install-doc --prefix=$(pwd)/install
+  - make -s $JOBS
   - make -s $JOBS install
   # Useful info to report issues to the Ruby.
-  - $SETARCH $(pwd)/install/bin/ruby -v
+  - $(pwd)/install/bin/ruby -v
   # Useful info To report issues to the RubyGems.
-  - $SETARCH $(pwd)/install/bin/gem env
+  - $(pwd)/install/bin/gem env
 
 script:
-  - $SETARCH make -s test
-  - ../tool/travis_wait.sh $SETARCH make -s test-all RUBYOPT="-w"
-  - ../tool/travis_wait.sh $SETARCH make -s test-spec
+  - make -s test
+  - ../tool/travis_wait.sh make -s test-all RUBYOPT="-w"
+  - ../tool/travis_wait.sh make -s test-spec
 
 # We want to be notified when something happens.
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,153 @@
+# -*- YAML -*-
+# Copyright (C) 2011 Urabe, Shyouhei.  All rights reserved.
+#
+# This file is  a part of the programming language  Ruby.  Permission is hereby
+# granted,  to either  redistribute  or  modify this  file,  provided that  the
+# conditions  mentioned in  the file  COPYING are  met.  Consult  the  file for
+# details.
+
+# When you see Travis CI issues, or you are interested in understanding how to
+# manage, please check the link below.
+# https://github.com/ruby/ruby/wiki/CI-Servers#travis-ci
+
+# We enable Travis on the specific branches or forked repositories here.
+if: >-
+  (repo != ruby/ruby OR branch = master OR branch =~ /^ruby_\d_\d$/)
+  AND (commit_message !~ /\[DOC\]/)
+
+language: c
+
+os: linux
+
+dist: jammy
+
+git:
+  quiet: true
+
+env:
+  global:
+    - NPROC="$(nproc)"
+    - JOBS="-j${NPROC}"
+    # SETARCH are overridden when necessary. See below.
+    - SETARCH=
+    # https://github.com/travis-ci/travis-build/blob/e411371dda21430a60f61b8f3f57943d2fe4d344/lib/travis/build/bash/travis_apt_get_options.bash#L7
+    - travis_apt_get_options='--allow-downgrades --allow-remove-essential --allow-change-held-packages'
+    - travis_apt_get_options="-yq --no-install-suggests --no-install-recommends $travis_apt_get_options"
+    # -g0 disables backtraces when SEGV. Do not set that.
+    - debugflags=-ggdb3
+    - RUBY_TESTOPTS="$JOBS -q --tty=no"
+
+.org.ruby-lang.ci.matrix-definitions:
+  - &gcc-11
+    compiler: gcc-11
+    before_install:
+      - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
+      - >-
+        tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
+        gcc-11
+        g++-11
+        libffi-dev
+        libncurses-dev
+        libncursesw5-dev
+        libreadline-dev
+        libssl-dev
+        libyaml-dev
+        openssl
+        zlib1g-dev
+      - gcc-11 --version
+  - &arm64-linux
+    name: arm64-linux
+    arch: arm64
+    <<: *gcc-11
+  - &ppc64le-linux
+    name: ppc64le-linux
+    arch: ppc64le
+    <<: *gcc-11
+  - &s390x-linux
+    name: s390x-linux
+    arch: s390x
+    <<: *gcc-11
+    env:
+      # Avoid possible test failures with the zlib applying the following patch
+      # on s390x CPU architecture.
+      # https://github.com/madler/zlib/pull/410
+      - DFLTCC=0
+  - &arm32-linux
+    name: arm32-linux
+    arch: arm64
+    # https://packages.ubuntu.com/jammy/crossbuild-essential-armhf
+    compiler: arm-linux-gnueabihf-gcc
+    env:
+      - SETARCH='setarch linux32 --verbose --32bit'
+      # Still keep the -O1 for only arm32, while we want to test with the
+      # default optflags -O3.
+      # Because bootstraptest/test_ractor.rb fails with segfualt with the
+      # default -O3.
+      # https://bugs.ruby-lang.org/issues/19981
+      - optflags=-O1
+    before_install:
+      - sudo dpkg --add-architecture armhf
+      - tool/travis_retry.sh sudo bash -c "rm -rf '${TRAVIS_ROOT}/var/lib/apt/lists/'* && exec apt-get update -yq"
+      - >-
+        tool/travis_retry.sh sudo -E apt-get $travis_apt_get_options install
+        crossbuild-essential-armhf
+        libc6:armhf
+        libstdc++-10-dev:armhf
+        libffi-dev:armhf
+        libncurses-dev:armhf
+        libncursesw5-dev:armhf
+        libreadline-dev:armhf
+        libssl-dev:armhf
+        libyaml-dev:armhf
+        linux-libc-dev:armhf
+        zlib1g-dev:armhf
+
+matrix:
+  include:
+    - <<: *arm64-linux
+    - <<: *ppc64le-linux
+    - <<: *s390x-linux
+    # FIXME: lib/rubygems/util.rb:104 glob_files_in_dir -
+    # <internal:dir>:411:in glob: File name too long - (Errno::ENAMETOOLONG)
+    # https://github.com/rubygems/rubygems/issues/7132
+    - <<: *arm32-linux
+  allow_failures:
+    # The arm64 is very slow to start the jobs.
+    - name: arm64-linux
+    - name: ppc64le-linux
+    - name: s390x-linux
+    # The arm64 is very slow to start the jobs.
+    - name: arm32-linux
+  fast_finish: true
+
+before_script:
+  - lscpu
+  - ./autogen.sh
+  - mkdir build
+  - cd build
+  - $SETARCH ../configure -C --disable-install-doc --prefix=$(pwd)/install
+  - $SETARCH make -s $JOBS
+  - make -s $JOBS install
+  # Useful info to report issues to the Ruby.
+  - $SETARCH $(pwd)/install/bin/ruby -v
+  # Useful info To report issues to the RubyGems.
+  - $SETARCH $(pwd)/install/bin/gem env
+
+script:
+  - $SETARCH make -s test
+  - ../tool/travis_wait.sh $SETARCH make -s test-all RUBYOPT="-w"
+  - ../tool/travis_wait.sh $SETARCH make -s test-spec
+
+# We want to be notified when something happens.
+notifications:
+  webhooks:
+    urls:
+      # ruby-lang slack: ruby/simpler-alerts-bot (travis)
+      - secure: mRsoS/UbqDkKkW5p3AEqM27d4SZnV6Gsylo3bm8T/deltQzTsGzZwrm7OIBXZv0UFZdE68XmPlyHfZFLSP2V9QZ7apXMf9/vw0GtcSe1gchtnjpAPF6lYBn7nMCbVPPx9cS0dwL927fjdRM1vj7IKZ2bk4F0lAJ25R25S6teqdk=
+    on_success: never
+    on_failure: always
+  email:
+    recipients:
+      - jun.aruga@gmail.com
+    on_success: never
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@
 # https://github.com/ruby/ruby/wiki/CI-Servers#travis-ci
 
 # We enable Travis on the specific branches or forked repositories here.
+# https://docs.travis-ci.com/user/conditions-v1
 if: >-
-  (repo != ruby/ruby OR branch = master OR branch =~ /^ruby_\d_\d$/)
-  AND (commit_message !~ /\[DOC\]/)
+  (fork OR branch = master OR branch =~ /^ruby_\d_\d$/)
+  AND (commit_message !~ /(\[DOC\]|Document)/)
+  AND NOT (type = 'push' AND sender =~ /\[bot\]/)
 
 language: c
 


### PR DESCRIPTION
This fixes the <https://bugs.ruby-lang.org/issues/20810>.
Related to <https://bugs.ruby-lang.org/issues/20013>.

This PR is based on the https://github.com/ruby/ruby/pull/11943. I and nobu have worked for the subject together.

Note I want to keep enabling the `allow_failures` for now on this PR. Because I saw the following ppc64le's random failure during my tests in my forked repository.

https://app.travis-ci.com/github/junaruga/ruby/jobs/627419975#L1759
