### PR TITLE
Fix use-of-uninitialized-value in YJIT initialization

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -10737,7 +10737,7 @@ pub fn yjit_reg_method_codegen_fns() {
 /// See also: [lookup_cfunc_codegen].
 fn reg_method_codegen(klass: VALUE, mid_str: &str, gen_fn: MethodGenFn) {
     let id_string = std::ffi::CString::new(mid_str).expect("couldn't convert to CString!");
-    let mid = unsafe { rb_intern(id_string.as_ptr()) };
+    let mid = unsafe { rb_intern2(id_string.as_ptr(), id_string.count_bytes() as i64) };
     let me = unsafe { rb_method_entry_at(klass, mid) };
 
     if me.is_null() {


### PR DESCRIPTION
Rust strings are not null-terminated but rb_intern uses strlen on the string, which causes a use-of-uninitialized-value error in MSAN because it ends up reading past the end of the string.

    ==16730==WARNING: MemorySanitizer: use-of-uninitialized-value
          #0 0x555555b9ff7e in rb_intern /home/peter/src/ruby/build/../symbol.c:825:29
          #1 0x555555e536c7 in yjit::codegen::reg_method_codegen::hd714bff47c241e12 /home/peter/src/ruby/build/../yjit/src/codegen.rs:10740:24
          #2 0x555555e5304a in yjit::codegen::yjit_reg_method_codegen_fns::h086ce92dc4885e15 /home/peter/src/ruby/build/../yjit/src/codegen.rs:10661:9
          #3 0x555555e9deb7 in rb_yjit_init /home/peter/src/ruby/build/../yjit/src/yjit.rs:40:5