### PR TITLE
ZJIT: Catch more failed recursive compilations

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -120,20 +120,24 @@ fn gen_iseq_entry_point_body(cb: &mut CodeBlock, iseq: IseqPtr) -> *const u8 {
     };
 
     // Compile the High-level IR
-    let (start_ptr, mut branch_iseqs) = match gen_function(cb, iseq, &function) {
+    let (start_ptr, gc_offsets, mut branch_iseqs) = match gen_function(cb, iseq, &function) {
         Some((start_ptr, gc_offsets, jit)) => {
-            // Remember the block address to reuse it later
-            let payload = get_or_create_iseq_payload(iseq);
-            payload.start_ptr = Some(start_ptr);
-            append_gc_offsets(iseq, &gc_offsets);
-
             // Compile an entry point to the JIT code
-            (gen_entry(cb, iseq, &function, start_ptr), jit.branch_iseqs)
+            if let Some(ptr) = gen_entry(cb, iseq, &function, start_ptr) {
+                (ptr, gc_offsets, jit.branch_iseqs)
+            } else {
+                debug!("Failed to compile iseq: gen_entry failed: {}", iseq_get_location(iseq, 0));
+                return std::ptr::null();
+            }
         },
-        None => (None, vec![]),
+        None => {
+            debug!("Failed to compile iseq: gen_function failed: {}", iseq_get_location(iseq, 0));
+            return std::ptr::null();
+        }
     };
 
     // Recursively compile callee ISEQs
+    let caller_iseq = iseq;
     while let Some((branch, iseq)) = branch_iseqs.pop() {
         // Disable profiling. This will be the last use of the profiling information for the ISEQ.
         unsafe { rb_zjit_profile_disable(iseq); }
@@ -147,12 +151,19 @@ fn gen_iseq_entry_point_body(cb: &mut CodeBlock, iseq: IseqPtr) -> *const u8 {
             branch_iseqs.extend(callee_branch_iseqs);
         } else {
             // Failed to compile the callee. Bail out of compiling this graph of ISEQs.
+            debug!("Failed to compile iseq: could not compile callee: {} -> {}",
+                   iseq_get_location(caller_iseq, 0), iseq_get_location(iseq, 0));
             return std::ptr::null();
         }
     }
 
-    // Return a JIT code address or a null pointer
-    start_ptr.map(|start_ptr| start_ptr.raw_ptr(cb)).unwrap_or(std::ptr::null())
+    // Remember the block address to reuse it later
+    let payload = get_or_create_iseq_payload(iseq);
+    payload.start_ptr = Some(start_ptr);
+    append_gc_offsets(iseq, &gc_offsets);
+
+    // Return a JIT code address
+    start_ptr.raw_ptr(cb)
 }
 
 /// Write an entry to the perf map in /tmp
@@ -1161,7 +1172,8 @@ fn compile_iseq(iseq: IseqPtr) -> Option<Function> {
     let mut function = match iseq_to_hir(iseq) {
         Ok(function) => function,
         Err(err) => {
-            debug!("ZJIT: iseq_to_hir: {err:?}");
+            let name = crate::cruby::iseq_get_location(iseq, 0);
+            debug!("ZJIT: iseq_to_hir: {err:?}: {name}");
             return None;
         }
     };

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -120,13 +120,13 @@ fn gen_iseq_entry_point_body(cb: &mut CodeBlock, iseq: IseqPtr) -> *const u8 {
     };
 
     // Compile the High-level IR
-    let Some((inner_ptr, gc_offsets, jit)) = gen_function(cb, iseq, &function) else {
+    let Some((start_ptr, gc_offsets, jit)) = gen_function(cb, iseq, &function) else {
         debug!("Failed to compile iseq: gen_function failed: {}", iseq_get_location(iseq, 0));
         return std::ptr::null();
     };
 
     // Compile an entry point to the JIT code
-    let Some(start_ptr) = gen_entry(cb, iseq, &function, inner_ptr) else {
+    let Some(entry_ptr) = gen_entry(cb, iseq, &function, start_ptr) else {
         debug!("Failed to compile iseq: gen_entry failed: {}", iseq_get_location(iseq, 0));
         return std::ptr::null();
     };
@@ -159,7 +159,7 @@ fn gen_iseq_entry_point_body(cb: &mut CodeBlock, iseq: IseqPtr) -> *const u8 {
     append_gc_offsets(iseq, &gc_offsets);
 
     // Return a JIT code address
-    start_ptr.raw_ptr(cb)
+    entry_ptr.raw_ptr(cb)
 }
 
 /// Write an entry to the perf map in /tmp

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2474,6 +2474,7 @@ pub enum ParseError {
     UnknownParameterType(ParameterType),
     MalformedIseq(u32), // insn_idx into iseq_encoded
     Validation(ValidationError),
+    NotAllowed,
 }
 
 /// Return the number of locals in the current ISEQ (includes parameters)

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2474,7 +2474,6 @@ pub enum ParseError {
     UnknownParameterType(ParameterType),
     MalformedIseq(u32), // insn_idx into iseq_encoded
     Validation(ValidationError),
-    NotAllowed,
 }
 
 /// Return the number of locals in the current ISEQ (includes parameters)


### PR DESCRIPTION
Untangle the logic a bit and specifically:

* catch `gen_entry` failures
* don't set `start_ptr` until all recursive calls succeed

Co-authored-by: Alan Wu <alanwu@ruby-lang.org>