### PR TITLE
[Feature #21028] ObjectSpace#find_paths_to_unshareable_objects

### DIFF
--- a/test/objspace/test_ractor.rb
+++ b/test/objspace/test_ractor.rb
@@ -1,4 +1,5 @@
 require "test/unit"
+require "objspace"
 
 class TestObjSpaceRactor < Test::Unit::TestCase
   def test_tracing_does_not_crash
@@ -51,5 +52,42 @@ class TestObjSpaceRactor < Test::Unit::TestCase
 
       ractors.each(&:join)
     RUBY
+  end
+
+  def test_find_paths_to_unshareable_objects
+    # Direct shareable object
+    assert_equal([], ObjectSpace.find_paths_to_unshareable_objects(1).to_a)
+
+    # Direct unshareable object
+    assert_equal([["unfrozen"]], ObjectSpace.find_paths_to_unshareable_objects("unfrozen").to_a)
+
+    # Hash containing unshareable object
+    obj = { a: 1, b: "frozen".freeze, c: "unfrozen" }
+    paths = ObjectSpace.find_paths_to_unshareable_objects(obj).to_a
+    assert_include(paths, [obj])
+    assert_include(paths, [obj, "unfrozen"])
+
+    # Array containing unshareable object
+    obj = [1, 2, "unfrozen", "frozen".freeze]
+    paths = ObjectSpace.find_paths_to_unshareable_objects(obj).to_a
+    assert_include(paths, [obj])
+    assert_include(paths, [obj, "unfrozen"])
+
+    # Custom class
+    klass = Class.new do
+      attr_accessor :value
+    end
+    obj = klass.new
+    obj.value = "unfrozen"
+    paths = ObjectSpace.find_paths_to_unshareable_objects(obj).to_a
+    assert_include(paths, [obj])
+    assert_include(paths, [obj, "unfrozen"])
+
+    # Circular reference
+    obj1 = { name: "obj1" }
+    obj2 = { name: "obj2", ref: obj1 }
+    obj1[:ref] = obj2
+    paths = ObjectSpace.find_paths_to_unshareable_objects(obj1).to_a
+    assert_include(paths, [obj1, obj2, "obj2"]) # does not circle back to obj1
   end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21028

Add a method to find paths to Ractor-unshareable objects which can be traced from an object.

Example:

```ruby
class Container
  attr_reader :value
  def initialize(value)
    @value = value
  end
end

mutable_string = "hello"
container = Container.new(mutable_string)

pp ObjectSpace.find_paths_to_unshareable_objects(container).to_a
  #=> [
    [#<Container:0x00007fc35843e388 @value="hello">],
    [#<Container:0x00007fc35843e388 @value="hello">, "hello"]
  ]
```

Co-authored-by: Yusuke Endoh <mame@ruby-lang.org>
