### PR TITLE
ZJIT: Add flag to disable the HIR optimizer

### DIFF
--- a/tool/zjit_bisect.rb
+++ b/tool/zjit_bisect.rb
@@ -118,6 +118,11 @@ Tempfile.create "jit_list" do |temp_file|
   jit_list = File.readlines(temp_file.path).map(&:strip).reject(&:empty?)
 end
 LOGGER.info("Starting with JIT list of #{jit_list.length} items.")
+# Try running without the optimizer
+_, stderr, exitcode = run_with_jit_list(RUBY, ["--zjit-disable-hir-opt", *OPTIONS], jit_list)
+if exitcode == 0
+  LOGGER.warn "*** Command suceeded with HIR optimizer disabled. HIR optimizer is probably at fault. ***"
+end
 # Now narrow it down
 command = lambda do |items|
   _, _, exitcode = run_with_jit_list(RUBY, OPTIONS, items)

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1275,7 +1275,9 @@ fn compile_iseq(iseq: IseqPtr) -> Option<Function> {
             return None;
         }
     };
-    function.optimize();
+    if !get_option!(disable_hir_opt) {
+        function.optimize();
+    }
     if let Err(err) = function.validate() {
         debug!("ZJIT: compile_iseq: {err:?}");
         return None;

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -31,6 +31,9 @@ pub struct Options {
     /// Enable debug logging
     pub debug: bool,
 
+    /// Turn off the HIR optimizer
+    pub disable_hir_opt: bool,
+
     /// Dump initial High-level IR before optimization
     pub dump_hir_init: Option<DumpHIR>,
 
@@ -61,6 +64,7 @@ impl Default for Options {
             num_profiles: 1,
             stats: false,
             debug: false,
+            disable_hir_opt: false,
             dump_hir_init: None,
             dump_hir_opt: None,
             dump_hir_graphviz: false,
@@ -184,6 +188,8 @@ fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
         }
 
         ("debug", "") => options.debug = true,
+
+        ("disable-hir-opt", "") => options.disable_hir_opt = true,
 
         // --zjit-dump-hir dumps the actual input to the codegen, which is currently the same as --zjit-dump-hir-opt.
         ("dump-hir" | "dump-hir-opt", "") => options.dump_hir_opt = Some(DumpHIR::WithoutSnapshot),


### PR DESCRIPTION
Also add a check in the bisect script that can assign blame to the HIR
optimizer.
