### PR TITLE
Add dbg debugging helper method

### DIFF
--- a/lib/dbg.rb
+++ b/lib/dbg.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# This is a simple debugging helper method that can be used to
+# print out the source file and line number of the caller
+# together with the debugged value.
+
+# Usage:
+# dbg("Hello world", [1, 2, 3])
+# => [file.rb:12] "Hello world"
+# => [file.rb:12] [1, 2, 3]
+
+def dbg(*msgs)
+  loc = caller_locations.first.to_s
+  matching_loc = loc.match(/.+(rb)\:\d+\:(in)\s/)
+  src = if matching_loc.nil?
+      loc
+    else
+      matching_loc[0][0..-5]
+    end
+  file, line = src.split(":")
+  file = file.split("/").last(2).join("/")
+  src = "[#{file}:#{line}]"
+
+  msgs.each do |msg|
+    puts "#{src} #{msg.inspect}"
+  end
+  nil
+end


### PR DESCRIPTION
Hi. I’m author of https://github.com/pawurb/dbg-rb gem. This PR implements a minimal `dbg` method without any external dependencies.

`dbg` method is inspired by Rust where it's built-in [into std-lib](https://doc.rust-lang.org/std/macro.dbg.html).  AFAIK in Ruby there's no simple mechanism to puts debug values together with caller info without using external dependencies. What’s more frustrating is that while `p nil` will output `“nil”` to the std, `puts nil` will print a blank line, sometimes making debugging sessions confusing. 

`dbg` produces verbose output together with informative file name and LOC info. I think that such built-in feature would be useful for many Ruby devs. 

<img width="351" alt="Screenshot 2024-12-27 at 00 00 23" src="https://github.com/user-attachments/assets/80288a49-0901-472c-a12c-1dc952cc0685" />


