### PR TITLE
[DOC] Warn about missing rdoc-ref target

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -23,3 +23,4 @@ autolink_excluded_words:
 - YJIT
 
 canonical_root: https://docs.ruby-lang.org/en/master
+warn_missing_rdoc_ref: true


### PR DESCRIPTION
RDoc resolves `rdoc-ref` when generating links and with this option it can emit warnings on missing targets, like:

```
exceptions_md.html: `rdoc-ref:Exceptione` can't be resolved for `Built-In Exception Class Hierarchy`
```

Currently there's no missing `rdoc-ref` but it'd be helpful capturing new ones.