### PR TITLE
Mark `fiber_entry` no-return

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -822,6 +822,7 @@ fiber_restore_thread(rb_thread_t *th, rb_fiber_t *fiber)
     VM_ASSERT(th->ec->fiber_ptr == fiber);
 }
 
+NORETURN(static COROUTINE fiber_entry(struct coroutine_context * from, struct coroutine_context * to));
 static COROUTINE
 fiber_entry(struct coroutine_context * from, struct coroutine_context * to)
 {


### PR DESCRIPTION
```
  /github/workspace/src/cont.c:827:1: warning: function 'fiber_entry' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
    827 | {
        | ^
```