### PR TITLE
Move out from quarantine a Marshal.dump spec for Float

### DIFF
--- a/spec/ruby/core/marshal/dump_spec.rb
+++ b/spec/ruby/core/marshal/dump_spec.rb
@@ -291,7 +291,7 @@ describe "Marshal.dump" do
       # aren't used for Float values but on amd64 - object links are used
 
       dump = Marshal.dump([0.0, 0.0])
-      (dump == "\x04\b[\af\x060@\x06" || dump == "\x04\b[\af\x060f\x060").should == true
+      ["\x04\b[\af\x060@\x06", "\x04\b[\af\x060f\x060"].should.include?(dump)
 
       # if object links aren't used - entries in the objects table are still
       # occupied by Float values

--- a/spec/ruby/core/marshal/dump_spec.rb
+++ b/spec/ruby/core/marshal/dump_spec.rb
@@ -286,9 +286,20 @@ describe "Marshal.dump" do
       ].should be_computed_by(:dump)
     end
 
-    quarantine! do # fails on i686 with 'Expected "\x04\b[\af\x060f\x060" == "\x04\b[\af\x060@\x06" to be truthy but was false'
-      it "uses object links for objects repeatedly dumped" do
-        Marshal.dump([0.0, 0.0]).should == "\x04\b[\af\x060@\x06" # @\x06 is a link to the float value
+    it "may or may not use object links for objects repeatedly dumped" do
+      # it's an MRI implementation detail - on x86 architecture object links
+      # aren't used for Float values but on amd64 - object links are used
+
+      dump = Marshal.dump([0.0, 0.0])
+      (dump == "\x04\b[\af\x060@\x06" || dump == "\x04\b[\af\x060f\x060").should == true
+
+      # if object links aren't used - entries in the objects table are still
+      # occupied by Float values
+      if dump == "\x04\b[\af\x060f\x060"
+        s = "string"
+        # an index of "string" ("@\b") in the object table equals 3 (`"\b".ord - 5`),
+        # so `0.0, 0,0` elements occupied indices 1 and 2
+        Marshal.dump([0.0, 0.0, s, s]).should == "\x04\b[\tf\x060f\x060\"\vstring@\b"
       end
     end
   end


### PR DESCRIPTION
Fix a quarantined test in the ruby/spec suite.

During the recent ruby/spec syncing (#12679) one new test was disabled in 97c7b52eba4db5b938206815cb5b624801824d5f.

Fix it here (but not in the ruby/spec Git repository) to avoid Git conflicts during the next synchronisation - the test was quarantined in the downstreaming PR here.

