### PR TITLE
Remove unused field on Thread struct

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -3498,7 +3498,6 @@ thread_mark(void *ptr)
     if (th->root_fiber) rb_fiber_mark_self(th->root_fiber);
 
     RUBY_ASSERT(th->ec == rb_fiberptr_get_ec(th->ec->fiber_ptr));
-    rb_gc_mark(th->stat_insn_usage);
     rb_gc_mark(th->last_status);
     rb_gc_mark(th->locking_mutex);
     rb_gc_mark(th->name);

--- a/vm_core.h
+++ b/vm_core.h
@@ -1167,9 +1167,6 @@ typedef struct rb_thread_struct {
         thread_invoke_type_func
     } invoke_type;
 
-    /* statistics data for profiler */
-    VALUE stat_insn_usage;
-
     /* fiber */
     rb_fiber_t *root_fiber;
 


### PR DESCRIPTION
It looks like stat_insn_usage was introduced with YARV, but as far as I can tell the field has never been used.  I think we should remove the field since we don't use it.