### PR TITLE
Allow for lock-free lookups in `RClass.cc_tbl`

### DIFF
--- a/debug_counter.h
+++ b/debug_counter.h
@@ -49,7 +49,7 @@ RB_DEBUG_COUNTER(cc_temp)       //           dummy CC (stack-allocated)
 RB_DEBUG_COUNTER(cc_found_in_ccs)      // count for CC lookup success in CCS
 RB_DEBUG_COUNTER(cc_not_found_in_ccs)  // count for CC lookup success in CCS
 
-RB_DEBUG_COUNTER(cc_ent_invalidate) // count for invalidating cc (cc->klass = 0)
+RB_DEBUG_COUNTER(cc_ent_invalidate) // count for invalidating cc (cc->klass = Qundef)
 RB_DEBUG_COUNTER(cc_cme_invalidate) // count for invalidating CME
 
 RB_DEBUG_COUNTER(cc_invalidate_leaf)          // count for invalidating klass if klass has no-subclasses

--- a/gc.c
+++ b/gc.c
@@ -1208,7 +1208,6 @@ classext_free(rb_classext_t *ext, bool is_prime, VALUE namespace, void *arg)
     struct classext_foreach_args *args = (struct classext_foreach_args *)arg;
 
     rb_id_table_free(RCLASSEXT_M_TBL(ext));
-    rb_cc_tbl_free(RCLASSEXT_CC_TBL(ext), args->klass);
 
     if (!RCLASSEXT_SHARED_CONST_TBL(ext) && (tbl = RCLASSEXT_CONST_TBL(ext)) != NULL) {
         rb_free_const_table(tbl);
@@ -1239,7 +1238,6 @@ classext_iclass_free(rb_classext_t *ext, bool is_prime, VALUE namespace, void *a
     if (RCLASSEXT_CALLABLE_M_TBL(ext) != NULL) {
         rb_id_table_free(RCLASSEXT_CALLABLE_M_TBL(ext));
     }
-    rb_cc_tbl_free(RCLASSEXT_CC_TBL(ext), args->klass);
 
     rb_class_classext_free_subclasses(ext, args->klass);
 
@@ -2263,24 +2261,6 @@ rb_gc_after_updating_jit_code(void)
 #endif
 }
 
-static enum rb_id_table_iterator_result
-cc_table_memsize_i(VALUE ccs_ptr, void *data_ptr)
-{
-    size_t *total_size = data_ptr;
-    struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_ptr;
-    *total_size += sizeof(*ccs);
-    *total_size += sizeof(ccs->entries[0]) * ccs->capa;
-    return ID_TABLE_CONTINUE;
-}
-
-static size_t
-cc_table_memsize(struct rb_id_table *cc_table)
-{
-    size_t total = rb_id_table_memsize(cc_table);
-    rb_id_table_foreach_values(cc_table, cc_table_memsize_i, &total);
-    return total;
-}
-
 static void
 classext_memsize(rb_classext_t *ext, bool prime, VALUE namespace, void *arg)
 {
@@ -2295,9 +2275,6 @@ classext_memsize(rb_classext_t *ext, bool prime, VALUE namespace, void *arg)
     }
     if (RCLASSEXT_CONST_TBL(ext)) {
         s += rb_id_table_memsize(RCLASSEXT_CONST_TBL(ext));
-    }
-    if (RCLASSEXT_CC_TBL(ext)) {
-        s += cc_table_memsize(RCLASSEXT_CC_TBL(ext));
     }
     if (RCLASSEXT_SUPERCLASSES_WITH_SELF(ext)) {
         s += (RCLASSEXT_SUPERCLASS_DEPTH(ext) + 1) * sizeof(VALUE);
@@ -2348,9 +2325,6 @@ rb_obj_memsize_of(VALUE obj)
             if (RCLASS_M_TBL(obj)) {
                 size += rb_id_table_memsize(RCLASS_M_TBL(obj));
             }
-        }
-        if (RCLASS_WRITABLE_CC_TBL(obj)) {
-            size += cc_table_memsize(RCLASS_WRITABLE_CC_TBL(obj));
         }
         break;
       case T_STRING:
@@ -2836,47 +2810,6 @@ mark_const_tbl(rb_objspace_t *objspace, struct rb_id_table *tbl)
     rb_id_table_foreach_values(tbl, mark_const_entry_i, objspace);
 }
 
-struct mark_cc_entry_args {
-    rb_objspace_t *objspace;
-    VALUE klass;
-};
-
-static enum rb_id_table_iterator_result
-mark_cc_entry_i(VALUE ccs_ptr, void *data)
-{
-    struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_ptr;
-
-    VM_ASSERT(vm_ccs_p(ccs));
-
-    if (METHOD_ENTRY_INVALIDATED(ccs->cme)) {
-        rb_vm_ccs_free(ccs);
-        return ID_TABLE_DELETE;
-    }
-    else {
-        gc_mark_internal((VALUE)ccs->cme);
-
-        for (int i=0; i<ccs->len; i++) {
-            VM_ASSERT(((struct mark_cc_entry_args *)data)->klass == ccs->entries[i].cc->klass);
-            VM_ASSERT(vm_cc_check_cme(ccs->entries[i].cc, ccs->cme));
-
-            gc_mark_internal((VALUE)ccs->entries[i].cc);
-        }
-        return ID_TABLE_CONTINUE;
-    }
-}
-
-static void
-mark_cc_tbl(rb_objspace_t *objspace, struct rb_id_table *tbl, VALUE klass)
-{
-    struct mark_cc_entry_args args;
-
-    if (!tbl) return;
-
-    args.objspace = objspace;
-    args.klass = klass;
-    rb_id_table_foreach_values(tbl, mark_cc_entry_i, (void *)&args);
-}
-
 static enum rb_id_table_iterator_result
 mark_cvc_tbl_i(VALUE cvc_entry, void *objspace)
 {
@@ -3114,7 +3047,6 @@ gc_mark_classext_module(rb_classext_t *ext, bool prime, VALUE namespace, void *a
 {
     struct gc_mark_classext_foreach_arg *foreach_arg = (struct gc_mark_classext_foreach_arg *)arg;
     rb_objspace_t *objspace = foreach_arg->objspace;
-    VALUE obj = foreach_arg->obj;
 
     if (RCLASSEXT_SUPER(ext)) {
         gc_mark_internal(RCLASSEXT_SUPER(ext));
@@ -3125,7 +3057,7 @@ gc_mark_classext_module(rb_classext_t *ext, bool prime, VALUE namespace, void *a
         mark_const_tbl(objspace, RCLASSEXT_CONST_TBL(ext));
     }
     mark_m_tbl(objspace, RCLASSEXT_CALLABLE_M_TBL(ext));
-    mark_cc_tbl(objspace, RCLASSEXT_CC_TBL(ext), obj);
+    gc_mark_internal(RCLASSEXT_CC_TBL(ext));
     mark_cvc_tbl(objspace, RCLASSEXT_CVC_TBL(ext));
     gc_mark_internal(RCLASSEXT_CLASSPATH(ext));
 }
@@ -3135,7 +3067,6 @@ gc_mark_classext_iclass(rb_classext_t *ext, bool prime, VALUE namespace, void *a
 {
     struct gc_mark_classext_foreach_arg *foreach_arg = (struct gc_mark_classext_foreach_arg *)arg;
     rb_objspace_t *objspace = foreach_arg->objspace;
-    VALUE iclass = foreach_arg->obj;
 
     if (RCLASSEXT_SUPER(ext)) {
         gc_mark_internal(RCLASSEXT_SUPER(ext));
@@ -3147,7 +3078,7 @@ gc_mark_classext_iclass(rb_classext_t *ext, bool prime, VALUE namespace, void *a
         gc_mark_internal(RCLASSEXT_INCLUDER(ext));
     }
     mark_m_tbl(objspace, RCLASSEXT_CALLABLE_M_TBL(ext));
-    mark_cc_tbl(objspace, RCLASSEXT_CC_TBL(ext), iclass);
+    gc_mark_internal(RCLASSEXT_CC_TBL(ext));
 }
 
 #define TYPED_DATA_REFS_OFFSET_LIST(d) (size_t *)(uintptr_t)RTYPEDDATA_TYPE(d)->function.dmark
@@ -3712,33 +3643,6 @@ update_m_tbl(void *objspace, struct rb_id_table *tbl)
 }
 
 static enum rb_id_table_iterator_result
-update_cc_tbl_i(VALUE ccs_ptr, void *objspace)
-{
-    struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_ptr;
-    VM_ASSERT(vm_ccs_p(ccs));
-
-    if (rb_gc_impl_object_moved_p(objspace, (VALUE)ccs->cme)) {
-        ccs->cme = (const rb_callable_method_entry_t *)gc_location_internal(objspace, (VALUE)ccs->cme);
-    }
-
-    for (int i=0; i<ccs->len; i++) {
-        if (rb_gc_impl_object_moved_p(objspace, (VALUE)ccs->entries[i].cc)) {
-            ccs->entries[i].cc = (struct rb_callcache *)gc_location_internal(objspace, (VALUE)ccs->entries[i].cc);
-        }
-    }
-
-    // do not replace
-    return ID_TABLE_CONTINUE;
-}
-
-static void
-update_cc_tbl(void *objspace, struct rb_id_table *tbl)
-{
-    if (!tbl) return;
-    rb_id_table_foreach_values(tbl, update_cc_tbl_i, objspace);
-}
-
-static enum rb_id_table_iterator_result
 update_cvc_tbl_i(VALUE cvc_entry, void *objspace)
 {
     struct rb_cvar_class_tbl_entry *entry;
@@ -3836,7 +3740,7 @@ update_classext(rb_classext_t *ext, bool is_prime, VALUE namespace, void *arg)
     if (!RCLASSEXT_SHARED_CONST_TBL(ext)) {
         update_const_tbl(objspace, RCLASSEXT_CONST_TBL(ext));
     }
-    update_cc_tbl(objspace, RCLASSEXT_CC_TBL(ext));
+    UPDATE_IF_MOVED(objspace, RCLASSEXT_CC_TBL(ext));
     update_cvc_tbl(objspace, RCLASSEXT_CVC_TBL(ext));
     update_superclasses(objspace, ext);
     update_subclasses(objspace, ext);
@@ -3855,7 +3759,7 @@ update_iclass_classext(rb_classext_t *ext, bool is_prime, VALUE namespace, void 
     }
     update_m_tbl(objspace, RCLASSEXT_M_TBL(ext));
     update_m_tbl(objspace, RCLASSEXT_CALLABLE_M_TBL(ext));
-    update_cc_tbl(objspace, RCLASSEXT_CC_TBL(ext));
+    UPDATE_IF_MOVED(objspace, RCLASSEXT_CC_TBL(ext));
     update_subclasses(objspace, ext);
 
     update_classext_values(objspace, ext, true);

--- a/gc.c
+++ b/gc.c
@@ -1209,6 +1209,7 @@ classext_free(rb_classext_t *ext, bool is_prime, VALUE namespace, void *arg)
 
     rb_id_table_free(RCLASSEXT_M_TBL(ext));
     rb_cc_tbl_free(RCLASSEXT_CC_TBL(ext), args->klass);
+
     if (!RCLASSEXT_SHARED_CONST_TBL(ext) && (tbl = RCLASSEXT_CONST_TBL(ext)) != NULL) {
         rb_free_const_table(tbl);
     }
@@ -1743,7 +1744,7 @@ rb_objspace_free_objects(void *objspace)
 int
 rb_objspace_garbage_object_p(VALUE obj)
 {
-    return rb_gc_impl_garbage_object_p(rb_gc_get_objspace(), obj);
+    return !SPECIAL_CONST_P(obj) && rb_gc_impl_garbage_object_p(rb_gc_get_objspace(), obj);
 }
 
 bool
@@ -4924,11 +4925,11 @@ rb_raw_obj_info_buitin_type(char *const buff, const size_t buff_size, const VALU
               case imemo_callcache:
                 {
                     const struct rb_callcache *cc = (const struct rb_callcache *)obj;
-                    VALUE class_path = cc->klass ? rb_class_path_cached(cc->klass) : Qnil;
+                    VALUE class_path = vm_cc_valid(cc) ? rb_class_path_cached(cc->klass) : Qnil;
                     const rb_callable_method_entry_t *cme = vm_cc_cme(cc);
 
                     APPEND_F("(klass:%s cme:%s%s (%p) call:%p",
-                             NIL_P(class_path) ? (cc->klass ? "??" : "<NULL>") : RSTRING_PTR(class_path),
+                             NIL_P(class_path) ? (vm_cc_valid(cc) ? "??" : "<NULL>") : RSTRING_PTR(class_path),
                              cme ? rb_id2name(cme->called_id) : "<NULL>",
                              cme ? (METHOD_ENTRY_INVALIDATED(cme) ? " [inv]" : "") : "",
                              (void *)cme,

--- a/id_table.c
+++ b/id_table.c
@@ -395,7 +395,7 @@ VALUE
 rb_managed_id_table_dup(VALUE old_table)
 {
     struct rb_id_table *new_tbl;
-    VALUE obj = TypedData_Make_Struct(0, struct rb_id_table, &rb_managed_id_table_type, new_tbl);
+    VALUE obj = TypedData_Make_Struct(0, struct rb_id_table, RTYPEDDATA_TYPE(old_table), new_tbl);
     struct rb_id_table *old_tbl = managed_id_table_ptr(old_table);
     rb_id_table_init(new_tbl, old_tbl->num + 1);
     rb_id_table_foreach(old_tbl, managed_id_table_dup_i, new_tbl);

--- a/id_table.h
+++ b/id_table.h
@@ -35,12 +35,17 @@ void rb_id_table_foreach(struct rb_id_table *tbl, rb_id_table_foreach_func_t *fu
 void rb_id_table_foreach_values(struct rb_id_table *tbl, rb_id_table_foreach_values_func_t *func, void *data);
 void rb_id_table_foreach_values_with_replace(struct rb_id_table *tbl, rb_id_table_foreach_values_func_t *func, rb_id_table_update_value_callback_func_t *replace, void *data);
 
+VALUE rb_managed_id_table_create(const rb_data_type_t *type, size_t capa);
 VALUE rb_managed_id_table_new(size_t capa);
 VALUE rb_managed_id_table_dup(VALUE table);
 int rb_managed_id_table_insert(VALUE table, ID id, VALUE val);
 int rb_managed_id_table_lookup(VALUE table, ID id, VALUE *valp);
 size_t rb_managed_id_table_size(VALUE table);
 void rb_managed_id_table_foreach(VALUE table, rb_id_table_foreach_func_t *func, void *data);
+void rb_managed_id_table_foreach_values(VALUE table, rb_id_table_foreach_values_func_t *func, void *data);
+int rb_managed_id_table_delete(VALUE table, ID id);
+
+extern const rb_data_type_t rb_managed_id_table_type;
 
 RUBY_SYMBOL_EXPORT_BEGIN
 size_t rb_id_table_size(const struct rb_id_table *tbl);

--- a/imemo.c
+++ b/imemo.c
@@ -550,26 +550,6 @@ rb_vm_ccs_free(struct rb_class_cc_entries *ccs)
     vm_ccs_free(ccs, true, Qundef);
 }
 
-static enum rb_id_table_iterator_result
-cc_tbl_free_i(VALUE ccs_ptr, void *data)
-{
-    struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_ptr;
-    VALUE klass = (VALUE)data;
-    VM_ASSERT(vm_ccs_p(ccs));
-
-    vm_ccs_free(ccs, false, klass);
-
-    return ID_TABLE_CONTINUE;
-}
-
-void
-rb_cc_tbl_free(struct rb_id_table *cc_tbl, VALUE klass)
-{
-    if (!cc_tbl) return;
-    rb_id_table_foreach_values(cc_tbl, cc_tbl_free_i, (void *)klass);
-    rb_id_table_free(cc_tbl);
-}
-
 static inline void
 imemo_fields_free(struct rb_fields *fields)
 {

--- a/internal/class.h
+++ b/internal/class.h
@@ -83,7 +83,7 @@ struct rb_classext_struct {
     struct rb_id_table *m_tbl;
     struct rb_id_table *const_tbl;
     struct rb_id_table *callable_m_tbl;
-    struct rb_id_table *cc_tbl; /* ID -> [[ci1, cc1], [ci2, cc2] ...] */
+    VALUE cc_tbl; /* { ID => { cme, [cc1, cc2, ...] }, ... } */
     struct rb_id_table *cvc_tbl;
     VALUE *superclasses;
     /**
@@ -262,7 +262,7 @@ static inline void RCLASS_WRITE_SUPER(VALUE klass, VALUE super);
 static inline void RCLASS_SET_CONST_TBL(VALUE klass, struct rb_id_table *table, bool shared);
 static inline void RCLASS_WRITE_CONST_TBL(VALUE klass, struct rb_id_table *table, bool shared);
 static inline void RCLASS_WRITE_CALLABLE_M_TBL(VALUE klass, struct rb_id_table *table);
-static inline void RCLASS_WRITE_CC_TBL(VALUE klass, struct rb_id_table *table);
+static inline void RCLASS_WRITE_CC_TBL(VALUE klass, VALUE table);
 static inline void RCLASS_SET_CVC_TBL(VALUE klass, struct rb_id_table *table);
 static inline void RCLASS_WRITE_CVC_TBL(VALUE klass, struct rb_id_table *table);
 
@@ -628,9 +628,9 @@ RCLASS_WRITE_CALLABLE_M_TBL(VALUE klass, struct rb_id_table *table)
 }
 
 static inline void
-RCLASS_WRITE_CC_TBL(VALUE klass, struct rb_id_table *table)
+RCLASS_WRITE_CC_TBL(VALUE klass, VALUE table)
 {
-    RCLASSEXT_CC_TBL(RCLASS_EXT_WRITABLE(klass)) = table;
+    RB_OBJ_WRITE(klass, &RCLASSEXT_CC_TBL(RCLASS_EXT_WRITABLE(klass)), table);
 }
 
 static inline void

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -148,7 +148,6 @@ static inline void MEMO_V2_SET(struct MEMO *m, VALUE v);
 
 size_t rb_imemo_memsize(VALUE obj);
 void rb_imemo_mark_and_move(VALUE obj, bool reference_updating);
-void rb_cc_tbl_free(struct rb_id_table *cc_tbl, VALUE klass);
 void rb_imemo_free(VALUE obj);
 
 RUBY_SYMBOL_EXPORT_BEGIN

--- a/iseq.c
+++ b/iseq.c
@@ -325,15 +325,13 @@ cc_is_active(const struct rb_callcache *cc, bool reference_updating)
             cc = (const struct rb_callcache *)rb_gc_location((VALUE)cc);
         }
 
-        if (vm_cc_markable(cc)) {
-            if (cc->klass) { // cc is not invalidated
-                const struct rb_callable_method_entry_struct *cme = vm_cc_cme(cc);
-                if (reference_updating) {
-                    cme = (const struct rb_callable_method_entry_struct *)rb_gc_location((VALUE)cme);
-                }
-                if (!METHOD_ENTRY_INVALIDATED(cme)) {
-                    return true;
-                }
+        if (vm_cc_markable(cc) && vm_cc_valid(cc)) {
+            const struct rb_callable_method_entry_struct *cme = vm_cc_cme(cc);
+            if (reference_updating) {
+                cme = (const struct rb_callable_method_entry_struct *)rb_gc_location((VALUE)cme);
+            }
+            if (!METHOD_ENTRY_INVALIDATED(cme)) {
+                return true;
             }
         }
     }

--- a/method.h
+++ b/method.h
@@ -259,6 +259,6 @@ void rb_vm_delete_cc_refinement(const struct rb_callcache *cc);
 
 void rb_clear_method_cache(VALUE klass_or_module, ID mid);
 void rb_clear_all_refinement_method_cache(void);
-void rb_invalidate_method_caches(struct rb_id_table *cm_tbl, struct rb_id_table *cc_tbl);
+void rb_invalidate_method_caches(struct rb_id_table *cm_tbl, VALUE cc_tbl);
 
 #endif /* RUBY_METHOD_H */

--- a/vm.c
+++ b/vm.c
@@ -607,7 +607,7 @@ rb_serial_t ruby_vm_global_cvar_state = 1;
 
 static const struct rb_callcache vm_empty_cc = {
     .flags = T_IMEMO | (imemo_callcache << FL_USHIFT) | VM_CALLCACHE_UNMARKABLE,
-    .klass = Qfalse,
+    .klass = Qundef,
     .cme_  = NULL,
     .call_ = vm_call_general,
     .aux_  = {
@@ -617,7 +617,7 @@ static const struct rb_callcache vm_empty_cc = {
 
 static const struct rb_callcache vm_empty_cc_for_super = {
     .flags = T_IMEMO | (imemo_callcache << FL_USHIFT) | VM_CALLCACHE_UNMARKABLE,
-    .klass = Qfalse,
+    .klass = Qundef,
     .cme_  = NULL,
     .call_ = vm_call_super_method,
     .aux_  = {

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -279,9 +279,7 @@ struct rb_callcache {
     const VALUE flags;
 
     /* inline cache: key */
-    const VALUE klass; // should not mark it because klass can not be free'd
-                       // because of this marking. When klass is collected,
-                       // cc will be cleared (cc->klass = 0) at vm_ccs_free().
+    const VALUE klass; // Weak reference. When klass is collected, `cc->klass = Qundef`.
 
     /* inline cache: values */
     const struct rb_callable_method_entry_struct * const cme_;
@@ -324,12 +322,20 @@ vm_cc_attr_index_initialize(const struct rb_callcache *cc, shape_id_t shape_id)
     vm_cc_attr_index_set(cc, (attr_index_t)-1, shape_id);
 }
 
+static inline VALUE
+cc_check_class(VALUE klass)
+{
+    VM_ASSERT(klass == Qundef || RB_TYPE_P(klass, T_CLASS) || RB_TYPE_P(klass, T_ICLASS));
+    return klass;
+}
+
 static inline const struct rb_callcache *
 vm_cc_new(VALUE klass,
           const struct rb_callable_method_entry_struct *cme,
           vm_call_handler call,
           enum vm_cc_type type)
 {
+    cc_check_class(klass);
     struct rb_callcache *cc = IMEMO_NEW(struct rb_callcache, imemo_callcache, klass);
     *((struct rb_callable_method_entry_struct **)&cc->cme_) = (struct rb_callable_method_entry_struct *)cme;
     *((vm_call_handler *)&cc->call_) = call;
@@ -374,7 +380,7 @@ vm_cc_refinement_p(const struct rb_callcache *cc)
             (imemo_callcache << FL_USHIFT) |  \
             VM_CALLCACHE_UNMARKABLE |         \
             VM_CALLCACHE_ON_STACK,            \
-        .klass = clazz,                       \
+        .klass = cc_check_class(clazz),       \
         .cme_  = cme,                         \
         .call_ = call,                        \
         .aux_  = aux,                         \
@@ -384,8 +390,7 @@ static inline bool
 vm_cc_class_check(const struct rb_callcache *cc, VALUE klass)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
-    VM_ASSERT(cc->klass == 0 ||
-              RB_TYPE_P(cc->klass, T_CLASS) || RB_TYPE_P(cc->klass, T_ICLASS));
+    VM_ASSERT(cc_check_class(cc->klass));
     return cc->klass == klass;
 }
 
@@ -394,6 +399,15 @@ vm_cc_markable(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
     return FL_TEST_RAW((VALUE)cc, VM_CALLCACHE_UNMARKABLE) == 0;
+}
+
+static inline bool
+vm_cc_valid(const struct rb_callcache *cc)
+{
+    VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
+    VM_ASSERT(cc_check_class(cc->klass));
+
+    return !UNDEF_P(cc->klass);
 }
 
 static inline const struct rb_callable_method_entry_struct *
@@ -447,7 +461,7 @@ vm_cc_cmethod_missing_reason(const struct rb_callcache *cc)
 static inline bool
 vm_cc_invalidated_p(const struct rb_callcache *cc)
 {
-    if (cc->klass && !METHOD_ENTRY_INVALIDATED(vm_cc_cme(cc))) {
+    if (vm_cc_valid(cc) && !METHOD_ENTRY_INVALIDATED(vm_cc_cme(cc))) {
         return false;
     }
     else {
@@ -543,9 +557,9 @@ vm_cc_invalidate(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
     VM_ASSERT(cc != vm_cc_empty());
-    VM_ASSERT(cc->klass != 0); // should be enable
+    VM_ASSERT(cc->klass != Qundef); // should be enable
 
-    *(VALUE *)&cc->klass = 0;
+    *(VALUE *)&cc->klass = Qundef;
     RB_DEBUG_COUNTER_INC(cc_ent_invalidate);
 }
 

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -329,6 +329,8 @@ cc_check_class(VALUE klass)
     return klass;
 }
 
+VALUE rb_vm_cc_table_create(size_t capa);
+
 static inline const struct rb_callcache *
 vm_cc_new(VALUE klass,
           const struct rb_callable_method_entry_struct *cme,

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -57,7 +57,7 @@ static inline VALUE vm_call0_cc(rb_execution_context_t *ec, VALUE recv, ID id, i
 VALUE
 rb_vm_call0(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE *argv, const rb_callable_method_entry_t *cme, int kw_splat)
 {
-    const struct rb_callcache cc = VM_CC_ON_STACK(Qfalse, vm_call_general, {{ 0 }}, cme);
+    const struct rb_callcache cc = VM_CC_ON_STACK(Qundef, vm_call_general, {{ 0 }}, cme);
     return vm_call0_cc(ec, recv, id, argc, argv, &cc, kw_splat);
 }
 
@@ -104,7 +104,7 @@ vm_call0_cc(rb_execution_context_t *ec, VALUE recv, ID id, int argc, const VALUE
 static VALUE
 vm_call0_cme(rb_execution_context_t *ec, struct rb_calling_info *calling, const VALUE *argv, const rb_callable_method_entry_t *cme)
 {
-    calling->cc = &VM_CC_ON_STACK(Qfalse, vm_call_general, {{ 0 }}, cme);
+    calling->cc = &VM_CC_ON_STACK(Qundef, vm_call_general, {{ 0 }}, cme);
     return vm_call0_body(ec, calling, argv);
 }
 

--- a/vm_method.c
+++ b/vm_method.c
@@ -409,7 +409,7 @@ invalidate_cc_refinement(st_data_t key, st_data_t data)
 
         VM_ASSERT(vm_cc_refinement_p(cc));
 
-        if (cc->klass) {
+        if (vm_cc_valid(cc)) {
             vm_cc_invalidate(cc);
         }
     }

--- a/vm_method.c
+++ b/vm_method.c
@@ -22,6 +22,126 @@ static inline rb_method_entry_t *lookup_method_table(VALUE klass, ID id);
 #define ruby_running (GET_VM()->running)
 /* int ruby_running = 0; */
 
+static void
+vm_ccs_free(struct rb_class_cc_entries *ccs)
+{
+    if (ccs->entries) {
+        ruby_xfree(ccs->entries);
+    }
+    ruby_xfree(ccs);
+}
+
+static enum rb_id_table_iterator_result
+mark_cc_entry_i(VALUE ccs_ptr, void *data)
+{
+    struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_ptr;
+
+    VM_ASSERT(vm_ccs_p(ccs));
+
+    if (METHOD_ENTRY_INVALIDATED(ccs->cme)) {
+        vm_ccs_free(ccs);
+        return ID_TABLE_DELETE;
+    }
+    else {
+        rb_gc_mark_movable((VALUE)ccs->cme);
+
+        for (int i=0; i<ccs->len; i++) {
+            VM_ASSERT(vm_cc_check_cme(ccs->entries[i].cc, ccs->cme));
+
+            rb_gc_mark_movable((VALUE)ccs->entries[i].cc);
+        }
+        return ID_TABLE_CONTINUE;
+    }
+}
+
+static void
+vm_cc_table_mark(void *data)
+{
+    struct rb_id_table *tbl = (struct rb_id_table *)data;
+    if (tbl) {
+        rb_id_table_foreach_values(tbl, mark_cc_entry_i, NULL);
+    }
+}
+
+static enum rb_id_table_iterator_result
+cc_table_free_i(VALUE ccs_ptr, void *data)
+{
+    struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_ptr;
+    VM_ASSERT(vm_ccs_p(ccs));
+
+    vm_ccs_free(ccs);
+
+    return ID_TABLE_CONTINUE;
+}
+
+static void
+vm_cc_table_free(void *data)
+{
+    struct rb_id_table *tbl = (struct rb_id_table *)data;
+
+    rb_id_table_foreach_values(tbl, cc_table_free_i, NULL);
+    rb_managed_id_table_type.function.dfree(data);
+}
+
+static enum rb_id_table_iterator_result
+cc_table_memsize_i(VALUE ccs_ptr, void *data_ptr)
+{
+    size_t *total_size = data_ptr;
+    struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_ptr;
+    *total_size += sizeof(*ccs);
+    *total_size += sizeof(ccs->entries[0]) * ccs->capa;
+    return ID_TABLE_CONTINUE;
+}
+
+static size_t
+vm_cc_table_memsize(const void *data)
+{
+    size_t memsize = rb_managed_id_table_type.function.dsize(data);
+    struct rb_id_table *tbl = (struct rb_id_table *)data;
+    rb_id_table_foreach_values(tbl, cc_table_memsize_i, &memsize);
+    return memsize;
+}
+
+static enum rb_id_table_iterator_result
+compact_cc_entry_i(VALUE ccs_ptr, void *data)
+{
+    struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_ptr;
+
+    ccs->cme = (const struct rb_callable_method_entry_struct *)rb_gc_location((VALUE)ccs->cme);
+    VM_ASSERT(vm_ccs_p(ccs));
+
+    for (int i=0; i<ccs->len; i++) {
+        ccs->entries[i].cc = (const struct rb_callcache *)rb_gc_location((VALUE)ccs->entries[i].cc);
+    }
+
+    return ID_TABLE_CONTINUE;
+}
+
+static void
+vm_cc_table_compact(void *data)
+{
+    struct rb_id_table *tbl = (struct rb_id_table *)data;
+    rb_id_table_foreach_values(tbl, compact_cc_entry_i, NULL);
+}
+
+static const rb_data_type_t cc_table_type = {
+    .wrap_struct_name = "VM/cc_table",
+    .function = {
+        .dmark = vm_cc_table_mark,
+        .dfree = vm_cc_table_free,
+        .dsize = vm_cc_table_memsize,
+        .dcompact = vm_cc_table_compact,
+    },
+    .parent = &rb_managed_id_table_type,
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE,
+};
+
+VALUE
+rb_vm_cc_table_create(size_t capa)
+{
+    return rb_managed_id_table_create(&cc_table_type, capa);
+}
+
 static enum rb_id_table_iterator_result
 vm_ccs_dump_i(ID mid, VALUE val, void *data)
 {
@@ -39,18 +159,18 @@ vm_ccs_dump_i(ID mid, VALUE val, void *data)
 static void
 vm_ccs_dump(VALUE klass, ID target_mid)
 {
-    struct rb_id_table *cc_tbl = RCLASS_WRITABLE_CC_TBL(klass);
+    VALUE cc_tbl = RCLASS_WRITABLE_CC_TBL(klass);
     if (cc_tbl) {
         VALUE ccs;
         if (target_mid) {
-            if (rb_id_table_lookup(cc_tbl, target_mid, &ccs)) {
+            if (rb_managed_id_table_lookup(cc_tbl, target_mid, &ccs)) {
                 fprintf(stderr, "  [CCTB] %p\n", (void *)cc_tbl);
                 vm_ccs_dump_i(target_mid, ccs, NULL);
             }
         }
         else {
             fprintf(stderr, "  [CCTB] %p\n", (void *)cc_tbl);
-            rb_id_table_foreach(cc_tbl, vm_ccs_dump_i, (void *)target_mid);
+            rb_managed_id_table_foreach(cc_tbl, vm_ccs_dump_i, (void *)target_mid);
         }
     }
 }
@@ -169,15 +289,15 @@ static const rb_callable_method_entry_t *complemented_callable_method_entry(VALU
 static const rb_callable_method_entry_t *lookup_overloaded_cme(const rb_callable_method_entry_t *cme);
 
 static void
-invalidate_method_cache_in_cc_table(struct rb_id_table *tbl, ID mid)
+invalidate_method_cache_in_cc_table(VALUE tbl, ID mid)
 {
     VALUE ccs_data;
-    if (tbl && rb_id_table_lookup(tbl, mid, &ccs_data)) {
+    if (tbl && rb_managed_id_table_lookup(tbl, mid, &ccs_data)) {
         struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_data;
         rb_yjit_cme_invalidate((rb_callable_method_entry_t *)ccs->cme);
         if (NIL_P(ccs->cme->owner)) invalidate_negative_cache(mid);
         rb_vm_ccs_free(ccs);
-        rb_id_table_delete(tbl, mid);
+        rb_managed_id_table_delete(tbl, mid);
         RB_DEBUG_COUNTER_INC(cc_invalidate_leaf_ccs);
     }
 }
@@ -253,7 +373,7 @@ clear_method_cache_by_id_in_class(VALUE klass, ID mid)
             // check only current class
 
             // invalidate CCs
-            struct rb_id_table *cc_tbl = RCLASS_WRITABLE_CC_TBL(klass);
+            VALUE cc_tbl = RCLASS_WRITABLE_CC_TBL(klass);
             invalidate_method_cache_in_cc_table(cc_tbl, mid);
             if (RCLASS_CC_TBL_NOT_PRIME_P(klass, cc_tbl)) {
                 invalidate_method_cache_in_cc_table(RCLASS_PRIME_CC_TBL(klass), mid);
@@ -385,13 +505,13 @@ invalidate_ccs_in_iclass_cc_tbl(VALUE value, void *data)
 }
 
 void
-rb_invalidate_method_caches(struct rb_id_table *cm_tbl, struct rb_id_table *cc_tbl)
+rb_invalidate_method_caches(struct rb_id_table *cm_tbl, VALUE cc_tbl)
 {
     if (cm_tbl) {
         rb_id_table_foreach_values(cm_tbl, invalidate_method_entry_in_iclass_callable_m_tbl, NULL);
     }
     if (cc_tbl) {
-        rb_id_table_foreach_values(cc_tbl, invalidate_ccs_in_iclass_cc_tbl, NULL);
+        rb_managed_id_table_foreach_values(cc_tbl, invalidate_ccs_in_iclass_cc_tbl, NULL);
     }
 }
 
@@ -1559,10 +1679,10 @@ cached_callable_method_entry(VALUE klass, ID mid)
 {
     ASSERT_vm_locking();
 
-    struct rb_id_table *cc_tbl = RCLASS_WRITABLE_CC_TBL(klass);
+    VALUE cc_tbl = RCLASS_WRITABLE_CC_TBL(klass);
     VALUE ccs_data;
 
-    if (cc_tbl && rb_id_table_lookup(cc_tbl, mid, &ccs_data)) {
+    if (cc_tbl && rb_managed_id_table_lookup(cc_tbl, mid, &ccs_data)) {
         struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_data;
         VM_ASSERT(vm_ccs_p(ccs));
 
@@ -1573,7 +1693,7 @@ cached_callable_method_entry(VALUE klass, ID mid)
         }
         else {
             rb_vm_ccs_free(ccs);
-            rb_id_table_delete(cc_tbl, mid);
+            rb_managed_id_table_delete(cc_tbl, mid);
         }
     }
 
@@ -1587,15 +1707,15 @@ cache_callable_method_entry(VALUE klass, ID mid, const rb_callable_method_entry_
     ASSERT_vm_locking();
     VM_ASSERT(cme != NULL);
 
-    struct rb_id_table *cc_tbl = RCLASS_WRITABLE_CC_TBL(klass);
+    VALUE cc_tbl = RCLASS_WRITABLE_CC_TBL(klass);
     VALUE ccs_data;
 
     if (!cc_tbl) {
-        cc_tbl = rb_id_table_create(2);
+        cc_tbl = rb_vm_cc_table_create(2);
         RCLASS_WRITE_CC_TBL(klass, cc_tbl);
     }
 
-    if (rb_id_table_lookup(cc_tbl, mid, &ccs_data)) {
+    if (rb_managed_id_table_lookup(cc_tbl, mid, &ccs_data)) {
 #if VM_CHECK_MODE > 0
         struct rb_class_cc_entries *ccs = (struct rb_class_cc_entries *)ccs_data;
         VM_ASSERT(ccs->cme == cme);


### PR DESCRIPTION
This PR is composed of three commits for easier review.

One of the biggest remaining contention point is `RClass.cc_table`. The logical solution is to turn it into a managed object, so we can use an RCU strategy, given it is expected to be read heavy.

However, that's not currently possible because the table can't be freed before the owning class, given the class free function MUST go over all the CC entries to invalidate them. By relying on `rb_gc_mark_weak`, we can break this dependency. However this means that `cc.klass` now defaults to `Qundef` instead of `Qfalse`.

The second commit turns `RClass.cc_tbl` into a managed object. It's a sub-type of `rb_managed_id_table`, and is in change of freeing the `rb_class_cc_entries`.

Then the third commit refactor `vm_lookup_cc` to be lock-free on the happy path. We still lock the VM when we need to evict an invalidated CC, and when we miss. When in single Ractor mode, we still directly mutate the `cc_tbl`, however in multi-ractor mode, we first deep-dup it, modify it, and then atomically swap it.

There are a number of small optimizations that could be done on the slowpath, but I chose to try to keep the PR as simple as possible to ease the review.