### PR TITLE
Fixes to encoding/transcoding for ractors.

### DIFF
--- a/depend
+++ b/depend
@@ -1401,7 +1401,6 @@ compile.$(OBJEXT): $(top_srcdir)/prism/pack.h
 compile.$(OBJEXT): $(top_srcdir)/prism/parser.h
 compile.$(OBJEXT): $(top_srcdir)/prism/prettyprint.h
 compile.$(OBJEXT): $(top_srcdir)/prism/prism.h
-compile.$(OBJEXT): $(top_srcdir)/prism/prism.h
 compile.$(OBJEXT): $(top_srcdir)/prism/regexp.h
 compile.$(OBJEXT): $(top_srcdir)/prism/static_literals.h
 compile.$(OBJEXT): $(top_srcdir)/prism/util/pm_buffer.h
@@ -17727,6 +17726,7 @@ transcode.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 transcode.$(OBJEXT): $(top_srcdir)/internal/array.h
 transcode.$(OBJEXT): $(top_srcdir)/internal/class.h
 transcode.$(OBJEXT): $(top_srcdir)/internal/compilers.h
+transcode.$(OBJEXT): $(top_srcdir)/internal/encoding.h
 transcode.$(OBJEXT): $(top_srcdir)/internal/gc.h
 transcode.$(OBJEXT): $(top_srcdir)/internal/inits.h
 transcode.$(OBJEXT): $(top_srcdir)/internal/object.h

--- a/internal/encoding.h
+++ b/internal/encoding.h
@@ -29,6 +29,7 @@ void rb_encdb_declare(const char *name);
 void rb_enc_set_base(const char *name, const char *orig);
 int rb_enc_set_dummy(int index);
 void rb_enc_raw_set(VALUE obj, rb_encoding *enc);
+int rb_enc_registered(const char *name);
 
 PUREFUNC(int rb_data_is_encoding(VALUE obj));
 

--- a/test/ruby/test_encoding.rb
+++ b/test/ruby/test_encoding.rb
@@ -157,4 +157,23 @@ class TestEncoding < Test::Unit::TestCase
       assert rs.empty?
     end;
   end
+
+  def test_ractor_set_default_external_string
+    assert_ractor("#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+    $-w = nil
+    rs = []
+    7.times do |i|
+      rs << Ractor.new(i) do |i|
+        Encoding.default_external = "us-ascii"
+      end
+    end
+
+    while rs.any?
+      r, _obj = Ractor.select(*rs)
+      rs.delete(r)
+    end
+    assert rs.empty?
+    end;
+  end
 end


### PR DESCRIPTION
Not all ractor-related encoding issues were fixed by 1afc07e815051e2f73493f055f2130cb642ba12a. I found more by running my test-all branch with 3 ractors for each test.