### PR TITLE
Launchable: Fix broken links by passing GITHUB_SERVER_URL

### DIFF
--- a/.github/actions/compilers/action.yml
+++ b/.github/actions/compilers/action.yml
@@ -122,4 +122,5 @@ runs:
         --env GITHUB_EVENT_NAME
         --env GITHUB_SHA
         --env GITHUB_HEAD_REF
+        --env GITHUB_SERVER_URL
         'ghcr.io/ruby/ruby-ci-image:${{ inputs.tag }}'


### PR DESCRIPTION
@peterzhu2118  mentioned that "View workflow run" button is broken in Launchable. It's because invalid URL is sent from compilers/actions.yaml. [Launchable CLI builds URL based on the environment variables](https://github.com/launchableinc/cli/blob/ad802cce67ca4b607147db6bb7ce176325f4fa4e/launchable/utils/link.py#L46). In those variables, GITHUB_SERVER_URL is not set in this case.

Hence, I set GITHUB_SERVER_URL in compilers/actions.yaml in this PR.




![image](https://github.com/user-attachments/assets/3b0b0e62-ff71-4b32-b2b0-5828bdd9f467)
