### PR TITLE
Add test for `String#byteslice` with multibyte characters

### DIFF
--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -2481,7 +2481,6 @@ CODE
         i & integer\\
         L & unsigned long\\
         l & long\\
-
         m & string encoded in base64 (uuencoded)\\
         N & long, network (big-endian) byte order\\
         n & short, network (big-endian) byte-order\\
@@ -2493,8 +2492,7 @@ CODE
         v & short, little-endian byte order\\
         X & back up a byte\\
         x & null byte\\
-        Z & ASCII string (null padded, count is width)\\
-"
+        Z & ASCII string (null padded, count is width)\\"
 =end
   end
 
@@ -2845,13 +2843,11 @@ CODE
     assert_equal("\u3042", ("\u3042" * 100)[-1])
   end
 
-=begin
   def test_compare_different_encoding_string
     s1 = S("\xff".force_encoding("UTF-8"))
     s2 = S("\xff".force_encoding("ISO-2022-JP"))
     assert_equal([-1, 1], [s1 <=> s2, s2 <=> s1].sort)
   end
-=end
 
   def test_casecmp
     assert_equal(0, S("FoO").casecmp("fOO"))
@@ -3320,6 +3316,11 @@ CODE
     assert_equal(u("\x81\x82"), S("\u3042").byteslice(1..2))
 
     assert_equal(u("\x82")+("\u3042"*9), S("\u3042"*10).byteslice(2, 28))
+
+    assert_equal("\xE3", S("こんにちは").byteslice(0))
+    assert_equal("こんにちは", S("こんにちは").byteslice(0, 15))
+    assert_equal("こ", S("こんにちは").byteslice(0, 3))
+    assert_equal("は", S("こんにちは").byteslice(12, 15))
 
     bug7954 = '[ruby-dev:47108]'
     assert_equal(false, S("\u3042").byteslice(0, 2).valid_encoding?, bug7954)

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -2847,6 +2847,10 @@ CODE
     s1 = S("\xff".force_encoding("UTF-8"))
     s2 = S("\xff".force_encoding("ISO-2022-JP"))
     assert_equal([-1, 1], [s1 <=> s2, s2 <=> s1].sort)
+
+    s3 = S("あ".force_encoding("UTF-16LE"))
+    s4 = S("a".force_encoding("IBM437"))
+    assert_equal([-1, 1], [s3 <=> s4, s4 <=> s3].sort)
   end
 
   def test_casecmp
@@ -2949,7 +2953,6 @@ CODE
     s5 = S("\u0000\u3042")
     assert_equal("\u3042", s5.lstrip!)
     assert_equal("\u3042", s5)
-
   end
 
   def test_delete_prefix_type_error


### PR DESCRIPTION
1 - This PR adds a test case to verify the behavior of String#byteslice when used with multibyte UTF-8 characters.

The test uses the Japanese string `"こんにちは"` (Hello).

It asserts that `s.byteslice(0, 3)` correctly returns `"こ"`, which is the first character encoded in 3 bytes in UTF-8.

This helps ensure that byteslice operates correctly at byte-level boundaries for multibyte strings, and protects against regressions in encoding-sensitive code.

Test added to:
`test/ruby/test_string.rb`

2 - Uncomment existing `test_compare_different_encoding_string` test in the same file, this commented out 17 years ago when comparing strings with different encodings. Historically, there has been ambiguity and assumptions around this might return inconsistent or raise an error when comparing strings of incompatible or broken encodings.

But currently running with the `master` this test consistently performs a byte-by-byte comparison `s1<=>s2` regardless of encoding incompatibility, always returning an integer (-1, 0, or 1).

I have run this test against all `Encoding.name_list` and it passed.
List:
```
[
  "ASCII-8BIT",
  "UTF-8",
  "US-ASCII",
  "UTF-16BE",
  "UTF-16LE",
  "UTF-32BE",
  "UTF-32LE",
  "UTF-16",
  "UTF-32",
  "UTF8-MAC",
  "EUC-JP",
  "Windows-31J",
  "Big5",
  "Big5-HKSCS",
  "Big5-UAO",
  "CESU-8",
  "CP949",
  "Emacs-Mule",
  "EUC-KR",
  "EUC-TW",
  "GB18030",
  "GBK",
  "ISO-8859-1",
  "ISO-8859-2",
  "ISO-8859-3",
  "ISO-8859-4",
  "ISO-8859-5",
  "ISO-8859-6",
  "ISO-8859-7",
  "ISO-8859-8",
  "ISO-8859-9",
  "ISO-8859-10",
  "ISO-8859-11",
  "ISO-8859-13",
  "ISO-8859-14",
  "ISO-8859-15",
  "ISO-8859-16",
  "KOI8-R",
  "KOI8-U",
  "Shift_JIS",
  "Windows-1250",
  "Windows-1251",
  "Windows-1252",
  "Windows-1253",
  "Windows-1254",
  "Windows-1257",
  "BINARY",
  "IBM437",
  "CP437",
  "IBM720",
  "CP720",
  "IBM737",
  "CP737",
  "IBM775",
  "CP775",
  "CP850",
  "IBM850",
  "IBM852",
  "CP852",
  "IBM855",
  "CP855",
  "IBM857",
  "CP857",
  "IBM860",
  "CP860",
  "IBM861",
  "CP861",
  "IBM862",
  "CP862",
  "IBM863",
  "CP863",
  "IBM864",
  "CP864",
  "IBM865",
  "CP865",
  "IBM866",
  "CP866",
  "IBM869",
  "CP869",
  "Windows-1258",
  "CP1258",
  "GB1988",
  "macCentEuro",
  "macCroatian",
  "macCyrillic",
  "macGreek",
  "macIceland",
  "macRoman",
  "macRomania",
  "macThai",
  "macTurkish",
  "macUkraine",
  "CP950",
  "Big5-HKSCS:2008",
  "CP951",
  "IBM037",
  "ebcdic-cp-us",
  "stateless-ISO-2022-JP",
  "eucJP",
  "eucJP-ms",
  "euc-jp-ms",
  "CP51932",
  "EUC-JIS-2004",
  "EUC-JISX0213",
  "eucKR",
  "eucTW",
  "GB2312",
  "EUC-CN",
  "eucCN",
  "GB12345",
  "CP936",
  "ISO-2022-JP",
  "ISO2022-JP",
  "ISO-2022-JP-2",
  "ISO2022-JP2",
  "CP50220",
  "CP50221",
  "ISO8859-1",
  "ISO8859-2",
  "ISO8859-3",
  "ISO8859-4",
  "ISO8859-5",
  "ISO8859-6",
  "Windows-1256",
  "CP1256",
  "ISO8859-7",
  "ISO8859-8",
  "Windows-1255",
  "CP1255",
  "ISO8859-9",
  "ISO8859-10",
  "ISO8859-11",
  "TIS-620",
  "Windows-874",
  "CP874",
  "ISO8859-13",
  "ISO8859-14",
  "ISO8859-15",
  "ISO8859-16",
  "CP878",
  "MacJapanese",
  "MacJapan",
  "ASCII",
  "ANSI_X3.4-1968",
  "646",
  "UTF-7",
  "CP65000",
  "CP65001",
  "UTF-8-MAC",
  "UTF-8-HFS",
  "UCS-2BE",
  "UCS-4BE",
  "UCS-4LE",
  "CP932",
  "csWindows31J",
  "SJIS",
  "PCK",
  "CP1250",
  "CP1251",
  "CP1252",
  "CP1253",
  "CP1254",
  "CP1257",
  "UTF8-DoCoMo",
  "SJIS-DoCoMo",
  "UTF8-KDDI",
  "SJIS-KDDI",
  "ISO-2022-JP-KDDI",
  "stateless-ISO-2022-JP-KDDI",
  "UTF8-SoftBank",
  "SJIS-SoftBank",
  "locale",
  "external",
  "filesystem",
  "internal"
]
```