### PR TITLE
Omit TestException#test_detailed_message_under_gc_compact_stress at Ruby 3.3

### DIFF
--- a/test/ruby/test_exception.rb
+++ b/test/ruby/test_exception.rb
@@ -1460,6 +1460,7 @@ $stderr = $stdout; raise "\x82\xa0"') do |outs, errs, status|
   end
 
   def test_detailed_message_under_gc_compact_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     EnvUtil.under_gc_compact_stress do
       e = RuntimeError.new("foo\nbar\nbaz")
       assert_equal("foo (RuntimeError)\nbar\nbaz", e.detailed_message)


### PR DESCRIPTION
Partly picked from https://github.com/ruby/ruby/pull/10073

for https://rubyci.s3.amazonaws.com/s390x/ruby-3.3/log/20250701T065934Z.fail.html.gz