### PR TITLE
Shink RClass when it is known they can't be namespaced

### DIFF
--- a/class.c
+++ b/class.c
@@ -394,7 +394,7 @@ class_classext_foreach_i(st_data_t key, st_data_t value, st_data_t arg)
 void
 rb_class_classext_foreach(VALUE klass, rb_class_classext_foreach_callback_func *func, void *arg)
 {
-    st_table *tbl = RCLASS(klass)->ns_classext_tbl;
+    st_table *tbl = RCLASS_CLASSEXT_TBL(klass);
     struct class_classext_foreach_arg foreach_arg;
     if (tbl) {
         foreach_arg.func = func;
@@ -649,7 +649,11 @@ class_alloc(enum ruby_value_type type, VALUE klass)
     rb_ns_subclasses_t *ns_subclasses;
     rb_subclass_anchor_t *anchor;
     const rb_namespace_t *ns = rb_definition_namespace();
-    size_t alloc_size = sizeof(struct RClass) + sizeof(rb_classext_t);
+
+    size_t alloc_size = sizeof(struct RClass_and_rb_classext_t);
+    if (!ruby_namespace_init_done) {
+        alloc_size = sizeof(struct RClass_namespaceable);
+    }
 
     // class_alloc is supposed to return a new object that is not promoted yet.
     // So, we need to avoid GC after NEWOBJ_OF.

--- a/eval.c
+++ b/eval.c
@@ -78,6 +78,7 @@ ruby_setup(void)
 #endif
     Init_BareVM();
     rb_vm_encoded_insn_data_table_init();
+    Init_enable_namespace();
     Init_vm_objects();
     Init_fstring_table();
 

--- a/gc.c
+++ b/gc.c
@@ -1286,8 +1286,8 @@ rb_gc_obj_free(void *objspace, VALUE obj)
       case T_CLASS:
         args.klass = obj;
         rb_class_classext_foreach(obj, classext_free, (void *)&args);
-        if (RCLASS(obj)->ns_classext_tbl) {
-            st_free_table(RCLASS(obj)->ns_classext_tbl);
+        if (RCLASS_CLASSEXT_TBL(obj)) {
+            st_free_table(RCLASS_CLASSEXT_TBL(obj));
         }
         (void)RB_DEBUG_COUNTER_INC_IF(obj_module_ptr, BUILTIN_TYPE(obj) == T_MODULE);
         (void)RB_DEBUG_COUNTER_INC_IF(obj_class_ptr, BUILTIN_TYPE(obj) == T_CLASS);
@@ -1390,8 +1390,8 @@ rb_gc_obj_free(void *objspace, VALUE obj)
         args.klass = obj;
 
         rb_class_classext_foreach(obj, classext_iclass_free, (void *)&args);
-        if (RCLASS(obj)->ns_classext_tbl) {
-            st_free_table(RCLASS(obj)->ns_classext_tbl);
+        if (RCLASS_CLASSEXT_TBL(obj)) {
+            st_free_table(RCLASS_CLASSEXT_TBL(obj));
         }
 
         RB_DEBUG_COUNTER_INC(obj_iclass_ptr);

--- a/internal/class.h
+++ b/internal/class.h
@@ -293,6 +293,7 @@ static inline void RCLASS_WRITE_CLASSPATH(VALUE klass, VALUE classpath, bool per
 #define RCLASS_PRIME_CLASSEXT_WRITABLE FL_USER2
 #define RCLASS_IS_INITIALIZED FL_USER3
 // 3 is RMODULE_IS_REFINEMENT for RMODULE
+#define RCLASS_NAMESPACEABLE FL_USER4
 
 /* class.c */
 rb_classext_t * rb_class_duplicate_classext(rb_classext_t *orig, VALUE obj, const rb_namespace_t *ns);

--- a/internal/inits.h
+++ b/internal/inits.h
@@ -25,6 +25,9 @@ int Init_enc_set_filesystem_encoding(void);
 /* newline.c */
 void Init_newline(void);
 
+/* namespace.c */
+void Init_enable_namespace(void);
+
 /* vm.c */
 void Init_BareVM(void);
 void Init_vm_objects(void);

--- a/internal/namespace.h
+++ b/internal/namespace.h
@@ -52,6 +52,7 @@ typedef struct rb_namespace_struct rb_namespace_t;
 #define NAMESPACE_CC_ENTRIES(ccs) (ccs ? NAMESPACE_METHOD_ENTRY(ccs->cme) : NULL)
 
 RUBY_EXTERN bool ruby_namespace_enabled;
+RUBY_EXTERN bool ruby_namespace_init_done;
 
 static inline bool
 rb_namespace_available(void)
@@ -81,5 +82,5 @@ VALUE rb_namespace_exec(const rb_namespace_t *ns, namespace_exec_func *func, VAL
 VALUE rb_namespace_local_extension(VALUE namespace, VALUE fname, VALUE path);
 
 void rb_initialize_main_namespace(void);
-
+void rb_namespace_init_done(void);
 #endif /* INTERNAL_NAMESPACE_H */

--- a/internal/namespace.h
+++ b/internal/namespace.h
@@ -51,7 +51,14 @@ typedef struct rb_namespace_struct rb_namespace_t;
 #define NAMESPACE_CC(cc) (cc ? NAMESPACE_METHOD_ENTRY(cc->cme_) : NULL)
 #define NAMESPACE_CC_ENTRIES(ccs) (ccs ? NAMESPACE_METHOD_ENTRY(ccs->cme) : NULL)
 
-int rb_namespace_available(void);
+RUBY_EXTERN bool ruby_namespace_enabled;
+
+static inline bool
+rb_namespace_available(void)
+{
+    return ruby_namespace_enabled;
+}
+
 void rb_namespace_enable_builtin(void);
 void rb_namespace_disable_builtin(void);
 void rb_namespace_push_loading_namespace(const rb_namespace_t *);

--- a/lib/rubygems.rb
+++ b/lib/rubygems.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 #--
 # Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.
 # All rights reserved.

--- a/namespace.c
+++ b/namespace.c
@@ -47,29 +47,10 @@ static bool tmp_dir_has_dirsep;
 # define DIRSEP "/"
 #endif
 
-static int namespace_availability = 0;
+bool ruby_namespace_enabled = false; // extern
 
 VALUE rb_resolve_feature_path(VALUE klass, VALUE fname);
 static VALUE rb_namespace_inspect(VALUE obj);
-
-int
-rb_namespace_available(void)
-{
-    const char *env;
-    if (namespace_availability) {
-        return namespace_availability > 0 ? 1 : 0;
-    }
-    env = getenv("RUBY_NAMESPACE");
-    if (env && strlen(env) > 0) {
-        if (strcmp(env, "1") == 0) {
-            namespace_availability = 1;
-            return 1;
-        }
-    }
-    namespace_availability = -1;
-    return 0;
-}
-
 static void namespace_push(rb_thread_t *th, VALUE namespace);
 static VALUE namespace_pop(VALUE th_value);
 
@@ -1029,6 +1010,15 @@ namespace_define_loader_method(const char *name)
 {
     rb_define_private_method(rb_mNamespaceLoader, name, rb_namespace_user_loading_func, -1);
     rb_define_singleton_method(rb_mNamespaceLoader, name, rb_namespace_user_loading_func, -1);
+}
+
+void
+Init_enable_namespace(void)
+{
+    const char *env = getenv("RUBY_NAMESPACE");
+    if (env && strlen(env) == 1 && env[0] == '1') {
+        ruby_namespace_enabled = true;
+    }
 }
 
 void

--- a/namespace.c
+++ b/namespace.c
@@ -48,11 +48,18 @@ static bool tmp_dir_has_dirsep;
 #endif
 
 bool ruby_namespace_enabled = false; // extern
+bool ruby_namespace_init_done = false; // extern
 
 VALUE rb_resolve_feature_path(VALUE klass, VALUE fname);
 static VALUE rb_namespace_inspect(VALUE obj);
 static void namespace_push(rb_thread_t *th, VALUE namespace);
 static VALUE namespace_pop(VALUE th_value);
+
+void
+rb_namespace_init_done(void)
+{
+    ruby_namespace_init_done = true;
+}
 
 void
 rb_namespace_enable_builtin(void)
@@ -1018,6 +1025,9 @@ Init_enable_namespace(void)
     const char *env = getenv("RUBY_NAMESPACE");
     if (env && strlen(env) == 1 && env[0] == '1') {
         ruby_namespace_enabled = true;
+    }
+    else {
+        ruby_namespace_init_done = true;
     }
 }
 

--- a/ruby.c
+++ b/ruby.c
@@ -1822,8 +1822,6 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
     GET_VM()->running = 1;
     memset(ruby_vm_redefined_flag, 0, sizeof(ruby_vm_redefined_flag));
 
-    ruby_init_prelude();
-
     if (rb_namespace_available())
         rb_initialize_main_namespace();
 
@@ -1844,6 +1842,8 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
     Init_builtin_yjit_hook();
 #endif
 
+    rb_namespace_init_done();
+    ruby_init_prelude();
     ruby_set_script_name(opt->script_name);
     require_libraries(&opt->req_list);
 }


### PR DESCRIPTION
Even when namespaces are enabled, only a few core classes created during init will eventually be namespaced.

For these it's OK to allocate a 320B slot to hold the extra namespace stuff.
    
But for any class created post init, we know we'll never need the namespace and we can fit in a 160B slot.
