### PR TITLE
Add a temporal debugging code

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -824,7 +824,14 @@ console_winsize(VALUE io)
 {
     rb_console_size_t ws;
     int fd = GetWriteFD(io);
+#if defined TIOCGWINSZ
+    // temporal debugging code
+    int ret = ioctl(fd, TIOCGWINSZ, &ws);
+    if (ret == -1) sys_fail(io);
+    if (ret != 0) rb_bug("ioctl(TIOCGWINSZ) returned %d", ret);
+#else
     if (!getwinsize(fd, &ws)) sys_fail(io);
+#endif
     return rb_assoc_new(INT2NUM(winsize_row(&ws)), INT2NUM(winsize_col(&ws)));
 }
 


### PR DESCRIPTION
... to check the return value of ioctl

http://ci.rvm.jp/results/trunk_asan@ruby-sp1/5423172
```
/tmp/ruby/src/trunk_asan/lib/reline/io/ansi.rb:192: [BUG] rb_sys_fail_str(<STDIN>) - errno == 0
```