### PR TITLE
Skip an unstable Ractor test for windows

### DIFF
--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -164,7 +164,7 @@ class TestRactor < Test::Unit::TestCase
 
   # [Bug #21398]
   def test_port_receive_dnt_with_port_send
-    omit 'unstable on macos-14' if RUBY_PLATFORM =~ /darwin/
+    omit 'unstable on windows and macos-14' if RUBY_PLATFORM =~ /mswin|darwin/
     assert_ractor(<<~'RUBY', timeout: 90)
       THREADS = 10
       JOBS_PER_THREAD = 50


### PR DESCRIPTION
So I attempted to stabilize the test by increasing the timeout, but it still failed with a fairly long timeout. The test doesn't seem reliable on Windows, so let me skip it for Windows https://github.com/ruby/ruby/actions/runs/16995599804/job/48185434078?pr=14242 to make PRs mergeable on GitHub.

cc: @luke-gru @jhawthorn 