### PR TITLE
ZJIT: Add more opcodes and Array fast-paths

### DIFF
--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -78,6 +78,8 @@ pub fn init() -> Annotations {
     annotate!(rb_cString, "bytesize", types::Fixnum, no_gc, leaf);
     annotate!(rb_cModule, "name", types::StringExact.union(types::NilClassExact), no_gc, leaf, elidable);
     annotate!(rb_cModule, "===", types::BoolExact, no_gc, leaf);
+    annotate!(rb_cArray, "length", types::Fixnum, no_gc, leaf, elidable);
+    annotate!(rb_cArray, "size", types::Fixnum, no_gc, leaf, elidable);
 
     Annotations {
         cfuncs: std::mem::take(cfuncs)

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4367,6 +4367,40 @@ mod opt_tests {
     }
 
     #[test]
+    fn eliminate_array_length() {
+        eval("
+            def test
+              x = [].length
+              5
+            end
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0():
+              PatchPoint MethodRedefined(Array@0x1000, length@0x1008)
+              v6:Fixnum[5] = Const Value(5)
+              Return v6
+        "#]]);
+    }
+
+    #[test]
+    fn eliminate_array_size() {
+        eval("
+            def test
+              x = [].length
+              5
+            end
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0():
+              PatchPoint MethodRedefined(Array@0x1000, length@0x1008)
+              v6:Fixnum[5] = Const Value(5)
+              Return v6
+        "#]]);
+    }
+
+    #[test]
     fn kernel_itself_argc_mismatch() {
         eval("
             def test = 1.itself(0)
@@ -4563,8 +4597,9 @@ mod opt_tests {
             fn test:
             bb0(v0:BasicObject, v1:BasicObject):
               v4:ArrayExact = NewArray v0, v1
-              v6:BasicObject = SendWithoutBlock v4, :length
-              Return v6
+              PatchPoint MethodRedefined(Array@0x1000, length@0x1008)
+              v9:Fixnum = CCall length@0x1010, v4
+              Return v9
         "#]]);
     }
 
@@ -4577,8 +4612,9 @@ mod opt_tests {
             fn test:
             bb0(v0:BasicObject, v1:BasicObject):
               v4:ArrayExact = NewArray v0, v1
-              v6:BasicObject = SendWithoutBlock v4, :size
-              Return v6
+              PatchPoint MethodRedefined(Array@0x1000, size@0x1008)
+              v9:Fixnum = CCall size@0x1010, v4
+              Return v9
         "#]]);
     }
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2191,6 +2191,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                 YARVINSN_opt_aset |
                 YARVINSN_opt_length |
                 YARVINSN_opt_size |
+                YARVINSN_opt_aref |
                 YARVINSN_opt_send_without_block => {
                     let cd: *const rb_call_data = get_arg(pc, 0).as_ptr();
                     let call_info = unsafe { rb_get_call_data_ci(cd) };
@@ -3477,6 +3478,34 @@ mod tests {
               ArrayPush v3, v5
               ArrayPush v3, v6
               Return v3
+        "#]]);
+    }
+
+    #[test]
+    fn test_aset() {
+        eval("
+            def test(a, b) = a[b] = 1
+        ");
+        assert_method_hir("test",  expect![[r#"
+            fn test:
+            bb0(v0:BasicObject, v1:BasicObject):
+              v3:NilClassExact = Const Value(nil)
+              v4:Fixnum[1] = Const Value(1)
+              v6:BasicObject = SendWithoutBlock v0, :[]=, v1, v4
+              Return v4
+        "#]]);
+    }
+
+    #[test]
+    fn test_aref() {
+        eval("
+            def test(a, b) = a[b]
+        ");
+        assert_method_hir("test",  expect![[r#"
+            fn test:
+            bb0(v0:BasicObject, v1:BasicObject):
+              v4:BasicObject = SendWithoutBlock v0, :[], v1
+              Return v4
         "#]]);
     }
 }


### PR DESCRIPTION
- **ZJIT: Add fast-paths for Array#length and Array#size**
- **ZJIT: Parse opt_aref into HIR**
- **ZJIT: Parse branchnil into HIR**
