### PR TITLE
[Bug #20941] Bail out when recursing no memory

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4446,6 +4446,13 @@ rb_memerror(void)
     EC_JUMP_TAG(ec, TAG_RAISE);
 }
 
+bool
+rb_memerror_reentered(void)
+{
+    rb_execution_context_t *ec = GET_EC();
+    return (ec && rb_ec_raised_p(ec, RAISED_NOMEMORY));
+}
+
 void
 rb_malloc_info_show_results(void)
 {

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2470,6 +2470,9 @@ newobj_slowpath(VALUE klass, VALUE flags, rb_objspace_t *objspace, rb_ractor_new
             if (during_gc) {
                 dont_gc_on();
                 during_gc = 0;
+                if (rb_memerror_reentered()) {
+                    rb_memerror();
+                }
                 rb_bug("object allocation during garbage collection phase");
             }
 

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -69,6 +69,7 @@ uint32_t rb_gc_rebuild_shape(VALUE obj, size_t heap_id);
 size_t rb_obj_memsize_of(VALUE obj);
 void rb_gc_prepare_heap_process_object(VALUE obj);
 bool ruby_free_at_exit_p(void);
+bool rb_memerror_reentered(void);
 
 #if USE_MODULAR_GC
 bool rb_gc_event_hook_required_p(rb_event_flag_t event);


### PR DESCRIPTION
[[Bug #20941]](https://bugs.ruby-lang.org/issues/20941)