### PR TITLE
[DOC] typo fix in NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,7 +76,7 @@ Note: We're only listing outstanding class updates.
     * `Ractor.main?` is added. [[Feature #20627]]
 
     * `Ractor.[key]` and Ractor.[val]=` is added to access the ractor local storage
-      of the current Racotr. [[Feature #20715]]
+      of the current Ractor. [[Feature #20715]]
 
 * Range
 


### PR DESCRIPTION
follow up: https://github.com/ruby/ruby/pull/12196/files#r1861730753