### PR TITLE
rb_error_frozen_object: fix `FrozenError` message.

### DIFF
--- a/error.c
+++ b/error.c
@@ -4159,7 +4159,7 @@ rb_error_frozen_object(VALUE frozen_obj)
     rb_yjit_lazy_push_frame(GET_EC()->cfp->pc);
 
     VALUE mesg = rb_sprintf("can't modify frozen %"PRIsVALUE": ",
-                            CLASS_OF(frozen_obj));
+                            rb_obj_class(frozen_obj));
     VALUE exc = rb_exc_new_str(rb_eFrozenError, mesg);
 
     rb_ivar_set(exc, id_recv, frozen_obj);

--- a/test/ruby/test_frozen_error.rb
+++ b/test/ruby/test_frozen_error.rb
@@ -25,11 +25,15 @@ class TestFrozenError < Test::Unit::TestCase
   end
 
   def test_message
-    obj = Object.new.freeze
-    e = assert_raise_with_message(FrozenError, /can't modify frozen #{obj.class}/) {
-      obj.instance_variable_set(:@test, true)
-    }
-    assert_include(e.message, obj.inspect)
+    [
+      Object.new.freeze,
+      Object.new.freeze.tap(&:singleton_class),  # [Bug #21282]
+    ].each do |obj|
+      e = assert_raise_with_message(FrozenError, /can't modify frozen #{obj.class}/) {
+        obj.instance_variable_set(:@test, true)
+      }
+      assert_include(e.message, obj.inspect)
+    end
 
     klass = Class.new do
       def init


### PR DESCRIPTION
Show the real class of the frozen object in the exception message.

Fixes: https://bugs.ruby-lang.org/issues/21282