### PR TITLE
Win32: Defer change of timezone name encoding after 3.4

### DIFF
--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -717,15 +717,13 @@ class TestTime < Test::Unit::TestCase
     assert_equal("2000-01-01 09:12:34 +091234", t2000.localtime(9*3600+12*60+34).inspect)
   end
 
-  FIXED_ZONE_ENCODING = (Encoding::UTF_8 if /mswin|mingw/.match?(RUBY_PLATFORM))
-
   def assert_zone_encoding(time)
     zone = time.zone
     assert_predicate(zone, :valid_encoding?)
     if zone.ascii_only?
       assert_equal(Encoding::US_ASCII, zone.encoding)
     else
-      enc = FIXED_ZONE_ENCODING || Encoding.find('locale')
+      enc = Encoding.default_internal || Encoding.find('locale')
       assert_equal(enc, zone.encoding)
     end
   end

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -785,7 +785,6 @@ $(CONFIG_H): $(MKFILES) $(srcdir)/win32/Makefile.sub $(win_srcdir)/Makefile.sub
 #define HAVE_STRUCT_TIMEVAL 1
 !if $(MSC_VER) >= 1900
 #define HAVE_STRUCT_TIMESPEC
-#define HAVE_LOCALE_H 1
 !endif
 !if $(MSC_VER) >= 1600
 #define HAVE_INTTYPES_H 1


### PR DESCRIPTION
This change will be merged into 3.5 along with other encoding, command line, environment variables, etc.

Revert following commits:

- bd831bcca534955533d9135d8c2f22d7ae5b9aa8 [Bug #20929] Win32: Use `wcsftime`

- 1c15f641cc2bb88fa88123a11036ed58fbf9aa6d [Bug #20929] Win32: Encode timezone name in UTF-8

- 78762b52185aa80ee55c0d49b495aceed863dce2 [Bug #20929] Fix `assert_zone_encoding`

https://bugs.ruby-lang.org/issues/20929#note-4