### PR TITLE
rb_feature_p: skip `get_expanded_load_path` for absolute paths

### DIFF
--- a/load.c
+++ b/load.c
@@ -597,7 +597,7 @@ rb_feature_p(rb_vm_t *vm, const char *feature, const char *ext, int rb, int expa
 
     loading_tbl = get_loading_table(vm);
     f = 0;
-    if (!expanded) {
+    if (!expanded && !rb_is_absolute_path(feature)) {
         struct loaded_feature_searching fs;
         fs.name = feature;
         fs.len = len;


### PR DESCRIPTION
Ref: https://github.com/fxn/zeitwerk/pull/308

```ruby
require 'benchmark'

$LOAD_PATH << 'relative-path'

autoload :FOO, '/tmp/foo.rb'

puts Benchmark.realtime {
  500_000.times do
    Object.autoload?(:FOO)
  end
}
```

The above script takes 2.5 seconds on `master`, and only
50ms on this branch.

When we're looking for a feature with an absolute path, we don't
need to call the expensive `get_expanded_load_path`.