### PR TITLE
Fix the unknown warning group on wasm

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -4779,7 +4779,7 @@ rb_gc_set_stack_end(VALUE **stack_end_p)
 {
     VALUE stack_end;
 COMPILER_WARNING_PUSH
-#ifdef __GNUC__
+#if RBIMPL_COMPILER_IS(GCC)
 COMPILER_WARNING_IGNORED(-Wdangling-pointer);
 #endif
     *stack_end_p = &stack_end;


### PR DESCRIPTION
```
../src/thread.c:4783:1: warning: unknown warning group '-Wdangling-pointer', ignored [-Wunknown-warning-option]
 4783 | COMPILER_WARNING_IGNORED(-Wdangling-pointer);
      | ^
```