### PR TITLE
Suppress warnings for variables

### DIFF
--- a/test/ruby/test_proc.rb
+++ b/test/ruby/test_proc.rb
@@ -1655,7 +1655,7 @@ class TestProc < Test::Unit::TestCase
 
   def test_numparam_is_not_local_variables
     "foo".tap do
-      _9
+      _9 and flunk
       assert_equal([], binding.local_variables)
       assert_raise(NameError) { binding.local_variable_get(:_9) }
       assert_raise(NameError) { binding.local_variable_set(:_9, 1) }
@@ -1674,7 +1674,7 @@ class TestProc < Test::Unit::TestCase
       assert_raise(NameError) { binding.local_variable_get(:_9) }
       assert_raise(NameError) { binding.local_variable_set(:_9, 1) }
       "bar".tap do
-        _9
+        _9 and flunk
         assert_equal([], binding.local_variables)
         assert_raise(NameError) { binding.local_variable_get(:_9) }
         assert_raise(NameError) { binding.local_variable_set(:_9, 1) }

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -875,7 +875,7 @@ class TestRubyOptions < Test::Unit::TestCase
                  '-e', '$".clear',
                  '-e', '$".unshift Bogus.new',
                  '-e', '(p $"; abort) unless $".size == 1',
-                ], success: false)
+                ], bug7402, success: false)
   end
 
   def test_segv_setproctitle

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -419,6 +419,7 @@ class TestVariable < Test::Unit::TestCase
         x
       end
     end
+    objs or flunk
   end
 
   def test_local_variables_with_kwarg
@@ -440,7 +441,7 @@ class TestVariable < Test::Unit::TestCase
   end
 
   def test_local_variables_encoding
-    α = 1
+    α = 1 or flunk
     b = binding
     b.eval("".encode("us-ascii"))
     assert_equal(%i[α b], b.local_variables)


### PR DESCRIPTION
```
test/ruby/test_variable.rb:412: warning: assigned but unused variable - objs
test/ruby/test_variable.rb:443: warning: assigned but unused variable - α
test/ruby/test_proc.rb:1658: warning: possibly useless use of a variable in void context
test/ruby/test_proc.rb:1677: warning: possibly useless use of a variable in void context
test/ruby/test_rubyoptions.rb:871: warning: assigned but unused variable - bug7402
```
