### PR TITLE
ruby2_keywords warning: Fully quote non-UTF8 method names

### DIFF
--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -2794,6 +2794,12 @@ class TestKeywordArguments < Test::Unit::TestCase
       assert_nil(c.send(:ruby2_keywords, :bar))
     end
 
+    utf16_sym = "abcdef".encode("UTF-16LE").to_sym
+    c.send(:define_method, utf16_sym, c.instance_method(:itself))
+    assert_warn(/abcdef/) do
+      assert_nil(c.send(:ruby2_keywords, utf16_sym))
+    end
+
     o = Object.new
     class << o
       alias bar p

--- a/vm_method.c
+++ b/vm_method.c
@@ -2605,7 +2605,7 @@ rb_mod_ruby2_keywords(int argc, VALUE *argv, VALUE module)
                     rb_clear_method_cache(module, name);
                 }
                 else {
-                    rb_warn("Skipping set of ruby2_keywords flag for %s (method accepts keywords or method does not accept argument splat)", rb_id2name(name));
+                    rb_warn("Skipping set of ruby2_keywords flag for %"PRIsVALUE" (method accepts keywords or method does not accept argument splat)", QUOTE_ID(name));
                 }
                 break;
               case VM_METHOD_TYPE_BMETHOD: {
@@ -2624,19 +2624,19 @@ rb_mod_ruby2_keywords(int argc, VALUE *argv, VALUE module)
                         rb_clear_method_cache(module, name);
                     }
                     else {
-                        rb_warn("Skipping set of ruby2_keywords flag for %s (method accepts keywords or method does not accept argument splat)", rb_id2name(name));
+                        rb_warn("Skipping set of ruby2_keywords flag for %"PRIsVALUE" (method accepts keywords or method does not accept argument splat)", QUOTE_ID(name));
                     }
                     break;
                 }
               }
               /* fallthrough */
               default:
-                rb_warn("Skipping set of ruby2_keywords flag for %s (method not defined in Ruby)", rb_id2name(name));
+                rb_warn("Skipping set of ruby2_keywords flag for %"PRIsVALUE" (method not defined in Ruby)", QUOTE_ID(name));
                 break;
             }
         }
         else {
-            rb_warn("Skipping set of ruby2_keywords flag for %s (can only set in method defining module)", rb_id2name(name));
+            rb_warn("Skipping set of ruby2_keywords flag for %"PRIsVALUE" (can only set in method defining module)", QUOTE_ID(name));
         }
     }
     return Qnil;


### PR DESCRIPTION
It used to quote only part of the method name because NUL byte in
the method terminates the C string:

```
(irb)> "abcdef".encode("UTF-16LE").bytes
=> [97, 0, 98, 0, 99, 0, 100, 0, 101, 0, 102, 0]
```

```
expected: /abcdef/
actual: warning: Skipping set of ruby2_keywords flag for a (method not defined in Ruby)\n".
```
