### PR TITLE
Omit `test_email_regexp` with `--repeat-count=2`

### DIFF
--- a/test/uri/test_mailto.rb
+++ b/test/uri/test_mailto.rb
@@ -211,6 +211,9 @@ class URI::TestMailTo < Test::Unit::TestCase
   end
 
   def test_email_regexp
+    # CI with `make (test-all, --repeat-count=2, macos-14)` is failing now.
+    omit if Test::Unit::Runner.runner.options[:repeat_count].to_i > 0
+
     re = URI::MailTo::EMAIL_REGEXP
 
     repeat = 10


### PR DESCRIPTION
https://github.com/ruby/ruby/actions/runs/16269652593/job/45933709903?pr=13875

```
    1) Error:
  URI::TestMailTo#test_email_regexp:
  Test::Unit::ProxyError: [100]: in 0.10464730909757938s (tmin: 0.0004060409999999959, tmax: 0.0008837090000000103, tbase: 0.010464730909757938)
      /Users/runner/work/ruby/ruby/src/test/uri/test_mailto.rb:227:in 'block (2 levels) in URI::TestMailTo#test_email_regexp'
      /Users/runner/work/ruby/ruby/src/test/uri/test_mailto.rb:227:in 'Integer#times'
      /Users/runner/work/ruby/ruby/src/test/uri/test_mailto.rb:227:in 'block in URI::TestMailTo#test_email_regexp'
```