### PR TITLE
Fix early write barrier rb_marshal_define_compat

### DIFF
--- a/marshal.c
+++ b/marshal.c
@@ -145,12 +145,14 @@ rb_marshal_define_compat(VALUE newclass, VALUE oldclass, VALUE (*dumper)(VALUE),
 
     compat_allocator_table();
     compat = ALLOC(marshal_compat_t);
-    RB_OBJ_WRITE(compat_allocator_tbl_wrapper, &compat->newclass, newclass);
-    RB_OBJ_WRITE(compat_allocator_tbl_wrapper, &compat->oldclass, oldclass);
+    compat->newclass = newclass;
+    compat->oldclass = oldclass;
     compat->dumper = dumper;
     compat->loader = loader;
 
     st_insert(compat_allocator_table(), (st_data_t)allocator, (st_data_t)compat);
+    RB_OBJ_WRITTEN(compat_allocator_tbl_wrapper, Qundef, newclass);
+    RB_OBJ_WRITTEN(compat_allocator_tbl_wrapper, Qundef, oldclass);
 }
 
 struct dump_arg {


### PR DESCRIPTION
I found this using my wbcheck tool (See #13557)

```
WBCHECK ERROR: Missed write barrier detected!
  Parent object: 0x64a8bb6cee40 (wb_protected: true)
    rb_obj_info_dump: 0x000064a8bb6cee40 marshal_compat_table/marshal_compat_table
  Reference counts - snapshot: 7, writebarrier: 2, current: 11, missed: 1
  Missing reference to: 0x64a8bb87dfd0
    rb_obj_info_dump: 0x000064a8bb87dfd0 T_CLASS/Process::Status
```

This write barrier occurred before the entry was added to the table, so if GC occurred when inserting into the table, the write could be missed.

Similar to #13629