### PR TITLE
RTypedData: keep direct reference to IMEMO/fields

### DIFF
--- a/include/ruby/internal/abi.h
+++ b/include/ruby/internal/abi.h
@@ -24,7 +24,7 @@
  * In released versions of Ruby, this number is not defined since teeny
  * versions of Ruby should guarantee ABI compatibility.
  */
-#define RUBY_ABI_VERSION 2
+#define RUBY_ABI_VERSION 3
 
 /* Windows does not support weak symbols so ruby_abi_version will not exist
  * in the shared library. */

--- a/include/ruby/internal/core/rdata.h
+++ b/include/ruby/internal/core/rdata.h
@@ -133,12 +133,6 @@ struct RData {
      */
     RUBY_DATA_FUNC dmark;
 
-    /** Pointer to the actual C level struct that you want to wrap.
-      * This is in between dmark and dfree to allow DATA_PTR to continue
-      * to work for both RData and non-embedded RTypedData.
-      */
-    void *data;
-
     /**
      * This function is called when the object  is no longer used.  You need to
      * do whatever necessary to avoid memory leaks.
@@ -147,6 +141,12 @@ struct RData {
      *           impossible at that moment (that is why GC runs).
      */
     RUBY_DATA_FUNC dfree;
+
+    /** Pointer to the actual C level struct that you want to wrap.
+      * This is in between dmark and dfree to allow DATA_PTR to continue
+      * to work for both RData and non-embedded RTypedData.
+      */
+    void *data;
 };
 
 RBIMPL_SYMBOL_EXPORT_BEGIN()

--- a/include/ruby/internal/core/rtypeddata.h
+++ b/include/ruby/internal/core/rtypeddata.h
@@ -355,6 +355,9 @@ struct RTypedData {
     /** The part that all ruby objects have in common. */
     struct RBasic basic;
 
+    /** Direct reference to the slots that holds instance variables, if any **/
+    VALUE fields_obj;
+
     /**
      * This is a `const rb_data_type_t *const` value, with the low bits set:
      *


### PR DESCRIPTION
Similar to f3206cc79bec2fd852e81ec56de59f0a67ab32b7 but for TypedData.

It's quite common for TypedData objects to have a mix of reference in their struct and some ivars.
Since we do happen to have 8B free in the RtypedData struct, we could use it to keep a direct reference to the IMEMO/fields saving having to synchronize the VM and lookup the `gen_fields_tbl` on every ivar access.

For old school Data classes however, we don't have free space, but this API is soft-deprecated and no longer very common.

cc @tenderlove as mentioned.