### PR TITLE
ZJIT: Add option to dump LIR

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -10,6 +10,7 @@ use crate::backend::lir::{self, asm_comment, Assembler, Opnd, Target, CFP, C_ARG
 use crate::hir::{iseq_to_hir, Block, BlockId, BranchEdge, CallInfo};
 use crate::hir::{Const, FrameState, Function, Insn, InsnId};
 use crate::hir_type::{types::Fixnum, Type};
+use crate::options::get_option;
 
 /// Ephemeral code generation state
 struct JITState {
@@ -221,6 +222,10 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, function: &Function) -> Optio
                 return None;
             }
         }
+    }
+
+    if get_option!(dump_lir) {
+        println!("LIR:\nfn {}:\n{:?}", iseq_name(iseq), asm);
     }
 
     // Generate code if everything can be compiled

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -27,6 +27,9 @@ pub struct Options {
     /// Dump High-level IR after optimization, right before codegen.
     pub dump_hir_opt: Option<DumpHIR>,
 
+    /// Dump low-level IR
+    pub dump_lir: bool,
+
     /// Dump all compiled machine code.
     pub dump_disasm: bool,
 }
@@ -70,6 +73,7 @@ pub fn init_options() -> Options {
         debug: false,
         dump_hir_init: None,
         dump_hir_opt: None,
+        dump_lir: false,
         dump_disasm: false,
     }
 }
@@ -126,6 +130,8 @@ fn parse_option(options: &mut Options, str_ptr: *const std::os::raw::c_char) -> 
         ("dump-hir-init", "") => options.dump_hir_init = Some(DumpHIR::WithoutSnapshot),
         ("dump-hir-init", "all") => options.dump_hir_init = Some(DumpHIR::All),
         ("dump-hir-init", "debug") => options.dump_hir_init = Some(DumpHIR::Debug),
+
+        ("dump-lir", "") => options.dump_lir = true,
 
         ("dump-disasm", "") => options.dump_disasm = true,
 


### PR DESCRIPTION
Now we can dump HIR, optimized HIR, LIR, and assembly.

```
plum% ../build-dev/miniruby --zjit-dump-hir --zjit-dump-lir /tmp/defint.rb
HIR:
fn foo:
bb0():
  v1:Fixnum[5] = Const Value(5)
  Return v1

LIR:
fn foo:
Assembler
    000 Label() -> None
    001 FrameSetup() -> None
    002 Add(A64Reg { num_bits: 64, reg_no: 19 }, 38_u64) -> Out64(0)
    003 Mov(A64Reg { num_bits: 64, reg_no: 19 }, Out64(0)) -> None
    004 Mov(Mem64[Reg(20) + 16], A64Reg { num_bits: 64, reg_no: 19 }) -> None
    005 FrameTeardown() -> None
    006 CRet(Value(VALUE(11))) -> None
plum%
```