### PR TITLE
[DOC] Fix indentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -362,27 +362,27 @@ The following bundled gems are promoted from default gems.
 
 * `Kernel#Float()` now accepts a decimal string with decimal part omitted. [[Feature #20705]]
 
-  ```rb
-  Float("1.")    #=> 1.0 (previously, an ArgumentError was raised)
-  Float("1.E-1") #=> 0.1 (previously, an ArgumentError was raised)
-  ```
+    ```rb
+    Float("1.")    #=> 1.0 (previously, an ArgumentError was raised)
+    Float("1.E-1") #=> 0.1 (previously, an ArgumentError was raised)
+    ```
 
 * `String#to_f` now accepts a decimal string with decimal part omitted. [[Feature #20705]]
   Note that the result changes when an exponent is specified.
 
-  ```rb
-  "1.".to_f    #=> 1.0
-  "1.E-1".to_f #=> 0.1 (previously, 1.0 was returned)
-  ```
+    ```rb
+    "1.".to_f    #=> 1.0
+    "1.E-1".to_f #=> 0.1 (previously, 1.0 was returned)
+    ```
 
 * `Object#singleton_method` now returns methods in modules prepended to or included in the
   receiver's singleton class. [[Bug #20620]]
 
-  ```rb
-  o = Object.new
-  o.extend(Module.new{def a = 1})
-  o.singleton_method(:a).call #=> 1
-  ```
+    ```rb
+    o = Object.new
+    o.extend(Module.new{def a = 1})
+    o.singleton_method(:a).call #=> 1
+    ```
 
 * `Refinement#refined_class` has been removed. [[Feature #19714]]
 


### PR DESCRIPTION
RDoc markdown parser requires exact 4 spaces or tab as indentation.