### PR TITLE
Do not warn unused block when using forwarding

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1756,6 +1756,8 @@ pm_setup_args_core(const pm_arguments_node_t *arguments_node, const pm_node_t *b
                 break;
               }
               case PM_FORWARDING_ARGUMENTS_NODE: { // not counted in argc return value
+                iseq_set_use_block(ISEQ_BODY(iseq)->local_iseq);
+
                 if (ISEQ_BODY(ISEQ_BODY(iseq)->local_iseq)->param.flags.forwardable) {
                     *flags |= VM_CALL_FORWARDING;
 

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -1776,5 +1776,13 @@ class TestMethod < Test::Unit::TestCase
     RUBY
       assert_equal 0, err.size, err.join("\n")
     end
+
+    assert_in_out_err '-w', <<-'RUBY' do |_out, err, _status|
+      def foo(*, &block) = block
+      def bar(buz, ...) = foo(buz, ...)
+      bar(:test) {} # do not warn because of forwarding
+    RUBY
+      assert_equal 0, err.size, err.join("\n")
+    end
   end
 end


### PR DESCRIPTION
Fixes [Bug #21003]