### PR TITLE
Move object_id to flags for ObjectSpace dumps

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -636,11 +636,6 @@ dump_object(VALUE obj, struct dump_config *dc)
         dump_append_sizet(dc, memsize);
     }
 
-    if (FL_TEST(obj, FL_SEEN_OBJ_ID)) {
-        dump_append(dc, ", \"object_id\":");
-        dump_append_lu(dc, RB_NUM2ULONG(rb_obj_id(obj)));
-    }
-
     struct rb_gc_object_metadata_entry *gc_metadata = rb_gc_object_metadata(obj);
     for (int i = 0; gc_metadata[i].name != 0; i++) {
         if (i == 0) {

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -6197,7 +6197,7 @@ rb_gc_impl_object_metadata(void *objspace_ptr, VALUE obj)
 {
     rb_objspace_t *objspace = objspace_ptr;
     size_t n = 0;
-    static ID ID_wb_protected, ID_age, ID_old, ID_uncollectible, ID_marking, ID_marked, ID_pinned;
+    static ID ID_wb_protected, ID_age, ID_old, ID_uncollectible, ID_marking, ID_marked, ID_pinned, ID_object_id;
 
     if (!ID_marked) {
 #define I(s) ID_##s = rb_intern(#s);
@@ -6208,6 +6208,7 @@ rb_gc_impl_object_metadata(void *objspace_ptr, VALUE obj)
         I(marking);
         I(marked);
         I(pinned);
+        I(object_id);
 #undef I
     }
 
@@ -6225,6 +6226,7 @@ rb_gc_impl_object_metadata(void *objspace_ptr, VALUE obj)
     if (RVALUE_MARKING(objspace, obj)) SET_ENTRY(marking, Qtrue);
     if (RVALUE_MARKED(objspace, obj)) SET_ENTRY(marked, Qtrue);
     if (RVALUE_PINNED(objspace, obj)) SET_ENTRY(pinned, Qtrue);
+    if (FL_TEST(obj, FL_SEEN_OBJ_ID)) SET_ENTRY(object_id, rb_obj_id(obj));
 
     object_metadata_entries[n].name = 0;
     object_metadata_entries[n].val = 0;


### PR DESCRIPTION
Moving object_id dumping from ObjectSpace to the GC flags allows ObjectSpace to not assume the FL_SEEN_OBJ_ID flag and instead move it to the responsibility of the GC.