### PR TITLE
tool/downloader.rb: Stop caching already existing files

### DIFF
--- a/tool/downloader.rb
+++ b/tool/downloader.rb
@@ -213,9 +213,6 @@ class Downloader
         $stdout.puts "#{file} already exists"
         $stdout.flush
       end
-      if cache_save
-        save_cache(cache, file, name)
-      end
       return file.to_path
     end
     if dryrun


### PR DESCRIPTION
Previously, the script was caching any file already present in the destination directory, regardless of its origin. This caused issues when the directory contained files copied from external sources like `autoreconf --install`.

For example:
1. `./autogen.sh --install` copies `config.guess` and `config.sub` from the system to `./tool`.
2. `ruby tool/downloader.rb -d tool -e gnu config.guess config.sub` treats those files as if they were downloaded and caches them.
3. Removing the files: `rm tool/config.guess tool/config.sub`.
4. Running the downloader again, it mistakenly restores the cached files instead of downloading fresh versions.