### PR TITLE
[Bug #20988] [prism] Fix escaped octal character literals

### DIFF
--- a/prism/prism.c
+++ b/prism/prism.c
@@ -9728,6 +9728,7 @@ escape_read(pm_parser_t *parser, pm_buffer_t *buffer, pm_buffer_t *regular_expre
                 }
             }
 
+            value = escape_byte(value, flags);
             escape_write_byte(parser, buffer, regular_expression_buffer, flags, value);
             return;
         }

--- a/test/ruby/test_literal.rb
+++ b/test/ruby/test_literal.rb
@@ -101,6 +101,8 @@ class TestRubyLiteral < Test::Unit::TestCase
     assert_raise(SyntaxError) {eval('"\C-\\' "\u3042" '"')}
     assert_raise(SyntaxError) {eval('"\M-' "\u3042" '"')}
     assert_raise(SyntaxError) {eval('"\M-\\' "\u3042" '"')}
+
+    assert_equal "\x09 \xC9 \x89", eval('"\C-\111 \M-\111 \M-\C-\111"')
   ensure
     $VERBOSE = verbose_bak
   end


### PR DESCRIPTION
[[Bug #20988]](https://bugs.ruby-lang.org/issues/20988)