### PR TITLE
Fix indents in Onigmo files to use spaces instead of tabs

### DIFF
--- a/regcomp.c
+++ b/regcomp.c
@@ -640,17 +640,17 @@ compile_cclass_node(CClassNode* cc, regex_t* reg)
   else {
     if (ONIGENC_MBC_MINLEN(reg->enc) > 1 || bitset_is_empty(cc->bs)) {
       if (IS_NCCLASS_NOT(cc))
-	add_opcode(reg, OP_CCLASS_MB_NOT);
+        add_opcode(reg, OP_CCLASS_MB_NOT);
       else
-	add_opcode(reg, OP_CCLASS_MB);
+        add_opcode(reg, OP_CCLASS_MB);
 
       r = add_multi_byte_cclass(cc->mbuf, reg);
     }
     else {
       if (IS_NCCLASS_NOT(cc))
-	add_opcode(reg, OP_CCLASS_MIX_NOT);
+        add_opcode(reg, OP_CCLASS_MIX_NOT);
       else
-	add_opcode(reg, OP_CCLASS_MIX);
+        add_opcode(reg, OP_CCLASS_MIX);
 
       r = add_bitset(reg, cc->bs);
       if (r) return r;
@@ -762,9 +762,9 @@ compile_length_quantifier_node(QtfrNode* qn, regex_t* reg)
   if (NTYPE(qn->target) == NT_CANY) {
     if (qn->greedy && infinite) {
       if (IS_NOT_NULL(qn->next_head_exact) && !CKN_ON)
-	return SIZE_OP_ANYCHAR_STAR_PEEK_NEXT + tlen * qn->lower + cklen;
+        return SIZE_OP_ANYCHAR_STAR_PEEK_NEXT + tlen * qn->lower + cklen;
       else
-	return SIZE_OP_ANYCHAR_STAR + tlen * qn->lower + cklen;
+        return SIZE_OP_ANYCHAR_STAR + tlen * qn->lower + cklen;
     }
   }
 
@@ -776,17 +776,17 @@ compile_length_quantifier_node(QtfrNode* qn, regex_t* reg)
   if (infinite && qn->lower <= 1) {
     if (qn->greedy) {
       if (qn->lower == 1)
-	len = SIZE_OP_JUMP;
+        len = SIZE_OP_JUMP;
       else
-	len = 0;
+        len = 0;
 
       len += SIZE_OP_PUSH + cklen + mod_tlen + SIZE_OP_JUMP;
     }
     else {
       if (qn->lower == 0)
-	len = SIZE_OP_JUMP;
+        len = SIZE_OP_JUMP;
       else
-	len = 0;
+        len = 0;
 
       len += mod_tlen + SIZE_OP_PUSH + cklen;
     }
@@ -800,10 +800,10 @@ compile_length_quantifier_node(QtfrNode* qn, regex_t* reg)
   else if (qn->upper == 1 && qn->greedy) {
     if (qn->lower == 0) {
       if (CKN_ON) {
-	len = SIZE_OP_STATE_CHECK_PUSH + tlen;
+        len = SIZE_OP_STATE_CHECK_PUSH + tlen;
       }
       else {
-	len = SIZE_OP_PUSH + tlen;
+        len = SIZE_OP_PUSH + tlen;
       }
     }
     else {
@@ -841,31 +841,31 @@ compile_quantifier_node(QtfrNode* qn, regex_t* reg)
     if (r) return r;
     if (IS_NOT_NULL(qn->next_head_exact) && !CKN_ON) {
       if (IS_MULTILINE(reg->options))
-	r = add_opcode(reg, OP_ANYCHAR_ML_STAR_PEEK_NEXT);
+        r = add_opcode(reg, OP_ANYCHAR_ML_STAR_PEEK_NEXT);
       else
-	r = add_opcode(reg, OP_ANYCHAR_STAR_PEEK_NEXT);
+        r = add_opcode(reg, OP_ANYCHAR_STAR_PEEK_NEXT);
       if (r) return r;
       if (CKN_ON) {
-	r = add_state_check_num(reg, ckn);
-	if (r) return r;
+        r = add_state_check_num(reg, ckn);
+        if (r) return r;
       }
 
       return add_bytes(reg, NSTR(qn->next_head_exact)->s, 1);
     }
     else {
       if (IS_MULTILINE(reg->options)) {
-	r = add_opcode(reg, (CKN_ON ?
-			       OP_STATE_CHECK_ANYCHAR_ML_STAR
-			     : OP_ANYCHAR_ML_STAR));
+        r = add_opcode(reg, (CKN_ON ?
+                               OP_STATE_CHECK_ANYCHAR_ML_STAR
+                             : OP_ANYCHAR_ML_STAR));
       }
       else {
-	r = add_opcode(reg, (CKN_ON ?
-			       OP_STATE_CHECK_ANYCHAR_STAR
-			     : OP_ANYCHAR_STAR));
+        r = add_opcode(reg, (CKN_ON ?
+                               OP_STATE_CHECK_ANYCHAR_STAR
+                             : OP_ANYCHAR_STAR));
       }
       if (r) return r;
       if (CKN_ON)
-	r = add_state_check_num(reg, ckn);
+        r = add_state_check_num(reg, ckn);
 
       return r;
     }
@@ -879,45 +879,45 @@ compile_quantifier_node(QtfrNode* qn, regex_t* reg)
   if (infinite && qn->lower <= 1) {
     if (qn->greedy) {
       if (qn->lower == 1) {
-	r = add_opcode_rel_addr(reg, OP_JUMP,
-			(CKN_ON ? SIZE_OP_STATE_CHECK_PUSH : SIZE_OP_PUSH));
-	if (r) return r;
+        r = add_opcode_rel_addr(reg, OP_JUMP,
+                        (CKN_ON ? SIZE_OP_STATE_CHECK_PUSH : SIZE_OP_PUSH));
+        if (r) return r;
       }
 
       if (CKN_ON) {
-	r = add_opcode(reg, OP_STATE_CHECK_PUSH);
-	if (r) return r;
-	r = add_state_check_num(reg, ckn);
-	if (r) return r;
-	r = add_rel_addr(reg, mod_tlen + SIZE_OP_JUMP);
+        r = add_opcode(reg, OP_STATE_CHECK_PUSH);
+        if (r) return r;
+        r = add_state_check_num(reg, ckn);
+        if (r) return r;
+        r = add_rel_addr(reg, mod_tlen + SIZE_OP_JUMP);
       }
       else {
-	r = add_opcode_rel_addr(reg, OP_PUSH, mod_tlen + SIZE_OP_JUMP);
+        r = add_opcode_rel_addr(reg, OP_PUSH, mod_tlen + SIZE_OP_JUMP);
       }
       if (r) return r;
       r = compile_tree_empty_check(qn->target, reg, empty_info);
       if (r) return r;
       r = add_opcode_rel_addr(reg, OP_JUMP,
-	      -(mod_tlen + (int )SIZE_OP_JUMP
-		+ (int )(CKN_ON ? SIZE_OP_STATE_CHECK_PUSH : SIZE_OP_PUSH)));
+              -(mod_tlen + (int )SIZE_OP_JUMP
+                + (int )(CKN_ON ? SIZE_OP_STATE_CHECK_PUSH : SIZE_OP_PUSH)));
     }
     else {
       if (qn->lower == 0) {
-	r = add_opcode_rel_addr(reg, OP_JUMP, mod_tlen);
-	if (r) return r;
+        r = add_opcode_rel_addr(reg, OP_JUMP, mod_tlen);
+        if (r) return r;
       }
       r = compile_tree_empty_check(qn->target, reg, empty_info);
       if (r) return r;
       if (CKN_ON) {
-	r = add_opcode(reg, OP_STATE_CHECK_PUSH_OR_JUMP);
-	if (r) return r;
-	r = add_state_check_num(reg, ckn);
-	if (r) return r;
-	r = add_rel_addr(reg,
-		 -(mod_tlen + (int )SIZE_OP_STATE_CHECK_PUSH_OR_JUMP));
+        r = add_opcode(reg, OP_STATE_CHECK_PUSH_OR_JUMP);
+        if (r) return r;
+        r = add_state_check_num(reg, ckn);
+        if (r) return r;
+        r = add_rel_addr(reg,
+                 -(mod_tlen + (int )SIZE_OP_STATE_CHECK_PUSH_OR_JUMP));
       }
       else
-	r = add_opcode_rel_addr(reg, OP_PUSH, -(mod_tlen + (int )SIZE_OP_PUSH));
+        r = add_opcode_rel_addr(reg, OP_PUSH, -(mod_tlen + (int )SIZE_OP_PUSH));
     }
   }
   else if (qn->upper == 0) {
@@ -932,14 +932,14 @@ compile_quantifier_node(QtfrNode* qn, regex_t* reg)
   else if (qn->upper == 1 && qn->greedy) {
     if (qn->lower == 0) {
       if (CKN_ON) {
-	r = add_opcode(reg, OP_STATE_CHECK_PUSH);
-	if (r) return r;
-	r = add_state_check_num(reg, ckn);
-	if (r) return r;
-	r = add_rel_addr(reg, tlen);
+        r = add_opcode(reg, OP_STATE_CHECK_PUSH);
+        if (r) return r;
+        r = add_state_check_num(reg, ckn);
+        if (r) return r;
+        r = add_rel_addr(reg, tlen);
       }
       else {
-	r = add_opcode_rel_addr(reg, OP_PUSH, tlen);
+        r = add_opcode_rel_addr(reg, OP_PUSH, tlen);
       }
       if (r) return r;
     }
@@ -991,9 +991,9 @@ compile_length_quantifier_node(QtfrNode* qn, regex_t* reg)
   if (NTYPE(qn->target) == NT_CANY) {
     if (qn->greedy && infinite) {
       if (IS_NOT_NULL(qn->next_head_exact))
-	return SIZE_OP_ANYCHAR_STAR_PEEK_NEXT + tlen * qn->lower;
+        return SIZE_OP_ANYCHAR_STAR_PEEK_NEXT + tlen * qn->lower;
       else
-	return SIZE_OP_ANYCHAR_STAR + tlen * qn->lower;
+        return SIZE_OP_ANYCHAR_STAR + tlen * qn->lower;
     }
   }
 
@@ -1014,13 +1014,13 @@ compile_length_quantifier_node(QtfrNode* qn, regex_t* reg)
     if (qn->greedy) {
 #ifdef USE_OP_PUSH_OR_JUMP_EXACT
       if (IS_NOT_NULL(qn->head_exact))
-	len += SIZE_OP_PUSH_OR_JUMP_EXACT1 + mod_tlen + SIZE_OP_JUMP;
+        len += SIZE_OP_PUSH_OR_JUMP_EXACT1 + mod_tlen + SIZE_OP_JUMP;
       else
 #endif
       if (IS_NOT_NULL(qn->next_head_exact))
-	len += SIZE_OP_PUSH_IF_PEEK_NEXT + mod_tlen + SIZE_OP_JUMP;
+        len += SIZE_OP_PUSH_IF_PEEK_NEXT + mod_tlen + SIZE_OP_JUMP;
       else
-	len += SIZE_OP_PUSH + mod_tlen + SIZE_OP_JUMP;
+        len += SIZE_OP_PUSH + mod_tlen + SIZE_OP_JUMP;
     }
     else
       len += SIZE_OP_JUMP + mod_tlen + SIZE_OP_PUSH;
@@ -1060,17 +1060,17 @@ compile_quantifier_node(QtfrNode* qn, regex_t* reg)
     if (r) return r;
     if (IS_NOT_NULL(qn->next_head_exact)) {
       if (IS_MULTILINE(reg->options))
-	r = add_opcode(reg, OP_ANYCHAR_ML_STAR_PEEK_NEXT);
+        r = add_opcode(reg, OP_ANYCHAR_ML_STAR_PEEK_NEXT);
       else
-	r = add_opcode(reg, OP_ANYCHAR_STAR_PEEK_NEXT);
+        r = add_opcode(reg, OP_ANYCHAR_STAR_PEEK_NEXT);
       if (r) return r;
       return add_bytes(reg, NSTR(qn->next_head_exact)->s, 1);
     }
     else {
       if (IS_MULTILINE(reg->options))
-	return add_opcode(reg, OP_ANYCHAR_ML_STAR);
+        return add_opcode(reg, OP_ANYCHAR_ML_STAR);
       else
-	return add_opcode(reg, OP_ANYCHAR_STAR);
+        return add_opcode(reg, OP_ANYCHAR_STAR);
     }
   }
 
@@ -1084,17 +1084,17 @@ compile_quantifier_node(QtfrNode* qn, regex_t* reg)
     if (qn->lower == 1 && tlen > QUANTIFIER_EXPAND_LIMIT_SIZE) {
       if (qn->greedy) {
 #ifdef USE_OP_PUSH_OR_JUMP_EXACT
-	if (IS_NOT_NULL(qn->head_exact))
-	  r = add_opcode_rel_addr(reg, OP_JUMP, SIZE_OP_PUSH_OR_JUMP_EXACT1);
-	else
+        if (IS_NOT_NULL(qn->head_exact))
+          r = add_opcode_rel_addr(reg, OP_JUMP, SIZE_OP_PUSH_OR_JUMP_EXACT1);
+        else
 #endif
-	if (IS_NOT_NULL(qn->next_head_exact))
-	  r = add_opcode_rel_addr(reg, OP_JUMP, SIZE_OP_PUSH_IF_PEEK_NEXT);
-	else
-	  r = add_opcode_rel_addr(reg, OP_JUMP, SIZE_OP_PUSH);
+        if (IS_NOT_NULL(qn->next_head_exact))
+          r = add_opcode_rel_addr(reg, OP_JUMP, SIZE_OP_PUSH_IF_PEEK_NEXT);
+        else
+          r = add_opcode_rel_addr(reg, OP_JUMP, SIZE_OP_PUSH);
       }
       else {
-	r = add_opcode_rel_addr(reg, OP_JUMP, SIZE_OP_JUMP);
+        r = add_opcode_rel_addr(reg, OP_JUMP, SIZE_OP_JUMP);
       }
       if (r) return r;
     }
@@ -1106,34 +1106,34 @@ compile_quantifier_node(QtfrNode* qn, regex_t* reg)
     if (qn->greedy) {
 #ifdef USE_OP_PUSH_OR_JUMP_EXACT
       if (IS_NOT_NULL(qn->head_exact)) {
-	r = add_opcode_rel_addr(reg, OP_PUSH_OR_JUMP_EXACT1,
-			     mod_tlen + SIZE_OP_JUMP);
-	if (r) return r;
-	add_bytes(reg, NSTR(qn->head_exact)->s, 1);
-	r = compile_tree_empty_check(qn->target, reg, empty_info);
-	if (r) return r;
-	r = add_opcode_rel_addr(reg, OP_JUMP,
-	-(mod_tlen + (int )SIZE_OP_JUMP + (int )SIZE_OP_PUSH_OR_JUMP_EXACT1));
+        r = add_opcode_rel_addr(reg, OP_PUSH_OR_JUMP_EXACT1,
+                             mod_tlen + SIZE_OP_JUMP);
+        if (r) return r;
+        add_bytes(reg, NSTR(qn->head_exact)->s, 1);
+        r = compile_tree_empty_check(qn->target, reg, empty_info);
+        if (r) return r;
+        r = add_opcode_rel_addr(reg, OP_JUMP,
+        -(mod_tlen + (int )SIZE_OP_JUMP + (int )SIZE_OP_PUSH_OR_JUMP_EXACT1));
       }
       else
 #endif
       if (IS_NOT_NULL(qn->next_head_exact)) {
-	r = add_opcode_rel_addr(reg, OP_PUSH_IF_PEEK_NEXT,
-				mod_tlen + SIZE_OP_JUMP);
-	if (r) return r;
-	add_bytes(reg, NSTR(qn->next_head_exact)->s, 1);
-	r = compile_tree_empty_check(qn->target, reg, empty_info);
-	if (r) return r;
-	r = add_opcode_rel_addr(reg, OP_JUMP,
+        r = add_opcode_rel_addr(reg, OP_PUSH_IF_PEEK_NEXT,
+                                mod_tlen + SIZE_OP_JUMP);
+        if (r) return r;
+        add_bytes(reg, NSTR(qn->next_head_exact)->s, 1);
+        r = compile_tree_empty_check(qn->target, reg, empty_info);
+        if (r) return r;
+        r = add_opcode_rel_addr(reg, OP_JUMP,
           -(mod_tlen + (int )SIZE_OP_JUMP + (int )SIZE_OP_PUSH_IF_PEEK_NEXT));
       }
       else {
-	r = add_opcode_rel_addr(reg, OP_PUSH, mod_tlen + SIZE_OP_JUMP);
-	if (r) return r;
-	r = compile_tree_empty_check(qn->target, reg, empty_info);
-	if (r) return r;
-	r = add_opcode_rel_addr(reg, OP_JUMP,
-		     -(mod_tlen + (int )SIZE_OP_JUMP + (int )SIZE_OP_PUSH));
+        r = add_opcode_rel_addr(reg, OP_PUSH, mod_tlen + SIZE_OP_JUMP);
+        if (r) return r;
+        r = compile_tree_empty_check(qn->target, reg, empty_info);
+        if (r) return r;
+        r = add_opcode_rel_addr(reg, OP_JUMP,
+                     -(mod_tlen + (int )SIZE_OP_JUMP + (int )SIZE_OP_PUSH));
       }
     }
     else {
@@ -1159,7 +1159,7 @@ compile_quantifier_node(QtfrNode* qn, regex_t* reg)
 
     for (i = 0; i < n; i++) {
       r = add_opcode_rel_addr(reg, OP_PUSH,
-			   (n - i) * tlen + (n - i - 1) * SIZE_OP_PUSH);
+                           (n - i) * tlen + (n - i - 1) * SIZE_OP_PUSH);
       if (r) return r;
       r = compile_tree(qn->target, reg);
       if (r) return r;
@@ -1246,29 +1246,29 @@ compile_length_enclose_node(EncloseNode* node, regex_t* reg)
 #ifdef USE_SUBEXP_CALL
     if (IS_ENCLOSE_CALLED(node)) {
       len = SIZE_OP_MEMORY_START_PUSH + tlen
-	  + SIZE_OP_CALL + SIZE_OP_JUMP + SIZE_OP_RETURN;
+          + SIZE_OP_CALL + SIZE_OP_JUMP + SIZE_OP_RETURN;
       if (BIT_STATUS_AT(reg->bt_mem_end, node->regnum))
-	len += (IS_ENCLOSE_RECURSION(node)
-		? SIZE_OP_MEMORY_END_PUSH_REC : SIZE_OP_MEMORY_END_PUSH);
+        len += (IS_ENCLOSE_RECURSION(node)
+                ? SIZE_OP_MEMORY_END_PUSH_REC : SIZE_OP_MEMORY_END_PUSH);
       else
-	len += (IS_ENCLOSE_RECURSION(node)
-		? SIZE_OP_MEMORY_END_REC : SIZE_OP_MEMORY_END);
+        len += (IS_ENCLOSE_RECURSION(node)
+                ? SIZE_OP_MEMORY_END_REC : SIZE_OP_MEMORY_END);
     }
     else if (IS_ENCLOSE_RECURSION(node)) {
       len = SIZE_OP_MEMORY_START_PUSH;
       len += tlen + (BIT_STATUS_AT(reg->bt_mem_end, node->regnum)
-		     ? SIZE_OP_MEMORY_END_PUSH_REC : SIZE_OP_MEMORY_END_REC);
+                     ? SIZE_OP_MEMORY_END_PUSH_REC : SIZE_OP_MEMORY_END_REC);
     }
     else
 #endif
     {
       if (BIT_STATUS_AT(reg->bt_mem_start, node->regnum))
-	len = SIZE_OP_MEMORY_START_PUSH;
+        len = SIZE_OP_MEMORY_START_PUSH;
       else
-	len = SIZE_OP_MEMORY_START;
+        len = SIZE_OP_MEMORY_START;
 
       len += tlen + (BIT_STATUS_AT(reg->bt_mem_end, node->regnum)
-		     ? SIZE_OP_MEMORY_END_PUSH : SIZE_OP_MEMORY_END);
+                     ? SIZE_OP_MEMORY_END_PUSH : SIZE_OP_MEMORY_END);
     }
     break;
 
@@ -1283,7 +1283,7 @@ compile_length_enclose_node(EncloseNode* node, regex_t* reg)
       if (tlen < 0) return tlen;
 
       len = tlen * qn->lower
-	  + SIZE_OP_PUSH + tlen + SIZE_OP_POP + SIZE_OP_JUMP;
+          + SIZE_OP_PUSH + tlen + SIZE_OP_POP + SIZE_OP_JUMP;
     }
     else {
 #endif
@@ -1348,11 +1348,11 @@ compile_enclose_node(EncloseNode* node, regex_t* reg)
       len = compile_length_tree(node->target, reg);
       len += (SIZE_OP_MEMORY_START_PUSH + SIZE_OP_RETURN);
       if (BIT_STATUS_AT(reg->bt_mem_end, node->regnum))
-	len += (IS_ENCLOSE_RECURSION(node)
-		? SIZE_OP_MEMORY_END_PUSH_REC : SIZE_OP_MEMORY_END_PUSH);
+        len += (IS_ENCLOSE_RECURSION(node)
+                ? SIZE_OP_MEMORY_END_PUSH_REC : SIZE_OP_MEMORY_END_PUSH);
       else
-	len += (IS_ENCLOSE_RECURSION(node)
-		? SIZE_OP_MEMORY_END_REC : SIZE_OP_MEMORY_END);
+        len += (IS_ENCLOSE_RECURSION(node)
+                ? SIZE_OP_MEMORY_END_REC : SIZE_OP_MEMORY_END);
 
       r = add_opcode_rel_addr(reg, OP_JUMP, len);
       if (r) return r;
@@ -1370,11 +1370,11 @@ compile_enclose_node(EncloseNode* node, regex_t* reg)
 #ifdef USE_SUBEXP_CALL
     if (IS_ENCLOSE_CALLED(node)) {
       if (BIT_STATUS_AT(reg->bt_mem_end, node->regnum))
-	r = add_opcode(reg, (IS_ENCLOSE_RECURSION(node)
-			     ? OP_MEMORY_END_PUSH_REC : OP_MEMORY_END_PUSH));
+        r = add_opcode(reg, (IS_ENCLOSE_RECURSION(node)
+                             ? OP_MEMORY_END_PUSH_REC : OP_MEMORY_END_PUSH));
       else
-	r = add_opcode(reg, (IS_ENCLOSE_RECURSION(node)
-			     ? OP_MEMORY_END_REC : OP_MEMORY_END));
+        r = add_opcode(reg, (IS_ENCLOSE_RECURSION(node)
+                             ? OP_MEMORY_END_REC : OP_MEMORY_END));
 
       if (r) return r;
       r = add_mem_num(reg, node->regnum);
@@ -1383,9 +1383,9 @@ compile_enclose_node(EncloseNode* node, regex_t* reg)
     }
     else if (IS_ENCLOSE_RECURSION(node)) {
       if (BIT_STATUS_AT(reg->bt_mem_end, node->regnum))
-	r = add_opcode(reg, OP_MEMORY_END_PUSH_REC);
+        r = add_opcode(reg, OP_MEMORY_END_PUSH_REC);
       else
-	r = add_opcode(reg, OP_MEMORY_END_REC);
+        r = add_opcode(reg, OP_MEMORY_END_REC);
       if (r) return r;
       r = add_mem_num(reg, node->regnum);
     }
@@ -1393,9 +1393,9 @@ compile_enclose_node(EncloseNode* node, regex_t* reg)
 #endif
     {
       if (BIT_STATUS_AT(reg->bt_mem_end, node->regnum))
-	r = add_opcode(reg, OP_MEMORY_END_PUSH);
+        r = add_opcode(reg, OP_MEMORY_END_PUSH);
       else
-	r = add_opcode(reg, OP_MEMORY_END);
+        r = add_opcode(reg, OP_MEMORY_END);
       if (r) return r;
       r = add_mem_num(reg, node->regnum);
     }
@@ -1421,7 +1421,7 @@ compile_enclose_node(EncloseNode* node, regex_t* reg)
       r = add_opcode(reg, OP_POP);
       if (r) return r;
       r = add_opcode_rel_addr(reg, OP_JUMP,
-	 -((int )SIZE_OP_PUSH + len + (int )SIZE_OP_POP + (int )SIZE_OP_JUMP));
+         -((int )SIZE_OP_PUSH + len + (int )SIZE_OP_POP + (int )SIZE_OP_JUMP));
     }
     else {
 #endif
@@ -1579,11 +1579,11 @@ compile_anchor_node(AnchorNode* node, regex_t* reg)
       r = add_opcode(reg, OP_LOOK_BEHIND);
       if (r) return r;
       if (node->char_len < 0) {
-	r = get_char_length_tree(node->target, reg, &n);
-	if (r) return ONIGERR_INVALID_LOOK_BEHIND_PATTERN;
+        r = get_char_length_tree(node->target, reg, &n);
+        if (r) return ONIGERR_INVALID_LOOK_BEHIND_PATTERN;
       }
       else
-	n = node->char_len;
+        n = node->char_len;
       r = add_length(reg, n);
       if (r) return r;
       r = compile_tree(node->target, reg);
@@ -1595,14 +1595,14 @@ compile_anchor_node(AnchorNode* node, regex_t* reg)
       int n;
       len = compile_length_tree(node->target, reg);
       r = add_opcode_rel_addr(reg, OP_PUSH_LOOK_BEHIND_NOT,
-			   len + SIZE_OP_FAIL_LOOK_BEHIND_NOT);
+                           len + SIZE_OP_FAIL_LOOK_BEHIND_NOT);
       if (r) return r;
       if (node->char_len < 0) {
-	r = get_char_length_tree(node->target, reg, &n);
-	if (r) return ONIGERR_INVALID_LOOK_BEHIND_PATTERN;
+        r = get_char_length_tree(node->target, reg, &n);
+        if (r) return ONIGERR_INVALID_LOOK_BEHIND_PATTERN;
       }
       else
-	n = node->char_len;
+        n = node->char_len;
       r = add_length(reg, n);
       if (r) return r;
       r = compile_tree(node->target, reg);
@@ -1641,10 +1641,10 @@ compile_length_tree(Node* node, regex_t* reg)
       int n = 0;
       len = 0;
       do {
-	r = compile_length_tree(NCAR(node), reg);
-	if (r < 0) return r;
-	len += r;
-	n++;
+        r = compile_length_tree(NCAR(node), reg);
+        if (r < 0) return r;
+        len += r;
+        n++;
       } while (IS_NOT_NULL(node = NCDR(node)));
       r = len;
       r += (SIZE_OP_PUSH + SIZE_OP_JUMP) * (n - 1);
@@ -1673,17 +1673,17 @@ compile_length_tree(Node* node, regex_t* reg)
 
 #ifdef USE_BACKREF_WITH_LEVEL
       if (IS_BACKREF_NEST_LEVEL(br)) {
-	r = SIZE_OPCODE + SIZE_OPTION + SIZE_LENGTH +
+        r = SIZE_OPCODE + SIZE_OPTION + SIZE_LENGTH +
             SIZE_LENGTH + (SIZE_MEMNUM * br->back_num);
       }
       else
 #endif
       if (br->back_num == 1) {
-	r = ((!IS_IGNORECASE(reg->options) && br->back_static[0] <= 2)
-	     ? SIZE_OPCODE : (SIZE_OPCODE + SIZE_MEMNUM));
+        r = ((!IS_IGNORECASE(reg->options) && br->back_static[0] <= 2)
+             ? SIZE_OPCODE : (SIZE_OPCODE + SIZE_MEMNUM));
       }
       else {
-	r = SIZE_OPCODE + SIZE_LENGTH + (SIZE_MEMNUM * br->back_num);
+        r = SIZE_OPCODE + SIZE_LENGTH + (SIZE_MEMNUM * br->back_num);
       }
     }
     break;
@@ -1732,26 +1732,26 @@ compile_tree(Node* node, regex_t* reg)
       Node* x = node;
       len = 0;
       do {
-	len += compile_length_tree(NCAR(x), reg);
-	if (NCDR(x) != NULL) {
-	  len += SIZE_OP_PUSH + SIZE_OP_JUMP;
-	}
+        len += compile_length_tree(NCAR(x), reg);
+        if (NCDR(x) != NULL) {
+          len += SIZE_OP_PUSH + SIZE_OP_JUMP;
+        }
       } while (IS_NOT_NULL(x = NCDR(x)));
       pos = reg->used + len;  /* goal position */
 
       do {
-	len = compile_length_tree(NCAR(node), reg);
-	if (IS_NOT_NULL(NCDR(node))) {
-	  r = add_opcode_rel_addr(reg, OP_PUSH, len + SIZE_OP_JUMP);
-	  if (r) break;
-	}
-	r = compile_tree(NCAR(node), reg);
-	if (r) break;
-	if (IS_NOT_NULL(NCDR(node))) {
-	  len = pos - (reg->used + SIZE_OP_JUMP);
-	  r = add_opcode_rel_addr(reg, OP_JUMP, len);
-	  if (r) break;
-	}
+        len = compile_length_tree(NCAR(node), reg);
+        if (IS_NOT_NULL(NCDR(node))) {
+          r = add_opcode_rel_addr(reg, OP_PUSH, len + SIZE_OP_JUMP);
+          if (r) break;
+        }
+        r = compile_tree(NCAR(node), reg);
+        if (r) break;
+        if (IS_NOT_NULL(NCDR(node))) {
+          len = pos - (reg->used + SIZE_OP_JUMP);
+          r = add_opcode_rel_addr(reg, OP_JUMP, len);
+          if (r) break;
+        }
       } while (IS_NOT_NULL(node = NCDR(node)));
     }
     break;
@@ -1773,18 +1773,18 @@ compile_tree(Node* node, regex_t* reg)
 
       switch (NCTYPE(node)->ctype) {
       case ONIGENC_CTYPE_WORD:
-	if (NCTYPE(node)->ascii_range != 0) {
-	  if (NCTYPE(node)->not != 0)  op = OP_NOT_ASCII_WORD;
-	  else                         op = OP_ASCII_WORD;
-	}
-	else {
-	  if (NCTYPE(node)->not != 0)  op = OP_NOT_WORD;
-	  else                         op = OP_WORD;
-	}
-	break;
+        if (NCTYPE(node)->ascii_range != 0) {
+          if (NCTYPE(node)->not != 0)  op = OP_NOT_ASCII_WORD;
+          else                         op = OP_ASCII_WORD;
+        }
+        else {
+          if (NCTYPE(node)->not != 0)  op = OP_NOT_WORD;
+          else                         op = OP_WORD;
+        }
+        break;
       default:
-	return ONIGERR_TYPE_BUG;
-	break;
+        return ONIGERR_TYPE_BUG;
+        break;
       }
       r = add_opcode(reg, op);
     }
@@ -1803,58 +1803,58 @@ compile_tree(Node* node, regex_t* reg)
 
 #ifdef USE_BACKREF_WITH_LEVEL
       if (IS_BACKREF_NEST_LEVEL(br)) {
-	r = add_opcode(reg, OP_BACKREF_WITH_LEVEL);
-	if (r) return r;
-	r = add_option(reg, (reg->options & ONIG_OPTION_IGNORECASE));
-	if (r) return r;
-	r = add_length(reg, br->nest_level);
-	if (r) return r;
+        r = add_opcode(reg, OP_BACKREF_WITH_LEVEL);
+        if (r) return r;
+        r = add_option(reg, (reg->options & ONIG_OPTION_IGNORECASE));
+        if (r) return r;
+        r = add_length(reg, br->nest_level);
+        if (r) return r;
 
-	goto add_bacref_mems;
+        goto add_bacref_mems;
       }
       else
 #endif
       if (br->back_num == 1) {
-	n = br->back_static[0];
-	if (IS_IGNORECASE(reg->options)) {
-	  r = add_opcode(reg, OP_BACKREFN_IC);
-	  if (r) return r;
-	  r = add_mem_num(reg, n);
-	}
-	else {
-	  switch (n) {
-	  case 1:  r = add_opcode(reg, OP_BACKREF1); break;
-	  case 2:  r = add_opcode(reg, OP_BACKREF2); break;
-	  default:
-	    r = add_opcode(reg, OP_BACKREFN);
-	    if (r) return r;
-	    r = add_mem_num(reg, n);
-	    break;
-	  }
-	}
+        n = br->back_static[0];
+        if (IS_IGNORECASE(reg->options)) {
+          r = add_opcode(reg, OP_BACKREFN_IC);
+          if (r) return r;
+          r = add_mem_num(reg, n);
+        }
+        else {
+          switch (n) {
+          case 1:  r = add_opcode(reg, OP_BACKREF1); break;
+          case 2:  r = add_opcode(reg, OP_BACKREF2); break;
+          default:
+            r = add_opcode(reg, OP_BACKREFN);
+            if (r) return r;
+            r = add_mem_num(reg, n);
+            break;
+          }
+        }
       }
       else {
-	int i;
-	int* p;
+        int i;
+        int* p;
 
-	if (IS_IGNORECASE(reg->options)) {
-	  r = add_opcode(reg, OP_BACKREF_MULTI_IC);
-	}
-	else {
-	  r = add_opcode(reg, OP_BACKREF_MULTI);
-	}
-	if (r) return r;
+        if (IS_IGNORECASE(reg->options)) {
+          r = add_opcode(reg, OP_BACKREF_MULTI_IC);
+        }
+        else {
+          r = add_opcode(reg, OP_BACKREF_MULTI);
+        }
+        if (r) return r;
 
 #ifdef USE_BACKREF_WITH_LEVEL
       add_bacref_mems:
 #endif
-	r = add_length(reg, br->back_num);
-	if (r) return r;
-	p = BACKREFS_P(br);
-	for (i = br->back_num - 1; i >= 0; i--) {
-	  r = add_mem_num(reg, p[i]);
-	  if (r) return r;
-	}
+        r = add_length(reg, br->back_num);
+        if (r) return r;
+        p = BACKREFS_P(br);
+        for (i = br->back_num - 1; i >= 0; i--) {
+          r = add_mem_num(reg, p[i]);
+          if (r) return r;
+        }
       }
     }
     break;
@@ -1909,7 +1909,7 @@ noname_disable_map(Node** plink, GroupNumRemap* map, int* counter)
       Node*  old = *ptarget;
       r = noname_disable_map(ptarget, map, counter);
       if (*ptarget != old && NTYPE(*ptarget) == NT_QTFR) {
-	onig_reduce_nested_quantifier(node, *ptarget);
+        onig_reduce_nested_quantifier(node, *ptarget);
       }
     }
     break;
@@ -1918,18 +1918,18 @@ noname_disable_map(Node** plink, GroupNumRemap* map, int* counter)
     {
       EncloseNode* en = NENCLOSE(node);
       if (en->type == ENCLOSE_MEMORY) {
-	if (IS_ENCLOSE_NAMED_GROUP(en)) {
-	  (*counter)++;
-	  map[en->regnum].new_val = *counter;
-	  en->regnum = *counter;
-	}
-	else if (en->regnum != 0) {
-	  *plink = en->target;
-	  en->target = NULL_NODE;
-	  onig_node_free(node);
-	  r = noname_disable_map(plink, map, counter);
-	  break;
-	}
+        if (IS_ENCLOSE_NAMED_GROUP(en)) {
+          (*counter)++;
+          map[en->regnum].new_val = *counter;
+          en->regnum = *counter;
+        }
+        else if (en->regnum != 0) {
+          *plink = en->target;
+          en->target = NULL_NODE;
+          onig_node_free(node);
+          r = noname_disable_map(plink, map, counter);
+          break;
+        }
       }
       r = noname_disable_map(&(en->target), map, counter);
     }
@@ -1995,8 +1995,8 @@ renumber_by_map(Node* node, GroupNumRemap* map, const int num_mem)
     {
       EncloseNode* en = NENCLOSE(node);
       if (en->type == ENCLOSE_CONDITION) {
-	if (en->regnum > num_mem)  return ONIGERR_INVALID_BACKREF;
-	en->regnum = map[en->regnum].new_val;
+        if (en->regnum > num_mem)  return ONIGERR_INVALID_BACKREF;
+        en->regnum = map[en->regnum].new_val;
       }
       r = renumber_by_map(en->target, map, num_mem);
     }
@@ -2127,8 +2127,8 @@ quantifiers_memory_node_info(Node* node)
     {
       int v;
       do {
-	v = quantifiers_memory_node_info(NCAR(node));
-	if (v > r) r = v;
+        v = quantifiers_memory_node_info(NCAR(node));
+        if (v > r) r = v;
       } while (v >= 0 && IS_NOT_NULL(node = NCDR(node)));
     }
     break;
@@ -2147,7 +2147,7 @@ quantifiers_memory_node_info(Node* node)
     {
       QtfrNode* qn = NQTFR(node);
       if (qn->upper != 0) {
-	r = quantifiers_memory_node_info(qn->target);
+        r = quantifiers_memory_node_info(qn->target);
       }
     }
     break;
@@ -2157,17 +2157,17 @@ quantifiers_memory_node_info(Node* node)
       EncloseNode* en = NENCLOSE(node);
       switch (en->type) {
       case ENCLOSE_MEMORY:
-	return NQ_TARGET_IS_EMPTY_MEM;
-	break;
+        return NQ_TARGET_IS_EMPTY_MEM;
+        break;
 
       case ENCLOSE_OPTION:
       case ENCLOSE_STOP_BACKTRACK:
       case ENCLOSE_CONDITION:
       case ENCLOSE_ABSENT:
-	r = quantifiers_memory_node_info(en->target);
-	break;
+        r = quantifiers_memory_node_info(en->target);
+        break;
       default:
-	break;
+        break;
       }
     }
     break;
@@ -2207,10 +2207,10 @@ get_min_match_length(Node* node, OnigDistance *min, ScanEnv* env)
       r = get_min_match_length(nodes[backs[0]], min, env);
       if (r != 0) break;
       for (i = 1; i < br->back_num; i++) {
-	if (backs[i] > env->num_mem)  return ONIGERR_INVALID_BACKREF;
-	r = get_min_match_length(nodes[backs[i]], &tmin, env);
-	if (r != 0) break;
-	if (*min > tmin) *min = tmin;
+        if (backs[i] > env->num_mem)  return ONIGERR_INVALID_BACKREF;
+        r = get_min_match_length(nodes[backs[i]], &tmin, env);
+        if (r != 0) break;
+        if (*min > tmin) *min = tmin;
       }
     }
     break;
@@ -2220,7 +2220,7 @@ get_min_match_length(Node* node, OnigDistance *min, ScanEnv* env)
     if (IS_CALL_RECURSION(NCALL(node))) {
       EncloseNode* en = NENCLOSE(NCALL(node)->target);
       if (IS_ENCLOSE_MIN_FIXED(en))
-	*min = en->min_len;
+        *min = en->min_len;
     }
     else
       r = get_min_match_length(NCALL(node)->target, min, env);
@@ -2239,11 +2239,11 @@ get_min_match_length(Node* node, OnigDistance *min, ScanEnv* env)
       Node *x, *y;
       y = node;
       do {
-	x = NCAR(y);
-	r = get_min_match_length(x, &tmin, env);
-	if (r != 0) break;
-	if (y == node) *min = tmin;
-	else if (*min > tmin) *min = tmin;
+        x = NCAR(y);
+        r = get_min_match_length(x, &tmin, env);
+        if (r != 0) break;
+        if (y == node) *min = tmin;
+        else if (*min > tmin) *min = tmin;
       } while (r == 0 && IS_NOT_NULL(y = NCDR(y)));
     }
     break;
@@ -2269,9 +2269,9 @@ get_min_match_length(Node* node, OnigDistance *min, ScanEnv* env)
       QtfrNode* qn = NQTFR(node);
 
       if (qn->lower > 0) {
-	r = get_min_match_length(qn->target, min, env);
-	if (r == 0)
-	  *min = distance_multiply(*min, qn->lower);
+        r = get_min_match_length(qn->target, min, env);
+        if (r == 0)
+          *min = distance_multiply(*min, qn->lower);
       }
     }
     break;
@@ -2284,28 +2284,28 @@ get_min_match_length(Node* node, OnigDistance *min, ScanEnv* env)
         if (IS_ENCLOSE_MIN_FIXED(en))
           *min = en->min_len;
         else {
-	  if (IS_ENCLOSE_MARK1(NENCLOSE(node)))
-	    *min = 0;  /* recursive */
-	  else {
-	    SET_ENCLOSE_STATUS(node, NST_MARK1);
-	    r = get_min_match_length(en->target, min, env);
-	    CLEAR_ENCLOSE_STATUS(node, NST_MARK1);
-	    if (r == 0) {
-	      en->min_len = *min;
-	      SET_ENCLOSE_STATUS(node, NST_MIN_FIXED);
-	    }
-	  }
+          if (IS_ENCLOSE_MARK1(NENCLOSE(node)))
+            *min = 0;  /* recursive */
+          else {
+            SET_ENCLOSE_STATUS(node, NST_MARK1);
+            r = get_min_match_length(en->target, min, env);
+            CLEAR_ENCLOSE_STATUS(node, NST_MARK1);
+            if (r == 0) {
+              en->min_len = *min;
+              SET_ENCLOSE_STATUS(node, NST_MIN_FIXED);
+            }
+          }
         }
         break;
 
       case ENCLOSE_OPTION:
       case ENCLOSE_STOP_BACKTRACK:
       case ENCLOSE_CONDITION:
-	r = get_min_match_length(en->target, min, env);
-	break;
+        r = get_min_match_length(en->target, min, env);
+        break;
 
       case ENCLOSE_ABSENT:
-	break;
+        break;
       }
     }
     break;
@@ -2330,7 +2330,7 @@ get_max_match_length(Node* node, OnigDistance *max, ScanEnv* env)
     do {
       r = get_max_match_length(NCAR(node), &tmax, env);
       if (r == 0)
-	*max = distance_add(*max, tmax);
+        *max = distance_add(*max, tmax);
     } while (r == 0 && IS_NOT_NULL(node = NCDR(node)));
     break;
 
@@ -2364,15 +2364,15 @@ get_max_match_length(Node* node, OnigDistance *max, ScanEnv* env)
       Node** nodes = SCANENV_MEM_NODES(env);
       BRefNode* br = NBREF(node);
       if (br->state & NST_RECURSION) {
-	*max = ONIG_INFINITE_DISTANCE;
-	break;
+        *max = ONIG_INFINITE_DISTANCE;
+        break;
       }
       backs = BACKREFS_P(br);
       for (i = 0; i < br->back_num; i++) {
-	if (backs[i] > env->num_mem)  return ONIGERR_INVALID_BACKREF;
-	r = get_max_match_length(nodes[backs[i]], &tmax, env);
-	if (r != 0) break;
-	if (*max < tmax) *max = tmax;
+        if (backs[i] > env->num_mem)  return ONIGERR_INVALID_BACKREF;
+        r = get_max_match_length(nodes[backs[i]], &tmax, env);
+        if (r != 0) break;
+        if (*max < tmax) *max = tmax;
       }
     }
     break;
@@ -2391,13 +2391,13 @@ get_max_match_length(Node* node, OnigDistance *max, ScanEnv* env)
       QtfrNode* qn = NQTFR(node);
 
       if (qn->upper != 0) {
-	r = get_max_match_length(qn->target, max, env);
-	if (r == 0 && *max != 0) {
-	  if (! IS_REPEAT_INFINITE(qn->upper))
-	    *max = distance_multiply(*max, qn->upper);
-	  else
-	    *max = ONIG_INFINITE_DISTANCE;
-	}
+        r = get_max_match_length(qn->target, max, env);
+        if (r == 0 && *max != 0) {
+          if (! IS_REPEAT_INFINITE(qn->upper))
+            *max = distance_multiply(*max, qn->upper);
+          else
+            *max = ONIG_INFINITE_DISTANCE;
+        }
       }
     }
     break;
@@ -2407,31 +2407,31 @@ get_max_match_length(Node* node, OnigDistance *max, ScanEnv* env)
       EncloseNode* en = NENCLOSE(node);
       switch (en->type) {
       case ENCLOSE_MEMORY:
-	if (IS_ENCLOSE_MAX_FIXED(en))
-	  *max = en->max_len;
-	else {
-	  if (IS_ENCLOSE_MARK1(NENCLOSE(node)))
-	    *max = ONIG_INFINITE_DISTANCE;
-	  else {
-	    SET_ENCLOSE_STATUS(node, NST_MARK1);
-	    r = get_max_match_length(en->target, max, env);
-	    CLEAR_ENCLOSE_STATUS(node, NST_MARK1);
-	    if (r == 0) {
-	      en->max_len = *max;
-	      SET_ENCLOSE_STATUS(node, NST_MAX_FIXED);
-	    }
-	  }
-	}
-	break;
+        if (IS_ENCLOSE_MAX_FIXED(en))
+          *max = en->max_len;
+        else {
+          if (IS_ENCLOSE_MARK1(NENCLOSE(node)))
+            *max = ONIG_INFINITE_DISTANCE;
+          else {
+            SET_ENCLOSE_STATUS(node, NST_MARK1);
+            r = get_max_match_length(en->target, max, env);
+            CLEAR_ENCLOSE_STATUS(node, NST_MARK1);
+            if (r == 0) {
+              en->max_len = *max;
+              SET_ENCLOSE_STATUS(node, NST_MAX_FIXED);
+            }
+          }
+        }
+        break;
 
       case ENCLOSE_OPTION:
       case ENCLOSE_STOP_BACKTRACK:
       case ENCLOSE_CONDITION:
-	r = get_max_match_length(en->target, max, env);
-	break;
+        r = get_max_match_length(en->target, max, env);
+        break;
 
       case ENCLOSE_ABSENT:
-	break;
+        break;
       }
     }
     break;
@@ -2461,7 +2461,7 @@ get_char_length_tree1(Node* node, regex_t* reg, int* len, int level)
     do {
       r = get_char_length_tree1(NCAR(node), reg, &tlen, level);
       if (r == 0)
-	*len = (int )distance_add(*len, tlen);
+        *len = (int )distance_add(*len, tlen);
     } while (r == 0 && IS_NOT_NULL(node = NCDR(node)));
     break;
 
@@ -2472,21 +2472,21 @@ get_char_length_tree1(Node* node, regex_t* reg, int* len, int level)
 
       r = get_char_length_tree1(NCAR(node), reg, &tlen, level);
       while (r == 0 && IS_NOT_NULL(node = NCDR(node))) {
-	r = get_char_length_tree1(NCAR(node), reg, &tlen2, level);
-	if (r == 0) {
-	  if (tlen != tlen2)
-	    varlen = 1;
-	}
+        r = get_char_length_tree1(NCAR(node), reg, &tlen2, level);
+        if (r == 0) {
+          if (tlen != tlen2)
+            varlen = 1;
+        }
       }
       if (r == 0) {
-	if (varlen != 0) {
-	  if (level == 1)
-	    r = GET_CHAR_LEN_TOP_ALT_VARLEN;
-	  else
-	    r = GET_CHAR_LEN_VARLEN;
-	}
-	else
-	  *len = tlen;
+        if (varlen != 0) {
+          if (level == 1)
+            r = GET_CHAR_LEN_TOP_ALT_VARLEN;
+          else
+            r = GET_CHAR_LEN_VARLEN;
+        }
+        else
+          *len = tlen;
       }
     }
     break;
@@ -2496,8 +2496,8 @@ get_char_length_tree1(Node* node, regex_t* reg, int* len, int level)
       StrNode* sn = NSTR(node);
       UChar *s = sn->s;
       while (s < sn->end) {
-	s += enclen(reg->enc, s, sn->end);
-	(*len)++;
+        s += enclen(reg->enc, s, sn->end);
+        (*len)++;
       }
     }
     break;
@@ -2506,12 +2506,12 @@ get_char_length_tree1(Node* node, regex_t* reg, int* len, int level)
     {
       QtfrNode* qn = NQTFR(node);
       if (qn->lower == qn->upper) {
-	r = get_char_length_tree1(qn->target, reg, &tlen, level);
-	if (r == 0)
-	  *len = (int )distance_multiply(tlen, qn->lower);
+        r = get_char_length_tree1(qn->target, reg, &tlen, level);
+        if (r == 0)
+          *len = (int )distance_multiply(tlen, qn->lower);
       }
       else
-	r = GET_CHAR_LEN_VARLEN;
+        r = GET_CHAR_LEN_VARLEN;
     }
     break;
 
@@ -2539,25 +2539,25 @@ get_char_length_tree1(Node* node, regex_t* reg, int* len, int level)
       switch (en->type) {
       case ENCLOSE_MEMORY:
 #ifdef USE_SUBEXP_CALL
-	if (IS_ENCLOSE_CLEN_FIXED(en))
-	  *len = en->char_len;
-	else {
-	  r = get_char_length_tree1(en->target, reg, len, level);
-	  if (r == 0) {
-	    en->char_len = *len;
-	    SET_ENCLOSE_STATUS(node, NST_CLEN_FIXED);
-	  }
-	}
-	break;
+        if (IS_ENCLOSE_CLEN_FIXED(en))
+          *len = en->char_len;
+        else {
+          r = get_char_length_tree1(en->target, reg, len, level);
+          if (r == 0) {
+            en->char_len = *len;
+            SET_ENCLOSE_STATUS(node, NST_CLEN_FIXED);
+          }
+        }
+        break;
 #endif
       case ENCLOSE_OPTION:
       case ENCLOSE_STOP_BACKTRACK:
       case ENCLOSE_CONDITION:
-	r = get_char_length_tree1(en->target, reg, len, level);
-	break;
+        r = get_char_length_tree1(en->target, reg, len, level);
+        break;
       case ENCLOSE_ABSENT:
       default:
-	break;
+        break;
       }
     }
     break;
@@ -2596,29 +2596,29 @@ is_not_included(Node* x, Node* y, regex_t* reg)
     {
       switch (ytype) {
       case NT_CTYPE:
-	if (NCTYPE(y)->ctype == NCTYPE(x)->ctype &&
-	    NCTYPE(y)->not   != NCTYPE(x)->not &&
-	    NCTYPE(y)->ascii_range == NCTYPE(x)->ascii_range)
-	  return 1;
-	else
-	  return 0;
-	break;
+        if (NCTYPE(y)->ctype == NCTYPE(x)->ctype &&
+            NCTYPE(y)->not   != NCTYPE(x)->not &&
+            NCTYPE(y)->ascii_range == NCTYPE(x)->ascii_range)
+          return 1;
+        else
+          return 0;
+        break;
 
       case NT_CCLASS:
       swap:
-	{
-	  Node* tmp;
-	  tmp = x; x = y; y = tmp;
-	  goto retry;
-	}
-	break;
+        {
+          Node* tmp;
+          tmp = x; x = y; y = tmp;
+          goto retry;
+        }
+        break;
 
       case NT_STR:
-	goto swap;
-	break;
+        goto swap;
+        break;
 
       default:
-	break;
+        break;
       }
     }
     break;
@@ -2628,80 +2628,80 @@ is_not_included(Node* x, Node* y, regex_t* reg)
       CClassNode* xc = NCCLASS(x);
       switch (ytype) {
       case NT_CTYPE:
-	switch (NCTYPE(y)->ctype) {
-	case ONIGENC_CTYPE_WORD:
-	  if (NCTYPE(y)->not == 0) {
-	    if (IS_NULL(xc->mbuf) && !IS_NCCLASS_NOT(xc)) {
-	      for (i = 0; i < SINGLE_BYTE_SIZE; i++) {
-		if (BITSET_AT(xc->bs, i)) {
-		  if (NCTYPE(y)->ascii_range) {
-		    if (IS_CODE_SB_WORD(reg->enc, i)) return 0;
-		  }
-		  else {
-		    if (ONIGENC_IS_CODE_WORD(reg->enc, i)) return 0;
-		  }
-		}
-	      }
-	      return 1;
-	    }
-	    return 0;
-	  }
-	  else {
-	    if (IS_NOT_NULL(xc->mbuf)) return 0;
-	    for (i = 0; i < SINGLE_BYTE_SIZE; i++) {
-	      int is_word;
-	      if (NCTYPE(y)->ascii_range)
-		is_word = IS_CODE_SB_WORD(reg->enc, i);
-	      else
-		is_word = ONIGENC_IS_CODE_WORD(reg->enc, i);
-	      if (! is_word) {
-		if (!IS_NCCLASS_NOT(xc)) {
-		  if (BITSET_AT(xc->bs, i))
-		    return 0;
-		}
-		else {
-		  if (! BITSET_AT(xc->bs, i))
-		    return 0;
-		}
-	      }
-	    }
-	    return 1;
-	  }
-	  break;
+        switch (NCTYPE(y)->ctype) {
+        case ONIGENC_CTYPE_WORD:
+          if (NCTYPE(y)->not == 0) {
+            if (IS_NULL(xc->mbuf) && !IS_NCCLASS_NOT(xc)) {
+              for (i = 0; i < SINGLE_BYTE_SIZE; i++) {
+                if (BITSET_AT(xc->bs, i)) {
+                  if (NCTYPE(y)->ascii_range) {
+                    if (IS_CODE_SB_WORD(reg->enc, i)) return 0;
+                  }
+                  else {
+                    if (ONIGENC_IS_CODE_WORD(reg->enc, i)) return 0;
+                  }
+                }
+              }
+              return 1;
+            }
+            return 0;
+          }
+          else {
+            if (IS_NOT_NULL(xc->mbuf)) return 0;
+            for (i = 0; i < SINGLE_BYTE_SIZE; i++) {
+              int is_word;
+              if (NCTYPE(y)->ascii_range)
+                is_word = IS_CODE_SB_WORD(reg->enc, i);
+              else
+                is_word = ONIGENC_IS_CODE_WORD(reg->enc, i);
+              if (! is_word) {
+                if (!IS_NCCLASS_NOT(xc)) {
+                  if (BITSET_AT(xc->bs, i))
+                    return 0;
+                }
+                else {
+                  if (! BITSET_AT(xc->bs, i))
+                    return 0;
+                }
+              }
+            }
+            return 1;
+          }
+          break;
 
-	default:
-	  break;
-	}
-	break;
+        default:
+          break;
+        }
+        break;
 
       case NT_CCLASS:
-	{
-	  int v;
-	  CClassNode* yc = NCCLASS(y);
+        {
+          int v;
+          CClassNode* yc = NCCLASS(y);
 
-	  for (i = 0; i < SINGLE_BYTE_SIZE; i++) {
-	    v = BITSET_AT(xc->bs, i);
-	    if ((v != 0 && !IS_NCCLASS_NOT(xc)) ||
-		(v == 0 && IS_NCCLASS_NOT(xc))) {
-	      v = BITSET_AT(yc->bs, i);
-	      if ((v != 0 && !IS_NCCLASS_NOT(yc)) ||
-		  (v == 0 && IS_NCCLASS_NOT(yc)))
-		return 0;
-	    }
-	  }
-	  if ((IS_NULL(xc->mbuf) && !IS_NCCLASS_NOT(xc)) ||
-	      (IS_NULL(yc->mbuf) && !IS_NCCLASS_NOT(yc)))
-	    return 1;
-	  return 0;
-	}
-	break;
+          for (i = 0; i < SINGLE_BYTE_SIZE; i++) {
+            v = BITSET_AT(xc->bs, i);
+            if ((v != 0 && !IS_NCCLASS_NOT(xc)) ||
+                (v == 0 && IS_NCCLASS_NOT(xc))) {
+              v = BITSET_AT(yc->bs, i);
+              if ((v != 0 && !IS_NCCLASS_NOT(yc)) ||
+                  (v == 0 && IS_NCCLASS_NOT(yc)))
+                return 0;
+            }
+          }
+          if ((IS_NULL(xc->mbuf) && !IS_NCCLASS_NOT(xc)) ||
+              (IS_NULL(yc->mbuf) && !IS_NCCLASS_NOT(yc)))
+            return 1;
+          return 0;
+        }
+        break;
 
       case NT_STR:
-	goto swap;
-	break;
+        goto swap;
+        break;
 
       default:
-	break;
+        break;
       }
     }
     break;
@@ -2710,60 +2710,60 @@ is_not_included(Node* x, Node* y, regex_t* reg)
     {
       StrNode* xs = NSTR(x);
       if (NSTRING_LEN(x) == 0)
-	break;
+        break;
 
       switch (ytype) {
       case NT_CTYPE:
-	switch (NCTYPE(y)->ctype) {
-	case ONIGENC_CTYPE_WORD:
-	  if (NCTYPE(y)->ascii_range) {
-	    if (ONIGENC_IS_MBC_ASCII_WORD(reg->enc, xs->s, xs->end))
-	      return NCTYPE(y)->not;
-	    else
-	      return !(NCTYPE(y)->not);
-	  }
-	  else {
-	    if (ONIGENC_IS_MBC_WORD(reg->enc, xs->s, xs->end))
-	      return NCTYPE(y)->not;
-	    else
-	      return !(NCTYPE(y)->not);
-	  }
-	  break;
-	default:
-	  break;
-	}
-	break;
+        switch (NCTYPE(y)->ctype) {
+        case ONIGENC_CTYPE_WORD:
+          if (NCTYPE(y)->ascii_range) {
+            if (ONIGENC_IS_MBC_ASCII_WORD(reg->enc, xs->s, xs->end))
+              return NCTYPE(y)->not;
+            else
+              return !(NCTYPE(y)->not);
+          }
+          else {
+            if (ONIGENC_IS_MBC_WORD(reg->enc, xs->s, xs->end))
+              return NCTYPE(y)->not;
+            else
+              return !(NCTYPE(y)->not);
+          }
+          break;
+        default:
+          break;
+        }
+        break;
 
       case NT_CCLASS:
-	{
-	  CClassNode* cc = NCCLASS(y);
+        {
+          CClassNode* cc = NCCLASS(y);
 
-	  code = ONIGENC_MBC_TO_CODE(reg->enc, xs->s,
-				     xs->s + ONIGENC_MBC_MAXLEN(reg->enc));
-	  return (onig_is_code_in_cc(reg->enc, code, cc) != 0 ? 0 : 1);
-	}
-	break;
+          code = ONIGENC_MBC_TO_CODE(reg->enc, xs->s,
+                                     xs->s + ONIGENC_MBC_MAXLEN(reg->enc));
+          return (onig_is_code_in_cc(reg->enc, code, cc) != 0 ? 0 : 1);
+        }
+        break;
 
       case NT_STR:
-	{
-	  UChar *q;
-	  StrNode* ys = NSTR(y);
-	  len = NSTRING_LEN(x);
-	  if (len > NSTRING_LEN(y)) len = NSTRING_LEN(y);
-	  if (NSTRING_IS_AMBIG(x) || NSTRING_IS_AMBIG(y)) {
-	    /* tiny version */
-	    return 0;
-	  }
-	  else {
-	    for (i = 0, p = ys->s, q = xs->s; (OnigDistance )i < len; i++, p++, q++) {
-	      if (*p != *q) return 1;
-	    }
-	  }
-	}
-	break;
+        {
+          UChar *q;
+          StrNode* ys = NSTR(y);
+          len = NSTRING_LEN(x);
+          if (len > NSTRING_LEN(y)) len = NSTRING_LEN(y);
+          if (NSTRING_IS_AMBIG(x) || NSTRING_IS_AMBIG(y)) {
+            /* tiny version */
+            return 0;
+          }
+          else {
+            for (i = 0, p = ys->s, q = xs->s; (OnigDistance )i < len; i++, p++, q++) {
+              if (*p != *q) return 1;
+            }
+          }
+        }
+        break;
 
       default:
-	break;
+        break;
       }
     }
     break;
@@ -2805,13 +2805,13 @@ get_head_value_node(Node* node, int exact, regex_t* reg)
       StrNode* sn = NSTR(node);
 
       if (sn->end <= sn->s)
-	break;
+        break;
 
       if (exact != 0 &&
-	  !NSTRING_IS_RAW(node) && IS_IGNORECASE(reg->options)) {
+          !NSTRING_IS_RAW(node) && IS_IGNORECASE(reg->options)) {
       }
       else {
-	n = node;
+        n = node;
       }
     }
     break;
@@ -2821,11 +2821,11 @@ get_head_value_node(Node* node, int exact, regex_t* reg)
       QtfrNode* qn = NQTFR(node);
       if (qn->lower > 0) {
 #ifdef USE_OP_PUSH_OR_JUMP_EXACT
-	if (IS_NOT_NULL(qn->head_exact))
-	  n = qn->head_exact;
-	else
+        if (IS_NOT_NULL(qn->head_exact))
+          n = qn->head_exact;
+        else
 #endif
-	  n = get_head_value_node(qn->target, exact, reg);
+          n = get_head_value_node(qn->target, exact, reg);
       }
     }
     break;
@@ -2835,23 +2835,23 @@ get_head_value_node(Node* node, int exact, regex_t* reg)
       EncloseNode* en = NENCLOSE(node);
       switch (en->type) {
       case ENCLOSE_OPTION:
-	{
-	  OnigOptionType options = reg->options;
+        {
+          OnigOptionType options = reg->options;
 
-	  reg->options = NENCLOSE(node)->option;
-	  n = get_head_value_node(NENCLOSE(node)->target, exact, reg);
-	  reg->options = options;
-	}
-	break;
+          reg->options = NENCLOSE(node)->option;
+          n = get_head_value_node(NENCLOSE(node)->target, exact, reg);
+          reg->options = options;
+        }
+        break;
 
       case ENCLOSE_MEMORY:
       case ENCLOSE_STOP_BACKTRACK:
       case ENCLOSE_CONDITION:
-	n = get_head_value_node(en->target, exact, reg);
-	break;
+        n = get_head_value_node(en->target, exact, reg);
+        break;
 
       case ENCLOSE_ABSENT:
-	break;
+        break;
       }
     }
     break;
@@ -2882,20 +2882,20 @@ check_type_tree(Node* node, int type_mask, int enclose_mask, int anchor_mask)
   case NT_ALT:
     do {
       r = check_type_tree(NCAR(node), type_mask, enclose_mask,
-			  anchor_mask);
+                          anchor_mask);
     } while (r == 0 && IS_NOT_NULL(node = NCDR(node)));
     break;
 
   case NT_QTFR:
     r = check_type_tree(NQTFR(node)->target, type_mask, enclose_mask,
-			anchor_mask);
+                        anchor_mask);
     break;
 
   case NT_ENCLOSE:
     {
       EncloseNode* en = NENCLOSE(node);
       if ((en->type & enclose_mask) == 0)
-	return 1;
+        return 1;
 
       r = check_type_tree(en->target, type_mask, enclose_mask, anchor_mask);
     }
@@ -2908,7 +2908,7 @@ check_type_tree(Node* node, int type_mask, int enclose_mask, int anchor_mask)
 
     if (NANCHOR(node)->target)
       r = check_type_tree(NANCHOR(node)->target,
-			  type_mask, enclose_mask, anchor_mask);
+                          type_mask, enclose_mask, anchor_mask);
     break;
 
   default:
@@ -2938,14 +2938,14 @@ subexp_inf_recursive_check(Node* node, ScanEnv* env, int head)
 
       x = node;
       do {
-	ret = subexp_inf_recursive_check(NCAR(x), env, head);
-	if (ret < 0 || ret == RECURSION_INFINITE) return ret;
-	r |= ret;
-	if (head) {
-	  ret = get_min_match_length(NCAR(x), &min, env);
-	  if (ret != 0) return ret;
-	  if (min != 0) head = 0;
-	}
+        ret = subexp_inf_recursive_check(NCAR(x), env, head);
+        if (ret < 0 || ret == RECURSION_INFINITE) return ret;
+        r |= ret;
+        if (head) {
+          ret = get_min_match_length(NCAR(x), &min, env);
+          if (ret != 0) return ret;
+          if (min != 0) head = 0;
+        }
       } while (IS_NOT_NULL(x = NCDR(x)));
     }
     break;
@@ -2955,9 +2955,9 @@ subexp_inf_recursive_check(Node* node, ScanEnv* env, int head)
       int ret;
       r = RECURSION_EXIST;
       do {
-	ret = subexp_inf_recursive_check(NCAR(node), env, head);
-	if (ret < 0 || ret == RECURSION_INFINITE) return ret;
-	r &= ret;
+        ret = subexp_inf_recursive_check(NCAR(node), env, head);
+        if (ret < 0 || ret == RECURSION_INFINITE) return ret;
+        r &= ret;
       } while (IS_NOT_NULL(node = NCDR(node)));
     }
     break;
@@ -2977,8 +2977,8 @@ subexp_inf_recursive_check(Node* node, ScanEnv* env, int head)
       case ANCHOR_PREC_READ_NOT:
       case ANCHOR_LOOK_BEHIND:
       case ANCHOR_LOOK_BEHIND_NOT:
-	r = subexp_inf_recursive_check(an->target, env, head);
-	break;
+        r = subexp_inf_recursive_check(an->target, env, head);
+        break;
       }
     }
     break;
@@ -3033,8 +3033,8 @@ subexp_inf_recursive_check_trav(Node* node, ScanEnv* env)
       case ANCHOR_PREC_READ_NOT:
       case ANCHOR_LOOK_BEHIND:
       case ANCHOR_LOOK_BEHIND_NOT:
-	r = subexp_inf_recursive_check_trav(an->target, env);
-	break;
+        r = subexp_inf_recursive_check_trav(an->target, env);
+        break;
       }
     }
     break;
@@ -3044,10 +3044,10 @@ subexp_inf_recursive_check_trav(Node* node, ScanEnv* env)
       EncloseNode* en = NENCLOSE(node);
 
       if (IS_ENCLOSE_RECURSION(en)) {
-	SET_ENCLOSE_STATUS(node, NST_MARK1);
-	r = subexp_inf_recursive_check(en->target, env, 1);
-	if (r > 0) return ONIGERR_NEVER_ENDING_RECURSION;
-	CLEAR_ENCLOSE_STATUS(node, NST_MARK1);
+        SET_ENCLOSE_STATUS(node, NST_MARK1);
+        r = subexp_inf_recursive_check(en->target, env, 1);
+        if (r > 0) return ONIGERR_NEVER_ENDING_RECURSION;
+        CLEAR_ENCLOSE_STATUS(node, NST_MARK1);
       }
       r = subexp_inf_recursive_check_trav(en->target, env);
     }
@@ -3086,8 +3086,8 @@ subexp_recursive_check(Node* node)
       case ANCHOR_PREC_READ_NOT:
       case ANCHOR_LOOK_BEHIND:
       case ANCHOR_LOOK_BEHIND_NOT:
-	r = subexp_recursive_check(an->target);
-	break;
+        r = subexp_recursive_check(an->target);
+        break;
       }
     }
     break;
@@ -3132,9 +3132,9 @@ subexp_recursive_check_trav(Node* node, ScanEnv* env)
     {
       int ret;
       do {
-	ret = subexp_recursive_check_trav(NCAR(node), env);
-	if (ret == FOUND_CALLED_NODE) r = FOUND_CALLED_NODE;
-	else if (ret < 0) return ret;
+        ret = subexp_recursive_check_trav(NCAR(node), env);
+        if (ret == FOUND_CALLED_NODE) r = FOUND_CALLED_NODE;
+        else if (ret < 0) return ret;
       } while (IS_NOT_NULL(node = NCDR(node)));
     }
     break;
@@ -3143,7 +3143,7 @@ subexp_recursive_check_trav(Node* node, ScanEnv* env)
     r = subexp_recursive_check_trav(NQTFR(node)->target, env);
     if (NQTFR(node)->upper == 0) {
       if (r == FOUND_CALLED_NODE)
-	NQTFR(node)->is_referred = 1;
+        NQTFR(node)->is_referred = 1;
     }
     break;
 
@@ -3155,8 +3155,8 @@ subexp_recursive_check_trav(Node* node, ScanEnv* env)
       case ANCHOR_PREC_READ_NOT:
       case ANCHOR_LOOK_BEHIND:
       case ANCHOR_LOOK_BEHIND_NOT:
-	r = subexp_recursive_check_trav(an->target, env);
-	break;
+        r = subexp_recursive_check_trav(an->target, env);
+        break;
       }
     }
     break;
@@ -3166,16 +3166,16 @@ subexp_recursive_check_trav(Node* node, ScanEnv* env)
       EncloseNode* en = NENCLOSE(node);
 
       if (! IS_ENCLOSE_RECURSION(en)) {
-	if (IS_ENCLOSE_CALLED(en)) {
-	  SET_ENCLOSE_STATUS(node, NST_MARK1);
-	  r = subexp_recursive_check(en->target);
-	  if (r != 0) SET_ENCLOSE_STATUS(node, NST_RECURSION);
-	  CLEAR_ENCLOSE_STATUS(node, NST_MARK1);
-	}
+        if (IS_ENCLOSE_CALLED(en)) {
+          SET_ENCLOSE_STATUS(node, NST_MARK1);
+          r = subexp_recursive_check(en->target);
+          if (r != 0) SET_ENCLOSE_STATUS(node, NST_RECURSION);
+          CLEAR_ENCLOSE_STATUS(node, NST_MARK1);
+        }
       }
       r = subexp_recursive_check_trav(en->target, env);
       if (IS_ENCLOSE_CALLED(en))
-	r |= FOUND_CALLED_NODE;
+        r |= FOUND_CALLED_NODE;
     }
     break;
 
@@ -3219,60 +3219,60 @@ setup_subexp_call(Node* node, ScanEnv* env)
       Node** nodes = SCANENV_MEM_NODES(env);
 
       if (cn->group_num != 0) {
-	int gnum = cn->group_num;
+        int gnum = cn->group_num;
 
 # ifdef USE_NAMED_GROUP
-	if (env->num_named > 0 &&
-	    IS_SYNTAX_BV(env->syntax, ONIG_SYN_CAPTURE_ONLY_NAMED_GROUP) &&
-	    !ONIG_IS_OPTION_ON(env->option, ONIG_OPTION_CAPTURE_GROUP)) {
-	  return ONIGERR_NUMBERED_BACKREF_OR_CALL_NOT_ALLOWED;
-	}
+        if (env->num_named > 0 &&
+            IS_SYNTAX_BV(env->syntax, ONIG_SYN_CAPTURE_ONLY_NAMED_GROUP) &&
+            !ONIG_IS_OPTION_ON(env->option, ONIG_OPTION_CAPTURE_GROUP)) {
+          return ONIGERR_NUMBERED_BACKREF_OR_CALL_NOT_ALLOWED;
+        }
 # endif
-	if (gnum > env->num_mem) {
-	  onig_scan_env_set_error_string(env,
-		 ONIGERR_UNDEFINED_GROUP_REFERENCE, cn->name, cn->name_end);
-	  return ONIGERR_UNDEFINED_GROUP_REFERENCE;
-	}
+        if (gnum > env->num_mem) {
+          onig_scan_env_set_error_string(env,
+                 ONIGERR_UNDEFINED_GROUP_REFERENCE, cn->name, cn->name_end);
+          return ONIGERR_UNDEFINED_GROUP_REFERENCE;
+        }
 
 # ifdef USE_NAMED_GROUP
       set_call_attr:
 # endif
-	cn->target = nodes[cn->group_num];
-	if (IS_NULL(cn->target)) {
-	  onig_scan_env_set_error_string(env,
-		 ONIGERR_UNDEFINED_NAME_REFERENCE, cn->name, cn->name_end);
-	  return ONIGERR_UNDEFINED_NAME_REFERENCE;
-	}
-	SET_ENCLOSE_STATUS(cn->target, NST_CALLED);
-	BIT_STATUS_ON_AT(env->bt_mem_start, cn->group_num);
-	cn->unset_addr_list = env->unset_addr_list;
+        cn->target = nodes[cn->group_num];
+        if (IS_NULL(cn->target)) {
+          onig_scan_env_set_error_string(env,
+                 ONIGERR_UNDEFINED_NAME_REFERENCE, cn->name, cn->name_end);
+          return ONIGERR_UNDEFINED_NAME_REFERENCE;
+        }
+        SET_ENCLOSE_STATUS(cn->target, NST_CALLED);
+        BIT_STATUS_ON_AT(env->bt_mem_start, cn->group_num);
+        cn->unset_addr_list = env->unset_addr_list;
       }
 # ifdef USE_NAMED_GROUP
 #  ifdef USE_PERL_SUBEXP_CALL
       else if (cn->name == cn->name_end) {
-	goto set_call_attr;
+        goto set_call_attr;
       }
 #  endif
       else {
-	int *refs;
+        int *refs;
 
-	int n = onig_name_to_group_numbers(env->reg, cn->name, cn->name_end,
-					   &refs);
-	if (n <= 0) {
-	  onig_scan_env_set_error_string(env,
-		 ONIGERR_UNDEFINED_NAME_REFERENCE, cn->name, cn->name_end);
-	  return ONIGERR_UNDEFINED_NAME_REFERENCE;
-	}
-	else if (n > 1 &&
-	    ! IS_SYNTAX_BV(env->syntax, ONIG_SYN_ALLOW_MULTIPLEX_DEFINITION_NAME_CALL)) {
-	  onig_scan_env_set_error_string(env,
-	    ONIGERR_MULTIPLEX_DEFINITION_NAME_CALL, cn->name, cn->name_end);
-	  return ONIGERR_MULTIPLEX_DEFINITION_NAME_CALL;
-	}
-	else {
-	  cn->group_num = refs[0];
-	  goto set_call_attr;
-	}
+        int n = onig_name_to_group_numbers(env->reg, cn->name, cn->name_end,
+                                           &refs);
+        if (n <= 0) {
+          onig_scan_env_set_error_string(env,
+                 ONIGERR_UNDEFINED_NAME_REFERENCE, cn->name, cn->name_end);
+          return ONIGERR_UNDEFINED_NAME_REFERENCE;
+        }
+        else if (n > 1 &&
+            ! IS_SYNTAX_BV(env->syntax, ONIG_SYN_ALLOW_MULTIPLEX_DEFINITION_NAME_CALL)) {
+          onig_scan_env_set_error_string(env,
+            ONIGERR_MULTIPLEX_DEFINITION_NAME_CALL, cn->name, cn->name_end);
+          return ONIGERR_MULTIPLEX_DEFINITION_NAME_CALL;
+        }
+        else {
+          cn->group_num = refs[0];
+          goto set_call_attr;
+        }
       }
 # endif
     }
@@ -3287,8 +3287,8 @@ setup_subexp_call(Node* node, ScanEnv* env)
       case ANCHOR_PREC_READ_NOT:
       case ANCHOR_LOOK_BEHIND:
       case ANCHOR_LOOK_BEHIND_NOT:
-	r = setup_subexp_call(an->target, env);
-	break;
+        r = setup_subexp_call(an->target, env);
+        break;
       }
     }
     break;
@@ -3370,26 +3370,26 @@ next_setup(Node* node, Node* next_node, regex_t* reg)
       Node* n = get_head_value_node(next_node, 1, reg);
       /* '\0': for UTF-16BE etc... */
       if (IS_NOT_NULL(n) && NSTR(n)->s[0] != '\0') {
-	qn->next_head_exact = n;
+        qn->next_head_exact = n;
       }
 #endif
       /* automatic possessification a*b ==> (?>a*)b */
       if (qn->lower <= 1) {
-	int ttype = NTYPE(qn->target);
-	if (IS_NODE_TYPE_SIMPLE(ttype)) {
-	  Node *x, *y;
-	  x = get_head_value_node(qn->target, 0, reg);
-	  if (IS_NOT_NULL(x)) {
-	    y = get_head_value_node(next_node,  0, reg);
-	    if (IS_NOT_NULL(y) && is_not_included(x, y, reg)) {
-	      Node* en = onig_node_new_enclose(ENCLOSE_STOP_BACKTRACK);
-	      CHECK_NULL_RETURN_MEMERR(en);
-	      SET_ENCLOSE_STATUS(en, NST_STOP_BT_SIMPLE_REPEAT);
-	      swap_node(node, en);
-	      NENCLOSE(node)->target = en;
-	    }
-	  }
-	}
+        int ttype = NTYPE(qn->target);
+        if (IS_NODE_TYPE_SIMPLE(ttype)) {
+          Node *x, *y;
+          x = get_head_value_node(qn->target, 0, reg);
+          if (IS_NOT_NULL(x)) {
+            y = get_head_value_node(next_node,  0, reg);
+            if (IS_NOT_NULL(y) && is_not_included(x, y, reg)) {
+              Node* en = onig_node_new_enclose(ENCLOSE_STOP_BACKTRACK);
+              CHECK_NULL_RETURN_MEMERR(en);
+              SET_ENCLOSE_STATUS(en, NST_STOP_BT_SIMPLE_REPEAT);
+              swap_node(node, en);
+              NENCLOSE(node)->target = en;
+            }
+          }
+        }
       }
     }
   }
@@ -3425,15 +3425,15 @@ update_string_node_case_fold(regex_t* reg, Node *node)
     len = ONIGENC_MBC_CASE_FOLD(reg->enc, reg->case_fold_flag, &p, end, buf);
     for (i = 0; i < len; i++) {
       if (sp >= ebuf) {
-	UChar* p = (UChar* )xrealloc(sbuf, sbuf_size * 2);
-	if (IS_NULL(p)) {
-	  xfree(sbuf);
-	  return ONIGERR_MEMORY;
-	}
-	sbuf = p;
-	sp = sbuf + sbuf_size;
-	sbuf_size *= 2;
-	ebuf = sbuf + sbuf_size;
+        UChar* p = (UChar* )xrealloc(sbuf, sbuf_size * 2);
+        if (IS_NULL(p)) {
+          xfree(sbuf);
+          return ONIGERR_MEMORY;
+        }
+        sbuf = p;
+        sp = sbuf + sbuf_size;
+        sbuf_size *= 2;
+        ebuf = sbuf + sbuf_size;
       }
 
       *sp++ = buf[i];
@@ -3448,7 +3448,7 @@ update_string_node_case_fold(regex_t* reg, Node *node)
 
 static int
 expand_case_fold_make_rem_string(Node** rnode, UChar *s, UChar *end,
-				 regex_t* reg)
+                                 regex_t* reg)
 {
   int r;
   Node *node;
@@ -3470,7 +3470,7 @@ expand_case_fold_make_rem_string(Node** rnode, UChar *s, UChar *end,
 
 static int
 is_case_fold_variable_len(int item_num, OnigCaseFoldCodeItem items[],
-			  int slen)
+                          int slen)
 {
   int i;
 
@@ -3487,8 +3487,8 @@ is_case_fold_variable_len(int item_num, OnigCaseFoldCodeItem items[],
 
 static int
 expand_case_fold_string_alt(int item_num, OnigCaseFoldCodeItem items[],
-			    UChar *p, int slen, UChar *end,
-			    regex_t* reg, Node **rnode)
+                            UChar *p, int slen, UChar *end,
+                            regex_t* reg, Node **rnode)
 {
   int r, i, j, len, varlen;
   Node *anode, *var_anode, *snode, *xnode, *an;
@@ -3533,8 +3533,8 @@ expand_case_fold_string_alt(int item_num, OnigCaseFoldCodeItem items[],
     for (j = 0; j < items[i].code_len; j++) {
       len = ONIGENC_CODE_TO_MBC(reg->enc, items[i].code[j], buf);
       if (len < 0) {
-	r = len;
-	goto mem_err2;
+        r = len;
+        goto mem_err2;
       }
 
       r = onig_node_str_cat(snode, buf, buf + len);
@@ -3551,29 +3551,29 @@ expand_case_fold_string_alt(int item_num, OnigCaseFoldCodeItem items[],
       UChar *q = p + items[i].byte_len;
 
       if (q < end) {
-	r = expand_case_fold_make_rem_string(&rem, q, end, reg);
-	if (r != 0) {
-	  onig_node_free(an);
-	  goto mem_err2;
-	}
+        r = expand_case_fold_make_rem_string(&rem, q, end, reg);
+        if (r != 0) {
+          onig_node_free(an);
+          goto mem_err2;
+        }
 
-	xnode = onig_node_list_add(NULL_NODE, snode);
-	if (IS_NULL(xnode)) {
-	  onig_node_free(an);
-	  onig_node_free(rem);
-	  goto mem_err2;
-	}
-	if (IS_NULL(onig_node_list_add(xnode, rem))) {
-	  onig_node_free(an);
-	  onig_node_free(xnode);
-	  onig_node_free(rem);
-	  goto mem_err;
-	}
+        xnode = onig_node_list_add(NULL_NODE, snode);
+        if (IS_NULL(xnode)) {
+          onig_node_free(an);
+          onig_node_free(rem);
+          goto mem_err2;
+        }
+        if (IS_NULL(onig_node_list_add(xnode, rem))) {
+          onig_node_free(an);
+          onig_node_free(xnode);
+          onig_node_free(rem);
+          goto mem_err;
+        }
 
-	NCAR(an) = xnode;
+        NCAR(an) = xnode;
       }
       else {
-	NCAR(an) = snode;
+        NCAR(an) = snode;
       }
 
       NCDR(var_anode) = an;
@@ -3621,7 +3621,7 @@ expand_case_fold_string(Node* node, regex_t* reg)
   p = start;
   while (p < end) {
     n = ONIGENC_GET_CASE_FOLD_CODES_BY_STR(reg->enc, reg->case_fold_flag,
-					   p, end, items);
+                                           p, end, items);
     if (n < 0) {
       r = n;
       goto err;
@@ -3632,23 +3632,23 @@ expand_case_fold_string(Node* node, regex_t* reg)
     varlen = is_case_fold_variable_len(n, items, len);
     if (n == 0 || varlen == 0) {
       if (IS_NULL(snode)) {
-	if (IS_NULL(root) && IS_NOT_NULL(prev_node)) {
+        if (IS_NULL(root) && IS_NOT_NULL(prev_node)) {
           onig_node_free(top_root);
-	  top_root = root = onig_node_list_add(NULL_NODE, prev_node);
-	  if (IS_NULL(root)) {
-	    onig_node_free(prev_node);
-	    goto mem_err;
-	  }
-	}
+          top_root = root = onig_node_list_add(NULL_NODE, prev_node);
+          if (IS_NULL(root)) {
+            onig_node_free(prev_node);
+            goto mem_err;
+          }
+        }
 
-	prev_node = snode = onig_node_new_str(NULL, NULL);
-	if (IS_NULL(snode)) goto mem_err;
-	if (IS_NOT_NULL(root)) {
-	  if (IS_NULL(onig_node_list_add(root, snode))) {
-	    onig_node_free(snode);
-	    goto mem_err;
-	  }
-	}
+        prev_node = snode = onig_node_new_str(NULL, NULL);
+        if (IS_NULL(snode)) goto mem_err;
+        if (IS_NOT_NULL(root)) {
+          if (IS_NULL(onig_node_list_add(root, snode))) {
+            onig_node_free(snode);
+            goto mem_err;
+          }
+        }
       }
 
       r = onig_node_str_cat(snode, p, p + len);
@@ -3659,42 +3659,42 @@ expand_case_fold_string(Node* node, regex_t* reg)
       if (alt_num > THRESHOLD_CASE_FOLD_ALT_FOR_EXPANSION) break;
 
       if (IS_NOT_NULL(snode)) {
-	r = update_string_node_case_fold(reg, snode);
-	if (r == 0) {
-	  NSTRING_SET_AMBIG(snode);
-	}
+        r = update_string_node_case_fold(reg, snode);
+        if (r == 0) {
+          NSTRING_SET_AMBIG(snode);
+        }
       }
       if (IS_NULL(root) && IS_NOT_NULL(prev_node)) {
         onig_node_free(top_root);
-	top_root = root = onig_node_list_add(NULL_NODE, prev_node);
-	if (IS_NULL(root)) {
-	  onig_node_free(prev_node);
-	  goto mem_err;
-	}
+        top_root = root = onig_node_list_add(NULL_NODE, prev_node);
+        if (IS_NULL(root)) {
+          onig_node_free(prev_node);
+          goto mem_err;
+        }
       }
 
       r = expand_case_fold_string_alt(n, items, p, len, end, reg, &prev_node);
       if (r < 0) goto mem_err;
       if (r == 1) {
-	if (IS_NULL(root)) {
-	  top_root = prev_node;
-	}
-	else {
-	  if (IS_NULL(onig_node_list_add(root, prev_node))) {
-	    onig_node_free(prev_node);
-	    goto mem_err;
-	  }
-	}
+        if (IS_NULL(root)) {
+          top_root = prev_node;
+        }
+        else {
+          if (IS_NULL(onig_node_list_add(root, prev_node))) {
+            onig_node_free(prev_node);
+            goto mem_err;
+          }
+        }
 
-	root = NCAR(prev_node);
+        root = NCAR(prev_node);
       }
       else { /* r == 0 */
-	if (IS_NOT_NULL(root)) {
-	  if (IS_NULL(onig_node_list_add(root, prev_node))) {
-	    onig_node_free(prev_node);
-	    goto mem_err;
-	  }
-	}
+        if (IS_NOT_NULL(root)) {
+          if (IS_NULL(onig_node_list_add(root, prev_node))) {
+            onig_node_free(prev_node);
+            goto mem_err;
+          }
+        }
       }
 
       snode = NULL_NODE;
@@ -3719,9 +3719,9 @@ expand_case_fold_string(Node* node, regex_t* reg)
       onig_node_free(top_root);
       top_root = root = onig_node_list_add(NULL_NODE, prev_node);
       if (IS_NULL(root)) {
-	onig_node_free(srem);
-	onig_node_free(prev_node);
-	goto mem_err;
+        onig_node_free(srem);
+        onig_node_free(prev_node);
+        goto mem_err;
       }
     }
 
@@ -3730,8 +3730,8 @@ expand_case_fold_string(Node* node, regex_t* reg)
     }
     else {
       if (IS_NULL(onig_node_list_add(root, srem))) {
-	onig_node_free(srem);
-	goto mem_err;
+        onig_node_free(srem);
+        goto mem_err;
       }
     }
   }
@@ -3771,7 +3771,7 @@ setup_comb_exp_check(Node* node, int state, ScanEnv* env)
   case NT_LIST:
     {
       do {
-	r = setup_comb_exp_check(NCAR(node), r, env);
+        r = setup_comb_exp_check(NCAR(node), r, env);
       } while (r >= 0 && IS_NOT_NULL(node = NCDR(node)));
     }
     break;
@@ -3780,8 +3780,8 @@ setup_comb_exp_check(Node* node, int state, ScanEnv* env)
     {
       int ret;
       do {
-	ret = setup_comb_exp_check(NCAR(node), state, env);
-	r |= ret;
+        ret = setup_comb_exp_check(NCAR(node), state, env);
+        r |= ret;
       } while (ret >= 0 && IS_NOT_NULL(node = NCDR(node)));
     }
     break;
@@ -3795,55 +3795,55 @@ setup_comb_exp_check(Node* node, int state, ScanEnv* env)
       int var_num;
 
       if (! IS_REPEAT_INFINITE(qn->upper)) {
-	if (qn->upper > 1) {
-	  /* {0,1}, {1,1} are allowed */
-	  child_state |= CEC_IN_FINITE_REPEAT;
+        if (qn->upper > 1) {
+          /* {0,1}, {1,1} are allowed */
+          child_state |= CEC_IN_FINITE_REPEAT;
 
-	  /* check (a*){n,m}, (a+){n,m} => (a*){n,n}, (a+){n,n} */
-	  if (env->backrefed_mem == 0) {
-	    if (NTYPE(qn->target) == NT_ENCLOSE) {
-	      EncloseNode* en = NENCLOSE(qn->target);
-	      if (en->type == ENCLOSE_MEMORY) {
-		if (NTYPE(en->target) == NT_QTFR) {
-		  QtfrNode* q = NQTFR(en->target);
-		  if (IS_REPEAT_INFINITE(q->upper)
-		      && q->greedy == qn->greedy) {
-		    qn->upper = (qn->lower == 0 ? 1 : qn->lower);
-		    if (qn->upper == 1)
-		      child_state = state;
-		  }
-		}
-	      }
-	    }
-	  }
-	}
+          /* check (a*){n,m}, (a+){n,m} => (a*){n,n}, (a+){n,n} */
+          if (env->backrefed_mem == 0) {
+            if (NTYPE(qn->target) == NT_ENCLOSE) {
+              EncloseNode* en = NENCLOSE(qn->target);
+              if (en->type == ENCLOSE_MEMORY) {
+                if (NTYPE(en->target) == NT_QTFR) {
+                  QtfrNode* q = NQTFR(en->target);
+                  if (IS_REPEAT_INFINITE(q->upper)
+                      && q->greedy == qn->greedy) {
+                    qn->upper = (qn->lower == 0 ? 1 : qn->lower);
+                    if (qn->upper == 1)
+                      child_state = state;
+                  }
+                }
+              }
+            }
+          }
+        }
       }
 
       if (state & CEC_IN_FINITE_REPEAT) {
-	qn->comb_exp_check_num = -1;
+        qn->comb_exp_check_num = -1;
       }
       else {
-	if (IS_REPEAT_INFINITE(qn->upper)) {
-	  var_num = CEC_INFINITE_NUM;
-	  child_state |= CEC_IN_INFINITE_REPEAT;
-	}
-	else {
-	  var_num = qn->upper - qn->lower;
-	}
+        if (IS_REPEAT_INFINITE(qn->upper)) {
+          var_num = CEC_INFINITE_NUM;
+          child_state |= CEC_IN_INFINITE_REPEAT;
+        }
+        else {
+          var_num = qn->upper - qn->lower;
+        }
 
-	if (var_num >= CEC_THRES_NUM_BIG_REPEAT)
-	  add_state |= CEC_CONT_BIG_REPEAT;
+        if (var_num >= CEC_THRES_NUM_BIG_REPEAT)
+          add_state |= CEC_CONT_BIG_REPEAT;
 
-	if (((state & CEC_IN_INFINITE_REPEAT) != 0 && var_num != 0) ||
-	    ((state & CEC_CONT_BIG_REPEAT) != 0 &&
-	     var_num >= CEC_THRES_NUM_BIG_REPEAT)) {
-	  if (qn->comb_exp_check_num == 0) {
-	    env->num_comb_exp_check++;
-	    qn->comb_exp_check_num = env->num_comb_exp_check;
-	    if (env->curr_max_regnum > env->comb_exp_max_regnum)
-	      env->comb_exp_max_regnum = env->curr_max_regnum;
-	  }
-	}
+        if (((state & CEC_IN_INFINITE_REPEAT) != 0 && var_num != 0) ||
+            ((state & CEC_CONT_BIG_REPEAT) != 0 &&
+             var_num >= CEC_THRES_NUM_BIG_REPEAT)) {
+          if (qn->comb_exp_check_num == 0) {
+            env->num_comb_exp_check++;
+            qn->comb_exp_check_num = env->num_comb_exp_check;
+            if (env->curr_max_regnum > env->comb_exp_max_regnum)
+              env->comb_exp_max_regnum = env->curr_max_regnum;
+          }
+        }
       }
 
       r = setup_comb_exp_check(target, child_state, env);
@@ -3857,17 +3857,17 @@ setup_comb_exp_check(Node* node, int state, ScanEnv* env)
 
       switch (en->type) {
       case ENCLOSE_MEMORY:
-	{
-	  if (env->curr_max_regnum < en->regnum)
-	    env->curr_max_regnum = en->regnum;
+        {
+          if (env->curr_max_regnum < en->regnum)
+            env->curr_max_regnum = en->regnum;
 
-	  r = setup_comb_exp_check(en->target, state, env);
-	}
-	break;
+          r = setup_comb_exp_check(en->target, state, env);
+        }
+        break;
 
       default:
-	r = setup_comb_exp_check(en->target, state, env);
-	break;
+        r = setup_comb_exp_check(en->target, state, env);
+        break;
       }
     }
     break;
@@ -3917,11 +3917,11 @@ restart:
     {
       Node* prev = NULL_NODE;
       do {
-	r = setup_tree(NCAR(node), reg, state, env);
-	if (IS_NOT_NULL(prev) && r == 0) {
-	  r = next_setup(prev, NCAR(node), reg);
-	}
-	prev = NCAR(node);
+        r = setup_tree(NCAR(node), reg, state, env);
+        if (IS_NOT_NULL(prev) && r == 0) {
+          r = next_setup(prev, NCAR(node), reg);
+        }
+        prev = NCAR(node);
       } while (r == 0 && IS_NOT_NULL(node = NCDR(node)));
     }
     break;
@@ -3958,15 +3958,15 @@ restart:
       BRefNode* br = NBREF(node);
       p = BACKREFS_P(br);
       for (i = 0; i < br->back_num; i++) {
-	if (p[i] > env->num_mem)  return ONIGERR_INVALID_BACKREF;
-	BIT_STATUS_ON_AT(env->backrefed_mem, p[i]);
-	BIT_STATUS_ON_AT(env->bt_mem_start, p[i]);
+        if (p[i] > env->num_mem)  return ONIGERR_INVALID_BACKREF;
+        BIT_STATUS_ON_AT(env->backrefed_mem, p[i]);
+        BIT_STATUS_ON_AT(env->bt_mem_start, p[i]);
 #ifdef USE_BACKREF_WITH_LEVEL
-	if (IS_BACKREF_NEST_LEVEL(br)) {
-	  BIT_STATUS_ON_AT(env->bt_mem_end, p[i]);
-	}
+        if (IS_BACKREF_NEST_LEVEL(br)) {
+          BIT_STATUS_ON_AT(env->bt_mem_end, p[i]);
+        }
 #endif
-	SET_ENCLOSE_STATUS(nodes[p[i]], NST_MEM_BACKREFED);
+        SET_ENCLOSE_STATUS(nodes[p[i]], NST_MEM_BACKREFED);
       }
     }
     break;
@@ -3978,100 +3978,100 @@ restart:
       Node* target = qn->target;
 
       if ((state & IN_REPEAT) != 0) {
-	qn->state |= NST_IN_REPEAT;
+        qn->state |= NST_IN_REPEAT;
       }
 
       if (IS_REPEAT_INFINITE(qn->upper) || qn->upper >= 1) {
-	r = get_min_match_length(target, &d, env);
-	if (r) break;
-	if (d == 0) {
-	  qn->target_empty_info = NQ_TARGET_IS_EMPTY;
+        r = get_min_match_length(target, &d, env);
+        if (r) break;
+        if (d == 0) {
+          qn->target_empty_info = NQ_TARGET_IS_EMPTY;
 #ifdef USE_MONOMANIAC_CHECK_CAPTURES_IN_ENDLESS_REPEAT
-	  r = quantifiers_memory_node_info(target);
-	  if (r < 0) break;
-	  if (r > 0) {
-	    qn->target_empty_info = r;
-	  }
+          r = quantifiers_memory_node_info(target);
+          if (r < 0) break;
+          if (r > 0) {
+            qn->target_empty_info = r;
+          }
 #endif
 #if 0
-	  r = get_max_match_length(target, &d, env);
-	  if (r == 0 && d == 0) {
-	    /*  ()* ==> ()?, ()+ ==> ()  */
-	    qn->upper = 1;
-	    if (qn->lower > 1) qn->lower = 1;
-	    if (NTYPE(target) == NT_STR) {
-	      qn->upper = qn->lower = 0;  /* /(?:)+/ ==> // */
-	    }
-	  }
+          r = get_max_match_length(target, &d, env);
+          if (r == 0 && d == 0) {
+            /*  ()* ==> ()?, ()+ ==> ()  */
+            qn->upper = 1;
+            if (qn->lower > 1) qn->lower = 1;
+            if (NTYPE(target) == NT_STR) {
+              qn->upper = qn->lower = 0;  /* /(?:)+/ ==> // */
+            }
+          }
 #endif
-	}
+        }
       }
 
       state |= IN_REPEAT;
       if (qn->lower != qn->upper)
-	state |= IN_VAR_REPEAT;
+        state |= IN_VAR_REPEAT;
       r = setup_tree(target, reg, state, env);
       if (r) break;
 
       /* expand string */
 #define EXPAND_STRING_MAX_LENGTH  100
       if (NTYPE(target) == NT_STR) {
-	if (qn->lower > 1) {
-	  int i, n = qn->lower;
-	  OnigDistance len = NSTRING_LEN(target);
-	  StrNode* sn = NSTR(target);
-	  Node* np;
+        if (qn->lower > 1) {
+          int i, n = qn->lower;
+          OnigDistance len = NSTRING_LEN(target);
+          StrNode* sn = NSTR(target);
+          Node* np;
 
-	  np = onig_node_new_str(sn->s, sn->end);
-	  if (IS_NULL(np)) return ONIGERR_MEMORY;
-	  NSTR(np)->flag = sn->flag;
+          np = onig_node_new_str(sn->s, sn->end);
+          if (IS_NULL(np)) return ONIGERR_MEMORY;
+          NSTR(np)->flag = sn->flag;
 
-	  for (i = 1; i < n && (i+1) * len <= EXPAND_STRING_MAX_LENGTH; i++) {
-	    r = onig_node_str_cat(np, sn->s, sn->end);
-	    if (r) {
-	      onig_node_free(np);
-	      return r;
-	    }
-	  }
-	  if (i < qn->upper || IS_REPEAT_INFINITE(qn->upper)) {
-	    Node *np1, *np2;
+          for (i = 1; i < n && (i+1) * len <= EXPAND_STRING_MAX_LENGTH; i++) {
+            r = onig_node_str_cat(np, sn->s, sn->end);
+            if (r) {
+              onig_node_free(np);
+              return r;
+            }
+          }
+          if (i < qn->upper || IS_REPEAT_INFINITE(qn->upper)) {
+            Node *np1, *np2;
 
-	    qn->lower -= i;
-	    if (! IS_REPEAT_INFINITE(qn->upper))
-	      qn->upper -= i;
+            qn->lower -= i;
+            if (! IS_REPEAT_INFINITE(qn->upper))
+              qn->upper -= i;
 
-	    np1 = onig_node_new_list(np, NULL);
-	    if (IS_NULL(np1)) {
-	      onig_node_free(np);
-	      return ONIGERR_MEMORY;
-	    }
-	    swap_node(np1, node);
-	    np2 = onig_node_list_add(node, np1);
-	    if (IS_NULL(np2)) {
-	      onig_node_free(np1);
-	      return ONIGERR_MEMORY;
-	    }
-	  }
-	  else {
-	    swap_node(np, node);
-	    onig_node_free(np);
-	  }
-	  break; /* break case NT_QTFR: */
-	}
+            np1 = onig_node_new_list(np, NULL);
+            if (IS_NULL(np1)) {
+              onig_node_free(np);
+              return ONIGERR_MEMORY;
+            }
+            swap_node(np1, node);
+            np2 = onig_node_list_add(node, np1);
+            if (IS_NULL(np2)) {
+              onig_node_free(np1);
+              return ONIGERR_MEMORY;
+            }
+          }
+          else {
+            swap_node(np, node);
+            onig_node_free(np);
+          }
+          break; /* break case NT_QTFR: */
+        }
       }
 
 #ifdef USE_OP_PUSH_OR_JUMP_EXACT
       if (qn->greedy && (qn->target_empty_info != 0)) {
-	if (NTYPE(target) == NT_QTFR) {
-	  QtfrNode* tqn = NQTFR(target);
-	  if (IS_NOT_NULL(tqn->head_exact)) {
-	    qn->head_exact  = tqn->head_exact;
-	    tqn->head_exact = NULL;
-	  }
-	}
-	else {
-	  qn->head_exact = get_head_value_node(qn->target, 1, reg);
-	}
+        if (NTYPE(target) == NT_QTFR) {
+          QtfrNode* tqn = NQTFR(target);
+          if (IS_NOT_NULL(tqn->head_exact)) {
+            qn->head_exact  = tqn->head_exact;
+            tqn->head_exact = NULL;
+          }
+        }
+        else {
+          qn->head_exact = get_head_value_node(qn->target, 1, reg);
+        }
       }
 #endif
     }
@@ -4083,61 +4083,61 @@ restart:
 
       switch (en->type) {
       case ENCLOSE_OPTION:
-	{
-	  OnigOptionType options = reg->options;
-	  reg->options = NENCLOSE(node)->option;
-	  r = setup_tree(NENCLOSE(node)->target, reg, state, env);
-	  reg->options = options;
-	}
-	break;
+        {
+          OnigOptionType options = reg->options;
+          reg->options = NENCLOSE(node)->option;
+          r = setup_tree(NENCLOSE(node)->target, reg, state, env);
+          reg->options = options;
+        }
+        break;
 
       case ENCLOSE_MEMORY:
-	if ((state & (IN_ALT | IN_NOT | IN_VAR_REPEAT | IN_CALL)) != 0) {
-	  BIT_STATUS_ON_AT(env->bt_mem_start, en->regnum);
-	  /* SET_ENCLOSE_STATUS(node, NST_MEM_IN_ALT_NOT); */
-	}
-	if (IS_ENCLOSE_CALLED(en))
-	  state |= IN_CALL;
-	if (IS_ENCLOSE_RECURSION(en))
-	  state |= IN_RECCALL;
-	else if ((state & IN_RECCALL) != 0)
-	  SET_CALL_RECURSION(node);
-	r = setup_tree(en->target, reg, state, env);
-	break;
+        if ((state & (IN_ALT | IN_NOT | IN_VAR_REPEAT | IN_CALL)) != 0) {
+          BIT_STATUS_ON_AT(env->bt_mem_start, en->regnum);
+          /* SET_ENCLOSE_STATUS(node, NST_MEM_IN_ALT_NOT); */
+        }
+        if (IS_ENCLOSE_CALLED(en))
+          state |= IN_CALL;
+        if (IS_ENCLOSE_RECURSION(en))
+          state |= IN_RECCALL;
+        else if ((state & IN_RECCALL) != 0)
+          SET_CALL_RECURSION(node);
+        r = setup_tree(en->target, reg, state, env);
+        break;
 
       case ENCLOSE_STOP_BACKTRACK:
-	{
-	  Node* target = en->target;
-	  r = setup_tree(target, reg, state, env);
-	  if (NTYPE(target) == NT_QTFR) {
-	    QtfrNode* tqn = NQTFR(target);
-	    if (IS_REPEAT_INFINITE(tqn->upper) && tqn->lower <= 1 &&
-		tqn->greedy != 0) {  /* (?>a*), a*+ etc... */
-	      int qtype = NTYPE(tqn->target);
-	      if (IS_NODE_TYPE_SIMPLE(qtype))
-		SET_ENCLOSE_STATUS(node, NST_STOP_BT_SIMPLE_REPEAT);
-	    }
-	  }
-	}
-	break;
+        {
+          Node* target = en->target;
+          r = setup_tree(target, reg, state, env);
+          if (NTYPE(target) == NT_QTFR) {
+            QtfrNode* tqn = NQTFR(target);
+            if (IS_REPEAT_INFINITE(tqn->upper) && tqn->lower <= 1 &&
+                tqn->greedy != 0) {  /* (?>a*), a*+ etc... */
+              int qtype = NTYPE(tqn->target);
+              if (IS_NODE_TYPE_SIMPLE(qtype))
+                SET_ENCLOSE_STATUS(node, NST_STOP_BT_SIMPLE_REPEAT);
+            }
+          }
+        }
+        break;
 
       case ENCLOSE_CONDITION:
 #ifdef USE_NAMED_GROUP
-	if (! IS_ENCLOSE_NAME_REF(NENCLOSE(node)) &&
-	    env->num_named > 0 &&
-	    IS_SYNTAX_BV(env->syntax, ONIG_SYN_CAPTURE_ONLY_NAMED_GROUP) &&
-	    !ONIG_IS_OPTION_ON(env->option, ONIG_OPTION_CAPTURE_GROUP)) {
-	  return ONIGERR_NUMBERED_BACKREF_OR_CALL_NOT_ALLOWED;
-	}
+        if (! IS_ENCLOSE_NAME_REF(NENCLOSE(node)) &&
+            env->num_named > 0 &&
+            IS_SYNTAX_BV(env->syntax, ONIG_SYN_CAPTURE_ONLY_NAMED_GROUP) &&
+            !ONIG_IS_OPTION_ON(env->option, ONIG_OPTION_CAPTURE_GROUP)) {
+          return ONIGERR_NUMBERED_BACKREF_OR_CALL_NOT_ALLOWED;
+        }
 #endif
-	if (NENCLOSE(node)->regnum > env->num_mem)
-	  return ONIGERR_INVALID_BACKREF;
-	r = setup_tree(NENCLOSE(node)->target, reg, state, env);
-	break;
+        if (NENCLOSE(node)->regnum > env->num_mem)
+          return ONIGERR_INVALID_BACKREF;
+        r = setup_tree(NENCLOSE(node)->target, reg, state, env);
+        break;
 
       case ENCLOSE_ABSENT:
-	r = setup_tree(NENCLOSE(node)->target, reg, state, env);
-	break;
+        r = setup_tree(NENCLOSE(node)->target, reg, state, env);
+        break;
       }
     }
     break;
@@ -4148,11 +4148,11 @@ restart:
 
       switch (an->type) {
       case ANCHOR_PREC_READ:
-	r = setup_tree(an->target, reg, state, env);
-	break;
+        r = setup_tree(an->target, reg, state, env);
+        break;
       case ANCHOR_PREC_READ_NOT:
-	r = setup_tree(an->target, reg, (state | IN_NOT), env);
-	break;
+        r = setup_tree(an->target, reg, (state | IN_NOT), env);
+        break;
 
 /* allowed node types in look-behind */
 #define ALLOWED_TYPE_IN_LB  \
@@ -4174,30 +4174,30 @@ restart:
   ANCHOR_WORD_BEGIN | ANCHOR_WORD_END )
 
       case ANCHOR_LOOK_BEHIND:
-	{
-	  r = check_type_tree(an->target, ALLOWED_TYPE_IN_LB,
-			      ALLOWED_ENCLOSE_IN_LB, ALLOWED_ANCHOR_IN_LB);
-	  if (r < 0) return r;
-	  if (r > 0) return ONIGERR_INVALID_LOOK_BEHIND_PATTERN;
-	  if (NTYPE(node) != NT_ANCHOR) goto restart;
-	  r = setup_tree(an->target, reg, state, env);
-	  if (r != 0) return r;
-	  r = setup_look_behind(node, reg, env);
-	}
-	break;
+        {
+          r = check_type_tree(an->target, ALLOWED_TYPE_IN_LB,
+                              ALLOWED_ENCLOSE_IN_LB, ALLOWED_ANCHOR_IN_LB);
+          if (r < 0) return r;
+          if (r > 0) return ONIGERR_INVALID_LOOK_BEHIND_PATTERN;
+          if (NTYPE(node) != NT_ANCHOR) goto restart;
+          r = setup_tree(an->target, reg, state, env);
+          if (r != 0) return r;
+          r = setup_look_behind(node, reg, env);
+        }
+        break;
 
       case ANCHOR_LOOK_BEHIND_NOT:
-	{
-	  r = check_type_tree(an->target, ALLOWED_TYPE_IN_LB,
-		      ALLOWED_ENCLOSE_IN_LB_NOT, ALLOWED_ANCHOR_IN_LB_NOT);
-	  if (r < 0) return r;
-	  if (r > 0) return ONIGERR_INVALID_LOOK_BEHIND_PATTERN;
-	  if (NTYPE(node) != NT_ANCHOR) goto restart;
-	  r = setup_tree(an->target, reg, (state | IN_NOT), env);
-	  if (r != 0) return r;
-	  r = setup_look_behind(node, reg, env);
-	}
-	break;
+        {
+          r = check_type_tree(an->target, ALLOWED_TYPE_IN_LB,
+                      ALLOWED_ENCLOSE_IN_LB_NOT, ALLOWED_ANCHOR_IN_LB_NOT);
+          if (r < 0) return r;
+          if (r > 0) return ONIGERR_INVALID_LOOK_BEHIND_PATTERN;
+          if (NTYPE(node) != NT_ANCHOR) goto restart;
+          r = setup_tree(an->target, reg, (state | IN_NOT), env);
+          if (r != 0) return r;
+          r = setup_look_behind(node, reg, env);
+        }
+        break;
       }
     }
     break;
@@ -4213,7 +4213,7 @@ restart:
 /* set skip map for Boyer-Moore search */
 static int
 set_bm_skip(UChar* s, UChar* end, regex_t* reg,
-	    UChar skip[], int** int_skip, int ignore_case)
+            UChar skip[], int** int_skip, int ignore_case)
 {
   OnigDistance i, len;
   int clen, flen, n, j, k;
@@ -4229,24 +4229,24 @@ set_bm_skip(UChar* s, UChar* end, regex_t* reg,
     for (i = 0; i < len - 1; i += clen) {
       p = s + i;
       if (ignore_case)
-	n = ONIGENC_GET_CASE_FOLD_CODES_BY_STR(enc, reg->case_fold_flag,
-					       p, end, items);
+        n = ONIGENC_GET_CASE_FOLD_CODES_BY_STR(enc, reg->case_fold_flag,
+                                               p, end, items);
       clen = enclen(enc, p, end);
       if (p + clen > end)
-	clen = (int )(end - p);
+        clen = (int )(end - p);
 
       for (j = 0; j < n; j++) {
-	if ((items[j].code_len != 1) || (items[j].byte_len != clen))
-	  return 1;  /* different length isn't supported. */
-	flen = ONIGENC_CODE_TO_MBC(enc, items[j].code[0], buf[j]);
-	if (flen != clen)
-	  return 1;  /* different length isn't supported. */
+        if ((items[j].code_len != 1) || (items[j].byte_len != clen))
+          return 1;  /* different length isn't supported. */
+        flen = ONIGENC_CODE_TO_MBC(enc, items[j].code[0], buf[j]);
+        if (flen != clen)
+          return 1;  /* different length isn't supported. */
       }
       for (j = 0; j < clen; j++) {
-	skip[s[i + j]] = (UChar )(len - 1 - i - j);
-	for (k = 0; k < n; k++) {
-	  skip[buf[k][j]] = (UChar )(len - 1 - i - j);
-	}
+        skip[s[i + j]] = (UChar )(len - 1 - i - j);
+        for (k = 0; k < n; k++) {
+          skip[buf[k][j]] = (UChar )(len - 1 - i - j);
+        }
       }
     }
   }
@@ -4265,24 +4265,24 @@ set_bm_skip(UChar* s, UChar* end, regex_t* reg,
     for (i = 0; i < len - 1; i += clen) {
       p = s + i;
       if (ignore_case)
-	n = ONIGENC_GET_CASE_FOLD_CODES_BY_STR(enc, reg->case_fold_flag,
-					       p, end, items);
+        n = ONIGENC_GET_CASE_FOLD_CODES_BY_STR(enc, reg->case_fold_flag,
+                                               p, end, items);
       clen = enclen(enc, p, end);
       if (p + clen > end)
-	clen = (int )(end - p);
+        clen = (int )(end - p);
 
       for (j = 0; j < n; j++) {
-	if ((items[j].code_len != 1) || (items[j].byte_len != clen))
-	  return 1;  /* different length isn't supported. */
-	flen = ONIGENC_CODE_TO_MBC(enc, items[j].code[0], buf[j]);
-	if (flen != clen)
-	  return 1;  /* different length isn't supported. */
+        if ((items[j].code_len != 1) || (items[j].byte_len != clen))
+          return 1;  /* different length isn't supported. */
+        flen = ONIGENC_CODE_TO_MBC(enc, items[j].code[0], buf[j]);
+        if (flen != clen)
+          return 1;  /* different length isn't supported. */
       }
       for (j = 0; j < clen; j++) {
-	(*int_skip)[s[i + j]] = (int )(len - 1 - i - j);
-	for (k = 0; k < n; k++) {
-	  (*int_skip)[buf[k][j]] = (int )(len - 1 - i - j);
-	}
+        (*int_skip)[s[i + j]] = (int )(len - 1 - i - j);
+        for (k = 0; k < n; k++) {
+          (*int_skip)[buf[k][j]] = (int )(len - 1 - i - j);
+        }
       }
     }
 # endif
@@ -4295,7 +4295,7 @@ set_bm_skip(UChar* s, UChar* end, regex_t* reg,
 /* set skip map for Sunday's quick search */
 static int
 set_bm_skip(UChar* s, UChar* end, regex_t* reg,
-	    UChar skip[], int** int_skip, int ignore_case)
+            UChar skip[], int** int_skip, int ignore_case)
 {
   OnigDistance i, len;
   int clen, flen, n, j, k;
@@ -4311,24 +4311,24 @@ set_bm_skip(UChar* s, UChar* end, regex_t* reg,
     for (i = 0; i < len; i += clen) {
       p = s + i;
       if (ignore_case)
-	n = ONIGENC_GET_CASE_FOLD_CODES_BY_STR(enc, reg->case_fold_flag,
-					       p, end, items);
+        n = ONIGENC_GET_CASE_FOLD_CODES_BY_STR(enc, reg->case_fold_flag,
+                                               p, end, items);
       clen = enclen(enc, p, end);
       if (p + clen > end)
-	clen = (int )(end - p);
+        clen = (int )(end - p);
 
       for (j = 0; j < n; j++) {
-	if ((items[j].code_len != 1) || (items[j].byte_len != clen))
-	  return 1;  /* different length isn't supported. */
-	flen = ONIGENC_CODE_TO_MBC(enc, items[j].code[0], buf[j]);
-	if (flen != clen)
-	  return 1;  /* different length isn't supported. */
+        if ((items[j].code_len != 1) || (items[j].byte_len != clen))
+          return 1;  /* different length isn't supported. */
+        flen = ONIGENC_CODE_TO_MBC(enc, items[j].code[0], buf[j]);
+        if (flen != clen)
+          return 1;  /* different length isn't supported. */
       }
       for (j = 0; j < clen; j++) {
-	skip[s[i + j]] = (UChar )(len - i - j);
-	for (k = 0; k < n; k++) {
-	  skip[buf[k][j]] = (UChar )(len - i - j);
-	}
+        skip[s[i + j]] = (UChar )(len - i - j);
+        for (k = 0; k < n; k++) {
+          skip[buf[k][j]] = (UChar )(len - i - j);
+        }
       }
     }
   }
@@ -4347,24 +4347,24 @@ set_bm_skip(UChar* s, UChar* end, regex_t* reg,
     for (i = 0; i < len; i += clen) {
       p = s + i;
       if (ignore_case)
-	n = ONIGENC_GET_CASE_FOLD_CODES_BY_STR(enc, reg->case_fold_flag,
-					       p, end, items);
+        n = ONIGENC_GET_CASE_FOLD_CODES_BY_STR(enc, reg->case_fold_flag,
+                                               p, end, items);
       clen = enclen(enc, p, end);
       if (p + clen > end)
-	clen = (int )(end - p);
+        clen = (int )(end - p);
 
       for (j = 0; j < n; j++) {
-	if ((items[j].code_len != 1) || (items[j].byte_len != clen))
-	  return 1;  /* different length isn't supported. */
-	flen = ONIGENC_CODE_TO_MBC(enc, items[j].code[0], buf[j]);
-	if (flen != clen)
-	  return 1;  /* different length isn't supported. */
+        if ((items[j].code_len != 1) || (items[j].byte_len != clen))
+          return 1;  /* different length isn't supported. */
+        flen = ONIGENC_CODE_TO_MBC(enc, items[j].code[0], buf[j]);
+        if (flen != clen)
+          return 1;  /* different length isn't supported. */
       }
       for (j = 0; j < clen; j++) {
-	(*int_skip)[s[i + j]] = (int )(len - i - j);
-	for (k = 0; k < n; k++) {
-	  (*int_skip)[buf[k][j]] = (int )(len - i - j);
-	}
+        (*int_skip)[s[i + j]] = (int )(len - i - j);
+        for (k = 0; k < n; k++) {
+          (*int_skip)[buf[k][j]] = (int )(len - i - j);
+        }
       }
     }
 # endif
@@ -4562,7 +4562,7 @@ copy_opt_anc_info(OptAncInfo* to, OptAncInfo* from)
 
 static void
 concat_opt_anc_info(OptAncInfo* to, OptAncInfo* left, OptAncInfo* right,
-		    OnigDistance left_len, OnigDistance right_len)
+                    OnigDistance left_len, OnigDistance right_len)
 {
   clear_opt_anc_info(to);
 
@@ -4678,7 +4678,7 @@ concat_opt_exact_info(OptExactInfo* to, OptExactInfo* add, OnigEncoding enc)
 
 static void
 concat_opt_exact_info_str(OptExactInfo* to, UChar* s, UChar* end,
-			  int raw ARG_UNUSED, OnigEncoding enc)
+                          int raw ARG_UNUSED, OnigEncoding enc)
 {
   int i, j, len;
   UChar *p;
@@ -4923,7 +4923,7 @@ concat_left_node_opt_info(OnigEncoding enc, NodeOptInfo* to, NodeOptInfo* add)
 
   if (add->exb.len > 0 && to->len.max == 0) {
     concat_opt_anc_info(&tanc, &to->anc, &add->exb.anc,
-			to->len.max, add->len.max);
+                        to->len.max, add->len.max);
     copy_opt_anc_info(&add->exb.anc, &tanc);
   }
 
@@ -4954,12 +4954,12 @@ concat_left_node_opt_info(OnigEncoding enc, NodeOptInfo* to, NodeOptInfo* add)
   if (to->expr.len > 0) {
     if (add->len.max > 0) {
       if (to->expr.len > (int )add->len.max)
-	to->expr.len = (int )add->len.max;
+        to->expr.len = (int )add->len.max;
 
       if (to->expr.mmd.max == 0)
-	select_opt_exact_info(enc, &to->exb, &to->expr);
+        select_opt_exact_info(enc, &to->exb, &to->expr);
       else
-	select_opt_exact_info(enc, &to->exm, &to->expr);
+        select_opt_exact_info(enc, &to->exm, &to->expr);
     }
   }
   else if (add->expr.len > 0) {
@@ -5005,11 +5005,11 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
 
       copy_opt_env(&nenv, env);
       do {
-	r = optimize_node_left(NCAR(nd), &nopt, &nenv);
-	if (r == 0) {
-	  add_mml(&nenv.mmd, &nopt.len);
-	  concat_left_node_opt_info(env->enc, opt, &nopt);
-	}
+        r = optimize_node_left(NCAR(nd), &nopt, &nenv);
+        if (r == 0) {
+          add_mml(&nenv.mmd, &nopt.len);
+          concat_left_node_opt_info(env->enc, opt, &nopt);
+        }
       } while (r == 0 && IS_NOT_NULL(nd = NCDR(nd)));
     }
     break;
@@ -5020,11 +5020,11 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
       Node* nd = node;
 
       do {
-	r = optimize_node_left(NCAR(nd), &nopt, env);
-	if (r == 0) {
-	  if (nd == node) copy_node_opt_info(opt, &nopt);
-	  else            alt_merge_node_opt_info(opt, &nopt, env);
-	}
+        r = optimize_node_left(NCAR(nd), &nopt, env);
+        if (r == 0) {
+          if (nd == node) copy_node_opt_info(opt, &nopt);
+          else            alt_merge_node_opt_info(opt, &nopt, env);
+        }
       } while ((r == 0) && IS_NOT_NULL(nd = NCDR(nd)));
     }
     break;
@@ -5036,40 +5036,40 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
       int is_raw = NSTRING_IS_RAW(node);
 
       if (! NSTRING_IS_AMBIG(node)) {
-	concat_opt_exact_info_str(&opt->exb, sn->s, sn->end,
-				  is_raw, env->enc);
-	opt->exb.ignore_case = 0;
-	if (slen > 0) {
-	  add_char_opt_map_info(&opt->map, *(sn->s), env->enc);
-	}
-	set_mml(&opt->len, slen, slen);
+        concat_opt_exact_info_str(&opt->exb, sn->s, sn->end,
+                                  is_raw, env->enc);
+        opt->exb.ignore_case = 0;
+        if (slen > 0) {
+          add_char_opt_map_info(&opt->map, *(sn->s), env->enc);
+        }
+        set_mml(&opt->len, slen, slen);
       }
       else {
-	OnigDistance max;
+        OnigDistance max;
 
-	if (NSTRING_IS_DONT_GET_OPT_INFO(node)) {
-	  int n = onigenc_strlen(env->enc, sn->s, sn->end);
-	  max = ONIGENC_MBC_MAXLEN_DIST(env->enc) * (OnigDistance)n;
-	}
-	else {
-	  concat_opt_exact_info_str(&opt->exb, sn->s, sn->end,
-				    is_raw, env->enc);
-	  opt->exb.ignore_case = 1;
+        if (NSTRING_IS_DONT_GET_OPT_INFO(node)) {
+          int n = onigenc_strlen(env->enc, sn->s, sn->end);
+          max = ONIGENC_MBC_MAXLEN_DIST(env->enc) * (OnigDistance)n;
+        }
+        else {
+          concat_opt_exact_info_str(&opt->exb, sn->s, sn->end,
+                                    is_raw, env->enc);
+          opt->exb.ignore_case = 1;
 
-	  if (slen > 0) {
-	    r = add_char_amb_opt_map_info(&opt->map, sn->s, sn->end,
-					  env->enc, env->case_fold_flag);
-	    if (r != 0) break;
-	  }
+          if (slen > 0) {
+            r = add_char_amb_opt_map_info(&opt->map, sn->s, sn->end,
+                                          env->enc, env->case_fold_flag);
+            if (r != 0) break;
+          }
 
-	  max = slen;
-	}
+          max = slen;
+        }
 
-	set_mml(&opt->len, slen, max);
+        set_mml(&opt->len, slen, max);
       }
 
       if ((OnigDistance )opt->exb.len == slen)
-	opt->exb.reach_end = 1;
+        opt->exb.reach_end = 1;
     }
     break;
 
@@ -5081,19 +5081,19 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
       /* no need to check ignore case. (set in setup_tree()) */
 
       if (IS_NOT_NULL(cc->mbuf) || IS_NCCLASS_NOT(cc)) {
-	OnigDistance min = ONIGENC_MBC_MINLEN(env->enc);
-	OnigDistance max = ONIGENC_MBC_MAXLEN_DIST(env->enc);
+        OnigDistance min = ONIGENC_MBC_MINLEN(env->enc);
+        OnigDistance max = ONIGENC_MBC_MAXLEN_DIST(env->enc);
 
-	set_mml(&opt->len, min, max);
+        set_mml(&opt->len, min, max);
       }
       else {
-	for (i = 0; i < SINGLE_BYTE_SIZE; i++) {
-	  z = BITSET_AT(cc->bs, i);
-	  if ((z && !IS_NCCLASS_NOT(cc)) || (!z && IS_NCCLASS_NOT(cc))) {
-	    add_char_opt_map_info(&opt->map, (UChar )i, env->enc);
-	  }
-	}
-	set_mml(&opt->len, 1, 1);
+        for (i = 0; i < SINGLE_BYTE_SIZE; i++) {
+          z = BITSET_AT(cc->bs, i);
+          if ((z && !IS_NCCLASS_NOT(cc)) || (!z && IS_NCCLASS_NOT(cc))) {
+            add_char_opt_map_info(&opt->map, (UChar )i, env->enc);
+          }
+        }
+        set_mml(&opt->len, 1, 1);
       }
     }
     break;
@@ -5106,30 +5106,30 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
       max = ONIGENC_MBC_MAXLEN_DIST(env->enc);
 
       if (max == 1) {
-	min = 1;
+        min = 1;
 
-	maxcode = NCTYPE(node)->ascii_range ? 0x80 : SINGLE_BYTE_SIZE;
-	switch (NCTYPE(node)->ctype) {
-	case ONIGENC_CTYPE_WORD:
-	  if (NCTYPE(node)->not != 0) {
-	    for (i = 0; i < SINGLE_BYTE_SIZE; i++) {
-	      if (! ONIGENC_IS_CODE_WORD(env->enc, i) || i >= maxcode) {
-		add_char_opt_map_info(&opt->map, (UChar )i, env->enc);
-	      }
-	    }
-	  }
-	  else {
-	    for (i = 0; i < maxcode; i++) {
-	      if (ONIGENC_IS_CODE_WORD(env->enc, i)) {
-		add_char_opt_map_info(&opt->map, (UChar )i, env->enc);
-	      }
-	    }
-	  }
-	  break;
-	}
+        maxcode = NCTYPE(node)->ascii_range ? 0x80 : SINGLE_BYTE_SIZE;
+        switch (NCTYPE(node)->ctype) {
+        case ONIGENC_CTYPE_WORD:
+          if (NCTYPE(node)->not != 0) {
+            for (i = 0; i < SINGLE_BYTE_SIZE; i++) {
+              if (! ONIGENC_IS_CODE_WORD(env->enc, i) || i >= maxcode) {
+                add_char_opt_map_info(&opt->map, (UChar )i, env->enc);
+              }
+            }
+          }
+          else {
+            for (i = 0; i < maxcode; i++) {
+              if (ONIGENC_IS_CODE_WORD(env->enc, i)) {
+                add_char_opt_map_info(&opt->map, (UChar )i, env->enc);
+              }
+            }
+          }
+          break;
+        }
       }
       else {
-	min = ONIGENC_MBC_MINLEN(env->enc);
+        min = ONIGENC_MBC_MINLEN(env->enc);
       }
       set_mml(&opt->len, min, max);
     }
@@ -5158,20 +5158,20 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
 
     case ANCHOR_PREC_READ:
       {
-	NodeOptInfo nopt;
+        NodeOptInfo nopt;
 
-	r = optimize_node_left(NANCHOR(node)->target, &nopt, env);
-	if (r == 0) {
-	  if (nopt.exb.len > 0)
-	    copy_opt_exact_info(&opt->expr, &nopt.exb);
-	  else if (nopt.exm.len > 0)
-	    copy_opt_exact_info(&opt->expr, &nopt.exm);
+        r = optimize_node_left(NANCHOR(node)->target, &nopt, env);
+        if (r == 0) {
+          if (nopt.exb.len > 0)
+            copy_opt_exact_info(&opt->expr, &nopt.exb);
+          else if (nopt.exm.len > 0)
+            copy_opt_exact_info(&opt->expr, &nopt.exm);
 
-	  opt->expr.reach_end = 0;
+          opt->expr.reach_end = 0;
 
-	  if (nopt.map.value > 0)
-	    copy_opt_map_info(&opt->map, &nopt.map);
-	}
+          if (nopt.map.value > 0)
+            copy_opt_map_info(&opt->map, &nopt.map);
+        }
       }
       break;
 
@@ -5189,8 +5189,8 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
       BRefNode* br = NBREF(node);
 
       if (br->state & NST_RECURSION) {
-	set_mml(&opt->len, 0, ONIG_INFINITE_DISTANCE);
-	break;
+        set_mml(&opt->len, 0, ONIG_INFINITE_DISTANCE);
+        break;
       }
       backs = BACKREFS_P(br);
       r = get_min_match_length(nodes[backs[0]], &min, env->scan_env);
@@ -5198,12 +5198,12 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
       r = get_max_match_length(nodes[backs[0]], &max, env->scan_env);
       if (r != 0) break;
       for (i = 1; i < br->back_num; i++) {
-	r = get_min_match_length(nodes[backs[i]], &tmin, env->scan_env);
-	if (r != 0) break;
-	r = get_max_match_length(nodes[backs[i]], &tmax, env->scan_env);
-	if (r != 0) break;
-	if (min > tmin) min = tmin;
-	if (max < tmax) max = tmax;
+        r = get_min_match_length(nodes[backs[i]], &tmin, env->scan_env);
+        if (r != 0) break;
+        r = get_max_match_length(nodes[backs[i]], &tmax, env->scan_env);
+        if (r != 0) break;
+        if (min > tmin) min = tmin;
+        if (max < tmax) max = tmax;
       }
       if (r == 0) set_mml(&opt->len, min, max);
     }
@@ -5233,44 +5233,44 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
       if (r) break;
 
       if (/*qn->lower == 0 &&*/ IS_REPEAT_INFINITE(qn->upper)) {
-	if (env->mmd.max == 0 &&
-	    NTYPE(qn->target) == NT_CANY && qn->greedy) {
-	  if (IS_MULTILINE(env->options))
-	    /* implicit anchor: /.*a/ ==> /\A.*a/ */
-	    add_opt_anc_info(&opt->anc, ANCHOR_ANYCHAR_STAR_ML);
-	  else
-	    add_opt_anc_info(&opt->anc, ANCHOR_ANYCHAR_STAR);
-	}
+        if (env->mmd.max == 0 &&
+            NTYPE(qn->target) == NT_CANY && qn->greedy) {
+          if (IS_MULTILINE(env->options))
+            /* implicit anchor: /.*a/ ==> /\A.*a/ */
+            add_opt_anc_info(&opt->anc, ANCHOR_ANYCHAR_STAR_ML);
+          else
+            add_opt_anc_info(&opt->anc, ANCHOR_ANYCHAR_STAR);
+        }
       }
       else {
-	if (qn->lower > 0) {
-	  copy_node_opt_info(opt, &nopt);
-	  if (nopt.exb.len > 0) {
-	    if (nopt.exb.reach_end) {
-	      for (i = 2; i <= qn->lower &&
-			  ! is_full_opt_exact_info(&opt->exb); i++) {
-		concat_opt_exact_info(&opt->exb, &nopt.exb, env->enc);
-	      }
-	      if (i < qn->lower) {
-		opt->exb.reach_end = 0;
-	      }
-	    }
-	  }
+        if (qn->lower > 0) {
+          copy_node_opt_info(opt, &nopt);
+          if (nopt.exb.len > 0) {
+            if (nopt.exb.reach_end) {
+              for (i = 2; i <= qn->lower &&
+                          ! is_full_opt_exact_info(&opt->exb); i++) {
+                concat_opt_exact_info(&opt->exb, &nopt.exb, env->enc);
+              }
+              if (i < qn->lower) {
+                opt->exb.reach_end = 0;
+              }
+            }
+          }
 
-	  if (qn->lower != qn->upper) {
-	    opt->exb.reach_end = 0;
-	    opt->exm.reach_end = 0;
-	  }
-	  if (qn->lower > 1)
-	    opt->exm.reach_end = 0;
-	}
+          if (qn->lower != qn->upper) {
+            opt->exb.reach_end = 0;
+            opt->exm.reach_end = 0;
+          }
+          if (qn->lower > 1)
+            opt->exm.reach_end = 0;
+        }
       }
 
       min = distance_multiply(nopt.len.min, qn->lower);
       if (IS_REPEAT_INFINITE(qn->upper))
-	max = (nopt.len.max > 0 ? ONIG_INFINITE_DISTANCE : 0);
+        max = (nopt.len.max > 0 ? ONIG_INFINITE_DISTANCE : 0);
       else
-	max = distance_multiply(nopt.len.max, qn->upper);
+        max = distance_multiply(nopt.len.max, qn->upper);
 
       set_mml(&opt->len, min, max);
     }
@@ -5282,47 +5282,47 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
 
       switch (en->type) {
       case ENCLOSE_OPTION:
-	{
-	  OnigOptionType save = env->options;
+        {
+          OnigOptionType save = env->options;
 
-	  env->options = en->option;
-	  r = optimize_node_left(en->target, opt, env);
-	  env->options = save;
-	}
-	break;
+          env->options = en->option;
+          r = optimize_node_left(en->target, opt, env);
+          env->options = save;
+        }
+        break;
 
       case ENCLOSE_MEMORY:
 #ifdef USE_SUBEXP_CALL
-	en->opt_count++;
-	if (en->opt_count > MAX_NODE_OPT_INFO_REF_COUNT) {
-	  OnigDistance min, max;
+        en->opt_count++;
+        if (en->opt_count > MAX_NODE_OPT_INFO_REF_COUNT) {
+          OnigDistance min, max;
 
-	  min = 0;
-	  max = ONIG_INFINITE_DISTANCE;
-	  if (IS_ENCLOSE_MIN_FIXED(en)) min = en->min_len;
-	  if (IS_ENCLOSE_MAX_FIXED(en)) max = en->max_len;
-	  set_mml(&opt->len, min, max);
-	}
-	else
+          min = 0;
+          max = ONIG_INFINITE_DISTANCE;
+          if (IS_ENCLOSE_MIN_FIXED(en)) min = en->min_len;
+          if (IS_ENCLOSE_MAX_FIXED(en)) max = en->max_len;
+          set_mml(&opt->len, min, max);
+        }
+        else
 #endif
-	{
-	  r = optimize_node_left(en->target, opt, env);
+        {
+          r = optimize_node_left(en->target, opt, env);
 
-	  if (is_set_opt_anc_info(&opt->anc, ANCHOR_ANYCHAR_STAR_MASK)) {
-	    if (BIT_STATUS_AT(env->scan_env->backrefed_mem, en->regnum))
-	      remove_opt_anc_info(&opt->anc, ANCHOR_ANYCHAR_STAR_MASK);
-	  }
-	}
-	break;
+          if (is_set_opt_anc_info(&opt->anc, ANCHOR_ANYCHAR_STAR_MASK)) {
+            if (BIT_STATUS_AT(env->scan_env->backrefed_mem, en->regnum))
+              remove_opt_anc_info(&opt->anc, ANCHOR_ANYCHAR_STAR_MASK);
+          }
+        }
+        break;
 
       case ENCLOSE_STOP_BACKTRACK:
       case ENCLOSE_CONDITION:
-	r = optimize_node_left(en->target, opt, env);
-	break;
+        r = optimize_node_left(en->target, opt, env);
+        break;
 
       case ENCLOSE_ABSENT:
-	set_mml(&opt->len, 0, ONIG_INFINITE_DISTANCE);
-	break;
+        set_mml(&opt->len, 0, ONIG_INFINITE_DISTANCE);
+        break;
       }
     }
     break;
@@ -5330,7 +5330,7 @@ optimize_node_left(Node* node, NodeOptInfo* opt, OptEnv* env)
   default:
 #ifdef ONIG_DEBUG
     fprintf(stderr, "optimize_node_left: undefined node type %d\n",
-	    NTYPE(node));
+            NTYPE(node));
 #endif
     r = ONIGERR_TYPE_BUG;
     break;
@@ -5353,18 +5353,18 @@ set_optimize_exact_info(regex_t* reg, OptExactInfo* e)
   reg->exact_end = reg->exact + e->len;
 
   allow_reverse =
-	ONIGENC_IS_ALLOWED_REVERSE_MATCH(reg->enc, reg->exact, reg->exact_end);
+        ONIGENC_IS_ALLOWED_REVERSE_MATCH(reg->enc, reg->exact, reg->exact_end);
 
   if (e->ignore_case > 0) {
     if (e->len >= 3 || (e->len >= 2 && allow_reverse)) {
       r = set_bm_skip(reg->exact, reg->exact_end, reg,
-		      reg->map, &(reg->int_map), 1);
+                      reg->map, &(reg->int_map), 1);
       if (r == 0) {
-	reg->optimize = (allow_reverse != 0
-			 ? ONIG_OPTIMIZE_EXACT_BM_IC : ONIG_OPTIMIZE_EXACT_BM_NOT_REV_IC);
+        reg->optimize = (allow_reverse != 0
+                         ? ONIG_OPTIMIZE_EXACT_BM_IC : ONIG_OPTIMIZE_EXACT_BM_NOT_REV_IC);
       }
       else {
-	reg->optimize = ONIG_OPTIMIZE_EXACT_IC;
+        reg->optimize = ONIG_OPTIMIZE_EXACT_IC;
       }
     }
     else {
@@ -5374,13 +5374,13 @@ set_optimize_exact_info(regex_t* reg, OptExactInfo* e)
   else {
     if (e->len >= 3 || (e->len >= 2 && allow_reverse)) {
       r = set_bm_skip(reg->exact, reg->exact_end, reg,
-		      reg->map, &(reg->int_map), 0);
+                      reg->map, &(reg->int_map), 0);
       if (r == 0) {
-	reg->optimize = (allow_reverse != 0
-		       ? ONIG_OPTIMIZE_EXACT_BM : ONIG_OPTIMIZE_EXACT_BM_NOT_REV);
+        reg->optimize = (allow_reverse != 0
+                       ? ONIG_OPTIMIZE_EXACT_BM : ONIG_OPTIMIZE_EXACT_BM_NOT_REV);
       }
       else {
-	reg->optimize = ONIG_OPTIMIZE_EXACT;
+        reg->optimize = ONIG_OPTIMIZE_EXACT;
       }
     }
     else {
@@ -5451,7 +5451,7 @@ set_optimize_info_from_tree(Node* node, regex_t* reg, ScanEnv* scan_env)
     reg->anchor &= ~ANCHOR_ANYCHAR_STAR_ML;
 
   reg->anchor |= opt.anc.right_anchor & (ANCHOR_END_BUF | ANCHOR_SEMI_END_BUF |
-	ANCHOR_PREC_READ_NOT);
+        ANCHOR_PREC_READ_NOT);
 
   if (reg->anchor & (ANCHOR_END_BUF | ANCHOR_SEMI_END_BUF)) {
     reg->anchor_dmin = opt.len.min;
@@ -5461,7 +5461,7 @@ set_optimize_info_from_tree(Node* node, regex_t* reg, ScanEnv* scan_env)
   if (opt.exb.len > 0 || opt.exm.len > 0) {
     select_opt_exact_info(reg->enc, &opt.exb, &opt.exm);
     if (opt.map.value > 0 &&
-	comp_opt_exact_or_map_info(&opt.exb, &opt.map) > 0) {
+        comp_opt_exact_or_map_info(&opt.exb, &opt.map) > 0) {
       goto set_map;
     }
     else {
@@ -5503,7 +5503,7 @@ clear_optimize_info(regex_t* reg)
 #ifdef ONIG_DEBUG
 
 static void print_enc_string(FILE* fp, OnigEncoding enc,
-			     const UChar *s, const UChar *end)
+                             const UChar *s, const UChar *end)
 {
   fprintf(fp, "\nPATTERN: /");
 
@@ -5515,10 +5515,10 @@ static void print_enc_string(FILE* fp, OnigEncoding enc,
     while (p < end) {
       code = ONIGENC_MBC_TO_CODE(enc, p, end);
       if (code >= 0x80) {
-	fprintf(fp, " 0x%04x ", (int )code);
+        fprintf(fp, " 0x%04x ", (int )code);
       }
       else {
-	fputc((int )code, fp);
+        fputc((int )code, fp);
       }
 
       p += enclen(enc, p, end);
@@ -5639,15 +5639,15 @@ print_optimize_info(FILE* f, regex_t* reg)
       c = 0;
       fputc('[', f);
       for (i = 0; i < ONIG_CHAR_TABLE_SIZE; i++) {
-	if (reg->map[i] != 0) {
-	  if (c > 0)  fputs(", ", f);
-	  c++;
-	  if (ONIGENC_MBC_MAXLEN(reg->enc) == 1 &&
-	      ONIGENC_IS_CODE_PRINT(reg->enc, (OnigCodePoint )i))
-	    fputc(i, f);
-	  else
-	    fprintf(f, "%d", i);
-	}
+        if (reg->map[i] != 0) {
+          if (c > 0)  fputs(", ", f);
+          c++;
+          if (ONIGENC_MBC_MAXLEN(reg->enc) == 1 &&
+              ONIGENC_IS_CODE_PRINT(reg->enc, (OnigCodePoint )i))
+            fputc(i, f);
+          else
+            fprintf(f, "%d", i);
+        }
       }
       fprintf(f, "]\n");
     }
@@ -5806,7 +5806,7 @@ static void print_tree(FILE* f, Node* node);
 #ifdef RUBY
 extern int
 onig_compile(regex_t* reg, const UChar* pattern, const UChar* pattern_end,
-	     OnigErrorInfo* einfo)
+             OnigErrorInfo* einfo)
 {
   return onig_compile_ruby(reg, pattern, pattern_end, einfo, NULL, 0);
 }
@@ -5815,11 +5815,11 @@ onig_compile(regex_t* reg, const UChar* pattern, const UChar* pattern_end,
 #ifdef RUBY
 extern int
 onig_compile_ruby(regex_t* reg, const UChar* pattern, const UChar* pattern_end,
-	      OnigErrorInfo* einfo, const char *sourcefile, int sourceline)
+              OnigErrorInfo* einfo, const char *sourcefile, int sourceline)
 #else
 extern int
 onig_compile(regex_t* reg, const UChar* pattern, const UChar* pattern_end,
-	     OnigErrorInfo* einfo)
+             OnigErrorInfo* einfo)
 #endif
 {
 #define COMPILE_INIT_SIZE  20
@@ -5936,10 +5936,10 @@ onig_compile(regex_t* reg, const UChar* pattern, const UChar* pattern_end,
     if (scan_env.comb_exp_max_regnum > 0) {
       int i;
       for (i = 1; i <= scan_env.comb_exp_max_regnum; i++) {
-	if (BIT_STATUS_AT(scan_env.backrefed_mem, i) != 0) {
-	  scan_env.num_comb_exp_check = 0;
-	  break;
-	}
+        if (BIT_STATUS_AT(scan_env.backrefed_mem, i) != 0) {
+          scan_env.num_comb_exp_check = 0;
+          break;
+        }
       }
     }
   }
@@ -5973,9 +5973,9 @@ onig_compile(regex_t* reg, const UChar* pattern, const UChar* pattern_end,
       reg->stack_pop_level = STACK_POP_LEVEL_ALL;
     else {
       if (reg->bt_mem_start != 0)
-	reg->stack_pop_level = STACK_POP_LEVEL_MEM_START;
+        reg->stack_pop_level = STACK_POP_LEVEL_MEM_START;
       else
-	reg->stack_pop_level = STACK_POP_LEVEL_FREE;
+        reg->stack_pop_level = STACK_POP_LEVEL_FREE;
     }
   }
 #ifdef USE_SUBEXP_CALL
@@ -6021,8 +6021,8 @@ static int onig_inited = 0;
 
 extern int
 onig_reg_init(regex_t* reg, OnigOptionType option,
-	      OnigCaseFoldType case_fold_flag,
-	      OnigEncoding enc, const OnigSyntaxType* syntax)
+              OnigCaseFoldType case_fold_flag,
+              OnigEncoding enc, const OnigSyntaxType* syntax)
 {
   if (! onig_inited)
     onig_init();
@@ -6082,8 +6082,8 @@ onig_new_without_alloc(regex_t* reg, const UChar* pattern,
 
 extern int
 onig_new(regex_t** reg, const UChar* pattern, const UChar* pattern_end,
-	  OnigOptionType option, OnigEncoding enc, const OnigSyntaxType* syntax,
-	  OnigErrorInfo* einfo)
+          OnigOptionType option, OnigEncoding enc, const OnigSyntaxType* syntax,
+          OnigErrorInfo* einfo)
 {
   *reg = (regex_t* )xmalloc(sizeof(regex_t));
   if (IS_NULL(*reg)) return ONIGERR_MEMORY;
@@ -6436,9 +6436,9 @@ onig_print_compiled_byte_code(FILE* f, UChar* bp, UChar* bpend, UChar** nextp,
       break;
     case ARG_OPTION:
       {
-	OnigOptionType option = *((OnigOptionType* )bp);
-	bp += SIZE_OPTION;
-	fprintf(f, ":%d", option);
+        OnigOptionType option = *((OnigOptionType* )bp);
+        bp += SIZE_OPTION;
+        fprintf(f, ":%d", option);
       }
       break;
 
@@ -6487,13 +6487,13 @@ onig_print_compiled_byte_code(FILE* f, UChar* bp, UChar* bpend, UChar** nextp,
       break;
     case OP_EXACTMBN:
       {
-	int mb_len;
+        int mb_len;
 
-	GET_LENGTH_INC(mb_len, bp);
-	GET_LENGTH_INC(len, bp);
-	fprintf(f, ":%d:%d:", mb_len, len);
-	n = len * mb_len;
-	while (n-- > 0) { fputc(*bp++, f); }
+        GET_LENGTH_INC(mb_len, bp);
+        GET_LENGTH_INC(len, bp);
+        fprintf(f, ":%d:%d:", mb_len, len);
+        n = len * mb_len;
+        while (n-- > 0) { fputc(*bp++, f); }
       }
       break;
 
@@ -6557,40 +6557,40 @@ onig_print_compiled_byte_code(FILE* f, UChar* bp, UChar* bpend, UChar** nextp,
       fputs(" ", f);
       GET_LENGTH_INC(len, bp);
       for (i = 0; i < len; i++) {
-	GET_MEMNUM_INC(mem, bp);
-	if (i > 0) fputs(", ", f);
-	fprintf(f, "%d", mem);
+        GET_MEMNUM_INC(mem, bp);
+        if (i > 0) fputs(", ", f);
+        fprintf(f, "%d", mem);
       }
       break;
 
     case OP_BACKREF_WITH_LEVEL:
       {
-	OnigOptionType option;
-	LengthType level;
+        OnigOptionType option;
+        LengthType level;
 
-	GET_OPTION_INC(option, bp);
-	fprintf(f, ":%d", option);
-	GET_LENGTH_INC(level, bp);
-	fprintf(f, ":%d", level);
+        GET_OPTION_INC(option, bp);
+        fprintf(f, ":%d", option);
+        GET_LENGTH_INC(level, bp);
+        fprintf(f, ":%d", level);
 
-	fputs(" ", f);
-	GET_LENGTH_INC(len, bp);
-	for (i = 0; i < len; i++) {
-	  GET_MEMNUM_INC(mem, bp);
-	  if (i > 0) fputs(", ", f);
-	  fprintf(f, "%d", mem);
-	}
+        fputs(" ", f);
+        GET_LENGTH_INC(len, bp);
+        for (i = 0; i < len; i++) {
+          GET_MEMNUM_INC(mem, bp);
+          if (i > 0) fputs(", ", f);
+          fprintf(f, "%d", mem);
+        }
       }
       break;
 
     case OP_REPEAT:
     case OP_REPEAT_NG:
       {
-	mem = *((MemNumType* )bp);
-	bp += SIZE_MEMNUM;
-	addr = *((RelAddrType* )bp);
-	bp += SIZE_RELADDR;
-	fprintf(f, ":%d:%d", mem, addr);
+        mem = *((MemNumType* )bp);
+        bp += SIZE_MEMNUM;
+        addr = *((RelAddrType* )bp);
+        bp += SIZE_RELADDR;
+        fprintf(f, ":%d:%d", mem, addr);
       }
       break;
 
@@ -6631,7 +6631,7 @@ onig_print_compiled_byte_code(FILE* f, UChar* bp, UChar* bpend, UChar** nextp,
 
     default:
       fprintf(stderr, "onig_print_compiled_byte_code: undefined code %d\n",
-	      bp[-1]);
+              bp[-1]);
     }
   }
   fputs("]", f);
@@ -6688,8 +6688,8 @@ print_indent_tree(FILE* f, Node* node, int indent)
     print_indent_tree(f, NCAR(node), indent + add);
     while (IS_NOT_NULL(node = NCDR(node))) {
       if (NTYPE(node) != type) {
-	fprintf(f, "ERROR: list/alt right is not a cons. %d\n", NTYPE(node));
-	exit(0);
+        fprintf(f, "ERROR: list/alt right is not a cons. %d\n", NTYPE(node));
+        exit(0);
       }
       print_indent_tree(f, NCAR(node), indent + add);
     }
@@ -6697,12 +6697,12 @@ print_indent_tree(FILE* f, Node* node, int indent)
 
   case NT_STR:
     fprintf(f, "<string%s:%"PRIxPTR">",
-	    (NSTRING_IS_RAW(node) ? "-raw" : ""), (intptr_t )node);
+            (NSTRING_IS_RAW(node) ? "-raw" : ""), (intptr_t )node);
     for (p = NSTR(node)->s; p < NSTR(node)->end; p++) {
       if (*p >= 0x20 && *p < 0x7f)
-	fputc(*p, f);
+        fputc(*p, f);
       else {
-	fprintf(f, " 0x%02x", *p);
+        fprintf(f, " 0x%02x", *p);
       }
     }
     break;
@@ -6716,8 +6716,8 @@ print_indent_tree(FILE* f, Node* node, int indent)
       OnigCodePoint* end = (OnigCodePoint* )(bbuf->p + bbuf->used);
       fprintf(f, "%d", *data++);
       for (; data < end; data+=2) {
-	fprintf(f, ",");
-	fprintf(f, "%04x-%04x", data[0], data[1]);
+        fprintf(f, ",");
+        fprintf(f, "%04x-%04x", data[0], data[1]);
       }
     }
     break;
@@ -6727,9 +6727,9 @@ print_indent_tree(FILE* f, Node* node, int indent)
     switch (NCTYPE(node)->ctype) {
     case ONIGENC_CTYPE_WORD:
       if (NCTYPE(node)->not != 0)
-	fputs("not word",       f);
+        fputs("not word",       f);
       else
-	fputs("word",           f);
+        fputs("word",           f);
       break;
 
     default:
@@ -6777,8 +6777,8 @@ print_indent_tree(FILE* f, Node* node, int indent)
       p = BACKREFS_P(br);
       fprintf(f, "<backref:%"PRIxPTR">", (intptr_t )node);
       for (i = 0; i < br->back_num; i++) {
-	if (i > 0) fputs(", ", f);
-	fprintf(f, "%d", p[i]);
+        if (i > 0) fputs(", ", f);
+        fprintf(f, "%d", p[i]);
       }
     }
     break;
@@ -6795,8 +6795,8 @@ print_indent_tree(FILE* f, Node* node, int indent)
 
   case NT_QTFR:
     fprintf(f, "<quantifier:%"PRIxPTR">{%d,%d}%s\n", (intptr_t )node,
-	    NQTFR(node)->lower, NQTFR(node)->upper,
-	    (NQTFR(node)->greedy ? "" : "?"));
+            NQTFR(node)->lower, NQTFR(node)->upper,
+            (NQTFR(node)->greedy ? "" : "?"));
     print_indent_tree(f, NQTFR(node)->target, indent + add);
     break;
 

--- a/regenc.c
+++ b/regenc.c
@@ -89,7 +89,7 @@ onigenc_get_right_adjust_char_head(OnigEncoding enc, const UChar* start, const U
 
 extern UChar*
 onigenc_get_right_adjust_char_head_with_prev(OnigEncoding enc,
-				   const UChar* start, const UChar* s, const UChar* end, const UChar** prev)
+                                   const UChar* start, const UChar* s, const UChar* end, const UChar** prev)
 {
   UChar* p = ONIGENC_LEFT_ADJUST_CHAR_HEAD(enc, start, s, end);
 
@@ -425,8 +425,8 @@ const OnigPairCaseFoldCodes OnigAsciiLowerMap[] = {
 
 extern int
 onigenc_ascii_apply_all_case_fold(OnigCaseFoldType flag ARG_UNUSED,
-				  OnigApplyAllCaseFoldFunc f, void* arg,
-				  OnigEncoding enc ARG_UNUSED)
+                                  OnigApplyAllCaseFoldFunc f, void* arg,
+                                  OnigEncoding enc ARG_UNUSED)
 {
   OnigCodePoint code;
   int i, r;
@@ -446,8 +446,8 @@ onigenc_ascii_apply_all_case_fold(OnigCaseFoldType flag ARG_UNUSED,
 
 extern int
 onigenc_ascii_get_case_fold_codes_by_str(OnigCaseFoldType flag ARG_UNUSED,
-	 const OnigUChar* p, const OnigUChar* end ARG_UNUSED,
-	 OnigCaseFoldCodeItem items[], OnigEncoding enc ARG_UNUSED)
+         const OnigUChar* p, const OnigUChar* end ARG_UNUSED,
+         OnigCaseFoldCodeItem items[], OnigEncoding enc ARG_UNUSED)
 {
   if (0x41 <= *p && *p <= 0x5a) {
     items[0].byte_len = 1;
@@ -467,7 +467,7 @@ onigenc_ascii_get_case_fold_codes_by_str(OnigCaseFoldType flag ARG_UNUSED,
 
 static int
 ss_apply_all_case_fold(OnigCaseFoldType flag ARG_UNUSED,
-		       OnigApplyAllCaseFoldFunc f, void* arg)
+                       OnigApplyAllCaseFoldFunc f, void* arg)
 {
   OnigCodePoint ss[] = { 0x73, 0x73 };
 
@@ -513,7 +513,7 @@ onigenc_get_case_fold_codes_by_str_with_map(int map_size,
     items[0].code_len = 1;
     items[0].code[0] = (OnigCodePoint )(*p + 0x20);
     if (*p == 0x53 && ess_tsett_flag != 0 && end > p + 1
-	&& (*(p+1) == 0x53 || *(p+1) == 0x73)) {
+        && (*(p+1) == 0x53 || *(p+1) == 0x73)) {
       /* SS */
       items[1].byte_len = 2;
       items[1].code_len = 1;
@@ -528,7 +528,7 @@ onigenc_get_case_fold_codes_by_str_with_map(int map_size,
     items[0].code_len = 1;
     items[0].code[0] = (OnigCodePoint )(*p - 0x20);
     if (*p == 0x73 && ess_tsett_flag != 0 && end > p + 1
-	&& (*(p+1) == 0x73 || *(p+1) == 0x53)) {
+        && (*(p+1) == 0x73 || *(p+1) == 0x53)) {
       /* ss */
       items[1].byte_len = 2;
       items[1].code_len = 1;
@@ -566,16 +566,16 @@ onigenc_get_case_fold_codes_by_str_with_map(int map_size,
 
     for (i = 0; i < map_size; i++) {
       if (*p == map[i].from) {
-	items[0].byte_len = 1;
-	items[0].code_len = 1;
-	items[0].code[0] = map[i].to;
-	return 1;
+        items[0].byte_len = 1;
+        items[0].code_len = 1;
+        items[0].code[0] = map[i].to;
+        return 1;
       }
       else if (*p == map[i].to) {
-	items[0].byte_len = 1;
-	items[0].code_len = 1;
-	items[0].code[0] = map[i].from;
-	return 1;
+        items[0].byte_len = 1;
+        items[0].code_len = 1;
+        items[0].code[0] = map[i].from;
+        return 1;
       }
     }
   }
@@ -586,9 +586,9 @@ onigenc_get_case_fold_codes_by_str_with_map(int map_size,
 
 extern int
 onigenc_not_support_get_ctype_code_range(OnigCtype ctype ARG_UNUSED,
-	 OnigCodePoint* sb_out ARG_UNUSED,
-	 const OnigCodePoint* ranges[] ARG_UNUSED,
-	 OnigEncoding enc)
+         OnigCodePoint* sb_out ARG_UNUSED,
+         const OnigCodePoint* ranges[] ARG_UNUSED,
+         OnigEncoding enc)
 {
   return ONIG_NO_SUPPORT_CONFIG;
 }
@@ -605,7 +605,7 @@ onigenc_is_mbc_newline_0x0a(const UChar* p, const UChar* end, OnigEncoding enc A
 /* for single byte encodings */
 extern int
 onigenc_ascii_mbc_case_fold(OnigCaseFoldType flag ARG_UNUSED, const UChar** p,
-			    const UChar* end, UChar* lower, OnigEncoding enc ARG_UNUSED)
+                            const UChar* end, UChar* lower, OnigEncoding enc ARG_UNUSED)
 {
   *lower = ONIGENC_ASCII_CODE_TO_LOWER_CASE(**p);
 
@@ -616,7 +616,7 @@ onigenc_ascii_mbc_case_fold(OnigCaseFoldType flag ARG_UNUSED, const UChar** p,
 #if 0
 extern int
 onigenc_ascii_is_mbc_ambiguous(OnigCaseFoldType flag ARG_UNUSED,
-			       const UChar** pp, const UChar* end ARG_UNUSED)
+                               const UChar** pp, const UChar* end ARG_UNUSED)
 {
   const UChar* p = *pp;
 
@@ -627,14 +627,14 @@ onigenc_ascii_is_mbc_ambiguous(OnigCaseFoldType flag ARG_UNUSED,
 
 extern int
 onigenc_single_byte_mbc_enc_len(const UChar* p ARG_UNUSED, const UChar* e ARG_UNUSED,
-				OnigEncoding enc ARG_UNUSED)
+                                OnigEncoding enc ARG_UNUSED)
 {
   return 1;
 }
 
 extern OnigCodePoint
 onigenc_single_byte_mbc_to_code(const UChar* p, const UChar* end ARG_UNUSED,
-				OnigEncoding enc ARG_UNUSED)
+                                OnigEncoding enc ARG_UNUSED)
 {
   return (OnigCodePoint )(*p);
 }
@@ -658,25 +658,25 @@ onigenc_single_byte_code_to_mbc(OnigCodePoint code, UChar *buf, OnigEncoding enc
 
 extern UChar*
 onigenc_single_byte_left_adjust_char_head(const UChar* start ARG_UNUSED,
-					  const UChar* s,
-					  const UChar* end ARG_UNUSED,
-					  OnigEncoding enc ARG_UNUSED)
+                                          const UChar* s,
+                                          const UChar* end ARG_UNUSED,
+                                          OnigEncoding enc ARG_UNUSED)
 {
   return (UChar* )s;
 }
 
 extern int
 onigenc_always_true_is_allowed_reverse_match(const UChar* s   ARG_UNUSED,
-					     const UChar* end ARG_UNUSED,
-					     OnigEncoding enc ARG_UNUSED)
+                                             const UChar* end ARG_UNUSED,
+                                             OnigEncoding enc ARG_UNUSED)
 {
   return TRUE;
 }
 
 extern int
 onigenc_always_false_is_allowed_reverse_match(const UChar* s   ARG_UNUSED,
-					      const UChar* end ARG_UNUSED,
-					      OnigEncoding enc ARG_UNUSED)
+                                              const UChar* end ARG_UNUSED,
+                                              OnigEncoding enc ARG_UNUSED)
 {
   return FALSE;
 }
@@ -712,7 +712,7 @@ onigenc_mbn_mbc_to_code(OnigEncoding enc, const UChar* p, const UChar* end)
 extern int
 onigenc_mbn_mbc_case_fold(OnigEncoding enc, OnigCaseFoldType flag ARG_UNUSED,
                           const UChar** pp, const UChar* end ARG_UNUSED,
-			  UChar* lower)
+                          UChar* lower)
 {
   int len;
   const UChar *p = *pp;
@@ -843,7 +843,7 @@ onigenc_minimum_property_name_to_ctype(OnigEncoding enc, const UChar* p, const U
 
 extern int
 onigenc_mb2_is_code_ctype(OnigEncoding enc, OnigCodePoint code,
-			  unsigned int ctype)
+                          unsigned int ctype)
 {
   if (code < 128)
     return ONIGENC_IS_ASCII_CODE_CTYPE(code, ctype);
@@ -858,7 +858,7 @@ onigenc_mb2_is_code_ctype(OnigEncoding enc, OnigCodePoint code,
 
 extern int
 onigenc_mb4_is_code_ctype(OnigEncoding enc, OnigCodePoint code,
-			  unsigned int ctype)
+                          unsigned int ctype)
 {
   if (code < 128)
     return ONIGENC_IS_ASCII_CODE_CTYPE(code, ctype);
@@ -961,14 +961,14 @@ onigenc_property_list_add_property(UChar* name, const OnigCodePoint* prop,
 
   *pnum = *pnum + 1;
   onig_st_insert_strend(*table, name, name + strlen((char* )name),
-			(hash_data_type )(*pnum + ONIGENC_MAX_STD_CTYPE));
+                        (hash_data_type )(*pnum + ONIGENC_MAX_STD_CTYPE));
   return 0;
 }
 #endif
 
 extern int
 onigenc_ascii_only_case_map(OnigCaseFoldType* flagP, const OnigUChar** pp, const OnigUChar* end,
-			    OnigUChar* to, OnigUChar* to_end, const struct OnigEncodingTypeST* enc)
+                            OnigUChar* to, OnigUChar* to_end, const struct OnigEncodingTypeST* enc)
 {
   OnigCodePoint code;
   OnigUChar *to_start = to;
@@ -987,7 +987,7 @@ onigenc_ascii_only_case_map(OnigCaseFoldType* flagP, const OnigUChar** pp, const
       code += 'A' - 'a';
     }
     else if (code >= 'A' && code <= 'Z' &&
-	(flags & (ONIGENC_CASE_DOWNCASE | ONIGENC_CASE_FOLD))) {
+        (flags & (ONIGENC_CASE_DOWNCASE | ONIGENC_CASE_FOLD))) {
       flags |= ONIGENC_CASE_MODIFIED;
       code += 'a' - 'A';
     }
@@ -1001,8 +1001,8 @@ onigenc_ascii_only_case_map(OnigCaseFoldType* flagP, const OnigUChar** pp, const
 
 extern int
 onigenc_single_byte_ascii_only_case_map(OnigCaseFoldType* flagP, const OnigUChar** pp,
-					const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
-					const struct OnigEncodingTypeST* enc)
+                                        const OnigUChar* end, OnigUChar* to, OnigUChar* to_end,
+                                        const struct OnigEncodingTypeST* enc)
 {
   OnigCodePoint code;
   OnigUChar *to_start = to;
@@ -1016,7 +1016,7 @@ onigenc_single_byte_ascii_only_case_map(OnigCaseFoldType* flagP, const OnigUChar
       code += 'A' - 'a';
     }
     else if (code >= 'A' && code <= 'Z' &&
-	(flags & (ONIGENC_CASE_DOWNCASE | ONIGENC_CASE_FOLD))) {
+        (flags & (ONIGENC_CASE_DOWNCASE | ONIGENC_CASE_FOLD))) {
       flags |= ONIGENC_CASE_MODIFIED;
       code += 'a' - 'A';
     }

--- a/regenc.h
+++ b/regenc.h
@@ -192,8 +192,8 @@ ONIG_EXTERN int onigenc_unicode_apply_all_case_fold(OnigCaseFoldType flag, OnigA
 #define UTF16_IS_SURROGATE_SECOND(c)   (((c) & 0xfc) == 0xdc)
 #define UTF16_IS_SURROGATE(c)          (((c) & 0xf8) == 0xd8)
 #define UNICODE_VALID_CODEPOINT_P(c) ( \
-	((c) <= 0x10ffff) && \
-	!((c) < 0x10000 && UTF16_IS_SURROGATE((c) >> 8)))
+        ((c) <= 0x10ffff) && \
+        !((c) < 0x10000 && UTF16_IS_SURROGATE((c) >> 8)))
 
 #define ONIGENC_ISO_8859_1_TO_LOWER_CASE(c) \
   OnigEncISO_8859_1_ToLowerCaseTable[c]
@@ -239,8 +239,8 @@ extern int ONIG_ENC_REGISTER(const char *, OnigEncoding);
 # define OnigEncodingDefine(f,n)			     \
     OnigEncodingDeclare(n);			     \
     void Init_##f(void) {			     \
-	ONIG_ENC_REGISTER(OnigEncodingName(n).name,  \
-			  &OnigEncodingName(n));     \
+        ONIG_ENC_REGISTER(OnigEncodingName(n).name,  \
+                          &OnigEncodingName(n));     \
     }						     \
     OnigEncodingDeclare(n)
 #else

--- a/regerror.c
+++ b/regerror.c
@@ -194,7 +194,7 @@ static void sprint_byte_with_x(char* s, unsigned int v)
 }
 
 static int to_ascii(OnigEncoding enc, UChar *s, UChar *end,
-		    UChar buf[], int buf_size, int *is_over)
+                    UChar buf[], int buf_size, int *is_over)
 {
   int len;
   UChar *p;
@@ -206,24 +206,24 @@ static int to_ascii(OnigEncoding enc, UChar *s, UChar *end,
     while (p < end) {
       code = ONIGENC_MBC_TO_CODE(enc, p, end);
       if (code >= 0x80) {
-	if (code > 0xffff && len + 10 <= buf_size) {
-	  sprint_byte_with_x((char*)(&(buf[len])), (unsigned int)(code >> 24));
-	  sprint_byte((char*)(&(buf[len+4])),      (unsigned int)(code >> 16));
-	  sprint_byte((char*)(&(buf[len+6])),      (unsigned int)(code >>  8));
-	  sprint_byte((char*)(&(buf[len+8])),      (unsigned int)code);
-	  len += 10;
-	}
-	else if (len + 6 <= buf_size) {
-	  sprint_byte_with_x((char*)(&(buf[len])), (unsigned int)(code >> 8));
-	  sprint_byte((char*)(&(buf[len+4])),      (unsigned int)code);
-	  len += 6;
-	}
-	else {
-	  break;
-	}
+        if (code > 0xffff && len + 10 <= buf_size) {
+          sprint_byte_with_x((char*)(&(buf[len])), (unsigned int)(code >> 24));
+          sprint_byte((char*)(&(buf[len+4])),      (unsigned int)(code >> 16));
+          sprint_byte((char*)(&(buf[len+6])),      (unsigned int)(code >>  8));
+          sprint_byte((char*)(&(buf[len+8])),      (unsigned int)code);
+          len += 10;
+        }
+        else if (len + 6 <= buf_size) {
+          sprint_byte_with_x((char*)(&(buf[len])), (unsigned int)(code >> 8));
+          sprint_byte((char*)(&(buf[len+4])),      (unsigned int)code);
+          len += 6;
+        }
+        else {
+          break;
+        }
       }
       else {
-	buf[len++] = (UChar )code;
+        buf[len++] = (UChar )code;
       }
 
       p += enclen(enc, p, end);
@@ -267,27 +267,27 @@ onig_error_code_to_str(UChar* s, OnigPosition code, ...)
   case ONIGERR_INVALID_CHAR_PROPERTY_NAME:
     einfo = va_arg(vargs, OnigErrorInfo*);
     len = to_ascii(einfo->enc, einfo->par, einfo->par_end,
-		   parbuf, MAX_ERROR_PAR_LEN - 3, &is_over);
+                   parbuf, MAX_ERROR_PAR_LEN - 3, &is_over);
     q = onig_error_code_to_format(code);
     p = s;
     while (*q != '\0') {
       if (*q == '%') {
-	q++;
-	if (*q == 'n') { /* '%n': name */
-	  xmemcpy(p, parbuf, len);
-	  p += len;
-	  if (is_over != 0) {
-	    xmemcpy(p, "...", 3);
-	    p += 3;
-	  }
-	  q++;
-	}
-	else
-	  goto normal_char;
+        q++;
+        if (*q == 'n') { /* '%n': name */
+          xmemcpy(p, parbuf, len);
+          p += len;
+          if (is_over != 0) {
+            xmemcpy(p, "...", 3);
+            p += 3;
+          }
+          q++;
+        }
+        else
+          goto normal_char;
       }
       else {
       normal_char:
-	*p++ = *q++;
+        *p++ = *q++;
       }
     }
     *p = '\0';
@@ -348,24 +348,24 @@ onig_vsnprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc,
         }
       }
       else if (*p == '\\') {
-	*s++ = *p++;
-	len = enclen(enc, p, pat_end);
-	while (len-- > 0) *s++ = *p++;
+        *s++ = *p++;
+        len = enclen(enc, p, pat_end);
+        while (len-- > 0) *s++ = *p++;
       }
       else if (*p == '/') {
-	*s++ = (unsigned char )'\\';
-	*s++ = *p++;
+        *s++ = (unsigned char )'\\';
+        *s++ = *p++;
       }
       else if (!ONIGENC_IS_CODE_PRINT(enc, *p) &&
-	       (!ONIGENC_IS_CODE_SPACE(enc, *p) ||
+               (!ONIGENC_IS_CODE_SPACE(enc, *p) ||
                 ONIGENC_IS_CODE_CNTRL(enc, *p))) {
-	sprint_byte_with_x((char* )bs, (unsigned int )(*p++));
-	len = onigenc_str_bytelen_null(ONIG_ENCODING_ASCII, bs);
+        sprint_byte_with_x((char* )bs, (unsigned int )(*p++));
+        len = onigenc_str_bytelen_null(ONIG_ENCODING_ASCII, bs);
         bp = bs;
-	while (len-- > 0) *s++ = *bp++;
+        while (len-- > 0) *s++ = *bp++;
       }
       else {
-	*s++ = *p++;
+        *s++ = *p++;
       }
     }
 
@@ -382,7 +382,7 @@ onig_snprintf_with_pattern(UChar buf[], int bufsize, OnigEncoding enc,
   va_list args;
   va_start(args, fmt);
   onig_vsnprintf_with_pattern(buf, bufsize, enc,
-	  pat, pat_end, fmt, args);
+          pat, pat_end, fmt, args);
   va_end(args);
 }
 #endif

--- a/regexec.c
+++ b/regexec.c
@@ -55,7 +55,7 @@ rb_enc_asciicompat(OnigEncoding enc)
 # define ONIGENC_IS_MBC_ASCII_WORD(enc,s,end) \
     (rb_enc_asciicompat(enc) ? (ISALNUM(*s) || *s=='_') : \
    onigenc_ascii_is_code_ctype( \
-	ONIGENC_MBC_TO_CODE(enc,s,end),ONIGENC_CTYPE_WORD,enc))
+        ONIGENC_MBC_TO_CODE(enc,s,end),ONIGENC_CTYPE_WORD,enc))
 #endif /* RUBY */
 
 #ifdef USE_CRNL_AS_LINE_TERMINATOR
@@ -66,28 +66,28 @@ rb_enc_asciicompat(OnigEncoding enc)
   is_mbc_newline_ex((enc),(p),(start),(end),(option),(check_prev))
 static int
 is_mbc_newline_ex(OnigEncoding enc, const UChar *p, const UChar *start,
-		  const UChar *end, OnigOptionType option, int check_prev)
+                  const UChar *end, OnigOptionType option, int check_prev)
 {
   if (IS_NEWLINE_CRLF(option)) {
     if (ONIGENC_MBC_TO_CODE(enc, p, end) == 0x0a) {
       if (check_prev) {
-	const UChar *prev = onigenc_get_prev_char_head(enc, start, p, end);
-	if ((prev != NULL) && ONIGENC_MBC_TO_CODE(enc, prev, end) == 0x0d)
-	  return 0;
-	else
-	  return 1;
+        const UChar *prev = onigenc_get_prev_char_head(enc, start, p, end);
+        if ((prev != NULL) && ONIGENC_MBC_TO_CODE(enc, prev, end) == 0x0d)
+          return 0;
+        else
+          return 1;
       }
       else
-	return 1;
+        return 1;
     }
     else {
       const UChar *pnext = p + enclen(enc, p, end);
       if (pnext < end &&
-	  ONIGENC_MBC_TO_CODE(enc, p, end) == 0x0d &&
-	  ONIGENC_MBC_TO_CODE(enc, pnext, end) == 0x0a)
-	return 1;
+          ONIGENC_MBC_TO_CODE(enc, p, end) == 0x0d &&
+          ONIGENC_MBC_TO_CODE(enc, pnext, end) == 0x0a)
+        return 1;
       if (ONIGENC_IS_MBC_NEWLINE(enc, p, end))
-	return 1;
+        return 1;
       return 0;
     }
   }
@@ -111,7 +111,7 @@ history_tree_clear(OnigCaptureTreeNode* node)
   if (IS_NOT_NULL(node)) {
     for (i = 0; i < node->num_childs; i++) {
       if (IS_NOT_NULL(node->childs[i])) {
-	history_tree_free(node->childs[i]);
+        history_tree_free(node->childs[i]);
       }
     }
     for (i = 0; i < node->allocated; i++) {
@@ -170,18 +170,18 @@ history_tree_add_child(OnigCaptureTreeNode* parent, OnigCaptureTreeNode* child)
     if (IS_NULL(parent->childs)) {
       n = HISTORY_TREE_INIT_ALLOC_SIZE;
       parent->childs =
-	(OnigCaptureTreeNode** )xmalloc(sizeof(OnigCaptureTreeNode*) * n);
+        (OnigCaptureTreeNode** )xmalloc(sizeof(OnigCaptureTreeNode*) * n);
       CHECK_NULL_RETURN_MEMERR(parent->childs);
     }
     else {
       OnigCaptureTreeNode** tmp;
       n = parent->allocated * 2;
       tmp =
-	(OnigCaptureTreeNode** )xrealloc(parent->childs,
-					 sizeof(OnigCaptureTreeNode*) * n);
+        (OnigCaptureTreeNode** )xrealloc(parent->childs,
+                                         sizeof(OnigCaptureTreeNode*) * n);
       if (tmp == 0) {
-	history_tree_clear(parent);
-	return ONIGERR_MEMORY;
+        history_tree_clear(parent);
+        return ONIGERR_MEMORY;
       }
       parent->childs = tmp;
     }
@@ -276,7 +276,7 @@ static OnigPosition count_num_cache_opcodes_inner(
     switch (*p++) {
       case OP_FINISH:
       case OP_END:
-	break;
+        break;
 
       case OP_EXACT1: p++; break;
       case OP_EXACT2: p += 2; break;
@@ -284,50 +284,50 @@ static OnigPosition count_num_cache_opcodes_inner(
       case OP_EXACT4: p += 4; break;
       case OP_EXACT5: p += 5; break;
       case OP_EXACTN:
-	GET_LENGTH_INC(len, p); p += len; break;
+        GET_LENGTH_INC(len, p); p += len; break;
       case OP_EXACTMB2N1: p += 2; break;
       case OP_EXACTMB2N2: p += 4; break;
       case OP_EXACTMB2N3: p += 6; break;
       case OP_EXACTMB2N:
-	GET_LENGTH_INC(len, p); p += len * 2; break;
+        GET_LENGTH_INC(len, p); p += len * 2; break;
       case OP_EXACTMB3N:
-	GET_LENGTH_INC(len, p); p += len * 3; break;
+        GET_LENGTH_INC(len, p); p += len * 3; break;
       case OP_EXACTMBN:
-	{
-	  int mb_len;
-	  GET_LENGTH_INC(mb_len, p);
-	  GET_LENGTH_INC(len, p);
-	  p += mb_len * len;
-	}
-	break;
+        {
+          int mb_len;
+          GET_LENGTH_INC(mb_len, p);
+          GET_LENGTH_INC(len, p);
+          p += mb_len * len;
+        }
+        break;
 
       case OP_EXACT1_IC:
-	len = enclen(enc, p, pend); p += len; break;
+        len = enclen(enc, p, pend); p += len; break;
       case OP_EXACTN_IC:
-	GET_LENGTH_INC(len, p); p += len; break;
+        GET_LENGTH_INC(len, p); p += len; break;
 
       case OP_CCLASS:
       case OP_CCLASS_NOT:
-	p += SIZE_BITSET; break;
+        p += SIZE_BITSET; break;
       case OP_CCLASS_MB:
       case OP_CCLASS_MB_NOT:
-	GET_LENGTH_INC(len, p); p += len; break;
+        GET_LENGTH_INC(len, p); p += len; break;
       case OP_CCLASS_MIX:
       case OP_CCLASS_MIX_NOT:
-	p += SIZE_BITSET;
-	GET_LENGTH_INC(len, p);
-	p += len;
-	break;
+        p += SIZE_BITSET;
+        GET_LENGTH_INC(len, p);
+        p += len;
+        break;
 
       case OP_ANYCHAR:
       case OP_ANYCHAR_ML:
-	break;
+        break;
       case OP_ANYCHAR_STAR:
       case OP_ANYCHAR_ML_STAR:
-	num_cache_opcodes++; break;
+        num_cache_opcodes++; break;
       case OP_ANYCHAR_STAR_PEEK_NEXT:
       case OP_ANYCHAR_ML_STAR_PEEK_NEXT:
-	p++; num_cache_opcodes++; break;
+        p++; num_cache_opcodes++; break;
 
       case OP_WORD:
       case OP_NOT_WORD:
@@ -335,7 +335,7 @@ static OnigPosition count_num_cache_opcodes_inner(
       case OP_NOT_WORD_BOUND:
       case OP_WORD_BEGIN:
       case OP_WORD_END:
-	break;
+        break;
 
       case OP_ASCII_WORD:
       case OP_NOT_ASCII_WORD:
@@ -343,7 +343,7 @@ static OnigPosition count_num_cache_opcodes_inner(
       case OP_NOT_ASCII_WORD_BOUND:
       case OP_ASCII_WORD_BEGIN:
       case OP_ASCII_WORD_END:
-	break;
+        break;
 
       case OP_BEGIN_BUF:
       case OP_END_BUF:
@@ -351,7 +351,7 @@ static OnigPosition count_num_cache_opcodes_inner(
       case OP_END_LINE:
       case OP_SEMI_END_BUF:
       case OP_BEGIN_POSITION:
-	break;
+        break;
 
       case OP_BACKREF1:
       case OP_BACKREF2:
@@ -360,7 +360,7 @@ static OnigPosition count_num_cache_opcodes_inner(
       case OP_BACKREF_MULTI:
       case OP_BACKREF_MULTI_IC:
       case OP_BACKREF_WITH_LEVEL:
-	goto impossible;
+        goto impossible;
 
       case OP_MEMORY_START:
       case OP_MEMORY_START_PUSH:
@@ -368,158 +368,158 @@ static OnigPosition count_num_cache_opcodes_inner(
       case OP_MEMORY_END_PUSH_REC:
       case OP_MEMORY_END:
       case OP_MEMORY_END_REC:
-	p += SIZE_MEMNUM;
-	// A memory (capture) in look-around is found.
-	if (lookaround_nesting != 0) {
-	  goto impossible;
+        p += SIZE_MEMNUM;
+        // A memory (capture) in look-around is found.
+        if (lookaround_nesting != 0) {
+          goto impossible;
         }
-	break;
+        break;
 
       case OP_KEEP:
-	break;
+        break;
 
       case OP_FAIL:
-	break;
+        break;
       case OP_JUMP:
-	p += SIZE_RELADDR;
-	break;
+        p += SIZE_RELADDR;
+        break;
       case OP_PUSH:
-	p += SIZE_RELADDR;
-	num_cache_opcodes++;
-	break;
+        p += SIZE_RELADDR;
+        num_cache_opcodes++;
+        break;
       case OP_POP:
-	break;
+        break;
       case OP_PUSH_OR_JUMP_EXACT1:
       case OP_PUSH_IF_PEEK_NEXT:
-	p += SIZE_RELADDR + 1; num_cache_opcodes++; break;
+        p += SIZE_RELADDR + 1; num_cache_opcodes++; break;
       case OP_REPEAT:
       case OP_REPEAT_NG:
-	if (current_repeat_mem != -1) {
-	  // A nested OP_REPEAT is not yet supported.
-	  goto impossible;
-	}
-	GET_MEMNUM_INC(repeat_mem, p);
-	p += SIZE_RELADDR;
-	if (reg->repeat_range[repeat_mem].lower == 0 && reg->repeat_range[repeat_mem].upper == 0) {
-	  long dummy_num_cache_opcodes = 0;
-	  result = count_num_cache_opcodes_inner(reg, repeat_mem, lookaround_nesting, &p, &dummy_num_cache_opcodes);
-	  if (result < 0 || dummy_num_cache_opcodes < 0) {
-	    goto fail;
-	  }
-	} else {
-	  if (reg->repeat_range[repeat_mem].lower == 0) {
-	    num_cache_opcodes++;
-	  }
-	  result = count_num_cache_opcodes_inner(reg, repeat_mem, lookaround_nesting, &p, &num_cache_opcodes);
-	  if (result < 0 || num_cache_opcodes < 0) {
-	    goto fail;
-	  }
-	  OnigRepeatRange *repeat_range = &reg->repeat_range[repeat_mem];
-	  if (repeat_range->lower < repeat_range->upper) {
-	    num_cache_opcodes++;
-	  }
-	}
-	break;
+        if (current_repeat_mem != -1) {
+          // A nested OP_REPEAT is not yet supported.
+          goto impossible;
+        }
+        GET_MEMNUM_INC(repeat_mem, p);
+        p += SIZE_RELADDR;
+        if (reg->repeat_range[repeat_mem].lower == 0 && reg->repeat_range[repeat_mem].upper == 0) {
+          long dummy_num_cache_opcodes = 0;
+          result = count_num_cache_opcodes_inner(reg, repeat_mem, lookaround_nesting, &p, &dummy_num_cache_opcodes);
+          if (result < 0 || dummy_num_cache_opcodes < 0) {
+            goto fail;
+          }
+        } else {
+          if (reg->repeat_range[repeat_mem].lower == 0) {
+            num_cache_opcodes++;
+          }
+          result = count_num_cache_opcodes_inner(reg, repeat_mem, lookaround_nesting, &p, &num_cache_opcodes);
+          if (result < 0 || num_cache_opcodes < 0) {
+            goto fail;
+          }
+          OnigRepeatRange *repeat_range = &reg->repeat_range[repeat_mem];
+          if (repeat_range->lower < repeat_range->upper) {
+            num_cache_opcodes++;
+          }
+        }
+        break;
       case OP_REPEAT_INC:
       case OP_REPEAT_INC_NG:
-	GET_MEMNUM_INC(repeat_mem, p);
-	if (repeat_mem != current_repeat_mem) {
-	  // A lone or invalid OP_REPEAT_INC is found.
-	  goto impossible;
-	}
-	goto exit;
+        GET_MEMNUM_INC(repeat_mem, p);
+        if (repeat_mem != current_repeat_mem) {
+          // A lone or invalid OP_REPEAT_INC is found.
+          goto impossible;
+        }
+        goto exit;
       case OP_REPEAT_INC_SG:
       case OP_REPEAT_INC_NG_SG:
-	goto impossible;
+        goto impossible;
       case OP_NULL_CHECK_START:
-	p += SIZE_MEMNUM;
-	break;
+        p += SIZE_MEMNUM;
+        break;
       case OP_NULL_CHECK_END:
       case OP_NULL_CHECK_END_MEMST_PUSH:
-	p += SIZE_MEMNUM;
-	break;
+        p += SIZE_MEMNUM;
+        break;
       case OP_NULL_CHECK_END_MEMST:
-	p += SIZE_MEMNUM;
-	break;
+        p += SIZE_MEMNUM;
+        break;
 
       case OP_PUSH_POS:
-	if (lookaround_nesting < 0) {
-	  // A look-around nested in a atomic grouping is found.
-	  goto impossible;
-	}
-	result = count_num_cache_opcodes_inner(reg, current_repeat_mem, lookaround_nesting + 1, &p, &num_cache_opcodes);
-	if (result < 0 || num_cache_opcodes < 0) {
-	  goto fail;
-	}
-	break;
+        if (lookaround_nesting < 0) {
+          // A look-around nested in a atomic grouping is found.
+          goto impossible;
+        }
+        result = count_num_cache_opcodes_inner(reg, current_repeat_mem, lookaround_nesting + 1, &p, &num_cache_opcodes);
+        if (result < 0 || num_cache_opcodes < 0) {
+          goto fail;
+        }
+        break;
       case OP_PUSH_POS_NOT:
-	if (lookaround_nesting < 0) {
-	  // A look-around nested in a atomic grouping is found.
-	  goto impossible;
-	}
-	p += SIZE_RELADDR;
-	result = count_num_cache_opcodes_inner(reg, current_repeat_mem, lookaround_nesting + 1, &p, &num_cache_opcodes);
-	if (result < 0 || num_cache_opcodes < 0) {
-	  goto fail;
-	}
-	break;
+        if (lookaround_nesting < 0) {
+          // A look-around nested in a atomic grouping is found.
+          goto impossible;
+        }
+        p += SIZE_RELADDR;
+        result = count_num_cache_opcodes_inner(reg, current_repeat_mem, lookaround_nesting + 1, &p, &num_cache_opcodes);
+        if (result < 0 || num_cache_opcodes < 0) {
+          goto fail;
+        }
+        break;
       case OP_PUSH_LOOK_BEHIND_NOT:
-	if (lookaround_nesting < 0) {
-	  // A look-around nested in a atomic grouping is found.
-	  goto impossible;
-	}
-	p += SIZE_RELADDR;
-	p += SIZE_LENGTH;
-	result = count_num_cache_opcodes_inner(reg, current_repeat_mem, lookaround_nesting + 1, &p, &num_cache_opcodes);
-	if (result < 0 || num_cache_opcodes < 0) {
-	  goto fail;
-	}
-	break;
+        if (lookaround_nesting < 0) {
+          // A look-around nested in a atomic grouping is found.
+          goto impossible;
+        }
+        p += SIZE_RELADDR;
+        p += SIZE_LENGTH;
+        result = count_num_cache_opcodes_inner(reg, current_repeat_mem, lookaround_nesting + 1, &p, &num_cache_opcodes);
+        if (result < 0 || num_cache_opcodes < 0) {
+          goto fail;
+        }
+        break;
       case OP_PUSH_STOP_BT:
-	if (lookaround_nesting != 0) {
-	  // A nested atomic grouping is found.
-	  goto impossible;
-	}
-	result = count_num_cache_opcodes_inner(reg, current_repeat_mem, -1, &p, &num_cache_opcodes);
-	if (result < 0 || num_cache_opcodes < 0) {
-	  goto fail;
-	}
-	break;
+        if (lookaround_nesting != 0) {
+          // A nested atomic grouping is found.
+          goto impossible;
+        }
+        result = count_num_cache_opcodes_inner(reg, current_repeat_mem, -1, &p, &num_cache_opcodes);
+        if (result < 0 || num_cache_opcodes < 0) {
+          goto fail;
+        }
+        break;
       case OP_POP_POS:
       case OP_FAIL_POS:
       case OP_FAIL_LOOK_BEHIND_NOT:
       case OP_POP_STOP_BT:
-	goto exit;
+        goto exit;
       case OP_LOOK_BEHIND:
-	p += SIZE_LENGTH;
-	break;
+        p += SIZE_LENGTH;
+        break;
 
       case OP_PUSH_ABSENT_POS:
       case OP_ABSENT_END:
       case OP_ABSENT:
-	goto impossible;
+        goto impossible;
 
       case OP_CALL:
       case OP_RETURN:
-	goto impossible;
+        goto impossible;
 
       case OP_CONDITION:
-	goto impossible;
+        goto impossible;
 
       case OP_STATE_CHECK_PUSH:
       case OP_STATE_CHECK_PUSH_OR_JUMP:
       case OP_STATE_CHECK:
       case OP_STATE_CHECK_ANYCHAR_STAR:
       case OP_STATE_CHECK_ANYCHAR_ML_STAR:
-	goto impossible;
+        goto impossible;
 
       case OP_SET_OPTION_PUSH:
       case OP_SET_OPTION:
-	p += SIZE_OPTION;
-	break;
+        p += SIZE_OPTION;
+        break;
 
       default:
-	goto bytecode_error;
+        goto bytecode_error;
     }
   }
 
@@ -588,7 +588,7 @@ init_cache_opcodes_inner(
     switch (*p++) {
       case OP_FINISH:
       case OP_END:
-	break;
+        break;
 
       case OP_EXACT1: p++; break;
       case OP_EXACT2: p += 2; break;
@@ -596,53 +596,53 @@ init_cache_opcodes_inner(
       case OP_EXACT4: p += 4; break;
       case OP_EXACT5: p += 5; break;
       case OP_EXACTN:
-	GET_LENGTH_INC(len, p); p += len; break;
+        GET_LENGTH_INC(len, p); p += len; break;
       case OP_EXACTMB2N1: p += 2; break;
       case OP_EXACTMB2N2: p += 4; break;
       case OP_EXACTMB2N3: p += 6; break;
       case OP_EXACTMB2N:
-	GET_LENGTH_INC(len, p); p += len * 2; break;
+        GET_LENGTH_INC(len, p); p += len * 2; break;
       case OP_EXACTMB3N:
-	GET_LENGTH_INC(len, p); p += len * 3; break;
+        GET_LENGTH_INC(len, p); p += len * 3; break;
       case OP_EXACTMBN:
-	{
-	  int mb_len;
-	  GET_LENGTH_INC(mb_len, p);
-	  GET_LENGTH_INC(len, p);
-	  p += mb_len * len;
-	}
-	break;
+        {
+          int mb_len;
+          GET_LENGTH_INC(mb_len, p);
+          GET_LENGTH_INC(len, p);
+          p += mb_len * len;
+        }
+        break;
 
       case OP_EXACT1_IC:
-	len = enclen(enc, p, pend); p += len; break;
+        len = enclen(enc, p, pend); p += len; break;
       case OP_EXACTN_IC:
-	GET_LENGTH_INC(len, p); p += len; break;
+        GET_LENGTH_INC(len, p); p += len; break;
 
       case OP_CCLASS:
       case OP_CCLASS_NOT:
-	p += SIZE_BITSET; break;
+        p += SIZE_BITSET; break;
       case OP_CCLASS_MB:
       case OP_CCLASS_MB_NOT:
-	GET_LENGTH_INC(len, p); p += len; break;
+        GET_LENGTH_INC(len, p); p += len; break;
       case OP_CCLASS_MIX:
       case OP_CCLASS_MIX_NOT:
-	p += SIZE_BITSET;
-	GET_LENGTH_INC(len, p);
-	p += len;
-	break;
+        p += SIZE_BITSET;
+        GET_LENGTH_INC(len, p);
+        p += len;
+        break;
 
       case OP_ANYCHAR:
       case OP_ANYCHAR_ML:
-	break;
+        break;
       case OP_ANYCHAR_STAR:
       case OP_ANYCHAR_ML_STAR:
-	INC_CACHE_OPCODES;
-	break;
+        INC_CACHE_OPCODES;
+        break;
       case OP_ANYCHAR_STAR_PEEK_NEXT:
       case OP_ANYCHAR_ML_STAR_PEEK_NEXT:
-	p++;
-	INC_CACHE_OPCODES;
-	break;
+        p++;
+        INC_CACHE_OPCODES;
+        break;
 
       case OP_WORD:
       case OP_NOT_WORD:
@@ -650,7 +650,7 @@ init_cache_opcodes_inner(
       case OP_NOT_WORD_BOUND:
       case OP_WORD_BEGIN:
       case OP_WORD_END:
-	break;
+        break;
 
       case OP_ASCII_WORD:
       case OP_NOT_ASCII_WORD:
@@ -658,7 +658,7 @@ init_cache_opcodes_inner(
       case OP_NOT_ASCII_WORD_BOUND:
       case OP_ASCII_WORD_BEGIN:
       case OP_ASCII_WORD_END:
-	break;
+        break;
 
       case OP_BEGIN_BUF:
       case OP_END_BUF:
@@ -666,7 +666,7 @@ init_cache_opcodes_inner(
       case OP_END_LINE:
       case OP_SEMI_END_BUF:
       case OP_BEGIN_POSITION:
-	break;
+        break;
 
       case OP_BACKREF1:
       case OP_BACKREF2:
@@ -675,7 +675,7 @@ init_cache_opcodes_inner(
       case OP_BACKREF_MULTI:
       case OP_BACKREF_MULTI_IC:
       case OP_BACKREF_WITH_LEVEL:
-	goto unexpected_bytecode_error;
+        goto unexpected_bytecode_error;
 
       case OP_MEMORY_START:
       case OP_MEMORY_START_PUSH:
@@ -683,158 +683,158 @@ init_cache_opcodes_inner(
       case OP_MEMORY_END_PUSH_REC:
       case OP_MEMORY_END:
       case OP_MEMORY_END_REC:
-	p += SIZE_MEMNUM;
-	if (lookaround_nesting != 0) {
-	  goto unexpected_bytecode_error;
-	}
-	break;
+        p += SIZE_MEMNUM;
+        if (lookaround_nesting != 0) {
+          goto unexpected_bytecode_error;
+        }
+        break;
 
       case OP_KEEP:
-	break;
+        break;
 
       case OP_FAIL:
-	break;
+        break;
       case OP_JUMP:
-	p += SIZE_RELADDR;
-	break;
+        p += SIZE_RELADDR;
+        break;
       case OP_PUSH:
-	p += SIZE_RELADDR;
-	INC_CACHE_OPCODES;
-	break;
+        p += SIZE_RELADDR;
+        INC_CACHE_OPCODES;
+        break;
       case OP_POP:
-	break;
+        break;
       case OP_PUSH_OR_JUMP_EXACT1:
       case OP_PUSH_IF_PEEK_NEXT:
-	p += SIZE_RELADDR + 1;
-	INC_CACHE_OPCODES;
-	break;
+        p += SIZE_RELADDR + 1;
+        INC_CACHE_OPCODES;
+        break;
       case OP_REPEAT:
       case OP_REPEAT_NG:
-	GET_MEMNUM_INC(repeat_mem, p);
-	p += SIZE_RELADDR;
-	if (reg->repeat_range[repeat_mem].lower == 0 && reg->repeat_range[repeat_mem].upper == 0) {
-	  long dummy_num_cache_points = 0;
-	  OnigCacheOpcode* dummy_cache_opcodes = NULL;
-	  result = init_cache_opcodes_inner(reg, repeat_mem, lookaround_nesting, &dummy_cache_opcodes, &p, &dummy_num_cache_points);
-	  if (result != 0) {
-	    goto fail;
-	  }
-	} else {
-	  if (reg->repeat_range[repeat_mem].lower == 0) {
-	    INC_CACHE_OPCODES;
-	  }
-	  {
-	    long num_cache_points_in_repeat = 0;
-	    long num_cache_points_at_repeat = cache_point;
-	    OnigCacheOpcode* cache_opcodes_in_repeat = cache_opcodes;
-	    result = init_cache_opcodes_inner(reg, repeat_mem, lookaround_nesting, &cache_opcodes, &p, &num_cache_points_in_repeat);
-	    if (result != 0) {
-	      goto fail;
-	    }
-	    OnigRepeatRange *repeat_range = &reg->repeat_range[repeat_mem];
-	    if (repeat_range->lower < repeat_range->upper) {
-	      INC_CACHE_OPCODES;
-	      cache_point -= lookaround_nesting != 0 ? 2 : 1;
-	    }
-	    int repeat_bounds = repeat_range->upper == 0x7fffffff ? 1 : repeat_range->upper - repeat_range->lower;
-	    cache_point += num_cache_points_in_repeat * repeat_range->lower + (num_cache_points_in_repeat + (lookaround_nesting != 0 ? 2 : 1)) * repeat_bounds;
-	    for (; cache_opcodes_in_repeat < cache_opcodes; cache_opcodes_in_repeat++) {
-	      cache_opcodes_in_repeat->num_cache_points_at_outer_repeat = num_cache_points_at_repeat;
-	      cache_opcodes_in_repeat->num_cache_points_in_outer_repeat = num_cache_points_in_repeat;
-	    }
-	  }
-	}
-	break;
+        GET_MEMNUM_INC(repeat_mem, p);
+        p += SIZE_RELADDR;
+        if (reg->repeat_range[repeat_mem].lower == 0 && reg->repeat_range[repeat_mem].upper == 0) {
+          long dummy_num_cache_points = 0;
+          OnigCacheOpcode* dummy_cache_opcodes = NULL;
+          result = init_cache_opcodes_inner(reg, repeat_mem, lookaround_nesting, &dummy_cache_opcodes, &p, &dummy_num_cache_points);
+          if (result != 0) {
+            goto fail;
+          }
+        } else {
+          if (reg->repeat_range[repeat_mem].lower == 0) {
+            INC_CACHE_OPCODES;
+          }
+          {
+            long num_cache_points_in_repeat = 0;
+            long num_cache_points_at_repeat = cache_point;
+            OnigCacheOpcode* cache_opcodes_in_repeat = cache_opcodes;
+            result = init_cache_opcodes_inner(reg, repeat_mem, lookaround_nesting, &cache_opcodes, &p, &num_cache_points_in_repeat);
+            if (result != 0) {
+              goto fail;
+            }
+            OnigRepeatRange *repeat_range = &reg->repeat_range[repeat_mem];
+            if (repeat_range->lower < repeat_range->upper) {
+              INC_CACHE_OPCODES;
+              cache_point -= lookaround_nesting != 0 ? 2 : 1;
+            }
+            int repeat_bounds = repeat_range->upper == 0x7fffffff ? 1 : repeat_range->upper - repeat_range->lower;
+            cache_point += num_cache_points_in_repeat * repeat_range->lower + (num_cache_points_in_repeat + (lookaround_nesting != 0 ? 2 : 1)) * repeat_bounds;
+            for (; cache_opcodes_in_repeat < cache_opcodes; cache_opcodes_in_repeat++) {
+              cache_opcodes_in_repeat->num_cache_points_at_outer_repeat = num_cache_points_at_repeat;
+              cache_opcodes_in_repeat->num_cache_points_in_outer_repeat = num_cache_points_in_repeat;
+            }
+          }
+        }
+        break;
       case OP_REPEAT_INC:
       case OP_REPEAT_INC_NG:
-	p += SIZE_MEMNUM;
+        p += SIZE_MEMNUM;
         goto exit;
       case OP_REPEAT_INC_SG:
       case OP_REPEAT_INC_NG_SG:
-	goto unexpected_bytecode_error;
+        goto unexpected_bytecode_error;
       case OP_NULL_CHECK_START:
-	p += SIZE_MEMNUM;
-	break;
+        p += SIZE_MEMNUM;
+        break;
       case OP_NULL_CHECK_END:
       case OP_NULL_CHECK_END_MEMST_PUSH:
-	p += SIZE_MEMNUM;
-	break;
+        p += SIZE_MEMNUM;
+        break;
       case OP_NULL_CHECK_END_MEMST:
-	p += SIZE_MEMNUM;
-	break;
+        p += SIZE_MEMNUM;
+        break;
 
       case OP_PUSH_POS:
-	lookaround:
-	{
-	  OnigCacheOpcode* cache_opcodes_in_lookaround = cache_opcodes;
-	  result = init_cache_opcodes_inner(reg, current_repeat_mem, lookaround_nesting + 1, &cache_opcodes, &p, &cache_point);
-	  if (result != 0) {
-	    goto fail;
-	  }
-	  UChar* match_addr = p - 1;
-	  for (; cache_opcodes_in_lookaround < cache_opcodes; cache_opcodes_in_lookaround++) {
-	    if (cache_opcodes_in_lookaround->match_addr == NULL) {
-	      cache_opcodes_in_lookaround->match_addr = match_addr;
-	    }
-	  }
-	}
-	break;
+        lookaround:
+        {
+          OnigCacheOpcode* cache_opcodes_in_lookaround = cache_opcodes;
+          result = init_cache_opcodes_inner(reg, current_repeat_mem, lookaround_nesting + 1, &cache_opcodes, &p, &cache_point);
+          if (result != 0) {
+            goto fail;
+          }
+          UChar* match_addr = p - 1;
+          for (; cache_opcodes_in_lookaround < cache_opcodes; cache_opcodes_in_lookaround++) {
+            if (cache_opcodes_in_lookaround->match_addr == NULL) {
+              cache_opcodes_in_lookaround->match_addr = match_addr;
+            }
+          }
+        }
+        break;
       case OP_PUSH_POS_NOT:
-	p += SIZE_RELADDR;
+        p += SIZE_RELADDR;
         goto lookaround;
       case OP_PUSH_LOOK_BEHIND_NOT:
-	p += SIZE_RELADDR;
-	p += SIZE_LENGTH;
+        p += SIZE_RELADDR;
+        p += SIZE_LENGTH;
         goto lookaround;
       case OP_PUSH_STOP_BT:
-	{
-	  OnigCacheOpcode* cache_opcodes_in_atomic = cache_opcodes;
-	  result = init_cache_opcodes_inner(reg, current_repeat_mem, -1, &cache_opcodes, &p, &cache_point);
-	  if (result != 0) {
-	    goto fail;
-	  }
-	  UChar* match_addr = p - 1;
-	  for (; cache_opcodes_in_atomic < cache_opcodes; cache_opcodes_in_atomic++) {
-	    if (cache_opcodes_in_atomic->match_addr == NULL) {
-	      cache_opcodes_in_atomic->match_addr = match_addr;
-	    }
-	  }
-	}
-	break;
+        {
+          OnigCacheOpcode* cache_opcodes_in_atomic = cache_opcodes;
+          result = init_cache_opcodes_inner(reg, current_repeat_mem, -1, &cache_opcodes, &p, &cache_point);
+          if (result != 0) {
+            goto fail;
+          }
+          UChar* match_addr = p - 1;
+          for (; cache_opcodes_in_atomic < cache_opcodes; cache_opcodes_in_atomic++) {
+            if (cache_opcodes_in_atomic->match_addr == NULL) {
+              cache_opcodes_in_atomic->match_addr = match_addr;
+            }
+          }
+        }
+        break;
       case OP_POP_POS:
       case OP_FAIL_POS:
       case OP_FAIL_LOOK_BEHIND_NOT:
       case OP_POP_STOP_BT:
-	goto exit;
+        goto exit;
       case OP_LOOK_BEHIND:
-	p += SIZE_LENGTH;
-	break;
+        p += SIZE_LENGTH;
+        break;
 
       case OP_ABSENT_END:
       case OP_ABSENT:
-	goto unexpected_bytecode_error;
+        goto unexpected_bytecode_error;
 
       case OP_CALL:
       case OP_RETURN:
-	goto unexpected_bytecode_error;
+        goto unexpected_bytecode_error;
 
       case OP_CONDITION:
-	goto unexpected_bytecode_error;
+        goto unexpected_bytecode_error;
 
       case OP_STATE_CHECK_PUSH:
       case OP_STATE_CHECK_PUSH_OR_JUMP:
       case OP_STATE_CHECK:
       case OP_STATE_CHECK_ANYCHAR_STAR:
       case OP_STATE_CHECK_ANYCHAR_ML_STAR:
-	goto unexpected_bytecode_error;
+        goto unexpected_bytecode_error;
 
       case OP_SET_OPTION_PUSH:
       case OP_SET_OPTION:
-	p += SIZE_OPTION;
-	break;
+        p += SIZE_OPTION;
+        break;
 
       default:
-	goto bytecode_error;
+        goto bytecode_error;
     }
   }
 
@@ -1192,7 +1192,7 @@ onig_region_copy(OnigRegion* to, const OnigRegion* from)
   }\
   else {\
     alloc_addr = (char* )xalloca(sizeof(OnigStackIndex) * (ptr_num)\
-		       + sizeof(OnigStackType) * (stack_num));\
+                       + sizeof(OnigStackType) * (stack_num));\
     heap_addr  = NULL;\
     stk_alloc  = (OnigStackType* )(alloc_addr + sizeof(OnigStackIndex) * (ptr_num));\
     stk_base   = stk_alloc;\
@@ -1225,7 +1225,7 @@ onig_set_match_stack_limit_size(unsigned int size)
 
 static int
 stack_double(OnigStackType** arg_stk_base, OnigStackType** arg_stk_end,
-	     OnigStackType** arg_stk, OnigStackType* stk_alloc, OnigMatchArg* msa)
+             OnigStackType** arg_stk, OnigStackType* stk_alloc, OnigMatchArg* msa)
 {
   size_t n;
   OnigStackType *x, *stk_base, *stk_end, *stk;
@@ -1249,9 +1249,9 @@ stack_double(OnigStackType** arg_stk_base, OnigStackType** arg_stk_end,
     n *= 2;
     if (limit_size != 0 && n > limit_size) {
       if ((unsigned int )(stk_end - stk_base) == limit_size)
-	return ONIGERR_MATCH_STACK_LIMIT_OVER;
+        return ONIGERR_MATCH_STACK_LIMIT_OVER;
       else
-	n = limit_size;
+        n = limit_size;
     }
     x = (OnigStackType* )xrealloc(stk_base, sizeof(OnigStackType) * n);
     if (IS_NULL(x)) {
@@ -1901,7 +1901,7 @@ stack_double(OnigStackType** arg_stk_base, OnigStackType** arg_stk_end,
 } while(0)
 
 static int string_cmp_ic(OnigEncoding enc, int case_fold_flag,
-			 UChar* s1, UChar** ps2, OnigDistance mblen, const UChar* text_end)
+                         UChar* s1, UChar** ps2, OnigDistance mblen, const UChar* text_end)
 {
   UChar buf1[ONIGENC_MBC_CASE_FOLD_MAXLEN];
   UChar buf2[ONIGENC_MBC_CASE_FOLD_MAXLEN];
@@ -1988,29 +1988,29 @@ make_capture_history_tree(OnigCaptureTreeNode* node, OnigStackType** kp,
     if (k->type == STK_MEM_START) {
       n = k->u.mem.num;
       if (n <= ONIG_MAX_CAPTURE_HISTORY_GROUP &&
-	  BIT_STATUS_AT(reg->capture_history, n) != 0) {
-	child = history_node_new();
-	CHECK_NULL_RETURN_MEMERR(child);
-	child->group = n;
-	child->beg = k->u.mem.pstr - str;
-	r = history_tree_add_child(node, child);
-	if (r != 0) {
-	  history_tree_free(child);
-	  return r;
-	}
-	*kp = (k + 1);
-	r = make_capture_history_tree(child, kp, stk_top, str, reg);
-	if (r != 0) return r;
+          BIT_STATUS_AT(reg->capture_history, n) != 0) {
+        child = history_node_new();
+        CHECK_NULL_RETURN_MEMERR(child);
+        child->group = n;
+        child->beg = k->u.mem.pstr - str;
+        r = history_tree_add_child(node, child);
+        if (r != 0) {
+          history_tree_free(child);
+          return r;
+        }
+        *kp = (k + 1);
+        r = make_capture_history_tree(child, kp, stk_top, str, reg);
+        if (r != 0) return r;
 
-	k = *kp;
-	child->end = k->u.mem.pstr - str;
+        k = *kp;
+        child->end = k->u.mem.pstr - str;
       }
     }
     else if (k->type == STK_MEM_END) {
       if (k->u.mem.num == node->group) {
-	node->end = k->u.mem.pstr - str;
-	*kp = k;
-	return 0;
+        node->end = k->u.mem.pstr - str;
+        *kp = k;
+        return 0;
       }
     }
     k++;
@@ -2035,9 +2035,9 @@ mem_is_in_memp(int mem, int num, UChar* memp)
 }
 
 static int backref_match_at_nested_level(regex_t* reg,
-	 OnigStackType* top, OnigStackType* stk_base,
-	 int ignore_case, int case_fold_flag,
-	 int nest, int mem_num, UChar* memp, UChar** s, const UChar* send)
+         OnigStackType* top, OnigStackType* stk_base,
+         int ignore_case, int case_fold_flag,
+         int nest, int mem_num, UChar* memp, UChar** s, const UChar* send)
 {
   UChar *ss, *p, *pstart, *pend = NULL_UCHARP;
   int level;
@@ -2055,33 +2055,33 @@ static int backref_match_at_nested_level(regex_t* reg,
     }
     else if (level == nest) {
       if (k->type == STK_MEM_START) {
-	if (mem_is_in_memp(k->u.mem.num, mem_num, memp)) {
-	  pstart = k->u.mem.pstr;
-	  if (pend != NULL_UCHARP) {
-	    if (pend - pstart > send - *s) return 0; /* or goto next_mem; */
-	    p  = pstart;
-	    ss = *s;
+        if (mem_is_in_memp(k->u.mem.num, mem_num, memp)) {
+          pstart = k->u.mem.pstr;
+          if (pend != NULL_UCHARP) {
+            if (pend - pstart > send - *s) return 0; /* or goto next_mem; */
+            p  = pstart;
+            ss = *s;
 
-	    if (ignore_case != 0) {
-	      if (string_cmp_ic(reg->enc, case_fold_flag,
-				pstart, &ss, pend - pstart, send) == 0)
-		return 0; /* or goto next_mem; */
-	    }
-	    else {
-	      while (p < pend) {
-		if (*p++ != *ss++) return 0; /* or goto next_mem; */
-	      }
-	    }
+            if (ignore_case != 0) {
+              if (string_cmp_ic(reg->enc, case_fold_flag,
+                                pstart, &ss, pend - pstart, send) == 0)
+                return 0; /* or goto next_mem; */
+            }
+            else {
+              while (p < pend) {
+                if (*p++ != *ss++) return 0; /* or goto next_mem; */
+              }
+            }
 
-	    *s = ss;
-	    return 1;
-	  }
-	}
+            *s = ss;
+            return 1;
+          }
+        }
       }
       else if (k->type == STK_MEM_END) {
-	if (mem_is_in_memp(k->u.mem.num, mem_num, memp)) {
-	  pend = k->u.mem.pstr;
-	}
+        if (mem_is_in_memp(k->u.mem.num, mem_num, memp)) {
+          pend = k->u.mem.pstr;
+        }
       }
     }
     k--;
@@ -2099,7 +2099,7 @@ static int backref_match_at_nested_level(regex_t* reg,
 static LARGE_INTEGER ts, te, freq;
 #  define GETTIME(t)	  QueryPerformanceCounter(&(t))
 #  define TIMEDIFF(te,ts) (unsigned long )(((te).QuadPart - (ts).QuadPart) \
-			    * 1000000 / freq.QuadPart)
+                            * 1000000 / freq.QuadPart)
 # else /* _WIN32 */
 
 #  define USE_TIMEOFDAY
@@ -2165,7 +2165,7 @@ onig_print_statistics(FILE* f)
   fprintf(f, "   count      prev        time\n");
   for (i = 0; OnigOpInfo[i].opcode >= 0; i++) {
     fprintf(f, "%8d: %8d: %10lu: %s\n",
-	    OpCounter[i], OpPrevCounter[i], OpTime[i], OnigOpInfo[i].name);
+            OpCounter[i], OpPrevCounter[i], OpTime[i], OnigOpInfo[i].name);
   }
   fprintf(f, "\nmax stack depth: %d\n", MaxStackDepth);
 }
@@ -2310,9 +2310,9 @@ memoize_extended_match_cache_point(uint8_t *match_cache_buf, long match_cache_po
 static OnigPosition
 match_at(regex_t* reg, const UChar* str, const UChar* end,
 #ifdef USE_MATCH_RANGE_MUST_BE_INSIDE_OF_SPECIFIED_RANGE
-	 const UChar* right_range,
+         const UChar* right_range,
 #endif
-	 const UChar* sstart, UChar* sprev, OnigMatchArg* msa)
+         const UChar* sstart, UChar* sprev, OnigMatchArg* msa)
 {
   static const UChar FinishCode[] = { OP_FINISH };
 
@@ -2562,16 +2562,16 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
   }
 #ifndef USE_SUBEXP_CALL
   mem_start_stk--; /* for index start from 1,
-		      mem_start_stk[1]..mem_start_stk[num_mem] */
+                      mem_start_stk[1]..mem_start_stk[num_mem] */
   mem_end_stk--;   /* for index start from 1,
-		      mem_end_stk[1]..mem_end_stk[num_mem] */
+                      mem_end_stk[1]..mem_end_stk[num_mem] */
 #endif
 
 #ifdef ONIG_DEBUG_MATCH
   fprintf(stderr, "match_at: str: %"PRIuPTR" (%p), end: %"PRIuPTR" (%p), start: %"PRIuPTR" (%p), sprev: %"PRIuPTR" (%p)\n",
-	  (uintptr_t )str, str, (uintptr_t )end, end, (uintptr_t )sstart, sstart, (uintptr_t )sprev, sprev);
+          (uintptr_t )str, str, (uintptr_t )end, end, (uintptr_t )sstart, sstart, (uintptr_t )sprev, sprev);
   fprintf(stderr, "size: %d, start offset: %d\n",
-	  (int )(end - str), (int )(sstart - str));
+          (int )(end - str), (int )(sstart - str));
   fprintf(stderr, "\n ofs> str                   stk:type   addr:opcode\n");
 #endif
 
@@ -2591,10 +2591,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       bp = buf;                                                         \
       q = s;                                                            \
       if (*op != OP_FINISH) {    /* s may not be a valid pointer if OP_FINISH. */ \
-	for (i = 0; i < 7 && q < end; i++) {                            \
-	  len = enclen(encode, q, end);                                 \
-	  while (len-- > 0) *bp++ = *q++;                               \
-	}                                                               \
+        for (i = 0; i < 7 && q < end; i++) {                            \
+          len = enclen(encode, q, end);                                 \
+          while (len-- > 0) *bp++ = *q++;                               \
+        }                                                               \
         if (q < end) { xmemcpy(bp, "...", 3); bp += 3; }                \
       }                                                                 \
       xmemcpy(bp, "\"", 1); bp += 1;                                    \
@@ -2602,9 +2602,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       fputs((char* )buf, stderr);                                       \
       for (i = 0; i < 20 - (bp - buf); i++) fputc(' ', stderr);         \
       fprintf(stderr, "%4"PRIdPTR":%s %4"PRIdPTR":",                    \
-	  stk - stk_base - 1,                                           \
-	  (stk > stk_base) ? stack_type_str(stk[-1].type) : "      ",   \
-	  (op == FinishCode) ? (ptrdiff_t )-1 : op - reg->p);           \
+          stk - stk_base - 1,                                           \
+          (stk > stk_base) ? stack_type_str(stk[-1].type) : "      ",   \
+          (op == FinishCode) ? (ptrdiff_t )-1 : op - reg->p);           \
       onig_print_compiled_byte_code(stderr, op, reg->p+reg->used, NULL, encode); \
       fprintf(stderr, "\n");                                            \
     }
@@ -2633,18 +2633,18 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       uint8_t match_cache_point_mask = 1 << (match_cache_point & 7);\
       MATCH_CACHE_DEBUG;\
       if (msa->match_cache_buf[match_cache_point_index] & match_cache_point_mask) {\
-	MATCH_CACHE_DEBUG_HIT; MATCH_CACHE_HIT;\
-	if (cache_opcode->lookaround_nesting == 0) goto fail;\
-	else if (cache_opcode->lookaround_nesting < 0) {\
-	  if (check_extended_match_cache_point(msa->match_cache_buf, match_cache_point_index, match_cache_point_mask)) {\
+        MATCH_CACHE_DEBUG_HIT; MATCH_CACHE_HIT;\
+        if (cache_opcode->lookaround_nesting == 0) goto fail;\
+        else if (cache_opcode->lookaround_nesting < 0) {\
+          if (check_extended_match_cache_point(msa->match_cache_buf, match_cache_point_index, match_cache_point_mask)) {\
             STACK_STOP_BT_FAIL;\
             goto fail;\
           }\
           else goto fail;\
         }\
         else {\
-	  if (check_extended_match_cache_point(msa->match_cache_buf, match_cache_point_index, match_cache_point_mask)) {\
-	    p = cache_opcode->match_addr;\
+          if (check_extended_match_cache_point(msa->match_cache_buf, match_cache_point_index, match_cache_point_mask)) {\
+            p = cache_opcode->match_addr;\
             MOP_OUT;\
             JUMP;\
           }\
@@ -2663,66 +2663,66 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_END)  MOP_IN(OP_END);
       n = s - sstart;
       if (n > best_len) {
-	OnigRegion* region;
+        OnigRegion* region;
 #ifdef USE_FIND_LONGEST_SEARCH_ALL_OF_RANGE
-	if (IS_FIND_LONGEST(option)) {
-	  if (n > msa->best_len) {
-	    msa->best_len = n;
-	    msa->best_s   = (UChar* )sstart;
-	  }
-	  else
-	    goto end_best_len;
-	}
+        if (IS_FIND_LONGEST(option)) {
+          if (n > msa->best_len) {
+            msa->best_len = n;
+            msa->best_s   = (UChar* )sstart;
+          }
+          else
+            goto end_best_len;
+        }
 #endif
-	best_len = n;
-	region = msa->region;
-	if (region) {
-	  region->beg[0] = ((pkeep > s) ? s : pkeep) - str;
-	  region->end[0] = s - str;
-	  for (i = 1; i <= num_mem; i++) {
-	    if (mem_end_stk[i] != INVALID_STACK_INDEX) {
-	      if (BIT_STATUS_AT(reg->bt_mem_start, i))
-		region->beg[i] = STACK_AT(mem_start_stk[i])->u.mem.pstr - str;
-	      else
-		region->beg[i] = (UChar* )((void* )mem_start_stk[i]) - str;
+        best_len = n;
+        region = msa->region;
+        if (region) {
+          region->beg[0] = ((pkeep > s) ? s : pkeep) - str;
+          region->end[0] = s - str;
+          for (i = 1; i <= num_mem; i++) {
+            if (mem_end_stk[i] != INVALID_STACK_INDEX) {
+              if (BIT_STATUS_AT(reg->bt_mem_start, i))
+                region->beg[i] = STACK_AT(mem_start_stk[i])->u.mem.pstr - str;
+              else
+                region->beg[i] = (UChar* )((void* )mem_start_stk[i]) - str;
 
-	      region->end[i] = (BIT_STATUS_AT(reg->bt_mem_end, i)
-				? STACK_AT(mem_end_stk[i])->u.mem.pstr
-				: (UChar* )((void* )mem_end_stk[i])) - str;
-	    }
-	    else {
-	      region->beg[i] = region->end[i] = ONIG_REGION_NOTPOS;
-	    }
-	  }
+              region->end[i] = (BIT_STATUS_AT(reg->bt_mem_end, i)
+                                ? STACK_AT(mem_end_stk[i])->u.mem.pstr
+                                : (UChar* )((void* )mem_end_stk[i])) - str;
+            }
+            else {
+              region->beg[i] = region->end[i] = ONIG_REGION_NOTPOS;
+            }
+          }
 
 #ifdef USE_CAPTURE_HISTORY
-	  if (reg->capture_history != 0) {
-	    int r;
-	    OnigCaptureTreeNode* node;
+          if (reg->capture_history != 0) {
+            int r;
+            OnigCaptureTreeNode* node;
 
-	    if (IS_NULL(region->history_root)) {
-	      region->history_root = node = history_node_new();
-	      CHECK_NULL_RETURN_MEMERR(node);
-	    }
-	    else {
-	      node = region->history_root;
-	      history_tree_clear(node);
-	    }
+            if (IS_NULL(region->history_root)) {
+              region->history_root = node = history_node_new();
+              CHECK_NULL_RETURN_MEMERR(node);
+            }
+            else {
+              node = region->history_root;
+              history_tree_clear(node);
+            }
 
-	    node->group = 0;
-	    node->beg   = ((pkeep > s) ? s : pkeep) - str;
-	    node->end   = s - str;
+            node->group = 0;
+            node->beg   = ((pkeep > s) ? s : pkeep) - str;
+            node->end   = s - str;
 
-	    stkp = stk_base;
-	    r = make_capture_history_tree(region->history_root, &stkp,
-		stk, (UChar* )str, reg);
-	    if (r < 0) {
-	      best_len = r; /* error code */
-	      goto finish;
-	    }
-	  }
+            stkp = stk_base;
+            r = make_capture_history_tree(region->history_root, &stkp,
+                stk, (UChar* )str, reg);
+            if (r < 0) {
+              best_len = r; /* error code */
+              goto finish;
+            }
+          }
 #endif /* USE_CAPTURE_HISTORY */
-	} /* if (region) */
+        } /* if (region) */
       } /* n > best_len */
 
 #ifdef USE_FIND_LONGEST_SEARCH_ALL_OF_RANGE
@@ -2731,13 +2731,13 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       MOP_OUT;
 
       if (IS_FIND_CONDITION(option)) {
-	if (IS_FIND_NOT_EMPTY(option) && s == sstart) {
-	  best_len = ONIG_MISMATCH;
-	  goto fail; /* for retry */
-	}
-	if (IS_FIND_LONGEST(option) && DATA_ENSURE_CHECK1) {
-	  goto fail; /* for retry */
-	}
+        if (IS_FIND_NOT_EMPTY(option) && s == sstart) {
+          best_len = ONIG_MISMATCH;
+          goto fail; /* for retry */
+        }
+        if (IS_FIND_LONGEST(option) && DATA_ENSURE_CHECK1) {
+          goto fail; /* for retry */
+        }
       }
 
       /* default behavior: return first-matching result. */
@@ -2753,22 +2753,22 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_EXACT1_IC)  MOP_IN(OP_EXACT1_IC);
       {
-	int len;
-	UChar *q, lowbuf[ONIGENC_MBC_CASE_FOLD_MAXLEN];
+        int len;
+        UChar *q, lowbuf[ONIGENC_MBC_CASE_FOLD_MAXLEN];
 
-	DATA_ENSURE(1);
-	len = ONIGENC_MBC_CASE_FOLD(encode,
-		    /* DISABLE_CASE_FOLD_MULTI_CHAR(case_fold_flag), */
-		    case_fold_flag,
-		    &s, end, lowbuf);
-	DATA_ENSURE(0);
-	q = lowbuf;
-	while (len-- > 0) {
-	  if (*p != *q) {
-	    goto fail;
-	  }
-	  p++; q++;
-	}
+        DATA_ENSURE(1);
+        len = ONIGENC_MBC_CASE_FOLD(encode,
+                    /* DISABLE_CASE_FOLD_MULTI_CHAR(case_fold_flag), */
+                    case_fold_flag,
+                    &s, end, lowbuf);
+        DATA_ENSURE(0);
+        q = lowbuf;
+        while (len-- > 0) {
+          if (*p != *q) {
+            goto fail;
+          }
+          p++; q++;
+        }
       }
       MOP_OUT;
       NEXT;
@@ -2829,7 +2829,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       GET_LENGTH_INC(tlen, p);
       DATA_ENSURE(tlen);
       while (tlen-- > 0) {
-	if (*p++ != *s++) goto fail;
+        if (*p++ != *s++) goto fail;
       }
       sprev = s - 1;
       MOP_OUT;
@@ -2837,26 +2837,26 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_EXACTN_IC)  MOP_IN(OP_EXACTN_IC);
       {
-	int len;
-	UChar *q, *endp, lowbuf[ONIGENC_MBC_CASE_FOLD_MAXLEN];
+        int len;
+        UChar *q, *endp, lowbuf[ONIGENC_MBC_CASE_FOLD_MAXLEN];
 
-	GET_LENGTH_INC(tlen, p);
-	endp = p + tlen;
+        GET_LENGTH_INC(tlen, p);
+        endp = p + tlen;
 
-	while (p < endp) {
-	  sprev = s;
-	  DATA_ENSURE(1);
-	  len = ONIGENC_MBC_CASE_FOLD(encode,
-		      /* DISABLE_CASE_FOLD_MULTI_CHAR(case_fold_flag), */
-		      case_fold_flag,
-		      &s, end, lowbuf);
-	  DATA_ENSURE(0);
-	  q = lowbuf;
-	  while (len-- > 0) {
-	    if (*p != *q) goto fail;
-	    p++; q++;
-	  }
-	}
+        while (p < endp) {
+          sprev = s;
+          DATA_ENSURE(1);
+          len = ONIGENC_MBC_CASE_FOLD(encode,
+                      /* DISABLE_CASE_FOLD_MULTI_CHAR(case_fold_flag), */
+                      case_fold_flag,
+                      &s, end, lowbuf);
+          DATA_ENSURE(0);
+          q = lowbuf;
+          while (len-- > 0) {
+            if (*p != *q) goto fail;
+            p++; q++;
+          }
+        }
       }
 
       MOP_OUT;
@@ -2907,10 +2907,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       GET_LENGTH_INC(tlen, p);
       DATA_ENSURE(tlen * 2);
       while (tlen-- > 0) {
-	if (*p != *s) goto fail;
-	p++; s++;
-	if (*p != *s) goto fail;
-	p++; s++;
+        if (*p != *s) goto fail;
+        p++; s++;
+        if (*p != *s) goto fail;
+        p++; s++;
       }
       sprev = s - 2;
       MOP_OUT;
@@ -2920,12 +2920,12 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       GET_LENGTH_INC(tlen, p);
       DATA_ENSURE(tlen * 3);
       while (tlen-- > 0) {
-	if (*p != *s) goto fail;
-	p++; s++;
-	if (*p != *s) goto fail;
-	p++; s++;
-	if (*p != *s) goto fail;
-	p++; s++;
+        if (*p != *s) goto fail;
+        p++; s++;
+        if (*p != *s) goto fail;
+        p++; s++;
+        if (*p != *s) goto fail;
+        p++; s++;
       }
       sprev = s - 3;
       MOP_OUT;
@@ -2937,8 +2937,8 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       tlen2 *= tlen;
       DATA_ENSURE(tlen2);
       while (tlen2-- > 0) {
-	if (*p != *s) goto fail;
-	p++; s++;
+        if (*p != *s) goto fail;
+        p++; s++;
       }
       sprev = s - tlen;
       MOP_OUT;
@@ -2958,23 +2958,23 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     cclass_mb:
       GET_LENGTH_INC(tlen, p);
       {
-	OnigCodePoint code;
-	UChar *ss;
-	int mb_len;
+        OnigCodePoint code;
+        UChar *ss;
+        int mb_len;
 
-	DATA_ENSURE(1);
-	mb_len = enclen_approx(encode, s, end);
-	DATA_ENSURE(mb_len);
-	ss = s;
-	s += mb_len;
-	code = ONIGENC_MBC_TO_CODE(encode, ss, s);
+        DATA_ENSURE(1);
+        mb_len = enclen_approx(encode, s, end);
+        DATA_ENSURE(mb_len);
+        ss = s;
+        s += mb_len;
+        code = ONIGENC_MBC_TO_CODE(encode, ss, s);
 
 #ifdef PLATFORM_UNALIGNED_WORD_ACCESS
-	if (! onig_is_in_code_range(p, code)) goto fail;
+        if (! onig_is_in_code_range(p, code)) goto fail;
 #else
-	q = p;
-	ALIGNMENT_RIGHT(q);
-	if (! onig_is_in_code_range(q, code)) goto fail;
+        q = p;
+        ALIGNMENT_RIGHT(q);
+        if (! onig_is_in_code_range(q, code)) goto fail;
 #endif
       }
       p += tlen;
@@ -2984,17 +2984,17 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_CCLASS_MIX)  MOP_IN(OP_CCLASS_MIX);
       DATA_ENSURE(1);
       if (ONIGENC_IS_MBC_HEAD(encode, s, end)) {
-	p += SIZE_BITSET;
-	goto cclass_mb;
+        p += SIZE_BITSET;
+        goto cclass_mb;
       }
       else {
-	if (BITSET_AT(((BitSetRef )p), *s) == 0)
-	  goto fail;
+        if (BITSET_AT(((BitSetRef )p), *s) == 0)
+          goto fail;
 
-	p += SIZE_BITSET;
-	GET_LENGTH_INC(tlen, p);
-	p += tlen;
-	s++;
+        p += SIZE_BITSET;
+        GET_LENGTH_INC(tlen, p);
+        p += tlen;
+        s++;
       }
       MOP_OUT;
       NEXT;
@@ -3010,36 +3010,36 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_CCLASS_MB_NOT)  MOP_IN(OP_CCLASS_MB_NOT);
       DATA_ENSURE(1);
       if (! ONIGENC_IS_MBC_HEAD(encode, s, end)) {
-	s++;
-	GET_LENGTH_INC(tlen, p);
-	p += tlen;
-	goto cc_mb_not_success;
+        s++;
+        GET_LENGTH_INC(tlen, p);
+        p += tlen;
+        goto cc_mb_not_success;
       }
 
     cclass_mb_not:
       GET_LENGTH_INC(tlen, p);
       {
-	OnigCodePoint code;
-	UChar *ss;
-	int mb_len = enclen(encode, s, end);
+        OnigCodePoint code;
+        UChar *ss;
+        int mb_len = enclen(encode, s, end);
 
-	if (! DATA_ENSURE_CHECK(mb_len)) {
-	  DATA_ENSURE(1);
-	  s = (UChar* )end;
-	  p += tlen;
-	  goto cc_mb_not_success;
-	}
+        if (! DATA_ENSURE_CHECK(mb_len)) {
+          DATA_ENSURE(1);
+          s = (UChar* )end;
+          p += tlen;
+          goto cc_mb_not_success;
+        }
 
-	ss = s;
-	s += mb_len;
-	code = ONIGENC_MBC_TO_CODE(encode, ss, s);
+        ss = s;
+        s += mb_len;
+        code = ONIGENC_MBC_TO_CODE(encode, ss, s);
 
 #ifdef PLATFORM_UNALIGNED_WORD_ACCESS
-	if (onig_is_in_code_range(p, code)) goto fail;
+        if (onig_is_in_code_range(p, code)) goto fail;
 #else
-	q = p;
-	ALIGNMENT_RIGHT(q);
-	if (onig_is_in_code_range(q, code)) goto fail;
+        q = p;
+        ALIGNMENT_RIGHT(q);
+        if (onig_is_in_code_range(q, code)) goto fail;
 #endif
       }
       p += tlen;
@@ -3051,17 +3051,17 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_CCLASS_MIX_NOT)  MOP_IN(OP_CCLASS_MIX_NOT);
       DATA_ENSURE(1);
       if (ONIGENC_IS_MBC_HEAD(encode, s, end)) {
-	p += SIZE_BITSET;
-	goto cclass_mb_not;
+        p += SIZE_BITSET;
+        goto cclass_mb_not;
       }
       else {
-	if (BITSET_AT(((BitSetRef )p), *s) != 0)
-	  goto fail;
+        if (BITSET_AT(((BitSetRef )p), *s) != 0)
+          goto fail;
 
-	p += SIZE_BITSET;
-	GET_LENGTH_INC(tlen, p);
-	p += tlen;
-	s++;
+        p += SIZE_BITSET;
+        GET_LENGTH_INC(tlen, p);
+        p += tlen;
+        s++;
       }
       MOP_OUT;
       NEXT;
@@ -3085,52 +3085,52 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_ANYCHAR_STAR)  MOP_IN(OP_ANYCHAR_STAR);
       while (DATA_ENSURE_CHECK1) {
-	CHECK_MATCH_CACHE;
-	STACK_PUSH_ALT(p, s, sprev, pkeep);
-	n = enclen_approx(encode, s, end);
-	DATA_ENSURE(n);
-	if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0))  goto fail;
-	sprev = s;
-	s += n;
+        CHECK_MATCH_CACHE;
+        STACK_PUSH_ALT(p, s, sprev, pkeep);
+        n = enclen_approx(encode, s, end);
+        DATA_ENSURE(n);
+        if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0))  goto fail;
+        sprev = s;
+        s += n;
       }
       MOP_OUT;
       JUMP;
 
     CASE(OP_ANYCHAR_ML_STAR)  MOP_IN(OP_ANYCHAR_ML_STAR);
       while (DATA_ENSURE_CHECK1) {
-	CHECK_MATCH_CACHE;
-	STACK_PUSH_ALT(p, s, sprev, pkeep);
-	n = enclen_approx(encode, s, end);
-	if (n > 1) {
-	  DATA_ENSURE(n);
-	  sprev = s;
-	  s += n;
-	}
-	else {
-	  sprev = s;
-	  s++;
-	}
+        CHECK_MATCH_CACHE;
+        STACK_PUSH_ALT(p, s, sprev, pkeep);
+        n = enclen_approx(encode, s, end);
+        if (n > 1) {
+          DATA_ENSURE(n);
+          sprev = s;
+          s += n;
+        }
+        else {
+          sprev = s;
+          s++;
+        }
       }
       MOP_OUT;
       JUMP;
 
     CASE(OP_ANYCHAR_STAR_PEEK_NEXT)  MOP_IN(OP_ANYCHAR_STAR_PEEK_NEXT);
       while (DATA_ENSURE_CHECK1) {
-	CHECK_MATCH_CACHE;
-	if (*p == *s) {
-	  STACK_PUSH_ALT(p + 1, s, sprev, pkeep);
-	} else {
+        CHECK_MATCH_CACHE;
+        if (*p == *s) {
+          STACK_PUSH_ALT(p + 1, s, sprev, pkeep);
+        } else {
 #ifdef USE_MATCH_CACHE
-	  /* We need to increment num_fails here, for invoking a cache optimization correctly. */
-	  /* Actually, the matching will be failed if we use `OP_ANYCHAR_STAR` simply in this case.*/
-	  msa->num_fails++;
+          /* We need to increment num_fails here, for invoking a cache optimization correctly. */
+          /* Actually, the matching will be failed if we use `OP_ANYCHAR_STAR` simply in this case.*/
+          msa->num_fails++;
 #endif
-	}
-	n = enclen_approx(encode, s, end);
-	DATA_ENSURE(n);
-	if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0))  goto fail;
-	sprev = s;
-	s += n;
+        }
+        n = enclen_approx(encode, s, end);
+        DATA_ENSURE(n);
+        if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0))  goto fail;
+        sprev = s;
+        s += n;
       }
       p++;
       MOP_OUT;
@@ -3138,26 +3138,26 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_ANYCHAR_ML_STAR_PEEK_NEXT)MOP_IN(OP_ANYCHAR_ML_STAR_PEEK_NEXT);
       while (DATA_ENSURE_CHECK1) {
-	CHECK_MATCH_CACHE;
-	if (*p == *s) {
-	  STACK_PUSH_ALT(p + 1, s, sprev, pkeep);
-	} else {
+        CHECK_MATCH_CACHE;
+        if (*p == *s) {
+          STACK_PUSH_ALT(p + 1, s, sprev, pkeep);
+        } else {
 #ifdef USE_MATCH_CACHE
-	  /* We need to increment num_fails here, for invoking a cache optimization correctly. */
-	  /* Actually, the matching will be failed if we use `OP_ANYCHAR_STAR_ML` simply in this case.*/
-	  msa->num_fails++;
+          /* We need to increment num_fails here, for invoking a cache optimization correctly. */
+          /* Actually, the matching will be failed if we use `OP_ANYCHAR_STAR_ML` simply in this case.*/
+          msa->num_fails++;
 #endif
-	}
-	n = enclen_approx(encode, s, end);
-	if (n > 1) {
-	  DATA_ENSURE(n);
-	  sprev = s;
-	  s += n;
-	}
-	else {
-	  sprev = s;
-	  s++;
-	}
+        }
+        n = enclen_approx(encode, s, end);
+        if (n > 1) {
+          DATA_ENSURE(n);
+          sprev = s;
+          s += n;
+        }
+        else {
+          sprev = s;
+          s++;
+        }
       }
       p++;
       MOP_OUT;
@@ -3167,15 +3167,15 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_STATE_CHECK_ANYCHAR_STAR)  MOP_IN(OP_STATE_CHECK_ANYCHAR_STAR);
       GET_STATE_CHECK_NUM_INC(mem, p);
       while (DATA_ENSURE_CHECK1) {
-	STATE_CHECK_VAL(scv, mem);
-	if (scv) goto fail;
+        STATE_CHECK_VAL(scv, mem);
+        if (scv) goto fail;
 
-	STACK_PUSH_ALT_WITH_STATE_CHECK(p, s, sprev, mem, pkeep);
-	n = enclen_approx(encode, s, end);
-	DATA_ENSURE(n);
-	if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0))  goto fail;
-	sprev = s;
-	s += n;
+        STACK_PUSH_ALT_WITH_STATE_CHECK(p, s, sprev, mem, pkeep);
+        n = enclen_approx(encode, s, end);
+        DATA_ENSURE(n);
+        if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 0))  goto fail;
+        sprev = s;
+        s += n;
       }
       MOP_OUT;
       NEXT;
@@ -3185,20 +3185,20 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
       GET_STATE_CHECK_NUM_INC(mem, p);
       while (DATA_ENSURE_CHECK1) {
-	STATE_CHECK_VAL(scv, mem);
-	if (scv) goto fail;
+        STATE_CHECK_VAL(scv, mem);
+        if (scv) goto fail;
 
-	STACK_PUSH_ALT_WITH_STATE_CHECK(p, s, sprev, mem, pkeep);
-	n = enclen_approx(encode, s, end);
-	if (n > 1) {
-	  DATA_ENSURE(n);
-	  sprev = s;
-	  s += n;
-	}
-	else {
-	  sprev = s;
-	  s++;
-	}
+        STACK_PUSH_ALT_WITH_STATE_CHECK(p, s, sprev, mem, pkeep);
+        n = enclen_approx(encode, s, end);
+        if (n > 1) {
+          DATA_ENSURE(n);
+          sprev = s;
+          s += n;
+        }
+        else {
+          sprev = s;
+          s++;
+        }
       }
       MOP_OUT;
       NEXT;
@@ -3207,7 +3207,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_WORD)  MOP_IN(OP_WORD);
       DATA_ENSURE(1);
       if (! ONIGENC_IS_MBC_WORD(encode, s, end))
-	goto fail;
+        goto fail;
 
       s += enclen(encode, s, end);
       MOP_OUT;
@@ -3216,7 +3216,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_ASCII_WORD)  MOP_IN(OP_ASCII_WORD);
       DATA_ENSURE(1);
       if (! ONIGENC_IS_MBC_ASCII_WORD(encode, s, end))
-	goto fail;
+        goto fail;
 
       s += enclen(encode, s, end);
       MOP_OUT;
@@ -3225,7 +3225,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_NOT_WORD)  MOP_IN(OP_NOT_WORD);
       DATA_ENSURE(1);
       if (ONIGENC_IS_MBC_WORD(encode, s, end))
-	goto fail;
+        goto fail;
 
       s += enclen(encode, s, end);
       MOP_OUT;
@@ -3234,7 +3234,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_NOT_ASCII_WORD)  MOP_IN(OP_NOT_ASCII_WORD);
       DATA_ENSURE(1);
       if (ONIGENC_IS_MBC_ASCII_WORD(encode, s, end))
-	goto fail;
+        goto fail;
 
       s += enclen(encode, s, end);
       MOP_OUT;
@@ -3242,70 +3242,70 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_WORD_BOUND)  MOP_IN(OP_WORD_BOUND);
       if (ON_STR_BEGIN(s)) {
-	DATA_ENSURE(1);
-	if (! ONIGENC_IS_MBC_WORD(encode, s, end))
-	  goto fail;
+        DATA_ENSURE(1);
+        if (! ONIGENC_IS_MBC_WORD(encode, s, end))
+          goto fail;
       }
       else if (ON_STR_END(s)) {
-	if (! ONIGENC_IS_MBC_WORD(encode, sprev, end))
-	  goto fail;
+        if (! ONIGENC_IS_MBC_WORD(encode, sprev, end))
+          goto fail;
       }
       else {
-	if (ONIGENC_IS_MBC_WORD(encode, s, end)
-	    == ONIGENC_IS_MBC_WORD(encode, sprev, end))
-	  goto fail;
+        if (ONIGENC_IS_MBC_WORD(encode, s, end)
+            == ONIGENC_IS_MBC_WORD(encode, sprev, end))
+          goto fail;
       }
       MOP_OUT;
       JUMP;
 
     CASE(OP_ASCII_WORD_BOUND)  MOP_IN(OP_ASCII_WORD_BOUND);
       if (ON_STR_BEGIN(s)) {
-	DATA_ENSURE(1);
-	if (! ONIGENC_IS_MBC_ASCII_WORD(encode, s, end))
-	  goto fail;
+        DATA_ENSURE(1);
+        if (! ONIGENC_IS_MBC_ASCII_WORD(encode, s, end))
+          goto fail;
       }
       else if (ON_STR_END(s)) {
-	if (! ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end))
-	  goto fail;
+        if (! ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end))
+          goto fail;
       }
       else {
-	if (ONIGENC_IS_MBC_ASCII_WORD(encode, s, end)
-	    == ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end))
-	  goto fail;
+        if (ONIGENC_IS_MBC_ASCII_WORD(encode, s, end)
+            == ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end))
+          goto fail;
       }
       MOP_OUT;
       JUMP;
 
     CASE(OP_NOT_WORD_BOUND)  MOP_IN(OP_NOT_WORD_BOUND);
       if (ON_STR_BEGIN(s)) {
-	if (DATA_ENSURE_CHECK1 && ONIGENC_IS_MBC_WORD(encode, s, end))
-	  goto fail;
+        if (DATA_ENSURE_CHECK1 && ONIGENC_IS_MBC_WORD(encode, s, end))
+          goto fail;
       }
       else if (ON_STR_END(s)) {
-	if (ONIGENC_IS_MBC_WORD(encode, sprev, end))
-	  goto fail;
+        if (ONIGENC_IS_MBC_WORD(encode, sprev, end))
+          goto fail;
       }
       else {
-	if (ONIGENC_IS_MBC_WORD(encode, s, end)
-	    != ONIGENC_IS_MBC_WORD(encode, sprev, end))
-	  goto fail;
+        if (ONIGENC_IS_MBC_WORD(encode, s, end)
+            != ONIGENC_IS_MBC_WORD(encode, sprev, end))
+          goto fail;
       }
       MOP_OUT;
       JUMP;
 
     CASE(OP_NOT_ASCII_WORD_BOUND)  MOP_IN(OP_NOT_ASCII_WORD_BOUND);
       if (ON_STR_BEGIN(s)) {
-	if (DATA_ENSURE_CHECK1 && ONIGENC_IS_MBC_ASCII_WORD(encode, s, end))
-	  goto fail;
+        if (DATA_ENSURE_CHECK1 && ONIGENC_IS_MBC_ASCII_WORD(encode, s, end))
+          goto fail;
       }
       else if (ON_STR_END(s)) {
-	if (ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end))
-	  goto fail;
+        if (ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end))
+          goto fail;
       }
       else {
-	if (ONIGENC_IS_MBC_ASCII_WORD(encode, s, end)
-	    != ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end))
-	  goto fail;
+        if (ONIGENC_IS_MBC_ASCII_WORD(encode, s, end)
+            != ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end))
+          goto fail;
       }
       MOP_OUT;
       JUMP;
@@ -3313,40 +3313,40 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 #ifdef USE_WORD_BEGIN_END
     CASE(OP_WORD_BEGIN)  MOP_IN(OP_WORD_BEGIN);
       if (DATA_ENSURE_CHECK1 && ONIGENC_IS_MBC_WORD(encode, s, end)) {
-	if (ON_STR_BEGIN(s) || !ONIGENC_IS_MBC_WORD(encode, sprev, end)) {
-	  MOP_OUT;
-	  JUMP;
-	}
+        if (ON_STR_BEGIN(s) || !ONIGENC_IS_MBC_WORD(encode, sprev, end)) {
+          MOP_OUT;
+          JUMP;
+        }
       }
       goto fail;
       NEXT;
 
     CASE(OP_ASCII_WORD_BEGIN)  MOP_IN(OP_ASCII_WORD_BEGIN);
       if (DATA_ENSURE_CHECK1 && ONIGENC_IS_MBC_ASCII_WORD(encode, s, end)) {
-	if (ON_STR_BEGIN(s) || !ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end)) {
-	  MOP_OUT;
-	  JUMP;
-	}
+        if (ON_STR_BEGIN(s) || !ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end)) {
+          MOP_OUT;
+          JUMP;
+        }
       }
       goto fail;
       NEXT;
 
     CASE(OP_WORD_END)  MOP_IN(OP_WORD_END);
       if (!ON_STR_BEGIN(s) && ONIGENC_IS_MBC_WORD(encode, sprev, end)) {
-	if (ON_STR_END(s) || !ONIGENC_IS_MBC_WORD(encode, s, end)) {
-	  MOP_OUT;
-	  JUMP;
-	}
+        if (ON_STR_END(s) || !ONIGENC_IS_MBC_WORD(encode, s, end)) {
+          MOP_OUT;
+          JUMP;
+        }
       }
       goto fail;
       NEXT;
 
     CASE(OP_ASCII_WORD_END)  MOP_IN(OP_ASCII_WORD_END);
       if (!ON_STR_BEGIN(s) && ONIGENC_IS_MBC_ASCII_WORD(encode, sprev, end)) {
-	if (ON_STR_END(s) || !ONIGENC_IS_MBC_ASCII_WORD(encode, s, end)) {
-	  MOP_OUT;
-	  JUMP;
-	}
+        if (ON_STR_END(s) || !ONIGENC_IS_MBC_ASCII_WORD(encode, s, end)) {
+          MOP_OUT;
+          JUMP;
+        }
       }
       goto fail;
       NEXT;
@@ -3368,18 +3368,18 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_BEGIN_LINE)  MOP_IN(OP_BEGIN_LINE);
       if (ON_STR_BEGIN(s)) {
-	if (IS_NOTBOL(msa->options)) goto fail;
-	MOP_OUT;
-	JUMP;
+        if (IS_NOTBOL(msa->options)) goto fail;
+        MOP_OUT;
+        JUMP;
       }
       else if (ONIGENC_IS_MBC_NEWLINE(encode, sprev, end)
 #ifdef USE_CRNL_AS_LINE_TERMINATOR
-		&& !(IS_NEWLINE_CRLF(option)
-		     && ONIGENC_IS_MBC_CRNL(encode, sprev, end))
+                && !(IS_NEWLINE_CRLF(option)
+                     && ONIGENC_IS_MBC_CRNL(encode, sprev, end))
 #endif
-		&& !ON_STR_END(s)) {
-	MOP_OUT;
-	JUMP;
+                && !ON_STR_END(s)) {
+        MOP_OUT;
+        JUMP;
       }
       goto fail;
       NEXT;
@@ -3387,18 +3387,18 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_END_LINE)  MOP_IN(OP_END_LINE);
       if (ON_STR_END(s)) {
 #ifndef USE_NEWLINE_AT_END_OF_STRING_HAS_EMPTY_LINE
-	if (IS_EMPTY_STR || !ONIGENC_IS_MBC_NEWLINE_EX(encode, sprev, str, end, option, 1)) {
+        if (IS_EMPTY_STR || !ONIGENC_IS_MBC_NEWLINE_EX(encode, sprev, str, end, option, 1)) {
 #endif
-	  if (IS_NOTEOL(msa->options)) goto fail;
-	  MOP_OUT;
-	  JUMP;
+          if (IS_NOTEOL(msa->options)) goto fail;
+          MOP_OUT;
+          JUMP;
 #ifndef USE_NEWLINE_AT_END_OF_STRING_HAS_EMPTY_LINE
-	}
+        }
 #endif
       }
       else if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 1)) {
-	MOP_OUT;
-	JUMP;
+        MOP_OUT;
+        JUMP;
       }
       goto fail;
       NEXT;
@@ -3406,30 +3406,30 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_SEMI_END_BUF)  MOP_IN(OP_SEMI_END_BUF);
       if (ON_STR_END(s)) {
 #ifndef USE_NEWLINE_AT_END_OF_STRING_HAS_EMPTY_LINE
-	if (IS_EMPTY_STR || !ONIGENC_IS_MBC_NEWLINE_EX(encode, sprev, str, end, option, 1)) {
+        if (IS_EMPTY_STR || !ONIGENC_IS_MBC_NEWLINE_EX(encode, sprev, str, end, option, 1)) {
 #endif
-	  if (IS_NOTEOL(msa->options)) goto fail;
-	  MOP_OUT;
-	  JUMP;
+          if (IS_NOTEOL(msa->options)) goto fail;
+          MOP_OUT;
+          JUMP;
 #ifndef USE_NEWLINE_AT_END_OF_STRING_HAS_EMPTY_LINE
-	}
+        }
 #endif
       }
       else if (ONIGENC_IS_MBC_NEWLINE_EX(encode, s, str, end, option, 1)) {
-	UChar* ss = s + enclen(encode, s, end);
-	if (ON_STR_END(ss)) {
-	  MOP_OUT;
-	  JUMP;
-	}
+        UChar* ss = s + enclen(encode, s, end);
+        if (ON_STR_END(ss)) {
+          MOP_OUT;
+          JUMP;
+        }
 #ifdef USE_CRNL_AS_LINE_TERMINATOR
-	else if (IS_NEWLINE_CRLF(option)
-	    && ONIGENC_IS_MBC_CRNL(encode, s, end)) {
-	  ss += enclen(encode, ss, end);
-	  if (ON_STR_END(ss)) {
-	    MOP_OUT;
-	    JUMP;
-	  }
-	}
+        else if (IS_NEWLINE_CRLF(option)
+            && ONIGENC_IS_MBC_CRNL(encode, s, end)) {
+          ss += enclen(encode, ss, end);
+          if (ON_STR_END(ss)) {
+            MOP_OUT;
+            JUMP;
+          }
+        }
 #endif
       }
       goto fail;
@@ -3437,7 +3437,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_BEGIN_POSITION)  MOP_IN(OP_BEGIN_POSITION);
       if (s != msa->gpos)
-	goto fail;
+        goto fail;
 
       MOP_OUT;
       JUMP;
@@ -3487,9 +3487,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       STACK_GET_MEM_START(mem, stkp);
 
       if (BIT_STATUS_AT(reg->bt_mem_start, mem))
-	mem_start_stk[mem] = GET_STACK_INDEX(stkp);
+        mem_start_stk[mem] = GET_STACK_INDEX(stkp);
       else
-	mem_start_stk[mem] = (OnigStackIndex )((void* )stkp->u.mem.pstr);
+        mem_start_stk[mem] = (OnigStackIndex )((void* )stkp->u.mem.pstr);
 
       STACK_PUSH_MEM_END_MARK(mem);
       MOP_OUT;
@@ -3510,167 +3510,167 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       GET_MEMNUM_INC(mem, p);
     backref:
       {
-	int len;
-	UChar *pstart, *pend;
+        int len;
+        UChar *pstart, *pend;
 
-	/* if you want to remove following line,
-	   you should check in parse and compile time. */
-	if (mem > num_mem) goto fail;
-	if (mem_end_stk[mem]   == INVALID_STACK_INDEX) goto fail;
-	if (mem_start_stk[mem] == INVALID_STACK_INDEX) goto fail;
+        /* if you want to remove following line,
+           you should check in parse and compile time. */
+        if (mem > num_mem) goto fail;
+        if (mem_end_stk[mem]   == INVALID_STACK_INDEX) goto fail;
+        if (mem_start_stk[mem] == INVALID_STACK_INDEX) goto fail;
 
-	if (BIT_STATUS_AT(reg->bt_mem_start, mem))
-	  pstart = STACK_AT(mem_start_stk[mem])->u.mem.pstr;
-	else
-	  pstart = (UChar* )((void* )mem_start_stk[mem]);
+        if (BIT_STATUS_AT(reg->bt_mem_start, mem))
+          pstart = STACK_AT(mem_start_stk[mem])->u.mem.pstr;
+        else
+          pstart = (UChar* )((void* )mem_start_stk[mem]);
 
-	pend = (BIT_STATUS_AT(reg->bt_mem_end, mem)
-		? STACK_AT(mem_end_stk[mem])->u.mem.pstr
-		: (UChar* )((void* )mem_end_stk[mem]));
-	n = pend - pstart;
-	DATA_ENSURE(n);
-	sprev = s;
-	STRING_CMP(pstart, s, n);
-	while (sprev + (len = enclen_approx(encode, sprev, end)) < s)
-	  sprev += len;
+        pend = (BIT_STATUS_AT(reg->bt_mem_end, mem)
+                ? STACK_AT(mem_end_stk[mem])->u.mem.pstr
+                : (UChar* )((void* )mem_end_stk[mem]));
+        n = pend - pstart;
+        DATA_ENSURE(n);
+        sprev = s;
+        STRING_CMP(pstart, s, n);
+        while (sprev + (len = enclen_approx(encode, sprev, end)) < s)
+          sprev += len;
 
-	MOP_OUT;
-	JUMP;
+        MOP_OUT;
+        JUMP;
       }
 
     CASE(OP_BACKREFN_IC)  MOP_IN(OP_BACKREFN_IC);
       GET_MEMNUM_INC(mem, p);
       {
-	int len;
-	UChar *pstart, *pend;
+        int len;
+        UChar *pstart, *pend;
 
-	/* if you want to remove following line,
-	   you should check in parse and compile time. */
-	if (mem > num_mem) goto fail;
-	if (mem_end_stk[mem]   == INVALID_STACK_INDEX) goto fail;
-	if (mem_start_stk[mem] == INVALID_STACK_INDEX) goto fail;
+        /* if you want to remove following line,
+           you should check in parse and compile time. */
+        if (mem > num_mem) goto fail;
+        if (mem_end_stk[mem]   == INVALID_STACK_INDEX) goto fail;
+        if (mem_start_stk[mem] == INVALID_STACK_INDEX) goto fail;
 
-	if (BIT_STATUS_AT(reg->bt_mem_start, mem))
-	  pstart = STACK_AT(mem_start_stk[mem])->u.mem.pstr;
-	else
-	  pstart = (UChar* )((void* )mem_start_stk[mem]);
+        if (BIT_STATUS_AT(reg->bt_mem_start, mem))
+          pstart = STACK_AT(mem_start_stk[mem])->u.mem.pstr;
+        else
+          pstart = (UChar* )((void* )mem_start_stk[mem]);
 
-	pend = (BIT_STATUS_AT(reg->bt_mem_end, mem)
-		? STACK_AT(mem_end_stk[mem])->u.mem.pstr
-		: (UChar* )((void* )mem_end_stk[mem]));
-	n = pend - pstart;
-	DATA_ENSURE(n);
-	sprev = s;
-	STRING_CMP_IC(case_fold_flag, pstart, &s, n, end);
-	while (sprev + (len = enclen_approx(encode, sprev, end)) < s)
-	  sprev += len;
+        pend = (BIT_STATUS_AT(reg->bt_mem_end, mem)
+                ? STACK_AT(mem_end_stk[mem])->u.mem.pstr
+                : (UChar* )((void* )mem_end_stk[mem]));
+        n = pend - pstart;
+        DATA_ENSURE(n);
+        sprev = s;
+        STRING_CMP_IC(case_fold_flag, pstart, &s, n, end);
+        while (sprev + (len = enclen_approx(encode, sprev, end)) < s)
+          sprev += len;
 
-	MOP_OUT;
-	JUMP;
+        MOP_OUT;
+        JUMP;
       }
       NEXT;
 
     CASE(OP_BACKREF_MULTI)  MOP_IN(OP_BACKREF_MULTI);
       {
-	int len, is_fail;
-	UChar *pstart, *pend, *swork;
+        int len, is_fail;
+        UChar *pstart, *pend, *swork;
 
-	GET_LENGTH_INC(tlen, p);
-	for (i = 0; i < tlen; i++) {
-	  GET_MEMNUM_INC(mem, p);
+        GET_LENGTH_INC(tlen, p);
+        for (i = 0; i < tlen; i++) {
+          GET_MEMNUM_INC(mem, p);
 
-	  if (mem_end_stk[mem]   == INVALID_STACK_INDEX) continue;
-	  if (mem_start_stk[mem] == INVALID_STACK_INDEX) continue;
+          if (mem_end_stk[mem]   == INVALID_STACK_INDEX) continue;
+          if (mem_start_stk[mem] == INVALID_STACK_INDEX) continue;
 
-	  if (BIT_STATUS_AT(reg->bt_mem_start, mem))
-	    pstart = STACK_AT(mem_start_stk[mem])->u.mem.pstr;
-	  else
-	    pstart = (UChar* )((void* )mem_start_stk[mem]);
+          if (BIT_STATUS_AT(reg->bt_mem_start, mem))
+            pstart = STACK_AT(mem_start_stk[mem])->u.mem.pstr;
+          else
+            pstart = (UChar* )((void* )mem_start_stk[mem]);
 
-	  pend = (BIT_STATUS_AT(reg->bt_mem_end, mem)
-		  ? STACK_AT(mem_end_stk[mem])->u.mem.pstr
-		  : (UChar* )((void* )mem_end_stk[mem]));
-	  n = pend - pstart;
-	  DATA_ENSURE_CONTINUE(n);
-	  sprev = s;
-	  swork = s;
-	  STRING_CMP_VALUE(pstart, swork, n, is_fail);
-	  if (is_fail) continue;
-	  s = swork;
-	  while (sprev + (len = enclen_approx(encode, sprev, end)) < s)
-	    sprev += len;
+          pend = (BIT_STATUS_AT(reg->bt_mem_end, mem)
+                  ? STACK_AT(mem_end_stk[mem])->u.mem.pstr
+                  : (UChar* )((void* )mem_end_stk[mem]));
+          n = pend - pstart;
+          DATA_ENSURE_CONTINUE(n);
+          sprev = s;
+          swork = s;
+          STRING_CMP_VALUE(pstart, swork, n, is_fail);
+          if (is_fail) continue;
+          s = swork;
+          while (sprev + (len = enclen_approx(encode, sprev, end)) < s)
+            sprev += len;
 
-	  p += (SIZE_MEMNUM * (tlen - i - 1));
-	  break; /* success */
-	}
-	if (i == tlen) goto fail;
-	MOP_OUT;
-	JUMP;
+          p += (SIZE_MEMNUM * (tlen - i - 1));
+          break; /* success */
+        }
+        if (i == tlen) goto fail;
+        MOP_OUT;
+        JUMP;
       }
       NEXT;
 
     CASE(OP_BACKREF_MULTI_IC)  MOP_IN(OP_BACKREF_MULTI_IC);
       {
-	int len, is_fail;
-	UChar *pstart, *pend, *swork;
+        int len, is_fail;
+        UChar *pstart, *pend, *swork;
 
-	GET_LENGTH_INC(tlen, p);
-	for (i = 0; i < tlen; i++) {
-	  GET_MEMNUM_INC(mem, p);
+        GET_LENGTH_INC(tlen, p);
+        for (i = 0; i < tlen; i++) {
+          GET_MEMNUM_INC(mem, p);
 
-	  if (mem_end_stk[mem]   == INVALID_STACK_INDEX) continue;
-	  if (mem_start_stk[mem] == INVALID_STACK_INDEX) continue;
+          if (mem_end_stk[mem]   == INVALID_STACK_INDEX) continue;
+          if (mem_start_stk[mem] == INVALID_STACK_INDEX) continue;
 
-	  if (BIT_STATUS_AT(reg->bt_mem_start, mem))
-	    pstart = STACK_AT(mem_start_stk[mem])->u.mem.pstr;
-	  else
-	    pstart = (UChar* )((void* )mem_start_stk[mem]);
+          if (BIT_STATUS_AT(reg->bt_mem_start, mem))
+            pstart = STACK_AT(mem_start_stk[mem])->u.mem.pstr;
+          else
+            pstart = (UChar* )((void* )mem_start_stk[mem]);
 
-	  pend = (BIT_STATUS_AT(reg->bt_mem_end, mem)
-		  ? STACK_AT(mem_end_stk[mem])->u.mem.pstr
-		  : (UChar* )((void* )mem_end_stk[mem]));
-	  n = pend - pstart;
-	  DATA_ENSURE_CONTINUE(n);
-	  sprev = s;
-	  swork = s;
-	  STRING_CMP_VALUE_IC(case_fold_flag, pstart, &swork, n, end, is_fail);
-	  if (is_fail) continue;
-	  s = swork;
-	  while (sprev + (len = enclen(encode, sprev, end)) < s)
-	    sprev += len;
+          pend = (BIT_STATUS_AT(reg->bt_mem_end, mem)
+                  ? STACK_AT(mem_end_stk[mem])->u.mem.pstr
+                  : (UChar* )((void* )mem_end_stk[mem]));
+          n = pend - pstart;
+          DATA_ENSURE_CONTINUE(n);
+          sprev = s;
+          swork = s;
+          STRING_CMP_VALUE_IC(case_fold_flag, pstart, &swork, n, end, is_fail);
+          if (is_fail) continue;
+          s = swork;
+          while (sprev + (len = enclen(encode, sprev, end)) < s)
+            sprev += len;
 
-	  p += (SIZE_MEMNUM * (tlen - i - 1));
-	  break; /* success */
-	}
-	if (i == tlen) goto fail;
-	MOP_OUT;
-	JUMP;
+          p += (SIZE_MEMNUM * (tlen - i - 1));
+          break; /* success */
+        }
+        if (i == tlen) goto fail;
+        MOP_OUT;
+        JUMP;
       }
 
 #ifdef USE_BACKREF_WITH_LEVEL
     CASE(OP_BACKREF_WITH_LEVEL)
       {
-	int len;
-	OnigOptionType ic;
-	LengthType level;
+        int len;
+        OnigOptionType ic;
+        LengthType level;
 
-	GET_OPTION_INC(ic,    p);
-	GET_LENGTH_INC(level, p);
-	GET_LENGTH_INC(tlen,  p);
+        GET_OPTION_INC(ic,    p);
+        GET_LENGTH_INC(level, p);
+        GET_LENGTH_INC(tlen,  p);
 
-	sprev = s;
-	if (backref_match_at_nested_level(reg, stk, stk_base, ic,
-		  case_fold_flag, (int )level, (int )tlen, p, &s, end)) {
-	  while (sprev + (len = enclen(encode, sprev, end)) < s)
-	    sprev += len;
+        sprev = s;
+        if (backref_match_at_nested_level(reg, stk, stk_base, ic,
+                  case_fold_flag, (int )level, (int )tlen, p, &s, end)) {
+          while (sprev + (len = enclen(encode, sprev, end)) < s)
+            sprev += len;
 
-	  p += (SIZE_MEMNUM * tlen);
-	}
-	else
-	  goto fail;
+          p += (SIZE_MEMNUM * tlen);
+        }
+        else
+          goto fail;
 
-	MOP_OUT;
-	JUMP;
+        MOP_OUT;
+        JUMP;
       }
 
 #endif
@@ -3697,33 +3697,33 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_NULL_CHECK_END)  MOP_IN(OP_NULL_CHECK_END);
       {
-	int isnull;
+        int isnull;
 
-	GET_MEMNUM_INC(mem, p); /* mem: null check id */
-	STACK_NULL_CHECK(isnull, mem, s);
-	if (isnull) {
+        GET_MEMNUM_INC(mem, p); /* mem: null check id */
+        STACK_NULL_CHECK(isnull, mem, s);
+        if (isnull) {
 #ifdef ONIG_DEBUG_MATCH
-	  fprintf(stderr, "NULL_CHECK_END: skip  id:%d, s:%"PRIuPTR" (%p)\n",
-		  (int )mem, (uintptr_t )s, s);
+          fprintf(stderr, "NULL_CHECK_END: skip  id:%d, s:%"PRIuPTR" (%p)\n",
+                  (int )mem, (uintptr_t )s, s);
 #endif
-	null_check_found:
-	  /* empty loop founded, skip next instruction */
-	  switch (*p++) {
-	  case OP_JUMP:
-	  case OP_PUSH:
-	    p += SIZE_RELADDR;
-	    break;
-	  case OP_REPEAT_INC:
-	  case OP_REPEAT_INC_NG:
-	  case OP_REPEAT_INC_SG:
-	  case OP_REPEAT_INC_NG_SG:
-	    p += SIZE_MEMNUM;
-	    break;
-	  default:
-	    goto unexpected_bytecode_error;
-	    break;
-	  }
-	}
+        null_check_found:
+          /* empty loop founded, skip next instruction */
+          switch (*p++) {
+          case OP_JUMP:
+          case OP_PUSH:
+            p += SIZE_RELADDR;
+            break;
+          case OP_REPEAT_INC:
+          case OP_REPEAT_INC_NG:
+          case OP_REPEAT_INC_SG:
+          case OP_REPEAT_INC_NG_SG:
+            p += SIZE_MEMNUM;
+            break;
+          default:
+            goto unexpected_bytecode_error;
+            break;
+          }
+        }
       }
       MOP_OUT;
       JUMP;
@@ -3731,18 +3731,18 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 #ifdef USE_MONOMANIAC_CHECK_CAPTURES_IN_ENDLESS_REPEAT
     CASE(OP_NULL_CHECK_END_MEMST)  MOP_IN(OP_NULL_CHECK_END_MEMST);
       {
-	int isnull;
+        int isnull;
 
-	GET_MEMNUM_INC(mem, p); /* mem: null check id */
-	STACK_NULL_CHECK_MEMST(isnull, mem, s, reg);
-	if (isnull) {
+        GET_MEMNUM_INC(mem, p); /* mem: null check id */
+        STACK_NULL_CHECK_MEMST(isnull, mem, s, reg);
+        if (isnull) {
 # ifdef ONIG_DEBUG_MATCH
-	  fprintf(stderr, "NULL_CHECK_END_MEMST: skip  id:%d, s:%"PRIuPTR" (%p)\n",
-		  (int )mem, (uintptr_t )s, s);
+          fprintf(stderr, "NULL_CHECK_END_MEMST: skip  id:%d, s:%"PRIuPTR" (%p)\n",
+                  (int )mem, (uintptr_t )s, s);
 # endif
-	  if (isnull == -1) goto fail;
-	  goto null_check_found;
-	}
+          if (isnull == -1) goto fail;
+          goto null_check_found;
+        }
       }
       MOP_OUT;
       JUMP;
@@ -3752,25 +3752,25 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_NULL_CHECK_END_MEMST_PUSH)
       MOP_IN(OP_NULL_CHECK_END_MEMST_PUSH);
       {
-	int isnull;
+        int isnull;
 
-	GET_MEMNUM_INC(mem, p); /* mem: null check id */
+        GET_MEMNUM_INC(mem, p); /* mem: null check id */
 # ifdef USE_MONOMANIAC_CHECK_CAPTURES_IN_ENDLESS_REPEAT
-	STACK_NULL_CHECK_MEMST_REC(isnull, mem, s, reg);
+        STACK_NULL_CHECK_MEMST_REC(isnull, mem, s, reg);
 # else
-	STACK_NULL_CHECK_REC(isnull, mem, s);
+        STACK_NULL_CHECK_REC(isnull, mem, s);
 # endif
-	if (isnull) {
+        if (isnull) {
 # ifdef ONIG_DEBUG_MATCH
-	  fprintf(stderr, "NULL_CHECK_END_MEMST_PUSH: skip  id:%d, s:%"PRIuPTR" (%p)\n",
-		  (int )mem, (uintptr_t )s, s);
+          fprintf(stderr, "NULL_CHECK_END_MEMST_PUSH: skip  id:%d, s:%"PRIuPTR" (%p)\n",
+                  (int )mem, (uintptr_t )s, s);
 # endif
-	  if (isnull == -1) goto fail;
-	  goto null_check_found;
-	}
-	else {
-	  STACK_PUSH_NULL_CHECK_END(mem);
-	}
+          if (isnull == -1) goto fail;
+          goto null_check_found;
+        }
+        else {
+          STACK_PUSH_NULL_CHECK_END(mem);
+        }
       }
       MOP_OUT;
       JUMP;
@@ -3806,10 +3806,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       GET_RELADDR_INC(addr, p);
       STATE_CHECK_VAL(scv, mem);
       if (scv) {
-	p += addr;
+        p += addr;
       }
       else {
-	STACK_PUSH_ALT_WITH_STATE_CHECK(p + addr, s, sprev, mem, pkeep);
+        STACK_PUSH_ALT_WITH_STATE_CHECK(p + addr, s, sprev, mem, pkeep);
       }
       MOP_OUT;
       JUMP;
@@ -3838,11 +3838,11 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     CASE(OP_PUSH_OR_JUMP_EXACT1)  MOP_IN(OP_PUSH_OR_JUMP_EXACT1);
       GET_RELADDR_INC(addr, p);
       if (*p == *s && DATA_ENSURE_CHECK1) {
-	p++;
-	CHECK_MATCH_CACHE;
-	STACK_PUSH_ALT(p + addr, s, sprev, pkeep);
-	MOP_OUT;
-	JUMP;
+        p++;
+        CHECK_MATCH_CACHE;
+        STACK_PUSH_ALT(p + addr, s, sprev, pkeep);
+        MOP_OUT;
+        JUMP;
       }
       p += (addr + 1);
       MOP_OUT;
@@ -3853,10 +3853,10 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       GET_RELADDR_INC(addr, p);
       CHECK_MATCH_CACHE;
       if (*p == *s) {
-	p++;
-	STACK_PUSH_ALT(p + addr, s, sprev, pkeep);
-	MOP_OUT;
-	JUMP;
+        p++;
+        STACK_PUSH_ALT(p + addr, s, sprev, pkeep);
+        MOP_OUT;
+        JUMP;
       }
       p++;
       INC_NUM_FAILS;
@@ -3865,35 +3865,35 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_REPEAT)  MOP_IN(OP_REPEAT);
       {
-	GET_MEMNUM_INC(mem, p);    /* mem: OP_REPEAT ID */
-	GET_RELADDR_INC(addr, p);
+        GET_MEMNUM_INC(mem, p);    /* mem: OP_REPEAT ID */
+        GET_RELADDR_INC(addr, p);
 
-	STACK_ENSURE(1);
-	repeat_stk[mem] = GET_STACK_INDEX(stk);
-	STACK_PUSH_REPEAT(mem, p);
+        STACK_ENSURE(1);
+        repeat_stk[mem] = GET_STACK_INDEX(stk);
+        STACK_PUSH_REPEAT(mem, p);
 
-	if (reg->repeat_range[mem].lower == 0) {
-	  CHECK_MATCH_CACHE;
-	  STACK_PUSH_ALT(p + addr, s, sprev, pkeep);
-	}
+        if (reg->repeat_range[mem].lower == 0) {
+          CHECK_MATCH_CACHE;
+          STACK_PUSH_ALT(p + addr, s, sprev, pkeep);
+        }
       }
       MOP_OUT;
       JUMP;
 
     CASE(OP_REPEAT_NG)  MOP_IN(OP_REPEAT_NG);
       {
-	GET_MEMNUM_INC(mem, p);    /* mem: OP_REPEAT ID */
-	GET_RELADDR_INC(addr, p);
+        GET_MEMNUM_INC(mem, p);    /* mem: OP_REPEAT ID */
+        GET_RELADDR_INC(addr, p);
 
-	STACK_ENSURE(1);
-	repeat_stk[mem] = GET_STACK_INDEX(stk);
-	STACK_PUSH_REPEAT(mem, p);
+        STACK_ENSURE(1);
+        repeat_stk[mem] = GET_STACK_INDEX(stk);
+        STACK_PUSH_REPEAT(mem, p);
 
-	if (reg->repeat_range[mem].lower == 0) {
-	  CHECK_MATCH_CACHE;
-	  STACK_PUSH_ALT(p, s, sprev, pkeep);
-	  p += addr;
-	}
+        if (reg->repeat_range[mem].lower == 0) {
+          CHECK_MATCH_CACHE;
+          STACK_PUSH_ALT(p, s, sprev, pkeep);
+          p += addr;
+        }
       }
       MOP_OUT;
       JUMP;
@@ -3906,23 +3906,23 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     repeat_inc:
       stkp->u.repeat.count++;
       if (stkp->u.repeat.count >= reg->repeat_range[mem].upper) {
-	/* end of repeat. Nothing to do. */
+        /* end of repeat. Nothing to do. */
       }
       else if (stkp->u.repeat.count >= reg->repeat_range[mem].lower) {
 #ifdef USE_MATCH_CACHE
-	if (*pbegin == OP_REPEAT_INC) {
+        if (*pbegin == OP_REPEAT_INC) {
 #undef MATCH_CACHE_HIT
 #define MATCH_CACHE_HIT stkp->u.repeat.count--;
-	  CHECK_MATCH_CACHE;
+          CHECK_MATCH_CACHE;
 #undef MATCH_CACHE_HIT
 #define MATCH_CACHE_HIT ((void) 0)
-	}
+        }
 #endif
-	STACK_PUSH_ALT(p, s, sprev, pkeep);
-	p = STACK_AT(si)->u.repeat.pcode; /* Don't use stkp after PUSH. */
+        STACK_PUSH_ALT(p, s, sprev, pkeep);
+        p = STACK_AT(si)->u.repeat.pcode; /* Don't use stkp after PUSH. */
       }
       else {
-	p = stkp->u.repeat.pcode;
+        p = stkp->u.repeat.pcode;
       }
       STACK_PUSH_REPEAT_INC(si);
       MOP_OUT;
@@ -3944,22 +3944,22 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
     repeat_inc_ng:
       stkp->u.repeat.count++;
       if (stkp->u.repeat.count < reg->repeat_range[mem].upper) {
-	if (stkp->u.repeat.count >= reg->repeat_range[mem].lower) {
-	  UChar* pcode = stkp->u.repeat.pcode;
+        if (stkp->u.repeat.count >= reg->repeat_range[mem].lower) {
+          UChar* pcode = stkp->u.repeat.pcode;
 
-	  STACK_PUSH_REPEAT_INC(si);
-	  if (*pbegin == OP_REPEAT_INC_NG) {
-	    CHECK_MATCH_CACHE;
-	  }
-	  STACK_PUSH_ALT(pcode, s, sprev, pkeep);
-	}
-	else {
-	  p = stkp->u.repeat.pcode;
-	  STACK_PUSH_REPEAT_INC(si);
-	}
+          STACK_PUSH_REPEAT_INC(si);
+          if (*pbegin == OP_REPEAT_INC_NG) {
+            CHECK_MATCH_CACHE;
+          }
+          STACK_PUSH_ALT(pcode, s, sprev, pkeep);
+        }
+        else {
+          p = stkp->u.repeat.pcode;
+          STACK_PUSH_REPEAT_INC(si);
+        }
       }
       else if (stkp->u.repeat.count == reg->repeat_range[mem].upper) {
-	STACK_PUSH_REPEAT_INC(si);
+        STACK_PUSH_REPEAT_INC(si);
       }
       MOP_OUT;
       CHECK_INTERRUPT_IN_MATCH_AT;
@@ -3979,9 +3979,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_POP_POS)  MOP_IN(OP_POP_POS);
       {
-	STACK_POS_END(stkp);
-	s     = stkp->u.state.pstr;
-	sprev = stkp->u.state.pstr_prev;
+        STACK_POS_END(stkp);
+        s     = stkp->u.state.pstr;
+        sprev = stkp->u.state.pstr_prev;
       }
       MOP_OUT;
       JUMP;
@@ -4020,15 +4020,15 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       GET_LENGTH_INC(tlen, p);
       q = (UChar* )ONIGENC_STEP_BACK(encode, str, s, end, (int )tlen);
       if (IS_NULL(q)) {
-	/* too short case -> success. ex. /(?<!XXX)a/.match("a")
-	   If you want to change to fail, replace following line. */
-	p += addr;
-	/* goto fail; */
+        /* too short case -> success. ex. /(?<!XXX)a/.match("a")
+           If you want to change to fail, replace following line. */
+        p += addr;
+        /* goto fail; */
       }
       else {
-	STACK_PUSH_LOOK_BEHIND_NOT(p + addr, s, sprev, pkeep);
-	s = q;
-	sprev = (UChar* )onigenc_get_prev_char_head(encode, str, s, end);
+        STACK_PUSH_LOOK_BEHIND_NOT(p + addr, s, sprev, pkeep);
+        s = q;
+        sprev = (UChar* )onigenc_get_prev_char_head(encode, str, s, end);
       }
       MOP_OUT;
       JUMP;
@@ -4046,44 +4046,44 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_ABSENT)  MOP_IN(OP_ABSENT);
       {
-	const UChar* aend = ABSENT_END_POS;
-	UChar* absent;
-	UChar* selfp = p - 1;
+        const UChar* aend = ABSENT_END_POS;
+        UChar* absent;
+        UChar* selfp = p - 1;
 
-	STACK_POP_ABSENT_POS(absent, ABSENT_END_POS);  /* Restore end-pos. */
-	GET_RELADDR_INC(addr, p);
+        STACK_POP_ABSENT_POS(absent, ABSENT_END_POS);  /* Restore end-pos. */
+        GET_RELADDR_INC(addr, p);
 #ifdef ONIG_DEBUG_MATCH
-	fprintf(stderr, "ABSENT: s:%p, end:%p, absent:%p, aend:%p\n", s, end, absent, aend);
+        fprintf(stderr, "ABSENT: s:%p, end:%p, absent:%p, aend:%p\n", s, end, absent, aend);
 #endif
-	if ((absent > aend) && (s > absent)) {
-	  /* An empty match occurred in (?~...) at the start point.
-	   * Never match. */
-	  STACK_POP;
-	  goto fail;
-	}
-	else if ((s >= aend) && (s > absent)) {
-	  if (s > aend) {
-	    /* Only one (or less) character matched in the last iteration.
-	     * This is not a possible point. */
-	    goto fail;
-	  }
-	  /* All possible points were found. Try matching after (?~...). */
-	  DATA_ENSURE(0);
-	  p += addr;
-	}
-	else if (s == end) {
-	  /* At the end of the string, just match with it */
-	  DATA_ENSURE(0);
-	  p += addr;
-	}
-	else {
-	  STACK_PUSH_ALT(p + addr, s, sprev, pkeep); /* Push possible point. */
-	  n = enclen(encode, s, end);
-	  STACK_PUSH_ABSENT_POS(absent, ABSENT_END_POS); /* Save the original pos. */
-	  STACK_PUSH_ALT(selfp, s + n, s, pkeep); /* Next iteration. */
-	  STACK_PUSH_ABSENT;
-	  ABSENT_END_POS = aend;
-	}
+        if ((absent > aend) && (s > absent)) {
+          /* An empty match occurred in (?~...) at the start point.
+           * Never match. */
+          STACK_POP;
+          goto fail;
+        }
+        else if ((s >= aend) && (s > absent)) {
+          if (s > aend) {
+            /* Only one (or less) character matched in the last iteration.
+             * This is not a possible point. */
+            goto fail;
+          }
+          /* All possible points were found. Try matching after (?~...). */
+          DATA_ENSURE(0);
+          p += addr;
+        }
+        else if (s == end) {
+          /* At the end of the string, just match with it */
+          DATA_ENSURE(0);
+          p += addr;
+        }
+        else {
+          STACK_PUSH_ALT(p + addr, s, sprev, pkeep); /* Push possible point. */
+          n = enclen(encode, s, end);
+          STACK_PUSH_ABSENT_POS(absent, ABSENT_END_POS); /* Save the original pos. */
+          STACK_PUSH_ALT(selfp, s + n, s, pkeep); /* Next iteration. */
+          STACK_PUSH_ABSENT;
+          ABSENT_END_POS = aend;
+        }
       }
       MOP_OUT;
       JUMP;
@@ -4092,7 +4092,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       /* The pattern inside (?~...) was matched.
        * Set the end-pos temporary and go to next iteration. */
       if (sprev < ABSENT_END_POS)
-	ABSENT_END_POS = sprev;
+        ABSENT_END_POS = sprev;
 #ifdef ONIG_DEBUG_MATCH
       fprintf(stderr, "ABSENT_END: end:%p\n", ABSENT_END_POS);
 #endif
@@ -4119,9 +4119,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
       GET_MEMNUM_INC(mem, p);
       GET_RELADDR_INC(addr, p);
       if ((mem > num_mem) ||
-	  (mem_end_stk[mem]   == INVALID_STACK_INDEX) ||
-	  (mem_start_stk[mem] == INVALID_STACK_INDEX)) {
-	p += addr;
+          (mem_end_stk[mem]   == INVALID_STACK_INDEX) ||
+          (mem_start_stk[mem] == INVALID_STACK_INDEX)) {
+        p += addr;
       }
       MOP_OUT;
       JUMP;
@@ -4132,9 +4132,9 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
     CASE(OP_FAIL)
       if (0) {
-	/* fall */
+        /* fall */
       fail:
-	MOP_OUT;
+        MOP_OUT;
       }
       MOP_IN(OP_FAIL);
       STACK_POP;
@@ -4145,71 +4145,71 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
 #ifdef USE_MATCH_CACHE
       if (
-	  msa->match_cache_status != MATCH_CACHE_STATUS_DISABLED &&
-	  ++msa->num_fails >= (long)(end - str) * msa->num_cache_opcodes
+          msa->match_cache_status != MATCH_CACHE_STATUS_DISABLED &&
+          ++msa->num_fails >= (long)(end - str) * msa->num_cache_opcodes
       ) {
-	if (msa->match_cache_status == MATCH_CACHE_STATUS_UNINIT) {
-	  msa->match_cache_status = MATCH_CACHE_STATUS_INIT;
-	  OnigPosition r = count_num_cache_opcodes(reg, &msa->num_cache_opcodes);
-	  if (r < 0) goto bytecode_error;
-	}
-	if (msa->num_cache_opcodes == NUM_CACHE_OPCODES_IMPOSSIBLE || msa->num_cache_opcodes == 0) {
-	  msa->match_cache_status = MATCH_CACHE_STATUS_DISABLED;
-	  goto fail_match_cache;
-	}
-	if (msa->num_fails < (long)(end - str) * msa->num_cache_opcodes) {
-	  goto fail_match_cache;
-	}
-	if (msa->cache_opcodes == NULL) {
-	  msa->match_cache_status = MATCH_CACHE_STATUS_ENABLED;
-	  OnigCacheOpcode* cache_opcodes = (OnigCacheOpcode*)xmalloc(msa->num_cache_opcodes * sizeof(OnigCacheOpcode));
-	  if (cache_opcodes == NULL) {
-	    return ONIGERR_MEMORY;
-	  }
-	  OnigPosition r = init_cache_opcodes(reg, cache_opcodes, &msa->num_cache_points);
-	  if (r < 0) {
-	    if (r == ONIGERR_UNEXPECTED_BYTECODE) goto unexpected_bytecode_error;
-	    else goto bytecode_error;
-	  }
-	  msa->cache_opcodes = cache_opcodes;
+        if (msa->match_cache_status == MATCH_CACHE_STATUS_UNINIT) {
+          msa->match_cache_status = MATCH_CACHE_STATUS_INIT;
+          OnigPosition r = count_num_cache_opcodes(reg, &msa->num_cache_opcodes);
+          if (r < 0) goto bytecode_error;
+        }
+        if (msa->num_cache_opcodes == NUM_CACHE_OPCODES_IMPOSSIBLE || msa->num_cache_opcodes == 0) {
+          msa->match_cache_status = MATCH_CACHE_STATUS_DISABLED;
+          goto fail_match_cache;
+        }
+        if (msa->num_fails < (long)(end - str) * msa->num_cache_opcodes) {
+          goto fail_match_cache;
+        }
+        if (msa->cache_opcodes == NULL) {
+          msa->match_cache_status = MATCH_CACHE_STATUS_ENABLED;
+          OnigCacheOpcode* cache_opcodes = (OnigCacheOpcode*)xmalloc(msa->num_cache_opcodes * sizeof(OnigCacheOpcode));
+          if (cache_opcodes == NULL) {
+            return ONIGERR_MEMORY;
+          }
+          OnigPosition r = init_cache_opcodes(reg, cache_opcodes, &msa->num_cache_points);
+          if (r < 0) {
+            if (r == ONIGERR_UNEXPECTED_BYTECODE) goto unexpected_bytecode_error;
+            else goto bytecode_error;
+          }
+          msa->cache_opcodes = cache_opcodes;
 #ifdef ONIG_DEBUG_MATCH_CACHE
-	  fprintf(stderr, "MATCH CACHE: #cache opcodes = %ld\n", msa->num_cache_opcodes);
-	  fprintf(stderr, "MATCH CACHE: #cache points = %ld\n", msa->num_cache_points);
-	  fprintf(stderr, "MATCH CACHE: cache opcodes (%p):\n", msa->cache_opcodes);
-	  for (int i = 0; i < msa->num_cache_opcodes; i++) {
-	    fprintf(stderr, "MATCH CACHE:   [%p] cache_point=%ld outer_repeat_mem=%d num_cache_opcodes_at_outer_repeat=%ld num_cache_opcodes_in_outer_repeat=%ld lookaround_nesting=%d match_addr=%p\n", msa->cache_opcodes[i].addr, msa->cache_opcodes[i].cache_point, msa->cache_opcodes[i].outer_repeat_mem, msa->cache_opcodes[i].num_cache_points_at_outer_repeat, msa->cache_opcodes[i].num_cache_points_in_outer_repeat, msa->cache_opcodes[i].lookaround_nesting, msa->cache_opcodes[i].match_addr);
-	  }
+          fprintf(stderr, "MATCH CACHE: #cache opcodes = %ld\n", msa->num_cache_opcodes);
+          fprintf(stderr, "MATCH CACHE: #cache points = %ld\n", msa->num_cache_points);
+          fprintf(stderr, "MATCH CACHE: cache opcodes (%p):\n", msa->cache_opcodes);
+          for (int i = 0; i < msa->num_cache_opcodes; i++) {
+            fprintf(stderr, "MATCH CACHE:   [%p] cache_point=%ld outer_repeat_mem=%d num_cache_opcodes_at_outer_repeat=%ld num_cache_opcodes_in_outer_repeat=%ld lookaround_nesting=%d match_addr=%p\n", msa->cache_opcodes[i].addr, msa->cache_opcodes[i].cache_point, msa->cache_opcodes[i].outer_repeat_mem, msa->cache_opcodes[i].num_cache_points_at_outer_repeat, msa->cache_opcodes[i].num_cache_points_in_outer_repeat, msa->cache_opcodes[i].lookaround_nesting, msa->cache_opcodes[i].match_addr);
+          }
 #endif
-	}
-	if (msa->match_cache_buf == NULL) {
-	  size_t length = (end - str) + 1;
-	  size_t num_match_cache_points = (size_t)msa->num_cache_points * length;
+        }
+        if (msa->match_cache_buf == NULL) {
+          size_t length = (end - str) + 1;
+          size_t num_match_cache_points = (size_t)msa->num_cache_points * length;
 #ifdef ONIG_DEBUG_MATCH_CACHE
-	  fprintf(stderr, "MATCH CACHE: #match cache points = %zu (length = %zu)\n", num_match_cache_points, length);
+          fprintf(stderr, "MATCH CACHE: #match cache points = %zu (length = %zu)\n", num_match_cache_points, length);
 #endif
-	  /* Overflow check */
-	  if (num_match_cache_points / length != (size_t)msa->num_cache_points) {
-	    return ONIGERR_MEMORY;
-	  }
-	  if (num_match_cache_points >= LONG_MAX_LIMIT) {
-	    return ONIGERR_MEMORY;
-	  }
-	  size_t match_cache_buf_length = (num_match_cache_points >> 3) + (num_match_cache_points & 7 ? 1 : 0) + 1;
-	  uint8_t* match_cache_buf = (uint8_t*)xmalloc(match_cache_buf_length * sizeof(uint8_t));
-	  if (match_cache_buf == NULL) {
-	    return ONIGERR_MEMORY;
-	  }
-	  xmemset(match_cache_buf, 0, match_cache_buf_length * sizeof(uint8_t));
-	  msa->match_cache_buf = match_cache_buf;
-	}
+          /* Overflow check */
+          if (num_match_cache_points / length != (size_t)msa->num_cache_points) {
+            return ONIGERR_MEMORY;
+          }
+          if (num_match_cache_points >= LONG_MAX_LIMIT) {
+            return ONIGERR_MEMORY;
+          }
+          size_t match_cache_buf_length = (num_match_cache_points >> 3) + (num_match_cache_points & 7 ? 1 : 0) + 1;
+          uint8_t* match_cache_buf = (uint8_t*)xmalloc(match_cache_buf_length * sizeof(uint8_t));
+          if (match_cache_buf == NULL) {
+            return ONIGERR_MEMORY;
+          }
+          xmemset(match_cache_buf, 0, match_cache_buf_length * sizeof(uint8_t));
+          msa->match_cache_buf = match_cache_buf;
+        }
       }
       fail_match_cache:
 #endif
 
 #ifdef USE_COMBINATION_EXPLOSION_CHECK
       if (stk->u.state.state_check != 0) {
-	stk->type = STK_STATE_CHECK_MARK;
-	stk++;
+        stk->type = STK_STATE_CHECK_MARK;
+        stk++;
       }
 #endif
 
@@ -4252,7 +4252,7 @@ match_at(regex_t* reg, const UChar* str, const UChar* end,
 
 static UChar*
 slow_search(OnigEncoding enc, UChar* target, UChar* target_end,
-	    const UChar* text, const UChar* text_end, UChar* text_range)
+            const UChar* text, const UChar* text_end, UChar* text_range)
 {
   UChar *t, *p, *s, *end;
 
@@ -4268,10 +4268,10 @@ slow_search(OnigEncoding enc, UChar* target, UChar* target_end,
 
     while (s < end) {
       if (*s == *target) {
-	p = s + 1;
-	t = target + 1;
-	if (target_end == t || memcmp(t, p, target_end - t) == 0)
-	  return s;
+        p = s + 1;
+        t = target + 1;
+        if (target_end == t || memcmp(t, p, target_end - t) == 0)
+          return s;
       }
       s += n;
     }
@@ -4282,7 +4282,7 @@ slow_search(OnigEncoding enc, UChar* target, UChar* target_end,
       p = s + 1;
       t = target + 1;
       if (target_end == t || memcmp(t, p, target_end - t) == 0)
-	return s;
+        return s;
     }
     s += enclen(enc, s, text_end);
   }
@@ -4292,8 +4292,8 @@ slow_search(OnigEncoding enc, UChar* target, UChar* target_end,
 
 static int
 str_lower_case_match(OnigEncoding enc, int case_fold_flag,
-		     const UChar* t, const UChar* tend,
-		     const UChar* p, const UChar* end)
+                     const UChar* t, const UChar* tend,
+                     const UChar* p, const UChar* end)
 {
   int lowlen;
   UChar *q, lowbuf[ONIGENC_MBC_CASE_FOLD_MAXLEN];
@@ -4312,8 +4312,8 @@ str_lower_case_match(OnigEncoding enc, int case_fold_flag,
 
 static UChar*
 slow_search_ic(OnigEncoding enc, int case_fold_flag,
-	       UChar* target, UChar* target_end,
-	       const UChar* text, const UChar* text_end, UChar* text_range)
+               UChar* target, UChar* target_end,
+               const UChar* text, const UChar* text_end, UChar* text_range)
 {
   UChar *s, *end;
 
@@ -4326,7 +4326,7 @@ slow_search_ic(OnigEncoding enc, int case_fold_flag,
 
   while (s < end) {
     if (str_lower_case_match(enc, case_fold_flag, target, target_end,
-			     s, text_end))
+                             s, text_end))
       return s;
 
     s += enclen(enc, s, text_end);
@@ -4337,8 +4337,8 @@ slow_search_ic(OnigEncoding enc, int case_fold_flag,
 
 static UChar*
 slow_search_backward(OnigEncoding enc, UChar* target, UChar* target_end,
-		     const UChar* text, const UChar* adjust_text,
-		     const UChar* text_end, const UChar* text_start)
+                     const UChar* text, const UChar* adjust_text,
+                     const UChar* text_end, const UChar* text_start)
 {
   UChar *t, *p, *s;
 
@@ -4354,12 +4354,12 @@ slow_search_backward(OnigEncoding enc, UChar* target, UChar* target_end,
       p = s + 1;
       t = target + 1;
       while (t < target_end) {
-	if (*t != *p++)
-	  break;
-	t++;
+        if (*t != *p++)
+          break;
+        t++;
       }
       if (t == target_end)
-	return s;
+        return s;
     }
     s = (UChar* )onigenc_get_prev_char_head(enc, adjust_text, s, text_end);
   }
@@ -4369,9 +4369,9 @@ slow_search_backward(OnigEncoding enc, UChar* target, UChar* target_end,
 
 static UChar*
 slow_search_backward_ic(OnigEncoding enc, int case_fold_flag,
-			UChar* target, UChar* target_end,
-			const UChar* text, const UChar* adjust_text,
-			const UChar* text_end, const UChar* text_start)
+                        UChar* target, UChar* target_end,
+                        const UChar* text, const UChar* adjust_text,
+                        const UChar* text_end, const UChar* text_start)
 {
   UChar *s;
 
@@ -4384,7 +4384,7 @@ slow_search_backward_ic(OnigEncoding enc, int case_fold_flag,
 
   while (s >= text) {
     if (str_lower_case_match(enc, case_fold_flag,
-			     target, target_end, s, text_end))
+                             target, target_end, s, text_end))
       return s;
 
     s = (UChar* )onigenc_get_prev_char_head(enc, adjust_text, s, text_end);
@@ -4397,8 +4397,8 @@ slow_search_backward_ic(OnigEncoding enc, int case_fold_flag,
 /* Boyer-Moore-Horspool search applied to a multibyte string */
 static UChar*
 bm_search_notrev(regex_t* reg, const UChar* target, const UChar* target_end,
-		 const UChar* text, const UChar* text_end,
-		 const UChar* text_range)
+                 const UChar* text, const UChar* text_end,
+                 const UChar* text_range)
 {
   const UChar *s, *se, *t, *p, *end;
   const UChar *tail;
@@ -4406,7 +4406,7 @@ bm_search_notrev(regex_t* reg, const UChar* target, const UChar* target_end,
 
 # ifdef ONIG_DEBUG_SEARCH
   fprintf(stderr, "bm_search_notrev: text: %"PRIuPTR" (%p), text_end: %"PRIuPTR" (%p), text_range: %"PRIuPTR" (%p)\n",
-	  (uintptr_t )text, text, (uintptr_t )text_end, text_end, (uintptr_t )text_range, text_range);
+          (uintptr_t )text, text, (uintptr_t )text_end, text_end, (uintptr_t )text_range, text_range);
 # endif
 
   tail = target_end - 1;
@@ -4422,13 +4422,13 @@ bm_search_notrev(regex_t* reg, const UChar* target, const UChar* target_end,
       p = se = s + tlen1;
       t = tail;
       while (*p == *t) {
-	if (t == target) return (UChar* )s;
-	p--; t--;
+        if (t == target) return (UChar* )s;
+        p--; t--;
       }
       skip = reg->map[*se];
       t = s;
       do {
-	s += enclen(reg->enc, s, end);
+        s += enclen(reg->enc, s, end);
       } while ((s - t) < skip && s < end);
     }
   }
@@ -4438,13 +4438,13 @@ bm_search_notrev(regex_t* reg, const UChar* target, const UChar* target_end,
       p = se = s + tlen1;
       t = tail;
       while (*p == *t) {
-	if (t == target) return (UChar* )s;
-	p--; t--;
+        if (t == target) return (UChar* )s;
+        p--; t--;
       }
       skip = reg->int_map[*se];
       t = s;
       do {
-	s += enclen(reg->enc, s, end);
+        s += enclen(reg->enc, s, end);
       } while ((s - t) < skip && s < end);
     }
 # endif
@@ -4456,14 +4456,14 @@ bm_search_notrev(regex_t* reg, const UChar* target, const UChar* target_end,
 /* Boyer-Moore-Horspool search */
 static UChar*
 bm_search(regex_t* reg, const UChar* target, const UChar* target_end,
-	  const UChar* text, const UChar* text_end, const UChar* text_range)
+          const UChar* text, const UChar* text_end, const UChar* text_range)
 {
   const UChar *s, *t, *p, *end;
   const UChar *tail;
 
 # ifdef ONIG_DEBUG_SEARCH
   fprintf(stderr, "bm_search: text: %"PRIuPTR" (%p), text_end: %"PRIuPTR" (%p), text_range: %"PRIuPTR" (%p)\n",
-	  (uintptr_t )text, text, (uintptr_t )text_end, text_end, (uintptr_t )text_range, text_range);
+          (uintptr_t )text, text, (uintptr_t )text_end, text_end, (uintptr_t )text_range, text_range);
 # endif
 
   end = text_range + (target_end - target) - 1;
@@ -4478,11 +4478,11 @@ bm_search(regex_t* reg, const UChar* target, const UChar* target_end,
       t = tail;
 # ifdef ONIG_DEBUG_SEARCH
       fprintf(stderr, "bm_search_loop: pos: %"PRIdPTR" %s\n",
-	  (intptr_t )(s - text), s);
+          (intptr_t )(s - text), s);
 # endif
       while (*p == *t) {
-	if (t == target) return (UChar* )p;
-	p--; t--;
+        if (t == target) return (UChar* )p;
+        p--; t--;
       }
       s += reg->map[*s];
     }
@@ -4493,8 +4493,8 @@ bm_search(regex_t* reg, const UChar* target, const UChar* target_end,
       p = s;
       t = tail;
       while (*p == *t) {
-	if (t == target) return (UChar* )p;
-	p--; t--;
+        if (t == target) return (UChar* )p;
+        p--; t--;
       }
       s += reg->int_map[*s];
     }
@@ -4506,8 +4506,8 @@ bm_search(regex_t* reg, const UChar* target, const UChar* target_end,
 /* Boyer-Moore-Horspool search applied to a multibyte string (ignore case) */
 static UChar*
 bm_search_notrev_ic(regex_t* reg, const UChar* target, const UChar* target_end,
-		    const UChar* text, const UChar* text_end,
-		    const UChar* text_range)
+                    const UChar* text, const UChar* text_end,
+                    const UChar* text_range)
 {
   const UChar *s, *se, *t, *end;
   const UChar *tail;
@@ -4517,7 +4517,7 @@ bm_search_notrev_ic(regex_t* reg, const UChar* target, const UChar* target_end,
 
 # ifdef ONIG_DEBUG_SEARCH
   fprintf(stderr, "bm_search_notrev_ic: text: %d (%p), text_end: %d (%p), text_range: %d (%p)\n",
-	  (int )text, text, (int )text_end, text_end, (int )text_range, text_range);
+          (int )text, text, (int )text_end, text_end, (int )text_range, text_range);
 # endif
 
   tail = target_end - 1;
@@ -4532,12 +4532,12 @@ bm_search_notrev_ic(regex_t* reg, const UChar* target, const UChar* target_end,
     while (s < end) {
       se = s + tlen1;
       if (str_lower_case_match(enc, case_fold_flag, target, target_end,
-			       s, se + 1))
-	return (UChar* )s;
+                               s, se + 1))
+        return (UChar* )s;
       skip = reg->map[*se];
       t = s;
       do {
-	s += enclen(reg->enc, s, end);
+        s += enclen(reg->enc, s, end);
       } while ((s - t) < skip && s < end);
     }
   }
@@ -4546,12 +4546,12 @@ bm_search_notrev_ic(regex_t* reg, const UChar* target, const UChar* target_end,
     while (s < end) {
       se = s + tlen1;
       if (str_lower_case_match(enc, case_fold_flag, target, target_end,
-			       s, se + 1))
-	return (UChar* )s;
+                               s, se + 1))
+        return (UChar* )s;
       skip = reg->int_map[*se];
       t = s;
       do {
-	s += enclen(reg->enc, s, end);
+        s += enclen(reg->enc, s, end);
       } while ((s - t) < skip && s < end);
     }
 # endif
@@ -4563,7 +4563,7 @@ bm_search_notrev_ic(regex_t* reg, const UChar* target, const UChar* target_end,
 /* Boyer-Moore-Horspool search (ignore case) */
 static UChar*
 bm_search_ic(regex_t* reg, const UChar* target, const UChar* target_end,
-	     const UChar* text, const UChar* text_end, const UChar* text_range)
+             const UChar* text, const UChar* text_end, const UChar* text_range)
 {
   const UChar *s, *p, *end;
   const UChar *tail;
@@ -4572,7 +4572,7 @@ bm_search_ic(regex_t* reg, const UChar* target, const UChar* target_end,
 
 # ifdef ONIG_DEBUG_SEARCH
   fprintf(stderr, "bm_search_ic: text: %d (%p), text_end: %d (%p), text_range: %d (%p)\n",
-	  (int )text, text, (int )text_end, text_end, (int )text_range, text_range);
+          (int )text, text, (int )text_end, text_end, (int )text_range, text_range);
 # endif
 
   end = text_range + (target_end - target) - 1;
@@ -4585,8 +4585,8 @@ bm_search_ic(regex_t* reg, const UChar* target, const UChar* target_end,
     while (s < end) {
       p = s - (target_end - target) + 1;
       if (str_lower_case_match(enc, case_fold_flag, target, target_end,
-			       p, s + 1))
-	return (UChar* )p;
+                               p, s + 1))
+        return (UChar* )p;
       s += reg->map[*s];
     }
   }
@@ -4595,8 +4595,8 @@ bm_search_ic(regex_t* reg, const UChar* target, const UChar* target_end,
     while (s < end) {
       p = s - (target_end - target) + 1;
       if (str_lower_case_match(enc, case_fold_flag, target, target_end,
-			       p, s + 1))
-	return (UChar* )p;
+                               p, s + 1))
+        return (UChar* )p;
       s += reg->int_map[*s];
     }
 # endif
@@ -4609,8 +4609,8 @@ bm_search_ic(regex_t* reg, const UChar* target, const UChar* target_end,
 /* Sunday's quick search applied to a multibyte string */
 static UChar*
 bm_search_notrev(regex_t* reg, const UChar* target, const UChar* target_end,
-		 const UChar* text, const UChar* text_end,
-		 const UChar* text_range)
+                 const UChar* text, const UChar* text_end,
+                 const UChar* text_range)
 {
   const UChar *s, *se, *t, *p, *end;
   const UChar *tail;
@@ -4619,7 +4619,7 @@ bm_search_notrev(regex_t* reg, const UChar* target, const UChar* target_end,
 
 # ifdef ONIG_DEBUG_SEARCH
   fprintf(stderr, "bm_search_notrev: text: %"PRIuPTR" (%p), text_end: %"PRIuPTR" (%p), text_range: %"PRIuPTR" (%p)\n",
-	  (uintptr_t )text, text, (uintptr_t )text_end, text_end, (uintptr_t )text_range, text_range);
+          (uintptr_t )text, text, (uintptr_t )text_end, text_end, (uintptr_t )text_range, text_range);
 # endif
 
   tail = target_end - 1;
@@ -4635,14 +4635,14 @@ bm_search_notrev(regex_t* reg, const UChar* target, const UChar* target_end,
       p = se = s + tlen1;
       t = tail;
       while (*p == *t) {
-	if (t == target) return (UChar* )s;
-	p--; t--;
+        if (t == target) return (UChar* )s;
+        p--; t--;
       }
       if (s + 1 >= end) break;
       skip = reg->map[se[1]];
       t = s;
       do {
-	s += enclen(enc, s, end);
+        s += enclen(enc, s, end);
       } while ((s - t) < skip && s < end);
     }
   }
@@ -4652,14 +4652,14 @@ bm_search_notrev(regex_t* reg, const UChar* target, const UChar* target_end,
       p = se = s + tlen1;
       t = tail;
       while (*p == *t) {
-	if (t == target) return (UChar* )s;
-	p--; t--;
+        if (t == target) return (UChar* )s;
+        p--; t--;
       }
       if (s + 1 >= end) break;
       skip = reg->int_map[se[1]];
       t = s;
       do {
-	s += enclen(enc, s, end);
+        s += enclen(enc, s, end);
       } while ((s - t) < skip && s < end);
     }
 # endif
@@ -4671,7 +4671,7 @@ bm_search_notrev(regex_t* reg, const UChar* target, const UChar* target_end,
 /* Sunday's quick search */
 static UChar*
 bm_search(regex_t* reg, const UChar* target, const UChar* target_end,
-	  const UChar* text, const UChar* text_end, const UChar* text_range)
+          const UChar* text, const UChar* text_end, const UChar* text_range)
 {
   const UChar *s, *t, *p, *end;
   const UChar *tail;
@@ -4679,7 +4679,7 @@ bm_search(regex_t* reg, const UChar* target, const UChar* target_end,
 
 # ifdef ONIG_DEBUG_SEARCH
   fprintf(stderr, "bm_search: text: %"PRIuPTR" (%p), text_end: %"PRIuPTR" (%p), text_range: %"PRIuPTR" (%p)\n",
-	  (uintptr_t )text, text, (uintptr_t )text_end, text_end, (uintptr_t )text_range, text_range);
+          (uintptr_t )text, text, (uintptr_t )text_end, text_end, (uintptr_t )text_range, text_range);
 # endif
 
   tail = target_end - 1;
@@ -4694,8 +4694,8 @@ bm_search(regex_t* reg, const UChar* target, const UChar* target_end,
       p = s;
       t = tail;
       while (*p == *t) {
-	if (t == target) return (UChar* )p;
-	p--; t--;
+        if (t == target) return (UChar* )p;
+        p--; t--;
       }
       if (s + 1 >= end) break;
       s += reg->map[s[1]];
@@ -4707,8 +4707,8 @@ bm_search(regex_t* reg, const UChar* target, const UChar* target_end,
       p = s;
       t = tail;
       while (*p == *t) {
-	if (t == target) return (UChar* )p;
-	p--; t--;
+        if (t == target) return (UChar* )p;
+        p--; t--;
       }
       if (s + 1 >= end) break;
       s += reg->int_map[s[1]];
@@ -4721,8 +4721,8 @@ bm_search(regex_t* reg, const UChar* target, const UChar* target_end,
 /* Sunday's quick search applied to a multibyte string (ignore case) */
 static UChar*
 bm_search_notrev_ic(regex_t* reg, const UChar* target, const UChar* target_end,
-		    const UChar* text, const UChar* text_end,
-		    const UChar* text_range)
+                    const UChar* text, const UChar* text_end,
+                    const UChar* text_range)
 {
   const UChar *s, *se, *t, *end;
   const UChar *tail;
@@ -4732,7 +4732,7 @@ bm_search_notrev_ic(regex_t* reg, const UChar* target, const UChar* target_end,
 
 # ifdef ONIG_DEBUG_SEARCH
   fprintf(stderr, "bm_search_notrev_ic: text: %"PRIuPTR" (%p), text_end: %"PRIuPTR" (%p), text_range: %"PRIuPTR" (%p)\n",
-	  (uintptr_t )text, text, (uintptr_t )text_end, text_end, (uintptr_t )text_range, text_range);
+          (uintptr_t )text, text, (uintptr_t )text_end, text_end, (uintptr_t )text_range, text_range);
 # endif
 
   tail = target_end - 1;
@@ -4747,13 +4747,13 @@ bm_search_notrev_ic(regex_t* reg, const UChar* target, const UChar* target_end,
     while (s < end) {
       se = s + tlen1;
       if (str_lower_case_match(enc, case_fold_flag, target, target_end,
-			       s, se + 1))
-	return (UChar* )s;
+                               s, se + 1))
+        return (UChar* )s;
       if (s + 1 >= end) break;
       skip = reg->map[se[1]];
       t = s;
       do {
-	s += enclen(enc, s, end);
+        s += enclen(enc, s, end);
       } while ((s - t) < skip && s < end);
     }
   }
@@ -4762,13 +4762,13 @@ bm_search_notrev_ic(regex_t* reg, const UChar* target, const UChar* target_end,
     while (s < end) {
       se = s + tlen1;
       if (str_lower_case_match(enc, case_fold_flag, target, target_end,
-			       s, se + 1))
-	return (UChar* )s;
+                               s, se + 1))
+        return (UChar* )s;
       if (s + 1 >= end) break;
       skip = reg->int_map[se[1]];
       t = s;
       do {
-	s += enclen(enc, s, end);
+        s += enclen(enc, s, end);
       } while ((s - t) < skip && s < end);
     }
 # endif
@@ -4780,7 +4780,7 @@ bm_search_notrev_ic(regex_t* reg, const UChar* target, const UChar* target_end,
 /* Sunday's quick search (ignore case) */
 static UChar*
 bm_search_ic(regex_t* reg, const UChar* target, const UChar* target_end,
-	     const UChar* text, const UChar* text_end, const UChar* text_range)
+             const UChar* text, const UChar* text_end, const UChar* text_range)
 {
   const UChar *s, *p, *end;
   const UChar *tail;
@@ -4790,7 +4790,7 @@ bm_search_ic(regex_t* reg, const UChar* target, const UChar* target_end,
 
 # ifdef ONIG_DEBUG_SEARCH
   fprintf(stderr, "bm_search_ic: text: %"PRIuPTR" (%p), text_end: %"PRIuPTR" (%p), text_range: %"PRIuPTR" (%p)\n",
-	  (uintptr_t )text, text, (uintptr_t )text_end, text_end, (uintptr_t )text_range, text_range);
+          (uintptr_t )text, text, (uintptr_t )text_end, text_end, (uintptr_t )text_range, text_range);
 # endif
 
   tail = target_end - 1;
@@ -4804,8 +4804,8 @@ bm_search_ic(regex_t* reg, const UChar* target, const UChar* target_end,
     while (s < end) {
       p = s - tlen1;
       if (str_lower_case_match(enc, case_fold_flag, target, target_end,
-			       p, s + 1))
-	return (UChar* )p;
+                               p, s + 1))
+        return (UChar* )p;
       if (s + 1 >= end) break;
       s += reg->map[s[1]];
     }
@@ -4815,8 +4815,8 @@ bm_search_ic(regex_t* reg, const UChar* target, const UChar* target_end,
     while (s < end) {
       p = s - tlen1;
       if (str_lower_case_match(enc, case_fold_flag, target, target_end,
-			       p, s + 1))
-	return (UChar* )p;
+                               p, s + 1))
+        return (UChar* )p;
       if (s + 1 >= end) break;
       s += reg->int_map[s[1]];
     }
@@ -4829,7 +4829,7 @@ bm_search_ic(regex_t* reg, const UChar* target, const UChar* target_end,
 #ifdef USE_INT_MAP_BACKWARD
 static int
 set_bm_backward_skip(UChar* s, UChar* end, OnigEncoding enc ARG_UNUSED,
-		     int** skip)
+                     int** skip)
 {
   int i, len;
 
@@ -4850,8 +4850,8 @@ set_bm_backward_skip(UChar* s, UChar* end, OnigEncoding enc ARG_UNUSED,
 
 static UChar*
 bm_search_backward(regex_t* reg, const UChar* target, const UChar* target_end,
-		   const UChar* text, const UChar* adjust_text,
-		   const UChar* text_end, const UChar* text_start)
+                   const UChar* text, const UChar* adjust_text,
+                   const UChar* text_end, const UChar* text_start)
 {
   const UChar *s, *t, *p;
 
@@ -4880,7 +4880,7 @@ bm_search_backward(regex_t* reg, const UChar* target, const UChar* target_end,
 
 static UChar*
 map_search(OnigEncoding enc, UChar map[],
-	   const UChar* text, const UChar* text_range, const UChar* text_end)
+           const UChar* text, const UChar* text_range, const UChar* text_end)
 {
   const UChar *s = text;
 
@@ -4894,8 +4894,8 @@ map_search(OnigEncoding enc, UChar map[],
 
 static UChar*
 map_search_backward(OnigEncoding enc, UChar map[],
-		    const UChar* text, const UChar* adjust_text,
-		    const UChar* text_start, const UChar* text_end)
+                    const UChar* text, const UChar* adjust_text,
+                    const UChar* text_start, const UChar* text_end)
 {
   const UChar *s = text_start;
 
@@ -4909,7 +4909,7 @@ map_search_backward(OnigEncoding enc, UChar map[],
 
 extern OnigPosition
 onig_match(regex_t* reg, const UChar* str, const UChar* end, const UChar* at, OnigRegion* region,
-	    OnigOptionType option)
+            OnigOptionType option)
 {
   ptrdiff_t r;
   UChar *prev;
@@ -4933,9 +4933,9 @@ onig_match(regex_t* reg, const UChar* str, const UChar* end, const UChar* at, On
     prev = (UChar* )onigenc_get_prev_char_head(reg->enc, str, at, end);
     r = match_at(reg, str, end,
 #ifdef USE_MATCH_RANGE_MUST_BE_INSIDE_OF_SPECIFIED_RANGE
-		 end,
+                 end,
 #endif
-		 at, prev, &msa);
+                 at, prev, &msa);
   }
 
   MATCH_ARG_FREE(msa);
@@ -4944,14 +4944,14 @@ onig_match(regex_t* reg, const UChar* str, const UChar* end, const UChar* at, On
 
 static int
 forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
-		     UChar* range, UChar** low, UChar** high, UChar** low_prev)
+                     UChar* range, UChar** low, UChar** high, UChar** low_prev)
 {
   UChar *p, *pprev = (UChar* )NULL;
   size_t input_len = end - str;
 
 #ifdef ONIG_DEBUG_SEARCH
   fprintf(stderr, "forward_search_range: str: %"PRIuPTR" (%p), end: %"PRIuPTR" (%p), s: %"PRIuPTR" (%p), range: %"PRIuPTR" (%p)\n",
-	  (uintptr_t )str, str, (uintptr_t )end, end, (uintptr_t )s, s, (uintptr_t )range, range);
+          (uintptr_t )str, str, (uintptr_t )end, end, (uintptr_t )s, s, (uintptr_t )range, range);
 #endif
 
   if (reg->dmin > input_len) {
@@ -4978,7 +4978,7 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
     break;
   case ONIG_OPTIMIZE_EXACT_IC:
     p = slow_search_ic(reg->enc, reg->case_fold_flag,
-		       reg->exact, reg->exact_end, p, end, range);
+                       reg->exact, reg->exact_end, p, end, range);
     break;
 
   case ONIG_OPTIMIZE_EXACT_BM:
@@ -5015,62 +5015,62 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
 
       switch (reg->sub_anchor) {
       case ANCHOR_BEGIN_LINE:
-	if (!ON_STR_BEGIN(p)) {
-	  prev = onigenc_get_prev_char_head(reg->enc,
-					    (pprev ? pprev : str), p, end);
-	  if (!ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, prev, str, end, reg->options, 0))
-	    goto retry_gate;
-	}
-	break;
+        if (!ON_STR_BEGIN(p)) {
+          prev = onigenc_get_prev_char_head(reg->enc,
+                                            (pprev ? pprev : str), p, end);
+          if (!ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, prev, str, end, reg->options, 0))
+            goto retry_gate;
+        }
+        break;
 
       case ANCHOR_END_LINE:
-	if (ON_STR_END(p)) {
+        if (ON_STR_END(p)) {
 #ifndef USE_NEWLINE_AT_END_OF_STRING_HAS_EMPTY_LINE
-	  prev = (UChar* )onigenc_get_prev_char_head(reg->enc,
-					    (pprev ? pprev : str), p);
-	  if (prev && ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, prev, str, end, reg->options, 1))
-	    goto retry_gate;
+          prev = (UChar* )onigenc_get_prev_char_head(reg->enc,
+                                            (pprev ? pprev : str), p);
+          if (prev && ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, prev, str, end, reg->options, 1))
+            goto retry_gate;
 #endif
-	}
-	else if (! ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, p, str, end, reg->options, 1))
-	  goto retry_gate;
-	break;
+        }
+        else if (! ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, p, str, end, reg->options, 1))
+          goto retry_gate;
+        break;
       }
     }
 
     if (reg->dmax == 0) {
       *low = p;
       if (low_prev) {
-	if (*low > s)
-	  *low_prev = onigenc_get_prev_char_head(reg->enc, s, p, end);
-	else
-	  *low_prev = onigenc_get_prev_char_head(reg->enc,
-						 (pprev ? pprev : str), p, end);
+        if (*low > s)
+          *low_prev = onigenc_get_prev_char_head(reg->enc, s, p, end);
+        else
+          *low_prev = onigenc_get_prev_char_head(reg->enc,
+                                                 (pprev ? pprev : str), p, end);
       }
       *high = p;
     }
     else {
       if (reg->dmax != ONIG_INFINITE_DISTANCE) {
-	if ((OnigDistance)(p - str) < reg->dmax) {
-	  *low = (UChar* )str;
-	  if (low_prev)
-	    *low_prev = onigenc_get_prev_char_head(reg->enc, str, *low, end);
-	}
-	else {
-	  *low = p - reg->dmax;
-	  if (*low > s) {
-	    *low = onigenc_get_right_adjust_char_head_with_prev(reg->enc, s,
-								*low, end, (const UChar** )low_prev);
-	    if (low_prev && IS_NULL(*low_prev))
-	      *low_prev = onigenc_get_prev_char_head(reg->enc,
-						     (pprev ? pprev : s), *low, end);
-	  }
-	  else {
-	    if (low_prev)
-	      *low_prev = onigenc_get_prev_char_head(reg->enc,
-						 (pprev ? pprev : str), *low, end);
-	  }
-	}
+        if ((OnigDistance)(p - str) < reg->dmax) {
+          *low = (UChar* )str;
+          if (low_prev)
+            *low_prev = onigenc_get_prev_char_head(reg->enc, str, *low, end);
+        }
+        else {
+          *low = p - reg->dmax;
+          if (*low > s) {
+            *low = onigenc_get_right_adjust_char_head_with_prev(reg->enc, s,
+                                                                *low, end, (const UChar** )low_prev);
+            if (low_prev && IS_NULL(*low_prev))
+              *low_prev = onigenc_get_prev_char_head(reg->enc,
+                                                     (pprev ? pprev : s), *low, end);
+          }
+          else {
+            if (low_prev)
+              *low_prev = onigenc_get_prev_char_head(reg->enc,
+                                                 (pprev ? pprev : str), *low, end);
+          }
+        }
       }
       /* no needs to adjust *high, *high is used as range check only */
       if ((OnigDistance)(p - str) < reg->dmin)
@@ -5082,7 +5082,7 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
 #ifdef ONIG_DEBUG_SEARCH
     fprintf(stderr,
     "forward_search_range success: low: %"PRIdPTR", high: %"PRIdPTR", dmin: %"PRIdPTR", dmax: %"PRIdPTR"\n",
-	    *low - str, *high - str, reg->dmin, reg->dmax);
+            *low - str, *high - str, reg->dmin, reg->dmax);
 #endif
     return 1; /* success */
   }
@@ -5094,8 +5094,8 @@ forward_search_range(regex_t* reg, const UChar* str, const UChar* end, UChar* s,
 
 static int
 backward_search_range(regex_t* reg, const UChar* str, const UChar* end,
-		      UChar* s, const UChar* range, UChar* adjrange,
-		      UChar** low, UChar** high)
+                      UChar* s, const UChar* range, UChar* adjrange,
+                      UChar** low, UChar** high)
 {
   UChar *p;
   size_t input_len = end - str;
@@ -5111,15 +5111,15 @@ backward_search_range(regex_t* reg, const UChar* str, const UChar* end,
   case ONIG_OPTIMIZE_EXACT:
   exact_method:
     p = slow_search_backward(reg->enc, reg->exact, reg->exact_end,
-			     range, adjrange, end, p);
+                             range, adjrange, end, p);
     break;
 
   case ONIG_OPTIMIZE_EXACT_IC:
   case ONIG_OPTIMIZE_EXACT_BM_IC:
   case ONIG_OPTIMIZE_EXACT_BM_NOT_REV_IC:
     p = slow_search_backward_ic(reg->enc, reg->case_fold_flag,
-				reg->exact, reg->exact_end,
-				range, adjrange, end, p);
+                                reg->exact, reg->exact_end,
+                                range, adjrange, end, p);
     break;
 
   case ONIG_OPTIMIZE_EXACT_BM:
@@ -5128,14 +5128,14 @@ backward_search_range(regex_t* reg, const UChar* str, const UChar* end,
     if (IS_NULL(reg->int_map_backward)) {
       int r;
       if (s - range < BM_BACKWARD_SEARCH_LENGTH_THRESHOLD)
-	goto exact_method;
+        goto exact_method;
 
       r = set_bm_backward_skip(reg->exact, reg->exact_end, reg->enc,
-			       &(reg->int_map_backward));
+                               &(reg->int_map_backward));
       if (r) return r;
     }
     p = bm_search_backward(reg, reg->exact, reg->exact_end, range, adjrange,
-			   end, p);
+                           end, p);
 #else
     goto exact_method;
 #endif
@@ -5152,49 +5152,49 @@ backward_search_range(regex_t* reg, const UChar* str, const UChar* end,
 
       switch (reg->sub_anchor) {
       case ANCHOR_BEGIN_LINE:
-	if (!ON_STR_BEGIN(p)) {
-	  prev = onigenc_get_prev_char_head(reg->enc, str, p, end);
-	  if (!ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, prev, str, end, reg->options, 0)) {
-	    p = prev;
-	    goto retry;
-	  }
-	}
-	break;
+        if (!ON_STR_BEGIN(p)) {
+          prev = onigenc_get_prev_char_head(reg->enc, str, p, end);
+          if (!ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, prev, str, end, reg->options, 0)) {
+            p = prev;
+            goto retry;
+          }
+        }
+        break;
 
       case ANCHOR_END_LINE:
-	if (ON_STR_END(p)) {
+        if (ON_STR_END(p)) {
 #ifndef USE_NEWLINE_AT_END_OF_STRING_HAS_EMPTY_LINE
-	  prev = onigenc_get_prev_char_head(reg->enc, adjrange, p);
-	  if (IS_NULL(prev)) goto fail;
-	  if (ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, prev, str, end, reg->options, 1)) {
-	    p = prev;
-	    goto retry;
-	  }
+          prev = onigenc_get_prev_char_head(reg->enc, adjrange, p);
+          if (IS_NULL(prev)) goto fail;
+          if (ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, prev, str, end, reg->options, 1)) {
+            p = prev;
+            goto retry;
+          }
 #endif
-	}
-	else if (! ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, p, str, end, reg->options, 1)) {
-	  p = onigenc_get_prev_char_head(reg->enc, adjrange, p, end);
-	  if (IS_NULL(p)) goto fail;
-	  goto retry;
-	}
-	break;
+        }
+        else if (! ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, p, str, end, reg->options, 1)) {
+          p = onigenc_get_prev_char_head(reg->enc, adjrange, p, end);
+          if (IS_NULL(p)) goto fail;
+          goto retry;
+        }
+        break;
       }
     }
 
     if (reg->dmax != ONIG_INFINITE_DISTANCE) {
       if ((OnigDistance)(p - str) < reg->dmax)
-	*low = (UChar* )str;
+        *low = (UChar* )str;
       else
-	*low = p - reg->dmax;
+        *low = p - reg->dmax;
 
       if (reg->dmin != 0) {
-	if ((OnigDistance)(p - str) < reg->dmin)
-	  *high = (UChar* )str;
-	else
-	  *high = p - reg->dmin;
+        if ((OnigDistance)(p - str) < reg->dmin)
+          *high = (UChar* )str;
+        else
+          *high = p - reg->dmin;
       }
       else {
-	*high = p;
+        *high = p;
       }
 
       *high = onigenc_get_right_adjust_char_head(reg->enc, adjrange, *high, end);
@@ -5202,7 +5202,7 @@ backward_search_range(regex_t* reg, const UChar* str, const UChar* end,
 
 #ifdef ONIG_DEBUG_SEARCH
     fprintf(stderr, "backward_search_range: low: %d, high: %d\n",
-	    (int )(*low - str), (int )(*high - str));
+            (int )(*low - str), (int )(*high - str));
 #endif
     return 1; /* success */
   }
@@ -5217,15 +5217,15 @@ backward_search_range(regex_t* reg, const UChar* str, const UChar* end,
 
 extern OnigPosition
 onig_search(regex_t* reg, const UChar* str, const UChar* end,
-	    const UChar* start, const UChar* range, OnigRegion* region, OnigOptionType option)
+            const UChar* start, const UChar* range, OnigRegion* region, OnigOptionType option)
 {
   return onig_search_gpos(reg, str, end, start, start, range, region, option);
 }
 
 extern OnigPosition
 onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
-	    const UChar* global_pos,
-	    const UChar* start, const UChar* range, OnigRegion* region, OnigOptionType option)
+            const UChar* global_pos,
+            const UChar* start, const UChar* range, OnigRegion* region, OnigOptionType option)
 {
   ptrdiff_t r;
   UChar *s, *prev;
@@ -5325,30 +5325,30 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
     begin_position:
       if (range > start)
       {
-	if (global_pos > start)
-	{
-	  if (global_pos < range)
-	    range = global_pos + 1;
-	}
-	else
-	  range = start + 1;
+        if (global_pos > start)
+        {
+          if (global_pos < range)
+            range = global_pos + 1;
+        }
+        else
+          range = start + 1;
       }
       else
-	range = start;
+        range = start;
     }
     else if (reg->anchor & ANCHOR_BEGIN_BUF) {
       /* search str-position only */
       if (range > start) {
-	if (start != str) goto mismatch_no_msa;
-	range = str + 1;
+        if (start != str) goto mismatch_no_msa;
+        range = str + 1;
       }
       else {
-	if (range <= str) {
-	  start = str;
-	  range = str;
-	}
-	else
-	  goto mismatch_no_msa;
+        if (range <= str) {
+          start = str;
+          range = str;
+        }
+        else
+          goto mismatch_no_msa;
       }
     }
     else if (reg->anchor & ANCHOR_END_BUF) {
@@ -5356,38 +5356,38 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
 
     end_buf:
       if ((OnigDistance)(max_semi_end - str) < reg->anchor_dmin)
-	goto mismatch_no_msa;
+        goto mismatch_no_msa;
 
       if (range > start) {
-	if ((OnigDistance)(min_semi_end - start) > reg->anchor_dmax) {
-	  start = min_semi_end - reg->anchor_dmax;
-	  if (start < end)
-	    start = onigenc_get_right_adjust_char_head(reg->enc, str, start, end);
-	}
-	if ((OnigDistance)(max_semi_end - (range - 1)) < reg->anchor_dmin) {
-	  if ((OnigDistance)(max_semi_end - str + 1) < reg->anchor_dmin)
-	    goto mismatch_no_msa;
-	  else
-	    range = max_semi_end - reg->anchor_dmin + 1;
-	}
+        if ((OnigDistance)(min_semi_end - start) > reg->anchor_dmax) {
+          start = min_semi_end - reg->anchor_dmax;
+          if (start < end)
+            start = onigenc_get_right_adjust_char_head(reg->enc, str, start, end);
+        }
+        if ((OnigDistance)(max_semi_end - (range - 1)) < reg->anchor_dmin) {
+          if ((OnigDistance)(max_semi_end - str + 1) < reg->anchor_dmin)
+            goto mismatch_no_msa;
+          else
+            range = max_semi_end - reg->anchor_dmin + 1;
+        }
 
-	if (start > range) goto mismatch_no_msa;
-	/* If start == range, match with empty at end.
-	   Backward search is used. */
+        if (start > range) goto mismatch_no_msa;
+        /* If start == range, match with empty at end.
+           Backward search is used. */
       }
       else {
-	if ((OnigDistance)(min_semi_end - range) > reg->anchor_dmax) {
-	  range = min_semi_end - reg->anchor_dmax;
-	}
-	if ((OnigDistance)(max_semi_end - start) < reg->anchor_dmin) {
-	  if ((OnigDistance)(max_semi_end - str) < reg->anchor_dmin)
-	    goto mismatch_no_msa;
-	  else {
-	    start = max_semi_end - reg->anchor_dmin;
-	    start = ONIGENC_LEFT_ADJUST_CHAR_HEAD(reg->enc, str, start, end);
-	  }
-	}
-	if (range > start) goto mismatch_no_msa;
+        if ((OnigDistance)(min_semi_end - range) > reg->anchor_dmax) {
+          range = min_semi_end - reg->anchor_dmax;
+        }
+        if ((OnigDistance)(max_semi_end - start) < reg->anchor_dmin) {
+          if ((OnigDistance)(max_semi_end - str) < reg->anchor_dmin)
+            goto mismatch_no_msa;
+          else {
+            start = max_semi_end - reg->anchor_dmin;
+            start = ONIGENC_LEFT_ADJUST_CHAR_HEAD(reg->enc, str, start, end);
+          }
+        }
+        if (range > start) goto mismatch_no_msa;
       }
     }
     else if (reg->anchor & ANCHOR_SEMI_END_BUF) {
@@ -5395,23 +5395,23 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
 
       max_semi_end = (UChar* )end;
       if (ONIGENC_IS_MBC_NEWLINE(reg->enc, pre_end, end)) {
-	min_semi_end = pre_end;
+        min_semi_end = pre_end;
 
 #ifdef USE_CRNL_AS_LINE_TERMINATOR
-	pre_end = ONIGENC_STEP_BACK(reg->enc, str, pre_end, end, 1);
-	if (IS_NOT_NULL(pre_end) &&
-	    IS_NEWLINE_CRLF(reg->options) &&
-	    ONIGENC_IS_MBC_CRNL(reg->enc, pre_end, end)) {
-	  min_semi_end = pre_end;
-	}
+        pre_end = ONIGENC_STEP_BACK(reg->enc, str, pre_end, end, 1);
+        if (IS_NOT_NULL(pre_end) &&
+            IS_NEWLINE_CRLF(reg->options) &&
+            ONIGENC_IS_MBC_CRNL(reg->enc, pre_end, end)) {
+          min_semi_end = pre_end;
+        }
 #endif
-	if (min_semi_end > str && start <= min_semi_end) {
-	  goto end_buf;
-	}
+        if (min_semi_end > str && start <= min_semi_end) {
+          goto end_buf;
+        }
       }
       else {
-	min_semi_end = (UChar* )end;
-	goto end_buf;
+        min_semi_end = (UChar* )end;
+        goto end_buf;
       }
     }
     else if ((reg->anchor & ANCHOR_ANYCHAR_STAR_ML)) {
@@ -5443,7 +5443,7 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
 
 #ifdef ONIG_DEBUG_SEARCH
   fprintf(stderr, "onig_search(apply anchor): end: %d, start: %d, range: %d\n",
-	  (int )(end - str), (int )(start - str), (int )(range - str));
+          (int )(end - str), (int )(start - str), (int )(range - str));
 #endif
 
   MATCH_ARG_INIT(msa, option, region, start, global_pos);
@@ -5465,58 +5465,58 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
       UChar *sch_range, *low, *high, *low_prev;
 
       if (reg->dmax != 0) {
-	if (reg->dmax == ONIG_INFINITE_DISTANCE)
-	  sch_range = (UChar* )end;
-	else {
-	  if ((OnigDistance)(end - range) < reg->dmax)
-	    sch_range = (UChar* )end;
-	  else {
-	    sch_range = (UChar* )range + reg->dmax;
-	  }
-	}
+        if (reg->dmax == ONIG_INFINITE_DISTANCE)
+          sch_range = (UChar* )end;
+        else {
+          if ((OnigDistance)(end - range) < reg->dmax)
+            sch_range = (UChar* )end;
+          else {
+            sch_range = (UChar* )range + reg->dmax;
+          }
+        }
       }
       else
-	sch_range = (UChar* )range;
+        sch_range = (UChar* )range;
 
       if ((end - start) < reg->threshold_len)
-	goto mismatch;
+        goto mismatch;
 
       if (reg->dmax != ONIG_INFINITE_DISTANCE) {
-	do {
-	  if (! forward_search_range(reg, str, end, s, sch_range,
-				     &low, &high, &low_prev)) goto mismatch;
-	  if (s < low) {
-	    s    = low;
-	    prev = low_prev;
-	  }
-	  while (s <= high) {
-	    MATCH_AND_RETURN_CHECK(orig_range);
-	    prev = s;
-	    s += enclen(reg->enc, s, end);
-	  }
-	} while (s < range);
-	goto mismatch;
+        do {
+          if (! forward_search_range(reg, str, end, s, sch_range,
+                                     &low, &high, &low_prev)) goto mismatch;
+          if (s < low) {
+            s    = low;
+            prev = low_prev;
+          }
+          while (s <= high) {
+            MATCH_AND_RETURN_CHECK(orig_range);
+            prev = s;
+            s += enclen(reg->enc, s, end);
+          }
+        } while (s < range);
+        goto mismatch;
       }
       else { /* check only. */
-	if (! forward_search_range(reg, str, end, s, sch_range,
-				   &low, &high, (UChar** )NULL)) goto mismatch;
+        if (! forward_search_range(reg, str, end, s, sch_range,
+                                   &low, &high, (UChar** )NULL)) goto mismatch;
 
-	if ((reg->anchor & ANCHOR_ANYCHAR_STAR) != 0) {
-	  do {
-	    MATCH_AND_RETURN_CHECK(orig_range);
-	    prev = s;
-	    s += enclen(reg->enc, s, end);
+        if ((reg->anchor & ANCHOR_ANYCHAR_STAR) != 0) {
+          do {
+            MATCH_AND_RETURN_CHECK(orig_range);
+            prev = s;
+            s += enclen(reg->enc, s, end);
 
-	    if ((reg->anchor & (ANCHOR_LOOK_BEHIND | ANCHOR_PREC_READ_NOT)) == 0) {
-	      while (!ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, prev, str, end, reg->options, 0)
-		  && s < range) {
-		prev = s;
-		s += enclen(reg->enc, s, end);
-	      }
-	    }
-	  } while (s < range);
-	  goto mismatch;
-	}
+            if ((reg->anchor & (ANCHOR_LOOK_BEHIND | ANCHOR_PREC_READ_NOT)) == 0) {
+              while (!ONIGENC_IS_MBC_NEWLINE_EX(reg->enc, prev, str, end, reg->options, 0)
+                  && s < range) {
+                prev = s;
+                s += enclen(reg->enc, s, end);
+              }
+            }
+          } while (s < range);
+          goto mismatch;
+        }
       }
     }
 
@@ -5536,58 +5536,58 @@ onig_search_gpos(regex_t* reg, const UChar* str, const UChar* end,
       const UChar *min_range;
 
       if (range < end)
-	adjrange = ONIGENC_LEFT_ADJUST_CHAR_HEAD(reg->enc, str, range, end);
+        adjrange = ONIGENC_LEFT_ADJUST_CHAR_HEAD(reg->enc, str, range, end);
       else
-	adjrange = (UChar* )end;
+        adjrange = (UChar* )end;
 
       if ((OnigDistance)(end - range) > reg->dmin)
-	min_range = range + reg->dmin;
+        min_range = range + reg->dmin;
       else
-	min_range = end;
+        min_range = end;
 
       if (reg->dmax != ONIG_INFINITE_DISTANCE &&
-	  end - range >= reg->threshold_len) {
-	do {
-	  if ((OnigDistance)(end - s) > reg->dmax)
-	    sch_start = s + reg->dmax;
-	  else
-	    sch_start = (UChar* )end;
+          end - range >= reg->threshold_len) {
+        do {
+          if ((OnigDistance)(end - s) > reg->dmax)
+            sch_start = s + reg->dmax;
+          else
+            sch_start = (UChar* )end;
 
-	  if (backward_search_range(reg, str, end, sch_start, min_range, adjrange,
-				    &low, &high) <= 0)
-	    goto mismatch;
+          if (backward_search_range(reg, str, end, sch_start, min_range, adjrange,
+                                    &low, &high) <= 0)
+            goto mismatch;
 
-	  if (s > high)
-	    s = high;
+          if (s > high)
+            s = high;
 
-	  while (s >= low) {
-	    prev = onigenc_get_prev_char_head(reg->enc, str, s, end);
-	    MATCH_AND_RETURN_CHECK(orig_start);
-	    s = prev;
-	  }
-	} while (s >= range);
-	goto mismatch;
+          while (s >= low) {
+            prev = onigenc_get_prev_char_head(reg->enc, str, s, end);
+            MATCH_AND_RETURN_CHECK(orig_start);
+            s = prev;
+          }
+        } while (s >= range);
+        goto mismatch;
       }
       else { /* check only. */
-	if (end - range < reg->threshold_len) goto mismatch;
+        if (end - range < reg->threshold_len) goto mismatch;
 
-	if (reg->dmax != 0) {
-	  if (reg->dmax == ONIG_INFINITE_DISTANCE)
-	    sch_start = (UChar* )end;
-	  else {
-	    if ((OnigDistance)(end - s) > reg->dmax) {
-	      sch_start = s + reg->dmax;
-	      sch_start = ONIGENC_LEFT_ADJUST_CHAR_HEAD(reg->enc,
-						    start, sch_start, end);
-	    } else
-	      sch_start = (UChar* )end;
-	  }
-	}
-	else
-	  sch_start = (UChar* )s;
+        if (reg->dmax != 0) {
+          if (reg->dmax == ONIG_INFINITE_DISTANCE)
+            sch_start = (UChar* )end;
+          else {
+            if ((OnigDistance)(end - s) > reg->dmax) {
+              sch_start = s + reg->dmax;
+              sch_start = ONIGENC_LEFT_ADJUST_CHAR_HEAD(reg->enc,
+                                                    start, sch_start, end);
+            } else
+              sch_start = (UChar* )end;
+          }
+        }
+        else
+          sch_start = (UChar* )s;
 
-	if (backward_search_range(reg, str, end, sch_start, min_range, adjrange,
-				  &low, &high) <= 0) goto mismatch;
+        if (backward_search_range(reg, str, end, sch_start, min_range, adjrange,
+                                  &low, &high) <= 0) goto mismatch;
       }
     }
 
@@ -5644,9 +5644,9 @@ timeout:
 
 extern OnigPosition
 onig_scan(regex_t* reg, const UChar* str, const UChar* end,
-	  OnigRegion* region, OnigOptionType option,
-	  int (*scan_callback)(OnigPosition, OnigPosition, OnigRegion*, void*),
-	  void* callback_arg)
+          OnigRegion* region, OnigOptionType option,
+          int (*scan_callback)(OnigPosition, OnigPosition, OnigRegion*, void*),
+          void* callback_arg)
 {
   OnigPosition r;
   OnigPosition n;
@@ -5661,17 +5661,17 @@ onig_scan(regex_t* reg, const UChar* str, const UChar* end,
       rs = scan_callback(n, r, region, callback_arg);
       n++;
       if (rs != 0)
-	return rs;
+        return rs;
 
       if (region->end[0] == start - str) {
-	if (start >= end) break;
-	start += enclen(reg->enc, start, end);
+        if (start >= end) break;
+        start += enclen(reg->enc, start, end);
       }
       else
-	start = str + region->end[0];
+        start = str + region->end[0];
 
       if (start > end)
-	break;
+        break;
     }
     else if (r == ONIG_MISMATCH) {
       break;

--- a/regparse.c
+++ b/regparse.c
@@ -329,7 +329,7 @@ strdup_with_null(OnigEncoding enc, const UChar* s, const UChar* end)
 
 static UChar*
 strcat_capa(UChar* dest, UChar* dest_end, const UChar* src, const UChar* src_end,
-	      size_t capa)
+              size_t capa)
 {
   UChar* r;
 
@@ -346,7 +346,7 @@ strcat_capa(UChar* dest, UChar* dest_end, const UChar* src, const UChar* src_end
 /* dest on static area */
 static UChar*
 strcat_capa_from_static(UChar* dest, UChar* dest_end,
-			const UChar* src, const UChar* src_end, size_t capa)
+                        const UChar* src, const UChar* src_end, size_t capa)
 {
   UChar* r;
 
@@ -426,7 +426,7 @@ onig_st_init_strend_table_with_size(st_index_t size)
 
 extern int
 onig_st_lookup_strend(hash_table_type* table, const UChar* str_key,
-		      const UChar* end_key, hash_data_type *value)
+                      const UChar* end_key, hash_data_type *value)
 {
   st_str_end_key key;
 
@@ -438,7 +438,7 @@ onig_st_lookup_strend(hash_table_type* table, const UChar* str_key,
 
 extern int
 onig_st_insert_strend(hash_table_type* table, const UChar* str_key,
-		      const UChar* end_key, hash_data_type value)
+                      const UChar* end_key, hash_data_type value)
 {
   st_str_end_key* key;
   int result;
@@ -629,10 +629,10 @@ i_names(HashDataType key_ ARG_UNUSED, HashDataType e_, HashDataType arg_)
   NameEntry* e = (NameEntry *)e_;
   INamesArg* arg = (INamesArg *)arg_;
   int r = (*(arg->func))(e->name,
-			 e->name + e->name_len,
-			 e->back_num,
-			 (e->back_num > 1 ? e->back_refs : &(e->back_ref1)),
-			 arg->reg, arg->arg);
+                         e->name + e->name_len,
+                         e->back_num,
+                         (e->back_num > 1 ? e->back_refs : &(e->back_ref1)),
+                         arg->reg, arg->arg);
   if (r != 0) {
     arg->ret = r;
     return ST_STOP;
@@ -724,16 +724,16 @@ onig_print_names(FILE* fp, regex_t* reg)
       e = &(t->e[i]);
       fprintf(fp, "%s: ", e->name);
       if (e->back_num == 0) {
-	fputs("-", fp);
+        fputs("-", fp);
       }
       else if (e->back_num == 1) {
-	fprintf(fp, "%d", e->back_ref1);
+        fprintf(fp, "%d", e->back_ref1);
       }
       else {
-	for (j = 0; j < e->back_num; j++) {
-	  if (j > 0) fprintf(fp, ", ");
-	  fprintf(fp, "%d", e->back_refs[j]);
-	}
+        for (j = 0; j < e->back_num; j++) {
+          if (j > 0) fprintf(fp, ", ");
+          fprintf(fp, "%d", e->back_refs[j]);
+        }
       }
       fputs("\n", fp);
     }
@@ -754,13 +754,13 @@ names_clear(regex_t* reg)
     for (i = 0; i < t->num; i++) {
       e = &(t->e[i]);
       if (IS_NOT_NULL(e->name)) {
-	xfree(e->name);
-	e->name       = NULL;
-	e->name_len   = 0;
-	e->back_num   = 0;
-	e->back_alloc = 0;
-	xfree(e->back_refs);
-	e->back_refs = (int* )NULL;
+        xfree(e->name);
+        e->name       = NULL;
+        e->name_len   = 0;
+        e->back_num   = 0;
+        e->back_alloc = 0;
+        xfree(e->back_refs);
+        e->back_refs = (int* )NULL;
       }
     }
 
@@ -840,7 +840,7 @@ name_find(regex_t* reg, const UChar* name, const UChar* name_end)
     for (i = 0; i < t->num; i++) {
       e = &(t->e[i]);
       if (len == e->name_len && onig_strncmp(name, e->name, len) == 0)
-	return e;
+        return e;
     }
   }
   return (NameEntry* )NULL;
@@ -858,8 +858,8 @@ onig_foreach_name(regex_t* reg,
     for (i = 0; i < t->num; i++) {
       e = &(t->e[i]);
       r = (*func)(e->name, e->name + e->name_len, e->back_num,
-		  (e->back_num > 1 ? e->back_refs : &(e->back_ref1)),
-		  reg, arg);
+                  (e->back_num > 1 ? e->back_refs : &(e->back_ref1)),
+                  reg, arg);
       if (r != 0) return r;
     }
   }
@@ -948,8 +948,8 @@ name_add(regex_t* reg, UChar* name, UChar* name_end, int backref, ScanEnv* env)
 
       t->e = (NameEntry* )xmalloc(sizeof(NameEntry) * alloc);
       if (IS_NULL(t->e)) {
-	xfree(t);
-	return ONIGERR_MEMORY;
+        xfree(t);
+        return ONIGERR_MEMORY;
       }
       t->alloc = alloc;
       reg->name_table = t;
@@ -967,11 +967,11 @@ name_add(regex_t* reg, UChar* name, UChar* name_end, int backref, ScanEnv* env)
 
     clear:
       for (i = t->num; i < t->alloc; i++) {
-	t->e[i].name       = NULL;
-	t->e[i].name_len   = 0;
-	t->e[i].back_num   = 0;
-	t->e[i].back_alloc = 0;
-	t->e[i].back_refs  = (int* )NULL;
+        t->e[i].name       = NULL;
+        t->e[i].name_len   = 0;
+        t->e[i].back_num   = 0;
+        t->e[i].back_alloc = 0;
+        t->e[i].back_refs  = (int* )NULL;
       }
     }
     e = &(t->e[t->num]);
@@ -985,7 +985,7 @@ name_add(regex_t* reg, UChar* name, UChar* name_end, int backref, ScanEnv* env)
   if (e->back_num >= 1 &&
       ! IS_SYNTAX_BV(env->syntax, ONIG_SYN_ALLOW_MULTIPLEX_DEFINITION_NAME)) {
     onig_scan_env_set_error_string(env, ONIGERR_MULTIPLEX_DEFINED_NAME,
-				    name, name_end);
+                                    name, name_end);
     return ONIGERR_MULTIPLEX_DEFINED_NAME;
   }
 
@@ -1004,12 +1004,12 @@ name_add(regex_t* reg, UChar* name, UChar* name_end, int backref, ScanEnv* env)
     }
     else {
       if (e->back_num > e->back_alloc) {
-	int* p;
-	alloc = e->back_alloc * 2;
-	p = (int* )xrealloc(e->back_refs, sizeof(int) * alloc);
-	CHECK_NULL_RETURN_MEMERR(p);
-	e->back_refs = p;
-	e->back_alloc = alloc;
+        int* p;
+        alloc = e->back_alloc * 2;
+        p = (int* )xrealloc(e->back_refs, sizeof(int) * alloc);
+        CHECK_NULL_RETURN_MEMERR(p);
+        e->back_refs = p;
+        e->back_alloc = alloc;
       }
       e->back_refs[e->back_num - 1] = backref;
     }
@@ -1020,7 +1020,7 @@ name_add(regex_t* reg, UChar* name, UChar* name_end, int backref, ScanEnv* env)
 
 extern int
 onig_name_to_group_numbers(regex_t* reg, const UChar* name,
-			   const UChar* name_end, int** nums)
+                           const UChar* name_end, int** nums)
 {
   NameEntry* e = name_find(reg, name, name_end);
 
@@ -1042,7 +1042,7 @@ onig_name_to_group_numbers(regex_t* reg, const UChar* name,
 
 extern int
 onig_name_to_backref_number(regex_t* reg, const UChar* name,
-			    const UChar* name_end, const OnigRegion *region)
+                            const UChar* name_end, const OnigRegion *region)
 {
   int i, n, *nums;
 
@@ -1056,8 +1056,8 @@ onig_name_to_backref_number(regex_t* reg, const UChar* name,
   else {
     if (IS_NOT_NULL(region)) {
       for (i = n - 1; i >= 0; i--) {
-	if (region->beg[nums[i]] != ONIG_REGION_NOTPOS)
-	  return nums[i];
+        if (region->beg[nums[i]] != ONIG_REGION_NOTPOS)
+          return nums[i];
       }
     }
     return nums[n - 1];
@@ -1068,14 +1068,14 @@ onig_name_to_backref_number(regex_t* reg, const UChar* name,
 
 extern int
 onig_name_to_group_numbers(regex_t* reg, const UChar* name,
-			   const UChar* name_end, int** nums)
+                           const UChar* name_end, int** nums)
 {
   return ONIG_NO_SUPPORT_CONFIG;
 }
 
 extern int
 onig_name_to_backref_number(regex_t* reg, const UChar* name,
-			    const UChar* name_end, const OnigRegion* region)
+                            const UChar* name_end, const OnigRegion* region)
 {
   return ONIG_NO_SUPPORT_CONFIG;
 }
@@ -1164,20 +1164,20 @@ scan_env_add_mem_entry(ScanEnv* env)
   if (need >= SCANENV_MEMNODES_SIZE) {
     if (env->mem_alloc <= need) {
       if (IS_NULL(env->mem_nodes_dynamic)) {
-	alloc = INIT_SCANENV_MEMNODES_ALLOC_SIZE;
-	p = (Node** )xmalloc(sizeof(Node*) * alloc);
-	CHECK_NULL_RETURN_MEMERR(p);
-	xmemcpy(p, env->mem_nodes_static,
-		sizeof(Node*) * SCANENV_MEMNODES_SIZE);
+        alloc = INIT_SCANENV_MEMNODES_ALLOC_SIZE;
+        p = (Node** )xmalloc(sizeof(Node*) * alloc);
+        CHECK_NULL_RETURN_MEMERR(p);
+        xmemcpy(p, env->mem_nodes_static,
+                sizeof(Node*) * SCANENV_MEMNODES_SIZE);
       }
       else {
-	alloc = env->mem_alloc * 2;
-	p = (Node** )xrealloc(env->mem_nodes_dynamic, sizeof(Node*) * alloc);
-	CHECK_NULL_RETURN_MEMERR(p);
+        alloc = env->mem_alloc * 2;
+        p = (Node** )xrealloc(env->mem_nodes_dynamic, sizeof(Node*) * alloc);
+        CHECK_NULL_RETURN_MEMERR(p);
       }
 
       for (i = env->num_mem + 1; i < alloc; i++)
-	p[i] = NULL_NODE;
+        p[i] = NULL_NODE;
 
       env->mem_nodes_dynamic = p;
       env->mem_alloc = alloc;
@@ -1208,7 +1208,7 @@ onig_node_free(Node* node)
   switch (NTYPE(node)) {
   case NT_STR:
     if (NSTR(node)->capa != 0 &&
-	IS_NOT_NULL(NSTR(node)->s) && NSTR(node)->s != NSTR(node)->buf) {
+        IS_NOT_NULL(NSTR(node)->s) && NSTR(node)->s != NSTR(node)->buf) {
       xfree(NSTR(node)->s);
     }
     break;
@@ -1371,9 +1371,9 @@ onig_node_new_anchor(int type)
 static Node*
 node_new_backref(int back_num, int* backrefs, int by_name,
 #ifdef USE_BACKREF_WITH_LEVEL
-		 int exist_level, int nest_level,
+                 int exist_level, int nest_level,
 #endif
-		 ScanEnv* env)
+                 ScanEnv* env)
 {
   int i;
   Node* node = node_new();
@@ -1396,7 +1396,7 @@ node_new_backref(int back_num, int* backrefs, int by_name,
 
   for (i = 0; i < back_num; i++) {
     if (backrefs[i] <= env->num_mem &&
-	IS_NULL(SCANENV_MEM_NODES(env)[backrefs[i]])) {
+        IS_NULL(SCANENV_MEM_NODES(env)[backrefs[i]])) {
       NBREF(node)->state |= NST_RECURSION;   /* /...(\1).../ */
       break;
     }
@@ -1521,18 +1521,18 @@ onig_node_str_cat(Node* node, const UChar* s, const UChar* end)
       ptrdiff_t capa = len + addlen + NODE_STR_MARGIN;
 
       if (capa <= NSTR(node)->capa) {
-	onig_strcpy(NSTR(node)->s + len, s, end);
+        onig_strcpy(NSTR(node)->s + len, s, end);
       }
       else {
-	if (NSTR(node)->s == NSTR(node)->buf)
-	  p = strcat_capa_from_static(NSTR(node)->s, NSTR(node)->end,
-				      s, end, capa);
-	else
-	  p = strcat_capa(NSTR(node)->s, NSTR(node)->end, s, end, capa);
+        if (NSTR(node)->s == NSTR(node)->buf)
+          p = strcat_capa_from_static(NSTR(node)->s, NSTR(node)->end,
+                                      s, end, capa);
+        else
+          p = strcat_capa(NSTR(node)->s, NSTR(node)->end, s, end, capa);
 
-	CHECK_NULL_RETURN_MEMERR(p);
-	NSTR(node)->s    = p;
-	NSTR(node)->capa = (int )capa;
+        CHECK_NULL_RETURN_MEMERR(p);
+        NSTR(node)->s    = p;
+        NSTR(node)->capa = (int )capa;
       }
     }
     else {
@@ -1654,7 +1654,7 @@ str_node_split_last_char(StrNode* sn, OnigEncoding enc)
     if (p && p > sn->s) { /* can be split. */
       n = node_new_str(p, sn->end);
       if (IS_NOT_NULL(n) && (sn->flag & NSTR_RAW) != 0)
-	NSTRING_SET_RAW(n);
+        NSTRING_SET_RAW(n);
       sn->end = (UChar* )p;
     }
   }
@@ -1702,7 +1702,7 @@ onig_scan_unsigned_number(UChar** src, const UChar* end, OnigEncoding enc)
     if (ONIGENC_IS_CODE_DIGIT(enc, c)) {
       val = (unsigned int )DIGITVAL(c);
       if ((INT_MAX_LIMIT - val) / 10UL < num)
-	return -1;  /* overflow */
+        return -1;  /* overflow */
 
       num = num * 10 + val;
     }
@@ -1717,7 +1717,7 @@ onig_scan_unsigned_number(UChar** src, const UChar* end, OnigEncoding enc)
 
 static int
 scan_unsigned_hexadecimal_number(UChar** src, UChar* end, int minlen,
-				 int maxlen, OnigEncoding enc)
+                                 int maxlen, OnigEncoding enc)
 {
   OnigCodePoint c;
   unsigned int num, val;
@@ -1732,7 +1732,7 @@ scan_unsigned_hexadecimal_number(UChar** src, UChar* end, int minlen,
     if (ONIGENC_IS_CODE_XDIGIT(enc, c)) {
       val = (unsigned int )XDIGITVAL(enc,c);
       if ((INT_MAX_LIMIT - val) / 16UL < num)
-	return -1;  /* overflow */
+        return -1;  /* overflow */
 
       num = (num << 4) + XDIGITVAL(enc,c);
     }
@@ -1750,7 +1750,7 @@ scan_unsigned_hexadecimal_number(UChar** src, UChar* end, int minlen,
 
 static int
 scan_unsigned_octal_number(UChar** src, UChar* end, int maxlen,
-			   OnigEncoding enc)
+                           OnigEncoding enc)
 {
   OnigCodePoint c;
   unsigned int num, val;
@@ -1763,7 +1763,7 @@ scan_unsigned_octal_number(UChar** src, UChar* end, int maxlen,
     if (ONIGENC_IS_CODE_DIGIT(enc, c) && c < '8') {
       val = ODIGITVAL(c);
       if ((INT_MAX_LIMIT - val) / 8UL < num)
-	return -1;  /* overflow */
+        return -1;  /* overflow */
 
       num = (num << 3) + val;
     }
@@ -1804,7 +1804,7 @@ new_code_range(BBuf** pbuf)
 
 static int
 add_code_range_to_buf0(BBuf** pbuf, ScanEnv* env, OnigCodePoint from, OnigCodePoint to,
-	int checkdup)
+        int checkdup)
 {
   int r, inc_n, pos;
   OnigCodePoint low, high, bound, x;
@@ -1855,7 +1855,7 @@ add_code_range_to_buf0(BBuf** pbuf, ScanEnv* env, OnigCodePoint from, OnigCodePo
 
   if (inc_n != 1) {
     if (checkdup && from <= data[low*2+1]
-	&& (data[low*2] <= from || data[low*2+1] <= to))
+        && (data[low*2] <= from || data[low*2+1] <= to))
       CC_DUP_WARN(env, from, to);
     if (from > data[low*2])
       from = data[low*2];
@@ -1869,8 +1869,8 @@ add_code_range_to_buf0(BBuf** pbuf, ScanEnv* env, OnigCodePoint from, OnigCodePo
 
     if (inc_n > 0) {
       if (high < n) {
-	int size = (n - high) * 2 * SIZE_CODE_POINT;
-	BBUF_MOVE_RIGHT(bbuf, from_pos, to_pos, size);
+        int size = (n - high) * 2 * SIZE_CODE_POINT;
+        BBUF_MOVE_RIGHT(bbuf, from_pos, to_pos, size);
       }
     }
     else {
@@ -1980,10 +1980,10 @@ or_code_range_buf(OnigEncoding enc, BBuf* bbuf1, int not1,
     }
     else {
       if (not2 == 0) {
-	return bbuf_clone(pbuf, bbuf2);
+        return bbuf_clone(pbuf, bbuf2);
       }
       else {
-	return not_code_range_buf(enc, bbuf2, pbuf, env);
+        return not_code_range_buf(enc, bbuf2, pbuf, env);
       }
     }
   }
@@ -2014,7 +2014,7 @@ or_code_range_buf(OnigEncoding enc, BBuf* bbuf1, int not1,
 
 static int
 and_code_range1(BBuf** pbuf, ScanEnv* env, OnigCodePoint from1, OnigCodePoint to1,
-		OnigCodePoint* data, int n)
+                OnigCodePoint* data, int n)
 {
   int i, r;
   OnigCodePoint from2, to2;
@@ -2025,19 +2025,19 @@ and_code_range1(BBuf** pbuf, ScanEnv* env, OnigCodePoint from1, OnigCodePoint to
     if (from2 < from1) {
       if (to2 < from1) continue;
       else {
-	from1 = to2 + 1;
+        from1 = to2 + 1;
       }
     }
     else if (from2 <= to1) {
       if (to2 < to1) {
-	if (from1 <= from2 - 1) {
-	  r = add_code_range_to_buf(pbuf, env, from1, from2-1);
-	  if (r != 0) return r;
-	}
-	from1 = to2 + 1;
+        if (from1 <= from2 - 1) {
+          r = add_code_range_to_buf(pbuf, env, from1, from2-1);
+          if (r != 0) return r;
+        }
+        from1 = to2 + 1;
       }
       else {
-	to1 = from2 - 1;
+        to1 = from2 - 1;
       }
     }
     else {
@@ -2086,14 +2086,14 @@ and_code_range_buf(BBuf* bbuf1, int not1, BBuf* bbuf2, int not2, BBuf** pbuf, Sc
       from1 = data1[i*2];
       to1   = data1[i*2+1];
       for (j = 0; j < n2; j++) {
-	from2 = data2[j*2];
-	to2   = data2[j*2+1];
-	if (from2 > to1) break;
-	if (to2 < from1) continue;
-	from = MAX(from1, from2);
-	to   = MIN(to1, to2);
-	r = add_code_range_to_buf(pbuf, env, from, to);
-	if (r != 0) return r;
+        from2 = data2[j*2];
+        to2   = data2[j*2+1];
+        if (from2 > to1) break;
+        if (to2 < from1) continue;
+        from = MAX(from1, from2);
+        to   = MIN(to1, to2);
+        r = add_code_range_to_buf(pbuf, env, from, to);
+        if (r != 0) return r;
       }
     }
   }
@@ -2149,10 +2149,10 @@ and_cclass(CClassNode* dest, CClassNode* cc, ScanEnv* env)
     else {
       r = and_code_range_buf(buf1, not1, buf2, not2, &pbuf, env);
       if (r == 0 && not1 != 0) {
-	BBuf *tbuf = 0;
-	r = not_code_range_buf(enc, pbuf, &tbuf, env);
-	bbuf_free(pbuf);
-	pbuf = tbuf;
+        BBuf *tbuf = 0;
+        r = not_code_range_buf(enc, pbuf, &tbuf, env);
+        bbuf_free(pbuf);
+        pbuf = tbuf;
       }
     }
     if (r != 0) {
@@ -2207,10 +2207,10 @@ or_cclass(CClassNode* dest, CClassNode* cc, ScanEnv* env)
     else {
       r = or_code_range_buf(enc, buf1, not1, buf2, not2, &pbuf, env);
       if (r == 0 && not1 != 0) {
-	BBuf *tbuf = 0;
-	r = not_code_range_buf(enc, pbuf, &tbuf, env);
-	bbuf_free(pbuf);
-	pbuf = tbuf;
+        BBuf *tbuf = 0;
+        r = not_code_range_buf(enc, pbuf, &tbuf, env);
+        bbuf_free(pbuf);
+        pbuf = tbuf;
       }
     }
     if (r != 0) {
@@ -2242,12 +2242,12 @@ conv_backslash_value(OnigCodePoint c, ScanEnv* env)
     case 'e': return '\033';
     case 'v':
       if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_ESC_V_VTAB))
-	return '\v';
+        return '\v';
       break;
 
     default:
       if (('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z'))
-	  UNKNOWN_ESC_WARN(env, c);
+          UNKNOWN_ESC_WARN(env, c);
       break;
     }
   }
@@ -2506,7 +2506,7 @@ fetch_range_quantifier(UChar** src, UChar* end, OnigToken* tok, ScanEnv* env)
 
     if (p == prev) {
       if (non_low != 0)
-	goto invalid;
+        goto invalid;
       up = REPEAT_INFINITE;  /* {n,} : {n,infinite} */
     }
   }
@@ -2566,8 +2566,8 @@ fetch_escaped_value(UChar** src, UChar* end, ScanEnv* env, OnigCodePoint* val)
       if (PEND) return ONIGERR_END_PATTERN_AT_META;
       PFETCH_S(c);
       if (c == MC_ESC(env->syntax)) {
-	v = fetch_escaped_value(&p, end, env, &c);
-	if (v < 0) return v;
+        v = fetch_escaped_value(&p, end, env, &c);
+        if (v < 0) return v;
       }
       c = ((c & 0xff) | 0x80);
     }
@@ -2591,14 +2591,14 @@ fetch_escaped_value(UChar** src, UChar* end, ScanEnv* env, OnigCodePoint* val)
       if (PEND) return ONIGERR_END_PATTERN_AT_CONTROL;
       PFETCH_S(c);
       if (c == '?') {
-	c = 0177;
+        c = 0177;
       }
       else {
-	if (c == MC_ESC(env->syntax)) {
-	  v = fetch_escaped_value(&p, end, env, &c);
-	  if (v < 0) return v;
-	}
-	c &= 0x9f;
+        if (c == MC_ESC(env->syntax)) {
+          v = fetch_escaped_value(&p, end, env, &c);
+          if (v < 0) return v;
+        }
+        c &= 0x9f;
       }
       break;
     }
@@ -2649,8 +2649,8 @@ get_name_end_code_point(OnigCodePoint start)
 */
 static int
 fetch_name_with_level(OnigCodePoint start_code, UChar** src, UChar* end,
-		      UChar** rname_end, ScanEnv* env,
-		      int* rback_num, int* rlevel)
+                      UChar** rname_end, ScanEnv* env,
+                      int* rback_num, int* rlevel)
 {
   int r, sign, is_num, exist_level;
   OnigCodePoint end_code;
@@ -2701,11 +2701,11 @@ fetch_name_with_level(OnigCodePoint start_code, UChar** src, UChar* end,
 
     if (is_num != 0) {
       if (ONIGENC_IS_CODE_DIGIT(enc, c)) {
-	is_num = 1;
+        is_num = 1;
       }
       else {
-	r = ONIGERR_INVALID_GROUP_NAME;
-	is_num = 0;
+        r = ONIGERR_INVALID_GROUP_NAME;
+        is_num = 0;
       }
     }
     else if (!ONIGENC_IS_CODE_NAME(enc, c)) {
@@ -2719,8 +2719,8 @@ fetch_name_with_level(OnigCodePoint start_code, UChar** src, UChar* end,
       int flag = (c == '-' ? -1 : 1);
 
       if (PEND) {
-	r = ONIGERR_INVALID_CHAR_IN_GROUP_NAME;
-	goto end;
+        r = ONIGERR_INVALID_CHAR_IN_GROUP_NAME;
+        goto end;
       }
       PFETCH(c);
       if (! ONIGENC_IS_CODE_DIGIT(enc, c)) goto err;
@@ -2731,9 +2731,9 @@ fetch_name_with_level(OnigCodePoint start_code, UChar** src, UChar* end,
       exist_level = 1;
 
       if (!PEND) {
-	PFETCH(c);
-	if (c == end_code)
-	  goto end;
+        PFETCH(c);
+        if (c == end_code)
+          goto end;
       }
     }
 
@@ -2769,7 +2769,7 @@ fetch_name_with_level(OnigCodePoint start_code, UChar** src, UChar* end,
 */
 static int
 fetch_name(OnigCodePoint start_code, UChar** src, UChar* end,
-	   UChar** rname_end, ScanEnv* env, int* rback_num, int ref)
+           UChar** rname_end, ScanEnv* env, int* rback_num, int ref)
 {
   int r, is_num, sign;
   OnigCodePoint end_code;
@@ -2798,21 +2798,21 @@ fetch_name(OnigCodePoint start_code, UChar** src, UChar* end,
 
     if (ONIGENC_IS_CODE_DIGIT(enc, c)) {
       if (ref == 1)
-	is_num = 1;
+        is_num = 1;
       else {
-	r = ONIGERR_INVALID_GROUP_NAME;
-	is_num = 0;
+        r = ONIGERR_INVALID_GROUP_NAME;
+        is_num = 0;
       }
     }
     else if (c == '-') {
       if (ref == 1) {
-	is_num = 2;
-	sign = -1;
-	pnum_head = p;
+        is_num = 2;
+        sign = -1;
+        pnum_head = p;
       }
       else {
-	r = ONIGERR_INVALID_GROUP_NAME;
-	is_num = 0;
+        r = ONIGERR_INVALID_GROUP_NAME;
+        is_num = 0;
       }
     }
     else if (!ONIGENC_IS_CODE_NAME(enc, c)) {
@@ -2825,30 +2825,30 @@ fetch_name(OnigCodePoint start_code, UChar** src, UChar* end,
       name_end = p;
       PFETCH_S(c);
       if (c == end_code || c == ')') {
-	if (is_num == 2) {
-	  r = ONIGERR_INVALID_GROUP_NAME;
-	  goto teardown;
-	}
-	break;
+        if (is_num == 2) {
+          r = ONIGERR_INVALID_GROUP_NAME;
+          goto teardown;
+        }
+        break;
       }
 
       if (is_num != 0) {
-	if (ONIGENC_IS_CODE_DIGIT(enc, c)) {
-	  is_num = 1;
-	}
-	else {
-	  if (!ONIGENC_IS_CODE_WORD(enc, c))
-	    r = ONIGERR_INVALID_CHAR_IN_GROUP_NAME;
-	  else
-	    r = ONIGERR_INVALID_GROUP_NAME;
-	  goto teardown;
-	}
+        if (ONIGENC_IS_CODE_DIGIT(enc, c)) {
+          is_num = 1;
+        }
+        else {
+          if (!ONIGENC_IS_CODE_WORD(enc, c))
+            r = ONIGERR_INVALID_CHAR_IN_GROUP_NAME;
+          else
+            r = ONIGERR_INVALID_GROUP_NAME;
+          goto teardown;
+        }
       }
       else {
-	if (!ONIGENC_IS_CODE_NAME(enc, c)) {
-	  r = ONIGERR_INVALID_CHAR_IN_GROUP_NAME;
-	  goto teardown;
-	}
+        if (!ONIGENC_IS_CODE_NAME(enc, c)) {
+          r = ONIGERR_INVALID_CHAR_IN_GROUP_NAME;
+          goto teardown;
+        }
       }
     }
 
@@ -2862,8 +2862,8 @@ fetch_name(OnigCodePoint start_code, UChar** src, UChar* end,
       *rback_num = onig_scan_unsigned_number(&pnum_head, name_end, enc);
       if (*rback_num < 0) return ONIGERR_TOO_BIG_NUMBER;
       else if (*rback_num == 0) {
-	r = ONIGERR_INVALID_GROUP_NAME;
-	goto err;
+        r = ONIGERR_INVALID_GROUP_NAME;
+        goto err;
       }
 
       *rback_num *= sign;
@@ -2879,7 +2879,7 @@ teardown:
       name_end = p;
       PFETCH_S(c);
       if (c == end_code || c == ')')
-	break;
+        break;
     }
     if (PEND)
       name_end = end;
@@ -2892,7 +2892,7 @@ teardown:
 #else
 static int
 fetch_name(OnigCodePoint start_code, UChar** src, UChar* end,
-	   UChar** rname_end, ScanEnv* env, int* rback_num, int ref)
+           UChar** rname_end, ScanEnv* env, int* rback_num, int ref)
 {
   int r, is_num, sign;
   OnigCodePoint end_code;
@@ -2980,8 +2980,8 @@ onig_syntax_warn(ScanEnv *env, const char *fmt, ...)
     UChar buf[WARN_BUFSIZE];
     va_start(args, fmt);
     onig_vsnprintf_with_pattern(buf, WARN_BUFSIZE, env->enc,
-		env->pattern, env->pattern_end,
-		fmt, args);
+                env->pattern, env->pattern_end,
+                fmt, args);
     va_end(args);
 #ifdef RUBY
     if (env->sourcefile == NULL)
@@ -3043,7 +3043,7 @@ UNKNOWN_ESC_WARN(ScanEnv *env, int c)
 
 static UChar*
 find_str_position(OnigCodePoint s[], int n, UChar* from, UChar* to,
-		  UChar **next, OnigEncoding enc)
+                  UChar **next, OnigEncoding enc)
 {
   int i;
   OnigCodePoint x;
@@ -3055,14 +3055,14 @@ find_str_position(OnigCodePoint s[], int n, UChar* from, UChar* to,
     q = p + enclen(enc, p, to);
     if (x == s[0]) {
       for (i = 1; i < n && q < to; i++) {
-	x = ONIGENC_MBC_TO_CODE(enc, q, to);
-	if (x != s[i]) break;
-	q += enclen(enc, q, to);
+        x = ONIGENC_MBC_TO_CODE(enc, q, to);
+        if (x != s[i]) break;
+        q += enclen(enc, q, to);
       }
       if (i >= n) {
-	if (IS_NOT_NULL(next))
-	  *next = q;
-	return p;
+        if (IS_NOT_NULL(next))
+          *next = q;
+        return p;
       }
     }
     p = q;
@@ -3072,7 +3072,7 @@ find_str_position(OnigCodePoint s[], int n, UChar* from, UChar* to,
 
 static int
 str_exist_check_with_esc(OnigCodePoint s[], int n, UChar* from, UChar* to,
-		 OnigCodePoint bad, OnigEncoding enc, const OnigSyntaxType* syn)
+                 OnigCodePoint bad, OnigEncoding enc, const OnigSyntaxType* syn)
 {
   int i, in_esc;
   OnigCodePoint x;
@@ -3089,19 +3089,19 @@ str_exist_check_with_esc(OnigCodePoint s[], int n, UChar* from, UChar* to,
       x = ONIGENC_MBC_TO_CODE(enc, p, to);
       q = p + enclen(enc, p, to);
       if (x == s[0]) {
-	for (i = 1; i < n && q < to; i++) {
-	  x = ONIGENC_MBC_TO_CODE(enc, q, to);
-	  if (x != s[i]) break;
-	  q += enclen(enc, q, to);
-	}
-	if (i >= n) return 1;
-	p += enclen(enc, p, to);
+        for (i = 1; i < n && q < to; i++) {
+          x = ONIGENC_MBC_TO_CODE(enc, q, to);
+          if (x != s[i]) break;
+          q += enclen(enc, q, to);
+        }
+        if (i >= n) return 1;
+        p += enclen(enc, p, to);
       }
       else {
-	x = ONIGENC_MBC_TO_CODE(enc, p, to);
-	if (x == bad) return 0;
-	else if (x == MC_ESC(syn)) in_esc = 1;
-	p = q;
+        x = ONIGENC_MBC_TO_CODE(enc, p, to);
+        if (x == bad) return 0;
+        else if (x == MC_ESC(syn)) in_esc = 1;
+        p = q;
       }
     }
   }
@@ -3195,22 +3195,22 @@ fetch_token_in_cc(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 
       c2 = PPEEK;
       if (c2 == '{' &&
-	  IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_P_BRACE_CHAR_PROPERTY)) {
-	PINC;
-	tok->type = TK_CHAR_PROPERTY;
-	tok->u.prop.not = (c == 'P' ? 1 : 0);
+          IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_P_BRACE_CHAR_PROPERTY)) {
+        PINC;
+        tok->type = TK_CHAR_PROPERTY;
+        tok->u.prop.not = (c == 'P' ? 1 : 0);
 
-	if (!PEND && IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_P_BRACE_CIRCUMFLEX_NOT)) {
-	  PFETCH(c2);
-	  if (c2 == '^') {
-	    tok->u.prop.not = (tok->u.prop.not == 0 ? 1 : 0);
-	  }
-	  else
-	    PUNFETCH;
-	}
+        if (!PEND && IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_P_BRACE_CIRCUMFLEX_NOT)) {
+          PFETCH(c2);
+          if (c2 == '^') {
+            tok->u.prop.not = (tok->u.prop.not == 0 ? 1 : 0);
+          }
+          else
+            PUNFETCH;
+        }
       }
       else {
-	onig_syntax_warn(env, "invalid Unicode Property \\%c", c);
+        onig_syntax_warn(env, "invalid Unicode Property \\%c", c);
       }
       break;
 
@@ -3219,35 +3219,35 @@ fetch_token_in_cc(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 
       prev = p;
       if (PPEEK_IS('{') && IS_SYNTAX_OP(syn, ONIG_SYN_OP_ESC_X_BRACE_HEX8)) {
-	PINC;
-	num = scan_unsigned_hexadecimal_number(&p, end, 0, 8, enc);
-	if (num < 0) return ONIGERR_TOO_BIG_WIDE_CHAR_VALUE;
-	if (!PEND) {
-	  c2 = PPEEK;
-	  if (ONIGENC_IS_CODE_XDIGIT(enc, c2))
-	    return ONIGERR_TOO_LONG_WIDE_CHAR_VALUE;
-	}
+        PINC;
+        num = scan_unsigned_hexadecimal_number(&p, end, 0, 8, enc);
+        if (num < 0) return ONIGERR_TOO_BIG_WIDE_CHAR_VALUE;
+        if (!PEND) {
+          c2 = PPEEK;
+          if (ONIGENC_IS_CODE_XDIGIT(enc, c2))
+            return ONIGERR_TOO_LONG_WIDE_CHAR_VALUE;
+        }
 
-	if (p > prev + enclen(enc, prev, end) && !PEND && (PPEEK_IS('}'))) {
-	  PINC;
-	  tok->type   = TK_CODE_POINT;
-	  tok->base   = 16;
-	  tok->u.code = (OnigCodePoint )num;
-	}
-	else {
-	  /* can't read nothing or invalid format */
-	  p = prev;
-	}
+        if (p > prev + enclen(enc, prev, end) && !PEND && (PPEEK_IS('}'))) {
+          PINC;
+          tok->type   = TK_CODE_POINT;
+          tok->base   = 16;
+          tok->u.code = (OnigCodePoint )num;
+        }
+        else {
+          /* can't read nothing or invalid format */
+          p = prev;
+        }
       }
       else if (IS_SYNTAX_OP(syn, ONIG_SYN_OP_ESC_X_HEX2)) {
-	num = scan_unsigned_hexadecimal_number(&p, end, 0, 2, enc);
-	if (num < 0) return ONIGERR_TOO_BIG_NUMBER;
-	if (p == prev) {  /* can't read nothing. */
-	  num = 0; /* but, it's not error */
-	}
-	tok->type = TK_RAW_BYTE;
-	tok->base = 16;
-	tok->u.c  = num;
+        num = scan_unsigned_hexadecimal_number(&p, end, 0, 2, enc);
+        if (num < 0) return ONIGERR_TOO_BIG_NUMBER;
+        if (p == prev) {  /* can't read nothing. */
+          num = 0; /* but, it's not error */
+        }
+        tok->type = TK_RAW_BYTE;
+        tok->base = 16;
+        tok->u.c  = num;
       }
       break;
 
@@ -3256,15 +3256,15 @@ fetch_token_in_cc(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 
       prev = p;
       if (IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_U_HEX4)) {
-	num = scan_unsigned_hexadecimal_number(&p, end, 4, 4, enc);
-	if (num < -1) return ONIGERR_TOO_SHORT_DIGITS;
-	else if (num < 0) return ONIGERR_TOO_BIG_NUMBER;
-	if (p == prev) {  /* can't read nothing. */
-	  num = 0; /* but, it's not error */
-	}
-	tok->type   = TK_CODE_POINT;
-	tok->base   = 16;
-	tok->u.code = (OnigCodePoint )num;
+        num = scan_unsigned_hexadecimal_number(&p, end, 4, 4, enc);
+        if (num < -1) return ONIGERR_TOO_SHORT_DIGITS;
+        else if (num < 0) return ONIGERR_TOO_BIG_NUMBER;
+        if (p == prev) {  /* can't read nothing. */
+          num = 0; /* but, it's not error */
+        }
+        tok->type   = TK_CODE_POINT;
+        tok->base   = 16;
+        tok->u.code = (OnigCodePoint )num;
       }
       break;
 
@@ -3273,41 +3273,41 @@ fetch_token_in_cc(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 
       prev = p;
       if (PPEEK_IS('{') && IS_SYNTAX_OP(syn, ONIG_SYN_OP_ESC_O_BRACE_OCTAL)) {
-	PINC;
-	num = scan_unsigned_octal_number(&p, end, 11, enc);
-	if (num < 0) return ONIGERR_TOO_BIG_WIDE_CHAR_VALUE;
-	if (!PEND) {
-	  c2 = PPEEK;
-	  if (ONIGENC_IS_CODE_DIGIT(enc, c2) && c2 < '8')
-	    return ONIGERR_TOO_LONG_WIDE_CHAR_VALUE;
-	}
+        PINC;
+        num = scan_unsigned_octal_number(&p, end, 11, enc);
+        if (num < 0) return ONIGERR_TOO_BIG_WIDE_CHAR_VALUE;
+        if (!PEND) {
+          c2 = PPEEK;
+          if (ONIGENC_IS_CODE_DIGIT(enc, c2) && c2 < '8')
+            return ONIGERR_TOO_LONG_WIDE_CHAR_VALUE;
+        }
 
-	if (p > prev + enclen(enc, prev, end) && !PEND && (PPEEK_IS('}'))) {
-	  PINC;
-	  tok->type   = TK_CODE_POINT;
-	  tok->base   = 8;
-	  tok->u.code = (OnigCodePoint )num;
-	}
-	else {
-	  /* can't read nothing or invalid format */
-	  p = prev;
-	}
+        if (p > prev + enclen(enc, prev, end) && !PEND && (PPEEK_IS('}'))) {
+          PINC;
+          tok->type   = TK_CODE_POINT;
+          tok->base   = 8;
+          tok->u.code = (OnigCodePoint )num;
+        }
+        else {
+          /* can't read nothing or invalid format */
+          p = prev;
+        }
       }
       break;
 
     case '0':
     case '1': case '2': case '3': case '4': case '5': case '6': case '7':
       if (IS_SYNTAX_OP(syn, ONIG_SYN_OP_ESC_OCTAL3)) {
-	PUNFETCH;
-	prev = p;
-	num = scan_unsigned_octal_number(&p, end, 3, enc);
-	if (num < 0 || 0xff < num) return ONIGERR_TOO_BIG_NUMBER;
-	if (p == prev) {  /* can't read nothing. */
-	  num = 0; /* but, it's not error */
-	}
-	tok->type = TK_RAW_BYTE;
-	tok->base = 8;
-	tok->u.c  = num;
+        PUNFETCH;
+        prev = p;
+        num = scan_unsigned_octal_number(&p, end, 3, enc);
+        if (num < 0 || 0xff < num) return ONIGERR_TOO_BIG_NUMBER;
+        if (p == prev) {  /* can't read nothing. */
+          num = 0; /* but, it's not error */
+        }
+        tok->type = TK_RAW_BYTE;
+        tok->base = 8;
+        tok->u.c  = num;
       }
       break;
 
@@ -3316,8 +3316,8 @@ fetch_token_in_cc(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
       num = fetch_escaped_value(&p, end, env, &c2);
       if (num < 0) return num;
       if ((OnigCodePoint )tok->u.c != c2) {
-	tok->u.code = (OnigCodePoint )c2;
-	tok->type   = TK_CODE_POINT;
+        tok->u.code = (OnigCodePoint )c2;
+        tok->type   = TK_CODE_POINT;
       }
       break;
     }
@@ -3329,26 +3329,26 @@ fetch_token_in_cc(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
       PINC;
       if (str_exist_check_with_esc(send, 2, p, end,
                                    (OnigCodePoint )']', enc, syn)) {
-	tok->type = TK_POSIX_BRACKET_OPEN;
+        tok->type = TK_POSIX_BRACKET_OPEN;
       }
       else {
-	PUNFETCH;
-	goto cc_in_cc;
+        PUNFETCH;
+        goto cc_in_cc;
       }
     }
     else {
     cc_in_cc:
       if (IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_CCLASS_SET_OP)) {
-	tok->type = TK_CC_CC_OPEN;
+        tok->type = TK_CC_CC_OPEN;
       }
       else {
-	CC_ESC_WARN(env, (UChar* )"[");
+        CC_ESC_WARN(env, (UChar* )"[");
       }
     }
   }
   else if (c == '&') {
     if (IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_CCLASS_SET_OP) &&
-	!PEND && (PPEEK_IS('&'))) {
+        !PEND && (PPEEK_IS('&'))) {
       PINC;
       tok->type = TK_CC_AND;
     }
@@ -3362,7 +3362,7 @@ fetch_token_in_cc(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 #ifdef USE_NAMED_GROUP
 static int
 fetch_named_backref_token(OnigCodePoint c, OnigToken* tok, UChar** src,
-			  UChar* end, ScanEnv* env)
+                          UChar* end, ScanEnv* env)
 {
   int r, num;
   const OnigSyntaxType* syn = env->syntax;
@@ -3377,7 +3377,7 @@ fetch_named_backref_token(OnigCodePoint c, OnigToken* tok, UChar** src,
 # ifdef USE_BACKREF_WITH_LEVEL
   name_end = NULL_UCHARP; /* no need. escape gcc warning. */
   r = fetch_name_with_level(c, &p, end, &name_end,
-			    env, &back_num, &tok->u.backref.level);
+                            env, &back_num, &tok->u.backref.level);
   if (r == 1) tok->u.backref.exist_level = 1;
   else        tok->u.backref.exist_level = 0;
 # else
@@ -3389,13 +3389,13 @@ fetch_named_backref_token(OnigCodePoint c, OnigToken* tok, UChar** src,
     if (back_num < 0) {
       back_num = BACKREF_REL_TO_ABS(back_num, env);
       if (back_num <= 0)
-	return ONIGERR_INVALID_BACKREF;
+        return ONIGERR_INVALID_BACKREF;
     }
 
     if (IS_SYNTAX_BV(syn, ONIG_SYN_STRICT_CHECK_BACKREF)) {
       if (back_num > env->num_mem ||
-	  IS_NULL(SCANENV_MEM_NODES(env)[back_num]))
-	return ONIGERR_INVALID_BACKREF;
+          IS_NULL(SCANENV_MEM_NODES(env)[back_num]))
+        return ONIGERR_INVALID_BACKREF;
     }
     tok->type = TK_BACKREF;
     tok->u.backref.by_name = 0;
@@ -3406,15 +3406,15 @@ fetch_named_backref_token(OnigCodePoint c, OnigToken* tok, UChar** src,
     num = onig_name_to_group_numbers(env->reg, prev, name_end, &backs);
     if (num <= 0) {
       onig_scan_env_set_error_string(env,
-		     ONIGERR_UNDEFINED_NAME_REFERENCE, prev, name_end);
+                     ONIGERR_UNDEFINED_NAME_REFERENCE, prev, name_end);
       return ONIGERR_UNDEFINED_NAME_REFERENCE;
     }
     if (IS_SYNTAX_BV(syn, ONIG_SYN_STRICT_CHECK_BACKREF)) {
       int i;
       for (i = 0; i < num; i++) {
-	if (backs[i] > env->num_mem ||
-	    IS_NULL(SCANENV_MEM_NODES(env)[backs[i]]))
-	  return ONIGERR_INVALID_BACKREF;
+        if (backs[i] > env->num_mem ||
+            IS_NULL(SCANENV_MEM_NODES(env)[backs[i]]))
+          return ONIGERR_INVALID_BACKREF;
       }
     }
 
@@ -3488,26 +3488,26 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
       tok->u.repeat.upper = 1;
     greedy_check:
       if (!PEND && PPEEK_IS('?') &&
-	  IS_SYNTAX_OP(syn, ONIG_SYN_OP_QMARK_NON_GREEDY)) {
-	PFETCH(c);
-	tok->u.repeat.greedy     = 0;
-	tok->u.repeat.possessive = 0;
+          IS_SYNTAX_OP(syn, ONIG_SYN_OP_QMARK_NON_GREEDY)) {
+        PFETCH(c);
+        tok->u.repeat.greedy     = 0;
+        tok->u.repeat.possessive = 0;
       }
       else {
       possessive_check:
-	if (!PEND && PPEEK_IS('+') &&
-	    ((IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_PLUS_POSSESSIVE_REPEAT) &&
-	      tok->type != TK_INTERVAL)  ||
-	     (IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_PLUS_POSSESSIVE_INTERVAL) &&
-	      tok->type == TK_INTERVAL))) {
-	  PFETCH(c);
-	  tok->u.repeat.greedy     = 1;
-	  tok->u.repeat.possessive = 1;
-	}
-	else {
-	  tok->u.repeat.greedy     = 1;
-	  tok->u.repeat.possessive = 0;
-	}
+        if (!PEND && PPEEK_IS('+') &&
+            ((IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_PLUS_POSSESSIVE_REPEAT) &&
+              tok->type != TK_INTERVAL)  ||
+             (IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_PLUS_POSSESSIVE_INTERVAL) &&
+              tok->type == TK_INTERVAL))) {
+          PFETCH(c);
+          tok->u.repeat.greedy     = 1;
+          tok->u.repeat.possessive = 1;
+        }
+        else {
+          tok->u.repeat.greedy     = 1;
+          tok->u.repeat.possessive = 0;
+        }
       }
       break;
 
@@ -3517,10 +3517,10 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
       if (r < 0) return r;  /* error */
       if (r == 0) goto greedy_check;
       else if (r == 2) { /* {n} */
-	if (IS_SYNTAX_BV(syn, ONIG_SYN_FIXED_INTERVAL_IS_GREEDY_ONLY))
-	  goto possessive_check;
+        if (IS_SYNTAX_BV(syn, ONIG_SYN_FIXED_INTERVAL_IS_GREEDY_ONLY))
+          goto possessive_check;
 
-	goto greedy_check;
+        goto greedy_check;
       }
       /* r == 1 : normal char */
       break;
@@ -3559,7 +3559,7 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
       tok->type = TK_ANCHOR;
       tok->u.anchor.subtype = ANCHOR_WORD_BOUND;
       tok->u.anchor.ascii_range = IS_ASCII_RANGE(env->option)
-		&& ! IS_WORD_BOUND_ALL_RANGE(env->option);
+                && ! IS_WORD_BOUND_ALL_RANGE(env->option);
       break;
 
     case 'B':
@@ -3567,7 +3567,7 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
       tok->type = TK_ANCHOR;
       tok->u.anchor.subtype = ANCHOR_NOT_WORD_BOUND;
       tok->u.anchor.ascii_range = IS_ASCII_RANGE(env->option)
-		&& ! IS_WORD_BOUND_ALL_RANGE(env->option);
+                && ! IS_WORD_BOUND_ALL_RANGE(env->option);
       break;
 
 #ifdef USE_WORD_BEGIN_END
@@ -3669,33 +3669,33 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 
       prev = p;
       if (PPEEK_IS('{') && IS_SYNTAX_OP(syn, ONIG_SYN_OP_ESC_X_BRACE_HEX8)) {
-	PINC;
-	num = scan_unsigned_hexadecimal_number(&p, end, 0, 8, enc);
-	if (num < 0) return ONIGERR_TOO_BIG_WIDE_CHAR_VALUE;
-	if (!PEND) {
-	  if (ONIGENC_IS_CODE_XDIGIT(enc, PPEEK))
-	    return ONIGERR_TOO_LONG_WIDE_CHAR_VALUE;
-	}
+        PINC;
+        num = scan_unsigned_hexadecimal_number(&p, end, 0, 8, enc);
+        if (num < 0) return ONIGERR_TOO_BIG_WIDE_CHAR_VALUE;
+        if (!PEND) {
+          if (ONIGENC_IS_CODE_XDIGIT(enc, PPEEK))
+            return ONIGERR_TOO_LONG_WIDE_CHAR_VALUE;
+        }
 
-	if ((p > prev + enclen(enc, prev, end)) && !PEND && PPEEK_IS('}')) {
-	  PINC;
-	  tok->type   = TK_CODE_POINT;
-	  tok->u.code = (OnigCodePoint )num;
-	}
-	else {
-	  /* can't read nothing or invalid format */
-	  p = prev;
-	}
+        if ((p > prev + enclen(enc, prev, end)) && !PEND && PPEEK_IS('}')) {
+          PINC;
+          tok->type   = TK_CODE_POINT;
+          tok->u.code = (OnigCodePoint )num;
+        }
+        else {
+          /* can't read nothing or invalid format */
+          p = prev;
+        }
       }
       else if (IS_SYNTAX_OP(syn, ONIG_SYN_OP_ESC_X_HEX2)) {
-	num = scan_unsigned_hexadecimal_number(&p, end, 0, 2, enc);
-	if (num < 0) return ONIGERR_TOO_BIG_NUMBER;
-	if (p == prev) {  /* can't read nothing. */
-	  num = 0; /* but, it's not error */
-	}
-	tok->type = TK_RAW_BYTE;
-	tok->base = 16;
-	tok->u.c  = num;
+        num = scan_unsigned_hexadecimal_number(&p, end, 0, 2, enc);
+        if (num < 0) return ONIGERR_TOO_BIG_NUMBER;
+        if (p == prev) {  /* can't read nothing. */
+          num = 0; /* but, it's not error */
+        }
+        tok->type = TK_RAW_BYTE;
+        tok->base = 16;
+        tok->u.c  = num;
       }
       break;
 
@@ -3704,15 +3704,15 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 
       prev = p;
       if (IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_U_HEX4)) {
-	num = scan_unsigned_hexadecimal_number(&p, end, 4, 4, enc);
-	if (num < -1) return ONIGERR_TOO_SHORT_DIGITS;
-	else if (num < 0) return ONIGERR_TOO_BIG_NUMBER;
-	if (p == prev) {  /* can't read nothing. */
-	  num = 0; /* but, it's not error */
-	}
-	tok->type   = TK_CODE_POINT;
-	tok->base   = 16;
-	tok->u.code = (OnigCodePoint )num;
+        num = scan_unsigned_hexadecimal_number(&p, end, 4, 4, enc);
+        if (num < -1) return ONIGERR_TOO_SHORT_DIGITS;
+        else if (num < 0) return ONIGERR_TOO_BIG_NUMBER;
+        if (p == prev) {  /* can't read nothing. */
+          num = 0; /* but, it's not error */
+        }
+        tok->type   = TK_CODE_POINT;
+        tok->base   = 16;
+        tok->u.code = (OnigCodePoint )num;
       }
       break;
 
@@ -3721,24 +3721,24 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 
       prev = p;
       if (PPEEK_IS('{') && IS_SYNTAX_OP(syn, ONIG_SYN_OP_ESC_O_BRACE_OCTAL)) {
-	PINC;
-	num = scan_unsigned_octal_number(&p, end, 11, enc);
-	if (num < 0) return ONIGERR_TOO_BIG_WIDE_CHAR_VALUE;
-	if (!PEND) {
-	  OnigCodePoint c = PPEEK;
-	  if (ONIGENC_IS_CODE_DIGIT(enc, c) && c < '8')
-	    return ONIGERR_TOO_LONG_WIDE_CHAR_VALUE;
-	}
+        PINC;
+        num = scan_unsigned_octal_number(&p, end, 11, enc);
+        if (num < 0) return ONIGERR_TOO_BIG_WIDE_CHAR_VALUE;
+        if (!PEND) {
+          OnigCodePoint c = PPEEK;
+          if (ONIGENC_IS_CODE_DIGIT(enc, c) && c < '8')
+            return ONIGERR_TOO_LONG_WIDE_CHAR_VALUE;
+        }
 
-	if ((p > prev + enclen(enc, prev, end)) && !PEND && PPEEK_IS('}')) {
-	  PINC;
-	  tok->type   = TK_CODE_POINT;
-	  tok->u.code = (OnigCodePoint )num;
-	}
-	else {
-	  /* can't read nothing or invalid format */
-	  p = prev;
-	}
+        if ((p > prev + enclen(enc, prev, end)) && !PEND && PPEEK_IS('}')) {
+          PINC;
+          tok->type   = TK_CODE_POINT;
+          tok->u.code = (OnigCodePoint )num;
+        }
+        else {
+          /* can't read nothing or invalid format */
+          p = prev;
+        }
       }
       break;
 
@@ -3748,64 +3748,64 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
       prev = p;
       num = onig_scan_unsigned_number(&p, end, enc);
       if (num < 0 || num > ONIG_MAX_BACKREF_NUM) {
-	goto skip_backref;
+        goto skip_backref;
       }
 
       if (IS_SYNTAX_OP(syn, ONIG_SYN_OP_DECIMAL_BACKREF) &&
-	  (num <= env->num_mem || num <= 9)) { /* This spec. from GNU regex */
-	if (IS_SYNTAX_BV(syn, ONIG_SYN_STRICT_CHECK_BACKREF)) {
-	  if (num > env->num_mem || IS_NULL(SCANENV_MEM_NODES(env)[num]))
-	    return ONIGERR_INVALID_BACKREF;
-	}
+          (num <= env->num_mem || num <= 9)) { /* This spec. from GNU regex */
+        if (IS_SYNTAX_BV(syn, ONIG_SYN_STRICT_CHECK_BACKREF)) {
+          if (num > env->num_mem || IS_NULL(SCANENV_MEM_NODES(env)[num]))
+            return ONIGERR_INVALID_BACKREF;
+        }
 
-	tok->type = TK_BACKREF;
-	tok->u.backref.num     = 1;
-	tok->u.backref.ref1    = num;
-	tok->u.backref.by_name = 0;
+        tok->type = TK_BACKREF;
+        tok->u.backref.num     = 1;
+        tok->u.backref.ref1    = num;
+        tok->u.backref.by_name = 0;
 #ifdef USE_BACKREF_WITH_LEVEL
-	tok->u.backref.exist_level = 0;
+        tok->u.backref.exist_level = 0;
 #endif
-	break;
+        break;
       }
 
     skip_backref:
       if (c == '8' || c == '9') {
-	/* normal char */
-	p = prev; PINC;
-	break;
+        /* normal char */
+        p = prev; PINC;
+        break;
       }
 
       p = prev;
       /* fall through */
     case '0':
       if (IS_SYNTAX_OP(syn, ONIG_SYN_OP_ESC_OCTAL3)) {
-	prev = p;
-	num = scan_unsigned_octal_number(&p, end, (c == '0' ? 2:3), enc);
-	if (num < 0 || 0xff < num) return ONIGERR_TOO_BIG_NUMBER;
-	if (p == prev) {  /* can't read nothing. */
-	  num = 0; /* but, it's not error */
-	}
-	tok->type = TK_RAW_BYTE;
-	tok->base = 8;
-	tok->u.c  = num;
+        prev = p;
+        num = scan_unsigned_octal_number(&p, end, (c == '0' ? 2:3), enc);
+        if (num < 0 || 0xff < num) return ONIGERR_TOO_BIG_NUMBER;
+        if (p == prev) {  /* can't read nothing. */
+          num = 0; /* but, it's not error */
+        }
+        tok->type = TK_RAW_BYTE;
+        tok->base = 8;
+        tok->u.c  = num;
       }
       else if (c != '0') {
-	PINC;
+        PINC;
       }
       break;
 
 #ifdef USE_NAMED_GROUP
     case 'k':
       if (!PEND && IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_K_NAMED_BACKREF)) {
-	PFETCH(c);
-	if (c == '<' || c == '\'') {
-	  r = fetch_named_backref_token(c, tok, &p, end, env);
-	  if (r < 0) return r;
-	}
-	else {
-	  PUNFETCH;
-	  onig_syntax_warn(env, "invalid back reference");
-	}
+        PFETCH(c);
+        if (c == '<' || c == '\'') {
+          r = fetch_named_backref_token(c, tok, &p, end, env);
+          if (r < 0) return r;
+        }
+        else {
+          PUNFETCH;
+          onig_syntax_warn(env, "invalid back reference");
+        }
       }
       break;
 #endif
@@ -3814,52 +3814,52 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
     case 'g':
 # ifdef USE_NAMED_GROUP
       if (!PEND && IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_G_BRACE_BACKREF)) {
-	PFETCH(c);
-	if (c == '{') {
-	  r = fetch_named_backref_token(c, tok, &p, end, env);
-	  if (r < 0) return r;
-	}
-	else
-	  PUNFETCH;
+        PFETCH(c);
+        if (c == '{') {
+          r = fetch_named_backref_token(c, tok, &p, end, env);
+          if (r < 0) return r;
+        }
+        else
+          PUNFETCH;
       }
 # endif
 # ifdef USE_SUBEXP_CALL
       if (!PEND && IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_G_SUBEXP_CALL)) {
-	PFETCH(c);
-	if (c == '<' || c == '\'') {
-	  int gnum = -1, rel = 0;
-	  UChar* name_end;
-	  OnigCodePoint cnext;
+        PFETCH(c);
+        if (c == '<' || c == '\'') {
+          int gnum = -1, rel = 0;
+          UChar* name_end;
+          OnigCodePoint cnext;
 
-	  cnext = PPEEK;
-	  if (cnext == '0') {
-	    PINC;
-	    if (PPEEK_IS(get_name_end_code_point(c))) {  /* \g<0>, \g'0' */
-	      PINC;
-	      name_end = p;
-	      gnum = 0;
-	    }
-	  }
-	  else if (cnext == '+') {
-	    PINC;
-	    rel = 1;
-	  }
-	  prev = p;
-	  if (gnum < 0) {
-	    r = fetch_name((OnigCodePoint )c, &p, end, &name_end, env, &gnum, 1);
-	    if (r < 0) return r;
-	  }
+          cnext = PPEEK;
+          if (cnext == '0') {
+            PINC;
+            if (PPEEK_IS(get_name_end_code_point(c))) {  /* \g<0>, \g'0' */
+              PINC;
+              name_end = p;
+              gnum = 0;
+            }
+          }
+          else if (cnext == '+') {
+            PINC;
+            rel = 1;
+          }
+          prev = p;
+          if (gnum < 0) {
+            r = fetch_name((OnigCodePoint )c, &p, end, &name_end, env, &gnum, 1);
+            if (r < 0) return r;
+          }
 
-	  tok->type = TK_CALL;
-	  tok->u.call.name     = prev;
-	  tok->u.call.name_end = name_end;
-	  tok->u.call.gnum     = gnum;
-	  tok->u.call.rel      = rel;
-	}
-	else {
-	  onig_syntax_warn(env, "invalid subexp call");
-	  PUNFETCH;
-	}
+          tok->type = TK_CALL;
+          tok->u.call.name     = prev;
+          tok->u.call.name_end = name_end;
+          tok->u.call.gnum     = gnum;
+          tok->u.call.rel      = rel;
+        }
+        else {
+          onig_syntax_warn(env, "invalid subexp call");
+          PUNFETCH;
+        }
       }
 # endif
       break;
@@ -3867,65 +3867,65 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 
     case 'Q':
       if (IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_CAPITAL_Q_QUOTE)) {
-	tok->type = TK_QUOTE_OPEN;
+        tok->type = TK_QUOTE_OPEN;
       }
       break;
 
     case 'p':
     case 'P':
       if (PPEEK_IS('{') &&
-	  IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_P_BRACE_CHAR_PROPERTY)) {
-	PINC;
-	tok->type = TK_CHAR_PROPERTY;
-	tok->u.prop.not = (c == 'P' ? 1 : 0);
+          IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_P_BRACE_CHAR_PROPERTY)) {
+        PINC;
+        tok->type = TK_CHAR_PROPERTY;
+        tok->u.prop.not = (c == 'P' ? 1 : 0);
 
-	if (!PEND && IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_P_BRACE_CIRCUMFLEX_NOT)) {
-	  PFETCH(c);
-	  if (c == '^') {
-	    tok->u.prop.not = (tok->u.prop.not == 0 ? 1 : 0);
-	  }
-	  else
-	    PUNFETCH;
-	}
+        if (!PEND && IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_P_BRACE_CIRCUMFLEX_NOT)) {
+          PFETCH(c);
+          if (c == '^') {
+            tok->u.prop.not = (tok->u.prop.not == 0 ? 1 : 0);
+          }
+          else
+            PUNFETCH;
+        }
       }
       else {
-	onig_syntax_warn(env, "invalid Unicode Property \\%c", c);
+        onig_syntax_warn(env, "invalid Unicode Property \\%c", c);
       }
       break;
 
     case 'R':
       if (IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_CAPITAL_R_LINEBREAK)) {
-	tok->type = TK_LINEBREAK;
+        tok->type = TK_LINEBREAK;
       }
       break;
 
     case 'X':
       if (IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_CAPITAL_X_EXTENDED_GRAPHEME_CLUSTER)) {
-	tok->type = TK_EXTENDED_GRAPHEME_CLUSTER;
+        tok->type = TK_EXTENDED_GRAPHEME_CLUSTER;
       }
       break;
 
     case 'K':
       if (IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_ESC_CAPITAL_K_KEEP)) {
-	tok->type = TK_KEEP;
+        tok->type = TK_KEEP;
       }
       break;
 
     default:
       {
-	OnigCodePoint c2;
+        OnigCodePoint c2;
 
-	PUNFETCH;
-	num = fetch_escaped_value(&p, end, env, &c2);
-	if (num < 0) return num;
-	/* set_raw: */
-	if ((OnigCodePoint )tok->u.c != c2) {
-	  tok->type = TK_CODE_POINT;
-	  tok->u.code = (OnigCodePoint )c2;
-	}
-	else { /* string */
-	  p = tok->backp + enclen(enc, tok->backp, end);
-	}
+        PUNFETCH;
+        num = fetch_escaped_value(&p, end, env, &c2);
+        if (num < 0) return num;
+        /* set_raw: */
+        if ((OnigCodePoint )tok->u.c != c2) {
+          tok->type = TK_CODE_POINT;
+          tok->u.code = (OnigCodePoint )c2;
+        }
+        else { /* string */
+          p = tok->backp + enclen(enc, tok->backp, end);
+        }
       }
       break;
     }
@@ -3936,18 +3936,18 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 
 #ifdef USE_VARIABLE_META_CHARS
     if ((c != ONIG_INEFFECTIVE_META_CHAR) &&
-	IS_SYNTAX_OP(syn, ONIG_SYN_OP_VARIABLE_META_CHARACTERS)) {
+        IS_SYNTAX_OP(syn, ONIG_SYN_OP_VARIABLE_META_CHARACTERS)) {
       if (c == MC_ANYCHAR(syn))
-	goto any_char;
+        goto any_char;
       else if (c == MC_ANYTIME(syn))
-	goto anytime;
+        goto anytime;
       else if (c == MC_ZERO_OR_ONE_TIME(syn))
-	goto zero_or_one_time;
+        goto zero_or_one_time;
       else if (c == MC_ONE_OR_MORE_TIME(syn))
-	goto one_or_more_time;
+        goto one_or_more_time;
       else if (c == MC_ANYCHAR_ANYTIME(syn)) {
-	tok->type = TK_ANYCHAR_ANYTIME;
-	goto out;
+        tok->type = TK_ANYCHAR_ANYTIME;
+        goto out;
       }
     }
 #endif
@@ -4000,10 +4000,10 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
       if (r < 0) return r;  /* error */
       if (r == 0) goto greedy_check;
       else if (r == 2) { /* {n} */
-	if (IS_SYNTAX_BV(syn, ONIG_SYN_FIXED_INTERVAL_IS_GREEDY_ONLY))
-	  goto possessive_check;
+        if (IS_SYNTAX_BV(syn, ONIG_SYN_FIXED_INTERVAL_IS_GREEDY_ONLY))
+          goto possessive_check;
 
-	goto greedy_check;
+        goto greedy_check;
       }
       /* r == 1 : normal char */
       break;
@@ -4015,114 +4015,114 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 
     case '(':
       if (PPEEK_IS('?') &&
-	  IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_QMARK_GROUP_EFFECT)) {
-	PINC;
-	if (PPEEK_IS('#')) {
-	  PFETCH(c);
-	  while (1) {
-	    if (PEND) return ONIGERR_END_PATTERN_IN_GROUP;
-	    PFETCH(c);
-	    if (c == MC_ESC(syn)) {
-	      if (!PEND) PFETCH(c);
-	    }
-	    else {
-	      if (c == ')') break;
-	    }
-	  }
-	  goto start;
-	}
+          IS_SYNTAX_OP2(syn, ONIG_SYN_OP2_QMARK_GROUP_EFFECT)) {
+        PINC;
+        if (PPEEK_IS('#')) {
+          PFETCH(c);
+          while (1) {
+            if (PEND) return ONIGERR_END_PATTERN_IN_GROUP;
+            PFETCH(c);
+            if (c == MC_ESC(syn)) {
+              if (!PEND) PFETCH(c);
+            }
+            else {
+              if (c == ')') break;
+            }
+          }
+          goto start;
+        }
 #ifdef USE_PERL_SUBEXP_CALL
-	/* (?&name), (?n), (?R), (?0), (?+n), (?-n) */
-	c = PPEEK;
-	if ((c == '&' || c == 'R' || ONIGENC_IS_CODE_DIGIT(enc, c)) &&
-	    IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_SUBEXP_CALL)) {
-	  /* (?&name), (?n), (?R), (?0) */
-	  int gnum;
-	  UChar *name;
-	  UChar *name_end;
+        /* (?&name), (?n), (?R), (?0), (?+n), (?-n) */
+        c = PPEEK;
+        if ((c == '&' || c == 'R' || ONIGENC_IS_CODE_DIGIT(enc, c)) &&
+            IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_SUBEXP_CALL)) {
+          /* (?&name), (?n), (?R), (?0) */
+          int gnum;
+          UChar *name;
+          UChar *name_end;
 
-	  if (c == 'R' || c == '0') {
-	    PINC;   /* skip 'R' / '0' */
-	    if (!PPEEK_IS(')')) return ONIGERR_INVALID_GROUP_NAME;
-	    PINC;   /* skip ')' */
-	    name_end = name = p;
-	    gnum = 0;
-	  }
-	  else {
-	    int numref = 1;
-	    if (c == '&') {     /* (?&name) */
-	      PINC;
-	      numref = 0;       /* don't allow number name */
-	    }
-	    name = p;
-	    r = fetch_name((OnigCodePoint )'(', &p, end, &name_end, env, &gnum, numref);
-	    if (r < 0) return r;
-	  }
+          if (c == 'R' || c == '0') {
+            PINC;   /* skip 'R' / '0' */
+            if (!PPEEK_IS(')')) return ONIGERR_INVALID_GROUP_NAME;
+            PINC;   /* skip ')' */
+            name_end = name = p;
+            gnum = 0;
+          }
+          else {
+            int numref = 1;
+            if (c == '&') {     /* (?&name) */
+              PINC;
+              numref = 0;       /* don't allow number name */
+            }
+            name = p;
+            r = fetch_name((OnigCodePoint )'(', &p, end, &name_end, env, &gnum, numref);
+            if (r < 0) return r;
+          }
 
-	  tok->type = TK_CALL;
-	  tok->u.call.name     = name;
-	  tok->u.call.name_end = name_end;
-	  tok->u.call.gnum     = gnum;
-	  tok->u.call.rel      = 0;
-	  break;
-	}
-	else if ((c == '-' || c == '+') &&
-	    IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_SUBEXP_CALL)) {
-	  /* (?+n), (?-n) */
-	  int gnum;
-	  UChar *name;
-	  UChar *name_end;
-	  OnigCodePoint cnext;
-	  PFETCH_READY;
+          tok->type = TK_CALL;
+          tok->u.call.name     = name;
+          tok->u.call.name_end = name_end;
+          tok->u.call.gnum     = gnum;
+          tok->u.call.rel      = 0;
+          break;
+        }
+        else if ((c == '-' || c == '+') &&
+            IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_SUBEXP_CALL)) {
+          /* (?+n), (?-n) */
+          int gnum;
+          UChar *name;
+          UChar *name_end;
+          OnigCodePoint cnext;
+          PFETCH_READY;
 
-	  PINC;     /* skip '-' / '+' */
-	  cnext = PPEEK;
-	  if (ONIGENC_IS_CODE_DIGIT(enc, cnext)) {
-	    if (c == '-') PUNFETCH;
-	    name = p;
-	    r = fetch_name((OnigCodePoint )'(', &p, end, &name_end, env, &gnum, 1);
-	    if (r < 0) return r;
+          PINC;     /* skip '-' / '+' */
+          cnext = PPEEK;
+          if (ONIGENC_IS_CODE_DIGIT(enc, cnext)) {
+            if (c == '-') PUNFETCH;
+            name = p;
+            r = fetch_name((OnigCodePoint )'(', &p, end, &name_end, env, &gnum, 1);
+            if (r < 0) return r;
 
-	    tok->type = TK_CALL;
-	    tok->u.call.name     = name;
-	    tok->u.call.name_end = name_end;
-	    tok->u.call.gnum     = gnum;
-	    tok->u.call.rel      = 1;
-	    break;
-	  }
-	}
+            tok->type = TK_CALL;
+            tok->u.call.name     = name;
+            tok->u.call.name_end = name_end;
+            tok->u.call.gnum     = gnum;
+            tok->u.call.rel      = 1;
+            break;
+          }
+        }
 #endif /* USE_PERL_SUBEXP_CALL */
 #ifdef USE_CAPITAL_P_NAMED_GROUP
-	if (PPEEK_IS('P') &&
-	    IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_CAPITAL_P_NAMED_GROUP)) {
-	  int gnum;
-	  UChar *name;
-	  UChar *name_end;
-	  PFETCH_READY;
+        if (PPEEK_IS('P') &&
+            IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_CAPITAL_P_NAMED_GROUP)) {
+          int gnum;
+          UChar *name;
+          UChar *name_end;
+          PFETCH_READY;
 
-	  PINC;     /* skip 'P' */
-	  if (PEND) return ONIGERR_UNDEFINED_GROUP_OPTION;
-	  PFETCH(c);
-	  if (c == '=') {       /* (?P=name): backref */
-	    r = fetch_named_backref_token((OnigCodePoint )'(', tok, &p, end, env);
-	    if (r < 0) return r;
-	    break;
-	  }
-	  else if (c == '>') {  /* (?P>name): subexp call */
-	    name = p;
-	    r = fetch_name((OnigCodePoint )'(', &p, end, &name_end, env, &gnum, 0);
-	    if (r < 0) return r;
+          PINC;     /* skip 'P' */
+          if (PEND) return ONIGERR_UNDEFINED_GROUP_OPTION;
+          PFETCH(c);
+          if (c == '=') {       /* (?P=name): backref */
+            r = fetch_named_backref_token((OnigCodePoint )'(', tok, &p, end, env);
+            if (r < 0) return r;
+            break;
+          }
+          else if (c == '>') {  /* (?P>name): subexp call */
+            name = p;
+            r = fetch_name((OnigCodePoint )'(', &p, end, &name_end, env, &gnum, 0);
+            if (r < 0) return r;
 
-	    tok->type = TK_CALL;
-	    tok->u.call.name     = name;
-	    tok->u.call.name_end = name_end;
-	    tok->u.call.gnum     = gnum;
-	    tok->u.call.rel      = 0;
-	    break;
-	  }
-	}
+            tok->type = TK_CALL;
+            tok->u.call.name     = name;
+            tok->u.call.name_end = name_end;
+            tok->u.call.gnum     = gnum;
+            tok->u.call.rel      = 0;
+            break;
+          }
+        }
 #endif /* USE_CAPITAL_P_NAMED_GROUP */
-	PUNFETCH;
+        PUNFETCH;
       }
 
       if (! IS_SYNTAX_OP(syn, ONIG_SYN_OP_LPAREN_SUBEXP)) break;
@@ -4138,14 +4138,14 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
       if (! IS_SYNTAX_OP(syn, ONIG_SYN_OP_LINE_ANCHOR)) break;
       tok->type = TK_ANCHOR;
       tok->u.anchor.subtype = (IS_SINGLELINE(env->option)
-			       ? ANCHOR_BEGIN_BUF : ANCHOR_BEGIN_LINE);
+                               ? ANCHOR_BEGIN_BUF : ANCHOR_BEGIN_LINE);
       break;
 
     case '$':
       if (! IS_SYNTAX_OP(syn, ONIG_SYN_OP_LINE_ANCHOR)) break;
       tok->type = TK_ANCHOR;
       tok->u.anchor.subtype = (IS_SINGLELINE(env->option)
-			       ? ANCHOR_SEMI_END_BUF : ANCHOR_END_LINE);
+                               ? ANCHOR_SEMI_END_BUF : ANCHOR_END_LINE);
       break;
 
     case '[':
@@ -4155,24 +4155,24 @@ fetch_token(OnigToken* tok, UChar** src, UChar* end, ScanEnv* env)
 
     case ']':
       if (*src > env->pattern)   /* /].../ is allowed. */
-	CLOSE_BRACKET_WITHOUT_ESC_WARN(env, (UChar* )"]");
+        CLOSE_BRACKET_WITHOUT_ESC_WARN(env, (UChar* )"]");
       break;
 
     case '#':
       if (IS_EXTEND(env->option)) {
-	while (!PEND) {
-	  PFETCH(c);
-	  if (ONIGENC_IS_CODE_NEWLINE(enc, c))
-	    break;
-	}
-	goto start;
-	break;
+        while (!PEND) {
+          PFETCH(c);
+          if (ONIGENC_IS_CODE_NEWLINE(enc, c))
+            break;
+        }
+        goto start;
+        break;
       }
       break;
 
     case ' ': case '\t': case '\n': case '\r': case '\f':
       if (IS_EXTEND(env->option))
-	goto start;
+        goto start;
       break;
 
     default:
@@ -4201,18 +4201,18 @@ add_ctype_to_cc_by_range(CClassNode* cc, int ctype ARG_UNUSED, int not,
   if (not == 0) {
     for (i = 0; i < n; i++) {
       for (j = ONIGENC_CODE_RANGE_FROM(mbr, i);
-	  j <= ONIGENC_CODE_RANGE_TO(mbr, i); j++) {
-	if (j >= sb_out) {
-	  if (j > ONIGENC_CODE_RANGE_FROM(mbr, i)) {
-	    r = add_code_range_to_buf(&(cc->mbuf), env, j,
-				      ONIGENC_CODE_RANGE_TO(mbr, i));
-	    if (r != 0) return r;
-	    i++;
-	  }
+          j <= ONIGENC_CODE_RANGE_TO(mbr, i); j++) {
+        if (j >= sb_out) {
+          if (j > ONIGENC_CODE_RANGE_FROM(mbr, i)) {
+            r = add_code_range_to_buf(&(cc->mbuf), env, j,
+                                      ONIGENC_CODE_RANGE_TO(mbr, i));
+            if (r != 0) return r;
+            i++;
+          }
 
-	  goto sb_end;
-	}
-	BITSET_SET_BIT_CHKDUP(cc->bs, j);
+          goto sb_end;
+        }
+        BITSET_SET_BIT_CHKDUP(cc->bs, j);
       }
     }
 
@@ -4229,11 +4229,11 @@ add_ctype_to_cc_by_range(CClassNode* cc, int ctype ARG_UNUSED, int not,
 
     for (i = 0; i < n; i++) {
       for (j = prev;
-	   j < ONIGENC_CODE_RANGE_FROM(mbr, i); j++) {
-	if (j >= sb_out) {
-	  goto sb_end2;
-	}
-	BITSET_SET_BIT_CHKDUP(cc->bs, j);
+           j < ONIGENC_CODE_RANGE_FROM(mbr, i); j++) {
+        if (j >= sb_out) {
+          goto sb_end2;
+        }
+        BITSET_SET_BIT_CHKDUP(cc->bs, j);
       }
       prev = ONIGENC_CODE_RANGE_TO(mbr, i) + 1;
     }
@@ -4246,9 +4246,9 @@ add_ctype_to_cc_by_range(CClassNode* cc, int ctype ARG_UNUSED, int not,
 
     for (i = 0; i < n; i++) {
       if (prev < ONIGENC_CODE_RANGE_FROM(mbr, i)) {
-	r = add_code_range_to_buf(&(cc->mbuf), env, prev,
+        r = add_code_range_to_buf(&(cc->mbuf), env, prev,
                                   ONIGENC_CODE_RANGE_FROM(mbr, i) - 1);
-	if (r != 0) return r;
+        if (r != 0) return r;
       }
       prev = ONIGENC_CODE_RANGE_TO(mbr, i) + 1;
     }
@@ -4276,30 +4276,30 @@ add_ctype_to_cc(CClassNode* cc, int ctype, int not, int ascii_range, ScanEnv* en
       CClassNode ccwork;
       initialize_cclass(&ccwork);
       r = add_ctype_to_cc_by_range(&ccwork, ctype, not, env, sb_out,
-				   ranges);
+                                   ranges);
       if (r == 0) {
-	if (not) {
-	  r = add_code_range_to_buf0(&(ccwork.mbuf), env, 0x80, ONIG_LAST_CODE_POINT, FALSE);
-	}
-	else {
-	  CClassNode ccascii;
-	  initialize_cclass(&ccascii);
-	  if (ONIGENC_MBC_MINLEN(env->enc) > 1) {
-	    r = add_code_range(&(ccascii.mbuf), env, 0x00, 0x7F);
-	  }
-	  else {
-	    bitset_set_range(env, ccascii.bs, 0x00, 0x7F);
-	    r = 0;
-	  }
-	  if (r == 0) {
-	    r = and_cclass(&ccwork, &ccascii, env);
-	  }
-	  if (IS_NOT_NULL(ccascii.mbuf)) bbuf_free(ccascii.mbuf);
-	}
-	if (r == 0) {
-	  r = or_cclass(cc, &ccwork, env);
-	}
-	if (IS_NOT_NULL(ccwork.mbuf)) bbuf_free(ccwork.mbuf);
+        if (not) {
+          r = add_code_range_to_buf0(&(ccwork.mbuf), env, 0x80, ONIG_LAST_CODE_POINT, FALSE);
+        }
+        else {
+          CClassNode ccascii;
+          initialize_cclass(&ccascii);
+          if (ONIGENC_MBC_MINLEN(env->enc) > 1) {
+            r = add_code_range(&(ccascii.mbuf), env, 0x00, 0x7F);
+          }
+          else {
+            bitset_set_range(env, ccascii.bs, 0x00, 0x7F);
+            r = 0;
+          }
+          if (r == 0) {
+            r = and_cclass(&ccwork, &ccascii, env);
+          }
+          if (IS_NOT_NULL(ccascii.mbuf)) bbuf_free(ccascii.mbuf);
+        }
+        if (r == 0) {
+          r = or_cclass(cc, &ccwork, env);
+        }
+        if (IS_NOT_NULL(ccwork.mbuf)) bbuf_free(ccwork.mbuf);
       }
     }
     else {
@@ -4327,15 +4327,15 @@ add_ctype_to_cc(CClassNode* cc, int ctype, int not, int ascii_range, ScanEnv* en
   case ONIGENC_CTYPE_ALNUM:
     if (not != 0) {
       for (c = 0; c < SINGLE_BYTE_SIZE; c++) {
-	if (! ONIGENC_IS_CODE_CTYPE(enc, (OnigCodePoint )c, ctype))
-	  BITSET_SET_BIT_CHKDUP(cc->bs, c);
+        if (! ONIGENC_IS_CODE_CTYPE(enc, (OnigCodePoint )c, ctype))
+          BITSET_SET_BIT_CHKDUP(cc->bs, c);
       }
       ADD_ALL_MULTI_BYTE_RANGE(enc, cc->mbuf);
     }
     else {
       for (c = 0; c < SINGLE_BYTE_SIZE; c++) {
-	if (ONIGENC_IS_CODE_CTYPE(enc, (OnigCodePoint )c, ctype))
-	  BITSET_SET_BIT_CHKDUP(cc->bs, c);
+        if (ONIGENC_IS_CODE_CTYPE(enc, (OnigCodePoint )c, ctype))
+          BITSET_SET_BIT_CHKDUP(cc->bs, c);
       }
     }
     break;
@@ -4344,39 +4344,39 @@ add_ctype_to_cc(CClassNode* cc, int ctype, int not, int ascii_range, ScanEnv* en
   case ONIGENC_CTYPE_PRINT:
     if (not != 0) {
       for (c = 0; c < SINGLE_BYTE_SIZE; c++) {
-	if (! ONIGENC_IS_CODE_CTYPE(enc, (OnigCodePoint )c, ctype)
-	    || c >= maxcode)
-	  BITSET_SET_BIT_CHKDUP(cc->bs, c);
+        if (! ONIGENC_IS_CODE_CTYPE(enc, (OnigCodePoint )c, ctype)
+            || c >= maxcode)
+          BITSET_SET_BIT_CHKDUP(cc->bs, c);
       }
       if (ascii_range)
-	ADD_ALL_MULTI_BYTE_RANGE(enc, cc->mbuf);
+        ADD_ALL_MULTI_BYTE_RANGE(enc, cc->mbuf);
     }
     else {
       for (c = 0; c < maxcode; c++) {
-	if (ONIGENC_IS_CODE_CTYPE(enc, (OnigCodePoint )c, ctype))
-	  BITSET_SET_BIT_CHKDUP(cc->bs, c);
+        if (ONIGENC_IS_CODE_CTYPE(enc, (OnigCodePoint )c, ctype))
+          BITSET_SET_BIT_CHKDUP(cc->bs, c);
       }
       if (! ascii_range)
-	ADD_ALL_MULTI_BYTE_RANGE(enc, cc->mbuf);
+        ADD_ALL_MULTI_BYTE_RANGE(enc, cc->mbuf);
     }
     break;
 
   case ONIGENC_CTYPE_WORD:
     if (not == 0) {
       for (c = 0; c < maxcode; c++) {
-	if (ONIGENC_IS_CODE_WORD(enc, c)) BITSET_SET_BIT_CHKDUP(cc->bs, c);
+        if (ONIGENC_IS_CODE_WORD(enc, c)) BITSET_SET_BIT_CHKDUP(cc->bs, c);
       }
       if (! ascii_range)
-	ADD_ALL_MULTI_BYTE_RANGE(enc, cc->mbuf);
+        ADD_ALL_MULTI_BYTE_RANGE(enc, cc->mbuf);
     }
     else {
       for (c = 0; c < SINGLE_BYTE_SIZE; c++) {
-	if ((ONIGENC_CODE_TO_MBCLEN(enc, c) > 0) /* check invalid code point */
-	    && (! ONIGENC_IS_CODE_WORD(enc, c) || c >= maxcode))
-	  BITSET_SET_BIT_CHKDUP(cc->bs, c);
+        if ((ONIGENC_CODE_TO_MBCLEN(enc, c) > 0) /* check invalid code point */
+            && (! ONIGENC_IS_CODE_WORD(enc, c) || c >= maxcode))
+          BITSET_SET_BIT_CHKDUP(cc->bs, c);
       }
       if (ascii_range)
-	ADD_ALL_MULTI_BYTE_RANGE(enc, cc->mbuf);
+        ADD_ALL_MULTI_BYTE_RANGE(enc, cc->mbuf);
     }
     break;
 
@@ -4390,7 +4390,7 @@ add_ctype_to_cc(CClassNode* cc, int ctype, int not, int ascii_range, ScanEnv* en
 
 static int
 parse_posix_bracket(CClassNode* cc, CClassNode* asc_cc,
-		    UChar** src, UChar* end, ScanEnv* env)
+                    UChar** src, UChar* end, ScanEnv* env)
 {
 #define POSIX_BRACKET_CHECK_LIMIT_LENGTH  20
 #define POSIX_BRACKET_NAME_MIN_LEN         4
@@ -4430,22 +4430,22 @@ parse_posix_bracket(CClassNode* cc, CClassNode* asc_cc,
     goto not_posix_bracket;
 
   ascii_range = IS_ASCII_RANGE(env->option) &&
-		  ! IS_POSIX_BRACKET_ALL_RANGE(env->option);
+                  ! IS_POSIX_BRACKET_ALL_RANGE(env->option);
   for (pb = PBS; pb < PBS + numberof(PBS); pb++) {
     if (onigenc_with_ascii_strncmp(enc, p, end, pb->name, pb->len) == 0) {
       p = (UChar* )onigenc_step(enc, p, end, pb->len);
       if (onigenc_with_ascii_strncmp(enc, p, end, (UChar* )":]", 2) != 0)
-	return ONIGERR_INVALID_POSIX_BRACKET_TYPE;
+        return ONIGERR_INVALID_POSIX_BRACKET_TYPE;
 
       r = add_ctype_to_cc(cc, pb->ctype, not, ascii_range, env);
       if (r != 0) return r;
 
       if (IS_NOT_NULL(asc_cc)) {
-	if (pb->ctype != ONIGENC_CTYPE_WORD &&
-	    pb->ctype != ONIGENC_CTYPE_ASCII &&
-	    !ascii_range)
-	  r = add_ctype_to_cc(asc_cc, pb->ctype, not, ascii_range, env);
-	if (r != 0) return r;
+        if (pb->ctype != ONIGENC_CTYPE_WORD &&
+            pb->ctype != ONIGENC_CTYPE_ASCII &&
+            !ascii_range)
+          r = add_ctype_to_cc(asc_cc, pb->ctype, not, ascii_range, env);
+        if (r != 0) return r;
       }
 
       PINC_S; PINC_S;
@@ -4466,7 +4466,7 @@ parse_posix_bracket(CClassNode* cc, CClassNode* asc_cc,
     if (! PEND) {
       PFETCH_S(c);
       if (c == ']')
-	return ONIGERR_INVALID_POSIX_BRACKET_TYPE;
+        return ONIGERR_INVALID_POSIX_BRACKET_TYPE;
     }
   }
 
@@ -4507,7 +4507,7 @@ static int cclass_case_fold(Node** np, CClassNode* cc, CClassNode* asc_cc, ScanE
 
 static int
 parse_char_property(Node** np, OnigToken* tok, UChar** src, UChar* end,
-		    ScanEnv* env)
+                    ScanEnv* env)
 {
   int r, ctype;
   CClassNode* cc;
@@ -4545,8 +4545,8 @@ enum CCVALTYPE {
 
 static int
 next_state_class(CClassNode* cc, CClassNode* asc_cc,
-		 OnigCodePoint* vs, enum CCVALTYPE* type,
-		 enum CCSTATE* state, ScanEnv* env)
+                 OnigCodePoint* vs, enum CCVALTYPE* type,
+                 enum CCSTATE* state, ScanEnv* env)
 {
   int r;
 
@@ -4557,14 +4557,14 @@ next_state_class(CClassNode* cc, CClassNode* asc_cc,
     if (*type == CCV_SB) {
       BITSET_SET_BIT_CHKDUP(cc->bs, (int )(*vs));
       if (IS_NOT_NULL(asc_cc))
-	BITSET_SET_BIT(asc_cc->bs, (int )(*vs));
+        BITSET_SET_BIT(asc_cc->bs, (int )(*vs));
     }
     else if (*type == CCV_CODE_POINT) {
       r = add_code_range(&(cc->mbuf), env, *vs, *vs);
       if (r < 0) return r;
       if (IS_NOT_NULL(asc_cc)) {
-	r = add_code_range0(&(asc_cc->mbuf), env, *vs, *vs, 0);
-	if (r < 0) return r;
+        r = add_code_range0(&(asc_cc->mbuf), env, *vs, *vs, 0);
+        if (r < 0) return r;
       }
     }
   }
@@ -4576,10 +4576,10 @@ next_state_class(CClassNode* cc, CClassNode* asc_cc,
 
 static int
 next_state_val(CClassNode* cc, CClassNode* asc_cc,
-	       OnigCodePoint *from, OnigCodePoint to,
-	       int* from_israw, int to_israw,
-	       enum CCVALTYPE intype, enum CCVALTYPE* type,
-	       enum CCSTATE* state, ScanEnv* env)
+               OnigCodePoint *from, OnigCodePoint to,
+               int* from_israw, int to_israw,
+               enum CCVALTYPE intype, enum CCVALTYPE* type,
+               enum CCSTATE* state, ScanEnv* env)
 {
   int r;
 
@@ -4588,14 +4588,14 @@ next_state_val(CClassNode* cc, CClassNode* asc_cc,
     if (*type == CCV_SB) {
       BITSET_SET_BIT_CHKDUP(cc->bs, (int )(*from));
       if (IS_NOT_NULL(asc_cc))
-	BITSET_SET_BIT(asc_cc->bs, (int )(*from));
+        BITSET_SET_BIT(asc_cc->bs, (int )(*from));
     }
     else if (*type == CCV_CODE_POINT) {
       r = add_code_range(&(cc->mbuf), env, *from, *from);
       if (r < 0) return r;
       if (IS_NOT_NULL(asc_cc)) {
-	r = add_code_range0(&(asc_cc->mbuf), env, *from, *from, 0);
-	if (r < 0) return r;
+        r = add_code_range0(&(asc_cc->mbuf), env, *from, *from, 0);
+        if (r < 0) return r;
       }
     }
     break;
@@ -4603,42 +4603,42 @@ next_state_val(CClassNode* cc, CClassNode* asc_cc,
   case CCS_RANGE:
     if (intype == *type) {
       if (intype == CCV_SB) {
-	if (*from > 0xff || to > 0xff)
-	  return ONIGERR_INVALID_CODE_POINT_VALUE;
+        if (*from > 0xff || to > 0xff)
+          return ONIGERR_INVALID_CODE_POINT_VALUE;
 
-	if (*from > to) {
-	  if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_ALLOW_EMPTY_RANGE_IN_CC))
-	    goto ccs_range_end;
-	  else
-	    return ONIGERR_EMPTY_RANGE_IN_CHAR_CLASS;
-	}
-	bitset_set_range(env, cc->bs, (int )*from, (int )to);
-	if (IS_NOT_NULL(asc_cc))
-	  bitset_set_range(env, asc_cc->bs, (int )*from, (int )to);
+        if (*from > to) {
+          if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_ALLOW_EMPTY_RANGE_IN_CC))
+            goto ccs_range_end;
+          else
+            return ONIGERR_EMPTY_RANGE_IN_CHAR_CLASS;
+        }
+        bitset_set_range(env, cc->bs, (int )*from, (int )to);
+        if (IS_NOT_NULL(asc_cc))
+          bitset_set_range(env, asc_cc->bs, (int )*from, (int )to);
       }
       else {
-	r = add_code_range(&(cc->mbuf), env, *from, to);
-	if (r < 0) return r;
-	if (IS_NOT_NULL(asc_cc)) {
-	  r = add_code_range0(&(asc_cc->mbuf), env, *from, to, 0);
-	  if (r < 0) return r;
-	}
+        r = add_code_range(&(cc->mbuf), env, *from, to);
+        if (r < 0) return r;
+        if (IS_NOT_NULL(asc_cc)) {
+          r = add_code_range0(&(asc_cc->mbuf), env, *from, to, 0);
+          if (r < 0) return r;
+        }
       }
     }
     else {
       if (*from > to) {
-	if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_ALLOW_EMPTY_RANGE_IN_CC))
-	  goto ccs_range_end;
-	else
-	  return ONIGERR_EMPTY_RANGE_IN_CHAR_CLASS;
+        if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_ALLOW_EMPTY_RANGE_IN_CC))
+          goto ccs_range_end;
+        else
+          return ONIGERR_EMPTY_RANGE_IN_CHAR_CLASS;
       }
       bitset_set_range(env, cc->bs, (int )*from, (int )(to < 0xff ? to : 0xff));
       r = add_code_range(&(cc->mbuf), env, (OnigCodePoint )*from, to);
       if (r < 0) return r;
       if (IS_NOT_NULL(asc_cc)) {
-	bitset_set_range(env, asc_cc->bs, (int )*from, (int )(to < 0xff ? to : 0xff));
-	r = add_code_range0(&(asc_cc->mbuf), env, (OnigCodePoint )*from, to, 0);
-	if (r < 0) return r;
+        bitset_set_range(env, asc_cc->bs, (int )*from, (int )(to < 0xff ? to : 0xff));
+        r = add_code_range0(&(asc_cc->mbuf), env, (OnigCodePoint )*from, to, 0);
+        if (r < 0) return r;
       }
     }
   ccs_range_end:
@@ -4662,7 +4662,7 @@ next_state_val(CClassNode* cc, CClassNode* asc_cc,
 
 static int
 code_exist_check(OnigCodePoint c, UChar* from, UChar* end, int ignore_escaped,
-		 ScanEnv* env)
+                 ScanEnv* env)
 {
   int in_esc;
   OnigCodePoint code;
@@ -4685,7 +4685,7 @@ code_exist_check(OnigCodePoint c, UChar* from, UChar* end, int ignore_escaped,
 
 static int
 parse_char_class(Node** np, Node** asc_np, OnigToken* tok, UChar** src, UChar* end,
-		 ScanEnv* env)
+                 ScanEnv* env)
 {
   int r, neg, len, fetched, and_start;
   OnigCodePoint v, vs;
@@ -4746,16 +4746,16 @@ parse_char_class(Node** np, Node** asc_np, OnigToken* tok, UChar** src, UChar* e
     switch (r) {
     case TK_CHAR:
       if ((tok->u.code >= SINGLE_BYTE_SIZE) ||
-	  (len = ONIGENC_CODE_TO_MBCLEN(env->enc, tok->u.c)) > 1) {
-	in_type = CCV_CODE_POINT;
+          (len = ONIGENC_CODE_TO_MBCLEN(env->enc, tok->u.c)) > 1) {
+        in_type = CCV_CODE_POINT;
       }
       else if (len < 0) {
-	r = len;
-	goto err;
+        r = len;
+        goto err;
       }
       else {
       sb_char:
-	in_type = CCV_SB;
+        in_type = CCV_SB;
       }
       v = (OnigCodePoint )tok->u.c;
       in_israw = 0;
@@ -4765,54 +4765,54 @@ parse_char_class(Node** np, Node** asc_np, OnigToken* tok, UChar** src, UChar* e
     case TK_RAW_BYTE:
       /* tok->base != 0 : octal or hexadec. */
       if (! ONIGENC_IS_SINGLEBYTE(env->enc) && tok->base != 0) {
-	UChar buf[ONIGENC_CODE_TO_MBC_MAXLEN];
-	UChar* bufe = buf + ONIGENC_CODE_TO_MBC_MAXLEN;
-	UChar* psave = p;
-	int i, base = tok->base;
+        UChar buf[ONIGENC_CODE_TO_MBC_MAXLEN];
+        UChar* bufe = buf + ONIGENC_CODE_TO_MBC_MAXLEN;
+        UChar* psave = p;
+        int i, base = tok->base;
 
-	buf[0] = (UChar )tok->u.c;
-	for (i = 1; i < ONIGENC_MBC_MAXLEN(env->enc); i++) {
-	  r = fetch_token_in_cc(tok, &p, end, env);
-	  if (r < 0) goto err;
-	  if (r != TK_RAW_BYTE || tok->base != base) {
-	    fetched = 1;
-	    break;
-	  }
-	  buf[i] = (UChar )tok->u.c;
-	}
+        buf[0] = (UChar )tok->u.c;
+        for (i = 1; i < ONIGENC_MBC_MAXLEN(env->enc); i++) {
+          r = fetch_token_in_cc(tok, &p, end, env);
+          if (r < 0) goto err;
+          if (r != TK_RAW_BYTE || tok->base != base) {
+            fetched = 1;
+            break;
+          }
+          buf[i] = (UChar )tok->u.c;
+        }
 
-	if (i < ONIGENC_MBC_MINLEN(env->enc)) {
-	  r = ONIGERR_TOO_SHORT_MULTI_BYTE_STRING;
-	  goto err;
-	}
+        if (i < ONIGENC_MBC_MINLEN(env->enc)) {
+          r = ONIGERR_TOO_SHORT_MULTI_BYTE_STRING;
+          goto err;
+        }
 
-	len = enclen(env->enc, buf, buf + i);
-	if (i < len) {
-	  r = ONIGERR_TOO_SHORT_MULTI_BYTE_STRING;
-	  goto err;
-	}
-	else if (i > len) { /* fetch back */
-	  p = psave;
-	  for (i = 1; i < len; i++) {
-	    (void)fetch_token_in_cc(tok, &p, end, env);
-	    /* no need to check the return value (already checked above) */
-	  }
-	  fetched = 0;
-	}
+        len = enclen(env->enc, buf, buf + i);
+        if (i < len) {
+          r = ONIGERR_TOO_SHORT_MULTI_BYTE_STRING;
+          goto err;
+        }
+        else if (i > len) { /* fetch back */
+          p = psave;
+          for (i = 1; i < len; i++) {
+            (void)fetch_token_in_cc(tok, &p, end, env);
+            /* no need to check the return value (already checked above) */
+          }
+          fetched = 0;
+        }
 
-	if (i == 1) {
-	  v = (OnigCodePoint )buf[0];
-	  goto raw_single;
-	}
-	else {
-	  v = ONIGENC_MBC_TO_CODE(env->enc, buf, bufe);
-	  in_type = CCV_CODE_POINT;
-	}
+        if (i == 1) {
+          v = (OnigCodePoint )buf[0];
+          goto raw_single;
+        }
+        else {
+          v = ONIGENC_MBC_TO_CODE(env->enc, buf, bufe);
+          in_type = CCV_CODE_POINT;
+        }
       }
       else {
-	v = (OnigCodePoint )tok->u.c;
+        v = (OnigCodePoint )tok->u.c;
       raw_single:
-	in_type = CCV_SB;
+        in_type = CCV_SB;
       }
       in_israw = 1;
       goto val_entry2;
@@ -4824,13 +4824,13 @@ parse_char_class(Node** np, Node** asc_np, OnigToken* tok, UChar** src, UChar* e
     val_entry:
       len = ONIGENC_CODE_TO_MBCLEN(env->enc, v);
       if (len < 0) {
-	r = len;
-	goto err;
+        r = len;
+        goto err;
       }
       in_type = (len == 1 ? CCV_SB : CCV_CODE_POINT);
     val_entry2:
       r = next_state_val(cc, asc_cc, &vs, v, &val_israw, in_israw, in_type, &val_type,
-			 &state, env);
+                         &state, env);
       if (r != 0) goto err;
       break;
 
@@ -4838,24 +4838,24 @@ parse_char_class(Node** np, Node** asc_np, OnigToken* tok, UChar** src, UChar* e
       r = parse_posix_bracket(cc, asc_cc, &p, end, env);
       if (r < 0) goto err;
       if (r == 1) {  /* is not POSIX bracket */
-	CC_ESC_WARN(env, (UChar* )"[");
-	p = tok->backp;
-	v = (OnigCodePoint )tok->u.c;
-	in_israw = 0;
-	goto val_entry;
+        CC_ESC_WARN(env, (UChar* )"[");
+        p = tok->backp;
+        v = (OnigCodePoint )tok->u.c;
+        in_israw = 0;
+        goto val_entry;
       }
       goto next_class;
       break;
 
     case TK_CHAR_TYPE:
       r = add_ctype_to_cc(cc, tok->u.prop.ctype, tok->u.prop.not,
-			  IS_ASCII_RANGE(env->option), env);
+                          IS_ASCII_RANGE(env->option), env);
       if (r != 0) return r;
       if (IS_NOT_NULL(asc_cc)) {
-	if (tok->u.prop.ctype != ONIGENC_CTYPE_WORD)
-	  r = add_ctype_to_cc(asc_cc, tok->u.prop.ctype, tok->u.prop.not,
-			      IS_ASCII_RANGE(env->option), env);
-	if (r != 0) return r;
+        if (tok->u.prop.ctype != ONIGENC_CTYPE_WORD)
+          r = add_ctype_to_cc(asc_cc, tok->u.prop.ctype, tok->u.prop.not,
+                              IS_ASCII_RANGE(env->option), env);
+        if (r != 0) return r;
       }
 
     next_class:
@@ -4865,133 +4865,133 @@ parse_char_class(Node** np, Node** asc_np, OnigToken* tok, UChar** src, UChar* e
 
     case TK_CHAR_PROPERTY:
       {
-	int ctype;
+        int ctype;
 
-	ctype = fetch_char_property_to_ctype(&p, end, env);
-	if (ctype < 0) return ctype;
-	r = add_ctype_to_cc(cc, ctype, tok->u.prop.not, 0, env);
-	if (r != 0) return r;
-	if (IS_NOT_NULL(asc_cc)) {
-	  if (ctype != ONIGENC_CTYPE_ASCII)
-	    r = add_ctype_to_cc(asc_cc, ctype, tok->u.prop.not, 0, env);
-	  if (r != 0) return r;
-	}
-	goto next_class;
+        ctype = fetch_char_property_to_ctype(&p, end, env);
+        if (ctype < 0) return ctype;
+        r = add_ctype_to_cc(cc, ctype, tok->u.prop.not, 0, env);
+        if (r != 0) return r;
+        if (IS_NOT_NULL(asc_cc)) {
+          if (ctype != ONIGENC_CTYPE_ASCII)
+            r = add_ctype_to_cc(asc_cc, ctype, tok->u.prop.not, 0, env);
+          if (r != 0) return r;
+        }
+        goto next_class;
       }
       break;
 
     case TK_CC_RANGE:
       if (state == CCS_VALUE) {
-	r = fetch_token_in_cc(tok, &p, end, env);
-	if (r < 0) goto err;
-	fetched = 1;
-	if (r == TK_CC_CLOSE) { /* allow [x-] */
-	range_end_val:
-	  v = (OnigCodePoint )'-';
-	  in_israw = 0;
-	  goto val_entry;
-	}
-	else if (r == TK_CC_AND) {
-	  CC_ESC_WARN(env, (UChar* )"-");
-	  goto range_end_val;
-	}
+        r = fetch_token_in_cc(tok, &p, end, env);
+        if (r < 0) goto err;
+        fetched = 1;
+        if (r == TK_CC_CLOSE) { /* allow [x-] */
+        range_end_val:
+          v = (OnigCodePoint )'-';
+          in_israw = 0;
+          goto val_entry;
+        }
+        else if (r == TK_CC_AND) {
+          CC_ESC_WARN(env, (UChar* )"-");
+          goto range_end_val;
+        }
 
-	if (val_type == CCV_CLASS) {
-	  r = ONIGERR_UNMATCHED_RANGE_SPECIFIER_IN_CHAR_CLASS;
-	  goto err;
-	}
+        if (val_type == CCV_CLASS) {
+          r = ONIGERR_UNMATCHED_RANGE_SPECIFIER_IN_CHAR_CLASS;
+          goto err;
+        }
 
-	state = CCS_RANGE;
+        state = CCS_RANGE;
       }
       else if (state == CCS_START) {
-	/* [-xa] is allowed */
-	v = (OnigCodePoint )tok->u.c;
-	in_israw = 0;
+        /* [-xa] is allowed */
+        v = (OnigCodePoint )tok->u.c;
+        in_israw = 0;
 
-	r = fetch_token_in_cc(tok, &p, end, env);
-	if (r < 0) goto err;
-	fetched = 1;
-	/* [--x] or [a&&-x] is warned. */
-	if (r == TK_CC_RANGE || and_start != 0)
-	  CC_ESC_WARN(env, (UChar* )"-");
+        r = fetch_token_in_cc(tok, &p, end, env);
+        if (r < 0) goto err;
+        fetched = 1;
+        /* [--x] or [a&&-x] is warned. */
+        if (r == TK_CC_RANGE || and_start != 0)
+          CC_ESC_WARN(env, (UChar* )"-");
 
-	goto val_entry;
+        goto val_entry;
       }
       else if (state == CCS_RANGE) {
-	CC_ESC_WARN(env, (UChar* )"-");
-	goto sb_char;  /* [!--x] is allowed */
+        CC_ESC_WARN(env, (UChar* )"-");
+        goto sb_char;  /* [!--x] is allowed */
       }
       else { /* CCS_COMPLETE */
-	r = fetch_token_in_cc(tok, &p, end, env);
-	if (r < 0) goto err;
-	fetched = 1;
-	if (r == TK_CC_CLOSE) goto range_end_val; /* allow [a-b-] */
-	else if (r == TK_CC_AND) {
-	  CC_ESC_WARN(env, (UChar* )"-");
-	  goto range_end_val;
-	}
+        r = fetch_token_in_cc(tok, &p, end, env);
+        if (r < 0) goto err;
+        fetched = 1;
+        if (r == TK_CC_CLOSE) goto range_end_val; /* allow [a-b-] */
+        else if (r == TK_CC_AND) {
+          CC_ESC_WARN(env, (UChar* )"-");
+          goto range_end_val;
+        }
 
-	if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_ALLOW_DOUBLE_RANGE_OP_IN_CC)) {
-	  CC_ESC_WARN(env, (UChar* )"-");
-	  goto range_end_val;   /* [0-9-a] is allowed as [0-9\-a] */
-	}
-	r = ONIGERR_UNMATCHED_RANGE_SPECIFIER_IN_CHAR_CLASS;
-	goto err;
+        if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_ALLOW_DOUBLE_RANGE_OP_IN_CC)) {
+          CC_ESC_WARN(env, (UChar* )"-");
+          goto range_end_val;   /* [0-9-a] is allowed as [0-9\-a] */
+        }
+        r = ONIGERR_UNMATCHED_RANGE_SPECIFIER_IN_CHAR_CLASS;
+        goto err;
       }
       break;
 
     case TK_CC_CC_OPEN: /* [ */
       {
-	Node *anode, *aasc_node;
-	CClassNode* acc;
+        Node *anode, *aasc_node;
+        CClassNode* acc;
 
-	r = parse_char_class(&anode, &aasc_node, tok, &p, end, env);
-	if (r == 0) {
-	  acc = NCCLASS(anode);
-	  r = or_cclass(cc, acc, env);
-	}
-	if (r == 0 && IS_NOT_NULL(aasc_node)) {
-	  acc = NCCLASS(aasc_node);
-	  r = or_cclass(asc_cc, acc, env);
-	}
-	onig_node_free(anode);
-	onig_node_free(aasc_node);
-	if (r != 0) goto err;
+        r = parse_char_class(&anode, &aasc_node, tok, &p, end, env);
+        if (r == 0) {
+          acc = NCCLASS(anode);
+          r = or_cclass(cc, acc, env);
+        }
+        if (r == 0 && IS_NOT_NULL(aasc_node)) {
+          acc = NCCLASS(aasc_node);
+          r = or_cclass(asc_cc, acc, env);
+        }
+        onig_node_free(anode);
+        onig_node_free(aasc_node);
+        if (r != 0) goto err;
       }
       break;
 
     case TK_CC_AND: /* && */
       {
-	if (state == CCS_VALUE) {
-	  r = next_state_val(cc, asc_cc, &vs, 0, &val_israw, 0, val_type,
-			     &val_type, &state, env);
-	  if (r != 0) goto err;
-	}
-	/* initialize local variables */
-	and_start = 1;
-	state = CCS_START;
+        if (state == CCS_VALUE) {
+          r = next_state_val(cc, asc_cc, &vs, 0, &val_israw, 0, val_type,
+                             &val_type, &state, env);
+          if (r != 0) goto err;
+        }
+        /* initialize local variables */
+        and_start = 1;
+        state = CCS_START;
 
-	if (IS_NOT_NULL(prev_cc)) {
-	  r = and_cclass(prev_cc, cc, env);
-	  if (r != 0) goto err;
-	  bbuf_free(cc->mbuf);
-	  if (IS_NOT_NULL(asc_cc)) {
-	    r = and_cclass(asc_prev_cc, asc_cc, env);
-	    if (r != 0) goto err;
-	    bbuf_free(asc_cc->mbuf);
-	  }
-	}
-	else {
-	  prev_cc = cc;
-	  cc = &work_cc;
-	  if (IS_NOT_NULL(asc_cc)) {
-	    asc_prev_cc = asc_cc;
-	    asc_cc = &asc_work_cc;
-	  }
-	}
-	initialize_cclass(cc);
-	if (IS_NOT_NULL(asc_cc))
-	  initialize_cclass(asc_cc);
+        if (IS_NOT_NULL(prev_cc)) {
+          r = and_cclass(prev_cc, cc, env);
+          if (r != 0) goto err;
+          bbuf_free(cc->mbuf);
+          if (IS_NOT_NULL(asc_cc)) {
+            r = and_cclass(asc_prev_cc, asc_cc, env);
+            if (r != 0) goto err;
+            bbuf_free(asc_cc->mbuf);
+          }
+        }
+        else {
+          prev_cc = cc;
+          cc = &work_cc;
+          if (IS_NOT_NULL(asc_cc)) {
+            asc_prev_cc = asc_cc;
+            asc_cc = &asc_work_cc;
+          }
+        }
+        initialize_cclass(cc);
+        if (IS_NOT_NULL(asc_cc))
+          initialize_cclass(asc_cc);
       }
       break;
 
@@ -5015,7 +5015,7 @@ parse_char_class(Node** np, Node** asc_np, OnigToken* tok, UChar** src, UChar* e
 
   if (state == CCS_VALUE) {
     r = next_state_val(cc, asc_cc, &vs, 0, &val_israw, 0, val_type,
-		       &val_type, &state, env);
+                       &val_type, &state, env);
     if (r != 0) goto err;
   }
 
@@ -5054,12 +5054,12 @@ parse_char_class(Node** np, Node** asc_np, OnigToken* tok, UChar** src, UChar* e
 #define NEWLINE_CODE    0x0a
 
       if (ONIGENC_IS_CODE_NEWLINE(env->enc, NEWLINE_CODE)) {
-	if (ONIGENC_CODE_TO_MBCLEN(env->enc, NEWLINE_CODE) == 1)
-	  BITSET_SET_BIT_CHKDUP(cc->bs, NEWLINE_CODE);
-	else {
-	  r = add_code_range(&(cc->mbuf), env, NEWLINE_CODE, NEWLINE_CODE);
-	  if (r < 0) goto err;
-	}
+        if (ONIGENC_CODE_TO_MBCLEN(env->enc, NEWLINE_CODE) == 1)
+          BITSET_SET_BIT_CHKDUP(cc->bs, NEWLINE_CODE);
+        else {
+          r = add_code_range(&(cc->mbuf), env, NEWLINE_CODE, NEWLINE_CODE);
+          if (r < 0) goto err;
+        }
       }
     }
   }
@@ -5076,11 +5076,11 @@ parse_char_class(Node** np, Node** asc_np, OnigToken* tok, UChar** src, UChar* e
 }
 
 static int parse_subexp(Node** top, OnigToken* tok, int term,
-			UChar** src, UChar* end, ScanEnv* env);
+                        UChar** src, UChar* end, ScanEnv* env);
 
 static int
 parse_enclose(Node** np, OnigToken* tok, int term, UChar** src, UChar* end,
-	      ScanEnv* env)
+              ScanEnv* env)
 {
   int r = 0, num;
   Node *target, *work1 = NULL, *work2 = NULL;
@@ -5127,28 +5127,28 @@ parse_enclose(Node** np, OnigToken* tok, int term, UChar** src, UChar* end,
       break;
     case '~':   /* (?~...) absent operator */
       if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_TILDE_ABSENT)) {
-	*np = node_new_enclose(ENCLOSE_ABSENT);
+        *np = node_new_enclose(ENCLOSE_ABSENT);
       }
       else {
-	return ONIGERR_UNDEFINED_GROUP_OPTION;
+        return ONIGERR_UNDEFINED_GROUP_OPTION;
       }
       break;
 
 #ifdef USE_NAMED_GROUP
     case '\'':
       if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_LT_NAMED_GROUP)) {
-	goto named_group1;
+        goto named_group1;
       }
       else
-	return ONIGERR_UNDEFINED_GROUP_OPTION;
+        return ONIGERR_UNDEFINED_GROUP_OPTION;
       break;
 
 # ifdef USE_CAPITAL_P_NAMED_GROUP
     case 'P':   /* (?P<name>...) */
       if (!PEND &&
-	  IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_CAPITAL_P_NAMED_GROUP)) {
-	PFETCH(c);
-	if (c == '<') goto named_group1;
+          IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_CAPITAL_P_NAMED_GROUP)) {
+        PFETCH(c);
+        if (c == '<') goto named_group1;
       }
       return ONIGERR_UNDEFINED_GROUP_OPTION;
       break;
@@ -5159,49 +5159,49 @@ parse_enclose(Node** np, OnigToken* tok, int term, UChar** src, UChar* end,
       if (PEND) return ONIGERR_END_PATTERN_WITH_UNMATCHED_PARENTHESIS;
       PFETCH(c);
       if (c == '=')
-	*np = onig_node_new_anchor(ANCHOR_LOOK_BEHIND);
+        *np = onig_node_new_anchor(ANCHOR_LOOK_BEHIND);
       else if (c == '!')
-	*np = onig_node_new_anchor(ANCHOR_LOOK_BEHIND_NOT);
+        *np = onig_node_new_anchor(ANCHOR_LOOK_BEHIND_NOT);
 #ifdef USE_NAMED_GROUP
       else {    /* (?<name>...) */
-	if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_LT_NAMED_GROUP)) {
-	  UChar *name;
-	  UChar *name_end;
+        if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_LT_NAMED_GROUP)) {
+          UChar *name;
+          UChar *name_end;
 
-	  PUNFETCH;
-	  c = '<';
+          PUNFETCH;
+          c = '<';
 
-	named_group1:
-	  list_capture = 0;
+        named_group1:
+          list_capture = 0;
 
 # ifdef USE_CAPTURE_HISTORY
-	named_group2:
+        named_group2:
 # endif
-	  name = p;
-	  r = fetch_name((OnigCodePoint )c, &p, end, &name_end, env, &num, 0);
-	  if (r < 0) return r;
+          name = p;
+          r = fetch_name((OnigCodePoint )c, &p, end, &name_end, env, &num, 0);
+          if (r < 0) return r;
 
-	  num = scan_env_add_mem_entry(env);
-	  if (num < 0) return num;
-	  if (list_capture != 0 && num >= (int )BIT_STATUS_BITS_NUM)
-	    return ONIGERR_GROUP_NUMBER_OVER_FOR_CAPTURE_HISTORY;
+          num = scan_env_add_mem_entry(env);
+          if (num < 0) return num;
+          if (list_capture != 0 && num >= (int )BIT_STATUS_BITS_NUM)
+            return ONIGERR_GROUP_NUMBER_OVER_FOR_CAPTURE_HISTORY;
 
-	  r = name_add(env->reg, name, name_end, num, env);
-	  if (r != 0) return r;
-	  *np = node_new_enclose_memory(env->option, 1);
-	  CHECK_NULL_RETURN_MEMERR(*np);
-	  NENCLOSE(*np)->regnum = num;
-	  if (list_capture != 0)
-	    BIT_STATUS_ON_AT_SIMPLE(env->capture_history, num);
-	  env->num_named++;
-	}
-	else {
-	  return ONIGERR_UNDEFINED_GROUP_OPTION;
-	}
+          r = name_add(env->reg, name, name_end, num, env);
+          if (r != 0) return r;
+          *np = node_new_enclose_memory(env->option, 1);
+          CHECK_NULL_RETURN_MEMERR(*np);
+          NENCLOSE(*np)->regnum = num;
+          if (list_capture != 0)
+            BIT_STATUS_ON_AT_SIMPLE(env->capture_history, num);
+          env->num_named++;
+        }
+        else {
+          return ONIGERR_UNDEFINED_GROUP_OPTION;
+        }
       }
 #else
       else {
-	return ONIGERR_UNDEFINED_GROUP_OPTION;
+        return ONIGERR_UNDEFINED_GROUP_OPTION;
       }
 #endif
       break;
@@ -5210,122 +5210,122 @@ parse_enclose(Node** np, OnigToken* tok, int term, UChar** src, UChar* end,
     case '@':
       if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_ATMARK_CAPTURE_HISTORY)) {
 # ifdef USE_NAMED_GROUP
-	if (!PEND &&
-	    IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_LT_NAMED_GROUP)) {
-	  PFETCH(c);
-	  if (c == '<' || c == '\'') {
-	    list_capture = 1;
-	    goto named_group2; /* (?@<name>...) */
-	  }
-	  PUNFETCH;
-	}
+        if (!PEND &&
+            IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_LT_NAMED_GROUP)) {
+          PFETCH(c);
+          if (c == '<' || c == '\'') {
+            list_capture = 1;
+            goto named_group2; /* (?@<name>...) */
+          }
+          PUNFETCH;
+        }
 # endif
-	*np = node_new_enclose_memory(env->option, 0);
-	CHECK_NULL_RETURN_MEMERR(*np);
-	num = scan_env_add_mem_entry(env);
-	if (num < 0) return num;
-	if (num >= (int )BIT_STATUS_BITS_NUM)
-	  return ONIGERR_GROUP_NUMBER_OVER_FOR_CAPTURE_HISTORY;
+        *np = node_new_enclose_memory(env->option, 0);
+        CHECK_NULL_RETURN_MEMERR(*np);
+        num = scan_env_add_mem_entry(env);
+        if (num < 0) return num;
+        if (num >= (int )BIT_STATUS_BITS_NUM)
+          return ONIGERR_GROUP_NUMBER_OVER_FOR_CAPTURE_HISTORY;
 
-	NENCLOSE(*np)->regnum = num;
-	BIT_STATUS_ON_AT_SIMPLE(env->capture_history, num);
+        NENCLOSE(*np)->regnum = num;
+        BIT_STATUS_ON_AT_SIMPLE(env->capture_history, num);
       }
       else {
-	return ONIGERR_UNDEFINED_GROUP_OPTION;
+        return ONIGERR_UNDEFINED_GROUP_OPTION;
       }
       break;
 #endif /* USE_CAPTURE_HISTORY */
 
     case '(':   /* conditional expression: (?(cond)yes), (?(cond)yes|no) */
       if (!PEND &&
-	  IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_LPAREN_CONDITION)) {
-	UChar *name = NULL;
-	UChar *name_end;
-	PFETCH(c);
-	if (ONIGENC_IS_CODE_DIGIT(enc, c)) {     /* (n) */
-	  PUNFETCH;
-	  r = fetch_name((OnigCodePoint )'(', &p, end, &name_end, env, &num, 1);
-	  if (r < 0) return r;
+          IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_LPAREN_CONDITION)) {
+        UChar *name = NULL;
+        UChar *name_end;
+        PFETCH(c);
+        if (ONIGENC_IS_CODE_DIGIT(enc, c)) {     /* (n) */
+          PUNFETCH;
+          r = fetch_name((OnigCodePoint )'(', &p, end, &name_end, env, &num, 1);
+          if (r < 0) return r;
 #if 0
-	  /* Relative number is not currently supported. (same as Perl) */
-	  if (num < 0) {
-	    num = BACKREF_REL_TO_ABS(num, env);
-	    if (num <= 0)
-	      return ONIGERR_INVALID_BACKREF;
-	  }
+          /* Relative number is not currently supported. (same as Perl) */
+          if (num < 0) {
+            num = BACKREF_REL_TO_ABS(num, env);
+            if (num <= 0)
+              return ONIGERR_INVALID_BACKREF;
+          }
 #endif
-	  if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_STRICT_CHECK_BACKREF)) {
-	    if (num > env->num_mem ||
-		IS_NULL(SCANENV_MEM_NODES(env)[num]))
-	    return ONIGERR_INVALID_BACKREF;
-	  }
-	}
+          if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_STRICT_CHECK_BACKREF)) {
+            if (num > env->num_mem ||
+                IS_NULL(SCANENV_MEM_NODES(env)[num]))
+            return ONIGERR_INVALID_BACKREF;
+          }
+        }
 #ifdef USE_NAMED_GROUP
-	else if (c == '<' || c == '\'') {    /* (<name>), ('name') */
-	  name = p;
-	  r = fetch_named_backref_token(c, tok, &p, end, env);
-	  if (r < 0) return r;
-	  if (!PPEEK_IS(')')) return ONIGERR_UNDEFINED_GROUP_OPTION;
-	  PINC;
+        else if (c == '<' || c == '\'') {    /* (<name>), ('name') */
+          name = p;
+          r = fetch_named_backref_token(c, tok, &p, end, env);
+          if (r < 0) return r;
+          if (!PPEEK_IS(')')) return ONIGERR_UNDEFINED_GROUP_OPTION;
+          PINC;
 
-	  if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_USE_LEFT_MOST_NAMED_GROUP)) {
-	    num = tok->u.backref.ref1;
-	  }
-	  else {
-	    /* FIXME:
-	     * Use left most named group for now. This is the same as Perl.
-	     * However this should use the same strategy as normal back-
-	     * references on Ruby syntax; search right to left. */
-	    int len = tok->u.backref.num;
-	    num = len > 1 ? tok->u.backref.refs[0] : tok->u.backref.ref1;
-	  }
-	}
+          if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_USE_LEFT_MOST_NAMED_GROUP)) {
+            num = tok->u.backref.ref1;
+          }
+          else {
+            /* FIXME:
+             * Use left most named group for now. This is the same as Perl.
+             * However this should use the same strategy as normal back-
+             * references on Ruby syntax; search right to left. */
+            int len = tok->u.backref.num;
+            num = len > 1 ? tok->u.backref.refs[0] : tok->u.backref.ref1;
+          }
+        }
 #endif
-	else
-	  return ONIGERR_INVALID_CONDITION_PATTERN;
-	*np = node_new_enclose(ENCLOSE_CONDITION);
-	CHECK_NULL_RETURN_MEMERR(*np);
-	NENCLOSE(*np)->regnum = num;
-	if (IS_NOT_NULL(name)) NENCLOSE(*np)->state |= NST_NAME_REF;
+        else
+          return ONIGERR_INVALID_CONDITION_PATTERN;
+        *np = node_new_enclose(ENCLOSE_CONDITION);
+        CHECK_NULL_RETURN_MEMERR(*np);
+        NENCLOSE(*np)->regnum = num;
+        if (IS_NOT_NULL(name)) NENCLOSE(*np)->state |= NST_NAME_REF;
       }
       else
-	return ONIGERR_UNDEFINED_GROUP_OPTION;
+        return ONIGERR_UNDEFINED_GROUP_OPTION;
       break;
 
 #if 0
     case '|':   /* branch reset: (?|...) */
       if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_QMARK_VBAR_BRANCH_RESET)) {
-	/* TODO */
+        /* TODO */
       }
       else
-	return ONIGERR_UNDEFINED_GROUP_OPTION;
+        return ONIGERR_UNDEFINED_GROUP_OPTION;
       break;
 #endif
 
     case '^':   /* loads default options */
       if (!PEND && IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL)) {
-	/* d-imsx */
-	ONOFF(option, ONIG_OPTION_ASCII_RANGE, 1);
-	ONOFF(option, ONIG_OPTION_IGNORECASE, 1);
-	ONOFF(option, ONIG_OPTION_SINGLELINE, 0);
-	ONOFF(option, ONIG_OPTION_MULTILINE,  1);
-	ONOFF(option, ONIG_OPTION_EXTEND, 1);
-	PFETCH(c);
+        /* d-imsx */
+        ONOFF(option, ONIG_OPTION_ASCII_RANGE, 1);
+        ONOFF(option, ONIG_OPTION_IGNORECASE, 1);
+        ONOFF(option, ONIG_OPTION_SINGLELINE, 0);
+        ONOFF(option, ONIG_OPTION_MULTILINE,  1);
+        ONOFF(option, ONIG_OPTION_EXTEND, 1);
+        PFETCH(c);
       }
 #if 0
       else if (!PEND && IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_RUBY)) {
-	/* d-imx */
-	ONOFF(option, ONIG_OPTION_ASCII_RANGE, 0);
-	ONOFF(option, ONIG_OPTION_POSIX_BRACKET_ALL_RANGE, 0);
-	ONOFF(option, ONIG_OPTION_WORD_BOUND_ALL_RANGE, 0);
-	ONOFF(option, ONIG_OPTION_IGNORECASE, 1);
-	ONOFF(option, ONIG_OPTION_MULTILINE,  1);
-	ONOFF(option, ONIG_OPTION_EXTEND, 1);
-	PFETCH(c);
+        /* d-imx */
+        ONOFF(option, ONIG_OPTION_ASCII_RANGE, 0);
+        ONOFF(option, ONIG_OPTION_POSIX_BRACKET_ALL_RANGE, 0);
+        ONOFF(option, ONIG_OPTION_WORD_BOUND_ALL_RANGE, 0);
+        ONOFF(option, ONIG_OPTION_IGNORECASE, 1);
+        ONOFF(option, ONIG_OPTION_MULTILINE,  1);
+        ONOFF(option, ONIG_OPTION_EXTEND, 1);
+        PFETCH(c);
       }
 #endif
       else {
-	return ONIGERR_UNDEFINED_GROUP_OPTION;
+        return ONIGERR_UNDEFINED_GROUP_OPTION;
       }
       /* fall through */
 #ifdef USE_POSIXLINE_OPTION
@@ -5334,120 +5334,120 @@ parse_enclose(Node** np, OnigToken* tok, int term, UChar** src, UChar* end,
     case '-': case 'i': case 'm': case 's': case 'x':
     case 'a': case 'd': case 'l': case 'u':
       {
-	int neg = 0;
+        int neg = 0;
 
-	while (1) {
-	  switch (c) {
-	  case ':':
-	  case ')':
-	  break;
+        while (1) {
+          switch (c) {
+          case ':':
+          case ')':
+          break;
 
-	  case '-':  neg = 1; break;
-	  case 'x':  ONOFF(option, ONIG_OPTION_EXTEND,     neg); break;
-	  case 'i':  ONOFF(option, ONIG_OPTION_IGNORECASE, neg); break;
-	  case 's':
-	    if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL)) {
-	      ONOFF(option, ONIG_OPTION_MULTILINE,  neg);
-	    }
-	    else
-	      return ONIGERR_UNDEFINED_GROUP_OPTION;
-	    break;
+          case '-':  neg = 1; break;
+          case 'x':  ONOFF(option, ONIG_OPTION_EXTEND,     neg); break;
+          case 'i':  ONOFF(option, ONIG_OPTION_IGNORECASE, neg); break;
+          case 's':
+            if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL)) {
+              ONOFF(option, ONIG_OPTION_MULTILINE,  neg);
+            }
+            else
+              return ONIGERR_UNDEFINED_GROUP_OPTION;
+            break;
 
-	  case 'm':
-	    if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL)) {
-	      ONOFF(option, ONIG_OPTION_SINGLELINE, (neg == 0 ? 1 : 0));
-	    }
-	    else if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_RUBY)) {
-	      ONOFF(option, ONIG_OPTION_MULTILINE,  neg);
-	    }
-	    else
-	      return ONIGERR_UNDEFINED_GROUP_OPTION;
-	    break;
+          case 'm':
+            if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL)) {
+              ONOFF(option, ONIG_OPTION_SINGLELINE, (neg == 0 ? 1 : 0));
+            }
+            else if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_RUBY)) {
+              ONOFF(option, ONIG_OPTION_MULTILINE,  neg);
+            }
+            else
+              return ONIGERR_UNDEFINED_GROUP_OPTION;
+            break;
 #ifdef USE_POSIXLINE_OPTION
-	  case 'p':
-	    ONOFF(option, ONIG_OPTION_MULTILINE|ONIG_OPTION_SINGLELINE, neg);
-	    break;
+          case 'p':
+            ONOFF(option, ONIG_OPTION_MULTILINE|ONIG_OPTION_SINGLELINE, neg);
+            break;
 #endif
 
-	  case 'a':     /* limits \d, \s, \w and POSIX brackets to ASCII range */
-	    if ((IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL) ||
-		 IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_RUBY)) &&
-		(neg == 0)) {
-	      ONOFF(option, ONIG_OPTION_ASCII_RANGE, 0);
-	      ONOFF(option, ONIG_OPTION_POSIX_BRACKET_ALL_RANGE, 1);
-	      ONOFF(option, ONIG_OPTION_WORD_BOUND_ALL_RANGE, 1);
-	    }
-	    else
-	      return ONIGERR_UNDEFINED_GROUP_OPTION;
-	    break;
+          case 'a':     /* limits \d, \s, \w and POSIX brackets to ASCII range */
+            if ((IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL) ||
+                 IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_RUBY)) &&
+                (neg == 0)) {
+              ONOFF(option, ONIG_OPTION_ASCII_RANGE, 0);
+              ONOFF(option, ONIG_OPTION_POSIX_BRACKET_ALL_RANGE, 1);
+              ONOFF(option, ONIG_OPTION_WORD_BOUND_ALL_RANGE, 1);
+            }
+            else
+              return ONIGERR_UNDEFINED_GROUP_OPTION;
+            break;
 
-	  case 'u':
-	    if ((IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL) ||
-		 IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_RUBY)) &&
-		(neg == 0)) {
-	      ONOFF(option, ONIG_OPTION_ASCII_RANGE, 1);
-	      ONOFF(option, ONIG_OPTION_POSIX_BRACKET_ALL_RANGE, 1);
-	      ONOFF(option, ONIG_OPTION_WORD_BOUND_ALL_RANGE, 1);
-	    }
-	    else
-	      return ONIGERR_UNDEFINED_GROUP_OPTION;
-	    break;
+          case 'u':
+            if ((IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL) ||
+                 IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_RUBY)) &&
+                (neg == 0)) {
+              ONOFF(option, ONIG_OPTION_ASCII_RANGE, 1);
+              ONOFF(option, ONIG_OPTION_POSIX_BRACKET_ALL_RANGE, 1);
+              ONOFF(option, ONIG_OPTION_WORD_BOUND_ALL_RANGE, 1);
+            }
+            else
+              return ONIGERR_UNDEFINED_GROUP_OPTION;
+            break;
 
-	  case 'd':
-	    if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL) &&
-		(neg == 0)) {
-	      ONOFF(option, ONIG_OPTION_ASCII_RANGE, 1);
-	    }
-	    else if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_RUBY) &&
-		(neg == 0)) {
-	      ONOFF(option, ONIG_OPTION_ASCII_RANGE, 0);
-	      ONOFF(option, ONIG_OPTION_POSIX_BRACKET_ALL_RANGE, 0);
-	      ONOFF(option, ONIG_OPTION_WORD_BOUND_ALL_RANGE, 0);
-	    }
-	    else
-	      return ONIGERR_UNDEFINED_GROUP_OPTION;
-	    break;
+          case 'd':
+            if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL) &&
+                (neg == 0)) {
+              ONOFF(option, ONIG_OPTION_ASCII_RANGE, 1);
+            }
+            else if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_RUBY) &&
+                (neg == 0)) {
+              ONOFF(option, ONIG_OPTION_ASCII_RANGE, 0);
+              ONOFF(option, ONIG_OPTION_POSIX_BRACKET_ALL_RANGE, 0);
+              ONOFF(option, ONIG_OPTION_WORD_BOUND_ALL_RANGE, 0);
+            }
+            else
+              return ONIGERR_UNDEFINED_GROUP_OPTION;
+            break;
 
-	  case 'l':
-	    if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL) && (neg == 0)) {
-	      ONOFF(option, ONIG_OPTION_ASCII_RANGE, 1);
-	    }
-	    else
-	      return ONIGERR_UNDEFINED_GROUP_OPTION;
-	    break;
+          case 'l':
+            if (IS_SYNTAX_OP2(env->syntax, ONIG_SYN_OP2_OPTION_PERL) && (neg == 0)) {
+              ONOFF(option, ONIG_OPTION_ASCII_RANGE, 1);
+            }
+            else
+              return ONIGERR_UNDEFINED_GROUP_OPTION;
+            break;
 
-	  default:
-	    return ONIGERR_UNDEFINED_GROUP_OPTION;
-	  }
+          default:
+            return ONIGERR_UNDEFINED_GROUP_OPTION;
+          }
 
-	  if (c == ')') {
-	    *np = node_new_option(option);
-	    CHECK_NULL_RETURN_MEMERR(*np);
-	    *src = p;
-	    return 2; /* option only */
-	  }
-	  else if (c == ':') {
-	    OnigOptionType prev = env->option;
+          if (c == ')') {
+            *np = node_new_option(option);
+            CHECK_NULL_RETURN_MEMERR(*np);
+            *src = p;
+            return 2; /* option only */
+          }
+          else if (c == ':') {
+            OnigOptionType prev = env->option;
 
-	    env->option = option;
-	    r = fetch_token(tok, &p, end, env);
-	    if (r < 0) {
-	      env->option = prev;
-	      return r;
-	    }
-	    r = parse_subexp(&target, tok, term, &p, end, env);
-	    env->option = prev;
-	    if (r < 0) return r;
-	    *np = node_new_option(option);
-	    CHECK_NULL_RETURN_MEMERR(*np);
-	    NENCLOSE(*np)->target = target;
-	    *src = p;
-	    return 0;
-	  }
+            env->option = option;
+            r = fetch_token(tok, &p, end, env);
+            if (r < 0) {
+              env->option = prev;
+              return r;
+            }
+            r = parse_subexp(&target, tok, term, &p, end, env);
+            env->option = prev;
+            if (r < 0) return r;
+            *np = node_new_option(option);
+            CHECK_NULL_RETURN_MEMERR(*np);
+            NENCLOSE(*np)->target = target;
+            *src = p;
+            return 0;
+          }
 
-	  if (PEND) return ONIGERR_END_PATTERN_IN_GROUP;
-	  PFETCH(c);
-	}
+          if (PEND) return ONIGERR_END_PATTERN_IN_GROUP;
+          PFETCH(c);
+        }
       }
       break;
 
@@ -5486,14 +5486,14 @@ parse_enclose(Node** np, OnigToken* tok, int term, UChar** src, UChar* end,
     }
     else if (NENCLOSE(*np)->type == ENCLOSE_CONDITION) {
       if (NTYPE(target) != NT_ALT) {
-	/* convert (?(cond)yes) to (?(cond)yes|empty) */
-	work1 = node_new_empty();
-	if (IS_NULL(work1)) goto err;
-	work2 = onig_node_new_alt(work1, NULL_NODE);
-	if (IS_NULL(work2)) goto err;
-	work1 = onig_node_new_alt(target, work2);
-	if (IS_NULL(work1)) goto err;
-	NENCLOSE(*np)->target = work1;
+        /* convert (?(cond)yes) to (?(cond)yes|empty) */
+        work1 = node_new_empty();
+        if (IS_NULL(work1)) goto err;
+        work2 = onig_node_new_alt(work1, NULL_NODE);
+        if (IS_NULL(work2)) goto err;
+        work1 = onig_node_new_alt(target, work2);
+        if (IS_NULL(work1)) goto err;
+        NENCLOSE(*np)->target = work1;
       }
     }
   }
@@ -5532,11 +5532,11 @@ set_quantifier(Node* qnode, Node* target, int group, ScanEnv* env)
     if (! group) {
       StrNode* sn = NSTR(target);
       if (str_node_can_be_split(sn, env->enc)) {
-	Node* n = str_node_split_last_char(sn, env->enc);
-	if (IS_NOT_NULL(n)) {
-	  qn->target = n;
-	  return 2;
-	}
+        Node* n = str_node_split_last_char(sn, env->enc);
+        if (IS_NOT_NULL(n)) {
+          qn->target = n;
+          return 2;
+        }
       }
     }
     break;
@@ -5550,43 +5550,43 @@ set_quantifier(Node* qnode, Node* target, int group, ScanEnv* env)
 
 #ifdef USE_WARNING_REDUNDANT_NESTED_REPEAT_OPERATOR
       if (nestq_num >= 0 && targetq_num >= 0 &&
-	  IS_SYNTAX_BV(env->syntax, ONIG_SYN_WARN_REDUNDANT_NESTED_REPEAT)) {
-	switch (ReduceTypeTable[targetq_num][nestq_num]) {
-	case RQ_ASIS:
-	  break;
+          IS_SYNTAX_BV(env->syntax, ONIG_SYN_WARN_REDUNDANT_NESTED_REPEAT)) {
+        switch (ReduceTypeTable[targetq_num][nestq_num]) {
+        case RQ_ASIS:
+          break;
 
-	case RQ_DEL:
-	  if (onig_warn != onig_null_warn) {
-	    onig_syntax_warn(env, "regular expression has redundant nested repeat operator '%s'",
-		PopularQStr[targetq_num]);
-	  }
-	  goto warn_exit;
-	  break;
+        case RQ_DEL:
+          if (onig_warn != onig_null_warn) {
+            onig_syntax_warn(env, "regular expression has redundant nested repeat operator '%s'",
+                PopularQStr[targetq_num]);
+          }
+          goto warn_exit;
+          break;
 
-	default:
-	  if (onig_warn != onig_null_warn) {
-	    onig_syntax_warn(env, "nested repeat operator '%s' and '%s' was replaced with '%s' in regular expression",
-		PopularQStr[targetq_num], PopularQStr[nestq_num],
-		ReduceQStr[ReduceTypeTable[targetq_num][nestq_num]]);
-	  }
-	  goto warn_exit;
-	  break;
-	}
+        default:
+          if (onig_warn != onig_null_warn) {
+            onig_syntax_warn(env, "nested repeat operator '%s' and '%s' was replaced with '%s' in regular expression",
+                PopularQStr[targetq_num], PopularQStr[nestq_num],
+                ReduceQStr[ReduceTypeTable[targetq_num][nestq_num]]);
+          }
+          goto warn_exit;
+          break;
+        }
       }
 
     warn_exit:
 #endif
       if (targetq_num >= 0) {
-	if (nestq_num >= 0) {
-	  onig_reduce_nested_quantifier(qnode, target);
-	  goto q_exit;
-	}
-	else if (targetq_num == 1 || targetq_num == 2) { /* * or + */
-	  /* (?:a*){n,m}, (?:a+){n,m} => (?:a*){n,n}, (?:a+){n,n} */
-	  if (! IS_REPEAT_INFINITE(qn->upper) && qn->upper > 1 && qn->greedy) {
-	    qn->upper = (qn->lower == 0 ? 1 : qn->lower);
-	  }
-	}
+        if (nestq_num >= 0) {
+          onig_reduce_nested_quantifier(qnode, target);
+          goto q_exit;
+        }
+        else if (targetq_num == 1 || targetq_num == 2) { /* * or + */
+          /* (?:a*){n,m}, (?:a+){n,m} => (?:a*){n,n}, (?:a+){n,n} */
+          if (! IS_REPEAT_INFINITE(qn->upper) && qn->upper > 1 && qn->greedy) {
+            qn->upper = (qn->lower == 0 ? 1 : qn->lower);
+          }
+        }
       }
     }
     break;
@@ -5652,7 +5652,7 @@ typedef struct {
 
 static int
 i_apply_case_fold(OnigCodePoint from, OnigCodePoint to[],
-		  int to_len, void* arg)
+                  int to_len, void* arg)
 {
   IApplyCaseFoldArg* iarg;
   ScanEnv* env;
@@ -5683,7 +5683,7 @@ i_apply_case_fold(OnigCodePoint from, OnigCodePoint to[],
     int is_in = onig_is_code_in_cc(env->enc, from, cc);
 #ifdef CASE_FOLD_IS_APPLIED_INSIDE_NEGATIVE_CCLASS
     if ((is_in != 0 && !IS_NCCLASS_NOT(cc)) ||
-	(is_in == 0 &&  IS_NCCLASS_NOT(cc))) {
+        (is_in == 0 &&  IS_NCCLASS_NOT(cc))) {
       if (add_flag) {
         if (is_singlebyte_range(*to, env->enc)) {
           BITSET_SET_BIT(bs, *to);
@@ -5721,26 +5721,26 @@ i_apply_case_fold(OnigCodePoint from, OnigCodePoint to[],
 
     if (onig_is_code_in_cc(env->enc, from, cc)
 #ifdef CASE_FOLD_IS_APPLIED_INSIDE_NEGATIVE_CCLASS
-	&& !IS_NCCLASS_NOT(cc)
+        && !IS_NCCLASS_NOT(cc)
 #endif
-	) {
+        ) {
       for (i = 0; i < to_len; i++) {
-	len = ONIGENC_CODE_TO_MBC(env->enc, to[i], buf);
-	if (i == 0) {
-	  snode = onig_node_new_str(buf, buf + len);
-	  CHECK_NULL_RETURN_MEMERR(snode);
+        len = ONIGENC_CODE_TO_MBC(env->enc, to[i], buf);
+        if (i == 0) {
+          snode = onig_node_new_str(buf, buf + len);
+          CHECK_NULL_RETURN_MEMERR(snode);
 
-	  /* char-class expanded multi-char only
-	     compare with string folded at match time. */
-	  NSTRING_SET_AMBIG(snode);
-	}
-	else {
-	  r = onig_node_str_cat(snode, buf, buf + len);
-	  if (r < 0) {
-	    onig_node_free(snode);
-	    return r;
-	  }
-	}
+          /* char-class expanded multi-char only
+             compare with string folded at match time. */
+          NSTRING_SET_AMBIG(snode);
+        }
+        else {
+          r = onig_node_str_cat(snode, buf, buf + len);
+          if (r < 0) {
+            onig_node_free(snode);
+            return r;
+          }
+        }
       }
 
       *(iarg->ptail) = onig_node_new_alt(snode, NULL_NODE);
@@ -5765,7 +5765,7 @@ cclass_case_fold(Node** np, CClassNode* cc, CClassNode* asc_cc, ScanEnv* env)
   iarg.ptail       = &(iarg.alt_root);
 
   r = ONIGENC_APPLY_ALL_CASE_FOLD(env->enc, env->case_fold_flag,
-				  i_apply_case_fold, &iarg);
+                                  i_apply_case_fold, &iarg);
   if (r != 0) {
     onig_node_free(iarg.alt_root);
     return r;
@@ -6270,8 +6270,8 @@ is_onechar_cclass(CClassNode* cc, OnigCodePoint* code)
       /* only one char found in the bbuf, save the code point. */
       c = data[0];
       if (((c < SINGLE_BYTE_SIZE) && BITSET_AT(cc->bs, c))) {
-	/* skip if c is included in the bitset */
-	c = not_found;
+        /* skip if c is included in the bitset */
+        c = not_found;
       }
     }
     else {
@@ -6284,10 +6284,10 @@ is_onechar_cclass(CClassNode* cc, OnigCodePoint* code)
     Bits b1 = cc->bs[i];
     if (b1 != 0) {
       if (((b1 & (b1 - 1)) == 0) && (c == not_found)) {
-	c = BITS_IN_ROOM * i + countbits(b1 - 1);
+        c = BITS_IN_ROOM * i + countbits(b1 - 1);
       }
       else {
-	return 0;  /* the character class contains multiple chars */
+        return 0;  /* the character class contains multiple chars */
       }
     }
   }
@@ -6304,7 +6304,7 @@ is_onechar_cclass(CClassNode* cc, OnigCodePoint* code)
 
 static int
 parse_exp(Node** np, OnigToken* tok, int term,
-	  UChar** src, UChar* end, ScanEnv* env)
+          UChar** src, UChar* end, ScanEnv* env)
 {
   int r, len, group = 0;
   Node* qn;
@@ -6333,14 +6333,14 @@ parse_exp(Node** np, OnigToken* tok, int term,
       env->option = NENCLOSE(*np)->option;
       r = fetch_token(tok, src, end, env);
       if (r < 0) {
-	env->option = prev;
-	return r;
+        env->option = prev;
+        return r;
       }
       r = parse_subexp(&target, tok, term, src, end, env);
       env->option = prev;
       if (r < 0) {
-	onig_node_free(target);
-	return r;
+        onig_node_free(target);
+        return r;
       }
       NENCLOSE(*np)->target = target;
       return tok->type;
@@ -6378,20 +6378,20 @@ parse_exp(Node** np, OnigToken* tok, int term,
 
     string_loop:
       while (1) {
-	r = fetch_token(tok, src, end, env);
-	if (r < 0) return r;
-	if (r == TK_STRING) {
-	  r = onig_node_str_cat(*np, tok->backp, *src);
-	}
+        r = fetch_token(tok, src, end, env);
+        if (r < 0) return r;
+        if (r == TK_STRING) {
+          r = onig_node_str_cat(*np, tok->backp, *src);
+        }
 #ifndef NUMBERED_CHAR_IS_NOT_CASE_AMBIG
-	else if (r == TK_CODE_POINT) {
-	  r = node_str_cat_codepoint(*np, env->enc, tok->u.code);
-	}
+        else if (r == TK_CODE_POINT) {
+          r = node_str_cat_codepoint(*np, env->enc, tok->u.code);
+        }
 #endif
-	else {
-	  break;
-	}
-	if (r < 0) return r;
+        else {
+          break;
+        }
+        if (r < 0) return r;
       }
 
     string_end:
@@ -6407,36 +6407,36 @@ parse_exp(Node** np, OnigToken* tok, int term,
       CHECK_NULL_RETURN_MEMERR(*np);
       len = 1;
       while (1) {
-	if (len >= ONIGENC_MBC_MINLEN(env->enc)) {
-	  if (len == enclen(env->enc, NSTR(*np)->s, NSTR(*np)->end)) {
-	    r = fetch_token(tok, src, end, env);
-	    NSTRING_CLEAR_RAW(*np);
-	    goto string_end;
-	  }
-	}
+        if (len >= ONIGENC_MBC_MINLEN(env->enc)) {
+          if (len == enclen(env->enc, NSTR(*np)->s, NSTR(*np)->end)) {
+            r = fetch_token(tok, src, end, env);
+            NSTRING_CLEAR_RAW(*np);
+            goto string_end;
+          }
+        }
 
-	r = fetch_token(tok, src, end, env);
-	if (r < 0) return r;
-	if (r != TK_RAW_BYTE) {
-	  /* Don't use this, it is wrong for little endian encodings. */
+        r = fetch_token(tok, src, end, env);
+        if (r < 0) return r;
+        if (r != TK_RAW_BYTE) {
+          /* Don't use this, it is wrong for little endian encodings. */
 #ifdef USE_PAD_TO_SHORT_BYTE_CHAR
-	  int rem;
-	  if (len < ONIGENC_MBC_MINLEN(env->enc)) {
-	    rem = ONIGENC_MBC_MINLEN(env->enc) - len;
-	    (void )node_str_head_pad(NSTR(*np), rem, (UChar )0);
-	    if (len + rem == enclen(env->enc, NSTR(*np)->s)) {
-	      NSTRING_CLEAR_RAW(*np);
-	      goto string_end;
-	    }
-	  }
+          int rem;
+          if (len < ONIGENC_MBC_MINLEN(env->enc)) {
+            rem = ONIGENC_MBC_MINLEN(env->enc) - len;
+            (void )node_str_head_pad(NSTR(*np), rem, (UChar )0);
+            if (len + rem == enclen(env->enc, NSTR(*np)->s)) {
+              NSTRING_CLEAR_RAW(*np);
+              goto string_end;
+            }
+          }
 #endif
-	  return ONIGERR_TOO_SHORT_MULTI_BYTE_STRING;
-	}
+          return ONIGERR_TOO_SHORT_MULTI_BYTE_STRING;
+        }
 
-	r = node_str_cat_char(*np, (UChar )tok->u.c);
-	if (r < 0) return r;
+        r = node_str_cat_char(*np, (UChar )tok->u.c);
+        if (r < 0) return r;
 
-	len++;
+        len++;
       }
     }
     break;
@@ -6465,7 +6465,7 @@ parse_exp(Node** np, OnigToken* tok, int term,
       qstart = *src;
       qend = find_str_position(end_op, 2, qstart, end, &nextp, env->enc);
       if (IS_NULL(qend)) {
-	nextp = qend = end;
+        nextp = qend = end;
       }
       *np = node_new_str(qstart, qend);
       CHECK_NULL_RETURN_MEMERR(*np);
@@ -6477,30 +6477,30 @@ parse_exp(Node** np, OnigToken* tok, int term,
     {
       switch (tok->u.prop.ctype) {
       case ONIGENC_CTYPE_WORD:
-	*np = node_new_ctype(tok->u.prop.ctype, tok->u.prop.not,
-			     IS_ASCII_RANGE(env->option));
-	CHECK_NULL_RETURN_MEMERR(*np);
-	break;
+        *np = node_new_ctype(tok->u.prop.ctype, tok->u.prop.not,
+                             IS_ASCII_RANGE(env->option));
+        CHECK_NULL_RETURN_MEMERR(*np);
+        break;
 
       case ONIGENC_CTYPE_SPACE:
       case ONIGENC_CTYPE_DIGIT:
       case ONIGENC_CTYPE_XDIGIT:
-	{
-	  CClassNode* cc;
+        {
+          CClassNode* cc;
 
-	  *np = node_new_cclass();
-	  CHECK_NULL_RETURN_MEMERR(*np);
-	  cc = NCCLASS(*np);
-	  r = add_ctype_to_cc(cc, tok->u.prop.ctype, 0,
-	      IS_ASCII_RANGE(env->option), env);
-	  if (r != 0) return r;
-	  if (tok->u.prop.not != 0) NCCLASS_SET_NOT(cc);
-	}
-	break;
+          *np = node_new_cclass();
+          CHECK_NULL_RETURN_MEMERR(*np);
+          cc = NCCLASS(*np);
+          r = add_ctype_to_cc(cc, tok->u.prop.ctype, 0,
+              IS_ASCII_RANGE(env->option), env);
+          if (r != 0) return r;
+          if (tok->u.prop.not != 0) NCCLASS_SET_NOT(cc);
+        }
+        break;
 
       default:
-	return ONIGERR_PARSER_BUG;
-	break;
+        return ONIGERR_PARSER_BUG;
+        break;
       }
     }
     break;
@@ -6518,26 +6518,26 @@ parse_exp(Node** np, OnigToken* tok, int term,
 
       r = parse_char_class(np, &asc_node, tok, src, end, env);
       if (r != 0) {
-	onig_node_free(asc_node);
-	return r;
+        onig_node_free(asc_node);
+        return r;
       }
 
       cc = NCCLASS(*np);
       if (is_onechar_cclass(cc, &code)) {
-	onig_node_free(*np);
-	onig_node_free(asc_node);
-	*np = node_new_empty();
-	CHECK_NULL_RETURN_MEMERR(*np);
-	r = node_str_cat_codepoint(*np, env->enc, code);
-	if (r != 0) return r;
-	goto string_loop;
+        onig_node_free(*np);
+        onig_node_free(asc_node);
+        *np = node_new_empty();
+        CHECK_NULL_RETURN_MEMERR(*np);
+        r = node_str_cat_codepoint(*np, env->enc, code);
+        if (r != 0) return r;
+        goto string_loop;
       }
       if (IS_IGNORECASE(env->option)) {
-	r = cclass_case_fold(np, cc, NCCLASS(asc_node), env);
-	if (r != 0) {
-	  onig_node_free(asc_node);
-	  return r;
-	}
+        r = cclass_case_fold(np, cc, NCCLASS(asc_node), env);
+        if (r != 0) {
+          onig_node_free(asc_node);
+          return r;
+        }
       }
       onig_node_free(asc_node);
     }
@@ -6560,13 +6560,13 @@ parse_exp(Node** np, OnigToken* tok, int term,
   case TK_BACKREF:
     len = tok->u.backref.num;
     *np = node_new_backref(len,
-		   (len > 1 ? tok->u.backref.refs : &(tok->u.backref.ref1)),
-			   tok->u.backref.by_name,
+                   (len > 1 ? tok->u.backref.refs : &(tok->u.backref.ref1)),
+                           tok->u.backref.by_name,
 #ifdef USE_BACKREF_WITH_LEVEL
-			   tok->u.backref.exist_level,
-			   tok->u.backref.level,
+                           tok->u.backref.exist_level,
+                           tok->u.backref.level,
 #endif
-			   env);
+                           env);
     CHECK_NULL_RETURN_MEMERR(*np);
     break;
 
@@ -6576,10 +6576,10 @@ parse_exp(Node** np, OnigToken* tok, int term,
       int gnum = tok->u.call.gnum;
 
       if (gnum < 0 || tok->u.call.rel != 0) {
-	if (gnum > 0) gnum--;
-	gnum = BACKREF_REL_TO_ABS(gnum, env);
-	if (gnum <= 0)
-	  return ONIGERR_INVALID_BACKREF;
+        if (gnum > 0) gnum--;
+        gnum = BACKREF_REL_TO_ABS(gnum, env);
+        if (gnum <= 0)
+          return ONIGERR_INVALID_BACKREF;
       }
       *np = node_new_call(tok->u.call.name, tok->u.call.name_end, gnum);
       CHECK_NULL_RETURN_MEMERR(*np);
@@ -6598,9 +6598,9 @@ parse_exp(Node** np, OnigToken* tok, int term,
   case TK_INTERVAL:
     if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_CONTEXT_INDEP_REPEAT_OPS)) {
       if (IS_SYNTAX_BV(env->syntax, ONIG_SYN_CONTEXT_INVALID_REPEAT_OPS))
-	return ONIGERR_TARGET_OF_REPEAT_OPERATOR_NOT_SPECIFIED;
+        return ONIGERR_TARGET_OF_REPEAT_OPERATOR_NOT_SPECIFIED;
       else
-	*np = node_new_empty();
+        *np = node_new_empty();
     }
     else {
       goto tk_byte;
@@ -6622,49 +6622,49 @@ parse_exp(Node** np, OnigToken* tok, int term,
   repeat:
     if (r == TK_OP_REPEAT || r == TK_INTERVAL) {
       if (is_invalid_quantifier_target(*targetp))
-	return ONIGERR_TARGET_OF_REPEAT_OPERATOR_INVALID;
+        return ONIGERR_TARGET_OF_REPEAT_OPERATOR_INVALID;
 
       qn = node_new_quantifier(tok->u.repeat.lower, tok->u.repeat.upper,
-			       (r == TK_INTERVAL ? 1 : 0));
+                               (r == TK_INTERVAL ? 1 : 0));
       CHECK_NULL_RETURN_MEMERR(qn);
       NQTFR(qn)->greedy = tok->u.repeat.greedy;
       r = set_quantifier(qn, *targetp, group, env);
       if (r < 0) {
-	onig_node_free(qn);
-	return r;
+        onig_node_free(qn);
+        return r;
       }
 
       if (tok->u.repeat.possessive != 0) {
-	Node* en;
-	en = node_new_enclose(ENCLOSE_STOP_BACKTRACK);
-	if (IS_NULL(en)) {
-	  onig_node_free(qn);
-	  return ONIGERR_MEMORY;
-	}
-	NENCLOSE(en)->target = qn;
-	qn = en;
+        Node* en;
+        en = node_new_enclose(ENCLOSE_STOP_BACKTRACK);
+        if (IS_NULL(en)) {
+          onig_node_free(qn);
+          return ONIGERR_MEMORY;
+        }
+        NENCLOSE(en)->target = qn;
+        qn = en;
       }
 
       if (r == 0) {
-	*targetp = qn;
+        *targetp = qn;
       }
       else if (r == 1) {
-	onig_node_free(qn);
+        onig_node_free(qn);
       }
       else if (r == 2) { /* split case: /abc+/ */
-	Node *tmp;
+        Node *tmp;
 
-	*targetp = node_new_list(*targetp, NULL);
-	if (IS_NULL(*targetp)) {
-	  onig_node_free(qn);
-	  return ONIGERR_MEMORY;
-	}
-	tmp = NCDR(*targetp) = node_new_list(qn, NULL);
-	if (IS_NULL(tmp)) {
-	  onig_node_free(qn);
-	  return ONIGERR_MEMORY;
-	}
-	targetp = &(NCAR(tmp));
+        *targetp = node_new_list(*targetp, NULL);
+        if (IS_NULL(*targetp)) {
+          onig_node_free(qn);
+          return ONIGERR_MEMORY;
+        }
+        tmp = NCDR(*targetp) = node_new_list(qn, NULL);
+        if (IS_NULL(tmp)) {
+          onig_node_free(qn);
+          return ONIGERR_MEMORY;
+        }
+        targetp = &(NCAR(tmp));
       }
       goto re_entry;
     }
@@ -6675,7 +6675,7 @@ parse_exp(Node** np, OnigToken* tok, int term,
 
 static int
 parse_branch(Node** top, OnigToken* tok, int term,
-	     UChar** src, UChar* end, ScanEnv* env)
+             UChar** src, UChar* end, ScanEnv* env)
 {
   int r;
   Node *node, **headp;
@@ -6696,18 +6696,18 @@ parse_branch(Node** top, OnigToken* tok, int term,
     while (r != TK_EOT && r != term && r != TK_ALT) {
       r = parse_exp(&node, tok, term, src, end, env);
       if (r < 0) {
-	onig_node_free(node);
-	return r;
+        onig_node_free(node);
+        return r;
       }
 
       if (NTYPE(node) == NT_LIST) {
-	*headp = node;
-	while (IS_NOT_NULL(NCDR(node))) node = NCDR(node);
-	headp = &(NCDR(node));
+        *headp = node;
+        while (IS_NOT_NULL(NCDR(node))) node = NCDR(node);
+        headp = &(NCDR(node));
       }
       else {
-	*headp = node_new_list(node, NULL);
-	headp = &(NCDR(*headp));
+        *headp = node_new_list(node, NULL);
+        headp = &(NCDR(*headp));
       }
     }
   }
@@ -6718,7 +6718,7 @@ parse_branch(Node** top, OnigToken* tok, int term,
 /* term_tok: TK_EOT or TK_SUBEXP_CLOSE */
 static int
 parse_subexp(Node** top, OnigToken* tok, int term,
-	     UChar** src, UChar* end, ScanEnv* env)
+             UChar** src, UChar* end, ScanEnv* env)
 {
   int r;
   Node *node, *topnode, **headp;
@@ -6742,13 +6742,13 @@ parse_subexp(Node** top, OnigToken* tok, int term,
     while (r == TK_ALT) {
       r = fetch_token(tok, src, end, env);
       if (r < 0) {
-	onig_node_free(topnode);
-	return r;
+        onig_node_free(topnode);
+        return r;
       }
       r = parse_branch(&node, tok, term, src, end, env);
       if (r < 0) {
-	onig_node_free(topnode);
-	return r;
+        onig_node_free(topnode);
+        return r;
       }
 
       *headp = onig_node_new_alt(node, NULL);
@@ -6796,8 +6796,8 @@ parse_regexp(Node** top, UChar** src, UChar* end, ScanEnv* env)
     NENCLOSE(np)->target = *top;
     r = scan_env_set_mem_node(env, num, np);
     if (r != 0) {
-	onig_node_free(np);
-	return r;
+        onig_node_free(np);
+        return r;
     }
     *top = np;
   }
@@ -6807,7 +6807,7 @@ parse_regexp(Node** top, UChar** src, UChar* end, ScanEnv* env)
 
 extern int
 onig_parse_make_tree(Node** root, const UChar* pattern, const UChar* end,
-		     regex_t* reg, ScanEnv* env)
+                     regex_t* reg, ScanEnv* env)
 {
   int r;
   UChar* p;
@@ -6834,7 +6834,7 @@ onig_parse_make_tree(Node** root, const UChar* pattern, const UChar* end,
 
 extern void
 onig_scan_env_set_error_string(ScanEnv* env, int ecode ARG_UNUSED,
-				UChar* arg, UChar* arg_end)
+                                UChar* arg, UChar* arg_end)
 {
   env->error     = arg;
   env->error_end = arg_end;

--- a/regparse.h
+++ b/regparse.h
@@ -69,8 +69,8 @@ RUBY_SYMBOL_EXPORT_BEGIN
 #define NTYPE(node)             ((node)->u.base.type)
 #define SET_NTYPE(node, ntype) \
     do { \
-	int value = ntype; \
-	memcpy(&((node)->u.base.type), &value, sizeof(int)); \
+        int value = ntype; \
+        memcpy(&((node)->u.base.type), &value, sizeof(int)); \
     } while (0)
 
 #define NSTR(node)         (&((node)->u.str))


### PR DESCRIPTION
This PR fixes indents in Onigmo files to use 8 spaces instead of tabs. Actually, this PR is created by applying the following script to `reg*.{c,h}` files:

```ruby
filename = ARGV[0]
lines = File.read(filename).lines
new_lines = lines.map do |line|
  line.gsub(/^\t+/) do |m|
    ' ' * (m.size * 8)
  end
end

File.write filename, new_lines.join
```
