### PR TITLE
Remove dependancy of default.c on internal/object.h

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -28,7 +28,6 @@
 #include "ruby/util.h"
 #include "ruby/vm.h"
 #include "ruby/internal/encoding/string.h"
-#include "internal/object.h"
 #include "ccan/list/list.h"
 #include "darray.h"
 #include "gc/gc.h"
@@ -2972,7 +2971,7 @@ rb_gc_impl_shutdown_free_objects(void *objspace_ptr)
                 if (RB_BUILTIN_TYPE(vp) != T_NONE) {
                     rb_gc_obj_free_vm_weak_references(vp);
                     if (rb_gc_obj_free(objspace, vp)) {
-                        RBASIC_RESET_FLAGS(vp);
+                        RBASIC(vp)->flags = 0;
                     }
                 }
             }
@@ -3046,7 +3045,7 @@ rb_gc_impl_shutdown_call_finalizer(void *objspace_ptr)
                 if (rb_gc_shutdown_call_finalizer_p(vp)) {
                     rb_gc_obj_free_vm_weak_references(vp);
                     if (rb_gc_obj_free(objspace, vp)) {
-                        RBASIC_RESET_FLAGS(vp);
+                        RBASIC(vp)->flags = 0;
                     }
                 }
             }

--- a/internal/object.h
+++ b/internal/object.h
@@ -60,13 +60,4 @@ RBASIC_SET_CLASS(VALUE obj, VALUE klass)
     RBASIC_SET_CLASS_RAW(obj, klass);
     RB_OBJ_WRITTEN(obj, oldv, klass);
 }
-
-static inline void
-RBASIC_RESET_FLAGS(VALUE obj)
-{
-    RBASIC(obj)->flags = 0;
-#if RBASIC_SHAPE_ID_FIELD
-    RBASIC(obj)->shape_id = 0;
-#endif
-}
 #endif /* INTERNAL_OBJECT_H */


### PR DESCRIPTION
We don't want the default GC to depend on Ruby internals so we can build it as a modular GC.