### PR TITLE
Fixed inconsistency gemspec location

### DIFF
--- a/lib/erb/erb.gemspec
+++ b/lib/erb/erb.gemspec
@@ -2,7 +2,7 @@ begin
   require_relative 'lib/erb/version'
 rescue LoadError
   # for Ruby core repository
-  require_relative 'erb/version'
+  require_relative 'version'
 end
 
 Gem::Specification.new do |spec|


### PR DESCRIPTION
foo.gemspec should be located under the `lib/foo` directory.