### PR TITLE
ZJIT: Panic unimplemented for OOB basic block args

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -730,6 +730,12 @@ fn gen_push_frame(asm: &mut Assembler, recv: Opnd) {
 fn param_reg(idx: usize) -> Reg {
     // To simplify the implementation, allocate a fixed register for each basic block argument for now.
     // TODO: Allow allocating arbitrary registers for basic block arguments
+    if idx >= ALLOC_REGS.len() {
+        unimplemented!(
+            "register spilling not yet implemented, too many basic block arguments ({}/{})",
+            idx + 1, ALLOC_REGS.len()
+        );
+    }
     ALLOC_REGS[idx]
 }
 


### PR DESCRIPTION
- Go from 8 to 10 `ALLOC_REGS` registers for ARM64 and x86_64
- Panic about unimplemented register spilling when block args are out of bounds

Testing ZJIT I noticed an index out of bounds panic with:

```sh
ruby --zjit -e "pp 0"
```

Pending the implementation of register spilling, I propose:
1) Improve the panic message when there aren't enough registers for block arguments
2) Increase the number of basic block registers from 8 to 10 to cover many more cases in the interim.