### PR TITLE
Win32: Remove unreferenced COMDAT from object files

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -3583,7 +3583,7 @@ thread_alloc(VALUE klass)
     return TypedData_Make_Struct(klass, rb_thread_t, &thread_data_type, th);
 }
 
-inline void
+void
 rb_ec_set_vm_stack(rb_execution_context_t *ec, VALUE *stack, size_t size)
 {
     ec->vm_stack = stack;

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -163,6 +163,9 @@ OPTFLAGS = -O2b2xg-
 OPTFLAGS = -O2sy-
 !endif
 !endif
+!if $(MSC_VER) >= 1900
+OPTFLAGS = $(OPTFLAGS) -Zc:inline
+!endif
 !if !defined(incflags)
 incflags =
 !endif

--- a/win32/mkexports.rb
+++ b/win32/mkexports.rb
@@ -122,7 +122,6 @@ class Exports::Mswin < Exports
           elsif !l.sub!(/^(\S+) \([^@?\`\']*\)$/, '\1')
             next
           end
-          next if /\A_?ucrt_/ =~ l
         when /DLL/
           next unless l.sub!(/^\s*\d+\s+[[:xdigit:]]+\s+[[:xdigit:]]+\s+/, '')
         else


### PR DESCRIPTION
Windows 11 SDK Version 10.0.26100.0 introduced a new internal inline function in ucrt/corecrt_math.h.  Even it appears in object files and will be included in the DEF file, it will be removed from the DLL and result in a linker error.