### PR TITLE
Fix test - wording changed.

### DIFF
--- a/bootstraptest/test_fork.rb
+++ b/bootstraptest/test_fork.rb
@@ -84,7 +84,7 @@ assert_equal 'ok', %q{
 
   10.times do
     pid = fork{ exit!(0) }
-    deadline = now + 10
+    deadline = now + 30
     until Process.waitpid(pid, Process::WNOHANG)
       if now > deadline
         Process.kill(:KILL, pid)

--- a/spec/bundler/install/gemfile/git_spec.rb
+++ b/spec/bundler/install/gemfile/git_spec.rb
@@ -1204,7 +1204,7 @@ RSpec.describe "bundle install with git sources" do
         gem "foo", :git => "#{lib_path("foo-1.0")}", :branch => "deadbeef"
       G
 
-      expect(err).to include("Revision deadbeef does not exist in the repository")
+      expect(err).to match(/deadbeef (not found in upstream origin|does not exist in the repository)/)
     end
   end
 


### PR DESCRIPTION
expect "fatal: Remote branch deadbeef not found in upstream origin" to include "Revision deadbeef does not exist in the repository"