### PR TITLE
[Bug #21312] Use the original gemspec from release package of RDoc

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -39,7 +39,7 @@ ostruct             0.6.1   https://github.com/ruby/ostruct 50d51248bec5560a102a
 pstore              0.2.0   https://github.com/ruby/pstore
 benchmark           0.4.1   https://github.com/ruby/benchmark
 logger              1.7.0   https://github.com/ruby/logger
-rdoc                6.14.0  https://github.com/ruby/rdoc
+rdoc                6.14.0  https://github.com/ruby/rdoc 27869f5d06b6c72657c5aac72258a65f518489b0
 win32ole            1.9.2   https://github.com/ruby/win32ole
 irb                 1.15.2  https://github.com/ruby/irb
 reline              0.6.1   https://github.com/ruby/reline

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -10,7 +10,7 @@ github_actions = ENV["GITHUB_ACTIONS"] == "true"
 
 allowed_failures = ENV['TEST_BUNDLED_GEMS_ALLOW_FAILURES'] || ''
 if RUBY_PLATFORM =~ /mswin|mingw/
-  allowed_failures = [allowed_failures, "rbs,debug,irb"].join(',')
+  allowed_failures = [allowed_failures, "rbs,debug,irb,net-imap"].join(',')
 end
 allowed_failures = allowed_failures.split(',').uniq.reject(&:empty?)
 


### PR DESCRIPTION
Fixed https://bugs.ruby-lang.org/issues/21312
Related with https://github.com/ruby/rdoc/pull/1379