### PR TITLE
[PRISM] using []= to set kwargs is a syntax error

### DIFF
--- a/prism/prism.c
+++ b/prism/prism.c
@@ -13767,6 +13767,9 @@ parse_write(pm_parser_t *parser, pm_node_t *target, pm_token_t *operator, pm_nod
 
                 // Replace the name with "[]=".
                 call->name = pm_parser_constant_id_constant(parser, "[]=", 3);
+
+                // Ensure that the arguments for []= don't contain keywords
+                pm_index_arguments_check(parser, call->arguments, NULL);
                 pm_node_flag_set((pm_node_t *) call, PM_CALL_NODE_FLAGS_ATTRIBUTE_WRITE | pm_implicit_array_write_flags(value, PM_CALL_NODE_FLAGS_IMPLICIT_ARRAY));
 
                 return target;

--- a/test/prism/errors/keyword_args_in_array_assignment.txt
+++ b/test/prism/errors/keyword_args_in_array_assignment.txt
@@ -1,0 +1,3 @@
+matrix[5, axis: :y] = 8
+          ^~~~~~~~ unexpected keyword arg given in index assignment; keywords are not allowed in index assignment expressions
+


### PR DESCRIPTION
Fixes [Bug #20952]