### PR TITLE
Restore `Warning[:deprecated]`

### DIFF
--- a/tool/lib/core_assertions.rb
+++ b/tool/lib/core_assertions.rb
@@ -690,17 +690,15 @@ eom
         assert_warning(*args) {$VERBOSE = false; yield}
       end
 
-      def assert_deprecated_warning(mesg = /deprecated/)
+      def assert_deprecated_warning(mesg = /deprecated/, &block)
         assert_warning(mesg) do
-          Warning[:deprecated] = true if Warning.respond_to?(:[]=)
-          yield
+          EnvUtil.deprecation_warning(&block)
         end
       end
 
       def assert_deprecated_warn(mesg = /deprecated/)
         assert_warn(mesg) do
-          Warning[:deprecated] = true if Warning.respond_to?(:[]=)
-          yield
+          EnvUtil.deprecation_warning(&block)
         end
       end
 

--- a/tool/lib/core_assertions.rb
+++ b/tool/lib/core_assertions.rb
@@ -696,7 +696,7 @@ eom
         end
       end
 
-      def assert_deprecated_warn(mesg = /deprecated/)
+      def assert_deprecated_warn(mesg = /deprecated/, &block)
         assert_warn(mesg) do
           EnvUtil.deprecation_warning(&block)
         end

--- a/tool/lib/envutil.rb
+++ b/tool/lib/envutil.rb
@@ -297,6 +297,21 @@ module EnvUtil
   end
   module_function :verbose_warning
 
+  if defined?(Warning.[]=)
+    def deprecation_warning
+      previous_deprecated = Warning[:deprecated]
+      Warning[:deprecated] = true
+      yield
+    ensure
+      Warning[:deprecated] = previous_deprecated
+    end
+  else
+    def deprecation_warning
+      yield
+    end
+  end
+  module_function :deprecation_warning
+
   def default_warning
     $VERBOSE = false
     yield


### PR DESCRIPTION
from https://github.com/ruby/test-unit-ruby-core/pull/8