### PR TITLE
Fix return value of setting in GC.config

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -4354,7 +4354,7 @@ gc_config_set(rb_execution_context_t *ec, VALUE self, VALUE hash)
 
     rb_gc_impl_config_set(objspace, hash);
 
-    return rb_gc_impl_config_get(objspace);
+    return Qnil;
 }
 
 static VALUE

--- a/gc.rb
+++ b/gc.rb
@@ -324,17 +324,17 @@ module GC
   #   reasons, it is recommended to warm up an application using +Process.warmup+
   #   before setting this parameter to +false+.
   def self.config hash = nil
-    return Primitive.gc_config_get unless hash
-
-    if(Primitive.cexpr!("RBOOL(RB_TYPE_P(hash, T_HASH))"))
+    if Primitive.cexpr!("RBOOL(RB_TYPE_P(hash, T_HASH))")
       if hash.include?(:implementation)
         raise ArgumentError, 'Attempting to set read-only key "Implementation"'
       end
 
       Primitive.gc_config_set hash
-    else
+    elsif hash != nil
       raise ArgumentError
     end
+
+    Primitive.gc_config_get
   end
 
   # call-seq:

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -75,12 +75,9 @@ class TestGc < Test::Unit::TestCase
     GC.start
   end
 
-  def test_gc_config_setting_returns_nil_for_missing_keys
-    missing_value = GC.config(no_such_key: true)[:no_such_key]
-    assert_nil(missing_value)
-  ensure
-    GC.config(full_mark: true)
-    GC.start
+  def test_gc_config_setting_returns_config_hash
+    hash = GC.config(no_such_key: true)
+    assert_equal(GC.config, hash)
   end
 
   def test_gc_config_disable_major


### PR DESCRIPTION
gc_config_set returned rb_gc_impl_config_get, but gc_config_get also added the implementation key to the return value. This caused the return value of GC.config to differ depending on whether the optional hash argument is provided or not.