### PR TITLE
encoding.c: Acquire VM lock around `require_silent_safe`

### DIFF
--- a/load.c
+++ b/load.c
@@ -372,6 +372,8 @@ features_index_add_single(vm_ns_t *vm_ns, const char* str, size_t len, VALUE off
 static void
 features_index_add(vm_ns_t *vm_ns, VALUE feature, VALUE offset)
 {
+    RUBY_ASSERT(rb_ractor_main_p());
+
     const char *feature_str, *feature_end, *ext, *p;
     bool rb = false;
 

--- a/load.c
+++ b/load.c
@@ -1525,6 +1525,10 @@ require_internal(rb_execution_context_t *ec, VALUE fname, int exception, bool wa
 int
 rb_require_internal_silent(VALUE fname)
 {
+    if (!rb_ractor_main_p()) {
+        return NUM2INT(rb_ractor_require(fname, true));
+    }
+
     rb_execution_context_t *ec = GET_EC();
     return require_internal(ec, fname, 1, false);
 }
@@ -1561,7 +1565,7 @@ rb_require_string_internal(VALUE fname, bool resurrect)
     // main ractor check
     if (!rb_ractor_main_p()) {
         if (resurrect) fname = rb_str_resurrect(fname);
-        return rb_ractor_require(fname);
+        return rb_ractor_require(fname, false);
     }
     else {
         int result = require_internal(ec, fname, 1, RTEST(ruby_verbose));

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -134,7 +134,7 @@ void rb_ractor_terminate_all(void);
 bool rb_ractor_main_p_(void);
 void rb_ractor_atfork(rb_vm_t *vm, rb_thread_t *th);
 void rb_ractor_terminate_atfork(rb_vm_t *vm, rb_ractor_t *th);
-VALUE rb_ractor_require(VALUE feature);
+VALUE rb_ractor_require(VALUE feature, bool silent);
 VALUE rb_ractor_autoload_load(VALUE space, ID id);
 
 VALUE rb_ractor_ensure_shareable(VALUE obj, VALUE name);


### PR DESCRIPTION
`require_silent_safe` calls into `features_index_add` and a few other routines that need to be synchronized.

There are other Ractor related concerns with autoloaded encodings but this one is the biggest.

```ruby
def assert(bool)
  raise "fail" unless bool
end

$-w = nil
rs = []
100.times do
  rs << Ractor.new do
    "abc".force_encoding(Encoding.list.shuffle.first)
  end
end
while rs.any?
  r, _obj = Ractor.select(*rs)
  rs.delete(r)
end
assert rs.empty?
```

On master this fails with:

```
../st.c:795: Assertion Failed: rebuild_table_with:new_tab->num_entries == tab->num_entrie

    frame #5: 0x0000000100120d14 ruby`rb_assert_failure(file="../st.c", line=795, name="rebuild_table_with", expr="new_tab->num_entries == tab->num_entries") at error.c:1191:5
    frame #6: 0x000000010035c5f8 ruby`rebuild_table_with(new_tab=0x0000600000e04b40, tab=0x0000600000e125c0) at st.c:795:5
    frame #7: 0x000000010035e948 ruby`rebuild_table(tab=0x0000600000e125c0) at st.c:755:9
    frame #8: 0x00000001003596b0 ruby`rebuild_table_if_necessary(tab=0x0000600000e125c0) at st.c:1125:9
    frame #9: 0x0000000100359b2c ruby`st_add_direct_with_hash(tab=0x0000600000e125c0, key=16093565924368724757, value=15, hash=16236907536934075596) at st.c:1187:5
    frame #10: 0x000000010035ace8 ruby`rb_st_update(tab=0x0000600000e125c0, key=16093565924368724757, func=(ruby`features_index_add_single_callback at load.c:283), arg=4753754832) at st.c:1511:13
    frame #11: 0x00000001001e4d04 ruby`features_index_add_single(vm_ns=0x000000011b588e30, str="enc/encdb.bundle", len=16, offset=15, rb=false) at load.c:361:5
    frame #12: 0x00000001001e496c ruby`features_index_add(vm_ns=0x000000011b588e30, feature=4741083552, offset=15) at load.c:399:9
    frame #13: 0x00000001001e45a8 ruby`get_loaded_features_index(vm_ns=0x000000011b588e30) at load.c:455:13
    frame #14: 0x00000001001df2e0 ruby`rb_provide_feature(vm_ns=0x000000011b588e30, feature=5288623440) at load.c:754:5
    frame #15: 0x00000001001e13d0 ruby`require_internal(ec=0x000000014f842cd0, fname=5288623536, exception=1, warn=false) at load.c:1509:9
    frame #16: 0x00000001001e0bfc ruby`rb_require_internal_silent(fname=5288623536) at load.c:1527:12
    frame #17: 0x00000001000f5270 ruby`load_encoding(name="CP949") at encoding.c:746:14
    frame #18: 0x00000001000f4f80 ruby`rb_enc_autoload(enc=0x000060000293ca20) at encoding.c:797:13
    frame #19: 0x00000001000f91dc ruby`check_encoding(enc=0x000060000293ca20) at encoding.c:205:17
```