### PR TITLE
thread_cleanup: set CFP to NULL before clearing ec's stack

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -3675,10 +3675,10 @@ rb_ec_initialize_vm_stack(rb_execution_context_t *ec, VALUE *stack, size_t size)
 void
 rb_ec_clear_vm_stack(rb_execution_context_t *ec)
 {
-    rb_ec_set_vm_stack(ec, NULL, 0);
-
-    // Avoid dangling pointers:
+    // set cfp to NULL before clearing the stack in case `thread_profile_frames`
+    // gets called in this middle of `rb_ec_set_vm_stack` via signal handler.
     ec->cfp = NULL;
+    rb_ec_set_vm_stack(ec, NULL, 0);
 }
 
 static void


### PR DESCRIPTION
We clear the CFP first so that if a sampling profiler interrupts the current thread during `rb_ec_set_vm_stack`, `thread_profile_frames` returns early instead of trying to walk the stack that's no longer set on the ec.

The early return in `thread_profile_frames` was introduced at eab7f4623fb.

Fixes [Bug #21441]