### PR TITLE
[Bug #20981] Bring back `rb_undefine_finalizer`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1619,6 +1619,12 @@ os_each_obj(int argc, VALUE *argv, VALUE os)
 static VALUE
 undefine_final(VALUE os, VALUE obj)
 {
+    return rb_undefine_finalizer(obj);
+}
+
+VALUE
+rb_undefine_finalizer(VALUE obj)
+{
     rb_check_frozen(obj);
 
     rb_gc_impl_undefine_finalizer(rb_gc_get_objspace(), obj);


### PR DESCRIPTION
[[Bug #20981]](https://bugs.ruby-lang.org/issues/20981)