### PR TITLE
Refine marshal-skipping instance variables

### DIFF
--- a/ext/-test-/marshal/internal_ivar/internal_ivar.c
+++ b/ext/-test-/marshal/internal_ivar/internal_ivar.c
@@ -1,13 +1,14 @@
 #include <ruby.h>
 
-static ID id_normal_ivar, id_internal_ivar, id_encoding_short;
+static ID id_normal_ivar, id_internal_ivar, id_encoding_short, id_encoding_long;
 
 static VALUE
-init(VALUE self, VALUE arg1, VALUE arg2, VALUE arg3)
+init(VALUE self, VALUE arg1, VALUE arg2, VALUE arg3, VALUE arg4)
 {
     rb_ivar_set(self, id_normal_ivar, arg1);
     rb_ivar_set(self, id_internal_ivar, arg2);
     rb_ivar_set(self, id_encoding_short, arg3);
+    rb_ivar_set(self, id_encoding_long, arg4);
     return self;
 }
 
@@ -29,6 +30,12 @@ get_encoding_short(VALUE self)
     return rb_attr_get(self, id_encoding_short);
 }
 
+static VALUE
+get_encoding_long(VALUE self)
+{
+    return rb_attr_get(self, id_encoding_long);
+}
+
 void
 Init_internal_ivar(void)
 {
@@ -38,8 +45,10 @@ Init_internal_ivar(void)
     id_normal_ivar = rb_intern_const("normal");
     id_internal_ivar = rb_intern_const("K");
     id_encoding_short = rb_intern_const("E");
-    rb_define_method(newclass, "initialize", init, 3);
+    id_encoding_long = rb_intern_const("encoding");
+    rb_define_method(newclass, "initialize", init, 4);
     rb_define_method(newclass, "normal", get_normal, 0);
     rb_define_method(newclass, "internal", get_internal, 0);
     rb_define_method(newclass, "encoding_short", get_encoding_short, 0);
+    rb_define_method(newclass, "encoding_long", get_encoding_long, 0);
 }

--- a/test/-ext-/marshal/test_internal_ivar.rb
+++ b/test/-ext-/marshal/test_internal_ivar.rb
@@ -7,11 +7,16 @@ module Bug end
 module Bug::Marshal
   class TestInternalIVar < Test::Unit::TestCase
     def test_marshal
-      v = InternalIVar.new("hello", "world", "bye")
+      v = InternalIVar.new("hello", "world", "bye", "hi")
       assert_equal("hello", v.normal)
       assert_equal("world", v.internal)
       assert_equal("bye", v.encoding_short)
-      dump = assert_warn(/instance variable 'E' on class \S+ is not dumped/) {
+      assert_equal("hi", v.encoding_long)
+      warnings = ->(s) {
+        w = s.scan(/instance variable '(.+?)' on class \S+ is not dumped/)
+        assert_equal(%w[E K encoding], w.flatten.sort)
+      }
+      dump = assert_warn(warnings) {
         ::Marshal.dump(v)
       }
       v = assert_nothing_raised {break ::Marshal.load(dump)}
@@ -19,6 +24,7 @@ module Bug::Marshal
       assert_equal("hello", v.normal)
       assert_nil(v.internal)
       assert_nil(v.encoding_short)
+      assert_nil(v.encoding_long)
     end
   end
 end

--- a/tool/lib/core_assertions.rb
+++ b/tool/lib/core_assertions.rb
@@ -489,14 +489,13 @@ eom
         case expected
         when String
           assert = :assert_equal
-        when Regexp
-          assert = :assert_match
         else
-          raise TypeError, "Expected #{expected.inspect} to be a kind of String or Regexp, not #{expected.class}"
+          assert_respond_to(expected, :===)
+          assert = :assert_match
         end
 
         ex = m = nil
-        EnvUtil.with_default_internal(expected.encoding) do
+        EnvUtil.with_default_internal(of: expected) do
           ex = assert_raise(exception, msg || proc {"Exception(#{exception}) with message matches to #{expected.inspect}"}) do
             yield
           end
@@ -670,7 +669,7 @@ eom
 
       def assert_warning(pat, msg = nil)
         result = nil
-        stderr = EnvUtil.with_default_internal(pat.encoding) {
+        stderr = EnvUtil.with_default_internal(of: pat) {
           EnvUtil.verbose_warning {
             result = yield
           }

--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -279,7 +279,8 @@ module EnvUtil
   end
   module_function :without_gc
 
-  def with_default_external(enc)
+  def with_default_external(enc = nil, of: nil)
+    enc = of.encoding if defined?(of.encoding)
     suppress_warning { Encoding.default_external = enc }
     yield
   ensure
@@ -287,7 +288,8 @@ module EnvUtil
   end
   module_function :with_default_external
 
-  def with_default_internal(enc)
+  def with_default_internal(enc = nil, of: nil)
+    enc = of.encoding if defined?(of.encoding)
     suppress_warning { Encoding.default_internal = enc }
     yield
   ensure


### PR DESCRIPTION
Instance variable `encoding` is also not dumped.