### PR TITLE
Add Shared GC builds to CI

### DIFF
--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -1,0 +1,204 @@
+name: ModGC
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - '**/man/*'
+      - '**.md'
+      - '**.rdoc'
+      - '**/.document'
+      - '.*.yml'
+  pull_request:
+    # Do not use paths-ignore for required status checks
+    # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }} / ${{ startsWith(github.event_name, 'pull') && github.ref_name || github.sha }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull') }}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    strategy:
+      matrix:
+        gc:
+          - name: default
+          - name: mmtk
+            mmtk_plan: MarkSweep
+            mmtk_build: release
+        os: [macos-latest, ubuntu-latest]
+        include:
+          - test_task: check
+      fail-fast: false
+
+    env:
+      GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
+      RUBY_DEBUG: ci
+
+    runs-on: ${{ matrix.os }}
+
+    if: >-
+      ${{!(false
+      || contains(github.event.head_commit.message, '[DOC]')
+      || contains(github.event.head_commit.message, 'Document')
+      || contains(github.event.pull_request.title, '[DOC]')
+      || contains(github.event.pull_request.title, 'Document')
+      || contains(github.event.pull_request.labels.*.name, 'Documentation')
+      || (github.event_name == 'push' && github.event.pull_request.user.login == 'dependabot[bot]')
+      )}}
+
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: /.github
+
+      - name: Install libraries (macOS)
+        uses: ./.github/actions/setup/macos
+        if: ${{ contains(matrix.os, 'macos') }}
+
+      - name: Install libraries (Ubuntu)
+        uses: ./.github/actions/setup/ubuntu
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+
+      - uses: ruby/setup-ruby@a6e6f86333f0a2523ece813039b8b4be04560854 # v1.190.0
+        with:
+          ruby-version: '3.0'
+          bundler: none
+        if: ${{ contains(matrix.os, 'ubuntu') }}
+
+      - uses: ./.github/actions/setup/directories
+        with:
+          srcdir: src
+          builddir: build
+          makeup: true
+          clean: true
+          dummy-files: false
+          # Set fetch-depth: 10 so that Launchable can receive commits information.
+          fetch-depth: 10
+
+      - name: make sure that kern.coredump=1
+        run: |
+          sysctl -n kern.coredump
+          sudo sysctl -w kern.coredump=1
+          sudo chmod -R +rwx /cores/
+        if: ${{ contains(matrix.os, 'macos') }}
+
+      - name: Delete unused SDKs
+        # To free up disk space to not run out during the run
+        run: |
+          sudo rm -rf ~/.dotnet
+          sudo rm -rf /Library/Android
+          sudo rm -rf /Library/Developer/CoreSimulator
+        continue-on-error: true
+        if: ${{ contains(matrix.os, 'macos') }}
+
+      - name: Setup Ruby GC Directory
+        run: |
+          if [ "${{ contains(matrix.os, 'macos') }}" == "true" ]; then
+            echo "MODULAR_GC_DIR=/Users/runner/ruby_gc" >> $GITHUB_ENV
+          else
+            echo "MODULAR_GC_DIR=/home/runner/ruby_gc" >> $GITHUB_ENV
+          fi
+
+      - name: Run configure
+        env:
+          arch: ${{ matrix.arch }}
+        run: >-
+          $SETARCH ../src/configure -C --disable-install-doc --with-modular-gc=${{ env.MODULAR_GC_DIR }}
+          ${arch:+--target=$arch-$OSTYPE --host=$arch-$OSTYPE}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Set MMTk environment variables
+        run: |
+          if [[ ${{ matrix.gc.mmtk_build }} == debug ]]; then
+            echo 'RUST_LOG=' >> $GITHUB_ENV
+            # Debug builds run much slower so we should increase the timeout
+            echo 'RUBY_TEST_TIMEOUT_SCALE=10' >> $GITHUB_ENV
+            # SYNTAX_SUGGEST_TIMEOUT defaults to 1 second
+            echo 'SYNTAX_SUGGEST_TIMEOUT=60' >> $GITHUB_ENV
+          fi
+          echo 'MMTK_PLAN=${{ matrix.gc.mmtk_plan }}' >> $GITHUB_ENV
+          echo 'EXCLUDES=../src/test/.excludes-mmtk' >> $GITHUB_ENV
+          echo 'MSPECOPT=-B../src/spec/mmtk.mspec' >> $GITHUB_ENV
+        if: ${{ matrix.gc.name == 'mmtk' }}
+
+      - run: $SETARCH make
+
+      - name: Build Modular  GC
+        run: |
+          echo "RUBY_GC_LIBRARY=${{ matrix.gc.name }}" >> $GITHUB_ENV
+          make modular-gc MODULAR_GC=${{ matrix.gc.name }} MMTK_BUILD=${{ matrix.gc.mmtk_build }}
+          make distclean-modular-gc MODULAR_GC=${{ matrix.gc.name }}
+
+      - run: |
+          $SETARCH make golf
+          case "${{ matrix.configure }}" in
+          *'--enable-shared'*)
+            $SETARCH make runnable
+            ./bin/goruby -veh
+            ;;
+          *)
+            ./goruby -veh
+            ;;
+          esac
+
+      - name: Set test options for skipped tests
+        run: |
+          set -x
+          TESTS="$(echo "${{ matrix.skipped_tests }}" | sed 's| |$$/ -n!/|g;s|^|-n!/|;s|$|$$/|')"
+          echo "TESTS=${TESTS}" >> $GITHUB_ENV
+        if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
+
+      - name: Set up Launchable
+        uses: ./.github/actions/launchable/setup
+        with:
+          os: ${{ matrix.os || 'ubuntu-22.04' }}
+          test-opts: ${{ matrix.configure }}
+          launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
+          builddir: build
+          srcdir: src
+        continue-on-error: true
+
+      - name: make ${{ matrix.test_task }}
+        run: >-
+          $SETARCH make -s ${{ matrix.test_task }}
+          ${TESTS:+TESTS="$TESTS"}
+          ${{ !contains(matrix.test_task, 'bundle') && 'RUBYOPT=-w' || '' }}
+        timeout-minutes: ${{ matrix.gc.timeout || 40 }}
+        env:
+          RUBY_TESTOPTS: '-q --tty=no'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof'
+          PRECHECK_BUNDLED_GEMS: 'no'
+
+      - name: make skipped tests
+        run: |
+          $SETARCH make -s test-all TESTS="${TESTS//-n!\//-n/}"
+        env:
+          GNUMAKEFLAGS: ''
+          RUBY_TESTOPTS: '-v --tty=no'
+        if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
+        continue-on-error: ${{ matrix.continue-on-skipped_tests || false }}
+
+      - uses: ./.github/actions/slack
+        with:
+          label: ${{ matrix.test_task }} ${{ matrix.configure }}${{ matrix.arch }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
+        if: ${{ failure() }}
+
+  result:
+    if: ${{ always() }}
+    name: ${{ github.workflow }} result
+    runs-on: ubuntu-latest
+    needs: [check]
+    steps:
+      - run: exit 1
+        working-directory:
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+
+defaults:
+  run:
+    working-directory: build

--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -124,6 +124,7 @@ jobs:
           echo 'MMTK_PLAN=${{ matrix.gc.mmtk_plan }}' >> $GITHUB_ENV
           echo 'EXCLUDES=../src/test/.excludes-mmtk' >> $GITHUB_ENV
           echo 'MSPECOPT=-B../src/spec/mmtk.mspec' >> $GITHUB_ENV
+          echo 'GITHUB_WORKFLOW=ModGC' >> $GITHUB_ENV
         if: ${{ matrix.gc.name == 'mmtk' }}
 
       - run: $SETARCH make

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -33,9 +33,6 @@ jobs:
             configure: '--disable-yjit'
           - test_task: check
             configure: '--enable-shared --enable-load-relative'
-          - test_task: check
-            modular_gc: true
-            configure: '--with-modular-gc=/home/runner/ruby_gc'
           - test_task: test-bundler-parallel
             timeout: 50
           - test_task: test-bundled-gems
@@ -98,13 +95,6 @@ jobs:
         if: ${{ matrix.test_task == 'test-bundled-gems' }}
 
       - run: $SETARCH make
-
-      - name: Build modular GC
-        run: |
-          echo "RUBY_GC_LIBRARY=default" >> $GITHUB_ENV
-          make modular-gc MODULAR_GC=default
-          make distclean-modular-gc MODULAR_GC=default
-        if: ${{ matrix.modular_gc }}
 
       - run: |
           $SETARCH make golf

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -215,7 +215,8 @@ assert_equal '[:a, :b, :c, :d, :e, :f, :g]', %q{
 ###
 # Ractor still has several memory corruption so skip huge number of tests
 if ENV['GITHUB_WORKFLOW'] &&
-   ENV['GITHUB_WORKFLOW'] == 'Compilations'
+   (ENV['GITHUB_WORKFLOW'] == 'Compilations' ||
+   ENV['GITHUB_WORKFLOW'] == 'ModGC')
    # ignore the follow
 else
 

--- a/common.mk
+++ b/common.mk
@@ -753,6 +753,7 @@ clean-extout: PHONY
 	-$(Q)$(RMDIR) $(EXTOUT)/$(arch) $(RUBYCOMMONDIR) $(EXTOUT) 2> $(NULL) || $(NULLCMD)
 clean-gc: PHONY
 	$(Q) $(RMALL) .gc
+	$(Q) $(RMALL) gc
 clean-docs: clean-rdoc clean-html clean-capi
 clean-spec: PHONY
 clean-rubyspec: clean-spec
@@ -1960,7 +1961,7 @@ clean-modular-gc:
 	- $(CHDIR) gc/$(MODULAR_GC) && $(exec) $(MAKE) TARGET_SO_DIR=./ clean || $(NULLCMD)
 distclean-modular-gc: clean-modular-gc
 	- $(CHDIR) gc/$(MODULAR_GC) && $(exec) $(MAKE) TARGET_SO_DIR=./ distclean || $(NULLCMD)
-	$(RMDIRS) gc/$(MODULAR_GC)
+	$(RMALL) gc/$(MODULAR_GC)
 
 help: PHONY
 	$(MESSAGE_BEGIN) \


### PR DESCRIPTION
In order to prevent regressions to the GC API that will break existing modular GC's we should add cases to CI that cover building existing known shared GC implementations included with Ruby.