### PR TITLE
Restore rbs schema test

### DIFF
--- a/ext/json/parser/parser.c
+++ b/ext/json/parser/parser.c
@@ -476,7 +476,7 @@ static const bool whitespace[256] = {
     ['/'] = 1,
 };
 
-static void
+static bool
 json_eat_comments(JSON_ParserState *state)
 {
     if (state->cursor + 1 < state->end) {
@@ -508,9 +508,10 @@ json_eat_comments(JSON_ParserState *state)
                 break;
             }
             default:
-                return;
+                return false;
         }
     }
+    return true;
 }
 
 static inline void
@@ -520,7 +521,9 @@ json_eat_whitespace(JSON_ParserState *state)
         if (RB_LIKELY(*state->cursor != '/')) {
             state->cursor++;
         } else {
-            json_eat_comments(state);
+            if (!json_eat_comments(state)) {
+                return;
+            }
         }
     }
 }

--- a/test/json/json_parser_test.rb
+++ b/test/json/json_parser_test.rb
@@ -629,6 +629,13 @@ class JSONParserTest < Test::Unit::TestCase
     end
   end
 
+  def test_parse_leading_slash
+    # ref: https://github.com/ruby/ruby/pull/12598
+    assert_raise(JSON::ParserError) do
+      JSON.parse("/foo/bar")
+    end
+  end
+
   private
 
   def string_deduplication_available?

--- a/tool/rbs_skip_tests
+++ b/tool/rbs_skip_tests
@@ -44,8 +44,5 @@ test_compile(RegexpSingletonTest)
 test_linear_time?(RegexpSingletonTest)
 test_new(RegexpSingletonTest)
 
-# https://github.com/ruby/ruby/pull/12598#issuecomment-2601479034
-# The handrolled parser of JSON is not working with `json-schema` gem
-RBS::SchemaTest
-
 ## Failed tests caused by unreleased version of Ruby
+


### PR DESCRIPTION
Now that the root cause has been fixed, we can resume `BS::SchemaTest` testing.

Followup: https://github.com/ruby/ruby/pull/12598