### PR TITLE
ZJIT: Add codegen for uncached getinstancevariable, setinstancevariable

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -559,6 +559,15 @@ class TestZJIT < Test::Unit::TestCase
     }
   end
 
+  def test_setinstancevariable
+    assert_compiles '1', %q{
+      def test() = @foo = 1
+
+      test()
+      @foo
+    }
+  end
+
   # tool/ruby_vm/views/*.erb relies on the zjit instructions a) being contiguous and
   # b) being reliably ordered after all the other instructions.
   def test_instruction_order

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -381,6 +381,7 @@ fn main() {
         .allowlist_function("rb_attr_get")
         .allowlist_function("rb_ivar_defined")
         .allowlist_function("rb_ivar_get")
+        .allowlist_function("rb_ivar_set")
         .allowlist_function("rb_mod_name")
 
         // From include/ruby/internal/intern/vm.h

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -829,6 +829,7 @@ unsafe extern "C" {
     pub fn rb_str_intern(str_: VALUE) -> VALUE;
     pub fn rb_mod_name(mod_: VALUE) -> VALUE;
     pub fn rb_ivar_get(obj: VALUE, name: ID) -> VALUE;
+    pub fn rb_ivar_set(obj: VALUE, name: ID, val: VALUE) -> VALUE;
     pub fn rb_ivar_defined(obj: VALUE, name: ID) -> VALUE;
     pub fn rb_attr_get(obj: VALUE, name: ID) -> VALUE;
     pub fn rb_obj_info_dump(obj: VALUE);


### PR DESCRIPTION
I didn't know `rb_ivar_get` existed until @Xrxr pointed me to it.
Thanks, Alan!
