### PR TITLE
ZJIT: Support invokebuiltin opcodes

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -76,6 +76,21 @@ class TestZJIT < Test::Unit::TestCase
     }
   end
 
+  def test_invokebuiltin
+    assert_compiles '["."]', %q{
+      def test = Dir.glob(".")
+      test
+    }
+  end
+
+  def test_invokebuiltin_delegate
+    assert_compiles '[[], true]', %q{
+      def test = [].clone(freeze: true)
+      r = test
+      [r, r.frozen?]
+    }
+  end
+
   def test_opt_plus_const
     assert_compiles '3', %q{
       def test = 1 + 2

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -1038,8 +1038,8 @@ pub mod test_utils {
     }
 
     /// Get the ISeq of a specified method
-    pub fn get_method_iseq(name: &str) -> *const rb_iseq_t {
-        let wrapped_iseq = eval(&format!("RubyVM::InstructionSequence.of(method(:{}))", name));
+    pub fn get_method_iseq(recv: &str, name: &str) -> *const rb_iseq_t {
+        let wrapped_iseq = eval(&format!("RubyVM::InstructionSequence.of({}.method(:{}))", recv, name));
         unsafe { rb_iseqw_to_iseq(wrapped_iseq) }
     }
 


### PR DESCRIPTION
* `invokebuiltin`
* `invokebuiltin_delegate`
* `invokebuiltin_delegate_leave`

These instructions all call out to a C function, passing EC, self, and some number of arguments. `invokebuiltin` gets the arguments from the stack, whereas the `_delegate` instructions use a subset of the locals.

`opt_invokebuiltin_delegate_leave` has a fast path for `leave`, but I'm not sure we need to do anything special for that here (FWIW YJIT appears to treat the two delegate instructions the same).