### PR TITLE
Add Set C-API

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -2268,6 +2268,7 @@ array.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 array.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 array.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 array.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+array.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 array.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 array.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 array.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -2506,6 +2507,7 @@ ast.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 ast.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 ast.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 ast.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+ast.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 ast.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 ast.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 ast.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -2721,6 +2723,7 @@ bignum.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 bignum.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 bignum.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 bignum.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+bignum.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 bignum.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 bignum.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 bignum.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -2947,6 +2950,7 @@ builtin.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 builtin.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 builtin.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 builtin.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+builtin.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 builtin.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 builtin.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 builtin.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -3160,6 +3164,7 @@ class.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 class.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 class.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 class.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+class.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 class.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 class.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 class.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -3355,6 +3360,7 @@ compar.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 compar.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 compar.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 compar.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+compar.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 compar.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 compar.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 compar.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -3595,6 +3601,7 @@ compile.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 compile.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 compile.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 compile.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+compile.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 compile.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 compile.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 compile.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -3825,6 +3832,7 @@ complex.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 complex.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 complex.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 complex.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+complex.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 complex.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 complex.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 complex.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -3876,10 +3884,10 @@ concurrent_set.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 concurrent_set.$(OBJEXT): $(top_srcdir)/internal/array.h
 concurrent_set.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 concurrent_set.$(OBJEXT): $(top_srcdir)/internal/compilers.h
+concurrent_set.$(OBJEXT): $(top_srcdir)/internal/concurrent_set.h
 concurrent_set.$(OBJEXT): $(top_srcdir)/internal/gc.h
 concurrent_set.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 concurrent_set.$(OBJEXT): $(top_srcdir)/internal/namespace.h
-concurrent_set.$(OBJEXT): $(top_srcdir)/internal/concurrent_set.h
 concurrent_set.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 concurrent_set.$(OBJEXT): $(top_srcdir)/internal/serial.h
 concurrent_set.$(OBJEXT): $(top_srcdir)/internal/set_table.h
@@ -3897,6 +3905,7 @@ concurrent_set.$(OBJEXT): {$(VPATH)}backward/2/limits.h
 concurrent_set.$(OBJEXT): {$(VPATH)}backward/2/long_long.h
 concurrent_set.$(OBJEXT): {$(VPATH)}backward/2/stdalign.h
 concurrent_set.$(OBJEXT): {$(VPATH)}backward/2/stdarg.h
+concurrent_set.$(OBJEXT): {$(VPATH)}concurrent_set.c
 concurrent_set.$(OBJEXT): {$(VPATH)}config.h
 concurrent_set.$(OBJEXT): {$(VPATH)}debug_counter.h
 concurrent_set.$(OBJEXT): {$(VPATH)}defines.h
@@ -4028,6 +4037,7 @@ concurrent_set.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 concurrent_set.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 concurrent_set.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 concurrent_set.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+concurrent_set.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 concurrent_set.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 concurrent_set.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 concurrent_set.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -4059,7 +4069,6 @@ concurrent_set.$(OBJEXT): {$(VPATH)}missing.h
 concurrent_set.$(OBJEXT): {$(VPATH)}node.h
 concurrent_set.$(OBJEXT): {$(VPATH)}onigmo.h
 concurrent_set.$(OBJEXT): {$(VPATH)}oniguruma.h
-concurrent_set.$(OBJEXT): {$(VPATH)}concurrent_set.c
 concurrent_set.$(OBJEXT): {$(VPATH)}ruby_assert.h
 concurrent_set.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 concurrent_set.$(OBJEXT): {$(VPATH)}rubyparser.h
@@ -4263,6 +4272,7 @@ cont.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 cont.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 cont.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 cont.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+cont.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 cont.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 cont.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 cont.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -4480,6 +4490,7 @@ debug.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 debug.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 debug.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 debug.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+debug.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 debug.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 debug.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 debug.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -4659,6 +4670,7 @@ debug_counter.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 debug_counter.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 debug_counter.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 debug_counter.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+debug_counter.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 debug_counter.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 debug_counter.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 debug_counter.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -4862,6 +4874,7 @@ dir.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 dir.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 dir.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 dir.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+dir.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 dir.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 dir.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 dir.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -5040,6 +5053,7 @@ dln.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 dln.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 dln.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 dln.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+dln.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 dln.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 dln.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 dln.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -5198,6 +5212,7 @@ dln_find.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 dln_find.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 dln_find.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 dln_find.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+dln_find.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 dln_find.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 dln_find.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 dln_find.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -5355,6 +5370,7 @@ dmydln.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 dmydln.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 dmydln.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 dmydln.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+dmydln.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 dmydln.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 dmydln.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 dmydln.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -6375,6 +6391,7 @@ encoding.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 encoding.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 encoding.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 encoding.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+encoding.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 encoding.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 encoding.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 encoding.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -6586,6 +6603,7 @@ enum.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 enum.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 enum.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 enum.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+enum.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 enum.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 enum.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 enum.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -6796,6 +6814,7 @@ enumerator.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 enumerator.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 enumerator.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 enumerator.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+enumerator.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 enumerator.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 enumerator.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 enumerator.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -7014,6 +7033,7 @@ error.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 error.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 error.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 error.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+error.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 error.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 error.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 error.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -7260,6 +7280,7 @@ eval.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 eval.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 eval.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 eval.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+eval.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 eval.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 eval.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 eval.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -7499,6 +7520,7 @@ file.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 file.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 file.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 file.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+file.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 file.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 file.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 file.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -7747,6 +7769,7 @@ gc.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 gc.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 gc.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 gc.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+gc.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 gc.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 gc.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 gc.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -8003,6 +8026,7 @@ goruby.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 goruby.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 goruby.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 goruby.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+goruby.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 goruby.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 goruby.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 goruby.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -8249,6 +8273,7 @@ hash.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 hash.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 hash.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 hash.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+hash.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 hash.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 hash.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 hash.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -8467,6 +8492,7 @@ imemo.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 imemo.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 imemo.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 imemo.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+imemo.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 imemo.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 imemo.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 imemo.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -8645,6 +8671,7 @@ inits.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 inits.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 inits.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 inits.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+inits.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 inits.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 inits.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 inits.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -8855,6 +8882,7 @@ io.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 io.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 io.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 io.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+io.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 io.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 io.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 io.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -9073,6 +9101,7 @@ io_buffer.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 io_buffer.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 io_buffer.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 io_buffer.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+io_buffer.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 io_buffer.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 io_buffer.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 io_buffer.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -9322,6 +9351,7 @@ iseq.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 iseq.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 iseq.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 iseq.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+iseq.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 iseq.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 iseq.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 iseq.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -9564,6 +9594,7 @@ jit.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 jit.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 jit.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 jit.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+jit.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 jit.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 jit.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 jit.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -9814,6 +9845,7 @@ load.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 load.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 load.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 load.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+load.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 load.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 load.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 load.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -9996,6 +10028,7 @@ loadpath.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 loadpath.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 loadpath.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 loadpath.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+loadpath.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 loadpath.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 loadpath.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 loadpath.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -10166,6 +10199,7 @@ localeinit.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 localeinit.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 localeinit.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 localeinit.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+localeinit.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 localeinit.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 localeinit.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 localeinit.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -10331,6 +10365,7 @@ main.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 main.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 main.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 main.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+main.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 main.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 main.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 main.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -10540,6 +10575,7 @@ marshal.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 marshal.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 marshal.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 marshal.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+marshal.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 marshal.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 marshal.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 marshal.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -10730,6 +10766,7 @@ math.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 math.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 math.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 math.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+math.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 math.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 math.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 math.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -10923,6 +10960,7 @@ memory_view.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 memory_view.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 memory_view.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 memory_view.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+memory_view.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 memory_view.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 memory_view.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 memory_view.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -11165,6 +11203,7 @@ miniinit.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 miniinit.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 miniinit.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 miniinit.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+miniinit.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 miniinit.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 miniinit.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 miniinit.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -11399,6 +11438,7 @@ namespace.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 namespace.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 namespace.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 namespace.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+namespace.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 namespace.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 namespace.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 namespace.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -11605,6 +11645,7 @@ node.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 node.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 node.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 node.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+node.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 node.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 node.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 node.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -11819,6 +11860,7 @@ node_dump.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 node_dump.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 node_dump.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 node_dump.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+node_dump.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 node_dump.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 node_dump.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 node_dump.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -12036,6 +12078,7 @@ numeric.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 numeric.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 numeric.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 numeric.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+numeric.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 numeric.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 numeric.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 numeric.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -12256,6 +12299,7 @@ object.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 object.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 object.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 object.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+object.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 object.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 object.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 object.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -12472,6 +12516,7 @@ pack.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 pack.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 pack.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 pack.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+pack.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 pack.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 pack.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 pack.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -12696,6 +12741,7 @@ parse.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 parse.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 parse.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 parse.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+parse.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 parse.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 parse.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 parse.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -12973,6 +13019,7 @@ prism/api_node.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 prism/api_node.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 prism/api_node.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 prism/api_node.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+prism/api_node.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 prism/api_node.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 prism/api_node.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 prism/api_node.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -13168,6 +13215,7 @@ prism/api_pack.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 prism/api_pack.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 prism/api_pack.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 prism/api_pack.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+prism/api_pack.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 prism/api_pack.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 prism/api_pack.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 prism/api_pack.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -13377,6 +13425,7 @@ prism/extension.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 prism/extension.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 prism/extension.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 prism/extension.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+prism/extension.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 prism/extension.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 prism/extension.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 prism/extension.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -13766,6 +13815,7 @@ prism_init.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 prism_init.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 prism_init.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 prism_init.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+prism_init.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 prism_init.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 prism_init.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 prism_init.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -13992,6 +14042,7 @@ proc.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 proc.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 proc.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 proc.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+proc.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 proc.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 proc.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 proc.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -14225,6 +14276,7 @@ process.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 process.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 process.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 process.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+process.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 process.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 process.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 process.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -14452,6 +14504,7 @@ ractor.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 ractor.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 ractor.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 ractor.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+ractor.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 ractor.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 ractor.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 ractor.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -14668,6 +14721,7 @@ random.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 random.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 random.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 random.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+random.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 random.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 random.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 random.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -14875,6 +14929,7 @@ range.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 range.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 range.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 range.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+range.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 range.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 range.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 range.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -15076,6 +15131,7 @@ rational.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 rational.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 rational.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 rational.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+rational.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 rational.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 rational.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 rational.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -15291,6 +15347,7 @@ re.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 re.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 re.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 re.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+re.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 re.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 re.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 re.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -15469,6 +15526,7 @@ regcomp.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 regcomp.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 regcomp.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 regcomp.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+regcomp.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 regcomp.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 regcomp.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 regcomp.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -15631,6 +15689,7 @@ regenc.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 regenc.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 regenc.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 regenc.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+regenc.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 regenc.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 regenc.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 regenc.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -15792,6 +15851,7 @@ regerror.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 regerror.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 regerror.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 regerror.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+regerror.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 regerror.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 regerror.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 regerror.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -15953,6 +16013,7 @@ regexec.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 regexec.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 regexec.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 regexec.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+regexec.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 regexec.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 regexec.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 regexec.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -16118,6 +16179,7 @@ regparse.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 regparse.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 regparse.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 regparse.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+regparse.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 regparse.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 regparse.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 regparse.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -16280,6 +16342,7 @@ regsyntax.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 regsyntax.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 regsyntax.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 regsyntax.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+regsyntax.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 regsyntax.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 regsyntax.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 regsyntax.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -16531,6 +16594,7 @@ ruby.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 ruby.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 ruby.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 ruby.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+ruby.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 ruby.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 ruby.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 ruby.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -16738,6 +16802,7 @@ ruby_parser.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+ruby_parser.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -16935,6 +17000,7 @@ scheduler.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 scheduler.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 scheduler.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 scheduler.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+scheduler.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 scheduler.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 scheduler.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 scheduler.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -17146,6 +17212,7 @@ set.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 set.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 set.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 set.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+set.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 set.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 set.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 set.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -17317,6 +17384,7 @@ setproctitle.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 setproctitle.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 setproctitle.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 setproctitle.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+setproctitle.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 setproctitle.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 setproctitle.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 setproctitle.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -17515,6 +17583,7 @@ shape.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 shape.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 shape.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 shape.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+shape.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 shape.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 shape.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 shape.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -17730,6 +17799,7 @@ signal.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 signal.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 signal.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 signal.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+signal.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 signal.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 signal.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 signal.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -17937,6 +18007,7 @@ sprintf.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 sprintf.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 sprintf.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 sprintf.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+sprintf.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 sprintf.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 sprintf.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 sprintf.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -18111,6 +18182,7 @@ st.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 st.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 st.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 st.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+st.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 st.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 st.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 st.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -18288,6 +18360,7 @@ strftime.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 strftime.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 strftime.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 strftime.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+strftime.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 strftime.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 strftime.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 strftime.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -18335,6 +18408,7 @@ string.$(OBJEXT): $(top_srcdir)/internal/bits.h
 string.$(OBJEXT): $(top_srcdir)/internal/class.h
 string.$(OBJEXT): $(top_srcdir)/internal/compar.h
 string.$(OBJEXT): $(top_srcdir)/internal/compilers.h
+string.$(OBJEXT): $(top_srcdir)/internal/concurrent_set.h
 string.$(OBJEXT): $(top_srcdir)/internal/encoding.h
 string.$(OBJEXT): $(top_srcdir)/internal/error.h
 string.$(OBJEXT): $(top_srcdir)/internal/fixnum.h
@@ -18345,7 +18419,6 @@ string.$(OBJEXT): $(top_srcdir)/internal/namespace.h
 string.$(OBJEXT): $(top_srcdir)/internal/numeric.h
 string.$(OBJEXT): $(top_srcdir)/internal/object.h
 string.$(OBJEXT): $(top_srcdir)/internal/proc.h
-string.$(OBJEXT): $(top_srcdir)/internal/concurrent_set.h
 string.$(OBJEXT): $(top_srcdir)/internal/re.h
 string.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 string.$(OBJEXT): $(top_srcdir)/internal/serial.h
@@ -18502,6 +18575,7 @@ string.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 string.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 string.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 string.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+string.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 string.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 string.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 string.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -18753,6 +18827,7 @@ struct.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 struct.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 struct.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 struct.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+struct.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 struct.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 struct.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 struct.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -18969,6 +19044,7 @@ symbol.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 symbol.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 symbol.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 symbol.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+symbol.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 symbol.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 symbol.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 symbol.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -19219,6 +19295,7 @@ thread.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 thread.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 thread.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 thread.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+thread.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 thread.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 thread.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 thread.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -19447,6 +19524,7 @@ time.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 time.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 time.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 time.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+time.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 time.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 time.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 time.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -19647,6 +19725,7 @@ transcode.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 transcode.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 transcode.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 transcode.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+transcode.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 transcode.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 transcode.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 transcode.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -19822,6 +19901,7 @@ util.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 util.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 util.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 util.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+util.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 util.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 util.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 util.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -20025,6 +20105,7 @@ variable.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 variable.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 variable.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 variable.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+variable.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 variable.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 variable.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 variable.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -20240,6 +20321,7 @@ version.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 version.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 version.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 version.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+version.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 version.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 version.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 version.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -20500,6 +20582,7 @@ vm.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 vm.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 vm.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 vm.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+vm.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 vm.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 vm.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 vm.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -20758,6 +20841,7 @@ vm_backtrace.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+vm_backtrace.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 vm_backtrace.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -20989,6 +21073,7 @@ vm_dump.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 vm_dump.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 vm_dump.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 vm_dump.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+vm_dump.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 vm_dump.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 vm_dump.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 vm_dump.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -21202,6 +21287,7 @@ vm_sync.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 vm_sync.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 vm_sync.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 vm_sync.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+vm_sync.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 vm_sync.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 vm_sync.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 vm_sync.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -21438,6 +21524,7 @@ vm_trace.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 vm_trace.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 vm_trace.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 vm_trace.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+vm_trace.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 vm_trace.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 vm_trace.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 vm_trace.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -21650,6 +21737,7 @@ weakmap.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 weakmap.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 weakmap.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 weakmap.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+weakmap.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 weakmap.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 weakmap.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 weakmap.$(OBJEXT): {$(VPATH)}internal/intern/string.h
@@ -21886,6 +21974,7 @@ yjit.$(OBJEXT): {$(VPATH)}internal/intern/re.h
 yjit.$(OBJEXT): {$(VPATH)}internal/intern/ruby.h
 yjit.$(OBJEXT): {$(VPATH)}internal/intern/select.h
 yjit.$(OBJEXT): {$(VPATH)}internal/intern/select/largesize.h
+yjit.$(OBJEXT): {$(VPATH)}internal/intern/set.h
 yjit.$(OBJEXT): {$(VPATH)}internal/intern/signal.h
 yjit.$(OBJEXT): {$(VPATH)}internal/intern/sprintf.h
 yjit.$(OBJEXT): {$(VPATH)}internal/intern/string.h

--- a/enc/depend
+++ b/enc/depend
@@ -317,6 +317,7 @@ enc/ascii.$(OBJEXT): internal/intern/re.h
 enc/ascii.$(OBJEXT): internal/intern/ruby.h
 enc/ascii.$(OBJEXT): internal/intern/select.h
 enc/ascii.$(OBJEXT): internal/intern/select/largesize.h
+enc/ascii.$(OBJEXT): internal/intern/set.h
 enc/ascii.$(OBJEXT): internal/intern/signal.h
 enc/ascii.$(OBJEXT): internal/intern/sprintf.h
 enc/ascii.$(OBJEXT): internal/intern/string.h
@@ -479,6 +480,7 @@ enc/big5.$(OBJEXT): internal/intern/re.h
 enc/big5.$(OBJEXT): internal/intern/ruby.h
 enc/big5.$(OBJEXT): internal/intern/select.h
 enc/big5.$(OBJEXT): internal/intern/select/largesize.h
+enc/big5.$(OBJEXT): internal/intern/set.h
 enc/big5.$(OBJEXT): internal/intern/signal.h
 enc/big5.$(OBJEXT): internal/intern/sprintf.h
 enc/big5.$(OBJEXT): internal/intern/string.h
@@ -651,6 +653,7 @@ enc/cesu_8.$(OBJEXT): internal/intern/re.h
 enc/cesu_8.$(OBJEXT): internal/intern/ruby.h
 enc/cesu_8.$(OBJEXT): internal/intern/select.h
 enc/cesu_8.$(OBJEXT): internal/intern/select/largesize.h
+enc/cesu_8.$(OBJEXT): internal/intern/set.h
 enc/cesu_8.$(OBJEXT): internal/intern/signal.h
 enc/cesu_8.$(OBJEXT): internal/intern/sprintf.h
 enc/cesu_8.$(OBJEXT): internal/intern/string.h
@@ -813,6 +816,7 @@ enc/cp949.$(OBJEXT): internal/intern/re.h
 enc/cp949.$(OBJEXT): internal/intern/ruby.h
 enc/cp949.$(OBJEXT): internal/intern/select.h
 enc/cp949.$(OBJEXT): internal/intern/select/largesize.h
+enc/cp949.$(OBJEXT): internal/intern/set.h
 enc/cp949.$(OBJEXT): internal/intern/signal.h
 enc/cp949.$(OBJEXT): internal/intern/sprintf.h
 enc/cp949.$(OBJEXT): internal/intern/string.h
@@ -974,6 +978,7 @@ enc/emacs_mule.$(OBJEXT): internal/intern/re.h
 enc/emacs_mule.$(OBJEXT): internal/intern/ruby.h
 enc/emacs_mule.$(OBJEXT): internal/intern/select.h
 enc/emacs_mule.$(OBJEXT): internal/intern/select/largesize.h
+enc/emacs_mule.$(OBJEXT): internal/intern/set.h
 enc/emacs_mule.$(OBJEXT): internal/intern/signal.h
 enc/emacs_mule.$(OBJEXT): internal/intern/sprintf.h
 enc/emacs_mule.$(OBJEXT): internal/intern/string.h
@@ -1145,6 +1150,7 @@ enc/encdb.$(OBJEXT): internal/intern/re.h
 enc/encdb.$(OBJEXT): internal/intern/ruby.h
 enc/encdb.$(OBJEXT): internal/intern/select.h
 enc/encdb.$(OBJEXT): internal/intern/select/largesize.h
+enc/encdb.$(OBJEXT): internal/intern/set.h
 enc/encdb.$(OBJEXT): internal/intern/signal.h
 enc/encdb.$(OBJEXT): internal/intern/sprintf.h
 enc/encdb.$(OBJEXT): internal/intern/string.h
@@ -1309,6 +1315,7 @@ enc/euc_jp.$(OBJEXT): internal/intern/re.h
 enc/euc_jp.$(OBJEXT): internal/intern/ruby.h
 enc/euc_jp.$(OBJEXT): internal/intern/select.h
 enc/euc_jp.$(OBJEXT): internal/intern/select/largesize.h
+enc/euc_jp.$(OBJEXT): internal/intern/set.h
 enc/euc_jp.$(OBJEXT): internal/intern/signal.h
 enc/euc_jp.$(OBJEXT): internal/intern/sprintf.h
 enc/euc_jp.$(OBJEXT): internal/intern/string.h
@@ -1470,6 +1477,7 @@ enc/euc_kr.$(OBJEXT): internal/intern/re.h
 enc/euc_kr.$(OBJEXT): internal/intern/ruby.h
 enc/euc_kr.$(OBJEXT): internal/intern/select.h
 enc/euc_kr.$(OBJEXT): internal/intern/select/largesize.h
+enc/euc_kr.$(OBJEXT): internal/intern/set.h
 enc/euc_kr.$(OBJEXT): internal/intern/signal.h
 enc/euc_kr.$(OBJEXT): internal/intern/sprintf.h
 enc/euc_kr.$(OBJEXT): internal/intern/string.h
@@ -1631,6 +1639,7 @@ enc/euc_tw.$(OBJEXT): internal/intern/re.h
 enc/euc_tw.$(OBJEXT): internal/intern/ruby.h
 enc/euc_tw.$(OBJEXT): internal/intern/select.h
 enc/euc_tw.$(OBJEXT): internal/intern/select/largesize.h
+enc/euc_tw.$(OBJEXT): internal/intern/set.h
 enc/euc_tw.$(OBJEXT): internal/intern/signal.h
 enc/euc_tw.$(OBJEXT): internal/intern/sprintf.h
 enc/euc_tw.$(OBJEXT): internal/intern/string.h
@@ -1792,6 +1801,7 @@ enc/gb18030.$(OBJEXT): internal/intern/re.h
 enc/gb18030.$(OBJEXT): internal/intern/ruby.h
 enc/gb18030.$(OBJEXT): internal/intern/select.h
 enc/gb18030.$(OBJEXT): internal/intern/select/largesize.h
+enc/gb18030.$(OBJEXT): internal/intern/set.h
 enc/gb18030.$(OBJEXT): internal/intern/signal.h
 enc/gb18030.$(OBJEXT): internal/intern/sprintf.h
 enc/gb18030.$(OBJEXT): internal/intern/string.h
@@ -1953,6 +1963,7 @@ enc/gb2312.$(OBJEXT): internal/intern/re.h
 enc/gb2312.$(OBJEXT): internal/intern/ruby.h
 enc/gb2312.$(OBJEXT): internal/intern/select.h
 enc/gb2312.$(OBJEXT): internal/intern/select/largesize.h
+enc/gb2312.$(OBJEXT): internal/intern/set.h
 enc/gb2312.$(OBJEXT): internal/intern/signal.h
 enc/gb2312.$(OBJEXT): internal/intern/sprintf.h
 enc/gb2312.$(OBJEXT): internal/intern/string.h
@@ -2114,6 +2125,7 @@ enc/gbk.$(OBJEXT): internal/intern/re.h
 enc/gbk.$(OBJEXT): internal/intern/ruby.h
 enc/gbk.$(OBJEXT): internal/intern/select.h
 enc/gbk.$(OBJEXT): internal/intern/select/largesize.h
+enc/gbk.$(OBJEXT): internal/intern/set.h
 enc/gbk.$(OBJEXT): internal/intern/signal.h
 enc/gbk.$(OBJEXT): internal/intern/sprintf.h
 enc/gbk.$(OBJEXT): internal/intern/string.h
@@ -2276,6 +2288,7 @@ enc/iso_8859_1.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_1.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_1.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_1.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_1.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_1.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_1.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_1.$(OBJEXT): internal/intern/string.h
@@ -2438,6 +2451,7 @@ enc/iso_8859_10.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_10.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_10.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_10.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_10.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_10.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_10.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_10.$(OBJEXT): internal/intern/string.h
@@ -2599,6 +2613,7 @@ enc/iso_8859_11.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_11.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_11.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_11.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_11.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_11.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_11.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_11.$(OBJEXT): internal/intern/string.h
@@ -2761,6 +2776,7 @@ enc/iso_8859_13.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_13.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_13.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_13.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_13.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_13.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_13.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_13.$(OBJEXT): internal/intern/string.h
@@ -2923,6 +2939,7 @@ enc/iso_8859_14.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_14.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_14.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_14.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_14.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_14.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_14.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_14.$(OBJEXT): internal/intern/string.h
@@ -3085,6 +3102,7 @@ enc/iso_8859_15.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_15.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_15.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_15.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_15.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_15.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_15.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_15.$(OBJEXT): internal/intern/string.h
@@ -3247,6 +3265,7 @@ enc/iso_8859_16.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_16.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_16.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_16.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_16.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_16.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_16.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_16.$(OBJEXT): internal/intern/string.h
@@ -3409,6 +3428,7 @@ enc/iso_8859_2.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_2.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_2.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_2.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_2.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_2.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_2.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_2.$(OBJEXT): internal/intern/string.h
@@ -3571,6 +3591,7 @@ enc/iso_8859_3.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_3.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_3.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_3.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_3.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_3.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_3.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_3.$(OBJEXT): internal/intern/string.h
@@ -3733,6 +3754,7 @@ enc/iso_8859_4.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_4.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_4.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_4.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_4.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_4.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_4.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_4.$(OBJEXT): internal/intern/string.h
@@ -3894,6 +3916,7 @@ enc/iso_8859_5.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_5.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_5.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_5.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_5.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_5.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_5.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_5.$(OBJEXT): internal/intern/string.h
@@ -4055,6 +4078,7 @@ enc/iso_8859_6.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_6.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_6.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_6.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_6.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_6.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_6.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_6.$(OBJEXT): internal/intern/string.h
@@ -4216,6 +4240,7 @@ enc/iso_8859_7.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_7.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_7.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_7.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_7.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_7.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_7.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_7.$(OBJEXT): internal/intern/string.h
@@ -4377,6 +4402,7 @@ enc/iso_8859_8.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_8.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_8.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_8.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_8.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_8.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_8.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_8.$(OBJEXT): internal/intern/string.h
@@ -4539,6 +4565,7 @@ enc/iso_8859_9.$(OBJEXT): internal/intern/re.h
 enc/iso_8859_9.$(OBJEXT): internal/intern/ruby.h
 enc/iso_8859_9.$(OBJEXT): internal/intern/select.h
 enc/iso_8859_9.$(OBJEXT): internal/intern/select/largesize.h
+enc/iso_8859_9.$(OBJEXT): internal/intern/set.h
 enc/iso_8859_9.$(OBJEXT): internal/intern/signal.h
 enc/iso_8859_9.$(OBJEXT): internal/intern/sprintf.h
 enc/iso_8859_9.$(OBJEXT): internal/intern/string.h
@@ -4700,6 +4727,7 @@ enc/koi8_r.$(OBJEXT): internal/intern/re.h
 enc/koi8_r.$(OBJEXT): internal/intern/ruby.h
 enc/koi8_r.$(OBJEXT): internal/intern/select.h
 enc/koi8_r.$(OBJEXT): internal/intern/select/largesize.h
+enc/koi8_r.$(OBJEXT): internal/intern/set.h
 enc/koi8_r.$(OBJEXT): internal/intern/signal.h
 enc/koi8_r.$(OBJEXT): internal/intern/sprintf.h
 enc/koi8_r.$(OBJEXT): internal/intern/string.h
@@ -4861,6 +4889,7 @@ enc/koi8_u.$(OBJEXT): internal/intern/re.h
 enc/koi8_u.$(OBJEXT): internal/intern/ruby.h
 enc/koi8_u.$(OBJEXT): internal/intern/select.h
 enc/koi8_u.$(OBJEXT): internal/intern/select/largesize.h
+enc/koi8_u.$(OBJEXT): internal/intern/set.h
 enc/koi8_u.$(OBJEXT): internal/intern/signal.h
 enc/koi8_u.$(OBJEXT): internal/intern/sprintf.h
 enc/koi8_u.$(OBJEXT): internal/intern/string.h
@@ -5025,6 +5054,7 @@ enc/shift_jis.$(OBJEXT): internal/intern/re.h
 enc/shift_jis.$(OBJEXT): internal/intern/ruby.h
 enc/shift_jis.$(OBJEXT): internal/intern/select.h
 enc/shift_jis.$(OBJEXT): internal/intern/select/largesize.h
+enc/shift_jis.$(OBJEXT): internal/intern/set.h
 enc/shift_jis.$(OBJEXT): internal/intern/signal.h
 enc/shift_jis.$(OBJEXT): internal/intern/sprintf.h
 enc/shift_jis.$(OBJEXT): internal/intern/string.h
@@ -5185,6 +5215,7 @@ enc/trans/big5.$(OBJEXT): internal/intern/re.h
 enc/trans/big5.$(OBJEXT): internal/intern/ruby.h
 enc/trans/big5.$(OBJEXT): internal/intern/select.h
 enc/trans/big5.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/big5.$(OBJEXT): internal/intern/set.h
 enc/trans/big5.$(OBJEXT): internal/intern/signal.h
 enc/trans/big5.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/big5.$(OBJEXT): internal/intern/string.h
@@ -5344,6 +5375,7 @@ enc/trans/cesu_8.$(OBJEXT): internal/intern/re.h
 enc/trans/cesu_8.$(OBJEXT): internal/intern/ruby.h
 enc/trans/cesu_8.$(OBJEXT): internal/intern/select.h
 enc/trans/cesu_8.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/cesu_8.$(OBJEXT): internal/intern/set.h
 enc/trans/cesu_8.$(OBJEXT): internal/intern/signal.h
 enc/trans/cesu_8.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/cesu_8.$(OBJEXT): internal/intern/string.h
@@ -5503,6 +5535,7 @@ enc/trans/chinese.$(OBJEXT): internal/intern/re.h
 enc/trans/chinese.$(OBJEXT): internal/intern/ruby.h
 enc/trans/chinese.$(OBJEXT): internal/intern/select.h
 enc/trans/chinese.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/chinese.$(OBJEXT): internal/intern/set.h
 enc/trans/chinese.$(OBJEXT): internal/intern/signal.h
 enc/trans/chinese.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/chinese.$(OBJEXT): internal/intern/string.h
@@ -5662,6 +5695,7 @@ enc/trans/ebcdic.$(OBJEXT): internal/intern/re.h
 enc/trans/ebcdic.$(OBJEXT): internal/intern/ruby.h
 enc/trans/ebcdic.$(OBJEXT): internal/intern/select.h
 enc/trans/ebcdic.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/ebcdic.$(OBJEXT): internal/intern/set.h
 enc/trans/ebcdic.$(OBJEXT): internal/intern/signal.h
 enc/trans/ebcdic.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/ebcdic.$(OBJEXT): internal/intern/string.h
@@ -5821,6 +5855,7 @@ enc/trans/emoji.$(OBJEXT): internal/intern/re.h
 enc/trans/emoji.$(OBJEXT): internal/intern/ruby.h
 enc/trans/emoji.$(OBJEXT): internal/intern/select.h
 enc/trans/emoji.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/emoji.$(OBJEXT): internal/intern/set.h
 enc/trans/emoji.$(OBJEXT): internal/intern/signal.h
 enc/trans/emoji.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/emoji.$(OBJEXT): internal/intern/string.h
@@ -5980,6 +6015,7 @@ enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/intern/re.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/intern/ruby.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/intern/select.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/intern/set.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/intern/signal.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/emoji_iso2022_kddi.$(OBJEXT): internal/intern/string.h
@@ -6139,6 +6175,7 @@ enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/intern/re.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/intern/ruby.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/intern/select.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/intern/set.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/intern/signal.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/emoji_sjis_docomo.$(OBJEXT): internal/intern/string.h
@@ -6298,6 +6335,7 @@ enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/intern/re.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/intern/ruby.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/intern/select.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/intern/set.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/intern/signal.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/emoji_sjis_kddi.$(OBJEXT): internal/intern/string.h
@@ -6457,6 +6495,7 @@ enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/intern/re.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/intern/ruby.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/intern/select.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/intern/set.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/intern/signal.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/emoji_sjis_softbank.$(OBJEXT): internal/intern/string.h
@@ -6616,6 +6655,7 @@ enc/trans/escape.$(OBJEXT): internal/intern/re.h
 enc/trans/escape.$(OBJEXT): internal/intern/ruby.h
 enc/trans/escape.$(OBJEXT): internal/intern/select.h
 enc/trans/escape.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/escape.$(OBJEXT): internal/intern/set.h
 enc/trans/escape.$(OBJEXT): internal/intern/signal.h
 enc/trans/escape.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/escape.$(OBJEXT): internal/intern/string.h
@@ -6775,6 +6815,7 @@ enc/trans/gb18030.$(OBJEXT): internal/intern/re.h
 enc/trans/gb18030.$(OBJEXT): internal/intern/ruby.h
 enc/trans/gb18030.$(OBJEXT): internal/intern/select.h
 enc/trans/gb18030.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/gb18030.$(OBJEXT): internal/intern/set.h
 enc/trans/gb18030.$(OBJEXT): internal/intern/signal.h
 enc/trans/gb18030.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/gb18030.$(OBJEXT): internal/intern/string.h
@@ -6934,6 +6975,7 @@ enc/trans/gbk.$(OBJEXT): internal/intern/re.h
 enc/trans/gbk.$(OBJEXT): internal/intern/ruby.h
 enc/trans/gbk.$(OBJEXT): internal/intern/select.h
 enc/trans/gbk.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/gbk.$(OBJEXT): internal/intern/set.h
 enc/trans/gbk.$(OBJEXT): internal/intern/signal.h
 enc/trans/gbk.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/gbk.$(OBJEXT): internal/intern/string.h
@@ -7094,6 +7136,7 @@ enc/trans/iso2022.$(OBJEXT): internal/intern/re.h
 enc/trans/iso2022.$(OBJEXT): internal/intern/ruby.h
 enc/trans/iso2022.$(OBJEXT): internal/intern/select.h
 enc/trans/iso2022.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/iso2022.$(OBJEXT): internal/intern/set.h
 enc/trans/iso2022.$(OBJEXT): internal/intern/signal.h
 enc/trans/iso2022.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/iso2022.$(OBJEXT): internal/intern/string.h
@@ -7253,6 +7296,7 @@ enc/trans/japanese.$(OBJEXT): internal/intern/re.h
 enc/trans/japanese.$(OBJEXT): internal/intern/ruby.h
 enc/trans/japanese.$(OBJEXT): internal/intern/select.h
 enc/trans/japanese.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/japanese.$(OBJEXT): internal/intern/set.h
 enc/trans/japanese.$(OBJEXT): internal/intern/signal.h
 enc/trans/japanese.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/japanese.$(OBJEXT): internal/intern/string.h
@@ -7412,6 +7456,7 @@ enc/trans/japanese_euc.$(OBJEXT): internal/intern/re.h
 enc/trans/japanese_euc.$(OBJEXT): internal/intern/ruby.h
 enc/trans/japanese_euc.$(OBJEXT): internal/intern/select.h
 enc/trans/japanese_euc.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/japanese_euc.$(OBJEXT): internal/intern/set.h
 enc/trans/japanese_euc.$(OBJEXT): internal/intern/signal.h
 enc/trans/japanese_euc.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/japanese_euc.$(OBJEXT): internal/intern/string.h
@@ -7571,6 +7616,7 @@ enc/trans/japanese_sjis.$(OBJEXT): internal/intern/re.h
 enc/trans/japanese_sjis.$(OBJEXT): internal/intern/ruby.h
 enc/trans/japanese_sjis.$(OBJEXT): internal/intern/select.h
 enc/trans/japanese_sjis.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/japanese_sjis.$(OBJEXT): internal/intern/set.h
 enc/trans/japanese_sjis.$(OBJEXT): internal/intern/signal.h
 enc/trans/japanese_sjis.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/japanese_sjis.$(OBJEXT): internal/intern/string.h
@@ -7730,6 +7776,7 @@ enc/trans/korean.$(OBJEXT): internal/intern/re.h
 enc/trans/korean.$(OBJEXT): internal/intern/ruby.h
 enc/trans/korean.$(OBJEXT): internal/intern/select.h
 enc/trans/korean.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/korean.$(OBJEXT): internal/intern/set.h
 enc/trans/korean.$(OBJEXT): internal/intern/signal.h
 enc/trans/korean.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/korean.$(OBJEXT): internal/intern/string.h
@@ -7888,6 +7935,7 @@ enc/trans/newline.$(OBJEXT): internal/intern/re.h
 enc/trans/newline.$(OBJEXT): internal/intern/ruby.h
 enc/trans/newline.$(OBJEXT): internal/intern/select.h
 enc/trans/newline.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/newline.$(OBJEXT): internal/intern/set.h
 enc/trans/newline.$(OBJEXT): internal/intern/signal.h
 enc/trans/newline.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/newline.$(OBJEXT): internal/intern/string.h
@@ -8047,6 +8095,7 @@ enc/trans/single_byte.$(OBJEXT): internal/intern/re.h
 enc/trans/single_byte.$(OBJEXT): internal/intern/ruby.h
 enc/trans/single_byte.$(OBJEXT): internal/intern/select.h
 enc/trans/single_byte.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/single_byte.$(OBJEXT): internal/intern/set.h
 enc/trans/single_byte.$(OBJEXT): internal/intern/signal.h
 enc/trans/single_byte.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/single_byte.$(OBJEXT): internal/intern/string.h
@@ -8206,6 +8255,7 @@ enc/trans/transdb.$(OBJEXT): internal/intern/re.h
 enc/trans/transdb.$(OBJEXT): internal/intern/ruby.h
 enc/trans/transdb.$(OBJEXT): internal/intern/select.h
 enc/trans/transdb.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/transdb.$(OBJEXT): internal/intern/set.h
 enc/trans/transdb.$(OBJEXT): internal/intern/signal.h
 enc/trans/transdb.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/transdb.$(OBJEXT): internal/intern/string.h
@@ -8366,6 +8416,7 @@ enc/trans/utf8_mac.$(OBJEXT): internal/intern/re.h
 enc/trans/utf8_mac.$(OBJEXT): internal/intern/ruby.h
 enc/trans/utf8_mac.$(OBJEXT): internal/intern/select.h
 enc/trans/utf8_mac.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/utf8_mac.$(OBJEXT): internal/intern/set.h
 enc/trans/utf8_mac.$(OBJEXT): internal/intern/signal.h
 enc/trans/utf8_mac.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/utf8_mac.$(OBJEXT): internal/intern/string.h
@@ -8525,6 +8576,7 @@ enc/trans/utf_16_32.$(OBJEXT): internal/intern/re.h
 enc/trans/utf_16_32.$(OBJEXT): internal/intern/ruby.h
 enc/trans/utf_16_32.$(OBJEXT): internal/intern/select.h
 enc/trans/utf_16_32.$(OBJEXT): internal/intern/select/largesize.h
+enc/trans/utf_16_32.$(OBJEXT): internal/intern/set.h
 enc/trans/utf_16_32.$(OBJEXT): internal/intern/signal.h
 enc/trans/utf_16_32.$(OBJEXT): internal/intern/sprintf.h
 enc/trans/utf_16_32.$(OBJEXT): internal/intern/string.h
@@ -8687,6 +8739,7 @@ enc/unicode.$(OBJEXT): internal/intern/re.h
 enc/unicode.$(OBJEXT): internal/intern/ruby.h
 enc/unicode.$(OBJEXT): internal/intern/select.h
 enc/unicode.$(OBJEXT): internal/intern/select/largesize.h
+enc/unicode.$(OBJEXT): internal/intern/set.h
 enc/unicode.$(OBJEXT): internal/intern/signal.h
 enc/unicode.$(OBJEXT): internal/intern/sprintf.h
 enc/unicode.$(OBJEXT): internal/intern/string.h
@@ -8858,6 +8911,7 @@ enc/us_ascii.$(OBJEXT): internal/intern/re.h
 enc/us_ascii.$(OBJEXT): internal/intern/ruby.h
 enc/us_ascii.$(OBJEXT): internal/intern/select.h
 enc/us_ascii.$(OBJEXT): internal/intern/select/largesize.h
+enc/us_ascii.$(OBJEXT): internal/intern/set.h
 enc/us_ascii.$(OBJEXT): internal/intern/signal.h
 enc/us_ascii.$(OBJEXT): internal/intern/sprintf.h
 enc/us_ascii.$(OBJEXT): internal/intern/string.h
@@ -9021,6 +9075,7 @@ enc/utf_16be.$(OBJEXT): internal/intern/re.h
 enc/utf_16be.$(OBJEXT): internal/intern/ruby.h
 enc/utf_16be.$(OBJEXT): internal/intern/select.h
 enc/utf_16be.$(OBJEXT): internal/intern/select/largesize.h
+enc/utf_16be.$(OBJEXT): internal/intern/set.h
 enc/utf_16be.$(OBJEXT): internal/intern/signal.h
 enc/utf_16be.$(OBJEXT): internal/intern/sprintf.h
 enc/utf_16be.$(OBJEXT): internal/intern/string.h
@@ -9183,6 +9238,7 @@ enc/utf_16le.$(OBJEXT): internal/intern/re.h
 enc/utf_16le.$(OBJEXT): internal/intern/ruby.h
 enc/utf_16le.$(OBJEXT): internal/intern/select.h
 enc/utf_16le.$(OBJEXT): internal/intern/select/largesize.h
+enc/utf_16le.$(OBJEXT): internal/intern/set.h
 enc/utf_16le.$(OBJEXT): internal/intern/signal.h
 enc/utf_16le.$(OBJEXT): internal/intern/sprintf.h
 enc/utf_16le.$(OBJEXT): internal/intern/string.h
@@ -9345,6 +9401,7 @@ enc/utf_32be.$(OBJEXT): internal/intern/re.h
 enc/utf_32be.$(OBJEXT): internal/intern/ruby.h
 enc/utf_32be.$(OBJEXT): internal/intern/select.h
 enc/utf_32be.$(OBJEXT): internal/intern/select/largesize.h
+enc/utf_32be.$(OBJEXT): internal/intern/set.h
 enc/utf_32be.$(OBJEXT): internal/intern/signal.h
 enc/utf_32be.$(OBJEXT): internal/intern/sprintf.h
 enc/utf_32be.$(OBJEXT): internal/intern/string.h
@@ -9507,6 +9564,7 @@ enc/utf_32le.$(OBJEXT): internal/intern/re.h
 enc/utf_32le.$(OBJEXT): internal/intern/ruby.h
 enc/utf_32le.$(OBJEXT): internal/intern/select.h
 enc/utf_32le.$(OBJEXT): internal/intern/select/largesize.h
+enc/utf_32le.$(OBJEXT): internal/intern/set.h
 enc/utf_32le.$(OBJEXT): internal/intern/signal.h
 enc/utf_32le.$(OBJEXT): internal/intern/sprintf.h
 enc/utf_32le.$(OBJEXT): internal/intern/string.h
@@ -9678,6 +9736,7 @@ enc/utf_8.$(OBJEXT): internal/intern/re.h
 enc/utf_8.$(OBJEXT): internal/intern/ruby.h
 enc/utf_8.$(OBJEXT): internal/intern/select.h
 enc/utf_8.$(OBJEXT): internal/intern/select/largesize.h
+enc/utf_8.$(OBJEXT): internal/intern/set.h
 enc/utf_8.$(OBJEXT): internal/intern/signal.h
 enc/utf_8.$(OBJEXT): internal/intern/sprintf.h
 enc/utf_8.$(OBJEXT): internal/intern/string.h
@@ -9841,6 +9900,7 @@ enc/windows_1250.$(OBJEXT): internal/intern/re.h
 enc/windows_1250.$(OBJEXT): internal/intern/ruby.h
 enc/windows_1250.$(OBJEXT): internal/intern/select.h
 enc/windows_1250.$(OBJEXT): internal/intern/select/largesize.h
+enc/windows_1250.$(OBJEXT): internal/intern/set.h
 enc/windows_1250.$(OBJEXT): internal/intern/signal.h
 enc/windows_1250.$(OBJEXT): internal/intern/sprintf.h
 enc/windows_1250.$(OBJEXT): internal/intern/string.h
@@ -10002,6 +10062,7 @@ enc/windows_1251.$(OBJEXT): internal/intern/re.h
 enc/windows_1251.$(OBJEXT): internal/intern/ruby.h
 enc/windows_1251.$(OBJEXT): internal/intern/select.h
 enc/windows_1251.$(OBJEXT): internal/intern/select/largesize.h
+enc/windows_1251.$(OBJEXT): internal/intern/set.h
 enc/windows_1251.$(OBJEXT): internal/intern/signal.h
 enc/windows_1251.$(OBJEXT): internal/intern/sprintf.h
 enc/windows_1251.$(OBJEXT): internal/intern/string.h
@@ -10164,6 +10225,7 @@ enc/windows_1252.$(OBJEXT): internal/intern/re.h
 enc/windows_1252.$(OBJEXT): internal/intern/ruby.h
 enc/windows_1252.$(OBJEXT): internal/intern/select.h
 enc/windows_1252.$(OBJEXT): internal/intern/select/largesize.h
+enc/windows_1252.$(OBJEXT): internal/intern/set.h
 enc/windows_1252.$(OBJEXT): internal/intern/signal.h
 enc/windows_1252.$(OBJEXT): internal/intern/sprintf.h
 enc/windows_1252.$(OBJEXT): internal/intern/string.h
@@ -10325,6 +10387,7 @@ enc/windows_1253.$(OBJEXT): internal/intern/re.h
 enc/windows_1253.$(OBJEXT): internal/intern/ruby.h
 enc/windows_1253.$(OBJEXT): internal/intern/select.h
 enc/windows_1253.$(OBJEXT): internal/intern/select/largesize.h
+enc/windows_1253.$(OBJEXT): internal/intern/set.h
 enc/windows_1253.$(OBJEXT): internal/intern/signal.h
 enc/windows_1253.$(OBJEXT): internal/intern/sprintf.h
 enc/windows_1253.$(OBJEXT): internal/intern/string.h
@@ -10487,6 +10550,7 @@ enc/windows_1254.$(OBJEXT): internal/intern/re.h
 enc/windows_1254.$(OBJEXT): internal/intern/ruby.h
 enc/windows_1254.$(OBJEXT): internal/intern/select.h
 enc/windows_1254.$(OBJEXT): internal/intern/select/largesize.h
+enc/windows_1254.$(OBJEXT): internal/intern/set.h
 enc/windows_1254.$(OBJEXT): internal/intern/signal.h
 enc/windows_1254.$(OBJEXT): internal/intern/sprintf.h
 enc/windows_1254.$(OBJEXT): internal/intern/string.h
@@ -10649,6 +10713,7 @@ enc/windows_1257.$(OBJEXT): internal/intern/re.h
 enc/windows_1257.$(OBJEXT): internal/intern/ruby.h
 enc/windows_1257.$(OBJEXT): internal/intern/select.h
 enc/windows_1257.$(OBJEXT): internal/intern/select/largesize.h
+enc/windows_1257.$(OBJEXT): internal/intern/set.h
 enc/windows_1257.$(OBJEXT): internal/intern/signal.h
 enc/windows_1257.$(OBJEXT): internal/intern/sprintf.h
 enc/windows_1257.$(OBJEXT): internal/intern/string.h
@@ -10813,6 +10878,7 @@ enc/windows_31j.$(OBJEXT): internal/intern/re.h
 enc/windows_31j.$(OBJEXT): internal/intern/ruby.h
 enc/windows_31j.$(OBJEXT): internal/intern/select.h
 enc/windows_31j.$(OBJEXT): internal/intern/select/largesize.h
+enc/windows_31j.$(OBJEXT): internal/intern/set.h
 enc/windows_31j.$(OBJEXT): internal/intern/signal.h
 enc/windows_31j.$(OBJEXT): internal/intern/sprintf.h
 enc/windows_31j.$(OBJEXT): internal/intern/string.h

--- a/ext/-test-/RUBY_ALIGNOF/depend
+++ b/ext/-test-/RUBY_ALIGNOF/depend
@@ -128,6 +128,7 @@ c.o: $(hdrdir)/ruby/internal/intern/re.h
 c.o: $(hdrdir)/ruby/internal/intern/ruby.h
 c.o: $(hdrdir)/ruby/internal/intern/select.h
 c.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+c.o: $(hdrdir)/ruby/internal/intern/set.h
 c.o: $(hdrdir)/ruby/internal/intern/signal.h
 c.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 c.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/arith_seq/beg_len_step/depend
+++ b/ext/-test-/arith_seq/beg_len_step/depend
@@ -127,6 +127,7 @@ beg_len_step.o: $(hdrdir)/ruby/internal/intern/re.h
 beg_len_step.o: $(hdrdir)/ruby/internal/intern/ruby.h
 beg_len_step.o: $(hdrdir)/ruby/internal/intern/select.h
 beg_len_step.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+beg_len_step.o: $(hdrdir)/ruby/internal/intern/set.h
 beg_len_step.o: $(hdrdir)/ruby/internal/intern/signal.h
 beg_len_step.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 beg_len_step.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/arith_seq/extract/depend
+++ b/ext/-test-/arith_seq/extract/depend
@@ -127,6 +127,7 @@ extract.o: $(hdrdir)/ruby/internal/intern/re.h
 extract.o: $(hdrdir)/ruby/internal/intern/ruby.h
 extract.o: $(hdrdir)/ruby/internal/intern/select.h
 extract.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+extract.o: $(hdrdir)/ruby/internal/intern/set.h
 extract.o: $(hdrdir)/ruby/internal/intern/signal.h
 extract.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 extract.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/array/concat/depend
+++ b/ext/-test-/array/concat/depend
@@ -128,6 +128,7 @@ to_ary_concat.o: $(hdrdir)/ruby/internal/intern/re.h
 to_ary_concat.o: $(hdrdir)/ruby/internal/intern/ruby.h
 to_ary_concat.o: $(hdrdir)/ruby/internal/intern/select.h
 to_ary_concat.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+to_ary_concat.o: $(hdrdir)/ruby/internal/intern/set.h
 to_ary_concat.o: $(hdrdir)/ruby/internal/intern/signal.h
 to_ary_concat.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 to_ary_concat.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/array/resize/depend
+++ b/ext/-test-/array/resize/depend
@@ -127,6 +127,7 @@ resize.o: $(hdrdir)/ruby/internal/intern/re.h
 resize.o: $(hdrdir)/ruby/internal/intern/ruby.h
 resize.o: $(hdrdir)/ruby/internal/intern/select.h
 resize.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+resize.o: $(hdrdir)/ruby/internal/intern/set.h
 resize.o: $(hdrdir)/ruby/internal/intern/signal.h
 resize.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 resize.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/asan/depend
+++ b/ext/-test-/asan/depend
@@ -127,6 +127,7 @@ asan.o: $(hdrdir)/ruby/internal/intern/re.h
 asan.o: $(hdrdir)/ruby/internal/intern/ruby.h
 asan.o: $(hdrdir)/ruby/internal/intern/select.h
 asan.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+asan.o: $(hdrdir)/ruby/internal/intern/set.h
 asan.o: $(hdrdir)/ruby/internal/intern/signal.h
 asan.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 asan.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/bignum/depend
+++ b/ext/-test-/bignum/depend
@@ -127,6 +127,7 @@ big2str.o: $(hdrdir)/ruby/internal/intern/re.h
 big2str.o: $(hdrdir)/ruby/internal/intern/ruby.h
 big2str.o: $(hdrdir)/ruby/internal/intern/select.h
 big2str.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+big2str.o: $(hdrdir)/ruby/internal/intern/set.h
 big2str.o: $(hdrdir)/ruby/internal/intern/signal.h
 big2str.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 big2str.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -287,6 +288,7 @@ bigzero.o: $(hdrdir)/ruby/internal/intern/re.h
 bigzero.o: $(hdrdir)/ruby/internal/intern/ruby.h
 bigzero.o: $(hdrdir)/ruby/internal/intern/select.h
 bigzero.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+bigzero.o: $(hdrdir)/ruby/internal/intern/set.h
 bigzero.o: $(hdrdir)/ruby/internal/intern/signal.h
 bigzero.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 bigzero.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -447,6 +449,7 @@ div.o: $(hdrdir)/ruby/internal/intern/re.h
 div.o: $(hdrdir)/ruby/internal/intern/ruby.h
 div.o: $(hdrdir)/ruby/internal/intern/select.h
 div.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+div.o: $(hdrdir)/ruby/internal/intern/set.h
 div.o: $(hdrdir)/ruby/internal/intern/signal.h
 div.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 div.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -608,6 +611,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -767,6 +771,7 @@ intpack.o: $(hdrdir)/ruby/internal/intern/re.h
 intpack.o: $(hdrdir)/ruby/internal/intern/ruby.h
 intpack.o: $(hdrdir)/ruby/internal/intern/select.h
 intpack.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+intpack.o: $(hdrdir)/ruby/internal/intern/set.h
 intpack.o: $(hdrdir)/ruby/internal/intern/signal.h
 intpack.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 intpack.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -927,6 +932,7 @@ mul.o: $(hdrdir)/ruby/internal/intern/re.h
 mul.o: $(hdrdir)/ruby/internal/intern/ruby.h
 mul.o: $(hdrdir)/ruby/internal/intern/select.h
 mul.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+mul.o: $(hdrdir)/ruby/internal/intern/set.h
 mul.o: $(hdrdir)/ruby/internal/intern/signal.h
 mul.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 mul.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1087,6 +1093,7 @@ str2big.o: $(hdrdir)/ruby/internal/intern/re.h
 str2big.o: $(hdrdir)/ruby/internal/intern/ruby.h
 str2big.o: $(hdrdir)/ruby/internal/intern/select.h
 str2big.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+str2big.o: $(hdrdir)/ruby/internal/intern/set.h
 str2big.o: $(hdrdir)/ruby/internal/intern/signal.h
 str2big.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 str2big.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/bug-14834/depend
+++ b/ext/-test-/bug-14834/depend
@@ -128,6 +128,7 @@ bug-14834.o: $(hdrdir)/ruby/internal/intern/re.h
 bug-14834.o: $(hdrdir)/ruby/internal/intern/ruby.h
 bug-14834.o: $(hdrdir)/ruby/internal/intern/select.h
 bug-14834.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+bug-14834.o: $(hdrdir)/ruby/internal/intern/set.h
 bug-14834.o: $(hdrdir)/ruby/internal/intern/signal.h
 bug-14834.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 bug-14834.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/bug-3571/depend
+++ b/ext/-test-/bug-3571/depend
@@ -128,6 +128,7 @@ bug.o: $(hdrdir)/ruby/internal/intern/re.h
 bug.o: $(hdrdir)/ruby/internal/intern/ruby.h
 bug.o: $(hdrdir)/ruby/internal/intern/select.h
 bug.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+bug.o: $(hdrdir)/ruby/internal/intern/set.h
 bug.o: $(hdrdir)/ruby/internal/intern/signal.h
 bug.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 bug.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/bug-5832/depend
+++ b/ext/-test-/bug-5832/depend
@@ -128,6 +128,7 @@ bug.o: $(hdrdir)/ruby/internal/intern/re.h
 bug.o: $(hdrdir)/ruby/internal/intern/ruby.h
 bug.o: $(hdrdir)/ruby/internal/intern/select.h
 bug.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+bug.o: $(hdrdir)/ruby/internal/intern/set.h
 bug.o: $(hdrdir)/ruby/internal/intern/signal.h
 bug.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 bug.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/bug_reporter/depend
+++ b/ext/-test-/bug_reporter/depend
@@ -128,6 +128,7 @@ bug_reporter.o: $(hdrdir)/ruby/internal/intern/re.h
 bug_reporter.o: $(hdrdir)/ruby/internal/intern/ruby.h
 bug_reporter.o: $(hdrdir)/ruby/internal/intern/select.h
 bug_reporter.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+bug_reporter.o: $(hdrdir)/ruby/internal/intern/set.h
 bug_reporter.o: $(hdrdir)/ruby/internal/intern/signal.h
 bug_reporter.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 bug_reporter.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/class/depend
+++ b/ext/-test-/class/depend
@@ -127,6 +127,7 @@ class2name.o: $(hdrdir)/ruby/internal/intern/re.h
 class2name.o: $(hdrdir)/ruby/internal/intern/ruby.h
 class2name.o: $(hdrdir)/ruby/internal/intern/select.h
 class2name.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+class2name.o: $(hdrdir)/ruby/internal/intern/set.h
 class2name.o: $(hdrdir)/ruby/internal/intern/signal.h
 class2name.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 class2name.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -287,6 +288,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/debug/depend
+++ b/ext/-test-/debug/depend
@@ -128,6 +128,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -288,6 +289,7 @@ inspector.o: $(hdrdir)/ruby/internal/intern/re.h
 inspector.o: $(hdrdir)/ruby/internal/intern/ruby.h
 inspector.o: $(hdrdir)/ruby/internal/intern/select.h
 inspector.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+inspector.o: $(hdrdir)/ruby/internal/intern/set.h
 inspector.o: $(hdrdir)/ruby/internal/intern/signal.h
 inspector.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 inspector.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -448,6 +450,7 @@ profile_frames.o: $(hdrdir)/ruby/internal/intern/re.h
 profile_frames.o: $(hdrdir)/ruby/internal/intern/ruby.h
 profile_frames.o: $(hdrdir)/ruby/internal/intern/select.h
 profile_frames.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+profile_frames.o: $(hdrdir)/ruby/internal/intern/set.h
 profile_frames.o: $(hdrdir)/ruby/internal/intern/signal.h
 profile_frames.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 profile_frames.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/dln/empty/depend
+++ b/ext/-test-/dln/empty/depend
@@ -128,6 +128,7 @@ empty.o: $(hdrdir)/ruby/internal/intern/re.h
 empty.o: $(hdrdir)/ruby/internal/intern/ruby.h
 empty.o: $(hdrdir)/ruby/internal/intern/select.h
 empty.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+empty.o: $(hdrdir)/ruby/internal/intern/set.h
 empty.o: $(hdrdir)/ruby/internal/intern/signal.h
 empty.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 empty.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/econv/depend
+++ b/ext/-test-/econv/depend
@@ -138,6 +138,7 @@ append.o: $(hdrdir)/ruby/internal/intern/re.h
 append.o: $(hdrdir)/ruby/internal/intern/ruby.h
 append.o: $(hdrdir)/ruby/internal/intern/select.h
 append.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+append.o: $(hdrdir)/ruby/internal/intern/set.h
 append.o: $(hdrdir)/ruby/internal/intern/signal.h
 append.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 append.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -300,6 +301,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/ensure_and_callcc/depend
+++ b/ext/-test-/ensure_and_callcc/depend
@@ -128,6 +128,7 @@ ensure_and_callcc.o: $(hdrdir)/ruby/internal/intern/re.h
 ensure_and_callcc.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ensure_and_callcc.o: $(hdrdir)/ruby/internal/intern/select.h
 ensure_and_callcc.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ensure_and_callcc.o: $(hdrdir)/ruby/internal/intern/set.h
 ensure_and_callcc.o: $(hdrdir)/ruby/internal/intern/signal.h
 ensure_and_callcc.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ensure_and_callcc.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/enumerator_kw/depend
+++ b/ext/-test-/enumerator_kw/depend
@@ -128,6 +128,7 @@ enumerator_kw.o: $(hdrdir)/ruby/internal/intern/re.h
 enumerator_kw.o: $(hdrdir)/ruby/internal/intern/ruby.h
 enumerator_kw.o: $(hdrdir)/ruby/internal/intern/select.h
 enumerator_kw.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+enumerator_kw.o: $(hdrdir)/ruby/internal/intern/set.h
 enumerator_kw.o: $(hdrdir)/ruby/internal/intern/signal.h
 enumerator_kw.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 enumerator_kw.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/eval/depend
+++ b/ext/-test-/eval/depend
@@ -127,6 +127,7 @@ eval.o: $(hdrdir)/ruby/internal/intern/re.h
 eval.o: $(hdrdir)/ruby/internal/intern/ruby.h
 eval.o: $(hdrdir)/ruby/internal/intern/select.h
 eval.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+eval.o: $(hdrdir)/ruby/internal/intern/set.h
 eval.o: $(hdrdir)/ruby/internal/intern/signal.h
 eval.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 eval.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/exception/depend
+++ b/ext/-test-/exception/depend
@@ -127,6 +127,7 @@ dataerror.o: $(hdrdir)/ruby/internal/intern/re.h
 dataerror.o: $(hdrdir)/ruby/internal/intern/ruby.h
 dataerror.o: $(hdrdir)/ruby/internal/intern/select.h
 dataerror.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+dataerror.o: $(hdrdir)/ruby/internal/intern/set.h
 dataerror.o: $(hdrdir)/ruby/internal/intern/signal.h
 dataerror.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 dataerror.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -297,6 +298,7 @@ enc_raise.o: $(hdrdir)/ruby/internal/intern/re.h
 enc_raise.o: $(hdrdir)/ruby/internal/intern/ruby.h
 enc_raise.o: $(hdrdir)/ruby/internal/intern/select.h
 enc_raise.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+enc_raise.o: $(hdrdir)/ruby/internal/intern/set.h
 enc_raise.o: $(hdrdir)/ruby/internal/intern/signal.h
 enc_raise.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 enc_raise.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -459,6 +461,7 @@ ensured.o: $(hdrdir)/ruby/internal/intern/re.h
 ensured.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ensured.o: $(hdrdir)/ruby/internal/intern/select.h
 ensured.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ensured.o: $(hdrdir)/ruby/internal/intern/set.h
 ensured.o: $(hdrdir)/ruby/internal/intern/signal.h
 ensured.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ensured.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -619,6 +622,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/fatal/depend
+++ b/ext/-test-/fatal/depend
@@ -129,6 +129,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -289,6 +290,7 @@ invalid.o: $(hdrdir)/ruby/internal/intern/re.h
 invalid.o: $(hdrdir)/ruby/internal/intern/ruby.h
 invalid.o: $(hdrdir)/ruby/internal/intern/select.h
 invalid.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+invalid.o: $(hdrdir)/ruby/internal/intern/set.h
 invalid.o: $(hdrdir)/ruby/internal/intern/signal.h
 invalid.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 invalid.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -449,6 +451,7 @@ rb_fatal.o: $(hdrdir)/ruby/internal/intern/re.h
 rb_fatal.o: $(hdrdir)/ruby/internal/intern/ruby.h
 rb_fatal.o: $(hdrdir)/ruby/internal/intern/select.h
 rb_fatal.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+rb_fatal.o: $(hdrdir)/ruby/internal/intern/set.h
 rb_fatal.o: $(hdrdir)/ruby/internal/intern/signal.h
 rb_fatal.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 rb_fatal.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/file/depend
+++ b/ext/-test-/file/depend
@@ -137,6 +137,7 @@ fs.o: $(hdrdir)/ruby/internal/intern/re.h
 fs.o: $(hdrdir)/ruby/internal/intern/ruby.h
 fs.o: $(hdrdir)/ruby/internal/intern/select.h
 fs.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+fs.o: $(hdrdir)/ruby/internal/intern/set.h
 fs.o: $(hdrdir)/ruby/internal/intern/signal.h
 fs.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 fs.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -300,6 +301,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -469,6 +471,7 @@ newline_conv.o: $(hdrdir)/ruby/internal/intern/re.h
 newline_conv.o: $(hdrdir)/ruby/internal/intern/ruby.h
 newline_conv.o: $(hdrdir)/ruby/internal/intern/select.h
 newline_conv.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+newline_conv.o: $(hdrdir)/ruby/internal/intern/set.h
 newline_conv.o: $(hdrdir)/ruby/internal/intern/signal.h
 newline_conv.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 newline_conv.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -641,6 +644,7 @@ stat.o: $(hdrdir)/ruby/internal/intern/re.h
 stat.o: $(hdrdir)/ruby/internal/intern/ruby.h
 stat.o: $(hdrdir)/ruby/internal/intern/select.h
 stat.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+stat.o: $(hdrdir)/ruby/internal/intern/set.h
 stat.o: $(hdrdir)/ruby/internal/intern/signal.h
 stat.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 stat.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/float/depend
+++ b/ext/-test-/float/depend
@@ -131,6 +131,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -291,6 +292,7 @@ nextafter.o: $(hdrdir)/ruby/internal/intern/re.h
 nextafter.o: $(hdrdir)/ruby/internal/intern/ruby.h
 nextafter.o: $(hdrdir)/ruby/internal/intern/select.h
 nextafter.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+nextafter.o: $(hdrdir)/ruby/internal/intern/set.h
 nextafter.o: $(hdrdir)/ruby/internal/intern/signal.h
 nextafter.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 nextafter.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/funcall/depend
+++ b/ext/-test-/funcall/depend
@@ -128,6 +128,7 @@ funcall.o: $(hdrdir)/ruby/internal/intern/re.h
 funcall.o: $(hdrdir)/ruby/internal/intern/ruby.h
 funcall.o: $(hdrdir)/ruby/internal/intern/select.h
 funcall.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+funcall.o: $(hdrdir)/ruby/internal/intern/set.h
 funcall.o: $(hdrdir)/ruby/internal/intern/signal.h
 funcall.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 funcall.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/gvl/call_without_gvl/depend
+++ b/ext/-test-/gvl/call_without_gvl/depend
@@ -127,6 +127,7 @@ call_without_gvl.o: $(hdrdir)/ruby/internal/intern/re.h
 call_without_gvl.o: $(hdrdir)/ruby/internal/intern/ruby.h
 call_without_gvl.o: $(hdrdir)/ruby/internal/intern/select.h
 call_without_gvl.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+call_without_gvl.o: $(hdrdir)/ruby/internal/intern/set.h
 call_without_gvl.o: $(hdrdir)/ruby/internal/intern/signal.h
 call_without_gvl.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 call_without_gvl.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/hash/depend
+++ b/ext/-test-/hash/depend
@@ -128,6 +128,7 @@ delete.o: $(hdrdir)/ruby/internal/intern/re.h
 delete.o: $(hdrdir)/ruby/internal/intern/ruby.h
 delete.o: $(hdrdir)/ruby/internal/intern/select.h
 delete.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+delete.o: $(hdrdir)/ruby/internal/intern/set.h
 delete.o: $(hdrdir)/ruby/internal/intern/signal.h
 delete.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 delete.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -288,6 +289,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/integer/depend
+++ b/ext/-test-/integer/depend
@@ -128,6 +128,7 @@ core_ext.o: $(hdrdir)/ruby/internal/intern/re.h
 core_ext.o: $(hdrdir)/ruby/internal/intern/ruby.h
 core_ext.o: $(hdrdir)/ruby/internal/intern/select.h
 core_ext.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+core_ext.o: $(hdrdir)/ruby/internal/intern/set.h
 core_ext.o: $(hdrdir)/ruby/internal/intern/signal.h
 core_ext.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 core_ext.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -296,6 +297,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -456,6 +458,7 @@ my_integer.o: $(hdrdir)/ruby/internal/intern/re.h
 my_integer.o: $(hdrdir)/ruby/internal/intern/ruby.h
 my_integer.o: $(hdrdir)/ruby/internal/intern/select.h
 my_integer.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+my_integer.o: $(hdrdir)/ruby/internal/intern/set.h
 my_integer.o: $(hdrdir)/ruby/internal/intern/signal.h
 my_integer.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 my_integer.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/iseq_load/depend
+++ b/ext/-test-/iseq_load/depend
@@ -128,6 +128,7 @@ iseq_load.o: $(hdrdir)/ruby/internal/intern/re.h
 iseq_load.o: $(hdrdir)/ruby/internal/intern/ruby.h
 iseq_load.o: $(hdrdir)/ruby/internal/intern/select.h
 iseq_load.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+iseq_load.o: $(hdrdir)/ruby/internal/intern/set.h
 iseq_load.o: $(hdrdir)/ruby/internal/intern/signal.h
 iseq_load.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 iseq_load.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/iter/depend
+++ b/ext/-test-/iter/depend
@@ -128,6 +128,7 @@ break.o: $(hdrdir)/ruby/internal/intern/re.h
 break.o: $(hdrdir)/ruby/internal/intern/ruby.h
 break.o: $(hdrdir)/ruby/internal/intern/select.h
 break.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+break.o: $(hdrdir)/ruby/internal/intern/set.h
 break.o: $(hdrdir)/ruby/internal/intern/signal.h
 break.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 break.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -288,6 +289,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -448,6 +450,7 @@ yield.o: $(hdrdir)/ruby/internal/intern/re.h
 yield.o: $(hdrdir)/ruby/internal/intern/ruby.h
 yield.o: $(hdrdir)/ruby/internal/intern/select.h
 yield.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+yield.o: $(hdrdir)/ruby/internal/intern/set.h
 yield.o: $(hdrdir)/ruby/internal/intern/signal.h
 yield.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 yield.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/load/dot.dot/depend
+++ b/ext/-test-/load/dot.dot/depend
@@ -128,6 +128,7 @@ dot.dot.o: $(hdrdir)/ruby/internal/intern/re.h
 dot.dot.o: $(hdrdir)/ruby/internal/intern/ruby.h
 dot.dot.o: $(hdrdir)/ruby/internal/intern/select.h
 dot.dot.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+dot.dot.o: $(hdrdir)/ruby/internal/intern/set.h
 dot.dot.o: $(hdrdir)/ruby/internal/intern/signal.h
 dot.dot.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 dot.dot.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/load/protect/depend
+++ b/ext/-test-/load/protect/depend
@@ -128,6 +128,7 @@ protect.o: $(hdrdir)/ruby/internal/intern/re.h
 protect.o: $(hdrdir)/ruby/internal/intern/ruby.h
 protect.o: $(hdrdir)/ruby/internal/intern/select.h
 protect.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+protect.o: $(hdrdir)/ruby/internal/intern/set.h
 protect.o: $(hdrdir)/ruby/internal/intern/signal.h
 protect.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 protect.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/load/resolve_symbol_resolver/depend
+++ b/ext/-test-/load/resolve_symbol_resolver/depend
@@ -128,6 +128,7 @@ resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/intern/re.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/intern/ruby.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/intern/select.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/intern/set.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/intern/signal.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 resolve_symbol_resolver.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/load/resolve_symbol_target/depend
+++ b/ext/-test-/load/resolve_symbol_target/depend
@@ -128,6 +128,7 @@ resolve_symbol_target.o: $(hdrdir)/ruby/internal/intern/re.h
 resolve_symbol_target.o: $(hdrdir)/ruby/internal/intern/ruby.h
 resolve_symbol_target.o: $(hdrdir)/ruby/internal/intern/select.h
 resolve_symbol_target.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+resolve_symbol_target.o: $(hdrdir)/ruby/internal/intern/set.h
 resolve_symbol_target.o: $(hdrdir)/ruby/internal/intern/signal.h
 resolve_symbol_target.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 resolve_symbol_target.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/load/stringify_symbols/depend
+++ b/ext/-test-/load/stringify_symbols/depend
@@ -128,6 +128,7 @@ stringify_symbols.o: $(hdrdir)/ruby/internal/intern/re.h
 stringify_symbols.o: $(hdrdir)/ruby/internal/intern/ruby.h
 stringify_symbols.o: $(hdrdir)/ruby/internal/intern/select.h
 stringify_symbols.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+stringify_symbols.o: $(hdrdir)/ruby/internal/intern/set.h
 stringify_symbols.o: $(hdrdir)/ruby/internal/intern/signal.h
 stringify_symbols.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 stringify_symbols.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/load/stringify_target/depend
+++ b/ext/-test-/load/stringify_target/depend
@@ -128,6 +128,7 @@ stringify_target.o: $(hdrdir)/ruby/internal/intern/re.h
 stringify_target.o: $(hdrdir)/ruby/internal/intern/ruby.h
 stringify_target.o: $(hdrdir)/ruby/internal/intern/select.h
 stringify_target.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+stringify_target.o: $(hdrdir)/ruby/internal/intern/set.h
 stringify_target.o: $(hdrdir)/ruby/internal/intern/signal.h
 stringify_target.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 stringify_target.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/marshal/compat/depend
+++ b/ext/-test-/marshal/compat/depend
@@ -128,6 +128,7 @@ usrcompat.o: $(hdrdir)/ruby/internal/intern/re.h
 usrcompat.o: $(hdrdir)/ruby/internal/intern/ruby.h
 usrcompat.o: $(hdrdir)/ruby/internal/intern/select.h
 usrcompat.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+usrcompat.o: $(hdrdir)/ruby/internal/intern/set.h
 usrcompat.o: $(hdrdir)/ruby/internal/intern/signal.h
 usrcompat.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 usrcompat.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/marshal/internal_ivar/depend
+++ b/ext/-test-/marshal/internal_ivar/depend
@@ -128,6 +128,7 @@ internal_ivar.o: $(hdrdir)/ruby/internal/intern/re.h
 internal_ivar.o: $(hdrdir)/ruby/internal/intern/ruby.h
 internal_ivar.o: $(hdrdir)/ruby/internal/intern/select.h
 internal_ivar.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+internal_ivar.o: $(hdrdir)/ruby/internal/intern/set.h
 internal_ivar.o: $(hdrdir)/ruby/internal/intern/signal.h
 internal_ivar.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 internal_ivar.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/marshal/usr/depend
+++ b/ext/-test-/marshal/usr/depend
@@ -128,6 +128,7 @@ usrmarshal.o: $(hdrdir)/ruby/internal/intern/re.h
 usrmarshal.o: $(hdrdir)/ruby/internal/intern/ruby.h
 usrmarshal.o: $(hdrdir)/ruby/internal/intern/select.h
 usrmarshal.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+usrmarshal.o: $(hdrdir)/ruby/internal/intern/set.h
 usrmarshal.o: $(hdrdir)/ruby/internal/intern/signal.h
 usrmarshal.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 usrmarshal.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/memory_view/depend
+++ b/ext/-test-/memory_view/depend
@@ -128,6 +128,7 @@ memory_view.o: $(hdrdir)/ruby/internal/intern/re.h
 memory_view.o: $(hdrdir)/ruby/internal/intern/ruby.h
 memory_view.o: $(hdrdir)/ruby/internal/intern/select.h
 memory_view.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+memory_view.o: $(hdrdir)/ruby/internal/intern/set.h
 memory_view.o: $(hdrdir)/ruby/internal/intern/signal.h
 memory_view.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 memory_view.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/method/depend
+++ b/ext/-test-/method/depend
@@ -128,6 +128,7 @@ arity.o: $(hdrdir)/ruby/internal/intern/re.h
 arity.o: $(hdrdir)/ruby/internal/intern/ruby.h
 arity.o: $(hdrdir)/ruby/internal/intern/select.h
 arity.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+arity.o: $(hdrdir)/ruby/internal/intern/set.h
 arity.o: $(hdrdir)/ruby/internal/intern/signal.h
 arity.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 arity.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -288,6 +289,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/notimplement/depend
+++ b/ext/-test-/notimplement/depend
@@ -128,6 +128,7 @@ bug.o: $(hdrdir)/ruby/internal/intern/re.h
 bug.o: $(hdrdir)/ruby/internal/intern/ruby.h
 bug.o: $(hdrdir)/ruby/internal/intern/select.h
 bug.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+bug.o: $(hdrdir)/ruby/internal/intern/set.h
 bug.o: $(hdrdir)/ruby/internal/intern/signal.h
 bug.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 bug.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/num2int/depend
+++ b/ext/-test-/num2int/depend
@@ -128,6 +128,7 @@ num2int.o: $(hdrdir)/ruby/internal/intern/re.h
 num2int.o: $(hdrdir)/ruby/internal/intern/ruby.h
 num2int.o: $(hdrdir)/ruby/internal/intern/select.h
 num2int.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+num2int.o: $(hdrdir)/ruby/internal/intern/set.h
 num2int.o: $(hdrdir)/ruby/internal/intern/signal.h
 num2int.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 num2int.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/path_to_class/depend
+++ b/ext/-test-/path_to_class/depend
@@ -128,6 +128,7 @@ path_to_class.o: $(hdrdir)/ruby/internal/intern/re.h
 path_to_class.o: $(hdrdir)/ruby/internal/intern/ruby.h
 path_to_class.o: $(hdrdir)/ruby/internal/intern/select.h
 path_to_class.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+path_to_class.o: $(hdrdir)/ruby/internal/intern/set.h
 path_to_class.o: $(hdrdir)/ruby/internal/intern/signal.h
 path_to_class.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 path_to_class.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/popen_deadlock/depend
+++ b/ext/-test-/popen_deadlock/depend
@@ -128,6 +128,7 @@ infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/intern/re.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/intern/ruby.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/intern/select.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/intern/set.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/intern/signal.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 infinite_loop_dlsym.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/postponed_job/depend
+++ b/ext/-test-/postponed_job/depend
@@ -129,6 +129,7 @@ postponed_job.o: $(hdrdir)/ruby/internal/intern/re.h
 postponed_job.o: $(hdrdir)/ruby/internal/intern/ruby.h
 postponed_job.o: $(hdrdir)/ruby/internal/intern/select.h
 postponed_job.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+postponed_job.o: $(hdrdir)/ruby/internal/intern/set.h
 postponed_job.o: $(hdrdir)/ruby/internal/intern/signal.h
 postponed_job.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 postponed_job.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/printf/depend
+++ b/ext/-test-/printf/depend
@@ -138,6 +138,7 @@ printf.o: $(hdrdir)/ruby/internal/intern/re.h
 printf.o: $(hdrdir)/ruby/internal/intern/ruby.h
 printf.o: $(hdrdir)/ruby/internal/intern/select.h
 printf.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+printf.o: $(hdrdir)/ruby/internal/intern/set.h
 printf.o: $(hdrdir)/ruby/internal/intern/signal.h
 printf.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 printf.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/proc/depend
+++ b/ext/-test-/proc/depend
@@ -128,6 +128,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -288,6 +289,7 @@ receiver.o: $(hdrdir)/ruby/internal/intern/re.h
 receiver.o: $(hdrdir)/ruby/internal/intern/ruby.h
 receiver.o: $(hdrdir)/ruby/internal/intern/select.h
 receiver.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+receiver.o: $(hdrdir)/ruby/internal/intern/set.h
 receiver.o: $(hdrdir)/ruby/internal/intern/signal.h
 receiver.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 receiver.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -448,6 +450,7 @@ super.o: $(hdrdir)/ruby/internal/intern/re.h
 super.o: $(hdrdir)/ruby/internal/intern/ruby.h
 super.o: $(hdrdir)/ruby/internal/intern/select.h
 super.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+super.o: $(hdrdir)/ruby/internal/intern/set.h
 super.o: $(hdrdir)/ruby/internal/intern/signal.h
 super.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 super.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/random/depend
+++ b/ext/-test-/random/depend
@@ -127,6 +127,7 @@ bad_version.o: $(hdrdir)/ruby/internal/intern/re.h
 bad_version.o: $(hdrdir)/ruby/internal/intern/ruby.h
 bad_version.o: $(hdrdir)/ruby/internal/intern/select.h
 bad_version.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+bad_version.o: $(hdrdir)/ruby/internal/intern/set.h
 bad_version.o: $(hdrdir)/ruby/internal/intern/signal.h
 bad_version.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 bad_version.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -288,6 +289,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -447,6 +449,7 @@ loop.o: $(hdrdir)/ruby/internal/intern/re.h
 loop.o: $(hdrdir)/ruby/internal/intern/ruby.h
 loop.o: $(hdrdir)/ruby/internal/intern/select.h
 loop.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+loop.o: $(hdrdir)/ruby/internal/intern/set.h
 loop.o: $(hdrdir)/ruby/internal/intern/signal.h
 loop.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 loop.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/rational/depend
+++ b/ext/-test-/rational/depend
@@ -132,6 +132,7 @@ rat.o: $(hdrdir)/ruby/internal/intern/re.h
 rat.o: $(hdrdir)/ruby/internal/intern/ruby.h
 rat.o: $(hdrdir)/ruby/internal/intern/select.h
 rat.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+rat.o: $(hdrdir)/ruby/internal/intern/set.h
 rat.o: $(hdrdir)/ruby/internal/intern/signal.h
 rat.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 rat.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/rb_call_super_kw/depend
+++ b/ext/-test-/rb_call_super_kw/depend
@@ -128,6 +128,7 @@ rb_call_super_kw.o: $(hdrdir)/ruby/internal/intern/re.h
 rb_call_super_kw.o: $(hdrdir)/ruby/internal/intern/ruby.h
 rb_call_super_kw.o: $(hdrdir)/ruby/internal/intern/select.h
 rb_call_super_kw.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+rb_call_super_kw.o: $(hdrdir)/ruby/internal/intern/set.h
 rb_call_super_kw.o: $(hdrdir)/ruby/internal/intern/signal.h
 rb_call_super_kw.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 rb_call_super_kw.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/recursion/depend
+++ b/ext/-test-/recursion/depend
@@ -128,6 +128,7 @@ recursion.o: $(hdrdir)/ruby/internal/intern/re.h
 recursion.o: $(hdrdir)/ruby/internal/intern/ruby.h
 recursion.o: $(hdrdir)/ruby/internal/intern/select.h
 recursion.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+recursion.o: $(hdrdir)/ruby/internal/intern/set.h
 recursion.o: $(hdrdir)/ruby/internal/intern/signal.h
 recursion.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 recursion.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/regexp/depend
+++ b/ext/-test-/regexp/depend
@@ -128,6 +128,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -288,6 +289,7 @@ parse_depth_limit.o: $(hdrdir)/ruby/internal/intern/re.h
 parse_depth_limit.o: $(hdrdir)/ruby/internal/intern/ruby.h
 parse_depth_limit.o: $(hdrdir)/ruby/internal/intern/select.h
 parse_depth_limit.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+parse_depth_limit.o: $(hdrdir)/ruby/internal/intern/set.h
 parse_depth_limit.o: $(hdrdir)/ruby/internal/intern/signal.h
 parse_depth_limit.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 parse_depth_limit.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/scan_args/depend
+++ b/ext/-test-/scan_args/depend
@@ -128,6 +128,7 @@ scan_args.o: $(hdrdir)/ruby/internal/intern/re.h
 scan_args.o: $(hdrdir)/ruby/internal/intern/ruby.h
 scan_args.o: $(hdrdir)/ruby/internal/intern/select.h
 scan_args.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+scan_args.o: $(hdrdir)/ruby/internal/intern/set.h
 scan_args.o: $(hdrdir)/ruby/internal/intern/signal.h
 scan_args.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 scan_args.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/st/foreach/depend
+++ b/ext/-test-/st/foreach/depend
@@ -128,6 +128,7 @@ foreach.o: $(hdrdir)/ruby/internal/intern/re.h
 foreach.o: $(hdrdir)/ruby/internal/intern/ruby.h
 foreach.o: $(hdrdir)/ruby/internal/intern/select.h
 foreach.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+foreach.o: $(hdrdir)/ruby/internal/intern/set.h
 foreach.o: $(hdrdir)/ruby/internal/intern/signal.h
 foreach.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 foreach.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/st/numhash/depend
+++ b/ext/-test-/st/numhash/depend
@@ -128,6 +128,7 @@ numhash.o: $(hdrdir)/ruby/internal/intern/re.h
 numhash.o: $(hdrdir)/ruby/internal/intern/ruby.h
 numhash.o: $(hdrdir)/ruby/internal/intern/select.h
 numhash.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+numhash.o: $(hdrdir)/ruby/internal/intern/set.h
 numhash.o: $(hdrdir)/ruby/internal/intern/signal.h
 numhash.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 numhash.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/st/update/depend
+++ b/ext/-test-/st/update/depend
@@ -128,6 +128,7 @@ update.o: $(hdrdir)/ruby/internal/intern/re.h
 update.o: $(hdrdir)/ruby/internal/intern/ruby.h
 update.o: $(hdrdir)/ruby/internal/intern/select.h
 update.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+update.o: $(hdrdir)/ruby/internal/intern/set.h
 update.o: $(hdrdir)/ruby/internal/intern/signal.h
 update.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 update.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/stack/depend
+++ b/ext/-test-/stack/depend
@@ -139,6 +139,7 @@ stack.o: $(hdrdir)/ruby/internal/intern/re.h
 stack.o: $(hdrdir)/ruby/internal/intern/ruby.h
 stack.o: $(hdrdir)/ruby/internal/intern/select.h
 stack.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+stack.o: $(hdrdir)/ruby/internal/intern/set.h
 stack.o: $(hdrdir)/ruby/internal/intern/signal.h
 stack.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 stack.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/string/depend
+++ b/ext/-test-/string/depend
@@ -139,6 +139,7 @@ capacity.o: $(hdrdir)/ruby/internal/intern/re.h
 capacity.o: $(hdrdir)/ruby/internal/intern/ruby.h
 capacity.o: $(hdrdir)/ruby/internal/intern/select.h
 capacity.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+capacity.o: $(hdrdir)/ruby/internal/intern/set.h
 capacity.o: $(hdrdir)/ruby/internal/intern/signal.h
 capacity.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 capacity.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -472,6 +473,7 @@ coderange.o: $(hdrdir)/ruby/internal/intern/re.h
 coderange.o: $(hdrdir)/ruby/internal/intern/ruby.h
 coderange.o: $(hdrdir)/ruby/internal/intern/select.h
 coderange.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+coderange.o: $(hdrdir)/ruby/internal/intern/set.h
 coderange.o: $(hdrdir)/ruby/internal/intern/signal.h
 coderange.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 coderange.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -644,6 +646,7 @@ cstr.o: $(hdrdir)/ruby/internal/intern/re.h
 cstr.o: $(hdrdir)/ruby/internal/intern/ruby.h
 cstr.o: $(hdrdir)/ruby/internal/intern/select.h
 cstr.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+cstr.o: $(hdrdir)/ruby/internal/intern/set.h
 cstr.o: $(hdrdir)/ruby/internal/intern/signal.h
 cstr.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 cstr.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -809,6 +812,7 @@ ellipsize.o: $(hdrdir)/ruby/internal/intern/re.h
 ellipsize.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ellipsize.o: $(hdrdir)/ruby/internal/intern/select.h
 ellipsize.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ellipsize.o: $(hdrdir)/ruby/internal/intern/set.h
 ellipsize.o: $(hdrdir)/ruby/internal/intern/signal.h
 ellipsize.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ellipsize.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -979,6 +983,7 @@ enc_associate.o: $(hdrdir)/ruby/internal/intern/re.h
 enc_associate.o: $(hdrdir)/ruby/internal/intern/ruby.h
 enc_associate.o: $(hdrdir)/ruby/internal/intern/select.h
 enc_associate.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+enc_associate.o: $(hdrdir)/ruby/internal/intern/set.h
 enc_associate.o: $(hdrdir)/ruby/internal/intern/signal.h
 enc_associate.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 enc_associate.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1151,6 +1156,7 @@ enc_dummy.o: $(hdrdir)/ruby/internal/intern/re.h
 enc_dummy.o: $(hdrdir)/ruby/internal/intern/ruby.h
 enc_dummy.o: $(hdrdir)/ruby/internal/intern/select.h
 enc_dummy.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+enc_dummy.o: $(hdrdir)/ruby/internal/intern/set.h
 enc_dummy.o: $(hdrdir)/ruby/internal/intern/signal.h
 enc_dummy.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 enc_dummy.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1322,6 +1328,7 @@ enc_str_buf_cat.o: $(hdrdir)/ruby/internal/intern/re.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/internal/intern/ruby.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/internal/intern/select.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+enc_str_buf_cat.o: $(hdrdir)/ruby/internal/intern/set.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/internal/intern/signal.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 enc_str_buf_cat.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1495,6 +1502,7 @@ fstring.o: $(hdrdir)/ruby/internal/intern/re.h
 fstring.o: $(hdrdir)/ruby/internal/intern/ruby.h
 fstring.o: $(hdrdir)/ruby/internal/intern/select.h
 fstring.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+fstring.o: $(hdrdir)/ruby/internal/intern/set.h
 fstring.o: $(hdrdir)/ruby/internal/intern/signal.h
 fstring.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 fstring.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1659,6 +1667,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1819,6 +1828,7 @@ modify.o: $(hdrdir)/ruby/internal/intern/re.h
 modify.o: $(hdrdir)/ruby/internal/intern/ruby.h
 modify.o: $(hdrdir)/ruby/internal/intern/select.h
 modify.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+modify.o: $(hdrdir)/ruby/internal/intern/set.h
 modify.o: $(hdrdir)/ruby/internal/intern/signal.h
 modify.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 modify.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1989,6 +1999,7 @@ new.o: $(hdrdir)/ruby/internal/intern/re.h
 new.o: $(hdrdir)/ruby/internal/intern/ruby.h
 new.o: $(hdrdir)/ruby/internal/intern/select.h
 new.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+new.o: $(hdrdir)/ruby/internal/intern/set.h
 new.o: $(hdrdir)/ruby/internal/intern/signal.h
 new.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 new.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2151,6 +2162,7 @@ nofree.o: $(hdrdir)/ruby/internal/intern/re.h
 nofree.o: $(hdrdir)/ruby/internal/intern/ruby.h
 nofree.o: $(hdrdir)/ruby/internal/intern/select.h
 nofree.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+nofree.o: $(hdrdir)/ruby/internal/intern/set.h
 nofree.o: $(hdrdir)/ruby/internal/intern/signal.h
 nofree.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 nofree.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2320,6 +2332,7 @@ normalize.o: $(hdrdir)/ruby/internal/intern/re.h
 normalize.o: $(hdrdir)/ruby/internal/intern/ruby.h
 normalize.o: $(hdrdir)/ruby/internal/intern/select.h
 normalize.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+normalize.o: $(hdrdir)/ruby/internal/intern/set.h
 normalize.o: $(hdrdir)/ruby/internal/intern/signal.h
 normalize.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 normalize.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2493,6 +2506,7 @@ qsort.o: $(hdrdir)/ruby/internal/intern/re.h
 qsort.o: $(hdrdir)/ruby/internal/intern/ruby.h
 qsort.o: $(hdrdir)/ruby/internal/intern/select.h
 qsort.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+qsort.o: $(hdrdir)/ruby/internal/intern/set.h
 qsort.o: $(hdrdir)/ruby/internal/intern/signal.h
 qsort.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 qsort.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2656,6 +2670,7 @@ rb_interned_str.o: $(hdrdir)/ruby/internal/intern/re.h
 rb_interned_str.o: $(hdrdir)/ruby/internal/intern/ruby.h
 rb_interned_str.o: $(hdrdir)/ruby/internal/intern/select.h
 rb_interned_str.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+rb_interned_str.o: $(hdrdir)/ruby/internal/intern/set.h
 rb_interned_str.o: $(hdrdir)/ruby/internal/intern/signal.h
 rb_interned_str.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 rb_interned_str.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2816,6 +2831,7 @@ rb_str_dup.o: $(hdrdir)/ruby/internal/intern/re.h
 rb_str_dup.o: $(hdrdir)/ruby/internal/intern/ruby.h
 rb_str_dup.o: $(hdrdir)/ruby/internal/intern/select.h
 rb_str_dup.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+rb_str_dup.o: $(hdrdir)/ruby/internal/intern/set.h
 rb_str_dup.o: $(hdrdir)/ruby/internal/intern/signal.h
 rb_str_dup.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 rb_str_dup.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2976,6 +2992,7 @@ set_len.o: $(hdrdir)/ruby/internal/intern/re.h
 set_len.o: $(hdrdir)/ruby/internal/intern/ruby.h
 set_len.o: $(hdrdir)/ruby/internal/intern/select.h
 set_len.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+set_len.o: $(hdrdir)/ruby/internal/intern/set.h
 set_len.o: $(hdrdir)/ruby/internal/intern/signal.h
 set_len.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 set_len.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/struct/depend
+++ b/ext/-test-/struct/depend
@@ -128,6 +128,7 @@ data.o: $(hdrdir)/ruby/internal/intern/re.h
 data.o: $(hdrdir)/ruby/internal/intern/ruby.h
 data.o: $(hdrdir)/ruby/internal/intern/select.h
 data.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+data.o: $(hdrdir)/ruby/internal/intern/set.h
 data.o: $(hdrdir)/ruby/internal/intern/signal.h
 data.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 data.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -288,6 +289,7 @@ duplicate.o: $(hdrdir)/ruby/internal/intern/re.h
 duplicate.o: $(hdrdir)/ruby/internal/intern/ruby.h
 duplicate.o: $(hdrdir)/ruby/internal/intern/select.h
 duplicate.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+duplicate.o: $(hdrdir)/ruby/internal/intern/set.h
 duplicate.o: $(hdrdir)/ruby/internal/intern/signal.h
 duplicate.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 duplicate.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -448,6 +450,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -608,6 +611,7 @@ len.o: $(hdrdir)/ruby/internal/intern/re.h
 len.o: $(hdrdir)/ruby/internal/intern/ruby.h
 len.o: $(hdrdir)/ruby/internal/intern/select.h
 len.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+len.o: $(hdrdir)/ruby/internal/intern/set.h
 len.o: $(hdrdir)/ruby/internal/intern/signal.h
 len.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 len.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -768,6 +772,7 @@ member.o: $(hdrdir)/ruby/internal/intern/re.h
 member.o: $(hdrdir)/ruby/internal/intern/ruby.h
 member.o: $(hdrdir)/ruby/internal/intern/select.h
 member.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+member.o: $(hdrdir)/ruby/internal/intern/set.h
 member.o: $(hdrdir)/ruby/internal/intern/signal.h
 member.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 member.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/symbol/depend
+++ b/ext/-test-/symbol/depend
@@ -128,6 +128,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -288,6 +289,7 @@ type.o: $(hdrdir)/ruby/internal/intern/re.h
 type.o: $(hdrdir)/ruby/internal/intern/ruby.h
 type.o: $(hdrdir)/ruby/internal/intern/select.h
 type.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+type.o: $(hdrdir)/ruby/internal/intern/set.h
 type.o: $(hdrdir)/ruby/internal/intern/signal.h
 type.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 type.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/thread/id/depend
+++ b/ext/-test-/thread/id/depend
@@ -128,6 +128,7 @@ id.o: $(hdrdir)/ruby/internal/intern/re.h
 id.o: $(hdrdir)/ruby/internal/intern/ruby.h
 id.o: $(hdrdir)/ruby/internal/intern/select.h
 id.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+id.o: $(hdrdir)/ruby/internal/intern/set.h
 id.o: $(hdrdir)/ruby/internal/intern/signal.h
 id.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 id.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/thread/instrumentation/depend
+++ b/ext/-test-/thread/instrumentation/depend
@@ -128,6 +128,7 @@ instrumentation.o: $(hdrdir)/ruby/internal/intern/re.h
 instrumentation.o: $(hdrdir)/ruby/internal/intern/ruby.h
 instrumentation.o: $(hdrdir)/ruby/internal/intern/select.h
 instrumentation.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+instrumentation.o: $(hdrdir)/ruby/internal/intern/set.h
 instrumentation.o: $(hdrdir)/ruby/internal/intern/signal.h
 instrumentation.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 instrumentation.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/thread/lock_native_thread/depend
+++ b/ext/-test-/thread/lock_native_thread/depend
@@ -127,6 +127,7 @@ lock_native_thread.o: $(hdrdir)/ruby/internal/intern/re.h
 lock_native_thread.o: $(hdrdir)/ruby/internal/intern/ruby.h
 lock_native_thread.o: $(hdrdir)/ruby/internal/intern/select.h
 lock_native_thread.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+lock_native_thread.o: $(hdrdir)/ruby/internal/intern/set.h
 lock_native_thread.o: $(hdrdir)/ruby/internal/intern/signal.h
 lock_native_thread.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 lock_native_thread.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/time/depend
+++ b/ext/-test-/time/depend
@@ -128,6 +128,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -289,6 +290,7 @@ leap_second.o: $(hdrdir)/ruby/internal/intern/re.h
 leap_second.o: $(hdrdir)/ruby/internal/intern/ruby.h
 leap_second.o: $(hdrdir)/ruby/internal/intern/select.h
 leap_second.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+leap_second.o: $(hdrdir)/ruby/internal/intern/set.h
 leap_second.o: $(hdrdir)/ruby/internal/intern/signal.h
 leap_second.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 leap_second.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -453,6 +455,7 @@ new.o: $(hdrdir)/ruby/internal/intern/re.h
 new.o: $(hdrdir)/ruby/internal/intern/ruby.h
 new.o: $(hdrdir)/ruby/internal/intern/select.h
 new.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+new.o: $(hdrdir)/ruby/internal/intern/set.h
 new.o: $(hdrdir)/ruby/internal/intern/signal.h
 new.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 new.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/tracepoint/depend
+++ b/ext/-test-/tracepoint/depend
@@ -128,6 +128,7 @@ gc_hook.o: $(hdrdir)/ruby/internal/intern/re.h
 gc_hook.o: $(hdrdir)/ruby/internal/intern/ruby.h
 gc_hook.o: $(hdrdir)/ruby/internal/intern/select.h
 gc_hook.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+gc_hook.o: $(hdrdir)/ruby/internal/intern/set.h
 gc_hook.o: $(hdrdir)/ruby/internal/intern/signal.h
 gc_hook.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 gc_hook.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -288,6 +289,7 @@ tracepoint.o: $(hdrdir)/ruby/internal/intern/re.h
 tracepoint.o: $(hdrdir)/ruby/internal/intern/ruby.h
 tracepoint.o: $(hdrdir)/ruby/internal/intern/select.h
 tracepoint.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+tracepoint.o: $(hdrdir)/ruby/internal/intern/set.h
 tracepoint.o: $(hdrdir)/ruby/internal/intern/signal.h
 tracepoint.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 tracepoint.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/typeddata/depend
+++ b/ext/-test-/typeddata/depend
@@ -128,6 +128,7 @@ typeddata.o: $(hdrdir)/ruby/internal/intern/re.h
 typeddata.o: $(hdrdir)/ruby/internal/intern/ruby.h
 typeddata.o: $(hdrdir)/ruby/internal/intern/select.h
 typeddata.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+typeddata.o: $(hdrdir)/ruby/internal/intern/set.h
 typeddata.o: $(hdrdir)/ruby/internal/intern/signal.h
 typeddata.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 typeddata.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/vm/depend
+++ b/ext/-test-/vm/depend
@@ -127,6 +127,7 @@ at_exit.o: $(hdrdir)/ruby/internal/intern/re.h
 at_exit.o: $(hdrdir)/ruby/internal/intern/ruby.h
 at_exit.o: $(hdrdir)/ruby/internal/intern/select.h
 at_exit.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+at_exit.o: $(hdrdir)/ruby/internal/intern/set.h
 at_exit.o: $(hdrdir)/ruby/internal/intern/signal.h
 at_exit.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 at_exit.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/-test-/wait/depend
+++ b/ext/-test-/wait/depend
@@ -137,6 +137,7 @@ wait.o: $(hdrdir)/ruby/internal/intern/re.h
 wait.o: $(hdrdir)/ruby/internal/intern/ruby.h
 wait.o: $(hdrdir)/ruby/internal/intern/select.h
 wait.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+wait.o: $(hdrdir)/ruby/internal/intern/set.h
 wait.o: $(hdrdir)/ruby/internal/intern/signal.h
 wait.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 wait.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/cgi/escape/depend
+++ b/ext/cgi/escape/depend
@@ -138,6 +138,7 @@ escape.o: $(hdrdir)/ruby/internal/intern/re.h
 escape.o: $(hdrdir)/ruby/internal/intern/ruby.h
 escape.o: $(hdrdir)/ruby/internal/intern/select.h
 escape.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+escape.o: $(hdrdir)/ruby/internal/intern/set.h
 escape.o: $(hdrdir)/ruby/internal/intern/signal.h
 escape.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 escape.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/continuation/depend
+++ b/ext/continuation/depend
@@ -127,6 +127,7 @@ continuation.o: $(hdrdir)/ruby/internal/intern/re.h
 continuation.o: $(hdrdir)/ruby/internal/intern/ruby.h
 continuation.o: $(hdrdir)/ruby/internal/intern/select.h
 continuation.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+continuation.o: $(hdrdir)/ruby/internal/intern/set.h
 continuation.o: $(hdrdir)/ruby/internal/intern/signal.h
 continuation.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 continuation.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/coverage/depend
+++ b/ext/coverage/depend
@@ -140,6 +140,7 @@ coverage.o: $(hdrdir)/ruby/internal/intern/re.h
 coverage.o: $(hdrdir)/ruby/internal/intern/ruby.h
 coverage.o: $(hdrdir)/ruby/internal/intern/select.h
 coverage.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+coverage.o: $(hdrdir)/ruby/internal/intern/set.h
 coverage.o: $(hdrdir)/ruby/internal/intern/signal.h
 coverage.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 coverage.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/date/depend
+++ b/ext/date/depend
@@ -138,6 +138,7 @@ date_core.o: $(hdrdir)/ruby/internal/intern/re.h
 date_core.o: $(hdrdir)/ruby/internal/intern/ruby.h
 date_core.o: $(hdrdir)/ruby/internal/intern/select.h
 date_core.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+date_core.o: $(hdrdir)/ruby/internal/intern/set.h
 date_core.o: $(hdrdir)/ruby/internal/intern/signal.h
 date_core.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 date_core.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -313,6 +314,7 @@ date_parse.o: $(hdrdir)/ruby/internal/intern/re.h
 date_parse.o: $(hdrdir)/ruby/internal/intern/ruby.h
 date_parse.o: $(hdrdir)/ruby/internal/intern/select.h
 date_parse.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+date_parse.o: $(hdrdir)/ruby/internal/intern/set.h
 date_parse.o: $(hdrdir)/ruby/internal/intern/signal.h
 date_parse.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 date_parse.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -478,6 +480,7 @@ date_strftime.o: $(hdrdir)/ruby/internal/intern/re.h
 date_strftime.o: $(hdrdir)/ruby/internal/intern/ruby.h
 date_strftime.o: $(hdrdir)/ruby/internal/intern/select.h
 date_strftime.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+date_strftime.o: $(hdrdir)/ruby/internal/intern/set.h
 date_strftime.o: $(hdrdir)/ruby/internal/intern/signal.h
 date_strftime.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 date_strftime.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -650,6 +653,7 @@ date_strptime.o: $(hdrdir)/ruby/internal/intern/re.h
 date_strptime.o: $(hdrdir)/ruby/internal/intern/ruby.h
 date_strptime.o: $(hdrdir)/ruby/internal/intern/select.h
 date_strptime.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+date_strptime.o: $(hdrdir)/ruby/internal/intern/set.h
 date_strptime.o: $(hdrdir)/ruby/internal/intern/signal.h
 date_strptime.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 date_strptime.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/digest/bubblebabble/depend
+++ b/ext/digest/bubblebabble/depend
@@ -128,6 +128,7 @@ bubblebabble.o: $(hdrdir)/ruby/internal/intern/re.h
 bubblebabble.o: $(hdrdir)/ruby/internal/intern/ruby.h
 bubblebabble.o: $(hdrdir)/ruby/internal/intern/select.h
 bubblebabble.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+bubblebabble.o: $(hdrdir)/ruby/internal/intern/set.h
 bubblebabble.o: $(hdrdir)/ruby/internal/intern/signal.h
 bubblebabble.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 bubblebabble.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/digest/depend
+++ b/ext/digest/depend
@@ -128,6 +128,7 @@ digest.o: $(hdrdir)/ruby/internal/intern/re.h
 digest.o: $(hdrdir)/ruby/internal/intern/ruby.h
 digest.o: $(hdrdir)/ruby/internal/intern/select.h
 digest.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+digest.o: $(hdrdir)/ruby/internal/intern/set.h
 digest.o: $(hdrdir)/ruby/internal/intern/signal.h
 digest.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 digest.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/digest/md5/depend
+++ b/ext/digest/md5/depend
@@ -131,6 +131,7 @@ md5.o: $(hdrdir)/ruby/internal/intern/re.h
 md5.o: $(hdrdir)/ruby/internal/intern/ruby.h
 md5.o: $(hdrdir)/ruby/internal/intern/select.h
 md5.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+md5.o: $(hdrdir)/ruby/internal/intern/set.h
 md5.o: $(hdrdir)/ruby/internal/intern/signal.h
 md5.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 md5.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -293,6 +294,7 @@ md5init.o: $(hdrdir)/ruby/internal/intern/re.h
 md5init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 md5init.o: $(hdrdir)/ruby/internal/intern/select.h
 md5init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+md5init.o: $(hdrdir)/ruby/internal/intern/set.h
 md5init.o: $(hdrdir)/ruby/internal/intern/signal.h
 md5init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 md5init.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/digest/rmd160/depend
+++ b/ext/digest/rmd160/depend
@@ -131,6 +131,7 @@ rmd160.o: $(hdrdir)/ruby/internal/intern/re.h
 rmd160.o: $(hdrdir)/ruby/internal/intern/ruby.h
 rmd160.o: $(hdrdir)/ruby/internal/intern/select.h
 rmd160.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+rmd160.o: $(hdrdir)/ruby/internal/intern/set.h
 rmd160.o: $(hdrdir)/ruby/internal/intern/signal.h
 rmd160.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 rmd160.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -293,6 +294,7 @@ rmd160init.o: $(hdrdir)/ruby/internal/intern/re.h
 rmd160init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 rmd160init.o: $(hdrdir)/ruby/internal/intern/select.h
 rmd160init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+rmd160init.o: $(hdrdir)/ruby/internal/intern/set.h
 rmd160init.o: $(hdrdir)/ruby/internal/intern/signal.h
 rmd160init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 rmd160init.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/digest/sha1/depend
+++ b/ext/digest/sha1/depend
@@ -131,6 +131,7 @@ sha1.o: $(hdrdir)/ruby/internal/intern/re.h
 sha1.o: $(hdrdir)/ruby/internal/intern/ruby.h
 sha1.o: $(hdrdir)/ruby/internal/intern/select.h
 sha1.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+sha1.o: $(hdrdir)/ruby/internal/intern/set.h
 sha1.o: $(hdrdir)/ruby/internal/intern/signal.h
 sha1.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 sha1.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -293,6 +294,7 @@ sha1init.o: $(hdrdir)/ruby/internal/intern/re.h
 sha1init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 sha1init.o: $(hdrdir)/ruby/internal/intern/select.h
 sha1init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+sha1init.o: $(hdrdir)/ruby/internal/intern/set.h
 sha1init.o: $(hdrdir)/ruby/internal/intern/signal.h
 sha1init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 sha1init.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/digest/sha2/depend
+++ b/ext/digest/sha2/depend
@@ -131,6 +131,7 @@ sha2.o: $(hdrdir)/ruby/internal/intern/re.h
 sha2.o: $(hdrdir)/ruby/internal/intern/ruby.h
 sha2.o: $(hdrdir)/ruby/internal/intern/select.h
 sha2.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+sha2.o: $(hdrdir)/ruby/internal/intern/set.h
 sha2.o: $(hdrdir)/ruby/internal/intern/signal.h
 sha2.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 sha2.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -293,6 +294,7 @@ sha2init.o: $(hdrdir)/ruby/internal/intern/re.h
 sha2init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 sha2init.o: $(hdrdir)/ruby/internal/intern/select.h
 sha2init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+sha2init.o: $(hdrdir)/ruby/internal/intern/set.h
 sha2init.o: $(hdrdir)/ruby/internal/intern/signal.h
 sha2init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 sha2init.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/etc/depend
+++ b/ext/etc/depend
@@ -143,6 +143,7 @@ etc.o: $(hdrdir)/ruby/internal/intern/re.h
 etc.o: $(hdrdir)/ruby/internal/intern/ruby.h
 etc.o: $(hdrdir)/ruby/internal/intern/select.h
 etc.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+etc.o: $(hdrdir)/ruby/internal/intern/set.h
 etc.o: $(hdrdir)/ruby/internal/intern/signal.h
 etc.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 etc.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/fcntl/depend
+++ b/ext/fcntl/depend
@@ -128,6 +128,7 @@ fcntl.o: $(hdrdir)/ruby/internal/intern/re.h
 fcntl.o: $(hdrdir)/ruby/internal/intern/ruby.h
 fcntl.o: $(hdrdir)/ruby/internal/intern/select.h
 fcntl.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+fcntl.o: $(hdrdir)/ruby/internal/intern/set.h
 fcntl.o: $(hdrdir)/ruby/internal/intern/signal.h
 fcntl.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 fcntl.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/io/console/depend
+++ b/ext/io/console/depend
@@ -139,6 +139,7 @@ console.o: $(hdrdir)/ruby/internal/intern/re.h
 console.o: $(hdrdir)/ruby/internal/intern/ruby.h
 console.o: $(hdrdir)/ruby/internal/intern/select.h
 console.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+console.o: $(hdrdir)/ruby/internal/intern/set.h
 console.o: $(hdrdir)/ruby/internal/intern/signal.h
 console.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 console.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/io/nonblock/depend
+++ b/ext/io/nonblock/depend
@@ -138,6 +138,7 @@ nonblock.o: $(hdrdir)/ruby/internal/intern/re.h
 nonblock.o: $(hdrdir)/ruby/internal/intern/ruby.h
 nonblock.o: $(hdrdir)/ruby/internal/intern/select.h
 nonblock.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+nonblock.o: $(hdrdir)/ruby/internal/intern/set.h
 nonblock.o: $(hdrdir)/ruby/internal/intern/signal.h
 nonblock.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 nonblock.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/io/wait/depend
+++ b/ext/io/wait/depend
@@ -138,6 +138,7 @@ wait.o: $(hdrdir)/ruby/internal/intern/re.h
 wait.o: $(hdrdir)/ruby/internal/intern/ruby.h
 wait.o: $(hdrdir)/ruby/internal/intern/select.h
 wait.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+wait.o: $(hdrdir)/ruby/internal/intern/set.h
 wait.o: $(hdrdir)/ruby/internal/intern/signal.h
 wait.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 wait.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/json/generator/depend
+++ b/ext/json/generator/depend
@@ -142,6 +142,7 @@ generator.o: $(hdrdir)/ruby/internal/intern/re.h
 generator.o: $(hdrdir)/ruby/internal/intern/ruby.h
 generator.o: $(hdrdir)/ruby/internal/intern/select.h
 generator.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+generator.o: $(hdrdir)/ruby/internal/intern/set.h
 generator.o: $(hdrdir)/ruby/internal/intern/signal.h
 generator.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 generator.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/json/parser/depend
+++ b/ext/json/parser/depend
@@ -141,6 +141,7 @@ parser.o: $(hdrdir)/ruby/internal/intern/re.h
 parser.o: $(hdrdir)/ruby/internal/intern/ruby.h
 parser.o: $(hdrdir)/ruby/internal/intern/select.h
 parser.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+parser.o: $(hdrdir)/ruby/internal/intern/set.h
 parser.o: $(hdrdir)/ruby/internal/intern/signal.h
 parser.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 parser.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/monitor/depend
+++ b/ext/monitor/depend
@@ -127,6 +127,7 @@ monitor.o: $(hdrdir)/ruby/internal/intern/re.h
 monitor.o: $(hdrdir)/ruby/internal/intern/ruby.h
 monitor.o: $(hdrdir)/ruby/internal/intern/select.h
 monitor.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+monitor.o: $(hdrdir)/ruby/internal/intern/set.h
 monitor.o: $(hdrdir)/ruby/internal/intern/signal.h
 monitor.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 monitor.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/objspace/depend
+++ b/ext/objspace/depend
@@ -140,6 +140,7 @@ object_tracing.o: $(hdrdir)/ruby/internal/intern/re.h
 object_tracing.o: $(hdrdir)/ruby/internal/intern/ruby.h
 object_tracing.o: $(hdrdir)/ruby/internal/intern/select.h
 object_tracing.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+object_tracing.o: $(hdrdir)/ruby/internal/intern/set.h
 object_tracing.o: $(hdrdir)/ruby/internal/intern/signal.h
 object_tracing.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 object_tracing.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -343,6 +344,7 @@ objspace.o: $(hdrdir)/ruby/internal/intern/re.h
 objspace.o: $(hdrdir)/ruby/internal/intern/ruby.h
 objspace.o: $(hdrdir)/ruby/internal/intern/select.h
 objspace.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+objspace.o: $(hdrdir)/ruby/internal/intern/set.h
 objspace.o: $(hdrdir)/ruby/internal/intern/signal.h
 objspace.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 objspace.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -557,6 +559,7 @@ objspace_dump.o: $(hdrdir)/ruby/internal/intern/re.h
 objspace_dump.o: $(hdrdir)/ruby/internal/intern/ruby.h
 objspace_dump.o: $(hdrdir)/ruby/internal/intern/select.h
 objspace_dump.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+objspace_dump.o: $(hdrdir)/ruby/internal/intern/set.h
 objspace_dump.o: $(hdrdir)/ruby/internal/intern/signal.h
 objspace_dump.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 objspace_dump.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/openssl/depend
+++ b/ext/openssl/depend
@@ -142,6 +142,7 @@ ossl.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -338,6 +339,7 @@ ossl_asn1.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_asn1.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_asn1.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_asn1.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_asn1.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_asn1.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_asn1.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_asn1.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -534,6 +536,7 @@ ossl_bio.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_bio.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_bio.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_bio.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_bio.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_bio.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_bio.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_bio.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -730,6 +733,7 @@ ossl_bn.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_bn.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_bn.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_bn.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_bn.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_bn.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_bn.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_bn.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -926,6 +930,7 @@ ossl_cipher.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_cipher.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_cipher.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_cipher.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_cipher.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_cipher.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_cipher.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_cipher.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1122,6 +1127,7 @@ ossl_config.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_config.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_config.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_config.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_config.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_config.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_config.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_config.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1318,6 +1324,7 @@ ossl_digest.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_digest.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_digest.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_digest.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_digest.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_digest.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_digest.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_digest.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1514,6 +1521,7 @@ ossl_engine.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_engine.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_engine.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_engine.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_engine.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_engine.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_engine.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_engine.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1710,6 +1718,7 @@ ossl_hmac.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_hmac.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_hmac.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_hmac.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_hmac.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_hmac.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_hmac.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_hmac.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1906,6 +1915,7 @@ ossl_kdf.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_kdf.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_kdf.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_kdf.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_kdf.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_kdf.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_kdf.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_kdf.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2102,6 +2112,7 @@ ossl_ns_spki.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_ns_spki.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_ns_spki.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_ns_spki.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_ns_spki.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_ns_spki.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_ns_spki.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_ns_spki.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2298,6 +2309,7 @@ ossl_ocsp.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_ocsp.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_ocsp.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_ocsp.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_ocsp.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_ocsp.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_ocsp.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_ocsp.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2494,6 +2506,7 @@ ossl_pkcs12.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_pkcs12.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_pkcs12.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_pkcs12.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_pkcs12.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_pkcs12.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_pkcs12.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_pkcs12.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2690,6 +2703,7 @@ ossl_pkcs7.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_pkcs7.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_pkcs7.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_pkcs7.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_pkcs7.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_pkcs7.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_pkcs7.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_pkcs7.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2886,6 +2900,7 @@ ossl_pkey.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_pkey.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_pkey.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_pkey.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_pkey.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_pkey.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_pkey.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_pkey.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -3082,6 +3097,7 @@ ossl_pkey_dh.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_pkey_dh.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_pkey_dh.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -3278,6 +3294,7 @@ ossl_pkey_dsa.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_pkey_dsa.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_pkey_dsa.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -3474,6 +3491,7 @@ ossl_pkey_ec.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_pkey_ec.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_pkey_ec.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -3670,6 +3688,7 @@ ossl_pkey_rsa.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_pkey_rsa.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_pkey_rsa.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -3866,6 +3885,7 @@ ossl_provider.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_provider.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_provider.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_provider.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_provider.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_provider.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_provider.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_provider.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -4062,6 +4082,7 @@ ossl_rand.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_rand.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_rand.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_rand.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_rand.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_rand.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_rand.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_rand.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -4258,6 +4279,7 @@ ossl_ssl.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_ssl.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_ssl.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_ssl.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_ssl.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_ssl.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_ssl.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_ssl.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -4454,6 +4476,7 @@ ossl_ssl_session.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_ssl_session.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_ssl_session.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_ssl_session.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_ssl_session.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_ssl_session.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_ssl_session.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_ssl_session.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -4650,6 +4673,7 @@ ossl_ts.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_ts.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_ts.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_ts.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_ts.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_ts.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_ts.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_ts.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -4846,6 +4870,7 @@ ossl_x509.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_x509.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_x509.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_x509.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_x509.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_x509.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_x509.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_x509.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -5042,6 +5067,7 @@ ossl_x509attr.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_x509attr.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_x509attr.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_x509attr.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_x509attr.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_x509attr.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_x509attr.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_x509attr.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -5238,6 +5264,7 @@ ossl_x509cert.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_x509cert.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_x509cert.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_x509cert.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_x509cert.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_x509cert.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_x509cert.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_x509cert.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -5434,6 +5461,7 @@ ossl_x509crl.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_x509crl.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_x509crl.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_x509crl.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_x509crl.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_x509crl.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_x509crl.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_x509crl.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -5630,6 +5658,7 @@ ossl_x509ext.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_x509ext.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_x509ext.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_x509ext.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_x509ext.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_x509ext.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_x509ext.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_x509ext.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -5826,6 +5855,7 @@ ossl_x509name.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_x509name.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_x509name.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_x509name.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_x509name.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_x509name.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_x509name.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_x509name.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -6022,6 +6052,7 @@ ossl_x509req.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_x509req.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_x509req.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_x509req.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_x509req.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_x509req.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_x509req.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_x509req.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -6218,6 +6249,7 @@ ossl_x509revoked.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_x509revoked.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_x509revoked.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_x509revoked.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_x509revoked.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_x509revoked.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_x509revoked.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_x509revoked.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -6414,6 +6446,7 @@ ossl_x509store.o: $(hdrdir)/ruby/internal/intern/re.h
 ossl_x509store.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ossl_x509store.o: $(hdrdir)/ruby/internal/intern/select.h
 ossl_x509store.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ossl_x509store.o: $(hdrdir)/ruby/internal/intern/set.h
 ossl_x509store.o: $(hdrdir)/ruby/internal/intern/signal.h
 ossl_x509store.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ossl_x509store.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/pathname/depend
+++ b/ext/pathname/depend
@@ -138,6 +138,7 @@ pathname.o: $(hdrdir)/ruby/internal/intern/re.h
 pathname.o: $(hdrdir)/ruby/internal/intern/ruby.h
 pathname.o: $(hdrdir)/ruby/internal/intern/select.h
 pathname.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+pathname.o: $(hdrdir)/ruby/internal/intern/set.h
 pathname.o: $(hdrdir)/ruby/internal/intern/signal.h
 pathname.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 pathname.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/psych/depend
+++ b/ext/psych/depend
@@ -152,6 +152,7 @@ psych.o: $(hdrdir)/ruby/internal/intern/re.h
 psych.o: $(hdrdir)/ruby/internal/intern/ruby.h
 psych.o: $(hdrdir)/ruby/internal/intern/select.h
 psych.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+psych.o: $(hdrdir)/ruby/internal/intern/set.h
 psych.o: $(hdrdir)/ruby/internal/intern/signal.h
 psych.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 psych.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -329,6 +330,7 @@ psych_emitter.o: $(hdrdir)/ruby/internal/intern/re.h
 psych_emitter.o: $(hdrdir)/ruby/internal/intern/ruby.h
 psych_emitter.o: $(hdrdir)/ruby/internal/intern/select.h
 psych_emitter.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+psych_emitter.o: $(hdrdir)/ruby/internal/intern/set.h
 psych_emitter.o: $(hdrdir)/ruby/internal/intern/signal.h
 psych_emitter.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 psych_emitter.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -506,6 +508,7 @@ psych_parser.o: $(hdrdir)/ruby/internal/intern/re.h
 psych_parser.o: $(hdrdir)/ruby/internal/intern/ruby.h
 psych_parser.o: $(hdrdir)/ruby/internal/intern/select.h
 psych_parser.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+psych_parser.o: $(hdrdir)/ruby/internal/intern/set.h
 psych_parser.o: $(hdrdir)/ruby/internal/intern/signal.h
 psych_parser.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 psych_parser.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -683,6 +686,7 @@ psych_to_ruby.o: $(hdrdir)/ruby/internal/intern/re.h
 psych_to_ruby.o: $(hdrdir)/ruby/internal/intern/ruby.h
 psych_to_ruby.o: $(hdrdir)/ruby/internal/intern/select.h
 psych_to_ruby.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+psych_to_ruby.o: $(hdrdir)/ruby/internal/intern/set.h
 psych_to_ruby.o: $(hdrdir)/ruby/internal/intern/signal.h
 psych_to_ruby.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 psych_to_ruby.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -860,6 +864,7 @@ psych_yaml_tree.o: $(hdrdir)/ruby/internal/intern/re.h
 psych_yaml_tree.o: $(hdrdir)/ruby/internal/intern/ruby.h
 psych_yaml_tree.o: $(hdrdir)/ruby/internal/intern/select.h
 psych_yaml_tree.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+psych_yaml_tree.o: $(hdrdir)/ruby/internal/intern/set.h
 psych_yaml_tree.o: $(hdrdir)/ruby/internal/intern/signal.h
 psych_yaml_tree.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 psych_yaml_tree.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/pty/depend
+++ b/ext/pty/depend
@@ -138,6 +138,7 @@ pty.o: $(hdrdir)/ruby/internal/intern/re.h
 pty.o: $(hdrdir)/ruby/internal/intern/ruby.h
 pty.o: $(hdrdir)/ruby/internal/intern/select.h
 pty.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+pty.o: $(hdrdir)/ruby/internal/intern/set.h
 pty.o: $(hdrdir)/ruby/internal/intern/signal.h
 pty.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 pty.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/rbconfig/sizeof/depend
+++ b/ext/rbconfig/sizeof/depend
@@ -142,6 +142,7 @@ limits.o: $(hdrdir)/ruby/internal/intern/re.h
 limits.o: $(hdrdir)/ruby/internal/intern/ruby.h
 limits.o: $(hdrdir)/ruby/internal/intern/select.h
 limits.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+limits.o: $(hdrdir)/ruby/internal/intern/set.h
 limits.o: $(hdrdir)/ruby/internal/intern/signal.h
 limits.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 limits.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -301,6 +302,7 @@ sizes.o: $(hdrdir)/ruby/internal/intern/re.h
 sizes.o: $(hdrdir)/ruby/internal/intern/ruby.h
 sizes.o: $(hdrdir)/ruby/internal/intern/select.h
 sizes.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+sizes.o: $(hdrdir)/ruby/internal/intern/set.h
 sizes.o: $(hdrdir)/ruby/internal/intern/signal.h
 sizes.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 sizes.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/ripper/depend
+++ b/ext/ripper/depend
@@ -181,6 +181,7 @@ eventids1.o: $(hdrdir)/ruby/internal/intern/re.h
 eventids1.o: $(hdrdir)/ruby/internal/intern/ruby.h
 eventids1.o: $(hdrdir)/ruby/internal/intern/select.h
 eventids1.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+eventids1.o: $(hdrdir)/ruby/internal/intern/set.h
 eventids1.o: $(hdrdir)/ruby/internal/intern/signal.h
 eventids1.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 eventids1.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -352,6 +353,7 @@ eventids2.o: $(hdrdir)/ruby/internal/intern/re.h
 eventids2.o: $(hdrdir)/ruby/internal/intern/ruby.h
 eventids2.o: $(hdrdir)/ruby/internal/intern/select.h
 eventids2.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+eventids2.o: $(hdrdir)/ruby/internal/intern/set.h
 eventids2.o: $(hdrdir)/ruby/internal/intern/signal.h
 eventids2.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 eventids2.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -532,6 +534,7 @@ ripper.o: $(hdrdir)/ruby/internal/intern/re.h
 ripper.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ripper.o: $(hdrdir)/ruby/internal/intern/select.h
 ripper.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ripper.o: $(hdrdir)/ruby/internal/intern/set.h
 ripper.o: $(hdrdir)/ruby/internal/intern/signal.h
 ripper.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ripper.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -772,6 +775,7 @@ ripper_init.o: $(hdrdir)/ruby/internal/intern/re.h
 ripper_init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ripper_init.o: $(hdrdir)/ruby/internal/intern/select.h
 ripper_init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ripper_init.o: $(hdrdir)/ruby/internal/intern/set.h
 ripper_init.o: $(hdrdir)/ruby/internal/intern/signal.h
 ripper_init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ripper_init.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/socket/depend
+++ b/ext/socket/depend
@@ -151,6 +151,7 @@ ancdata.o: $(hdrdir)/ruby/internal/intern/re.h
 ancdata.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ancdata.o: $(hdrdir)/ruby/internal/intern/select.h
 ancdata.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ancdata.o: $(hdrdir)/ruby/internal/intern/set.h
 ancdata.o: $(hdrdir)/ruby/internal/intern/signal.h
 ancdata.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ancdata.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -365,6 +366,7 @@ basicsocket.o: $(hdrdir)/ruby/internal/intern/re.h
 basicsocket.o: $(hdrdir)/ruby/internal/intern/ruby.h
 basicsocket.o: $(hdrdir)/ruby/internal/intern/select.h
 basicsocket.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+basicsocket.o: $(hdrdir)/ruby/internal/intern/set.h
 basicsocket.o: $(hdrdir)/ruby/internal/intern/signal.h
 basicsocket.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 basicsocket.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -579,6 +581,7 @@ constants.o: $(hdrdir)/ruby/internal/intern/re.h
 constants.o: $(hdrdir)/ruby/internal/intern/ruby.h
 constants.o: $(hdrdir)/ruby/internal/intern/select.h
 constants.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+constants.o: $(hdrdir)/ruby/internal/intern/set.h
 constants.o: $(hdrdir)/ruby/internal/intern/signal.h
 constants.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 constants.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -794,6 +797,7 @@ ifaddr.o: $(hdrdir)/ruby/internal/intern/re.h
 ifaddr.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ifaddr.o: $(hdrdir)/ruby/internal/intern/select.h
 ifaddr.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ifaddr.o: $(hdrdir)/ruby/internal/intern/set.h
 ifaddr.o: $(hdrdir)/ruby/internal/intern/signal.h
 ifaddr.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ifaddr.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1008,6 +1012,7 @@ init.o: $(hdrdir)/ruby/internal/intern/re.h
 init.o: $(hdrdir)/ruby/internal/intern/ruby.h
 init.o: $(hdrdir)/ruby/internal/intern/select.h
 init.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+init.o: $(hdrdir)/ruby/internal/intern/set.h
 init.o: $(hdrdir)/ruby/internal/intern/signal.h
 init.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 init.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1222,6 +1227,7 @@ ipsocket.o: $(hdrdir)/ruby/internal/intern/re.h
 ipsocket.o: $(hdrdir)/ruby/internal/intern/ruby.h
 ipsocket.o: $(hdrdir)/ruby/internal/intern/select.h
 ipsocket.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+ipsocket.o: $(hdrdir)/ruby/internal/intern/set.h
 ipsocket.o: $(hdrdir)/ruby/internal/intern/signal.h
 ipsocket.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 ipsocket.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1436,6 +1442,7 @@ option.o: $(hdrdir)/ruby/internal/intern/re.h
 option.o: $(hdrdir)/ruby/internal/intern/ruby.h
 option.o: $(hdrdir)/ruby/internal/intern/select.h
 option.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+option.o: $(hdrdir)/ruby/internal/intern/set.h
 option.o: $(hdrdir)/ruby/internal/intern/signal.h
 option.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 option.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1650,6 +1657,7 @@ raddrinfo.o: $(hdrdir)/ruby/internal/intern/re.h
 raddrinfo.o: $(hdrdir)/ruby/internal/intern/ruby.h
 raddrinfo.o: $(hdrdir)/ruby/internal/intern/select.h
 raddrinfo.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+raddrinfo.o: $(hdrdir)/ruby/internal/intern/set.h
 raddrinfo.o: $(hdrdir)/ruby/internal/intern/signal.h
 raddrinfo.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 raddrinfo.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -1864,6 +1872,7 @@ socket.o: $(hdrdir)/ruby/internal/intern/re.h
 socket.o: $(hdrdir)/ruby/internal/intern/ruby.h
 socket.o: $(hdrdir)/ruby/internal/intern/select.h
 socket.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+socket.o: $(hdrdir)/ruby/internal/intern/set.h
 socket.o: $(hdrdir)/ruby/internal/intern/signal.h
 socket.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 socket.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2078,6 +2087,7 @@ sockssocket.o: $(hdrdir)/ruby/internal/intern/re.h
 sockssocket.o: $(hdrdir)/ruby/internal/intern/ruby.h
 sockssocket.o: $(hdrdir)/ruby/internal/intern/select.h
 sockssocket.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+sockssocket.o: $(hdrdir)/ruby/internal/intern/set.h
 sockssocket.o: $(hdrdir)/ruby/internal/intern/signal.h
 sockssocket.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 sockssocket.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2292,6 +2302,7 @@ tcpserver.o: $(hdrdir)/ruby/internal/intern/re.h
 tcpserver.o: $(hdrdir)/ruby/internal/intern/ruby.h
 tcpserver.o: $(hdrdir)/ruby/internal/intern/select.h
 tcpserver.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+tcpserver.o: $(hdrdir)/ruby/internal/intern/set.h
 tcpserver.o: $(hdrdir)/ruby/internal/intern/signal.h
 tcpserver.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 tcpserver.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2506,6 +2517,7 @@ tcpsocket.o: $(hdrdir)/ruby/internal/intern/re.h
 tcpsocket.o: $(hdrdir)/ruby/internal/intern/ruby.h
 tcpsocket.o: $(hdrdir)/ruby/internal/intern/select.h
 tcpsocket.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+tcpsocket.o: $(hdrdir)/ruby/internal/intern/set.h
 tcpsocket.o: $(hdrdir)/ruby/internal/intern/signal.h
 tcpsocket.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 tcpsocket.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2720,6 +2732,7 @@ udpsocket.o: $(hdrdir)/ruby/internal/intern/re.h
 udpsocket.o: $(hdrdir)/ruby/internal/intern/ruby.h
 udpsocket.o: $(hdrdir)/ruby/internal/intern/select.h
 udpsocket.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+udpsocket.o: $(hdrdir)/ruby/internal/intern/set.h
 udpsocket.o: $(hdrdir)/ruby/internal/intern/signal.h
 udpsocket.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 udpsocket.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -2934,6 +2947,7 @@ unixserver.o: $(hdrdir)/ruby/internal/intern/re.h
 unixserver.o: $(hdrdir)/ruby/internal/intern/ruby.h
 unixserver.o: $(hdrdir)/ruby/internal/intern/select.h
 unixserver.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+unixserver.o: $(hdrdir)/ruby/internal/intern/set.h
 unixserver.o: $(hdrdir)/ruby/internal/intern/signal.h
 unixserver.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 unixserver.o: $(hdrdir)/ruby/internal/intern/string.h
@@ -3148,6 +3162,7 @@ unixsocket.o: $(hdrdir)/ruby/internal/intern/re.h
 unixsocket.o: $(hdrdir)/ruby/internal/intern/ruby.h
 unixsocket.o: $(hdrdir)/ruby/internal/intern/select.h
 unixsocket.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+unixsocket.o: $(hdrdir)/ruby/internal/intern/set.h
 unixsocket.o: $(hdrdir)/ruby/internal/intern/signal.h
 unixsocket.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 unixsocket.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/stringio/depend
+++ b/ext/stringio/depend
@@ -138,6 +138,7 @@ stringio.o: $(hdrdir)/ruby/internal/intern/re.h
 stringio.o: $(hdrdir)/ruby/internal/intern/ruby.h
 stringio.o: $(hdrdir)/ruby/internal/intern/select.h
 stringio.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+stringio.o: $(hdrdir)/ruby/internal/intern/set.h
 stringio.o: $(hdrdir)/ruby/internal/intern/signal.h
 stringio.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 stringio.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/strscan/depend
+++ b/ext/strscan/depend
@@ -138,6 +138,7 @@ strscan.o: $(hdrdir)/ruby/internal/intern/re.h
 strscan.o: $(hdrdir)/ruby/internal/intern/ruby.h
 strscan.o: $(hdrdir)/ruby/internal/intern/select.h
 strscan.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+strscan.o: $(hdrdir)/ruby/internal/intern/set.h
 strscan.o: $(hdrdir)/ruby/internal/intern/signal.h
 strscan.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 strscan.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/ext/zlib/depend
+++ b/ext/zlib/depend
@@ -138,6 +138,7 @@ zlib.o: $(hdrdir)/ruby/internal/intern/re.h
 zlib.o: $(hdrdir)/ruby/internal/intern/ruby.h
 zlib.o: $(hdrdir)/ruby/internal/intern/select.h
 zlib.o: $(hdrdir)/ruby/internal/intern/select/largesize.h
+zlib.o: $(hdrdir)/ruby/internal/intern/set.h
 zlib.o: $(hdrdir)/ruby/internal/intern/signal.h
 zlib.o: $(hdrdir)/ruby/internal/intern/sprintf.h
 zlib.o: $(hdrdir)/ruby/internal/intern/string.h

--- a/include/ruby/intern.h
+++ b/include/ruby/intern.h
@@ -51,6 +51,7 @@
 #include "ruby/internal/intern/re.h"
 #include "ruby/internal/intern/ruby.h"
 #include "ruby/internal/intern/select.h"
+#include "ruby/internal/intern/set.h"
 #include "ruby/internal/intern/signal.h"
 #include "ruby/internal/intern/sprintf.h"
 #include "ruby/internal/intern/string.h"

--- a/include/ruby/internal/globals.h
+++ b/include/ruby/internal/globals.h
@@ -93,6 +93,7 @@ RUBY_EXTERN VALUE rb_cRandom;                 /**< `Random` class. */
 RUBY_EXTERN VALUE rb_cRange;                  /**< `Range` class. */
 RUBY_EXTERN VALUE rb_cRational;               /**< `Rational` class. */
 RUBY_EXTERN VALUE rb_cRegexp;                 /**< `Regexp` class. */
+RUBY_EXTERN VALUE rb_cSet;                    /**< `Set` class. */
 RUBY_EXTERN VALUE rb_cStat;                   /**< `File::Stat` class. */
 RUBY_EXTERN VALUE rb_cString;                 /**< `String` class. */
 RUBY_EXTERN VALUE rb_cStruct;                 /**< `Struct` class. */

--- a/include/ruby/internal/intern/set.h
+++ b/include/ruby/internal/intern/set.h
@@ -1,0 +1,111 @@
+#ifndef RBIMPL_INTERN_SET_H                         /*-*-C++-*-vi:se ft=cpp:*/
+#define RBIMPL_INTERN_SET_H
+/**
+ * @file
+ * @author     Ruby developers <ruby-core@ruby-lang.org>
+ * @copyright  This  file  is   a  part  of  the   programming  language  Ruby.
+ *             Permission  is hereby  granted,  to  either redistribute  and/or
+ *             modify this file, provided that  the conditions mentioned in the
+ *             file COPYING are met.  Consult the file for details.
+ * @warning    Symbols   prefixed  with   either  `RBIMPL`   or  `rbimpl`   are
+ *             implementation details.   Don't take  them as canon.  They could
+ *             rapidly appear then vanish.  The name (path) of this header file
+ *             is also an  implementation detail.  Do not expect  it to persist
+ *             at the place it is now.  Developers are free to move it anywhere
+ *             anytime at will.
+ * @note       To  ruby-core:  remember  that   this  header  can  be  possibly
+ *             recursively included  from extension  libraries written  in C++.
+ *             Do not  expect for  instance `__VA_ARGS__` is  always available.
+ *             We assume C99  for ruby itself but we don't  assume languages of
+ *             extension libraries.  They could be written in C++98.
+ * @brief      Public APIs related to ::rb_cSet.
+ */
+#include "ruby/internal/attr/nonnull.h"
+#include "ruby/internal/dllexport.h"
+#include "ruby/internal/value.h"
+
+RBIMPL_SYMBOL_EXPORT_BEGIN()
+
+/* set.c */
+
+RBIMPL_ATTR_NONNULL(())
+/**
+ * Iterates   over  a   set.  Calls func with each element of the set and the
+ * argument given. func should return ST_CONTINUE, ST_STOP, or ST_DELETE.
+ *
+ * @param[in]  set               An instance of ::rb_cSet to iterate over.
+ * @param[in]  func              Callback function to yield.
+ * @param[in]  arg               Passed as-is to `func`.
+ * @exception  rb_eRuntimeError  `set` was tampered during iterating.
+ */
+void rb_set_foreach(VALUE set, int (*func)(VALUE element, VALUE arg), VALUE arg);
+
+/**
+ * Creates a new, empty set object.
+ *
+ * @return  An allocated new instance of ::rb_cSet.
+ */
+VALUE rb_set_new(void);
+
+/**
+ * Identical to rb_set_new(), except it additionally specifies how many elements
+ * it is expected to contain. This way you can create a set that is large enough
+ * for your need. For large sets, it means it won't need to be reallocated
+ * much, improving performance.
+ *
+ * @param[in]  capa  Designed capacity of the set.
+ * @return     An empty Set, whose capacity is `capa`.
+ */
+VALUE rb_set_new_capa(size_t capa);
+
+/**
+ * Whether the set contains the given element.
+ *
+ * @param[in]  set      Set to look into.
+ * @param[in]  element  Set element to look for.
+ * @return     true if element is in the set, falst otherwise.
+ */
+bool rb_set_lookup(VALUE set, VALUE element);
+
+/**
+ * Adds element to set.
+ *
+ * @param[in]   set              Target set table to modify.
+ * @param[in]   element          Arbitrary Ruby object.
+ * @exception   rb_eFrozenError  `set` is frozen.
+ * @return      true if element was not already in set, false otherwise
+ * @post        `element` is in `set`.
+ */
+bool rb_set_add(VALUE set, VALUE element);
+
+/**
+ * Removes all entries from set.
+ *
+ * @param[out]  set             Target to clear.
+ * @exception   rb_eFrozenError  `set`is frozen.
+ * @return      The passed `set`
+ * @post        `set` has no elements.
+ */
+VALUE rb_set_clear(VALUE set);
+
+/**
+ * Removes the element from from set.
+ *
+ * @param[in]   set        Target set to modify.
+ * @param[in]   element    Key to delete.
+ * @retval      true if element was already in set, false otherwise
+ * @post        `set` does not have `element` as an element.
+ */
+bool rb_set_delete(VALUE set, VALUE element);
+
+/**
+ * Returns the number of elements in the set.
+ *
+ * @param[in]  set  A set object.
+ * @return     The size of the set.
+ */
+size_t rb_set_size(VALUE set);
+
+RBIMPL_SYMBOL_EXPORT_END()
+
+#endif /* RBIMPL_INTERN_SET_H */

--- a/internal/set_table.h
+++ b/internal/set_table.h
@@ -39,24 +39,24 @@ set_table *rb_set_init_table_with_size(set_table *tab, const struct st_hash_type
 set_table *rb_set_init_numtable(void);
 #define set_init_numtable_with_size rb_set_init_numtable_with_size
 set_table *rb_set_init_numtable_with_size(st_index_t size);
-#define set_delete rb_set_delete
-int rb_set_delete(set_table *, st_data_t *); /* returns 0:notfound 1:deleted */
+#define set_table_delete rb_set_table_delete
+int rb_set_table_delete(set_table *, st_data_t *); /* returns 0:notfound 1:deleted */
 #define set_insert rb_set_insert
 int rb_set_insert(set_table *, st_data_t);
-#define set_lookup rb_set_lookup
-int rb_set_lookup(set_table *, st_data_t);
+#define set_table_lookup rb_set_table_lookup
+int rb_set_table_lookup(set_table *, st_data_t);
 #define set_foreach_with_replace rb_set_foreach_with_replace
 int rb_set_foreach_with_replace(set_table *tab, set_foreach_check_callback_func *func, set_update_callback_func *replace, st_data_t arg);
-#define set_foreach rb_set_foreach
-int rb_set_foreach(set_table *, set_foreach_callback_func *, st_data_t);
+#define set_table_foreach rb_set_table_foreach
+int rb_set_table_foreach(set_table *, set_foreach_callback_func *, st_data_t);
 #define set_foreach_check rb_set_foreach_check
 int rb_set_foreach_check(set_table *, set_foreach_check_callback_func *, st_data_t, st_data_t);
 #define set_keys rb_set_keys
 st_index_t rb_set_keys(set_table *table, st_data_t *keys, st_index_t size);
 #define set_free_table rb_set_free_table
 void rb_set_free_table(set_table *);
-#define set_clear rb_set_clear
-void rb_set_clear(set_table *);
+#define set_table_clear rb_set_table_clear
+void rb_set_table_clear(set_table *);
 #define set_copy rb_set_copy
 set_table *rb_set_copy(set_table *new_table, set_table *old_table);
 #define set_memsize rb_set_memsize

--- a/iseq.c
+++ b/iseq.c
@@ -113,7 +113,7 @@ remove_from_constant_cache(ID id, IC ic)
 
     if (rb_id_table_lookup(vm->constant_cache, id, &lookup_result)) {
         set_table *ics = (set_table *)lookup_result;
-        set_delete(ics, &ic_data);
+        set_table_delete(ics, &ic_data);
 
         if (ics->num_entries == 0 &&
                 // See comment in vm_track_constant_cache on why we need this check

--- a/set.c
+++ b/set.c
@@ -1913,6 +1913,56 @@ compat_loader(VALUE self, VALUE a)
     return set_i_from_hash(self, rb_ivar_get(a, id_i_hash));
 }
 
+/* C-API functions */
+
+void
+rb_set_foreach(VALUE set, int (*func)(VALUE element, VALUE arg), VALUE arg)
+{
+    set_iter(set, func, arg);
+}
+
+VALUE
+rb_set_new(void)
+{
+    return set_alloc_with_size(rb_cSet, 0);
+}
+
+VALUE
+rb_set_new_capa(size_t capa)
+{
+    return set_alloc_with_size(rb_cSet, (st_index_t)capa);
+}
+
+bool
+rb_set_lookup(VALUE set, VALUE element)
+{
+    return RSET_IS_MEMBER(set, element);
+}
+
+bool
+rb_set_add(VALUE set, VALUE element)
+{
+    return set_i_add_p(set, element) != Qnil;
+}
+
+VALUE
+rb_set_clear(VALUE set)
+{
+    return set_i_clear(set);
+}
+
+bool
+rb_set_delete(VALUE set, VALUE element)
+{
+    return set_i_delete_p(set, element) != Qnil;
+}
+
+size_t
+rb_set_size(VALUE set)
+{
+    return RSET_SIZE(set);
+}
+
 /*
  *  Document-class: Set
  *

--- a/spec/ruby/optional/capi/ext/set_spec.c
+++ b/spec/ruby/optional/capi/ext/set_spec.c
@@ -1,0 +1,62 @@
+#include "ruby.h"
+#include "rubyspec.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RBOOL(x) ((x) ? Qtrue : Qfalse)
+
+int yield_element_and_arg(VALUE element, VALUE arg) {
+  return RTEST(rb_yield_values(2, element, arg)) ? ST_CONTINUE : ST_STOP;
+}
+
+VALUE set_spec_rb_set_foreach(VALUE self, VALUE set, VALUE arg) {
+  rb_set_foreach(set, yield_element_and_arg, arg);
+  return Qnil;
+}
+
+VALUE set_spec_rb_set_new(VALUE self) {
+  return rb_set_new();
+}
+
+VALUE set_spec_rb_set_new_capa(VALUE self, VALUE capa) {
+  return rb_set_new_capa(NUM2INT(capa));
+}
+
+VALUE set_spec_rb_set_lookup(VALUE self, VALUE set, VALUE element) {
+  return RBOOL(rb_set_lookup(set, element));
+}
+
+VALUE set_spec_rb_set_add(VALUE self, VALUE set, VALUE element) {
+  return RBOOL(rb_set_add(set, element));
+}
+
+VALUE set_spec_rb_set_clear(VALUE self, VALUE set) {
+  return rb_set_clear(set);
+}
+
+VALUE set_spec_rb_set_delete(VALUE self, VALUE set, VALUE element) {
+  return RBOOL(rb_set_delete(set, element));
+}
+
+VALUE set_spec_rb_set_size(VALUE self, VALUE set) {
+  return SIZET2NUM(rb_set_size(set));
+}
+
+void Init_set_spec(void) {
+  VALUE cls = rb_define_class("CApiSetSpecs", rb_cObject);
+  rb_define_method(cls, "rb_set_foreach", set_spec_rb_set_foreach, 2);
+  rb_define_method(cls, "rb_set_new", set_spec_rb_set_new, 0);
+  rb_define_method(cls, "rb_set_new_capa", set_spec_rb_set_new_capa, 1);
+  rb_define_method(cls, "rb_set_lookup", set_spec_rb_set_lookup, 2);
+  rb_define_method(cls, "rb_set_add", set_spec_rb_set_add, 2);
+  rb_define_method(cls, "rb_set_clear", set_spec_rb_set_clear, 1);
+  rb_define_method(cls, "rb_set_delete", set_spec_rb_set_delete, 2);
+  rb_define_method(cls, "rb_set_size", set_spec_rb_set_size, 1);
+}
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/spec/ruby/optional/capi/set_spec.rb
+++ b/spec/ruby/optional/capi/set_spec.rb
@@ -1,0 +1,96 @@
+require_relative 'spec_helper'
+
+load_extension("set")
+
+describe "C-API Set function" do
+  before :each do
+    @s = CApiSetSpecs.new
+  end
+
+  ruby_version_is "3.5" do
+    describe "rb_set_foreach" do
+      it "calls function with each element and arg" do
+        a = []
+        @s.rb_set_foreach(Set[1, 2], 3) {|*args| a.concat(args) }
+        a.should == [1, 3, 2, 3]
+      end
+
+      it "respects function return value" do
+        a = []
+        @s.rb_set_foreach(Set[1, 2], 3) do |*args|
+          a.concat(args)
+          false
+        end
+        a.should == [1, 3]
+      end
+    end
+
+    describe "rb_set_new" do
+      it "returns a new set" do
+        @s.rb_set_new.should == Set[]
+      end
+    end
+
+    describe "rb_set_new_capa" do
+      it "returns a new set" do
+        @s.rb_set_new_capa(3).should == Set[]
+      end
+    end
+
+    describe "rb_set_lookup" do
+      it "returns whether the element is in the set" do
+        set = Set[1]
+        @s.rb_set_lookup(set, 1).should == true
+        @s.rb_set_lookup(set, 2).should == false
+      end
+    end
+
+    describe "rb_set_add" do
+      it "adds element to set" do
+        set = Set[]
+        @s.rb_set_add(set, 1).should == true
+        set.should == Set[1]
+        @s.rb_set_add(set, 2).should == true
+        set.should == Set[1, 2]
+      end
+
+      it "returns false if element is already in set" do
+        set = Set[1]
+        @s.rb_set_add(set, 1).should == false
+        set.should == Set[1]
+      end
+    end
+
+    describe "rb_set_clear" do
+      it "empties and returns self" do
+        set = Set[1]
+        @s.rb_set_clear(set).should equal(set)
+        set.should == Set[]
+      end
+    end
+
+    describe "rb_set_delete" do
+      it "removes element from set" do
+        set = Set[1, 2]
+        @s.rb_set_delete(set, 1).should == true
+        set.should == Set[2]
+        @s.rb_set_delete(set, 2).should == true
+        set.should == Set[]
+      end
+
+      it "returns false if element is not already in set" do
+        set = Set[2]
+        @s.rb_set_delete(set, 1).should == false
+        set.should == Set[2]
+      end
+    end
+
+    describe "rb_set_size" do
+      it "returns number of elements in set" do
+        @s.rb_set_size(Set[]).should == 0
+        @s.rb_set_size(Set[1]).should == 1
+        @s.rb_set_size(Set[1,2]).should == 2
+      end
+    end
+  end
+end

--- a/st.c
+++ b/st.c
@@ -2488,7 +2488,7 @@ set_table_size(const struct set_table *tbl)
 
 /* Make table TAB empty.  */
 void
-set_clear(set_table *tab)
+set_table_clear(set_table *tab)
 {
     set_make_tab_empty(tab);
     tab->rebuilds_num++;
@@ -2857,7 +2857,7 @@ set_find_table_bin_ptr_and_reserve(set_table *tab, st_hash_t *hash_value,
 /* Find an entry with KEY in table TAB.  Return non-zero if we found
    it.  */
 int
-set_lookup(set_table *tab, st_data_t key)
+set_table_lookup(set_table *tab, st_data_t key)
 {
     st_index_t bin;
     st_hash_t hash = set_do_hash(key, tab);
@@ -2997,7 +2997,7 @@ set_update_range_for_deleted(set_table *tab, st_index_t n)
 /* Delete entry with KEY from table TAB, and return non-zero.  If
    there is no entry with KEY in the table, return zero.  */
 int
-set_delete(set_table *tab, st_data_t *key)
+set_table_delete(set_table *tab, st_data_t *key)
 {
     set_table_entry *entry;
     st_index_t bin;
@@ -3155,7 +3155,7 @@ set_apply_functor(st_data_t k, st_data_t d, int _)
 }
 
 int
-set_foreach(set_table *tab, set_foreach_callback_func *func, st_data_t arg)
+set_table_foreach(set_table *tab, set_foreach_callback_func *func, st_data_t arg)
 {
     const struct set_functor f = { func, arg };
     return set_general_foreach(tab, set_apply_functor, NULL, (st_data_t)&f, FALSE);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3038,7 +3038,7 @@ warn_unused_block(const rb_callable_method_entry_t *cme, const rb_iseq_t *iseq, 
     if (!strict_unused_block) {
         key = (st_data_t)cme->def->original_id;
 
-        if (set_lookup(dup_check_table, key)) {
+        if (set_table_lookup(dup_check_table, key)) {
             return;
         }
     }

--- a/vm_method.c
+++ b/vm_method.c
@@ -142,7 +142,7 @@ rb_clear_constant_cache_for_id(ID id)
 
     if (rb_id_table_lookup(vm->constant_cache, id, &lookup_result)) {
         set_table *ics = (set_table *)lookup_result;
-        set_foreach(ics, rb_clear_constant_cache_for_id_i, (st_data_t) NULL);
+        set_table_foreach(ics, rb_clear_constant_cache_for_id_i, (st_data_t) NULL);
         ruby_vm_constant_cache_invalidations += ics->num_entries;
     }
 
@@ -549,7 +549,7 @@ rb_vm_delete_cc_refinement(const struct rb_callcache *cc)
     rb_vm_t *vm = GET_VM();
     st_data_t key = (st_data_t)cc;
 
-    rb_set_delete(vm->cc_refinement_table, &key);
+    rb_set_table_delete(vm->cc_refinement_table, &key);
 }
 
 void
@@ -559,8 +559,8 @@ rb_clear_all_refinement_method_cache(void)
 
     RB_VM_LOCK_ENTER();
     {
-        rb_set_foreach(vm->cc_refinement_table, invalidate_cc_refinement, (st_data_t)NULL);
-        rb_set_clear(vm->cc_refinement_table);
+        rb_set_table_foreach(vm->cc_refinement_table, invalidate_cc_refinement, (st_data_t)NULL);
+        rb_set_table_clear(vm->cc_refinement_table);
         rb_set_compact_table(vm->cc_refinement_table);
     }
     RB_VM_LOCK_LEAVE();

--- a/zjit.c
+++ b/zjit.c
@@ -32,8 +32,6 @@
 
 #include <errno.h>
 
-RUBY_EXTERN VALUE rb_cSet; // defined in set.c and it's not exposed yet
-
 uint32_t
 rb_zjit_get_page_size(void)
 {

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -756,6 +756,7 @@ unsafe extern "C" {
     pub static mut rb_cNumeric: VALUE;
     pub static mut rb_cRange: VALUE;
     pub static mut rb_cRegexp: VALUE;
+    pub static mut rb_cSet: VALUE;
     pub static mut rb_cString: VALUE;
     pub static mut rb_cSymbol: VALUE;
     pub static mut rb_cThread: VALUE;
@@ -905,7 +906,6 @@ unsafe extern "C" {
         lines: *mut ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
     pub fn rb_jit_cont_each_iseq(callback: rb_iseq_callback, data: *mut ::std::os::raw::c_void);
-    pub static mut rb_cSet: VALUE;
     pub fn rb_zjit_get_page_size() -> u32;
     pub fn rb_zjit_reserve_addr_space(mem_size: u32) -> *mut u8;
     pub fn rb_zjit_profile_disable(iseq: *const rb_iseq_t);


### PR DESCRIPTION
This should be a minimal C-API needed to deal with Set objects. It
supports creating the sets, checking whether an element is the set,
adding and removing elements, iterating over the elements, clearing
a set, and returning the size of the set.

As some of the function names I wanted to use in the C-API were
already used internally, I had to rename some existing internal functions.