### PR TITLE
ZJIT: setglobal should not return output

### DIFF
--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -108,6 +108,7 @@ jobs:
           RUST_BACKTRACE=1 ruby --disable=gems ../src/bootstraptest/runner.rb --ruby="./miniruby -I../src/lib -I. -I.ext/common --zjit-call-threshold=1" \
           ../src/bootstraptest/test_attr.rb \
           ../src/bootstraptest/test_autoload.rb \
+          ../src/bootstraptest/test_class.rb \
           ../src/bootstraptest/test_constant_cache.rb \
           ../src/bootstraptest/test_env.rb \
           ../src/bootstraptest/test_fiber.rb \
@@ -128,7 +129,6 @@ jobs:
           ../src/bootstraptest/test_yjit_30k_methods.rb \
           ../src/bootstraptest/test_yjit_rust_port.rb
         # ../src/bootstraptest/test_block.rb \
-        # ../src/bootstraptest/test_class.rb \
         # ../src/bootstraptest/test_eval.rb \
         # ../src/bootstraptest/test_exception.rb \
         # ../src/bootstraptest/test_gc.rb \

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -130,6 +130,7 @@ jobs:
           RUST_BACKTRACE=1 ruby --disable=gems ../src/bootstraptest/runner.rb --ruby="./miniruby -I../src/lib -I. -I.ext/common --zjit-call-threshold=1" \
           ../src/bootstraptest/test_attr.rb \
           ../src/bootstraptest/test_autoload.rb \
+          ../src/bootstraptest/test_class.rb \
           ../src/bootstraptest/test_constant_cache.rb \
           ../src/bootstraptest/test_env.rb \
           ../src/bootstraptest/test_fiber.rb \
@@ -151,7 +152,6 @@ jobs:
           ../src/bootstraptest/test_yjit_30k_methods.rb \
           ../src/bootstraptest/test_yjit_rust_port.rb
         # ../src/bootstraptest/test_block.rb \
-        # ../src/bootstraptest/test_class.rb \
         # ../src/bootstraptest/test_eval.rb \
         # ../src/bootstraptest/test_exception.rb \
         # ../src/bootstraptest/test_gc.rb \

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -278,7 +278,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::PatchPoint(_) => return Some(()), // For now, rb_zjit_bop_redefined() panics. TODO: leave a patch point and fix rb_zjit_bop_redefined()
         Insn::CCall { cfun, args, name: _, return_type: _, elidable: _ } => gen_ccall(jit, asm, *cfun, args)?,
         Insn::GetIvar { self_val, id, state: _ } => gen_getivar(asm, opnd!(self_val), *id),
-        Insn::SetGlobal { id, val, state: _ } => return gen_setglobal(asm, *id, opnd!(val)),
+        Insn::SetGlobal { id, val, state: _ } => return Some(gen_setglobal(asm, *id, opnd!(val))),
         Insn::GetGlobal { id, state: _ } => gen_getglobal(asm, *id),
         &Insn::GetLocal { ep_offset, level } => gen_nested_getlocal(asm, ep_offset, level)?,
         Insn::SetLocal { val, ep_offset, level } => return gen_nested_setlocal(asm, opnd!(val), *ep_offset, *level),
@@ -451,10 +451,9 @@ fn gen_getglobal(asm: &mut Assembler, id: ID) -> Opnd {
 }
 
 /// Set global variables
-fn gen_setglobal(asm: &mut Assembler, id: ID, val: Opnd) -> Option<()> {
+fn gen_setglobal(asm: &mut Assembler, id: ID, val: Opnd) {
     asm_comment!(asm, "call rb_gvar_set");
     asm.ccall(rb_gvar_set as *const u8, vec![Opnd::UImm(id.0), val]);
-    Some(())
 }
 
 /// Side-exit into the interpreter

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -278,7 +278,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::PatchPoint(_) => return Some(()), // For now, rb_zjit_bop_redefined() panics. TODO: leave a patch point and fix rb_zjit_bop_redefined()
         Insn::CCall { cfun, args, name: _, return_type: _, elidable: _ } => gen_ccall(jit, asm, *cfun, args)?,
         Insn::GetIvar { self_val, id, state: _ } => gen_getivar(asm, opnd!(self_val), *id),
-        Insn::SetGlobal { id, val, state: _ } => gen_setglobal(asm, *id, opnd!(val)),
+        Insn::SetGlobal { id, val, state: _ } => return gen_setglobal(asm, *id, opnd!(val)),
         Insn::GetGlobal { id, state: _ } => gen_getglobal(asm, *id),
         &Insn::GetLocal { ep_offset, level } => gen_nested_getlocal(asm, ep_offset, level)?,
         Insn::SetLocal { val, ep_offset, level } => return gen_nested_setlocal(asm, opnd!(val), *ep_offset, *level),
@@ -294,7 +294,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         }
     };
 
-    assert!(insn.has_output(), "Cannot write LIR output of HIR instruction with no output");
+    assert!(insn.has_output(), "Cannot write LIR output of HIR instruction with no output: {insn}");
 
     // If the instruction has an output, remember it in jit.opnds
     jit.opnds[insn_id.0] = Some(out_opnd);
@@ -451,12 +451,10 @@ fn gen_getglobal(asm: &mut Assembler, id: ID) -> Opnd {
 }
 
 /// Set global variables
-fn gen_setglobal(asm: &mut Assembler, id: ID, val: Opnd) -> Opnd {
+fn gen_setglobal(asm: &mut Assembler, id: ID, val: Opnd) -> Option<()> {
     asm_comment!(asm, "call rb_gvar_set");
-    asm.ccall(
-        rb_gvar_set as *const u8,
-        vec![Opnd::UImm(id.0), val],
-    )
+    asm.ccall(rb_gvar_set as *const u8, vec![Opnd::UImm(id.0), val]);
+    Some(())
 }
 
 /// Side-exit into the interpreter

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1120,7 +1120,7 @@ impl Function {
             | Insn::IfTrue { .. } | Insn::IfFalse { .. } | Insn::Return { .. }
             | Insn::PatchPoint { .. } | Insn::SetIvar { .. } | Insn::ArrayExtend { .. }
             | Insn::ArrayPush { .. } | Insn::SideExit { .. } | Insn::SetLocal { .. } =>
-                panic!("Cannot infer type of instruction with no output"),
+                panic!("Cannot infer type of instruction with no output: {}", self.insns[insn.0]),
             Insn::Const { val: Const::Value(val) } => Type::from_value(*val),
             Insn::Const { val: Const::CBool(val) } => Type::from_cbool(*val),
             Insn::Const { val: Const::CInt8(val) } => Type::from_cint(types::CInt8, *val as i64),


### PR DESCRIPTION
This PR fixes a crash in btest `test_class.rb`. 

`gen_setglobal()` returns an output, so `Insn::SetGlobal` should be considered to have output to avoid assertion failures.