### PR TITLE
Add DEFINED NODE locations

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -948,6 +948,10 @@ node_locations(VALUE ast_value, const NODE *node)
                                     location_new(&RNODE_YIELD(node)->keyword_loc),
                                     location_new(&RNODE_YIELD(node)->lparen_loc),
                                     location_new(&RNODE_YIELD(node)->rparen_loc));
+      case NODE_DEFINED:
+        return rb_ary_new_from_args(2,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_DEFINED(node)->keyword_loc));
       case NODE_ARGS_AUX:
       case NODE_LAST:
         break;

--- a/node_dump.c
+++ b/node_dump.c
@@ -1105,8 +1105,9 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("defined? expression");
         ANN("format: defined?([nd_head])");
         ANN("example: defined?(foo)");
-        LAST_NODE;
         F_NODE(nd_head, RNODE_DEFINED, "expr");
+        LAST_NODE;
+        F_LOC(keyword_loc, RNODE_DEFINED);
         return;
 
       case NODE_POSTEXE:

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -962,6 +962,7 @@ typedef struct RNode_DEFINED {
     NODE node;
 
     struct RNode *nd_head;
+    rb_code_location_t keyword_loc;
 } rb_node_defined_t;
 
 typedef struct RNode_POSTEXE {

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1655,6 +1655,11 @@ dummy
       assert_locations(node.children[-1].children[-1].children[-1].locations, [[1, 9, 1, 20], [1, 9, 1, 14], [1, 14, 1, 15], [1, 19, 1, 20]])
     end
 
+    def test_defined_locations
+      node = ast_parse("defined? x")
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 10], [1, 0, 1, 8]])
+    end
+
     private
     def ast_parse(src, **options)
       begin


### PR DESCRIPTION
Add `keyword_defined` locations to struct `RNode_DEFINED`.

This implementation references other add keyword locations pull requests and Prism AST information.
Please let me know if any additional changes are required.