### PR TITLE
Get rid of `gen_fields_tbl.fields_count`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4093,7 +4093,8 @@ vm_weak_table_gen_fields_foreach(st_data_t key, st_data_t value, st_data_t data)
             );
         }
         else {
-            for (uint32_t i = 0; i < fields_tbl->as.shape.fields_count; i++) {
+            uint32_t fields_count = RSHAPE_LEN(RBASIC_SHAPE_ID((VALUE)key));
+            for (uint32_t i = 0; i < fields_count; i++) {
                 if (SPECIAL_CONST_P(fields_tbl->as.shape.fields[i])) continue;
 
                 int ivar_ret = iter_data->callback(fields_tbl->as.shape.fields[i], iter_data->data);

--- a/ractor.c
+++ b/ractor.c
@@ -1658,10 +1658,9 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
             if (d.stop) return 1;
         }
         else {
-            for (uint32_t i = 0; i < fields_tbl->as.shape.fields_count; i++) {
-                if (!UNDEF_P(fields_tbl->as.shape.fields[i])) {
-                    CHECK_AND_REPLACE(fields_tbl->as.shape.fields[i]);
-                }
+            uint32_t fields_count = RSHAPE_LEN(RBASIC_SHAPE_ID(obj));
+            for (uint32_t i = 0; i < fields_count; i++) {
+                CHECK_AND_REPLACE(fields_tbl->as.shape.fields[i]);
             }
         }
     }

--- a/variable.h
+++ b/variable.h
@@ -15,7 +15,6 @@
 struct gen_fields_tbl {
     union {
         struct {
-            uint32_t fields_count;
             VALUE fields[1];
         } shape;
         struct {


### PR DESCRIPTION
This data is redundant because the shape already contains both the length and capacity of the object's fields.

So it both waste space and create the possibility of a desync between the two.

We also do not need to initialize everything to Qundef, this seem to be a left-over from pre-shape instance variables.

I'm also semi hoping this may solve the GC crash we've been seeing for the last 3 days:

```
ruby(sigsegv+0x54) [0xaaab7d46ae6c] /home/opc/ruby/src/master/signal.c:934
ruby(RVALUE_WB_UNPROTECTED+0x8) [0xaaab7d373430] /home/opc/ruby/src/master/gc/default/default.c:1195
ruby(rgengc_check_relation) /home/opc/ruby/src/master/gc/default/default.c:4300
ruby(gc_mark) /home/opc/ruby/src/master/gc/default/default.c:4369
ruby(rb_mark_generic_ivar+0x98) [0xaaab7d4de838] /home/opc/ruby/src/master/variable.c:1257
ruby(rb_gc_mark_children+0x38c) [0xaaab7d374074] /home/opc/ruby/src/master/gc.c:3179
ruby(gc_mark_stacked_objects+0x80) [0xaaab7d374360] /home/opc/ruby/src/master/gc/default/default.c:4563
ruby(gc_mark_stacked_objects_all+0xc) [0xaaab7d377408] /home/opc/ruby/src/master/gc/default/default.c:4622
ruby(gc_marks_rest) /home/opc/ruby/src/master/gc/default/default.c:5639
```

I never managed to reproduce it locally, but from the crash report we're marking garbage from a `gen_fields_tbl`, so that may be caused by a desync between the two.