### PR TITLE
ZJIT: Remove no-op movs after register allocation

### DIFF
--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1425,6 +1425,20 @@ mod tests {
     }
 
     #[test]
+    fn no_dead_mov_from_vreg() {
+        let (mut asm, mut cb) = setup_asm();
+
+        let ret_val = asm.load(Opnd::mem(64, C_RET_OPND, 0));
+        asm.cret(ret_val);
+
+        asm.compile_with_num_regs(&mut cb, 1);
+        assert_disasm!(cb, "000040f8c0035fd6", "
+            0x0: ldur x0, [x0]
+            0x4: ret
+        ");
+    }
+
+    #[test]
     fn test_emit_add() {
         let (mut asm, mut cb) = setup_asm();
 

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1752,6 +1752,9 @@ impl Assembler
                         asm.push_insn(Insn::PosMarker(end_marker));
                     }
                 }
+                Insn::Mov { src, dest } | Insn::LoadInto { dest, opnd: src } if src == dest => {
+                    // Remove no-op move now that VReg are resolved to physical Reg
+                }
                 _ => asm.push_insn(insn),
             }
 

--- a/zjit/src/disasm.rs
+++ b/zjit/src/disasm.rs
@@ -44,7 +44,7 @@ pub fn disasm_addr_range(cb: &CodeBlock, start_addr: usize, end_addr: usize) -> 
                 writeln!(&mut out, "  {BOLD_BEGIN}# {comment}{BOLD_END}").unwrap();
             }
         }
-        writeln!(&mut out, "  {insn}").unwrap();
+        writeln!(&mut out, "  {}", format!("{insn}").trim()).unwrap();
     }
 
     return out;


### PR DESCRIPTION
    Previously `no_dead_mov_from_vreg` generated:

        0x0: ldur x0, [x0]
        0x4: mov x0, x0
        0x8: ret

    Because of phase ordering. Split couldn't recognize that the no-op mov
    because at that point it sees a `VReg`.

~Re the capstone change, it seems fairly easy to fix upstream. I'll try and toss
them a PR.~ https://github.com/capstone-rust/capstone-rs/pull/184
