### PR TITLE
Revert "Fix redefinition of `clock_gettime` and `clock_getres`"

### DIFF
--- a/win32/win32.c
+++ b/win32/win32.c
@@ -4761,7 +4761,6 @@ gettimeofday(struct timeval *tv, struct timezone *tz)
     return 0;
 }
 
-#ifndef HAVE_CLOCK_GETTIME
 /* License: Ruby's */
 int
 clock_gettime(clockid_t clock_id, struct timespec *sp)
@@ -4801,9 +4800,7 @@ clock_gettime(clockid_t clock_id, struct timespec *sp)
         return -1;
     }
 }
-#endif
 
-#ifndef HAVE_CLOCK_GETRES
 /* License: Ruby's */
 int
 clock_getres(clockid_t clock_id, struct timespec *sp)
@@ -4831,7 +4828,6 @@ clock_getres(clockid_t clock_id, struct timespec *sp)
         return -1;
     }
 }
-#endif
 
 /* License: Ruby's */
 static char *


### PR DESCRIPTION
This reverts commit 585598623da949c92d0f2ea94029a863142ec908.

This broke Windows CIs

```
linking miniruby.exe
   Creating library miniruby.lib and object miniruby.exp
process.obj : error LNK2019: unresolved external symbol clock_gettime referenced in function rb_clock_gettime
random.obj : error LNK2001: unresolved external symbol clock_gettime
thread.obj : error LNK2001: unresolved external symbol clock_gettime
time.obj : error LNK2001: unresolved external symbol clock_gettime
process.obj : error LNK2019: unresolved external symbol clock_getres referenced in function rb_clock_getres
miniruby.exe : fatal error LNK1120: 2 unresolved externals
NMAKE : fatal error U1077: '"C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.29.30133\bin\HostX64\x64\cl.EXE"' : return code '0x2'
```