### PR TITLE
Allow T_CLASS and generic types to be too_complex

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1872,26 +1872,7 @@ object_id(VALUE obj)
     // we'd at least need to generate the object_id using atomics.
     lock_lev = rb_gc_vm_lock();
 
-    if (rb_shape_too_complex_p(shape)) {
-        st_table *table = ROBJECT_FIELDS_HASH(obj);
-        if (rb_shape_has_object_id(shape)) {
-            st_lookup(table, (st_data_t)ruby_internal_object_id, (st_data_t *)&id);
-            RUBY_ASSERT(id, "object_id missing");
-
-            rb_gc_vm_unlock(lock_lev);
-            return id;
-        }
-
-        id = ULL2NUM(next_object_id);
-        next_object_id += OBJ_ID_INCREMENT;
-        rb_shape_t *object_id_shape = rb_shape_object_id_shape(obj);
-        st_insert(table, (st_data_t)ruby_internal_object_id, (st_data_t)id);
-        rb_shape_set_shape(obj, object_id_shape);
-        if (RB_UNLIKELY(id_to_obj_tbl)) {
-            st_insert(id_to_obj_tbl, (st_data_t)id, (st_data_t)obj);
-        }
-    }
-    else if (rb_shape_has_object_id(shape)) {
+    if (rb_shape_has_object_id(shape)) {
         rb_shape_t *object_id_shape = rb_shape_object_id_shape(obj);
         id = rb_obj_field_get(obj, object_id_shape);
     }

--- a/test/ruby/test_object_id.rb
+++ b/test/ruby/test_object_id.rb
@@ -137,10 +137,14 @@ class TestObjectIdTooComplex < TestObjectId
       assert_equal 8, RubyVM::Shape::SHAPE_MAX_VARIATIONS
     end
     8.times do |i|
-      TooComplex.new.instance_variable_set("@a#{i}", 1)
+      TooComplex.new.instance_variable_set("@TestObjectIdTooComplex#{i}", 1)
     end
     @obj = TooComplex.new
-    @obj.instance_variable_set(:@test, 1)
+    @obj.instance_variable_set("@a#{rand(10_000)}", 1)
+
+    if defined?(RubyVM::Shape)
+      assert_predicate(RubyVM::Shape.of(@obj), :too_complex?)
+    end
   end
 end
 
@@ -152,11 +156,21 @@ class TestObjectIdTooComplexClass < TestObjectId
     if defined?(RubyVM::Shape::SHAPE_MAX_VARIATIONS)
       assert_equal 8, RubyVM::Shape::SHAPE_MAX_VARIATIONS
     end
-    8.times do |i|
-      TooComplex.new.instance_variable_set("@a#{i}", 1)
-    end
+
     @obj = TooComplex.new
-    @obj.instance_variable_set(:@test, 1)
+
+    @obj.instance_variable_set("@___#{rand(100_000)}", 1)
+
+    8.times do |i|
+      @obj.instance_variable_set("@TestObjectIdTooComplexClass#{i}", 1)
+      @obj.remove_instance_variable("@TestObjectIdTooComplexClass#{i}")
+    end
+
+    @obj.instance_variable_set("@___#{rand(100_000)}", 1)
+
+    if defined?(RubyVM::Shape)
+      assert_predicate(RubyVM::Shape.of(@obj), :too_complex?)
+    end
   end
 end
 
@@ -169,9 +183,14 @@ class TestObjectIdTooComplexGeneric < TestObjectId
       assert_equal 8, RubyVM::Shape::SHAPE_MAX_VARIATIONS
     end
     8.times do |i|
-      TooComplex.new.instance_variable_set("@a#{i}", 1)
+      TooComplex.new.instance_variable_set("@TestObjectIdTooComplexGeneric#{i}", 1)
     end
     @obj = TooComplex.new
-    @obj.instance_variable_set(:@test, 1)
+    @obj.instance_variable_set("@a#{rand(10_000)}", 1)
+    @obj.instance_variable_set("@a#{rand(10_000)}", 1)
+
+    if defined?(RubyVM::Shape)
+      assert_predicate(RubyVM::Shape.of(@obj), :too_complex?)
+    end
   end
 end


### PR DESCRIPTION
The intial complex shape implementation never allowed objects other than T_OBJECT to become too complex, unless we run out of shapes.

I don't see any reason to prevent that.

Ref: https://github.com/ruby/ruby/pull/6931