### PR TITLE
Ensure IO.copy_stream buffer is an independent string

### DIFF
--- a/io.c
+++ b/io.c
@@ -13139,6 +13139,7 @@ copy_stream_fallback_body(VALUE arg)
     while (1) {
         long numwrote;
         long l;
+        rb_str_make_independent(buf);
         if (stp->copy_length < (rb_off_t)0) {
             l = buflen;
         }


### PR DESCRIPTION
Otherwise, changes to the buffer by the destination write method could result in data changing for supposedly independent strings.

Fixes [Bug #21131]