### PR TITLE
Fix `USE_MN_THREADS=0` builds on macOS

### DIFF
--- a/vm_dump.c
+++ b/vm_dump.c
@@ -515,9 +515,13 @@ rb_vmdebug_thread_dump_state(FILE *errout, VALUE self)
 static bool
 is_coroutine_start(unw_word_t ip)
 {
+#if USE_MN_THREADS
     struct coroutine_context;
     extern void ruby_coroutine_start(struct coroutine_context *, struct coroutine_context *);
     return ((void *)(ip) == (void *)ruby_coroutine_start);
+#else
+    return false;
+#endif
 }
 #  endif
 


### PR DESCRIPTION
This was recently broken.