### PR TITLE
Implement YIELD NODE locations

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -875,6 +875,12 @@ node_locations(VALUE ast_value, const NODE *node)
                                     location_new(nd_code_loc(node)),
                                     location_new(&RNODE_UNTIL(node)->keyword_loc),
                                     location_new(&RNODE_UNTIL(node)->closing_loc));
+      case NODE_YIELD:
+        return rb_ary_new_from_args(4,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_YIELD(node)->keyword_loc),
+                                    location_new(&RNODE_YIELD(node)->lparen_loc),
+                                    location_new(&RNODE_YIELD(node)->rparen_loc));
       case NODE_ARGS_AUX:
       case NODE_LAST:
         break;

--- a/node_dump.c
+++ b/node_dump.c
@@ -694,8 +694,11 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("yield invocation");
         ANN("format: yield [nd_head]");
         ANN("example: yield 1");
-        LAST_NODE;
         F_NODE(nd_head, RNODE_YIELD, "arguments");
+        F_LOC(keyword_loc, RNODE_YIELD);
+        F_LOC(lparen_loc, RNODE_YIELD);
+        LAST_NODE;
+        F_LOC(rparen_loc, RNODE_YIELD);
         return;
 
       case NODE_LVAR:

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -590,6 +590,9 @@ typedef struct RNode_YIELD {
     NODE node;
 
     struct RNode *nd_head;
+    rb_code_location_t keyword_loc;
+    rb_code_location_t lparen_loc;
+    rb_code_location_t rparen_loc;
 } rb_node_yield_t;
 
 typedef struct RNode_LVAR {

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1501,6 +1501,20 @@ dummy
       assert_locations(node.children[-1].locations, [[1, 0, 1, 9], [1, 2, 1, 7], nil])
     end
 
+    def test_yield_locations
+      node = ast_parse("def foo; yield end")
+      assert_locations(node.children[-1].children[-1].children[-1].locations, [[1, 9, 1, 14], [1, 9, 1, 14], nil, nil])
+
+      node = ast_parse("def foo; yield() end")
+      assert_locations(node.children[-1].children[-1].children[-1].locations, [[1, 9, 1, 16], [1, 9, 1, 14], [1, 14, 1, 15], [1, 15, 1, 16]])
+
+      node = ast_parse("def foo; yield 1, 2 end")
+      assert_locations(node.children[-1].children[-1].children[-1].locations, [[1, 9, 1, 19], [1, 9, 1, 14], nil, nil])
+
+      node = ast_parse("def foo; yield(1, 2) end")
+      assert_locations(node.children[-1].children[-1].children[-1].locations, [[1, 9, 1, 20], [1, 9, 1, 14], [1, 14, 1, 15], [1, 19, 1, 20]])
+  end
+
     private
     def ast_parse(src, **options)
       begin


### PR DESCRIPTION
The following Location information has been added This is the information required for parse.y to be a universal parser:

```
❯ ruby --parser=prism --dump=parsetree -e 'def foo; yield end'
@ ProgramNode (location: (1,0)-(1,18))
+-- locals: []
+-- statements:
    @ StatementsNode (location: (1,0)-(1,18))
    +-- body: (length: 1)
        +-- @ DefNode (location: (1,0)-(1,18))
            +-- name: :foo
            +-- name_loc: (1,4)-(1,7) = "foo"
            +-- receiver: nil
            +-- parameters: nil
            +-- body:
            |   @ StatementsNode (location: (1,9)-(1,14))
            |   +-- body: (length: 1)
            |       +-- @ YieldNode (location: (1,9)-(1,14))
            |           +-- keyword_loc: (1,9)-(1,14) = "yield"
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            |           +-- lparen_loc: nil
                        ^^^^^^^^^^^^^^^^^^^
            |           +-- arguments: nil
            |           +-- rparen_loc: nil
                        ^^^^^^^^^^^^^^^^^^^
            +-- locals: []
            +-- def_keyword_loc: (1,0)-(1,3) = "def"
            +-- operator_loc: nil
            +-- lparen_loc: nil
            +-- rparen_loc: nil
            +-- equal_loc: nil
            +-- end_keyword_loc: (1,15)-(1,18) = "end"
```