### PR TITLE
rb_alias: improve "undefined method" error message.

### DIFF
--- a/test/ruby/test_alias.rb
+++ b/test/ruby/test_alias.rb
@@ -328,4 +328,17 @@ class TestAlias < Test::Unit::TestCase
       }
     end;
   end
+
+  def test_undef_method_error_message_with_zsuper_method
+    modules = [
+      Module.new { private :class },
+      Module.new { prepend Module.new { private :class } },
+    ]
+    message = "undefined method 'class' for module '%s'"
+    modules.each do |mod|
+      assert_raise_with_message(NameError, message % mod) do
+        mod.alias_method :xyz, :class
+      end
+    end
+  end
 end

--- a/vm_method.c
+++ b/vm_method.c
@@ -2311,7 +2311,7 @@ rb_alias(VALUE klass, ID alias_name, ID original_name)
         if ((!RB_TYPE_P(klass, T_MODULE)) ||
             (orig_me = search_method(rb_cObject, original_name, &defined_class),
              UNDEFINED_METHOD_ENTRY_P(orig_me))) {
-            rb_print_undef(klass, original_name, METHOD_VISI_UNDEF);
+            rb_print_undef(target_klass, original_name, METHOD_VISI_UNDEF);
         }
     }
 


### PR DESCRIPTION
The current implementation of `rb_alias` can raise `NameError` exceptions with confusing error messages when the original method cannot be found and ZSUPER methods are involved in the inheritance chain traversal.
This PR aims at fixing the issue by invoking `rb_print_undef` with `target_klass` as argument.

Before:

```ruby
module M
  private :class
  alias_method :xyz, :class  # raises 'Module#alias_method': undefined method 'class' for class 'false' (NameError)
end
```

```ruby
module M
  private :class
end
module N
  prepend M
  alias_method :xyz, :class  # raises 'Module#alias_method': undefined method 'class' for class '#<N:0x0000000124ba7f00>' (NameError)
end
```

After:

```ruby
module M
  private :class
  alias_method :xyz, :class  # raises 'Module#alias_method': undefined method 'class' for module 'M' (NameError)
end
```

```ruby
module M
  private :class
end
module N
  prepend M
  alias_method :xyz, :class  # raises 'Module#alias_method': undefined method 'class' for module 'N' (NameError)
end
```

[[Bug #21098]](https://bugs.ruby-lang.org/issues/21098)