### PR TITLE
Get rid of frozen shapes

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -818,9 +818,6 @@ shape_id_i(shape_id_t shape_id, void *data)
         dump_append_id(dc, shape->edge_name);
 
         break;
-      case SHAPE_FROZEN:
-        dump_append(dc, ", \"shape_type\":\"FROZEN\"");
-        break;
       case SHAPE_T_OBJECT:
         dump_append(dc, ", \"shape_type\":\"T_OBJECT\"");
         break;

--- a/id_table.c
+++ b/id_table.c
@@ -381,6 +381,7 @@ managed_id_table_dup_i(ID id, VALUE val, void *data)
 VALUE
 rb_managed_id_table_dup(VALUE old_table)
 {
+    RUBY_ASSERT(RB_TYPE_P(old_table, T_DATA));
     RUBY_ASSERT(rb_typeddata_inherited_p(RTYPEDDATA_TYPE(old_table), &managed_id_table_type));
 
     struct rb_id_table *new_tbl;
@@ -394,6 +395,7 @@ rb_managed_id_table_dup(VALUE old_table)
 int
 rb_managed_id_table_lookup(VALUE table, ID id, VALUE *valp)
 {
+    RUBY_ASSERT(RB_TYPE_P(table, T_DATA));
     RUBY_ASSERT(rb_typeddata_inherited_p(RTYPEDDATA_TYPE(table), &managed_id_table_type));
 
     return rb_id_table_lookup(RTYPEDDATA_GET_DATA(table), id, valp);
@@ -402,6 +404,7 @@ rb_managed_id_table_lookup(VALUE table, ID id, VALUE *valp)
 int
 rb_managed_id_table_insert(VALUE table, ID id, VALUE val)
 {
+    RUBY_ASSERT(RB_TYPE_P(table, T_DATA));
     RUBY_ASSERT(rb_typeddata_inherited_p(RTYPEDDATA_TYPE(table), &managed_id_table_type));
 
     return rb_id_table_insert(RTYPEDDATA_GET_DATA(table), id, val);
@@ -410,6 +413,7 @@ rb_managed_id_table_insert(VALUE table, ID id, VALUE val)
 size_t
 rb_managed_id_table_size(VALUE table)
 {
+    RUBY_ASSERT(RB_TYPE_P(table, T_DATA));
     RUBY_ASSERT(rb_typeddata_inherited_p(RTYPEDDATA_TYPE(table), &managed_id_table_type));
 
     return rb_id_table_size(RTYPEDDATA_GET_DATA(table));
@@ -418,6 +422,7 @@ rb_managed_id_table_size(VALUE table)
 void
 rb_managed_id_table_foreach(VALUE table, rb_id_table_foreach_func_t *func, void *data)
 {
+    RUBY_ASSERT(RB_TYPE_P(table, T_DATA));
     RUBY_ASSERT(rb_typeddata_inherited_p(RTYPEDDATA_TYPE(table), &managed_id_table_type));
 
     rb_id_table_foreach(RTYPEDDATA_GET_DATA(table), func, data);

--- a/internal/class.h
+++ b/internal/class.h
@@ -297,7 +297,6 @@ static inline void RCLASS_WRITE_CLASSPATH(VALUE klass, VALUE classpath, bool per
 #define RCLASS_PRIME_CLASSEXT_WRITABLE FL_USER2
 #define RCLASS_IS_INITIALIZED FL_USER3
 // 3 is RMODULE_IS_REFINEMENT for RMODULE
-// 4-19: SHAPE_FLAG_MASK
 
 /* class.c */
 rb_classext_t * rb_class_duplicate_classext(rb_classext_t *orig, VALUE obj, const rb_namespace_t *ns);

--- a/object.c
+++ b/object.c
@@ -496,12 +496,7 @@ rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze)
 
         if (RB_OBJ_FROZEN(obj)) {
             shape_id_t next_shape_id = rb_shape_transition_frozen(clone);
-            if (!rb_shape_obj_too_complex_p(clone) && rb_shape_too_complex_p(next_shape_id)) {
-                rb_evict_ivars_to_hash(clone);
-            }
-            else {
-                rb_obj_set_shape_id(clone, next_shape_id);
-            }
+            rb_obj_set_shape_id(clone, next_shape_id);
         }
         break;
       case Qtrue: {
@@ -518,14 +513,7 @@ rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze)
         rb_funcallv_kw(clone, id_init_clone, 2, argv, RB_PASS_KEYWORDS);
         RBASIC(clone)->flags |= FL_FREEZE;
         shape_id_t next_shape_id = rb_shape_transition_frozen(clone);
-        // If we're out of shapes, but we want to freeze, then we need to
-        // evacuate this clone to a hash
-        if (!rb_shape_obj_too_complex_p(clone) && rb_shape_too_complex_p(next_shape_id)) {
-            rb_evict_ivars_to_hash(clone);
-        }
-        else {
-            rb_obj_set_shape_id(clone, next_shape_id);
-        }
+        rb_obj_set_shape_id(clone, next_shape_id);
         break;
       }
       case Qfalse: {

--- a/shape.c
+++ b/shape.c
@@ -303,7 +303,7 @@ static void
 shape_tree_mark(void *data)
 {
     rb_shape_t *cursor = rb_shape_get_root_shape();
-    rb_shape_t *end = RSHAPE(GET_SHAPE_TREE()->next_shape_id);
+    rb_shape_t *end = RSHAPE(GET_SHAPE_TREE()->next_shape_id - 1);
     while (cursor < end) {
         if (cursor->edges && !SINGLE_CHILD_P(cursor->edges)) {
             // FIXME: GC compaction may call `rb_shape_traverse_from_new_root`

--- a/shape.h
+++ b/shape.h
@@ -3,17 +3,23 @@
 
 #include "internal/gc.h"
 
-#define SIZEOF_SHAPE_T 4
 typedef uint16_t attr_index_t;
 typedef uint32_t shape_id_t;
 #define SHAPE_ID_NUM_BITS 32
+#define SHAPE_ID_OFFSET_NUM_BITS 19
+
+STATIC_ASSERT(shape_id_num_bits, SHAPE_ID_NUM_BITS == sizeof(shape_id_t) * CHAR_BIT);
+
+#define SHAPE_BUFFER_SIZE (1 << SHAPE_ID_OFFSET_NUM_BITS)
+#define SHAPE_ID_OFFSET_MASK (SHAPE_BUFFER_SIZE - 1)
+#define SHAPE_ID_FLAGS_MASK (shape_id_t)(((1 << (SHAPE_ID_NUM_BITS - SHAPE_ID_OFFSET_NUM_BITS)) - 1) << SHAPE_ID_OFFSET_NUM_BITS)
+#define SHAPE_ID_FL_FROZEN (SHAPE_FL_FROZEN << SHAPE_ID_OFFSET_NUM_BITS)
 
 typedef uint32_t redblack_id_t;
 
 #define SHAPE_MAX_FIELDS (attr_index_t)(-1)
-
+#define SHAPE_FLAG_SHIFT ((SIZEOF_VALUE * CHAR_BIT) - SHAPE_ID_NUM_BITS)
 #define SHAPE_FLAG_MASK (((VALUE)-1) >> SHAPE_ID_NUM_BITS)
-#define SHAPE_FLAG_SHIFT ((SIZEOF_VALUE * 8) - SHAPE_ID_NUM_BITS)
 
 #define SHAPE_MAX_VARIATIONS 8
 
@@ -21,9 +27,9 @@ typedef uint32_t redblack_id_t;
 #define ATTR_INDEX_NOT_SET ((attr_index_t)-1)
 
 #define ROOT_SHAPE_ID               0x0
-#define SPECIAL_CONST_SHAPE_ID      0x1
-//      ROOT_TOO_COMPLEX_SHAPE_ID   0x2
-#define FIRST_T_OBJECT_SHAPE_ID     0x3
+//      ROOT_TOO_COMPLEX_SHAPE_ID   0x1
+#define SPECIAL_CONST_SHAPE_ID      (ROOT_SHAPE_ID | SHAPE_ID_FL_FROZEN)
+#define FIRST_T_OBJECT_SHAPE_ID     0x2
 
 extern ID ruby_internal_object_id;
 
@@ -54,9 +60,16 @@ enum shape_type {
     SHAPE_ROOT,
     SHAPE_IVAR,
     SHAPE_OBJ_ID,
-    SHAPE_FROZEN,
     SHAPE_T_OBJECT,
     SHAPE_OBJ_TOO_COMPLEX,
+};
+
+enum shape_flags {
+    SHAPE_FL_FROZEN             = 1 << 0,
+    SHAPE_FL_HAS_OBJECT_ID      = 1 << 1,
+    SHAPE_FL_TOO_COMPLEX        = 1 << 2,
+
+    SHAPE_FL_NON_CANONICAL_MASK = SHAPE_FL_FROZEN | SHAPE_FL_HAS_OBJECT_ID,
 };
 
 typedef struct {
@@ -105,7 +118,6 @@ RBASIC_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
 #if RBASIC_SHAPE_ID_FIELD
     RBASIC(obj)->shape_id = (VALUE)shape_id;
 #else
-    // Ractors are occupying the upper 32 bits of flags, but only in debug mode
     // Object shapes are occupying top bits
     RBASIC(obj)->flags &= SHAPE_FLAG_MASK;
     RBASIC(obj)->flags |= ((VALUE)(shape_id) << SHAPE_FLAG_SHIFT);
@@ -141,7 +153,7 @@ void rb_shape_copy_complex_ivars(VALUE dest, VALUE obj, shape_id_t src_shape_id,
 static inline bool
 rb_shape_canonical_p(shape_id_t shape_id)
 {
-    return !RSHAPE(shape_id)->flags;
+    return !(shape_id & SHAPE_ID_FLAGS_MASK) && !RSHAPE(shape_id)->flags;
 }
 
 static inline shape_id_t

--- a/shape.h
+++ b/shape.h
@@ -14,6 +14,7 @@ STATIC_ASSERT(shape_id_num_bits, SHAPE_ID_NUM_BITS == sizeof(shape_id_t) * CHAR_
 #define SHAPE_ID_OFFSET_MASK (SHAPE_BUFFER_SIZE - 1)
 #define SHAPE_ID_FLAGS_MASK (shape_id_t)(((1 << (SHAPE_ID_NUM_BITS - SHAPE_ID_OFFSET_NUM_BITS)) - 1) << SHAPE_ID_OFFSET_NUM_BITS)
 #define SHAPE_ID_FL_FROZEN (SHAPE_FL_FROZEN << SHAPE_ID_OFFSET_NUM_BITS)
+#define SHAPE_ID_READ_ONLY_MASK (~SHAPE_ID_FL_FROZEN)
 
 typedef uint32_t redblack_id_t;
 
@@ -108,6 +109,14 @@ RBASIC_SHAPE_ID(VALUE obj)
 #else
     return (shape_id_t)((RBASIC(obj)->flags) >> SHAPE_FLAG_SHIFT);
 #endif
+}
+
+// Same as RBASIC_SHAPE_ID but with flags that have no impact
+// on reads removed. e.g. Remove FL_FROZEN.
+static inline shape_id_t
+RBASIC_SHAPE_ID_FOR_READ(VALUE obj)
+{
+    return RBASIC_SHAPE_ID(obj) & SHAPE_ID_READ_ONLY_MASK;
 }
 
 static inline void

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -1055,11 +1055,12 @@ class TestShapes < Test::Unit::TestCase
 
   def test_freezing_and_duplicating_object
     obj = Object.new.freeze
+    assert_predicate(RubyVM::Shape.of(obj), :shape_frozen?)
+
+    # dup'd objects shouldn't be frozen
     obj2 = obj.dup
     refute_predicate(obj2, :frozen?)
-    # dup'd objects shouldn't be frozen, and the shape should be the
-    # parent shape of the copied object
-    assert_equal(RubyVM::Shape.of(obj).parent.id, RubyVM::Shape.of(obj2).id)
+    refute_predicate(RubyVM::Shape.of(obj2), :shape_frozen?)
   end
 
   def test_freezing_and_duplicating_object_with_ivars
@@ -1076,6 +1077,7 @@ class TestShapes < Test::Unit::TestCase
     str.freeze
     str2 = str.dup
     refute_predicate(str2, :frozen?)
+
     refute_equal(RubyVM::Shape.of(str).id, RubyVM::Shape.of(str2).id)
     assert_equal(str2.instance_variable_get(:@a), 1)
   end
@@ -1092,8 +1094,7 @@ class TestShapes < Test::Unit::TestCase
     obj2 = obj.clone(freeze: true)
     assert_predicate(obj2, :frozen?)
     refute_shape_equal(RubyVM::Shape.of(obj), RubyVM::Shape.of(obj2))
-    assert_equal(RubyVM::Shape::SHAPE_FROZEN, RubyVM::Shape.of(obj2).type)
-    assert_shape_equal(RubyVM::Shape.of(obj), RubyVM::Shape.of(obj2).parent)
+    assert_predicate(RubyVM::Shape.of(obj2), :shape_frozen?)
   end
 
   def test_freezing_and_cloning_object_with_ivars

--- a/variable.c
+++ b/variable.c
@@ -2057,12 +2057,6 @@ void rb_obj_freeze_inline(VALUE x)
         }
 
         shape_id_t next_shape_id = rb_shape_transition_frozen(x);
-
-        // If we're transitioning from "not complex" to "too complex"
-        // then evict ivars.  This can happen if we run out of shapes
-        if (rb_shape_too_complex_p(next_shape_id) && !rb_shape_obj_too_complex_p(x)) {
-            rb_evict_fields_to_hash(x);
-        }
         rb_obj_set_shape_id(x, next_shape_id);
 
         if (RBASIC_CLASS(x)) {
@@ -2227,8 +2221,6 @@ iterate_over_shapes_with_callback(rb_shape_t *shape, rb_ivar_foreach_callback_fu
             }
         }
         return false;
-      case SHAPE_FROZEN:
-        return iterate_over_shapes_with_callback(RSHAPE(shape->parent_id), callback, itr_data);
       case SHAPE_OBJ_TOO_COMPLEX:
       default:
         rb_bug("Unreachable");

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1215,14 +1215,13 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
 {
 #if OPT_IC_FOR_IVAR
     VALUE val = Qundef;
-    shape_id_t shape_id;
     VALUE * ivar_list;
 
     if (SPECIAL_CONST_P(obj)) {
         return default_value;
     }
 
-    shape_id = RBASIC_SHAPE_ID(obj);
+    shape_id_t shape_id = RBASIC_SHAPE_ID_FOR_READ(obj);
 
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:


### PR DESCRIPTION
Instead `shape_id_t` higher bits contain flags, and the first one tells whether the shape is frozen.

This has multiple benefits:
  - Can check if a shape is frozen with a single bit check instead of
    dereferencing a pointer.
  - Guarantees it is always possible to transition to frozen.
  - This allow reclaiming `FL_FREEZE`  (TODO).
  - Allow to efficiently normalize the `shape_id` on `getivar` so that frozen status doesn't invalidate inline caches.
