### PR TITLE
Use rb_fiber_scheduler_get() instead of rb_fiber_scheduler_current()

### DIFF
--- a/vm_dump.c
+++ b/vm_dump.c
@@ -1141,7 +1141,7 @@ rb_vm_bugreport(const void *ctx, FILE *errout)
                 "---------------------------------------------------\n");
         kprintf("Total ractor count: %u\n", vm->ractor.cnt);
         kprintf("Ruby thread count for this ractor: %u\n", rb_ec_ractor_ptr(ec)->threads.cnt);
-        if (rb_fiber_scheduler_current() != Qnil) {
+        if (rb_fiber_scheduler_get() != Qnil) {
             kprintf("Note that the Fiber scheduler is enabled\n");
         }
         kputs("\n");


### PR DESCRIPTION
`rb_fiber_scheduler_current()` may return `nil` depending on whether the scheduler is being prevented for some reason, e.g., `Fiber.blocking{}`.

Using `rb_fiber_scheduler_get()` returns the scheduler, if one was set, even in a blocking context.