### PR TITLE
JITs: Add back MACOSX_DEPLOYMENT_TARGET=11.0 setting to avoid warning

### DIFF
--- a/defs/jit.mk
+++ b/defs/jit.mk
@@ -7,6 +7,10 @@
 RUST_LIB_TOUCH = touch $@
 
 ifneq ($(JIT_CARGO_SUPPORT),no)
+# NOTE: MACOSX_DEPLOYMENT_TARGET to match `rustc --print deployment-target` to avoid the warning below.
+#    ld: warning: object file (target/debug/libjit.a(<libcapstone object>)) was built for
+#    newer macOS version (15.2) than being linked (15.0)
+# This limits us to an older set of macOS API in the rust code, but we don't use any.
 $(RUST_LIB): $(srcdir)/jit.rs
 	$(Q)if [ '$(ZJIT_SUPPORT)' != no -a '$(YJIT_SUPPORT)' != no ]; then \
 	    echo 'building YJIT and ZJIT ($(JIT_CARGO_SUPPORT:yes=release) mode)'; \
@@ -17,6 +21,7 @@ $(RUST_LIB): $(srcdir)/jit.rs
 	fi
 	+$(Q)CARGO_TARGET_DIR='$(CARGO_TARGET_DIR)' \
 	    CARGO_TERM_PROGRESS_WHEN='never' \
+	    MACOSX_DEPLOYMENT_TARGET=11.0 \
 	    $(CARGO) $(CARGO_VERBOSE) build --manifest-path '$(top_srcdir)/Cargo.toml' $(CARGO_BUILD_ARGS)
 	$(RUST_LIB_TOUCH)
 endif


### PR DESCRIPTION
See: 41251fdd309d4ff8f699268e33c32a114257211e
