### PR TITLE
Implement LAMBDA NODE locations

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -812,6 +812,12 @@ node_locations(VALUE ast_value, const NODE *node)
                                     location_new(nd_code_loc(node)),
                                     location_new(&RNODE_EVSTR(node)->opening_loc),
                                     location_new(&RNODE_EVSTR(node)->closing_loc));
+      case NODE_LAMBDA:
+        return rb_ary_new_from_args(4,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_LAMBDA(node)->operator_loc),
+                                    location_new(&RNODE_LAMBDA(node)->opening_loc),
+                                    location_new(&RNODE_LAMBDA(node)->closing_loc));
       case NODE_IF:
         return rb_ary_new_from_args(4,
                                     location_new(nd_code_loc(node)),

--- a/node_dump.c
+++ b/node_dump.c
@@ -1113,8 +1113,11 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("lambda expression");
         ANN("format: -> [nd_body]");
         ANN("example: -> { foo }");
-        LAST_NODE;
         F_NODE(nd_body, RNODE_LAMBDA, "lambda clause");
+        F_LOC(operator_loc, RNODE_LAMBDA);
+        F_LOC(opening_loc, RNODE_LAMBDA);
+        LAST_NODE;
+        F_LOC(closing_loc, RNODE_LAMBDA);
         return;
 
       case NODE_OPT_ARG:

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -968,6 +968,9 @@ typedef struct RNode_LAMBDA {
     NODE node;
 
     struct RNode *nd_body;
+    rb_code_location_t operator_loc;
+    rb_code_location_t opening_loc;
+    rb_code_location_t closing_loc;
 } rb_node_lambda_t;
 
 typedef struct RNode_ARYPTN {

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1384,6 +1384,14 @@ dummy
       assert_locations(node.children[-1].children[1].locations, [[1, 0, 1, 5], [1, 1, 1, 2], nil])
     end
 
+    def test_lambda_locations
+      node = ast_parse("-> (a, b) { foo }")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 17], [1, 0, 1, 2], [1, 10, 1, 11], [1, 16, 1, 17]])
+
+      node = ast_parse("-> (a, b) do foo end")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 20], [1, 0, 1, 2], [1, 10, 1, 12], [1, 17, 1, 20]])
+    end
+
     def test_if_locations
       node = ast_parse("if cond then 1 else 2 end")
       assert_locations(node.children[-1].locations, [[1, 0, 1, 25], [1, 0, 1, 2], [1, 8, 1, 12], [1, 22, 1, 25]])


### PR DESCRIPTION
The following Location information has been added This is the information required for parse.y to be a universal parser:

```
❯ ruby --parser=prism --dump=parsetree -e "-> (a, b) do foo end"
@ ProgramNode (location: (1,0)-(1,20))
+-- locals: []
+-- statements:
    @ StatementsNode (location: (1,0)-(1,20))
    +-- body: (length: 1)
        +-- @ LambdaNode (location: (1,0)-(1,20))
            +-- locals: [:a, :b]
            +-- operator_loc: (1,0)-(1,2) = "->"
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- opening_loc: (1,10)-(1,12) = "do"
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- closing_loc: (1,17)-(1,20) = "end"
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
: (snip)
```