### PR TITLE
Use getaddrinfo_shared->lock consistently

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -3033,7 +3033,7 @@ free_fast_fallback_getaddrinfo_shared(struct fast_fallback_getaddrinfo_shared **
     (*shared)->node = NULL;
     free((*shared)->service);
     (*shared)->service = NULL;
-    rb_nativethread_lock_destroy((*shared)->lock);
+    rb_nativethread_lock_destroy(&(*shared)->lock);
     free(*shared);
     *shared = NULL;
 }
@@ -3092,7 +3092,7 @@ do_fast_fallback_getaddrinfo(void *ptr)
         }
     }
 
-    rb_nativethread_lock_lock(shared->lock);
+    rb_nativethread_lock_lock(&shared->lock);
     {
         entry->err = err;
         if (shared->cancelled) {
@@ -3112,7 +3112,7 @@ do_fast_fallback_getaddrinfo(void *ptr)
         if (--(entry->refcount) == 0) need_free = 1;
         if (--(shared->refcount) == 0) shared_need_free = 1;
     }
-    rb_nativethread_lock_unlock(shared->lock);
+    rb_nativethread_lock_unlock(&shared->lock);
 
     if (need_free && entry) {
         free_fast_fallback_getaddrinfo_entry(&entry);

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -443,7 +443,7 @@ struct fast_fallback_getaddrinfo_shared
     int notify, refcount;
     int cancelled;
     char *node, *service;
-    rb_nativethread_lock_t *lock;
+    rb_nativethread_lock_t lock;
     struct fast_fallback_getaddrinfo_entry getaddrinfo_entries[FLEX_ARY_LEN];
 };
 


### PR DESCRIPTION
In some locations we were using shared->lock and in others &shared->lock, despite it being a pointer, and we were leaking the allocated memory.

Previously, after building with ASAN:

```
$ ASAN_OPTIONS="detect_leaks=1" RUBY_FREE_AT_EXIT=1 make test-all TESTS=test/socket/test_tcp.rb
---8<---
==2624456==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 200 byte(s) in 5 object(s) allocated from:
    #0 0x58dd3649c7a9 in calloc /home/runner/work/llvm-project/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:75:3
    #1 0x7808acdb4978 in init_fast_fallback_inetsock_internal /home/jhawthorn/src/ruby/ext/socket/ipsocket.c:598:37
    #2 0x58dd364e28a9 in rb_ensure /home/jhawthorn/src/ruby/eval.c:1053:18
    #3 0x7808acdb41b9 in rsock_init_inetsock /home/jhawthorn/src/ruby/ext/socket/ipsocket.c:1317:20
    #4 0x7808acdbaf8a in tcp_init /home/jhawthorn/src/ruby/ext/socket/tcpsocket.c:91:12
    #5 0x58dd36746984 in vm_call0_cfunc_with_frame /home/jhawthorn/src/ruby/./vm_eval.c:164:15
```

cc @shioimm 