### PR TITLE
Support Marshal.{dump,load} for core Set

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -2253,7 +2253,7 @@ rb_hash_default(int argc, VALUE *argv, VALUE hash)
  *  See {Hash Default}[rdoc-ref:Hash@Hash+Default].
  */
 
-static VALUE
+VALUE
 rb_hash_set_default(VALUE hash, VALUE ifnone)
 {
     rb_hash_modify_check(hash);

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -72,6 +72,7 @@ struct RHash {
 /* hash.c */
 void rb_hash_st_table_set(VALUE hash, st_table *st);
 VALUE rb_hash_default_value(VALUE hash, VALUE key);
+VALUE rb_hash_set_default(VALUE hash, VALUE ifnone);
 VALUE rb_hash_set_default_proc(VALUE hash, VALUE proc);
 long rb_dbl_long_hash(double d);
 st_table *rb_init_identtable(void);

--- a/set.c
+++ b/set.c
@@ -2196,7 +2196,6 @@ Init_Set(void)
     rb_define_method(rb_cSet, "to_a", set_i_to_a, 0);
     rb_define_method(rb_cSet, "to_h", set_i_to_h, 0);
     rb_define_method(rb_cSet, "to_set", set_i_to_set, -1);
-    // rb_define_singleton_method(rb_cSet, "from_hash", compat_loader, 1);
 
     /* :nodoc: */
     VALUE compat = rb_define_class_under(rb_cSet, "compatible", rb_cObject);

--- a/test/ruby/test_set.rb
+++ b/test/ruby/test_set.rb
@@ -6,6 +6,29 @@ class TC_Set < Test::Unit::TestCase
   class Set2 < Set
   end
 
+  def test_marshal
+    set = Set[1, 2, 3]
+    mset = Marshal.load(Marshal.dump(set))
+    assert_equal(set, mset)
+    assert_equal(set.compare_by_identity?, mset.compare_by_identity?)
+
+    set.compare_by_identity
+    mset = Marshal.load(Marshal.dump(set))
+    assert_equal(set, mset)
+    assert_equal(set.compare_by_identity?, mset.compare_by_identity?)
+
+    set.instance_variable_set(:@a, 1)
+    mset = Marshal.load(Marshal.dump(set))
+    assert_equal(set, mset)
+    assert_equal(set.compare_by_identity?, mset.compare_by_identity?)
+    assert_equal(1, mset.instance_variable_get(:@a))
+
+    # Not sure if possible to support?
+    # 'Marshal.load': dump format error (ArgumentError)
+    # old_stdlib_set_data = "\x04\bo:\bSet\x06:\n@hash}\bi\x06Ti\aTi\bTF".b
+    # assert_equal(Set[1, 2, 3], Marshal.load(old_stdlib_set_data))
+  end
+
   def test_aref
     assert_nothing_raised {
       Set[]

--- a/test/ruby/test_set.rb
+++ b/test/ruby/test_set.rb
@@ -23,10 +23,13 @@ class TC_Set < Test::Unit::TestCase
     assert_equal(set.compare_by_identity?, mset.compare_by_identity?)
     assert_equal(1, mset.instance_variable_get(:@a))
 
-    # Not sure if possible to support?
-    # 'Marshal.load': dump format error (ArgumentError)
-    # old_stdlib_set_data = "\x04\bo:\bSet\x06:\n@hash}\bi\x06Ti\aTi\bTF".b
-    # assert_equal(Set[1, 2, 3], Marshal.load(old_stdlib_set_data))
+    old_stdlib_set_data = "\x04\bo:\bSet\x06:\n@hash}\bi\x06Ti\aTi\bTF".b
+    set = Marshal.load(old_stdlib_set_data)
+    assert_equal(Set[1, 2, 3], set)
+
+    old_stdlib_set_cbi_data = "\x04\bo:\bSet\x06:\n@hashC:\tHash}\ai\x06Ti\aTF".b
+    set = Marshal.load(old_stdlib_set_cbi_data)
+    assert_equal(Set[1, 2].compare_by_identity, set)
   end
 
   def test_aref


### PR DESCRIPTION
This was missed when adding core Set, because it's handled implicitly for T_OBJECT.

I attempted to allow core Set to support Marshal.load with stdlib Set marshal output, but it doesn't look like Marshal supports this, raising `dump format error (ArgumentError)`.  If the object was previously relying on the default Marshal.dump implementation for T_OBJECT, it doesn't look like you can restore it to a non-T_OBJECT, regardless of how that object implements _load/marshal_load.  I think it would require changes to Marshal to allow that.