### PR TITLE
enumerator.c: Add a debug assertion

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -3771,6 +3771,10 @@ rb_arith_seq_new(VALUE obj, VALUE meth, int argc, VALUE const *argv,
     rb_ivar_set(aseq, id_end, end);
     rb_ivar_set(aseq, id_step, step);
     rb_ivar_set(aseq, id_exclude_end, RBOOL(excl));
+
+    // DEBUG: I'm tracking down a generic ivar corruption bug, and one possible explanation is
+    // that aseq sometimes becomes too_complex. This assertion is to attempt to confirm it.
+    RUBY_ASSERT(!rb_shape_obj_too_complex_p(aseq));
     return aseq;
 }
 


### PR DESCRIPTION
I'm tracking down a generic ivar corruption bug, and one possible explanation is that aseq sometimes becomes too_complex. This assertion is to attempt to confirm it.

```
ruby(sigsegv+0x54) [signal.c:934
ruby(rb_float_noflonum_value+0x0) internal/numeric.h:238
ruby(rb_float_value_inline) internal/numeric.h:241
ruby(flo_to_i) numeric.c:2654
ruby(vm_call0_cfunc_with_frame+0x7c) [0xaaac4f141a74] vm_eval.c:164
ruby(vm_call0_cfunc) vm_eval.c:178
ruby(vm_call0_body) vm_eval.c:229
ruby(vm_call0_cc+0xc8) vm_eval.c:101
ruby(rb_vm_call0+0x3c) vm_eval.c:61
ruby(rb_vm_call_kw) vm_eval.c:326
ruby(rb_check_funcall_default_kw) vm_eval.c:712
ruby(convert_type_with_id+0x8) object.c:3170
ruby(rb_to_integer_with_id_exception) object.c:3285
ruby(rb_to_int) object.c:3315
ruby(rb_num2long+0x68) numeric.c:3218
ruby(rb_num2long_inline+0x8) include/ruby/internal/arithmetic/long.h:272
ruby(rb_arithmetic_sequence_beg_len_step) enumerator.c:3865
ruby(rb_ary_aref1+0x24) array.c:1924
ruby(rb_ary_aref1) array.c:1915
ruby(rb_ary_aref) array.c:1900
```