### PR TITLE
shape.c: Implement a lock-free version of get_next_shape_internal

### DIFF
--- a/id_table.h
+++ b/id_table.h
@@ -16,7 +16,10 @@ enum rb_id_table_iterator_result {
 };
 
 struct rb_id_table *rb_id_table_create(size_t size);
+struct rb_id_table *rb_id_table_init(struct rb_id_table *tbl, size_t capa);
+
 void rb_id_table_free(struct rb_id_table *tbl);
+void rb_id_table_free_items(struct rb_id_table *tbl);
 void rb_id_table_clear(struct rb_id_table *tbl);
 
 size_t rb_id_table_memsize(const struct rb_id_table *tbl);
@@ -31,6 +34,13 @@ typedef enum rb_id_table_iterator_result rb_id_table_foreach_values_func_t(VALUE
 void rb_id_table_foreach(struct rb_id_table *tbl, rb_id_table_foreach_func_t *func, void *data);
 void rb_id_table_foreach_values(struct rb_id_table *tbl, rb_id_table_foreach_values_func_t *func, void *data);
 void rb_id_table_foreach_values_with_replace(struct rb_id_table *tbl, rb_id_table_foreach_values_func_t *func, rb_id_table_update_value_callback_func_t *replace, void *data);
+
+VALUE rb_managed_id_table_new(size_t capa);
+VALUE rb_managed_id_table_dup(VALUE table);
+int rb_managed_id_table_insert(VALUE table, ID id, VALUE val);
+int rb_managed_id_table_lookup(VALUE table, ID id, VALUE *valp);
+size_t rb_managed_id_table_size(VALUE table);
+void rb_managed_id_table_foreach(VALUE table, rb_id_table_foreach_func_t *func, void *data);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 size_t rb_id_table_size(const struct rb_id_table *tbl);

--- a/include/ruby/internal/core/rtypeddata.h
+++ b/include/ruby/internal/core/rtypeddata.h
@@ -471,8 +471,7 @@ RBIMPL_SYMBOL_EXPORT_END()
 /**
  * Identical to #TypedData_Wrap_Struct,  except it allocates a  new data region
  * internally instead of taking an existing  one.  The allocation is done using
- * ruby_calloc().  Hence  it makes no sense  for `data_type->function.dfree` to
- * be anything other than ::RUBY_TYPED_DEFAULT_FREE.
+ * ruby_calloc().
  *
  * @param      klass          Ruby level class of the object.
  * @param      type           Type name of the C struct.

--- a/shape.c
+++ b/shape.c
@@ -324,7 +324,14 @@ shape_tree_mark(void *data)
     rb_shape_t *end = RSHAPE(GET_SHAPE_TREE()->next_shape_id);
     while (cursor < end) {
         if (cursor->edges && !SINGLE_CHILD_P(cursor->edges)) {
-            rb_gc_mark_movable(cursor->edges);
+            // FIXME: GC compaction may call `rb_shape_traverse_from_new_root`
+            // to migrate objects from one object slot to another.
+            // Because of this if we don't pin `cursor->edges` it might be turned
+            // into a T_MOVED during GC.
+            // We'd need to eliminate `SHAPE_T_OBJECT` so that GC never need to lookup
+            // shapes this way.
+            // rb_gc_mark_movable(cursor->edges);
+            rb_gc_mark(cursor->edges);
         }
         cursor++;
     }

--- a/shape.h
+++ b/shape.h
@@ -42,7 +42,7 @@ extern ID ruby_internal_object_id;
 typedef struct redblack_node redblack_node_t;
 
 struct rb_shape {
-    struct rb_id_table *edges; // id_table from ID (ivar) to next shape
+    VALUE edges; // id_table from ID (ivar) to next shape
     ID edge_name; // ID (ivar) for transition from parent to rb_shape
     attr_index_t next_field_index; // Fields are either ivars or internal properties like `object_id`
     attr_index_t capacity; // Total capacity of the object with this shape
@@ -75,7 +75,7 @@ typedef struct {
     /* object shapes */
     rb_shape_t *shape_list;
     rb_shape_t *root_shape;
-    shape_id_t next_shape_id;
+    rb_atomic_t next_shape_id;
 
     redblack_node_t *shape_cache;
     unsigned int cache_size;

--- a/vm.c
+++ b/vm.c
@@ -3294,8 +3294,7 @@ vm_memsize(const void *ptr)
         vm_memsize_builtin_function_table(vm->builtin_function_table) +
         rb_id_table_memsize(vm->negative_cme_table) +
         rb_st_memsize(vm->overloaded_cme_table) +
-        vm_memsize_constant_cache() +
-        GET_SHAPE_TREE()->cache_size * sizeof(redblack_node_t)
+        vm_memsize_constant_cache()
     );
 
     // TODO

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -395,11 +395,6 @@ pub struct rb_namespace_struct {
 }
 pub type rb_namespace_t = rb_namespace_struct;
 pub type rb_serial_t = ::std::os::raw::c_ulonglong;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rb_id_table {
-    _unused: [u8; 0],
-}
 pub const imemo_env: imemo_type = 0;
 pub const imemo_cref: imemo_type = 1;
 pub const imemo_svar: imemo_type = 2;
@@ -695,9 +690,8 @@ pub type shape_id_t = u32;
 pub type redblack_id_t = u32;
 pub type redblack_node_t = redblack_node;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct rb_shape {
-    pub edges: *mut rb_id_table,
+    pub edges: VALUE,
     pub edge_name: ID,
     pub next_field_index: attr_index_t,
     pub capacity: attr_index_t,

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -212,11 +212,6 @@ pub const BOP_INCLUDE_P: ruby_basic_operators = 33;
 pub const BOP_LAST_: ruby_basic_operators = 34;
 pub type ruby_basic_operators = u32;
 pub type rb_serial_t = ::std::os::raw::c_ulonglong;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rb_id_table {
-    _unused: [u8; 0],
-}
 pub const imemo_env: imemo_type = 0;
 pub const imemo_cref: imemo_type = 1;
 pub const imemo_svar: imemo_type = 2;
@@ -404,7 +399,7 @@ pub type redblack_id_t = u32;
 pub type redblack_node_t = redblack_node;
 #[repr(C)]
 pub struct rb_shape {
-    pub edges: *mut rb_id_table,
+    pub edges: VALUE,
     pub edge_name: ID,
     pub next_field_index: attr_index_t,
     pub capacity: attr_index_t,


### PR DESCRIPTION
Whenever we run into an inline cache miss when we try to set an ivar, we may need to take the global lock, just to be able to lookup inside `shape->edges`.

To solve that, when we're in multi-ractor mode, we can treat the `shape->edges` as immutable. When we need to add a new edge, we first copy the table, and then replace it with CAS.

This increases memory allocations, however we expect that creating new transitions becomes increasingly rare over time.

```ruby
class A
  def initialize(bool)
    @a = 1
    if bool
      @b = 2
    else
      @c = 3
    end
  end

  def test
    @d = 4
  end
end

def bench(iterations)
  i = iterations
  while i > 0
    A.new(true).test
    A.new(false).test
    i -= 1
  end
end

if ARGV.first == "ractor"
  ractors = 8.times.map do
    Ractor.new do
      bench(20_000_000 / 8)
    end
  end
  ractors.each(&:take)
else
  bench(20_000_000)
end
```

The above benchmark takes 27 seconds in Ractor mode on Ruby 3.4, and only 1.7s with this branch.

cc @etiennebarrie @jhawthorn @tenderlove @luke-gruber 
