### PR TITLE
`alias` should care complemented flag

### DIFF
--- a/test/ruby/test_alias.rb
+++ b/test/ruby/test_alias.rb
@@ -292,4 +292,40 @@ class TestAlias < Test::Unit::TestCase
       end
     end;
   end
+
+  def test_alias_complemented_method
+    assert_in_out_err(%w[-w], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      module M
+        def foo = 1
+        self.extend M
+      end
+
+      3.times{|i|
+        module M
+          alias foo2 foo
+          remove_method :foo
+          def foo = 2
+        ensure
+          remove_method :foo
+          alias foo foo2
+          remove_method :foo2
+        end
+
+        M.foo
+
+        original_foo = M.method(:foo)
+
+        M.class_eval do
+          remove_method :foo
+          def foo = 3
+        end
+
+        M.class_eval do
+          remove_method :foo
+          define_method :foo, original_foo
+        end
+      }
+    end;
+  end
 end

--- a/vm_method.c
+++ b/vm_method.c
@@ -2332,7 +2332,13 @@ rb_alias(VALUE klass, ID alias_name, ID original_name)
 
         alias_me = method_entry_set(target_klass, alias_name, orig_me, visi, orig_me->owner);
         RB_OBJ_WRITE(alias_me, &alias_me->owner, target_klass);
-        RB_OBJ_WRITE(alias_me, &alias_me->defined_class, orig_me->defined_class);
+
+        if (RB_TYPE_P(target_klass, T_MODULE)) {
+            // defined_class should not be set
+        }
+        else {
+            RB_OBJ_WRITE(alias_me, &alias_me->defined_class, orig_me->defined_class);
+        }
     }
 }
 


### PR DESCRIPTION
`me->defined_class` should be 0 for method entries of Modules. The current implementation violates this condition when the aliased object was complemented cme.

This patch checks this condition
and fix https://github.com/ruby/ruby/pull/11965#issuecomment-2448291790