### PR TITLE
[CI] add CI matrix for GCC 14

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -83,6 +83,7 @@ jobs:
           optflags: '-O2'
           enable_shared: false
       - { uses: './.github/actions/compilers', name: 'ext/Setup', with: { static_exts: 'etc json/* */escape' } }
+      - { uses: './.github/actions/compilers', name: 'GCC 14', with: { tag: 'gcc-14' } }
       - { uses: './.github/actions/compilers', name: 'GCC 13', with: { tag: 'gcc-13' } }
       - { uses: './.github/actions/compilers', name: 'GCC 12', with: { tag: 'gcc-12' } }
       - { uses: './.github/actions/compilers', name: 'GCC 11', with: { tag: 'gcc-11' } }


### PR DESCRIPTION
Why not?

See also https://github.com/ruby/ruby-ci-image/pull/78