### PR TITLE
Implement POSTEXE NODE locations

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -868,6 +868,12 @@ node_locations(VALUE ast_value, const NODE *node)
                                     location_new(&RNODE_OP_ASGN2(node)->call_operator_loc),
                                     location_new(&RNODE_OP_ASGN2(node)->message_loc),
                                     location_new(&RNODE_OP_ASGN2(node)->binary_operator_loc));
+      case NODE_POSTEXE:
+        return rb_ary_new_from_args(4,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_POSTEXE(node)->keyword_loc),
+                                    location_new(&RNODE_POSTEXE(node)->opening_loc),
+                                    location_new(&RNODE_POSTEXE(node)->closing_loc));
       case NODE_REDO:
         return rb_ary_new_from_args(2,
                                     location_new(nd_code_loc(node)),

--- a/node_dump.c
+++ b/node_dump.c
@@ -1106,8 +1106,11 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("post-execution");
         ANN("format: END { [nd_body] }");
         ANN("example: END { foo }");
-        LAST_NODE;
         F_NODE(nd_body, RNODE_POSTEXE, "END clause");
+        F_LOC(keyword_loc, RNODE_POSTEXE);
+        F_LOC(opening_loc, RNODE_POSTEXE);
+        LAST_NODE;
+        F_LOC(closing_loc, RNODE_POSTEXE);
         return;
 
       case NODE_ATTRASGN:

--- a/parse.y
+++ b/parse.y
@@ -1156,7 +1156,7 @@ static rb_node_true_t *rb_node_true_new(struct parser_params *p, const YYLTYPE *
 static rb_node_false_t *rb_node_false_new(struct parser_params *p, const YYLTYPE *loc);
 static rb_node_errinfo_t *rb_node_errinfo_new(struct parser_params *p, const YYLTYPE *loc);
 static rb_node_defined_t *rb_node_defined_new(struct parser_params *p, NODE *nd_head, const YYLTYPE *loc);
-static rb_node_postexe_t *rb_node_postexe_new(struct parser_params *p, NODE *nd_body, const YYLTYPE *loc);
+static rb_node_postexe_t *rb_node_postexe_new(struct parser_params *p, NODE *nd_body, const YYLTYPE *loc, const YYLTYPE *keyword_loc, const YYLTYPE *opening_loc, const YYLTYPE *closing_loc);
 static rb_node_sym_t *rb_node_sym_new(struct parser_params *p, VALUE str, const YYLTYPE *loc);
 static rb_node_dsym_t *rb_node_dsym_new(struct parser_params *p, rb_parser_string_t *string, long nd_alen, NODE *nd_next, const YYLTYPE *loc);
 static rb_node_attrasgn_t *rb_node_attrasgn_new(struct parser_params *p, NODE *nd_recv, ID nd_mid, NODE *nd_args, const YYLTYPE *loc);
@@ -1264,7 +1264,7 @@ static rb_node_error_t *rb_node_error_new(struct parser_params *p, const YYLTYPE
 #define NEW_FALSE(loc) (NODE *)rb_node_false_new(p,loc)
 #define NEW_ERRINFO(loc) (NODE *)rb_node_errinfo_new(p,loc)
 #define NEW_DEFINED(e,loc) (NODE *)rb_node_defined_new(p,e,loc)
-#define NEW_POSTEXE(b,loc) (NODE *)rb_node_postexe_new(p,b,loc)
+#define NEW_POSTEXE(b,loc,k_loc,o_loc,c_loc) (NODE *)rb_node_postexe_new(p,b,loc,k_loc,o_loc,c_loc)
 #define NEW_SYM(str,loc) (NODE *)rb_node_sym_new(p,str,loc)
 #define NEW_DSYM(s,l,n,loc) (NODE *)rb_node_dsym_new(p,s,l,n,loc)
 #define NEW_ATTRASGN(r,m,a,loc) (NODE *)rb_node_attrasgn_new(p,r,m,a,loc)
@@ -3314,7 +3314,7 @@ stmt		: keyword_alias fitem {SET_LEX_STATE(EXPR_FNAME|EXPR_FITEM);} fitem
                         p->ctxt = $k_END;
                         {
                             NODE *scope = NEW_SCOPE2(0 /* tbl */, 0 /* args */, $compstmt /* body */, &@$);
-                            $$ = NEW_POSTEXE(scope, &@$);
+                            $$ = NEW_POSTEXE(scope, &@$, &@1, &@3, &@5);
                         }
                     /*% ripper: END!($:compstmt) %*/
                     }
@@ -12272,10 +12272,13 @@ rb_node_defined_new(struct parser_params *p, NODE *nd_head, const YYLTYPE *loc)
 }
 
 static rb_node_postexe_t *
-rb_node_postexe_new(struct parser_params *p, NODE *nd_body, const YYLTYPE *loc)
+rb_node_postexe_new(struct parser_params *p, NODE *nd_body, const YYLTYPE *loc, const YYLTYPE *keyword_loc, const YYLTYPE *opening_loc, const YYLTYPE *closing_loc)
 {
     rb_node_postexe_t *n = NODE_NEWNODE(NODE_POSTEXE, rb_node_postexe_t, loc);
     n->nd_body = nd_body;
+    n->keyword_loc = *keyword_loc;
+    n->opening_loc = *opening_loc;
+    n->closing_loc = *closing_loc;
 
     return n;
 }

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -961,6 +961,9 @@ typedef struct RNode_POSTEXE {
     NODE node;
 
     struct RNode *nd_body;
+    rb_code_location_t keyword_loc;
+    rb_code_location_t opening_loc;
+    rb_code_location_t closing_loc;
 } rb_node_postexe_t;
 
 typedef struct RNode_SYM {

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1497,6 +1497,14 @@ dummy
       assert_locations(node.children[-1].children[-1].locations, [[1, 4, 1, 15], [1, 8, 1, 9], [1, 9, 1, 10], [1, 11, 1, 13]])
     end
 
+    def test_postexe_locations
+      node = ast_parse("END {  }")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 8], [1, 0, 1, 3], [1, 4, 1, 5], [1, 7, 1, 8]])
+
+      node = ast_parse("END { 1 }")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 9], [1, 0, 1, 3], [1, 4, 1, 5], [1, 8, 1, 9]])
+    end
+
     def test_redo_locations
       node = ast_parse("loop { redo }")
       assert_locations(node.children[-1].children[-1].children[-1].locations, [[1, 7, 1, 11], [1, 7, 1, 11]])


### PR DESCRIPTION
The following Location information has been added This is the information required for parse.y to be a universal parser:

```
❯ ruby --parser=prism --dump=parsetree -e "END {  }"
@ ProgramNode (location: (1,0)-(1,8))
+-- locals: []
+-- statements:
    @ StatementsNode (location: (1,0)-(1,8))
    +-- body: (length: 1)
        +-- @ PostExecutionNode (location: (1,0)-(1,8))
            +-- statements: nil
            +-- keyword_loc: (1,0)-(1,3) = "END"
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- opening_loc: (1,4)-(1,5) = "{"
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- closing_loc: (1,7)-(1,8) = "}"
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```