### PR TITLE
Optimize `rb_must_asciicompat`

### DIFF
--- a/string.c
+++ b/string.c
@@ -2691,10 +2691,17 @@ str_discard(VALUE str)
 void
 rb_must_asciicompat(VALUE str)
 {
-    rb_encoding *enc = rb_enc_get(str);
-    if (!enc) {
+    int encindex = rb_enc_get_index(str);
+
+    if (RB_UNLIKELY(encindex == -1)) {
         rb_raise(rb_eTypeError, "not encoding capable object");
     }
+
+    if (RB_LIKELY(str_encindex_fastpath(encindex))) {
+        return;
+    }
+
+    rb_encoding *enc = rb_enc_from_index(encindex);
     if (!rb_enc_asciicompat(enc)) {
         rb_raise(rb_eEncCompatError, "ASCII incompatible encoding: %s", rb_enc_name(enc));
     }


### PR DESCRIPTION
While profiling `strscan`, I noticed `rb_must_asciicompat` was quite slow, as more than 5% of the benchmark was spent in it: https://share.firefox.dev/49bOcTn

By checking for the common 3 ASCII compatible encoding index first, we can skip a lot of expensive operations in the happy path.