### PR TITLE
Support `cause:` in `Thread#raise` and `Fiber#raise`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -104,6 +104,16 @@ Note: We're only listing outstanding class updates.
     * Update Unicode to Version 16.0.0 and Emoji Version 16.0.
       [[Feature #19908]][[Feature #20724]] (also applies to Regexp)
 
+* Thread
+
+    * Introduce support for `Thread#raise(cause:)` argument similar to
+      `Kernel#raise`. [[Feature #21360]]
+
+* Fiber
+
+    * Introduce support for `Fiber#raise(cause:)` argument similar to
+      `Kernel#raise`. [[Feature #21360]]
+
 * Fiber::Scheduler
 
     * Introduce `Fiber::Scheduler#fiber_interrupt` to interrupt a fiber with a
@@ -243,3 +253,4 @@ The following bundled gems are updated.
 [Feature #21262]: https://bugs.ruby-lang.org/issues/21262
 [Feature #21287]: https://bugs.ruby-lang.org/issues/21287
 [Feature #21347]: https://bugs.ruby-lang.org/issues/21347
+[Feature #21360]: https://bugs.ruby-lang.org/issues/21360

--- a/common.mk
+++ b/common.mk
@@ -4094,6 +4094,7 @@ cont.$(OBJEXT): $(top_srcdir)/internal/basic_operators.h
 cont.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 cont.$(OBJEXT): $(top_srcdir)/internal/cont.h
 cont.$(OBJEXT): $(top_srcdir)/internal/error.h
+cont.$(OBJEXT): $(top_srcdir)/internal/eval.h
 cont.$(OBJEXT): $(top_srcdir)/internal/gc.h
 cont.$(OBJEXT): $(top_srcdir)/internal/imemo.h
 cont.$(OBJEXT): $(top_srcdir)/internal/namespace.h
@@ -19292,6 +19293,7 @@ thread.$(OBJEXT): $(top_srcdir)/internal/class.h
 thread.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 thread.$(OBJEXT): $(top_srcdir)/internal/cont.h
 thread.$(OBJEXT): $(top_srcdir)/internal/error.h
+thread.$(OBJEXT): $(top_srcdir)/internal/eval.h
 thread.$(OBJEXT): $(top_srcdir)/internal/gc.h
 thread.$(OBJEXT): $(top_srcdir)/internal/hash.h
 thread.$(OBJEXT): $(top_srcdir)/internal/imemo.h

--- a/cont.c
+++ b/cont.c
@@ -30,6 +30,7 @@ extern int madvise(caddr_t, size_t, int);
 #include "internal/cont.h"
 #include "internal/thread.h"
 #include "internal/error.h"
+#include "internal/eval.h"
 #include "internal/gc.h"
 #include "internal/proc.h"
 #include "internal/sanitizers.h"
@@ -3218,9 +3219,9 @@ fiber_raise(rb_fiber_t *fiber, VALUE exception)
 }
 
 VALUE
-rb_fiber_raise(VALUE fiber, int argc, const VALUE *argv)
+rb_fiber_raise(VALUE fiber, int argc, VALUE *argv)
 {
-    VALUE exception = rb_make_exception(argc, argv);
+    VALUE exception = rb_exception_setup(argc, argv);
 
     return fiber_raise(fiber_ptr(fiber), exception);
 }

--- a/include/ruby/internal/intern/cont.h
+++ b/include/ruby/internal/intern/cont.h
@@ -275,7 +275,7 @@ VALUE rb_fiber_transfer_kw(VALUE fiber, int argc, const VALUE *argv, int kw_spla
  * @exception   rb_eFiberError  `fiber` is terminated etc.
  * @return      (See rb_fiber_resume() for details)
  */
-VALUE rb_fiber_raise(VALUE fiber, int argc, const VALUE *argv);
+VALUE rb_fiber_raise(VALUE fiber, int argc, VALUE *argv);
 
 RBIMPL_SYMBOL_EXPORT_END()
 

--- a/internal/eval.h
+++ b/internal/eval.h
@@ -26,6 +26,7 @@ extern ID ruby_static_id_status;
 VALUE rb_refinement_module_get_refined_class(VALUE module);
 void rb_class_modify_check(VALUE);
 NORETURN(VALUE rb_f_raise(int argc, VALUE *argv));
+VALUE rb_exception_setup(int argc, VALUE *argv);
 void rb_refinement_setup(struct rb_refinements_data *data, VALUE module, VALUE klass);
 void rb_vm_using_module(VALUE module);
 VALUE rb_top_main_class(const char *method);

--- a/spec/ruby/core/fiber/fixtures/classes.rb
+++ b/spec/ruby/core/fiber/fixtures/classes.rb
@@ -1,9 +1,19 @@
 module FiberSpecs
 
   class NewFiberToRaise
-    def self.raise(*args, **kwargs)
-      fiber = Fiber.new { Fiber.yield }
+    def self.raise(*args, **kwargs, &block)
+      fiber = Fiber.new do
+        if block_given?
+          block.call do
+            Fiber.yield
+          end
+        else
+          Fiber.yield
+        end
+      end
+
       fiber.resume
+
       fiber.raise(*args, **kwargs)
     end
   end

--- a/spec/ruby/core/fiber/fixtures/classes.rb
+++ b/spec/ruby/core/fiber/fixtures/classes.rb
@@ -1,10 +1,10 @@
 module FiberSpecs
 
   class NewFiberToRaise
-    def self.raise(*args)
+    def self.raise(*args, **kwargs)
       fiber = Fiber.new { Fiber.yield }
       fiber.resume
-      fiber.raise(*args)
+      fiber.raise(*args, **kwargs)
     end
   end
 

--- a/spec/ruby/core/fiber/raise_spec.rb
+++ b/spec/ruby/core/fiber/raise_spec.rb
@@ -136,3 +136,87 @@ describe "Fiber#raise" do
     -> { fiber.raise "msg" }.should raise_error(RuntimeError, "msg")
   end
 end
+
+ruby_version_is "3.5" do
+  describe "Fiber#raise with cause keyword argument" do
+    it "accepts a cause keyword argument that overrides the last exception" do
+      original_cause = nil
+      override_cause = StandardError.new("override cause")
+      result = nil
+
+      fiber = Fiber.new do
+        begin
+          begin
+            raise "first error"
+          rescue => error
+            original_cause = error
+            Fiber.yield
+          end
+        rescue => error
+          result = error
+        end
+      end
+
+      fiber.resume
+      fiber.raise("second error", cause: override_cause)
+
+      result.should be_kind_of(RuntimeError)
+      result.message.should == "second error"
+      result.cause.should == override_cause
+      result.cause.should_not == original_cause
+    end
+
+    it "supports automatic cause chaining from calling context" do
+      result = nil
+
+      fiber = Fiber.new do
+        begin
+          begin
+            raise "original error"
+          rescue
+            Fiber.yield
+          end
+        rescue => result
+          # Ignore.
+        end
+      end
+
+      fiber.resume
+      # No explicit cause - should use calling context's `$!`:
+      fiber.raise("new error")
+
+      result.should be_kind_of(RuntimeError)
+      result.message.should == "new error"
+      # Calling context has no current exception:
+      result.cause.should == nil
+    end
+
+    it "supports explicit cause: nil to prevent cause chaining" do
+      result = nil
+
+      fiber = Fiber.new do
+        begin
+          begin
+            raise "original error"
+          rescue
+            Fiber.yield
+          end
+        rescue => result
+          # Ignore.
+        end
+      end
+
+      begin
+        raise "calling context error"
+      rescue
+        fiber.resume
+        # Explicit nil prevents chaining:
+        fiber.raise("new error", cause: nil)
+
+        result.should be_kind_of(RuntimeError)
+        result.message.should == "new error"
+        result.cause.should == nil
+      end
+    end
+  end
+end

--- a/spec/ruby/core/thread/fixtures/classes.rb
+++ b/spec/ruby/core/thread/fixtures/classes.rb
@@ -6,6 +6,30 @@ module ThreadSpecs
     end
   end
 
+  class NewThreadToRaise
+    def self.raise(*args, **kwargs, &block)
+      thread = Thread.new do
+        Thread.current.report_on_exception = false
+
+        if block_given?
+          block.call do
+            sleep
+          end
+        else
+          sleep
+        end
+      end
+
+      Thread.pass until thread.stop?
+
+      thread.raise(*args, **kwargs)
+
+      thread.join
+    ensure
+      thread.kill if thread.alive?
+    end
+  end
+
   class Status
     attr_reader :thread, :inspect, :status, :to_s
     def initialize(thread)

--- a/spec/ruby/core/thread/raise_spec.rb
+++ b/spec/ruby/core/thread/raise_spec.rb
@@ -3,6 +3,9 @@ require_relative 'fixtures/classes'
 require_relative '../../shared/kernel/raise'
 
 describe "Thread#raise" do
+  it_behaves_like :kernel_raise, :raise, ThreadSpecs::NewThreadToRaise
+  it_behaves_like :kernel_raise_across_contexts, :raise, ThreadSpecs::NewThreadToRaise
+
   it "ignores dead threads and returns nil" do
     t = Thread.new { :dead }
     Thread.pass while t.alive?
@@ -228,94 +231,5 @@ describe "Thread#raise on same thread" do
       end
     end
     -> { t.value }.should raise_error(RuntimeError, '')
-  end
-end
-
-ruby_version_is "3.5" do
-  describe "Thread#raise with cause keyword argument" do
-    before :each do
-      ScratchPad.clear
-    end
-
-    it "accepts a cause keyword argument that overrides the last exception" do
-      original_cause = nil
-      override_cause = StandardError.new("override cause")
-
-      thread = Thread.new do
-        Thread.current.report_on_exception = false
-        begin
-          begin
-            raise "first error"
-          rescue => error
-            original_cause = error
-            sleep
-          end
-        rescue => error
-          error
-        end
-      end
-
-      ThreadSpecs.spin_until_sleeping(thread)
-      thread.raise("second error", cause: override_cause)
-      result = thread.value
-
-      result.should be_kind_of(RuntimeError)
-      result.message.should == "second error"
-      result.cause.should == override_cause
-      result.cause.should_not == original_cause
-    end
-
-    it "supports automatic cause chaining from calling context" do
-      thread = Thread.new do
-        Thread.current.report_on_exception = false
-        begin
-          begin
-            raise "original error"
-          rescue
-            sleep
-          end
-        rescue => error
-          error
-        end
-      end
-
-      ThreadSpecs.spin_until_sleeping(thread)
-      # No explicit cause - should use calling context's `$!`:
-      thread.raise("new error")
-      result = thread.value
-
-      result.should be_kind_of(RuntimeError)
-      result.message.should == "new error"
-      # Calling context has no current exception:
-      result.cause.should == nil
-    end
-
-    it "supports explicit cause: nil to prevent cause chaining" do
-      thread = Thread.new do
-        Thread.current.report_on_exception = false
-        begin
-          begin
-            raise "original error"
-          rescue
-            sleep
-          end
-        rescue => error
-          error
-        end
-      end
-
-      begin
-        raise "calling context error"
-      rescue
-        ThreadSpecs.spin_until_sleeping(thread)
-        # Explicit nil prevents chaining:
-        thread.raise("new error", cause: nil)
-        result = thread.value
-
-        result.should be_kind_of(RuntimeError)
-        result.message.should == "new error"
-        result.cause.should == nil
-      end
-    end
   end
 end


### PR DESCRIPTION
See <https://bugs.ruby-lang.org/issues/21360> for context. See <https://github.com/socketry/async/pull/388> for example usage (stop with `cause:`).