### PR TITLE
ZJIT: IsNil optimization and codegen support

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -831,6 +831,15 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 2
   end
 
+  def test_branchnil
+    assert_compiles '[2, nil]', %q{
+      def test(x)
+        x&.succ
+      end
+      [test(1), test(nil)]
+    }, call_threshold: 1, insns: [:branchnil]
+  end
+
   # tool/ruby_vm/views/*.erb relies on the zjit instructions a) being contiguous and
   # b) being reliably ordered after all the other instructions.
   def test_instruction_order

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -272,6 +272,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::FixnumLe { left, right } => gen_fixnum_le(asm, opnd!(left), opnd!(right))?,
         Insn::FixnumGt { left, right } => gen_fixnum_gt(asm, opnd!(left), opnd!(right))?,
         Insn::FixnumGe { left, right } => gen_fixnum_ge(asm, opnd!(left), opnd!(right))?,
+        Insn::IsNil { val } => gen_isnil(asm, opnd!(val))?,
         Insn::Test { val } => gen_test(asm, opnd!(val))?,
         Insn::GuardType { val, guard_type, state } => gen_guard_type(jit, asm, opnd!(val), *guard_type, &function.frame_state(*state))?,
         Insn::GuardBitEquals { val, expected, state } => gen_guard_bit_equals(jit, asm, opnd!(val), *expected, &function.frame_state(*state))?,
@@ -888,6 +889,13 @@ fn gen_fixnum_gt(asm: &mut Assembler, left: lir::Opnd, right: lir::Opnd) -> Opti
 fn gen_fixnum_ge(asm: &mut Assembler, left: lir::Opnd, right: lir::Opnd) -> Option<lir::Opnd> {
     asm.cmp(left, right);
     Some(asm.csel_ge(Qtrue.into(), Qfalse.into()))
+}
+
+// Compile val == nil
+fn gen_isnil(asm: &mut Assembler, val: lir::Opnd) -> Option<lir::Opnd> {
+    asm.cmp(val, Qnil.into());
+    // TODO: Implement and use setcc
+    Some(asm.csel_e(Opnd::Imm(1), Opnd::Imm(0)))
 }
 
 fn gen_anytostring(asm: &mut Assembler, val: lir::Opnd, str: lir::Opnd, state: &FrameState) -> Option<lir::Opnd> {


### PR DESCRIPTION
This PR adds optimizations and codegen support for `IsNil`. 

Currently:
```
./miniruby --zjit-debug -e "def test = 1&.itself; test; test"
ZJIT: gen_function: unexpected insn IsNil v15
Failed to compile insn: v5 IsNil v15
```

---

Closes: https://github.com/Shopify/ruby/issues/600