### PR TITLE
ZJIT: Create delta debugging script to narrow JIT failures

### DIFF
--- a/tool/zjit_bisect.rb
+++ b/tool/zjit_bisect.rb
@@ -1,0 +1,97 @@
+#!/usr/bin/env ruby
+require 'logger'
+require 'open3'
+require 'tempfile'
+require 'timeout'
+
+RUBY = ARGV[0] || raise("Usage: ruby jit_bisect.rb <path_to_ruby> <options>")
+OPTIONS = ARGV[1] || raise("Usage: ruby jit_bisect.rb <path_to_ruby> <options>")
+TIMEOUT_SEC = 5
+LOGGER = Logger.new($stdout)
+
+# From https://github.com/tekknolagi/omegastar
+# MIT License
+# Copyright (c) 2024 Maxwell Bernstein and Meta Platforms
+# Attempt to reduce the `items` argument as much as possible, returning the
+# shorter version. `fixed` will always be used as part of the items when
+# running `command`.
+# `command` should return True if the command succeeded (the failure did not
+# reproduce) and False if the command failed (the failure reproduced).
+def bisect_impl(command, fixed, items, indent="")
+  LOGGER.info("#{indent}step fixed[#{fixed.length}] and items[#{items.length}]")
+  while items.length > 1
+    LOGGER.info("#{indent}#{fixed.length + items.length} candidates")
+    # Return two halves of the given list. For odd-length lists, the second
+    # half will be larger.
+    half = items.length / 2
+    left = items[0...half]
+    right = items[half..]
+    if !command.call(fixed + left)
+      items = left
+      next
+    end
+    if !command.call(fixed + right)
+      items = right
+      next
+    end
+    # We need something from both halves to trigger the failure. Try
+    # holding each half fixed and bisecting the other half to reduce the
+    # candidates.
+    new_right = bisect_impl(command, fixed + left, right, indent + "< ")
+    new_left = bisect_impl(command, fixed + new_right, left, indent + "> ")
+    return new_left + new_right
+  end
+  items
+end
+
+# From https://github.com/tekknolagi/omegastar
+# MIT License
+# Copyright (c) 2024 Maxwell Bernstein and Meta Platforms
+def run_bisect(command, items)
+  LOGGER.info("Verifying items")
+  if command.call(items)
+    raise StandardError.new("Command succeeded with full items")
+  end
+  if !command.call([])
+    raise StandardError.new("Command failed with empty items")
+  end
+  bisect_impl(command, [], items)
+end
+
+def run_with_jit_list(ruby, options, jit_list)
+  # Make a new temporary file containing the JIT list
+  Tempfile.create("jit_list") do |temp_file|
+    temp_file.write(jit_list.join("\n"))
+    temp_file.flush
+    temp_file.close
+    # Run the JIT with the temporary file
+    Open3.capture3("#{ruby} --zjit-allowed-iseqs=#{temp_file.path} #{options}")
+  end
+end
+
+# Try running with no JIT list to get a stable baseline
+_, stderr, status = run_with_jit_list(RUBY, OPTIONS, [])
+if !status.success?
+  raise "Command failed with empty JIT list: #{stderr}"
+end
+# Collect the JIT list from the failing Ruby process
+jit_list = nil
+Tempfile.create "jit_list" do |temp_file|
+  Open3.capture3("#{RUBY} --zjit-log-compiled-iseqs=#{temp_file.path} #{OPTIONS}")
+  jit_list = File.readlines(temp_file.path).map(&:strip).reject(&:empty?)
+end
+LOGGER.info("Starting with JIT list of #{jit_list.length} items.")
+# Now narrow it down
+command = lambda do |items|
+  status = Timeout.timeout(TIMEOUT_SEC) do
+    _, _, status = run_with_jit_list(RUBY, OPTIONS, items)
+    status
+  end
+  status.success?
+end
+result = run_bisect(command, jit_list)
+File.open("jitlist.txt", "w") do |file|
+  file.puts(result)
+end
+puts "Reduced JIT list (available in jitlist.txt):"
+puts result

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -284,6 +284,10 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, function: &Function) -> Optio
             let iseq_name = iseq_get_location(iseq, 0);
             register_with_perf(iseq_name, start_usize, code_size);
         }
+        if ZJITState::should_log_compiled_iseqs() {
+            let iseq_name = iseq_get_location(iseq, 0);
+            ZJITState::log_compile(iseq_name);
+        }
     }
     result
 }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2480,6 +2480,7 @@ pub enum ParseError {
     UnknownParameterType(ParameterType),
     MalformedIseq(u32), // insn_idx into iseq_encoded
     Validation(ValidationError),
+    NotAllowed,
 }
 
 /// Return the number of locals in the current ISEQ (includes parameters)
@@ -2545,6 +2546,9 @@ fn filter_unknown_parameter_type(iseq: *const rb_iseq_t) -> Result<(), ParseErro
 
 /// Compile ISEQ into High-level IR
 pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
+    if !ZJITState::can_compile_iseq(iseq) {
+        return Err(ParseError::NotAllowed);
+    }
     filter_unknown_parameter_type(iseq)?;
     let payload = get_or_create_iseq_payload(iseq);
     let mut profiles = ProfileOracle::new(payload);


### PR DESCRIPTION
Add support for `--zjit-allowed-iseqs=SomeFile` and
`--zjit-save-compiled-iseqs=SomeFile` so we can restrict and inspect
which ISEQs get compiled.

Then add `jit_bisect.rb` which we can run to try and narrow a failing
script. For example:

    plum% ./jit_bisect.rb ../build-dev/miniruby "test.rb"
    I, [2025-07-29T12:41:18.657177 #96899]  INFO -- : Starting with JIT list of 4 items.
    I, [2025-07-29T12:41:18.657229 #96899]  INFO -- : Verifying items
    I, [2025-07-29T12:41:18.726213 #96899]  INFO -- : step fixed[0] and items[4]
    I, [2025-07-29T12:41:18.726246 #96899]  INFO -- : 4 candidates
    I, [2025-07-29T12:41:18.797212 #96899]  INFO -- : 2 candidates
    Reduced JIT list:
    bar@test.rb:8
    plum%

We start with 4 compiled functions and shrink to just one.