### PR TITLE
object_id_to_ref: complete incremental GC before iterating

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1755,7 +1755,6 @@ rb_gc_pointer_to_heap_p(VALUE obj)
 #define LAST_OBJECT_ID() (object_id_counter * OBJ_ID_INCREMENT)
 static VALUE id2ref_value = 0;
 static st_table *id2ref_tbl = NULL;
-static bool id2ref_tbl_built = false;
 
 #if SIZEOF_SIZE_T == SIZEOF_LONG_LONG
 static size_t object_id_counter = 1;
@@ -1947,6 +1946,7 @@ build_id2ref_i(VALUE obj, void *data)
       case T_CLASS:
       case T_MODULE:
         if (RCLASS(obj)->object_id) {
+            RUBY_ASSERT(!rb_objspace_garbage_object_p(obj));
             st_insert(id2ref_tbl, RCLASS(obj)->object_id, obj);
         }
         break;
@@ -1955,6 +1955,7 @@ build_id2ref_i(VALUE obj, void *data)
         break;
       default:
         if (rb_shape_obj_has_id(obj)) {
+            RUBY_ASSERT(!rb_objspace_garbage_object_p(obj));
             st_insert(id2ref_tbl, rb_obj_id(obj), obj);
         }
         break;
@@ -1979,12 +1980,12 @@ object_id_to_ref(void *objspace_ptr, VALUE object_id)
 
         // build_id2ref_i will most certainly malloc, which could trigger GC and sweep
         // objects we just added to the table.
-        bool gc_disabled = RTEST(rb_gc_disable_no_rest());
+        // By calling rb_gc_disable() we also save having to handle potentially garbage objects.
+        bool gc_disabled = RTEST(rb_gc_disable());
         {
             rb_gc_impl_each_object(objspace, build_id2ref_i, (void *)id2ref_tbl);
         }
         if (!gc_disabled) rb_gc_enable();
-        id2ref_tbl_built = true;
     }
 
     VALUE obj;
@@ -2036,10 +2037,9 @@ obj_free_object_id(VALUE obj)
             RUBY_ASSERT(FIXNUM_P(obj_id) || RB_TYPE_P(obj_id, T_BIGNUM));
 
             if (!st_delete(id2ref_tbl, (st_data_t *)&obj_id, NULL)) {
-                // If we're currently building the table then it's not a bug.
                 // The the object is a T_IMEMO/fields, then it's possible the actual object
                 // has been garbage collected already.
-                if (id2ref_tbl_built && !RB_TYPE_P(obj, T_IMEMO)) {
+                if (!RB_TYPE_P(obj, T_IMEMO)) {
                     rb_bug("Object ID seen, but not in _id2ref table: object_id=%llu object=%s", NUM2ULL(obj_id), rb_obj_info(obj));
                 }
             }


### PR DESCRIPTION
Fix: https://github.com/ruby/ruby/pull/14146#

Otherwise dealing with garbage objects is tricky.

Hoping this would fix the following ASAN issue:

```
=================================================================
==252918==ERROR: AddressSanitizer: use-after-poison on address 0x7f63c776f4a8 at pc 0x6340aff886b3 bp 0x7fffcfbe8730 sp 0x7fffcfbe8728
READ of size 8 at 0x7f63c776f4a8 thread T0
    #0 0x6340aff886b2 in RB_FL_TEST_RAW /tmp/ruby/src/trunk_asan/include/ruby/internal/fl_type.h:466:25
    #1 0x6340aff886b2 in rb_imemo_fields_ptr /tmp/ruby/src/trunk_asan/internal/imemo.h:291:9
    #2 0x6340aff886b2 in rb_obj_field_get /tmp/ruby/src/trunk_asan/variable.c:1356:18
    #3 0x6340afc18fe3 in object_id /tmp/ruby/src/trunk_asan/gc.c:1938:12
    #4 0x6340afc18fe3 in rb_find_object_id /tmp/ruby/src/trunk_asan/gc.c:2171:12
    #5 0x6340afc18fe3 in rb_obj_id /tmp/ruby/src/trunk_asan/gc.c:2226:12
    #6 0x6340afc2952e in build_id2ref_i /tmp/ruby/src/trunk_asan/gc.c:1958:35
    #7 0x6340afc2952e in rb_gc_impl_each_object /tmp/ruby/src/trunk_asan/gc/default/default.c:3079:17
    #8 0x6340afc2952e in object_id_to_ref /tmp/ruby/src/trunk_asan/gc.c:1984:13
    #9 0x6340afc2952e in id2ref /tmp/ruby/src/trunk_asan/gc.c:2143:17
    #10 0x6340afc2952e in os_id2ref /tmp/ruby/src/trunk_asan/gc.c:2157:12
    #11 0x6340b0016c57 in vm_call_cfunc_with_frame_ /tmp/ruby/src/trunk_asan/vm_insnhelper.c:3848:11
```