### PR TITLE
Update `RB_GC_OBJECT_METADATA_ENTRY_COUNT`

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -6191,7 +6191,7 @@ rb_gc_impl_writebarrier_remember(void *objspace_ptr, VALUE obj)
     }
 }
 
-#define RB_GC_OBJECT_METADATA_ENTRY_COUNT 7
+#define RB_GC_OBJECT_METADATA_ENTRY_COUNT 9
 static struct rb_gc_object_metadata_entry object_metadata_entries[RB_GC_OBJECT_METADATA_ENTRY_COUNT + 1];
 
 struct rb_gc_object_metadata_entry *


### PR DESCRIPTION
Ref: http://ci.rvm.jp/results/trunk_asan@ruby-sp1/5731894

In cb1ea54bbf6cdf49c53f42720fec1a151069810c I added one more metadata flag, but didn't notice `RB_GC_OBJECT_METADATA_ENTRY_COUNT` had to be incremented.

This should fix ASAN builds.

Interestingly, bdb25959fb047af0358f33d7327b7752dca14aa4 already caused the count to be off by one, so I had to increment it by 2.

FYI: @ko1 @peterzhu2118 