### PR TITLE
ZJIT: Avoid splitting add_into/sub_into

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1889,9 +1889,8 @@ impl Assembler {
         out
     }
 
-    pub fn add_into(&mut self, left: Opnd, right: Opnd) -> Opnd {
+    pub fn add_into(&mut self, left: Opnd, right: Opnd) {
         self.push_insn(Insn::Add { left, right, out: left });
-        left
     }
 
     #[must_use]
@@ -2233,10 +2232,8 @@ impl Assembler {
         out
     }
 
-    pub fn sub_into(&mut self, left: Opnd, right: Opnd) -> Opnd {
-        let out = self.sub(left, right);
-        self.mov(left, out);
-        out
+    pub fn sub_into(&mut self, left: Opnd, right: Opnd) {
+        self.push_insn(Insn::Sub { left, right, out: left });
     }
 
     #[must_use]

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -197,8 +197,14 @@ impl Assembler
                                     }
                                 },
                                 // We have to load memory operands to avoid corrupting them
-                                (Opnd::Mem(_) | Opnd::Reg(_), _) => {
+                                (Opnd::Mem(_), _) => {
                                     *left = asm.load(*left);
+                                },
+                                // We have to load register operands to avoid corrupting them
+                                (Opnd::Reg(_), _) => {
+                                    if *left != *out {
+                                        *left = asm.load(*left);
+                                    }
                                 },
                                 // The first operand can't be an immediate value
                                 (Opnd::UImm(_), _) => {
@@ -1164,7 +1170,21 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_eq!(format!("{:x}", cb), "4983c540");
+        assert_disasm!(cb, "4983c540", {"
+            0x0: add r13, 0x40
+        "});
+    }
+
+    #[test]
+    fn test_add_into() {
+        let (mut asm, mut cb) = setup_asm();
+
+        asm.add_into(CFP, Opnd::UImm(0x40));
+        asm.compile_with_num_regs(&mut cb, 1);
+
+        assert_disasm!(cb, "4983c540", {"
+            0x0: add r13, 0x40
+        "});
     }
 
     #[test]
@@ -1175,7 +1195,21 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_eq!(format!("{:x}", cb), "4983ed40");
+        assert_disasm!(cb, "4983ed40", {"
+            0x0: sub r13, 0x40
+        "});
+    }
+
+    #[test]
+    fn test_sub_into() {
+        let (mut asm, mut cb) = setup_asm();
+
+        asm.sub_into(CFP, Opnd::UImm(0x40));
+        asm.compile_with_num_regs(&mut cb, 1);
+
+        assert_disasm!(cb, "4983ed40", {"
+            0x0: sub r13, 0x40
+        "});
     }
 
     #[test]


### PR DESCRIPTION
This PR addresses https://github.com/ruby/ruby/pull/14154#discussion_r2268083538.

We were splitting `asm.add_into` to two instructions. By fixing it, this PR also updates `asm.sub_into` to use an implementation that looks similar to `asm.add_into`.

## Before

`add_into` in concatstrings looked like this:

```asm
  # restore C stack pointer
  0x652fd19ee1b8: mov rdi, rsp
  0x652fd19ee1bb: add rdi, 0x20
```

## After

It's now:

```asm
  # restore C stack pointer
  0x5629f326e1b8: add rsp, 0x20
```

The instructions generated by `sub_into` in concatstrings stayed the same because merging sub + mov works fine.