### PR TITLE
[DOC] Fix `LoadError`'s linking issue

### DIFF
--- a/error.c
+++ b/error.c
@@ -3392,7 +3392,7 @@ syserr_eqq(VALUE self, VALUE exc)
  *
  *  * NoMemoryError
  *  * ScriptError
- *    * {LoadError}[https://docs.ruby-lang.org/en/master/LoadError.html]
+ *    * LoadError
  *    * NotImplementedError
  *    * SyntaxError
  *  * SecurityError

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -1,8 +1,6 @@
 # -*- frozen-string-literal: true -*-
 
-# :stopdoc:
-
-module Gem::BUNDLED_GEMS
+module Gem::BUNDLED_GEMS # :nodoc:
   SINCE = {
     "matrix" => "3.1.0",
     "net-ftp" => "3.1.0",
@@ -247,7 +245,7 @@ end
 # for RubyGems without Bundler environment.
 # If loading library is not part of the default gems and the bundled gems, warn it.
 class LoadError
-  def message
+  def message # :nodoc:
     return super unless path
 
     name = path.tr("/", "-")
@@ -257,5 +255,3 @@ class LoadError
     super
   end
 end
-
-# :startdoc:


### PR DESCRIPTION
Original issue: https://github.com/ruby/rdoc/issues/1128

The problem is caused by the `# :stopdoc:` directive in `bundled_gems.rb`, which's scope covers the redefinition of `LoadError`.

Since the goal of `# :stopdoc:` is to hide the documentation of `Gem::BUNDLED_GEMS`, we can use `# :nodoc:` on it instead.

### Result

`LoadError` is now auto-linked like other classes/modules:

<img width="50%" alt="Screenshot 2024-12-12 at 12 57 29" src="https://github.com/user-attachments/assets/1cf0a0df-b53e-4de2-ad02-e3be78994bc8" />

The patched `message` method is still not included in the documentation:

<img width="50%" alt="Screenshot 2024-12-12 at 12 58 19" src="https://github.com/user-attachments/assets/63637f84-23be-48c3-b912-654c683ffbc8" />

And the `Gem::BUNDLED_GEMS` module is now properly hidden from the documentation:

**Before**

<img width="50%" alt="Screenshot 2024-12-12 at 12 59 22" src="https://github.com/user-attachments/assets/e49f4f85-ae35-4fde-9ff9-589fd5e3c70f" />

**After**

<img width="50%" alt="Screenshot 2024-12-12 at 12 59 04" src="https://github.com/user-attachments/assets/0eb0b0c4-2a2c-4836-b1b8-d8a86ac46ca5" />
