### PR TITLE
[Bug #21176] Fix case-insensitive matching for single-byte encodings

### DIFF
--- a/regparse.c
+++ b/regparse.c
@@ -5669,31 +5669,44 @@ i_apply_case_fold(OnigCodePoint from, OnigCodePoint to[],
     if ((is_in != 0 && !IS_NCCLASS_NOT(cc)) ||
 	(is_in == 0 &&  IS_NCCLASS_NOT(cc))) {
       if (add_flag) {
-	if (ONIGENC_MBC_MINLEN(env->enc) > 1 || *to >= 0x80) {
-	  r = add_code_range0(&(cc->mbuf), env, *to, *to, 0);
-	  if (r < 0) return r;
-	}
-	else {
-	  BITSET_SET_BIT(bs, *to);
-	}
+        if (ONIGENC_MBC_MAXLEN(env->enc) == 1) {
+          // single byte encoding
+          BITSET_SET_BIT(bs, *to);
+        } else {
+          // multi byte encoding
+          if (ONIGENC_MBC_MINLEN(env->enc) > 1 || *to >= 0x80) {
+            r = add_code_range0(&(cc->mbuf), env, *to, *to, 0);
+            if (r < 0) return r;
+          } else {
+            BITSET_SET_BIT(bs, *to);
+          }
+        }
       }
     }
 #else
     if (is_in != 0) {
       if (add_flag) {
-	if (ONIGENC_MBC_MINLEN(env->enc) > 1 || *to >= 0x80) {
-	  if (IS_NCCLASS_NOT(cc)) clear_not_flag_cclass(cc, env->enc);
-	  r = add_code_range0(&(cc->mbuf), env, *to, *to, 0);
-	  if (r < 0) return r;
-	}
-	else {
-	  if (IS_NCCLASS_NOT(cc)) {
-	    BITSET_CLEAR_BIT(bs, *to);
-	  }
-	  else {
-	    BITSET_SET_BIT(bs, *to);
-	  }
-	}
+        if (ONIGENC_MBC_MAXLEN(env->enc) == 1) {
+          // single byte encoding
+          if (IS_NCCLASS_NOT(cc)) {
+            BITSET_CLEAR_BIT(bs, *to);
+          } else {
+            BITSET_SET_BIT(bs, *to);
+          }
+        } else {
+          // multi byte encoding && to >= 0x80
+          if (ONIGENC_MBC_MINLEN(env->enc) > 1 || *to >= 0x80) {
+            if (IS_NCCLASS_NOT(cc)) clear_not_flag_cclass(cc, env->enc);
+            r = add_code_range0(&(cc->mbuf), env, *to, *to, 0);
+            if (r < 0) return r;
+          } else {
+            if (IS_NCCLASS_NOT(cc)) {
+              BITSET_CLEAR_BIT(bs, *to);
+            } else {
+              BITSET_SET_BIT(bs, *to);
+            }
+          }
+        }
       }
     }
 #endif /* CASE_FOLD_IS_APPLIED_INSIDE_NEGATIVE_CCLASS */

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -2115,13 +2115,16 @@ class TestRegexp < Test::Unit::TestCase
     end
   end
 
-  def test_bug_16145_caseinsensitive_small_utf # [Bug#16145]
-    o_acute_lower = 243.chr('UTF-8')
-    o_acute_upper = 211.chr('UTF-8')
-    assert_match(/[x#{o_acute_lower}]/i, "abc#{o_acute_upper}", "should match o acute case insensitive")
+  def test_bug_16145_and_bug_21176_caseinsensitive_small # [Bug#16145] [Bug#21176]
+    encodings = [Encoding::UTF_8, Encoding::ISO_8859_1]
+    encodings.each do |enc|
+      o_acute_lower = "\u00F3".encode(enc)
+      o_acute_upper = "\u00D3".encode(enc)
+      assert_match(/[x#{o_acute_lower}]/i, "abc#{o_acute_upper}", "should match o acute case insensitive")
 
-    e_acute_lower = 233.chr('UTF-8')
-    e_acute_upper = 201.chr('UTF-8')
-    assert_match(/[x#{e_acute_lower}]/i, "CAF#{e_acute_upper}", "should match e acute case insensitive")
+      e_acute_lower = "\u00E9".encode(enc)
+      e_acute_upper = "\u00C9".encode(enc)
+      assert_match(/[x#{e_acute_lower}]/i, "CAF#{e_acute_upper}", "should match e acute case insensitive")
+    end
   end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21176