### PR TITLE
Don't print bug report in asan_death_callback when no VM

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -940,7 +940,9 @@ ruby_modular_gc_init(void)
 static void
 asan_death_callback(void)
 {
-    rb_bug_without_die("ASAN error");
+    if (GET_VM()) {
+        rb_bug_without_die("ASAN error");
+    }
 }
 #endif
 


### PR DESCRIPTION
If we don't have the VM (e.g. printing memory leaks in LSAN after shutdown) then we will crash when we try to print the bug report. This issue was reported in: https://github.com/ruby/ruby/pull/12309#issuecomment-2555766525