### PR TITLE
Add MODULE NODE locations

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -866,6 +866,11 @@ node_locations(VALUE ast_value, const NODE *node)
                                     location_new(&RNODE_IF(node)->if_keyword_loc),
                                     location_new(&RNODE_IF(node)->then_keyword_loc),
                                     location_new(&RNODE_IF(node)->end_keyword_loc));
+      case NODE_MODULE:
+        return rb_ary_new_from_args(3,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_MODULE(node)->module_keyword_loc),
+                                    location_new(&RNODE_MODULE(node)->end_keyword_loc));
       case NODE_NEXT:
         return rb_ary_new_from_args(2,
                                     location_new(nd_code_loc(node)),

--- a/node_dump.c
+++ b/node_dump.c
@@ -1009,8 +1009,10 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("format: module [nd_cpath]; [nd_body]; end");
         ANN("example: module M; ..; end");
         F_NODE(nd_cpath, RNODE_MODULE, "module path");
-        LAST_NODE;
         F_NODE(nd_body, RNODE_MODULE, "module definition");
+        F_LOC(module_keyword_loc, RNODE_MODULE);
+        LAST_NODE;
+        F_LOC(end_keyword_loc, RNODE_MODULE);
         return;
 
       case NODE_SCLASS:

--- a/parse.y
+++ b/parse.y
@@ -1145,7 +1145,7 @@ static rb_node_alias_t *rb_node_alias_new(struct parser_params *p, NODE *nd_1st,
 static rb_node_valias_t *rb_node_valias_new(struct parser_params *p, ID nd_alias, ID nd_orig, const YYLTYPE *loc, const YYLTYPE *keyword_loc);
 static rb_node_undef_t *rb_node_undef_new(struct parser_params *p, NODE *nd_undef, const YYLTYPE *loc);
 static rb_node_class_t *rb_node_class_new(struct parser_params *p, NODE *nd_cpath, NODE *nd_body, NODE *nd_super, const YYLTYPE *loc, const YYLTYPE *class_keyword_loc, const YYLTYPE *inheritance_operator_loc, const YYLTYPE *end_keyword_loc);
-static rb_node_module_t *rb_node_module_new(struct parser_params *p, NODE *nd_cpath, NODE *nd_body, const YYLTYPE *loc);
+static rb_node_module_t *rb_node_module_new(struct parser_params *p, NODE *nd_cpath, NODE *nd_body, const YYLTYPE *loc, const YYLTYPE *module_keyword_loc, const YYLTYPE *end_keyword_loc);
 static rb_node_sclass_t *rb_node_sclass_new(struct parser_params *p, NODE *nd_recv, NODE *nd_body, const YYLTYPE *loc);
 static rb_node_colon2_t *rb_node_colon2_new(struct parser_params *p, NODE *nd_head, ID nd_mid, const YYLTYPE *loc, const YYLTYPE *delimiter_loc, const YYLTYPE *name_loc);
 static rb_node_colon3_t *rb_node_colon3_new(struct parser_params *p, ID nd_mid, const YYLTYPE *loc, const YYLTYPE *delimiter_loc, const YYLTYPE *name_loc);
@@ -1253,7 +1253,7 @@ static rb_node_error_t *rb_node_error_new(struct parser_params *p, const YYLTYPE
 #define NEW_VALIAS(n,o,loc,k_loc) (NODE *)rb_node_valias_new(p,n,o,loc,k_loc)
 #define NEW_UNDEF(i,loc) (NODE *)rb_node_undef_new(p,i,loc)
 #define NEW_CLASS(n,b,s,loc,ck_loc,io_loc,ek_loc) (NODE *)rb_node_class_new(p,n,b,s,loc,ck_loc,io_loc,ek_loc)
-#define NEW_MODULE(n,b,loc) (NODE *)rb_node_module_new(p,n,b,loc)
+#define NEW_MODULE(n,b,loc,mk_loc,ek_loc) (NODE *)rb_node_module_new(p,n,b,loc,mk_loc,ek_loc)
 #define NEW_SCLASS(r,b,loc) (NODE *)rb_node_sclass_new(p,r,b,loc)
 #define NEW_COLON2(c,i,loc,d_loc,n_loc) (NODE *)rb_node_colon2_new(p,c,i,loc,d_loc,n_loc)
 #define NEW_COLON3(i,loc,d_loc,n_loc) (NODE *)rb_node_colon3_new(p,i,loc,d_loc,n_loc)
@@ -4621,7 +4621,7 @@ primary		: inline_primary
               bodystmt
               k_end
                 {
-                    $$ = NEW_MODULE($cpath, $bodystmt, &@$);
+                    $$ = NEW_MODULE($cpath, $bodystmt, &@$, &@k_module, &@k_end);
                     nd_set_line(RNODE_MODULE($$)->nd_body, @k_end.end_pos.lineno);
                     set_line_body($bodystmt, @cpath.end_pos.lineno);
                     nd_set_line($$, @cpath.end_pos.lineno);
@@ -11438,13 +11438,15 @@ rb_node_sclass_new(struct parser_params *p, NODE *nd_recv, NODE *nd_body, const 
 }
 
 static rb_node_module_t *
-rb_node_module_new(struct parser_params *p, NODE *nd_cpath, NODE *nd_body, const YYLTYPE *loc)
+rb_node_module_new(struct parser_params *p, NODE *nd_cpath, NODE *nd_body, const YYLTYPE *loc, const YYLTYPE *module_keyword_loc, const YYLTYPE *end_keyword_loc)
 {
     /* Keep the order of node creation */
     NODE *scope = NEW_SCOPE(0, nd_body, loc);
     rb_node_module_t *n = NODE_NEWNODE(NODE_MODULE, rb_node_module_t, loc);
     n->nd_cpath = nd_cpath;
     n->nd_body = scope;
+    n->module_keyword_loc = *module_keyword_loc;
+    n->end_keyword_loc = *end_keyword_loc;
 
     return n;
 }

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -901,6 +901,8 @@ typedef struct RNode_MODULE {
 
     struct RNode *nd_cpath;
     struct RNode *nd_body;
+    rb_code_location_t module_keyword_loc;
+    rb_code_location_t end_keyword_loc;
 } rb_node_module_t;
 
 typedef struct RNode_SCLASS {

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1491,6 +1491,11 @@ dummy
       assert_locations(node.children[-1].locations, [[1, 0, 1, 20], [1, 0, 1, 2], [1, 10, 1, 12], [1, 17, 1, 20]])
     end
 
+    def test_module_locations
+      node = ast_parse('module A end')
+      assert_locations(node.children[-1].locations, [[1, 0, 1, 12], [1, 0, 1, 6], [1, 9, 1, 12]])
+    end
+
     def test_if_locations
       node = ast_parse("if cond then 1 else 2 end")
       assert_locations(node.children[-1].locations, [[1, 0, 1, 25], [1, 0, 1, 2], [1, 8, 1, 12], [1, 22, 1, 25]])


### PR DESCRIPTION
Add `keyword_module` amd `keyword_end` locations to struct `RNode_MODULE`.

memo:
```
>ruby --dump=parsetree -e 'module A end'
@ ProgramNode (location: (1,0)-(1,12))
+-- locals: []
+-- statements:
    @ StatementsNode (location: (1,0)-(1,12))
    +-- body: (length: 1)
        +-- @ ModuleNode (location: (1,0)-(1,12))
            +-- locals: []
            +-- module_keyword_loc: (1,0)-(1,6) = "module"
            +-- constant_path:
            |   @ ConstantReadNode (location: (1,7)-(1,8))
            |   +-- name: :A
            +-- body: nil
            +-- end_keyword_loc: (1,9)-(1,12) = "end"
            +-- name: :A
```
