### PR TITLE
Remove LIKELY macro for Universal Parser

### DIFF
--- a/universal_parser.c
+++ b/universal_parser.c
@@ -13,7 +13,6 @@
 #include "ruby/backward/2/inttypes.h"
 #include "probes.h"
 
-#define LIKELY(x) RB_LIKELY(x)
 #define UNLIKELY(x) RB_UNLIKELY(x)
 #ifndef TRUE
 # define TRUE    1


### PR DESCRIPTION
Ruby Parser not used LIKELY macro.
So, can remove it.