### PR TITLE
[win32] fix arm64 instruction decoding

### DIFF
--- a/win32/win32.c
+++ b/win32/win32.c
@@ -2580,7 +2580,7 @@ set_pioinfo_extra(void)
     const uint32_t adrp_id = 0x90000000;
     const uint32_t adrp_mask = 0x9f000000;
     const uint32_t add_id = 0x11000000;
-    const uint32_t add_mask = 0x3fc00000;
+    const uint32_t add_mask = 0x7fc00000;
     for(; pc > start; pc--) {
         if (IS_INSN(pc, adrp) && IS_INSN(pc + 1, add)) {
             break;
@@ -2600,17 +2600,14 @@ set_pioinfo_extra(void)
     const uint32_t adrp_insn = *pc;
     const uint32_t adrp_immhi = (adrp_insn & 0x00ffffe0) >> 5;
     const uint32_t adrp_immlo = (adrp_insn & 0x60000000) >> (5 + 19 + 5);
-    /* imm = immhi:immlo:Zeros(12), 64 */
-    const uint64_t adrp_imm = ((adrp_immhi << 2) | adrp_immlo) << 12;
+    const int64_t  adrp_sign  = (adrp_insn & 0x00800000) ? ~0x001fffff : 0;
+    /* imm = SignExtend(immhi:immlo:Zeros(12), 64) */
+    const int64_t adrp_imm = (adrp_sign | (adrp_immhi << 2) | adrp_immlo) << 12;
     /* base = PC64<63:12>:Zeros(12) */
     const uint64_t adrp_base = (uint64_t)pc & 0xfffffffffffff000;
 
     const uint32_t add_insn = *(pc + 1);
-    const uint32_t add_sh = (add_insn & 0x400000) >> (12 + 5 + 5);
-    /* case sh of
-      when '0' imm = ZeroExtend(imm12, datasize);
-      when '1' imm = ZeroExtend(imm12:Zeros(12), datasize); */
-    const uint64_t add_imm = ((add_insn & 0x3ffc00) >> (5 + 5)) << (add_sh ? 12 : 0);
+    const uint64_t add_imm = (add_insn & 0x3ffc00) >> (5 + 5);
 
     __pioinfo = (ioinfo**)(adrp_base + adrp_imm + add_imm);
 #else /* _M_ARM64 */


### PR DESCRIPTION
Two minor fixes to arm64 instruction decoding when looking for __pioinfo:
1. add_mask was shifted by one bit, it was intended to be 0x7f800000.  However, since the mask was already excluding matching the 'sh' bit, and since the purpose of the add following the adrp is to add in the lower 12 bits, I opted to set the mask to 0x7fc00000 and simply remove the handling for the 12 bit shift option which is now required to be disabled in order to match.
2. adrp's immediate was supposed to be sign extended.  So far, I have not seen cases where the global variable ends up before the code in memory, but it's a possibility, so handle the sign extension.

See the recent commentary on #8995 between me and @pbo-linaro