### PR TITLE
Avoid dangling pointer on cygwin

### DIFF
--- a/dln.c
+++ b/dln.c
@@ -284,7 +284,7 @@ dln_incompatible_func(void *handle, const char *funcname, void *const fp, const 
     void *ex = dlsym(handle, funcname);
     if (!ex) return false;
     if (ex == fp) return false;
-#  if defined(HAVE_DLADDR)
+#  if defined(HAVE_DLADDR) && !defined(__CYGWIN__)
     Dl_info dli;
     if (dladdr(ex, &dli)) {
         *libname = dli.dli_fname;


### PR DESCRIPTION
The compiler warns because Dl_info.dli_fname in cygwin is char[].

```
dln.c: In function 'dln_incompatible_func':
dln.c:290:18: warning: storing the address of local variable 'dli' in '*libname' [-Wdangling-pointer=]
  290 |         *libname = dli.dli_fname;
      |         ~~~~~~~~~^~~~~~~~~~~~~~~
dln.c:288:13: note: 'dli' declared here
  288 |     Dl_info dli;
      |             ^~~
dln.c:288:13: note: 'libname' declared here
```

https://www.cygwin.com/cgit/newlib-cygwin/tree/winsup/cygwin/include/dlfcn.h?h=cygwin-3.5.4

```
struct Dl_info
{
   char        dli_fname[PATH_MAX];  /* Filename of defining object */
   void       *dli_fbase;            /* Load address of that object */
   const char *dli_sname;            /* Name of nearest lower symbol */
   void       *dli_saddr;            /* Exact value of nearest symbol */
};
```

On cygwin, dladdr is implemented, but libname is only used in error messages, so it is preferable to have it behave as on platforms that do not support dladdr.
