### PR TITLE
Fix enc_list across ractors

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -1394,10 +1394,8 @@ enc_names(VALUE self)
 static VALUE
 enc_list(VALUE klass)
 {
-    VALUE ary = rb_ary_new2(ENCODING_LIST_CAPA);
     VALUE list = RUBY_ATOMIC_VALUE_LOAD(rb_encoding_list);
-    rb_ary_replace(ary, list);
-    return ary;
+    return rb_ary_dup(list);
 }
 
 /*


### PR DESCRIPTION
Calling rb_ary_replace(copy, orig) can modify orig, which is not safe across ractors because orig is shared (it's the global encoding list).

Hoping to address CI failures such as https://ci.rvm.jp/results/trunk-gc-asserts@ruby-sp2-noble-docker/5890058