### PR TITLE
Fix case insensitive matching for small UTF chars #16145

### DIFF
--- a/regparse.c
+++ b/regparse.c
@@ -5669,7 +5669,7 @@ i_apply_case_fold(OnigCodePoint from, OnigCodePoint to[],
     if ((is_in != 0 && !IS_NCCLASS_NOT(cc)) ||
 	(is_in == 0 &&  IS_NCCLASS_NOT(cc))) {
       if (add_flag) {
-	if (ONIGENC_MBC_MINLEN(env->enc) > 1 || *to >= SINGLE_BYTE_SIZE) {
+	if (ONIGENC_MBC_MINLEN(env->enc) > 1 || *to >= 0x80) {
 	  r = add_code_range0(&(cc->mbuf), env, *to, *to, 0);
 	  if (r < 0) return r;
 	}
@@ -5681,7 +5681,7 @@ i_apply_case_fold(OnigCodePoint from, OnigCodePoint to[],
 #else
     if (is_in != 0) {
       if (add_flag) {
-	if (ONIGENC_MBC_MINLEN(env->enc) > 1 || *to >= SINGLE_BYTE_SIZE) {
+	if (ONIGENC_MBC_MINLEN(env->enc) > 1 || *to >= 0x80) {
 	  if (IS_NCCLASS_NOT(cc)) clear_not_flag_cclass(cc, env->enc);
 	  r = add_code_range0(&(cc->mbuf), env, *to, *to, 0);
 	  if (r < 0) return r;

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -2114,4 +2114,17 @@ class TestRegexp < Test::Unit::TestCase
       re =~ s
     end
   end
+
+  def test_bug_16145_caseinsensitive_small_utf # [Bug#16145]
+    o_acute_lower = 243.chr('UTF-8')
+    o_acute_upper = 211.chr('UTF-8')
+    # [xó] =~ "abcÓ"
+    assert(/[x#{o_acute_lower}]/i.match?("abc#{o_acute_upper}"), "should match o acute case insensitive")
+
+
+    e_acute_lower = 233.chr('UTF-8')
+    e_acute_upper = 201.chr('UTF-8')
+    # [xé] =~ 'CAFÉ'
+    assert(/[x#{e_acute_lower}]/i.match?("CAF#{e_acute_upper}"), "should match e acute case insensitive")
+  end
 end

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -2118,13 +2118,10 @@ class TestRegexp < Test::Unit::TestCase
   def test_bug_16145_caseinsensitive_small_utf # [Bug#16145]
     o_acute_lower = 243.chr('UTF-8')
     o_acute_upper = 211.chr('UTF-8')
-    # [xó] =~ "abcÓ"
-    assert(/[x#{o_acute_lower}]/i.match?("abc#{o_acute_upper}"), "should match o acute case insensitive")
-
+    assert_match(/[x#{o_acute_lower}]/i, "abc#{o_acute_upper}", "should match o acute case insensitive")
 
     e_acute_lower = 233.chr('UTF-8')
     e_acute_upper = 201.chr('UTF-8')
-    # [xé] =~ 'CAFÉ'
-    assert(/[x#{e_acute_lower}]/i.match?("CAF#{e_acute_upper}"), "should match e acute case insensitive")
+    assert_match(/[x#{e_acute_lower}]/i, "CAF#{e_acute_upper}", "should match e acute case insensitive")
   end
 end


### PR DESCRIPTION
There are two data structures backing a character class: a bitset for ASCII and a buffer for multibyte characters. Bitset could theoretically hold single-byte chars beyond ascii limit (with codepoints 128-255). When a character is beyond ascii range, we use [case `OP_CLASS_MB`](https://github.com/ruby/ruby/blob/1bc57b5e0e3cd15e8702c8856a276e98b6e46ba8/regexec.c#L2928-L2943) where we use the buffer (not the bitset) for checking if a character is in the character class.

This PR fixes a corner case for non-ASCII characters that fit into a single byte for case fold. On `master` when we add a case folded codepoint of such character, we use the bitset (because the codepoint fits into one byte), but then when we read the character class, we don't check the bitset, but the multibyte buffer (as described above).

As a result case insensitive matching fails for those characters:
```
[28] pry(main)> (1..0xD799).map{chr = _1.chr('UTF-8'); [_1, chr, /[#{Regexp.escape(chr)}x]/i.match?(chr.downcase)]}.select{!_1.last}  
=> [[192, "À", false],  
[193, "Á", false],  
[194, "Â", false],  
[195, "Ã", false],  
[196, "Ä", false],  
[197, "Å", false],  
[198, "Æ", false],  
[199, "Ç", false],  
[200, "È", false],  
[201, "É", false],  
[202, "Ê", false],  
[203, "Ë", false],  
[204, "Ì", false],  
[205, "Í", false],  
[206, "Î", false],  
[207, "Ï", false],  
[208, "Ð", false],  
[209, "Ñ", false],  
[210, "Ò", false],  
[211, "Ó", false],  
[212, "Ô", false],  
[213, "Õ", false],  
[214, "Ö", false],  
[216, "Ø", false],  
[217, "Ù", false],  
[218, "Ú", false],  
[219, "Û", false],  
[220, "Ü", false],  
[221, "Ý", false],  
[222, "Þ", false],  
[376, "Ÿ", false],  
[8491, "Å", false]]
```

In this PR I change the conditional in case folding  to make sure we put only ASCII chars into the bitset.

Note that it doesn't dix the issues with `"Ÿ"` and `"Å"`

Fixes https://bugs.ruby-lang.org/issues/16145