### PR TITLE
Reject numbered parameters from `Binding#local_variables`

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -4391,4 +4391,6 @@ Init_ISeq(void)
 
     rb_undef_method(CLASS_OF(rb_cISeq), "translate");
     rb_undef_method(CLASS_OF(rb_cISeq), "load_iseq");
+
+    rb_it_id = rb_make_internal_id();
 }

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6331,7 +6331,7 @@ pm_compile_scope_node(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_nod
     }
 
     if (scope_node->parameters != NULL && PM_NODE_TYPE_P(scope_node->parameters, PM_IT_PARAMETERS_NODE)) {
-        ID local = rb_make_temporary_id(local_index);
+        ID local = rb_it_id;
         local_table_for_iseq->ids[local_index++] = local;
     }
 

--- a/proc.c
+++ b/proc.c
@@ -497,6 +497,12 @@ bind_local_variables(VALUE bindval)
     return rb_vm_env_local_variables(env);
 }
 
+static int
+numparam_id_p(ID id)
+{
+    return (tNUMPARAM_1 << ID_SCOPE_SHIFT) <= id && id < ((tNUMPARAM_1 + 10) << ID_SCOPE_SHIFT);
+}
+
 /*
  *  call-seq:
  *     binding.local_variable_get(symbol) -> obj
@@ -523,6 +529,10 @@ bind_local_variable_get(VALUE bindval, VALUE sym)
     const rb_env_t *env;
 
     if (!lid) goto undefined;
+    if (numparam_id_p(lid)) {
+        rb_name_err_raise("numbered parameter '%1$s' is not a local variable",
+                          bindval, ID2SYM(lid));
+    }
 
     GetBindingPtr(bindval, bind);
 
@@ -572,6 +582,10 @@ bind_local_variable_set(VALUE bindval, VALUE sym, VALUE val)
     const rb_env_t *env;
 
     if (!lid) lid = rb_intern_str(sym);
+    if (numparam_id_p(lid)) {
+        rb_name_err_raise("numbered parameter '%1$s' is not a local variable",
+                          bindval, ID2SYM(lid));
+    }
 
     GetBindingPtr(bindval, bind);
     env = VM_ENV_ENVVAL_PTR(vm_block_ep(&bind->block));

--- a/proc.c
+++ b/proc.c
@@ -24,6 +24,8 @@
 #include "vm_core.h"
 #include "yjit.h"
 
+ID rb_it_id;
+
 const rb_cref_t *rb_vm_cref_in_context(VALUE self, VALUE cbase);
 
 struct METHOD {
@@ -724,6 +726,50 @@ bind_numbered_parameter_defined_p(VALUE bindval, VALUE sym)
     GetBindingPtr(bindval, bind);
     env = VM_ENV_ENVVAL_PTR(vm_block_ep(&bind->block));
     return RBOOL(get_numbered_parameter_ptr(env, lid));
+}
+
+/*
+ *  call-seq:
+ *     binding.it_get -> obj
+ *
+ *  TODO
+ */
+static VALUE
+bind_it_get(VALUE bindval)
+{
+    const rb_binding_t *bind;
+    const VALUE *ptr;
+    const rb_env_t *env;
+
+    GetBindingPtr(bindval, bind);
+
+    env = VM_ENV_ENVVAL_PTR(vm_block_ep(&bind->block));
+    if ((ptr = get_numbered_parameter_ptr(env, rb_it_id)) != NULL) {
+        return *ptr;
+    }
+
+    VALUE sym = ID2SYM(rb_it_id);
+    rb_name_err_raise("'it' is not defined",
+                      bindval, sym);
+    UNREACHABLE_RETURN(Qundef);
+}
+
+/*
+ *  call-seq:
+ *     binding.it_defined?(symbol) -> obj
+ *
+ *  TODO
+ */
+
+static VALUE
+bind_it_defined_p(VALUE bindval)
+{
+    const rb_binding_t *bind;
+    const rb_env_t *env;
+
+    GetBindingPtr(bindval, bind);
+    env = VM_ENV_ENVVAL_PTR(vm_block_ep(&bind->block));
+    return RBOOL(get_numbered_parameter_ptr(env, rb_it_id));
 }
 
 /*
@@ -4648,6 +4694,8 @@ Init_Binding(void)
     rb_define_method(rb_cBinding, "numbered_parameters", bind_numbered_parameters, 0);
     rb_define_method(rb_cBinding, "numbered_parameter_get", bind_numbered_parameter_get, 1);
     rb_define_method(rb_cBinding, "numbered_parameter_defined?", bind_numbered_parameter_defined_p, 1);
+    rb_define_method(rb_cBinding, "it_get", bind_it_get, 0);
+    rb_define_method(rb_cBinding, "it_defined?", bind_it_defined_p, 0);
     rb_define_method(rb_cBinding, "receiver", bind_receiver, 0);
     rb_define_method(rb_cBinding, "source_location", bind_location, 0);
     rb_define_global_function("binding", rb_f_binding, 0);

--- a/spec/ruby/language/numbered_parameters_spec.rb
+++ b/spec/ruby/language/numbered_parameters_spec.rb
@@ -90,9 +90,18 @@ describe "Numbered parameters" do
     proc { _2 }.parameters.should == [[:opt, :_1], [:opt, :_2]]
   end
 
-  it "affects binding local variables" do
-    -> { _1; binding.local_variables }.call("a").should == [:_1]
-    -> { _2; binding.local_variables }.call("a", "b").should == [:_1, :_2]
+  ruby_version_is "".."3.4" do
+    it "affects binding local variables" do
+      -> { _1; binding.local_variables }.call("a").should == [:_1]
+      -> { _2; binding.local_variables }.call("a", "b").should == [:_1, :_2]
+    end
+  end
+
+  ruby_version_is "3.5" do
+    it "does not affect binding local variables" do
+      -> { _1; binding.local_variables }.call("a").should == []
+      -> { _2; binding.local_variables }.call("a", "b").should == []
+    end
   end
 
   it "does not work in methods" do

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -1669,6 +1669,44 @@ class TestProc < Test::Unit::TestCase
     assert_equal(false, b.local_variable_defined?(:b))
   end
 
+  def test_numbered_parameters
+    "foo".tap do
+      _9
+      assert_equal([], binding.local_variables)
+      assert_equal([:_1, :_2, :_3, :_4, :_5, :_6, :_7, :_8, :_9], binding.numbered_parameters)
+      assert_equal("foo", binding.numbered_parameter_get(:_1))
+      assert_equal(true, binding.numbered_parameter_defined?(:_1))
+      "bar".tap do
+        assert_equal([], binding.local_variables)
+        assert_equal([], binding.numbered_parameters)
+        assert_raise(NameError) { binding.numbered_parameter_get(:_1) }
+        assert_equal(false, binding.numbered_parameter_defined?(:_1))
+      end
+      assert_equal([], binding.local_variables)
+      assert_equal([:_1, :_2, :_3, :_4, :_5, :_6, :_7, :_8, :_9], binding.numbered_parameters)
+      assert_equal("foo", binding.numbered_parameter_get(:_1))
+      assert_equal(true, binding.numbered_parameter_defined?(:_1))
+    end
+
+    "foo".tap do
+      assert_equal([], binding.local_variables)
+      assert_equal([], binding.numbered_parameters)
+      assert_raise(NameError) { binding.numbered_parameter_get(:_1) }
+      assert_equal(false, binding.numbered_parameter_defined?(:_1))
+      "bar".tap do
+        _9
+        assert_equal([], binding.local_variables)
+        assert_equal([:_1, :_2, :_3, :_4, :_5, :_6, :_7, :_8, :_9], binding.numbered_parameters)
+        assert_equal("bar", binding.numbered_parameter_get(:_1))
+        assert_equal(true, binding.numbered_parameter_defined?(:_1))
+      end
+      assert_equal([], binding.local_variables)
+      assert_equal([], binding.numbered_parameters)
+      assert_raise(NameError) { binding.numbered_parameter_get(:_1) }
+      assert_equal(false, binding.numbered_parameter_defined?(:_1))
+    end
+  end
+
   def test_binding_receiver
     feature8779 = '[ruby-dev:47613] [Feature #8779]'
 

--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -1707,6 +1707,47 @@ class TestProc < Test::Unit::TestCase
     end
   end
 
+  def test_it
+    "foo".tap do
+      it
+      assert_equal([], binding.local_variables)
+      assert_equal("foo", binding.it_get)
+      assert_equal(true, binding.it_defined?)
+      "bar".tap do
+        assert_equal([], binding.local_variables)
+        assert_raise(NameError) { binding.it_get }
+        assert_equal(false, binding.it_defined?)
+      end
+      assert_equal([], binding.local_variables)
+      assert_equal("foo", binding.it_get)
+      assert_equal(true, binding.it_defined?)
+      "bar".tap do
+        it
+        assert_equal([], binding.local_variables)
+        assert_equal("bar", binding.it_get)
+        assert_equal(true, binding.it_defined?)
+      end
+      assert_equal([], binding.local_variables)
+      assert_equal("foo", binding.it_get)
+      assert_equal(true, binding.it_defined?)
+    end
+
+    "foo".tap do
+      assert_equal([], binding.local_variables)
+      assert_raise(NameError) { binding.it_get }
+      assert_equal(false, binding.it_defined?)
+      "bar".tap do
+        it
+        assert_equal([], binding.local_variables)
+        assert_equal("bar", binding.it_get)
+        assert_equal(true, binding.it_defined?)
+      end
+      assert_equal([], binding.local_variables)
+      assert_raise(NameError) { binding.it_get }
+      assert_equal(false, binding.it_defined?)
+    end
+  end
+
   def test_binding_receiver
     feature8779 = '[ruby-dev:47613] [Feature #8779]'
 

--- a/vm.c
+++ b/vm.c
@@ -1121,6 +1121,21 @@ rb_vm_env_local_variables(const rb_env_t *env)
 }
 
 VALUE
+rb_vm_env_numbered_parameters(const rb_env_t *env)
+{
+    struct local_var_list vars;
+    local_var_list_init(&vars);
+    // if (VM_ENV_FLAGS(env->ep, VM_ENV_FLAG_ISOLATED)) break; // TODO: is this needed?
+    const rb_iseq_t *iseq = env->iseq;
+    unsigned int i;
+    if (!iseq) return 0;
+    for (i = 0; i < ISEQ_BODY(iseq)->local_table_size; i++) {
+        numparam_list_add(&vars, ISEQ_BODY(iseq)->local_table[i]);
+    }
+    return local_var_list_finish(&vars);
+}
+
+VALUE
 rb_iseq_local_variables(const rb_iseq_t *iseq)
 {
     struct local_var_list vars;

--- a/vm_core.h
+++ b/vm_core.h
@@ -2248,4 +2248,6 @@ RUBY_EXTERN VALUE rb_eRactorIsolationError;
 
 RUBY_SYMBOL_EXPORT_END
 
+extern ID rb_it_id;
+
 #endif /* RUBY_VM_CORE_H */

--- a/vm_core.h
+++ b/vm_core.h
@@ -1860,6 +1860,7 @@ rb_vm_make_lambda(const rb_execution_context_t *ec, const struct rb_captured_blo
 
 VALUE rb_vm_make_binding(const rb_execution_context_t *ec, const rb_control_frame_t *src_cfp);
 VALUE rb_vm_env_local_variables(const rb_env_t *env);
+VALUE rb_vm_env_numbered_parameters(const rb_env_t *env);
 const rb_env_t *rb_vm_env_prev_env(const rb_env_t *env);
 const VALUE *rb_binding_add_dynavars(VALUE bindval, rb_binding_t *bind, int dyncount, const ID *dynvars);
 void rb_vm_inc_const_missing_count(void);

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -2664,8 +2664,26 @@ local_var_list_update(st_data_t *key, st_data_t *value, st_data_t arg, int exist
 static void
 local_var_list_add(const struct local_var_list *vars, ID lid)
 {
-    if (lid && rb_is_local_id(lid)) {
-        /* should skip temporary variable */
+    /* should skip temporary variable */
+    if (!lid) return;
+    if (!rb_is_local_id(lid)) return;
+
+    /* should skip numbered parameters as well */
+    if ((tNUMPARAM_1 << ID_SCOPE_SHIFT) <= lid && lid < ((tNUMPARAM_1 + 10) << ID_SCOPE_SHIFT)) return;
+
+    st_data_t idx = 0;	/* tbl->num_entries */
+    rb_hash_stlike_update(vars->tbl, ID2SYM(lid), local_var_list_update, idx);
+}
+
+static void
+numparam_list_add(const struct local_var_list *vars, ID lid)
+{
+    /* should skip temporary variable */
+    if (!lid) return;
+    if (!rb_is_local_id(lid)) return;
+
+    /* should skip anything but numbered parameters */
+    if ((tNUMPARAM_1 << ID_SCOPE_SHIFT) <= lid && lid < ((tNUMPARAM_1 + 10) << ID_SCOPE_SHIFT)) {
         st_data_t idx = 0;	/* tbl->num_entries */
         rb_hash_stlike_update(vars->tbl, ID2SYM(lid), local_var_list_update, idx);
     }


### PR DESCRIPTION
Also, `Binding#local_variable_get` and `#local_variable_set` reject numbered parameters too.

This PR includes `Binding#numbered_parameters`, `Binding#numbered_parameter_get`, `Binding#numbered_parameter_defined?`, `Binding#it_get`, and `Binding#it_defined?` just for a proof-of-concept. But I am not sure that they deserve or not.