### PR TITLE
[Bug #21440] Stop caching member list in frozen Data/Struct class

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -52,7 +52,8 @@ struct_ivar_get(VALUE c, ID id)
         RUBY_ASSERT(RB_TYPE_P(c, T_CLASS));
         ivar = rb_attr_get(c, id);
         if (!NIL_P(ivar)) {
-            return rb_ivar_set(orig, id, ivar);
+            if (!OBJ_FROZEN(orig)) rb_ivar_set(orig, id, ivar);
+            return ivar;
         }
     }
 }

--- a/test/ruby/test_data.rb
+++ b/test/ruby/test_data.rb
@@ -280,4 +280,10 @@ class TestData < Test::Unit::TestCase
     assert_not_same(test, loaded)
     assert_predicate(loaded, :frozen?)
   end
+
+  def test_frozen_subclass
+    test = Class.new(Data.define(:a)).freeze.new(a: 0)
+    assert_kind_of(Data, test)
+    assert_equal([:a], test.members)
+  end
 end

--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -550,6 +550,12 @@ module TestStruct
     CODE
   end
 
+  def test_frozen_subclass
+    test = Class.new(@Struct.new(:a)).freeze.new(a: 0)
+    assert_kind_of(@Struct, test)
+    assert_equal([:a], test.members)
+  end
+
   class TopStruct < Test::Unit::TestCase
     include TestStruct
 


### PR DESCRIPTION
[[Bug #21440]](https://bugs.ruby-lang.org/issues/21440)