### PR TITLE
Ractor: Fix moving embedded objects

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2101,13 +2101,3 @@ assert_equal 'ok', %q{
     :fail
   end
 }
-
-# moved objects keep their object_id
-assert_equal 'ok', %q{
-  ractor = Ractor.new { Ractor.receive }
-  obj = Object.new
-  id = obj.object_id
-  ractor.send(obj, move: true)
-  roundtripped_obj = ractor.take
-  roundtripped_obj.object_id == id ? :ok : :fail
-}

--- a/common.mk
+++ b/common.mk
@@ -13531,6 +13531,7 @@ ractor.$(OBJEXT): $(top_srcdir)/internal/gc.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/hash.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/numeric.h
+ractor.$(OBJEXT): $(top_srcdir)/internal/object.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/ractor.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/rational.h
 ractor.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h

--- a/gc.c
+++ b/gc.c
@@ -665,6 +665,7 @@ typedef struct gc_function_map {
     // Object ID
     VALUE (*object_id)(void *objspace_ptr, VALUE obj);
     VALUE (*object_id_to_ref)(void *objspace_ptr, VALUE object_id);
+    void (*object_id_move)(void *objspace_ptr, VALUE dest, VALUE src);
     // Forking
     void (*before_fork)(void *objspace_ptr);
     void (*after_fork)(void *objspace_ptr, rb_pid_t pid);
@@ -842,6 +843,7 @@ ruby_modular_gc_init(void)
     // Object ID
     load_modular_gc_func(object_id);
     load_modular_gc_func(object_id_to_ref);
+    load_modular_gc_func(object_id_move);
     // Forking
     load_modular_gc_func(before_fork);
     load_modular_gc_func(after_fork);
@@ -925,6 +927,7 @@ ruby_modular_gc_init(void)
 // Object ID
 # define rb_gc_impl_object_id rb_gc_functions.object_id
 # define rb_gc_impl_object_id_to_ref rb_gc_functions.object_id_to_ref
+# define rb_gc_impl_object_id_move rb_gc_functions.object_id_move
 // Forking
 # define rb_gc_impl_before_fork rb_gc_functions.before_fork
 # define rb_gc_impl_after_fork rb_gc_functions.after_fork
@@ -966,7 +969,6 @@ rb_objspace_alloc(void)
 
     void *objspace = rb_gc_impl_objspace_alloc();
     ruby_current_vm_ptr->gc.objspace = objspace;
-
     rb_gc_impl_objspace_init(objspace);
     rb_gc_impl_stress_set(objspace, initial_stress);
 
@@ -2658,6 +2660,19 @@ rb_gc_mark_roots(void *objspace, const char **categoryp)
 }
 
 #define TYPED_DATA_REFS_OFFSET_LIST(d) (size_t *)(uintptr_t)RTYPEDDATA(d)->type->function.dmark
+
+void
+rb_gc_ractor_moved(VALUE dest, VALUE src)
+{
+    void *objspace = rb_gc_get_objspace();
+    if (UNLIKELY(FL_TEST_RAW(src, FL_SEEN_OBJ_ID))) {
+        rb_gc_impl_object_id_move(objspace, dest, src);
+    }
+
+    rb_gc_obj_free(objspace, src);
+    MEMZERO((void *)src, char, rb_gc_obj_slot_size(src));
+    RBASIC(src)->flags = T_OBJECT | FL_FREEZE; // Avoid mutations using bind_call, etc.
+}
 
 void
 rb_gc_mark_children(void *objspace, VALUE obj)

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -1614,27 +1614,6 @@ rb_gc_impl_object_id_to_ref(void *objspace_ptr, VALUE object_id)
     }
 }
 
-void
-rb_gc_impl_object_id_move(void *objspace_ptr, VALUE dest, VALUE src)
-{
-   /* If the source object's object_id has been seen, we need to update
-    * the object to object id mapping. */
-   st_data_t id = 0;
-   rb_objspace_t *objspace = objspace_ptr;
-
-   unsigned int lev = rb_gc_vm_lock();
-   st_data_t key = (st_data_t)src;
-   if (!st_delete(objspace->obj_to_id_tbl, &key, &id)) {
-       rb_bug("gc_move: object ID seen, but not in mapping table: %s", rb_obj_info(src));
-   }
-   FL_UNSET_RAW(src, FL_SEEN_OBJ_ID);
-
-   st_insert(objspace->obj_to_id_tbl, (st_data_t)dest, id);
-   st_insert(objspace->id_to_obj_tbl, id, (st_data_t)dest);
-   FL_SET_RAW(dest, FL_SEEN_OBJ_ID);
-   rb_gc_vm_unlock(lev);
-}
-
 static void free_stack_chunks(mark_stack_t *);
 static void mark_stack_free_cache(mark_stack_t *);
 static void heap_page_free(rb_objspace_t *objspace, struct heap_page *page);

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -103,6 +103,7 @@ GC_IMPL_FN void rb_gc_impl_shutdown_call_finalizer(void *objspace_ptr);
 // Object ID
 GC_IMPL_FN VALUE rb_gc_impl_object_id(void *objspace_ptr, VALUE obj);
 GC_IMPL_FN VALUE rb_gc_impl_object_id_to_ref(void *objspace_ptr, VALUE object_id);
+GC_IMPL_FN void rb_gc_impl_object_id_move(void *objspace_ptr, VALUE dest, VALUE src);
 // Forking
 GC_IMPL_FN void rb_gc_impl_before_fork(void *objspace_ptr);
 GC_IMPL_FN void rb_gc_impl_after_fork(void *objspace_ptr, rb_pid_t pid);

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -103,7 +103,6 @@ GC_IMPL_FN void rb_gc_impl_shutdown_call_finalizer(void *objspace_ptr);
 // Object ID
 GC_IMPL_FN VALUE rb_gc_impl_object_id(void *objspace_ptr, VALUE obj);
 GC_IMPL_FN VALUE rb_gc_impl_object_id_to_ref(void *objspace_ptr, VALUE object_id);
-GC_IMPL_FN void rb_gc_impl_object_id_move(void *objspace_ptr, VALUE dest, VALUE src);
 // Forking
 GC_IMPL_FN void rb_gc_impl_before_fork(void *objspace_ptr);
 GC_IMPL_FN void rb_gc_impl_after_fork(void *objspace_ptr, rb_pid_t pid);

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -1108,16 +1108,21 @@ objspace_obj_id_init(struct objspace *objspace)
 VALUE
 rb_gc_impl_object_id(void *objspace_ptr, VALUE obj)
 {
+    VALUE id;
     struct objspace *objspace = objspace_ptr;
 
     unsigned int lev = rb_gc_vm_lock();
-
-    VALUE id;
-    if (st_lookup(objspace->obj_to_id_tbl, (st_data_t)obj, &id)) {
-        RUBY_ASSERT(FL_TEST(obj, FL_SEEN_OBJ_ID));
+    if (FL_TEST(obj, FL_SEEN_OBJ_ID)) {
+        st_data_t val;
+        if (st_lookup(objspace->obj_to_id_tbl, (st_data_t)obj, &val)) {
+            id = (VALUE)val;
+        }
+        else {
+            rb_bug("rb_gc_impl_object_id: FL_SEEN_OBJ_ID flag set but not found in table");
+        }
     }
     else {
-        RUBY_ASSERT(!FL_TEST(obj, FL_SEEN_OBJ_ID));
+        RUBY_ASSERT(!st_lookup(objspace->obj_to_id_tbl, (st_data_t)obj, NULL));
 
         id = ULL2NUM(objspace->next_object_id);
         objspace->next_object_id += OBJ_ID_INCREMENT;
@@ -1126,7 +1131,6 @@ rb_gc_impl_object_id(void *objspace_ptr, VALUE obj)
         st_insert(objspace->id_to_obj_tbl, (st_data_t)id, (st_data_t)obj);
         FL_SET(obj, FL_SEEN_OBJ_ID);
     }
-
     rb_gc_vm_unlock(lev);
 
     return id;
@@ -1149,6 +1153,27 @@ rb_gc_impl_object_id_to_ref(void *objspace_ptr, VALUE object_id)
     else {
         rb_raise(rb_eRangeError, "%+"PRIsVALUE" is recycled object", rb_funcall(object_id, rb_intern("to_s"), 1, INT2FIX(10)));
     }
+}
+
+void
+rb_gc_impl_object_id_move(void *objspace_ptr, VALUE dest, VALUE src)
+{
+   /* If the source object's object_id has been seen, we need to update
+    * the object to object id mapping. */
+   st_data_t id = 0;
+   struct objspace *objspace = objspace_ptr;
+
+   unsigned int lev = rb_gc_vm_lock();
+   st_data_t key = (st_data_t)src;
+   if (!st_delete(objspace->obj_to_id_tbl, &key, &id)) {
+       rb_bug("gc_move: object ID seen, but not in mapping table: %s", rb_obj_info(src));
+   }
+   FL_UNSET_RAW(src, FL_SEEN_OBJ_ID);
+
+   st_insert(objspace->obj_to_id_tbl, (st_data_t)dest, id);
+   st_insert(objspace->id_to_obj_tbl, id, (st_data_t)dest);
+   FL_SET_RAW(dest, FL_SEEN_OBJ_ID);
+   rb_gc_vm_unlock(lev);
 }
 
 // Forking

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -1155,27 +1155,6 @@ rb_gc_impl_object_id_to_ref(void *objspace_ptr, VALUE object_id)
     }
 }
 
-void
-rb_gc_impl_object_id_move(void *objspace_ptr, VALUE dest, VALUE src)
-{
-   /* If the source object's object_id has been seen, we need to update
-    * the object to object id mapping. */
-   st_data_t id = 0;
-   struct objspace *objspace = objspace_ptr;
-
-   unsigned int lev = rb_gc_vm_lock();
-   st_data_t key = (st_data_t)src;
-   if (!st_delete(objspace->obj_to_id_tbl, &key, &id)) {
-       rb_bug("gc_move: object ID seen, but not in mapping table: %s", rb_obj_info(src));
-   }
-   FL_UNSET_RAW(src, FL_SEEN_OBJ_ID);
-
-   st_insert(objspace->obj_to_id_tbl, (st_data_t)dest, id);
-   st_insert(objspace->id_to_obj_tbl, id, (st_data_t)dest);
-   FL_SET_RAW(dest, FL_SEEN_OBJ_ID);
-   rb_gc_vm_unlock(lev);
-}
-
 // Forking
 
 void

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -183,6 +183,7 @@ struct rb_gc_object_metadata_entry {
 /* gc.c */
 RUBY_ATTR_MALLOC void *ruby_mimmalloc(size_t size);
 RUBY_ATTR_MALLOC void *ruby_mimcalloc(size_t num, size_t size);
+void rb_gc_ractor_moved(VALUE dest, VALUE src);
 void ruby_mimfree(void *ptr);
 void rb_gc_prepare_heap(void);
 void rb_objspace_set_event_hook(const rb_event_flag_t event);

--- a/variable.c
+++ b/variable.c
@@ -2158,27 +2158,6 @@ rb_copy_generic_ivar(VALUE clone, VALUE obj)
 }
 
 void
-rb_replace_generic_ivar(VALUE clone, VALUE obj)
-{
-    RUBY_ASSERT(FL_TEST(obj, FL_EXIVAR));
-
-    RB_VM_LOCK_ENTER();
-    {
-        st_data_t ivtbl, obj_data = (st_data_t)obj;
-        if (st_lookup(generic_iv_tbl_, (st_data_t)obj, &ivtbl)) {
-            st_insert(generic_iv_tbl_, (st_data_t)clone, ivtbl);
-            st_delete(generic_iv_tbl_, &obj_data, NULL);
-        }
-        else {
-            rb_bug("unreachable");
-        }
-    }
-    RB_VM_LOCK_LEAVE();
-
-    FL_SET(clone, FL_EXIVAR);
-}
-
-void
 rb_ivar_foreach(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg)
 {
     if (SPECIAL_CONST_P(obj)) return;


### PR DESCRIPTION
[[Bug #20271]](https://bugs.ruby-lang.org/issues/20271)
[[Bug #20267]](https://bugs.ruby-lang.org/issues/20267)
[[Bug #20255]](https://bugs.ruby-lang.org/issues/20255)

`rb_obj_alloc(RBASIC_CLASS(obj))` will always allocate from the basic 40B pool, so if `obj` is larger than `40B`, we'll create a corrupted object when we later copy the shape_id.

Instead we can use the same logic than ractor copy, which is to use `rb_obj_clone`, and later ask the GC to free the original object.

We then must turn it into a `T_OBJECT`, because otherwise just changing its class to `RactorMoved` leaves a lot of ways to keep using the object, e.g.:

```
a = [1, 2, 3]
Ractor.new{}.send(a, move: true)
[].concat(a) # Should raise, but wasn't.
```

If it turns out that `rb_obj_clone` isn't performant enough for some uses, we can always have carefully crafted specialized paths for the types that would benefit from it.