### PR TITLE
[Feature #20884] Reserve toplevel `Ruby` name

### DIFF
--- a/defs/id.def
+++ b/defs/id.def
@@ -101,6 +101,8 @@ firstline, predefined = __LINE__+1, %[\
   $_                                                    LASTLINE
   $~                                                    BACKREF
   $!                                                    ERROR_INFO
+
+  Ruby
 ]
 
 # VM ID         OP      Parser Token

--- a/error.c
+++ b/error.c
@@ -575,6 +575,18 @@ rb_warn_deprecated_to_remove(const char *removal, const char *fmt, const char *s
     }
 }
 
+void
+rb_warn_reserved_name(const char *coming, const char *fmt, ...)
+{
+    if (!deprecation_warning_enabled()) return;
+
+    with_warning_string_from(mesg, 0, fmt, fmt) {
+        rb_str_set_len(mesg, RSTRING_LEN(mesg) - 1);
+        rb_str_catf(mesg, " is reserved for Ruby %s\n", coming);
+        rb_warn_category(mesg, ID2SYM(id_deprecated));
+    }
+}
+
 static inline int
 end_with_asciichar(VALUE str, int c)
 {

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -1326,4 +1326,19 @@ class TestRubyOptions < Test::Unit::TestCase
     assert_ruby_status([env, "-e;"])
     assert_in_out_err([env, "-W"], "", [], /Free at exit is experimental and may be unstable/)
   end
+
+  def test_toplevel_ruby
+    reserved = ["", [], /::Ruby is reserved/]
+    env = {"RUBYOPT"=>""}
+    args = %w[-e Ruby=1]
+    assert_in_out_err([env, *args])
+    assert_in_out_err([env, "-w", *args], *reserved)
+    assert_in_out_err([env, "-W:deprecated", *args], *reserved)
+    assert_in_out_err([env, "-w", "-W:no-deprecated", *args])
+
+    args = ["-e", "class A; Ruby=1; end"]
+    assert_in_out_err([env, *args])
+    assert_in_out_err([env, "-w", *args])
+    assert_in_out_err([env, "-W:deprecated", *args])
+  end
 end

--- a/variable.c
+++ b/variable.c
@@ -3626,6 +3626,9 @@ const_set(VALUE klass, ID id, VALUE val)
             }
         }
     }
+    if (klass == rb_cObject && id == idRuby) {
+        rb_warn_reserved_name_at(3.5, "::Ruby");
+    }
 }
 
 void


### PR DESCRIPTION
[[Feature #20884]](https://bugs.ruby-lang.org/issues/20884)