### PR TITLE
Log `ec->interrupt_flag` if non-zero.

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -649,7 +649,7 @@ rb_fiber_scheduler_unblock(VALUE scheduler, VALUE blocker, VALUE fiber)
 #ifdef RUBY_DEBUG
     rb_execution_context_t *ec = GET_EC();
     if (ec->interrupt_flag) {
-        rb_bug("rb_fiber_scheduler_unblock called with interrupt flags set");
+        rb_bug("rb_fiber_scheduler_unblock called with interrupt flags set: %d", ec->interrupt_flag);
     }
 #endif
 
@@ -1079,7 +1079,7 @@ VALUE rb_fiber_scheduler_fiber_interrupt(VALUE scheduler, VALUE fiber, VALUE exc
 #ifdef RUBY_DEBUG
     rb_execution_context_t *ec = GET_EC();
     if (ec->interrupt_flag) {
-        rb_bug("rb_fiber_scheduler_fiber_interrupt called with interrupt flags set");
+        rb_bug("rb_fiber_scheduler_fiber_interrupt called with interrupt flags set: %d", ec->interrupt_flag);
     }
 #endif
 


### PR DESCRIPTION
Let's try to get more information in this kind of failure: http://ci.rvm.jp/results/trunk-random1@ruby-sp2-noble-docker/5784229