### PR TITLE
Use a T_DATA for cross_ractor_require

### DIFF
--- a/internal/thread.h
+++ b/internal/thread.h
@@ -90,6 +90,7 @@ typedef VALUE (rb_interrupt_exec_func_t)(void *data);
 enum rb_interrupt_exec_flag {
     rb_interrupt_exec_flag_none = 0x00,
     rb_interrupt_exec_flag_value_data = 0x01,
+    rb_interrupt_exec_flag_new_thread = 0x02,
 };
 
 // interrupt the target_th and run func.

--- a/ractor.c
+++ b/ractor.c
@@ -2339,8 +2339,8 @@ rb_ractor_require(VALUE feature)
     VALUE crr_obj = TypedData_Make_Struct(0, struct cross_ractor_require, &cross_ractor_require_data_type, crr);
     FL_SET_RAW(crr_obj, RUBY_FL_SHAREABLE);
 
-    // TODO: make feature shareable
-    crr->feature = feature;
+    // Convert feature to proper file path and make it shareable as fstring
+    crr->feature = rb_fstring(FilePathValue(feature));
     crr->port = ractor_port_new(GET_RACTOR());
     crr->result = Qundef;
     crr->exception = Qundef;

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -98,6 +98,21 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  def test_require_non_string
+    assert_ractor(<<~'RUBY')
+      require "tempfile"
+      require "pathname"
+      f = Tempfile.new(["file_to_require_from_ractor", ".rb"])
+      f.write("puts 'success'")
+      f.flush
+      result = Ractor.new(f.path) do |path|
+        require Pathname.new(path)
+        "success"
+      end.value
+      assert_equal "success", result
+    RUBY
+  end
+
   def assert_make_shareable(obj)
     refute Ractor.shareable?(obj), "object was already shareable"
     Ractor.make_shareable(obj)


### PR DESCRIPTION
Fixes [Bug #21090](https://bugs.ruby-lang.org/issues/21090)

The struct was previously allocated on the stack, which could be freed if the Thread is terminated. Moving this to a T_DATA on the heap should mean this is no longer an issue.

```
1000.times { Ractor.new { th = Thread.new { require "rbconfig" }; Thread.pass }.take }
```

Previously this would segfault, due to accessing the Thread's memory after it was terminated (when the Ractor exits). Now it prints 1000 times:

```
#<Thread:0x000077b21ddaa5e0 run> terminated with exception (report_on_exception is true):
The port was already closed (Ractor::ClosedError)
```

The error comes from trying to send the result of the require back through the port. Maybe we could have a better error message, but that seems pretty reasonable to me given how much of an edge case this is.

cc @ko1 @luke-gru 