### PR TITLE
[Bug #21108] Don't yield from Ractor.yield when terminating

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -1349,6 +1349,11 @@ ractor_try_yield(rb_execution_context_t *ec, rb_ractor_t *cr, struct rb_ractor_q
             }
         }
 
+        // Do nothing if the ractor is terminating.
+        if ((cr->threads.main->ec->interrupt_flag & TERMINATE_INTERRUPT_MASK) == TERMINATE_INTERRUPT_MASK) {
+            return false;
+        }
+
         RACTOR_LOCK(tr);
         {
             VM_ASSERT(basket_type_p(tb, basket_type_yielding));


### PR DESCRIPTION
When the Ractor is in the process of termination, the basket could be basket_type_none (cleared), therefore invalid state for yielding. Yield nothing and return false in such cases.