### PR TITLE
Improve docs of -I ruby option

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -332,8 +332,8 @@ usage(const char *name, int help, int highlight, int columns)
         M("-Fpattern",	   "",			   "Set input field separator ($;); used with -a."),
         M("-i[extension]", "",			   "Set ARGF in-place mode;\n"
             "create backup files with given extension."),
-        M("-Idirpath",     "",			   "Add specified directory to load paths ($LOAD_PATH);\n"
-            "multiple -I allowed."),
+        M("-Idirpath",     "",			   "Prepend specified directory to load paths ($LOAD_PATH);\n"
+            "relative paths are expanded; multiple -I are allowed."),
         M("-l",		   "",			   "Set output record separator ($\\) to $/;\n"
             "used for line-oriented output."),
         M("-n",		   "",			   "Run program in gets loop."),


### PR DESCRIPTION
The currrent docs of `-I` say

> Add specified directory to load paths ($LOAD_PATH)

Now, consider this

```
ruby -Ilib foo.rb
```

As a user I wonder:

1. Is `lib` added at the start or at the end of `$LOAD_PATH`?
2. I am pushing `lib` literally? Like, is it a relative path that could be problematic with `chdir`?

The proposed docs address those questions.