### PR TITLE
Skip VS2022 17.13.x build for Ruby 3.3

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         include:
           - vs: 2019
-          - vs: 2022
+          # - vs: 2022
       fail-fast: false
 
     runs-on: windows-${{ matrix.vs < 2022 && '2019' || matrix.vs }}


### PR DESCRIPTION
see https://github.com/ruby/ruby/pull/12830