### PR TITLE
Explicitly load Gem::Version and Gem.rubygems_version for Gem::Deprecate

### DIFF
--- a/ext/extmk.rb
+++ b/ext/extmk.rb
@@ -8,7 +8,9 @@ module Gem
     RbConfig::CONFIG
   end
 end
-# only needs Gem::Platform
+# Gem::Platform uses Gem::Deprecate now.
+# Gem::Deprecate needs to load `rubygems.rb`
+require 'rubygems'
 require 'rubygems/platform'
 
 # :stopdoc:


### PR DESCRIPTION
for https://github.com/rubygems/rubygems/pull/8900