### PR TITLE
rake 13.3.0 -> 13.2.1

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -8,7 +8,7 @@
 
 minitest            5.25.5  https://github.com/minitest/minitest
 power_assert        2.0.5   https://github.com/ruby/power_assert a7dab941153b233d3412e249d25da52a6c5691de
-rake                13.3.0  https://github.com/ruby/rake
+rake                13.2.1  https://github.com/ruby/rake
 test-unit           3.6.8   https://github.com/test-unit/test-unit
 rexml               3.4.1   https://github.com/ruby/rexml
 rss                 0.3.1   https://github.com/ruby/rss

--- a/spec/bundler/support/builders.rb
+++ b/spec/bundler/support/builders.rb
@@ -25,7 +25,7 @@ module Spec
     end
 
     def rake_version
-      "13.3.0"
+      "13.2.1"
     end
 
     def build_repo1


### PR DESCRIPTION
`make test-bundler-parallel` prints many errors, so try to downgrade rake version.

```
  219) bundle install --standalone run in a subdirectory with --binstubs creates stubs that can be symlinked
       Failure/Error:
               raise <<~ERROR
                 #{error_header}

                 ----------------------------------------------------------------------
                 #{stdboth}
                 ----------------------------------------------------------------------
               ERROR

       RuntimeError:

         Commands:
         $ /home/ko1/ruby/build/trunk/ruby -I/home/ko1/ruby/src/trunk/spec/bundler -r/home/ko1/ruby/src/trunk/spec/bundler/support/artifice/compact_index.rb -r/home/ko1/ruby/src/trunk/spec/bundler/support/hax.rb /home/ko1/ruby/src/trunk/tmp/2.13/gems/system/bin/bundle config set --local path /home/ko1/ruby/src/trunk/tmp/2.13/bundled_app/bundle
         # $? => 0
         Invoking `/home/ko1/ruby/build/trunk/ruby -I/home/ko1/ruby/src/trunk/spec/bundler -r/home/ko1/ruby/src/trunk/spec/bundler/support/artifice/compact_index.rb -r/home/ko1/ruby/src/trunk/spec/bundler/support/hax.rb /home/ko1/ruby/src/trunk/tmp/2.13/gems/system/bin/bundle install --standalone --binstubs` failed with output:

         ----------------------------------------------------------------------
         [DEPRECATED] The --binstubs option will be removed in favor of `bundle binstubs --all`
         Could not find compatible versions

         Because every version of rails depends on rake = 13.3.0
           and rake = 13.3.0 could not be found in rubygems repository https://gem.repo1/ or installed locally,
           rails cannot be used.
         So, because Gemfile depends on rails >= 0,
           version solving has failed.
         Fetching gem metadata from https://gem.repo1/...
         Resolving dependencies...
         ----------------------------------------------------------------------
       Shared Example Group: "bundle install --standalone" called from ./spec/bundler/install/gems/standalone_spec.rb:532
       # /home/ko1/ruby/src/trunk/spec/bundler/support/command_execution.rb:26:in 'Spec::CommandExecution#raise_error!'
       # /home/ko1/ruby/src/trunk/spec/bundler/support/subprocess.rb:66:in 'Spec::Subprocess#sh'
       # /home/ko1/ruby/src/trunk/spec/bundler/support/helpers.rb:216:in 'Spec::Helpers#sys_exec'
       # /home/ko1/ruby/src/trunk/spec/bundler/support/helpers.rb:107:in 'Spec::Helpers#bundle'
       # /home/ko1/ruby/src/trunk/spec/bundler/install/gems/standalone_spec.rb:482:in 'block (3 levels) in <top (required)>'
       # /home/ko1/ruby/src/trunk/spec/bundler/spec_helper.rb:107:in 'block (4 levels) in <top (required)>'
       # /home/ko1/ruby/src/trunk/spec/bundler/spec_helper.rb:107:in 'block (3 levels) in <top (required)>'
       # /home/ko1/ruby/src/trunk/spec/bundler/support/helpers.rb:355:in 'block in Spec::Helpers#with_gem_path_as'
       # /home/ko1/ruby/src/trunk/spec/bundler/support/helpers.rb:369:in 'Spec::Helpers#without_env_side_effects'
       # /home/ko1/ruby/src/trunk/spec/bundler/support/helpers.rb:350:in 'Spec::Helpers#with_gem_path_as'
       # /home/ko1/ruby/src/trunk/spec/bundler/spec_helper.rb:106:in 'block (2 levels) in <top (required)>'
```