### PR TITLE
Fix memory leak of Ractor basket when sending to closed Ractor

### DIFF
--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -1197,6 +1197,7 @@ ractor_send_basket(rb_execution_context_t *ec, const struct ractor_port *rp, str
         RUBY_DEBUG_LOG("closed:%u@r%u", (unsigned int)ractor_port_id(rp), rb_ractor_id(rp->r));
 
         if (raise_on_error) {
+            ractor_basket_free(b);
             rb_raise(rb_eRactorClosedError, "The port was already closed");
         }
     }


### PR DESCRIPTION
The following script leaks memory:

```ruby
r = Ractor.new { }
r.value

10.times do
  100_000.times do
    r.send(123)
  rescue Ractor::ClosedError
  end

  puts `ps -o rss= -p #{$$}`
end
```

Before:

    18508
    25420
    32460
    40012
    47308
    54092
    61132
    68300
    75724
    83020

After:

    11432
    11432
    11432
    11432
    11432
    11432
    11432
    11432
    11432
    11688