### PR TITLE
[DOC] Fix the block parameter name in `Array#zip`

### DIFF
--- a/array.c
+++ b/array.c
@@ -4464,7 +4464,7 @@ take_items(VALUE obj, long n)
 /*
  *  call-seq:
  *    zip(*other_arrays) -> new_array
- *    zip(*other_arrays) {|other_array| ... } -> nil
+ *    zip(*other_arrays) {|sub_array| ... } -> nil
  *
  *  With no block given, combines +self+ with the collection of +other_arrays+;
  *  returns a new array of sub-arrays:


### PR DESCRIPTION
The array passed to the block is referenced to as a "sub-array" in the documentation.
Additionally, using `other_array` might be confusing because it could sound like part of the `other_arrays` method argument.