### PR TITLE
Remove rb_reg_check_preprocessfor Parser

### DIFF
--- a/ruby_parser.c
+++ b/ruby_parser.c
@@ -420,7 +420,6 @@ static const rb_parser_config_t rb_global_parser_config = {
     .gc_mark = rb_gc_mark,
 
     .reg_compile = rb_reg_compile,
-    .reg_check_preprocess = rb_reg_check_preprocess,
     .memcicmp = rb_memcicmp,
 
     .compile_warn = rb_compile_warn,

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1323,7 +1323,6 @@ typedef struct rb_parser_config_struct {
 
     /* Re */
     VALUE (*reg_compile)(VALUE str, int options, const char *sourcefile, int sourceline);
-    VALUE (*reg_check_preprocess)(VALUE str);
     int (*memcicmp)(const void *x, const void *y, long len);
 
     /* Error */

--- a/universal_parser.c
+++ b/universal_parser.c
@@ -175,7 +175,6 @@
 #define rb_gc_mark p->config->gc_mark
 
 #define rb_reg_compile          p->config->reg_compile
-#define rb_reg_check_preprocess p->config->reg_check_preprocess
 #define rb_memcicmp p->config->memcicmp
 
 #define rb_compile_warn    p->config->compile_warn


### PR DESCRIPTION
Ruby Parser not used rb_reg_check_preprocess.
And reg_check_preprocess property can be removed from Universal Parser.