### PR TITLE
ignore confirming belonging while finrializer

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -288,6 +288,7 @@ rb_gc_run_obj_finalizer(VALUE objid, long count, VALUE (*callback)(long i, void 
     saved.finished = 0;
     saved.final = Qundef;
 
+    rb_ractor_ignore_belonging(true);
     EC_PUSH_TAG(ec);
     enum ruby_tag_type state = EC_EXEC_TAG();
     if (state != TAG_NONE) {
@@ -306,6 +307,7 @@ rb_gc_run_obj_finalizer(VALUE objid, long count, VALUE (*callback)(long i, void 
         rb_check_funcall(saved.final, idCall, 1, &objid);
     }
     EC_POP_TAG();
+    rb_ractor_ignore_belonging(false);
 #undef RESTORE_FINALIZER
 }
 

--- a/ractor.c
+++ b/ractor.c
@@ -33,6 +33,11 @@ static VALUE rb_cRactorMovedObject;
 
 static void vm_ractor_blocking_cnt_inc(rb_vm_t *vm, rb_ractor_t *r, const char *file, int line);
 
+
+#if RACTOR_CHECK_MODE > 0
+bool rb_ractor_ignore_belonging_flag = false;
+#endif
+
 // Ractor locking
 
 static void

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -266,9 +266,13 @@ rb_ractor_belonging(VALUE obj)
     }
 }
 
+extern bool rb_ractor_ignore_belonging_flag;
+
 static inline VALUE
 rb_ractor_confirm_belonging(VALUE obj)
 {
+    if (rb_ractor_ignore_belonging_flag) return obj;
+
     uint32_t id = rb_ractor_belonging(obj);
 
     if (id == 0) {
@@ -288,6 +292,14 @@ rb_ractor_confirm_belonging(VALUE obj)
     }
     return obj;
 }
+
+static inline void
+rb_ractor_ignore_belonging(bool flag)
+{
+    rb_ractor_ignore_belonging_flag = flag;
+}
+
 #else
 #define rb_ractor_confirm_belonging(obj) obj
+#define rb_ractor_ignore_belonging(flag) (0)
 #endif


### PR DESCRIPTION
A finalizer registerred in Ractor A can be invoked in B.

```ruby
require "tempfile"
r = Ractor.new{
  10_000.times{|i|
    Tempfile.new(["file_to_require_from_ractor#{i}", ".rb"])
  }
}
sleep 0.1
```

For example, above script makes tempfiles which have finalizers on Ractor r, but at the end of the process, main Ractor will invoke finalizers and it violates belonging check. This patch just ignore the belonging check to avoid CI failure.

Of course it violates Ractor's isolation and wrong workaround. This issue will be solved with Ractor local GC.