### PR TITLE
Prevent fork from happening in getnameinfo

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -713,6 +713,12 @@ do_getnameinfo(void *ptr)
 }
 
 static void *
+fork_safe_do_getnameinfo(void *ptr)
+{
+    return rb_thread_prevent_fork(do_getnameinfo, ptr);
+}
+
+static void *
 wait_getnameinfo(void *ptr)
 {
     struct getnameinfo_arg *arg = (struct getnameinfo_arg *)ptr;
@@ -752,7 +758,7 @@ start:
     }
 
     pthread_t th;
-    if (raddrinfo_pthread_create(&th, do_getnameinfo, arg) != 0) {
+    if (raddrinfo_pthread_create(&th, fork_safe_do_getnameinfo, arg) != 0) {
         int err = errno;
         free_getnameinfo_arg(arg);
         errno = err;


### PR DESCRIPTION
This PR applies the same fork-safety lock as getaddrinfo https://github.com/ruby/ruby/pull/10864 to getnameinfo.

Given that `do_getaddrinfo` and `do_getnameinfo` have a very similar structure and one of them needs a fork-safety lock, it seems likely that we need the same thing for the other one.

We're seeing segfaults on `rb_getnameinfo` at Shopify. I'm not sure if this change fixes the situation, but it helps us investigate the issue by ruling out the possibility of `fork` during `rb_getnameinfo`.