### PR TITLE
Implement `gen_fields_tbl` cache

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -3441,6 +3441,9 @@ rb_execution_context_update(rb_execution_context_t *ec)
     }
 
     ec->storage = rb_gc_location(ec->storage);
+
+    ec->gen_fields_cache.obj = rb_gc_location(ec->gen_fields_cache.obj);
+    ec->gen_fields_cache.fields_obj = rb_gc_location(ec->gen_fields_cache.fields_obj);
 }
 
 static enum rb_id_table_iterator_result
@@ -3505,6 +3508,9 @@ rb_execution_context_mark(const rb_execution_context_t *ec)
     rb_gc_mark(ec->private_const_reference);
 
     rb_gc_mark_movable(ec->storage);
+
+    rb_gc_mark_weak((VALUE *)&ec->gen_fields_cache.obj);
+    rb_gc_mark_weak((VALUE *)&ec->gen_fields_cache.fields_obj);
 }
 
 void rb_fiber_mark_self(rb_fiber_t *fib);

--- a/vm_core.h
+++ b/vm_core.h
@@ -1070,6 +1070,11 @@ struct rb_execution_context_struct {
 
     VALUE private_const_reference;
 
+    struct {
+        VALUE obj;
+        VALUE fields_obj;
+    } gen_fields_cache;
+
     /* for GC */
     struct {
         VALUE *stack_start;


### PR DESCRIPTION
When accessing an object ivars, it's not rare to access the same object's ivar quickly after.

For instance from enumerator.c:

```c
    enumerator = rb_obj_alloc(rb_cEnumerator);
    rb_ivar_set(enumerator, id_sliceafter_enum, enumerable);
    rb_ivar_set(enumerator, id_sliceafter_pat, pat);
    rb_ivar_set(enumerator, id_sliceafter_pred, pred);
```

If we keep a cache of the last IMEMO/fields we interacted with, we can save having to lookup the `gen_fields_tbl`, synchronize the VM lock, etc.