### PR TITLE
Inline ASAN poison functions when ASAN is not enabled

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4933,6 +4933,7 @@ rb_raw_obj_info_buitin_type(char *const buff, const size_t buff_size, const VALU
 
 #undef C
 
+#ifdef RUBY_ASAN_ENABLED
 void
 rb_asan_poison_object(VALUE obj)
 {
@@ -4953,6 +4954,7 @@ rb_asan_poisoned_object_p(VALUE obj)
     MAYBE_UNUSED(struct RVALUE *) ptr = (void *)obj;
     return __asan_region_is_poisoned(ptr, rb_gc_obj_slot_size(obj));
 }
+#endif
 
 static void
 raw_obj_info(char *const buff, const size_t buff_size, VALUE obj)

--- a/internal/sanitizers.h
+++ b/internal/sanitizers.h
@@ -127,6 +127,7 @@ asan_poison_memory_region(const volatile void *ptr, size_t size)
 #define asan_poison_object_if(ptr, obj) ((void)(ptr), (void)(obj))
 #endif
 
+#ifdef RUBY_ASAN_ENABLED
 RUBY_SYMBOL_EXPORT_BEGIN
 /**
  * This is a variant of asan_poison_memory_region that takes a VALUE.
@@ -153,6 +154,11 @@ void *rb_asan_poisoned_object_p(VALUE obj);
 void rb_asan_unpoison_object(VALUE obj, bool newobj_p);
 
 RUBY_SYMBOL_EXPORT_END
+#else
+# define rb_asan_poison_object(obj) ((void)obj)
+# define rb_asan_poisoned_object_p(obj) ((void)obj, NULL)
+# define rb_asan_unpoison_object(obj, newobj_p) ((void)obj, (void)newobj_p)
+#endif
 
 /**
  * This function asserts that a (formally poisoned) memory region from ptr to


### PR DESCRIPTION
The ASAN poison functions was always defined in gc.c, even if ASAN was not enabled. This made function calls to happen all the time even if ASAN is not enabled. This commit defines these functions as empty macros when ASAN is not enabled.