### PR TITLE
Update default gems with `-flto` support

### DIFF
--- a/ext/etc/extconf.rb
+++ b/ext/etc/extconf.rb
@@ -10,8 +10,30 @@ headers = []
 have_library("sun", "getpwnam")	# NIS (== YP) interface for IRIX 4
 have_func("uname((struct utsname *)NULL)", headers)
 have_func("getlogin")
-have_func("getpwent")
-have_func("getgrent")
+if have_func("getpwent")
+  have_struct_member('struct passwd', 'pw_gecos', 'pwd.h')
+  have_struct_member('struct passwd', 'pw_change', 'pwd.h')
+  have_struct_member('struct passwd', 'pw_quota', 'pwd.h')
+  if have_struct_member('struct passwd', 'pw_age', 'pwd.h')
+    case what_type?('struct passwd', 'pw_age', 'pwd.h')
+    when "string"
+      f = "safe_setup_str"
+    when "long long"
+      f = "LL2NUM"
+    else
+      f = "INT2NUM"
+    end
+    $defs.push("-DPW_AGE2VAL="+f)
+  end
+  have_struct_member('struct passwd', 'pw_class', 'pwd.h')
+  have_struct_member('struct passwd', 'pw_comment', 'pwd.h') unless /cygwin/ === RUBY_PLATFORM
+  have_struct_member('struct passwd', 'pw_expire', 'pwd.h')
+  have_struct_member('struct passwd', 'pw_passwd', 'pwd.h')
+end
+if have_func("getgrent")
+  have_struct_member('struct group', 'gr_passwd', 'grp.h')
+end
+
 if (sysconfdir = RbConfig::CONFIG["sysconfdir"] and
     !RbConfig.expand(sysconfdir.dup, "prefix"=>"", "DESTDIR"=>"").empty?)
   $defs.push("-DSYSCONFDIR=#{Shellwords.escape(sysconfdir.dump)}")
@@ -20,26 +42,6 @@ end
 have_func("sysconf")
 have_func("confstr")
 have_func("fpathconf")
-
-have_struct_member('struct passwd', 'pw_gecos', 'pwd.h')
-have_struct_member('struct passwd', 'pw_change', 'pwd.h')
-have_struct_member('struct passwd', 'pw_quota', 'pwd.h')
-if have_struct_member('struct passwd', 'pw_age', 'pwd.h')
-  case what_type?('struct passwd', 'pw_age', 'pwd.h')
-  when "string"
-    f = "safe_setup_str"
-  when "long long"
-    f = "LL2NUM"
-  else
-    f = "INT2NUM"
-  end
-  $defs.push("-DPW_AGE2VAL="+f)
-end
-have_struct_member('struct passwd', 'pw_class', 'pwd.h')
-have_struct_member('struct passwd', 'pw_comment', 'pwd.h') unless /cygwin/ === RUBY_PLATFORM
-have_struct_member('struct passwd', 'pw_expire', 'pwd.h')
-have_struct_member('struct passwd', 'pw_passwd', 'pwd.h')
-have_struct_member('struct group', 'gr_passwd', 'grp.h')
 
 # for https://github.com/ruby/etc
 srcdir = File.expand_path("..", __FILE__)
@@ -58,7 +60,7 @@ end
 # TODO: remove when dropping 2.7 support, as exported since 3.0
 have_func('rb_deprecate_constant(Qnil, "None")')
 
-have_func("rb_io_descriptor")
+have_func("rb_io_descriptor", "ruby/io.h")
 
 $distcleanfiles << "constdefs.h"
 

--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -4,7 +4,7 @@
  */
 
 static const char *const
-IO_CONSOLE_VERSION = "0.8.0";
+IO_CONSOLE_VERSION = "0.8.1";
 
 #include "ruby.h"
 #include "ruby/io.h"

--- a/ext/io/console/extconf.rb
+++ b/ext/io/console/extconf.rb
@@ -10,11 +10,11 @@ have_func("rb_syserr_new_str(0, Qnil)") or
   abort
 
 have_func("rb_interned_str_cstr")
-have_func("rb_io_path")
-have_func("rb_io_descriptor")
-have_func("rb_io_get_write_io")
-have_func("rb_io_closed_p")
-have_func("rb_io_open_descriptor")
+have_func("rb_io_path", "ruby/io.h")
+have_func("rb_io_descriptor", "ruby/io.h")
+have_func("rb_io_get_write_io", "ruby/io.h")
+have_func("rb_io_closed_p", "ruby/io.h")
+have_func("rb_io_open_descriptor", "ruby/io.h")
 have_func("rb_ractor_local_storage_value_newkey")
 
 is_wasi = /wasi/ =~ MakeMakefile::RbConfig::CONFIG["platform"]

--- a/ext/io/nonblock/extconf.rb
+++ b/ext/io/nonblock/extconf.rb
@@ -7,7 +7,7 @@ unless RUBY_ENGINE == 'ruby'
   return
 end
 
-have_func("rb_io_descriptor")
+have_func("rb_io_descriptor", "ruby/io.h")
 
 hdr = %w"fcntl.h"
 if have_macro("O_NONBLOCK", hdr) and

--- a/ext/io/nonblock/io-nonblock.gemspec
+++ b/ext/io/nonblock/io-nonblock.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "io-nonblock"
-  spec.version       = "0.3.1"
+  spec.version       = "0.3.2"
   spec.authors       = ["Nobu Nakada"]
   spec.email         = ["nobu@ruby-lang.org"]
 
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Enables non-blocking mode with IO class}
   spec.homepage      = "https://github.com/ruby/io-nonblock"
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/ext/io/wait/extconf.rb
+++ b/ext/io/wait/extconf.rb
@@ -1,25 +1,21 @@
 # frozen_string_literal: false
 require 'mkmf'
 
-if RUBY_VERSION < "2.6"
-  File.write("Makefile", dummy_makefile($srcdir).join(""))
+target = "io/wait"
+have_func("rb_io_wait", "ruby/io.h")
+have_func("rb_io_descriptor", "ruby/io.h")
+unless macro_defined?("DOSISH", "#include <ruby.h>")
+  have_header(ioctl_h = "sys/ioctl.h") or ioctl_h = nil
+  fionread = %w[sys/ioctl.h sys/filio.h sys/socket.h].find do |h|
+    have_macro("FIONREAD", [h, ioctl_h].compact)
+  end
+  if fionread
+    $defs << "-DFIONREAD_HEADER=\"<#{fionread}>\""
+    create_makefile(target)
+  end
 else
-  target = "io/wait"
-  have_func("rb_io_wait")
-  have_func("rb_io_descriptor")
-  unless macro_defined?("DOSISH", "#include <ruby.h>")
-    have_header(ioctl_h = "sys/ioctl.h") or ioctl_h = nil
-    fionread = %w[sys/ioctl.h sys/filio.h sys/socket.h].find do |h|
-      have_macro("FIONREAD", [h, ioctl_h].compact)
-    end
-    if fionread
-      $defs << "-DFIONREAD_HEADER=\"<#{fionread}>\""
-      create_makefile(target)
-    end
-  else
-    if have_func("rb_w32_ioctlsocket", "ruby.h")
-      have_func("rb_w32_is_socket", "ruby.h")
-      create_makefile(target)
-    end
+  if have_func("rb_w32_ioctlsocket", "ruby.h")
+    have_func("rb_w32_is_socket", "ruby.h")
+    create_makefile(target)
   end
 end

--- a/ext/io/wait/io-wait.gemspec
+++ b/ext/io/wait/io-wait.gemspec
@@ -1,4 +1,4 @@
-_VERSION = "0.3.1"
+_VERSION = "0.3.2"
 
 Gem::Specification.new do |spec|
   spec.name          = "io-wait"
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Waits until IO is readable or writable without blocking.}
   spec.homepage      = "https://github.com/ruby/io-wait"
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
+  spec.required_ruby_version = Gem::Requirement.new(">= 3.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/ext/io/wait/wait.c
+++ b/ext/io/wait/wait.c
@@ -312,7 +312,7 @@ io_event_from_value(VALUE value)
 /*
  * call-seq:
  *   io.wait(events, timeout) -> event mask, false or nil
- *   io.wait(timeout = nil, mode = :read) -> self, true, or false
+ *   io.wait(*event_symbols[, timeout]) -> self, true, or false
  *
  * Waits until the IO becomes ready for the specified events and returns the
  * subset of events that become ready, or a falsy value when times out.
@@ -320,10 +320,14 @@ io_event_from_value(VALUE value)
  * The events can be a bit mask of +IO::READABLE+, +IO::WRITABLE+ or
  * +IO::PRIORITY+.
  *
- * Returns a truthy value immediately when buffered data is available.
+ * Returns an event mask (truthy value) immediately when buffered data is
+ * available.
  *
- * Optional parameter +mode+ is one of +:read+, +:write+, or
- * +:read_write+.
+ * The second form: if one or more event symbols (+:read+, +:write+, or
+ * +:read_write+) are passed, the event mask is the bit OR of the bitmask
+ * corresponding to those symbols.  In this form, +timeout+ is optional, the
+ * order of the arguments is arbitrary, and returns +io+ if any of the
+ * events is ready.
  *
  * You must require 'io/wait' to use this method.
  */
@@ -360,10 +364,6 @@ io_wait(int argc, VALUE *argv, VALUE io)
     rb_io_event_t events = 0;
     int i, return_io = 0;
 
-    /* The documented signature for this method is actually incorrect.
-     * A single timeout is allowed in any position, and multiple symbols can be given.
-     * Whether this is intentional or not, I don't know, and as such I consider this to
-     * be a legacy/slow path. */
     if (argc != 2 || (RB_SYMBOL_P(argv[0]) || RB_SYMBOL_P(argv[1]))) {
         /* We'd prefer to return the actual mask, but this form would return the io itself: */
         return_io = 1;

--- a/ext/json/parser/extconf.rb
+++ b/ext/json/parser/extconf.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'mkmf'
 
-have_func("rb_enc_interned_str", "ruby.h") # RUBY_VERSION >= 3.0
+have_func("rb_enc_interned_str", "ruby/encoding.h") # RUBY_VERSION >= 3.0
 have_func("rb_hash_new_capa", "ruby.h") # RUBY_VERSION >= 3.2
 have_func("rb_hash_bulk_insert", "ruby.h") # Missing on TruffleRuby
 have_func("rb_category_warn", "ruby.h") # Missing on TruffleRuby

--- a/ext/openssl/extconf.rb
+++ b/ext/openssl/extconf.rb
@@ -40,7 +40,7 @@ Logging::message "=== OpenSSL for Ruby configurator ===\n"
 
 $defs.push("-D""OPENSSL_SUPPRESS_DEPRECATED")
 
-have_func("rb_io_descriptor")
+have_func("rb_io_descriptor", "ruby/io.h")
 have_func("rb_io_maybe_wait(0, Qnil, Qnil, Qnil)", "ruby/io.h") # Ruby 3.1
 have_func("rb_io_timeout", "ruby/io.h")
 

--- a/ext/strscan/extconf.rb
+++ b/ext/strscan/extconf.rb
@@ -2,8 +2,8 @@
 require 'mkmf'
 if RUBY_ENGINE == 'ruby'
   $INCFLAGS << " -I$(top_srcdir)" if $extmk
-  have_func("onig_region_memsize", "ruby.h")
-  have_func("rb_reg_onig_match", "ruby.h")
+  have_func("onig_region_memsize")
+  have_func("rb_reg_onig_match", "ruby/re.h")
   create_makefile 'strscan'
 else
   File.write('Makefile', dummy_makefile("").join)

--- a/ext/strscan/extconf.rb
+++ b/ext/strscan/extconf.rb
@@ -2,7 +2,7 @@
 require 'mkmf'
 if RUBY_ENGINE == 'ruby'
   $INCFLAGS << " -I$(top_srcdir)" if $extmk
-  have_func("onig_region_memsize")
+  have_func("onig_region_memsize(NULL)")
   have_func("rb_reg_onig_match", "ruby/re.h")
   create_makefile 'strscan'
 else

--- a/test/etc/test_etc.rb
+++ b/test/etc/test_etc.rb
@@ -178,6 +178,10 @@ class TestEtc < Test::Unit::TestCase
     omit "This test is flaky and intermittently failing now on ModGC workflow" if ENV['GITHUB_WORKFLOW'] == 'ModGC'
 
     assert_ractor(<<~RUBY, require: 'etc', timeout: 60)
+      class Ractor
+        alias join take
+      end unless Ractor.method_defined? :value # compat with Ruby 3.4 and olders
+
       10.times.map do
         Ractor.new do
           100.times do
@@ -204,6 +208,10 @@ class TestEtc < Test::Unit::TestCase
 
   def test_ractor_unsafe
     assert_ractor(<<~RUBY, require: 'etc')
+      class Ractor
+        alias value take
+      end unless Ractor.method_defined? :value # compat with Ruby 3.4 and olders
+
       r = Ractor.new do
         begin
           Etc.passwd

--- a/test/io/console/test_ractor.rb
+++ b/test/io/console/test_ractor.rb
@@ -8,6 +8,10 @@ class TestIOConsoleInRactor < Test::Unit::TestCase
     path = $".find {|path| path.end_with?(ext)}
     assert_in_out_err(%W[-r#{path}], "#{<<~"begin;"}\n#{<<~'end;'}", ["true"], [])
     begin;
+      class Ractor
+        alias value take
+      end unless Ractor.method_defined? :value # compat with Ruby 3.4 and olders
+
       $VERBOSE = nil
       r = Ractor.new do
         $stdout.console_mode
@@ -18,17 +22,21 @@ class TestIOConsoleInRactor < Test::Unit::TestCase
       else
         true                    # should not success
       end
-      puts r.take
+      puts r.value
     end;
 
     assert_in_out_err(%W[-r#{path}], "#{<<~"begin;"}\n#{<<~'end;'}", ["true"], [])
     begin;
+      class Ractor
+        alias value take
+      end unless Ractor.method_defined? :value # compat with Ruby 3.4 and olders
+
       console = IO.console
       $VERBOSE = nil
       r = Ractor.new do
         IO.console
       end
-      puts console.class == r.take.class
+      puts console.class == r.value.class
     end;
   end
 end if defined? Ractor

--- a/test/io/wait/test_io_wait.rb
+++ b/test/io/wait/test_io_wait.rb
@@ -78,7 +78,8 @@ class TestIOWait < Test::Unit::TestCase
     ret = nil
     assert_nothing_raised(Timeout::Error) do
       q.push(true)
-      Timeout.timeout(0.1) { ret = @r.wait }
+      t = EnvUtil.apply_timeout_scale(0.1)
+      Timeout.timeout(t) { ret = @r.wait }
     end
     assert_equal @r, ret
   ensure
@@ -113,7 +114,8 @@ class TestIOWait < Test::Unit::TestCase
     ret = nil
     assert_nothing_raised(Timeout::Error) do
       q.push(true)
-      Timeout.timeout(0.1) { ret = @r.wait_readable }
+      t = EnvUtil.apply_timeout_scale(0.1)
+      Timeout.timeout(t) { ret = @r.wait_readable }
     end
     assert_equal @r, ret
   ensure

--- a/test/io/wait/test_ractor.rb
+++ b/test/io/wait/test_ractor.rb
@@ -7,11 +7,15 @@ class TestIOWaitInRactor < Test::Unit::TestCase
     ext = "/io/wait.#{RbConfig::CONFIG['DLEXT']}"
     path = $".find {|path| path.end_with?(ext)}
     assert_in_out_err(%W[-r#{path}], <<-"end;", ["true"], [])
+      class Ractor
+        alias value take
+      end unless Ractor.method_defined? :value # compat with Ruby 3.4 and olders
+
       $VERBOSE = nil
       r = Ractor.new do
         $stdout.equal?($stdout.wait_writable)
       end
-      puts r.take
+      puts r.value
     end;
   end
 end if defined? Ractor


### PR DESCRIPTION
from https://bugs.ruby-lang.org/issues/21496

I released and sync the following gems with `-flto` support.

* io-console
* io-wait
* io-nonblock
* etc and `Ractor#take` workaround

They are contained other changes. But I believe these changes are minor and will not cause new issues.

Unfotunately, the following gems couldn't release with `-flto` support because they have a lot of changes from bundled version of Ruby 3.4. So, I only backport `-flto` support for them.

* strscan
* openssl
* json

BTW, we confirm to work all of default gems with GCC 15.1 at Fedora 42 CI at https://rubyci.s3.amazonaws.com/fedora42-arm/ruby-3.4/summary.html.

This issue happend with Gentoo linux https://bugs.ruby-lang.org/issues/21497