### PR TITLE
set.c: Store `set_table->bins` at the end of `set_table->entries`

### DIFF
--- a/internal/set_table.h
+++ b/internal/set_table.h
@@ -15,13 +15,16 @@ struct set_table {
     const struct st_hash_type *type;
     /* Number of entries currently in the table.  */
     st_index_t num_entries;
-    /* Array of bins used for access by keys.  */
-    st_index_t *bins;
+
     /* Start and bound index of entries in array entries.
        entries_starts and entries_bound are in interval
        [0,allocated_entries].  */
     st_index_t entries_start, entries_bound;
-    /* Array of size 2^entry_power.  */
+
+    /**
+     * Array of size 2^entry_power.
+     * Followed by st_index_t *bins, Array of bins used for access by keys.
+     */
     set_table_entry *entries;
 };
 

--- a/set.c
+++ b/set.c
@@ -139,7 +139,6 @@ set_mark(void *ptr)
 static void
 set_free_embedded(struct set_object *sobj)
 {
-    free((&sobj->table)->bins);
     free((&sobj->table)->entries);
 }
 

--- a/test/ruby/test_set.rb
+++ b/test/ruby/test_set.rb
@@ -924,6 +924,18 @@ class TC_Set < Test::Unit::TestCase
     end
     end;
   end
+
+  def test_larger_sets
+    set = Set.new
+    10_000.times do |i|
+      set << i
+    end
+    set = set.dup
+
+    10_000.times do |i|
+      assert_includes set, i
+    end
+  end
 end
 
 class TC_Enumerable < Test::Unit::TestCase


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/14134

This saves one pointer in `struct set_table`, which would allow `Set` objects to still fit in 80B TypedData slots even if RTypedData goes from 32B to 40B large.

The existing set benchmark seem to show this doesn't have a very significant impact. Smaller sets are a bit faster, larger sets a bit slower.

It seem consistent over multiple runs, but it's unclear how much of that is just error margin.

```
compare-ruby: ruby 3.5.0dev (2025-08-12T02:14:57Z master 428937a536) +YJIT +PRISM [arm64-darwin24]
built-ruby: ruby 3.5.0dev (2025-08-12T07:22:26Z set-entries-bounds da30024fdc) +YJIT +PRISM [arm64-darwin24]
warming up........

|                         |compare-ruby|built-ruby|
|:------------------------|-----------:|---------:|
|new_0                    |     15.459M|   15.823M|
|                         |           -|     1.02x|
|new_10                   |      3.484M|    3.574M|
|                         |           -|     1.03x|
|new_100                  |    546.992k|  564.679k|
|                         |           -|     1.03x|
|new_1000                 |     49.391k|   48.169k|
|                         |       1.03x|         -|
|aref_0                   |     18.643M|   19.350M|
|                         |           -|     1.04x|
|aref_10                  |      5.941M|    6.006M|
|                         |           -|     1.01x|
|aref_100                 |    822.197k|  814.219k|
|                         |       1.01x|         -|
|aref_1000                |     83.230k|   79.411k|
|                         |       1.05x|         -|
```