### PR TITLE
Backport e1adb6cb15129a54df0c55a337e98b92b2a55e3f

### DIFF
--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -281,6 +281,10 @@ WARNFLAGS = -W2 -wd4100 -wd4127 -wd4210 -wd4214 -wd4255 -wd4574 \
 !else
 WARNFLAGS = -W2
 !endif
+!if $(MSC_VER) >= 1944
+# https://developercommunity.visualstudio.com/t/warning-C5287:-operands-are-different-e/10877942
+WARNFLAGS = $(WARNFLAGS) -wd5287
+!endif
 !endif
 WERRORFLAG = -WX
 !if !defined(CFLAGS_NO_ARCH)


### PR DESCRIPTION
This backport is same as https://github.com/ruby/ruby/pull/13695#issue-3174045312

```
Win: Suppress false warnings from Visual C 17.14.1

https://developercommunity.visualstudio.com/t/warning-C5287:-operands-are-different-e/10877942?

It is not able to silence "operands are different enum types" warnings, even using an explicit cast, as the message says.
```