### PR TITLE
CI: In parse.y runs, use ./configure --with-parser=parse.y

### DIFF
--- a/.github/workflows/parsey.yml
+++ b/.github/workflows/parsey.yml
@@ -69,7 +69,7 @@ jobs:
           dummy-files: ${{ matrix.test_task == 'check' }}
 
       - name: Run configure
-        run: ../src/configure -C --disable-install-doc cppflags=-DRUBY_DEBUG
+        run: ../src/configure -C --disable-install-doc cppflags=-DRUBY_DEBUG --with-praser=parse.y
 
       - run: make
 


### PR DESCRIPTION
Because tests might not use the command-line --parser option, or be
aware that they should be, it's better to test with the default
parser set.
