### PR TITLE
ZJIT: Make --zjit-dump-hir work with HIR opt disabled

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1313,6 +1313,7 @@ fn compile_iseq(iseq: IseqPtr) -> Option<Function> {
     if !get_option!(disable_hir_opt) {
         function.optimize();
     }
+    function.dump_hir();
     #[cfg(debug_assertions)]
     if let Err(err) = function.validate() {
         debug!("ZJIT: compile_iseq: {err:?}");

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2143,7 +2143,10 @@ impl Function {
         #[cfg(debug_assertions)] self.assert_validates();
         self.eliminate_dead_code();
         #[cfg(debug_assertions)] self.assert_validates();
+    }
 
+    /// Dump HIR passed to codegen if specified by options.
+    pub fn dump_hir(&self) {
         // Dump HIR after optimization
         match get_option!(dump_hir_opt) {
             Some(DumpHIR::WithoutSnapshot) => println!("Optimized HIR:\n{}", FunctionPrinter::without_snapshot(&self)),
@@ -2156,7 +2159,6 @@ impl Function {
             println!("{}", FunctionGraphvizPrinter::new(&self));
         }
     }
-
 
     /// Validates the following:
     /// 1. Basic block jump args match parameter arity.


### PR DESCRIPTION
This PR allows `--zjit-dump-hir` to work when `--zjit-disable-hir-opt`. ref: https://github.com/ruby/ruby/pull/14181

I know `--zjit-dump-hir-init` still works, but I want to keep using `--zjit-dump-hir` when switching `--zjit-disable-hir-opt` because I use it as "dump HIR used by codegen", which should work even when HIR optimizer is disabled.