### PR TITLE
Disabled built-in cache feature of vcpkg for Windows Arm build

### DIFF
--- a/.github/workflows/windows-arm.yml
+++ b/.github/workflows/windows-arm.yml
@@ -46,7 +46,6 @@ jobs:
     env:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
       OS_VER: windows-${{ matrix.os }}
-      VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
       VCPKG_DEFAULT_TRIPLET: arm64-windows
       RUBY_OPT_DIR: C:/a/ruby/ruby/src/vcpkg_installed/%VCPKG_DEFAULT_TRIPLET%
 
@@ -61,13 +60,6 @@ jobs:
           Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
           scoop install vcpkg uutils-coreutils cmake@3.31.6
         shell: pwsh
-
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Install libraries with vcpkg
         run: |
-          vcpkg install --vcpkg-root=C:\Users\runneradmin\scoop\apps\vcpkg\current
+          vcpkg install --vcpkg-root=C:\Users\runneradmin\scoop\apps\vcpkg\current --debug
         working-directory: src
 
       # TODO: We should use `../src` instead of `D:/a/ruby/ruby/src`


### PR DESCRIPTION
It may conflict `x64-windows` build.