### PR TITLE
Revert "Fix jump buffer leak in setjmp handler in WASI builds"

### DIFF
--- a/eval_intern.h
+++ b/eval_intern.h
@@ -102,11 +102,11 @@ extern int select_large_fdset(int, fd_set *, fd_set *, fd_set *, struct timeval 
   _tag.tag = Qundef; \
   _tag.prev = _ec->tag; \
   _tag.lock_rec = rb_ec_vm_lock_rec(_ec); \
-  rb_vm_tag_jmpbuf_init(&_tag);
+  rb_vm_tag_jmpbuf_init(&_tag.buf); \
 
 #define EC_POP_TAG() \
   _ec->tag = _tag.prev; \
-  rb_vm_tag_jmpbuf_deinit(&_tag); \
+  rb_vm_tag_jmpbuf_deinit(&_tag.buf); \
 } while (0)
 
 #define EC_TMPPOP_TAG() \

--- a/vm_core.h
+++ b/vm_core.h
@@ -946,16 +946,37 @@ typedef void *rb_jmpbuf_t[5];
   Therefore, we allocates the buffer on the heap on such
   environments.
 */
-typedef struct _rb_vm_tag_jmpbuf {
-    struct _rb_vm_tag_jmpbuf *next;
-    rb_jmpbuf_t buf;
-} *rb_vm_tag_jmpbuf_t;
+typedef rb_jmpbuf_t *rb_vm_tag_jmpbuf_t;
 
-#define RB_VM_TAG_JMPBUF_GET(jmpbuf) ((jmpbuf)->buf)
+#define RB_VM_TAG_JMPBUF_GET(buf) (*buf)
+
+static inline void
+rb_vm_tag_jmpbuf_init(rb_vm_tag_jmpbuf_t *jmpbuf)
+{
+    *jmpbuf = ruby_xmalloc(sizeof(rb_jmpbuf_t));
+}
+
+static inline void
+rb_vm_tag_jmpbuf_deinit(const rb_vm_tag_jmpbuf_t *jmpbuf)
+{
+    ruby_xfree(*jmpbuf);
+}
 #else
 typedef rb_jmpbuf_t rb_vm_tag_jmpbuf_t;
 
-#define RB_VM_TAG_JMPBUF_GET(jmpbuf) (jmpbuf)
+#define RB_VM_TAG_JMPBUF_GET(buf) (buf)
+
+static inline void
+rb_vm_tag_jmpbuf_init(rb_vm_tag_jmpbuf_t *jmpbuf)
+{
+    // no-op
+}
+
+static inline void
+rb_vm_tag_jmpbuf_deinit(const rb_vm_tag_jmpbuf_t *jmpbuf)
+{
+    // no-op
+}
 #endif
 
 /*
@@ -970,54 +991,6 @@ struct rb_vm_tag {
     enum ruby_tag_type state;
     unsigned int lock_rec;
 };
-
-#if defined(__wasm__) && !defined(__EMSCRIPTEN__)
-static inline void
-_rb_vm_tag_jmpbuf_deinit_internal(rb_vm_tag_jmpbuf_t jmpbuf)
-{
-    rb_vm_tag_jmpbuf_t buf = jmpbuf;
-    while (buf != NULL) {
-        rb_vm_tag_jmpbuf_t next = buf->next;
-        ruby_xfree(buf);
-        buf = next;
-    }
-}
-
-static inline void
-rb_vm_tag_jmpbuf_init(struct rb_vm_tag *tag)
-{
-    if (tag->prev != NULL && tag->prev->buf->next != NULL) {
-        _rb_vm_tag_jmpbuf_deinit_internal(tag->prev->buf->next);
-        tag->prev->buf->next = NULL;
-    }
-    tag->buf = ruby_xmalloc(sizeof *tag->buf);
-    tag->buf->next = NULL;
-    if (tag->prev != NULL) {
-        tag->prev->buf->next = tag->buf;
-    }
-}
-
-static inline void
-rb_vm_tag_jmpbuf_deinit(struct rb_vm_tag *tag)
-{
-    if (tag->prev != NULL) {
-        tag->prev->buf->next = NULL;
-    }
-    _rb_vm_tag_jmpbuf_deinit_internal(tag->buf);
-}
-#else
-static inline void
-rb_vm_tag_jmpbuf_init(struct rb_vm_tag *tag)
-{
-    // no-op
-}
-
-static inline void
-rb_vm_tag_jmpbuf_deinit(struct rb_vm_tag *tag)
-{
-    // no-op
-}
-#endif
 
 STATIC_ASSERT(rb_vm_tag_buf_offset, offsetof(struct rb_vm_tag, buf) > 0);
 STATIC_ASSERT(rb_vm_tag_buf_end,


### PR DESCRIPTION
This reverts the following commits as it's causing OOM in some cases in ruby/ruby.wasm test suite.
* 372515f33c908b36b3f5fbd2edcb34c69b418500
* 3a730be8b464454878a42132f6fecb98ab4c1b5b