### PR TITLE
ractor_wakeup was broken when compiled with USE_RUBY_DEBUG_LOG

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -576,9 +576,8 @@ ractor_wakeup(rb_ractor_t *r, rb_thread_t *th /* can be NULL */, enum rb_ractor_
 {
     ASSERT_ractor_locking(r);
 
-    RUBY_DEBUG_LOG("r:%u wait_by:%s -> wait:%s wakeup:%s",
+    RUBY_DEBUG_LOG("r:%u wait:%s wakeup:%s",
                    rb_ractor_id(r),
-                   wait_status_str(th->ractor_waiting.wait_status),
                    wait_status_str(wait_status),
                    wakeup_status_str(wakeup_status));
 


### PR DESCRIPTION
The `ractor_wakeup` function takes an optional `th` argument, so it can be NULL. There is a macro call to RUBY_DEBUG_LOG that dereferences `th` without checking if it's NULL first. To fix this, we never dereference `th` in this macro call.