### PR TITLE
 Refactor `rb_obj_hash` to rely on object address instead of object_id

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -828,6 +828,9 @@ shape_i(rb_shape_t *shape, void *data)
       case SHAPE_OBJ_ID:
         dump_append(dc, ", \"shape_type\":\"OBJ_ID\"");
         break;
+      case SHAPE_OLD_ADDRESS:
+        dump_append(dc, ", \"shape_type\":\"OLD_ADDRESS\"");
+        break;
     }
 
     dump_append(dc, ", \"edges\":");

--- a/include/ruby/internal/fl_type.h
+++ b/include/ruby/internal/fl_type.h
@@ -281,11 +281,13 @@ ruby_fl_type {
                          = 0,
 
    /**
-    * This flag is no longer in use
+    * This flag is used to mark when an object address has been observed by
+    * `rb_obj_hash` or similar. This indicates to the GC that the old address
+    * must be recorded inside the moved object to keep `rb_obj_hash` stable.
     *
     * @internal
     */
-    RUBY_FL_UNUSED9  = (1<<9),
+    RUBY_FL_ADDRESS_SEEN  = (1<<9),
 
     /**
      * This flag has something to do with instance variables.  3rd parties need

--- a/shape.c
+++ b/shape.c
@@ -769,6 +769,31 @@ rb_shape_transition_old_address(VALUE obj)
 }
 
 bool
+rb_obj_old_address_p(VALUE obj)
+{
+    return rb_obj_shape(obj)->flags & SHAPE_FL_HAS_OLD_ADDRESS;
+}
+
+rb_shape_t *
+rb_obj_old_address_shape(VALUE obj)
+{
+    rb_shape_t* shape = rb_obj_shape(obj);
+    RUBY_ASSERT(shape);
+
+    if (shape->flags & SHAPE_FL_HAS_OLD_ADDRESS) {
+        while (shape->type != SHAPE_OLD_ADDRESS) {
+            shape = RSHAPE(shape->parent_id);
+        }
+        return shape;
+    }
+
+    bool dont_care;
+    rb_shape_t* next_shape = get_next_shape_internal(shape, id_old_address, SHAPE_OLD_ADDRESS, &dont_care, true);
+    RUBY_ASSERT(next_shape);
+    return next_shape;
+}
+
+bool
 rb_shape_has_object_id(rb_shape_t *shape)
 {
     return shape->flags & SHAPE_FL_HAS_OBJECT_ID;

--- a/shape.h
+++ b/shape.h
@@ -170,6 +170,9 @@ bool rb_shape_transition_remove_ivar(VALUE obj, ID id, VALUE *removed);
 shape_id_t rb_shape_transition_add_ivar(VALUE obj, ID id);
 shape_id_t rb_shape_transition_add_ivar_no_warnings(VALUE obj, ID id);
 
+bool rb_obj_old_address_p(VALUE obj);
+rb_shape_t *rb_obj_old_address_shape(VALUE obj);
+
 rb_shape_t *rb_shape_object_id_shape(VALUE obj);
 bool rb_shape_has_object_id(rb_shape_t *shape);
 void rb_shape_free_all(void);

--- a/shape.h
+++ b/shape.h
@@ -67,6 +67,7 @@ enum shape_type {
     SHAPE_ROOT,
     SHAPE_IVAR,
     SHAPE_OBJ_ID,
+    SHAPE_OLD_ADDRESS,
     SHAPE_FROZEN,
     SHAPE_T_OBJECT,
     SHAPE_OBJ_TOO_COMPLEX,

--- a/variable.c
+++ b/variable.c
@@ -1303,7 +1303,7 @@ rb_field_get(VALUE obj, rb_shape_t *target_shape)
 {
     RUBY_ASSERT(!SPECIAL_CONST_P(obj));
     RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));
-    RUBY_ASSERT(target_shape->type == SHAPE_IVAR || target_shape->type == SHAPE_OBJ_ID);
+    RUBY_ASSERT(target_shape->type == SHAPE_IVAR || target_shape->type == SHAPE_OBJ_ID || target_shape->type == SHAPE_OLD_ADDRESS);
 
     attr_index_t attr_index = target_shape->next_field_index - 1;
 

--- a/variable.c
+++ b/variable.c
@@ -2142,6 +2142,7 @@ iterate_over_shapes_with_callback(rb_shape_t *shape, rb_ivar_foreach_callback_fu
       case SHAPE_T_OBJECT:
         return false;
       case SHAPE_OBJ_ID:
+      case SHAPE_OLD_ADDRESS:
         if (itr_data->ivar_only) {
             return iterate_over_shapes_with_callback(RSHAPE(shape->parent_id), callback, itr_data);
         }


### PR DESCRIPTION
Whenever we observe the address of an object we record that as an object flag. Then if later on the object has to be moved, either by the GC compaction or through the Ractor API, then we store the old address inline inside the object fields.

cc @eightbitraptor 