### PR TITLE
Purge the oldest TRAP cache generated by CodeQL

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -123,8 +123,6 @@ jobs:
 
       - name: Purge the oldest TRAP cache
         if: ${{ github.repository == 'ruby/ruby' && matrix.language == 'cpp'}}
-        run: |
-          gh extension install actions/gh-actions-cache
-          gh actions-cache list --key codeql --order asc --limit 1 |  cut -f 1 | xargs -I{} gh actions-cache delete {} --confirm
+        run: gh cache list --key codeql --order asc --limit 1 --json key --jq '.[].key' | xargs -I{} gh cache delete {}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.MATZBOT_GITHUB_WORKFLOW_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,7 +50,6 @@ jobs:
 
     env:
       enable_install_doc: no
-      CODEQL_ACTION_CLEANUP_TRAP_CACHES: true
 
     strategy:
       fail-fast: false
@@ -81,7 +80,6 @@ jobs:
         uses: github/codeql-action/init@df409f7d9260372bd5f19e5b04e83cb3c43714ae # v3.27.9
         with:
           languages: ${{ matrix.language }}
-          dependency-caching: false
           debug: true
 
       - name: Autobuild
@@ -122,3 +120,11 @@ jobs:
         with:
           sarif_file: sarif-results/${{ matrix.language }}.sarif
         continue-on-error: true
+
+      - name: Purge the oldest TRAP cache
+        if: ${{ github.repository == 'ruby/ruby' && matrix.language == 'cpp'}}
+        run: |
+          gh extension install actions/gh-actions-cache
+          gh actions-cache list --key codeql --order asc --limit 1 |  cut -f 1 | xargs -I{} gh actions-cache delete {} --confirm
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,6 +81,7 @@ jobs:
         uses: github/codeql-action/init@df409f7d9260372bd5f19e5b04e83cb3c43714ae # v3.27.9
         with:
           languages: ${{ matrix.language }}
+          dependency-caching: false
           debug: true
 
       - name: Autobuild


### PR DESCRIPTION
I tried to disable TRAP cache generated by CodeQL in recent weeks. But `CODEQL_ACTION_CLEANUP_TRAP_CACHES` and `dependency-cache: false` are not working that.

I have no idea to disable that. The average size of TRAP cache is 300MB+ and generated each jobs of GitHub actions. It's harmful for our cache strategy. In fact, vcpkg cache of Windows sometimes purged and rebuild with 40 min.

## Solution

I removed TRAP cache with `gh cache` command manually each jobs.