### PR TITLE
[DOC] Tweaks for Case Mapping doc

### DIFF
--- a/doc/case_mapping.rdoc
+++ b/doc/case_mapping.rdoc
@@ -37,7 +37,7 @@ Context-dependent case mapping as described in
 {Table 3-17 (Context Specification for Casing) of the Unicode standard}[https://www.unicode.org/versions/latest/ch03.pdf]
 is currently not supported.
 
-In most cases, case conversions of a string have the same number of characters.
+In most cases, the case conversion of a string has the same number of characters as before.
 There are exceptions (see also +:fold+ below):
 
   s = "\u00DF" # => "ß"
@@ -58,25 +58,18 @@ Case changes may not be reversible:
   s.downcase.upcase  # => "HELLO WORLD!" # Different from original s.
 
 Case changing methods may not maintain Unicode normalization.
-See String#unicode_normalize).
+See String#unicode_normalize.
 
-== Options for Case Mapping
+== Case Mappings
 
 Except for +casecmp+ and +casecmp?+,
 each of the case-mapping methods listed above
-accepts optional arguments, <tt>*options</tt>.
+accepts an optional argument, <tt>mapping</tt>.
 
-The arguments may be:
+The argument is one of:
 
-- +:ascii+ only.
-- +:fold+ only.
-- +:turkic+ or +:lithuanian+ or both.
-
-The options:
-
-- +:ascii+:
-  ASCII-only mapping:
-  uppercase letters ('A'..'Z') are mapped to lowercase letters ('a'..'z);
+- +:ascii+: ASCII-only mapping.
+  Uppercase letters ('A'..'Z') are mapped to lowercase letters ('a'..'z);
   other characters are not changed
 
     s = "Foo \u00D8 \u00F8 Bar" # => "Foo Ø ø Bar"
@@ -85,8 +78,8 @@ The options:
     s.upcase(:ascii)            # => "FOO Ø ø BAR"
     s.downcase(:ascii)          # => "foo Ø ø bar"
 
-- +:turkic+:
-  Full Unicode case mapping, adapted for the Turkic languages
+- +:turkic+: Full Unicode case mapping.
+  For the Turkic languages
   that distinguish dotted and dotless I, for example Turkish and Azeri.
 
     s = 'Türkiye'       # => "Türkiye"
@@ -97,11 +90,8 @@ The options:
     s.downcase          # => "türkiye"
     s.downcase(:turkic) # => "türkıye" # No dot above.
 
-- +:lithuanian+:
-  Not yet implemented.
-
 - +:fold+ (available only for String#downcase, String#downcase!,
-  and Symbol#downcase):
+  and Symbol#downcase).
   Unicode case folding,
   which is more far-reaching than Unicode case mapping.
 

--- a/string.c
+++ b/string.c
@@ -8102,7 +8102,7 @@ upcase_single(VALUE str)
 
 /*
  *  call-seq:
- *    upcase!(*options) -> self or nil
+ *    upcase!(mapping) -> self or nil
  *
  *  Upcases the characters in +self+;
  *  returns +self+ if any changes were made, +nil+ otherwise:
@@ -8112,7 +8112,7 @@ upcase_single(VALUE str)
  *    s                  # => "HELLO WORLD!"
  *    s.upcase!          # => nil
  *
- *  The casing may be affected by the given +options+;
+ *  The casing may be affected by the given +mapping+;
  *  see {Case Mapping}[rdoc-ref:case_mapping.rdoc].
  *
  *  Related: String#upcase, String#downcase, String#downcase!.
@@ -8144,14 +8144,14 @@ rb_str_upcase_bang(int argc, VALUE *argv, VALUE str)
 
 /*
  *  call-seq:
- *    upcase(*options) -> string
+ *    upcase(mapping) -> string
  *
  *  Returns a string containing the upcased characters in +self+:
  *
  *     s = 'Hello World!' # => "Hello World!"
  *     s.upcase           # => "HELLO WORLD!"
  *
- *  The casing may be affected by the given +options+;
+ *  The casing may be affected by the given +mapping+;
  *  see {Case Mapping}[rdoc-ref:case_mapping.rdoc].
  *
  *  Related: String#upcase!, String#downcase, String#downcase!.
@@ -8204,7 +8204,7 @@ downcase_single(VALUE str)
 
 /*
  *  call-seq:
- *    downcase!(*options) -> self or nil
+ *    downcase!(mapping) -> self or nil
  *
  *  Downcases the characters in +self+;
  *  returns +self+ if any changes were made, +nil+ otherwise:
@@ -8214,7 +8214,7 @@ downcase_single(VALUE str)
  *    s                  # => "hello world!"
  *    s.downcase!        # => nil
  *
- *  The casing may be affected by the given +options+;
+ *  The casing may be affected by the given +mapping+;
  *  see {Case Mapping}[rdoc-ref:case_mapping.rdoc].
  *
  *  Related: String#downcase, String#upcase, String#upcase!.
@@ -8246,14 +8246,14 @@ rb_str_downcase_bang(int argc, VALUE *argv, VALUE str)
 
 /*
  *  call-seq:
- *    downcase(*options) -> string
+ *    downcase(mapping) -> string
  *
  *  Returns a string containing the downcased characters in +self+:
  *
  *     s = 'Hello World!' # => "Hello World!"
  *     s.downcase         # => "hello world!"
  *
- *  The casing may be affected by the given +options+;
+ *  The casing may be affected by the given +mapping+;
  *  see {Case Mapping}[rdoc-ref:case_mapping.rdoc].
  *
  *  Related: String#downcase!, String#upcase, String#upcase!.
@@ -8288,7 +8288,7 @@ rb_str_downcase(int argc, VALUE *argv, VALUE str)
 
 /*
  *  call-seq:
- *    capitalize!(*options) -> self or nil
+ *    capitalize!(mapping) -> self or nil
  *
  *  Upcases the first character in +self+;
  *  downcases the remaining characters;
@@ -8299,7 +8299,7 @@ rb_str_downcase(int argc, VALUE *argv, VALUE str)
  *    s                  # => "Hello world!"
  *    s.capitalize!      # => nil
  *
- *  The casing may be affected by the given +options+;
+ *  The casing may be affected by the given +mapping+;
  *  see {Case Mapping}[rdoc-ref:case_mapping.rdoc].
  *
  *  Related: String#capitalize.
@@ -8328,7 +8328,7 @@ rb_str_capitalize_bang(int argc, VALUE *argv, VALUE str)
 
 /*
  *  call-seq:
- *    capitalize(*options) -> string
+ *    capitalize(mapping) -> string
  *
  *  Returns a string containing the characters in +self+;
  *  the first character is upcased;
@@ -8337,7 +8337,7 @@ rb_str_capitalize_bang(int argc, VALUE *argv, VALUE str)
  *     s = 'hello World!' # => "hello World!"
  *     s.capitalize       # => "Hello world!"
  *
- *  The casing may be affected by the given +options+;
+ *  The casing may be affected by the given +mapping+;
  *  see {Case Mapping}[rdoc-ref:case_mapping.rdoc].
  *
  *  Related: String#capitalize!.
@@ -8367,7 +8367,7 @@ rb_str_capitalize(int argc, VALUE *argv, VALUE str)
 
 /*
  *  call-seq:
- *    swapcase!(*options) -> self or nil
+ *    swapcase!(mapping) -> self or nil
  *
  *  Upcases each lowercase character in +self+;
  *  downcases uppercase character;
@@ -8378,7 +8378,7 @@ rb_str_capitalize(int argc, VALUE *argv, VALUE str)
  *    s                  # => "hELLO wORLD!"
  *    ''.swapcase!       # => nil
  *
- *  The casing may be affected by the given +options+;
+ *  The casing may be affected by the given +mapping+;
  *  see {Case Mapping}[rdoc-ref:case_mapping.rdoc].
  *
  *  Related: String#swapcase.
@@ -8406,7 +8406,7 @@ rb_str_swapcase_bang(int argc, VALUE *argv, VALUE str)
 
 /*
  *  call-seq:
- *    swapcase(*options) -> string
+ *    swapcase(mapping) -> string
  *
  *  Returns a string containing the characters in +self+, with cases reversed;
  *  each uppercase character is downcased;
@@ -8415,7 +8415,7 @@ rb_str_swapcase_bang(int argc, VALUE *argv, VALUE str)
  *     s = 'Hello World!' # => "Hello World!"
  *     s.swapcase         # => "hELLO wORLD!"
  *
- *  The casing may be affected by the given +options+;
+ *  The casing may be affected by the given +mapping+;
  *  see {Case Mapping}[rdoc-ref:case_mapping.rdoc].
  *
  *  Related: String#swapcase!.
@@ -12528,7 +12528,7 @@ sym_empty(VALUE sym)
 
 /*
  *  call-seq:
- *    upcase(*options) -> symbol
+ *    upcase(mapping) -> symbol
  *
  *  Equivalent to <tt>sym.to_s.upcase.to_sym</tt>.
  *
@@ -12544,7 +12544,7 @@ sym_upcase(int argc, VALUE *argv, VALUE sym)
 
 /*
  *  call-seq:
- *    downcase(*options) -> symbol
+ *    downcase(mapping) -> symbol
  *
  *  Equivalent to <tt>sym.to_s.downcase.to_sym</tt>.
  *
@@ -12562,7 +12562,7 @@ sym_downcase(int argc, VALUE *argv, VALUE sym)
 
 /*
  *  call-seq:
- *    capitalize(*options) -> symbol
+ *    capitalize(mapping) -> symbol
  *
  *  Equivalent to <tt>sym.to_s.capitalize.to_sym</tt>.
  *
@@ -12578,7 +12578,7 @@ sym_capitalize(int argc, VALUE *argv, VALUE sym)
 
 /*
  *  call-seq:
- *    swapcase(*options) -> symbol
+ *    swapcase(mapping) -> symbol
  *
  *  Equivalent to <tt>sym.to_s.swapcase.to_sym</tt>.
  *


### PR DESCRIPTION
I don't think we need to mention the unimplemented argument value `:lithuanian`.  Omitting it means that instead of arguments `*options`, we can have one argument, `mapping`.

Marking this as Draft.  If agreed upon, I'll add commits changing the argument name `*options` to `mapping` in the dozen or so affected methods' calling sequences.