### PR TITLE
variable.c: Fix compilation warnings

### DIFF
--- a/test/ruby/test_env.rb
+++ b/test/ruby/test_env.rb
@@ -914,11 +914,11 @@ class TestEnv < Test::Unit::TestCase
         h2 = {}
         ENV.each_pair {|k, v| h2[k] = v }
         Ractor.yield [h1, h2]
-        Ractor.yield (ENV.delete_if {|k, v| #{ignore_case_str} ? k.upcase == "TEST" : k == "test" }).object_id
+        Ractor.yield (ENV.delete_if {|k, v| #{ignore_case_str} ? k.upcase == "TEST" : k == "test" })
       end
       h1, h2 = r.take
       assert_equal(h1, h2)
-      assert_equal(ENV.object_id, r.take)
+      assert_same(ENV, r.take)
     end;
   end
 
@@ -968,11 +968,11 @@ class TestEnv < Test::Unit::TestCase
         h2 = {}
         ENV.each_pair {|k, v| h2[k] = v }
         Ractor.yield [h1, h2]
-        Ractor.yield (ENV.keep_if {|k, v| #{ignore_case_str} ? k.upcase != "TEST" : k != "test" }).object_id
+        Ractor.yield (ENV.keep_if {|k, v| #{ignore_case_str} ? k.upcase != "TEST" : k != "test" })
       end
       h1, h2 = r.take
       assert_equal(h1, h2)
-      assert_equal(ENV.object_id, r.take)
+      assert_equal(ENV, r.take)
     end;
   end
 

--- a/variable.c
+++ b/variable.c
@@ -1316,7 +1316,7 @@ rb_field_get(VALUE obj, rb_shape_t *target_shape)
         return ROBJECT_FIELDS(obj)[attr_index];
       default:
         RUBY_ASSERT(FL_TEST_RAW(obj, FL_EXIVAR));
-        struct gen_fields_tbl *fields_tbl;
+        struct gen_fields_tbl *fields_tbl = NULL;
         rb_ivar_generic_fields_tbl_lookup(obj, &fields_tbl);
         RUBY_ASSERT(fields_tbl);
         return fields_tbl->as.shape.fields[attr_index];
@@ -2184,6 +2184,7 @@ iterate_over_shapes_with_callback(rb_shape_t *shape, rb_ivar_foreach_callback_fu
         return iterate_over_shapes_with_callback(rb_shape_get_parent(shape), callback, itr_data);
       case SHAPE_OBJ_TOO_COMPLEX:
         rb_bug("Unreachable");
+        UNREACHABLE_RETURN(false);
     }
 }
 


### PR DESCRIPTION
Ref: http://ci.rvm.jp/results/trunk-repeat20@ruby-sp2-noble-docker/5748658

```
variable.c: In function ‘iterate_over_shapes_with_callback’:
variable.c:2188:1: warning: control reaches end of non-void function [-Wreturn-type]
	 2188 | }
	      | ^
variable.c: In function ‘rb_field_get’:
variable.c:1322:43: warning: ‘fields_tbl’ may be used uninitialized [-Wmaybe-uninitialized]
	 1322 |         return fields_tbl->as.shape.fields[attr_index];
	      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
variable.c:1319:32: note: ‘fields_tbl’ was declared here
	 1319 |         struct gen_fields_tbl *fields_tbl;
	      |
```