### PR TITLE
Allow Method objects to be Ractor shareable

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1361,6 +1361,28 @@ assert_equal 'true', %q{
   Ractor.shareable?(pr)
 }
 
+# Ractor.make_shareable(a_proc) makes inner structure shareable and freezes it
+assert_equal 'true,true,true,true', %q{
+  class Proc
+    attr_reader :obj
+    def initialize
+      @obj = Object.new
+    end
+  end
+
+  pr = Ractor.current.instance_eval do
+    Proc.new {}
+  end
+
+  results = []
+  Ractor.make_shareable(pr)
+  results << Ractor.shareable?(pr)
+  results << pr.frozen?
+  results << Ractor.shareable?(pr.obj)
+  results << pr.obj.frozen?
+  results.map(&:to_s).join(',')
+}
+
 # Ractor.shareable?(recursive_objects)
 assert_equal '[false, false]', %q{
   y = []
@@ -1387,6 +1409,21 @@ assert_equal '[C, M]', %q{
   module M; end
 
   Ractor.make_shareable(ary = [C, M])
+}
+
+# Ractor.make_shareable with curried proc checks isolation of original proc
+assert_equal 'isolation error', %q{
+  a = Object.new
+  orig = proc { a }
+  curried = orig.curry
+
+  begin
+    Ractor.make_shareable(curried)
+  rescue Ractor::IsolationError
+    'isolation error'
+  else
+    'no error'
+  end
 }
 
 # define_method() can invoke different Ractor's proc if the proc is shareable.

--- a/ractor.c
+++ b/ractor.c
@@ -3045,7 +3045,7 @@ rb_obj_traverse(VALUE obj,
 }
 
 static int
-frozen_shareable_p(VALUE obj, bool *made_shareable)
+allow_frozen_shareable_p(VALUE obj)
 {
     if (!RB_TYPE_P(obj, T_DATA)) {
         return true;
@@ -3054,13 +3054,6 @@ frozen_shareable_p(VALUE obj, bool *made_shareable)
         const rb_data_type_t *type = RTYPEDDATA_TYPE(obj);
         if (type->flags & RUBY_TYPED_FROZEN_SHAREABLE) {
             return true;
-        }
-        else if (made_shareable && rb_obj_is_proc(obj)) {
-            // special path to make shareable Proc.
-            rb_proc_ractor_make_shareable(obj);
-            *made_shareable = true;
-            VM_ASSERT(RB_OBJ_SHAREABLE_P(obj));
-            return false;
         }
     }
 
@@ -3071,18 +3064,22 @@ static enum obj_traverse_iterator_result
 make_shareable_check_shareable(VALUE obj)
 {
     VM_ASSERT(!SPECIAL_CONST_P(obj));
-    bool made_shareable = false;
 
     if (rb_ractor_shareable_p(obj)) {
         return traverse_skip;
     }
-    if (!frozen_shareable_p(obj, &made_shareable)) {
-        if (made_shareable) {
-            return traverse_skip;
+    else if (!allow_frozen_shareable_p(obj)) {
+        if (rb_obj_is_proc(obj)) {
+            rb_proc_ractor_make_shareable(obj);
+            return traverse_cont;
         }
         else {
             rb_raise(rb_eRactorError, "can not make shareable object for %"PRIsVALUE, obj);
         }
+    }
+
+    if (RB_TYPE_P(obj, T_IMEMO)) {
+        return traverse_skip;
     }
 
     if (!RB_OBJ_FROZEN_RAW(obj)) {
@@ -3156,7 +3153,7 @@ shareable_p_enter(VALUE obj)
         return traverse_skip;
     }
     else if (RB_OBJ_FROZEN_RAW(obj) &&
-             frozen_shareable_p(obj, NULL)) {
+             allow_frozen_shareable_p(obj)) {
         return traverse_cont;
     }
 

--- a/ractor.c
+++ b/ractor.c
@@ -12,6 +12,7 @@
 #include "internal/error.h"
 #include "internal/gc.h"
 #include "internal/hash.h"
+#include "internal/proc.h"
 #include "internal/ractor.h"
 #include "internal/rational.h"
 #include "internal/struct.h"
@@ -3071,6 +3072,13 @@ make_shareable_check_shareable(VALUE obj)
     else if (!allow_frozen_shareable_p(obj)) {
         if (rb_obj_is_proc(obj)) {
             rb_proc_ractor_make_shareable(obj);
+            return traverse_cont;
+        } else if (rb_obj_is_method(obj)) {
+            if (!rb_ractor_shareable_p(rb_callable_receiver(obj))) {
+                rb_raise(rb_eRactorIsolationError,
+                        "Method's receiver is not shareable: %" PRIsVALUE,
+                        obj);
+            }
             return traverse_cont;
         }
         else {

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: false
+require 'test/unit'
+
+class TestRactor < Test::Unit::TestCase
+  def test_shareability_of_iseq_proc
+    y = nil.instance_eval do
+      foo = []
+      proc { foo }
+    end
+    assert_unshareable(y, /unshareable object \[\] from variable 'foo'/)
+
+    y = [].instance_eval { proc { self } }
+    assert_unshareable(y, /Proc's self is not shareable/)
+
+    y = [].freeze.instance_eval { proc { self } }
+    assert_make_shareable(y)
+  end
+
+  def test_shareability_of_curried_proc
+    x = nil.instance_eval do
+      foo = []
+      proc { foo }.curry
+    end
+    assert_unshareable(x, /unshareable object \[\] from variable 'foo'/)
+
+    x = nil.instance_eval do
+      foo = 123
+      proc { foo }.curry
+    end
+    assert_make_shareable(x)
+  end
+
+  def test_shareability_of_method_proc
+    str = +""
+
+    x = str.instance_exec { proc { to_s } }
+    assert_unshareable(x, /Proc's self is not shareable/)
+
+    x = str.instance_exec { method(:to_s) }
+    assert_unshareable(x, "can not make shareable object for #<Method: String#to_s()>", exception: Ractor::Error)
+
+    x = str.instance_exec { method(:to_s).to_proc }
+    assert_unshareable(x, "can not make shareable object for #<Method: String#to_s()>", exception: Ractor::Error)
+
+    x = str.instance_exec { method(:itself).to_proc }
+    assert_unshareable(x, "can not make shareable object for #<Method: String(Kernel)#itself()>", exception: Ractor::Error)
+
+    str.freeze
+
+    x = str.instance_exec { proc { to_s } }
+    assert_make_shareable(x)
+
+    x = str.instance_exec { method(:to_s) }
+    assert_unshareable(x, "can not make shareable object for #<Method: String#to_s()>", exception: Ractor::Error)
+
+    x = str.instance_exec { method(:to_s).to_proc }
+    assert_unshareable(x, "can not make shareable object for #<Method: String#to_s()>", exception: Ractor::Error)
+
+    x = str.instance_exec { method(:itself).to_proc }
+    assert_unshareable(x, "can not make shareable object for #<Method: String(Kernel)#itself()>", exception: Ractor::Error)
+  end
+
+  def assert_make_shareable(obj)
+    refute Ractor.shareable?(obj), "object was already shareable"
+    Ractor.make_shareable(obj)
+    assert Ractor.shareable?(obj), "object didn't become shareable"
+  end
+
+  def assert_unshareable(obj, msg=nil, exception: Ractor::IsolationError)
+    refute Ractor.shareable?(obj), "object is already shareable"
+    assert_raise_with_message(exception, msg) do
+      Ractor.make_shareable(obj)
+    end
+    refute Ractor.shareable?(obj), "despite raising, object became shareable"
+  end
+end

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -37,13 +37,10 @@ class TestRactor < Test::Unit::TestCase
     assert_unshareable(x, /Proc's self is not shareable/)
 
     x = str.instance_exec { method(:to_s) }
-    assert_unshareable(x, "can not make shareable object for #<Method: String#to_s()>", exception: Ractor::Error)
+    assert_unshareable(x, "Method's receiver is not shareable: #<Method: String#to_s()>")
 
     x = str.instance_exec { method(:to_s).to_proc }
-    assert_unshareable(x, "can not make shareable object for #<Method: String#to_s()>", exception: Ractor::Error)
-
-    x = str.instance_exec { method(:itself).to_proc }
-    assert_unshareable(x, "can not make shareable object for #<Method: String(Kernel)#itself()>", exception: Ractor::Error)
+    assert_unshareable(x, "Method's receiver is not shareable: #<Method: String#to_s()>")
 
     str.freeze
 
@@ -51,13 +48,13 @@ class TestRactor < Test::Unit::TestCase
     assert_make_shareable(x)
 
     x = str.instance_exec { method(:to_s) }
-    assert_unshareable(x, "can not make shareable object for #<Method: String#to_s()>", exception: Ractor::Error)
+    assert_make_shareable(x)
 
     x = str.instance_exec { method(:to_s).to_proc }
-    assert_unshareable(x, "can not make shareable object for #<Method: String#to_s()>", exception: Ractor::Error)
+    assert_make_shareable(x)
 
     x = str.instance_exec { method(:itself).to_proc }
-    assert_unshareable(x, "can not make shareable object for #<Method: String(Kernel)#itself()>", exception: Ractor::Error)
+    assert_make_shareable(x)
   end
 
   def assert_make_shareable(obj)

--- a/vm.c
+++ b/vm.c
@@ -1415,7 +1415,7 @@ rb_proc_ractor_make_shareable(VALUE self)
         proc->is_isolated = TRUE;
     }
 
-    FL_SET_RAW(self, RUBY_FL_SHAREABLE);
+    rb_obj_freeze(self);
     return self;
 }
 


### PR DESCRIPTION
This is built on top of https://github.com/ruby/ruby/pull/12977 (itself just a rebase of https://github.com/ruby/ruby/pull/7182). The last commit, bbad06701c0f86b9a678c3959816792ef717a576, has the noteable change.

This makes Method objects shareable via `Ractor.make_shareable`, with similar semantics to making iseq procs shareable. That is, it will only be made shareable if the receiver is already frozen/shareable, otherwise it will raise `Ractor::IsolationError`.

I'll file a redmine ticket, since I think the behaviour should be discussed.