### PR TITLE
Use csv 3.3.4

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -33,7 +33,7 @@ rinda               0.2.0   https://github.com/ruby/rinda
 drb                 2.2.1   https://github.com/ruby/drb
 nkf                 0.2.0   https://github.com/ruby/nkf
 syslog              0.3.0   https://github.com/ruby/syslog
-csv                 3.3.3   https://github.com/ruby/csv e0874e47e2730dacccdb0c534a2cdc073d3bdaea
+csv                 3.3.4   https://github.com/ruby/csv
 repl_type_completor 0.1.11  https://github.com/ruby/repl_type_completor
 ostruct             0.6.1   https://github.com/ruby/ostruct
 pstore              0.2.0   https://github.com/ruby/pstore


### PR DESCRIPTION
csv 3.3.3 introduced an experimental executable `csv-filter` but 3.3.4 removed it. So we can use released version.

Fixes [Bug #21207]