### PR TITLE
Launchable: Terminate Launchable CLI process quickly by sending singa…

### DIFF
--- a/.github/actions/compilers/entrypoint.sh
+++ b/.github/actions/compilers/entrypoint.sh
@@ -143,7 +143,7 @@ if [ "$LAUNCHABLE_ENABLED" = "true" ]; then
     btest_session_file='launchable_btest_session.txt'
     test_spec_session_file='launchable_test_spec_session.txt'
     setup_pid=$$
-    (sleep 180; echo "setup_launchable timed out; killing"; kill -INT "$setup_pid" 2> /dev/null) & sleep_pid=$!
+    (sleep 180; echo "setup_launchable timed out; killing"; kill -INT "-$setup_pid" 2> /dev/null) & sleep_pid=$!
     launchable_failed=false
     trap "launchable_failed=true" INT
     setup_launchable


### PR DESCRIPTION
…ls to a process group

Sometimes, the timeout errors occurred in Compilations workflow, this is because Launchable CLI process was not terminated correctly. To address this issue, we'll send signals to a process group.

https://github.com/ruby/ruby/actions/runs/15614867686
https://github.com/ruby/ruby/actions/runs/15662906947