### PR TITLE
Extend open_timeout for test failure on s390x

### DIFF
--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -589,9 +589,9 @@ module TestNetHTTP_version_1_1_methods
       port = server.addr[1]
 
       conn = Net::HTTP.new('localhost', port)
-      conn.write_timeout = 0.01
-      conn.read_timeout = 0.01 if windows?
-      conn.open_timeout = 1
+      conn.write_timeout = EnvUtil.apply_timeout_scale(0.01)
+      conn.read_timeout = EnvUtil.apply_timeout_scale(0.01) if windows?
+      conn.open_timeout = EnvUtil.apply_timeout_scale(1)
 
       req = Net::HTTP::Post.new('/')
       data = "a"*50_000_000

--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -565,7 +565,7 @@ module TestNetHTTP_version_1_1_methods
       conn = Net::HTTP.new('localhost', port)
       conn.write_timeout = EnvUtil.apply_timeout_scale(0.01)
       conn.read_timeout = EnvUtil.apply_timeout_scale(0.01) if windows?
-      conn.open_timeout = EnvUtil.apply_timeout_scale(0.1)
+      conn.open_timeout = EnvUtil.apply_timeout_scale(1)
 
       th = Thread.new do
         err = !windows? ? Net::WriteTimeout : Net::ReadTimeout
@@ -591,7 +591,7 @@ module TestNetHTTP_version_1_1_methods
       conn = Net::HTTP.new('localhost', port)
       conn.write_timeout = 0.01
       conn.read_timeout = 0.01 if windows?
-      conn.open_timeout = 0.1
+      conn.open_timeout = 1
 
       req = Net::HTTP::Post.new('/')
       data = "a"*50_000_000


### PR DESCRIPTION
https://rubyci.s3.amazonaws.com/s390x/ruby-master/log/20250403T060004Z.fail.html.gz