### PR TITLE
Bump REXML to 3.3.9 for Ruby 3.3

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -9,7 +9,7 @@ minitest        5.20.0  https://github.com/minitest/minitest
 power_assert    2.0.3   https://github.com/ruby/power_assert
 rake            13.1.0  https://github.com/ruby/rake
 test-unit       3.6.1   https://github.com/test-unit/test-unit
-rexml           3.3.6   https://github.com/ruby/rexml
+rexml           3.3.9   https://github.com/ruby/rexml
 rss             0.3.1   https://github.com/ruby/rss
 net-ftp         0.3.4   https://github.com/ruby/net-ftp
 net-imap        0.4.9.1   https://github.com/ruby/net-imap


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2024/10/28/redos-rexml-cve-2024-49761/


https://hub.docker.com/layers/library/ruby/3.3-alpine3.20/images/sha256-d1a1669b4cbef147088d1cd12463ece81586b3f53bcc1fa3f8a8b8d24e809cad?context=explore

We utilize the Ruby 3.3-Alpine docker image, and it seems to have the linked rexml vulnerability. This Pr simply bumps it up to a more secure version. 