### PR TITLE
Remove rb_usascii_encoding for Parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -180,12 +180,6 @@ intern3(const char *name, long len, parser_encoding *enc)
     return rb_intern3(name, len, enc);
 }
 
-static parser_encoding *
-usascii_encoding(void)
-{
-    return rb_usascii_encoding();
-}
-
 static int
 enc_symname_type(const char *name, long len, parser_encoding *enc, unsigned int allowed_attrset)
 {
@@ -405,7 +399,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .enc_isspace = enc_isspace,
     .enc_coderange_7bit = ENC_CODERANGE_7BIT,
     .enc_coderange_unknown = ENC_CODERANGE_UNKNOWN,
-    .usascii_encoding = usascii_encoding,
     .enc_mbminlen = enc_mbminlen,
     .enc_isascii = enc_isascii,
     .enc_mbc_to_codepoint = enc_mbc_to_codepoint,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1293,7 +1293,6 @@ typedef struct rb_parser_config_struct {
     int (*enc_find_index)(const char *name);
     rb_encoding *(*enc_from_index)(int idx);
     int (*enc_isspace)(OnigCodePoint c, rb_encoding *enc);
-    rb_encoding *(*usascii_encoding)(void);
     int (*enc_mbminlen)(rb_encoding *enc);
     bool (*enc_isascii)(OnigCodePoint c, rb_encoding *enc);
     OnigCodePoint (*enc_mbc_to_codepoint)(const char *p, const char *e, rb_encoding *enc);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -156,7 +156,6 @@
 #define rb_enc_isspace          p->config->enc_isspace
 #define ENC_CODERANGE_7BIT      p->config->enc_coderange_7bit
 #define ENC_CODERANGE_UNKNOWN   p->config->enc_coderange_unknown
-#define rb_usascii_encoding     p->config->usascii_encoding
 
 #define rb_local_defined          p->config->local_defined
 #define rb_dvar_defined           p->config->dvar_defined


### PR DESCRIPTION
Ruby Parser not used rb_usascii_encoding.
And usascii_encoding property can be removed from Universal Parser.