### PR TITLE
Backport GH-13617 for s390x

### DIFF
--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -413,6 +413,7 @@ class TestVariable < Test::Unit::TestCase
   end
 
   def test_exivar_resize_with_compaction_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     objs = 10_000.times.map do
       ExIvar.new
     end


### PR DESCRIPTION
https://github.com/ruby/ruby/pull/13617

for https://rubyci.s3.amazonaws.com/s390x/ruby-3.4/log/20250701T063135Z.fail.html.gz