### PR TITLE
Remove undefined function from bindgen

### DIFF
--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -421,7 +421,6 @@ fn main() {
         .allowlist_function("rb_get_def_iseq_ptr")
         .allowlist_function("rb_get_def_bmethod_proc")
         .allowlist_function("rb_iseq_encoded_size")
-        .allowlist_function("rb_get_iseq_body_total_calls")
         .allowlist_function("rb_get_iseq_body_local_iseq")
         .allowlist_function("rb_get_iseq_body_parent_iseq")
         .allowlist_function("rb_get_iseq_body_iseq_encoded")


### PR DESCRIPTION
`rb_get_iseq_body_total_calls` was removed in cd8d20cd1fbcf9bf9d438b306beb65b2417fcc04, but it's still in the YJIT bindgen file.  This commit just removes it from bindgen