### PR TITLE
Fix handling of cancelled blocking operations.

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -1061,9 +1061,8 @@ VALUE rb_fiber_scheduler_blocking_operation_wait(VALUE scheduler, void* (*functi
     operation->data2 = NULL;
     operation->unblock_function = NULL;
 
-    // If the blocking operation was never executed, return Qundef to signal
-    // the caller to use rb_nogvl instead
-    if (current_status != RB_FIBER_SCHEDULER_BLOCKING_OPERATION_STATUS_COMPLETED) {
+    // If the blocking operation was never executed, return Qundef to signal the caller to use rb_nogvl instead
+    if (current_status == RB_FIBER_SCHEDULER_BLOCKING_OPERATION_STATUS_QUEUED) {
         return Qundef;
     }
 


### PR DESCRIPTION
Cancelled operations were returning `Qundef` causing a `rb_nogvl` to retry the execution of the given function.