### PR TITLE
Atomic CC table set in cache_callable_method_entry

### DIFF
--- a/internal/class.h
+++ b/internal/class.h
@@ -630,7 +630,7 @@ RCLASS_WRITE_CALLABLE_M_TBL(VALUE klass, struct rb_id_table *table)
 static inline void
 RCLASS_WRITE_CC_TBL(VALUE klass, VALUE table)
 {
-    RB_OBJ_WRITE(klass, &RCLASSEXT_CC_TBL(RCLASS_EXT_WRITABLE(klass)), table);
+    RB_OBJ_ATOMIC_WRITE(klass, &RCLASSEXT_CC_TBL(RCLASS_EXT_WRITABLE(klass)), table);
 }
 
 static inline void

--- a/vm_method.c
+++ b/vm_method.c
@@ -1782,7 +1782,14 @@ cache_callable_method_entry(VALUE klass, ID mid, const rb_callable_method_entry_
 #endif
     }
     else {
-        vm_ccs_create(klass, cc_tbl, mid, cme);
+        if (rb_multi_ractor_p()) {
+            VALUE new_cc_tbl = rb_vm_cc_table_dup(cc_tbl);
+            vm_ccs_create(klass, new_cc_tbl, mid, cme);
+            RB_OBJ_ATOMIC_WRITE(klass, &RCLASSEXT_CC_TBL(RCLASS_EXT_WRITABLE(klass)), new_cc_tbl);
+        }
+        else {
+            vm_ccs_create(klass, cc_tbl, mid, cme);
+        }
     }
 }
 


### PR DESCRIPTION
`cache_callable_method_entry` needs to do the same dance as `vm_populate_cc` otherwise we could mutate the table while it's being read.

cc @casperisfine @peterzhu2118 