### PR TITLE
Sync net-http commits

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -475,8 +475,7 @@ module Net   #:nodoc:
   #
   # - {::start}[rdoc-ref:Net::HTTP.start]:
   #   Begins a new session in a new \Net::HTTP object.
-  # - {#started?}[rdoc-ref:Net::HTTP#started?]
-  #   (aliased as {#active?}[rdoc-ref:Net::HTTP#active?]):
+  # - {#started?}[rdoc-ref:Net::HTTP#started?]:
   #   Returns whether in a session.
   # - {#finish}[rdoc-ref:Net::HTTP#finish]:
   #   Ends an active session.
@@ -556,18 +555,15 @@ module Net   #:nodoc:
   #   Sends a PUT request and returns a response object.
   # - {#request}[rdoc-ref:Net::HTTP#request]:
   #   Sends a request and returns a response object.
-  # - {#request_get}[rdoc-ref:Net::HTTP#request_get]
-  #   (aliased as {#get2}[rdoc-ref:Net::HTTP#get2]):
+  # - {#request_get}[rdoc-ref:Net::HTTP#request_get]:
   #   Sends a GET request and forms a response object;
   #   if a block given, calls the block with the object,
   #   otherwise returns the object.
-  # - {#request_head}[rdoc-ref:Net::HTTP#request_head]
-  #   (aliased as {#head2}[rdoc-ref:Net::HTTP#head2]):
+  # - {#request_head}[rdoc-ref:Net::HTTP#request_head]:
   #   Sends a HEAD request and forms a response object;
   #   if a block given, calls the block with the object,
   #   otherwise returns the object.
-  # - {#request_post}[rdoc-ref:Net::HTTP#request_post]
-  #   (aliased as {#post2}[rdoc-ref:Net::HTTP#post2]):
+  # - {#request_post}[rdoc-ref:Net::HTTP#request_post]:
   #   Sends a POST request and forms a response object;
   #   if a block given, calls the block with the object,
   #   otherwise returns the object.
@@ -605,8 +601,7 @@ module Net   #:nodoc:
   #   Returns whether +self+ is a proxy class.
   # - {#proxy?}[rdoc-ref:Net::HTTP#proxy?]:
   #   Returns whether +self+ has a proxy.
-  # - {#proxy_address}[rdoc-ref:Net::HTTP#proxy_address]
-  #   (aliased as {#proxyaddr}[rdoc-ref:Net::HTTP#proxyaddr]):
+  # - {#proxy_address}[rdoc-ref:Net::HTTP#proxy_address]:
   #   Returns the proxy address.
   # - {#proxy_from_env?}[rdoc-ref:Net::HTTP#proxy_from_env?]:
   #   Returns whether the proxy is taken from an environment variable.
@@ -718,8 +713,7 @@ module Net   #:nodoc:
   # === \HTTP Version
   #
   # - {::version_1_2?}[rdoc-ref:Net::HTTP.version_1_2?]
-  #   (aliased as {::is_version_1_2?}[rdoc-ref:Net::HTTP.is_version_1_2?]
-  #   and {::version_1_2}[rdoc-ref:Net::HTTP.version_1_2]):
+  #   (aliased as {::version_1_2}[rdoc-ref:Net::HTTP.version_1_2]):
   #   Returns true; retained for compatibility.
   #
   # === Debugging
@@ -1552,11 +1546,11 @@ module Net   #:nodoc:
     attr_accessor :cert_store
 
     # Sets or returns the available SSL ciphers.
-    # See {OpenSSL::SSL::SSLContext#ciphers=}[rdoc-ref:OpenSSL::SSL::SSLContext#ciphers-3D].
+    # See {OpenSSL::SSL::SSLContext#ciphers=}[OpenSSL::SSL::SSL::Context#ciphers=].
     attr_accessor :ciphers
 
     # Sets or returns the extra X509 certificates to be added to the certificate chain.
-    # See {OpenSSL::SSL::SSLContext#add_certificate}[rdoc-ref:OpenSSL::SSL::SSLContext#add_certificate].
+    # See {OpenSSL::SSL::SSLContext#add_certificate}[OpenSSL::SSL::SSL::Context#add_certificate].
     attr_accessor :extra_chain_cert
 
     # Sets or returns the OpenSSL::PKey::RSA or OpenSSL::PKey::DSA object.
@@ -1566,15 +1560,15 @@ module Net   #:nodoc:
     attr_accessor :ssl_timeout
 
     # Sets or returns the SSL version.
-    # See {OpenSSL::SSL::SSLContext#ssl_version=}[rdoc-ref:OpenSSL::SSL::SSLContext#ssl_version-3D].
+    # See {OpenSSL::SSL::SSLContext#ssl_version=}[OpenSSL::SSL::SSL::Context#ssl_version=].
     attr_accessor :ssl_version
 
     # Sets or returns the minimum SSL version.
-    # See {OpenSSL::SSL::SSLContext#min_version=}[rdoc-ref:OpenSSL::SSL::SSLContext#min_version-3D].
+    # See {OpenSSL::SSL::SSLContext#min_version=}[OpenSSL::SSL::SSL::Context#min_version=].
     attr_accessor :min_version
 
     # Sets or returns the maximum SSL version.
-    # See {OpenSSL::SSL::SSLContext#max_version=}[rdoc-ref:OpenSSL::SSL::SSLContext#max_version-3D].
+    # See {OpenSSL::SSL::SSLContext#max_version=}[OpenSSL::SSL::SSL::Context#max_version=].
     attr_accessor :max_version
 
     # Sets or returns the callback for the server certification verification.
@@ -1590,7 +1584,7 @@ module Net   #:nodoc:
 
     # Sets or returns whether to verify that the server certificate is valid
     # for the hostname.
-    # See {OpenSSL::SSL::SSLContext#verify_hostname=}[rdoc-ref:OpenSSL::SSL::SSLContext#attribute-i-verify_mode].
+    # See {OpenSSL::SSL::SSLContext#verify_hostname=}[OpenSSL::SSL::SSL::Context#verify_hostname=].
     attr_accessor :verify_hostname
 
     # Returns the X509 certificate chain (an array of strings)


### PR DESCRIPTION
Syncing the below commits from https://github.com/ruby/net-http/pull/199 failed:
- https://github.com/ruby/net-http/commit/9bcf818fd009eafb11107c7457aa56d533d16d94 
- https://github.com/ruby/net-http/commit/5e34e74261f40f4f10c93d7700761c437117f494