### PR TITLE
ZJIT: Implement `ToArray` and `ArrayExtend`

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -489,6 +489,42 @@ class TestZJIT < Test::Unit::TestCase
     }
   end
 
+  def test_array_splat_custom_to_a
+    assert_compiles '[1, 2, 3]', %q{
+      class Foo
+        def to_a
+          [1, 2, 3]
+        end
+      end
+      def bar(*a) = a
+      def test = bar(*Foo.new)
+      test
+    }, insns: [:splatarray]
+  end
+
+  def test_array_splat_nil
+    assert_compiles '1', %q{
+      def foo = 1
+      def test = foo(*nil)
+      test
+    }, insns: [:splatarray]
+  end
+
+  def test_array_splat
+    assert_compiles '"foo"', %q{
+      def foo(b) = b
+      def test(a) = foo(*a)
+      test("foo")
+    }, insns: [:splatarray]
+  end
+
+  def test_array_concat_implicit
+    assert_compiles '[1, 2, 3]', %q{
+      def test(a) = [1, *a]
+      test([2, 3])
+    }, insns: [:concattoarray]
+  end
+
   def test_new_range_inclusive
     assert_compiles '1..5', %q{
       def test(a, b) = a..b

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -118,6 +118,7 @@ fn main() {
         .allowlist_function("rb_obj_is_kind_of")
         .allowlist_function("rb_obj_frozen_p")
         .allowlist_function("rb_class_inherited_p")
+        .allowlist_function("rb_Array")
 
         // From ruby/internal/encoding/encoding.h
         .allowlist_type("ruby_encoding_consts")
@@ -149,6 +150,7 @@ fn main() {
         .allowlist_function("rb_ary_dup")
         .allowlist_function("rb_ary_push")
         .allowlist_function("rb_ary_unshift_m")
+        .allowlist_function("rb_ary_concat")
 
         // From internal/array.h
         .allowlist_function("rb_ec_ary_new_from_values")

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -778,6 +778,7 @@ unsafe extern "C" {
     pub fn rb_ary_cat(ary: VALUE, train: *const VALUE, len: ::std::os::raw::c_long) -> VALUE;
     pub fn rb_ary_push(ary: VALUE, elem: VALUE) -> VALUE;
     pub fn rb_ary_clear(ary: VALUE) -> VALUE;
+    pub fn rb_ary_concat(lhs: VALUE, rhs: VALUE) -> VALUE;
     pub fn rb_hash_new() -> VALUE;
     pub fn rb_hash_aref(hash: VALUE, key: VALUE) -> VALUE;
     pub fn rb_hash_aset(hash: VALUE, key: VALUE, val: VALUE) -> VALUE;
@@ -798,6 +799,7 @@ unsafe extern "C" {
     pub fn rb_obj_is_kind_of(obj: VALUE, klass: VALUE) -> VALUE;
     pub fn rb_obj_frozen_p(obj: VALUE) -> VALUE;
     pub fn rb_class_inherited_p(scion: VALUE, ascendant: VALUE) -> VALUE;
+    pub fn rb_Array(val: VALUE) -> VALUE;
     pub fn rb_backref_get() -> VALUE;
     pub fn rb_range_new(beg: VALUE, end: VALUE, excl: ::std::os::raw::c_int) -> VALUE;
     pub fn rb_reg_nth_match(n: ::std::os::raw::c_int, md: VALUE) -> VALUE;


### PR DESCRIPTION
- ToArray is used in both `concattoarray` and `splatarray` instructions to convert a value to an array OR put the value in an array
- ArrayExtend is used in `concattoarray` to extend `ary1` with `ary2`

With this change, ZJIT can actually execute `concattoarray` and `splatarray` instructions.