### PR TITLE
Set iclass_is_origin flag for FrozenCore

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -4019,6 +4019,7 @@ Init_VM(void)
     rb_vm_register_global_object(rb_class_path_cached(fcore));
     RB_FL_UNSET_RAW(fcore, T_MASK);
     RB_FL_SET_RAW(fcore, T_ICLASS);
+    RCLASSEXT_ICLASS_IS_ORIGIN(RCLASS_EXT_PRIME(fcore)) = true;
     klass = rb_singleton_class(fcore);
     rb_define_method_id(klass, id_core_set_method_alias, m_core_set_method_alias, 3);
     rb_define_method_id(klass, id_core_set_variable_alias, m_core_set_variable_alias, 2);


### PR DESCRIPTION
We don't free the method table for FrozenCore since it is converted to an iclass and doesn't have the iclass_is_origin flag set. This causes a memory leak to be reported during RUBY_FREE_AT_EXIT:

    14  dyld                                  0x19f13ab98 start + 6076
    13  miniruby                              0x100644928 main + 96  main.c:62
    12  miniruby                              0x10064498c rb_main + 48  main.c:42
    11  miniruby                              0x10073be0c ruby_init + 16  eval.c:98
    10  miniruby                              0x10073bc6c ruby_setup + 232  eval.c:87
    9   miniruby                              0x100786b98 rb_call_inits + 168  inits.c:63
    8   miniruby                              0x1009b5010 Init_VM + 212  vm.c:4017
    7   miniruby                              0x10067aae8 rb_class_new + 44  class.c:834
    6   miniruby                              0x10067a04c rb_class_boot + 48  class.c:748
    5   miniruby                              0x10067a250 class_initialize_method_table + 32  class.c:721
    4   miniruby                              0x1009412a8 rb_id_table_create + 24  id_table.c:98
    3   miniruby                              0x100759fac ruby_xmalloc + 24  gc.c:5201
    2   miniruby                              0x10075fc14 ruby_xmalloc_body + 52  gc.c:5211
    1   miniruby                              0x1007726b4 rb_gc_impl_malloc + 92  default.c:8141
    0   libsystem_malloc.dylib                0x19f30d12c _malloc_zone_malloc_instrumented_or_legacy + 152