### PR TITLE
Port Oniguruma patches to prevent integer overflow

### DIFF
--- a/regexec.c
+++ b/regexec.c
@@ -4960,7 +4960,7 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
 
   p = s;
   if (reg->dmin != 0) {
-    if ((ptrdiff_t)(end - p) <= (ptrdiff_t)reg->dmin) return 0; /* fail */
+    if ((OnigDistance)(end - p) <= reg->dmin) return 0; /* fail */
     if (ONIGENC_IS_SINGLEBYTE(reg->enc)) {
       p += reg->dmin;
     }
@@ -5003,7 +5003,7 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
   }
 
   if (p && p < range) {
-    if ((ptrdiff_t)(p - s) < (ptrdiff_t)reg->dmin) {
+    if ((OnigDistance)(p - s) < reg->dmin) {
     retry_gate:
       pprev = p;
       p += enclen(reg->enc, p, end);
@@ -5051,7 +5051,7 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
     }
     else {
       if (reg->dmax != ONIG_INFINITE_DISTANCE) {
-	if ((ptrdiff_t)(p - str) < (ptrdiff_t)reg->dmax) {
+	if ((OnigDistance)(p - str) < reg->dmax) {
 	  *low = (UChar* )str;
 	  if (low_prev)
 	    *low_prev = onigenc_get_prev_char_head(reg->enc, str, *low, end);
@@ -5073,7 +5073,7 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
 	}
       }
       /* no needs to adjust *high, *high is used as range check only */
-      if ((ptrdiff_t)(p - str) < (ptrdiff_t)reg->dmin)
+      if ((OnigDistance)(p - str) < reg->dmin)
         *high = (UChar* )str;
       else
         *high = p - reg->dmin;
@@ -5182,13 +5182,13 @@ backward_search_range(regex_t* reg, const UChar* str, const UChar* end,
     }
 
     if (reg->dmax != ONIG_INFINITE_DISTANCE) {
-      if ((ptrdiff_t)(p - str) < (ptrdiff_t)reg->dmax)
+      if ((OnigDistance)(p - str) < reg->dmax)
 	*low = (UChar* )str;
       else
 	*low = p - reg->dmax;
 
       if (reg->dmin != 0) {
-	if ((ptrdiff_t)(p - str) < (ptrdiff_t)reg->dmin)
+	if ((OnigDistance)(p - str) < reg->dmin)
 	  *high = (UChar* )str;
 	else
 	  *high = p - reg->dmin;
@@ -5355,17 +5355,17 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
       min_semi_end = max_semi_end = (UChar* )end;
 
     end_buf:
-      if ((ptrdiff_t)(max_semi_end - str) < (ptrdiff_t)reg->anchor_dmin)
+      if ((OnigDistance)(max_semi_end - str) < reg->anchor_dmin)
 	goto mismatch_no_msa;
 
       if (range > start) {
-	if ((ptrdiff_t)(min_semi_end - start) > (ptrdiff_t)reg->anchor_dmax) {
+	if ((OnigDistance)(min_semi_end - start) > reg->anchor_dmax) {
 	  start = min_semi_end - reg->anchor_dmax;
 	  if (start < end)
 	    start = onigenc_get_right_adjust_char_head(reg->enc, str, start, end);
 	}
-	if ((ptrdiff_t)(max_semi_end - (range - 1)) < (ptrdiff_t)reg->anchor_dmin) {
-	  if ((ptrdiff_t)(max_semi_end - str + 1) < (ptrdiff_t)reg->anchor_dmin)
+	if ((OnigDistance)(max_semi_end - (range - 1)) < reg->anchor_dmin) {
+	  if ((OnigDistance)(max_semi_end - str + 1) < reg->anchor_dmin)
 	    goto mismatch_no_msa;
 	  else
 	    range = max_semi_end - reg->anchor_dmin + 1;
@@ -5376,11 +5376,11 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
 	   Backward search is used. */
       }
       else {
-	if ((ptrdiff_t)(min_semi_end - range) > (ptrdiff_t)reg->anchor_dmax) {
+	if ((OnigDistance)(min_semi_end - range) > reg->anchor_dmax) {
 	  range = min_semi_end - reg->anchor_dmax;
 	}
-	if ((ptrdiff_t)(max_semi_end - start) < (ptrdiff_t)reg->anchor_dmin) {
-	  if ((ptrdiff_t)(max_semi_end - str) < (ptrdiff_t)reg->anchor_dmin)
+	if ((OnigDistance)(max_semi_end - start) < reg->anchor_dmin) {
+	  if ((OnigDistance)(max_semi_end - str) < reg->anchor_dmin)
 	    goto mismatch_no_msa;
 	  else {
 	    start = max_semi_end - reg->anchor_dmin;
@@ -5468,7 +5468,7 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
 	if (reg->dmax == ONIG_INFINITE_DISTANCE)
 	  sch_range = (UChar* )end;
 	else {
-	  if ((ptrdiff_t)(end - range) < (ptrdiff_t)reg->dmax)
+	  if ((OnigDistance)(end - range) < reg->dmax)
 	    sch_range = (UChar* )end;
 	  else {
 	    sch_range = (UChar* )range + reg->dmax;
@@ -5540,15 +5540,15 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
       else
 	adjrange = (UChar* )end;
 
-      if ((ptrdiff_t)(end - range) > (ptrdiff_t)reg->dmin)
+      if ((OnigDistance)(end - range) > reg->dmin)
 	min_range = range + reg->dmin;
       else
 	min_range = end;
 
       if (reg->dmax != ONIG_INFINITE_DISTANCE &&
-	  (ptrdiff_t)(end - range) >= (ptrdiff_t)reg->threshold_len) {
+	  end - range >= reg->threshold_len) {
 	do {
-	  if ((ptrdiff_t)(end - s) > (ptrdiff_t)reg->dmax)
+	  if ((OnigDistance)(end - s) > reg->dmax)
 	    sch_start = s + reg->dmax;
 	  else
 	    sch_start = (UChar* )end;
@@ -5569,13 +5569,13 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
 	goto mismatch;
       }
       else { /* check only. */
-	if ((ptrdiff_t)(end - range) < (ptrdiff_t)reg->threshold_len) goto mismatch;
+	if (end - range < reg->threshold_len) goto mismatch;
 
 	if (reg->dmax != 0) {
 	  if (reg->dmax == ONIG_INFINITE_DISTANCE)
 	    sch_start = (UChar* )end;
 	  else {
-	    if ((ptrdiff_t)(end - s) > (ptrdiff_t)reg->dmax) {
+	    if ((OnigDistance)(end - s) > reg->dmax) {
 	      sch_start = s + reg->dmax;
 	      sch_start = ONIGENC_LEFT_ADJUST_CHAR_HEAD(reg->enc,
 						    start, sch_start, end);

--- a/regexec.c
+++ b/regexec.c
@@ -4960,7 +4960,7 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
 
   p = s;
   if (reg->dmin != 0) {
-    if (end - p <= reg->dmin) return 0; /* fail */
+    if ((ptrdiff_t)(end - p) <= (ptrdiff_t)reg->dmin) return 0; /* fail */
     if (ONIGENC_IS_SINGLEBYTE(reg->enc)) {
       p += reg->dmin;
     }
@@ -5003,7 +5003,7 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
   }
 
   if (p && p < range) {
-    if (p - s < reg->dmin) {
+    if ((ptrdiff_t)(p - s) < (ptrdiff_t)reg->dmin) {
     retry_gate:
       pprev = p;
       p += enclen(reg->enc, p, end);
@@ -5051,7 +5051,7 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
     }
     else {
       if (reg->dmax != ONIG_INFINITE_DISTANCE) {
-	if (p - str < reg->dmax) {
+	if ((ptrdiff_t)(p - str) < (ptrdiff_t)reg->dmax) {
 	  *low = (UChar* )str;
 	  if (low_prev)
 	    *low_prev = onigenc_get_prev_char_head(reg->enc, str, *low, end);
@@ -5073,7 +5073,7 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
 	}
       }
       /* no needs to adjust *high, *high is used as range check only */
-      if (p - str < reg->dmin)
+      if ((ptrdiff_t)(p - str) < (ptrdiff_t)reg->dmin)
         *high = (UChar* )str;
       else
         *high = p - reg->dmin;
@@ -5182,13 +5182,13 @@ backward_search_range(regex_t* reg, const UChar* str, const UChar* end,
     }
 
     if (reg->dmax != ONIG_INFINITE_DISTANCE) {
-      if (p - str < reg->dmax)
+      if ((ptrdiff_t)(p - str) < (ptrdiff_t)reg->dmax)
 	*low = (UChar* )str;
       else
 	*low = p - reg->dmax;
 
       if (reg->dmin != 0) {
-	if (p - str < reg->dmin)
+	if ((ptrdiff_t)(p - str) < (ptrdiff_t)reg->dmin)
 	  *high = (UChar* )str;
 	else
 	  *high = p - reg->dmin;
@@ -5355,17 +5355,20 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
       min_semi_end = max_semi_end = (UChar* )end;
 
     end_buf:
-      if ((OnigDistance )(max_semi_end - str) < reg->anchor_dmin)
+      if ((ptrdiff_t)(max_semi_end - str) < (ptrdiff_t)reg->anchor_dmin)
 	goto mismatch_no_msa;
 
       if (range > start) {
-	if ((OnigDistance )(min_semi_end - start) > reg->anchor_dmax) {
+	if ((ptrdiff_t)(min_semi_end - start) > (ptrdiff_t)reg->anchor_dmax) {
 	  start = min_semi_end - reg->anchor_dmax;
 	  if (start < end)
 	    start = onigenc_get_right_adjust_char_head(reg->enc, str, start, end);
 	}
-	if ((OnigDistance )(max_semi_end - (range - 1)) < reg->anchor_dmin) {
-	  range = max_semi_end - reg->anchor_dmin + 1;
+	if ((ptrdiff_t)(max_semi_end - (range - 1)) < (ptrdiff_t)reg->anchor_dmin) {
+	  if ((ptrdiff_t)(max_semi_end - str + 1) < (ptrdiff_t)reg->anchor_dmin)
+	    goto mismatch_no_msa;
+	  else
+	    range = max_semi_end - reg->anchor_dmin + 1;
 	}
 
 	if (start > range) goto mismatch_no_msa;
@@ -5373,12 +5376,16 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
 	   Backward search is used. */
       }
       else {
-	if ((OnigDistance )(min_semi_end - range) > reg->anchor_dmax) {
+	if ((ptrdiff_t)(min_semi_end - range) > (ptrdiff_t)reg->anchor_dmax) {
 	  range = min_semi_end - reg->anchor_dmax;
 	}
-	if ((OnigDistance )(max_semi_end - start) < reg->anchor_dmin) {
-	  start = max_semi_end - reg->anchor_dmin;
-	  start = ONIGENC_LEFT_ADJUST_CHAR_HEAD(reg->enc, str, start, end);
+	if ((ptrdiff_t)(max_semi_end - start) < (ptrdiff_t)reg->anchor_dmin) {
+	  if ((ptrdiff_t)(max_semi_end - str) < (ptrdiff_t)reg->anchor_dmin)
+	    goto mismatch_no_msa;
+	  else {
+	    start = max_semi_end - reg->anchor_dmin;
+	    start = ONIGENC_LEFT_ADJUST_CHAR_HEAD(reg->enc, str, start, end);
+	  }
 	}
 	if (range > start) goto mismatch_no_msa;
       }
@@ -5461,7 +5468,7 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
 	if (reg->dmax == ONIG_INFINITE_DISTANCE)
 	  sch_range = (UChar* )end;
 	else {
-	  if ((end - range) < reg->dmax)
+	  if ((ptrdiff_t)(end - range) < (ptrdiff_t)reg->dmax)
 	    sch_range = (UChar* )end;
 	  else {
 	    sch_range = (UChar* )range + reg->dmax;
@@ -5533,15 +5540,15 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
       else
 	adjrange = (UChar* )end;
 
-      if (end - range > reg->dmin)
+      if ((ptrdiff_t)(end - range) > (ptrdiff_t)reg->dmin)
 	min_range = range + reg->dmin;
       else
 	min_range = end;
 
       if (reg->dmax != ONIG_INFINITE_DISTANCE &&
-	  (end - range) >= reg->threshold_len) {
+	  (ptrdiff_t)(end - range) >= (ptrdiff_t)reg->threshold_len) {
 	do {
-	  if (end - s > reg->dmax)
+	  if ((ptrdiff_t)(end - s) > (ptrdiff_t)reg->dmax)
 	    sch_start = s + reg->dmax;
 	  else
 	    sch_start = (UChar* )end;
@@ -5562,13 +5569,13 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
 	goto mismatch;
       }
       else { /* check only. */
-	if ((end - range) < reg->threshold_len) goto mismatch;
+	if ((ptrdiff_t)(end - range) < (ptrdiff_t)reg->threshold_len) goto mismatch;
 
 	if (reg->dmax != 0) {
 	  if (reg->dmax == ONIG_INFINITE_DISTANCE)
 	    sch_start = (UChar* )end;
 	  else {
-	    if (end - s > reg->dmax) {
+	    if ((ptrdiff_t)(end - s) > (ptrdiff_t)reg->dmax) {
 	      sch_start = s + reg->dmax;
 	      sch_start = ONIGENC_LEFT_ADJUST_CHAR_HEAD(reg->enc,
 						    start, sch_start, end);
@@ -5576,6 +5583,8 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
 	      sch_start = (UChar* )end;
 	  }
 	}
+	else
+	  sch_start = (UChar* )s;
 
 	if (backward_search_range(reg, str, end, sch_start, min_range, adjrange,
 				  &low, &high) <= 0) goto mismatch;

--- a/regexec.c
+++ b/regexec.c
@@ -4959,14 +4959,14 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
   }
 
   p = s;
-  if (reg->dmin > 0) {
+  if (reg->dmin != 0) {
+    if (end - p <= reg->dmin) return 0; /* fail */
     if (ONIGENC_IS_SINGLEBYTE(reg->enc)) {
       p += reg->dmin;
     }
     else {
       UChar *q = p + reg->dmin;
 
-      if (q >= end) return 0; /* fail */
       while (p < q) p += enclen(reg->enc, p, end);
     }
   }
@@ -5003,7 +5003,7 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
   }
 
   if (p && p < range) {
-    if (p - reg->dmin < s) {
+    if (p - s < reg->dmin) {
     retry_gate:
       pprev = p;
       p += enclen(reg->enc, p, end);
@@ -5047,10 +5047,11 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
 	  *low_prev = onigenc_get_prev_char_head(reg->enc,
 						 (pprev ? pprev : str), p, end);
       }
+      *high = p;
     }
     else {
       if (reg->dmax != ONIG_INFINITE_DISTANCE) {
-	if (p < str + reg->dmax) {
+	if (p - str < reg->dmax) {
 	  *low = (UChar* )str;
 	  if (low_prev)
 	    *low_prev = onigenc_get_prev_char_head(reg->enc, str, *low, end);
@@ -5071,9 +5072,12 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
 	  }
 	}
       }
+      /* no needs to adjust *high, *high is used as range check only */
+      if (p - str < reg->dmin)
+        *high = (UChar* )str;
+      else
+        *high = p - reg->dmin;
     }
-    /* no needs to adjust *high, *high is used as range check only */
-    *high = p - reg->dmin;
 
 #ifdef ONIG_DEBUG_SEARCH
     fprintf(stderr,

--- a/regexec.c
+++ b/regexec.c
@@ -5104,7 +5104,6 @@ backward_search_range(regex_t* reg, const UChar* str, const UChar* end,
     return 0;
   }
 
-  range += reg->dmin;
   p = s;
 
  retry:
@@ -5182,10 +5181,22 @@ backward_search_range(regex_t* reg, const UChar* str, const UChar* end,
       }
     }
 
-    /* no needs to adjust *high, *high is used as range check only */
     if (reg->dmax != ONIG_INFINITE_DISTANCE) {
-      *low  = p - reg->dmax;
-      *high = p - reg->dmin;
+      if (p - str < reg->dmax)
+	*low = (UChar* )str;
+      else
+	*low = p - reg->dmax;
+
+      if (reg->dmin != 0) {
+	if (p - str < reg->dmin)
+	  *high = (UChar* )str;
+	else
+	  *high = p - reg->dmin;
+      }
+      else {
+	*high = p;
+      }
+
       *high = onigenc_get_right_adjust_char_head(reg->enc, adjrange, *high, end);
     }
 
@@ -5511,18 +5522,24 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
   else {  /* backward search */
     if (reg->optimize != ONIG_OPTIMIZE_NONE) {
       UChar *low, *high, *adjrange, *sch_start;
+      const UChar *min_range;
 
       if (range < end)
 	adjrange = ONIGENC_LEFT_ADJUST_CHAR_HEAD(reg->enc, str, range, end);
       else
 	adjrange = (UChar* )end;
 
+      if (end - range > reg->dmin)
+	min_range = range + reg->dmin;
+      else
+	min_range = end;
+
       if (reg->dmax != ONIG_INFINITE_DISTANCE &&
 	  (end - range) >= reg->threshold_len) {
 	do {
 	  sch_start = s + reg->dmax;
 	  if (sch_start > end) sch_start = (UChar* )end;
-	  if (backward_search_range(reg, str, end, sch_start, range, adjrange,
+	  if (backward_search_range(reg, str, end, sch_start, min_range, adjrange,
 				    &low, &high) <= 0)
 	    goto mismatch;
 
@@ -5552,7 +5569,7 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
 						    start, sch_start, end);
 	  }
 	}
-	if (backward_search_range(reg, str, end, sch_start, range, adjrange,
+	if (backward_search_range(reg, str, end, sch_start, min_range, adjrange,
 				  &low, &high) <= 0) goto mismatch;
       }
     }


### PR DESCRIPTION
I ported Oniguruma patches referred to kkos/oniguruma#164, which are to prevent integer overflow related to `reg->dmax`, `reg->dmin`, etc.