### PR TITLE
Fix deadlock on th->interrupt_lock after fork

### DIFF
--- a/bootstraptest/test_fork.rb
+++ b/bootstraptest/test_fork.rb
@@ -85,12 +85,17 @@ assert_equal 'ok', %q{
   10.times do
     pid = fork{ exit!(0) }
     deadline = now + 10
-    until Process.waitpid(pid, Process::WNOHANG)
+    while true
+      _, status = Process.waitpid2(pid, Process::WNOHANG)
+      break if status
       if now > deadline
         Process.kill(:KILL, pid)
         raise "failed"
       end
       sleep 0.001
+    end
+    unless status.success?
+      raise "child exited with status #{status}"
     end
   rescue NotImplementedError
   end

--- a/thread.c
+++ b/thread.c
@@ -4756,6 +4756,7 @@ static void
 terminate_atfork_i(rb_thread_t *th, const rb_thread_t *current_th)
 {
     if (th != current_th) {
+        rb_native_mutex_initialize(&th->interrupt_lock);
         rb_mutex_abandon_keeping_mutexes(th);
         rb_mutex_abandon_locking_mutex(th);
         thread_cleanup_func(th, TRUE);

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1549,6 +1549,11 @@ thread_sched_atfork(struct rb_thread_sched *sched)
     vm->ractor.sched.running_cnt = 0;
 
     rb_native_mutex_initialize(&vm->ractor.sched.lock);
+#if VM_CHECK_MODE > 0
+    vm->ractor.sched.lock_owner = NULL;
+    vm->ractor.sched.locked = false;
+#endif
+
     // rb_native_cond_destroy(&vm->ractor.sched.cond);
     rb_native_cond_initialize(&vm->ractor.sched.cond);
     rb_native_cond_initialize(&vm->ractor.sched.barrier_complete_cond);


### PR DESCRIPTION
This should fix the flaky test we've been seeing on CI