### PR TITLE
ZJIT: Mark objects baked in JIT code

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -973,6 +973,13 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 2
   end
 
+  def test_require_rubygems_with_auto_compact
+    assert_runs 'true', %q{
+      GC.auto_compact = true
+      require 'rubygems'
+    }, call_threshold: 2
+  end
+
   def test_bop_redefinition
     assert_runs '[3, :+, 100]', %q{
       def test

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -106,6 +106,10 @@ impl CodeBlock {
         self.write_pos
     }
 
+    pub fn write_mem(&self, write_ptr: CodePtr, byte: u8) -> Result<(), WriteError> {
+        self.mem_block.borrow_mut().write_byte(write_ptr, byte)
+    }
+
     /// Get a (possibly dangling) direct pointer to the current write position
     pub fn get_write_ptr(&self) -> CodePtr {
         self.get_ptr(self.write_pos)

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1767,8 +1767,7 @@ impl Assembler
     /// Compile the instructions down to machine code.
     /// Can fail due to lack of code memory and inopportune code placement, among other reasons.
     #[must_use]
-    pub fn compile(self, cb: &mut CodeBlock) -> Option<(CodePtr, Vec<CodePtr>)>
-    {
+    pub fn compile(self, cb: &mut CodeBlock) -> Option<(CodePtr, Vec<CodePtr>)> {
         #[cfg(feature = "disasm")]
         let start_addr = cb.get_write_ptr();
         let alloc_regs = Self::get_alloc_regs();
@@ -1785,8 +1784,7 @@ impl Assembler
 
     /// Compile with a limited number of registers. Used only for unit tests.
     #[cfg(test)]
-    pub fn compile_with_num_regs(self, cb: &mut CodeBlock, num_regs: usize) -> (CodePtr, Vec<CodePtr>)
-    {
+    pub fn compile_with_num_regs(self, cb: &mut CodeBlock, num_regs: usize) -> (CodePtr, Vec<CodePtr>) {
         let mut alloc_regs = Self::get_alloc_regs();
         let alloc_regs = alloc_regs.drain(0..num_regs).collect();
         self.compile_with_regs(cb, alloc_regs).unwrap()

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1767,7 +1767,7 @@ impl Assembler
     /// Compile the instructions down to machine code.
     /// Can fail due to lack of code memory and inopportune code placement, among other reasons.
     #[must_use]
-    pub fn compile(self, cb: &mut CodeBlock) -> Option<(CodePtr, Vec<u32>)>
+    pub fn compile(self, cb: &mut CodeBlock) -> Option<(CodePtr, Vec<CodePtr>)>
     {
         #[cfg(feature = "disasm")]
         let start_addr = cb.get_write_ptr();
@@ -1785,7 +1785,7 @@ impl Assembler
 
     /// Compile with a limited number of registers. Used only for unit tests.
     #[cfg(test)]
-    pub fn compile_with_num_regs(self, cb: &mut CodeBlock, num_regs: usize) -> (CodePtr, Vec<u32>)
+    pub fn compile_with_num_regs(self, cb: &mut CodeBlock, num_regs: usize) -> (CodePtr, Vec<CodePtr>)
     {
         let mut alloc_regs = Self::get_alloc_regs();
         let alloc_regs = alloc_regs.drain(0..num_regs).collect();

--- a/zjit/src/gc.rs
+++ b/zjit/src/gc.rs
@@ -1,7 +1,7 @@
 // This module is responsible for marking/moving objects on GC.
 
 use std::ffi::c_void;
-use crate::{cruby::*, profile::IseqProfile, virtualmem::CodePtr};
+use crate::{cruby::*, profile::IseqProfile, state::ZJITState, virtualmem::CodePtr};
 
 /// This is all the data ZJIT stores on an ISEQ. We mark objects in this struct on GC.
 #[derive(Debug)]
@@ -12,12 +12,17 @@ pub struct IseqPayload {
     /// JIT code address of the first block
     pub start_ptr: Option<CodePtr>,
 
-    // TODO: Add references to GC offsets in JIT code
+    /// GC offsets of the JIT code. These are the addresses of objects that need to be marked.
+    pub gc_offsets: Vec<CodePtr>,
 }
 
 impl IseqPayload {
     fn new(iseq_size: u32) -> Self {
-        Self { profile: IseqProfile::new(iseq_size), start_ptr: None }
+        Self {
+            profile: IseqProfile::new(iseq_size),
+            start_ptr: None,
+            gc_offsets: vec![],
+        }
     }
 }
 
@@ -66,17 +71,65 @@ pub extern "C" fn rb_zjit_iseq_mark(payload: *mut c_void) {
         }
     };
 
+    // Mark objects retained by profiling instructions
     payload.profile.each_object(|object| {
-        // TODO: Implement `rb_zjit_iseq_update_references` and use `rb_gc_mark_movable`
-        unsafe { rb_gc_mark(object); }
+        unsafe { rb_gc_mark_movable(object); }
     });
 
-    // TODO: Mark objects in JIT code
+    // Mark objects baked in JIT code
+    let cb = ZJITState::get_code_block();
+    for &offset in payload.gc_offsets.iter() {
+        let value_ptr: *const u8 = offset.raw_ptr(cb);
+        // Creating an unaligned pointer is well defined unlike in C.
+        let value_ptr = value_ptr as *const VALUE;
+
+        unsafe {
+            let object = value_ptr.read_unaligned();
+            rb_gc_mark_movable(object);
+        }
+    }
 }
 
 /// GC callback for updating GC objects in the per-iseq payload.
+/// This is a mirror of [rb_zjit_iseq_mark].
 #[unsafe(no_mangle)]
-pub extern "C" fn rb_zjit_iseq_update_references(_payload: *mut c_void) {
-    // TODO: let `rb_zjit_iseq_mark` use `rb_gc_mark_movable`
-    // and update references using `rb_gc_location` here.
+pub extern "C" fn rb_zjit_iseq_update_references(payload: *mut c_void) {
+    let payload = if payload.is_null() {
+        return; // nothing to mark
+    } else {
+        // SAFETY: The GC takes the VM lock while marking, which
+        // we assert, so we should be synchronized and data race free.
+        //
+        // For aliasing, having the VM lock hopefully also implies that no one
+        // else has an overlapping &mut IseqPayload.
+        unsafe {
+            rb_assert_holding_vm_lock();
+            &mut *(payload as *mut IseqPayload)
+        }
+    };
+
+    // Move objects retained by profiling instructions
+    payload.profile.each_object_mut(|object| {
+        *object = unsafe { rb_gc_location(*object) };
+    });
+
+    // Move objects baked in JIT code
+    let cb = ZJITState::get_code_block();
+    for &offset in payload.gc_offsets.iter() {
+        let value_ptr: *const u8 = offset.raw_ptr(cb);
+        // Creating an unaligned pointer is well defined unlike in C.
+        let value_ptr = value_ptr as *const VALUE;
+
+        let object = unsafe { value_ptr.read_unaligned() };
+        let new_addr = unsafe { rb_gc_location(object) };
+
+        // Only write when the VALUE moves, to be copy-on-write friendly.
+        if new_addr != object {
+            for (byte_idx, &byte) in new_addr.as_u64().to_le_bytes().iter().enumerate() {
+                let byte_code_ptr = offset.add_bytes(byte_idx);
+                cb.write_mem(byte_code_ptr, byte).expect("patching existing code should be within bounds");
+            }
+        }
+    }
+    cb.mark_all_executable();
 }

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -288,9 +288,22 @@ impl Type {
         }
     }
 
-    /// Return a mutable reference to the object specialization, if any.
-    pub fn ruby_object_mut(&mut self) -> Option<&mut VALUE> {
+    /// Return a Ruby object that needs to be marked on GC.
+    /// This covers Type and TypeExact unlike ruby_object().
+    pub fn gc_object(&self) -> Option<VALUE> {
+        match self.spec {
+            Specialization::Type(val) |
+            Specialization::TypeExact(val) |
+            Specialization::Object(val) => Some(val),
+            _ => None,
+        }
+    }
+
+    /// Mutable version of gc_object().
+    pub fn gc_object_mut(&mut self) -> Option<&mut VALUE> {
         match &mut self.spec {
+            Specialization::Type(val) |
+            Specialization::TypeExact(val) |
             Specialization::Object(val) => Some(val),
             _ => None,
         }

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -288,6 +288,14 @@ impl Type {
         }
     }
 
+    /// Return a mutable reference to the object specialization, if any.
+    pub fn ruby_object_mut(&mut self) -> Option<&mut VALUE> {
+        match &mut self.spec {
+            Specialization::Object(val) => Some(val),
+            _ => None,
+        }
+    }
+
     pub fn unspecialized(&self) -> Self {
         Type { spec: Specialization::Any, ..*self }
     }

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -119,4 +119,15 @@ impl IseqProfile {
             }
         }
     }
+
+    /// Run a given callback with a mutable reference to every object in IseqProfile
+    pub fn each_object_mut(&mut self, callback: impl Fn(&mut VALUE)) {
+        for types in self.opnd_types.iter_mut() {
+            for opnd_type in types.iter_mut() {
+                if let Some(object) = opnd_type.ruby_object_mut() {
+                    callback(object);
+                }
+            }
+        }
+    }
 }

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -113,7 +113,7 @@ impl IseqProfile {
     pub fn each_object(&self, callback: impl Fn(VALUE)) {
         for types in &self.opnd_types {
             for opnd_type in types {
-                if let Some(object) = opnd_type.ruby_object() {
+                if let Some(object) = opnd_type.gc_object() {
                     callback(object);
                 }
             }
@@ -124,7 +124,7 @@ impl IseqProfile {
     pub fn each_object_mut(&mut self, callback: impl Fn(&mut VALUE)) {
         for types in self.opnd_types.iter_mut() {
             for opnd_type in types.iter_mut() {
-                if let Some(object) = opnd_type.ruby_object_mut() {
+                if let Some(object) = opnd_type.gc_object_mut() {
                     callback(object);
                 }
             }

--- a/zjit/src/virtualmem.rs
+++ b/zjit/src/virtualmem.rs
@@ -74,6 +74,13 @@ impl CodePtr {
         CodePtr(raw + bytes)
     }
 
+    /// Subtract bytes from the CodePtr
+    pub fn sub_bytes(self, bytes: usize) -> Self {
+        let CodePtr(raw) = self;
+        let bytes: u32 = bytes.try_into().unwrap();
+        CodePtr(raw.saturating_sub(bytes))
+    }
+
     /// Note that the raw pointer might be dangling if there hasn't
     /// been any writes to it through the [VirtualMemory] yet.
     pub fn raw_ptr(self, base: &impl CodePtrBase) -> *const u8 {


### PR DESCRIPTION
This PR updates `rb_zjit_iseq_mark` to mark objects in JIT code. It also implements `rb_zjit_iseq_update_references` to avoid pinning objects in `rb_zjit_iseq_mark`.

It was a TODO in YJIT that we want to use `CodePtr` instead of `u32` for GC offsets. So I updated `compile*()` functions to use `CodePtr`. While doing so, I noticed there's some leftover code for retrying YJIT's code layout switches. Because we no longer have the concept of code layout splitting, I cleaned up the code as well.