### PR TITLE
YJIT: Use raw memory write to update pointers in code

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -2091,11 +2091,9 @@ pub extern "C" fn rb_yjit_iseq_update_references(iseq: IseqPtr) {
 
                 // Only write when the VALUE moves, to be copy-on-write friendly.
                 if new_addr != object {
-                    for (byte_idx, &byte) in new_addr.as_u64().to_le_bytes().iter().enumerate() {
-                        let byte_code_ptr = value_code_ptr.add_bytes(byte_idx);
-                        cb.write_mem(byte_code_ptr, byte)
-                            .expect("patching existing code should be within bounds");
-                    }
+                    // SAFETY: Since we already set code memory writable before the compacting phase,
+                    // we can use raw memory accesses directly.
+                    unsafe { value_ptr.write_unaligned(new_addr); }
                 }
             }
         }


### PR DESCRIPTION
Because we have set all code memory to writable before the reference updating phase, we can use raw memory writes directly.

This change should have been part of a previous pull request https://github.com/ruby/ruby/pull/13843 for supporting parallel GC with YJIT.  With the `RefCell` moved down to `VirtualMem`, offset-to-address computation no longer needs to borrow anything.  But `cb.write_mem` still needs to borrow the `VirtualMemoryMut`.  We now replace the use of `cb.write_mem` with direct raw memory access because we have already set the permission of the code memory to writable.

I tried a microbenchmark that just calls `GC.compact` in a loop.  This PR has no visible impact on the compaction time.