### PR TITLE
Fix failing example with help output of bundle gem cli

### DIFF
--- a/lib/bundler/man/bundle-gem.1
+++ b/lib/bundler/man/bundle-gem.1
@@ -78,10 +78,9 @@ When Bundler is unconfigured, an interactive prompt will be displayed and the an
 .IP "\(bu" 4
 \fB\-\-rubocop\fR: Add rubocop to the generated Rakefile and gemspec\. Set a default with \fBbundle config set \-\-global gem\.rubocop true\fR\.
 .IP "\(bu" 4
-\fB\-\-edit=EDIT\fR, \fB\-e=EDIT\fR: Open the resulting GEM_NAME\.gemspec in EDIT, or the default editor if not specified\. The default is \fB$BUNDLER_EDITOR\fR, \fB$VISUAL\fR, or \fB$EDITOR\fR\.
+\fB\-\-edit[=EDIT]\fR, \fB\-e[=EDIT]\fR: Open the resulting GEM_NAME\.gemspec in EDIT, or the default editor if not specified\. The default is \fB$BUNDLER_EDITOR\fR, \fB$VISUAL\fR, or \fB$EDITOR\fR\.
 .IP "" 0
 .SH "SEE ALSO"
 .IP "\(bu" 4
 bundle config(1) \fIbundle\-config\.1\.html\fR
 .IP "" 0
-

--- a/lib/bundler/man/bundle-gem.1.ronn
+++ b/lib/bundler/man/bundle-gem.1.ronn
@@ -140,7 +140,7 @@ configuration file using the following names:
 * `--rubocop`:
   Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`.
 
-* `--edit=EDIT`, `-e=EDIT`:
+* `--edit[=EDIT]`, `-e[=EDIT]`:
   Open the resulting GEM_NAME.gemspec in EDIT, or the default editor if not
   specified. The default is `$BUNDLER_EDITOR`, `$VISUAL`, or `$EDITOR`.
 


### PR DESCRIPTION
I'm not sure why the following example is failing with my local box.

```
Failures:

  1) bundle commands expects all commands to have all options documented
     Failure/Error: expect(man_page_content).to include(help)

       expected "bundle-gem(1) -- Generate a project skeleton for creating a rubygem\n===================================================================\n\n## SYNOPSIS\n\n`bundle gem` <GEM_NAME> [OPTIONS]\n\n## DESCRIPTION\n\nGenerates a directory named `GEM_NAME` with a `Rakefile`, `GEM_NAME.gemspec`,\nand other supporting files and directories that can be used to develop a\nrubygem with that name.\n\nRun `rake -T` in the resulting project for a list of Rake tasks that can be used\nto test and publish the gem ...bundle gem`\n  use.\n\n* `--no-linter`:\n  Do not add a linter (overrides `--linter` specified in the global config).\n\n* `--rubocop`:\n  Add rubocop to the generated Rakefile and gemspec. Set a default with `bundle config set --global gem.rubocop true`.\n\n* `--edit=EDIT`, `-e=EDIT`:\n  Open the resulting GEM_NAME.gemspec in EDIT, or the default editor if not\n  specified. The default is `$BUNDLER_EDITOR`, `$VISUAL`, or `$EDITOR`.\n\n## SEE ALSO\n\n* [bundle config(1)](bundle-config.1.html)\n" to include "* `--edit[=EDIT]`, `-e[=EDIT]`:"
       Diff:
       @@ -1,149 +1,297 @@
       -* `--edit[=EDIT]`, `-e[=EDIT]`:
       +bundle-gem(1) -- Generate a project skeleton for creating a rubygem
       +===================================================================
```