### PR TITLE
Fix a build failure with musl

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -75,8 +75,7 @@
 #endif
 
 /* For ruby_annotate_mmap */
-#ifdef __linux__
-#include <linux/prctl.h>
+#ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
 #endif
 
@@ -4516,7 +4515,7 @@ Init_GC(void)
 void
 ruby_annotate_mmap(const void *addr, unsigned long size, const char *name)
 {
-#if defined(__linux__) && defined(PR_SET_VMA) && defined(PR_SET_VMA_ANON_NAME)
+#if defined(HAVE_SYS_PRCTL_H) && defined(PR_SET_VMA) && defined(PR_SET_VMA_ANON_NAME)
     // The name length cannot exceed 80 (including the '\0').
     RUBY_ASSERT(strlen(name) < 80);
     prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, (unsigned long)addr, size, name);

--- a/gc/default.c
+++ b/gc/default.c
@@ -5,8 +5,7 @@
 #ifndef _WIN32
 # include <sys/mman.h>
 # include <unistd.h>
-# ifdef __linux__
-#  include <linux/prctl.h>
+# ifdef HAVE_SYS_PRCTL_H
 #  include <sys/prctl.h>
 # endif
 #endif
@@ -1875,7 +1874,7 @@ heap_page_body_allocate(void)
         // `default.c` as a shared library, we will not have access to private
         // symbols, and we have to either call prctl directly or make our own
         // wrapper.
-#if defined(__linux__) && defined(PR_SET_VMA) && defined(PR_SET_VMA_ANON_NAME)
+#if defined(HAVE_SYS_PRCTL_H) && defined(PR_SET_VMA) && defined(PR_SET_VMA_ANON_NAME)
         prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, ptr, mmap_size, "Ruby:GC:default:heap_page_body_allocate");
         errno = 0;
 #endif


### PR DESCRIPTION
After https://github.com/ruby/ruby/pull/12119 was merged, attempting a build on musl/alpine fails with the following error:

```
compiling gc.c
In file included from gc.c:80:
/usr/include/sys/prctl.h:88:8: error: redefinition of 'struct prctl_mm_map'
   88 | struct prctl_mm_map {
      |        ^~~~~~~~~~~~
In file included from gc.c:79:
/usr/include/linux/prctl.h:134:8: note: originally defined here
  134 | struct prctl_mm_map {
      |        ^~~~~~~~~~~~
```

The first include is not needed and is what causes this issue. Two other places in ruby already exclusively use the sys import.

See https://github.com/seccomp/libseccomp/issues/19 for a similar problem.