### PR TITLE
YJIT: Probe away from the heap when requesting exec memory

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -294,8 +294,11 @@ rb_yjit_reserve_addr_space(uint32_t mem_size)
                 break;
             }
 
-            // +4MB
-            req_addr += 4 * 1024 * 1024;
+            // -4MiB. Downwards to probe away from the heap. (On x86/A64 Linux
+            // main_code_addr < heap_addr, and in case we are in a shared
+            // library mapped higher than the heap, downwards is still better
+            // since it's towards the end of the heap rather than the stack.)
+            req_addr -= 4 * 1024 * 1024;
         } while (req_addr < probe_region_end);
 
     // On MacOS and other platforms


### PR DESCRIPTION
I was looking at some crash reports and noticed that many have a line
like the following for YJIT code memory:

    <addr>-<addr> r-xp 00000000 00:00 0  [heap]

I guess YJIT confused the kernel into thinking this region is from
sbrk(). While this seems to have no consequences beyond mislabeling,
it's still a little concerning.

Probe downwards instead.
