### PR TITLE
Confirm issue with `IO.select`.

### DIFF
--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -3812,7 +3812,7 @@ __END__
   def test_io_select_with_many_files
     bug8080 = '[ruby-core:53349]'
 
-    assert_normal_exit %q{
+    assert_separately [], <<~RUBY
       require "tempfile"
 
       # Unfortunately, ruby doesn't export FD_SETSIZE. then we assume it's 1024.
@@ -3838,7 +3838,7 @@ __END__
           File.unlink(t.path)
         }
       end
-    }, bug8080, timeout: 100
+    RUBY
   end if defined?(Process::RLIMIT_NOFILE)
 
   def test_read_32bit_boundary


### PR DESCRIPTION
I have been having issues with `IO.select` when the number of file descriptors exceeds 1024. However, for some reason, this test is not failing except in my PR: <https://github.com/ruby/ruby/pull/13127/files#diff-3080daee16d233672f1d0bd0112b9fd8dbf64a03d2a02d26583d783aeb4b1fd2> - I want to investigate further.