### PR TITLE
[DOC] Fix string output example that contains old Hash#inspect style

### DIFF
--- a/array.c
+++ b/array.c
@@ -5084,7 +5084,7 @@ rb_ary_concat(VALUE x, VALUE y)
  *  When string argument +string_separator+ is given,
  *  equivalent to <tt>self.join(string_separator)</tt>:
  *
- *    [0, [0, 1], {foo: 0}] * ', ' # => "0, 0, 1, {:foo=>0}"
+ *    [0, [0, 1], {foo: 0}] * ', ' # => "0, 0, 1, {foo: 0}"
  *
  */
 

--- a/doc/syntax/pattern_matching.rdoc
+++ b/doc/syntax/pattern_matching.rdoc
@@ -247,7 +247,7 @@ The "rest" part of a pattern also can be bound to a variable:
   else
     "not matched"
   end
-  #=> "matched: 1, {:b=>2, :c=>3}"
+  #=> "matched: 1, {b: 2, c: 3}"
 
 Binding to variables currently does NOT work for alternative patterns joined with <code>|</code>:
 

--- a/hash.c
+++ b/hash.c
@@ -3490,7 +3490,7 @@ inspect_hash(VALUE hash, VALUE dummy, int recur)
  *  Returns a new String containing the hash entries:
 
  *    h = {foo: 0, bar: 1, baz: 2}
- *    h.inspect # => "{:foo=>0, :bar=>1, :baz=>2}"
+ *    h.inspect # => "{foo: 0, bar: 1, baz: 2}"
  *
  */
 

--- a/object.c
+++ b/object.c
@@ -3827,7 +3827,7 @@ rb_String(VALUE val)
  *
  *    String([0, 1, 2])        # => "[0, 1, 2]"
  *    String(0..5)             # => "0..5"
- *    String({foo: 0, bar: 1}) # => "{:foo=>0, :bar=>1}"
+ *    String({foo: 0, bar: 1}) # => "{foo: 0, bar: 1}"
  *
  *  Raises +TypeError+ if +object+ cannot be converted to a string.
  */


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20962

This pull request fixes document of Hash#inspect and some more string output examples.
But does not fix these kind of documents:
```ruby
h # => {:x=>0, :y=>100}

h.slice(:baz, :foo) # => {:baz=>2, :foo=>0}
```
because it's not clearly wrong, and there are too many of them.