### PR TITLE
Sync ruby/rdoc#1238

### DIFF
--- a/lib/rdoc/generator/template/darkfish/js/darkfish.js
+++ b/lib/rdoc/generator/template/darkfish/js/darkfish.js
@@ -103,6 +103,12 @@ function hookSidebar() {
   if (isSmallViewport) {
     navigation.hidden = true;
     navigationToggle.ariaExpanded = false;
+    document.addEventListener('click', (e) => {
+      if (e.target.closest('#navigation a')) {
+        navigation.hidden = true;
+        navigationToggle.ariaExpanded = false;
+      }
+    });
   }
 }
 


### PR DESCRIPTION
I was meant to merge this before the auto-syncing stops but was late a little bit. It's a frontend change for RDoc so ideally we'd want to test it on docs.ruby-lang.org for a few days before the 3.4 release.