### PR TITLE
Launchable: Fix `launchable record session` command failures

### DIFF
--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -159,10 +159,10 @@ runs:
           launchable record session \
             --build "${build_name}" \
             --observation \
-            --flavor os=${{ inputs.os }} \
-            --flavor test_task=${{ inputs.test-task }} \
-            --flavor test_opts=${test_opts} \
-            --flavor workflow=${{ github.workflow }} \
+            --flavor os="${{ inputs.os }}" \
+            --flavor test_task="${{ inputs.test-task }}" \
+            --flavor test_opts="${test_opts}" \
+            --flavor workflow="${{ github.workflow }}" \
             --test-suite ${test_all_test_suite} \
             > "${test_all_session_file}"
           launchable subset \
@@ -177,10 +177,10 @@ runs:
           launchable record session \
             --build "${build_name}" \
             --observation \
-            --flavor os=${{ inputs.os }} \
-            --flavor test_task=${{ inputs.test-task }} \
-            --flavor test_opts=${test_opts} \
-            --flavor workflow=${{ github.workflow }} \
+            --flavor os="${{ inputs.os }}" \
+            --flavor test_task="${{ inputs.test-task }}" \
+            --flavor test_opts="${test_opts}" \
+            --flavor workflow="${{ github.workflow }}" \
             --test-suite ${btest_test_suite} \
             > "${btest_session_file}"
           launchable subset \
@@ -195,10 +195,10 @@ runs:
           launchable record session \
             --build "${build_name}" \
             --observation \
-            --flavor os=${{ inputs.os }} \
-            --flavor test_task=${{ inputs.test-task }} \
-            --flavor test_opts=${test_opts} \
-            --flavor workflow=${{ github.workflow }} \
+            --flavor os="${{ inputs.os }}" \
+            --flavor test_task="${{ inputs.test-task }}" \
+            --flavor test_opts="${test_opts}" \
+            --flavor workflow="${{ github.workflow }}" \
             --test-suite ${test_spec_test_suite} \
             > "${test_spec_session_file}"
           launchable subset \


### PR DESCRIPTION
Currently, the `launchable record session` command is failing some workflows such as YJIT on macOS. This occurs because of word splitting, as explained in https://www.shellcheck.net/wiki/SC2086. This PR addresses the issue.

```
+ launchable record session --build refs_pull_12785_merge_5ac818aaf7402e232de6b3e1b078765da3dc6279 --observation --flavor os=macos-14 --flavor test_task=check --flavor test_opts=--enable-yjit --flavor workflow=YJIT macOS Arm64 --test-suite yjit-test-all
Usage: launchable record session [OPTIONS]
Try 'launchable record session --help' for help.

Error: Got unexpected extra arguments (macOS Arm64)
Error: Process completed with exit code 2.
```

https://github.com/ruby/ruby/actions/runs/13535324545/job/37825826044#step:10:354