### PR TITLE
Fix possible dereference of NULL

### DIFF
--- a/node.h
+++ b/node.h
@@ -74,7 +74,7 @@ RUBY_SYMBOL_EXPORT_END
 #define NODE_LSHIFT (NODE_TYPESHIFT+7)
 #define NODE_LMASK  (((SIGNED_VALUE)1<<(sizeof(VALUE)*CHAR_BIT-NODE_LSHIFT))-1)
 
-#define nd_line(n) (int)(((SIGNED_VALUE)(n)->flags)>>NODE_LSHIFT)
+#define nd_line(n) (int)((n) ? ((SIGNED_VALUE)(n)->flags)>>NODE_LSHIFT : -1)
 #define nd_set_line(n,l) \
     (n)->flags=(((n)->flags&~((VALUE)(-1)<<NODE_LSHIFT))|((VALUE)((l)&NODE_LMASK)<<NODE_LSHIFT))
 


### PR DESCRIPTION
In some places in compile.c (for example in compile_builtin_arg) ERROR_ARGS macro is used while node = NULL. This macro uses nd_line which dereferences node. Add check for NULL to prevent such errors.