### PR TITLE
Restore getrandom(2) path for Linux with glibc 2.36 or later

### DIFF
--- a/random.c
+++ b/random.c
@@ -547,18 +547,16 @@ fill_random_bytes_syscall(void *seed, size_t size, int unused)
     }
     return 0;
 }
-#elif defined(HAVE_ARC4RANDOM_BUF)
+#elif defined(HAVE_ARC4RANDOM_BUF) && \
+    ((defined(__OpenBSD__) && OpenBSD >= 201411) || \
+     (defined(__NetBSD__)  && __NetBSD_Version__ >= 700000000) || \
+     (defined(__FreeBSD__) && __FreeBSD_version >= 1200079))
+// [Bug #15039] arc4random_buf(3) should used only if we know it is fork-safe
 static int
 fill_random_bytes_syscall(void *buf, size_t size, int unused)
 {
-#if (defined(__OpenBSD__) && OpenBSD >= 201411) || \
-    (defined(__NetBSD__)  && __NetBSD_Version__ >= 700000000) || \
-    (defined(__FreeBSD__) && __FreeBSD_version >= 1200079)
     arc4random_buf(buf, size);
     return 0;
-#else
-    return -1;
-#endif
 }
 #elif defined(_WIN32)
 


### PR DESCRIPTION
This is a follow-up to commit b120f5e38d9c (avoid fork-unsafe arc4random implementations, 2018-09-04).

Avoid defining a no-op `fill_random_bytes_syscall()` if `arc4random_buf(3)` exists, but we are unsure if it is fork-safe. Check for other options instead. IOW, see if `getrandom(2)` is available.

glibc 2.36, released in 2022, started to provide `arc4random_buf(3)` on Linux. This causes `fill_random_bytes_syscall()` to use neither of them and makes `Random.urandom` solely rely on `getentropy(3)` via `fill_random_bytes_urandom()`.

While the glibc implementation is safe, I did not add it to the list because using `getrandom(2)` directly is preferable on Linux.