### PR TITLE
CI: Also show errors in rust-warnings.yml

### DIFF
--- a/.github/workflows/rust-warnings.yml
+++ b/.github/workflows/rust-warnings.yml
@@ -42,10 +42,10 @@ jobs:
         run: rustup default beta
 
       - name: Rust warnings
+        shell: bash
         run: |
-          set -euo pipefail
+          set -eu
           cargo check --quiet --all-features --message-format=json \
-            | jq -r 'select(.reason == "compiler-message" and .message.level == "warning") | .message.rendered' \
-            > warnings.txt
-          cat warnings.txt
-          ! grep --quiet '[^[:space:]]' warnings.txt
+            | jq -r 'select(.message.level == "warning" or .message.level == "error") | .message.rendered' \
+            | tee messages.txt
+          (exit "${PIPESTATUS[0]}") && ! grep --quiet '[^[:space:]]' messages.txt


### PR DESCRIPTION
Demos:
- errors: https://github.com/ruby/ruby/actions/runs/16998802932
- warnings: https://github.com/ruby/ruby/actions/runs/16998864751/job/48196086544?pr=14249
- success: this PR

At under a minute, this check runs faster than a lot of the other CI checks,
so we might as well show errors from `cargo check` to serve
as a smoke check in addition to surfacing warnings.

https://github.com/ruby/ruby/pull/14173#discussion_r2279409225