### PR TITLE
Don't check the symbol's fstr at shutdown

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -353,11 +353,6 @@ rb_gc_shutdown_call_finalizer_p(VALUE obj)
         return true;
 
       case T_SYMBOL:
-        if (RSYMBOL(obj)->fstr &&
-                (BUILTIN_TYPE(RSYMBOL(obj)->fstr) == T_NONE ||
-                    BUILTIN_TYPE(RSYMBOL(obj)->fstr) == T_ZOMBIE)) {
-            RSYMBOL(obj)->fstr = 0;
-        }
         return true;
 
       case T_NONE:


### PR DESCRIPTION
During Ruby's shutdown, we no longer need to check the fstr of the symbol because we don't use the fstr anymore for freeing the symbol. This can also fix the following ASAN error:

```
==2721247==ERROR: AddressSanitizer: use-after-poison on address 0x75fa90a627b8 at pc 0x64a7b06fb4bc bp 0x7ffdf95ba9b0 sp 0x7ffdf95ba9a8 READ of size 8 at 0x75fa90a627b8 thread T0
    #0 0x64a7b06fb4bb in RB_BUILTIN_TYPE include/ruby/internal/value_type.h:191:30
    #1 0x64a7b06fb4bb in rb_gc_shutdown_call_finalizer_p gc.c:357:18
    #2 0x64a7b06fb4bb in rb_gc_impl_shutdown_call_finalizer gc/default/default.c:3045:21
    #3 0x64a7b06fb4bb in rb_objspace_call_finalizer gc.c:1739:5
    #4 0x64a7b06ca1b2 in rb_ec_finalize eval.c:165:5
    #5 0x64a7b06ca1b2 in rb_ec_cleanup eval.c:256:5
    #6 0x64a7b06c98a3 in ruby_cleanup eval.c:179:12
```