### PR TITLE
Support more node types in compilation of PM_DEFINED_NODE

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3845,9 +3845,10 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
               }
               case PM_ASSOC_SPLAT_NODE: {
                 const pm_assoc_splat_node_t *assoc_splat = (const pm_assoc_splat_node_t *) element;
-
-                pm_compile_defined_expr0(iseq, assoc_splat->value, node_location, ret, popped, scope_node, true, lfinish, false);
-                PUSH_INSNL(ret, location, branchunless, lfinish[1]);
+                if (assoc_splat->value != NULL) {
+                    pm_compile_defined_expr0(iseq, assoc_splat->value, node_location, ret, popped, scope_node, true, lfinish, false);
+                    PUSH_INSNL(ret, location, branchunless, lfinish[1]);
+                }
 
                 break;
               }
@@ -3862,13 +3863,15 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
       }
       case PM_SPLAT_NODE: {
         const pm_splat_node_t *cast = (const pm_splat_node_t *) node;
-        pm_compile_defined_expr0(iseq, cast->expression, node_location, ret, popped, scope_node, in_condition, lfinish, false);
+        if (cast->expression != NULL) {
+            pm_compile_defined_expr0(iseq, cast->expression, node_location, ret, popped, scope_node, in_condition, lfinish, false);
 
-        if (!lfinish[1]) {
-            lfinish[1] = NEW_LABEL(location.line);
+            if (!lfinish[1]) {
+                lfinish[1] = NEW_LABEL(location.line);
+            }
+
+            PUSH_INSNL(ret, location, branchunless, lfinish[1]);
         }
-
-        PUSH_INSNL(ret, location, branchunless, lfinish[1]);
         dtype = DEFINED_EXPR;
         break;
       }

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -3877,6 +3877,8 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
         pm_compile_defined_expr0(iseq, cast->value, node_location, ret, popped, scope_node, in_condition, lfinish, false);
         return;
       }
+      case PM_ALIAS_GLOBAL_VARIABLE_NODE:
+      case PM_ALIAS_METHOD_NODE:
       case PM_AND_NODE:
       case PM_BEGIN_NODE:
       case PM_BREAK_NODE:
@@ -3885,26 +3887,32 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
       case PM_CLASS_NODE:
       case PM_DEF_NODE:
       case PM_DEFINED_NODE:
+      case PM_FLIP_FLOP_NODE:
       case PM_FLOAT_NODE:
       case PM_FOR_NODE:
+      case PM_FORWARDING_ARGUMENTS_NODE:
       case PM_IF_NODE:
       case PM_IMAGINARY_NODE:
       case PM_INTEGER_NODE:
+      case PM_INTERPOLATED_MATCH_LAST_LINE_NODE:
       case PM_INTERPOLATED_REGULAR_EXPRESSION_NODE:
       case PM_INTERPOLATED_STRING_NODE:
       case PM_INTERPOLATED_SYMBOL_NODE:
       case PM_INTERPOLATED_X_STRING_NODE:
       case PM_LAMBDA_NODE:
+      case PM_MATCH_LAST_LINE_NODE:
       case PM_MATCH_PREDICATE_NODE:
       case PM_MATCH_REQUIRED_NODE:
       case PM_MATCH_WRITE_NODE:
       case PM_MODULE_NODE:
       case PM_NEXT_NODE:
       case PM_OR_NODE:
+      case PM_POST_EXECUTION_NODE:
       case PM_RANGE_NODE:
       case PM_RATIONAL_NODE:
       case PM_REDO_NODE:
       case PM_REGULAR_EXPRESSION_NODE:
+      case PM_RESCUE_MODIFIER_NODE:
       case PM_RETRY_NODE:
       case PM_RETURN_NODE:
       case PM_SINGLETON_CLASS_NODE:
@@ -3913,12 +3921,14 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
       case PM_SOURCE_LINE_NODE:
       case PM_STRING_NODE:
       case PM_SYMBOL_NODE:
+      case PM_UNDEF_NODE:
       case PM_UNLESS_NODE:
       case PM_UNTIL_NODE:
       case PM_WHILE_NODE:
       case PM_X_STRING_NODE:
         dtype = DEFINED_EXPR;
         break;
+      case PM_IT_LOCAL_VARIABLE_READ_NODE:
       case PM_LOCAL_VARIABLE_READ_NODE:
         dtype = DEFINED_LVAR;
         break;
@@ -4068,6 +4078,8 @@ pm_compile_defined_expr0(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
       case PM_CONSTANT_PATH_OPERATOR_WRITE_NODE:
       case PM_CONSTANT_PATH_OR_WRITE_NODE:
       case PM_CONSTANT_PATH_WRITE_NODE:
+
+      case PM_SHAREABLE_CONSTANT_NODE:
 
       case PM_GLOBAL_VARIABLE_WRITE_NODE:
       case PM_GLOBAL_VARIABLE_OPERATOR_WRITE_NODE:

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -266,6 +266,17 @@ module Prism
       assert_prism_eval("defined?(while a != 1; end)")
       assert_prism_eval("defined?(until a == 1; end)")
       assert_prism_eval("defined?(unless true; 1; end)")
+      assert_prism_eval("defined?((alias a b))")
+      assert_prism_eval("defined?((alias $a $b))")
+      assert_prism_eval("defined?(!(a..b))")
+      assert_prism_eval("def f(...); defined?(p(...)); end")
+      assert_prism_eval("defined?(!/foo/)")
+      assert_prism_eval('defined?(!/#{1}/)')
+      assert_prism_eval("defined?((END{}))")
+      assert_prism_eval("defined?((a rescue b))")
+      assert_prism_eval("# shareable-constant-value: experimental_everything\ndefined?(A=1)")
+      assert_prism_eval("defined?((undef a))")
+      assert_prism_eval("tap { defined?(it) }")
     end
 
     def test_GlobalVariableReadNode

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -270,6 +270,8 @@ module Prism
       assert_prism_eval("defined?((alias $a $b))")
       assert_prism_eval("defined?(!(a..b))")
       assert_prism_eval("def f(...); defined?(p(...)); end")
+      assert_prism_eval("def f(*, **, &); defined?(p(*, **, &)); end")
+      assert_prism_eval("def f(*, **, &); defined?([*, **]); end")
       assert_prism_eval("defined?(!/foo/)")
       assert_prism_eval('defined?(!/#{1}/)')
       assert_prism_eval("defined?((END{}))")


### PR DESCRIPTION
Fix compiling `defined?(f(*))`, `defined?(f(**))`, `defined?([*])`, `defined?([**])`
```ruby
def f(*, **, &); defined?(p(*, **, &)); end
def f(*, **, &); defined?([*, **]); end
```

Add more node types into switch-case branch of pm_compile_defined_expr0 to support these codes.

```ruby
defined?((alias a b))
defined?((alias $a $b))
defined?(!(a..b))
def f(...); defined?(f(...)); end
defined?(!/foo/)
defined?(!/#{1}/)
defined?((END{}))
defined?((a rescue b))
defined?((undef a))
tap { defined?(it) }
```
and
```ruby
# shareable-constant-value: experimental_everything
defined?(A=1)
```

`!/foo/` `!/#{1}/` `!(a..b)` are `"method"`.
Standalone PM_MATCH_LAST_LINE_NODE, PM_INTERPOLATED_MATCH_LAST_LINE_NODE, PM_FLIP_FLOP_NODE is treated as `"expression"` in this pull request. It does not affect the result because they don't appear directly under PM_DEFINED_NODE. 
