### PR TITLE
sprintf.c: avoid excessive rb_str_resize() calls

### DIFF
--- a/sprintf.c
+++ b/sprintf.c
@@ -66,15 +66,17 @@ sign_bits(int base, const char *p)
 #define FPREC0 128
 
 #define CHECK(l) do {\
-    int cr = ENC_CODERANGE(result);\
     RUBY_ASSERT(bsiz >= blen); \
-    while ((l) > bsiz - blen) {\
-        bsiz*=2;\
-        if (bsiz<0) rb_raise(rb_eArgError, "too big specifier");\
+    if ((l) > bsiz - blen) {\
+        while ((l) > bsiz - blen) {\
+            bsiz*=2;\
+            if (bsiz<0) rb_raise(rb_eArgError, "too big specifier");\
+        }\
+        int cr = ENC_CODERANGE(result);\
+        rb_str_resize(result, bsiz);\
+        ENC_CODERANGE_SET(result, cr);\
+        buf = RSTRING_PTR(result);\
     }\
-    rb_str_resize(result, bsiz);\
-    ENC_CODERANGE_SET(result, cr);\
-    buf = RSTRING_PTR(result);\
 } while (0)
 
 #define PUSH(s, l) do { \

--- a/sprintf.c
+++ b/sprintf.c
@@ -1062,9 +1062,9 @@ ruby__sfvwrite(register rb_printf_buffer *fp, register struct __suio *uio)
 {
     struct __siov *iov;
     VALUE result = (VALUE)fp->_bf._base;
-    char *buf = (char*)fp->_p;
+    char *buf = RSTRING_PTR(result);
     long len, n;
-    long blen = buf - RSTRING_PTR(result), bsiz = fp->_w;
+    long blen = (char *)fp->_p - buf, bsiz = fp->_w;
 
     if (RBASIC(result)->klass) {
         rb_raise(rb_eRuntimeError, "rb_vsprintf reentered");


### PR DESCRIPTION
Calling rb_str_resize() with the same length repeatedly is pointless. This is currently done every single time something is about to be appended to the result String. This makes a difference in this micro-benchmark:

    $ cat t-sprintf.yml
    prelude: |
      fmt1 = "%d"
      args1 = [1]
      fmt2 = "%d"*10000
      args2 = [1]*10000

    benchmark:
      rep1: fmt1 % args1
      rep10000: fmt2 % args2
    $ benchmark-driver -e ./miniruby-654404a9c266 -e ./miniruby ./t-sprintf.yml
    [...]
    Comparison:
                                 rep1
              ./miniruby:   7261451.0 i/s
    ./miniruby-654404a9c266:   6704623.2 i/s - 1.08x  slower

                             rep10000
              ./miniruby:      7825.9 i/s
    ./miniruby-654404a9c266:      5592.9 i/s - 1.40x  slower

