### PR TITLE
Check dump size in ibf_dump_write

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -12602,8 +12602,13 @@ static ibf_offset_t
 ibf_dump_write(struct ibf_dump *dump, const void *buff, unsigned long size)
 {
     ibf_offset_t pos = ibf_dump_pos(dump);
+#if SIZEOF_LONG > SIZEOF_INT
+    /* ensure the resulting dump does not exceed UINT_MAX */
+    if (size >= UINT_MAX || pos + size >= UINT_MAX) {
+        rb_raise(rb_eRuntimeError, "dump size exceeds");
+    }
+#endif
     rb_str_cat(dump->current_buffer->str, (const char *)buff, size);
-    /* TODO: overflow check */
     return pos;
 }
 


### PR DESCRIPTION
Fixes TODO added by @ko1 in https://github.com/ruby/ruby/commit/3dbb390180a0e9f98623b6db0d71b0213359c541.