### PR TITLE
Allow `IO#close` to interrupt IO operations on fibers using `fiber_interrupt` hook.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,13 @@ Note: We're only listing outstanding class updates.
     * Update Unicode to Version 16.0.0 and Emoji Version 16.0.
       [[Feature #19908]][[Feature #20724]] (also applies to Regexp)
 
+* Fiber::Scheduler
+
+    * Introduce `Fiber::Scheduler#fiber_interrupt` to interrupt a fiber with a
+      given exception. The initial use case is to interrupt a fiber that is
+      waiting on a blocking IO operation when the IO operation is closed.
+      [[Feature #21166]]
+
 ## Stdlib updates
 
 The following bundled gems are promoted from default gems.
@@ -134,6 +141,7 @@ The following bundled gems are updated.
 [Feature #20724]: https://bugs.ruby-lang.org/issues/20724
 [Feature #21047]: https://bugs.ruby-lang.org/issues/21047
 [Bug #21049]:     https://bugs.ruby-lang.org/issues/21049
+[Feature #21166]: https://bugs.ruby-lang.org/issues/21166
 [Feature #21216]: https://bugs.ruby-lang.org/issues/21216
 [Feature #21258]: https://bugs.ruby-lang.org/issues/21258
 [Feature #21287]: https://bugs.ruby-lang.org/issues/21287

--- a/benchmark/io_close.yml
+++ b/benchmark/io_close.yml
@@ -1,0 +1,13 @@
+prelude: |
+  ios = 1000.times.map do
+    100.times.map{IO.pipe}
+  end
+benchmark:
+  # Close IO
+  io_close: |
+    # Process each batch of ios per iteration of the benchmark.
+    ios.pop.each do |r, w|
+      r.close
+      w.close
+    end
+loop_count: 100

--- a/benchmark/io_close_contended.yml
+++ b/benchmark/io_close_contended.yml
@@ -1,0 +1,21 @@
+prelude: |
+  ios = 100.times.map do
+    10.times.map do
+      pipe = IO.pipe.tap do |r, w|
+        Thread.new do
+          r.read
+        rescue IOError
+          # Ignore
+        end
+      end
+    end
+  end
+benchmark:
+  # Close IO
+  io_close_contended: |
+    # Process each batch of ios per iteration of the benchmark.
+    ios.pop.each do |r, w|
+      r.close
+      w.close
+    end
+loop_count: 10

--- a/include/ruby/fiber/scheduler.h
+++ b/include/ruby/fiber/scheduler.h
@@ -199,6 +199,8 @@ VALUE rb_fiber_scheduler_block(VALUE scheduler, VALUE blocker, VALUE timeout);
 /**
  * Wakes up a fiber previously blocked using rb_fiber_scheduler_block().
  *
+ * This function may be called from a different thread.
+ *
  * @param[in]  scheduler  Target scheduler.
  * @param[in]  blocker    What was awaited for.
  * @param[in]  fiber      What to unblock.
@@ -410,6 +412,14 @@ struct rb_fiber_scheduler_blocking_operation_state {
  * @return     otherwise         What `scheduler.blocking_operation_wait` returns.
  */
 VALUE rb_fiber_scheduler_blocking_operation_wait(VALUE scheduler, void* (*function)(void *), void *data, rb_unblock_function_t *unblock_function, void *data2, int flags, struct rb_fiber_scheduler_blocking_operation_state *state);
+
+/**
+ * Interrupt a fiber by raising an exception. You can construct an exception using `rb_make_exception`.
+ *
+ * This hook may be invoked by a different thread.
+ *
+ */
+VALUE rb_fiber_scheduler_fiber_interrupt(VALUE scheduler, VALUE fiber, VALUE exception);
 
 /**
  * Create and schedule a non-blocking fiber.

--- a/internal/thread.h
+++ b/internal/thread.h
@@ -72,6 +72,9 @@ void *rb_thread_prevent_fork(void *(*func)(void *), void *data); /* for ext/sock
 VALUE rb_thread_io_blocking_region(struct rb_io *io, rb_blocking_function_t *func, void *data1);
 VALUE rb_thread_io_blocking_call(struct rb_io *io, rb_blocking_function_t *func, void *data1, int events);
 
+// Invoke the given function, with the specified argument, in a way that `IO#close` from another execution context can interrupt it.
+VALUE rb_thread_io_blocking_operation(VALUE self, VALUE(*function)(VALUE), VALUE argument);
+
 /* thread.c (export) */
 int ruby_thread_has_gvl_p(void); /* for ext/fiddle/closure.c */
 

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2733,7 +2733,6 @@ io_buffer_blocking_region_ensure(VALUE _argument)
 static VALUE
 io_buffer_blocking_region(VALUE io, struct rb_io_buffer *buffer, rb_blocking_function_t *function, void *data)
 {
-    io = rb_io_get_io(io);
     struct rb_io *ioptr;
     RB_IO_POINTER(io, ioptr);
 
@@ -2798,6 +2797,8 @@ io_buffer_read_internal(void *_argument)
 VALUE
 rb_io_buffer_read(VALUE self, VALUE io, size_t length, size_t offset)
 {
+    io = rb_io_get_io(io);
+
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
         VALUE result = rb_fiber_scheduler_io_read(scheduler, io, self, length, offset);
@@ -2915,6 +2916,8 @@ io_buffer_pread_internal(void *_argument)
 VALUE
 rb_io_buffer_pread(VALUE self, VALUE io, rb_off_t from, size_t length, size_t offset)
 {
+    io = rb_io_get_io(io);
+
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
         VALUE result = rb_fiber_scheduler_io_pread(scheduler, io, from, self, length, offset);
@@ -3035,6 +3038,8 @@ io_buffer_write_internal(void *_argument)
 VALUE
 rb_io_buffer_write(VALUE self, VALUE io, size_t length, size_t offset)
 {
+    io = rb_io_get_write_io(rb_io_get_io(io));
+
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
         VALUE result = rb_fiber_scheduler_io_write(scheduler, io, self, length, offset);
@@ -3099,6 +3104,7 @@ io_buffer_write(int argc, VALUE *argv, VALUE self)
 
     return rb_io_buffer_write(self, io, length, offset);
 }
+
 struct io_buffer_pwrite_internal_argument {
     // The file descriptor to write to:
     int descriptor;
@@ -3144,6 +3150,8 @@ io_buffer_pwrite_internal(void *_argument)
 VALUE
 rb_io_buffer_pwrite(VALUE self, VALUE io, rb_off_t from, size_t length, size_t offset)
 {
+    io = rb_io_get_write_io(rb_io_get_io(io));
+
     VALUE scheduler = rb_fiber_scheduler_current();
     if (scheduler != Qnil) {
         VALUE result = rb_fiber_scheduler_io_pwrite(scheduler, io, from, self, length, offset);

--- a/thread.c
+++ b/thread.c
@@ -2751,6 +2751,7 @@ rb_thread_io_close_interrupt(struct rb_io *io)
     // This is used to ensure the correct execution context is woken up after the blocking operation is interrupted:
     io->wakeup_mutex = rb_mutex_new();
 
+    // We need to use a mutex here as entering the fiber scheduler may cause a context switch:
     VALUE result = rb_mutex_synchronize(io->wakeup_mutex, thread_io_close_notify_all, (VALUE)io);
 
     return (size_t)result;


### PR DESCRIPTION
Ruby's `IO#close` can cause `IO#read`, `IO#write`, `IO#wait`, `IO#wait_readable` and `IO#wait_writable` to be interrupted with an IOError (stream closed on another thread).

The fiber scheduler did not implement this for `io_read`, `io_write` and `io_wait` hooks. Finally after several years, someone made a bug report - see <https://github.com/socketry/async/issues/368> for background. In order to solve this problem for the fiber scheduler, we need to expose the ability for `IO#close` to interrupt a fiber.

This PR introduces a new internal C function `rb_thread_io_blocking_operation` which takes an IO instance and a callback. During that callback, if the IO is closed, the callback will be interrupted.

It also introduces a new fiber scheduler method, `fiber_interrupt` which allows us to interrupt a specific fiber with an error, in this case with an `IOError`.

https://bugs.ruby-lang.org/issues/21166