### PR TITLE
Make `rb_enc_autoload_p` atomic

### DIFF
--- a/internal/encoding.h
+++ b/internal/encoding.h
@@ -11,7 +11,6 @@
 #include "ruby/ruby.h"          /* for ID */
 #include "ruby/encoding.h"      /* for rb_encoding */
 
-#define rb_enc_autoload_p(enc) (!rb_enc_mbmaxlen(enc))
 #define rb_is_usascii_enc(enc) ((enc) == rb_usascii_encoding())
 #define rb_is_ascii8bit_enc(enc) ((enc) == rb_ascii8bit_encoding())
 #define rb_is_locale_enc(enc) ((enc) == rb_locale_encoding())
@@ -24,6 +23,7 @@ rb_encoding *rb_enc_check_str(VALUE str1, VALUE str2);
 int rb_encdb_replicate(const char *alias, const char *orig);
 int rb_encdb_alias(const char *alias, const char *orig);
 int rb_enc_autoload(rb_encoding *enc);
+bool rb_enc_autoload_p(rb_encoding *enc);
 int rb_encdb_dummy(const char *name);
 void rb_encdb_declare(const char *name);
 void rb_enc_set_base(const char *name, const char *orig);


### PR DESCRIPTION
 Using `encoding->max_enc_len` as a way to check if the encoding has been loaded isn't atomic, because it's not atomically set last.
    
Instead we can use a dedicated atomic value inside the encoding table.