### PR TITLE
Prevent memory leak

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -3047,7 +3047,6 @@ free_fast_fallback_getaddrinfo_entry(struct fast_fallback_getaddrinfo_entry **en
         freeaddrinfo((*entry)->ai);
         (*entry)->ai = NULL;
     }
-    free(*entry);
     *entry = NULL;
 }
 

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -138,6 +138,7 @@
 
 #include "internal.h"
 #include "internal/array.h"
+#include "internal/compilers.h"
 #include "internal/error.h"
 #include "internal/gc.h"
 #include "internal/io.h"
@@ -426,15 +427,6 @@ char *port_str(VALUE port, char *pbuf, size_t pbuflen, int *flags_ptr);
 #    define IPV4_HOSTNAME_RESOLVED '2'
 #    define SELECT_CANCELLED '3'
 
-struct fast_fallback_getaddrinfo_shared
-{
-    int wait, notify, refcount, connection_attempt_fds_size;
-    int cancelled;
-    int *connection_attempt_fds;
-    char *node, *service;
-    rb_nativethread_lock_t *lock;
-};
-
 struct fast_fallback_getaddrinfo_entry
 {
     int family, err, refcount;
@@ -444,6 +436,16 @@ struct fast_fallback_getaddrinfo_entry
     int has_syserr;
     long test_sleep_ms;
     int test_ecode;
+};
+
+struct fast_fallback_getaddrinfo_shared
+{
+    int wait, notify, refcount, connection_attempt_fds_size;
+    int cancelled;
+    int *connection_attempt_fds;
+    char *node, *service;
+    rb_nativethread_lock_t *lock;
+    struct fast_fallback_getaddrinfo_entry getaddrinfo_entries[FLEX_ARY_LEN];
 };
 
 int raddrinfo_pthread_create(pthread_t *th, void *(*start_routine) (void *), void *arg);


### PR DESCRIPTION
```
for (int i = 0; i < arg->family_size; i++) {
    arg->getaddrinfo_entries[i] = allocate_fast_fallback_getaddrinfo_entry();
    if (!(arg->getaddrinfo_entries[i])) rb_syserr_fail(errno, "calloc(3)");
```

If the allocation fails in the second interation, the memory allocated in the first iteration would be leaked.

This change prevents the memory leak by allocating the memory in advance.
(The struct name `fast_fallback_getaddrinfo_shared` might no longer be good.)