### PR TITLE
YJIT: Rename send_iseq_forwarding->send_forwarding

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -9009,7 +9009,7 @@ fn gen_send_general(
 
     // Dynamic stack layout. No good way to support without inlining.
     if ci_flags & VM_CALL_FORWARDING != 0 {
-        gen_counter_incr(jit, asm, Counter::send_iseq_forwarding);
+        gen_counter_incr(jit, asm, Counter::send_forwarding);
         return None;
     }
 

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -358,6 +358,7 @@ make_counters! {
 
     // Method calls that fallback to dynamic dispatch
     send_singleton_class,
+    send_forwarding,
     send_ivar_set_method,
     send_zsuper_method,
     send_undef_method,
@@ -385,7 +386,6 @@ make_counters! {
     send_iseq_block_arg_type,
     send_iseq_clobbering_block_arg,
     send_iseq_complex_discard_extras,
-    send_iseq_forwarding,
     send_iseq_leaf_builtin_block_arg_block_param,
     send_iseq_kw_splat_non_nil,
     send_iseq_kwargs_mismatch,


### PR DESCRIPTION
It's in gen_send_general(), so nothing specifically to do with iseqs.
