### PR TITLE
Move in-place interning spec to Ruby's tests

### DIFF
--- a/spec/ruby/core/string/shared/dedup.rb
+++ b/spec/ruby/core/string/shared/dedup.rb
@@ -48,9 +48,4 @@ describe :string_dedup, shared: true do
     dynamic.send(@method).should_not equal("this string is frozen".send(@method).freeze)
     dynamic.send(@method).should equal(dynamic)
   end
-
-  it "interns the provided string if it is frozen" do
-    dynamic = "this string is unique and frozen #{rand}".freeze
-    dynamic.send(@method).should equal(dynamic)
-  end
 end

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -3397,6 +3397,12 @@ CODE
     assert_same(str, bar, "uminus deduplicates [Feature #13077] str: #{ObjectSpace.dump(str)} bar: #{ObjectSpace.dump(bar)}")
   end
 
+  def test_uminus_dedup_in_place
+    dynamic = "this string is unique and frozen #{rand}".freeze
+    assert_same dynamic, -dynamic
+    assert_same dynamic, -dynamic.dup
+  end
+
   def test_uminus_frozen
     return unless @cls == String
 


### PR DESCRIPTION
Fix: https://github.com/ruby/spec/issues/1249

JRuby and TruffleRuby can't implement this behavior. While quite a lot of code out there relies on it, if it's not implemented it will simply result in slightly less efficient code, so not the end of the world.