### PR TITLE
ZJIT: Profile type+shape distributions

### DIFF
--- a/jit.c
+++ b/jit.c
@@ -454,15 +454,3 @@ rb_set_cfp_sp(struct rb_control_frame_struct *cfp, VALUE *sp)
 {
     cfp->sp = sp;
 }
-
-const uint32_t
-RB_SPECIAL_CONST_SHAPE_ID = SPECIAL_CONST_SHAPE_ID;
-
-const uint32_t
-RB_INVALID_SHAPE_ID = INVALID_SHAPE_ID;
-
-bool
-rb_zjit_singleton_class_p(VALUE klass)
-{
-    return RCLASS_SINGLETON_P(klass);
-}

--- a/jit.c
+++ b/jit.c
@@ -454,3 +454,15 @@ rb_set_cfp_sp(struct rb_control_frame_struct *cfp, VALUE *sp)
 {
     cfp->sp = sp;
 }
+
+const uint32_t
+RB_SPECIAL_CONST_SHAPE_ID = SPECIAL_CONST_SHAPE_ID;
+
+const uint32_t
+RB_INVALID_SHAPE_ID = INVALID_SHAPE_ID;
+
+bool
+rb_zjit_singleton_class_p(VALUE klass)
+{
+    return RCLASS_SINGLETON_P(klass);
+}

--- a/zjit.c
+++ b/zjit.c
@@ -351,11 +351,10 @@ VALUE rb_zjit_assert_compiles(rb_execution_context_t *ec, VALUE self);
 VALUE rb_zjit_stats(rb_execution_context_t *ec, VALUE self);
 VALUE rb_zjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
 
-const uint32_t
-RB_SPECIAL_CONST_SHAPE_ID = SPECIAL_CONST_SHAPE_ID;
-
-const uint32_t
-RB_INVALID_SHAPE_ID = INVALID_SHAPE_ID;
+enum {
+    RB_SPECIAL_CONST_SHAPE_ID = SPECIAL_CONST_SHAPE_ID,
+    RB_INVALID_SHAPE_ID = INVALID_SHAPE_ID,
+};
 
 bool
 rb_zjit_singleton_class_p(VALUE klass)

--- a/zjit.c
+++ b/zjit.c
@@ -346,11 +346,6 @@ rb_zjit_shape_obj_too_complex_p(VALUE obj)
     return rb_shape_obj_too_complex_p(obj);
 }
 
-// Primitives used by zjit.rb. Don't put other functions below, which wouldn't use them.
-VALUE rb_zjit_assert_compiles(rb_execution_context_t *ec, VALUE self);
-VALUE rb_zjit_stats(rb_execution_context_t *ec, VALUE self);
-VALUE rb_zjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
-
 enum {
     RB_SPECIAL_CONST_SHAPE_ID = SPECIAL_CONST_SHAPE_ID,
     RB_INVALID_SHAPE_ID = INVALID_SHAPE_ID,
@@ -361,6 +356,11 @@ rb_zjit_singleton_class_p(VALUE klass)
 {
     return RCLASS_SINGLETON_P(klass);
 }
+
+// Primitives used by zjit.rb. Don't put other functions below, which wouldn't use them.
+VALUE rb_zjit_assert_compiles(rb_execution_context_t *ec, VALUE self);
+VALUE rb_zjit_stats(rb_execution_context_t *ec, VALUE self);
+VALUE rb_zjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
 
 // Preprocessed zjit.rb generated during build
 #include "zjit.rbinc"

--- a/zjit.c
+++ b/zjit.c
@@ -351,5 +351,17 @@ VALUE rb_zjit_assert_compiles(rb_execution_context_t *ec, VALUE self);
 VALUE rb_zjit_stats(rb_execution_context_t *ec, VALUE self);
 VALUE rb_zjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
 
+const uint32_t
+RB_SPECIAL_CONST_SHAPE_ID = SPECIAL_CONST_SHAPE_ID;
+
+const uint32_t
+RB_INVALID_SHAPE_ID = INVALID_SHAPE_ID;
+
+bool
+rb_zjit_singleton_class_p(VALUE klass)
+{
+    return RCLASS_SINGLETON_P(klass);
+}
+
 // Preprocessed zjit.rb generated during build
 #include "zjit.rbinc"

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -351,11 +351,14 @@ fn main() {
         .allowlist_function("rb_optimized_call")
         .allowlist_function("rb_zjit_icache_invalidate")
         .allowlist_function("rb_zjit_print_exception")
+        .allowlist_function("rb_zjit_singleton_class_p")
         .allowlist_type("robject_offsets")
         .allowlist_type("rstring_offsets")
 
         // From jit.c
         .allowlist_function("rb_assert_holding_vm_lock")
+        .allowlist_var("RB_SPECIAL_CONST_SHAPE_ID")
+        .allowlist_var("RB_INVALID_SHAPE_ID")
 
         // from vm_sync.h
         .allowlist_function("rb_vm_barrier")

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -354,11 +354,11 @@ fn main() {
         .allowlist_function("rb_zjit_singleton_class_p")
         .allowlist_type("robject_offsets")
         .allowlist_type("rstring_offsets")
+        .allowlist_var("RB_SPECIAL_CONST_SHAPE_ID")
+        .allowlist_var("RB_INVALID_SHAPE_ID")
 
         // From jit.c
         .allowlist_function("rb_assert_holding_vm_lock")
-        .allowlist_var("RB_SPECIAL_CONST_SHAPE_ID")
-        .allowlist_var("RB_INVALID_SHAPE_ID")
 
         // from vm_sync.h
         .allowlist_function("rb_vm_barrier")

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -265,6 +265,12 @@ pub struct ID(pub ::std::os::raw::c_ulong);
 /// Pointer to an ISEQ
 pub type IseqPtr = *const rb_iseq_t;
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct ShapeId(pub u32);
+
+pub const SPECIAL_CONST_SHAPE_ID: ShapeId = ShapeId(RB_SPECIAL_CONST_SHAPE_ID);
+pub const INVALID_SHAPE_ID: ShapeId = ShapeId(RB_INVALID_SHAPE_ID);
+
 // Given an ISEQ pointer, convert PC to insn_idx
 pub fn iseq_pc_to_insn_idx(iseq: IseqPtr, pc: *mut VALUE) -> Option<u16> {
     let pc_zero = unsafe { rb_iseq_pc_at_idx(iseq, 0) };
@@ -487,8 +493,8 @@ impl VALUE {
         unsafe { rb_zjit_shape_obj_too_complex_p(self) }
     }
 
-    pub fn shape_id_of(self) -> u32 {
-        unsafe { rb_obj_shape_id(self) }
+    pub fn shape_id_of(self) -> ShapeId {
+        ShapeId(unsafe { rb_obj_shape_id(self) })
     }
 
     pub fn embedded_p(self) -> bool {

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -719,9 +719,10 @@ pub const DEFINED_REF: defined_type = 15;
 pub const DEFINED_FUNC: defined_type = 16;
 pub const DEFINED_CONST_FROM: defined_type = 17;
 pub type defined_type = u32;
+pub const RB_SPECIAL_CONST_SHAPE_ID: _bindgen_ty_12 = 33554432;
+pub const RB_INVALID_SHAPE_ID: _bindgen_ty_12 = 4294967295;
+pub type _bindgen_ty_12 = u32;
 pub type rb_iseq_param_keyword_struct = rb_iseq_constant_body__bindgen_ty_1_rb_iseq_param_keyword;
-pub const RB_SPECIAL_CONST_SHAPE_ID: u32 = 33554432;
-pub const RB_INVALID_SHAPE_ID: u32 = 4294967295;
 unsafe extern "C" {
     pub fn ruby_xfree(ptr: *mut ::std::os::raw::c_void);
     pub fn rb_class_attached_object(klass: VALUE) -> VALUE;
@@ -940,6 +941,7 @@ unsafe extern "C" {
     pub fn rb_iseq_set_zjit_payload(iseq: *const rb_iseq_t, payload: *mut ::std::os::raw::c_void);
     pub fn rb_zjit_print_exception();
     pub fn rb_zjit_shape_obj_too_complex_p(obj: VALUE) -> bool;
+    pub fn rb_zjit_singleton_class_p(klass: VALUE) -> bool;
     pub fn rb_iseq_encoded_size(iseq: *const rb_iseq_t) -> ::std::os::raw::c_uint;
     pub fn rb_iseq_pc_at_idx(iseq: *const rb_iseq_t, insn_idx: u32) -> *mut VALUE;
     pub fn rb_iseq_opcode_at_pc(iseq: *const rb_iseq_t, pc: *const VALUE) -> ::std::os::raw::c_int;
@@ -1019,5 +1021,4 @@ unsafe extern "C" {
     pub fn rb_yarv_ary_entry_internal(ary: VALUE, offset: ::std::os::raw::c_long) -> VALUE;
     pub fn rb_set_cfp_pc(cfp: *mut rb_control_frame_struct, pc: *const VALUE);
     pub fn rb_set_cfp_sp(cfp: *mut rb_control_frame_struct, sp: *mut VALUE);
-    pub fn rb_zjit_singleton_class_p(klass: VALUE) -> bool;
 }

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -720,6 +720,8 @@ pub const DEFINED_FUNC: defined_type = 16;
 pub const DEFINED_CONST_FROM: defined_type = 17;
 pub type defined_type = u32;
 pub type rb_iseq_param_keyword_struct = rb_iseq_constant_body__bindgen_ty_1_rb_iseq_param_keyword;
+pub const RB_SPECIAL_CONST_SHAPE_ID: u32 = 33554432;
+pub const RB_INVALID_SHAPE_ID: u32 = 4294967295;
 unsafe extern "C" {
     pub fn ruby_xfree(ptr: *mut ::std::os::raw::c_void);
     pub fn rb_class_attached_object(klass: VALUE) -> VALUE;
@@ -1017,4 +1019,5 @@ unsafe extern "C" {
     pub fn rb_yarv_ary_entry_internal(ary: VALUE, offset: ::std::os::raw::c_long) -> VALUE;
     pub fn rb_set_cfp_pc(cfp: *mut rb_control_frame_struct, pc: *const VALUE);
     pub fn rb_set_cfp_sp(cfp: *mut rb_control_frame_struct, sp: *mut VALUE);
+    pub fn rb_zjit_singleton_class_p(klass: VALUE) -> bool;
 }

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -719,9 +719,9 @@ pub const DEFINED_REF: defined_type = 15;
 pub const DEFINED_FUNC: defined_type = 16;
 pub const DEFINED_CONST_FROM: defined_type = 17;
 pub type defined_type = u32;
-pub const RB_SPECIAL_CONST_SHAPE_ID: _bindgen_ty_12 = 33554432;
-pub const RB_INVALID_SHAPE_ID: _bindgen_ty_12 = 4294967295;
-pub type _bindgen_ty_12 = u32;
+pub const RB_SPECIAL_CONST_SHAPE_ID: _bindgen_ty_38 = 33554432;
+pub const RB_INVALID_SHAPE_ID: _bindgen_ty_38 = 4294967295;
+pub type _bindgen_ty_38 = u32;
 pub type rb_iseq_param_keyword_struct = rb_iseq_constant_body__bindgen_ty_1_rb_iseq_param_keyword;
 unsafe extern "C" {
     pub fn ruby_xfree(ptr: *mut ::std::os::raw::c_void);

--- a/zjit/src/distribution.rs
+++ b/zjit/src/distribution.rs
@@ -15,21 +15,26 @@ impl<T: Copy + PartialEq + Default, const N: usize> Distribution<T, N> {
     }
 
     pub fn observe(&mut self, item: T) {
-        for (idx, (bucket, count)) in self.buckets.iter_mut().zip(self.counts.iter_mut()).enumerate() {
+        for (bucket, count) in self.buckets.iter_mut().zip(self.counts.iter_mut()) {
             if *bucket == item || *count == 0 {
                 *bucket = item;
                 *count += 1;
                 // Keep the most frequent item at the front
-                let mut j = idx;
-                while j > 0 && self.counts[j] > self.counts[j - 1] {
-                    self.counts.swap(j, j - 1);
-                    self.buckets.swap(j, j - 1);
-                    j -= 1;
-                }
+                self.bubble_up();
                 return;
             }
         }
         self.other += 1;
+    }
+
+    /// Keep the highest counted bucket at index 0
+    fn bubble_up(&mut self) {
+        if N == 0 { return; }
+        let max_index = self.counts.into_iter().enumerate().max_by_key(|(_, val)| *val).unwrap().0;
+        if max_index != 0 {
+            self.counts.swap(0, max_index);
+            self.buckets.swap(0, max_index);
+        }
     }
 
     pub fn each_item(&self) -> impl Iterator<Item = T> + '_ {

--- a/zjit/src/distribution.rs
+++ b/zjit/src/distribution.rs
@@ -1,0 +1,258 @@
+#[derive(Debug, Clone)]
+pub struct Distribution<T: Copy + PartialEq + Default, const N: usize> {
+    /// buckets and counts have the same length
+    /// buckets[0] is always the most common item
+    buckets: [T; N],
+    counts: [usize; N],
+    /// if there is no more room, increment the fallback
+    other: usize,
+    // TODO(max): Add count disparity, which can help determine when to reset the distribution
+}
+
+impl<T: Copy + PartialEq + Default, const N: usize> Distribution<T, N> {
+    pub fn new() -> Self {
+        Self { buckets: [Default::default(); N], counts: [0; N], other: 0 }
+    }
+
+    pub fn observe(&mut self, item: T) {
+        for (idx, (bucket, count)) in self.buckets.iter_mut().zip(self.counts.iter_mut()).enumerate() {
+            if *bucket == item || *count == 0 {
+                *bucket = item;
+                *count += 1;
+                // Keep the most frequent item at the front
+                let mut j = idx;
+                while j > 0 && self.counts[j] > self.counts[j - 1] {
+                    self.counts.swap(j, j - 1);
+                    self.buckets.swap(j, j - 1);
+                    j -= 1;
+                }
+                return;
+            }
+        }
+        self.other += 1;
+    }
+
+    pub fn each_item(&self) -> impl Iterator<Item = T> + '_ {
+        self.buckets.iter().zip(self.counts.iter())
+            .filter_map(|(&bucket, &count)| if count > 0 { Some(bucket) } else { None })
+    }
+
+    pub fn each_item_mut(&mut self) -> impl Iterator<Item = &mut T> + '_ {
+        self.buckets.iter_mut().zip(self.counts.iter())
+            .filter_map(|(bucket, &count)| if count > 0 { Some(bucket) } else { None })
+    }
+}
+
+#[derive(PartialEq, Debug, Clone, Copy)]
+enum DistributionKind {
+    /// No types seen
+    Empty,
+    /// One type seen
+    Monomorphic,
+    /// Between 2 and (fixed) N types seen
+    Polymorphic,
+    /// Polymorphic, but with a significant skew towards one type
+    SkewedPolymorphic,
+    /// More than N types seen with no clear winner
+    Megamorphic,
+    /// Megamorphic, but with a significant skew towards one type
+    SkewedMegamorphic,
+}
+
+#[derive(Debug)]
+pub struct DistributionSummary<T: Copy + PartialEq + Default + std::fmt::Debug, const N: usize> {
+    kind: DistributionKind,
+    buckets: [T; N],
+    // TODO(max): Determine if we need some notion of stability
+}
+
+const SKEW_THRESHOLD: f64 = 0.75;
+
+impl<T: Copy + PartialEq + Default + std::fmt::Debug, const N: usize> DistributionSummary<T, N> {
+    pub fn new(dist: &Distribution<T, N>) -> Self {
+        #[cfg(debug_assertions)]
+        {
+            let first_count = dist.counts[0];
+            for &count in &dist.counts[1..] {
+                assert!(first_count >= count, "First count should be the largest");
+            }
+        }
+        let num_seen = dist.counts.iter().sum::<usize>() + dist.other;
+        let kind = if dist.other == 0 {
+            // Seen <= N types total
+            if dist.counts[0] == 0 {
+                DistributionKind::Empty
+            } else if dist.counts[1] == 0 {
+                DistributionKind::Monomorphic
+            } else if (dist.counts[0] as f64)/(num_seen as f64) >= SKEW_THRESHOLD {
+                DistributionKind::SkewedPolymorphic
+            } else {
+                DistributionKind::Polymorphic
+            }
+        } else {
+            // Seen > N types total; considered megamorphic
+            if (dist.counts[0] as f64)/(num_seen as f64) >= SKEW_THRESHOLD {
+                DistributionKind::SkewedMegamorphic
+            } else {
+                DistributionKind::Megamorphic
+            }
+        };
+        Self { kind, buckets: dist.buckets.clone() }
+    }
+
+    pub fn is_monomorphic(&self) -> bool {
+        self.kind == DistributionKind::Monomorphic
+    }
+
+    pub fn is_skewed_polymorphic(&self) -> bool {
+        self.kind == DistributionKind::SkewedPolymorphic
+    }
+
+    pub fn is_skewed_megamorphic(&self) -> bool {
+        self.kind == DistributionKind::SkewedMegamorphic
+    }
+
+    pub fn bucket(&self, idx: usize) -> T {
+        assert!(idx < N, "index {idx} out of bounds for buckets[{N}]");
+        self.buckets[idx]
+    }
+}
+
+#[cfg(test)]
+mod distribution_tests {
+    use super::*;
+
+    #[test]
+    fn start_empty() {
+        let dist = Distribution::<usize, 4>::new();
+        assert_eq!(dist.other, 0);
+        assert!(dist.counts.iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn observe_adds_record() {
+        let mut dist = Distribution::<usize, 4>::new();
+        dist.observe(10);
+        assert_eq!(dist.buckets[0], 10);
+        assert_eq!(dist.counts[0], 1);
+        assert_eq!(dist.other, 0);
+    }
+
+    #[test]
+    fn observe_increments_record() {
+        let mut dist = Distribution::<usize, 4>::new();
+        dist.observe(10);
+        dist.observe(10);
+        assert_eq!(dist.buckets[0], 10);
+        assert_eq!(dist.counts[0], 2);
+        assert_eq!(dist.other, 0);
+    }
+
+    #[test]
+    fn observe_two() {
+        let mut dist = Distribution::<usize, 4>::new();
+        dist.observe(10);
+        dist.observe(10);
+        dist.observe(11);
+        dist.observe(11);
+        dist.observe(11);
+        assert_eq!(dist.buckets[0], 11);
+        assert_eq!(dist.counts[0], 3);
+        assert_eq!(dist.buckets[1], 10);
+        assert_eq!(dist.counts[1], 2);
+        assert_eq!(dist.other, 0);
+    }
+
+    #[test]
+    fn observe_with_max_increments_other() {
+        let mut dist = Distribution::<usize, 0>::new();
+        dist.observe(10);
+        assert!(dist.buckets.is_empty());
+        assert!(dist.counts.is_empty());
+        assert_eq!(dist.other, 1);
+    }
+
+    #[test]
+    fn empty_distribution_returns_empty_summary() {
+        let dist = Distribution::<usize, 4>::new();
+        let summary = DistributionSummary::new(&dist);
+        assert_eq!(summary.kind, DistributionKind::Empty);
+    }
+
+    #[test]
+    fn monomorphic_distribution_returns_monomorphic_summary() {
+        let mut dist = Distribution::<usize, 4>::new();
+        dist.observe(10);
+        dist.observe(10);
+        let summary = DistributionSummary::new(&dist);
+        assert_eq!(summary.kind, DistributionKind::Monomorphic);
+        assert_eq!(summary.buckets[0], 10);
+    }
+
+    #[test]
+    fn polymorphic_distribution_returns_polymorphic_summary() {
+        let mut dist = Distribution::<usize, 4>::new();
+        dist.observe(10);
+        dist.observe(11);
+        dist.observe(11);
+        let summary = DistributionSummary::new(&dist);
+        assert_eq!(summary.kind, DistributionKind::Polymorphic);
+        assert_eq!(summary.buckets[0], 11);
+        assert_eq!(summary.buckets[1], 10);
+    }
+
+    #[test]
+    fn skewed_polymorphic_distribution_returns_skewed_polymorphic_summary() {
+        let mut dist = Distribution::<usize, 4>::new();
+        dist.observe(10);
+        dist.observe(11);
+        dist.observe(11);
+        dist.observe(11);
+        let summary = DistributionSummary::new(&dist);
+        assert_eq!(summary.kind, DistributionKind::SkewedPolymorphic);
+        assert_eq!(summary.buckets[0], 11);
+        assert_eq!(summary.buckets[1], 10);
+    }
+
+    #[test]
+    fn megamorphic_distribution_returns_megamorphic_summary() {
+        let mut dist = Distribution::<usize, 4>::new();
+        dist.observe(10);
+        dist.observe(11);
+        dist.observe(12);
+        dist.observe(13);
+        dist.observe(14);
+        dist.observe(11);
+        let summary = DistributionSummary::new(&dist);
+        assert_eq!(summary.kind, DistributionKind::Megamorphic);
+        assert_eq!(summary.buckets[0], 11);
+    }
+
+    #[test]
+    fn skewed_megamorphic_distribution_returns_skewed_megamorphic_summary() {
+        let mut dist = Distribution::<usize, 4>::new();
+        dist.observe(10);
+        dist.observe(11);
+        dist.observe(11);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(12);
+        dist.observe(13);
+        dist.observe(14);
+        let summary = DistributionSummary::new(&dist);
+        assert_eq!(summary.kind, DistributionKind::SkewedMegamorphic);
+        assert_eq!(summary.buckets[0], 12);
+    }
+}

--- a/zjit/src/distribution.rs
+++ b/zjit/src/distribution.rs
@@ -1,3 +1,6 @@
+/// This implementation was inspired by the type feedback module from Google's S6, which was
+/// written in C++ for use with Python. This is a new implementation in Rust created for use with
+/// Ruby instead of Python.
 #[derive(Debug, Clone)]
 pub struct Distribution<T: Copy + PartialEq + Default, const N: usize> {
     /// buckets and counts have the same length

--- a/zjit/src/lib.rs
+++ b/zjit/src/lib.rs
@@ -6,6 +6,7 @@
 pub use std;
 
 mod state;
+mod distribution;
 mod cruby;
 mod cruby_methods;
 mod hir;

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -1,7 +1,8 @@
 // We use the YARV bytecode constants which have a CRuby-style name
 #![allow(non_upper_case_globals)]
 
-use crate::{cruby::*, gc::get_or_create_iseq_payload, hir_type::{types::{Empty}, Type}, options::get_option};
+use crate::{cruby::*, gc::get_or_create_iseq_payload, options::get_option};
+use crate::distribution::{Distribution, DistributionSummary};
 
 /// Ephemeral state for profiling runtime information
 struct Profiler {
@@ -79,25 +80,100 @@ fn profile_insn(profiler: &mut Profiler, bare_opcode: ruby_vminsn_type) {
     }
 }
 
+const DISTRIBUTION_SIZE: usize = 4;
+
+pub type TypeDistribution = Distribution<ProfiledType, DISTRIBUTION_SIZE>;
+
+pub type TypeDistributionSummary = DistributionSummary<ProfiledType, DISTRIBUTION_SIZE>;
+
 /// Profile the Type of top-`n` stack operands
 fn profile_operands(profiler: &mut Profiler, profile: &mut IseqProfile, n: usize) {
     let types = &mut profile.opnd_types[profiler.insn_idx];
-    if types.len() <= n {
-        types.resize(n, Empty);
+    if types.is_empty() {
+        types.resize(n, TypeDistribution::new());
     }
     for i in 0..n {
-        let opnd_type = Type::from_value(profiler.peek_at_stack((n - i - 1) as isize));
-        types[i] = types[i].union(opnd_type);
-        if let Some(object) = types[i].gc_object() {
-            unsafe { rb_gc_writebarrier(profiler.iseq.into(), object) };
-        }
+        let obj = profiler.peek_at_stack((n - i - 1) as isize);
+        // TODO(max): Handle GC-hidden classes like Array, Hash, etc and make them look normal or
+        // drop them or something
+        let ty = ProfiledType::new(obj.class_of(), obj.shape_id_of());
+        unsafe { rb_gc_writebarrier(profiler.iseq.into(), ty.class()) };
+        types[i].observe(ty);
+    }
+}
+
+/// opt_send_without_block/opt_plus/... should store:
+/// * the class of the receiver, so we can do method lookup
+/// * the shape of the receiver, so we can optimize ivar lookup
+/// with those two, pieces of information, we can also determine when an object is an immediate:
+/// * Integer + SPECIAL_CONST_SHAPE_ID == Fixnum
+/// * Float + SPECIAL_CONST_SHAPE_ID == Flonum
+/// * Symbol + SPECIAL_CONST_SHAPE_ID == StaticSymbol
+/// * NilClass == Nil
+/// * TrueClass == True
+/// * FalseClass == False
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProfiledType {
+    class: VALUE,
+    shape: ShapeId,
+}
+
+impl Default for ProfiledType {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl ProfiledType {
+    fn new(class: VALUE, shape: ShapeId) -> Self {
+        Self { class, shape }
+    }
+
+    pub fn empty() -> Self {
+        Self { class: VALUE(0), shape: INVALID_SHAPE_ID }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.class == VALUE(0)
+    }
+
+    pub fn class(&self) -> VALUE {
+        self.class
+    }
+
+    pub fn shape(&self) -> ShapeId {
+        self.shape
+    }
+
+    pub fn is_fixnum(&self) -> bool {
+        self.class == unsafe { rb_cInteger } && self.shape == SPECIAL_CONST_SHAPE_ID
+    }
+
+    pub fn is_flonum(&self) -> bool {
+        self.class == unsafe { rb_cFloat } && self.shape == SPECIAL_CONST_SHAPE_ID
+    }
+
+    pub fn is_static_symbol(&self) -> bool {
+        self.class == unsafe { rb_cSymbol } && self.shape == SPECIAL_CONST_SHAPE_ID
+    }
+
+    pub fn is_nil(&self) -> bool {
+        self.class == unsafe { rb_cNilClass } && self.shape == SPECIAL_CONST_SHAPE_ID
+    }
+
+    pub fn is_true(&self) -> bool {
+        self.class == unsafe { rb_cTrueClass } && self.shape == SPECIAL_CONST_SHAPE_ID
+    }
+
+    pub fn is_false(&self) -> bool {
+        self.class == unsafe { rb_cFalseClass } && self.shape == SPECIAL_CONST_SHAPE_ID
     }
 }
 
 #[derive(Debug)]
 pub struct IseqProfile {
     /// Type information of YARV instruction operands, indexed by the instruction index
-    opnd_types: Vec<Vec<Type>>,
+    opnd_types: Vec<Vec<TypeDistribution>>,
 
     /// Number of profiled executions for each YARV instruction, indexed by the instruction index
     num_profiles: Vec<u8>,
@@ -112,16 +188,17 @@ impl IseqProfile {
     }
 
     /// Get profiled operand types for a given instruction index
-    pub fn get_operand_types(&self, insn_idx: usize) -> Option<&[Type]> {
+    pub fn get_operand_types(&self, insn_idx: usize) -> Option<&[TypeDistribution]> {
         self.opnd_types.get(insn_idx).map(|v| &**v)
     }
 
     /// Run a given callback with every object in IseqProfile
     pub fn each_object(&self, callback: impl Fn(VALUE)) {
-        for types in &self.opnd_types {
-            for opnd_type in types {
-                if let Some(object) = opnd_type.gc_object() {
-                    callback(object);
+        for operands in &self.opnd_types {
+            for distribution in operands {
+                for profiled_type in distribution.each_item() {
+                    // If the type is a GC object, call the callback
+                    callback(profiled_type.class);
                 }
             }
         }
@@ -129,10 +206,11 @@ impl IseqProfile {
 
     /// Run a given callback with a mutable reference to every object in IseqProfile
     pub fn each_object_mut(&mut self, callback: impl Fn(&mut VALUE)) {
-        for types in self.opnd_types.iter_mut() {
-            for opnd_type in types.iter_mut() {
-                if let Some(object) = opnd_type.gc_object_mut() {
-                    callback(object);
+        for operands in &mut self.opnd_types {
+            for distribution in operands {
+                for ref mut profiled_type in distribution.each_item_mut() {
+                    // If the type is a GC object, call the callback
+                    callback(&mut profiled_type.class);
                 }
             }
         }


### PR DESCRIPTION
ZJIT uses the interpreter to take type profiles of what objects pass through
the code. It stores a compressed record of the history per opcode for the
opcodes we select.

Before this change, we re-used the HIR Type data-structure, a shallow type
lattice, to store historical type information. This was quick for bringup but
is quite lossy as profiles go: we get one bit per built-in type seen, and if we
see a non-built-in type in addition, we end up with BasicObject. Not very
helpful. Additionally, it does not give us any notion of cardinality: how many
of each type did we see?

This change brings with it a much more interesting slice of type history: a
histogram. A Distribution holds a record of the top-N (where N is fixed at Ruby
compile-time) `(Class, ShapeId)` pairs and their counts. It also holds an
*other* count in case we see more than N pairs.

Using this distribution, we can make more informed decisions about when we
should use type information. We can determine if we are strictly monomorphic,
very nearly monomorphic, or something else. Maybe the call-site is polymorphic,
so we should have a polymorphic inline cache. Exciting stuff.

I also plumb this new distribution into the HIR part of the compilation
pipeline.