### PR TITLE
`Ractor.local_storage_init`

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1513,6 +1513,21 @@ assert_equal '[nil, "b", "a"]', %q{
   ans << Ractor.current[:key]
 }
 
+assert_equal '1', %q{
+  N = 1_000
+  Ractor.new{
+    a = []
+    1_000.times.map{|i|
+      Thread.new(i){|i|
+        Thread.pass if i < N
+        a << Ractor.local_storage_init(:i){ i }
+        a << Ractor.current[:i]
+      }
+    }.each(&:join)
+    a.uniq.size
+  }.take
+}
+
 ###
 ### Synchronization tests
 ###

--- a/ractor.rb
+++ b/ractor.rb
@@ -834,6 +834,10 @@ class Ractor
     end
   end
 
+  def self.local_storage_init(sym)
+    Primitive.ractor_local_storage_init(sym)
+  end
+
   # get a value from ractor-local storage
   def [](sym)
     Primitive.ractor_local_value(sym)

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -180,6 +180,7 @@ struct rb_ractor_struct {
 
     st_table *local_storage;
     struct rb_id_table *idkey_local_storage;
+    VALUE idkey_init_lock;
 
     VALUE r_stdin;
     VALUE r_stdout;


### PR DESCRIPTION
to initialize Ractor local storage slot atomically. [Feature #20875]