### PR TITLE
Avoid accessing to a local variable that is out of scope

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -8569,6 +8569,8 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
       case PM_CONSTANT_PATH_NODE: {
         // Foo::Bar
         // ^^^^^^^^
+        DECL_ANCHOR(prefix);
+        DECL_ANCHOR(body);
         VALUE parts;
 
         if (ISEQ_COMPILE_DATA(iseq)->option->inline_const_cache && ((parts = pm_constant_path_parts(node, scope_node)) != Qnil)) {
@@ -8576,10 +8578,7 @@ pm_compile_node(rb_iseq_t *iseq, const pm_node_t *node, LINK_ANCHOR *const ret, 
             PUSH_INSN1(ret, location, opt_getconstant_path, parts);
         }
         else {
-            DECL_ANCHOR(prefix);
             INIT_ANCHOR(prefix);
-
-            DECL_ANCHOR(body);
             INIT_ANCHOR(body);
 
             pm_compile_constant_path(iseq, node, prefix, body, popped, scope_node);

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -958,6 +958,7 @@ static void
 pm_compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const pm_node_t *cond, LABEL *then_label, LABEL *else_label, bool popped, pm_scope_node_t *scope_node)
 {
     const pm_node_location_t location = PM_NODE_START_LOCATION(scope_node->parser, cond);
+    DECL_ANCHOR(cond_seq);
 
 again:
     switch (PM_NODE_TYPE(cond)) {
@@ -999,7 +1000,6 @@ again:
         break;
       }
       default: {
-        DECL_ANCHOR(cond_seq);
         INIT_ANCHOR(cond_seq);
         pm_compile_node(iseq, cond, cond_seq, false, scope_node);
 


### PR DESCRIPTION
`PUSH_SEQ(ret, cond_seq)` stores to `ret` a pointer to `cond_seq`. After `cond_seq` is out of scope, `PUSH_INSNL(ret, ...)` attempts to dereference of the pointer.

This change moves `DECL_ANCHOR(cond_seq)` to the toplevel.

Coverity Scan found this issue.