### PR TITLE
Memerror is fatal if VM cannot be unlocked.

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4460,7 +4460,8 @@ rb_memerror(void)
     VALUE exc = GET_VM()->special_exceptions[ruby_error_nomemory];
 
     if (!exc ||
-        rb_ec_raised_p(ec, RAISED_NOMEMORY)) {
+        rb_ec_raised_p(ec, RAISED_NOMEMORY) ||
+        rb_ec_vm_lock_rec(ec) != ec->tag->lock_rec) {
         fprintf(stderr, "[FATAL] failed to allocate memory\n");
         exit(EXIT_FAILURE);
     }


### PR DESCRIPTION
[Bug #20942]

If we've raised a memerror while the VM is locked, and the tag we're jumping to has been locked at a different level to the current lock (ie. we've locked the VM again since the tag we're jumping to) then we should consider this memerror fatal and exit, since the tag cannot unlock the VM.