### PR TITLE
Launchable: Remove `launchable subset` command

### DIFF
--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -182,12 +182,6 @@ runs:
             --flavor workflow="${{ github.workflow }}" \
             --test-suite ${suite} \
             )
-          launchable subset \
-            --get-tests-from-previous-sessions \
-            --non-blocking \
-            --target 90% \
-            --session "${session}" \
-            raw > /dev/null
           echo "${target}_session=${session}" >> $GITHUB_OUTPUT
         }
 


### PR DESCRIPTION
I've enabled the [Predictive Test Selection](https://www.launchableinc.com/docs/features/predictive-test-selection/) feature, which let machine-learning model selects the appropriate tests to reduce CI execution time in https://github.com/ruby/ruby/pull/12617.

However, I noticed that there are some problems for enabling PTS in Ruby CI after several experiments. Until fixing the problem, I'll disable this feature by removing `launchable subset` command.