### PR TITLE
Update vcpkg baseline with latest version

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -100,6 +100,7 @@ jobs:
         run: |
           iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
           Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
+          scoop install vcpkg
         shell: pwsh
 
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,5 +6,5 @@
     "openssl",
     "zlib"
   ],
-  "builtin-baseline": "a4275b7eee79fb24ec2e135481ef5fce8b41c339"
+  "builtin-baseline": "65be7019941e1401e02daaba0738cab2c8a4a355"
 }


### PR DESCRIPTION
```
    libffi:x64-windows@3.4.6
    libyaml:x64-windows@0.2.5#5
    openssl:x64-windows@3.4.0
  * vcpkg-cmake:x64-windows@2024-04-23
  * vcpkg-cmake-config:x64-windows@2024-05-23
  * vcpkg-cmake-get-vars:x64-windows@2024-09-22
    zlib:x64-windows@1.3.1
```