### PR TITLE
[Bug #21008] Normalize before sum to float

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -4704,7 +4704,7 @@ sum_iter(VALUE i, struct enum_sum_memo *memo)
     }
     else switch (TYPE(memo->v)) {
       default:      sum_iter_some_value(i, memo);    return;
-      case T_FLOAT: sum_iter_Kahan_Babuska(i, memo); return;
+      case T_FLOAT:
       case T_FIXNUM:
       case T_BIGNUM:
       case T_RATIONAL:

--- a/test/ruby/test_enumerator.rb
+++ b/test/ruby/test_enumerator.rb
@@ -1043,4 +1043,19 @@ class TestEnumerator < Test::Unit::TestCase
     assert_raise(FrozenError) { e.feed 1 }
     assert_raise(FrozenError) { e.rewind }
   end
+
+  def test_sum_of_numeric
+    num = Class.new(Numeric) do
+      attr_reader :to_f
+      def initialize(val)
+        @to_f = Float(val)
+      end
+    end
+
+    ary = [5, 10, 20].map {|i| num.new(i)}
+
+    assert_equal(35.0, ary.sum)
+    enum = ary.each
+    assert_equal(35.0, enum.sum)
+  end
 end


### PR DESCRIPTION
After switching to `Float`-mode when summing `Numeric` objects, normalization for `Float` is still needed.