### PR TITLE
Prefer `0.000001` over `0.000001f` for timeout calculations.

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -271,7 +271,7 @@ VALUE
 rb_fiber_scheduler_make_timeout(struct timeval *timeout)
 {
     if (timeout) {
-        return rb_float_new((double)timeout->tv_sec + (0.000001f * timeout->tv_usec));
+        return rb_float_new((double)timeout->tv_sec + (0.000001 * timeout->tv_usec));
     }
 
     return Qnil;

--- a/spec/ruby/optional/capi/ext/io_spec.c
+++ b/spec/ruby/optional/capi/ext/io_spec.c
@@ -241,7 +241,7 @@ VALUE io_spec_rb_wait_for_single_fd(VALUE self, VALUE io, VALUE events, VALUE se
 #ifdef RUBY_VERSION_IS_3_0
   VALUE timeout = Qnil;
   if (!NIL_P(secs)) {
-      timeout = rb_float_new((double)FIX2INT(secs) + (0.000001f * FIX2INT(usecs)));
+      timeout = rb_float_new((double)FIX2INT(secs) + (0.000001 * FIX2INT(usecs)));
   }
   VALUE result = rb_io_wait(io, events, timeout);
   if (result == Qfalse) return INT2FIX(0);


### PR DESCRIPTION
See <https://github.com/trilogy-libraries/trilogy/pull/47#discussion_r1968518994> for context.