### PR TITLE
prepare IDs for `Ractor::monitor`

### DIFF
--- a/defs/id.def
+++ b/defs/id.def
@@ -63,6 +63,8 @@ firstline, predefined = __LINE__+1, %[\
   pack
   buffer
   include?
+  aborted
+  exited
 
   _                                                     UScore
 

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -533,11 +533,11 @@ ractor_exit_token(bool exc)
 {
     if (exc) {
         RUBY_DEBUG_LOG("aborted");
-        return ID2SYM(rb_intern("aborted"));
+        return ID2SYM(idAborted);
     }
     else {
         RUBY_DEBUG_LOG("exited");
-        return ID2SYM(rb_intern("exited"));
+        return ID2SYM(idExited);
     }
 }
 


### PR DESCRIPTION
To prevent the following strange error, prepare IDs at first.

```
     <internal:ractor>:596:in 'Ractor#monitor': symbol :exited is already registered with 98610c (fatal)
             from <internal:ractor>:550:in 'Ractor#join'
             from <internal:ractor>:574:in 'Ractor#value'
             from bootstraptest.test_ractor.rb_2013_1309.rb:12:in '<main>'
```

BTW, the error should be fixed on ID management system.