### PR TITLE
[DOC] Restore calendars page

### DIFF
--- a/doc/.document
+++ b/doc/.document
@@ -5,6 +5,7 @@ contributing
 NEWS
 syntax
 optparse
+date
 rdoc
 regexp
 rjit


### PR DESCRIPTION
This works with https://github.com/ruby/date/pull/113 to make sure `rdoc-ref` links to the calendar doc in `Date` works correctly.