### PR TITLE
Use `RSTRING_PTR` instead of `StringValuePtr`

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -14649,7 +14649,7 @@ ibf_load_setup(struct ibf_load *load, VALUE loader_obj, VALUE str)
         str = rb_str_new(RSTRING_PTR(str), RSTRING_LEN(str));
     }
 
-    ibf_load_setup_bytes(load, loader_obj, StringValuePtr(str), RSTRING_LEN(str));
+    ibf_load_setup_bytes(load, loader_obj, RSTRING_PTR(str), RSTRING_LEN(str));
     RB_OBJ_WRITE(loader_obj, &load->str, str);
 }
 


### PR DESCRIPTION
... since it is certain to be a String in this context.

Also, I want to avoid the anxious use of `StringValuePtr(str)` and `RSTRING_LEN(str)` as arguments in the same function call.