### PR TITLE
[Bug #20800] Move executable binary file path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,6 +149,7 @@ dnl checks for alternative programs
 AC_CANONICAL_BUILD
 AC_CANONICAL_HOST
 AC_CANONICAL_TARGET
+AC_SUBST(config_target, $target)
 AS_CASE(["$target_cpu-$target_os"],
     [aarch64-darwin*], [
         target_cpu=arm64

--- a/configure.ac
+++ b/configure.ac
@@ -3592,6 +3592,7 @@ AS_CASE("$enable_shared", [yes], [
      ])
     ])
 
+  relative_libprefix="/../${multiarch+../}${libdir_basename}"
   AS_CASE(["$target_os"],
     [sunos4*], [
 	LIBRUBY_ALIASES='$(LIBRUBY_SONAME) lib$(RUBY_SO_NAME).$(SOEXT)'
@@ -3600,7 +3601,7 @@ AS_CASE("$enable_shared", [yes], [
 	RUBY_APPEND_OPTIONS(LIBRUBY_DLDFLAGS, ['-Wl,-soname,$(LIBRUBY_SONAME)' "$LDFLAGS_OPTDIR"])
 	LIBRUBY_ALIASES='$(LIBRUBY_SONAME) lib$(RUBY_SO_NAME).$(SOEXT)'
 	AS_IF([test "$load_relative" = yes], [
-	    libprefix="'\$\${ORIGIN}/../${multiarch+../../}${libdir_basename}'"
+	    libprefix="'\$\${ORIGIN}${relative_libprefix}'"
 	    LIBRUBY_RPATHFLAGS="-Wl,-rpath,${libprefix}"
 	    LIBRUBY_RELATIVE=yes
 	])
@@ -3612,7 +3613,7 @@ AS_CASE("$enable_shared", [yes], [
 	    LIBRUBY_SO="$LIBRUBY_SO.\$(TEENY)"
 	    LIBRUBY_ALIASES=''
 	], [test "$load_relative" = yes], [
-	    libprefix="'\$\$ORIGIN/../${multiarch+../../}${libdir_basename}'"
+	    libprefix="'\$\$ORIGIN${relative_libprefix}'"
 	    LIBRUBY_RPATHFLAGS="-Wl,-rpath,${libprefix}"
 	    LIBRUBY_RELATIVE=yes
 	])
@@ -3636,7 +3637,7 @@ AS_CASE("$enable_shared", [yes], [
 	LIBRUBY_ALIASES='$(LIBRUBY_SONAME) lib$(RUBY_SO_NAME).$(SOEXT)'
 	RUBY_APPEND_OPTIONS(LIBRUBY_DLDFLAGS, ["${linker_flag}-h${linker_flag:+,}"'$(@F)'])
 	AS_IF([test "$load_relative" = yes], [
-	    libprefix="'\$\$ORIGIN/../${multiarch+../../}${libdir_basename}'"
+	    libprefix="'\$\$ORIGIN${relative_libprefix}'"
 	    LIBRUBY_RPATHFLAGS="-R${libprefix}"
 	    LIBRUBY_RELATIVE=yes
 	], [
@@ -3653,7 +3654,7 @@ AS_CASE("$enable_shared", [yes], [
 	LIBRUBY_SONAME='$(LIBRUBY_SO)'
 	LIBRUBY_ALIASES='lib$(RUBY_INSTALL_NAME).$(SOEXT)'
 	AS_IF([test "$load_relative" = yes], [
-	    libprefix="@executable_path/../${multiarch+../../}${libdir_basename}"
+	    libprefix="@executable_path${relative_libprefix}"
 	    LIBRUBY_RELATIVE=yes
 	])
 	LIBRUBY_DLDFLAGS="$LIBRUBY_DLDFLAGS -install_name ${libprefix}"'/$(LIBRUBY_SONAME)'

--- a/tool/mkrunnable.rb
+++ b/tool/mkrunnable.rb
@@ -34,7 +34,10 @@ vendordir = config["vendordir"]
 rubylibdir = config["rubylibdir"]
 rubyarchdir = config["rubyarchdir"]
 archdir = "#{extout}/#{arch}"
-exedir = libdirname == "archlibdir" ? "#{config["libexecdir"]}/#{arch}" : bindir
+exedir = bindir
+if libdirname == "archlibdir"
+  exedir = exedir.sub(%r[/\K(?=[^/]+\z)]) {extout+"/"}
+end
 [exedir, libdir, archdir].uniq.each do |dir|
   File.directory?(dir) or mkdir_p(dir)
 end

--- a/tool/mkrunnable.rb
+++ b/tool/mkrunnable.rb
@@ -34,7 +34,7 @@ vendordir = config["vendordir"]
 rubylibdir = config["rubylibdir"]
 rubyarchdir = config["rubyarchdir"]
 archdir = "#{extout}/#{arch}"
-exedir = libdirname == "archlibdir" ? "#{config["libexecdir"]}/#{arch}/bin" : bindir
+exedir = libdirname == "archlibdir" ? "#{config["libexecdir"]}/#{arch}" : bindir
 [exedir, libdir, archdir].uniq.each do |dir|
   File.directory?(dir) or mkdir_p(dir)
 end

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -371,7 +371,7 @@ if CONFIG["libdirname"] == "archlibdir"
   unless libexecdir.sub!(/\$\(lib\K(?=dir\))/) {"exec"}
     libexecdir = "$(libexecdir)/$(arch)"
   end
-  archbindir = RbConfig.expand(libexecdir) + "/bin"
+  archbindir = RbConfig.expand(libexecdir)
 end
 libdir = CONFIG[CONFIG.fetch("libdirname", "libdir"), true]
 rubyhdrdir = CONFIG["rubyhdrdir", true]

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -367,7 +367,7 @@ goruby_install_name = "go" + ruby_install_name
 
 bindir = CONFIG["bindir", true]
 if CONFIG["libdirname"] == "archlibdir"
-  archbindir = bindir.sub(%r[/\K(?=[^/]+\z)]) {CONFIG["target"] + "/"}
+  archbindir = bindir.sub(%r[/\K(?=[^/]+\z)]) {CONFIG["config_target"] + "/"}
 end
 libdir = CONFIG[CONFIG.fetch("libdirname", "libdir"), true]
 rubyhdrdir = CONFIG["rubyhdrdir", true]

--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -367,11 +367,7 @@ goruby_install_name = "go" + ruby_install_name
 
 bindir = CONFIG["bindir", true]
 if CONFIG["libdirname"] == "archlibdir"
-  libexecdir = MAKEFILE_CONFIG["archlibdir"].dup
-  unless libexecdir.sub!(/\$\(lib\K(?=dir\))/) {"exec"}
-    libexecdir = "$(libexecdir)/$(arch)"
-  end
-  archbindir = RbConfig.expand(libexecdir)
+  archbindir = bindir.sub(%r[/\K(?=[^/]+\z)]) {CONFIG["target"] + "/"}
 end
 libdir = CONFIG[CONFIG.fetch("libdirname", "libdir"), true]
 rubyhdrdir = CONFIG["rubyhdrdir", true]


### PR DESCRIPTION
From under "libexec", under `$(target)/bin` like as binutils.