### PR TITLE
[DOC] Show `NONE` within `Measure` namespace

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -1759,7 +1759,8 @@ rb_data_define(VALUE super, ...)
  *  important for redefining initialize in order to convert arguments or provide
  *  defaults:
  *
- *     Measure = Data.define(:amount, :unit) do
+ *     Measure = Data.define(:amount, :unit)
+ *     class Measure
  *       NONE = Data.define
  *
  *       def initialize(amount:, unit: NONE.new)
@@ -1768,7 +1769,7 @@ rb_data_define(VALUE super, ...)
  *     end
  *
  *     Measure.new('10', 'km') # => #<data Measure amount=10.0, unit="km">
- *     Measure.new(10_000)     # => #<data Measure amount=10000.0, unit=#<data NONE>>
+ *     Measure.new(10_000)     # => #<data Measure amount=10000.0, unit=#<data Measure::NONE>>
  *
  */
 


### PR DESCRIPTION
A couple times in code review I've seen constants inadvertently leak to top level from within a `Struct` or `Data` do block. I think it would be nice to show reopening the `Data` class when a constant is defined, so the constant is defined within the namespace. In this case, `Measure::NONE` instead of top level `Object::NONE`. It would also show readers that it's okay to reopen a `Data` class, which seems nice since some folk might not realize. Thanks for considering!