### PR TITLE
ZJIT: Remove some builtin subclasses from lattice

### DIFF
--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -76,12 +76,12 @@ pub fn init() -> Annotations {
 
     annotate!(rb_mKernel, "itself", types::BasicObject, no_gc, leaf, elidable);
     annotate!(rb_cString, "bytesize", types::Fixnum, no_gc, leaf);
-    annotate!(rb_cModule, "name", types::StringExact.union(types::NilClassExact), no_gc, leaf, elidable);
+    annotate!(rb_cModule, "name", types::StringExact.union(types::NilClass), no_gc, leaf, elidable);
     annotate!(rb_cModule, "===", types::BoolExact, no_gc, leaf);
     annotate!(rb_cArray, "length", types::Fixnum, no_gc, leaf, elidable);
     annotate!(rb_cArray, "size", types::Fixnum, no_gc, leaf, elidable);
-    annotate!(rb_cNilClass, "nil?", types::TrueClassExact, no_gc, leaf, elidable);
-    annotate!(rb_mKernel, "nil?", types::FalseClassExact, no_gc, leaf, elidable);
+    annotate!(rb_cNilClass, "nil?", types::TrueClass, no_gc, leaf, elidable);
+    annotate!(rb_mKernel, "nil?", types::FalseClass, no_gc, leaf, elidable);
 
     Annotations {
         cfuncs: std::mem::take(cfuncs)

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1234,8 +1234,8 @@ impl Function {
             Insn::Test { val } if self.type_of(*val).is_known_falsy() => Type::from_cbool(false),
             Insn::Test { val } if self.type_of(*val).is_known_truthy() => Type::from_cbool(true),
             Insn::Test { .. } => types::CBool,
-            Insn::IsNil { val } if self.is_a(*val, types::NilClassExact) => Type::from_cbool(true),
-            Insn::IsNil { val } if !self.type_of(*val).could_be(types::NilClassExact) => Type::from_cbool(false),
+            Insn::IsNil { val } if self.is_a(*val, types::NilClass) => Type::from_cbool(true),
+            Insn::IsNil { val } if !self.type_of(*val).could_be(types::NilClass) => Type::from_cbool(false),
             Insn::IsNil { .. } => types::CBool,
             Insn::StringCopy { .. } => types::StringExact,
             Insn::StringIntern { .. } => types::StringExact,
@@ -3494,7 +3494,7 @@ mod infer_tests {
     fn test_const() {
         let mut function = Function::new(std::ptr::null());
         let val = function.push_insn(function.entry_block, Insn::Const { val: Const::Value(Qnil) });
-        assert_bit_equal(function.infer_type(val), types::NilClassExact);
+        assert_bit_equal(function.infer_type(val), types::NilClass);
     }
 
     #[test]
@@ -3593,7 +3593,7 @@ mod infer_tests {
         let param = function.push_insn(exit, Insn::Param { idx: 0 });
         crate::cruby::with_rubyvm(|| {
             function.infer_types();
-            assert_bit_equal(function.type_of(param), types::TrueClassExact.union(types::FalseClassExact));
+            assert_bit_equal(function.type_of(param), types::TrueClass.union(types::FalseClass));
         });
     }
 }
@@ -3975,7 +3975,7 @@ mod tests {
         assert_method_hir_with_opcodes("test", &[YARVINSN_getlocal_WC_0, YARVINSN_setlocal_WC_0], expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject):
-              v1:NilClassExact = Const Value(nil)
+              v1:NilClass = Const Value(nil)
               v3:Fixnum[1] = Const Value(1)
               Return v3
         "#]]);
@@ -4042,10 +4042,10 @@ mod tests {
         assert_method_hir_with_opcode("test", YARVINSN_defined, expect![[r#"
             fn test@<compiled>:2:
             bb0(v0:BasicObject):
-              v2:NilClassExact = Const Value(nil)
+              v2:NilClass = Const Value(nil)
               v3:BasicObject = Defined constant, v2
               v4:BasicObject = Defined func, v0
-              v5:NilClassExact = Const Value(nil)
+              v5:NilClass = Const Value(nil)
               v6:BasicObject = Defined global-variable, v5
               v8:ArrayExact = NewArray v3, v4, v6
               Return v8
@@ -4091,12 +4091,12 @@ mod tests {
         assert_method_hir("test", expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject, v1:BasicObject):
-              v2:NilClassExact = Const Value(nil)
+              v2:NilClass = Const Value(nil)
               v4:CBool = Test v1
               IfFalse v4, bb1(v0, v1, v2)
               v6:Fixnum[3] = Const Value(3)
               Jump bb2(v0, v1, v6)
-            bb1(v8:BasicObject, v9:BasicObject, v10:NilClassExact):
+            bb1(v8:BasicObject, v9:BasicObject, v10:NilClass):
               v12:Fixnum[4] = Const Value(4)
               Jump bb2(v8, v9, v12)
             bb2(v14:BasicObject, v15:BasicObject, v16:Fixnum):
@@ -4261,8 +4261,8 @@ mod tests {
         assert_method_hir("test",  expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject):
-              v1:NilClassExact = Const Value(nil)
-              v2:NilClassExact = Const Value(nil)
+              v1:NilClass = Const Value(nil)
+              v2:NilClass = Const Value(nil)
               v4:Fixnum[0] = Const Value(0)
               v5:Fixnum[10] = Const Value(10)
               Jump bb2(v0, v4, v5)
@@ -4271,7 +4271,7 @@ mod tests {
               v13:BasicObject = SendWithoutBlock v9, :>, v11
               v14:CBool = Test v13
               IfTrue v14, bb1(v7, v8, v9)
-              v16:NilClassExact = Const Value(nil)
+              v16:NilClass = Const Value(nil)
               Return v8
             bb1(v18:BasicObject, v19:BasicObject, v20:BasicObject):
               v22:Fixnum[1] = Const Value(1)
@@ -4311,8 +4311,8 @@ mod tests {
         assert_method_hir("test", expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject):
-              v1:NilClassExact = Const Value(nil)
-              v3:TrueClassExact = Const Value(true)
+              v1:NilClass = Const Value(nil)
+              v3:TrueClass = Const Value(true)
               v4:CBool[true] = Test v3
               IfFalse v4, bb1(v0, v3)
               v6:Fixnum[3] = Const Value(3)
@@ -4528,12 +4528,12 @@ mod tests {
             fn test@<compiled>:3:
             bb0(v0:BasicObject):
               v3:BasicObject = GetConstantPath 0x1000
-              v4:NilClassExact = Const Value(nil)
+              v4:NilClass = Const Value(nil)
               Jump bb1(v0, v4, v3)
-            bb1(v6:BasicObject, v7:NilClassExact, v8:BasicObject):
+            bb1(v6:BasicObject, v7:NilClass, v8:BasicObject):
               v11:BasicObject = SendWithoutBlock v8, :new
               Jump bb2(v6, v11, v7)
-            bb2(v13:BasicObject, v14:BasicObject, v15:NilClassExact):
+            bb2(v13:BasicObject, v14:BasicObject, v15:NilClass):
               Return v14
         "#]]);
     }
@@ -4580,8 +4580,8 @@ mod tests {
         assert_method_hir_with_opcode("test", YARVINSN_opt_newarray_send, expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v3:NilClassExact = Const Value(nil)
-              v4:NilClassExact = Const Value(nil)
+              v3:NilClass = Const Value(nil)
+              v4:NilClass = Const Value(nil)
               v7:BasicObject = SendWithoutBlock v1, :+, v2
               SideExit UnknownNewarraySend(MIN)
         "#]]);
@@ -4600,8 +4600,8 @@ mod tests {
         assert_method_hir_with_opcode("test", YARVINSN_opt_newarray_send, expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v3:NilClassExact = Const Value(nil)
-              v4:NilClassExact = Const Value(nil)
+              v3:NilClass = Const Value(nil)
+              v4:NilClass = Const Value(nil)
               v7:BasicObject = SendWithoutBlock v1, :+, v2
               SideExit UnknownNewarraySend(HASH)
         "#]]);
@@ -4620,8 +4620,8 @@ mod tests {
         assert_method_hir_with_opcode("test", YARVINSN_opt_newarray_send, expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v3:NilClassExact = Const Value(nil)
-              v4:NilClassExact = Const Value(nil)
+              v3:NilClass = Const Value(nil)
+              v4:NilClass = Const Value(nil)
               v7:BasicObject = SendWithoutBlock v1, :+, v2
               v8:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
               v9:StringExact = StringCopy v8
@@ -4644,8 +4644,8 @@ mod tests {
         assert_method_hir_with_opcode("test", YARVINSN_opt_newarray_send, expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v3:NilClassExact = Const Value(nil)
-              v4:NilClassExact = Const Value(nil)
+              v3:NilClass = Const Value(nil)
+              v4:NilClass = Const Value(nil)
               v7:BasicObject = SendWithoutBlock v1, :+, v2
               SideExit UnknownNewarraySend(INCLUDE_P)
         "#]]);
@@ -4808,7 +4808,7 @@ mod tests {
         assert_method_hir_with_opcode("test", YARVINSN_opt_aset, expect![[r#"
             fn test@<compiled>:2:
             bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v4:NilClassExact = Const Value(nil)
+              v4:NilClass = Const Value(nil)
               v5:Fixnum[1] = Const Value(1)
               v7:BasicObject = SendWithoutBlock v1, :[]=, v2, v5
               Return v5
@@ -4957,9 +4957,9 @@ mod tests {
         assert_method_hir_with_opcode("reverse_odd", YARVINSN_opt_reverse, expect![[r#"
             fn reverse_odd@<compiled>:3:
             bb0(v0:BasicObject):
-              v1:NilClassExact = Const Value(nil)
-              v2:NilClassExact = Const Value(nil)
-              v3:NilClassExact = Const Value(nil)
+              v1:NilClass = Const Value(nil)
+              v2:NilClass = Const Value(nil)
+              v3:NilClass = Const Value(nil)
               v6:BasicObject = GetIvar v0, :@a
               v8:BasicObject = GetIvar v0, :@b
               v10:BasicObject = GetIvar v0, :@c
@@ -4969,10 +4969,10 @@ mod tests {
         assert_method_hir_with_opcode("reverse_even", YARVINSN_opt_reverse, expect![[r#"
             fn reverse_even@<compiled>:8:
             bb0(v0:BasicObject):
-              v1:NilClassExact = Const Value(nil)
-              v2:NilClassExact = Const Value(nil)
-              v3:NilClassExact = Const Value(nil)
-              v4:NilClassExact = Const Value(nil)
+              v1:NilClass = Const Value(nil)
+              v2:NilClass = Const Value(nil)
+              v3:NilClass = Const Value(nil)
+              v4:NilClass = Const Value(nil)
               v7:BasicObject = GetIvar v0, :@a
               v9:BasicObject = GetIvar v0, :@b
               v11:BasicObject = GetIvar v0, :@c
@@ -5031,7 +5031,7 @@ mod tests {
         assert_function_hir(function, expect![[r#"
             fn start@<internal:gc>:36:
             bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject, v3:BasicObject, v4:BasicObject):
-              v6:FalseClassExact = Const Value(false)
+              v6:FalseClass = Const Value(false)
               v8:BasicObject = InvokeBuiltin gc_start_internal, v0, v1, v2, v3, v6
               Return v8
         "#]]);
@@ -5045,7 +5045,7 @@ mod tests {
         assert_method_hir_with_opcode("test", YARVINSN_dupn, expect![[r#"
             fn test@<compiled>:2:
             bb0(v0:BasicObject, v1:BasicObject):
-              v3:NilClassExact = Const Value(nil)
+              v3:NilClass = Const Value(nil)
               v4:Fixnum[0] = Const Value(0)
               v5:Fixnum[1] = Const Value(1)
               v7:BasicObject = SendWithoutBlock v1, :[], v4, v5
@@ -5054,7 +5054,7 @@ mod tests {
               v10:Fixnum[2] = Const Value(2)
               v12:BasicObject = SendWithoutBlock v1, :[]=, v4, v5, v10
               Return v10
-            bb1(v14:BasicObject, v15:BasicObject, v16:NilClassExact, v17:BasicObject, v18:Fixnum[0], v19:Fixnum[1], v20:BasicObject):
+            bb1(v14:BasicObject, v15:BasicObject, v16:NilClass, v17:BasicObject, v18:Fixnum[0], v19:Fixnum[1], v20:BasicObject):
               Return v20
         "#]]);
     }
@@ -5488,7 +5488,7 @@ mod opt_tests {
         assert_optimized_method_hir("block", expect![[r#"
             fn block@<compiled>:6:
             bb0(v0:BasicObject, v1:BasicObject):
-              v3:NilClassExact = Const Value(nil)
+              v3:NilClass = Const Value(nil)
               Return v3
         "#]]);
         assert_optimized_method_hir("post", expect![[r#"
@@ -5499,7 +5499,7 @@ mod opt_tests {
         assert_optimized_method_hir("forwardable", expect![[r#"
             fn forwardable@<compiled>:7:
             bb0(v0:BasicObject, v1:BasicObject):
-              v3:NilClassExact = Const Value(nil)
+              v3:NilClass = Const Value(nil)
               Return v3
         "#]]);
     }
@@ -6185,7 +6185,7 @@ mod opt_tests {
         assert_optimized_method_hir("test", expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject):
-              v1:NilClassExact = Const Value(nil)
+              v1:NilClass = Const Value(nil)
               v4:ArrayExact = NewArray
               PatchPoint MethodRedefined(Array@0x1000, itself@0x1008, cme:0x1010)
               v7:Fixnum[1] = Const Value(1)
@@ -6206,7 +6206,7 @@ mod opt_tests {
         assert_optimized_method_hir("test", expect![[r#"
             fn test@<compiled>:4:
             bb0(v0:BasicObject):
-              v1:NilClassExact = Const Value(nil)
+              v1:NilClass = Const Value(nil)
               PatchPoint SingleRactorMode
               PatchPoint StableConstantNames(0x1000, M)
               v11:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
@@ -6227,7 +6227,7 @@ mod opt_tests {
         assert_optimized_method_hir("test", expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject):
-              v1:NilClassExact = Const Value(nil)
+              v1:NilClass = Const Value(nil)
               v4:ArrayExact = NewArray
               PatchPoint MethodRedefined(Array@0x1000, length@0x1008, cme:0x1010)
               v7:Fixnum[5] = Const Value(5)
@@ -6327,7 +6327,7 @@ mod opt_tests {
         assert_optimized_method_hir("test", expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject):
-              v1:NilClassExact = Const Value(nil)
+              v1:NilClass = Const Value(nil)
               v4:ArrayExact = NewArray
               PatchPoint MethodRedefined(Array@0x1000, size@0x1008, cme:0x1010)
               v7:Fixnum[5] = Const Value(5)
@@ -6379,7 +6379,7 @@ mod opt_tests {
         assert_optimized_method_hir("test", expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject, v1:BasicObject):
-              v2:NilClassExact = Const Value(nil)
+              v2:NilClass = Const Value(nil)
               v4:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
               v6:ArrayExact = ArrayDup v4
               PatchPoint MethodRedefined(Array@0x1008, first@0x1010, cme:0x1018)
@@ -6587,7 +6587,7 @@ mod opt_tests {
               PatchPoint SingleRactorMode
               PatchPoint StableConstantNames(0x1000, C)
               v20:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              v4:NilClassExact = Const Value(nil)
+              v4:NilClass = Const Value(nil)
               v11:BasicObject = SendWithoutBlock v20, :new
               Return v11
         "#]]);
@@ -6610,7 +6610,7 @@ mod opt_tests {
               PatchPoint SingleRactorMode
               PatchPoint StableConstantNames(0x1000, C)
               v22:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              v4:NilClassExact = Const Value(nil)
+              v4:NilClass = Const Value(nil)
               v5:Fixnum[1] = Const Value(1)
               v13:BasicObject = SendWithoutBlock v22, :new, v5
               Return v13
@@ -6744,7 +6744,7 @@ mod opt_tests {
             fn test@<compiled>:2:
             bb0(v0:BasicObject):
               v3:HashExact = NewHash
-              v4:NilClassExact = Const Value(nil)
+              v4:NilClass = Const Value(nil)
               v6:BasicObject = SendWithoutBlock v3, :freeze, v4
               Return v6
         "#]]);
@@ -6803,7 +6803,7 @@ mod opt_tests {
             fn test@<compiled>:2:
             bb0(v0:BasicObject):
               v3:ArrayExact = NewArray
-              v4:NilClassExact = Const Value(nil)
+              v4:NilClass = Const Value(nil)
               v6:BasicObject = SendWithoutBlock v3, :freeze, v4
               Return v6
         "#]]);
@@ -6864,7 +6864,7 @@ mod opt_tests {
             bb0(v0:BasicObject):
               v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
               v3:StringExact = StringCopy v2
-              v4:NilClassExact = Const Value(nil)
+              v4:NilClass = Const Value(nil)
               v6:BasicObject = SendWithoutBlock v3, :freeze, v4
               Return v6
         "#]]);
@@ -6958,7 +6958,7 @@ mod opt_tests {
         assert_optimized_method_hir("test", expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject):
-              v3:NilClassExact = Const Value(nil)
+              v3:NilClass = Const Value(nil)
               Return v3
         "#]]);
     }
@@ -7028,7 +7028,7 @@ mod opt_tests {
               PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
               v5:Fixnum[-10] = Const Value(-10)
               PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_AREF)
-              v11:NilClassExact = Const Value(nil)
+              v11:NilClass = Const Value(nil)
               Return v11
         "#]]);
     }
@@ -7045,7 +7045,7 @@ mod opt_tests {
               PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
               v5:Fixnum[10] = Const Value(10)
               PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_AREF)
-              v11:NilClassExact = Const Value(nil)
+              v11:NilClass = Const Value(nil)
               Return v11
         "#]]);
     }
@@ -7129,9 +7129,9 @@ mod opt_tests {
         assert_optimized_method_hir("test", expect![[r#"
             fn test@<compiled>:2:
             bb0(v0:BasicObject):
-              v2:NilClassExact = Const Value(nil)
+              v2:NilClass = Const Value(nil)
               PatchPoint MethodRedefined(NilClass@0x1000, nil?@0x1008, cme:0x1010)
-              v7:TrueClassExact = CCall nil?@0x1038, v2
+              v7:TrueClass = CCall nil?@0x1038, v2
               Return v7
         "#]]);
     }
@@ -7147,7 +7147,7 @@ mod opt_tests {
         assert_optimized_method_hir("test", expect![[r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject):
-              v2:NilClassExact = Const Value(nil)
+              v2:NilClass = Const Value(nil)
               PatchPoint MethodRedefined(NilClass@0x1000, nil?@0x1008, cme:0x1010)
               v5:Fixnum[1] = Const Value(1)
               Return v5
@@ -7164,7 +7164,7 @@ mod opt_tests {
             bb0(v0:BasicObject):
               v2:Fixnum[1] = Const Value(1)
               PatchPoint MethodRedefined(Integer@0x1000, nil?@0x1008, cme:0x1010)
-              v7:FalseClassExact = CCall nil?@0x1038, v2
+              v7:FalseClass = CCall nil?@0x1038, v2
               Return v7
         "#]]);
     }
@@ -7198,8 +7198,8 @@ mod opt_tests {
             fn test@<compiled>:2:
             bb0(v0:BasicObject, v1:BasicObject):
               PatchPoint MethodRedefined(NilClass@0x1000, nil?@0x1008, cme:0x1010)
-              v7:NilClassExact = GuardType v1, NilClassExact
-              v8:TrueClassExact = CCall nil?@0x1038, v7
+              v7:NilClass = GuardType v1, NilClass
+              v8:TrueClass = CCall nil?@0x1038, v7
               Return v8
         "#]]);
     }
@@ -7215,8 +7215,8 @@ mod opt_tests {
             fn test@<compiled>:2:
             bb0(v0:BasicObject, v1:BasicObject):
               PatchPoint MethodRedefined(FalseClass@0x1000, nil?@0x1008, cme:0x1010)
-              v7:FalseClassExact = GuardType v1, FalseClassExact
-              v8:FalseClassExact = CCall nil?@0x1038, v7
+              v7:FalseClass = GuardType v1, FalseClass
+              v8:FalseClass = CCall nil?@0x1038, v7
               Return v8
         "#]]);
     }
@@ -7232,8 +7232,8 @@ mod opt_tests {
             fn test@<compiled>:2:
             bb0(v0:BasicObject, v1:BasicObject):
               PatchPoint MethodRedefined(TrueClass@0x1000, nil?@0x1008, cme:0x1010)
-              v7:TrueClassExact = GuardType v1, TrueClassExact
-              v8:FalseClassExact = CCall nil?@0x1038, v7
+              v7:TrueClass = GuardType v1, TrueClass
+              v8:FalseClass = CCall nil?@0x1038, v7
               Return v8
         "#]]);
     }
@@ -7250,7 +7250,7 @@ mod opt_tests {
             bb0(v0:BasicObject, v1:BasicObject):
               PatchPoint MethodRedefined(Symbol@0x1000, nil?@0x1008, cme:0x1010)
               v7:StaticSymbol = GuardType v1, StaticSymbol
-              v8:FalseClassExact = CCall nil?@0x1038, v7
+              v8:FalseClass = CCall nil?@0x1038, v7
               Return v8
         "#]]);
     }
@@ -7267,7 +7267,7 @@ mod opt_tests {
             bb0(v0:BasicObject, v1:BasicObject):
               PatchPoint MethodRedefined(Integer@0x1000, nil?@0x1008, cme:0x1010)
               v7:Fixnum = GuardType v1, Fixnum
-              v8:FalseClassExact = CCall nil?@0x1038, v7
+              v8:FalseClass = CCall nil?@0x1038, v7
               Return v8
         "#]]);
     }
@@ -7284,7 +7284,7 @@ mod opt_tests {
             bb0(v0:BasicObject, v1:BasicObject):
               PatchPoint MethodRedefined(Float@0x1000, nil?@0x1008, cme:0x1010)
               v7:Flonum = GuardType v1, Flonum
-              v8:FalseClassExact = CCall nil?@0x1038, v7
+              v8:FalseClass = CCall nil?@0x1038, v7
               Return v8
         "#]]);
     }
@@ -7301,7 +7301,7 @@ mod opt_tests {
             bb0(v0:BasicObject, v1:BasicObject):
               PatchPoint MethodRedefined(String@0x1000, nil?@0x1008, cme:0x1010)
               v7:StringExact = GuardType v1, StringExact
-              v8:FalseClassExact = CCall nil?@0x1038, v7
+              v8:FalseClass = CCall nil?@0x1038, v7
               Return v8
         "#]]);
     }

--- a/zjit/src/hir_type/gen_hir_type.rb
+++ b/zjit/src/hir_type/gen_hir_type.rb
@@ -89,19 +89,19 @@ integer_exact = final_type "Integer"
 fixnum = integer_exact.subtype "Fixnum"
 integer_exact.subtype "Bignum"
 
-_, float_exact = base_type "Float"
+float_exact = final_type "Float"
 # CRuby partitions Float into immediate and non-immediate variants.
 flonum = float_exact.subtype "Flonum"
 float_exact.subtype "HeapFloat"
 
-_, symbol_exact = base_type "Symbol"
+symbol_exact = final_type "Symbol"
 # CRuby partitions Symbol into immediate and non-immediate variants.
 static_sym = symbol_exact.subtype "StaticSymbol"
 symbol_exact.subtype "DynamicSymbol"
 
-_, nil_exact = base_type "NilClass"
-_, true_exact = base_type "TrueClass"
-_, false_exact = base_type "FalseClass"
+nil_exact = final_type "NilClass"
+true_exact = final_type "TrueClass"
+false_exact = final_type "FalseClass"
 
 # Build the cvalue object universe. This is for C-level types that may be
 # passed around when calling into the Ruby VM or after some strength reduction

--- a/zjit/src/hir_type/gen_hir_type.rb
+++ b/zjit/src/hir_type/gen_hir_type.rb
@@ -68,6 +68,13 @@ def base_type name
   [type, exact]
 end
 
+# Define a new type that cannot be subclassed.
+def final_type name
+  type = $object.subtype name
+  $builtin_exact << type.name
+  type
+end
+
 base_type "String"
 base_type "Array"
 base_type "Hash"
@@ -77,7 +84,7 @@ base_type "Regexp"
 module_class, _ = base_type "Module"
 module_class.subtype "Class"
 
-_, integer_exact = base_type "Integer"
+integer_exact = final_type "Integer"
 # CRuby partitions Integer into immediate and non-immediate variants.
 fixnum = integer_exact.subtype "Fixnum"
 integer_exact.subtype "Bignum"

--- a/zjit/src/hir_type/hir_type.inc.rs
+++ b/zjit/src/hir_type/hir_type.inc.rs
@@ -9,7 +9,7 @@ mod bits {
   pub const BasicObjectSubclass: u64 = 1u64 << 3;
   pub const Bignum: u64 = 1u64 << 4;
   pub const BoolExact: u64 = FalseClassExact | TrueClassExact;
-  pub const BuiltinExact: u64 = ArrayExact | BasicObjectExact | FalseClassExact | FloatExact | HashExact | IntegerExact | ModuleExact | NilClassExact | ObjectExact | RangeExact | RegexpExact | SetExact | StringExact | SymbolExact | TrueClassExact;
+  pub const BuiltinExact: u64 = ArrayExact | BasicObjectExact | FalseClassExact | FloatExact | HashExact | Integer | ModuleExact | NilClassExact | ObjectExact | RangeExact | RegexpExact | SetExact | StringExact | SymbolExact | TrueClassExact;
   pub const CBool: u64 = 1u64 << 5;
   pub const CDouble: u64 = 1u64 << 6;
   pub const CInt: u64 = CSigned | CUnsigned;
@@ -43,41 +43,39 @@ mod bits {
   pub const HashSubclass: u64 = 1u64 << 26;
   pub const HeapFloat: u64 = 1u64 << 27;
   pub const Immediate: u64 = FalseClassExact | Fixnum | Flonum | NilClassExact | StaticSymbol | TrueClassExact | Undef;
-  pub const Integer: u64 = IntegerExact | IntegerSubclass;
-  pub const IntegerExact: u64 = Bignum | Fixnum;
-  pub const IntegerSubclass: u64 = 1u64 << 28;
+  pub const Integer: u64 = Bignum | Fixnum;
   pub const Module: u64 = Class | ModuleExact | ModuleSubclass;
-  pub const ModuleExact: u64 = 1u64 << 29;
-  pub const ModuleSubclass: u64 = 1u64 << 30;
+  pub const ModuleExact: u64 = 1u64 << 28;
+  pub const ModuleSubclass: u64 = 1u64 << 29;
   pub const NilClass: u64 = NilClassExact | NilClassSubclass;
-  pub const NilClassExact: u64 = 1u64 << 31;
-  pub const NilClassSubclass: u64 = 1u64 << 32;
+  pub const NilClassExact: u64 = 1u64 << 30;
+  pub const NilClassSubclass: u64 = 1u64 << 31;
   pub const Object: u64 = Array | FalseClass | Float | Hash | Integer | Module | NilClass | ObjectExact | ObjectSubclass | Range | Regexp | Set | String | Symbol | TrueClass;
-  pub const ObjectExact: u64 = 1u64 << 33;
-  pub const ObjectSubclass: u64 = 1u64 << 34;
+  pub const ObjectExact: u64 = 1u64 << 32;
+  pub const ObjectSubclass: u64 = 1u64 << 33;
   pub const Range: u64 = RangeExact | RangeSubclass;
-  pub const RangeExact: u64 = 1u64 << 35;
-  pub const RangeSubclass: u64 = 1u64 << 36;
+  pub const RangeExact: u64 = 1u64 << 34;
+  pub const RangeSubclass: u64 = 1u64 << 35;
   pub const Regexp: u64 = RegexpExact | RegexpSubclass;
-  pub const RegexpExact: u64 = 1u64 << 37;
-  pub const RegexpSubclass: u64 = 1u64 << 38;
+  pub const RegexpExact: u64 = 1u64 << 36;
+  pub const RegexpSubclass: u64 = 1u64 << 37;
   pub const RubyValue: u64 = BasicObject | CallableMethodEntry | Undef;
   pub const Set: u64 = SetExact | SetSubclass;
-  pub const SetExact: u64 = 1u64 << 39;
-  pub const SetSubclass: u64 = 1u64 << 40;
-  pub const StaticSymbol: u64 = 1u64 << 41;
+  pub const SetExact: u64 = 1u64 << 38;
+  pub const SetSubclass: u64 = 1u64 << 39;
+  pub const StaticSymbol: u64 = 1u64 << 40;
   pub const String: u64 = StringExact | StringSubclass;
-  pub const StringExact: u64 = 1u64 << 42;
-  pub const StringSubclass: u64 = 1u64 << 43;
-  pub const Subclass: u64 = ArraySubclass | BasicObjectSubclass | FalseClassSubclass | FloatSubclass | HashSubclass | IntegerSubclass | ModuleSubclass | NilClassSubclass | ObjectSubclass | RangeSubclass | RegexpSubclass | SetSubclass | StringSubclass | SymbolSubclass | TrueClassSubclass;
+  pub const StringExact: u64 = 1u64 << 41;
+  pub const StringSubclass: u64 = 1u64 << 42;
+  pub const Subclass: u64 = ArraySubclass | BasicObjectSubclass | FalseClassSubclass | FloatSubclass | HashSubclass | ModuleSubclass | NilClassSubclass | ObjectSubclass | RangeSubclass | RegexpSubclass | SetSubclass | StringSubclass | SymbolSubclass | TrueClassSubclass;
   pub const Symbol: u64 = SymbolExact | SymbolSubclass;
   pub const SymbolExact: u64 = DynamicSymbol | StaticSymbol;
-  pub const SymbolSubclass: u64 = 1u64 << 44;
+  pub const SymbolSubclass: u64 = 1u64 << 43;
   pub const TrueClass: u64 = TrueClassExact | TrueClassSubclass;
-  pub const TrueClassExact: u64 = 1u64 << 45;
-  pub const TrueClassSubclass: u64 = 1u64 << 46;
-  pub const Undef: u64 = 1u64 << 47;
-  pub const AllBitPatterns: [(&'static str, u64); 77] = [
+  pub const TrueClassExact: u64 = 1u64 << 44;
+  pub const TrueClassSubclass: u64 = 1u64 << 45;
+  pub const Undef: u64 = 1u64 << 46;
+  pub const AllBitPatterns: [(&'static str, u64); 75] = [
     ("Any", Any),
     ("RubyValue", RubyValue),
     ("Immediate", Immediate),
@@ -114,8 +112,6 @@ mod bits {
     ("Module", Module),
     ("ModuleSubclass", ModuleSubclass),
     ("ModuleExact", ModuleExact),
-    ("Integer", Integer),
-    ("IntegerSubclass", IntegerSubclass),
     ("Float", Float),
     ("FloatExact", FloatExact),
     ("HeapFloat", HeapFloat),
@@ -124,7 +120,7 @@ mod bits {
     ("HashExact", HashExact),
     ("Flonum", Flonum),
     ("FloatSubclass", FloatSubclass),
-    ("IntegerExact", IntegerExact),
+    ("Integer", Integer),
     ("Fixnum", Fixnum),
     ("FalseClass", FalseClass),
     ("FalseClassSubclass", FalseClassSubclass),
@@ -156,7 +152,7 @@ mod bits {
     ("ArrayExact", ArrayExact),
     ("Empty", Empty),
   ];
-  pub const NumTypeBits: u64 = 48;
+  pub const NumTypeBits: u64 = 47;
 }
 pub mod types {
   use super::*;
@@ -204,8 +200,6 @@ pub mod types {
   pub const HeapFloat: Type = Type::from_bits(bits::HeapFloat);
   pub const Immediate: Type = Type::from_bits(bits::Immediate);
   pub const Integer: Type = Type::from_bits(bits::Integer);
-  pub const IntegerExact: Type = Type::from_bits(bits::IntegerExact);
-  pub const IntegerSubclass: Type = Type::from_bits(bits::IntegerSubclass);
   pub const Module: Type = Type::from_bits(bits::Module);
   pub const ModuleExact: Type = Type::from_bits(bits::ModuleExact);
   pub const ModuleSubclass: Type = Type::from_bits(bits::ModuleSubclass);

--- a/zjit/src/hir_type/hir_type.inc.rs
+++ b/zjit/src/hir_type/hir_type.inc.rs
@@ -8,8 +8,8 @@ mod bits {
   pub const BasicObjectExact: u64 = 1u64 << 2;
   pub const BasicObjectSubclass: u64 = 1u64 << 3;
   pub const Bignum: u64 = 1u64 << 4;
-  pub const BoolExact: u64 = FalseClassExact | TrueClassExact;
-  pub const BuiltinExact: u64 = ArrayExact | BasicObjectExact | FalseClassExact | FloatExact | HashExact | Integer | ModuleExact | NilClassExact | ObjectExact | RangeExact | RegexpExact | SetExact | StringExact | SymbolExact | TrueClassExact;
+  pub const BoolExact: u64 = FalseClass | TrueClass;
+  pub const BuiltinExact: u64 = ArrayExact | BasicObjectExact | FalseClass | Float | HashExact | Integer | ModuleExact | NilClass | ObjectExact | RangeExact | RegexpExact | SetExact | StringExact | Symbol | TrueClass;
   pub const CBool: u64 = 1u64 << 5;
   pub const CDouble: u64 = 1u64 << 6;
   pub const CInt: u64 = CSigned | CUnsigned;
@@ -30,70 +30,56 @@ mod bits {
   pub const Class: u64 = 1u64 << 18;
   pub const DynamicSymbol: u64 = 1u64 << 19;
   pub const Empty: u64 = 0u64;
-  pub const FalseClass: u64 = FalseClassExact | FalseClassSubclass;
-  pub const FalseClassExact: u64 = 1u64 << 20;
-  pub const FalseClassSubclass: u64 = 1u64 << 21;
-  pub const Fixnum: u64 = 1u64 << 22;
-  pub const Float: u64 = FloatExact | FloatSubclass;
-  pub const FloatExact: u64 = Flonum | HeapFloat;
-  pub const FloatSubclass: u64 = 1u64 << 23;
-  pub const Flonum: u64 = 1u64 << 24;
+  pub const FalseClass: u64 = 1u64 << 20;
+  pub const Fixnum: u64 = 1u64 << 21;
+  pub const Float: u64 = Flonum | HeapFloat;
+  pub const Flonum: u64 = 1u64 << 22;
   pub const Hash: u64 = HashExact | HashSubclass;
-  pub const HashExact: u64 = 1u64 << 25;
-  pub const HashSubclass: u64 = 1u64 << 26;
-  pub const HeapFloat: u64 = 1u64 << 27;
-  pub const Immediate: u64 = FalseClassExact | Fixnum | Flonum | NilClassExact | StaticSymbol | TrueClassExact | Undef;
+  pub const HashExact: u64 = 1u64 << 23;
+  pub const HashSubclass: u64 = 1u64 << 24;
+  pub const HeapFloat: u64 = 1u64 << 25;
+  pub const Immediate: u64 = FalseClass | Fixnum | Flonum | NilClass | StaticSymbol | TrueClass | Undef;
   pub const Integer: u64 = Bignum | Fixnum;
   pub const Module: u64 = Class | ModuleExact | ModuleSubclass;
-  pub const ModuleExact: u64 = 1u64 << 28;
-  pub const ModuleSubclass: u64 = 1u64 << 29;
-  pub const NilClass: u64 = NilClassExact | NilClassSubclass;
-  pub const NilClassExact: u64 = 1u64 << 30;
-  pub const NilClassSubclass: u64 = 1u64 << 31;
+  pub const ModuleExact: u64 = 1u64 << 26;
+  pub const ModuleSubclass: u64 = 1u64 << 27;
+  pub const NilClass: u64 = 1u64 << 28;
   pub const Object: u64 = Array | FalseClass | Float | Hash | Integer | Module | NilClass | ObjectExact | ObjectSubclass | Range | Regexp | Set | String | Symbol | TrueClass;
-  pub const ObjectExact: u64 = 1u64 << 32;
-  pub const ObjectSubclass: u64 = 1u64 << 33;
+  pub const ObjectExact: u64 = 1u64 << 29;
+  pub const ObjectSubclass: u64 = 1u64 << 30;
   pub const Range: u64 = RangeExact | RangeSubclass;
-  pub const RangeExact: u64 = 1u64 << 34;
-  pub const RangeSubclass: u64 = 1u64 << 35;
+  pub const RangeExact: u64 = 1u64 << 31;
+  pub const RangeSubclass: u64 = 1u64 << 32;
   pub const Regexp: u64 = RegexpExact | RegexpSubclass;
-  pub const RegexpExact: u64 = 1u64 << 36;
-  pub const RegexpSubclass: u64 = 1u64 << 37;
+  pub const RegexpExact: u64 = 1u64 << 33;
+  pub const RegexpSubclass: u64 = 1u64 << 34;
   pub const RubyValue: u64 = BasicObject | CallableMethodEntry | Undef;
   pub const Set: u64 = SetExact | SetSubclass;
-  pub const SetExact: u64 = 1u64 << 38;
-  pub const SetSubclass: u64 = 1u64 << 39;
-  pub const StaticSymbol: u64 = 1u64 << 40;
+  pub const SetExact: u64 = 1u64 << 35;
+  pub const SetSubclass: u64 = 1u64 << 36;
+  pub const StaticSymbol: u64 = 1u64 << 37;
   pub const String: u64 = StringExact | StringSubclass;
-  pub const StringExact: u64 = 1u64 << 41;
-  pub const StringSubclass: u64 = 1u64 << 42;
-  pub const Subclass: u64 = ArraySubclass | BasicObjectSubclass | FalseClassSubclass | FloatSubclass | HashSubclass | ModuleSubclass | NilClassSubclass | ObjectSubclass | RangeSubclass | RegexpSubclass | SetSubclass | StringSubclass | SymbolSubclass | TrueClassSubclass;
-  pub const Symbol: u64 = SymbolExact | SymbolSubclass;
-  pub const SymbolExact: u64 = DynamicSymbol | StaticSymbol;
-  pub const SymbolSubclass: u64 = 1u64 << 43;
-  pub const TrueClass: u64 = TrueClassExact | TrueClassSubclass;
-  pub const TrueClassExact: u64 = 1u64 << 44;
-  pub const TrueClassSubclass: u64 = 1u64 << 45;
-  pub const Undef: u64 = 1u64 << 46;
-  pub const AllBitPatterns: [(&'static str, u64); 75] = [
+  pub const StringExact: u64 = 1u64 << 38;
+  pub const StringSubclass: u64 = 1u64 << 39;
+  pub const Subclass: u64 = ArraySubclass | BasicObjectSubclass | HashSubclass | ModuleSubclass | ObjectSubclass | RangeSubclass | RegexpSubclass | SetSubclass | StringSubclass;
+  pub const Symbol: u64 = DynamicSymbol | StaticSymbol;
+  pub const TrueClass: u64 = 1u64 << 40;
+  pub const Undef: u64 = 1u64 << 41;
+  pub const AllBitPatterns: [(&'static str, u64); 65] = [
     ("Any", Any),
     ("RubyValue", RubyValue),
     ("Immediate", Immediate),
     ("Undef", Undef),
     ("BasicObject", BasicObject),
     ("Object", Object),
-    ("TrueClass", TrueClass),
-    ("Subclass", Subclass),
-    ("TrueClassSubclass", TrueClassSubclass),
     ("BuiltinExact", BuiltinExact),
     ("BoolExact", BoolExact),
-    ("TrueClassExact", TrueClassExact),
-    ("Symbol", Symbol),
-    ("SymbolSubclass", SymbolSubclass),
+    ("TrueClass", TrueClass),
     ("String", String),
+    ("Subclass", Subclass),
     ("StringSubclass", StringSubclass),
     ("StringExact", StringExact),
-    ("SymbolExact", SymbolExact),
+    ("Symbol", Symbol),
     ("StaticSymbol", StaticSymbol),
     ("Set", Set),
     ("SetSubclass", SetSubclass),
@@ -107,24 +93,18 @@ mod bits {
     ("ObjectSubclass", ObjectSubclass),
     ("ObjectExact", ObjectExact),
     ("NilClass", NilClass),
-    ("NilClassSubclass", NilClassSubclass),
-    ("NilClassExact", NilClassExact),
     ("Module", Module),
     ("ModuleSubclass", ModuleSubclass),
     ("ModuleExact", ModuleExact),
     ("Float", Float),
-    ("FloatExact", FloatExact),
     ("HeapFloat", HeapFloat),
     ("Hash", Hash),
     ("HashSubclass", HashSubclass),
     ("HashExact", HashExact),
     ("Flonum", Flonum),
-    ("FloatSubclass", FloatSubclass),
     ("Integer", Integer),
     ("Fixnum", Fixnum),
     ("FalseClass", FalseClass),
-    ("FalseClassSubclass", FalseClassSubclass),
-    ("FalseClassExact", FalseClassExact),
     ("DynamicSymbol", DynamicSymbol),
     ("Class", Class),
     ("CallableMethodEntry", CallableMethodEntry),
@@ -152,7 +132,7 @@ mod bits {
     ("ArrayExact", ArrayExact),
     ("Empty", Empty),
   ];
-  pub const NumTypeBits: u64 = 47;
+  pub const NumTypeBits: u64 = 42;
 }
 pub mod types {
   use super::*;
@@ -187,12 +167,8 @@ pub mod types {
   pub const DynamicSymbol: Type = Type::from_bits(bits::DynamicSymbol);
   pub const Empty: Type = Type::from_bits(bits::Empty);
   pub const FalseClass: Type = Type::from_bits(bits::FalseClass);
-  pub const FalseClassExact: Type = Type::from_bits(bits::FalseClassExact);
-  pub const FalseClassSubclass: Type = Type::from_bits(bits::FalseClassSubclass);
   pub const Fixnum: Type = Type::from_bits(bits::Fixnum);
   pub const Float: Type = Type::from_bits(bits::Float);
-  pub const FloatExact: Type = Type::from_bits(bits::FloatExact);
-  pub const FloatSubclass: Type = Type::from_bits(bits::FloatSubclass);
   pub const Flonum: Type = Type::from_bits(bits::Flonum);
   pub const Hash: Type = Type::from_bits(bits::Hash);
   pub const HashExact: Type = Type::from_bits(bits::HashExact);
@@ -204,8 +180,6 @@ pub mod types {
   pub const ModuleExact: Type = Type::from_bits(bits::ModuleExact);
   pub const ModuleSubclass: Type = Type::from_bits(bits::ModuleSubclass);
   pub const NilClass: Type = Type::from_bits(bits::NilClass);
-  pub const NilClassExact: Type = Type::from_bits(bits::NilClassExact);
-  pub const NilClassSubclass: Type = Type::from_bits(bits::NilClassSubclass);
   pub const Object: Type = Type::from_bits(bits::Object);
   pub const ObjectExact: Type = Type::from_bits(bits::ObjectExact);
   pub const ObjectSubclass: Type = Type::from_bits(bits::ObjectSubclass);
@@ -225,10 +199,6 @@ pub mod types {
   pub const StringSubclass: Type = Type::from_bits(bits::StringSubclass);
   pub const Subclass: Type = Type::from_bits(bits::Subclass);
   pub const Symbol: Type = Type::from_bits(bits::Symbol);
-  pub const SymbolExact: Type = Type::from_bits(bits::SymbolExact);
-  pub const SymbolSubclass: Type = Type::from_bits(bits::SymbolSubclass);
   pub const TrueClass: Type = Type::from_bits(bits::TrueClass);
-  pub const TrueClassExact: Type = Type::from_bits(bits::TrueClassExact);
-  pub const TrueClassSubclass: Type = Type::from_bits(bits::TrueClassSubclass);
   pub const Undef: Type = Type::from_bits(bits::Undef);
 }

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -442,7 +442,7 @@ impl Type {
         if self.is_subtype(types::FalseClassExact) { return Some(unsafe { rb_cFalseClass }); }
         if self.is_subtype(types::FloatExact) { return Some(unsafe { rb_cFloat }); }
         if self.is_subtype(types::HashExact) { return Some(unsafe { rb_cHash }); }
-        if self.is_subtype(types::IntegerExact) { return Some(unsafe { rb_cInteger }); }
+        if self.is_subtype(types::Integer) { return Some(unsafe { rb_cInteger }); }
         if self.is_subtype(types::ModuleExact) { return Some(unsafe { rb_cModule }); }
         if self.is_subtype(types::NilClassExact) { return Some(unsafe { rb_cNilClass }); }
         if self.is_subtype(types::ObjectExact) { return Some(unsafe { rb_cObject }); }
@@ -547,10 +547,8 @@ mod tests {
         assert_subtype(Type::fixnum(123), Type::fixnum(123));
         assert_not_subtype(Type::fixnum(123), Type::fixnum(200));
         assert_subtype(Type::from_value(VALUE::fixnum_from_usize(123)), types::Fixnum);
-        assert_subtype(types::Fixnum, types::IntegerExact);
-        assert_subtype(types::Bignum, types::IntegerExact);
-        assert_subtype(types::IntegerExact, types::Integer);
-        assert_subtype(types::IntegerSubclass, types::Integer);
+        assert_subtype(types::Fixnum, types::Integer);
+        assert_subtype(types::Bignum, types::Integer);
     }
 
     #[test]
@@ -590,7 +588,6 @@ mod tests {
     fn fixnum_has_ruby_object() {
         assert_eq!(Type::fixnum(3).ruby_object(), Some(VALUE::fixnum_from_usize(3)));
         assert_eq!(types::Fixnum.ruby_object(), None);
-        assert_eq!(types::IntegerExact.ruby_object(), None);
         assert_eq!(types::Integer.ruby_object(), None);
     }
 
@@ -608,7 +605,6 @@ mod tests {
     fn integer_has_exact_ruby_class() {
         assert_eq!(Type::fixnum(3).exact_ruby_class(), Some(unsafe { rb_cInteger }.into()));
         assert_eq!(types::Fixnum.exact_ruby_class(), None);
-        assert_eq!(types::IntegerExact.exact_ruby_class(), None);
         assert_eq!(types::Integer.exact_ruby_class(), None);
     }
 
@@ -636,7 +632,6 @@ mod tests {
     fn integer_has_ruby_class() {
         assert_eq!(Type::fixnum(3).inexact_ruby_class(), Some(unsafe { rb_cInteger }.into()));
         assert_eq!(types::Fixnum.inexact_ruby_class(), None);
-        assert_eq!(types::IntegerExact.inexact_ruby_class(), None);
         assert_eq!(types::Integer.inexact_ruby_class(), None);
     }
 
@@ -670,7 +665,6 @@ mod tests {
         assert_eq!(format!("{}", Type::from_cbool(false)), "CBool[false]");
         assert_eq!(format!("{}", types::Fixnum), "Fixnum");
         assert_eq!(format!("{}", types::Integer), "Integer");
-        assert_eq!(format!("{}", types::IntegerExact), "IntegerExact");
     }
 
     #[test]
@@ -688,12 +682,10 @@ mod tests {
 
     #[test]
     fn union_bits_subtype() {
-        assert_bit_equal(types::Fixnum.union(types::IntegerExact), types::IntegerExact);
         assert_bit_equal(types::Fixnum.union(types::Integer), types::Integer);
         assert_bit_equal(types::Fixnum.union(types::Object), types::Object);
         assert_bit_equal(Type::fixnum(3).union(types::Fixnum), types::Fixnum);
 
-        assert_bit_equal(types::IntegerExact.union(types::Fixnum), types::IntegerExact);
         assert_bit_equal(types::Integer.union(types::Fixnum), types::Integer);
         assert_bit_equal(types::Object.union(types::Fixnum), types::Object);
         assert_bit_equal(types::Fixnum.union(Type::fixnum(3)), types::Fixnum);


### PR DESCRIPTION
While Integer can technically be subclassed, instances of subclasses
cannot be created. Remove it from the type lattice.
