### PR TITLE
Fix coderange for sprintf on binary strings

### DIFF
--- a/sprintf.c
+++ b/sprintf.c
@@ -67,7 +67,8 @@ sign_bits(int base, const char *p)
 
 #define CHECK(l) do {\
     int cr = ENC_CODERANGE(result);\
-    while ((l) >= bsiz - blen) {\
+    RUBY_ASSERT(bsiz >= blen); \
+    while ((l) > bsiz - blen) {\
         bsiz*=2;\
         if (bsiz<0) rb_raise(rb_eArgError, "too big specifier");\
     }\

--- a/sprintf.c
+++ b/sprintf.c
@@ -247,8 +247,7 @@ rb_str_format(int argc, const VALUE *argv, VALUE fmt)
     }
 
 #define update_coderange(partial) do { \
-        if (coderange != ENC_CODERANGE_BROKEN && scanned < blen \
-            && rb_enc_to_index(enc) /* != ENCINDEX_ASCII_8BIT */) { \
+        if (coderange != ENC_CODERANGE_BROKEN && scanned < blen) { \
             int cr = coderange; \
             scanned += rb_str_coderange_scan_restartable(buf+scanned, buf+blen, enc, &cr); \
             ENC_CODERANGE_SET(result, \

--- a/test/ruby/test_sprintf.rb
+++ b/test/ruby/test_sprintf.rb
@@ -546,4 +546,12 @@ class TestSprintf < Test::Unit::TestCase
       sprintf("%*s", RbConfig::LIMITS["INT_MIN"], "")
     end
   end
+
+  def test_binary_format_coderange
+    1.upto(500) do |i|
+      str = sprintf("%*s".b, i, "\xe2".b)
+      refute_predicate str, :ascii_only?
+      assert_equal i, str.bytesize
+    end
+  end
 end


### PR DESCRIPTION
Fixes [Bug #20883](https://bugs.ruby-lang.org/issues/20883)

In 9dc60653db186b1ae9400ed75b413a07728ce6ff we stopped updating the coderange when the encoding became ENCINDEX_ASCII_8BIT. Then later in #9552 `rb_str_resize` was made to clear the coderange more often, unintentionally fixing this.

We should keep updating the coderange for `ENCINDEX_ASCII_8BIT` 1) to fix this bug in Ruby 3.3, 2) so that we don't rely on the fact that `rb_str_resize` clears the coderange in cases it doesn't need to, as we may want it more optimized in the future.