### PR TITLE
Fix flaky test_AREF_fstring_key

### DIFF
--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -1986,9 +1986,12 @@ class TestHashOnly < Test::Unit::TestCase
     ObjectSpace.count_objects
 
     h = {"abc" => 1}
-    before = ObjectSpace.count_objects[:T_STRING]
-    5.times{ h["abc"] }
-    assert_equal before, ObjectSpace.count_objects[:T_STRING]
+
+    EnvUtil.without_gc do
+      before = ObjectSpace.count_objects[:T_STRING]
+      5.times{ h["abc"] }
+      assert_equal before, ObjectSpace.count_objects[:T_STRING]
+    end
   end
 
   def test_AREF_fstring_key_default_proc


### PR DESCRIPTION
The code between the two ObjectSpace.count_objects could trigger a GC, which could free string objects causing this test to fail.

We can see this failure on CI http://ci.rvm.jp/results/trunk-random2@ruby-sp2-noble-docker/5651016

    TestHashOnly#test_AREF_fstring_key [test/ruby/test_hash.rb:1991]:
    <197483> expected but was
    <129689>.