### PR TITLE
Add an environment variable for controlling the default Thread quantum

### DIFF
--- a/man/ruby.1
+++ b/man/ruby.1
@@ -537,6 +537,10 @@ Introduced in Ruby 3.3, default: unset.
 .Pp
 .It Ev RUBY_PAGER
 The pager command that will be used for
+.Pp
+.It Ev RUBY_THREAD_TIMESLICE
+Sets the default thread time slice (thread quantum) in milliseconds.
+Introduced in Ruby 3.4, default: 100ms.
 .Fl -help
 option.
 Introduced in Ruby 3.0, default:

--- a/thread_none.c
+++ b/thread_none.c
@@ -19,10 +19,6 @@
 # include "wasm/machine.h"
 #endif
 
-#define TIME_QUANTUM_MSEC (100)
-#define TIME_QUANTUM_USEC (TIME_QUANTUM_MSEC * 1000)
-#define TIME_QUANTUM_NSEC (TIME_QUANTUM_USEC * 1000)
-
 // Do nothing for GVL
 static void
 thread_sched_to_running(struct rb_thread_sched *sched, rb_thread_t *th)

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -317,13 +317,6 @@ static void threadptr_trap_interrupt(rb_thread_t *);
 #define native_thread_yield() ((void)0)
 #endif
 
-/* 100ms.  10ms is too small for user level thread scheduling
- * on recent Linux (tested on 2.6.35)
- */
-#define TIME_QUANTUM_MSEC (100)
-#define TIME_QUANTUM_USEC (TIME_QUANTUM_MSEC * 1000)
-#define TIME_QUANTUM_NSEC (TIME_QUANTUM_USEC * 1000)
-
 static void native_thread_dedicated_inc(rb_vm_t *vm, rb_ractor_t *cr, struct rb_native_thread *nt);
 static void native_thread_dedicated_dec(rb_vm_t *vm, rb_ractor_t *cr, struct rb_native_thread *nt);
 static void native_thread_assign(struct rb_native_thread *nt, rb_thread_t *th);


### PR DESCRIPTION
This commit adds an environment variable `RUBY_THREAD_TIMESLICE` for
specifying the default thread quantum in milliseconds.  You can adjust
this variable to tune throughput, which is especially useful on
multithreaded systems that are mixing CPU bound work and IO bound work.

The default quantum remains 100ms.

[Feature #20861]