### PR TITLE
Merge NODE_LINE and NODE_ENCODING cases in cond0 function

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -14228,13 +14228,7 @@ cond0(struct parser_params *p, NODE *node, enum cond_type type, const YYLTYPE *l
         break;
 
       case NODE_LINE:
-        SWITCH_BY_COND_TYPE(type, warning, "");
-        break;
-
       case NODE_ENCODING:
-        SWITCH_BY_COND_TYPE(type, warning, "");
-        break;
-
       case NODE_INTEGER:
       case NODE_FLOAT:
       case NODE_RATIONAL:


### PR DESCRIPTION
NODE_LINE and NODE_ENCODING cases are used SWITCH_BY_COND_TYPE macro that is same to NODE_INTEGER and other cases.
NODE_LINE and NODE_ENCODING cases can be marge to NODE_INTEGER and other node cases.