### PR TITLE
Avoid marking CC children after invalidation

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -451,13 +451,16 @@ dump_object(VALUE obj, struct dump_config *dc)
             break;
 
           case imemo_callcache:
-            mid = vm_cc_cme((const struct rb_callcache *)obj)->called_id;
-            if (mid != 0) {
-                dump_append(dc, ", \"called_id\":");
-                dump_append_id(dc, mid);
-
+            {
                 VALUE klass = ((const struct rb_callcache *)obj)->klass;
-                if (klass != 0) {
+                if (klass != Qundef) {
+                    mid = vm_cc_cme((const struct rb_callcache *)obj)->called_id;
+                    if (mid != 0) {
+                        dump_append(dc, ", \"called_id\":");
+                        dump_append_id(dc, mid);
+
+                    }
+
                     dump_append(dc, ", \"receiver_class\":");
                     dump_append_ref(dc, klass);
                 }

--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -418,6 +418,8 @@ static inline const struct rb_callable_method_entry_struct *
 vm_cc_cme(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
+    VM_ASSERT(cc->klass != Qundef || !vm_cc_markable(cc));
+    VM_ASSERT(cc_check_class(cc->klass));
     VM_ASSERT(cc->call_ == NULL   || // not initialized yet
               !vm_cc_markable(cc) ||
               cc->cme_ != NULL);
@@ -430,6 +432,8 @@ vm_cc_call(const struct rb_callcache *cc)
 {
     VM_ASSERT(IMEMO_TYPE_P(cc, imemo_callcache));
     VM_ASSERT(cc->call_ != NULL);
+    VM_ASSERT(cc->klass != Qundef || !vm_cc_markable(cc));
+    VM_ASSERT(cc_check_class(cc->klass));
     return cc->call_;
 }
 


### PR DESCRIPTION
This should fix an ASAN crash which is occurring on CI that was introduced by our recent move of cc->klass to a weakref.

```
==2646891==ERROR: AddressSanitizer: use-after-poison on address 0x7f5b3363be20 at pc 0x5a7c84bf61e1 bp 0x7fffa787af50 sp 0x7fffa787af48
--
  | READ of size 8 at 0x7f5b3363be20 thread T0
  | #0 0x5a7c84bf61e0 in RB_BUILTIN_TYPE /tmp/ruby/src/trunk_asan/include/ruby/internal/value_type.h:191:30
  | #1 0x5a7c84bf61e0 in moved_or_living_object_strictly_p /tmp/ruby/src/trunk_asan/imemo.c:276:76
  | #2 0x5a7c84bf61e0 in rb_imemo_mark_and_move /tmp/ruby/src/trunk_asan/imemo.c:356:17
  | #3 0x5a7c84bb03e1 in rb_gc_update_object_references /tmp/ruby/src/trunk_asan/gc.c:4082:9
  | #4 0x5a7c84bb03e1 in gc_ref_update /tmp/ruby/src/trunk_asan/gc/default/default.c
  | #5 0x5a7c84bb03e1 in gc_update_references /tmp/ruby/src/trunk_asan/gc/default/default.c:7086:13
  | #6 0x5a7c84bb03e1 in gc_compact_finish /tmp/ruby/src/trunk_asan/gc/default/default.c:3414:5
```

Once klass becomes Qundef, it's disconnected, and won't be invalidated when the CME is. So once that happens we must not mark or attempt to move the cme_ field.