### PR TITLE
[DOC] New homepage for docs.ruby-lang.org/en

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -2,7 +2,7 @@
 page_dir: doc
 charset: UTF-8
 encoding: UTF-8
-main_page: README.md
+main_page: index.md
 title: Documentation for Ruby development version
 visibility: :private
 rdoc_include:

--- a/doc/index.md
+++ b/doc/index.md
@@ -20,10 +20,8 @@ Explore the essential classes and modules:
 - [File](File.html) - \File operations and handling.
 - [IO](IO.html) - Input/output functionality.
 - [Time](Time.html) - \Time representation.
-- [Date](Date.html) - \Date representation.
 - [Regexp](Regexp.html) - Regular expressions for pattern matching.
 - [Range](Range.html) - Representing a range of values.
-- [JSON](JSON.html) - \JSON encoding and decoding.
 - [Exception](Exception.html) - Base class for all exceptions.
 - [Thread](Thread.html) - Multithreading and concurrency.
 
@@ -35,9 +33,16 @@ Deep dive into Ruby's syntax and features:
 - [Exceptions](exceptions_md.html)
 - [Implicit Conversions](implicit_conversions_md.html)
 
-## Standard Library
+## Standard Libraries
 
-Access the comprehensive set of libraries included with Ruby:
+There are some standard libraries included in Ruby that are also commonly used, such as:
+
+- [Date](Date.html) - \Date representation.
+- [JSON](JSON.html) - \JSON encoding and decoding.
+- [ERB](ERB.html) - Embedded Ruby for templating.
+- [Net::HTTP](Net/HTTP.html) - HTTP client library.
+
+Use the following links to access the comprehensive set of libraries included with Ruby:
 
 - [Standard Library Documentation](standard_library_rdoc.html)
 - [Maintainers](maintainers_md.html)
@@ -51,10 +56,10 @@ Get involved with the Ruby community:
 - [Reporting Issues](contributing/reporting_issues_md.html)
 - [Building Ruby](contributing/building_ruby_md.html)
 - [Testing Ruby](contributing/testing_ruby_md.html)
+- [Issue Tracker](https://bugs.ruby-lang.org/projects/ruby-master/issues)
 
 ## Additional Resources
 
 - [Ruby Homepage](https://www.ruby-lang.org/)
 - [RubyGems](https://rubygems.org/)
-- [Ruby on Rails](https://rubyonrails.org/)
 - [Ruby Community](https://www.ruby-lang.org/en/community/)

--- a/doc/index.md
+++ b/doc/index.md
@@ -29,9 +29,9 @@ Explore the essential classes and modules:
 
 Deep dive into Ruby's syntax and features:
 
-- [Ruby Syntax](syntax_rdoc.html)
-- [Exceptions](exceptions_md.html)
-- [Implicit Conversions](implicit_conversions_md.html)
+- [Ruby Syntax](rdoc-ref:syntax.rdoc)
+- [Exceptions](rdoc-ref:exceptions.md)
+- [Implicit Conversions](rdoc-ref:implicit_conversion.rdoc)
 
 ## Standard Libraries
 
@@ -44,18 +44,18 @@ There are some standard libraries included in Ruby that are also commonly used, 
 
 Use the following links to access the comprehensive set of libraries included with Ruby:
 
-- [Standard Library Documentation](standard_library_rdoc.html)
-- [Maintainers](maintainers_md.html)
+- [Standard Library Documentation](rdoc-ref:standard_library.rdoc)
+- [Maintainers](rdoc-ref:maintainers.md)
 
 ## Contribute to Ruby
 
 Get involved with the Ruby community:
 
-- [Contribution Guide](contributing_md.html)
-- [Documentation Guide](contributing/documentation_guide_md.html)
-- [Reporting Issues](contributing/reporting_issues_md.html)
-- [Building Ruby](contributing/building_ruby_md.html)
-- [Testing Ruby](contributing/testing_ruby_md.html)
+- [Contribution Guide](rdoc-ref:contributing.md)
+- [Documentation Guide](rdoc-ref:contributing/documentation_guide.md)
+- [Reporting Issues](rdoc-ref:contributing/reporting_issues.md)
+- [Building Ruby](rdoc-ref:contributing/building_ruby.md)
+- [Testing Ruby](rdoc-ref:contributing/testing_ruby.md)
 - [Issue Tracker](https://bugs.ruby-lang.org/projects/ruby-master/issues)
 
 ## Additional Resources

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,0 +1,60 @@
+# Ruby Documentation
+
+Welcome to the official Ruby programming language documentation.
+
+## Getting Started
+
+New to Ruby? Start with our [Getting Started Guide](https://www.ruby-lang.org/en/documentation/quickstart/).
+
+## Core Classes and Modules
+
+Explore the essential classes and modules:
+
+- [String](String.html) - Text manipulation and string utilities.
+- [Symbol](Symbol.html) - Named identifiers inside the Ruby interpreter.
+- [Array](Array.html) - Ordered collections of objects.
+- [Hash](Hash.html) - Key-value pairs for efficient data retrieval.
+- [Integer](Integer.html) - \Integer number class.
+- [Float](Float.html) - Floating-point number class.
+- [Enumerable](Enumerable.html) - Collection traversal and searching.
+- [File](File.html) - \File operations and handling.
+- [IO](IO.html) - Input/output functionality.
+- [Time](Time.html) - \Time representation.
+- [Date](Date.html) - \Date representation.
+- [Regexp](Regexp.html) - Regular expressions for pattern matching.
+- [Range](Range.html) - Representing a range of values.
+- [JSON](JSON.html) - \JSON encoding and decoding.
+- [Exception](Exception.html) - Base class for all exceptions.
+- [Thread](Thread.html) - Multithreading and concurrency.
+
+## Language Reference
+
+Deep dive into Ruby's syntax and features:
+
+- [Ruby Syntax](syntax_rdoc.html)
+- [Exceptions](exceptions_md.html)
+- [Implicit Conversions](implicit_conversions_md.html)
+
+## Standard Library
+
+Access the comprehensive set of libraries included with Ruby:
+
+- [Standard Library Documentation](standard_library_rdoc.html)
+- [Maintainers](maintainers_md.html)
+
+## Contribute to Ruby
+
+Get involved with the Ruby community:
+
+- [Contribution Guide](contributing_md.html)
+- [Documentation Guide](contributing/documentation_guide_md.html)
+- [Reporting Issues](contributing/reporting_issues_md.html)
+- [Building Ruby](contributing/building_ruby_md.html)
+- [Testing Ruby](contributing/testing_ruby_md.html)
+
+## Additional Resources
+
+- [Ruby Homepage](https://www.ruby-lang.org/)
+- [RubyGems](https://rubygems.org/)
+- [Ruby on Rails](https://rubyonrails.org/)
+- [Ruby Community](https://www.ruby-lang.org/en/community/)


### PR DESCRIPTION
The homepage of a language's documentation website should provide developers with quick access to important components, topics, and resources. Here are some good examples:

- [Ruby's Japanese Documentation](https://docs.ruby-lang.org/ja/master/doc/index.html)
- [Python Documentation](https://docs.python.org/)
- [Go Documentation](https://go.dev/doc/)
- [TypeScript Documentation](https://www.typescriptlang.org/docs/)
- [Ruby API](https://rubyapi.org/)

Currently, [docs.ruby-lang.org/en](https://docs.ruby-lang.org/en) uses the project README as its homepage, which offers less value to most users. I propose creating a dedicated index page to serve as the homepage for [docs.ruby-lang.org/en](https://docs.ruby-lang.org/en). This would improve the user experience by providing easy navigation to essential documentation topics.

### Result

<img width="80%" alt="Screenshot 2024-11-30 at 18 32 31" src="https://github.com/user-attachments/assets/12787c19-3ab8-441a-984e-bbc40e5b1f35">
