### PR TITLE
Use rb_gc_enable/rb_gc_disable_no_rest instead of ruby_disable_gc

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -982,7 +982,6 @@ struct RZombie {
 
 #define RZOMBIE(o) ((struct RZombie *)(o))
 
-int ruby_disable_gc = 0;
 int ruby_enable_autocompact = 0;
 #if RGENGC_CHECK_MODE
 gc_compact_compare_func ruby_autocompact_compare_func;
@@ -6263,7 +6262,7 @@ heap_ready_to_gc(rb_objspace_t *objspace, rb_heap_t *heap)
 static int
 ready_to_gc(rb_objspace_t *objspace)
 {
-    if (dont_gc_val() || during_gc || ruby_disable_gc) {
+    if (dont_gc_val() || during_gc) {
         for (int i = 0; i < HEAP_COUNT; i++) {
             rb_heap_t *heap = &heaps[i];
             heap_ready_to_gc(objspace, heap);

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -175,7 +175,6 @@ struct rb_objspace; /* in vm_core.h */
     if (_already_disabled == Qfalse) rb_gc_enable()
 
 /* gc.c */
-extern int ruby_disable_gc;
 RUBY_ATTR_MALLOC void *ruby_mimmalloc(size_t size);
 RUBY_ATTR_MALLOC void *ruby_mimcalloc(size_t num, size_t size);
 void ruby_mimfree(void *ptr);

--- a/signal.c
+++ b/signal.c
@@ -751,7 +751,10 @@ rb_get_next_signal(void)
 
 #if defined SIGSEGV || defined SIGBUS || defined SIGILL || defined SIGFPE
 static const char *received_signal;
-# define clear_received_signal() (void)(ruby_disable_gc = 0, received_signal = 0)
+# define clear_received_signal() do { \
+    if (GET_VM() != NULL) rb_gc_enable(); \
+    received_signal = 0; \
+} while (0)
 #else
 # define clear_received_signal() ((void)0)
 #endif
@@ -1001,7 +1004,9 @@ check_reserved_signal_(const char *name, size_t name_len, int signo)
         ruby_abort();
     }
 
-    ruby_disable_gc = 1;
+    if (GET_VM() != NULL) {
+        rb_gc_disable_no_rest();
+    }
 }
 #endif
 


### PR DESCRIPTION
We should use the rb_gc_enable/rb_gc_disable_no_rest APIs instead of directly setting the ruby_disable_gc variable.