### PR TITLE
ZJIT: Run against all tests

### DIFF
--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - test_task: 'zjit-test'
+          - test_task: 'zjit-check'
             configure: '--enable-yjit=dev --enable-zjit'
 
           - test_task: 'ruby' # build test for combo build
@@ -84,7 +84,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9
-        if: ${{ matrix.test_task == 'zjit-test' }}
+        if: ${{ matrix.test_task == 'zjit-check' }}
 
       - name: Install Rust # TODO(alan): remove when GitHub images catch up past 1.85.0
         run: rustup default 1.85.0

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -37,7 +37,7 @@ jobs:
             configure: '--enable-zjit=dev --with-gcc=clang-14'
             libclang_path: '/usr/lib/llvm-14/lib/libclang.so.1'
 
-          - test_task: 'zjit-test'
+          - test_task: 'zjit-check'
             configure: '--enable-yjit --enable-zjit=dev'
 
           - test_task: 'zjit-test-all'
@@ -85,7 +85,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9
-        if: ${{ matrix.test_task == 'zjit-test' }}
+        if: ${{ matrix.test_task == 'zjit-check' }}
 
 
       - uses: ./.github/actions/setup/directories

--- a/test/.excludes-zjit/ErrorHighlightTest.rb
+++ b/test/.excludes-zjit/ErrorHighlightTest.rb
@@ -1,0 +1,1 @@
+exclude(:test_local_variable_get, 'Test fails with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/OSSL.rb
+++ b/test/.excludes-zjit/OpenSSL/OSSL.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestASN1.rb
+++ b/test/.excludes-zjit/OpenSSL/TestASN1.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestBN.rb
+++ b/test/.excludes-zjit/OpenSSL/TestBN.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestBuffering.rb
+++ b/test/.excludes-zjit/OpenSSL/TestBuffering.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestCase.rb
+++ b/test/.excludes-zjit/OpenSSL/TestCase.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestCipher.rb
+++ b/test/.excludes-zjit/OpenSSL/TestCipher.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestConfig.rb
+++ b/test/.excludes-zjit/OpenSSL/TestConfig.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestDigest.rb
+++ b/test/.excludes-zjit/OpenSSL/TestDigest.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestEC.rb
+++ b/test/.excludes-zjit/OpenSSL/TestEC.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestEOF1.rb
+++ b/test/.excludes-zjit/OpenSSL/TestEOF1.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestEOF1LowlevelSocket.rb
+++ b/test/.excludes-zjit/OpenSSL/TestEOF1LowlevelSocket.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestEOF2.rb
+++ b/test/.excludes-zjit/OpenSSL/TestEOF2.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestEOF2LowlevelSocket.rb
+++ b/test/.excludes-zjit/OpenSSL/TestEOF2LowlevelSocket.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestEngine.rb
+++ b/test/.excludes-zjit/OpenSSL/TestEngine.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestFIPS.rb
+++ b/test/.excludes-zjit/OpenSSL/TestFIPS.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestHMAC.rb
+++ b/test/.excludes-zjit/OpenSSL/TestHMAC.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestKDF.rb
+++ b/test/.excludes-zjit/OpenSSL/TestKDF.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestNSSPI.rb
+++ b/test/.excludes-zjit/OpenSSL/TestNSSPI.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestOCSP.rb
+++ b/test/.excludes-zjit/OpenSSL/TestOCSP.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestPKCS12.rb
+++ b/test/.excludes-zjit/OpenSSL/TestPKCS12.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestPKCS7.rb
+++ b/test/.excludes-zjit/OpenSSL/TestPKCS7.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestPKey.rb
+++ b/test/.excludes-zjit/OpenSSL/TestPKey.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestPKeyDH.rb
+++ b/test/.excludes-zjit/OpenSSL/TestPKeyDH.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestPKeyDSA.rb
+++ b/test/.excludes-zjit/OpenSSL/TestPKeyDSA.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestPKeyRSA.rb
+++ b/test/.excludes-zjit/OpenSSL/TestPKeyRSA.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestPair.rb
+++ b/test/.excludes-zjit/OpenSSL/TestPair.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestPairLowlevelSocket.rb
+++ b/test/.excludes-zjit/OpenSSL/TestPairLowlevelSocket.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestProvider.rb
+++ b/test/.excludes-zjit/OpenSSL/TestProvider.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestRandom.rb
+++ b/test/.excludes-zjit/OpenSSL/TestRandom.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestSSL.rb
+++ b/test/.excludes-zjit/OpenSSL/TestSSL.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestSSLSession.rb
+++ b/test/.excludes-zjit/OpenSSL/TestSSLSession.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestTimestamp.rb
+++ b/test/.excludes-zjit/OpenSSL/TestTimestamp.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestX509Attribute.rb
+++ b/test/.excludes-zjit/OpenSSL/TestX509Attribute.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestX509CRL.rb
+++ b/test/.excludes-zjit/OpenSSL/TestX509CRL.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestX509Certificate.rb
+++ b/test/.excludes-zjit/OpenSSL/TestX509Certificate.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestX509Extension.rb
+++ b/test/.excludes-zjit/OpenSSL/TestX509Extension.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestX509Name.rb
+++ b/test/.excludes-zjit/OpenSSL/TestX509Name.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestX509Request.rb
+++ b/test/.excludes-zjit/OpenSSL/TestX509Request.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/OpenSSL/TestX509Store.rb
+++ b/test/.excludes-zjit/OpenSSL/TestX509Store.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests fail with ZJIT')

--- a/test/.excludes-zjit/Prism/DumpTest.rb
+++ b/test/.excludes-zjit/Prism/DumpTest.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests crash with ZJIT')

--- a/test/.excludes-zjit/Prism/SnippetsTest.rb
+++ b/test/.excludes-zjit/Prism/SnippetsTest.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'Tests crash with ZJIT')

--- a/test/.excludes-zjit/TestBugReporter.rb
+++ b/test/.excludes-zjit/TestBugReporter.rb
@@ -1,0 +1,1 @@
+exclude(:test_bug_reporter_add, 'Test fails with ZJIT')

--- a/test/.excludes-zjit/TestERBCore.rb
+++ b/test/.excludes-zjit/TestERBCore.rb
@@ -1,0 +1,1 @@
+exclude(:test_invalid_trim_mode, 'Test fails with ZJIT')

--- a/test/.excludes-zjit/TestERBCoreWOStrScan.rb
+++ b/test/.excludes-zjit/TestERBCoreWOStrScan.rb
@@ -1,0 +1,1 @@
+exclude(:test_invalid_trim_mode, 'Test fails with ZJIT')

--- a/test/.excludes-zjit/TestObjSpace.rb
+++ b/test/.excludes-zjit/TestObjSpace.rb
@@ -1,0 +1,2 @@
+exclude(:test_dump_to_io, 'Test fails with ZJIT')
+exclude(:test_dump_to_default, 'Test fails with ZJIT')

--- a/test/.excludes-zjit/TestResolvDNS.rb
+++ b/test/.excludes-zjit/TestResolvDNS.rb
@@ -1,0 +1,8 @@
+# Only happens when running with other tests
+# Panics with:
+#
+#  thread '<unnamed>' panicked at zjit/src/asm/arm64/mod.rs:939:13:
+#  Expected displacement -264 to be 9 bits or less
+#
+# May be related to https://github.com/Shopify/ruby/issues/646
+exclude(/test_/, 'Tests make ZJIT panic')

--- a/test/.excludes-zjit/TestTimeout.rb
+++ b/test/.excludes-zjit/TestTimeout.rb
@@ -1,0 +1,3 @@
+exclude(:test_timeout, 'Test hangs with ZJIT')
+exclude(:test_nested_timeout, 'Test hangs with ZJIT')
+exclude(:test_nested_timeout_error_identity, 'Test hangs with ZJIT')

--- a/test/.excludes-zjit/TestTracepointObj.rb
+++ b/test/.excludes-zjit/TestTracepointObj.rb
@@ -1,0 +1,1 @@
+exclude(/test_/, 'TracePoint tests fail intermittently with ZJIT')

--- a/zjit/zjit.mk
+++ b/zjit/zjit.mk
@@ -52,7 +52,7 @@ zjit-check:
 
 .PHONY: zjit-test-all
 zjit-test-all:
-	$(MAKE) test-all RUST_BACKTRACE=1 TEST_EXCLUDES='--excludes-dir=$(top_srcdir)/test/.excludes-zjit --name=!/memory_leak/' RUN_OPTS='--zjit-call-threshold=1' TESTS='$(top_srcdir)/test/ruby'
+	$(MAKE) test-all RUST_BACKTRACE=1 TEST_EXCLUDES='--excludes-dir=$(top_srcdir)/test/.excludes-zjit --name=!/memory_leak/' RUN_OPTS='--zjit-call-threshold=1'
 
 ZJIT_BINDGEN_DIFF_OPTS =
 


### PR DESCRIPTION
- `make zjit-test-all` now runs all test under `/test`, which includes several default gems' tests
- Some additional exclusions have been added to `/test/.excludes-zjit/`
- Since now `zjit-test-all` takes quite a while, I think we can run `zjit-check` instead of `zjit-test` on CI to get a faster feedback, even tho `test_zjit.rb` will be run twice (another time in `zjit-test-all`)