### PR TITLE
Use no-inline version `rb_current_ec` on Arm64

### DIFF
--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -133,8 +133,8 @@ struct rb_thread_sched {
 #ifdef RB_THREAD_LOCAL_SPECIFIER
   NOINLINE(void rb_current_ec_set(struct rb_execution_context_struct *));
 
-  # ifdef __APPLE__
-    // on Darwin, TLS can not be accessed across .so
+  # if defined(__arm64__) || defined(__aarch64__)
+    // on Arm64, TLS can not be accessed across .so
     NOINLINE(struct rb_execution_context_struct *rb_current_ec(void));
   # else
     RUBY_EXTERN RB_THREAD_LOCAL_SPECIFIER struct rb_execution_context_struct *ruby_current_ec;

--- a/vm.c
+++ b/vm.c
@@ -571,7 +571,7 @@ rb_current_ec_set(rb_execution_context_t *ec)
 }
 
 
-#ifdef __APPLE__
+#if defined(__arm64__) || defined(__aarch64__)
 rb_execution_context_t *
 rb_current_ec(void)
 {

--- a/vm_core.h
+++ b/vm_core.h
@@ -1977,7 +1977,7 @@ static inline rb_execution_context_t *
 rb_current_execution_context(bool expect_ec)
 {
 #ifdef RB_THREAD_LOCAL_SPECIFIER
-  #ifdef __APPLE__
+  #if defined(__arm64__) || defined(__aarch64__)
     rb_execution_context_t *ec = rb_current_ec();
   #else
     rb_execution_context_t *ec = ruby_current_ec;


### PR DESCRIPTION
The TLS across .so issue seems related to Arm64, but not Darwin.