### PR TITLE
[Bug #21128] Include fcntl.h before checking for O_CLOEXEC

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -22,10 +22,6 @@
 #include <unistd.h>
 #endif
 
-#ifndef O_CLOEXEC
-#  define O_CLOEXEC 0
-#endif
-
 #ifndef USE_OPENDIR_AT
 # if defined(HAVE_FDOPENDIR) && defined(HAVE_DIRFD) && \
     defined(HAVE_OPENAT) && defined(HAVE_FSTATAT)
@@ -35,8 +31,12 @@
 # endif
 #endif
 
-#if USE_OPENDIR_AT
-# include <fcntl.h>
+#ifdef HAVE_FCNTL_H
+#  include <fcntl.h>
+#endif
+
+#ifndef O_CLOEXEC
+#  define O_CLOEXEC 0
 #endif
 
 #undef HAVE_DIRENT_NAMLEN


### PR DESCRIPTION
On glibc O_CLOEXEC is defined in fcntl.h and not unistd.h so this change prevents the macro from being redefined.