### PR TITLE
Add sleep to PTY tests to stabilize flaky failures

### DIFF
--- a/test/test_pty.rb
+++ b/test/test_pty.rb
@@ -12,7 +12,7 @@ class TestPTY < Test::Unit::TestCase
   RUBY = EnvUtil.rubybin
 
   def test_spawn_without_block
-    r, w, pid = PTY.spawn(RUBY, '-e', 'puts "a"')
+    r, w, pid = PTY.spawn(RUBY, '-e', 'puts "a"; sleep 0.1')
   rescue RuntimeError
     omit $!
   else
@@ -24,7 +24,7 @@ class TestPTY < Test::Unit::TestCase
   end
 
   def test_spawn_with_block
-    PTY.spawn(RUBY, '-e', 'puts "b"') {|r,w,pid|
+    PTY.spawn(RUBY, '-e', 'puts "b"; sleep 0.1') {|r,w,pid|
       begin
         assert_equal("b\r\n", r.gets)
       ensure
@@ -38,7 +38,7 @@ class TestPTY < Test::Unit::TestCase
   end
 
   def test_commandline
-    commandline = Shellwords.join([RUBY, '-e', 'puts "foo"'])
+    commandline = Shellwords.join([RUBY, '-e', 'puts "foo"; sleep 0.1'])
     PTY.spawn(commandline) {|r,w,pid|
       begin
         assert_equal("foo\r\n", r.gets)
@@ -53,7 +53,7 @@ class TestPTY < Test::Unit::TestCase
   end
 
   def test_argv0
-    PTY.spawn([RUBY, "argv0"], '-e', 'puts "bar"') {|r,w,pid|
+    PTY.spawn([RUBY, "argv0"], '-e', 'puts "bar"; sleep 0.1') {|r,w,pid|
       begin
         assert_equal("bar\r\n", r.gets)
       ensure


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20682

The following tests are flaky only on MacOS.

- test_spawn_without_block
- test_spawn_with_block
- test_commandline
- test_argv0

The reason is because the slave PTY output is lost after a child process exits in macOS. So, I investigated if we can reduce flaky failures by adding `sleep 0.1`. Here is the experimentation.

1. Repeat the execution of `test-all` with disabling retry.
Code link: https://github.com/ruby/ruby/pull/12681/files#diff-7b74d73de878e0e53f6768bbf3a3d4b50c3c6f1f16f9b64518690028b8206b1cR127
PR: https://github.com/ruby/ruby/pull/12681

2. Confirm if we could reduce flaky failures by adding `sleep 0.1.`.
Commit link: https://github.com/ruby/ruby/pull/12687/commits/fcfac0a249ffcd50cbb2d0b191700bc7a1d940d0=
PR: https://github.com/ruby/ruby/pull/12687

I summarized the result in the following spreadsheet. Most of workflows failed because of flaky tests before adding `sleep 0.1. On the other hand, all of workflows were terminated because of workflow timeout, not flaky tests after adding `sleep 0.1`.

https://docs.google.com/spreadsheets/d/1GejZojJhqf18qDk_nEAMgqhy1TWkphDE8Zer11dD2Hw/edit?gid=0#gid=0


From the above result, I think that this change is valid for reducing flaky failures of PTY.