### PR TITLE
Fix `object_id` for classes and modules in namespace context

### DIFF
--- a/internal/class.h
+++ b/internal/class.h
@@ -138,6 +138,7 @@ STATIC_ASSERT(shape_max_variations, SHAPE_MAX_VARIATIONS < (1 << (sizeof(((rb_cl
 struct RClass {
     struct RBasic basic;
     st_table *ns_classext_tbl; // ns_object -> (rb_classext_t *)
+    VALUE object_id;
     /*
      * If ns_classext_tbl is NULL, then the prime classext is readable (because no other classext exists).
      * For the check whether writable or not, check flag RCLASS_PRIME_CLASSEXT_WRITABLE


### PR DESCRIPTION
Given classes and modules have a different set of fields in every namespace, we can't store the `object_id` in fields for them.

First because the `shape_id` is different if an object has an `object_id`, so we'd lookup the ID in a `st_table` that may not have it and crash.
But even if somehow each `class_ext` had a `shape_id`, the `object_id` would be different in every namespace, and as far as I understand that's not how namespaces are supposed to work.

Given that some space was freed in `RClass` we can store it there instead, which has the benefit of allowing it to be lockless (not fully in this PR but I have another one to generate object IDs atomically).

@tagomoris did I get namespaces correctly?

Also cc @jhawthorn 