### PR TITLE
Improve test-bundled-gems

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1646,8 +1646,9 @@ test-bundled-gems-spec: $(TEST_RUNNABLE)-test-bundled-gems-spec
 yes-test-bundled-gems-spec: yes-test-spec-precheck $(PREPARE_BUNDLED_GEMS)
 	$(ACTIONS_GROUP)
 	$(gnumake_recursive)$(Q) \
-	BUNDLED_GEMS=$(BUNDLED_GEMS) $(RUNRUBY) -r./$(arch)-fake -r$(tooldir)/lib/_tmpdir \
-		$(srcdir)/spec/mspec/bin/mspec run -B $(srcdir)/spec/bundled_gems.mspec $(MSPECOPT) $(SPECOPTS)
+	$(RUNRUBY) -r./$(arch)-fake -r$(tooldir)/lib/_tmpdir \
+		$(srcdir)/spec/mspec/bin/mspec run --env BUNDLED_GEMS=$(BUNDLED_GEMS) -B $(srcdir)/spec/bundled_gems.mspec \
+		$(MSPECOPT) $(SPECOPTS)
 	$(ACTIONS_ENDGROUP)
 no-test-bundled-gems-spec:
 

--- a/common.mk
+++ b/common.mk
@@ -1646,7 +1646,7 @@ test-bundled-gems-spec: $(TEST_RUNNABLE)-test-bundled-gems-spec
 yes-test-bundled-gems-spec: yes-test-spec-precheck $(PREPARE_BUNDLED_GEMS)
 	$(ACTIONS_GROUP)
 	$(gnumake_recursive)$(Q) \
-	$(RUNRUBY) -r./$(arch)-fake -r$(tooldir)/lib/_tmpdir \
+	BUNDLED_GEMS=$(BUNDLED_GEMS) $(RUNRUBY) -r./$(arch)-fake -r$(tooldir)/lib/_tmpdir \
 		$(srcdir)/spec/mspec/bin/mspec run -B $(srcdir)/spec/bundled_gems.mspec $(MSPECOPT) $(SPECOPTS)
 	$(ACTIONS_ENDGROUP)
 no-test-bundled-gems-spec:

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -53,7 +53,7 @@ module Gem::BUNDLED_GEMS
   WARNED = {}                   # unfrozen
 
   conf = ::RbConfig::CONFIG
-  if ENV["TEST_BUNDLED_GEMS"]
+  if ENV["TEST_BUNDLED_GEMS_FAKE_RBCONFIG"]
     LIBDIR = (File.expand_path(File.join(__dir__, "..", "lib")) + "/").freeze
     rubyarchdir = $LOAD_PATH.find{|path| path.include?(".ext/common") }
     ARCHDIR = (File.expand_path(rubyarchdir) + "/").freeze

--- a/spec/bundled_gems.mspec
+++ b/spec/bundled_gems.mspec
@@ -2,7 +2,7 @@ load File.dirname(__FILE__) + '/default.mspec'
 
 class MSpecScript
   test_bundled_gems = get(:stdlibs).to_a & get(:bundled_gems).to_a
-  unless ENV["BUNDLED_GEMS"].nil?
+  unless ENV["BUNDLED_GEMS"].nil? || ENV["BUNDLED_GEMS"].empty?
     test_bundled_gems = ENV["BUNDLED_GEMS"].split(",").map do |gem|
       test_bundled_gems.find{|test_gem| test_gem.include?(gem) }
     end.compact

--- a/spec/bundled_gems.mspec
+++ b/spec/bundled_gems.mspec
@@ -2,7 +2,7 @@ load File.dirname(__FILE__) + '/default.mspec'
 
 class MSpecScript
   test_bundled_gems = get(:stdlibs).to_a & get(:bundled_gems).to_a
-  unless ENV["BUNDLED_GEMS"].empty?
+  unless ENV["BUNDLED_GEMS"].nil?
     test_bundled_gems = ENV["BUNDLED_GEMS"].split(",").map do |gem|
       test_bundled_gems.find{|test_gem| test_gem.include?(gem) }
     end.compact

--- a/spec/bundled_gems.mspec
+++ b/spec/bundled_gems.mspec
@@ -1,6 +1,13 @@
 load File.dirname(__FILE__) + '/default.mspec'
 
 class MSpecScript
-  set :library, get(:stdlibs).to_a & get(:bundled_gems).to_a
+  test_bundled_gems = get(:stdlibs).to_a & get(:bundled_gems).to_a
+  unless ENV["BUNDLED_GEMS"].empty?
+    test_bundled_gems = ENV["BUNDLED_GEMS"].split(",").map do |gem|
+      test_bundled_gems.find{|test_gem| test_gem.include?(gem) }
+    end.compact
+    exit if test_bundled_gems.empty?
+  end
+  set :library, test_bundled_gems
   set :files, get(:library)
 end

--- a/spec/bundled_gems_spec.rb
+++ b/spec/bundled_gems_spec.rb
@@ -20,7 +20,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     Gem.ruby = ENV["RUBY"] if ENV["RUBY"]
-    ENV["TEST_BUNDLED_GEMS"] = "true"
+    ENV["TEST_BUNDLED_GEMS_FAKE_RBCONFIG"] = "true"
 
     require_relative "bundler/support/rubygems_ext"
     Spec::Rubygems.test_setup

--- a/spec/mspec/lib/mspec/commands/mspec-run.rb
+++ b/spec/mspec/lib/mspec/commands/mspec-run.rb
@@ -32,6 +32,7 @@ class MSpecRun < MSpecScript
     options.chdir
     options.prefix
     options.configure { |f| load f }
+    options.env
     options.randomize
     options.repeat
     options.pretend

--- a/spec/mspec/lib/mspec/utils/options.rb
+++ b/spec/mspec/lib/mspec/utils/options.rb
@@ -204,6 +204,13 @@ class MSpecOptions
        "Load FILE containing configuration options", &block)
   end
 
+  def env
+    on("--env", "KEY=VALUE", "Set environment variable") do |env|
+      key, value = env.split('=', 2)
+      ENV[key] = value
+    end
+  end
+
   def targets
     on("-t", "--target", "TARGET",
        "Implementation to run the specs, where TARGET is:") do |t|
@@ -484,6 +491,7 @@ class MSpecOptions
 
   def all
     configure {}
+    env
     targets
     formatters
     filters

--- a/tool/fetch-bundled_gems.rb
+++ b/tool/fetch-bundled_gems.rb
@@ -6,7 +6,9 @@ BEGIN {
   color = Colorize.new
 
   if ARGV.first.start_with?("BUNDLED_GEMS=")
-    bundled_gems = ARGV.shift[13..-1].split(" ")
+    bundled_gems = ARGV.shift[13..-1]
+    sep = bundled_gems.include?(",") ? "," : " "
+    bundled_gems = bundled_gems.split(sep)
     bundled_gems = nil if bundled_gems.empty?
   end
 

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -11,6 +11,9 @@ github_actions = ENV["GITHUB_ACTIONS"] == "true"
 allowed_failures = ENV['TEST_BUNDLED_GEMS_ALLOW_FAILURES'] || ''
 allowed_failures = allowed_failures.split(',').reject(&:empty?)
 
+# make test-bundled-gems BUNDLED_GEMS=gem1,gem2,gem3
+bundled_gems = ARGV.first || ''
+
 colorize = Colorize.new
 rake = File.realpath("../../.bundle/bin/rake", __FILE__)
 gem_dir = File.realpath('../../gems', __FILE__)
@@ -21,7 +24,7 @@ failed = []
 File.foreach("#{gem_dir}/bundled_gems") do |line|
   next if /^\s*(?:#|$)/ =~ line
   gem = line.split.first
-  next unless ARGV.empty? or ARGV.any? {|pat| File.fnmatch?(pat, gem)}
+  next unless bundled_gems.delete_prefix("BUNDLED_GEMS=").split(",").include?(gem)
   next unless File.directory?("#{gem_dir}/src/#{gem}/test")
 
   test_command = "#{ruby} -C #{gem_dir}/src/#{gem} #{rake} test"

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -24,7 +24,7 @@ failed = []
 File.foreach("#{gem_dir}/bundled_gems") do |line|
   next if /^\s*(?:#|$)/ =~ line
   gem = line.split.first
-  next unless bundled_gems.delete_prefix("BUNDLED_GEMS=").split(",").include?(gem)
+  next unless bundled_gems.empty? || bundled_gems.split(",").include?(gem)
   next unless File.directory?("#{gem_dir}/src/#{gem}/test")
 
   test_command = "#{ruby} -C #{gem_dir}/src/#{gem} #{rake} test"


### PR DESCRIPTION
We can test only csv and drb with `make test-bundled-gems BUNDLED_GEMS=csv,drb`.