### PR TITLE
[DOC] Improve the NEWS page's rendering on docs.ruby-lang.org

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -182,96 +182,97 @@ The following default gem is added.
 The following default gems are updated.
 
 * RubyGems 3.6.1
-  * 3.5.3 to [v3.5.4][RubyGems-v3.5.4], [v3.5.5][RubyGems-v3.5.5], [v3.5.6][RubyGems-v3.5.6], [v3.5.7][RubyGems-v3.5.7], [v3.5.8][RubyGems-v3.5.8], [v3.5.9][RubyGems-v3.5.9], [v3.5.10][RubyGems-v3.5.10], [v3.5.11][RubyGems-v3.5.11], [v3.5.12][RubyGems-v3.5.12], [v3.5.13][RubyGems-v3.5.13], [v3.5.14][RubyGems-v3.5.14], [v3.5.15][RubyGems-v3.5.15], [v3.5.16][RubyGems-v3.5.16], [v3.5.17][RubyGems-v3.5.17], [v3.5.18][RubyGems-v3.5.18], [v3.5.19][RubyGems-v3.5.19], [v3.5.20][RubyGems-v3.5.20], [v3.5.21][RubyGems-v3.5.21], [v3.5.22][RubyGems-v3.5.22], [v3.5.23][RubyGems-v3.5.23], [v3.6.0][RubyGems-v3.6.0], [v3.6.1][RubyGems-v3.6.1]
+    * 3.5.3 to [v3.5.4][RubyGems-v3.5.4], [v3.5.5][RubyGems-v3.5.5], [v3.5.6][RubyGems-v3.5.6], [v3.5.7][RubyGems-v3.5.7], [v3.5.8][RubyGems-v3.5.8], [v3.5.9][RubyGems-v3.5.9], [v3.5.10][RubyGems-v3.5.10], [v3.5.11][RubyGems-v3.5.11], [v3.5.12][RubyGems-v3.5.12], [v3.5.13][RubyGems-v3.5.13], [v3.5.14][RubyGems-v3.5.14], [v3.5.15][RubyGems-v3.5.15], [v3.5.16][RubyGems-v3.5.16], [v3.5.17][RubyGems-v3.5.17], [v3.5.18][RubyGems-v3.5.18], [v3.5.19][RubyGems-v3.5.19], [v3.5.20][RubyGems-v3.5.20], [v3.5.21][RubyGems-v3.5.21], [v3.5.22][RubyGems-v3.5.22], [v3.5.23][RubyGems-v3.5.23], [v3.6.0][RubyGems-v3.6.0], [v3.6.1][RubyGems-v3.6.1]
 * benchmark 0.4.0
-  * 0.3.0 to [v0.4.0][benchmark-v0.4.0]
+    * 0.3.0 to [v0.4.0][benchmark-v0.4.0]
 * bundler 2.6.1
-  * 2.5.3 to [v2.5.4][bundler-v2.5.4], [v2.5.5][bundler-v2.5.5], [v2.5.6][bundler-v2.5.6], [v2.5.7][bundler-v2.5.7], [v2.5.8][bundler-v2.5.8], [v2.5.9][bundler-v2.5.9], [v2.5.10][bundler-v2.5.10], [v2.5.11][bundler-v2.5.11], [v2.5.12][bundler-v2.5.12], [v2.5.13][bundler-v2.5.13], [v2.5.14][bundler-v2.5.14], [v2.5.15][bundler-v2.5.15], [v2.5.16][bundler-v2.5.16], [v2.5.17][bundler-v2.5.17], [v2.5.18][bundler-v2.5.18], [v2.5.19][bundler-v2.5.19], [v2.5.20][bundler-v2.5.20], [v2.5.21][bundler-v2.5.21], [v2.5.22][bundler-v2.5.22], [v2.5.23][bundler-v2.5.23], [v2.6.0][bundler-v2.6.0], [v2.6.1][bundler-v2.6.1]
+    * 2.5.3 to [v2.5.4][bundler-v2.5.4], [v2.5.5][bundler-v2.5.5], [v2.5.6][bundler-v2.5.6], [v2.5.7][bundler-v2.5.7], [v2.5.8][bundler-v2.5.8], [v2.5.9][bundler-v2.5.9], [v2.5.10][bundler-v2.5.10], [v2.5.11][bundler-v2.5.11], [v2.5.12][bundler-v2.5.12], [v2.5.13][bundler-v2.5.13], [v2.5.14][bundler-v2.5.14], [v2.5.15][bundler-v2.5.15], [v2.5.16][bundler-v2.5.16], [v2.5.17][bundler-v2.5.17], [v2.5.18][bundler-v2.5.18], [v2.5.19][bundler-v2.5.19], [v2.5.20][bundler-v2.5.20], [v2.5.21][bundler-v2.5.21], [v2.5.22][bundler-v2.5.22], [v2.5.23][bundler-v2.5.23], [v2.6.0][bundler-v2.6.0], [v2.6.1][bundler-v2.6.1]
 * date 3.4.1
-  * 3.3.4 to [v3.4.0][date-v3.4.0], [v3.4.1][date-v3.4.1]
+    * 3.3.4 to [v3.4.0][date-v3.4.0], [v3.4.1][date-v3.4.1]
 * delegate 0.4.0
-  * 0.3.1 to [v0.4.0][delegate-v0.4.0]
+    * 0.3.1 to [v0.4.0][delegate-v0.4.0]
 * did_you_mean 2.0.0
-  * 1.6.3 to [v2.0.0][did_you_mean-v2.0.0]
+    * 1.6.3 to [v2.0.0][did_you_mean-v2.0.0]
 * digest 3.2.0
-  * 3.1.1 to [v3.2.0.pre0][digest-v3.2.0.pre0], [v3.2.0][digest-v3.2.0]
+    * 3.1.1 to [v3.2.0.pre0][digest-v3.2.0.pre0], [v3.2.0][digest-v3.2.0]
 * erb 4.0.4
-  * 4.0.3 to [v4.0.4][erb-v4.0.4]
+    * 4.0.3 to [v4.0.4][erb-v4.0.4]
 * error_highlight 0.7.0
+    * 0.6.0 to [v0.7.0][error_highlight-v0.7.0]
 * etc 1.4.5
-  * 1.4.3 to [v1.4.4][etc-v1.4.4], [v1.4.5][etc-v1.4.5]
+    * 1.4.3 to [v1.4.4][etc-v1.4.4], [v1.4.5][etc-v1.4.5]
 * fcntl 1.2.0
-  * 1.1.0 to [v1.2.0][fcntl-v1.2.0]
+    * 1.1.0 to [v1.2.0][fcntl-v1.2.0]
 * fiddle 1.1.6
-  * 1.1.2 to [v1.1.3][fiddle-v1.1.3], [v1.1.4][fiddle-v1.1.4], [v1.1.5][fiddle-v1.1.5], [v1.1.6][fiddle-v1.1.6]
+    * 1.1.2 to [v1.1.3][fiddle-v1.1.3], [v1.1.4][fiddle-v1.1.4], [v1.1.5][fiddle-v1.1.5], [v1.1.6][fiddle-v1.1.6]
 * fileutils 1.7.3
-  * 1.7.2 to [v1.7.3][fileutils-v1.7.3]
+    * 1.7.2 to [v1.7.3][fileutils-v1.7.3]
 * io-console 0.8.0
-  * 0.7.1 to [v0.7.2][io-console-v0.7.2], [v0.8.0.beta1][io-console-v0.8.0.beta1], [v0.8.0][io-console-v0.8.0]
+    * 0.7.1 to [v0.7.2][io-console-v0.7.2], [v0.8.0.beta1][io-console-v0.8.0.beta1], [v0.8.0][io-console-v0.8.0]
 * io-nonblock 0.3.1
-  * 0.3.0 to [v0.3.1][io-nonblock-v0.3.1]
+    * 0.3.0 to [v0.3.1][io-nonblock-v0.3.1]
 * ipaddr 1.2.7
-  * 1.2.6 to [v1.2.7][ipaddr-v1.2.7]
+    * 1.2.6 to [v1.2.7][ipaddr-v1.2.7]
 * irb 1.14.3
-  * 1.11.0 to [v1.11.1][irb-v1.11.1], [v1.11.2][irb-v1.11.2], [v1.12.0][irb-v1.12.0], [v1.13.0][irb-v1.13.0], [v1.13.1][irb-v1.13.1], [v1.13.2][irb-v1.13.2], [v1.14.0][irb-v1.14.0], [v1.14.1][irb-v1.14.1], [v1.14.2][irb-v1.14.2], [v1.14.3][irb-v1.14.3]
+    * 1.11.0 to [v1.11.1][irb-v1.11.1], [v1.11.2][irb-v1.11.2], [v1.12.0][irb-v1.12.0], [v1.13.0][irb-v1.13.0], [v1.13.1][irb-v1.13.1], [v1.13.2][irb-v1.13.2], [v1.14.0][irb-v1.14.0], [v1.14.1][irb-v1.14.1], [v1.14.2][irb-v1.14.2], [v1.14.3][irb-v1.14.3]
 * json 2.9.1
-  * 2.7.1 to [v2.7.2][json-v2.7.2], [v2.7.3.rc1][json-v2.7.3.rc1], [v2.7.3][json-v2.7.3], [v2.7.4][json-v2.7.4], [v2.7.5][json-v2.7.5], [v2.7.6][json-v2.7.6], [v2.8.0][json-v2.8.0], [v2.8.1][json-v2.8.1], [v2.8.2][json-v2.8.2], [v2.9.0][json-v2.9.0], [v2.9.1][json-v2.9.1]
+    * 2.7.1 to [v2.7.2][json-v2.7.2], [v2.7.3.rc1][json-v2.7.3.rc1], [v2.7.3][json-v2.7.3], [v2.7.4][json-v2.7.4], [v2.7.5][json-v2.7.5], [v2.7.6][json-v2.7.6], [v2.8.0][json-v2.8.0], [v2.8.1][json-v2.8.1], [v2.8.2][json-v2.8.2], [v2.9.0][json-v2.9.0], [v2.9.1][json-v2.9.1]
 * logger 1.6.4
-  * 1.6.0 to [v1.6.1][logger-v1.6.1], [v1.6.2][logger-v1.6.2], [v1.6.3][logger-v1.6.3], [v1.6.4][logger-v1.6.4]
+    * 1.6.0 to [v1.6.1][logger-v1.6.1], [v1.6.2][logger-v1.6.2], [v1.6.3][logger-v1.6.3], [v1.6.4][logger-v1.6.4]
 * net-http 0.6.0
-  * 0.4.0 to [v0.4.1][net-http-v0.4.1], [v0.5.0][net-http-v0.5.0], [v0.6.0][net-http-v0.6.0]
+    * 0.4.0 to [v0.4.1][net-http-v0.4.1], [v0.5.0][net-http-v0.5.0], [v0.6.0][net-http-v0.6.0]
 * open-uri 0.5.0
-  * 0.4.1 to [v0.5.0][open-uri-v0.5.0]
+    * 0.4.1 to [v0.5.0][open-uri-v0.5.0]
 * optparse 0.6.0
-  * 0.4.0 to [v0.5.0][optparse-v0.5.0], [v0.6.0][optparse-v0.6.0]
+    * 0.4.0 to [v0.5.0][optparse-v0.5.0], [v0.6.0][optparse-v0.6.0]
 * ostruct 0.6.1
-  * 0.6.0 to [v0.6.1][ostruct-v0.6.1]
+    * 0.6.0 to [v0.6.1][ostruct-v0.6.1]
 * pathname 0.4.0
-  * 0.3.0 to [v0.4.0][pathname-v0.4.0]
+    * 0.3.0 to [v0.4.0][pathname-v0.4.0]
 * pp 0.6.2
-  * 0.5.0 to [v0.6.0][pp-v0.6.0], [v0.6.1][pp-v0.6.1], [v0.6.2][pp-v0.6.2]
+    * 0.5.0 to [v0.6.0][pp-v0.6.0], [v0.6.1][pp-v0.6.1], [v0.6.2][pp-v0.6.2]
 * prism 1.2.0
-  * 0.19.0 to [v0.20.0][prism-v0.20.0], [v0.21.0][prism-v0.21.0], [v0.22.0][prism-v0.22.0], [v0.23.0][prism-v0.23.0], [v0.24.0][prism-v0.24.0], [v0.25.0][prism-v0.25.0], [v0.26.0][prism-v0.26.0], [v0.27.0][prism-v0.27.0], [v0.28.0][prism-v0.28.0], [v0.29.0][prism-v0.29.0], [v0.30.0][prism-v0.30.0], [v1.0.0][prism-v1.0.0], [v1.1.0][prism-v1.1.0], [v1.2.0][prism-v1.2.0]
+    * 0.19.0 to [v0.20.0][prism-v0.20.0], [v0.21.0][prism-v0.21.0], [v0.22.0][prism-v0.22.0], [v0.23.0][prism-v0.23.0], [v0.24.0][prism-v0.24.0], [v0.25.0][prism-v0.25.0], [v0.26.0][prism-v0.26.0], [v0.27.0][prism-v0.27.0], [v0.28.0][prism-v0.28.0], [v0.29.0][prism-v0.29.0], [v0.30.0][prism-v0.30.0], [v1.0.0][prism-v1.0.0], [v1.1.0][prism-v1.1.0], [v1.2.0][prism-v1.2.0]
 * pstore 0.1.4
-  * 0.1.3 to [v0.1.4][pstore-v0.1.4]
+    * 0.1.3 to [v0.1.4][pstore-v0.1.4]
 * psych 5.2.2
-  * 5.1.2 to [v5.2.0.beta1][psych-v5.2.0.beta1], [v5.2.0.beta2][psych-v5.2.0.beta2], [v5.2.0.beta3][psych-v5.2.0.beta3], [v5.2.0.beta4][psych-v5.2.0.beta4], [v5.2.0.beta5][psych-v5.2.0.beta5], [v5.2.0.beta6][psych-v5.2.0.beta6], [v5.2.0.beta7][psych-v5.2.0.beta7], [v5.2.0][psych-v5.2.0], [v5.2.1][psych-v5.2.1], [v5.2.2][psych-v5.2.2]
+    * 5.1.2 to [v5.2.0.beta1][psych-v5.2.0.beta1], [v5.2.0.beta2][psych-v5.2.0.beta2], [v5.2.0.beta3][psych-v5.2.0.beta3], [v5.2.0.beta4][psych-v5.2.0.beta4], [v5.2.0.beta5][psych-v5.2.0.beta5], [v5.2.0.beta6][psych-v5.2.0.beta6], [v5.2.0.beta7][psych-v5.2.0.beta7], [v5.2.0][psych-v5.2.0], [v5.2.1][psych-v5.2.1], [v5.2.2][psych-v5.2.2]
 * rdoc 6.10.0
-  * 6.6.2 to [v6.7.0][rdoc-v6.7.0], [v6.8.0][rdoc-v6.8.0], [v6.8.1][rdoc-v6.8.1], [v6.9.0][rdoc-v6.9.0], [v6.9.1][rdoc-v6.9.1], [v6.10.0][rdoc-v6.10.0]
+    * 6.6.2 to [v6.7.0][rdoc-v6.7.0], [v6.8.0][rdoc-v6.8.0], [v6.8.1][rdoc-v6.8.1], [v6.9.0][rdoc-v6.9.0], [v6.9.1][rdoc-v6.9.1], [v6.10.0][rdoc-v6.10.0]
 * reline 0.6.0
-  * 0.4.1 to [v0.4.2][reline-v0.4.2], [v0.4.3][reline-v0.4.3], [v0.5.0.pre.1][reline-v0.5.0.pre.1], [v0.5.0][reline-v0.5.0], [v0.5.1][reline-v0.5.1], [v0.5.2][reline-v0.5.2], [v0.5.3][reline-v0.5.3], [v0.5.4][reline-v0.5.4], [v0.5.5][reline-v0.5.5], [v0.5.6][reline-v0.5.6], [v0.5.7][reline-v0.5.7], [v0.5.8][reline-v0.5.8], [v0.5.9][reline-v0.5.9], [v0.5.10][reline-v0.5.10], [v0.5.11][reline-v0.5.11], [v0.5.12][reline-v0.5.12], [v0.6.0][reline-v0.6.0]
+    * 0.4.1 to [v0.4.2][reline-v0.4.2], [v0.4.3][reline-v0.4.3], [v0.5.0.pre.1][reline-v0.5.0.pre.1], [v0.5.0][reline-v0.5.0], [v0.5.1][reline-v0.5.1], [v0.5.2][reline-v0.5.2], [v0.5.3][reline-v0.5.3], [v0.5.4][reline-v0.5.4], [v0.5.5][reline-v0.5.5], [v0.5.6][reline-v0.5.6], [v0.5.7][reline-v0.5.7], [v0.5.8][reline-v0.5.8], [v0.5.9][reline-v0.5.9], [v0.5.10][reline-v0.5.10], [v0.5.11][reline-v0.5.11], [v0.5.12][reline-v0.5.12], [v0.6.0][reline-v0.6.0]
 * resolv 0.6.0
-  * 0.3.0 to [v0.4.0][resolv-v0.4.0], [v0.5.0][resolv-v0.5.0], [v0.6.0][resolv-v0.6.0]
+    * 0.3.0 to [v0.4.0][resolv-v0.4.0], [v0.5.0][resolv-v0.5.0], [v0.6.0][resolv-v0.6.0]
 * securerandom 0.4.1
-  * 0.3.1 to [v0.3.2][securerandom-v0.3.2], [v0.4.0][securerandom-v0.4.0], [v0.4.1][securerandom-v0.4.1]
+    * 0.3.1 to [v0.3.2][securerandom-v0.3.2], [v0.4.0][securerandom-v0.4.0], [v0.4.1][securerandom-v0.4.1]
 * set 1.1.1
-  * 1.1.0 to [v1.1.1][set-v1.1.1]
+    * 1.1.0 to [v1.1.1][set-v1.1.1]
 * shellwords 0.2.2
-  * 0.2.0 to [v0.2.1][shellwords-v0.2.1], [v0.2.2][shellwords-v0.2.2]
+    * 0.2.0 to [v0.2.1][shellwords-v0.2.1], [v0.2.2][shellwords-v0.2.2]
 * singleton 0.3.0
-  * 0.2.0 to [v0.3.0][singleton-v0.3.0]
+    * 0.2.0 to [v0.3.0][singleton-v0.3.0]
 * stringio 3.1.2
-  * 3.1.0 to [v3.1.1][stringio-v3.1.1], [v3.1.2][stringio-v3.1.2]
+    * 3.1.0 to [v3.1.1][stringio-v3.1.1], [v3.1.2][stringio-v3.1.2]
 * strscan 3.1.2
-  * 3.0.7 to [v3.0.8][strscan-v3.0.8], [v3.0.9][strscan-v3.0.9], [v3.1.0][strscan-v3.1.0], [v3.1.1][strscan-v3.1.1], [v3.1.2][strscan-v3.1.2]
+    * 3.0.7 to [v3.0.8][strscan-v3.0.8], [v3.0.9][strscan-v3.0.9], [v3.1.0][strscan-v3.1.0], [v3.1.1][strscan-v3.1.1], [v3.1.2][strscan-v3.1.2]
 * syntax_suggest 2.0.2
-  * 2.0.0 to [v2.0.1][syntax_suggest-v2.0.1], [v2.0.2][syntax_suggest-v2.0.2]
+    * 2.0.0 to [v2.0.1][syntax_suggest-v2.0.1], [v2.0.2][syntax_suggest-v2.0.2]
 * tempfile 0.3.1
-  * 0.2.1 to [v0.3.0][tempfile-v0.3.0], [v0.3.1][tempfile-v0.3.1]
+    * 0.2.1 to [v0.3.0][tempfile-v0.3.0], [v0.3.1][tempfile-v0.3.1]
 * time 0.4.1
-  * 0.3.0 to [v0.4.0][time-v0.4.0], [v0.4.1][time-v0.4.1]
+    * 0.3.0 to [v0.4.0][time-v0.4.0], [v0.4.1][time-v0.4.1]
 * timeout 0.4.3
-  * 0.4.1 to [v0.4.2][timeout-v0.4.2], [v0.4.3][timeout-v0.4.3]
+    * 0.4.1 to [v0.4.2][timeout-v0.4.2], [v0.4.3][timeout-v0.4.3]
 * tmpdir 0.3.1
-  * 0.2.0 to [v0.3.0][tmpdir-v0.3.0], [v0.3.1][tmpdir-v0.3.1]
+    * 0.2.0 to [v0.3.0][tmpdir-v0.3.0], [v0.3.1][tmpdir-v0.3.1]
 * uri 1.0.2
-  * 0.13.0 to [v0.13.1][uri-v0.13.1], [v1.0.0][uri-v1.0.0], [v1.0.1][uri-v1.0.1], [v1.0.2][uri-v1.0.2]
+    * 0.13.0 to [v0.13.1][uri-v0.13.1], [v1.0.0][uri-v1.0.0], [v1.0.1][uri-v1.0.1], [v1.0.2][uri-v1.0.2]
 * win32ole 1.9.1
-  * 1.8.10 to [v1.9.0][win32ole-v1.9.0], [v1.9.1][win32ole-v1.9.1]
+    * 1.8.10 to [v1.9.0][win32ole-v1.9.0], [v1.9.1][win32ole-v1.9.1]
 * yaml 0.4.0
-  * 0.3.0 to [v0.4.0][yaml-v0.4.0]
+    * 0.3.0 to [v0.4.0][yaml-v0.4.0]
 * zlib 3.2.1
-  * 3.1.0 to [v3.1.1][zlib-v3.1.1], [v3.2.0][zlib-v3.2.0], [v3.2.1][zlib-v3.2.1]
+    * 3.1.0 to [v3.1.1][zlib-v3.1.1], [v3.2.0][zlib-v3.2.0], [v3.2.1][zlib-v3.2.1]
 
 The following bundled gem is added.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -276,56 +276,56 @@ The following default gems are updated.
 
 The following bundled gem is added.
 
-* repl_type_completor 0.1.9
+* [repl_type_completor][repl_type_completor] 0.1.9
 
 The following bundled gems are updated.
 
-* minitest 5.25.4
-* power_assert 2.0.4
-  * 2.0.3 to [v2.0.4][power_assert-v2.0.4]
-* rake 13.2.1
-  * 13.1.0 to [v13.2.0][rake-v13.2.0], [v13.2.1][rake-v13.2.1]
-* test-unit 3.6.7
-  * 3.6.1 to [3.6.2][test-unit-3.6.2], [3.6.3][test-unit-3.6.3], [3.6.4][test-unit-3.6.4], [3.6.5][test-unit-3.6.5], [3.6.6][test-unit-3.6.6], [3.6.7][test-unit-3.6.7]
-* rexml 3.4.0
-  * 3.2.6 to [v3.2.7][rexml-v3.2.7], [v3.2.8][rexml-v3.2.8], [v3.2.9][rexml-v3.2.9], [v3.3.0][rexml-v3.3.0], [v3.3.1][rexml-v3.3.1], [v3.3.2][rexml-v3.3.2], [v3.3.3][rexml-v3.3.3], [v3.3.4][rexml-v3.3.4], [v3.3.5][rexml-v3.3.5], [v3.3.6][rexml-v3.3.6], [v3.3.7][rexml-v3.3.7], [v3.3.8][rexml-v3.3.8], [v3.3.9][rexml-v3.3.9], [v3.4.0][rexml-v3.4.0]
-* rss 0.3.1
-  * 0.3.0 to [0.3.1][rss-0.3.1]
-* net-ftp 0.3.8
-  * 0.3.3 to [v0.3.4][net-ftp-v0.3.4], [v0.3.5][net-ftp-v0.3.5], [v0.3.6][net-ftp-v0.3.6], [v0.3.7][net-ftp-v0.3.7], [v0.3.8][net-ftp-v0.3.8]
-* net-imap 0.5.2
-  * 0.4.9 to [v0.4.9.1][net-imap-v0.4.9.1], [v0.4.10][net-imap-v0.4.10], [v0.4.11][net-imap-v0.4.11], [v0.4.12][net-imap-v0.4.12], [v0.4.13][net-imap-v0.4.13], [v0.4.14][net-imap-v0.4.14], [v0.4.15][net-imap-v0.4.15], [v0.4.16][net-imap-v0.4.16], [v0.4.17][net-imap-v0.4.17], [v0.5.0][net-imap-v0.5.0], [v0.4.18][net-imap-v0.4.18], [v0.5.1][net-imap-v0.5.1], [v0.5.2][net-imap-v0.5.2]
-* net-smtp 0.5.0
-  * 0.4.0 to [v0.4.0.1][net-smtp-v0.4.0.1], [v0.5.0][net-smtp-v0.5.0]
-* prime 0.1.3
-  * [v0.1.3][prime-v0.1.3]
-* rbs 3.7.0
-  * 3.4.0 to [v3.4.1][rbs-v3.4.1], [v3.4.2][rbs-v3.4.2], [v3.4.3][rbs-v3.4.3], [v3.4.4][rbs-v3.4.4], [v3.5.0.pre.1][rbs-v3.5.0.pre.1], [v3.5.0.pre.2][rbs-v3.5.0.pre.2], [v3.5.0][rbs-v3.5.0], [v3.5.1][rbs-v3.5.1], [v3.5.2][rbs-v3.5.2], [v3.5.3][rbs-v3.5.3], [v3.6.0.dev.1][rbs-v3.6.0.dev.1], [v3.6.0.pre.1][rbs-v3.6.0.pre.1], [v3.6.0.pre.2][rbs-v3.6.0.pre.2], [v3.6.0.pre.3][rbs-v3.6.0.pre.3], [v3.6.0][rbs-v3.6.0], [v3.6.1][rbs-v3.6.1], [v3.7.0.dev.1][rbs-v3.7.0.dev.1], [v3.7.0.pre.1][rbs-v3.7.0.pre.1], [v3.7.0][rbs-v3.7.0]
-* debug 1.10.0
-  * 1.9.1 to [v1.9.2][debug-v1.9.2], [v1.10.0][debug-v1.10.0]
-* racc 1.8.1
-  * 1.7.3 to [v1.8.0][racc-v1.8.0], [v1.8.1][racc-v1.8.1]
+* [minitest][minitest] 5.25.4
+* [power_assert][power_assert] 2.0.4
+    * 2.0.3 to [v2.0.4][power_assert-v2.0.4]
+* [rake][rake] 13.2.1
+    * 13.1.0 to [v13.2.0][rake-v13.2.0], [v13.2.1][rake-v13.2.1]
+* [test-unit][test-unit] 3.6.7
+    * 3.6.1 to [3.6.2][test-unit-3.6.2], [3.6.3][test-unit-3.6.3], [3.6.4][test-unit-3.6.4], [3.6.5][test-unit-3.6.5], [3.6.6][test-unit-3.6.6], [3.6.7][test-unit-3.6.7]
+* [rexml][rexml] 3.4.0
+    * 3.2.6 to [v3.2.7][rexml-v3.2.7], [v3.2.8][rexml-v3.2.8], [v3.2.9][rexml-v3.2.9], [v3.3.0][rexml-v3.3.0], [v3.3.1][rexml-v3.3.1], [v3.3.2][rexml-v3.3.2], [v3.3.3][rexml-v3.3.3], [v3.3.4][rexml-v3.3.4], [v3.3.5][rexml-v3.3.5], [v3.3.6][rexml-v3.3.6], [v3.3.7][rexml-v3.3.7], [v3.3.8][rexml-v3.3.8], [v3.3.9][rexml-v3.3.9], [v3.4.0][rexml-v3.4.0]
+* [rss][rss] 0.3.1
+    * 0.3.0 to [0.3.1][rss-0.3.1]
+* [net-ftp][net-ftp] 0.3.8
+    * 0.3.3 to [v0.3.4][net-ftp-v0.3.4], [v0.3.5][net-ftp-v0.3.5], [v0.3.6][net-ftp-v0.3.6], [v0.3.7][net-ftp-v0.3.7], [v0.3.8][net-ftp-v0.3.8]
+* [net-imap][net-imap] 0.5.2
+    * 0.4.9 to [v0.4.9.1][net-imap-v0.4.9.1], [v0.4.10][net-imap-v0.4.10], [v0.4.11][net-imap-v0.4.11], [v0.4.12][net-imap-v0.4.12], [v0.4.13][net-imap-v0.4.13], [v0.4.14][net-imap-v0.4.14], [v0.4.15][net-imap-v0.4.15], [v0.4.16][net-imap-v0.4.16], [v0.4.17][net-imap-v0.4.17], [v0.5.0][net-imap-v0.5.0], [v0.4.18][net-imap-v0.4.18], [v0.5.1][net-imap-v0.5.1], [v0.5.2][net-imap-v0.5.2]
+* [net-smtp][net-smtp] 0.5.0
+    * 0.4.0 to [v0.4.0.1][net-smtp-v0.4.0.1], [v0.5.0][net-smtp-v0.5.0]
+* [prime][prime] 0.1.3
+    * [v0.1.3][prime-v0.1.3]
+* [rbs][rbs] 3.7.0
+    * 3.4.0 to [v3.4.1][rbs-v3.4.1], [v3.4.2][rbs-v3.4.2], [v3.4.3][rbs-v3.4.3], [v3.4.4][rbs-v3.4.4], [v3.5.0.pre.1][rbs-v3.5.0.pre.1], [v3.5.0.pre.2][rbs-v3.5.0.pre.2], [v3.5.0][rbs-v3.5.0], [v3.5.1][rbs-v3.5.1], [v3.5.2][rbs-v3.5.2], [v3.5.3][rbs-v3.5.3], [v3.6.0.dev.1][rbs-v3.6.0.dev.1], [v3.6.0.pre.1][rbs-v3.6.0.pre.1], [v3.6.0.pre.2][rbs-v3.6.0.pre.2], [v3.6.0.pre.3][rbs-v3.6.0.pre.3], [v3.6.0][rbs-v3.6.0], [v3.6.1][rbs-v3.6.1], [v3.7.0.dev.1][rbs-v3.7.0.dev.1], [v3.7.0.pre.1][rbs-v3.7.0.pre.1], [v3.7.0][rbs-v3.7.0]
+* [debug][debug] 1.10.0
+    * 1.9.1 to [v1.9.2][debug-v1.9.2], [v1.10.0][debug-v1.10.0]
+* [racc][racc] 1.8.1
+    * 1.7.3 to [v1.8.0][racc-v1.8.0], [v1.8.1][racc-v1.8.1]
 
 The following bundled gems are promoted from default gems.
 
-* mutex_m 0.3.0
-  * 0.2.0 to [v0.3.0][mutex_m-v0.3.0]
-* getoptlong 0.2.1
-* base64 0.2.0
-* bigdecimal 3.1.8
-  * 3.1.5 to [v3.1.6][bigdecimal-v3.1.6], [v3.1.7][bigdecimal-v3.1.7], [v3.1.8][bigdecimal-v3.1.8]
-* observer 0.1.2
-* abbrev 0.1.2
-* resolv-replace 0.1.1
-* rinda 0.2.0
-* drb 2.2.1
-  * 2.2.0 to [v2.2.1][drb-v2.2.1]
-* nkf 0.2.0
-  * 0.1.3 to [v0.2.0][nkf-v0.2.0]
-* syslog 0.2.0
-  * 0.1.2 to [v0.2.0][syslog-v0.2.0]
-* csv 3.3.1
-  * 3.2.8 to [v3.2.9][csv-v3.2.9], [v3.3.0][csv-v3.3.0], [v3.3.1][csv-v3.3.1]
+* [mutex_m][mutex_m] 0.3.0
+    * 0.2.0 to [v0.3.0][mutex_m-v0.3.0]
+* [getoptlong][getoptlong] 0.2.1
+* [base64][base64] 0.2.0
+* [bigdecimal][bigdecimal] 3.1.8
+    * 3.1.5 to [v3.1.6][bigdecimal-v3.1.6], [v3.1.7][bigdecimal-v3.1.7], [v3.1.8][bigdecimal-v3.1.8]
+* [observer][observer] 0.1.2
+* [abbrev][abbrev] 0.1.2
+* [resolv-replace][resolv-replace] 0.1.1
+* [rinda][rinda] 0.2.0
+* [drb][drb] 2.2.1
+    * 2.2.0 to [v2.2.1][drb-v2.2.1]
+* [nkf][nkf] 0.2.0
+    * 0.1.3 to [v0.2.0][nkf-v0.2.0]
+* [syslog][syslog] 0.2.0
+    * 0.1.2 to [v0.2.0][syslog-v0.2.0]
+* [csv][csv] 3.3.1
+    * 3.2.8 to [v3.2.9][csv-v3.2.9], [v3.3.0][csv-v3.3.0], [v3.3.1][csv-v3.3.1]
 
 ## Supported platforms
 
@@ -845,3 +845,30 @@ The following bundled gems are promoted from default gems.
 [win32ole]: https://github.com/ruby/win32ole
 [yaml]: https://github.com/ruby/yaml
 [zlib]: https://github.com/ruby/zlib
+
+[repl_type_completor]: https://github.com/ruby/repl_type_completor
+[minitest]: https://github.com/seattlerb/minitest
+[power_assert]: https://github.com/ruby/power_assert
+[rake]: https://github.com/ruby/rake
+[test-unit]: https://github.com/test-unit/test-unit
+[rexml]: https://github.com/ruby/rexml
+[rss]: https://github.com/ruby/rss
+[net-ftp]: https://github.com/ruby/net-ftp
+[net-imap]: https://github.com/ruby/net-imap
+[net-smtp]: https://github.com/ruby/net-smtp
+[prime]: https://github.com/ruby/prime
+[rbs]: https://github.com/ruby/rbs
+[debug]: https://github.com/ruby/debug
+[racc]: https://github.com/ruby/racc
+[mutex_m]: https://github.com/ruby/mutex_m
+[getoptlong]: https://github.com/ruby/getoptlong
+[base64]: https://github.com/ruby/base64
+[bigdecimal]: https://github.com/ruby/bigdecimal
+[observer]: https://github.com/ruby/observer
+[abbrev]: https://github.com/ruby/abbrev
+[resolv-replace]: https://github.com/ruby/resolv-replace
+[rinda]: https://github.com/ruby/rinda
+[drb]: https://github.com/ruby/drb
+[nkf]: https://github.com/ruby/nkf
+[syslog]: https://github.com/ruby/syslog
+[csv]: https://github.com/ruby/csv

--- a/NEWS.md
+++ b/NEWS.md
@@ -181,97 +181,97 @@ The following default gem is added.
 
 The following default gems are updated.
 
-* RubyGems 3.6.1
+* [RubyGems][RubyGems] 3.6.1
     * 3.5.3 to [v3.5.4][RubyGems-v3.5.4], [v3.5.5][RubyGems-v3.5.5], [v3.5.6][RubyGems-v3.5.6], [v3.5.7][RubyGems-v3.5.7], [v3.5.8][RubyGems-v3.5.8], [v3.5.9][RubyGems-v3.5.9], [v3.5.10][RubyGems-v3.5.10], [v3.5.11][RubyGems-v3.5.11], [v3.5.12][RubyGems-v3.5.12], [v3.5.13][RubyGems-v3.5.13], [v3.5.14][RubyGems-v3.5.14], [v3.5.15][RubyGems-v3.5.15], [v3.5.16][RubyGems-v3.5.16], [v3.5.17][RubyGems-v3.5.17], [v3.5.18][RubyGems-v3.5.18], [v3.5.19][RubyGems-v3.5.19], [v3.5.20][RubyGems-v3.5.20], [v3.5.21][RubyGems-v3.5.21], [v3.5.22][RubyGems-v3.5.22], [v3.5.23][RubyGems-v3.5.23], [v3.6.0][RubyGems-v3.6.0], [v3.6.1][RubyGems-v3.6.1]
-* benchmark 0.4.0
+* [benchmark][benchmark] 0.4.0
     * 0.3.0 to [v0.4.0][benchmark-v0.4.0]
-* bundler 2.6.1
-    * 2.5.3 to [v2.5.4][bundler-v2.5.4], [v2.5.5][bundler-v2.5.5], [v2.5.6][bundler-v2.5.6], [v2.5.7][bundler-v2.5.7], [v2.5.8][bundler-v2.5.8], [v2.5.9][bundler-v2.5.9], [v2.5.10][bundler-v2.5.10], [v2.5.11][bundler-v2.5.11], [v2.5.12][bundler-v2.5.12], [v2.5.13][bundler-v2.5.13], [v2.5.14][bundler-v2.5.14], [v2.5.15][bundler-v2.5.15], [v2.5.16][bundler-v2.5.16], [v2.5.17][bundler-v2.5.17], [v2.5.18][bundler-v2.5.18], [v2.5.19][bundler-v2.5.19], [v2.5.20][bundler-v2.5.20], [v2.5.21][bundler-v2.5.21], [v2.5.22][bundler-v2.5.22], [v2.5.23][bundler-v2.5.23], [v2.6.0][bundler-v2.6.0], [v2.6.1][bundler-v2.6.1]
-* date 3.4.1
+* [bundler][bundler] 2.6.1
+    * 2.5.3 to [v2.5.4][bundler-v2.5.4], [v2.5.5][bundler-v2.5.5], [v2.5.6][bundler-v2.5.6], [v2.5.7][bundler-v2.5.7], [v2.5.8][bundler-v2.5.8], [v2.5.9][bundler-v2.5.9], [v2.5.10][bundler-v2.5.10], [v2.5.11][bundler-v2.5.11], [v2.5.12][bundler-v2.5.12], [v2.5.13][bundler-v2.5.13], [v2.5.14][bundler-v2.5.5.14], [v2.5.15][bundler-v2.5.15], [v2.5.16][bundler-v2.5.16], [v2.5.17][bundler-v2.5.17], [v2.5.18][bundler-v2.5.18], [v2.5.19][bundler-v2.5.19], [v2.5.20][bundler-v2.5.20], [v2.5.21][bundler-v2.5.21], [v2.5.22][bundler-v2.5.22], [v2.5.23][bundler-v2.5.23], [v2.6.0][bundler-v2.6.0], [v2.6.1][bundler-v2.6.1]
+* [date][date] 3.4.1
     * 3.3.4 to [v3.4.0][date-v3.4.0], [v3.4.1][date-v3.4.1]
-* delegate 0.4.0
+* [delegate][delegate] 0.4.0
     * 0.3.1 to [v0.4.0][delegate-v0.4.0]
-* did_you_mean 2.0.0
+* [did_you_mean][did_you_mean] 2.0.0
     * 1.6.3 to [v2.0.0][did_you_mean-v2.0.0]
-* digest 3.2.0
+* [digest][digest] 3.2.0
     * 3.1.1 to [v3.2.0.pre0][digest-v3.2.0.pre0], [v3.2.0][digest-v3.2.0]
-* erb 4.0.4
+* [erb][erb] 4.0.4
     * 4.0.3 to [v4.0.4][erb-v4.0.4]
-* error_highlight 0.7.0
+* [error_highlight][error_highlight] 0.7.0
     * 0.6.0 to [v0.7.0][error_highlight-v0.7.0]
-* etc 1.4.5
+* [etc][etc] 1.4.5
     * 1.4.3 to [v1.4.4][etc-v1.4.4], [v1.4.5][etc-v1.4.5]
-* fcntl 1.2.0
+* [fcntl][fcntl] 1.2.0
     * 1.1.0 to [v1.2.0][fcntl-v1.2.0]
-* fiddle 1.1.6
+* [fiddle][fiddle] 1.1.6
     * 1.1.2 to [v1.1.3][fiddle-v1.1.3], [v1.1.4][fiddle-v1.1.4], [v1.1.5][fiddle-v1.1.5], [v1.1.6][fiddle-v1.1.6]
-* fileutils 1.7.3
+* [fileutils][fileutils] 1.7.3
     * 1.7.2 to [v1.7.3][fileutils-v1.7.3]
-* io-console 0.8.0
+* [io-console][io-console] 0.8.0
     * 0.7.1 to [v0.7.2][io-console-v0.7.2], [v0.8.0.beta1][io-console-v0.8.0.beta1], [v0.8.0][io-console-v0.8.0]
-* io-nonblock 0.3.1
+* [io-nonblock][io-nonblock] 0.3.1
     * 0.3.0 to [v0.3.1][io-nonblock-v0.3.1]
-* ipaddr 1.2.7
+* [ipaddr][ipaddr] 1.2.7
     * 1.2.6 to [v1.2.7][ipaddr-v1.2.7]
-* irb 1.14.3
+* [irb][irb] 1.14.3
     * 1.11.0 to [v1.11.1][irb-v1.11.1], [v1.11.2][irb-v1.11.2], [v1.12.0][irb-v1.12.0], [v1.13.0][irb-v1.13.0], [v1.13.1][irb-v1.13.1], [v1.13.2][irb-v1.13.2], [v1.14.0][irb-v1.14.0], [v1.14.1][irb-v1.14.1], [v1.14.2][irb-v1.14.2], [v1.14.3][irb-v1.14.3]
-* json 2.9.1
+* [json][json] 2.9.1
     * 2.7.1 to [v2.7.2][json-v2.7.2], [v2.7.3.rc1][json-v2.7.3.rc1], [v2.7.3][json-v2.7.3], [v2.7.4][json-v2.7.4], [v2.7.5][json-v2.7.5], [v2.7.6][json-v2.7.6], [v2.8.0][json-v2.8.0], [v2.8.1][json-v2.8.1], [v2.8.2][json-v2.8.2], [v2.9.0][json-v2.9.0], [v2.9.1][json-v2.9.1]
-* logger 1.6.4
+* [logger][logger] 1.6.4
     * 1.6.0 to [v1.6.1][logger-v1.6.1], [v1.6.2][logger-v1.6.2], [v1.6.3][logger-v1.6.3], [v1.6.4][logger-v1.6.4]
-* net-http 0.6.0
+* [net-http][net-http] 0.6.0
     * 0.4.0 to [v0.4.1][net-http-v0.4.1], [v0.5.0][net-http-v0.5.0], [v0.6.0][net-http-v0.6.0]
-* open-uri 0.5.0
+* [open-uri][open-uri] 0.5.0
     * 0.4.1 to [v0.5.0][open-uri-v0.5.0]
-* optparse 0.6.0
+* [optparse][optparse] 0.6.0
     * 0.4.0 to [v0.5.0][optparse-v0.5.0], [v0.6.0][optparse-v0.6.0]
-* ostruct 0.6.1
+* [ostruct][ostruct] 0.6.1
     * 0.6.0 to [v0.6.1][ostruct-v0.6.1]
-* pathname 0.4.0
+* [pathname][pathname] 0.4.0
     * 0.3.0 to [v0.4.0][pathname-v0.4.0]
-* pp 0.6.2
+* [pp][pp] 0.6.2
     * 0.5.0 to [v0.6.0][pp-v0.6.0], [v0.6.1][pp-v0.6.1], [v0.6.2][pp-v0.6.2]
-* prism 1.2.0
+* [prism][prism] 1.2.0
     * 0.19.0 to [v0.20.0][prism-v0.20.0], [v0.21.0][prism-v0.21.0], [v0.22.0][prism-v0.22.0], [v0.23.0][prism-v0.23.0], [v0.24.0][prism-v0.24.0], [v0.25.0][prism-v0.25.0], [v0.26.0][prism-v0.26.0], [v0.27.0][prism-v0.27.0], [v0.28.0][prism-v0.28.0], [v0.29.0][prism-v0.29.0], [v0.30.0][prism-v0.30.0], [v1.0.0][prism-v1.0.0], [v1.1.0][prism-v1.1.0], [v1.2.0][prism-v1.2.0]
-* pstore 0.1.4
+* [pstore][pstore] 0.1.4
     * 0.1.3 to [v0.1.4][pstore-v0.1.4]
-* psych 5.2.2
+* [psych][psych] 5.2.2
     * 5.1.2 to [v5.2.0.beta1][psych-v5.2.0.beta1], [v5.2.0.beta2][psych-v5.2.0.beta2], [v5.2.0.beta3][psych-v5.2.0.beta3], [v5.2.0.beta4][psych-v5.2.0.beta4], [v5.2.0.beta5][psych-v5.2.0.beta5], [v5.2.0.beta6][psych-v5.2.0.beta6], [v5.2.0.beta7][psych-v5.2.0.beta7], [v5.2.0][psych-v5.2.0], [v5.2.1][psych-v5.2.1], [v5.2.2][psych-v5.2.2]
-* rdoc 6.10.0
+* [rdoc][rdoc] 6.10.0
     * 6.6.2 to [v6.7.0][rdoc-v6.7.0], [v6.8.0][rdoc-v6.8.0], [v6.8.1][rdoc-v6.8.1], [v6.9.0][rdoc-v6.9.0], [v6.9.1][rdoc-v6.9.1], [v6.10.0][rdoc-v6.10.0]
-* reline 0.6.0
+* [reline][reline] 0.6.0
     * 0.4.1 to [v0.4.2][reline-v0.4.2], [v0.4.3][reline-v0.4.3], [v0.5.0.pre.1][reline-v0.5.0.pre.1], [v0.5.0][reline-v0.5.0], [v0.5.1][reline-v0.5.1], [v0.5.2][reline-v0.5.2], [v0.5.3][reline-v0.5.3], [v0.5.4][reline-v0.5.4], [v0.5.5][reline-v0.5.5], [v0.5.6][reline-v0.5.6], [v0.5.7][reline-v0.5.7], [v0.5.8][reline-v0.5.8], [v0.5.9][reline-v0.5.9], [v0.5.10][reline-v0.5.10], [v0.5.11][reline-v0.5.11], [v0.5.12][reline-v0.5.12], [v0.6.0][reline-v0.6.0]
-* resolv 0.6.0
+* [resolv][resolv] 0.6.0
     * 0.3.0 to [v0.4.0][resolv-v0.4.0], [v0.5.0][resolv-v0.5.0], [v0.6.0][resolv-v0.6.0]
-* securerandom 0.4.1
+* [securerandom][securerandom] 0.4.1
     * 0.3.1 to [v0.3.2][securerandom-v0.3.2], [v0.4.0][securerandom-v0.4.0], [v0.4.1][securerandom-v0.4.1]
-* set 1.1.1
+* [set][set] 1.1.1
     * 1.1.0 to [v1.1.1][set-v1.1.1]
-* shellwords 0.2.2
+* [shellwords][shellwords] 0.2.2
     * 0.2.0 to [v0.2.1][shellwords-v0.2.1], [v0.2.2][shellwords-v0.2.2]
-* singleton 0.3.0
+* [singleton][singleton] 0.3.0
     * 0.2.0 to [v0.3.0][singleton-v0.3.0]
-* stringio 3.1.2
+* [stringio][stringio] 3.1.2
     * 3.1.0 to [v3.1.1][stringio-v3.1.1], [v3.1.2][stringio-v3.1.2]
-* strscan 3.1.2
+* [strscan][strscan] 3.1.2
     * 3.0.7 to [v3.0.8][strscan-v3.0.8], [v3.0.9][strscan-v3.0.9], [v3.1.0][strscan-v3.1.0], [v3.1.1][strscan-v3.1.1], [v3.1.2][strscan-v3.1.2]
-* syntax_suggest 2.0.2
+* [syntax_suggest][syntax_suggest] 2.0.2
     * 2.0.0 to [v2.0.1][syntax_suggest-v2.0.1], [v2.0.2][syntax_suggest-v2.0.2]
-* tempfile 0.3.1
+* [tempfile][tempfile] 0.3.1
     * 0.2.1 to [v0.3.0][tempfile-v0.3.0], [v0.3.1][tempfile-v0.3.1]
-* time 0.4.1
+* [time][time] 0.4.1
     * 0.3.0 to [v0.4.0][time-v0.4.0], [v0.4.1][time-v0.4.1]
-* timeout 0.4.3
+* [timeout][timeout] 0.4.3
     * 0.4.1 to [v0.4.2][timeout-v0.4.2], [v0.4.3][timeout-v0.4.3]
-* tmpdir 0.3.1
+* [tmpdir][tmpdir] 0.3.1
     * 0.2.0 to [v0.3.0][tmpdir-v0.3.0], [v0.3.1][tmpdir-v0.3.1]
-* uri 1.0.2
+* [uri][uri] 1.0.2
     * 0.13.0 to [v0.13.1][uri-v0.13.1], [v1.0.0][uri-v1.0.0], [v1.0.1][uri-v1.0.1], [v1.0.2][uri-v1.0.2]
-* win32ole 1.9.1
+* [win32ole][win32ole] 1.9.1
     * 1.8.10 to [v1.9.0][win32ole-v1.9.0], [v1.9.1][win32ole-v1.9.1]
-* yaml 0.4.0
+* [yaml][yaml] 0.4.0
     * 0.3.0 to [v0.4.0][yaml-v0.4.0]
-* zlib 3.2.1
+* [zlib][zlib] 3.2.1
     * 3.1.0 to [v3.1.1][zlib-v3.1.1], [v3.2.0][zlib-v3.2.0], [v3.2.1][zlib-v3.2.1]
 
 The following bundled gem is added.
@@ -798,3 +798,50 @@ The following bundled gems are promoted from default gems.
 [csv-v3.3.0]: https://github.com/ruby/csv/releases/tag/v3.3.0
 [csv-v3.3.1]: https://github.com/ruby/csv/releases/tag/v3.3.1
 [ruby/net-http-sspi]: https://github.com/ruby/net-http-sspi
+
+[RubyGems]: https://github.com/rubygems/rubygems
+[benchmark]: https://github.com/ruby/benchmark
+[bundler]: https://github.com/rubygems/rubygems
+[date]: https://github.com/ruby/date
+[delegate]: https://github.com/ruby/delegate
+[did_you_mean]: https://github.com/ruby/did_you_mean
+[digest]: https://github.com/ruby/digest
+[erb]: https://github.com/ruby/erb
+[error_highlight]: https://github.com/ruby/error_highlight
+[etc]: https://github.com/ruby/etc
+[fcntl]: https://github.com/ruby/fcntl
+[fiddle]: https://github.com/ruby/fiddle
+[fileutils]: https://github.com/ruby/fileutils
+[io-console]: https://github.com/ruby/io-console
+[io-nonblock]: https://github.com/ruby/io-nonblock
+[ipaddr]: https://github.com/ruby/ipaddr
+[irb]: https://github.com/ruby/irb
+[json]: https://github.com/ruby/json
+[logger]: https://github.com/ruby/logger
+[net-http]: https://github.com/ruby/net-http
+[open-uri]: https://github.com/ruby/open-uri
+[optparse]: https://github.com/ruby/optparse
+[ostruct]: https://github.com/ruby/ostruct
+[pathname]: https://github.com/ruby/pathname
+[pp]: https://github.com/ruby/pp
+[prism]: https://github.com/ruby/prism
+[pstore]: https://github.com/ruby/pstore
+[psych]: https://github.com/ruby/psych
+[rdoc]: https://github.com/ruby/rdoc
+[reline]: https://github.com/ruby/reline
+[resolv]: https://github.com/ruby/resolv
+[securerandom]: https://github.com/ruby/securerandom
+[set]: https://github.com/ruby/set
+[shellwords]: https://github.com/ruby/shellwords
+[singleton]: https://github.com/ruby/singleton
+[stringio]: https://github.com/ruby/stringio
+[strscan]: https://github.com/ruby/strscan
+[syntax_suggest]: https://github.com/ruby/syntax_suggest
+[tempfile]: https://github.com/ruby/tempfile
+[time]: https://github.com/ruby/time
+[timeout]: https://github.com/ruby/timeout
+[tmpdir]: https://github.com/ruby/tmpdir
+[uri]: https://github.com/ruby/uri
+[win32ole]: https://github.com/ruby/win32ole
+[yaml]: https://github.com/ruby/yaml
+[zlib]: https://github.com/ruby/zlib


### PR DESCRIPTION
1. RDoc's markdown parser expects 4 spaces for nested lists. So currently default/bundled gems' releases are not rendered correctly on [docs.ruby-lang.org/en](https://docs.ruby-lang.org/en/master/NEWS_md.html)
    <img width="50%" alt="Screenshot 2024-12-18 at 20 18 42" src="https://github.com/user-attachments/assets/6d55fbe2-c5de-45d4-b1b1-8f550c1e5c8a" />

2. I think it'd be very helpful to link to default/bundled gems' GitHub repos.