### PR TITLE
Optimize String#casecmp? for ASCII-only strings

### DIFF
--- a/string.c
+++ b/string.c
@@ -4790,7 +4790,6 @@ static VALUE
 str_casecmp_p(VALUE str1, VALUE str2)
 {
     rb_encoding *enc;
-    VALUE folded_str1, folded_str2;
     VALUE fold_opt = sym_fold;
 
     enc = rb_enc_compatible(str1, str2);
@@ -4798,8 +4797,14 @@ str_casecmp_p(VALUE str1, VALUE str2)
         return Qnil;
     }
 
-    folded_str1 = rb_str_downcase(1, &fold_opt, str1);
-    folded_str2 = rb_str_downcase(1, &fold_opt, str2);
+    if (ENC_CODERANGE(str1) == ENC_CODERANGE_7BIT &&
+        ENC_CODERANGE(str2) == ENC_CODERANGE_7BIT) {
+        VALUE cmp = str_casecmp(str1, str2);
+        return RBOOL(cmp == INT2FIX(0));
+    }
+
+    VALUE folded_str1 = rb_str_downcase(1, &fold_opt, str1);
+    VALUE folded_str2 = rb_str_downcase(1, &fold_opt, str2);
 
     return rb_str_eql(folded_str1, folded_str2);
 }


### PR DESCRIPTION
Optimized the routine for case-insensitive string comparison to avoid unnecessary allocations for ASCII-only strings. The check now uses `ENC_CODERANGE` and a direct comparison before falling back to Unicode case folding.