### PR TITLE
Enable Dependabot updates for vcpkg

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
     directory: '/yjit'
     schedule:
       interval: 'daily'
+  - package-ecosystem: 'vcpkg'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
See https://github.blog/changelog/2025-08-12-dependabot-version-updates-now-support-vcpkg/