### PR TITLE
Fix Windows CI for Ruby 3.4

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,13 +96,6 @@ jobs:
           windows-toolchain: none
         if: ${{ matrix.os != '2025' }}
 
-      - name: Export GitHub Actions cache environment variables
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
       - name: Install libraries with scoop
         run: |
           iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
@@ -153,12 +146,16 @@ jobs:
         run: Get-Volume
         shell: pwsh
 
+      - name: Restore vcpkg artifact
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ${{ github.workspace }}/src/vcpkg_installed
+          key: windows-${{ matrix.os }}-vcpkg-${{ hashFiles('src/vcpkg.json') }}
+
       - name: Install libraries with vcpkg
         run: |
           vcpkg install
         working-directory: src
-        env:
-          VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
 
       # TODO: We should use `../src` instead of `D:/a/ruby/ruby/src`
       - name: Configure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Install libraries with vcpkg
         run: |
-          vcpkg install
+          vcpkg install --vcpkg-root=C:\Users\runneradmin\scoop\apps\vcpkg\current
         working-directory: src
 
       # TODO: We should use `../src` instead of `D:/a/ruby/ruby/src`

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,6 +55,7 @@ jobs:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
       OS_VER: windows-${{ matrix.os }}
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.target || 'x64' }}-windows
+      TEST_BUNDLED_GEMS_ALLOW_FAILURES: "rake" # test-bundled-gems with windows-2025 is failed with rake test
 
     steps:
       - run: md build

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -286,6 +286,10 @@ WARNFLAGS = -W2 -wd4100 -wd4127 -wd4210 -wd4214 -wd4255 -wd4574 \
 !else
 WARNFLAGS = -W2
 !endif
+!if $(MSC_VER) >= 1944
+# https://developercommunity.visualstudio.com/t/warning-C5287:-operands-are-different-e/10877942
+WARNFLAGS = $(WARNFLAGS) -wd5287
+!endif
 !endif
 WERRORFLAG = -WX
 !if !defined(CFLAGS_NO_ARCH)


### PR DESCRIPTION
https://github.com/ruby/ruby/actions/runs/15866161213/job/44733343866 is failing now. It may be fixed with the following commit.

e1adb6cb15129a54df0c55a337e98b92b2a55e3f

```
Win: Suppress false warnings from Visual C 17.14.1

https://developercommunity.visualstudio.com/t/warning-C5287:-operands-are-different-e/10877942?

It is not able to silence "operands are different enum types" warnings, even using an explicit cast, as the message says.
```