### PR TITLE
Freeze UNUSABLE_CHARS constant

### DIFF
--- a/lib/tmpdir.rb
+++ b/lib/tmpdir.rb
@@ -139,7 +139,7 @@ class Dir
     end
 
     # Unusable characters as path name
-    UNUSABLE_CHARS = "^,-.0-9A-Z_a-z~"
+    UNUSABLE_CHARS = "^,-.0-9A-Z_a_z~".freeze
 
     # Dedicated random number generator
     RANDOM = Object.new


### PR DESCRIPTION
The constant listing invalid characters for temporary file names is now frozen to prevent accidental modification, aligning it with the other constants in the module.