### PR TITLE
Skip the optional capi digest specs if fiddle is not installed

### DIFF
--- a/spec/ruby/optional/capi/digest_spec.rb
+++ b/spec/ruby/optional/capi/digest_spec.rb
@@ -1,6 +1,10 @@
 require_relative 'spec_helper'
 
-require 'fiddle'
+begin
+  require 'fiddle'
+rescue LoadError
+  return
+end
 
 load_extension('digest')
 


### PR DESCRIPTION
Should fix a failure on the OpenBSD RubyCI machine.