### PR TITLE
[backport 3.4] Time#utc? doc changes

### DIFF
--- a/time.c
+++ b/time.c
@@ -4007,9 +4007,17 @@ time_eql(VALUE time1, VALUE time2)
  *    now = Time.now
  *    # => 2022-08-18 10:24:13.5398485 -0500
  *    now.utc? # => false
+ *    now.getutc.utc? # => true
  *    utc = Time.utc(2000, 1, 1, 20, 15, 1)
  *    # => 2000-01-01 20:15:01 UTC
  *    utc.utc? # => true
+ *
+ *  Note that only +Time+ objects created with these methods
+ *  considered in UTC:
+ *
+ *  * Time.utc
+ *  * Time#utc
+ *  * Time#getutc
  *
  *  Related: Time.utc.
  */

--- a/time.c
+++ b/time.c
@@ -4012,12 +4012,15 @@ time_eql(VALUE time1, VALUE time2)
  *    # => 2000-01-01 20:15:01 UTC
  *    utc.utc? # => true
  *
- *  Note that only +Time+ objects created with these methods
- *  considered in UTC:
+ *  +Time+ objects created with these methods are considered to be in
+ *  UTC:
  *
  *  * Time.utc
  *  * Time#utc
  *  * Time#getutc
+ *
+ *  Objects created in other ways will not be treated as UTC even if
+ *  the environment variable "TZ" is "UTC".
  *
  *  Related: Time.utc.
  */


### PR DESCRIPTION
- **[Backport #21141] [DOC] Clarify what time is in UTC**
- **[[Backport #21141]](https://bugs.ruby-lang.org/issues/21141) [DOC] Refine description of `Time#utc?`**
