### PR TITLE
[DOC] Fix broken rdoc-ref links

### DIFF
--- a/complex.c
+++ b/complex.c
@@ -2473,7 +2473,7 @@ float_arg(VALUE self)
  *
  * You can create a \Complex object from rectangular coordinates with:
  *
- * - A {complex literal}[rdoc-ref:doc/syntax/literals.rdoc@Complex+Literals].
+ * - A {complex literal}[rdoc-ref:syntax/literals.rdoc@Complex+Literals].
  * - \Method Complex.rect.
  * - \Method Kernel#Complex, either with numeric arguments or with certain string arguments.
  * - \Method String#to_c, for certain strings.

--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -628,7 +628,7 @@ class Socket < BasicSocket
   # algorithm by default.
   #
   # For details on Happy Eyeballs Version 2,
-  # see {Socket.tcp_fast_fallback=}[rdoc-ref:Socket#tcp_fast_fallback=].
+  # see {Socket.tcp_fast_fallback=}[rdoc-ref:Socket.tcp_fast_fallback=].
   #
   # To make it behave the same as in Ruby 3.3 and earlier,
   # explicitly specify the option fast_fallback:false.

--- a/ext/socket/socket.c
+++ b/ext/socket/socket.c
@@ -1870,7 +1870,7 @@ socket_s_ip_address_list(VALUE self)
  * If false, Happy Eyeballs Version 2 is disabled.
  *
  * For details on Happy Eyeballs Version 2,
- * see {Socket.tcp_fast_fallback=}[rdoc-ref:Socket#tcp_fast_fallback=].
+ * see {Socket.tcp_fast_fallback=}[rdoc-ref:Socket.tcp_fast_fallback=].
  */
 VALUE socket_s_tcp_fast_fallback(VALUE self) {
     return rb_ivar_get(rb_cSocket, tcp_fast_fallback);

--- a/ext/socket/tcpsocket.c
+++ b/ext/socket/tcpsocket.c
@@ -23,7 +23,7 @@
  * algorithm by default, except on Windows.
  *
  * For details on Happy Eyeballs Version 2,
- * see {Socket.tcp_fast_fallback=}[rdoc-ref:Socket#tcp_fast_fallback=].
+ * see {Socket.tcp_fast_fallback=}[rdoc-ref:Socket.tcp_fast_fallback=].
  *
  * To make it behave the same as in Ruby 3.3 and earlier,
  * explicitly specify the option fast_fallback:false.

--- a/re.c
+++ b/re.c
@@ -3653,7 +3653,7 @@ reg_match_pos(VALUE re, VALUE *strp, long pos, VALUE* set_match)
  *  if and only if +self+:
  *
  *  - Is a regexp literal;
- *    see {Regexp Literals}[rdoc-ref:literals.rdoc@Regexp+Literals].
+ *    see {Regexp Literals}[rdoc-ref:syntax/literals.rdoc@Regexp+Literals].
  *  - Does not contain interpolations;
  *    see {Regexp interpolation}[rdoc-ref:Regexp@Interpolation+Mode].
  *  - Is at the left of the expression.


### PR DESCRIPTION
Detected through https://github.com/ruby/rdoc/pull/1241

- Links to `Socket.tcp_fast_fallback=` should use `.` instead of `#` as it's a singleton method.
- The correct reference to the [literals page](https://docs.ruby-lang.org/en/master/syntax/literals_rdoc.html) is `syntax/literals.rdoc`.