### PR TITLE
YJIT: Generate specialized code for Symbol for objtostring

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -9942,6 +9942,7 @@ fn gen_objtostring(
         // Same optimization done in the interpreter: rb_sym_to_s() allocates a mutable string, but since we are only
         // going to use this string for interpolation, it's fine to use the
         // frozen string.
+        // rb_sym2str does not allocate.
         let sym = recv;
         let str = asm.ccall(rb_sym2str as *const u8, vec![sym]);
         asm.stack_pop(1);

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -9923,6 +9923,34 @@ fn gen_objtostring(
 
         // No work needed. The string value is already on the top of the stack.
         Some(KeepCompiling)
+    } else if unsafe { RB_TYPE_P(comptime_recv, RUBY_T_SYMBOL) } && assume_method_basic_definition(jit, asm, comptime_recv.class_of(), ID!(to_s)) {
+        jit_guard_known_klass(
+            jit,
+            asm,
+            comptime_recv.class_of(),
+            recv,
+            recv.into(),
+            comptime_recv,
+            SEND_MAX_DEPTH,
+            Counter::objtostring_not_string,
+        );
+
+        extern "C" {
+            fn rb_sym2str(sym: VALUE) -> VALUE;
+        }
+
+        // Same optimization done in the interpreter: rb_sym_to_s() allocates a mutable string, but since we are only
+        // going to use this string for interpolation, it's fine to use the
+        // frozen string.
+        let sym = recv;
+        let str = asm.ccall(rb_sym2str as *const u8, vec![sym]);
+        asm.stack_pop(1);
+
+        // Push the return value
+        let stack_ret = asm.stack_push(Type::TString);
+        asm.mov(stack_ret, str);
+
+        Some(KeepCompiling)
     } else {
         let cd = jit.get_arg(0).as_ptr();
         perf_call! { gen_send_general(jit, asm, cd, None) }

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -823,6 +823,7 @@ pub(crate) mod ids {
         name: NULL               content: b""
         name: respond_to_missing content: b"respond_to_missing?"
         name: to_ary             content: b"to_ary"
+        name: to_s               content: b"to_s"
         name: eq                 content: b"=="
         name: include_p          content: b"include?"
     }


### PR DESCRIPTION
For YJIT: This adds specialized code for objtostring when dealing with Symbol. We're looking to get the same memory optimization that is done in the interpreter, [see this commit a while back in the interpreter](https://github.com/ruby/ruby/commit/b08dacfea39ad8da3f1fd7fdd0e4538cc892ec44).

The premise for the optimization is that during string interpolation (which doesn't require a mutable string), we can avoid extra allocations for Symbol by calling `rb_sym2str` to get its frozen string literal without any object allocations.

## Testing & Metrics
We [used this test to record the number of allocations](https://gist.github.com/jhawthorn/0c3844867e267949db39f90032827122) for to_s.

Results:
`./miniruby --yjit --yjit-call-threshold=1 test.rb`
Before: 3.4.0 master (af5c34fb0b6d06f9c78952bccc9879fa735b3857)
Output: 2000001
After:
Output: 1000001

## Performance
Rough performance testing with `time`, we can see improvements in total time:
**Before: 3.4.0 master (af5c34fb0b6d06f9c78952bccc9879fa735b3857) (YJIT disabled)**
`./miniruby test.rb  1.39s user 0.03s system 88% cpu 1.607 total`
**Before: 3.4.0 master (af5c34fb0b6d06f9c78952bccc9879fa735b3857) (YJIT enabled)**
`./miniruby --yjit --yjit-call-threshold=1 test.rb  1.42s user 0.03s system 87% cpu 1.646 total`

**After:**
`./miniruby --yjit --yjit-call-threshold=1 test.rb  0.89s user 0.02s system 94% cpu 0.957 total`

Co-authored with @jhawthorn