### PR TITLE
time.c: fix time_mark_and_move when WIDEVALUE_IS_WIDER

### DIFF
--- a/time.c
+++ b/time.c
@@ -1891,8 +1891,8 @@ static void
 time_mark_and_move(void *ptr)
 {
     struct time_object *tobj = ptr;
-    if (!FIXWV_P(tobj->timew)) {
-        rb_gc_mark_and_move(&WIDEVAL_GET(tobj->timew));
+    if (!WIDEVALUE_IS_WIDER || !FIXWV_P(tobj->timew)) {
+        rb_gc_mark_and_move((VALUE *)&WIDEVAL_GET(tobj->timew));
     }
     rb_gc_mark_and_move(&tobj->vtm.year);
     rb_gc_mark_and_move(&tobj->vtm.subsecx);


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/14139

In such case the pointer need to be casted.

@Earlopain could you try this branch?