### PR TITLE
ZJIT: Add a graphviz dumper for HIR

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2333,7 +2333,7 @@ impl<'a> std::fmt::Display for FunctionGraphvizPrinter<'a> {
         write_encoded!(f, "# {iseq_name}")?;
         write!(f, "\n")?;
         writeln!(f, "node [shape=plaintext];")?;
-        writeln!(f, "mode=hier; overlap=false; splines=curved;")?;
+        writeln!(f, "mode=hier; overlap=false; splines=true;")?;
         for block_id in fun.rpo() {
             writeln!(f, r#"  {block_id} [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">"#)?;
             write!(f, r#"<TR><TD ALIGN="LEFT" PORT="params" BGCOLOR="gray">{block_id}("#)?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2330,7 +2330,8 @@ impl<'a> std::fmt::Display for FunctionGraphvizPrinter<'a> {
         let fun = &self.fun;
         let iseq_name = iseq_get_location(fun.iseq, 0);
         writeln!(f, "digraph G {{")?;
-        writeln!(f, "  # {iseq_name}")?;
+        write_encoded!(f, "  # {iseq_name}")?;
+        write!(f, "\n")?;
         writeln!(f, "  node [shape=plaintext];")?;
         for block_id in fun.rpo() {
             writeln!(f, r#"  {block_id} [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">"#)?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2319,8 +2319,6 @@ impl<'a, 'b> std::fmt::Write for HtmlEncoder<'a, 'b> {
 
 impl<'a> std::fmt::Display for FunctionGraphvizPrinter<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        /// macro write_encoded! that looks like normal write! but creates a temporary HtmlEncoder and writes to it instead
-        // let mut f = HtmlEncoder { formatter: out };
         macro_rules! write_encoded {
             ($f:ident, $($arg:tt)*) => {
                 HtmlEncoder { formatter: $f }.write_fmt(format_args!($($arg)*))

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2330,9 +2330,10 @@ impl<'a> std::fmt::Display for FunctionGraphvizPrinter<'a> {
         let fun = &self.fun;
         let iseq_name = iseq_get_location(fun.iseq, 0);
         writeln!(f, "digraph G {{")?;
-        write_encoded!(f, "  # {iseq_name}")?;
+        write_encoded!(f, "# {iseq_name}")?;
         write!(f, "\n")?;
-        writeln!(f, "  node [shape=plaintext];")?;
+        writeln!(f, "node [shape=plaintext];")?;
+        writeln!(f, "mode=hier; overlap=false; splines=curved;")?;
         for block_id in fun.rpo() {
             writeln!(f, r#"  {block_id} [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">"#)?;
             write!(f, r#"<TR><TD ALIGN="LEFT" PORT="params" BGCOLOR="gray">{block_id}("#)?;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2123,7 +2123,7 @@ impl Function {
         }
 
         if get_option!(dump_hir_graphviz) {
-            println!("Optimized HIR Graphviz:\n{}", FunctionGraphvizPrinter::new(&self));
+            println!("{}", FunctionGraphvizPrinter::new(&self));
         }
     }
 
@@ -2327,8 +2327,8 @@ impl<'a> std::fmt::Display for FunctionGraphvizPrinter<'a> {
         use std::fmt::Write;
         let fun = &self.fun;
         let iseq_name = iseq_get_location(fun.iseq, 0);
-        writeln!(f, "digraph G {{")?;
-        write_encoded!(f, "# {iseq_name}")?;
+        write!(f, "digraph G {{ # ")?;
+        write_encoded!(f, "{iseq_name}")?;
         write!(f, "\n")?;
         writeln!(f, "node [shape=plaintext];")?;
         writeln!(f, "mode=hier; overlap=false; splines=true;")?;

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -37,6 +37,8 @@ pub struct Options {
     /// Dump High-level IR after optimization, right before codegen.
     pub dump_hir_opt: Option<DumpHIR>,
 
+    pub dump_hir_graphviz: bool,
+
     /// Dump low-level IR
     pub dump_lir: bool,
 
@@ -61,6 +63,7 @@ impl Default for Options {
             debug: false,
             dump_hir_init: None,
             dump_hir_opt: None,
+            dump_hir_graphviz: false,
             dump_lir: false,
             dump_disasm: false,
             perf: false,
@@ -186,6 +189,7 @@ fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         ("dump-hir" | "dump-hir-opt", "") => options.dump_hir_opt = Some(DumpHIR::WithoutSnapshot),
         ("dump-hir" | "dump-hir-opt", "all") => options.dump_hir_opt = Some(DumpHIR::All),
         ("dump-hir" | "dump-hir-opt", "debug") => options.dump_hir_opt = Some(DumpHIR::Debug),
+        ("dump-hir-graphviz", "") => options.dump_hir_graphviz = true,
 
         ("dump-hir-init", "") => options.dump_hir_init = Some(DumpHIR::WithoutSnapshot),
         ("dump-hir-init", "all") => options.dump_hir_init = Some(DumpHIR::All),


### PR DESCRIPTION
This is moderately useful just in stdout (copy and paste into a renderer) but potentially more useful alongside a tool that parses stdout looking for `digraph G { ... }` and renders those automatically.