### PR TITLE
Fix tests using assert_raise_with_message on US-ASCII systems

### DIFF
--- a/test/-ext-/symbol/test_type.rb
+++ b/test/-ext-/symbol/test_type.rb
@@ -123,16 +123,20 @@ module Test_Symbol
 
     def test_check_id_invalid_type
       cx = EnvUtil.labeled_class("X\u{1f431}")
-      assert_raise_with_message(TypeError, /X\u{1F431}/) {
-        Bug::Symbol.pinneddown?(cx)
-      }
+      EnvUtil.with_default_internal(Encoding::UTF_8) do
+        assert_raise_with_message(TypeError, /X\u{1F431}/) {
+          Bug::Symbol.pinneddown?(cx)
+        }
+      end
     end
 
     def test_check_symbol_invalid_type
       cx = EnvUtil.labeled_class("X\u{1f431}")
-      assert_raise_with_message(TypeError, /X\u{1F431}/) {
-        Bug::Symbol.find(cx)
-      }
+      EnvUtil.with_default_internal(Encoding::UTF_8) do
+        assert_raise_with_message(TypeError, /X\u{1F431}/) {
+          Bug::Symbol.find(cx)
+        }
+      end
     end
 
     def test_const_name_type

--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -696,9 +696,11 @@ class TestClass < Test::Unit::TestCase
   def test_namescope_error_message
     m = Module.new
     o = m.module_eval "class A\u{3042}; self; end.new"
-    assert_raise_with_message(TypeError, /A\u{3042}/) {
-      o::Foo
-    }
+    EnvUtil.with_default_internal(Encoding::UTF_8) do
+      assert_raise_with_message(TypeError, /A\u{3042}/) {
+        o::Foo
+      }
+    end
   end
 
   def test_redefinition_mismatch

--- a/test/ruby/test_float.rb
+++ b/test/ruby/test_float.rb
@@ -861,7 +861,9 @@ class TestFloat < Test::Unit::TestCase
     assert_raise(Encoding::CompatibilityError) {Float("0".encode("utf-32le"))}
     assert_raise(Encoding::CompatibilityError) {Float("0".encode("iso-2022-jp"))}
 
-    assert_raise_with_message(ArgumentError, /\u{1f4a1}/) {Float("\u{1f4a1}")}
+    EnvUtil.with_default_internal(Encoding::UTF_8) do
+      assert_raise_with_message(ArgumentError, /\u{1f4a1}/) {Float("\u{1f4a1}")}
+    end
   end
 
   def test_invalid_str

--- a/test/ruby/test_integer.rb
+++ b/test/ruby/test_integer.rb
@@ -158,7 +158,9 @@ class TestInteger < Test::Unit::TestCase
     assert_raise(Encoding::CompatibilityError, bug6192) {Integer("0".encode("utf-32le"))}
     assert_raise(Encoding::CompatibilityError, bug6192) {Integer("0".encode("iso-2022-jp"))}
 
-    assert_raise_with_message(ArgumentError, /\u{1f4a1}/) {Integer("\u{1f4a1}")}
+    EnvUtil.with_default_internal(Encoding::UTF_8) do
+      assert_raise_with_message(ArgumentError, /\u{1f4a1}/) {Integer("\u{1f4a1}")}
+    end
 
     obj = Struct.new(:s).new(%w[42 not-an-integer])
     def obj.to_str; s.shift; end

--- a/test/ruby/test_method.rb
+++ b/test/ruby/test_method.rb
@@ -284,8 +284,10 @@ class TestMethod < Test::Unit::TestCase
     assert_raise(TypeError) { m.bind(Object.new) }
 
     cx = EnvUtil.labeled_class("X\u{1f431}")
-    assert_raise_with_message(TypeError, /X\u{1f431}/) do
-      o.method(cx)
+    EnvUtil.with_default_internal(Encoding::UTF_8) do
+      assert_raise_with_message(TypeError, /X\u{1f431}/) do
+        o.method(cx)
+      end
     end
   end
 
@@ -315,9 +317,12 @@ class TestMethod < Test::Unit::TestCase
     assert_raise(TypeError) do
       Class.new.class_eval { define_method(:bar, o.method(:bar)) }
     end
+
     cx = EnvUtil.labeled_class("X\u{1f431}")
-    assert_raise_with_message(TypeError, /X\u{1F431}/) do
-      Class.new {define_method(cx) {}}
+    EnvUtil.with_default_internal(Encoding::UTF_8) do
+      assert_raise_with_message(TypeError, /X\u{1F431}/) do
+        Class.new {define_method(cx) {}}
+      end
     end
   end
 

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -1291,8 +1291,11 @@ class TestModule < Test::Unit::TestCase
     assert_raise(NameError) { c1.const_set("X\u{3042}".encode("utf-16le"), :foo) }
     assert_raise(NameError) { c1.const_set("X\u{3042}".encode("utf-32be"), :foo) }
     assert_raise(NameError) { c1.const_set("X\u{3042}".encode("utf-32le"), :foo) }
+
     cx = EnvUtil.labeled_class("X\u{3042}")
-    assert_raise_with_message(TypeError, /X\u{3042}/) { c1.const_set(cx, :foo) }
+    EnvUtil.with_default_internal(Encoding::UTF_8) do
+      assert_raise_with_message(TypeError, /X\u{3042}/) { c1.const_set(cx, :foo) }
+    end
   end
 
   def test_const_get_invalid_name

--- a/test/ruby/test_numeric.rb
+++ b/test/ruby/test_numeric.rb
@@ -18,20 +18,24 @@ class TestNumeric < Test::Unit::TestCase
     assert_raise_with_message(TypeError, /can't be coerced into /) {1|:foo}
     assert_raise_with_message(TypeError, /can't be coerced into /) {1^:foo}
 
-    assert_raise_with_message(TypeError, /:\u{3042}/) {1+:"\u{3042}"}
-    assert_raise_with_message(TypeError, /:\u{3042}/) {1&:"\u{3042}"}
-    assert_raise_with_message(TypeError, /:\u{3042}/) {1|:"\u{3042}"}
-    assert_raise_with_message(TypeError, /:\u{3042}/) {1^:"\u{3042}"}
+    EnvUtil.with_default_internal(Encoding::UTF_8) do
+      assert_raise_with_message(TypeError, /:\u{3042}/) {1+:"\u{3042}"}
+      assert_raise_with_message(TypeError, /:\u{3042}/) {1&:"\u{3042}"}
+      assert_raise_with_message(TypeError, /:\u{3042}/) {1|:"\u{3042}"}
+      assert_raise_with_message(TypeError, /:\u{3042}/) {1^:"\u{3042}"}
+
+      assert_raise_with_message(TypeError, /:\u{3044}/) {1+"\u{3044}".to_sym}
+      assert_raise_with_message(TypeError, /:\u{3044}/) {1&"\u{3044}".to_sym}
+      assert_raise_with_message(TypeError, /:\u{3044}/) {1|"\u{3044}".to_sym}
+      assert_raise_with_message(TypeError, /:\u{3044}/) {1^"\u{3044}".to_sym}
+    end
+
     EnvUtil.with_default_internal(Encoding::US_ASCII) do
       assert_raise_with_message(TypeError, /:"\\u3042"/) {1+:"\u{3042}"}
       assert_raise_with_message(TypeError, /:"\\u3042"/) {1&:"\u{3042}"}
       assert_raise_with_message(TypeError, /:"\\u3042"/) {1|:"\u{3042}"}
       assert_raise_with_message(TypeError, /:"\\u3042"/) {1^:"\u{3042}"}
     end
-    assert_raise_with_message(TypeError, /:\u{3044}/) {1+"\u{3044}".to_sym}
-    assert_raise_with_message(TypeError, /:\u{3044}/) {1&"\u{3044}".to_sym}
-    assert_raise_with_message(TypeError, /:\u{3044}/) {1|"\u{3044}".to_sym}
-    assert_raise_with_message(TypeError, /:\u{3044}/) {1^"\u{3044}".to_sym}
 
     bug10711 = '[ruby-core:67405] [Bug #10711]'
     exp = "1.2 can't be coerced into Integer"

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -114,14 +114,19 @@ class TestProcess < Test::Unit::TestCase
     }
     assert_raise(ArgumentError) { Process.getrlimit(:FOO) }
     assert_raise(ArgumentError) { Process.getrlimit("FOO") }
-    assert_raise_with_message(ArgumentError, /\u{30eb 30d3 30fc}/) { Process.getrlimit("\u{30eb 30d3 30fc}") }
+
+    EnvUtil.with_default_internal(Encoding::UTF_8) do
+      assert_raise_with_message(ArgumentError, /\u{30eb 30d3 30fc}/) { Process.getrlimit("\u{30eb 30d3 30fc}") }
+    end
   end
 
   def test_rlimit_value
     return unless rlimit_exist?
     assert_raise(ArgumentError) { Process.setrlimit(:FOO, 0) }
     assert_raise(ArgumentError) { Process.setrlimit(:CORE, :FOO) }
-    assert_raise_with_message(ArgumentError, /\u{30eb 30d3 30fc}/) { Process.setrlimit("\u{30eb 30d3 30fc}", 0) }
+    EnvUtil.with_default_internal(Encoding::UTF_8) do
+      assert_raise_with_message(ArgumentError, /\u{30eb 30d3 30fc}/) { Process.setrlimit("\u{30eb 30d3 30fc}", 0) }
+    end
     assert_raise_with_message(ArgumentError, /\u{30eb 30d3 30fc}/) { Process.setrlimit(:CORE, "\u{30eb 30d3 30fc}") }
     with_tmpchdir do
       s = run_in_child(<<-'End')

--- a/test/ruby/test_rational.rb
+++ b/test/ruby/test_rational.rb
@@ -117,9 +117,13 @@ class Rational_Test < Test::Unit::TestCase
     assert_equal(Rational(111, 1000), Rational('1.11e-1'))
     assert_raise(TypeError){Rational(nil)}
     assert_raise(ArgumentError){Rational('')}
-    assert_raise_with_message(ArgumentError, /\u{221a 2668}/) {
-      Rational("\u{221a 2668}")
-    }
+
+    EnvUtil.with_default_internal(Encoding::UTF_8) do
+      assert_raise_with_message(ArgumentError, /\u{221a 2668}/) {
+        Rational("\u{221a 2668}")
+      }
+    end
+
     assert_warning('') {
       assert_predicate(Rational('1e-99999999999999999999'), :zero?)
     }


### PR DESCRIPTION
On systems where the Encoding.default_internal defaults to US-ASCII instead of UTF-8, some tests using assert_raise_with_message can fail since it no longer changes Encoding.default_internal in 79f5202.

This tests explicitly uses EnvUtil.with_default_internal on systems where these tests fail.