### PR TITLE
Fix Set#to_h to be backwards compatible when called with a block

### DIFF
--- a/set.c
+++ b/set.c
@@ -1858,9 +1858,20 @@ set_to_hash_i(st_data_t key, st_data_t arg)
     return ST_CONTINUE;
 }
 
+/*
+ *  call-seq:
+ *    to_h -> hash
+ *    to_h {|element| ...} -> hash
+ *
+ *  Without a block, returns a hash where the set's elements
+ *  are keys, and all values are true.  With a block, calls
+ *  super (Enumerable#to_h).
+ */
 static VALUE
 set_i_to_h(VALUE set)
 {
+    if (rb_block_given_p()) return rb_call_super(0, NULL);
+
     st_index_t size = RSET_SIZE(set);
     VALUE hash;
     if (RSET_COMPARE_BY_IDENTITY(set)) {

--- a/test/ruby/test_set.rb
+++ b/test/ruby/test_set.rb
@@ -143,6 +143,12 @@ class TC_Set < Test::Unit::TestCase
     assert_equal([1,2,3], ary.sort)
   end
 
+  def test_to_h
+    set = Set[1,2]
+    assert_equal({1 => true, 2 => true}, set.to_h)
+    assert_equal({1 => false, 2 => false}, set.to_h { [it, false] })
+  end
+
   def test_flatten
     # test1
     set1 = Set[


### PR DESCRIPTION
Set includes Enumerable, and Enumerable#to_h accepts a block, so there is likely code relying on the block being respected and not ignored.  If a block is given, call super (Enumerable#to_h) to restore backwards compatibility.

Also add tests and documentation for the method.