### PR TITLE
Handle cases without bundle environment

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -195,14 +195,16 @@ module Gem::BUNDLED_GEMS # :nodoc:
     Bundler.reset!
 
     builder = Bundler::Dsl.new
+
     if Bundler::SharedHelpers.in_bundle?
-      if Bundler.definition.gemfiles.empty?
+      if Bundler.locked_gems
         Bundler.locked_gems.specs.each{|spec| builder.gem spec.name, spec.version.to_s }
-      else
+      elsif Bundler.definition.gemfiles.size > 0
         Bundler.definition.gemfiles.each{|gemfile| builder.eval_gemfile(gemfile) }
       end
-      builder.gem gem
     end
+
+    builder.gem gem
 
     definition = builder.to_definition(nil, true)
     definition.validate_runtime!

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -191,15 +191,18 @@ module Gem::BUNDLED_GEMS # :nodoc:
   end
 
   def self.force_activate(gem)
+    require "bundler"
     Bundler.reset!
 
     builder = Bundler::Dsl.new
-    if Bundler.definition.gemfiles.empty? # bundler/inline
-      Bundler.definition.locked_gems.specs.each{|spec| builder.gem spec.name, spec.version.to_s }
-    else
-      Bundler.definition.gemfiles.each{|gemfile| builder.eval_gemfile(gemfile) }
+    if Bundler::SharedHelpers.in_bundle?
+      if Bundler.definition.gemfiles.empty?
+        Bundler.locked_gems.specs.each{|spec| builder.gem spec.name, spec.version.to_s }
+      else
+        Bundler.definition.gemfiles.each{|gemfile| builder.eval_gemfile(gemfile) }
+      end
+      builder.gem gem
     end
-    builder.gem gem
 
     definition = builder.to_definition(nil, true)
     definition.validate_runtime!

--- a/spec/bundled_gems_spec.rb
+++ b/spec/bundled_gems_spec.rb
@@ -361,4 +361,17 @@ RSpec.describe "bundled_gems.rb" do
 
     expect(err).to be_empty
   end
+
+  describe ".force_activate" do
+    context "when gem activation fails" do
+      before do
+        allow_any_instance_of(Bundler::Runtime).to receive(:setup).and_raise(Bundler::GemNotFound)
+      end
+
+      it "warns about installation requirement" do
+        expect_any_instance_of(Object).to receive(:warn)
+        Gem::BUNDLED_GEMS.force_activate("csv")
+      end
+    end
+  end
 end


### PR DESCRIPTION
`BundledGems.force_activate` raised the following under the directory without `Gemfile`.

```
Bundler::GemfileNotFound:
  Could not locate Gemfile
```
