### PR TITLE
Use malloc for prism string source

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -10840,7 +10840,7 @@ pm_read_file(pm_string_t *string, const char *filepath)
         }
 
         size_t length = (size_t) len;
-        uint8_t *source = xmalloc(length);
+        uint8_t *source = malloc(length);
         memcpy(source, RSTRING_PTR(contents), length);
         *string = (pm_string_t) { .type = PM_STRING_OWNED, .source = source, .length = length };
 


### PR DESCRIPTION
Prism will later free this string via free rather than xfree, so we need to use malloc rather than xmalloc.

Compiling with ASAN and `-DCALC_EXACT_MALLOC_SIZE`

```
TestRubyOptions#test_null_script [/home/jhawthorn/src/ruby/test/ruby/test_rubyoptions.rb:1321]:
pid 3848197 exit 1
| =================================================================
| ==3848197==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x502000000d18 in thread T0
|     #0 0x5ac0bfb37336 in free /home/runner/work/llvm-project/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:52:3
|     #1 0x5ac0bff626d4 in pm_parse_result_free /home/jhawthorn/src/ruby/./prism_compile.c:10103:5
|     #2 0x5ac0bfcf3ebb in process_options /home/jhawthorn/src/ruby/ruby.c:2618:13
|     #3 0x5ac0bfcf2a6f in ruby_process_options /home/jhawthorn/src/ruby/ruby.c:3169:12
|     #4 0x5ac0bfb7b1a8 in ruby_options /home/jhawthorn/src/ruby/eval.c:117:16
|     #5 0x5ac0bfb77d5b in rb_main /home/jhawthorn/src/ruby/./main.c:43:26
|     #6 0x5ac0bfb77c37 in main /home/jhawthorn/src/ruby/./main.c:68:12
|     #7 0x7b270fcd9e07 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
|     #8 0x7b270fcd9ecb in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:360:3
|     #9 0x5ac0bfa98324 in _start (/home/jhawthorn/src/ruby/ruby+0x174324)
|
| 0x502000000d18 is located 8 bytes inside of 9-byte region [0x502000000d10,0x502000000d19)
| allocated by thread T0 here:
|     #0 0x5ac0bfb375cf in malloc /home/runner/work/llvm-project/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
|     #1 0x5ac0bfbb1ea3 in rb_gc_impl_malloc /home/jhawthorn/src/ruby/./gc/default/default.c:8202:5
|     #2 0x5ac0bfb9b6b8 in ruby_xmalloc /home/jhawthorn/src/ruby/gc.c:4478:34
|     #3 0x5ac0bff62b38 in pm_read_file /home/jhawthorn/src/ruby/./prism_compile.c:10843:27
|     #4 0x5ac0bff6278c in pm_load_file /home/jhawthorn/src/ruby/./prism_compile.c:10882:43
|     #5 0x5ac0bfcfb6fc in prism_script /home/jhawthorn/src/ruby/ruby.c:2209:17
|     #6 0x5ac0bfcf394d in process_options /home/jhawthorn/src/ruby/ruby.c:2538:9
|     #7 0x5ac0bfcf2a6f in ruby_process_options /home/jhawthorn/src/ruby/ruby.c:3169:12
|     #8 0x5ac0bfb7b1a8 in ruby_options /home/jhawthorn/src/ruby/eval.c:117:16
|     #9 0x5ac0bfb77d5b in rb_main /home/jhawthorn/src/ruby/./main.c:43:26
|     #10 0x5ac0bfb77c37 in main /home/jhawthorn/src/ruby/./main.c:68:12
|     #11 0x7b270fcd9e07 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
|     #12 0x7b270fcd9ecb in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:360:3
|     #13 0x5ac0bfa98324 in _start (/home/jhawthorn/src/ruby/ruby+0x174324)
|
| SUMMARY: AddressSanitizer: bad-free /home/jhawthorn/src/ruby/./prism_compile.c:10103:5 in pm_parse_result_free
| ==3848197==ABORTING
```