### PR TITLE
Use macos-15 as default macos CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,25 +26,25 @@ jobs:
       matrix:
         include:
           - test_task: check
-            os: macos-14
+            os: macos-15
           - test_task: check
-            os: macos-14
+            os: macos-15
             configure_args: '--with-gcc=gcc-14'
           - test_task: check
-            os: macos-14
+            os: macos-15
             configure_args: '--with-jemalloc --with-opt-dir=$(brew --prefix jemalloc)'
           - test_task: check
-            os: macos-14
+            os: macos-15
             configure_args: '--with-gmp'
           - test_task: test-all
             test_opts: --repeat-count=2
-            os: macos-14
-          - test_task: test-bundler-parallel
-            os: macos-14
-          - test_task: test-bundled-gems
-            os: macos-14
-          - test_task: check
             os: macos-15
+          - test_task: test-bundler-parallel
+            os: macos-15
+          - test_task: test-bundled-gems
+            os: macos-15
+          - test_task: check
+            os: macos-14
           - test_task: check
             os: macos-13
       fail-fast: false


### PR DESCRIPTION
We should use macos-15 with test options for platform issues of macos-14

https://github.com/ruby/ruby/actions/runs/16269652593/job/45933709903?pr=13875

```
    1) Error:
  URI::TestMailTo#test_email_regexp:
  Test::Unit::ProxyError: [100]: in 0.10464730909757938s (tmin: 0.0004060409999999959, tmax: 0.0008837090000000103, tbase: 0.010464730909757938)
      /Users/runner/work/ruby/ruby/src/test/uri/test_mailto.rb:227:in 'block (2 levels) in URI::TestMailTo#test_email_regexp'
      /Users/runner/work/ruby/ruby/src/test/uri/test_mailto.rb:227:in 'Integer#times'
      /Users/runner/work/ruby/ruby/src/test/uri/test_mailto.rb:227:in 'block in URI::TestMailTo#test_email_regexp'
```