### PR TITLE
Avoid file descriptor leak

### DIFF
--- a/process.c
+++ b/process.c
@@ -3366,6 +3366,7 @@ run_exec_dup2(VALUE ary, VALUE tmpbuf, struct rb_execarg *sargp, char *errmsg, s
             //   in #assert_close_on_exec because the FD_CLOEXEC is not dup'd by default
             if (fd_get_cloexec(pairs[i].oldfd, errmsg, errmsg_buflen)) {
                 if (fd_set_cloexec(extra_fd, errmsg, errmsg_buflen)) {
+                    close(extra_fd);
                     goto fail;
                 }
             }


### PR DESCRIPTION
`extra_fd` was leaked if `fd_set_cloexec` fails -- I can't think of any chance of that happening here, but just in case.

Coverity Scan found this issue.