### PR TITLE
Update bundled gems

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -16,8 +16,8 @@ net-ftp             0.3.8   https://github.com/ruby/net-ftp
 net-imap            0.5.8   https://github.com/ruby/net-imap
 net-pop             0.1.2   https://github.com/ruby/net-pop
 net-smtp            0.5.1   https://github.com/ruby/net-smtp
-matrix              0.4.2   https://github.com/ruby/matrix 200efebc35dc1a8d16fad671f7006c85cbd0e3f5
-prime               0.1.3   https://github.com/ruby/prime d97973271103f2bdde91f3f0bd3e42526401ad77
+matrix              0.4.3   https://github.com/ruby/matrix
+prime               0.1.4   https://github.com/ruby/prime
 rbs                 3.9.4   https://github.com/ruby/rbs
 typeprof            0.30.1  https://github.com/ruby/typeprof
 debug               1.11.0  https://github.com/ruby/debug
@@ -35,11 +35,11 @@ nkf                 0.2.0   https://github.com/ruby/nkf
 syslog              0.3.0   https://github.com/ruby/syslog
 csv                 3.3.5   https://github.com/ruby/csv
 repl_type_completor 0.1.11  https://github.com/ruby/repl_type_completor 25108aa8d69ddaba0b5da3feff1c0035371524b2
-ostruct             0.6.1   https://github.com/ruby/ostruct 50d51248bec5560a102a1024aff4174b31dca8cc
+ostruct             0.6.2   https://github.com/ruby/ostruct
 pstore              0.2.0   https://github.com/ruby/pstore
 benchmark           0.4.1   https://github.com/ruby/benchmark
 logger              1.7.0   https://github.com/ruby/logger
-rdoc                6.14.0  https://github.com/ruby/rdoc 27869f5d06b6c72657c5aac72258a65f518489b0
+rdoc                6.14.1  https://github.com/ruby/rdoc
 win32ole            1.9.2   https://github.com/ruby/win32ole
 irb                 1.15.2  https://github.com/ruby/irb 331c4e851296b115db766c291e8cf54a2492fb36
 reline              0.6.1   https://github.com/ruby/reline

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -10,7 +10,7 @@ github_actions = ENV["GITHUB_ACTIONS"] == "true"
 
 allowed_failures = ENV['TEST_BUNDLED_GEMS_ALLOW_FAILURES'] || ''
 if RUBY_PLATFORM =~ /mswin|mingw/
-  allowed_failures = [allowed_failures, "rbs,debug,irb"].join(',')
+  allowed_failures = [allowed_failures, "irb"].join(',')
 end
 allowed_failures = allowed_failures.split(',').uniq.reject(&:empty?)
 

--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -10,7 +10,7 @@ github_actions = ENV["GITHUB_ACTIONS"] == "true"
 
 allowed_failures = ENV['TEST_BUNDLED_GEMS_ALLOW_FAILURES'] || ''
 if RUBY_PLATFORM =~ /mswin|mingw/
-  allowed_failures = [allowed_failures, "rbs,debug,irb,net-imap"].join(',')
+  allowed_failures = [allowed_failures, "rbs,debug,irb"].join(',')
 end
 allowed_failures = allowed_failures.split(',').uniq.reject(&:empty?)
 


### PR DESCRIPTION
We couldn't specify development version of RDoc. Because rdoc need to generate `markdown.rb` from that repository. So, development branch specified commit hash didn't contain that file.

Fixed https://rubyci.s3.amazonaws.com/osx1400arm-no-yjit/ruby-master/log/20250618T045007Z.fail.html.gz

