### PR TITLE
ZJIT: Pretty-print symbols in HIR dump

### DIFF
--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -228,6 +228,7 @@ fn main() {
         .allowlist_function("rb_sym2id")
         .allowlist_function("rb_str_intern")
         .allowlist_function("rb_id2str")
+        .allowlist_function("rb_sym2str")
 
         // From internal/numeric.h
         .allowlist_function("rb_fix_aref")

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -738,6 +738,11 @@ fn ruby_str_to_rust(v: VALUE) -> String {
     }
 }
 
+pub fn ruby_sym_to_rust(v: VALUE) -> String {
+    let ruby_str = unsafe { rb_sym2str(v) };
+    ruby_str_to_rust(ruby_str)
+}
+
 /// A location in Rust code for integrating with debugging facilities defined in C.
 /// Use the [src_loc!] macro to crate an instance.
 pub struct SourceLocation {

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -701,7 +701,7 @@ pub fn iseq_name(iseq: IseqPtr) -> String {
     if iseq_label == Qnil {
         "None".to_string()
     } else {
-        ruby_str_to_rust(iseq_label)
+        ruby_str_to_rust_string(iseq_label)
     }
 }
 
@@ -717,7 +717,7 @@ pub fn iseq_get_location(iseq: IseqPtr, pos: u16) -> String {
     if iseq_path == Qnil {
         s.push_str("None");
     } else {
-        s.push_str(&ruby_str_to_rust(iseq_path));
+        s.push_str(&ruby_str_to_rust_string(iseq_path));
     }
     s.push_str(":");
     s.push_str(&iseq_lineno.to_string());
@@ -728,7 +728,7 @@ pub fn iseq_get_location(iseq: IseqPtr, pos: u16) -> String {
 // Convert a CRuby UTF-8-encoded RSTRING into a Rust string.
 // This should work fine on ASCII strings and anything else
 // that is considered legal UTF-8, including embedded nulls.
-fn ruby_str_to_rust(v: VALUE) -> String {
+fn ruby_str_to_rust_string(v: VALUE) -> String {
     let str_ptr = unsafe { rb_RSTRING_PTR(v) } as *mut u8;
     let str_len: usize = unsafe { rb_RSTRING_LEN(v) }.try_into().unwrap();
     let str_slice: &[u8] = unsafe { std::slice::from_raw_parts(str_ptr, str_len) };
@@ -738,9 +738,9 @@ fn ruby_str_to_rust(v: VALUE) -> String {
     }
 }
 
-pub fn ruby_sym_to_rust(v: VALUE) -> String {
+pub fn ruby_sym_to_rust_string(v: VALUE) -> String {
     let ruby_str = unsafe { rb_sym2str(v) };
-    ruby_str_to_rust(ruby_str)
+    ruby_str_to_rust_string(ruby_str)
 }
 
 /// A location in Rust code for integrating with debugging facilities defined in C.

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -790,6 +790,7 @@ unsafe extern "C" {
     pub fn rb_intern(name: *const ::std::os::raw::c_char) -> ID;
     pub fn rb_intern2(name: *const ::std::os::raw::c_char, len: ::std::os::raw::c_long) -> ID;
     pub fn rb_id2str(id: ID) -> VALUE;
+    pub fn rb_sym2str(symbol: VALUE) -> VALUE;
     pub fn rb_class2name(klass: VALUE) -> *const ::std::os::raw::c_char;
     pub fn rb_obj_is_kind_of(obj: VALUE, klass: VALUE) -> VALUE;
     pub fn rb_obj_frozen_p(obj: VALUE) -> VALUE;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3376,8 +3376,8 @@ mod tests {
         assert_method_hir_with_opcode("test", YARVINSN_newhash, expect![[r#"
             fn test:
             bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v4:StaticSymbol[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v5:StaticSymbol[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+              v4:StaticSymbol[:a] = Const Value(VALUE(0x1000))
+              v5:StaticSymbol[:b] = Const Value(VALUE(0x1008))
               v7:HashExact = NewHash v4: v1, v5: v2
               Return v7
         "#]]);
@@ -3434,7 +3434,7 @@ mod tests {
         assert_method_hir_with_opcode("test", YARVINSN_putobject, expect![[r#"
             fn test:
             bb0(v0:BasicObject):
-              v2:StaticSymbol[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+              v2:StaticSymbol[:foo] = Const Value(VALUE(0x1000))
               Return v2
         "#]]);
     }
@@ -4028,7 +4028,7 @@ mod tests {
               v5:HashExact = NewHash
               v7:BasicObject = SendWithoutBlock v3, :core#hash_merge_kwd, v5, v1
               v8:BasicObject[VMFrozenCore] = Const Value(VALUE(0x1000))
-              v9:StaticSymbol[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+              v9:StaticSymbol[:b] = Const Value(VALUE(0x1008))
               v10:Fixnum[1] = Const Value(1)
               v12:BasicObject = SendWithoutBlock v8, :core#hash_merge_ptr, v7, v9, v10
               SideExit
@@ -4478,8 +4478,8 @@ mod tests {
             bb0(v0:BasicObject):
               v2:BasicObject[VMFrozenCore] = Const Value(VALUE(0x1000))
               v3:BasicObject = PutSpecialObject CBase
-              v4:StaticSymbol[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              v5:StaticSymbol[VALUE(0x1010)] = Const Value(VALUE(0x1010))
+              v4:StaticSymbol[:aliased] = Const Value(VALUE(0x1008))
+              v5:StaticSymbol[:__callee__] = Const Value(VALUE(0x1010))
               v7:BasicObject = SendWithoutBlock v2, :core#set_method_alias, v3, v4, v5
               Return v7
         "#]]);

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -3,7 +3,7 @@ use crate::cruby::{Qfalse, Qnil, Qtrue, VALUE, RUBY_T_ARRAY, RUBY_T_STRING, RUBY
 use crate::cruby::{rb_cInteger, rb_cFloat, rb_cArray, rb_cHash, rb_cString, rb_cSymbol, rb_cObject, rb_cTrueClass, rb_cFalseClass, rb_cNilClass, rb_cRange, rb_cSet};
 use crate::cruby::ClassRelationship;
 use crate::cruby::get_class_name;
-use crate::cruby::ruby_sym_to_rust;
+use crate::cruby::ruby_sym_to_rust_string;
 use crate::cruby::rb_mRubyVMFrozenCore;
 use crate::hir::PtrPrintMap;
 
@@ -71,7 +71,7 @@ fn write_spec(f: &mut std::fmt::Formatter, printer: &TypePrinter) -> std::fmt::R
     match ty.spec {
         Specialization::Any | Specialization::Empty => { Ok(()) },
         Specialization::Object(val) if val == unsafe { rb_mRubyVMFrozenCore } => write!(f, "[VMFrozenCore]"),
-        Specialization::Object(val) if ty.is_subtype(types::SymbolExact) => write!(f, "[:{}]", ruby_sym_to_rust(val)),
+        Specialization::Object(val) if ty.is_subtype(types::SymbolExact) => write!(f, "[:{}]", ruby_sym_to_rust_string(val)),
         Specialization::Object(val) => write!(f, "[{}]", val.print(printer.ptr_map)),
         Specialization::Type(val) => write!(f, "[class:{}]", get_class_name(val)),
         Specialization::TypeExact(val) => write!(f, "[class_exact:{}]", get_class_name(val)),

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -3,6 +3,7 @@ use crate::cruby::{Qfalse, Qnil, Qtrue, VALUE, RUBY_T_ARRAY, RUBY_T_STRING, RUBY
 use crate::cruby::{rb_cInteger, rb_cFloat, rb_cArray, rb_cHash, rb_cString, rb_cSymbol, rb_cObject, rb_cTrueClass, rb_cFalseClass, rb_cNilClass, rb_cRange, rb_cSet};
 use crate::cruby::ClassRelationship;
 use crate::cruby::get_class_name;
+use crate::cruby::ruby_sym_to_rust;
 use crate::cruby::rb_mRubyVMFrozenCore;
 use crate::hir::PtrPrintMap;
 
@@ -70,6 +71,7 @@ fn write_spec(f: &mut std::fmt::Formatter, printer: &TypePrinter) -> std::fmt::R
     match ty.spec {
         Specialization::Any | Specialization::Empty => { Ok(()) },
         Specialization::Object(val) if val == unsafe { rb_mRubyVMFrozenCore } => write!(f, "[VMFrozenCore]"),
+        Specialization::Object(val) if ty.is_subtype(types::SymbolExact) => write!(f, "[:{}]", ruby_sym_to_rust(val)),
         Specialization::Object(val) => write!(f, "[{}]", val.print(printer.ptr_map)),
         Specialization::Type(val) => write!(f, "[class:{}]", get_class_name(val)),
         Specialization::TypeExact(val) => write!(f, "[class_exact:{}]", get_class_name(val)),


### PR DESCRIPTION
This lets us better see what is going on, for example in pattern
matching code, which has a bunch of dynamic method lookups and
`respond_to?` sends.
