### PR TITLE
Include stdbool.h without relying on autoconf check

### DIFF
--- a/include/ruby/internal/stdbool.h
+++ b/include/ruby/internal/stdbool.h
@@ -31,17 +31,9 @@
 #  define __bool_true_false_are_defined
 # endif
 
-#elif defined(HAVE_STDBOOL_H)
-# /* Take stdbool.h definition. */
+#else
+# /* Take stdbool.h definition. It exists since GCC 3.0 and VS 2015. */
 # include <stdbool.h>
-
-#elif !defined(HAVE__BOOL)
-typedef unsigned char _Bool;
-# /* See also http://www.open-std.org/jtc1/sc22/wg14/www/docs/n2229.htm */
-# define bool  _Bool
-# define true  ((_Bool)+1)
-# define false ((_Bool)+0)
-# define __bool_true_false_are_defined
 #endif
 
 #endif /* RBIMPL_STDBOOL_H */


### PR DESCRIPTION
As reported in <https://bugs.ruby-lang.org/issues/21340>, older autoconf
have a AC_HEADER_STDBOOL that's incompatible with C23. Autoconf 2.72
fixed the macro, but also mentions that it's deprecated since all
current compilers have this header.

Since we require C99 [1] and VS 2015 [2], we might actually be able take
this suggestion and include stdbool.h without a check. I want to try
this on rubyci.org and will revert if this cause any issues. Not
touching AC_HEADER_STDBOOL in configure.ac for now.

[1]: https://bugs.ruby-lang.org/issues/15347
[2]: https://bugs.ruby-lang.org/issues/19982
