### PR TITLE
Remove unused SPECIAL_CONST_SHAPE_ID

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -1625,7 +1625,6 @@ Init_shape(void)
     rb_define_const(rb_cShape, "SHAPE_IVAR", INT2NUM(SHAPE_IVAR));
     rb_define_const(rb_cShape, "SHAPE_ID_NUM_BITS", INT2NUM(SHAPE_ID_NUM_BITS));
     rb_define_const(rb_cShape, "SHAPE_FLAG_SHIFT", INT2NUM(SHAPE_FLAG_SHIFT));
-    rb_define_const(rb_cShape, "SPECIAL_CONST_SHAPE_ID", INT2NUM(SPECIAL_CONST_SHAPE_ID));
     rb_define_const(rb_cShape, "SHAPE_MAX_VARIATIONS", INT2NUM(SHAPE_MAX_VARIATIONS));
     rb_define_const(rb_cShape, "SIZEOF_RB_SHAPE_T", INT2NUM(sizeof(rb_shape_t)));
     rb_define_const(rb_cShape, "SIZEOF_REDBLACK_NODE_T", INT2NUM(sizeof(redblack_node_t)));

--- a/shape.h
+++ b/shape.h
@@ -72,7 +72,6 @@ typedef uint32_t redblack_id_t;
 #define ROOT_SHAPE_WITH_OBJ_ID          0x1
 #define ROOT_TOO_COMPLEX_SHAPE_ID       (ROOT_SHAPE_ID | SHAPE_ID_FL_TOO_COMPLEX)
 #define ROOT_TOO_COMPLEX_WITH_OBJ_ID    (ROOT_SHAPE_WITH_OBJ_ID | SHAPE_ID_FL_TOO_COMPLEX | SHAPE_ID_FL_HAS_OBJECT_ID)
-#define SPECIAL_CONST_SHAPE_ID          (ROOT_SHAPE_ID | SHAPE_ID_FL_FROZEN)
 
 typedef struct redblack_node redblack_node_t;
 

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -1051,8 +1051,10 @@ class TestShapes < Test::Unit::TestCase
     # RUBY_PLATFORM =~ /i686/
   end
 
-  def test_root_shape_transition_to_special_const_on_frozen
-    assert_equal(RubyVM::Shape::SPECIAL_CONST_SHAPE_ID, RubyVM::Shape.of([].freeze).id)
+  def test_root_shape_frozen
+    frozen_root_shape = RubyVM::Shape.of([].freeze)
+    assert_predicate(frozen_root_shape, :frozen?)
+    assert_equal(RubyVM::Shape.root_shape.id, frozen_root_shape.raw_id)
   end
 
   def test_basic_shape_transition

--- a/zjit.c
+++ b/zjit.c
@@ -347,7 +347,6 @@ rb_zjit_shape_obj_too_complex_p(VALUE obj)
 }
 
 enum {
-    RB_SPECIAL_CONST_SHAPE_ID = SPECIAL_CONST_SHAPE_ID,
     RB_INVALID_SHAPE_ID = INVALID_SHAPE_ID,
 };
 

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -361,7 +361,6 @@ fn main() {
         .allowlist_function("rb_zjit_singleton_class_p")
         .allowlist_type("robject_offsets")
         .allowlist_type("rstring_offsets")
-        .allowlist_var("RB_SPECIAL_CONST_SHAPE_ID")
         .allowlist_var("RB_INVALID_SHAPE_ID")
 
         // From jit.c

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -269,7 +269,6 @@ pub type IseqPtr = *const rb_iseq_t;
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct ShapeId(pub u32);
 
-pub const SPECIAL_CONST_SHAPE_ID: ShapeId = ShapeId(RB_SPECIAL_CONST_SHAPE_ID);
 pub const INVALID_SHAPE_ID: ShapeId = ShapeId(RB_INVALID_SHAPE_ID);
 
 // Given an ISEQ pointer, convert PC to insn_idx

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -724,7 +724,6 @@ pub const DEFINED_REF: defined_type = 15;
 pub const DEFINED_FUNC: defined_type = 16;
 pub const DEFINED_CONST_FROM: defined_type = 17;
 pub type defined_type = u32;
-pub const RB_SPECIAL_CONST_SHAPE_ID: _bindgen_ty_38 = 33554432;
 pub const RB_INVALID_SHAPE_ID: _bindgen_ty_38 = 4294967295;
 pub type _bindgen_ty_38 = u32;
 pub type rb_iseq_param_keyword_struct = rb_iseq_constant_body__bindgen_ty_1_rb_iseq_param_keyword;


### PR DESCRIPTION
Its usage was removed in 306d50811dd060d876d1eb364a0d5e6106f5e4f1 (#14266).