### PR TITLE
[PRISM] Blocks are also a syntax error in array assignment

### DIFF
--- a/prism/prism.c
+++ b/prism/prism.c
@@ -13769,7 +13769,7 @@ parse_write(pm_parser_t *parser, pm_node_t *target, pm_token_t *operator, pm_nod
                 call->name = pm_parser_constant_id_constant(parser, "[]=", 3);
 
                 // Ensure that the arguments for []= don't contain keywords
-                pm_index_arguments_check(parser, call->arguments, NULL);
+                pm_index_arguments_check(parser, call->arguments, call->block);
                 pm_node_flag_set((pm_node_t *) call, PM_CALL_NODE_FLAGS_ATTRIBUTE_WRITE | pm_implicit_array_write_flags(value, PM_CALL_NODE_FLAGS_IMPLICIT_ARRAY));
 
                 return target;

--- a/test/prism/errors/block_args_in_array_assignment.txt
+++ b/test/prism/errors/block_args_in_array_assignment.txt
@@ -1,0 +1,3 @@
+matrix[5, &block] = 8
+          ^~~~~~ unexpected block arg given in index assignment; blocks are not allowed in index assignment expressions
+


### PR DESCRIPTION
Actually close [Bug #20952]