### PR TITLE
Fix regression caused by ruby/ruby#12995

### DIFF
--- a/eval_intern.h
+++ b/eval_intern.h
@@ -102,11 +102,11 @@ extern int select_large_fdset(int, fd_set *, fd_set *, fd_set *, struct timeval 
   _tag.tag = Qundef; \
   _tag.prev = _ec->tag; \
   _tag.lock_rec = rb_ec_vm_lock_rec(_ec); \
-  rb_vm_tag_jmpbuf_init(&_tag.buf); \
+  rb_vm_tag_jmpbuf_init(&_tag);
 
 #define EC_POP_TAG() \
   _ec->tag = _tag.prev; \
-  rb_vm_tag_jmpbuf_deinit(&_tag.buf); \
+  rb_vm_tag_jmpbuf_deinit(&_tag); \
 } while (0)
 
 #define EC_TMPPOP_TAG() \


### PR DESCRIPTION
#12995 was reverted by #13026 because it caused some of the tests from [ruby.wasm](https://github.com/ruby/ruby.wasm) to fail. This pull request reverts #13026 and then fixes the bug introduced by #12995 that caused the tests from ruby.wasm to fail.

Requesting a review from @kateinoigakukun.