### PR TITLE
[DOC] Fix typo in Regular Expressions docs (_regexp.rdoc)

### DIFF
--- a/doc/_regexp.rdoc
+++ b/doc/_regexp.rdoc
@@ -502,7 +502,7 @@ An added _quantifier_ specifies how many matches are required or allowed:
     /\w*/.match('x')
     # => #<MatchData "x">
     /\w*/.match('xyz')
-    # => #<MatchData "yz">
+    # => #<MatchData "xyz">
 
 - <tt>+</tt> - Matches one or more times:
 


### PR DESCRIPTION
Small fix for a typo in the regular expression docs. The line of code above this change does not produce the output shown in the docs. With this change the docs will show the correct output for this example of using regex quantifiers.