### PR TITLE
Revert LoongArch register changes

### DIFF
--- a/vm_dump.c
+++ b/vm_dump.c
@@ -1001,22 +1001,22 @@ rb_dump_machine_register(FILE *errout, const ucontext_t *ctx)
 #   elif defined __loongarch64
         dump_machine_register(mctx->__gregs[LARCH_REG_SP], "sp");
         dump_machine_register(mctx->__gregs[LARCH_REG_A0], "a0");
-        dump_machine_register(mctx->__gregs[LARCH_REG_A1], "a1");
-        dump_machine_register(mctx->__gregs[LARCH_REG_A2], "a2");
-        dump_machine_register(mctx->__gregs[LARCH_REG_A3], "a3");
-        dump_machine_register(mctx->__gregs[LARCH_REG_A4], "a4");
-        dump_machine_register(mctx->__gregs[LARCH_REG_A5], "a5");
-        dump_machine_register(mctx->__gregs[LARCH_REG_A6], "a6");
-        dump_machine_register(mctx->__gregs[LARCH_REG_A7], "a7");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+1], "a1");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+2], "a2");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+3], "a3");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+4], "a4");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+5], "a5");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+6], "a6");
+        dump_machine_register(mctx->__gregs[LARCH_REG_A0+7], "a7");
         dump_machine_register(mctx->__gregs[LARCH_REG_S0], "s0");
         dump_machine_register(mctx->__gregs[LARCH_REG_S1], "s1");
-        dump_machine_register(mctx->__gregs[LARCH_REG_S2], "s2");
-        dump_machine_register(mctx->__gregs[LARCH_REG_S3], "s3");
-        dump_machine_register(mctx->__gregs[LARCH_REG_S4], "s4");
-        dump_machine_register(mctx->__gregs[LARCH_REG_S5], "s5");
-        dump_machine_register(mctx->__gregs[LARCH_REG_S6], "s6");
-        dump_machine_register(mctx->__gregs[LARCH_REG_S7], "s7");
-        dump_machine_register(mctx->__gregs[LARCH_REG_S8], "s8");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+2], "s2");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+3], "s3");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+4], "s4");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+5], "s5");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+6], "s6");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+7], "s7");
+        dump_machine_register(mctx->__gregs[LARCH_REG_S0+8], "s8");
 #   endif
     }
 # elif defined __APPLE__

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -1008,7 +1008,6 @@ rb_dump_machine_register(FILE *errout, const ucontext_t *ctx)
         dump_machine_register(mctx->__gregs[LARCH_REG_A5], "a5");
         dump_machine_register(mctx->__gregs[LARCH_REG_A6], "a6");
         dump_machine_register(mctx->__gregs[LARCH_REG_A7], "a7");
-        dump_machine_register(mctx->__gregs[LARCH_REG_FP], "fp");
         dump_machine_register(mctx->__gregs[LARCH_REG_S0], "s0");
         dump_machine_register(mctx->__gregs[LARCH_REG_S1], "s1");
         dump_machine_register(mctx->__gregs[LARCH_REG_S2], "s2");


### PR DESCRIPTION
Commits 71b253cdf3 ("Added LARCH_REG_FP to dump results") and a07bf6d5ff ("Use constants for register numbers") introduced registers never defined in glibc or musl, the only two widely used C libraries available for LoongArch, causing build failures.

Reverting these two commits fixes build on glibc (musl build and tests pending) and passes all unit tests.