### PR TITLE
[DOC] Fix typo in related class reference

### DIFF
--- a/ast.rb
+++ b/ast.rb
@@ -283,7 +283,7 @@ module RubyVM::AbstractSyntaxTree
   end
 
   # RubyVM::AbstractSyntaxTree::Location instances are created by
-  # RubyVM::AbstractSyntaxTree#locations.
+  # RubyVM::AbstractSyntaxTree::Node#locations.
   #
   # This class is MRI specific.
   #


### PR DESCRIPTION
Just a wrong reference [here](https://docs.ruby-lang.org/en/master/RubyVM/AbstractSyntaxTree/Location.html)