### PR TITLE
[Feature #21126] Drop default and default_proc on Hash#freeze

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -107,6 +107,11 @@ static VALUE rb_hash_s_try_convert(VALUE, VALUE);
 VALUE
 rb_hash_freeze(VALUE hash)
 {
+    if (!RB_OBJ_FROZEN(hash)) {
+        // Drop default and default proc
+        rb_hash_set_default_proc(hash, Qnil);
+    }
+
     return rb_obj_freeze(hash);
 }
 

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -308,6 +308,13 @@ class TestHash < Test::Unit::TestCase
     assert_equal(:xyzzy, @h.default)
   end
 
+  def test_default_after_freeze
+    assert_nil(@h.default)
+    h = @cls.new(:xyzzy)
+    h.freeze
+    assert_equal(nil, h.default)
+  end
+
   def test_delete
     h1 = @cls[ 1 => 'one', 2 => 'two', true => 'true' ]
     h2 = @cls[ 1 => 'one', 2 => 'two' ]
@@ -965,6 +972,12 @@ class TestHash < Test::Unit::TestCase
     assert_equal(true, h[:nope])
     h = @cls[]
     assert_nil(h.default_proc)
+  end
+
+  def test_default_proc_after_freeze
+    h = @cls.new {|hh, k| hh + k + "baz" }
+    h.freeze
+    assert_equal(nil, h.default_proc)
   end
 
   def test_shift2


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21126

Let Hash#freeze drop `default` and `default_proc` set on the Hash instance. They will not be used as the default value after the hash gets frozen and immutable.

This change allows frozen Hash instances to be sent/moved across Ractors, even if they got initialized with a default_proc.

The following code shall now be valid:

```ruby
h = Hash.new {|h, k| h[k] = [] }
h[:foo] << 1
h.freeze
Ractor.new(h) {|h| p h }.take
```