### PR TITLE
[3.3] Fix use-after-free when resizing exivars

### DIFF
--- a/st.c
+++ b/st.c
@@ -1482,7 +1482,16 @@ st_update(st_table *tab, st_data_t key,
         value = entry->record;
     }
     old_key = key;
+
+    unsigned int rebuilds_num = tab->rebuilds_num;
+
     retval = (*func)(&key, &value, arg, existing);
+
+    // We need to make sure that the callback didn't cause a table rebuild
+    // Ideally we would make sure no operations happened
+    assert(rebuilds_num == tab->rebuilds_num);
+    (void)rebuilds_num;
+
     switch (retval) {
       case ST_CONTINUE:
         if (! existing) {

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -393,18 +393,36 @@ class TestVariable < Test::Unit::TestCase
       @a = 1
       @b = 2
       @c = 3
+      @d = 4
+      @e = 5
+      @f = 6
+      @g = 7
+      @h = 8
     end
 
     def ivars
-      [@a, @b, @c]
+      [@a, @b, @c, @d, @e, @f, @g, @h]
     end
   end
 
   def test_external_ivars
     3.times{
       # check inline cache for external ivar access
-      assert_equal [1, 2, 3], ExIvar.new.ivars
+      assert_equal [1, 2, 3, 4, 5, 6, 7, 8], ExIvar.new.ivars
     }
+  end
+
+  def test_exivar_resize_with_compaction_stress
+    objs = 10_000.times.map do
+      ExIvar.new
+    end
+    EnvUtil.under_gc_compact_stress do
+      10.times do
+        x = ExIvar.new
+        x.instance_variable_set(:@resize, 1)
+        x
+      end
+    end
   end
 
   def test_local_variables_with_kwarg


### PR DESCRIPTION
[Bug #21438]
Ref: https://bugs.ruby-lang.org/issues/21438
Backport of https://github.com/ruby/ruby/pull/13635 and https://github.com/ruby/ruby/pull/13589.

Previously GC could trigger a table rebuild of the generic ivar st_table in the middle of calling the st_update callback.
This could cause entries to be reallocated or rearranged and the update to be for the wrong entry.

This commit adds an assertion to make that case easier to detect, and replaces the st_update with a separate st_lookup and st_insert.

Also free after insert in generic_ivar_set_shape_ivptr

Previously we were performing a realloc and then inserting the new value into the table.
If the table was flagged as requiring a rebuild, this could trigger GC work and marking within that GC could access the ivptr freed by realloc.


