### PR TITLE
Skip some PTY tests in MacOS environment

### DIFF
--- a/test/test_pty.rb
+++ b/test/test_pty.rb
@@ -12,6 +12,7 @@ class TestPTY < Test::Unit::TestCase
   RUBY = EnvUtil.rubybin
 
   def test_spawn_without_block
+    omit "[Bug #20682] Flaky test behavior on MacOS" if /darwin/ =~ RUBY_PLATFORM
     r, w, pid = PTY.spawn(RUBY, '-e', 'puts "a"')
   rescue RuntimeError
     omit $!
@@ -24,6 +25,7 @@ class TestPTY < Test::Unit::TestCase
   end
 
   def test_spawn_with_block
+    omit "[Bug #20682] Flaky test behavior on MacOS" if /darwin/ =~ RUBY_PLATFORM
     PTY.spawn(RUBY, '-e', 'puts "b"') {|r,w,pid|
       begin
         assert_equal("b\r\n", r.gets)
@@ -38,6 +40,7 @@ class TestPTY < Test::Unit::TestCase
   end
 
   def test_commandline
+    omit "[Bug #20682] Flaky test behavior on MacOS" if /darwin/ =~ RUBY_PLATFORM
     commandline = Shellwords.join([RUBY, '-e', 'puts "foo"'])
     PTY.spawn(commandline) {|r,w,pid|
       begin
@@ -53,6 +56,7 @@ class TestPTY < Test::Unit::TestCase
   end
 
   def test_argv0
+    omit "[Bug #20682] Flaky test behavior on MacOS" if /darwin/ =~ RUBY_PLATFORM
     PTY.spawn([RUBY, "argv0"], '-e', 'puts "bar"') {|r,w,pid|
       begin
         assert_equal("bar\r\n", r.gets)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20682

The following tests are flaky only on MacOS, so I'm gonna skip them as a workaround.

* test_spawn_without_block
* test_spawn_with_block
* test_commandline
* test_argv0