### PR TITLE
ZJIT: Panic on BOP redefinition only when needed

### DIFF
--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -119,6 +119,7 @@ jobs:
           ../src/bootstraptest/test_flow.rb \
           ../src/bootstraptest/test_fork.rb \
           ../src/bootstraptest/test_gc.rb \
+          ../src/bootstraptest/test_insns.rb \
           ../src/bootstraptest/test_io.rb \
           ../src/bootstraptest/test_jump.rb \
           ../src/bootstraptest/test_literal.rb \
@@ -138,7 +139,6 @@ jobs:
           ../src/bootstraptest/test_yjit_30k_methods.rb \
           ../src/bootstraptest/test_yjit_rust_port.rb
         # ../src/bootstraptest/test_eval.rb \
-        # ../src/bootstraptest/test_insns.rb \
         # ../src/bootstraptest/test_yjit.rb \
         if: ${{ matrix.test_task == 'btest' }}
 

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -141,6 +141,7 @@ jobs:
           ../src/bootstraptest/test_flow.rb \
           ../src/bootstraptest/test_fork.rb \
           ../src/bootstraptest/test_gc.rb \
+          ../src/bootstraptest/test_insns.rb \
           ../src/bootstraptest/test_io.rb \
           ../src/bootstraptest/test_jump.rb \
           ../src/bootstraptest/test_literal.rb \
@@ -160,7 +161,6 @@ jobs:
           ../src/bootstraptest/test_yjit_30k_methods.rb \
           ../src/bootstraptest/test_yjit_rust_port.rb
         # ../src/bootstraptest/test_eval.rb \
-        # ../src/bootstraptest/test_insns.rb \
         # ../src/bootstraptest/test_yjit.rb \
         if: ${{ matrix.test_task == 'btest' }}
 

--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -815,6 +815,21 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 2
   end
 
+  def test_bop_invalidation
+    omit 'Invalidation on BOP redefinition is not implemented yet'
+    assert_compiles '', %q{
+      def test
+        eval(<<~RUBY)
+          class Integer
+            def +(_) = 100
+          end
+        RUBY
+        1 + 2
+      end
+      test
+    }
+  end
+
   def test_defined_yield
     assert_compiles "nil", "defined?(yield)"
     assert_compiles '[nil, nil, "yield"]', %q{

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -892,7 +892,6 @@ impl Assembler
         let mut pos_markers: Vec<(usize, CodePtr)> = vec![];
 
         // For each instruction
-        //let start_write_pos = cb.get_write_pos();
         let mut insn_idx: usize = 0;
         while let Some(insn) = self.insns.get(insn_idx) {
             //let src_ptr = cb.get_write_ptr();
@@ -1256,9 +1255,6 @@ impl Assembler
                     csel(cb, out.into(), truthy.into(), falsy.into(), Condition::GE);
                 }
                 Insn::LiveReg { .. } => (), // just a reg alloc signal, no code
-                Insn::PadInvalPatch => {
-                    unimplemented!("we haven't needed padding in ZJIT yet");
-                }
             };
 
             // On failure, jump to the next page and retry the current insn

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -484,10 +484,6 @@ pub enum Insn {
     // binary OR operation.
     Or { left: Opnd, right: Opnd, out: Opnd },
 
-    /// Pad nop instructions to accommodate Op::Jmp in case the block or the insn
-    /// is invalidated.
-    PadInvalPatch,
-
     // Mark a position in the generated code
     PosMarker(PosMarkerFn),
 
@@ -607,7 +603,6 @@ impl Insn {
             Insn::Mov { .. } => "Mov",
             Insn::Not { .. } => "Not",
             Insn::Or { .. } => "Or",
-            Insn::PadInvalPatch => "PadEntryExit",
             Insn::PosMarker(_) => "PosMarker",
             Insn::RShift { .. } => "RShift",
             Insn::Store { .. } => "Store",
@@ -801,7 +796,6 @@ impl<'a> Iterator for InsnOpndIterator<'a> {
             Insn::CPushAll |
             Insn::FrameSetup |
             Insn::FrameTeardown |
-            Insn::PadInvalPatch |
             Insn::PosMarker(_) => None,
 
             Insn::CPopInto(opnd) |
@@ -956,7 +950,6 @@ impl<'a> InsnOpndMutIterator<'a> {
             Insn::CPushAll |
             Insn::FrameSetup |
             Insn::FrameTeardown |
-            Insn::PadInvalPatch |
             Insn::PosMarker(_) => None,
 
             Insn::CPopInto(opnd) |
@@ -2169,10 +2162,6 @@ impl Assembler {
         let out = self.new_vreg(Opnd::match_num_bits(&[left, right]));
         self.push_insn(Insn::Or { left, right, out });
         out
-    }
-
-    pub fn pad_inval_patch(&mut self) {
-        self.push_insn(Insn::PadInvalPatch);
     }
 
     //pub fn pos_marker<F: FnMut(CodePtr)>(&mut self, marker_fn: F)

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -444,7 +444,6 @@ impl Assembler
         let mut pos_markers: Vec<(usize, CodePtr)> = vec![];
 
         // For each instruction
-        //let start_write_pos = cb.get_write_pos();
         let mut insn_idx: usize = 0;
         while let Some(insn) = self.insns.get(insn_idx) {
             //let src_ptr = cb.get_write_ptr();
@@ -795,15 +794,6 @@ impl Assembler
                     emit_csel(cb, *truthy, *falsy, *out, cmovge, cmovl);
                 }
                 Insn::LiveReg { .. } => (), // just a reg alloc signal, no code
-                Insn::PadInvalPatch => {
-                    unimplemented!("we don't need padding yet");
-                    /*
-                    let code_size = cb.get_write_pos().saturating_sub(std::cmp::max(start_write_pos, cb.page_start_pos()));
-                    if code_size < cb.jmp_ptr_bytes() {
-                        nop(cb, (cb.jmp_ptr_bytes() - code_size) as u32);
-                    }
-                    */
-                }
             };
 
             // On failure, jump to the next page and retry the current insn

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -1,6 +1,6 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use crate::{cruby::{ruby_basic_operators, IseqPtr, RedefinitionFlag}, state::ZJITState, state::zjit_enabled_p};
+use crate::{cruby::{ruby_basic_operators, IseqPtr, RedefinitionFlag}, state::{zjit_enabled_p, ZJITState}, virtualmem::CodePtr};
 
 /// Used to track all of the various block references that contain assumptions
 /// about the state of the virtual machine.
@@ -11,19 +11,28 @@ pub struct Invariants {
 
     /// Set of ISEQs whose JIT code assumes that it doesn't escape EP
     no_ep_escape_iseqs: HashSet<IseqPtr>,
+
+    /// Map from a class and its associated basic operator to a set of patch points
+    bop_patch_points: HashMap<(RedefinitionFlag, ruby_basic_operators), HashSet<CodePtr>>,
 }
 
 /// Called when a basic operator is redefined. Note that all the blocks assuming
 /// the stability of different operators are invalidated together and we don't
 /// do fine-grained tracking.
 #[unsafe(no_mangle)]
-pub extern "C" fn rb_zjit_bop_redefined(_klass: RedefinitionFlag, _bop: ruby_basic_operators) {
+pub extern "C" fn rb_zjit_bop_redefined(klass: RedefinitionFlag, bop: ruby_basic_operators) {
     // If ZJIT isn't enabled, do nothing
     if !zjit_enabled_p() {
         return;
     }
 
-    unimplemented!("Invalidation on BOP redefinition is not implemented yet");
+    let invariants = ZJITState::get_invariants();
+    if let Some(code_ptrs) = invariants.bop_patch_points.get(&(klass, bop)) {
+        // Invalidate all patch points for this BOP
+        for &ptr in code_ptrs {
+            unimplemented!("Invalidation on BOP redefinition is not implemented yet: {ptr:?}");
+        }
+    }
 }
 
 /// Invalidate blocks for a given ISEQ that assumes environment pointer is
@@ -56,4 +65,10 @@ pub fn track_no_ep_escape_assumption(iseq: IseqPtr) {
 /// Returns true if a given ISEQ has previously escaped environment pointer.
 pub fn iseq_escapes_ep(iseq: IseqPtr) -> bool {
     ZJITState::get_invariants().ep_escape_iseqs.contains(&iseq)
+}
+
+/// Track a patch point for a basic operator in a given class.
+pub fn track_bop_assumption(klass: RedefinitionFlag, bop: ruby_basic_operators, code_ptr: CodePtr) {
+    let invariants = ZJITState::get_invariants();
+    invariants.bop_patch_points.entry((klass, bop)).or_default().insert(code_ptr);
 }

--- a/zjit/src/virtualmem.rs
+++ b/zjit/src/virtualmem.rs
@@ -62,7 +62,7 @@ pub trait Allocator {
 
 /// Pointer into a [VirtualMemory] represented as an offset from the base.
 /// Note: there is no NULL constant for [CodePtr]. You should use `Option<CodePtr>` instead.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Debug)]
 #[repr(C, packed)]
 pub struct CodePtr(u32);
 


### PR DESCRIPTION
This PR changes `rb_zjit_bop_redefined` to panic only when JIT code relies on the BOP assumption while it used to panic whenever any BOP is redefined. It allows us to run `bootstraptest/test_insns.rb` without crashing.

It also removes LIR `Insn::PadInvalPatch` because the instruction's semantics don't seem useful when we're not doing block-level invalidation. I think we want to invalidate JIT code on HIR instruction boundaries, so padding nops based on the number of instructions from the beginning of the block seems useless.