### PR TITLE
Fix Open3 documentation: clarify redirection options and blocking behavior

### DIFF
--- a/lib/open3.rb
+++ b/lib/open3.rb
@@ -78,6 +78,10 @@ require 'open3/version'
 # - An optional hash of execution options;
 #   see {Execution Options}[rdoc-ref:Process@Execution+Options].
 #
+# Note: When using methods that set up pipes for I/O streams,
+# the corresponding redirection options in the execution options
+# will be ignored for those streams.
+#
 module Open3
 
   # :call-seq:
@@ -147,6 +151,9 @@ module Open3
   # If the last argument is a hash, it becomes trailing argument +options+
   # in the call to Process.spawn;
   # see {Execution Options}[rdoc-ref:Process@Execution+Options].
+  #
+  # Note: The redirection options :in, :out, and :err will be ignored
+  # because popen3 sets up pipes for stdin, stdout, and stderr.
   #
   # The single required argument is one of the following:
   #
@@ -301,6 +308,9 @@ module Open3
   # in the call to Process.spawn;
   # see {Execution Options}[rdoc-ref:Process@Execution+Options].
   #
+  # Note: The redirection options :in and :out will be ignored
+  # because popen2 sets up pipes for stdin and stdout.
+  #
   # The single required argument is one of the following:
   #
   # - +command_line+ if it is a string,
@@ -445,6 +455,9 @@ module Open3
   # in the call to Process.spawn;
   # see {Execution Options}[rdoc-ref:Process@Execution+Options].
   #
+  # Note: The redirection options :in and [:out, :err] will be ignored
+  # because popen2e sets up pipes for stdin and merged stdout/stderr.
+  #
   # The single required argument is one of the following:
   #
   # - +command_line+ if it is a string,
@@ -583,6 +596,9 @@ module Open3
   # in the call to Open3.popen3;
   # see {Execution Options}[rdoc-ref:Process@Execution+Options].
   #
+  # Note: The redirection options :in, :out, and :err will be ignored
+  # because capture3 manages stdin, stdout, and stderr internally.
+  #
   # The hash +options+ is given;
   # two options have local effect in method Open3.capture3:
   #
@@ -708,6 +724,9 @@ module Open3
   # If the last argument is a hash, it becomes trailing argument +options+
   # in the call to Open3.popen3;
   # see {Execution Options}[rdoc-ref:Process@Execution+Options].
+  #
+  # Note: The redirection options :in and :out will be ignored
+  # because capture2 manages stdin and stdout internally.
   #
   # The hash +options+ is given;
   # two options have local effect in method Open3.capture2:
@@ -836,6 +855,9 @@ module Open3
   # If the last argument is a hash, it becomes trailing argument +options+
   # in the call to Open3.popen3;
   # see {Execution Options}[rdoc-ref:Process@Execution+Options].
+  #
+  # Note: The redirection options :in and [:out, :err] will be ignored
+  # because capture2e manages stdin and merged stdout/stderr internally.
   #
   # The hash +options+ is given;
   # two options have local effect in method Open3.capture2e:
@@ -1001,6 +1023,10 @@ module Open3
   # in each call to Process.spawn;
   # see {Execution Options}[rdoc-ref:Process@Execution+Options].
   #
+  # Note: The redirection options for the first process's stdin (:in)
+  # and the last process's stdout (:out) will be ignored
+  # because pipeline_rw sets up pipes for these.
+  #
   # Each remaining argument in +cmds+ is one of:
   #
   # - A +command_line+: a string that begins with a shell reserved word
@@ -1090,6 +1116,9 @@ module Open3
   # If the last argument is a hash, it becomes trailing argument +options+
   # in each call to Process.spawn;
   # see {Execution Options}[rdoc-ref:Process@Execution+Options].
+  #
+  # Note: The redirection option for the last process's stdout (:out)
+  # will be ignored because pipeline_r sets up a pipe for it.
   #
   # Each remaining argument in +cmds+ is one of:
   #
@@ -1182,6 +1211,9 @@ module Open3
   # in each call to Process.spawn;
   # see {Execution Options}[rdoc-ref:Process@Execution+Options].
   #
+  # Note: The redirection option for the first process's stdin (:in)
+  # will be ignored because pipeline_w sets up a pipe for it.
+  #
   # Each remaining argument in +cmds+ is one of:
   #
   # - A +command_line+: a string that begins with a shell reserved word
@@ -1259,6 +1291,9 @@ module Open3
   # in each call to Process.spawn;
   # see {Execution Options}[rdoc-ref:Process@Execution+Options].
   #
+  # Note: All redirection options are honored because pipeline_start
+  # does not set up any pipes automatically.
+  #
   # Each remaining argument in +cmds+ is one of:
   #
   # - A +command_line+: a string that begins with a shell reserved word
@@ -1318,8 +1353,11 @@ module Open3
   # see {Execution Environment}[rdoc-ref:Process@Execution+Environment].
   #
   # If the last argument is a hash, it becomes trailing argument +options+
-  # in each call to Process.spawn'
+  # in each call to Process.spawn;
   # see {Execution Options}[rdoc-ref:Process@Execution+Options].
+  #
+  # Note: Redirection options are generally honored, but pipes between
+  # commands are automatically managed.
   #
   # Each remaining argument in +cmds+ is one of:
   #

--- a/lib/open3.rb
+++ b/lib/open3.rb
@@ -141,8 +141,10 @@ module Open3
   # if called with untrusted input;
   # see {Command Injection}[rdoc-ref:command_injection.rdoc@Command+Injection].
   #
-  # Unlike Process.spawn, this method waits for the child process to exit
-  # before returning, so the caller need not do so.
+  # Blocking behavior:
+  # - With a block: waits for the child process to exit before returning.
+  # - Without a block: returns immediately without waiting for the child process;
+  #   the caller must call +wait_thread.join+ to wait for the process to exit.
   #
   # If the first argument is a hash, it becomes leading argument +env+
   # in the call to Process.spawn;
@@ -297,8 +299,10 @@ module Open3
   # if called with untrusted input;
   # see {Command Injection}[rdoc-ref:command_injection.rdoc@Command+Injection].
   #
-  # Unlike Process.spawn, this method waits for the child process to exit
-  # before returning, so the caller need not do so.
+  # Blocking behavior:
+  # - With a block: waits for the child process to exit before returning.
+  # - Without a block: returns immediately without waiting for the child process;
+  #   the caller must call +wait_thread.join+ to wait for the process to exit.
   #
   # If the first argument is a hash, it becomes leading argument +env+
   # in the call to Process.spawn;
@@ -444,8 +448,10 @@ module Open3
   # if called with untrusted input;
   # see {Command Injection}[rdoc-ref:command_injection.rdoc@Command+Injection].
   #
-  # Unlike Process.spawn, this method waits for the child process to exit
-  # before returning, so the caller need not do so.
+  # Blocking behavior:
+  # - With a block: waits for the child process to exit before returning.
+  # - Without a block: returns immediately without waiting for the child process;
+  #   the caller must call +wait_thread.join+ to wait for the process to exit.
   #
   # If the first argument is a hash, it becomes leading argument +env+
   # in the call to Process.spawn;
@@ -994,15 +1000,14 @@ module Open3
   #
   # With a block given, calls the block with the +stdin+ stream of the first child,
   # the +stdout+ stream  of the last child,
-  # and an array of the wait processes:
+  # and an array of the wait processes.
+  # The method automatically waits for all processes to exit after the block returns.
   #
   #   Open3.pipeline_rw('sort', 'cat -n') do |first_stdin, last_stdout, wait_threads|
   #     first_stdin.puts "foo\nbar\nbaz"
   #     first_stdin.close # send EOF to sort.
   #     puts last_stdout.read
-  #     wait_threads.each do |wait_thread|
-  #       wait_thread.join
-  #     end
+  #     # No need to join wait_threads - the method handles it automatically
   #   end
   #
   # Output:
@@ -1091,13 +1096,12 @@ module Open3
   #
   # With a block given, calls the block with the +stdout+ stream
   # of the last child process,
-  # and an array of the wait processes:
+  # and an array of the wait processes.
+  # The method automatically waits for all processes to exit after the block returns.
   #
   #   Open3.pipeline_r('ls', 'grep R') do |last_stdout, wait_threads|
   #     puts last_stdout.read
-  #     wait_threads.each do |wait_thread|
-  #       wait_thread.join
-  #     end
+  #     # No need to join wait_threads - the method handles it automatically
   #   end
   #
   # Output:
@@ -1183,14 +1187,13 @@ module Open3
   #
   # With a block given, calls the block with the +stdin+ stream
   # of the first child process,
-  # and an array of the wait processes:
+  # and an array of the wait processes.
+  # The method automatically waits for all processes to exit after the block returns.
   #
   #   Open3.pipeline_w('sort', 'cat -n') do |first_stdin, wait_threads|
   #     first_stdin.puts("foo\nbar\nbaz")
   #     first_stdin.close # Send EOF to sort.
-  #     wait_threads.each do |wait_thread|
-  #       wait_thread.join
-  #     end
+  #     # No need to join wait_threads - the method handles it automatically
   #   end
   #
   # Output:
@@ -1266,12 +1269,11 @@ module Open3
   #   Rakefile
   #   README.md
   #
-  # With a block given, calls the block with an array of the wait processes:
+  # With a block given, calls the block with an array of the wait processes.
+  # The method automatically waits for all processes to exit after the block returns.
   #
   #   Open3.pipeline_start('ls', 'grep R') do |wait_threads|
-  #     wait_threads.each do |wait_thread|
-  #       wait_thread.join
-  #     end
+  #     # No need to join wait_threads - the method handles it automatically
   #   end
   #
   # Output:


### PR DESCRIPTION
## Summary

This PR fixes documentation issues in the Open3 module:

1. **Clarifies ignored redirection options**: Each method that sets up pipes now clearly documents which redirection options will be ignored
2. **Fixes blocking behavior documentation**: The popen methods (popen3, popen2, popen2e) incorrectly stated they always wait for child processes. They actually only wait when used with a block
3. **Improves pipeline examples**: Removed misleading manual thread joining in block examples since the block form automatically waits

🤖 Generated with [Claude Code](https://claude.ai/code)