### PR TITLE
Add Enumerable#join_map for efficient map and join

### DIFF
--- a/test/ruby/test_enum.rb
+++ b/test/ruby/test_enum.rb
@@ -1337,6 +1337,36 @@ class TestEnumerable < Test::Unit::TestCase
     assert_instance_of(Enumerator, @obj.filter_map)
   end
 
+  def test_join_map
+    @obj = [1, 2, 3]
+    assert_equal("2,4,6", @obj.join_map(",") { |n| n * 2 })
+    assert_equal("246", @obj.join_map { |n| n * 2 })
+    assert_equal("1|2|3", @obj.join_map("|") { |n| n })
+    assert_instance_of(Enumerator, @obj.join_map)
+    assert_instance_of(Enumerator, @obj.join_map(","))
+
+    @obj = %w[foo bar baz]
+    assert_equal("FOO-BAR-BAZ", @obj.join_map("-", &:upcase))
+    assert_equal("foo, bar, baz", @obj.join_map(", ") { |s| s })
+
+    @obj = []
+    assert_equal("", @obj.join_map(",") { |x| x })
+    assert_equal("", @obj.join_map { |x| x })
+
+    @obj = (1..5)
+    assert_equal("1-2-3-4-5", @obj.join_map("-") { |n| n })
+    assert_equal("2:4:6:8:10", @obj.join_map(":") { |n| n * 2 })
+
+    @obj = {foo: 0, bar: 1, baz: 2}
+    assert_equal("foo=0|bar=1|baz=2", @obj.join_map("|") { |k, v| "#{k}=#{v}" })
+
+    @obj = [1, nil, 3, nil, 5]
+    assert_equal("1,,3,,5", @obj.join_map(",") { |x| x })
+
+    @obj = [false, true, nil, 0, ""]
+    assert_equal("false true  0 ", @obj.join_map(" ") { |x| x })
+  end
+
   def test_ruby_svar
     klass = Class.new do
       include Enumerable


### PR DESCRIPTION
## Summary

This PR adds `Enumerable#join_map` method that combines mapping and joining operations in a single pass through the enumerable.

Implements [Feature #21386](https://bugs.ruby-lang.org/issues/21386)

## Motivation

The current pattern of `.map { ... }.join(sep)` is:
- Repetitive across Ruby codebases
- Inefficient due to intermediate array creation
- Could be more idiomatic

## Usage

```ruby
# Basic usage
[1, 2, 3].join_map(",") { |n| n * 2 }  # => "2,4,6"

# With objects
users = [{name: "Alice"}, {name: "Bob"}]
users.join_map(", ") { |u| u[:name] }  # => "Alice, Bob"

# Default separator is empty string
(1..3).join_map { |n| n }  # => "123"
```

## Performance

Benchmarks show consistent 28-30% performance improvement:

```
Array Size | map{}.join (ms) | join_map (ms) | Improvement
------------------------------------------------------------
10         |          0.0015 |        0.0012 |       23.2%
100        |          0.0123 |        0.0088 |       28.6%
1000       |          0.1211 |        0.0866 |       28.5%
10000      |          1.2275 |        0.8531 |       30.5%
```

I haven't committed the benchmark code, but please let me know if I should do that.