### PR TITLE
Simplify gc/mmtk/extconf.rb

### DIFF
--- a/gc/extconf_base.rb
+++ b/gc/extconf_base.rb
@@ -9,6 +9,6 @@ $CPPFLAGS << " -DBUILDING_MODULAR_GC"
 
 append_cflags("-fPIC")
 
-def create_gc_makefile(name)
-  create_makefile("librubygc.#{name}")
+def create_gc_makefile(name, &block)
+  create_makefile("librubygc.#{name}", &block)
 end

--- a/gc/mmtk/depend
+++ b/gc/mmtk/depend
@@ -1,0 +1,18 @@
+$(TARGET_SO): $(MMTK_BUILD)/$(LIBMMTK_RUBY)
+
+# Add the `libmmtk_ruby.a` target to run `cargo build`
+
+release/$(LIBMMTK_RUBY) debug/$(LIBMMTK_RUBY): $(RUSTSRCS) $(srcdir)/Cargo.toml $(srcdir)/Cargo.toml
+
+release/$(LIBMMTK_RUBY):
+	CARGO_TARGET_DIR="." cargo build --manifest-path=$(srcdir)/Cargo.toml --release
+
+debug/$(LIBMMTK_RUBY):
+	CARGO_TARGET_DIR="." cargo build --manifest-path=$(srcdir)/Cargo.toml
+
+clean: clean-mmtk
+
+.PHONY: clean-mmtk
+clean-mmtk:
+	-$(Q)$(RM_RF) debug release
+	-$(Q)$(RM) .rustc_info.json

--- a/gc/mmtk/extconf.rb
+++ b/gc/mmtk/extconf.rb
@@ -3,42 +3,18 @@
 require_relative "../extconf_base"
 
 # Statically link `libmmtk_ruby.a`
-$LIBS << " $(MMTK_BUILD)/libmmtk_ruby.#{RbConfig::CONFIG["LIBEXT"]}"
+$LIBS << " $(MMTK_BUILD)/$(LIBMMTK_RUBY)"
 
-create_gc_makefile("mmtk")
+rustsrcs = Dir.glob("src/*.rs", base: __dir__).map {|s| "$(srcdir)/#{s}"}
 
-makefile = File.read("Makefile")
+create_gc_makefile("mmtk") do |makefile|
+  [
+    *makefile,
 
-makefile.prepend("MMTK_BUILD=debug\n")
-
-# Add `libmmtk_ruby.a` as an object file
-makefile.gsub!(/^OBJS = (.*)$/, "OBJS = \\1 $(MMTK_BUILD)/libmmtk_ruby.#{RbConfig::CONFIG["LIBEXT"]}")
-
-# Modify the `all` target to run the `libmmtk_ruby.a` target first
-makefile.gsub!(/^all:\s+(.*)$/, "all: $(MMTK_BUILD)/libmmtk_ruby.#{RbConfig::CONFIG["LIBEXT"]} \\1")
-
-# Add the `libmmtk_ruby.a` target to run `cargo build`
-makefile << <<~MAKEFILE
-  $(MMTK_BUILD)/libmmtk_ruby.#{RbConfig::CONFIG["LIBEXT"]}: $(wildcard $(srcdir)/src/*.rs) $(srcdir)/Cargo.toml $(srcdir)/Cargo.toml
-  	$(Q) case $(MMTK_BUILD) in \
-  		release) \
-  			CARGO_TARGET_DIR="." cargo build --manifest-path=$(srcdir)/Cargo.toml --release \
-  			;; \
-  		debug) \
-  			CARGO_TARGET_DIR="." cargo build --manifest-path=$(srcdir)/Cargo.toml \
-  			;; \
-  		*) \
-  			$(ECHO) Unknown MMTK_BUILD=$(MMTK_BUILD) \
-  			exit 1 \
-  			;; \
-  	esac
-
-  clean: clean-mmtk
-
-  .PHONY: clean-mmtk
-  clean-mmtk:
-  	-$(Q)$(RM_RF) debug release
-  	-$(Q)$(RM) .rustc_info.json
-MAKEFILE
-
-File.open("Makefile", "w") { |file| file.puts(makefile) }
+    <<~MAKEFILE,
+    MMTK_BUILD = debug
+    LIBMMTK_RUBY = libmmtk_ruby.#$LIBEXT
+    RUSTSRCS = #{rustsrcs.join(" \\\n\t   ")}
+    MAKEFILE
+  ]
+end


### PR DESCRIPTION
- Split static recipes to depend file.
- Modify makefile configurations in the block to `create_makefile`.
- Expand rust sources in extconf.rb instead of GNU make extension.

TODO: pass `CARGO_TARGET_DIR` without shell syntax.