### PR TITLE
Properly document Ractor#require

### DIFF
--- a/ractor.rb
+++ b/ractor.rb
@@ -889,7 +889,7 @@ class Ractor
   end
 
   # internal method
-  def self._require feature
+  def self._require feature # :nodoc:
     if main?
       super feature
     else
@@ -901,11 +901,11 @@ class Ractor
     private
 
     # internal method that is called when the first "Ractor.new" is called
-    def _activated
+    def _activated # :nodoc:
       Kernel.prepend Module.new{|m|
         m.set_temporary_name '<RactorRequire>'
 
-        def require feature
+        def require feature # :nodoc: -- otherwise RDoc outputs it as a class method
           if Ractor.main?
             super
           else


### PR DESCRIPTION
[Currently](https://docs.ruby-lang.org/en/master/Ractor.html), the docs have:
* internal methods `Ractor._activated` and `Ractor._require` included;
* (metaprogrammed) `Ractor.require` wrongly recognized by RDoc as class method (with no documentation).

This PR just adds `:nodoc: for those methods.