### PR TITLE
Revert "[Bug #21256] Fix `it` parameter when splatting and `define_method` is used"

### DIFF
--- a/prism_compile.c
+++ b/prism_compile.c
@@ -6777,17 +6777,6 @@ pm_compile_scope_node(rb_iseq_t *iseq, pm_scope_node_t *scope_node, const pm_nod
         body->param.flags.has_lead = true;
     }
 
-    if (scope_node->parameters && PM_NODE_TYPE_P(scope_node->parameters, PM_IT_PARAMETERS_NODE)) {
-        const uint8_t param_name[] = { 'i', 't' };
-        pm_constant_id_t constant_id = pm_constant_pool_find(&scope_node->parser->constant_pool, param_name, 2);
-        RUBY_ASSERT(constant_id && "parser should fill in `it` parameter");
-        pm_insert_local_index(constant_id, local_index, index_lookup_table, local_table_for_iseq, scope_node);
-
-        local_index++;
-        body->param.lead_num = 1;
-        body->param.flags.has_lead = true;
-    }
-
     //********END OF STEP 3**********
 
     //********STEP 4**********

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1957,19 +1957,6 @@ eom
     assert_equal(/9/, eval('9.then { /#{it}/o }'))
   end
 
-  def test_it_with_splat_super_method
-    bug21256 = '[ruby-core:121592] [Bug #21256]'
-
-    a = Class.new do
-      define_method(:foo) { it }
-    end
-    b = Class.new(a) do
-      def foo(*args) = super
-    end
-
-    assert_equal(1, b.new.foo(1), bug21256)
-  end
-
   def test_value_expr_in_condition
     mesg = /void value expression/
     assert_syntax_error("tap {a = (true ? next : break)}", mesg)


### PR DESCRIPTION
Reverts ruby/ruby#13108

That change caused the following ASAN error:

https://ci.rvm.jp/results/trunk_asan@ruby-sp1/5837210
```
=================================================================
--
  | ==178168==ERROR: AddressSanitizer: dynamic-stack-buffer-overflow on address 0x7ffe1edb26b0 at pc 0x5e3d13c2362d bp 0x7ffe1edb2670 sp 0x7ffe1edb2668
  | WRITE of size 8 at 0x7ffe1edb26b0 thread T0
  | #0 0x5e3d13c2362c in pm_insert_local_index /tmp/ruby/src/trunk_asan/prism_compile.c:4681:44
  | #1 0x5e3d13c2362c in pm_compile_scope_node /tmp/ruby/src/trunk_asan/prism_compile.c:6784:9
  | #2 0x5e3d13b38b6e in pm_compile_node /tmp/ruby/src/trunk_asan/prism_compile.c:10253:9
  | #3 0x5e3d13b30165 in pm_iseq_compile_node /tmp/ruby/src/trunk_asan/prism_compile.c:10564:9
  | #4 0x5e3d135a4b8a in pm_iseq_new_with_opt_try /tmp/ruby/src/trunk_asan/iseq.c:1057:5
  | #5 0x5e3d134b2b07 in rb_protect /tmp/ruby/src/trunk_asan/eval.c:1060:18
  | #6 0x5e3d135a3110 in pm_iseq_new_with_opt /tmp/ruby/src/trunk_asan/iseq.c:1110:5
  | #7 0x5e3d13c2f1a1 in pm_new_child_iseq /tmp/ruby/src/trunk_asan/prism_compile.c:1261:27
  | #8 0x5e3d13c2f1a1 in pm_compile_call /tmp/ruby/src/trunk_asan/prism_compile.c:3703:22
  | #9 0x5e3d13bd70d8 in pm_compile_call_node /tmp/ruby/src/trunk_asan/prism_compile.c:7476:5
  | #10 0x5e3d13b3650a in pm_compile_node /tmp/ruby/src/trunk_asan/prism_compile.c:8848:9
  | #11 0x5e3d13b3bab6 in pm_compile_node /tmp/ruby/src/trunk_asan/prism_compile.c
  | #12 0x5e3d13c1d23c in pm_compile_scope_node /tmp/ruby/src/trunk_asan/prism_compile.c:7026:13
  | #13 0x5e3d13b38b6e in pm_compile_node /tmp/ruby/src/trunk_asan/prism_compile.c:10253:9
  | #14 0x5e3d13b30165 in pm_iseq_compile_node /tmp/ruby/src/trunk_asan/prism_compile.c:10564:9
  | #15 0x5e3d135a4b8a in pm_iseq_new_with_opt_try /tmp/ruby/src/trunk_asan/iseq.c:1057:5
  | #16 0x5e3d134b2b07 in rb_protect /tmp/ruby/src/trunk_asan/eval.c:1060:18
  | #17 0x5e3d135a3110 in pm_iseq_new_with_opt /tmp/ruby/src/trunk_asan/iseq.c:1110:5
  | #18 0x5e3d13be3d22 in pm_new_child_iseq /tmp/ruby/src/trunk_asan/prism_compile.c:1261:27
  | #19 0x5e3d13b35cfc in pm_compile_node /tmp/ruby/src/trunk_asan/prism_compile.c:9127:34
  | #20 0x5e3d13b3ba45 in pm_compile_node /tmp/ruby/src/trunk_asan/prism_compile.c:10380:17
  | #21 0x5e3d13c1c52a in pm_compile_scope_node /tmp/ruby/src/trunk_asan/prism_compile.c:7064:13
  | #22 0x5e3d13b38b6e in pm_compile_node /tmp/ruby/src/trunk_asan/prism_compile.c:10253:9
  | #23 0x5e3d13b2ffff in pm_iseq_compile_node /tmp/ruby/src/trunk_asan/prism_compile.c:10554:9
  | #24 0x5e3d135a4b8a in pm_iseq_new_with_opt_try /tmp/ruby/src/trunk_asan/iseq.c:1057:5
  | #25 0x5e3d134b2b07 in rb_protect /tmp/ruby/src/trunk_asan/eval.c:1060:18
  | #26 0x5e3d135a3110 in pm_iseq_new_with_opt /tmp/ruby/src/trunk_asan/iseq.c:1110:5
  | #27 0x5e3d135b7038 in pm_iseq_compile_with_option /tmp/ruby/src/trunk_asan/iseq.c:1379:16
  | #28 0x5e3d135b7038 in iseqw_s_compile_parser /tmp/ruby/src/trunk_asan/iseq.c:1588:16
  | #29 0x5e3d138ded57 in vm_call_cfunc_with_frame_ /tmp/ruby/src/trunk_asan/vm_insnhelper.c:3784:11
  | #30 0x5e3d138823ab in vm_sendish /tmp/ruby/src/trunk_asan/vm_insnhelper.c:5991:15
  | #31 0x5e3d138823ab in vm_exec_core /tmp/ruby/build/trunk_asan/../../src/trunk_asan/insns.def:899:11
  | #32 0x5e3d13870d8a in rb_vm_exec /tmp/ruby/src/trunk_asan/vm.c:2621:22
  | #33 0x5e3d138fea81 in invoke_iseq_block_from_c /tmp/ruby/src/trunk_asan/vm.c:1651:12
  | #34 0x5e3d138fea81 in invoke_block_from_c_bh /tmp/ruby/src/trunk_asan/vm.c:1665:20
  | #35 0x5e3d138a1f47 in vm_yield_with_cref /tmp/ruby/src/trunk_asan/vm.c:1702:12
  | #36 0x5e3d138a1f47 in vm_yield /tmp/ruby/src/trunk_asan/vm.c:1710:12
  | #37 0x5e3d138a1f47 in rb_yield_0 /tmp/ruby/src/trunk_asan/vm_eval.c:1362:12
  | #38 0x5e3d138a1f47 in rb_yield /tmp/ruby/src/trunk_asan/vm_eval.c
  | #39 0x5e3d13a64c62 in rb_ary_collect /tmp/ruby/src/trunk_asan/array.c:3654:30
  | #40 0x5e3d138ded57 in vm_call_cfunc_with_frame_ /tmp/ruby/src/trunk_asan/vm_insnhelper.c:3784:11
  | #41 0x5e3d1387cc79 in vm_sendish /tmp/ruby/src/trunk_asan/vm_insnhelper.c:5991:15
  | #42 0x5e3d1387cc79 in vm_exec_core /tmp/ruby/build/trunk_asan/../../src/trunk_asan/insns.def:851:11
  | #43 0x5e3d1387117a in vm_exec_loop /tmp/ruby/src/trunk_asan/vm.c:2648:22
  | #44 0x5e3d1387117a in rb_vm_exec /tmp/ruby/src/trunk_asan/vm.c:2627:18
  | #45 0x5e3d138fea81 in invoke_iseq_block_from_c /tmp/ruby/src/trunk_asan/vm.c:1651:12
  | #46 0x5e3d138fea81 in invoke_block_from_c_bh /tmp/ruby/src/trunk_asan/vm.c:1665:20
  | #47 0x5e3d138a1f47 in vm_yield_with_cref /tmp/ruby/src/trunk_asan/vm.c:1702:12
  | #48 0x5e3d138a1f47 in vm_yield /tmp/ruby/src/trunk_asan/vm.c:1710:12
  | #49 0x5e3d138a1f47 in rb_yield_0 /tmp/ruby/src/trunk_asan/vm_eval.c:1362:12
  | #50 0x5e3d138a1f47 in rb_yield /tmp/ruby/src/trunk_asan/vm_eval.c
  | #51 0x5e3d13a64c62 in rb_ary_collect /tmp/ruby/src/trunk_asan/array.c:3654:30
  | #52 0x5e3d138ded57 in vm_call_cfunc_with_frame_ /tmp/ruby/src/trunk_asan/vm_insnhelper.c:3784:11
  | #53 0x5e3d1387cc79 in vm_sendish /tmp/ruby/src/trunk_asan/vm_insnhelper.c:5991:15
  | #54 0x5e3d1387cc79 in vm_exec_core /tmp/ruby/build/trunk_asan/../../src/trunk_asan/insns.def:851:11
  | #55 0x5e3d1387117a in vm_exec_loop /tmp/ruby/src/trunk_asan/vm.c:2648:22
  | #56 0x5e3d1387117a in rb_vm_exec /tmp/ruby/src/trunk_asan/vm.c:2627:18
  | #57 0x5e3d138b8db7 in rb_iseq_eval_main /tmp/ruby/src/trunk_asan/vm.c:2901:11
  | #58 0x5e3d134aed94 in rb_ec_exec_node /tmp/ruby/src/trunk_asan/eval.c:282:9
  | #59 0x5e3d134aed94 in ruby_run_node /tmp/ruby/src/trunk_asan/eval.c:320:30
  | #60 0x5e3d134a7c36 in rb_main /tmp/ruby/src/trunk_asan/main.c:42:12
  | #61 0x5e3d134a7c36 in main /tmp/ruby/src/trunk_asan/main.c:62:12
  | #62 0x7fdf6ea2a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
  | #63 0x7fdf6ea2a28a in __libc_start_main csu/../csu/libc-start.c:360:3
  | #64 0x5e3d133cba04 in _start (/tmp/ruby/build/trunk_asan/ruby+0x16ba04) (BuildId: 9b3561139ee9b38241d6a8b17d91f5e8f9fa8415)
```

PM_IT_PARAMETERS_NODE is already handled here:

https://github.com/ruby/ruby/blob/81515aca67a0d3cc50205ff0a99cdc44ed0a927d/prism_compile.c#L6421-L6424

That change adds another handling code for PM_IT_PARAMETERS_NODE, which results in adding two local variable entries.

https://github.com/ruby/ruby/blob/81515aca67a0d3cc50205ff0a99cdc44ed0a927d/prism_compile.c#L6780-L6789

I tried to revert the first, old handling code, but it caused the following errors:

```
  1) Failure:
TestProc#test_parameters_lambda [/home/mame/work/ruby/test/ruby/test_proc.rb:1445]:
<[[:req]]> expected but was
<[[:req, :it]]>.

  2) Failure:
TestProc#test_parameters [/home/mame/work/ruby/test/ruby/test_proc.rb:1395]:
<[[:opt]]> expected but was
<[[:opt, :it]]>.

  3) Failure:
TestProc#test_it_is_not_local_variable [/home/mame/work/ruby/test/ruby/test_proc.rb:1691]:
<[]> expected but was
<[:it]>.

  4) Failure:
TestSyntax#test_it [/home/mame/work/ruby/test/ruby/test_syntax.rb:1943]:
<[:a]> expected but was
<[0]>.
```

Looks like the proper fix is not trivial, so I revert that change for now.
