### PR TITLE
Add `continue-on-error` to failed Windows 2025 build.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,6 +22,7 @@ permissions:
 
 jobs:
   make:
+    continue-on-error: ${{ matrix.os == 2025 }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
The Windows 2025 build is currently failing due to dependency installation failure. Prevent it from failing CI so that we can continue to merge things.