### PR TITLE
[Bug #21256] Fix `it` parameter when splatting and `define_method` is used

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6689,6 +6689,17 @@ pm_compile_scope_node(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_nod
         body->param.flags.has_lead = true;
     }
 
+    if (scope_node->parameters && PM_NODE_TYPE_P(scope_node->parameters, PM_IT_PARAMETERS_NODE)) {
+        const uint8_t param_name[] = { 'i', 't' };
+        pm_constant_id_t constant_id = pm_constant_pool_find(&scope_node->parser->constant_pool, param_name, 2);
+        RUBY_ASSERT(constant_id && "parser should fill in `it` parameter");
+        pm_insert_local_index(constant_id, local_index, index_lookup_table, local_table_for_iseq, scope_node);
+
+        local_index++;
+        body->param.lead_num = 1;
+        body->param.flags.has_lead = true;
+    }
+
     //********END OF STEP 3**********
 
     //********STEP 4**********

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1948,6 +1948,19 @@ eom
     assert_syntax_error('p { [it **2] }', /unexpected \*\*/)
   end
 
+  def test_it_with_splat_super_method
+    bug21256 = '[ruby-core:121592] [Bug #21256]'
+
+    a = Class.new do
+      define_method(:foo) { it }
+    end
+    b = Class.new(a) do
+      def foo(*args) = super
+    end
+
+    assert_equal(1, b.new.foo(1), bug21256)
+  end
+
   def test_value_expr_in_condition
     mesg = /void value expression/
     assert_syntax_error("tap {a = (true ? next : break)}", mesg)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21256

It was failing to set the leads, like numblocks do, causing the result to be wrapped in an array