### PR TITLE
ZJIT: Allow DCE to remove some CCalls

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -273,7 +273,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::GuardType { val, guard_type, state } => gen_guard_type(asm, opnd!(val), *guard_type, &function.frame_state(*state))?,
         Insn::GuardBitEquals { val, expected, state } => gen_guard_bit_equals(asm, opnd!(val), *expected, &function.frame_state(*state))?,
         Insn::PatchPoint(_) => return Some(()), // For now, rb_zjit_bop_redefined() panics. TODO: leave a patch point and fix rb_zjit_bop_redefined()
-        Insn::CCall { cfun, args, name: _, return_type: _ } => gen_ccall(jit, asm, *cfun, args)?,
+        Insn::CCall { cfun, args, name: _, return_type: _, elidable: _ } => gen_ccall(jit, asm, *cfun, args)?,
         _ => {
             debug!("ZJIT: gen_function: unexpected insn {:?}", insn);
             return None;

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -26,6 +26,8 @@ pub struct FnProperties {
     pub leaf: bool,
     /// What Type the C function returns
     pub return_type: Type,
+    /// Whether it's legal to remove the call if the result is unused
+    pub elidable: bool,
 }
 
 impl Annotations {
@@ -64,7 +66,7 @@ pub fn init() -> Annotations {
 
     macro_rules! annotate {
         ($module:ident, $method_name:literal, $return_type:expr, $($properties:ident),+) => {
-            let mut props = FnProperties { no_gc: false, leaf: false, return_type: $return_type };
+            let mut props = FnProperties { no_gc: false, leaf: false, elidable: false, return_type: $return_type };
             $(
                 props.$properties = true;
             )+
@@ -72,9 +74,9 @@ pub fn init() -> Annotations {
         }
     }
 
-    annotate!(rb_mKernel, "itself", types::BasicObject, no_gc, leaf);
+    annotate!(rb_mKernel, "itself", types::BasicObject, no_gc, leaf, elidable);
     annotate!(rb_cString, "bytesize", types::Fixnum, no_gc, leaf);
-    annotate!(rb_cModule, "name", types::StringExact.union(types::NilClassExact), no_gc, leaf);
+    annotate!(rb_cModule, "name", types::StringExact.union(types::NilClassExact), no_gc, leaf, elidable);
     annotate!(rb_cModule, "===", types::BoolExact, no_gc, leaf);
 
     Annotations {


### PR DESCRIPTION
Add is_elidable field that signals that there would be no discernible
effect if the call to the method were removed. The default is false.
