### PR TITLE
[DOC] Turn on missing rdoc-ref warning

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -20,3 +20,5 @@ autolink_excluded_words:
 - RDoc
 - Ruby
 - Set
+
+warn_missing_rdoc_ref: true


### PR DESCRIPTION
With this configuration, RDoc will warn when a `rdoc-ref` link's target is missing.

I've fixed all detectable missing `rdoc-ref` links in the last few weeks so now it doesn't create any warning.