### PR TITLE
Fix restoring $VERBOSE in json/json_common_interface_test.rb

### DIFF
--- a/test/json/json_common_interface_test.rb
+++ b/test/json/json_common_interface_test.rb
@@ -209,7 +209,6 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
     Encoding.default_external = encoding
     yield
   ensure
-    verbose = $VERBOSE
     Encoding.default_external = previous_encoding
     $VERBOSE = verbose
   end


### PR DESCRIPTION
Sync https://github.com/ruby/json/pull/704
Fixes this ci failure
```
1) Failure:
--
  | TestIRB::ShowDocTest#test_show_doc_without_rdoc [/tmp/ruby/src/trunk-random2/test/irb/test_command.rb:775]:
  | Expected "" to include "Can't display document because `rdoc` is not installed.\n".
  | make: *** [uncommon.mk:963: yes-test-all] Error 1
```
