### PR TITLE
Avoid test failures on hosts that only support IPv4

### DIFF
--- a/test/socket/test_tcp.rb
+++ b/test/socket/test_tcp.rb
@@ -146,9 +146,11 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
     return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
 
     begin
+      # Verify that "localhost" can be resolved to an IPv6 address
+      Socket.getaddrinfo("localhost", 0, Socket::AF_INET6)
       server = TCPServer.new("::1", 0)
-    rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
-      exit
+    rescue Socket::ResolutionError, Errno::EADDRNOTAVAIL # IPv6 is not supported
+      return
     end
 
     server_thread = Thread.new { server.accept }
@@ -192,9 +194,11 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
     return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
 
     begin
+      # Verify that "localhost" can be resolved to an IPv6 address
+      Socket.getaddrinfo("localhost", 0, Socket::AF_INET6)
       server = TCPServer.new("::1", 0)
-    rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
-      exit
+    rescue Socket::ResolutionError, Errno::EADDRNOTAVAIL # IPv6 is not supported
+      return
     end
 
     port = server.addr[1]
@@ -290,7 +294,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
     begin
       server = TCPServer.new("::1", 0)
     rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
-      exit
+      return
     end
 
     port = server.connect_address.ip_port
@@ -314,8 +318,9 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
     begin
       server = TCPServer.new("::1", 0)
     rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
-      exit
+      return
     end
+
     port = server.connect_address.ip_port
     server.close
 
@@ -353,7 +358,7 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
     begin
       server = TCPServer.new("::1", 0)
     rescue Errno::EADDRNOTAVAIL # IPv6 is not supported
-      exit
+      return
     end
 
     server_thread = Thread.new { server.accept }


### PR DESCRIPTION
To verify the behavior of HEv2, some tests were prepared. But unexpected failures occur in certain environments. This happens in environments where "localhost" resolves only to an IPv4 address during tests that verify connections to IPv6.

For example, the following situation can occur:

- The server process is bound to ::1.
- The client socket always resolves "localhost" to 127.0.0.1 and attempts to connect to 127.0.0.1.
- Since no server is bound to 127.0.0.1, an ECONNREFUSED error is raised.

In such situations, the behavior of `TCPSocket.new` remains unchanged from before the introduction of HEv2. (The failures occur because tests explicitly binding to ::1 were added to verify HEv2 behavior.)

This change ensures that the affected tests are skipped in environments of this kind.