### PR TITLE
Fix crash in TCPSocket.open

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -593,7 +593,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
         arg->getaddrinfo_shared->notify = hostname_resolution_notifier;
 
         arg->getaddrinfo_shared->node = arg->hostp ? ruby_strdup(arg->hostp) : NULL;
-        arg->getaddrinfo_shared->service = ruby_strdup(arg->portp);
+        arg->getaddrinfo_shared->service = arg->portp ? ruby_strdup(arg->portp) : NULL;
         arg->getaddrinfo_shared->refcount = arg->family_size + 1;
 
         for (int i = 0; i < arg->family_size; i++) {

--- a/test/socket/test_tcp.rb
+++ b/test/socket/test_tcp.rb
@@ -18,6 +18,12 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
   end
 
   def test_initialize_failure
+    assert_raise(Socket::ResolutionError) do
+      t = TCPSocket.open(nil, nil)
+    ensure
+      t&.close
+    end
+
     # These addresses are chosen from TEST-NET-1, TEST-NET-2, and TEST-NET-3.
     # [RFC 5737]
     # They are chosen because probably they are not used as a host address.


### PR DESCRIPTION
Fix segfault crash observable with TCPSocket.open(nil, nil)