### PR TITLE
Accurate GC.stat under multi-Ractor mode

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -178,13 +178,13 @@ rb_gc_vm_barrier(void)
     rb_vm_barrier();
 }
 
-#if USE_MODULAR_GC
 void *
 rb_gc_get_ractor_newobj_cache(void)
 {
     return GET_RACTOR()->newobj_cache;
 }
 
+#if USE_MODULAR_GC
 void
 rb_gc_initialize_vm_context(struct rb_gc_vm_context *context)
 {

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2215,6 +2215,17 @@ rb_gc_impl_size_allocatable_p(size_t size)
 }
 
 static const size_t ALLOCATED_COUNT_STEP = 1024;
+static void
+ractor_cache_flush_count(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache)
+{
+    for (int heap_idx = 0; heap_idx < HEAP_COUNT; heap_idx++) {
+        rb_ractor_newobj_heap_cache_t *heap_cache = &cache->heap_caches[heap_idx];
+
+        rb_heap_t *heap = &heaps[heap_idx];
+        RUBY_ATOMIC_SIZE_ADD(heap->total_allocated_objects, heap_cache->allocated_objects_count);
+        heap_cache->allocated_objects_count = 0;
+    }
+}
 
 static inline VALUE
 ractor_cache_allocate_slot(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *cache,
@@ -2239,19 +2250,11 @@ ractor_cache_allocate_slot(rb_objspace_t *objspace, rb_ractor_newobj_cache_t *ca
         rb_asan_unpoison_object(obj, true);
         heap_cache->freelist = p->next;
 
-        if (rb_gc_multi_ractor_p()) {
-            heap_cache->allocated_objects_count++;
-            rb_heap_t *heap = &heaps[heap_idx];
-            if (heap_cache->allocated_objects_count >= ALLOCATED_COUNT_STEP) {
-                RUBY_ATOMIC_SIZE_ADD(heap->total_allocated_objects, heap_cache->allocated_objects_count);
-                heap_cache->allocated_objects_count = 0;
-            }
-        }
-        else {
-            rb_heap_t *heap = &heaps[heap_idx];
-            heap->total_allocated_objects++;
-            GC_ASSERT(heap->total_slots >=
-                    (heap->total_allocated_objects - heap->total_freed_objects - heap->final_slots_count));
+        heap_cache->allocated_objects_count++;
+        rb_heap_t *heap = &heaps[heap_idx];
+        if (heap_cache->allocated_objects_count >= ALLOCATED_COUNT_STEP) {
+            RUBY_ATOMIC_SIZE_ADD(heap->total_allocated_objects, heap_cache->allocated_objects_count);
+            heap_cache->allocated_objects_count = 0;
         }
 
 #if RGENGC_CHECK_MODE
@@ -7456,6 +7459,8 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
 
     setup_gc_stat_symbols();
 
+    ractor_cache_flush_count(objspace, rb_gc_get_ractor_newobj_cache());
+
     if (RB_TYPE_P(hash_or_sym, T_HASH)) {
         hash = hash_or_sym;
     }
@@ -7598,6 +7603,8 @@ VALUE
 rb_gc_impl_stat_heap(void *objspace_ptr, VALUE heap_name, VALUE hash_or_sym)
 {
     rb_objspace_t *objspace = objspace_ptr;
+
+    ractor_cache_flush_count(objspace, rb_gc_get_ractor_newobj_cache());
 
     setup_gc_stat_heap_symbols();
 

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -72,10 +72,10 @@ void rb_gc_prepare_heap_process_object(VALUE obj);
 bool ruby_free_at_exit_p(void);
 bool rb_memerror_reentered(void);
 bool rb_obj_id_p(VALUE);
+void *rb_gc_get_ractor_newobj_cache(void);
 
 #if USE_MODULAR_GC
 bool rb_gc_event_hook_required_p(rb_event_flag_t event);
-void *rb_gc_get_ractor_newobj_cache(void);
 void rb_gc_initialize_vm_context(struct rb_gc_vm_context *context);
 void rb_gc_worker_thread_set_vm_context(struct rb_gc_vm_context *context);
 void rb_gc_worker_thread_unset_vm_context(struct rb_gc_vm_context *context);


### PR DESCRIPTION
This commit flushes the `allocated_objects_count` from the current Ractor's rb_ractor_newobj_cache_t whenever GC.stat or GC.stat_heap is called. This should allow measuring a small number of allocations as expected even after starting a Ractor.

If allocations happen in another Ractor, those still may not be immediately visible. I don't think it's worth having a VM barrier for this, and one should expect unpredictable results in this case anyways.

This also allows us to unify the single- and multi-ractor branches, now that there should not be a downside.

cc @byroot @etiennebarrie 