### PR TITLE
[DOC] ractor.md: Remove link to Complex class

### DIFF
--- a/doc/ractor.md
+++ b/doc/ractor.md
@@ -334,7 +334,7 @@ as << obj
 as.sort == ['r1', 'r2'] #=> true
 ```
 
-Complex example:
+\Complex example:
 
 ```ruby
 pipe = Ractor.new do


### PR DESCRIPTION
This sample code has nothing to do with the Complex class, however it is automatically linked. Remove the link.

<img width="372" alt="image" src="https://github.com/user-attachments/assets/6205f349-fc3d-48b2-a94a-266e982a7cfb" />
