### PR TITLE
[Bug #20915] Fix segfault with `TracePoint#parameters` and aliased C method

### DIFF
--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -94,6 +94,22 @@ class TestSetTraceFunc < Test::Unit::TestCase
     assert_equal([[:req]], parameters)
   end
 
+  def test_c_call_aliased_method
+    # [Bug #20915]
+    klass = Class.new do
+      alias_method :new_method, :method
+    end
+
+    instance = klass.new
+    parameters = nil
+
+    TracePoint.new(:c_call) do |tp|
+      parameters = tp.parameters
+    end.enable { instance.new_method(:to_s) }
+
+    assert_equal([[:req]], parameters)
+  end
+
   def test_call
     events = []
     name = "#{self.class}\##{__method__}"

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -937,6 +937,9 @@ rb_tracearg_parameters(rb_trace_arg_t *trace_arg)
             const rb_method_entry_t *me;
             VALUE iclass = Qnil;
             me = rb_method_entry_without_refinements(trace_arg->klass, trace_arg->called_id, &iclass);
+            if (!me) {
+                me = rb_method_entry_without_refinements(trace_arg->klass, trace_arg->id, &iclass);
+            }
             return rb_unnamed_parameters(rb_method_entry_arity(me));
         }
         break;


### PR DESCRIPTION
See https://bugs.ruby-lang.org/issues/20915