### PR TITLE
Never use flags on T_NODE

### DIFF
--- a/include/ruby/internal/fl_type.h
+++ b/include/ruby/internal/fl_type.h
@@ -442,10 +442,8 @@ RB_FL_ABLE(VALUE obj)
     if (RB_SPECIAL_CONST_P(obj)) {
         return false;
     }
-    else if (RB_TYPE_P(obj, RUBY_T_NODE)) {
-        return false;
-    }
     else {
+        RBIMPL_ASSERT_OR_ASSUME(!RB_TYPE_P(obj, RUBY_T_NODE));
         return true;
     }
 }


### PR DESCRIPTION
Previously, any time we used FL_TEST or variations we would need to add an additional test that it wasn't a T_NODE. I think that was only needed historically and we can avoid compiling that extra branch.