### PR TITLE
Remove a useless check

### DIFF
--- a/node.c
+++ b/node.c
@@ -225,7 +225,7 @@ free_ast_value(rb_ast_t *ast, void *ctx, NODE *node)
 static void
 rb_node_buffer_free(rb_ast_t *ast, node_buffer_t *nb)
 {
-    if (nb && nb->tokens) {
+    if (nb->tokens) {
         parser_tokens_free(ast, nb->tokens);
     }
     iterate_node_values(ast, &nb->buffer_list, free_ast_value, NULL);


### PR DESCRIPTION
Here `nb` should never be NULL. If it were, the following `nb->buffer_list` would be strange.

A follow-up to ddd8da4b6ba3dfcca21ca710e7cef2fa3b9632d7