### PR TITLE
Sync the main branch of `ruby/mmtk`

### DIFF
--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -38,7 +38,7 @@ module SyncDefaultGems
     irb: 'ruby/irb',
     json: 'ruby/json',
     logger: 'ruby/logger',
-    mmtk: 'ruby/mmtk',
+    mmtk: ['ruby/mmtk', "main"],
     open3: "ruby/open3",
     openssl: "ruby/openssl",
     optparse: "ruby/optparse",


### PR DESCRIPTION
The sync script defaults to `master` when analysing which commits to pick, but the default for new repos now is `main`.