### PR TITLE
Interpolated strings must not be frozen

### DIFF
--- a/prism/prism.c
+++ b/prism/prism.c
@@ -5279,6 +5279,10 @@ pm_interpolated_string_node_append(pm_interpolated_string_node_t *node, pm_node_
 
     switch (PM_NODE_TYPE(part)) {
         case PM_STRING_NODE:
+            // If inner string is not frozen, clear flags for this string
+            if (!PM_NODE_FLAG_P(part, PM_STRING_FLAGS_FROZEN)) {
+                CLEAR_FLAGS(node);
+            }
             part->flags = (pm_node_flags_t) ((part->flags | PM_NODE_FLAG_STATIC_LITERAL | PM_STRING_FLAGS_FROZEN) & ~PM_STRING_FLAGS_MUTABLE);
             break;
         case PM_INTERPOLATED_STRING_NODE:

--- a/test/prism/result/static_literals_test.rb
+++ b/test/prism/result/static_literals_test.rb
@@ -4,6 +4,11 @@ require_relative "../test_helper"
 
 module Prism
   class StaticLiteralsTest < TestCase
+    def test_concatenanted_string_literal_is_not_static
+      node = Prism.parse_statement("'a' 'b'")
+      refute_predicate node, :static_literal?
+    end
+
     def test_static_literals
       assert_warning("1")
       assert_warning("0xA", "10", "10")


### PR DESCRIPTION
Strings concatenated with backslash may end up being frozen when they shouldn't be.  This commit fixes the issue.  It required a change upstream in Prism, but also a change to the Prism compiler in CRuby.

  https://github.com/ruby/prism/pull/3606

[Bug #21187]