### PR TITLE
[Backport 3.4] Fix C level backtraces for USE_ELF

### DIFF
--- a/addr2line.c
+++ b/addr2line.c
@@ -2173,9 +2173,8 @@ fill_lines(int num_traces, void **traces, int check_debuglink,
         }
     }
 
-    if (offset == -1) {
+    if (offset == 0) {
         /* main executable */
-        offset = 0;
         if (dynsym_shdr && dynstr_shdr) {
             char *strtab = file + dynstr_shdr->sh_offset;
             ElfW(Sym) *symtab = (ElfW(Sym) *)(file + dynsym_shdr->sh_offset);


### PR DESCRIPTION
[[Backport #21289]](https://bugs.ruby-lang.org/issues/21289)