### PR TITLE
Fix documentation about struct RData's data field

### DIFF
--- a/include/ruby/internal/core/rdata.h
+++ b/include/ruby/internal/core/rdata.h
@@ -143,8 +143,8 @@ struct RData {
     RUBY_DATA_FUNC dfree;
 
     /** Pointer to the actual C level struct that you want to wrap.
-      * This is in between dmark and dfree to allow DATA_PTR to continue
-      * to work for both RData and non-embedded RTypedData.
+      * This is after dmark and dfree to allow DATA_PTR to continue to work for
+      * both RData and non-embedded RTypedData.
       */
     void *data;
 };

--- a/include/ruby/internal/core/rtypeddata.h
+++ b/include/ruby/internal/core/rtypeddata.h
@@ -37,6 +37,7 @@
 #include "ruby/internal/dllexport.h"
 #include "ruby/internal/error.h"
 #include "ruby/internal/fl_type.h"
+#include "ruby/internal/static_assert.h"
 #include "ruby/internal/stdbool.h"
 #include "ruby/internal/value_type.h"
 
@@ -373,6 +374,8 @@ struct RTypedData {
     /** Pointer to the actual C level struct that you want to wrap. */
     void *data;
 };
+
+RBIMPL_STATIC_ASSERT(data_in_rtypeddata, offsetof(struct RData, data) == offsetof(struct RTypedData, data));
 
 RBIMPL_SYMBOL_EXPORT_BEGIN()
 RBIMPL_ATTR_NONNULL((3))


### PR DESCRIPTION
Also adds a static assertion to ensure the documented behavior stays true, namely that the data field is at the same position in the RData and RTypedData structs.

This was changed in 360be94d0492f766b08cc39e33f5e248f49a89b7. cc @byroot 