### PR TITLE
Avoid adding garbage objects to id2ref table

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1954,7 +1954,14 @@ object_id(VALUE obj)
 static void
 build_id2ref_i(VALUE obj, void *data)
 {
+    rb_objspace_t *objspace = rb_gc_get_objspace();
     st_table *id2ref_tbl = (st_table *)data;
+
+    if (rb_gc_impl_garbage_object_p(objspace, obj)) {
+        return;
+    }
+
+    GC_ASSERT(BUILTIN_TYPE(obj) != T_NONE);
 
     switch (BUILTIN_TYPE(obj)) {
       case T_CLASS:


### PR DESCRIPTION
We didn't confirm that this is causing the CI failures, but this is our guess.

The id2ref table is built calling `disable_gc_no_rest`, which won't finish on ongoing GC, so it seems reasonable that that will end up with garbage objects inside the id2ref table.

cc @byroot 