### PR TITLE
[Bug #21512] Socket.tcp_with_fast_fallback: Pass proper addr family to getaddrinfo

### DIFF
--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -704,7 +704,7 @@ class Socket < BasicSocket
 
     if resolving_family_names.size == 1
       family_name = resolving_family_names.first
-      addrinfos = Addrinfo.getaddrinfo(host, port, family_name, :STREAM, timeout: resolv_timeout)
+      addrinfos = Addrinfo.getaddrinfo(host, port, ADDRESS_FAMILIES[:family_name], :STREAM, timeout: resolv_timeout)
       resolution_store.add_resolved(family_name, addrinfos)
       hostname_resolution_result = nil
       hostname_resolution_notifier = nil


### PR DESCRIPTION
Addrinfo.getaddrinfo expects Socket::AF_INET or Socket::AF_INET6 as its third argument (family). However Socket.tcp_with_fast_fallback was incorrectly passing :ipv4 or :ipv6.

Repro:

```ruby
require 'socket'
Socket.tcp_with_fast_fallback('example.com', 80, '127.0.0.1')
```

Expected behavior: Returns a Socket object
Actual: Raises unknown socket domain: ipv4 (SocketError)