### PR TITLE
Use snprintf instead of deprecated sprintf

### DIFF
--- a/yjit.c
+++ b/yjit.c
@@ -622,8 +622,9 @@ rb_yjit_iseq_inspect(const rb_iseq_t *iseq)
     const char *path = RSTRING_PTR(rb_iseq_path(iseq));
     int lineno = iseq->body->location.code_location.beg_pos.lineno;
 
-    char *buf = ZALLOC_N(char, strlen(label) + strlen(path) + num_digits(lineno) + 3);
-    sprintf(buf, "%s@%s:%d", label, path, lineno);
+    const size_t size = strlen(label) + strlen(path) + num_digits(lineno) + 3;
+    char *buf = ZALLOC_N(char, size);
+    snprintf(buf, size, "%s@%s:%d", label, path, lineno);
     return buf;
 }
 


### PR DESCRIPTION
When compiling with -fsanitize=address on macOS, the deprecation of sprintf is effective and prevents compiling yjit.c.

More details: https://openradar.appspot.com/FB11761475.

```
../../yjit.c:626:5: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
  626 |     sprintf(buf, "%s@%s:%d", label, path, lineno);
      |     ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_stdio.h:278:1: note: 'sprintf' has been explicitly marked deprecated here
  278 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
      | ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:218:48: note: expanded from macro '__deprecated_msg'
  218 |         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
      |                                                       ^
```