### PR TITLE
Removed vcvars from windows-2025 runner

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -30,15 +30,13 @@ jobs:
             vcvars: '14.2' # VS 2022 17.13.x is broken at windows-2022
             test_task: check
           - os: 2025
-            vc: 2019
-            vcvars: '14.2'
+            vc: 2022
             test_task: check
           - os: 11-arm
             test_task: 'btest test-basic test-tool' # check and test-spec are broken yet.
             target: arm64
-          - os: 2022
-            vc: 2019
-            vcvars: '14.2'
+          - os: 2025
+            vc: 2022
             test_task: test-bundled-gems
       fail-fast: false
 


### PR DESCRIPTION
windows-2025 runner updated Visual Studio from broken version.