### PR TITLE
Fix size assertion in concurrent set resizing

### DIFF
--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -139,7 +139,7 @@ concurrent_set_try_resize_without_locking(VALUE old_set_obj, VALUE *set_obj_ptr)
             if (entry->key == CONCURRENT_SET_EMPTY) {
                 new_set->size++;
 
-                RUBY_ASSERT(new_set->size < new_set->capacity / 2);
+                RUBY_ASSERT(new_set->size <= new_set->capacity / 2);
                 RUBY_ASSERT(entry->hash == 0);
 
                 entry->key = key;


### PR DESCRIPTION
Since we resize when `prev_size > set->capacity / 2`, it's possible that `prev_size == set->capacity / 2`, so we need to change the assertion in concurrent_set_try_resize_without_locking to be `new_set->size <= new_set->capacity / 2`.