### PR TITLE
Add debug message to test_heaps_grow_independently

### DIFF
--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -701,7 +701,9 @@ class TestGc < Test::Unit::TestCase
         allocate_large_object
       end
 
-      assert_operator(GC.stat(:heap_available_slots), :<, COUNT * 2)
+      heap_available_slots = GC.stat(:heap_available_slots)
+
+      assert_operator(heap_available_slots, :<, COUNT * 2, "GC.stat: #{GC.stat}\nGC.stat_heap: #{GC.stat_heap}")
     RUBY
   end
 


### PR DESCRIPTION
To debug flaky failures on i686 that look like:

```
1) Failure:
TestGc#test_heaps_grow_independently [test/ruby/test_gc.rb:704]:
Expected 2061929 to be < 2000000.
```