### PR TITLE
ZJIT: 2 newrange fixes

### DIFF
--- a/range.c
+++ b/range.c
@@ -47,6 +47,7 @@ static VALUE r_cover_p(VALUE, VALUE, VALUE, VALUE);
 static void
 range_init(VALUE range, VALUE beg, VALUE end, VALUE exclude_end)
 {
+    // Changing this condition has implications for JITs. If you do, please let maintainers know.
     if ((!FIXNUM_P(beg) || !FIXNUM_P(end)) && !NIL_P(beg) && !NIL_P(end)) {
         VALUE v;
 

--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -1855,6 +1855,21 @@ class TestZJIT < Test::Unit::TestCase
     }, insns: [:toregexp]
   end
 
+  def test_new_range_non_leaf
+    assert_compiles '(0/1)..1', %q{
+      def jit_entry(v) = make_range_then_exit(v)
+
+      def make_range_then_exit(v)
+        range = (v..1)
+        super rescue range # TODO(alan): replace super with side-exit intrinsic
+      end
+
+      jit_entry(0)    # profile
+      jit_entry(0)    # compile
+      jit_entry(0/1r) # run without stub
+    }, call_threshold: 2
+  end
+
   private
 
   # Assert that every method call in `test_script` can be compiled by ZJIT

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -338,7 +338,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::Const { val: Const::Value(val) } => gen_const(*val),
         Insn::NewArray { elements, state } => gen_new_array(asm, opnds!(elements), &function.frame_state(*state)),
         Insn::NewHash { elements, state } => gen_new_hash(jit, asm, elements, &function.frame_state(*state)),
-        Insn::NewRange { low, high, flag, state } => gen_new_range(asm, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
+        Insn::NewRange { low, high, flag, state } => gen_new_range(jit, asm, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
         Insn::ArrayDup { val, state } => gen_array_dup(asm, opnd!(val), &function.frame_state(*state)),
         Insn::StringCopy { val, chilled, state } => gen_string_copy(asm, opnd!(val), *chilled, &function.frame_state(*state)),
         // concatstrings shouldn't have 0 strings
@@ -1040,13 +1040,15 @@ fn gen_new_hash(
 
 /// Compile a new range instruction
 fn gen_new_range(
+    jit: &JITState,
     asm: &mut Assembler,
     low: lir::Opnd,
     high: lir::Opnd,
     flag: RangeType,
     state: &FrameState,
 ) -> lir::Opnd {
-    gen_prepare_call_with_gc(asm, state);
+    // Sometimes calls `low.<=>(high)`
+    gen_prepare_non_leaf_call(jit, asm, state);
 
     // Call rb_range_new(low, high, flag)
     asm_ccall!(asm, rb_range_new, low, high, (flag as i64).into())


### PR DESCRIPTION
- **ZJIT: Prepare for rb_range_new() calling <=>**
- **ZJIT: Mark Insn::NewRange as having side effects**

Fixes: https://github.com/Shopify/ruby/issues/708
