### PR TITLE
ZJIT: Handle GCed objects in profiling data

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -915,6 +915,12 @@ class TestZJIT < Test::Unit::TestCase
     end
   end
 
+  def test_require_rubygems
+    assert_runs 'true', %q{
+      require 'rubygems'
+    }, call_threshold: 2
+  end
+
   private
 
   # Assert that every method call in `test_script` can be compiled by ZJIT

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -423,7 +423,7 @@ impl VALUE {
     }
 
     pub fn string_p(self) -> bool {
-        self.class_of() == unsafe { rb_cString }
+        self.class_of() == Some(unsafe { rb_cString })
     }
 
     /// Read the flags bits from the RBasic object, then return a Ruby type enum (e.g. RUBY_T_ARRAY)
@@ -440,14 +440,17 @@ impl VALUE {
         flags_bits
     }
 
-    pub fn class_of(self) -> VALUE {
+    pub fn class_of(self) -> Option<VALUE> {
         if !self.special_const_p() {
             let builtin_type = self.builtin_type();
-            assert_ne!(builtin_type, RUBY_T_NONE, "ZJIT should only see live objects");
-            assert_ne!(builtin_type, RUBY_T_MOVED, "ZJIT should only see live objects");
+            if builtin_type == RUBY_T_NONE || builtin_type == RUBY_T_MOVED {
+                // Objects observed during profiling cycles may have been GCed when we look at the
+                // profiling data on compilation. In that case, we can't know what the class was.
+                return None;
+            }
         }
 
-        unsafe { rb_yarv_class_of(self) }
+        Some(unsafe { rb_yarv_class_of(self) })
     }
 
     /// Check if `self` is a subclass of `other`. Assumes both `self` and `other` are class

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -128,21 +128,21 @@ impl std::fmt::Display for Type {
 
 fn is_array_exact(val: VALUE) -> bool {
     // Prism hides array values in the constant pool from the GC, so class_of will return 0
-    val.class_of() == unsafe { rb_cArray } || (val.class_of() == VALUE(0) && val.builtin_type() == RUBY_T_ARRAY)
+    val.class_of() == Some(unsafe { rb_cArray }) || (val.class_of() == Some(VALUE(0)) && val.builtin_type() == RUBY_T_ARRAY)
 }
 
 fn is_string_exact(val: VALUE) -> bool {
     // Prism hides string values in the constant pool from the GC, so class_of will return 0
-    val.class_of() == unsafe { rb_cString } || (val.class_of() == VALUE(0) && val.builtin_type() == RUBY_T_STRING)
+    val.class_of() == Some(unsafe { rb_cString }) || (val.class_of() == Some(VALUE(0)) && val.builtin_type() == RUBY_T_STRING)
 }
 
 fn is_hash_exact(val: VALUE) -> bool {
     // Prism hides hash values in the constant pool from the GC, so class_of will return 0
-    val.class_of() == unsafe { rb_cHash } || (val.class_of() == VALUE(0) && val.builtin_type() == RUBY_T_HASH)
+    val.class_of() == Some(unsafe { rb_cHash }) || (val.class_of() == Some(VALUE(0)) && val.builtin_type() == RUBY_T_HASH)
 }
 
 fn is_range_exact(val: VALUE) -> bool {
-    val.class_of() == unsafe { rb_cRange }
+    val.class_of() == Some(unsafe { rb_cRange })
 }
 
 impl Type {
@@ -176,13 +176,13 @@ impl Type {
             // valid on imemo.
             Type { bits: bits::CallableMethodEntry, spec: Specialization::Object(val) }
         }
-        else if val.class_of() == unsafe { rb_cInteger } {
+        else if val.class_of() == Some(unsafe { rb_cInteger }) {
             Type { bits: bits::Bignum, spec: Specialization::Object(val) }
         }
-        else if val.class_of() == unsafe { rb_cFloat } {
+        else if val.class_of() == Some(unsafe { rb_cFloat }) {
             Type { bits: bits::HeapFloat, spec: Specialization::Object(val) }
         }
-        else if val.class_of() == unsafe { rb_cSymbol } {
+        else if val.class_of() == Some(unsafe { rb_cSymbol }) {
             Type { bits: bits::DynamicSymbol, spec: Specialization::Object(val) }
         }
         else if is_array_exact(val) {
@@ -197,13 +197,13 @@ impl Type {
         else if is_string_exact(val) {
             Type { bits: bits::StringExact, spec: Specialization::Object(val) }
         }
-        else if val.class_of() == unsafe { rb_cRegexp } {
+        else if val.class_of() == Some(unsafe { rb_cRegexp }) {
             Type { bits: bits::RegexpExact, spec: Specialization::Object(val) }
         }
-        else if val.class_of() == unsafe { rb_cSet } {
+        else if val.class_of() == Some(unsafe { rb_cSet }) {
             Type { bits: bits::SetExact, spec: Specialization::Object(val) }
         }
-        else if val.class_of() == unsafe { rb_cObject } {
+        else if val.class_of() == Some(unsafe { rb_cObject }) {
             Type { bits: bits::ObjectExact, spec: Specialization::Object(val) }
         }
         else {
@@ -371,7 +371,7 @@ impl Type {
     pub fn exact_ruby_class(&self) -> Option<VALUE> {
         match self.spec {
             // If we're looking at a precise object, we can pull out its class.
-            Specialization::Object(val) => Some(val.class_of()),
+            Specialization::Object(val) => val.class_of(),
             Specialization::TypeExact(val) => Some(val),
             _ => None,
         }
@@ -382,7 +382,7 @@ impl Type {
     pub fn inexact_ruby_class(&self) -> Option<VALUE> {
         match self.spec {
             // If we're looking at a precise object, we can pull out its class.
-            Specialization::Object(val) => Some(val.class_of()),
+            Specialization::Object(val) => val.class_of(),
             Specialization::TypeExact(val) | Specialization::Type(val) => Some(val),
             _ => None,
         }


### PR DESCRIPTION
This PR fixes a crash in `VALUE::class_of()`. It allows us to run some micro-benchmarks on yjit-bench's default harness.

The assertions were copied from YJIT, and that was valid for YJIT because it only looks at objects that are on stack during compilation. However, it's not necessarily the case for ZJIT because it looks at objects collected in past profiling cycles, which could be GC-ed. So they could be freed or moved in ZJIT.