### PR TITLE
Fix test_loading_kwargs_memory_leak

### DIFF
--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -880,7 +880,7 @@ class TestISeq < Test::Unit::TestCase
 
   def test_loading_kwargs_memory_leak
     assert_no_memory_leak([], "#{<<~"begin;"}", "#{<<~'end;'}", rss: true)
-    a = iseq_to_binary(RubyVM::InstructionSequence.compile("foo(bar: :baz)"))
+      a = RubyVM::InstructionSequence.compile("foo(bar: :baz)").to_binary
     begin;
       1_000_000.times do
         RubyVM::InstructionSequence.load_from_binary(a)


### PR DESCRIPTION
The test fails with:

    TestISeq#test_loading_kwargs_memory_leak [test/ruby/test_iseq.rb:882]:
    pid 18222 exit 1
    | -:2:in '<main>': undefined method 'iseq_to_binary' for main (NoMethodError)