### PR TITLE
ZJIT: Avoid double negative in Mem debug

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -45,7 +45,7 @@ impl fmt::Debug for Mem {
         write!(fmt, "Mem{}[{:?}", self.num_bits, self.base)?;
         if self.disp != 0 {
             let sign = if self.disp > 0 { '+' } else { '-' };
-            write!(fmt, " {sign} {}", self.disp)?;
+            write!(fmt, " {sign} {}", self.disp.abs())?;
         }
 
         write!(fmt, "]")


### PR DESCRIPTION
Prior to this commit the debug output for negative offsets would look like:

```
Mem64[Reg(3) - -8]
```

That makes it look like we're adding instead of subtracting. After this commit we'll print:

```
Mem64[Reg(3) - 8]
```