### PR TITLE
Correctly set node_id on iseq location

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -1072,7 +1072,7 @@ pm_iseq_new_with_opt(pm_scope_node_t *node, VALUE name, VALUE path, VALUE realpa
         .end_pos = { .lineno = (int) end.line, .column = (int) end.column }
     };
 
-    prepare_iseq_build(iseq, name, path, realpath, first_lineno, &code_location, -1,
+    prepare_iseq_build(iseq, name, path, realpath, first_lineno, &code_location, node->ast_node->node_id,
                        parent, isolated_depth, type, node->script_lines == NULL ? Qnil : *node->script_lines, option);
 
     struct pm_iseq_new_with_opt_data data = {

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6486,7 +6486,7 @@ pm_compile_scope_node(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_nod
       case ISEQ_TYPE_BLOCK: {
         LABEL *start = ISEQ_COMPILE_DATA(iseq)->start_label = NEW_LABEL(0);
         LABEL *end = ISEQ_COMPILE_DATA(iseq)->end_label = NEW_LABEL(0);
-        const pm_node_location_t block_location = { .line = body->location.first_lineno, .node_id = -1 };
+        const pm_node_location_t block_location = { .line = body->location.first_lineno, .node_id = scope_node->ast_node->node_id };
 
         start->rescued = LABEL_RESCUE_BEG;
         end->rescued = LABEL_RESCUE_END;
@@ -6612,7 +6612,7 @@ pm_compile_scope_node(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_nod
     }
 
     if (!PM_NODE_TYPE_P(scope_node->ast_node, PM_ENSURE_NODE)) {
-        const pm_node_location_t location = { .line = ISEQ_COMPILE_DATA(iseq)->last_line, .node_id = -1 };
+        const pm_node_location_t location = { .line = ISEQ_COMPILE_DATA(iseq)->last_line, .node_id = scope_node->ast_node->node_id };
         PUSH_INSN(ret, location, leave);
     }
 }

--- a/test/ruby/test_compile_prism.rb
+++ b/test/ruby/test_compile_prism.rb
@@ -3,6 +3,12 @@
 # This file is organized to match itemization in https://github.com/ruby/prism/issues/1335
 module Prism
   class TestCompilePrism < Test::Unit::TestCase
+    def test_iseq_has_node_id
+      code = "proc { <<END }\n hello\nEND"
+      iseq = RubyVM::InstructionSequence.compile_prism(code)
+      assert_operator iseq.to_a[4][:node_id], :>, -1
+    end
+
     # Subclass is used for tests which need it
     class Subclass; end
     ############################################################################


### PR DESCRIPTION
The iseq location object has a slot for node ids.  parse.y was correctly populating that field but Prism was not. This commit populates the field with the ast node id for that iseq

[Bug #21014]