### PR TITLE
ZJIT: Fix `ObjToString` rewrite

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6209,6 +6209,14 @@ vm_objtostring(const rb_iseq_t *iseq, VALUE recv, CALL_DATA cd)
     return Qundef;
 }
 
+// ZJIT implementation is using the C function
+// and needs to call a non-static function
+VALUE
+rb_vm_objtostring(const rb_iseq_t *iseq, VALUE recv, CALL_DATA cd)
+{
+    return vm_objtostring(iseq, recv, cd);
+}
+
 static VALUE
 vm_opt_ary_freeze(VALUE ary, int bop, ID id)
 {

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -159,6 +159,7 @@ unsafe extern "C" {
     pub fn rb_vm_stack_canary() -> VALUE;
     pub fn rb_vm_push_cfunc_frame(cme: *const rb_callable_method_entry_t, recv_idx: c_int);
     pub fn rb_obj_class(klass: VALUE) -> VALUE;
+    pub fn rb_vm_objtostring(iseq: IseqPtr, recv: VALUE, cd: *const rb_call_data) -> VALUE;
 }
 
 // Renames


### PR DESCRIPTION
Currently, the rewrite for `ObjToString` always replaces it with a `SendWithoutBlock(to_s)` instruction when the receiver is not a string literal. This is incorrect because it calls `to_s` on the receiver even if it's already a string.

This change fixes it by:
- Avoiding the `SendWithoutBlock(to_s)` rewrite
- Implement codegen for `ObjToString`