### PR TITLE
Fix global-buffer-overflow when outputting C backtrace

### DIFF
--- a/addr2line.c
+++ b/addr2line.c
@@ -2632,7 +2632,7 @@ rb_dump_backtrace_with_lines(int num_traces, void **traces, FILE *errout)
 	    memcpy(main_path, binary_filename, len+1);
 	    append_obj(&obj);
 	    obj->path = main_path;
-	    addr = fill_lines(num_traces, traces, 1, &obj, lines, -1, errout);
+	    addr = fill_lines(num_traces, traces, 1, &obj, lines, 0, errout);
 	    if (addr != (uintptr_t)-1) {
 		dladdr_fbases[0] = (void *)addr;
 	    }


### PR DESCRIPTION
fill_lines is passed -1 for offset, which causes it to read the -1 index of traces. This is not valid memory as -1 is reading before the trace global variable in rb_print_backtrace. This code comes from commit 99d1f5f88b9b6de3124e31019902f91e030d334f, where there used to be special handling for the -1 index.

We can see this error in ASAN:

    ==71037==ERROR: AddressSanitizer: global-buffer-overflow on address 0x00010157abf8 at pc 0x00010116f3b8 bp 0x00016f92c3b0 sp 0x00016f92c3a8
    READ of size 8 at 0x00010157abf8 thread T0
        #0 0x10116f3b4 in debug_info_read addr2line.c:1945
        #1 0x10116cc90 in fill_lines addr2line.c:2497
        #2 0x101169dbc in rb_dump_backtrace_with_lines addr2line.c:2635
        #3 0x100e56788 in rb_print_backtrace vm_dump.c:825
        #4 0x100e56db4 in rb_vm_bugreport vm_dump.c:1155
        #5 0x100734dc4 in rb_bug_without_die error.c:1085
        #6 0x100734ae4 in rb_bug error.c:109