### PR TITLE
Fix CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,6 +235,7 @@ lcov*.info
 # for `make test-bundler`
 /.rspec_status
 /tool/bundler/*.lock
+!tool/bundler/test_gems.rb.lock
 
 # /tool/
 /tool/config.guess

--- a/tool/bundler/test_gems.rb.lock
+++ b/tool/bundler/test_gems.rb.lock
@@ -1,0 +1,74 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.2.0)
+    builder (3.3.0)
+    compact_index (0.15.0)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    rack (3.1.8)
+    rack-protection (4.0.0)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
+    rake (13.2.1)
+    rb_sys (0.9.102)
+    ruby2_keywords (0.0.5)
+    rubygems-generate_index (1.1.3)
+      compact_index (~> 0.15.0)
+    sinatra (4.0.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.0.0)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    tilt (2.4.0)
+    webrick (1.8.2)
+
+PLATFORMS
+  java
+  ruby
+  universal-java
+  x64-mingw-ucrt
+  x86_64-darwin
+  x86_64-linux
+
+DEPENDENCIES
+  base64
+  builder (~> 3.2)
+  compact_index (~> 0.15.0)
+  rack (~> 3.0)
+  rack-test (~> 2.1)
+  rackup (~> 2.1)
+  rake (~> 13.1)
+  rb_sys
+  rubygems-generate_index (~> 1.1)
+  sinatra (~> 4.0)
+  webrick (~> 1.8)
+
+CHECKSUMS
+  base64 (0.2.0) sha256=0f25e9b21a02a0cc0cea8ef92b2041035d39350946e8789c562b2d1a3da01507
+  builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  compact_index (0.15.0) sha256=5c6c404afca8928a7d9f4dde9524f6e1610db17e675330803055db282da84a8b
+  mustermann (3.0.3) sha256=d1f8e9ba2ddaed47150ddf81f6a7ea046826b64c672fbc92d83bce6b70657e88
+  rack (3.1.8) sha256=d3fbcbca43dc2b43c9c6d7dfbac01667ae58643c42cea10013d0da970218a1b1
+  rack-protection (4.0.0) sha256=d0db6185caa46a8c0d134c2c6b4803f4f392a67b2984da311409cb505f67bbf6
+  rack-session (2.0.0) sha256=db04b2063e180369192a9046b4559af311990af38c6a93d4c600cee4eb6d4e81
+  rack-test (2.1.0) sha256=0c61fc61904049d691922ea4bb99e28004ed3f43aa5cfd495024cc345f125dfb
+  rackup (2.1.0) sha256=6ecb884a581990332e45ee17bdfdc14ccbee46c2f710ae1566019907869a6c4d
+  rake (13.2.1) sha256=46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d
+  rb_sys (0.9.102) sha256=6ed736cc0d0bc236327e233f349ba16913231051df1c886c471ed268ce0e623b
+  ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
+  rubygems-generate_index (1.1.3) sha256=3571424322666598e9586a906485e1543b617f87644913eaf137d986a3393f5c
+  sinatra (4.0.0) sha256=54f6687b1daf2cfda6cef3f5dc90f47a8d05563cae7753e77cb01f4d3615497d
+  tilt (2.4.0) sha256=df74f29a451daed26591a85e8e0cebb198892cb75b6573394303acda273fba4d
+  webrick (1.8.2) sha256=431746a349199546ff9dd272cae10849c865f938216e41c402a6489248f12f21
+
+BUNDLED WITH
+   2.6.0.dev

--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -147,6 +147,7 @@ module SyncDefaultGems
       %w[dev_gems test_gems rubocop_gems standard_gems].each do |gemfile|
         cp_r("#{upstream}/tool/bundler/#{gemfile}.rb", "tool/bundler")
       end
+      cp_r("#{upstream}/tool/bundler/test_gems.rb.lock", "tool/bundler")
       rm_rf Dir.glob("spec/bundler/support/artifice/{vcr_cassettes,used_cassettes.txt}")
       rm_rf Dir.glob("lib/{bundler,rubygems}/**/{COPYING,LICENSE,README}{,.{md,txt,rdoc}}")
     when "rdoc"


### PR DESCRIPTION
Bundler specs broke because of a change in Sinatra 4.1.0. In my opinion, a change in an external test dependency should not break ruby-core's CI.

This is how Bundler specs were run until
426434556f43e597da8ddfa33c659321971f1b83, but I'm not sure what the motivation for that commit was.

I'm working on adapting Bundler specs to sinatra changes but for now I wanted to propose this since it encourages a more stable CI both here and in rubygems/rubygems.