### PR TITLE
ZJIT: objtostring to HIR

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -444,6 +444,8 @@ pub enum Insn {
     FixnumGt   { left: InsnId, right: InsnId },
     FixnumGe   { left: InsnId, right: InsnId },
 
+    ObjToString { val: InsnId, call_info: CallInfo, cd: *const rb_call_data, state: InsnId },
+
     /// Side-exit if val doesn't have the expected type.
     GuardType { val: InsnId, guard_type: Type, state: InsnId },
     /// Side-exit if val is not the expected VALUE.
@@ -636,6 +638,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::ToNewArray { val, .. } => write!(f, "ToNewArray {val}"),
             Insn::ArrayExtend { left, right, .. } => write!(f, "ArrayExtend {left}, {right}"),
             Insn::ArrayPush { array, val, .. } => write!(f, "ArrayPush {array}, {val}"),
+            Insn::ObjToString { val, .. } => { write!(f, "ObjToString {val}") },
             Insn::SideExit { .. } => write!(f, "SideExit"),
             insn => { write!(f, "{insn:?}") }
         }
@@ -950,6 +953,12 @@ impl Function {
             FixnumGe { left, right } => FixnumGe { left: find!(*left), right: find!(*right) },
             FixnumLt { left, right } => FixnumLt { left: find!(*left), right: find!(*right) },
             FixnumLe { left, right } => FixnumLe { left: find!(*left), right: find!(*right) },
+            ObjToString { val, call_info, cd, state } => ObjToString {
+                val: find!(*val),
+                call_info: call_info.clone(),
+                cd: *cd,
+                state: *state,
+            },
             SendWithoutBlock { self_val, call_info, cd, args, state } => SendWithoutBlock {
                 self_val: find!(*self_val),
                 call_info: call_info.clone(),
@@ -1076,6 +1085,7 @@ impl Function {
             Insn::GetIvar { .. } => types::BasicObject,
             Insn::ToNewArray { .. } => types::ArrayExact,
             Insn::ToArray { .. } => types::ArrayExact,
+            Insn::ObjToString { .. } => types::BasicObject,
         }
     }
 
@@ -1282,6 +1292,14 @@ impl Function {
                         self.push_insn(block, Insn::PatchPoint(Invariant::StableConstantNames { idlist }));
                         let replacement = self.push_insn(block, Insn::Const { val: Const::Value(unsafe { (*ice).value }) });
                         self.make_equal_to(insn_id, replacement);
+                    }
+                    Insn::ObjToString { val, call_info, cd, state, .. } => {
+                        if self.is_a(val, types::StringExact) {
+                            self.make_equal_to(insn_id, val);
+                        } else {
+                            let replacement = self.push_insn(block, Insn::SendWithoutBlock { self_val: val, call_info, cd, args: vec![], state });
+                            self.make_equal_to(insn_id, replacement)
+                        }
                     }
                     _ => { self.push_insn_id(block, insn_id); }
                 }
@@ -1643,6 +1661,10 @@ impl Function {
                 }
                 Insn::ArrayPush { array, val, state } => {
                     worklist.push_back(array);
+                    worklist.push_back(val);
+                    worklist.push_back(state);
+                }
+                Insn::ObjToString { val, state, .. } => {
                     worklist.push_back(val);
                     worklist.push_back(state);
                 }
@@ -2480,6 +2502,26 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let exit_id = fun.push_insn(block, Insn::Snapshot { state: exit_state });
                     let insn_id = fun.push_insn(block, Insn::NewRange { low, high, flag, state: exit_id });
                     state.stack_push(insn_id);
+                }
+                YARVINSN_objtostring => {
+                    let cd: *const rb_call_data = get_arg(pc, 0).as_ptr();
+                    let call_info = unsafe { rb_get_call_data_ci(cd) };
+
+                    if unknown_call_type(unsafe { rb_vm_ci_flag(call_info) }) {
+                        assert!(false, "objtostring should not have unknown call type");
+                    }
+                    let argc = unsafe { vm_ci_argc((*cd).ci) };
+                    assert_eq!(0, argc, "objtostring should not have args");
+
+                    let method_name: String = unsafe {
+                        let mid = rb_vm_ci_mid(call_info);
+                        mid.contents_lossy().into_owned()
+                    };
+
+                    let recv = state.stack_pop()?;
+                    let exit_id = fun.push_insn(block, Insn::Snapshot { state: exit_state });
+                    let objtostring = fun.push_insn(block, Insn::ObjToString { val: recv, call_info: CallInfo { method_name }, cd, state: exit_id });
+                    state.stack_push(objtostring)
                 }
                 _ => {
                     // Unknown opcode; side-exit into the interpreter
@@ -3963,6 +4005,21 @@ mod tests {
               Return v10
         "#]]);
     }
+
+    #[test]
+    fn test_objtostring() {
+        eval("
+            def test = \"#{1}\"
+        ");
+        assert_method_hir_with_opcode("test", YARVINSN_objtostring, expect![[r#"
+            fn test:
+            bb0(v0:BasicObject):
+              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+              v3:Fixnum[1] = Const Value(1)
+              v5:BasicObject = ObjToString v3
+              SideExit
+        "#]]);
+    }
 }
 
 #[cfg(test)]
@@ -5295,6 +5352,36 @@ mod opt_tests {
               v2:Fixnum[1] = Const Value(1)
               SetIvar v0, :@foo, v2
               Return v2
+        "#]]);
+    }
+
+    #[test]
+    fn test_objtostring_string() {
+        eval("
+            def test = \"#{('foo')}\"
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0(v0:BasicObject):
+              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+              v3:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+              v4:StringExact = StringCopy v3
+              SideExit
+        "#]]);
+    }
+
+    #[test]
+    fn test_objtostring_fallback() {
+        eval("
+            def test = \"#{1}\"
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0(v0:BasicObject):
+              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+              v3:Fixnum[1] = Const Value(1)
+              v8:BasicObject = SendWithoutBlock v3, :to_s
+              SideExit
         "#]]);
     }
 }


### PR DESCRIPTION
This PR adds the `objtostring` opcode for the HIR. Also adds a fast path for known strings at compile time. 

`objtostring` is an instruction that appears when doing string interpolation. It appears with `concatstrings` and `anytostring`. `concatstrings` does not do any string coercion and so relies on `objtostring` and `anytostring` to ensure the contents on the stack are strings. 

```
ywenc in ~/Documents/github/ruby  (zjit-objtostring) % ./miniruby --dump=i -e '"#{('foo')}"'
== disasm: #<ISeq:<main>@-e:1 (1,0)-(1,10)>
0000 putobject                              ""                        (   1)[Li]
0002 putself
0003 opt_send_without_block                 <calldata!mid:foo, argc:0, FCALL|VCALL|ARGS_SIMPLE>
0005 dup
0006 objtostring                            <calldata!mid:to_s, argc:0, FCALL|ARGS_SIMPLE>
0008 anytostring
0009 concatstrings                          2
0011 leave
```

For the interpreter, `objtostring` has fast paths for some classes like strings and symbols, and if the fast paths don't return anything, we call the method id `to_s`.  In the fast path for strings, [the original string is returned](https://github.com/ruby/ruby/blob/95201299fd7bf0918dfbd8c127ce2b5b33ffa537/vm_insnhelper.c#L6068-L6071). `Insn::ObjToString` is similarly implemented - this PR currently contains a fast path for strings that returns the value from the stack if we know it is a string, otherwise the instruction uses `SendWithoutBlock` with `to_s`. We added `Insn::ObjToString` as its own instruction so that it can be optimized for it specifically, instead of optimizing `SendWithoutBlock` with `to_s`. `to_s` can be overridden on the String class, which is what is called when calling `to_s` directly. 

--

Instead of replacing `Insn::ObjToString` with `Insn::SendWithoutBlock` as the fallback in `optimize_direct_sends`,  we also considered making `Insn::ObjToString` alias to `gen_send_without_block` in `gen_insn`. But have decided to keep it there for now so changes are in fewer files, and so that `Insn::ObjToString` makes some more sense inside `optimizing_direct_sends`.

We also considered doing the fast path and SendWithoutBlock as a fallback in the initial HIR construction, instead of in the optimizer. But have left things in the optimizer because [`infer_types` happens at the end of `iseq_to_hir`](https://github.com/ruby/ruby/blob/master/zjit/src/hir.rs#L2510).