### PR TITLE
Provide compaction support for argf_type

### DIFF
--- a/io.c
+++ b/io.c
@@ -9996,9 +9996,20 @@ argf_memsize(const void *ptr)
     return size;
 }
 
+static void
+argf_compact(void *ptr)
+{
+    struct argf *p = ptr;
+    p->filename = rb_gc_location(p->filename);
+    p->current_file = rb_gc_location(p->current_file);
+    p->argv = rb_gc_location(p->argv);
+    p->inplace = rb_gc_location(p->inplace);
+    p->encs.ecopts = rb_gc_location(p->encs.ecopts);
+}
+
 static const rb_data_type_t argf_type = {
     "ARGF",
-    {argf_mark, RUBY_TYPED_DEFAULT_FREE, argf_memsize},
+    {argf_mark, RUBY_TYPED_DEFAULT_FREE, argf_memsize, argf_compact},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 


### PR DESCRIPTION
We can't use declarative references here because of the deep reference into `p->encs`