### PR TITLE
ZJIT: Remove an extra slash from $(TESTS)

### DIFF
--- a/zjit/zjit.mk
+++ b/zjit/zjit.mk
@@ -56,7 +56,7 @@ zjit-check:
 
 .PHONY: zjit-test-all
 zjit-test-all:
-	$(MAKE) test-all RUST_BACKTRACE=1 TEST_EXCLUDES='--excludes-dir=$(top_srcdir)/test/.excludes-zjit --name=!/memory_leak/' RUN_OPTS='--zjit-call-threshold=1' TESTS='$(top_srcdir)/test/ruby/'
+	$(MAKE) test-all RUST_BACKTRACE=1 TEST_EXCLUDES='--excludes-dir=$(top_srcdir)/test/.excludes-zjit --name=!/memory_leak/' RUN_OPTS='--zjit-call-threshold=1' TESTS='$(top_srcdir)/test/ruby'
 
 ZJIT_BINDGEN_DIFF_OPTS =
 


### PR DESCRIPTION
The double slashes in the CI output bothers me. This PR removes the slash to fix it.

```
  # Running tests:
  
  [  1/164] 39877=../src/test/ruby//test_condition
  [  2/164] 39876=../src/test/ruby//enc/test_cp949
  [  3/164] 39879=../src/test/ruby//enc/test_emoji
  [  4/164] 39878=../src/test/ruby//test_thread_queue
  [  5/164] 39877=../src/test/ruby//test_frozen
  [  6/164] 39877=../src/test/ruby//test_float
  [  7/164] 39876=../src/test/ruby//test_require
  [  8/164] 39879=../src/test/ruby//test_namespace
  [  9/164] 39879=../src/test/ruby//enc/test_euc_kr
  [ 10/164] 39879=../src/test/ruby//test_unicode_escape
...
```