### PR TITLE
YJIT: Side-exit on String#dup when it's not leaf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ path = "jit.rs"
 
 [features]
 disasm = ["yjit?/disasm", "zjit?/disasm"]
-# TODO(GH-642) Turning this on trips a btest failure.
-runtime_checks = [] # ["yjit?/runtime_checks", "zjit?/runtime_checks"]
+runtime_checks = ["yjit?/runtime_checks", "zjit?/runtime_checks"]
 yjit = [ "dep:yjit" ]
 zjit = [ "dep:zjit" ]
 

--- a/shape.h
+++ b/shape.h
@@ -48,7 +48,8 @@ enum shape_id_fl_type {
 
 // This masks allows to check if a shape_id contains any ivar.
 // It rely on ROOT_SHAPE_WITH_OBJ_ID==1.
-#define SHAPE_ID_HAS_IVAR_MASK (SHAPE_ID_FL_TOO_COMPLEX | (SHAPE_ID_OFFSET_MASK - 1))
+#define SHAPE_ID_HAS_IVAR_MASK 0x807fffe
+STATIC_ASSERT(shape_id_has_ivar_mask, SHAPE_ID_HAS_IVAR_MASK == (SHAPE_ID_FL_TOO_COMPLEX | (SHAPE_ID_OFFSET_MASK - 1)));
 
 // The interpreter doesn't care about frozen status or slot size when reading ivars.
 // So we normalize shape_id by clearing these bits to improve cache hits.

--- a/shape.h
+++ b/shape.h
@@ -48,8 +48,9 @@ enum shape_id_fl_type {
 
 // This masks allows to check if a shape_id contains any ivar.
 // It rely on ROOT_SHAPE_WITH_OBJ_ID==1.
-#define SHAPE_ID_HAS_IVAR_MASK 0x807fffe
-STATIC_ASSERT(shape_id_has_ivar_mask, SHAPE_ID_HAS_IVAR_MASK == (SHAPE_ID_FL_TOO_COMPLEX | (SHAPE_ID_OFFSET_MASK - 1)));
+enum {
+    SHAPE_ID_HAS_IVAR_MASK = SHAPE_ID_FL_TOO_COMPLEX | (SHAPE_ID_OFFSET_MASK - 1),
+};
 
 // The interpreter doesn't care about frozen status or slot size when reading ivars.
 // So we normalize shape_id by clearing these bits to improve cache hits.

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -103,6 +103,7 @@ fn main() {
         .allowlist_function("rb_yjit_shape_capacity")
         .allowlist_function("rb_yjit_shape_index")
         .allowlist_var("SHAPE_ID_NUM_BITS")
+        .allowlist_var("SHAPE_ID_HAS_IVAR_MASK")
 
         // From ruby/internal/intern/object.h
         .allowlist_function("rb_obj_is_kind_of")
@@ -228,7 +229,6 @@ fn main() {
         .allowlist_function("rb_obj_as_string_result")
         .allowlist_function("rb_str_byte_substr")
         .allowlist_function("rb_str_substr_two_fixnums")
-        .allowlist_function("rb_str_dup_m")
 
         // From include/ruby/internal/intern/parse.h
         .allowlist_function("rb_backref_get")

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -171,6 +171,7 @@ pub const VM_ENV_DATA_INDEX_SPECVAL: i32 = -1;
 pub const VM_ENV_DATA_INDEX_FLAGS: u32 = 0;
 pub const VM_BLOCK_HANDLER_NONE: u32 = 0;
 pub const SHAPE_ID_NUM_BITS: u32 = 32;
+pub const SHAPE_ID_HAS_IVAR_MASK: u32 = 134742014;
 pub type ID = ::std::os::raw::c_ulong;
 pub type rb_alloc_func_t = ::std::option::Option<unsafe extern "C" fn(klass: VALUE) -> VALUE>;
 pub const RUBY_Qfalse: ruby_special_consts = 0;
@@ -1120,7 +1121,6 @@ extern "C" {
     pub fn rb_gvar_set(arg1: ID, arg2: VALUE) -> VALUE;
     pub fn rb_ensure_iv_list_size(obj: VALUE, current_len: u32, newsize: u32);
     pub fn rb_vm_barrier();
-    pub fn rb_str_dup_m(str_: VALUE) -> VALUE;
     pub fn rb_str_byte_substr(str_: VALUE, beg: VALUE, len: VALUE) -> VALUE;
     pub fn rb_str_substr_two_fixnums(
         str_: VALUE,

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -171,7 +171,6 @@ pub const VM_ENV_DATA_INDEX_SPECVAL: i32 = -1;
 pub const VM_ENV_DATA_INDEX_FLAGS: u32 = 0;
 pub const VM_BLOCK_HANDLER_NONE: u32 = 0;
 pub const SHAPE_ID_NUM_BITS: u32 = 32;
-pub const SHAPE_ID_HAS_IVAR_MASK: u32 = 134742014;
 pub type ID = ::std::os::raw::c_ulong;
 pub type rb_alloc_func_t = ::std::option::Option<unsafe extern "C" fn(klass: VALUE) -> VALUE>;
 pub const RUBY_Qfalse: ruby_special_consts = 0;
@@ -690,6 +689,8 @@ pub const VM_ENV_FLAG_ISOLATED: vm_frame_env_flags = 16;
 pub type vm_frame_env_flags = u32;
 pub type attr_index_t = u16;
 pub type shape_id_t = u32;
+pub const SHAPE_ID_HAS_IVAR_MASK: _bindgen_ty_37 = 134742014;
+pub type _bindgen_ty_37 = u32;
 #[repr(C)]
 pub struct rb_cvar_class_tbl_entry {
     pub index: u32,


### PR DESCRIPTION
This fixes https://github.com/ruby/ruby/commit/ccbbe06a0277db74cfbf7dc1f26722cbf4904b72.

`rb_obj_dup` is not leaf, so it gives a wrong backtrace if you skip pushing a frame when the string has ivars and falls back to `rb_obj_dup`. This PR changes it to side-exit, reversing the simplification we made in https://github.com/ruby/ruby/pull/13606.