### PR TITLE
Fix 'require' from a ractor when the required file raises an error

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -4215,9 +4215,12 @@ rb_ractor_require(VALUE feature)
     rb_ractor_channel_close(ec, crr.ch);
 
     if (crr.exception != Qundef) {
+        ractor_reset_belonging(crr.exception);
         rb_exc_raise(crr.exception);
     }
     else {
+        RUBY_ASSERT(crr.result != Qundef);
+        ractor_reset_belonging(crr.result);
         return crr.result;
     }
 }


### PR DESCRIPTION
If you catch an error that was raised from a file you required in a ractor, that error did not have its belonging reset from the main ractor to the current ractor, so you hit assertion errors in debug mode.