### PR TITLE
Increase timeout on slow tests

### DIFF
--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -447,7 +447,7 @@ class TestGc < Test::Unit::TestCase
   end
 
   def test_singleton_method_added
-    assert_in_out_err([], <<-EOS, [], [], "[ruby-dev:44436]")
+    assert_in_out_err([], <<-EOS, [], [], "[ruby-dev:44436]", timeout: 30)
       class BasicObject
         undef singleton_method_added
         def singleton_method_added(mid)

--- a/test/ruby/test_keyword.rb
+++ b/test/ruby/test_keyword.rb
@@ -4033,7 +4033,7 @@ class TestKeywordArguments < Test::Unit::TestCase
       tap { m }
       GC.start
       tap { m }
-    }, bug8964
+    }, bug8964, timeout: 30
     assert_normal_exit %q{
       prc = Proc.new {|a: []|}
       GC.stress = true


### PR DESCRIPTION
Seeing this [in CI](https://github.com/ruby/ruby/actions/runs/17045056804/job/48318563985?pr=14188):

```
    1) Error:
  TestKeywordArguments#test_gced_object_in_stack:
  Test::Unit::ProxyError: execution of Test::Unit::CoreAssertions#assert_normal_exit expired timeout (10 sec)
  pid 52150 exit 0
  | 
  
      /Users/runner/work/ruby/ruby/src/test/ruby/test_keyword.rb:4029:in 'TestKeywordArguments#test_gced_object_in_stack'
  
    2) Error:
  TestGc#test_singleton_method_added:
  Test::Unit::ProxyError: execution of Test::Unit::CoreAssertions#assert_in_out_err expired timeout (10 sec)
  pid 52152 exit 0
  | 
  
      /Users/runner/work/ruby/ruby/src/test/ruby/test_gc.rb:450:in 'TestGc#test_singleton_method_added'
  
  Finished tests in 172.275893s, 167.9806 tests/s, 35561.5919 assertions/s.
  28939 tests, 6126405 assertions, 0 failures, 2 errors, 157 skips
  
  ruby -v: ruby 3.5.0dev (2025-08-18T15:28:36Z pull/14188/merge 4ac76f23f7) +PRISM [arm64-darwin23]
```