### PR TITLE
io_buffer: Reimplement dcompact for IO::Buffer

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -273,6 +273,13 @@ io_buffer_free(struct rb_io_buffer *buffer)
 }
 
 static void
+rb_io_buffer_type_mark(void *_buffer)
+{
+    struct rb_io_buffer *buffer = _buffer;
+    rb_gc_mark(buffer->source);
+}
+
+static void
 rb_io_buffer_type_free(void *_buffer)
 {
     struct rb_io_buffer *buffer = _buffer;
@@ -293,20 +300,15 @@ rb_io_buffer_type_size(const void *_buffer)
     return total;
 }
 
-RUBY_REFERENCES(io_buffer_refs) = {
-    RUBY_REF_EDGE(struct rb_io_buffer, source),
-    RUBY_REF_END
-};
-
 static const rb_data_type_t rb_io_buffer_type = {
     .wrap_struct_name = "IO::Buffer",
     .function = {
-        .dmark = RUBY_REFS_LIST_PTR(io_buffer_refs),
+        .dmark = rb_io_buffer_type_mark,
         .dfree = rb_io_buffer_type_free,
         .dsize = rb_io_buffer_type_size,
     },
     .data = NULL,
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE | RUBY_TYPED_DECL_MARKING,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE,
 };
 
 static inline enum rb_io_buffer_flags

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -683,4 +683,17 @@ class TestIOBuffer < Test::Unit::TestCase
     buf.set_string('a', 0, 0)
     assert_predicate buf, :empty?
   end
+
+  # https://bugs.ruby-lang.org/issues/21210
+  def test_bug_21210
+    omit "compaction is not supported on this platform" unless GC.respond_to?(:compact)
+
+    str = +"hello"
+    buf = IO::Buffer.for(str)
+    assert_predicate buf, :valid?
+
+    GC.verify_compaction_references(expand_heap: true, toward: :empty)
+
+    assert_predicate buf, :valid?
+  end
 end


### PR DESCRIPTION
Proposed patch for [[Bug #21210]](https://bugs.ruby-lang.org/issues/21210)