### PR TITLE
[Backport 3.2] [Bug #21170] Replace tombstone when converting AR to ST hash

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -14894,6 +14894,7 @@ st.$(OBJEXT): {$(VPATH)}internal/variable.h
 st.$(OBJEXT): {$(VPATH)}internal/warning_push.h
 st.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 st.$(OBJEXT): {$(VPATH)}missing.h
+st.$(OBJEXT): {$(VPATH)}ruby_assert.h
 st.$(OBJEXT): {$(VPATH)}st.c
 st.$(OBJEXT): {$(VPATH)}st.h
 st.$(OBJEXT): {$(VPATH)}subst.h

--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -2275,4 +2275,18 @@ class TestHash < Test::Unit::TestCase
       end
     end;
   end
+
+  def test_ar_to_st_reserved_value
+    klass = Class.new do
+      attr_reader :hash
+      def initialize(val) = @hash = val
+    end
+
+    values = 0.downto(-16).to_a
+    hash = {}
+    values.each do |val|
+      hash[klass.new(val)] = val
+    end
+    assert_equal values, hash.values, "[ruby-core:121239] [Bug #21170]"
+  end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21170
https://github.com/ruby/ruby/pull/12852