### PR TITLE
Windows: Remove workaround for LLVM windres

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -521,7 +521,6 @@ AS_CASE(["$target_os"],
     ])
     rb_cv_binary_elf=no
     : ${enable_shared=yes}
-    AS_IF([$WINDRES --version | grep LLVM > /dev/null], [USE_LLVM_WINDRES=yes], [USE_LLVM_WINDRES=no])
     ],
 [hiuxmpp*], [AC_DEFINE(__HIUX_MPP__)])    # by TOYODA Eizi <toyoda@npd.kishou.go.jp>
 
@@ -4293,7 +4292,6 @@ AC_SUBST(MINIOBJS)
 AC_SUBST(THREAD_MODEL)
 AC_SUBST(COROUTINE_TYPE, ${coroutine_type})
 AC_SUBST(PLATFORM_DIR)
-AC_SUBST(USE_LLVM_WINDRES)
 
 firstmf=`echo $FIRSTMAKEFILE | sed 's/:.*//'`
 firsttmpl=`echo $FIRSTMAKEFILE | sed 's/.*://'`

--- a/cygwin/GNUmakefile.in
+++ b/cygwin/GNUmakefile.in
@@ -6,14 +6,9 @@ MUNICODE_FLAG := $(if $(filter mingw%,$(target_os)),-municode)
 override EXE_LDFLAGS += $(MUNICODE_FLAG)
 
 DLLWRAP = @DLLWRAP@ --target=$(target_os) --driver-name="$(CC)"
-ifeq (@USE_LLVM_WINDRES@,yes) # USE_LLVM_WINDRES
-	# llvm-windres fails when preprocessor options are added
-	windres-cpp :=
-else
-	windres-cpp := $(CPP) -xc
-	windres-cpp := --preprocessor=$(firstword $(windres-cpp)) \
-		$(addprefix --preprocessor-arg=,$(wordlist 2,$(words $(windres-cpp)),$(windres-cpp)))
-endif
+windres-cpp := $(CPP) -xc
+windres-cpp := --preprocessor=$(firstword $(windres-cpp)) \
+	$(addprefix --preprocessor-arg=,$(wordlist 2,$(words $(windres-cpp)),$(windres-cpp)))
 WINDRES = @WINDRES@ $(windres-cpp) -DRC_INVOKED
 STRIP = @STRIP@
 


### PR DESCRIPTION
It was introduced as part of the Arm64-on-Windows patch:  https://github.com/ruby/ruby/pull/8995

But a few days later it was fixed on the LLVM side for llvm-18 and backported to MSYS2:
  https://github.com/msys2/MINGW-packages/pull/19157#issuecomment-1825285063

Now this code is only unnecessary complexity.