### PR TITLE
Do not respect ruby2_keywords on method/proc with post arguments

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -4012,12 +4012,13 @@ proc_ruby2_keywords(VALUE procval)
     switch (proc->block.type) {
       case block_type_iseq:
         if (ISEQ_BODY(proc->block.as.captured.code.iseq)->param.flags.has_rest &&
+                !ISEQ_BODY(proc->block.as.captured.code.iseq)->param.flags.has_post &&
                 !ISEQ_BODY(proc->block.as.captured.code.iseq)->param.flags.has_kw &&
                 !ISEQ_BODY(proc->block.as.captured.code.iseq)->param.flags.has_kwrest) {
             ISEQ_BODY(proc->block.as.captured.code.iseq)->param.flags.ruby2_keywords = 1;
         }
         else {
-            rb_warn("Skipping set of ruby2_keywords flag for proc (proc accepts keywords or proc does not accept argument splat)");
+            rb_warn("Skipping set of ruby2_keywords flag for proc (proc accepts keywords or post arguments or proc does not accept argument splat)");
         }
         break;
       default:

--- a/spec/ruby/core/module/ruby2_keywords_spec.rb
+++ b/spec/ruby/core/module/ruby2_keywords_spec.rb
@@ -213,7 +213,7 @@ describe "Module#ruby2_keywords" do
 
   it "prints warning when a method accepts keywords" do
     obj = Object.new
-    def obj.foo(a:, b:) end
+    def obj.foo(*a, b:) end
 
     -> {
       obj.singleton_class.class_exec do
@@ -224,12 +224,25 @@ describe "Module#ruby2_keywords" do
 
   it "prints warning when a method accepts keyword splat" do
     obj = Object.new
-    def obj.foo(**a) end
+    def obj.foo(*a, **b) end
 
     -> {
       obj.singleton_class.class_exec do
         ruby2_keywords :foo
       end
     }.should complain(/Skipping set of ruby2_keywords flag for/)
+  end
+
+  ruby_version_is "3.5" do
+    it "prints warning when a method accepts post arguments" do
+      obj = Object.new
+      def obj.foo(*a, b) end
+
+      -> {
+        obj.singleton_class.class_exec do
+          ruby2_keywords :foo
+        end
+      }.should complain(/Skipping set of ruby2_keywords flag for/)
+    end
   end
 end

--- a/spec/ruby/core/proc/ruby2_keywords_spec.rb
+++ b/spec/ruby/core/proc/ruby2_keywords_spec.rb
@@ -39,7 +39,7 @@ describe "Proc#ruby2_keywords" do
   end
 
   it "prints warning when a proc accepts keywords" do
-    f = -> a:, b: { }
+    f = -> *a, b: { }
 
     -> {
       f.ruby2_keywords
@@ -47,10 +47,20 @@ describe "Proc#ruby2_keywords" do
   end
 
   it "prints warning when a proc accepts keyword splat" do
-    f = -> **a { }
+    f = -> *a, **b { }
 
     -> {
       f.ruby2_keywords
     }.should complain(/Skipping set of ruby2_keywords flag for/)
+  end
+
+  ruby_version_is "3.5" do
+    it "prints warning when a proc accepts post arguments" do
+      f = -> *a, b { }
+
+      -> {
+        f.ruby2_keywords
+      }.should complain(/Skipping set of ruby2_keywords flag for/)
+    end
   end
 end

--- a/vm_method.c
+++ b/vm_method.c
@@ -2959,13 +2959,14 @@ rb_mod_ruby2_keywords(int argc, VALUE *argv, VALUE module)
             switch (me->def->type) {
               case VM_METHOD_TYPE_ISEQ:
                 if (ISEQ_BODY(me->def->body.iseq.iseqptr)->param.flags.has_rest &&
+                        !ISEQ_BODY(me->def->body.iseq.iseqptr)->param.flags.has_post &&
                         !ISEQ_BODY(me->def->body.iseq.iseqptr)->param.flags.has_kw &&
                         !ISEQ_BODY(me->def->body.iseq.iseqptr)->param.flags.has_kwrest) {
                     ISEQ_BODY(me->def->body.iseq.iseqptr)->param.flags.ruby2_keywords = 1;
                     rb_clear_method_cache(module, name);
                 }
                 else {
-                    rb_warn("Skipping set of ruby2_keywords flag for %"PRIsVALUE" (method accepts keywords or method does not accept argument splat)", QUOTE_ID(name));
+                    rb_warn("Skipping set of ruby2_keywords flag for %"PRIsVALUE" (method accepts keywords or post arguments or method does not accept argument splat)", QUOTE_ID(name));
                 }
                 break;
               case VM_METHOD_TYPE_BMETHOD: {
@@ -2978,13 +2979,14 @@ rb_mod_ruby2_keywords(int argc, VALUE *argv, VALUE module)
                     const struct rb_captured_block *captured = VM_BH_TO_ISEQ_BLOCK(procval);
                     const rb_iseq_t *iseq = rb_iseq_check(captured->code.iseq);
                     if (ISEQ_BODY(iseq)->param.flags.has_rest &&
+                            !ISEQ_BODY(iseq)->param.flags.has_post &&
                             !ISEQ_BODY(iseq)->param.flags.has_kw &&
                             !ISEQ_BODY(iseq)->param.flags.has_kwrest) {
                         ISEQ_BODY(iseq)->param.flags.ruby2_keywords = 1;
                         rb_clear_method_cache(module, name);
                     }
                     else {
-                        rb_warn("Skipping set of ruby2_keywords flag for %"PRIsVALUE" (method accepts keywords or method does not accept argument splat)", QUOTE_ID(name));
+                        rb_warn("Skipping set of ruby2_keywords flag for %"PRIsVALUE" (method accepts keywords or post arguments or method does not accept argument splat)", QUOTE_ID(name));
                     }
                     break;
                 }


### PR DESCRIPTION
Previously, ruby2_keywords could be used on a method or proc with
post arguments, but I don't think the behavior is desired:

```ruby
def a(*c, **kw) [c, kw] end
def b(*a, b) a(*a, b) end
ruby2_keywords(:b)

b({foo: 1}, bar: 1)
# Before: [[{foo: 1}], {bar: 1}]
#  After: [[{foo: 1}, {bar: 1}], {}]
```

This changes ruby2_keywords to emit a warning and not set the
flag on a method/proc with post arguments.

While here, fix the ruby2_keywords specs for warnings, since they
weren't testing what they should be testing.  They all warned
because the method didn't accept a rest argument, not because it
accepted a keyword or keyword rest argument