### PR TITLE
variable.c: avoid out of bound write in `generic_field_set`

### DIFF
--- a/test/ruby/test_object_id.rb
+++ b/test/ruby/test_object_id.rb
@@ -115,6 +115,14 @@ class TestObjectId < Test::Unit::TestCase
     assert_equal 42, copy.instance_variable_get(:@foo)
     refute_predicate copy, :frozen?
   end
+
+  def test_object_id_need_resize
+    (3 - @obj.instance_variables.size).times do |i|
+      @obj.instance_variable_set("@a_#{i}", "[Bug #21445]")
+    end
+    @obj.object_id
+    GC.start
+  end
 end
 
 class TestObjectIdClass < TestObjectId

--- a/variable.c
+++ b/variable.c
@@ -1922,7 +1922,7 @@ generic_field_set(VALUE obj, shape_id_t target_shape_id, VALUE val)
     else {
         attr_index_t index = RSHAPE_INDEX(target_shape_id);
         if (index >= RSHAPE_CAPACITY(current_shape_id)) {
-            fields_obj = rb_imemo_fields_new(rb_obj_class(obj), index);
+            fields_obj = rb_imemo_fields_new(rb_obj_class(obj), RSHAPE_CAPACITY(target_shape_id));
             if (original_fields_obj) {
                 attr_index_t fields_count = RSHAPE_LEN(current_shape_id);
                 VALUE *fields = rb_imemo_fields_ptr(fields_obj);


### PR DESCRIPTION
[[Bug #21445]](https://bugs.ruby-lang.org/issues/21445)

FYI: @yahonda, @Earlopain @composerinteralia 