### PR TITLE
[Bug #21150] macOS: Temporary workaround at unwinding coroutine

### DIFF
--- a/addr2line.c
+++ b/addr2line.c
@@ -296,9 +296,11 @@ fill_filename(int file, uint8_t format, uint16_t version, const char *include_di
         for (i = 1; i <= file; i++) {
             filename = p;
             if (!*p) {
+#ifndef __APPLE__
                 /* Need to output binary file name? */
                 kprintf("Unexpected file number %d in %s at %tx\n",
                         file, binary_filename, filenames - obj->mapped);
+#endif
                 return;
             }
             while (*p) p++;

--- a/thread_pthread_mn.c
+++ b/thread_pthread_mn.c
@@ -429,7 +429,12 @@ native_thread_check_and_create_shared(rb_vm_t *vm)
     }
 }
 
-static COROUTINE
+#ifdef __APPLE__
+# define co_start ruby_coroutine_start
+#else
+static
+#endif
+COROUTINE
 co_start(struct coroutine_context *from, struct coroutine_context *self)
 {
 #ifdef RUBY_ASAN_ENABLED


### PR DESCRIPTION
On arm64 macOS, libunwind (both of system library and homebrew llvm-18) seems not to handle our coroutine switching code.

[[Bug #21150]](https://bugs.ruby-lang.org/issues/21150)