### PR TITLE
Add shape_id to RBasic under 32 bit

### DIFF
--- a/class.c
+++ b/class.c
@@ -42,10 +42,6 @@
  * 2:    RCLASS_PRIME_CLASSEXT_PRIME_WRITABLE
  *           This class's prime classext is the only classext and writable from any namespaces.
  *           If unset, the prime classext is writable only from the root namespace.
- * if !SHAPE_IN_BASIC_FLAGS
- * 4-19: SHAPE_FLAG_MASK
- *           Shape ID for the class.
- * endif
  */
 
 /* Flags of T_ICLASS
@@ -53,10 +49,6 @@
  * 2:    RCLASS_PRIME_CLASSEXT_PRIME_WRITABLE
  *           This module's prime classext is the only classext and writable from any namespaces.
  *           If unset, the prime classext is writable only from the root namespace.
- * if !SHAPE_IN_BASIC_FLAGS
- * 4-19: SHAPE_FLAG_MASK
- *           Shape ID. This is set but not used.
- * endif
  */
 
 /* Flags of T_MODULE
@@ -71,10 +63,6 @@
  *           If unset, the prime classext is writable only from the root namespace.
  * 3:    RMODULE_IS_REFINEMENT
  *           Module is used for refinements.
- * if !SHAPE_IN_BASIC_FLAGS
- * 4-19: SHAPE_FLAG_MASK
- *           Shape ID for the module.
- * endif
  */
 
 #define METACLASS_OF(k) RBASIC(k)->klass

--- a/gc.c
+++ b/gc.c
@@ -1965,6 +1965,7 @@ build_id2ref_i(VALUE obj, void *data)
         }
         break;
       case T_IMEMO:
+      case T_NONE:
         break;
       default:
         if (rb_shape_obj_has_id(obj)) {

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -4,6 +4,7 @@
 #include "ruby/assert.h"
 #include "ruby/atomic.h"
 #include "ruby/debug.h"
+#include "internal/object.h"
 
 #include "gc/gc.h"
 #include "gc/gc_impl.h"
@@ -453,6 +454,7 @@ rb_gc_impl_init(void)
 {
     VALUE gc_constants = rb_hash_new();
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("BASE_SLOT_SIZE")), SIZET2NUM(sizeof(VALUE) * 5));
+    rb_hash_aset(gc_constants, ID2SYM(rb_intern("RBASIC_SIZE")), SIZET2NUM(sizeof(struct RBasic)));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVALUE_OVERHEAD")), INT2NUM(0));
     rb_hash_aset(gc_constants, ID2SYM(rb_intern("RVARGC_MAX_ALLOCATE_SIZE")), LONG2FIX(640));
     // Pretend we have 5 size pools
@@ -1019,7 +1021,7 @@ rb_gc_impl_shutdown_call_finalizer(void *objspace_ptr)
 
         if (rb_gc_shutdown_call_finalizer_p(obj)) {
             rb_gc_obj_free(objspace_ptr, obj);
-            RBASIC(obj)->flags = 0;
+            RBASIC_RESET_FLAGS(obj);
         }
     }
     mmtk_free_raw_vec_of_obj_ref(registered_candidates);

--- a/include/ruby/internal/core/rbasic.h
+++ b/include/ruby/internal/core/rbasic.h
@@ -55,6 +55,12 @@ enum ruby_rvalue_flags {
     RVALUE_EMBED_LEN_MAX = RBIMPL_RVALUE_EMBED_LEN_MAX
 };
 
+#if (SIZEOF_VALUE < SIZEOF_UINT64_T)
+#define RBASIC_SHAPE_ID_FIELD 1
+#else
+#define RBASIC_SHAPE_ID_FIELD 0
+#endif
+
 /**
  * Ruby object's base components. All Ruby objects have them in common.
  */
@@ -85,6 +91,10 @@ RBasic {
      */
     const VALUE klass;
 
+#if RBASIC_SHAPE_ID_FIELD
+    VALUE shape_id;
+#endif
+
 #ifdef __cplusplus
   public:
     RBIMPL_ATTR_CONSTEXPR(CXX11)
@@ -100,6 +110,9 @@ RBasic {
     RBasic() :
         flags(RBIMPL_VALUE_NULL),
         klass(RBIMPL_VALUE_NULL)
+#if RBASIC_SHAPE_ID_FIELD
+        , shape_id(RBIMPL_VALUE_NULL)
+#endif
     {
     }
 #endif

--- a/internal/class.h
+++ b/internal/class.h
@@ -577,7 +577,7 @@ RCLASS_FIELDS_COUNT(VALUE obj)
         return count;
     }
     else {
-        return RSHAPE(RCLASS_SHAPE_ID(obj))->next_field_index;
+        return RSHAPE(RBASIC_SHAPE_ID(obj))->next_field_index;
     }
 }
 

--- a/internal/object.h
+++ b/internal/object.h
@@ -60,4 +60,13 @@ RBASIC_SET_CLASS(VALUE obj, VALUE klass)
     RBASIC_SET_CLASS_RAW(obj, klass);
     RB_OBJ_WRITTEN(obj, oldv, klass);
 }
+
+static inline void
+RBASIC_RESET_FLAGS(VALUE obj)
+{
+    RBASIC(obj)->flags = 0;
+#if RBASIC_SHAPE_ID_FIELD
+    RBASIC(obj)->shape_id = 0;
+#endif
+}
 #endif /* INTERNAL_OBJECT_H */

--- a/object.c
+++ b/object.c
@@ -50,10 +50,6 @@
  *           The object has its instance variables embedded (the array of
  *           instance variables directly follow the object, rather than being
  *           on a separately allocated buffer).
- * if !SHAPE_IN_BASIC_FLAGS
- * 4-19: SHAPE_FLAG_MASK
- *           Shape ID for the object.
- * endif
  */
 
 /*!
@@ -134,8 +130,7 @@ rb_class_allocate_instance(VALUE klass)
 
     RUBY_ASSERT(rb_obj_shape(obj)->type == SHAPE_ROOT);
 
-    // Set the shape to the specific T_OBJECT shape.
-    ROBJECT_SET_SHAPE_ID(obj, rb_shape_root(rb_gc_heap_id_for_size(size)));
+    RBASIC_SET_SHAPE_ID(obj, rb_shape_root(rb_gc_heap_id_for_size(size)));
 
 #if RUBY_DEBUG
     RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));

--- a/ractor.c
+++ b/ractor.c
@@ -3667,10 +3667,10 @@ move_leave(VALUE obj, struct obj_traverse_replace_data *data)
         rb_replace_generic_ivar(data->replacement, obj);
     }
 
-    VALUE flags = T_OBJECT | FL_FREEZE | (RBASIC(obj)->flags & FL_PROMOTED);
+    VALUE flags = T_OBJECT | FL_FREEZE | ROBJECT_EMBED | (RBASIC(obj)->flags & FL_PROMOTED);
 
     // Avoid mutations using bind_call, etc.
-    MEMZERO((char *)obj + sizeof(struct RBasic), char, size - sizeof(struct RBasic));
+    MEMZERO((char *)obj, char, sizeof(struct RBasic));
     RBASIC(obj)->flags = flags;
     RBASIC_SET_CLASS_RAW(obj, rb_cRactorMovedObject);
     return traverse_cont;

--- a/shape.c
+++ b/shape.c
@@ -347,10 +347,6 @@ rb_shape_lookup(shape_id_t shape_id)
     return &GET_SHAPE_TREE()->shape_list[shape_id];
 }
 
-#if !SHAPE_IN_BASIC_FLAGS
-shape_id_t rb_generic_shape_id(VALUE obj);
-#endif
-
 RUBY_FUNC_EXPORTED shape_id_t
 rb_obj_shape_id(VALUE obj)
 {
@@ -358,20 +354,7 @@ rb_obj_shape_id(VALUE obj)
         return SPECIAL_CONST_SHAPE_ID;
     }
 
-#if SHAPE_IN_BASIC_FLAGS
     return RBASIC_SHAPE_ID(obj);
-#else
-    switch (BUILTIN_TYPE(obj)) {
-      case T_OBJECT:
-        return ROBJECT_SHAPE_ID(obj);
-        break;
-      case T_CLASS:
-      case T_MODULE:
-        return RCLASS_SHAPE_ID(obj);
-      default:
-        return rb_generic_shape_id(obj);
-    }
-#endif
 }
 
 size_t

--- a/shape.h
+++ b/shape.h
@@ -6,7 +6,6 @@
 #if (SIZEOF_UINT64_T <= SIZEOF_VALUE)
 
 #define SIZEOF_SHAPE_T 4
-#define SHAPE_IN_BASIC_FLAGS 1
 typedef uint32_t attr_index_t;
 typedef uint32_t shape_id_t;
 # define SHAPE_ID_NUM_BITS 32
@@ -14,7 +13,6 @@ typedef uint32_t shape_id_t;
 #else
 
 #define SIZEOF_SHAPE_T 2
-#define SHAPE_IN_BASIC_FLAGS 0
 typedef uint16_t attr_index_t;
 typedef uint16_t shape_id_t;
 # define SHAPE_ID_NUM_BITS 16
@@ -91,65 +89,30 @@ rb_current_shape_tree(void)
 #define GET_SHAPE_TREE() rb_current_shape_tree()
 
 static inline shape_id_t
-get_shape_id_from_flags(VALUE obj)
-{
-    RUBY_ASSERT(!RB_SPECIAL_CONST_P(obj));
-    RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO));
-    return (shape_id_t)((RBASIC(obj)->flags) >> SHAPE_FLAG_SHIFT);
-}
-
-static inline void
-set_shape_id_in_flags(VALUE obj, shape_id_t shape_id)
-{
-    RUBY_ASSERT(!RB_SPECIAL_CONST_P(obj));
-    RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO));
-    // Ractors are occupying the upper 32 bits of flags, but only in debug mode
-    // Object shapes are occupying top bits
-    RBASIC(obj)->flags &= SHAPE_FLAG_MASK;
-    RBASIC(obj)->flags |= ((VALUE)(shape_id) << SHAPE_FLAG_SHIFT);
-}
-
-
-#if SHAPE_IN_BASIC_FLAGS
-static inline shape_id_t
 RBASIC_SHAPE_ID(VALUE obj)
 {
-    return get_shape_id_from_flags(obj);
+    RUBY_ASSERT(!RB_SPECIAL_CONST_P(obj));
+    RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO));
+#if RBASIC_SHAPE_ID_FIELD
+    return (shape_id_t)((RBASIC(obj)->shape_id));
+#else
+    return (shape_id_t)((RBASIC(obj)->flags) >> SHAPE_FLAG_SHIFT);
+#endif
 }
 
 static inline void
 RBASIC_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
 {
-    set_shape_id_in_flags(obj, shape_id);
-}
+    RUBY_ASSERT(!RB_SPECIAL_CONST_P(obj));
+    RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO));
+#if RBASIC_SHAPE_ID_FIELD
+    RBASIC(obj)->shape_id = (VALUE)shape_id;
+#else
+    // Ractors are occupying the upper 32 bits of flags, but only in debug mode
+    // Object shapes are occupying top bits
+    RBASIC(obj)->flags &= SHAPE_FLAG_MASK;
+    RBASIC(obj)->flags |= ((VALUE)(shape_id) << SHAPE_FLAG_SHIFT);
 #endif
-
-static inline shape_id_t
-ROBJECT_SHAPE_ID(VALUE obj)
-{
-    RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
-    return get_shape_id_from_flags(obj);
-}
-
-static inline void
-ROBJECT_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
-{
-    RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
-    set_shape_id_in_flags(obj, shape_id);
-}
-
-static inline shape_id_t
-RCLASS_SHAPE_ID(VALUE obj)
-{
-    RUBY_ASSERT(RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE));
-    return get_shape_id_from_flags(obj);
-}
-
-static inline void
-RCLASS_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
-{
-    RUBY_ASSERT(RB_TYPE_P(obj, T_CLASS) || RB_TYPE_P(obj, T_MODULE));
-    set_shape_id_in_flags(obj, shape_id);
 }
 
 #define RSHAPE rb_shape_lookup
@@ -203,7 +166,7 @@ ROBJECT_FIELDS_CAPACITY(VALUE obj)
     // Asking for capacity doesn't make sense when the object is using
     // a hash table for storing instance variables
     RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));
-    return RSHAPE(ROBJECT_SHAPE_ID(obj))->capacity;
+    return RSHAPE(RBASIC_SHAPE_ID(obj))->capacity;
 }
 
 static inline st_table *
@@ -222,8 +185,6 @@ ROBJECT_SET_FIELDS_HASH(VALUE obj, const st_table *tbl)
     ROBJECT(obj)->as.heap.fields = (VALUE *)tbl;
 }
 
-size_t rb_id_table_size(const struct rb_id_table *tbl);
-
 static inline uint32_t
 ROBJECT_FIELDS_COUNT(VALUE obj)
 {
@@ -233,7 +194,7 @@ ROBJECT_FIELDS_COUNT(VALUE obj)
     else {
         RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
         RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));
-        return RSHAPE(ROBJECT_SHAPE_ID(obj))->next_field_index;
+        return RSHAPE(RBASIC_SHAPE_ID(obj))->next_field_index;
     }
 }
 

--- a/string.c
+++ b/string.c
@@ -960,6 +960,8 @@ setup_fake_str(struct RString *fake_str, const char *name, long len, int encidx)
 {
     fake_str->basic.flags = T_STRING|RSTRING_NOEMBED|STR_NOFREE|STR_FAKESTR;
 
+    rb_shape_set_shape_id((VALUE)fake_str, 0);
+
     if (!name) {
         RUBY_ASSERT_ALWAYS(len == 0);
         name = "";

--- a/test/-ext-/string/test_capacity.rb
+++ b/test/-ext-/string/test_capacity.rb
@@ -66,7 +66,7 @@ class Test_StringCapacity < Test::Unit::TestCase
   end
 
   def embed_header_size
-    3 * RbConfig::SIZEOF['void*']
+    GC::INTERNAL_CONSTANTS[:RBASIC_SIZE] + RbConfig::SIZEOF['void*']
   end
 
   def max_embed_len

--- a/variable.h
+++ b/variable.h
@@ -13,9 +13,6 @@
 #include "shape.h"
 
 struct gen_fields_tbl {
-#if !SHAPE_IN_BASIC_FLAGS
-    uint16_t shape_id;
-#endif
     union {
         struct {
             uint32_t fields_count;
@@ -28,10 +25,6 @@ struct gen_fields_tbl {
 };
 
 int rb_ivar_generic_fields_tbl_lookup(VALUE obj, struct gen_fields_tbl **);
-
-#if !SHAPE_IN_BASIC_FLAGS
-shape_id_t rb_generic_shape_id(VALUE obj);
-#endif
 
 void rb_free_rb_global_tbl(void);
 void rb_free_generic_fields_tbl_(void);


### PR DESCRIPTION
[[Feature #21353]](https://bugs.ruby-lang.org/issues/21353)

This adds a separate VALUE-sized shape_id field for 32-bit platforms. Allowing them to work much more similarly to how shapes always being available on 64-bit.

This does increase the size of objects by 4 bytes on 32 bit platforms, but shape access should be faster, more consistent, of the same size (32 bits) and much simpler.