### PR TITLE
`-municode` is available for MinGW-w64 targets only

### DIFF
--- a/cygwin/GNUmakefile.in
+++ b/cygwin/GNUmakefile.in
@@ -2,7 +2,12 @@ gnumake = yes
 
 include Makefile
 
+ifeq ($(target_os),cygwin)
+MUNICODE_FLAG =
+else
 override EXE_LDFLAGS += -municode
+MUNICODE_FLAG = -municode
+endif
 
 DLLWRAP = @DLLWRAP@ --target=$(target_os) --driver-name="$(CC)"
 ifeq (@USE_LLVM_WINDRES@,yes) # USE_LLVM_WINDRES
@@ -71,7 +76,7 @@ $(PROGRAM): $(RUBY_INSTALL_NAME).res.$(OBJEXT)
 $(WPROGRAM): $(RUBYW_INSTALL_NAME).res.$(OBJEXT)
 	@rm -f $@
 	$(ECHO) linking $@
-	$(Q) $(PURIFY) $(CC) -municode -mwindows -e $(SYMBOL_PREFIX)mainCRTStartup $(LDFLAGS) $(XLDFLAGS) \
+	$(Q) $(PURIFY) $(CC) $(MUNICODE_FLAG) -mwindows -e $(SYMBOL_PREFIX)mainCRTStartup $(LDFLAGS) $(XLDFLAGS) \
 	  $(MAINOBJ) $(EXTOBJS) $(LIBRUBYARG) $(LIBS) -o $@
 $(STUBPROGRAM): $(RUBY_INSTALL_NAME).res.$(OBJEXT)
 

--- a/cygwin/GNUmakefile.in
+++ b/cygwin/GNUmakefile.in
@@ -2,12 +2,8 @@ gnumake = yes
 
 include Makefile
 
-ifeq ($(target_os),cygwin)
-MUNICODE_FLAG =
-else
-override EXE_LDFLAGS += -municode
-MUNICODE_FLAG = -municode
-endif
+MUNICODE_FLAG = $(if $(filter mingw%,$(target_os)),-municode)
+override EXE_LDFLAGS += $(MUNICODE_FLAG)
 
 DLLWRAP = @DLLWRAP@ --target=$(target_os) --driver-name="$(CC)"
 ifeq (@USE_LLVM_WINDRES@,yes) # USE_LLVM_WINDRES


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc/Cygwin-and-MinGW-Options.html#index-municode
> -municode
> This option is available for MinGW-w64 targets. It causes the UNICODE preprocessor macro to be predefined, and chooses Unicode-capable runtime startup code.

```
gcc: error: unrecognized command-line option '-municode'
```
