### PR TITLE
Deprecate `ObjectSpace._id2ref`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1772,6 +1772,8 @@ rb_gc_pointer_to_heap_p(VALUE obj)
  *
  *  On multi-ractor mode, if the object is not shareable, it raises
  *  RangeError.
+ *
+ *  This method is deprecated and should no longer be used.
  */
 
 static VALUE
@@ -1819,6 +1821,7 @@ id2ref(VALUE objid)
 static VALUE
 os_id2ref(VALUE os, VALUE objid)
 {
+    rb_category_warn(RB_WARN_CATEGORY_DEPRECATED, "ObjectSpace._id2ref is deprecated");
     return id2ref(objid);
 }
 


### PR DESCRIPTION
[[Feature #15408]](https://bugs.ruby-lang.org/issues/15408)

Matz decided to deprecate it for Ruby 2.6 or 2.7 but that never actually happened.

Given the object_id table is a contention point for Ractors it seems sensible to finally deprecate this API so we can generate and store object ids more efficiently in the future.