### PR TITLE
Ignore return value of `into_raw_fd`

### DIFF
--- a/yjit/src/disasm.rs
+++ b/yjit/src/disasm.rs
@@ -120,7 +120,7 @@ pub fn dump_disasm_addr_range(cb: &CodeBlock, start_addr: CodePtr, end_addr: Cod
                     // Write with the fd opened during boot
                     let mut file = unsafe { std::fs::File::from_raw_fd(*fd) };
                     file.write_all(disasm.as_bytes()).unwrap();
-                    file.into_raw_fd(); // keep the fd open
+                    let _ = file.into_raw_fd(); // keep the fd open
                 }
             };
         }

--- a/yjit/src/log.rs
+++ b/yjit/src/log.rs
@@ -81,7 +81,7 @@ impl Log {
                     let mut file = unsafe { std::fs::File::from_raw_fd(fd) };
                     writeln!(file, "{}", entry).unwrap();
                     file.flush().unwrap();
-                    file.into_raw_fd(); // keep the fd open
+                    let _ = file.into_raw_fd(); // keep the fd open
                 }
 
                 LogOutput::MemoryOnly => () // Don't print or write anything


### PR DESCRIPTION
Fix as the compiler orders:
```
warning: unused return value of `into_raw_fd` that must be used
   --> ../src/yjit/src/disasm.rs:123:21
    |
123 |                     file.into_raw_fd(); // keep the fd open
    |                     ^^^^^^^^^^^^^^^^^^
    |
    = note: losing the raw file descriptor may leak resources
    = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
    |
123 |                     let _ = file.into_raw_fd(); // keep the fd open
    |                     +++++++

warning: unused return value of `into_raw_fd` that must be used
  --> ../src/yjit/src/log.rs:84:21
   |
84 |                     file.into_raw_fd(); // keep the fd open
   |                     ^^^^^^^^^^^^^^^^^^
   |
   = note: losing the raw file descriptor may leak resources
help: use `let _ = ...` to ignore the resulting value
   |
84 |                     let _ = file.into_raw_fd(); // keep the fd open
   |                     +++++++
```