### PR TITLE
Fix jump buffer leak in WASI builds

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -853,6 +853,7 @@ check_stack_overflow(int sig, const uintptr_t addr, const ucontext_t *ctx)
              * otherwise it can cause stack overflow again at the same
              * place. */
             if ((crit = (!ec->tag->prev || !--uplevel)) != FALSE) break;
+            rb_vm_tag_jmpbuf_deinit(&ec->tag->buf);
             ec->tag = ec->tag->prev;
         }
         reset_sigmask(sig);

--- a/vm.c
+++ b/vm.c
@@ -2852,6 +2852,7 @@ vm_exec_handle_exception(rb_execution_context_t *ec, enum ruby_tag_type state, V
             if (VM_FRAME_FINISHED_P(ec->cfp)) {
                 rb_vm_pop_frame(ec);
                 ec->errinfo = (VALUE)err;
+                rb_vm_tag_jmpbuf_deinit(&ec->tag->buf);
                 ec->tag = ec->tag->prev;
                 EC_JUMP_TAG(ec, state);
             }

--- a/vm_trace.c
+++ b/vm_trace.c
@@ -453,6 +453,7 @@ rb_exec_event_hooks(rb_trace_arg_t *trace_arg, rb_hook_list_t *hooks, int pop_p)
             if (state) {
                 if (pop_p) {
                     if (VM_FRAME_FINISHED_P(ec->cfp)) {
+                        rb_vm_tag_jmpbuf_deinit(&ec->tag->buf);
                         ec->tag = ec->tag->prev;
                     }
                     rb_vm_pop_frame(ec);


### PR DESCRIPTION
This pull request fixes a memory leak in WASI (WebAssembly) builds of Ruby caused by the VM jump buffers not being freed in certain parts of the code.

I originally attempted to fix this memory leak in #12995 (it's the second memory leak mentioned in that pull request), but the fix was reverted by #13026 due to test failures. The fix has been rewritten to be much simpler and less invasive so that it has less of a chance of breaking things.

I've already tested building with this patch here: https://github.com/white-axe/ruby.wasm/actions/runs/14563460222/job/40849624514

For ease of reference, I'm mentioning again here that there's [a test](https://github.com/ruby/ruby/pull/12995#issuecomment-2764643641) to determine if a WASI build of Ruby is affected by the two memory leaks mentioned in #12995:

> Here's a test to see if a WASI build is affected by these two memory leaks. This script causes all of the current WASI builds from https://github.com/ruby/ruby.wasm to rapidly consume around 800 mebibytes of memory due to the jump buffer leak and then crash from what I believe is stack buffer overflow caused by the stack pointer leak:
> ```ruby
> loop do
>   array = [0]
>   for item in array
>     break
>   end
> end
> ```
> To test it out, save it as test.rb in the current working directory, and then:
> ```
> curl -Lo ruby.tar.gz https://github.com/ruby/ruby.wasm/releases/download/2.7.1/ruby-3.4-wasm32-unknown-wasip1-full.tar.gz
> tar xzf ruby.tar.gz --strip-components=1
> wasmtime --dir .::/ usr/local/bin/ruby test.rb
> ```

Note: The first memory leak has been fixed in the master branch so it won't immediately crash from stack buffer overflow anymore, but the test still crashes from running out of memory due to the second memory leak.

Requesting a review from @kateinoigakukun.