### PR TITLE
Add Timeout message when bootstraptest times out

### DIFF
--- a/bootstraptest/runner.rb
+++ b/bootstraptest/runner.rb
@@ -625,6 +625,8 @@ class Assertion < Struct.new(:src, :path, :lineno, :proc)
     end
   end
 
+  class Timeout < StandardError; end
+
   def get_result_string(opt = '', timeout: BT.timeout, **argh)
     if BT.ruby
       timeout = BT.apply_timeout_scale(timeout)
@@ -634,7 +636,11 @@ class Assertion < Struct.new(:src, :path, :lineno, :proc)
         out = IO.popen("#{BT.ruby} -W0 #{opt} #{filename}", **kw)
         pid = out.pid
         th = Thread.new {out.read.tap {Process.waitpid(pid); out.close}}
-        th.value if th.join(timeout)
+        if th.join(timeout)
+          th.value
+        else
+          Timeout.new("timed out after #{timeout} seconds")
+        end
       ensure
         raise Interrupt if $? and $?.signaled? && $?.termsig == Signal.list["INT"]
 


### PR DESCRIPTION
I've often been a bit confused when btest times out (though we could assume that's what `nil` means). This makes it a bit more obvious, which should be nicer when diagnosing errors on CI

**Before:**

```
#1 test_sleep.rb:1:
   sleep(1000)
  #=> nil (expected "ok")
test_sleep.rb  FAIL 1/1
```

**After**

```
#1 test_sleep.rb:1:
   sleep(1000)
  #=> #<Assertion::Timeout: timed out after 180 seconds> (expected "ok")
test_sleep.rb  FAIL 1/1
```
