### PR TITLE
Tweak: Add prefix to non-static function names

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -1217,8 +1217,8 @@ rsock_init_inetsock(VALUE self, VALUE remote_host, VALUE remote_serv, VALUE loca
         char *hostp, *portp;
         char hbuf[NI_MAXHOST], pbuf[NI_MAXSERV];
         int additional_flags = 0;
-        hostp = host_str(remote_host, hbuf, sizeof(hbuf), &additional_flags);
-        portp = port_str(remote_serv, pbuf, sizeof(pbuf), &additional_flags);
+        hostp = raddrinfo_host_str(remote_host, hbuf, sizeof(hbuf), &additional_flags);
+        portp = raddrinfo_port_str(remote_serv, pbuf, sizeof(pbuf), &additional_flags);
 
         if (!is_specified_ip_address(hostp)) {
             int target_families[2] = { 0, 0 };

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -823,7 +823,7 @@ str_is_number(const char *p)
      rb_strlen_lit(name) == (len) && memcmp(ptr, name, len) == 0)
 
 char*
-host_str(VALUE host, char *hbuf, size_t hbuflen, int *flags_ptr)
+raddrinfo_host_str(VALUE host, char *hbuf, size_t hbuflen, int *flags_ptr)
 {
     if (NIL_P(host)) {
         return NULL;
@@ -862,7 +862,7 @@ host_str(VALUE host, char *hbuf, size_t hbuflen, int *flags_ptr)
 }
 
 char*
-port_str(VALUE port, char *pbuf, size_t pbuflen, int *flags_ptr)
+raddrinfo_port_str(VALUE port, char *pbuf, size_t pbuflen, int *flags_ptr)
 {
     if (NIL_P(port)) {
         return 0;
@@ -914,7 +914,7 @@ rb_scheduler_getaddrinfo(VALUE scheduler, VALUE host, const char *service,
 
     for(i=0; i<len; i++) {
         ip_address = rb_ary_entry(ip_addresses_array, i);
-        hostp = host_str(ip_address, _hbuf, sizeof(_hbuf), &_additional_flags);
+        hostp = raddrinfo_host_str(ip_address, _hbuf, sizeof(_hbuf), &_additional_flags);
         error = numeric_getaddrinfo(hostp, service, hints, &ai);
         if (error == 0) {
             if (!res_allocated) {
@@ -950,8 +950,8 @@ rsock_getaddrinfo(VALUE host, VALUE port, struct addrinfo *hints, int socktype_h
     char hbuf[NI_MAXHOST], pbuf[NI_MAXSERV];
     int additional_flags = 0;
 
-    hostp = host_str(host, hbuf, sizeof(hbuf), &additional_flags);
-    portp = port_str(port, pbuf, sizeof(pbuf), &additional_flags);
+    hostp = raddrinfo_host_str(host, hbuf, sizeof(hbuf), &additional_flags);
+    portp = raddrinfo_port_str(port, pbuf, sizeof(pbuf), &additional_flags);
 
     if (socktype_hack && hints->ai_socktype == 0 && str_is_number(portp)) {
         hints->ai_socktype = SOCK_DGRAM;
@@ -1137,7 +1137,7 @@ make_hostent_internal(VALUE v)
         hostp = addr->ai_canonname;
     }
     else {
-        hostp = host_str(host, hbuf, sizeof(hbuf), NULL);
+        hostp = raddrinfo_host_str(host, hbuf, sizeof(hbuf), NULL);
     }
     rb_ary_push(ary, rb_str_new2(hostp));
 

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -414,8 +414,8 @@ ssize_t rsock_recvmsg(int socket, struct msghdr *message, int flags);
 void rsock_discard_cmsg_resource(struct msghdr *mh, int msg_peek_p);
 #endif
 
-char *host_str(VALUE host, char *hbuf, size_t hbuflen, int *flags_ptr);
-char *port_str(VALUE port, char *pbuf, size_t pbuflen, int *flags_ptr);
+char *raddrinfo_host_str(VALUE host, char *hbuf, size_t hbuflen, int *flags_ptr);
+char *raddrinfo_port_str(VALUE port, char *pbuf, size_t pbuflen, int *flags_ptr);
 
 #ifndef FAST_FALLBACK_INIT_INETSOCK_IMPL
 #  if !defined(HAVE_PTHREAD_CREATE) || !defined(HAVE_PTHREAD_DETACH) || defined(__MINGW32__) || defined(__MINGW64__)


### PR DESCRIPTION
to avoid conflicts with other functions.
This was pointed out in https://github.com/ruby/ruby/pull/11653#discussion_r1837356617 , but it was not fixed at that time.