### PR TITLE
Fix bundled gems warning for sub feature locations

### DIFF
--- a/spec/bundled_gems_spec.rb
+++ b/spec/bundled_gems_spec.rb
@@ -128,11 +128,8 @@ RSpec.describe "bundled_gems.rb" do
       require "fiddle/import"
     RUBY
 
-    expect(err).to include(/fiddle was loaded from (.*) from Ruby 3.5.0/)
-    # We should assert caller location of sub-feature like below:
-    # expect(err).to include(/-e:7/)
-    # The current warning message is the location of fiddle itself on sub-feature.
-    expect(err).to include(/fiddle\/import\.rb:2/) # brittle
+    expect(err).to include(/fiddle\/import is found in fiddle, which will no longer be part of the default gems starting from Ruby 3\.5\.0/)
+    expect(err).to include(/-e:7/)
   end
 
   it "Show warning when bundle exec with ruby and script" do


### PR DESCRIPTION
This fixes the remaining issue with subfeature locations mentioned by @hsbt in https://github.com/ruby/ruby/pull/12412.

I also use a modified version of the benchmark shared by @casperisfine at https://bugs.ruby-lang.org/issues/20641 to make sure performance stays the same, hopefully I did it correctly:


```ruby
# frozen_string_literal: true

name = if $LOAD_PATH.include?(File.expand_path("lib"))
  "modified"
else
  "current"
end

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "benchmark-ips"
end

Benchmark.ips do |x|
  x.report(name) { require "erb" }
  x.save! "/tmp/require.bench"
  x.compare!
end
```

```
$ ruby bench.rb 
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
ruby 3.3.6 (2024-11-05 revision 75015d4c1f) [arm64-darwin23]
Warming up --------------------------------------
             current    16.289k i/100ms
Calculating -------------------------------------
             current    166.285k (± 1.1%) i/s    (6.01 μs/i) -    847.028k in   5.094454s

$ ruby -Ilib bench.rb
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
ruby 3.3.6 (2024-11-05 revision 75015d4c1f) [arm64-darwin23]
Warming up --------------------------------------
            modified    16.323k i/100ms
Calculating -------------------------------------
            modified    164.724k (± 1.7%) i/s    (6.07 μs/i) -    832.473k in   5.055326s

Comparison:
             current:   166285.2 i/s
            modified:   164724.4 i/s - same-ish: difference falls within error
```
