### PR TITLE
ractor_sync.c: Optimize ractor_set_successor_once to be lock free

### DIFF
--- a/benchmark/lib/benchmark_driver/runner/ractor.rb
+++ b/benchmark/lib/benchmark_driver/runner/ractor.rb
@@ -87,7 +87,7 @@ __bmdv_ractors << Ractor.new(__bmdv_loop_after - __bmdv_loop_before) { |__bmdv_l
 <% end %>
 
 # Wait for all Ractors before executing code to write results
-__bmdv_ractors.map!(&:take)
+__bmdv_ractors.map!(&:value)
 
 <% results.each do |result| %>
 File.write(<%= result.dump %>, __bmdv_ractors.shift)

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -729,19 +729,9 @@ static rb_ractor_t *
 ractor_set_successor_once(rb_ractor_t *r, rb_ractor_t *cr)
 {
     if (r->sync.successor == NULL) {
-        RACTOR_LOCK(r);
-        {
-            if (r->sync.successor != NULL) {
-                // already `value`ed
-            }
-            else {
-                r->sync.successor = cr;
-            }
-        }
-        RACTOR_UNLOCK(r);
+        rb_ractor_t *successor = ATOMIC_PTR_CAS(r->sync.successor, NULL, cr);
+        return successor == NULL ? cr : successor;
     }
-
-    VM_ASSERT(r->sync.successor != NULL);
 
     return r->sync.successor;
 }


### PR DESCRIPTION
Use CAS instead, it's cheaper.

Benchmarking it is a bit complicated though, because either way it's quite cheap compared to allocating a new Ractor.
