### PR TITLE
Allow `io_buffer_memmove` to release the GVL for large buffers.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,10 @@ Note: We're only listing outstanding class updates.
     * An optional `Fiber::Scheduler#blocking_operation_wait` hook allows blocking operations to be moved out of the
       event loop in order to reduce latency and improve multi-core processor utilization. [[Feature #20876]]
 
+* IO::Buffer
+
+    * `IO::Buffer#copy` can release the GVL, allowing other threads to run while copying data. [[Feature #20902]]
+
 ## Stdlib updates
 
 * Tempfile
@@ -242,3 +246,4 @@ details of the default gems or bundled gems.
 [Feature #20624]: https://bugs.ruby-lang.org/issues/20624
 [Feature #20775]: https://bugs.ruby-lang.org/issues/20775
 [Feature #20876]: https://bugs.ruby-lang.org/issues/20876
+[Feature #20902]: https://bugs.ruby-lang.org/issues/20902

--- a/common.mk
+++ b/common.mk
@@ -8816,6 +8816,7 @@ io_buffer.$(OBJEXT): {$(VPATH)}onigmo.h
 io_buffer.$(OBJEXT): {$(VPATH)}oniguruma.h
 io_buffer.$(OBJEXT): {$(VPATH)}st.h
 io_buffer.$(OBJEXT): {$(VPATH)}subst.h
+io_buffer.$(OBJEXT): {$(VPATH)}thread.h
 io_buffer.$(OBJEXT): {$(VPATH)}thread_native.h
 iseq.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
 iseq.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20902

It turns out, `memmove` can take a long time for large buffers. Well, hardly surprising I suppose.

Here is a script you can use for experimentation:

```ruby
SIZE = 1024*1024*10

def copy_buffers(size = SIZE)
  source = IO::Buffer.new(size)
  destination = IO::Buffer.new(size)

  destination.copy(source)
end

start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
threads = 8.times.map do
  Thread.new{copy_buffers}
end

threads.each(&:join)

duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time

puts "Duration: #{duration} seconds"
```

Again, we will have to hard code some magic number/heuristic (or compute it at startup) to determine when releasing the GVL makes sense. Maybe anything bigger than X pages?