### PR TITLE
Fix `RCLASS_WRITE_M_TBL_WORKAROUND` to avoid Ruby crash

### DIFF
--- a/internal/class.h
+++ b/internal/class.h
@@ -8,6 +8,7 @@
  *             file COPYING are met.  Consult the file for details.
  * @brief      Internal header for Class.
  */
+#include "gc.h"
 #include "id.h"
 #include "id_table.h"           /* for struct rb_id_table */
 #include "internal/namespace.h" /* for rb_current_namespace */
@@ -261,7 +262,7 @@ static inline void RCLASS_SET_SUPER(VALUE klass, VALUE super);
 static inline void RCLASS_WRITE_SUPER(VALUE klass, VALUE super);
 // TODO: rename RCLASS_SET_M_TBL_WORKAROUND (and _WRITE_) to RCLASS_SET_M_TBL with write barrier
 static inline void RCLASS_SET_M_TBL_WORKAROUND(VALUE klass, struct rb_id_table *table, bool check_promoted);
-static inline void RCLASS_WRITE_M_TBL_WORKAROUND(VALUE klass, struct rb_id_table *table, bool check_promoted);
+static inline void RCLASS_WRITE_M_TBL_WORKAROUND(VALUE klass, struct rb_id_table *table);
 static inline void RCLASS_SET_CONST_TBL(VALUE klass, struct rb_id_table *table, bool shared);
 static inline void RCLASS_WRITE_CONST_TBL(VALUE klass, struct rb_id_table *table, bool shared);
 static inline void RCLASS_WRITE_CALLABLE_M_TBL(VALUE klass, struct rb_id_table *table);
@@ -604,16 +605,16 @@ RCLASS_SET_M_TBL_WORKAROUND(VALUE klass, struct rb_id_table *table, bool check_p
     RCLASSEXT_M_TBL(RCLASS_EXT_PRIME(klass)) = table;
 }
 
-#define RCLASS_WRITE_M_TBL_EVEN_WHEN_PROMOTED(klass, table) RCLASS_WRITE_M_TBL_WORKAROUND(klass, table, false)
-#define RCLASS_WRITE_M_TBL(klass, table) RCLASS_WRITE_M_TBL_WORKAROUND(klass, table, true)
+#define RCLASS_WRITE_M_TBL_EVEN_WHEN_PROMOTED(klass, table) RCLASS_WRITE_M_TBL_WORKAROUND(klass, table)
+#define RCLASS_WRITE_M_TBL(klass, table) RCLASS_WRITE_M_TBL_WORKAROUND(klass, table)
 
 static inline void
-RCLASS_WRITE_M_TBL_WORKAROUND(VALUE klass, struct rb_id_table *table, bool check_promoted)
+RCLASS_WRITE_M_TBL_WORKAROUND(VALUE klass, struct rb_id_table *table)
 {
-    RUBY_ASSERT(!check_promoted || !RB_OBJ_PROMOTED(klass));
     // TODO: add write barrier here to guard assigning m_tbl
     //       see commit 28a6e4ea9d9379a654a8f7c4b37fa33aa3ccd0b7
     RCLASSEXT_M_TBL(RCLASS_EXT_WRITABLE(klass)) = table;
+    rb_gc_writebarrier_remember(klass);
 }
 
 static inline void


### PR DESCRIPTION
On the current master, running `test_refinement.rb` with GC stress would cause Ruby to crash:

```
make test-all TESTS='../test/ruby/test_refinement.rb --gc-stress'
```

```
TestRefinement#test_refine_alias_in_subclass../internal/class.h:613:
Assertion Failed: RCLASS_WRITE_M_TBL_WORKAROUND:!check_promoted || !RB_OBJ_PROMOTED(klass)
```

This commit fixes the crash by applying write barrier remember to the klass, which is still a workaround, but avoids crashing Ruby with an assertion.