### PR TITLE
Grow GC heaps independently

### DIFF
--- a/test/.excludes-mmtk/TestGc.rb
+++ b/test/.excludes-mmtk/TestGc.rb
@@ -7,6 +7,7 @@ exclude(:test_gc_config_setting_returns_updated_config_hash, "testing behaviour 
 exclude(:test_gc_internals, "testing behaviour specific to default GC")
 exclude(:test_gc_parameter, "testing behaviour specific to default GC")
 exclude(:test_gc_parameter_init_slots, "testing behaviour specific to default GC")
+exclude(:test_heaps_grow_independently, "testing behaviour specific to default GC")
 exclude(:test_latest_gc_info, "testing behaviour specific to default GC")
 exclude(:test_latest_gc_info_argument, "testing behaviour specific to default GC")
 exclude(:test_latest_gc_info_need_major_by, "testing behaviour specific to default GC")


### PR DESCRIPTION
If we allocate objects where one heap holds transient objects and another holds long lived objects, then the heap with transient objects will grow along the heap with long lived objects, causing higher memory usage.

For example, we can see this issue in this script:

```ruby
def allocate_small_object = []
def allocate_large_object = Array.new(10)

arys = Array.new(1_000_000) do
  # Allocate 10 small transient objects
  10.times { allocate_small_object }
  # Allocate 1 large object that is persistent
  allocate_large_object
end

pp GC.stat
pp GC.stat_heap
```

Before this change:

    heap_live_slots: 2837243
    {0 =>
      {slot_size: 40,
       heap_eden_pages: 1123,
       heap_eden_slots: 1838807},
     2 =>
      {slot_size: 160,
       heap_eden_pages: 2449,
       heap_eden_slots: 1001149},
    }

After this change:

    heap_live_slots: 1094474
    {0 =>
      {slot_size: 40,
       heap_eden_pages: 58,
       heap_eden_slots: 94973},
     2 =>
      {slot_size: 160,
       heap_eden_pages: 2449,
       heap_eden_slots: 1001149},
    }