### PR TITLE
ZJIT: A64: Use MOVN for small negative immediates

### DIFF
--- a/zjit/src/asm/arm64/inst/mov.rs
+++ b/zjit/src/asm/arm64/inst/mov.rs
@@ -2,6 +2,9 @@ use super::super::arg::Sf;
 
 /// Which operation is being performed.
 enum Op {
+    /// A movn operation which inverts the immediate and zeroes out the other bits.
+    MOVN = 0b00,
+
     /// A movz operation which zeroes out the other bits.
     MOVZ = 0b10,
 
@@ -61,6 +64,12 @@ impl Mov {
         Self { rd, imm16, hw: hw.into(), op: Op::MOVK, sf: num_bits.into() }
     }
 
+    /// MOVN
+    /// <https://developer.arm.com/documentation/ddi0602/2025-06/Base-Instructions/MOVN--Move-wide-with-NOT->
+    pub fn movn(rd: u8, imm16: u16, hw: u8, num_bits: u8) -> Self {
+        Self { rd, imm16, hw: hw.into(), op: Op::MOVN, sf: num_bits.into() }
+    }
+
     /// MOVZ
     /// <https://developer.arm.com/documentation/ddi0602/2022-03/Base-Instructions/MOVZ--Move-wide-with-zero-?lang=en>
     pub fn movz(rd: u8, imm16: u16, hw: u8, num_bits: u8) -> Self {
@@ -102,6 +111,34 @@ mod tests {
         let inst = Mov::movk(0, 123, 0, 64);
         let result: u32 = inst.into();
         assert_eq!(0xf2800f60, result);
+    }
+
+    #[test]
+    fn test_movn_unshifted() {
+        let inst = Mov::movn(0, 123, 0, 64);
+        let result: u32 = inst.into();
+        assert_eq!(0x92800f60, result);
+    }
+
+    #[test]
+    fn test_movn_shifted_16() {
+        let inst = Mov::movn(0, 123, 16, 64);
+        let result: u32 = inst.into();
+        assert_eq!(0x92a00f60, result);
+    }
+
+    #[test]
+    fn test_movn_shifted_32() {
+        let inst = Mov::movn(0, 123, 32, 64);
+        let result: u32 = inst.into();
+        assert_eq!(0x92c00f60, result);
+    }
+
+    #[test]
+    fn test_movn_shifted_48() {
+        let inst = Mov::movn(0, 123, 48, 64);
+        let result: u32 = inst.into();
+        assert_eq!(0x92e00f60, result);
     }
 
     #[test]

--- a/zjit/src/asm/arm64/mod.rs
+++ b/zjit/src/asm/arm64/mod.rs
@@ -716,6 +716,21 @@ pub fn movk(cb: &mut CodeBlock, rd: A64Opnd, imm16: A64Opnd, shift: u8) {
     cb.write_bytes(&bytes);
 }
 
+/// MOVN - load a register with the complement of a shifted then zero extended 16-bit immediate
+/// <https://developer.arm.com/documentation/ddi0602/2025-06/Base-Instructions/MOVN--Move-wide-with-NOT->
+pub fn movn(cb: &mut CodeBlock, rd: A64Opnd, imm16: A64Opnd, shift: u8) {
+    let bytes: [u8; 4] = match (rd, imm16) {
+        (A64Opnd::Reg(rd), A64Opnd::UImm(imm16)) => {
+            assert!(uimm_fits_bits(imm16, 16), "The immediate operand must be 16 bits or less.");
+
+            Mov::movn(rd.reg_no, imm16 as u16, shift, rd.num_bits).into()
+        },
+        _ => panic!("Invalid operand combination to movn instruction.")
+    };
+
+    cb.write_bytes(&bytes);
+}
+
 /// MOVZ - move a 16 bit immediate into a register, zero the other bits
 pub fn movz(cb: &mut CodeBlock, rd: A64Opnd, imm16: A64Opnd, shift: u8) {
     let bytes: [u8; 4] = match (rd, imm16) {
@@ -1541,6 +1556,11 @@ mod tests {
     #[test]
     fn test_movk() {
         check_bytes("600fa0f2", |cb| movk(cb, X0, A64Opnd::new_uimm(123), 16));
+    }
+
+    #[test]
+    fn test_movn() {
+        check_bytes("600fa092", |cb| movn(cb, X0, A64Opnd::new_uimm(123), 16));
     }
 
     #[test]


### PR DESCRIPTION
Save a couple instructions to load a small negative constant into a
register. In fact MOVN is speced to alias as `mov` in the official
disassembly.
