### PR TITLE
Allow concurrent use of system(), IO.popen and Process.spawn in ractors

### DIFF
--- a/process.c
+++ b/process.c
@@ -4010,6 +4010,7 @@ retry_fork_async_signal_safe(struct rb_process_status *status, int *ep,
 
     while (1) {
         prefork();
+        rb_thread_acquire_fork_lock();
         disable_child_handler_before_fork(&old);
 #ifdef HAVE_WORKING_VFORK
         if (!has_privilege())
@@ -4036,6 +4037,7 @@ retry_fork_async_signal_safe(struct rb_process_status *status, int *ep,
         }
         err = errno;
         disable_child_handler_fork_parent(&old);
+        rb_thread_release_fork_lock();
         if (0 < pid) /* fork succeed, parent process */
             return pid;
         /* fork failed */


### PR DESCRIPTION
These ruby methods call `fork` or `vfork` internally, so we need to grab the fork lock in the parent and release it after the call. We don't reset the lock in the child because we're going to exec right after anyway. Without this lock, strange things were happening having to do with the timer thread. Sometimes multiple timers were running.