### PR TITLE
Removed Process::Status#& and Process::Status#>>

### DIFF
--- a/lib/bundler/dependency.rb
+++ b/lib/bundler/dependency.rb
@@ -9,7 +9,7 @@ module Bundler
     attr_reader :autorequire
     attr_reader :groups, :platforms, :gemfile, :path, :git, :github, :branch, :ref, :glob
 
-    ALL_RUBY_VERSIONS = (18..27).to_a.concat((30..34).to_a).freeze
+    ALL_RUBY_VERSIONS = (18..27).to_a.concat((30..35).to_a).freeze
     PLATFORM_MAP = {
       ruby: [Gem::Platform::RUBY, ALL_RUBY_VERSIONS],
       mri: [Gem::Platform::RUBY, ALL_RUBY_VERSIONS],

--- a/process.c
+++ b/process.c
@@ -875,109 +875,6 @@ pst_equal(VALUE st1, VALUE st2)
 
 /*
  *  call-seq:
- *    stat & mask -> integer
- *
- *  This method is deprecated as #to_i value is system-specific; use
- *  predicate methods like #exited? or #stopped?, or getters like #exitstatus
- *  or #stopsig.
- *
- *  Returns the logical AND of the value of #to_i with +mask+:
- *
- *    `cat /nop`
- *    stat = $?                 # => #<Process::Status: pid 1155508 exit 1>
- *    sprintf('%x', stat.to_i)  # => "100"
- *    stat & 0x00               # => 0
- *
- *  ArgumentError is raised if +mask+ is negative.
- */
-
-static VALUE
-pst_bitand(VALUE st1, VALUE st2)
-{
-    int status = PST2INT(st1);
-    int mask = NUM2INT(st2);
-
-    if (mask < 0) {
-        rb_raise(rb_eArgError, "negative mask value: %d", mask);
-    }
-#define WARN_SUGGEST(suggest) \
-    rb_warn_deprecated_to_remove_at(3.5, "Process::Status#&", suggest)
-
-    switch (mask) {
-      case 0x80:
-        WARN_SUGGEST("Process::Status#coredump?");
-        break;
-      case 0x7f:
-        WARN_SUGGEST("Process::Status#signaled? or Process::Status#termsig");
-        break;
-      case 0xff:
-        WARN_SUGGEST("Process::Status#exited?, Process::Status#stopped? or Process::Status#coredump?");
-        break;
-      case 0xff00:
-        WARN_SUGGEST("Process::Status#exitstatus or Process::Status#stopsig");
-        break;
-      default:
-        WARN_SUGGEST("other Process::Status predicates");
-        break;
-    }
-#undef WARN_SUGGEST
-    status &= mask;
-
-    return INT2NUM(status);
-}
-
-
-/*
- *  call-seq:
- *    stat >> places -> integer
- *
- *  This method is deprecated as #to_i value is system-specific; use
- *  predicate methods like #exited? or #stopped?, or getters like #exitstatus
- *  or #stopsig.
- *
- *  Returns the value of #to_i, shifted +places+ to the right:
- *
- *     `cat /nop`
- *     stat = $?                 # => #<Process::Status: pid 1155508 exit 1>
- *     stat.to_i                 # => 256
- *     stat >> 1                 # => 128
- *     stat >> 2                 # => 64
- *
- *  ArgumentError is raised if +places+ is negative.
- */
-
-static VALUE
-pst_rshift(VALUE st1, VALUE st2)
-{
-    int status = PST2INT(st1);
-    int places = NUM2INT(st2);
-
-    if (places < 0) {
-        rb_raise(rb_eArgError, "negative shift value: %d", places);
-    }
-#define WARN_SUGGEST(suggest) \
-    rb_warn_deprecated_to_remove_at(3.5, "Process::Status#>>", suggest)
-
-    switch (places) {
-      case 7:
-        WARN_SUGGEST("Process::Status#coredump?");
-        break;
-      case 8:
-        WARN_SUGGEST("Process::Status#exitstatus or Process::Status#stopsig");
-        break;
-      default:
-        WARN_SUGGEST("other Process::Status attributes");
-        break;
-    }
-#undef WARN_SUGGEST
-    status >>= places;
-
-    return INT2NUM(status);
-}
-
-
-/*
- *  call-seq:
  *    stopped? -> true or false
  *
  *  Returns +true+ if this process is stopped,
@@ -9346,8 +9243,6 @@ InitVM_process(void)
     rb_define_singleton_method(rb_cProcessStatus, "wait", rb_process_status_waitv, -1);
 
     rb_define_method(rb_cProcessStatus, "==", pst_equal, 1);
-    rb_define_method(rb_cProcessStatus, "&", pst_bitand, 1);
-    rb_define_method(rb_cProcessStatus, ">>", pst_rshift, 1);
     rb_define_method(rb_cProcessStatus, "to_i", pst_to_i, 0);
     rb_define_method(rb_cProcessStatus, "to_s", pst_to_s, 0);
     rb_define_method(rb_cProcessStatus, "inspect", pst_inspect, 0);

--- a/spec/bundled_gems_spec.rb
+++ b/spec/bundled_gems_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "bundled_gems.rb" do
       require "fiddle/import"
     RUBY
 
-    expect(err).to include(/fiddle\/import is found in fiddle, which will no longer be part of the default gems starting from Ruby 3\.5\.0/)
+    expect(err).to include(/fiddle\/import is found in fiddle, (.*) part of the default gems starting from Ruby 3\.5\.0/)
     expect(err).to include(/-e:7/)
   end
 

--- a/spec/bundler/bundler/dependency_spec.rb
+++ b/spec/bundler/bundler/dependency_spec.rb
@@ -56,6 +56,7 @@ RSpec.describe Bundler::Dependency do
         ruby_32: Gem::Platform::RUBY,
         ruby_33: Gem::Platform::RUBY,
         ruby_34: Gem::Platform::RUBY,
+        ruby_35: Gem::Platform::RUBY,
         mri: Gem::Platform::RUBY,
         mri_18: Gem::Platform::RUBY,
         mri_19: Gem::Platform::RUBY,
@@ -72,6 +73,7 @@ RSpec.describe Bundler::Dependency do
         mri_32: Gem::Platform::RUBY,
         mri_33: Gem::Platform::RUBY,
         mri_34: Gem::Platform::RUBY,
+        mri_35: Gem::Platform::RUBY,
         rbx: Gem::Platform::RUBY,
         truffleruby: Gem::Platform::RUBY,
         jruby: Gem::Platform::JAVA,
@@ -92,7 +94,8 @@ RSpec.describe Bundler::Dependency do
         windows_31: Gem::Platform::WINDOWS,
         windows_32: Gem::Platform::WINDOWS,
         windows_33: Gem::Platform::WINDOWS,
-        windows_34: Gem::Platform::WINDOWS }
+        windows_34: Gem::Platform::WINDOWS,
+        windows_35: Gem::Platform::WINDOWS }
     end
 
     let(:deprecated) do
@@ -112,6 +115,7 @@ RSpec.describe Bundler::Dependency do
         mswin_32: Gem::Platform::MSWIN,
         mswin_33: Gem::Platform::MSWIN,
         mswin_34: Gem::Platform::MSWIN,
+        mswin_35: Gem::Platform::MSWIN,
         mswin64: Gem::Platform::MSWIN64,
         mswin64_19: Gem::Platform::MSWIN64,
         mswin64_20: Gem::Platform::MSWIN64,
@@ -127,6 +131,7 @@ RSpec.describe Bundler::Dependency do
         mswin64_32: Gem::Platform::MSWIN64,
         mswin64_33: Gem::Platform::MSWIN64,
         mswin64_34: Gem::Platform::MSWIN64,
+        mswin64_35: Gem::Platform::MSWIN64,
         mingw: Gem::Platform::MINGW,
         mingw_18: Gem::Platform::MINGW,
         mingw_19: Gem::Platform::MINGW,
@@ -143,6 +148,7 @@ RSpec.describe Bundler::Dependency do
         mingw_32: Gem::Platform::MINGW,
         mingw_33: Gem::Platform::MINGW,
         mingw_34: Gem::Platform::MINGW,
+        mingw_35: Gem::Platform::MINGW,
         x64_mingw: Gem::Platform::X64_MINGW,
         x64_mingw_20: Gem::Platform::X64_MINGW,
         x64_mingw_21: Gem::Platform::X64_MINGW,
@@ -156,7 +162,8 @@ RSpec.describe Bundler::Dependency do
         x64_mingw_31: Gem::Platform::X64_MINGW,
         x64_mingw_32: Gem::Platform::X64_MINGW,
         x64_mingw_33: Gem::Platform::X64_MINGW,
-        x64_mingw_34: Gem::Platform::X64_MINGW }
+        x64_mingw_34: Gem::Platform::X64_MINGW,
+        x64_mingw_35: Gem::Platform::X64_MINGW }
     end
     # rubocop:enable Naming/VariableNumber
 

--- a/spec/ruby/core/process/status/bit_and_spec.rb
+++ b/spec/ruby/core/process/status/bit_and_spec.rb
@@ -17,7 +17,7 @@ ruby_version_is ""..."3.5" do
       end
     end
 
-    ruby_version_is "3.3" do
+    ruby_version_is "3.3"..."3.5" do
       it "raises an ArgumentError if mask is negative" do
         suppress_warning do
           ruby_exe("exit(0)")

--- a/spec/ruby/core/process/status/bit_and_spec.rb
+++ b/spec/ruby/core/process/status/bit_and_spec.rb
@@ -1,35 +1,38 @@
 require_relative '../../../spec_helper'
 
-describe "Process::Status#&" do
-  it "returns a bitwise and of the integer status of an exited child" do
-    suppress_warning do
-      ruby_exe("exit(29)", exit_status: 29)
-      ($? & 0).should == 0
-      ($? & $?.to_i).should == $?.to_i
+ruby_version_is ""..."3.5" do
 
-      # Actual value is implementation specific
-      platform_is :linux do
-        # 29 == 0b11101
-        ($? & 0b1011100000000).should == 0b1010100000000
+  describe "Process::Status#&" do
+    it "returns a bitwise and of the integer status of an exited child" do
+      suppress_warning do
+        ruby_exe("exit(29)", exit_status: 29)
+        ($? & 0).should == 0
+        ($? & $?.to_i).should == $?.to_i
+
+        # Actual value is implementation specific
+        platform_is :linux do
+          # 29 == 0b11101
+          ($? & 0b1011100000000).should == 0b1010100000000
+        end
       end
     end
-  end
 
-  ruby_version_is "3.3" do
-    it "raises an ArgumentError if mask is negative" do
-      suppress_warning do
+    ruby_version_is "3.3" do
+      it "raises an ArgumentError if mask is negative" do
+        suppress_warning do
+          ruby_exe("exit(0)")
+          -> {
+            $? & -1
+          }.should raise_error(ArgumentError, 'negative mask value: -1')
+        end
+      end
+
+      it "shows a deprecation warning" do
         ruby_exe("exit(0)")
         -> {
-          $? & -1
-        }.should raise_error(ArgumentError, 'negative mask value: -1')
+          $? & 0
+        }.should complain(/warning: Process::Status#& is deprecated and will be removed .*use other Process::Status predicates instead/)
       end
-    end
-
-    it "shows a deprecation warning" do
-      ruby_exe("exit(0)")
-      -> {
-        $? & 0
-      }.should complain(/warning: Process::Status#& is deprecated and will be removed .*use other Process::Status predicates instead/)
     end
   end
 end

--- a/spec/ruby/core/process/status/right_shift_spec.rb
+++ b/spec/ruby/core/process/status/right_shift_spec.rb
@@ -16,7 +16,7 @@ ruby_version_is ""..."3.5" do
       end
     end
 
-    ruby_version_is "3.3" do
+    ruby_version_is "3.3"..."3.5" do
       it "raises an ArgumentError if shift value is negative" do
         suppress_warning do
           ruby_exe("exit(0)")

--- a/spec/ruby/core/process/status/right_shift_spec.rb
+++ b/spec/ruby/core/process/status/right_shift_spec.rb
@@ -1,34 +1,37 @@
 require_relative '../../../spec_helper'
 
-describe "Process::Status#>>" do
-  it "returns a right shift of the integer status of an exited child" do
-    suppress_warning do
-      ruby_exe("exit(29)", exit_status: 29)
-      ($? >> 0).should == $?.to_i
-      ($? >> 1).should == $?.to_i >> 1
+ruby_version_is ""..."3.5" do
 
-      # Actual value is implementation specific
-      platform_is :linux do
-        ($? >> 8).should == 29
+  describe "Process::Status#>>" do
+    it "returns a right shift of the integer status of an exited child" do
+      suppress_warning do
+        ruby_exe("exit(29)", exit_status: 29)
+        ($? >> 0).should == $?.to_i
+        ($? >> 1).should == $?.to_i >> 1
+
+        # Actual value is implementation specific
+        platform_is :linux do
+          ($? >> 8).should == 29
+        end
       end
     end
-  end
 
-  ruby_version_is "3.3" do
-    it "raises an ArgumentError if shift value is negative" do
-      suppress_warning do
+    ruby_version_is "3.3" do
+      it "raises an ArgumentError if shift value is negative" do
+        suppress_warning do
+          ruby_exe("exit(0)")
+          -> {
+            $? >> -1
+          }.should raise_error(ArgumentError, 'negative shift value: -1')
+        end
+      end
+
+      it "shows a deprecation warning" do
         ruby_exe("exit(0)")
         -> {
-          $? >> -1
-        }.should raise_error(ArgumentError, 'negative shift value: -1')
+          $? >> 0
+        }.should complain(/warning: Process::Status#>> is deprecated and will be removed .*use other Process::Status attributes instead/)
       end
-    end
-
-    it "shows a deprecation warning" do
-      ruby_exe("exit(0)")
-      -> {
-        $? >> 0
-      }.should complain(/warning: Process::Status#>> is deprecated and will be removed .*use other Process::Status attributes instead/)
     end
   end
 end

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1454,15 +1454,6 @@ class TestProcess < Test::Unit::TestCase
       assert_equal(s, s)
       assert_equal(s, s.to_i)
 
-      assert_deprecated_warn(/\buse .*Process::Status/) do
-        assert_equal(s.to_i & 0x55555555, s & 0x55555555)
-      end
-      assert_deprecated_warn(/\buse .*Process::Status/) do
-        assert_equal(s.to_i >> 1, s >> 1)
-      end
-      assert_raise(ArgumentError) do
-        s >> -1
-      end
       assert_equal(false, s.stopped?)
       assert_equal(nil, s.stopsig)
 


### PR DESCRIPTION
This is for Ruby 3.5.

/cc @nobu 