### PR TITLE
Harden `TestObjSpace#test_memsize_of_root_shared_string`

### DIFF
--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -32,7 +32,7 @@ class TestObjSpace < Test::Unit::TestCase
     a = "a" * GC::INTERNAL_CONSTANTS[:RVARGC_MAX_ALLOCATE_SIZE]
     b = a.dup
     c = nil
-    ObjectSpace.each_object(String) {|x| break c = x if x == a and x.frozen?}
+    ObjectSpace.each_object(String) {|x| break c = x if a == x and x.frozen?}
     rv_size = GC::INTERNAL_CONSTANTS[:BASE_SLOT_SIZE]
     assert_equal([rv_size, rv_size, a.length + 1 + rv_size], [a, b, c].map {|x| ObjectSpace.memsize_of(x)})
   end


### PR DESCRIPTION
This test occasionally fail because it runs into a String instance that had its `==` method removed.

I couldn't identify where this String comes from, but in general when using `each_object` it's best to not assume returned objectd are functional.

By just inverting the operands of `==` we ensure it's always `String#==` that is called.

```
  1) Error:
TestObjSpace#test_memsize_of_root_shared_string:
NoMethodError: undefined method '==' for #<String:0x00007f9b50e8c978>
    /tmp/ruby/src/trunk-random1/test/objspace/test_objspace.rb:35:in 'block in TestObjSpace#test_memsize_of_root_shared_string'
    /tmp/ruby/src/trunk-random1/test/objspace/test_objspace.rb:35:in 'ObjectSpace.each_object'
    /tmp/ruby/src/trunk-random1/test/objspace/test_objspace.rb:35:in 'TestObjSpace#test_memsize_of_root_shared_string'
```