### PR TITLE
Fix `IO#close` use-after-free in `blocking_operation_wait` and `fiber_interrupt` hooks.

### DIFF
--- a/inits.c
+++ b/inits.c
@@ -63,9 +63,9 @@ rb_call_inits(void)
     CALL(ISeq);
     CALL(Thread);
     CALL(signal);
+    CALL(Cont);
     CALL(Fiber_Scheduler);
     CALL(process);
-    CALL(Cont);
     CALL(Rational);
     CALL(Complex);
     CALL(MemoryView);

--- a/internal/io.h
+++ b/internal/io.h
@@ -25,7 +25,7 @@ struct rb_io_blocking_operation {
     // The linked list data structure.
     struct ccan_list_node list;
 
-    // The execution context of the blocking operation:
+    // The execution context of the blocking operation.
     struct rb_execution_context_struct *ec;
 };
 

--- a/scheduler.c
+++ b/scheduler.c
@@ -422,6 +422,13 @@ rb_fiber_scheduler_unblock(VALUE scheduler, VALUE blocker, VALUE fiber)
     // If we explicitly preserve `errno` in `io_binwrite` and other similar functions (e.g. by returning it), this code is no longer needed. I hope in the future we will be able to remove it.
     int saved_errno = errno;
 
+#ifdef RUBY_DEBUG
+    rb_execution_context_t *ec = GET_EC();
+    if (ec->interrupt_flag) {
+        rb_bug("rb_fiber_scheduler_unblock called with interrupt flags set");
+    }
+#endif
+
     VALUE result = rb_funcall(scheduler, id_unblock, 2, blocker, fiber);
 
     errno = saved_errno;
@@ -852,6 +859,13 @@ VALUE rb_fiber_scheduler_fiber_interrupt(VALUE scheduler, VALUE fiber, VALUE exc
     VALUE arguments[] = {
         fiber, exception
     };
+
+#ifdef RUBY_DEBUG
+    rb_execution_context_t *ec = GET_EC();
+    if (ec->interrupt_flag) {
+        rb_bug("rb_fiber_scheduler_fiber_interrupt called with interrupt flags set");
+    }
+#endif
 
     return rb_check_funcall(scheduler, id_fiber_interrupt, 2, arguments);
 }

--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -341,7 +341,7 @@ class Scheduler
   end
 
   def blocking_operation_wait(work)
-    thread = Thread.new(&work)
+    thread = Thread.new{work.call}
 
     thread.join
 

--- a/test/fiber/test_io_close.rb
+++ b/test/fiber/test_io_close.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+require 'test/unit'
+require_relative 'scheduler'
+
+class TestFiberIOClose < Test::Unit::TestCase
+  def with_socket_pair(&block)
+    omit "UNIXSocket is not defined!" unless defined?(UNIXSocket)
+
+    UNIXSocket.pair do |i, o|
+      if RUBY_PLATFORM =~ /mswin|mingw/
+        i.nonblock = true
+        o.nonblock = true
+      end
+
+      yield i, o
+    end
+  end
+
+  # Problematic on Windows.
+  def test_io_close_across_fibers
+    omit "Interrupting a io_wait read is not supported!" if RUBY_PLATFORM =~ /mswin|mingw/
+
+    with_socket_pair do |i, o|
+      error = nil
+
+      thread = Thread.new do
+        scheduler = Scheduler.new
+        Fiber.set_scheduler scheduler
+
+        Fiber.schedule do
+          i.read
+        rescue => error
+          # Ignore.
+        end
+
+        Fiber.schedule do
+          i.close
+        end
+      end
+
+      thread.join
+
+      assert_instance_of IOError, error
+      assert_match(/closed/, error.message)
+    end
+  end
+
+  # Okay on all platforms.
+  def test_io_close_blocking_thread
+    omit "Interrupting a io_wait read is not supported!" if RUBY_PLATFORM =~ /mswin|mingw/
+
+    with_socket_pair do |i, o|
+      error = nil
+
+      reading_thread = Thread.new do
+        i.read
+      rescue => error
+        # Ignore.
+      end
+
+      Thread.pass until reading_thread.status == 'sleep'
+
+      thread = Thread.new do
+        scheduler = Scheduler.new
+        Fiber.set_scheduler scheduler
+
+        Fiber.schedule do
+          i.close
+        end
+      end
+
+      thread.join
+      reading_thread.join
+
+      assert_instance_of IOError, error
+      assert_match(/closed/, error.message)
+    end
+  end
+
+  # Problematic on Windows.
+  def test_io_close_blocking_fiber
+    omit "Interrupting a io_wait read is not supported!" if RUBY_PLATFORM =~ /mswin|mingw/
+
+    with_socket_pair do |i, o|
+      error = nil
+
+      thread = Thread.new do
+        scheduler = Scheduler.new
+        Fiber.set_scheduler scheduler
+
+        Fiber.schedule do
+          begin
+            i.read
+          rescue => error
+            # Ignore.
+          end
+        end
+      end
+
+      Thread.pass until thread.status == 'sleep'
+
+      i.close
+
+      thread.join
+
+      assert_instance_of IOError, error
+      assert_match(/closed/, error.message)
+    end
+  end
+end

--- a/test/fiber/test_io_close.rb
+++ b/test/fiber/test_io_close.rb
@@ -16,9 +16,8 @@ class TestFiberIOClose < Test::Unit::TestCase
     end
   end
 
-  # Problematic on Windows.
   def test_io_close_across_fibers
-    omit "Interrupting a io_wait read is not supported!" if RUBY_PLATFORM =~ /mswin|mingw/
+    # omit "Interrupting a io_wait read is not supported!" if RUBY_PLATFORM =~ /mswin|mingw/
 
     with_socket_pair do |i, o|
       error = nil
@@ -45,7 +44,6 @@ class TestFiberIOClose < Test::Unit::TestCase
     end
   end
 
-  # Okay on all platforms.
   def test_io_close_blocking_thread
     omit "Interrupting a io_wait read is not supported!" if RUBY_PLATFORM =~ /mswin|mingw/
 
@@ -77,9 +75,8 @@ class TestFiberIOClose < Test::Unit::TestCase
     end
   end
 
-  # Problematic on Windows.
   def test_io_close_blocking_fiber
-    omit "Interrupting a io_wait read is not supported!" if RUBY_PLATFORM =~ /mswin|mingw/
+    # omit "Interrupting a io_wait read is not supported!" if RUBY_PLATFORM =~ /mswin|mingw/
 
     with_socket_pair do |i, o|
       error = nil

--- a/thread.c
+++ b/thread.c
@@ -1552,7 +1552,7 @@ rb_nogvl(void *(*func)(void *), void *data1,
     if (flags & RB_NOGVL_OFFLOAD_SAFE) {
         VALUE scheduler = rb_fiber_scheduler_current();
         if (scheduler != Qnil) {
-            struct rb_fiber_scheduler_blocking_operation_state state;
+            struct rb_fiber_scheduler_blocking_operation_state state = {0};
 
             VALUE result = rb_fiber_scheduler_blocking_operation_wait(scheduler, func, data1, ubf, data2, flags, &state);
 


### PR DESCRIPTION
This PR fixes memory safety and interrupt handling issues discovered while debugging `IO#close` across fibers.

## Fix interrupt handling affecting `rb_io_blocking_operation_exit`

If `rb_io_blocking_operation_exit` executes with pending interrupts, user code that checks interrupts can exit unexpectedly. Instead, move the exception check into the `EC_PUSH_TAG` block so that by the time we reach `rb_io_blocking_operation_exit` the exception is already propagating and it behaves more like `ensure`.

Without this change, the following program can hang:

```ruby
#!/usr/bin/env ruby

require_relative 'lib/async'

Async do
  r, w = IO.pipe
  
  read_thread = Thread.new do
    Thread.current.report_on_exception = false
    r.read(5)
  end
  
  # Wait until read_thread blocks on I/O
  Thread.pass until read_thread.status == "sleep"
  
  close_task = Async do
    r.close
  end
  
  close_task.wait
  begin
    read_thread.join
  rescue => error
    puts "Caught exception: #{error.class} - #{error.message}"
  end
end
```

This is a follow up to https://github.com/ruby/ruby/pull/12839

## Fix use-after-free in `blocking_operation_wait` hook

`IO#close` could trigger stack-allocated memory access after the function returned. The new implementation uses a heap-allocated `BlockingOperation` instance which also exposes a C interface for (safe) native work pool execution.

https://bugs.ruby-lang.org/issues/21198

### Technical Implementation

The blocking operation system now provides:
- **Thread-safe cancellation** with atomic state transitions
- **Cross-platform atomic operations** supporting Windows, macOS, and Linux  
- **Anonymous BlockingOperation class** hidden from public API
- **Comprehensive state machine** for operation lifecycle management
- **GC-safe object management** with proper root registration

### API Improvements

- `rb_fiber_scheduler_blocking_operation_extract` - Safely extract operation data while holding GVL
- `rb_fiber_scheduler_blocking_operation_execute` - Execute in thread pools without GVL concerns  
- `rb_fiber_scheduler_blocking_operation_cancel` - Thread-safe cancellation support
- Consistent naming with `RB_FIBER_SCHEDULER_BLOCKING_OPERATION_STATUS_*` enum values

### Testing

Enhanced tests covering:
- IO#close across fibers 
- Memory safety verification
- Blocking operation cancellation
- Interrupt handling scenarios