### PR TITLE
YJIT: Add missing prepare before calling rb_str_dup

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -6123,7 +6123,7 @@ fn jit_rb_str_to_s(
 }
 
 fn jit_rb_str_dup(
-    _jit: &mut JITState,
+    jit: &mut JITState,
     asm: &mut Assembler,
     _ci: *const rb_callinfo,
     _cme: *const rb_callable_method_entry_t,
@@ -6136,6 +6136,8 @@ fn jit_rb_str_dup(
         return false;
     }
     asm_comment!(asm, "String#dup");
+
+    jit_prepare_call_with_gc(jit, asm);
 
     // Check !FL_ANY_RAW(str, FL_EXIVAR), which is part of BARE_STRING_P.
     let recv_opnd = asm.stack_pop(1);


### PR DESCRIPTION
With the specialization of `rb_str_dup` introduced in #12090 we need to GC prepare otherwise when object tracing is enabled we crash due to cfp->pc being stale.

``` ruby
require "objspace"
ObjectSpace.trace_object_allocations_start

def foo(str)
  str.dup
end

1000.times { Object.new; foo("") }
```

```
❯ ./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --yjit ./test.rb
vm_backtrace.c:60: Assertion Failed: calc_pos:n >= 0
ruby 3.4.0dev (2024-11-26T22:04:26Z master 092a48de7e) +YJIT dev +PRISM [x86_64-linux]

-- Control frame information -----------------------------------------------
vm_backtrace.c:60: Assertion Failed: calc_pos:n >= 0
ruby 3.4.0dev (2024-11-26T22:04:26Z master 092a48de7e) +YJIT dev +PRISM [x86_64-linux]

Crashed while printing bug report
```