### PR TITLE
[Backport #21370] compile.c: Handle anonymous variables in `outer_variable_cmp`

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -13234,6 +13234,13 @@ outer_variable_cmp(const void *a, const void *b, void *arg)
 {
     const struct outer_variable_pair *ap = (const struct outer_variable_pair *)a;
     const struct outer_variable_pair *bp = (const struct outer_variable_pair *)b;
+
+    if (!ap->name) {
+        return -1;
+    } else if (!bp->name) {
+        return 1;
+    }
+
     return rb_str_cmp(ap->name, bp->name);
 }
 

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -905,6 +905,25 @@ class TestISeq < Test::Unit::TestCase
     end
   end
 
+  def test_serialize_anonymous_outer_variables
+    iseq = RubyVM::InstructionSequence.compile(<<~'RUBY')
+      obj = Object.new
+      def obj.test
+        [1].each do
+          raise "Oops"
+        rescue
+          return it
+        end
+      end
+      obj
+    RUBY
+
+    binary = iseq.to_binary # [Bug # 21370]
+    roundtripped_iseq = RubyVM::InstructionSequence.load_from_binary(binary)
+    object = roundtripped_iseq.eval
+    assert_equal 1, object.test
+  end
+
   def test_loading_kwargs_memory_leak
     assert_no_memory_leak([], "#{<<~"begin;"}", "#{<<~'end;'}", rss: true)
     a = RubyVM::InstructionSequence.compile("foo(bar: :baz)").to_binary


### PR DESCRIPTION
This PR attempts to backport https://github.com/ruby/ruby/pull/13436 to ruby_3_4.