### PR TITLE
ZJIT: Remove try_num_bits

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -147,26 +147,15 @@ impl Opnd
         }
     }
 
-    /// Return Some(Opnd) with a given num_bits if self has num_bits.
-    /// None if self doesn't have a num_bits field.
-    pub fn try_num_bits(&self, num_bits: u8) -> Option<Opnd> {
-        assert!(num_bits == 8 || num_bits == 16 || num_bits == 32 || num_bits == 64);
-        match *self {
-            Opnd::Reg(reg) => Some(Opnd::Reg(reg.with_num_bits(num_bits))),
-            Opnd::Mem(Mem { base, disp, .. }) => Some(Opnd::Mem(Mem { base, disp, num_bits })),
-            Opnd::VReg { idx, .. } => Some(Opnd::VReg { idx, num_bits }),
-            _ => None,
-        }
-    }
-
-    /// Return Opnd with a given num_bits if self has num_bits.
-    /// Panic otherwise. This should be used only when you know which Opnd self is.
+    /// Return Opnd with a given num_bits if self has num_bits. Panic otherwise.
     #[track_caller]
     pub fn with_num_bits(&self, num_bits: u8) -> Opnd {
-        if let Some(opnd) = self.try_num_bits(num_bits) {
-            opnd
-        } else {
-            unreachable!("with_num_bits should not be used on: {self:?}");
+        assert!(num_bits == 8 || num_bits == 16 || num_bits == 32 || num_bits == 64);
+        match *self {
+            Opnd::Reg(reg) => Opnd::Reg(reg.with_num_bits(num_bits)),
+            Opnd::Mem(Mem { base, disp, .. }) => Opnd::Mem(Mem { base, disp, num_bits }),
+            Opnd::VReg { idx, .. } => Opnd::VReg { idx, num_bits },
+            _ => unreachable!("with_num_bits should not be used for: {self:?}"),
         }
     }
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1183,8 +1183,8 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, guard
         asm.jne(side_exit(jit, state, GuardType(guard_type)));
     } else if guard_type.is_subtype(types::StaticSymbol) {
         // Static symbols have (val & 0xff) == RUBY_SYMBOL_FLAG
-        // Use 8-bit comparison like YJIT does
-        debug_assert!(val.try_num_bits(8).is_some(), "GuardType should not be used for a known constant, but val was: {val:?}");
+        // Use 8-bit comparison like YJIT does. GuardType should not be used
+        // for a known VALUE, which with_num_bits() does not support.
         asm.cmp(val.with_num_bits(8), Opnd::UImm(RUBY_SYMBOL_FLAG as u64));
         asm.jne(side_exit(jit, state, GuardType(guard_type)));
     } else if guard_type.is_subtype(types::NilClass) {


### PR DESCRIPTION
Fixes https://github.com/ruby/ruby/pull/14265#discussion_r2283374794

https://github.com/ruby/ruby/pull/14265 removed the use of `try_num_bits` (other than in the debug assertion), so this PR removes the function.