### PR TITLE
Remove unused `FIXNUM_OR` macro from compile.c

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -49,7 +49,6 @@
 #include "insns_info.inc"
 
 #define FIXNUM_INC(n, i) ((n)+(INT2FIX(i)&~FIXNUM_FLAG))
-#define FIXNUM_OR(n, i) ((n)|INT2FIX(i))
 
 typedef struct iseq_link_element {
     enum {


### PR DESCRIPTION
This PR remove unused FIXNUM_OR macro from compile.c

before:
```
❯ git grep 'FIXNUM_OR'
compile.c:#define FIXNUM_OR(n, i) ((n)|INT2FIX(i))
```

after:
```
❯ git grep 'FIXNUM_OR'

```