### PR TITLE
string.c: Directly create strings with the correct encoding

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -968,6 +968,21 @@ enc_set_index(VALUE obj, int idx)
 }
 
 void
+rb_enc_raw_set(VALUE obj, rb_encoding *enc)
+{
+    RUBY_ASSERT(enc_capable(obj));
+
+    int idx = enc ? ENC_TO_ENCINDEX(enc) : 0;
+
+    if (idx < ENCODING_INLINE_MAX) {
+        ENCODING_SET_INLINED(obj, idx);
+        return;
+    }
+    ENCODING_SET_INLINED(obj, ENCODING_INLINE_MAX);
+    rb_ivar_set(obj, rb_id_encoding(), INT2NUM(idx));
+}
+
+void
 rb_enc_set_index(VALUE obj, int idx)
 {
     rb_check_frozen(obj);

--- a/internal/encoding.h
+++ b/internal/encoding.h
@@ -28,6 +28,8 @@ int rb_encdb_dummy(const char *name);
 void rb_encdb_declare(const char *name);
 void rb_enc_set_base(const char *name, const char *orig);
 int rb_enc_set_dummy(int index);
+void rb_enc_raw_set(VALUE obj, rb_encoding *enc);
+
 PUREFUNC(int rb_data_is_encoding(VALUE obj));
 
 /* vm.c */


### PR DESCRIPTION
While profiling msgpack-ruby I noticed a very substantial amout of time spent in `rb_enc_associate_index`, called by `rb_utf8_str_new`.

On that benchmark, `rb_utf8_str_new` is 33% of the total runtime, in big part because it cause GC to trigger often, but even then `5.3%` of the total runtime is spent in `rb_enc_associate_index` called by `rb_utf8_str_new`.

After closer inspection, it appears that it's performing a lot of safety check we can assert we don't need, and other extra useless operations, because strings are first created and filled as ASCII-8BIT and then later reassociated to the desired encoding.

By directly allocating the string with the right encoding, it allow to skip a lot of duplicated and useless operations.

After this change, the time spent in `rb_utf8_str_new` is down to `28.4%` of total runtime, and most of that is GC.

Profile before:
<img width="2486" alt="ruby_associate_enc_index" src="https://github.com/user-attachments/assets/48e0de8f-9a8a-442e-aa6a-6e170e764d8f">

Profile after:
<img width="2484" alt="ruby_no_associate" src="https://github.com/user-attachments/assets/b2a01563-6061-4dda-a310-454b98851ee9">
