### PR TITLE
Allow `Mutex#lock` in trap context.

### DIFF
--- a/internal/thread.h
+++ b/internal/thread.h
@@ -50,7 +50,6 @@ int rb_thread_to_be_killed(VALUE thread);
 void rb_thread_acquire_fork_lock(void);
 void rb_thread_release_fork_lock(void);
 void rb_thread_reset_fork_lock(void);
-void rb_mutex_allow_trap(VALUE self, int val);
 VALUE rb_uninterruptible(VALUE (*b_proc)(VALUE), VALUE data);
 VALUE rb_mutex_owned_p(VALUE self);
 VALUE rb_exec_recursive_outer_mid(VALUE (*f)(VALUE g, VALUE h, int r), VALUE g, VALUE h, ID mid);

--- a/io.c
+++ b/io.c
@@ -1864,7 +1864,6 @@ io_allocate_write_buffer(rb_io_t *fptr, int sync)
 
     if (NIL_P(fptr->write_lock)) {
         fptr->write_lock = rb_mutex_new();
-        rb_mutex_allow_trap(fptr->write_lock, 1);
     }
 }
 

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -36,8 +36,6 @@ struct queue_sleep_arg {
     rb_hrtime_t end;
 };
 
-#define MUTEX_ALLOW_TRAP FL_USER1
-
 static void
 sync_wakeup(struct ccan_list_head *head, long max)
 {
@@ -300,12 +298,6 @@ do_mutex_lock(VALUE self, int interruptible_p)
     rb_fiber_t *fiber = ec->fiber_ptr;
     rb_mutex_t *mutex = mutex_ptr(self);
     rb_atomic_t saved_ints = 0;
-
-    /* When running trap handler */
-    if (!FL_TEST_RAW(self, MUTEX_ALLOW_TRAP) &&
-        th->ec->interrupt_mask & TRAP_INTERRUPT_MASK) {
-        rb_raise(rb_eThreadError, "can't be called from trap context");
-    }
 
     if (rb_mutex_trylock(self) == Qfalse) {
         if (mutex->fiber == fiber) {
@@ -658,17 +650,6 @@ rb_mutex_synchronize_m(VALUE self)
     }
 
     return rb_mutex_synchronize(self, rb_yield, Qundef);
-}
-
-void
-rb_mutex_allow_trap(VALUE self, int val)
-{
-    Check_TypedStruct(self, &mutex_data_type);
-
-    if (val)
-        FL_SET_RAW(self, MUTEX_ALLOW_TRAP);
-    else
-        FL_UNSET_RAW(self, MUTEX_ALLOW_TRAP);
 }
 
 /* Queue */


### PR DESCRIPTION
See <https://bugs.ruby-lang.org/issues/19473> for context.