### PR TITLE
Fix compilation with MALLOC_ALLOCATED_SIZE

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -8037,9 +8037,9 @@ objspace_malloc_increase_body(rb_objspace_t *objspace, void *mem, size_t new_siz
     }
     else {
         size_t dec_size = old_size - new_size;
-        size_t allocated_size = objspace->malloc_params.allocated_size;
 
 #if MALLOC_ALLOCATED_SIZE_CHECK
+        size_t allocated_size = objspace->malloc_params.allocated_size;
         if (allocated_size < dec_size) {
             rb_bug("objspace_malloc_increase: underflow malloc_params.allocated_size.");
         }
@@ -9286,7 +9286,8 @@ rb_gc_impl_objspace_free(void *objspace_ptr)
 static VALUE
 gc_malloc_allocated_size(VALUE self)
 {
-    return UINT2NUM(rb_objspace.malloc_params.allocated_size);
+    rb_objspace_t *objspace = (rb_objspace_t *)rb_gc_get_objspace();
+    return ULL2NUM(objspace->malloc_params.allocated_size);
 }
 
 /*
@@ -9301,7 +9302,8 @@ gc_malloc_allocated_size(VALUE self)
 static VALUE
 gc_malloc_allocations(VALUE self)
 {
-    return UINT2NUM(rb_objspace.malloc_params.allocations);
+    rb_objspace_t *objspace = (rb_objspace_t *)rb_gc_get_objspace();
+    return ULL2NUM(objspace->malloc_params.allocations);
 }
 #endif
 


### PR DESCRIPTION
Previously compilation failed with `-DMALLOC_ALLOCATED_SIZE=1`