### PR TITLE
Show the class variable name which caused a RactorIsolationError

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1121,7 +1121,7 @@ values.join
 }
 
 # cvar in shareable-objects are not allowed to access from non-main Ractor
-assert_equal 'can not access class variables from non-main Ractors', %q{
+assert_equal 'can not access class variable @@cv from non-main Ractors', %q{
   class C
     @@cv = 'str'
   end
@@ -1140,7 +1140,7 @@ assert_equal 'can not access class variables from non-main Ractors', %q{
 }
 
 # also cached cvar in shareable-objects are not allowed to access from non-main Ractor
-assert_equal 'can not access class variables from non-main Ractors', %q{
+assert_equal 'can not access class variable @@cv from non-main Ractors', %q{
   class C
     @@cv = 'str'
     def self.cv

--- a/variable.c
+++ b/variable.c
@@ -1121,7 +1121,7 @@ IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(ID id)
 
 #define CVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR() \
   if (UNLIKELY(!rb_ractor_main_p())) { \
-      rb_raise(rb_eRactorIsolationError, "can not access class variables from non-main Ractors"); \
+      rb_raise(rb_eRactorIsolationError, "can not access class variable %s from non-main Ractors", rb_id2name(id)); \
   }
 
 static inline struct st_table *


### PR DESCRIPTION
Class variable (@@var) access is prohibited in non-main Ractors and causes a RactorIsolationError.
Currently, RactorIsolationErrors do not carry any information about the actual class variable access which caused the violation. This makes it hard to debug non-Ractor-compatible code, especially when the culprit is in the middle of a long line.

This patch adds the class variable name which triggered the RactorIsolationError into its message. This follows the pattern of the "can not access non-shareable objects in constant FOO" error.