### PR TITLE
ZJIT: Precise GC writebarriers

### DIFF
--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -88,11 +88,10 @@ fn profile_operands(profiler: &mut Profiler, profile: &mut IseqProfile, n: usize
     for i in 0..n {
         let opnd_type = Type::from_value(profiler.peek_at_stack((n - i - 1) as isize));
         types[i] = types[i].union(opnd_type);
+        if let Some(object) = types[i].gc_object() {
+            unsafe { rb_gc_writebarrier(profiler.iseq.into(), object) };
+        }
     }
-    // In the loop above, we probably added a new reference to the profile through
-    // the VALUE in Type. It's messy and relatively slow to conditionally run a
-    // write barrier for each Type, so just remember to re-mark the iseq.
-    unsafe { rb_gc_writebarrier_remember(profiler.iseq.into()) };
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This issues writebarriers for objects added via gc_offsets or by profiling. This may be slower than writebarrier_remember, but we would like it to be more debuggable.

We found the lack of gc_offset writebarriers via [wbcheck](https://github.com/ruby/ruby/pull/13557)