### PR TITLE
Remove rb_exc_raise for Parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -412,7 +412,6 @@ static const rb_parser_config_t rb_global_parser_config = {
 
     .errinfo = rb_errinfo,
     .set_errinfo = rb_set_errinfo,
-    .exc_raise = rb_exc_raise,
     .make_exception = rb_make_exception,
 
     .sized_xfree = ruby_sized_xfree,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1313,7 +1313,6 @@ typedef struct rb_parser_config_struct {
     /* Eval */
     VALUE (*errinfo)(void);
     void (*set_errinfo)(VALUE err);
-    void (*exc_raise)(VALUE mesg);
     VALUE (*make_exception)(int argc, const VALUE *argv);
 
     /* GC */

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -166,7 +166,6 @@
 
 #define rb_errinfo p->config->errinfo
 #define rb_set_errinfo p->config->set_errinfo
-#define rb_exc_raise p->config->exc_raise
 #define rb_make_exception p->config->make_exception
 
 #define ruby_sized_xfree p->config->sized_xfree


### PR DESCRIPTION
Ruby Parser not used rb_exc_raise.
And exc_raise property can be removed from Universal Parser.