### PR TITLE
Bundle repl_type_completor 0.1.9

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -34,4 +34,4 @@ drb                 2.2.1   https://github.com/ruby/drb
 nkf                 0.2.0   https://github.com/ruby/nkf
 syslog              0.2.0   https://github.com/ruby/syslog
 csv                 3.3.1   https://github.com/ruby/csv
-repl_type_completor 0.1.7   https://github.com/ruby/repl_type_completor
+repl_type_completor 0.1.9   https://github.com/ruby/repl_type_completor


### PR DESCRIPTION
It was updated to 0.1.8 in #12351, then Rolled back to 0.1.7 because of test-bundled-gems ci failure.
0.1.9 should fix(omit) the failed test.

The failed test is omitted (omit only when run from test-bundled-gems ci) because the environment did not meet the prerequisites of the test.