### PR TITLE
Launchable: Send stdout and stderr

### DIFF
--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -247,6 +247,10 @@ runs:
           mkdir "${test_spec_report_path}"
           echo test_spec_report_path="${test_spec_report_path}" >> $GITHUB_OUTPUT
         fi
+        stdout_report_path="${dir}${builddir:+${builddir}/}launchable_stdout.log"
+        stderr_report_path="${dir}${builddir:+${builddir}/}launchable_stderr.log"
+        echo stdout_report_path="${stdout_report_path}" >> $GITHUB_OUTPUT
+        echo stderr_report_path="${stderr_report_path}" >> $GITHUB_OUTPUT
       if: steps.enable-launchable.outputs.enable-launchable
       env:
         srcdir: ${{ inputs.srcdir }}
@@ -264,20 +268,35 @@ runs:
         shell: bash
         working-directory: ${{ inputs.srcdir }}
         post: |
-          [[ "${test_all_enabled}" = "true" ]] && \
+          if [[ "${test_all_enabled}" = "true" ]]; then \
+            launchable record attachment \
+              --session "$(cat "${test_all_session_file}")" \
+              "${stdout_report_path}" \
+              "${stderr_report_path}"; \
             launchable record tests \
               --session "$(cat "${test_all_session_file}")" \
-              raw "${test_report_path}" || true
+              raw "${test_report_path}" || true; \
+          fi
 
-          [[ "${btest_enabled}" = "true" ]] && \
+          if [[ "${btest_enabled}" = "true" ]]; then \
+            launchable record attachment \
+              --session "$(cat "${btest_session_file}")" \
+              "${stdout_report_path}" \
+              "${stderr_report_path}"; \
             launchable record tests \
               --session "$(cat "${btest_session_file}")" \
-              raw "${btest_report_path}" || true
+              raw "${btest_report_path}" || true; \
+          fi
 
-          [[ "${test_spec_enabled}" = "true" ]] && \
+          if [[ "${test_spec_enabled}" = "true" ]]; then \
+            launchable record attachment \
+              --session "$(cat "${test_spec_session_file}")" \
+              "${stdout_report_path}" \
+              "${stderr_report_path}"; \
             launchable record tests \
               --session "$(cat "${test_spec_session_file}")" \
-              raw ${test_spec_report_path}/* || true
+              raw ${test_spec_report_path}/* || true; \
+          fi
 
           rm -f "${test_all_session_file}"
           rm -f "${btest_session_file}"
@@ -285,6 +304,8 @@ runs:
           rm -f "${test_report_path}"
           rm -f "${btest_report_path}"
           rm -fr "${test_spec_report_path}"
+          rm -f "${stdout_report_path}"
+          rm -f "${stderr_report_path}"
       if: ${{ always() && steps.enable-launchable.outputs.enable-launchable }}
       env:
         test_report_path: ${{ steps.variables.outputs.test_report_path }}
@@ -296,3 +317,5 @@ runs:
         test_all_session_file: ${{ steps.global.outputs.test_all_session_file }}
         btest_session_file: ${{ steps.global.outputs.btest_session_file }}
         test_spec_session_file: ${{ steps.global.outputs.test_spec_session_file }}
+        stdout_report_path: ${{ steps.variables.outputs.stdout_report_path }}
+        stderr_report_path: ${{ steps.variables.outputs.stderr_report_path }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -132,6 +132,12 @@ jobs:
 
       - name: make ${{ matrix.test_task }}
         run: |
+          if [ -n "${LAUNCHABLE_ORGANIZATION}" ]; then
+            exec
+            > >(tee launchable_stdout.log) \
+            2> >(tee launchable_stderr.log)
+          fi
+
           ulimit -c unlimited
           make -s ${{ matrix.test_task }} ${TESTS:+TESTS="$TESTS"}
         timeout-minutes: 60

--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -141,10 +141,16 @@ jobs:
         continue-on-error: true
 
       - name: make ${{ matrix.test_task }}
-        run: >-
-          $SETARCH make -s ${{ matrix.test_task }}
-          ${TESTS:+TESTS="$TESTS"}
-          ${{ !contains(matrix.test_task, 'bundle') && 'RUBYOPT=-w' || '' }}
+        run: |
+          if [ -n "${LAUNCHABLE_ORGANIZATION}" ]; then
+            exec
+            > >(tee launchable_stdout.log) \
+            2> >(tee launchable_stderr.log)
+          fi
+
+          $SETARCH make -s ${{ matrix.test_task }} \
+            ${TESTS:+TESTS="$TESTS"} \
+            ${{ !contains(matrix.test_task, 'bundle') && 'RUBYOPT=-w' || '' }}
         timeout-minutes: ${{ matrix.gc.timeout || 40 }}
         env:
           RUBY_TESTOPTS: '-q --tty=no'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -117,9 +117,15 @@ jobs:
         continue-on-error: true
 
       - name: make ${{ matrix.test_task }}
-        run: >-
-          $SETARCH make -s ${{ matrix.test_task }}
-          ${TESTS:+TESTS="$TESTS"}
+        run: |
+          if [ -n "${LAUNCHABLE_ORGANIZATION}" ]; then
+            exec
+            > >(tee launchable_stdout.log) \
+            2> >(tee launchable_stderr.log)
+          fi
+
+          $SETARCH make -s ${{ matrix.test_task }} \
+          ${TESTS:+TESTS="$TESTS"} \
           ${{ !contains(matrix.test_task, 'bundle') && 'RUBYOPT=-w' || '' }}
         timeout-minutes: ${{ matrix.timeout || 40 }}
         env:

--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -128,10 +128,16 @@ jobs:
         continue-on-error: true
 
       - name: make ${{ matrix.test_task }}
-        run: >-
-          make -s ${{ matrix.test_task }} ${TESTS:+TESTS="$TESTS"}
-          RUN_OPTS="$RUN_OPTS"
-          SPECOPTS="$SPECOPTS"
+        run: |
+          if [ -n "${LAUNCHABLE_ORGANIZATION}" ]; then
+            exec
+            > >(tee launchable_stdout.log) \
+            2> >(tee launchable_stderr.log)
+          fi
+
+          make -s ${{ matrix.test_task }} ${TESTS:+TESTS="$TESTS"} \
+            RUN_OPTS="$RUN_OPTS" \
+            SPECOPTS="$SPECOPTS"
         timeout-minutes: 60
         env:
           RUBY_TESTOPTS: '-q --tty=no'

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -182,10 +182,16 @@ jobs:
         continue-on-error: true
 
       - name: make ${{ matrix.test_task }}
-        run: >-
-          make -s ${{ matrix.test_task }} ${TESTS:+TESTS="$TESTS"}
-          RUN_OPTS="$RUN_OPTS" MSPECOPT=--debug SPECOPTS="$SPECOPTS"
-          YJIT_BENCH_OPTS="$YJIT_BENCH_OPTS" YJIT_BINDGEN_DIFF_OPTS="$YJIT_BINDGEN_DIFF_OPTS"
+        run: |
+          if [ -n "${LAUNCHABLE_ORGANIZATION}" ]; then
+            exec
+            > >(tee launchable_stdout.log) \
+            2> >(tee launchable_stderr.log)
+          fi
+
+          make -s ${{ matrix.test_task }} ${TESTS:+TESTS="$TESTS"} \
+            RUN_OPTS="$RUN_OPTS" MSPECOPT=--debug SPECOPTS="$SPECOPTS" \
+            YJIT_BENCH_OPTS="$YJIT_BENCH_OPTS" YJIT_BINDGEN_DIFF_OPTS="$YJIT_BINDGEN_DIFF_OPTS"
         timeout-minutes: 90
         env:
           RUBY_TESTOPTS: '-q --tty=no'


### PR DESCRIPTION
Currently, the Launchable team is developing a new feature to attach any logs. Attached log can be anything, such as system logs or stdout. Users can find these logs using any text search. Please note that this feature is a work in progress, so we can't use it yet. 

I'm going to attach stdout and stderr as attached logs because they will be useful for finding interpreter bugs. When running tests, we sometimes see interpreter itself crash, and the stack is output to stderr. When debugging the cause of the issue, this feature is useful.