### PR TITLE
Handle mutation of array being merged into set

### DIFF
--- a/set.c
+++ b/set.c
@@ -1120,14 +1120,10 @@ set_merge_enum_into(VALUE set, VALUE arg)
         set_iter(arg, set_merge_i, (st_data_t)&args);
     }
     else if (RB_TYPE_P(arg, T_ARRAY)) {
-        long len = RARRAY_LEN(arg);
-        if (RARRAY_LEN(arg) != 0) {
-            set_table *into = RSET_TABLE(set);
-            RARRAY_PTR_USE(arg, ptr, {
-                for(; len > 0; len--, ptr++) {
-                    set_table_insert_wb(into, set, *ptr, NULL);
-                }
-            });
+        long i;
+        set_table *into = RSET_TABLE(set);
+        for (i=0; i<RARRAY_LEN(arg); i++) {
+            set_table_insert_wb(into, set, RARRAY_AREF(arg, i), NULL);
         }
     }
     else {

--- a/set.c
+++ b/set.c
@@ -494,18 +494,13 @@ set_i_initialize(int argc, VALUE *argv, VALUE set)
 
     if (argc > 0 && (other = argv[0]) != Qnil) {
         if (RB_TYPE_P(other, T_ARRAY)) {
-            long len = RARRAY_LEN(other);
-            if (RARRAY_LEN(other) != 0) {
-                set_table *into = RSET_TABLE(set);
-                VALUE key;
-                int block_given = rb_block_given_p();
-                RARRAY_PTR_USE(other, ptr, {
-                    for(; len > 0; len--, ptr++) {
-                        key = *ptr;
-                        if (block_given) key = rb_yield(key);
-                        set_table_insert_wb(into, set, key, NULL);
-                    }
-                });
+            long i;
+            int block_given = rb_block_given_p();
+            set_table *into = RSET_TABLE(set);
+            for (i=0; i<RARRAY_LEN(other); i++) {
+                VALUE key = RARRAY_AREF(other, i);
+                if (block_given) key = rb_yield(key);
+                set_table_insert_wb(into, set, key, NULL);
             }
         }
         else {

--- a/test/ruby/test_set.rb
+++ b/test/ruby/test_set.rb
@@ -632,6 +632,17 @@ class TC_Set < Test::Unit::TestCase
     }
   end
 
+  def test_merge_mutating_hash_bug_21305
+    a = (1..100).to_a
+    o = Object.new
+    o.define_singleton_method(:hash) do
+      a.clear
+      0
+    end
+    a.unshift o
+    assert_equal([o], Set.new.merge(a).to_a)
+  end
+
   def test_subtract
     set = Set[1,2,3]
 

--- a/test/ruby/test_set.rb
+++ b/test/ruby/test_set.rb
@@ -643,6 +643,11 @@ class TC_Set < Test::Unit::TestCase
     assert_equal([o], Set.new.merge(a).to_a)
   end
 
+  def test_initialize_mutating_array_bug_21306
+    a = (1..100).to_a
+    assert_equal(Set[0], Set.new(a){a.clear; 0})
+  end
+
   def test_subtract
     set = Set[1,2,3]
 


### PR DESCRIPTION
Check length of array during every iteration, as a #hash method could truncate the array, resulting in heap-use-after-free.

Fixes [Bug #21305]