### PR TITLE
Remove rb_obj_as_string for Parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -374,7 +374,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .rb_sprintf = rb_sprintf,
     .rstring_ptr = RSTRING_PTR,
     .rstring_len = RSTRING_LEN,
-    .obj_as_string = rb_obj_as_string,
 
     .int2num = rb_int2num_inline,
 

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1260,7 +1260,6 @@ typedef struct rb_parser_config_struct {
     VALUE (*rb_sprintf)(const char *format, ...);
     char *(*rstring_ptr)(VALUE str);
     long (*rstring_len)(VALUE str);
-    VALUE (*obj_as_string)(VALUE);
 
     /* Numeric */
     VALUE (*int2num)(int v);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -124,7 +124,6 @@
 #define RSTRING_PTR                       p->config->rstring_ptr
 #undef RSTRING_LEN
 #define RSTRING_LEN                       p->config->rstring_len
-#define rb_obj_as_string                  p->config->obj_as_string
 
 #undef INT2NUM
 #define INT2NUM             p->config->int2num


### PR DESCRIPTION
Ruby Parser not used rb_obj_as_string.
And obj_as_string property can be removed from Universal Parser.