### PR TITLE
Avoid some false positive bundled gem warnings

### DIFF
--- a/spec/bundled_gems_spec.rb
+++ b/spec/bundled_gems_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "bundled_gems.rb" do
     ruby(code, options)
   end
 
-  it "Show warning require and LoadError" do
+  it "Show warning on require, but not when LoadError is rescued" do
     script <<-RUBY
       gemfile do
         source "https://rubygems.org"
@@ -91,8 +91,8 @@ RSpec.describe "bundled_gems.rb" do
       require "openssl"
     RUBY
 
-    expect(err).to include(/csv used to be loaded from (.*) since Ruby 3.4.0/)
-    expect(err).to include(/-e:15/)
+    expect(err).not_to include(/csv used to be loaded from (.*) since Ruby 3.4.0/)
+    expect(err).not_to include(/-e:15/)
     expect(err).to include(/openssl used to be loaded from (.*) since Ruby #{RUBY_VERSION}/)
     expect(err).to include(/-e:18/)
   end
@@ -117,20 +117,17 @@ RSpec.describe "bundled_gems.rb" do
     expect(err).to include(/lib\/active_support\/all\.rb:1/)
   end
 
-  it "Show warning dash gem like net/smtp" do
-    script <<-RUBY
+  it "Show error with dash gem already removed like net/smtp" do
+    script <<-RUBY, raise_on_error: false
       gemfile do
         source "https://rubygems.org"
       end
 
-      begin
-        require "net/smtp"
-      rescue LoadError
-      end
+      require "net/smtp"
     RUBY
 
     expect(err).to include(/net\/smtp used to be loaded from (.*) since Ruby 3.1.0/)
-    expect(err).to include(/-e:15/)
+    expect(err).to include(/-e:14/)
     expect(err).to include("You can add net-smtp")
   end
 

--- a/test/test_bundled_gems.rb
+++ b/test/test_bundled_gems.rb
@@ -12,7 +12,9 @@ class TestBundlerGem < Gem::TestCase
   end
 
   def test_warning
-    assert Gem::BUNDLED_GEMS.warning?("csv", specs: {})
+    warning_info = Gem::BUNDLED_GEMS.warning?("csv", specs: {})
+    assert warning_info
+    Gem::BUNDLED_GEMS.build_message(warning_info)
     assert_nil Gem::BUNDLED_GEMS.warning?("csv", specs: {})
   end
 
@@ -23,13 +25,17 @@ class TestBundlerGem < Gem::TestCase
 
   def test_warning_libdir
     path = File.join(::RbConfig::CONFIG.fetch("rubylibdir"), "csv.rb")
-    assert Gem::BUNDLED_GEMS.warning?(path, specs: {})
+    warning_info = Gem::BUNDLED_GEMS.warning?(path, specs: {})
+    assert warning_info
+    Gem::BUNDLED_GEMS.build_message(warning_info)
     assert_nil Gem::BUNDLED_GEMS.warning?(path, specs: {})
   end
 
   def test_warning_archdir
     path = File.join(::RbConfig::CONFIG.fetch("rubyarchdir"), "syslog.so")
-    assert Gem::BUNDLED_GEMS.warning?(path, specs: {})
+    warning_info = Gem::BUNDLED_GEMS.warning?(path, specs: {})
+    assert warning_info
+    Gem::BUNDLED_GEMS.build_message(warning_info)
     assert_nil Gem::BUNDLED_GEMS.warning?(path, specs: {})
   end
 end


### PR DESCRIPTION
When a bundled gem has already been removed, a `require` caller is rescuing `LoadError`, no warning/error messages should be displayed.

Instead, let the bundled gem message be part of `LoadError`, so that it's not displayed when rescued, but still gets to the user when not rescued.

This is an idea to reintroduce https://github.com/ruby/ruby/pull/11550, but without the issue that made @hsbt revert the original approach: If users upgrade Ruby from a version that did not show any warnings, to a version where the default gem has already been removed, then they'll miss any noticed about removal of the default gem. By making the notice part of the `LoadError`, they will not miss it.