### PR TITLE
Lock json-schema-5.1.0 for Ruby 3.3

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -238,7 +238,7 @@ jobs:
       - run: id
         working-directory:
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           sparse-checkout-cone-mode: false
           sparse-checkout: /.github

--- a/common.mk
+++ b/common.mk
@@ -1560,7 +1560,7 @@ no-test-bundled-gems-prepare: no-test-bundled-gems-precheck
 yes-test-bundled-gems-prepare: yes-test-bundled-gems-precheck
 	$(ACTIONS_GROUP)
 	$(XRUBY) -C "$(srcdir)" bin/gem install --no-document \
-		--install-dir .bundle --conservative "hoe" "json-schema" "test-unit-rr"
+		--install-dir .bundle --conservative "hoe" "json-schema:5.1.0" "test-unit-rr"
 	$(ACTIONS_ENDGROUP)
 
 PREPARE_BUNDLED_GEMS = test-bundled-gems-prepare


### PR DESCRIPTION
Fixed https://github.com/ruby/actions/actions/runs/12125808886/job/33806775870

```
  Building native extensions. This could take a while...
  ERROR:  Error installing json-schema:
  	ERROR: Failed to build gem native extension.
  
      current directory: /home/runner/work/actions/actions/snapshot-ruby_3_3/.bundle/gems/bigdecimal-3.1.8/ext/bigdecimal
  /usr/local/bin/ruby -I/home/runner/work/actions/actions/snapshot-ruby_3_3/lib extconf.rb
  extconf failedNo such file or directory - /usr/local/bin/ruby
```

We can't use C extension with `make test-bundled-gems`.