### PR TITLE
Implement Set#init_with and Set#encode_with builtin

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1219,6 +1219,7 @@ BUILTIN_RB_SRCS = \
 		$(srcdir)/kernel.rb \
 		$(srcdir)/ractor.rb \
 		$(srcdir)/symbol.rb \
+		$(srcdir)/set.rb \
 		$(srcdir)/timev.rb \
 		$(srcdir)/thread_sync.rb \
 		$(srcdir)/nilclass.rb \
@@ -16716,6 +16717,8 @@ set.$(OBJEXT): {$(VPATH)}ruby_assert.h
 set.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 set.$(OBJEXT): {$(VPATH)}rubyparser.h
 set.$(OBJEXT): {$(VPATH)}set.c
+set.$(OBJEXT): {$(VPATH)}builtin.h
+set.$(OBJEXT): {$(VPATH)}set.rbinc
 set.$(OBJEXT): {$(VPATH)}shape.h
 set.$(OBJEXT): {$(VPATH)}st.h
 set.$(OBJEXT): {$(VPATH)}subst.h

--- a/ext/psych/lib/psych/core_ext.rb
+++ b/ext/psych/lib/psych/core_ext.rb
@@ -17,17 +17,3 @@ end
 if defined?(::IRB)
   require_relative 'y'
 end
-
-
-# TODO: how best to check for builtin Set?
-if defined?(::Set) && Object.const_source_location(:Set) == ["ruby", 0]
-  class Set
-    def encode_with(coder)
-      coder["hash"] = to_h
-    end
-
-    def init_with(coder)
-      replace(coder["hash"].keys)
-    end
-  end
-end

--- a/inits.c
+++ b/inits.c
@@ -101,6 +101,7 @@ rb_call_builtin_inits(void)
     BUILTIN(array);
     BUILTIN(hash);
     BUILTIN(symbol);
+    BUILTIN(set);
     BUILTIN(timev);
     BUILTIN(thread_sync);
     BUILTIN(nilclass);

--- a/set.c
+++ b/set.c
@@ -14,6 +14,7 @@
 #include "internal/symbol.h"
 #include "internal/variable.h"
 #include "ruby_assert.h"
+#include "builtin.h"
 
 #include <stdio.h>
 #ifdef HAVE_STDLIB_H
@@ -2202,3 +2203,5 @@ Init_Set(void)
 
     rb_provide("set.rb");
 }
+
+#include "set.rbinc"

--- a/set.rb
+++ b/set.rb
@@ -1,0 +1,9 @@
+class Set
+  def encode_with(coder) # :nodoc:
+    coder["hash"] = to_h
+  end
+
+  def init_with(coder) # :nodoc:
+    replace(coder["hash"].keys)
+  end
+end


### PR DESCRIPTION
Followup: https://github.com/ruby/psych/pull/725

Adding these methods from `psych` isn't enough because `psych` is a default gem, so you may run Ruby 3.5.0 with a very old `psych` version that doesn't know how to serialize Ruby 3.5 sets.

It's a bit weird to implement these methods directly into Ruby, but `encode_with/init_with` is a common serialization convention so it makes sense.

@tenderlove @jeremyevans what do you think? No objections?