### PR TITLE
ZJIT: Partially enable btest on CI

### DIFF
--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -42,6 +42,9 @@ jobs:
             configure: '--enable-zjit=dev'
             tests: '../src/test/ruby/test_zjit.rb'
 
+          - test_task: 'btest'
+            configure: '--enable-zjit=dev'
+
     env:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
       RUN_OPTS: ${{ matrix.zjit_opts }}
@@ -100,6 +103,45 @@ jobs:
           ruby -ne 'raise "Disassembly seems broken in dev build (output has too few lines)" unless $_.to_i > 10'
         if: ${{ contains(matrix.configure, 'jit=dev') }}
 
+      - name: btest
+        run: |
+          RUST_BACKTRACE=1 ruby --disable=gems ../src/bootstraptest/runner.rb --ruby="./miniruby -I../src/lib -I. -I.ext/common --zjit-call-threshold=1" \
+          ../src/bootstraptest/test_attr.rb \
+          ../src/bootstraptest/test_constant_cache.rb \
+          ../src/bootstraptest/test_env.rb \
+          ../src/bootstraptest/test_finalizer.rb \
+          ../src/bootstraptest/test_flip.rb \
+          ../src/bootstraptest/test_literal.rb \
+          ../src/bootstraptest/test_literal_suffix.rb \
+          ../src/bootstraptest/test_string.rb \
+          ../src/bootstraptest/test_struct.rb \
+          ../src/bootstraptest/test_yjit_30k_ifelse.rb \
+          ../src/bootstraptest/test_yjit_30k_methods.rb
+        # ../src/bootstraptest/test_autoload.rb \
+        # ../src/bootstraptest/test_block.rb \
+        # ../src/bootstraptest/test_class.rb \
+        # ../src/bootstraptest/test_eval.rb \
+        # ../src/bootstraptest/test_exception.rb \
+        # ../src/bootstraptest/test_fiber.rb \
+        # ../src/bootstraptest/test_flow.rb \
+        # ../src/bootstraptest/test_fork.rb \
+        # ../src/bootstraptest/test_gc.rb \
+        # ../src/bootstraptest/test_insns.rb \
+        # ../src/bootstraptest/test_io.rb \
+        # ../src/bootstraptest/test_jump.rb \
+        # ../src/bootstraptest/test_load.rb \
+        # ../src/bootstraptest/test_marshal.rb \
+        # ../src/bootstraptest/test_massign.rb \
+        # ../src/bootstraptest/test_method.rb \
+        # ../src/bootstraptest/test_objectspace.rb \
+        # ../src/bootstraptest/test_proc.rb \
+        # ../src/bootstraptest/test_ractor.rb \
+        # ../src/bootstraptest/test_syntax.rb \
+        # ../src/bootstraptest/test_thread.rb \
+        # ../src/bootstraptest/test_yjit.rb \
+        # ../src/bootstraptest/test_yjit_rust_port.rb \
+        if: ${{ matrix.test_task == 'btest' }}
+
       - name: make ${{ matrix.test_task }}
         run: >-
           make -s ${{ matrix.test_task }} ${TESTS:+TESTS="$TESTS"}
@@ -113,6 +155,7 @@ jobs:
           PRECHECK_BUNDLED_GEMS: 'no'
           TESTS: ${{ matrix.tests }}
         continue-on-error: ${{ matrix.continue-on-test_task || false }}
+        if: ${{ matrix.test_task != 'btest' }}
 
   result:
     if: ${{ always() }}

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -44,6 +44,9 @@ jobs:
             configure: '--enable-zjit=dev'
             tests: '../src/test/ruby/test_zjit.rb'
 
+          - test_task: 'btest'
+            configure: '--enable-zjit=dev'
+
     env:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
       RUN_OPTS: ${{ matrix.zjit_opts }}
@@ -122,6 +125,45 @@ jobs:
         run: ./miniruby --zjit -v | grep "+ZJIT"
         if: ${{ matrix.configure != '--disable-zjit' }}
 
+      - name: btest
+        run: |
+          RUST_BACKTRACE=1 ruby --disable=gems ../src/bootstraptest/runner.rb --ruby="./miniruby -I../src/lib -I. -I.ext/common --zjit-call-threshold=1" \
+          ../src/bootstraptest/test_attr.rb \
+          ../src/bootstraptest/test_constant_cache.rb \
+          ../src/bootstraptest/test_env.rb \
+          ../src/bootstraptest/test_finalizer.rb \
+          ../src/bootstraptest/test_flip.rb \
+          ../src/bootstraptest/test_literal.rb \
+          ../src/bootstraptest/test_literal_suffix.rb \
+          ../src/bootstraptest/test_massign.rb \
+          ../src/bootstraptest/test_string.rb \
+          ../src/bootstraptest/test_struct.rb \
+          ../src/bootstraptest/test_yjit_30k_ifelse.rb \
+          ../src/bootstraptest/test_yjit_30k_methods.rb
+        # ../src/bootstraptest/test_autoload.rb \
+        # ../src/bootstraptest/test_block.rb \
+        # ../src/bootstraptest/test_class.rb \
+        # ../src/bootstraptest/test_eval.rb \
+        # ../src/bootstraptest/test_exception.rb \
+        # ../src/bootstraptest/test_fiber.rb \
+        # ../src/bootstraptest/test_flow.rb \
+        # ../src/bootstraptest/test_fork.rb \
+        # ../src/bootstraptest/test_gc.rb \
+        # ../src/bootstraptest/test_insns.rb \
+        # ../src/bootstraptest/test_io.rb \
+        # ../src/bootstraptest/test_jump.rb \
+        # ../src/bootstraptest/test_load.rb \
+        # ../src/bootstraptest/test_marshal.rb \
+        # ../src/bootstraptest/test_method.rb \
+        # ../src/bootstraptest/test_objectspace.rb \
+        # ../src/bootstraptest/test_proc.rb \
+        # ../src/bootstraptest/test_ractor.rb \
+        # ../src/bootstraptest/test_syntax.rb \
+        # ../src/bootstraptest/test_thread.rb \
+        # ../src/bootstraptest/test_yjit.rb \
+        # ../src/bootstraptest/test_yjit_rust_port.rb \
+        if: ${{ matrix.test_task == 'btest' }}
+
       - name: make ${{ matrix.test_task }}
         run: >-
           make -s ${{ matrix.test_task }} ${TESTS:+TESTS="$TESTS"}
@@ -137,6 +179,7 @@ jobs:
           LIBCLANG_PATH: ${{ matrix.libclang_path }}
           TESTS: ${{ matrix.tests }}
         continue-on-error: ${{ matrix.continue-on-test_task || false }}
+        if: ${{ matrix.test_task != 'btest' }}
 
   result:
     if: ${{ always() }}


### PR DESCRIPTION
This PR adds a CI job to run bootstraptests that already run correctly with `--zjit-call-threshold=1`. We should enable more tests as we fix them. The setup is copied from what we used for YJIT before https://github.com/Shopify/ruby/pull/334.

Unlike YJIT, `--zjit-call-threshold=1` would miss profiling-based optimizations, but we should make `--zjit-call-threshold=1` work anyway. Since btests are not designed for `--zjit-call-threshold=2`, I didn't add such a job.