### PR TITLE
Fix a ractor scheduling issue

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1939,3 +1939,26 @@ assert_equal 'LoadError', %q{
   end
   r.take
 }
+
+###
+### Scheduler tests
+###
+
+# [Bug #20905]
+assert_equal 'success', %q{
+  def counter_loop
+    counter = 0
+    counter += 1 while counter < 3_000_000
+  end
+
+  ractors = 5.times.map { Ractor.new { Thread.new { counter_loop }; counter_loop } }
+  counter_loop
+
+  while ractors.any?
+    r, obj = Ractor.select(*ractors)
+    if r
+      ractors.delete(r)
+    end
+  end
+  'success'
+}

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -481,6 +481,9 @@ co_start(struct coroutine_context *from, struct coroutine_context *self)
             thread_sched_switch0(th->sched.context, next_th, nt, true);
         }
         else {
+            if (next_th && !next_th->nt) {
+                ractor_sched_enq(next_th->vm, next_th->ractor);
+            }
             // switch to the next Ractor
             th->sched.finished = true;
             coroutine_transfer0(self, nt->nt_context, true);


### PR DESCRIPTION
This issue occurs when there are multiple ractors and threads within those ractors. When an SNT finishes with a thread and the ractor global run queue (grq) is non-empty, make sure the next thread's ractor is enqueued before switching back to native context. Before this change, this did not always occur and could all SNTs sleeping on dequeuing an empty grq when there was work left.

Fixes [Bug #20905]