### PR TITLE
[Bug #20009] Support marshaling non-ASCII name class/module

### DIFF
--- a/spec/ruby/core/marshal/dump_spec.rb
+++ b/spec/ruby/core/marshal/dump_spec.rb
@@ -231,9 +231,12 @@ describe "Marshal.dump" do
       Marshal.dump(MarshalSpec::ClassWithOverriddenName).should == "\x04\bc)MarshalSpec::ClassWithOverriddenName"
     end
 
-    it "dumps a class with multibyte characters in name" do
-      source_object = eval("MarshalSpec::MultibyteぁあぃいClass".dup.force_encoding(Encoding::UTF_8))
-      Marshal.dump(source_object).should == "\x04\bc,MarshalSpec::Multibyte\xE3\x81\x81\xE3\x81\x82\xE3\x81\x83\xE3\x81\x84Class"
+    ruby_version_is "3.5" do
+      it "dumps a class with multibyte characters in name" do
+        source_object = eval("MarshalSpec::MultibyteぁあぃいClass".dup.force_encoding(Encoding::UTF_8))
+        Marshal.dump(source_object).should == "\x04\bIc,MarshalSpec::Multibyte\xE3\x81\x81\xE3\x81\x82\xE3\x81\x83\xE3\x81\x84Class\x06:\x06ET"
+        Marshal.load(Marshal.dump(source_object)) == source_object
+      end
     end
 
     it "uses object links for objects repeatedly dumped" do
@@ -258,9 +261,12 @@ describe "Marshal.dump" do
       Marshal.dump(MarshalSpec::ModuleWithOverriddenName).should == "\x04\bc*MarshalSpec::ModuleWithOverriddenName"
     end
 
-    it "dumps a module with multibyte characters in name" do
-      source_object = eval("MarshalSpec::MultibyteけげこごModule".dup.force_encoding(Encoding::UTF_8))
-      Marshal.dump(source_object).should == "\x04\bm-MarshalSpec::Multibyte\xE3\x81\x91\xE3\x81\x92\xE3\x81\x93\xE3\x81\x94Module"
+    ruby_version_is "3.5" do
+      it "dumps a module with multibyte characters in name" do
+        source_object = eval("MarshalSpec::MultibyteけげこごModule".dup.force_encoding(Encoding::UTF_8))
+        Marshal.dump(source_object).should == "\x04\bIm-MarshalSpec::Multibyte\xE3\x81\x91\xE3\x81\x92\xE3\x81\x93\xE3\x81\x94Module\x06:\x06ET"
+        Marshal.load(Marshal.dump(source_object)) == source_object
+      end
     end
 
     it "uses object links for objects repeatedly dumped" do
@@ -874,9 +880,12 @@ describe "Marshal.dump" do
       Marshal.dump(obj).should include("MarshalSpec::TimeWithOverriddenName")
     end
 
-    it "dumps a Time subclass with multibyte characters in name" do
-      source_object = eval("MarshalSpec::MultibyteぁあぃいTime".dup.force_encoding(Encoding::UTF_8))
-      Marshal.dump(source_object).should == "\x04\bc+MarshalSpec::Multibyte\xE3\x81\x81\xE3\x81\x82\xE3\x81\x83\xE3\x81\x84Time"
+    ruby_version_is "3.5" do
+      it "dumps a Time subclass with multibyte characters in name" do
+        source_object = eval("MarshalSpec::MultibyteぁあぃいTime".dup.force_encoding(Encoding::UTF_8))
+        Marshal.dump(source_object).should == "\x04\bIc+MarshalSpec::Multibyte\xE3\x81\x81\xE3\x81\x82\xE3\x81\x83\xE3\x81\x84Time\x06:\x06ET"
+        Marshal.load(Marshal.dump(source_object)) == source_object
+      end
     end
 
     it "uses object links for objects repeatedly dumped" do

--- a/test/ruby/test_marshal.rb
+++ b/test/ruby/test_marshal.rb
@@ -268,7 +268,11 @@ class TestMarshal < Test::Unit::TestCase
   classISO8859_1.name
   ClassISO8859_1 = classISO8859_1
 
-  def test_class_nonascii
+  moduleUTF8 = const_set("C\u{30af 30e9 30b9}", Module.new)
+  moduleUTF8.name
+  ModuleUTF8 = moduleUTF8
+
+  def test_nonascii_class_instance
     a = ClassUTF8.new
     assert_instance_of(ClassUTF8, Marshal.load(Marshal.dump(a)), '[ruby-core:24790]')
 
@@ -299,6 +303,12 @@ class TestMarshal < Test::Unit::TestCase
       assert_equal(a.instance_variables, b.instance_variables, bug1932)
       assert_equal(b, b.instance_variable_get(a.instance_variables[0]), bug1932)
     end
+  end
+
+  def test_nonascii_class_module
+    assert_same(ClassUTF8, Marshal.load(Marshal.dump(ClassUTF8)))
+    assert_same(ClassISO8859_1, Marshal.load(Marshal.dump(ClassISO8859_1)))
+    assert_same(ModuleUTF8, Marshal.load(Marshal.dump(ModuleUTF8)))
   end
 
   def test_regexp2


### PR DESCRIPTION
[[Bug #20009]](https://bugs.ruby-lang.org/issues/20009)