### PR TITLE
Fix missing write barrier in rb_vm_rewrite_cref

### DIFF
--- a/class.c
+++ b/class.c
@@ -849,8 +849,7 @@ static void
 clone_method(VALUE old_klass, VALUE new_klass, ID mid, const rb_method_entry_t *me)
 {
     if (me->def->type == VM_METHOD_TYPE_ISEQ) {
-        rb_cref_t *new_cref;
-        rb_vm_rewrite_cref(me->def->body.iseq.cref, old_klass, new_klass, &new_cref);
+        rb_cref_t *new_cref = rb_vm_rewrite_cref(me->def->body.iseq.cref, old_klass, new_klass);
         rb_add_method_iseq(new_klass, mid, me->def->body.iseq.iseqptr, new_cref, METHOD_ENTRY_VISI(me));
     }
     else {

--- a/vm.c
+++ b/vm.c
@@ -233,13 +233,9 @@ vm_cref_new0(VALUE klass, rb_method_visibility_t visi, int module_func, rb_cref_
     int omod_shared = FALSE;
 
     /* scope */
-    union {
-        rb_scope_visibility_t visi;
-        VALUE value;
-    } scope_visi;
-
-    scope_visi.visi.method_visi = visi;
-    scope_visi.visi.module_func = module_func;
+    rb_scope_visibility_t scope_visi;
+    scope_visi.method_visi = visi;
+    scope_visi.module_func = module_func;
 
     /* refinements */
     if (prev_cref != NULL && prev_cref != (void *)1 /* TODO: why CREF_NEXT(cref) is 1? */) {
@@ -256,7 +252,7 @@ vm_cref_new0(VALUE klass, rb_method_visibility_t visi, int module_func, rb_cref_
     rb_cref_t *cref = IMEMO_NEW(rb_cref_t, imemo_cref, refinements);
     cref->klass_or_self = klass;
     cref->next = use_prev_prev ? CREF_NEXT(prev_cref) : prev_cref;
-    *((rb_scope_visibility_t *)&cref->scope_visi) = scope_visi.visi;
+    *((rb_scope_visibility_t *)&cref->scope_visi) = scope_visi;
 
     if (pushed_by_eval) CREF_PUSHED_BY_EVAL_SET(cref);
     if (omod_shared) CREF_OMOD_SHARED_SET(cref);

--- a/vm_core.h
+++ b/vm_core.h
@@ -1922,7 +1922,7 @@ void rb_vm_register_special_exception_str(enum ruby_special_exceptions sp, VALUE
 
 void rb_gc_mark_machine_context(const rb_execution_context_t *ec);
 
-void rb_vm_rewrite_cref(rb_cref_t *node, VALUE old_klass, VALUE new_klass, rb_cref_t **new_cref_ptr);
+rb_cref_t *rb_vm_rewrite_cref(rb_cref_t *node, VALUE old_klass, VALUE new_klass);
 
 const rb_callable_method_entry_t *rb_vm_frame_method_entry(const rb_control_frame_t *cfp);
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -981,7 +981,7 @@ rb_vm_rewrite_cref(rb_cref_t *cref, VALUE old_klass, VALUE new_klass)
 
     #define ADD_NEW_CREF(new_cref) \
         if (new_cref_tail) { \
-            new_cref_tail->next = new_cref; \
+            RB_OBJ_WRITE(new_cref_tail, &new_cref_tail->next, new_cref); \
         } else { \
             new_cref_head = new_cref; \
         } \

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -973,23 +973,36 @@ vm_get_const_key_cref(const VALUE *ep)
     return NULL;
 }
 
-void
-rb_vm_rewrite_cref(rb_cref_t *cref, VALUE old_klass, VALUE new_klass, rb_cref_t **new_cref_ptr)
+rb_cref_t *
+rb_vm_rewrite_cref(rb_cref_t *cref, VALUE old_klass, VALUE new_klass)
 {
-    rb_cref_t *new_cref;
+    rb_cref_t *new_cref_head = NULL;
+    rb_cref_t *new_cref_tail = NULL;
+
+    #define ADD_NEW_CREF(new_cref) \
+        if (new_cref_tail) { \
+            new_cref_tail->next = new_cref; \
+        } else { \
+            new_cref_head = new_cref; \
+        } \
+        new_cref_tail = new_cref;
 
     while (cref) {
+        rb_cref_t *new_cref;
         if (CREF_CLASS(cref) == old_klass) {
             new_cref = vm_cref_new_use_prev(new_klass, METHOD_VISI_UNDEF, FALSE, cref, FALSE);
-            *new_cref_ptr = new_cref;
-            return;
+            ADD_NEW_CREF(new_cref);
+            return new_cref_head;
         }
         new_cref = vm_cref_new_use_prev(CREF_CLASS(cref), METHOD_VISI_UNDEF, FALSE, cref, FALSE);
         cref = CREF_NEXT(cref);
-        *new_cref_ptr = new_cref;
-        new_cref_ptr = &new_cref->next;
+        ADD_NEW_CREF(new_cref);
     }
-    *new_cref_ptr = NULL;
+
+    #undef ADD_NEW_CREF
+
+    // Could we just reuse the original cref?
+    return new_cref_head;
 }
 
 static rb_cref_t *


### PR DESCRIPTION
If we flatten the operation this is doing it would look like:

```c
cref_a = allocate_cref();
cref_b = allocate_cref(); // cref_a _could_ be incrementally marked here
cref_a->next = cref_b;    // cref_a gains a reference to cref_b
```

I refactored `rb_vm_rewrite_cref` to return the new cref rather than assigning it through an output pointer parameter, since I needed to keep a reference anyways for the write barrier.