### PR TITLE
Extend the timeout of fork-exit bootstraptest

### DIFF
--- a/bootstraptest/test_fork.rb
+++ b/bootstraptest/test_fork.rb
@@ -84,7 +84,7 @@ assert_equal 'ok', %q{
 
   10.times do
     pid = fork{ exit!(0) }
-    deadline = now + 1
+    deadline = now + 10
     until Process.waitpid(pid, Process::WNOHANG)
       if now > deadline
         Process.kill(:KILL, pid)


### PR DESCRIPTION
It often fails randomly.

http://ci.rvm.jp/results/trunk-yjit@ruby-sp2-noble-docker/5421564
```
 Fstderr output is not empty
   bootstraptest.test_fork.rb_78_287.rb:16:in 'block in <main>': failed (RuntimeError)
           from <internal:numeric>:257:in 'Integer#times'
           from bootstraptest.test_fork.rb_78_287.rb:10:in '<main>'
```

I'm not sure why the frequency of failure has suddenly increased, though.