### PR TITLE
[Bug #21004] Fix memory leak with "it" in parse.y

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -5155,6 +5155,7 @@ lambda		: tLAMBDA[lpar]
                             nd_set_line(RNODE_LAMBDA($$)->nd_body, @body.end_pos.lineno);
                             nd_set_line($$, @args.end_pos.lineno);
                             nd_set_first_loc($$, @1.beg_pos);
+                            xfree($body);
                         }
                     /*% ripper: lambda!($:args, $:body) %*/
                         numparam_pop(p, $numparam);

--- a/parse.y
+++ b/parse.y
@@ -439,7 +439,6 @@ struct local_vars {
 
 typedef struct rb_locations_lambda_body_t {
     NODE *node;
-    YYLTYPE loc;
     YYLTYPE opening_loc;
     YYLTYPE closing_loc;
 } rb_locations_lambda_body_t;
@@ -12843,7 +12842,6 @@ new_locations_lambda_body(struct parser_params* p, NODE *node, const YYLTYPE *lo
 {
     rb_locations_lambda_body_t *body = xcalloc(1, sizeof(rb_locations_lambda_body_t));
     body->node = node;
-    body->loc = *loc;
     body->opening_loc = *opening_loc;
     body->closing_loc = *closing_loc;
     return body;

--- a/test/ripper/test_ripper.rb
+++ b/test/ripper/test_ripper.rb
@@ -187,6 +187,13 @@ end
         Ripper.parse("-> {")
       end
     end;
+
+    # [Bug #21004]
+    assert_no_memory_leak(%w(-rripper), "", <<~RUBY, rss: true)
+      1_000_000.times do
+        Ripper.parse("-> do it end")
+      end
+    RUBY
   end
 
   def test_sexp_no_memory_leak


### PR DESCRIPTION
Parsing `-> do it end` in parse.y leaks memory. We can see this in the Valgrind output:

    56 bytes in 1 blocks are definitely lost in loss record 1 of 6
        at 0x484E0DC: calloc (vg_replace_malloc.c:1675)
        by 0x188970: calloc1 (default.c:1472)
        by 0x188970: rb_gc_impl_calloc (default.c:8208)
        by 0x188970: ruby_xcalloc_body (gc.c:4598)
        by 0x18B8BC: ruby_xcalloc (gc.c:4592)
        by 0x21DCCA70: new_locations_lambda_body (ripper.y:12844)
        by 0x21DCCA70: ripper_yyparse (ripper.y:5194)
        by 0x21DDA521: rb_ruby_ripper_parse0 (ripper.y:15798)