### PR TITLE
`gc/default/default.c`: don't call `malloc_usable_size` when hint is present

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -7944,10 +7944,11 @@ static inline size_t
 objspace_malloc_size(rb_objspace_t *objspace, void *ptr, size_t hint)
 {
 #ifdef HAVE_MALLOC_USABLE_SIZE
-    return malloc_usable_size(ptr);
-#else
-    return hint;
+    if (!hint) {
+        hint = malloc_usable_size(ptr);
+    }
 #endif
+    return hint;
 }
 
 enum memop_type {


### PR DESCRIPTION
Depending on the allocator, `malloc_usable_size` may be very cheap or quite expensive. On `macOS` for instance, it's about as expensive as `malloc`.

In many case we call `objspace_malloc_size` with as size we initially requested as `hint`. The real usable size may be a few bytes bigger, but since we only use that data to feed GC heuristics, I don't think it's very important to be perfectly accurate.

It would make sense to call `malloc_usable_size` after growing a String or Array to use the extra capacity, but here we don't do that, so the call isn't worth its cost.

References:

  - `ruby/json` experimental branch profile showing a big overhead from `malloc_size` on macOS: https://share.firefox.dev/40dqHXk
  - Context on the profile: https://byroot.github.io/ruby/json/2024/12/29/optimizing-ruby-json-part-4.html#using-an-rstring-as-buffer
  - Some older article on `malloc_size` performance: https://lemire.me/blog/2017/09/15/how-fast-are-malloc_size-and-malloc_usable_size-in-c/