### PR TITLE
newobj_fill: don't assume RBasic size

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2073,10 +2073,10 @@ heap_prepare(rb_objspace_t *objspace, rb_heap_t *heap)
 static inline VALUE
 newobj_fill(VALUE obj, VALUE v1, VALUE v2, VALUE v3)
 {
-    VALUE *p = (VALUE *)obj;
-    p[2] = v1;
-    p[3] = v2;
-    p[4] = v3;
+    VALUE *p = (VALUE *)(obj + sizeof(struct RBasic));
+    p[0] = v1;
+    p[1] = v2;
+    p[2] = v3;
     return obj;
 }
 


### PR DESCRIPTION
The previous implementation assumed `RBasic` size is `2 * sizeof(VALUE)`, might as well not make assumption and use a proper `sizeof`.

cc @jhawthorn 