### PR TITLE
Get rid of TOO_COMPLEX shape type

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -821,9 +821,6 @@ shape_id_i(shape_id_t shape_id, void *data)
       case SHAPE_T_OBJECT:
         dump_append(dc, ", \"shape_type\":\"T_OBJECT\"");
         break;
-      case SHAPE_OBJ_TOO_COMPLEX:
-        dump_append(dc, ", \"shape_type\":\"OBJ_TOO_COMPLEX\"");
-        break;
       case SHAPE_OBJ_ID:
         dump_append(dc, ", \"shape_type\":\"OBJ_ID\"");
         break;

--- a/variable.c
+++ b/variable.c
@@ -2240,10 +2240,6 @@ iterate_over_shapes_with_callback(rb_shape_t *shape, rb_ivar_foreach_callback_fu
             }
         }
         return false;
-      case SHAPE_OBJ_TOO_COMPLEX:
-      default:
-        rb_bug("Unreachable");
-        UNREACHABLE_RETURN(false);
     }
 }
 

--- a/yjit.c
+++ b/yjit.c
@@ -781,6 +781,18 @@ rb_object_shape_count(void)
     return ULONG2NUM((unsigned long)GET_SHAPE_TREE()->next_shape_id);
 }
 
+bool
+rb_yjit_shape_too_complex_p(shape_id_t shape_id)
+{
+    return rb_shape_too_complex_p(shape_id);
+}
+
+bool
+rb_yjit_shape_obj_too_complex_p(VALUE obj)
+{
+    return rb_shape_obj_too_complex_p(obj);
+}
+
 // Assert that we have the VM lock. Relevant mostly for multi ractor situations.
 // The GC takes the lock before calling us, and this asserts that it indeed happens.
 void

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -99,8 +99,8 @@ fn main() {
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")
         .allowlist_function("rb_shape_transition_add_ivar_no_warnings")
-        .allowlist_function("rb_shape_obj_too_complex_p")
-        .allowlist_function("rb_shape_too_complex_p")
+        .allowlist_function("rb_yjit_shape_obj_too_complex_p")
+        .allowlist_function("rb_yjit_shape_too_complex_p")
         .allowlist_var("SHAPE_ID_NUM_BITS")
 
         // From ruby/internal/intern/object.h

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3124,7 +3124,7 @@ fn gen_set_ivar(
 
         // If the VM ran out of shapes, or this class generated too many leaf,
         // it may be de-optimized into OBJ_TOO_COMPLEX_SHAPE (hash-table).
-        new_shape_too_complex = unsafe { rb_shape_too_complex_p(next_shape_id) };
+        new_shape_too_complex = unsafe { rb_yjit_shape_too_complex_p(next_shape_id) };
         if new_shape_too_complex {
             Some((next_shape_id, None, 0_usize))
         } else {

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -441,7 +441,7 @@ impl VALUE {
     }
 
     pub fn shape_too_complex(self) -> bool {
-        unsafe { rb_shape_obj_too_complex_p(self) }
+        unsafe { rb_yjit_shape_obj_too_complex_p(self) }
     }
 
     pub fn shape_id_of(self) -> u32 {

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1137,8 +1137,6 @@ extern "C" {
     pub fn rb_shape_lookup(shape_id: shape_id_t) -> *mut rb_shape_t;
     pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
-    pub fn rb_shape_obj_too_complex_p(obj: VALUE) -> bool;
-    pub fn rb_shape_too_complex_p(shape_id: shape_id_t) -> bool;
     pub fn rb_shape_transition_add_ivar_no_warnings(obj: VALUE, id: ID) -> shape_id_t;
     pub fn rb_gvar_get(arg1: ID) -> VALUE;
     pub fn rb_gvar_set(arg1: ID, arg2: VALUE) -> VALUE;
@@ -1265,6 +1263,8 @@ extern "C" {
         line: ::std::os::raw::c_int,
     );
     pub fn rb_object_shape_count() -> VALUE;
+    pub fn rb_yjit_shape_too_complex_p(shape_id: shape_id_t) -> bool;
+    pub fn rb_yjit_shape_obj_too_complex_p(obj: VALUE) -> bool;
     pub fn rb_yjit_assert_holding_vm_lock();
     pub fn rb_yjit_sendish_sp_pops(ci: *const rb_callinfo) -> usize;
     pub fn rb_yjit_invokeblock_sp_pops(ci: *const rb_callinfo) -> usize;

--- a/zjit.c
+++ b/zjit.c
@@ -330,6 +330,11 @@ rb_zjit_print_exception(void)
     rb_warn("Ruby error: %"PRIsVALUE"", rb_funcall(exception, rb_intern("full_message"), 0));
 }
 
+bool
+rb_zjit_shape_obj_too_complex_p(VALUE obj)
+{
+    return rb_shape_obj_too_complex_p(obj);
+}
+
 // Preprocessed zjit.rb generated during build
 #include "zjit.rbinc"
-

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -112,7 +112,7 @@ fn main() {
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")
         .allowlist_function("rb_shape_transition_add_ivar_no_warnings")
-        .allowlist_function("rb_shape_obj_too_complex_p")
+        .allowlist_function("rb_zjit_shape_obj_too_complex_p")
         .allowlist_var("SHAPE_ID_NUM_BITS")
 
         // From ruby/internal/intern/object.h

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -478,7 +478,7 @@ impl VALUE {
     }
 
     pub fn shape_too_complex(self) -> bool {
-        unsafe { rb_shape_obj_too_complex_p(self) }
+        unsafe { rb_zjit_shape_obj_too_complex_p(self) }
     }
 
     pub fn shape_id_of(self) -> u32 {

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -868,7 +868,6 @@ unsafe extern "C" {
     pub fn rb_shape_lookup(shape_id: shape_id_t) -> *mut rb_shape_t;
     pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
-    pub fn rb_shape_obj_too_complex_p(obj: VALUE) -> bool;
     pub fn rb_shape_transition_add_ivar_no_warnings(obj: VALUE, id: ID) -> shape_id_t;
     pub fn rb_gvar_get(arg1: ID) -> VALUE;
     pub fn rb_gvar_set(arg1: ID, arg2: VALUE) -> VALUE;
@@ -945,6 +944,7 @@ unsafe extern "C" {
     pub fn rb_iseq_get_zjit_payload(iseq: *const rb_iseq_t) -> *mut ::std::os::raw::c_void;
     pub fn rb_iseq_set_zjit_payload(iseq: *const rb_iseq_t, payload: *mut ::std::os::raw::c_void);
     pub fn rb_zjit_print_exception();
+    pub fn rb_zjit_shape_obj_too_complex_p(obj: VALUE) -> bool;
     pub fn rb_iseq_encoded_size(iseq: *const rb_iseq_t) -> ::std::os::raw::c_uint;
     pub fn rb_iseq_pc_at_idx(iseq: *const rb_iseq_t, insn_idx: u32) -> *mut VALUE;
     pub fn rb_iseq_opcode_at_pc(iseq: *const rb_iseq_t, pc: *const VALUE) -> ::std::os::raw::c_int;


### PR DESCRIPTION
Instead it's now a `shape_id` flag.

This allows to check if an object is complex without having to chase the `rb_shape_t` pointer.
