### PR TITLE
Fix ext/-test-/namespace/yay{1,2} for mswin

### DIFF
--- a/ext/-test-/namespace/yay1/yay1.def
+++ b/ext/-test-/namespace/yay1/yay1.def
@@ -1,4 +1,3 @@
-LIBRARY yay1
 EXPORTS
   Init_yay1
   yay_value

--- a/ext/-test-/namespace/yay1/yay1.h
+++ b/ext/-test-/namespace/yay1/yay1.h
@@ -1,4 +1,4 @@
 #include <ruby.h>
 #include "ruby/internal/dllexport.h"
 
-RUBY_EXTERN VALUE yay_value(void);
+RUBY_FUNC_EXPORTED VALUE yay_value(void);

--- a/ext/-test-/namespace/yay2/yay2.def
+++ b/ext/-test-/namespace/yay2/yay2.def
@@ -1,4 +1,3 @@
-LIBRARY yay2
 EXPORTS
   Init_yay2
   yay_value

--- a/ext/-test-/namespace/yay2/yay2.h
+++ b/ext/-test-/namespace/yay2/yay2.h
@@ -1,4 +1,4 @@
 #include <ruby.h>
 #include "ruby/internal/dllexport.h"
 
-RUBY_EXTERN VALUE yay_value(void);
+RUBY_FUNC_EXPORTED VALUE yay_value(void);


### PR DESCRIPTION
Visual C:
```
compiling ../../../../../src/ext/-test-/namespace/yay1/yay1.c
yay1.c
../../../../../src/ext/-test-/namespace/yay1/yay1.c(4): warning C4273: 'yay_value': inconsistent dll linkage
C:\a\ruby\ruby\src\ext\-test-\namespace\yay1\yay1.h(4): note: see previous definition of 'yay_value'
linking shared-object -test-/namespace/yay1.so
   Creating library yay1-arm64-mswin64_140.lib and object yay1-arm64-mswin64_140.exp
yay1-arm64-mswin64_140.exp : warning LNK4070: /OUT:yay1.dll directive in .EXP differs from output filename '..\..\..\..\.ext\arm64-mswin64_140\-test-\namespace\yay1.so'; ignoring directive
compiling ../../../../../src/ext/-test-/namespace/yay2/yay2.c
yay2.c
../../../../../src/ext/-test-/namespace/yay2/yay2.c(4): warning C4273: 'yay_value': inconsistent dll linkage
C:\a\ruby\ruby\src\ext\-test-\namespace\yay2\yay2.h(4): note: see previous definition of 'yay_value'
linking shared-object -test-/namespace/yay2.so
   Creating library yay2-arm64-mswin64_140.lib and object yay2-arm64-mswin64_140.exp
yay2-arm64-mswin64_140.exp : warning LNK4070: /OUT:yay2.dll directive in .EXP differs from output filename '..\..\..\..\.ext\arm64-mswin64_140\-test-\namespace\yay2.so'; ignoring directive
```

From MinGW gcc:
```
../../../../../src/ext/-test-/namespace/yay1/yay1.c:4:1: warning: 'yay_value' redeclared without dllimport attribute: previous dllimport ignored [-Wattributes]
    4 | yay_value(void)
      | ^~~~~~~~~
../../../../../src/ext/-test-/namespace/yay2/yay2.c:4:1: warning: 'yay_value' redeclared without dllimport attribute: previous dllimport ignored [-Wattributes]
    4 | yay_value(void)
      | ^~~~~~~~~
```