### PR TITLE
Allow `Range#last(n)` for beginless ranges with Integer end

### DIFF
--- a/range.c
+++ b/range.c
@@ -1360,7 +1360,7 @@ rb_int_range_last(int argc, VALUE *argv, VALUE range)
 {
     static const VALUE ONE = INT2FIX(1);
 
-    VALUE b, e, len_1, len, nv, ary;
+    VALUE b, e, len_1, len = Qundef, nv, ary;
     int x;
     long n;
 
@@ -1368,21 +1368,26 @@ rb_int_range_last(int argc, VALUE *argv, VALUE range)
 
     b = RANGE_BEG(range);
     e = RANGE_END(range);
-    RUBY_ASSERT(RB_INTEGER_TYPE_P(b) && RB_INTEGER_TYPE_P(e));
+    RUBY_ASSERT((NIL_P(b) || RB_INTEGER_TYPE_P(b)) && RB_INTEGER_TYPE_P(e));
 
     x = EXCL(range);
 
-    len_1 = rb_int_minus(e, b);
-    if (x) {
-        e = rb_int_minus(e, ONE);
-        len = len_1;
-    }
-    else {
-        len = rb_int_plus(len_1, ONE);
+    if (!NIL_P(b)) {
+        len_1 = rb_int_minus(e, b);
+        if (x) {
+            len = len_1;
+        }
+        else {
+            len = rb_int_plus(len_1, ONE);
+        }
+
+        if (FIXNUM_ZERO_P(len) || rb_num_negative_p(len)) {
+            return rb_ary_new_capa(0);
+        }
     }
 
-    if (FIXNUM_ZERO_P(len) || rb_num_negative_p(len)) {
-        return rb_ary_new_capa(0);
+    if (x) {
+        e = rb_int_minus(e, ONE);
     }
 
     rb_scan_args(argc, argv, "1", &nv);
@@ -1392,7 +1397,7 @@ rb_int_range_last(int argc, VALUE *argv, VALUE range)
     }
 
     nv = LONG2NUM(n);
-    if (RTEST(rb_int_gt(nv, len))) {
+    if (len != Qundef && RTEST(rb_int_gt(nv, len))) {
         nv = len;
         n = NUM2LONG(nv);
     }
@@ -1455,7 +1460,7 @@ range_last(int argc, VALUE *argv, VALUE range)
 
     b = RANGE_BEG(range);
     e = RANGE_END(range);
-    if (RB_INTEGER_TYPE_P(b) && RB_INTEGER_TYPE_P(e) &&
+    if ((NIL_P(b) || RB_INTEGER_TYPE_P(b)) && RB_INTEGER_TYPE_P(e) &&
         RB_LIKELY(rb_method_basic_definition_p(rb_cRange, idEach))) {
         return rb_int_range_last(argc, argv, range);
     }

--- a/spec/ruby/core/range/last_spec.rb
+++ b/spec/ruby/core/range/last_spec.rb
@@ -56,4 +56,16 @@ describe "Range#last" do
   it "raises a RangeError when called on an endless range" do
     -> { eval("(1..)").last }.should raise_error(RangeError)
   end
+
+  ruby_version_is ""..."3.4" do
+    it "raises a TypeError when passed a Integer for beginless range" do
+      -> { (..5).last(3) }.should raise_error(TypeError)
+    end
+  end
+
+  ruby_version_is "3.4" do
+    it "returns the specified number of elements for beginless range with the Integer end" do
+      (..5).last(3).should == [3, 4, 5]
+    end
+  end
 end

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -856,6 +856,8 @@ class TestRange < Test::Unit::TestCase
     assert_raise(RangeError) { (0..nil).last(3) }
     assert_raise(RangeError) { (nil..0).first }
     assert_raise(RangeError) { (nil..0).first(3) }
+    assert_equal([-2,-1,0], (nil..0).last(3))
+    assert_equal([-3,-2,-1], (nil...0).last(3))
 
     assert_equal([0, 1, 2], (0..10).first(3.0))
     assert_equal([8, 9, 10], (0..10).last(3.0))


### PR DESCRIPTION
`Range#last(n)` raises an exception on beginless ranges.

```ruby
(..5).last(3) #=> can't iterate from NilClass (TypeError)
```

Since Ruby 3.3, `Range#reverse_each` for beginless ranges with an integer end has been allowed.

```ruby
(..5).reverse_each { p _1 } #=> 5, 4, 3, 2, 1, ...
```

Therefore, shouldn't `Range#last(n)` for such ranges also be acceptable?

```ruby
# before
(..5).last(3) => can't iterate from NilClass (TypeError)
# after
(..5).last(3) => [3, 4, 5]
```

If this is accepted, a similar change could be considered for `Range#max(n)` as well.
