### PR TITLE
[Bug #21106] Remove the useless last iteration in `Array#shuffle`

### DIFF
--- a/array.c
+++ b/array.c
@@ -6701,7 +6701,7 @@ rb_ary_shuffle_bang(rb_execution_context_t *ec, VALUE ary, VALUE randgen)
     rb_ary_modify(ary);
     i = len = RARRAY_LEN(ary);
     RARRAY_PTR_USE(ary, ptr, {
-        while (i) {
+        while (i > 1) {
             long j = RAND_UPTO(i);
             VALUE tmp;
             if (len != RARRAY_LEN(ary) || ptr != RARRAY_CONST_PTR(ary)) {

--- a/spec/ruby/core/array/sample_spec.rb
+++ b/spec/ruby/core/array/sample_spec.rb
@@ -114,6 +114,13 @@ describe "Array#sample" do
 
         -> { [1, 2].sample(random: random) }.should raise_error(RangeError)
       end
+
+      it "raises a RangeError if the value is greater than the Array size" do
+        random = mock("array_sample_random")
+        random.should_receive(:rand).and_return(3)
+
+        -> { [1, 2].sample(random: random) }.should raise_error(RangeError)
+      end
     end
   end
 

--- a/spec/ruby/core/array/shuffle_spec.rb
+++ b/spec/ruby/core/array/shuffle_spec.rb
@@ -69,9 +69,18 @@ describe "Array#shuffle" do
     -> { [1, 2].shuffle(random: random) }.should raise_error(RangeError)
   end
 
-  it "raises a RangeError if the value is equal to one" do
+  it "raises a RangeError if the value is equal to the Array size" do
     value = mock("array_shuffle_random_value")
-    value.should_receive(:to_int).at_least(1).times.and_return(1)
+    value.should_receive(:to_int).at_least(1).times.and_return(2)
+    random = mock("array_shuffle_random")
+    random.should_receive(:rand).at_least(1).times.and_return(value)
+
+    -> { [1, 2].shuffle(random: random) }.should raise_error(RangeError)
+  end
+
+  it "raises a RangeError if the value is greater than the Array size" do
+    value = mock("array_shuffle_random_value")
+    value.should_receive(:to_int).at_least(1).times.and_return(3)
     random = mock("array_shuffle_random")
     random.should_receive(:rand).at_least(1).times.and_return(value)
 


### PR DESCRIPTION
When only one element remains, this simply swaps the first identical element and has no actual effect.
