### PR TITLE
Optimize `benchmark/vm_ivar_of_class`

### DIFF
--- a/internal/class.h
+++ b/internal/class.h
@@ -432,7 +432,7 @@ static inline rb_classext_t *
 RCLASS_EXT_WRITABLE(VALUE obj)
 {
     const rb_namespace_t *ns;
-    if (RCLASS_PRIME_CLASSEXT_WRITABLE_P(obj)) {
+    if (LIKELY(RCLASS_PRIME_CLASSEXT_WRITABLE_P(obj))) {
         return RCLASS_EXT_PRIME(obj);
     }
     // delay namespace loading to optimize for unmodified classes

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1253,7 +1253,7 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
                 return default_value;
             }
             ivar_list = rb_imemo_class_fields_ptr(fields_obj);
-            shape_id = rb_obj_shape_id(fields_obj);
+            shape_id = fields_obj ? RBASIC_SHAPE_ID_FOR_READ(fields_obj) : ROOT_SHAPE_ID;
 
             break;
         }


### PR DESCRIPTION
```
compare-ruby: ruby 3.5.0dev (2025-06-17T08:45:40Z master e9d35671d2) +PRISM [arm64-darwin24]
last_commit=[ruby/json] Fix a typo
built-ruby: ruby 3.5.0dev (2025-06-17T09:27:05Z opt-getivar-for-cl.. ed1d7cd778) +PRISM [arm64-darwin24]

|                      |compare-ruby|built-ruby|
|:---------------------|-----------:|---------:|
|vm_ivar_of_class_set  |     12.306M|   13.957M|
|                      |           -|     1.13x|
|vm_ivar_of_class      |     16.167M|   24.029M|
|                      |           -|     1.49x|
```