### PR TITLE
Fix comment about debugging shapes

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -1219,7 +1219,7 @@ rb_shape_verify_consistency(VALUE obj, shape_id_t shape_id)
 #if SHAPE_DEBUG
 
 /*
- * Exposing Shape to Ruby via RubyVM.debug_shape
+ * Exposing Shape to Ruby via RubyVM::Shape.of(object)
  */
 
 static VALUE


### PR DESCRIPTION
This method was moved to `RubyVM::Shape` in 913979bede2a1b79109fa2072352882560d55fe0.