### PR TITLE
Increase timeouts in Compilations actions to reduce intermittent failures

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -187,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -207,7 +207,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -227,7 +227,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -267,7 +267,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
@@ -287,7 +287,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile-if
     if: ${{ needs.compile-if.result == 'success' }}
-    timeout-minutes: 40
+    timeout-minutes: 60
     services: { docuum: { image: 'stephanmisc/docuum', options: '--init', volumes: [ '/root', '/var/run/docker.sock:/var/run/docker.sock' ] } }
     steps:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0


### PR DESCRIPTION
Compilations actions are flaky and intermittently failing now. This run (https://github.com/ruby/ruby/actions/runs/13572112090) is an example of the issue. The job fails due to exceeding the timeout, resulting in termination. To prevent these intermittent failures, I'm going to increase the timeout.