### PR TITLE
ZJIT: Parse opt freeze insns to HIR

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -255,6 +255,34 @@ class TestZJIT < Test::Unit::TestCase
     }, insns: [:opt_ge], call_threshold: 2
   end
 
+  def test_opt_hash_freeze
+    assert_compiles '{}', <<~RUBY, insns: [:opt_hash_freeze]
+      def test = {}.freeze
+      test
+    RUBY
+  end
+
+  def test_opt_ary_freeze
+    assert_compiles '[]', <<~RUBY, insns: [:opt_ary_freeze]
+      def test = [].freeze
+      test
+    RUBY
+  end
+
+  def test_opt_str_freeze
+    assert_compiles '""', <<~RUBY, insns: [:opt_str_freeze]
+      def test = "".freeze
+      test
+    RUBY
+  end
+
+  def test_opt_str_uminus
+    assert_compiles '""', <<~RUBY, insns: [:opt_str_uminus]
+      def test = -""
+      test
+    RUBY
+  end
+
   def test_new_array_empty
     assert_compiles '[]', %q{
       def test = []


### PR DESCRIPTION
* `opt_hash_freeze`
* `opt_ary_freeze`
* `opt_str_freeze`
* `opt_str_uminus`

Largely borrowed from `opt_neq`, but there are no args for `freeze`

Fixes https://github.com/Shopify/ruby/issues/582
Fixes https://github.com/Shopify/ruby/issues/583
Fixes https://github.com/Shopify/ruby/issues/584
Fixes https://github.com/Shopify/ruby/issues/585