### PR TITLE
Fix Cntrl, Graph and Print character properties of Cf characters.

### DIFF
--- a/tool/enc-unicode.rb
+++ b/tool/enc-unicode.rb
@@ -142,7 +142,7 @@ def define_posix_props(data)
   data['Alnum'] = data['Alpha'] + data['Digit']
   data['Space'] = data['White_Space']
   data['Blank'] = data['Space_Separator'] + [0x0009]
-  data['Cntrl'] = data['Cc']
+  data['Cntrl'] = data['Cc'] + data['Cf']
   data['Word'] = data['Alpha'] + data['Mark'] + data['Digit'] + data['Connector_Punctuation']
   data['Graph'] = data['Any'] - data['Space'] - data['Cntrl'] -
     data['Surrogate'] - data['Unassigned']


### PR DESCRIPTION
Currently the invisible characters like BOM and other formatting characters from the `Cf `category are part of the `Graph` and `Print` group, which I believe is wrong, as they do not match the "Non-blank character (excludes spaces, control characters, and similar)" definition at all.  This change makes them part of `Cntrl` group instead.

Alternatively, if this is not accepted, at least the documentation of the `Graph` group should mention that it actually includes these characters, otherwise people might get burned by assuming they are not.