### PR TITLE
Fix TestParallel#test_hungup when RUBY_TEST_TIMEOUT_SCALE is set

### DIFF
--- a/tool/test/testunit/tests_for_parallel/test4test_hungup.rb
+++ b/tool/test/testunit/tests_for_parallel/test4test_hungup.rb
@@ -8,7 +8,7 @@ class TestHung < Test::Unit::TestCase
 
   def test_hungup_at_worker
     if on_parallel_worker?
-      sleep 10
+      sleep EnvUtil.apply_timeout_scale(10)
     end
     assert true
   end


### PR DESCRIPTION
When RUBY_TEST_TIMEOUT_SCALE is set, the timeout increases by the multiple specified. However, the test in test4test_hungup.rb does not scale, so if RUBY_TEST_TIMEOUT_SCALE is a large number like 10, then the test will not time out causing the tests test to fail.