### PR TITLE
[Bug #20682] Add sleep 0.1 to stabilize flaky failures on macOS

### DIFF
--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -444,7 +444,9 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
 
     def test_ttyname
       return unless IO.method_defined?(:ttyname)
-      assert_equal(["true"], run_pty("p STDIN.ttyname == STDOUT.ttyname"))
+      # [Bug #20682]
+      # `sleep 0.1` is added to stabilize flaky failures on macOS.
+      assert_equal(["true"], run_pty("p STDIN.ttyname == STDOUT.ttyname; sleep 0.1"))
     end
   end
 


### PR DESCRIPTION
 https://bugs.ruby-lang.org/issues/20682

TestIO_Console#test_ttyname is a flaky test and failing intermittently, especially on macOS. This is because the slave PTY output is lost after a child process exits in macOS. Therefore, we can reduce this flaky failure by adding `sleep 0.1`

```
   1) Error:
  TestIO_Console#test_ttyname:
  Test::Unit::ProxyError: undefined method 'chomp' for nil
      /Users/runner/work/ruby/ruby/src/test/io/console/test_io_console.rb:476:in 'block in TestIO_Console#run_pty'
      <internal:numeric>:257:in 'Integer#times'
      /Users/runner/work/ruby/ruby/src/test/io/console/test_io_console.rb:476:in 'TestIO_Console#run_pty'
      /Users/runner/work/ruby/ruby/src/test/io/console/test_io_console.rb:447:in 'TestIO_Console#test_ttyname'
```

## Launchable

https://app.launchableinc.com/organizations/ruby/workspaces/ruby/data/test-paths/file%3Dtest%2Fio%2Fconsole%2Ftest_io_console.rb%23%23%23class%3DTestIO_Console%23%23%23testcase%3Dtest_ttyname?testSessionStatus=flake

<img width="1204" alt="Screenshot 2025-02-28 at 13 53 08" src="https://github.com/user-attachments/assets/641e5247-a8c5-4dd7-9c88-0e0f17966625" />

## GitHub Actions

https://github.com/ruby/ruby/actions/runs/13579998087/job/37964135232#step:14:873
https://github.com/ruby/ruby/actions/runs/13560498203/job/37902584339#step:14:807
