### PR TITLE
Fix flaky failure in TestSetTraceFunc#test_tracepoint_disable

### DIFF
--- a/test/ruby/test_settracefunc.rb
+++ b/test/ruby/test_settracefunc.rb
@@ -845,6 +845,9 @@ CODE
     args = nil
     trace = TracePoint.trace(:call){|tp|
       next if !target_thread?
+      # In parallel testing, unexpected events like IO operations may be traced,
+      # so we filter out events here.
+      next unless [__FILE__, "<internal:trace_point>"].include?(tp.path)
       ary << tp.method_id
     }
     foo


### PR DESCRIPTION
Altenative implementation of https://github.com/ruby/ruby/pull/12854