### PR TITLE
Windows: Change command line interface to UTF-8

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -2527,14 +2527,8 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
 #endif
     }
     rb_enc_associate(opt->script_name, IF_UTF8_PATH(uenc, lenc));
-#if UTF8_PATH
-    if (uenc != lenc) {
-        opt->script_name = str_conv_enc(opt->script_name, uenc, lenc);
-        opt->script = RSTRING_PTR(opt->script_name);
-    }
-#endif
     rb_obj_freeze(opt->script_name);
-    if (IF_UTF8_PATH(uenc != lenc, 1)) {
+    {
         long i;
         VALUE load_path = box->load_path;
         const ID id_initial_load_path_mark = INITIAL_LOAD_PATH_MARK;
@@ -2544,13 +2538,7 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
         for (i = 0; i < RARRAY_LEN(load_path); ++i) {
             VALUE path = RARRAY_AREF(load_path, i);
             int mark = rb_attr_get(path, id_initial_load_path_mark) == path;
-#if UTF8_PATH
-            VALUE newpath = rb_str_conv_enc(path, uenc, lenc);
-            if (newpath == path) continue;
-            path = newpath;
-#else
-            if (!(path = copy_str(path, lenc, !mark))) continue;
-#endif
+            if (!(path = copy_str(path, IF_UTF8_PATH(uenc, lenc), !mark))) continue;
             if (mark) rb_ivar_set(path, id_initial_load_path_mark, path);
             if (!modifiable) {
                 rb_ary_modify(load_path);
@@ -2678,11 +2666,6 @@ process_options(int argc, char **argv, ruby_cmdline_options_t *opt)
         VALUE path = Qnil;
         if (!opt->e_script && strcmp(opt->script, "-")) {
             path = rb_realpath_internal(Qnil, opt->script_name, 1);
-#if UTF8_PATH
-            if (uenc != lenc) {
-                path = str_conv_enc(path, uenc, lenc);
-            }
-#endif
             if (!ENCODING_GET(path)) { /* ASCII-8BIT */
                 rb_enc_copy(path, opt->script_name);
             }

--- a/spec/ruby/language/magic_comment_spec.rb
+++ b/spec/ruby/language/magic_comment_spec.rb
@@ -3,7 +3,13 @@ require_relative '../spec_helper'
 # See core/kernel/eval_spec.rb for more magic comments specs for eval()
 describe :magic_comments, shared: true do
   before :each do
-    @default = @method == :locale ? Encoding.find('locale') : Encoding::UTF_8
+    @default = if @method == :locale &&
+        ( platform_is_not(:windows) || ruby_version_is(""..."4.1") )
+    then
+      Encoding.find('locale')
+    else
+      Encoding::UTF_8
+    end
   end
 
   it "are optional" do

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -1060,19 +1060,11 @@ class TestRubyOptions < Test::Unit::TestCase
 
     def test_command_line_progname_nonascii
       bug10555 = '[ruby-dev:48752] [Bug #10555]'
-      name = expected = nil
-      unless (0x80..0x10000).any? {|c|
-               name = c.chr(Encoding::UTF_8)
-               expected = name.encode("locale") rescue nil
-             }
-        omit "can't make locale name"
-      end
-      name << ".rb"
-      expected << ".rb"
+      name = "\u{20ac}.rb"
       with_tmpchdir do |dir|
         open(name, "w") {|f| f.puts "puts File.basename($0)"}
-        assert_in_out_err([name], "", [expected], [],
-                          bug10555, encoding: "locale")
+        assert_in_out_err([name], "", [name], [],
+                          bug10555, encoding: "utf-8")
       end
     end
 


### PR DESCRIPTION
The following inputs are changed to consistently work with UTF-8:
- script name
- include paths
- ~~script input from stdin~~ - already merged in #17514

They are currently a inconsistent mix of locale encoding and UTF-8, depending on the situation.

Given the following script and a codepage of 850 it changes `from:` to `to:`

```ruby
# execute with: ruby -It€st täst-locale-enc.rb
def pr(*strs)
  strs.each do |str|
    p [str, IO===str ? str.external_encoding&.name : str.encoding.name]
  end
end

if $0==__FILE__
  pr STDIN      # from: [#<IO:<STDIN>>, "CP850"]
                # to:   [#<IO:<STDIN>>, "UTF-8"]
  pr $0         # from: ["t\x84st-locale-enc.rb", "CP850"]
                # to:   ["täst-locale-enc.rb", "UTF-8"]
  pr __FILE__   # from: ["t\x84st-locale-enc.rb", "CP850"]
                # to:   ["täst-locale-enc.rb", "UTF-8"]
  pr __dir__    # from: ["C:/Users/Lars/ruby", "CP850"]
                # to:   ["C:/Users/Lars/ruby", "UTF-8"]
  pr 'ä'        # from: ["ä", "UTF-8"]
                # to:   ["ä", "UTF-8"]
  pr '€'        # from: ["€", "UTF-8"]
                # to:   ["€", "UTF-8"]
  pr $:.first   # from: ["C:/Users/Lars/ruby/t\xE2\x82\xACst", "ASCII-8BIT"]
                # to:   ["C:/Users/Lars/ruby/t€st", "UTF-8"]
  pr $:.last    # from: ["c:/Ruby34/lib/ruby/3.4.0+1/aarch64-mingw-ucrt", "CP850"]
                # to:   ["C:/Users/Lars/ruby/lib/ruby/3.4.0+1/aarch64-mingw-ucrt", "UTF-8"]
end
```

... and with code from STDIN the changes look like so:

```ruby
# execute with: cat täst-locale-enc.rb | ruby -It€st
if $0==__FILE__
  pr STDIN      # from: [#<IO:<STDIN>>, "UTF-8"]
                # to:   [#<IO:<STDIN>>, "UTF-8"]
  pr $0         # from: ["-", "CP850"]
                # to:   ["-", "UTF-8"]
  pr __FILE__   # from: ["-", "UTF-8"]
                # to:   ["-", "UTF-8"]
  pr __dir__    # from: [".", "US-ASCII"]
                # to:   [".", "US-ASCII"]
  pr 'ä'        # from: ["\xC3\xA4", "CP850"]
                # to:   ["ä", "UTF-8"]
  pr '€'        # from: ["\xE2\x82\xAC", "CP850"]
                # to:   ["€", "UTF-8"]
  pr $:.first   # from: ["C:/Users/Lars/ruby/t\xE2\x82\xACst", "ASCII-8BIT"]
                # to:   ["C:/Users/Lars/ruby/t€st", "UTF-8"]
  pr $:.last    # from: ["c:/Ruby34/lib/ruby/3.4.0+1/aarch64-mingw-ucrt", "CP850"]
                # to:   ["C:/Users/Lars/ruby/lib/ruby/3.4.0+1/aarch64-mingw-ucrt", "UTF-8"]
end
```

This PR doesn't change `STDIN` encoding when keystrokes are read from the console. They are still in locale encoding. This is because it is difficult to implement UTF-8 there and it is a different topic than the command line interface.

This PR works equally with Prism and Parse.y parser.

Closes [[Bug #20774]](https://bugs.ruby-lang.org/issues/20774)
Closes [[Bug #20699]](https://bugs.ruby-lang.org/issues/20699)
Closes https://github.com/oneclick/rubyinstaller2/issues/265
