### PR TITLE
Avoid opt_aset_with optimization inside multiple assignment

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -10237,7 +10237,8 @@ compile_attrasgn(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node
     /* optimization shortcut
      *   obj["literal"] = value -> opt_aset_with(obj, "literal", value)
      */
-    if (mid == idASET && !private_recv_p(node) && RNODE_ATTRASGN(node)->nd_args &&
+    if (!ISEQ_COMPILE_DATA(iseq)->in_masgn &&
+        mid == idASET && !private_recv_p(node) && RNODE_ATTRASGN(node)->nd_args &&
         nd_type_p(RNODE_ATTRASGN(node)->nd_args, NODE_LIST) && RNODE_LIST(RNODE_ATTRASGN(node)->nd_args)->as.nd_alen == 2 &&
         (nd_type_p(RNODE_LIST(RNODE_ATTRASGN(node)->nd_args)->nd_head, NODE_STR) || nd_type_p(RNODE_LIST(RNODE_ATTRASGN(node)->nd_args)->nd_head, NODE_FILE)) &&
         ISEQ_COMPILE_DATA(iseq)->current_block == NULL &&
@@ -10790,7 +10791,10 @@ iseq_compile_each0(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const no
       }
 
       case NODE_MASGN:{
+        bool prev_in_masgn = ISEQ_COMPILE_DATA(iseq)->in_masgn;
+        ISEQ_COMPILE_DATA(iseq)->in_masgn = true;
         compile_massign(iseq, ret, node, popped);
+        ISEQ_COMPILE_DATA(iseq)->in_masgn = prev_in_masgn;
         break;
       }
 

--- a/iseq.h
+++ b/iseq.h
@@ -119,6 +119,7 @@ struct iseq_compile_data {
       struct iseq_compile_data_storage *storage_current;
     } insn;
     bool in_rescue;
+    bool in_masgn;
     int loopval_popped;	/* used by NODE_BREAK */
     int last_line;
     int label_no;

--- a/test/ruby/test_assignment.rb
+++ b/test/ruby/test_assignment.rb
@@ -248,6 +248,17 @@ class TestAssignment < Test::Unit::TestCase
     a,b,*c = *[*[1,2]]; assert_equal([1,2,[]], [a,b,c])
   end
 
+  def test_massign_optimized_literal_bug_21012
+    singleton_class.attr_reader :a
+    @a = []
+    def (@a).[]=(*args)
+      push args
+    end
+    a["a", "b"], = 1
+    a["a", 10], = 2
+    assert_equal [["a", "b", 1], ["a", 10, 2]], @a
+  end
+
   def test_assign_rescue
     a = raise rescue 2; assert_equal(2, a)
     a, b = raise rescue [3,4]; assert_equal([3, 4], [a, b])

--- a/test/ruby/test_assignment.rb
+++ b/test/ruby/test_assignment.rb
@@ -249,14 +249,13 @@ class TestAssignment < Test::Unit::TestCase
   end
 
   def test_massign_optimized_literal_bug_21012
-    singleton_class.attr_reader :a
-    @a = []
-    def (@a).[]=(*args)
+    a = []
+    def a.[]=(*args)
       push args
     end
     a["a", "b"], = 1
     a["a", 10], = 2
-    assert_equal [["a", "b", 1], ["a", 10, 2]], @a
+    assert_equal [["a", "b", 1], ["a", 10, 2]], a
   end
 
   def test_assign_rescue


### PR DESCRIPTION
Previously, since the opt_aset_with optimization was introduced, use of the opt_aset_with optimization inside multiple assignment would result in a segfault or incorrect instructions.

Fixes [Bug #21012]