### PR TITLE
Fix vm_objtostring optimization for Symbol

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -2339,6 +2339,12 @@ check_cfunc(const rb_callable_method_entry_t *me, cfunc_type func)
 }
 
 static inline int
+check_method_basic_definition(const rb_callable_method_entry_t *me)
+{
+    return me && METHOD_ENTRY_BASIC(me);
+}
+
+static inline int
 vm_method_cfunc_is(const rb_iseq_t *iseq, CALL_DATA cd, VALUE recv, cfunc_type func)
 {
     VM_ASSERT(iseq != NULL);
@@ -6072,7 +6078,7 @@ vm_objtostring(const rb_iseq_t *iseq, VALUE recv, CALL_DATA cd)
 
     switch (type) {
       case T_SYMBOL:
-        if (check_cfunc(vm_cc_cme(cc), rb_sym_to_s)) {
+        if (check_method_basic_definition(vm_cc_cme(cc))) {
             // rb_sym_to_s() allocates a mutable string, but since we are only
             // going to use this string for interpolation, it's fine to use the
             // frozen string.


### PR DESCRIPTION
Previously in `vm_objtostring`, there was an optimization that tried to avoid allocating a string for a Symbol (when to_s has not been overridden). [After this change to `Symbol#to_s`](https://github.com/ruby/ruby/commit/51753ec7fa82fb5c3f7ef3c5766b0e84c47d3d21#diff-c47a66d0320b41f7dbc9b403686b34caad228642a4c2c73d99aa984a9ef81581R10), the optimization stopped working due to `check_cfunc` returning false. 

We try to fix this by adding `check_method_basic_definition` to check if `to_s` is overridden instead of `check_cfunc`. Based on our understanding that `METHOD_ENTRY_BASIC` indicates that the method should not have been overridden.


## Testing & Metrics

We [used this test to record the number of allocations](https://gist.github.com/jhawthorn/0c3844867e267949db39f90032827122) for `to_s`.

### Results

**Before (3.4 master (0f41cc442e1eace3c854f2e0d09e079f481a5dce)):**
Output: `2000001`
**After**: 
Output: `1000001`