### PR TITLE
change Net::HTTPResponse.value to return self

### DIFF
--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -284,6 +284,7 @@ class Net::HTTPResponse
   # Raises an HTTP error if the response is not 2xx (success).
   def value
     error! unless self.kind_of?(Net::HTTPSuccess)
+    self
   end
 
   def uri= uri # :nodoc:


### PR DESCRIPTION
It's kind of a strange behaviour now. you call .value and get nil in a successful request, which contradicts the name. returning self would make it more useful especially with chaining.