### PR TITLE
Ensure to close pipes when `TCPSocket.new` finishes processing

### DIFF
--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -440,7 +440,7 @@ struct fast_fallback_getaddrinfo_entry
 
 struct fast_fallback_getaddrinfo_shared
 {
-    int wait, notify, refcount, connection_attempt_fds_size;
+    int notify, refcount, connection_attempt_fds_size;
     int cancelled;
     int *connection_attempt_fds;
     char *node, *service;


### PR DESCRIPTION
`TCPSocket.new` with HEv2 uses three threads.
The last of these threads to exit closed pipes.
However, if pipes were open at the end of the main thread, they would leak. This change avoids this by closing pipes at the end of the main thread.
