### PR TITLE
YJIT: Spill/load argument registers to reuse blocks

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1317,7 +1317,7 @@ impl Assembler
     }
 
     /// Spill a stack temp from a register to the stack
-    fn spill_reg(&mut self, opnd: Opnd) {
+    pub fn spill_reg(&mut self, opnd: Opnd) {
         assert_ne!(self.ctx.get_reg_mapping().get_reg(opnd.reg_opnd()), None);
 
         // Use different RegMappings for dest and src operands

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -8217,7 +8217,7 @@ fn gen_send_iseq(
                             let loaded_temp = asm.stack_opnd(argc - local_idx as i32 - 1);
                             asm.load_into(Opnd::Reg(loaded_reg), loaded_temp);
                         }
-                        RegOpnd::Stack(_) => unreachable!("diff_allowing_reg_mismatch should not leave {:?}", reg_opnd),
+                        RegOpnd::Stack(_) => unreachable!("find_most_compatible_reg_mapping should not leave {:?}", reg_opnd),
                     }
                 }
             }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -8192,7 +8192,8 @@ fn gen_send_iseq(
         if let Some(existing_reg_mapping) = find_most_compatible_reg_mapping(callee_blockid, &callee_ctx) {
             asm_comment!(asm, "reuse maps: {:?} -> {:?}", callee_ctx.get_reg_mapping(), existing_reg_mapping);
 
-            // Spill registers that are not used by the existing block
+            // Spill the registers that are not used in the existing block.
+            // When the same ISEQ is compiled as an entry block, it starts with no registers allocated.
             for &reg_opnd in callee_ctx.get_reg_mapping().get_reg_opnds().iter() {
                 if existing_reg_mapping.get_reg(reg_opnd).is_none() {
                     match reg_opnd {
@@ -8207,7 +8208,8 @@ fn gen_send_iseq(
             }
             assert!(callee_ctx.get_reg_mapping().get_reg_opnds().len() <= existing_reg_mapping.get_reg_opnds().len());
 
-            // Load registers that are currently not used but used by the existing block
+            // Load the registers that are spilled in this block but used in the existing block.
+            // When there are multiple callsites, some registers spilled in this block may be used at other callsites.
             for &reg_opnd in existing_reg_mapping.get_reg_opnds().iter() {
                 if callee_ctx.get_reg_mapping().get_reg(reg_opnd).is_none() {
                     match reg_opnd {

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -447,25 +447,9 @@ impl RegMapping {
         self.0.iter().filter_map(|&reg_opnd| reg_opnd).collect()
     }
 
-    /// Return TypeDiff::Compatible(diff) if dst has a mapping that can be made by moving registers
-    /// in self `diff` times. TypeDiff::Incompatible if they have different things in registers.
-    pub fn diff(&self, dst: RegMapping) -> TypeDiff {
-        let src_opnds = self.get_reg_opnds();
-        let dst_opnds = dst.get_reg_opnds();
-        if src_opnds.len() != dst_opnds.len() {
-            return TypeDiff::Incompatible;
-        }
-
-        let mut diff = 0;
-        for &reg_opnd in src_opnds.iter() {
-            match (self.get_reg(reg_opnd), dst.get_reg(reg_opnd)) {
-                (Some(src_idx), Some(dst_idx)) => if src_idx != dst_idx {
-                    diff += 1;
-                }
-                _ => return TypeDiff::Incompatible,
-            }
-        }
-        TypeDiff::Compatible(diff)
+    /// Count the number of registers that store a different operand from `dst`.
+    pub fn diff(&self, dst: RegMapping) -> usize {
+        self.0.iter().enumerate().filter(|&(reg_idx, &reg)| reg != dst.0[reg_idx]).count()
     }
 }
 
@@ -2240,13 +2224,12 @@ fn find_block_version(blockid: BlockId, ctx: &Context) -> Option<BlockRef> {
     return best_version;
 }
 
-/// Basically find_block_version() but allows RegMapping incompatibility
-/// that can be fixed by register moves and returns Context
-pub fn find_block_ctx_with_same_regs(blockid: BlockId, ctx: &Context) -> Option<Context> {
+/// Find the closest RegMapping among ones that have already been compiled.
+pub fn find_most_compatible_reg_mapping(blockid: BlockId, ctx: &Context) -> Option<RegMapping> {
     let versions = get_version_list(blockid)?;
 
     // Best match found
-    let mut best_ctx: Option<Context> = None;
+    let mut best_mapping: Option<RegMapping> = None;
     let mut best_diff = usize::MAX;
 
     // For each version matching the blockid
@@ -2254,17 +2237,17 @@ pub fn find_block_ctx_with_same_regs(blockid: BlockId, ctx: &Context) -> Option<
         let block = unsafe { blockref.as_ref() };
         let block_ctx = Context::decode(block.ctx);
 
-        // Discover the best block that is compatible if we move registers
-        match ctx.diff_with_same_regs(&block_ctx) {
+        // Discover the best block that is compatible if we load/spill registers
+        match ctx.diff_allowing_reg_mismatch(&block_ctx) {
             TypeDiff::Compatible(diff) if diff < best_diff => {
-                best_ctx = Some(block_ctx);
+                best_mapping = Some(block_ctx.get_reg_mapping());
                 best_diff = diff;
             }
             _ => {}
         }
     }
 
-    best_ctx
+    best_mapping
 }
 
 /// Allow inlining a Block up to MAX_INLINE_VERSIONS times.
@@ -2596,6 +2579,14 @@ impl Context {
         self.sp_opnd(-ep_offset + offset)
     }
 
+    /// Start using a register for a given stack temp or a local.
+    pub fn alloc_reg(&mut self, opnd: RegOpnd) {
+        let mut reg_mapping = self.get_reg_mapping();
+        if reg_mapping.alloc_reg(opnd) {
+            self.set_reg_mapping(reg_mapping);
+        }
+    }
+
     /// Stop using a register for a given stack temp or a local.
     /// This allows us to reuse the register for a value that we know is dead
     /// and will no longer be used (e.g. popped stack temp).
@@ -2898,19 +2889,26 @@ impl Context {
         return TypeDiff::Compatible(diff);
     }
 
-    /// Basically diff() but allows RegMapping incompatibility that can be fixed
-    /// by register moves.
-    pub fn diff_with_same_regs(&self, dst: &Context) -> TypeDiff {
+    /// Basically diff() but allows RegMapping incompatibility that could be fixed by
+    /// spilling, loading, or shuffling registers.
+    pub fn diff_allowing_reg_mismatch(&self, dst: &Context) -> TypeDiff {
+        // We shuffle only RegOpnd::Local and spill any other RegOpnd::Stack.
+        // If dst has RegOpnd::Stack, we can't reuse the block as a callee.
+        for reg_opnd in dst.get_reg_mapping().get_reg_opnds() {
+            if matches!(reg_opnd, RegOpnd::Stack(_)) {
+                return TypeDiff::Incompatible;
+            }
+        }
+
         // Prepare a Context with the same registers
         let mut dst_with_same_regs = dst.clone();
         dst_with_same_regs.set_reg_mapping(self.get_reg_mapping());
 
         // Diff registers and other stuff separately, and merge them
-        match (self.diff(&dst_with_same_regs), self.get_reg_mapping().diff(dst.get_reg_mapping())) {
-            (TypeDiff::Compatible(ctx_diff), TypeDiff::Compatible(reg_diff)) => {
-                TypeDiff::Compatible(ctx_diff + reg_diff)
-            }
-            _ => TypeDiff::Incompatible
+        if let TypeDiff::Compatible(ctx_diff) = self.diff(&dst_with_same_regs) {
+            TypeDiff::Compatible(ctx_diff + self.get_reg_mapping().diff(dst.get_reg_mapping()))
+        } else {
+            TypeDiff::Incompatible
         }
     }
 


### PR DESCRIPTION
This PR improves the argument register allocator in `gen_send_iseq` to reuse existing blocks with different registers.  It previously allowed only moving operands already in a register, but this PR also allows spilling and loading registers. It allows YJIT to avoid compiling duplicated blocks to handle different `RegMapping` variations in most cases.

## YJIT stats
On lobsters, it reduces compilation time and inline_code_size by 3.3% (48ms and 154KB).

### Before
```
compiled_block_count:   71,284
inline_code_size:    4,728,964
outlined_code_size:  4,404,724
code_region_size:   11,628,544
yjit_alloc_size:    26,731,381
yjit_compile_time:   1464.60ms
```

### After
```
compiled_block_count:     68,339
inline_code_size:      4,574,334
outlined_code_size:    4,060,763
code_region_size:     11,157,504
yjit_alloc_size:      25,974,041
yjit_compile_time:     1416.86ms
```

## Benchmark
It seems to have a positive impact on multiple benchmarks. `chunky-png`, `erubi-rails`, `liquid-compile`, and `ruby-lsp` show 4-5% improvements. `activerecord`, `hexapdf`, and `psych-load` are 1% better too.

```
before: ruby 3.4.0dev (2024-12-07T10:02:17Z master bd831bcca5) +YJIT +PRISM [x86_64-linux]
after: ruby 3.4.0dev (2024-12-08T09:06:52Z yjit-reg-reuse 91c1d394f7) +YJIT +PRISM [x86_64-linux]

--------------  -----------  ----------  ----------  ----------  -------------  ------------
bench           before (ms)  stddev (%)  after (ms)  stddev (%)  after 1st itr  before/after
activerecord    97.3         0.3         95.8        0.2         1.034          1.016
chunky-png      250.0        0.4         239.1       0.3         1.043          1.046
erubi-rails     486.8        0.2         466.6       0.2         1.042          1.043
hexapdf         1040.9       2.1         1022.1      2.0         1.092          1.018
liquid-c        30.4         0.9         30.5        0.9         1.026          0.997
liquid-compile  34.1         0.8         32.6        2.7         1.021          1.047
liquid-render   40.8         0.6         41.1        0.6         1.021          0.991
lobsters        510.8        2.0         507.2       1.5         1.016          1.007
mail            70.4         0.3         70.4        0.3         1.022          1.000
psych-load      972.9        0.1         957.1       0.1         1.023          1.017
railsbench      1200.5       1.5         1197.6      2.7         1.037          1.002
rubocop         61.9         4.4         61.4        4.1         1.031          1.007
ruby-lsp        72.4         0.9         68.6        0.7         1.018          1.056
sequel          34.0         0.4         33.8        0.4         0.999          1.005
--------------  -----------  ----------  ----------  ----------  -------------  ------------
```