### PR TITLE
Backport: [Bug #21161] [ruby/prism] Use a locale-insensitive version of tolower

### DIFF
--- a/prism/util/pm_strncasecmp.c
+++ b/prism/util/pm_strncasecmp.c
@@ -1,6 +1,18 @@
 #include "prism/util/pm_strncasecmp.h"
 
 /**
+ * A locale-insensitive version of `tolower(3)`
+ */
+static inline int
+pm_tolower(int c)
+{
+    if ('A' <= c && c <= 'Z') {
+        return c | 0x20;
+    }
+    return c;
+}
+
+/**
  * Compare two strings, ignoring case, up to the given length. Returns 0 if the
  * strings are equal, a negative number if string1 is less than string2, or a
  * positive number if string1 is greater than string2.
@@ -16,7 +28,7 @@ pm_strncasecmp(const uint8_t *string1, const uint8_t *string2, size_t length) {
 
     while (offset < length && string1[offset] != '\0') {
         if (string2[offset] == '\0') return string1[offset];
-        if ((difference = tolower(string1[offset]) - tolower(string2[offset])) != 0) return difference;
+        if ((difference = pm_tolower(string1[offset]) - pm_tolower(string2[offset])) != 0) return difference;
         offset++;
     }
 


### PR DESCRIPTION
[Bug #21161]

The `tolower` function provided by the libc is locale dependent and can behave in ways you wouldn't expect for some value of `LC_CTYPE`.

https://github.com/ruby/prism/commit/e3488256b4