### PR TITLE
shape.c: cleanup unused IDs

### DIFF
--- a/shape.h
+++ b/shape.h
@@ -45,8 +45,6 @@ typedef uint32_t redblack_id_t;
 #define ROOT_TOO_COMPLEX_WITH_OBJ_ID    (ROOT_SHAPE_WITH_OBJ_ID | SHAPE_ID_FL_TOO_COMPLEX | SHAPE_ID_FL_HAS_OBJECT_ID)
 #define SPECIAL_CONST_SHAPE_ID          (ROOT_SHAPE_ID | SHAPE_ID_FL_FROZEN)
 
-extern ID ruby_internal_object_id;
-
 typedef struct redblack_node redblack_node_t;
 
 struct rb_shape {


### PR DESCRIPTION
`id_frozen` and `id_t_object` are no longer used.
`id_object_id` no longer need to be exposed.