### PR TITLE
math.c: cleanup unused `#include <errno.h>`

### DIFF
--- a/math.c
+++ b/math.c
@@ -15,7 +15,6 @@
 # define _USE_MATH_DEFINES 1
 #endif
 
-#include <errno.h>
 #include <float.h>
 #include <math.h>
 


### PR DESCRIPTION
`errno` is no longer used after 5073155a178a9f478950afef4f148e44fd14b5d6