### PR TITLE
ZJIT: Stop duplicating context-less side exits

### DIFF
--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1372,7 +1372,7 @@ impl Assembler
     pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Option<(CodePtr, Vec<CodePtr>)> {
         let asm = self.arm64_split();
         let mut asm = asm.alloc_regs(regs)?;
-        asm.compile_side_exits()?;
+        asm.compile_side_exits();
 
         // Create label instances in the code block
         for (idx, name) in asm.label_names.iter().enumerate() {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -281,14 +281,6 @@ impl From<VALUE> for Opnd {
     }
 }
 
-/// Set of things we need to restore for side exits.
-#[derive(Clone, Debug)]
-pub struct SideExitContext {
-    pub pc: *const VALUE,
-    pub stack: Vec<Opnd>,
-    pub locals: Vec<Opnd>,
-}
-
 /// Branch target (something that we can jump to)
 /// for branch instructions
 #[derive(Clone, Debug)]
@@ -300,9 +292,9 @@ pub enum Target
     Label(Label),
     /// Side exit to the interpreter
     SideExit {
-        /// Context to restore on regular side exits. None for side exits right
-        /// after JIT-to-JIT calls because we restore them before the JIT call.
-        context: Option<SideExitContext>,
+        pc: *const VALUE,
+        stack: Vec<Opnd>,
+        locals: Vec<Opnd>,
         /// We use this to enrich asm comments.
         reason: SideExitReason,
         /// Some if the side exit should write this label. We use it for patch points.
@@ -786,7 +778,7 @@ impl<'a> Iterator for InsnOpndIterator<'a> {
             Insn::Label(target) |
             Insn::LeaJumpTarget { target, .. } |
             Insn::PatchPoint(target) => {
-                if let Target::SideExit { context: Some(SideExitContext { stack, locals, .. }), .. } = target {
+                if let Target::SideExit { stack, locals, .. } = target {
                     let stack_idx = self.idx;
                     if stack_idx < stack.len() {
                         let opnd = &stack[stack_idx];
@@ -811,7 +803,7 @@ impl<'a> Iterator for InsnOpndIterator<'a> {
                     return Some(opnd);
                 }
 
-                if let Target::SideExit { context: Some(SideExitContext { stack, locals, .. }), .. } = target {
+                if let Target::SideExit { stack, locals, .. } = target {
                     let stack_idx = self.idx - 1;
                     if stack_idx < stack.len() {
                         let opnd = &stack[stack_idx];
@@ -942,7 +934,7 @@ impl<'a> InsnOpndMutIterator<'a> {
             Insn::Label(target) |
             Insn::LeaJumpTarget { target, .. } |
             Insn::PatchPoint(target) => {
-                if let Target::SideExit { context: Some(SideExitContext { stack, locals, .. }), .. } = target {
+                if let Target::SideExit { stack, locals, .. } = target {
                     let stack_idx = self.idx;
                     if stack_idx < stack.len() {
                         let opnd = &mut stack[stack_idx];
@@ -967,7 +959,7 @@ impl<'a> InsnOpndMutIterator<'a> {
                     return Some(opnd);
                 }
 
-                if let Target::SideExit { context: Some(SideExitContext { stack, locals, .. }), .. } = target {
+                if let Target::SideExit { stack, locals, .. } = target {
                     let stack_idx = self.idx - 1;
                     if stack_idx < stack.len() {
                         let opnd = &mut stack[stack_idx];
@@ -1813,8 +1805,7 @@ impl Assembler
     }
 
     /// Compile Target::SideExit and convert it into Target::CodePtr for all instructions
-    #[must_use]
-    pub fn compile_side_exits(&mut self) -> Option<()> {
+    pub fn compile_side_exits(&mut self) {
         let mut targets = HashMap::new();
         for (idx, insn) in self.insns.iter().enumerate() {
             if let Some(target @ Target::SideExit { .. }) = insn.target() {
@@ -1825,7 +1816,7 @@ impl Assembler
         for (idx, target) in targets {
             // Compile a side exit. Note that this is past the split pass and alloc_regs(),
             // so you can't use a VReg or an instruction that needs to be split.
-            if let Target::SideExit { context, reason, label } = target {
+            if let Target::SideExit { pc, stack, locals, reason, label } = target {
                 asm_comment!(self, "Exit: {reason}");
                 let side_exit_label = if let Some(label) = label {
                     Target::Label(label)
@@ -1836,26 +1827,24 @@ impl Assembler
 
                 // Restore the PC and the stack for regular side exits. We don't do this for
                 // side exits right after JIT-to-JIT calls, which restore them before the call.
-                if let Some(SideExitContext { pc, stack, locals }) = context {
-                    asm_comment!(self, "write stack slots: {stack:?}");
-                    for (idx, &opnd) in stack.iter().enumerate() {
-                        self.store(Opnd::mem(64, SP, idx as i32 * SIZEOF_VALUE_I32), opnd);
-                    }
-
-                    asm_comment!(self, "write locals: {locals:?}");
-                    for (idx, &opnd) in locals.iter().enumerate() {
-                        self.store(Opnd::mem(64, SP, (-local_size_and_idx_to_ep_offset(locals.len(), idx) - 1) * SIZEOF_VALUE_I32), opnd);
-                    }
-
-                    asm_comment!(self, "save cfp->pc");
-                    self.load_into(Opnd::Reg(Assembler::SCRATCH_REG), Opnd::const_ptr(pc));
-                    self.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_PC), Opnd::Reg(Assembler::SCRATCH_REG));
-
-                    asm_comment!(self, "save cfp->sp");
-                    self.lea_into(Opnd::Reg(Assembler::SCRATCH_REG), Opnd::mem(64, SP, stack.len() as i32 * SIZEOF_VALUE_I32));
-                    let cfp_sp = Opnd::mem(64, CFP, RUBY_OFFSET_CFP_SP);
-                    self.store(cfp_sp, Opnd::Reg(Assembler::SCRATCH_REG));
+                asm_comment!(self, "write stack slots: {stack:?}");
+                for (idx, &opnd) in stack.iter().enumerate() {
+                    self.store(Opnd::mem(64, SP, idx as i32 * SIZEOF_VALUE_I32), opnd);
                 }
+
+                asm_comment!(self, "write locals: {locals:?}");
+                for (idx, &opnd) in locals.iter().enumerate() {
+                    self.store(Opnd::mem(64, SP, (-local_size_and_idx_to_ep_offset(locals.len(), idx) - 1) * SIZEOF_VALUE_I32), opnd);
+                }
+
+                asm_comment!(self, "save cfp->pc");
+                self.load_into(Opnd::Reg(Assembler::SCRATCH_REG), Opnd::const_ptr(pc));
+                self.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_PC), Opnd::Reg(Assembler::SCRATCH_REG));
+
+                asm_comment!(self, "save cfp->sp");
+                self.lea_into(Opnd::Reg(Assembler::SCRATCH_REG), Opnd::mem(64, SP, stack.len() as i32 * SIZEOF_VALUE_I32));
+                let cfp_sp = Opnd::mem(64, CFP, RUBY_OFFSET_CFP_SP);
+                self.store(cfp_sp, Opnd::Reg(Assembler::SCRATCH_REG));
 
                 asm_comment!(self, "exit to the interpreter");
                 self.frame_teardown(&[]); // matching the setup in :bb0-prologue:
@@ -1865,7 +1854,6 @@ impl Assembler
                 *self.insns[idx].target_mut().unwrap() = side_exit_label;
             }
         }
-        Some(())
     }
 }
 

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -895,7 +895,7 @@ impl Assembler
     pub fn compile_with_regs(self, cb: &mut CodeBlock, regs: Vec<Reg>) -> Option<(CodePtr, Vec<CodePtr>)> {
         let asm = self.x86_split();
         let mut asm = asm.alloc_regs(regs)?;
-        asm.compile_side_exits()?;
+        asm.compile_side_exits();
 
         // Create label instances in the code block
         for (idx, name) in asm.label_names.iter().enumerate() {


### PR DESCRIPTION
This PR refactors side-exit implementations using the fact that exits after JIT-to-JIT calls no longer restore `c_stack_bytes` after https://github.com/ruby/ruby/pull/14019 and thus can be shared among all JIT-to-JIT calls.

We can use the same trampoline used by function stubs for JIT-to-JIT calls. Now that `compile_side_exits` never generate context-less side exits, `Target::SideExit` can be simpler too.