### PR TITLE
[DOC] ObjectSpace#each_object behavior in multi-Ractor mode

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1545,10 +1545,9 @@ os_obj_of(VALUE of)
  *     2.2250738585072e-308
  *     Total count: 7
  *
- *  Due to implementation limitations, this method will not yield
- *  Ractor-unshareable the process is in multi-Ractor mode (when
+ *  Due to a current known Ractor implementation issue, this method will not yield
+ *  Ractor-unshareable objects in multi-Ractor mode (when
  *  <code>Ractor.new</code> has been called within the process at least once).
- *  This behavior is not considered ideal.
  *  See https://bugs.ruby-lang.org/issues/19387 for more information.
  *
  *     a = 12345678987654321 # shareable

--- a/gc.c
+++ b/gc.c
@@ -1545,9 +1545,11 @@ os_obj_of(VALUE of)
  *     2.2250738585072e-308
  *     Total count: 7
  *
- *  When the process is in multi-Ractor mode (when <code>Ractor.new</code>
- *  has been called within the process at least once), this method yields
- *  Ractor-shareable objects only.
+ *  Due to implementation limitations, this method will not yield
+ *  Ractor-unshareable the process is in multi-Ractor mode (when
+ *  <code>Ractor.new</code> has been called within the process at least once).
+ *  This behavior is not considered ideal.
+ *  See https://bugs.ruby-lang.org/issues/19387 for more information.
  *
  *     a = 12345678987654321 # shareable
  *     b = [].freeze # shareable

--- a/gc.c
+++ b/gc.c
@@ -1545,6 +1545,17 @@ os_obj_of(VALUE of)
  *     2.2250738585072e-308
  *     Total count: 7
  *
+ *  When the process is in multi-Ractor mode (when <code>Ractor.new</code>
+ *  has been called within the process at least once), this method yields
+ *  Ractor-shareable objects only.
+ *
+ *     a = 12345678987654321 # shareable
+ *     b = [].freeze # shareable
+ *     c = {} # not shareable
+ *     ObjectSpace.each_object {|x| x } # yields a, b, and c
+ *     Ractor.new {} # enter multi-Ractor mode
+ *     ObjectSpace.each_object {|x| x } # does not yield c
+ *
  */
 
 static VALUE


### PR DESCRIPTION
This behavior of ObjectSpace#each_object has been around since Ruby 3.0 when Ractors were first introduced, but was never documented and has caused some amount of confusion:

https://bugs.ruby-lang.org/issues/17360
https://bugs.ruby-lang.org/issues/19387
https://bugs.ruby-lang.org/issues/21149