### PR TITLE
Fix memory leak in rb_gc_vm_weak_table_foreach

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -7555,6 +7555,7 @@ gc.$(OBJEXT): {$(VPATH)}thread.h
 gc.$(OBJEXT): {$(VPATH)}thread_$(THREAD_MODEL).h
 gc.$(OBJEXT): {$(VPATH)}thread_native.h
 gc.$(OBJEXT): {$(VPATH)}util.h
+gc.$(OBJEXT): {$(VPATH)}variable.h
 gc.$(OBJEXT): {$(VPATH)}vm.h
 gc.$(OBJEXT): {$(VPATH)}vm_callinfo.h
 gc.$(OBJEXT): {$(VPATH)}vm_core.h


### PR DESCRIPTION
When deleting from the generic ivar table, we need to free the gen_ivtbl otherwise we will have a memory leak.