### PR TITLE
ZJIT: Improve asm comments for side exits

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7,12 +7,7 @@ use crate::{
     cast::IntoUsize, cruby::*, options::{get_option, DumpHIR}, gc::{get_or_create_iseq_payload, IseqPayload}, state::ZJITState
 };
 use std::{
-    cell::RefCell,
-    collections::{HashMap, HashSet, VecDeque},
-    ffi::{c_int, c_void, CStr},
-    mem::{align_of, size_of},
-    ptr,
-    slice::Iter
+    cell::RefCell, collections::{HashMap, HashSet, VecDeque}, ffi::{c_int, c_void, CStr}, fmt::Display, mem::{align_of, size_of}, ptr, slice::Iter
 };
 use crate::hir_type::{Type, types};
 use crate::bitset::BitSet;
@@ -145,6 +140,12 @@ pub enum Invariant {
 impl Invariant {
     pub fn print(self, ptr_map: &PtrPrintMap) -> InvariantPrinter {
         InvariantPrinter { inner: self, ptr_map }
+    }
+}
+
+impl Display for Invariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.print(&PtrPrintMap::identity()).fmt(f)
     }
 }
 
@@ -402,11 +403,18 @@ impl PtrPrintMap {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum SideExitReason {
     UnknownNewarraySend(vm_opt_newarray_send_type),
     UnknownCallType,
     UnknownOpcode(u32),
+    FixnumAddOverflow,
+    FixnumSubOverflow,
+    FixnumMultOverflow,
+    GuardTypeFixnum,
+    GuardTypeClassExact,
+    GuardBitEquals,
+    PatchPoint(Invariant),
 }
 
 impl std::fmt::Display for SideExitReason {
@@ -419,6 +427,7 @@ impl std::fmt::Display for SideExitReason {
             SideExitReason::UnknownNewarraySend(VM_OPT_NEWARRAY_SEND_PACK) => write!(f, "UnknownNewarraySend(PACK)"),
             SideExitReason::UnknownNewarraySend(VM_OPT_NEWARRAY_SEND_PACK_BUFFER) => write!(f, "UnknownNewarraySend(PACK_BUFFER)"),
             SideExitReason::UnknownNewarraySend(VM_OPT_NEWARRAY_SEND_INCLUDE_P) => write!(f, "UnknownNewarraySend(INCLUDE_P)"),
+            SideExitReason::PatchPoint(invariant) => write!(f, "PatchPoint({invariant})"),
             _ => write!(f, "{self:?}"),
         }
     }


### PR DESCRIPTION
This PR adds a `SideExitReason` asm comment to every side exit.

example:

```asm
  # Block: bb0(v0)
  # Insn: v2 Const Value(1)
  # Insn: v3 Const Value(2)
  # Insn: v7 PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
  # Insn: v9 Const Value(3)
  # Insn: v6 Return v9
  # pop stack frame
  0x6260b3064084: add r13, 0x38
  0x6260b3064088: mov qword ptr [r12 + 0x10], r13
  0x6260b306408d: mov eax, 7
  0x6260b3064092: ret
  # Exit: PatchPoint(BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS))
  # write stack slots: [3_u64, 5_u64]
  0x6260b3064093: mov qword ptr [rbx], 3
  0x6260b306409a: mov qword ptr [rbx + 8], 5
  # write locals: []
  # save cfp->pc
  0x6260b30640a2: movabs r11, 0x6260e5525208
  0x6260b30640ac: mov qword ptr [r13], r11
  # save cfp->sp
  0x6260b30640b0: lea r11, [rbx + 0x10]
  0x6260b30640b4: mov qword ptr [r13 + 8], r11
  # exit to the interpreter
  0x6260b30640b8: mov eax, 0x24
  0x6260b30640bd: ret
```
