### PR TITLE
Fix threads stuck as zombie under M:N

### DIFF
--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -475,8 +475,8 @@ co_start(struct coroutine_context *from, struct coroutine_context *self)
         if (!has_ready_ractor && next_th && !next_th->nt) {
             // switch to the next thread
             thread_sched_set_lock_owner(sched, NULL);
-            thread_sched_switch0(th->sched.context, next_th, nt, true);
             th->sched.finished = true;
+            thread_sched_switch0(th->sched.context, next_th, nt, true);
         }
         else {
             // switch to the next Ractor


### PR DESCRIPTION
In this case thread_sched_switch0 never returns, so we would never end up setting finished to true.

**Before**

```
RUBY_MN_THREADS=1 ./miniruby -e '500.times { 50.times.map { Thread.new{} }.map(&:join) }; sleep 1; GC.start; p ObjectSpace.each_object(Thread).count'
24501
```

**After**

```
RUBY_MN_THREADS=1 ./miniruby -e '500.times { 50.times.map { Thread.new{} }.map(&:join) }; sleep 1; GC.start; p ObjectSpace.each_object(Thread).count'
1
```

Fixes [Bug #20638]