### PR TITLE
YJIT: End the block after OPTIMIZE_METHOD_TYPE_CALL

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -9375,7 +9375,6 @@ fn gen_send_general(
 
                     }
                     OPTIMIZED_METHOD_TYPE_CALL => {
-
                         if block.is_some() {
                             gen_counter_incr(jit, asm, Counter::send_call_block);
                             return None;
@@ -9427,8 +9426,9 @@ fn gen_send_general(
 
                         let stack_ret = asm.stack_push(Type::Unknown);
                         asm.mov(stack_ret, ret);
-                        return Some(KeepCompiling);
 
+                        // End the block to allow invalidating the next instruction
+                        return jump_to_next_insn(jit, asm);
                     }
                     OPTIMIZED_METHOD_TYPE_BLOCK_CALL => {
                         gen_counter_incr(jit, asm, Counter::send_optimized_method_block_call);


### PR DESCRIPTION
This PR lets `OPTIMIZE_METHOD_TYPE_CALL` end the block at the instruction, which currently keeps compiling. 

If we don't end the block and it's followed by a setlocal in the same block, we can't invalidate the setlocal instruction properly when `OPTIMIZE_METHOD_TYPE_CALL` escapes the EP.

See also: https://github.com/ruby/ruby/pull/10487, which relies on https://github.com/ruby/ruby/pull/10539