### PR TITLE
[DOC] Escape `Binding` reference in pattern matching docs

### DIFF
--- a/doc/syntax/pattern_matching.rdoc
+++ b/doc/syntax/pattern_matching.rdoc
@@ -221,7 +221,7 @@ For hash patterns, even a simpler form exists: key-only specification (without a
   end
   #=> "matched: 1"
 
-Binding works for nested patterns as well:
+\Binding works for nested patterns as well:
 
   case {name: 'John', friends: [{name: 'Jane'}, {name: 'Rajesh'}]}
   in name:, friends: [{name: first_friend}, *]
@@ -249,7 +249,7 @@ The "rest" part of a pattern also can be bound to a variable:
   end
   #=> "matched: 1, {b: 2, c: 3}"
 
-Binding to variables currently does NOT work for alternative patterns joined with <code>|</code>:
+\Binding to variables currently does NOT work for alternative patterns joined with <code>|</code>:
 
   case {a: 1, b: 2}
   in {a: } | Array


### PR DESCRIPTION
![Screenshot 2025-03-20 at 6 45 37 pm](https://github.com/user-attachments/assets/782c2e1e-d5ea-4627-98a4-ff3b0fae4528)