### PR TITLE
fix: `Date#hash` for large years

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -6936,13 +6936,24 @@ d_lite_eql_p(VALUE self, VALUE other)
 static VALUE
 d_lite_hash(VALUE self)
 {
-    st_index_t v, h[4];
+    st_index_t v, h[5];
+    VALUE nth;
 
     get_d1(self);
-    h[0] = m_nth(dat);
-    h[1] = m_jd(dat);
-    h[2] = m_df(dat);
-    h[3] = m_sf(dat);
+    nth = m_nth(dat);
+
+    if (FIXNUM_P(nth)) {
+        h[0] = 0;
+        h[1] = (st_index_t)nth;
+    } else {
+        h[0] = 1;
+        h[1] = (st_index_t)FIX2LONG(rb_hash(nth));
+    }
+
+    h[2] = m_jd(dat);
+    h[3] = m_df(dat);
+    h[4] = m_sf(dat);
+
     v = rb_memhash(h, sizeof(h));
     return ST2FIX(v);
 }

--- a/spec/ruby/library/date/hash_spec.rb
+++ b/spec/ruby/library/date/hash_spec.rb
@@ -4,5 +4,6 @@ require 'date'
 describe "Date#hash" do
   it "returns the same value for equal dates" do
     Date.civil(2004, 7, 12).hash.should == Date.civil(2004, 7, 12).hash
+    Date.civil(3171505571716611468830131104691, 2, 19).hash.should == Date.civil(3171505571716611468830131104691, 2, 19).hash
   end
 end


### PR DESCRIPTION
Addresses https://bugs.ruby-lang.org/issues/21437

I am not 100% sure about the fix - this is the first time I am contributing to the C part of the codebase. Please let me know if the fix is sufficient