### PR TITLE
Do not wait connection attempt delay without in progress fds

### DIFF
--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -568,8 +568,8 @@ module TestNetHTTP_version_1_1_methods
       conn.open_timeout = EnvUtil.apply_timeout_scale(0.1)
 
       th = Thread.new do
-        err = !windows? ? [Net::WriteTimeout, Net::OpenTimeout] : Net::ReadTimeout
-        assert_raise(*err) do
+        err = !windows? ? Net::WriteTimeout : Net::ReadTimeout
+        assert_raise(err) do
           assert_warning(/Content-Type did not set/) do
             conn.post('/', "a"*50_000_000)
           end
@@ -600,7 +600,7 @@ module TestNetHTTP_version_1_1_methods
       req.body_stream = StringIO.new(data)
 
       th = Thread.new do
-        assert_raise(Net::WriteTimeout, Net::OpenTimeout) { conn.request(req) }
+        assert_raise(Net::WriteTimeout) { conn.request(req) }
       end
       assert th.join(10)
     }


### PR DESCRIPTION
Reset Connection Attempt Delay when connection fails and there is no other socket connection in progress.
This is intended to resolve an issue that was temporarily worked around in Pull Request #12062.

`TCPServer::new` (used in tests such as `TestNetHTTP_v1_2_chunked#test_timeout_during_non_chunked_streamed_HTTP_session_write`) can only connect over either IPv6 or IPv4, depending on the environment.
Since HEv2 attempts to connect over IPv6 first, environments where IPv6 connections are unavailable return ECONNREFUSED immediately.
In such cases, the client should immediately retry the connection over IPv4.
However, HEv2 includes a specification for a "Connection Attempt Delay," where it waits 250ms after the previous connection attempt before starting the next one.
This delay causes Net::OpenTimeout (100ms) to be exceeded while waiting for the next connection attempt to start.

With this change, when a connection attempt fails, if there are sockets still attempting to connect and there are addresses yet to be tried, the Connection Attempt Delay will be resetted, allowing the next connection attempt to start immediately.

---

Additionally, the following minor fixes have been made:

- The `nfds` value used for select(2) is now reset with each wait.