### PR TITLE
[DOC] Set canonical root for online docs

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -20,3 +20,5 @@ autolink_excluded_words:
 - RDoc
 - Ruby
 - Set
+
+canonical_root: https://docs.ruby-lang.org/en/master


### PR DESCRIPTION
This [feature](https://github.com/ruby/rdoc/pull/1354) is introduced in RDoc v6.14.0 and will help search engines filter and group links to the docs.