### PR TITLE
Add some missing write barriers on Time objects

### DIFF
--- a/time.c
+++ b/time.c
@@ -4088,7 +4088,9 @@ time_init_copy(VALUE copy, VALUE time)
     if (!OBJ_INIT_COPY(copy, time)) return copy;
     GetTimeval(time, tobj);
     GetNewTimeval(copy, tcopy);
-    MEMCPY(tcopy, tobj, struct time_object, 1);
+
+    time_set_timew(copy, tcopy, tobj->timew);
+    time_set_vtm(copy, tcopy, tobj->vtm);
 
     return copy;
 }

--- a/time.c
+++ b/time.c
@@ -5800,8 +5800,10 @@ tm_from_time(VALUE klass, VALUE time)
     tm = time_s_alloc(klass);
     ttm = RTYPEDDATA_GET_DATA(tm);
     v = &vtm;
-    GMTIMEW(ttm->timew = tobj->timew, v);
-    ttm->timew = wsub(ttm->timew, v->subsecx);
+
+    WIDEVALUE timew = tobj->timew;
+    GMTIMEW(timew, v);
+    time_set_timew(tm, ttm, wsub(timew, v->subsecx));
     v->subsecx = INT2FIX(0);
     v->zone = Qnil;
     time_set_vtm(tm, ttm, *v);


### PR DESCRIPTION
This fixes three cases of missing write barriers as found by wbcheck (see https://github.com/ruby/ruby/pull/13557). They're likely all quite rare, but I think all real issues.

* The timew was assigned to `Time::tm` without a write barrier. This is usually a FIXNUM, but can be rational or bignum for large dates.
* zone was sometimes assigned without a write barrier
* `time_init_copy` did not include write barriers. I would expect this to usually be run on a brand new object, but that isn't guaranteed