### PR TITLE
fix building issue when using gcc15, because C23 is default

### DIFF
--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -292,8 +292,8 @@ extern VALUE rb_eResolution;
 #ifdef SOCKS
 extern VALUE rb_cSOCKSSocket;
 #  ifndef SOCKS5
-void SOCKSinit();
-int Rconnect();
+void SOCKSinit(char *);
+int Rconnect(int, const struct sockaddr *, socklen_t);
 #  endif
 #endif
 


### PR DESCRIPTION
otherwise build is failed with:

> error: static declaration of ‘rb_io_closed_p’ follows non-static declaration