### PR TITLE
[Bug #20903] `rb_econv_str_append` arguments expected to be String

### DIFF
--- a/ext/-test-/econv/append.c
+++ b/ext/-test-/econv/append.c
@@ -5,6 +5,8 @@ static VALUE
 econv_append(VALUE self, VALUE src, VALUE dst)
 {
     rb_econv_t *ec = DATA_PTR(self);
+    StringValue(src);
+    StringValue(dst);
     return rb_econv_str_append(ec, src, dst, 0);
 }
 


### PR DESCRIPTION
[[Bug #20903]](https://bugs.ruby-lang.org/issues/20903)
