### PR TITLE
Launchable: Set env variables to prevent CI slowdowns

### DIFF
--- a/.github/actions/compilers/entrypoint.sh
+++ b/.github/actions/compilers/entrypoint.sh
@@ -79,6 +79,7 @@ setup_launchable() {
     pushd ${srcdir}
     # To prevent a slowdown in CI, disable request retries when the Launchable server is unstable.
     export LAUNCHABLE_SKIP_TIMEOUT_RETRY=1
+    export LAUNCHABLE_COMMIT_TIMEOUT=1
     # Launchable creates .launchable file in the current directory, but cannot a file to ${srcdir} directory.
     # As a workaround, we set LAUNCHABLE_SESSION_DIR to ${builddir}.
     export LAUNCHABLE_SESSION_DIR=${builddir}

--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -123,6 +123,7 @@ runs:
         echo "LAUNCHABLE_TOKEN=${{ inputs.launchable-token }}" >> $GITHUB_ENV
         : # To prevent a slowdown in CI, disable request retries when the Launchable server is unstable.
         echo "LAUNCHABLE_SKIP_TIMEOUT_RETRY=1" >> $GITHUB_ENV
+        echo "LAUNCHABLE_COMMIT_TIMEOUT=1" >> $GITHUB_ENV
       if: steps.enable-launchable.outputs.enable-launchable
 
     - name: Set up path


### PR DESCRIPTION
When Launchable in unstable, the round trip time takes a long time, which slows down CI execution. In this PR I configured the environment variable `LAUNCHABLE_COMMIT_TIMEOUT` to configure the timeout.

https://github.com/launchableinc/cli/pull/1015