### PR TITLE
Add link to Ruby options doc in help text

### DIFF
--- a/depend
+++ b/depend
@@ -14598,6 +14598,7 @@ ruby.$(OBJEXT): $(top_srcdir)/prism/util/pm_newline_list.h
 ruby.$(OBJEXT): $(top_srcdir)/prism/util/pm_string.h
 ruby.$(OBJEXT): $(top_srcdir)/prism/util/pm_strncasecmp.h
 ruby.$(OBJEXT): $(top_srcdir)/prism/util/pm_strpbrk.h
+ruby.$(OBJEXT): $(top_srcdir)/version.h
 ruby.$(OBJEXT): {$(VPATH)}assert.h
 ruby.$(OBJEXT): {$(VPATH)}atomic.h
 ruby.$(OBJEXT): {$(VPATH)}backward/2/assume.h
@@ -14781,6 +14782,7 @@ ruby.$(OBJEXT): {$(VPATH)}prism/ast.h
 ruby.$(OBJEXT): {$(VPATH)}prism/diagnostic.h
 ruby.$(OBJEXT): {$(VPATH)}prism/version.h
 ruby.$(OBJEXT): {$(VPATH)}prism_compile.h
+ruby.$(OBJEXT): {$(VPATH)}revision.h
 ruby.$(OBJEXT): {$(VPATH)}ruby.c
 ruby.$(OBJEXT): {$(VPATH)}ruby_assert.h
 ruby.$(OBJEXT): {$(VPATH)}ruby_atomic.h

--- a/doc/ruby/options.md
+++ b/doc/ruby/options.md
@@ -1,3 +1,10 @@
+<!---
+  CAUTION
+
+  This page on docs.ruby-lang.org is displayed in Ruby's help message (-h and --help).
+  Please make sure you update the link when renaming or moving this file.
+--->
+
 # Ruby Command-Line Options
 
 ## About the Examples

--- a/ruby.c
+++ b/ruby.c
@@ -61,6 +61,7 @@
 #include "ruby/util.h"
 #include "ruby/version.h"
 #include "ruby/internal/error.h"
+#include "version.h"
 
 #define singlebit_only_p(x) !((x) & ((x)-1))
 STATIC_ASSERT(Qnil_1bit_from_Qfalse, singlebit_only_p(Qnil^Qfalse));
@@ -403,7 +404,10 @@ usage(const char *name, int help, int highlight, int columns)
     unsigned int w = (columns > 80 ? (columns - 79) / 2 : 0) + 16;
 #define SHOW(m) show_usage_line(&(m), help, highlight, w, columns)
 
-    printf("%sUsage:%s %s [options] [--] [filepath] [arguments]\n", sb, se, name);
+    printf("%sUsage:%s %s [options] [--] [filepath] [arguments]\n\n", sb, se, name);
+    printf("Details and examples at https://docs.ruby-lang.org/en/%s/ruby/options_md.html\n",
+           RUBY_PATCHLEVEL == -1 ? "master" : STRINGIZE(RUBY_VERSION_MAJOR) "." STRINGIZE(RUBY_VERSION_MINOR));
+
     for (i = 0; i < num; ++i)
         SHOW(usage_msg[i]);
 

--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -49,18 +49,24 @@ class TestRubyOptions < Test::Unit::TestCase
 
   def test_usage
     assert_in_out_err(%w(-h)) do |r, e|
-      assert_operator(r.size, :<=, 25)
-      longer = r[1..-1].select {|x| x.size >= 80}
+      assert_operator(r.size, :<=, 26)
+      longer = r[3..-1].select {|x| x.size >= 80}
       assert_equal([], longer)
       assert_equal([], e)
+
+      version = RUBY_PATCHLEVEL == -1 ? "master" : "#{RUBY_VERSION_MAJOR}.#{RUBY_VERSION_MINOR}"
+      assert_include(r, "Details and examples at https://docs.ruby-lang.org/en/#{version}/ruby/options_md.html")
     end
   end
 
   def test_usage_long
     assert_in_out_err(%w(--help)) do |r, e|
-      longer = r[1..-1].select {|x| x.size > 80}
+      longer = r[3..-1].select {|x| x.size > 80}
       assert_equal([], longer)
       assert_equal([], e)
+
+      version = RUBY_PATCHLEVEL == -1 ? "master" : "#{RUBY_VERSION_MAJOR}.#{RUBY_VERSION_MINOR}"
+      assert_include(r, "Details and examples at https://docs.ruby-lang.org/en/#{version}/ruby/options_md.html")
     end
   end
 


### PR DESCRIPTION
Adds link to https://docs.ruby-lang.org/en/master/ruby/options_md.html in Ruby help text (-h and --help).