### PR TITLE
Only check RubyVM on CRuby

### DIFF
--- a/test/coverage/test_coverage.rb
+++ b/test/coverage/test_coverage.rb
@@ -11,7 +11,7 @@ class TestCoverage < Test::Unit::TestCase
   # through.
   ARGV = ["-rcoverage"]
 
-  if RubyVM::InstructionSequence.compile('').to_a[4][:parser] == :prism
+  if RUBY_ENGINE == "ruby" && RubyVM::InstructionSequence.compile('').to_a[4][:parser] == :prism
     ARGV << "-W:no-experimental"
     ARGV << "--parser=prism"
   end


### PR DESCRIPTION
Blind use of the RubyVM constant here prevents this test from running on non-CRuby. This patch guards it with RUBY_ENGINE == "ruby" to make sure that doesn't happen.