### PR TITLE
ZJIT: Mark GetLocal as having no effects

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -570,6 +570,7 @@ impl Insn {
             Insn::FixnumLe   { .. } => false,
             Insn::FixnumGt   { .. } => false,
             Insn::FixnumGe   { .. } => false,
+            Insn::GetLocal   { .. } => false,
             Insn::CCall { elidable, .. } => !elidable,
             _ => true,
         }


### PR DESCRIPTION
This removes the GetLocal of l3 from:

    def test
      l3 = 3
      1.times do |l2|
        _ = l3
        1
      end
    end
