### PR TITLE
Output object_id in ObjectSpace.dump

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -638,6 +638,11 @@ dump_object(VALUE obj, struct dump_config *dc)
         dump_append_sizet(dc, memsize);
     }
 
+    if (FL_TEST(obj, FL_SEEN_OBJ_ID)) {
+        dump_append(dc, ", \"object_id\":");
+        dump_append_lu(dc, RB_NUM2ULONG(rb_obj_id(obj)));
+    }
+
     if ((n = rb_obj_gc_flags(obj, flags, sizeof(flags))) > 0) {
         dump_append(dc, ", \"flags\":{");
         for (i=0; i<n; i++) {

--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -486,6 +486,20 @@ class TestObjSpace < Test::Unit::TestCase
     assert_match(/"value":"foobar\h+"/, dump)
   end
 
+  def test_dump_outputs_object_id
+    obj = Object.new
+
+    # Doesn't output object_id when it has not been seen
+    dump = ObjectSpace.dump(obj)
+    assert_not_include(dump, "\"object_id\"")
+
+    id = obj.object_id
+
+    # Outputs object_id when it has been seen
+    dump = ObjectSpace.dump(obj)
+    assert_include(dump, "\"object_id\":#{id}")
+  end
+
   def test_dump_includes_imemo_type
     assert_in_out_err(%w[-robjspace], "#{<<-"begin;"}\n#{<<-'end;'}") do |output, error|
       begin;


### PR DESCRIPTION
Outputs the object ID in the dump for objects that have it seen.