### PR TITLE
Allow passing a block to Hash#store (to update current value)

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2897,10 +2897,39 @@ hash_aset_str(st_data_t *key, st_data_t *val, struct update_arg *arg, int existi
 NOINSERT_UPDATE_CALLBACK(hash_aset)
 NOINSERT_UPDATE_CALLBACK(hash_aset_str)
 
+static int
+hash_store_yield(st_data_t *key, st_data_t *val, struct update_arg *arg, int existing)
+{
+    VALUE current_value;
+    if(existing) {
+        current_value = *val;
+    } else {
+        if (FL_TEST(arg->hash, RHASH_PROC_DEFAULT)) {
+            current_value = Qnil;
+        } else {
+            current_value = RHASH_IFNONE(arg->hash);
+        }
+    }
+
+    *val = rb_yield(current_value);
+    return ST_CONTINUE;
+}
+
+static int
+hash_store_yield_str(st_data_t *key, st_data_t *val, struct update_arg *arg, int existing)
+{
+    if (!existing && !RB_OBJ_FROZEN(*key)) {
+        *key = rb_hash_key_str(*key);
+    }
+    return hash_store_yield(key, val, arg, existing);
+}
+
+NOINSERT_UPDATE_CALLBACK(hash_store_yield)
+NOINSERT_UPDATE_CALLBACK(hash_store_yield_str)
+
 /*
  *  call-seq:
  *    hash[key] = value -> value
- *    hash.store(key, value)
  *
  *  Associates the given +value+ with the given +key+; returns +value+.
  *
@@ -2909,16 +2938,14 @@ NOINSERT_UPDATE_CALLBACK(hash_aset_str)
  *  (see {Entry Order}[rdoc-ref:Hash@Entry+Order]):
  *    h = {foo: 0, bar: 1}
  *    h[:foo] = 2 # => 2
- *    h.store(:bar, 3) # => 3
- *    h # => {:foo=>2, :bar=>3}
+ *    h # => {:foo=>2, :bar=>1}
  *
  *  If +key+ does not exist, adds the +key+ and +value+;
  *  the new entry is last in the order
  *  (see {Entry Order}[rdoc-ref:Hash@Entry+Order]):
  *    h = {foo: 0, bar: 1}
  *    h[:baz] = 2 # => 2
- *    h.store(:bat, 3) # => 3
- *    h # => {:foo=>0, :bar=>1, :baz=>2, :bat=>3}
+ *    h # => {:foo=>0, :bar=>1, :baz=>2}
  */
 
 VALUE
@@ -2936,6 +2963,80 @@ rb_hash_aset(VALUE hash, VALUE key, VALUE val)
     }
     return val;
 }
+
+
+/*
+ *  call-seq:
+ *    hash.store(key, value)
+ *    hash.store(key) {|value| ... }
+ *
+ *  Associates the given +value+ with the given +key+; returns +value+.
+ *
+ *  If the given +key+ exists, replaces its value with the given +value+;
+ *  the ordering is not affected
+ *  (see {Entry Order}[rdoc-ref:Hash@Entry+Order]):
+ *    h = {foo: 0, bar: 1}
+ *    h.store(:bar, 3) # => 3
+ *    h # => {:foo=>2, :bar=>3}
+ *
+ *  If +key+ does not exist, adds the +key+ and +value+;
+ *  the new entry is last in the order
+ *  (see {Entry Order}[rdoc-ref:Hash@Entry+Order]):
+ *    h = {foo: 0, bar: 1}
+ *    h.store(:baz, 3) # => 3
+ *    h # => {:foo=>0, :bar=>1, :baz=>3}
+ *
+ *  If a block is given, yields the value currently associated with +key+ or,
+ *  if +key+ is not found, the hash's default value (see {Default Values}[rdoc-ref:Hash@Default+Values]),
+ *  and associates +key+ with the value returned by the block:
+ *    h = {foo: 0}
+ *    h.store(:foo) { |v| v + 1 } # => 1
+ *    h.store(:bar) { |v| v || 100  } # => 100
+ *    h.default = 1000
+ *    h.store(:baz) { |v| v + 1 } # => 1001
+ *    h # => {:foo=>1, :bar=>100, :baz=>1001}
+ *
+ *  Note that if you set a default proc via #default_proc=, the block will yield +nil+.
+ */
+
+VALUE
+rb_hash_store(int argc, VALUE *argv, VALUE hash)
+{
+    bool block_given = rb_block_given_p();
+    VALUE val;
+    VALUE key;
+
+    if(block_given) {
+        argc = rb_check_arity(argc, 1, 1);
+        key = argv[0];
+        val = Qnil;
+    } else {
+        argc = rb_check_arity(argc, 2, 2);
+        key = argv[0];
+        val = argv[1];
+    }
+
+    bool iter_p = hash_iterating_p(hash);
+    rb_hash_modify(hash);
+
+    if(block_given) {
+        if (!RHASH_STRING_KEY_P(hash, key)) {
+            RHASH_UPDATE_ITER(hash, iter_p, key, hash_store_yield, val);
+        }
+        else {
+            RHASH_UPDATE_ITER(hash, iter_p, key, hash_store_yield_str, val);
+        }
+    } else {
+        if (!RHASH_STRING_KEY_P(hash, key)) {
+            RHASH_UPDATE_ITER(hash, iter_p, key, hash_aset, val);
+        }
+        else {
+            RHASH_UPDATE_ITER(hash, iter_p, key, hash_aset_str, val);
+        }
+    }
+    return val;
+}
+
 
 /*
  *  call-seq:
@@ -7128,7 +7229,7 @@ Init_Hash(void)
     rb_define_method(rb_cHash, "eql?", rb_hash_eql, 1);
     rb_define_method(rb_cHash, "fetch", rb_hash_fetch_m, -1);
     rb_define_method(rb_cHash, "[]=", rb_hash_aset, 2);
-    rb_define_method(rb_cHash, "store", rb_hash_aset, 2);
+    rb_define_method(rb_cHash, "store", rb_hash_store, -1);
     rb_define_method(rb_cHash, "default", rb_hash_default, -1);
     rb_define_method(rb_cHash, "default=", rb_hash_set_default, 1);
     rb_define_method(rb_cHash, "default_proc", rb_hash_default_proc, 0);

--- a/spec/ruby/core/hash/store_spec.rb
+++ b/spec/ruby/core/hash/store_spec.rb
@@ -4,4 +4,58 @@ require_relative 'shared/store'
 
 describe "Hash#store" do
   it_behaves_like :hash_store, :store
+
+  ruby_version_is "3.4" do
+    context "when a block is given" do
+      it "yields nil if no default value is set" do
+        h = {}
+        h.store("foo") do |v|
+          v.should == nil
+          nil
+        end
+      end
+
+      it "yields the default value if set" do
+        h = {}
+        h.default = 100
+        h.store("foo") do |v|
+          v.should == 100
+          nil
+        end
+      end
+
+      it "yields nil if a default proc is set" do
+        h = Hash.new {|h, k| h[k] = 0}
+        h.store("foo") do |v|
+          v.should == nil
+          nil
+        end
+
+        h = {}
+        h.default = 100
+        h.default_proc = lambda {|h, k| h[k] = 0}
+        h.store("foo") do |v|
+          v.should == nil
+          nil
+        end
+      end
+
+      it "associates the key with the value returned by the block" do
+        h = {}
+        h.store("foo") do |v|
+          "bar"
+        end
+        h["foo"].should == "bar"
+
+        h.store("foo") do |v|
+          "baz"
+        end
+        h["foo"].should == "baz"
+      end
+
+      it "raises ArgumentError if a block and an explicit value are passed" do
+        -> { {}.store("foo", "bar") { "baz" } }.should raise_error(ArgumentError)
+      end
+    end
+  end
 end

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -802,6 +802,25 @@ class TestHash < Test::Unit::TestCase
     assert_equal(99,      h[nil])
     assert_equal(nil,     h['nil'])
     assert_equal(nil,     h['koala'])
+
+    h.store(1, 0)
+    h.store(1){ _1 + 1}
+    assert_equal(1, h[1])
+
+    h.default = 99
+    h.store('undefined_key') {_1 + 1}
+    assert_equal(100, h['undefined_key'])
+
+    h.default_proc = lambda { |h, k| h[k] = "1"}
+    h.store('thousand') do |v|
+      # setting #default_proc sets #default to nil
+      assert_equal(nil, v)
+      nil
+    end
+
+    assert_raise(ArgumentError) do
+      h.store(1,2) {_1 + 1}
+    end
   end
 
   def test_to_a


### PR DESCRIPTION
This is a proposal to allow passing a block to `Hash#store` to obtain the value to be stored.
The block is called with the current value or, if unset, the hash's default value; the block's return value will be the value that is stored. This is similar to e.g., `computeIfPresent`/`computeIfAbsent` in Java (I think).

I can think of several situations where this is useful, in particular for caches and counters.
For instance:
```ruby
counts = {}
elements.each do |element|
  counts.store(element){ (_1 || 0) + element.weight}
end
```

or even more elegant with a default value:
```ruby
counts = {}
counts.default = 0
elements.each do |element|
  counts.store(element){ _1 + element.weight}
end
```

Moreover, using the block form we should be able to do operations such as  `h[k] ||= x`, `h[k] -= x`, `h[k] += x`, or more generally `h[k] = f(h[k])`, with a single "hashing round-trip". If I'm not mistaken, currently these involve two separate calls to `#[]` and `#[]=` (with two calls to `#hash`?).

Finally, this makes `#store` a proper dual of `#fetch` which, similarly, can be passed a block.

I'm not entirely sure whether it is safe to call `rb_yield` from inside the hash update callback (e.g., because the block may raise).
At any rate, this change will likely need further discussion.

 