### PR TITLE
Time#zone respects Encoding.default_internal

### DIFF
--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -725,7 +725,7 @@ class TestTime < Test::Unit::TestCase
     if zone.ascii_only?
       assert_equal(Encoding::US_ASCII, zone.encoding)
     else
-      enc = FIXED_ZONE_ENCODING || Encoding.find('locale')
+      enc = Encoding.default_internal || (FIXED_ZONE_ENCODING || Encoding.find('locale'))
       assert_equal(enc, zone.encoding)
     end
   end

--- a/time.c
+++ b/time.c
@@ -957,10 +957,11 @@ zone_str(const char *zone)
     }
     else {
 #if defined(_WIN32)
-        str = rb_utf8_str_new(zone, len);
+        rb_encoding *enc = rb_utf8_encoding();
 #else
-        str = rb_enc_str_new(zone, len, rb_locale_encoding());
+        rb_encoding *enc = rb_locale_encoding();
 #endif
+        str = rb_external_str_new_with_enc(zone, strlen(zone), enc);
     }
     return rb_fstring(str);
 }


### PR DESCRIPTION
[[Bug #20929]](https://bugs.ruby-lang.org/issues/20929)