### PR TITLE
[3.4 backport] Fix `Socket.tcp_with_fast_fallback` to be usable from a Ractor

### DIFF
--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -1021,8 +1021,8 @@ class Socket < BasicSocket
   private_constant :HostnameResolutionResult
 
   class HostnameResolutionStore
-    PRIORITY_ON_V6 = [:ipv6, :ipv4]
-    PRIORITY_ON_V4 = [:ipv4, :ipv6]
+    PRIORITY_ON_V6 = [:ipv6, :ipv4].freeze
+    PRIORITY_ON_V4 = [:ipv4, :ipv6].freeze
 
     def initialize(family_names)
       @family_names = family_names


### PR DESCRIPTION
[[Bug #21179]](https://bugs.ruby-lang.org/issues/21179)

```
socket.rb:1046:in 'Socket::HostnameResolutionStore#get_addrinfo': can not access non-shareable objects in constant
Socket::HostnameResolutionStore::PRIORITY_ON_V6 by non-main ractor. (Ractor::IsolationError)
	from socket.rb:724:in 'block in Socket.tcp_with_fast_fallback'
	from socket.rb:720:in 'Socket.tcp_with_fast_fallback'
```