### PR TITLE
Remove SYM2ID for Parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -362,7 +362,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .id2name = rb_id2name,
     .id2str = rb_id2str,
     .id2sym = rb_id2sym,
-    .sym2id = rb_sym2id,
 
     .str_catf = rb_str_catf,
     .str_cat_cstr = rb_str_cat_cstr,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1226,7 +1226,6 @@ typedef struct rb_parser_config_struct {
     const char *(*id2name)(ID id);
     VALUE (*id2str)(ID id);
     VALUE (*id2sym)(ID x);
-    ID (*sym2id)(VALUE sym);
 
     /* String */
     RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 2, 3)

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -107,8 +107,6 @@
 #define rb_id2str                p->config->id2str
 #undef ID2SYM
 #define ID2SYM                   p->config->id2sym
-#undef SYM2ID
-#define SYM2ID                   p->config->sym2id
 
 #define rb_str_catf                       p->config->str_catf
 #undef rb_str_cat_cstr


### PR DESCRIPTION
Ruby Parser not used SYM2ID.
And sym2id property can be removed from Universal Parser.