### PR TITLE
Make gemspec files for default gems with extensions

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1605,7 +1605,7 @@ install-for-test-bundled-gems: update-default-gemspecs
 test-bundled-gems-fetch: yes-test-bundled-gems-fetch
 yes-test-bundled-gems-fetch:
 	$(ACTIONS_GROUP)
-	$(Q) $(BASERUBY) -C $(srcdir)/gems ../tool/fetch-bundled_gems.rb src bundled_gems
+	$(Q) $(BASERUBY) -C $(srcdir)/gems ../tool/fetch-bundled_gems.rb BUNDLED_GEMS="$(BUNDLED_GEMS)" src bundled_gems
 	$(ACTIONS_ENDGROUP)
 no-test-bundled-gems-fetch:
 

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -13,7 +13,7 @@ test-unit           3.6.2   https://github.com/test-unit/test-unit
 rexml               3.3.9   https://github.com/ruby/rexml
 rss                 0.3.1   https://github.com/ruby/rss
 net-ftp             0.3.8   https://github.com/ruby/net-ftp
-net-imap            0.5.0   https://github.com/ruby/net-imap 898ee6e7878fdb2d0b79a4691fd68b6d8b228426
+net-imap            0.5.0   https://github.com/ruby/net-imap
 net-pop             0.1.2   https://github.com/ruby/net-pop
 net-smtp            0.5.0   https://github.com/ruby/net-smtp
 matrix              0.4.2   https://github.com/ruby/matrix

--- a/tool/fetch-bundled_gems.rb
+++ b/tool/fetch-bundled_gems.rb
@@ -5,6 +5,11 @@ BEGIN {
 
   color = Colorize.new
 
+  if ARGV.first.start_with?("BUNDLED_GEMS=")
+    bundled_gems = ARGV.shift[13..-1].split(" ")
+    bundled_gems = nil if bundled_gems.empty?
+  end
+
   dir = ARGV.shift
   ARGF.eof?
   FileUtils.mkdir_p(dir)
@@ -15,6 +20,7 @@ n, v, u, r = $F
 
 next unless n
 next if n =~ /^#/
+next if bundled_gems&.all? {|pat| !File.fnmatch?(pat, n)}
 
 if File.directory?(n)
   puts "updating #{color.notice(n)} ..."

--- a/tool/lib/gem_env.rb
+++ b/tool/lib/gem_env.rb
@@ -1,0 +1,2 @@
+ENV['GEM_HOME'] = gem_home = File.expand_path('.bundle')
+ENV['GEM_PATH'] = [gem_home, File.expand_path('../../../.bundle', __FILE__)].uniq.join(File::PATH_SEPARATOR)

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -61,7 +61,6 @@ File.foreach("#{gem_dir}/bundled_gems") do |line|
   if load_path
     libs = IO.popen([ruby, "-e", "old = $:.dup; require '#{toplib}'; puts $:-old"], &:read)
     next unless $?.success?
-    puts libs
     ENV["RUBYLIB"] = [libs.split("\n"), rubylib].join(File::PATH_SEPARATOR)
   else
     ENV["RUBYLIB"] = rubylib

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -2,6 +2,7 @@ require 'rbconfig'
 require 'timeout'
 require 'fileutils'
 require_relative 'lib/colorize'
+require_relative 'lib/gem_env'
 
 ENV.delete("GNUMAKEFLAGS")
 
@@ -9,8 +10,6 @@ github_actions = ENV["GITHUB_ACTIONS"] == "true"
 
 allowed_failures = ENV['TEST_BUNDLED_GEMS_ALLOW_FAILURES'] || ''
 allowed_failures = allowed_failures.split(',').reject(&:empty?)
-
-ENV["GEM_PATH"] = [File.realpath('.bundle'), File.realpath('../.bundle', __dir__)].join(File::PATH_SEPARATOR)
 
 colorize = Colorize.new
 rake = File.realpath("../../.bundle/bin/rake", __FILE__)


### PR DESCRIPTION
Make gemspec files for default gems with extensions, so that rubygems can find them as gems.
However, the `--install-dir` option of `gem install` seems to exclude prerelease gems, even already installed in that directory, from the dependencies for some reasons; use the `GEM_HOME` environment variable instead.

Now net-imap 0.5.0 depends on json gem.