### PR TITLE
Extract vm_locked_by_ractor_p

### DIFF
--- a/misc/tsan_suppressions.txt
+++ b/misc/tsan_suppressions.txt
@@ -30,13 +30,6 @@ race:check_reserved_signal_
 
 race_top:rb_check_deadlock
 
-# lock_owner
-race_top:thread_sched_setup_running_threads
-race_top:vm_lock_enter
-race_top:rb_ec_vm_lock_rec
-race_top:vm_lock_enter
-race_top:vm_locked
-
 # vm->ractor.sched.grq_cnt++
 race_top:ractor_sched_enq
 race_top:ractor_sched_deq

--- a/vm_sync.c
+++ b/vm_sync.c
@@ -12,7 +12,7 @@ void rb_ractor_sched_barrier_end(rb_vm_t *vm, rb_ractor_t *cr);
 static bool
 vm_locked(rb_vm_t *vm)
 {
-    return vm->ractor.sync.lock_owner == GET_RACTOR();
+    return vm_locked_by_ractor_p(vm, GET_RACTOR());
 }
 
 #if RUBY_DEBUG > 0


### PR DESCRIPTION
This introduces a new method to encapsulate checking whether the current Ractor owns the vm->ractor.sync lock. This allows us to disable TSan on it since that operation should be safe, and still get validation of other uses.