### PR TITLE
[DOC] Fix contributing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See ["Contributing to Ruby"](https://docs.ruby-lang.org/en/master/contributing_md.html), which includes setup and build instructions.
+See ["Contributing to Ruby"](https://docs.ruby-lang.org/en/master/contributing/contributing_md.html), which includes setup and build instructions.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Bugs should be reported at https://bugs.ruby-lang.org. Read ["Reporting Issues"]
 
 ## Contributing
 
-See ["Contributing to Ruby"](https://docs.ruby-lang.org/en/master/contributing_md.html), which includes setup and build instructions.
+See ["Contributing to Ruby"](https://docs.ruby-lang.org/en/master/contributing/contributing_md.html), which includes setup and build instructions.
 
 ## The Author
 


### PR DESCRIPTION
It moved in https://github.com/ruby/ruby/pull/13012 but wasn't updated here