### PR TITLE
Autoload encodings on the main ractor

### DIFF
--- a/ractor_core.h
+++ b/ractor_core.h
@@ -134,7 +134,7 @@ void rb_ractor_terminate_all(void);
 bool rb_ractor_main_p_(void);
 void rb_ractor_atfork(rb_vm_t *vm, rb_thread_t *th);
 void rb_ractor_terminate_atfork(rb_vm_t *vm, rb_ractor_t *th);
-VALUE rb_ractor_require(VALUE feature);
+VALUE rb_ractor_require(VALUE feature, bool silent);
 VALUE rb_ractor_autoload_load(VALUE space, ID id);
 
 VALUE rb_ractor_ensure_shareable(VALUE obj, VALUE name);


### PR DESCRIPTION
Superseeds: https://github.com/ruby/ruby/pull/13788

None of the datastructures involved in the require process are safe to call on a secondary ractor, however when autoloading encodings, we do so from the current ractor.

So all sorts of corruption can happen when using an autoloaded encoding for the first time from a secondary ractor.