### PR TITLE
try to show timeout sec

### DIFF
--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -274,4 +274,20 @@ class TestTimeout < Test::Unit::TestCase
       }.join
     end;
   end
+
+  # TODO: remove it
+  require 'envutil'
+
+  def test_timeout_scale
+    scale = ENV['RUBY_TEST_TIMEOUT_SCALE']&.to_f
+    sec = 5
+
+    if scale
+      assert_equal sec * scale, EnvUtil.apply_timeout_scale(sec)
+    else
+      assert_equal sec, EnvUtil.apply_timeout_scale(sec)
+    end
+
+    STDERR.puts [scale, sec, EnvUtil.apply_timeout_scale(sec)].inspect
+  end
 end


### PR DESCRIPTION
http://ci.rvm.jp/results/trunk-gc-asserts@ruby-sp2-noble-docker/5632508
```
  1) Error:
TestEval#test_outer_local_variable_under_gc_compact_stress:
Test::Unit::ProxyError: execution of Test::Unit::CoreAssertions#assert_separately expired timeout (10 sec)
pid 1339179 killed by SIGABRT (signal 6) (core dumped)
```

seems that timeout scale doesn't work even though `RUBY_TEST_TIMEOUT_SCALE` is specified.

This patch tries to print the timeout with scale information.