### PR TITLE
Add missing fiber nil check to avoid slow rb_check_funcall()

### DIFF
--- a/process.c
+++ b/process.c
@@ -1200,8 +1200,10 @@ rb_process_status_wait(rb_pid_t pid, int flags)
     // We only enter the scheduler if we are "blocking":
     if (!(flags & WNOHANG)) {
         VALUE scheduler = rb_fiber_scheduler_current();
-        VALUE result = rb_fiber_scheduler_process_wait(scheduler, pid, flags);
-        if (!UNDEF_P(result)) return result;
+        if (scheduler != Qnil) {
+            VALUE result = rb_fiber_scheduler_process_wait(scheduler, pid, flags);
+            if (!UNDEF_P(result)) return result;
+        }
     }
 
     struct waitpid_state waitpid_state;


### PR DESCRIPTION
Check for nil like other callers of rb_fiber_scheduler_current().
