### PR TITLE
ZJIT: Give up JIT-to-JIT calls for 6+ args

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -133,6 +133,21 @@ class TestZJIT < Test::Unit::TestCase
     }
   end
 
+  def test_send_with_six_args
+    assert_compiles '[1, 2, 3, 4, 5, 6]', %q{
+      def foo(a1, a2, a3, a4, a5, a6)
+        [a1, a2, a3, a4, a5, a6]
+      end
+
+      def test
+        foo(1, 2, 3, 4, 5, 6)
+      end
+
+      test # profile send
+      test
+    }, call_threshold: 2
+  end
+
   def test_invokebuiltin
     omit 'Test fails at the moment due to not handling optional parameters'
     assert_compiles '["."]', %q{

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -291,6 +291,9 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::IfTrue { val, target } => return gen_if_true(jit, asm, opnd!(val), target),
         Insn::IfFalse { val, target } => return gen_if_false(jit, asm, opnd!(val), target),
         Insn::SendWithoutBlock { call_info, cd, state, self_val, args, .. } => gen_send_without_block(jit, asm, call_info, *cd, &function.frame_state(*state), opnd!(self_val), opnds!(args))?,
+        // Give up SendWithoutBlockDirect for 6+ args since asm.ccall() doesn't support it.
+        Insn::SendWithoutBlockDirect { call_info, cd, state, self_val, args, .. } if args.len() + 1 > C_ARG_OPNDS.len() => // +1 for self
+            gen_send_without_block(jit, asm, call_info, *cd, &function.frame_state(*state), opnd!(self_val), opnds!(args))?,
         Insn::SendWithoutBlockDirect { cme, iseq, self_val, args, state, .. } => gen_send_without_block_direct(cb, jit, asm, *cme, *iseq, opnd!(self_val), opnds!(args), &function.frame_state(*state))?,
         Insn::InvokeBuiltin { bf, args, state } => gen_invokebuiltin(asm, &function.frame_state(*state), bf, opnds!(args))?,
         Insn::Return { val } => return Some(gen_return(jit, asm, opnd!(val))?),


### PR DESCRIPTION
This PR fixes the following panic on blurhash benchmark:

```
thread '<unnamed>' panicked at zjit/src/backend/x86_64/mod.rs:349:21:
assertion failed: opnds.len() <= C_ARG_OPNDS.len()
```

Since our current `asm.ccall()` supports only six arguments, we can't use `SendWithoutBlockDirect` that passes method params as arguments to `asm.ccall()`. Let's use `SendWithoutBlock` until we fix `asm.ccall()`.