### PR TITLE
Downloader update

### DIFF
--- a/tool/downloader.rb
+++ b/tool/downloader.rb
@@ -20,13 +20,20 @@ class Downloader
   end
 
   class GNU < self
+    Mirrors = %w[
+      https://raw.githubusercontent.com/autotools-mirror/autoconf/refs/heads/master/build-aux/
+      https://cdn.jsdelivr.net/gh/gcc-mirror/gcc@master
+    ]
+
     def self.download(name, *rest, **options)
-      begin
-        super("https://cdn.jsdelivr.net/gh/gcc-mirror/gcc@master/#{name}", name, *rest, **options)
+      Mirrors.each_with_index do |url, i|
+        super("#{url}/#{name}", name, *rest, **options)
       rescue => e
+        raise if i + 1 == Mirrors.size # no more URLs
         m1, m2 = e.message.split("\n", 2)
         STDERR.puts "Download failed (#{m1}), try another URL\n#{m2}"
-        super("https://raw.githubusercontent.com/gcc-mirror/gcc/master/#{name}", name, *rest, **options)
+      else
+        return
       end
     end
   end

--- a/tool/downloader.rb
+++ b/tool/downloader.rb
@@ -191,13 +191,7 @@ class Downloader
     mtime = nil
     options = options.merge(http_options(file, since.nil? ? true : since))
     begin
-      data = with_retry(10) do
-        data = url.read(options)
-        if mtime = data.meta["last-modified"]
-          mtime = Time.httpdate(mtime)
-        end
-        data
-      end
+      data = with_retry(10) {url.read(options)}
     rescue OpenURI::HTTPError => http_error
       case http_error.message
       when /^304 / # 304 Not Modified
@@ -225,6 +219,10 @@ class Downloader
         return file.to_path
       end
       raise
+    else
+      if mtime = data.meta["last-modified"]
+        mtime = Time.httpdate(mtime)
+      end
     end
     dest = (cache_save && cache && !cache.exist? ? cache : file)
     dest.parent.mkpath


### PR DESCRIPTION
* Drop HTTP support

    The only use case is access to `repo.or.cz`, and it redirects HTTP requests to HTTPS now.

* Prefer autotools repository mirror for build-aux files

    gcc master still using 2021 version files.