### PR TITLE
Remove Set#to_h

### DIFF
--- a/set.c
+++ b/set.c
@@ -2184,7 +2184,6 @@ Init_Set(void)
     rb_define_method(rb_cSet, "superset?", set_i_superset, 1);
     rb_define_alias(rb_cSet, ">=", "superset?");
     rb_define_method(rb_cSet, "to_a", set_i_to_a, 0);
-    rb_define_method(rb_cSet, "to_h", set_i_to_h, 0);
     rb_define_method(rb_cSet, "to_set", set_i_to_set, -1);
 
     /* :nodoc: */


### PR DESCRIPTION
This overrides Enumerable#to_h, but doesn't handle a block, breaking backwards compatibility.

Set#to_h was added in the marshalling support commit, but isn't necessary for that, as the underlying function is called.

Fix psych to call to_h with a block instead of relying on this new Set#to_h.