### PR TITLE
[Bug #20933] Fix IO::Buffer overlap calculation

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3395,7 +3395,7 @@ io_buffer_overlaps(const struct rb_io_buffer *a, const struct rb_io_buffer *b)
         return io_buffer_overlaps(b, a);
     }
 
-    return (b->base >= a->base) && (b->base <= (void*)((unsigned char *)a->base + a->size));
+    return (b->base >= a->base) && (b->base < (void*)((unsigned char *)a->base + a->size));
 }
 
 static inline void


### PR DESCRIPTION
The allocated buffers may be consecutive memory addresses. This will mean that `b->base == a->base + a->size` even though `a` and `b` are separate buffers.