### PR TITLE
[DOC] Fix incorrect rdoc-ref links in array.rb

### DIFF
--- a/array.c
+++ b/array.c
@@ -8288,16 +8288,16 @@ rb_ary_deconstruct(VALUE ary)
  *
  *  You can create an \Array object explicitly with:
  *
- *  - An {array literal}[rdoc-ref:literals.rdoc@Array+Literals]:
+ *  - An {array literal}[rdoc-ref:syntax/literals.rdoc@Array+Literals]:
  *
  *      [1, 'one', :one, [2, 'two', :two]]
  *
- *  - A {%w or %W: string-array Literal}[rdoc-ref:literals.rdoc@25w+and+-25W-3A+String-Array+Literals]:
+ *  - A {%w or %W string-array Literal}[rdoc-ref:syntax/literals.rdoc@25w+and+-25W-3A+String-Array+Literals]:
  *
  *      %w[foo bar baz] # => ["foo", "bar", "baz"]
  *      %w[1 % *]       # => ["1", "%", "*"]
  *
- *  - A {%i pr %I: symbol-array Literal}[rdoc-ref:literals.rdoc@25i+and+-25I-3A+Symbol-Array+Literals]:
+ *  - A {%i or %I symbol-array Literal}[rdoc-ref:syntax/literals.rdoc@25i+and+-25I-3A+Symbol-Array+Literals]:
  *
  *      %i[foo bar baz] # => [:foo, :bar, :baz]
  *      %i[1 % *]       # => [:"1", :%, :*]


### PR DESCRIPTION
Because the `rdoc-ref` targets aren't correct, the links aren't properly rendered atm.

**Before**

<img width="70%" alt="Screenshot 2024-12-13 at 22 57 38" src="https://github.com/user-attachments/assets/fe92efdc-62d8-49c4-81f4-59fc8744c017" />

**After**

<img width="70%" alt="Screenshot 2024-12-13 at 23 00 59" src="https://github.com/user-attachments/assets/7183e16b-f90f-4500-a168-27060b90264f" />
