### PR TITLE
Add `void rb_gc_update_reference(VALUE *ptr)` API

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2878,6 +2878,15 @@ rb_gc_location(VALUE value)
     return gc_location_internal(rb_gc_get_objspace(), value);
 }
 
+void
+rb_gc_update_reference(VALUE *value_ptr)
+{
+    void *objspace = rb_gc_get_objspace();
+    if (rb_gc_impl_object_moved_p(objspace, *value_ptr)) {
+        *value_ptr = gc_location_internal(objspace, *value_ptr);
+    }
+}
+
 #if defined(__wasm__)
 
 

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -210,6 +210,7 @@ bool rb_gc_size_allocatable_p(size_t size);
 size_t *rb_gc_heap_sizes(void);
 size_t rb_gc_heap_id_for_size(size_t size);
 
+void rb_gc_update_reference(VALUE *ptr);
 void rb_gc_mark_and_move(VALUE *ptr);
 
 void rb_gc_mark_weak(VALUE *ptr);

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -138,7 +138,7 @@ static void
 location_ref_update(void *ptr)
 {
     struct valued_frame_info *vfi = ptr;
-    vfi->btobj = rb_gc_location(vfi->btobj);
+    rb_gc_update_reference(&vfi->btobj);
 }
 
 static void


### PR DESCRIPTION
The existing `VALUE rb_gc_location(VALUE obj)` API isn't ideal in my opinion, because the idomatic way to use it is:

```c
struct->field = rb_gc_location(struct->field);
```

Which means that when running `GC.compact`, any reference that is movable is rewritten, even if the referenced object didn't move.

I suspect this is a lot of unnecessary writes that are trashing shared pages.

Inside the GC itself, there's the much more convenient `UPDATE_IF_MOVED` macro, that only update the reference if it's actually needed.

I only rewrote a single `dcompact` function to show how it works, and haven't made the API public. But @peterzhu2118 and @eightbitraptor: if you agree this is a good idea, I'd like to propose this to be made a public API.