### PR TITLE
Skip birthtime failures on old linux

### DIFF
--- a/spec/ruby/core/file/birthtime_spec.rb
+++ b/spec/ruby/core/file/birthtime_spec.rb
@@ -13,14 +13,20 @@ platform_is :windows, :darwin, :freebsd, :netbsd, :linux do
     it "returns the birth time for the named file as a Time object" do
       File.birthtime(@file)
       File.birthtime(@file).should be_kind_of(Time)
+    rescue NotImplementedError => e
+      skip e.message if e.message.start_with?("birthtime() function")
     end
 
     it "accepts an object that has a #to_path method" do
       File.birthtime(mock_to_path(@file))
+    rescue NotImplementedError => e
+      skip e.message if e.message.start_with?("birthtime() function")
     end
 
     it "raises an Errno::ENOENT exception if the file is not found" do
       -> { File.birthtime('bogus') }.should raise_error(Errno::ENOENT)
+    rescue NotImplementedError => e
+      skip e.message if e.message.start_with?("birthtime() function")
     end
   end
 
@@ -37,8 +43,8 @@ platform_is :windows, :darwin, :freebsd, :netbsd, :linux do
     it "returns the birth time for self" do
       @file.birthtime
       @file.birthtime.should be_kind_of(Time)
+    rescue NotImplementedError => e
+      skip e.message if e.message.start_with?("birthtime() function")
     end
   end
-
-  # TODO: depends on Linux kernel version
 end

--- a/spec/ruby/core/file/stat/birthtime_spec.rb
+++ b/spec/ruby/core/file/stat/birthtime_spec.rb
@@ -17,6 +17,8 @@ platform_is(:windows, :darwin, :freebsd, :netbsd,
       st = File.stat(@file)
       st.birthtime.should be_kind_of(Time)
       st.birthtime.should <= Time.now
+    rescue NotImplementedError => e
+      skip e.message if e.message.start_with?("birthtime() function")
     end
   end
 end


### PR DESCRIPTION
`statx(2)` is available since Linux 4.11 and glibc 2.28.