### PR TITLE
Add NODE IN locations

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -866,6 +866,12 @@ node_locations(VALUE ast_value, const NODE *node)
                                     location_new(&RNODE_IF(node)->if_keyword_loc),
                                     location_new(&RNODE_IF(node)->then_keyword_loc),
                                     location_new(&RNODE_IF(node)->end_keyword_loc));
+      case NODE_IN:
+        return rb_ary_new_from_args(4,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_IN(node)->in_keyword_loc),
+                                    location_new(&RNODE_IN(node)->then_keyword_loc),
+                                    location_new(&RNODE_IN(node)->operator_loc));
       case NODE_MODULE:
         return rb_ary_new_from_args(3,
                                     location_new(nd_code_loc(node)),

--- a/node_dump.c
+++ b/node_dump.c
@@ -309,8 +309,11 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("example: case x; in 1; foo; in 2; bar; else baz; end");
         F_NODE(nd_head, RNODE_IN, "in pattern");
         F_NODE(nd_body, RNODE_IN, "in body");
-        LAST_NODE;
         F_NODE(nd_next, RNODE_IN, "next in clause");
+        F_LOC(in_keyword_loc, RNODE_IN);
+        F_LOC(then_keyword_loc, RNODE_IN);
+        LAST_NODE;
+        F_LOC(operator_loc, RNODE_IN);
         return;
 
       case NODE_WHILE:

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -324,6 +324,9 @@ typedef struct RNode_IN {
     struct RNode *nd_head;
     struct RNode *nd_body;
     struct RNode *nd_next;
+    rb_code_location_t in_keyword_loc;
+    rb_code_location_t then_keyword_loc;
+    rb_code_location_t operator_loc;
 } rb_node_in_t;
 
 typedef struct RNode_LOOP {

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1514,6 +1514,20 @@ dummy
       assert_locations(node.children[-1].children[1].children[0].locations, [[1, 11, 1, 17], [1, 13, 1, 15], nil, nil])
     end
 
+    def test_in_locations
+      node = ast_parse("case 1; in 2 then 3; end")
+      assert_locations(node.children[-1].children[1].locations, [[1, 8, 1, 20], [1, 8, 1, 10], [1, 13, 1, 17], nil])
+
+      node = ast_parse("1 => a")
+      assert_locations(node.children[-1].children[1].locations, [[1, 5, 1, 6], nil, nil, [1, 2, 1, 4]])
+
+      node = ast_parse("1 in a")
+      assert_locations(node.children[-1].children[1].locations, [[1, 5, 1, 6], [1, 2, 1, 4], nil, nil])
+
+      node = ast_parse("case 1; in 2; 3; end")
+      assert_locations(node.children[-1].children[1].locations, [[1, 8, 1, 16], [1, 8, 1, 10], [1, 12, 1, 13], nil])
+    end
+
     def test_next_locations
       node = ast_parse("loop { next 1 }")
       assert_locations(node.children[-1].children[-1].children[-1].locations, [[1, 7, 1, 13], [1, 7, 1, 11]])


### PR DESCRIPTION
Add locations to struct `RNode_IN`.

memo:

```bash
> ruby -e 'case 1; in 2 then 3; end' --parser=prism --dump=parsetree
@ ProgramNode (location: (1,0)-(1,24))
+-- locals: []
+-- statements:
    @ StatementsNode (location: (1,0)-(1,24))
    +-- body: (length: 1)
        +-- @ CaseMatchNode (location: (1,0)-(1,24))
            +-- predicate:
            |   @ IntegerNode (location: (1,5)-(1,6))
            |   +-- IntegerBaseFlags: decimal
            |   +-- value: 1
            +-- conditions: (length: 1)
            |   +-- @ InNode (location: (1,8)-(1,19))
            |       +-- pattern:
            |       |   @ IntegerNode (location: (1,11)-(1,12))
            |       |   +-- IntegerBaseFlags: decimal
            |       |   +-- value: 2
            |       +-- statements:
            |       |   @ StatementsNode (location: (1,18)-(1,19))
            |       |   +-- body: (length: 1)
            |       |       +-- @ IntegerNode (location: (1,18)-(1,19))
            |       |           +-- IntegerBaseFlags: decimal
            |       |           +-- value: 3
            |       +-- in_loc: (1,8)-(1,10) = "in"
            |       +-- then_loc: (1,13)-(1,17) = "then"
            +-- else_clause: nil
            +-- case_keyword_loc: (1,0)-(1,4) = "case"
            +-- end_keyword_loc: (1,21)-(1,24) = "end"
```