### PR TITLE
Add missing lock in `rb_gc_impl_define_finalizer`

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2834,6 +2834,8 @@ rb_gc_impl_define_finalizer(void *objspace_ptr, VALUE obj, VALUE block)
 
     RBASIC(obj)->flags |= FL_FINALIZE;
 
+    int lev = rb_gc_vm_lock();
+
     if (st_lookup(finalizer_table, obj, &data)) {
         table = (VALUE)data;
 
@@ -2857,6 +2859,8 @@ rb_gc_impl_define_finalizer(void *objspace_ptr, VALUE obj, VALUE block)
         rb_obj_hide(table);
         st_add_direct(finalizer_table, obj, table);
     }
+
+    rb_gc_vm_unlock(lev);
 
     return block;
 }

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -973,6 +973,8 @@ rb_gc_impl_define_finalizer(void *objspace_ptr, VALUE obj, VALUE block)
 
     RBASIC(obj)->flags |= FL_FINALIZE;
 
+    int lev = rb_gc_vm_lock();
+
     if (st_lookup(objspace->finalizer_table, obj, &data)) {
         table = (VALUE)data;
 
@@ -996,6 +998,8 @@ rb_gc_impl_define_finalizer(void *objspace_ptr, VALUE obj, VALUE block)
         rb_obj_hide(table);
         st_add_direct(objspace->finalizer_table, obj, table);
     }
+
+    rb_gc_vm_unlock(lev);
 
     return block;
 }


### PR DESCRIPTION
`objspace->finalizer_table` must be synchronized,
otherwise concurrent insertion from multiple ractors will cause a crash.

Repro:

```ruby
ractors = 5.times.map do |i|
  Ractor.new do
    100_000.times.map do
      o = Object.new
      ObjectSpace.define_finalizer(o, ->(id) {})
      o
    end
  end
end

ractors.each(&:take)
```

FYI: @tenderlove @jhawthorn @etiennebarrie 