### PR TITLE
ZJIT: Fix "memory operand with non-register base"

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -148,6 +148,18 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 2
   end
 
+  def test_send_on_heap_object_in_spilled_arg
+    # This leads to a register spill, so not using `assert_compiles`
+    assert_runs 'Hash', %q{
+      def entry(a1, a2, a3, a4, a5, a6, a7, a8, a9)
+        a9.itself.class
+      end
+
+      entry(1, 2, 3, 4, 5, 6, 7, 8, {}) # profile
+      entry(1, 2, 3, 4, 5, 6, 7, 8, {})
+    }, call_threshold: 2
+  end
+
   def test_invokebuiltin
     omit 'Test fails at the moment due to not handling optional parameters'
     assert_compiles '["."]', %q{

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -111,7 +111,7 @@ impl Opnd
                 })
             },
 
-            _ => unreachable!("memory operand with non-register base")
+            _ => unreachable!("memory operand with non-register base: {base:?}")
         }
     }
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1089,6 +1089,7 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, guard
         asm_comment!(asm, "guard exact class for non-immediate types");
 
         // If val isn't in a register, load it to use it as the base of Opnd::mem later.
+        // TODO: Max thinks codegen should not care about the shapes of the operands except to create them. (Shopify/ruby#685)
         let val = match val {
             Opnd::Reg(_) | Opnd::VReg { .. } => val,
             _ => asm.load(val),


### PR DESCRIPTION
Follow-up on: https://github.com/ruby/ruby/pull/14136

This fixes a crash on benchmarks with "internal error: entered unreachable code: memory operand with non-register base".

`val` can be of any operand type. When it's a memory operand, e.g. a spilled basic block argument, you cannot use it as the base of `Opnd::mem(64, val, RUBY_OFFSET_RBASIC_KLASS)`. So this PR loads such an operand into a register. It does it a bit early to hopefully speed up checks on `val`.