### PR TITLE
YJIT: Add Counter::invalidate_everything

### DIFF
--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -626,6 +626,8 @@ pub extern "C" fn rb_yjit_tracing_invalidate_all() {
         return;
     }
 
+    incr_counter!(invalidate_everything);
+
     // Stop other ractors since we are going to patch machine code.
     with_vm_lock(src_loc!(), || {
         // Make it so all live block versions are no longer valid branch targets

--- a/yjit/src/stats.rs
+++ b/yjit/src/stats.rs
@@ -293,6 +293,7 @@ pub const DEFAULT_COUNTERS: &'static [Counter] = &[
     Counter::invalidate_constant_ic_fill,
     Counter::invalidate_no_singleton_class,
     Counter::invalidate_ep_escape,
+    Counter::invalidate_everything,
 ];
 
 /// Macro to increase a counter by name and count
@@ -589,6 +590,7 @@ make_counters! {
     invalidate_constant_ic_fill,
     invalidate_no_singleton_class,
     invalidate_ep_escape,
+    invalidate_everything,
 
     // Currently, it's out of the ordinary (might be impossible) for YJIT to leave gaps in
     // executable memory, so this should be 0.


### PR DESCRIPTION
When YJIT is forced to discard all the code, that's bad for
performance, so there should be an easy way to know about it.
