### PR TITLE
YJIT: Specialize String#dup

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -212,6 +212,15 @@ assert_equal 'Sub', %q{
   call(Sub.new('o')).class
 }
 
+# String#dup with FL_EXIVAR
+assert_equal '["str", "ivar"]', %q{
+  def str_dup(str) = str.dup
+  str = "str"
+  str.instance_variable_set(:@ivar, "ivar")
+  str = str_dup(str)
+  [str, str.instance_variable_get(:@ivar)]
+}
+
 # test splat filling required and feeding rest
 assert_equal '[0, 1, 2, [3, 4]]', %q{
   public def lead_rest(a, b, *rest)

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -422,6 +422,7 @@ make_counters! {
     send_optimized_block_arg,
     send_pred_not_fixnum,
     send_pred_underflow,
+    send_str_dup_exivar,
 
     invokesuper_defined_class_mismatch,
     invokesuper_forwarding,


### PR DESCRIPTION
This PR skips pushing a frame for `String#dup` when a receiver is a `rb_cString` and doesn't have instance variables.

It speeds up `mail` by 0.5%.

```
before: ruby 3.4.0dev (2024-11-14T17:29:47Z master 4074c6b427) +YJIT +PRISM [x86_64-linux]
after: ruby 3.4.0dev (2024-11-14T21:35:54Z yjit-str-dup e4e526ed38) +YJIT +PRISM [x86_64-linux]

-----  -----------  ----------  ----------  ----------  -------------  ------------
bench  before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
mail   69.8         0.4         69.4        0.2         1.004          1.005
-----  -----------  ----------  ----------  ----------  -------------  ------------
```