### PR TITLE
ZJIT: Fix a splitting condition for LHS

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -86,6 +86,14 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 2
   end
 
+  def test_opt_plus_left_imm
+    assert_compiles '3', %q{
+      def test(a) = 1 + a
+      test(1) # profile opt_plus
+      test(2)
+    }, call_threshold: 2
+  end
+
   # Test argument ordering
   def test_opt_minus
     assert_compiles '2', %q{

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -183,7 +183,7 @@ impl Assembler
                                     *left = asm.load(*left);
                                 },
                                 // The first operand can't be an immediate value
-                                (Opnd::Value(_), _) => {
+                                (Opnd::UImm(_), _) => {
                                     *left = asm.load(*left);
                                 }
                                 _ => {}


### PR DESCRIPTION
This PR fixes a splitting logic in the x86_64 backend. I re-discovered this bug while writing a test case for side exits.

The `Opnd::Value` match arm added in https://github.com/Shopify/zjit/pull/38 was broken by the backend refactoring https://github.com/Shopify/zjit/pull/86 that removed the concept of `unmapped_opnd`, which had `Opnd::Value`. It now only deals with `Opnd::UImm` lowered from `Opnd::Value`, so the match arm should check for `Opnd::UImm`.