### PR TITLE
Fix flaky TestGc#test_heaps_grow_independently

### DIFF
--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -701,6 +701,11 @@ class TestGc < Test::Unit::TestCase
         allocate_large_object
       end
 
+      # Running GC here is required to prevent this test from being flaky because
+      # the heap for the small transient objects may not have been cleared by the
+      # GC causing heap_available_slots to be slightly over 2 * COUNT.
+      GC.start
+
       heap_available_slots = GC.stat(:heap_available_slots)
 
       assert_operator(heap_available_slots, :<, COUNT * 2, "GC.stat: #{GC.stat}\nGC.stat_heap: #{GC.stat_heap}")


### PR DESCRIPTION
The test sometimes fails with "Expected 2062788 to be < 2000000" because heap 0 has not been cleared yet by GC. This commit fixes it to run GC before the assertion to ensure that it does not flake.