### PR TITLE
Make rb_concurrent_set_funcs const

### DIFF
--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -21,7 +21,7 @@ struct concurrent_set {
     rb_atomic_t size;
     unsigned int capacity;
     unsigned int deleted_entries;
-    struct rb_concurrent_set_funcs *funcs;
+    const struct rb_concurrent_set_funcs *funcs;
     struct concurrent_set_entry *entries;
 };
 
@@ -51,7 +51,7 @@ static const rb_data_type_t concurrent_set_type = {
 };
 
 VALUE
-rb_concurrent_set_new(struct rb_concurrent_set_funcs *funcs, int capacity)
+rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity)
 {
     struct concurrent_set *set;
     VALUE obj = TypedData_Make_Struct(0, struct concurrent_set, &concurrent_set_type, set);

--- a/internal/concurrent_set.h
+++ b/internal/concurrent_set.h
@@ -13,7 +13,7 @@ struct rb_concurrent_set_funcs {
     rb_concurrent_set_create_func create;
 };
 
-VALUE rb_concurrent_set_new(struct rb_concurrent_set_funcs *funcs, int capacity);
+VALUE rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity);
 VALUE rb_concurrent_set_find_or_insert(VALUE *set_obj_ptr, VALUE key, void *data);
 VALUE rb_concurrent_set_delete_by_identity(VALUE set_obj, VALUE key);
 void rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data);

--- a/string.c
+++ b/string.c
@@ -548,7 +548,7 @@ fstring_concurrent_set_create(VALUE str, void *data)
     return str;
 }
 
-static struct rb_concurrent_set_funcs fstring_concurrent_set_funcs = {
+static const struct rb_concurrent_set_funcs fstring_concurrent_set_funcs = {
     .hash = fstring_concurrent_set_hash,
     .cmp = fstring_concurrent_set_cmp,
     .create = fstring_concurrent_set_create,


### PR DESCRIPTION
We should never modify rb_concurrent_set_funcs during runtime, so we can make it const.