### PR TITLE
Remove dependency on bits.h in default.c when BUILDING_MODULAR_GC

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -15,7 +15,11 @@
 # include <sys/user.h>
 #endif
 
-#include "internal/bits.h"
+#ifdef BUILDING_MODULAR_GC
+# define nlz_int64(x) (x == 0 ? 64 : (unsigned int)__builtin_clzll((unsigned long long)x))
+#else
+# include "internal/bits.h"
+#endif
 
 #include "ruby/ruby.h"
 #include "ruby/atomic.h"

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2117,10 +2117,8 @@ rb_gc_impl_source_location_cstr(int *ptr)
 static inline VALUE
 newobj_init(VALUE klass, VALUE flags, int wb_protected, rb_objspace_t *objspace, VALUE obj)
 {
-#if !__has_feature(memory_sanitizer)
     GC_ASSERT(BUILTIN_TYPE(obj) == T_NONE);
     GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
-#endif
     RBASIC(obj)->flags = flags;
     *((VALUE *)&RBASIC(obj)->klass) = klass;
 


### PR DESCRIPTION
We can assume that the compiler will have __builtin_clzll so we can implement nlz_int64 using that.