### PR TITLE
YJIT: Rename get_temp_regs2() back to get_temp_regs()

### DIFF
--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -1086,7 +1086,7 @@ impl Assembler
     }
 
     /// Get the list of registers that can be used for stack temps.
-    pub fn get_temp_regs2() -> &'static [Reg] {
+    pub fn get_temp_regs() -> &'static [Reg] {
         let num_regs = get_option!(num_temp_regs);
         &TEMP_REGS[0..num_regs]
     }
@@ -1204,7 +1204,7 @@ impl Assembler
 
         // Convert Opnd::Stack to Opnd::Reg
         fn reg_opnd(opnd: &Opnd, reg_idx: usize) -> Opnd {
-            let regs = Assembler::get_temp_regs2();
+            let regs = Assembler::get_temp_regs();
             if let Opnd::Stack { num_bits, .. } = *opnd {
                 incr_counter!(temp_reg_opnd);
                 Opnd::Reg(regs[reg_idx]).with_num_bits(num_bits).unwrap()

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -3805,7 +3805,7 @@ pub fn gen_branch_stub_hit_trampoline(ocb: &mut OutlinedCb) -> Option<CodePtr> {
 
 /// Return registers to be pushed and popped on branch_stub_hit.
 pub fn caller_saved_temp_regs() -> impl Iterator<Item = &'static Reg> + DoubleEndedIterator {
-    let temp_regs = Assembler::get_temp_regs2().iter();
+    let temp_regs = Assembler::get_temp_regs().iter();
     let len = temp_regs.len();
     // The return value gen_leave() leaves in C_RET_REG
     // needs to survive the branch_stub_hit() call.


### PR DESCRIPTION
I don't remember why I renamed it in https://github.com/ruby/ruby/pull/11157. This PR renames it back since it just looks weird.