### PR TITLE
rb_gc_impl_mark_and_move: avoid needless writes

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -4420,7 +4420,10 @@ rb_gc_impl_mark_and_move(void *objspace_ptr, VALUE *ptr)
         GC_ASSERT(objspace->flags.during_compacting);
         GC_ASSERT(during_gc);
 
-        *ptr = rb_gc_impl_location(objspace, *ptr);
+        VALUE destination = rb_gc_impl_location(objspace, *ptr);
+        if (destination != *ptr) {
+            *ptr = destination;
+        }
     }
     else {
         gc_mark(objspace, *ptr);


### PR DESCRIPTION
Assuming not all objects are moved during compaction, it is preferable to avoid rewriting references that haven't moved as to avoid invalidating potentially shared memory pages.