### PR TITLE
[DOC] Mention VS Code debugging setup in the debugging guide

### DIFF
--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -248,6 +248,16 @@ following make targets:
 * `make lldb-ruby`: Runs `test.rb` using Ruby in lldb
 * `make gdb-ruby`: Runs `test.rb` using Ruby in gdb
 
+For VS Code users, you can set up editor-based debugging experience by running:
+
+```shell
+cp -r misc/.vscode .vscode
+```
+
+This will add launch configurations for debugging Ruby itself by running `test.rb` with `lldb`.
+
+**Note**: if you build Ruby under the `./build` folder, you'll need to update `.vscode/launch.json`'s program entry accordingly to: `"${workspaceFolder}/build/ruby"`
+
 ### Compiling for Debugging
 
 You should configure Ruby without optimization and other flags that may


### PR DESCRIPTION
VS Code debugging is usually more friendly to new contributors so I think it's worth mentioning that Ruby already provides a template for setting it up (created by @k0kubun)

![Screenshot 2025-04-18 at 13 37 30](https://github.com/user-attachments/assets/fb38d6ec-6c11-4abd-9817-1bd12d0d5f57)
