### PR TITLE
Add `Math.log1p` and `Math.expm1`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,10 @@ Note: We're only listing outstanding class updates.
     * `IO.select` accepts +Float::INFINITY+ as a timeout argument.
       [[Feature #20610]]
 
+* Math
+
+    * `Math.log1p` and `Math.expm1` are added. [[Feature #21527]]
+
 * Socket
 
     * `Socket.tcp` & `TCPSocket.new` accepts `open_timeout` as a keyword argument to specify
@@ -254,3 +258,4 @@ The following bundled gems are updated.
 [Feature #21287]: https://bugs.ruby-lang.org/issues/21287
 [Feature #21347]: https://bugs.ruby-lang.org/issues/21347
 [Feature #21360]: https://bugs.ruby-lang.org/issues/21360
+[Feature #21527]: https://bugs.ruby-lang.org/issues/21527

--- a/math.c
+++ b/math.c
@@ -457,6 +457,34 @@ math_exp(VALUE unused_obj, VALUE x)
     return DBL2NUM(exp(Get_Double(x)));
 }
 
+/*
+ *  call-seq:
+ *    Math.expm1(x) -> float
+ *
+ *  Returns "exp(x) - 1", +e+ raised to the +x+ power, minus 1.
+ *
+ *
+ *  - Domain: <tt>[-INFINITY, INFINITY]</tt>.
+ *  - Range: <tt>[-1.0, INFINITY]</tt>.
+ *
+ *  Examples:
+ *
+ *    expm1(-INFINITY) # => 0.0
+ *    expm1(-1.0)      # => -0.6321205588285577 # 1.0/E - 1
+ *    expm1(0.0)       # => 0.0
+ *    expm1(0.5)       # => 0.6487212707001282  # sqrt(E) - 1
+ *    expm1(1.0)       # => 1.718281828459045   # E - 1
+ *    expm1(2.0)       # => 6.38905609893065    # E**2 - 1
+ *    expm1(INFINITY)  # => Infinity
+ *
+ */
+
+static VALUE
+math_expm1(VALUE unused_obj, VALUE x)
+{
+    return DBL2NUM(expm1(Get_Double(x)));
+}
+
 #if defined __CYGWIN__
 # include <cygwin/version.h>
 # if CYGWIN_VERSION_DLL_MAJOR < 1005
@@ -644,6 +672,47 @@ math_log10(VALUE unused_obj, VALUE x)
     if (d == 0.0) return DBL2NUM(-HUGE_VAL);
 
     return DBL2NUM(log10(d) + numbits * log10(2)); /* log10(d * 2 ** numbits) */
+}
+
+/*
+ *  call-seq:
+ *    Math.log1p(x) -> float
+ *
+ *  Returns "log(x + 1)", the base E {logarithm}[https://en.wikipedia.org/wiki/Logarithm] of (+x+ + 1).
+ *
+ *  - Domain: <tt>[-1, INFINITY]</tt>.
+ *  - Range: <tt>[-INFINITY, INFINITY]</tt>.
+ *
+ *  Examples:
+ *
+ *    log1p(-1.0)     # => -Infinity
+ *    log1p(0.0)      # => 0.0
+ *    log1p(E - 1)    # => 1.0
+ *    log1p(INFINITY) # => Infinity
+ *
+ */
+
+static VALUE
+math_log1p(VALUE unused_obj, VALUE x)
+{
+    size_t numbits;
+    double d = get_double_rshift(x, &numbits);
+
+    if (numbits != 0) {
+        x = rb_big_plus(x, INT2FIX(1));
+        d = math_log_split(x, &numbits);
+        /* check for pole error */
+        if (d == 0.0) return DBL2NUM(-HUGE_VAL);
+        d = log(d);
+        d += numbits * M_LN2;
+        return DBL2NUM(d);
+    }
+
+    domain_check_min(d, -1.0, "log1p");
+    /* check for pole error */
+    if (d == -1.0) return DBL2NUM(-HUGE_VAL);
+
+    return DBL2NUM(log1p(d)); /* log10(d * 2 ** numbits) */
 }
 
 static VALUE rb_math_sqrt(VALUE x);
@@ -1120,9 +1189,11 @@ InitVM_Math(void)
     rb_define_module_function(rb_mMath, "atanh", math_atanh, 1);
 
     rb_define_module_function(rb_mMath, "exp", math_exp, 1);
+    rb_define_module_function(rb_mMath, "expm1", math_expm1, 1);
     rb_define_module_function(rb_mMath, "log", math_log, -1);
     rb_define_module_function(rb_mMath, "log2", math_log2, 1);
     rb_define_module_function(rb_mMath, "log10", math_log10, 1);
+    rb_define_module_function(rb_mMath, "log1p", math_log1p, 1);
     rb_define_module_function(rb_mMath, "sqrt", math_sqrt, 1);
     rb_define_module_function(rb_mMath, "cbrt", math_cbrt, 1);
 

--- a/test/ruby/test_math.rb
+++ b/test/ruby/test_math.rb
@@ -147,6 +147,13 @@ class TestMath < Test::Unit::TestCase
     check(Math::E ** 2, Math.exp(2))
   end
 
+  def test_expm1
+    check(0, Math.expm1(0))
+    check(Math.sqrt(Math::E) - 1, Math.expm1(0.5))
+    check(Math::E - 1, Math.expm1(1))
+    check(Math::E ** 2 - 1, Math.expm1(2))
+  end
+
   def test_log
     check(0, Math.log(1))
     check(1, Math.log(Math::E))
@@ -199,6 +206,19 @@ class TestMath < Test::Unit::TestCase
     assert_raise_with_message(Math::DomainError, /\blog10\b/) { Math.log10(-Float::EPSILON) }
     assert_nothing_raised { assert_nan(Math.log10(Float::NAN)) }
     assert_nothing_raised { assert_infinity(-Math.log10(0)) }
+  end
+
+  def test_log1p
+    check(0, Math.log1p(0))
+    check(1, Math.log1p(Math::E - 1))
+    check(Math.log(2.0 ** 64 + 1), Math.log1p(1 << 64))
+    check(Math.log(2) * 1024.0, Math.log1p(2 ** 1024))
+    assert_nothing_raised { assert_infinity(Math.log1p(1.0/0)) }
+    assert_nothing_raised { assert_infinity(-Math.log1p(-1.0)) }
+    assert_raise_with_message(Math::DomainError, /\blog1p\b/) { Math.log1p(-1.1) }
+    assert_raise_with_message(Math::DomainError, /\blog1p\b/) { Math.log1p(-Float::EPSILON-1) }
+    assert_nothing_raised { assert_nan(Math.log1p(Float::NAN)) }
+    assert_nothing_raised { assert_infinity(-Math.log1p(-1)) }
   end
 
   def test_sqrt


### PR DESCRIPTION
This commit adds two new methods to the `Math` module:

* `Math.log1p(x)`: Computes `Math.log(x + 1)`
* `Math.expm1(x)`: Computes `Math.exp(x) - 1`

These methods are often more accurate than the straightforward computation, especially when `x` is close to zero. The corresponding functions, `log1p` and `expm1`, are defined in the C99 standard math library.