### PR TITLE
Allow Net::HTTP#request to raise Net::OpenTimeout

### DIFF
--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -568,8 +568,8 @@ module TestNetHTTP_version_1_1_methods
       conn.open_timeout = EnvUtil.apply_timeout_scale(0.1)
 
       th = Thread.new do
-        err = !windows? ? Net::WriteTimeout : Net::ReadTimeout
-        assert_raise(err) do
+        err = !windows? ? [Net::WriteTimeout, Net::OpenTimeout] : Net::ReadTimeout
+        assert_raise(*err) do
           assert_warning(/Content-Type did not set/) do
             conn.post('/', "a"*50_000_000)
           end
@@ -600,7 +600,7 @@ module TestNetHTTP_version_1_1_methods
       req.body_stream = StringIO.new(data)
 
       th = Thread.new do
-        assert_raise(Net::WriteTimeout) { conn.request(req) }
+        assert_raise(Net::WriteTimeout, Net::OpenTimeout) { conn.request(req) }
       end
       assert th.join(10)
     }


### PR DESCRIPTION
with a TCPSoerver that is only listening
to avoid AssertionFailedError on Ubuntu.

---

The tests such as
`TestNetHTTP_v1_2_chunked#test_timeout_during_non_chunked_streamed_HTTP_session_write` expect to raise a `Net::WriteTimeout` due to a failure in writing to the server.

However, on Ubuntu environments,
the server immediately returns a "Connection Refused" in such cases. The socket created with `TCPSocket.new` that supports HEv2 catches this immediately and raises a `Net::OpenTimeout`.
As a result, these tests fail due to raising a different exception than expected. This PR adds `Net::OpenTimeout` asexceptions to avoid these test failures.