### PR TITLE
ZJIT: Allocate register for VRegs that begin and end at the same index

### DIFF
--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -2079,6 +2079,7 @@ mod tests {
 
     #[test]
     fn test_reorder_c_args_single_cycle() {
+        crate::options::rb_zjit_prepare_options();
         let (mut asm, mut cb) = setup_asm();
 
         // x0 and x1 form a cycle

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1398,6 +1398,9 @@ impl Assembler
                 _ => None,
             };
             if vreg_idx.is_some() {
+                if live_ranges[vreg_idx.unwrap()].end() == index {
+                    debug!("Allocating a register for VReg({}) at instruction index {} even though it does not live past this index", vreg_idx.unwrap(), index);
+                }
                 // This is going to be the output operand that we will set on the
                 // instruction. CCall and LiveReg need to use a specific register.
                 let mut out_reg = match insn {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1391,8 +1391,7 @@ impl Assembler
                 }
             }
 
-            // If the output VReg of this instruction is used by another instruction,
-            // we need to allocate a register to it
+            // Allocate a register for the output operand if it exists
             let vreg_idx = match insn.out_opnd() {
                 Some(Opnd::VReg { idx, .. }) => Some(*idx),
                 _ => None,
@@ -1480,6 +1479,8 @@ impl Assembler
                 }
             }
 
+            // If we have an output that dies at its definition (it is unused), free up the
+            // register
             if let Some(idx) = vreg_idx {
                 if live_ranges[idx].end() == index {
                     if let Some(reg) = reg_mapping[idx] {

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1213,7 +1213,7 @@ impl Assembler
     /// Append an instruction onto the current list of instructions and update
     /// the live ranges of any instructions whose outputs are being used as
     /// operands to this instruction.
-    pub fn push_insn(&mut self, mut insn: Insn) {
+    pub fn push_insn(&mut self, insn: Insn) {
         // Index of this instruction
         let insn_idx = self.insns.len();
 
@@ -1225,7 +1225,7 @@ impl Assembler
         }
 
         // If we find any VReg from previous instructions, extend the live range to insn_idx
-        let mut opnd_iter = insn.opnd_iter_mut();
+        let mut opnd_iter = insn.opnd_iter();
         while let Some(opnd) = opnd_iter.next() {
             match *opnd {
                 Opnd::VReg { idx, .. } |

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1397,7 +1397,7 @@ impl Assembler
                 Some(Opnd::VReg { idx, .. }) => Some(*idx),
                 _ => None,
             };
-            if vreg_idx.is_some() && live_ranges[vreg_idx.unwrap()].end() != index {
+            if vreg_idx.is_some() {
                 // This is going to be the output operand that we will set on the
                 // instruction. CCall and LiveReg need to use a specific register.
                 let mut out_reg = match insn {
@@ -1474,6 +1474,16 @@ impl Assembler
                         *opnd = Opnd::Mem(Mem { base, disp, num_bits });
                     }
                     _ => {},
+                }
+            }
+
+            if let Some(idx) = vreg_idx {
+                if live_ranges[idx].end() == index {
+                    if let Some(reg) = reg_mapping[idx] {
+                        pool.dealloc_reg(&reg);
+                    } else {
+                        unreachable!("no register allocated for insn {:?}", insn);
+                    }
                 }
             }
 

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1247,6 +1247,7 @@ mod tests {
 
     #[test]
     fn test_reorder_c_args_no_cycle() {
+        rb_zjit_prepare_options();
         let (mut asm, mut cb) = setup_asm();
 
         asm.ccall(0 as _, vec![
@@ -1263,6 +1264,7 @@ mod tests {
 
     #[test]
     fn test_reorder_c_args_single_cycle() {
+        rb_zjit_prepare_options();
         let (mut asm, mut cb) = setup_asm();
 
         // rdi and rsi form a cycle
@@ -1284,6 +1286,7 @@ mod tests {
 
     #[test]
     fn test_reorder_c_args_two_cycles() {
+        rb_zjit_prepare_options();
         let (mut asm, mut cb) = setup_asm();
 
         // rdi and rsi form a cycle, and rdx and rcx form another cycle
@@ -1309,6 +1312,7 @@ mod tests {
 
     #[test]
     fn test_reorder_c_args_large_cycle() {
+        rb_zjit_prepare_options();
         let (mut asm, mut cb) = setup_asm();
 
         // rdi, rsi, and rdx form a cycle

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1254,7 +1254,7 @@ mod tests {
             C_ARG_OPNDS[0], // mov rdi, rdi (optimized away)
             C_ARG_OPNDS[1], // mov rsi, rsi (optimized away)
         ]);
-        asm.compile_with_num_regs(&mut cb, 1);
+        asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
         assert_disasm!(cb, "b800000000ffd0", {"
             0x0: mov eax, 0
@@ -1273,7 +1273,7 @@ mod tests {
             C_ARG_OPNDS[0], // mov rsi, rdi
             C_ARG_OPNDS[2], // mov rdx, rdx (optimized away)
         ]);
-        asm.compile_with_num_regs(&mut cb, 1);
+        asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
         assert_disasm!(cb, "4989f34889fe4c89dfb800000000ffd0", {"
             0x0: mov r11, rsi
@@ -1296,7 +1296,7 @@ mod tests {
             C_ARG_OPNDS[3], // mov rdx, rcx
             C_ARG_OPNDS[2], // mov rcx, rdx
         ]);
-        asm.compile_with_num_regs(&mut cb, 1);
+        asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
         assert_disasm!(cb, "4989f34889fe4c89df4989cb4889d14c89dab800000000ffd0", {"
             0x0: mov r11, rsi
@@ -1321,7 +1321,7 @@ mod tests {
             C_ARG_OPNDS[2], // mov rsi, rdx
             C_ARG_OPNDS[0], // mov rdx, rdi
         ]);
-        asm.compile_with_num_regs(&mut cb, 1);
+        asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
         assert_disasm!(cb, "4989f34889d64889fa4c89dfb800000000ffd0", {"
             0x0: mov r11, rsi

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1253,7 +1253,7 @@ mod tests {
             C_ARG_OPNDS[0], // mov rdi, rdi (optimized away)
             C_ARG_OPNDS[1], // mov rsi, rsi (optimized away)
         ]);
-        asm.compile_with_num_regs(&mut cb, 0);
+        asm.compile_with_num_regs(&mut cb, 1);
 
         assert_disasm!(cb, "b800000000ffd0", {"
             0x0: mov eax, 0
@@ -1271,7 +1271,7 @@ mod tests {
             C_ARG_OPNDS[0], // mov rsi, rdi
             C_ARG_OPNDS[2], // mov rdx, rdx (optimized away)
         ]);
-        asm.compile_with_num_regs(&mut cb, 0);
+        asm.compile_with_num_regs(&mut cb, 1);
 
         assert_disasm!(cb, "4989f34889fe4c89dfb800000000ffd0", {"
             0x0: mov r11, rsi
@@ -1293,7 +1293,7 @@ mod tests {
             C_ARG_OPNDS[3], // mov rdx, rcx
             C_ARG_OPNDS[2], // mov rcx, rdx
         ]);
-        asm.compile_with_num_regs(&mut cb, 0);
+        asm.compile_with_num_regs(&mut cb, 1);
 
         assert_disasm!(cb, "4989f34889fe4c89df4989cb4889d14c89dab800000000ffd0", {"
             0x0: mov r11, rsi
@@ -1317,7 +1317,7 @@ mod tests {
             C_ARG_OPNDS[2], // mov rsi, rdx
             C_ARG_OPNDS[0], // mov rdx, rdi
         ]);
-        asm.compile_with_num_regs(&mut cb, 0);
+        asm.compile_with_num_regs(&mut cb, 1);
 
         assert_disasm!(cb, "4989f34889d64889fa4c89dfb800000000ffd0", {"
             0x0: mov r11, rsi

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1247,7 +1247,7 @@ mod tests {
 
     #[test]
     fn test_reorder_c_args_no_cycle() {
-        rb_zjit_prepare_options();
+        crate::options::rb_zjit_prepare_options();
         let (mut asm, mut cb) = setup_asm();
 
         asm.ccall(0 as _, vec![
@@ -1264,7 +1264,7 @@ mod tests {
 
     #[test]
     fn test_reorder_c_args_single_cycle() {
-        rb_zjit_prepare_options();
+        crate::options::rb_zjit_prepare_options();
         let (mut asm, mut cb) = setup_asm();
 
         // rdi and rsi form a cycle
@@ -1286,7 +1286,7 @@ mod tests {
 
     #[test]
     fn test_reorder_c_args_two_cycles() {
-        rb_zjit_prepare_options();
+        crate::options::rb_zjit_prepare_options();
         let (mut asm, mut cb) = setup_asm();
 
         // rdi and rsi form a cycle, and rdx and rcx form another cycle
@@ -1312,7 +1312,7 @@ mod tests {
 
     #[test]
     fn test_reorder_c_args_large_cycle() {
-        rb_zjit_prepare_options();
+        crate::options::rb_zjit_prepare_options();
         let (mut asm, mut cb) = setup_asm();
 
         // rdi, rsi, and rdx form a cycle


### PR DESCRIPTION
If the LiveRange looks like (idx, idx), we will currently not allocate a
register. This change allocates a register and then immediately
deallocates it.

Fix https://github.com/Shopify/ruby/issues/614
