### PR TITLE
Fix fiddle test dlopen for .so filename with more than one digit

### DIFF
--- a/test/fiddle/test_fiddle.rb
+++ b/test/fiddle/test_fiddle.rb
@@ -83,7 +83,7 @@ class TestFiddle < Fiddle::TestCase
     handle = Fiddle.dlopen("libc.so")
     begin
       assert_equal("libc.so",
-                   File.basename(handle.file_name, ".*"))
+                   File.basename(handle.file_name, ".*").gsub(/\.so.\d+/,'.so'))
     ensure
       handle.close
     end


### PR DESCRIPTION
In alpha architecture, we have libc.so.6.1 which causes a failure in this test:

 1) Failure:
TestFiddle#test_dlopen_linker_script_group_linux [/<<PKGBUILDDIR>>/test/fiddle/test_fiddle.rb:52]: <"libc.so"> expected but was
<"libc.so.6">.

Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1085238