### PR TITLE
Do not intern invalid symbols in eval parse

### DIFF
--- a/test/.excludes/TestVariable.rb
+++ b/test/.excludes/TestVariable.rb
@@ -1,3 +1,0 @@
-if RUBY_DESCRIPTION.include?("+PRISM")
-  exclude(:test_local_variables_encoding, "[Bug #20992]")
-end


### PR DESCRIPTION
When the inner code cannot represent the name of the locals in the outer code, do not bother putting them into the constant pool as they will not be referenced.

Fixes [Bug #20992]