### PR TITLE
Fix missing write barrier on class fields

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -4726,7 +4726,12 @@ class_fields_ivar_set(VALUE klass, VALUE fields_obj, ID id, VALUE val, bool conc
             // so that we're embedded as long as possible.
             fields_obj = rb_imemo_fields_new(rb_singleton_class(klass), next_capacity);
             if (original_fields_obj) {
-                MEMCPY(rb_imemo_fields_ptr(fields_obj), rb_imemo_fields_ptr(original_fields_obj), VALUE, RSHAPE_LEN(current_shape_id));
+                VALUE *fields = rb_imemo_fields_ptr(fields_obj);
+                attr_index_t fields_count = RSHAPE_LEN(current_shape_id);
+                MEMCPY(fields, rb_imemo_fields_ptr(original_fields_obj), VALUE, fields_count);
+                for (attr_index_t i = 0; i < fields_count; i++) {
+                    RB_OBJ_WRITTEN(fields_obj, Qundef, fields[i]);
+                }
             }
         }
 


### PR DESCRIPTION
Found by wbcheck

```
klass = Class.new
200.times do |iv|
  klass.instance_variable_set("@_iv_#{iv}", Object.new)
end
```

```
WBCHECK ERROR: Missed write barrier detected!
  Parent object: 0x73037bce6390 (wb_protected: true)
    rb_obj_info_dump: 0x000073037bce6390 T_IMEMO/<fields>
  Reference counts - snapshot: 1, writebarrier: 122, current: 201, missed: 78
  Missing reference to: 0x73037bcdc750
    rb_obj_info_dump: 0x000073037bcdc750 T_OBJECT/Object (embed) len:3
  Missing reference to: 0x73037bcdcb90
    rb_obj_info_dump: 0x000073037bcdcb90 T_OBJECT/Object (embed) len:3
  Missing reference to: 0x73037bcdcd10
    rb_obj_info_dump: 0x000073037bcdcd10 T_OBJECT/Object (embed) len:3
  Missing reference to: 0x73037bcdce90
...
```

cc @byroot 