### PR TITLE
Use BUILDING_SHARED_GC instead of RB_AMALGAMATED_DEFAULT_GC

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -615,7 +615,6 @@ rb_gc_guarded_ptr_val(volatile VALUE *ptr, VALUE val)
 #endif
 
 static const char *obj_type_name(VALUE obj);
-#define RB_AMALGAMATED_DEFAULT_GC
 #include "gc/default/default.c"
 static int external_gc_loaded = FALSE;
 

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -10,6 +10,9 @@
  */
 #include "ruby/ruby.h"
 
+#ifdef BUILDING_SHARED_GC
+# define GC_IMPL_FN
+#else
 // `GC_IMPL_FN` is an implementation detail of `!USE_SHARED_GC` builds
 // to have the default GC in the same translation unit as gc.c for
 // the sake of optimizer visibility. It expands to nothing unless
@@ -18,10 +21,7 @@
 // For the default GC, do not copy-paste this when implementing
 // these functions. This takes advantage of internal linkage winning
 // when appearing first. See C99 6.2.2p4.
-#ifdef RB_AMALGAMATED_DEFAULT_GC
 # define GC_IMPL_FN static
-#else
-# define GC_IMPL_FN
 #endif
 
 // Bootup


### PR DESCRIPTION
We can use the BUILDING_SHARED_GC flag to check if we're building gc_impl.h as a shared GC or building the default GC.