### PR TITLE
Update man and help: -d option set `$VERBOSE` to `true`

### DIFF
--- a/man/ruby.1
+++ b/man/ruby.1
@@ -287,6 +287,8 @@ to the standard output.
 .It Fl -debug
 Turns on debug mode.
 .Li "$DEBUG"
+and
+.Li "$VERBOSE"
 will be set to true.
 .Pp
 .It Fl e Ar command

--- a/ruby.c
+++ b/ruby.c
@@ -326,7 +326,7 @@ usage(const char *name, int help, int highlight, int columns)
         M("-a",		   "",                     "Split each input line ($_) into fields ($F)."),
         M("-c",		   "",			   "Check syntax (no execution)."),
         M("-Cdirpath",     "",			   "Execute program in specified directory."),
-        M("-d",		   ", --debug",		   "Set debugging flag ($DEBUG) to true."),
+        M("-d",		   ", --debug",		   "Set debugging flag ($DEBUG) and $VERBOSE to true."),
         M("-e 'code'",     "",			   "Execute given Ruby code; multiple -e allowed."),
         M("-Eex[:in]",     ", --encoding=ex[:in]", "Set default external and internal encodings."),
         M("-Fpattern",	   "",			   "Set input field separator ($;); used with -a."),


### PR DESCRIPTION
Option `-d`/`--debug` sets not only `$DEBUG` but also `$VERBOSE` to `true`.

```
% ~/tmp/r/bin/ruby -d -e 'p [$DEBUG, $VERBOSE]'
Exception 'LoadError' at /Users/ani/tmp/r/lib/ruby/3.4.0+0/rubygems.rb:1369 - cannot load such file -- rubygems/defaults/operating_system
Exception 'LoadError' at /Users/ani/tmp/r/lib/ruby/3.4.0+0/rubygems.rb:1386 - cannot load such file -- rubygems/defaults/ruby
[true, true]
```