### PR TITLE
[Bug #18119] Fix crash when instantiating classes in Ractors

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2259,3 +2259,20 @@ rescue NotImplementedError
   :ok
 end
 }
+
+# Creating classes inside of Ractors
+# [Bug #18119]
+assert_equal 'ok', %q{
+  workers = (0...8).map do
+    Ractor.new do
+      loop do
+        100.times.map { Class.new }
+        Ractor.yield nil
+      end
+    end
+  end
+
+  100.times { Ractor.select(*workers) }
+
+  'ok'
+}

--- a/class.c
+++ b/class.c
@@ -83,23 +83,25 @@ RUBY_EXTERN rb_serial_t ruby_vm_global_cvar_state;
 static rb_subclass_entry_t *
 push_subclass_entry_to_list(VALUE super, VALUE klass)
 {
-    rb_subclass_entry_t *entry, *head;
-
-    entry = ZALLOC(rb_subclass_entry_t);
+    rb_subclass_entry_t *entry = ZALLOC(rb_subclass_entry_t);
     entry->klass = klass;
 
-    head = RCLASS_SUBCLASSES(super);
-    if (!head) {
-        head = ZALLOC(rb_subclass_entry_t);
-        RCLASS_SUBCLASSES(super) = head;
-    }
-    entry->next = head->next;
-    entry->prev = head;
+    RB_VM_LOCK_ENTER();
+    {
+        rb_subclass_entry_t *head = RCLASS_SUBCLASSES(super);
+        if (!head) {
+            head = ZALLOC(rb_subclass_entry_t);
+            RCLASS_SUBCLASSES(super) = head;
+        }
+        entry->next = head->next;
+        entry->prev = head;
 
-    if (head->next) {
-        head->next->prev = entry;
+        if (head->next) {
+            head->next->prev = entry;
+        }
+        head->next = entry;
     }
-    head->next = entry;
+    RB_VM_LOCK_LEAVE();
 
     return entry;
 }


### PR DESCRIPTION
When we create classes, it pushes the class to the subclass list of the superclass. This access needs to be synchronized because multiple Ractors may be creating classes with the same superclass, which would cause race conditions and cause the linked list to be corrupted.

For example, we can reproduce with this script crashing:

```ruby
workers = (0...8).map do
  Ractor.new do
    loop do
      100.times.map { Class.new }
      Ractor.yield nil
    end
  end
end

100.times { Ractor.select(*workers) }
```

With ASAN enabled, we can see that there are use-after-free errors:

    ==176013==ERROR: AddressSanitizer: heap-use-after-free on address 0x5030000974f0 at pc 0x62f9e56f892d bp 0x7a503f1ffd90 sp 0x7a503f1ffd88
    WRITE of size 8 at 0x5030000974f0 thread T4
        #0 0x62f9e56f892c in rb_class_remove_from_super_subclasses class.c:149:24
        #1 0x62f9e58c9dd2 in rb_gc_obj_free gc.c:1262:9
        #2 0x62f9e58f6e19 in gc_sweep_plane gc/default/default.c:3450:21
        #3 0x62f9e58f686a in gc_sweep_page gc/default/default.c:3535:13
        #4 0x62f9e58f12b4 in gc_sweep_step gc/default/default.c:3810:9
        #5 0x62f9e58ed2a7 in gc_sweep gc/default/default.c:4058:13
        #6 0x62f9e58fac93 in gc_start gc/default/default.c:6402:13
        #7 0x62f9e58e8b69 in heap_prepare gc/default/default.c:2032:13
        #8 0x62f9e58e8b69 in heap_next_free_page gc/default/default.c:2255:9
        #9 0x62f9e58e8b69 in newobj_cache_miss gc/default/default.c:2362:38
    ...
    0x5030000974f0 is located 16 bytes inside of 24-byte region [0x5030000974e0,0x5030000974f8)
    freed by thread T4 here:
        #0 0x62f9e562f28a in free (miniruby+0x1fd28a) (BuildId: 5ad6d9e7cec8318df6726ea5ce34d3c76d0d0233)
        #1 0x62f9e58ca2ab in rb_gc_impl_free gc/default/default.c:8102:9
        #2 0x62f9e58ca2ab in ruby_sized_xfree gc.c:5029:13
        #3 0x62f9e58ca2ab in ruby_xfree gc.c:5040:5
        #4 0x62f9e56f88e6 in rb_class_remove_from_super_subclasses class.c:152:9
        #5 0x62f9e58c9dd2 in rb_gc_obj_free gc.c:1262:9
        #6 0x62f9e58f6e19 in gc_sweep_plane gc/default/default.c:3450:21
        #7 0x62f9e58f686a in gc_sweep_page gc/default/default.c:3535:13
        #8 0x62f9e58f12b4 in gc_sweep_step gc/default/default.c:3810:9
        #9 0x62f9e58ed2a7 in gc_sweep gc/default/default.c:4058:13
    ...
    previously allocated by thread T5 here:
        #0 0x62f9e562f70d in calloc (miniruby+0x1fd70d) (BuildId: 5ad6d9e7cec8318df6726ea5ce34d3c76d0d0233)
        #1 0x62f9e58c8e1a in calloc1 gc/default/default.c:1472:12
        #2 0x62f9e58c8e1a in rb_gc_impl_calloc gc/default/default.c:8138:5
        #3 0x62f9e58c8e1a in ruby_xcalloc_body gc.c:4964:12
        #4 0x62f9e58c8e1a in ruby_xcalloc gc.c:4958:34
        #5 0x62f9e56f906e in push_subclass_entry_to_list class.c:88:13
        #6 0x62f9e56f906e in rb_class_subclass_add class.c:111:38
        #7 0x62f9e56f906e in RCLASS_SET_SUPER internal/class.h:257:9
        #8 0x62f9e56fca7a in make_metaclass class.c:786:5
        #9 0x62f9e59db982 in rb_class_initialize object.c:2101:5