### PR TITLE
Launchable: Temporarily remove Launchable integration from Compilatio…

### DIFF
--- a/.github/actions/compilers/entrypoint.sh
+++ b/.github/actions/compilers/entrypoint.sh
@@ -74,64 +74,6 @@ btests=''
 tests=''
 spec_opts=''
 
-# Launchable
-launchable_record_session() {
-    launchable record session \
-        --build "${build_name}" \
-        --flavor test_task=$1 \
-        --flavor workflow=Compilations \
-        --flavor with-gcc="${INPUT_WITH_GCC}" \
-        --flavor CFLAGS="${INPUT_CFLAGS}" \
-        --flavor CXXFLAGS="${INPUT_CXXFLAGS}" \
-        --flavor optflags="${INPUT_OPTFLAGS}" \
-        --flavor cppflags="${INPUT_CPPFLAGS}" \
-        --test-suite ${2-$1}
-}
-setup_launchable() {
-    pushd ${srcdir}
-    # To prevent a slowdown in CI, disable request retries when the Launchable server is unstable.
-    export LAUNCHABLE_SKIP_TIMEOUT_RETRY=1
-    export LAUNCHABLE_COMMIT_TIMEOUT=1
-    # Launchable creates .launchable file in the current directory, but cannot a file to ${srcdir} directory.
-    # As a workaround, we set LAUNCHABLE_SESSION_DIR to ${builddir}.
-    export LAUNCHABLE_SESSION_DIR=${builddir}
-    local github_ref="${GITHUB_REF//\//_}"
-    local build_name="${github_ref}"_"${GITHUB_PR_HEAD_SHA}"
-    launchable record build --name "${build_name}" || true
-    btest_session=$(launchable_record_session test btest) \
-        && btests+=--launchable-test-reports="${btest_report_path}" || :
-    if [ "$INPUT_CHECK" = "true" ]; then
-        test_all_session=$(launchable_record_session test-all) \
-            && tests+=--launchable-test-reports="${test_report_path}" || :
-        mkdir "${builddir}"/"${test_spec_report_path}"
-        test_spec_session=$(launchable_record_session test-spec) \
-            && spec_opts+=--launchable-test-reports="${test_spec_report_path}" || :
-    fi
-}
-launchable_record_test() {
-    pushd "${builddir}"
-    grouped launchable record tests --session "${btest_session}" raw "${btest_report_path}" || true
-    if [ "$INPUT_CHECK" = "true" ]; then
-        grouped launchable record tests --session "${test_all_session}" raw "${test_report_path}" || true
-        grouped launchable record tests --session "${test_spec_session}" raw "${test_spec_report_path}"/* || true
-    fi
-}
-if [ "$LAUNCHABLE_ENABLED" = "true" ]; then
-    echo "::group::Setup Launchable"
-    btest_report_path='launchable_bootstraptest.json'
-    test_report_path='launchable_test_all.json'
-    test_spec_report_path='launchable_test_spec_report'
-    setup_pid=$$
-    (sleep 180; echo "setup_launchable timed out; killing"; kill -INT "-$setup_pid" 2> /dev/null) & sleep_pid=$!
-    launchable_failed=false
-    trap "launchable_failed=true" INT
-    setup_launchable
-    kill "$sleep_pid" 2> /dev/null
-    trap - INT
-    echo "::endgroup::"
-    $launchable_failed || trap launchable_record_test EXIT
-fi
-
 pushd ${builddir}
 
 grouped make showflags


### PR DESCRIPTION
…ns workflow

Currently, Launchable is unstable, which occationally causes workflow issues. Until this problem is fixed, we'll temporary disable Launchable in the Compilations workflow.