### PR TITLE
Include flags in RSHAPE_PARENT

### DIFF
--- a/shape.h
+++ b/shape.h
@@ -273,7 +273,7 @@ rb_shape_root(size_t heap_id)
 static inline shape_id_t
 RSHAPE_PARENT(shape_id_t shape_id)
 {
-    return RSHAPE(shape_id)->parent_id;
+    return RSHAPE(shape_id)->parent_id | (shape_id & SHAPE_ID_FLAGS_MASK);
 }
 
 static inline enum shape_type


### PR DESCRIPTION
Previously RSHAPE_PARENT dropped all the flags, which made all setinstancevariable instructions which needed to modify shape (ie. setting a new instance variable) have a cache miss.

``` ruby
class Foo
  def initialize
    @a = @b = @c = @d = @e = @f = @g = @h = @i = @j = @k = @l = @m = @n = @o = @p = nil
  end
end
1_000_000.times { Foo.new }
```

**Before**:
```
❯ time ./miniruby test_many_ivars.rb
./miniruby test_many_ivars.rb  0.74s user 0.00s system 99% cpu 0.745 total
```

**After**

```
❯ time ./miniruby test_many_ivars.rb
./miniruby test_many_ivars.rb  0.26s user 0.00s system 99% cpu 0.262 total
```

@luke-gruber and @tenderlove helped me look at this

cc @byroot it feels like we might also be able to avoid the [capacity check](https://github.com/ruby/ruby/blob/master/vm_insnhelper.c#L1519) when setting a new ivar if our shape's heap index flags match, but I'm not too sure with the logic around embedded capacity vs shape->capacity