### PR TITLE
Bug: Fix range.rb to raise ArgErr when calling step(0) for ranges with string or symbol

### DIFF
--- a/range.c
+++ b/range.c
@@ -508,7 +508,7 @@ range_step(int argc, VALUE *argv, VALUE range)
 
     const VALUE step_num_p = rb_obj_is_kind_of(step, rb_cNumeric);
 
-    if (step_num_p && b_num_p && rb_equal(step, INT2FIX(0))) {
+    if (step_num_p && (b_num_p | str_b | sym_b) && rb_equal(step, INT2FIX(0))) {
         rb_raise(rb_eArgError, "step can't be 0");
     }
 

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -322,6 +322,11 @@ class TestRange < Test::Unit::TestCase
       assert_raise(ArgumentError) { (from..to).step(0) {} }
       assert_raise(ArgumentError) { (from..to).step(0) }
 
+      assert_raise(ArgumentError) { ("a".."c").step(0) {}}
+      assert_raise(ArgumentError) { ("a".."c").step(0) }
+      assert_raise(ArgumentError) { (:a..:c).step(0) {}}
+      assert_raise(ArgumentError) { (:a..:c).step(0) }
+
       # default step
 
       a = []


### PR DESCRIPTION
This PR is to fix the current 3.4-dev's behavior of `Range#step` when calling `step(0)` on string or symbol ranges such as `('a'..'c').step(0)` or `(:a..:c).step(0)`.

See the following article and the [comments](https://zverok.space/blog/2024-07-26-range-evolution.html#comment-6552115538) for the detail:

* [How it became like this? Ruby Range class](https://zverok.space/blog/2024-07-26-range-evolution.html)

zverok, the author of the article, agreed on the reply to the comment that the following behavior is a small but a nasty bug, but it seems that he might have been too busy to fix the bug, so I sent the PR instead.

## Expected behavior

`step(0)` should raise ArgumentError on string/symbol ranges as integer ranges:

```ruby
# checked with the current 3.3.6 or earlier:
(1..5).step(0)
#=> 'step': step can't be 0 (ArgumentError)
('a'..'c').step(0)
#=> `step': step can't be 0 (ArgumentError)
(:a..:c).step(0)
#=> `step': step can't be 0 (ArgumentError)
```

Note that the current 3.3.6 or earlier has not been affected by the bug.

## Actual behavior on current 3.4-dev

> ruby 3.4.0dev (2024-12-08T23:14:18Z master 895f2c2152) +YJIT +PRISM [arm64-darwin24]

`step(0)` does not raise ArgumentError on string/symbol ranges while integer ranges raises:

```ruby
(1..5).step(0)
#=> 'step': step can't be 0 (ArgumentError)
('a'..'c').step(0)
#=> #<Enumerator: ...>
(:a..:c).step(0)
#=> #<Enumerator: ...>
```

(This is my first PR to Ruby)
Best regards, 