### PR TITLE
Fix library/socket/basicsocket/recv_* specs

### DIFF
--- a/spec/ruby/library/socket/basicsocket/recv_nonblock_spec.rb
+++ b/spec/ruby/library/socket/basicsocket/recv_nonblock_spec.rb
@@ -113,7 +113,6 @@ describe "Socket::BasicSocket#recv_nonblock" do
       end
 
       ruby_version_is ""..."3.3" do
-        quarantine! do # May fail with "IO::EAGAINWaitReadable: Resource temporarily unavailable - recvfrom(2) would block" error
         it "returns an empty String on a closed stream socket" do
           ready = false
 
@@ -121,7 +120,11 @@ describe "Socket::BasicSocket#recv_nonblock" do
             client = @server.accept
 
             Thread.pass while !ready
-            client.recv_nonblock(10)
+            begin
+              client.recv_nonblock(10)
+            rescue IO::EAGAINWaitReadable
+              retry
+            end
           ensure
             client.close if client
           end
@@ -135,7 +138,6 @@ describe "Socket::BasicSocket#recv_nonblock" do
 
           t.value.should == ""
         end
-        end
       end
 
       ruby_version_is "3.3" do
@@ -146,7 +148,11 @@ describe "Socket::BasicSocket#recv_nonblock" do
             client = @server.accept
 
             Thread.pass while !ready
-            client.recv_nonblock(10)
+            begin
+              client.recv_nonblock(10)
+            rescue IO::EAGAINWaitReadable
+              retry
+            end
           ensure
             client.close if client
           end

--- a/spec/ruby/library/socket/basicsocket/recvmsg_nonblock_spec.rb
+++ b/spec/ruby/library/socket/basicsocket/recvmsg_nonblock_spec.rb
@@ -236,7 +236,6 @@ describe 'BasicSocket#recvmsg_nonblock' do
       end
 
       ruby_version_is ""..."3.3" do
-        quarantine! do # May fail with "IO::EAGAINWaitReadable: Resource temporarily unavailable - recvfrom(2) would block" error
         it "returns an empty String as received data on a closed stream socket" do
           ready = false
 
@@ -244,7 +243,11 @@ describe 'BasicSocket#recvmsg_nonblock' do
             client = @server.accept
 
             Thread.pass while !ready
-            client.recvmsg_nonblock(10)
+            begin
+              client.recvmsg_nonblock(10)
+            rescue IO::EAGAINWaitReadable
+              retry
+            end
           ensure
             client.close if client
           end
@@ -259,7 +262,6 @@ describe 'BasicSocket#recvmsg_nonblock' do
           t.value.should.is_a? Array
           t.value[0].should == ""
         end
-        end
       end
 
       ruby_version_is "3.3" do
@@ -271,7 +273,11 @@ describe 'BasicSocket#recvmsg_nonblock' do
               client = @server.accept
 
               Thread.pass while !ready
-              client.recvmsg_nonblock(10)
+              begin
+                client.recvmsg_nonblock(10)
+              rescue IO::EAGAINWaitReadable
+                retry
+              end
             ensure
               client.close if client
             end

--- a/spec/ruby/library/socket/socket/recvfrom_nonblock_spec.rb
+++ b/spec/ruby/library/socket/socket/recvfrom_nonblock_spec.rb
@@ -159,7 +159,6 @@ describe 'Socket#recvfrom_nonblock' do
       end
 
       ruby_version_is ""..."3.3" do
-        quarantine! do # May fail with "IO::EAGAINWaitReadable: Resource temporarily unavailable - recvfrom(2) would block" error
         it "returns an empty String as received data on a closed stream socket" do
           ready = false
 
@@ -167,7 +166,11 @@ describe 'Socket#recvfrom_nonblock' do
             client, _ = @server.accept
 
             Thread.pass while !ready
-            client.recvfrom_nonblock(10)
+            begin
+              client.recvfrom_nonblock(10)
+            rescue IO::EAGAINWaitReadable
+              retry
+            end
           ensure
             client.close if client
           end
@@ -182,11 +185,9 @@ describe 'Socket#recvfrom_nonblock' do
           t.value.should.is_a? Array
           t.value[0].should == ""
         end
-        end
       end
 
       ruby_version_is "3.3" do
-        quarantine! do # May fail with "IO::EAGAINWaitReadable: Resource temporarily unavailable - recvfrom(2) would block" error
         it "returns nil on a closed stream socket" do
           ready = false
 
@@ -194,7 +195,11 @@ describe 'Socket#recvfrom_nonblock' do
             client, _ = @server.accept
 
             Thread.pass while !ready
-            client.recvfrom_nonblock(10)
+            begin
+              client.recvfrom_nonblock(10)
+            rescue IO::EAGAINWaitReadable
+              retry
+            end
           ensure
             client.close if client
           end
@@ -207,7 +212,6 @@ describe 'Socket#recvfrom_nonblock' do
           ready = true
 
           t.value.should be_nil
-        end
         end
       end
     end


### PR DESCRIPTION
Changes:
- retry on IO::EAGAINWaitReadable when a closed socket is still not available for reading in ruby/specs

The issue was introduced recently in #12679. Socket non-blocking reading methods may raise `IO::EAGAINWaitReadable` even when a socket is already closed (in a concurrent thread).

Fixes issue https://bugs.ruby-lang.org/issues/21122