### PR TITLE
Use `127.0.0.1` explicitly for net/http tests

### DIFF
--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -1249,7 +1249,7 @@ end
 
 class TestNetHTTPLocalBind < Test::Unit::TestCase
   CONFIG = {
-    'host' => 'localhost',
+    'host' => '127.0.0.1',
     'proxy_host' => nil,
     'proxy_port' => nil,
   }
@@ -1286,7 +1286,7 @@ end
 
 class TestNetHTTPForceEncoding < Test::Unit::TestCase
   CONFIG = {
-    'host' => 'localhost',
+    'host' => '127.0.0.1',
     'proxy_host' => nil,
     'proxy_port' => nil,
   }

--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -23,7 +23,7 @@ class TestNetHTTPS < Test::Unit::TestCase
   TEST_STORE = OpenSSL::X509::Store.new.tap {|s| s.add_cert(CA_CERT) }
 
   CONFIG = {
-    'host' => HOST,
+    'host' => HOST_IP,
     'proxy_host' => nil,
     'proxy_port' => nil,
     'ssl_enable' => true,


### PR DESCRIPTION
https://rubyci.s3.amazonaws.com/s390x/ruby-3.3/log/20250403T072101Z.fail.html.gz