### PR TITLE
Use IPv4 for test server because TestNetHTTPS is failing with s390x

### DIFF
--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -23,7 +23,7 @@ class TestNetHTTPS < Test::Unit::TestCase
   TEST_STORE = OpenSSL::X509::Store.new.tap {|s| s.add_cert(CA_CERT) }
 
   CONFIG = {
-    'host' => HOST,
+    'host' => HOST_IP,
     'proxy_host' => nil,
     'proxy_port' => nil,
     'ssl_enable' => true,


### PR DESCRIPTION
https://rubyci.s3.amazonaws.com/s390x/ruby-3.2/log/20250403T005659Z.fail.html.gz