### PR TITLE
Fix calling symbol proc from `using` scope outside

### DIFF
--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -2712,6 +2712,18 @@ class TestRefinement < Test::Unit::TestCase
     INPUT
   end
 
+  # [Bug #21265]
+  def test_symbol_proc_from_using_scope
+    assert_separately([], <<~RUBY)
+      class RefinedScope
+        using(Module.new { refine(Kernel) { def itself = 0 } })
+        ITSELF = :itself.to_proc
+      end
+
+      assert_equal(1, RefinedScope::ITSELF[1])
+    RUBY
+  end
+
   private
 
   def eval_using(mod, s)

--- a/vm_method.c
+++ b/vm_method.c
@@ -1636,7 +1636,6 @@ resolve_refined_method(VALUE refinements, const rb_method_entry_t *me, VALUE *de
 
         tmp_me = me->def->body.refined.orig_me;
         if (tmp_me) {
-            if (defined_class_ptr) *defined_class_ptr = tmp_me->defined_class;
             return tmp_me;
         }
 


### PR DESCRIPTION
Previously, resolve_refined_method() wrote to defined_class_ptr by using
rb_method_entry_t::defined_class, which by definition can be 0. Since
`*defined_class_ptr` is used as a back-up when
rb_method_entry_t::defined_class is 0, this wasn't a good strategy to
not have 0 at the end. This caused a crash since it overwrote a properly
set defined_class put by a `search_method*` function earlier.

Since resolve_refined_method() is always called after calling a
`search_method_*` function which writes through defined_class_ptr already,
just don't write through deinfed_class_ptr.

[[Bug #21265]](https://bugs.ruby-lang.org/issues/21265)
