### PR TITLE
Only clear Ractor cache in child

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -9218,7 +9218,9 @@ gc_malloc_allocations(VALUE self)
 
 void rb_gc_impl_before_fork(void *objspace_ptr) { /* no-op */ }
 void rb_gc_impl_after_fork(void *objspace_ptr, rb_pid_t pid) {
-    rb_gc_ractor_newobj_cache_foreach(gc_ractor_newobj_cache_clear, NULL);
+    if (pid == 0) { /* child process */
+        rb_gc_ractor_newobj_cache_foreach(gc_ractor_newobj_cache_clear, NULL);
+    }
 }
 
 VALUE rb_ident_hash_new_with_size(st_index_t size);


### PR DESCRIPTION
This avoids a race condition where we were clearing the cache from another ractor while it was in use. Oops!

I wasn't paying close enough attention that:
1. `rb_gc_impl_after_fork` is run both on the parent and child
2. We don't trigger a vm_barrier when forking

Fixes this failure http://ci.rvm.jp/results/master@oci-aarch64/5750416

This was quite helpfully detected by TSAN (along with other warnings 😅)

```
WARNING: ThreadSanitizer: data race (pid=2069161)
  Read of size 8 at 0x722000012a08 by thread T2 (mutexes: write M0):
    #0 ractor_cache_allocate_slot /home/jhawthorn/src/ruby/./gc/default/default.c:2204:39 (miniruby+0x27e1ff) (BuildId: eed1f43ed8ad8c47bfee3b1462aef464f78905d2)
    #1 newobj_alloc /home/jhawthorn/src/ruby/./gc/default/default.c:2383:17 (miniruby+0x27e1ff)
    #2 rb_gc_impl_new_obj /home/jhawthorn/src/ruby/./gc/default/default.c:2465:15 (miniruby+0x27e1ff)
    #3 newobj_of /home/jhawthorn/src/ruby/gc.c:1005:17 (miniruby+0x27e1ff)
----8<----

  Previous write of size 8 at 0x722000012a08 by main thread:
    #0 __tsan_memset <null> (miniruby+0xae418) (BuildId: eed1f43ed8ad8c47bfee3b1462aef464f78905d2)
    #1 gc_ractor_newobj_cache_clear /home/jhawthorn/src/ruby/./gc/default/default.c:3684:25 (miniruby+0x29572f) (BuildId: eed1f43ed8ad8c47bfee3b1462aef464f78905d2)
    #2 rb_gc_ractor_newobj_cache_foreach /home/jhawthorn/src/ruby/gc.c:263:13 (miniruby+0x28c0a1) (BuildId: eed1f43ed8ad8c47bfee3b1462aef464f78905d2)
    #3 rb_gc_impl_after_fork /home/jhawthorn/src/ruby/./gc/default/default.c:9223:5 (miniruby+0x28c0a1)
    #4 rb_gc_after_fork /home/jhawthorn/src/ruby/gc.c:5180:5 (miniruby+0x28c0a1)
----8<----

  Location is heap block of size 128 at 0x722000012a00 allocated by main thread:
    #0 calloc <null> (miniruby+0xbf99f) (BuildId: eed1f43ed8ad8c47bfee3b1462aef464f78905d2)
    #1 calloc1 /home/jhawthorn/src/ruby/./gc/default/default.c:1472:12 (miniruby+0x28534e) (BuildId: eed1f43ed8ad8c47bfee3b1462aef464f78905d2)
    #2 rb_gc_impl_ractor_cache_alloc /home/jhawthorn/src/ruby/./gc/default/default.c:6158:12 (miniruby+0x28534e)
    #3 rb_gc_ractor_cache_alloc /home/jhawthorn/src/ruby/gc.c:3173:12 (miniruby+0x28534e)
----8<----
```