### PR TITLE
[DOC] Fix quote in the example

### DIFF
--- a/doc/_regexp.rdoc
+++ b/doc/_regexp.rdoc
@@ -713,7 +713,7 @@ Analysis:
 
 1. The leading subexpression <tt>"</tt> in the pattern matches the first character
    <tt>"</tt> in the target string.
-2. The next subexpression <tt>.*</tt> matches the next substring <tt>Quote“</tt>
+2. The next subexpression <tt>.*</tt> matches the next substring <tt>Quote"</tt>
    (including the trailing double-quote).
 3. Now there is nothing left in the target string to match
    the trailing subexpression <tt>"</tt> in the pattern;


### PR DESCRIPTION
The character in the example is U+0022 QUOTATION MARK, not U+201C LEFT DOUBLE QUOTATION MARK.