### PR TITLE
Typofix under the zjit directory

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -414,7 +414,7 @@ fn gen_entry_prologue(asm: &mut Assembler, iseq: IseqPtr) {
         asm.cpush(SP);
     }
 
-    // EC and CFP are pased as arguments
+    // EC and CFP are passed as arguments
     asm.mov(EC, C_ARG_OPNDS[0]);
     asm.mov(CFP, C_ARG_OPNDS[1]);
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3128,7 +3128,7 @@ mod tests {
         let iseq = crate::cruby::with_rubyvm(|| get_method_iseq("self", method));
         unsafe { crate::cruby::rb_zjit_profile_disable(iseq) };
         let result = iseq_to_hir(iseq);
-        assert!(result.is_err(), "Expected an error but succesfully compiled to HIR: {}", FunctionPrinter::without_snapshot(&result.unwrap()));
+        assert!(result.is_err(), "Expected an error but successfully compiled to HIR: {}", FunctionPrinter::without_snapshot(&result.unwrap()));
         assert_eq!(result.unwrap_err(), reason);
     }
 


### PR DESCRIPTION
I'm trying to separate credential for only `auto_request_review.yml` now.

https://github.com/ruby/ruby/commit/fafae10d9a19e966f5c4cccbe7a6e6a418821c62