### PR TITLE
[Bug #21173] RUBY_FREE_AT_EXIT does not work when error in -r

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -3131,16 +3131,16 @@ ruby_process_options(int argc, char **argv)
     ruby_init_setproctitle(argc, argv);
 #endif
 
+    if (getenv("RUBY_FREE_AT_EXIT")) {
+        rb_free_at_exit = true;
+        rb_category_warn(RB_WARN_CATEGORY_EXPERIMENTAL, "Free at exit is experimental and may be unstable");
+    }
+
     iseq = process_options(argc, argv, cmdline_options_init(&opt));
 
     if (opt.crash_report && *opt.crash_report) {
         void ruby_set_crash_report(const char *template);
         ruby_set_crash_report(opt.crash_report);
-    }
-
-    if (getenv("RUBY_FREE_AT_EXIT")) {
-        rb_free_at_exit = true;
-        rb_category_warn(RB_WARN_CATEGORY_EXPERIMENTAL, "Free at exit is experimental and may be unstable");
     }
 
     return (void*)(struct RData*)iseq;


### PR DESCRIPTION
When loading a file using the command line -r, it is processed before RUBY_FREE_AT_EXIT is checked. So if the loaded file raises an error, it will cause memory to not be freed with RUBY_FREE_AT_EXIT.

For example `ruby -rtest.rb -e ""` will report a large amount of memory leaks if `test.rb` raises.