### PR TITLE
Backport [Bug #21024] <cstdbool> header has been useless

### DIFF
--- a/include/ruby/internal/stdbool.h
+++ b/include/ruby/internal/stdbool.h
@@ -27,10 +27,6 @@
 
 #elif defined(__cplusplus)
 # /* bool is a keyword in C++. */
-# if defined(HAVE_STDBOOL_H) && (__cplusplus >= 201103L)
-#  include <cstdbool>
-# endif
-#
 # ifndef __bool_true_false_are_defined
 #  define __bool_true_false_are_defined
 # endif


### PR DESCRIPTION
And finally deprecated at C++-17.
Patched by jprokop (Jarek Prokop).

---

Following discussion on https://github.com/ruby/ruby/pull/12551#discussion_r1913285350 I'd also like to backport this to Ruby 3.4 as that is currently the Ruby delivered in Fedora in combination with GCC 15 that throws the warning when including the header.