### PR TITLE
Revert "Temporary pend unknown behavior of parallel tests"

### DIFF
--- a/tool/test/testunit/test_parallel.rb
+++ b/tool/test/testunit/test_parallel.rb
@@ -127,9 +127,7 @@ module TestParallel
 
         result = Marshal.load($1.chomp.unpack1("m"))
         assert_equal(5, result[0])
-        pend "TODO: result[1] returns 17. We should investigate it" do # TODO: misusage of pend (pend doens't use given block)
-          assert_equal(12, result[1])
-        end
+        assert_equal(12, result[1])
         assert_kind_of(Array,result[2])
         assert_kind_of(Array,result[3])
         assert_kind_of(Array,result[4])

--- a/tool/test/testunit/test_parallel.rb
+++ b/tool/test/testunit/test_parallel.rb
@@ -126,17 +126,19 @@ module TestParallel
         assert_not_nil($1, "'done' was not found")
 
         result = Marshal.load($1.chomp.unpack1("m"))
-        assert_equal(5, result[0])
-        assert_equal(12, result[1])
-        assert_kind_of(Array,result[2])
-        assert_kind_of(Array,result[3])
-        assert_kind_of(Array,result[4])
-        assert_kind_of(Array,result[2][1])
-        assert_kind_of(Test::Unit::AssertionFailedError,result[2][0][2])
-        assert_kind_of(Test::Unit::PendedError,result[2][1][2])
-        assert_kind_of(Test::Unit::PendedError,result[2][2][2])
-        assert_kind_of(Exception, result[2][3][2])
-        assert_equal(result[5], "TestE")
+        tests, asserts, reports, failures, loadpaths, suite = result
+        assert_equal(5, tests)
+        assert_equal(12, asserts)
+        assert_kind_of(Array, reports)
+        assert_kind_of(Array, failures)
+        assert_kind_of(Array, loadpaths)
+        reports.sort_by! {|_, t| t}
+        assert_kind_of(Array, reports[1])
+        assert_kind_of(Test::Unit::AssertionFailedError, reports[0][2])
+        assert_kind_of(Test::Unit::PendedError, reports[1][2])
+        assert_kind_of(Test::Unit::PendedError, reports[2][2])
+        assert_kind_of(Exception, reports[3][2])
+        assert_equal("TestE", suite)
       end
     end
 

--- a/tool/test/testunit/tests_for_parallel/ptest_forth.rb
+++ b/tool/test/testunit/tests_for_parallel/ptest_forth.rb
@@ -8,19 +8,19 @@ class TestE < Test::Unit::TestCase
     assert_equal(1,1)
   end
 
-  def test_always_skip
-    skip "always"
+  def test_always_omit
+    omit "always"
   end
 
   def test_always_fail
     assert_equal(0,1)
   end
 
-  def test_skip_after_unknown_error
+  def test_pend_after_unknown_error
     begin
       raise UnknownError, "unknown error"
     rescue
-      skip "after raise"
+      pend "after raise"
     end
   end
 


### PR DESCRIPTION
This reverts commit 980f61935f6e8331e0908dc963e60fb727ab4d8c, which seems no longer needed.