### PR TITLE
Free parse result when run with -c

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -2566,7 +2566,10 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
     if (dump & DUMP_BIT(syntax)) {
         printf("Syntax OK\n");
         dump &= ~DUMP_BIT(syntax);
-        if (!dump) return Qtrue;
+        if (!dump) {
+            dispose_result();
+            return Qtrue;
+        }
     }
 
     if (dump & DUMP_BIT(parsetree)) {


### PR DESCRIPTION
We should free the parse result when run in `-c` "check syntax" mode.

This is a benign leak since we'll be exiting shortly after, but it avoids the leak being reported by valgrind or LSAN (and we were doing this in the other branches).

```
❯ ASAN_OPTIONS="detect_leaks=1" RUBY_FREE_AT_EXIT=1 ruby -ce ''
Syntax OK
-e: warning: Free at exit is experimental and may be unstable

=================================================================
==269255==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x606ed7e21a49 in calloc /home/runner/work/llvm-project/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:75:3
    #1 0x606ed82040f0 in pm_constant_pool_init /home/jhawthorn/src/ruby/prism/util/pm_constant_pool.c:181:20

Direct leak of 56 byte(s) in 1 object(s) allocated from:
----8<----
(7 more leaks)
```