### PR TITLE
Fix ENV tests on Windows on ARM64

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -280,7 +280,7 @@ class TestProcess < Test::Unit::TestCase
   when /linux/
     MANDATORY_ENVS << 'LD_PRELOAD'
   when /mswin|mingw/
-    MANDATORY_ENVS.concat(%w[HOME USER TMPDIR])
+    MANDATORY_ENVS.concat(%w[HOME USER TMPDIR PROCESSOR_ARCHITECTURE])
   when /darwin/
     MANDATORY_ENVS.concat(ENV.keys.grep(/\A__CF_/))
   end


### PR DESCRIPTION
Due to the x64 emulation of Windows 11 on ARM the environment variable PROCESSOR_ARCHITECTURE is set by the process startup code. It must therefore be excluded from tests.
Otherwise tests fail like so:

```
[30585/32394] TestProcess#test_execopts_unsetenv_others = 0.10 s
 16) Failure:
TestProcess#test_execopts_unsetenv_others [C:/Users/Lars/ruby/test/ruby/test_process.rb:446]:
<""> expected but was
<"PROCESSOR_ARCHITECTURE=ARM64\n">.

[30616/32394] TestProcess#test_execopts_env = 0.16 s
 17) Failure:
TestProcess#test_execopts_env [C:/Users/Lars/ruby/test/ruby/test_process.rb:326]:
<"PATH\n"> expected but was
<"PATH\n" + "PROCESSOR_ARCHITECTURE\n">.
```