### PR TITLE
Backport GH-13617 for s390x (#13757)

### DIFF
--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -413,6 +413,7 @@ class TestVariable < Test::Unit::TestCase
   end
 
   def test_exivar_resize_with_compaction_stress
+    omit "compaction doesn't work well on s390x" if RUBY_PLATFORM =~ /s390x/ # https://github.com/ruby/ruby/pull/5077
     objs = 10_000.times.map do
       ExIvar.new
     end


### PR DESCRIPTION
https://github.com/ruby/ruby/pull/13617

Same reason as https://github.com/ruby/ruby/pull/13757
But it was hit on Fedora's infra: https://koji.fedoraproject.org/koji/taskinfo?taskID=136229016

Failure can be seen in: https://kojipkgs.fedoraproject.org//work/tasks/9016/136229016/build.log
(Ephemeral log)

```
169) Error:
TestVariable#test_exivar_resize_with_compaction_stress:
RuntimeError: compaction doesn't work well on s390x. Omit the test in the caller.
    /builddir/build/BUILD/ruby-3.3.9-build/ruby-3.3.9/tool/lib/envutil.rb:249:in `under_gc_compact_stress'
    /builddir/build/BUILD/ruby-3.3.9-build/ruby-3.3.9/test/ruby/test_variable.rb:419:in `test_exivar_resize_with_compaction_stress'
Finished tests in 617.443873s, 43.1958 tests/s, 10265.6149 assertions/s.
26671 tests, 6338441 assertions, 0 failures, 1 errors, 168 skips
ruby -v: ruby 3.3.9 (2025-07-24 revision f5c772fc7c) [s390x-linux]
```

---

Cherry-picked https://github.com/ruby/ruby/pull/13757