### PR TITLE
[DOC] Tweaks for Hash#has_value?

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3890,9 +3890,10 @@ rb_hash_search_value(VALUE key, VALUE value, VALUE arg)
 /*
  *  call-seq:
  *    has_value?(value) -> true or false
- *    value?(value) -> true or false
  *
- *  Returns +true+ if +value+ is a value in +self+, otherwise +false+.
+ *  Returns whether +value+ is a value in +self+.
+ *
+ *  Related: {Methods for Querying}[rdoc-ref:Hash@Methods+for+Querying].
  */
 
 static VALUE


### PR DESCRIPTION
@peterzhu2118, there is something wrong here.  Even in https://docs.ruby-lang.org/en/master/Hash.html#method-i-has_value-3F, the `Source` button does not work (does nothing except re-orient the arrow).