### PR TITLE
Update child module name when parent gets a temp name set

### DIFF
--- a/spec/ruby/core/module/set_temporary_name_spec.rb
+++ b/spec/ruby/core/module/set_temporary_name_spec.rb
@@ -64,5 +64,14 @@ ruby_version_is "3.3" do
       m::M = m::N
       m::M.name.should =~ /\A#<Module:0x\h+>::M\z/m
     end
+
+    it "can update the name of child constants" do
+      m = Module.new
+      m::N = Module.new
+      m::N.name.should =~ /\A#<Module:0x\h+>::N\z/
+      m.set_temporary_name("foo")
+      m.name == "foo"
+      m::N.name == "foo"
+    end
   end
 end


### PR DESCRIPTION
When calling `set_temporary_name` on a parent module the child modules should get their name updated too.

Before:

```ruby
m = Module.new
m::N = Module.new
p m::N.name # => "#<Module:0x000000010d0a00b0>::N"

m.set_temporary_name("foo")
p m::N.name # => "#<Module:0x000000010d0a00b0>::N"
```

After:

```ruby
m = Module.new
m::N = Module.new
p m::N.name # => "#<Module:0x000000010d0a00b0>::N"

m.set_temporary_name("foo")
p m::N.name # => "foo::N"
```

[Bug #21094]