### PR TITLE
Add locks around accesses/modifications to global encodings table

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -93,12 +93,16 @@ static rb_encoding *global_enc_ascii,
                    *global_enc_utf_8,
                    *global_enc_us_ascii;
 
+// re-entrant lock
 #define GLOBAL_ENC_TABLE_LOCKING(tbl) \
     for (struct enc_table *tbl = &global_enc_table, **locking = &tbl; \
          locking; \
          locking = NULL) \
         RB_VM_LOCKING()
+#define GLOBAL_ENC_TABLE_LOCK_ENTER_LEV(tbl, lev) struct enc_table *tbl = &global_enc_table; RB_VM_LOCK_ENTER_LEV(lev)
+#define GLOBAL_ENC_TABLE_LOCK_LEAVE_LEV(lev) RB_VM_LOCK_LEAVE_LEV(lev)
 
+#define ASSERT_GLOBAL_ENC_TABLE_LOCKED() ASSERT_vm_locking()
 
 #define ENC_DUMMY_FLAG (1<<24)
 #define ENC_INDEX_MASK (~(~0U<<24))
@@ -140,6 +144,7 @@ enc_new(rb_encoding *encoding)
 static void
 enc_list_update(int index, rb_raw_encoding *encoding)
 {
+    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     RUBY_ASSERT(index < ENCODING_LIST_CAPA);
 
     VALUE list = rb_encoding_list;
@@ -155,9 +160,11 @@ enc_list_lookup(int idx)
     VALUE list, enc = Qnil;
 
     if (idx < ENCODING_LIST_CAPA) {
-        list = rb_encoding_list;
-        RUBY_ASSERT(list);
-        enc = rb_ary_entry(list, idx);
+        GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+            list = rb_encoding_list;
+            RUBY_ASSERT(list);
+            enc = rb_ary_entry(list, idx);
+        }
     }
 
     if (NIL_P(enc)) {
@@ -344,6 +351,7 @@ enc_table_expand(struct enc_table *enc_table, int newsize)
 static int
 enc_register_at(struct enc_table *enc_table, int index, const char *name, rb_encoding *base_encoding)
 {
+    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     struct rb_encoding_entry *ent = &enc_table->list[index];
     rb_raw_encoding *encoding;
 
@@ -376,6 +384,7 @@ enc_register_at(struct enc_table *enc_table, int index, const char *name, rb_enc
 static int
 enc_register(struct enc_table *enc_table, const char *name, rb_encoding *encoding)
 {
+    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     int index = enc_table->count;
 
     enc_table->count = enc_table_expand(enc_table, index + 1);
@@ -388,28 +397,47 @@ static int enc_registered(struct enc_table *enc_table, const char *name);
 static rb_encoding *
 enc_from_index(struct enc_table *enc_table, int index)
 {
-    if (UNLIKELY(index < 0 || enc_table->count <= (index &= ENC_INDEX_MASK))) {
-        return 0;
-    }
+    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     return enc_table->list[index].enc;
 }
 
 rb_encoding *
 rb_enc_from_index(int index)
 {
-    return enc_from_index(&global_enc_table, index);
+    rb_encoding *enc;
+    switch (index) {
+        case ENCINDEX_US_ASCII:
+            return global_enc_us_ascii;
+        case ENCINDEX_UTF_8:
+            return global_enc_utf_8;
+        case ENCINDEX_ASCII_8BIT:
+            return global_enc_ascii;
+        default:
+            break;
+    }
+    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+        if (UNLIKELY(index < 0 || enc_table->count <= (index &= ENC_INDEX_MASK))) {
+            enc = NULL;
+        }
+        else {
+            enc = enc_from_index(enc_table, index);
+        }
+    }
+    return enc;
 }
 
 int
 rb_enc_register(const char *name, rb_encoding *encoding)
 {
     int index;
+    unsigned int lev;
 
-    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+    GLOBAL_ENC_TABLE_LOCK_ENTER_LEV(enc_table, &lev);
+    {
         index = enc_registered(enc_table, name);
 
         if (index >= 0) {
-            rb_encoding *oldenc = enc_from_index(enc_table, index);
+            rb_encoding *oldenc = rb_enc_from_index(index);
             if (STRCASECMP(name, rb_enc_name(oldenc))) {
                 index = enc_register(enc_table, name, encoding);
             }
@@ -417,6 +445,7 @@ rb_enc_register(const char *name, rb_encoding *encoding)
                 enc_register_at(enc_table, index, name, encoding);
             }
             else {
+                GLOBAL_ENC_TABLE_LOCK_LEAVE_LEV(&lev);
                 rb_raise(rb_eArgError, "encoding %s is already registered", name);
             }
         }
@@ -425,6 +454,7 @@ rb_enc_register(const char *name, rb_encoding *encoding)
             set_encoding_const(name, rb_enc_from_index(index));
         }
     }
+    GLOBAL_ENC_TABLE_LOCK_LEAVE_LEV(&lev);
     return index;
 }
 
@@ -432,6 +462,7 @@ int
 enc_registered(struct enc_table *enc_table, const char *name)
 {
     st_data_t idx = 0;
+    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
 
     if (!name) return -1;
     if (!enc_table->names) return -1;
@@ -467,6 +498,7 @@ enc_check_addable(struct enc_table *enc_table, const char *name)
 static rb_encoding*
 set_base_encoding(struct enc_table *enc_table, int index, rb_encoding *base)
 {
+    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     rb_encoding *enc = enc_table->list[index].enc;
 
     ASSUME(enc);
@@ -504,6 +536,7 @@ static int
 enc_replicate(struct enc_table *enc_table, const char *name, rb_encoding *encoding)
 {
     int idx;
+    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
 
     enc_check_addable(enc_table, name);
     idx = enc_register(enc_table, name, encoding);
@@ -637,6 +670,7 @@ enc_dup_name(st_data_t name)
 static int
 enc_alias_internal(struct enc_table *enc_table, const char *alias, int idx)
 {
+    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     return st_insert2(enc_table->names, (st_data_t)alias, (st_data_t)idx,
                       enc_dup_name);
 }
@@ -644,9 +678,10 @@ enc_alias_internal(struct enc_table *enc_table, const char *alias, int idx)
 static int
 enc_alias(struct enc_table *enc_table, const char *alias, int idx)
 {
+    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     if (!valid_encoding_name_p(alias)) return -1;
     if (!enc_alias_internal(enc_table, alias, idx))
-        set_encoding_const(alias, enc_from_index(enc_table, idx));
+        set_encoding_const(alias, rb_enc_from_index(idx));
     return idx;
 }
 
@@ -728,6 +763,7 @@ int rb_require_internal_silent(VALUE fname);
 static int
 load_encoding(const char *name)
 {
+    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     VALUE enclib = rb_sprintf("enc/%s.so", name);
     VALUE debug = ruby_debug;
     VALUE errinfo;
@@ -747,16 +783,14 @@ load_encoding(const char *name)
     ruby_debug = debug;
     rb_set_errinfo(errinfo);
 
-    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
-        if (loaded < 0 || 1 < loaded) {
-            idx = -1;
-        }
-        else if ((idx = enc_registered(enc_table, name)) < 0) {
-            idx = -1;
-        }
-        else if (rb_enc_autoload_p(enc_table->list[idx].enc)) {
-            idx = -1;
-        }
+    if (loaded < 0 || 1 < loaded) {
+        idx = -1;
+    }
+    else if ((idx = enc_registered(&global_enc_table, name)) < 0) {
+        idx = -1;
+    }
+    else if (rb_enc_autoload_p(global_enc_table.list[idx].enc)) {
+        idx = -1;
     }
 
     return idx;
@@ -765,6 +799,7 @@ load_encoding(const char *name)
 static int
 enc_autoload_body(struct enc_table *enc_table, rb_encoding *enc)
 {
+    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     rb_encoding *base = enc_table->list[ENC_TO_ENCINDEX(enc)].base;
 
     if (base) {
@@ -792,9 +827,9 @@ rb_enc_autoload(rb_encoding *enc)
     int i;
     GLOBAL_ENC_TABLE_LOCKING(enc_table) {
         i = enc_autoload_body(enc_table, enc);
-    }
-    if (i == -2) {
-        i = load_encoding(rb_enc_name(enc));
+        if (i == -2) {
+            i = load_encoding(rb_enc_name(enc));
+        }
     }
     return i;
 }
@@ -803,13 +838,24 @@ rb_enc_autoload(rb_encoding *enc)
 int
 rb_enc_find_index(const char *name)
 {
-    int i = enc_registered(&global_enc_table, name);
-    rb_encoding *enc;
-
-    if (i < 0) {
-        i = load_encoding(name);
+    int i;
+    rb_encoding *enc = NULL;
+    bool loaded_encoding = false;
+    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+        i = enc_registered(enc_table, name);
+        if (i < 0) {
+            i = load_encoding(name);
+            loaded_encoding = true;
+        }
+        else {
+            enc = rb_enc_from_index(i);
+        }
     }
-    else if (!(enc = rb_enc_from_index(i))) {
+    if (loaded_encoding) {
+        return i;
+    }
+
+    if (!enc) {
         if (i != UNSPECIFIED_ENCODING) {
             rb_raise(rb_eArgError, "encoding %s is not registered", name);
         }
@@ -838,9 +884,13 @@ rb_enc_find_index2(const char *name, long len)
 rb_encoding *
 rb_enc_find(const char *name)
 {
-    int idx = rb_enc_find_index(name);
-    if (idx < 0) idx = 0;
-    return rb_enc_from_index(idx);
+    rb_encoding *enc;
+    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+        int idx = rb_enc_find_index(name);
+        if (idx < 0) idx = 0;
+        enc = rb_enc_from_index(idx);
+    }
+    return enc;
 }
 
 static inline int
@@ -1309,7 +1359,9 @@ enc_names(VALUE self)
 
     args[0] = (VALUE)rb_to_encoding_index(self);
     args[1] = rb_ary_new2(0);
-    st_foreach(global_enc_table.names, enc_names_i, (st_data_t)args);
+    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+        st_foreach(enc_table->names, enc_names_i, (st_data_t)args);
+    }
     return args[1];
 }
 
@@ -1484,14 +1536,14 @@ rb_locale_encindex(void)
 
     if (idx < 0) idx = ENCINDEX_UTF_8;
 
-    if (enc_registered(&global_enc_table, "locale") < 0) {
+    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+        if (enc_registered(enc_table, "locale") < 0) {
 # if defined _WIN32
-        void Init_w32_codepage(void);
-        Init_w32_codepage();
+            void Init_w32_codepage(void);
+            Init_w32_codepage();
 # endif
-        GLOBAL_ENC_TABLE_LOCKING(enc_table) {
-            enc_alias_internal(enc_table, "locale", idx);
         }
+        enc_alias_internal(enc_table, "locale", idx);
     }
 
     return idx;
@@ -1506,7 +1558,10 @@ rb_locale_encoding(void)
 int
 rb_filesystem_encindex(void)
 {
-    int idx = enc_registered(&global_enc_table, "filesystem");
+    int idx;
+    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+        idx = enc_registered(enc_table, "filesystem");
+    }
     if (idx < 0) idx = ENCINDEX_ASCII_8BIT;
     return idx;
 }
@@ -1564,15 +1619,21 @@ enc_set_default_encoding(struct default_encoding *def, VALUE encoding, const cha
 rb_encoding *
 rb_default_external_encoding(void)
 {
-    if (default_external.enc) return default_external.enc;
-
-    if (default_external.index >= 0) {
-        default_external.enc = rb_enc_from_index(default_external.index);
-        return default_external.enc;
+    rb_encoding *enc = NULL;
+    // TODO: make lock-free
+    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+        if (default_external.enc) {
+            enc = default_external.enc;
+        }
+        else if (default_external.index >= 0) {
+            default_external.enc = rb_enc_from_index(default_external.index);
+            enc = default_external.enc;
+        }
+        else {
+            enc = rb_locale_encoding();
+        }
     }
-    else {
-        return rb_locale_encoding();
-    }
+    return enc;
 }
 
 VALUE
@@ -1651,10 +1712,15 @@ static struct default_encoding default_internal = {-2};
 rb_encoding *
 rb_default_internal_encoding(void)
 {
-    if (!default_internal.enc && default_internal.index >= 0) {
-        default_internal.enc = rb_enc_from_index(default_internal.index);
+    rb_encoding *enc = NULL;
+    // TODO: make lock-free
+    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+        if (!default_internal.enc && default_internal.index >= 0) {
+            default_internal.enc = rb_enc_from_index(default_internal.index);
+        }
+        enc = default_internal.enc;
     }
-    return default_internal.enc; /* can be NULL */
+    return enc; /* can be NULL */
 }
 
 VALUE
@@ -1803,8 +1869,11 @@ rb_enc_name_list_i(st_data_t name, st_data_t idx, st_data_t arg)
 static VALUE
 rb_enc_name_list(VALUE klass)
 {
-    VALUE ary = rb_ary_new2(global_enc_table.names->num_entries);
-    st_foreach(global_enc_table.names, rb_enc_name_list_i, (st_data_t)ary);
+    VALUE ary;
+    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+        ary = rb_ary_new2(enc_table->names->num_entries);
+        st_foreach(enc_table->names, rb_enc_name_list_i, (st_data_t)ary);
+    }
     return ary;
 }
 
@@ -1850,7 +1919,9 @@ rb_enc_aliases(VALUE klass)
     aliases[0] = rb_hash_new();
     aliases[1] = rb_ary_new();
 
-    st_foreach(global_enc_table.names, rb_enc_aliases_enc_i, (st_data_t)aliases);
+    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+        st_foreach(enc_table->names, rb_enc_aliases_enc_i, (st_data_t)aliases);
+    }
 
     return aliases[0];
 }
@@ -1951,5 +2022,7 @@ Init_encodings(void)
 void
 rb_enc_foreach_name(int (*func)(st_data_t name, st_data_t idx, st_data_t arg), st_data_t arg)
 {
-    st_foreach(global_enc_table.names, func, arg);
+    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+        st_foreach(enc_table->names, func, arg);
+    }
 }

--- a/encoding.c
+++ b/encoding.c
@@ -26,6 +26,7 @@
 #include "regenc.h"
 #include "ruby/encoding.h"
 #include "ruby/util.h"
+#include "ruby/atomic.h"
 #include "ruby_assert.h"
 #include "vm_sync.h"
 
@@ -51,6 +52,12 @@ int rb_encdb_replicate(const char *name, const char *orig);
 int rb_encdb_dummy(const char *name);
 int rb_encdb_alias(const char *alias, const char *orig);
 #pragma GCC visibility pop
+#endif
+
+#if ENC_DEBUG
+#define encdebug(...) fprintf(stderr, __VA_ARGS__)
+#else
+#define encdebug(...) (void)0
 #endif
 
 static ID id_encoding;
@@ -144,11 +151,11 @@ enc_new(rb_encoding *encoding)
 static void
 enc_list_update(int index, rb_raw_encoding *encoding)
 {
-    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     RUBY_ASSERT(index < ENCODING_LIST_CAPA);
 
     VALUE list = rb_encoding_list;
     if (list && NIL_P(rb_ary_entry(list, index))) {
+        RUBY_ASSERT(!rb_multi_ractor_p());
         /* initialize encoding data */
         rb_ary_store(list, index, enc_new(encoding));
     }
@@ -160,11 +167,9 @@ enc_list_lookup(int idx)
     VALUE list, enc = Qnil;
 
     if (idx < ENCODING_LIST_CAPA) {
-        GLOBAL_ENC_TABLE_LOCKING(enc_table) {
-            list = rb_encoding_list;
-            RUBY_ASSERT(list);
-            enc = rb_ary_entry(list, idx);
-        }
+        list = rb_encoding_list;
+        RUBY_ASSERT(list);
+        enc = rb_ary_entry(list, idx);
     }
 
     if (NIL_P(enc)) {
@@ -206,10 +211,13 @@ static int
 check_encoding(rb_encoding *enc)
 {
     int index = rb_enc_to_index(enc);
-    if (rb_enc_from_index(index) != enc)
+    if (rb_enc_from_index(index) != enc) {
+        encdebug("check_encoding(%s): rb_enc_from_index(index) != enc, return -1\n", rb_enc_name(enc));
         return -1;
+    }
     if (rb_enc_autoload_p(enc)) {
         index = rb_enc_autoload(enc);
+        encdebug("check_encoding(%s): rb_enc_autoload_p(enc), index after autoload:%d\n", rb_enc_name(enc), index);
     }
     return index;
 }
@@ -340,7 +348,7 @@ rb_find_encoding(VALUE enc)
 }
 
 static int
-enc_table_expand(struct enc_table *enc_table, int newsize)
+enc_table_count_check(int newsize)
 {
     if (newsize > ENCODING_LIST_CAPA) {
         rb_raise(rb_eEncodingError, "too many encoding (> %d)", ENCODING_LIST_CAPA);
@@ -348,46 +356,49 @@ enc_table_expand(struct enc_table *enc_table, int newsize)
     return newsize;
 }
 
+// If called with a `base_encoding` of NULL, it is an autoloaded encoding
 static int
 enc_register_at(struct enc_table *enc_table, int index, const char *name, rb_encoding *base_encoding)
 {
-    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     struct rb_encoding_entry *ent = &enc_table->list[index];
     rb_raw_encoding *encoding;
-
     if (!valid_encoding_name_p(name)) return -1;
-    if (!ent->name) {
-        ent->name = name = strdup(name);
+    GLOBAL_ENC_TABLE_LOCKING(table) {
+        if (!ent->name) {
+            ent->name = name = strdup(name);
+        }
+        else if (STRCASECMP(name, ent->name)) {
+            index = -1;
+        }
+        if (index != -1) {
+            encoding = (rb_raw_encoding *)ent->enc;
+            if (!encoding) {
+                encoding = xmalloc(sizeof(rb_encoding));
+            }
+            if (base_encoding) {
+                *encoding = *base_encoding;
+            }
+            else {
+                memset(encoding, 0, sizeof(*ent->enc));
+            }
+            encoding->name = name;
+            ent->enc = encoding;
+            st_insert(table->names, (st_data_t)name, (st_data_t)index);
+            enc_list_update(index, encoding);
+            encoding->ruby_encoding_index = index;
+        }
     }
-    else if (STRCASECMP(name, ent->name)) {
-        return -1;
-    }
-    encoding = (rb_raw_encoding *)ent->enc;
-    if (!encoding) {
-        encoding = xmalloc(sizeof(rb_encoding));
-    }
-    if (base_encoding) {
-        *encoding = *base_encoding;
-    }
-    else {
-        memset(encoding, 0, sizeof(*ent->enc));
-    }
-    encoding->name = name;
-    encoding->ruby_encoding_index = index;
-    ent->enc = encoding;
-    st_insert(enc_table->names, (st_data_t)name, (st_data_t)index);
 
-    enc_list_update(index, encoding);
     return index;
 }
 
 static int
 enc_register(struct enc_table *enc_table, const char *name, rb_encoding *encoding)
 {
-    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     int index = enc_table->count;
+    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
 
-    enc_table->count = enc_table_expand(enc_table, index + 1);
+    enc_table->count = enc_table_count_check(index + 1);
     return enc_register_at(enc_table, index, name, encoding);
 }
 
@@ -397,43 +408,30 @@ static int enc_registered(struct enc_table *enc_table, const char *name);
 static rb_encoding *
 enc_from_index(struct enc_table *enc_table, int index)
 {
-    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     return enc_table->list[index].enc;
 }
 
+// NOTE: there is no lock needed here, even with multi-ractor
 rb_encoding *
 rb_enc_from_index(int index)
 {
     rb_encoding *enc;
-    switch (index) {
-        case ENCINDEX_US_ASCII:
-            return global_enc_us_ascii;
-        case ENCINDEX_UTF_8:
-            return global_enc_utf_8;
-        case ENCINDEX_ASCII_8BIT:
-            return global_enc_ascii;
-        default:
-            break;
+    if (UNLIKELY(index < 0 || global_enc_table.count <= (index &= ENC_INDEX_MASK))) {
+        enc = NULL;
     }
-    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
-        if (UNLIKELY(index < 0 || enc_table->count <= (index &= ENC_INDEX_MASK))) {
-            enc = NULL;
-        }
-        else {
-            enc = enc_from_index(enc_table, index);
-        }
+    else {
+        enc = enc_from_index(&global_enc_table, index);
     }
     return enc;
 }
 
+// This can be called from non-main ractors during autoloading of encodings
 int
 rb_enc_register(const char *name, rb_encoding *encoding)
 {
     int index;
-    unsigned int lev;
 
-    GLOBAL_ENC_TABLE_LOCK_ENTER_LEV(enc_table, &lev);
-    {
+    GLOBAL_ENC_TABLE_LOCKING(enc_table) {
         index = enc_registered(enc_table, name);
 
         if (index >= 0) {
@@ -445,7 +443,6 @@ rb_enc_register(const char *name, rb_encoding *encoding)
                 enc_register_at(enc_table, index, name, encoding);
             }
             else {
-                GLOBAL_ENC_TABLE_LOCK_LEAVE_LEV(&lev);
                 rb_raise(rb_eArgError, "encoding %s is already registered", name);
             }
         }
@@ -454,14 +451,14 @@ rb_enc_register(const char *name, rb_encoding *encoding)
             set_encoding_const(name, rb_enc_from_index(index));
         }
     }
-    GLOBAL_ENC_TABLE_LOCK_LEAVE_LEV(&lev);
     return index;
 }
 
-int
+static int
 enc_registered(struct enc_table *enc_table, const char *name)
 {
     st_data_t idx = 0;
+
     ASSERT_GLOBAL_ENC_TABLE_LOCKED();
 
     if (!name) return -1;
@@ -472,6 +469,7 @@ enc_registered(struct enc_table *enc_table, const char *name)
     return -1;
 }
 
+// Set up an encoding with a zeroed out entry->enc, which means it will be autoloaded
 void
 rb_encdb_declare(const char *name)
 {
@@ -498,7 +496,6 @@ enc_check_addable(struct enc_table *enc_table, const char *name)
 static rb_encoding*
 set_base_encoding(struct enc_table *enc_table, int index, rb_encoding *base)
 {
-    ASSERT_GLOBAL_ENC_TABLE_LOCKED();
     rb_encoding *enc = enc_table->list[index].enc;
 
     ASSUME(enc);
@@ -565,6 +562,7 @@ enc_replicate_with_index(struct enc_table *enc_table, const char *name, rb_encod
     return idx;
 }
 
+// Setup a new encoding `name` that it a copy of `orig`, with a base of `orig`. Set `name` as dummy if `orig` is dummy.
 int
 rb_encdb_replicate(const char *name, const char *orig)
 {
@@ -723,7 +721,7 @@ rb_encdb_alias(const char *alias, const char *orig)
 static void
 rb_enc_init(struct enc_table *enc_table)
 {
-    enc_table_expand(enc_table, ENCODING_COUNT + 1);
+    enc_table_count_check(ENCODING_COUNT + 1);
     if (!enc_table->names) {
         enc_table->names = st_init_strcasetable_with_size(ENCODING_LIST_CAPA);
     }
@@ -777,6 +775,7 @@ load_encoding(const char *name)
         ++s;
     }
     enclib = rb_fstring(enclib);
+    encdebug("load_encoding(%s)\n", RSTRING_PTR(enclib));
     ruby_debug = Qfalse;
     errinfo = rb_errinfo();
     loaded = rb_require_internal_silent(enclib);
@@ -784,15 +783,19 @@ load_encoding(const char *name)
     rb_set_errinfo(errinfo);
 
     if (loaded < 0 || 1 < loaded) {
+        encdebug("BAD load_encoding(%s): %d\n", name, loaded);
         idx = -1;
     }
     else if ((idx = enc_registered(&global_enc_table, name)) < 0) {
+        encdebug("load_encoding(%s) after, enc_registered(name) < 0: %d\n", name, idx);
         idx = -1;
     }
     else if (rb_enc_autoload_p(global_enc_table.list[idx].enc)) {
+        encdebug("load_encoding(%s) after, enc_autoload_p still true\n", name);
         idx = -1;
     }
 
+    encdebug("load_encoding(%s) returned index: %d\n", name, idx);
     return idx;
 }
 
@@ -811,6 +814,7 @@ enc_autoload_body(struct enc_table *enc_table, rb_encoding *enc)
             if (rb_enc_autoload(base) < 0) return -1;
         }
         i = enc->ruby_encoding_index;
+        encdebug("enc_autoload_body of enc %s from base %s\n", rb_enc_name(enc), rb_enc_name(base));
         enc_register_at(enc_table, i & ENC_INDEX_MASK, rb_enc_name(enc), base);
         ((rb_raw_encoding *)enc)->ruby_encoding_index = i;
         i &= ENC_INDEX_MASK;
@@ -826,15 +830,25 @@ rb_enc_autoload(rb_encoding *enc)
 {
     int i;
     GLOBAL_ENC_TABLE_LOCKING(enc_table) {
-        i = enc_autoload_body(enc_table, enc);
-        if (i == -2) {
-            i = load_encoding(rb_enc_name(enc));
+        if (rb_enc_autoload_p(enc)) {
+            i = enc_autoload_body(enc_table, enc);
+            if (i == -2) {
+                i = load_encoding(rb_enc_name(enc));
+                encdebug("enc_autoload_body returned -2 (no base), loaded encoding %s, got ret i=%d\n", rb_enc_name(enc), i);
+            }
+            else if (i == -1) {
+                encdebug("enc_autoload_body returned -1 for encoding %s, autoload failed\n", rb_enc_name(enc));
+            }
+        }
+        else {
+            encdebug("already autoloaded: %s\n", rb_enc_name(enc));
+            i = check_encoding(enc);
         }
     }
     return i;
 }
 
-/* Return encoding index or UNSPECIFIED_ENCODING from encoding name */
+/* Return encoding index or UNSPECIFIED_ENCODING from encoding name. Loads autoloaded and unregistered encodings. */
 int
 rb_enc_find_index(const char *name)
 {
@@ -844,6 +858,7 @@ rb_enc_find_index(const char *name)
     GLOBAL_ENC_TABLE_LOCKING(enc_table) {
         i = enc_registered(enc_table, name);
         if (i < 0) {
+            encdebug("rb_enc_find_index not found, loading encoding %s\n", name);
             i = load_encoding(name);
             loaded_encoding = true;
         }
@@ -864,7 +879,7 @@ rb_enc_find_index(const char *name)
         if (rb_enc_autoload(enc) < 0) {
             rb_warn("failed to load encoding (%s); use ASCII-8BIT instead",
                     name);
-            return 0;
+            return ENCINDEX_ASCII_8BIT;
         }
     }
     return i;
@@ -1584,14 +1599,15 @@ enc_set_default_encoding(struct default_encoding *def, VALUE encoding, const cha
 {
     int overridden = FALSE;
 
-    if (def->index != -2)
-        /* Already set */
-        overridden = TRUE;
-
     GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+        if (def->index != -2) {
+            /* Already set */
+            overridden = TRUE;
+        }
         if (NIL_P(encoding)) {
+            RUBY_ASSERT(def != &default_external);
             def->index = -1;
-            def->enc = 0;
+            RUBY_ATOMIC_PTR_SET(def->enc, 0);
             char *name_dup = strdup(name);
 
             st_data_t existing_name = (st_data_t)name_dup;
@@ -1603,9 +1619,10 @@ enc_set_default_encoding(struct default_encoding *def, VALUE encoding, const cha
                       (st_data_t)UNSPECIFIED_ENCODING);
         }
         else {
-            def->index = rb_enc_to_index(rb_to_encoding(encoding));
-            def->enc = 0;
+            rb_encoding *enc = rb_to_encoding(encoding); // NOTE: this autoloads the encoding if necessary
+            def->index = rb_enc_to_index(enc);
             enc_alias_internal(enc_table, name, def->index);
+            RUBY_ATOMIC_PTR_SET(def->enc, 0);
         }
 
         if (def == &default_external) {
@@ -1619,15 +1636,18 @@ enc_set_default_encoding(struct default_encoding *def, VALUE encoding, const cha
 rb_encoding *
 rb_default_external_encoding(void)
 {
-    rb_encoding *enc = NULL;
-    // TODO: make lock-free
+    rb_encoding *enc;
+    enc = (rb_encoding*)RUBY_ATOMIC_PTR_LOAD(default_external.enc);
+    if (enc) {
+        return enc;
+    }
     GLOBAL_ENC_TABLE_LOCKING(enc_table) {
         if (default_external.enc) {
             enc = default_external.enc;
         }
         else if (default_external.index >= 0) {
-            default_external.enc = rb_enc_from_index(default_external.index);
-            enc = default_external.enc;
+            enc = rb_enc_from_index(default_external.index);
+            RUBY_ATOMIC_PTR_SET(default_external.enc, (void*)enc);
         }
         else {
             enc = rb_locale_encoding();
@@ -1712,15 +1732,20 @@ static struct default_encoding default_internal = {-2};
 rb_encoding *
 rb_default_internal_encoding(void)
 {
-    rb_encoding *enc = NULL;
-    // TODO: make lock-free
+    rb_encoding *enc = RUBY_ATOMIC_PTR_LOAD(default_internal.enc);
+    if (enc) {
+        return enc;
+    }
+    else if (default_internal.index < 0) {
+        return NULL;
+    }
     GLOBAL_ENC_TABLE_LOCKING(enc_table) {
         if (!default_internal.enc && default_internal.index >= 0) {
-            default_internal.enc = rb_enc_from_index(default_internal.index);
+            enc = rb_enc_from_index(default_internal.index);
+            RUBY_ATOMIC_PTR_SET(default_internal.enc, (void*)enc);
         }
-        enc = default_internal.enc;
     }
-    return enc; /* can be NULL */
+    return enc;
 }
 
 VALUE
@@ -1962,6 +1987,7 @@ Init_Encoding(void)
 {
     VALUE list;
     int i;
+    encdebug("Init_Encoding\n");
 
     rb_cEncoding = rb_define_class("Encoding", rb_cObject);
     rb_define_alloc_func(rb_cEncoding, enc_s_alloc);
@@ -1993,6 +2019,7 @@ Init_Encoding(void)
     RBASIC_CLEAR_CLASS(list);
     rb_vm_register_global_object(list);
 
+    encdebug("enc_table->count: %d\n", enc_table->count);
     for (i = 0; i < enc_table->count; ++i) {
         rb_ary_push(list, enc_new(enc_table->list[i].enc));
     }
@@ -2014,6 +2041,7 @@ Init_unicode_version(void)
 void
 Init_encodings(void)
 {
+    encdebug("Init_encodings\n");
     rb_enc_init(&global_enc_table);
 }
 

--- a/test/ruby/test_encoding.rb
+++ b/test/ruby/test_encoding.rb
@@ -144,7 +144,9 @@ class TestEncoding < Test::Unit::TestCase
       rs = []
       100.times do
         rs << Ractor.new do
-          "abc".force_encoding(Encoding.list.shuffle.first)
+          10_000.times do
+            "abc".force_encoding(Encoding.list.shuffle.first)
+          end
         end
       end
       while rs.any?

--- a/test/ruby/test_encoding.rb
+++ b/test/ruby/test_encoding.rb
@@ -136,4 +136,22 @@ class TestEncoding < Test::Unit::TestCase
       assert "[Bug #19562]"
     end;
   end
+
+  def test_ractor_force_encoding_parallel
+    assert_ractor("#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      $-w = nil
+      rs = []
+      100.times do
+        rs << Ractor.new do
+          "abc".force_encoding(Encoding.list.shuffle.first)
+        end
+      end
+      while rs.any?
+        r, _obj = Ractor.select(*rs)
+        rs.delete(r)
+      end
+      assert rs.empty?
+    end;
+  end
 end


### PR DESCRIPTION
Add locks around accesses/modifications to global encodings table

This fixes segfaults and errors of the type "Encoding not found" when
using encoding-related methods and internal encoding c functions across
ractors.

Example of a possible segfault in release mode or assertion error in debug mode:

```ruby
rs = []
100.times do
  rs << Ractor.new do
    "abc".force_encoding(Encoding.list.shuffle.first)
  end
end
while rs.any?
  r, obj = Ractor.select(*rs)
  rs.delete(r)
end
```