### PR TITLE
Use `rb_thread_fd_select` instead of select(2)

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -228,6 +228,7 @@ struct fast_fallback_inetsock_arg
     int additional_flags;
     struct fast_fallback_getaddrinfo_entry *getaddrinfo_entries[2];
     struct fast_fallback_getaddrinfo_shared *getaddrinfo_shared;
+    rb_fdset_t readfds, writefds;
     int wait;
     int connection_attempt_fds_size;
     int *connection_attempt_fds;
@@ -281,43 +282,6 @@ reallocate_connection_attempt_fds(int **fds, int current_capacity, int additiona
 
     for (int i = current_capacity; i < new_capacity; i++) (*fds)[i] = -1;
     return new_capacity;
-}
-
-struct wait_fast_fallback_arg
-{
-    int status, nfds;
-    fd_set *readfds, *writefds;
-    struct timeval *delay;
-    int *cancelled;
-};
-
-static void *
-wait_fast_fallback(void *ptr)
-{
-    struct wait_fast_fallback_arg *arg = (struct wait_fast_fallback_arg *)ptr;
-    int status;
-    status = select(arg->nfds, arg->readfds, arg->writefds, NULL, arg->delay);
-    arg->status = status;
-    if (errno == EINTR) *arg->cancelled = true;
-    return 0;
-}
-
-static void
-cancel_fast_fallback(void *ptr)
-{
-    if (!ptr) return;
-
-    struct fast_fallback_getaddrinfo_shared *arg = (struct fast_fallback_getaddrinfo_shared *)ptr;
-
-    rb_nativethread_lock_lock(&arg->lock);
-    {
-        arg->cancelled = true;
-        char notification = SELECT_CANCELLED;
-        if (arg->notify != -1 && (write(arg->notify, &notification, 1)) < 0) {
-            rb_syserr_fail(errno, "write(2)");
-        }
-    }
-    rb_nativethread_lock_unlock(&arg->lock);
 }
 
 struct hostname_resolution_result
@@ -556,13 +520,11 @@ init_fast_fallback_inetsock_internal(VALUE v)
     ssize_t resolved_type_size;
     int hostname_resolution_waiter = -1, hostname_resolution_notifier = -1;
     int pipefd[2];
-    fd_set readfds, writefds;
 
-    struct wait_fast_fallback_arg wait_arg;
+    int nfds = 0;
     struct timeval *ends_at = NULL;
     struct timeval delay = (struct timeval){ -1, -1 };
-    wait_arg.writefds = &writefds;
-    wait_arg.status = 0;
+    struct timeval *delay_p = NULL;
 
     struct hostname_resolution_store resolution_store;
     resolution_store.is_all_finised = false;
@@ -590,7 +552,6 @@ init_fast_fallback_inetsock_internal(VALUE v)
     arg->wait = hostname_resolution_waiter;
 
     hostname_resolution_notifier = pipefd[1];
-    wait_arg.readfds = &readfds;
 
     arg->getaddrinfo_shared = allocate_fast_fallback_getaddrinfo_shared(arg->family_size);
     if (!arg->getaddrinfo_shared) rb_syserr_fail(errno, "calloc(3)");
@@ -598,8 +559,6 @@ init_fast_fallback_inetsock_internal(VALUE v)
     rb_nativethread_lock_initialize(&arg->getaddrinfo_shared->lock);
 
     arg->getaddrinfo_shared->notify = hostname_resolution_notifier;
-    arg->getaddrinfo_shared->cancelled = false;
-    wait_arg.cancelled = &arg->getaddrinfo_shared->cancelled;
 
     struct timeval resolution_delay_storage;
     struct timeval *resolution_delay_expires_at = NULL;
@@ -896,41 +855,33 @@ init_fast_fallback_inetsock_internal(VALUE v)
         );
         if (ends_at) {
             delay = tv_to_timeout(ends_at, now);
-            wait_arg.delay = &delay;
+            delay_p = &delay;
         } else {
-            wait_arg.delay = NULL;
+            delay_p = NULL;
         }
 
-        wait_arg.nfds = 0;
-        FD_ZERO(wait_arg.writefds);
+        nfds = 0;
+        rb_fd_zero(&arg->writefds);
         if (in_progress_fds(arg->connection_attempt_fds_size)) {
             int n = 0;
             for (int i = 0; i < arg->connection_attempt_fds_size; i++) {
                 int cfd = arg->connection_attempt_fds[i];
                 if (cfd < 0) continue;
                 if (cfd > n) n = cfd;
-                FD_SET(cfd, wait_arg.writefds);
+                rb_fd_set(cfd, &arg->writefds);
             }
             if (n > 0) n++;
-            wait_arg.nfds = n;
+            nfds = n;
         }
 
-        FD_ZERO(wait_arg.readfds);
-        FD_SET(hostname_resolution_waiter, wait_arg.readfds);
-        if ((hostname_resolution_waiter + 1) > wait_arg.nfds) {
-            wait_arg.nfds = hostname_resolution_waiter + 1;
+        rb_fd_zero(&arg->readfds);
+        rb_fd_set(hostname_resolution_waiter, &arg->readfds);
+
+        if ((hostname_resolution_waiter + 1) > nfds) {
+            nfds = hostname_resolution_waiter + 1;
         }
 
-        rb_thread_call_without_gvl2(
-            wait_fast_fallback,
-            &wait_arg,
-            cancel_fast_fallback,
-            arg->getaddrinfo_shared
-        );
-        rb_thread_check_ints();
-        if (errno == EINTR || arg->getaddrinfo_shared->cancelled) break;
-
-        status = wait_arg.status;
+        status = rb_thread_fd_select(nfds, &arg->readfds, &arg->writefds, NULL, delay_p);
         syscall = "select(2)";
 
         now = current_clocktime_ts();
@@ -948,7 +899,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
             if (in_progress_fds(arg->connection_attempt_fds_size)) {
                 for (int i = 0; i < arg->connection_attempt_fds_size; i++) {
                     int fd = arg->connection_attempt_fds[i];
-                    if (fd < 0 || !FD_ISSET(fd, wait_arg.writefds)) continue;
+                    if (fd < 0 || !rb_fd_isset(fd, &arg->writefds)) continue;
 
                     int err;
                     socklen_t len = sizeof(err);
@@ -1021,7 +972,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
             }
 
             /* check for hostname resolution */
-            if (!resolution_store.is_all_finised && FD_ISSET(hostname_resolution_waiter, wait_arg.readfds)) {
+            if (!resolution_store.is_all_finised && rb_fd_isset(hostname_resolution_waiter, &arg->readfds)) {
                 while (true) {
                     resolved_type_size = read(
                         hostname_resolution_waiter,
@@ -1087,7 +1038,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                 }
             }
 
-            status = wait_arg.status = 0;
+            status = 0;
         }
 
         if (!resolution_store.is_all_finised) {
@@ -1160,8 +1111,6 @@ init_fast_fallback_inetsock_internal(VALUE v)
         }
     }
 
-    rb_thread_check_ints();
-
     if (NIL_P(arg->io)) {
         /* create new instance */
         arg->io = rsock_init_sock(arg->self, connected_fd);
@@ -1229,6 +1178,9 @@ fast_fallback_inetsock_cleanup(VALUE v)
             close(connection_attempt_fd);
        }
     }
+
+    if (arg->readfds.fdset) rb_fd_term(&arg->readfds);
+    if (arg->writefds.fdset) rb_fd_term(&arg->writefds);
 
     if (arg->connection_attempt_fds) {
         free(arg->connection_attempt_fds);
@@ -1311,6 +1263,9 @@ rsock_init_inetsock(VALUE self, VALUE remote_host, VALUE remote_serv, VALUE loca
             fast_fallback_arg.families = resolving_families;
             fast_fallback_arg.family_size = resolving_family_size;
             fast_fallback_arg.test_mode_settings = test_mode_settings;
+
+            rb_fd_init(&fast_fallback_arg.readfds);
+            rb_fd_init(&fast_fallback_arg.writefds);
 
             return rb_ensure(init_fast_fallback_inetsock_internal, (VALUE)&fast_fallback_arg,
                              fast_fallback_inetsock_cleanup, (VALUE)&fast_fallback_arg);

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -3095,19 +3095,12 @@ do_fast_fallback_getaddrinfo(void *ptr)
     rb_nativethread_lock_lock(&shared->lock);
     {
         entry->err = err;
-        if (shared->cancelled) {
-            if (entry->ai) {
-                freeaddrinfo(entry->ai);
-                entry->ai = NULL;
-            }
-        } else {
-            const char notification = entry->family == AF_INET6 ?
-            IPV6_HOSTNAME_RESOLVED : IPV4_HOSTNAME_RESOLVED;
+        const char notification = entry->family == AF_INET6 ?
+        IPV6_HOSTNAME_RESOLVED : IPV4_HOSTNAME_RESOLVED;
 
-            if (shared->notify != -1 && (write(shared->notify, &notification, 1)) < 0) {
-                entry->err = errno;
-                entry->has_syserr = true;
-            }
+        if (shared->notify != -1 && (write(shared->notify, &notification, 1)) < 0) {
+            entry->err = errno;
+            entry->has_syserr = true;
         }
         if (--(entry->refcount) == 0) need_free = 1;
         if (--(shared->refcount) == 0) shared_need_free = 1;

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -441,7 +441,6 @@ struct fast_fallback_getaddrinfo_entry
 struct fast_fallback_getaddrinfo_shared
 {
     int notify, refcount;
-    int cancelled;
     char *node, *service;
     rb_nativethread_lock_t lock;
     struct fast_fallback_getaddrinfo_entry getaddrinfo_entries[FLEX_ARY_LEN];


### PR DESCRIPTION
For fixing https://bugs.ruby-lang.org/issues/20932 .
`TCPSocket.new`, which internally uses select(2) for HEv2, can cause SEGV if the number of file descriptors exceeds `FD_SETSIZE`.
This change avoids that issue by replacing select(2) with `rb_thread_fd_select`, which is provided as part of Ruby's internal API.