### PR TITLE
Launchable: Disable request retries when a timeout exception occurs

### DIFF
--- a/.github/actions/compilers/entrypoint.sh
+++ b/.github/actions/compilers/entrypoint.sh
@@ -77,6 +77,8 @@ spec_opts=''
 # Launchable
 setup_launchable() {
     pushd ${srcdir}
+    # To prevent a slowdown in CI, disable request retries when the Launchable server is unstable.
+    export LAUNCHABLE_SKIP_TIMEOUT_RETRY=1
     # Launchable creates .launchable file in the current directory, but cannot a file to ${srcdir} directory.
     # As a workaround, we set LAUNCHABLE_SESSION_DIR to ${builddir}.
     export LAUNCHABLE_SESSION_DIR=${builddir}

--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -121,6 +121,8 @@ runs:
         : # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/authentication.py#L71
         echo "GITHUB_PR_HEAD_SHA=${{ github.event.pull_request.head.sha || github.sha }}" >> $GITHUB_ENV
         echo "LAUNCHABLE_TOKEN=${{ inputs.launchable-token }}" >> $GITHUB_ENV
+        : # To prevent a slowdown in CI, disable request retries when the Launchable server is unstable.
+        echo "LAUNCHABLE_SKIP_TIMEOUT_RETRY=1" >> $GITHUB_ENV
       if: steps.enable-launchable.outputs.enable-launchable
 
     - name: Set up path


### PR DESCRIPTION
When a Launchable server is unstable, a ReadTimeoutException occurs in the Launchable CLI. In such case, the Launchable CLI retries requests, which slows down CI execution. In this PR, I configured the environment variable SKIP_TIMEOUT_RETRY to disable retry attempts on requests(Link: https://github.com/launchableinc/cli/pull/992).

```
WARNING:urllib3.connectionpool:Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='api.mercury.launchableinc.com', port=443): Read timed out. (read timeout=15)")': /intake/organizations/ruby/workspaces/ruby/commits/collect/options
  WARNING:urllib3.connectionpool:Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='api.mercury.launchableinc.com', port=443): Read timed out. (read timeout=15)")': /intake/organizations/ruby/workspaces/ruby/commits/collect/options
  WARNING:urllib3.connectionpool:Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'ReadTimeoutError("HTTPSConnectionPool(host='api.mercury.launchableinc.com', port=443): Read timed out. (read timeout=15)")': /intake/organizations/ruby/workspaces/ruby/commits/collect/options
  HTTPSConnectionPool(host='api.mercury.launchableinc.com', port=443): Max retries exceeded with url: /intake/organizations/ruby/workspaces/ruby/commits/collect/options (Caused by ReadTimeoutError("HTTPSConnectionPool(host='api.mercury.launchableinc.com', port=443): Read timed out. (read timeout=15)"))
  Exception in thread "main" javax.net.ssl.SSLException: Connection reset
  	at sun.security.ssl.Alert.createSSLException(Alert.java:127)
  	at sun.security.ssl.TransportContext.fatal(TransportContext.java:331)
  	at sun.security.ssl.TransportContext.fatal(TransportContext.java:274)
  	at sun.security.ssl.TransportContext.fatal(TransportContext.java:269)
  	at sun.security.ssl.SSLSocketImpl.handleException(SSLSocketImpl.java:1572)
  	at sun.security.ssl.SSLSocketImpl.access$400(SSLSocketImpl.java:73)
  	at sun.security.ssl.SSLSocketImpl$AppInputStream.read(SSLSocketImpl.java:982)
  	at org.apache.http.impl.io.SessionInputBufferImpl.streamRead(SessionInputBufferImpl.java:137)
  	at org.apache.http.impl.io.SessionInputBufferImpl.fillBuffer(SessionInputBufferImpl.java:153)
  	at org.apache.http.impl.io.SessionInputBufferImpl.readLine(SessionInputBufferImpl.java:280)
  	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:138)
  	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:56)
  	at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:259)
  	at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:163)
  	at org.apache.http.impl.conn.CPoolProxy.receiveResponseHeader(CPoolProxy.java:157)
  	at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:273)
  	at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:125)
  	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:272)
  	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
  	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)
  	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
  	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
  	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
  	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108)
  	at com.launchableinc.ingest.commits.CommitGraphCollector.transfer(CommitGraphCollector.java:131)
  	at com.launchableinc.ingest.commits.CommitIngester.run(CommitIngester.java:145)
  	at com.launchableinc.ingest.commits.CommitIngester.main(CommitIngester.java:72)
  	Suppressed: java.net.SocketException: Broken pipe (Write failed)
  		at java.net.SocketOutputStream.socketWrite0(Native Method)
  		at java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:111)
  		at java.net.SocketOutputStream.write(SocketOutputStream.java:155)
  		at sun.security.ssl.SSLSocketOutputRecord.encodeAlert(SSLSocketOutputRecord.java:81)
  		at sun.security.ssl.TransportContext.fatal(TransportContext.java:362)
  		... 25 more
  Caused by: java.net.SocketException: Connection reset
  	at java.net.SocketInputStream.read(SocketInputStream.java:210)
  	at java.net.SocketInputStream.read(SocketInputStream.java:141)
  	at sun.security.ssl.SSLSocketInputRecord.read(SSLSocketInputRecord.java:464)
  	at sun.security.ssl.SSLSocketInputRecord.bytesInCompletePacket(SSLSocketInputRecord.java:68)
  	at sun.security.ssl.SSLSocketImpl.readApplicationRecord(SSLSocketImpl.java:1350)
  	at sun.security.ssl.SSLSocketImpl.access$300(SSLSocketImpl.java:73)
  	at sun.security.ssl.SSLSocketImpl$AppInputStream.read(SSLSocketImpl.java:966)
  	... 20 more
  Couldn't get commit history from `/github/workspace/src`. Do you run command root of git-controlled directory? If not, please set a directory use by --source option.
  HTTPSConnectionPool(host='api.mercury.launchableinc.com', port=443): Read timed out. (read timeout=60)
  Command '['java', '-jar', '/root/.local/pipx/venvs/launchable/lib/python3.10/site-packages/launchable/jar/exe_deploy.jar', 'ingest:commit', '-endpoint', 
```

https://github.com/ruby/ruby/actions/runs/13572112090/job/37939529243