### PR TITLE
Add timeout to compilers workflow

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    timeout-minutes: 40
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -71,6 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    timeout-minutes: 40
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -98,6 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    timeout-minutes: 40
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -116,6 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    timeout-minutes: 40
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -136,6 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    timeout-minutes: 40
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -161,6 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    timeout-minutes: 40
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -180,6 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    timeout-minutes: 40
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -199,6 +206,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    timeout-minutes: 40
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -218,6 +226,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    timeout-minutes: 40
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -237,6 +246,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    timeout-minutes: 40
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -256,6 +266,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    timeout-minutes: 40
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -275,6 +286,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
+    timeout-minutes: 40
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0


### PR DESCRIPTION
The default timeout on GitHub Actions is 360 minutes, the job usually takes around 20 to 30 minutes to complete. This commit sets the timeout to be 40 minutes so jobs that hang will timeout faster.