### PR TITLE
ZJIT: Prepare non-leaf calls for SetGlobal

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -61,6 +61,30 @@ class TestZJIT < Test::Unit::TestCase
     }
   end
 
+  def test_setglobal
+    assert_compiles '1', %q{
+      def test
+        $a = 1
+        $a
+      end
+
+      test
+    }, insns: [:setglobal]
+  end
+
+  def test_setglobal_with_trace_var_exception
+    assert_compiles '"rescued"', %q{
+      def test
+        $a = 1
+      rescue
+        "rescued"
+      end
+
+      trace_var(:$a) { raise }
+      test
+    }, insns: [:setglobal]
+  end
+
   def test_setlocal
     assert_compiles '3', %q{
       def test(n)


### PR DESCRIPTION
When `trace_var` is used, setting a global variable can cause exceptions to be raised. We need to prepare for that.