### PR TITLE
Revert "[Bug #20965] Define `it` like an ordinary argument"

### DIFF
--- a/defs/id.def
+++ b/defs/id.def
@@ -63,7 +63,6 @@ firstline, predefined = __LINE__+1, %[\
   pack
   buffer
   include?
-  it
 
   _                                                     UScore
 

--- a/parse.y
+++ b/parse.y
@@ -13060,7 +13060,7 @@ gettable(struct parser_params *p, ID id, const YYLTYPE *loc)
                 return 0;
             }
             if (!p->it_id) {
-                p->it_id = idIt;
+                p->it_id = internal_id(p);
                 vtable_add(p->lvtbl->args, p->it_id);
             }
             NODE *node = NEW_DVAR(p->it_id, loc);

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -5951,7 +5951,7 @@ pm_compile_scope_node(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_nod
     }
 
     if (scope_node->parameters != NULL && PM_NODE_TYPE_P(scope_node->parameters, PM_IT_PARAMETERS_NODE)) {
-        ID local = idIt;
+        ID local = rb_make_temporary_id(local_index);
         local_table_for_iseq->ids[local_index++] = local;
     }
 

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1930,15 +1930,12 @@ eom
     1.times do
       [
         assert_equal(0, it),
-        assert_equal([0], eval('[:a].map{it}')),
-        assert_equal(0, eval('it')),
+        assert_equal([:a], eval('[:a].map{it}')),
+        assert_raise(NameError) {eval('it')},
       ]
     end
     assert_valid_syntax('proc {def foo(_);end;it}')
     assert_syntax_error('p { [it **2] }', /unexpected \*\*/)
-
-    b = proc {it; binding}.call
-    assert_include(b.local_variables, :it)
   end
 
   def test_value_expr_in_condition


### PR DESCRIPTION
Reverts ruby/ruby#12398 as per https://bugs.ruby-lang.org/issues/20970#note-6 and https://bugs.ruby-lang.org/issues/20965#note-7. We need more time to design the intended behavior, and it's too late for Ruby 3.4.