### PR TITLE
[Bug #21159] module names should not be modifiable

### DIFF
--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -3371,13 +3371,17 @@ class TestModule < Test::Unit::TestCase
     m.const_set(:N, Module.new)
 
     assert_match(/\A#<Module:0x\h+>::N\z/, m::N.name)
-    m::N.set_temporary_name("fake_name_under_M")
+    m::N.set_temporary_name(name = "fake_name_under_M")
+    name.upcase!
     assert_equal("fake_name_under_M", m::N.name)
+    assert_raise(FrozenError) {m::N.name.upcase!}
     m::N.set_temporary_name(nil)
     assert_nil(m::N.name)
 
-    m.set_temporary_name("fake_name")
+    m.set_temporary_name(name = "fake_name")
+    name.upcase!
     assert_equal("fake_name", m.name)
+    assert_raise(FrozenError) {m.name.upcase!}
 
     m.set_temporary_name(nil)
     assert_nil m.name

--- a/variable.c
+++ b/variable.c
@@ -238,6 +238,8 @@ rb_mod_set_temporary_name(VALUE mod, VALUE name)
             rb_raise(rb_eArgError, "the temporary name must not be a constant path to avoid confusion");
         }
 
+        name = rb_str_new_frozen(name);
+
         // Set the temporary classpath to the given name:
         RCLASS_SET_CLASSPATH(mod, name, FALSE);
     }


### PR DESCRIPTION
[[Bug #21159]](https://bugs.ruby-lang.org/issues/21159)