### PR TITLE
thread.c: fix `fiber_scheduler_closed` and `event_thread_end_hooked` clobbering

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -666,7 +666,7 @@ thread_start_func_2(rb_thread_t *th, VALUE *stack_start)
     // Ensure that we are not joinable.
     VM_ASSERT(UNDEF_P(th->value));
 
-    int fiber_scheduler_closed = 0, event_thread_end_hooked = 0;
+    volatile int fiber_scheduler_closed = 0, event_thread_end_hooked = 0;
     VALUE result = Qundef;
 
     EC_PUSH_TAG(th->ec);


### PR DESCRIPTION
The variables `fiber_scheduler_closed` and `event_thread_end_hooked` are modified between `setjmp` and `longjmp` calls. Since they are `int`s and their addresses are not used, they can be allocated on registers and get clobbered. Fix by making them `volatile`.

This bug can be observed by adding `printf`s for the variables before the `if`s where they are checked, building with Clang, and running `bootstraptest/test_ractor.rb:286`. The second time, the variables should be equal to 1, but they are reset to 0.