### PR TITLE
Bump net-imap to 0.4.19 for Ruby 3.3 (CVE-2025-25186)

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -12,7 +12,7 @@ test-unit       3.6.1   https://github.com/test-unit/test-unit
 rexml           3.3.9   https://github.com/ruby/rexml
 rss             0.3.1   https://github.com/ruby/rss
 net-ftp         0.3.4   https://github.com/ruby/net-ftp
-net-imap        0.4.9.1   https://github.com/ruby/net-imap
+net-imap        0.4.19  https://github.com/ruby/net-imap
 net-pop         0.1.2   https://github.com/ruby/net-pop
 net-smtp        0.5.1   https://github.com/ruby/net-smtp
 matrix          0.4.2   https://github.com/ruby/matrix


### PR DESCRIPTION
This update addresses CVE-2025-25186 (GHSA-7fc5-f82f-cx69).