### PR TITLE
Increase timeout in TestParallel testing to reduce flaky failures

### DIFF
--- a/tool/test/testunit/test_parallel.rb
+++ b/tool/test/testunit/test_parallel.rb
@@ -6,7 +6,7 @@ module TestParallel
   PARALLEL_RB = "#{__dir__}/../../lib/test/unit/parallel.rb"
   TESTS = "#{__dir__}/tests_for_parallel"
   # use large timeout for --jit-wait
-  TIMEOUT = EnvUtil.apply_timeout_scale(30)
+  TIMEOUT = EnvUtil.apply_timeout_scale(100)
 
   class TestParallelWorker < Test::Unit::TestCase
     def setup


### PR DESCRIPTION
Currently, the following tests are flaky and failing intermittently, so I'm going to increase the timeout to improve stability.

```  
    1) Failure:
  TestParallel::TestParallel#test_hungup [/Users/runner/work/ruby/ruby/src/tool/lib/zombie_hunter.rb:6]:
  Expected [[42009, #<Process::Status: pid 42009 SIGKILL (signal 9)>]] to be empty.
  
    2) Error:
  TestParallel::TestParallel#test_hungup:
  Test::Unit::ProxyError: execution expired
      /Users/runner/work/ruby/ruby/src/lib/timeout.rb:40:in 'Timeout::Error.handle_timeout'
      /Users/runner/work/ruby/ruby/src/lib/timeout.rb:194:in 'Timeout.timeout'
      /Users/runner/work/ruby/ruby/src/tool/test/testunit/test_parallel.rb:210:in 'TestParallel::TestParallel#test_hungup'

```
https://github.com/ruby/ruby/actions/runs/13560087551/job/37901506230#step:14:105

```
    1) Error:
  TestParallel::TestParallel#test_retry_workers:
  Test::Unit::ProxyError: execution expired
      /Users/runner/work/ruby/ruby/src/lib/timeout.rb:40:in 'Timeout::Error.handle_timeout'
      /Users/runner/work/ruby/ruby/src/lib/timeout.rb:194:in 'Timeout.timeout'
      /Users/runner/work/ruby/ruby/src/tool/test/testunit/test_parallel.rb:217:in 'TestParallel::TestParallel#test_retry_workers'
```
https://github.com/ruby/ruby/actions/runs/13559151505/job/37899041580#step:14:106