### PR TITLE
Skip vs2022 build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,10 +31,10 @@ jobs:
             test_task: check
           - vs: 2019
             test_task: check
-          - vs: 2022
-            test_task: check
-          - vs: 2022
+          - vs: 2019
             test_task: test-bundled-gems
+          # - vs: 2022
+          #   test_task: check
       fail-fast: false
 
     runs-on: windows-${{ matrix.vs < 2022 && '2019' || matrix.vs }}


### PR DESCRIPTION
Visual Studio 2022 17.13.x couldn't build miniruby.exe. It prevents other PRs.

https://github.com/actions/runner-images/commit/e43209e1398efe7739e42509162b3187515b9359

```
user32.lib advapi32.lib shell32.lib ws2_32.lib iphlpapi.lib gmp.lib imagehlp.lib shlwapi.lib bcrypt.lib
linking miniruby.exe
   Creating library miniruby.lib and object miniruby.exp
[BUG] heap_idx_for_size: allocation size too large (size=145u, heap_idx=25u)
ruby 3.5.0dev (2025-02-28T01:12:37Z pull/12827/merge 3d6a5a1883) [x64-mswin64_140]
```

```
user32.lib advapi32.lib shell32.lib ws2_32.lib iphlpapi.lib imagehlp.lib shlwapi.lib bcrypt.lib
  linking miniruby.exe
  NMAKE : fatal error U1077: '@ miniruby.exe -v' : return code '0xc0000005'
```