### PR TITLE
Fix outdated `ENV::clone` method description

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -7610,7 +7610,7 @@ Init_Hash(void)
      *
      * - ::assoc: Returns a 2-element array containing the name and value
      *   of the named environment variable if it exists:
-     * - ::clone: Returns +ENV+ (and issues a warning).
+     * - ::clone: Raises an exception.
      * - ::except: Returns a hash of all name/value pairs except those given.
      * - ::fetch: Returns the value for the given name.
      * - ::inspect: Returns the contents of +ENV+ as a string.


### PR DESCRIPTION
It does raise an exception rather than just issuing a warning:

```shell
$ docker run -e ALL_RUBY_SINCE=2.7 --rm rubylang/all-ruby ./all-ruby -We 'ENV.clone'
ruby-2.7.0
...
ruby-3.0.7
ruby-3.1.0-preview1 -e:1: warning: ENV.clone is deprecated; use ENV.to_h instead
...
ruby-3.2.0-preview1 -e:1: warning: ENV.clone is deprecated; use ENV.to_h instead
ruby-3.2.0-preview2 -e:1:in `clone': Cannot clone ENV, use ENV.to_h to get a copy of ENV as a hash (TypeError)
                    	from -e:1:in `<main>'
                exit 1
...
ruby-3.3.9          -e:1:in `clone': Cannot clone ENV, use ENV.to_h to get a copy of ENV as a hash (TypeError)
                    	from -e:1:in `<main>'
                exit 1
ruby-3.4.0-preview1 -e:1:in 'clone': Cannot clone ENV, use ENV.to_h to get a copy of ENV as a hash (TypeError)
                    	from -e:1:in '<main>'
                exit 1
...
ruby-3.5.0-preview1 -e:1:in 'clone': Cannot clone ENV, use ENV.to_h to get a copy of ENV as a hash (TypeError)
                    	from -e:1:in '<main>'
                exit 1

```