### PR TITLE
Use `cgi/util` instead of `cgi`

### DIFF
--- a/lib/bundler/fetcher.rb
+++ b/lib/bundler/fetcher.rb
@@ -2,7 +2,6 @@
 
 require_relative "vendored_persistent"
 require_relative "vendored_timeout"
-require "cgi"
 require_relative "vendored_securerandom"
 require "zlib"
 

--- a/lib/bundler/fetcher/dependency.rb
+++ b/lib/bundler/fetcher/dependency.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "base"
-require "cgi"
+require "cgi/util"
 
 module Bundler
   class Fetcher

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -102,7 +102,7 @@ module Bundler
     def issues_url(exception)
       message = exception.message.lines.first.tr(":", " ").chomp
       message = message.split("-").first if exception.is_a?(Errno)
-      require "cgi"
+      require "cgi/util"
       "https://github.com/rubygems/rubygems/search?q=" \
         "#{CGI.escape(message)}&type=Issues"
     end

--- a/lib/rubygems/gemcutter_utilities/webauthn_listener.rb
+++ b/lib/rubygems/gemcutter_utilities/webauthn_listener.rb
@@ -85,10 +85,17 @@ module Gem::GemcutterUtilities
     end
 
     def parse_otp_from_uri(uri)
-      require "cgi"
+      query = uri.query
+      return unless query && !query.empty?
 
-      return if uri.query.nil?
-      CGI.parse(uri.query).dig("code", 0)
+      query.split('&') do |param|
+        key, value = param.split('=', 2)
+        if value && Gem::URI.decode_www_form_component(key) == "code"
+          return Gem::URI.decode_www_form_component(value)
+        end
+      end
+
+      nil
     end
 
     class SocketResponder

--- a/lib/rubygems/uri_formatter.rb
+++ b/lib/rubygems/uri_formatter.rb
@@ -17,7 +17,7 @@ class Gem::UriFormatter
   # Creates a new URI formatter for +uri+.
 
   def initialize(uri)
-    require "cgi"
+    require "cgi/util"
 
     @uri = uri
   end

--- a/prism/templates/lib/prism/dot_visitor.rb.erb
+++ b/prism/templates/lib/prism/dot_visitor.rb.erb
@@ -1,4 +1,4 @@
-require "cgi"
+require "cgi/util"
 
 module Prism
   # This visitor provides the ability to call Node#to_dot, which converts a


### PR DESCRIPTION
For https://bugs.ruby-lang.org/issues/21258

I have a plan to retire `cgi` library in the future. The libraries should use `cgi/util` instead of `cgi` if they used only like `CGI.escape`.