### PR TITLE
ZJIT: Add SideExit HIR opcode and use it instead of failing to compile

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -903,7 +903,7 @@ impl Function {
             ArrayDup { val , state } => ArrayDup { val: find!(*val), state: *state },
             &HashDup { val , state } => HashDup { val: find!(val), state },
             &CCall { cfun, ref args, name, return_type, elidable } => CCall { cfun: cfun, args: args.iter().map(|arg| find!(*arg)).collect(), name: name, return_type: return_type, elidable },
-            Defined { .. } => todo!("find(Defined)"),
+            &Defined { op_type, obj, pushval, v } => Defined { op_type, obj, pushval, v: find!(v) },
             NewArray { elements, state } => NewArray { elements: find_vec!(*elements), state: find!(*state) },
             &NewHash { ref elements, state } => {
                 let mut found_elements = vec![];

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -422,7 +422,7 @@ impl Insn {
     /// Return true if the instruction ends a basic block and false otherwise.
     pub fn is_terminator(&self) -> bool {
         match self {
-            Insn::Jump(_) | Insn::Return { .. } => true,
+            Insn::Jump(_) | Insn::Return { .. } | Insn::SideExit { .. } => true,
             _ => false,
         }
     }


### PR DESCRIPTION
- **ZJIT: Side-exit into the interpreter on unknown opcodes**
- **ZJIT: Side-exit into the interpreter on unknown opt_newarray_send**
- **ZJIT: Side-exit into the interpreter on unknown call types**
