### PR TITLE
Add back summary table for pack/unpack directives

### DIFF
--- a/doc/packed_data.rdoc
+++ b/doc/packed_data.rdoc
@@ -95,6 +95,103 @@ Both methods can accept a block:
   # The single unpacked object is passed to the block.
   'AB'.unpack1('C*') {|ele| p ele } # => 65
 
+== Summary Table of Directives
+
+This is a concise way to describe and compare the available directives.
+Keep reading below for more details about each directive.
+
+#   Integer       |         |
+#   Directive     | Type    | Meaning
+#   ----------------------------------------------------------------------------
+#   C             | Integer | 8-bit unsigned (unsigned char)
+#   S             | Integer | 16-bit unsigned, native endian (uint16_t)
+#   L             | Integer | 32-bit unsigned, native endian (uint32_t)
+#   Q             | Integer | 64-bit unsigned, native endian (uint64_t)
+#   J             | Integer | pointer width unsigned, native endian (uintptr_t)
+#                 |         |
+#   c             | Integer | 8-bit signed (signed char)
+#   s             | Integer | 16-bit signed, native endian (int16_t)
+#   l             | Integer | 32-bit signed, native endian (int32_t)
+#   q             | Integer | 64-bit signed, native endian (int64_t)
+#   j             | Integer | pointer width signed, native endian (intptr_t)
+#                 |         |
+#   S_ S!         | Integer | unsigned short, native endian
+#   I I_ I!       | Integer | unsigned int, native endian
+#   L_ L!         | Integer | unsigned long, native endian
+#   Q_ Q!         | Integer | unsigned long long, native endian (ArgumentError
+#                 |         | if the platform has no long long type.)
+#   J!            | Integer | uintptr_t, native endian (same with J)
+#                 |         |
+#   s_ s!         | Integer | signed short, native endian
+#   i i_ i!       | Integer | signed int, native endian
+#   l_ l!         | Integer | signed long, native endian
+#   q_ q!         | Integer | signed long long, native endian (ArgumentError
+#                 |         | if the platform has no long long type.)
+#   j!            | Integer | intptr_t, native endian (same with j)
+#                 |         |
+#   S> s> S!> s!> | Integer | same as the directives without ">" except
+#   L> l> L!> l!> |         | big endian
+#   I!> i!>       |         |
+#   Q> q> Q!> q!> |         | "S>" is the same as "n"
+#   J> j> J!> j!> |         | "L>" is the same as "N"
+#                 |         |
+#   S< s< S!< s!< | Integer | same as the directives without "<" except
+#   L< l< L!< l!< |         | little endian
+#   I!< i!<       |         |
+#   Q< q< Q!< q!< |         | "S<" is the same as "v"
+#   J< j< J!< j!< |         | "L<" is the same as "V"
+#                 |         |
+#   n             | Integer | 16-bit unsigned, network (big-endian) byte order
+#   N             | Integer | 32-bit unsigned, network (big-endian) byte order
+#   v             | Integer | 16-bit unsigned, VAX (little-endian) byte order
+#   V             | Integer | 32-bit unsigned, VAX (little-endian) byte order
+#                 |         |
+#   U             | Integer | UTF-8 character
+#   w             | Integer | BER-compressed integer
+#
+#   Float        |         |
+#   Directive    | Type    | Meaning
+#   ---------------------------------------------------------------------------
+#   D d          | Float   | double-precision, native format
+#   F f          | Float   | single-precision, native format
+#   E            | Float   | double-precision, little-endian byte order
+#   e            | Float   | single-precision, little-endian byte order
+#   G            | Float   | double-precision, network (big-endian) byte order
+#   g            | Float   | single-precision, network (big-endian) byte order
+#
+#   String       |         |
+#   Directive    | Type    | Meaning
+#   ---------------------------------------------------------------------------
+#   A            | String  | arbitrary binary string (remove trailing nulls and ASCII spaces)
+#   a            | String  | arbitrary binary string
+#   Z            | String  | null-terminated string
+#   B            | String  | bit string (MSB first)
+#   b            | String  | bit string (LSB first)
+#   H            | String  | hex string (high nibble first)
+#   h            | String  | hex string (low nibble first)
+#   u            | String  | UU-encoded string
+#   M            | String  | quoted-printable, MIME encoding (see RFC2045)
+#   m            | String  | base64 encoded string (RFC 2045) (default)
+#                |         | base64 encoded string (RFC 4648) if followed by 0
+#   P            | String  | pointer to a structure (fixed-length string)
+#   p            | String  | pointer to a null-terminated string
+#
+#   Misc.        |         |
+#   Directive    |         |
+#   for pack     | Type    | Meaning
+#   ---------------------------------------------------------------------------
+#   @            | ---     | moves to absolute position
+#   X            | ---     | back up a byte
+#   x            | ---     | null byte
+#
+#   Misc.        |         |
+#   Directive    |         |
+#   for unpack   | Type    | Meaning
+#   ---------------------------------------------------------------------------
+#   @            | ---     | skip to the offset given by the length argument
+#   X            | ---     | skip backward one byte
+#   x            | ---     | skip forward one byte
+
 == \Integer Directives
 
 Each integer directive specifies the packing or unpacking

--- a/doc/packed_data.rdoc
+++ b/doc/packed_data.rdoc
@@ -100,97 +100,97 @@ Both methods can accept a block:
 This is a concise way to describe and compare the available directives.
 Keep reading below for more details about each directive.
 
-#   Integer       |         |
-#   Directive     | Type    | Meaning
-#   ----------------------------------------------------------------------------
-#   C             | Integer | 8-bit unsigned (unsigned char)
-#   S             | Integer | 16-bit unsigned, native endian (uint16_t)
-#   L             | Integer | 32-bit unsigned, native endian (uint32_t)
-#   Q             | Integer | 64-bit unsigned, native endian (uint64_t)
-#   J             | Integer | pointer width unsigned, native endian (uintptr_t)
-#                 |         |
-#   c             | Integer | 8-bit signed (signed char)
-#   s             | Integer | 16-bit signed, native endian (int16_t)
-#   l             | Integer | 32-bit signed, native endian (int32_t)
-#   q             | Integer | 64-bit signed, native endian (int64_t)
-#   j             | Integer | pointer width signed, native endian (intptr_t)
-#                 |         |
-#   S_ S!         | Integer | unsigned short, native endian
-#   I I_ I!       | Integer | unsigned int, native endian
-#   L_ L!         | Integer | unsigned long, native endian
-#   Q_ Q!         | Integer | unsigned long long, native endian (ArgumentError
-#                 |         | if the platform has no long long type.)
-#   J!            | Integer | uintptr_t, native endian (same with J)
-#                 |         |
-#   s_ s!         | Integer | signed short, native endian
-#   i i_ i!       | Integer | signed int, native endian
-#   l_ l!         | Integer | signed long, native endian
-#   q_ q!         | Integer | signed long long, native endian (ArgumentError
-#                 |         | if the platform has no long long type.)
-#   j!            | Integer | intptr_t, native endian (same with j)
-#                 |         |
-#   S> s> S!> s!> | Integer | same as the directives without ">" except
-#   L> l> L!> l!> |         | big endian
-#   I!> i!>       |         |
-#   Q> q> Q!> q!> |         | "S>" is the same as "n"
-#   J> j> J!> j!> |         | "L>" is the same as "N"
-#                 |         |
-#   S< s< S!< s!< | Integer | same as the directives without "<" except
-#   L< l< L!< l!< |         | little endian
-#   I!< i!<       |         |
-#   Q< q< Q!< q!< |         | "S<" is the same as "v"
-#   J< j< J!< j!< |         | "L<" is the same as "V"
-#                 |         |
-#   n             | Integer | 16-bit unsigned, network (big-endian) byte order
-#   N             | Integer | 32-bit unsigned, network (big-endian) byte order
-#   v             | Integer | 16-bit unsigned, VAX (little-endian) byte order
-#   V             | Integer | 32-bit unsigned, VAX (little-endian) byte order
-#                 |         |
-#   U             | Integer | UTF-8 character
-#   w             | Integer | BER-compressed integer
-#
-#   Float        |         |
-#   Directive    | Type    | Meaning
-#   ---------------------------------------------------------------------------
-#   D d          | Float   | double-precision, native format
-#   F f          | Float   | single-precision, native format
-#   E            | Float   | double-precision, little-endian byte order
-#   e            | Float   | single-precision, little-endian byte order
-#   G            | Float   | double-precision, network (big-endian) byte order
-#   g            | Float   | single-precision, network (big-endian) byte order
-#
-#   String       |         |
-#   Directive    | Type    | Meaning
-#   ---------------------------------------------------------------------------
-#   A            | String  | arbitrary binary string (remove trailing nulls and ASCII spaces)
-#   a            | String  | arbitrary binary string
-#   Z            | String  | null-terminated string
-#   B            | String  | bit string (MSB first)
-#   b            | String  | bit string (LSB first)
-#   H            | String  | hex string (high nibble first)
-#   h            | String  | hex string (low nibble first)
-#   u            | String  | UU-encoded string
-#   M            | String  | quoted-printable, MIME encoding (see RFC2045)
-#   m            | String  | base64 encoded string (RFC 2045) (default)
-#                |         | base64 encoded string (RFC 4648) if followed by 0
-#   P            | String  | pointer to a structure (fixed-length string)
-#   p            | String  | pointer to a null-terminated string
-#
-#   Misc.        |         |
-#   Directive    |         |
-#   for pack     | Type    | Meaning
-#   ---------------------------------------------------------------------------
-#   @            | ---     | moves to absolute position
-#   X            | ---     | back up a byte
-#   x            | ---     | null byte
-#
-#   Misc.        |         |
-#   Directive    |         |
-#   for unpack   | Type    | Meaning
-#   ---------------------------------------------------------------------------
-#   @            | ---     | skip to the offset given by the length argument
-#   X            | ---     | skip backward one byte
-#   x            | ---     | skip forward one byte
+Integer       |         |
+Directive     | Type    | Meaning
+----------------------------------------------------------------------------
+C             | Integer | 8-bit unsigned (unsigned char)
+S             | Integer | 16-bit unsigned, native endian (uint16_t)
+L             | Integer | 32-bit unsigned, native endian (uint32_t)
+Q             | Integer | 64-bit unsigned, native endian (uint64_t)
+J             | Integer | pointer width unsigned, native endian (uintptr_t)
+              |         |
+c             | Integer | 8-bit signed (signed char)
+s             | Integer | 16-bit signed, native endian (int16_t)
+l             | Integer | 32-bit signed, native endian (int32_t)
+q             | Integer | 64-bit signed, native endian (int64_t)
+j             | Integer | pointer width signed, native endian (intptr_t)
+              |         |
+S_ S!         | Integer | unsigned short, native endian
+I I_ I!       | Integer | unsigned int, native endian
+L_ L!         | Integer | unsigned long, native endian
+Q_ Q!         | Integer | unsigned long long, native endian (ArgumentError
+              |         | if the platform has no long long type.)
+J!            | Integer | uintptr_t, native endian (same with J)
+              |         |
+s_ s!         | Integer | signed short, native endian
+i i_ i!       | Integer | signed int, native endian
+l_ l!         | Integer | signed long, native endian
+q_ q!         | Integer | signed long long, native endian (ArgumentError
+              |         | if the platform has no long long type.)
+j!            | Integer | intptr_t, native endian (same with j)
+              |         |
+S> s> S!> s!> | Integer | same as the directives without ">" except
+L> l> L!> l!> |         | big endian
+I!> i!>       |         |
+Q> q> Q!> q!> |         | "S>" is the same as "n"
+J> j> J!> j!> |         | "L>" is the same as "N"
+              |         |
+S< s< S!< s!< | Integer | same as the directives without "<" except
+L< l< L!< l!< |         | little endian
+I!< i!<       |         |
+Q< q< Q!< q!< |         | "S<" is the same as "v"
+J< j< J!< j!< |         | "L<" is the same as "V"
+              |         |
+n             | Integer | 16-bit unsigned, network (big-endian) byte order
+N             | Integer | 32-bit unsigned, network (big-endian) byte order
+v             | Integer | 16-bit unsigned, VAX (little-endian) byte order
+V             | Integer | 32-bit unsigned, VAX (little-endian) byte order
+              |         |
+U             | Integer | UTF-8 character
+w             | Integer | BER-compressed integer
+
+Float        |         |
+Directive    | Type    | Meaning
+---------------------------------------------------------------------------
+D d          | Float   | double-precision, native format
+F f          | Float   | single-precision, native format
+E            | Float   | double-precision, little-endian byte order
+e            | Float   | single-precision, little-endian byte order
+G            | Float   | double-precision, network (big-endian) byte order
+g            | Float   | single-precision, network (big-endian) byte order
+
+String       |         |
+Directive    | Type    | Meaning
+---------------------------------------------------------------------------
+A            | String  | arbitrary binary string (remove trailing nulls and ASCII spaces)
+a            | String  | arbitrary binary string
+Z            | String  | null-terminated string
+B            | String  | bit string (MSB first)
+b            | String  | bit string (LSB first)
+H            | String  | hex string (high nibble first)
+h            | String  | hex string (low nibble first)
+u            | String  | UU-encoded string
+M            | String  | quoted-printable, MIME encoding (see RFC2045)
+m            | String  | base64 encoded string (RFC 2045) (default)
+             |         | base64 encoded string (RFC 4648) if followed by 0
+P            | String  | pointer to a structure (fixed-length string)
+p            | String  | pointer to a null-terminated string
+
+Misc.        |         |
+Directive    |         |
+for pack     | Type    | Meaning
+---------------------------------------------------------------------------
+@            | ---     | moves to absolute position
+X            | ---     | back up a byte
+x            | ---     | null byte
+
+Misc.        |         |
+Directive    |         |
+for unpack   | Type    | Meaning
+---------------------------------------------------------------------------
+@            | ---     | skip to the offset given by the length argument
+X            | ---     | skip backward one byte
+x            | ---     | skip forward one byte
 
 == \Integer Directives
 

--- a/doc/packed_data.rdoc
+++ b/doc/packed_data.rdoc
@@ -1,5 +1,106 @@
 = Packed \Data
 
+== Quick Reference
+
+These tables summarize the directives for packing and unpacking.
+
+=== For Integers
+
+  Directive     | Meaning
+  --------------|---------------------------------------------------------------
+  C             | 8-bit unsigned (unsigned char)
+  S             | 16-bit unsigned, native endian (uint16_t)
+  L             | 32-bit unsigned, native endian (uint32_t)
+  Q             | 64-bit unsigned, native endian (uint64_t)
+  J             | pointer width unsigned, native endian (uintptr_t)
+
+  c             | 8-bit signed (signed char)
+  s             | 16-bit signed, native endian (int16_t)
+  l             | 32-bit signed, native endian (int32_t)
+  q             | 64-bit signed, native endian (int64_t)
+  j             | pointer width signed, native endian (intptr_t)
+
+  S_ S!         | unsigned short, native endian
+  I I_ I!       | unsigned int, native endian
+  L_ L!         | unsigned long, native endian
+  Q_ Q!         | unsigned long long, native endian
+                |   (raises ArgumentError if the platform has no long long type)
+  J!            | uintptr_t, native endian (same with J)
+
+  s_ s!         | signed short, native endian
+  i i_ i!       | signed int, native endian
+  l_ l!         | signed long, native endian
+  q_ q!         | signed long long, native endian
+                |   (raises ArgumentError if the platform has no long long type)
+  j!            | intptr_t, native endian (same with j)
+
+  S> s> S!> s!> | each the same as the directive without >, but big endian
+  L> l> L!> l!> |   S> is the same as n
+  I!> i!>       |   L> is the same as N
+  Q> q> Q!> q!> |
+  J> j> J!> j!> |
+
+  S< s< S!< s!< | each the same as the directive without <, but little endian
+  L< l< L!< l!< |   S< is the same as v
+  I!< i!<       |   L< is the same as V
+  Q< q< Q!< q!< |
+  J< j< J!< j!< |
+
+  n             | 16-bit unsigned, network (big-endian) byte order
+  N             | 32-bit unsigned, network (big-endian) byte order
+  v             | 16-bit unsigned, VAX (little-endian) byte order
+  V             | 32-bit unsigned, VAX (little-endian) byte order
+
+  U             | UTF-8 character
+  w             | BER-compressed integer
+
+=== For Floats
+
+  Directive | Meaning
+  ----------|--------------------------------------------------
+  D d       | double-precision, native format
+  F f       | single-precision, native format
+  E         | double-precision, little-endian byte order
+  e         | single-precision, little-endian byte order
+  G         | double-precision, network (big-endian) byte order
+  g         | single-precision, network (big-endian) byte order
+
+=== For Strings
+
+  Directive | Meaning
+  ----------|-----------------------------------------------------------------
+  A         | arbitrary binary string (remove trailing nulls and ASCII spaces)
+  a         | arbitrary binary string
+  Z         | null-terminated string
+  B         | bit string (MSB first)
+  b         | bit string (LSB first)
+  H         | hex string (high nibble first)
+  h         | hex string (low nibble first)
+  u         | UU-encoded string
+  M         | quoted-printable, MIME encoding (see RFC2045)
+  m         | base64 encoded string (RFC 2045) (default)
+            |   base64 encoded string (RFC 4648) if followed by 0
+  P         | pointer to a structure (fixed-length string)
+  p         | pointer to a null-terminated string
+
+=== Additional Directives for Packing
+
+  Directive | Meaning
+  ----------|----------------------------------------------------------------
+  @         | moves to absolute position
+  X         | back up a byte
+  x         | null byte
+
+=== Additional Directives for Unpacking
+
+  Directive | Meaning
+  ----------|----------------------------------------------------------------
+  @         | skip to the offset given by the length argument
+  X         | skip backward one byte
+  x         | skip forward one byte
+
+== Packing and Unpacking
+
 Certain Ruby core methods deal with packing and unpacking data:
 
 - \Method Array#pack:
@@ -94,103 +195,6 @@ Both methods can accept a block:
 
   # The single unpacked object is passed to the block.
   'AB'.unpack1('C*') {|ele| p ele } # => 65
-
-== Summary Table of Directives
-
-This is a concise way to describe and compare the available directives.
-Keep reading below for more details about each directive.
-
-Integer       |         |
-Directive     | Type    | Meaning
-----------------------------------------------------------------------------
-C             | Integer | 8-bit unsigned (unsigned char)
-S             | Integer | 16-bit unsigned, native endian (uint16_t)
-L             | Integer | 32-bit unsigned, native endian (uint32_t)
-Q             | Integer | 64-bit unsigned, native endian (uint64_t)
-J             | Integer | pointer width unsigned, native endian (uintptr_t)
-              |         |
-c             | Integer | 8-bit signed (signed char)
-s             | Integer | 16-bit signed, native endian (int16_t)
-l             | Integer | 32-bit signed, native endian (int32_t)
-q             | Integer | 64-bit signed, native endian (int64_t)
-j             | Integer | pointer width signed, native endian (intptr_t)
-              |         |
-S_ S!         | Integer | unsigned short, native endian
-I I_ I!       | Integer | unsigned int, native endian
-L_ L!         | Integer | unsigned long, native endian
-Q_ Q!         | Integer | unsigned long long, native endian (ArgumentError
-              |         | if the platform has no long long type.)
-J!            | Integer | uintptr_t, native endian (same with J)
-              |         |
-s_ s!         | Integer | signed short, native endian
-i i_ i!       | Integer | signed int, native endian
-l_ l!         | Integer | signed long, native endian
-q_ q!         | Integer | signed long long, native endian (ArgumentError
-              |         | if the platform has no long long type.)
-j!            | Integer | intptr_t, native endian (same with j)
-              |         |
-S> s> S!> s!> | Integer | same as the directives without ">" except
-L> l> L!> l!> |         | big endian
-I!> i!>       |         |
-Q> q> Q!> q!> |         | "S>" is the same as "n"
-J> j> J!> j!> |         | "L>" is the same as "N"
-              |         |
-S< s< S!< s!< | Integer | same as the directives without "<" except
-L< l< L!< l!< |         | little endian
-I!< i!<       |         |
-Q< q< Q!< q!< |         | "S<" is the same as "v"
-J< j< J!< j!< |         | "L<" is the same as "V"
-              |         |
-n             | Integer | 16-bit unsigned, network (big-endian) byte order
-N             | Integer | 32-bit unsigned, network (big-endian) byte order
-v             | Integer | 16-bit unsigned, VAX (little-endian) byte order
-V             | Integer | 32-bit unsigned, VAX (little-endian) byte order
-              |         |
-U             | Integer | UTF-8 character
-w             | Integer | BER-compressed integer
-
-Float        |         |
-Directive    | Type    | Meaning
----------------------------------------------------------------------------
-D d          | Float   | double-precision, native format
-F f          | Float   | single-precision, native format
-E            | Float   | double-precision, little-endian byte order
-e            | Float   | single-precision, little-endian byte order
-G            | Float   | double-precision, network (big-endian) byte order
-g            | Float   | single-precision, network (big-endian) byte order
-
-String       |         |
-Directive    | Type    | Meaning
----------------------------------------------------------------------------
-A            | String  | arbitrary binary string (remove trailing nulls and ASCII spaces)
-a            | String  | arbitrary binary string
-Z            | String  | null-terminated string
-B            | String  | bit string (MSB first)
-b            | String  | bit string (LSB first)
-H            | String  | hex string (high nibble first)
-h            | String  | hex string (low nibble first)
-u            | String  | UU-encoded string
-M            | String  | quoted-printable, MIME encoding (see RFC2045)
-m            | String  | base64 encoded string (RFC 2045) (default)
-             |         | base64 encoded string (RFC 4648) if followed by 0
-P            | String  | pointer to a structure (fixed-length string)
-p            | String  | pointer to a null-terminated string
-
-Misc.        |         |
-Directive    |         |
-for pack     | Type    | Meaning
----------------------------------------------------------------------------
-@            | ---     | moves to absolute position
-X            | ---     | back up a byte
-x            | ---     | null byte
-
-Misc.        |         |
-Directive    |         |
-for unpack   | Type    | Meaning
----------------------------------------------------------------------------
-@            | ---     | skip to the offset given by the length argument
-X            | ---     | skip backward one byte
-x            | ---     | skip forward one byte
 
 == \Integer Directives
 

--- a/doc/packed_data.rdoc
+++ b/doc/packed_data.rdoc
@@ -79,7 +79,7 @@ These tables summarize the directives for packing and unpacking.
   u         | UU-encoded string
   M         | quoted-printable, MIME encoding (see RFC2045)
   m         | base64 encoded string (RFC 2045) (default)
-            |   base64 encoded string (RFC 4648) if followed by 0
+            |   (base64 encoded string (RFC 4648) if followed by 0)
   P         | pointer to a structure (fixed-length string)
   p         | pointer to a null-terminated string
 


### PR DESCRIPTION
* This concise summary is very helpful e.g. to find the right Integer directive, and is much better at getting an overview than very long text.
* From https://github.com/ruby/ruby/pull/6567
* I merged the tables for Array#pack and String#unpack, there were almost the same except for String and Misc. directives.

@st0012 Is there special syntax for tables in RDoc?
I used the same markup as before (without leading `#`), so I suppose it should just work?

Note: I don't have much time to work on this, so if some small edits are wanted please just push them to this PR or merge & commit them after.

cc @st0012 @BurdetteLamar @zenspider 