### PR TITLE
Fix description comment typo

### DIFF
--- a/gc.rb
+++ b/gc.rb
@@ -307,7 +307,7 @@ module GC
   #
   #   A flag will be set to notify that a full mark has been
   #   requested. This flag is accessible using
-  #   <code>GC.latest_gc_info(:needs_major_by)</code>
+  #   <code>GC.latest_gc_info(:need_major_by)</code>
   #
   #   The user can trigger a major collection at any time using
   #   <code>GC.start(full_mark: true)</code>


### PR DESCRIPTION
Typo in description

```
> irb                                                                                                                                                                                                                                                                             
3.4.1 :001 > GC.latest_gc_info(:need_major_by)
 => nil
3.4.1 :002 > GC.latest_gc_info(:needs_major_by)
<internal:gc>:353:in 'GC.latest_gc_info': unknown key: needs_major_by (ArgumentError)
```