### PR TITLE
Use atomic operations for interrupt flag and signal buf

### DIFF
--- a/misc/tsan_suppressions.txt
+++ b/misc/tsan_suppressions.txt
@@ -22,7 +22,6 @@ race_top:push_subclass_entry_to_list
 race:objspace_malloc_increase_body
 
 # Signals and ubf
-race_top:rb_signal_buff_size
 race:unregister_ubf_list
 
 # It's already crashing. We're doing our best

--- a/misc/tsan_suppressions.txt
+++ b/misc/tsan_suppressions.txt
@@ -25,11 +25,6 @@ race:objspace_malloc_increase_body
 race_top:rb_signal_buff_size
 race:unregister_ubf_list
 
-# interrupt flag is set atomically, but read non-atomically
-race_top:RUBY_VM_INTERRUPTED_ANY
-race_top:unblock_function_set
-race_top:threadptr_get_interrupts
-
 # It's already crashing. We're doing our best
 signal:rb_vm_bugreport
 race:check_reserved_signal_

--- a/misc/tsan_suppressions.txt
+++ b/misc/tsan_suppressions.txt
@@ -70,6 +70,7 @@ race_top:RVALUE_AGE_SET
 
 # Inline caches
 race_top:vm_cc_call_set
+race_top:vm_cc_class_check
 race_top:vm_search_cc
 race_top:vm_search_method_slowpath0
 race_top:rb_vm_opt_getconstant_path
@@ -105,6 +106,7 @@ race_top:method_definition_addref
 # Switching to setting up tracing. Likely other ractors should be stopped for this.
 race_top:encoded_iseq_trace_instrument
 race:rb_iseq_trace_set_all
+race:rb_tracepoint_enable
 
 # We walk the machine stack looking for markable objects, a thread with the GVL
 # released could by mutating the stack with non-Ruby-objects

--- a/ruby_atomic.h
+++ b/ruby_atomic.h
@@ -1,3 +1,6 @@
+#ifndef INTERNAL_ATOMIC_H
+#define INTERNAL_ATOMIC_H
+
 #include "ruby/atomic.h"
 
 /* shim macros only */
@@ -21,3 +24,16 @@
 #define ATOMIC_SUB(var, val) RUBY_ATOMIC_SUB(var, val)
 #define ATOMIC_VALUE_CAS(var, oldval, val) RUBY_ATOMIC_VALUE_CAS(var, oldval, val)
 #define ATOMIC_VALUE_EXCHANGE(var, val) RUBY_ATOMIC_VALUE_EXCHANGE(var, val)
+
+static inline rb_atomic_t
+rbimpl_atomic_load_relaxed(rb_atomic_t *ptr)
+{
+#if defined(HAVE_GCC_ATOMIC_BUILTINS)
+    return __atomic_load_n(ptr, __ATOMIC_RELAXED);
+#else
+    return *ptr;
+#endif
+}
+#define ATOMIC_LOAD_RELAXED(var) rbimpl_atomic_load_relaxed(&(var))
+
+#endif

--- a/signal.c
+++ b/signal.c
@@ -710,7 +710,7 @@ sighandler(int sig)
 int
 rb_signal_buff_size(void)
 {
-    return signal_buff.size;
+    return RUBY_ATOMIC_LOAD(signal_buff.size);
 }
 
 static void
@@ -738,7 +738,7 @@ rb_get_next_signal(void)
 {
     int i, sig = 0;
 
-    if (signal_buff.size != 0) {
+    if (rb_signal_buff_size() != 0) {
         for (i=1; i<RUBY_NSIG; i++) {
             if (signal_buff.cnt[i] > 0) {
                 ATOMIC_DEC(signal_buff.cnt[i]);

--- a/thread.c
+++ b/thread.c
@@ -2465,8 +2465,9 @@ threadptr_get_interrupts(rb_thread_t *th)
     rb_atomic_t interrupt;
     rb_atomic_t old;
 
+    old = ATOMIC_LOAD_RELAXED(ec->interrupt_flag);
     do {
-        interrupt = ec->interrupt_flag;
+        interrupt = old;
         old = ATOMIC_CAS(ec->interrupt_flag, interrupt, interrupt & ec->interrupt_mask);
     } while (old != interrupt);
     return interrupt & (rb_atomic_t)~ec->interrupt_mask;

--- a/vm_core.h
+++ b/vm_core.h
@@ -2102,8 +2102,12 @@ enum {
 #define RUBY_VM_SET_TRAP_INTERRUPT(ec)		ATOMIC_OR((ec)->interrupt_flag, TRAP_INTERRUPT_MASK)
 #define RUBY_VM_SET_TERMINATE_INTERRUPT(ec)     ATOMIC_OR((ec)->interrupt_flag, TERMINATE_INTERRUPT_MASK)
 #define RUBY_VM_SET_VM_BARRIER_INTERRUPT(ec)    ATOMIC_OR((ec)->interrupt_flag, VM_BARRIER_INTERRUPT_MASK)
-#define RUBY_VM_INTERRUPTED(ec)			((ec)->interrupt_flag & ~(ec)->interrupt_mask & \
-                                                 (PENDING_INTERRUPT_MASK|TRAP_INTERRUPT_MASK))
+
+static inline bool
+RUBY_VM_INTERRUPTED(rb_execution_context_t *ec)
+{
+    return (ATOMIC_LOAD_RELAXED(ec->interrupt_flag) & ~(ec->interrupt_mask) & (PENDING_INTERRUPT_MASK|TRAP_INTERRUPT_MASK));
+}
 
 static inline bool
 RUBY_VM_INTERRUPTED_ANY(rb_execution_context_t *ec)
@@ -2116,7 +2120,7 @@ RUBY_VM_INTERRUPTED_ANY(rb_execution_context_t *ec)
         RUBY_VM_SET_TIMER_INTERRUPT(ec);
     }
 #endif
-    return ec->interrupt_flag & ~(ec)->interrupt_mask;
+    return ATOMIC_LOAD_RELAXED(ec->interrupt_flag) & ~(ec)->interrupt_mask;
 }
 
 VALUE rb_exc_set_backtrace(VALUE exc, VALUE bt);


### PR DESCRIPTION
These are updated concurrently across threads, so for correctness they should be atomic operations, not just volatile.

Because RUBY_VM_INTERRUPTED_ANY is a very hot path, I made sure to introduce a relaxed version of ATOMIC_LOAD. For platforms that don't have GCC's atomics I was conservative and made it just dereference the volatile pointer, which is what the code used to do. I would expect the code that's generated by this to be unchanged (but I checked disassembly only on x86_64).

The main benefit of this in practice is that this will avoid TSan errors at these locations, and it will ensure the compiler won't perform an optimization it shouldn't (which it _probably_ wouldn't for volatile anyways)