### PR TITLE
Fix too early writebarrier in tally_up

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -1215,14 +1215,15 @@ tally_up(st_data_t *group, st_data_t *value, st_data_t arg, int existing)
         RB_OBJ_WRITTEN(hash, Qundef, tally);
     }
     *value = (st_data_t)tally;
-    if (!SPECIAL_CONST_P(*group)) RB_OBJ_WRITTEN(hash, Qundef, *group);
     return ST_CONTINUE;
 }
 
 static VALUE
 rb_enum_tally_up(VALUE hash, VALUE group)
 {
-    rb_hash_stlike_update(hash, group, tally_up, (st_data_t)hash);
+    if (!rb_hash_stlike_update(hash, group, tally_up, (st_data_t)hash)) {
+        RB_OBJ_WRITTEN(hash, Qundef, group);
+    }
     return hash;
 }
 


### PR DESCRIPTION
This is a "too early" write barrier which I found this using my wbcheck tool (See #13557). I added an option to re-verify objects on the first possible GC after they have a write barrier.

So what _could_ have happened is:
1. The previous RB_OBJ_WRITTEN is hit in tally_up, but there is not yet GC happening so nothing is recorded
2. `st_update` realizes it needs to resize the table, and so allocates. This triggers GC which incrementally marks `hash`, but `group` has not yet been written
3. By the time the rest of GC happens the other parents of `group` are never marked and freed, and `group` is never marked

```
$ RUBY_GC_LIBRARY=wbcheck WBCHECK_VERIFY_AFTER_WB=1 ./miniruby -e '(0...100).map(&:to_s).tally'

WBCHECK ERROR: Missed write barrier detected!
  Parent object: 0x5fe8145822d0 (wb_protected: true)
    rb_obj_info_dump: 0x00005fe8145822d0 T_HASH/Hash [S] 32
  Reference counts - snapshot: 17, writebarrier: 16, current: 33, missed: 1
  Missing reference to: 0x5fe814585940
    rb_obj_info_dump: 0x00005fe814585940 T_STRING/String  len: 2, capa: 15 "16"
```

