### PR TITLE
Pre-mark classes as shareable

### DIFF
--- a/class.c
+++ b/class.c
@@ -677,6 +677,7 @@ class_alloc0(enum ruby_value_type type, VALUE klass, bool namespaceable)
     VALUE flags = type;
     if (RGENGC_WB_PROTECTED_CLASS) flags |= FL_WB_PROTECTED;
     if (namespaceable) flags |= RCLASS_NAMESPACEABLE;
+    flags |= RUBY_FL_SHAREABLE;
 
     NEWOBJ_OF(obj, struct RClass, klass, flags, alloc_size, 0);
 

--- a/ractor.c
+++ b/ractor.c
@@ -1466,9 +1466,7 @@ shareable_p_enter(VALUE obj)
     else if (RB_TYPE_P(obj, T_CLASS)  ||
              RB_TYPE_P(obj, T_MODULE) ||
              RB_TYPE_P(obj, T_ICLASS)) {
-        // TODO: remove it
-        mark_shareable(obj);
-        return traverse_skip;
+        UNREACHABLE;
     }
     else if (RB_OBJ_FROZEN_RAW(obj) &&
              allow_frozen_shareable_p(obj)) {


### PR DESCRIPTION
Classes are supposed to be always shareable. It's better for us to eagerly allocate them this way, otherwise we end up unsafely concurrently mutating their flags.

cc @ko1