### PR TITLE
rb_ary_size_as_embedded: only consider len, not capacity

### DIFF
--- a/array.c
+++ b/array.c
@@ -221,7 +221,7 @@ rb_ary_size_as_embedded(VALUE ary)
         real_size = ary_embed_size(ARY_EMBED_LEN(ary));
     }
     else if (rb_ary_embeddable_p(ary)) {
-        real_size = ary_embed_size(ARY_HEAP_CAPA(ary));
+        real_size = ary_embed_size(ARY_HEAP_LEN(ary));
     }
     else {
         real_size = sizeof(struct RArray);


### PR DESCRIPTION
Repro:
```ruby
def test
  a = [1, 2, 3]
  a << 7 << 8
  a
end

ar = [test, test]
require 'objspace'
puts ObjectSpace.dump(ar[0])
puts ObjectSpace.dump(ar[1])

GC.verify_compaction_references(toward: :empty, expand_heap: true)
puts
puts
puts ObjectSpace.dump(ar[0])
```

In the above script, the array is being moved to size pool 320 instead of size pool 80. This is because the compaction logic consider the array's capacity to compute the ideal size instead of its length.

You could probably make an argument about preserving the capacity, but we're not doing that for strings.