### PR TITLE
Fix test failure for Ruby 3.2

### DIFF
--- a/cygwin/GNUmakefile.in
+++ b/cygwin/GNUmakefile.in
@@ -2,7 +2,7 @@ gnumake = yes
 
 include Makefile
 
-MUNICODE_FLAG = $(if $(filter mingw%,$(target_os)),-municode)
+MUNICODE_FLAG := $(if $(filter mingw%,$(target_os)),-municode)
 override EXE_LDFLAGS += $(MUNICODE_FLAG)
 
 DLLWRAP = @DLLWRAP@ --target=$(target_os) --driver-name="$(CC)"

--- a/cygwin/GNUmakefile.in
+++ b/cygwin/GNUmakefile.in
@@ -2,7 +2,12 @@ gnumake = yes
 
 include Makefile
 
+ifeq ($(target_os),cygwin)
+MUNICODE_FLAG =
+else
 override EXE_LDFLAGS += -municode
+MUNICODE_FLAG = -municode
+endif
 
 DLLWRAP = @DLLWRAP@ --target=$(target_os) --driver-name="$(CC)"
 windres-cpp := $(CPP) -xc
@@ -65,7 +70,7 @@ $(PROGRAM): $(RUBY_INSTALL_NAME).res.$(OBJEXT)
 $(WPROGRAM): $(RUBYW_INSTALL_NAME).res.$(OBJEXT)
 	@rm -f $@
 	$(ECHO) linking $@
-	$(Q) $(PURIFY) $(CC) -municode -mwindows -e $(SYMBOL_PREFIX)mainCRTStartup $(LDFLAGS) $(XLDFLAGS) \
+	$(Q) $(PURIFY) $(CC) $(MUNICODE_FLAG) -mwindows -e $(SYMBOL_PREFIX)mainCRTStartup $(LDFLAGS) $(XLDFLAGS) \
 	  $(MAINOBJ) $(EXTOBJS) $(LIBRUBYARG) $(LIBS) -o $@
 $(STUBPROGRAM): $(RUBY_INSTALL_NAME).res.$(OBJEXT)
 

--- a/cygwin/GNUmakefile.in
+++ b/cygwin/GNUmakefile.in
@@ -2,6 +2,8 @@ gnumake = yes
 
 include Makefile
 
+override EXE_LDFLAGS += -municode
+
 DLLWRAP = @DLLWRAP@ --target=$(target_os) --driver-name="$(CC)"
 windres-cpp := $(CPP) -xc
 windres-cpp := --preprocessor=$(firstword $(windres-cpp)) \
@@ -63,7 +65,7 @@ $(PROGRAM): $(RUBY_INSTALL_NAME).res.$(OBJEXT)
 $(WPROGRAM): $(RUBYW_INSTALL_NAME).res.$(OBJEXT)
 	@rm -f $@
 	$(ECHO) linking $@
-	$(Q) $(PURIFY) $(CC) -mwindows -e $(SYMBOL_PREFIX)mainCRTStartup $(LDFLAGS) $(XLDFLAGS) \
+	$(Q) $(PURIFY) $(CC) -municode -mwindows -e $(SYMBOL_PREFIX)mainCRTStartup $(LDFLAGS) $(XLDFLAGS) \
 	  $(MAINOBJ) $(EXTOBJS) $(LIBRUBYARG) $(LIBS) -o $@
 $(STUBPROGRAM): $(RUBY_INSTALL_NAME).res.$(OBJEXT)
 

--- a/cygwin/GNUmakefile.in
+++ b/cygwin/GNUmakefile.in
@@ -2,12 +2,8 @@ gnumake = yes
 
 include Makefile
 
-ifeq ($(target_os),cygwin)
-MUNICODE_FLAG =
-else
-override EXE_LDFLAGS += -municode
-MUNICODE_FLAG = -municode
-endif
+MUNICODE_FLAG = $(if $(filter mingw%,$(target_os)),-municode)
+override EXE_LDFLAGS += $(MUNICODE_FLAG)
 
 DLLWRAP = @DLLWRAP@ --target=$(target_os) --driver-name="$(CC)"
 windres-cpp := $(CPP) -xc

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -1,5 +1,5 @@
 # gem-name version-to-bundle repository-url [optional-commit-hash-to-test-or-defaults-to-v-version]
-minitest        5.16.3  https://github.com/seattlerb/minitest
+minitest        5.25.1  https://github.com/seattlerb/minitest
 power_assert    2.0.3   https://github.com/ruby/power_assert
 rake            13.0.6  https://github.com/ruby/rake
 test-unit       3.5.7   https://github.com/test-unit/test-unit

--- a/main.c
+++ b/main.c
@@ -43,6 +43,12 @@ int rb_wasm_rt_start(int (main)(int argc, char **argv), int argc, char **argv);
 #define rb_main(argc, argv) rb_wasm_rt_start(rb_main, argc, argv)
 #endif
 
+#ifdef _WIN32
+#define main(argc, argv) w32_main(argc, argv)
+static int main(int argc, char **argv);
+int wmain(void) {return main(0, NULL);}
+#endif
+
 int
 main(int argc, char **argv)
 {
@@ -56,7 +62,3 @@ main(int argc, char **argv)
     ruby_sysinit(&argc, &argv);
     return rb_main(argc, argv);
 }
-
-#ifdef _WIN32
-int wmain(void) {return main(0, NULL);}
-#endif

--- a/main.c
+++ b/main.c
@@ -56,3 +56,7 @@ main(int argc, char **argv)
     ruby_sysinit(&argc, &argv);
     return rb_main(argc, argv);
 }
+
+#ifdef _WIN32
+int wmain(void) {return main(0, NULL);}
+#endif

--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -167,18 +167,16 @@ class TestNetHTTPS < Test::Unit::TestCase
   def test_session_reuse_but_expire
     # FIXME: The new_session_cb is known broken for clients in OpenSSL 1.1.0h.
     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 1.1.0h')
-    omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.2.')
-    omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.3.')
 
     http = Net::HTTP.new(HOST, config("port"))
     http.use_ssl = true
     http.cert_store = TEST_STORE
 
-    http.ssl_timeout = -1
+    http.ssl_timeout = 1
     http.start
     http.get("/")
     http.finish
-
+    sleep 1.25
     http.start
     http.get("/")
 

--- a/test/openssl/test_x509req.rb
+++ b/test/openssl/test_x509req.rb
@@ -39,11 +39,6 @@ class OpenSSL::TestX509Request < OpenSSL::TestCase
     assert_equal(0, req.version)
     req = OpenSSL::X509::Request.new(req.to_der)
     assert_equal(0, req.version)
-
-    req = issue_csr(1, @dn, @rsa1024, OpenSSL::Digest.new('SHA256'))
-    assert_equal(1, req.version)
-    req = OpenSSL::X509::Request.new(req.to_der)
-    assert_equal(1, req.version)
   end
 
   def test_subject
@@ -106,7 +101,7 @@ class OpenSSL::TestX509Request < OpenSSL::TestCase
     assert_equal(false, req.verify(@rsa2048))
     assert_equal(false, request_error_returns_false { req.verify(@dsa256) })
     assert_equal(false, request_error_returns_false { req.verify(@dsa512) })
-    req.version = 1
+    req.subject = OpenSSL::X509::Name.parse("/C=JP/CN=FooBarFooBar")
     assert_equal(false, req.verify(@rsa1024))
   rescue OpenSSL::X509::RequestError # RHEL 9 disables SHA1
   end

--- a/vm.c
+++ b/vm.c
@@ -3307,7 +3307,7 @@ thread_alloc(VALUE klass)
     return TypedData_Make_Struct(klass, rb_thread_t, &thread_data_type, th);
 }
 
-inline void
+void
 rb_ec_set_vm_stack(rb_execution_context_t *ec, VALUE *stack, size_t size)
 {
     ec->vm_stack = stack;

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -158,6 +158,9 @@ OPTFLAGS = -O2b2xg-
 OPTFLAGS = -O2sy-
 !endif
 !endif
+!if $(MSC_VER) >= 1900
+OPTFLAGS = $(OPTFLAGS) -Zc:inline
+!endif
 !if !defined(incflags)
 incflags =
 !endif

--- a/win32/winmain.c
+++ b/win32/winmain.c
@@ -1,10 +1,10 @@
 #include <windows.h>
 #include <stdio.h>
 
-extern int main(int, char**);
+extern int wmain(int, WCHAR**);
 
 int WINAPI
 WinMain(HINSTANCE current, HINSTANCE prev, LPSTR cmdline, int showcmd)
 {
-    return main(0, NULL);
+    return wmain(0, NULL);
 }


### PR DESCRIPTION
Fixed the followings:

* https://github.com/ruby/actions/actions/runs/11898853810/job/33156475298
* Resolve MinGW codepage issues
* Support latest version of VS2022
* Support OpenSSL 3.4+