### PR TITLE
try to show timeout sec

### DIFF
--- a/tool/test/testunit/test_timeout.rb
+++ b/tool/test/testunit/test_timeout.rb
@@ -1,10 +1,24 @@
 # frozen_string_literal: false
 require 'test/unit'
+require 'envutil'
 
 class TestTiemout < Test::Unit::TestCase
   def test_timeout
     cmd = [*@__runner_options__[:ruby], "#{File.dirname(__FILE__)}/test4test_timeout.rb"]
     result = IO.popen(cmd, err: [:child, :out], &:read)
     assert_not_match(/^T{10}$/, result)
+  end
+
+  def test_timeout_scale
+    scale = ENV['RUBY_TEST_TIMEOUT_SCALE']&.to_f
+    sec = 5
+
+    if scale
+      assert_equal sec * scale, EnvUtil.apply_timeout_scale(sec)
+    else
+      assert_equal sec, EnvUtil.apply_timeout_scale(sec)
+    end
+
+    STDERR.puts [scale, sec, EnvUtil.apply_timeout_scale(sec)].inspect
   end
 end


### PR DESCRIPTION
http://ci.rvm.jp/results/trunk-gc-asserts@ruby-sp2-noble-docker/5632508
```
  1) Error:
TestEval#test_outer_local_variable_under_gc_compact_stress:
Test::Unit::ProxyError: execution of Test::Unit::CoreAssertions#assert_separately expired timeout (10 sec)
pid 1339179 killed by SIGABRT (signal 6) (core dumped)
```

seems that timeout scale doesn't work even though `RUBY_TEST_TIMEOUT_SCALE` is specified.

This patch tries to print the timeout with scale information.