### PR TITLE
Prefer FL_TEST_RAW() in GC on known on-heap objects

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2877,7 +2877,7 @@ rb_gc_impl_copy_finalizer(void *objspace_ptr, VALUE dest, VALUE obj)
 static VALUE
 get_object_id_in_finalizer(rb_objspace_t *objspace, VALUE obj)
 {
-    if (FL_TEST(obj, FL_SEEN_OBJ_ID)) {
+    if (FL_TEST_RAW(obj, FL_SEEN_OBJ_ID)) {
         return rb_gc_impl_object_id(objspace, obj);
     }
     else {
@@ -2933,7 +2933,7 @@ finalize_list(rb_objspace_t *objspace, VALUE zombie)
         int lev = rb_gc_vm_lock();
         {
             GC_ASSERT(BUILTIN_TYPE(zombie) == T_ZOMBIE);
-            if (FL_TEST(zombie, FL_SEEN_OBJ_ID)) {
+            if (FL_TEST_RAW(zombie, FL_SEEN_OBJ_ID)) {
                 obj_free_object_id(objspace, zombie);
             }
 
@@ -3541,7 +3541,7 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
 
                 rb_gc_event_hook(vp, RUBY_INTERNAL_EVENT_FREEOBJ);
 
-                bool has_object_id = FL_TEST(vp, FL_SEEN_OBJ_ID);
+                bool has_object_id = FL_TEST_RAW(vp, FL_SEEN_OBJ_ID);
                 rb_gc_obj_free_vm_weak_references(vp);
                 if (rb_gc_obj_free(objspace, vp)) {
                     if (has_object_id) {
@@ -6893,7 +6893,7 @@ gc_is_moveable_obj(rb_objspace_t *objspace, VALUE obj)
       case T_RATIONAL:
       case T_NODE:
       case T_CLASS:
-        if (FL_TEST(obj, FL_FINALIZE)) {
+        if (FL_TEST_RAW(obj, FL_FINALIZE)) {
             /* The finalizer table is a numtable. It looks up objects by address.
              * We can't mark the keys in the finalizer table because that would
              * prevent the objects from being collected.  This check prevents
@@ -6946,7 +6946,7 @@ gc_move(rb_objspace_t *objspace, VALUE src, VALUE dest, size_t src_slot_size, si
     CLEAR_IN_BITMAP(GET_HEAP_UNCOLLECTIBLE_BITS(src), src);
     CLEAR_IN_BITMAP(GET_HEAP_PAGE(src)->remembered_bits, src);
 
-    if (FL_TEST(src, FL_SEEN_OBJ_ID)) {
+    if (FL_TEST_RAW(src, FL_SEEN_OBJ_ID)) {
         /* If the source object's object_id has been seen, we need to update
          * the object to object id mapping. */
         st_data_t srcid = (st_data_t)src, id;


### PR DESCRIPTION
Was reading some generated code and noticed the dead branches generated
for FL_TEST(). This is just a quick basic pass to change the obvious
places; there may be other cases.
