### PR TITLE
Remove a useless condition expression

### DIFF
--- a/random.c
+++ b/random.c
@@ -378,8 +378,8 @@ rand_init(const rb_random_interface_t *rng, rb_random_t *rnd, VALUE seed)
         INTEGER_PACK_LSWORD_FIRST|INTEGER_PACK_NATIVE_BYTE_ORDER);
     if (sign < 0)
         sign = -sign;
-    if (len <= 1) {
-        rng->init_int32(rnd, len ? buf[0] : 0);
+    if (len == 1) {
+        rng->init_int32(rnd, buf[0]);
     }
     else {
         if (sign != 2 && buf[len-1] == 1) /* remove leading-zero-guard */


### PR DESCRIPTION
`len` is always at least 1 here.