### PR TITLE
ZJIT: Define make recipes only when configured (+2 misc.)

### DIFF
--- a/defs/jit.mk
+++ b/defs/jit.mk
@@ -7,6 +7,12 @@
 RUST_LIB_TOUCH = touch $@
 
 ifneq ($(JIT_CARGO_SUPPORT),no)
+
+# Show Cargo progress when doing `make V=1`
+CARGO_VERBOSE_0 = -q
+CARGO_VERBOSE_1 =
+CARGO_VERBOSE = $(CARGO_VERBOSE_$(V))
+
 # NOTE: MACOSX_DEPLOYMENT_TARGET to match `rustc --print deployment-target` to avoid the warning below.
 #    ld: warning: object file (target/debug/libjit.a(<libcapstone object>)) was built for
 #    newer macOS version (15.2) than being linked (15.0)

--- a/yjit/yjit.mk
+++ b/yjit/yjit.mk
@@ -1,10 +1,5 @@
 # -*- mode: makefile-gmake; indent-tabs-mode: t -*-
 
-# Show Cargo progress when doing `make V=1`
-CARGO_VERBOSE_0 = -q
-CARGO_VERBOSE_1 =
-CARGO_VERBOSE = $(CARGO_VERBOSE_$(V))
-
 YJIT_SRC_FILES = $(wildcard \
 	$(top_srcdir)/yjit/Cargo.* \
 	$(top_srcdir)/yjit/src/*.rs \

--- a/zjit/zjit.mk
+++ b/zjit/zjit.mk
@@ -1,5 +1,8 @@
 # -*- mode: makefile-gmake; indent-tabs-mode: t -*-
 
+# Put no definitions when ZJIT isn't configured
+ifneq ($(ZJIT_SUPPORT),no)
+
 # Show Cargo progress when doing `make V=1`
 CARGO_VERBOSE_0 = -q
 CARGO_VERBOSE_1 =
@@ -12,6 +15,8 @@ ZJIT_SRC_FILES = $(wildcard \
 	$(top_srcdir)/zjit/src/*/*/*.rs \
 	$(top_srcdir)/zjit/src/*/*/*/*.rs \
 	)
+
+$(RUST_LIB): $(ZJIT_SRC_FILES)
 
 # Because of Cargo cache, if the actual binary is not changed from the
 # previous build, the mtime is preserved as the cached file.
@@ -29,10 +34,6 @@ $(BUILD_ZJIT_LIBS): $(ZJIT_SRC_FILES)
 	$(ECHO) 'building Rust ZJIT (release mode)'
 	+$(Q) $(RUSTC) $(ZJIT_RUSTC_ARGS)
 	$(ZJIT_LIB_TOUCH)
-endif
-
-ifneq ($(ZJIT_SUPPORT),no)
-$(RUST_LIB): $(ZJIT_SRC_FILES)
 endif
 
 # By using ZJIT_BENCH_OPTS instead of RUN_OPTS, you can skip passing the options to `make install`
@@ -110,4 +111,6 @@ libminiruby.a: miniruby$(EXEEXT)
 	$(Q) $(AR) $(ARFLAGS) $@ $(MINIOBJS) $(COMMONOBJS)
 
 libminiruby: libminiruby.a
-endif
+
+endif # ifneq ($(strip $(CARGO)),
+endif # ifneq ($(ZJIT_SUPPORT),no)

--- a/zjit/zjit.mk
+++ b/zjit/zjit.mk
@@ -3,11 +3,6 @@
 # Put no definitions when ZJIT isn't configured
 ifneq ($(ZJIT_SUPPORT),no)
 
-# Show Cargo progress when doing `make V=1`
-CARGO_VERBOSE_0 = -q
-CARGO_VERBOSE_1 =
-CARGO_VERBOSE = $(CARGO_VERBOSE_$(V))
-
 ZJIT_SRC_FILES = $(wildcard \
 	$(top_srcdir)/zjit/Cargo.* \
 	$(top_srcdir)/zjit/src/*.rs \


### PR DESCRIPTION
commit be68bcb0c9c3b6bb12b37aa6b17d2534be6e78c6

    DRY up CARGO_VERBOSE for JITs

commit 2aa5b15c36a74707bc7c076df0bba28a9c11d49b

    ZJIT: Define make recipes only when configured
    
    This gives a better signal when say you try to run `make zjit-test` on a
    YJIT-only build.

commit 90ddc74814ff5890b17555414d7c66ec7a6c904f

    ZJIT: Link to GH issue in comment [ci skip]
