### PR TITLE
Suppress warnings for flip-flop in test_ast.rb

### DIFF
--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1594,7 +1594,7 @@ dummy
     private
     def ast_parse(src, **options)
       begin
-        verbose_bak, $VERBOSE = $VERBOSE, false
+        verbose_bak, $VERBOSE = $VERBOSE, nil
         RubyVM::AbstractSyntaxTree.parse(src, **options)
       ensure
         $VERBOSE = verbose_bak


### PR DESCRIPTION
There are warnings emitted from test_flip2_locations and test_flip3_locations. This commit changes ast_parse to suppress all warnings.

    warning: integer literal in flip-flop
    warning: string literal in flip-flop