### PR TITLE
YJIT: call alloc func directly in new

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -4913,7 +4913,13 @@ fn gen_opt_new(
         // call rb_class_alloc to actually allocate
         jit_prepare_non_leaf_call(jit, asm);
 
-        let allocator = unsafe { rb_get_alloc_func(comptime_recv) };
+        let allocator =
+            if unsafe { FL_TEST(comptime_recv, VALUE(RUBY_FL_SINGLETON as usize)) } != VALUE(0) {
+                None
+            } else {
+                unsafe { rb_get_alloc_func(comptime_recv) }
+            };
+
         let allocator = allocator.unwrap_or(rb_obj_alloc);
         let obj = asm.ccall(allocator as _, vec![comptime_recv.into()]);
 


### PR DESCRIPTION
This removes an indirect branch by calling the allocator function from the class directly.

```
Benchmark 1: ./miniruby_master --yjit -e '20_000_000.times { Object.new }'
  Time (mean ± σ):      1.203 s ±  0.020 s    [User: 1.187 s, System: 0.011 s]
  Range (min … max):    1.168 s …  1.230 s    10 runs

Benchmark 2: ./miniruby_allocator --yjit -e '20_000_000.times { Object.new }'
  Time (mean ± σ):     967.5 ms ±  22.4 ms    [User: 951.6 ms, System: 11.5 ms]
  Range (min … max):   949.9 ms … 1026.0 ms    10 runs

Summary
  ./miniruby_allocator --yjit -e '20_000_000.times { Object.new }' ran
    1.24 ± 0.04 times faster than ./miniruby_master --yjit -e '20_000_000.times { Object.new }'
```

cc @tenderlove 