### PR TITLE
Use ruby_strdup/xfree in fast_fallback

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -592,8 +592,8 @@ init_fast_fallback_inetsock_internal(VALUE v)
         rb_nativethread_lock_initialize(&arg->getaddrinfo_shared->lock);
         arg->getaddrinfo_shared->notify = hostname_resolution_notifier;
 
-        arg->getaddrinfo_shared->node = arg->hostp ? strdup(arg->hostp) : NULL;
-        arg->getaddrinfo_shared->service = strdup(arg->portp);
+        arg->getaddrinfo_shared->node = arg->hostp ? ruby_strdup(arg->hostp) : NULL;
+        arg->getaddrinfo_shared->service = ruby_strdup(arg->portp);
         arg->getaddrinfo_shared->refcount = arg->family_size + 1;
 
         for (int i = 0; i < arg->family_size; i++) {

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -3029,9 +3029,9 @@ rsock_io_socket_addrinfo(VALUE io, struct sockaddr *addr, socklen_t len)
 void
 free_fast_fallback_getaddrinfo_shared(struct fast_fallback_getaddrinfo_shared **shared)
 {
-    free((*shared)->node);
+    xfree((*shared)->node);
     (*shared)->node = NULL;
-    free((*shared)->service);
+    xfree((*shared)->service);
     (*shared)->service = NULL;
     rb_nativethread_lock_destroy(&(*shared)->lock);
     free(*shared);


### PR DESCRIPTION
Any memory allocated with `xmalloc` needs to be matched with `xfree` rather than plain `free`.

Ruby unfortunately [redefines `strdup` to be `ruby_strdup`](https://github.com/ruby/ruby/blob/34e68548d43175c5d496b533dec280e935a8d2d5/include/ruby/util.h#L179-L187), which uses `xmalloc` so needs to be `xfree`d. Previously these were mismatched.

This commit changes the copy to be an explicit `ruby_strdup` (to avoid confusion) and the free to be `xfree`.