### PR TITLE
Remove rb_gc_start from cancel_single_ractor_mode

### DIFF
--- a/ext/-test-/thread/instrumentation/instrumentation.c
+++ b/ext/-test-/thread/instrumentation/instrumentation.c
@@ -6,7 +6,6 @@
 #  define RB_THREAD_LOCAL_SPECIFIER
 #endif
 
-static VALUE last_thread = Qnil;
 static VALUE timeline_value = Qnil;
 
 struct thread_event {
@@ -211,9 +210,8 @@ Init_instrumentation(void)
     VALUE mBug = rb_define_module("Bug");
     VALUE klass = rb_define_module_under(mBug, "ThreadInstrumentation");
     rb_global_variable(&timeline_value);
-    timeline_value = TypedData_Wrap_Struct(0, &event_timeline_type, 0);
+    timeline_value = TypedData_Wrap_Struct(0, &event_timeline_type, (void *)1);
 
-    rb_global_variable(&last_thread);
     rb_define_singleton_method(klass, "register_callback", thread_register_callback, 1);
     rb_define_singleton_method(klass, "unregister_callback", thread_unregister_callback, 0);
     rb_define_singleton_method(klass, "register_and_unregister_callbacks", thread_register_and_unregister_callback, 0);

--- a/ractor.c
+++ b/ractor.c
@@ -1980,14 +1980,6 @@ cancel_single_ractor_mode(void)
     // enable multi-ractor mode
     RUBY_DEBUG_LOG("enable multi-ractor mode");
 
-    VALUE was_disabled = rb_gc_enable();
-
-    rb_gc_start();
-
-    if (was_disabled) {
-        rb_gc_disable();
-    }
-
     ruby_single_main_ractor = NULL;
     rb_funcall(rb_cRactor, rb_intern("_activated"), 0);
 }


### PR DESCRIPTION
In 307732ccee7f9f28f8422bab2f839da021d8cdec Ractors were changed to explicitly run GC when the first non-main one was activated in order to disable the transient heap. Theap no longer exists so I don't think we need to do this.