### PR TITLE
Fix and simplify `make test-bundler`

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1685,8 +1685,7 @@ test-bundler: $(TEST_RUNNABLE)-test-bundler
 yes-test-bundler: $(PREPARE_BUNDLER)
 	$(gnumake_recursive)$(XRUBY) \
 		-r./$(arch)-fake \
-		-e "exec(*ARGV)" -- \
-		$(XRUBY) -C $(srcdir) -Ispec/bundler -Ispec/lib spec/bin/rspec \
+		-C $(srcdir) -Ispec/bundler -Ispec/lib spec/bin/rspec \
 		-r spec_helper $(RSPECOPTS) spec/bundler/$(BUNDLER_SPECS)
 no-test-bundler:
 

--- a/common.mk
+++ b/common.mk
@@ -1686,7 +1686,7 @@ yes-test-bundler: $(PREPARE_BUNDLER)
 	$(gnumake_recursive)$(XRUBY) \
 		-r./$(arch)-fake \
 		-e "exec(*ARGV)" -- \
-		$(XRUBY) -C $(srcdir) -Ispec/bundler -Ispec/lib .bundle/bin/rspec \
+		$(XRUBY) -C $(srcdir) -Ispec/bundler -Ispec/lib spec/bin/rspec \
 		-r spec_helper $(RSPECOPTS) spec/bundler/$(BUNDLER_SPECS)
 no-test-bundler:
 

--- a/spec/bin/rspec
+++ b/spec/bin/rspec
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../bundler/support/setup"
+
+Spec::Rubygems.gem_load("rspec-core", "rspec")

--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -136,9 +136,11 @@ module SyncDefaultGems
       cp_r("#{upstream}/bundler/spec", "spec/bundler")
       rm_rf("spec/bundler/bin")
 
-      parallel_tests_content = File.read("#{upstream}/bundler/bin/parallel_rspec").gsub("../spec", "../bundler")
-      File.write("spec/bin/parallel_rspec", parallel_tests_content)
-      chmod("+x", "spec/bin/parallel_rspec")
+      ["parallel_rspec", "rspec"].each do |binstub|
+        content = File.read("#{upstream}/bundler/bin/#{binstub}").gsub("../spec", "../bundler")
+        File.write("spec/bin/#{binstub}", content)
+        chmod("+x", "spec/bin/#{binstub}")
+      end
 
       %w[dev_gems test_gems rubocop_gems standard_gems].each do |gemfile|
         ["rb.lock", "rb"].each do |ext|


### PR DESCRIPTION
This make target was recently broken by upstream changes. This change catches up with those changes so that it works again.