### PR TITLE
Cleanup shapes API

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -414,7 +414,7 @@ dump_object(VALUE obj, struct dump_config *dc)
     dump_append(dc, obj_type(obj));
     dump_append(dc, "\"");
 
-    size_t shape_id = RB_OBJ_SHAPE_ID(obj);
+    size_t shape_id = rb_obj_shape_id(obj);
     dump_append(dc, ", \"shape_id\":");
     dump_append_sizet(dc, shape_id);
 

--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -587,7 +587,7 @@ dump_object(VALUE obj, struct dump_config *dc)
 
         dump_append(dc, ", \"ivars\":");
         dump_append_lu(dc, ROBJECT_FIELDS_COUNT(obj));
-        if (rb_shape_obj_too_complex(obj)) {
+        if (rb_shape_obj_too_complex_p(obj)) {
             dump_append(dc, ", \"too_complex_shape\":true");
         }
         break;

--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -786,7 +786,7 @@ shape_i(rb_shape_t *shape, void *data)
 {
     struct dump_config *dc = (struct dump_config *)data;
 
-    size_t shape_id = rb_shape_id(shape);
+    shape_id_t shape_id = rb_shape_id(shape);
     if (shape_id < dc->shapes_since) {
         return;
     }
@@ -803,7 +803,7 @@ shape_i(rb_shape_t *shape, void *data)
     }
 
     dump_append(dc, ", \"depth\":");
-    dump_append_sizet(dc, rb_shape_depth(shape));
+    dump_append_sizet(dc, rb_shape_depth(shape_id));
 
     switch((enum shape_type)shape->type) {
       case SHAPE_ROOT:
@@ -831,10 +831,10 @@ shape_i(rb_shape_t *shape, void *data)
     }
 
     dump_append(dc, ", \"edges\":");
-    dump_append_sizet(dc, rb_shape_edges_count(shape));
+    dump_append_sizet(dc, rb_shape_edges_count(shape_id));
 
     dump_append(dc, ", \"memsize\":");
-    dump_append_sizet(dc, rb_shape_memsize(shape));
+    dump_append_sizet(dc, rb_shape_memsize(shape_id));
 
     dump_append(dc, "}\n");
 }

--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -414,7 +414,7 @@ dump_object(VALUE obj, struct dump_config *dc)
     dump_append(dc, obj_type(obj));
     dump_append(dc, "\"");
 
-    size_t shape_id = rb_shape_get_shape_id(obj);
+    size_t shape_id = RB_OBJ_SHAPE_ID(obj);
     dump_append(dc, ", \"shape_id\":");
     dump_append_sizet(dc, shape_id);
 

--- a/gc.c
+++ b/gc.c
@@ -2999,8 +2999,6 @@ rb_gc_mark_children(void *objspace, VALUE obj)
       }
 
       case T_OBJECT: {
-        rb_shape_t *shape = RSHAPE(ROBJECT_SHAPE_ID(obj));
-
         if (rb_shape_obj_too_complex_p(obj)) {
             gc_mark_tbl_no_pin(ROBJECT_FIELDS_HASH(obj));
         }
@@ -3013,13 +3011,13 @@ rb_gc_mark_children(void *objspace, VALUE obj)
             }
         }
 
-        if (shape) {
+        attr_index_t fields_count = ROBJECT_FIELDS_COUNT(obj);
+        if (fields_count) {
             VALUE klass = RBASIC_CLASS(obj);
 
             // Increment max_iv_count if applicable, used to determine size pool allocation
-            attr_index_t num_of_ivs = shape->next_field_index;
-            if (RCLASS_EXT(klass)->max_iv_count < num_of_ivs) {
-                RCLASS_EXT(klass)->max_iv_count = num_of_ivs;
+            if (RCLASS_EXT(klass)->max_iv_count < fields_count) {
+                RCLASS_EXT(klass)->max_iv_count = fields_count;
             }
         }
 

--- a/gc.c
+++ b/gc.c
@@ -1228,7 +1228,7 @@ rb_gc_obj_free(void *objspace, VALUE obj)
 
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
-        if (rb_shape_obj_too_complex(obj)) {
+        if (rb_shape_obj_too_complex_p(obj)) {
             RB_DEBUG_COUNTER_INC(obj_obj_too_complex);
             st_free_table(ROBJECT_FIELDS_HASH(obj));
         }
@@ -1244,7 +1244,7 @@ rb_gc_obj_free(void *objspace, VALUE obj)
       case T_CLASS:
         rb_id_table_free(RCLASS_M_TBL(obj));
         rb_cc_table_free(obj);
-        if (rb_shape_obj_too_complex(obj)) {
+        if (rb_shape_obj_too_complex_p(obj)) {
             st_free_table((st_table *)RCLASS_FIELDS(obj));
         }
         else {
@@ -2124,7 +2124,7 @@ rb_obj_memsize_of(VALUE obj)
 
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
-        if (rb_shape_obj_too_complex(obj)) {
+        if (rb_shape_obj_too_complex_p(obj)) {
             size += rb_st_memsize(ROBJECT_FIELDS_HASH(obj));
         }
         else if (!(RBASIC(obj)->flags & ROBJECT_EMBED)) {
@@ -2912,7 +2912,7 @@ rb_gc_mark_children(void *objspace, VALUE obj)
         mark_m_tbl(objspace, RCLASS_M_TBL(obj));
         mark_cvc_tbl(objspace, obj);
         rb_cc_table_mark(obj);
-        if (rb_shape_obj_too_complex(obj)) {
+        if (rb_shape_obj_too_complex_p(obj)) {
             gc_mark_tbl_no_pin((st_table *)RCLASS_FIELDS(obj));
         }
         else {
@@ -3001,7 +3001,7 @@ rb_gc_mark_children(void *objspace, VALUE obj)
       case T_OBJECT: {
         rb_shape_t *shape = RSHAPE(ROBJECT_SHAPE_ID(obj));
 
-        if (rb_shape_obj_too_complex(obj)) {
+        if (rb_shape_obj_too_complex_p(obj)) {
             gc_mark_tbl_no_pin(ROBJECT_FIELDS_HASH(obj));
         }
         else {
@@ -3089,7 +3089,7 @@ rb_gc_obj_optimal_size(VALUE obj)
         return rb_ary_size_as_embedded(obj);
 
       case T_OBJECT:
-        if (rb_shape_obj_too_complex(obj)) {
+        if (rb_shape_obj_too_complex_p(obj)) {
             return sizeof(struct RObject);
         }
         else {
@@ -3331,7 +3331,7 @@ gc_ref_update_object(void *objspace, VALUE v)
 {
     VALUE *ptr = ROBJECT_FIELDS(v);
 
-    if (rb_shape_obj_too_complex(v)) {
+    if (rb_shape_obj_too_complex_p(v)) {
         gc_ref_update_table_values_only(ROBJECT_FIELDS_HASH(v));
         return;
     }
@@ -3629,7 +3629,7 @@ vm_weak_table_foreach_update_weak_value(st_data_t *key, st_data_t *value, st_dat
 static void
 free_gen_fields_tbl(VALUE obj, struct gen_fields_tbl *fields_tbl)
 {
-    if (UNLIKELY(rb_shape_obj_too_complex(obj))) {
+    if (UNLIKELY(rb_shape_obj_too_complex_p(obj))) {
         st_free_table(fields_tbl->as.complex.table);
     }
 
@@ -3724,7 +3724,7 @@ vm_weak_table_gen_fields_foreach(st_data_t key, st_data_t value, st_data_t data)
     if (!iter_data->weak_only) {
         struct gen_fields_tbl *fields_tbl = (struct gen_fields_tbl *)value;
 
-        if (rb_shape_obj_too_complex((VALUE)key)) {
+        if (rb_shape_obj_too_complex_p((VALUE)key)) {
             st_foreach_with_replace(
                 fields_tbl->as.complex.table,
                 vm_weak_table_gen_fields_foreach_too_complex_i,
@@ -3886,7 +3886,7 @@ rb_gc_update_object_references(void *objspace, VALUE obj)
         update_cvc_tbl(objspace, obj);
         update_superclasses(objspace, obj);
 
-        if (rb_shape_obj_too_complex(obj)) {
+        if (rb_shape_obj_too_complex_p(obj)) {
             gc_ref_update_table_values_only(RCLASS_FIELDS_HASH(obj));
         }
         else {
@@ -4573,7 +4573,7 @@ rb_raw_obj_info_buitin_type(char *const buff, const size_t buff_size, const VALU
             }
           case T_OBJECT:
             {
-                if (rb_shape_obj_too_complex(obj)) {
+                if (rb_shape_obj_too_complex_p(obj)) {
                     size_t hash_len = rb_st_table_size(ROBJECT_FIELDS_HASH(obj));
                     APPEND_F("(too_complex) len:%zu", hash_len);
                 }

--- a/gc.c
+++ b/gc.c
@@ -367,7 +367,7 @@ rb_gc_shutdown_call_finalizer_p(VALUE obj)
 uint32_t
 rb_gc_get_shape(VALUE obj)
 {
-    return (uint32_t)RB_OBJ_SHAPE_ID(obj);
+    return (uint32_t)rb_obj_shape_id(obj);
 }
 
 void
@@ -379,7 +379,7 @@ rb_gc_set_shape(VALUE obj, uint32_t shape_id)
 uint32_t
 rb_gc_rebuild_shape(VALUE obj, size_t heap_id)
 {
-    shape_id_t orig_shape_id = RB_OBJ_SHAPE_ID(obj);
+    shape_id_t orig_shape_id = rb_obj_shape_id(obj);
     if (rb_shape_id_too_complex_p(orig_shape_id)) {
         return (uint32_t)orig_shape_id;
     }
@@ -1815,7 +1815,7 @@ static VALUE
 object_id(VALUE obj)
 {
     VALUE id = Qfalse;
-    rb_shape_t *shape = RB_OBJ_SHAPE(obj);
+    rb_shape_t *shape = rb_obj_shape(obj);
     unsigned int lock_lev;
 
     // We could avoid locking if the object isn't shareable

--- a/gc.c
+++ b/gc.c
@@ -384,13 +384,14 @@ rb_gc_rebuild_shape(VALUE obj, size_t heap_id)
         return (uint32_t)orig_shape_id;
     }
 
-    rb_shape_t *orig_shape = rb_shape_get_shape_by_id(orig_shape_id);
-    rb_shape_t *initial_shape = rb_shape_get_shape_by_id((shape_id_t)(heap_id + FIRST_T_OBJECT_SHAPE_ID));
-    rb_shape_t *new_shape = rb_shape_traverse_from_new_root(initial_shape, orig_shape);
+    shape_id_t initial_shape_id = (shape_id_t)(heap_id + FIRST_T_OBJECT_SHAPE_ID);
+    shape_id_t new_shape_id = rb_shape_traverse_from_new_root(initial_shape_id, orig_shape_id);
 
-    if (!new_shape) return 0;
+    if (new_shape_id == INVALID_SHAPE_ID) {
+         return 0;
+     }
 
-    return (uint32_t)rb_shape_id(new_shape);
+    return (uint32_t)new_shape_id;
 }
 
 void rb_vm_update_references(void *ptr);

--- a/gc.c
+++ b/gc.c
@@ -2999,7 +2999,7 @@ rb_gc_mark_children(void *objspace, VALUE obj)
       }
 
       case T_OBJECT: {
-        rb_shape_t *shape = rb_shape_get_shape_by_id(ROBJECT_SHAPE_ID(obj));
+        rb_shape_t *shape = RSHAPE(ROBJECT_SHAPE_ID(obj));
 
         if (rb_shape_obj_too_complex(obj)) {
             gc_mark_tbl_no_pin(ROBJECT_FIELDS_HASH(obj));

--- a/gc.c
+++ b/gc.c
@@ -367,7 +367,7 @@ rb_gc_shutdown_call_finalizer_p(VALUE obj)
 uint32_t
 rb_gc_get_shape(VALUE obj)
 {
-    return (uint32_t)rb_shape_get_shape_id(obj);
+    return (uint32_t)RB_OBJ_SHAPE_ID(obj);
 }
 
 void
@@ -379,7 +379,7 @@ rb_gc_set_shape(VALUE obj, uint32_t shape_id)
 uint32_t
 rb_gc_rebuild_shape(VALUE obj, size_t heap_id)
 {
-    shape_id_t orig_shape_id = rb_shape_get_shape_id(obj);
+    shape_id_t orig_shape_id = RB_OBJ_SHAPE_ID(obj);
     if (rb_shape_id_too_complex_p(orig_shape_id)) {
         return (uint32_t)orig_shape_id;
     }
@@ -1815,7 +1815,7 @@ static VALUE
 object_id(VALUE obj)
 {
     VALUE id = Qfalse;
-    rb_shape_t *shape = rb_shape_get_shape(obj);
+    rb_shape_t *shape = RB_OBJ_SHAPE(obj);
     unsigned int lock_lev;
 
     // We could avoid locking if the object isn't shareable

--- a/internal/class.h
+++ b/internal/class.h
@@ -117,7 +117,7 @@ static inline st_table *
 RCLASS_FIELDS_HASH(VALUE obj)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, RUBY_T_CLASS) || RB_TYPE_P(obj, RUBY_T_MODULE));
-    RUBY_ASSERT(rb_shape_obj_too_complex(obj));
+    RUBY_ASSERT(rb_shape_obj_too_complex_p(obj));
     return (st_table *)RCLASS_FIELDS(obj);
 }
 
@@ -125,7 +125,7 @@ static inline void
 RCLASS_SET_FIELDS_HASH(VALUE obj, const st_table *tbl)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, RUBY_T_CLASS) || RB_TYPE_P(obj, RUBY_T_MODULE));
-    RUBY_ASSERT(rb_shape_obj_too_complex(obj));
+    RUBY_ASSERT(rb_shape_obj_too_complex_p(obj));
     RCLASS_FIELDS(obj) = (VALUE *)tbl;
 }
 
@@ -133,7 +133,7 @@ static inline uint32_t
 RCLASS_FIELDS_COUNT(VALUE obj)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, RUBY_T_CLASS) || RB_TYPE_P(obj, RUBY_T_MODULE));
-    if (rb_shape_obj_too_complex(obj)) {
+    if (rb_shape_obj_too_complex_p(obj)) {
         uint32_t count;
 
         // "Too complex" classes could have their IV hash mutated in

--- a/internal/class.h
+++ b/internal/class.h
@@ -147,7 +147,7 @@ RCLASS_FIELDS_COUNT(VALUE obj)
         return count;
     }
     else {
-        return rb_shape_get_shape_by_id(RCLASS_SHAPE_ID(obj))->next_field_index;
+        return RSHAPE(RCLASS_SHAPE_ID(obj))->next_field_index;
     }
 }
 

--- a/marshal.c
+++ b/marshal.c
@@ -718,15 +718,13 @@ w_ivar_each(VALUE obj, st_index_t num, struct dump_call_arg *arg)
     if (!num) return;
     rb_ivar_foreach(obj, w_obj_each, (st_data_t)&ivarg);
 
-    if (shape_id != rb_shape_get_shape_id(arg->obj)) {
-        rb_shape_t * expected_shape = rb_shape_get_shape_by_id(shape_id);
-        rb_shape_t * actual_shape = rb_shape_get_shape(arg->obj);
-
+    shape_id_t actual_shape_id = rb_shape_get_shape_id(arg->obj);
+    if (shape_id != actual_shape_id) {
         // If the shape tree got _shorter_ then we probably removed an IV
         // If the shape tree got longer, then we probably added an IV.
         // The exception message might not be accurate when someone adds and
         // removes the same number of IVs, but they will still get an exception
-        if (rb_shape_depth(expected_shape) > rb_shape_depth(actual_shape)) {
+        if (rb_shape_depth(shape_id) > rb_shape_depth(rb_shape_get_shape_id(arg->obj))) {
             rb_raise(rb_eRuntimeError, "instance variable removed from %"PRIsVALUE" instance",
                     CLASS_OF(arg->obj));
         }

--- a/marshal.c
+++ b/marshal.c
@@ -713,18 +713,18 @@ has_ivars(VALUE obj, VALUE encname, VALUE *ivobj)
 static void
 w_ivar_each(VALUE obj, st_index_t num, struct dump_call_arg *arg)
 {
-    shape_id_t shape_id = rb_shape_get_shape_id(arg->obj);
+    shape_id_t shape_id = RB_OBJ_SHAPE_ID(arg->obj);
     struct w_ivar_arg ivarg = {arg, num};
     if (!num) return;
     rb_ivar_foreach(obj, w_obj_each, (st_data_t)&ivarg);
 
-    shape_id_t actual_shape_id = rb_shape_get_shape_id(arg->obj);
+    shape_id_t actual_shape_id = RB_OBJ_SHAPE_ID(arg->obj);
     if (shape_id != actual_shape_id) {
         // If the shape tree got _shorter_ then we probably removed an IV
         // If the shape tree got longer, then we probably added an IV.
         // The exception message might not be accurate when someone adds and
         // removes the same number of IVs, but they will still get an exception
-        if (rb_shape_depth(shape_id) > rb_shape_depth(rb_shape_get_shape_id(arg->obj))) {
+        if (rb_shape_depth(shape_id) > rb_shape_depth(RB_OBJ_SHAPE_ID(arg->obj))) {
             rb_raise(rb_eRuntimeError, "instance variable removed from %"PRIsVALUE" instance",
                     CLASS_OF(arg->obj));
         }

--- a/marshal.c
+++ b/marshal.c
@@ -713,18 +713,18 @@ has_ivars(VALUE obj, VALUE encname, VALUE *ivobj)
 static void
 w_ivar_each(VALUE obj, st_index_t num, struct dump_call_arg *arg)
 {
-    shape_id_t shape_id = RB_OBJ_SHAPE_ID(arg->obj);
+    shape_id_t shape_id = rb_obj_shape_id(arg->obj);
     struct w_ivar_arg ivarg = {arg, num};
     if (!num) return;
     rb_ivar_foreach(obj, w_obj_each, (st_data_t)&ivarg);
 
-    shape_id_t actual_shape_id = RB_OBJ_SHAPE_ID(arg->obj);
+    shape_id_t actual_shape_id = rb_obj_shape_id(arg->obj);
     if (shape_id != actual_shape_id) {
         // If the shape tree got _shorter_ then we probably removed an IV
         // If the shape tree got longer, then we probably added an IV.
         // The exception message might not be accurate when someone adds and
         // removes the same number of IVs, but they will still get an exception
-        if (rb_shape_depth(shape_id) > rb_shape_depth(RB_OBJ_SHAPE_ID(arg->obj))) {
+        if (rb_shape_depth(shape_id) > rb_shape_depth(rb_obj_shape_id(arg->obj))) {
             rb_raise(rb_eRuntimeError, "instance variable removed from %"PRIsVALUE" instance",
                     CLASS_OF(arg->obj));
         }

--- a/object.c
+++ b/object.c
@@ -138,7 +138,7 @@ rb_class_allocate_instance(VALUE klass)
     ROBJECT_SET_SHAPE_ID(obj, (shape_id_t)(rb_gc_heap_id_for_size(size) + FIRST_T_OBJECT_SHAPE_ID));
 
 #if RUBY_DEBUG
-    RUBY_ASSERT(!rb_shape_obj_too_complex(obj));
+    RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));
     VALUE *ptr = ROBJECT_FIELDS(obj);
     for (size_t i = 0; i < ROBJECT_FIELDS_CAPACITY(obj); i++) {
         ptr[i] = Qundef;
@@ -520,7 +520,7 @@ rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze)
 
         if (RB_OBJ_FROZEN(obj)) {
             shape_id_t next_shape_id = rb_shape_transition_frozen(clone);
-            if (!rb_shape_obj_too_complex(clone) && rb_shape_id_too_complex_p(next_shape_id)) {
+            if (!rb_shape_obj_too_complex_p(clone) && rb_shape_id_too_complex_p(next_shape_id)) {
                 rb_evict_ivars_to_hash(clone);
             }
             else {
@@ -544,7 +544,7 @@ rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze)
         shape_id_t next_shape_id = rb_shape_transition_frozen(clone);
         // If we're out of shapes, but we want to freeze, then we need to
         // evacuate this clone to a hash
-        if (!rb_shape_obj_too_complex(clone) && rb_shape_id_too_complex_p(next_shape_id)) {
+        if (!rb_shape_obj_too_complex_p(clone) && rb_shape_id_too_complex_p(next_shape_id)) {
             rb_evict_ivars_to_hash(clone);
         }
         else {

--- a/object.c
+++ b/object.c
@@ -519,12 +519,12 @@ rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze)
         }
 
         if (RB_OBJ_FROZEN(obj)) {
-            rb_shape_t *next_shape = rb_shape_transition_shape_frozen(clone);
-            if (!rb_shape_obj_too_complex(clone) && rb_shape_too_complex_p(next_shape)) {
+            shape_id_t next_shape_id = rb_shape_transition_frozen(clone);
+            if (!rb_shape_obj_too_complex(clone) && rb_shape_id_too_complex_p(next_shape_id)) {
                 rb_evict_ivars_to_hash(clone);
             }
             else {
-                rb_shape_set_shape(clone, next_shape);
+                rb_shape_set_shape_id(clone, next_shape_id);
             }
         }
         break;
@@ -541,14 +541,14 @@ rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze)
         argv[1] = freeze_true_hash;
         rb_funcallv_kw(clone, id_init_clone, 2, argv, RB_PASS_KEYWORDS);
         RBASIC(clone)->flags |= FL_FREEZE;
-        rb_shape_t *next_shape = rb_shape_transition_shape_frozen(clone);
+        shape_id_t next_shape_id = rb_shape_transition_frozen(clone);
         // If we're out of shapes, but we want to freeze, then we need to
         // evacuate this clone to a hash
-        if (!rb_shape_obj_too_complex(clone) && rb_shape_too_complex_p(next_shape)) {
+        if (!rb_shape_obj_too_complex(clone) && rb_shape_id_too_complex_p(next_shape_id)) {
             rb_evict_ivars_to_hash(clone);
         }
         else {
-            rb_shape_set_shape(clone, next_shape);
+            rb_shape_set_shape_id(clone, next_shape_id);
         }
         break;
       }

--- a/object.c
+++ b/object.c
@@ -388,12 +388,12 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
         while (src_shape->parent_id != INVALID_SHAPE_ID) {
             if (src_shape->type == SHAPE_IVAR) {
                 while (dest_shape->edge_name != src_shape->edge_name) {
-                    dest_shape = rb_shape_get_shape_by_id(dest_shape->parent_id);
+                    dest_shape = RSHAPE(dest_shape->parent_id);
                 }
 
                 RB_OBJ_WRITE(dest, &dest_buf[dest_shape->next_field_index - 1], src_buf[src_shape->next_field_index - 1]);
             }
-            src_shape = rb_shape_get_shape_by_id(src_shape->parent_id);
+            src_shape = RSHAPE(src_shape->parent_id);
         }
     }
 

--- a/object.c
+++ b/object.c
@@ -132,7 +132,7 @@ rb_class_allocate_instance(VALUE klass)
               T_OBJECT | ROBJECT_EMBED | (RGENGC_WB_PROTECTED_OBJECT ? FL_WB_PROTECTED : 0), size, 0);
     VALUE obj = (VALUE)o;
 
-    RUBY_ASSERT(rb_shape_get_shape(obj)->type == SHAPE_ROOT);
+    RUBY_ASSERT(RB_OBJ_SHAPE(obj)->type == SHAPE_ROOT);
 
     // Set the shape to the specific T_OBJECT shape.
     ROBJECT_SET_SHAPE_ID(obj, (shape_id_t)(rb_gc_heap_id_for_size(size) + FIRST_T_OBJECT_SHAPE_ID));
@@ -335,7 +335,7 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
         return;
     }
 
-    rb_shape_t *src_shape = rb_shape_get_shape(obj);
+    rb_shape_t *src_shape = RB_OBJ_SHAPE(obj);
 
     if (rb_shape_too_complex_p(src_shape)) {
         // obj is TOO_COMPLEX so we can copy its iv_hash
@@ -350,7 +350,7 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
     }
 
     rb_shape_t *shape_to_set_on_dest = src_shape;
-    rb_shape_t *initial_shape = rb_shape_get_shape(dest);
+    rb_shape_t *initial_shape = RB_OBJ_SHAPE(dest);
 
     if (initial_shape->heap_index != src_shape->heap_index || !rb_shape_canonical_p(src_shape)) {
         RUBY_ASSERT(initial_shape->type == SHAPE_T_OBJECT);

--- a/object.c
+++ b/object.c
@@ -132,7 +132,7 @@ rb_class_allocate_instance(VALUE klass)
               T_OBJECT | ROBJECT_EMBED | (RGENGC_WB_PROTECTED_OBJECT ? FL_WB_PROTECTED : 0), size, 0);
     VALUE obj = (VALUE)o;
 
-    RUBY_ASSERT(RB_OBJ_SHAPE(obj)->type == SHAPE_ROOT);
+    RUBY_ASSERT(rb_obj_shape(obj)->type == SHAPE_ROOT);
 
     // Set the shape to the specific T_OBJECT shape.
     ROBJECT_SET_SHAPE_ID(obj, (shape_id_t)(rb_gc_heap_id_for_size(size) + FIRST_T_OBJECT_SHAPE_ID));
@@ -335,7 +335,7 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
         return;
     }
 
-    rb_shape_t *src_shape = RB_OBJ_SHAPE(obj);
+    rb_shape_t *src_shape = rb_obj_shape(obj);
 
     if (rb_shape_too_complex_p(src_shape)) {
         // obj is TOO_COMPLEX so we can copy its iv_hash
@@ -350,7 +350,7 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
     }
 
     rb_shape_t *shape_to_set_on_dest = src_shape;
-    rb_shape_t *initial_shape = RB_OBJ_SHAPE(dest);
+    rb_shape_t *initial_shape = rb_obj_shape(dest);
 
     if (initial_shape->heap_index != src_shape->heap_index || !rb_shape_canonical_p(src_shape)) {
         RUBY_ASSERT(initial_shape->type == SHAPE_T_OBJECT);

--- a/ractor.c
+++ b/ractor.c
@@ -3374,7 +3374,7 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
         struct gen_fields_tbl *fields_tbl;
         rb_ivar_generic_fields_tbl_lookup(obj, &fields_tbl);
 
-        if (UNLIKELY(rb_shape_obj_too_complex(obj))) {
+        if (UNLIKELY(rb_shape_obj_too_complex_p(obj))) {
             struct obj_traverse_replace_callback_data d = {
                 .stop = false,
                 .data = data,
@@ -3412,7 +3412,7 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
 
       case T_OBJECT:
         {
-            if (rb_shape_obj_too_complex(obj)) {
+            if (rb_shape_obj_too_complex_p(obj)) {
                 struct obj_traverse_replace_callback_data d = {
                     .stop = false,
                     .data = data,

--- a/shape.c
+++ b/shape.c
@@ -382,9 +382,10 @@ rb_shape_get_shape_id(VALUE obj)
 }
 
 size_t
-rb_shape_depth(rb_shape_t *shape)
+rb_shape_depth(shape_id_t shape_id)
 {
     size_t depth = 1;
+    rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
 
     while (shape->parent_id != INVALID_SHAPE_ID) {
         depth++;
@@ -1120,8 +1121,9 @@ rb_shape_too_complex_p(rb_shape_t *shape)
 }
 
 size_t
-rb_shape_edges_count(rb_shape_t *shape)
+rb_shape_edges_count(shape_id_t shape_id)
 {
+    rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
     if (shape->edges) {
         if (SINGLE_CHILD_P(shape->edges)) {
             return 1;
@@ -1134,8 +1136,10 @@ rb_shape_edges_count(rb_shape_t *shape)
 }
 
 size_t
-rb_shape_memsize(rb_shape_t *shape)
+rb_shape_memsize(shape_id_t shape_id)
 {
+    rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
+
     size_t memsize = sizeof(rb_shape_t);
     if (shape->edges && !SINGLE_CHILD_P(shape->edges)) {
         memsize += rb_id_table_memsize(shape->edges);
@@ -1244,9 +1248,8 @@ rb_shape_edge_name(rb_shape_t *shape)
 static VALUE
 rb_shape_export_depth(VALUE self)
 {
-    rb_shape_t *shape;
-    shape = rb_shape_get_shape_by_id(NUM2INT(rb_struct_getmember(self, rb_intern("id"))));
-    return SIZET2NUM(rb_shape_depth(shape));
+    shape_id_t shape_id = NUM2INT(rb_struct_getmember(self, rb_intern("id")));
+    return SIZET2NUM(rb_shape_depth(shape_id));
 }
 
 static VALUE

--- a/shape.c
+++ b/shape.c
@@ -1110,7 +1110,7 @@ rb_shape_rebuild_shape(rb_shape_t *initial_shape, rb_shape_t *dest_shape)
 }
 
 RUBY_FUNC_EXPORTED bool
-rb_shape_obj_too_complex(VALUE obj)
+rb_shape_obj_too_complex_p(VALUE obj)
 {
     return rb_shape_too_complex_p(rb_shape_get_shape(obj));
 }

--- a/shape.c
+++ b/shape.c
@@ -645,8 +645,10 @@ remove_shape_recursive(rb_shape_t *shape, ID id, rb_shape_t **removed_shape)
 }
 
 bool
-rb_shape_transition_shape_remove_ivar(VALUE obj, ID id, rb_shape_t *shape, VALUE *removed)
+rb_shape_transition_remove_ivar(VALUE obj, ID id, VALUE *removed)
 {
+    rb_shape_t *shape = rb_shape_get_shape(obj);
+
     if (UNLIKELY(rb_shape_too_complex_p(shape))) {
         return false;
     }

--- a/shape.c
+++ b/shape.c
@@ -757,16 +757,6 @@ rb_shape_has_object_id(rb_shape_t *shape)
     return shape->flags & SHAPE_FL_HAS_OBJECT_ID;
 }
 
-attr_index_t
-rb_shape_object_id_index(rb_shape_t *shape)
-{
-    RUBY_ASSERT(shape->flags & SHAPE_FL_HAS_OBJECT_ID);
-    while (shape->type != SHAPE_OBJ_ID) {
-        shape = rb_shape_get_parent(shape);
-    }
-    return shape->next_field_index - 1;
-}
-
 rb_shape_t *
 rb_shape_object_id_shape(VALUE obj)
 {

--- a/shape.c
+++ b/shape.c
@@ -588,7 +588,7 @@ get_next_shape_internal(rb_shape_t *shape, ID id, enum shape_type shape_type, bo
     return res;
 }
 
-bool
+static inline bool
 rb_shape_frozen_shape_p(rb_shape_t *shape)
 {
     return SHAPE_FL_FROZEN & shape->flags;

--- a/shape.c
+++ b/shape.c
@@ -789,12 +789,20 @@ rb_shape_object_id_shape(VALUE obj)
  * This function is used for assertions where we don't want to increment
  * max_iv_count
  */
-rb_shape_t *
-rb_shape_get_next_iv_shape(rb_shape_t *shape, ID id)
+static inline rb_shape_t *
+shape_get_next_iv_shape(rb_shape_t *shape, ID id)
 {
     RUBY_ASSERT(!is_instance_id(id) || RTEST(rb_sym2str(ID2SYM(id))));
     bool dont_care;
     return get_next_shape_internal(shape, id, SHAPE_IVAR, &dont_care, true);
+}
+
+shape_id_t
+rb_shape_get_next_iv_shape(shape_id_t shape_id, ID id)
+{
+    rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
+    rb_shape_t *next_shape = shape_get_next_iv_shape(shape, id);
+    return rb_shape_id(next_shape);
 }
 
 static inline rb_shape_t *
@@ -1087,7 +1095,7 @@ rb_shape_rebuild_shape(rb_shape_t *initial_shape, rb_shape_t *dest_shape)
 
     switch ((enum shape_type)dest_shape->type) {
       case SHAPE_IVAR:
-        midway_shape = rb_shape_get_next_iv_shape(midway_shape, dest_shape->edge_name);
+        midway_shape = shape_get_next_iv_shape(midway_shape, dest_shape->edge_name);
         break;
       case SHAPE_OBJ_ID:
       case SHAPE_ROOT:

--- a/shape.c
+++ b/shape.c
@@ -358,7 +358,7 @@ shape_id_t rb_generic_shape_id(VALUE obj);
 #endif
 
 RUBY_FUNC_EXPORTED shape_id_t
-rb_shape_get_shape_id(VALUE obj)
+RB_OBJ_SHAPE_ID(VALUE obj)
 {
     if (RB_SPECIAL_CONST_P(obj)) {
         return SPECIAL_CONST_SHAPE_ID;
@@ -395,9 +395,9 @@ rb_shape_depth(shape_id_t shape_id)
 }
 
 rb_shape_t *
-rb_shape_get_shape(VALUE obj)
+RB_OBJ_SHAPE(VALUE obj)
 {
-    return RSHAPE(rb_shape_get_shape_id(obj));
+    return RSHAPE(RB_OBJ_SHAPE_ID(obj));
 }
 
 static rb_shape_t *
@@ -647,7 +647,7 @@ remove_shape_recursive(rb_shape_t *shape, ID id, rb_shape_t **removed_shape)
 bool
 rb_shape_transition_remove_ivar(VALUE obj, ID id, VALUE *removed)
 {
-    rb_shape_t *shape = rb_shape_get_shape(obj);
+    rb_shape_t *shape = RB_OBJ_SHAPE(obj);
 
     if (UNLIKELY(rb_shape_too_complex_p(shape))) {
         return false;
@@ -707,7 +707,7 @@ rb_shape_transition_frozen(VALUE obj)
 {
     RUBY_ASSERT(RB_OBJ_FROZEN(obj));
 
-    shape_id_t shape_id = rb_shape_get_shape_id(obj);
+    shape_id_t shape_id = RB_OBJ_SHAPE_ID(obj);
     if (shape_id == ROOT_SHAPE_ID) {
         return SPECIAL_CONST_SHAPE_ID;
     }
@@ -747,7 +747,7 @@ shape_transition_too_complex(rb_shape_t *original_shape)
 shape_id_t
 rb_shape_transition_complex(VALUE obj)
 {
-    rb_shape_t *original_shape = rb_shape_get_shape(obj);
+    rb_shape_t *original_shape = RB_OBJ_SHAPE(obj);
     return rb_shape_id(shape_transition_too_complex(original_shape));
 }
 
@@ -760,7 +760,7 @@ rb_shape_has_object_id(rb_shape_t *shape)
 rb_shape_t *
 rb_shape_object_id_shape(VALUE obj)
 {
-    rb_shape_t* shape = rb_shape_get_shape(obj);
+    rb_shape_t* shape = RB_OBJ_SHAPE(obj);
     RUBY_ASSERT(shape);
 
     if (shape->flags & SHAPE_FL_HAS_OBJECT_ID) {
@@ -850,13 +850,13 @@ shape_get_next(rb_shape_t *shape, VALUE obj, ID id, bool emit_warnings)
 shape_id_t
 rb_shape_transition_add_ivar(VALUE obj, ID id)
 {
-    return rb_shape_id(shape_get_next(rb_shape_get_shape(obj), obj, id, true));
+    return rb_shape_id(shape_get_next(RB_OBJ_SHAPE(obj), obj, id, true));
 }
 
 shape_id_t
 rb_shape_transition_add_ivar_no_warnings(VALUE obj, ID id)
 {
-    return rb_shape_id(shape_get_next(rb_shape_get_shape(obj), obj, id, false));
+    return rb_shape_id(shape_get_next(RB_OBJ_SHAPE(obj), obj, id, false));
 }
 
 // Same as rb_shape_get_iv_index, but uses a provided valid shape id and index
@@ -1104,7 +1104,7 @@ rb_shape_rebuild_shape(rb_shape_t *initial_shape, rb_shape_t *dest_shape)
 RUBY_FUNC_EXPORTED bool
 rb_shape_obj_too_complex_p(VALUE obj)
 {
-    return rb_shape_too_complex_p(rb_shape_get_shape(obj));
+    return rb_shape_too_complex_p(RB_OBJ_SHAPE(obj));
 }
 
 bool
@@ -1267,7 +1267,7 @@ rb_shape_parent(VALUE self)
 static VALUE
 rb_shape_debug_shape(VALUE self, VALUE obj)
 {
-    return rb_shape_t_to_rb_cShape(rb_shape_get_shape(obj));
+    return rb_shape_t_to_rb_cShape(RB_OBJ_SHAPE(obj));
 }
 
 static VALUE

--- a/shape.c
+++ b/shape.c
@@ -1432,6 +1432,21 @@ Init_default_shapes(void)
 }
 
 void
+rb_shape_free_all(void)
+{
+    rb_shape_t *cursor = rb_shape_get_root_shape();
+    rb_shape_t *end = rb_shape_get_shape_by_id(GET_SHAPE_TREE()->next_shape_id);
+    while (cursor < end) {
+        if (cursor->edges && !SINGLE_CHILD_P(cursor->edges)) {
+            rb_id_table_free(cursor->edges);
+        }
+        cursor++;
+    }
+
+    xfree(GET_SHAPE_TREE());
+}
+
+void
 Init_shape(void)
 {
 #if SHAPE_DEBUG

--- a/shape.c
+++ b/shape.c
@@ -700,28 +700,28 @@ rb_shape_transition_shape_remove_ivar(VALUE obj, ID id, rb_shape_t *shape, VALUE
     return true;
 }
 
-rb_shape_t *
-rb_shape_transition_shape_frozen(VALUE obj)
+shape_id_t
+rb_shape_transition_frozen(VALUE obj)
 {
-    rb_shape_t *shape = rb_shape_get_shape(obj);
-    RUBY_ASSERT(shape);
     RUBY_ASSERT(RB_OBJ_FROZEN(obj));
 
-    if (rb_shape_frozen_shape_p(shape)) {
-        return shape;
+    shape_id_t shape_id = rb_shape_get_shape_id(obj);
+    if (shape_id == ROOT_SHAPE_ID) {
+        return SPECIAL_CONST_SHAPE_ID;
     }
 
-    rb_shape_t *next_shape;
+    rb_shape_t *shape = RSHAPE(shape_id);
+    RUBY_ASSERT(shape);
 
-    if (shape == rb_shape_get_root_shape()) {
-        return RSHAPE(SPECIAL_CONST_SHAPE_ID);
+    if (rb_shape_frozen_shape_p(shape)) {
+        return shape_id;
     }
 
     bool dont_care;
-    next_shape = get_next_shape_internal(shape, id_frozen, SHAPE_FROZEN, &dont_care, true);
+    rb_shape_t *next_shape = get_next_shape_internal(shape, id_frozen, SHAPE_FROZEN, &dont_care, true);
 
     RUBY_ASSERT(next_shape);
-    return next_shape;
+    return rb_shape_id(next_shape);
 }
 
 static rb_shape_t *

--- a/shape.c
+++ b/shape.c
@@ -857,16 +857,16 @@ shape_get_next(rb_shape_t *shape, VALUE obj, ID id, bool emit_warnings)
     return new_shape;
 }
 
-rb_shape_t *
-rb_shape_get_next(rb_shape_t *shape, VALUE obj, ID id)
+shape_id_t
+rb_shape_transition_add_ivar(VALUE obj, ID id)
 {
-    return shape_get_next(shape, obj, id, true);
+    return rb_shape_id(shape_get_next(rb_shape_get_shape(obj), obj, id, true));
 }
 
-rb_shape_t *
-rb_shape_get_next_no_warnings(rb_shape_t *shape, VALUE obj, ID id)
+shape_id_t
+rb_shape_transition_add_ivar_no_warnings(VALUE obj, ID id)
 {
-    return shape_get_next(shape, obj, id, false);
+    return rb_shape_id(shape_get_next(rb_shape_get_shape(obj), obj, id, false));
 }
 
 // Same as rb_shape_get_iv_index, but uses a provided valid shape id and index

--- a/shape.c
+++ b/shape.c
@@ -332,7 +332,7 @@ void
 rb_shape_each_shape(each_shape_callback callback, void *data)
 {
     rb_shape_t *cursor = rb_shape_get_root_shape();
-    rb_shape_t *end = rb_shape_get_shape_by_id(GET_SHAPE_TREE()->next_shape_id);
+    rb_shape_t *end = RSHAPE(GET_SHAPE_TREE()->next_shape_id);
     while (cursor < end) {
         callback(cursor, data);
         cursor += 1;
@@ -340,18 +340,17 @@ rb_shape_each_shape(each_shape_callback callback, void *data)
 }
 
 RUBY_FUNC_EXPORTED rb_shape_t *
-rb_shape_get_shape_by_id(shape_id_t shape_id)
+RSHAPE(shape_id_t shape_id)
 {
     RUBY_ASSERT(shape_id != INVALID_SHAPE_ID);
 
-    rb_shape_t *shape = &GET_SHAPE_TREE()->shape_list[shape_id];
-    return shape;
+    return &GET_SHAPE_TREE()->shape_list[shape_id];
 }
 
 rb_shape_t *
 rb_shape_get_parent(rb_shape_t *shape)
 {
-    return rb_shape_get_shape_by_id(shape->parent_id);
+    return RSHAPE(shape->parent_id);
 }
 
 #if !SHAPE_IN_BASIC_FLAGS
@@ -385,7 +384,7 @@ size_t
 rb_shape_depth(shape_id_t shape_id)
 {
     size_t depth = 1;
-    rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
+    rb_shape_t *shape = RSHAPE(shape_id);
 
     while (shape->parent_id != INVALID_SHAPE_ID) {
         depth++;
@@ -398,7 +397,7 @@ rb_shape_depth(shape_id_t shape_id)
 rb_shape_t *
 rb_shape_get_shape(VALUE obj)
 {
-    return rb_shape_get_shape_by_id(rb_shape_get_shape_id(obj));
+    return RSHAPE(rb_shape_get_shape_id(obj));
 }
 
 static rb_shape_t *
@@ -715,7 +714,7 @@ rb_shape_transition_shape_frozen(VALUE obj)
     rb_shape_t *next_shape;
 
     if (shape == rb_shape_get_root_shape()) {
-        return rb_shape_get_shape_by_id(SPECIAL_CONST_SHAPE_ID);
+        return RSHAPE(SPECIAL_CONST_SHAPE_ID);
     }
 
     bool dont_care;
@@ -728,7 +727,7 @@ rb_shape_transition_shape_frozen(VALUE obj)
 static rb_shape_t *
 shape_transition_too_complex(rb_shape_t *original_shape)
 {
-    rb_shape_t *next_shape = rb_shape_get_shape_by_id(ROOT_TOO_COMPLEX_SHAPE_ID);
+    rb_shape_t *next_shape = RSHAPE(ROOT_TOO_COMPLEX_SHAPE_ID);
 
     if (original_shape->flags & SHAPE_FL_FROZEN) {
         bool dont_care;
@@ -800,7 +799,7 @@ shape_get_next_iv_shape(rb_shape_t *shape, ID id)
 shape_id_t
 rb_shape_get_next_iv_shape(shape_id_t shape_id, ID id)
 {
-    rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
+    rb_shape_t *shape = RSHAPE(shape_id);
     rb_shape_t *next_shape = shape_get_next_iv_shape(shape, id);
     return rb_shape_id(next_shape);
 }
@@ -874,7 +873,7 @@ bool
 rb_shape_get_iv_index_with_hint(shape_id_t shape_id, ID id, attr_index_t *value, shape_id_t *shape_id_hint)
 {
     attr_index_t index_hint = *value;
-    rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
+    rb_shape_t *shape = RSHAPE(shape_id);
     rb_shape_t *initial_shape = shape;
 
     if (*shape_id_hint == INVALID_SHAPE_ID) {
@@ -882,7 +881,7 @@ rb_shape_get_iv_index_with_hint(shape_id_t shape_id, ID id, attr_index_t *value,
         return rb_shape_get_iv_index(shape, id, value);
     }
 
-    rb_shape_t *shape_hint = rb_shape_get_shape_by_id(*shape_id_hint);
+    rb_shape_t *shape_hint = RSHAPE(*shape_id_hint);
 
     // We assume it's likely shape_id_hint and shape_id have a close common
     // ancestor, so we check up to ANCESTOR_SEARCH_MAX_DEPTH ancestors before
@@ -1065,8 +1064,8 @@ shape_traverse_from_new_root(rb_shape_t *initial_shape, rb_shape_t *dest_shape)
 shape_id_t
 rb_shape_traverse_from_new_root(shape_id_t initial_shape_id, shape_id_t dest_shape_id)
 {
-    rb_shape_t *initial_shape = rb_shape_get_shape_by_id(initial_shape_id);
-    rb_shape_t *dest_shape = rb_shape_get_shape_by_id(dest_shape_id);
+    rb_shape_t *initial_shape = RSHAPE(initial_shape_id);
+    rb_shape_t *dest_shape = RSHAPE(dest_shape_id);
     return rb_shape_id(shape_traverse_from_new_root(initial_shape, dest_shape));
 }
 
@@ -1119,7 +1118,7 @@ rb_shape_obj_too_complex(VALUE obj)
 bool
 rb_shape_id_too_complex_p(shape_id_t shape_id)
 {
-    return rb_shape_too_complex_p(rb_shape_get_shape_by_id(shape_id));
+    return rb_shape_too_complex_p(RSHAPE(shape_id));
 }
 
 bool
@@ -1131,7 +1130,7 @@ rb_shape_too_complex_p(rb_shape_t *shape)
 size_t
 rb_shape_edges_count(shape_id_t shape_id)
 {
-    rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
+    rb_shape_t *shape = RSHAPE(shape_id);
     if (shape->edges) {
         if (SINGLE_CHILD_P(shape->edges)) {
             return 1;
@@ -1146,7 +1145,7 @@ rb_shape_edges_count(shape_id_t shape_id)
 size_t
 rb_shape_memsize(shape_id_t shape_id)
 {
-    rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
+    rb_shape_t *shape = RSHAPE(shape_id);
 
     size_t memsize = sizeof(rb_shape_t);
     if (shape->edges && !SINGLE_CHILD_P(shape->edges)) {
@@ -1164,7 +1163,7 @@ static VALUE
 shape_too_complex(VALUE self)
 {
     shape_id_t shape_id = NUM2INT(rb_struct_getmember(self, rb_intern("id")));
-    rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
+    rb_shape_t *shape = RSHAPE(shape_id);
     return RBOOL(rb_shape_too_complex_p(shape));
 }
 
@@ -1172,7 +1171,7 @@ static VALUE
 shape_frozen(VALUE self)
 {
     shape_id_t shape_id = NUM2INT(rb_struct_getmember(self, rb_intern("id")));
-    rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
+    rb_shape_t *shape = RSHAPE(shape_id);
     return RBOOL(rb_shape_frozen_shape_p(shape));
 }
 
@@ -1180,7 +1179,7 @@ static VALUE
 shape_has_object_id(VALUE self)
 {
     shape_id_t shape_id = NUM2INT(rb_struct_getmember(self, rb_intern("id")));
-    rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
+    rb_shape_t *shape = RSHAPE(shape_id);
     return RBOOL(rb_shape_has_object_id(shape));
 }
 
@@ -1224,7 +1223,7 @@ rb_shape_edges(VALUE self)
 {
     rb_shape_t *shape;
 
-    shape = rb_shape_get_shape_by_id(NUM2INT(rb_struct_getmember(self, rb_intern("id"))));
+    shape = RSHAPE(NUM2INT(rb_struct_getmember(self, rb_intern("id"))));
 
     VALUE hash = rb_hash_new();
 
@@ -1264,7 +1263,7 @@ static VALUE
 rb_shape_parent(VALUE self)
 {
     rb_shape_t *shape;
-    shape = rb_shape_get_shape_by_id(NUM2INT(rb_struct_getmember(self, rb_intern("id"))));
+    shape = RSHAPE(NUM2INT(rb_struct_getmember(self, rb_intern("id"))));
     if (shape->parent_id != INVALID_SHAPE_ID) {
         return rb_shape_t_to_rb_cShape(rb_shape_get_parent(shape));
     }
@@ -1353,7 +1352,7 @@ rb_shape_find_by_id(VALUE mod, VALUE id)
     if (shape_id >= GET_SHAPE_TREE()->next_shape_id) {
         rb_raise(rb_eArgError, "Shape ID %d is out of bounds\n", shape_id);
     }
-    return rb_shape_t_to_rb_cShape(rb_shape_get_shape_by_id(shape_id));
+    return rb_shape_t_to_rb_cShape(RSHAPE(shape_id));
 }
 #endif
 
@@ -1457,7 +1456,7 @@ void
 rb_shape_free_all(void)
 {
     rb_shape_t *cursor = rb_shape_get_root_shape();
-    rb_shape_t *end = rb_shape_get_shape_by_id(GET_SHAPE_TREE()->next_shape_id);
+    rb_shape_t *end = RSHAPE(GET_SHAPE_TREE()->next_shape_id);
     while (cursor < end) {
         if (cursor->edges && !SINGLE_CHILD_P(cursor->edges)) {
             rb_id_table_free(cursor->edges);

--- a/shape.c
+++ b/shape.c
@@ -742,11 +742,11 @@ shape_transition_too_complex(rb_shape_t *original_shape)
     return next_shape;
 }
 
-rb_shape_t *
-rb_shape_transition_shape_too_complex(VALUE obj)
+shape_id_t
+rb_shape_transition_complex(VALUE obj)
 {
     rb_shape_t *original_shape = rb_shape_get_shape(obj);
-    return shape_transition_too_complex(original_shape);
+    return rb_shape_id(shape_transition_too_complex(original_shape));
 }
 
 bool

--- a/shape.h
+++ b/shape.h
@@ -167,7 +167,7 @@ rb_shape_t *rb_shape_get_shape(VALUE obj);
 bool rb_shape_frozen_shape_p(rb_shape_t *shape);
 shape_id_t rb_shape_transition_frozen(VALUE obj);
 shape_id_t rb_shape_transition_complex(VALUE obj);
-bool rb_shape_transition_shape_remove_ivar(VALUE obj, ID id, rb_shape_t *shape, VALUE *removed);
+bool rb_shape_transition_remove_ivar(VALUE obj, ID id, VALUE *removed);
 rb_shape_t *rb_shape_get_next(rb_shape_t *shape, VALUE obj, ID id);
 rb_shape_t *rb_shape_get_next_no_warnings(rb_shape_t *shape, VALUE obj, ID id);
 rb_shape_t *rb_shape_object_id_shape(VALUE obj);

--- a/shape.h
+++ b/shape.h
@@ -232,7 +232,7 @@ RBASIC_FIELDS_COUNT(VALUE obj)
     return rb_shape_get_shape_by_id(rb_shape_get_shape_id(obj))->next_field_index;
 }
 
-rb_shape_t *rb_shape_traverse_from_new_root(rb_shape_t *initial_shape, rb_shape_t *orig_shape);
+shape_id_t rb_shape_traverse_from_new_root(shape_id_t initial_shape_id, shape_id_t orig_shape_id);
 
 bool rb_shape_set_shape_id(VALUE obj, shape_id_t shape_id);
 

--- a/shape.h
+++ b/shape.h
@@ -242,8 +242,6 @@ rb_shape_obj_has_id(VALUE obj)
     return rb_shape_has_object_id(rb_shape_get_shape(obj));
 }
 
-VALUE rb_obj_debug_shape(VALUE self, VALUE obj);
-
 // For ext/objspace
 RUBY_SYMBOL_EXPORT_BEGIN
 typedef void each_shape_callback(rb_shape_t *shape, void *data);

--- a/shape.h
+++ b/shape.h
@@ -25,14 +25,13 @@ typedef uint32_t redblack_id_t;
 
 #define SHAPE_MAX_FIELDS (attr_index_t)(-1)
 
-# define SHAPE_MASK (((uintptr_t)1 << SHAPE_ID_NUM_BITS) - 1)
 # define SHAPE_FLAG_MASK (((VALUE)-1) >> SHAPE_ID_NUM_BITS)
 
 # define SHAPE_FLAG_SHIFT ((SIZEOF_VALUE * 8) - SHAPE_ID_NUM_BITS)
 
 # define SHAPE_MAX_VARIATIONS 8
 
-# define INVALID_SHAPE_ID SHAPE_MASK
+# define INVALID_SHAPE_ID (((uintptr_t)1 << SHAPE_ID_NUM_BITS) - 1)
 
 #define ROOT_SHAPE_ID               0x0
 #define SPECIAL_CONST_SHAPE_ID      0x1
@@ -95,7 +94,7 @@ static inline shape_id_t
 get_shape_id_from_flags(VALUE obj)
 {
     RUBY_ASSERT(!RB_SPECIAL_CONST_P(obj));
-    return (shape_id_t)(SHAPE_MASK & ((RBASIC(obj)->flags) >> SHAPE_FLAG_SHIFT));
+    return (shape_id_t)((RBASIC(obj)->flags) >> SHAPE_FLAG_SHIFT);
 }
 
 static inline void

--- a/shape.h
+++ b/shape.h
@@ -156,7 +156,7 @@ rb_shape_t *rb_shape_get_parent(rb_shape_t *shape);
 
 RUBY_FUNC_EXPORTED rb_shape_t *rb_shape_get_shape_by_id(shape_id_t shape_id);
 RUBY_FUNC_EXPORTED shape_id_t rb_shape_get_shape_id(VALUE obj);
-rb_shape_t *rb_shape_get_next_iv_shape(rb_shape_t *shape, ID id);
+shape_id_t rb_shape_get_next_iv_shape(shape_id_t shape_id, ID id);
 bool rb_shape_get_iv_index(rb_shape_t *shape, ID id, attr_index_t *value);
 bool rb_shape_get_iv_index_with_hint(shape_id_t shape_id, ID id, attr_index_t *value, shape_id_t *shape_id_hint);
 RUBY_FUNC_EXPORTED bool rb_shape_obj_too_complex(VALUE obj);

--- a/shape.h
+++ b/shape.h
@@ -162,7 +162,6 @@ bool rb_shape_id_too_complex_p(shape_id_t shape_id);
 
 void rb_shape_set_shape(VALUE obj, rb_shape_t *shape);
 rb_shape_t *RB_OBJ_SHAPE(VALUE obj);
-bool rb_shape_frozen_shape_p(rb_shape_t *shape);
 shape_id_t rb_shape_transition_frozen(VALUE obj);
 shape_id_t rb_shape_transition_complex(VALUE obj);
 bool rb_shape_transition_remove_ivar(VALUE obj, ID id, VALUE *removed);

--- a/shape.h
+++ b/shape.h
@@ -150,7 +150,6 @@ RCLASS_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
     set_shape_id_in_flags(obj, shape_id);
 }
 
-rb_shape_t *rb_shape_get_root_shape(void);
 int32_t rb_shape_id_offset(void);
 
 rb_shape_t *rb_shape_get_parent(rb_shape_t *shape);

--- a/shape.h
+++ b/shape.h
@@ -149,10 +149,12 @@ RCLASS_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
     set_shape_id_in_flags(obj, shape_id);
 }
 
+#define RSHAPE rb_shape_lookup
+
 int32_t rb_shape_id_offset(void);
 
-RUBY_FUNC_EXPORTED rb_shape_t *RSHAPE(shape_id_t shape_id);
-RUBY_FUNC_EXPORTED shape_id_t RB_OBJ_SHAPE_ID(VALUE obj);
+RUBY_FUNC_EXPORTED rb_shape_t *rb_shape_lookup(shape_id_t shape_id);
+RUBY_FUNC_EXPORTED shape_id_t rb_obj_shape_id(VALUE obj);
 shape_id_t rb_shape_get_next_iv_shape(shape_id_t shape_id, ID id);
 bool rb_shape_get_iv_index(rb_shape_t *shape, ID id, attr_index_t *value);
 bool rb_shape_get_iv_index_with_hint(shape_id_t shape_id, ID id, attr_index_t *value, shape_id_t *shape_id_hint);
@@ -161,7 +163,6 @@ bool rb_shape_too_complex_p(rb_shape_t *shape);
 bool rb_shape_id_too_complex_p(shape_id_t shape_id);
 
 void rb_shape_set_shape(VALUE obj, rb_shape_t *shape);
-rb_shape_t *RB_OBJ_SHAPE(VALUE obj);
 shape_id_t rb_shape_transition_frozen(VALUE obj);
 shape_id_t rb_shape_transition_complex(VALUE obj);
 bool rb_shape_transition_remove_ivar(VALUE obj, ID id, VALUE *removed);
@@ -173,6 +174,12 @@ bool rb_shape_has_object_id(rb_shape_t *shape);
 void rb_shape_free_all(void);
 
 rb_shape_t *rb_shape_rebuild_shape(rb_shape_t *initial_shape, rb_shape_t *dest_shape);
+
+static inline rb_shape_t *
+rb_obj_shape(VALUE obj)
+{
+    return RSHAPE(rb_obj_shape_id(obj));
+}
 
 static inline bool
 rb_shape_canonical_p(rb_shape_t *shape)
@@ -224,7 +231,7 @@ ROBJECT_FIELDS_COUNT(VALUE obj)
 static inline uint32_t
 RBASIC_FIELDS_COUNT(VALUE obj)
 {
-    return RSHAPE(RB_OBJ_SHAPE_ID(obj))->next_field_index;
+    return RSHAPE(rb_obj_shape_id(obj))->next_field_index;
 }
 
 shape_id_t rb_shape_traverse_from_new_root(shape_id_t initial_shape_id, shape_id_t orig_shape_id);
@@ -234,7 +241,7 @@ bool rb_shape_set_shape_id(VALUE obj, shape_id_t shape_id);
 static inline bool
 rb_shape_obj_has_id(VALUE obj)
 {
-    return rb_shape_has_object_id(RB_OBJ_SHAPE(obj));
+    return rb_shape_has_object_id(rb_obj_shape(obj));
 }
 
 // For ext/objspace

--- a/shape.h
+++ b/shape.h
@@ -154,7 +154,7 @@ int32_t rb_shape_id_offset(void);
 
 rb_shape_t *rb_shape_get_parent(rb_shape_t *shape);
 
-RUBY_FUNC_EXPORTED rb_shape_t *rb_shape_get_shape_by_id(shape_id_t shape_id);
+RUBY_FUNC_EXPORTED rb_shape_t *RSHAPE(shape_id_t shape_id);
 RUBY_FUNC_EXPORTED shape_id_t rb_shape_get_shape_id(VALUE obj);
 shape_id_t rb_shape_get_next_iv_shape(shape_id_t shape_id, ID id);
 bool rb_shape_get_iv_index(rb_shape_t *shape, ID id, attr_index_t *value);
@@ -191,7 +191,7 @@ ROBJECT_FIELDS_CAPACITY(VALUE obj)
     // Asking for capacity doesn't make sense when the object is using
     // a hash table for storing instance variables
     RUBY_ASSERT(!rb_shape_obj_too_complex(obj));
-    return rb_shape_get_shape_by_id(ROBJECT_SHAPE_ID(obj))->capacity;
+    return RSHAPE(ROBJECT_SHAPE_ID(obj))->capacity;
 }
 
 static inline st_table *
@@ -221,14 +221,14 @@ ROBJECT_FIELDS_COUNT(VALUE obj)
     else {
         RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
         RUBY_ASSERT(!rb_shape_obj_too_complex(obj));
-        return rb_shape_get_shape_by_id(ROBJECT_SHAPE_ID(obj))->next_field_index;
+        return RSHAPE(ROBJECT_SHAPE_ID(obj))->next_field_index;
     }
 }
 
 static inline uint32_t
 RBASIC_FIELDS_COUNT(VALUE obj)
 {
-    return rb_shape_get_shape_by_id(rb_shape_get_shape_id(obj))->next_field_index;
+    return RSHAPE(rb_shape_get_shape_id(obj))->next_field_index;
 }
 
 shape_id_t rb_shape_traverse_from_new_root(shape_id_t initial_shape_id, shape_id_t orig_shape_id);

--- a/shape.h
+++ b/shape.h
@@ -158,7 +158,7 @@ RUBY_FUNC_EXPORTED shape_id_t rb_shape_get_shape_id(VALUE obj);
 shape_id_t rb_shape_get_next_iv_shape(shape_id_t shape_id, ID id);
 bool rb_shape_get_iv_index(rb_shape_t *shape, ID id, attr_index_t *value);
 bool rb_shape_get_iv_index_with_hint(shape_id_t shape_id, ID id, attr_index_t *value, shape_id_t *shape_id_hint);
-RUBY_FUNC_EXPORTED bool rb_shape_obj_too_complex(VALUE obj);
+RUBY_FUNC_EXPORTED bool rb_shape_obj_too_complex_p(VALUE obj);
 bool rb_shape_too_complex_p(rb_shape_t *shape);
 bool rb_shape_id_too_complex_p(shape_id_t shape_id);
 
@@ -189,7 +189,7 @@ ROBJECT_FIELDS_CAPACITY(VALUE obj)
     RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
     // Asking for capacity doesn't make sense when the object is using
     // a hash table for storing instance variables
-    RUBY_ASSERT(!rb_shape_obj_too_complex(obj));
+    RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));
     return RSHAPE(ROBJECT_SHAPE_ID(obj))->capacity;
 }
 
@@ -197,7 +197,7 @@ static inline st_table *
 ROBJECT_FIELDS_HASH(VALUE obj)
 {
     RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
-    RUBY_ASSERT(rb_shape_obj_too_complex(obj));
+    RUBY_ASSERT(rb_shape_obj_too_complex_p(obj));
     return (st_table *)ROBJECT(obj)->as.heap.fields;
 }
 
@@ -205,7 +205,7 @@ static inline void
 ROBJECT_SET_FIELDS_HASH(VALUE obj, const st_table *tbl)
 {
     RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
-    RUBY_ASSERT(rb_shape_obj_too_complex(obj));
+    RUBY_ASSERT(rb_shape_obj_too_complex_p(obj));
     ROBJECT(obj)->as.heap.fields = (VALUE *)tbl;
 }
 
@@ -214,12 +214,12 @@ size_t rb_id_table_size(const struct rb_id_table *tbl);
 static inline uint32_t
 ROBJECT_FIELDS_COUNT(VALUE obj)
 {
-    if (rb_shape_obj_too_complex(obj)) {
+    if (rb_shape_obj_too_complex_p(obj)) {
         return (uint32_t)rb_st_table_size(ROBJECT_FIELDS_HASH(obj));
     }
     else {
         RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
-        RUBY_ASSERT(!rb_shape_obj_too_complex(obj));
+        RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));
         return RSHAPE(ROBJECT_SHAPE_ID(obj))->next_field_index;
     }
 }

--- a/shape.h
+++ b/shape.h
@@ -168,8 +168,9 @@ bool rb_shape_frozen_shape_p(rb_shape_t *shape);
 shape_id_t rb_shape_transition_frozen(VALUE obj);
 shape_id_t rb_shape_transition_complex(VALUE obj);
 bool rb_shape_transition_remove_ivar(VALUE obj, ID id, VALUE *removed);
-rb_shape_t *rb_shape_get_next(rb_shape_t *shape, VALUE obj, ID id);
-rb_shape_t *rb_shape_get_next_no_warnings(rb_shape_t *shape, VALUE obj, ID id);
+shape_id_t rb_shape_transition_add_ivar(VALUE obj, ID id);
+shape_id_t rb_shape_transition_add_ivar_no_warnings(VALUE obj, ID id);
+
 rb_shape_t *rb_shape_object_id_shape(VALUE obj);
 bool rb_shape_has_object_id(rb_shape_t *shape);
 attr_index_t rb_shape_object_id_index(rb_shape_t *shape);

--- a/shape.h
+++ b/shape.h
@@ -154,7 +154,7 @@ int32_t rb_shape_id_offset(void);
 rb_shape_t *rb_shape_get_parent(rb_shape_t *shape);
 
 RUBY_FUNC_EXPORTED rb_shape_t *RSHAPE(shape_id_t shape_id);
-RUBY_FUNC_EXPORTED shape_id_t rb_shape_get_shape_id(VALUE obj);
+RUBY_FUNC_EXPORTED shape_id_t RB_OBJ_SHAPE_ID(VALUE obj);
 shape_id_t rb_shape_get_next_iv_shape(shape_id_t shape_id, ID id);
 bool rb_shape_get_iv_index(rb_shape_t *shape, ID id, attr_index_t *value);
 bool rb_shape_get_iv_index_with_hint(shape_id_t shape_id, ID id, attr_index_t *value, shape_id_t *shape_id_hint);
@@ -163,7 +163,7 @@ bool rb_shape_too_complex_p(rb_shape_t *shape);
 bool rb_shape_id_too_complex_p(shape_id_t shape_id);
 
 void rb_shape_set_shape(VALUE obj, rb_shape_t *shape);
-rb_shape_t *rb_shape_get_shape(VALUE obj);
+rb_shape_t *RB_OBJ_SHAPE(VALUE obj);
 bool rb_shape_frozen_shape_p(rb_shape_t *shape);
 shape_id_t rb_shape_transition_frozen(VALUE obj);
 shape_id_t rb_shape_transition_complex(VALUE obj);
@@ -227,7 +227,7 @@ ROBJECT_FIELDS_COUNT(VALUE obj)
 static inline uint32_t
 RBASIC_FIELDS_COUNT(VALUE obj)
 {
-    return RSHAPE(rb_shape_get_shape_id(obj))->next_field_index;
+    return RSHAPE(RB_OBJ_SHAPE_ID(obj))->next_field_index;
 }
 
 shape_id_t rb_shape_traverse_from_new_root(shape_id_t initial_shape_id, shape_id_t orig_shape_id);
@@ -237,7 +237,7 @@ bool rb_shape_set_shape_id(VALUE obj, shape_id_t shape_id);
 static inline bool
 rb_shape_obj_has_id(VALUE obj)
 {
-    return rb_shape_has_object_id(rb_shape_get_shape(obj));
+    return rb_shape_has_object_id(RB_OBJ_SHAPE(obj));
 }
 
 // For ext/objspace

--- a/shape.h
+++ b/shape.h
@@ -166,7 +166,7 @@ void rb_shape_set_shape(VALUE obj, rb_shape_t *shape);
 rb_shape_t *rb_shape_get_shape(VALUE obj);
 bool rb_shape_frozen_shape_p(rb_shape_t *shape);
 shape_id_t rb_shape_transition_frozen(VALUE obj);
-rb_shape_t *rb_shape_transition_shape_too_complex(VALUE obj);
+shape_id_t rb_shape_transition_complex(VALUE obj);
 bool rb_shape_transition_shape_remove_ivar(VALUE obj, ID id, rb_shape_t *shape, VALUE *removed);
 rb_shape_t *rb_shape_get_next(rb_shape_t *shape, VALUE obj, ID id);
 rb_shape_t *rb_shape_get_next_no_warnings(rb_shape_t *shape, VALUE obj, ID id);

--- a/shape.h
+++ b/shape.h
@@ -151,8 +151,6 @@ RCLASS_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
 
 int32_t rb_shape_id_offset(void);
 
-rb_shape_t *rb_shape_get_parent(rb_shape_t *shape);
-
 RUBY_FUNC_EXPORTED rb_shape_t *RSHAPE(shape_id_t shape_id);
 RUBY_FUNC_EXPORTED shape_id_t RB_OBJ_SHAPE_ID(VALUE obj);
 shape_id_t rb_shape_get_next_iv_shape(shape_id_t shape_id, ID id);

--- a/shape.h
+++ b/shape.h
@@ -248,9 +248,9 @@ VALUE rb_obj_debug_shape(VALUE self, VALUE obj);
 RUBY_SYMBOL_EXPORT_BEGIN
 typedef void each_shape_callback(rb_shape_t *shape, void *data);
 void rb_shape_each_shape(each_shape_callback callback, void *data);
-size_t rb_shape_memsize(rb_shape_t *shape);
-size_t rb_shape_edges_count(rb_shape_t *shape);
-size_t rb_shape_depth(rb_shape_t *shape);
+size_t rb_shape_memsize(shape_id_t shape);
+size_t rb_shape_edges_count(shape_id_t shape_id);
+size_t rb_shape_depth(shape_id_t shape_id);
 shape_id_t rb_shape_id(rb_shape_t *shape);
 RUBY_SYMBOL_EXPORT_END
 

--- a/shape.h
+++ b/shape.h
@@ -173,7 +173,6 @@ shape_id_t rb_shape_transition_add_ivar_no_warnings(VALUE obj, ID id);
 
 rb_shape_t *rb_shape_object_id_shape(VALUE obj);
 bool rb_shape_has_object_id(rb_shape_t *shape);
-attr_index_t rb_shape_object_id_index(rb_shape_t *shape);
 void rb_shape_free_all(void);
 
 rb_shape_t *rb_shape_rebuild_shape(rb_shape_t *initial_shape, rb_shape_t *dest_shape);

--- a/shape.h
+++ b/shape.h
@@ -165,7 +165,7 @@ bool rb_shape_id_too_complex_p(shape_id_t shape_id);
 void rb_shape_set_shape(VALUE obj, rb_shape_t *shape);
 rb_shape_t *rb_shape_get_shape(VALUE obj);
 bool rb_shape_frozen_shape_p(rb_shape_t *shape);
-rb_shape_t *rb_shape_transition_shape_frozen(VALUE obj);
+shape_id_t rb_shape_transition_frozen(VALUE obj);
 rb_shape_t *rb_shape_transition_shape_too_complex(VALUE obj);
 bool rb_shape_transition_shape_remove_ivar(VALUE obj, ID id, rb_shape_t *shape, VALUE *removed);
 rb_shape_t *rb_shape_get_next(rb_shape_t *shape, VALUE obj, ID id);

--- a/shape.h
+++ b/shape.h
@@ -175,6 +175,7 @@ rb_shape_t *rb_shape_get_next_no_warnings(rb_shape_t *shape, VALUE obj, ID id);
 rb_shape_t *rb_shape_object_id_shape(VALUE obj);
 bool rb_shape_has_object_id(rb_shape_t *shape);
 attr_index_t rb_shape_object_id_index(rb_shape_t *shape);
+void rb_shape_free_all(void);
 
 rb_shape_t *rb_shape_rebuild_shape(rb_shape_t *initial_shape, rb_shape_t *dest_shape);
 

--- a/variable.c
+++ b/variable.c
@@ -1511,7 +1511,7 @@ static void
 obj_transition_too_complex(VALUE obj, st_table *table)
 {
     RUBY_ASSERT(!rb_shape_obj_too_complex(obj));
-    shape_id_t shape_id = rb_shape_id(rb_shape_transition_shape_too_complex(obj));
+    shape_id_t shape_id = rb_shape_transition_complex(obj);
 
     VALUE *old_fields = NULL;
 
@@ -1803,7 +1803,7 @@ generic_ivar_set_too_complex_table(VALUE obj, void *data)
     if (!rb_gen_fields_tbl_get(obj, 0, &fields_tbl)) {
         fields_tbl = xmalloc(sizeof(struct gen_fields_tbl));
 #if !SHAPE_IN_BASIC_FLAGS
-        fields_tbl->shape_id = rb_shape_id(rb_shape_transition_shape_too_complex(obj));
+        fields_tbl->shape_id = rb_shape_transition_complex(obj);
 #endif
         fields_tbl->as.complex.table = st_init_numtable_with_size(1);
 

--- a/variable.c
+++ b/variable.c
@@ -2010,14 +2010,14 @@ void rb_obj_freeze_inline(VALUE x)
             RB_FL_UNSET_RAW(x, FL_USER2 | FL_USER3); // STR_CHILLED
         }
 
-        rb_shape_t * next_shape = rb_shape_transition_shape_frozen(x);
+        shape_id_t next_shape_id = rb_shape_transition_frozen(x);
 
         // If we're transitioning from "not complex" to "too complex"
         // then evict ivars.  This can happen if we run out of shapes
-        if (rb_shape_too_complex_p(next_shape) && !rb_shape_obj_too_complex(x)) {
+        if (rb_shape_id_too_complex_p(next_shape_id) && !rb_shape_obj_too_complex(x)) {
             rb_evict_fields_to_hash(x);
         }
-        rb_shape_set_shape(x, next_shape);
+        rb_shape_set_shape_id(x, next_shape_id);
 
         if (RBASIC_CLASS(x)) {
             rb_freeze_singleton_class(x);

--- a/variable.c
+++ b/variable.c
@@ -1360,7 +1360,7 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
                 }
                 else {
                     attr_index_t index = 0;
-                    shape = rb_shape_get_shape_by_id(shape_id);
+                    shape = RSHAPE(shape_id);
                     found = rb_shape_get_iv_index(shape, id, &index);
 
                     if (found) {
@@ -1432,7 +1432,7 @@ rb_ivar_lookup(VALUE obj, ID id, VALUE undef)
     }
 
     attr_index_t index = 0;
-    shape = rb_shape_get_shape_by_id(shape_id);
+    shape = RSHAPE(shape_id);
     if (rb_shape_get_iv_index(shape, id, &index)) {
         return ivar_list[index];
     }
@@ -1729,7 +1729,7 @@ generic_fields_lookup_ensure_size(st_data_t *k, st_data_t *v, st_data_t u, int e
     if (!existing || fields_lookup->resize) {
         if (existing) {
             RUBY_ASSERT(fields_lookup->shape->type == SHAPE_IVAR || fields_lookup->shape->type == SHAPE_OBJ_ID);
-            RUBY_ASSERT(rb_shape_get_shape_by_id(fields_lookup->shape->parent_id)->capacity < fields_lookup->shape->capacity);
+            RUBY_ASSERT(RSHAPE(fields_lookup->shape->parent_id)->capacity < fields_lookup->shape->capacity);
         }
         else {
             FL_SET_RAW((VALUE)*k, FL_EXIVAR);
@@ -2338,12 +2338,12 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
             while (src_shape->parent_id != INVALID_SHAPE_ID) {
                 if (src_shape->type == SHAPE_IVAR) {
                     while (dest_shape->edge_name != src_shape->edge_name) {
-                        dest_shape = rb_shape_get_shape_by_id(dest_shape->parent_id);
+                        dest_shape = RSHAPE(dest_shape->parent_id);
                     }
 
                     RB_OBJ_WRITE(dest, &dest_buf[dest_shape->next_field_index - 1], src_buf[src_shape->next_field_index - 1]);
                 }
-                src_shape = rb_shape_get_shape_by_id(src_shape->parent_id);
+                src_shape = RSHAPE(src_shape->parent_id);
             }
         }
 

--- a/variable.c
+++ b/variable.c
@@ -1639,7 +1639,8 @@ general_ivar_set(VALUE obj, ID id, VALUE val, void *data,
             rb_raise(rb_eArgError, "too many instance variables");
         }
 
-        rb_shape_t *next_shape = rb_shape_get_next(current_shape, obj, id);
+        shape_id_t next_shape_id = rb_shape_transition_add_ivar(obj, id);
+        rb_shape_t *next_shape = RSHAPE(next_shape_id);
         if (UNLIKELY(rb_shape_too_complex_p(next_shape))) {
             transition_too_complex_func(obj, data);
             goto too_complex;

--- a/variable.c
+++ b/variable.c
@@ -1460,13 +1460,11 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
     rb_check_frozen(obj);
 
     VALUE val = undef;
-    rb_shape_t *shape = rb_shape_get_shape(obj);
-
     if (BUILTIN_TYPE(obj) == T_CLASS || BUILTIN_TYPE(obj) == T_MODULE) {
         IVAR_ACCESSOR_SHOULD_BE_MAIN_RACTOR(id);
     }
 
-    if (!rb_shape_transition_shape_remove_ivar(obj, id, shape, &val)) {
+    if (!rb_shape_transition_remove_ivar(obj, id, &val)) {
         if (!rb_shape_obj_too_complex_p(obj)) {
             rb_evict_fields_to_hash(obj);
         }

--- a/variable.c
+++ b/variable.c
@@ -2143,12 +2143,12 @@ iterate_over_shapes_with_callback(rb_shape_t *shape, rb_ivar_foreach_callback_fu
         return false;
       case SHAPE_OBJ_ID:
         if (itr_data->ivar_only) {
-            return iterate_over_shapes_with_callback(rb_shape_get_parent(shape), callback, itr_data);
+            return iterate_over_shapes_with_callback(RSHAPE(shape->parent_id), callback, itr_data);
         }
         // fallthrough
       case SHAPE_IVAR:
         ASSUME(callback);
-        if (iterate_over_shapes_with_callback(rb_shape_get_parent(shape), callback, itr_data)) {
+        if (iterate_over_shapes_with_callback(RSHAPE(shape->parent_id), callback, itr_data)) {
             return true;
         }
 
@@ -2180,7 +2180,7 @@ iterate_over_shapes_with_callback(rb_shape_t *shape, rb_ivar_foreach_callback_fu
         }
         return false;
       case SHAPE_FROZEN:
-        return iterate_over_shapes_with_callback(rb_shape_get_parent(shape), callback, itr_data);
+        return iterate_over_shapes_with_callback(RSHAPE(shape->parent_id), callback, itr_data);
       case SHAPE_OBJ_TOO_COMPLEX:
       default:
         rb_bug("Unreachable");

--- a/variable.c
+++ b/variable.c
@@ -1570,8 +1570,8 @@ rb_obj_init_too_complex(VALUE obj, st_table *table)
 {
     // This method is meant to be called on newly allocated object.
     RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));
-    RUBY_ASSERT(rb_shape_canonical_p(rb_shape_get_shape(obj)));
-    RUBY_ASSERT(rb_shape_get_shape(obj)->next_field_index == 0);
+    RUBY_ASSERT(rb_shape_canonical_p(RB_OBJ_SHAPE(obj)));
+    RUBY_ASSERT(RB_OBJ_SHAPE(obj)->next_field_index == 0);
 
     obj_transition_too_complex(obj, table);
 }
@@ -1584,7 +1584,7 @@ rb_evict_fields_to_hash(VALUE obj)
 
     RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));
 
-    rb_shape_t *shape = rb_shape_get_shape(obj);
+    rb_shape_t *shape = RB_OBJ_SHAPE(obj);
     st_table *table = st_init_numtable_with_size(shape->next_field_index);
     rb_obj_copy_fields_to_hash_table(obj, table);
     obj_transition_too_complex(obj, table);
@@ -1624,7 +1624,7 @@ general_ivar_set(VALUE obj, ID id, VALUE val, void *data,
         .existing = true
     };
 
-    rb_shape_t *current_shape = rb_shape_get_shape(obj);
+    rb_shape_t *current_shape = RB_OBJ_SHAPE(obj);
 
     if (UNLIKELY(rb_shape_too_complex_p(current_shape))) {
         goto too_complex;
@@ -1681,7 +1681,7 @@ general_field_set(VALUE obj, rb_shape_t *target_shape, VALUE val, void *data,
                   void (*transition_too_complex_func)(VALUE, void *),
                   st_table *(*too_complex_table_func)(VALUE, void *))
 {
-    rb_shape_t *current_shape = rb_shape_get_shape(obj);
+    rb_shape_t *current_shape = RB_OBJ_SHAPE(obj);
 
     if (UNLIKELY(rb_shape_too_complex_p(target_shape))) {
         if (UNLIKELY(!rb_shape_too_complex_p(current_shape))) {
@@ -1964,7 +1964,7 @@ rb_vm_set_ivar_id(VALUE obj, ID id, VALUE val)
 bool
 rb_shape_set_shape_id(VALUE obj, shape_id_t shape_id)
 {
-    if (rb_shape_get_shape_id(obj) == shape_id) {
+    if (RB_OBJ_SHAPE_ID(obj) == shape_id) {
         return false;
     }
 
@@ -2119,7 +2119,7 @@ rb_ivar_defined(VALUE obj, ID id)
         return Qtrue;
     }
     else {
-        return RBOOL(rb_shape_get_iv_index(rb_shape_get_shape(obj), id, &index));
+        return RBOOL(rb_shape_get_iv_index(RB_OBJ_SHAPE(obj), id, &index));
     }
 }
 
@@ -2206,7 +2206,7 @@ obj_fields_each(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg, b
         .ivar_only = ivar_only,
     };
 
-    rb_shape_t *shape = rb_shape_get_shape(obj);
+    rb_shape_t *shape = RB_OBJ_SHAPE(obj);
     if (rb_shape_too_complex_p(shape)) {
         rb_st_foreach(ROBJECT_FIELDS_HASH(obj), each_hash_iv, (st_data_t)&itr_data);
     }
@@ -2218,7 +2218,7 @@ obj_fields_each(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg, b
 static void
 gen_fields_each(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg, bool ivar_only)
 {
-    rb_shape_t *shape = rb_shape_get_shape(obj);
+    rb_shape_t *shape = RB_OBJ_SHAPE(obj);
     struct gen_fields_tbl *fields_tbl;
     if (!rb_gen_fields_tbl_get(obj, 0, &fields_tbl)) return;
 
@@ -2243,7 +2243,7 @@ class_fields_each(VALUE obj, rb_ivar_foreach_callback_func *func, st_data_t arg,
 {
     RUBY_ASSERT(RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE));
 
-    rb_shape_t *shape = rb_shape_get_shape(obj);
+    rb_shape_t *shape = RB_OBJ_SHAPE(obj);
     struct iv_itr_data itr_data = {
         .obj = obj,
         .arg = arg,
@@ -2276,7 +2276,7 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
         goto clear;
     }
 
-    rb_shape_t *src_shape = rb_shape_get_shape(obj);
+    rb_shape_t *src_shape = RB_OBJ_SHAPE(obj);
 
     if (rb_gen_fields_tbl_get(obj, 0, &obj_fields_tbl)) {
         if (gen_fields_tbl_count(obj, obj_fields_tbl) == 0)
@@ -2297,7 +2297,7 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
         }
 
         rb_shape_t *shape_to_set_on_dest = src_shape;
-        rb_shape_t *initial_shape = rb_shape_get_shape(dest);
+        rb_shape_t *initial_shape = RB_OBJ_SHAPE(dest);
 
         if (!rb_shape_canonical_p(src_shape)) {
             RUBY_ASSERT(initial_shape->type == SHAPE_ROOT);
@@ -4586,7 +4586,7 @@ rb_fields_tbl_copy(VALUE dst, VALUE src)
     RUBY_ASSERT(rb_type(dst) == rb_type(src));
     RUBY_ASSERT(RB_TYPE_P(dst, T_CLASS) || RB_TYPE_P(dst, T_MODULE));
 
-    RUBY_ASSERT(rb_shape_get_shape(dst)->type == SHAPE_ROOT);
+    RUBY_ASSERT(RB_OBJ_SHAPE(dst)->type == SHAPE_ROOT);
     RUBY_ASSERT(!RCLASS_FIELDS(dst));
 
     rb_ivar_foreach(src, tbl_copy_i, dst);

--- a/vm.c
+++ b/vm.c
@@ -3115,16 +3115,7 @@ ruby_vm_destruct(rb_vm_t *vm)
 
             rb_id_table_free(RCLASS(rb_mRubyVMFrozenCore)->m_tbl);
 
-            rb_shape_t *cursor = rb_shape_get_root_shape();
-            rb_shape_t *end = rb_shape_get_shape_by_id(GET_SHAPE_TREE()->next_shape_id);
-            while (cursor < end) {
-                // 0x1 == SINGLE_CHILD_P
-                if (cursor->edges && !(((uintptr_t)cursor->edges) & 0x1))
-                    rb_id_table_free(cursor->edges);
-                cursor += 1;
-            }
-
-            xfree(GET_SHAPE_TREE());
+            rb_shape_free_all();
 
             st_free_table(vm->static_ext_inits);
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1476,8 +1476,8 @@ vm_setivar_default(VALUE obj, ID id, VALUE val, shape_id_t dest_shape_id, attr_i
         RUBY_ASSERT(dest_shape_id != INVALID_SHAPE_ID && shape_id != INVALID_SHAPE_ID);
     }
     else if (dest_shape_id != INVALID_SHAPE_ID) {
-        rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
-        rb_shape_t *dest_shape = rb_shape_get_shape_by_id(dest_shape_id);
+        rb_shape_t *shape = RSHAPE(shape_id);
+        rb_shape_t *dest_shape = RSHAPE(dest_shape_id);
 
         if (shape_id == dest_shape->parent_id && dest_shape->edge_name == id && shape->capacity == dest_shape->capacity) {
             RUBY_ASSERT(index < dest_shape->capacity);
@@ -1524,8 +1524,8 @@ vm_setivar(VALUE obj, ID id, VALUE val, shape_id_t dest_shape_id, attr_index_t i
                 VM_ASSERT(!rb_ractor_shareable_p(obj));
             }
             else if (dest_shape_id != INVALID_SHAPE_ID) {
-                rb_shape_t *shape = rb_shape_get_shape_by_id(shape_id);
-                rb_shape_t *dest_shape = rb_shape_get_shape_by_id(dest_shape_id);
+                rb_shape_t *shape = RSHAPE(shape_id);
+                rb_shape_t *dest_shape = RSHAPE(dest_shape_id);
                 shape_id_t source_shape_id = dest_shape->parent_id;
 
                 if (shape_id == source_shape_id && dest_shape->edge_name == id && shape->capacity == dest_shape->capacity) {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1533,7 +1533,7 @@ vm_setivar(VALUE obj, ID id, VALUE val, shape_id_t dest_shape_id, attr_index_t i
 
                     ROBJECT_SET_SHAPE_ID(obj, dest_shape_id);
 
-                    RUBY_ASSERT(rb_shape_get_next_iv_shape(rb_shape_get_shape_by_id(source_shape_id), id) == dest_shape);
+                    RUBY_ASSERT(rb_shape_get_next_iv_shape(source_shape_id, id) == dest_shape_id);
                     RUBY_ASSERT(index < dest_shape->capacity);
                 }
                 else {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1546,7 +1546,7 @@ vm_setivar(VALUE obj, ID id, VALUE val, shape_id_t dest_shape_id, attr_index_t i
 
             VALUE *ptr = ROBJECT_FIELDS(obj);
 
-            RUBY_ASSERT(!rb_shape_obj_too_complex(obj));
+            RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));
             RB_OBJ_WRITE(obj, &ptr[index], val);
 
             RB_DEBUG_COUNTER_INC(ivar_set_ic_hit);

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -94,7 +94,7 @@ fn main() {
         .allowlist_function("rb_bug")
 
         // From shape.h
-        .allowlist_function("rb_shape_get_shape_id")
+        .allowlist_function("RB_OBJ_SHAPE_ID")
         .allowlist_function("RSHAPE")
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -98,7 +98,7 @@ fn main() {
         .allowlist_function("RSHAPE")
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")
-        .allowlist_function("rb_shape_get_next_no_warnings")
+        .allowlist_function("rb_shape_transition_add_ivar_no_warnings")
         .allowlist_function("rb_shape_id")
         .allowlist_function("rb_shape_obj_too_complex_p")
         .allowlist_function("rb_shape_too_complex_p")

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -95,7 +95,7 @@ fn main() {
 
         // From shape.h
         .allowlist_function("rb_shape_get_shape_id")
-        .allowlist_function("rb_shape_get_shape_by_id")
+        .allowlist_function("RSHAPE")
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")
         .allowlist_function("rb_shape_get_next_no_warnings")

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -94,8 +94,8 @@ fn main() {
         .allowlist_function("rb_bug")
 
         // From shape.h
-        .allowlist_function("RB_OBJ_SHAPE_ID")
-        .allowlist_function("RSHAPE")
+        .allowlist_function("rb_obj_shape_id")
+        .allowlist_function("rb_shape_lookup")
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")
         .allowlist_function("rb_shape_transition_add_ivar_no_warnings")

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -100,7 +100,7 @@ fn main() {
         .allowlist_function("rb_shape_get_iv_index")
         .allowlist_function("rb_shape_get_next_no_warnings")
         .allowlist_function("rb_shape_id")
-        .allowlist_function("rb_shape_obj_too_complex")
+        .allowlist_function("rb_shape_obj_too_complex_p")
         .allowlist_function("rb_shape_too_complex_p")
         .allowlist_var("SHAPE_ID_NUM_BITS")
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2909,7 +2909,7 @@ fn gen_get_ivar(
     // Compile time self is embedded and the ivar index lands within the object
     let embed_test_result = unsafe { FL_TEST_RAW(comptime_receiver, VALUE(ROBJECT_EMBED.as_usize())) != VALUE(0) };
 
-    let expected_shape = unsafe { rb_shape_get_shape_id(comptime_receiver) };
+    let expected_shape = unsafe { RB_OBJ_SHAPE_ID(comptime_receiver) };
     let shape_id_offset = unsafe { rb_shape_id_offset() };
     let shape_opnd = Opnd::mem(SHAPE_ID_NUM_BITS as u8, recv, shape_id_offset);
 
@@ -3187,7 +3187,7 @@ fn gen_set_ivar(
         // Upgrade type
         guard_object_is_heap(asm, recv, recv_opnd, Counter::setivar_not_heap);
 
-        let expected_shape = unsafe { rb_shape_get_shape_id(comptime_receiver) };
+        let expected_shape = unsafe { RB_OBJ_SHAPE_ID(comptime_receiver) };
         let shape_id_offset = unsafe { rb_shape_id_offset() };
         let shape_opnd = Opnd::mem(SHAPE_ID_NUM_BITS as u8, recv, shape_id_offset);
 

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3112,8 +3112,8 @@ fn gen_set_ivar(
     let mut new_shape_too_complex = false;
     let new_shape = if !shape_too_complex && receiver_t_object && ivar_index.is_none() {
         let current_shape = comptime_receiver.shape_of();
-        let next_shape = unsafe { rb_shape_get_next_no_warnings(current_shape, comptime_receiver, ivar_name) };
-        let next_shape_id = unsafe { rb_shape_id(next_shape) };
+        let next_shape_id = unsafe { rb_shape_transition_add_ivar_no_warnings(comptime_receiver, ivar_name) };
+        let next_shape = unsafe { RSHAPE(next_shape_id) };
 
         // If the VM ran out of shapes, or this class generated too many leaf,
         // it may be de-optimized into OBJ_TOO_COMPLEX_SHAPE (hash-table).

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2894,7 +2894,7 @@ fn gen_get_ivar(
 
     let ivar_index = unsafe {
         let shape_id = comptime_receiver.shape_id_of();
-        let shape = RSHAPE(shape_id);
+        let shape = rb_shape_lookup(shape_id);
         let mut ivar_index: u32 = 0;
         if rb_shape_get_iv_index(shape, ivar_name, &mut ivar_index) {
             Some(ivar_index as usize)
@@ -2909,7 +2909,7 @@ fn gen_get_ivar(
     // Compile time self is embedded and the ivar index lands within the object
     let embed_test_result = unsafe { FL_TEST_RAW(comptime_receiver, VALUE(ROBJECT_EMBED.as_usize())) != VALUE(0) };
 
-    let expected_shape = unsafe { RB_OBJ_SHAPE_ID(comptime_receiver) };
+    let expected_shape = unsafe { rb_obj_shape_id(comptime_receiver) };
     let shape_id_offset = unsafe { rb_shape_id_offset() };
     let shape_opnd = Opnd::mem(SHAPE_ID_NUM_BITS as u8, recv, shape_id_offset);
 
@@ -3097,7 +3097,7 @@ fn gen_set_ivar(
     let shape_too_complex = comptime_receiver.shape_too_complex();
     let ivar_index = if !shape_too_complex {
         let shape_id = comptime_receiver.shape_id_of();
-        let shape = unsafe { RSHAPE(shape_id) };
+        let shape = unsafe { rb_shape_lookup(shape_id) };
         let mut ivar_index: u32 = 0;
         if unsafe { rb_shape_get_iv_index(shape, ivar_name, &mut ivar_index) } {
             Some(ivar_index as usize)
@@ -3113,7 +3113,7 @@ fn gen_set_ivar(
     let new_shape = if !shape_too_complex && receiver_t_object && ivar_index.is_none() {
         let current_shape = comptime_receiver.shape_of();
         let next_shape_id = unsafe { rb_shape_transition_add_ivar_no_warnings(comptime_receiver, ivar_name) };
-        let next_shape = unsafe { RSHAPE(next_shape_id) };
+        let next_shape = unsafe { rb_shape_lookup(next_shape_id) };
 
         // If the VM ran out of shapes, or this class generated too many leaf,
         // it may be de-optimized into OBJ_TOO_COMPLEX_SHAPE (hash-table).
@@ -3187,7 +3187,7 @@ fn gen_set_ivar(
         // Upgrade type
         guard_object_is_heap(asm, recv, recv_opnd, Counter::setivar_not_heap);
 
-        let expected_shape = unsafe { RB_OBJ_SHAPE_ID(comptime_receiver) };
+        let expected_shape = unsafe { rb_obj_shape_id(comptime_receiver) };
         let shape_id_offset = unsafe { rb_shape_id_offset() };
         let shape_opnd = Opnd::mem(SHAPE_ID_NUM_BITS as u8, recv, shape_id_offset);
 
@@ -3387,7 +3387,7 @@ fn gen_definedivar(
 
     let shape_id = comptime_receiver.shape_id_of();
     let ivar_exists = unsafe {
-        let shape = RSHAPE(shape_id);
+        let shape = rb_shape_lookup(shape_id);
         let mut ivar_index: u32 = 0;
         rb_shape_get_iv_index(shape, ivar_name, &mut ivar_index)
     };

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2894,7 +2894,7 @@ fn gen_get_ivar(
 
     let ivar_index = unsafe {
         let shape_id = comptime_receiver.shape_id_of();
-        let shape = rb_shape_get_shape_by_id(shape_id);
+        let shape = RSHAPE(shape_id);
         let mut ivar_index: u32 = 0;
         if rb_shape_get_iv_index(shape, ivar_name, &mut ivar_index) {
             Some(ivar_index as usize)
@@ -3097,7 +3097,7 @@ fn gen_set_ivar(
     let shape_too_complex = comptime_receiver.shape_too_complex();
     let ivar_index = if !shape_too_complex {
         let shape_id = comptime_receiver.shape_id_of();
-        let shape = unsafe { rb_shape_get_shape_by_id(shape_id) };
+        let shape = unsafe { RSHAPE(shape_id) };
         let mut ivar_index: u32 = 0;
         if unsafe { rb_shape_get_iv_index(shape, ivar_name, &mut ivar_index) } {
             Some(ivar_index as usize)
@@ -3387,7 +3387,7 @@ fn gen_definedivar(
 
     let shape_id = comptime_receiver.shape_id_of();
     let ivar_exists = unsafe {
-        let shape = rb_shape_get_shape_by_id(shape_id);
+        let shape = RSHAPE(shape_id);
         let mut ivar_index: u32 = 0;
         rb_shape_get_iv_index(shape, ivar_name, &mut ivar_index)
     };

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -445,7 +445,7 @@ impl VALUE {
     }
 
     pub fn shape_id_of(self) -> u32 {
-        unsafe { rb_shape_get_shape_id(self) }
+        unsafe { RB_OBJ_SHAPE_ID(self) }
     }
 
     pub fn shape_of(self) -> *mut rb_shape {

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -441,7 +441,7 @@ impl VALUE {
     }
 
     pub fn shape_too_complex(self) -> bool {
-        unsafe { rb_shape_obj_too_complex(self) }
+        unsafe { rb_shape_obj_too_complex_p(self) }
     }
 
     pub fn shape_id_of(self) -> u32 {

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -445,12 +445,12 @@ impl VALUE {
     }
 
     pub fn shape_id_of(self) -> u32 {
-        unsafe { RB_OBJ_SHAPE_ID(self) }
+        unsafe { rb_obj_shape_id(self) }
     }
 
     pub fn shape_of(self) -> *mut rb_shape {
         unsafe {
-            let shape = RSHAPE(self.shape_id_of());
+            let shape = rb_shape_lookup(self.shape_id_of());
 
             if shape.is_null() {
                 panic!("Shape should not be null");

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -450,7 +450,7 @@ impl VALUE {
 
     pub fn shape_of(self) -> *mut rb_shape {
         unsafe {
-            let shape = rb_shape_get_shape_by_id(self.shape_id_of());
+            let shape = RSHAPE(self.shape_id_of());
 
             if shape.is_null() {
                 panic!("Shape should not be null");

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1093,11 +1093,7 @@ extern "C" {
     pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_obj_too_complex_p(obj: VALUE) -> bool;
     pub fn rb_shape_too_complex_p(shape: *mut rb_shape_t) -> bool;
-    pub fn rb_shape_get_next_no_warnings(
-        shape: *mut rb_shape_t,
-        obj: VALUE,
-        id: ID,
-    ) -> *mut rb_shape_t;
+    pub fn rb_shape_transition_add_ivar_no_warnings(obj: VALUE, id: ID) -> shape_id_t;
     pub fn rb_shape_id(shape: *mut rb_shape_t) -> shape_id_t;
     pub fn rb_gvar_get(arg1: ID) -> VALUE;
     pub fn rb_gvar_set(arg1: ID, arg2: VALUE) -> VALUE;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1088,8 +1088,8 @@ extern "C" {
     pub fn rb_obj_info(obj: VALUE) -> *const ::std::os::raw::c_char;
     pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
     pub fn rb_shape_id_offset() -> i32;
-    pub fn RSHAPE(shape_id: shape_id_t) -> *mut rb_shape_t;
-    pub fn RB_OBJ_SHAPE_ID(obj: VALUE) -> shape_id_t;
+    pub fn rb_shape_lookup(shape_id: shape_id_t) -> *mut rb_shape_t;
+    pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_obj_too_complex_p(obj: VALUE) -> bool;
     pub fn rb_shape_too_complex_p(shape: *mut rb_shape_t) -> bool;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1088,7 +1088,7 @@ extern "C" {
     pub fn rb_obj_info(obj: VALUE) -> *const ::std::os::raw::c_char;
     pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
     pub fn rb_shape_id_offset() -> i32;
-    pub fn rb_shape_get_shape_by_id(shape_id: shape_id_t) -> *mut rb_shape_t;
+    pub fn RSHAPE(shape_id: shape_id_t) -> *mut rb_shape_t;
     pub fn rb_shape_get_shape_id(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_obj_too_complex(obj: VALUE) -> bool;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1089,7 +1089,7 @@ extern "C" {
     pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
     pub fn rb_shape_id_offset() -> i32;
     pub fn RSHAPE(shape_id: shape_id_t) -> *mut rb_shape_t;
-    pub fn rb_shape_get_shape_id(obj: VALUE) -> shape_id_t;
+    pub fn RB_OBJ_SHAPE_ID(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_obj_too_complex_p(obj: VALUE) -> bool;
     pub fn rb_shape_too_complex_p(shape: *mut rb_shape_t) -> bool;

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1091,7 +1091,7 @@ extern "C" {
     pub fn RSHAPE(shape_id: shape_id_t) -> *mut rb_shape_t;
     pub fn rb_shape_get_shape_id(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
-    pub fn rb_shape_obj_too_complex(obj: VALUE) -> bool;
+    pub fn rb_shape_obj_too_complex_p(obj: VALUE) -> bool;
     pub fn rb_shape_too_complex_p(shape: *mut rb_shape_t) -> bool;
     pub fn rb_shape_get_next_no_warnings(
         shape: *mut rb_shape_t,

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -107,8 +107,8 @@ fn main() {
         .allowlist_function("rb_bug")
 
         // From shape.h
-        .allowlist_function("RB_OBJ_SHAPE_ID")
-        .allowlist_function("RSHAPE")
+        .allowlist_function("rb_obj_shape_id")
+        .allowlist_function("rb_shape_lookup")
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")
         .allowlist_function("rb_shape_transition_add_ivar_no_warnings")

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -107,7 +107,7 @@ fn main() {
         .allowlist_function("rb_bug")
 
         // From shape.h
-        .allowlist_function("rb_shape_get_shape_id")
+        .allowlist_function("RB_OBJ_SHAPE_ID")
         .allowlist_function("RSHAPE")
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
 
         // From shape.h
         .allowlist_function("rb_shape_get_shape_id")
-        .allowlist_function("rb_shape_get_shape_by_id")
+        .allowlist_function("RSHAPE")
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")
         .allowlist_function("rb_shape_get_next_no_warnings")

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -113,7 +113,7 @@ fn main() {
         .allowlist_function("rb_shape_get_iv_index")
         .allowlist_function("rb_shape_get_next_no_warnings")
         .allowlist_function("rb_shape_id")
-        .allowlist_function("rb_shape_obj_too_complex")
+        .allowlist_function("rb_shape_obj_too_complex_p")
         .allowlist_var("SHAPE_ID_NUM_BITS")
 
         // From ruby/internal/intern/object.h

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -111,7 +111,7 @@ fn main() {
         .allowlist_function("RSHAPE")
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")
-        .allowlist_function("rb_shape_get_next_no_warnings")
+        .allowlist_function("rb_shape_transition_add_ivar_no_warnings")
         .allowlist_function("rb_shape_id")
         .allowlist_function("rb_shape_obj_too_complex_p")
         .allowlist_var("SHAPE_ID_NUM_BITS")

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -487,7 +487,7 @@ impl VALUE {
 
     pub fn shape_of(self) -> *mut rb_shape {
         unsafe {
-            let shape = rb_shape_get_shape_by_id(self.shape_id_of());
+            let shape = RSHAPE(self.shape_id_of());
 
             if shape.is_null() {
                 panic!("Shape should not be null");

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -482,7 +482,7 @@ impl VALUE {
     }
 
     pub fn shape_id_of(self) -> u32 {
-        unsafe { rb_shape_get_shape_id(self) }
+        unsafe { RB_OBJ_SHAPE_ID(self) }
     }
 
     pub fn shape_of(self) -> *mut rb_shape {

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -482,12 +482,12 @@ impl VALUE {
     }
 
     pub fn shape_id_of(self) -> u32 {
-        unsafe { RB_OBJ_SHAPE_ID(self) }
+        unsafe { rb_obj_shape_id(self) }
     }
 
     pub fn shape_of(self) -> *mut rb_shape {
         unsafe {
-            let shape = RSHAPE(self.shape_id_of());
+            let shape = rb_shape_lookup(self.shape_id_of());
 
             if shape.is_null() {
                 panic!("Shape should not be null");

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -478,7 +478,7 @@ impl VALUE {
     }
 
     pub fn shape_too_complex(self) -> bool {
-        unsafe { rb_shape_obj_too_complex(self) }
+        unsafe { rb_shape_obj_too_complex_p(self) }
     }
 
     pub fn shape_id_of(self) -> u32 {

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -868,7 +868,7 @@ unsafe extern "C" {
     pub fn rb_obj_info(obj: VALUE) -> *const ::std::os::raw::c_char;
     pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
     pub fn rb_shape_id_offset() -> i32;
-    pub fn rb_shape_get_shape_by_id(shape_id: shape_id_t) -> *mut rb_shape_t;
+    pub fn RSHAPE(shape_id: shape_id_t) -> *mut rb_shape_t;
     pub fn rb_shape_get_shape_id(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_obj_too_complex(obj: VALUE) -> bool;

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -871,7 +871,7 @@ unsafe extern "C" {
     pub fn RSHAPE(shape_id: shape_id_t) -> *mut rb_shape_t;
     pub fn rb_shape_get_shape_id(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
-    pub fn rb_shape_obj_too_complex(obj: VALUE) -> bool;
+    pub fn rb_shape_obj_too_complex_p(obj: VALUE) -> bool;
     pub fn rb_shape_get_next_no_warnings(
         shape: *mut rb_shape_t,
         obj: VALUE,

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -872,11 +872,7 @@ unsafe extern "C" {
     pub fn rb_shape_get_shape_id(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_obj_too_complex_p(obj: VALUE) -> bool;
-    pub fn rb_shape_get_next_no_warnings(
-        shape: *mut rb_shape_t,
-        obj: VALUE,
-        id: ID,
-    ) -> *mut rb_shape_t;
+    pub fn rb_shape_transition_add_ivar_no_warnings(obj: VALUE, id: ID) -> shape_id_t;
     pub fn rb_shape_id(shape: *mut rb_shape_t) -> shape_id_t;
     pub fn rb_gvar_get(arg1: ID) -> VALUE;
     pub fn rb_gvar_set(arg1: ID, arg2: VALUE) -> VALUE;

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -868,8 +868,8 @@ unsafe extern "C" {
     pub fn rb_obj_info(obj: VALUE) -> *const ::std::os::raw::c_char;
     pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
     pub fn rb_shape_id_offset() -> i32;
-    pub fn RSHAPE(shape_id: shape_id_t) -> *mut rb_shape_t;
-    pub fn RB_OBJ_SHAPE_ID(obj: VALUE) -> shape_id_t;
+    pub fn rb_shape_lookup(shape_id: shape_id_t) -> *mut rb_shape_t;
+    pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_obj_too_complex_p(obj: VALUE) -> bool;
     pub fn rb_shape_transition_add_ivar_no_warnings(obj: VALUE, id: ID) -> shape_id_t;

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -869,7 +869,7 @@ unsafe extern "C" {
     pub fn rb_ec_stack_check(ec: *mut rb_execution_context_struct) -> ::std::os::raw::c_int;
     pub fn rb_shape_id_offset() -> i32;
     pub fn RSHAPE(shape_id: shape_id_t) -> *mut rb_shape_t;
-    pub fn rb_shape_get_shape_id(obj: VALUE) -> shape_id_t;
+    pub fn RB_OBJ_SHAPE_ID(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape: *mut rb_shape_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_obj_too_complex_p(obj: VALUE) -> bool;
     pub fn rb_shape_transition_add_ivar_no_warnings(obj: VALUE, id: ID) -> shape_id_t;


### PR DESCRIPTION
- Reduce usage of `rb_shape_t *` in favor of the more opaque `shape_id_t`.
- Improve the functions naming convention.

There are still some `rb_shape_t *` use left, but this PR is already quite big, and realistically not all uses should be eliminated. In some cases you need to check multiple fields on the shape, and dealing with an opaque `shape_id_t` wouldn't be as convenient.

The goal in the near future is to use the lower bits in `shape_id_t` to store some tags, such as whether the shape is frozen. This way freezing an object wouldn't be a shape transition anymore, just flipping the lower bit in the `shape_id_t`.

Similarly it would make sense to reserve one bit for `too_complex` so that it can be checked without any pointer chasing.

cc @jhawthorn 