### PR TITLE
Use symbol.h in vm.c to get macro for faster ID to sym

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -20049,6 +20049,7 @@ vm.$(OBJEXT): {$(VPATH)}rubyparser.h
 vm.$(OBJEXT): {$(VPATH)}shape.h
 vm.$(OBJEXT): {$(VPATH)}st.h
 vm.$(OBJEXT): {$(VPATH)}subst.h
+vm.$(OBJEXT): {$(VPATH)}symbol.h
 vm.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 vm.$(OBJEXT): {$(VPATH)}thread_native.h
 vm.$(OBJEXT): {$(VPATH)}variable.h

--- a/vm.c
+++ b/vm.c
@@ -33,6 +33,7 @@
 #include "internal/variable.h"
 #include "iseq.h"
 #include "rjit.h"
+#include "symbol.h" // This includes a macro for a more performant rb_id2sym.
 #include "yjit.h"
 #include "ruby/st.h"
 #include "ruby/vm.h"


### PR DESCRIPTION
The macro provided by symbol.h uses STATIC_ID2SYM
when it can which speeds up methods that declare keyword args.

With the `keyword_args` benchmark from yjit-bench, the interpreter gets a noticeable speedup:

```
bench         master (ms)  stddev (%)  opt (ms)  stddev (%)  opt 1st itr  master/opt
keyword_args  301.5        0.3         277.1     0.4         1.093        1.088 
```