### PR TITLE
FREE_AT_EXIT: Free all allocations from fiber pool

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -277,7 +277,12 @@ static struct fiber_pool shared_fiber_pool = {NULL, NULL, 0, 0, 0, 0};
 void
 rb_free_shared_fiber_pool(void)
 {
-    xfree(shared_fiber_pool.allocations);
+    struct fiber_pool_allocation *allocations = shared_fiber_pool.allocations;
+    while (allocations) {
+        struct fiber_pool_allocation *next = allocations->next;
+        xfree(allocations);
+        allocations = next;
+    }
 }
 
 static ID fiber_initialize_keywords[3] = {0};


### PR DESCRIPTION
The fiber pool allocations form a singly-linked list, so when we're running with RUBY_FREE_AT_EXIT we need to walk the linked list freeing each element, otherwise it can be detected as a memory leak.


```
=================================================================
==3536==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x5b2bb23fb59f in malloc /home/runner/work/llvm-project/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x5b2bb2578a33 in rb_gc_impl_malloc /home/jhawthorn/src/ruby/./gc/default/default.c:8195:5
    #2 0x5b2bb2562268 in ruby_xmalloc /home/jhawthorn/src/ruby/gc.c:4528:34
    #3 0x5b2bb250742d in fiber_pool_expand /home/jhawthorn/src/ruby/cont.c:521:49
    #4 0x5b2bb25070f7 in fiber_pool_stack_acquire /home/jhawthorn/src/ruby/cont.c:667:9
    #5 0x5b2bb2506ed8 in fiber_initialize_coroutine /home/jhawthorn/src/ruby/cont.c:872:20
    #6 0x5b2bb2506d89 in fiber_prepare_stack /home/jhawthorn/src/ruby/cont.c:2185:23
    #7 0x5b2bb2506ab5 in fiber_store /home/jhawthorn/src/ruby/cont.c:2579:9
    #8 0x5b2bb250320e in fiber_switch /home/jhawthorn/src/ruby/cont.c:2673:5
    #9 0x5b2bb27dcc3c in vm_call_cfunc_with_frame_ /home/jhawthorn/src/ruby/./vm_insnhelper.c:3801:11
    #10 0x5b2bb27aab2d in vm_sendish /home/jhawthorn/src/ruby/./vm_insnhelper.c
    #11 0x5b2bb27b23eb in vm_exec_core /home/jhawthorn/src/ruby/insns.def:898:11
    #12 0x5b2bb27ab0a7 in rb_vm_exec /home/jhawthorn/src/ruby/vm.c:2595:22
    #13 0x5b2bb2542a6c in rb_ec_exec_node /home/jhawthorn/src/ruby/eval.c:281:9
    #14 0x5b2bb2542872 in ruby_run_node /home/jhawthorn/src/ruby/eval.c:319:30
    #15 0x5b2bb243bd33 in rb_main /home/jhawthorn/src/ruby/./main.c:43:12
    #16 0x5b2bb243bc07 in main /home/jhawthorn/src/ruby/./main.c:68:12
    #17 0x7de829502e07 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #18 0x7de829502ecb in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:360:3
    #19 0x5b2bb235c2f4 in _start (/home/jhawthorn/src/ruby/miniruby+0x1752f4)

Indirect leak of 672 byte(s) in 12 object(s) allocated from:
    #0 0x5b2bb23fb59f in malloc /home/runner/work/llvm-project/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x5b2bb2578a33 in rb_gc_impl_malloc /home/jhawthorn/src/ruby/./gc/default/default.c:8195:5
    #2 0x5b2bb2562268 in ruby_xmalloc /home/jhawthorn/src/ruby/gc.c:4528:34
    #3 0x5b2bb250742d in fiber_pool_expand /home/jhawthorn/src/ruby/cont.c:521:49
    #4 0x5b2bb25070f7 in fiber_pool_stack_acquire /home/jhawthorn/src/ruby/cont.c:667:9
    #5 0x5b2bb2506ed8 in fiber_initialize_coroutine /home/jhawthorn/src/ruby/cont.c:872:20
    #6 0x5b2bb2506d89 in fiber_prepare_stack /home/jhawthorn/src/ruby/cont.c:2185:23
    #7 0x5b2bb2506ab5 in fiber_store /home/jhawthorn/src/ruby/cont.c:2579:9
    #8 0x5b2bb250320e in fiber_switch /home/jhawthorn/src/ruby/cont.c:2673:5
    #9 0x5b2bb27dcc3c in vm_call_cfunc_with_frame_ /home/jhawthorn/src/ruby/./vm_insnhelper.c:3801:11
    #10 0x5b2bb27aab2d in vm_sendish /home/jhawthorn/src/ruby/./vm_insnhelper.c
    #11 0x5b2bb27b23eb in vm_exec_core /home/jhawthorn/src/ruby/insns.def:898:11
    #12 0x5b2bb27ab0a7 in rb_vm_exec /home/jhawthorn/src/ruby/vm.c:2595:22
    #13 0x5b2bb2542a6c in rb_ec_exec_node /home/jhawthorn/src/ruby/eval.c:281:9
    #14 0x5b2bb2542872 in ruby_run_node /home/jhawthorn/src/ruby/eval.c:319:30
    #15 0x5b2bb243bd33 in rb_main /home/jhawthorn/src/ruby/./main.c:43:12
    #16 0x5b2bb243bc07 in main /home/jhawthorn/src/ruby/./main.c:68:12
    #17 0x7de829502e07 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #18 0x7de829502ecb in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:360:3
    #19 0x5b2bb235c2f4 in _start (/home/jhawthorn/src/ruby/miniruby+0x1752f4)

Indirect leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x5b2bb23fb59f in malloc /home/runner/work/llvm-project/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x5b2bb2578a33 in rb_gc_impl_malloc /home/jhawthorn/src/ruby/./gc/default/default.c:8195:5
    #2 0x5b2bb2562268 in ruby_xmalloc /home/jhawthorn/src/ruby/gc.c:4528:34
    #3 0x5b2bb250742d in fiber_pool_expand /home/jhawthorn/src/ruby/cont.c:521:49
    #4 0x5b2bb2504165 in Init_Cont /home/jhawthorn/src/ruby/cont.c:3383:5
    #5 0x5b2bb258caa9 in rb_call_inits /home/jhawthorn/src/ruby/inits.c:68:5
    #6 0x5b2bb254179d in ruby_setup /home/jhawthorn/src/ruby/eval.c:86:9
    #7 0x5b2bb2541a68 in ruby_init /home/jhawthorn/src/ruby/eval.c:98:17
    #8 0x5b2bb243bd1f in rb_main /home/jhawthorn/src/ruby/./main.c:42:5
    #9 0x5b2bb243bc07 in main /home/jhawthorn/src/ruby/./main.c:68:12
    #10 0x7de829502e07 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #11 0x7de829502ecb in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:360:3
    #12 0x5b2bb235c2f4 in _start (/home/jhawthorn/src/ruby/miniruby+0x1752f4)

SUMMARY: AddressSanitizer: 784 byte(s) leaked in 14 allocation(s).
```