### PR TITLE
[PRISM] Fix compiling popped opt_str_uminus and opt_str_freeze

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6913,6 +6913,7 @@ pm_compile_call_node(rb_iseq_t *iseq, const pm_call_node_t *node, LINK_ANCHOR *c
             VALUE value = parse_static_literal_string(iseq, scope_node, node->receiver, &((const pm_string_node_t * ) node->receiver)->unescaped);
             const struct rb_callinfo *callinfo = new_callinfo(iseq, idUMinus, 0, 0, NULL, FALSE);
             PUSH_INSN2(ret, location, opt_str_uminus, value, callinfo);
+            if (popped) PUSH_INSN(ret, location, pop);
             return;
         }
         break;
@@ -6922,6 +6923,7 @@ pm_compile_call_node(rb_iseq_t *iseq, const pm_call_node_t *node, LINK_ANCHOR *c
             VALUE value = parse_static_literal_string(iseq, scope_node, node->receiver, &((const pm_string_node_t * ) node->receiver)->unescaped);
             const struct rb_callinfo *callinfo = new_callinfo(iseq, idFreeze, 0, 0, NULL, FALSE);
             PUSH_INSN2(ret, location, opt_str_freeze, value, callinfo);
+            if (popped) PUSH_INSN(ret, location, pop);
             return;
         }
         break;

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -1993,6 +1993,10 @@ end
         end
         test_prism_call_node
       CODE
+
+      # Specialized instructions
+      assert_prism_eval(%{-"literal"})
+      assert_prism_eval(%{"literal".freeze})
     end
 
     def test_CallAndWriteNode


### PR DESCRIPTION
Put a pop as needed. This example currently causes [BUG]:

	$ ruby --parser=prism -e'1.times{"".freeze;nil}'
	-e:1: [BUG] Stack consistency error (sp: 15, bp: 14)
	ruby 3.4.0dev (2024-12-20T00:48:01Z master 978df259ca) +PRISM [x86_64-linux]