### PR TITLE
ZJIT: Fix "immediate value too large" on cmp for x86_64

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -283,6 +283,14 @@ class TestZJIT < Test::Unit::TestCase
     }, insns: [:opt_eq], call_threshold: 2
   end
 
+  def test_opt_eq_with_minus_one
+    assert_compiles '[false, true]', %q{
+      def test(a) = a == -1
+      test(1) # profile opt_eq
+      [test(0), test(-1)]
+    }, insns: [:opt_eq], call_threshold: 2
+  end
+
   def test_opt_neq_dynamic
     # TODO(max): Don't split this test; instead, run all tests with and without
     # profiling.


### PR DESCRIPTION
This PR fixes an "immediate value too large" error when encoding `cmp` for x86_64.

When the rhs is `-1` (`UImm(0xffffffffffffffff)`), it doesn't fit in 32 bits. So it needs to be loaded into a register first.