### PR TITLE
[Bug #21185] Fix Range#overlap? with infinite range

### DIFF
--- a/range.c
+++ b/range.c
@@ -2561,7 +2561,7 @@ range_overlap(VALUE range, VALUE other)
         /* if both begin values are equal, no more comparisons needed */
         if (rb_cmpint(cmp, self_beg, other_beg) == 0) return Qtrue;
     }
-    else if (NIL_P(self_beg) && !NIL_P(self_end) && NIL_P(other_beg)) {
+    else if (NIL_P(self_beg) && !NIL_P(self_end) && NIL_P(other_beg) && !NIL_P(other_end)) {
         VALUE cmp = rb_funcall(self_end, id_cmp, 1, other_end);
         return RBOOL(!NIL_P(cmp));
     }

--- a/test/ruby/test_range.rb
+++ b/test/ruby/test_range.rb
@@ -1513,6 +1513,7 @@ class TestRange < Test::Unit::TestCase
     assert_operator((nil..nil), :overlap?, (3..))
     assert_operator((nil...nil), :overlap?, (nil..))
     assert_operator((nil..nil), :overlap?, (..3))
+    assert_operator((..3), :overlap?, (nil..nil))
 
     assert_raise(TypeError) { (1..3).overlap?(1) }
 


### PR DESCRIPTION
Infinite ranges, i.e. unbounded ranges, should overlap with any other range which wasn't the case in the following example: `(0..3).overlap?(nil..nil)`

[[Bug #21185]](https://bugs.ruby-lang.org/issues/21185)

Similar to #11609, but adds fix for another edge case.