### PR TITLE
Bump the required BASERUBY version to 3.1

### DIFF
--- a/.github/workflows/annocheck.yml
+++ b/.github/workflows/annocheck.yml
@@ -76,7 +76,7 @@ jobs:
 
       - uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
           bundler: none
 
       # Minimal flags to pass the check.

--- a/.github/workflows/baseruby.yml
+++ b/.github/workflows/baseruby.yml
@@ -45,7 +45,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - ruby-3.0
           - ruby-3.1
           - ruby-3.2
           - ruby-3.3

--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
           bundler: none
 
       - name: Run configure

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -50,7 +50,6 @@ jobs:
           # To mitigate flakiness of MinGW CI, we test only one runtime that newer MSYS2 uses.
           # Ruby 3.2 is the first Windows Ruby to use OpenSSL 3.x
           - msystem: 'UCRT64'
-            baseruby: '3.2'
             test_task: 'check'
             test-all-opts: '--name=!/TestObjSpace#test_reachable_objects_during_iteration/'
       fail-fast: false
@@ -69,7 +68,7 @@ jobs:
       - name: Set up Ruby & MSYS2
         uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
         with:
-          ruby-version: ${{ matrix.baseruby }}
+          ruby-version: '3.2'
 
       - name: Misc system & package info
         working-directory:

--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
           bundler: none
         if: ${{ contains(matrix.os, 'ubuntu') }}
 

--- a/.github/workflows/parse_y.yml
+++ b/.github/workflows/parse_y.yml
@@ -60,6 +60,11 @@ jobs:
 
       - uses: ./.github/actions/setup/ubuntu
 
+      - uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
+        with:
+          ruby-version: '3.1'
+          bundler: none
+
       - uses: ./.github/actions/setup/directories
         with:
           srcdir: src

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -70,7 +70,7 @@ jobs:
 
       - uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
           bundler: none
         if: ${{ !endsWith(matrix.os, 'arm') }}
 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -102,7 +102,7 @@ jobs:
 
       - uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
           bundler: none
 
       - name: Build baseruby

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,7 +70,6 @@ jobs:
           ruby-version: '3.1'
           bundler: none
           windows-toolchain: none
-        if: ${{ matrix.os != '11-arm' }}
 
       - name: Install libraries with scoop
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
       - run: md build
         working-directory:
 
-      - uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
+      - uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
         with:
           ruby-version: '3.1'
           bundler: none

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,8 @@ jobs:
 
       - uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
         with:
-          ruby-version: '3.1'
+          # windows-11-arm has only 3.4.1, 3.4.2, 3.4.3, head
+          ruby-version: ${{ matrix.os != '11-arm' && '3.1' || '3.4' }}
           bundler: none
           windows-toolchain: none
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
 
       - uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
           bundler: none
           windows-toolchain: none
         if: ${{ matrix.os != '11-arm' }}

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -137,7 +137,7 @@ jobs:
 
       - uses: ruby/setup-ruby@d8d83c3960843afb664e821fed6be52f37da5267 # v1.231.0
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
           bundler: none
 
       - uses: ./.github/actions/setup/directories

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: ruby/setup-ruby@a6e6f86333f0a2523ece813039b8b4be04560854 # v1.190.0
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.1'
           bundler: none
 
       - uses: taiki-e/install-action@v2

--- a/tool/missing-baseruby.bat
+++ b/tool/missing-baseruby.bat
@@ -18,6 +18,6 @@
 : ; abort () { exit 1; }
 
 call :warn "executable host ruby is required.  use --with-baseruby option."
-call :warn "Note that BASERUBY must be Ruby 3.0.0 or later."
+call :warn "Note that BASERUBY must be Ruby 3.1.0 or later."
 call :abort
 : || (:^; abort if RUBY_VERSION < s[%r"warn .*Ruby ([\d.]+)(?:\.0)?",1])


### PR DESCRIPTION
[[Misc #16671]](https://bugs.ruby-lang.org/issues/16671)

[Matz decided](https://bugs.ruby-lang.org/issues/16671#note-10) that the latest version of Debian should determine the required BASERUBY version. We also consider the latest stable Ubuntu release. 

* Debian 12 (bookworm): Ruby 3.1
* Ubuntu 24.04 (Noble): Ruby 3.2

As per Matz' policy, and given Ruby 3.0 is EOL, we should be able to upgrade BASERUBY to Ruby 3.1.