### PR TITLE
Fix race condition in signal handler query

### DIFF
--- a/internal/signal.h
+++ b/internal/signal.h
@@ -19,6 +19,7 @@ void (*ruby_posix_signal(int, void (*)(int)))(int);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* signal.c (export) */
+void rb_signal_atfork(void);
 RUBY_SYMBOL_EXPORT_END
 
 #endif /* INTERNAL_SIGNAL_H */

--- a/signal.c
+++ b/signal.c
@@ -678,9 +678,12 @@ signal_ignored(int sig)
     // SIG_GET: Returns the current value of the signal.
     func = signal(sig, SIG_GET);
 #else
-    // TODO: this is not a thread-safe way to do it. Needs lock.
-    sighandler_t old = signal(sig, SIG_DFL);
+    static rb_nativethread_lock_t sig_check_lock = RB_NATIVETHREAD_LOCK_INIT;
+    sighandler_t old;
+    rb_native_mutex_lock(&sig_check_lock);
+    old = signal(sig, SIG_DFL);
     signal(sig, old);
+    rb_native_mutex_unlock(&sig_check_lock);
     func = old;
 #endif
     if (func == SIG_IGN) return 1;

--- a/thread.c
+++ b/thread.c
@@ -4933,6 +4933,7 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
 
     thread_sched_atfork(TH_SCHED(th));
     ubf_list_atfork();
+    rb_signal_atfork();
 
     // OK. Only this thread accesses:
     ccan_list_for_each(&vm->ractor.set, r, vmlr_node) {


### PR DESCRIPTION
Introduced a static mutex when checking non-POSIX signal handlers, making the operation thread-safe and preventing races around the signal retrieval and restoration. Fixes TODO added by @luke-gruber in https://github.com/ruby/ruby/commit/1d4822a175a0dfccca8f252b0e757a1991bd54f9#diff-47e173231fbc1ddb6c555f7116c157cb32ab63d04e85047b55ff378e71fb965eR679.