### PR TITLE
Fix a design issue in the debug inspector API

### DIFF
--- a/ext/-test-/debug/inspector.c
+++ b/ext/-test-/debug/inspector.c
@@ -4,8 +4,7 @@
 static VALUE
 callback(const rb_debug_inspector_t *dbg_context, void *data)
 {
-    VALUE locs = rb_debug_inspector_backtrace_locations(dbg_context);
-    long i, len = RARRAY_LEN(locs);
+    long i, len = rb_debug_inspector_frame_count(dbg_context);
     VALUE binds = rb_ary_new();
     for (i = 0; i < len; ++i) {
         VALUE entry = rb_ary_new();
@@ -14,7 +13,7 @@ callback(const rb_debug_inspector_t *dbg_context, void *data)
         rb_ary_push(entry, rb_debug_inspector_frame_binding_get(dbg_context, i));
         rb_ary_push(entry, rb_debug_inspector_frame_class_get(dbg_context, i));
         rb_ary_push(entry, rb_debug_inspector_frame_iseq_get(dbg_context, i));
-        rb_ary_push(entry, rb_ary_entry(locs, i));
+        rb_ary_push(entry, rb_debug_inspector_frame_loc_get(dbg_context, i));
     }
     return binds;
 }

--- a/include/ruby/debug.h
+++ b/include/ruby/debug.h
@@ -233,9 +233,21 @@ VALUE rb_debug_inspector_open(rb_debug_inspector_func_t func, void *data);
  * @param[in]  dc  A debug context.
  * @return     An array  of `Thread::Backtrace::Location` which  represents the
  *             current point of execution at `dc`.
+ * @deprecated This API returns a backtrace with makeup applied. (Specifically,
+ *             rescue and ensure frames are excluded.) Therefore, inconsistency
+ *             occurs between the index of this backtrace object and the index of
+ *             arguments such as rb_debug_inspector_frame_self_get.
 
  */
 VALUE rb_debug_inspector_backtrace_locations(const rb_debug_inspector_t *dc);
+
+/**
+ * Returns the frame count of the context.
+ *
+ * @param[in]  dc  A debug context.
+ * @return     The count of the frames.
+ */
+VALUE rb_debug_inspector_frame_count(const rb_debug_inspector_t *dc);
 
 /**
  * Queries the current receiver of the passed context's upper frame.
@@ -279,6 +291,16 @@ VALUE rb_debug_inspector_frame_binding_get(const rb_debug_inspector_t *dc, long 
  *                          frame.
  */
 VALUE rb_debug_inspector_frame_iseq_get(const rb_debug_inspector_t *dc, long index);
+
+/**
+ * Queries the backtrace location object of the passed context's upper frame.
+ *
+ * @param[in]  dc           A debug context.
+ * @param[in]  index        Index of the frame from top to bottom.
+ * @exception  rb_eArgError `index` out of range.
+ * @retval     The backtrace location object at `index`-th frame in Integer.
+ */
+VALUE rb_debug_inspector_frame_loc_get(const rb_debug_inspector_t *dc, long index);
 
 /**
  * Queries the depth of the passed context's upper frame.


### PR DESCRIPTION
Previously, a user of the debug inspector API was supposed to use `rb_debug_inspector_backtrace_locations` to get an array of `Thread::Backtrace::Location`, and then used its index to get more information from `rb_debug_inspector _frame_binding_get(index)`, etc.

However, `rb_debug_inspector_backtrace_locations` returned an array of backtraces excluding rescue/ensure frames. On the other hand, `rb_debug_inspector_frame_binding_get(index)` interprets index with rescue/ensure frames. This led to inconsistency of the index, and it was very difficult to correctly use the debug inspector API.

This change deprecates `rb_debug_inspector_backtrace_locations` and introduces instead `rb_debug_inspector_frame_loc_get(index)`, which returns a `Thread::Backtrace::Location` object for the frame specified by `index`. Also `rb_debug_inspector_frame_count` is introduced to get the length of the backtrace.