### PR TITLE
Fix class instance variable inside namespaces

### DIFF
--- a/imemo.c
+++ b/imemo.c
@@ -155,11 +155,14 @@ rb_imemo_class_fields_clone(VALUE fields_obj)
 
     if (rb_shape_too_complex_p(shape_id)) {
         clone = rb_imemo_class_fields_new_complex(CLASS_OF(fields_obj), 0);
+        RBASIC_SET_SHAPE_ID(clone, shape_id);
+
         st_table *src_table = rb_imemo_class_fields_complex_tbl(fields_obj);
         st_replace(rb_imemo_class_fields_complex_tbl(clone), src_table);
     }
     else {
         clone = imemo_class_fields_new(CLASS_OF(fields_obj), RSHAPE_CAPACITY(shape_id));
+        RBASIC_SET_SHAPE_ID(clone, shape_id);
         MEMCPY(rb_imemo_class_fields_ptr(clone), rb_imemo_class_fields_ptr(fields_obj), VALUE, RSHAPE_LEN(shape_id));
     }
 

--- a/namespace.c
+++ b/namespace.c
@@ -450,9 +450,6 @@ namespace_initialize(VALUE namespace)
     // If a code in the namespace adds a constant, the constant will be visible even from root/main.
     RCLASS_SET_PRIME_CLASSEXT_WRITABLE(namespace, true);
 
-    // fallback to ivptr for ivars from shapes to manipulate the constant table
-    rb_evict_ivars_to_hash(namespace);
-
     // Get a clean constant table of Object even by writable one
     // because ns was just created, so it has not touched any constants yet.
     object_classext = RCLASS_EXT_WRITABLE_IN_NS(rb_cObject, ns);

--- a/shape.c
+++ b/shape.c
@@ -397,7 +397,7 @@ rb_obj_shape_id(VALUE obj)
     }
 
     if (BUILTIN_TYPE(obj) == T_CLASS || BUILTIN_TYPE(obj) == T_MODULE) {
-        VALUE fields_obj = RCLASS_FIELDS_OBJ(obj);
+        VALUE fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(obj);
         if (fields_obj) {
             return RBASIC_SHAPE_ID(fields_obj);
         }

--- a/test/ruby/namespace/instance_variables.rb
+++ b/test/ruby/namespace/instance_variables.rb
@@ -1,0 +1,21 @@
+class String
+  class << self
+    attr_reader :str_ivar1
+
+    def str_ivar2
+      @str_ivar2
+    end
+  end
+
+  @str_ivar1 = 111
+  @str_ivar2 = 222
+end
+
+class StringDelegator < BasicObject
+private
+  def method_missing(...)
+    ::String.public_send(...)
+  end
+end
+
+StringDelegatorObj = StringDelegator.new

--- a/test/ruby/test_namespace.rb
+++ b/test/ruby/test_namespace.rb
@@ -222,6 +222,26 @@ class TestNamespace < Test::Unit::TestCase
     end;
   end
 
+  def test_instance_variable
+    pend unless Namespace.enabled?
+
+    @n.require_relative('namespace/instance_variables')
+
+    assert_equal [], String.instance_variables
+    assert_equal [:@str_ivar1, :@str_ivar2], @n::StringDelegatorObj.instance_variables
+    assert_equal 111, @n::StringDelegatorObj.str_ivar1
+    assert_equal 222, @n::StringDelegatorObj.str_ivar2
+    assert_equal 222, @n::StringDelegatorObj.instance_variable_get(:@str_ivar2)
+
+    @n::StringDelegatorObj.instance_variable_set(:@str_ivar3, 333)
+    assert_equal 333, @n::StringDelegatorObj.instance_variable_get(:@str_ivar3)
+    @n::StringDelegatorObj.remove_instance_variable(:@str_ivar1)
+    assert_nil @n::StringDelegatorObj.str_ivar1
+    assert_equal [:@str_ivar2, :@str_ivar3], @n::StringDelegatorObj.instance_variables
+
+    assert_equal [], String.instance_variables
+  end
+
   def test_methods_added_in_namespace_are_invisible_globally
     pend unless Namespace.enabled?
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1248,7 +1248,7 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
                 }
             }
 
-            fields_obj = RCLASS_FIELDS_OBJ(obj);
+            fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(obj);
             if (!fields_obj) {
                 return default_value;
             }


### PR DESCRIPTION
Now that classes fields are delegated to an object with its own shape_id, we no longer need to mark all classes as TOO_COMPLEX.