### PR TITLE
Fix build on alpine with statx change

### DIFF
--- a/file.c
+++ b/file.c
@@ -543,7 +543,7 @@ rb_stat_new(const struct stat *st)
     if (st) {
 #if RUBY_USE_STATX
 # define CP(m) .stx_ ## m = st->st_ ## m
-# define CP_32(m) .stx_ ## m = (__u32)st->st_ ## m
+# define CP_32(m) .stx_ ## m = (uint32_t)st->st_ ## m
 # define CP_TS(m) .stx_ ## m = stat_ ## m ## spec(st)
         rb_st->stat = (struct statx){
             .stx_mask = STATX_BASIC_STATS,


### PR DESCRIPTION
Since https://github.com/ruby/ruby/commit/18a036a6133bd141dfc25cd48ced9a2b78826af6 (https://github.com/ruby/ruby/pull/13474) building on alpine fails because usage of `__u32`, which is not portable.

> file.c: In function 'rb_stat_new':
> file.c:546:33: error: '__u32' undeclared (first use in this function)
>   \# define CP_32(m) .stx_ ## m = (__u32)st->st_ ## m