### PR TITLE
Avoid illegal pointer

### DIFF
--- a/random.c
+++ b/random.c
@@ -895,7 +895,7 @@ rand_mt_load(VALUE obj, VALUE dump)
         sizeof(*mt->state), 0,
         INTEGER_PACK_LSWORD_FIRST|INTEGER_PACK_NATIVE_BYTE_ORDER);
     x = NUM2ULONG(left);
-    if (x > numberof(mt->state)) {
+    if (x > numberof(mt->state) || x == 0) {
         rb_raise(rb_eArgError, "wrong value");
     }
     mt->left = (unsigned int)x;

--- a/test/ruby/test_rand.rb
+++ b/test/ruby/test_rand.rb
@@ -434,4 +434,9 @@ class TestRand < Test::Unit::TestCase
     # probability of failure <= 1/256**8
     assert_operator(size.fdiv(n), :>, 15)
   end
+
+  def test_broken_marshal
+    assert_raise(ArgumentError) { Marshal.load("\x04\bU:\vRandom" + Marshal.dump([1,0,1])[2..]) }
+    assert_raise(ArgumentError) { Marshal.load("\x04\bU:\vRandom" + Marshal.dump([1,-1,1])[2..]) }
+  end
 end


### PR DESCRIPTION
When loading a crafted marshal data of Random, a pointer to an illegal address was created. I don't think there is any harm since the data is normalized before access, but just to be safe, I add a check to make it an error.