### PR TITLE
Win: Strip CRs from `cpp` and `nm` output

### DIFF
--- a/template/fake.rb.in
+++ b/template/fake.rb.in
@@ -9,6 +9,7 @@ while /\A(\w+)=(.*)/ =~ ARGV[0]
 end
 if inc = arg['i']
   src = inc == '-' ? STDIN.read : File.read(inc)
+  src.tr!("\r", " ")
   src.gsub!(/^#.*\n/, '')
 else
   src = ""

--- a/win32/mkexports.rb
+++ b/win32/mkexports.rb
@@ -146,7 +146,9 @@ class Exports::Cygwin < Exports
   end
 
   def each_line(objs, &block)
-    IO.foreach("|#{self.class.nm} --extern-only --defined-only #{objs.join(' ')}", &block)
+    IO.popen(%W[#{self.class.nm} --extern-only --defined-only] + objs) do |f|
+      f.each(&block)
+    end
   end
 
   def each_export(objs)
@@ -155,7 +157,7 @@ class Exports::Cygwin < Exports
     re = /\s(?:(T)|[[:upper:]])\s#{symprefix}((?!#{PrivateNames}).*)$/
     objdump(objs) do |l|
       next if /@.*@/ =~ l
-      yield $2, !$1 if re =~ l
+      yield $2.strip, !$1 if re =~ l
     end
   end
 end


### PR DESCRIPTION
The combination of mingw tools and cygin/msys2 ruby leaves CRs.