### PR TITLE
Allow arguments to be passed through Binding#irb

### DIFF
--- a/prelude.rb
+++ b/prelude.rb
@@ -1,13 +1,13 @@
 class Binding
   # :nodoc:
-  def irb
+  def irb(*args)
     begin
       require 'irb'
     rescue LoadError, Gem::LoadError
       Gem::BUNDLED_GEMS.force_activate 'irb'
       retry
     end
-    irb
+    irb(*args)
   end
 
   # suppress redefinition warning

--- a/prelude.rb
+++ b/prelude.rb
@@ -1,6 +1,6 @@
 class Binding
   # :nodoc:
-  def irb(*args)
+  def irb(...)
     begin
       require 'irb'
     rescue LoadError, Gem::LoadError

--- a/prelude.rb
+++ b/prelude.rb
@@ -7,7 +7,7 @@ class Binding
       Gem::BUNDLED_GEMS.force_activate 'irb'
       retry
     end
-    irb(*args)
+    irb(...)
   end
 
   # suppress redefinition warning


### PR DESCRIPTION
This PR allows passing arguments to `Binding#irb` method.

Currently, if we want to use options like [show_code: true](https://github.com/ruby/irb/blob/3c90aa613a7689b406ab04e5f4ce5a7b0e6539d7/lib/irb.rb#L706) with `binding.irb`, we need to require 'irb' first.


Without `require 'irb'`, we can't pass any arguments:

```bash
➜ ruby -e "binding.irb(show_code: true)"
<internal:prelude>:3:in 'irb': wrong number of arguments (given 1, expected 0) (ArgumentError)
        from -e:1:in '<main>'
```

This PR modifies Binding#irb to forward any arguments to the underlying irb method, making it more flexible like Kernel#pp. This allows users to use irb options directly without explicitly requiring 'irb' first.

This change also paves the way for supporting additional options in the future, like the `do` and `pre` keywords mentioned in https://github.com/ruby/irb/issues/1083.

