### PR TITLE
dtoa.c: Use an on-stack buffer for small bigints

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -30,6 +30,7 @@
 #include "internal/object.h"
 #include "internal/thread.h"
 #include "internal/variable.h"
+#include "internal/missing.h"
 #include "ruby/fiber/scheduler.h"
 #include "iseq.h"
 #include "probes.h"
@@ -77,6 +78,7 @@ ruby_setup(void)
     prctl(PR_SET_THP_DISABLE, 1, 0, 0, 0);
 #endif
     Init_BareVM();
+    ruby_init_dtoa();
     rb_vm_encoded_insn_data_table_init();
     Init_vm_objects();
     Init_fstring_table();

--- a/internal/missing.h
+++ b/internal/missing.h
@@ -16,4 +16,7 @@ extern void ruby_init_setproctitle(int argc, char *argv[]);
 extern void ruby_free_proctitle(void);
 #endif
 
+/* missing/dtoa.c */
+void ruby_init_dtoa(void);
+
 #endif /* INTERNAL_MISSING_H */

--- a/missing/dtoa.c
+++ b/missing/dtoa.c
@@ -501,8 +501,8 @@ extern double rnd_prod(double, double), rnd_quot(double, double);
 #define Kmax 15
 
 struct Bigint {
-    unsigned char k;
     unsigned short wds;
+    unsigned char k;
     unsigned char sign : 1;
     ULong x[1];
 };

--- a/missing/dtoa.c
+++ b/missing/dtoa.c
@@ -501,18 +501,13 @@ extern double rnd_prod(double, double), rnd_quot(double, double);
 #define Kmax 15
 
 struct Bigint {
-    int k, maxwds, sign, wds;
+    int k, sign, wds;
     ULong x[1];
 };
 
 typedef struct Bigint Bigint;
 
 static inline int MAXWDS(Bigint *b) {
-    RUBY_ASSERT_ALWAYS(b->maxwds == (1 << b->k));
-    if (b->maxwds != (1 << b->k)) {
-        rb_bug("wtf");
-    }
-    //return b->maxwds;
     return (1 << b->k);
 }
 
@@ -525,7 +520,6 @@ Balloc(int k)
     x = 1 << k;
     rv = (Bigint *)MALLOC(sizeof(Bigint) + (x-1)*sizeof(ULong));
     rv->k = k;
-    rv->maxwds = x;
     rv->sign = rv->wds = 0;
     return rv;
 }
@@ -536,7 +530,7 @@ Bfree(Bigint *v)
     FREE(v);
 }
 
-// Copy everything except k and maxwds
+// Copy everything except k
 static void Bcopy(Bigint *dst, Bigint *src) {
     dst->sign = src->sign;
     dst->wds = src->wds;

--- a/missing/dtoa.c
+++ b/missing/dtoa.c
@@ -501,7 +501,9 @@ extern double rnd_prod(double, double), rnd_quot(double, double);
 #define Kmax 15
 
 struct Bigint {
-    int k, sign, wds;
+    unsigned char k;
+    unsigned short wds;
+    unsigned char sign : 1;
     ULong x[1];
 };
 

--- a/missing/dtoa.c
+++ b/missing/dtoa.c
@@ -507,6 +507,15 @@ struct Bigint {
 
 typedef struct Bigint Bigint;
 
+static inline int MAXWDS(Bigint *b) {
+    RUBY_ASSERT_ALWAYS(b->maxwds == (1 << b->k));
+    if (b->maxwds != (1 << b->k)) {
+        rb_bug("wtf");
+    }
+    //return b->maxwds;
+    return (1 << b->k);
+}
+
 static Bigint *
 Balloc(int k)
 {
@@ -569,7 +578,7 @@ multadd(Bigint *b, int m, int a)   /* multiply by m and add a */
 #endif
     } while (++i < wds);
     if (carry) {
-        if (wds >= b->maxwds) {
+        if (wds >= MAXWDS(b)) {
             b1 = Balloc(b->k+1);
             Bcopy(b1, b);
             Bfree(b);
@@ -723,7 +732,7 @@ mult(Bigint *a, Bigint *b)
     wa = a->wds;
     wb = b->wds;
     wc = wa + wb;
-    if (wc > a->maxwds)
+    if (wc > MAXWDS(a))
         k++;
     c = Balloc(k);
     for (x = c->x, xa = x + wc; x < xa; x++)
@@ -846,7 +855,7 @@ lshift(Bigint *b, int k)
 #endif
     k1 = b->k;
     n1 = n + b->wds + 1;
-    for (i = b->maxwds; n1 > i; i <<= 1)
+    for (i = MAXWDS(b); n1 > i; i <<= 1)
         k1++;
     b1 = Balloc(k1);
     x1 = b1->x;

--- a/missing/dtoa.c
+++ b/missing/dtoa.c
@@ -513,8 +513,15 @@ static inline int MAXWDS(Bigint *b) {
     return (1 << b->k);
 }
 
+struct dtoa_state {
+};
+
+#define DTOA_STATE_INIT  struct dtoa_state __dtoa_state, *_dtoa_state = &__dtoa_state;
+#define DTOA_STATE_SIG   struct dtoa_state *_dtoa_state
+#define DTOA_STATE_CALL  (_dtoa_state)
+
 static Bigint *
-Balloc(int k)
+Balloc(DTOA_STATE_SIG, int k)
 {
     int x;
     Bigint *rv;
@@ -527,7 +534,7 @@ Balloc(int k)
 }
 
 static void
-Bfree(Bigint *v)
+Bfree(DTOA_STATE_SIG, Bigint *v)
 {
     FREE(v);
 }
@@ -540,7 +547,7 @@ static void Bcopy(Bigint *dst, Bigint *src) {
 }
 
 static Bigint *
-multadd(Bigint *b, int m, int a)   /* multiply by m and add a */
+multadd(DTOA_STATE_SIG, Bigint *b, int m, int a)   /* multiply by m and add a */
 {
     int i, wds;
     ULong *x;
@@ -579,9 +586,9 @@ multadd(Bigint *b, int m, int a)   /* multiply by m and add a */
     } while (++i < wds);
     if (carry) {
         if (wds >= MAXWDS(b)) {
-            b1 = Balloc(b->k+1);
+            b1 = Balloc(DTOA_STATE_CALL, b->k+1);
             Bcopy(b1, b);
-            Bfree(b);
+            Bfree(DTOA_STATE_CALL, b);
             b = b1;
         }
         b->x[wds++] = (ULong)carry;
@@ -591,7 +598,7 @@ multadd(Bigint *b, int m, int a)   /* multiply by m and add a */
 }
 
 static Bigint *
-s2b(const char *s, int nd0, int nd, ULong y9)
+s2b(DTOA_STATE_SIG, const char *s, int nd0, int nd, ULong y9)
 {
     Bigint *b;
     int i, k;
@@ -600,11 +607,11 @@ s2b(const char *s, int nd0, int nd, ULong y9)
     x = (nd + 8) / 9;
     for (k = 0, y = 1; x > y; y <<= 1, k++) ;
 #ifdef Pack_32
-    b = Balloc(k);
+    b = Balloc(DTOA_STATE_CALL, k);
     b->x[0] = y9;
     b->wds = 1;
 #else
-    b = Balloc(k+1);
+    b = Balloc(DTOA_STATE_CALL, k+1);
     b->x[0] = y9 & 0xffff;
     b->wds = (b->x[1] = y9 >> 16) ? 2 : 1;
 #endif
@@ -613,14 +620,14 @@ s2b(const char *s, int nd0, int nd, ULong y9)
     if (9 < nd0) {
         s += 9;
         do {
-            b = multadd(b, 10, *s++ - '0');
+            b = multadd(DTOA_STATE_CALL, b, 10, *s++ - '0');
         } while (++i < nd0);
         s++;
     }
     else
         s += 10;
     for (; i < nd; i++)
-        b = multadd(b, 10, *s++ - '0');
+        b = multadd(DTOA_STATE_CALL, b, 10, *s++ - '0');
     return b;
 }
 
@@ -697,18 +704,18 @@ lo0bits(ULong *y)
 }
 
 static Bigint *
-i2b(int i)
+i2b(DTOA_STATE_SIG, int i)
 {
     Bigint *b;
 
-    b = Balloc(1);
+    b = Balloc(DTOA_STATE_CALL, 1);
     b->x[0] = i;
     b->wds = 1;
     return b;
 }
 
 static Bigint *
-mult(Bigint *a, Bigint *b)
+mult(DTOA_STATE_SIG, Bigint *a, Bigint *b)
 {
     Bigint *c;
     int k, wa, wb, wc;
@@ -734,7 +741,7 @@ mult(Bigint *a, Bigint *b)
     wc = wa + wb;
     if (wc > MAXWDS(a))
         k++;
-    c = Balloc(k);
+    c = Balloc(DTOA_STATE_CALL, k);
     for (x = c->x, xa = x + wc; x < xa; x++)
         *x = 0;
     xa = a->x;
@@ -812,14 +819,14 @@ mult(Bigint *a, Bigint *b)
 static Bigint *p5s_static[MAX_P5];
 
 static Bigint *
-pow5mult(Bigint *b, int k)
+pow5mult(DTOA_STATE_SIG, Bigint *b, int k)
 {
     Bigint *b1, *p5, **p5s;
     int i;
     static const int p05[3] = { 5, 25, 125 };
 
     if ((i = k & 3) != 0)
-        b = multadd(b, p05[i-1], 0);
+        b = multadd(DTOA_STATE_CALL, b, p05[i-1], 0);
 
     if (!(k >>= 2))
         return b;
@@ -830,8 +837,8 @@ pow5mult(Bigint *b, int k)
         assert(p5);
 
         if (k & 1) {
-            b1 = mult(b, p5);
-            Bfree(b);
+            b1 = mult(DTOA_STATE_CALL, b, p5);
+            Bfree(DTOA_STATE_CALL, b);
             b = b1;
         }
 
@@ -842,7 +849,7 @@ pow5mult(Bigint *b, int k)
 }
 
 static Bigint *
-lshift(Bigint *b, int k)
+lshift(DTOA_STATE_SIG, Bigint *b, int k)
 {
     int i, k1, n, n1;
     Bigint *b1;
@@ -857,7 +864,7 @@ lshift(Bigint *b, int k)
     n1 = n + b->wds + 1;
     for (i = MAXWDS(b); n1 > i; i <<= 1)
         k1++;
-    b1 = Balloc(k1);
+    b1 = Balloc(DTOA_STATE_CALL, k1);
     x1 = b1->x;
     for (i = 0; i < n; i++)
         *x1++ = 0;
@@ -891,7 +898,7 @@ lshift(Bigint *b, int k)
             *x1++ = *x++;
         } while (x < xe);
     b1->wds = n1 - 1;
-    Bfree(b);
+    Bfree(DTOA_STATE_CALL, b);
     return b1;
 }
 
@@ -924,9 +931,9 @@ cmp(Bigint *a, Bigint *b)
     return 0;
 }
 
-NO_SANITIZE("unsigned-integer-overflow", static Bigint * diff(Bigint *a, Bigint *b));
+NO_SANITIZE("unsigned-integer-overflow", static Bigint * diff(DTOA_STATE_SIG, Bigint *a, Bigint *b));
 static Bigint *
-diff(Bigint *a, Bigint *b)
+diff(DTOA_STATE_SIG, Bigint *a, Bigint *b)
 {
     Bigint *c;
     int i, wa, wb;
@@ -942,7 +949,7 @@ diff(Bigint *a, Bigint *b)
 
     i = cmp(a,b);
     if (!i) {
-        c = Balloc(0);
+        c = Balloc(DTOA_STATE_CALL, 0);
         c->wds = 1;
         c->x[0] = 0;
         return c;
@@ -955,7 +962,7 @@ diff(Bigint *a, Bigint *b)
     }
     else
         i = 0;
-    c = Balloc(a->k);
+    c = Balloc(DTOA_STATE_CALL, a->k);
     c->sign = i;
     wa = a->wds;
     xa = a->x;
@@ -1115,7 +1122,7 @@ ret_d:
 }
 
 static Bigint *
-d2b(double d_, int *e, int *bits)
+d2b(DTOA_STATE_SIG, double d_, int *e, int *bits)
 {
     double_u d;
     Bigint *b;
@@ -1137,9 +1144,9 @@ d2b(double d_, int *e, int *bits)
 #endif
 
 #ifdef Pack_32
-    b = Balloc(1);
+    b = Balloc(DTOA_STATE_CALL, 1);
 #else
-    b = Balloc(2);
+    b = Balloc(DTOA_STATE_CALL, 2);
 #endif
     x = b->x;
 
@@ -1428,6 +1435,8 @@ strtod(const char *s00, char **se)
 #ifdef USE_LOCALE
     const char *s2;
 #endif
+
+    DTOA_STATE_INIT;
 
     errno = 0;
     sign = nz0 = nz = 0;
@@ -1890,13 +1899,13 @@ undfl:
 
     /* Put digits into bd: true value = bd * 10^e */
 
-    bd0 = s2b(s0, nd0, nd, y);
+    bd0 = s2b(DTOA_STATE_CALL, s0, nd0, nd, y);
 
     for (;;) {
-        bd = Balloc(bd0->k);
+        bd = Balloc(DTOA_STATE_CALL, bd0->k);
         Bcopy(bd, bd0);
-        bb = d2b(dval(rv), &bbe, &bbbits);  /* rv = bb * 2^bbe */
-        bs = i2b(1);
+        bb = d2b(DTOA_STATE_CALL, dval(rv), &bbe, &bbbits);  /* rv = bb * 2^bbe */
+        bs = i2b(DTOA_STATE_CALL, 1);
 
         if (e >= 0) {
             bb2 = bb5 = 0;
@@ -1952,20 +1961,20 @@ undfl:
             bs2 -= i;
         }
         if (bb5 > 0) {
-            bs = pow5mult(bs, bb5);
-            bb1 = mult(bs, bb);
-            Bfree(bb);
+            bs = pow5mult(DTOA_STATE_CALL, bs, bb5);
+            bb1 = mult(DTOA_STATE_CALL, bs, bb);
+            Bfree(DTOA_STATE_CALL, bb);
             bb = bb1;
         }
         if (bb2 > 0)
-            bb = lshift(bb, bb2);
+            bb = lshift(DTOA_STATE_CALL, bb, bb2);
         if (bd5 > 0)
-            bd = pow5mult(bd, bd5);
+            bd = pow5mult(DTOA_STATE_CALL, bd, bd5);
         if (bd2 > 0)
-            bd = lshift(bd, bd2);
+            bd = lshift(DTOA_STATE_CALL, bd, bd2);
         if (bs2 > 0)
-            bs = lshift(bs, bs2);
-        delta = diff(bb, bd);
+            bs = lshift(DTOA_STATE_CALL, bs, bs2);
+        delta = diff(DTOA_STATE_CALL, bb, bd);
         dsign = delta->sign;
         delta->sign = 0;
         i = cmp(delta, bs);
@@ -1997,7 +2006,7 @@ undfl:
                         if (y)
 #endif
                         {
-                            delta = lshift(delta,Log2P);
+                            delta = lshift(DTOA_STATE_CALL, delta,Log2P);
                             if (cmp(delta, bs) <= 0)
                                 adj = -0.5;
                         }
@@ -2086,7 +2095,7 @@ apply_adj:
 #endif
                 break;
             }
-            delta = lshift(delta,Log2P);
+            delta = lshift(DTOA_STATE_CALL, delta,Log2P);
             if (cmp(delta, bs) > 0)
                 goto drop_down;
             break;
@@ -2310,10 +2319,10 @@ drop_down:
         }
 #endif
 cont:
-        Bfree(bb);
-        Bfree(bd);
-        Bfree(bs);
-        Bfree(delta);
+        Bfree(DTOA_STATE_CALL, bb);
+        Bfree(DTOA_STATE_CALL, bd);
+        Bfree(DTOA_STATE_CALL, bs);
+        Bfree(DTOA_STATE_CALL, delta);
     }
 #ifdef SET_INEXACT
     if (inexact) {
@@ -2346,11 +2355,11 @@ cont:
     }
 #endif
 retfree:
-    Bfree(bb);
-    Bfree(bd);
-    Bfree(bs);
-    Bfree(bd0);
-    Bfree(delta);
+    Bfree(DTOA_STATE_CALL, bb);
+    Bfree(DTOA_STATE_CALL, bd);
+    Bfree(DTOA_STATE_CALL, bs);
+    Bfree(DTOA_STATE_CALL, bd0);
+    Bfree(DTOA_STATE_CALL, delta);
 ret:
     if (se)
         *se = (char *)s;
@@ -2605,6 +2614,8 @@ dtoa(double d_, int mode, int ndigits, int *decpt, int *sign, char **rve)
     int inexact, oldinexact;
 #endif
 
+    DTOA_STATE_INIT;
+
     dval(d) = d_;
 
 #ifndef MULTIPLE_THREADS
@@ -2660,7 +2671,7 @@ dtoa(double d_, int mode, int ndigits, int *decpt, int *sign, char **rve)
     }
 #endif
 
-    b = d2b(dval(d), &be, &bbits);
+    b = d2b(DTOA_STATE_CALL, dval(d), &be, &bbits);
 #ifdef Sudden_Underflow
     i = (int)(word0(d) >> Exp_shift1 & (Exp_mask>>Exp_shift1));
 #else
@@ -2966,7 +2977,7 @@ bump_up:
 #endif
         b2 += i;
         s2 += i;
-        mhi = i2b(1);
+        mhi = i2b(DTOA_STATE_CALL, 1);
     }
     if (m2 > 0 && s2 > 0) {
         i = m2 < s2 ? m2 : s2;
@@ -2977,20 +2988,20 @@ bump_up:
     if (b5 > 0) {
         if (leftright) {
             if (m5 > 0) {
-                mhi = pow5mult(mhi, m5);
-                b1 = mult(mhi, b);
-                Bfree(b);
+                mhi = pow5mult(DTOA_STATE_CALL, mhi, m5);
+                b1 = mult(DTOA_STATE_CALL, mhi, b);
+                Bfree(DTOA_STATE_CALL, b);
                 b = b1;
             }
             if ((j = b5 - m5) != 0)
-                b = pow5mult(b, j);
+                b = pow5mult(DTOA_STATE_CALL, b, j);
         }
         else
-            b = pow5mult(b, b5);
+            b = pow5mult(DTOA_STATE_CALL, b, b5);
     }
-    S = i2b(1);
+    S = i2b(DTOA_STATE_CALL, 1);
     if (s5 > 0)
-        S = pow5mult(S, s5);
+        S = pow5mult(DTOA_STATE_CALL, S, s5);
 
     /* Check for special case that d is a normalized power of 2. */
 
@@ -3039,20 +3050,20 @@ bump_up:
         s2 += i;
     }
     if (b2 > 0)
-        b = lshift(b, b2);
+        b = lshift(DTOA_STATE_CALL, b, b2);
     if (s2 > 0)
-        S = lshift(S, s2);
+        S = lshift(DTOA_STATE_CALL, S, s2);
     if (k_check) {
         if (cmp(b,S) < 0) {
             k--;
-            b = multadd(b, 10, 0);  /* we botched the k estimate */
+            b = multadd(DTOA_STATE_CALL, b, 10, 0);  /* we botched the k estimate */
             if (leftright)
-                mhi = multadd(mhi, 10, 0);
+                mhi = multadd(DTOA_STATE_CALL, mhi, 10, 0);
             ilim = ilim1;
         }
     }
     if (ilim <= 0 && (mode == 3 || mode == 5)) {
-        if (ilim < 0 || cmp(b,S = multadd(S,5,0)) <= 0) {
+        if (ilim < 0 || cmp(b,S = multadd(DTOA_STATE_CALL, S,5,0)) <= 0) {
             /* no digits, fcvt style */
 no_digits:
             k = -1 - ndigits;
@@ -3065,7 +3076,7 @@ one_digit:
     }
     if (leftright) {
         if (m2 > 0)
-            mhi = lshift(mhi, m2);
+            mhi = lshift(DTOA_STATE_CALL, mhi, m2);
 
         /* Compute mlo -- check for special case
          * that d is a normalized power of 2.
@@ -3073,9 +3084,9 @@ one_digit:
 
         mlo = mhi;
         if (spec_case) {
-            mhi = Balloc(mhi->k);
+            mhi = Balloc(DTOA_STATE_CALL, mhi->k);
             Bcopy(mhi, mlo);
-            mhi = lshift(mhi, Log2P);
+            mhi = lshift(DTOA_STATE_CALL, mhi, Log2P);
         }
 
         for (i = 1;;i++) {
@@ -3084,9 +3095,9 @@ one_digit:
              * that will round to d?
              */
             j = cmp(b, mlo);
-            delta = diff(S, mhi);
+            delta = diff(DTOA_STATE_CALL, S, mhi);
             j1 = delta->sign ? 1 : cmp(b, delta);
-            Bfree(delta);
+            Bfree(DTOA_STATE_CALL, delta);
 #ifndef ROUND_BIASED
             if (j1 == 0 && mode != 1 && !(word1(d) & 1)
 #ifdef Honor_FLT_ROUNDS
@@ -3124,7 +3135,7 @@ one_digit:
                     }
 #endif /*Honor_FLT_ROUNDS*/
                 if (j1 > 0) {
-                    b = lshift(b, 1);
+                    b = lshift(DTOA_STATE_CALL, b, 1);
                     j1 = cmp(b, S);
                     if ((j1 > 0 || (j1 == 0 && (dig & 1))) && dig++ == '9')
                         goto round_9_up;
@@ -3152,12 +3163,12 @@ keep_dig:
             *s++ = dig;
             if (i == ilim)
                 break;
-            b = multadd(b, 10, 0);
+            b = multadd(DTOA_STATE_CALL, b, 10, 0);
             if (mlo == mhi)
-                mlo = mhi = multadd(mhi, 10, 0);
+                mlo = mhi = multadd(DTOA_STATE_CALL, mhi, 10, 0);
             else {
-                mlo = multadd(mlo, 10, 0);
-                mhi = multadd(mhi, 10, 0);
+                mlo = multadd(DTOA_STATE_CALL, mlo, 10, 0);
+                mhi = multadd(DTOA_STATE_CALL, mhi, 10, 0);
             }
         }
     }
@@ -3172,7 +3183,7 @@ keep_dig:
             }
             if (i >= ilim)
                 break;
-            b = multadd(b, 10, 0);
+            b = multadd(DTOA_STATE_CALL, b, 10, 0);
         }
 
     /* Round off last digit */
@@ -3183,7 +3194,7 @@ keep_dig:
       case 2: goto roundoff;
     }
 #endif
-    b = lshift(b, 1);
+    b = lshift(DTOA_STATE_CALL, b, 1);
     j = cmp(b, S);
     if (j > 0 || (j == 0 && (dig & 1))) {
  roundoff:
@@ -3201,11 +3212,11 @@ keep_dig:
     }
     s++;
 ret:
-    Bfree(S);
+    Bfree(DTOA_STATE_CALL, S);
     if (mhi) {
         if (mlo && mlo != mhi)
-            Bfree(mlo);
-        Bfree(mhi);
+            Bfree(DTOA_STATE_CALL, mlo);
+        Bfree(DTOA_STATE_CALL, mhi);
     }
 ret1:
 #ifdef SET_INEXACT
@@ -3219,7 +3230,7 @@ ret1:
     else if (!oldinexact)
         clear_inexact();
 #endif
-    Bfree(b);
+    Bfree(DTOA_STATE_CALL, b);
     *s = 0;
     *decpt = k + 1;
     if (rve)
@@ -3367,10 +3378,12 @@ hdtoa(double d, const char *xdigs, int ndigits, int *decpt, int *sign, char **rv
 }
 
 void ruby_init_dtoa(void) {
-    Bigint *p5 = i2b(625);
+    DTOA_STATE_INIT;
+
+    Bigint *p5 = i2b(DTOA_STATE_CALL, 625);
     p5s_static[0] = p5;
     for (int i = 1; i < MAX_P5; i++) {
-        p5 = mult(p5,p5);
+        p5 = mult(DTOA_STATE_CALL, p5,p5);
         p5s_static[i] = p5;
     }
 }

--- a/missing/dtoa.c
+++ b/missing/dtoa.c
@@ -501,10 +501,9 @@ extern double rnd_prod(double, double), rnd_quot(double, double);
 #define Kmax 15
 
 struct Bigint {
-    unsigned short wds;
+    int wds;
     unsigned char k;
-    unsigned int sign : 1;
-    unsigned int stackbuf_pos : 4;
+    int sign : 1;
     ULong x[1];
 };
 

--- a/missing/dtoa.c
+++ b/missing/dtoa.c
@@ -536,8 +536,12 @@ Bfree(Bigint *v)
     FREE(v);
 }
 
-#define Bcopy(x,y) memcpy((char *)&(x)->sign, (char *)&(y)->sign, \
-(y)->wds*sizeof(Long) + 2*sizeof(int))
+// Copy everything except k and maxwds
+static void Bcopy(Bigint *dst, Bigint *src) {
+    dst->sign = src->sign;
+    dst->wds = src->wds;
+    memcpy(dst->x, src->x, sizeof(Long) * src->wds);
+}
 
 static Bigint *
 multadd(Bigint *b, int m, int a)   /* multiply by m and add a */


### PR DESCRIPTION
In https://github.com/ruby/ruby/pull/12991 I replaced a spinlock with malloc, which is about the same performance.

I think malloc implementations have gotten better since 1990, but this can still be a bit of a bottleneck. We seem to mostly be allocating a few small bigints (k <= 2) at a time, so this PR adds a small on-stack buffer we can allocate from without synchronization.

I need to test this a bit more before merging.