### PR TITLE
Use write barrier version for rb_proc_call_kw

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -992,7 +992,12 @@ rb_proc_call_kw(VALUE self, VALUE args, int kw_splat)
     VALUE vret;
     rb_proc_t *proc;
     int argc = check_argc(RARRAY_LEN(args));
-    const VALUE *argv = RARRAY_CONST_PTR(args);
+
+    // rb_vm_invoke_proc may end up modifying argv as part of calling and so we
+    // must use RARRAY_PTR, which marks the array as WB_UNPROTECTED instead of
+    // RARRAY_CONST_PTR. Unfortunately this is worse for GC.
+    // See invoke_block_from_c_proc
+    VALUE *argv = RARRAY_PTR(args);
     GetProcPtr(self, proc);
     vret = rb_vm_invoke_proc(GET_EC(), proc, argc, argv,
                              kw_splat, VM_BLOCK_HANDLER_NONE);


### PR DESCRIPTION
RARRAY_CONST_PTR requires that the elements in the Array are never modified. However inside [invoke_block_from_c_proc the last hash arg (which I think was assumed to be on the stack) could be replaced by a new object](https://github.com/ruby/ruby/blob/7cece235ab9d3834b314f4395d45b8c97399470c/vm.c#L1756).

Because of this that either needs a write barrier (which is challenging because there is no reference to the args array at that point), or we need to mark the array as WB unprotected (which will slow GC).

This was found by wbcheck

@jeremyevans is there another way we could do that in [invoke_block_from_c_proc](https://github.com/ruby/ruby/blob/7cece235ab9d3834b314f4395d45b8c97399470c/vm.c#L1756) ?