### PR TITLE
ZJIT: Stop loading an extra parameter

### DIFF
--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -107,39 +107,39 @@ jobs:
         run: |
           RUST_BACKTRACE=1 ruby --disable=gems ../src/bootstraptest/runner.rb --ruby="./miniruby -I../src/lib -I. -I.ext/common --zjit-call-threshold=1" \
           ../src/bootstraptest/test_attr.rb \
+          ../src/bootstraptest/test_autoload.rb \
           ../src/bootstraptest/test_constant_cache.rb \
           ../src/bootstraptest/test_env.rb \
+          ../src/bootstraptest/test_fiber.rb \
           ../src/bootstraptest/test_finalizer.rb \
           ../src/bootstraptest/test_flip.rb \
+          ../src/bootstraptest/test_flow.rb \
+          ../src/bootstraptest/test_fork.rb \
+          ../src/bootstraptest/test_io.rb \
+          ../src/bootstraptest/test_jump.rb \
           ../src/bootstraptest/test_literal.rb \
           ../src/bootstraptest/test_literal_suffix.rb \
+          ../src/bootstraptest/test_marshal.rb \
+          ../src/bootstraptest/test_objectspace.rb \
           ../src/bootstraptest/test_string.rb \
           ../src/bootstraptest/test_struct.rb \
+          ../src/bootstraptest/test_syntax.rb \
           ../src/bootstraptest/test_yjit_30k_ifelse.rb \
-          ../src/bootstraptest/test_yjit_30k_methods.rb
-        # ../src/bootstraptest/test_autoload.rb \
+          ../src/bootstraptest/test_yjit_30k_methods.rb \
+          ../src/bootstraptest/test_yjit_rust_port.rb
         # ../src/bootstraptest/test_block.rb \
         # ../src/bootstraptest/test_class.rb \
         # ../src/bootstraptest/test_eval.rb \
         # ../src/bootstraptest/test_exception.rb \
-        # ../src/bootstraptest/test_fiber.rb \
-        # ../src/bootstraptest/test_flow.rb \
-        # ../src/bootstraptest/test_fork.rb \
         # ../src/bootstraptest/test_gc.rb \
         # ../src/bootstraptest/test_insns.rb \
-        # ../src/bootstraptest/test_io.rb \
-        # ../src/bootstraptest/test_jump.rb \
         # ../src/bootstraptest/test_load.rb \
-        # ../src/bootstraptest/test_marshal.rb \
         # ../src/bootstraptest/test_massign.rb \
         # ../src/bootstraptest/test_method.rb \
-        # ../src/bootstraptest/test_objectspace.rb \
         # ../src/bootstraptest/test_proc.rb \
         # ../src/bootstraptest/test_ractor.rb \
-        # ../src/bootstraptest/test_syntax.rb \
         # ../src/bootstraptest/test_thread.rb \
         # ../src/bootstraptest/test_yjit.rb \
-        # ../src/bootstraptest/test_yjit_rust_port.rb \
         if: ${{ matrix.test_task == 'btest' }}
 
       - name: make ${{ matrix.test_task }}

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -129,39 +129,39 @@ jobs:
         run: |
           RUST_BACKTRACE=1 ruby --disable=gems ../src/bootstraptest/runner.rb --ruby="./miniruby -I../src/lib -I. -I.ext/common --zjit-call-threshold=1" \
           ../src/bootstraptest/test_attr.rb \
+          ../src/bootstraptest/test_autoload.rb \
           ../src/bootstraptest/test_constant_cache.rb \
           ../src/bootstraptest/test_env.rb \
+          ../src/bootstraptest/test_fiber.rb \
           ../src/bootstraptest/test_finalizer.rb \
           ../src/bootstraptest/test_flip.rb \
+          ../src/bootstraptest/test_flow.rb \
+          ../src/bootstraptest/test_fork.rb \
+          ../src/bootstraptest/test_io.rb \
+          ../src/bootstraptest/test_jump.rb \
           ../src/bootstraptest/test_literal.rb \
           ../src/bootstraptest/test_literal_suffix.rb \
+          ../src/bootstraptest/test_marshal.rb \
           ../src/bootstraptest/test_massign.rb \
+          ../src/bootstraptest/test_objectspace.rb \
           ../src/bootstraptest/test_string.rb \
           ../src/bootstraptest/test_struct.rb \
+          ../src/bootstraptest/test_syntax.rb \
           ../src/bootstraptest/test_yjit_30k_ifelse.rb \
-          ../src/bootstraptest/test_yjit_30k_methods.rb
-        # ../src/bootstraptest/test_autoload.rb \
+          ../src/bootstraptest/test_yjit_30k_methods.rb \
+          ../src/bootstraptest/test_yjit_rust_port.rb
         # ../src/bootstraptest/test_block.rb \
         # ../src/bootstraptest/test_class.rb \
         # ../src/bootstraptest/test_eval.rb \
         # ../src/bootstraptest/test_exception.rb \
-        # ../src/bootstraptest/test_fiber.rb \
-        # ../src/bootstraptest/test_flow.rb \
-        # ../src/bootstraptest/test_fork.rb \
         # ../src/bootstraptest/test_gc.rb \
         # ../src/bootstraptest/test_insns.rb \
-        # ../src/bootstraptest/test_io.rb \
-        # ../src/bootstraptest/test_jump.rb \
         # ../src/bootstraptest/test_load.rb \
-        # ../src/bootstraptest/test_marshal.rb \
         # ../src/bootstraptest/test_method.rb \
-        # ../src/bootstraptest/test_objectspace.rb \
         # ../src/bootstraptest/test_proc.rb \
         # ../src/bootstraptest/test_ractor.rb \
-        # ../src/bootstraptest/test_syntax.rb \
         # ../src/bootstraptest/test_thread.rb \
         # ../src/bootstraptest/test_yjit.rb \
-        # ../src/bootstraptest/test_yjit_rust_port.rb \
         if: ${{ matrix.test_task == 'btest' }}
 
       - name: make ${{ matrix.test_task }}

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -429,7 +429,7 @@ fn gen_method_params(asm: &mut Assembler, iseq: IseqPtr, entry_block: &Block) {
     let self_param = gen_param(asm, SELF_PARAM_IDX);
     asm.mov(self_param, Opnd::mem(VALUE_BITS, CFP, RUBY_OFFSET_CFP_SELF));
 
-    let num_params = entry_block.params().len();
+    let num_params = entry_block.params().len() - 1; // -1 to exclude self
     if num_params > 0 {
         asm_comment!(asm, "set method params: {num_params}");
 


### PR DESCRIPTION
Follow-up on: https://github.com/ruby/ruby/pull/13529

This PR fixes `gen_method_params()` to avoid loading one extra parameter. While we added a new basic block argument, we didn't decrement `num_params` at `gen_method_params()`. As a result, even if an ISEQ has no argument, `num_params` becomes 1 and we load a parameter that doesn't exist.

Currently, many btests are failing on `tool/fake.rb` loaded by the bootstraptest runner because `<main>` assumes EP == BP for loading a first parameter that doesn't exist on `<main>`. So fixing this makes a lot more tests pass.