### PR TITLE
[Bug #20873] Consider `-FIXNUM_MIN` overflow

### DIFF
--- a/sprintf.c
+++ b/sprintf.c
@@ -808,7 +808,7 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
                 if (FIXNUM_P(num)) {
                     if ((SIGNED_VALUE)num < 0) {
                         long n = -FIX2LONG(num);
-                        num = LONG2FIX(n);
+                        num = LONG2NUM(n);
                         sign = -1;
                     }
                 }

--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -227,6 +227,10 @@ class TestSprintf < Test::Unit::TestCase
 
     bug11766 = '[ruby-core:71806] [Bug #11766]'
     assert_equal("x"*10+"     1.0", sprintf("x"*10+"%8.1f", 1r), bug11766)
+
+    require 'rbconfig/sizeof'
+    fmin, fmax = RbConfig::LIMITS.values_at("FIXNUM_MIN", "FIXNUM_MAX")
+    assert_match(/\A-\d+\.\d+\z/, sprintf("%f", Rational(fmin, fmax)))
   end
 
   def test_rational_precision


### PR DESCRIPTION
`-FIXNUM_MIN` is usually greater than `FIXNUM_MAX` on platforms using two's complement representation.