### PR TITLE
Don't change Encoding.default_internal in assert_raise_with_message

### DIFF
--- a/test/ruby/test_numeric.rb
+++ b/test/ruby/test_numeric.rb
@@ -22,10 +22,12 @@ class TestNumeric < Test::Unit::TestCase
     assert_raise_with_message(TypeError, /:\u{3042}/) {1&:"\u{3042}"}
     assert_raise_with_message(TypeError, /:\u{3042}/) {1|:"\u{3042}"}
     assert_raise_with_message(TypeError, /:\u{3042}/) {1^:"\u{3042}"}
-    assert_raise_with_message(TypeError, /:"\\u3042"/) {1+:"\u{3042}"}
-    assert_raise_with_message(TypeError, /:"\\u3042"/) {1&:"\u{3042}"}
-    assert_raise_with_message(TypeError, /:"\\u3042"/) {1|:"\u{3042}"}
-    assert_raise_with_message(TypeError, /:"\\u3042"/) {1^:"\u{3042}"}
+    EnvUtil.with_default_internal(Encoding::US_ASCII) do
+      assert_raise_with_message(TypeError, /:"\\u3042"/) {1+:"\u{3042}"}
+      assert_raise_with_message(TypeError, /:"\\u3042"/) {1&:"\u{3042}"}
+      assert_raise_with_message(TypeError, /:"\\u3042"/) {1|:"\u{3042}"}
+      assert_raise_with_message(TypeError, /:"\\u3042"/) {1^:"\u{3042}"}
+    end
     assert_raise_with_message(TypeError, /:\u{3044}/) {1+"\u{3044}".to_sym}
     assert_raise_with_message(TypeError, /:\u{3044}/) {1&"\u{3044}".to_sym}
     assert_raise_with_message(TypeError, /:\u{3044}/) {1|"\u{3044}".to_sym}

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1036,10 +1036,12 @@ class TestRegexp < Test::Unit::TestCase
     [Encoding::UTF_8, Encoding::Shift_JIS, Encoding::EUC_JP].each do |enc|
       idx = key.encode(enc)
       pat = /#{idx}/
-      test.call {|m| assert_raise_with_message(IndexError, pat, bug10877) {m[idx]} }
-      test.call {|m| assert_raise_with_message(IndexError, pat, bug18160) {m.offset(idx)} }
-      test.call {|m| assert_raise_with_message(IndexError, pat, bug18160) {m.begin(idx)} }
-      test.call {|m| assert_raise_with_message(IndexError, pat, bug18160) {m.end(idx)} }
+      EnvUtil.with_default_internal(enc) do
+        test.call {|m| assert_raise_with_message(IndexError, pat, bug10877) {m[idx]} }
+        test.call {|m| assert_raise_with_message(IndexError, pat, bug18160) {m.offset(idx)} }
+        test.call {|m| assert_raise_with_message(IndexError, pat, bug18160) {m.begin(idx)} }
+        test.call {|m| assert_raise_with_message(IndexError, pat, bug18160) {m.end(idx)} }
+      end
     end
     test.call {|m| assert_equal(/a/, m.regexp) }
     test.call {|m| assert_equal("abc", m.string) }

--- a/tool/lib/core_assertions.rb
+++ b/tool/lib/core_assertions.rb
@@ -501,13 +501,10 @@ eom
           assert = :assert_match
         end
 
-        ex = m = nil
-        EnvUtil.with_default_internal(of: expected) do
-          ex = assert_raise(exception, msg || proc {"Exception(#{exception}) with message matches to #{expected.inspect}"}) do
-            yield
-          end
-          m = ex.message
+        ex = assert_raise(exception, msg || proc {"Exception(#{exception}) with message matches to #{expected.inspect}"}) do
+          yield
         end
+        m = ex.message
         msg = message(msg, "") {"Expected Exception(#{exception}) was raised, but the message doesn't match"}
 
         if assert == :assert_equal


### PR DESCRIPTION
For most tests (except two), we don't need to change Encoding.default_internal in assert_raise_with_message. We're trying to run the test suite across multiple Ractors and modifying Encoding.default_internal can cause other concurrently running tests to fail.