### PR TITLE
Use `EnvUtil.apply_timeout_scale` for `test_io_wait.rb`

### DIFF
--- a/test/io/wait/test_io_wait.rb
+++ b/test/io/wait/test_io_wait.rb
@@ -78,7 +78,8 @@ class TestIOWait < Test::Unit::TestCase
     ret = nil
     assert_nothing_raised(Timeout::Error) do
       q.push(true)
-      Timeout.timeout(0.1) { ret = @r.wait }
+      t = EnvUtil.apply_timeout_scale(0.1)
+      Timeout.timeout(t) { ret = @r.wait }
     end
     assert_equal @r, ret
   ensure
@@ -113,7 +114,8 @@ class TestIOWait < Test::Unit::TestCase
     ret = nil
     assert_nothing_raised(Timeout::Error) do
       q.push(true)
-      Timeout.timeout(0.1) { ret = @r.wait_readable }
+      t = EnvUtil.apply_timeout_scale(0.1)
+      Timeout.timeout(t) { ret = @r.wait_readable }
     end
     assert_equal @r, ret
   ensure


### PR DESCRIPTION
https://rubyci.s3.amazonaws.com/s390x/ruby-master/log/20250430T050005Z.fail.html.gz