### PR TITLE
Update test-unit 3.6.4

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -9,7 +9,7 @@
 minitest            5.25.2  https://github.com/minitest/minitest
 power_assert        2.0.4   https://github.com/ruby/power_assert
 rake                13.2.1  https://github.com/ruby/rake
-test-unit           3.6.3   https://github.com/test-unit/test-unit
+test-unit           3.6.4   https://github.com/test-unit/test-unit
 rexml               3.3.9   https://github.com/ruby/rexml
 rss                 0.3.1   https://github.com/ruby/rss
 net-ftp             0.3.8   https://github.com/ruby/net-ftp

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -9,7 +9,7 @@
 minitest            5.25.2  https://github.com/minitest/minitest
 power_assert        2.0.4   https://github.com/ruby/power_assert
 rake                13.2.1  https://github.com/ruby/rake
-test-unit           3.6.2   https://github.com/test-unit/test-unit
+test-unit           3.6.3   https://github.com/test-unit/test-unit
 rexml               3.3.9   https://github.com/ruby/rexml
 rss                 0.3.1   https://github.com/ruby/rss
 net-ftp             0.3.8   https://github.com/ruby/net-ftp


### PR DESCRIPTION
It failed with the following error:

```
Failure: test_basic_object_inspection(Test::Unit::TestAssertions::TestAssertEqual::TestSystemMessage):
  Should have the correct message.
  <"<inspected> expected but was\n<inspected>."> expected but was
  <"<#<Test::Unit::Assertions::AssertionMessage::Inspector:0x000000011f30eb28 ...>> expected but was\n<#<Test::Unit::Assertions::AssertionMessage::Inspector:0x000000011f30e6c8 ...>>.\n\ndiff:\n- #<Test::Unit::Assertions::AssertionMessage::Inspector:0x000000011f30df98 ...>\n?                                                                      ^^^\n+ #<Test::Unit::Assertions::AssertionMessage::Inspector:0x000000011f30dc00 ...>\n?                                                                      ^^^">
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/test-unit/test/test-assertions.rb:19:in 'Test::Unit::AssertionCheckable#check'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/test-unit/test/test-assertions.rb:58:in 'Test::Unit::AssertionCheckable#check_assertions'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/test-unit/test/test-assertions.rb:94:in 'Test::Unit::AssertionCheckable#check_fail'
/Users/hsbt/Documents/github.com/ruby/ruby/gems/src/test-unit/test/test-assertions.rb:335:in 'Test::Unit::TestAssertions::TestAssertEqual::TestSystemMessage#test_basic_object_inspection'
     332: <inspected> expected but was
     333: <inspected>.
     334: EOM
  => 335:             check_fail(message) do
     336:               assert_equal(object1, object2)
     337:             end
     338:           end
```

That is reproduced with `make test-bundled-gems BUNDLED_GEMS=test-unit` in ruby/ruby repo.

@kou I'm not sure why inspect result is different. Can you look this?