### PR TITLE
[Feature #21347] Add `open_timeout` as an overall timeout option for `TCPSocket.new`

### DIFF
--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -210,6 +210,10 @@ rsock_init_inetsock(
     VALUE resolv_timeout, VALUE connect_timeout, VALUE open_timeout,
     VALUE _fast_fallback, VALUE _test_mode_settings
 ) {
+    if (!NIL_P(open_timeout) && (!NIL_P(resolv_timeout) || !NIL_P(connect_timeout))) {
+        rb_raise(rb_eArgError, "Cannot specify open_timeout along with connect_timeout or resolv_timeout");
+    }
+
     struct inetsock_arg arg;
     arg.self = self;
     arg.io = Qnil;

--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -26,6 +26,14 @@ struct inetsock_arg
     VALUE open_timeout;
 };
 
+void
+rsock_raise_user_specified_timeout()
+{
+    VALUE errno_module = rb_const_get(rb_cObject, rb_intern("Errno"));
+    VALUE etimedout_error = rb_const_get(errno_module, rb_intern("ETIMEDOUT"));
+    rb_raise(etimedout_error, "user specified timeout");
+}
+
 static VALUE
 inetsock_cleanup(VALUE v)
 {
@@ -143,12 +151,7 @@ init_inetsock_internal(VALUE v)
             } else {
                 VALUE elapsed = rb_funcall(current_clocktime(), '-', 1, starts_at);
                 timeout = rb_funcall(open_timeout, '-', 1, elapsed);
-
-                if (rb_funcall(timeout, '<', 1, INT2FIX(0)) == Qtrue) {
-                    VALUE errno_module = rb_const_get(rb_cObject, rb_intern("Errno"));
-                    VALUE etimedout_error = rb_const_get(errno_module, rb_intern("ETIMEDOUT"));
-                    rb_raise(etimedout_error, "user specified timeout");
-                }
+                if (rb_funcall(timeout, '<', 1, INT2FIX(0)) == Qtrue) rsock_raise_user_specified_timeout();
             }
 
             if (status >= 0) {
@@ -1159,11 +1162,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
             }
         }
 
-        if (is_timeout_tv(user_specified_open_timeout_at, now)) {
-            VALUE errno_module = rb_const_get(rb_cObject, rb_intern("Errno"));
-            VALUE etimedout_error = rb_const_get(errno_module, rb_intern("ETIMEDOUT"));
-            rb_raise(etimedout_error, "user specified timeout");
-        }
+        if (is_timeout_tv(user_specified_open_timeout_at, now)) rsock_raise_user_specified_timeout();
 
         if (!any_addrinfos(&resolution_store)) {
             if (!in_progress_fds(arg->connection_attempt_fds_size) &&
@@ -1186,9 +1185,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                 resolution_store.is_all_finished) &&
                 (is_timeout_tv(user_specified_connect_timeout_at, now) ||
                 !in_progress_fds(arg->connection_attempt_fds_size))) {
-                VALUE errno_module = rb_const_get(rb_cObject, rb_intern("Errno"));
-                VALUE etimedout_error = rb_const_get(errno_module, rb_intern("ETIMEDOUT"));
-                rb_raise(etimedout_error, "user specified timeout");
+                rsock_raise_user_specified_timeout();
             }
         }
     }

--- a/ext/socket/lib/socket.rb
+++ b/ext/socket/lib/socket.rb
@@ -643,7 +643,7 @@ class Socket < BasicSocket
   #
   # [:resolv_timeout] Specifies the timeout in seconds from when the hostname resolution starts.
   # [:connect_timeout] This method sequentially attempts connecting to all candidate destination addresses.<br>The +connect_timeout+ specifies the timeout in seconds from the start of the connection attempt to the last candidate.<br>By default, all connection attempts continue until the timeout occurs.<br>When +fast_fallback:false+ is explicitly specified,<br>a timeout is set for each connection attempt and any connection attempt that exceeds its timeout will be canceled.
-  # [:open_timeout] Specifies the timeout in seconds from the start of the method execution.<br>If this timeout is reached while there are still addresses that have not yet been attempted for connection, no further attempts will be made.
+  # [:open_timeout] Specifies the timeout in seconds from the start of the method execution.<br>If this timeout is reached while there are still addresses that have not yet been attempted for connection, no further attempts will be made.<br>If this option is specified together with other timeout options, an +ArgumentError+ will be raised.
   # [:fast_fallback] Enables the Happy Eyeballs Version 2 algorithm (enabled by default).
   #
   # If a block is given, the block is called with the socket.

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -562,11 +562,7 @@ start:
 
     if (need_free) free_getaddrinfo_arg(arg);
 
-    if (timedout) {
-        VALUE errno_module = rb_const_get(rb_cObject, rb_intern("Errno"));
-        VALUE etimedout_error = rb_const_get(errno_module, rb_intern("ETIMEDOUT"));
-        rb_raise(etimedout_error, "user specified timeout");
-    }
+    if (timedout) rsock_raise_user_specified_timeout();
 
     // If the current thread is interrupted by asynchronous exception, the following raises the exception.
     // But if the current thread is interrupted by timer thread, the following returns; we need to manually retry.

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -454,6 +454,7 @@ void free_fast_fallback_getaddrinfo_shared(struct fast_fallback_getaddrinfo_shar
 #endif
 
 unsigned int rsock_value_timeout_to_msec(VALUE);
+void rsock_raise_user_specified_timeout(void);
 
 void rsock_init_basicsocket(void);
 void rsock_init_ipsocket(void);

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -355,7 +355,7 @@ int rsock_socket(int domain, int type, int proto);
 int rsock_detect_cloexec(int fd);
 VALUE rsock_init_sock(VALUE sock, int fd);
 VALUE rsock_sock_s_socketpair(int argc, VALUE *argv, VALUE klass);
-VALUE rsock_init_inetsock(VALUE sock, VALUE remote_host, VALUE remote_serv, VALUE local_host, VALUE local_serv, int type, VALUE resolv_timeout, VALUE connect_timeout, VALUE fast_fallback, VALUE test_mode_settings);
+VALUE rsock_init_inetsock(VALUE sock, VALUE remote_host, VALUE remote_serv, VALUE local_host, VALUE local_serv, int type, VALUE resolv_timeout, VALUE connect_timeout, VALUE open_timeout, VALUE fast_fallback, VALUE test_mode_settings);
 VALUE rsock_init_unixsock(VALUE sock, VALUE path, int server);
 
 struct rsock_send_arg {

--- a/ext/socket/sockssocket.c
+++ b/ext/socket/sockssocket.c
@@ -35,7 +35,7 @@ socks_init(VALUE sock, VALUE host, VALUE port)
         init = 1;
     }
 
-    return rsock_init_inetsock(sock, host, port, Qnil, Qnil, INET_SOCKS, Qnil, Qnil, Qfalse, Qnil);
+    return rsock_init_inetsock(sock, host, port, Qnil, Qnil, INET_SOCKS, Qnil, Qnil, Qnil, Qfalse, Qnil);
 }
 
 #ifdef SOCKS5

--- a/ext/socket/tcpserver.c
+++ b/ext/socket/tcpserver.c
@@ -36,7 +36,7 @@ tcp_svr_init(int argc, VALUE *argv, VALUE sock)
     VALUE hostname, port;
 
     rb_scan_args(argc, argv, "011", &hostname, &port);
-    return rsock_init_inetsock(sock, hostname, port, Qnil, Qnil, INET_SERVER, Qnil, Qnil, Qfalse, Qnil);
+    return rsock_init_inetsock(sock, hostname, port, Qnil, Qnil, INET_SERVER, Qnil, Qnil, Qnil, Qfalse, Qnil);
 }
 
 /*

--- a/ext/socket/tcpsocket.c
+++ b/ext/socket/tcpsocket.c
@@ -35,6 +35,7 @@
  *
  * [:resolv_timeout] Specifies the timeout in seconds from when the hostname resolution starts.
  * [:connect_timeout] This method sequentially attempts connecting to all candidate destination addresses.<br>The +connect_timeout+ specifies the timeout in seconds from the start of the connection attempt to the last candidate.<br>By default, all connection attempts continue until the timeout occurs.<br>When +fast_fallback:false+ is explicitly specified,<br>a timeout is set for each connection attempt and any connection attempt that exceeds its timeout will be canceled.
+ * [:open_timeout] Specifies the timeout in seconds from the start of the method execution.<br>If this timeout is reached while there are still addresses that have not yet been attempted for connection, no further attempts will be made.<br>If this option is specified together with other timeout options, an +ArgumentError+ will be raised.
  * [:fast_fallback] Enables the Happy Eyeballs Version 2 algorithm (enabled by default).
  */
 static VALUE
@@ -43,29 +44,32 @@ tcp_init(int argc, VALUE *argv, VALUE sock)
     VALUE remote_host, remote_serv;
     VALUE local_host, local_serv;
     VALUE opt;
-    static ID keyword_ids[4];
-    VALUE kwargs[4];
+    static ID keyword_ids[5];
+    VALUE kwargs[5];
     VALUE resolv_timeout = Qnil;
     VALUE connect_timeout = Qnil;
+    VALUE open_timeout = Qnil;
     VALUE fast_fallback = Qnil;
     VALUE test_mode_settings = Qnil;
 
     if (!keyword_ids[0]) {
         CONST_ID(keyword_ids[0], "resolv_timeout");
         CONST_ID(keyword_ids[1], "connect_timeout");
-        CONST_ID(keyword_ids[2], "fast_fallback");
-        CONST_ID(keyword_ids[3], "test_mode_settings");
+        CONST_ID(keyword_ids[2], "open_timeout");
+        CONST_ID(keyword_ids[3], "fast_fallback");
+        CONST_ID(keyword_ids[4], "test_mode_settings");
     }
 
     rb_scan_args(argc, argv, "22:", &remote_host, &remote_serv,
                         &local_host, &local_serv, &opt);
 
     if (!NIL_P(opt)) {
-        rb_get_kwargs(opt, keyword_ids, 0, 4, kwargs);
+        rb_get_kwargs(opt, keyword_ids, 0, 5, kwargs);
         if (kwargs[0] != Qundef) { resolv_timeout = kwargs[0]; }
         if (kwargs[1] != Qundef) { connect_timeout = kwargs[1]; }
-        if (kwargs[2] != Qundef) { fast_fallback = kwargs[2]; }
-        if (kwargs[3] != Qundef) { test_mode_settings = kwargs[3]; }
+        if (kwargs[2] != Qundef) { open_timeout = kwargs[2]; }
+        if (kwargs[3] != Qundef) { fast_fallback = kwargs[3]; }
+        if (kwargs[4] != Qundef) { test_mode_settings = kwargs[4]; }
     }
 
     if (fast_fallback == Qnil) {
@@ -75,8 +79,8 @@ tcp_init(int argc, VALUE *argv, VALUE sock)
 
     return rsock_init_inetsock(sock, remote_host, remote_serv,
                                local_host, local_serv, INET_CLIENT,
-                               resolv_timeout, connect_timeout, fast_fallback,
-                               test_mode_settings);
+                               resolv_timeout, connect_timeout, open_timeout,
+                               fast_fallback, test_mode_settings);
 }
 
 static VALUE

--- a/test/socket/test_tcp.rb
+++ b/test/socket/test_tcp.rb
@@ -73,6 +73,30 @@ class TestSocket_TCPSocket < Test::Unit::TestCase
     end
   end
 
+  def test_tcp_initialize_open_timeout
+    return if RUBY_PLATFORM =~ /mswin|mingw|cygwin/
+
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.connect_address.ip_port
+    server.close
+
+    assert_raise(Errno::ETIMEDOUT) do
+      TCPSocket.new(
+        "localhost",
+        port,
+        open_timeout: 0.01,
+        fast_fallback: true,
+        test_mode_settings: { delay: { ipv4: 1000 } }
+      )
+    end
+  end
+
+  def test_initialize_open_timeout_with_other_timeouts
+    assert_raise(ArgumentError) do
+      TCPSocket.new("localhost", 12345, open_timeout: 0.01, resolv_timeout: 0.01)
+    end
+  end
+
   def test_initialize_connect_timeout
     assert_raise(IO::TimeoutError, Errno::ENETUNREACH, Errno::EACCES) do
       TCPSocket.new("192.0.2.1", 80, connect_timeout: 0)


### PR DESCRIPTION
With this change, `TCPSocket.new` now accepts the `open_timeout` option.
This option raises an exception if the specified number of seconds has elapsed since the start of the method call, even if the operation is still in the middle of name resolution or connection attempts.

The addition of this option follows the same intent as the previously merged change to `Socket.tcp` .
[Feature #21347](https://bugs.ruby-lang.org/issues/21347)
https://github.com/ruby/ruby/pull/13368