### PR TITLE
error.c: call `va_end` before jumping

### DIFF
--- a/error.c
+++ b/error.c
@@ -3632,12 +3632,13 @@ rb_vraise(VALUE exc, const char *fmt, va_list ap)
 }
 
 void
-rb_raise(VALUE exc, const char *fmt, ...)
+rb_raise(VALUE exc_class, const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    rb_vraise(exc, fmt, args);
+    VALUE exc = rb_exc_new3(exc_class, rb_vsprintf(fmt, args));
     va_end(args);
+    rb_exc_raise(exc);
 }
 
 NORETURN(static void raise_loaderror(VALUE path, VALUE mesg));


### PR DESCRIPTION
The man page is clear that every `va_start` call MUST be succeeded by the corresponding `va_end` call.

So `rb_raise` can't call `rb_exc_raise` before `va_end`, otherwise `va_end` is never called.

NB: I'm not sure how bad this really is, as I'm unfamiliar with the various `va_end` implementations. From reading online it seems this could cause memory leaks on some platforms, but I assume it's not the case on the most common ones.

