### PR TITLE
Call `Set#add` from `initialize` on subclasses

### DIFF
--- a/set.c
+++ b/set.c
@@ -459,7 +459,12 @@ static VALUE
 set_initialize_with_block(RB_BLOCK_CALL_FUNC_ARGLIST(i, set))
 {
     VALUE element = rb_yield(i);
-    set_insert_wb(set, element, &element);
+    if (rb_obj_is_instance_of(set, rb_cSet)) {
+        set_insert_wb(set, element, &element);
+    }
+    else {
+        rb_funcall(set, rb_intern("add"), 1, element);
+    }
     return element;
 }
 
@@ -497,10 +502,17 @@ set_i_initialize(int argc, VALUE *argv, VALUE set)
             long i;
             int block_given = rb_block_given_p();
             set_table *into = RSET_TABLE(set);
+            VALUE is_subclass = !rb_obj_is_instance_of(set, rb_cSet);
+
             for (i=0; i<RARRAY_LEN(other); i++) {
                 VALUE key = RARRAY_AREF(other, i);
                 if (block_given) key = rb_yield(key);
-                set_table_insert_wb(into, set, key, NULL);
+                if (is_subclass) {
+                    rb_funcall(set, rb_intern("add"), 1, key);
+                }
+                else {
+                    set_table_insert_wb(into, set, key, NULL);
+                }
             }
         }
         else {

--- a/test/ruby/test_set.rb
+++ b/test/ruby/test_set.rb
@@ -6,6 +6,20 @@ class TC_Set < Test::Unit::TestCase
   class Set2 < Set
   end
 
+  class Set3 < Set
+    def add(item) = super(item.bytesize)
+  end
+
+  def test_new_calls_add
+    set = Set3.new(["foo"])
+    assert_equal(true, set.include?(3))
+  end
+
+  def test_new_with_block_calls_add
+    set = Set3.new(["foo"]) { |x| x + "o" }
+    assert_equal(true, set.include?(4))
+  end
+
   def test_marshal
     set = Set[1, 2, 3]
     mset = Marshal.load(Marshal.dump(set))


### PR DESCRIPTION
Set#new used to call add on items passed to initialize.  This adds backwards compatibility with subclasses of Set

[[Bug #21396]](https://bugs.ruby-lang.org/issues/21396)