### PR TITLE
[3.4 backport] YJIT: Explicitly specify C ABI to fix Rust warning

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -7403,7 +7403,7 @@ enum IseqReturn {
     Receiver,
 }
 
-extern {
+extern "C" {
     fn rb_simple_iseq_p(iseq: IseqPtr) -> bool;
     fn rb_iseq_only_kwparam_p(iseq: IseqPtr) -> bool;
 }


### PR DESCRIPTION
Backport of 7e733ca55168e3b1f10b685f6e9a52cf1deb5aff to
fix [[Bug #21514]](https://bugs.ruby-lang.org/issues/21514).
