### PR TITLE
ObjectSpace.dump: handle Module#set_temporary_name

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -549,9 +549,8 @@ dump_object(VALUE obj, struct dump_config *dc)
         if (dc->cur_obj_klass) {
             VALUE mod_name = rb_mod_name(obj);
             if (!NIL_P(mod_name)) {
-                dump_append(dc, ", \"name\":\"");
-                dump_append(dc, RSTRING_PTR(mod_name));
-                dump_append(dc, "\"");
+                dump_append(dc, ", \"name\":");
+                dump_append_string_value(dc, mod_name);
             }
             else {
                 VALUE real_mod_name = rb_mod_name(rb_class_real(obj));

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -902,6 +902,12 @@ class TestObjSpace < Test::Unit::TestCase
     # load_allocation_path_helper 'iseq = RubyVM::InstructionSequence.load_from_binary(File.binread(path))', to_binary: true
   end
 
+  def test_escape_class_name
+    class_name = '" little boby table [Bug #20892]'
+    json = ObjectSpace.dump(Class.new.tap { |c| c.set_temporary_name(class_name) })
+    assert_equal class_name, JSON.parse(json)["name"]
+  end
+
   def test_utf8_method_names
     name = "utf8_❨╯°□°❩╯︵┻━┻"
     obj = ObjectSpace.trace_object_allocations do


### PR DESCRIPTION
[[Bug #20892]](https://bugs.ruby-lang.org/issues/20892)

Until the introduction of that method, it was impossible for a Module name not to be valid JSON, hence it wasn't going through the slower escaping function.

This assumption no longer hold.