### PR TITLE
Fix [Bug #20779] Dedicated native thread creation failed bug

### DIFF
--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -2158,10 +2158,13 @@ native_thread_create_dedicated(rb_thread_t *th)
     rb_ec_initialize_vm_stack(th->ec, vm_stack, vm_stack_word_size);
     th->sched.context_stack = vm_stack;
 
-    // setup
-    thread_sched_to_ready(TH_SCHED(th), th);
 
-    return native_thread_create0(th->nt);
+    int err = native_thread_create0(th->nt);
+    if (!err) {
+        // setup
+        thread_sched_to_ready(TH_SCHED(th), th);
+    }
+    return err;
 }
 
 static void


### PR DESCRIPTION
When a dedicated native thread fails to create (OS can't create more threads), don't add the ruby-level thread to the thread scheduler. If it's added, then next time the thread is scheduled to run it will sleep forever, waiting for a native thread that doesn't exist to pick it up.