### PR TITLE
Don't check for stack overflow when ec is NULL

### DIFF
--- a/signal.c
+++ b/signal.c
@@ -879,7 +879,7 @@ check_stack_overflow(int sig, const void *addr)
     int ruby_stack_overflowed_p(const rb_thread_t *, const void *);
     rb_execution_context_t *ec = rb_current_execution_context(false);
     if (!ec) return;
-    rb_thread_t *th = GET_THREAD();
+    rb_thread_t *th = rb_ec_thread_ptr(ec);
     if (ruby_stack_overflowed_p(th, addr)) {
         reset_sigmask(sig);
         rb_ec_stack_overflow(th->ec, 1);


### PR DESCRIPTION
If we hit a SEGV on a non-Ruby thread or during shutdown, previously this would usually cause another segfault. Avoiding this might allow for more useful error logs (elsewhere in the bug report we do check for `ec` missing)