### PR TITLE
Removed the warning targets for Ruby 3.1

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -2,12 +2,6 @@
 
 module Gem::BUNDLED_GEMS # :nodoc:
   SINCE = {
-    "matrix" => "3.1.0",
-    "net-ftp" => "3.1.0",
-    "net-imap" => "3.1.0",
-    "net-pop" => "3.1.0",
-    "net-smtp" => "3.1.0",
-    "prime" => "3.1.0",
     "racc" => "3.3.0",
     "abbrev" => "3.4.0",
     "base64" => "3.4.0",


### PR DESCRIPTION
Ruby 3.1 will be EOL at April 2025. We shouldn't warn the bundled gems from Ruby 3.1.