### PR TITLE
Re-enabled result of `test-bundled-gems`

### DIFF
--- a/.github/workflows/bundled_gems.yml
+++ b/.github/workflows/bundled_gems.yml
@@ -104,7 +104,7 @@ jobs:
         timeout-minutes: 30
         env:
           RUBY_TESTOPTS: '-q --tty=no'
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,rbs,repl_type_completor,power_assert'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'power_assert'
         if: ${{ steps.diff.outputs.gems }}
 
       - name: Commit

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -146,7 +146,7 @@ jobs:
         timeout-minutes: 60
         env:
           RUBY_TESTOPTS: '-q --tty=no'
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,rbs,repl_type_completor,power_assert'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'power_assert'
           PRECHECK_BUNDLED_GEMS: 'no'
           LAUNCHABLE_STDOUT: ${{ steps.launchable.outputs.stdout_report_path }}
           LAUNCHABLE_STDERR: ${{ steps.launchable.outputs.stderr_report_path }}

--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -153,7 +153,7 @@ jobs:
         timeout-minutes: ${{ matrix.gc.timeout || 40 }}
         env:
           RUBY_TESTOPTS: '-q --tty=no'
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,rbs,repl_type_completor,power_assert'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'power_assert'
           PRECHECK_BUNDLED_GEMS: 'no'
           LAUNCHABLE_STDOUT: ${{ steps.launchable.outputs.stdout_report_path }}
           LAUNCHABLE_STDERR: ${{ steps.launchable.outputs.stderr_report_path }}

--- a/.github/workflows/parse_y.yml
+++ b/.github/workflows/parse_y.yml
@@ -87,7 +87,7 @@ jobs:
           EXCLUDES: '../src/test/.excludes-parsey'
           RUN_OPTS: ${{ matrix.run_opts || '--parser=parse.y' }}
           SPECOPTS: ${{ matrix.specopts || '-T --parser=parse.y' }}
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,rbs,repl_type_completor,power_assert'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'power_assert'
 
       - uses: ./.github/actions/slack
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -133,7 +133,7 @@ jobs:
         timeout-minutes: ${{ matrix.timeout || 40 }}
         env:
           RUBY_TESTOPTS: '-q --tty=no'
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,rbs,repl_type_completor,power_assert'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'power_assert'
           PRECHECK_BUNDLED_GEMS: 'no'
           LAUNCHABLE_STDOUT: ${{ steps.launchable.outputs.stdout_report_path }}
           LAUNCHABLE_STDERR: ${{ steps.launchable.outputs.stderr_report_path }}

--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -153,7 +153,7 @@ jobs:
         timeout-minutes: 60
         env:
           RUBY_TESTOPTS: '-q --tty=no'
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,rbs,repl_type_completor,power_assert'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'power_assert'
           SYNTAX_SUGGEST_TIMEOUT: '5'
           PRECHECK_BUNDLED_GEMS: 'no'
           LAUNCHABLE_STDOUT: ${{ steps.launchable.outputs.stdout_report_path }}

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -201,7 +201,7 @@ jobs:
         timeout-minutes: 90
         env:
           RUBY_TESTOPTS: '-q --tty=no'
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,rbs,repl_type_completor,power_assert'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'power_assert'
           PRECHECK_BUNDLED_GEMS: 'no'
           SYNTAX_SUGGEST_TIMEOUT: '5'
           YJIT_BINDGEN_DIFF_OPTS: '--exit-code'

--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -150,7 +150,7 @@ jobs:
         timeout-minutes: 60
         env:
           RUBY_TESTOPTS: '-q --tty=no'
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,power_assert'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'power_assert'
           SYNTAX_SUGGEST_TIMEOUT: '5'
           PRECHECK_BUNDLED_GEMS: 'no'
           TESTS: ${{ matrix.tests }}

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -172,7 +172,7 @@ jobs:
         timeout-minutes: 90
         env:
           RUBY_TESTOPTS: '-q --tty=no'
-          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'typeprof,power_assert'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: 'power_assert'
           PRECHECK_BUNDLED_GEMS: 'no'
           SYNTAX_SUGGEST_TIMEOUT: '5'
           ZJIT_BINDGEN_DIFF_OPTS: '--exit-code'


### PR DESCRIPTION
`typeprof`, `rbs` and `repl_type_completor` are working with HEAD now.