### PR TITLE
Remove dependency on debug_counter.h when BUILDING_MODULAR_GC

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -6481,7 +6481,6 @@ gc_start(rb_objspace_t *objspace, unsigned int reason)
               reason,
               do_full_mark, !is_incremental_marking(objspace), objspace->flags.immediate_sweep);
 
-#if USE_DEBUG_COUNTER
     RB_DEBUG_COUNTER_INC(gc_count);
 
     if (reason & GPR_FLAG_MAJOR_MASK) {
@@ -6500,7 +6499,6 @@ gc_start(rb_objspace_t *objspace, unsigned int reason)
         (void)RB_DEBUG_COUNTER_INC_IF(gc_minor_capi,   reason & GPR_FLAG_CAPI);
         (void)RB_DEBUG_COUNTER_INC_IF(gc_minor_stress, reason & GPR_FLAG_STRESS);
     }
-#endif
 
     objspace->profile.count++;
     objspace->profile.latest_gc_info = reason;

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -33,7 +33,13 @@
 # include "probes.h"
 #endif
 
-#include "debug_counter.h"
+#ifdef BUILDING_MODULAR_GC
+# define RB_DEBUG_COUNTER_INC(_name) ((void)0)
+# define RB_DEBUG_COUNTER_INC_IF(_name, cond) (!!(cond))
+#else
+# include "debug_counter.h"
+#endif
+
 #include "internal/sanitizers.h"
 
 /* MALLOC_HEADERS_BEGIN */


### PR DESCRIPTION
This allows the default GC to not need debug_counter.h when building as a modular GC.