### PR TITLE
ZJIT: Annotate `NilClass#nil?` and `Kernel#nil?`

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -840,6 +840,25 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 1, insns: [:branchnil]
   end
 
+  def test_nil_nil
+    assert_compiles 'true', %q{
+      def test = nil.nil?
+      test
+      test
+    }
+  end
+
+  def test_obsolete_nil_nil
+    assert_compiles '1', %q{
+      def test
+        nil.nil?
+        1
+      end
+      test
+      test
+    }
+  end
+
   # tool/ruby_vm/views/*.erb relies on the zjit instructions a) being contiguous and
   # b) being reliably ordered after all the other instructions.
   def test_instruction_order

--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -844,19 +844,14 @@ class TestZJIT < Test::Unit::TestCase
     assert_compiles 'true', %q{
       def test = nil.nil?
       test
-      test
-    }
+    }, insns: [:opt_nil_p]
   end
 
-  def test_obsolete_nil_nil
-    assert_compiles '1', %q{
-      def test
-        nil.nil?
-        1
-      end
+  def test_non_nil_nil
+    assert_compiles 'false', %q{
+      def test = 1.nil?
       test
-      test
-    }
+    }, insns: [:opt_nil_p]
   end
 
   # tool/ruby_vm/views/*.erb relies on the zjit instructions a) being contiguous and

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -81,6 +81,7 @@ pub fn init() -> Annotations {
     annotate!(rb_cArray, "length", types::Fixnum, no_gc, leaf, elidable);
     annotate!(rb_cArray, "size", types::Fixnum, no_gc, leaf, elidable);
     annotate!(rb_cNilClass, "nil?", types::TrueClassExact, no_gc, leaf, elidable);
+    annotate!(rb_mKernel, "nil?", types::FalseClassExact, no_gc, leaf, elidable);
 
     Annotations {
         cfuncs: std::mem::take(cfuncs)

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -80,6 +80,7 @@ pub fn init() -> Annotations {
     annotate!(rb_cModule, "===", types::BoolExact, no_gc, leaf);
     annotate!(rb_cArray, "length", types::Fixnum, no_gc, leaf, elidable);
     annotate!(rb_cArray, "size", types::Fixnum, no_gc, leaf, elidable);
+    annotate!(rb_cNilClass, "nil?", types::TrueClassExact, no_gc, leaf, elidable);
 
     Annotations {
         cfuncs: std::mem::take(cfuncs)

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6368,4 +6368,52 @@ mod opt_tests {
               Return v2
         "#]]);
     }
+
+    #[test]
+    fn test_nil_nil_specialized_to_ccall() {
+        eval("
+            def test = nil.nil?
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0(v0:BasicObject):
+              v2:NilClassExact = Const Value(nil)
+              PatchPoint MethodRedefined(NilClass@0x1000, nil?@0x1008)
+              v7:TrueClassExact = CCall nil?@0x1010, v2
+              Return v7
+        "#]]);
+    }
+
+    #[test]
+    fn test_eliminate_nil_nil_specialized_to_ccall() {
+        eval("
+            def test
+              nil.nil?
+              1
+            end
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0(v0:BasicObject):
+              PatchPoint MethodRedefined(NilClass@0x1000, nil?@0x1008)
+              v5:Fixnum[1] = Const Value(1)
+              Return v5
+        "#]]);
+    }
+
+    #[test]
+    fn test_object_nil_specialized_to_send() {
+        eval("
+            def test = Object.new.nil?
+        ");
+        assert_optimized_method_hir("test", expect![[r#"
+            fn test:
+            bb0(v0:BasicObject):
+              v3:BasicObject = GetConstantPath 0x1000
+              v4:NilClassExact = Const Value(nil)
+              v11:BasicObject = SendWithoutBlock v3, :new
+              v18:BasicObject = SendWithoutBlock v11, :nil?
+              Return v18
+       "#]]);
+    }
 }


### PR DESCRIPTION
These methods return fixed `true` or `false` so we can be certain about their return types.