### PR TITLE
Fix off-by-one in symbol next_id

### DIFF
--- a/symbol.c
+++ b/symbol.c
@@ -99,7 +99,9 @@ typedef struct {
     VALUE ids;
 } rb_symbols_t;
 
-rb_symbols_t ruby_global_symbols = {tNEXT_ID-1};
+rb_symbols_t ruby_global_symbols = {
+    .next_id = tNEXT_ID,
+};
 
 struct sym_set_static_sym_entry {
     VALUE sym;


### PR DESCRIPTION
Symbol last_id was changed to next_id, but it remained to be set to tNEXT_ID - 1 initially, causing the initial static symbol to overlap with the last built-in symbol in id.def.