### PR TITLE
[DOC] Describe new return value of source_location

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -1394,10 +1394,17 @@ rb_iseq_location(const rb_iseq_t *iseq)
 
 /*
  * call-seq:
- *    prc.source_location  -> [String, Integer]
+ *    prc.source_location  -> [String, Integer, Integer, Integer, Integer]
  *
- * Returns the Ruby source filename and line number containing this proc
- * or +nil+ if this proc was not defined in Ruby (i.e. native).
+ * Returns the location where the Proc was defined.
+ * The returned Array contains:
+ *   (1) the Ruby source filename
+ *   (2) the line number where the definition starts
+ *   (3) the column number where the definition starts
+ *   (4) the line number where the definition ends
+ *   (5) the column number where the definitions ends
+ *
+ * This method will return +nil+ if the Proc was not defined in Ruby (i.e. native).
  */
 
 VALUE
@@ -3056,10 +3063,17 @@ rb_method_entry_location(const rb_method_entry_t *me)
 
 /*
  * call-seq:
- *    meth.source_location  -> [String, Integer]
+ *    meth.source_location  -> [String, Integer, Integer, Integer, Integer]
  *
- * Returns the Ruby source filename and line number containing this method
- * or nil if this method was not defined in Ruby (i.e. native).
+ * Returns the location where the method was defined.
+ * The returned Array contains:
+ *   (1) the Ruby source filename
+ *   (2) the line number where the definition starts
+ *   (3) the column number where the definition starts
+ *   (4) the line number where the definition ends
+ *   (5) the column number where the definitions ends
+ *
+ * This method will return +nil+ if the method was not defined in Ruby (i.e. native).
  */
 
 VALUE


### PR DESCRIPTION
Proc#source_location, Method#source_location and
UnboundMethod#source_location carry more information since 073c4e1cc712064e626914fa4a5a8061f903a637.

https://bugs.ruby-lang.org/issues/6012
https://github.com/ruby/ruby/pull/12539