### PR TITLE
Fix assertion when envval of proc is Qundef

### DIFF
--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -377,6 +377,7 @@ class TestProc < Test::Unit::TestCase
   end
 
   def test_dup_clone
+    # iseq backed proc
     b = proc {|x| x + "bar" }
     class << b; attr_accessor :foo; end
 
@@ -389,6 +390,24 @@ class TestProc < Test::Unit::TestCase
     assert_equal("foobar", bc.call("foo"))
     bc.foo = :foo
     assert_equal(:foo, bc.foo)
+
+    # ifunc backed proc
+    b = {foo: "bar"}.to_proc
+
+    bd = b.dup
+    assert_equal("bar", bd.call(:foo))
+
+    bc = b.clone
+    assert_equal("bar", bc.call(:foo))
+
+    # symbol backed proc
+    b = :to_s.to_proc
+
+    bd = b.dup
+    assert_equal("testing", bd.call(:testing))
+
+    bc = b.clone
+    assert_equal("testing", bc.call(:testing))
   end
 
   def test_dup_subclass

--- a/vm.c
+++ b/vm.c
@@ -171,7 +171,7 @@ vm_ep_in_heap_p_(const rb_execution_context_t *ec, const VALUE *ep)
         if (!UNDEF_P(envval)) {
             const rb_env_t *env = (const rb_env_t *)envval;
 
-            VM_ASSERT(vm_assert_env(envval));
+            VM_ASSERT(imemo_type_p(envval, imemo_env));
             VM_ASSERT(VM_ENV_FLAGS(ep, VM_ENV_FLAG_ESCAPED));
             VM_ASSERT(env->ep == ep);
         }

--- a/vm_core.h
+++ b/vm_core.h
@@ -1489,22 +1489,13 @@ VM_ENV_ESCAPED_P(const VALUE *ep)
     return VM_ENV_FLAGS(ep, VM_ENV_FLAG_ESCAPED) ? 1 : 0;
 }
 
-#if VM_CHECK_MODE > 0
-static inline int
-vm_assert_env(VALUE obj)
-{
-    VM_ASSERT(obj == Qundef || imemo_type_p(obj, imemo_env));
-    return 1;
-}
-#endif
-
 RBIMPL_ATTR_NONNULL((1))
 static inline VALUE
 VM_ENV_ENVVAL(const VALUE *ep)
 {
     VALUE envval = ep[VM_ENV_DATA_INDEX_ENV];
     VM_ASSERT(VM_ENV_ESCAPED_P(ep));
-    VM_ASSERT(vm_assert_env(envval));
+    VM_ASSERT(envval == Qundef || imemo_type_p(envval, imemo_env));
     return envval;
 }
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -1493,7 +1493,7 @@ VM_ENV_ESCAPED_P(const VALUE *ep)
 static inline int
 vm_assert_env(VALUE obj)
 {
-    VM_ASSERT(imemo_type_p(obj, imemo_env));
+    VM_ASSERT(obj == Qundef || imemo_type_p(obj, imemo_env));
     return 1;
 }
 #endif


### PR DESCRIPTION
The following code crashes with assertions enabled because envval could
be Qundef:

    {}.to_proc.dup