### PR TITLE
Bump tolerance for weak reference test from 1 to 2

### DIFF
--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -417,8 +417,8 @@ class TestGc < Test::Unit::TestCase
       # Run full GC again to collect stats about weak references
       GC.start
 
-      # Sometimes the WeakMap has one element, which might be held on by registers.
-      assert_operator(wmap.size, :<=, 1)
+      # Sometimes the WeakMap has a few elements, which might be held on by registers.
+      assert_operator(wmap.size, :<=, 2)
 
       assert_operator(GC.latest_gc_info(:weak_references_count), :<=, before_weak_references_count - count + error_tolerance)
       assert_operator(GC.latest_gc_info(:retained_weak_references_count), :<=, before_retained_weak_references_count - count + error_tolerance)


### PR DESCRIPTION
The test fails sometimes with:

    TestGc#test_latest_gc_info_weak_references_count [test/ruby/test_gc.rb:421]:
    Expected 2 to be <= 1.