### PR TITLE
YJIT, ZJIT: Fix JITs compiling prelude

### DIFF
--- a/ruby.c
+++ b/ruby.c
@@ -1819,8 +1819,10 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
 
     if (rb_namespace_available())
         rb_initialize_main_namespace();
+    rb_namespace_init_done();
+    ruby_init_prelude();
 
-    // Initialize JITs after prelude because JITing prelude is typically not optimal.
+    // Initialize JITs after ruby_init_prelude() because JITing prelude is typically not optimal.
 #if USE_YJIT
     rb_yjit_init(opt->yjit);
 #endif
@@ -1831,8 +1833,6 @@ ruby_opt_init(ruby_cmdline_options_t *opt)
     }
 #endif
 
-    rb_namespace_init_done();
-    ruby_init_prelude();
     ruby_set_script_name(opt->script_name);
     require_libraries(&opt->req_list);
 }


### PR DESCRIPTION
This PR resurrects the behavior of https://github.com/ruby/ruby/pull/6597 that JITs are enabled after prelude.

Prelude often runs code that is never used after boot. To avoid wasting memory and compilation time for such code (and tidy up the output of `--*jit-dump-disasm`), we enable JITs after prelude. For some reason, https://github.com/ruby/ruby/pull/13650 put `ruby_init_prelude` after JIT inits. The PR or the commit message https://github.com/ruby/ruby/commit/96a0c2065a95d076978de41e8bfacbd19858d0bb didn't explain why, so I thought it was oversight and thus fixed it.