### PR TITLE
Fix RUBY_FREE_AT_EXIT for static symbols

### DIFF
--- a/internal/symbol.h
+++ b/internal/symbol.h
@@ -35,6 +35,7 @@ bool rb_obj_is_symbol_table(VALUE obj);
 void rb_sym_global_symbol_table_foreach_weak_reference(int (*callback)(VALUE *key, void *data), void *data);
 void rb_gc_free_dsymbol(VALUE);
 int rb_static_id_valid_p(ID id);
+void rb_free_global_symbol_table(void);
 
 #if __has_builtin(__builtin_constant_p)
 #define rb_sym_intern_ascii_cstr(ptr) \

--- a/symbol.c
+++ b/symbol.c
@@ -386,6 +386,20 @@ rb_sym_global_symbols_update_references(void)
     symbols->ids = rb_gc_location(symbols->ids);
 }
 
+static int
+rb_free_global_symbol_table_i(VALUE *sym_ptr, void *data)
+{
+    sym_set_free(*sym_ptr);
+
+    return ST_DELETE;
+}
+
+void
+rb_free_global_symbol_table(void)
+{
+    rb_concurrent_set_foreach_with_replace(ruby_global_symbols.sym_set, rb_free_global_symbol_table_i, NULL);
+}
+
 WARN_UNUSED_RESULT(static ID lookup_str_id(VALUE str));
 WARN_UNUSED_RESULT(static VALUE lookup_id_str(ID id));
 

--- a/vm.c
+++ b/vm.c
@@ -3146,6 +3146,7 @@ ruby_vm_destruct(rb_vm_t *vm)
             rb_free_encoded_insn_data();
             rb_free_global_enc_table();
             rb_free_loaded_builtin_table();
+            rb_free_global_symbol_table();
 
             rb_free_shared_fiber_pool();
             rb_free_transcoder_table();


### PR DESCRIPTION
Since static symbols allocate memory, we should deallocate them at shutdown to prevent memory leaks from being reported with RUBY_FREE_AT_EXIT.