### PR TITLE
[Bug #21177] Win32: Allow longer path name

### DIFF
--- a/test/ruby/test_dir.rb
+++ b/test/ruby/test_dir.rb
@@ -641,6 +641,19 @@ class TestDir < Test::Unit::TestCase
         assert_equal("C:/ruby/homepath", Dir.home)
       end;
     end
+
+    def test_children_long_name
+      Dir.mktmpdir do |dirname|
+        longest_possible_component = "b" * 255
+        long_path = File.join(dirname, longest_possible_component)
+        Dir.mkdir(long_path)
+        File.write("#{long_path}/c", "")
+        assert_equal(%w[c], Dir.children(long_path))
+      ensure
+        File.unlink("#{long_path}/c")
+        Dir.rmdir(long_path)
+      end
+    end
   end
 
   def test_home


### PR DESCRIPTION
[[Bug #21177]](https://bugs.ruby-lang.org/issues/21177)