### PR TITLE
Added altanative build to macOS with configure args 

### DIFF
--- a/.github/actions/setup/macos/action.yml
+++ b/.github/actions/setup/macos/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: brew
       shell: bash
       run: |
-        brew install --quiet gmp libffi openssl@3 zlib autoconf automake libtool
+        brew install --quiet jemalloc gmp libffi openssl@3 zlib autoconf automake libtool
 
     - name: Set ENV
       shell: bash

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,6 +33,9 @@ jobs:
           - test_task: check
             os: macos-14
             configure_args: '--with-jemalloc'
+          - test_task: check
+            os: macos-14
+            configure_args: '--with-gmp'
           - test_task: test-all
             test_opts: --repeat-count=2
             os: macos-14

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,6 +30,9 @@ jobs:
           - test_task: check
             os: macos-14
             configure_args: '--with-gcc=gcc-14'
+          - test_task: check
+            os: macos-14
+            configure_args: '--with-jemalloc'
           - test_task: test-all
             test_opts: --repeat-count=2
             os: macos-14

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,7 +32,7 @@ jobs:
             configure_args: '--with-gcc=gcc-14'
           - test_task: check
             os: macos-14
-            configure_args: '--with-jemalloc'
+            configure_args: '--with-jemalloc --with-opt-dir=$(brew --prefix jemalloc)'
           - test_task: check
             os: macos-14
             configure_args: '--with-gmp'


### PR DESCRIPTION
We didn't build jemalloc with macOS in GitHub Actions. Because we can't find https://bugs.ruby-lang.org/issues/20928 at that time. I added `--with-jemalloc` build to GitHub Actions.

And I also added `--with-gmp` build for same case. 