### PR TITLE
YJIT: Specialize Integer#pred

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -4594,6 +4594,11 @@ assert_equal '[2, 4611686018427387904]', %q{
   [1.succ, 4611686018427387903.succ]
 }
 
+# Integer pred and overflow
+assert_equal '[0, -4611686018427387905]', %q{
+  [1.pred, -4611686018427387904.pred]
+}
+
 # Integer right shift
 assert_equal '[0, 1, -4]', %q{
   [0 >> 1, 2 >> 1, -7 >> 1]

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -420,6 +420,8 @@ make_counters! {
     send_bmethod_ractor,
     send_bmethod_block_arg,
     send_optimized_block_arg,
+    send_pred_not_fixnum,
+    send_pred_underflow,
 
     invokesuper_defined_class_mismatch,
     invokesuper_forwarding,


### PR DESCRIPTION
This PR adds specialized codegen for `Integer#pred`. Since chunky-png uses `Integer#downto` a lot, https://github.com/ruby/ruby/pull/12074 made `Integer#pred` the most frequently called method in that benchmark.

```
Top-20 most frequent C calls (20.8% of C calls):
  3,355,140 (20.5%): Integer#pred
     16,171 ( 0.1%): Array#slice
      8,971 ( 0.1%): Enumerable#each_slice
      3,729 ( 0.0%): Integer#to_s
      3,600 ( 0.0%): String#*
...
```

Adding this specialization speeds up `chunky-png` a little.

```
before: ruby 3.4.0dev (2024-11-13T21:17:29Z master 30e1d6b5a8) +YJIT +PRISM [x86_64-linux]
after: ruby 3.4.0dev (2024-11-13T23:40:22Z yjit-pred 17c6d54fb2) +YJIT +PRISM [x86_64-linux]

----------  -----------  ----------  ----------  ----------  -------------  ------------
bench       before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
chunky-png  254.8        0.3         247.7       0.3         1.02           1.03
----------  -----------  ----------  ----------  ----------  -------------  ------------
```