### PR TITLE
Avoid uninitialized variable access

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -10474,8 +10474,8 @@ compile_shareable_literal_constant(rb_iseq_t *iseq, LINK_ANCHOR *ret, enum rb_pa
         INIT_ANCHOR(anchor);
         lit = rb_hash_new();
         for (NODE *n = RNODE_HASH(node)->nd_head; n; n = RNODE_LIST(RNODE_LIST(n)->nd_next)->nd_next) {
-            VALUE key_val;
-            VALUE value_val;
+            VALUE key_val = Qnil;
+            VALUE value_val = Qnil;
             int shareable_literal_p2;
             NODE *key = RNODE_LIST(n)->nd_head;
             NODE *val = RNODE_LIST(RNODE_LIST(n)->nd_next)->nd_head;


### PR DESCRIPTION
With parse.y, the following pattern caused an access to an uninitialized variable `key_val`.

```
C = { **{ a: 1 } }
```

Just for the case, `value_val` is also initialized.

Coverity Scan found this issue.