### PR TITLE
Use atomics for system_working global

### DIFF
--- a/misc/tsan_suppressions.txt
+++ b/misc/tsan_suppressions.txt
@@ -30,9 +30,6 @@ race_top:RUBY_VM_INTERRUPTED_ANY
 race_top:unblock_function_set
 race_top:threadptr_get_interrupts
 
-# system_working needs to be converted to atomic
-race:system_working
-
 # It's already crashing. We're doing our best
 signal:rb_vm_bugreport
 race:check_reserved_signal_

--- a/thread.c
+++ b/thread.c
@@ -148,7 +148,7 @@ static int hrtime_update_expire(rb_hrtime_t *, const rb_hrtime_t);
 NORETURN(static void async_bug_fd(const char *mesg, int errno_arg, int fd));
 MAYBE_UNUSED(static int consume_communication_pipe(int fd));
 
-static volatile int system_working = 1;
+static rb_atomic_t system_working = 1;
 static rb_internal_thread_specific_key_t specific_key_count;
 
 /********************************************************************************/

--- a/thread_win32.c
+++ b/thread_win32.c
@@ -798,14 +798,14 @@ rb_thread_create_timer_thread(void)
 static int
 native_stop_timer_thread(void)
 {
-    int stopped = --system_working <= 0;
-    if (stopped) {
-        SetEvent(timer_thread.lock);
-        native_thread_join(timer_thread.id);
-        CloseHandle(timer_thread.lock);
-        timer_thread.lock = 0;
-    }
-    return stopped;
+    RUBY_ATOMIC_SET(system_working, 0);
+
+    SetEvent(timer_thread.lock);
+    native_thread_join(timer_thread.id);
+    CloseHandle(timer_thread.lock);
+    timer_thread.lock = 0;
+
+    return 1;
 }
 
 static void


### PR DESCRIPTION
Although it almost certainly works in this case, volatile should not be used for multi-thread synchronization. Using atomics instead avoids warnings from TSan.

This also simplifies some logic, as system_working was previously only ever assigned to 1, so `--system_working <= 0` should always return true (unless it underflowed).

Fixes:

```
❯ TSAN_OPTIONS="halt_on_error=1:strip_path_prefix=$(pwd)/" ./miniruby -e 'Thread.new{}.join'
==================
WARNING: ThreadSanitizer: data race (pid=3458317)
  Write of size 4 at 0x555555e03118 by main thread:
    #0 native_stop_timer_thread thread_pthread.c:3128:15 (miniruby+0x478100) (BuildId: 15fb730468deee86fe6bbe9ca8c7e33a06fca03b)
    #1 rb_thread_stop_timer_thread thread.c:4701:37 (miniruby+0x478100)
    #2 rb_ec_cleanup eval.c:262:5 (miniruby+0x26cccc) (BuildId: 15fb730468deee86fe6bbe9ca8c7e33a06fca03b)
    #3 ruby_run_node eval.c:319:12 (miniruby+0x26d074) (BuildId: 15fb730468deee86fe6bbe9ca8c7e33a06fca03b)
    #4 rb_main main.c:42:12 (miniruby+0x14bc7c) (BuildId: 15fb730468deee86fe6bbe9ca8c7e33a06fca03b)
    #5 main main.c:62:12 (miniruby+0x14bc7c)

  Previous read of size 4 at 0x555555e03118 by thread T1:
    #0 timer_thread_func thread_pthread.c:3008:12 (miniruby+0x483e94) (BuildId: 15fb730468deee86fe6bbe9ca8c7e33a06fca03b)

  Location is global 'system_working' of size 4 at 0x555555e03118 (miniruby+0x8af118)

  Thread T1 (tid=3458319, running) created by main thread at:
    #0 pthread_create <null> (miniruby+0xc1fd9) (BuildId: 15fb730468deee86fe6bbe9ca8c7e33a06fca03b)
    #1 rb_thread_create_timer_thread thread_pthread.c:3121:5 (miniruby+0x478475) (BuildId: 15fb730468deee86fe6bbe9ca8c7e33a06fca03b)
    #2 Init_Thread thread.c:5589:5 (miniruby+0x47a908) (BuildId: 15fb730468deee86fe6bbe9ca8c7e33a06fca03b)
    #3 rb_call_inits inits.c:64:5 (miniruby+0x2b9cdc) (BuildId: 15fb730468deee86fe6bbe9ca8c7e33a06fca03b)
    #4 ruby_setup eval.c:86:9 (miniruby+0x26b8d8) (BuildId: 15fb730468deee86fe6bbe9ca8c7e33a06fca03b)
    #5 ruby_init eval.c:98:17 (miniruby+0x26ba75) (BuildId: 15fb730468deee86fe6bbe9ca8c7e33a06fca03b)
    #6 rb_main main.c:41:5 (miniruby+0x14bc6a) (BuildId: 15fb730468deee86fe6bbe9ca8c7e33a06fca03b)
    #7 main main.c:62:12 (miniruby+0x14bc6a)

SUMMARY: ThreadSanitizer: data race thread_pthread.c:3128:15 in native_stop_timer_thread
==================
```