### PR TITLE
Introduce `RUBY_ASSERT(ruby_thread_has_gvl_p())` to detect invalid interface usage.

### DIFF
--- a/array.c
+++ b/array.c
@@ -27,6 +27,7 @@
 #include "probes.h"
 #include "ruby/encoding.h"
 #include "ruby/st.h"
+#include "ruby/thread.h"
 #include "ruby/util.h"
 #include "vm_core.h"
 #include "builtin.h"
@@ -521,6 +522,8 @@ rb_ary_set_shared(VALUE ary, VALUE shared_root)
 static inline void
 rb_ary_modify_check(VALUE ary)
 {
+    RUBY_ASSERT(ruby_thread_has_gvl_p());
+
     rb_check_frozen(ary);
     ary_verify(ary);
 }
@@ -705,6 +708,8 @@ empty_ary_alloc(VALUE klass)
 static VALUE
 ary_new(VALUE klass, long capa)
 {
+    RUBY_ASSERT(ruby_thread_has_gvl_p());
+
     VALUE ary;
 
     if (capa < 0) {

--- a/common.mk
+++ b/common.mk
@@ -2276,6 +2276,7 @@ array.$(OBJEXT): {$(VPATH)}rubyparser.h
 array.$(OBJEXT): {$(VPATH)}shape.h
 array.$(OBJEXT): {$(VPATH)}st.h
 array.$(OBJEXT): {$(VPATH)}subst.h
+array.$(OBJEXT): {$(VPATH)}thread.h
 array.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 array.$(OBJEXT): {$(VPATH)}thread_native.h
 array.$(OBJEXT): {$(VPATH)}util.h
@@ -17547,6 +17548,7 @@ string.$(OBJEXT): {$(VPATH)}shape.h
 string.$(OBJEXT): {$(VPATH)}st.h
 string.$(OBJEXT): {$(VPATH)}string.c
 string.$(OBJEXT): {$(VPATH)}subst.h
+string.$(OBJEXT): {$(VPATH)}thread.h
 string.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 string.$(OBJEXT): {$(VPATH)}thread_native.h
 string.$(OBJEXT): {$(VPATH)}util.h

--- a/include/ruby/thread.h
+++ b/include/ruby/thread.h
@@ -333,6 +333,13 @@ void *rb_internal_thread_specific_get(VALUE thread_val, rb_internal_thread_speci
  */
 void rb_internal_thread_specific_set(VALUE thread_val, rb_internal_thread_specific_key_t key, void *data);
 
+/**
+ * Whether the current thread is holding the GVL.
+ *
+ * @return true if the current thread is holding the GVL, false otherwise.
+ */
+int ruby_thread_has_gvl_p(void);
+
 RBIMPL_SYMBOL_EXPORT_END()
 
 #endif /* RUBY_THREAD_H */

--- a/spec/ruby/optional/capi/ext/rubyspec.h
+++ b/spec/ruby/optional/capi/ext/rubyspec.h
@@ -35,6 +35,10 @@
    (RUBY_API_VERSION_MAJOR == (major) && RUBY_API_VERSION_MINOR < (minor)))
 #define RUBY_VERSION_SINCE(major,minor) (!RUBY_VERSION_BEFORE(major, minor))
 
+#if RUBY_VERSION_SINCE(3, 5)
+#define RUBY_VERSION_IS_3_5
+#endif
+
 #if RUBY_VERSION_SINCE(3, 4)
 #define RUBY_VERSION_IS_3_4
 #endif

--- a/spec/ruby/optional/capi/ext/thread_spec.c
+++ b/spec/ruby/optional/capi/ext/thread_spec.c
@@ -118,7 +118,6 @@ static VALUE thread_spec_rb_thread_wait_for(VALUE self, VALUE s, VALUE ms) {
   return Qnil;
 }
 
-
 VALUE thread_spec_call_proc(void *arg_ptr) {
   VALUE arg_array = (VALUE)arg_ptr;
   VALUE arg = rb_ary_pop(arg_array);
@@ -167,6 +166,12 @@ static VALUE thread_spec_ruby_native_thread_p_new_thread(VALUE self) {
 #endif
 }
 
+#ifdef RUBY_VERSION_IS_3_5
+static VALUE thread_spec_ruby_thread_has_gvl_p(VALUE self) {
+  return ruby_thread_has_gvl_p() ? Qtrue : Qfalse;
+}
+#endif
+
 void Init_thread_spec(void) {
   VALUE cls = rb_define_class("CApiThreadSpecs", rb_cObject);
   rb_define_method(cls, "rb_thread_alone", thread_spec_rb_thread_alone, 0);
@@ -180,6 +185,9 @@ void Init_thread_spec(void) {
   rb_define_method(cls,  "rb_thread_create", thread_spec_rb_thread_create, 2);
   rb_define_method(cls,  "ruby_native_thread_p", thread_spec_ruby_native_thread_p, 0);
   rb_define_method(cls,  "ruby_native_thread_p_new_thread", thread_spec_ruby_native_thread_p_new_thread, 0);
+#ifdef RUBY_VERSION_IS_3_5
+  rb_define_method(cls,  "ruby_thread_has_gvl_p", thread_spec_ruby_thread_has_gvl_p, 0);
+#endif
 }
 
 #ifdef __cplusplus

--- a/spec/ruby/optional/capi/thread_spec.rb
+++ b/spec/ruby/optional/capi/thread_spec.rb
@@ -184,4 +184,12 @@ describe "C-API Thread function" do
       thr.value.should be_true
     end
   end
+
+  ruby_version_is "3.5" do
+    describe "ruby_thread_has_gvl_p" do
+      it "returns true if the current thread has the GVL" do
+        @t.ruby_thread_has_gvl_p.should be_true
+      end
+    end
+  end
 end

--- a/string.c
+++ b/string.c
@@ -42,6 +42,7 @@
 #include "probes.h"
 #include "ruby/encoding.h"
 #include "ruby/re.h"
+#include "ruby/thread.h"
 #include "ruby/util.h"
 #include "ruby_assert.h"
 #include "vm_sync.h"
@@ -2586,6 +2587,8 @@ rb_check_lockedtmp(VALUE str)
 static inline void
 str_modifiable(VALUE str)
 {
+    RUBY_ASSERT(ruby_thread_has_gvl_p());
+
     if (RB_UNLIKELY(FL_ANY_RAW(str, STR_UNMODIFIABLE_MASK))) {
         if (CHILLED_STRING_P(str)) {
             CHILLED_STRING_MUTATED(str);
@@ -2612,6 +2615,8 @@ str_dependent_p(VALUE str)
 static inline int
 str_independent(VALUE str)
 {
+    RUBY_ASSERT(ruby_thread_has_gvl_p());
+
     if (RB_UNLIKELY(FL_ANY_RAW(str, STR_DEPENDANT_MASK))) {
         str_modifiable(str);
         return !str_dependent_p(str);
@@ -2622,6 +2627,8 @@ str_independent(VALUE str)
 static void
 str_make_independent_expand(VALUE str, long len, long expand, const int termlen)
 {
+    RUBY_ASSERT(ruby_thread_has_gvl_p());
+
     char *ptr;
     char *oldptr;
     long capa = len + expand;
@@ -2664,6 +2671,8 @@ rb_str_modify(VALUE str)
 void
 rb_str_modify_expand(VALUE str, long expand)
 {
+    RUBY_ASSERT(ruby_thread_has_gvl_p());
+
     int termlen = TERM_LEN(str);
     long len = RSTRING_LEN(str);
 
@@ -2727,6 +2736,8 @@ rb_must_asciicompat(VALUE str)
 VALUE
 rb_string_value(volatile VALUE *ptr)
 {
+    RUBY_ASSERT(ruby_thread_has_gvl_p());
+
     VALUE s = *ptr;
     if (!RB_TYPE_P(s, T_STRING)) {
         s = rb_str_to_str(s);
@@ -3286,6 +3297,8 @@ rb_str_locktmp_ensure(VALUE str, VALUE (*func)(VALUE), VALUE arg)
 void
 rb_str_set_len(VALUE str, long len)
 {
+    RUBY_ASSERT(ruby_thread_has_gvl_p());
+
     long capa;
     const int termlen = TERM_LEN(str);
 

--- a/thread.c
+++ b/thread.c
@@ -1937,11 +1937,6 @@ rb_thread_call_with_gvl(void *(*func)(void *), void *data1)
 
 /*
  * ruby_thread_has_gvl_p - check if current native thread has GVL.
- *
- ***
- *** This API is EXPERIMENTAL!
- *** We do not guarantee that this API remains in ruby 1.9.2 or later.
- ***
  */
 
 int


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20877

This was originally to demonstrate/show the problems with zlib. That has now been fixed: https://github.com/ruby/zlib/pull/88

This change helps us find other (similar) issues and prevent regressions.