### PR TITLE
Fix the tests using `RUBY_DESCRIPTION`

### DIFF
--- a/.github/workflows/parse_y.yml
+++ b/.github/workflows/parse_y.yml
@@ -78,7 +78,9 @@ jobs:
 
       - run: make
 
-      - run: make TESTRUN_SCRIPT='-e "exit !RUBY_DESCRIPTION.include?(%[+PRISM])"' run
+      - run: make TESTRUN_SCRIPT='-renvutil -v -e "exit EnvUtil.current_parser == %[parse.y]"' run
+        env:
+          RUNOPT0: -I$(tooldir)/lib
 
       - name: make ${{ matrix.test_task }}
         run: make -s ${{ matrix.test_task }} RUN_OPTS="$RUN_OPTS" SPECOPTS="$SPECOPTS"

--- a/spec/ruby/command_line/dash_v_spec.rb
+++ b/spec/ruby/command_line/dash_v_spec.rb
@@ -6,7 +6,7 @@ describe "The -v command line option" do
 
   describe "when used alone" do
     it "prints version and ends" do
-      ruby_exe(nil, args: '-v').sub("+PRISM ", "").should include(RUBY_DESCRIPTION.sub("+PRISM ", ""))
+      ruby_exe(nil, args: '-v').gsub("+PRISM ", "").should include(RUBY_DESCRIPTION.gsub("+PRISM ", ""))
     end unless (defined?(RubyVM::YJIT) && RubyVM::YJIT.enabled?) ||
                (defined?(RubyVM::RJIT) && RubyVM::RJIT.enabled?) ||
                (ENV['RUBY_GC_LIBRARY'] && ENV['RUBY_GC_LIBRARY'].length > 0) ||

--- a/spec/ruby/command_line/rubyopt_spec.rb
+++ b/spec/ruby/command_line/rubyopt_spec.rb
@@ -25,12 +25,12 @@ describe "Processing RUBYOPT" do
   guard -> { RbConfig::CONFIG["CROSS_COMPILING"] != "yes" } do
     it "prints the version number for '-v'" do
       ENV["RUBYOPT"] = '-v'
-      ruby_exe("").sub("+PRISM ", "").sub(/\+GC(\[\w+\]\s|\s)?/, "")[/\A.*/].should == RUBY_DESCRIPTION.sub("+PRISM ", "").sub(/\+GC(\[\w+\]\s|\s)?/, "")
+      ruby_exe("")[/\A.*/].gsub(/\s\+(PRISM|GC(\[\w+\])?)(?=\s)/, "").should == RUBY_DESCRIPTION.gsub(/\s\+(PRISM|GC(\[\w+\])?)(?=\s)/, "")
     end
 
     it "ignores whitespace around the option" do
       ENV["RUBYOPT"] = ' -v '
-      ruby_exe("").sub("+PRISM ", "").sub(/\+GC(\[\w+\]\s|\s)?/, "")[/\A.*/].should == RUBY_DESCRIPTION.sub("+PRISM ", "").sub(/\+GC(\[\w+\]\s|\s)?/, "")
+      ruby_exe("")[/\A.*/].gsub(/\s\+(PRISM|GC(\[\w+\])?)(?=\s)/, "").should == RUBY_DESCRIPTION.gsub(/\s\+(PRISM|GC(\[\w+\])?)(?=\s)/, "")
     end
   end
 

--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -226,7 +226,6 @@ module EnvUtil
     args = [args] if args.kind_of?(String)
     # use the same parser as current ruby
     if args.none? { |arg| arg.start_with?("--parser=") }
-      current_parser = RUBY_DESCRIPTION =~ /prism/i ? "prism" : "parse.y"
       args = ["--parser=#{current_parser}"] + args
     end
     pid = spawn(child_env, *precommand, rubybin, *args, opt)
@@ -275,6 +274,12 @@ module EnvUtil
     end
   end
   module_function :invoke_ruby
+
+  def current_parser
+    features = RUBY_DESCRIPTION[%r{\)\K [-+*/%._0-9a-zA-Z ]*(?=\[[-+*/%._0-9a-zA-Z]+\]\z)}]
+    features&.split&.include?("+PRISM") ? "prism" : "parse.y"
+  end
+  module_function :current_parser
 
   def verbose_warning
     class << (stderr = "".dup)


### PR DESCRIPTION
- Fix the current parser detection
  Since `RUBY_DESCRIPTION` contains the branch name, `/prism/i` can match unexpectedly.  Extract the feature lists between revision and platform infos.

- Fix stripping features from the description
  Ditto for stripping "+PRISM".