### PR TITLE
ZJIT: Compile from offset PC for optional args

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -76,6 +76,20 @@ class TestZJIT < Test::Unit::TestCase
     }
   end
 
+  def test_providing_optional_arg
+    assert_compiles 'true', %q{
+      def test(opt=false) = opt
+      test(true)
+    }
+  end
+
+  def test_omitting_optional_arg
+    assert_compiles 'false', %q{
+      def test(opt=false) = opt
+      test
+    }
+  end
+
   def test_invokebuiltin
     assert_compiles '["."]', %q{
       def test = Dir.glob(".")

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -262,7 +262,7 @@ pub struct ID(pub ::std::os::raw::c_ulong);
 pub type IseqPtr = *const rb_iseq_t;
 
 // Given an ISEQ pointer, convert PC to insn_idx
-pub fn iseq_pc_to_insn_idx(iseq: IseqPtr, pc: *mut VALUE) -> Option<u16> {
+pub fn iseq_pc_to_insn_idx(iseq: IseqPtr, pc: *mut VALUE) -> Option<u32> {
     let pc_zero = unsafe { rb_iseq_pc_at_idx(iseq, 0) };
     unsafe { pc.offset_from(pc_zero) }.try_into().ok()
 }


### PR DESCRIPTION
Prior to this commit we hard-coded the starting `insn_idx` to 0. But optional args work by looking up an offset in the iseq's `opt_table` and starting from that offset instead.

We still need a guard to prevent executing with a different offset than we compiled for, but I'll do that in a separate commit.