### PR TITLE
ZJIT: Drop a duplicated call into optimize

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -170,11 +170,10 @@ fn gen_iseq(cb: &mut CodeBlock, iseq: IseqPtr) -> Option<(CodePtr, Vec<(Rc<Branc
     }
 
     // Convert ISEQ into High-level IR
-    let mut function = match compile_iseq(iseq) {
+    let function = match compile_iseq(iseq) {
         Some(function) => function,
         None => return None,
     };
-    function.optimize();
 
     // Compile the High-level IR
     let result = gen_function(cb, iseq, &function);

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -169,7 +169,7 @@ fn gen_iseq(cb: &mut CodeBlock, iseq: IseqPtr) -> Option<(CodePtr, Vec<(Rc<Branc
         return Some((start_ptr, vec![]));
     }
 
-    // Convert ISEQ into High-level IR
+    // Convert ISEQ into High-level IR and optimize HIR
     let function = match compile_iseq(iseq) {
         Some(function) => function,
         None => return None,


### PR DESCRIPTION
This PR removes a duplicated call into `optimize()`, which is a minor follow-up on https://github.com/Shopify/zjit/pull/109.

`compile_iseq()` does that, so no need to call it after that.