### PR TITLE
Use an exclusive range for `ruby_version_is`

### DIFF
--- a/spec/ruby/language/numbered_parameters_spec.rb
+++ b/spec/ruby/language/numbered_parameters_spec.rb
@@ -90,7 +90,7 @@ describe "Numbered parameters" do
     proc { _2 }.parameters.should == [[:opt, :_1], [:opt, :_2]]
   end
 
-  ruby_version_is "".."3.4" do
+  ruby_version_is ""..."3.5" do
     it "affects binding local variables" do
       -> { _1; binding.local_variables }.call("a").should == [:_1]
       -> { _2; binding.local_variables }.call("a", "b").should == [:_1, :_2]


### PR DESCRIPTION
https://github.com/ruby/ruby/actions/runs/13385320432/job/37380864655#step:12:889
>   ruby_version_is with an inclusive range is deprecated, use an exclusive range ("2.1"..."2.3") instead.
>   from /home/runner/work/ruby/ruby/src/spec/ruby/language/numbered_parameters_spec.rb:93:in 'block in <top (required)>'
