### PR TITLE
[wasm] Stop using mprotect(PROT_NONE) on WASI

### DIFF
--- a/cont.c
+++ b/cont.c
@@ -551,6 +551,9 @@ fiber_pool_expand(struct fiber_pool * fiber_pool, size_t count)
             VirtualFree(allocation->base, 0, MEM_RELEASE);
             rb_raise(rb_eFiberError, "can't set a guard page: %s", ERRNOMSG);
         }
+#elif defined(__wasi__)
+        // wasi-libc's mprotect emulation doesn't support PROT_NONE.
+        (void)page;
 #else
         if (mprotect(page, RB_PAGE_SIZE, PROT_NONE) < 0) {
             munmap(allocation->base, count*stride);

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -3199,6 +3199,10 @@ protect_page_body(struct heap_page_body *body, DWORD protect)
     DWORD old_protect;
     return VirtualProtect(body, HEAP_PAGE_SIZE, protect, &old_protect) != 0;
 }
+#elif defined(__wasi__)
+// wasi-libc's mprotect emulation does not support PROT_NONE
+enum {HEAP_PAGE_LOCK, HEAP_PAGE_UNLOCK};
+#define protect_page_body(body, protect) 1
 #else
 enum {HEAP_PAGE_LOCK = PROT_NONE, HEAP_PAGE_UNLOCK = PROT_READ | PROT_WRITE};
 #define protect_page_body(body, protect) !mprotect((body), HEAP_PAGE_SIZE, (protect))

--- a/wasm/missing.c
+++ b/wasm/missing.c
@@ -121,13 +121,6 @@ umask(rb_mode_t mask)
 
 WASM_MISSING_LIBC_FUNC
 int
-mprotect(const void *addr, size_t len, int prot)
-{
-    return 0;
-}
-
-WASM_MISSING_LIBC_FUNC
-int
 pclose(FILE *stream)
 {
     errno = ENOTSUP;


### PR DESCRIPTION
we had been using a stub weak definition of `mprotect` in wasm/missing.c so far, but wasi-sdk 23 added mprotect emulation to wasi-libc[^1], so the emulation is now linked instead. However, the emulation doesn't support PROT_NONE and fails with ENOSYS, so we need to avoid calling mprotect completely on WASI.

[^1]: https://github.com/WebAssembly/wasi-libc/commit/7528b13170462c82e367d91ae0ecead84e470ceb