### PR TITLE
Add type check for `rb_big_modulo` first argument

### DIFF
--- a/bignum.c
+++ b/bignum.c
@@ -6136,6 +6136,9 @@ rb_big_modulo(VALUE x, VALUE y)
 {
     VALUE z;
 
+    if (!RB_BIGNUM_TYPE_P(x)) {
+        rb_raise(rb_eTypeError, "expected a bignum");
+    }
     if (FIXNUM_P(y)) {
         y = rb_int2big(FIX2LONG(y));
     }

--- a/spec/ruby/optional/capi/bignum_spec.rb
+++ b/spec/ruby/optional/capi/bignum_spec.rb
@@ -119,6 +119,18 @@ describe "CApiBignumSpecs" do
     end
   end
 
+  describe "rb_big_modulo" do
+    it "raises TypeError if the first argument is not a Bignum" do
+      -> { @s.rb_big_modulo(42, 5) }.should raise_error(TypeError)
+      -> { @s.rb_big_modulo(42, bignum_value) }.should raise_error(TypeError)
+    end
+
+    it "converts the second argument to a Bignum before calculating" do
+      val = 18_446_744_073_709_551_658
+      @s.rb_big_modulo(val, 5).should == 3
+    end
+  end
+
   describe "rb_big_pack" do
     it "packs a Bignum into an unsigned long" do
       val = @s.rb_big_pack(@max_ulong)

--- a/spec/ruby/optional/capi/ext/bignum_spec.c
+++ b/spec/ruby/optional/capi/ext/bignum_spec.c
@@ -39,6 +39,10 @@ static VALUE bignum_spec_rb_big_cmp(VALUE self, VALUE x, VALUE y) {
   return rb_big_cmp(x, y);
 }
 
+static VALUE bignum_spec_rb_big_modulo(VALUE self, VALUE x, VALUE y) {
+  return rb_big_modulo(x, y);
+}
+
 static VALUE bignum_spec_rb_big_pack(VALUE self, VALUE val) {
   unsigned long buff;
 
@@ -96,6 +100,7 @@ void Init_bignum_spec(void) {
   rb_define_method(cls, "rb_big2ulong", bignum_spec_rb_big2ulong, 1);
   rb_define_method(cls, "RBIGNUM_SIGN", bignum_spec_RBIGNUM_SIGN, 1);
   rb_define_method(cls, "rb_big_cmp", bignum_spec_rb_big_cmp, 2);
+  rb_define_method(cls, "rb_big_modulo", bignum_spec_rb_big_modulo, 2);
   rb_define_method(cls, "rb_big_pack", bignum_spec_rb_big_pack, 1);
   rb_define_method(cls, "rb_big_pack_array", bignum_spec_rb_big_pack_array, 2);
   rb_define_method(cls, "rb_big_pack_length", bignum_spec_rb_big_pack_length, 1);


### PR DESCRIPTION
This PR adds type checking to `rb_big_modulo` to ensure the first argument is a Bignum, preventing potential segmentation faults or undefined behavior when called with improper types.

I understand the API is meant to be called with a Bignum as first argument, but I think the check is worth it because it adds a safety layer that makes the codebase more robust against misuse.

Several other rb_big_* functions lack similar type checking and could benefit from the same fix, including:
- `rb_big_plus`
- `rb_big_minus`
- `rb_big_mul`
- `rb_big_div`
- `rb_big_idiv`
- `rb_big_divmod`
- `rb_big_and`
- `rb_big_or`
- `rb_big_xor`
- `rb_big_pack`

I wanted to see Ruby core's opinion on this approach before implementing similar fixes for these other functions.