### PR TITLE
[Bug #20900] Warn deprecated constant when removing

### DIFF
--- a/spec/ruby/core/module/deprecate_constant_spec.rb
+++ b/spec/ruby/core/module/deprecate_constant_spec.rb
@@ -44,6 +44,15 @@ describe "Module#deprecate_constant" do
     end
   end
 
+  ruby_bug '#20900', ''...'3.4' do
+    describe "when removing the deprecated module" do
+      it "warns with a message" do
+        @module.deprecate_constant :PUBLIC1
+        -> { @module.module_eval {remove_const :PUBLIC1} }.should complain(/warning: constant .+::PUBLIC1 is deprecated/)
+      end
+    end
+  end
+
   it "accepts multiple symbols and strings as constant names" do
     @module.deprecate_constant "PUBLIC1", :PUBLIC2
 

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -2148,9 +2148,8 @@ class TestModule < Test::Unit::TestCase
       Warning[:deprecated] = false
       Class.new(c)::FOO
     end
-    assert_warn('') do
-      Warning[:deprecated] = false
-      c.class_eval "FOO"
+    assert_warn(/deprecated/) do
+      c.class_eval {remove_const "FOO"}
     end
   end
 

--- a/variable.c
+++ b/variable.c
@@ -3280,6 +3280,7 @@ rb_const_remove(VALUE mod, ID id)
         undefined_constant(mod, ID2SYM(id));
     }
 
+    rb_const_warn_if_deprecated(ce, mod, id);
     rb_clear_constant_cache_for_id(id);
 
     val = ce->value;


### PR DESCRIPTION
[[Bug #20900]](https://bugs.ruby-lang.org/issues/20900)