### PR TITLE
Remove rb_make_exception for Parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -412,7 +412,6 @@ static const rb_parser_config_t rb_global_parser_config = {
 
     .errinfo = rb_errinfo,
     .set_errinfo = rb_set_errinfo,
-    .make_exception = rb_make_exception,
 
     .sized_xfree = ruby_sized_xfree,
     .sized_realloc_n = ruby_sized_realloc_n,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1313,7 +1313,6 @@ typedef struct rb_parser_config_struct {
     /* Eval */
     VALUE (*errinfo)(void);
     void (*set_errinfo)(VALUE err);
-    VALUE (*make_exception)(int argc, const VALUE *argv);
 
     /* GC */
     void (*sized_xfree)(void *x, size_t size);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -166,7 +166,6 @@
 
 #define rb_errinfo p->config->errinfo
 #define rb_set_errinfo p->config->set_errinfo
-#define rb_make_exception p->config->make_exception
 
 #define ruby_sized_xfree p->config->sized_xfree
 #define SIZED_REALLOC_N(v, T, m, n) ((v) = (T *)p->config->sized_realloc_n((void *)(v), (m), sizeof(T), (n)))


### PR DESCRIPTION
Ruby Parser not used rb_make_exception .
And make_exception property can be removed from Universal Parser.