### PR TITLE
Fix VMDEBUG

### DIFF
--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -65,13 +65,6 @@ calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
             /* use pos-1 because PC points next instruction at the beginning of instruction */
             pos--;
         }
-#if VMDEBUG && defined(HAVE_BUILTIN___BUILTIN_TRAP)
-        else {
-            /* SDR() is not possible; that causes infinite loop. */
-            rb_print_backtrace(stderr);
-            __builtin_trap();
-        }
-#endif
         if (lineno) *lineno = rb_iseq_line_no(iseq, pos);
 #ifdef USE_ISEQ_NODE_ID
         if (node_id) *node_id = rb_iseq_node_id(iseq, pos);

--- a/vm_core.h
+++ b/vm_core.h
@@ -40,11 +40,6 @@
 #define VMDEBUG 0
 #endif
 
-#if 0
-#undef  VMDEBUG
-#define VMDEBUG 3
-#endif
-
 #include "ruby/internal/config.h"
 
 #include <stddef.h>

--- a/vm_dump.c
+++ b/vm_dump.c
@@ -381,6 +381,8 @@ vm_stack_dump_each(const rb_execution_context_t *ec, const rb_control_frame_t *c
     else {
         rb_bug("unsupported frame type: %08lx", VM_FRAME_TYPE(cfp));
     }
+  error:
+    return;
 }
 #endif
 
@@ -440,7 +442,7 @@ rb_vmdebug_debug_print_pre(const rb_execution_context_t *ec, const rb_control_fr
 
 #if VMDEBUG > 3
     kprintf("        (1)");
-    rb_vmdebug_debug_print_register(errout, ec);
+    rb_vmdebug_debug_print_register(ec, errout);
 #endif
     return true;
 
@@ -452,12 +454,12 @@ bool
 rb_vmdebug_debug_print_post(const rb_execution_context_t *ec, const rb_control_frame_t *cfp, FILE *errout)
 {
 #if VMDEBUG > 9
-    if (!rb_vmdebug_stack_dump_raw(ec, cfp, errout)) goto errout;
+    if (!rb_vmdebug_stack_dump_raw(ec, cfp, errout)) goto error;
 #endif
 
 #if VMDEBUG > 3
     kprintf("        (2)");
-    rb_vmdebug_debug_print_register(errout, ec);
+    rb_vmdebug_debug_print_register(ec, errout);
 #endif
     /* stack_dump_raw(ec, cfp); */
 

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -19,12 +19,12 @@ typedef rb_iseq_t *ISEQ;
 #if VMDEBUG > 0
 #define debugs printf
 #define DEBUG_ENTER_INSN(insn) \
-    rb_vmdebug_debug_print_pre(ec, GET_CFP(), GET_PC());
+    rb_vmdebug_debug_print_pre(ec, GET_CFP(), GET_PC(), stderr);
 
 #define SC_REGS()
 
 #define DEBUG_END_INSN() \
-  rb_vmdebug_debug_print_post(ec, GET_CFP() SC_REGS());
+  rb_vmdebug_debug_print_post(ec, GET_CFP() SC_REGS(), stderr);
 
 #else
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -431,7 +431,7 @@ vm_push_frame(rb_execution_context_t *ec,
 
     ec->cfp = cfp;
 
-    if (VMDEBUG == 2) {
+    if (VMDEBUG == 2 && rb_current_execution_context(false) != NULL) {
         SDR();
     }
     vm_push_frame_debug_counter_inc(ec, cfp, type);


### PR DESCRIPTION
I've found some of the VMDEBUG levels helpful in learning how things work. But prior to this commit there were some compile errors, as well as a failed assertion and an early exit. I'd guess that VMDEBUG is not commonly used, and these things didn't get updated as the surrounding code changed.