### PR TITLE
[Bug #21336] Stop using `rb_ensure` during GC for hash iteration

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2675,10 +2675,10 @@ static void
 mark_hash(VALUE hash)
 {
     if (rb_hash_compare_by_id_p(hash)) {
-        rb_hash_stlike_foreach(hash, pin_key_mark_value, 0);
+        rb_hash_stlike_foreach_no_ensure(hash, pin_key_mark_value, 0);
     }
     else {
-        rb_hash_stlike_foreach(hash, mark_keyvalue, 0);
+        rb_hash_stlike_foreach_no_ensure(hash, mark_keyvalue, 0);
     }
 
     gc_mark_internal(RHASH(hash)->ifnone);
@@ -3536,7 +3536,7 @@ rb_gc_update_tbl_refs(st_table *ptr)
 static void
 gc_ref_update_hash(void *objspace, VALUE v)
 {
-    rb_hash_stlike_foreach_with_replace(v, hash_foreach_replace, hash_replace_ref, (st_data_t)objspace);
+    rb_hash_stlike_foreach_with_replace_no_ensure(v, hash_foreach_replace, hash_replace_ref, (st_data_t)objspace);
 }
 
 static void

--- a/hash.c
+++ b/hash.c
@@ -1442,6 +1442,18 @@ rb_hash_stlike_foreach(VALUE hash, st_foreach_callback_func *func, st_data_t arg
     return (int)ret;
 }
 
+int
+rb_hash_stlike_foreach_no_ensure(VALUE hash, st_foreach_callback_func *func, st_data_t arg)
+{
+    struct hash_stlike_foreach_arg args = {
+        .hash = hash,
+        .func = func,
+        .arg = arg,
+    };
+
+    return (int)hash_stlike_foreach_call((VALUE)&args);
+}
+
 struct hash_stlike_foreach_with_replace_arg {
     VALUE hash;
     st_foreach_check_callback_func *func;
@@ -1483,6 +1495,21 @@ rb_hash_stlike_foreach_with_replace(VALUE hash, st_foreach_check_callback_func *
                           hash_foreach_ensure, hash);
     return (int)ret;
 }
+
+int
+rb_hash_stlike_foreach_with_replace_no_ensure(VALUE hash, st_foreach_check_callback_func *func,
+                                              st_update_callback_func *replace, st_data_t arg)
+{
+    struct hash_stlike_foreach_with_replace_arg args = {
+        .hash = hash,
+        .func = func,
+        .replace = replace,
+        .arg = arg,
+    };
+
+    return (int)hash_stlike_foreach_with_replace_call((VALUE)&args);
+}
+
 
 static VALUE
 hash_foreach_call(VALUE arg)

--- a/internal/hash.h
+++ b/internal/hash.h
@@ -86,6 +86,8 @@ int rb_hash_add_new_element(VALUE hash, VALUE key, VALUE val);
 VALUE rb_hash_set_pair(VALUE hash, VALUE pair);
 int rb_hash_stlike_delete(VALUE hash, st_data_t *pkey, st_data_t *pval);
 int rb_hash_stlike_foreach_with_replace(VALUE hash, st_foreach_check_callback_func *func, st_update_callback_func *replace, st_data_t arg);
+int rb_hash_stlike_foreach_no_ensure(VALUE hash, st_foreach_callback_func *func, st_data_t arg);
+int rb_hash_stlike_foreach_with_replace_no_ensure(VALUE hash, st_foreach_check_callback_func *func, st_update_callback_func *replace, st_data_t arg);
 int rb_hash_stlike_update(VALUE hash, st_data_t key, st_update_callback_func *func, st_data_t arg);
 bool rb_hash_default_unredefined(VALUE hash);
 VALUE rb_ident_hash_new_with_size(st_index_t size);


### PR DESCRIPTION
bb180b87b43c45e17ff49735a26d7a188d5c8396 introduced some `rb_ensure` calls in `rb_hash_stlike_foreach{,with_replace}`. This caused "Cannot malloc during GC" on Wasm because:
1. `rb_ensure` calls `xmalloc` on Wasm to allocate jump buffers
2. `rb_hash_stlike_foreach{,with_replace}` is called during GC to mark hash values

All `rb_hash_stlike_foreach{,with_replace}` calls during GC are known not to raise exceptions, so we can safely use them without `rb_ensure`. This commit adds `_no_ensure` variants of these functions and uses them in the GC code to fix the Wasm issue.