### PR TITLE
Don't call hash tombstone compaction from GC compaction

### DIFF
--- a/set.c
+++ b/set.c
@@ -179,10 +179,9 @@ set_replace_ref(st_data_t *key, st_data_t argp, int existing)
 }
 
 static void
-set_compact(void *ptr)
+set_update_references(void *ptr)
 {
     struct set_object *sobj = ptr;
-    set_compact_table(&sobj->table);
     set_foreach_with_replace(&sobj->table, set_foreach_replace, set_replace_ref, 0);
 }
 
@@ -192,7 +191,7 @@ static const rb_data_type_t set_data_type = {
         .dmark = set_mark,
         .dfree = set_free,
         .dsize = set_size,
-        .dcompact = set_compact,
+        .dcompact = set_update_references,
     },
     .flags = RUBY_TYPED_EMBEDDABLE | RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FROZEN_SHAREABLE
 };

--- a/test/ruby/test_set.rb
+++ b/test/ruby/test_set.rb
@@ -864,6 +864,19 @@ class TC_Set < Test::Unit::TestCase
       assert_equal(klass.new([a]), set, klass.name)
     }
   end
+
+  def test_set_gc_compact_does_not_allocate
+    assert_in_out_err([], <<-"end;", [], [])
+    def x
+      s = Set.new
+      s << Object.new
+      s
+    end
+
+    x
+    GC.compact
+    end;
+  end
 end
 
 class TC_Enumerable < Test::Unit::TestCase


### PR DESCRIPTION
Tombstone removal may possibly require allocation, and we're not allowed to allocate during GC.  This commit also renames `set_compact` to `set_gc_compact` to differentiate tombstone removal compaction with GC object compaction.