### PR TITLE
Move `Kernel#with_yjit` to `Module#with_yjit`

### DIFF
--- a/kernel.rb
+++ b/kernel.rb
@@ -290,7 +290,9 @@ module Kernel
       Primitive.rb_f_integer(arg, base, exception)
     end
   end
+end
 
+class Module
   # Internal helper for built-in initializations to define methods only when YJIT is enabled.
   # This method is removed in yjit_hook.rb.
   private def with_yjit(&block) # :nodoc:

--- a/yjit_hook.rb
+++ b/yjit_hook.rb
@@ -4,6 +4,6 @@ if defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?
 end
 
 # Remove the helper defined in kernel.rb
-module Kernel
+class Module
   undef :with_yjit
 end


### PR DESCRIPTION
`Kernel#with_yjit` seems used only in `class`es, not the top level.
And `Kernel.with_yjit` is not used at all but still defined.