### PR TITLE
Skip test_rm_r_no_permissions test under root

### DIFF
--- a/test/fileutils/test_fileutils.rb
+++ b/test/fileutils/test_fileutils.rb
@@ -769,7 +769,7 @@ class TestFileUtils < Test::Unit::TestCase
   def test_rm_r_no_permissions
     check_singleton :rm_rf
 
-    return if /mswin|mingw/ =~ RUBY_PLATFORM
+    return if Process.uid == 0 || /mswin|mingw/ =~ RUBY_PLATFORM
 
     mkdir 'tmpdatadir'
     touch 'tmpdatadir/tmpdata'


### PR DESCRIPTION
Skip the test_rm_r_no_permissions test under the root user, as deletion always succeeds.