### PR TITLE
[DOC] Move Time#xmlschema docs to the core

### DIFF
--- a/time.c
+++ b/time.c
@@ -5242,6 +5242,27 @@ time_strftime(VALUE time, VALUE format)
     }
 }
 
+/*
+ *  call-seq:
+ *    xmlschema(fraction_digits=0) -> string
+ *
+ *  Returns a string which represents the time as a dateTime defined by XML
+ *  Schema:
+ *
+ *    CCYY-MM-DDThh:mm:ssTZD
+ *    CCYY-MM-DDThh:mm:ss.sssTZD
+ *
+ *  where TZD is Z or [+-]hh:mm.
+ *
+ *  If self is a UTC time, Z is used as TZD.  [+-]hh:mm is used otherwise.
+ *
+ *  +fraction_digits+ specifies a number of digits to use for fractional
+ *  seconds.  Its default value is 0.
+ *
+ *      t = Time.now
+ *      t.xmlschema  # => "2011-10-05T22:26:12-04:00"
+ */
+
 static VALUE
 time_xmlschema(int argc, VALUE *argv, VALUE time)
 {


### PR DESCRIPTION
While `Time#xmlschema` was moved to `time.c` in [Feature #20707](https://bugs.ruby-lang.org/issues/20707), its docs [still suggest](https://docs.ruby-lang.org/en/master/Time.html#method-i-xmlschema) `require 'time'` in text and code examples.

This PR does NOT solve the issue fully: while `Time#xmlschema` is still in [time.rb](https://github.com/ruby/time/blob/master/lib/time.rb#L721) (guarded by `unless method_defined?(:xmlschema)`), RDoc prefers that version of the docs.

I don’t know how to solve that right now (maybe there is some RDoc setting to prefer the “proper” version?). But I believe it makes sense to at least have a copy of the docs in the `time.c` anyway. 

PS: But actually, maybe it makes sense to remove the method from `time.rb` (and release the change in the gem version, which requires `ruby >= 3.4.0`)?..