### PR TITLE
Move RUBY_ATOMIC_VALUE_LOAD to ruby_atomic.h

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1851,8 +1851,6 @@ static const rb_data_type_t id2ref_tbl_type = {
     .flags = RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_FREE_IMMEDIATELY
 };
 
-#define RUBY_ATOMIC_VALUE_LOAD(x) (VALUE)(RUBY_ATOMIC_PTR_LOAD(x))
-
 static VALUE
 class_object_id(VALUE klass)
 {

--- a/ruby_atomic.h
+++ b/ruby_atomic.h
@@ -3,6 +3,8 @@
 
 #include "ruby/atomic.h"
 
+#define RUBY_ATOMIC_VALUE_LOAD(x) (VALUE)(RUBY_ATOMIC_PTR_LOAD(x))
+
 /* shim macros only */
 #define ATOMIC_ADD(var, val) RUBY_ATOMIC_ADD(var, val)
 #define ATOMIC_CAS(var, oldval, newval) RUBY_ATOMIC_CAS(var, oldval, newval)

--- a/shape.c
+++ b/shape.c
@@ -525,8 +525,6 @@ rb_shape_alloc_new_child(ID id, rb_shape_t *shape, enum shape_type shape_type)
     return new_shape;
 }
 
-#define RUBY_ATOMIC_VALUE_LOAD(x) (VALUE)(RUBY_ATOMIC_PTR_LOAD(x))
-
 static rb_shape_t *
 get_next_shape_internal_atomic(rb_shape_t *shape, ID id, enum shape_type shape_type, bool *variation_created, bool new_variations_allowed)
 {

--- a/string.c
+++ b/string.c
@@ -645,8 +645,6 @@ fstring_table_probe_next(struct fstring_table_probe *probe)
 }
 #endif
 
-#define RUBY_ATOMIC_VALUE_LOAD(x) (VALUE)(RUBY_ATOMIC_PTR_LOAD(x))
-
 static void
 fstring_insert_on_resize(struct fstring_table_struct *table, VALUE hash_code, VALUE value)
 {


### PR DESCRIPTION
Deduplicates RUBY_ATOMIC_VALUE_LOAD by moving it to ruby_atomic.h.