### PR TITLE
Assume that the symbol is not garbage in rb_sym2id

### DIFF
--- a/symbol.c
+++ b/symbol.c
@@ -926,7 +926,7 @@ rb_sym2id(VALUE sym)
     }
     else if (DYNAMIC_SYM_P(sym)) {
         GLOBAL_SYMBOLS_LOCKING(symbols) {
-            sym = dsymbol_check(symbols, sym);
+            RUBY_ASSERT(!rb_objspace_garbage_object_p(sym));
             id = RSYMBOL(sym)->id;
 
             if (UNLIKELY(!(id & ~ID_SCOPE_MASK))) {


### PR DESCRIPTION
rb_sym2id is a public API, so it is always a bug if the user holds on to a dead object and passes it in.