### PR TITLE
Implements [Feature #21455] Add a block argument to Array#join

### DIFF
--- a/array.c
+++ b/array.c
@@ -2925,6 +2925,8 @@ rb_ary_join(VALUE ary, VALUE sep)
     return result;
 }
 
+static VALUE rb_ary_collect(VALUE ary);
+
 /*
  *  call-seq:
  *    join(separator = $,) -> new_string
@@ -2947,6 +2949,13 @@ rb_ary_join(VALUE ary, VALUE sep)
  *    a = [:foo, 'bar', 2]
  *    a.join("\n") # => "foo\nbar\n2"
  *
+ *  With a block given, applies the block to each element and joins the results:
+ *
+ *    a = ['Hello', 'world', '!']
+ *    a.join { |s| s.upcase } # => "HELLOWORLD!"
+ *    a.join(' ') { |s| s.upcase } # => "HELLO WORLD !"
+ *    a.join(' ', &:upcase) # => "HELLO WORLD !"
+ *
  *  Joins recursively for nested arrays:
  *
  *   a = [:foo, [:bar, [:baz, :bat]]]
@@ -2966,7 +2975,12 @@ rb_ary_join_m(int argc, VALUE *argv, VALUE ary)
         }
     }
 
-    return rb_ary_join(ary, sep);
+    if (rb_block_given_p()) {
+        return rb_ary_join(rb_ary_collect(ary), sep);
+    }
+    else {
+        return rb_ary_join(ary, sep);
+    }
 }
 
 static VALUE

--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1213,6 +1213,23 @@ class TestArray < Test::Unit::TestCase
     $, = nil
   end
 
+  def test_join_with_block
+    assert_equal("", @cls[].join { |i| i ** 3 })
+    assert_equal("1", @cls[1].join { |i| i ** 3 })
+    assert_equal("18", @cls[1,2].join { |i| i ** 3 })
+    assert_equal("1827", @cls[1,2,3].join { |i| i ** 3 })
+
+    assert_equal("", @cls[].join(',') { |i| i ** 3 })
+    assert_equal("1", @cls[1].join(',') { |i| i ** 3 })
+    assert_equal("1,8", @cls[1,2].join(',') { |i| i ** 3 })
+    assert_equal("1,8,27", @cls[1,2,3].join(',') { |i| i ** 3 })
+
+    a = @cls['Hello', 'world', '!']
+    assert_equal("HELLOWORLD!", a.join { |s| s.upcase })
+    assert_equal("HELLO WORLD !", a.join(' ') { |s| s.upcase })
+    assert_equal("HELLO WORLD !", a.join(' ', &:upcase))
+  end
+
   def test_last
     assert_equal(nil, @cls[].last)
     assert_equal(1, @cls[1].last)


### PR DESCRIPTION
I sometimes come across code like this where
the `Array#join` at the end can easily
be overlooked or stands out like a sore thumb:

```ruby
hex_string = string.bytes.map do |byte|
  format('%02X', byte)
end.join(' ')
```

It seems idiomatic and more succinct
to pass the block to `Array#join` directly:

```ruby
hex_string = string.bytes.join(' ') do |byte|
  format('%02X', byte)
end
```