### PR TITLE
[Bug #20990] Reject escaped multibyte char with control/meta prefix

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -8231,6 +8231,10 @@ read_escape(struct parser_params *p, int flags, const char *begin)
         return '\0';
 
       default:
+        if (!ISASCII(c)) {
+            tokskip_mbchar(p);
+            goto eof;
+        }
         return c;
     }
 }

--- a/test/ripper/test_lexer.rb
+++ b/test/ripper/test_lexer.rb
@@ -355,6 +355,15 @@ world"
     ]
 
     assert_lexer(expected, code)
+
+    code = %["\\C-\\\u{3042}"]
+    expected = [
+      [[1, 0], :on_tstring_beg, '"', state(:EXPR_BEG)],
+      [[1, 1], :on_tstring_content, "\\C-\\\u{3042}", state(:EXPR_BEG)],
+      [[1, 8], :on_tstring_end, '"', state(:EXPR_END)],
+    ]
+
+    assert_lexer(expected, code)
   end
 
   def test_invalid_escape_meta_mbchar
@@ -363,6 +372,15 @@ world"
       [[1, 0], :on_tstring_beg, '"', state(:EXPR_BEG)],
       [[1, 1], :on_tstring_content, "\\M-\u{3042}", state(:EXPR_BEG)],
       [[1, 7], :on_tstring_end, '"', state(:EXPR_END)],
+    ]
+
+    assert_lexer(expected, code)
+
+    code = %["\\M-\\\u{3042}"]
+    expected = [
+      [[1, 0], :on_tstring_beg, '"', state(:EXPR_BEG)],
+      [[1, 1], :on_tstring_content, "\\M-\\\u{3042}", state(:EXPR_BEG)],
+      [[1, 8], :on_tstring_end, '"', state(:EXPR_END)],
     ]
 
     assert_lexer(expected, code)
@@ -377,6 +395,15 @@ world"
     ]
 
     assert_lexer(expected, code)
+
+    code = %["\\M-\\C-\\\u{3042}"]
+    expected = [
+      [[1, 0], :on_tstring_beg, '"', state(:EXPR_BEG)],
+      [[1, 1], :on_tstring_content, "\\M-\\C-\\\u{3042}", state(:EXPR_BEG)],
+      [[1, 11], :on_tstring_end, '"', state(:EXPR_END)],
+    ]
+
+    assert_lexer(expected, code)
   end
 
   def test_invalid_escape_ctrl_meta_mbchar
@@ -385,6 +412,15 @@ world"
       [[1, 0], :on_tstring_beg, '"', state(:EXPR_BEG)],
       [[1, 1], :on_tstring_content, "\\C-\\M-\u{3042}", state(:EXPR_BEG)],
       [[1, 10], :on_tstring_end, '"', state(:EXPR_END)],
+    ]
+
+    assert_lexer(expected, code)
+
+    code = %["\\C-\\M-\\\u{3042}"]
+    expected = [
+      [[1, 0], :on_tstring_beg, '"', state(:EXPR_BEG)],
+      [[1, 1], :on_tstring_content, "\\C-\\M-\\\u{3042}", state(:EXPR_BEG)],
+      [[1, 11], :on_tstring_end, '"', state(:EXPR_END)],
     ]
 
     assert_lexer(expected, code)

--- a/test/ruby/test_literal.rb
+++ b/test/ruby/test_literal.rb
@@ -97,6 +97,10 @@ class TestRubyLiteral < Test::Unit::TestCase
     assert_equal "ab", eval("?a 'b'")
     assert_equal "a\nb", eval("<<A 'b'\na\nA")
 
+    assert_raise(SyntaxError) {eval('"\C-' "\u3042" '"')}
+    assert_raise(SyntaxError) {eval('"\C-\\' "\u3042" '"')}
+    assert_raise(SyntaxError) {eval('"\M-' "\u3042" '"')}
+    assert_raise(SyntaxError) {eval('"\M-\\' "\u3042" '"')}
   ensure
     $VERBOSE = verbose_bak
   end


### PR DESCRIPTION
[[Bug #20990]](https://bugs.ruby-lang.org/issues/20990)