### PR TITLE
Make rb_objspace_garbage_object_p()=true on non-heap pointers

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1595,7 +1595,11 @@ rb_objspace_free_objects(void *objspace)
 int
 rb_objspace_garbage_object_p(VALUE obj)
 {
-    return rb_gc_impl_garbage_object_p(rb_gc_get_objspace(), obj);
+    void *objspace = rb_gc_get_objspace();
+    if (!rb_gc_impl_pointer_to_heap_p(objspace, (void *)obj)) {
+        return TRUE;
+    }
+    return rb_gc_impl_garbage_object_p(objspace, obj);
 }
 
 /*


### PR DESCRIPTION
In rare situations, by the time vm_ccs_free() runs, the stale cc pointer
might point to a heap page that has been freed a long time ago and is no
longer part of the active GC heap anymore. Previously we'd try to read
and write through the stale pointer anyways, which caused use-after-free
crashes. Surely other callers are at least fine with this change, if not
also avoid bugs in similar situations.

    if (!rb_objspace_garbage_object_p((VALUE)cc) &&
        IMEMO_TYPE_P(cc, imemo_callcache) && // <-- Previously UAF
        cc->klass == klass) {

Not changing rb_gc_impl_garbage_object_p(), since the GC always work
within the confines of its heap already, so no need to check there.
