### PR TITLE
Add GitHub workflows for auto-merge

### DIFF
--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -34,9 +34,11 @@ permissions:
 
 jobs:
   update-deps:
+    name: Dependency checks
+
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
       fail-fast: true
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -195,6 +195,16 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
         if: ${{ failure() }}
 
+  result:
+    if: ${{ always() }}
+    name: ${{ github.workflow }} result
+    runs-on: windows-latest
+    needs: [make]
+    steps:
+      - run: exit 1
+        working-directory:
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+
 defaults:
   run:
     working-directory: build


### PR DESCRIPTION
This PR adds missing GitHub workflows to set up required status checks. Once we merge this PR, `ruby_3_3` can have the same status-check jobs as `master` and `ruby_3_4`.