### PR TITLE
Bump net-imap to v0.5.7 for Ruby 3.4 (CVE-2025-43857)

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -13,7 +13,7 @@ test-unit           3.6.7   https://github.com/test-unit/test-unit
 rexml               3.4.0   https://github.com/ruby/rexml
 rss                 0.3.1   https://github.com/ruby/rss
 net-ftp             0.3.8   https://github.com/ruby/net-ftp
-net-imap            0.5.6   https://github.com/ruby/net-imap
+net-imap            0.5.8   https://github.com/ruby/net-imap
 net-pop             0.1.2   https://github.com/ruby/net-pop
 net-smtp            0.5.1   https://github.com/ruby/net-smtp
 matrix              0.4.2   https://github.com/ruby/matrix


### PR DESCRIPTION
[v0.5.7](https://github.com/ruby/net-imap/releases/tag/v0.5.7) addresses CVE-2025-43857 (GHSA-j3g3-5qv5-52mj).

[v0.5.8](https://github.com/ruby/net-imap/releases/tag/v0.5.8) fixes some bugs in `Net::IMAP::SequenceSet`.