### PR TITLE
[DOC] Fix wrong call-seq format

### DIFF
--- a/file.c
+++ b/file.c
@@ -5679,7 +5679,6 @@ rb_stat_s_alloc(VALUE klass)
 
 /*
  * call-seq:
- *
  *   File::Stat.new(file_name)  -> stat
  *
  * Create a File::Stat object for the given file name (raising an

--- a/thread.c
+++ b/thread.c
@@ -884,10 +884,10 @@ thread_create_core(VALUE thval, struct thread_create_params *params)
 #define threadptr_initialized(th) ((th)->invoke_type != thread_invoke_type_none)
 
 /*
- * call-seq:
- *  Thread.new { ... }			-> thread
- *  Thread.new(*args, &proc)		-> thread
- *  Thread.new(*args) { |args| ... }	-> thread
+ *  call-seq:
+ *    Thread.new { ... }		-> thread
+ *    Thread.new(*args, &proc)		-> thread
+ *    Thread.new(*args) { |args| ... }	-> thread
  *
  *  Creates a new thread executing the given block.
  *

--- a/time.c
+++ b/time.c
@@ -5700,7 +5700,6 @@ time_load(VALUE klass, VALUE str)
 
 /*
  * call-seq:
- *
  *   Time::tm.from_time(t) -> tm
  *
  * Creates new Time::tm object from a Time object.
@@ -5731,7 +5730,6 @@ tm_from_time(VALUE klass, VALUE time)
 
 /*
  * call-seq:
- *
  *   Time::tm.new(year, month=nil, day=nil, hour=nil, min=nil, sec=nil, zone=nil) -> tm
  *
  * Creates new Time::tm object.
@@ -5755,7 +5753,6 @@ tm_initialize(int argc, VALUE *argv, VALUE time)
 }
 
 /* call-seq:
- *
  *   tm.to_time -> time
  *
  * Returns a new Time object.


### PR DESCRIPTION
`call-seq:` of Thread.new needs indentation.

Blank like between `call-seq:` and actual call sequences is not correctly handled by RDoc
https://docs.ruby-lang.org/en/master/File/Stat.html#method-c-new
```c
/*
 * call-seq:
 *
 *   File::Stat.new(file_name)  -> stat
 */
```
