### PR TITLE
Allow parsing URIs without throwing exceptions

### DIFF
--- a/lib/uri/common.rb
+++ b/lib/uri/common.rb
@@ -204,8 +204,8 @@ module URI
   # It's recommended to first ::escape string +uri+
   # if it may contain invalid URI characters.
   #
-  def self.parse(uri)
-    DEFAULT_PARSER.parse(uri)
+  def self.parse(uri, exception: true)
+    DEFAULT_PARSER.parse(uri, exception:)
   end
 
   # Merges the given URI strings +str+

--- a/lib/uri/rfc2396_parser.rb
+++ b/lib/uri/rfc2396_parser.rb
@@ -117,7 +117,7 @@ module URI
     attr_reader :regexp
 
     # Returns a split URI against +regexp[:ABS_URI]+.
-    def split(uri)
+    def split(uri, exception: true)
       case uri
       when ''
         # null uri
@@ -173,6 +173,8 @@ module URI
         # server        = [ [ userinfo "@" ] hostport ]
 
       else
+        return unless exception
+
         raise InvalidURIError, "bad URI (is not URI?): #{uri}"
       end
 
@@ -206,8 +208,11 @@ module URI
     #   p.parse("ldap://ldap.example.com/dc=example?user=john")
     #   #=> #<URI::LDAP ldap://ldap.example.com/dc=example?user=john>
     #
-    def parse(uri)
-      URI.for(*self.split(uri), self)
+    def parse(uri, exception: true)
+      scheme = self.split(uri, exception:)
+      return if scheme.nil?
+
+      URI.for(*scheme, self)
     end
 
     #

--- a/lib/uri/rfc3986_parser.rb
+++ b/lib/uri/rfc3986_parser.rb
@@ -74,7 +74,7 @@ module URI
       @regexp = default_regexp.each_value(&:freeze).freeze
     end
 
-    def split(uri) #:nodoc:
+    def split(uri, exception: true) #:nodoc:
       begin
         uri = uri.to_str
       rescue NoMethodError
@@ -127,12 +127,17 @@ module URI
           m["fragment"]
         ]
       else
+        return unless exception
+
         raise InvalidURIError, "bad URI (is not URI?): #{uri.inspect}"
       end
     end
 
-    def parse(uri) # :nodoc:
-      URI.for(*self.split(uri), self)
+    def parse(uri, exception: true) # :nodoc:
+      scheme = self.split(uri, exception:)
+      return if scheme.nil?
+
+      URI.for(*scheme, self)
     end
 
     def join(*uris) # :nodoc:

--- a/spec/ruby/library/uri/shared/parse.rb
+++ b/spec/ruby/library/uri/shared/parse.rb
@@ -3,6 +3,22 @@ describe :uri_parse, shared: true do
     @object.parse("http://www.example.com/").should be_kind_of(URI::HTTP)
   end
 
+  it "returns nil for an invalid URI when exception is false" do
+    @object.parse("https://www.example.com/\[\]", exception: false).should be_nil
+  end
+
+  it "raises an error for an invalid URI when exception is true" do
+    -> {
+      @object.parse("https://www.example.com/\[\]", exception: true)
+    }.should raise_error(URI::InvalidURIError)
+  end
+
+  it "raises an error for an invalid URI when exception is not provided" do
+    -> {
+      @object.parse("https://www.example.com/\[\]")
+    }.should raise_error(URI::InvalidURIError)
+  end
+
   it "populates the components of a parsed URI::HTTP, setting the port to 80 by default" do
     # general case
     URISpec.components(@object.parse("http://user:pass@example.com/path/?query=val&q2=val2#fragment")).should == {


### PR DESCRIPTION
Similar to what `Integer(value, exception: false)` does but for `URI.parse(value, exception: false)`. The change is implemented for the default parser (RFC3986) and also RFC2396.

The goal is to allow parsing invalid/user provided input without having to have control flow via exceptions or by having to wrap URI.parse in a method that catches the exception per project (or as a library).

This change can be seen via
`~/.rubies/ruby-master/bin/ruby -r 'uri' -e
'URI.parse("https://example.com/\[\]", exception: false)'` and `~/.rubies/ruby-master/bin/ruby -r 'uri' -e
'URI.parse("https://example.com/\[\]")'` respectively (or with `exception: true`) and is also covered by specs.

**Question/Failing CI**
The tests for checking the exception behavior fail in the Rubyspec for older versions
since the change is only available on `master` but all previous invocations will work
the same and as expected.

What is the correct way of handling this?
Hopefully not to not write tests for it