### PR TITLE
{Y,Z}JIT: x86: Fix panic writing 32-bit number with top bit set

### DIFF
--- a/yjit/src/asm/x86_64/mod.rs
+++ b/yjit/src/asm/x86_64/mod.rs
@@ -1027,7 +1027,10 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
             }
 
             let output_num_bits:u32 = if mem.num_bits > 32 { 32 } else { mem.num_bits.into() };
-            assert!(imm_num_bits(imm.value) <= (output_num_bits as u8));
+            assert!(
+                mem.num_bits < 64 || imm_num_bits(imm.value) <= (output_num_bits as u8),
+                "immediate value should be small enough to survive sign extension"
+            );
             cb.write_int(imm.value as u64, output_num_bits);
         },
         // M + UImm
@@ -1042,7 +1045,10 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
             }
 
             let output_num_bits = if mem.num_bits > 32 { 32 } else { mem.num_bits.into() };
-            assert!(imm_num_bits(uimm.value as i64) <= (output_num_bits as u8));
+            assert!(
+                mem.num_bits < 64 || imm_num_bits(uimm.value as i64) <= (output_num_bits as u8),
+                "immediate value should be small enough to survive sign extension"
+            );
             cb.write_int(uimm.value, output_num_bits);
         },
         // * + Imm/UImm

--- a/yjit/src/asm/x86_64/tests.rs
+++ b/yjit/src/asm/x86_64/tests.rs
@@ -193,6 +193,7 @@ fn test_mov() {
     check_bytes("48c7470801000000", |cb| mov(cb, mem_opnd(64, RDI, 8), imm_opnd(1)));
     //check_bytes("67c7400411000000", |cb| mov(cb, mem_opnd(32, EAX, 4), imm_opnd(0x34))); // We don't distinguish between EAX and RAX here - that's probably fine?
     check_bytes("c7400411000000", |cb| mov(cb, mem_opnd(32, RAX, 4), imm_opnd(17)));
+    check_bytes("c7400401000080", |cb| mov(cb, mem_opnd(32, RAX, 4), uimm_opnd(0x80000001)));
     check_bytes("41895814", |cb| mov(cb, mem_opnd(32, R8, 20), EBX));
     check_bytes("4d8913", |cb| mov(cb, mem_opnd(64, R11, 0), R10));
     check_bytes("48c742f8f4ffffff", |cb| mov(cb, mem_opnd(64, RDX, -8), imm_opnd(-12)));

--- a/yjit/src/backend/x86_64/mod.rs
+++ b/yjit/src/backend/x86_64/mod.rs
@@ -315,19 +315,24 @@ impl Assembler
                             let opnd1 = asm.load(*src);
                             asm.mov(*dest, opnd1);
                         },
-                        (Opnd::Mem(_), Opnd::UImm(value)) => {
-                            // 32-bit values will be sign-extended
-                            if imm_num_bits(*value as i64) > 32 {
+                        (Opnd::Mem(Mem { num_bits, .. }), Opnd::UImm(value)) => {
+                            // For 64 bit destinations, 32-bit values will be sign-extended
+                            if *num_bits == 64 && imm_num_bits(*value as i64) > 32 {
                                 let opnd1 = asm.load(*src);
                                 asm.mov(*dest, opnd1);
                             } else {
                                 asm.mov(*dest, *src);
                             }
                         },
-                        (Opnd::Mem(_), Opnd::Imm(value)) => {
-                            if imm_num_bits(*value) > 32 {
+                        (Opnd::Mem(Mem { num_bits, .. }), Opnd::Imm(value)) => {
+                            // For 64 bit destinations, 32-bit values will be sign-extended
+                            if *num_bits == 64 && imm_num_bits(*value) > 32 {
                                 let opnd1 = asm.load(*src);
                                 asm.mov(*dest, opnd1);
+                            } else if uimm_num_bits(*value as u64) <= *num_bits {
+                                // If the bit string is short enough for the destination, use the unsigned representation.
+                                // Note that 64-bit and negative values are ruled out.
+                                asm.mov(*dest, Opnd::UImm(*value as u64));
                             } else {
                                 asm.mov(*dest, *src);
                             }
@@ -1315,6 +1320,21 @@ mod tests {
             0xa: mov ecx, 4
             0xf: cmove rax, rcx
             0x13: mov qword ptr [rbx], rax
+        "});
+    }
+
+    #[test]
+    fn test_mov_m32_imm32() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let shape_opnd = Opnd::mem(32, C_RET_OPND, 0);
+        asm.mov(shape_opnd, Opnd::UImm(0x8000_0001));
+        asm.mov(shape_opnd, Opnd::Imm(0x8000_0001));
+
+        asm.compile_with_num_regs(&mut cb, 0);
+        assert_disasm!(cb, "c70001000080c70001000080", {"
+            0x0: mov dword ptr [rax], 0x80000001
+            0x6: mov dword ptr [rax], 0x80000001
         "});
     }
 }

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-//use std::fmt;
+use std::fmt;
 use std::rc::Rc;
 use std::cell::RefCell;
 use std::mem;
@@ -257,6 +257,18 @@ impl CodeBlock {
     /// Make all the code in the region executable. Call this at the end of a write session.
     pub fn mark_all_executable(&mut self) {
         self.mem_block.borrow_mut().mark_all_executable();
+    }
+}
+
+/// Produce hex string output from the bytes in a code block
+impl fmt::LowerHex for CodeBlock {
+    fn fmt(&self, fmtr: &mut fmt::Formatter) -> fmt::Result {
+        for pos in 0..self.write_pos {
+            let mem_block = &*self.mem_block.borrow();
+            let byte = unsafe { mem_block.start_ptr().raw_ptr(mem_block).add(pos).read() };
+            fmtr.write_fmt(format_args!("{:02x}", byte))?;
+        }
+        Ok(())
     }
 }
 

--- a/zjit/src/asm/x86_64/mod.rs
+++ b/zjit/src/asm/x86_64/mod.rs
@@ -1024,7 +1024,10 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
             }
 
             let output_num_bits:u32 = if mem.num_bits > 32 { 32 } else { mem.num_bits.into() };
-            assert!(imm_num_bits(imm.value) <= (output_num_bits as u8));
+            assert!(
+                mem.num_bits < 64 || imm_num_bits(imm.value) <= (output_num_bits as u8),
+                "immediate value should be small enough to survive sign extension"
+            );
             cb.write_int(imm.value as u64, output_num_bits);
         },
         // M + UImm
@@ -1039,7 +1042,10 @@ pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
             }
 
             let output_num_bits = if mem.num_bits > 32 { 32 } else { mem.num_bits.into() };
-            assert!(imm_num_bits(uimm.value as i64) <= (output_num_bits as u8));
+            assert!(
+                mem.num_bits < 64 || imm_num_bits(uimm.value as i64) <= (output_num_bits as u8),
+                "immediate value should be small enough to survive sign extension"
+            );
             cb.write_int(uimm.value, output_num_bits);
         },
         // * + Imm/UImm

--- a/zjit/src/asm/x86_64/tests.rs
+++ b/zjit/src/asm/x86_64/tests.rs
@@ -1,11 +1,10 @@
 #![cfg(test)]
 
-//use crate::asm::x86_64::*;
+use crate::asm::x86_64::*;
 
-/*
 /// Check that the bytes for an instruction sequence match a hex string
 fn check_bytes<R>(bytes: &str, run: R) where R: FnOnce(&mut super::CodeBlock) {
-    let mut cb = super::CodeBlock::new_dummy(4096);
+    let mut cb = super::CodeBlock::new_dummy();
     run(&mut cb);
     assert_eq!(format!("{:x}", cb), bytes);
 }
@@ -439,9 +438,10 @@ fn basic_capstone_usage() -> std::result::Result<(), capstone::Error> {
 }
 
 #[test]
+#[ignore]
 #[cfg(feature = "disasm")]
 fn block_comments() {
-    let mut cb = super::CodeBlock::new_dummy(4096);
+    let mut cb = super::CodeBlock::new_dummy();
 
     let first_write_ptr = cb.get_write_ptr().raw_addr(&cb);
     cb.add_comment("Beginning");
@@ -458,4 +458,3 @@ fn block_comments() {
     assert_eq!(&vec!( "Two bytes in".to_string(), "Still two bytes in".to_string() ), cb.comments_at(second_write_ptr).unwrap());
     assert_eq!(&vec!( "Ten bytes in".to_string() ), cb.comments_at(third_write_ptr).unwrap());
 }
-*/

--- a/zjit/src/asm/x86_64/tests.rs
+++ b/zjit/src/asm/x86_64/tests.rs
@@ -193,6 +193,7 @@ fn test_mov() {
     check_bytes("48c7470801000000", |cb| mov(cb, mem_opnd(64, RDI, 8), imm_opnd(1)));
     //check_bytes("67c7400411000000", |cb| mov(cb, mem_opnd(32, EAX, 4), imm_opnd(0x34))); // We don't distinguish between EAX and RAX here - that's probably fine?
     check_bytes("c7400411000000", |cb| mov(cb, mem_opnd(32, RAX, 4), imm_opnd(17)));
+    check_bytes("c7400401000080", |cb| mov(cb, mem_opnd(32, RAX, 4), uimm_opnd(0x80000001)));
     check_bytes("41895814", |cb| mov(cb, mem_opnd(32, R8, 20), EBX));
     check_bytes("4d8913", |cb| mov(cb, mem_opnd(64, R11, 0), R10));
     check_bytes("48c742f8f4ffffff", |cb| mov(cb, mem_opnd(64, RDX, -8), imm_opnd(-12)));

--- a/zjit/src/assertions.rs
+++ b/zjit/src/assertions.rs
@@ -1,0 +1,21 @@
+/// Assert that CodeBlock has the code specified with hex. In addition, if tested with
+/// `cargo test --all-features`, it also checks it generates the specified disasm.
+#[cfg(test)]
+macro_rules! assert_disasm {
+    ($cb:expr, $hex:expr, $disasm:expr) => {
+        #[cfg(feature = "disasm")]
+        {
+            use $crate::disasm::disasm_addr_range;
+            use $crate::cruby::unindent;
+            let disasm = disasm_addr_range(
+                &$cb,
+                $cb.get_ptr(0).raw_addr(&$cb),
+                $cb.get_write_ptr().raw_addr(&$cb),
+            );
+            assert_eq!(unindent(&disasm, false), unindent(&$disasm, true));
+        }
+        assert_eq!(format!("{:x}", $cb), $hex);
+    };
+}
+#[cfg(test)]
+pub(crate) use assert_disasm;

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1345,14 +1345,30 @@ impl Assembler
     }
 }
 
-/*
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::disasm::*;
+    use crate::assertions::assert_disasm;
+
+    static TEMP_REGS: [Reg; 5] = [X1_REG, X9_REG, X10_REG, X14_REG, X15_REG];
 
     fn setup_asm() -> (Assembler, CodeBlock) {
-        (Assembler::new(0), CodeBlock::new_dummy(1024))
+        (Assembler::new(), CodeBlock::new_dummy())
+    }
+
+    #[test]
+    fn test_mul_with_immediate() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let out = asm.mul(Opnd::Reg(TEMP_REGS[1]), 3.into());
+        asm.mov(Opnd::Reg(TEMP_REGS[0]), out);
+        asm.compile_with_num_regs(&mut cb, 2);
+
+        assert_disasm!(cb, "600080d2207d009be10300aa", {"
+            0x0: mov x0, #3
+            0x4: mul x0, x9, x0
+            0x8: mov x1, x0
+        "});
     }
 
     #[test]
@@ -1361,7 +1377,7 @@ mod tests {
 
         let opnd = asm.add(Opnd::Reg(X0_REG), Opnd::Reg(X1_REG));
         asm.store(Opnd::mem(64, Opnd::Reg(X2_REG), 0), opnd);
-        asm.compile_with_regs(&mut cb, None, vec![X3_REG]);
+        asm.compile_with_regs(&mut cb, vec![X3_REG]);
 
         // Assert that only 2 instructions were written.
         assert_eq!(8, cb.get_write_pos());
@@ -1425,6 +1441,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 0);
     }
 
+    /*
     #[test]
     fn test_emit_lea_label() {
         let (mut asm, mut cb) = setup_asm();
@@ -1438,6 +1455,7 @@ mod tests {
 
         asm.compile_with_num_regs(&mut cb, 1);
     }
+    */
 
     #[test]
     fn test_emit_load_mem_disp_fits_into_load() {
@@ -1648,6 +1666,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 2);
     }
 
+    /*
     #[test]
     fn test_bcond_straddling_code_pages() {
         const LANDING_PAGE: usize = 65;
@@ -1784,20 +1803,5 @@ mod tests {
             0x8: mov x1, x11
         "});
     }
-
-    #[test]
-    fn test_mul_with_immediate() {
-        let (mut asm, mut cb) = setup_asm();
-
-        let out = asm.mul(Opnd::Reg(TEMP_REGS[1]), 3.into());
-        asm.mov(Opnd::Reg(TEMP_REGS[0]), out);
-        asm.compile_with_num_regs(&mut cb, 2);
-
-        assert_disasm!(cb, "6b0080d22b7d0b9be1030baa", {"
-            0x0: mov x11, #3
-            0x4: mul x11, x9, x11
-            0x8: mov x1, x11
-        "});
-    }
+    */
 }
-*/

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1751,6 +1751,15 @@ impl Assembler
         ret
     }
 
+    /// Compile with a limited number of registers. Used only for unit tests.
+    #[cfg(test)]
+    pub fn compile_with_num_regs(self, cb: &mut CodeBlock, num_regs: usize) -> (CodePtr, Vec<u32>)
+    {
+        let mut alloc_regs = Self::get_alloc_regs();
+        let alloc_regs = alloc_regs.drain(0..num_regs).collect();
+        self.compile_with_regs(cb, alloc_regs).unwrap()
+    }
+
     /// Compile Target::SideExit and convert it into Target::CodePtr for all instructions
     #[must_use]
     pub fn compile_side_exits(&mut self) -> Option<()> {

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -859,20 +859,17 @@ impl Assembler
     }
 }
 
-/*
 #[cfg(test)]
 mod tests {
-    use crate::disasm::assert_disasm;
-    #[cfg(feature = "disasm")]
-    use crate::disasm::{unindent, disasm_addr_range};
-
+    use crate::assertions::assert_disasm;
     use super::*;
 
     fn setup_asm() -> (Assembler, CodeBlock) {
-        (Assembler::new(0), CodeBlock::new_dummy(1024))
+        (Assembler::new(), CodeBlock::new_dummy())
     }
 
     #[test]
+    #[ignore]
     fn test_emit_add_lt_32_bits() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -883,6 +880,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_emit_add_gt_32_bits() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -893,6 +891,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_emit_and_lt_32_bits() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -903,6 +902,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_emit_and_gt_32_bits() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -957,6 +957,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_emit_or_lt_32_bits() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -967,6 +968,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_emit_or_gt_32_bits() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -977,6 +979,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_emit_sub_lt_32_bits() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -987,6 +990,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_emit_sub_gt_32_bits() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -1017,6 +1021,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_emit_xor_lt_32_bits() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -1027,6 +1032,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_emit_xor_gt_32_bits() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -1050,6 +1056,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_merge_lea_mem() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -1064,6 +1071,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_replace_cmp_0() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -1216,6 +1224,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_reorder_c_args_with_insn_out() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -1259,15 +1268,16 @@ mod tests {
 
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_disasm!(cb, "48837b1001b804000000480f4f03488903", {"
+        assert_disasm!(cb, "48837b1001bf04000000480f4f3b48893b", {"
             0x0: cmp qword ptr [rbx + 0x10], 1
-            0x5: mov eax, 4
-            0xa: cmovg rax, qword ptr [rbx]
-            0xe: mov qword ptr [rbx], rax
+            0x5: mov edi, 4
+            0xa: cmovg rdi, qword ptr [rbx]
+            0xe: mov qword ptr [rbx], rdi
         "});
     }
 
     #[test]
+    #[ignore]
     fn test_csel_split() {
         let (mut asm, mut cb) = setup_asm();
 
@@ -1285,5 +1295,3 @@ mod tests {
         "});
     }
 }
-
-*/

--- a/zjit/src/lib.rs
+++ b/zjit/src/lib.rs
@@ -21,3 +21,5 @@ mod disasm;
 mod options;
 mod profile;
 mod invariants;
+#[cfg(test)]
+mod assertions;


### PR DESCRIPTION
- **ZJIT: Revive most x64 backend tests**
- **ZJIT: Revive some A64 backend tests to fix unused warning**
- **YJIT: x86: Fix panic writing 32-bit number with top bit set**
- **ZJIT: x86: Fix panic writing 32-bit number with top bit set**

The test changes muddy up the diff a bit, but the actual fix isn't too complicated.