### PR TITLE
shape.c: match capacity growth with T_OBJECT embedded sizes

### DIFF
--- a/test/ruby/test_object_id.rb
+++ b/test/ruby/test_object_id.rb
@@ -131,6 +131,9 @@ end
 
 class TestObjectIdTooComplex < TestObjectId
   class TooComplex
+    def initialize
+      @too_complex_obj_id_test = 1
+    end
   end
 
   def setup


### PR DESCRIPTION
Extracted from: https://github.com/ruby/ruby/pull/13519

This helps with getting with of `SHAPE_T_OBJECT`, by ensuring that transitions will have capacities that match the next embed size.