### PR TITLE
[Bug #21092] Fallback variables after execonf has done

### DIFF
--- a/ext/extmk.rb
+++ b/ext/extmk.rb
@@ -173,8 +173,6 @@ def extmake(target, basedir = 'ext', maybestatic = true)
     $mdir = target
     $srcdir = File.join($top_srcdir, basedir, $mdir)
     $preload = nil
-    $objs = []
-    $srcs = []
     $extso = []
     makefile = "./Makefile"
     static = $static
@@ -208,7 +206,7 @@ def extmake(target, basedir = 'ext', maybestatic = true)
       begin
 	$extconf_h = nil
 	ok &&= extract_makefile(makefile)
-	old_objs = $objs
+	old_objs = $objs || []
 	old_cleanfiles = $distcleanfiles | $cleanfiles
 	conf = ["#{$srcdir}/makefile.rb", "#{$srcdir}/extconf.rb"].find {|f| File.exist?(f)}
 	if (!ok || ($extconf_h && !File.exist?($extconf_h)) ||
@@ -271,6 +269,8 @@ def extmake(target, basedir = 'ext', maybestatic = true)
     unless $destdir.to_s.empty? or $mflags.defined?("DESTDIR")
       args += ["DESTDIR=" + relative_from($destdir, "../"+prefix)]
     end
+    $objs ||= []
+    $srcs ||= []
     if $static and ok and !$objs.empty? and !noinstall
       args += ["static"]
       $extlist.push [(maybestatic ? $static : false), target, $target, $preload]


### PR DESCRIPTION
When reading from a dummy makefile, the global variables initialized in `init_mkmf` may not be overridden.