### PR TITLE
Fix a flaky test by making sure that a test thread stops

### DIFF
--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -243,6 +243,10 @@ class TestThread < Test::Unit::TestCase
 
   def test_join_argument_conversion
     t = Thread.new {}
+
+    # Make sure that the thread terminates
+    Thread.pass while t.status
+
     assert_raise(TypeError) {t.join(:foo)}
 
     limit = Struct.new(:to_f, :count).new(0.05)


### PR DESCRIPTION
```
    1) Failure:
  TestThread#test_join_argument_conversion [D:/a/ruby/ruby/src/test/ruby/test_thread.rb:249]:
  Expected nil (oid=4) to be the same as #<TestThread::Thread:0x000001e9e13bbc18 D:/a/ruby/ruby/src/test/ruby/test_thread.rb:245 run> (oid=3856).
```
https://github.com/ruby/ruby/actions/runs/14636019219/job/41067199813?pr=13169