### PR TITLE
ZJIT: `anytostring`

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -283,6 +283,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::SetIvar { self_val, id, val, state: _ } => return gen_setivar(asm, opnd!(self_val), *id, opnd!(val)),
         Insn::SideExit { state } => return gen_side_exit(jit, asm, &function.frame_state(*state)),
         Insn::PutSpecialObject { value_type } => gen_putspecialobject(asm, *value_type),
+        Insn::AnyToString { val, str, state } => gen_anytostring(asm, opnd!(val), opnd!(str), &function.frame_state(*state))?,
         _ => {
             debug!("ZJIT: gen_function: unexpected insn {:?}", insn);
             return None;
@@ -815,6 +816,17 @@ fn gen_fixnum_gt(asm: &mut Assembler, left: lir::Opnd, right: lir::Opnd) -> Opti
 fn gen_fixnum_ge(asm: &mut Assembler, left: lir::Opnd, right: lir::Opnd) -> Option<lir::Opnd> {
     asm.cmp(left, right);
     Some(asm.csel_ge(Qtrue.into(), Qfalse.into()))
+}
+
+fn gen_anytostring(asm: &mut Assembler, val: lir::Opnd, str: lir::Opnd, state: &FrameState) -> Option<lir::Opnd> {
+    // Save PC
+    gen_save_pc(asm, state);
+    
+    asm_comment!(asm, "call rb_obj_as_string_result");
+    Some(asm.ccall(
+        rb_obj_as_string_result as *const u8,
+        vec![str, val],
+    ))
 }
 
 /// Evaluate if a value is truthy


### PR DESCRIPTION
This PR adds support for `anytostring` with an optimization for known strings. 

`anytostring` is used with `objtostring` and `concatstrings` for string interpolation (see PR description in https://github.com/ruby/ruby/pull/13627 for more details). 

The implementation for `anytostring` pops two values from the stack. If the first value popped from the stack [is a `T_STRING`](https://github.com/ruby/ruby/blob/83fb07fb2c97b9922450979fa4a56f43324317a9/string.c#L2177), push it back on the stack, otherwise push the string coercion of the second.

This PR also piggybacks a fix for [string subclasses should also skip `:to_s` for `objtostring`](https://github.com/ruby/ruby/pull/13627#discussion_r2157269151) (cc @XrXr ).