### PR TITLE
ZJIT: Fix clobbering register for `self` in gen_entry_params()

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -811,6 +811,12 @@ class TestZJIT < Test::Unit::TestCase
       def a(n1,n2,n3,n4,n5,n6,n7,n8) = n8
       a(1,1,1,1,1,1,1,0)
     }
+
+    # self param with spilled param
+    assert_compiles '"main"', %q{
+      def a(n1,n2,n3,n4,n5,n6,n7,n8) = self
+      a(1,0,0,0,0,0,0,0).to_s
+    }
   end
 
   def test_opt_aref_with


### PR DESCRIPTION
Previously, for 8+ params we wound up clobbering the self param when
putting the last param in memory in the JIT entry point:

    # ZJIT entry point: a@../test.rb:5
    <snip>
    ldur x0, [x19, #0x18]
    # set method params: 8
    ldur x1, [x21, #-0x58]
    ldur x2, [x21, #-0x50]
    ldur x3, [x21, #-0x48]
    ldur x4, [x21, #-0x40]
    ldur x5, [x21, #-0x38]
    ldur x11, [x21, #-0x30]
    ldur x12, [x21, #-0x28]
    ldur x0, [x21, #-0x20]
    stur x0, [sp, #-0x20]
    bl #0x11e17018c

Doing the memcpys for parameters in memory first avoids this clobbering.

    # set method params: 8
    ldur x0, [x21, #-0x20]
    stur x0, [sp, #-0x20]
    ldur x12, [x21, #-0x28]
    ldur x11, [x21, #-0x30]
    ldur x5, [x21, #-0x38]
    ldur x4, [x21, #-0x40]
    ldur x3, [x21, #-0x48]
    ldur x2, [x21, #-0x50]
    ldur x1, [x21, #-0x58]
    ldur x0, [x19, #0x18]
