### PR TITLE
Restore vs2022 build with -O2 option.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,10 +31,10 @@ jobs:
             test_task: check
           - vs: 2019
             test_task: check
-          - vs: 2019
+          - vs: 2022
+            test_task: check
+          - vs: 2022
             test_task: test-bundled-gems
-          # - vs: 2022
-          #   test_task: check
       fail-fast: false
 
     runs-on: windows-${{ matrix.vs < 2022 && '2019' || matrix.vs }}

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -163,7 +163,7 @@ XCFLAGS = $(XCFLAGS) -Dmodular_gc_dir="$(modular_gc_dir)"
 !if $(MSC_VER) < 1400
 OPTFLAGS = -O2b2xg-
 !else
-OPTFLAGS = -O2sy-
+OPTFLAGS = -O2y-
 !endif
 !endif
 !if $(MSC_VER) >= 1900


### PR DESCRIPTION
from https://developercommunity.visualstudio.com/t/Use-of-the-result-of-bsr-before-that-i/10862351#T-N10863092-N10863860