### PR TITLE
Ensure shape_id is never used on T_IMEMO

### DIFF
--- a/eval.c
+++ b/eval.c
@@ -529,10 +529,14 @@ exc_setup_message(const rb_execution_context_t *ec, VALUE mesg, VALUE *cause)
         rb_exc_check_circular_cause(*cause);
 #else
         VALUE c = *cause;
-        while (!NIL_P(c = rb_attr_get(c, id_cause))) {
+        while (!NIL_P(c)) {
             if (c == mesg) {
                 rb_raise(rb_eArgError, "circular causes");
             }
+            if (THROW_DATA_P(c)) {
+                break;
+            }
+            c = rb_attr_get(c, id_cause);
         }
 #endif
     }

--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -414,9 +414,11 @@ dump_object(VALUE obj, struct dump_config *dc)
     dump_append(dc, obj_type(obj));
     dump_append(dc, "\"");
 
-    size_t shape_id = rb_obj_shape_id(obj);
-    dump_append(dc, ", \"shape_id\":");
-    dump_append_sizet(dc, shape_id);
+    if (BUILTIN_TYPE(obj) != T_IMEMO) {
+        size_t shape_id = rb_obj_shape_id(obj);
+        dump_append(dc, ", \"shape_id\":");
+        dump_append_sizet(dc, shape_id);
+    }
 
     dump_append(dc, ", \"slot_size\":");
     dump_append_sizet(dc, dc->cur_page_slot_size);

--- a/gc.c
+++ b/gc.c
@@ -1934,6 +1934,9 @@ object_id(VALUE obj)
         // in different namespaces, so we cannot store the object id
         // in fields.
         return class_object_id(obj);
+      case T_IMEMO:
+        rb_bug("T_IMEMO can't have an object_id");
+        break;
       default:
         break;
     }
@@ -1959,6 +1962,8 @@ build_id2ref_i(VALUE obj, void *data)
         if (RCLASS(obj)->object_id) {
             st_insert(id2ref_tbl, RCLASS(obj)->object_id, obj);
         }
+        break;
+      case T_IMEMO:
         break;
       default:
         if (rb_shape_obj_has_id(obj)) {
@@ -2007,6 +2012,10 @@ object_id_to_ref(void *objspace_ptr, VALUE object_id)
 static inline void
 obj_free_object_id(VALUE obj)
 {
+    if (RB_BUILTIN_TYPE(obj) == T_IMEMO) {
+        return;
+    }
+
     VALUE obj_id = 0;
     if (RB_UNLIKELY(id2ref_tbl)) {
         switch (BUILTIN_TYPE(obj)) {
@@ -2210,7 +2219,7 @@ rb_obj_id(VALUE obj)
 bool
 rb_obj_id_p(VALUE obj)
 {
-    return rb_shape_obj_has_id(obj);
+    return !RB_TYPE_P(obj, T_IMEMO) && rb_shape_obj_has_id(obj);
 }
 
 static enum rb_id_table_iterator_result

--- a/iseq.c
+++ b/iseq.c
@@ -1530,7 +1530,6 @@ iseqw_new(const rb_iseq_t *iseq)
 
         /* cache a wrapper object */
         RB_OBJ_WRITE((VALUE)iseq, &iseq->wrapper, obj);
-        RB_OBJ_FREEZE((VALUE)iseq);
 
         return obj;
     }

--- a/shape.h
+++ b/shape.h
@@ -94,12 +94,15 @@ static inline shape_id_t
 get_shape_id_from_flags(VALUE obj)
 {
     RUBY_ASSERT(!RB_SPECIAL_CONST_P(obj));
+    RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO));
     return (shape_id_t)((RBASIC(obj)->flags) >> SHAPE_FLAG_SHIFT);
 }
 
 static inline void
 set_shape_id_in_flags(VALUE obj, shape_id_t shape_id)
 {
+    RUBY_ASSERT(!RB_SPECIAL_CONST_P(obj));
+    RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO));
     // Ractors are occupying the upper 32 bits of flags, but only in debug mode
     // Object shapes are occupying top bits
     RBASIC(obj)->flags &= SHAPE_FLAG_MASK;


### PR DESCRIPTION
It doesn't make sense to set ivars or anything shape related on a T_IMEMO.

cc @jhawthorn 