### PR TITLE
Bump ABI_VERSION

### DIFF
--- a/include/ruby/internal/abi.h
+++ b/include/ruby/internal/abi.h
@@ -24,7 +24,7 @@
  * In released versions of Ruby, this number is not defined since teeny
  * versions of Ruby should guarantee ABI compatibility.
  */
-#define RUBY_ABI_VERSION 0
+#define RUBY_ABI_VERSION 1
 
 /* Windows does not support weak symbols so ruby_abi_version will not exist
  * in the shared library. */


### PR DESCRIPTION
`struct RTypedData` was changed significantly in https://github.com/ruby/ruby/pull/13190 which breaks many extensions.

Bumping the ABI version might save some people from needlessly investigating crashes.

Example: https://github.com/Shopify/bootsnap/actions/runs/15025769306/job/42226035365?pr=501#step:4:62