### PR TITLE
Win32: Define COROUTINE_DECL to suppress a warning

### DIFF
--- a/coroutine/win32/Context.h
+++ b/coroutine/win32/Context.h
@@ -16,6 +16,7 @@
 #include <string.h>
 
 #define COROUTINE __declspec(noreturn) void __fastcall
+#define COROUTINE_DECL void __fastcall
 #define COROUTINE_LIMITED_ADDRESS_SPACE
 
 /* This doesn't include thread information block */

--- a/coroutine/win64/Context.h
+++ b/coroutine/win64/Context.h
@@ -16,6 +16,7 @@
 #include <string.h>
 
 #define COROUTINE __declspec(noreturn) void
+#define COROUTINE_DECL void
 
 enum {
     COROUTINE_REGISTERS = 8,


### PR DESCRIPTION
In cont.c:

```
warning C4141: 'noreturn': used more than once
```
