### PR TITLE
Fix lldb debug scripts

### DIFF
--- a/misc/lldb_rb/rb_heap_structs.py
+++ b/misc/lldb_rb/rb_heap_structs.py
@@ -1,4 +1,5 @@
 import lldb
+import math
 from lldb_rb.lldb_interface import LLDBInterface
 from lldb_rb.constants import *
 
@@ -51,7 +52,6 @@ class RbObject(LLDBInterface):
         self.flUshift = self.ruby_globals["RUBY_FL_USHIFT"]
 
         self.tRBasic = self.target.FindFirstType("struct RBasic").GetPointerType()
-        self.tRValue = self.target.FindFirstType("struct RVALUE")
 
         self.val = ptr.Cast(self.tRBasic)
         self.page = HeapPage(self.debugger, self.val)
@@ -70,10 +70,12 @@ class RbObject(LLDBInterface):
             return ' '
 
     def dump_bits(self, result, end = "\n"):
-        tRValue = self.target.FindFirstType("struct RVALUE")
         tUintPtr = self.target.FindFirstType("uintptr_t") # bits_t
 
-        num_in_page = (self.val.GetValueAsUnsigned() & HEAP_PAGE_ALIGN_MASK) // tRValue.GetByteSize();
+        slot_size = self.page.to_heap_page_struct().GetChildMemberWithName("heap").GetChildMemberWithName("slot_size").unsigned
+        byte_size = 40 ** math.floor(math.log(slot_size, 40))
+
+        num_in_page = (self.val.GetValueAsUnsigned() & HEAP_PAGE_ALIGN_MASK) // byte_size;
         bits_bitlength = tUintPtr.GetByteSize() * 8
         bitmap_index = num_in_page // bits_bitlength
         bitmap_offset = num_in_page & (bits_bitlength - 1)
@@ -109,7 +111,14 @@ class RbObject(LLDBInterface):
             return False
 
     def as_type(self, type_name):
-        return self.val.Cast(self.tRValue.GetPointerType()).GetValueForExpressionPath("->as."+type_name)
+        if type_name == "array":
+            tRarray = self.target.FindFirstType("struct RArray")
+            return self.val.Cast(tRarray.GetPointerType())
+        elif type_name == "bignum":
+            tRbignum = self.target.FindFirstType("struct RBignum")
+            return self.val.Cast(tRbignum.GetPointerType())
+        else:
+            print("as_type is not implemented for:", type_name)
 
     def ary_ptr(self):
         rval = self.as_type("array")


### PR DESCRIPTION
In ruby/ruby#13008 `RVALUE` was removed without replacement. This means the lldb scripts that relied on `RVALUE` stopped working.

I updated the ones that were using it just for the bytesize to use `slot_size` and then round to the nearest power of 40. We can't use `slot_size` directly because in debug mode it's `48` but `RVALUE` is `40` bytes.

For the `as_type` method, I updated it to check the type. It's only used for `bignum` and `array` so that's a simple change.

Lastly, for the `dump_page` method I replaced it with `struct free_slot` since that's looking at the freelist.

`struct RVALUE` has been removed from all the scripts and I verified that `rp` is fixed. I'm not confident the `dump_page` method is fixed, the freelist looks off, but for now this gets us closer.