### PR TITLE
Socket#connect may be raise ECONNREFUSED

### DIFF
--- a/spec/ruby/library/socket/socket/connect_spec.rb
+++ b/spec/ruby/library/socket/socket/connect_spec.rb
@@ -63,7 +63,11 @@ describe 'Socket#connect' do
       client.timeout = 0
 
       -> {
-        client.connect(address)
+        begin
+          client.connect(address)
+        rescue Errno::ECONNREFUSED
+          skip "Outgoing packets may be filtered"
+        end
       }.should raise_error(IO::TimeoutError)
     end
   end


### PR DESCRIPTION
On my environment with `sudo ufw default reject outgoing`, outgoing packets are filtered without allow rules.