### PR TITLE
YJIT: track time since initialization

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -389,7 +389,9 @@ module RubyVM::YJIT
       end
       out.puts "max_inline_versions:   " + format_number(13, stats[:max_inline_versions])
       out.puts "compiled_branch_count: " + format_number(13, stats[:compiled_branch_count])
-      out.puts "compile_time_ms:       " + format_number(13, stats[:compile_time_ns] / (1000 * 1000))
+
+      out.puts "yjit_active_ms:        " + format_number(13, stats[:yjit_active_ns] / 10**6)
+      out.puts "compile_time_ms:       " + format_number_pct(13, stats[:compile_time_ns] / 10**6 , stats[:yjit_active_ns] / 10**6)
       out.puts "block_next_count:      " + format_number(13, stats[:block_next_count])
       out.puts "defer_count:           " + format_number(13, stats[:defer_count])
       out.puts "defer_empty_count:     " + format_number(13, stats[:defer_empty_count])

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use crate::codegen::CodegenGlobals;
 use crate::cruby::*;
 use crate::options::*;
-use crate::yjit::yjit_enabled_p;
+use crate::yjit::{yjit_enabled_p, YJIT_INIT_TIME};
 
 /// Running total of how many ISeqs are in the system.
 #[no_mangle]
@@ -797,6 +797,10 @@ fn rb_yjit_gen_stats_dict(key: VALUE) -> VALUE {
         set_stat_usize!(hash, "iseq_alloc_count", rb_yjit_iseq_alloc_count as usize);
 
         set_stat!(hash, "object_shape_count", rb_object_shape_count());
+
+        // Time since YJIT init in nanoseconds
+        let time_nanos = Instant::now().duration_since(YJIT_INIT_TIME.unwrap()).as_nanos();
+        set_stat_usize!(hash, "yjit_active_ns", time_nanos as usize);
     }
 
     // If we're not generating stats, put only default counters

--- a/yjit/src/yjit.rs
+++ b/yjit/src/yjit.rs
@@ -8,6 +8,7 @@ use crate::stats::incr_counter;
 use crate::stats::with_compile_time;
 
 use std::os::raw::{c_char, c_int};
+use std::time::Instant;
 use crate::log::Log;
 
 /// Is YJIT on? The interpreter uses this variable to decide whether to trigger
@@ -15,6 +16,9 @@ use crate::log::Log;
 #[allow(non_upper_case_globals)]
 #[no_mangle]
 pub static mut rb_yjit_enabled_p: bool = false;
+
+// Time when YJIT was yjit was initialized (see yjit_init)
+pub static mut YJIT_INIT_TIME: Option<Instant> = None;
 
 /// Parse one command-line option.
 /// This is called from ruby.c
@@ -75,6 +79,11 @@ fn yjit_init() {
         let perf_map = format!("/tmp/perf-{}.map", std::process::id());
         let _ = std::fs::remove_file(&perf_map);
         println!("YJIT perf map: {perf_map}");
+    }
+
+    // Note the time when YJIT was initialized
+    unsafe {
+        YJIT_INIT_TIME = Some(Instant::now());
     }
 }
 


### PR DESCRIPTION
I was looking at the YJIT stats dump on SFR the other day, and in particular the `compile_time_ms` value. It seemed to me that this value doesn't tell us that much if taken in isolation. It's much more useful if we can also know how long the process (or YJIT) has been active.

This PR keeps track of how much time has elapsed since `yjit_init` and tracks this in the stats. The `--yjit-stats` dump can then show `compile_time_ms` as a percentage of how long YJIT has been active. Eg for one single iteration of lobsters:
```
compiled_branch_count:        99,724
yjit_active_ms:                4,918
compile_time_ms:               1,265 (25.7%)
block_next_count:             48,513
```

35 iterations:
```
compiled_branch_count:       142,527
yjit_active_ms:               20,724
compile_time_ms:               2,198 (10.6%)
block_next_count:             68,677
```