### PR TITLE
Implement COLON2 and COLON3 NODE locations

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -812,6 +812,11 @@ node_locations(VALUE ast_value, const NODE *node)
                                     location_new(&RNODE_CLASS(node)->class_keyword_loc),
                                     location_new(&RNODE_CLASS(node)->inheritance_operator_loc),
                                     location_new(&RNODE_CLASS(node)->end_keyword_loc));
+      case NODE_COLON2:
+        return rb_ary_new_from_args(3,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_COLON2(node)->delimiter_loc),
+                                    location_new(&RNODE_COLON2(node)->name_loc));
       case NODE_DOT2:
         return rb_ary_new_from_args(2,
                                     location_new(nd_code_loc(node)),

--- a/ast.c
+++ b/ast.c
@@ -817,6 +817,11 @@ node_locations(VALUE ast_value, const NODE *node)
                                     location_new(nd_code_loc(node)),
                                     location_new(&RNODE_COLON2(node)->delimiter_loc),
                                     location_new(&RNODE_COLON2(node)->name_loc));
+      case NODE_COLON3:
+        return rb_ary_new_from_args(3,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_COLON3(node)->delimiter_loc),
+                                    location_new(&RNODE_COLON3(node)->name_loc));
       case NODE_DOT2:
         return rb_ary_new_from_args(2,
                                     location_new(nd_code_loc(node)),

--- a/node_dump.c
+++ b/node_dump.c
@@ -1027,8 +1027,10 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("format: [nd_head]::[nd_mid]");
         ANN("example: M::C");
         F_ID(nd_mid, RNODE_COLON2, "constant name");
-        LAST_NODE;
         F_NODE(nd_head, RNODE_COLON2, "receiver");
+        F_LOC(delimiter_loc, RNODE_COLON2);
+        LAST_NODE;
+        F_LOC(name_loc, RNODE_COLON2);
         return;
 
       case NODE_COLON3:

--- a/node_dump.c
+++ b/node_dump.c
@@ -1038,6 +1038,8 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("format: ::[nd_mid]");
         ANN("example: ::Object");
         F_ID(nd_mid, RNODE_COLON3, "constant name");
+        F_LOC(delimiter_loc, RNODE_COLON3);
+        F_LOC(name_loc, RNODE_COLON3);
         return;
 
       case NODE_DOT2:

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -923,6 +923,8 @@ typedef struct RNode_COLON3 {
     NODE node;
 
     ID nd_mid;
+    rb_code_location_t delimiter_loc;
+    rb_code_location_t name_loc;
 } rb_node_colon3_t;
 
 /* NODE_DOT2, NODE_DOT3, NODE_FLIP2, NODE_FLIP3 */

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -915,6 +915,8 @@ typedef struct RNode_COLON2 {
 
     struct RNode *nd_head;
     ID nd_mid;
+    rb_code_location_t delimiter_loc;
+    rb_code_location_t name_loc;
 } rb_node_colon2_t;
 
 typedef struct RNode_COLON3 {

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1397,6 +1397,15 @@ dummy
       assert_locations(node.children[-1].locations, [[1, 0, 1, 16], [1, 0, 1, 5], [1, 8, 1, 9], [1, 13, 1, 16]])
     end
 
+    def test_colon2_locations
+      node = ast_parse("A::B")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 4], [1, 1, 1, 3], [1, 3, 1, 4]])
+
+      node = ast_parse("A::B::C")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 7], [1, 4, 1, 6], [1, 6, 1, 7]])
+      assert_locations(node.children[-1].children[0].locations, [[1, 0, 1, 4], [1, 1, 1, 3], [1, 3, 1, 4]])
+    end
+
     def test_dot2_locations
       node = ast_parse("1..2")
       assert_locations(node.children[-1].locations, [[1, 0, 1, 4], [1, 1, 1, 3]])

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1406,6 +1406,15 @@ dummy
       assert_locations(node.children[-1].children[0].locations, [[1, 0, 1, 4], [1, 1, 1, 3], [1, 3, 1, 4]])
     end
 
+    def test_colon3_locations
+      node = ast_parse("::A")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 3], [1, 0, 1, 2], [1, 2, 1, 3]])
+
+      node = ast_parse("::A::B")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 6], [1, 3, 1, 5], [1, 5, 1, 6]])
+      assert_locations(node.children[-1].children[0].locations, [[1, 0, 1, 3], [1, 0, 1, 2], [1, 2, 1, 3]])
+    end
+
     def test_dot2_locations
       node = ast_parse("1..2")
       assert_locations(node.children[-1].locations, [[1, 0, 1, 4], [1, 1, 1, 3]])


### PR DESCRIPTION
The following Location information has been added This is the information required for parse.y to be a universal parser:

```
❯ ruby --parser=prism --dump=parsetree -e "A::B"                      
@ ProgramNode (location: (1,0)-(1,4))
+-- locals: []
+-- statements:
    @ StatementsNode (location: (1,0)-(1,4))
    +-- body: (length: 1)
        +-- @ ConstantPathNode (location: (1,0)-(1,4))
            +-- parent:
            |   @ ConstantReadNode (location: (1,0)-(1,1))
            |   +-- name: :A
            +-- name: :B
            +-- delimiter_loc: (1,1)-(1,3) = "::"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- name_loc: (1,3)-(1,4) = "B"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

❯ ruby --parser=prism --dump=parsetree -e "::A"                       
@ ProgramNode (location: (1,0)-(1,3))
+-- locals: []
+-- statements:
    @ StatementsNode (location: (1,0)-(1,3))
    +-- body: (length: 1)
        +-- @ ConstantPathNode (location: (1,0)-(1,3))
            +-- parent: nil
            +-- name: :A
            +-- delimiter_loc: (1,0)-(1,2) = "::"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- name_loc: (1,2)-(1,3) = "A"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```