### PR TITLE
Expand `$destdir` to enable rdoc plugins for rubygems

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -150,6 +150,7 @@ def parse_args(argv = ARGV)
   end
 
   $destdir ||= $mflags.defined?("DESTDIR")
+  $destdir = File.expand_path($destdir) if $destdir
   if $extout ||= $mflags.defined?("EXTOUT")
     RbConfig.expand($extout)
   end
@@ -686,9 +687,6 @@ module RbInstall
 
   class UnpackedInstaller < Gem::Installer
     def write_cache_file
-    end
-
-    def generate_plugins
     end
 
     def shebang(bin_file_name)


### PR DESCRIPTION
`Gem::InstallerUninstallerUtils#regenerate_plugins_for` assumes that `plugins_dir` is an absolute path as same as the target plugin files.