### PR TITLE
Configure ruby/mmtk sync

### DIFF
--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -38,6 +38,7 @@ module SyncDefaultGems
     irb: 'ruby/irb',
     json: 'ruby/json',
     logger: 'ruby/logger',
+    mmtk: 'ruby/mmtk',
     open3: "ruby/open3",
     openssl: "ruby/openssl",
     optparse: "ruby/optparse",
@@ -404,6 +405,9 @@ module SyncDefaultGems
       cp_r("#{upstream}/lib/win32/registry.rb", "ext/win32/lib/win32")
       cp_r("#{upstream}/test/win32/test_registry.rb", "test/win32")
       cp_r("#{upstream}/win32-registry.gemspec", "ext/win32")
+    when "mmtk"
+      rm_rf("gc/mmtk")
+      cp_r("#{upstream}/gc/mmtk", "gc")
     else
       sync_lib gem, upstream
     end
@@ -417,6 +421,7 @@ module SyncDefaultGems
 
   def check_prerelease_version(gem)
     return if gem == "rubygems"
+    return if gem == "mmtk"
 
     gem = gem.downcase
 


### PR DESCRIPTION
I think that after discussing some proposed file layout changes with @peterzhu2118 these are the changes to the sync script that will be needed to sync `ruby/mmtk` into `ruby/ruby` as per https://bugs.ruby-lang.org/issues/20860

Discussed in the November dev meeting recorded here: https://github.com/ruby/dev-meeting-log/blob/master/2024/DevMeeting-2024-11-07.md#feature-20860-merge-optional-experimental-feature-mmtk-into-ruby-peterzhu2118