### PR TITLE
Fix a stack-buffer-overflow bug

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -3102,7 +3102,7 @@ do_fast_fallback_getaddrinfo(void *ptr)
             const char notification = entry->family == AF_INET6 ?
             IPV6_HOSTNAME_RESOLVED : IPV4_HOSTNAME_RESOLVED;
 
-            if ((write(shared->notify, &notification, strlen(&notification))) < 0) {
+            if ((write(shared->notify, &notification, 1)) < 0) {
                 entry->err = errno;
                 entry->has_syserr = true;
             }


### PR DESCRIPTION
http://ci.rvm.jp/results/trunk_asan@ruby-sp1/5408428
```
==3159643==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x796cf8f09041 at pc 0x6539bbf68ded bp 0x796cfadffcf0 sp 0x796cfadff4b8
READ of size 2 at 0x796cf8f09041 thread T13
    #0 0x6539bbf68dec in strlen (/tmp/ruby/build/trunk_asan/ruby+0x18edec) (BuildId: cca267c7ae091060e1b82a6b4ed1aeaf00edebab)
```