### PR TITLE
Fix ATTRIBUTE_NO_ADDRESS_SAFETY_ANALYSIS for MSAN

### DIFF
--- a/internal/sanitizers.h
+++ b/internal/sanitizers.h
@@ -39,6 +39,9 @@
 #elif defined(RUBY_ASAN_ENABLED)
 # define ATTRIBUTE_NO_ADDRESS_SAFETY_ANALYSIS(x) \
     __attribute__((__no_sanitize__("address"), __noinline__)) x
+#elif defined(RUBY_MSAN_ENABLED)
+    # define ATTRIBUTE_NO_ADDRESS_SAFETY_ANALYSIS(x) \
+    __attribute__((__no_sanitize__("memory"), __noinline__)) x
 #elif defined(NO_SANITIZE_ADDRESS)
 # define ATTRIBUTE_NO_ADDRESS_SAFETY_ANALYSIS(x) \
     NO_SANITIZE_ADDRESS(NOINLINE(x))


### PR DESCRIPTION
There's no case for when RUBY_MSAN_ENABLED, so the macro ends up doing nothing when it should instead have `__attribute__((__no_sanitize__("memory")))`.