### PR TITLE
Replace recursion with iteration in UnicodeNormalize.nfc_one

### DIFF
--- a/lib/unicode_normalize/normalize.rb
+++ b/lib/unicode_normalize/normalize.rb
@@ -114,8 +114,26 @@ module UnicodeNormalize  # :nodoc:
         last_class = accent_class
       end
     end
-    accents = nfc_one(accents) if accents.length>1 # TODO: change from recursion to loop
-    hangul_comp_one(start+accents)
+
+    result = start
+    until accents.empty?
+      start = accents[0]
+      last_class = CLASS_TABLE[start]-1
+      rest = ''
+      accents[1..-1].each_char do |accent|
+        accent_class = CLASS_TABLE[accent]
+        if last_class < accent_class && (composite = COMPOSITION_TABLE[start + accent])
+          start = composite
+        else
+          rest << accent
+          last_class = accent_class
+        end
+      end
+      result << start
+      accents = rest
+    end
+
+    hangul_comp_one(result)
   end
 
   def self.normalize(string, form = :nfc)


### PR DESCRIPTION
Fixes [TODO](https://github.com/ruby/ruby/commit/900ece77b2d338300ea79d19e7c623043a0be810) added by @duerst