### PR TITLE
Fix prism instruction generation differences for `def a(x, ...); b(...); end`

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1763,7 +1763,7 @@ pm_setup_args_core(const pm_arguments_node_t *arguments_node, const pm_node_t *b
 
                 orig_argc += 2;
 
-                *flags |= VM_CALL_ARGS_SPLAT | VM_CALL_ARGS_SPLAT_MUT | VM_CALL_ARGS_BLOCKARG | VM_CALL_KW_SPLAT;
+                *flags |= VM_CALL_ARGS_SPLAT | VM_CALL_ARGS_BLOCKARG | VM_CALL_KW_SPLAT;
 
                 // Forwarding arguments nodes are treated as foo(*, **, &)
                 // So foo(...) equals foo(*, **, &) and as such the local
@@ -1772,7 +1772,7 @@ pm_setup_args_core(const pm_arguments_node_t *arguments_node, const pm_node_t *b
                 // Push the *
                 pm_local_index_t mult_local = pm_lookup_local_index(iseq, scope_node, PM_CONSTANT_MULT, 0);
                 PUSH_GETLOCAL(ret, location, mult_local.index, mult_local.level);
-                PUSH_INSN1(ret, location, splatarray, Qtrue);
+                PUSH_INSN1(ret, location, splatarray, Qfalse);
 
                 // Push the **
                 pm_local_index_t pow_local = pm_lookup_local_index(iseq, scope_node, PM_CONSTANT_POW, 0);
@@ -1781,7 +1781,6 @@ pm_setup_args_core(const pm_arguments_node_t *arguments_node, const pm_node_t *b
                 // Push the &
                 pm_local_index_t and_local = pm_lookup_local_index(iseq, scope_node, PM_CONSTANT_AND, 0);
                 PUSH_INSN2(ret, location, getblockparamproxy, INT2FIX(and_local.index + VM_ENV_DATA_SIZE - 1), INT2FIX(and_local.level));
-                PUSH_INSN(ret, location, splatkw);
 
                 break;
               }


### PR DESCRIPTION
Diff instructions against parse.y using:

    DUMP="puts RubyVM::InstructionSequence.compile(ARGV.first).disasm.gsub(/^\d+ /, '')"
    RUBY="def a(x, ...); b(...); end"

    env -u RUBYOPT \
        diff -U99 \
        <(./build/ruby -v --parser=parse.y -e "$DUMP" "$RUBY" 2>/dev/null) \
        <(./build/ruby -v --parser=prism   -e "$DUMP" "$RUBY" 2>/dev/null)