### PR TITLE
[Bug #20929] Fix timezone encoding

### DIFF
--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -717,13 +717,15 @@ class TestTime < Test::Unit::TestCase
     assert_equal("2000-01-01 09:12:34 +091234", t2000.localtime(9*3600+12*60+34).inspect)
   end
 
+  FIXED_ZONE_ENCODING = (Encoding::UTF_8 if /mswin|mingw/.match?(RUBY_PLATFORM))
+
   def assert_zone_encoding(time)
     zone = time.zone
     assert_predicate(zone, :valid_encoding?)
     if zone.ascii_only?
       assert_equal(Encoding::US_ASCII, zone.encoding)
     else
-      enc = Encoding.find('locale')
+      enc = FIXED_ZONE_ENCODING || Encoding.find('locale')
       assert_equal(enc, zone.encoding)
     end
   end

--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -723,7 +723,7 @@ class TestTime < Test::Unit::TestCase
     if zone.ascii_only?
       assert_equal(Encoding::US_ASCII, zone.encoding)
     else
-      enc = Encoding.default_internal || Encoding.find('locale')
+      enc = Encoding.find('locale')
       assert_equal(enc, zone.encoding)
     end
   end

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -779,6 +779,7 @@ $(CONFIG_H): $(MKFILES) $(srcdir)/win32/Makefile.sub $(win_srcdir)/Makefile.sub
 #define HAVE_STRUCT_TIMEVAL 1
 !if $(MSC_VER) >= 1900
 #define HAVE_STRUCT_TIMESPEC
+#define HAVE_LOCALE_H 1
 !endif
 !if $(MSC_VER) >= 1600
 #define HAVE_INTTYPES_H 1


### PR DESCRIPTION
- The default internal encoding is not taken into account to encode timezone name.
- Encode timezone name in UTF-8 on Windows.