### PR TITLE
Fix scheduler warning

### DIFF
--- a/test/fiber/test_scheduler.rb
+++ b/test/fiber/test_scheduler.rb
@@ -94,6 +94,9 @@ class TestFiberScheduler < Test::Unit::TestCase
     def scheduler.kernel_sleep
     end
 
+    def scheduler.fiber_interrupt(_fiber, _exception)
+    end
+
     thread = Thread.new do
       Fiber.set_scheduler scheduler
     end


### PR DESCRIPTION
```
test/fiber/test_scheduler.rb:98: warning: Scheduler should implement #fiber_interrupt
```

@ioquatix 