### PR TITLE
Fix gc_update_references_weak_table_i for ASAN

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -7113,7 +7113,11 @@ gc_ref_update(void *vstart, void *vend, size_t stride, rb_objspace_t *objspace, 
 static int
 gc_update_references_weak_table_i(VALUE obj, void *data)
 {
-    return BUILTIN_TYPE(obj) == T_MOVED ? ST_REPLACE : ST_CONTINUE;
+    int ret;
+    asan_unpoisoning_object(obj) {
+        ret = BUILTIN_TYPE(obj) == T_MOVED ? ST_REPLACE : ST_CONTINUE;
+    }
+    return ret;
 }
 
 static int


### PR DESCRIPTION
If the object is a T_MOVED, then it is poisoned in ASAN, so we need to unpoison it before checking the type.