### PR TITLE
Remove too_complex GC assertion

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3284,9 +3284,6 @@ rb_gc_mark_children(void *objspace, VALUE obj)
                     RCLASS_SET_MAX_IV_COUNT(klass, fields_count);
                 }
             }
-            else {
-                VM_ASSERT(rb_shape_obj_too_complex_p(klass));
-            }
         }
 
         break;


### PR DESCRIPTION
Classes from the default namespace are not writable, however they do not transition to too_complex until they have been written to inside a user namespace. So this assertion is invalid (as is the previous location it was) but it doesn't seem to provide us much value.