### PR TITLE
Register the `envtbl` global variable

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -7632,6 +7632,8 @@ Init_Hash(void)
      * envtbl = rb_define_class("ENV", rb_cObject);
      */
     origenviron = environ;
+
+    rb_gc_register_address(&envtbl);
     envtbl = TypedData_Wrap_Struct(rb_cObject, &env_data_type, NULL);
     rb_extend_object(envtbl, rb_mEnumerable);
     FL_SET_RAW(envtbl, RUBY_FL_SHAREABLE);


### PR DESCRIPTION
As far as I can tell, this global isn't registered anywhere. It won't be collected because it's referenced in a constant, but I don't see anything that would keep that global variable up to date in case of compaction.