### PR TITLE
ZJIT: Propagate disasm feature to ZJIT and YJIT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ crate-type = ["staticlib"]
 path = "jit.rs"
 
 [features]
-disasm = []
+disasm = ["yjit?/disasm", "zjit?/disasm"]
 runtime_checks = []
 yjit = [ "dep:yjit" ]
 zjit = [ "dep:zjit" ]

--- a/configure.ac
+++ b/configure.ac
@@ -3972,6 +3972,7 @@ AS_CASE(["${ZJIT_SUPPORT}"],
     [yes], [
     ],
     [dev], [
+        rb_cargo_features="$rb_cargo_features,disasm"
         JIT_CARGO_SUPPORT=dev
 	AC_DEFINE(RUBY_DEBUG, 1)
     ])


### PR DESCRIPTION
Follows up on: https://github.com/ruby/ruby/pull/13262

This PR fixes the `--zjit-dump-disasm` capability with `--enable-zjit=dev`. It fixes `--enable-zjit=dev` to enable `disasm` feature in the `jit` crate and propagates `jit/disasm` feature to `yjit/disasm` and `zjit/disasm`.

When either ZJIT or YJIT is enabled, it shouldn't enable the other crate. So we enable `yjit?/disasm` and `zjit?/disasm` instead of `yjit/disasm` and `zjit/disasm`.