### PR TITLE
Remove document file needless for ruby core

### DIFF
--- a/doc/time.rb
+++ b/doc/time.rb
@@ -1,3 +1,0 @@
-# Built-in class
-class Time
-end


### PR DESCRIPTION
This reverts commit 743a31d639d4c96827b1b17f59c829c1ec31abc3, "[ruby/date] [DOC] Make document coverage 100%".  This file is only for rdoc coverage in the date gem, and useless when the built-in Time is documented.