### PR TITLE
[DOC] Don't document gemspec files

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -10,3 +10,4 @@ rdoc_include:
 
 exclude:
 - lib/irb
+- .gemspec


### PR DESCRIPTION
Since https://github.com/ruby/ruby/commit/cf711863cbe0b81be5ff0adfb64936137995cc4e (https://github.com/ruby/ruby/pull/12325), gemspecs are included because the default exclude is overwritten.

I'm not sure if this change is the best way to solve it but it does remove these files from the generated documentation.

https://docs.ruby-lang.org/en/master/lib/English_gemspec.html

![image](https://github.com/user-attachments/assets/600c02b1-9aaa-4a98-8747-be70181e0306)