### PR TITLE
Improve the conditions for clearing the Connection Attempt Delay upon connection failure

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -1007,9 +1007,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                 if (connected_fd >= 0) break;
 
                 if (!in_progress_fds(arg->connection_attempt_fds_size)) {
-                    if (any_addrinfos(&resolution_store)) {
-                        connection_attempt_delay_expires_at = NULL;
-                    } else if (resolution_store.is_all_finised) {
+                    if (!any_addrinfos(&resolution_store) && resolution_store.is_all_finised) {
                         if (local_status < 0) {
                             host = arg->local.host;
                             serv = arg->local.serv;
@@ -1023,6 +1021,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                             rsock_syserr_fail_host_port(last_error.ecode, syscall, host, serv);
                         }
                     }
+                    connection_attempt_delay_expires_at = NULL;
                     user_specified_connect_timeout_at = NULL;
                 }
             }

--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -226,7 +226,6 @@ struct fast_fallback_inetsock_arg
     int *families;
     int family_size;
     int additional_flags;
-    rb_nativethread_lock_t *lock;
     struct fast_fallback_getaddrinfo_entry *getaddrinfo_entries[2];
     struct fast_fallback_getaddrinfo_shared *getaddrinfo_shared;
     int wait;
@@ -601,8 +600,6 @@ init_fast_fallback_inetsock_internal(VALUE v)
     rb_nativethread_lock_initialize(arg->getaddrinfo_shared->lock);
 
     arg->getaddrinfo_shared->notify = hostname_resolution_notifier;
-    arg->getaddrinfo_shared->connection_attempt_fds = arg->connection_attempt_fds;
-    arg->getaddrinfo_shared->connection_attempt_fds_size = arg->connection_attempt_fds_size;
     arg->getaddrinfo_shared->cancelled = false;
     wait_arg.cancelled = &arg->getaddrinfo_shared->cancelled;
 
@@ -620,7 +617,6 @@ init_fast_fallback_inetsock_internal(VALUE v)
     if (arg->family_size == 1) {
         arg->getaddrinfo_shared->node = NULL;
         arg->getaddrinfo_shared->service = NULL;
-        arg->getaddrinfo_shared->refcount = 1;
 
         int family = arg->families[0];
         arg->remote.res = rsock_addrinfo(

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -440,9 +440,8 @@ struct fast_fallback_getaddrinfo_entry
 
 struct fast_fallback_getaddrinfo_shared
 {
-    int notify, refcount, connection_attempt_fds_size;
+    int notify, refcount;
     int cancelled;
-    int *connection_attempt_fds;
     char *node, *service;
     rb_nativethread_lock_t *lock;
     struct fast_fallback_getaddrinfo_entry getaddrinfo_entries[FLEX_ARY_LEN];


### PR DESCRIPTION
Improve the conditions for clearing the Connection Attempt Delay upon connection failure.

This change addresses a case that was overlooked in ruby/ruby#12087.
In the previous change, the Connection Attempt Delay was cleared at the point of a connection failure only if both of the following conditions were met:

- No other sockets were attempting a connection
- There were addresses still available to start a new connection

In this update, the second condition has been removed.
As a result, if name resolution succeeds after a connection failure and new addresses are obtained, it will be able to immediately attempt a connection to one of them.

If there are no sockets attempting a connection, no addresses available for connection, and name resolution has completed, an exception will still be raised as before.

Additionally, the following minor fixes have been made:
- Refactor: Remove unnecessary members