### PR TITLE
Don't free Ractors in GC shutdown

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -343,7 +343,7 @@ rb_gc_shutdown_call_finalizer_p(VALUE obj)
         if (rb_obj_is_thread(obj)) return false;
         if (rb_obj_is_mutex(obj)) return false;
         if (rb_obj_is_fiber(obj)) return false;
-        if (rb_obj_is_main_ractor(obj)) return false;
+        if (rb_ractor_p(obj)) return false;
         if (rb_obj_is_fstring_table(obj)) return false;
         if (rb_obj_is_symbol_table(obj)) return false;
 


### PR DESCRIPTION
`rb_gc_shutdown_call_finalizer_p` returns false for threads and fibers, so it should probably do the same for all Ractors (not just the main one).

This hopefully mitigates a bug where, at exit, rb_ractor_terminate_all gets all Ractors to stop before continuing with the shutdown process. However when `vm->ractor.cnt` reaches 1, the native threads may still be running code at the end co_start, which reads/locks on `th->ractor->threads.sched`, so the Ractor is not safe to free.

A better solution might be to ensure that all native threads end up stopped or otherwise parked before this part of the shutdown, however that would be a bit more involved.

cc @peterzhu2118 @luke-gruber @etiennebarrie 
cc @ko1 