### PR TITLE
Fix an off by one in `rb_ary_resize`

### DIFF
--- a/array.c
+++ b/array.c
@@ -2304,7 +2304,7 @@ rb_ary_resize(VALUE ary, long len)
         rb_raise(rb_eIndexError, "index %ld too big", len);
     }
     if (len > olen) {
-        if (len >= ARY_CAPA(ary)) {
+        if (len > ARY_CAPA(ary)) {
             ary_double_capa(ary, len);
         }
         ary_mem_clear(ary, olen, len - olen);


### PR DESCRIPTION
When setting len to X we only need to grow the array if len is bigger than capa. If they're equal we don't need to increase capacity.