### PR TITLE
Fix a bug in rb_include_module that stops nested inclusion into module subclasses

### DIFF
--- a/class.c
+++ b/class.c
@@ -1204,8 +1204,8 @@ rb_include_module(VALUE klass, VALUE module)
             iclass = iclass->next;
         }
 
-        int do_include = 1;
         while (iclass) {
+            int do_include = 1;
             VALUE check_class = iclass->klass;
             /* During lazy sweeping, iclass->klass could be a dead object that
              * has not yet been swept. */

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -784,6 +784,18 @@ class TestModule < Test::Unit::TestCase
     assert_equal([:m1, :m0, :m, :sc, :m1, :m0, :c], sc.new.m)
   end
 
+  def test_include_into_module_after_prepend_bug_20871
+    bar = Module.new{def bar; 'bar'; end}
+    foo = Module.new{def foo; 'foo'; end}
+    m = Module.new
+    c = Class.new{include m}
+    m.prepend bar
+    Class.new{include m}
+    m.include foo
+    assert_include c.ancestors, foo
+    assert_equal "foo", c.new.foo
+  end
+
   def test_protected_include_into_included_module
     m1 = Module.new do
       def other_foo(other)


### PR DESCRIPTION
This bug was present since the code was originally added by me in 3556a834a2847e52162d1d3302d4c64390df1694.

Fixes [Bug #20871]