### PR TITLE
Fixed compatibility error with setup command and RDoc plugin on RubyGems

### DIFF
--- a/lib/rdoc/rubygems_hook.rb
+++ b/lib/rdoc/rubygems_hook.rb
@@ -270,12 +270,25 @@ end
 # `rubygems/rdoc.rb`.
 module RDoc
   class RubygemsHook
+
+    attr_accessor :generate_rdoc, :generate_ri
+
     def self.default_gem?
       !File.exist?(File.join(__dir__, "..", "rubygems_plugin.rb"))
     end
 
-    def initialize(spec)
+    def initialize(spec, generate_rdoc = false, generate_ri = true)
       @spec = spec
+      @generate_rdoc = generate_rdoc
+      @generate_ri   = generate_ri
+    end
+
+    def generate
+      # Do nothing if this is NOT a default gem.
+      return unless self.class.default_gem?
+
+      # Generate document for compatibility if this is a default gem.
+      RubyGemsHook.new(@spec, @generate_rdoc, @generate_ri).generate
     end
 
     def remove

--- a/test/rubygems/test_gem_rdoc.rb
+++ b/test/rubygems/test_gem_rdoc.rb
@@ -5,8 +5,6 @@ require_relative "helper"
 require "rubygems/rdoc"
 
 class TestGemRDoc < Gem::TestCase
-  Gem::RDoc.load_rdoc
-
   def setup
     super
 
@@ -20,10 +18,16 @@ class TestGemRDoc < Gem::TestCase
 
     install_gem @a
 
-    @hook = Gem::RDoc.new @a
+    hook_class = if defined?(RDoc::RubyGemsHook)
+        RDoc::RubyGemsHook
+      else
+        Gem::RDoc
+      end
+
+    @hook = hook_class.new @a
 
     begin
-      Gem::RDoc.load_rdoc
+      hook_class.load_rdoc
     rescue Gem::DocumentError => e
       pend e.message
     end


### PR DESCRIPTION
@mterada1228 @kou After merging https://github.com/ruby/rdoc/pull/1171, RubyGems tests are broken.

```
 10) Error:
TestGemCommandsSetupCommand#test_execute_regenerate_plugins_creates_plugins_dir_if_not_there:
NoMethodError: undefined method 'default_gem?' for an instance of RDoc::RubygemsHook
    /Users/hsbt/Documents/github.com/ruby/ruby/lib/rdoc/rubygems_hook.rb:285:in 'RDoc::RubygemsHook#generate'
    /Users/hsbt/Documents/github.com/ruby/ruby/lib/rubygems/commands/setup_command.rb:339:in 'Gem::Commands::SetupCommand#install_rdoc'
    /Users/hsbt/Documents/github.com/ruby/ruby/lib/rubygems/commands/setup_command.rb:178:in 'Gem::Commands::SetupCommand#execute'
    /Users/hsbt/Documents/github.com/ruby/ruby/test/rubygems/test_gem_commands_setup_command.rb:113:in 'TestGemCommandsSetupCommand#test_execute_regenerate_plugins_creates_plugins_dir_if_not_there'
```

First, setup_command calls `Gem::RDoc.generate` directlry in that methods. I expand to argument of `RubygemsHook.new` and added `RubygemsHook#generate` for that.

Second, `test/rubygems/test_gem_rdoc.rb` also uses `Gem::RDoc`. I added select condition of `Gem::RDoc` and `RDoc::RubyGemshook` for that. 