### PR TITLE
Fix `rb_gc_impl_copy_finalizer`

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2803,6 +2803,7 @@ rb_gc_impl_copy_finalizer(void *objspace_ptr, VALUE dest, VALUE obj)
 
     if (!FL_TEST(obj, FL_FINALIZE)) return;
 
+    int lev = rb_gc_vm_lock();
     if (RB_LIKELY(st_lookup(finalizer_table, obj, &data))) {
         table = (VALUE)data;
         st_insert(finalizer_table, dest, table);
@@ -2811,6 +2812,7 @@ rb_gc_impl_copy_finalizer(void *objspace_ptr, VALUE dest, VALUE obj)
     else {
         rb_bug("rb_gc_copy_finalizer: FL_FINALIZE set but not found in finalizer_table: %s", rb_obj_info(obj));
     }
+    rb_gc_vm_unlock(lev);
 }
 
 static VALUE

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2805,7 +2805,8 @@ rb_gc_impl_copy_finalizer(void *objspace_ptr, VALUE dest, VALUE obj)
 
     int lev = rb_gc_vm_lock();
     if (RB_LIKELY(st_lookup(finalizer_table, obj, &data))) {
-        table = (VALUE)data;
+        table = rb_ary_dup((VALUE)data);
+        RARRAY_ASET(table, 0, rb_obj_id(dest));
         st_insert(finalizer_table, dest, table);
         FL_SET(dest, FL_FINALIZE);
     }

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2857,9 +2857,9 @@ finalize_list(rb_objspace_t *objspace, VALUE zombie)
         next_zombie = RZOMBIE(zombie)->next;
         page = GET_HEAP_PAGE(zombie);
 
-        run_final(objspace, zombie);
-
         int lev = rb_gc_vm_lock();
+
+        run_final(objspace, zombie);
         {
             GC_ASSERT(BUILTIN_TYPE(zombie) == T_ZOMBIE);
             GC_ASSERT(page->heap->final_slots_count > 0);

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -983,6 +983,7 @@ rb_gc_impl_copy_finalizer(void *objspace_ptr, VALUE dest, VALUE obj)
 
     if (!FL_TEST(obj, FL_FINALIZE)) return;
 
+    int lev = rb_gc_vm_lock();
     if (RB_LIKELY(st_lookup(objspace->finalizer_table, obj, &data))) {
         table = (VALUE)data;
         st_insert(objspace->finalizer_table, dest, table);
@@ -991,6 +992,7 @@ rb_gc_impl_copy_finalizer(void *objspace_ptr, VALUE dest, VALUE obj)
     else {
         rb_bug("rb_gc_copy_finalizer: FL_FINALIZE set but not found in finalizer_table: %s", rb_obj_info(obj));
     }
+    rb_gc_vm_unlock(lev);
 }
 
 static int

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -985,7 +985,8 @@ rb_gc_impl_copy_finalizer(void *objspace_ptr, VALUE dest, VALUE obj)
 
     int lev = rb_gc_vm_lock();
     if (RB_LIKELY(st_lookup(objspace->finalizer_table, obj, &data))) {
-        table = (VALUE)data;
+        table = rb_ary_dup((VALUE)data);
+        RARRAY_ASET(table, 0, rb_obj_id(dest));
         st_insert(objspace->finalizer_table, dest, table);
         FL_SET(dest, FL_FINALIZE);
     }

--- a/object.c
+++ b/object.c
@@ -409,11 +409,11 @@ init_copy(VALUE dest, VALUE obj)
     RBASIC(dest)->flags &= ~(T_MASK|FL_EXIVAR);
     // Copies the shape id from obj to dest
     RBASIC(dest)->flags |= RBASIC(obj)->flags & (T_MASK|FL_EXIVAR);
-    rb_gc_copy_attributes(dest, obj);
     rb_copy_generic_ivar(dest, obj);
     if (RB_TYPE_P(obj, T_OBJECT)) {
         rb_obj_copy_ivar(dest, obj);
     }
+    rb_gc_copy_attributes(dest, obj);
 }
 
 static VALUE immutable_obj_clone(VALUE obj, VALUE kwfreeze);

--- a/object.c
+++ b/object.c
@@ -409,9 +409,11 @@ init_copy(VALUE dest, VALUE obj)
     RBASIC(dest)->flags &= ~(T_MASK|FL_EXIVAR);
     // Copies the shape id from obj to dest
     RBASIC(dest)->flags |= RBASIC(obj)->flags & (T_MASK|FL_EXIVAR);
-    rb_copy_generic_ivar(dest, obj);
     if (RB_TYPE_P(obj, T_OBJECT)) {
         rb_obj_copy_ivar(dest, obj);
+    }
+    else {
+        rb_copy_generic_ivar(dest, obj);
     }
     rb_gc_copy_attributes(dest, obj);
 }

--- a/test/objspace/test_ractor.rb
+++ b/test/objspace/test_ractor.rb
@@ -33,4 +33,25 @@ class TestObjSpaceRactor < Test::Unit::TestCase
       ractors.each(&:take)
     RUBY
   end
+
+  def test_copy_finalizer
+    assert_ractor(<<~'RUBY', require: 'objspace')
+      def fin
+        ->(id) { }
+      end
+      OBJ = Object.new
+      ObjectSpace.define_finalizer(OBJ, fin)
+      OBJ.freeze
+
+      ractors = 5.times.map do
+        Ractor.new do
+          10_000.times do
+            OBJ.clone
+          end
+        end
+      end
+
+      ractors.each(&:take)
+    RUBY
+  end
 end

--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -94,7 +94,7 @@ End
   end
 
   def test_finalizer
-    assert_in_out_err(["-e", <<-END], "", %w(:ok :ok :ok :ok), [])
+    assert_in_out_err(["-e", <<-END], "", %w(:ok :ok :ok), [])
       a = []
       ObjectSpace.define_finalizer(a) { p :ok }
       b = a.dup
@@ -135,6 +135,25 @@ End
     assert_raise_with_message(ArgumentError, /C\u{3042}/) {
       ObjectSpace.define_finalizer(o, c)
     }
+  end
+
+  def test_finalizer_copy
+    assert_in_out_err(["-e", <<~'RUBY'], "", %w(:ok), [])
+      def fin
+        ids = Set.new
+        ->(id) { puts "object_id (#{id}) reused" unless ids.add?(id) }
+      end
+
+      OBJ = Object.new
+      ObjectSpace.define_finalizer(OBJ, fin)
+      OBJ.freeze
+
+      10.times do
+        OBJ.clone
+      end
+
+      p :ok
+    RUBY
   end
 
   def test_finalizer_with_super

--- a/variable.c
+++ b/variable.c
@@ -2438,6 +2438,9 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
 
   clear:
     if (FL_TEST(dest, FL_EXIVAR)) {
+#if SHAPE_IN_BASIC_FLAGS
+        RBASIC_SET_SHAPE_ID(dest, ROOT_SHAPE_ID);
+#endif
         rb_free_generic_ivar(dest);
         FL_UNSET(dest, FL_EXIVAR);
     }


### PR DESCRIPTION
- Add missing VM_LOCK
- Generate a new object_id when copying finalizers
- Dup the finalizer entry so adding a finalizer on a cloned object doesn't impact the source object.