### PR TITLE
add VM Lock around `rb_const_remove` operations (Module#remove_const)

### DIFF
--- a/constant.h
+++ b/constant.h
@@ -44,7 +44,8 @@ void rb_free_const_table(struct rb_id_table *tbl);
 VALUE rb_const_source_location(VALUE, ID);
 
 int rb_autoloading_value(VALUE mod, ID id, VALUE *value, rb_const_flag_t *flag);
-rb_const_entry_t *rb_const_lookup(VALUE klass, ID id, rb_const_entry_t *entry_out);
+rb_const_entry_t *rb_const_lookup_locked(VALUE klass, ID id);
+bool rb_const_lookup_unlocked(VALUE klass, ID id, rb_const_entry_t *entry_out);
 VALUE rb_public_const_get_at(VALUE klass, ID id);
 VALUE rb_public_const_get_from(VALUE klass, ID id);
 int rb_public_const_defined_from(VALUE klass, ID id);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1090,10 +1090,9 @@ vm_get_ev_const(rb_execution_context_t *ec, VALUE orig_klass, ID id, bool allow_
 
             if (!NIL_P(klass)) {
                 VALUE av, am = 0;
-                rb_const_entry_t *ce;
                 rb_const_entry_t ce_out = {0};
               search_continue:
-                if ((ce = rb_const_lookup(klass, id, &ce_out))) {
+                if (rb_const_lookup_unlocked(klass, id, &ce_out)) {
                     rb_const_warn_if_deprecated(&ce_out, klass, id);
                     val = ce_out.value;
                     if (UNDEF_P(val)) {


### PR DESCRIPTION
Without a VM Lock, there's an unlocked `rb_id_table_delete` for the class's const_tbl which can cause problems. Example:

```ruby
class C
  CONSTANT = 3
end
$VERBOSE = nil
rs = []
100.times do
  rs << Ractor.new do
    10_000.times do
      if defined?(C::CONSTANT)
        C.send(:remove_const, :CONSTANT) rescue NameError
      else
        C.send(:const_set, :CONSTANT, 3)
      end
    end
  end
end
while rs.any?
  r, obj = Ractor.select(*rs)
  rs.delete(r)
end
```

Without lock:
../ruby-release/test.rb:14: [BUG] Segmentation fault at 0x0000000000000001 -- Control frame information ----------------------------------------------- miniruby(82790,0x16f49f000) malloc: *** error for object 0x600000f880a0: pointer being freed was not allocated miniruby(82790,0x16f49f000) malloc: *** set a breakpoint in malloc_error_break to debug