### PR TITLE
Fix sign-conversion warnings on IL32 platforms

### DIFF
--- a/include/ruby/internal/arithmetic/int.h
+++ b/include/ruby/internal/arithmetic/int.h
@@ -254,7 +254,7 @@ static inline VALUE
 rb_uint2num_inline(unsigned int v)
 {
     if (RB_POSFIXABLE(v))
-        return RB_LONG2FIX(v);
+        return RB_LONG2FIX(RBIMPL_CAST((long)v));
     else
         return rb_uint2big(v);
 }

--- a/include/ruby/internal/intern/select/win32.h
+++ b/include/ruby/internal/intern/select/win32.h
@@ -253,7 +253,7 @@ rb_fd_max(const rb_fdset_t *f)
     const fd_set *p = f->fdset;
 
     RBIMPL_ASSERT_OR_ASSUME(p);
-    return p->fd_count;
+    return RBIMPL_CAST((int)p->fd_count);
 }
 
 #endif /* RBIMPL_INTERN_SELECT_WIN32_H */


### PR DESCRIPTION
If `long` and `int` are the same size, `unsigned int` max would exceed `signed long` range.  It is guaranteed by `RB_POSFIXABLE` that `v` can be casted to `long` safely here.