### PR TITLE
Show performance warnings for easily avoidable unnecessary implicit splat allocations

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -6471,15 +6471,9 @@ keyword_node_single_splat_p(NODE *kwnode)
            RNODE_LIST(RNODE_LIST(node)->nd_next)->nd_next == NULL;
 }
 
-#define SPLATARRAY_FALSE 0
-#define SPLATARRAY_TRUE 1
-#define DUP_SINGLE_KW_SPLAT 2
-#define MAYBE_UNNECESSARY_ALLOC_SPLAT 4
-#define MAYBE_UNNECESSARY_ALLOC_KW_SPLAT 8
-
 static void
 compile_single_keyword_splat_mutable(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
-                                     NODE *kwnode, unsigned int *flag_ptr, unsigned int dup_rest)
+                                     NODE *kwnode, unsigned int *flag_ptr)
 {
     *flag_ptr |= VM_CALL_KW_SPLAT_MUT;
     ADD_INSN1(args, argn, putspecialobject, INT2FIX(VM_SPECIAL_OBJECT_VMCORE));
@@ -6487,16 +6481,19 @@ compile_single_keyword_splat_mutable(rb_iseq_t *iseq, LINK_ANCHOR *const args, c
     compile_hash(iseq, args, kwnode, TRUE, FALSE);
     ADD_SEND(args, argn, id_core_hash_merge_kwd, INT2FIX(2));
 
-    if (dup_rest & MAYBE_UNNECESSARY_ALLOC_KW_SPLAT) {
-        rb_category_warn(
-            RB_WARN_CATEGORY_PERFORMANCE,
-            "(Line: %d) This method call implicitly allocates a potentially unnecessary hash for the keyword splat, " \
-            "because the block pass expression could cause an evaluation order issue if a hash is not " \
-            "allocated for the keyword splat. You can avoid this allocation by assigning the block pass " \
-            "expression to a local variable, and using that local variable.",
-            nd_line(RNODE(kwnode)));
-    }
+    rb_category_warn(
+        RB_WARN_CATEGORY_PERFORMANCE,
+        "(Line: %d) This method call implicitly allocates a potentially unnecessary hash for the keyword splat, " \
+        "because the block pass expression could cause an evaluation order issue if a hash is not " \
+        "allocated for the keyword splat. You can avoid this allocation by assigning the block pass " \
+        "expression to a local variable, and using that local variable.",
+        nd_line(RNODE(kwnode)));
 }
+
+#define SPLATARRAY_FALSE 0
+#define SPLATARRAY_TRUE 1
+#define DUP_SINGLE_KW_SPLAT 2
+#define MAYBE_UNNECESSARY_ALLOC_SPLAT 4
 
 static int
 setup_args_core(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
@@ -6518,7 +6515,7 @@ setup_args_core(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
             }
             else {
                 if (keyword_node_single_splat_p(kwnode) && (*dup_rest & DUP_SINGLE_KW_SPLAT)) {
-                    compile_single_keyword_splat_mutable(iseq, args, argn, kwnode, flag_ptr, *dup_rest);
+                    compile_single_keyword_splat_mutable(iseq, args, argn, kwnode, flag_ptr);
                 }
                 else {
                     compile_hash(iseq, args, kwnode, TRUE, FALSE);
@@ -6600,7 +6597,7 @@ setup_args_core(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
                 compile_hash(iseq, args, kwnode, TRUE, FALSE);
             }
             else if (*dup_rest & DUP_SINGLE_KW_SPLAT) {
-                compile_single_keyword_splat_mutable(iseq, args, argn, kwnode, flag_ptr, *dup_rest);
+                compile_single_keyword_splat_mutable(iseq, args, argn, kwnode, flag_ptr);
             }
             else {
                 compile_hash(iseq, args, kwnode, TRUE, FALSE);
@@ -6725,7 +6722,8 @@ setup_args(rb_iseq_t *iseq, LINK_ANCHOR *const args, const NODE *argn,
 
         if (check_arg != argn && setup_args_dup_rest_p(RNODE_BLOCK_PASS(argn)->nd_body)) {
             // for block pass that may modify splatted argument, dup rest and kwrest if given
-            dup_rest = SPLATARRAY_TRUE | DUP_SINGLE_KW_SPLAT | MAYBE_UNNECESSARY_ALLOC_SPLAT | MAYBE_UNNECESSARY_ALLOC_KW_SPLAT;
+            if (dup_rest == SPLATARRAY_FALSE) dup_rest |= MAYBE_UNNECESSARY_ALLOC_SPLAT;
+            dup_rest |= SPLATARRAY_TRUE | DUP_SINGLE_KW_SPLAT;
         }
     }
     initial_dup_rest = dup_rest;

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1564,6 +1564,8 @@ pm_compile_hash_elements(rb_iseq_t *iseq, const pm_node_t *node, const pm_node_l
 #define SPLATARRAY_FALSE 0
 #define SPLATARRAY_TRUE 1
 #define DUP_SINGLE_KW_SPLAT 2
+#define MAYBE_UNNECESSARY_ALLOC_SPLAT 4
+#define MAYBE_UNNECESSARY_ALLOC_KW_SPLAT 8
 
 // This is details. Users should call pm_setup_args() instead.
 static int
@@ -1613,6 +1615,16 @@ pm_setup_args_core(const pm_arguments_node_t *arguments_node, const pm_node_t *b
                         PUSH_INSN1(ret, location, newhash, INT2FIX(0));
                         pm_compile_hash_elements(iseq, argument, elements, 0, Qundef, true, ret, scope_node);
                         PUSH_SEND(ret, location, id_core_hash_merge_kwd, INT2FIX(2));
+
+                        if (*dup_rest & MAYBE_UNNECESSARY_ALLOC_KW_SPLAT) {
+                            rb_category_warn(
+                                RB_WARN_CATEGORY_PERFORMANCE,
+                                "(Line %d) This method call implicitly allocates a potentially unnecessary hash for the keyword splat, " \
+                                "because the block pass expression could cause an evaluation order issue if a hash is not " \
+                                "allocated for the keyword splat. You can avoid this allocation by assigning the block pass " \
+                                "expression to a local variable, and using that local variable.",
+                                node_location->line);
+                        }
                     }
                     else {
                         pm_compile_hash_elements(iseq, argument, elements, 0, Qundef, true, ret, scope_node);
@@ -1914,12 +1926,12 @@ pm_setup_args(const pm_arguments_node_t *arguments_node, const pm_node_t *block,
             switch (PM_NODE_TYPE(element)) {
               case PM_ASSOC_NODE: {
                 const pm_assoc_node_t *assoc = (const pm_assoc_node_t *) element;
-                if (pm_setup_args_dup_rest_p(assoc->key) || pm_setup_args_dup_rest_p(assoc->value)) dup_rest = SPLATARRAY_TRUE;
+                if (pm_setup_args_dup_rest_p(assoc->key) || pm_setup_args_dup_rest_p(assoc->value)) dup_rest = SPLATARRAY_TRUE | MAYBE_UNNECESSARY_ALLOC_SPLAT;
                 break;
               }
               case PM_ASSOC_SPLAT_NODE: {
                 const pm_assoc_splat_node_t *assoc = (const pm_assoc_splat_node_t *) element;
-                if (assoc->value != NULL && pm_setup_args_dup_rest_p(assoc->value)) dup_rest = SPLATARRAY_TRUE;
+                if (assoc->value != NULL && pm_setup_args_dup_rest_p(assoc->value)) dup_rest = SPLATARRAY_TRUE | MAYBE_UNNECESSARY_ALLOC_SPLAT;
                 break;
               }
               default:
@@ -1939,7 +1951,7 @@ pm_setup_args(const pm_arguments_node_t *arguments_node, const pm_node_t *block,
         const pm_node_t *block_expr = ((const pm_block_argument_node_t *)block)->expression;
 
         if (block_expr && pm_setup_args_dup_rest_p(block_expr)) {
-            dup_rest = SPLATARRAY_TRUE | DUP_SINGLE_KW_SPLAT;
+            dup_rest = SPLATARRAY_TRUE | DUP_SINGLE_KW_SPLAT | MAYBE_UNNECESSARY_ALLOC_SPLAT | MAYBE_UNNECESSARY_ALLOC_KW_SPLAT;
             initial_dup_rest = dup_rest;
         }
 
@@ -1977,6 +1989,17 @@ pm_setup_args(const pm_arguments_node_t *arguments_node, const pm_node_t *block,
     // VM_CALL_ARGS_SPLAT_MUT flag.
     if (*flags & VM_CALL_ARGS_SPLAT && dup_rest != initial_dup_rest) {
         *flags |= VM_CALL_ARGS_SPLAT_MUT;
+
+        if (dup_rest & MAYBE_UNNECESSARY_ALLOC_SPLAT) {
+            rb_category_warn(
+                RB_WARN_CATEGORY_PERFORMANCE,
+                "(Line %d) This method call implicitly allocates a potentially unnecessary array for the positional splat, " \
+                "because a keyword, keyword splat, or block pass expression could cause an evaluation order issue " \
+                "if an array is not allocated for the positional splat. You can avoid this allocation by assigning " \
+                "the related keyword, keyword splat, or block pass expression to a local variable and using that " \
+                "local variable.",
+                node_location->line);
+        }
     }
 
     return argc;

--- a/test/ruby/test_call.rb
+++ b/test/ruby/test_call.rb
@@ -386,7 +386,7 @@ class TestCall < Test::Unit::TestCase
       Warning[:performance] = true
       eval(<<-RUBY)
         def self.kw = {}
-        def self.x(*, **) = nil
+        def self.x(...) = nil
         a = []
         x(*a, kw:)
       RUBY
@@ -399,7 +399,7 @@ class TestCall < Test::Unit::TestCase
       Warning[:performance] = true
       eval(<<-RUBY)
         def self.kw = {}
-        def self.x(*, **) = nil
+        def self.x(...) = nil
         a = []
         x(*a, **kw)
       RUBY
@@ -412,7 +412,7 @@ class TestCall < Test::Unit::TestCase
       Warning[:performance] = true
       eval(<<-RUBY)
         def self.kw = {}
-        def self.x(*, **) = nil
+        def self.x(...) = nil
         a = []
         x(*a, &kw)
       RUBY
@@ -430,7 +430,7 @@ class TestCall < Test::Unit::TestCase
       Warning[:performance] = true
       eval(<<-RUBY)
         def self.kw = {}
-        def self.x(*, **) = nil
+        def self.x(...) = nil
         h = {}
         x(**kw, &kw)
       RUBY


### PR DESCRIPTION
For the following method calls:

```ruby
m(*ary, kw: kw)
m(*ary, **kw)
m(*ary, &block)
m(**hash, &block)
```

If `kw` and `block` are method calls, Ruby must allocate an array for `*ary` and a hash for `**hash`, to avoid an evaluation order issue in the case where `kw` or `block` methods modify `ary` or `hash`.

These implicit allocations are trivial to avoid by assigning the values to a local variable:

```ruby
kw = self.kw
block = self.block
m(*ary, kw: kw)
m(*ary, **kw)
m(*ary, &block)
m(**hash, &block)
```

Ruby does not to allocate an array for `*ary` or a hash for `**kw` in these cases, because there is no evaluation order issue.

To help users optimize their code to avoid these unnecessary implicit allocations, this adds performance warnings in these cases, letting users know that they can optimize their code by assinging to a local variable:

```
$ ruby -W:performance -e 'def kw; {} end; a = []; p(*a, **kw)'
-e: warning: This method call implicitly allocates a potentially unnecessary
array for the positional splat, because a keyword, keyword splat, or block pass
expression could cause an evaluation order issue if an array is not allocated
for the positional splat. You can avoid this allocation by assigning the related
keyword, keyword splat, or block pass expression to a local variable and using
that local variable.

$ ruby -W:performance -e 'def b; ->{} end; h = {}; p(**h, &b)'
-e: warning: This method call implicitly allocates a potentially unnecessary
hash for the keyword splat, because the block pass expression could cause an
evaluation order issue if a hash is not allocated for the keyword splat. You
can avoid this allocation by assigning the block pass expression to a local
variable, and using that local variable.
```