### PR TITLE
Revert "Prefer `uname -n` over `hostname`."

### DIFF
--- a/spec/ruby/library/socket/socket/gethostname_spec.rb
+++ b/spec/ruby/library/socket/socket/gethostname_spec.rb
@@ -3,6 +3,6 @@ require_relative '../fixtures/classes'
 
 describe "Socket.gethostname" do
   it "returns the host name" do
-    Socket.gethostname.should == `uname -n`.strip
+    Socket.gethostname.should == `hostname`.strip
   end
 end


### PR DESCRIPTION
Reverts ruby/ruby#12647
See https://github.com/ruby/ruby/pull/12647#discussion_r1931980612