### PR TITLE
Prevent double free for too big repetition quantifiers

### DIFF
--- a/regparse.c
+++ b/regparse.c
@@ -6717,7 +6717,7 @@ parse_subexp(Node** top, OnigToken* tok, int term,
 	     UChar** src, UChar* end, ScanEnv* env)
 {
   int r;
-  Node *node, **headp;
+  Node *node, *topnode, **headp;
 
   *top = NULL;
   env->parse_depth++;
@@ -6733,26 +6733,29 @@ parse_subexp(Node** top, OnigToken* tok, int term,
     *top = node;
   }
   else if (r == TK_ALT) {
-    *top  = onig_node_new_alt(node, NULL);
-    headp = &(NCDR(*top));
+    topnode = onig_node_new_alt(node, NULL);
+    headp   = &(NCDR(topnode));
     while (r == TK_ALT) {
       r = fetch_token(tok, src, end, env);
       if (r < 0) {
-	onig_node_free(node);
+	onig_node_free(topnode);
 	return r;
       }
       r = parse_branch(&node, tok, term, src, end, env);
       if (r < 0) {
-	onig_node_free(node);
+	onig_node_free(topnode);
 	return r;
       }
 
       *headp = onig_node_new_alt(node, NULL);
-      headp = &(NCDR(*headp));
+      headp  = &(NCDR(*headp));
     }
 
-    if (tok->type != (enum TokenSyms )term)
+    if (tok->type != (enum TokenSyms )term) {
+      onig_node_free(topnode);
       goto err;
+    }
+    *top = topnode;
   }
   else {
     onig_node_free(node);

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1875,6 +1875,12 @@ class TestRegexp < Test::Unit::TestCase
     end;
   end
 
+  def test_too_big_number_for_repeat_range
+    assert_raise_with_message(SyntaxError, /too big number for repeat range/) do
+      eval(%[/|{1000000}/])
+    end
+  end
+
   # This assertion is for porting x2() tests in testpy.py of Onigmo.
   def assert_match_at(re, str, positions, msg = nil)
     re = Regexp.new(re) unless re.is_a?(Regexp)


### PR DESCRIPTION
The previous implementation calls `free(node)` twice (on parsing and compiling a regexp) when it has an error, so it leads to a double-free issue. This PR enforces `free(node)` once by introducing a temporal pointer to hold parsing nodes.