### PR TITLE
ZJIT: x86: split: Fix live ranges index-out-of-range panic

### DIFF
--- a/test/.excludes-zjit/TestFixnum.rb
+++ b/test/.excludes-zjit/TestFixnum.rb
@@ -1,2 +1,0 @@
-# Issue: https://github.com/Shopify/ruby/issues/646
-exclude(/test_/, 'Tests make ZJIT panic on Ubuntu')


### PR DESCRIPTION
Combined with the fix from GH-14125, we now pass TestFixnum on x86.
Just need to be careful when landing.

- **ZJIT: x86: split: Query new assembler for live ranges**
- **ZJIT: Run TestFixnum**
- **[drop later] fix for "immediate value too large"**
