### PR TITLE
ZJIT: A64: Fix splitting for large memory displacements

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -826,6 +826,17 @@ class TestZJIT < Test::Unit::TestCase
     }
   end
 
+  def test_forty_param_method
+    # This used to a trigger a miscomp on A64 due
+    # to a memory displacement larger than 9 bits.
+    assert_compiles '1', %Q{
+      def foo(#{'_,' * 39} n40) = n40
+
+      foo(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1)
+    }
+  end
+
+
   def test_opt_aref_with
     assert_compiles ':ok', %q{
       def aref_with(hash) = hash["key"]

--- a/zjit/src/asm/arm64/arg/shifted_imm.rs
+++ b/zjit/src/asm/arm64/arg/shifted_imm.rs
@@ -16,7 +16,6 @@ pub struct ShiftedImmediate {
 impl TryFrom<u64> for ShiftedImmediate {
     type Error = ();
 
-    /// Attempt to convert a u64 into a BitmaskImm.
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         let current = value;
         if current < 2_u64.pow(12) {

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -7,7 +7,9 @@ use crate::virtualmem::*;
 
 // Lots of manual vertical alignment in there that rustfmt doesn't handle well.
 #[rustfmt::skip]
+#[cfg(target_arch = "x86_64")]
 pub mod x86_64;
+#[cfg(target_arch = "aarch64")]
 pub mod arm64;
 
 /// Index to a label created by cb.new_label()


### PR DESCRIPTION
- **ZJIT: A64: Add add_extended() which can add a register to sp**

    On the ruby side, this fixes a crash for methods with 39 or more
    parameters. We used to miscomp those entry points due to Insn::Lea
    picking ADDS which cannot reference SP:

        # set method params: 40
        mov x0, #0xfee8
        movk x0, #0xffff, lsl #16
        movk x0, #0xffff, lsl #32
        movk x0, #0xffff, lsl #48
        adds x0, xzr, x0

    Have Lea work for all i32 displacements and avoid involving the split
    pass. Previously, direct use of Insn::Lea directly from the user (as
    opposed to generated by the split pass for some memory operations)
    wasn't split, so being able to handle the whole range in arm64_emit()
    was implicitly required. Also, not going through split reduces register
    pressure.

- **ZJIT: Remove false comment [ci skip]**
- **ZJIT: A64: Fix splitting for large memory displacements**
