### PR TITLE
Ensure that memory is not freed before calling `free_fast_fallback_getaddrinfo_*`

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -1168,9 +1168,13 @@ fast_fallback_inetsock_cleanup(VALUE v)
         rb_nativethread_lock_unlock(&getaddrinfo_shared->lock);
 
         for (int i = 0; i < arg->family_size; i++) {
-            if (need_free[i]) free_fast_fallback_getaddrinfo_entry(&arg->getaddrinfo_entries[i]);
+            if (arg->getaddrinfo_entries[i] && need_free[i]) {
+                free_fast_fallback_getaddrinfo_entry(&arg->getaddrinfo_entries[i]);
+            }
         }
-        if (shared_need_free) free_fast_fallback_getaddrinfo_shared(&getaddrinfo_shared);
+        if (getaddrinfo_shared && shared_need_free) {
+            free_fast_fallback_getaddrinfo_shared(&getaddrinfo_shared);
+        }
     }
 
     int connection_attempt_fd;


### PR DESCRIPTION
Ensure that `getaddrinfo_entry` and `getaddrinfo_shared` exist before free them in the main thread.