### PR TITLE
Fix rb_shape_transition_object_id transition to `TOO_COMPLEX`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1897,8 +1897,6 @@ object_id0(VALUE obj)
         return object_id_get(obj, shape_id);
     }
 
-    // rb_shape_object_id_shape may lock if the current shape has
-    // multiple children.
     shape_id_t object_id_shape_id = rb_shape_transition_object_id(obj);
 
     id = generate_next_object_id();

--- a/shape.c
+++ b/shape.c
@@ -716,6 +716,7 @@ shape_transition_object_id(shape_id_t original_shape_id)
     rb_shape_t *shape = get_next_shape_internal(RSHAPE(original_shape_id), id_object_id, SHAPE_OBJ_ID, &dont_care, true);
     if (!shape) {
         shape = RSHAPE(ROOT_SHAPE_WITH_OBJ_ID);
+        return transition_complex(shape_id(shape, original_shape_id) | SHAPE_ID_FL_HAS_OBJECT_ID);
     }
 
     RUBY_ASSERT(shape);

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -657,6 +657,14 @@ class TestShapes < Test::Unit::TestCase
   def test_object_id_transition_too_complex
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
+      obj = Object.new
+      obj.instance_variable_set(:@a, 1)
+      RubyVM::Shape.exhaust_shapes
+      assert_equal obj.object_id, obj.object_id
+    end;
+
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
       class Hi; end
       obj = Hi.new
       obj.instance_variable_set(:@a, 1)


### PR DESCRIPTION
If `get_next_shape_internal` fail to return a shape, we must transitiont to a complex shape. `shape_transition_object_id` mistakenly didn't.

Fix: https://github.com/ruby/ruby/pull/14072

