### PR TITLE
variable.c: refactor accesses to the `generic_fields_tbl`

### DIFF
--- a/internal/variable.h
+++ b/internal/variable.h
@@ -46,7 +46,6 @@ void rb_gvar_namespace_ready(const char *name);
  */
 VALUE rb_mod_set_temporary_name(VALUE, VALUE);
 
-int rb_gen_fields_tbl_get(VALUE obj, ID id, VALUE *fields_obj);
 void rb_obj_copy_ivs_to_hash_table(VALUE obj, st_table *table);
 void rb_obj_init_too_complex(VALUE obj, st_table *table);
 void rb_evict_ivars_to_hash(VALUE obj);

--- a/ractor.c
+++ b/ractor.c
@@ -1679,8 +1679,7 @@ obj_traverse_replace_i(VALUE obj, struct obj_traverse_replace_data *data)
 } while (0)
 
     if (UNLIKELY(rb_obj_exivar_p(obj))) {
-        VALUE fields_obj;
-        rb_ivar_generic_fields_tbl_lookup(obj, &fields_obj);
+        VALUE fields_obj = rb_obj_fields_no_ractor_check(obj);
 
         if (UNLIKELY(rb_shape_obj_too_complex_p(obj))) {
             struct obj_traverse_replace_callback_data d = {

--- a/variable.h
+++ b/variable.h
@@ -12,8 +12,14 @@
 
 #include "shape.h"
 
-int rb_ivar_generic_fields_tbl_lookup(VALUE obj, VALUE *);
 void rb_copy_complex_ivars(VALUE dest, VALUE obj, shape_id_t src_shape_id, st_table *fields_table);
+VALUE rb_obj_fields(VALUE obj, ID field_name);
+
+static inline VALUE
+rb_obj_fields_no_ractor_check(VALUE obj)
+{
+    return rb_obj_fields(obj, 0);
+}
 
 void rb_free_rb_global_tbl(void);
 void rb_free_generic_fields_tbl_(void);

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1267,8 +1267,8 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
         }
       default:
         if (rb_obj_exivar_p(obj)) {
-            VALUE fields_obj = 0;
-            if (!rb_gen_fields_tbl_get(obj, id, &fields_obj)) {
+            VALUE fields_obj = rb_obj_fields(obj, id);
+            if (!fields_obj) {
                 return default_value;
             }
             ivar_list = rb_imemo_fields_ptr(fields_obj);
@@ -1343,10 +1343,8 @@ vm_getivar(VALUE obj, ID id, const rb_iseq_t *iseq, IVC ic, const struct rb_call
                 break;
 
               default: {
-                VALUE fields_obj;
-                if (rb_gen_fields_tbl_get(obj, 0, &fields_obj)) {
-                    table = rb_imemo_fields_complex_tbl(fields_obj);
-                }
+                VALUE fields_obj = rb_obj_fields(obj, id);
+                table = rb_imemo_fields_complex_tbl(fields_obj);
                 break;
               }
             }
@@ -1466,8 +1464,6 @@ vm_setivar_default(VALUE obj, ID id, VALUE val, shape_id_t dest_shape_id, attr_i
 {
     shape_id_t shape_id = RBASIC_SHAPE_ID(obj);
 
-    VALUE fields_obj = 0;
-
     // Cache hit case
     if (shape_id == dest_shape_id) {
         RUBY_ASSERT(dest_shape_id != INVALID_SHAPE_ID && shape_id != INVALID_SHAPE_ID);
@@ -1484,13 +1480,14 @@ vm_setivar_default(VALUE obj, ID id, VALUE val, shape_id_t dest_shape_id, attr_i
         return Qundef;
     }
 
-    rb_gen_fields_tbl_get(obj, 0, &fields_obj);
+    VALUE fields_obj = rb_obj_fields(obj, id);
+    RUBY_ASSERT(fields_obj);
+    RB_OBJ_WRITE(fields_obj, &rb_imemo_fields_ptr(fields_obj)[index], val);
 
     if (shape_id != dest_shape_id) {
         RBASIC_SET_SHAPE_ID(obj, dest_shape_id);
+        RBASIC_SET_SHAPE_ID(fields_obj, dest_shape_id);
     }
-
-    RB_OBJ_WRITE(obj, &rb_imemo_fields_ptr(fields_obj)[index], val);
 
     RB_DEBUG_COUNTER_INC(ivar_set_ic_hit);
 


### PR DESCRIPTION
It's now mostly all encapsulated inside:

  - `rb_obj_fields`
  - `rb_obj_set_fields`
  - `rb_obj_replace_fields`