### PR TITLE
Make ARGF not pin references during marking

### DIFF
--- a/io.c
+++ b/io.c
@@ -9999,14 +9999,14 @@ io_wait(int argc, VALUE *argv, VALUE io)
 }
 
 static void
-argf_mark(void *ptr)
+argf_mark_and_move(void *ptr)
 {
     struct argf *p = ptr;
-    rb_gc_mark(p->filename);
-    rb_gc_mark(p->current_file);
-    rb_gc_mark(p->argv);
-    rb_gc_mark(p->inplace);
-    rb_gc_mark(p->encs.ecopts);
+    rb_gc_mark_and_move(&p->filename);
+    rb_gc_mark_and_move(&p->current_file);
+    rb_gc_mark_and_move(&p->argv);
+    rb_gc_mark_and_move(&p->inplace);
+    rb_gc_mark_and_move(&p->encs.ecopts);
 }
 
 static size_t
@@ -10017,20 +10017,9 @@ argf_memsize(const void *ptr)
     return size;
 }
 
-static void
-argf_compact(void *ptr)
-{
-    struct argf *p = ptr;
-    p->filename = rb_gc_location(p->filename);
-    p->current_file = rb_gc_location(p->current_file);
-    p->argv = rb_gc_location(p->argv);
-    p->inplace = rb_gc_location(p->inplace);
-    p->encs.ecopts = rb_gc_location(p->encs.ecopts);
-}
-
 static const rb_data_type_t argf_type = {
     "ARGF",
-    {argf_mark, RUBY_TYPED_DEFAULT_FREE, argf_memsize, argf_compact},
+    {argf_mark_and_move, RUBY_TYPED_DEFAULT_FREE, argf_memsize, argf_mark_and_move},
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
 


### PR DESCRIPTION
ARGF supports compaction, but it pins all of its references, which means that none of it can move. This commit changes it to actually support compaction.