### PR TITLE
Check programs for CC in the same path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -208,7 +208,7 @@ AC_ARG_VAR([STRIP],    [Strip command])
 set rb_dummy ${CC}
 rb_CC=$2
 AC_DEFUN([RUBY_CHECK_PROG_FOR_CC], [
-    rb_prog=`echo "${rb_CC}" | sed "$2"`
+    rb_prog=`echo "${rb_CC}" | sed ["s:$2\([^/]*\)$:$3\1:"]`
     AC_CHECK_PROG([$1], [$rb_prog], [$rb_prog])
 ])
 AS_CASE(["/${rb_CC} "],
@@ -219,17 +219,17 @@ AS_CASE(["/${rb_CC} "],
 [*icc*],              [
     # Intel C++ has interprocedural optimizations.  It tends to come with its
     # own linker etc.
-    RUBY_CHECK_PROG_FOR_CC([AR],      [s/icc/xiar/])
-    RUBY_CHECK_PROG_FOR_CC([CXX],     [s/icc/icpc/])
-    RUBY_CHECK_PROG_FOR_CC([LD],      [s/icc/xild/])
+    RUBY_CHECK_PROG_FOR_CC([AR],      [icc], [xiar])
+    RUBY_CHECK_PROG_FOR_CC([CXX],     [icc], [icpc])
+    RUBY_CHECK_PROG_FOR_CC([LD],      [icc], [xild])
 ],
 [*gcc*],              [
     # Ditto for GCC.
-    RUBY_CHECK_PROG_FOR_CC([LD],      [s/gcc/ld/])
-    RUBY_CHECK_PROG_FOR_CC([AR],      [s/gcc/gcc-ar/])
-    RUBY_CHECK_PROG_FOR_CC([CXX],     [s/gcc/g++/])
-    RUBY_CHECK_PROG_FOR_CC([NM],      [s/gcc/gcc-nm/])
-    RUBY_CHECK_PROG_FOR_CC([RANLIB],  [s/gcc/gcc-ranlib/])
+    RUBY_CHECK_PROG_FOR_CC([LD],      [gcc], [ld])
+    RUBY_CHECK_PROG_FOR_CC([AR],      [gcc], [gcc-ar])
+    RUBY_CHECK_PROG_FOR_CC([CXX],     [gcc], [g++])
+    RUBY_CHECK_PROG_FOR_CC([NM],      [gcc], [gcc-nm])
+    RUBY_CHECK_PROG_FOR_CC([RANLIB],  [gcc], [gcc-ranlib])
 ],
 [*clang*],            [
     # Ditto for LLVM.  Note however that llvm-as is a LLVM-IR to LLVM bitcode
@@ -242,15 +242,15 @@ AS_CASE(["/${rb_CC} "],
           [llvm_prefix=], [llvm_prefix=llvm-])
     # AC_PREPROC_IFELSE cannot be used before AC_USE_SYSTEM_EXTENSIONS
 
-    RUBY_CHECK_PROG_FOR_CC([LD],      [s/clang/ld/]) # ... maybe try lld ?
-    RUBY_CHECK_PROG_FOR_CC([AR],      [s/clang/${llvm_prefix}ar/])
-#   RUBY_CHECK_PROG_FOR_CC([AS],      [s/clang/${llvm_prefix}as/])
-    RUBY_CHECK_PROG_FOR_CC([CXX],     [s/clang/clang++/])
-    RUBY_CHECK_PROG_FOR_CC([NM],      [s/clang/${llvm_prefix}nm/])
-    RUBY_CHECK_PROG_FOR_CC([OBJCOPY], [s/clang/${llvm_prefix}objcopy/])
-    RUBY_CHECK_PROG_FOR_CC([OBJDUMP], [s/clang/${llvm_prefix}objdump/])
-    RUBY_CHECK_PROG_FOR_CC([RANLIB],  [s/clang/${llvm_prefix}ranlib/])
-    RUBY_CHECK_PROG_FOR_CC([STRIP],   [s/clang/${llvm_prefix}strip/])
+    RUBY_CHECK_PROG_FOR_CC([LD],      [clang], [ld]) # ... maybe try lld ?
+    RUBY_CHECK_PROG_FOR_CC([AR],      [clang], [${llvm_prefix}ar])
+#   RUBY_CHECK_PROG_FOR_CC([AS],      [clang], [${llvm_prefix}as])
+    RUBY_CHECK_PROG_FOR_CC([CXX],     [clang], [clang++])
+    RUBY_CHECK_PROG_FOR_CC([NM],      [clang], [${llvm_prefix}nm])
+    RUBY_CHECK_PROG_FOR_CC([OBJCOPY], [clang], [${llvm_prefix}objcopy])
+    RUBY_CHECK_PROG_FOR_CC([OBJDUMP], [clang], [${llvm_prefix}objdump])
+    RUBY_CHECK_PROG_FOR_CC([RANLIB],  [clang], [${llvm_prefix}ranlib])
+    RUBY_CHECK_PROG_FOR_CC([STRIP],   [clang], [${llvm_prefix}strip])
 ])
 AS_UNSET(rb_CC)
 AS_UNSET(rb_dummy)


### PR DESCRIPTION
When the path of `CC` contains the target program name, e.g., clang, the replaced program names were unexpected.  Replace basename part only.