### PR TITLE
rdoc: Enable the "embed mixins" feature

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -7,6 +7,7 @@ title: Documentation for Ruby development version
 visibility: :private
 rdoc_include:
 - doc
+embed_mixins: true
 
 exclude:
 - \Alib/irb


### PR DESCRIPTION
which will include methods, attributes, and constants from any included or extended Modules.

ref: https://ruby.github.io/rdoc/RDoc/Options.html#attribute-i-embed_mixins

As an example of the effect this change has, methods from `Enumerable` are documented in the `Array` docs:

![image](https://github.com/user-attachments/assets/c9969568-32a6-4013-9c4d-9ef6aceb020b)
