### PR TITLE
gc.c: Remove no-op code

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2404,7 +2404,6 @@ newobj_cache_miss(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache, size
 
     if (!vm_locked) {
         lev = rb_gc_cr_lock();
-        vm_locked = true;
         unlock_vm = true;
     }
 


### PR DESCRIPTION
In this context, `vm_locked` is a argument variable, and is not used later in the function.