### PR TITLE
ZJIT: Bail out of recursive compilation if we can't compile callee

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -126,6 +126,9 @@ fn gen_iseq_entry_point(iseq: IseqPtr) -> *const u8 {
                 asm.ccall(callee_addr, vec![]);
             });
             branch_iseqs.extend(callee_branch_iseqs);
+        } else {
+            // Failed to compile the callee. Bail out of compiling this graph of ISEQs.
+            return std::ptr::null();
         }
     }
 


### PR DESCRIPTION
Right now we just crash if we can't compile an ISEQ for any reason
(unimplemented in HIR, unimplemented in codegen, ...) and this fixes
that by bailing out.
