### PR TITLE
[Bug #20982] Put spaces in `ENV.inspect` results as well as `Hash`

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -5923,7 +5923,7 @@ env_inspect(VALUE _)
             }
             if (s) {
                 rb_str_buf_append(str, rb_str_inspect(env_enc_str_new(*env, s-*env, enc)));
-                rb_str_buf_cat2(str, "=>");
+                rb_str_buf_cat2(str, " => ");
                 s++;
                 rb_str_buf_append(str, rb_str_inspect(env_enc_str_new(s, strlen(s), enc)));
             }

--- a/spec/ruby/core/env/inspect_spec.rb
+++ b/spec/ruby/core/env/inspect_spec.rb
@@ -4,7 +4,7 @@ describe "ENV.inspect" do
 
   it "returns a String that looks like a Hash with real data" do
     ENV["foo"] = "bar"
-    ENV.inspect.should =~ /\{.*"foo"=>"bar".*\}/
+    ENV.inspect.should =~ /\{.*"foo" *=> *"bar".*\}/
     ENV.delete "foo"
   end
 

--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -345,7 +345,7 @@ class TestEnv < Test::Unit::TestCase
     ENV["foo"] = "bar"
     ENV["baz"] = "qux"
     s = ENV.inspect
-    expected = [%("foo"=>"bar"), %("baz"=>"qux")]
+    expected = [%("foo" => "bar"), %("baz" => "qux")]
     unless s.start_with?(/\{"foo"/i)
       expected.reverse!
     end
@@ -361,7 +361,7 @@ class TestEnv < Test::Unit::TestCase
     ENV.clear
     key = "VAR\u{e5 e1 e2 e4 e3 101 3042}"
     ENV[key] = "foo"
-    assert_equal(%{{"VAR\u{e5 e1 e2 e4 e3 101 3042}"=>"foo"}}, ENV.inspect)
+    assert_equal(%{{"VAR\u{e5 e1 e2 e4 e3 101 3042}" => "foo"}}, ENV.inspect)
   end
 
   def test_to_a
@@ -1096,7 +1096,7 @@ class TestEnv < Test::Unit::TestCase
         Ractor.yield s
       end
       s = r.take
-      expected = ['"foo"=>"bar"', '"baz"=>"qux"']
+      expected = ['"foo" => "bar"', '"baz" => "qux"']
       unless s.start_with?(/\{"foo"/i)
         expected.reverse!
       end


### PR DESCRIPTION
[[Bug #20982]](https://bugs.ruby-lang.org/issues/20982)