### PR TITLE
Fix "Relax expectations of errors from `getgrnam`"

### DIFF
--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -1693,7 +1693,7 @@ class TestProcess < Test::Unit::TestCase
       if g = Etc.getgrgid(Process.gid)
         assert_equal(Process.gid, Process::GID.from_name(g.name), g.name)
       end
-      exc = assert_raise(ArgumentError, SystemCallError) do
+      exc = assert_raise_kind_of(ArgumentError, SystemCallError) do
         Process::GID.from_name("\u{4e0d 5b58 5728}") # fu son zai ("absent" in Kanji)
       end
       assert_match(/\u{4e0d 5b58 5728}/, exc.message) if exc.is_a?(ArgumentError)


### PR DESCRIPTION
Use `assert_raise_kind_of` instead of `assert_raise`, that rejects sub classes of the given exceptions.