### PR TITLE
[DOC] Add a mention to git 2.32 in the building ruby documentation:

### DIFF
--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -20,6 +20,9 @@
     * ruby - 3.0 or later
         * We can upgrade this version to system ruby version of the latest
           Ubuntu LTS.
+    * git - 2.32 or later
+        * Anterior versions may work; 2.32 or later will prevent build
+          errors in case your system `.gitconfig` uses `$HOME` paths.
 
 2. Install optional, recommended dependencies:
 


### PR DESCRIPTION
Hello 👋 !  

Not sure if there is interest in tweaking the requirement recommendation for building Ruby but
the project now makes use of a feature added in git 2.32 (`GIT_CONFIG_SYSTEM` and `GIT_CONFIG_GLOBAL`). 

I had issues building Ruby as I was using git 2.30.
The error was:

> file2lastrev.rb: git rev-parse failed error: could not expand
> include path '~/.gitcinclude'

The default system git config includes paths making use of `$HOME`, but that env variable gets removed when building: https://github.com/ruby/ruby/blob/7070b1b1968f31f999636b42a1af872458cd5a81/tool/lib/vcs.rb#L546-L547

It works with git `>= 2.32` thanks to the `GIT_CONFIG_SYSTEM` feature which gets set to a Null IO in order to override the system gitconfig. https://github.com/ruby/ruby/blob/7070b1b1968f31f999636b42a1af872458cd5a81/tool/lib/vcs.rb#L549

I thought this could save other users from having to debug the problem.

Thanks!