### PR TITLE
Fix extra 'warning:' prefix for chilled Symbol#to_s

### DIFF
--- a/error.c
+++ b/error.c
@@ -4075,7 +4075,7 @@ rb_warn_unchilled_symbol_to_s(VALUE obj)
 {
     rb_category_warn(
         RB_WARN_CATEGORY_DEPRECATED,
-        "warning: string returned by :%s.to_s will be frozen in the future", RSTRING_PTR(obj)
+        "string returned by :%s.to_s will be frozen in the future", RSTRING_PTR(obj)
     );
 }
 


### PR DESCRIPTION
A very small adjustment to the change introduced in #12065: `rb_category_warn` adds the "warning:" to the message internally, so there is no need to do it explicitly.

Before the change, it does this:

```ruby
Warning[:deprecated] = true
:foo.to_s << 'test'
# (irb):12: warning: warning: string returned by :foo.to_s will be frozen in the future
#           ^^^^^^^^^^^^^^^^
```