### PR TITLE
Assert AR table entry stability on replace

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -882,8 +882,9 @@ ar_general_foreach(VALUE hash, st_foreach_check_callback_func *func, st_update_c
                 if (replace) {
                     (*replace)(&key, &val, arg, TRUE);
 
-                    // TODO: pair should be same as pair before.
-                    pair = RHASH_AR_TABLE_REF(hash, i);
+                    // Pair should not have moved
+                    HASH_ASSERT(pair == RHASH_AR_TABLE_REF(hash, i));
+
                     pair->key = (VALUE)key;
                     pair->val = (VALUE)val;
                 }


### PR DESCRIPTION
Improve hash internal iteration by verifying that AR table entries remain stable after `st_update_callback_func` replaces a key-value pair. Fixes a [TODO](https://github.com/ruby/ruby/commit/72825c35b0d8b9d566663de961fddbf4f010fff7#diff-2894a90fd17590e4f7afd08dfd8505526d5283e09fea645cc7a7d4873936bdffR864) by @ko1 from 2019.