### PR TITLE
Fix CI with `macos-14` for Ruby 3.4

### DIFF
--- a/lib/bundler/source/git/git_proxy.rb
+++ b/lib/bundler/source/git/git_proxy.rb
@@ -179,7 +179,8 @@ module Bundler
             _, err, status = capture(command, nil)
             return extra_ref if status.success?
 
-            if err.include?("Could not find remote branch")
+            if err.include?("Could not find remote branch") || # git up to 2.49
+               err.include?("Remote branch #{branch_option} not found") # git 2.49 or higher
               raise MissingGitRevisionError.new(command_with_no_credentials, nil, explicit_ref, credential_filtered_uri)
             else
               idx = command.index("--depth")
@@ -256,7 +257,7 @@ module Bundler
         end
 
         def not_pinned?
-          branch || tag || ref.nil?
+          branch_option || ref.nil?
         end
 
         def pinned_to_full_sha?
@@ -420,7 +421,7 @@ module Bundler
           # anyways.
           return args if @revision
 
-          args += ["--branch", branch || tag] if branch || tag
+          args += ["--branch", branch_option] if branch_option
           args
         end
 
@@ -434,6 +435,10 @@ module Bundler
           extra_args = [path.to_s, *depth_args]
           extra_args.push(ref)
           extra_args
+        end
+
+        def branch_option
+          branch || tag
         end
 
         def full_clone?


### PR DESCRIPTION
https://github.com/ruby/actions/actions/runs/14021865495/job/39254944435

That may be fixed with:


```
    [rubygems/rubygems] Support git 2.49

    One error message that we parse is now slightly different.

    https://github.com/rubygems/rubygems/commit/758528791d
```

