### PR TITLE
Remove accidentally committed method Module.gccct_clear_table

### DIFF
--- a/vm_eval.c
+++ b/vm_eval.c
@@ -2886,7 +2886,6 @@ Init_vm_eval(void)
     rb_define_method(rb_eUncaughtThrow, "value", uncaught_throw_value, 0);
     rb_define_method(rb_eUncaughtThrow, "to_s", uncaught_throw_to_s, 0);
 
-    rb_define_singleton_method(rb_cModule, "gccct_clear_table", rb_gccct_clear_table, 0);
     id_result = rb_intern_const("result");
     id_tag = rb_intern_const("tag");
     id_value = rb_intern_const("value");


### PR DESCRIPTION
This was probably meant to be only for debugging. It was introduced in the big namespace on read commit: 382645d440d