### PR TITLE
Fix possible dereference of NULL

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -8937,7 +8937,7 @@ compile_call_precheck_freeze(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE
     /* optimization shortcut
      *   obj["literal"] -> opt_aref_with(obj, "literal")
      */
-    if (get_node_call_nd_mid(node) == idAREF && !private_recv_p(node) && get_nd_args(node) &&
+    if (get_node_call_nd_mid(node) == idAREF && (!get_nd_recv(node) || !private_recv_p(node)) && get_nd_args(node) &&
         nd_type_p(get_nd_args(node), NODE_LIST) && RNODE_LIST(get_nd_args(node))->as.nd_alen == 1 &&
         (nd_type_p(RNODE_LIST(get_nd_args(node))->nd_head, NODE_STR) || nd_type_p(RNODE_LIST(get_nd_args(node))->nd_head, NODE_FILE)) &&
         ISEQ_COMPILE_DATA(iseq)->current_block == NULL &&


### PR DESCRIPTION
get_nd_recv(node) is dereferenced in private_recv_p and may be NULL (that is checked in first if in function). Add a check to prevent NULL-dereference.