### PR TITLE
Relax expectations of errors from `getgrnam`

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1693,12 +1693,7 @@ class TestProcess < Test::Unit::TestCase
       if g = Etc.getgrgid(Process.gid)
         assert_equal(Process.gid, Process::GID.from_name(g.name), g.name)
       end
-      expected_excs = [ArgumentError]
-      expected_excs << Errno::ENOENT if defined?(Errno::ENOENT)
-      expected_excs << Errno::ESRCH if defined?(Errno::ESRCH) # WSL 2 actually raises Errno::ESRCH
-      expected_excs << Errno::EBADF if defined?(Errno::EBADF)
-      expected_excs << Errno::EPERM if defined?(Errno::EPERM)
-      exc = assert_raise(*expected_excs) do
+      exc = assert_raise(ArgumentError, SystemCallError) do
         Process::GID.from_name("\u{4e0d 5b58 5728}") # fu son zai ("absent" in Kanji)
       end
       assert_match(/\u{4e0d 5b58 5728}/, exc.message) if exc.is_a?(ArgumentError)


### PR DESCRIPTION
The list of errors cited in 58bc97628c14933b73f13e0856d1a56e70e8b0e4 is not exhaustive and other errors may be raised by `getgrnam`.
Additionally, these errors are system dependent and may not be listed on all platforms.