### PR TITLE
Fix test failure with CMake 4 for Ruby 3.4

### DIFF
--- a/test/rubygems/test_gem_ext_cmake_builder.rb
+++ b/test/rubygems/test_gem_ext_cmake_builder.rb
@@ -29,7 +29,7 @@ class TestGemExtCmakeBuilder < Gem::TestCase
   def test_self_build
     File.open File.join(@ext, "CMakeLists.txt"), "w" do |cmakelists|
       cmakelists.write <<-EO_CMAKE
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 project(self_build NONE)
 install (FILES test.txt DESTINATION bin)
       EO_CMAKE


### PR DESCRIPTION
```
[rubygems/rubygems] Bump up minimum required version for cmake 4
https://github.com/rubygems/rubygems/commit/3e77caeddf
```