### PR TITLE
Simplify singleton class creation

### DIFF
--- a/class.c
+++ b/class.c
@@ -782,7 +782,6 @@ make_metaclass(VALUE klass)
     }
 
     super = RCLASS_SUPER(klass);
-    while (RB_TYPE_P(super, T_ICLASS)) super = RCLASS_SUPER(super);
     RCLASS_SET_SUPER(metaclass, super ? ENSURE_EIGENCLASS(super) : rb_cClass);
 
     // Full class ancestry may not have been filled until we reach here.

--- a/class.c
+++ b/class.c
@@ -808,7 +808,7 @@ make_singleton_class(VALUE obj)
     rb_singleton_class_attached(klass, obj);
     rb_yjit_invalidate_no_singleton_class(orig_class);
 
-    SET_METACLASS_OF(klass, METACLASS_OF(rb_class_real(orig_class)));
+    SET_METACLASS_OF(klass, METACLASS_OF(orig_class));
     return klass;
 }
 


### PR DESCRIPTION
Hi all 👋🏻 

This PR aims at simplifying singleton classes' creation a bit, by dropping code that, to my understanding, seems redundant.

The following are my (hopefully correct) assumptions:

- WRT `make_singleton_class`, what I can see is that:
  - `orig_class` is prevented to be a singleton class by client code (see `singleton_class_of`), and
  - `orig_class` cannot be an iclass.

  Thus it should be safe, IIUC, to avoid the call `rb_class_real(orig_class)` entirely.

- WRT `make_metaclass`: 

  The creation of a class is always immediately followed by the creation of the associated singleton class - that is, before any module can be included/prepended to the class. Because of this, `super` cannot be an iclass, and we should be able to safely avoid the search of an actual superclass.

It goes without saying, but given the criticality of the code this PR touches, I'm totally open to make changes (or close the PR entirely) should the above assumptions be wrong, or if the current approach is deemed to be ok as it is, for any reason.
This code has been sitting there for a while, and I'm aware that changing it may be a long shot.

Thanks for your time.
Cheers!