### PR TITLE
ZJIT: Fix fixnum folding for negative values

### DIFF
--- a/test/.excludes-zjit/TestTime.rb
+++ b/test/.excludes-zjit/TestTime.rb
@@ -1,1 +1,0 @@
-exclude(/test_/, 'Tests make ZJIT panic')

--- a/test/.excludes-zjit/TestTimeTZ.rb
+++ b/test/.excludes-zjit/TestTimeTZ.rb
@@ -1,1 +1,0 @@
-exclude(/test_/, 'Tests make ZJIT panic')


### PR DESCRIPTION
Use `fixnum_from_isize` instead of `fixnum_from_usize` in `fold_fixnum_bop` to properly handle negative values. Casting negative `i64` to `usize` produces large unsigned values that exceed `RUBY_FIXNUM_MAX`.

This fix allows us to run ZJIT against more tests.