### PR TITLE
Object#hash: use the object address for T_OBJECT

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -820,6 +820,8 @@ shape_id_i(shape_id_t shape_id, void *data)
         break;
       case SHAPE_OBJ_ID:
         dump_append(dc, ", \"shape_type\":\"OBJ_ID\"");
+      case SHAPE_OLD_ADDRESS:
+        dump_append(dc, ", \"shape_type\":\"OLD_ADDRESS\"");
         break;
     }
 

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -75,6 +75,7 @@ MODULAR_GC_FN size_t rb_gc_obj_optimal_size(VALUE obj);
 MODULAR_GC_FN void rb_gc_mark_children(void *objspace, VALUE obj);
 MODULAR_GC_FN void rb_gc_vm_weak_table_foreach(vm_table_foreach_callback_func callback, vm_table_update_callback_func update_callback, void *data, bool weak_only, enum rb_gc_vm_weak_tables table);
 MODULAR_GC_FN void rb_gc_update_object_references(void *objspace, VALUE obj);
+MODULAR_GC_FN void rb_gc_update_moved_object(void *objspace, VALUE dest, VALUE src);
 MODULAR_GC_FN void rb_gc_update_vm_references(void *objspace);
 MODULAR_GC_FN void rb_gc_event_hook(VALUE obj, rb_event_flag_t event);
 MODULAR_GC_FN void *rb_gc_get_objspace(void);

--- a/include/ruby/internal/core/rtypeddata.h
+++ b/include/ruby/internal/core/rtypeddata.h
@@ -182,7 +182,7 @@ rbimpl_typeddata_flags {
     /**
      * This flag no longer in use
      */
-    RUBY_TYPED_UNUSED           = RUBY_FL_UNUSED6,
+    RUBY_TYPED_UNUSED           = 0,
 
     /**
      * This flag determines whether marking and compaction should be carried out

--- a/include/ruby/internal/fl_type.h
+++ b/include/ruby/internal/fl_type.h
@@ -216,12 +216,15 @@ ruby_fl_type {
      */
     RUBY_FL_PROMOTED    = (1<<5),
 
-    /**
-     * This flag is no longer in use
-     *
-     * @internal
-     */
-    RUBY_FL_UNUSED6    = (1<<6),
+
+   /**
+    * This flag is used to mark when an object address has been observed by
+    * `rb_obj_hash` or similar. This indicates to the GC that the old address
+    * must be recorded inside the moved object to keep `rb_obj_hash` stable.
+    *
+    * @internal
+    */
+    RUBY_FL_ADDRESS_SEEN = (1<<6),
 
     /**
      * This flag has  something to do with finalisers.  A  ruby object can have

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -54,6 +54,8 @@ shape_id_t rb_evict_fields_to_hash(VALUE obj);
 VALUE rb_obj_field_get(VALUE obj, shape_id_t target_shape_id);
 void rb_ivar_set_internal(VALUE obj, ID id, VALUE val);
 void rb_obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val);
+st_index_t rb_obj_stable_address(VALUE obj);
+void rb_obj_set_stable_address(VALUE obj, VALUE old_address);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* variable.c (export) */

--- a/shape.h
+++ b/shape.h
@@ -28,7 +28,9 @@ STATIC_ASSERT(shape_id_num_bits, SHAPE_ID_NUM_BITS == sizeof(shape_id_t) * CHAR_
 //              Whether the object is frozen or not.
 //      23 SHAPE_ID_FL_HAS_OBJECT_ID
 //              Whether the object has an `SHAPE_OBJ_ID` transition.
-//      24 SHAPE_ID_FL_TOO_COMPLEX
+//      24 SHAPE_ID_FL_HAS_OLD_ADDRESS
+//              Whether the object has an `SHAPE_OLD_ADDRESS` transition.
+//      25 SHAPE_ID_FL_TOO_COMPLEX
 //              The object is backed by a `st_table`.
 
 enum shape_id_fl_type {
@@ -38,17 +40,14 @@ enum shape_id_fl_type {
 
     SHAPE_ID_FL_FROZEN = RBIMPL_SHAPE_ID_FL(3),
     SHAPE_ID_FL_HAS_OBJECT_ID = RBIMPL_SHAPE_ID_FL(4),
-    SHAPE_ID_FL_TOO_COMPLEX = RBIMPL_SHAPE_ID_FL(5),
+    SHAPE_ID_FL_HAS_OLD_ADDRESS = RBIMPL_SHAPE_ID_FL(5),
+    SHAPE_ID_FL_TOO_COMPLEX = RBIMPL_SHAPE_ID_FL(6),
 
-    SHAPE_ID_FL_NON_CANONICAL_MASK = SHAPE_ID_FL_FROZEN | SHAPE_ID_FL_HAS_OBJECT_ID,
+    SHAPE_ID_FL_NON_CANONICAL_MASK = SHAPE_ID_FL_FROZEN | SHAPE_ID_FL_HAS_OBJECT_ID | SHAPE_ID_FL_HAS_OLD_ADDRESS,
     SHAPE_ID_FLAGS_MASK = SHAPE_ID_HEAP_INDEX_MASK | SHAPE_ID_FL_NON_CANONICAL_MASK | SHAPE_ID_FL_TOO_COMPLEX,
 
 #undef RBIMPL_SHAPE_ID_FL
 };
-
-// This masks allows to check if a shape_id contains any ivar.
-// It rely on ROOT_SHAPE_WITH_OBJ_ID==1.
-#define SHAPE_ID_HAS_IVAR_MASK (SHAPE_ID_FL_TOO_COMPLEX | (SHAPE_ID_OFFSET_MASK - 1))
 
 // The interpreter doesn't care about frozen status or slot size when reading ivars.
 // So we normalize shape_id by clearing these bits to improve cache hits.
@@ -66,11 +65,17 @@ typedef uint32_t redblack_id_t;
 #define INVALID_SHAPE_ID ((shape_id_t)-1)
 #define ATTR_INDEX_NOT_SET ((attr_index_t)-1)
 
-#define ROOT_SHAPE_ID                   0x0
-#define ROOT_SHAPE_WITH_OBJ_ID          0x1
-#define ROOT_TOO_COMPLEX_SHAPE_ID       (ROOT_SHAPE_ID | SHAPE_ID_FL_TOO_COMPLEX)
-#define ROOT_TOO_COMPLEX_WITH_OBJ_ID    (ROOT_SHAPE_WITH_OBJ_ID | SHAPE_ID_FL_TOO_COMPLEX | SHAPE_ID_FL_HAS_OBJECT_ID)
-#define SPECIAL_CONST_SHAPE_ID          (ROOT_SHAPE_ID | SHAPE_ID_FL_FROZEN)
+#define ROOT_SHAPE_ID                           0x0
+#define ROOT_SHAPE_WITH_OBJ_ID                  0x1
+#define ROOT_SHAPE_WITH_OLD_ADDRESS             0x2
+#define ROOT_SHAPE_WITH_OBJ_ID_AND_OLD_ADDRESS  0x3
+#define ROOT_TOO_COMPLEX_SHAPE_ID               (ROOT_SHAPE_ID | SHAPE_ID_FL_TOO_COMPLEX)
+#define ROOT_TOO_COMPLEX_WITH_OBJ_ID            (ROOT_SHAPE_WITH_OBJ_ID | SHAPE_ID_FL_TOO_COMPLEX | SHAPE_ID_FL_HAS_OBJECT_ID)
+#define SPECIAL_CONST_SHAPE_ID                  (ROOT_SHAPE_ID | SHAPE_ID_FL_FROZEN)
+
+// This masks allows to check if a shape_id contains any ivar.
+// It rely on ROOT_SHAPE_WITH_OBJ_ID_AND_OLD_ADDRESS==3.
+#define SHAPE_ID_HAS_IVAR_MASK (SHAPE_ID_FL_TOO_COMPLEX | (SHAPE_ID_OFFSET_MASK - 3))
 
 typedef struct redblack_node redblack_node_t;
 
@@ -97,6 +102,7 @@ enum shape_type {
     SHAPE_ROOT,
     SHAPE_IVAR,
     SHAPE_OBJ_ID,
+    SHAPE_OLD_ADDRESS,
 };
 
 enum shape_flags {
@@ -211,9 +217,12 @@ shape_id_t rb_shape_transition_remove_ivar(VALUE obj, ID id, shape_id_t *removed
 shape_id_t rb_shape_transition_add_ivar(VALUE obj, ID id);
 shape_id_t rb_shape_transition_add_ivar_no_warnings(VALUE obj, ID id);
 shape_id_t rb_shape_transition_object_id(VALUE obj);
+shape_id_t rb_shape_transition_old_address(shape_id_t original_shape_id);
 shape_id_t rb_shape_transition_heap(VALUE obj, size_t heap_index);
 shape_id_t rb_shape_object_id(shape_id_t original_shape_id);
+shape_id_t rb_shape_old_address(shape_id_t original_shape_id);
 
+void rb_shape_update_references(shape_id_t shape_id);
 void rb_shape_free_all(void);
 
 shape_id_t rb_shape_rebuild(shape_id_t initial_shape_id, shape_id_t dest_shape_id);
@@ -236,6 +245,12 @@ static inline bool
 rb_shape_has_object_id(shape_id_t shape_id)
 {
     return shape_id & SHAPE_ID_FL_HAS_OBJECT_ID;
+}
+
+static inline bool
+rb_shape_has_old_address(shape_id_t shape_id)
+{
+    return shape_id & SHAPE_ID_FL_HAS_OLD_ADDRESS;
 }
 
 static inline bool

--- a/variable.c
+++ b/variable.c
@@ -1269,7 +1269,7 @@ VALUE
 rb_obj_field_get(VALUE obj, shape_id_t target_shape_id)
 {
     RUBY_ASSERT(!SPECIAL_CONST_P(obj));
-    RUBY_ASSERT(RSHAPE_TYPE_P(target_shape_id, SHAPE_IVAR) || RSHAPE_TYPE_P(target_shape_id, SHAPE_OBJ_ID));
+    RUBY_ASSERT(RSHAPE_EDGE_NAME(target_shape_id));
 
     if (BUILTIN_TYPE(obj) == T_CLASS || BUILTIN_TYPE(obj) == T_MODULE) {
         ASSERT_vm_locking();
@@ -1879,11 +1879,6 @@ imemo_fields_set(VALUE klass, VALUE fields_obj, shape_id_t target_shape_id, ID f
 static void
 generic_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val)
 {
-    if (!field_name) {
-        field_name = RSHAPE_EDGE_NAME(target_shape_id);
-        RUBY_ASSERT(field_name);
-    }
-
     const VALUE original_fields_obj = generic_fields_lookup(obj, field_name, false);
     VALUE fields_obj = imemo_fields_set(rb_obj_class(obj), original_fields_obj, target_shape_id, field_name, val, false);
 
@@ -2103,6 +2098,11 @@ rb_ivar_set_internal(VALUE obj, ID id, VALUE val)
 void
 rb_obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val)
 {
+    if (!field_name) {
+        field_name = RSHAPE_EDGE_NAME(target_shape_id);
+        RUBY_ASSERT(field_name);
+    }
+
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
         obj_field_set(obj, target_shape_id, val);
@@ -2405,8 +2405,10 @@ rb_ivar_count(VALUE obj)
     if (SPECIAL_CONST_P(obj)) return 0;
 
     st_index_t iv_count = 0;
+    shape_id_t shape_id;
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
+        shape_id = RBASIC_SHAPE_ID(obj);
         iv_count = ROBJECT_FIELDS_COUNT(obj);
         break;
 
@@ -2417,11 +2419,12 @@ rb_ivar_count(VALUE obj)
             if (!fields_obj) {
                 return 0;
             }
-            if (rb_shape_obj_too_complex_p(fields_obj)) {
+            shape_id = RBASIC_SHAPE_ID(fields_obj);
+            if (rb_shape_too_complex_p(shape_id)) {
                 iv_count = rb_st_table_size(rb_imemo_fields_complex_tbl(fields_obj));
             }
             else {
-                iv_count = RBASIC_FIELDS_COUNT(fields_obj);
+                iv_count = RSHAPE_LEN(shape_id);
             }
         }
         break;
@@ -2429,32 +2432,35 @@ rb_ivar_count(VALUE obj)
       case T_IMEMO:
         RUBY_ASSERT(IMEMO_TYPE_P(obj, imemo_fields));
 
-        if (rb_shape_obj_too_complex_p(obj)) {
+        shape_id = RBASIC_SHAPE_ID(obj);
+        if (rb_shape_too_complex_p(shape_id)) {
             iv_count = rb_st_table_size(rb_imemo_fields_complex_tbl(obj));
         }
         else {
-            iv_count = RBASIC_FIELDS_COUNT(obj);
+            iv_count = RSHAPE_LEN(shape_id);
         }
         break;
 
       default:
-        if (rb_obj_exivar_p(obj)) {
+        shape_id = RBASIC_SHAPE_ID(obj);
+        if (rb_shape_too_complex_p(shape_id)) {
+            VALUE fields_obj;
 
-            if (rb_shape_obj_too_complex_p(obj)) {
-                VALUE fields_obj;
-
-                if (rb_gen_fields_tbl_get(obj, 0, &fields_obj)) {
-                    iv_count = rb_st_table_size(rb_imemo_fields_complex_tbl(fields_obj));
-                }
+            if (rb_gen_fields_tbl_get(obj, 0, &fields_obj)) {
+                iv_count = rb_st_table_size(rb_imemo_fields_complex_tbl(fields_obj));
             }
-            else {
-                iv_count = RBASIC_FIELDS_COUNT(obj);
-            }
+        }
+        else {
+            iv_count = RSHAPE_LEN(shape_id);
         }
         break;
     }
 
-    if (rb_shape_obj_has_id(obj)) {
+    if (rb_shape_has_object_id(shape_id)) {
+        iv_count--;
+    }
+
+    if (rb_shape_has_old_address(shape_id)) {
         iv_count--;
     }
 
@@ -4782,3 +4788,53 @@ rb_const_lookup(VALUE klass, ID id)
     return const_lookup(RCLASS_CONST_TBL(klass), id);
 }
 
+st_index_t
+rb_obj_stable_address(VALUE obj)
+{
+    RUBY_ASSERT(FL_ABLE(obj));
+
+    // Only T_OBJECT can have a stable address, all other
+    // types store their fields in another object (imemo/fields),
+    // which can't be resized during compaction.
+    RUBY_ASSERT(RB_TYPE_P(obj, T_OBJECT));
+
+    if (FL_TEST_RAW(obj, RUBY_FL_ADDRESS_SEEN)) {
+        shape_id_t shape_id = RBASIC_SHAPE_ID(obj);
+        if (UNLIKELY(rb_shape_has_old_address(shape_id))) {
+            VALUE old_address = rb_obj_field_get(obj, rb_shape_old_address(shape_id));
+#if SIZEOF_LONG == SIZEOF_VOIDP
+            return (st_index_t)NUM2LONG(old_address);
+#elif SIZEOF_LONG_LONG == SIZEOF_VOIDP
+            return (st_index_t)NUM2LL(old_address);
+#else
+#error "Unexpected VALUE size"
+#endif
+        }
+    }
+    else {
+        FL_SET_RAW(obj, RUBY_FL_ADDRESS_SEEN);
+    }
+
+    return (st_index_t)obj;
+}
+
+void
+rb_obj_set_stable_address(VALUE obj, VALUE old_address)
+{
+    RUBY_ASSERT(FL_ABLE(obj));
+    RUBY_ASSERT(!RB_TYPE_P(obj, T_IMEMO));
+    RUBY_ASSERT(FL_TEST_RAW(obj, RUBY_FL_ADDRESS_SEEN));
+
+    shape_id_t shape_id = RBASIC_SHAPE_ID(obj);
+
+    if (!rb_shape_has_old_address(shape_id)) {
+#if SIZEOF_LONG == SIZEOF_VOIDP
+        old_address = LONG2NUM(old_address);
+#elif SIZEOF_LONG_LONG == SIZEOF_VOIDP
+        old_address = LL2NUM(old_address);
+#else
+#error "Unexpected VALUE size"
+#endif
+        rb_obj_field_set(obj, rb_shape_transition_old_address(shape_id), 0, old_address);
+    }
+}


### PR DESCRIPTION
Updated attempt at: https://github.com/ruby/ruby/pull/13290

Rather than to generate an object_id, we can use the object address. However we have to record that we did, so that if the object is later moved, we know to record its original address inline, so that it keeps a stable hash.

We can't use the same strategy for other objects because they delegate their fields to another IMEMO/fields object. So if they don't yet have fields or if the fields object is full, during compaction we'd need to allocate another one but that not allowed during GC.