### PR TITLE
[DOC] Bump autoconf requirement

### DIFF
--- a/doc/contributing/building_ruby.md
+++ b/doc/contributing/building_ruby.md
@@ -14,7 +14,7 @@
 
     If you want to build from the git repository, you will also need:
 
-    * [autoconf] - 2.67 or later
+    * [autoconf] - 2.70 or later
     * [gperf] - 3.1 or later
         * Usually unneeded; only if you edit some source files using gperf
     * ruby - 3.0 or later


### PR DESCRIPTION
Autoconf 2.70 or later is required to properly handle multi-line AC_CHECK_FUNCS lists. The recent changes in #13907 that split function lists across multiple lines require autoconf 2.70's improved whitespace handling.

Without autoconf 2.70+, the configure script generation fails with syntax errors like:
../configure: line 29306: syntax error near unexpected token `pthread_attr_get_np'

This is because autoconf 2.69 and earlier don't properly handle multi-line function lists in AC_CHECK_FUNCS without backslash continuations, while 2.70+ requires square brackets and handles newlines correctly.

cc @nobu 