### PR TITLE
Fix some missing write barriers in Ractor-related code

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -1882,6 +1882,9 @@ move_leave(VALUE obj, struct obj_traverse_replace_data *data)
         rb_gc_obj_slot_size(obj) - sizeof(VALUE)
     );
 
+    // We've copied obj's references to the replacement
+    rb_gc_writebarrier_remember(data->replacement);
+
     void rb_replace_generic_ivar(VALUE clone, VALUE obj); // variable.c
 
     rb_gc_obj_id_moved(data->replacement);

--- a/ractor.c
+++ b/ractor.c
@@ -1188,6 +1188,7 @@ obj_traverse_i(VALUE obj, struct obj_traverse_data *data)
         // already traversed
         return 0;
     }
+    RB_OBJ_WRITTEN(data->rec_hash, Qundef, obj);
 
     struct obj_traverse_callback_data d = {
         .stop = false,
@@ -1644,6 +1645,8 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
     }
     else {
         st_insert(obj_traverse_replace_rec(data), (st_data_t)obj, replacement);
+        RB_OBJ_WRITTEN(data->rec_hash, Qundef, obj);
+        RB_OBJ_WRITTEN(data->rec_hash, Qundef, replacement);
     }
 
     if (!data->move) {

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -81,6 +81,7 @@ ractor_port_init(VALUE rpv, rb_ractor_t *r)
     struct ractor_port *rp = RACTOR_PORT_PTR(rpv);
 
     rp->r = r;
+    RB_OBJ_WRITTEN(rpv, Qundef, r->pub.self);
     rp->id_ = ractor_genid_for_port(r);
 
     ractor_add_port(r, ractor_port_id(rp));
@@ -102,6 +103,7 @@ ractor_port_initialzie_copy(VALUE self, VALUE orig)
     struct ractor_port *dst = RACTOR_PORT_PTR(self);
     struct ractor_port *src = RACTOR_PORT_PTR(orig);
     dst->r = src->r;
+    RB_OBJ_WRITTEN(self, Qundef, dst->r->pub.self);
     dst->id_ = ractor_port_id(src);
 
     return self;


### PR DESCRIPTION
This fixes a few issue in our Ractor code which were detected by wbcheck.

First is a missing write barrier from , which was also found [on CI with GC assertions](https://ci.rvm.jp/results/trunk-gc-asserts@ruby-sp2-noble-docker/5796906):

```
verify_internal_consistency_reachable_i: WB miss (O->Y) 0x000071507d8bff80 ractor/port/Ractor::Port ractor/port -> 0x0000715097f5a470 ractor/Ractor r:1
<internal:kernel>:48: [BUG] gc_verify_internal_consistency: found internal inconsistency.
```

The other two commits deal with missing write barriers as part of the obj_traverse:
* We need to issue write barriers from rec_hash whenever we insert directly to its st_table
* We need to `rb_gc_writebarrier_remember` newly created objects after moving them