### PR TITLE
Do not depend on the evaluation order of C arguments

### DIFF
--- a/ext/fiddle/pointer.c
+++ b/ext/fiddle/pointer.c
@@ -827,7 +827,8 @@ rb_fiddle_ptr_read_mem(VALUE klass, VALUE address, VALUE len)
 static VALUE
 rb_fiddle_ptr_write_mem(VALUE klass, VALUE addr, VALUE str)
 {
-    memcpy(NUM2PTR(addr), StringValuePtr(str), RSTRING_LEN(str));
+    const char *ptr = StringValuePtr(str);
+    memcpy(NUM2PTR(addr), ptr, RSTRING_LEN(str));
     return str;
 }
 


### PR DESCRIPTION
The evaluation order of C arguments is unspecified. `RSTRING_LEN(str)` would fails if the conversion to a String by `StringValuePtr` is not done yet.

Coverity Scan found this issue.