### PR TITLE
Remove rb_enc_associate for Parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -138,12 +138,6 @@ utf8_encoding(void)
     return rb_utf8_encoding();
 }
 
-static VALUE
-enc_associate(VALUE obj, parser_encoding *enc)
-{
-    return rb_enc_associate(obj, enc);
-}
-
 static parser_encoding *
 ascii8bit_encoding(void)
 {
@@ -390,7 +384,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .enc_get = enc_get,
     .enc_asciicompat = enc_asciicompat,
     .utf8_encoding = utf8_encoding,
-    .enc_associate = enc_associate,
     .ascii8bit_encoding = ascii8bit_encoding,
     .enc_codelen = enc_codelen,
     .enc_mbcput = enc_mbcput,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1286,7 +1286,6 @@ typedef struct rb_parser_config_struct {
     rb_encoding* (*enc_get)(VALUE obj);
     int (*enc_asciicompat)(rb_encoding *enc);
     rb_encoding *(*utf8_encoding)(void);
-    VALUE (*enc_associate)(VALUE obj, rb_encoding *enc);
     rb_encoding *(*ascii8bit_encoding)(void);
     int (*enc_codelen)(int c, rb_encoding *enc);
     int (*enc_mbcput)(unsigned int c, void *buf, rb_encoding *enc);

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -147,7 +147,6 @@
 #define rb_enc_get              p->config->enc_get
 #define rb_enc_asciicompat      p->config->enc_asciicompat
 #define rb_utf8_encoding        p->config->utf8_encoding
-#define rb_enc_associate        p->config->enc_associate
 #define rb_ascii8bit_encoding   p->config->ascii8bit_encoding
 #define rb_enc_codelen          p->config->enc_codelen
 #define rb_enc_mbcput           p->config->enc_mbcput


### PR DESCRIPTION
Ruby Parser not used rb_enc_associate .
And enc_associate property can be removed from Universal Parser.