### PR TITLE
[Bug #20984] ENV.inspect should be encoding aware

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -5909,24 +5909,23 @@ env_to_s(VALUE _)
 static VALUE
 env_inspect(VALUE _)
 {
-    VALUE i;
     VALUE str = rb_str_buf_new2("{");
+    rb_encoding *enc = env_encoding();
 
     ENV_LOCK();
     {
         char **env = GET_ENVIRON(environ);
         while (*env) {
-            char *s = strchr(*env, '=');
+            const char *s = strchr(*env, '=');
 
             if (env != environ) {
                 rb_str_buf_cat2(str, ", ");
             }
             if (s) {
-                rb_str_buf_cat2(str, "\"");
-                rb_str_buf_cat(str, *env, s-*env);
-                rb_str_buf_cat2(str, "\"=>");
-                i = rb_inspect(rb_str_new2(s+1));
-                rb_str_buf_append(str, i);
+                rb_str_buf_append(str, rb_str_inspect(env_enc_str_new(*env, s-*env, enc)));
+                rb_str_buf_cat2(str, "=>");
+                s++;
+                rb_str_buf_append(str, rb_str_inspect(env_enc_str_new(s, strlen(s), enc)));
             }
             env++;
         }

--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -357,6 +357,13 @@ class TestEnv < Test::Unit::TestCase
     assert_equal(expected, s)
   end
 
+  def test_inspect_encoding
+    ENV.clear
+    key = "VAR\u{e5 e1 e2 e4 e3 101 3042}"
+    ENV[key] = "foo"
+    assert_equal(%{{"VAR\u{e5 e1 e2 e4 e3 101 3042}"=>"foo"}}, ENV.inspect)
+  end
+
   def test_to_a
     ENV.clear
     ENV["foo"] = "bar"


### PR DESCRIPTION
[[Bug #20984]](https://bugs.ruby-lang.org/issues/20984)