### PR TITLE
Lock json-schema-5.1.0 and fix build failure iwth prism

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1605,7 +1605,7 @@ no-install-for-test-bundled-gems: no-update-default-gemspecs
 yes-install-for-test-bundled-gems: yes-update-default-gemspecs
 	$(XRUBY) -C "$(srcdir)" -r./tool/lib/gem_env.rb bin/gem \
 		install --no-document --conservative \
-		"hoe" "json-schema" "test-unit-rr" "simplecov" "simplecov-html" "simplecov-json" "rspec" "zeitwerk" \
+		"hoe" "json-schema:5.1.0" "test-unit-rr" "simplecov" "simplecov-html" "simplecov-json" "rspec" "zeitwerk" \
 		"sinatra" "rack" "tilt" "mustermann" "base64" "compact_index" "rack-test"
 
 test-bundled-gems-fetch: yes-test-bundled-gems-fetch

--- a/prism/defines.h
+++ b/prism/defines.h
@@ -137,6 +137,14 @@
 #endif
 
 /**
+ * isinf on POSIX systems it accepts a float, a double, or a long double.
+ * But Windows didn't provide isinf, so we need to use _finite instead.
+ */
+#ifdef _WIN32
+#   include <float.h>
+#endif
+
+/**
  * If you build prism with a custom allocator, configure it with
  * "-D PRISM_XALLOCATOR" to use your own allocator that defines xmalloc,
  * xrealloc, xcalloc, and xfree.


### PR DESCRIPTION
We can't use C extension as json-schema dependency.