### PR TITLE
Fix moving old objects between Ractors

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2400,3 +2400,18 @@ unless /mswin/ =~ RUBY_PLATFORM
   r1.take.sort
   }
 end
+
+# Moving an old object
+assert_equal 'ok', %q{
+  r = Ractor.new do
+    o = Ractor.receive
+    GC.start
+    o
+  end
+
+  o = "ok"
+  # Make o an old object
+  3.times { GC.start }
+  r.send(o, move: true)
+  r.take
+}

--- a/ractor.c
+++ b/ractor.c
@@ -3678,9 +3678,11 @@ move_leave(VALUE obj, struct obj_traverse_replace_data *data)
         rb_replace_generic_ivar(data->replacement, obj);
     }
 
+    VALUE flags = T_OBJECT | FL_FREEZE | (RBASIC(obj)->flags & FL_PROMOTED);
+
     // Avoid mutations using bind_call, etc.
     MEMZERO((char *)obj + sizeof(struct RBasic), char, size - sizeof(struct RBasic));
-    RBASIC(obj)->flags = T_OBJECT | FL_FREEZE;
+    RBASIC(obj)->flags = flags;
     RBASIC_SET_CLASS_RAW(obj, rb_cRactorMovedObject);
     return traverse_cont;
 }


### PR DESCRIPTION
The FL_PROMOTED flag was not copied when moving objects, causing assertions to fail when an old object is moved:

    gc/default/default.c:834: Assertion Failed: RVALUE_AGE_SET:age <= RVALUE_OLD_AGE