### PR TITLE
Prefer `uname -n` over `hostname`.

### DIFF
--- a/spec/ruby/library/socket/socket/gethostname_spec.rb
+++ b/spec/ruby/library/socket/socket/gethostname_spec.rb
@@ -3,6 +3,6 @@ require_relative '../fixtures/classes'
 
 describe "Socket.gethostname" do
   it "returns the host name" do
-    Socket.gethostname.should == `hostname`.strip
+    Socket.gethostname.should == `uname -n`.strip
   end
 end


### PR DESCRIPTION
See <https://gitlab.archlinux.org/archlinux/packaging/packages/inetutils/-/issues/2#note_211062> for context.