### PR TITLE
Do not overwrite `GEM_PATH` if already set

### DIFF
--- a/ruby-runner.c
+++ b/ruby-runner.c
@@ -84,9 +84,11 @@ main(int argc, char **argv)
     insert_env_path(LIBPATHENV, builddir, dirsize, 1);
     insert_env_path("RUBYLIB", rubylib, sizeof(rubylib), 0);
 
-    insert_env_path_lit("GEM_PATH", ABS_SRCDIR"/.bundle", 1);
-    insert_env_path_lit("GEM_PATH", BUILDDIR"/.bundle", 1);
-    if (!getenv("GEM_HOME")) setenv("GEM_HOME", ABS_SRCDIR"/.bundle", 1);
+    if (!getenv("GEM_PATH")) {
+        insert_env_path_lit("GEM_PATH", ABS_SRCDIR"/.bundle", 1);
+        insert_env_path_lit("GEM_PATH", BUILDDIR"/.bundle", 1);
+        setenv("GEM_HOME", BUILDDIR"/.bundle", 0);
+    }
 
     if (!(p = strrchr(arg0, '/'))) p = arg0; else p++;
     if (strlen(p) < namesize - 1) {


### PR DESCRIPTION
The bundler's test sets the `GEM_PATH` and `GEM_HOME` environment variables by itself.  Overwriting them results in tons of errors.