### PR TITLE
[DOC] Link to special `fatal` class through `rdoc-ref`

### DIFF
--- a/error.c
+++ b/error.c
@@ -3434,7 +3434,7 @@ syserr_eqq(VALUE self, VALUE exc)
  *    * ZeroDivisionError
  *  * SystemExit
  *  * SystemStackError
- *  * {fatal}[https://docs.ruby-lang.org/en/master/fatal.html]
+ *  * {fatal}[rdoc-ref:fatal]
  *
  */
 


### PR DESCRIPTION
It's a small change but documentation in `ruby/ruby` should always use `rdoc-ref` when possible.

This change also makes the item's style more consistent with the rest of the list:

<img width="30%" alt="Screenshot 2024-12-18 at 20 38 58" src="https://github.com/user-attachments/assets/10a2e989-0afc-465a-a4e9-a4edc2f2c9ec" />

### Before

<img width="30%" alt="Screenshot 2024-12-18 at 20 39 38" src="https://github.com/user-attachments/assets/e61dd4d5-408d-4058-9bc1-dda8651d1916" />
