### PR TITLE
Ractor: Fix moving embedded objects

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1987,3 +1987,87 @@ assert_equal 'ok', %q{
   GC.start
   :ok.itself
 }
+
+# moved objects being corrupted if embeded (String)
+assert_equal 'ok', %q{
+  ractor = Ractor.new do
+    Ractor.receive
+  end
+  obj = "foobarbazfoobarbazfoobarbazfoobarbaz"
+  ractor.send(obj.dup, move: true)
+  rountriped_obj = ractor.take
+  rountriped_obj == obj ? :ok : rountriped_obj
+}
+
+# moved objects being corrupted if embeded (Array)
+assert_equal 'ok', %q{
+  ractor = Ractor.new do
+    Ractor.receive
+  end
+  obj = Array.new(10, 42)
+  ractor.send(obj.dup, move: true)
+  rountriped_obj = ractor.take
+  rountriped_obj == obj ? :ok : rountriped_obj
+}
+
+# moved objects being corrupted if embeded (Hash)
+assert_equal 'ok', %q{
+  ractor = Ractor.new do
+    Ractor.receive
+  end
+  obj = { foo: 1, bar: 2 }
+  ractor.send(obj.dup, move: true)
+  rountriped_obj = ractor.take
+  rountriped_obj == obj ? :ok : rountriped_obj
+}
+
+# moved objects being corrupted if embeded (MatchData)
+assert_equal 'ok', %q{
+  ractor = Ractor.new do
+    Ractor.receive
+  end
+  obj = "foo".match(/o/)
+  ractor.send(obj.dup, move: true)
+  rountriped_obj = ractor.take
+  rountriped_obj == obj ? :ok : rountriped_obj
+}
+
+# moved objects being corrupted if embeded (Struct)
+assert_equal 'ok', %q{
+  ractor = Ractor.new do
+    Ractor.receive
+  end
+  obj = Struct.new(:a, :b, :c, :d, :e, :f).new(1, 2, 3, 4, 5, 6)
+  ractor.send(obj.dup, move: true)
+  rountriped_obj = ractor.take
+  rountriped_obj == obj ? :ok : rountriped_obj
+}
+
+# moved objects being corrupted if embeded (Object)
+assert_equal 'ok', %q{
+  ractor = Ractor.new do
+    Ractor.receive
+  end
+  class SomeObject
+    attr_reader :a, :b, :c, :d, :e, :f
+    def initialize
+      @a = @b = @c = @d = @e = @f = 1
+    end
+
+    def ==(o)
+      @a == o.a &&
+      @b == o.b &&
+      @c == o.c &&
+      @d == o.d &&
+      @e == o.e &&
+      @f == o.f
+    end
+  end
+
+  SomeObject.new # initial non-embeded
+
+  obj = SomeObject.new
+  ractor.send(obj.dup, move: true)
+  rountriped_obj = ractor.take
+  rountriped_obj == obj ? :ok : rountriped_obj
+}

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2071,3 +2071,15 @@ assert_equal 'ok', %q{
   rountriped_obj = ractor.take
   rountriped_obj == obj ? :ok : rountriped_obj
 }
+
+# moved objects keep their object_id
+assert_equal 'ok', %q{
+  ractor = Ractor.new do
+    Ractor.receive
+  end
+  obj = Object.new
+  id = obj.object_id
+  ractor.send(obj, move: true)
+  rountriped_obj = ractor.take
+  rountriped_obj.object_id == id ? :ok : :fail
+}

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -190,6 +190,7 @@ VALUE rb_objspace_gc_enable(void *objspace);
 VALUE rb_objspace_gc_disable(void *objspace);
 void ruby_gc_set_params(void);
 void rb_gc_copy_attributes(VALUE dest, VALUE obj);
+void rb_gc_move_object(VALUE dest, VALUE src, size_t size);
 size_t rb_size_mul_or_raise(size_t, size_t, VALUE); /* used in compile.c */
 size_t rb_size_mul_add_or_raise(size_t, size_t, size_t, VALUE); /* used in iseq.h */
 size_t rb_malloc_grow_capa(size_t current_capacity, size_t type_size);

--- a/ractor.c
+++ b/ractor.c
@@ -3585,8 +3585,27 @@ move_enter(VALUE obj, struct obj_traverse_replace_data *data)
         return traverse_skip;
     }
     else {
-        VALUE moved = rb_obj_alloc(RBASIC_CLASS(obj));
-        rb_shape_set_shape(moved, rb_shape_get_shape(obj));
+        VALUE moved;
+        switch (RB_BUILTIN_TYPE(obj)) {
+          case T_STRING:
+            moved = rb_str_dup(obj);
+            break;
+          case T_ARRAY:
+            moved = rb_ary_dup(obj);
+            break;
+          case T_HASH:
+            moved = rb_hash_dup(obj);
+            break;
+          case T_MATCH:
+          case T_STRUCT:
+          case T_OBJECT:
+            // TODO: A more generic copy object with size that doesn't invoke init_copy?
+            moved = rb_obj_dup(obj);
+            break;
+          default:
+            rb_bug("move_enter unexpected type");
+            break;
+        }
         data->replacement = moved;
         return traverse_cont;
     }


### PR DESCRIPTION
`rb_obj_alloc(RBASIC_CLASS(obj))` will always allocate from the basic 40B pool, so if `obj` is larger than `40B`, we'll create a corrupted object when we later copy the shape_id.

I chose to use specialized `rb_*_dup` functions when possible to benefit from shared String/Arrays and trigger write barriers.

For some other types I resorted to the generic `rb_obj_dup`. It works but probably isn't ideal.
