### PR TITLE
Fix LLDB scripts by using the toplevel RBasic

### DIFF
--- a/misc/lldb_cruby.py
+++ b/misc/lldb_cruby.py
@@ -68,7 +68,7 @@ class BackTrace:
         return self.VM_FRAME_MAGIC_NAME.get(frame_type, "(none)")
 
     def rb_iseq_path_str(self, iseq):
-        tRBasic = self.target.FindFirstType("struct RBasic").GetPointerType()
+        tRBasic = self.target.FindFirstType("::RBasic").GetPointerType()
 
         pathobj = iseq.GetValueForExpressionPath("->body->location.pathobj")
         pathobj = pathobj.Cast(tRBasic)
@@ -270,7 +270,7 @@ def lldb_inspect(debugger, target, result, val):
     elif num & RUBY_IMMEDIATE_MASK:
         print('immediate(%x)' % num, file=result)
     else:
-        tRBasic = target.FindFirstType("struct RBasic").GetPointerType()
+        tRBasic = target.FindFirstType("::RBasic").GetPointerType()
 
         val = val.Cast(tRBasic)
         flags = val.GetValueForExpressionPath("->flags").GetValueAsUnsigned()
@@ -550,7 +550,7 @@ class HeapPageIter:
         self.num_slots = page.GetChildMemberWithName('total_slots').unsigned
         self.slot_size = page.GetChildMemberWithName('heap').GetChildMemberWithName('slot_size').unsigned
         self.counter = 0
-        self.tRBasic = target.FindFirstType("struct RBasic")
+        self.tRBasic = target.FindFirstType("::RBasic")
 
     def is_valid(self):
         heap_page_header_size = self.target.FindFirstType("struct heap_page_header").GetByteSize()

--- a/misc/lldb_rb/commands/heap_page_command.py
+++ b/misc/lldb_rb/commands/heap_page_command.py
@@ -8,14 +8,15 @@ class HeapPageCommand(RbBaseCommand):
     help_string = "prints out 'struct heap_page' for a VALUE pointer in the page"
 
     def call(self, debugger, command, exe_ctx, result):
+        self.result = result
         self.t_heap_page_body = self.target.FindFirstType("struct heap_page_body")
         self.t_heap_page_ptr = self.target.FindFirstType("struct heap_page").GetPointerType()
 
         page = self._get_page(self.frame.EvaluateExpression(command))
         page.Cast(self.t_heap_page_ptr)
 
-        self._append_expression(debugger, "(struct heap_page *) %0#x" % page.GetValueAsUnsigned(), result)
-        self._append_expression(debugger, "*(struct heap_page *) %0#x" % page.GetValueAsUnsigned(), result)
+        self._append_expression("(struct heap_page *) %0#x" % page.GetValueAsUnsigned())
+        self._append_expression("*(struct heap_page *) %0#x" % page.GetValueAsUnsigned())
 
     def _get_page(self, val):
         addr = val.GetValueAsUnsigned()

--- a/misc/lldb_rb/commands/print_flags_command.py
+++ b/misc/lldb_rb/commands/print_flags_command.py
@@ -11,7 +11,7 @@ class PrintFlagsCommand(RbBaseCommand):
 
     # call is where our command logic will be implemented
     def call(self, debugger, command, exe_ctx, result):
-        rclass_t = self.target.FindFirstType("struct RBasic")
+        rclass_t = self.target.FindFirstType("::RBasic")
         rcass_ptr = self.target.EvaluateExpression(command).Cast(rclass_t.GetPointerType())
         obj_flags = rcass_ptr.GetValueForExpressionPath("->flags").GetValueAsUnsigned()
 

--- a/misc/lldb_rb/lldb_interface.py
+++ b/misc/lldb_rb/lldb_interface.py
@@ -5,3 +5,14 @@ class LLDBInterface:
         self.process = self.target.GetProcess()
         self.thread = self.process.GetSelectedThread()
         self.frame = self.thread.GetSelectedFrame()
+
+    def _append_command_output(self, command):
+        output1 = self.result.GetOutput()
+        self.debugger.GetCommandInterpreter().HandleCommand(command, self.result)
+        output2 = self.result.GetOutput()
+        self.result.Clear()
+        self.result.write(output1)
+        self.result.write(output2)
+
+    def _append_expression(self, expression):
+        self._append_command_output("expression " + expression)

--- a/misc/lldb_rb/rb_heap_structs.py
+++ b/misc/lldb_rb/rb_heap_structs.py
@@ -51,7 +51,7 @@ class RbObject(LLDBInterface):
         self.flUser9 = self.ruby_globals["RUBY_FL_USER9"]
         self.flUshift = self.ruby_globals["RUBY_FL_USHIFT"]
 
-        self.tRBasic = self.target.FindFirstType("struct RBasic").GetPointerType()
+        self.tRBasic = self.target.FindFirstType("::RBasic").GetPointerType()
 
         self.val = ptr.Cast(self.tRBasic)
         self.page = HeapPage(self.debugger, self.val)

--- a/misc/lldb_rb/utils.py
+++ b/misc/lldb_rb/utils.py
@@ -8,17 +8,6 @@ class RbInspector(LLDBInterface):
         self.result = result
         self.ruby_globals = ruby_globals
 
-    def _append_command_output(self, command):
-        output1 = self.result.GetOutput()
-        self.debugger.GetCommandInterpreter().HandleCommand(command, self.result)
-        output2 = self.result.GetOutput()
-        self.result.Clear()
-        self.result.write(output1)
-        self.result.write(output2)
-
-    def _append_expression(self, expression):
-        self._append_command_output("expression " + expression)
-
     def string2cstr(self, rstring):
         """Returns the pointer to the C-string in the given String object"""
         if rstring.TypeIsPointerType():


### PR DESCRIPTION
With @eightbitraptor we figured the issue I had in #13048 by using `target.FindTypes` instead and looking at the results.

`target.FindFirstType("struct RBasic")` was returning the `yjit::cruby::autogened::RBasic` type instead of `struct RBasic` and then somehow getting the flags always returned 0.

Explicitly asking for the toplevel namespace `RBasic` by prefixing with `::` fixes that issue.

I also took the opportunity to fix the `heap_page` command by moving some parts of `RbInspector` into `LLDBInterface` and setting the `result` in the `call` method.

`rbbt` is still broken for me and `dump_page` just never returns or is very slow, but I still fixed the usage there for good measure.

**Before**
```console
(lldb) rp str
bits: [     ]
T_NONE: No value
(lldb) old_rp str
bits: [     ]
T_NONE: (yjit::cruby::autogened::RBasic) *$1 = {
  flags = (__0 = 5259269)
  klass = (__0 = 4304792640)
}
(lldb) heap_page str
Traceback (most recent call last):
  File "/Users/etienne/src/github.com/ruby/ruby/misc/lldb_rb/rb_base_command.py", line 48, in __call__
    self.call(debugger, command, exe_ctx, result)
  File "/Users/etienne/src/github.com/ruby/ruby/misc/lldb_rb/commands/heap_page_command.py", line 17, in call
    self._append_expression(debugger, "(struct heap_page *) %0#x" % page.GetValueAsUnsigned(), result)
AttributeError: 'HeapPageCommand' object has no attribute '_append_expression'
```

**After**
```console
(lldb) rp str
bits: [     ]
T_STRING: [UTF_8] [7BIT] (const char[6]) $1 = "string"
(lldb) old_rp str
bits: [     ]
T_STRING: [UTF_8] (const char[6]) $3 = "string"
(lldb) heap_page str
(struct heap_page *) $5 = 0x000000011e84b000
(struct heap_page) $6 = {
  slot_size = 40
  total_slots = 1638
# ✄
```