### PR TITLE
Fix RUBY_PAGER in manpage

### DIFF
--- a/man/ruby.1
+++ b/man/ruby.1
@@ -537,15 +537,15 @@ Introduced in Ruby 3.3, default: unset.
 .Pp
 .It Ev RUBY_PAGER
 The pager command that will be used for
-.Pp
-.It Ev RUBY_THREAD_TIMESLICE
-Sets the default thread time slice (thread quantum) in milliseconds.
-Introduced in Ruby 3.4, default: 100ms.
 .Fl -help
 option.
 Introduced in Ruby 3.0, default:
 .Ev PAGER
 environment variable.
+.Pp
+.It Ev RUBY_THREAD_TIMESLICE
+Sets the default thread time slice (thread quantum) in milliseconds.
+Introduced in Ruby 3.4, default: 100ms.
 .Pp
 .It Ev PATH
 Ruby refers to the


### PR DESCRIPTION
Before:

```
     RUBY_PAGER
                The pager command that will be used for

     RUBY_THREAD_TIMESLICE
                Sets the default thread time slice (thread quantum) in milliseconds.  Introduced in Ruby 3.4, default:
                100ms.  --help option.  Introduced in Ruby 3.0, default: PAGER environment variable.
```

After:

```
     RUBY_PAGER
                The pager command that will be used for --help option.  Introduced in Ruby 3.0, default: PAGER
                environment variable.

     RUBY_THREAD_TIMESLICE
                Sets the default thread time slice (thread quantum) in milliseconds.  Introduced in Ruby 3.4, default:
                100ms.
```