### PR TITLE
ZJIT: Implement patch points on BOP redefinition

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -973,6 +973,28 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 2
   end
 
+  def test_bop_redefinition
+    assert_runs '[3, :+, 100]', %q{
+      def test
+        1 + 2
+      end
+
+      test # profile opt_plus
+      [test, Integer.class_eval { def +(_) = 100 }, test]
+    }, call_threshold: 2
+  end
+
+  def test_bop_redefinition_with_adjacent_patch_points
+    assert_runs '[15, :+, 100]', %q{
+      def test
+        1 + 2 + 3 + 4 + 5
+      end
+
+      test # profile opt_plus
+      [test, Integer.class_eval { def +(_) = 100 }, test]
+    }, call_threshold: 2
+  end
+
   def test_module_name_with_guard_passes
     assert_compiles '"Integer"', %q{
       def test(mod)

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -112,7 +112,7 @@ impl CodeBlock {
     }
 
     /// Set the current write position from a pointer
-    fn set_write_ptr(&mut self, code_ptr: CodePtr) {
+    pub fn set_write_ptr(&mut self, code_ptr: CodePtr) {
         let pos = code_ptr.as_offset() - self.mem_block.borrow().start_ptr().as_offset();
         self.write_pos = pos.try_into().unwrap();
     }
@@ -246,6 +246,11 @@ impl CodeBlock {
         self.label_addrs.clear();
         self.label_names.clear();
         assert!(self.label_refs.is_empty());
+    }
+
+    /// Convert a Label to CodePtr
+    pub fn resolve_label(&self, label: Label) -> CodePtr {
+        self.get_ptr(self.label_addrs[label.0])
     }
 
     pub fn clear_labels(&mut self) {

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -1,6 +1,12 @@
-use std::collections::{HashMap, HashSet};
+use std::{collections::{HashMap, HashSet}};
 
-use crate::{cruby::{ruby_basic_operators, IseqPtr, RedefinitionFlag}, state::{zjit_enabled_p, ZJITState}, virtualmem::CodePtr};
+use crate::{backend::lir::{asm_comment, Assembler}, cruby::{ruby_basic_operators, src_loc, with_vm_lock, IseqPtr, RedefinitionFlag}, hir::{Invariant, PtrPrintMap}, options::debug, state::{zjit_enabled_p, ZJITState}, virtualmem::CodePtr};
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+struct Jump {
+    from: CodePtr,
+    to: CodePtr,
+}
 
 /// Used to track all of the various block references that contain assumptions
 /// about the state of the virtual machine.
@@ -13,7 +19,7 @@ pub struct Invariants {
     no_ep_escape_iseqs: HashSet<IseqPtr>,
 
     /// Map from a class and its associated basic operator to a set of patch points
-    bop_patch_points: HashMap<(RedefinitionFlag, ruby_basic_operators), HashSet<CodePtr>>,
+    bop_patch_points: HashMap<(RedefinitionFlag, ruby_basic_operators), HashSet<Jump>>,
 }
 
 /// Called when a basic operator is redefined. Note that all the blocks assuming
@@ -26,13 +32,26 @@ pub extern "C" fn rb_zjit_bop_redefined(klass: RedefinitionFlag, bop: ruby_basic
         return;
     }
 
-    let invariants = ZJITState::get_invariants();
-    if let Some(code_ptrs) = invariants.bop_patch_points.get(&(klass, bop)) {
-        // Invalidate all patch points for this BOP
-        for &ptr in code_ptrs {
-            unimplemented!("Invalidation on BOP redefinition is not implemented yet: {ptr:?}");
+    with_vm_lock(src_loc!(), || {
+        let invariants = ZJITState::get_invariants();
+        if let Some(jumps) = invariants.bop_patch_points.get(&(klass, bop)) {
+            let cb = ZJITState::get_code_block();
+
+            // Invalidate all patch points for this BOP
+            let bop = Invariant::BOPRedefined { klass, bop };
+            debug!("BOP is redefined: {}", bop.print(&PtrPrintMap::identity()));
+            for jump in jumps {
+                cb.with_write_ptr(jump.from, |cb| {
+                    let mut asm = Assembler::new();
+                    asm_comment!(asm, "BOP redefined: {}", bop.print(&PtrPrintMap::identity()));
+                    asm.jmp(jump.to.into());
+                    asm.compile(cb).expect("can write existing code");
+                });
+            }
+
+            cb.mark_all_executable();
         }
-    }
+    });
 }
 
 /// Invalidate blocks for a given ISEQ that assumes environment pointer is
@@ -68,7 +87,15 @@ pub fn iseq_escapes_ep(iseq: IseqPtr) -> bool {
 }
 
 /// Track a patch point for a basic operator in a given class.
-pub fn track_bop_assumption(klass: RedefinitionFlag, bop: ruby_basic_operators, code_ptr: CodePtr) {
+pub fn track_bop_assumption(
+    klass: RedefinitionFlag,
+    bop: ruby_basic_operators,
+    patch_point_ptr: CodePtr,
+    side_exit_ptr: CodePtr
+) {
     let invariants = ZJITState::get_invariants();
-    invariants.bop_patch_points.entry((klass, bop)).or_default().insert(code_ptr);
+    invariants.bop_patch_points.entry((klass, bop)).or_default().insert(Jump {
+        from: patch_point_ptr,
+        to: side_exit_ptr,
+    });
 }

--- a/zjit/src/state.rs
+++ b/zjit/src/state.rs
@@ -3,7 +3,7 @@ use crate::cruby_methods;
 use crate::invariants::Invariants;
 use crate::options::Options;
 use crate::asm::CodeBlock;
-use crate::backend::lir::{Assembler, C_RET_OPND};
+use crate::backend::lir::{asm_comment, Assembler, C_RET_OPND};
 use crate::virtualmem::CodePtr;
 
 #[allow(non_upper_case_globals)]
@@ -141,6 +141,7 @@ impl ZJITState {
     /// Generate a trampoline to propagate a callee's side exit to the caller
     fn gen_exit_trampoline(cb: &mut CodeBlock) -> Option<CodePtr> {
         let mut asm = Assembler::new();
+        asm_comment!(asm, "ZJIT exit trampoline");
         asm.frame_teardown();
         asm.cret(C_RET_OPND);
         asm.compile(cb).map(|(start_ptr, _)| start_ptr)


### PR DESCRIPTION
This PR compiles a side exit for patch points and rewrites them with a jump to the side exit on BOP redefinition.

To make sure these jump instructions overwrite each other, nop instructions are generated in between them. When multiple adjacent patch points have the same FrameState, we could merge them together to reduce the number of nop instructions, but it's out of scope in this PR.