### PR TITLE
ZJIT: CI: Use Rust version built into GitHub Actions image

### DIFF
--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -34,6 +34,7 @@ jobs:
         include:
           - test_task: 'zjit-check'
             configure: '--enable-yjit=dev --enable-zjit'
+            rust_version: "1.85.0"
 
           - test_task: 'ruby' # build test for combo build
             configure: '--enable-yjit --enable-zjit'
@@ -81,13 +82,16 @@ jobs:
           # Set fetch-depth: 10 so that Launchable can receive commits information.
           fetch-depth: 10
 
+      - name: Install Rust
+        if: ${{ matrix.rust_version }}
+        run: |
+          rustup install ${{ matrix.rust_version }} --profile minimal
+          rustup default ${{ matrix.rust_version }}
+
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9
         if: ${{ matrix.test_task == 'zjit-check' }}
-
-      - name: Install Rust # TODO(alan): remove when GitHub images catch up past 1.85.0
-        run: rustup default 1.85.0
 
       - name: Run configure
         run: ../src/configure -C --disable-install-doc ${{ matrix.configure }}

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -39,6 +39,7 @@ jobs:
 
           - test_task: 'zjit-check'
             configure: '--enable-yjit --enable-zjit=dev'
+            rust_version: '1.85.0'
 
           - test_task: 'zjit-test-all'
             configure: '--enable-zjit=dev'
@@ -98,7 +99,10 @@ jobs:
           fetch-depth: 10
 
       - name: Install Rust
-        run: rustup default 1.85.0
+        if: ${{ matrix.rust_version }}
+        run: |
+          rustup install ${{ matrix.rust_version }} --profile minimal
+          rustup default ${{ matrix.rust_version }}
 
       - name: Install rustfmt
         if: ${{ matrix.test_task == 'zjit-bindgen' }}


### PR DESCRIPTION
Saves the work of installing Rust for most jobs. Keep a job on each
platform that tests 1.85.0, the minimum supported version, though.
