### PR TITLE
[Bug #21203] Skip TestGc#test_gc_parameter_init_slots since it is flaky

### DIFF
--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -533,6 +533,8 @@ class TestGc < Test::Unit::TestCase
   end
 
   def test_gc_parameter_init_slots
+    omit "[Bug #21203] This test is flaky and intermittently failing now"
+
     assert_separately([], __FILE__, __LINE__, <<~RUBY, timeout: 60)
       # Constant from gc.c.
       GC_HEAP_INIT_SLOTS = 10_000


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21203

TestGc#test_gc_parameter_init_slots is a flaky test that fails intermittently. Until the issue with flakiness is resolved, I will skip it. 