### PR TITLE
[Bug #21400] Fix rb_bug() when killing current root fiber in non-main thread

### DIFF
--- a/bootstraptest/test_fiber.rb
+++ b/bootstraptest/test_fiber.rb
@@ -37,3 +37,8 @@ assert_normal_exit %q{
 assert_normal_exit %q{
   Fiber.new(&Object.method(:class_eval)).resume("foo")
 }, '[ruby-dev:34128]'
+
+# [Bug #21400]
+assert_normal_exit %q{
+  Thread.new { Fiber.current.kill }.join
+}

--- a/thread.c
+++ b/thread.c
@@ -1127,6 +1127,10 @@ thread_join(rb_thread_t *target_th, VALUE timeout, rb_hrtime_t *limit)
                 /* OK. killed. */
                 break;
               default:
+                if (err == RUBY_FATAL_FIBER_KILLED) { // not integer constant so can't be a case expression
+                    // root fiber killed in non-main thread
+                    break;
+                }
                 rb_bug("thread_join: Fixnum (%d) should not reach here.", FIX2INT(err));
             }
         }


### PR DESCRIPTION
Fixes the following:

```ruby
Thread.new { Fiber.current.kill }.join
```