### PR TITLE
Fix missing write barriers of imemo_fields in Ractor copy/move traversal

### DIFF
--- a/bootstraptest/test_ractor.rb
+++ b/bootstraptest/test_ractor.rb
@@ -1923,6 +1923,60 @@ assert_equal 'ok', %q{
   roundtripped_obj.instance_variable_get(:@array) == [1] ? :ok : roundtripped_obj
 }
 
+# move object with many generic ivars
+assert_equal 'ok', %q{
+  ractor = Ractor.new { Ractor.receive }
+  obj = Array.new(10, 42)
+  0.upto(300) do |i|
+    obj.instance_variable_set(:"@array#{i}", [i])
+  end
+
+  ractor.send(obj, move: true)
+  roundtripped_obj = ractor.value
+  roundtripped_obj.instance_variable_get(:@array1) == [1] ? :ok : roundtripped_obj
+}
+
+# move object with complex generic ivars
+assert_equal 'ok', %q{
+  # Make Array too_complex
+  30.times { |i| [].instance_variable_set(:"@complex#{i}", 1) }
+
+  ractor = Ractor.new { Ractor.receive }
+  obj = Array.new(10, 42)
+  obj.instance_variable_set(:@array1, [1])
+
+  ractor.send(obj, move: true)
+  roundtripped_obj = ractor.value
+  roundtripped_obj.instance_variable_get(:@array1) == [1] ? :ok : roundtripped_obj
+}
+
+# copy object with complex generic ivars
+assert_equal 'ok', %q{
+  # Make Array too_complex
+  30.times { |i| [].instance_variable_set(:"@complex#{i}", 1) }
+
+  ractor = Ractor.new { Ractor.receive }
+  obj = Array.new(10, 42)
+  obj.instance_variable_set(:@array1, [1])
+
+  ractor.send(obj)
+  roundtripped_obj = ractor.value
+  roundtripped_obj.instance_variable_get(:@array1) == [1] ? :ok : roundtripped_obj
+}
+
+# copy object with many generic ivars
+assert_equal 'ok', %q{
+  ractor = Ractor.new { Ractor.receive }
+  obj = Array.new(10, 42)
+  0.upto(300) do |i|
+    obj.instance_variable_set(:"@array#{i}", [i])
+  end
+
+  ractor.send(obj)
+  roundtripped_obj = ractor.value
+  roundtripped_obj.instance_variable_get(:@array1) == [1] ? :ok : roundtripped_obj
+}
+
 # moved composite types move their non-shareable parts properly
 assert_equal 'ok', %q{
   k, v = String.new("key"), String.new("value")

--- a/object.c
+++ b/object.c
@@ -363,7 +363,7 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
         dest_buf = ROBJECT_FIELDS(dest);
     }
 
-    rb_shape_copy_fields(dest, dest_buf, dest_shape_id, obj, src_buf, src_shape_id);
+    rb_shape_copy_fields(dest, dest_buf, dest_shape_id, src_buf, src_shape_id);
     rb_obj_set_shape_id(dest, dest_shape_id);
 }
 

--- a/ractor.c
+++ b/ractor.c
@@ -1653,10 +1653,10 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
         obj = replacement;
     }
 
-#define CHECK_AND_REPLACE(v) do { \
+#define CHECK_AND_REPLACE(parent_obj, v) do { \
     VALUE _val = (v); \
     if (obj_traverse_replace_i(_val, data)) { return 1; } \
-    else if (data->replacement != _val)     { RB_OBJ_WRITE(obj, &v, data->replacement); } \
+    else if (data->replacement != _val)     { RB_OBJ_WRITE(parent_obj, &v, data->replacement); } \
 } while (0)
 
     if (UNLIKELY(rb_obj_exivar_p(obj))) {
@@ -1681,7 +1681,7 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
             uint32_t fields_count = RSHAPE_LEN(RBASIC_SHAPE_ID(obj));
             VALUE *fields = rb_imemo_fields_ptr(fields_obj);
             for (uint32_t i = 0; i < fields_count; i++) {
-                CHECK_AND_REPLACE(fields[i]);
+                CHECK_AND_REPLACE(fields_obj, fields[i]);
             }
         }
     }
@@ -1720,7 +1720,7 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
                 VALUE *ptr = ROBJECT_FIELDS(obj);
 
                 for (uint32_t i = 0; i < len; i++) {
-                    CHECK_AND_REPLACE(ptr[i]);
+                    CHECK_AND_REPLACE(obj, ptr[i]);
                 }
             }
         }
@@ -1773,18 +1773,18 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
             const VALUE *ptr = RSTRUCT_CONST_PTR(obj);
 
             for (long i=0; i<len; i++) {
-                CHECK_AND_REPLACE(ptr[i]);
+                CHECK_AND_REPLACE(obj, ptr[i]);
             }
         }
         break;
 
       case T_RATIONAL:
-        CHECK_AND_REPLACE(RRATIONAL(obj)->num);
-        CHECK_AND_REPLACE(RRATIONAL(obj)->den);
+        CHECK_AND_REPLACE(obj, RRATIONAL(obj)->num);
+        CHECK_AND_REPLACE(obj, RRATIONAL(obj)->den);
         break;
       case T_COMPLEX:
-        CHECK_AND_REPLACE(RCOMPLEX(obj)->real);
-        CHECK_AND_REPLACE(RCOMPLEX(obj)->imag);
+        CHECK_AND_REPLACE(obj, RCOMPLEX(obj)->real);
+        CHECK_AND_REPLACE(obj, RCOMPLEX(obj)->imag);
         break;
 
       case T_DATA:

--- a/ractor.c
+++ b/ractor.c
@@ -1667,7 +1667,7 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
             struct obj_traverse_replace_callback_data d = {
                 .stop = false,
                 .data = data,
-                .src = obj,
+                .src = fields_obj,
             };
             rb_st_foreach_with_replace(
                 rb_imemo_fields_complex_tbl(fields_obj),

--- a/shape.c
+++ b/shape.c
@@ -1136,7 +1136,7 @@ rb_shape_rebuild(shape_id_t initial_shape_id, shape_id_t dest_shape_id)
 }
 
 void
-rb_shape_copy_fields(VALUE dest, VALUE *dest_buf, shape_id_t dest_shape_id, VALUE src, VALUE *src_buf, shape_id_t src_shape_id)
+rb_shape_copy_fields(VALUE dest, VALUE *dest_buf, shape_id_t dest_shape_id, VALUE *src_buf, shape_id_t src_shape_id)
 {
     rb_shape_t *dest_shape = RSHAPE(dest_shape_id);
     rb_shape_t *src_shape = RSHAPE(src_shape_id);

--- a/shape.h
+++ b/shape.h
@@ -217,7 +217,7 @@ shape_id_t rb_shape_object_id(shape_id_t original_shape_id);
 void rb_shape_free_all(void);
 
 shape_id_t rb_shape_rebuild(shape_id_t initial_shape_id, shape_id_t dest_shape_id);
-void rb_shape_copy_fields(VALUE dest, VALUE *dest_buf, shape_id_t dest_shape_id, VALUE src, VALUE *src_buf, shape_id_t src_shape_id);
+void rb_shape_copy_fields(VALUE dest, VALUE *dest_buf, shape_id_t dest_shape_id, VALUE *src_buf, shape_id_t src_shape_id);
 void rb_shape_copy_complex_ivars(VALUE dest, VALUE obj, shape_id_t src_shape_id, st_table *fields_table);
 
 static inline bool

--- a/variable.c
+++ b/variable.c
@@ -2355,6 +2355,7 @@ rb_replace_generic_ivar(VALUE clone, VALUE obj)
         st_data_t fields_tbl, obj_data = (st_data_t)obj;
         if (st_delete(generic_fields_tbl_, &obj_data, &fields_tbl)) {
             st_insert(generic_fields_tbl_, (st_data_t)clone, fields_tbl);
+            RB_OBJ_WRITTEN(clone, Qundef, fields_tbl);
         }
         else {
             rb_bug("unreachable");

--- a/variable.c
+++ b/variable.c
@@ -2331,7 +2331,7 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
         new_fields_obj = rb_imemo_fields_new(rb_obj_class(dest), RSHAPE_CAPACITY(dest_shape_id));
         VALUE *src_buf = rb_imemo_fields_ptr(fields_obj);
         VALUE *dest_buf = rb_imemo_fields_ptr(new_fields_obj);
-        rb_shape_copy_fields(dest, dest_buf, dest_shape_id, obj, src_buf, src_shape_id);
+        rb_shape_copy_fields(new_fields_obj, dest_buf, dest_shape_id, obj, src_buf, src_shape_id);
         RBASIC_SET_SHAPE_ID(new_fields_obj, dest_shape_id);
 
         RB_VM_LOCKING() {

--- a/variable.c
+++ b/variable.c
@@ -2331,7 +2331,7 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
         new_fields_obj = rb_imemo_fields_new(rb_obj_class(dest), RSHAPE_CAPACITY(dest_shape_id));
         VALUE *src_buf = rb_imemo_fields_ptr(fields_obj);
         VALUE *dest_buf = rb_imemo_fields_ptr(new_fields_obj);
-        rb_shape_copy_fields(new_fields_obj, dest_buf, dest_shape_id, obj, src_buf, src_shape_id);
+        rb_shape_copy_fields(new_fields_obj, dest_buf, dest_shape_id, src_buf, src_shape_id);
         RBASIC_SET_SHAPE_ID(new_fields_obj, dest_shape_id);
 
         RB_VM_LOCKING() {


### PR DESCRIPTION
Found by wbcheck. This fixes two cases where write barriers could be missed when Ractor copying/moving objects with generic fields.

* When we move a geniv object, the new object needs a write barrier because it gains a reference to the fields. (incremental GC could happen as during inserting the new key into the table)
* When we're copying a geniv object, the write barrier needs to come from the fields object rather than the object itself.

cc @byroot