### PR TITLE
Launchable: Remove unnecessary command `launchable verify`

### DIFF
--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -133,7 +133,6 @@ runs:
       run: |
         set -x
         pip install --user launchable
-        launchable verify || true
         : # The build name cannot include a slash, so we replace the string here.
         github_ref="${{ github.ref }}"
         github_ref="${github_ref//\//_}"


### PR DESCRIPTION
`launchable verify` command is designed for checking if CLI has been configured successfully. We've already checked it, so we don't need calling this command anymore.