### PR TITLE
ZJIT: Stop padding side exits

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1678,7 +1678,7 @@ impl Assembler
                     asm_comment!(asm, "side exit: {state}");
                     asm.ccall(Self::rb_zjit_side_exit as *const u8, vec![]);
                     asm.compile(cb)?;
-                    *target = Target::CodePtr(side_exit_ptr);
+                    *target = Target::SideExitPtr(side_exit_ptr);
                 }
             }
         }


### PR DESCRIPTION
This PR lets the backend compile jumps to side exits using `Target::SideExitPtr` instead of `Target::CodePtr` to avoid filling unnecessary `nop` instructions after such jumps.

The backend assumes any `Target::CodePtr` could be invalidated due to patch points or chain guards. However, we never invalidate side exits. So, in YJIT, we introduced `Target::SideExitPtr` to distinguish side exits from other jumps. 