### PR TITLE
Move the declaration of `rb_path_check`

### DIFF
--- a/include/ruby/internal/intern/file.h
+++ b/include/ruby/internal/intern/file.h
@@ -208,6 +208,19 @@ int rb_is_absolute_path(const char *path);
  */
 rb_off_t rb_file_size(VALUE file);
 
+/**
+ * If the PATH_SEPARATOR-separated list of directory names contains the name of
+ * a world-writable directory, issue a warning  for it.  This may do nothing on
+ * some platforms.
+ *
+ * @param[in]  path       A local path.
+ * @retval     0          The "check" succeeded.
+ * @retval     otherwise  The "check" failed.
+ * @note       This  feature may  be  disabled  by setting  `ENABLE_PATH_CHECK`
+ *             macro to zero at compilation time.
+ */
+int rb_path_check(const char *path);
+
 RBIMPL_SYMBOL_EXPORT_END()
 
 #endif /* RBIMPL_INTERN_FILE_H */

--- a/include/ruby/internal/intern/hash.h
+++ b/include/ruby/internal/intern/hash.h
@@ -284,23 +284,6 @@ typedef VALUE rb_hash_update_func(VALUE newkey, VALUE oldkey, VALUE value);
  */
 VALUE rb_hash_update_by(VALUE hash1, VALUE hash2, rb_hash_update_func *func);
 
-/* file.c */
-
-/**
- * If the PATH_SEPARATOR-separated list of directory names contains the name of
- * a world-writable directory, issue a warning  for it.  This may do nothing on
- * some platforms.
- *
- * @param[in]  path       A local path.
- * @retval     0          The "check" succeeded.
- * @retval     otherwise  The "check" failed.
- * @note       This  feature may  be  disabled  by setting  `ENABLE_PATH_CHECK`
- *             macro to zero at compilation time.
- */
-int rb_path_check(const char *path);
-
-/* hash.c */
-
 /**
  * Destructively removes every environment variables of the running process.
  *


### PR DESCRIPTION
Although this function is unrelated to hash, it was defined in hash.c to check PATH environment variable originally.  Then the definition was moeved to file.c but the declaration was left in the hash.c block.