### PR TITLE
[PRISM] Recurse use_deconstructed_cache in Alternation Nodes

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -2991,7 +2991,7 @@ pm_compile_pattern(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t
         // First, we're going to attempt to match against the left pattern. If
         // that pattern matches, then we'll skip matching the right pattern.
         PUSH_INSN(ret, location, dup);
-        CHECK(pm_compile_pattern(iseq, scope_node, cast->left, ret, matched_left_label, unmatched_left_label, in_single_pattern, true, true, base_index + 1));
+        CHECK(pm_compile_pattern(iseq, scope_node, cast->left, ret, matched_left_label, unmatched_left_label, in_single_pattern, true, use_deconstructed_cache, base_index + 1));
 
         // If we get here, then we matched on the left pattern. In this case we
         // should pop out the duplicate value that we preemptively added to
@@ -3004,7 +3004,7 @@ pm_compile_pattern(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_node_t
         // If we get here, then we didn't match on the left pattern. In this
         // case we attempt to match against the right pattern.
         PUSH_LABEL(ret, unmatched_left_label);
-        CHECK(pm_compile_pattern(iseq, scope_node, cast->right, ret, matched_label, unmatched_label, in_single_pattern, true, true, base_index));
+        CHECK(pm_compile_pattern(iseq, scope_node, cast->right, ret, matched_label, unmatched_label, in_single_pattern, true, use_deconstructed_cache, base_index));
         break;
       }
       case PM_PARENTHESES_NODE:

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -2485,6 +2485,9 @@ end
       assert_prism_eval("5 in foo")
 
       assert_prism_eval("1 in 2")
+
+      # Bug: https://bugs.ruby-lang.org/issues/20956
+      assert_prism_eval("1 in [1 | [1]]")
     end
 
     def test_MatchRequiredNode


### PR DESCRIPTION
This fixes the behavioural difference between Prism and parse.y when evaluating the following code

```ruby
1 in [1 | [1]]
```

Fixes [Bug #20956]