### PR TITLE
[DOC] Small fix and tweak to string literal syntax documentation

### DIFF
--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -138,46 +138,6 @@ Also \Rational numbers may be imaginary numbers.
 
 == \String Literals
 
-=== Escape Sequences
-
-Some characters can be represented as escape sequences in
-double-quoted strings,
-character literals,
-here document literals (non-quoted, double-quoted, and with backticks),
-double-quoted symbols,
-double-quoted symbol keys in Hash literals,
-Regexp literals, and
-several percent literals (<tt>%</tt>, <tt>%Q</tt>, <tt>%W</tt>, <tt>%I</tt>, <tt>%r</tt>, <tt>%x</tt>).
-
-They allow escape sequences such as <tt>\n</tt> for
-newline, <tt>\t</tt> for tab, etc.  The full list of supported escape
-sequences are as follows:
-
-  \a             bell, ASCII 07h (BEL)
-  \b             backspace, ASCII 08h (BS)
-  \t             horizontal tab, ASCII 09h (TAB)
-  \n             newline (line feed), ASCII 0Ah (LF)
-  \v             vertical tab, ASCII 0Bh (VT)
-  \f             form feed, ASCII 0Ch (FF)
-  \r             carriage return, ASCII 0Dh (CR)
-  \e             escape, ASCII 1Bh (ESC)
-  \s             space, ASCII 20h (SPC)
-  \\             backslash, \
-  \nnn           octal bit pattern, where nnn is 1-3 octal digits ([0-7])
-  \xnn           hexadecimal bit pattern, where nn is 1-2 hexadecimal digits ([0-9a-fA-F])
-  \unnnn         Unicode character, where nnnn is exactly 4 hexadecimal digits ([0-9a-fA-F])
-  \u{nnnn ...}   Unicode character(s), where each nnnn is 1-6 hexadecimal digits ([0-9a-fA-F])
-  \cx or \C-x    control character, where x is an ASCII printable character
-  \M-x           meta character, where x is an ASCII printable character
-  \M-\C-x        meta control character, where x is an ASCII printable character
-  \M-\cx         same as above
-  \c\M-x         same as above
-  \c? or \C-?    delete, ASCII 7Fh (DEL)
-  \<newline>     continuation line (empty string)
-
-The last one, <tt>\<newline></tt>, represents an empty string instead of a character.
-It is used to fold a line in a string.
-
 === Double-Quoted \String Literals
 
 The most common way of writing strings is using <tt>"</tt>:
@@ -264,6 +224,46 @@ that corresponds to a single codepoint in the script encoding:
   ?\M-\C-a #=> "\x81"
   ?\C-\M-a #=> "\x81", same as above
   ?あ      #=> "あ"
+
+=== Escape Sequences
+
+Some characters can be represented as escape sequences in
+double-quoted strings,
+character literals,
+here document literals (non-quoted, double-quoted, and with backticks),
+double-quoted symbols,
+double-quoted symbol keys in Hash literals,
+Regexp literals, and
+several percent literals (<tt>%</tt>, <tt>%Q</tt>, <tt>%W</tt>, <tt>%I</tt>, <tt>%r</tt>, <tt>%x</tt>).
+
+They allow escape sequences such as <tt>\n</tt> for
+newline, <tt>\t</tt> for tab, etc.  The full list of supported escape
+sequences are as follows:
+
+  \a             bell, ASCII 07h (BEL)
+  \b             backspace, ASCII 08h (BS)
+  \t             horizontal tab, ASCII 09h (TAB)
+  \n             newline (line feed), ASCII 0Ah (LF)
+  \v             vertical tab, ASCII 0Bh (VT)
+  \f             form feed, ASCII 0Ch (FF)
+  \r             carriage return, ASCII 0Dh (CR)
+  \e             escape, ASCII 1Bh (ESC)
+  \s             space, ASCII 20h (SPC)
+  \\             backslash, \
+  \nnn           octal bit pattern, where nnn is 1-3 octal digits ([0-7])
+  \xnn           hexadecimal bit pattern, where nn is 1-2 hexadecimal digits ([0-9a-fA-F])
+  \unnnn         Unicode character, where nnnn is exactly 4 hexadecimal digits ([0-9a-fA-F])
+  \u{nnnn ...}   Unicode character(s), where each nnnn is 1-6 hexadecimal digits ([0-9a-fA-F])
+  \cx or \C-x    control character, where x is an ASCII printable character
+  \M-x           meta character, where x is an ASCII printable character
+  \M-\C-x        meta control character, where x is an ASCII printable character
+  \M-\cx         same as above
+  \c\M-x         same as above
+  \c? or \C-?    delete, ASCII 7Fh (DEL)
+  \<newline>     continuation line (empty string)
+
+The last one, <tt>\<newline></tt>, represents an empty string instead of a character.
+It is used to fold a line in a string.
 
 === Here Document Literals
 

--- a/doc/syntax/literals.rdoc
+++ b/doc/syntax/literals.rdoc
@@ -136,7 +136,7 @@ Also \Rational numbers may be imaginary numbers.
 
   12.3ir      #=> Syntax error
 
-== Strings
+== \String Literals
 
 === Escape Sequences
 


### PR DESCRIPTION
Since https://github.com/ruby/ruby/commit/5e1001f754b34e1f0cc67563512c6036b6eb75ab, the "String Literals" link is broken on https://docs.ruby-lang.org/en/master/syntax/literals_rdoc.html

Instead of changing the anchor reference, I changed the header directly, to keep in line with other titles. I checked if there are references so `label-String` to not break other references and didn't find any, so this is probably fine?

In a separate commit, I moved the `Escape Sequence` documentation further down. I don't believe that should be the first (or even second) thing someone sees when looking up string syntax. Instead I've moved it after `Character Literal` and before `Here Document Literals` 