### PR TITLE
Adds a couple of specs

### DIFF
--- a/spec/ruby/core/class/inherited_spec.rb
+++ b/spec/ruby/core/class/inherited_spec.rb
@@ -98,4 +98,21 @@ describe "Class.inherited" do
     -> { Class.new(top) }.should_not raise_error
   end
 
+  it "if the subclass is assigned to a constant, it is all set" do
+    ScratchPad.record []
+
+    parent = Class.new do
+      def self.inherited(subclass)
+        ScratchPad << defined?(self::C)
+        ScratchPad << const_defined?(:C)
+        ScratchPad << constants
+        ScratchPad << const_get(:C)
+        ScratchPad << subclass.name.match?(/\A#<Class:0x\w+>::C\z/)
+      end
+    end
+
+    class parent::C < parent; end
+
+    ScratchPad.recorded.should == ["constant", true, [:C], parent::C, true]
+  end
 end

--- a/spec/ruby/core/module/const_added_spec.rb
+++ b/spec/ruby/core/module/const_added_spec.rb
@@ -219,5 +219,20 @@ describe "Module#const_added" do
 
       ScratchPad.recorded.should == [:const_added, :inherited]
     end
+
+    it "the superclass of a class assigned to a constant is set before const_added is called" do
+      ScratchPad.record []
+
+      parent = Class.new do
+        def self.const_added(name)
+          ScratchPad << name
+          ScratchPad << const_get(name).superclass
+        end
+      end
+
+      class parent::C < parent; end
+
+      ScratchPad.recorded.should == [:C, parent]
+    end
   end
 end


### PR DESCRIPTION
In a class definition like this:

```ruby
class D < C
end
```

there might be a `const_added` hook, and also an `inherited` hook being triggered when `D` is just created.

Those are user-level hooks, and the following is observable:

1) When they are invoked, the class object stored in `D` has been created and it has the expected superclass.
2) When they are invoked, the constant has been created and constant-related state reflects that.

The specs proposed in this patch specify this contract.

(What I described above is the consensus achieved in discussions in https://bugs.ruby-lang.org/issues/21143, https://bugs.ruby-lang.org/issues/21193, and related PRs.)

/cc @byroot @eregon 