### PR TITLE
Use `...` for forwarding in Forwardable module

### DIFF
--- a/lib/forwardable.rb
+++ b/lib/forwardable.rb
@@ -209,7 +209,7 @@ module Forwardable
       accessor = "#{accessor}()"
     end
 
-    method_call = ".__send__(:#{method}, *args, &block)"
+    method_call = ".__send__(:#{method}, ...)"
     if _valid_method?(method)
       loc, = caller_locations(2,1)
       pre = "_ ="
@@ -220,7 +220,7 @@ module Forwardable
             ::Kernel.warn #{mesg.dump}"\#{_.class}"'##{method}', uplevel: 1
             _#{method_call}
           else
-            _.#{method}(*args, &block)
+            _.#{method}(...)
           end
         end;
     end
@@ -228,7 +228,7 @@ module Forwardable
     _compile_method("#{<<-"begin;"}\n#{<<-"end;"}", __FILE__, __LINE__+1)
     begin;
       proc do
-        def #{ali}(*args, &block)
+        def #{ali}(...)
           #{pre}
           begin
             #{accessor}


### PR DESCRIPTION
This seems to speed up bechmarks from [Bug #19165](https://bugs.ruby-lang.org/issues/19165)  Before this change, forwardable was 3x slower than a regular method call. After this change it is only 2x slower.

I haven't investigated if this is backwards compatible or not (it probably isn't?)

Before:

```
$ ruby test.rb
ruby 3.5.0dev (2025-01-16T16:20:06Z master d05f6a9b8f) +PRISM [arm64-darwin24]
Warming up --------------------------------------
         simple call     3.459M i/100ms
delegate without splat
                         2.703M i/100ms
 delegate with splat     1.343M i/100ms
delegate with splat with name
                         1.347M i/100ms
delegate with splat and double splat
                         1.301M i/100ms
delegate with triple dots
                         2.109M i/100ms
delegate via forwardable
                         1.125M i/100ms
Calculating -------------------------------------
         simple call     34.395M (± 0.4%) i/s   (29.07 ns/i) -    172.947M in   5.028381s
delegate without splat
                         27.450M (± 1.5%) i/s   (36.43 ns/i) -    137.830M in   5.022175s
 delegate with splat     13.360M (± 0.5%) i/s   (74.85 ns/i) -     67.155M in   5.026767s
delegate with splat with name
                         13.662M (± 0.3%) i/s   (73.20 ns/i) -     68.678M in   5.027114s
delegate with splat and double splat
                         13.717M (± 0.5%) i/s   (72.90 ns/i) -     68.952M in   5.026767s
delegate with triple dots
                         20.958M (± 0.9%) i/s   (47.71 ns/i) -    105.464M in   5.032448s
delegate via forwardable
                         11.273M (± 0.7%) i/s   (88.71 ns/i) -     57.368M in   5.089149s

Comparison:
         simple call: 34394553.5 i/s
delegate without splat: 27450367.6 i/s - 1.25x  slower
delegate with triple dots: 20958426.8 i/s - 1.64x  slower
delegate with splat and double splat: 13717235.5 i/s - 2.51x  slower
delegate with splat with name: 13661705.2 i/s - 2.52x  slower
 delegate with splat: 13359936.0 i/s - 2.57x  slower
delegate via forwardable: 11273246.8 i/s - 3.05x  slower
```

After:

```
$ ruby test.rb
/Users/aaron/.rubies/arm64/ruby-master/lib/ruby/3.5.0+0/forwardable.rb:194: warning: Skipping set of ruby2_keywords flag for foo (method accepts keywords or method does not accept argument splat)
ruby 3.5.0dev (2025-01-16T16:20:06Z master d05f6a9b8f) +PRISM [arm64-darwin24]
Warming up --------------------------------------
         simple call     3.449M i/100ms
delegate without splat
                         2.739M i/100ms
 delegate with splat     1.344M i/100ms
delegate with splat with name
                         1.368M i/100ms
delegate with splat and double splat
                         1.370M i/100ms
delegate with triple dots
                         2.173M i/100ms
delegate via forwardable
                         1.636M i/100ms
Calculating -------------------------------------
         simple call     34.612M (± 0.1%) i/s   (28.89 ns/i) -    175.897M in   5.082036s
delegate without splat
                         27.335M (± 0.6%) i/s   (36.58 ns/i) -    136.963M in   5.010710s
 delegate with splat     13.466M (± 0.3%) i/s   (74.26 ns/i) -     68.551M in   5.090672s
delegate with splat with name
                         13.623M (± 0.6%) i/s   (73.41 ns/i) -     68.404M in   5.021518s
delegate with splat and double splat
                         13.665M (± 0.6%) i/s   (73.18 ns/i) -     68.510M in   5.013574s
delegate with triple dots
                         21.674M (± 1.3%) i/s   (46.14 ns/i) -    108.645M in   5.013558s
delegate via forwardable
                         16.876M (± 0.3%) i/s   (59.26 ns/i) -     85.072M in   5.041133s

Comparison:
         simple call: 34611564.1 i/s
delegate without splat: 27334854.9 i/s - 1.27x  slower
delegate with triple dots: 21674074.8 i/s - 1.60x  slower
delegate via forwardable: 16875781.8 i/s - 2.05x  slower
delegate with splat and double splat: 13665385.4 i/s - 2.53x  slower
delegate with splat with name: 13622624.9 i/s - 2.54x  slower
 delegate with splat: 13466096.0 i/s - 2.57x  slower
```