### PR TITLE
[Bug #21024] <cstdbool> header has been useless

### DIFF
--- a/include/ruby/internal/stdbool.h
+++ b/include/ruby/internal/stdbool.h
@@ -27,10 +27,6 @@
 
 #elif defined(__cplusplus)
 # /* bool is a keyword in C++. */
-# if defined(HAVE_STDBOOL_H) && (__cplusplus >= 201103L) && (__cplusplus < 201703L)
-#  include <cstdbool>
-# endif
-#
 # ifndef __bool_true_false_are_defined
 #  define __bool_true_false_are_defined
 # endif


### PR DESCRIPTION
And finally deprecated at C++-17.
Patched by jprokop (Jarek Prokop).