### PR TITLE
Picking test fix for test_inspect_encoding with Ruby 3.4

### DIFF
--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -363,7 +363,7 @@ class TestEnv < Test::Unit::TestCase
     ENV.clear
     key = "VAR\u{e5 e1 e2 e4 e3 101 3042}"
     ENV[key] = "foo"
-    assert_equal(%{{"VAR\u{e5 e1 e2 e4 e3 101 3042}" => "foo"}}, ENV.inspect)
+    assert_equal(%{{#{(key.encode(ENCODING) rescue key.b).inspect} => "foo"}}, ENV.inspect)
   end
 
   def test_to_a


### PR DESCRIPTION
For https://rubyci.s3.amazonaws.com/s390x/ruby-3.4/log/20250403T025650Z.fail.html.gz

The original change is https://github.com/ruby/ruby/commit/d78ff6a767ca813ac5fa178dd7611f20a993c191