### PR TITLE
Limit MMTK threads to 2 in CI

### DIFF
--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -111,6 +111,7 @@ jobs:
         run: |
           echo 'EXCLUDES=../src/test/.excludes-mmtk' >> $GITHUB_ENV
           echo 'MSPECOPT=-B../src/spec/mmtk.mspec' >> $GITHUB_ENV
+          echo 'MMTK_THREADS=2' >> $GITHUB_ENV
         if: ${{ matrix.gc.name == 'mmtk' }}
 
       - run: $SETARCH make


### PR DESCRIPTION
By default, MMTK uses threads equal to the number of cores. This may cause poor performance when we run tests in parallel.