### PR TITLE
CI: ubuntu-ibm.yml: Add GitHub Actions ppc64le case

### DIFF
--- a/.github/workflows/ubuntu-ibm.yml
+++ b/.github/workflows/ubuntu-ibm.yml
@@ -27,10 +27,7 @@ jobs:
         test_task: [check]
         configure: ['']
         os:
-          # FIXME Comment out ppc64le due to failing tests on GitHub Actions
-          # ppc64le
-          # https://bugs.ruby-lang.org/issues/21534
-          # - ubuntu-24.04-ppc64le
+          - ubuntu-24.04-ppc64le
           - ubuntu-24.04-s390x
           # Add a x86_64 case to make this CI pass on fork repositories.
           - ubuntu-24.04
@@ -107,8 +104,14 @@ jobs:
       - name: Run configure
         env:
           configure: ${{ matrix.configure }}
-        run: >-
-          ../src/configure -C --disable-install-doc ${configure:-cppflags=-DRUBY_DEBUG}
+        # Don't set cppflags=-DRUBY_DEBUG on ppc64le, due to some Ractor tests
+        # failing in the case.
+        # https://bugs.ruby-lang.org/issues/21534
+        run: |
+          if [ "$(uname -m)" != "ppc64le" ]; then
+            configure="${configure:-cppflags=-DRUBY_DEBUG}"
+          fi
+          ../src/configure -C --disable-install-doc ${configure}
 
       - run: make
 

--- a/.github/workflows/ubuntu-ibm.yml
+++ b/.github/workflows/ubuntu-ibm.yml
@@ -26,13 +26,14 @@ jobs:
       matrix:
         test_task: [check]
         configure: ['']
-        arch: ['']
         os:
           # FIXME Comment out ppc64le due to failing tests on GitHub Actions
           # ppc64le
           # https://bugs.ruby-lang.org/issues/21534
           # - ubuntu-24.04-ppc64le
           - ubuntu-24.04-s390x
+          # Add a x86_64 case to make this CI pass on fork repositories.
+          - ubuntu-24.04
         # The ppc64le/s390x runners work only in the registered repositories.
         # They don't work in forked repositories.
         # https://github.com/IBM/actionspz/blob/main/docs/FAQ.md#what-about-forked-repos
@@ -43,13 +44,15 @@ jobs:
             upstream: false
           - os: ubuntu-24.04-s390x
             upstream: false
+          - os: ubuntu-24.04
+            upstream: true
       fail-fast: false
 
     env:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
       RUBY_DEBUG: ci
 
-    runs-on: ${{ matrix.os || 'ubuntu-22.04' }}
+    runs-on: ${{ matrix.os }}
 
     if: >-
       ${{!(false
@@ -66,14 +69,12 @@ jobs:
           sparse-checkout: /.github
 
       - uses: ./.github/actions/setup/ubuntu
-        with:
-          arch: ${{ matrix.arch }}
 
       - uses: ruby/setup-ruby@a9bfc2ecf3dd40734a9418f89a7e9d484c32b990 # v1.248.0
         with:
           ruby-version: '3.1'
           bundler: none
-        if: ${{ !endsWith(matrix.os, 'arm') && !endsWith(matrix.os, 'ppc64le') && !endsWith(matrix.os, 's390x') }}
+        if: ${{ !endsWith(matrix.os, 'ppc64le') && !endsWith(matrix.os, 's390x') }}
 
       # Avoid possible test failures with the zlib applying the following patch
       # on s390x CPU architecture.
@@ -105,22 +106,17 @@ jobs:
 
       - name: Run configure
         env:
-          arch: ${{ matrix.arch }}
           configure: ${{ matrix.configure }}
         run: >-
-          $SETARCH ../src/configure -C --disable-install-doc ${configure:-cppflags=-DRUBY_DEBUG}
-          ${arch:+--target=$arch-$OSTYPE --host=$arch-$OSTYPE}
+          ../src/configure -C --disable-install-doc ${configure:-cppflags=-DRUBY_DEBUG}
 
-      - run: $SETARCH make prepare-gems
-        if: ${{ matrix.test_task == 'test-bundled-gems' }}
+      - run: make
 
-      - run: $SETARCH make
-
-      - run: $SETARCH make hello
+      - run: make hello
 
       - name: runirb
         run: |
-          echo IRB::VERSION | $SETARCH make runirb RUNOPT="-- -f"
+          echo IRB::VERSION | make runirb RUNOPT="-- -f"
 
       - name: Set test options for skipped tests
         run: |
@@ -133,7 +129,7 @@ jobs:
         id: launchable
         uses: ./.github/actions/launchable/setup
         with:
-          os: ${{ matrix.os || 'ubuntu-22.04' }}
+          os: ${{ matrix.os }}
           test-opts: ${{ matrix.configure }}
           launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
           builddir: build
@@ -157,7 +153,7 @@ jobs:
           test -n "${LAUNCHABLE_STDOUT}" && exec 1> >(tee "${LAUNCHABLE_STDOUT}")
           test -n "${LAUNCHABLE_STDERR}" && exec 2> >(tee "${LAUNCHABLE_STDERR}")
 
-          $SETARCH make -s ${{ matrix.test_task }} \
+          make -s ${{ matrix.test_task }} \
           ${TESTS:+TESTS="$TESTS"} \
           ${{ !contains(matrix.test_task, 'bundle') && 'RUBYOPT=-w' || '' }}
         timeout-minutes: ${{ matrix.timeout || 40 }}
@@ -170,7 +166,7 @@ jobs:
 
       - name: make skipped tests
         run: |
-          $SETARCH make -s test-all TESTS="${TESTS//-n!\//-n/}"
+          make -s test-all TESTS="${TESTS//-n!\//-n/}"
         env:
           GNUMAKEFLAGS: ''
           RUBY_TESTOPTS: '-v --tty=no'
@@ -180,11 +176,11 @@ jobs:
       - name: test-pc
         run: |
           DESTDIR=${RUNNER_TEMP-${TMPDIR-/tmp}}/installed
-          $SETARCH make test-pc "DESTDIR=$DESTDIR"
+          make test-pc "DESTDIR=$DESTDIR"
 
       - uses: ./.github/actions/slack
         with:
-          label: ${{ matrix.test_task }} ${{ matrix.configure }}${{ matrix.arch }}
+          label: ${{ matrix.test_task }} ${{ matrix.configure }}
           SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
         if: ${{ failure() }}
 

--- a/.github/workflows/ubuntu-ibm.yml
+++ b/.github/workflows/ubuntu-ibm.yml
@@ -1,0 +1,193 @@
+name: Ubuntu IBM
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - '**/man/*'
+      - '**.md'
+      - '**.rdoc'
+      - '**/.document'
+      - '.*.yml'
+  pull_request:
+    # Do not use paths-ignore for required status checks
+    # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }} / ${{ startsWith(github.event_name, 'pull') && github.ref_name || github.sha }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull') }}
+
+permissions:
+  contents: read
+
+jobs:
+  make:
+    strategy:
+      matrix:
+        test_task: [check]
+        configure: ['']
+        arch: ['']
+        os:
+          # FIXME Comment out ppc64le due to failing tests on GitHub Actions
+          # ppc64le
+          # https://bugs.ruby-lang.org/issues/21534
+          # - ubuntu-24.04-ppc64le
+          - ubuntu-24.04-s390x
+        # The ppc64le/s390x runners work only in the registered repositories.
+        # They don't work in forked repositories.
+        # https://github.com/IBM/actionspz/blob/main/docs/FAQ.md#what-about-forked-repos
+        upstream:
+          - ${{ github.repository == 'ruby/ruby' }}
+        exclude:
+          - os: ubuntu-24.04-ppc64le
+            upstream: false
+          - os: ubuntu-24.04-s390x
+            upstream: false
+      fail-fast: false
+
+    env:
+      GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
+      RUBY_DEBUG: ci
+
+    runs-on: ${{ matrix.os || 'ubuntu-22.04' }}
+
+    if: >-
+      ${{!(false
+      || contains(github.event.head_commit.message, '[DOC]')
+      || contains(github.event.pull_request.title, '[DOC]')
+      || contains(github.event.pull_request.labels.*.name, 'Documentation')
+      || (github.event_name == 'push' && github.event.pull_request.user.login == 'dependabot[bot]')
+      )}}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: /.github
+
+      - uses: ./.github/actions/setup/ubuntu
+        with:
+          arch: ${{ matrix.arch }}
+
+      - uses: ruby/setup-ruby@a9bfc2ecf3dd40734a9418f89a7e9d484c32b990 # v1.248.0
+        with:
+          ruby-version: '3.1'
+          bundler: none
+        if: ${{ !endsWith(matrix.os, 'arm') && !endsWith(matrix.os, 'ppc64le') && !endsWith(matrix.os, 's390x') }}
+
+      # Avoid possible test failures with the zlib applying the following patch
+      # on s390x CPU architecture.
+      # https://github.com/madler/zlib/pull/410
+      - name: Disable DFLTCC
+        run: echo "DFLTCC=0" >> $GITHUB_ENV
+        working-directory:
+        if: ${{ endsWith(matrix.os, 's390x') }}
+
+      # A temporary workaround: Set HOME env to pass the step
+      # ./.github/actions/setup/directories.
+      # https://github.com/IBM/actionspz/issues/30
+      - name: Set HOME env
+        run: |
+          echo "HOME: #{HOME}"
+          echo "HOME=$(ls -d ~)" >> $GITHUB_ENV
+        working-directory:
+        if: ${{ endsWith(matrix.os, 'ppc64le') || endsWith(matrix.os, 's390x') }}
+
+      - uses: ./.github/actions/setup/directories
+        with:
+          srcdir: src
+          builddir: build
+          makeup: true
+          clean: true
+          dummy-files: ${{ matrix.test_task == 'check' }}
+          # Set fetch-depth: 10 so that Launchable can receive commits information.
+          fetch-depth: 10
+
+      - name: Run configure
+        env:
+          arch: ${{ matrix.arch }}
+          configure: ${{ matrix.configure }}
+        run: >-
+          $SETARCH ../src/configure -C --disable-install-doc ${configure:-cppflags=-DRUBY_DEBUG}
+          ${arch:+--target=$arch-$OSTYPE --host=$arch-$OSTYPE}
+
+      - run: $SETARCH make prepare-gems
+        if: ${{ matrix.test_task == 'test-bundled-gems' }}
+
+      - run: $SETARCH make
+
+      - run: $SETARCH make hello
+
+      - name: runirb
+        run: |
+          echo IRB::VERSION | $SETARCH make runirb RUNOPT="-- -f"
+
+      - name: Set test options for skipped tests
+        run: |
+          set -x
+          TESTS="$(echo "${{ matrix.skipped_tests }}" | sed 's| |$$/ -n!/|g;s|^|-n!/|;s|$|$$/|')"
+          echo "TESTS=${TESTS}" >> $GITHUB_ENV
+        if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
+
+      - name: Set up Launchable
+        id: launchable
+        uses: ./.github/actions/launchable/setup
+        with:
+          os: ${{ matrix.os || 'ubuntu-22.04' }}
+          test-opts: ${{ matrix.configure }}
+          launchable-token: ${{ secrets.LAUNCHABLE_TOKEN }}
+          builddir: build
+          srcdir: src
+        continue-on-error: true
+        timeout-minutes: 3
+
+      # A temporary workaround: Skip user ground id test
+      # There is a mismatch between the group IDs of "id -g" and C function
+      # getpwuid(uid_t uid) pw_gid.
+      # https://github.com/IBM/actionspz/issues/31
+      - name: Skip user group id test
+        run: |
+          sed -i.orig '/^    it "returns user group id" do/a\      skip' \
+            ../src/spec/ruby/library/etc/struct_passwd_spec.rb
+          diff -u ../src/spec/ruby/library/etc/struct_passwd_spec.rb{.orig,} || :
+        if: ${{ endsWith(matrix.os, 'ppc64le') || endsWith(matrix.os, 's390x') }}
+
+      - name: make ${{ matrix.test_task }}
+        run: |
+          test -n "${LAUNCHABLE_STDOUT}" && exec 1> >(tee "${LAUNCHABLE_STDOUT}")
+          test -n "${LAUNCHABLE_STDERR}" && exec 2> >(tee "${LAUNCHABLE_STDERR}")
+
+          $SETARCH make -s ${{ matrix.test_task }} \
+          ${TESTS:+TESTS="$TESTS"} \
+          ${{ !contains(matrix.test_task, 'bundle') && 'RUBYOPT=-w' || '' }}
+        timeout-minutes: ${{ matrix.timeout || 40 }}
+        env:
+          RUBY_TESTOPTS: '-q --tty=no'
+          TEST_BUNDLED_GEMS_ALLOW_FAILURES: ''
+          PRECHECK_BUNDLED_GEMS: 'no'
+          LAUNCHABLE_STDOUT: ${{ steps.launchable.outputs.stdout_report_path }}
+          LAUNCHABLE_STDERR: ${{ steps.launchable.outputs.stderr_report_path }}
+
+      - name: make skipped tests
+        run: |
+          $SETARCH make -s test-all TESTS="${TESTS//-n!\//-n/}"
+        env:
+          GNUMAKEFLAGS: ''
+          RUBY_TESTOPTS: '-v --tty=no'
+        if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
+        continue-on-error: ${{ matrix.continue-on-skipped_tests || false }}
+
+      - name: test-pc
+        run: |
+          DESTDIR=${RUNNER_TEMP-${TMPDIR-/tmp}}/installed
+          $SETARCH make test-pc "DESTDIR=$DESTDIR"
+
+      - uses: ./.github/actions/slack
+        with:
+          label: ${{ matrix.test_task }} ${{ matrix.configure }}${{ matrix.arch }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
+        if: ${{ failure() }}
+
+defaults:
+  run:
+    working-directory: build


### PR DESCRIPTION
Note that the default configure option `./configure cppflags=-DRUBY_DEBUG`
causes the following Ractor test and other tests failing. So, we don't set the
option in ppc64le cases.

```
$ make btest BTESTS=bootstraptest/test_ractor.rb
```

You can check the following ticket for details.
https://bugs.ruby-lang.org/issues/21534
