### PR TITLE
Set MMTK_HEAP_MIN to 100MiB on CI

### DIFF
--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -111,6 +111,7 @@ jobs:
         run: |
           echo 'EXCLUDES=../src/test/.excludes-mmtk' >> $GITHUB_ENV
           echo 'MSPECOPT=-B../src/spec/mmtk.mspec' >> $GITHUB_ENV
+          echo 'MMTK_HEAP_MIN=100MiB' >> $GITHUB_ENV
         if: ${{ matrix.gc.name == 'mmtk' }}
 
       - run: $SETARCH make


### PR DESCRIPTION
Setting MMTK_HEAP_MIN to a larger size may prevent GC thrashing in CI and improve performance.