### PR TITLE
Add missing writebarrier on complex obj dup

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -1171,6 +1171,7 @@ rb_shape_copy_complex_ivars(VALUE dest, VALUE obj, shape_id_t src_shape_id, st_t
         st_delete(table, &id, NULL);
     }
     rb_obj_init_too_complex(dest, table);
+    rb_gc_writebarrier_remember(dest);
 }
 
 size_t


### PR DESCRIPTION
When we dup a complex object we need to issue a writebarrier_remember on the new object. This was caught by wbcheck inside the rubygems test suite.