### PR TITLE
[Bug #21449] Fix Set#divide{|a,b|} using Union-find structure

### DIFF
--- a/test/ruby/test_set.rb
+++ b/test/ruby/test_set.rb
@@ -781,6 +781,10 @@ class TC_Set < Test::Unit::TestCase
     ret.each { |s| n += s.size }
     assert_equal(set.size, n)
     assert_equal(set, ret.flatten)
+
+    set = Set[2,12,9,11,13,4,10,15,3,8,5,0,1,7,14]
+    ret = set.divide { |a,b| (a - b).abs == 1 }
+    assert_equal(2, ret.size)
   end
 
   def test_freeze


### PR DESCRIPTION
Implement `Set#divide` by union-find structure with path compression.
https://en.wikipedia.org/wiki/Disjoint-set_data_structure
Since `divide{|a,b|}` calls the given block `n**2` times in the worst case, there is no need to implement union-by-rank or union-by-size optimization.