### PR TITLE
Selective inspect of instance variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,26 @@ Note that each entry is kept to a minimum, see links for details.
 
 Note: We're only listing outstanding class updates.
 
+* Kernel
+
+    * `Kernel#inspect` now check for the existence of a `#instance_variables_to_inspect` method
+      allowing to control which instance variables are displayed in the `#inspect` string:
+
+      ```ruby
+      class DatabaseConfig
+        def initialize(host, user, password)
+          @host = host
+          @user = user
+          @password = password
+        end
+
+        private def instance_variables_to_inspect = [:@host, :@user]
+      end
+
+      conf = DatabaseConfig.new("localhost", "root", "hunter2")
+      conf.inspect #=> #<DatabaseConfig:0x0000000104def350 @host="localhost", @user="root">
+      ```
+
 * Binding
 
     * `Binding#local_variables` does no longer include numbered parameters.

--- a/spec/ruby/core/kernel/inspect_spec.rb
+++ b/spec/ruby/core/kernel/inspect_spec.rb
@@ -28,4 +28,34 @@ describe "Kernel#inspect" do
     end
     obj.inspect.should be_kind_of(String)
   end
+
+  ruby_version_is "3.5" do
+    it "calls #instance_variables_to_inspect private method to know which variables to display" do
+      obj = Object.new
+      obj.instance_eval do
+        @host = "localhost"
+        @user = "root"
+        @password = "hunter2"
+      end
+      obj.singleton_class.class_eval do
+        private def instance_variables_to_inspect = %i[@host @user @does_not_exist]
+      end
+
+      inspected = obj.inspect.sub(/^#<Object:0x[0-9a-f]+/, '#<Object:0x00')
+      inspected.should == '#<Object:0x00 @host="localhost", @user="root">'
+
+      obj = Object.new
+      obj.instance_eval do
+        @host = "localhost"
+        @user = "root"
+        @password = "hunter2"
+      end
+      obj.singleton_class.class_eval do
+        private def instance_variables_to_inspect = []
+      end
+
+      inspected = obj.inspect.sub(/^#<Object:0x[0-9a-f]+/, '#<Object:0x00')
+      inspected.should == "#<Object:0x00>"
+    end
+  end
 end

--- a/test/ruby/test_object.rb
+++ b/test/ruby/test_object.rb
@@ -950,6 +950,19 @@ class TestObject < Test::Unit::TestCase
     assert_match(/\bInspect\u{3042}:.* @\u{3044}=42\b/, x.inspect)
     x.instance_variable_set("@\u{3046}".encode(Encoding::EUC_JP), 6)
     assert_match(/@\u{3046}=6\b/, x.inspect)
+
+    x = Object.new
+    x.singleton_class.class_eval do
+      private def instance_variables_to_inspect = [:@host, :@user]
+    end
+
+    x.instance_variable_set(:@host, "localhost")
+    x.instance_variable_set(:@user, "root")
+    x.instance_variable_set(:@password, "hunter2")
+    s = x.inspect
+    assert_include(s, "@host=\"localhost\"")
+    assert_include(s, "@user=\"root\"")
+    assert_not_include(s, "@password=")
   end
 
   def test_singleton_methods


### PR DESCRIPTION
[Feature #21219]

Make Kernel#inspect ask which instance variables should be dumped by the result of `#instance_variables_to_inspect`.