### PR TITLE
Launchable: Refactor entrypoint.sh

### DIFF
--- a/.github/actions/compilers/entrypoint.sh
+++ b/.github/actions/compilers/entrypoint.sh
@@ -70,7 +70,7 @@ if [[ -n "${INPUT_STATIC_EXTS}" ]]; then
     echo "::endgroup::"
 fi
 
-ruby_test_opts=''
+btests=''
 tests=''
 
 # Launchable
@@ -80,18 +80,47 @@ setup_launchable() {
     # As a workaround, we set LAUNCHABLE_SESSION_DIR to ${builddir}.
     export LAUNCHABLE_SESSION_DIR=${builddir}
     local github_ref="${GITHUB_REF//\//_}"
-    boot_report_path='launchable_bootstraptest.json'
+    local build_name="${github_ref}"_"${GITHUB_PR_HEAD_SHA}"
+    btest_report_path='launchable_bootstraptest.json'
     test_report_path='launchable_test_all.json'
-    ruby_test_opts+=--launchable-test-reports="${boot_report_path}"
-    tests+=--launchable-test-reports="${test_report_path}"
-    grouped launchable record build --name "${github_ref}"_"${GITHUB_PR_HEAD_SHA}" || true
+    test_all_session_file='launchable_test_all_session.txt'
+    btest_session_file='launchable_btest_session.txt'
+    btests+=--launchable-test-reports="${btest_report_path}"
+    echo "::group::Setup Launchable"
+    launchable record build --name "${build_name}" || true
+    launchable record session \
+        --build "${build_name}" \
+        --flavor test_task=test \
+        --flavor workflow=Compilations \
+        --flavor with-gcc="${INPUT_WITH_GCC}" \
+        --flavor CFLAGS="${INPUT_CFLAGS}" \
+        --flavor CXXFLAGS="${INPUT_CXXFLAGS}" \
+        --flavor optflags="${INPUT_OPTFLAGS}" \
+        --flavor cppflags="${INPUT_CPPFLAGS}" \
+        --test-suite btest \
+        > "${builddir}"/${btest_session_file}
+    if [ "$INPUT_CHECK" = "true" ]; then
+        tests+=--launchable-test-reports="${test_report_path}"
+        launchable record session \
+            --build "${build_name}" \
+            --flavor test_task=test-all \
+            --flavor workflow=Compilations \
+            --flavor with-gcc="${INPUT_WITH_GCC}" \
+            --flavor CFLAGS="${INPUT_CFLAGS}" \
+            --flavor CXXFLAGS="${INPUT_CXXFLAGS}" \
+            --flavor optflags="${INPUT_OPTFLAGS}" \
+            --flavor cppflags="${INPUT_CPPFLAGS}" \
+            --test-suite test-all \
+            > "${builddir}"/${test_all_session_file}
+    fi
+    echo "::endgroup::"
     trap launchable_record_test EXIT
 }
 launchable_record_test() {
     pushd "${builddir}"
-    grouped launchable record tests --flavor test_task=test --test-suite bootstraptest raw "${boot_report_path}" || true
+    grouped launchable record tests --session "$(cat "${btest_session_file}")" raw "${btest_report_path}" || true
     if [ "$INPUT_CHECK" = "true" ]; then
-        grouped launchable record tests --flavor test_task=test-all --test-suite test-all raw "${test_report_path}" || true
+        grouped launchable record tests --session "$(cat "${test_all_session_file}")" raw "${test_report_path}" || true
     fi
 }
 if [ "$LAUNCHABLE_ENABLED" = "true" ]; then
@@ -102,7 +131,7 @@ pushd ${builddir}
 
 grouped make showflags
 grouped make all
-grouped make test RUBY_TESTOPTS="${ruby_test_opts}"
+grouped make test BTESTS="${btests}"
 
 [[ -z "${INPUT_CHECK}" ]] && exit 0
 


### PR DESCRIPTION
* Use `launchable record session` command to split test sessions based on test suites.
* Use BTESTS env instead of RUBY_TESTOPTS for passing CLI option to `make btest`.
* Group Launchable logs
* Add several flavors to identify the relationship between test session and GH workflow.