### PR TITLE
Fix bundled gem warnings locations

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -72,8 +72,9 @@ module Gem::BUNDLED_GEMS # :nodoc:
       kernel_class.send(:alias_method, :no_warning_require, :require)
       kernel_class.send(:define_method, :require) do |name|
         if message = ::Gem::BUNDLED_GEMS.warning?(name, specs: spec_names)
-          if ::Gem::BUNDLED_GEMS.uplevel > 0
-            Kernel.warn message, uplevel: ::Gem::BUNDLED_GEMS.uplevel
+          uplevel = ::Gem::BUNDLED_GEMS.uplevel
+          if uplevel > 0
+            Kernel.warn message, uplevel: uplevel
           else
             Kernel.warn message
           end

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -91,25 +91,22 @@ module Gem::BUNDLED_GEMS # :nodoc:
 
   def self.uplevel
     frame_count = 0
-    frames_to_skip = 3
+    require_labels = ["replace_require", "require"]
     uplevel = 0
     require_found = false
     Thread.each_caller_location do |cl|
       frame_count += 1
-      if frames_to_skip >= 1
-        frames_to_skip -= 1
-        next
-      end
-      uplevel += 1
+
       if require_found
-        if cl.base_label != "require"
+        unless require_labels.include?(cl.base_label)
           return uplevel
         end
       else
-        if cl.base_label == "require"
+        if require_labels.include?(cl.base_label)
           require_found = true
         end
       end
+      uplevel += 1
       # Don't show script name when bundle exec and call ruby script directly.
       if cl.path.end_with?("bundle")
         frame_count = 0

--- a/spec/bundled_gems_spec.rb
+++ b/spec/bundled_gems_spec.rb
@@ -75,7 +75,9 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/csv was loaded from (.*) from Ruby 3.4.0/)
+    expect(err).to include(/-e:8/)
     expect(err).to include(/ostruct was loaded from (.*) from Ruby 3.5.0/)
+    expect(err).to include(/-e:11/)
   end
 
   it "Show warning when bundled gems called as dependency" do
@@ -95,8 +97,7 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/ostruct was loaded from (.*) from Ruby 3.5.0/)
-    # TODO: We should assert caller location like below:
-    # $GEM_HOME/gems/activesupport-7.0.7.2/lib/active_support/core_ext/big_decimal.rb:3: warning: bigdecimal ...
+    expect(err).to include(/lib\/active_support\/all\.rb:1/)
   end
 
   it "Show warning dash gem like net/smtp" do
@@ -112,6 +113,7 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/net\/smtp was loaded from (.*) from Ruby 3.1.0/)
+    expect(err).to include(/-e:8/)
     expect(err).to include("You can add net-smtp")
   end
 
@@ -127,6 +129,7 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/fiddle was loaded from (.*) from Ruby 3.5.0/)
+    expect(err).to include(/fiddle\/import\.rb:2/) # brittle
   end
 
   it "Show warning when bundle exec with ruby and script" do
@@ -139,6 +142,7 @@ RSpec.describe "bundled_gems.rb" do
     bundle "exec ruby script.rb"
 
     expect(err).to include(/ostruct was loaded from (.*) from Ruby 3.5.0/)
+    expect(err).to include(/script\.rb:1/)
   end
 
   it "Show warning when bundle exec with shebang's script" do
@@ -155,6 +159,7 @@ RSpec.describe "bundled_gems.rb" do
     bundle "exec ./script.rb"
 
     expect(err).to include(/ostruct was loaded from (.*) from Ruby 3.5.0/)
+    expect(err).to include(/script\.rb:2/)
   end
 
   it "Show warning when bundle exec with -r option" do
@@ -185,6 +190,7 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/ostruct was loaded from (.*) from Ruby 3.5.0/)
+    expect(err).to include(/-e:12/)
   end
 
   it "Don't show warning when bundled gems called as dependency" do
@@ -295,8 +301,7 @@ RSpec.describe "bundled_gems.rb" do
     bundle "exec ruby script.rb"
 
     expect(err).to include(/ostruct was loaded from (.*) from Ruby 3.5.0/)
-    # TODO: We should assert caller location like below:
-    # test_warn_zeitwerk.rb:15: warning: ...
+    expect(err).to include(/script\.rb:6/)
   end
 
   it "Don't show warning fiddle/import when fiddle on Gemfile" do

--- a/spec/bundled_gems_spec.rb
+++ b/spec/bundled_gems_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe "bundled_gems.rb" do
     expect(err).to include(/ostruct was loaded from (.*) from Ruby 3.5.0/)
   end
 
-  it "Show warning when bundled gems called as dependency" do
+  it "Don't show warning when bundled gems called as dependency" do
     build_lib "activesupport", "7.0.7.2" do |s|
       s.write "lib/active_support/all.rb", "require 'ostruct'"
     end


### PR DESCRIPTION
I tried to fix some warnings bundled gems warnings when using Ruby 3.4.0-rc1 and it was inconvenient to find where `require`'s were actually happening because the uplevel seemed one level higher than I was expecting.

I'm trying to fix it here and add some specs to prove the fix. 