### PR TITLE
Get rid of `rb_obj_set_shape_id`

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -370,7 +370,7 @@ rb_gc_get_shape(VALUE obj)
 void
 rb_gc_set_shape(VALUE obj, uint32_t shape_id)
 {
-    rb_obj_set_shape_id(obj, (uint32_t)shape_id);
+    RBASIC_SET_SHAPE_ID(obj, (uint32_t)shape_id);
 }
 
 uint32_t

--- a/object.c
+++ b/object.c
@@ -362,7 +362,7 @@ rb_obj_copy_ivar(VALUE dest, VALUE obj)
     }
 
     rb_shape_copy_fields(dest, dest_buf, dest_shape_id, src_buf, src_shape_id);
-    rb_obj_set_shape_id(dest, dest_shape_id);
+    RBASIC_SET_SHAPE_ID(dest, dest_shape_id);
 }
 
 static void
@@ -496,7 +496,7 @@ rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze)
 
         if (RB_OBJ_FROZEN(obj)) {
             shape_id_t next_shape_id = rb_shape_transition_frozen(clone);
-            rb_obj_set_shape_id(clone, next_shape_id);
+            RBASIC_SET_SHAPE_ID(clone, next_shape_id);
         }
         break;
       case Qtrue: {

--- a/shape.h
+++ b/shape.h
@@ -380,8 +380,6 @@ RBASIC_FIELDS_COUNT(VALUE obj)
     return RSHAPE(rb_obj_shape_id(obj))->next_field_index;
 }
 
-bool rb_obj_set_shape_id(VALUE obj, shape_id_t shape_id);
-
 static inline bool
 rb_shape_obj_has_id(VALUE obj)
 {

--- a/variable.c
+++ b/variable.c
@@ -1672,7 +1672,7 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
         MEMCPY(ROBJECT_FIELDS(obj), fields, VALUE, new_fields_count);
         xfree(fields);
     }
-    rb_obj_set_shape_id(obj, next_shape_id);
+    RBASIC_SET_SHAPE_ID(obj, next_shape_id);
 
     return val;
 
@@ -1925,7 +1925,7 @@ rb_obj_ivar_set(VALUE obj, ID id, VALUE val)
                     "next_shape_id: 0x%" PRIx32 " RSHAPE_TYPE(next_shape_id): %d",
                     next_shape_id, (int)RSHAPE_TYPE(next_shape_id));
         RUBY_ASSERT(index == (RSHAPE_INDEX(next_shape_id)));
-        rb_obj_set_shape_id(obj, next_shape_id);
+        RBASIC_SET_SHAPE_ID(obj, next_shape_id);
     }
 
     VALUE *table = ROBJECT_FIELDS(obj);
@@ -1971,7 +1971,7 @@ obj_field_set(VALUE obj, shape_id_t target_shape_id, VALUE val)
         }
 
         if (RSHAPE_LEN(target_shape_id) > RSHAPE_LEN(current_shape_id)) {
-            rb_obj_set_shape_id(obj, target_shape_id);
+            RBASIC_SET_SHAPE_ID(obj, target_shape_id);
         }
 
         VALUE *table = ROBJECT_FIELDS(obj);
@@ -1989,18 +1989,6 @@ rb_vm_set_ivar_id(VALUE obj, ID id, VALUE val)
     rb_check_frozen(obj);
     rb_obj_ivar_set(obj, id, val);
     return val;
-}
-
-bool
-rb_obj_set_shape_id(VALUE obj, shape_id_t shape_id)
-{
-    shape_id_t old_shape_id = rb_obj_shape_id(obj);
-    if (old_shape_id == shape_id) {
-        return false;
-    }
-
-    RB_SET_SHAPE_ID(obj, shape_id);
-    return true;
 }
 
 void rb_obj_freeze_inline(VALUE x)
@@ -2281,7 +2269,7 @@ rb_copy_generic_ivar(VALUE dest, VALUE obj)
         }
 
         if (!RSHAPE_LEN(dest_shape_id)) {
-            rb_obj_set_shape_id(dest, dest_shape_id);
+            RBASIC_SET_SHAPE_ID(dest, dest_shape_id);
             return;
         }
 


### PR DESCRIPTION
Now that the shape_id has been unified across all types this helper function doesn't do much over `RBASIC_SET_SHAPE_ID`.

It still check if the write is needed, but it doesn't seem useful in places where it's used.