### PR TITLE
[DOC] Mention `Object#initialize_clone` and `#initialize_dup`

### DIFF
--- a/object.c
+++ b/object.c
@@ -604,6 +604,10 @@ rb_obj_dup_setup(VALUE obj, VALUE dup)
  *  When using #dup, any modules that the object has been extended with will not
  *  be copied.
  *
+ *  If you need #clone and #dup to behave differently, you can use
+ *  #+initialize_clone+ and #+initialize_dup+.
+ *  By default, both methods call #+initialize_copy+.
+ *
  *	class Klass
  *	  attr_accessor :str
  *	end


### PR DESCRIPTION
It seems there is no mention in the documentation about what `Object#initialize_clone` and `#initialize_dup` are.
Adding a brief explanation about them might be helpful.