### PR TITLE
[Bug #20958] fix ENV.keys encoding on windows

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -5731,7 +5731,7 @@ env_aset(VALUE nm, VALUE val)
 static VALUE
 env_keys(int raw)
 {
-    rb_encoding *enc = raw ? 0 : rb_locale_encoding();
+    rb_encoding *enc = raw ? 0 : env_encoding();
     VALUE ary = rb_ary_new();
 
     ENV_LOCKING() {

--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -195,6 +195,37 @@ class TestEnv < Test::Unit::TestCase
     a.each {|k| assert_kind_of(String, k) }
   end
 
+  def test_keys_encoding
+    bug20958 = '[ruby-core:120277] [Bug #20958]'
+    orig = ENV.to_hash
+    ENV.clear
+    key = "TEST20958\u{30c6 30b9 30c8}"
+    begin
+      ENV[key] = "x"
+    rescue
+      omit "platform does not support UTF-8 environment variables."
+    end
+    EnvUtil.with_default_internal(nil) do
+      enc = RUBY_PLATFORM =~ /mswin|mingw/ ?
+         Encoding::UTF_8 : Encoding.find("locale")
+      assert_equal(enc, ENV.keys.last.encoding, bug20958)
+      assert_equal(key.encode(enc), ENV.keys.last, bug20958)
+    end
+
+    ENV.update(orig) #required to restore ENV[RbConfig::CONFIG['LIBPATHENV']]
+    env = {key => "x", "LOCALE" => "en_US.UTF-8", "LC_ALL" => "en_US.UTF-8"}
+    load_path = $LOAD_PATH.map {|v| "-I#{v}" }
+    internal_enc = "Windows-31J"
+    params = [env, *load_path, "-Eutf-8:#{internal_enc}"]
+    assert_separately(params, <<-"EOS")
+      ENV.keep_if {|k,| k.start_with?("TEST20958") }
+      key = ENV.keys.last
+      assert_equal("#{internal_enc}", key.encoding.to_s, "#{bug20958}")
+      assert_equal("#{key.encode(Encoding.find(internal_enc)).bytes}",
+                   key.bytes.to_s, "#{bug20958}")
+    EOS
+  end
+
   def test_each_key
     ENV.each_key {|k| assert_kind_of(String, k) }
   end


### PR DESCRIPTION
Fix the encoding of ENV.keys elements to UTF-8 on windows. They contain UTF-8 byte sequences with locale encoding.