### PR TITLE
Remove meaningless NULL checks

### DIFF
--- a/weakmap.c
+++ b/weakmap.c
@@ -636,10 +636,8 @@ static int
 wkmap_mark_table_i(st_data_t key, st_data_t val_obj, st_data_t data)
 {
     VALUE **dead_entry = (VALUE **)data;
-    if (dead_entry != NULL) {
-        ruby_sized_xfree(*dead_entry, sizeof(VALUE));
-        *dead_entry = NULL;
-    }
+    ruby_sized_xfree(*dead_entry, sizeof(VALUE));
+    *dead_entry = NULL;
 
     VALUE *key_ptr = (VALUE *)key;
 
@@ -702,10 +700,8 @@ static int
 wkmap_compact_table_i(st_data_t key, st_data_t val_obj, st_data_t data, int _error)
 {
     VALUE **dead_entry = (VALUE **)data;
-    if (dead_entry != NULL) {
-        ruby_sized_xfree(*dead_entry, sizeof(VALUE));
-        *dead_entry = NULL;
-    }
+    ruby_sized_xfree(*dead_entry, sizeof(VALUE));
+    *dead_entry = NULL;
 
     VALUE *key_ptr = (VALUE *)key;
 


### PR DESCRIPTION
The functions dereference `*dead_entry` without a NULL check