### PR TITLE
Add assertion for RCLASS_SET_PRIME_CLASSEXT_WRITABLE

### DIFF
--- a/class.c
+++ b/class.c
@@ -702,7 +702,7 @@ class_alloc(VALUE flags, VALUE klass)
     RCLASS_PRIME_NS((VALUE)obj) = ns;
     // Classes/Modules defined in user namespaces are
     // writable directly because it exists only in a namespace.
-    RCLASS_SET_PRIME_CLASSEXT_WRITABLE((VALUE)obj, (NAMESPACE_USER_P(ns) || !rb_namespace_available()) ? true : false);
+    RCLASS_SET_PRIME_CLASSEXT_WRITABLE((VALUE)obj, !rb_namespace_available() || NAMESPACE_USER_P(ns) ? true : false);
 
     RCLASS_SET_ORIGIN((VALUE)obj, (VALUE)obj);
     RCLASS_SET_REFINED_CLASS((VALUE)obj, Qnil);

--- a/class.c
+++ b/class.c
@@ -702,7 +702,7 @@ class_alloc(VALUE flags, VALUE klass)
     RCLASS_PRIME_NS((VALUE)obj) = ns;
     // Classes/Modules defined in user namespaces are
     // writable directly because it exists only in a namespace.
-    RCLASS_SET_PRIME_CLASSEXT_WRITABLE((VALUE)obj, NAMESPACE_USER_P(ns) ? true : false);
+    RCLASS_SET_PRIME_CLASSEXT_WRITABLE((VALUE)obj, (NAMESPACE_USER_P(ns) || !rb_namespace_available()) ? true : false);
 
     RCLASS_SET_ORIGIN((VALUE)obj, (VALUE)obj);
     RCLASS_SET_REFINED_CLASS((VALUE)obj, Qnil);
@@ -857,6 +857,8 @@ rb_class_new(VALUE super)
     if (super != rb_cObject && super != rb_cBasicObject) {
         RCLASS_SET_MAX_IV_COUNT(klass, RCLASS_MAX_IV_COUNT(super));
     }
+
+    RUBY_ASSERT(getenv("RUBY_NAMESPACE") || RCLASS_PRIME_CLASSEXT_WRITABLE_P(klass));
 
     return klass;
 }

--- a/gc.c
+++ b/gc.c
@@ -3280,11 +3280,13 @@ rb_gc_mark_children(void *objspace, VALUE obj)
             // Skip updating max_iv_count if the prime classext is not writable
             // because GC context doesn't provide information about namespaces.
             if (RCLASS_PRIME_CLASSEXT_WRITABLE_P(klass)) {
-                VM_ASSERT(rb_shape_obj_too_complex_p(klass));
                 // Increment max_iv_count if applicable, used to determine size pool allocation
                 if (RCLASS_MAX_IV_COUNT(klass) < fields_count) {
                     RCLASS_SET_MAX_IV_COUNT(klass, fields_count);
                 }
+            }
+            else {
+                VM_ASSERT(rb_shape_obj_too_complex_p(klass));
             }
         }
 


### PR DESCRIPTION
When classes are booted, they should all be writeable unless namespaces are enabled.  This commit adds an assertion to ensure that classes are writable.