### PR TITLE
ZJIT: Shorten Debug print for 64-bit VReg

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -77,6 +77,7 @@ impl fmt::Debug for Opnd {
         match self {
             Self::None => write!(fmt, "None"),
             Value(val) => write!(fmt, "Value({val:?})"),
+            VReg { idx, num_bits } if *num_bits == 64 => write!(fmt, "VReg({idx})"),
             VReg { idx, num_bits } => write!(fmt, "VReg{num_bits}({idx})"),
             Imm(signed) => write!(fmt, "{signed:x}_i64"),
             UImm(unsigned) => write!(fmt, "{unsigned:x}_u64"),


### PR DESCRIPTION
This PR shortens the Debug print of `Opnd::VReg` from `VReg64(n)` to `VReg(n)`.

Most LIRs have only `num_bits: 64` VRegs, so it feels redundant to clarify that it's 64-bit. I want to just show `VReg(n)` by default and use a full-version output only for corner cases.