### PR TITLE
Fix backquote exit status docs

### DIFF
--- a/io.c
+++ b/io.c
@@ -10668,7 +10668,7 @@ argf_readlines(int argc, VALUE *argv, VALUE argf)
  *    $ `date`                 # => "Wed Apr  9 08:56:30 CDT 2003\n"
  *    $ `echo oops && exit 99` # => "oops\n"
  *    $ $?                     # => #<Process::Status: pid 17088 exit 99>
- *    $ $?.status              # => 99>
+ *    $ $?.exitstatus          # => 99>
  *
  *  The built-in syntax <tt>%x{...}</tt> uses this method.
  *


### PR DESCRIPTION
It is `exitstatus`, not `status`, per https://github.com/ruby/ruby/blob/3d5619c8b1a76626e0991d758b71afc549829c38/process.c#L581
