### PR TITLE
Run extract-gems before build-ext 

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -389,7 +389,7 @@ showconfig:
 
 EXTS_NOTE = -f $(EXTS_MK) $(mflags) RUBY="$(MINIRUBY)" top_srcdir="$(srcdir)" note
 
-exts: build-ext
+exts: extract-gems build-ext
 
 EXTS_MK = exts.mk
 $(EXTS_MK): ext/configure-ext.mk $(srcdir)/template/exts.mk.tmpl \


### PR DESCRIPTION
Because C-ext gems like syslog, rbs need to extract files before that build.

Now we always carefully to extract bundled gems like https://github.com/ruby/ruby/pull/12649. 