### PR TITLE
Fix stack-use-after-return

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -3093,7 +3093,7 @@ do_fast_fallback_getaddrinfo(void *ptr)
     rb_nativethread_lock_lock(shared->lock);
     {
         entry->err = err;
-        if (*shared->cancelled) {
+        if (shared->cancelled) {
             if (entry->ai) {
                 freeaddrinfo(entry->ai);
                 entry->ai = NULL;

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -429,7 +429,8 @@ char *port_str(VALUE port, char *pbuf, size_t pbuflen, int *flags_ptr);
 struct fast_fallback_getaddrinfo_shared
 {
     int wait, notify, refcount, connection_attempt_fds_size;
-    int *connection_attempt_fds, *cancelled;
+    int cancelled;
+    int *connection_attempt_fds;
     char *node, *service;
     rb_nativethread_lock_t *lock;
 };


### PR DESCRIPTION
http://ci.rvm.jp/results/trunk_asan@ruby-sp1/5409001

```
=================================================================
==3263562==ERROR: AddressSanitizer: stack-use-after-return on address 0x735a8f190da8 at pc 0x735a6f58dabc bp 0x735a639ffd10 sp 0x735a639ffd08
READ of size 4 at 0x735a8f190da8 thread T211
=================================================================
```