### PR TITLE
Handle to look up CGI::EscapeExt instead of using LoadError

### DIFF
--- a/lib/bundler/fetcher/dependency.rb
+++ b/lib/bundler/fetcher/dependency.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "base"
-begin
-  require "cgi/escape"
-rescue LoadError
-  require "cgi/util"
-end
+require "cgi/escape"
+require "cgi/util" unless defined?(CGI::EscapeExt)
 
 module Bundler
   class Fetcher

--- a/lib/bundler/friendly_errors.rb
+++ b/lib/bundler/friendly_errors.rb
@@ -102,11 +102,8 @@ module Bundler
     def issues_url(exception)
       message = exception.message.lines.first.tr(":", " ").chomp
       message = message.split("-").first if exception.is_a?(Errno)
-      begin
-        require "cgi/escape"
-      rescue LoadError
-        require "cgi/util"
-      end
+      require "cgi/escape"
+      require "cgi/util" unless defined?(CGI::EscapeExt)
       "https://github.com/rubygems/rubygems/search?q=" \
         "#{CGI.escape(message)}&type=Issues"
     end

--- a/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
+++ b/lib/bundler/vendor/net-http-persistent/lib/net/http/persistent.rb
@@ -1,10 +1,7 @@
 require_relative '../../../../../vendored_net_http'
 require_relative '../../../../../vendored_uri'
-begin
-  require 'cgi/escape'
-rescue LoadError
-  require 'cgi/util' # for escaping
-end
+require 'cgi/escape'
+require 'cgi/util' unless defined?(CGI::EscapeExt)
 require_relative '../../../../connection_pool/lib/connection_pool'
 
 autoload :OpenSSL, 'openssl'

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1917,11 +1917,8 @@ module Net   #:nodoc:
     private
 
     def unescape(value)
-      begin
-        require "cgi/escape"
-      rescue LoadError
-        require "cgi/util"
-      end
+      require 'cgi/escape'
+      require 'cgi/util' unless defined?(CGI::EscapeExt)
       CGI.unescape(value)
     end
 

--- a/lib/rubygems/uri_formatter.rb
+++ b/lib/rubygems/uri_formatter.rb
@@ -17,11 +17,8 @@ class Gem::UriFormatter
   # Creates a new URI formatter for +uri+.
 
   def initialize(uri)
-    begin
-      require "cgi/escape"
-    rescue LoadError
-      require "cgi/util"
-    end
+    require "cgi/escape"
+    require "cgi/util" unless defined?(CGI::EscapeExt)
 
     @uri = uri
   end

--- a/lib/rubygems/vendor/net-http/lib/net/http.rb
+++ b/lib/rubygems/vendor/net-http/lib/net/http.rb
@@ -1923,11 +1923,8 @@ module Gem::Net   #:nodoc:
     private
 
     def unescape(value)
-      begin
-        require "cgi/escape"
-      rescue LoadError
-        require "cgi/util"
-      end
+      require 'cgi/escape'
+      require 'cgi/util' unless defined?(CGI::EscapeExt)
       CGI.unescape(value)
     end
 

--- a/prism/templates/lib/prism/dot_visitor.rb.erb
+++ b/prism/templates/lib/prism/dot_visitor.rb.erb
@@ -1,8 +1,5 @@
-begin
-  require "cgi/escape"
-rescue LoadError
-  require "cgi/util"
-end
+require "cgi/escape"
+require "cgi/util" unless defined?(CGI::EscapeExt)
 
 module Prism
   # This visitor provides the ability to call Node#to_dot, which converts a


### PR DESCRIPTION
cgi/escape is provided snce Ruby 2.3. The current code always skip to load `cgi/util`.