### PR TITLE
YJIT: Fix BSD make build. Remove ZJIT stuff

### DIFF
--- a/yjit/not_gmake.mk
+++ b/yjit/not_gmake.mk
@@ -12,21 +12,7 @@ yjit-static-lib:
 	$(Q) $(RUSTC) $(YJIT_RUSTC_ARGS)
 
 # Assume GNU flavor LD and OBJCOPY. Works on FreeBSD 13, at least.
-$(YJIT_LIBOBJ): $(YJIT_LIBS)
+$(RUST_LIBOBJ): $(YJIT_LIBS)
 	$(ECHO) 'partial linking $(YJIT_LIBS) into $@'
 	$(Q) $(LD) -r -o $@ --whole-archive $(YJIT_LIBS)
-	-$(Q) $(OBJCOPY) --wildcard --keep-global-symbol='$(SYMBOL_PREFIX)rb_*' $(@)
-
-.PHONY: zjit-static-lib
-$(ZJIT_LIBS): zjit-static-lib
-	$(empty)
-
-zjit-static-lib:
-	$(ECHO) 'building Rust ZJIT (release mode)'
-	$(Q) $(RUSTC) $(ZJIT_RUSTC_ARGS)
-
-# Assume GNU flavor LD and OBJCOPY. Works on FreeBSD 13, at least.
-$(ZJIT_LIBOBJ): $(ZJIT_LIBS)
-	$(ECHO) 'partial linking $(ZJIT_LIBS) into $@'
-	$(Q) $(LD) -r -o $@ --whole-archive $(ZJIT_LIBS)
 	-$(Q) $(OBJCOPY) --wildcard --keep-global-symbol='$(SYMBOL_PREFIX)rb_*' $(@)


### PR DESCRIPTION
Thanks to nobu for pointing this out. This is a YJIT file so shouldn't
have ZJIT stuff in it. ZJIT doesn't support building on BSDs yet.

Fix: 92b218fbc379fe85792eb060b71520e271971335
