### PR TITLE
Remove rb_ary_push for parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -344,7 +344,6 @@ static const rb_parser_config_t rb_global_parser_config = {
 
     .attr_get = rb_attr_get,
 
-    .ary_push = rb_ary_push,
     .ary_new_from_args = rb_ary_new_from_args,
     .ary_unshift = rb_ary_unshift,
 

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1196,7 +1196,6 @@ typedef struct rb_parser_config_struct {
     VALUE (*attr_get)(VALUE obj, ID id);
 
     /* Array */
-    VALUE (*ary_push)(VALUE ary, VALUE elem);
     VALUE (*ary_new_from_args)(long n, ...);
     VALUE (*ary_unshift)(VALUE ary, VALUE item);
 

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -86,7 +86,6 @@
 
 #define rb_attr_get p->config->attr_get
 
-#define rb_ary_push          p->config->ary_push
 #undef rb_ary_new_from_args
 #define rb_ary_new_from_args p->config->ary_new_from_args
 #define rb_ary_unshift       p->config->ary_unshift


### PR DESCRIPTION
parser not used rb_ary_push function.
And that function can be removed from Universal Parser property.