### PR TITLE
[3.4 backport] FCALL shouldn't be forwarded from caller

### DIFF
--- a/bootstraptest/test_method.rb
+++ b/bootstraptest/test_method.rb
@@ -1395,3 +1395,27 @@ assert_equal 'ok', %q{
   no_args
   splat_args
 }
+
+assert_equal 'ok', %q{
+  class A
+    private
+    def foo = "ng"
+  end
+
+  class B
+    def initialize(o)
+      @o = o
+    end
+
+    def foo(...) = @o.foo(...)
+    def internal_foo = foo
+  end
+
+  b = B.new(A.new)
+
+  begin
+    b.internal_foo
+  rescue NoMethodError
+    "ok"
+  end
+}

--- a/vm_args.c
+++ b/vm_args.c
@@ -1177,7 +1177,8 @@ vm_caller_setup_fwd_args(const rb_execution_context_t *ec, rb_control_frame_t *r
 
     *adjusted_ci = VM_CI_ON_STACK(
             site_mid,
-            ((caller_flag & ~VM_CALL_ARGS_SIMPLE) | (site_flag & (VM_CALL_FCALL | VM_CALL_FORWARDING))),
+            ((caller_flag & ~(VM_CALL_ARGS_SIMPLE | VM_CALL_FCALL)) |
+             (site_flag & (VM_CALL_FCALL | VM_CALL_FORWARDING))),
             site_argc + caller_argc,
             kw
             );


### PR DESCRIPTION
When we forward an FCALL (a method call with an implicit self), we
shouldn't forward the FCALL flag because it ignores method visibility
checks.  This patch removes the FCALL flag from callers.

[Bug #21196]
