### PR TITLE
Embed const caches that aren't cref dependent

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -2696,7 +2696,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                                               ic_index, ISEQ_IS_SIZE(body));
                             }
 
-                            vm_icc_set_segments(ic, array_to_idlist(operands[j]));
+                            vm_icc_init(ic, array_to_idlist(operands[j]));
 
                             generated_iseq[code_index + 1 + j] = (VALUE)ic;
                         }
@@ -12914,7 +12914,7 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
                     VALUE arr = ibf_load_object(load, op);
 
                     IC ic = &ISEQ_IS_IC_ENTRY(load_body, ic_index++);
-                    vm_icc_set_segments(ic, array_to_idlist(arr));
+                    vm_icc_init(ic, array_to_idlist(arr));
 
                     code[code_index] = (VALUE)ic;
                 }

--- a/compile.c
+++ b/compile.c
@@ -2696,7 +2696,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                                               ic_index, ISEQ_IS_SIZE(body));
                             }
 
-                            ic->segments = array_to_idlist(operands[j]);
+                            vm_cc_set_segments(ic, array_to_idlist(operands[j]));
 
                             generated_iseq[code_index + 1 + j] = (VALUE)ic;
                         }
@@ -12790,7 +12790,7 @@ ibf_dump_code(struct ibf_dump *dump, const rb_iseq_t *iseq)
               case TS_IC:
                 {
                     IC ic = (IC)op;
-                    VALUE arr = idlist_to_array(ic->segments);
+                    VALUE arr = idlist_to_array(vm_cc_segments(ic));
                     wv = ibf_dump_object(dump, arr);
                 }
                 break;
@@ -12914,7 +12914,7 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
                     VALUE arr = ibf_load_object(load, op);
 
                     IC ic = &ISEQ_IS_IC_ENTRY(load_body, ic_index++);
-                    ic->segments = array_to_idlist(arr);
+                    vm_cc_set_segments(ic, array_to_idlist(arr));
 
                     code[code_index] = (VALUE)ic;
                 }

--- a/compile.c
+++ b/compile.c
@@ -2696,7 +2696,7 @@ iseq_set_sequence(rb_iseq_t *iseq, LINK_ANCHOR *const anchor)
                                               ic_index, ISEQ_IS_SIZE(body));
                             }
 
-                            vm_cc_set_segments(ic, array_to_idlist(operands[j]));
+                            vm_icc_set_segments(ic, array_to_idlist(operands[j]));
 
                             generated_iseq[code_index + 1 + j] = (VALUE)ic;
                         }
@@ -12790,7 +12790,7 @@ ibf_dump_code(struct ibf_dump *dump, const rb_iseq_t *iseq)
               case TS_IC:
                 {
                     IC ic = (IC)op;
-                    VALUE arr = idlist_to_array(vm_cc_segments(ic));
+                    VALUE arr = idlist_to_array(vm_icc_segments(ic));
                     wv = ibf_dump_object(dump, arr);
                 }
                 break;
@@ -12914,7 +12914,7 @@ ibf_load_code(const struct ibf_load *load, rb_iseq_t *iseq, ibf_offset_t bytecod
                     VALUE arr = ibf_load_object(load, op);
 
                     IC ic = &ISEQ_IS_IC_ENTRY(load_body, ic_index++);
-                    vm_cc_set_segments(ic, array_to_idlist(arr));
+                    vm_icc_set_segments(ic, array_to_idlist(arr));
 
                     code[code_index] = (VALUE)ic;
                 }

--- a/iseq.c
+++ b/iseq.c
@@ -141,7 +141,7 @@ iseq_clear_ic_references(const rb_iseq_t *iseq)
 
         // Iterate over the IC's constant path's segments and clean any references to
         // the ICs out of the VM's constant cache table.
-        const ID *segments = vm_cc_segments(ic);
+        const ID *segments = vm_icc_segments(ic);
 
         // It's possible that segments is NULL if we overallocated an IC but
         // optimizations removed the instruction using it
@@ -459,7 +459,7 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
             /* IC entries constant segments */
             for (unsigned int ic_idx = 0; ic_idx < body->ic_size; ic_idx++) {
                 IC ic = &ISEQ_IS_IC_ENTRY(body, ic_idx);
-                const ID *ids = vm_cc_segments((IC)ic);
+                const ID *ids = vm_icc_segments((IC)ic);
                 if (!ids) continue;
                 while (*ids++) {
                     size += sizeof(ID);
@@ -2485,7 +2485,7 @@ rb_insn_operand_intern(const rb_iseq_t *iseq,
       case TS_IC:
         {
             ret = rb_sprintf("<ic:%"PRIdPTRDIFF" ", (union iseq_inline_storage_entry *)op - ISEQ_BODY(iseq)->is_entries);
-            const ID *segments = vm_cc_segments((IC)op);
+            const ID *segments = vm_icc_segments((IC)op);
             rb_str_cat2(ret, rb_id2name(*segments++));
             while (*segments) {
                 rb_str_catf(ret, "::%s", rb_id2name(*segments++));
@@ -3364,7 +3364,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
               case TS_IC:
                 {
                     VALUE list = rb_ary_new();
-                    const ID *ids = vm_cc_segments((IC)*seq);
+                    const ID *ids = vm_icc_segments((IC)*seq);
                     while (*ids) {
                         rb_ary_push(list, ID2SYM(*ids++));
                     }

--- a/iseq.c
+++ b/iseq.c
@@ -268,9 +268,8 @@ rb_iseq_mark_and_move_each_value(const rb_iseq_t *iseq, VALUE *original_iseq)
         // IC Entries
         for (unsigned int i = 0; i < body->ic_size; i++, is_entries++) {
             IC ic = (IC)is_entries;
-            if (vm_icc_has_ext(ic)) {
-                rb_gc_mark_and_move_ptr(&ic->ext);
-            }
+            // ic->ext is either an IMEMO/constcache or the cached value.
+            rb_gc_mark_and_move_ptr(&ic->ext);
         }
     }
 

--- a/iseq.c
+++ b/iseq.c
@@ -268,7 +268,7 @@ rb_iseq_mark_and_move_each_value(const rb_iseq_t *iseq, VALUE *original_iseq)
         // IC Entries
         for (unsigned int i = 0; i < body->ic_size; i++, is_entries++) {
             IC ic = (IC)is_entries;
-            if (ic->entry) {
+            if (vm_icc_has_entry(ic)) {
                 rb_gc_mark_and_move_ptr(&ic->entry);
             }
         }

--- a/iseq.c
+++ b/iseq.c
@@ -268,8 +268,8 @@ rb_iseq_mark_and_move_each_value(const rb_iseq_t *iseq, VALUE *original_iseq)
         // IC Entries
         for (unsigned int i = 0; i < body->ic_size; i++, is_entries++) {
             IC ic = (IC)is_entries;
-            if (vm_icc_has_entry(ic)) {
-                rb_gc_mark_and_move_ptr(&ic->entry);
+            if (vm_icc_has_ext(ic)) {
+                rb_gc_mark_and_move_ptr(&ic->ext);
             }
         }
     }

--- a/iseq.c
+++ b/iseq.c
@@ -141,7 +141,7 @@ iseq_clear_ic_references(const rb_iseq_t *iseq)
 
         // Iterate over the IC's constant path's segments and clean any references to
         // the ICs out of the VM's constant cache table.
-        const ID *segments = ic->segments;
+        const ID *segments = vm_cc_segments(ic);
 
         // It's possible that segments is NULL if we overallocated an IC but
         // optimizations removed the instruction using it
@@ -459,7 +459,7 @@ rb_iseq_memsize(const rb_iseq_t *iseq)
             /* IC entries constant segments */
             for (unsigned int ic_idx = 0; ic_idx < body->ic_size; ic_idx++) {
                 IC ic = &ISEQ_IS_IC_ENTRY(body, ic_idx);
-                const ID *ids = ic->segments;
+                const ID *ids = vm_cc_segments((IC)ic);
                 if (!ids) continue;
                 while (*ids++) {
                     size += sizeof(ID);
@@ -2485,7 +2485,7 @@ rb_insn_operand_intern(const rb_iseq_t *iseq,
       case TS_IC:
         {
             ret = rb_sprintf("<ic:%"PRIdPTRDIFF" ", (union iseq_inline_storage_entry *)op - ISEQ_BODY(iseq)->is_entries);
-            const ID *segments = ((IC)op)->segments;
+            const ID *segments = vm_cc_segments((IC)op);
             rb_str_cat2(ret, rb_id2name(*segments++));
             while (*segments) {
                 rb_str_catf(ret, "::%s", rb_id2name(*segments++));
@@ -3364,7 +3364,7 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
               case TS_IC:
                 {
                     VALUE list = rb_ary_new();
-                    const ID *ids = ((IC)*seq)->segments;
+                    const ID *ids = vm_cc_segments((IC)*seq);
                     while (*ids) {
                         rb_ary_push(list, ID2SYM(*ids++));
                     }

--- a/iseq.c
+++ b/iseq.c
@@ -269,7 +269,7 @@ rb_iseq_mark_and_move_each_value(const rb_iseq_t *iseq, VALUE *original_iseq)
         for (unsigned int i = 0; i < body->ic_size; i++, is_entries++) {
             IC ic = (IC)is_entries;
             // ic->ext is either an IMEMO/constcache or the cached value.
-            rb_gc_mark_and_move_ptr(&ic->ext);
+            rb_gc_mark_and_move_ptr(&ic->c.ext);
         }
     }
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -309,6 +309,18 @@ vm_cc_flags(const struct iseq_inline_constant_cache *cc)
     return cc->entry->flags;
 }
 
+static inline VALUE
+vm_cc_value(const struct iseq_inline_constant_cache *cc)
+{
+    return cc->entry->value;
+}
+
+static inline void
+vm_cc_set_value(struct iseq_inline_constant_cache *cc, VALUE value)
+{
+    RB_OBJ_WRITE(cc->entry, &cc->entry->value, value);
+}
+
 struct iseq_inline_iv_cache_entry {
     uintptr_t value; // attr_index in lower bits, dest_shape_id in upper bits
     ID iv_set_name;

--- a/vm_core.h
+++ b/vm_core.h
@@ -312,6 +312,14 @@ vm_icc_is_set(const struct iseq_inline_constant_cache *cc)
 }
 
 static inline void
+vm_icc_reset(struct iseq_inline_constant_cache *cc)
+{
+    if (!UNDEF_P(cc->value)) {
+        cc->value = Qundef;
+    }
+}
+
+static inline void
 vm_icc_init(struct iseq_inline_constant_cache *cc, const ID *segments)
 {
     cc->value = Qundef;

--- a/vm_core.h
+++ b/vm_core.h
@@ -286,49 +286,49 @@ struct iseq_inline_constant_cache {
 };
 
 static inline void
-vm_cc_set_segments(struct iseq_inline_constant_cache *cc, const ID *segments)
+vm_icc_set_segments(struct iseq_inline_constant_cache *cc, const ID *segments)
 {
     cc->segments = segments;
 }
 
 static inline const ID *
-vm_cc_segments(const struct iseq_inline_constant_cache *cc)
+vm_icc_segments(const struct iseq_inline_constant_cache *cc)
 {
     return cc->segments;
 }
 
 static inline void
-vm_cc_set_flag(struct iseq_inline_constant_cache *cc, VALUE flag)
+vm_icc_set_flag(struct iseq_inline_constant_cache *cc, VALUE flag)
 {
     cc->entry->flags |= flag;
 }
 
 static inline VALUE
-vm_cc_flags(const struct iseq_inline_constant_cache *cc)
+vm_icc_flags(const struct iseq_inline_constant_cache *cc)
 {
     return cc->entry->flags;
 }
 
 static inline VALUE
-vm_cc_value(const struct iseq_inline_constant_cache *cc)
+vm_icc_value(const struct iseq_inline_constant_cache *cc)
 {
     return cc->entry->value;
 }
 
 static inline void
-vm_cc_set_value(struct iseq_inline_constant_cache *cc, VALUE value)
+vm_icc_set_value(struct iseq_inline_constant_cache *cc, VALUE value)
 {
     RB_OBJ_WRITE(cc->entry, &cc->entry->value, value);
 }
 
 static inline const rb_cref_t *
-vm_cc_cref(const struct iseq_inline_constant_cache *cc)
+vm_icc_cref(const struct iseq_inline_constant_cache *cc)
 {
     return cc->entry->ic_cref;
 }
 
 static inline void
-vm_cc_set_cref(struct iseq_inline_constant_cache *cc, const rb_cref_t *cref)
+vm_icc_set_cref(struct iseq_inline_constant_cache *cc, const rb_cref_t *cref)
 {
     cc->entry->ic_cref = cref;
 }

--- a/vm_core.h
+++ b/vm_core.h
@@ -297,6 +297,18 @@ vm_cc_segments(const struct iseq_inline_constant_cache *cc)
     return cc->segments;
 }
 
+static inline void
+vm_cc_set_flag(struct iseq_inline_constant_cache *cc, VALUE flag)
+{
+    cc->entry->flags |= flag;
+}
+
+static inline VALUE
+vm_cc_flags(const struct iseq_inline_constant_cache *cc)
+{
+    return cc->entry->flags;
+}
+
 struct iseq_inline_iv_cache_entry {
     uintptr_t value; // attr_index in lower bits, dest_shape_id in upper bits
     ID iv_set_name;

--- a/vm_core.h
+++ b/vm_core.h
@@ -305,6 +305,12 @@ vm_icc_has_entry(const struct iseq_inline_constant_cache *cc)
     return vm_icc_flags(cc) & IMEMO_CONST_CACHE_HAS_ENTRY;
 }
 
+static inline bool
+vm_icc_is_set(const struct iseq_inline_constant_cache *cc)
+{
+    return !UNDEF_P(cc->value);
+}
+
 static inline void
 vm_icc_init(struct iseq_inline_constant_cache *cc, const ID *segments)
 {

--- a/vm_core.h
+++ b/vm_core.h
@@ -285,6 +285,18 @@ struct iseq_inline_constant_cache {
     const ID *segments;
 };
 
+static inline void
+vm_cc_set_segments(struct iseq_inline_constant_cache *cc, const ID *segments)
+{
+    cc->segments = segments;
+}
+
+static inline const ID *
+vm_cc_segments(const struct iseq_inline_constant_cache *cc)
+{
+    return cc->segments;
+}
+
 struct iseq_inline_iv_cache_entry {
     uintptr_t value; // attr_index in lower bits, dest_shape_id in upper bits
     ID iv_set_name;

--- a/vm_core.h
+++ b/vm_core.h
@@ -321,6 +321,18 @@ vm_cc_set_value(struct iseq_inline_constant_cache *cc, VALUE value)
     RB_OBJ_WRITE(cc->entry, &cc->entry->value, value);
 }
 
+static inline const rb_cref_t *
+vm_cc_cref(const struct iseq_inline_constant_cache *cc)
+{
+    return cc->entry->ic_cref;
+}
+
+static inline void
+vm_cc_set_cref(struct iseq_inline_constant_cache *cc, const rb_cref_t *cref)
+{
+    cc->entry->ic_cref = cref;
+}
+
 struct iseq_inline_iv_cache_entry {
     uintptr_t value; // attr_index in lower bits, dest_shape_id in upper bits
     ID iv_set_name;

--- a/vm_core.h
+++ b/vm_core.h
@@ -276,7 +276,7 @@ struct iseq_inline_constant_cache {
     union {
         struct iseq_inline_constant_cache_entry *ext;
         VALUE value; // value is Qundef if the cache hasn't been set
-    };
+    } c;
 
     VALUE tagged_segments;
 };
@@ -296,21 +296,21 @@ vm_icc_has_ext(const struct iseq_inline_constant_cache *cc)
 static inline bool
 vm_icc_is_set(const struct iseq_inline_constant_cache *cc)
 {
-    return !UNDEF_P(cc->value);
+    return !UNDEF_P(cc->c.value);
 }
 
 static inline void
 vm_icc_reset(struct iseq_inline_constant_cache *cc)
 {
-    if (!UNDEF_P(cc->value)) {
-        cc->value = Qundef;
+    if (!UNDEF_P(cc->c.value)) {
+        cc->c.value = Qundef;
     }
 }
 
 static inline void
 vm_icc_init(struct iseq_inline_constant_cache *cc, const ID *segments)
 {
-    cc->value = Qundef;
+    cc->c.value = Qundef;
     cc->tagged_segments = (VALUE)segments;
 }
 
@@ -341,10 +341,10 @@ static inline VALUE
 vm_icc_value(const struct iseq_inline_constant_cache *cc)
 {
     if (vm_icc_has_ext(cc)) {
-        return cc->ext->value;
+        return cc->c.ext->value;
     }
     else {
-        return cc->value;
+        return cc->c.value;
     }
 }
 
@@ -352,7 +352,7 @@ static inline const rb_cref_t *
 vm_icc_cref(const struct iseq_inline_constant_cache *cc)
 {
     if (vm_icc_has_ext(cc)) {
-        return cc->ext->ic_cref;
+        return cc->c.ext->ic_cref;
     }
     return NULL;
 }

--- a/vm_core.h
+++ b/vm_core.h
@@ -304,6 +304,7 @@ vm_icc_reset(struct iseq_inline_constant_cache *cc)
 {
     if (!UNDEF_P(cc->c.value)) {
         cc->c.value = Qundef;
+        cc->tagged_segments &= ~CONST_CACHE_HAS_EXT;
     }
 }
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -304,7 +304,7 @@ vm_icc_reset(struct iseq_inline_constant_cache *cc)
 {
     if (!UNDEF_P(cc->c.value)) {
         cc->c.value = Qundef;
-        cc->tagged_segments &= ~CONST_CACHE_HAS_EXT;
+        cc->tagged_segments &= ~CONST_CACHE_FLAGS_MASK;
     }
 }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6403,9 +6403,7 @@ vm_ic_update(const rb_iseq_t *iseq, IC ic, VALUE val, const VALUE *reg_ep, const
 {
     if (ruby_vm_const_missing_count > 0) {
         ruby_vm_const_missing_count = 0;
-        if (!vm_icc_is_set(ic)) {
-            ic->value = Qundef;
-        }
+        vm_icc_reset(ic);
         return;
     }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6403,7 +6403,9 @@ vm_ic_update(const rb_iseq_t *iseq, IC ic, VALUE val, const VALUE *reg_ep, const
 {
     if (ruby_vm_const_missing_count > 0) {
         ruby_vm_const_missing_count = 0;
-        ic->entry = NULL;
+        if (!vm_icc_is_set(ic)) {
+            ic->value = Qundef;
+        }
         return;
     }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6388,9 +6388,8 @@ vm_inlined_ic_hit_p(VALUE flags, VALUE value, const rb_cref_t *ic_cref, const VA
 static bool
 vm_ic_hit_p(const struct iseq_inline_constant_cache *ic, const VALUE *reg_ep)
 {
-    const struct iseq_inline_constant_cache_entry *ice = ic->entry;
     VM_ASSERT(IMEMO_TYPE_P(ice, imemo_constcache));
-    return vm_inlined_ic_hit_p(vm_cc_flags(ic), vm_cc_value(ic), ice->ic_cref, reg_ep);
+    return vm_inlined_ic_hit_p(vm_cc_flags(ic), vm_cc_value(ic), vm_cc_cref(ic), reg_ep);
 }
 
 // YJIT needs this function to never allocate and never raise
@@ -6412,7 +6411,7 @@ vm_ic_update(const rb_iseq_t *iseq, IC ic, VALUE val, const VALUE *reg_ep, const
     struct iseq_inline_constant_cache_entry *ice = IMEMO_NEW(struct iseq_inline_constant_cache_entry, imemo_constcache, 0);
     RB_OBJ_WRITE(iseq, &ic->entry, ice);
     vm_cc_set_value(ic, val);
-    ice->ic_cref = vm_get_const_key_cref(reg_ep);
+    vm_cc_set_cref(ic, vm_get_const_key_cref(reg_ep));
     if (rb_ractor_shareable_p(val)) vm_cc_set_flag(ic, IMEMO_CONST_CACHE_SHAREABLE);
 
     RUBY_ASSERT(pc >= ISEQ_BODY(iseq)->iseq_encoded);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6389,7 +6389,7 @@ static bool
 vm_ic_hit_p(const struct iseq_inline_constant_cache *ic, const VALUE *reg_ep)
 {
     VM_ASSERT(IMEMO_TYPE_P(ice, imemo_constcache));
-    return vm_inlined_ic_hit_p(vm_cc_flags(ic), vm_cc_value(ic), vm_cc_cref(ic), reg_ep);
+    return vm_inlined_ic_hit_p(vm_icc_flags(ic), vm_icc_value(ic), vm_icc_cref(ic), reg_ep);
 }
 
 // YJIT needs this function to never allocate and never raise
@@ -6410,9 +6410,9 @@ vm_ic_update(const rb_iseq_t *iseq, IC ic, VALUE val, const VALUE *reg_ep, const
 
     struct iseq_inline_constant_cache_entry *ice = IMEMO_NEW(struct iseq_inline_constant_cache_entry, imemo_constcache, 0);
     RB_OBJ_WRITE(iseq, &ic->entry, ice);
-    vm_cc_set_value(ic, val);
-    vm_cc_set_cref(ic, vm_get_const_key_cref(reg_ep));
-    if (rb_ractor_shareable_p(val)) vm_cc_set_flag(ic, IMEMO_CONST_CACHE_SHAREABLE);
+    vm_icc_set_value(ic, val);
+    vm_icc_set_cref(ic, vm_get_const_key_cref(reg_ep));
+    if (rb_ractor_shareable_p(val)) vm_icc_set_flag(ic, IMEMO_CONST_CACHE_SHAREABLE);
 
     RUBY_ASSERT(pc >= ISEQ_BODY(iseq)->iseq_encoded);
     unsigned pos = (unsigned)(pc - ISEQ_BODY(iseq)->iseq_encoded);
@@ -6423,10 +6423,10 @@ VALUE
 rb_vm_opt_getconstant_path(rb_execution_context_t *ec, rb_control_frame_t *const reg_cfp, IC ic)
 {
     VALUE val;
-    const ID *segments = vm_cc_segments(ic);
+    const ID *segments = vm_icc_segments(ic);
     struct iseq_inline_constant_cache_entry *ice = ic->entry;
     if (ice && vm_ic_hit_p(ic, GET_EP())) {
-        val = vm_cc_value(ic);
+        val = vm_icc_value(ic);
 
         VM_ASSERT(val == vm_get_ev_const_chain(ec, segments));
     }

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6388,7 +6388,6 @@ vm_inlined_ic_hit_p(VALUE flags, VALUE value, const rb_cref_t *ic_cref, const VA
 static bool
 vm_ic_hit_p(const struct iseq_inline_constant_cache *ic, const VALUE *reg_ep)
 {
-    VM_ASSERT(IMEMO_TYPE_P(ice, imemo_constcache));
     return vm_inlined_ic_hit_p(vm_icc_flags(ic), vm_icc_value(ic), vm_icc_cref(ic), reg_ep);
 }
 
@@ -6396,7 +6395,7 @@ vm_ic_hit_p(const struct iseq_inline_constant_cache *ic, const VALUE *reg_ep)
 bool
 rb_vm_ic_hit_p(IC ic, const VALUE *reg_ep)
 {
-    return ic->entry && vm_ic_hit_p(ic, reg_ep);
+    return vm_icc_is_set(ic) && vm_ic_hit_p(ic, reg_ep);
 }
 
 static void
@@ -6432,7 +6431,7 @@ rb_vm_opt_getconstant_path(rb_execution_context_t *ec, rb_control_frame_t *const
 {
     VALUE val;
     const ID *segments = vm_icc_segments(ic);
-    if (!UNDEF_P(ic->value) && vm_ic_hit_p(ic, GET_EP())) {
+    if (vm_icc_is_set(ic) && vm_ic_hit_p(ic, GET_EP())) {
         val = vm_icc_value(ic);
 
         VM_ASSERT(val == vm_get_ev_const_chain(ec, segments));

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6408,11 +6408,19 @@ vm_ic_update(const rb_iseq_t *iseq, IC ic, VALUE val, const VALUE *reg_ep, const
         return;
     }
 
-    struct iseq_inline_constant_cache_entry *ice = IMEMO_NEW(struct iseq_inline_constant_cache_entry, imemo_constcache, 0);
-    RB_OBJ_WRITE(iseq, &ic->entry, ice);
-    vm_icc_set_value(ic, val);
-    vm_icc_set_cref(ic, vm_get_const_key_cref(reg_ep));
+    const rb_cref_t *cref = vm_get_const_key_cref(reg_ep);
+    if (cref) {
+        vm_icc_set_flag(ic, IMEMO_CONST_CACHE_HAS_ENTRY);
+        struct iseq_inline_constant_cache_entry *ice = IMEMO_NEW(struct iseq_inline_constant_cache_entry, imemo_constcache, 0);
+        RB_OBJ_WRITE(iseq, &ic->entry, ice);
+        RB_OBJ_WRITE(ic->entry, &ic->entry->value, val);
+        ic->entry->ic_cref = vm_get_const_key_cref(reg_ep);
+    }
+    else {
+        RB_OBJ_WRITE(iseq, &ic->value, val);
+    }
     if (rb_ractor_shareable_p(val)) vm_icc_set_flag(ic, IMEMO_CONST_CACHE_SHAREABLE);
+    /* vm_icc_update(ic, val, ) */
 
     RUBY_ASSERT(pc >= ISEQ_BODY(iseq)->iseq_encoded);
     unsigned pos = (unsigned)(pc - ISEQ_BODY(iseq)->iseq_encoded);
@@ -6424,8 +6432,7 @@ rb_vm_opt_getconstant_path(rb_execution_context_t *ec, rb_control_frame_t *const
 {
     VALUE val;
     const ID *segments = vm_icc_segments(ic);
-    struct iseq_inline_constant_cache_entry *ice = ic->entry;
-    if (ice && vm_ic_hit_p(ic, GET_EP())) {
+    if (!UNDEF_P(ic->value) && vm_ic_hit_p(ic, GET_EP())) {
         val = vm_icc_value(ic);
 
         VM_ASSERT(val == vm_get_ev_const_chain(ec, segments));

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6411,12 +6411,12 @@ vm_ic_update(const rb_iseq_t *iseq, IC ic, VALUE val, const VALUE *reg_ep, const
     if (cref) {
         vm_icc_set_flag(ic, CONST_CACHE_HAS_EXT);
         struct iseq_inline_constant_cache_entry *ice = IMEMO_NEW(struct iseq_inline_constant_cache_entry, imemo_constcache, 0);
-        RB_OBJ_WRITE(iseq, &ic->ext, ice);
-        RB_OBJ_WRITE(ic->ext, &ic->ext->value, val);
-        ic->ext->ic_cref = cref;
+        RB_OBJ_WRITE(iseq, &ic->c.ext, ice);
+        RB_OBJ_WRITE(ic->c.ext, &ice->value, val);
+        ice->ic_cref = cref;
     }
     else {
-        RB_OBJ_WRITE(iseq, &ic->value, val);
+        RB_OBJ_WRITE(iseq, &ic->c.value, val);
     }
     if (rb_ractor_shareable_p(val)) vm_icc_set_flag(ic, CONST_CACHE_SHAREABLE);
     /* vm_icc_update(ic, val, ) */

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6386,17 +6386,18 @@ vm_inlined_ic_hit_p(VALUE flags, VALUE value, const rb_cref_t *ic_cref, const VA
 }
 
 static bool
-vm_ic_hit_p(const struct iseq_inline_constant_cache_entry *ice, const VALUE *reg_ep)
+vm_ic_hit_p(const struct iseq_inline_constant_cache *ic, const VALUE *reg_ep)
 {
+    const struct iseq_inline_constant_cache_entry *ice = ic->entry;
     VM_ASSERT(IMEMO_TYPE_P(ice, imemo_constcache));
-    return vm_inlined_ic_hit_p(ice->flags, ice->value, ice->ic_cref, reg_ep);
+    return vm_inlined_ic_hit_p(vm_cc_flags(ic), ice->value, ice->ic_cref, reg_ep);
 }
 
 // YJIT needs this function to never allocate and never raise
 bool
 rb_vm_ic_hit_p(IC ic, const VALUE *reg_ep)
 {
-    return ic->entry && vm_ic_hit_p(ic->entry, reg_ep);
+    return ic->entry && vm_ic_hit_p(ic, reg_ep);
 }
 
 static void
@@ -6411,8 +6412,8 @@ vm_ic_update(const rb_iseq_t *iseq, IC ic, VALUE val, const VALUE *reg_ep, const
     struct iseq_inline_constant_cache_entry *ice = IMEMO_NEW(struct iseq_inline_constant_cache_entry, imemo_constcache, 0);
     RB_OBJ_WRITE(ice, &ice->value, val);
     ice->ic_cref = vm_get_const_key_cref(reg_ep);
-    if (rb_ractor_shareable_p(val)) ice->flags |= IMEMO_CONST_CACHE_SHAREABLE;
     RB_OBJ_WRITE(iseq, &ic->entry, ice);
+    if (rb_ractor_shareable_p(val)) vm_cc_set_flag(ic, IMEMO_CONST_CACHE_SHAREABLE);
 
     RUBY_ASSERT(pc >= ISEQ_BODY(iseq)->iseq_encoded);
     unsigned pos = (unsigned)(pc - ISEQ_BODY(iseq)->iseq_encoded);
@@ -6425,7 +6426,7 @@ rb_vm_opt_getconstant_path(rb_execution_context_t *ec, rb_control_frame_t *const
     VALUE val;
     const ID *segments = vm_cc_segments(ic);
     struct iseq_inline_constant_cache_entry *ice = ic->entry;
-    if (ice && vm_ic_hit_p(ice, GET_EP())) {
+    if (ice && vm_ic_hit_p(ic, GET_EP())) {
         val = ice->value;
 
         VM_ASSERT(val == vm_get_ev_const_chain(ec, segments));

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6401,9 +6401,10 @@ rb_vm_ic_hit_p(IC ic, const VALUE *reg_ep)
 static void
 vm_ic_update(const rb_iseq_t *iseq, IC ic, VALUE val, const VALUE *reg_ep, const VALUE *pc)
 {
+    vm_icc_reset(ic);
+
     if (ruby_vm_const_missing_count > 0) {
         ruby_vm_const_missing_count = 0;
-        vm_icc_reset(ic);
         return;
     }
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6376,8 +6376,8 @@ vm_ic_track_const_chain(rb_control_frame_t *cfp, IC ic, const ID *segments)
 static inline bool
 vm_inlined_ic_hit_p(VALUE flags, VALUE value, const rb_cref_t *ic_cref, const VALUE *reg_ep)
 {
-    if ((flags & IMEMO_CONST_CACHE_SHAREABLE) || rb_ractor_main_p()) {
-        VM_ASSERT(ractor_incidental_shareable_p(flags & IMEMO_CONST_CACHE_SHAREABLE, value));
+    if ((flags & CONST_CACHE_SHAREABLE) || rb_ractor_main_p()) {
+        VM_ASSERT(ractor_incidental_shareable_p(flags & CONST_CACHE_SHAREABLE, value));
 
         return (ic_cref == NULL || // no need to check CREF
                 ic_cref == vm_get_cref(reg_ep));
@@ -6409,16 +6409,16 @@ vm_ic_update(const rb_iseq_t *iseq, IC ic, VALUE val, const VALUE *reg_ep, const
 
     const rb_cref_t *cref = vm_get_const_key_cref(reg_ep);
     if (cref) {
-        vm_icc_set_flag(ic, IMEMO_CONST_CACHE_HAS_ENTRY);
+        vm_icc_set_flag(ic, CONST_CACHE_HAS_EXT);
         struct iseq_inline_constant_cache_entry *ice = IMEMO_NEW(struct iseq_inline_constant_cache_entry, imemo_constcache, 0);
-        RB_OBJ_WRITE(iseq, &ic->entry, ice);
-        RB_OBJ_WRITE(ic->entry, &ic->entry->value, val);
-        ic->entry->ic_cref = vm_get_const_key_cref(reg_ep);
+        RB_OBJ_WRITE(iseq, &ic->ext, ice);
+        RB_OBJ_WRITE(ic->ext, &ic->ext->value, val);
+        ic->ext->ic_cref = cref;
     }
     else {
         RB_OBJ_WRITE(iseq, &ic->value, val);
     }
-    if (rb_ractor_shareable_p(val)) vm_icc_set_flag(ic, IMEMO_CONST_CACHE_SHAREABLE);
+    if (rb_ractor_shareable_p(val)) vm_icc_set_flag(ic, CONST_CACHE_SHAREABLE);
     /* vm_icc_update(ic, val, ) */
 
     RUBY_ASSERT(pc >= ISEQ_BODY(iseq)->iseq_encoded);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6423,7 +6423,7 @@ VALUE
 rb_vm_opt_getconstant_path(rb_execution_context_t *ec, rb_control_frame_t *const reg_cfp, IC ic)
 {
     VALUE val;
-    const ID *segments = ic->segments;
+    const ID *segments = vm_cc_segments(ic);
     struct iseq_inline_constant_cache_entry *ice = ic->entry;
     if (ice && vm_ic_hit_p(ice, GET_EP())) {
         val = ice->value;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6390,7 +6390,7 @@ vm_ic_hit_p(const struct iseq_inline_constant_cache *ic, const VALUE *reg_ep)
 {
     const struct iseq_inline_constant_cache_entry *ice = ic->entry;
     VM_ASSERT(IMEMO_TYPE_P(ice, imemo_constcache));
-    return vm_inlined_ic_hit_p(vm_cc_flags(ic), ice->value, ice->ic_cref, reg_ep);
+    return vm_inlined_ic_hit_p(vm_cc_flags(ic), vm_cc_value(ic), ice->ic_cref, reg_ep);
 }
 
 // YJIT needs this function to never allocate and never raise
@@ -6410,9 +6410,9 @@ vm_ic_update(const rb_iseq_t *iseq, IC ic, VALUE val, const VALUE *reg_ep, const
     }
 
     struct iseq_inline_constant_cache_entry *ice = IMEMO_NEW(struct iseq_inline_constant_cache_entry, imemo_constcache, 0);
-    RB_OBJ_WRITE(ice, &ice->value, val);
-    ice->ic_cref = vm_get_const_key_cref(reg_ep);
     RB_OBJ_WRITE(iseq, &ic->entry, ice);
+    vm_cc_set_value(ic, val);
+    ice->ic_cref = vm_get_const_key_cref(reg_ep);
     if (rb_ractor_shareable_p(val)) vm_cc_set_flag(ic, IMEMO_CONST_CACHE_SHAREABLE);
 
     RUBY_ASSERT(pc >= ISEQ_BODY(iseq)->iseq_encoded);
@@ -6427,7 +6427,7 @@ rb_vm_opt_getconstant_path(rb_execution_context_t *ec, rb_control_frame_t *const
     const ID *segments = vm_cc_segments(ic);
     struct iseq_inline_constant_cache_entry *ice = ic->entry;
     if (ice && vm_ic_hit_p(ic, GET_EP())) {
-        val = ice->value;
+        val = vm_cc_value(ic);
 
         VM_ASSERT(val == vm_get_ev_const_chain(ec, segments));
     }

--- a/vm_method.c
+++ b/vm_method.c
@@ -127,7 +127,7 @@ vm_cme_invalidate(rb_callable_method_entry_t *cme)
 static int
 rb_clear_constant_cache_for_id_i(st_data_t ic, st_data_t idx, st_data_t arg)
 {
-    ((IC) ic)->entry = NULL;
+    vm_icc_reset((IC) ic);
     return ST_CONTINUE;
 }
 

--- a/yjit.c
+++ b/yjit.c
@@ -1069,10 +1069,28 @@ rb_IMEMO_TYPE_P(VALUE imemo, enum imemo_type imemo_type)
     return IMEMO_TYPE_P(imemo, imemo_type);
 }
 
+VALUE
+rb_yjit_constcache_value(const struct iseq_inline_constant_cache *ic)
+{
+    return vm_icc_value(ic);
+}
+
+const ID *
+rb_yjit_constcache_segments(const struct iseq_inline_constant_cache *ic)
+{
+    return vm_icc_segments(ic);
+}
+
+const rb_cref_t *
+rb_yjit_constcache_cref(const struct iseq_inline_constant_cache *ic)
+{
+    return vm_icc_cref(ic);
+}
+
 bool
 rb_yjit_constcache_shareable(const struct iseq_inline_constant_cache *ic)
 {
-    return (vm_icc_flags(ic) & IMEMO_CONST_CACHE_SHAREABLE) != 0;
+    return (vm_icc_flags(ic) & CONST_CACHE_SHAREABLE) != 0;
 }
 
 void

--- a/yjit.c
+++ b/yjit.c
@@ -1072,7 +1072,7 @@ rb_IMEMO_TYPE_P(VALUE imemo, enum imemo_type imemo_type)
 bool
 rb_yjit_constcache_shareable(const struct iseq_inline_constant_cache *ic)
 {
-    return (vm_cc_flags(ic) & IMEMO_CONST_CACHE_SHAREABLE) != 0;
+    return (vm_icc_flags(ic) & IMEMO_CONST_CACHE_SHAREABLE) != 0;
 }
 
 void

--- a/yjit.c
+++ b/yjit.c
@@ -1069,6 +1069,12 @@ rb_IMEMO_TYPE_P(VALUE imemo, enum imemo_type imemo_type)
     return IMEMO_TYPE_P(imemo, imemo_type);
 }
 
+bool
+rb_yjit_constcache_has_ext(const struct iseq_inline_constant_cache *ic)
+{
+    return vm_icc_has_ext(ic);
+}
+
 VALUE
 rb_yjit_constcache_value(const struct iseq_inline_constant_cache *ic)
 {

--- a/yjit.c
+++ b/yjit.c
@@ -1070,9 +1070,9 @@ rb_IMEMO_TYPE_P(VALUE imemo, enum imemo_type imemo_type)
 }
 
 bool
-rb_yjit_constcache_shareable(const struct iseq_inline_constant_cache_entry *ice)
+rb_yjit_constcache_shareable(const struct iseq_inline_constant_cache *ic)
 {
-    return (ice->flags & IMEMO_CONST_CACHE_SHAREABLE) != 0;
+    return (vm_cc_flags(ic) & IMEMO_CONST_CACHE_SHAREABLE) != 0;
 }
 
 void

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -280,7 +280,6 @@ fn main() {
         .allowlist_function("rb_vm_frame_method_entry")
         .allowlist_type("IVC") // pointer to iseq_inline_iv_cache_entry
         .allowlist_type("IC")  // pointer to iseq_inline_constant_cache
-        .allowlist_type("iseq_inline_constant_cache_entry")
         .blocklist_type("rb_cref_t")         // don't need this directly, opaqued to allow IC import
         .opaque_type("rb_cref_t")
         .allowlist_type("iseq_inline_iv_cache_entry")
@@ -326,7 +325,10 @@ fn main() {
         .allowlist_function("rb_yjit_vm_unlock")
         .allowlist_function("rb_assert_(iseq|cme)_handle")
         .allowlist_function("rb_IMEMO_TYPE_P")
+        .allowlist_function("rb_yjit_constcache_cref")
+        .allowlist_function("rb_yjit_constcache_segments")
         .allowlist_function("rb_yjit_constcache_shareable")
+        .allowlist_function("rb_yjit_constcache_value")
         .allowlist_function("rb_iseq_reset_jit_func")
         .allowlist_function("rb_yjit_dump_iseq_loc")
         .allowlist_function("rb_yjit_for_each_iseq")

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -326,6 +326,7 @@ fn main() {
         .allowlist_function("rb_assert_(iseq|cme)_handle")
         .allowlist_function("rb_IMEMO_TYPE_P")
         .allowlist_function("rb_yjit_constcache_cref")
+        .allowlist_function("rb_yjit_constcache_has_ext")
         .allowlist_function("rb_yjit_constcache_segments")
         .allowlist_function("rb_yjit_constcache_shareable")
         .allowlist_function("rb_yjit_constcache_value")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -10275,7 +10275,7 @@ fn gen_opt_getconstant_path(
     }
 
     let cref_sensitive = !unsafe { (*ice).ic_cref }.is_null();
-    let is_shareable = unsafe { rb_yjit_constcache_shareable(ice) };
+    let is_shareable = unsafe { rb_yjit_constcache_shareable(ic) };
     let needs_checks = cref_sensitive || (!is_shareable && !assume_single_ractor_mode(jit, asm));
 
     if needs_checks {

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1268,7 +1268,7 @@ extern "C" {
     pub fn rb_yjit_multi_ractor_p() -> bool;
     pub fn rb_assert_iseq_handle(handle: VALUE);
     pub fn rb_IMEMO_TYPE_P(imemo: VALUE, imemo_type: imemo_type) -> ::std::os::raw::c_int;
-    pub fn rb_yjit_constcache_shareable(ice: *const iseq_inline_constant_cache_entry) -> bool;
+    pub fn rb_yjit_constcache_shareable(ic: *const iseq_inline_constant_cache) -> bool;
     pub fn rb_assert_cme_handle(handle: VALUE);
     pub fn rb_yjit_for_each_iseq(callback: rb_iseq_callback, data: *mut ::std::os::raw::c_void);
     pub fn rb_yjit_obj_written(

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -465,7 +465,7 @@ pub struct iseq_inline_constant_cache_entry {
 }
 #[repr(C)]
 pub struct iseq_inline_constant_cache {
-    pub __bindgen_anon_1: iseq_inline_constant_cache__bindgen_ty_1,
+    pub c: iseq_inline_constant_cache__bindgen_ty_1,
     pub tagged_segments: VALUE,
 }
 #[repr(C)]
@@ -1273,6 +1273,7 @@ extern "C" {
     pub fn rb_yjit_multi_ractor_p() -> bool;
     pub fn rb_assert_iseq_handle(handle: VALUE);
     pub fn rb_IMEMO_TYPE_P(imemo: VALUE, imemo_type: imemo_type) -> ::std::os::raw::c_int;
+    pub fn rb_yjit_constcache_has_ext(ic: *const iseq_inline_constant_cache) -> bool;
     pub fn rb_yjit_constcache_value(ic: *const iseq_inline_constant_cache) -> VALUE;
     pub fn rb_yjit_constcache_segments(ic: *const iseq_inline_constant_cache) -> *const ID;
     pub fn rb_yjit_constcache_cref(ic: *const iseq_inline_constant_cache) -> *const rb_cref_t;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -464,10 +464,15 @@ pub struct iseq_inline_constant_cache_entry {
     pub ic_cref: *const rb_cref_t,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct iseq_inline_constant_cache {
-    pub entry: *mut iseq_inline_constant_cache_entry,
-    pub segments: *const ID,
+    pub __bindgen_anon_1: iseq_inline_constant_cache__bindgen_ty_1,
+    pub tagged_segments: VALUE,
+}
+#[repr(C)]
+pub struct iseq_inline_constant_cache__bindgen_ty_1 {
+    pub ext: __BindgenUnionField<*mut iseq_inline_constant_cache_entry>,
+    pub value: __BindgenUnionField<VALUE>,
+    pub bindgen_union_field: u64,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -1268,6 +1273,9 @@ extern "C" {
     pub fn rb_yjit_multi_ractor_p() -> bool;
     pub fn rb_assert_iseq_handle(handle: VALUE);
     pub fn rb_IMEMO_TYPE_P(imemo: VALUE, imemo_type: imemo_type) -> ::std::os::raw::c_int;
+    pub fn rb_yjit_constcache_value(ic: *const iseq_inline_constant_cache) -> VALUE;
+    pub fn rb_yjit_constcache_segments(ic: *const iseq_inline_constant_cache) -> *const ID;
+    pub fn rb_yjit_constcache_cref(ic: *const iseq_inline_constant_cache) -> *const rb_cref_t;
     pub fn rb_yjit_constcache_shareable(ic: *const iseq_inline_constant_cache) -> bool;
     pub fn rb_assert_cme_handle(handle: VALUE);
     pub fn rb_yjit_for_each_iseq(callback: rb_iseq_callback, data: *mut ::std::os::raw::c_void);

--- a/yjit/src/invariants.rs
+++ b/yjit/src/invariants.rs
@@ -495,7 +495,7 @@ pub extern "C" fn rb_yjit_constant_ic_update(iseq: *const rb_iseq_t, ic: IC, ins
         return;
     };
 
-    if !unsafe { (*(*ic).entry).ic_cref }.is_null() || unsafe { rb_yjit_multi_ractor_p() } {
+    if !unsafe { rb_yjit_constcache_cref(ic) }.is_null() || unsafe { rb_yjit_multi_ractor_p() } {
         // We can't generate code in these situations, so no need to invalidate.
         // See gen_opt_getinlinecache.
         return;


### PR DESCRIPTION
Opening this as a draft to get some CI coverage. I already know RJIT is broken.

Currently all `iseq_inline_constant_cache` have extra storage inside an IMEMO/constcache object.
That extension object stores one flag (so one bit), the reference to the cached value (8B) and the `cref` pointer (8B).

However the vast majority of const caches don't have a `cref`, which means we're allocating `40B`, and use `8B` to reference it, to store `8B` plus 1 bit.

Given that `iseq_inline_constant_cache.segments` is a pointer, we can use the lower 3 bits to store tags.

The idea here is to merge `iseq_inline_constant_cache_entry.flags` into `iseq_inline_constant_cache.segments` lower bits,
and also store an extra flag that records whether this cache is `cref` dependent.

When it's not (which is the vast majority of cases) we can store the cached value directly inside the inline cache, and not need the `_entry` object.

Expectations:

  - The vast majority of `IMEMO/constcache` instances are eliminated.
  - We're saving one pointer chasing, in exchange for a bitmask check and some pointer untagging.

cc @etiennebarrie 