### PR TITLE
Stop syncing json benchmarks.

### DIFF
--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -197,7 +197,7 @@ module SyncDefaultGems
       cp_r("#{upstream}/lib", "ext/json")
       cp_r("#{upstream}/json.gemspec", "ext/json")
       rm_rf(%w[ext/json/lib/json/ext ext/json/lib/json/pure.rb ext/json/lib/json/pure])
-      `git checkout ext/json/extconf.rb ext/json/parser/prereq.mk ext/json/generator/depend ext/json/parser/depend ext/json/depend`
+      `git checkout ext/json/extconf.rb ext/json/parser/prereq.mk ext/json/generator/depend ext/json/parser/depend ext/json/depend benchmark/`
     when "psych"
       rm_rf(%w[ext/psych test/psych])
       cp_r("#{upstream}/ext/psych", "ext")


### PR DESCRIPTION
I don't think the `benchmark/` directory contains the benchmarks of default gems upstream until 6e2619c9685c256f49f71fdc6460f69ffd073b67.
This PR intended to stop synchronizing `bechmark/` directory from ruby/json.
