### PR TITLE
Move more NilClass methods to ruby

### DIFF
--- a/benchmark/nilclass.yml
+++ b/benchmark/nilclass.yml
@@ -1,10 +1,16 @@
 prelude: |
   def a = nil
 benchmark:
+  rationalize:
+    nil.rationalize
+  to_c: |
+    nil.to_c
   to_i: |
     nil.to_i
   to_f: |
     nil.to_f
+  to_r: |
+    nil.to_r
   splat: |
     a(*nil)
 loop_count: 100000

--- a/complex.c
+++ b/complex.c
@@ -1927,21 +1927,6 @@ nucomp_to_c(VALUE self)
 
 /*
  * call-seq:
- *   to_c -> (0+0i)
- *
- * Returns zero as a Complex:
- *
- *   nil.to_c # => (0+0i)
- *
- */
-static VALUE
-nilclass_to_c(VALUE self)
-{
-    return rb_complex_new1(INT2FIX(0));
-}
-
-/*
- * call-seq:
  *   to_c -> complex
  *
  * Returns +self+ as a Complex object.
@@ -2693,7 +2678,6 @@ Init_Complex(void)
     rb_define_method(rb_cComplex, "to_r", nucomp_to_r, 0);
     rb_define_method(rb_cComplex, "rationalize", nucomp_rationalize, -1);
     rb_define_method(rb_cComplex, "to_c", nucomp_to_c, 0);
-    rb_define_method(rb_cNilClass, "to_c", nilclass_to_c, 0);
     rb_define_method(rb_cNumeric, "to_c", numeric_to_c, 0);
 
     rb_define_method(rb_cString, "to_c", string_to_c, 0);

--- a/nilclass.rb
+++ b/nilclass.rb
@@ -1,6 +1,32 @@
 class NilClass
   #
   #  call-seq:
+  #     rationalize(eps = nil)  ->  (0/1)
+  #
+  #  Returns zero as a Rational:
+  #
+  #     nil.rationalize # => (0/1)
+  #
+  #  Argument +eps+ is ignored.
+  #
+  def rationalize(eps = nil)
+    0r
+  end
+
+  #
+  #  call-seq:
+  #     to_c -> (0+0i)
+  #
+  #  Returns zero as a Complex:
+  #
+  #     nil.to_c # => (0+0i)
+  #
+  def to_c
+    0i
+  end
+
+  #
+  #  call-seq:
   #     nil.to_i -> 0
   #
   #  Always returns zero.
@@ -21,5 +47,17 @@ class NilClass
   #
   def to_f
     return 0.0
+  end
+
+  #
+  #  call-seq:
+  #     to_r  ->  (0/1)
+  #
+  #  Returns zero as a Rational:
+  #
+  #     nil.to_r # => (0/1)
+  #
+  def to_r
+    0r
   end
 end

--- a/rational.c
+++ b/rational.c
@@ -2109,39 +2109,6 @@ rb_float_denominator(VALUE self)
 
 /*
  * call-seq:
- *   to_r  ->  (0/1)
- *
- * Returns zero as a Rational:
- *
- *   nil.to_r # => (0/1)
- *
- */
-static VALUE
-nilclass_to_r(VALUE self)
-{
-    return rb_rational_new1(INT2FIX(0));
-}
-
-/*
- * call-seq:
- *   rationalize(eps = nil)  ->  (0/1)
- *
- * Returns zero as a Rational:
- *
- *   nil.rationalize # => (0/1)
- *
- * Argument +eps+ is ignored.
- *
- */
-static VALUE
-nilclass_rationalize(int argc, VALUE *argv, VALUE self)
-{
-    rb_check_arity(argc, 0, 1);
-    return nilclass_to_r(self);
-}
-
-/*
- * call-seq:
  *    int.to_r  ->  rational
  *
  * Returns the value as a rational.
@@ -2823,8 +2790,6 @@ Init_Rational(void)
     rb_define_method(rb_cFloat, "numerator", rb_float_numerator, 0);
     rb_define_method(rb_cFloat, "denominator", rb_float_denominator, 0);
 
-    rb_define_method(rb_cNilClass, "to_r", nilclass_to_r, 0);
-    rb_define_method(rb_cNilClass, "rationalize", nilclass_rationalize, -1);
     rb_define_method(rb_cInteger, "to_r", integer_to_r, 0);
     rb_define_method(rb_cInteger, "rationalize", integer_rationalize, -1);
     rb_define_method(rb_cFloat, "to_r", float_to_r, 0);


### PR DESCRIPTION
```
$ make benchmark ITEM=nilclass COMPARE_RUBY="/opt/rubies/ruby-master/bin/ruby"
/opt/rubies/3.4.2/bin/ruby --disable=gems -rrubygems -I../benchmark/lib ../benchmark/benchmark-driver/exe/benchmark-driver \
                    --executables="compare-ruby::/opt/rubies/ruby-master/bin/ruby -I.ext/common --disable-gem" \
                    --executables="built-ruby::./miniruby -I../lib -I. -I.ext/common  ../tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
                    --output=markdown --output-compare -v $(find ../benchmark -maxdepth 1 -name 'nilclass' -o -name '*nilclass*.yml' -o -name '*nilclass*.rb' | sort)
compare-ruby: ruby 3.5.0dev (2025-06-02T13:52:25Z master cbd49ecbbe) +PRISM [arm64-darwin24]
built-ruby: ruby 3.5.0dev (2025-06-02T22:47:21Z hm-ruby-nilclass 3e7f1f0466) +PRISM [arm64-darwin24]

|             |compare-ruby|built-ruby|
|:------------|-----------:|---------:|
|rationalize  |     24.056M|   53.908M|
|             |           -|     2.24x|
|to_c         |     23.652M|   82.781M|
|             |           -|     3.50x|
|to_i         |     89.526M|   84.388M|
|             |       1.06x|         -|
|to_f         |     84.746M|   96.899M|
|             |           -|     1.14x|
|to_r         |     25.107M|   83.472M|
|             |           -|     3.32x|
|splat        |     42.772M|   42.717M|
|             |       1.00x|         -|
```

This makes them much faster