### PR TITLE
Remove warnings from test suite

### DIFF
--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -48,7 +48,7 @@ class TestAst < Test::Unit::TestCase
       @path = path
       @errors = []
       @debug = false
-      @ast = RubyVM::AbstractSyntaxTree.parse(src) if src
+      @ast = EnvUtil.suppress_warning { RubyVM::AbstractSyntaxTree.parse(src) } if src
     end
 
     def validate_range
@@ -67,7 +67,7 @@ class TestAst < Test::Unit::TestCase
 
     def ast
       return @ast if defined?(@ast)
-      @ast = RubyVM::AbstractSyntaxTree.parse_file(@path)
+      @ast = EnvUtil.suppress_warning { RubyVM::AbstractSyntaxTree.parse_file(@path) }
     end
 
     private
@@ -135,7 +135,7 @@ class TestAst < Test::Unit::TestCase
 
   Dir.glob("test/**/*.rb", base: SRCDIR).each do |path|
     define_method("test_all_tokens:#{path}") do
-      node = RubyVM::AbstractSyntaxTree.parse_file("#{SRCDIR}/#{path}", keep_tokens: true)
+      node = EnvUtil.suppress_warning { RubyVM::AbstractSyntaxTree.parse_file("#{SRCDIR}/#{path}", keep_tokens: true) }
       tokens = node.all_tokens.sort_by { [_1.last[0], _1.last[1]] }
       tokens_bytes = tokens.map { _1[2]}.join.bytes
       source_bytes = File.read("#{SRCDIR}/#{path}").bytes

--- a/test/ruby/test_optimization.rb
+++ b/test/ruby/test_optimization.rb
@@ -606,11 +606,11 @@ class TestRubyOptimization < Test::Unit::TestCase
   end
 
   class Bug10557
-    def [](_)
+    def [](_, &)
       block_given?
     end
 
-    def []=(_, _)
+    def []=(_, _, &)
       block_given?
     end
   end

--- a/test/ruby/test_optimization.rb
+++ b/test/ruby/test_optimization.rb
@@ -1256,6 +1256,9 @@ class TestRubyOptimization < Test::Unit::TestCase
       insn = iseq.disasm
       assert_match(/opt_new/, insn)
       assert_match(/OptNewFoo:.+@a=1, @b=2/, iseq.eval.inspect)
+      # clean-up to avoid warnings
+      Object.send :remove_const, :OptNewFoo
+      Object.remove_method :optnew_foo if defined?(optnew_foo)
     end
     [
       'def optnew_foo(&) = OptNewFoo.new(&)',

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -457,7 +457,7 @@ class TestVariable < Test::Unit::TestCase
       instance.instance_variable_set(:@a3, 3)
       instance.instance_variable_set(:@a4, 4)
     end.resume
-    assert_equal 4, instance.instance_variable_get(:@a4)
+    assert_equal 4, instance.instance_variable_get(:@a4), bug21547
   end
 
   private


### PR DESCRIPTION
This removes warnings when the test suite runs.

These appear when running the test suite with `RUBYOPT=-w` like [chkbuild does](https://github.com/ruby/chkbuild/blob/72c06b8d9d891df248d53192670181652c468510/chkbuild/ruby.rb#L687).