### PR TITLE
Implement FOR NODE locations

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -828,6 +828,13 @@ node_locations(VALUE ast_value, const NODE *node)
         return rb_ary_new_from_args(2,
                                     location_new(nd_code_loc(node)),
                                     location_new(&RNODE_FLIP3(node)->operator_loc));
+      case NODE_FOR:
+        return rb_ary_new_from_args(5,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_FOR(node)->for_keyword_loc),
+                                    location_new(&RNODE_FOR(node)->in_keyword_loc),
+                                    location_new(&RNODE_FOR(node)->do_keyword_loc),
+                                    location_new(&RNODE_FOR(node)->end_keyword_loc));
       case NODE_LAMBDA:
         return rb_ary_new_from_args(4,
                                     location_new(nd_code_loc(node)),

--- a/node_dump.c
+++ b/node_dump.c
@@ -338,15 +338,22 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("method call with block");
         ANN("format: [nd_iter] { [nd_body] }");
         ANN("example: 3.times { foo }");
-        goto iter;
+        F_NODE(nd_iter, RNODE_ITER, "iteration receiver");
+        LAST_NODE;
+        F_NODE(nd_body, RNODE_ITER, "body");
+        return;
+
       case NODE_FOR:
         ANN("for statement");
         ANN("format: for * in [nd_iter] do [nd_body] end");
         ANN("example: for i in 1..3 do foo end");
-      iter:
-        F_NODE(nd_iter, RNODE_ITER, "iteration receiver");
+        F_NODE(nd_iter, RNODE_FOR, "iteration receiver");
+        F_NODE(nd_body, RNODE_FOR, "body");
+        F_LOC(for_keyword_loc, RNODE_FOR);
+        F_LOC(in_keyword_loc, RNODE_FOR);
+        F_LOC(do_keyword_loc, RNODE_FOR);
         LAST_NODE;
-        F_NODE(nd_body, RNODE_ITER, "body");
+        F_LOC(end_keyword_loc, RNODE_FOR);
         return;
 
       case NODE_FOR_MASGN:

--- a/parse.y
+++ b/parse.y
@@ -4541,11 +4541,8 @@ primary         : inline_primary
                         /* {|*internal_id| <m> = internal_id; ... } */
                         args = new_args(p, m, 0, id, 0, new_args_tail(p, 0, 0, 0, &@for_var), &@for_var);
                         scope = NEW_SCOPE2(tbl, args, $compstmt, &@$);
-                        if ($do == keyword_do_cond) {
-                            $$ = NEW_FOR($5, scope, &@$, &@k_for, &@keyword_in, &@do, &@k_end);
-                        } else {
-                            $$ = NEW_FOR($5, scope, &@$, &@k_for, &@keyword_in, &NULL_LOC, &@k_end);
-                        }
+                        YYLTYPE do_keyword_loc = $do == keyword_do_cond ? @do : NULL_LOC;
+                        $$ = NEW_FOR($5, scope, &@$, &@k_for, &@keyword_in, &do_keyword_loc, &@k_end);
                         fixpos($$, $for_var);
                     /*% ripper: for!($:for_var, $:expr_value, $:compstmt) %*/
                     }

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -341,7 +341,18 @@ typedef struct RNode_ITER {
 
     struct RNode *nd_body;
     struct RNode *nd_iter;
-} rb_node_iter_t, rb_node_for_t;
+} rb_node_iter_t;
+
+typedef struct RNode_FOR {
+    NODE node;
+
+    struct RNode *nd_body;
+    struct RNode *nd_iter;
+    rb_code_location_t for_keyword_loc;
+    rb_code_location_t in_keyword_loc;
+    rb_code_location_t do_keyword_loc;
+    rb_code_location_t end_keyword_loc;
+} rb_node_for_t;
 
 typedef struct RNode_FOR_MASGN {
     NODE node;

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1428,6 +1428,14 @@ dummy
       assert_locations(node.children[-1].children[0].locations, [[1, 3, 1, 8], [1, 4, 1, 7]])
     end
 
+    def test_for_locations
+      node = ast_parse("for a in b; end")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 15], [1, 0, 1, 3], [1, 6, 1, 8], nil, [1, 12, 1, 15]])
+
+      node = ast_parse("for a in b do; end")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 18], [1, 0, 1, 3], [1, 6, 1, 8], [1, 11, 1, 13], [1, 15, 1, 18]])
+    end
+
     def test_lambda_locations
       node = ast_parse("-> (a, b) { foo }")
       assert_locations(node.children[-1].locations, [[1, 0, 1, 17], [1, 0, 1, 2], [1, 10, 1, 11], [1, 16, 1, 17]])


### PR DESCRIPTION
The following Location information has been added This is the information required for parse.y to be a universal parser:

```
❯ ruby --parser=prism --dump=parsetree -e "for a in b do end"
@ ProgramNode (location: (1,0)-(1,17))
+-- locals: [:a]
+-- statements:
    @ StatementsNode (location: (1,0)-(1,17))
    +-- body: (length: 1)
        +-- @ ForNode (location: (1,0)-(1,17))
            +-- index:
            |   @ LocalVariableTargetNode (location: (1,4)-(1,5))
            |   +-- name: :a
            |   +-- depth: 0
            +-- collection:
            |   @ CallNode (location: (1,9)-(1,10))
            |   +-- CallNodeFlags: variable_call, ignore_visibility
            |   +-- receiver: nil
            |   +-- call_operator_loc: nil
            |   +-- name: :b
            |   +-- message_loc: (1,9)-(1,10) = "b"
            |   +-- opening_loc: nil
            |   +-- arguments: nil
            |   +-- closing_loc: nil
            |   +-- block: nil
            +-- statements: nil
            +-- for_keyword_loc: (1,0)-(1,3) = "for"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- in_keyword_loc: (1,6)-(1,8) = "in"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- do_keyword_loc: (1,11)-(1,13) = "do"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            +-- end_keyword_loc: (1,14)-(1,17) = "end"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```