### PR TITLE
`Ractor#take` and warn

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -2211,3 +2211,19 @@ assert_equal '[["Only the successor ractor can take a value", 9], ["ok", 2]]', %
     Ractor.receive
   }.tally.sort
 }
+
+# Ractor#take will warn for compatibility.
+# This method will be removed after 2025/09/01
+assert_equal "2", %q{
+  raise "remove Ractor#take and this test" if Time.now > Time.new(2025, 9, 2)
+  $VERBOSE = true
+  r = Ractor.new{42}
+  $msg = []
+  def Warning.warn(msg)
+    $msg << msg
+  end
+  r.take
+  r.take
+  raise unless $msg.all?{/Ractor#take/ =~ it}
+  $msg.size
+}

--- a/ractor.rb
+++ b/ractor.rb
@@ -575,6 +575,12 @@ class Ractor
     __builtin_ractor_value
   end
 
+  # keep it for compatibility
+  def take
+    Kernel.warn("Ractor#take was deprecated and use Ractor#value instead. This method will be removed after the end of Aug 2025", uplevel: 0)
+    self.value
+  end
+
   #
   # call-seq:
   #    ractor.monitor(port) -> self


### PR DESCRIPTION
`Ractor#take` was deprecated but some libraries can use it as an alias for `Ractor#value` (i.e., to wait for a Ractor's temrination and retrieve its result).
Therefore `Ractor#take` is simply an alias for `Ractor#value`.

This method will remain available until the end of August 2025, unless there is further discussion.