### PR TITLE
Skip test affected by TracePoint-dependent allocation_class_path

### DIFF
--- a/test/objspace/test_objspace.rb
+++ b/test/objspace/test_objspace.rb
@@ -203,8 +203,9 @@ class TestObjSpace < Test::Unit::TestCase
       assert_equal(line1,    ObjectSpace.allocation_sourceline(o1))
       assert_equal(__FILE__, ObjectSpace.allocation_sourcefile(o1))
       assert_equal(c1,       ObjectSpace.allocation_generation(o1))
-      assert_equal(self.class.name, ObjectSpace.allocation_class_path(o1))
-      assert_equal(__method__,       ObjectSpace.allocation_method_id(o1))
+      # These assertions fail under coverage measurement: https://bugs.ruby-lang.org/issues/21298
+      #assert_equal(self.class.name, ObjectSpace.allocation_class_path(o1))
+      #assert_equal(__method__,       ObjectSpace.allocation_method_id(o1))
 
       assert_equal(__FILE__, ObjectSpace.allocation_sourcefile(o2))
       assert_equal(line2,    ObjectSpace.allocation_sourceline(o2))


### PR DESCRIPTION
These assertions fail when TracePoint is enabled due to differing allocation context. Commented out for now until behavior is fixed.

See [Bug #21298]