### PR TITLE
Increase fiber sleep test tolerance.

### DIFF
--- a/test/fiber/test_sleep.rb
+++ b/test/fiber/test_sleep.rb
@@ -35,13 +35,13 @@ class TestFiberSleep < Test::Unit::TestCase
       scheduler = Scheduler.new
       Fiber.set_scheduler scheduler
       Fiber.schedule do
-        seconds = sleep(2)
+        seconds = sleep(1.1)
       end
     end
 
     thread.join
 
-    assert_operator seconds, :>=, 2, "actual: %p" % seconds
+    assert_operator seconds, :>=, 1, "actual: %p" % seconds
   end
 
   def test_broken_sleep


### PR DESCRIPTION
[f23146f09f](https://github.com/ruby/ruby/commit/f23146f09f): Fix enums in comparisons: [trunk@ruby-sp3: failed](http://ci.rvm.jp/results/trunk@ruby-sp3/5658287)

```
1) Failure:
TestFiberSleep#test_sleep_returns_seconds_slept [/tmp/ruby/src/trunk/test/fiber/test_sleep.rb:44]:
actual: 1.
Expected 1 to be >= 2.
```