### PR TITLE
Use artifacts built by vcpkg manifest mode

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Restore vcpkg artifact
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: C:\Users\runneradmin\AppData\Local\vcpkg\archives
+          path: ${{ github.workspace }}/src/vcpkg_installed
           key: windows-${{ matrix.os }}-vcpkg-${{ hashFiles('src/vcpkg.json') }}
 
       - name: Install libraries with vcpkg


### PR DESCRIPTION
I'm not sure why vcpkg cache is not using while recent weeks.