### PR TITLE
Refactor `FIRST_T_OBJECT_SHAPE_ID` to not be used outside `shape.c`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -384,7 +384,7 @@ rb_gc_rebuild_shape(VALUE obj, size_t heap_id)
         return (uint32_t)orig_shape_id;
     }
 
-    shape_id_t initial_shape_id = (shape_id_t)(heap_id + FIRST_T_OBJECT_SHAPE_ID);
+    shape_id_t initial_shape_id = rb_shape_root(heap_id);
     shape_id_t new_shape_id = rb_shape_traverse_from_new_root(initial_shape_id, orig_shape_id);
 
     if (new_shape_id == INVALID_SHAPE_ID) {

--- a/object.c
+++ b/object.c
@@ -135,7 +135,7 @@ rb_class_allocate_instance(VALUE klass)
     RUBY_ASSERT(rb_obj_shape(obj)->type == SHAPE_ROOT);
 
     // Set the shape to the specific T_OBJECT shape.
-    ROBJECT_SET_SHAPE_ID(obj, (shape_id_t)(rb_gc_heap_id_for_size(size) + FIRST_T_OBJECT_SHAPE_ID));
+    ROBJECT_SET_SHAPE_ID(obj, rb_shape_root(rb_gc_heap_id_for_size(size)));
 
 #if RUBY_DEBUG
     RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));

--- a/shape.c
+++ b/shape.c
@@ -1419,7 +1419,7 @@ Init_default_shapes(void)
         t_object_shape->capacity = (uint32_t)((sizes[i] - offsetof(struct RObject, as.ary)) / sizeof(VALUE));
         t_object_shape->edges = rb_id_table_create(0);
         t_object_shape->ancestor_index = LEAF;
-        RUBY_ASSERT(rb_shape_id(t_object_shape) == (shape_id_t)(i + FIRST_T_OBJECT_SHAPE_ID));
+        RUBY_ASSERT(rb_shape_id(t_object_shape) == rb_shape_root(i));
     }
 
     // Prebuild TOO_COMPLEX variations so that they already exist if we ever need them after we

--- a/shape.h
+++ b/shape.h
@@ -187,6 +187,12 @@ rb_shape_canonical_p(rb_shape_t *shape)
     return !shape->flags;
 }
 
+static inline shape_id_t
+rb_shape_root(size_t heap_id)
+{
+    return (shape_id_t)(heap_id + FIRST_T_OBJECT_SHAPE_ID);
+}
+
 static inline uint32_t
 ROBJECT_FIELDS_CAPACITY(VALUE obj)
 {


### PR DESCRIPTION
Makes further changes easier.