### PR TITLE
Always return jit_entry even if NULL

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -435,12 +435,9 @@ jit_compile(rb_execution_context_t *ec)
     const rb_iseq_t *iseq = ec->cfp->iseq;
     struct rb_iseq_constant_body *body = ISEQ_BODY(iseq);
     bool yjit_enabled = rb_yjit_enabled_p;
-    if (!(yjit_enabled || rb_rjit_call_p)) {
-        return NULL;
-    }
 
     // Increment the ISEQ's call counter and trigger JIT compilation if not compiled
-    if (body->jit_entry == NULL) {
+    if (body->jit_entry == NULL && (yjit_enabled || rb_rjit_call_p)) {
         body->jit_entry_calls++;
         if (yjit_enabled) {
             if (rb_yjit_threshold_hit(iseq, body->jit_entry_calls)) {


### PR DESCRIPTION
We can just always return the jit_entry since it will be initialized to NULL.  There is no reason to specifically return NULL if yjit / rjit are disabled