### PR TITLE
Fix flaky failure in TestSetTraceFunc#test_tracepoint_disable

### DIFF
--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -845,6 +845,9 @@ CODE
     args = nil
     trace = TracePoint.trace(:call){|tp|
       next if !target_thread?
+      # In parallel testing, unexpected events like IO operations may be traced,
+      # so we filter out events here.
+      next unless [TracePoint, TestSetTraceFunc].include?(tp.defined_class)
       ary << tp.method_id
     }
     foo


### PR DESCRIPTION
TestSetTraceFunc#test_tracepoint_disable is a flaky and failing intermittently. Here is an example of failure logs.

```
   1) Failure:
  TestSetTraceFunc#test_tracepoint_disable [/home/runner/work/ruby/ruby/src/test/ruby/test_settracefunc.rb:857]:
  <[:foo, :disable, :foo, :disable]> expected but was
  <[:call, :call, :foo, :disable, :foo, :disable]>.
```
https://github.com/ruby/ruby/actions/runs/13619175633/job/38066208546?pr=12585#step:12:875

I printed values of TracePoint objects as follows, and checked the values when failing intermittently.

https://github.com/ruby/ruby/blob/7f9a6fc582fb5cfd88ab73a61782f39894a37ba6/test/ruby/test_settracefunc.rb#L848

Here is the log when the TestSetTraceFunc#test_tracepoint_disable failed intermittently.

`2025-03-05T09:08:37.4075411Z e: call, f: /home/runner/work/ruby/ruby/src/lib/tempfile.rb, l: 386, i: call, d: Tempfile::FinalizerManager` is an unexpected events. Thus, I modified test code so that we can filter out unexpected trace events.

```
2025-03-05T09:08:37.4075411Z e: call, f: /home/runner/work/ruby/ruby/src/lib/tempfile.rb, l: 386, i: call, d: Tempfile::FinalizerManager
2025-03-05T09:08:37.4085009Z e: call, f: /home/runner/work/ruby/ruby/src/test/ruby/test_settracefunc.rb, l: 808, i: foo, d: TestSetTraceFunc
2025-03-05T09:08:37.4086042Z e: call, f: <internal:trace_point>, l: 295, i: disable, d: TracePoint
2025-03-05T09:08:37.4115693Z e: call, f: /home/runner/work/ruby/ruby/src/test/ruby/test_settracefunc.rb, l: 808, i: foo, d: TestSetTraceFunc
2025-03-05T09:08:37.4116734Z e: call, f: <internal:trace_point>, l: 295, i: disable, d: TracePoint
```