### PR TITLE
[DOC] Fix parameter name in YJIT.enable doc

### DIFF
--- a/yjit.rb
+++ b/yjit.rb
@@ -33,7 +33,7 @@ module RubyVM::YJIT
     Primitive.rb_yjit_reset_stats_bang
   end
 
-  # Enable \YJIT compilation. `stats` option decides whether to enable \YJIT stats or not. `compilation_log` decides
+  # Enable \YJIT compilation. `stats` option decides whether to enable \YJIT stats or not. `log` decides
   # whether to enable \YJIT compilation logging or not. Optional `mem_size` and `call_threshold` can be
   # provided to override default configuration.
   #


### PR DESCRIPTION
Fix a documentation-implementation mismatch in the parameter name; `compilation_log` -> `log`