### PR TITLE
[DOC] Fix broken parameter display and see links for Socket

### DIFF
--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -1590,7 +1590,7 @@ class Socket < BasicSocket
   # Returns 0 if successful, otherwise an exception is raised.
   #
   # === Parameter
-  #  # +remote_sockaddr+ - the +struct+ sockaddr contained in a string or Addrinfo object
+  # * +remote_sockaddr+ - the +struct+ sockaddr contained in a string or Addrinfo object
   #
   # === Example:
   #   # Pull down Google's web page
@@ -1625,7 +1625,7 @@ class Socket < BasicSocket
   # return the symbol +:wait_writable+ instead.
   #
   # === See
-  #  # Socket#connect
+  # * Socket#connect
   def connect_nonblock(addr, exception: true)
     __connect_nonblock(addr, exception)
   end


### PR DESCRIPTION
Fix broken parameter display and see links for the Socket doc

### Before

- Paramater
![Screenshot 2024-12-15 at 9 49 03 PM](https://github.com/user-attachments/assets/74369f48-eedd-45d2-ba37-9a72e7f5d728)

- See
![Screenshot 2024-12-15 at 10 02 53 PM](https://github.com/user-attachments/assets/e3f57fe6-c547-4aba-8a6f-0a65b94e11da)

### After

- Paramater
![Screenshot 2024-12-15 at 10 02 00 PM](https://github.com/user-attachments/assets/9a563223-6a73-4fba-b439-b5bf00f177be)

- See
![Screenshot 2024-12-15 at 10 03 04 PM](https://github.com/user-attachments/assets/06de0d40-fb42-4921-97b3-9402bdd61ba9)

