### PR TITLE
Fix a static assertion incompatible with C++98

### DIFF
--- a/include/ruby/internal/core/rtypeddata.h
+++ b/include/ruby/internal/core/rtypeddata.h
@@ -375,7 +375,9 @@ struct RTypedData {
     void *data;
 };
 
+#if !defined(__cplusplus) || __cplusplus >= 201103L
 RBIMPL_STATIC_ASSERT(data_in_rtypeddata, offsetof(struct RData, data) == offsetof(struct RTypedData, data));
+#endif
 
 RBIMPL_SYMBOL_EXPORT_BEGIN()
 RBIMPL_ATTR_NONNULL((3))


### PR DESCRIPTION
The CI was skipped for the PR, but https://github.com/ruby/ruby/pull/14221 has failed the C++98 CI. https://github.com/ruby/ruby/actions/runs/16973372638/job/48115906097

cc: @etiennebarrie @byroot 