### PR TITLE
Add `String#ensure_suffix`

### DIFF
--- a/doc/string/ensure_suffix.rdoc
+++ b/doc/string/ensure_suffix.rdoc
@@ -1,0 +1,5 @@
+Returns +self+ if it ends with the given +suffix+. Returns a new
+string with the +suffix+ appended, otherwise.
+
+  "Hell".ensure_suffix("o!")   # => "Hello!"
+  "Hello!".ensure_suffix("o!") # => "Hello!"

--- a/string.c
+++ b/string.c
@@ -11307,6 +11307,21 @@ rb_str_delete_suffix(VALUE str, VALUE suffix)
     return rb_str_subseq(str, 0, RSTRING_LEN(str) - suffixlen);
 }
 
+/*
+ *  call-seq:
+ *    ensure_suffix(suffix) -> self or new_string
+ *
+ *  :include: doc/string/ensure_suffix.rdoc
+ *
+ */
+static VALUE
+rb_str_ensure_suffix(VALUE str, VALUE suffix)
+{
+    if (rb_str_end_with(1, &suffix, str)) return str;
+
+    return rb_str_plus(str, suffix);
+}
+
 void
 rb_str_setter(VALUE val, ID id, VALUE *var)
 {
@@ -12678,6 +12693,7 @@ Init_String(void)
     rb_define_method(rb_cString, "rstrip", rb_str_rstrip, 0);
     rb_define_method(rb_cString, "delete_prefix", rb_str_delete_prefix, 1);
     rb_define_method(rb_cString, "delete_suffix", rb_str_delete_suffix, 1);
+    rb_define_method(rb_cString, "ensure_suffix", rb_str_ensure_suffix, 1);
 
     rb_define_method(rb_cString, "sub!", rb_str_sub_bang, -1);
     rb_define_method(rb_cString, "gsub!", rb_str_gsub_bang, -1);

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -3737,6 +3737,17 @@ CODE
     Warning[:deprecated] = deprecated
   end
 
+  def test_string_ensure_suffix
+    s = S("foobar")
+
+    assert_equal("foobarbaz", s.ensure_suffix("baz"))
+    assert_equal("foobar", s.ensure_suffix("bar"))
+    assert_equal(true, s.ensure_suffix("bar").equal?(s))
+    assert_equal("foobarBAR", s.ensure_suffix("BAR"))
+    assert_equal("foobar", s.ensure_suffix(""))
+    assert_equal(true, s.ensure_suffix("").equal?(s))
+  end
+
   private
 
   def assert_bytesplice_result(expected, s, *args)


### PR DESCRIPTION
This method returns self if the string ends with the given suffix. It returns a new string with the suffix appended, otherwise.

    "Hell".ensure_suffix("o!")   # => "Hello!"
    "Hello!".ensure_suffix("o!") # => "Hello!"

---

In my microbenchmarks writing it in C seems to be faster than in Ruby, but happy to change the implementation if the team prefers that.