### PR TITLE
[Bug #21024] <cstdbool> header is deprecated in C++17

### DIFF
--- a/include/ruby/internal/stdbool.h
+++ b/include/ruby/internal/stdbool.h
@@ -27,7 +27,7 @@
 
 #elif defined(__cplusplus)
 # /* bool is a keyword in C++. */
-# if defined(HAVE_STDBOOL_H) && (__cplusplus >= 201103L)
+# if defined(HAVE_STDBOOL_H) && (__cplusplus >= 201103L) && (__cplusplus < 201703L)
 #  include <cstdbool>
 # endif
 #


### PR DESCRIPTION
[[Bug #21024]](https://bugs.ruby-lang.org/issues/21024)