### PR TITLE
prism_compile.c: Avoid zero length allocation

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -11053,7 +11053,7 @@ pm_parse_process(pm_parse_result_t *result, pm_node_t *node, VALUE *script_lines
     // Now set up the constant pool and intern all of the various constants into
     // their corresponding IDs.
     scope_node->parser = parser;
-    scope_node->constants = xcalloc(parser->constant_pool.size, sizeof(ID));
+    scope_node->constants = parser->constant_pool.size ? xcalloc(parser->constant_pool.size, sizeof(ID)) : NULL;
 
     for (uint32_t index = 0; index < parser->constant_pool.size; index++) {
         pm_constant_t *constant = &parser->constant_pool.constants[index];


### PR DESCRIPTION
The constant pool may be empty.