### PR TITLE
Document order of execution const_added vs inherited

### DIFF
--- a/object.c
+++ b/object.c
@@ -1193,6 +1193,30 @@ rb_class_search_ancestor(VALUE cl, VALUE c)
  *
  *   Added :FOO
  *
+ * If we define a class using the <tt>class</tt> keyword, <tt>const_added</tt>
+ * runs before <tt>inherited</tt>:
+ *
+ *   module M
+ *     def self.const_added(const_name)
+ *       super
+ *       p :const_added
+ *     end
+ *
+ *     parent = Class.new do
+ *       def self.inherited(subclass)
+ *         super
+ *         p :inherited
+ *       end
+ *     end
+ *
+ *     class Child < parent
+ *     end
+ *   end
+ *
+ * <em>produces:</em>
+ *
+ *   :const_added
+ *   :inherited
  */
 #define rb_obj_mod_const_added rb_obj_dummy1
 

--- a/spec/ruby/core/module/const_added_spec.rb
+++ b/spec/ruby/core/module/const_added_spec.rb
@@ -199,5 +199,25 @@ describe "Module#const_added" do
 
       ScratchPad.recorded.should == [123, 456]
     end
+
+    it "for a class defined with the `class` keyword, const_added runs before inherited" do
+      ScratchPad.record []
+
+      mod = Module.new do
+        def self.const_added(_)
+          ScratchPad << :const_added
+        end
+      end
+
+      parent = Class.new do
+        def self.inherited(_)
+          ScratchPad << :inherited
+        end
+      end
+
+      class mod::C < parent; end
+
+      ScratchPad.recorded.should == [:const_added, :inherited]
+    end
   end
 end


### PR DESCRIPTION
I don't have a real use where this matters, but thought perhaps you'd like to document the order of execution here.

If it was preferred to leave this unspecified, then I could redo the patch to say so.

What do you think?

/cc @byroot 