### PR TITLE
Ractor: revert to moving object bytes, but size pool aware

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2101,3 +2101,24 @@ assert_equal 'ok', %q{
     :fail
   end
 }
+
+# move objects inside frozen containers
+assert_equal 'ok', %q{
+  ractor = Ractor.new { Ractor.receive }
+  obj = Array.new(10, 42)
+  original = obj.dup
+  ractor.send([obj].freeze, move: true)
+  roundtripped_obj = ractor.take[0]
+  roundtripped_obj == original ? :ok : roundtripped_obj
+}
+
+# move object with generic ivar
+assert_equal 'ok', %q{
+  ractor = Ractor.new { Ractor.receive }
+  obj = Array.new(10, 42)
+  obj.instance_variable_set(:@array, [1])
+
+  ractor.send(obj, move: true)
+  roundtripped_obj = ractor.take
+  roundtripped_obj.instance_variable_get(:@array) == [1] ? :ok : roundtripped_obj
+}

--- a/gc.c
+++ b/gc.c
@@ -2659,14 +2659,6 @@ rb_gc_mark_roots(void *objspace, const char **categoryp)
 #define TYPED_DATA_REFS_OFFSET_LIST(d) (size_t *)(uintptr_t)RTYPEDDATA(d)->type->function.dmark
 
 void
-rb_gc_ractor_moved(VALUE dest, VALUE src)
-{
-    rb_gc_obj_free(rb_gc_get_objspace(), src);
-    MEMZERO((void *)src, char, rb_gc_obj_slot_size(src));
-    RBASIC(src)->flags = T_OBJECT | FL_FREEZE; // Avoid mutations using bind_call, etc.
-}
-
-void
 rb_gc_mark_children(void *objspace, VALUE obj)
 {
     if (FL_TEST(obj, FL_EXIVAR)) {

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -183,7 +183,6 @@ struct rb_gc_object_metadata_entry {
 /* gc.c */
 RUBY_ATTR_MALLOC void *ruby_mimmalloc(size_t size);
 RUBY_ATTR_MALLOC void *ruby_mimcalloc(size_t num, size_t size);
-void rb_gc_ractor_moved(VALUE dest, VALUE src);
 void ruby_mimfree(void *ptr);
 void rb_gc_prepare_heap(void);
 void rb_objspace_set_event_hook(const rb_event_flag_t event);

--- a/variable.c
+++ b/variable.c
@@ -2158,6 +2158,27 @@ rb_copy_generic_ivar(VALUE clone, VALUE obj)
 }
 
 void
+rb_replace_generic_ivar(VALUE clone, VALUE obj)
+{
+    RUBY_ASSERT(FL_TEST(obj, FL_EXIVAR));
+
+    RB_VM_LOCK_ENTER();
+    {
+        st_data_t ivtbl, obj_data = (st_data_t)obj;
+        if (st_delete(generic_iv_tbl_, &obj_data, &ivtbl)) {
+            FL_UNSET_RAW(obj, FL_EXIVAR);
+
+            st_insert(generic_iv_tbl_, (st_data_t)clone, ivtbl);
+            FL_SET_RAW(clone, FL_EXIVAR);
+        }
+        else {
+            rb_bug("unreachable");
+        }
+    }
+    RB_VM_LOCK_LEAVE();
+}
+
+void
 rb_ivar_foreach(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg)
 {
     if (SPECIAL_CONST_P(obj)) return;


### PR DESCRIPTION
Using `rb_obj_clone` introduce other problems, such as `initialize_*` callbacks invocation in the context of the parent ractor.

So we can revert back to copy the content of the object slots, but in a way that is aware of size pools.

Followup: https://github.com/ruby/ruby/pull/13008