### PR TITLE
[Backport 3.3] [Bug #20886] Avoid double-free in regex timeout after stack_double

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -4217,9 +4217,8 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
   return ONIGERR_UNEXPECTED_BYTECODE;
 
  timeout:
+  STACK_SAVE;
   xfree(xmalloc_base);
-  if (stk_base != stk_alloc || IS_NOT_NULL(msa->stack_p))
-      xfree(stk_base);
   return ONIGERR_TIMEOUT;
 }
 

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1838,6 +1838,13 @@ class TestRegexp < Test::Unit::TestCase
     end;
   end
 
+  def test_bug_20886
+    re = Regexp.new("d()*+|a*a*bc", timeout: 0.02)
+    assert_raise(Regexp::TimeoutError) do
+      re === "b" + "a" * 1000
+    end
+  end
+
   def per_instance_redos_test(global_timeout, per_instance_timeout, expected_timeout)
     assert_separately([], "#{<<-"begin;"}\n#{<<-'end;'}")
       global_timeout = #{ EnvUtil.apply_timeout_scale(global_timeout).inspect }


### PR DESCRIPTION
Backport of #12030 to 3.3