### PR TITLE
Merge https://github.com/ruby/json/pull/728

### DIFF
--- a/ext/json/lib/json/common.rb
+++ b/ext/json/lib/json/common.rb
@@ -232,12 +232,13 @@ module JSON
   # - Option +max_nesting+, if not provided, defaults to +false+,
   #   which disables checking for nesting depth.
   # - Option +allow_nan+, if not provided, defaults to +true+.
-  def parse!(source, opts = {})
-    opts = {
+  def parse!(source, opts = nil)
+    options = {
       :max_nesting  => false,
       :allow_nan    => true
-    }.merge(opts)
-    Parser.new(source, **(opts||{})).parse
+    }
+    options.merge!(opts) if opts
+    Parser.new(source, options).parse
   end
 
   # :call-seq:
@@ -258,7 +259,7 @@ module JSON
   #   JSON.parse!(File.read(path, opts))
   #
   # See method #parse!
-  def load_file!(filespec, opts = {})
+  def load_file!(filespec, opts = nil)
     parse!(File.read(filespec, encoding: Encoding::UTF_8), opts)
   end
 

--- a/ext/json/lib/json/ext.rb
+++ b/ext/json/lib/json/ext.rb
@@ -11,6 +11,7 @@ module JSON
         def parse(...)
           new(...).parse
         end
+        alias_method :parse, :parse # Allow redefinition by extensions
       end
 
       def initialize(source, opts = nil)

--- a/ext/json/lib/json/ext.rb
+++ b/ext/json/lib/json/ext.rb
@@ -6,15 +6,36 @@ module JSON
   # This module holds all the modules/classes that implement JSON's
   # functionality as C extensions.
   module Ext
+    class Parser
+      class << self
+        def parse(...)
+          new(...).parse
+        end
+      end
+
+      def initialize(source, opts = nil)
+        @source = source
+        @config = Config.new(opts)
+      end
+
+      def source
+        @source.dup
+      end
+
+      def parse
+        @config.parse(@source)
+      end
+    end
+
+    require 'json/ext/parser'
+    Ext::Parser::Config = Ext::ParserConfig
+    JSON.parser = Ext::Parser
+
     if RUBY_ENGINE == 'truffleruby'
-      require 'json/ext/parser'
       require 'json/truffle_ruby/generator'
-      JSON.parser = Parser
       JSON.generator = ::JSON::TruffleRuby::Generator
     else
-      require 'json/ext/parser'
       require 'json/ext/generator'
-      JSON.parser = Parser
       JSON.generator = Generator
     end
   end

--- a/test/json/json_ext_parser_test.rb
+++ b/test/json/json_ext_parser_test.rb
@@ -6,11 +6,11 @@ class JSONExtParserTest < Test::Unit::TestCase
 
   def test_allocate
     parser = JSON::Ext::Parser.new("{}")
-    assert_raise(TypeError, '[ruby-core:35079]') do
-      parser.__send__(:initialize, "{}")
-    end
+    parser.__send__(:initialize, "{}")
+    assert_equal "{}", parser.source
+
     parser = JSON::Ext::Parser.allocate
-    assert_raise(TypeError, '[ruby-core:35079]') { parser.source }
+    assert_nil parser.source
   end
 
   def test_error_messages


### PR DESCRIPTION
@byroot @etiennebarrie

https://github.com/ruby/ruby/pull/12569/commits/220409f0c186e80da9f4d99cb0d99d8c9e9d0fa2 broke `test-bundler-parallel` and `test-bundled-gems`.

* https://github.com/ruby/ruby/actions/runs/12760760559/job/35566716077?pr=12569#step:14:128
* https://github.com/ruby/ruby/actions/runs/12760760559/job/35566716713?pr=12569#step:14:133

```
 expected `["/Users/runner/work/ruby/ruby/build/.ext/arm64-darwin23/json/ext/parser.bundle: warning: method redefined; discarding old parse"].empty?` to be truthy, got false
```

It simply failed with `foo.to be_empty` assertion. But `JSON.parse` warned for redefined  with pure ruby version.

Can you look this?

