### PR TITLE
Remove dead rehash check

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -1313,12 +1313,7 @@ hash_foreach_iter(st_data_t key, st_data_t value, st_data_t argp, int error)
 
     if (error) return ST_STOP;
 
-    st_table *tbl = RHASH_ST_TABLE(arg->hash);
     int status = (*arg->func)((VALUE)key, (VALUE)value, arg->arg);
-
-    if (RHASH_ST_TABLE(arg->hash) != tbl) {
-        rb_raise(rb_eRuntimeError, "rehash occurred during iteration");
-    }
 
     return hash_iter_status_check(status);
 }


### PR DESCRIPTION
Hash#rehash checks whether the hash is iterating, and with VWA,
RHASH_ST_TABLE() always returns the same thing for the same
hash.

    RHASH_ST_TABLE(VALUE h)
    {
        return (st_table *)((uintptr_t)h + sizeof(struct RHash));
    }

So this check never runs.
