### PR TITLE
Assert that non-empty LINK_ANCHOR does not loop

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -1290,9 +1290,14 @@ static void
 APPEND_LIST(ISEQ_ARG_DECLARE LINK_ANCHOR *const anc1, LINK_ANCHOR *const anc2)
 {
     if (anc2->anchor.next) {
+        /* LINK_ANCHOR must not loop */
+        RUBY_ASSERT(anc2->last != &anc2->anchor);
         anc1->last->next = anc2->anchor.next;
         anc2->anchor.next->prev = anc1->last;
         anc1->last = anc2->last;
+    }
+    else {
+        RUBY_ASSERT(anc2->last == &anc2->anchor);
     }
     verify_list("append", anc1);
 }


### PR DESCRIPTION
After any `LINK_ELEMENT` sequence is added, `LINK_ANCHOR` must not loop.