### PR TITLE
Add an assertion that rb_sourceline() never return 0

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -5662,6 +5662,9 @@ update_line_coverage(VALUE data, const rb_trace_arg_t *trace_arg)
         VALUE lines = RARRAY_AREF(coverage, COVERAGE_INDEX_LINES);
         if (lines) {
             long line = rb_sourceline() - 1;
+            if (UNLIKELY(line < 0)) {
+                rb_bug("rb_sourceline() returned 0");
+            }
             long count;
             VALUE num;
             void rb_iseq_clear_event_flags(const rb_iseq_t *iseq, size_t pos, rb_event_flag_t reset);


### PR DESCRIPTION
@mame what do you think? Or perhaps just a regular `RUBY_ASSERT` so it's optimized out, but I fear we're not that likely to run into it in the test suite.