### PR TITLE
Favor `rb_gc_mark_and_move` over `rb_gc_location`

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -280,28 +280,20 @@ enumerator_ptr(VALUE obj)
 }
 
 static void
-proc_entry_mark(void *p)
+proc_entry_mark_and_move(void *p)
 {
     struct proc_entry *ptr = p;
-    rb_gc_mark_movable(ptr->proc);
-    rb_gc_mark_movable(ptr->memo);
-}
-
-static void
-proc_entry_compact(void *p)
-{
-    struct proc_entry *ptr = p;
-    ptr->proc = rb_gc_location(ptr->proc);
-    ptr->memo = rb_gc_location(ptr->memo);
+    rb_gc_mark_and_move(&ptr->proc);
+    rb_gc_mark_and_move(&ptr->memo);
 }
 
 static const rb_data_type_t proc_entry_data_type = {
     "proc_entry",
     {
-        proc_entry_mark,
+        proc_entry_mark_and_move,
         RUBY_TYPED_DEFAULT_FREE,
         NULL, // Nothing allocated externally, so don't need a memsize function
-        proc_entry_compact,
+        proc_entry_mark_and_move,
     },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE
 };
@@ -1280,26 +1272,19 @@ enumerator_size(VALUE obj)
  * Yielder
  */
 static void
-yielder_mark(void *p)
+yielder_mark_and_move(void *p)
 {
     struct yielder *ptr = p;
-    rb_gc_mark_movable(ptr->proc);
-}
-
-static void
-yielder_compact(void *p)
-{
-    struct yielder *ptr = p;
-    ptr->proc = rb_gc_location(ptr->proc);
+    rb_gc_mark_and_move(&ptr->proc);
 }
 
 static const rb_data_type_t yielder_data_type = {
     "yielder",
     {
-        yielder_mark,
+        yielder_mark_and_move,
         RUBY_TYPED_DEFAULT_FREE,
         NULL,
-        yielder_compact,
+        yielder_mark_and_move,
     },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE
 };
@@ -1410,28 +1395,20 @@ yielder_new(void)
  * Generator
  */
 static void
-generator_mark(void *p)
+generator_mark_and_move(void *p)
 {
     struct generator *ptr = p;
-    rb_gc_mark_movable(ptr->proc);
-    rb_gc_mark_movable(ptr->obj);
-}
-
-static void
-generator_compact(void *p)
-{
-    struct generator *ptr = p;
-    ptr->proc = rb_gc_location(ptr->proc);
-    ptr->obj = rb_gc_location(ptr->obj);
+    rb_gc_mark_and_move(&ptr->proc);
+    rb_gc_mark_and_move(&ptr->obj);
 }
 
 static const rb_data_type_t generator_data_type = {
     "generator",
     {
-        generator_mark,
+        generator_mark_and_move,
         RUBY_TYPED_DEFAULT_FREE,
         NULL,
-        generator_compact,
+        generator_mark_and_move,
     },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE
 };
@@ -2894,19 +2871,11 @@ stop_result(VALUE self)
  */
 
 static void
-producer_mark(void *p)
+producer_mark_and_move(void *p)
 {
     struct producer *ptr = p;
-    rb_gc_mark_movable(ptr->init);
-    rb_gc_mark_movable(ptr->proc);
-}
-
-static void
-producer_compact(void *p)
-{
-    struct producer *ptr = p;
-    ptr->init = rb_gc_location(ptr->init);
-    ptr->proc = rb_gc_location(ptr->proc);
+    rb_gc_mark_and_move(&ptr->init);
+    rb_gc_mark_and_move(&ptr->proc);
 }
 
 #define producer_free RUBY_TYPED_DEFAULT_FREE
@@ -2920,10 +2889,10 @@ producer_memsize(const void *p)
 static const rb_data_type_t producer_data_type = {
     "producer",
     {
-        producer_mark,
+        producer_mark_and_move,
         producer_free,
         producer_memsize,
-        producer_compact,
+        producer_mark_and_move,
     },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE
 };
@@ -3082,17 +3051,10 @@ enumerator_s_produce(int argc, VALUE *argv, VALUE klass)
  */
 
 static void
-enum_chain_mark(void *p)
+enum_chain_mark_and_move(void *p)
 {
     struct enum_chain *ptr = p;
-    rb_gc_mark_movable(ptr->enums);
-}
-
-static void
-enum_chain_compact(void *p)
-{
-    struct enum_chain *ptr = p;
-    ptr->enums = rb_gc_location(ptr->enums);
+    rb_gc_mark_and_move(&ptr->enums);
 }
 
 #define enum_chain_free RUBY_TYPED_DEFAULT_FREE
@@ -3106,10 +3068,10 @@ enum_chain_memsize(const void *p)
 static const rb_data_type_t enum_chain_data_type = {
     "chain",
     {
-        enum_chain_mark,
+        enum_chain_mark_and_move,
         enum_chain_free,
         enum_chain_memsize,
-        enum_chain_compact,
+        enum_chain_mark_and_move,
     },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };
@@ -3404,17 +3366,10 @@ enumerator_plus(VALUE obj, VALUE eobj)
  */
 
 static void
-enum_product_mark(void *p)
+enum_product_mark_and_move(void *p)
 {
     struct enum_product *ptr = p;
-    rb_gc_mark_movable(ptr->enums);
-}
-
-static void
-enum_product_compact(void *p)
-{
-    struct enum_product *ptr = p;
-    ptr->enums = rb_gc_location(ptr->enums);
+    rb_gc_mark_and_move(&ptr->enums);
 }
 
 #define enum_product_free RUBY_TYPED_DEFAULT_FREE
@@ -3428,10 +3383,10 @@ enum_product_memsize(const void *p)
 static const rb_data_type_t enum_product_data_type = {
     "product",
     {
-        enum_product_mark,
+        enum_product_mark_and_move,
         enum_product_free,
         enum_product_memsize,
-        enum_product_compact,
+        enum_product_mark_and_move,
     },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY
 };

--- a/error.c
+++ b/error.c
@@ -2517,30 +2517,21 @@ typedef struct name_error_message_struct {
 } name_error_message_t;
 
 static void
-name_err_mesg_mark(void *p)
+name_err_mesg_mark_and_move(void *p)
 {
     name_error_message_t *ptr = (name_error_message_t *)p;
-    rb_gc_mark_movable(ptr->mesg);
-    rb_gc_mark_movable(ptr->recv);
-    rb_gc_mark_movable(ptr->name);
-}
-
-static void
-name_err_mesg_update(void *p)
-{
-    name_error_message_t *ptr = (name_error_message_t *)p;
-    ptr->mesg = rb_gc_location(ptr->mesg);
-    ptr->recv = rb_gc_location(ptr->recv);
-    ptr->name = rb_gc_location(ptr->name);
+    rb_gc_mark_and_move(&ptr->mesg);
+    rb_gc_mark_and_move(&ptr->recv);
+    rb_gc_mark_and_move(&ptr->name);
 }
 
 static const rb_data_type_t name_err_mesg_data_type = {
     "name_err_mesg",
     {
-        name_err_mesg_mark,
+        name_err_mesg_mark_and_move,
         RUBY_TYPED_DEFAULT_FREE,
         NULL, // No external memory to report,
-        name_err_mesg_update,
+        name_err_mesg_mark_and_move,
     },
     0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE
 };

--- a/gc.c
+++ b/gc.c
@@ -3028,7 +3028,7 @@ rb_gc_mark_roots(void *objspace, const char **categoryp)
     mark_current_machine_context(ec);
 
     MARK_CHECKPOINT("global_symbols");
-    rb_sym_global_symbols_mark();
+    rb_sym_global_symbols_mark_and_move();
 
     MARK_CHECKPOINT("finish");
 
@@ -4045,7 +4045,7 @@ rb_gc_update_vm_references(void *objspace)
 
     rb_vm_update_references(vm);
     rb_gc_update_global_tbl();
-    rb_sym_global_symbols_update_references();
+    rb_sym_global_symbols_mark_and_move();
 
 #if USE_YJIT
     void rb_yjit_root_update_references(void); // in Rust

--- a/internal/symbol.h
+++ b/internal/symbol.h
@@ -17,8 +17,7 @@
 #endif
 
 /* symbol.c */
-void rb_sym_global_symbols_mark(void);
-void rb_sym_global_symbols_update_references(void);
+void rb_sym_global_symbols_mark_and_move(void);
 VALUE rb_to_symbol_type(VALUE obj);
 VALUE rb_sym_intern(const char *ptr, long len, rb_encoding *enc);
 VALUE rb_sym_intern_ascii(const char *ptr, long len);

--- a/set.c
+++ b/set.c
@@ -172,9 +172,7 @@ set_foreach_replace(st_data_t key, st_data_t argp, int error)
 static int
 set_replace_ref(st_data_t *key, st_data_t argp, int existing)
 {
-    if (rb_gc_location((VALUE)*key) != (VALUE)*key) {
-        *key = rb_gc_location((VALUE)*key);
-    }
+    rb_gc_mark_and_move((VALUE *)key);
 
     return ST_CONTINUE;
 }

--- a/symbol.c
+++ b/symbol.c
@@ -371,21 +371,12 @@ Init_sym(void)
 }
 
 void
-rb_sym_global_symbols_mark(void)
+rb_sym_global_symbols_mark_and_move(void)
 {
     rb_symbols_t *symbols = &ruby_global_symbols;
 
-    rb_gc_mark_movable(symbols->sym_set);
-    rb_gc_mark_movable(symbols->ids);
-}
-
-void
-rb_sym_global_symbols_update_references(void)
-{
-    rb_symbols_t *symbols = &ruby_global_symbols;
-
-    symbols->sym_set = rb_gc_location(symbols->sym_set);
-    symbols->ids = rb_gc_location(symbols->ids);
+    rb_gc_mark_and_move(&symbols->sym_set);
+    rb_gc_mark_and_move(&symbols->ids);
 }
 
 static int

--- a/time.c
+++ b/time.c
@@ -1888,39 +1888,25 @@ force_make_tm(VALUE time, struct time_object *tobj)
 }
 
 static void
-time_mark(void *ptr)
+time_mark_and_move(void *ptr)
 {
     struct time_object *tobj = ptr;
     if (!FIXWV_P(tobj->timew)) {
-        rb_gc_mark_movable(w2v(tobj->timew));
+        rb_gc_mark_and_move(&WIDEVAL_GET(tobj->timew));
     }
-    rb_gc_mark_movable(tobj->vtm.year);
-    rb_gc_mark_movable(tobj->vtm.subsecx);
-    rb_gc_mark_movable(tobj->vtm.utc_offset);
-    rb_gc_mark_movable(tobj->vtm.zone);
-}
-
-static void
-time_compact(void *ptr)
-{
-    struct time_object *tobj = ptr;
-    if (!FIXWV_P(tobj->timew)) {
-        WIDEVAL_GET(tobj->timew) = WIDEVAL_WRAP(rb_gc_location(w2v(tobj->timew)));
-    }
-
-    tobj->vtm.year = rb_gc_location(tobj->vtm.year);
-    tobj->vtm.subsecx = rb_gc_location(tobj->vtm.subsecx);
-    tobj->vtm.utc_offset = rb_gc_location(tobj->vtm.utc_offset);
-    tobj->vtm.zone = rb_gc_location(tobj->vtm.zone);
+    rb_gc_mark_and_move(&tobj->vtm.year);
+    rb_gc_mark_and_move(&tobj->vtm.subsecx);
+    rb_gc_mark_and_move(&tobj->vtm.utc_offset);
+    rb_gc_mark_and_move(&tobj->vtm.zone);
 }
 
 static const rb_data_type_t time_data_type = {
     .wrap_struct_name = "time",
     .function = {
-        .dmark = time_mark,
+        .dmark = time_mark_and_move,
         .dfree = RUBY_TYPED_DEFAULT_FREE,
         .dsize = NULL,
-        .dcompact = time_compact,
+        .dcompact = time_mark_and_move,
     },
     .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_FROZEN_SHAREABLE | RUBY_TYPED_WB_PROTECTED | RUBY_TYPED_EMBEDDABLE,
 };


### PR DESCRIPTION
Previous discussion in https://github.com/ruby/ruby/pull/14076

The `p->field = rb_gc_location(p->field)` isn't ideal because it means all
references are rewritten on compaction, regardless of whether the referenced
object has moved. This isn't good for caches nor for Copy-on-Write.

`rb_gc_mark_and_move` avoid needless writes, and most of the time allow to
have a single function for both marking and updating references.
