### PR TITLE
darray.h does not depend on internal/bits.h

### DIFF
--- a/darray.h
+++ b/darray.h
@@ -5,8 +5,6 @@
 #include <stddef.h>
 #include <stdlib.h>
 
-#include "internal/bits.h"
-
 // Type for a dynamic array. Use to declare a dynamic array.
 // It is a pointer so it fits in st_table nicely. Designed
 // to be fairly type-safe.

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -15,6 +15,7 @@
 # include <sys/user.h>
 #endif
 
+#include "internal/bits.h"
 #include "internal/hash.h"
 
 #include "ruby/ruby.h"


### PR DESCRIPTION
darray.h no longer depends on internal/bits.h, so we can remove it.