### PR TITLE
ZJIT: Don't compile functions with unhandled parameter types

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -118,6 +118,7 @@ class TestZJIT < Test::Unit::TestCase
   end
 
   def test_invokebuiltin
+    omit 'Test fails at the moment due to not handling optional parameters'
     assert_compiles '["."]', %q{
       def test = Dir.glob(".")
       test


### PR DESCRIPTION
Follow-up on #13633.