### PR TITLE
[3.4 backport] YJIT: Fix crash when yielding keyword arguments

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -37,14 +37,18 @@ assert_equal "ok", %q{
 }
 
 # test discarding extra yield arguments
-assert_equal "2210150001501015", %q{
+assert_equal "22131300500015901015", %q{
   def splat_kw(ary) = yield *ary, a: 1
 
   def splat(ary) = yield *ary
 
-  def kw = yield 1, 2, a: 0
+  def kw = yield 1, 2, a: 3
+
+  def kw_only = yield a: 0
 
   def simple = yield 0, 1
+
+  def none = yield
 
   def calls
     [
@@ -52,12 +56,16 @@ assert_equal "2210150001501015", %q{
       splat([1, 1, 2]) { |y, opt = raise| opt + y},
       splat_kw([0, 1]) { |a:| a },
       kw { |a:| a },
-      kw { |a| a },
+      kw { |one| one },
+      kw { |one, a:| a },
+      kw_only { |a:| a },
+      kw_only { |a: 1| a },
       simple { 5.itself },
       simple { |a| a },
       simple { |opt = raise| opt },
       simple { |*rest| rest },
       simple { |opt_kw: 5| opt_kw },
+      none { |a: 9| a },
       # autosplat ineractions
       [0, 1, 2].yield_self { |a, b| [a, b] },
       [0, 1, 2].yield_self { |a, opt = raise| [a, opt] },

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -1742,6 +1742,14 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_yield_kwargs
+    assert_compiles(<<~RUBY, result: 3, no_send_fallbacks: true)
+      def req2kws = yield a: 1, b: 2
+
+      req2kws { |a:, b:| a + b }
+    RUBY
+  end
+
   private
 
   def code_gc_helpers

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -8011,14 +8011,14 @@ fn gen_send_iseq(
 
     // Pop surplus positional arguments when yielding
     if arg_setup_block {
-        let extras = argc - required_num - opt_num;
+        let extras = argc - required_num - opt_num - kw_arg_num;
         if extras > 0 {
             // Checked earlier. If there are keyword args, then
             // the positional arguments are not at the stack top.
             assert_eq!(0, kw_arg_num);
 
             asm.stack_pop(extras as usize);
-            argc = required_num + opt_num;
+            argc = required_num + opt_num + kw_arg_num;
         }
     }
 


### PR DESCRIPTION
Backport for #12499

Request: [[Bug #21013]](https://bugs.ruby-lang.org/issues/21013)