### PR TITLE
Fix a possible leak of a file descriptor

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -10900,6 +10900,7 @@ pm_read_file(pm_string_t *string, const char *filepath)
 
     source = mmap(NULL, size, PROT_READ, MAP_PRIVATE, fd, 0);
     if (source == MAP_FAILED) {
+        close(fd);
         return PM_STRING_INIT_ERROR_GENERIC;
     }
 


### PR DESCRIPTION
The same issue as https://github.com/ruby/prism/pull/3246

Coverity Scan found this issue.