### PR TITLE
Prefer `platform_is_not :windows`.

### DIFF
--- a/spec/ruby/library/socket/socket/gethostname_spec.rb
+++ b/spec/ruby/library/socket/socket/gethostname_spec.rb
@@ -3,11 +3,13 @@ require_relative '../fixtures/classes'
 
 describe "Socket.gethostname" do
   def system_hostname
-    # Most platforms implement this POSIX standard:
-    `uname -n`.strip
-  rescue
-    # Only really required for Windows without MSYS/MinGW/Cygwin etc:
-    `hostname`.strip
+    if platform_is_not :windows
+      # `uname -n` is the most portable way to get the hostname, as it is a POSIX standard:
+      `uname -n`.strip
+    else
+      # Windows does not have uname, so we use hostname instead:
+      `hostname`.strip
+    end
   end
 
   it "returns the host name" do


### PR DESCRIPTION
See <https://github.com/ruby/ruby/pull/12655> for prior discussion.