### PR TITLE
Allow wakeup mutex to be used in trap context.

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -2847,6 +2847,7 @@ rb_thread_io_close_interrupt(struct rb_io *io)
 
     // This is used to ensure the correct execution context is woken up after the blocking operation is interrupted:
     io->wakeup_mutex = rb_mutex_new();
+    rb_mutex_allow_trap(io->wakeup_mutex, 1);
 
     // We need to use a mutex here as entering the fiber scheduler may cause a context switch:
     VALUE result = rb_mutex_synchronize(io->wakeup_mutex, thread_io_close_notify_all, (VALUE)io);


### PR DESCRIPTION
Fixes this issue:

```
-- Control frame information -----------------------------------------------
c:0012 p:---- s:0061 e:000060 CFUNC  :write
c:0011 p:---- s:0058 e:000057 CFUNC  :<<
c:0010 p:0007 s:0053 e:000052 METHOD /Users/samuel/Developer/ioquatix/puma/lib/puma/server.rb:615
c:0009 p:0009 s:0047 e:000046 METHOD /Users/samuel/Developer/ioquatix/puma/lib/puma/server.rb:633
c:0008 p:0034 s:0042 e:000041 BLOCK  /Users/samuel/Developer/ioquatix/puma/lib/puma/cluster/worker.rb:106 [FINISH]
c:0007 p:---- s:0039 e:000038 CFUNC  :join
c:0006 p:0359 s:0035 E:001630 METHOD /Users/samuel/Developer/ioquatix/puma/lib/puma/cluster/worker.rb:146
c:0005 p:0044 s:0023 e:000022 BLOCK  /Users/samuel/Developer/ioquatix/puma/lib/puma/cluster/worker.rb:169 [FINISH]
c:0004 p:---- s:0019 e:000018 CFUNC  :fork
c:0003 p:0020 s:0015 e:000014 METHOD /Users/samuel/Developer/ioquatix/puma/lib/puma/cluster/worker.rb:162
c:0002 p:0117 s:0009 e:000007 BLOCK  /Users/samuel/Developer/ioquatix/puma/lib/puma/cluster/worker.rb:96 [FINISH]
c:0001 p:---- s:0003 e:000002 DUMMY  [FINISH]

-- Ruby level backtrace information ----------------------------------------
/Users/samuel/Developer/ioquatix/puma/lib/puma/cluster/worker.rb:96:in 'block in run'
/Users/samuel/Developer/ioquatix/puma/lib/puma/cluster/worker.rb:162:in 'spawn_worker'
/Users/samuel/Developer/ioquatix/puma/lib/puma/cluster/worker.rb:162:in 'fork'
/Users/samuel/Developer/ioquatix/puma/lib/puma/cluster/worker.rb:169:in 'block in spawn_worker'
/Users/samuel/Developer/ioquatix/puma/lib/puma/cluster/worker.rb:146:in 'run'
/Users/samuel/Developer/ioquatix/puma/lib/puma/cluster/worker.rb:146:in 'join'
/Users/samuel/Developer/ioquatix/puma/lib/puma/cluster/worker.rb:106:in 'block in run'
/Users/samuel/Developer/ioquatix/puma/lib/puma/server.rb:633:in 'stop'
/Users/samuel/Developer/ioquatix/puma/lib/puma/server.rb:615:in 'notify_safely'
/Users/samuel/Developer/ioquatix/puma/lib/puma/server.rb:615:in '<<'
/Users/samuel/Developer/ioquatix/puma/lib/puma/server.rb:615:in 'write'

-- Threading information ---------------------------------------------------
Total ractor count: 1
Ruby thread count for this ractor: 6

-- C level backtrace information -------------------------------------------
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_vm_bugreport+0xb74) [0x1045e5084]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_bug_without_die_internal+0x108) [0x104415204]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_bug+0x1c) [0x104739514]
/Users/samuel/.rubies/ruby-head/bin/ruby(do_mutex_lock.cold.2+0x0) [0x10473d5dc]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_mutex_owned_p+0x0) [0x10457dc28]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_thread_io_blocking_call+0x404) [0x104580adc]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_io_write_memory+0xa4) [0x104466968]
/Users/samuel/.rubies/ruby-head/bin/ruby(io_binwrite_string+0xa0) [0x104466684]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_ensure+0xb4) [0x104421358]
/Users/samuel/.rubies/ruby-head/bin/ruby(io_binwrite+0x154) [0x104455028]
/Users/samuel/.rubies/ruby-head/bin/ruby(io_write+0x15c) [0x10446b578]
/Users/samuel/.rubies/ruby-head/bin/ruby(vm_call0_body+0x388) [0x1045dbec4]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_funcallv_scope+0x250) [0x1045c5190]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_io_addstr+0x3c) [0x1044550e0]
/Users/samuel/.rubies/ruby-head/bin/ruby(vm_call_cfunc_with_frame_+0xf0) [0x1045d6368]
/Users/samuel/.rubies/ruby-head/bin/ruby(vm_exec_core+0x4298) [0x1045bcaec]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_vm_exec+0x1b0) [0x1045b749c]
/Users/samuel/.rubies/ruby-head/bin/ruby(vm_invoke_proc+0x2b8) [0x1045ca864]
/Users/samuel/.rubies/ruby-head/bin/ruby(vm_call0_body+0x7c0) [0x1045dc2fc]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_call0+0x360) [0x1045dd2d0]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_eval_cmd_kw+0x188) [0x1045c7154]
/Users/samuel/.rubies/ruby-head/bin/ruby(signal_exec+0x108) [0x10453b06c]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_threadptr_execute_interrupts+0x204) [0x104580f80]
/Users/samuel/.rubies/ruby-head/bin/ruby(thread_join_sleep+0x2b0) [0x10458b850]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_ensure+0xb4) [0x104421358]
/Users/samuel/.rubies/ruby-head/bin/ruby(thread_join+0xb4) [0x10458b4d0]
/Users/samuel/.rubies/ruby-head/bin/ruby(thread_join_m+0xe8) [0x104586004]
/Users/samuel/.rubies/ruby-head/bin/ruby(vm_call_cfunc_with_frame_+0xf0) [0x1045d6368]
/Users/samuel/.rubies/ruby-head/bin/ruby(vm_exec_core+0x4298) [0x1045bcaec]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_vm_exec+0x35c) [0x1045b7648]
/Users/samuel/.rubies/ruby-head/bin/ruby(invoke_block_from_c_bh+0x370) [0x1045dea40]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_yield+0xc0) [0x1045c5b98]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_protect+0xb8) [0x1044211f8]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_f_fork+0x90) [0x1044e561c]
/Users/samuel/.rubies/ruby-head/bin/ruby(vm_call_cfunc_with_frame_+0xf0) [0x1045d6368]
/Users/samuel/.rubies/ruby-head/bin/ruby(vm_exec_core+0x18c4) [0x1045ba118]
/Users/samuel/.rubies/ruby-head/bin/ruby(rb_vm_exec+0x1b0) [0x1045b749c]
/Users/samuel/.rubies/ruby-head/bin/ruby(vm_invoke_proc+0x2b8) [0x1045ca864]
/Users/samuel/.rubies/ruby-head/bin/ruby(thread_do_start_proc+0x2d0) [0x104588a64]
/Users/samuel/.rubies/ruby-head/bin/ruby(thread_start_func_2+0x30c) [0x104587ee0]
/Users/samuel/.rubies/ruby-head/bin/ruby(nt_start+0xf4) [0x10458a644]
/usr/lib/system/libsystem_pthread.dylib(_pthread_start+0x88) [0x19e266c0c]
```