### PR TITLE
Fix build failure for aarch64 with Ruby 3.3

### DIFF
--- a/ractor_core.h
+++ b/ractor_core.h
@@ -315,7 +315,7 @@ rb_ractor_set_current_ec_(rb_ractor_t *cr, rb_execution_context_t *ec, const cha
 {
 #ifdef RB_THREAD_LOCAL_SPECIFIER
 
-# ifdef __APPLE__
+# if defined(__arm64__) || defined(__aarch64__)
     rb_current_ec_set(ec);
 # else
     ruby_current_ec = ec;


### PR DESCRIPTION
* https://rubyci.s3.amazonaws.com/ubuntu-arm/ruby-3.3/log/20250403T010321Z.fail.html.gz
* https://rubyci.s3.amazonaws.com/fedora40-arm/ruby-3.3/log/20250403T012350Z.fail.html.gz