### PR TITLE
[WIP] Add safe dig

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -4902,6 +4902,12 @@ rb_hash_dig(int argc, VALUE *argv, VALUE self)
     return rb_obj_dig(argc, argv, self, Qnil);
 }
 
+static VALUE
+rb_safe_hash_dig(int argc, VALUE *argv, VALUE self)
+{
+    return 42;
+}
+
 static int
 hash_le_i(VALUE key, VALUE value, VALUE arg)
 {
@@ -7468,6 +7474,7 @@ Init_Hash(void)
 
     rb_define_method(rb_cHash, "any?", rb_hash_any_p, -1);
     rb_define_method(rb_cHash, "dig", rb_hash_dig, -1);
+    rb_define_method(rb_cHash, "safe_dig", rb_safe_hash_dig, -1);
 
     rb_define_method(rb_cHash, "<=", rb_hash_le, 1);
     rb_define_method(rb_cHash, "<", rb_hash_lt, 1);

--- a/spec/ruby/core/hash/safe_dig_spec.rb
+++ b/spec/ruby/core/hash/safe_dig_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../../spec_helper'
+
+describe "Hash#safe_dig" do
+  it "behaves like dig when not hitting rock bottom" do
+    h = { foo: { bar: "baz" }}
+    h.safe_dig(:foo, :bar).should == "baz"
+  end
+
+  it "returns nil instead of raising dig error when hitting rock bottom" do
+    h = { foo: { bar: '' } }
+    h.safe_dig(:foo, :bar, :baz).should == nil
+  end
+end


### PR DESCRIPTION
Digging hashes has always been a pain in Ruby.

When handling API responses, you may only care about the result if you can precisely dig there and don't want to catch intermediary errors such as dig not being defined. Sometimes APIs respond inconsistently, sometimes with strings and sometimes with hashes.


Currently dig does not work well with such mixed types:

```ruby

my_api_response = { status: "none" }
my_api_response.dig(:status, :code) # => TypeError: String does not have #dig method (TypeError)
```

It would be very nice if we could have a safe dig that returns early when it cannot dig further:

```ruby
my_api_response = { status: "none" }
my_api_response.safe_dig(:status, :code) # => nil
```