### PR TITLE
Fix warnings on cygwin

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -1889,8 +1889,8 @@ rb_thread_mn_schedulable(VALUE thval)
 VALUE
 rb_thread_io_blocking_call(struct rb_io* io, rb_blocking_function_t *func, void *data1, int events)
 {
-    rb_execution_context_t * ec = GET_EC();
-    rb_thread_t *th = rb_ec_thread_ptr(ec);
+    rb_execution_context_t * volatile ec = GET_EC();
+    rb_thread_t * volatile th = rb_ec_thread_ptr(ec);
 
     RUBY_DEBUG_LOG("th:%u fd:%d ev:%d", rb_th_serial(th), io->fd, events);
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -2002,9 +2002,9 @@ rb_current_execution_context(bool expect_ec)
 {
 #ifdef RB_THREAD_LOCAL_SPECIFIER
   #if defined(__arm64__) || defined(__aarch64__)
-    rb_execution_context_t *ec = rb_current_ec();
+    rb_execution_context_t * volatile ec = rb_current_ec();
   #else
-    rb_execution_context_t *ec = ruby_current_ec;
+    rb_execution_context_t * volatile ec = ruby_current_ec;
   #endif
 
     /* On the shared objects, `__tls_get_addr()` is used to access the TLS
@@ -2021,7 +2021,7 @@ rb_current_execution_context(bool expect_ec)
      */
     VM_ASSERT(ec == rb_current_ec_noinline());
 #else
-    rb_execution_context_t *ec = native_tls_get(ruby_current_ec_key);
+    rb_execution_context_t * volatile ec = native_tls_get(ruby_current_ec_key);
 #endif
     VM_ASSERT(!expect_ec || ec != NULL);
     return ec;


### PR DESCRIPTION
Same purpose as #12676
```
thread.c: In function ‘rb_thread_io_blocking_call’:
thread.c:1828:30: warning: variable ‘ec’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Wclobbered]
 1828 |     rb_execution_context_t * ec = GET_EC();
      |                              ^~
thread.c:1829:18: warning: variable ‘th’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Wclobbered]
 1829 |     rb_thread_t *th = rb_ec_thread_ptr(ec);
      |                  ^~
In file included from eval_intern.h:5,
                 from thread.c:75:
vm_core.h:2007:29: warning: variable ‘ec’ might be clobbered by ‘longjmp’ or ‘vfork’ [-Wclobbered]
 2007 |     rb_execution_context_t *ec = ruby_current_ec;
      |                             ^~
```
