### PR TITLE
Don't use namespaced classext for superclasses

### DIFF
--- a/benchmark/class_superclass.yml
+++ b/benchmark/class_superclass.yml
@@ -1,0 +1,23 @@
+prelude: |
+  class SimpleClass; end
+  class OneModuleClass
+    1.times { include Module.new }
+  end
+  class MediumClass
+    10.times { include Module.new }
+  end
+  class LargeClass
+    100.times { include Module.new }
+  end
+benchmark:
+  object_class_superclass: |
+    Object.superclass
+  simple_class_superclass: |
+    SimpleClass.superclass
+  one_module_class: |
+    OneModuleClass.superclass
+  medium_class_superclass: |
+    MediumClass.superclass
+  large_class_superclass: |
+    LargeClass.superclass
+loop_count: 20000000

--- a/class.c
+++ b/class.c
@@ -183,16 +183,6 @@ duplicate_classext_const_tbl(struct rb_id_table *src, VALUE klass)
     return dst;
 }
 
-static void
-duplicate_classext_superclasses(rb_classext_t *orig, rb_classext_t *copy)
-{
-    RCLASSEXT_SUPERCLASSES(copy) = RCLASSEXT_SUPERCLASSES(orig);
-    RCLASSEXT_SUPERCLASS_DEPTH(copy) = RCLASSEXT_SUPERCLASS_DEPTH(orig);
-    // the copy is always not the owner and the orig (or its parent class) will maintain the superclasses array
-    RCLASSEXT_SUPERCLASSES_OWNER(copy) = false;
-    RCLASSEXT_SUPERCLASSES_WITH_SELF(copy) = RCLASSEXT_SUPERCLASSES_WITH_SELF(orig);
-}
-
 static VALUE
 namespace_subclasses_tbl_key(const rb_namespace_t *ns)
 {
@@ -343,9 +333,6 @@ rb_class_duplicate_classext(rb_classext_t *orig, VALUE klass, const rb_namespace
      */
 
     RCLASSEXT_CVC_TBL(ext) = duplicate_classext_id_table(RCLASSEXT_CVC_TBL(orig), dup_iclass);
-
-    // superclass_depth, superclasses
-    duplicate_classext_superclasses(orig, ext);
 
     // subclasses, subclasses_index
     duplicate_classext_subclasses(orig, ext);
@@ -825,11 +812,11 @@ rb_class_update_superclasses(VALUE klass)
     }
     else {
         superclasses = class_superclasses_including_self(super);
-        RCLASS_WRITE_SUPERCLASSES(super, super_depth, superclasses, true, true);
+        RCLASS_WRITE_SUPERCLASSES(super, super_depth, superclasses, true);
     }
 
     size_t depth = super_depth == RCLASS_MAX_SUPERCLASS_DEPTH ? super_depth : super_depth + 1;
-    RCLASS_WRITE_SUPERCLASSES(klass, depth, superclasses, false, false);
+    RCLASS_WRITE_SUPERCLASSES(klass, depth, superclasses, false);
 }
 
 void

--- a/gc.c
+++ b/gc.c
@@ -1238,7 +1238,8 @@ classext_free(rb_classext_t *ext, bool is_prime, VALUE namespace, void *arg)
         rb_id_table_free(tbl);
     }
     rb_class_classext_free_subclasses(ext, args->klass);
-    if (RCLASSEXT_SUPERCLASSES_OWNER(ext)) {
+    if (RCLASSEXT_SUPERCLASSES_WITH_SELF(ext)) {
+        RUBY_ASSERT(is_prime); // superclasses should only be used on prime
         xfree(RCLASSEXT_SUPERCLASSES(ext));
     }
     if (!is_prime) { // the prime classext will be freed with RClass
@@ -2293,10 +2294,9 @@ classext_superclasses_memsize(rb_classext_t *ext, bool prime, VALUE namespace, v
 {
     size_t *size = (size_t *)arg;
     size_t array_size;
-    if (RCLASSEXT_SUPERCLASSES_OWNER(ext)) {
-        array_size = RCLASSEXT_SUPERCLASS_DEPTH(ext);
-        if (RCLASSEXT_SUPERCLASSES_WITH_SELF(ext))
-            array_size += 1;
+    if (RCLASSEXT_SUPERCLASSES_WITH_SELF(ext)) {
+        RUBY_ASSERT(prime);
+        array_size = RCLASSEXT_SUPERCLASS_DEPTH(ext) + 1;
         *size += array_size * sizeof(VALUE);
     }
 }
@@ -3805,10 +3805,8 @@ update_subclasses(void *objspace, rb_classext_t *ext)
 static void
 update_superclasses(rb_objspace_t *objspace, rb_classext_t *ext)
 {
-    size_t array_size = RCLASSEXT_SUPERCLASS_DEPTH(ext);
-    if (RCLASSEXT_SUPERCLASSES_OWNER(ext)) {
-        if (RCLASSEXT_SUPERCLASSES_WITH_SELF(ext))
-            array_size += 1;
+    if (RCLASSEXT_SUPERCLASSES_WITH_SELF(ext)) {
+        size_t array_size = RCLASSEXT_SUPERCLASS_DEPTH(ext) + 1;
         for (size_t i = 0; i < array_size; i++) {
             UPDATE_IF_MOVED(objspace, RCLASSEXT_SUPERCLASSES(ext)[i]);
         }

--- a/object.c
+++ b/object.c
@@ -2259,23 +2259,22 @@ rb_class_superclass(VALUE klass)
 {
     RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS));
 
-    VALUE super = RCLASS_SUPER(klass);
-    VALUE *superclasses;
-    size_t superclasses_depth;
+    VALUE *superclasses = RCLASS_SUPERCLASSES(klass);
+    size_t superclasses_depth = RCLASS_SUPERCLASS_DEPTH(klass);
 
-    if (!super) {
-        if (klass == rb_cBasicObject) return Qnil;
+    if (klass == rb_cBasicObject) return Qnil;
+
+    if (!superclasses) {
+        RUBY_ASSERT(!RCLASS_SUPER(klass));
         rb_raise(rb_eTypeError, "uninitialized class");
     }
 
-    superclasses_depth = RCLASS_SUPERCLASS_DEPTH(klass);
     if (!superclasses_depth) {
         return Qnil;
     }
     else {
-        superclasses = RCLASS_SUPERCLASSES(klass);
-        super = superclasses[superclasses_depth - 1];
-        RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS));
+        VALUE super = superclasses[superclasses_depth - 1];
+        RUBY_ASSERT(RB_TYPE_P(super, T_CLASS));
         return super;
     }
 }


### PR DESCRIPTION
Superclasses can't be modified by user code, so do not need namespace indirection. For example Object.superclass is always BasicObject, no matter what modules are included onto it. This first commit switches to always using `RCLASS_EXT_PRIME` for superclasses.

Additionally this avoids calling `RCLASS_SUPER`, which has become expensive, since it still needs to reference the namespace (because the immediate super may be an iclass).

This makes `Object.superclass` 3.6x faster when namespaces are enabled and about 10% faster when disabled. Unfortunately that's still slower than before namespaces were introduced (which made this nearly 4x slower than Ruby 3.4.4).

**Namespaces enabled**

```
❯ RUBY_NAMESPACE=1 /home/jhawthorn/.rubies/ruby-3.4.4/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="ruby-3.4.4::/home/jhawthorn/.rubies/ruby-3.4.4/bin/ruby --disable=gems -I.ext/common --disable-gem" \
            --executables="ruby-3.5.0dev::/home/jhawthorn/.rubies/ruby-dev/bin/ruby --disable=gems -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            --output=markdown --output-compare -v $(find ./benchmark -maxdepth 1 -name 'class_superclass' -o -name '*class_superclass*.yml' -o -name '*class_superclass*.rb' | sort) 2> err.txt
ruby-3.4.4: ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [x86_64-linux]
ruby-3.5.0dev: ruby 3.5.0dev (2025-05-21T00:34:31Z rb_inspect_on_ract.. 487bb2c20a) +PRISM [x86_64-linux]
built-ruby: ruby 3.5.0dev (2025-05-22T22:18:41Z superclasses_names.. 51a1553042) +PRISM [x86_64-linux]
# Iteration per second (i/s)

|                         |ruby-3.4.4|ruby-3.5.0dev|built-ruby|
|:------------------------|---------:|------------:|---------:|
|object_class_superclass  |   82.452M|      20.780M|   74.747M|
|                         |     3.97x|            -|     3.60x|
|simple_class_superclass  |   84.166M|      67.690M|   74.009M|
|                         |     1.24x|            -|     1.09x|
|one_module_class         |   84.463M|      63.787M|   75.712M|
|                         |     1.32x|            -|     1.19x|
|medium_class_superclass  |   83.369M|      66.333M|   77.146M|
|                         |     1.26x|            -|     1.16x|
|large_class_superclass   |   82.932M|      66.769M|   74.359M|
|                         |     1.24x|            -|     1.11x|
```

**Namespaces disabled**

```
❯ /home/jhawthorn/.rubies/ruby-3.4.4/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="ruby-3.4.4::/home/jhawthorn/.rubies/ruby-3.4.4/bin/ruby --disable=gems -I.ext/common --disable-gem" \
            --executables="ruby-3.5.0dev::/home/jhawthorn/.rubies/ruby-dev/bin/ruby --disable=gems -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            --output=markdown --output-compare -v $(find ./benchmark -maxdepth 1 -name 'class_superclass' -o -name '*class_superclass*.yml' -o -name '*class_superclass*.rb' | sort) 2> err.txt
ruby-3.4.4: ruby 3.4.4 (2025-05-14 revision a38531fd3f) +PRISM [x86_64-linux]
ruby-3.5.0dev: ruby 3.5.0dev (2025-05-21T00:34:31Z rb_inspect_on_ract.. 487bb2c20a) +PRISM [x86_64-linux]
built-ruby: ruby 3.5.0dev (2025-05-22T22:18:41Z superclasses_names.. 51a1553042) +PRISM [x86_64-linux]
# Iteration per second (i/s)

|                         |ruby-3.4.4|ruby-3.5.0dev|built-ruby|
|:------------------------|---------:|------------:|---------:|
|object_class_superclass  |   84.152M|      67.527M|   75.219M|
|                         |     1.25x|            -|     1.11x|
|simple_class_superclass  |   84.675M|      68.363M|   75.163M|
|                         |     1.24x|            -|     1.10x|
|one_module_class         |   83.759M|      67.420M|   74.137M|
|                         |     1.24x|            -|     1.10x|
|medium_class_superclass  |   84.982M|      67.618M|   73.804M|
|                         |     1.26x|            -|     1.09x|
|large_class_superclass   |   83.782M|      67.717M|   74.746M|
|                         |     1.24x|            -|     1.10x|
```