### PR TITLE
ZJIT: Create HeapObject Type

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5564,7 +5564,7 @@ mod opt_tests {
             fn test@<compiled>:5:
             bb0(v0:BasicObject):
               PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-              v6:BasicObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, BasicObject[class_exact*:Object@VALUE(0x1000)]
+              v6:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
               v7:BasicObject = SendWithoutBlockDirect v6, :foo (0x1038)
               Return v7
         "#]]);
@@ -5604,7 +5604,7 @@ mod opt_tests {
             fn test@<compiled>:6:
             bb0(v0:BasicObject):
               PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-              v6:BasicObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, BasicObject[class_exact*:Object@VALUE(0x1000)]
+              v6:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
               v7:BasicObject = SendWithoutBlockDirect v6, :foo (0x1038)
               Return v7
         "#]]);
@@ -5623,7 +5623,7 @@ mod opt_tests {
             bb0(v0:BasicObject):
               v2:Fixnum[3] = Const Value(3)
               PatchPoint MethodRedefined(Object@0x1000, Integer@0x1008, cme:0x1010)
-              v7:BasicObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, BasicObject[class_exact*:Object@VALUE(0x1000)]
+              v7:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
               v8:BasicObject = SendWithoutBlockDirect v7, :Integer (0x1038), v2
               Return v8
         "#]]);
@@ -5645,7 +5645,7 @@ mod opt_tests {
               v2:Fixnum[1] = Const Value(1)
               v3:Fixnum[2] = Const Value(2)
               PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-              v8:BasicObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, BasicObject[class_exact*:Object@VALUE(0x1000)]
+              v8:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
               v9:BasicObject = SendWithoutBlockDirect v8, :foo (0x1038), v2, v3
               Return v9
         "#]]);
@@ -5668,10 +5668,10 @@ mod opt_tests {
             fn test@<compiled>:7:
             bb0(v0:BasicObject):
               PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-              v8:BasicObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, BasicObject[class_exact*:Object@VALUE(0x1000)]
+              v8:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
               v9:BasicObject = SendWithoutBlockDirect v8, :foo (0x1038)
               PatchPoint MethodRedefined(Object@0x1000, bar@0x1040, cme:0x1048)
-              v11:BasicObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, BasicObject[class_exact*:Object@VALUE(0x1000)]
+              v11:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
               v12:BasicObject = SendWithoutBlockDirect v11, :bar (0x1038)
               Return v12
         "#]]);
@@ -6473,7 +6473,7 @@ mod opt_tests {
             fn test@<compiled>:8:
             bb0(v0:BasicObject, v1:BasicObject):
               PatchPoint MethodRedefined(C@0x1000, foo@0x1008, cme:0x1010)
-              v7:BasicObject[class_exact:C] = GuardType v1, BasicObject[class_exact:C]
+              v7:HeapObject[class_exact:C] = GuardType v1, HeapObject[class_exact:C]
               v8:BasicObject = SendWithoutBlockDirect v7, :foo (0x1038)
               Return v8
         "#]]);
@@ -7426,7 +7426,7 @@ mod opt_tests {
             fn test@<compiled>:3:
             bb0(v0:BasicObject):
               PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-              v6:BasicObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, BasicObject[class_exact*:Object@VALUE(0x1000)]
+              v6:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
               v7:BasicObject = SendWithoutBlockDirect v6, :foo (0x1038)
               Return v7
         "#]]);
@@ -7495,7 +7495,7 @@ mod opt_tests {
             fn test@<compiled>:6:
             bb0(v0:BasicObject, v1:BasicObject):
               PatchPoint MethodRedefined(C@0x1000, foo@0x1008, cme:0x1010)
-              v7:BasicObject[class_exact:C] = GuardType v1, BasicObject[class_exact:C]
+              v7:HeapObject[class_exact:C] = GuardType v1, HeapObject[class_exact:C]
               v8:BasicObject = GetIvar v7, :@foo
               Return v8
         "#]]);
@@ -7516,7 +7516,7 @@ mod opt_tests {
             fn test@<compiled>:6:
             bb0(v0:BasicObject, v1:BasicObject):
               PatchPoint MethodRedefined(C@0x1000, foo@0x1008, cme:0x1010)
-              v7:BasicObject[class_exact:C] = GuardType v1, BasicObject[class_exact:C]
+              v7:HeapObject[class_exact:C] = GuardType v1, HeapObject[class_exact:C]
               v8:BasicObject = GetIvar v7, :@foo
               Return v8
         "#]]);

--- a/zjit/src/hir_type/gen_hir_type.rb
+++ b/zjit/src/hir_type/gen_hir_type.rb
@@ -156,6 +156,7 @@ add_union "BuiltinExact", $builtin_exact
 add_union "Subclass", $subclass
 add_union "BoolExact", [true_exact.name, false_exact.name]
 add_union "Immediate", [fixnum.name, flonum.name, static_sym.name, nil_exact.name, true_exact.name, false_exact.name, undef_.name]
+$numeric_bits["HeapObject"] = $numeric_bits["BasicObject"] & ~$numeric_bits["Immediate"]
 
 # ===== Finished generating the DAG; write Rust code =====
 
@@ -165,7 +166,9 @@ $bits.keys.sort.map {|type_name|
   subtypes = $bits[type_name].join(" | ")
   puts "  pub const #{type_name}: u64 = #{subtypes};"
 }
-puts "  pub const AllBitPatterns: [(&'static str, u64); #{$bits.size}] = ["
+puts "  pub const HeapObject: u64 = BasicObject & !Immediate;"
+# +1 for HeapObject
+puts "  pub const AllBitPatterns: [(&'static str, u64); #{$bits.size+1}] = ["
 # Sort the bit patterns by decreasing value so that we can print the densest
 # possible to-string representation of a Type. For example, CSigned instead of
 # CInt8|CInt16|...
@@ -181,4 +184,5 @@ puts "pub mod types {
 $bits.keys.sort.map {|type_name|
     puts "  pub const #{type_name}: Type = Type::from_bits(bits::#{type_name});"
 }
+puts "  pub const HeapObject: Type = Type::from_bits(bits::HeapObject);"
 puts "}"

--- a/zjit/src/hir_type/gen_hir_type.rb
+++ b/zjit/src/hir_type/gen_hir_type.rb
@@ -156,6 +156,7 @@ add_union "BuiltinExact", $builtin_exact
 add_union "Subclass", $subclass
 add_union "BoolExact", [true_exact.name, false_exact.name]
 add_union "Immediate", [fixnum.name, flonum.name, static_sym.name, nil_exact.name, true_exact.name, false_exact.name, undef_.name]
+$bits["HeapObject"] = ["BasicObject & !Immediate"]
 $numeric_bits["HeapObject"] = $numeric_bits["BasicObject"] & ~$numeric_bits["Immediate"]
 
 # ===== Finished generating the DAG; write Rust code =====
@@ -166,9 +167,7 @@ $bits.keys.sort.map {|type_name|
   subtypes = $bits[type_name].join(" | ")
   puts "  pub const #{type_name}: u64 = #{subtypes};"
 }
-puts "  pub const HeapObject: u64 = BasicObject & !Immediate;"
-# +1 for HeapObject
-puts "  pub const AllBitPatterns: [(&'static str, u64); #{$bits.size+1}] = ["
+puts "  pub const AllBitPatterns: [(&'static str, u64); #{$bits.size}] = ["
 # Sort the bit patterns by decreasing value so that we can print the densest
 # possible to-string representation of a Type. For example, CSigned instead of
 # CInt8|CInt16|...
@@ -184,5 +183,4 @@ puts "pub mod types {
 $bits.keys.sort.map {|type_name|
     puts "  pub const #{type_name}: Type = Type::from_bits(bits::#{type_name});"
 }
-puts "  pub const HeapObject: Type = Type::from_bits(bits::HeapObject);"
 puts "}"

--- a/zjit/src/hir_type/hir_type.inc.rs
+++ b/zjit/src/hir_type/hir_type.inc.rs
@@ -38,6 +38,7 @@ mod bits {
   pub const HashExact: u64 = 1u64 << 23;
   pub const HashSubclass: u64 = 1u64 << 24;
   pub const HeapFloat: u64 = 1u64 << 25;
+  pub const HeapObject: u64 = BasicObject & !Immediate;
   pub const Immediate: u64 = FalseClass | Fixnum | Flonum | NilClass | StaticSymbol | TrueClass | Undef;
   pub const Integer: u64 = Bignum | Fixnum;
   pub const Module: u64 = Class | ModuleExact | ModuleSubclass;
@@ -65,7 +66,6 @@ mod bits {
   pub const Symbol: u64 = DynamicSymbol | StaticSymbol;
   pub const TrueClass: u64 = 1u64 << 40;
   pub const Undef: u64 = 1u64 << 41;
-  pub const HeapObject: u64 = BasicObject & !Immediate;
   pub const AllBitPatterns: [(&'static str, u64); 66] = [
     ("Any", Any),
     ("RubyValue", RubyValue),
@@ -176,6 +176,7 @@ pub mod types {
   pub const HashExact: Type = Type::from_bits(bits::HashExact);
   pub const HashSubclass: Type = Type::from_bits(bits::HashSubclass);
   pub const HeapFloat: Type = Type::from_bits(bits::HeapFloat);
+  pub const HeapObject: Type = Type::from_bits(bits::HeapObject);
   pub const Immediate: Type = Type::from_bits(bits::Immediate);
   pub const Integer: Type = Type::from_bits(bits::Integer);
   pub const Module: Type = Type::from_bits(bits::Module);
@@ -203,5 +204,4 @@ pub mod types {
   pub const Symbol: Type = Type::from_bits(bits::Symbol);
   pub const TrueClass: Type = Type::from_bits(bits::TrueClass);
   pub const Undef: Type = Type::from_bits(bits::Undef);
-  pub const HeapObject: Type = Type::from_bits(bits::HeapObject);
 }

--- a/zjit/src/hir_type/hir_type.inc.rs
+++ b/zjit/src/hir_type/hir_type.inc.rs
@@ -65,7 +65,8 @@ mod bits {
   pub const Symbol: u64 = DynamicSymbol | StaticSymbol;
   pub const TrueClass: u64 = 1u64 << 40;
   pub const Undef: u64 = 1u64 << 41;
-  pub const AllBitPatterns: [(&'static str, u64); 65] = [
+  pub const HeapObject: u64 = BasicObject & !Immediate;
+  pub const AllBitPatterns: [(&'static str, u64); 66] = [
     ("Any", Any),
     ("RubyValue", RubyValue),
     ("Immediate", Immediate),
@@ -75,6 +76,7 @@ mod bits {
     ("BuiltinExact", BuiltinExact),
     ("BoolExact", BoolExact),
     ("TrueClass", TrueClass),
+    ("HeapObject", HeapObject),
     ("String", String),
     ("Subclass", Subclass),
     ("StringSubclass", StringSubclass),
@@ -201,4 +203,5 @@ pub mod types {
   pub const Symbol: Type = Type::from_bits(bits::Symbol);
   pub const TrueClass: Type = Type::from_bits(bits::TrueClass);
   pub const Undef: Type = Type::from_bits(bits::Undef);
+  pub const HeapObject: Type = Type::from_bits(bits::HeapObject);
 }

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -606,6 +606,8 @@ mod tests {
         assert_subtype(types::DynamicSymbol, types::HeapObject);
         assert_not_subtype(types::Flonum, types::HeapObject);
         assert_subtype(types::HeapFloat, types::HeapObject);
+        assert_not_subtype(types::BasicObject, types::HeapObject);
+        assert_not_subtype(types::Object, types::HeapObject);
         assert_not_subtype(types::Immediate, types::HeapObject);
         assert_not_subtype(types::HeapObject, types::Immediate);
         crate::cruby::with_rubyvm(|| {


### PR DESCRIPTION
This is a counterpoint to the Immediate type and it represents all BasicObject subclasses except for the several immediate objects.

If we know something is a HeapObject, we know we can treat it as an RBasic pointer.