### PR TITLE
Add an additional test to module_eqq

### DIFF
--- a/benchmark/module_eqq.yml
+++ b/benchmark/module_eqq.yml
@@ -1,4 +1,5 @@
 prelude: |
+  module SomeModule; end
   class SimpleClass; end
   class MediumClass
     10.times { include Module.new }
@@ -24,4 +25,8 @@ benchmark:
     SimpleClass === LargeObj
   simple_class_eqq_huge_obj: |
     SimpleClass === HugeObj
-loop_count: 20000000
+  simple_class_eqq_module: |
+    SimpleClass === HugeObj
+  module_eqq_module: |
+    SomeModule === HugeObj
+loop_count: 10000000


### PR DESCRIPTION
Another case to help demonstrate the namespace performance penalty

```
❯ make benchmark ITEM=module_eqq
/home/jhawthorn/.rubies/ruby-3.4.1/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="compare-ruby::/home/jhawthorn/.rubies/ruby-3.4.1/bin/ruby --disable=gems -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            --output=markdown --output-compare -v $(find ./benchmark -maxdepth 1 -name 'module_eqq' -o -name '*module_eqq*.yml' -o -name '*module_eqq*.rb' | sort)
compare-ruby: ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
built-ruby: ruby 3.5.0dev (2025-05-12T07:49:59Z master 131ba059ca) +PRISM [x86_64-linux]
# Iteration per second (i/s)
|                             |compare-ruby|built-ruby|
|:----------------------------|-----------:|---------:|
|simple_class_eqq_simple_obj  |     62.318M|   48.763M|
|                             |       1.28x|         -|
|medium_class_eqq_simple_obj  |     62.044M|   49.489M|
|                             |       1.25x|         -|
|simple_class_eqq_medium_obj  |     61.798M|   50.382M|
|                             |       1.23x|         -|
|simple_class_eqq_large_obj   |     61.179M|   49.809M|
|                             |       1.23x|         -|
|simple_class_eqq_huge_obj    |     62.527M|   50.187M|
|                             |       1.25x|         -|
|simple_class_eqq_module      |     63.095M|   50.237M|
|                             |       1.26x|         -|
|module_eqq_module            |      3.261M|    1.952M|
|                             |       1.67x|         -|
```