### PR TITLE
Fix minor issues with shapes

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -380,7 +380,7 @@ rb_shape_depth(rb_shape_t *shape)
     return depth;
 }
 
-rb_shape_t*
+rb_shape_t *
 rb_shape_get_shape(VALUE obj)
 {
     return rb_shape_get_shape_by_id(rb_shape_get_shape_id(obj));
@@ -489,7 +489,7 @@ rb_shape_alloc_new_child(ID id, rb_shape_t *shape, enum shape_type shape_type)
     return new_shape;
 }
 
-static rb_shape_t*
+static rb_shape_t *
 get_next_shape_internal(rb_shape_t *shape, ID id, enum shape_type shape_type, bool *variation_created, bool new_variations_allowed)
 {
     rb_shape_t *res = NULL;
@@ -574,7 +574,7 @@ get_next_shape_internal(rb_shape_t *shape, ID id, enum shape_type shape_type, bo
 }
 
 int
-rb_shape_frozen_shape_p(rb_shape_t* shape)
+rb_shape_frozen_shape_p(rb_shape_t *shape)
 {
     return SHAPE_FROZEN == (enum shape_type)shape->type;
 }
@@ -682,7 +682,7 @@ rb_shape_transition_shape_remove_ivar(VALUE obj, ID id, rb_shape_t *shape, VALUE
 rb_shape_t *
 rb_shape_transition_shape_frozen(VALUE obj)
 {
-    rb_shape_t* shape = rb_shape_get_shape(obj);
+    rb_shape_t *shape = rb_shape_get_shape(obj);
     RUBY_ASSERT(shape);
     RUBY_ASSERT(RB_OBJ_FROZEN(obj));
 
@@ -690,7 +690,7 @@ rb_shape_transition_shape_frozen(VALUE obj)
         return shape;
     }
 
-    rb_shape_t* next_shape;
+    rb_shape_t *next_shape;
 
     if (shape == rb_shape_get_root_shape()) {
         return rb_shape_get_shape_by_id(SPECIAL_CONST_SHAPE_ID);
@@ -909,7 +909,7 @@ rb_shape_get_iv_index(rb_shape_t *shape, ID id, attr_index_t *value)
 }
 
 void
-rb_shape_set_shape(VALUE obj, rb_shape_t* shape)
+rb_shape_set_shape(VALUE obj, rb_shape_t *shape)
 {
     rb_shape_set_shape_id(obj, rb_shape_id(shape));
 }
@@ -1085,14 +1085,14 @@ rb_shape_t_to_rb_cShape(rb_shape_t *shape)
 static enum rb_id_table_iterator_result
 rb_edges_to_hash(ID key, VALUE value, void *ref)
 {
-    rb_hash_aset(*(VALUE *)ref, parse_key(key), rb_shape_t_to_rb_cShape((rb_shape_t*)value));
+    rb_hash_aset(*(VALUE *)ref, parse_key(key), rb_shape_t_to_rb_cShape((rb_shape_t *)value));
     return ID_TABLE_CONTINUE;
 }
 
 static VALUE
 rb_shape_edges(VALUE self)
 {
-    rb_shape_t* shape;
+    rb_shape_t *shape;
 
     shape = rb_shape_get_shape_by_id(NUM2INT(rb_struct_getmember(self, rb_intern("id"))));
 
@@ -1126,7 +1126,7 @@ rb_shape_edge_name(rb_shape_t *shape)
 static VALUE
 rb_shape_export_depth(VALUE self)
 {
-    rb_shape_t* shape;
+    rb_shape_t *shape;
     shape = rb_shape_get_shape_by_id(NUM2INT(rb_struct_getmember(self, rb_intern("id"))));
     return SIZET2NUM(rb_shape_depth(shape));
 }
@@ -1171,11 +1171,11 @@ rb_shape_exhaust(int argc, VALUE *argv, VALUE self)
     return Qnil;
 }
 
-VALUE rb_obj_shape(rb_shape_t* shape);
+VALUE rb_obj_shape(rb_shape_t *shape);
 
 static enum rb_id_table_iterator_result collect_keys_and_values(ID key, VALUE value, void *ref)
 {
-    rb_hash_aset(*(VALUE *)ref, parse_key(key), rb_obj_shape((rb_shape_t*)value));
+    rb_hash_aset(*(VALUE *)ref, parse_key(key), rb_obj_shape((rb_shape_t *)value));
     return ID_TABLE_CONTINUE;
 }
 
@@ -1193,7 +1193,7 @@ static VALUE edges(struct rb_id_table* edges)
 }
 
 VALUE
-rb_obj_shape(rb_shape_t* shape)
+rb_obj_shape(rb_shape_t *shape)
 {
     VALUE rb_shape = rb_hash_new();
 

--- a/shape.h
+++ b/shape.h
@@ -45,7 +45,7 @@ struct rb_shape {
     struct rb_id_table *edges; // id_table from ID (ivar) to next shape
     ID edge_name; // ID (ivar) for transition from parent to rb_shape
     attr_index_t next_iv_index;
-    uint32_t capacity; // Total capacity of the object with this shape
+    attr_index_t capacity; // Total capacity of the object with this shape
     uint8_t type;
     uint8_t heap_index;
     shape_id_t parent_id;

--- a/variable.c
+++ b/variable.c
@@ -1709,7 +1709,7 @@ generic_ivar_set_too_complex_table(VALUE obj, void *data)
     if (!rb_gen_ivtbl_get(obj, 0, &ivtbl)) {
         ivtbl = xmalloc(sizeof(struct gen_ivtbl));
 #if !SHAPE_IN_BASIC_FLAGS
-        ivtbl->shape_id = SHAPE_OBJ_TOO_COMPLEX;
+        ivtbl->shape_id = OBJ_TOO_COMPLEX_SHAPE_ID;
 #endif
         ivtbl->as.complex.table = st_init_numtable_with_size(1);
 
@@ -2117,7 +2117,7 @@ rb_copy_generic_ivar(VALUE clone, VALUE obj)
         if (rb_shape_obj_too_complex(obj)) {
             new_ivtbl = xmalloc(sizeof(struct gen_ivtbl));
 #if !SHAPE_IN_BASIC_FLAGS
-            new_ivtbl->shape_id = SHAPE_OBJ_TOO_COMPLEX;
+            new_ivtbl->shape_id = OBJ_TOO_COMPLEX_SHAPE_ID;
 #endif
             new_ivtbl->as.complex.table = st_copy(obj_ivtbl->as.complex.table);
         }

--- a/variable.c
+++ b/variable.c
@@ -2045,7 +2045,7 @@ each_hash_iv(st_data_t id, st_data_t val, st_data_t data)
 static void
 obj_ivar_each(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg)
 {
-    rb_shape_t* shape = rb_shape_get_shape(obj);
+    rb_shape_t *shape = rb_shape_get_shape(obj);
     struct iv_itr_data itr_data;
     itr_data.obj = obj;
     itr_data.arg = arg;
@@ -2083,7 +2083,7 @@ class_ivar_each(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE));
 
-    rb_shape_t* shape = rb_shape_get_shape(obj);
+    rb_shape_t *shape = rb_shape_get_shape(obj);
     struct iv_itr_data itr_data;
     itr_data.obj = obj;
     itr_data.arg = arg;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -649,7 +649,7 @@ pub struct rb_shape {
     pub edges: *mut rb_id_table,
     pub edge_name: ID,
     pub next_iv_index: attr_index_t,
-    pub capacity: u32,
+    pub capacity: attr_index_t,
     pub type_: u8,
     pub heap_index: u8,
     pub parent_id: shape_id_t,

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -406,7 +406,7 @@ pub struct rb_shape {
     pub edges: *mut rb_id_table,
     pub edge_name: ID,
     pub next_iv_index: attr_index_t,
-    pub capacity: u32,
+    pub capacity: attr_index_t,
     pub type_: u8,
     pub heap_index: u8,
     pub parent_id: shape_id_t,


### PR DESCRIPTION
There was a subtle bug in initialization of too complex objects with external ivars.

Also cleanup the type declaration for `rb_shape_t *` to use spacing consistent with the rest of the codebase.

And `rb_shape.capacity` was always declared as `uint32_t` even though on 32bit platforms it never goes larger than `uint16_t`.