### PR TITLE
Support `git ls-files ...`.split style for file list of gemspec

### DIFF
--- a/tool/rbinstall.rb
+++ b/tool/rbinstall.rb
@@ -783,7 +783,7 @@ def load_gemspec(file, base = nil)
     next if File.directory?(File.join(base, n))
     files << n.dump
   end if base
-  code.gsub!(/(?:`git[^\`]*`|%x\[git[^\]]*\])\.split\([^\)]*\)/m) do
+  code.gsub!(/(?:`git[^\`]*`|%x\[git[^\]]*\])\.split(\([^\)]*\))?/m) do
     "[" + files.join(", ") + "]"
   end
   code.gsub!(/IO\.popen\(.*git.*?\)/) do


### PR DESCRIPTION
```
code.gsub!(/(?:`git[^\`]*`|%x\[git[^\]]*\])\.split\([^\)]*\)/m) do
```

is not matched with gemspec of net-smtp-0.5.1.

```
`git ls-files README.md NEWS.md LICENSE.txt net-smtp.gemspec lib`.split
```

Because the current `rbinstall.rb` can't match `split` without parenthesis.