### PR TITLE
Remove `launchable record attachment` command

### DIFF
--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -55,17 +55,6 @@ inputs:
     description: >-
       Whether this workflow is executed on YJIT.
 
-outputs:
-  stdout_report_path:
-    value: ${{ steps.variables.outputs.stdout_report_path }}
-    description: >-
-      Report file path for standard output.
-
-  stderr_report_path:
-    value: ${{ steps.variables.outputs.stderr_report_path }}
-    description: >-
-      Report file path for standard error.
-
 runs:
   using: composite
 
@@ -261,10 +250,6 @@ runs:
           mkdir "${test_spec_report_path}"
           echo test_spec_report_path="${test_spec_report_path}" >> $GITHUB_OUTPUT
         fi
-        stdout_report_path="${dir}${builddir:+${builddir}/}launchable_stdout.log"
-        stderr_report_path="${dir}${builddir:+${builddir}/}launchable_stderr.log"
-        echo stdout_report_path="${stdout_report_path}" >> $GITHUB_OUTPUT
-        echo stderr_report_path="${stderr_report_path}" >> $GITHUB_OUTPUT
       if: steps.enable-launchable.outputs.enable-launchable
       env:
         srcdir: ${{ inputs.srcdir }}
@@ -283,30 +268,18 @@ runs:
         working-directory: ${{ inputs.srcdir }}
         post: |
           if [[ "${test_all_enabled}" = "true" ]]; then \
-            launchable record attachment \
-              --session "$(cat "${test_all_session_file}")" \
-              "${stdout_report_path}" \
-              "${stderr_report_path}"; \
             launchable record tests \
               --session "$(cat "${test_all_session_file}")" \
               raw "${test_report_path}" || true; \
           fi
 
           if [[ "${btest_enabled}" = "true" ]]; then \
-            launchable record attachment \
-              --session "$(cat "${btest_session_file}")" \
-              "${stdout_report_path}" \
-              "${stderr_report_path}"; \
             launchable record tests \
               --session "$(cat "${btest_session_file}")" \
               raw "${btest_report_path}" || true; \
           fi
 
           if [[ "${test_spec_enabled}" = "true" ]]; then \
-            launchable record attachment \
-              --session "$(cat "${test_spec_session_file}")" \
-              "${stdout_report_path}" \
-              "${stderr_report_path}"; \
             launchable record tests \
               --session "$(cat "${test_spec_session_file}")" \
               raw ${test_spec_report_path}/* || true; \
@@ -318,8 +291,6 @@ runs:
           rm -f "${test_report_path}"
           rm -f "${btest_report_path}"
           rm -fr "${test_spec_report_path}"
-          rm -f "${stdout_report_path}"
-          rm -f "${stderr_report_path}"
       if: ${{ always() && steps.enable-launchable.outputs.enable-launchable }}
       env:
         test_report_path: ${{ steps.variables.outputs.test_report_path }}
@@ -331,5 +302,3 @@ runs:
         test_all_session_file: ${{ steps.global.outputs.test_all_session_file }}
         btest_session_file: ${{ steps.global.outputs.btest_session_file }}
         test_spec_session_file: ${{ steps.global.outputs.test_spec_session_file }}
-        stdout_report_path: ${{ steps.variables.outputs.stdout_report_path }}
-        stderr_report_path: ${{ steps.variables.outputs.stderr_report_path }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -134,9 +134,6 @@ jobs:
 
       - name: make ${{ matrix.test_task }}
         run: |
-          test -n "${LAUNCHABLE_STDOUT}" && exec 1> >(tee "${LAUNCHABLE_STDOUT}")
-          test -n "${LAUNCHABLE_STDERR}" && exec 2> >(tee "${LAUNCHABLE_STDERR}")
-
           ulimit -c unlimited
           make -s ${{ matrix.test_task }} ${TESTS:+TESTS="$TESTS"}
         timeout-minutes: 60
@@ -144,8 +141,6 @@ jobs:
           RUBY_TESTOPTS: '-q --tty=no'
           TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,rbs,repl_type_completor'
           PRECHECK_BUNDLED_GEMS: 'no'
-          LAUNCHABLE_STDOUT: ${{ steps.launchable.outputs.stdout_report_path }}
-          LAUNCHABLE_STDERR: ${{ steps.launchable.outputs.stderr_report_path }}
 
       - name: make skipped tests
         run: |

--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -144,9 +144,6 @@ jobs:
 
       - name: make ${{ matrix.test_task }}
         run: |
-          test -n "${LAUNCHABLE_STDOUT}" && exec 1> >(tee "${LAUNCHABLE_STDOUT}")
-          test -n "${LAUNCHABLE_STDERR}" && exec 2> >(tee "${LAUNCHABLE_STDERR}")
-
           $SETARCH make -s ${{ matrix.test_task }} \
             ${TESTS:+TESTS="$TESTS"} \
             ${{ !contains(matrix.test_task, 'bundle') && 'RUBYOPT=-w' || '' }}
@@ -155,8 +152,6 @@ jobs:
           RUBY_TESTOPTS: '-q --tty=no'
           TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,rbs,repl_type_completor'
           PRECHECK_BUNDLED_GEMS: 'no'
-          LAUNCHABLE_STDOUT: ${{ steps.launchable.outputs.stdout_report_path }}
-          LAUNCHABLE_STDERR: ${{ steps.launchable.outputs.stderr_report_path }}
 
       - name: make skipped tests
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -120,9 +120,6 @@ jobs:
 
       - name: make ${{ matrix.test_task }}
         run: |
-          test -n "${LAUNCHABLE_STDOUT}" && exec 1> >(tee "${LAUNCHABLE_STDOUT}")
-          test -n "${LAUNCHABLE_STDERR}" && exec 2> >(tee "${LAUNCHABLE_STDERR}")
-
           $SETARCH make -s ${{ matrix.test_task }} \
           ${TESTS:+TESTS="$TESTS"} \
           ${{ !contains(matrix.test_task, 'bundle') && 'RUBYOPT=-w' || '' }}
@@ -131,8 +128,6 @@ jobs:
           RUBY_TESTOPTS: '-q --tty=no'
           TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,rbs,repl_type_completor'
           PRECHECK_BUNDLED_GEMS: 'no'
-          LAUNCHABLE_STDOUT: ${{ steps.launchable.outputs.stdout_report_path }}
-          LAUNCHABLE_STDERR: ${{ steps.launchable.outputs.stderr_report_path }}
 
       - name: make skipped tests
         run: |

--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -144,9 +144,6 @@ jobs:
 
       - name: make ${{ matrix.test_task }}
         run: |
-          test -n "${LAUNCHABLE_STDOUT}" && exec 1> >(tee "${LAUNCHABLE_STDOUT}")
-          test -n "${LAUNCHABLE_STDERR}" && exec 2> >(tee "${LAUNCHABLE_STDERR}")
-
           make -s ${{ matrix.test_task }} ${TESTS:+TESTS="$TESTS"} \
             RUN_OPTS="$RUN_OPTS" \
             SPECOPTS="$SPECOPTS"
@@ -156,8 +153,6 @@ jobs:
           TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,rbs,repl_type_completor'
           SYNTAX_SUGGEST_TIMEOUT: '5'
           PRECHECK_BUNDLED_GEMS: 'no'
-          LAUNCHABLE_STDOUT: ${{ steps.launchable.outputs.stdout_report_path }}
-          LAUNCHABLE_STDERR: ${{ steps.launchable.outputs.stderr_report_path }}
         continue-on-error: ${{ matrix.continue-on-test_task || false }}
 
       - name: make skipped tests

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -192,9 +192,6 @@ jobs:
 
       - name: make ${{ matrix.test_task }}
         run: |
-          test -n "${LAUNCHABLE_STDOUT}" && exec 1> >(tee "${LAUNCHABLE_STDOUT}")
-          test -n "${LAUNCHABLE_STDERR}" && exec 2> >(tee "${LAUNCHABLE_STDERR}")
-
           make -s ${{ matrix.test_task }} ${TESTS:+TESTS="$TESTS"} \
             RUN_OPTS="$RUN_OPTS" MSPECOPT=--debug SPECOPTS="$SPECOPTS" \
             YJIT_BENCH_OPTS="$YJIT_BENCH_OPTS" YJIT_BINDGEN_DIFF_OPTS="$YJIT_BINDGEN_DIFF_OPTS"
@@ -206,8 +203,6 @@ jobs:
           SYNTAX_SUGGEST_TIMEOUT: '5'
           YJIT_BINDGEN_DIFF_OPTS: '--exit-code'
           LIBCLANG_PATH: ${{ matrix.libclang_path }}
-          LAUNCHABLE_STDOUT: ${{ steps.launchable.outputs.stdout_report_path }}
-          LAUNCHABLE_STDERR: ${{ steps.launchable.outputs.stderr_report_path }}
         continue-on-error: ${{ matrix.continue-on-test_task || false }}
 
       - name: Show ${{ github.event.pull_request.base.ref }} GitHub URL for yjit-bench comparison


### PR DESCRIPTION
STDOUT and STDERR has been recorded by Launchable. To record them, we create the files and read them by executing `launchable record attachment` command.

When Launchable is unstable, the timeout happens, then the command `rm -f LAUNCHABLE_STDOUT_FILE` fails. Because it's hard to deal such error in Ruby CI, I'm gonna remove that whole process that records STDOUT and STDERR. After resolving the timeout issue, we'll start recording them again.

https://github.com/ruby/ruby/actions/runs/15480202456/job/43584524672#step:26:26