### PR TITLE
ZJIT: Add codegen for StringCopy

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -31,6 +31,20 @@ class TestZJIT < Test::Unit::TestCase
     }
   end
 
+  def test_putstring
+    assert_compiles '""', %q{
+      def test = "#{""}"
+      test
+    }, insns: [:putstring]
+  end
+
+  def test_putchilldedstring
+    assert_compiles '""', %q{
+      def test = ""
+      test
+    }, insns: [:putchilledstring]
+  end
+
   def test_leave_param
     assert_compiles '5', %q{
       def test(n) = n


### PR DESCRIPTION
Prior to this commit we compiled `putstring` and `putchilledstring` to `StringCopy`, but then failed to compile past HIR.

This commit adds codegen for `StringCopy` to call `rb_ec_str_ressurrect` as the VM does for these instructions.