### PR TITLE
Avoid double-free in regex timeout after stack_double

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -4217,9 +4217,8 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
   return ONIGERR_UNEXPECTED_BYTECODE;
 
  timeout:
+  STACK_SAVE;
   xfree(xmalloc_base);
-  if (stk_base != stk_alloc || IS_NOT_NULL(msa->stack_p))
-      xfree(stk_base);
   return ONIGERR_TIMEOUT;
 }
 

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1845,6 +1845,13 @@ class TestRegexp < Test::Unit::TestCase
     end
   end
 
+  def test_bug_20886
+    re = Regexp.new("d()*+|a*a*bc", timeout: 0.02)
+    assert_raise(Regexp::TimeoutError) do
+      re === "b" + "a" * 1000
+    end
+  end
+
   def per_instance_redos_test(global_timeout, per_instance_timeout, expected_timeout)
     assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
       global_timeout = #{ EnvUtil.apply_timeout_scale(global_timeout).inspect }


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20886

As of https://github.com/ruby/ruby/pull/11238, certain regex we end up freeing `stk_alloc` AKA `msa->stack_p` twice, once in FREE_MATCH_ARG and once in the code here. This is very similar to a problem which was previously fixed by 6f6a2d2170cc1f3cb4a5f0fa3792635162e7b746.

This one is a bit hard to reproduce. I'm still searching if there is a more reliable way to reproduce (either too short or too long a timeout and it doesn't seem to occur). I'll continue that tomorrow and then file a bug in the tracker for backport.

```
> Regexp.new('(?:xxx(?:s*[x]+)*+)|(?:^\s*(?:a|b|\s*)fxxx)', timeout: 0.2).match?("foo\n"*10 + (" " * 460 + "\n") * 10)
ruby(80654,0x1f357f840) malloc: double free for ptr 0x150008000
ruby(80654,0x1f357f840) malloc: *** set a breakpoint in malloc_error_break to debug
zsh: abort      irb
```

cc @composerinteralia @peterzhu2118 