### PR TITLE
[Feature #21086] Declare rb_profile_frames() family as async-signal-safe

### DIFF
--- a/include/ruby/debug.h
+++ b/include/ruby/debug.h
@@ -36,6 +36,8 @@ RBIMPL_ATTR_NONNULL((3))
  * issue a very  limited set of operations listed below.   Don't call arbitrary
  * ruby methods.
  *
+ * This function is async-signal-safe.
+ *
  * @param[in]   start  Start position (0 means the topmost).
  * @param[in]   limit  Number objects of `buff`.
  * @param[out]  buff   Return buffer.
@@ -58,6 +60,8 @@ int rb_profile_frames(int start, int limit, VALUE *buff, int *lines);
  * Arguments and return values are the same with rb_profile_frames() with the
  * exception of the first argument _thread_, which accepts the Thread to be
  * profiled/queried.
+ *
+ * This function is async-signal-safe.
  *
  * @param[in]   thread The Ruby Thread to be profiled.
  * @param[in]   start  Start position (0 means the topmost).

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1772,6 +1772,7 @@ thread_profile_frames(rb_execution_context_t *ec, int start, int limit, VALUE *b
     return i;
 }
 
+/* async-signal-safe */
 int
 rb_profile_frames(int start, int limit, VALUE *buff, int *lines)
 {
@@ -1786,6 +1787,7 @@ rb_profile_frames(int start, int limit, VALUE *buff, int *lines)
     return thread_profile_frames(ec, start, limit, buff, lines);
 }
 
+/* async-signal-safe */
 int
 rb_profile_thread_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines)
 {


### PR DESCRIPTION
Since 64fef3b870a8ed8147654531aef4c065d8a730c6, it should be safe to call rb_profile_frames() and rb_profile_thread_frames() in a signal handler.