### PR TITLE
Improve bundled gem warning messages

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -33,8 +33,6 @@ module Gem::BUNDLED_GEMS # :nodoc:
     # "readline" => "3.5.0", # This is wrapper for reline. We don't warn for this.
   }.freeze
 
-  SINCE_FAST_PATH = SINCE.transform_keys { |g| g.sub(/\A.*\-/, "") }.freeze
-
   EXACT = {
     "kconv" => "nkf",
   }.freeze
@@ -142,7 +140,7 @@ module Gem::BUNDLED_GEMS # :nodoc:
       end
     else
       name = feature.sub(LIBEXT, "")
-      return unless SINCE_FAST_PATH[name]
+      return unless SINCE[name]
     end
 
     return if specs.include?(name)

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -137,11 +137,11 @@ module Gem::BUNDLED_GEMS # :nodoc:
     end + build_message(name)
   end
 
-  def self.build_message(gem)
-    msg = " #{RUBY_VERSION < SINCE[gem] ? "will no longer be" : "is not"} part of the default gems starting from Ruby #{SINCE[gem]}."
+  def self.build_message(name)
+    msg = " #{RUBY_VERSION < SINCE[name] ? "will no longer be" : "is not"} part of the default gems starting from Ruby #{SINCE[name]}."
 
     if defined?(Bundler)
-      msg += "\nYou can add #{gem} to your Gemfile or gemspec to silence this warning."
+      msg += "\nYou can add #{name} to your Gemfile or gemspec to silence this warning."
 
       # We detect the gem name from caller_locations. First we walk until we find `require`
       # then take the first frame that's not from `require`.
@@ -179,11 +179,11 @@ module Gem::BUNDLED_GEMS # :nodoc:
           end
         end
         if caller_gem
-          msg += "\nAlso please contact the author of #{caller_gem} to request adding #{gem} into its gemspec."
+          msg += "\nAlso please contact the author of #{caller_gem} to request adding #{name} into its gemspec."
         end
       end
     else
-      msg += " Install #{gem} from RubyGems."
+      msg += " Install #{name} from RubyGems."
     end
 
     msg

--- a/spec/bundled_gems_spec.rb
+++ b/spec/bundled_gems_spec.rb
@@ -60,12 +60,10 @@ RSpec.describe "bundled_gems.rb" do
       Gem::BUNDLED_GEMS.send(:remove_const, :LIBDIR)
       Gem::BUNDLED_GEMS.send(:remove_const, :ARCHDIR)
       Gem::BUNDLED_GEMS.send(:remove_const, :SINCE)
-      Gem::BUNDLED_GEMS.send(:remove_const, :SINCE_FAST_PATH)
       Gem::BUNDLED_GEMS.send(:remove_const, :PREFIXED)
       Gem::BUNDLED_GEMS.const_set(:LIBDIR, File.expand_path(File.join(__dir__, "../../..", "lib")) + "/")
       Gem::BUNDLED_GEMS.const_set(:ARCHDIR, File.expand_path($LOAD_PATH.find{|path| path.include?(".ext/common") }) + "/")
       Gem::BUNDLED_GEMS.const_set(:SINCE, { "openssl" => RUBY_VERSION, "fileutils" => RUBY_VERSION, "csv" => "3.4.0", "net-smtp" => "3.1.0" })
-      Gem::BUNDLED_GEMS.const_set(:SINCE_FAST_PATH, Gem::BUNDLED_GEMS::SINCE.transform_keys { |g| g.sub(/\A.*\-/, "") } )
       Gem::BUNDLED_GEMS.const_set(:PREFIXED, { "openssl" => true })
     STUB
   }
@@ -95,9 +93,9 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/csv was loaded from (.*) from Ruby 3.4.0/)
-    expect(err).to include(/-e:19/)
+    expect(err).to include(/-e:17/)
     expect(err).to include(/openssl was loaded from (.*) from Ruby #{RUBY_VERSION}/)
-    expect(err).to include(/-e:22/)
+    expect(err).to include(/-e:20/)
   end
 
   it "Show warning when bundled gems called as dependency" do
@@ -133,7 +131,7 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/net\/smtp was loaded from (.*) from Ruby 3.1.0/)
-    expect(err).to include(/-e:19/)
+    expect(err).to include(/-e:17/)
     expect(err).to include("You can add net-smtp")
   end
 
@@ -149,7 +147,7 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/openssl\/bn is found in openssl, (.*) part of the default gems starting from Ruby #{RUBY_VERSION}/)
-    expect(err).to include(/-e:18/)
+    expect(err).to include(/-e:16/)
   end
 
   it "Show warning when bundle exec with ruby and script" do
@@ -163,7 +161,7 @@ RSpec.describe "bundled_gems.rb" do
     bundle "exec ruby script.rb"
 
     expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
-    expect(err).to include(/script\.rb:12/)
+    expect(err).to include(/script\.rb:10/)
   end
 
   it "Show warning when bundle exec with shebang's script" do
@@ -181,7 +179,7 @@ RSpec.describe "bundled_gems.rb" do
     bundle "exec ./script.rb"
 
     expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
-    expect(err).to include(/script\.rb:13/)
+    expect(err).to include(/script\.rb:11/)
   end
 
   it "Show warning when bundle exec with -r option" do
@@ -213,7 +211,7 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
-    expect(err).to include(/-e:23/)
+    expect(err).to include(/-e:21/)
   end
 
   it "Don't show warning when bundled gems called as dependency" do
@@ -324,7 +322,7 @@ RSpec.describe "bundled_gems.rb" do
     bundle "exec ruby script.rb"
 
     expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
-    expect(err).to include(/script\.rb:17/)
+    expect(err).to include(/script\.rb:15/)
   end
 
   it "Don't show warning openssl/bn when openssl on Gemfile" do

--- a/spec/bundled_gems_spec.rb
+++ b/spec/bundled_gems_spec.rb
@@ -60,11 +60,9 @@ RSpec.describe "bundled_gems.rb" do
       Gem::BUNDLED_GEMS.send(:remove_const, :LIBDIR)
       Gem::BUNDLED_GEMS.send(:remove_const, :ARCHDIR)
       Gem::BUNDLED_GEMS.send(:remove_const, :SINCE)
-      Gem::BUNDLED_GEMS.send(:remove_const, :PREFIXED)
       Gem::BUNDLED_GEMS.const_set(:LIBDIR, File.expand_path(File.join(__dir__, "../../..", "lib")) + "/")
       Gem::BUNDLED_GEMS.const_set(:ARCHDIR, File.expand_path($LOAD_PATH.find{|path| path.include?(".ext/common") }) + "/")
       Gem::BUNDLED_GEMS.const_set(:SINCE, { "openssl" => RUBY_VERSION, "fileutils" => RUBY_VERSION, "csv" => "3.4.0", "net-smtp" => "3.1.0" })
-      Gem::BUNDLED_GEMS.const_set(:PREFIXED, { "openssl" => true })
     STUB
   }
 
@@ -93,9 +91,9 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/csv was loaded from (.*) from Ruby 3.4.0/)
-    expect(err).to include(/-e:17/)
+    expect(err).to include(/-e:15/)
     expect(err).to include(/openssl was loaded from (.*) from Ruby #{RUBY_VERSION}/)
-    expect(err).to include(/-e:20/)
+    expect(err).to include(/-e:18/)
   end
 
   it "Show warning when bundled gems called as dependency" do
@@ -131,7 +129,7 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/net\/smtp was loaded from (.*) from Ruby 3.1.0/)
-    expect(err).to include(/-e:17/)
+    expect(err).to include(/-e:15/)
     expect(err).to include("You can add net-smtp")
   end
 
@@ -147,7 +145,7 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/openssl\/bn is found in openssl, (.*) part of the default gems starting from Ruby #{RUBY_VERSION}/)
-    expect(err).to include(/-e:16/)
+    expect(err).to include(/-e:14/)
   end
 
   it "Show warning when bundle exec with ruby and script" do
@@ -161,7 +159,7 @@ RSpec.describe "bundled_gems.rb" do
     bundle "exec ruby script.rb"
 
     expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
-    expect(err).to include(/script\.rb:10/)
+    expect(err).to include(/script\.rb:8/)
   end
 
   it "Show warning when bundle exec with shebang's script" do
@@ -179,7 +177,7 @@ RSpec.describe "bundled_gems.rb" do
     bundle "exec ./script.rb"
 
     expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
-    expect(err).to include(/script\.rb:11/)
+    expect(err).to include(/script\.rb:9/)
   end
 
   it "Show warning when bundle exec with -r option" do
@@ -211,7 +209,7 @@ RSpec.describe "bundled_gems.rb" do
     RUBY
 
     expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
-    expect(err).to include(/-e:21/)
+    expect(err).to include(/-e:19/)
   end
 
   it "Don't show warning when bundled gems called as dependency" do
@@ -322,7 +320,7 @@ RSpec.describe "bundled_gems.rb" do
     bundle "exec ruby script.rb"
 
     expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
-    expect(err).to include(/script\.rb:15/)
+    expect(err).to include(/script\.rb:13/)
   end
 
   it "Don't show warning openssl/bn when openssl on Gemfile" do

--- a/spec/bundled_gems_spec.rb
+++ b/spec/bundled_gems_spec.rb
@@ -90,9 +90,9 @@ RSpec.describe "bundled_gems.rb" do
       require "openssl"
     RUBY
 
-    expect(err).to include(/csv was loaded from (.*) from Ruby 3.4.0/)
+    expect(err).to include(/csv used to be loaded from (.*) since Ruby 3.4.0/)
     expect(err).to include(/-e:15/)
-    expect(err).to include(/openssl was loaded from (.*) from Ruby #{RUBY_VERSION}/)
+    expect(err).to include(/openssl used to be loaded from (.*) since Ruby #{RUBY_VERSION}/)
     expect(err).to include(/-e:18/)
   end
 
@@ -112,7 +112,7 @@ RSpec.describe "bundled_gems.rb" do
       require "active_support/all"
     RUBY
 
-    expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
+    expect(err).to include(/openssl used to be loaded from (.*) since Ruby 3.5.0/)
     expect(err).to include(/lib\/active_support\/all\.rb:1/)
   end
 
@@ -128,7 +128,7 @@ RSpec.describe "bundled_gems.rb" do
       end
     RUBY
 
-    expect(err).to include(/net\/smtp was loaded from (.*) from Ruby 3.1.0/)
+    expect(err).to include(/net\/smtp used to be loaded from (.*) since Ruby 3.1.0/)
     expect(err).to include(/-e:15/)
     expect(err).to include("You can add net-smtp")
   end
@@ -144,7 +144,7 @@ RSpec.describe "bundled_gems.rb" do
       require "openssl/bn"
     RUBY
 
-    expect(err).to include(/openssl\/bn is found in openssl, (.*) part of the default gems starting from Ruby #{RUBY_VERSION}/)
+    expect(err).to include(/openssl\/bn is found in openssl, (.*) part of the default gems since Ruby #{RUBY_VERSION}/)
     expect(err).to include(/-e:14/)
   end
 
@@ -158,7 +158,7 @@ RSpec.describe "bundled_gems.rb" do
 
     bundle "exec ruby script.rb"
 
-    expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
+    expect(err).to include(/openssl used to be loaded from (.*) since Ruby 3.5.0/)
     expect(err).to include(/script\.rb:8/)
   end
 
@@ -176,7 +176,7 @@ RSpec.describe "bundled_gems.rb" do
 
     bundle "exec ./script.rb"
 
-    expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
+    expect(err).to include(/openssl used to be loaded from (.*) since Ruby 3.5.0/)
     expect(err).to include(/script\.rb:9/)
   end
 
@@ -185,7 +185,7 @@ RSpec.describe "bundled_gems.rb" do
     create_file("Gemfile", "source 'https://rubygems.org'")
     bundle "exec ruby -r./stub -ropenssl -e ''"
 
-    expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
+    expect(err).to include(/openssl used to be loaded from (.*) since Ruby 3.5.0/)
   end
 
   it "Show warning when warn is not the standard one in the current scope" do
@@ -208,7 +208,7 @@ RSpec.describe "bundled_gems.rb" do
       My.my
     RUBY
 
-    expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
+    expect(err).to include(/openssl used to be loaded from (.*) since Ruby 3.5.0/)
     expect(err).to include(/-e:19/)
   end
 
@@ -250,7 +250,7 @@ RSpec.describe "bundled_gems.rb" do
       require Gem::BUNDLED_GEMS::ARCHDIR + 'openssl'
     RUBY
 
-    expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
+    expect(err).to include(/openssl used to be loaded from (.*) since Ruby 3.5.0/)
     # TODO: We should assert caller location like below:
     # test_warn_bootsnap.rb:14: warning: ...
   end
@@ -270,7 +270,7 @@ RSpec.describe "bundled_gems.rb" do
       require Gem::BUNDLED_GEMS::ARCHDIR + "openssl"
     RUBY
 
-    expect(err).to include(/openssl was loaded from (.*) from Ruby #{RUBY_VERSION}/)
+    expect(err).to include(/openssl used to be loaded from (.*) since Ruby #{RUBY_VERSION}/)
     # TODO: We should assert caller location like below:
     # test_warn_bootsnap_rubyarchdir_gem.rb:14: warning: ...
   end
@@ -299,7 +299,7 @@ RSpec.describe "bundled_gems.rb" do
       require Gem.loaded_specs["fileutils2"].full_gem_path + '/lib/fileutils2'
     RUBY
 
-    expect(err).to include(/fileutils was loaded from (.*) from Ruby #{RUBY_VERSION}/)
+    expect(err).to include(/fileutils used to be loaded from (.*) since Ruby #{RUBY_VERSION}/)
     # TODO: We should assert caller location like below:
     # $GEM_HOME/gems/childprocess-5.0.0/lib/childprocess.rb:7: warning:
   end
@@ -319,7 +319,7 @@ RSpec.describe "bundled_gems.rb" do
     create_file("Gemfile", "source 'https://rubygems.org'")
     bundle "exec ruby script.rb"
 
-    expect(err).to include(/openssl was loaded from (.*) from Ruby 3.5.0/)
+    expect(err).to include(/openssl used to be loaded from (.*) since Ruby 3.5.0/)
     expect(err).to include(/script\.rb:13/)
   end
 


### PR DESCRIPTION
The information about default gems no longer available at `require` time is currently a bit confusing once the default gem is no longer available.

This is because it suggests that the missing gem was actually loaded, and that the problem is a warning, not an actual error.

This PR improves the wording from something like

> irb was loaded from the standard library, but is not part of the default gems starting from Ruby 3.5.0

to something like

> irb used to be loaded from the standard library, but is not part of the default gems since Ruby 3.5.0

While looking into this improvement, I realized that the current implementation was much more complicated than it needed to, so I removed a bunch of code.