### PR TITLE
Launchable: Fix CI scripts by adding backslashes

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -133,7 +133,7 @@ jobs:
       - name: make ${{ matrix.test_task }}
         run: |
           if [ -n "${LAUNCHABLE_ORGANIZATION}" ]; then
-            exec
+            exec \
             > >(tee launchable_stdout.log) \
             2> >(tee launchable_stderr.log)
           fi

--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -143,7 +143,7 @@ jobs:
       - name: make ${{ matrix.test_task }}
         run: |
           if [ -n "${LAUNCHABLE_ORGANIZATION}" ]; then
-            exec
+            exec \
             > >(tee launchable_stdout.log) \
             2> >(tee launchable_stderr.log)
           fi

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -119,7 +119,7 @@ jobs:
       - name: make ${{ matrix.test_task }}
         run: |
           if [ -n "${LAUNCHABLE_ORGANIZATION}" ]; then
-            exec
+            exec \
             > >(tee launchable_stdout.log) \
             2> >(tee launchable_stderr.log)
           fi

--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -130,7 +130,7 @@ jobs:
       - name: make ${{ matrix.test_task }}
         run: |
           if [ -n "${LAUNCHABLE_ORGANIZATION}" ]; then
-            exec
+            exec \
             > >(tee launchable_stdout.log) \
             2> >(tee launchable_stderr.log)
           fi

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -184,7 +184,7 @@ jobs:
       - name: make ${{ matrix.test_task }}
         run: |
           if [ -n "${LAUNCHABLE_ORGANIZATION}" ]; then
-            exec
+            exec \
             > >(tee launchable_stdout.log) \
             2> >(tee launchable_stderr.log)
           fi


### PR DESCRIPTION
The following command doesn't work correctly since a backslash doesn't exist after `exec`. This PR fixes it.

```
if [ -n "${LAUNCHABLE_ORGANIZATION}" ]; then
  exec
  > >(tee launchable_stdout.log) \
  2> >(tee launchable_stderr.log)
fi
```