### PR TITLE
Enabled to cleanup codeql-trap cache

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,6 +50,7 @@ jobs:
 
     env:
       enable_install_doc: no
+      CODEQL_ACTION_CLEANUP_TRAP_CACHES: true
 
     strategy:
       fail-fast: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Install libraries with vcpkg
         run: |
-          vcpkg install
+          vcpkg install --vcpkg-root=C:\Users\runneradmin\scoop\apps\vcpkg\current
         working-directory: src
         env:
           VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"


### PR DESCRIPTION
codeql-trap cache is growing over 300MB. We should enable to cleanup needless cache from actions/cache.