### PR TITLE
Allow pass special constants to the write barrier

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -6006,8 +6006,9 @@ rb_gc_impl_writebarrier(void *objspace_ptr, VALUE a, VALUE b)
 
     if (RGENGC_CHECK_MODE) {
         if (SPECIAL_CONST_P(a)) rb_bug("rb_gc_writebarrier: a is special const: %"PRIxVALUE, a);
-        if (SPECIAL_CONST_P(b)) rb_bug("rb_gc_writebarrier: b is special const: %"PRIxVALUE, b);
     }
+
+    if (SPECIAL_CONST_P(b)) return;
 
     GC_ASSERT(RB_BUILTIN_TYPE(a) != T_NONE);
     GC_ASSERT(RB_BUILTIN_TYPE(a) != T_MOVED);

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -750,6 +750,8 @@ rb_gc_impl_writebarrier(void *objspace_ptr, VALUE a, VALUE b)
 {
     struct MMTk_ractor_cache *cache = rb_gc_get_ractor_newobj_cache();
 
+    if (SPECIAL_CONST_P(b)) return;
+
     mmtk_object_reference_write_post(cache->mutator, (MMTk_ObjectReference)a);
 }
 

--- a/include/ruby/internal/abi.h
+++ b/include/ruby/internal/abi.h
@@ -24,7 +24,7 @@
  * In released versions of Ruby, this number is not defined since teeny
  * versions of Ruby should guarantee ABI compatibility.
  */
-#define RUBY_ABI_VERSION 1
+#define RUBY_ABI_VERSION 2
 
 /* Windows does not support weak symbols so ruby_abi_version will not exist
  * in the shared library. */

--- a/include/ruby/internal/gc.h
+++ b/include/ruby/internal/gc.h
@@ -785,9 +785,7 @@ rb_obj_written(
     RGENGC_LOGGING_OBJ_WRITTEN(a, oldv, b, filename, line);
 #endif
 
-    if (!RB_SPECIAL_CONST_P(b)) {
-        rb_gc_writebarrier(a, b);
-    }
+    rb_gc_writebarrier(a, b);
 
     return a;
 }


### PR DESCRIPTION
Some GC implementations want to always know when an object is written to, even if the written value is a special constant. Checking special constants in rb_obj_written was a micro-optimization that made assumptions about the GC implementation.