### PR TITLE
Wrap `do_fast_fallback_getaddrinfo` with `rb_thread_prevent_fork`

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -637,7 +637,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                 }
             }
 
-            if (raddrinfo_pthread_create(&threads[i], do_fast_fallback_getaddrinfo, arg->getaddrinfo_entries[i]) != 0) {
+            if (raddrinfo_pthread_create(&threads[i], fork_safe_do_fast_fallback_getaddrinfo, arg->getaddrinfo_entries[i]) != 0) {
                 rsock_raise_resolution_error("getaddrinfo(3)", EAI_AGAIN);
             }
             pthread_detach(threads[i]);

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -3048,7 +3048,7 @@ free_fast_fallback_getaddrinfo_entry(struct fast_fallback_getaddrinfo_entry **en
     *entry = NULL;
 }
 
-void *
+static void *
 do_fast_fallback_getaddrinfo(void *ptr)
 {
     struct fast_fallback_getaddrinfo_entry *entry = (struct fast_fallback_getaddrinfo_entry *)ptr;
@@ -3115,6 +3115,12 @@ do_fast_fallback_getaddrinfo(void *ptr)
     }
 
     return 0;
+}
+
+void *
+fork_safe_do_fast_fallback_getaddrinfo(void *ptr)
+{
+    return rb_thread_prevent_fork(do_fast_fallback_getaddrinfo, ptr);
 }
 
 #endif

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -447,7 +447,7 @@ struct fast_fallback_getaddrinfo_shared
 };
 
 int raddrinfo_pthread_create(pthread_t *th, void *(*start_routine) (void *), void *arg);
-void *do_fast_fallback_getaddrinfo(void *ptr);
+void *fork_safe_do_fast_fallback_getaddrinfo(void *ptr);
 void free_fast_fallback_getaddrinfo_entry(struct fast_fallback_getaddrinfo_entry **entry);
 void free_fast_fallback_getaddrinfo_shared(struct fast_fallback_getaddrinfo_shared **shared);
 #  endif


### PR DESCRIPTION
Referencing PR #10864,
wrap `do_fast_fallback_getaddrinfo` with `rb_thread_prevent_fork` to avoid fork safety issues.

`do_fast_fallback_getaddrinfo` internally uses getaddrinfo(3), leading to fork safety issues, as described in PR #10864. This change ensures that `do_fast_fallback_getaddrinfo` is guarded by `rb_thread_prevent_fork`,
preventing fork during its execution and avoiding related issues.