### PR TITLE
ZJIT: Print a message about ZJIT_RB_BUG when unused

### DIFF
--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -860,6 +860,8 @@ pub fn rb_bug_panic_hook() {
             let panic_message = &format!("{}", panic_info)[..];
             let len = std::cmp::min(0x100, panic_message.len()) as c_int;
             unsafe { rb_bug(b"ZJIT: %*s\0".as_ref().as_ptr() as *const c_char, len, panic_message.as_ptr()); }
+        } else {
+            eprintln!("note: run with `ZJIT_RB_BUG=1` environment variable to display a Ruby backtrace");
         }
     }));
 }


### PR DESCRIPTION
This PR improves a message of the panic hook https://github.com/Shopify/zjit/pull/43.

When Rust panics on non-release builds, we do not show Rust and Ruby backtraces by default. You need to give `RUST_BACKTRACE=1` and/or `ZJIT_RB_BUG=1` to turn on each of them. The `RUST_BACKTRACE=1` is already instructed in the panic message, but `ZJIT_RB_BUG=1` isn't. So this PR changes it to print a message like:

```
thread '<unnamed>' panicked at zjit/src/codegen.rs:141:5:
...
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
note: run with `ZJIT_RB_BUG=1` environment variable to display a Ruby backtrace
ZJIT panicked while holding VM lock acquired at zjit/src/codegen.rs:86. Aborting...
```