### PR TITLE
Dont reset timeout scale

### DIFF
--- a/test/mmtk/helper.rb
+++ b/test/mmtk/helper.rb
@@ -18,7 +18,9 @@ module MMTk
     end
 
     def teardown
-      EnvUtil.timeout_scale = @original_timeout_scale
+      if using_mmtk?
+        EnvUtil.timeout_scale = @original_timeout_scale
+      end
     end
 
     private

--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -274,20 +274,4 @@ class TestTimeout < Test::Unit::TestCase
       }.join
     end;
   end
-
-  # TODO: remove it
-  require 'envutil'
-
-  def test_timeout_scale
-    scale = ENV['RUBY_TEST_TIMEOUT_SCALE']&.to_f
-    sec = 5
-
-    if scale
-      assert_equal sec * scale, EnvUtil.apply_timeout_scale(sec)
-    else
-      assert_equal sec, EnvUtil.apply_timeout_scale(sec)
-    end
-
-    STDERR.puts [scale, sec, EnvUtil.apply_timeout_scale(sec)].inspect
-  end
 end


### PR DESCRIPTION
Even if `setup` is omitted, but `teardown` is called and
`EnvUtil.timeout_scale` was reset with `nil`.