### PR TITLE
ZJIT: Enable or remove comments from YJIT

### DIFF
--- a/zjit/src/asm/arm64/inst/branch_cond.rs
+++ b/zjit/src/asm/arm64/inst/branch_cond.rs
@@ -47,7 +47,6 @@ impl From<BranchCond> for [u8; 4] {
     }
 }
 
-/*
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,4 +76,3 @@ mod tests {
         assert_eq!(0x54800000, result);
     }
 }
-*/

--- a/zjit/src/asm/arm64/inst/conditional.rs
+++ b/zjit/src/asm/arm64/inst/conditional.rs
@@ -60,7 +60,6 @@ impl From<Conditional> for [u8; 4] {
     }
 }
 
-/*
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -72,4 +71,3 @@ mod tests {
         assert_eq!(0x9a821020, result);
     }
 }
-*/

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -345,7 +345,6 @@ pub fn uimm_num_bits(uimm: u64) -> u8
     return 64;
 }
 
-/*
 #[cfg(test)]
 mod tests
 {
@@ -381,32 +380,5 @@ mod tests
         assert_eq!(uimm_num_bits((u32::MAX as u64) + 1), 64);
         assert_eq!(uimm_num_bits(u64::MAX), 64);
     }
-
-    #[test]
-    fn test_code_size() {
-        // Write 4 bytes in the first page
-        let mut cb = CodeBlock::new_dummy(CodeBlock::PREFERRED_CODE_PAGE_SIZE * 2);
-        cb.write_bytes(&[0, 0, 0, 0]);
-        assert_eq!(cb.code_size(), 4);
-
-        // Moving to the next page should not increase code_size
-        cb.next_page(cb.get_write_ptr(), |_, _| {});
-        assert_eq!(cb.code_size(), 4);
-
-        // Write 4 bytes in the second page
-        cb.write_bytes(&[0, 0, 0, 0]);
-        assert_eq!(cb.code_size(), 8);
-
-        // Rewrite 4 bytes in the first page
-        let old_write_pos = cb.get_write_pos();
-        cb.set_pos(0);
-        cb.write_bytes(&[1, 1, 1, 1]);
-
-        // Moving from an old page to the next page should not increase code_size
-        cb.next_page(cb.get_write_ptr(), |_, _| {});
-        cb.set_pos(old_write_pos);
-        assert_eq!(cb.code_size(), 8);
-    }
 }
 
-*/

--- a/zjit/src/asm/x86_64/mod.rs
+++ b/zjit/src/asm/x86_64/mod.rs
@@ -317,34 +317,6 @@ pub fn mem_opnd_sib(num_bits: u8, base_opnd: X86Opnd, index_opnd: X86Opnd, scale
     }
 }
 
-/*
-// Struct member operand
-#define member_opnd(base_reg, struct_type, member_name) mem_opnd( \
-    8 * sizeof(((struct_type*)0)->member_name), \
-    base_reg,                                   \
-    offsetof(struct_type, member_name)          \
-)
-
-// Struct member operand with an array index
-#define member_opnd_idx(base_reg, struct_type, member_name, idx) mem_opnd( \
-    8 * sizeof(((struct_type*)0)->member_name[0]),     \
-    base_reg,                                       \
-    (offsetof(struct_type, member_name) +           \
-     sizeof(((struct_type*)0)->member_name[0]) * idx)  \
-)
-*/
-
-/*
-// TODO: this should be a method, X86Opnd.resize() or X86Opnd.subreg()
-static x86opnd_t resize_opnd(x86opnd_t opnd, uint32_t num_bits)
-{
-    assert (num_bits % 8 == 0);
-    x86opnd_t sub = opnd;
-    sub.num_bits = num_bits;
-    return sub;
-}
-*/
-
 pub fn imm_opnd(value: i64) -> X86Opnd
 {
     X86Opnd::Imm(X86Imm { num_bits: imm_num_bits(value), value })
@@ -1102,46 +1074,6 @@ pub fn movsx(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
         unreachable!();
     }
 }
-
-/*
-/// movzx - Move with zero extension (unsigned values)
-void movzx(codeblock_t *cb, x86opnd_t dst, x86opnd_t src)
-{
-    cb.writeASM("movzx", dst, src);
-
-    uint32_t dstSize;
-    if (dst.isReg)
-        dstSize = dst.reg.size;
-    else
-        assert (false, "movzx dst must be a register");
-
-    uint32_t srcSize;
-    if (src.isReg)
-        srcSize = src.reg.size;
-    else if (src.isMem)
-        srcSize = src.mem.size;
-    else
-        assert (false);
-
-    assert (
-        srcSize < dstSize,
-        "movzx: srcSize >= dstSize"
-    );
-
-    if (srcSize is 8)
-    {
-        cb.writeRMInstr!('r', 0xFF, 0x0F, 0xB6)(dstSize is 16, dstSize is 64, dst, src);
-    }
-    else if (srcSize is 16)
-    {
-        cb.writeRMInstr!('r', 0xFF, 0x0F, 0xB7)(dstSize is 16, dstSize is 64, dst, src);
-    }
-    else
-    {
-        assert (false, "invalid src operand size for movxz");
-    }
-}
-*/
 
 /// nop - Noop, one or multiple bytes long
 pub fn nop(cb: &mut CodeBlock, length: u32) {

--- a/zjit/src/backend/tests.rs
+++ b/zjit/src/backend/tests.rs
@@ -1,4 +1,3 @@
-/*
 #![cfg(test)]
 use crate::asm::CodeBlock;
 use crate::backend::*;
@@ -328,5 +327,3 @@ fn test_no_pos_marker_callback_when_compile_fails() {
     let cb = &mut CodeBlock::new_dummy(8);
     assert!(asm.compile(cb, None).is_none(), "should fail due to tiny size limit");
 }
-
-*/


### PR DESCRIPTION
This PR enables or removes code that was copied from YJIT and commented out for the initial setup.

The enabled ones are backend tests that can be used today. The removed ones are tests on API that doesn't exist in ZJIT or implementations which I think wouldn't be used for ZJIT at this point.