### PR TITLE
Fix transition of object_id to too complex shape

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -818,9 +818,6 @@ shape_id_i(shape_id_t shape_id, void *data)
         dump_append_id(dc, RSHAPE_EDGE_NAME(shape_id));
 
         break;
-      case SHAPE_OBJ_ID:
-        dump_append(dc, ", \"shape_type\":\"OBJ_ID\"");
-        break;
     }
 
     dump_append(dc, ", \"edges\":");

--- a/gc.c
+++ b/gc.c
@@ -1870,13 +1870,7 @@ class_object_id(VALUE klass)
 static inline VALUE
 object_id_get(VALUE obj, shape_id_t shape_id)
 {
-    VALUE id;
-    if (rb_shape_too_complex_p(shape_id)) {
-        id = rb_obj_field_get(obj, ROOT_TOO_COMPLEX_WITH_OBJ_ID);
-    }
-    else {
-        id = rb_obj_field_get(obj, rb_shape_object_id(shape_id));
-    }
+    VALUE id = rb_ivar_get(obj, id_object_id);
 
 #if RUBY_DEBUG
     if (!(FIXNUM_P(id) || RB_TYPE_P(id, T_BIGNUM))) {
@@ -1898,14 +1892,9 @@ object_id0(VALUE obj)
         return object_id_get(obj, shape_id);
     }
 
-    // rb_shape_object_id_shape may lock if the current shape has
-    // multiple children.
-    shape_id_t object_id_shape_id = rb_shape_transition_object_id(obj);
-
     id = generate_next_object_id();
-    rb_obj_field_set(obj, object_id_shape_id, 0, id);
+    rb_ivar_set_internal(obj, id_object_id, id);
 
-    RUBY_ASSERT(RBASIC_SHAPE_ID(obj) == object_id_shape_id);
     RUBY_ASSERT(rb_shape_obj_has_id(obj));
 
     if (RB_UNLIKELY(id2ref_tbl)) {

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -53,7 +53,6 @@ void rb_evict_ivars_to_hash(VALUE obj);
 shape_id_t rb_evict_fields_to_hash(VALUE obj);
 VALUE rb_obj_field_get(VALUE obj, shape_id_t target_shape_id);
 void rb_ivar_set_internal(VALUE obj, ID id, VALUE val);
-void rb_obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* variable.c (export) */

--- a/shape.c
+++ b/shape.c
@@ -728,22 +728,6 @@ rb_shape_transition_object_id(VALUE obj)
     return shape_transition_object_id(RBASIC_SHAPE_ID(obj));
 }
 
-shape_id_t
-rb_shape_object_id(shape_id_t original_shape_id)
-{
-    RUBY_ASSERT(rb_shape_has_object_id(original_shape_id));
-
-    rb_shape_t *shape = RSHAPE(original_shape_id);
-    while (shape->type != SHAPE_OBJ_ID) {
-        if (UNLIKELY(shape->parent_id == INVALID_SHAPE_ID)) {
-            rb_bug("Missing object_id in shape tree");
-        }
-        shape = RSHAPE(shape->parent_id);
-    }
-
-    return shape_id(shape, original_shape_id) | SHAPE_ID_FL_HAS_OBJECT_ID;
-}
-
 static inline shape_id_t
 transition_complex(shape_id_t shape_id)
 {

--- a/shape.h
+++ b/shape.h
@@ -27,7 +27,7 @@ STATIC_ASSERT(shape_id_num_bits, SHAPE_ID_NUM_BITS == sizeof(shape_id_t) * CHAR_
 //      22 SHAPE_ID_FL_FROZEN
 //              Whether the object is frozen or not.
 //      23 SHAPE_ID_FL_HAS_OBJECT_ID
-//              Whether the object has an `SHAPE_OBJ_ID` transition.
+//              Whether the object has an instance variable for id_object_id.
 //      24 SHAPE_ID_FL_TOO_COMPLEX
 //              The object is backed by a `st_table`.
 
@@ -97,7 +97,6 @@ struct redblack_node {
 enum shape_type {
     SHAPE_ROOT,
     SHAPE_IVAR,
-    SHAPE_OBJ_ID,
 };
 
 enum shape_flags {
@@ -219,7 +218,6 @@ shape_id_t rb_shape_transition_complex(VALUE obj);
 shape_id_t rb_shape_transition_remove_ivar(VALUE obj, ID id, shape_id_t *removed_shape_id);
 shape_id_t rb_shape_transition_add_ivar(VALUE obj, ID id);
 shape_id_t rb_shape_transition_add_ivar_no_warnings(VALUE obj, ID id);
-shape_id_t rb_shape_transition_object_id(VALUE obj);
 shape_id_t rb_shape_transition_heap(VALUE obj, size_t heap_index);
 
 void rb_shape_free_all(void);

--- a/shape.h
+++ b/shape.h
@@ -221,7 +221,6 @@ shape_id_t rb_shape_transition_add_ivar(VALUE obj, ID id);
 shape_id_t rb_shape_transition_add_ivar_no_warnings(VALUE obj, ID id);
 shape_id_t rb_shape_transition_object_id(VALUE obj);
 shape_id_t rb_shape_transition_heap(VALUE obj, size_t heap_index);
-shape_id_t rb_shape_object_id(shape_id_t original_shape_id);
 
 void rb_shape_free_all(void);
 

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -657,6 +657,16 @@ class TestShapes < Test::Unit::TestCase
   def test_object_id_transition_too_complex
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
+      obj = Object.new
+      obj.instance_variable_set(:@a, 1)
+
+      RubyVM::Shape.exhaust_shapes
+
+      assert_equal obj.object_id, obj.object_id
+    end;
+
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
       class Hi; end
       obj = Hi.new
       obj.instance_variable_set(:@a, 1)

--- a/variable.c
+++ b/variable.c
@@ -1284,7 +1284,7 @@ VALUE
 rb_obj_field_get(VALUE obj, shape_id_t target_shape_id)
 {
     RUBY_ASSERT(!SPECIAL_CONST_P(obj));
-    RUBY_ASSERT(RSHAPE_TYPE_P(target_shape_id, SHAPE_IVAR) || RSHAPE_TYPE_P(target_shape_id, SHAPE_OBJ_ID));
+    RUBY_ASSERT(RSHAPE_TYPE_P(target_shape_id, SHAPE_IVAR));
 
     if (BUILTIN_TYPE(obj) == T_CLASS || BUILTIN_TYPE(obj) == T_MODULE) {
         ASSERT_vm_locking();


### PR DESCRIPTION
object_id0 tried to generate a new object ID, but this object ID may betoo complex. rb_obj_field_set didn't handle this transition and thus caused crashes.

This commit changes object_id to use the regular rb_ivar_set_internal API to handle the too complex transition.

For example, the following script crashes:

```ruby
o = Object.new
o.instance_variable_set(:https://github.com/hello, "hello!")

RubyVM::Shape.exhaust_shapes

puts o.object_id
```

With:

```
gc.c:1908: Assertion Failed: object_id0:RBASIC_SHAPE_ID(obj) == object_id_shape_id
```