### PR TITLE
GC guard lookup_name

### DIFF
--- a/load.c
+++ b/load.c
@@ -1124,6 +1124,7 @@ search_required(rb_vm_t *vm, VALUE fname, volatile VALUE *path, feature_func rb_
         ftptr = RSTRING_PTR(lookup_name);
         if (st_lookup(vm->static_ext_inits, (st_data_t)ftptr, NULL)) {
             *path = rb_filesystem_str_new_cstr(ftptr);
+            RB_GC_GUARD(lookup_name);
             return 's';
         }
     }


### PR DESCRIPTION
When searching for native extensions, if the name does not end in ".so" then we create a new string and append ".so" so it. If the native extension is in static_ext_inits, then we could trigger a GC in the rb_filesystem_str_new_cstr. This could cuase the GC to free lookup_name since we don't use the local variable anymore.

This bug was caught in this ASAN build:
http://ci.rvm.jp/results/trunk_asan@ruby-sp1/5479182

    ==435614==ERROR: AddressSanitizer: use-after-poison on address 0x715a63022da0 at pc 0x5e7463873e4e bp 0x7fff383c8b00 sp 0x7fff383c82c0
    READ of size 14 at 0x715a63022da0 thread T0
        #0 0x5e7463873e4d in __asan_memcpy (/tmp/ruby/build/trunk_asan/ruby+0x214e4d) (BuildId: 607411c0626a2f66b4c20c02179b346aace20898)
        #1 0x5e7463b50a82 in memcpy /usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:10
        #2 0x5e7463b50a82 in ruby_nonempty_memcpy /tmp/ruby/src/trunk_asan/include/ruby/internal/memory.h:671:16
        #3 0x5e7463b50a82 in str_enc_new /tmp/ruby/src/trunk_asan/string.c:1035:9
        #4 0x5e74639b97dd in search_required /tmp/ruby/src/trunk_asan/load.c:1126:21
        #5 0x5e74639b97dd in require_internal /tmp/ruby/src/trunk_asan/load.c:1274:17
        #6 0x5e74639b83c1 in rb_require_string_internal /tmp/ruby/src/trunk_asan/load.c:1401:22
        #7 0x5e74639b83c1 in rb_require_string /tmp/ruby/src/trunk_asan/load.c:1387:12