### PR TITLE
ZJIT: Enable IncrCounter for arm64

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -1095,6 +1095,14 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 2
   end
 
+  def test_stats
+    assert_runs 'true', %q{
+      def test = 1
+      test
+      RubyVM::ZJIT.stats[:zjit_insns_count] > 0
+    }, stats: true
+  end
+
   def test_zjit_option_uses_array_each_in_ruby
     omit 'ZJIT wrongly compiles Array#each, so it is disabled for now'
     assert_runs '"<internal:array>"', %q{
@@ -1414,12 +1422,13 @@ class TestZJIT < Test::Unit::TestCase
   end
 
   # Run a Ruby process with ZJIT options and a pipe for writing test results
-  def eval_with_jit(script, call_threshold: 1, num_profiles: 1, timeout: 1000, pipe_fd:, debug: true)
+  def eval_with_jit(script, call_threshold: 1, num_profiles: 1, stats: false, debug: true, timeout: 1000, pipe_fd:)
     args = [
       "--disable-gems",
       "--zjit-call-threshold=#{call_threshold}",
       "--zjit-num-profiles=#{num_profiles}",
     ]
+    args << "--zjit-stats" if stats
     args << "--zjit-debug" if debug
     args << "-e" << script_shell_encode(script)
     pipe_r, pipe_w = IO.pipe

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1305,8 +1305,7 @@ impl Assembler
                     }
                     last_patch_pos = Some(cb.get_write_pos());
                 },
-                Insn::IncrCounter { mem: _, value: _ } => {
-                    /*
+                Insn::IncrCounter { mem, value } => {
                     let label = cb.new_label("incr_counter_loop".to_string());
                     cb.write_label(label);
 
@@ -1322,8 +1321,6 @@ impl Assembler
 
                     cmp(cb, Self::SCRATCH1, A64Opnd::new_uimm(0));
                     emit_conditional_jump::<{Condition::NE}>(cb, Target::Label(label));
-                    */
-                    unimplemented!("labels are not supported yet");
                 },
                 Insn::Breakpoint => {
                     brk(cb, A64Opnd::None);


### PR DESCRIPTION
This PR fixes `--zjit-stats`'s panic on arm64.

The backend did not have label support when it was initially ported from YJIT, but we added that later. So there's no reason to comment out the `IncrCounter` implementation today.