### PR TITLE
Lock free hash set for fstrings

### DIFF
--- a/benchmark/ractor_string_fstring.yml
+++ b/benchmark/ractor_string_fstring.yml
@@ -1,0 +1,18 @@
+type: lib/benchmark_driver/runner/ractor
+benchmark:
+  ractor_fstring_random: |
+    i = 0
+    str = "same".dup
+    while i < 2000000
+      -(i.to_s.freeze)
+      i += 1
+    end
+  ractor_fstring_same: |
+    i = 0
+    str = "same".dup
+    while i < 2000000
+      -str
+      i += 1
+    end
+loop_count: 1
+ractor: 4

--- a/benchmark/string_fstring.yml
+++ b/benchmark/string_fstring.yml
@@ -1,0 +1,16 @@
+benchmark:
+  fstring_random: |
+    i = 0
+    str = "same".dup
+    while i < 5_000_000
+      -(i.to_s.freeze)
+      i += 1
+    end
+  fstring_same: |
+    i = 0
+    str = "same".dup
+    while i < 10_000_000
+      -str
+      i += 1
+    end
+loop_count: 1

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1580,6 +1580,21 @@ assert_equal "#{N}#{N}", %Q{
   }.map{|r| r.take}.join
 }
 
+assert_equal "ok", %Q{
+  N = #{N}
+  a, b = 2.times.map{
+    Ractor.new{
+      N.times.map{|i| -(i.to_s)}
+    }
+  }.map{|r| r.take}
+  N.times do |i|
+    unless a[i].equal?(b[i])
+      raise [a[i], b[i]].inspect
+    end
+  end
+  :ok
+}
+
 # Generic ivtbl
 n = N/2
 assert_equal "#{n}#{n}", %Q{

--- a/eval.c
+++ b/eval.c
@@ -79,6 +79,7 @@ ruby_setup(void)
     Init_BareVM();
     rb_vm_encoded_insn_data_table_init();
     Init_vm_objects();
+    Init_fstring_table();
 
     EC_PUSH_TAG(GET_EC());
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {

--- a/gc.c
+++ b/gc.c
@@ -1216,11 +1216,7 @@ rb_gc_obj_free_vm_weak_references(VALUE obj)
     switch (BUILTIN_TYPE(obj)) {
       case T_STRING:
         if (FL_TEST(obj, RSTRING_FSTR)) {
-            st_data_t fstr = (st_data_t)obj;
-            st_delete(rb_vm_fstring_table(), &fstr, NULL);
-            RB_DEBUG_COUNTER_INC(obj_str_fstr);
-
-            FL_UNSET(obj, RSTRING_FSTR);
+            rb_gc_free_fstring(obj);
         }
         break;
       case T_SYMBOL:

--- a/gc.c
+++ b/gc.c
@@ -341,6 +341,7 @@ rb_gc_shutdown_call_finalizer_p(VALUE obj)
         if (rb_obj_is_mutex(obj)) return false;
         if (rb_obj_is_fiber(obj)) return false;
         if (rb_obj_is_main_ractor(obj)) return false;
+        if (rb_obj_is_fstring_table(obj)) return false;
 
         return true;
 
@@ -3528,6 +3529,7 @@ vm_weak_table_frozen_strings_foreach(st_data_t key, st_data_t value, st_data_t d
     return retval;
 }
 
+void rb_fstring_foreach_with_replace(st_foreach_check_callback_func *func, st_update_callback_func *replace, st_data_t arg);
 void
 rb_gc_vm_weak_table_foreach(vm_table_foreach_callback_func callback,
                             vm_table_update_callback_func update_callback,
@@ -3590,14 +3592,11 @@ rb_gc_vm_weak_table_foreach(vm_table_foreach_callback_func callback,
         break;
       }
       case RB_GC_VM_FROZEN_STRINGS_TABLE: {
-        if (vm->frozen_strings) {
-            st_foreach_with_replace(
-                vm->frozen_strings,
-                vm_weak_table_frozen_strings_foreach,
-                vm_weak_table_foreach_update_weak_key,
-                (st_data_t)&foreach_data
-            );
-        }
+        rb_fstring_foreach_with_replace(
+            vm_weak_table_frozen_strings_foreach,
+            vm_weak_table_foreach_update_weak_key,
+            (st_data_t)&foreach_data
+        );
         break;
       }
       default:

--- a/internal/string.h
+++ b/internal/string.h
@@ -83,6 +83,7 @@ VALUE rb_setup_fake_str(struct RString *fake_str, const char *name, long len, rb
 RUBY_SYMBOL_EXPORT_END
 
 VALUE rb_fstring_new(const char *ptr, long len);
+void rb_gc_free_fstring(VALUE obj);
 VALUE rb_obj_as_string_result(VALUE str, VALUE obj);
 VALUE rb_str_opt_plus(VALUE x, VALUE y);
 VALUE rb_str_concat_literals(size_t num, const VALUE *strary);

--- a/internal/string.h
+++ b/internal/string.h
@@ -84,6 +84,8 @@ RUBY_SYMBOL_EXPORT_END
 
 VALUE rb_fstring_new(const char *ptr, long len);
 void rb_gc_free_fstring(VALUE obj);
+bool rb_obj_is_fstring_table(VALUE obj);
+void Init_fstring_table();
 VALUE rb_obj_as_string_result(VALUE str, VALUE obj);
 VALUE rb_str_opt_plus(VALUE x, VALUE y);
 VALUE rb_str_concat_literals(size_t num, const VALUE *strary);

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -56,7 +56,6 @@ void rb_vm_check_redefinition_by_prepend(VALUE klass);
 int rb_vm_check_optimizable_mid(VALUE mid);
 VALUE rb_yield_refine_block(VALUE refinement, VALUE refinements);
 VALUE ruby_vm_special_exception_copy(VALUE);
-PUREFUNC(st_table *rb_vm_fstring_table(void));
 
 void rb_lastline_set_up(VALUE val, unsigned int up);
 

--- a/string.c
+++ b/string.c
@@ -578,6 +578,16 @@ register_fstring(VALUE str, bool copy, bool force_precompute_hash)
     return args.fstr;
 }
 
+void rb_gc_free_fstring(VALUE obj) {
+    ASSERT_vm_locking();
+
+    st_data_t fstr = (st_data_t)obj;
+    st_delete(rb_vm_fstring_table(), &fstr, NULL);
+    RB_DEBUG_COUNTER_INC(obj_str_fstr);
+
+    FL_UNSET(obj, RSTRING_FSTR);
+}
+
 static VALUE
 setup_fake_str(struct RString *fake_str, const char *name, long len, int encidx)
 {

--- a/vm.c
+++ b/vm.c
@@ -3134,10 +3134,6 @@ ruby_vm_destruct(rb_vm_t *vm)
             st_free_table(vm->ci_table);
             vm->ci_table = NULL;
         }
-        if (vm->frozen_strings) {
-            st_free_table(vm->frozen_strings);
-            vm->frozen_strings = 0;
-        }
         RB_ALTSTACK_FREE(vm->main_altstack);
 
         struct global_object_list *next;
@@ -3236,7 +3232,6 @@ vm_memsize(const void *ptr)
         rb_vm_memsize_workqueue(&vm->workqueue) +
         vm_memsize_at_exit_list(vm->at_exit) +
         rb_st_memsize(vm->ci_table) +
-        rb_st_memsize(vm->frozen_strings) +
         vm_memsize_builtin_function_table(vm->builtin_function_table) +
         rb_id_table_memsize(vm->negative_cme_table) +
         rb_st_memsize(vm->overloaded_cme_table) +
@@ -4441,7 +4436,6 @@ Init_vm_objects(void)
     vm->mark_object_ary = pin_array_list_new(Qnil);
     vm->loading_table = st_init_strtable();
     vm->ci_table = st_init_table(&vm_ci_hashtype);
-    vm->frozen_strings = st_init_table_with_size(&rb_fstring_hash_type, 10000);
 }
 
 // Stub for builtin function when not building YJIT units
@@ -4502,12 +4496,6 @@ ruby_free_at_exit_p(void)
 VALUE rb_insn_operand_intern(const rb_iseq_t *iseq,
                              VALUE insn, int op_no, VALUE op,
                              int len, size_t pos, VALUE *pnop, VALUE child);
-
-st_table *
-rb_vm_fstring_table(void)
-{
-    return GET_VM()->frozen_strings;
-}
 
 #if VM_COLLECT_USAGE_DETAILS
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -778,8 +778,6 @@ typedef struct rb_vm_struct {
 
     rb_at_exit_list *at_exit;
 
-    st_table *frozen_strings;
-
     const struct rb_builtin_function *builtin_function_table;
 
     st_table *ci_table;


### PR DESCRIPTION
This implements a hash set which is wait-free for lookup and lock-free for insert (unless resizing) to use for fstring de-duplication.

As highlighted in https://bugs.ruby-lang.org/issues/19288, heavy use of fstrings (frozen interned strings) can significantly reduce the parallelism of Ractors.

I was at first intimidated by writing the lock-free version. I previously tried a few other approaches: using an RWLock, striping a series of RWlocks (partitioning the hash N-ways to reduce lock contention), and putting a cache in front of it. All of these improved the situation, but were unsatisfying as all still required locks for writes (and granular locks are awkward, since we run the risk of needing to reach a vm barrier) and this table is somewhat write-heavy.


My main reference for this was Cliff Click's talk on a lock free hash-table for java https://www.youtube.com/watch?v=HJ-719EGIts. It turns out this lock-free hash set is made easier to implement by a few properties:
* We only need a hash set rather than a hash table (we only need keys, not values), and so the full entry can be written as a single `VALUE`
* As a set we only need lookup/insert/delete, no update
* Delete is only run inside GC so does not need to be atomic (It could be made concurrent)
* ~I use rb_vm_barrier for the (rare) table rebuilds (It could be made concurrent)~ We VM lock (but don't require other threads to stop) for table rebuilds, as those are rare
* The conservative garbage collector makes deferred replication easy, using a T_DATA object


Another benefits of having a table specific to fstrings is that we compare by value on lookup/insert, but by identity on delete, as we only want to remove the exact string which is being freed. This is faster and provides a second way to avoid the race condition in https://bugs.ruby-lang.org/issues/21172.


This is a pretty standard open-addressing hash table with quadratic probing. Similar to our existing st_table or id_table. Deletes (which happen on GC) replace existing keys with a tombstone, which is the only type of update which can occur. Tombstones are only cleared out on resize.

Unlike st_table, the VALUEs are stored in the hash table itself (st_table's bins) rather than as a compact index. This avoids an extra pointer dereference and is possible because we don't need to preserve insertion order. The table targets a load factor of 2 (it is enlarged once it is half full). 
