### PR TITLE
ZJIT: Compile toregexp

### DIFF
--- a/internal/re.h
+++ b/internal/re.h
@@ -25,4 +25,9 @@ int rb_match_count(VALUE match);
 VALUE rb_reg_new_ary(VALUE ary, int options);
 VALUE rb_reg_last_defined(VALUE match);
 
+#define ARG_REG_OPTION_MASK \
+    (ONIG_OPTION_IGNORECASE|ONIG_OPTION_MULTILINE|ONIG_OPTION_EXTEND)
+#define ARG_ENCODING_FIXED    16
+#define ARG_ENCODING_NONE     32
+
 #endif /* INTERNAL_RE_H */

--- a/re.c
+++ b/re.c
@@ -290,11 +290,6 @@ rb_memsearch(const void *x0, long m, const void *y0, long n, rb_encoding *enc)
 
 #define KCODE_FIXED FL_USER4
 
-#define ARG_REG_OPTION_MASK \
-    (ONIG_OPTION_IGNORECASE|ONIG_OPTION_MULTILINE|ONIG_OPTION_EXTEND)
-#define ARG_ENCODING_FIXED    16
-#define ARG_ENCODING_NONE     32
-
 static int
 char_to_option(int c)
 {

--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -1847,6 +1847,14 @@ class TestZJIT < Test::Unit::TestCase
     }, insns: [:concatstrings]
   end
 
+  def test_regexp_interpolation
+    assert_compiles '/123/', %q{
+      def test = /#{1}#{2}#{3}/
+
+      test
+    }, insns: [:toregexp]
+  end
+
   private
 
   # Assert that every method call in `test_script` can be compiled by ZJIT

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -259,6 +259,13 @@ fn main() {
 
         // From internal/re.h
         .allowlist_function("rb_reg_new_ary")
+        .allowlist_var("ARG_ENCODING_FIXED")
+        .allowlist_var("ARG_ENCODING_NONE")
+
+        // From include/ruby/onigmo.h
+        .allowlist_var("ONIG_OPTION_IGNORECASE")
+        .allowlist_var("ONIG_OPTION_EXTEND")
+        .allowlist_var("ONIG_OPTION_MULTILINE")
 
         // `ruby_value_type` is a C enum and this stops it from
         // prefixing all the members with the name of the type

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -30,6 +30,11 @@ impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
         fmt.write_str("__IncompleteArrayField")
     }
 }
+pub const ONIG_OPTION_IGNORECASE: u32 = 1;
+pub const ONIG_OPTION_EXTEND: u32 = 2;
+pub const ONIG_OPTION_MULTILINE: u32 = 4;
+pub const ARG_ENCODING_FIXED: u32 = 16;
+pub const ARG_ENCODING_NONE: u32 = 32;
 pub const INTEGER_REDEFINED_OP_FLAG: u32 = 1;
 pub const FLOAT_REDEFINED_OP_FLAG: u32 = 2;
 pub const STRING_REDEFINED_OP_FLAG: u32 = 4;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -473,6 +473,9 @@ pub enum Insn {
     StringIntern { val: InsnId, state: InsnId },
     StringConcat { strings: Vec<InsnId>, state: InsnId },
 
+    /// Combine count stack values into a regexp
+    ToRegexp { opt: usize, values: Vec<InsnId>, state: InsnId },
+
     /// Put special object (VMCORE, CBASE, etc.) based on value_type
     PutSpecialObject { value_type: SpecialObjectType },
 
@@ -668,6 +671,14 @@ pub struct InsnPrinter<'a> {
     ptr_map: &'a PtrPrintMap,
 }
 
+static REGEXP_FLAGS: &[(u32, &str)] = &[
+    (ONIG_OPTION_MULTILINE, "MULTILINE"),
+    (ONIG_OPTION_IGNORECASE, "IGNORECASE"),
+    (ONIG_OPTION_EXTEND, "EXTENDED"),
+    (ARG_ENCODING_FIXED, "FIXEDENCODING"),
+    (ARG_ENCODING_NONE, "NOENCODING"),
+];
+
 impl<'a> std::fmt::Display for InsnPrinter<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match &self.inner {
@@ -712,6 +723,28 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 for string in strings {
                     write!(f, "{prefix}{string}")?;
                     prefix = ", ";
+                }
+
+                Ok(())
+            }
+            Insn::ToRegexp { values, opt, .. } => {
+                write!(f, "ToRegexp")?;
+                let mut prefix = " ";
+                for value in values {
+                    write!(f, "{prefix}{value}")?;
+                    prefix = ", ";
+                }
+
+                let opt = *opt as u32;
+                if opt != 0 {
+                    write!(f, ", ")?;
+                    let mut sep = "";
+                    for (flag, name) in REGEXP_FLAGS {
+                        if opt & flag != 0 {
+                            write!(f, "{sep}{name}")?;
+                            sep = "|";
+                        }
+                    }
                 }
 
                 Ok(())
@@ -1179,6 +1212,7 @@ impl Function {
             &StringCopy { val, chilled, state } => StringCopy { val: find!(val), chilled, state },
             &StringIntern { val, state } => StringIntern { val: find!(val), state: find!(state) },
             &StringConcat { ref strings, state } => StringConcat { strings: find_vec!(strings), state: find!(state) },
+            &ToRegexp { opt, ref values, state } => ToRegexp { opt, values: find_vec!(values), state },
             &Test { val } => Test { val: find!(val) },
             &IsNil { val } => IsNil { val: find!(val) },
             &Jump(ref target) => Jump(find_branch_edge!(target)),
@@ -1305,6 +1339,7 @@ impl Function {
             Insn::StringCopy { .. } => types::StringExact,
             Insn::StringIntern { .. } => types::Symbol,
             Insn::StringConcat { .. } => types::StringExact,
+            Insn::ToRegexp { .. } => types::RegexpExact,
             Insn::NewArray { .. } => types::ArrayExact,
             Insn::ArrayDup { .. } => types::ArrayExact,
             Insn::NewHash { .. } => types::HashExact,
@@ -1937,6 +1972,10 @@ impl Function {
             }
             &Insn::StringConcat { ref strings, state, .. } => {
                 worklist.extend(strings);
+                worklist.push_back(state);
+            }
+            &Insn::ToRegexp { ref values, state, .. } => {
+                worklist.extend(values);
                 worklist.push_back(state);
             }
             | &Insn::Return { val }
@@ -2861,6 +2900,15 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let exit_id = fun.push_insn(block, Insn::Snapshot { state: exit_state });
                     let strings = state.stack_pop_n(count as usize)?;
                     let insn_id = fun.push_insn(block, Insn::StringConcat { strings, state: exit_id });
+                    state.stack_push(insn_id);
+                }
+                YARVINSN_toregexp => {
+                    // First arg contains the options (multiline, extended, ignorecase) used to create the regexp
+                    let opt = get_arg(pc, 0).as_usize();
+                    let count = get_arg(pc, 1).as_usize();
+                    let exit_id = fun.push_insn(block, Insn::Snapshot { state: exit_state });
+                    let values = state.stack_pop_n(count)?;
+                    let insn_id = fun.push_insn(block, Insn::ToRegexp { opt, values, state: exit_id });
                     state.stack_push(insn_id);
                 }
                 YARVINSN_newarray => {
@@ -5327,6 +5375,47 @@ mod tests {
               v7:String = AnyToString v3, str: v5
               v9:StringExact = StringConcat v2, v7
               Return v9
+        "#]]);
+    }
+
+    #[test]
+    fn test_toregexp() {
+        eval(r##"
+            def test = /#{1}#{2}#{3}/
+        "##);
+        assert_method_hir_with_opcode("test", YARVINSN_toregexp, expect![[r#"
+            fn test@<compiled>:2:
+            bb0(v0:BasicObject):
+              v2:Fixnum[1] = Const Value(1)
+              v4:BasicObject = ObjToString v2
+              v6:String = AnyToString v2, str: v4
+              v7:Fixnum[2] = Const Value(2)
+              v9:BasicObject = ObjToString v7
+              v11:String = AnyToString v7, str: v9
+              v12:Fixnum[3] = Const Value(3)
+              v14:BasicObject = ObjToString v12
+              v16:String = AnyToString v12, str: v14
+              v18:RegexpExact = ToRegexp v6, v11, v16
+              Return v18
+        "#]]);
+    }
+
+    #[test]
+    fn test_toregexp_with_options() {
+        eval(r##"
+            def test = /#{1}#{2}/mixn
+        "##);
+        assert_method_hir_with_opcode("test", YARVINSN_toregexp, expect![[r#"
+            fn test@<compiled>:2:
+            bb0(v0:BasicObject):
+              v2:Fixnum[1] = Const Value(1)
+              v4:BasicObject = ObjToString v2
+              v6:String = AnyToString v2, str: v4
+              v7:Fixnum[2] = Const Value(2)
+              v9:BasicObject = ObjToString v7
+              v11:String = AnyToString v7, str: v9
+              v13:RegexpExact = ToRegexp v6, v11, MULTILINE|IGNORECASE|EXTENDED|NOENCODING
+              Return v13
         "#]]);
     }
 


### PR DESCRIPTION
`toregexp` is fairly similar to `concatstrings`, so this commit extracts a helper for pushing and popping operands on the native stack.

There's probably opportunity to move some of this into lir (e.g. Alan suggested a push_many that could use STP on ARM to push 2 at a time), but I might save that for another day.