### PR TITLE
ZJIT: Skip a hanging ractor test

### DIFF
--- a/bootstraptest/runner.rb
+++ b/bootstraptest/runner.rb
@@ -891,4 +891,8 @@ def yjit_enabled?
   ENV.key?('RUBY_YJIT_ENABLE') || ENV.fetch('RUN_OPTS', '').include?('yjit') || BT.ruby.include?('yjit')
 end
 
+def zjit_enabled?
+  ENV.key?('RUBY_ZJIT_ENABLE') || ENV.fetch('RUN_OPTS', '').include?('zjit') || BT.ruby.include?('zjit')
+end
+
 exit main

--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -389,7 +389,7 @@ assert_equal '{ok: 3}', %q{
   end
 
   3.times.map{Ractor.receive}.tally
-} unless yjit_enabled? # `[BUG] Bus Error at 0x000000010b7002d0` in jit_exec()
+} unless yjit_enabled? || zjit_enabled? # YJIT: `[BUG] Bus Error at 0x000000010b7002d0` in jit_exec(), ZJIT hangs
 
 # unshareable object are copied
 assert_equal 'false', %q{


### PR DESCRIPTION
After https://github.com/ruby/ruby/pull/13773, this is the only test in `bootstraptest/test_ractor.rb` that doesn't work. It hangs and never finishes.

I haven't looked into how it ends up hanging, but given that it doesn't even work for YJIT, I'm tempted to skip it for now so that we can start running other test cases in `test_ractor.rb` on CI, leaving an issue to revisit it. WDYT?

We need both PRs to be merged to enable `bootstraptest/test_ractor.rb`, so I haven't modified the workflow yet. I'll make sure it's enabled before or after a second PR gets merged.