### PR TITLE
Fix MEMMOVE in rb_darray_insert

### DIFF
--- a/darray.h
+++ b/darray.h
@@ -58,7 +58,7 @@
     MEMMOVE( \
         rb_darray_ref(*(ptr_to_ary), idx + 1), \
         rb_darray_ref(*(ptr_to_ary), idx), \
-        sizeof((*(ptr_to_ary))->data[0]), \
+        (*(ptr_to_ary))->data[0], \
         rb_darray_size(*(ptr_to_ary)) - idx); \
     rb_darray_set(*(ptr_to_ary), idx, element); \
     (*(ptr_to_ary))->meta.size++; \


### PR DESCRIPTION
Ruby's MEMMOVE takes in the element data type for the third argument, not the size of the element. What this did was do sizeof(sizeof( ... )) which always returned sizeof(size_t).