### PR TITLE
mark main Ractor object

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -481,11 +481,13 @@ ractor_init(rb_ractor_t *r, VALUE name, VALUE loc)
 void
 rb_ractor_main_setup(rb_vm_t *vm, rb_ractor_t *r, rb_thread_t *th)
 {
-    r->pub.self = TypedData_Wrap_Struct(rb_cRactor, &ractor_data_type, r);
+    VALUE rv = r->pub.self = TypedData_Wrap_Struct(rb_cRactor, &ractor_data_type, r);
     FL_SET_RAW(r->pub.self, RUBY_FL_SHAREABLE);
     ractor_init(r, Qnil, Qnil);
     r->threads.main = th;
     rb_ractor_living_threads_insert(r, th);
+
+    RB_GC_GUARD(rv);
 }
 
 static VALUE

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -796,7 +796,6 @@ class TestGc < Test::Unit::TestCase
   end
 
   def test_gc_stress_at_startup
-    omit "Ractor::Port patch makes faile. I'll investigate later" if Time.now < Time.new(2025, 6, 7)
     assert_in_out_err([{"RUBY_DEBUG"=>"gc_stress"}], '', [], [], '[Bug #15784]', success: true, timeout: 60)
   end
 


### PR DESCRIPTION
`RUBY_DEBUG=gc_stress ./miniruby -e0` crashes because of this marking miss.

BTW, to use `RUBY_DEBUG=gc_stress` we need to specify `--enable-debug-env` configure option. This is why I couldn't repro on my environments.

see c0c94ab183d0d428595ccb74ae71ee945f1afd45