### PR TITLE
Refactor `rb_obj_field_get` to handle complex shapes

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1844,7 +1844,7 @@ object_id(VALUE obj)
     }
     else if (rb_shape_has_object_id(shape)) {
         rb_shape_t *object_id_shape = rb_shape_object_id_shape(obj);
-        id = rb_field_get(obj, object_id_shape);
+        id = rb_obj_field_get(obj, object_id_shape);
     }
     else {
         id = ULL2NUM(next_object_id);

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -51,7 +51,7 @@ void rb_obj_copy_ivs_to_hash_table(VALUE obj, st_table *table);
 void rb_obj_init_too_complex(VALUE obj, st_table *table);
 void rb_evict_ivars_to_hash(VALUE obj);
 void rb_evict_fields_to_hash(VALUE obj);
-VALUE rb_field_get(VALUE obj, rb_shape_t *target_shape);
+VALUE rb_obj_field_get(VALUE obj, rb_shape_t *target_shape);
 void rb_ivar_set_internal(VALUE obj, ID id, VALUE val);
 void rb_obj_field_set(VALUE obj, rb_shape_t *target_shape, VALUE val);
 

--- a/variable.c
+++ b/variable.c
@@ -1299,7 +1299,7 @@ gen_fields_tbl_count(VALUE obj, const struct gen_fields_tbl *fields_tbl)
 }
 
 VALUE
-rb_field_get(VALUE obj, rb_shape_t *target_shape)
+rb_obj_field_get(VALUE obj, rb_shape_t *target_shape)
 {
     RUBY_ASSERT(!SPECIAL_CONST_P(obj));
     RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));


### PR DESCRIPTION
This allow to get or set fields without having to worry about the shape type.

