### PR TITLE
Change test to avoid stack overflow with MN threads

### DIFF
--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -2138,7 +2138,9 @@ class TestHashOnly < Test::Unit::TestCase
 
   def test_iterlevel_in_ivar_bug19589
     h = { a: nil }
-    hash_iter_recursion(h, 200)
+    # Recursion level should be over 127 to actually test iterlevel being set in an instance variable,
+    # but it should be under 131 not to overflow the stack under MN threads/ractors.
+    hash_iter_recursion(h, 130)
     assert true
   end
 


### PR DESCRIPTION
When using MN threads (such as running the test in a ractor), this test failed because it was raising a SystemStackError: stack level too deep.

This is because the machine stack is smaller under MN threads than on the native main thread.

You can reproduce the error by wrapping in a thread and running with `RUBY_MN_THREADS=1`:
```diff
diff --git i/test/ruby/test_hash.rb w/test/ruby/test_hash.rb
index dbf041a732..4d51d0dbf2 100644
--- i/test/ruby/test_hash.rb
+++ w/test/ruby/test_hash.rb
@@ -2140,7 +2140,9 @@ def test_iterlevel_in_ivar_bug19589
     h = { a: nil }
     # Recursion level should be over 127 to actually test iterlevel being set in an instance variable,
     # but it should be under 131 not to overflow the stack under MN threads/ractors.
-    hash_iter_recursion(h, 130)
+    Thread.new {
+    hash_iter_recursion(h, 131)
+    }.join
     assert true
   end
 
```

Using 131 levels and RUBY_MN_THREADS=1, this test fails.