### PR TITLE
Fix uplevel for `cgi` under bundler

### DIFF
--- a/lib/cgi.rb
+++ b/lib/cgi.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "cgi/escape"
-warn <<-WARNING, uplevel: 1 if $VERBOSE
+warn <<-WARNING, uplevel: Gem::BUNDLED_GEMS.uplevel if $VERBOSE
 CGI library is removed from Ruby 3.5. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
 If you need to use the full features of CGI library, Please install cgi gem.
 WARNING

--- a/lib/cgi/util.rb
+++ b/lib/cgi/util.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 require "cgi/escape"
-warn <<-WARNING, uplevel: 1 if $VERBOSE
+warn <<-WARNING, uplevel: Gem::BUNDLED_GEMS.uplevel if $VERBOSE
 CGI::Util is removed from Ruby 3.5. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
 WARNING


### PR DESCRIPTION
Since there is `bundled_gems.rb` it is not always one. Fixes the following:
```sh
$ ruby -w -rbundler/inline -e "gemfile {}; require 'cgi'"
/home/earlopain/.rbenv/versions/ruby-dev/lib/ruby/3.5.0+0/bundled_gems.rb:59: warning: CGI library is removed from Ruby 3.5. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
```

into:

```sh
$ ruby -w -rbundler/inline -e "gemfile {}; require 'cgi'"
-e:1: warning: CGI library is removed from Ruby 3.5. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
If you need to use the full features of CGI library, Please install cgi gem.
```