### PR TITLE
ZJIT: Fix Rust warnings

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3147,7 +3147,7 @@ mod validation_tests {
     fn one_block_no_terminator() {
         let mut function = Function::new(std::ptr::null());
         let entry = function.entry_block;
-        let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
+        function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
         assert_matches_err(function.validate(), ValidationError::BlockHasNoTerminator(format!("{:?}", function), entry));
     }
 
@@ -3166,7 +3166,6 @@ mod validation_tests {
         let mut function = Function::new(std::ptr::null());
         let entry = function.entry_block;
         let side = function.new_block();
-        let exit = function.new_block();
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(entry, Insn::IfTrue { val, target: BranchEdge { target: side, args: vec![val, val, val] } });
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(format!("{:?}", function), entry, 0, 3));
@@ -3177,7 +3176,6 @@ mod validation_tests {
         let mut function = Function::new(std::ptr::null());
         let entry = function.entry_block;
         let side = function.new_block();
-        let exit = function.new_block();
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(entry, Insn::IfFalse { val, target: BranchEdge { target: side, args: vec![val, val, val] } });
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(format!("{:?}", function), entry, 0, 3));
@@ -3188,7 +3186,6 @@ mod validation_tests {
         let mut function = Function::new(std::ptr::null());
         let entry = function.entry_block;
         let side = function.new_block();
-        let exit = function.new_block();
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(entry, Insn::Jump ( BranchEdge { target: side, args: vec![val, val, val] } ));
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(format!("{:?}", function), entry, 0, 3));


### PR DESCRIPTION
```
warning: unused variable: `val`
    --> zjit/src/hir.rs:3150:13
     |
3150 |         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
     |             ^^^ help: if this is intentional, prefix it with an underscore: `_val`
     |
     = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `exit`
    --> zjit/src/hir.rs:3169:13
     |
3169 |         let exit = function.new_block();
     |             ^^^^ help: if this is intentional, prefix it with an underscore: `_exit`

warning: unused variable: `exit`
    --> zjit/src/hir.rs:3180:13
     |
3180 |         let exit = function.new_block();
     |             ^^^^ help: if this is intentional, prefix it with an underscore: `_exit`

warning: unused variable: `exit`
    --> zjit/src/hir.rs:3191:13
     |
3191 |         let exit = function.new_block();
     |  
```