### PR TITLE
Test new pure C parser

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -18,7 +18,7 @@ net-pop             0.1.2   https://github.com/ruby/net-pop
 net-smtp            0.5.1   https://github.com/ruby/net-smtp
 matrix              0.4.2   https://github.com/ruby/matrix
 prime               0.1.3   https://github.com/ruby/prime
-rbs                 3.9.2   https://github.com/ruby/rbs
+rbs                 4.0.0.dev   https://github.com/ruby/rbs 4ecd51a60ddaae3b9ce0c735b04c794ca1997c9d
 typeprof            0.30.1  https://github.com/ruby/typeprof
 debug               1.10.0   https://github.com/ruby/debug
 racc                1.8.1   https://github.com/ruby/racc


### PR DESCRIPTION
This is to confirm the new pure C parser implemented in https://github.com/ruby/rbs/pull/2398 compiles in Ruby CI setting. This will break other bundled gems because RBS 4.0 has some breaking API changes.