### PR TITLE
Revert "Add locks around accesses/modifications to global encodings table"

### DIFF
--- a/test/ruby/test_encoding.rb
+++ b/test/ruby/test_encoding.rb
@@ -144,9 +144,7 @@ class TestEncoding < Test::Unit::TestCase
       rs = []
       100.times do
         rs << Ractor.new do
-          10_000.times do
-            "abc".force_encoding(Encoding.list.shuffle.first)
-          end
+          "abc".force_encoding(Encoding.list.shuffle.first)
         end
       end
       while rs.any?

--- a/test/ruby/test_encoding.rb
+++ b/test/ruby/test_encoding.rb
@@ -136,22 +136,4 @@ class TestEncoding < Test::Unit::TestCase
       assert "[Bug #19562]"
     end;
   end
-
-  def test_ractor_force_encoding_parallel
-    assert_ractor("#{<<~"begin;"}\n#{<<~'end;'}")
-    begin;
-      $-w = nil
-      rs = []
-      100.times do
-        rs << Ractor.new do
-          "abc".force_encoding(Encoding.list.shuffle.first)
-        end
-      end
-      while rs.any?
-        r, _obj = Ractor.select(*rs)
-        rs.delete(r)
-      end
-      assert rs.empty?
-    end;
-  end
 end


### PR DESCRIPTION
Reverts ruby/ruby#13600

We are seeing failures on CI, so may want to revert this for now