### PR TITLE
Get rid of `strcpy`

### DIFF
--- a/addr2line.c
+++ b/addr2line.c
@@ -637,12 +637,13 @@ follow_debuglink_build_id(const char *build_id, size_t build_id_size, int num_tr
                           obj_info_t **objp, line_info_t *lines, int offset, FILE *errout)
 {
     static const char global_debug_dir[] = "/usr/lib/debug/.build-id/";
+    static const char debug_suffix[] = ".debug";
     const size_t global_debug_dir_len = sizeof(global_debug_dir) - 1;
     char *p;
     obj_info_t *o1 = *objp, *o2;
     size_t i;
 
-    if (PATH_MAX < global_debug_dir_len + 1 + build_id_size * 2 + 6) return;
+    if (PATH_MAX < global_debug_dir_len + build_id_size * 2 + sizeof(debug_suffix)) return;
 
     memcpy(binary_filename, global_debug_dir, global_debug_dir_len);
     p = binary_filename + global_debug_dir_len;
@@ -653,7 +654,7 @@ follow_debuglink_build_id(const char *build_id, size_t build_id_size, int num_tr
         *p++ = tbl[n % 16];
         if (i == 0) *p++ = '/';
     }
-    strcpy(p, ".debug");
+    memcpy(p, debug_suffix, sizeof(debug_suffix));
 
     append_obj(objp);
     o2 = *objp;

--- a/ext/socket/getaddrinfo.c
+++ b/ext/socket/getaddrinfo.c
@@ -171,9 +171,7 @@ static const char *const ai_errlist[] = {
 
 #define GET_CANONNAME(ai, str) \
 if (pai->ai_flags & AI_CANONNAME) {\
-        if (((ai)->ai_canonname = (char *)malloc(strlen(str) + 1)) != NULL) {\
-                strcpy((ai)->ai_canonname, (str));\
-        } else {\
+        if (((ai)->ai_canonname = strdup(str)) == NULL) {\
                 error = EAI_MEMORY;\
                 goto free;\
         }\

--- a/ext/socket/getnameinfo.c
+++ b/ext/socket/getnameinfo.c
@@ -158,16 +158,14 @@ getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, socklen_t ho
                 /* what we should do? */
         } else if (flags & NI_NUMERICSERV) {
                 snprintf(numserv, sizeof(numserv), "%d", ntohs(port));
-                if (strlen(numserv) + 1 > servlen)
+                if (strlcpy(serv, numserv, servlen) >= servlen)
                         return ENI_MEMORY;
-                strcpy(serv, numserv);
         } else {
 #if defined(HAVE_GETSERVBYPORT)
                 struct servent *sp = getservbyport(port, (flags & NI_DGRAM) ? "udp" : "tcp");
                 if (sp) {
-                        if (strlen(sp->s_name) + 1 > servlen)
+                        if (strlcpy(serv, sp->s_name, servlen) >= servlen)
                                 return ENI_MEMORY;
-                        strcpy(serv, sp->s_name);
                 } else
                         return ENI_NOSERVNAME;
 #else
@@ -202,9 +200,8 @@ getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, socklen_t ho
                 if (inet_ntop(afd->a_af, addr, numaddr, sizeof(numaddr))
                     == NULL)
                         return ENI_SYSTEM;
-                if (strlen(numaddr) > hostlen)
+                if (strlcpy(host, numaddr, hostlen) >= hostlen)
                         return ENI_MEMORY;
-                strcpy(host, numaddr);
         } else {
 #ifdef INET6
                 hp = getipnodebyaddr(addr, afd->a_addrlen, afd->a_af, &h_error);
@@ -218,13 +215,12 @@ getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, socklen_t ho
                                 p = strchr(hp->h_name, '.');
                                 if (p) *p = '\0';
                         }
-                        if (strlen(hp->h_name) + 1 > hostlen) {
+                        if (strlcpy(host, hp->h_name, hostlen) >= hostlen) {
 #ifdef INET6
                                 freehostent(hp);
 #endif
                                 return ENI_MEMORY;
                         }
-                        strcpy(host, hp->h_name);
 #ifdef INET6
                         freehostent(hp);
 #endif
@@ -234,9 +230,8 @@ getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, socklen_t ho
                         if (inet_ntop(afd->a_af, addr, numaddr, sizeof(numaddr))
                             == NULL)
                                 return ENI_NOHOSTNAME;
-                        if (strlen(numaddr) > hostlen)
+                        if (strlcpy(host, numaddr, hostlen) >= hostlen)
                                 return ENI_MEMORY;
-                        strcpy(host, numaddr);
                 }
         }
         return SUCCESS;

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -387,7 +387,7 @@ allocate_getaddrinfo_arg(const char *hostp, const char *portp, const struct addr
 
     if (hostp) {
         arg->node = buf + hostp_offset;
-        strcpy(arg->node, hostp);
+        memcpy(arg->node, hostp, portp_offset - hostp_offset);
     }
     else {
         arg->node = NULL;
@@ -395,7 +395,7 @@ allocate_getaddrinfo_arg(const char *hostp, const char *portp, const struct addr
 
     if (portp) {
         arg->service = buf + portp_offset;
-        strcpy(arg->service, portp);
+        memcpy(arg->service, portp, bufsize - portp_offset);
     }
     else {
         arg->service = NULL;

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -4392,15 +4392,16 @@ static inline void
 gc_mark_check_t_none(rb_objspace_t *objspace, VALUE obj)
 {
     if (RB_UNLIKELY(RB_TYPE_P(obj, T_NONE))) {
-        char obj_info_buf[256];
-        rb_raw_obj_info(obj_info_buf, 256, obj);
+        enum {info_size = 256};
+        char obj_info_buf[info_size];
+        rb_raw_obj_info(obj_info_buf, info_size, obj);
 
-        char parent_obj_info_buf[256];
+        char parent_obj_info_buf[info_size];
         if (objspace->rgengc.parent_object == Qfalse) {
-            strcpy(parent_obj_info_buf, "(none)");
+            strlcpy(parent_obj_info_buf, "(none)", info_size);
         }
         else {
-            rb_raw_obj_info(parent_obj_info_buf, 256, objspace->rgengc.parent_object);
+            rb_raw_obj_info(parent_obj_info_buf, info_size, objspace->rgengc.parent_object);
         }
 
         rb_bug("try to mark T_NONE object (obj: %s, parent: %s)", obj_info_buf, parent_obj_info_buf);

--- a/namespace.c
+++ b/namespace.c
@@ -734,6 +734,7 @@ fname_without_suffix(const char *fname, char *rvalue, size_t rsize)
             len = pos - fname;
             break;
         }
+        if (fname + len - pos > DLEXT_MAXLEN) break;
     }
     if (len > rsize - 1) len = rsize - 1;
     memcpy(rvalue, fname, len);


### PR DESCRIPTION
On OpenBSD:

```
ld: warning: namespace.c:731(namespace.o:(rb_namespace_local_extension)): warning: strcpy() is almost always misused, please use strlcpy()
```