### PR TITLE
[Bug #20868] Fix Method#hash to not change after compaction

### DIFF
--- a/vm_method.c
+++ b/vm_method.c
@@ -2249,7 +2249,7 @@ rb_hash_method_definition(st_index_t hash, const rb_method_definition_t *def)
 
     switch (def->type) {
       case VM_METHOD_TYPE_ISEQ:
-        return rb_hash_uint(hash, (st_index_t)def->body.iseq.iseqptr);
+        return rb_hash_uint(hash, (st_index_t)def->body.iseq.iseqptr->body);
       case VM_METHOD_TYPE_CFUNC:
         hash = rb_hash_uint(hash, (st_index_t)def->body.cfunc.func);
         return rb_hash_uint(hash, def->body.cfunc.argc);


### PR DESCRIPTION
The hash value of a Method must remain constant after a compaction, otherwise it may not work as the key in a hash table.

For example:

```ruby
def a; end

# Need this method here because otherwise the iseq may be on the C stack
# which would get pinned and not move during compaction
def get_hash
  method(:a).hash
end

puts get_hash # => 2993401401091578131

GC.verify_compaction_references(expand_heap: true, toward: :empty)

puts get_hash # => -2162775864511574135
```