### PR TITLE
Handle spurious wakeups in `Thread#join`.

### DIFF
--- a/test/fiber/scheduler.rb
+++ b/test/fiber/scheduler.rb
@@ -126,7 +126,7 @@ class Scheduler
         end
 
         ready.each do |fiber|
-          fiber.transfer
+          fiber.transfer if fiber.alive?
         end
       end
     end


### PR DESCRIPTION
Extracted from <https://github.com/ruby/ruby/pull/13437>.

The fiber scheduler, if interrupted, could return to the caller before the thread was joined.