### PR TITLE
Fix require spec for Ruby 3.4

### DIFF
--- a/spec/ruby/core/kernel/shared/require.rb
+++ b/spec/ruby/core/kernel/shared/require.rb
@@ -223,7 +223,7 @@ describe :kernel_require, shared: true do
       it "loads c-extension file when passed absolute path without extension when no .rb is present" do
         # the error message is specific to what dlerror() returns
         path = File.join CODE_LOADING_DIR, "a", "load_fixture"
-        -> { @object.send(@method, path) }.should raise_error(Exception, /file too short|not a mach-o file|slice is not valid mach-o file/)
+        -> { @object.send(@method, path) }.should raise_error(LoadError)
       end
     end
 
@@ -231,7 +231,7 @@ describe :kernel_require, shared: true do
       it "loads .bundle file when passed absolute path with .so" do
         # the error message is specific to what dlerror() returns
         path = File.join CODE_LOADING_DIR, "a", "load_fixture.so"
-        -> { @object.send(@method, path) }.should raise_error(Exception, /load_fixture\.bundle.+(file too short|not a mach-o file|slice is not valid mach-o file)/)
+        -> { @object.send(@method, path) }.should raise_error(LoadError)
       end
     end
 

--- a/spec/ruby/core/kernel/shared/require.rb
+++ b/spec/ruby/core/kernel/shared/require.rb
@@ -223,7 +223,7 @@ describe :kernel_require, shared: true do
       it "loads c-extension file when passed absolute path without extension when no .rb is present" do
         # the error message is specific to what dlerror() returns
         path = File.join CODE_LOADING_DIR, "a", "load_fixture"
-        -> { @object.send(@method, path) }.should raise_error(Exception, /file too short|not a mach-o file/)
+        -> { @object.send(@method, path) }.should raise_error(Exception, /file too short|not a mach-o file|slice is not valid mach-o file/)
       end
     end
 
@@ -231,7 +231,7 @@ describe :kernel_require, shared: true do
       it "loads .bundle file when passed absolute path with .so" do
         # the error message is specific to what dlerror() returns
         path = File.join CODE_LOADING_DIR, "a", "load_fixture.so"
-        -> { @object.send(@method, path) }.should raise_error(Exception, /load_fixture\.bundle.+(file too short|not a mach-o file)/)
+        -> { @object.send(@method, path) }.should raise_error(Exception, /load_fixture\.bundle.+(file too short|not a mach-o file|slice is not valid mach-o file)/)
       end
     end
 


### PR DESCRIPTION
Picked related commits to resolve the following failure with Xcode 16.3 beta.

```
Kernel.require (path resolution) loads .bundle file when passed absolute path with .so ERROR
Expected Exception ((?-mix:load_fixture\.bundle.+(file too short|not a mach-o file)))
but got: LoadError (dlopen(/Users/hsbt/Documents/github.com/ruby/ruby.github/spec/ruby/fixtures/code/a/load_fixture.bundle, 0x0009): tried: '/Users/hsbt/Documents/github.com/ruby/ruby.build/ruby_3_4/load_fixture.bundle' (no such file), '/Users/hsbt/Documents/github.com/ruby/ruby.github/spec/ruby/fixtures/code/a/load_fixture.bundle' (slice is not valid mach-o file), '/System/Volumes/Preboot/Cryptexes/OS/Users/hsbt/Documents/github.com/ruby/ruby.github/spec/ruby/fixtures/code/a/load_fixture.bundle' (no such file), '/Users/hsbt/Documents/github.com/ruby/ruby.github/spec/ruby/fixtures/code/a/load_fixture.bundle' (slice is not valid mach-o file) - /Users/hsbt/Documents/github.com/ruby/ruby.github/spec/ruby/fixtures/code/a/load_fixture.bundle)
```