### PR TITLE
CODEQL_ACTION_CLEANUP_TRAP_CACHES needs `actions:write` permission

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,8 +26,9 @@ concurrency:
   group: ${{ github.workflow }} / ${{ startsWith(github.event_name, 'pull') && github.ref_name || github.sha }}
   cancel-in-progress: ${{ startsWith(github.event_name, 'pull') }}
 
-permissions: # added using https://github.com/step-security/secure-workflows
+permissions:
   contents: read
+  actions: write # for CODEQL_ACTION_CLEANUP_TRAP_CACHES
 
 jobs:
   analyze:


### PR DESCRIPTION
For reducing trap cache of CodeQL

```
Warning: Could not cleanup TRAP caches as the token did not have the required permissions. To clean up TRAP caches, ensure the token has the "actions:write" permission. See https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs for more information.
```