### PR TITLE
PoC: Add option to use musttail in interpreter loop

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -978,7 +978,7 @@ rb_iseq_compile_node(rb_iseq_t *iseq, const NODE *node)
 static int
 rb_iseq_translate_threaded_code(rb_iseq_t *iseq)
 {
-#if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE
+#if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
     const void * const *table = rb_vm_get_insns_address_table();
     unsigned int i;
     VALUE *encoded = (VALUE *)ISEQ_BODY(iseq)->iseq_encoded;
@@ -1009,7 +1009,7 @@ rb_iseq_original_iseq(const rb_iseq_t *iseq) /* cold path */
     original_code = ISEQ_ORIGINAL_ISEQ_ALLOC(iseq, ISEQ_BODY(iseq)->iseq_size);
     MEMCPY(original_code, ISEQ_BODY(iseq)->iseq_encoded, VALUE, ISEQ_BODY(iseq)->iseq_size);
 
-#if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE
+#if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
     {
         unsigned int i;
 

--- a/insns.def
+++ b/insns.def
@@ -1136,7 +1136,7 @@ leave
     }
 
     if (vm_pop_frame(ec, GET_CFP(), GET_EP())) {
-#if OPT_CALL_THREADED_CODE
+#if OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
         rb_ec_thread_ptr(ec)->retval = val;
         return 0;
 #else
@@ -1659,7 +1659,7 @@ opt_invokebuiltin_delegate_leave
     /* leave fastpath */
     /* TracePoint/return fallbacks this insn to opt_invokebuiltin_delegate */
     if (vm_pop_frame(ec, GET_CFP(), GET_EP())) {
-#if OPT_CALL_THREADED_CODE
+#if OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
         rb_ec_thread_ptr(ec)->retval = val;
         return 0;
 #else

--- a/iseq.c
+++ b/iseq.c
@@ -3739,7 +3739,7 @@ rb_free_encoded_insn_data(void)
 void
 rb_vm_encoded_insn_data_table_init(void)
 {
-#if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE
+#if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
     const void * const *table = rb_vm_get_insns_address_table();
 #define INSN_CODE(insn) ((VALUE)table[insn])
 #else
@@ -3806,7 +3806,7 @@ rb_vm_insn_addr2opcode(const void *addr)
 int
 rb_vm_insn_decode(const VALUE encoded)
 {
-#if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE
+#if OPT_DIRECT_THREADED_CODE || OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
     int insn = rb_vm_insn_addr2insn((void *)encoded);
 #else
     int insn = (int)encoded;

--- a/vm.c
+++ b/vm.c
@@ -3658,7 +3658,7 @@ th_init(rb_thread_t *th, VALUE self, rb_vm_t *vm)
 
     th->ec->storage = Qnil;
 
-#if OPT_CALL_THREADED_CODE
+#if OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
     th->retval = Qundef;
 #endif
     th->name = Qnil;
@@ -4169,7 +4169,7 @@ Init_VM(void)
     rb_ary_push(opts, rb_str_new2("direct threaded code"));
 #elif OPT_TOKEN_THREADED_CODE
     rb_ary_push(opts, rb_str_new2("token threaded code"));
-#elif OPT_CALL_THREADED_CODE
+#elif OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
     rb_ary_push(opts, rb_str_new2("call threaded code"));
 #endif
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -202,7 +202,7 @@ void *rb_register_sigaltstack(void *);
 #endif
 
 /* call threaded code */
-#if    OPT_CALL_THREADED_CODE
+#if    OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
 #if    OPT_DIRECT_THREADED_CODE
 #undef OPT_DIRECT_THREADED_CODE
 #endif /* OPT_DIRECT_THREADED_CODE */
@@ -1144,7 +1144,7 @@ typedef struct rb_thread_struct {
     VALUE value;
 
     /* temporary place of retval on OPT_CALL_THREADED_CODE */
-#if OPT_CALL_THREADED_CODE
+#if OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
     VALUE retval;
 #endif
 

--- a/vm_exec.c
+++ b/vm_exec.c
@@ -40,7 +40,7 @@ static void vm_analysis_insn(int insn);
 #endif
 /* #define DECL_SC_REG(r, reg) VALUE reg_##r */
 
-#if !OPT_CALL_THREADED_CODE
+#if !OPT_CALL_THREADED_CODE && !OPT_TAILCALL_THREADED_CODE
 static VALUE
 vm_exec_core(rb_execution_context_t *ec)
 {
@@ -115,7 +115,7 @@ rb_vm_get_insns_address_table(void)
     return (const void **)vm_exec_core(0);
 }
 
-#else /* OPT_CALL_THREADED_CODE */
+#else /* OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE */
 
 #include "vm.inc"
 #include "vmtc.inc"

--- a/vm_exec.c
+++ b/vm_exec.c
@@ -132,6 +132,11 @@ vm_exec_core(rb_execution_context_t *ec)
     register rb_control_frame_t *reg_cfp = ec->cfp;
     rb_thread_t *th;
 
+#ifdef OPT_TAILCALL_THREADED_CODE
+    reg_cfp = ((rb_insn_tailcall_func_t *) (*GET_PC()))(INSN_FUNC_ARGS);
+
+    RUBY_ASSERT_ALWAYS(reg_cfp == 0);
+#else
     while (1) {
         reg_cfp = ((rb_insn_func_t) (*GET_PC()))(ec, reg_cfp);
 
@@ -139,6 +144,7 @@ vm_exec_core(rb_execution_context_t *ec)
             break;
         }
     }
+#endif
 
     if (!UNDEF_P((th = rb_ec_thread_ptr(ec))->retval)) {
         VALUE ret = th->retval;

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -72,8 +72,8 @@ error !
 #define LABEL_PTR(x) &LABEL(x)
 
 #define INSN_FUNC_RET rb_control_frame_t *
-#define INSN_FUNC_PARAMS rb_execution_context_t *ec, rb_control_frame_t *reg_cfp
-#define INSN_FUNC_ARGS ec, reg_cfp
+#define INSN_FUNC_PARAMS rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VALUE *reg_pc
+#define INSN_FUNC_ARGS ec, reg_cfp, reg_pc
 
 typedef INSN_FUNC_RET rb_insn_tailcall_func_t(INSN_FUNC_PARAMS);
 
@@ -91,7 +91,7 @@ typedef INSN_FUNC_RET rb_insn_tailcall_func_t(INSN_FUNC_PARAMS);
 #define NEXT_INSN() TC_DISPATCH(__NEXT_INSN__)
 
 #define START_OF_ORIGINAL_INSN(x) /* ignore */
-#define DISPATCH_ORIGINAL_INSN(x) return LABEL(x)(ec, reg_cfp);
+#define DISPATCH_ORIGINAL_INSN(x) MUSTTAIL return LABEL(x)(INSN_FUNC_ARGS);
 
 /************************************************/
 #elif OPT_TOKEN_THREADED_CODE || OPT_DIRECT_THREADED_CODE

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -40,7 +40,7 @@ typedef rb_iseq_t *ISEQ;
 #if defined(DISPATCH_XXX)
 error !
 /************************************************/
-#elif OPT_CALL_THREADED_CODE
+#elif OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
 
 #define LABEL(x)  insn_func_##x
 #define ELABEL(x)
@@ -156,7 +156,7 @@ default:                        \
 
 #define VM_SP_CNT(ec, sp) ((sp) - (ec)->vm_stack)
 
-#if OPT_CALL_THREADED_CODE
+#if OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
 #define THROW_EXCEPTION(exc) do { \
     ec->errinfo = (VALUE)(exc); \
     return 0; \

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -77,9 +77,12 @@ error !
 
 typedef INSN_FUNC_RET rb_insn_tailcall_func_t(INSN_FUNC_PARAMS);
 
+#define INSN_FUNC_ATTRIBUTES \
+    __attribute__((no_stack_protector))
+
 #define INSN_ENTRY(insn) \
   static INSN_FUNC_RET \
-    FUNC_FASTCALL(LABEL(insn))(INSN_FUNC_PARAMS) {
+    FUNC_FASTCALL(LABEL(insn))(INSN_FUNC_PARAMS) INSN_FUNC_ATTRIBUTES {
 
 #define TC_DISPATCH(insn) \
   MUSTTAIL return (*(rb_insn_tailcall_func_t *)GET_CURRENT_INSN())(INSN_FUNC_ARGS);

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -71,18 +71,33 @@ error !
 #define ELABEL(x)
 #define LABEL_PTR(x) &LABEL(x)
 
+#if defined __has_attribute
+#if __has_attribute (preserve_none)
+#define HAS_PRESERVE_NONE 1
+#endif
+#endif
+#ifndef HAS_PRESERVE_NONE
+#define HAS_PRESERVE_NONE 0
+#endif
+
+#if HAS_PRESERVE_NONE
+#define INSN_FUNC_CONV __attribute__((preserve_none))
+#else
+#define INSN_FUNC_CONV
+#endif
+
 #define INSN_FUNC_RET rb_control_frame_t *
 #define INSN_FUNC_PARAMS rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, const VALUE *reg_pc
 #define INSN_FUNC_ARGS ec, reg_cfp, reg_pc
 
-typedef INSN_FUNC_RET rb_insn_tailcall_func_t(INSN_FUNC_PARAMS);
+typedef INSN_FUNC_CONV INSN_FUNC_RET rb_insn_tailcall_func_t(INSN_FUNC_PARAMS);
 
 #define INSN_FUNC_ATTRIBUTES \
     __attribute__((no_stack_protector))
 
 #define INSN_ENTRY(insn) \
   static INSN_FUNC_RET \
-    FUNC_FASTCALL(LABEL(insn))(INSN_FUNC_PARAMS) INSN_FUNC_ATTRIBUTES {
+    INSN_FUNC_CONV FUNC_FASTCALL(LABEL(insn))(INSN_FUNC_PARAMS) INSN_FUNC_ATTRIBUTES {
 
 #define TC_DISPATCH(insn) \
   MUSTTAIL return (*(rb_insn_tailcall_func_t *)GET_CURRENT_INSN())(INSN_FUNC_ARGS);

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -40,7 +40,7 @@ typedef rb_iseq_t *ISEQ;
 #if defined(DISPATCH_XXX)
 error !
 /************************************************/
-#elif OPT_CALL_THREADED_CODE || OPT_TAILCALL_THREADED_CODE
+#elif OPT_CALL_THREADED_CODE
 
 #define LABEL(x)  insn_func_##x
 #define ELABEL(x)
@@ -53,6 +53,42 @@ error !
 #define END_INSN(insn) return reg_cfp;}
 
 #define NEXT_INSN() return reg_cfp;
+
+#define START_OF_ORIGINAL_INSN(x) /* ignore */
+#define DISPATCH_ORIGINAL_INSN(x) return LABEL(x)(ec, reg_cfp);
+
+/************************************************/
+#elif OPT_TAILCALL_THREADED_CODE
+
+// https://blog.reverberate.org/2021/04/21/musttail-efficient-interpreters.html
+// https://sillycross.github.io/2022/11/22/2022-11-22/
+// https://github.com/wasm3/wasm3/blob/main/docs/Interpreter.md#m3-massey-meta-machine
+
+// TODO: move elsewhere
+#define MUSTTAIL __attribute__((musttail))
+
+#define LABEL(x)  insn_func_##x
+#define ELABEL(x)
+#define LABEL_PTR(x) &LABEL(x)
+
+#define INSN_FUNC_RET rb_control_frame_t *
+#define INSN_FUNC_PARAMS rb_execution_context_t *ec, rb_control_frame_t *reg_cfp
+#define INSN_FUNC_ARGS ec, reg_cfp
+
+typedef INSN_FUNC_RET rb_insn_tailcall_func_t(INSN_FUNC_PARAMS);
+
+#define INSN_ENTRY(insn) \
+  static INSN_FUNC_RET \
+    FUNC_FASTCALL(LABEL(insn))(INSN_FUNC_PARAMS) {
+
+#define TC_DISPATCH(insn) \
+  MUSTTAIL return (*(rb_insn_tailcall_func_t *)GET_CURRENT_INSN())(INSN_FUNC_ARGS);
+
+//#define END_INSN(insn) return reg_cfp;}
+#define END_INSN(insn) TC_DISPATCH(__NEXT_INSN__);}
+
+//#define NEXT_INSN() return reg_cfp;
+#define NEXT_INSN() TC_DISPATCH(__NEXT_INSN__)
 
 #define START_OF_ORIGINAL_INSN(x) /* ignore */
 #define DISPATCH_ORIGINAL_INSN(x) return LABEL(x)(ec, reg_cfp);

--- a/vm_opts.h
+++ b/vm_opts.h
@@ -32,14 +32,16 @@
  * 0: direct (using labeled goto using GCC special)
  * 1: token (switch/case)
  * 2: call (function call for each insn dispatch)
+ * 3: call continuation (musttail attribute)
  */
 #ifndef OPT_THREADED_CODE
-#define OPT_THREADED_CODE 0
+#define OPT_THREADED_CODE 3
 #endif
 
-#define OPT_DIRECT_THREADED_CODE (OPT_THREADED_CODE == 0)
-#define OPT_TOKEN_THREADED_CODE  (OPT_THREADED_CODE == 1)
-#define OPT_CALL_THREADED_CODE   (OPT_THREADED_CODE == 2)
+#define OPT_DIRECT_THREADED_CODE   (OPT_THREADED_CODE == 0)
+#define OPT_TOKEN_THREADED_CODE    (OPT_THREADED_CODE == 1)
+#define OPT_CALL_THREADED_CODE     (OPT_THREADED_CODE == 2)
+#define OPT_TAILCALL_THREADED_CODE (OPT_THREADED_CODE == 3)
 
 /* VM running option */
 #define OPT_CHECKED_RUN              1

--- a/vm_opts.h
+++ b/vm_opts.h
@@ -34,9 +34,9 @@
  * 2: call (function call for each insn dispatch)
  * 3: call continuation (musttail attribute)
  */
-#ifndef OPT_THREADED_CODE
+//#ifndef OPT_THREADED_CODE
 #define OPT_THREADED_CODE 3
-#endif
+//#endif
 
 #define OPT_DIRECT_THREADED_CODE   (OPT_THREADED_CODE == 0)
 #define OPT_TOKEN_THREADED_CODE    (OPT_THREADED_CODE == 1)


### PR DESCRIPTION
This adds a compile-time option, `OPT_TAILCALL_THREADED_CODE`, to use musttail for threading in the VM loop.

This works best with the latest LLVM, though the latest GCC also has musttail.

This also attempts to use `__attribute__((preserve_none))` when available (LLVM 19 or so?). This changes the calling convention of the instruction methods to save all registers and use what would normally be callee-saved registers to pass arguments. This significantly reduces pushing and popping when we end up calling non-tailcall methods from our VM instructions (which is pretty common for us).

(I will make benchmarks before more seriously proposing merging this)

Aside from performance a thing I really like about this is that profilers (like linux perf) are able to show the VM instructions we're spending time inside. It also allows using objdump to print out the source for individual instructions, which is much easier to read.

```
❯ llvm-objdump -d --symbolize-operands --x86-asm-syntax=intel --no-show-raw-insn --no-leading-addr --disassemble-symbols=insn_func_pop -S ./miniruby

./miniruby:     file format elf64-x86-64

Disassembly of section .text:

<insn_func_pop>:
;     ADD_PC(INSN_ATTR(width));
                lea     rax, [r14 + 0x8]
                mov     qword ptr [r13], rax
;     COLLECT_USAGE_INSN(INSN_ATTR(bin));
                inc     qword ptr fs:[-0x18]
;     INC_SP(INSN_ATTR(sp_inc));
                add     qword ptr [r13 + 0x8], -0x8
;     END_INSN(pop);
                mov     rcx, qword ptr [r14 + 0x8]
                mov     r14, rax
                jmp     rcx
                nop
```