### PR TITLE
Revert "Suppress occasional autoconf warnings"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2815,12 +2815,12 @@ AS_IF([test "$THREAD_MODEL" = pthread], [
     ], [
 	AC_DEFINE(NON_SCALAR_THREAD_ID)
     ])
-    AC_CHECK_FUNCS([sched_yield pthread_attr_setinheritsched
-	pthread_attr_get_np pthread_attr_getstack pthread_attr_getguardsize
-	pthread_get_stackaddr_np pthread_get_stacksize_np
-	thr_stksegment pthread_stackseg_np pthread_getthrds_np
-	pthread_condattr_setclock
-	pthread_setname_np pthread_set_name_np])
+    AC_CHECK_FUNCS(sched_yield pthread_attr_setinheritsched \
+	pthread_attr_get_np pthread_attr_getstack pthread_attr_getguardsize \
+	pthread_get_stackaddr_np pthread_get_stacksize_np \
+	thr_stksegment pthread_stackseg_np pthread_getthrds_np \
+	pthread_condattr_setclock \
+	pthread_setname_np pthread_set_name_np)
     AS_CASE(["$target_os"],[emscripten*],[ac_cv_func_pthread_sigmask=no],[AC_CHECK_FUNCS(pthread_sigmask)])
     AS_CASE(["$target_os"],[aix*],[ac_cv_func_pthread_getattr_np=no],[AC_CHECK_FUNCS(pthread_getattr_np)])
     set_current_thread_name=


### PR DESCRIPTION
This reverts commit 32bfb61d349b49ddedb7d34d9e434063324aafcc, that requires autoconf 2.70's improved whitespace handling.
It is too early for some platforms yet.

Fix GH-13910