### PR TITLE
Implement CLASS NODE locations

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -787,7 +787,6 @@ node_locations(VALUE ast_value, const NODE *node)
         return rb_ary_new_from_args(2,
                                     location_new(nd_code_loc(node)),
                                     location_new(&RNODE_BLOCK_PASS(node)->operator_loc));
-
       case NODE_BREAK:
         return rb_ary_new_from_args(2,
                                     location_new(nd_code_loc(node)),
@@ -807,6 +806,12 @@ node_locations(VALUE ast_value, const NODE *node)
                                     location_new(nd_code_loc(node)),
                                     location_new(&RNODE_CASE3(node)->case_keyword_loc),
                                     location_new(&RNODE_CASE3(node)->end_keyword_loc));
+      case NODE_CLASS:
+        return rb_ary_new_from_args(4,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_CLASS(node)->class_keyword_loc),
+                                    location_new(&RNODE_CLASS(node)->inheritance_operator_loc),
+                                    location_new(&RNODE_CLASS(node)->end_keyword_loc));
       case NODE_DOT2:
         return rb_ary_new_from_args(2,
                                     location_new(nd_code_loc(node)),

--- a/node_dump.c
+++ b/node_dump.c
@@ -997,8 +997,11 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("example: class C2 < C; ..; end");
         F_NODE(nd_cpath, RNODE_CLASS, "class path");
         F_NODE(nd_super, RNODE_CLASS, "superclass");
-        LAST_NODE;
         F_NODE(nd_body, RNODE_CLASS, "class definition");
+        F_LOC(class_keyword_loc, RNODE_CLASS);
+        F_LOC(inheritance_operator_loc, RNODE_CLASS);
+        LAST_NODE;
+        F_LOC(end_keyword_loc, RNODE_CLASS);
         return;
 
       case NODE_MODULE:

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -891,6 +891,9 @@ typedef struct RNode_CLASS {
     struct RNode *nd_cpath;
     struct RNode *nd_body;
     struct RNode *nd_super;
+    rb_code_location_t class_keyword_loc;
+    rb_code_location_t inheritance_operator_loc;
+    rb_code_location_t end_keyword_loc;
 } rb_node_class_t;
 
 typedef struct RNode_MODULE {

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1376,6 +1376,14 @@ dummy
       assert_locations(node.children[-1].locations, [[1, 0, 1, 17], [1, 0, 1, 4], [1, 14, 1, 17]])
     end
 
+    def test_class_locations
+      node = ast_parse("class A end")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 11], [1, 0, 1, 5], nil, [1, 8, 1, 11]])
+
+      node = ast_parse("class A < B; end")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 16], [1, 0, 1, 5], [1, 8, 1, 9], [1, 13, 1, 16]])
+    end
+
     def test_dot2_locations
       node = ast_parse("1..2")
       assert_locations(node.children[-1].locations, [[1, 0, 1, 4], [1, 1, 1, 3]])


### PR DESCRIPTION
The following Location information has been added This is the information required for parse.y to be a universal parser:

```
❯ ruby --parser=prism --dump=parsetree -e "class A < B; end"
@ ProgramNode (location: (1,0)-(1,16))
+-- locals: []
+-- statements:
    @ StatementsNode (location: (1,0)-(1,16))
    +-- body: (length: 1)
        +-- @ ClassNode (location: (1,0)-(1,16))
            +-- locals: []
            +-- class_keyword_loc: (1,0)-(1,5) = "class"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- constant_path:
            |   @ ConstantReadNode (location: (1,6)-(1,7))
            |   +-- name: :A
            +-- inheritance_operator_loc: (1,8)-(1,9) = "<"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- superclass:
            |   @ ConstantReadNode (location: (1,10)-(1,11))
            |   +-- name: :B
            +-- body: nil
            +-- end_keyword_loc: (1,13)-(1,16) = "end"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- name: :A
```