### PR TITLE
Windows: Revert to shell execution when invoking nm tool

### DIFF
--- a/win32/mkexports.rb
+++ b/win32/mkexports.rb
@@ -146,9 +146,7 @@ class Exports::Cygwin < Exports
   end
 
   def each_line(objs, &block)
-    IO.popen(%W[#{self.class.nm} --extern-only --defined-only] + objs) do |f|
-      f.each(&block)
-    end
+    IO.foreach("|#{self.class.nm} --extern-only --defined-only #{objs.join(' ')}", &block)
   end
 
   def each_export(objs)


### PR DESCRIPTION
This reverts a change of commit b3598cf2a355497693bb66097edc156af3152e9b . On Windows on ARM64 with LLVM the "NM" tool is called with a parameter like so:
```
  RbConfig::CONFIG["NM"] # => "llvm-nm --no-llvm-bc"
```

Therefore the command must be called with a shell string.

Compilation on `aarch64-mingw-ucrt` fails since that commit [like so](https://github.com/oneclick/rubyinstaller2-packages/actions/runs/16697064199/job/47262735477#step:8:995):
```
/c/hostedtoolcache/windows/Ruby/3.4.5/arm64/bin/ruby --disable=gems  -r./aarch64-mingw-ucrt-fake ../snapshot-master/win32/mkexports.rb -output=aarch64-ucrt-ruby350.def libaarch64-ucrt-ruby350-static.a
../snapshot-master/win32/mkexports.rb:149:in 'IO.popen': No such file or directory - llvm-nm --no-llvm-bc (Errno::ENOENT)
```