### PR TITLE
Use concurrent set for global symbol table

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -7578,6 +7578,7 @@ gc.$(OBJEXT): $(top_srcdir)/internal/class.h
 gc.$(OBJEXT): $(top_srcdir)/internal/compile.h
 gc.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 gc.$(OBJEXT): $(top_srcdir)/internal/complex.h
+gc.$(OBJEXT): $(top_srcdir)/internal/concurrent_set.h
 gc.$(OBJEXT): $(top_srcdir)/internal/cont.h
 gc.$(OBJEXT): $(top_srcdir)/internal/error.h
 gc.$(OBJEXT): $(top_srcdir)/internal/eval.h
@@ -19064,6 +19065,7 @@ symbol.$(OBJEXT): $(top_srcdir)/internal/array.h
 symbol.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 symbol.$(OBJEXT): $(top_srcdir)/internal/class.h
 symbol.$(OBJEXT): $(top_srcdir)/internal/compilers.h
+symbol.$(OBJEXT): $(top_srcdir)/internal/concurrent_set.h
 symbol.$(OBJEXT): $(top_srcdir)/internal/error.h
 symbol.$(OBJEXT): $(top_srcdir)/internal/gc.h
 symbol.$(OBJEXT): $(top_srcdir)/internal/hash.h

--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -176,6 +176,61 @@ concurrent_set_try_resize(VALUE old_set_obj, VALUE *set_obj_ptr)
 }
 
 VALUE
+rb_concurrent_set_find(VALUE *set_obj_ptr, VALUE key)
+{
+    RUBY_ASSERT(key >= CONCURRENT_SET_SPECIAL_VALUE_COUNT);
+
+    VALUE set_obj;
+
+  retry:
+    set_obj = RUBY_ATOMIC_VALUE_LOAD(*set_obj_ptr);
+    RUBY_ASSERT(set_obj);
+    struct concurrent_set *set = RTYPEDDATA_GET_DATA(set_obj);
+
+    struct concurrent_set_probe probe;
+    VALUE hash = set->funcs->hash(key);
+    int idx = concurrent_set_probe_start(&probe, set, hash);
+
+    while (true) {
+        struct concurrent_set_entry *entry = &set->entries[idx];
+        VALUE curr_key = RUBY_ATOMIC_VALUE_LOAD(entry->key);
+
+        switch (curr_key) {
+          case CONCURRENT_SET_EMPTY:
+            return 0;
+          case CONCURRENT_SET_DELETED:
+            break;
+          case CONCURRENT_SET_MOVED:
+            // Wait
+            RB_VM_LOCKING();
+
+            goto retry;
+          default: {
+            VALUE curr_hash = RUBY_ATOMIC_VALUE_LOAD(entry->hash);
+            if ((curr_hash == hash || curr_hash == 0) && set->funcs->cmp(key, curr_key)) {
+                // We've found a match.
+                if (UNLIKELY(!RB_SPECIAL_CONST_P(curr_key) && rb_objspace_garbage_object_p(curr_key))) {
+                    // This is a weakref set, so after marking but before sweeping is complete we may find a matching garbage object.
+                    // Skip it and mark it as deleted.
+                    RUBY_ATOMIC_VALUE_CAS(entry->key, curr_key, CONCURRENT_SET_DELETED);
+
+                    // Fall through and continue our search.
+                }
+                else {
+                    RB_GC_GUARD(set_obj);
+                    return curr_key;
+                }
+            }
+
+            break;
+          }
+        }
+
+        idx = concurrent_set_probe_next(&probe);
+    }
+}
+
+VALUE
 rb_concurrent_set_find_or_insert(VALUE *set_obj_ptr, VALUE key, void *data)
 {
     RUBY_ASSERT(key >= CONCURRENT_SET_SPECIAL_VALUE_COUNT);

--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -304,6 +304,14 @@ rb_concurrent_set_find_or_insert(VALUE *set_obj_ptr, VALUE key, void *data)
             if (set->funcs->cmp(key, curr_key)) {
                 // We've found a match.
                 RB_GC_GUARD(set_obj);
+
+                if (inserting) {
+                    // We created key using set->funcs->create, but we didn't end
+                    // up inserting it into the set. Free it here to prevent memory
+                    // leaks.
+                    if (set->funcs->free) set->funcs->free(key);
+                }
+
                 return curr_key;
             }
 

--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -363,6 +363,7 @@ rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key
     struct concurrent_set *set = RTYPEDDATA_GET_DATA(set_obj);
 
     for (unsigned int i = 0; i < set->capacity; i++) {
+        struct concurrent_set_entry *entry = &set->entries[i];
         VALUE key = set->entries[i].key;
 
         switch (key) {
@@ -373,7 +374,7 @@ rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key
             rb_bug("rb_concurrent_set_foreach_with_replace: moved entry");
             break;
           default: {
-            int ret = callback(&set->entries[i].key, data);
+            int ret = callback(&entry->key, data);
             switch (ret) {
               case ST_STOP:
                 return;

--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -61,6 +61,14 @@ rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity)
     return obj;
 }
 
+rb_atomic_t
+rb_concurrent_set_size(VALUE set_obj)
+{
+    struct concurrent_set *set = RTYPEDDATA_GET_DATA(set_obj);
+
+    return RUBY_ATOMIC_LOAD(set->size);
+}
+
 struct concurrent_set_probe {
     int idx;
     int d;

--- a/gc.c
+++ b/gc.c
@@ -3168,11 +3168,6 @@ rb_gc_mark_children(void *objspace, VALUE obj)
     switch (BUILTIN_TYPE(obj)) {
       case T_FLOAT:
       case T_BIGNUM:
-      case T_SYMBOL:
-        /* Not immediates, but does not have references and singleton class.
-         *
-         * RSYMBOL(obj)->fstr intentionally not marked. See log for 96815f1e
-         * ("symbol.c: remove rb_gc_mark_symbols()") */
         return;
 
       case T_NIL:
@@ -3228,6 +3223,10 @@ rb_gc_mark_children(void *objspace, VALUE obj)
 
       case T_HASH:
         mark_hash(obj);
+        break;
+
+      case T_SYMBOL:
+        gc_mark_internal(RSYMBOL(obj)->fstr);
         break;
 
       case T_STRING:

--- a/gc.c
+++ b/gc.c
@@ -91,6 +91,7 @@
 #include "internal/class.h"
 #include "internal/compile.h"
 #include "internal/complex.h"
+#include "internal/concurrent_set.h"
 #include "internal/cont.h"
 #include "internal/error.h"
 #include "internal/eval.h"
@@ -344,6 +345,7 @@ rb_gc_shutdown_call_finalizer_p(VALUE obj)
         if (rb_obj_is_fiber(obj)) return false;
         if (rb_obj_is_main_ractor(obj)) return false;
         if (rb_obj_is_fstring_table(obj)) return false;
+        if (rb_obj_is_symbol_table(obj)) return false;
 
         return true;
 
@@ -3864,9 +3866,6 @@ update_iclass_classext(rb_classext_t *ext, bool is_prime, VALUE namespace, void 
     update_classext_values(objspace, ext, true);
 }
 
-extern rb_symbols_t ruby_global_symbols;
-#define global_symbols ruby_global_symbols
-
 struct global_vm_table_foreach_data {
     vm_table_foreach_callback_func callback;
     vm_table_update_callback_func update_callback;
@@ -3924,34 +3923,20 @@ vm_weak_table_cc_refinement_foreach_update_update(st_data_t *key, st_data_t data
 
 
 static int
-vm_weak_table_str_sym_foreach(st_data_t key, st_data_t value, st_data_t data, int error)
+vm_weak_table_sym_set_foreach(VALUE *sym_ptr, void *data)
 {
+    VALUE sym = *sym_ptr;
     struct global_vm_table_foreach_data *iter_data = (struct global_vm_table_foreach_data *)data;
 
-    if (!iter_data->weak_only) {
-        int ret = iter_data->callback((VALUE)key, iter_data->data);
-        if (ret != ST_CONTINUE) return ret;
+    if (RB_SPECIAL_CONST_P(sym)) return ST_CONTINUE;
+
+    int ret = iter_data->callback(sym, iter_data->data);
+
+    if (ret == ST_REPLACE) {
+        ret = iter_data->update_callback(sym_ptr, iter_data->data);
     }
 
-    if (STATIC_SYM_P(value)) {
-        return ST_CONTINUE;
-    }
-    else {
-        return iter_data->callback((VALUE)value, iter_data->data);
-    }
-}
-
-static int
-vm_weak_table_foreach_update_weak_value(st_data_t *key, st_data_t *value, st_data_t data, int existing)
-{
-    struct global_vm_table_foreach_data *iter_data = (struct global_vm_table_foreach_data *)data;
-
-    if (!iter_data->weak_only) {
-        int ret = iter_data->update_callback((VALUE *)key, iter_data->data);
-        if (ret != ST_CONTINUE) return ret;
-    }
-
-    return iter_data->update_callback((VALUE *)value, iter_data->data);
+    return ret;
 }
 
 struct st_table *rb_generic_fields_tbl_get(void);
@@ -4098,14 +4083,10 @@ rb_gc_vm_weak_table_foreach(vm_table_foreach_callback_func callback,
         break;
       }
       case RB_GC_VM_GLOBAL_SYMBOLS_TABLE: {
-        if (global_symbols.str_sym) {
-            st_foreach_with_replace(
-                global_symbols.str_sym,
-                vm_weak_table_str_sym_foreach,
-                vm_weak_table_foreach_update_weak_value,
-                (st_data_t)&foreach_data
-            );
-        }
+        rb_sym_global_symbol_table_foreach_weak_reference(
+            vm_weak_table_sym_set_foreach,
+            &foreach_data
+        );
         break;
       }
       case RB_GC_VM_ID2REF_TABLE: {

--- a/hash.c
+++ b/hash.c
@@ -184,7 +184,7 @@ any_hash(VALUE a, st_index_t (*other_func)(VALUE))
             hnum = rb_hash_start(hnum);
         }
         else {
-            hnum = RSYMBOL(a)->hashval;
+            hnum = RSHIFT(RSYMBOL(a)->hashval, 1);
         }
         break;
       case T_FIXNUM:

--- a/internal/concurrent_set.h
+++ b/internal/concurrent_set.h
@@ -1,6 +1,7 @@
 #ifndef RUBY_RACTOR_SAFE_TABLE_H
 #define RUBY_RACTOR_SAFE_TABLE_H
 
+#include "ruby/atomic.h"
 #include "ruby/ruby.h"
 
 typedef VALUE (*rb_concurrent_set_hash_func)(VALUE key);
@@ -15,6 +16,7 @@ struct rb_concurrent_set_funcs {
 
 VALUE rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity);
 rb_atomic_t rb_concurrent_set_size(VALUE set_obj);
+VALUE rb_concurrent_set_find(VALUE *set_obj_ptr, VALUE key);
 VALUE rb_concurrent_set_find_or_insert(VALUE *set_obj_ptr, VALUE key, void *data);
 VALUE rb_concurrent_set_delete_by_identity(VALUE set_obj, VALUE key);
 void rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data);

--- a/internal/concurrent_set.h
+++ b/internal/concurrent_set.h
@@ -14,6 +14,7 @@ struct rb_concurrent_set_funcs {
 };
 
 VALUE rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity);
+rb_atomic_t rb_concurrent_set_size(VALUE set_obj);
 VALUE rb_concurrent_set_find_or_insert(VALUE *set_obj_ptr, VALUE key, void *data);
 VALUE rb_concurrent_set_delete_by_identity(VALUE set_obj, VALUE key);
 void rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data);

--- a/internal/concurrent_set.h
+++ b/internal/concurrent_set.h
@@ -4,14 +4,11 @@
 #include "ruby/atomic.h"
 #include "ruby/ruby.h"
 
-typedef VALUE (*rb_concurrent_set_hash_func)(VALUE key);
-typedef bool (*rb_concurrent_set_cmp_func)(VALUE a, VALUE b);
-typedef VALUE (*rb_concurrent_set_create_func)(VALUE key, void *data);
-
 struct rb_concurrent_set_funcs {
-    rb_concurrent_set_hash_func hash;
-    rb_concurrent_set_cmp_func cmp;
-    rb_concurrent_set_create_func create;
+    VALUE (*hash)(VALUE key);
+    bool (*cmp)(VALUE a, VALUE b);
+    VALUE (*create)(VALUE key, void *data);
+    void (*free)(VALUE key);
 };
 
 VALUE rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity);

--- a/internal/symbol.h
+++ b/internal/symbol.h
@@ -31,11 +31,10 @@ PUREFUNC(int rb_is_const_sym(VALUE sym));
 PUREFUNC(int rb_is_attrset_sym(VALUE sym));
 ID rb_make_internal_id(void);
 ID rb_make_temporary_id(size_t n);
+bool rb_obj_is_symbol_table(VALUE obj);
+void rb_sym_global_symbol_table_foreach_weak_reference(int (*callback)(VALUE *key, void *data), void *data);
 void rb_gc_free_dsymbol(VALUE);
 int rb_static_id_valid_p(ID id);
-
-/* vm.c */
-void rb_free_static_symid_str(void);
 
 #if __has_builtin(__builtin_constant_p)
 #define rb_sym_intern_ascii_cstr(ptr) \

--- a/string.c
+++ b/string.c
@@ -552,6 +552,7 @@ static const struct rb_concurrent_set_funcs fstring_concurrent_set_funcs = {
     .hash = fstring_concurrent_set_hash,
     .cmp = fstring_concurrent_set_cmp,
     .create = fstring_concurrent_set_create,
+    .free = NULL,
 };
 
 void

--- a/symbol.c
+++ b/symbol.c
@@ -315,10 +315,19 @@ sym_set_create(VALUE sym, void *data)
     }
 }
 
+static void
+sym_set_free(VALUE sym)
+{
+    if (sym_set_sym_static_p(sym)) {
+        xfree(sym_set_static_sym_untag(sym));
+    }
+}
+
 static const struct rb_concurrent_set_funcs sym_set_funcs = {
     .hash = sym_set_hash,
     .cmp = sym_set_cmp,
     .create = sym_set_create,
+    .free = sym_set_free,
 };
 
 static VALUE

--- a/symbol.c
+++ b/symbol.c
@@ -10,6 +10,7 @@
 **********************************************************************/
 
 #include "internal.h"
+#include "internal/concurrent_set.h"
 #include "internal/error.h"
 #include "internal/gc.h"
 #include "internal/hash.h"
@@ -42,6 +43,9 @@
 # define CHECK_ID_SERIAL SYMBOL_DEBUG
 #endif
 
+#define IDSET_ATTRSET_FOR_SYNTAX ((1U<<ID_LOCAL)|(1U<<ID_CONST))
+#define IDSET_ATTRSET_FOR_INTERN (~(~0U<<(1<<ID_SCOPE_SHIFT)) & ~(1U<<ID_ATTRSET))
+
 #define SYMBOL_PINNED_P(sym) (RSYMBOL(sym)->id&~ID_SCOPE_MASK)
 
 #define STATIC_SYM2ID(sym) RSHIFT((VALUE)(sym), RUBY_SPECIAL_SHIFT)
@@ -56,6 +60,13 @@ static ID register_static_symid_str(ID, VALUE);
 #define op_tbl_count numberof(op_tbl)
 STATIC_ASSERT(op_tbl_name_size, sizeof(op_tbl[0].name) == 3);
 #define op_tbl_len(i) (!op_tbl[i].name[1] ? 1 : !op_tbl[i].name[2] ? 2 : 3)
+
+
+#define GLOBAL_SYMBOLS_LOCKING(symbols) \
+    for (rb_symbols_t *symbols = &ruby_global_symbols, **locking = &symbols; \
+         locking; \
+         locking = NULL) \
+        RB_VM_LOCKING()
 
 static void
 Init_op_tbl(void)
@@ -82,12 +93,284 @@ enum id_entry_type {
     ID_ENTRY_SIZE
 };
 
+typedef struct {
+    rb_id_serial_t last_id;
+    VALUE sym_set;
+
+    VALUE ids;
+    VALUE dsymbol_fstr_hash;
+} rb_symbols_t;
+
 rb_symbols_t ruby_global_symbols = {tNEXT_ID-1};
 
-static const struct st_hash_type symhash = {
-    rb_str_hash_cmp,
-    rb_str_hash,
+struct sym_set_static_sym_entry {
+    VALUE sym;
+    VALUE str;
 };
+
+#define SYM_SET_SYM_STATIC_TAG 1
+
+static bool
+sym_set_sym_static_p(VALUE sym)
+{
+    return sym & SYM_SET_SYM_STATIC_TAG;
+}
+
+static VALUE
+sym_set_static_sym_tag(struct sym_set_static_sym_entry *sym)
+{
+    VALUE value = (VALUE)sym | SYM_SET_SYM_STATIC_TAG;
+    RUBY_ASSERT(IMMEDIATE_P(value));
+    RUBY_ASSERT(sym_set_sym_static_p(value));
+
+    return value;
+}
+
+static struct sym_set_static_sym_entry *
+sym_set_static_sym_untag(VALUE sym)
+{
+    RUBY_ASSERT(sym_set_sym_static_p(sym));
+
+    return (struct sym_set_static_sym_entry *)(sym & ~((VALUE)SYM_SET_SYM_STATIC_TAG));
+}
+
+static VALUE
+sym_set_sym_get_str(VALUE sym)
+{
+    VALUE str;
+    if (sym_set_sym_static_p(sym)) {
+        str = sym_set_static_sym_untag(sym)->str;
+    }
+    else {
+        RUBY_ASSERT(RB_TYPE_P(sym, T_SYMBOL));
+        str = RSYMBOL(sym)->fstr;
+    }
+
+    RUBY_ASSERT(RB_TYPE_P(str, T_STRING));
+
+    return str;
+}
+
+static VALUE
+sym_set_hash(VALUE sym)
+{
+    return (VALUE)rb_str_hash(sym_set_sym_get_str(sym));
+}
+
+static bool
+sym_set_cmp(VALUE a, VALUE b)
+{
+    return rb_str_hash_cmp(sym_set_sym_get_str(a), sym_set_sym_get_str(b)) == false;
+}
+
+
+static int
+sym_check_asciionly(VALUE str, bool fake_str)
+{
+    if (!rb_enc_asciicompat(rb_enc_get(str))) return FALSE;
+    switch (rb_enc_str_coderange(str)) {
+      case ENC_CODERANGE_BROKEN:
+        if (fake_str) {
+            str = rb_enc_str_new(RSTRING_PTR(str), RSTRING_LEN(str), rb_enc_get(str));
+        }
+        rb_raise(rb_eEncodingError, "invalid symbol in encoding %s :%+"PRIsVALUE,
+                 rb_enc_name(rb_enc_get(str)), str);
+      case ENC_CODERANGE_7BIT:
+        return TRUE;
+    }
+    return FALSE;
+}
+
+static VALUE
+dup_string_for_create(VALUE str)
+{
+    rb_encoding *enc = rb_enc_get(str);
+
+    str = rb_enc_str_new(RSTRING_PTR(str), RSTRING_LEN(str), enc);
+
+    rb_encoding *ascii = rb_usascii_encoding();
+    if (enc != ascii && sym_check_asciionly(str, false)) {
+        rb_enc_associate(str, ascii);
+    }
+    OBJ_FREEZE(str);
+
+    str = rb_fstring(str);
+
+    return str;
+}
+
+static int
+rb_str_symname_type(VALUE name, unsigned int allowed_attrset)
+{
+    const char *ptr = StringValuePtr(name);
+    long len = RSTRING_LEN(name);
+    int type = rb_enc_symname_type(ptr, len, rb_enc_get(name), allowed_attrset);
+    RB_GC_GUARD(name);
+    return type;
+}
+
+static ID
+next_id_base_with_lock(rb_symbols_t *symbols)
+{
+    ID id;
+    rb_id_serial_t next_serial = symbols->last_id + 1;
+
+    if (next_serial == 0) {
+        id = (ID)-1;
+    }
+    else {
+        const size_t num = ++symbols->last_id;
+        id = num << ID_SCOPE_SHIFT;
+    }
+
+    return id;
+}
+
+static ID
+next_id_base(void)
+{
+    ID id;
+    GLOBAL_SYMBOLS_LOCKING(symbols) {
+        id = next_id_base_with_lock(symbols);
+    }
+    return id;
+}
+
+static void
+set_id_entry(rb_symbols_t *symbols, rb_id_serial_t num, VALUE str, VALUE sym)
+{
+    ASSERT_vm_locking();
+    RUBY_ASSERT_BUILTIN_TYPE(str, T_STRING);
+    RUBY_ASSERT_BUILTIN_TYPE(sym, T_SYMBOL);
+
+    size_t idx = num / ID_ENTRY_UNIT;
+
+    VALUE ary, ids = symbols->ids;
+    if (idx >= (size_t)RARRAY_LEN(ids) || NIL_P(ary = rb_ary_entry(ids, (long)idx))) {
+        ary = rb_ary_hidden_new(ID_ENTRY_UNIT * ID_ENTRY_SIZE);
+        rb_ary_store(ids, (long)idx, ary);
+    }
+    idx = (num % ID_ENTRY_UNIT) * ID_ENTRY_SIZE;
+    rb_ary_store(ary, (long)idx + ID_ENTRY_STR, str);
+    rb_ary_store(ary, (long)idx + ID_ENTRY_SYM, sym);
+}
+
+static VALUE
+sym_set_create(VALUE sym, void *data)
+{
+    ASSERT_vm_locking();
+
+    bool create_dynamic_symbol = (bool)data;
+
+    struct sym_set_static_sym_entry *static_sym_entry = sym_set_static_sym_untag(sym);
+
+    VALUE str = dup_string_for_create(static_sym_entry->str);
+
+    if (create_dynamic_symbol) {
+        NEWOBJ_OF(obj, struct RSymbol, rb_cSymbol, T_SYMBOL | FL_WB_PROTECTED, sizeof(struct RSymbol), 0);
+
+        rb_encoding *enc = rb_enc_get(str);
+        rb_enc_set_index((VALUE)obj, rb_enc_to_index(enc));
+        OBJ_FREEZE((VALUE)obj);
+        RB_OBJ_WRITE((VALUE)obj, &obj->fstr, str);
+
+        int id = rb_str_symname_type(str, IDSET_ATTRSET_FOR_INTERN);
+        if (id < 0) id = ID_JUNK;
+        obj->id = id;
+
+        /* we want hashval to be in Fixnum range [ruby-core:15713] r15672 */
+        long hashval = (long)rb_str_hash(str);
+        obj->hashval = RSHIFT((long)hashval, 1);
+        rb_hash_aset(ruby_global_symbols.dsymbol_fstr_hash, str, Qtrue);
+        RUBY_DTRACE_CREATE_HOOK(SYMBOL, RSTRING_PTR(obj->fstr));
+
+        return (VALUE)obj;
+    }
+    else {
+        struct sym_set_static_sym_entry *new_static_sym_entry = xmalloc(sizeof(struct sym_set_static_sym_entry));
+        new_static_sym_entry->str = str;
+
+        VALUE static_sym = static_sym_entry->sym;
+        if (static_sym == 0) {
+            ID id = rb_str_symname_type(str, IDSET_ATTRSET_FOR_INTERN);
+            if (id == (ID)-1) id = ID_JUNK;
+
+            ID nid = next_id_base();
+            if (nid == (ID)-1) {
+                str = rb_str_ellipsize(str, 20);
+                rb_raise(rb_eRuntimeError, "symbol table overflow (symbol %"PRIsVALUE")", str);
+            }
+
+            id |= nid;
+            id |= ID_STATIC_SYM;
+
+            static_sym = STATIC_ID2SYM(id);
+        }
+        new_static_sym_entry->sym = static_sym;
+
+        set_id_entry(&ruby_global_symbols, rb_id_to_serial(STATIC_SYM2ID(static_sym)), str, static_sym);
+
+        return sym_set_static_sym_tag(new_static_sym_entry);
+    }
+}
+
+static const struct rb_concurrent_set_funcs sym_set_funcs = {
+    .hash = sym_set_hash,
+    .cmp = sym_set_cmp,
+    .create = sym_set_create,
+};
+
+static VALUE
+sym_set_entry_to_sym(VALUE entry)
+{
+    if (sym_set_sym_static_p(entry)) {
+        RUBY_ASSERT(STATIC_SYM_P(sym_set_static_sym_untag(entry)->sym));
+
+        if (!STATIC_SYM_P(sym_set_static_sym_untag(entry)->sym)) rb_bug("not sym");
+
+        return sym_set_static_sym_untag(entry)->sym;
+    }
+    else {
+        RUBY_ASSERT(DYNAMIC_SYM_P(entry));
+        if (!DYNAMIC_SYM_P(entry)) rb_bug("not sym");
+
+        return entry;
+    }
+}
+
+static VALUE
+sym_find_or_insert_dynamic_symbol(rb_symbols_t *symbols, const VALUE str)
+{
+    struct sym_set_static_sym_entry static_sym = {
+        .str = str
+    };
+    return sym_set_entry_to_sym(
+        rb_concurrent_set_find_or_insert(&symbols->sym_set, sym_set_static_sym_tag(&static_sym), (void *)true)
+    );
+}
+
+static VALUE
+sym_find_or_insert_static_symbol(rb_symbols_t *symbols, const VALUE str)
+{
+    struct sym_set_static_sym_entry static_sym = {
+        .str = str
+    };
+    return sym_set_entry_to_sym(
+        rb_concurrent_set_find_or_insert(&symbols->sym_set, sym_set_static_sym_tag(&static_sym), (void *)false)
+    );
+}
+
+static VALUE
+sym_find_or_insert_static_symbol_id(rb_symbols_t *symbols, const VALUE str, ID id)
+{
+    struct sym_set_static_sym_entry static_sym = {
+        .sym = STATIC_ID2SYM(id),
+        .str = str,
+    };
+    return sym_set_entry_to_sym(
+        rb_concurrent_set_find_or_insert(&symbols->sym_set, sym_set_static_sym_tag(&static_sym), (void *)false)
+    );
+}
 
 void
 Init_sym(void)
@@ -98,7 +381,7 @@ Init_sym(void)
     symbols->dsymbol_fstr_hash = dsym_fstrs;
     rb_obj_hide(dsym_fstrs);
 
-    symbols->str_sym = st_init_table_with_size(&symhash, 1000);
+    symbols->sym_set = rb_concurrent_set_new(&sym_set_funcs, 1024);
     symbols->ids = rb_ary_hidden_new(0);
 
     Init_op_tbl();
@@ -110,6 +393,7 @@ rb_sym_global_symbols_mark(void)
 {
     rb_symbols_t *symbols = &ruby_global_symbols;
 
+    rb_gc_mark_movable(symbols->sym_set);
     rb_gc_mark_movable(symbols->ids);
     rb_gc_mark_movable(symbols->dsymbol_fstr_hash);
 }
@@ -119,28 +403,17 @@ rb_sym_global_symbols_update_references(void)
 {
     rb_symbols_t *symbols = &ruby_global_symbols;
 
+    symbols->sym_set = rb_gc_location(symbols->sym_set);
     symbols->ids = rb_gc_location(symbols->ids);
     symbols->dsymbol_fstr_hash = rb_gc_location(symbols->dsymbol_fstr_hash);
 }
 
-WARN_UNUSED_RESULT(static VALUE dsymbol_alloc(rb_symbols_t *symbols, const VALUE klass, const VALUE str, rb_encoding *const enc, const ID type));
-WARN_UNUSED_RESULT(static VALUE dsymbol_check(rb_symbols_t *symbols, const VALUE sym));
 WARN_UNUSED_RESULT(static ID lookup_str_id(VALUE str));
-WARN_UNUSED_RESULT(static VALUE lookup_str_sym_with_lock(rb_symbols_t *symbols, const VALUE str));
-WARN_UNUSED_RESULT(static VALUE lookup_str_sym(const VALUE str));
 WARN_UNUSED_RESULT(static VALUE lookup_id_str(ID id));
-WARN_UNUSED_RESULT(static ID intern_str(VALUE str, int mutable));
-
-#define GLOBAL_SYMBOLS_LOCKING(symbols) \
-    for (rb_symbols_t *symbols = &ruby_global_symbols, **locking = &symbols; \
-         locking; \
-         locking = NULL) \
-        RB_VM_LOCKING()
 
 ID
 rb_id_attrset(ID id)
 {
-    VALUE str, sym;
     int scope;
 
     if (!is_notop_id(id)) {
@@ -161,7 +434,8 @@ rb_id_attrset(ID id)
             return id;
           default:
             {
-                if ((str = lookup_id_str(id)) != 0) {
+                VALUE str = lookup_id_str(id);
+                if (str != 0) {
                     rb_name_error(id, "cannot make unknown type ID %d:%"PRIsVALUE" attrset",
                                   scope, str);
                 }
@@ -176,11 +450,16 @@ rb_id_attrset(ID id)
     bool error = false;
     GLOBAL_SYMBOLS_LOCKING(symbols) {
         /* make new symbol and ID */
-        if ((str = lookup_id_str(id))) {
+        VALUE str = lookup_id_str(id);
+        if (str) {
             str = rb_str_dup(str);
             rb_str_cat(str, "=", 1);
-            sym = lookup_str_sym(str);
-            id = sym ? rb_sym2id(sym) : intern_str(str, 1);
+            if (sym_check_asciionly(str, false)) {
+                rb_enc_associate(str, rb_usascii_encoding());
+            }
+
+            VALUE sym = sym_find_or_insert_static_symbol(symbols, str);
+            id = rb_sym2id(sym);
         }
         else {
             error = true;
@@ -278,9 +557,6 @@ rb_sym_constant_char_p(const char *name, long nlen, rb_encoding *enc)
     }
     return FALSE;
 }
-
-#define IDSET_ATTRSET_FOR_SYNTAX ((1U<<ID_LOCAL)|(1U<<ID_CONST))
-#define IDSET_ATTRSET_FOR_INTERN (~(~0U<<(1<<ID_SCOPE_SHIFT)) & ~(1U<<ID_ATTRSET))
 
 struct enc_synmane_type_leading_chars_tag {
     const enum { invalid, stophere, needmore, } kind;
@@ -446,35 +722,6 @@ rb_enc_symname2_p(const char *name, long len, rb_encoding *enc)
     return rb_enc_symname_type(name, len, enc, IDSET_ATTRSET_FOR_SYNTAX) != -1;
 }
 
-static int
-rb_str_symname_type(VALUE name, unsigned int allowed_attrset)
-{
-    const char *ptr = StringValuePtr(name);
-    long len = RSTRING_LEN(name);
-    int type = rb_enc_symname_type(ptr, len, rb_enc_get(name), allowed_attrset);
-    RB_GC_GUARD(name);
-    return type;
-}
-
-static void
-set_id_entry(rb_symbols_t *symbols, rb_id_serial_t num, VALUE str, VALUE sym)
-{
-    ASSERT_vm_locking();
-    RUBY_ASSERT_BUILTIN_TYPE(str, T_STRING);
-    RUBY_ASSERT_BUILTIN_TYPE(sym, T_SYMBOL);
-
-    size_t idx = num / ID_ENTRY_UNIT;
-
-    VALUE ary, ids = symbols->ids;
-    if (idx >= (size_t)RARRAY_LEN(ids) || NIL_P(ary = rb_ary_entry(ids, (long)idx))) {
-        ary = rb_ary_hidden_new(ID_ENTRY_UNIT * ID_ENTRY_SIZE);
-        rb_ary_store(ids, (long)idx, ary);
-    }
-    idx = (num % ID_ENTRY_UNIT) * ID_ENTRY_SIZE;
-    rb_ary_store(ary, (long)idx + ID_ENTRY_STR, str);
-    rb_ary_store(ary, (long)idx + ID_ENTRY_SYM, sym);
-}
-
 static VALUE
 get_id_serial_entry(rb_id_serial_t num, ID id, const enum id_entry_type t)
 {
@@ -550,50 +797,6 @@ rb_id_serial_to_id(rb_id_serial_t num)
     }
 }
 
-static int
-register_sym_update_callback(st_data_t *key, st_data_t *value, st_data_t arg, int existing)
-{
-    if (existing) {
-        rb_fatal("symbol :% "PRIsVALUE" is already registered with %"PRIxVALUE,
-                 (VALUE)*key, (VALUE)*value);
-    }
-    *value = arg;
-    return ST_CONTINUE;
-}
-
-static void
-register_sym(rb_symbols_t *symbols, VALUE str, VALUE sym)
-{
-    ASSERT_vm_locking();
-
-    if (SYMBOL_DEBUG) {
-        st_update(symbols->str_sym, (st_data_t)str,
-                  register_sym_update_callback, (st_data_t)sym);
-    }
-    else {
-        st_add_direct(symbols->str_sym, (st_data_t)str, (st_data_t)sym);
-    }
-}
-
-void
-rb_free_static_symid_str(void)
-{
-    GLOBAL_SYMBOLS_LOCKING(symbols) {
-        st_free_table(symbols->str_sym);
-    }
-}
-
-static void
-unregister_sym(rb_symbols_t *symbols, VALUE str, VALUE sym)
-{
-    ASSERT_vm_locking();
-
-    st_data_t str_data = (st_data_t)str;
-    if (!st_delete(symbols->str_sym, &str_data, NULL)) {
-        rb_bug("%p can't remove str from str_id (%s)", (void *)sym, RSTRING_PTR(str));
-    }
-}
-
 static ID
 register_static_symid(ID id, const char *name, long len, rb_encoding *enc)
 {
@@ -604,162 +807,61 @@ register_static_symid(ID id, const char *name, long len, rb_encoding *enc)
 static ID
 register_static_symid_str(ID id, VALUE str)
 {
-    rb_id_serial_t num = rb_id_to_serial(id);
-    VALUE sym = STATIC_ID2SYM(id);
-
     OBJ_FREEZE(str);
     str = rb_fstring(str);
 
     RUBY_DTRACE_CREATE_HOOK(SYMBOL, RSTRING_PTR(str));
 
     GLOBAL_SYMBOLS_LOCKING(symbols) {
-        register_sym(symbols, str, sym);
-        set_id_entry(symbols, num, str, sym);
+        // TODO: remove this function
+        sym_find_or_insert_static_symbol_id(symbols, str, id);
     }
 
     return id;
 }
 
-static int
-sym_check_asciionly(VALUE str, bool fake_str)
-{
-    if (!rb_enc_asciicompat(rb_enc_get(str))) return FALSE;
-    switch (rb_enc_str_coderange(str)) {
-      case ENC_CODERANGE_BROKEN:
-        if (fake_str) {
-            str = rb_enc_str_new(RSTRING_PTR(str), RSTRING_LEN(str), rb_enc_get(str));
-        }
-        rb_raise(rb_eEncodingError, "invalid symbol in encoding %s :%+"PRIsVALUE,
-                 rb_enc_name(rb_enc_get(str)), str);
-      case ENC_CODERANGE_7BIT:
-        return TRUE;
-    }
-    return FALSE;
-}
-
-#if 0
-/*
- * _str_ itself will be registered at the global symbol table.  _str_
- * can be modified before the registration, since the encoding will be
- * set to ASCII-8BIT if it is a special global name.
- */
-
-static inline void
-must_be_dynamic_symbol(VALUE x)
-{
-    if (UNLIKELY(!DYNAMIC_SYM_P(x))) {
-        if (STATIC_SYM_P(x)) {
-            VALUE str = lookup_id_str(RSHIFT((unsigned long)(x),RUBY_SPECIAL_SHIFT));
-
-            if (str) {
-                rb_bug("wrong argument: %s (inappropriate Symbol)", RSTRING_PTR(str));
-            }
-            else {
-                rb_bug("wrong argument: inappropriate Symbol (%p)", (void *)x);
-            }
-        }
-        else {
-            rb_bug("wrong argument type %s (expected Symbol)", rb_builtin_class_name(x));
-        }
-    }
-}
-#endif
-
 static VALUE
-dsymbol_alloc(rb_symbols_t *symbols, const VALUE klass, const VALUE str, rb_encoding * const enc, const ID type)
+sym_find(VALUE str)
 {
-    ASSERT_vm_locking();
+    VALUE sym;
 
-    NEWOBJ_OF(obj, struct RSymbol, klass, T_SYMBOL | FL_WB_PROTECTED, sizeof(struct RSymbol), 0);
+    GLOBAL_SYMBOLS_LOCKING(symbols) {
+        struct sym_set_static_sym_entry static_sym = {
+            .str = str
+        };
+        sym = rb_concurrent_set_find(&symbols->sym_set, sym_set_static_sym_tag(&static_sym));
+    }
 
-    long hashval;
-
-    rb_enc_set_index((VALUE)obj, rb_enc_to_index(enc));
-    OBJ_FREEZE((VALUE)obj);
-    RB_OBJ_WRITE((VALUE)obj, &obj->fstr, str);
-    obj->id = type;
-
-    /* we want hashval to be in Fixnum range [ruby-core:15713] r15672 */
-    hashval = (long)rb_str_hash(str);
-    obj->hashval = RSHIFT((long)hashval, 1);
-    register_sym(symbols, str, (VALUE)obj);
-    rb_hash_aset(symbols->dsymbol_fstr_hash, str, Qtrue);
-    RUBY_DTRACE_CREATE_HOOK(SYMBOL, RSTRING_PTR(obj->fstr));
-
-    return (VALUE)obj;
-}
-
-static inline VALUE
-dsymbol_check(rb_symbols_t *symbols, const VALUE sym)
-{
-    ASSERT_vm_locking();
-
-    if (UNLIKELY(rb_objspace_garbage_object_p(sym))) {
-        const VALUE fstr = RSYMBOL(sym)->fstr;
-        const ID type = RSYMBOL(sym)->id & ID_SCOPE_MASK;
-        RSYMBOL(sym)->fstr = 0;
-        unregister_sym(symbols, fstr, sym);
-        return dsymbol_alloc(symbols, rb_cSymbol, fstr, rb_enc_get(fstr), type);
+    if (sym) {
+        return sym_set_entry_to_sym(sym);
     }
     else {
-        return sym;
+        return 0;
     }
 }
 
 static ID
 lookup_str_id(VALUE str)
 {
-    st_data_t sym_data;
-    int found;
+    VALUE sym = sym_find(str);
 
-    GLOBAL_SYMBOLS_LOCKING(symbols) {
-        found = st_lookup(symbols->str_sym, (st_data_t)str, &sym_data);
+    if (sym == 0) {
+        return (ID)0;
     }
 
-    if (found) {
-        const VALUE sym = (VALUE)sym_data;
-
-        if (STATIC_SYM_P(sym)) {
-            return STATIC_SYM2ID(sym);
-        }
-        else if (DYNAMIC_SYM_P(sym)) {
-            ID id = RSYMBOL(sym)->id;
-            if (id & ~ID_SCOPE_MASK) return id;
-        }
-        else {
-            rb_bug("non-symbol object %s:%"PRIxVALUE" for %"PRIsVALUE" in symbol table",
-                   rb_builtin_class_name(sym), sym, str);
-        }
+    if (STATIC_SYM_P(sym)) {
+        return STATIC_SYM2ID(sym);
     }
-    return (ID)0;
-}
-
-static VALUE
-lookup_str_sym_with_lock(rb_symbols_t *symbols, const VALUE str)
-{
-    st_data_t sym_data;
-    if (st_lookup(symbols->str_sym, (st_data_t)str, &sym_data)) {
-        VALUE sym = (VALUE)sym_data;
-        if (DYNAMIC_SYM_P(sym)) {
-            sym = dsymbol_check(symbols, sym);
-        }
-        return sym;
+    else if (DYNAMIC_SYM_P(sym)) {
+        ID id = RSYMBOL(sym)->id;
+        if (id & ~ID_SCOPE_MASK) return id;
     }
     else {
-        return Qfalse;
-    }
-}
-
-static VALUE
-lookup_str_sym(const VALUE str)
-{
-    VALUE sym;
-
-    GLOBAL_SYMBOLS_LOCKING(symbols) {
-        sym = lookup_str_sym_with_lock(symbols, str);
+        rb_bug("non-symbol object %s:%"PRIxVALUE" for %"PRIsVALUE" in symbol table",
+                rb_builtin_class_name(sym), sym, str);
     }
 
-    return sym;
+    return (ID)0;
 }
 
 static VALUE
@@ -771,75 +873,15 @@ lookup_id_str(ID id)
 ID
 rb_intern3(const char *name, long len, rb_encoding *enc)
 {
-    VALUE sym;
     struct RString fake_str;
     VALUE str = rb_setup_fake_str(&fake_str, name, len, enc);
     OBJ_FREEZE(str);
-    ID id;
 
+    VALUE sym;
     GLOBAL_SYMBOLS_LOCKING(symbols) {
-        sym = lookup_str_sym(str);
-        if (sym) {
-            id = rb_sym2id(sym);
-        }
-        else {
-            str = rb_enc_str_new(name, len, enc); /* make true string */
-            id = intern_str(str, 1);
-        }
+        sym = sym_find_or_insert_static_symbol(symbols, str);
     }
-
-    return id;
-}
-
-static ID
-next_id_base_with_lock(rb_symbols_t *symbols)
-{
-    ID id;
-    rb_id_serial_t next_serial = symbols->last_id + 1;
-
-    if (next_serial == 0) {
-        id = (ID)-1;
-    }
-    else {
-        const size_t num = ++symbols->last_id;
-        id = num << ID_SCOPE_SHIFT;
-    }
-
-    return id;
-}
-
-static ID
-next_id_base(void)
-{
-    ID id;
-    GLOBAL_SYMBOLS_LOCKING(symbols) {
-        id = next_id_base_with_lock(symbols);
-    }
-    return id;
-}
-
-static ID
-intern_str(VALUE str, int mutable)
-{
-    ASSERT_vm_locking();
-
-    ID id;
-    ID nid;
-
-    id = rb_str_symname_type(str, IDSET_ATTRSET_FOR_INTERN);
-    if (id == (ID)-1) id = ID_JUNK;
-    if (sym_check_asciionly(str, false)) {
-        if (!mutable) str = rb_str_dup(str);
-        rb_enc_associate(str, rb_usascii_encoding());
-    }
-    if ((nid = next_id_base()) == (ID)-1) {
-        str = rb_str_ellipsize(str, 20);
-        rb_raise(rb_eRuntimeError, "symbol table overflow (symbol %"PRIsVALUE")",
-                 str);
-    }
-    id |= nid;
-    id |= ID_STATIC_SYM;
-    return register_static_symid_str(id, str);
+    return rb_sym2id(sym);
 }
 
 ID
@@ -858,18 +900,51 @@ rb_intern(const char *name)
 ID
 rb_intern_str(VALUE str)
 {
-    ID id;
+    VALUE sym;
     GLOBAL_SYMBOLS_LOCKING(symbols) {
-        VALUE sym = lookup_str_sym(str);
-        if (sym) {
-            id = SYM2ID(sym);
-        }
-        else {
-            id = intern_str(str, 0);
-        }
+        sym = sym_find_or_insert_static_symbol(symbols, str);
     }
+    return SYM2ID(sym);
+}
 
-    return id;
+bool
+rb_obj_is_symbol_table(VALUE obj)
+{
+    return obj == ruby_global_symbols.sym_set;
+}
+
+struct global_symbol_table_foreach_weak_reference_data {
+    int (*callback)(VALUE *key, void *data);
+    void *data;
+};
+
+static int
+rb_sym_global_symbol_table_foreach_weak_reference_i(VALUE *key, void *d)
+{
+    struct global_symbol_table_foreach_weak_reference_data *data = d;
+    VALUE sym = *key;
+
+    if (sym_set_sym_static_p(sym)) {
+        struct sym_set_static_sym_entry *static_sym = sym_set_static_sym_untag(sym);
+
+        return data->callback(&static_sym->str, data->data);
+    }
+    else {
+        return data->callback(key, data->data);
+    }
+}
+
+void
+rb_sym_global_symbol_table_foreach_weak_reference(int (*callback)(VALUE *key, void *data), void *data)
+{
+    if (!ruby_global_symbols.sym_set) return;
+
+    struct global_symbol_table_foreach_weak_reference_data foreach_data = {
+        .callback = callback,
+        .data = data,
+    };
+
+    rb_concurrent_set_foreach_with_replace(ruby_global_symbols.sym_set, rb_sym_global_symbol_table_foreach_weak_reference_i, &foreach_data);
 }
 
 void
@@ -878,12 +953,12 @@ rb_gc_free_dsymbol(VALUE sym)
     VALUE str = RSYMBOL(sym)->fstr;
 
     if (str) {
-        RSYMBOL(sym)->fstr = 0;
-
         GLOBAL_SYMBOLS_LOCKING(symbols) {
-            unregister_sym(symbols, str, sym);
+            rb_concurrent_set_delete_by_identity(symbols->sym_set, sym);
             rb_hash_delete_entry(symbols->dsymbol_fstr_hash, str);
         }
+
+        RSYMBOL(sym)->fstr = 0;
     }
 }
 
@@ -913,33 +988,7 @@ rb_str_intern(VALUE str)
     VALUE sym = 0;
 
     GLOBAL_SYMBOLS_LOCKING(symbols) {
-        sym = lookup_str_sym_with_lock(symbols, str);
-
-        if (sym) {
-            // ok
-        }
-        else if (USE_SYMBOL_GC) {
-            rb_encoding *enc = rb_enc_get(str);
-            rb_encoding *ascii = rb_usascii_encoding();
-            if (enc != ascii && sym_check_asciionly(str, false)) {
-                str = rb_str_dup(str);
-                rb_enc_associate(str, ascii);
-                OBJ_FREEZE(str);
-                enc = ascii;
-            }
-            else {
-                str = rb_str_dup(str);
-                OBJ_FREEZE(str);
-            }
-            str = rb_fstring(str);
-            int type = rb_str_symname_type(str, IDSET_ATTRSET_FOR_INTERN);
-            if (type < 0) type = ID_JUNK;
-            sym = dsymbol_alloc(symbols, rb_cSymbol, str, enc, type);
-        }
-        else {
-            ID id = intern_str(str, 0);
-            sym = ID2SYM(id);
-        }
+        sym = sym_find_or_insert_dynamic_symbol(symbols, str);
     }
     return sym;
 }
@@ -1044,10 +1093,10 @@ rb_make_temporary_id(size_t n)
 }
 
 static int
-symbols_i(st_data_t key, st_data_t value, st_data_t arg)
+symbols_i(VALUE *key, void *data)
 {
-    VALUE ary = (VALUE)arg;
-    VALUE sym = (VALUE)value;
+    VALUE ary = (VALUE)data;
+    VALUE sym = (VALUE)*key;
 
     if (STATIC_SYM_P(sym)) {
         rb_ary_push(ary, sym);
@@ -1058,6 +1107,9 @@ symbols_i(st_data_t key, st_data_t value, st_data_t arg)
     }
     else if (!SYMBOL_PINNED_P(sym) && rb_objspace_garbage_object_p(sym)) {
         RSYMBOL(sym)->fstr = 0;
+        return ST_DELETE;
+    }
+    else if (rb_objspace_garbage_object_p(sym)) {
         return ST_DELETE;
     }
     else {
@@ -1073,8 +1125,8 @@ rb_sym_all_symbols(void)
     VALUE ary;
 
     GLOBAL_SYMBOLS_LOCKING(symbols) {
-        ary = rb_ary_new2(symbols->str_sym->num_entries);
-        st_foreach(symbols->str_sym, symbols_i, ary);
+        ary = rb_ary_new2(rb_concurrent_set_size(symbols->sym_set));
+        rb_concurrent_set_foreach_with_replace(symbols->sym_set, symbols_i, (void *)ary);
     }
 
     return ary;
@@ -1223,7 +1275,7 @@ rb_check_symbol(volatile VALUE *namep)
 
     sym_check_asciionly(name, false);
 
-    if ((sym = lookup_str_sym(name)) != 0) {
+    if ((sym = sym_find(name)) != 0) {
         return sym;
     }
 
@@ -1250,7 +1302,7 @@ rb_check_symbol_cstr(const char *ptr, long len, rb_encoding *enc)
 
     sym_check_asciionly(name, true);
 
-    if ((sym = lookup_str_sym(name)) != 0) {
+    if ((sym = sym_find(name)) != 0) {
         return sym;
     }
 

--- a/symbol.h
+++ b/symbol.h
@@ -58,13 +58,6 @@ static const uint32_t RB_ID_SERIAL_MAX = /* 256M on LP32 */
     ((sizeof(ID)-sizeof(rb_id_serial_t))*CHAR_BIT < RUBY_ID_SCOPE_SHIFT ?
      RUBY_ID_SCOPE_SHIFT : 0);
 
-typedef struct {
-    rb_id_serial_t last_id;
-    st_table *str_sym;
-    VALUE ids;
-    VALUE dsymbol_fstr_hash;
-} rb_symbols_t;
-
 static inline rb_id_serial_t
 rb_id_to_serial(ID id)
 {

--- a/vm.c
+++ b/vm.c
@@ -3148,7 +3148,6 @@ ruby_vm_destruct(rb_vm_t *vm)
             rb_free_loaded_builtin_table();
 
             rb_free_shared_fiber_pool();
-            rb_free_static_symid_str();
             rb_free_transcoder_table();
             rb_free_vm_opt_tables();
             rb_free_warning();


### PR DESCRIPTION
This PR switches the global symbol table and allows for symbol lookup and creation of dynamic symbols without needing the global VM lock. Creating static symbols still require the global VM lock but I will be investigating how to make that lock-free in the future.

Here's a microbenchmark demonstrating the speedup:

```ruby
ARGV[0].to_i.times.map do
  Ractor.new do
    1_000_000.times do |i|
      "hello#{i}".to_sym
    end
  end
end.map(&:value)
```

Results:

<img width="884" height="547" alt="chart" src="https://github.com/user-attachments/assets/75f84817-5876-4a0d-bd7e-cee1d5e94c11" />

Raw results:

| Ractor count | Branch (s) | Master (s) |
|--------------|------------|------------|
| 1            | 0.364      | 0.401      |
| 2            | 0.555      | 1.149      |
| 3            | 0.583      | 3.890      |
| 4            | 0.680      | 3.288      |
| 5            | 0.789      | 5.107      |