### PR TITLE
ZJIT: Allow querying a single ZJIT stat

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -18,6 +18,15 @@ class TestZJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_stats_enabled
+    assert_runs 'false', <<~RUBY, stats: false
+      RubyVM::ZJIT.stats_enabled?
+    RUBY
+    assert_runs 'true', <<~RUBY, stats: true
+      RubyVM::ZJIT.stats_enabled?
+    RUBY
+  end
+
   def test_enable_through_env
     child_env = {'RUBY_YJIT_ENABLE' => nil, 'RUBY_ZJIT_ENABLE' => '1'}
     assert_in_out_err([child_env, '-v'], '') do |stdout, stderr|

--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -1495,10 +1495,13 @@ class TestZJIT < Test::Unit::TestCase
   end
 
   def test_stats
-    assert_runs 'true', %q{
+    assert_runs '[true, true]', %q{
       def test = 1
       test
-      RubyVM::ZJIT.stats[:zjit_insns_count] > 0
+      [
+        RubyVM::ZJIT.stats[:zjit_insns_count] > 0,
+        RubyVM::ZJIT.stats(:zjit_insns_count) > 0,
+      ]
     }, stats: true
   end
 

--- a/zjit.c
+++ b/zjit.c
@@ -358,7 +358,7 @@ rb_zjit_singleton_class_p(VALUE klass)
 
 // Primitives used by zjit.rb. Don't put other functions below, which wouldn't use them.
 VALUE rb_zjit_assert_compiles(rb_execution_context_t *ec, VALUE self);
-VALUE rb_zjit_stats(rb_execution_context_t *ec, VALUE self);
+VALUE rb_zjit_stats(rb_execution_context_t *ec, VALUE self, VALUE target_key);
 VALUE rb_zjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
 
 // Preprocessed zjit.rb generated during build

--- a/zjit.rb
+++ b/zjit.rb
@@ -19,6 +19,11 @@ class << RubyVM::ZJIT
     Primitive.cexpr! 'RBOOL(rb_zjit_enabled_p)'
   end
 
+  # Check if `--zjit-stats` is used
+  def stats_enabled?
+    Primitive.rb_zjit_stats_enabled_p
+  end
+
   # Return ZJIT statistics as a Hash
   def stats
     stats = Primitive.rb_zjit_stats

--- a/zjit.rb
+++ b/zjit.rb
@@ -25,9 +25,9 @@ class << RubyVM::ZJIT
   end
 
   # Return ZJIT statistics as a Hash
-  def stats
-    stats = Primitive.rb_zjit_stats
-    return nil if stats.nil?
+  def stats(key = nil)
+    stats = Primitive.rb_zjit_stats(key)
+    return stats if stats.nil? || !key.nil?
 
     if stats.key?(:vm_insns_count) && stats.key?(:zjit_insns_count)
       stats[:total_insns_count] = stats[:vm_insns_count] + stats[:zjit_insns_count]


### PR DESCRIPTION
* Add `RubyVM::ZJIT.stats_enabled?`
* Allow `RubyVM::ZJIT.stats(key)` to query a specific stat

Ports from `RubyVM::YJIT`. I want them to improve ZJIT stats integration for yjit-bench.