### PR TITLE
Fix handling of PM_CONSTANT_PATH_NODE node in keyword arguments with ARGS_SPLAT

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1855,7 +1855,6 @@ pm_setup_args_dup_rest_p(const pm_node_t *node)
     switch (PM_NODE_TYPE(node)) {
       case PM_BACK_REFERENCE_READ_NODE:
       case PM_CLASS_VARIABLE_READ_NODE:
-      case PM_CONSTANT_PATH_NODE:
       case PM_CONSTANT_READ_NODE:
       case PM_FALSE_NODE:
       case PM_FLOAT_NODE:
@@ -1874,6 +1873,13 @@ pm_setup_args_dup_rest_p(const pm_node_t *node)
       case PM_SYMBOL_NODE:
       case PM_TRUE_NODE:
         return false;
+      case PM_CONSTANT_PATH_NODE: {
+        const pm_constant_path_node_t *cast = (const pm_constant_path_node_t *) node;
+        if (cast->parent != NULL) {
+            return pm_setup_args_dup_rest_p(cast->parent);
+        }
+        return false;
+      }
       case PM_IMPLICIT_NODE:
         return pm_setup_args_dup_rest_p(((const pm_implicit_node_t *) node)->value);
       default:


### PR DESCRIPTION
This was handled correctly in parse.y (NODE_COLON2), but not in prism. This wasn't caught earlier, because I only added tests for the optimized case and not the unoptimized case. Add tests for the unoptimized case.

In code terms:

```ruby
m(*a, kw: lvar::X)     # Does not require allocation for *a
m(*a, kw: method()::X) # Requires allocation for *a
```

This commit fixes the second case when prism is used.