### PR TITLE
Fix warnings in tests for ObjectSpace._id2ref

### DIFF
--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -8,7 +8,7 @@ class TestObjectSpace < Test::Unit::TestCase
     line = $1.to_i
     code = <<"End"
     define_method("test_id2ref_#{line}") {\
-      o = ObjectSpace._id2ref(obj.object_id);\
+      o = EnvUtil.suppress_warning { ObjectSpace._id2ref(obj.object_id) }
       assert_same(obj, o, "didn't round trip: \#{obj.inspect}");\
     }
 End
@@ -57,12 +57,12 @@ End
 
   def test_id2ref_invalid_argument
     msg = /no implicit conversion/
-    assert_raise_with_message(TypeError, msg) {ObjectSpace._id2ref(nil)}
-    assert_raise_with_message(TypeError, msg) {ObjectSpace._id2ref(false)}
-    assert_raise_with_message(TypeError, msg) {ObjectSpace._id2ref(true)}
-    assert_raise_with_message(TypeError, msg) {ObjectSpace._id2ref(:a)}
-    assert_raise_with_message(TypeError, msg) {ObjectSpace._id2ref("0")}
-    assert_raise_with_message(TypeError, msg) {ObjectSpace._id2ref(Object.new)}
+    assert_raise_with_message(TypeError, msg) { EnvUtil.suppress_warning { ObjectSpace._id2ref(nil) } }
+    assert_raise_with_message(TypeError, msg) { EnvUtil.suppress_warning { ObjectSpace._id2ref(false) } }
+    assert_raise_with_message(TypeError, msg) { EnvUtil.suppress_warning { ObjectSpace._id2ref(true) } }
+    assert_raise_with_message(TypeError, msg) { EnvUtil.suppress_warning { ObjectSpace._id2ref(:a) } }
+    assert_raise_with_message(TypeError, msg) { EnvUtil.suppress_warning { ObjectSpace._id2ref("0") } }
+    assert_raise_with_message(TypeError, msg) { EnvUtil.suppress_warning { ObjectSpace._id2ref(Object.new) } }
   end
 
   def test_id2ref_invalid_symbol_id
@@ -70,7 +70,7 @@ End
     # 8 bits of the object is equal to RUBY_SYMBOL_FLAG, so we need to make
     # sure that the bottom 8 bits remain unchanged.
     msg = /is not a symbol id value/
-    assert_raise_with_message(RangeError, msg) { ObjectSpace._id2ref(:a.object_id + 256) }
+    assert_raise_with_message(RangeError, msg) { EnvUtil.suppress_warning { ObjectSpace._id2ref(:a.object_id + 256) } }
   end
 
   def test_count_objects


### PR DESCRIPTION
There's a lot of warnings when running test_objectspace.rb because of ObjectSpace._id2ref. For example:

    test_objectspace.rb:19: warning: ObjectSpace._id2ref is deprecated