### PR TITLE
Add make dependency for main.c on id.h

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -9717,6 +9717,7 @@ main.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 main.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
 main.$(OBJEXT): {$(VPATH)}config.h
 main.$(OBJEXT): {$(VPATH)}defines.h
+main.$(OBJEXT): {$(VPATH)}id.h
 main.$(OBJEXT): {$(VPATH)}intern.h
 main.$(OBJEXT): {$(VPATH)}internal/abi.h
 main.$(OBJEXT): {$(VPATH)}internal/anyargs.h


### PR DESCRIPTION
main.c depends on id.h and id.h is auto-generated, so on a new build there is a race condition the build fails if main.c is compiled before id.h has been generated. The error looks like:

      In file included from ./main.c:28:
      In file included from ./internal/gc.h:17:
      ./vm_core.h:117:10: fatal error: 'id.h' file not found
      #include "id.h"
              ^~~~~~