### PR TITLE
wasm: increase the default Asyncify buffer size

### DIFF
--- a/wasm/setjmp.h
+++ b/wasm/setjmp.h
@@ -5,7 +5,7 @@
 #include <stdbool.h>
 
 #ifndef WASM_SETJMP_STACK_BUFFER_SIZE
-# define WASM_SETJMP_STACK_BUFFER_SIZE 6144
+# define WASM_SETJMP_STACK_BUFFER_SIZE 8192
 #endif
 
 struct __rb_wasm_asyncify_jmp_buf {


### PR DESCRIPTION
We will need more Asyncify space for the upcoming namespace changes as it will introduce more local variables and conditional jumps in asyncify'd functions.