### PR TITLE
Remove unused token definitions for `tRPAREN` in Ripper and parser files

### DIFF
--- a/ext/ripper/eventids2.c
+++ b/ext/ripper/eventids2.c
@@ -255,7 +255,6 @@ ripper_token2eventid(enum yytokentype tok)
         [tRATIONAL]		= O(rational),
         [tREGEXP_BEG]		= O(regexp_beg),
         [tREGEXP_END]		= O(regexp_end),
-        [tRPAREN]		= O(rparen),
         [tRSHFT]		= O(op),
         [tSTAR] 		= O(op),
         [tDSTAR]		= O(op),

--- a/parse.y
+++ b/parse.y
@@ -967,7 +967,6 @@ parser_token2char(struct parser_params *p, enum yytokentype tok)
       TOKEN2CHAR(tASSOC);
       TOKEN2CHAR(tLPAREN);
       TOKEN2CHAR(tLPAREN_ARG);
-      TOKEN2CHAR(tRPAREN);
       TOKEN2CHAR(tLBRACK);
       TOKEN2CHAR(tLBRACE);
       TOKEN2CHAR(tLBRACE_ARG);
@@ -2845,7 +2844,6 @@ rb_parser_ary_free(rb_parser_t *p, rb_parser_ary_t *ary)
 %token tASSOC		"=>"
 %token tLPAREN		"("
 %token tLPAREN_ARG	"( arg"
-%token tRPAREN		")"
 %token tLBRACK		"["
 %token tLBRACE		"{"
 %token tLBRACE_ARG	"{ arg"


### PR DESCRIPTION
This PR just remove unused token:

```
$ find . -type f | xargs grep "tRPAREN"    
./ext/ripper/eventids2.c:        [tRPAREN]              = O(rparen),
./lib/prism/translation/parser/lexer.rb:          PARENTHESIS_RIGHT: :tRPAREN,
./parse.y:      TOKEN2CHAR(tRPAREN);
./parse.y:%token tRPAREN                ")"
```