### PR TITLE
ZJIT: Split out Send strength reduction into the optimizer

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -495,6 +495,8 @@ fn gen_send_without_block_direct(
     let branch = Branch::new();
     let dummy_ptr = cb.get_write_ptr().raw_ptr(cb);
     jit.branch_iseqs.push((branch.clone(), iseq));
+    // TODO(max): Add a PatchPoint here that can side-exit the function if the callee messed with
+    // the frame's locals
     Some(asm.ccall_with_branch(dummy_ptr, c_args, &branch))
 }
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -789,7 +789,7 @@ impl Function {
 
     fn type_of(&self, insn: InsnId) -> Type {
         assert!(self.insns[insn.0].has_output());
-        self.insn_types[insn.0]
+        self.insn_types[self.union_find.find_const(insn).0]
     }
 
     /// Check if the type of `insn` is a subtype of `ty`.

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2892,6 +2892,109 @@ mod opt_tests {
     }
 
     #[test]
+    fn test_optimize_send_into_fixnum_add_both_profiled() {
+        eval("
+            def test(a, b) = a + b
+            test(1,2); test(3,4)
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0(v0:BasicObject, v1:BasicObject):
+              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
+              v7:Fixnum = GuardType v0, Fixnum
+              v8:Fixnum = GuardType v1, Fixnum
+              v9:Fixnum = FixnumAdd v7, v8
+              Return v9
+        "#]]);
+    }
+
+    #[test]
+    fn test_optimize_send_into_fixnum_add_left_profiled() {
+        eval("
+            def test(a) = a + 1
+            test(1); test(3)
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0(v0:BasicObject):
+              v2:Fixnum[1] = Const Value(1)
+              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
+              v7:Fixnum = GuardType v0, Fixnum
+              v8:Fixnum = FixnumAdd v7, v2
+              Return v8
+        "#]]);
+    }
+
+    #[test]
+    fn test_optimize_send_into_fixnum_add_right_profiled() {
+        eval("
+            def test(a) = 1 + a
+            test(1); test(3)
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0(v0:BasicObject):
+              v2:Fixnum[1] = Const Value(1)
+              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
+              v7:Fixnum = GuardType v0, Fixnum
+              v8:Fixnum = FixnumAdd v2, v7
+              Return v8
+        "#]]);
+    }
+
+    #[test]
+    fn test_optimize_send_into_fixnum_lt_both_profiled() {
+        eval("
+            def test(a, b) = a < b
+            test(1,2); test(3,4)
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0(v0:BasicObject, v1:BasicObject):
+              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
+              v7:Fixnum = GuardType v0, Fixnum
+              v8:Fixnum = GuardType v1, Fixnum
+              v9:BoolExact = FixnumLt v7, v8
+              Return v9
+        "#]]);
+    }
+
+    #[test]
+    fn test_optimize_send_into_fixnum_lt_left_profiled() {
+        eval("
+            def test(a) = a < 1
+            test(1); test(3)
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0(v0:BasicObject):
+              v2:Fixnum[1] = Const Value(1)
+              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
+              v7:Fixnum = GuardType v0, Fixnum
+              v8:BoolExact = FixnumLt v7, v2
+              Return v8
+        "#]]);
+    }
+
+    #[test]
+    fn test_optimize_send_into_fixnum_lt_right_profiled() {
+        eval("
+            def test(a) = 1 < a
+            test(1); test(3)
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0(v0:BasicObject):
+              v2:Fixnum[1] = Const Value(1)
+              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
+              v7:Fixnum = GuardType v0, Fixnum
+              v8:BoolExact = FixnumLt v2, v7
+              Return v8
+        "#]]);
+    }
+
+
+    #[test]
     fn test_eliminate_new_array() {
         eval("
             def test()


### PR DESCRIPTION
- **Simplify fixnum guarding code**
- **Strength reduce sends on Fixnums in the optimizer instead of HIR builder**
- **Make PatchPoint(CalleeModifiedLocals) implicit**
