### PR TITLE
[backport for 3.4.x] YJIT: Initialize locals in ISeqs defined with `...`

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -8068,7 +8068,6 @@ fn gen_send_iseq(
         }
     }
 
-    // Don't nil fill forwarding iseqs
     if !forwarding {
         // Nil-initialize missing optional parameters
         nil_fill(
@@ -8103,9 +8102,13 @@ fn gen_send_iseq(
         assert_eq!(1, num_params);
         // Write the CI in to the stack and ensure that it actually gets
         // flushed to memory
+        asm_comment!(asm, "put call info for forwarding");
         let ci_opnd = asm.stack_opnd(-1);
         asm.ctx.dealloc_reg(ci_opnd.reg_opnd());
         asm.mov(ci_opnd, VALUE(ci as usize).into());
+
+        // Nil-initialize other locals which are above the CI
+        nil_fill("nil-initialize locals", 1..num_locals, asm);
     }
 
     // Points to the receiver operand on the stack unless a captured environment is used


### PR DESCRIPTION
Backport of GH-12660:

    Previously, callers of forwardable ISeqs moved the stack pointer up
    without writing to the stack. If there happens to be a stale value in
    the area skipped over, it could crash due to "try to mark T_NONE". Also,
    the uninitialized local variables were observable through `binding`.

    Initialize the locals to nil.

    [Bug #21021]
