### PR TITLE
ZJIT: Add compile/profile/GC/invalidation time stats

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -42,7 +42,7 @@ class << RubyVM::ZJIT
       :zjit_insns_count,
       :ratio_in_zjit,
     ].each do |key|
-      # Some stats like vm_insns_count and ratio_in_yjit are not supported on the release build
+      # Some stats like vm_insns_count and ratio_in_zjit are not supported on the release build
       next unless stats.key?(key)
       value = stats[key]
 

--- a/zjit.rb
+++ b/zjit.rb
@@ -17,6 +17,7 @@ class << RubyVM::ZJIT
   # Return ZJIT statistics as a Hash
   def stats
     stats = Primitive.rb_zjit_stats
+    return nil if stats.nil?
 
     if stats.key?(:vm_insns_count) && stats.key?(:zjit_insns_count)
       stats[:total_insns_count] = stats[:vm_insns_count] + stats[:zjit_insns_count]
@@ -32,15 +33,29 @@ class << RubyVM::ZJIT
     stats = self.stats
 
     [
+      :compile_time_ns,
+      :profile_time_ns,
+      :gc_time_ns,
+      :invalidation_time_ns,
       :total_insns_count,
       :vm_insns_count,
       :zjit_insns_count,
       :ratio_in_zjit,
     ].each do |key|
+      # Some stats like vm_insns_count and ratio_in_yjit are not supported on the release build
+      next unless stats.key?(key)
       value = stats[key]
-      if key == :ratio_in_zjit
+
+      case key
+      when :ratio_in_zjit
         value = '%0.1f%%' % value
+      when /_time_ns\z/
+        key = key.to_s.sub(/_time_ns\z/, '_time')
+        value = "#{number_with_delimiter(value / 10**6)}ms"
+      else
+        value = number_with_delimiter(value)
       end
+
       buf << "#{'%-18s' % "#{key}:"} #{value}\n"
     end
     buf
@@ -53,6 +68,13 @@ class << RubyVM::ZJIT
 
   # :stopdoc:
   private
+
+  def number_with_delimiter(number)
+    s = number.to_s
+    i = s.index('.') || s.size
+    s.insert(i -= 3, ',') while i > 3
+    s
+  end
 
   # Print ZJIT stats
   def print_stats

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -1,36 +1,73 @@
-// Maxime would like to rebuild an improved stats system
-// Individual stats should be tagged as always available, or only available in stats mode
-// We could also tag which stats are fallback or exit counters, etc. Maybe even tag units?
-//
-// Comptime vs Runtime stats?
+use std::time::Instant;
 
 use crate::{cruby::*, options::get_option, state::{zjit_enabled_p, ZJITState}};
 
 macro_rules! make_counters {
-    ($($counter_name:ident,)+) => {
+    (
+        default {
+            $($default_counter_name:ident,)+
+        }
+        $($counter_name:ident,)+
+    ) => {
         /// Struct containing the counter values
         #[derive(Default, Debug)]
-        pub struct Counters { $(pub $counter_name: u64),+ }
+        pub struct Counters {
+            $(pub $default_counter_name: u64,)+
+            $(pub $counter_name: u64,)+
+        }
 
         /// Enum to represent a counter
         #[allow(non_camel_case_types)]
         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-        pub enum Counter { $($counter_name),+ }
+        pub enum Counter {
+            $($default_counter_name,)+
+            $($counter_name,)+
+        }
+
+        impl Counter {
+            pub fn name(&self) -> String {
+                match self {
+                    $( Counter::$default_counter_name => stringify!($default_counter_name).to_string(), )+
+                    $( Counter::$counter_name => stringify!($counter_name).to_string(), )+
+                }
+            }
+        }
 
         /// Map a counter to a pointer
         pub fn counter_ptr(counter: Counter) -> *mut u64 {
             let counters = $crate::state::ZJITState::get_counters();
             match counter {
-                $( Counter::$counter_name => std::ptr::addr_of_mut!(counters.$counter_name) ),+
+                $( Counter::$default_counter_name => std::ptr::addr_of_mut!(counters.$default_counter_name), )+
+                $( Counter::$counter_name => std::ptr::addr_of_mut!(counters.$counter_name), )+
             }
         }
+
+        /// The list of counters that are available without --zjit-stats.
+        /// They are incremented only by `incr_counter()` and don't use `gen_incr_counter()`.
+        pub const DEFAULT_COUNTERS: &'static [Counter] = &[
+            $( Counter::$default_counter_name, )+
+        ];
     }
 }
 
 // Declare all the counters we track
 make_counters! {
+    // Default counters that are available without --zjit-stats
+    default {
+        compile_time_ns,
+        profile_time_ns,
+        gc_time_ns,
+        invalidation_time_ns,
+    }
+
     // The number of times YARV instructions are executed on JIT code
     zjit_insns_count,
+}
+
+/// Increase a counter by a specified amount
+fn incr_counter(counter: Counter, amount: u64) {
+    let ptr = counter_ptr(counter);
+    unsafe { *ptr += amount; }
 }
 
 pub fn zjit_alloc_size() -> usize {
@@ -49,14 +86,30 @@ pub extern "C" fn rb_zjit_stats(_ec: EcPtr, _self: VALUE) -> VALUE {
     }
 
     let hash = unsafe { rb_hash_new() };
-    // TODO: Set counters that are always available here
+    let counters = ZJITState::get_counters();
+
+    for &counter in DEFAULT_COUNTERS {
+        let counter_val = unsafe { *counter_ptr(counter) };
+        set_stat(hash, &counter.name(), counter_val);
+    }
 
     // Set counters that are enabled when --zjit-stats is enabled
     if get_option!(stats) {
-        let counters = ZJITState::get_counters();
         set_stat(hash, "zjit_insns_count", counters.zjit_insns_count);
-        set_stat(hash, "vm_insns_count", unsafe { rb_vm_insns_count });
+
+        if unsafe { rb_vm_insns_count } > 0 {
+            set_stat(hash, "vm_insns_count", unsafe { rb_vm_insns_count });
+        }
     }
 
     hash
+}
+
+/// Measure the time taken by func() and add that to yjit_compile_time.
+pub fn with_time_stat<F, R>(counter: Counter, func: F) -> R where F: FnOnce() -> R {
+    let start = Instant::now();
+    let ret = func();
+    let nanos = Instant::now().duration_since(start).as_nanos();
+    incr_counter(counter, nanos as u64);
+    ret
 }

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -105,7 +105,7 @@ pub extern "C" fn rb_zjit_stats(_ec: EcPtr, _self: VALUE) -> VALUE {
     hash
 }
 
-/// Measure the time taken by func() and add that to yjit_compile_time.
+/// Measure the time taken by func() and add that to zjit_compile_time.
 pub fn with_time_stat<F, R>(counter: Counter, func: F) -> R where F: FnOnce() -> R {
     let start = Instant::now();
     let ret = func();


### PR DESCRIPTION
This PR introduces the following counters to `RubyVM::ZJIT.stats`:

* `compile_time_ns`
* `profile_time_ns`
* `gc_time_ns`
* `invalidation_time_ns`

They should allow us to investigate which part of ZJIT is adding overhead to yjit-bench.

They are added as default counters, which are available without `--zjit-stats`. We often need these metrics in production on production clusters that don't enable stats. It also refactors and improves the stats system a little.