### PR TITLE
Retire ubuntu-20.04

### DIFF
--- a/.github/workflows/baseruby.yml
+++ b/.github/workflows/baseruby.yml
@@ -30,7 +30,7 @@ jobs:
   baseruby:
     name: BASERUBY
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     if: >-
       ${{!(false

--- a/.github/workflows/rjit-bindgen.yml
+++ b/.github/workflows/rjit-bindgen.yml
@@ -33,7 +33,7 @@ jobs:
           - task: rjit-bindgen
       fail-fast: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     if: >-
       ${{!(false

--- a/.github/workflows/spec_guards.yml
+++ b/.github/workflows/spec_guards.yml
@@ -24,7 +24,7 @@ jobs:
   rubyspec:
     name: Rubyspec
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     if: >-
       ${{!(false

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -37,8 +37,6 @@ jobs:
             timeout: 50
           - test_task: test-bundled-gems
           - test_task: check
-            os: ubuntu-20.04
-          - test_task: check
             os: ubuntu-24.04
           - test_task: check
             os: ubuntu-24.04-arm

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -48,7 +48,7 @@ jobs:
       BINARYEN_VERSION: 113
       WASMTIME_VERSION: v15.0.0
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     if: >-
       ${{!(false

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -114,6 +114,12 @@ jobs:
           make
           make install
 
+      - name: Download config.guess with wasi version
+        run: |
+          rm tool/config.guess tool/config.sub
+          ruby tool/downloader.rb -d tool -e gnu config.guess config.sub
+        working-directory: src
+
       - name: Run configure
         run: |
           ../src/configure \

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -81,7 +81,7 @@ jobs:
         include:
           - test_task: 'yjit-bindgen'
             hint: 'To fix: use patch in logs'
-            configure: '--with-gcc=clang-12 --enable-yjit=dev'
+            configure: '--with-gcc=clang-14 --enable-yjit=dev'
 
           - test_task: 'check'
             # YJIT should be automatically built in release mode on x86-64 Linux with rustc present

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -82,6 +82,7 @@ jobs:
           - test_task: 'yjit-bindgen'
             hint: 'To fix: use patch in logs'
             configure: '--with-gcc=clang-14 --enable-yjit=dev'
+            libclang_path: '/usr/lib/llvm-14/lib/libclang.so.1'
 
           - test_task: 'check'
             # YJIT should be automatically built in release mode on x86-64 Linux with rustc present
@@ -192,6 +193,7 @@ jobs:
           PRECHECK_BUNDLED_GEMS: 'no'
           SYNTAX_SUGGEST_TIMEOUT: '5'
           YJIT_BINDGEN_DIFF_OPTS: '--exit-code'
+          LIBCLANG_PATH: ${{ matrix.libclang_path }}
         continue-on-error: ${{ matrix.continue-on-test_task || false }}
 
       - name: Show ${{ github.event.pull_request.base.ref }} GitHub URL for yjit-bench comparison

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -25,7 +25,7 @@ jobs:
     name: cargo test
 
     # GitHub Action's image seems to already contain a Rust 1.58.0.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     if: >-
       ${{!(false
@@ -57,7 +57,7 @@ jobs:
     name: cargo clippy
 
     # GitHub Action's image seems to already contain a Rust 1.58.0.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     if: >-
       ${{!(false
@@ -114,7 +114,7 @@ jobs:
       BUNDLE_JOBS: 8 # for yjit-bench
       RUST_BACKTRACE: 1
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     if: >-
       ${{!(false
@@ -172,7 +172,7 @@ jobs:
       - name: Set up Launchable
         uses: ./.github/actions/launchable/setup
         with:
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           test-opts: ${{ matrix.configure }}
           launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
           builddir: build


### PR DESCRIPTION
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

GitHub have a plan to brownout `ubuntu-20.04` in Mar 2025. I don't want to see unintentional failure with that. So, we should remove `ubuntu-20.04` for Ruby 3.5 development.