### PR TITLE
[DOC] Fix minor miscalculation of stack size

### DIFF
--- a/man/ruby.1
+++ b/man/ruby.1
@@ -706,11 +706,11 @@ All values are specified in bytes.
 .Bl -hang -compact -width "RUBY_THREAD_MACHINE_STACK_SIZE"
 .It Ev RUBY_THREAD_VM_STACK_SIZE
 VM stack size used at thread creation.
-default: 524288 (32-bit CPU) or 1048575 (64-bit)
+default: 524288 (32-bit CPU) or 1048576 (64-bit)
 .Pp
 .It Ev RUBY_THREAD_MACHINE_STACK_SIZE
 Machine stack size used at thread creation.
-default: 524288 or 1048575
+default: 524288 or 1048576
 .Pp
 .It Ev RUBY_FIBER_VM_STACK_SIZE
 VM stack size used at fiber creation.


### PR DESCRIPTION
I found a miscalculation in the docs.

`128 * 1024 * sizeof(VALUE) = 128 * 1024 * 8 = 1048576, not 1048575`.

`RUBY_THREAD_VM_STACK_SIZE`:

https://github.com/ruby/ruby/blob/e20f1f76f4d7479faa112b612ba6f712a46c49fc/vm_core.h#L826

`RUBY_THREAD_MACHINE_STACK_SIZE`

https://github.com/ruby/ruby/blob/e20f1f76f4d7479faa112b612ba6f712a46c49fc/vm_core.h#L828