### PR TITLE
Launchable: Add a workflow name as a flavor

### DIFF
--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -162,6 +162,7 @@ runs:
             --flavor os=${{ inputs.os }} \
             --flavor test_task=${{ inputs.test-task }} \
             --flavor test_opts=${test_opts} \
+            --flavor workflow=${{ github.workflow }} \
             --test-suite ${test_all_test_suite} \
             > "${test_all_session_file}"
           launchable subset \
@@ -179,6 +180,7 @@ runs:
             --flavor os=${{ inputs.os }} \
             --flavor test_task=${{ inputs.test-task }} \
             --flavor test_opts=${test_opts} \
+            --flavor workflow=${{ github.workflow }} \
             --test-suite ${btest_test_suite} \
             > "${btest_session_file}"
           launchable subset \
@@ -196,6 +198,7 @@ runs:
             --flavor os=${{ inputs.os }} \
             --flavor test_task=${{ inputs.test-task }} \
             --flavor test_opts=${test_opts} \
+            --flavor workflow=${{ github.workflow }} \
             --test-suite ${test_spec_test_suite} \
             > "${test_spec_session_file}"
           launchable subset \


### PR DESCRIPTION
Adding a workflow name would be easier to understand the connection between a test session and GitHub workflow.

## Before
![Screenshot 2025-02-10 at 16 52 13](https://github.com/user-attachments/assets/a9093d19-9d56-4dec-bd09-b9a717355aac)

## After
![Screenshot 2025-02-10 at 16 52 46](https://github.com/user-attachments/assets/4bf430f1-7217-4d35-9f9c-26fea136ec83)

