### PR TITLE
Suppress wmain warning for Ruby 3.1

### DIFF
--- a/main.c
+++ b/main.c
@@ -30,6 +30,12 @@
 # undef RUBY_DEBUG_ENV
 #endif
 
+#ifdef _WIN32
+#define main(argc, argv) w32_main(argc, argv)
+static int main(int argc, char **argv);
+int wmain(void) {return main(0, NULL);}
+#endif
+
 int
 main(int argc, char **argv)
 {
@@ -47,7 +53,3 @@ main(int argc, char **argv)
 	return ruby_run_node(ruby_options(argc, argv));
     }
 }
-
-#ifdef _WIN32
-int wmain(void) {return main(0, NULL);}
-#endif

--- a/win32/winmain.c
+++ b/win32/winmain.c
@@ -1,10 +1,10 @@
 #include <windows.h>
 #include <stdio.h>
 
-extern int main(int, char**);
+extern int wmain(int, WCHAR**);
 
 int WINAPI
 WinMain(HINSTANCE current, HINSTANCE prev, LPSTR cmdline, int showcmd)
 {
-    return main(0, NULL);
+    return wmain(0, NULL);
 }


### PR DESCRIPTION
Backport 8fe8021f5a5b48520f9c1095e7cfa1fd416b6dfd