### PR TITLE
Fix SystemCallError#message on windows

### DIFF
--- a/spec/ruby/core/exception/system_call_error_spec.rb
+++ b/spec/ruby/core/exception/system_call_error_spec.rb
@@ -25,7 +25,7 @@ describe "SystemCallError.new" do
     @example_errno_class = Errno::EINVAL
     @last_known_errno = Errno.constants.size - 1
     @unknown_errno = Errno.constants.size
-    @some_human_readable = "[[:graph:]]+"
+    @some_human_readable = /[[:graph:]]+/
   end
 
   it "requires at least one argument" do
@@ -97,11 +97,11 @@ describe "SystemCallError.new" do
   end
 
   it "sets an 'unknown error' message when an unknown error number" do
-    SystemCallError.new(-1).message.should =~ Regexp.new(@some_human_readable)
+    SystemCallError.new(-1).message.should =~ @some_human_readable
   end
 
   it "adds a custom error message to an 'unknown error' message when an unknown error number and a custom message specified" do
-    SystemCallError.new("custom message", -1).message.should =~ Regexp.new("#{@some_human_readable}.* - custom message")
+    SystemCallError.new("custom message", -1).message.should =~ /#{@some_human_readable}.* - custom message/
   end
 
   it "converts to Integer if errno is a Complex convertible to Integer" do
@@ -142,7 +142,7 @@ describe "SystemCallError#message" do
       SystemCallError.new(2**28).message.should =~ /Error .*occurred/i
     end
     platform_is_not :aix do
-      SystemCallError.new(2**28).message.should =~ Regexp.new(@some_human_readable)
+      SystemCallError.new(2**28).message.should =~ @some_human_readable
     end
   end
 

--- a/spec/ruby/core/exception/system_call_error_spec.rb
+++ b/spec/ruby/core/exception/system_call_error_spec.rb
@@ -25,6 +25,7 @@ describe "SystemCallError.new" do
     @example_errno_class = Errno::EINVAL
     @last_known_errno = Errno.constants.size - 1
     @unknown_errno = Errno.constants.size
+    @some_human_readable = "[[:graph:]]+"
   end
 
   it "requires at least one argument" do
@@ -96,23 +97,11 @@ describe "SystemCallError.new" do
   end
 
   it "sets an 'unknown error' message when an unknown error number" do
-    platform_is_not :windows do
-      SystemCallError.new(-1).message.should =~ /Unknown error(:)? -1/
-    end
-
-    platform_is :windows do
-      SystemCallError.new(-1).message.should == "The operation completed successfully."
-    end
+    SystemCallError.new(-1).message.should =~ Regexp.new(@some_human_readable)
   end
 
   it "adds a custom error message to an 'unknown error' message when an unknown error number and a custom message specified" do
-    platform_is_not :windows do
-      SystemCallError.new("custom message", -1).message.should =~ /Unknown error(:)? -1 - custom message/
-    end
-
-    platform_is :windows do
-      SystemCallError.new("custom message", -1).message.should == "The operation completed successfully. - custom message"
-    end
+    SystemCallError.new("custom message", -1).message.should =~ Regexp.new("#{@some_human_readable}.* - custom message")
   end
 
   it "converts to Integer if errno is a Complex convertible to Integer" do
@@ -153,7 +142,7 @@ describe "SystemCallError#message" do
       SystemCallError.new(2**28).message.should =~ /Error .*occurred/i
     end
     platform_is_not :aix do
-      SystemCallError.new(2**28).message.should =~ /Unknown error/i
+      SystemCallError.new(2**28).message.should =~ Regexp.new(@some_human_readable)
     end
   end
 

--- a/spec/ruby/core/exception/system_call_error_spec.rb
+++ b/spec/ruby/core/exception/system_call_error_spec.rb
@@ -138,12 +138,7 @@ end
 
 describe "SystemCallError#message" do
   it "returns the default message when no message is given" do
-    platform_is :aix do
-      SystemCallError.new(2**28).message.should =~ /Error .*occurred/i
-    end
-    platform_is_not :aix do
-      SystemCallError.new(2**28).message.should =~ @some_human_readable
-    end
+    SystemCallError.new(2**28).message.should =~ @some_human_readable
   end
 
   it "returns the message given as an argument to new" do

--- a/spec/ruby/optional/capi/kernel_spec.rb
+++ b/spec/ruby/optional/capi/kernel_spec.rb
@@ -196,14 +196,8 @@ describe "C-API Kernel function" do
       end.should raise_error(Errno::EINVAL, "Invalid argument")
     end
 
-    it "uses an 'unknown error' message when errno is unknown" do
-      platform_is_not :windows do
-        -> { @s.rb_syserr_fail(-10, nil) }.should raise_error(SystemCallError, /Unknown error(:)? -10/)
-      end
-
-      platform_is :windows do
-        -> { @s.rb_syserr_fail(-1, nil) }.should raise_error(SystemCallError, "The operation completed successfully.")
-      end
+    it "uses some kind of string as message when errno is unknown" do
+      -> { @s.rb_syserr_fail(-10, nil) }.should raise_error(SystemCallError, /[[:graph:]]+/)
     end
   end
 
@@ -220,14 +214,8 @@ describe "C-API Kernel function" do
       end.should raise_error(Errno::EINVAL, "Invalid argument")
     end
 
-    it "uses an 'unknown error' message when errno is unknown" do
-      platform_is_not :windows do
-        -> { @s.rb_syserr_fail_str(-10, nil) }.should raise_error(SystemCallError, /Unknown error(:)? -10/)
-      end
-
-      platform_is :windows do
-        -> { @s.rb_syserr_fail_str(-1, nil) }.should raise_error(SystemCallError, "The operation completed successfully.")
-      end
+    it "uses some kind of string as message when errno is unknown" do
+      -> { @s.rb_syserr_fail_str(-10, nil) }.should raise_error(SystemCallError, /[[:graph:]]+/)
     end
   end
 

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -2834,11 +2834,11 @@ rb_w32_strerror(int e)
     DWORD source = 0;
     char *p;
 
-    if (e < 0 || e > sys_nerr) {
-        if (e < 0)
-            e = GetLastError();
+    if (e < 0)
+        strlcpy(buffer, "Unknown Error", sizeof(buffer));
+    else if (e > sys_nerr) {
 #if WSAEWOULDBLOCK != EWOULDBLOCK
-        else if (e >= EADDRINUSE && e <= EWOULDBLOCK) {
+        if (e >= EADDRINUSE && e <= EWOULDBLOCK) {
             static int s = -1;
             int i;
             if (s < 0)


### PR DESCRIPTION
SystemCallError#message was unpredictable if errno is out of range on windows.
Result of SystemCallError.new(-1).message changed from "The operation completed successfully." to "Unknown Error".

Also change specs that stands on the wrong assumption.
SystemCallError.new(-1).message returns
on Ubuntu "Unknown error -1" (glibc)
on Alpine "No error information" (musl libc)
on Windows "Unknown Error" (ruby/win32/win32.c(this patch), ucrt does same)
It depends on the environment.
I didn't want to make too much assumption, so I chose to predict only that it would contain readable characters.

[Bug#21083](https://bugs.ruby-lang.org/issues/21083)