### PR TITLE
Refactor rb_obj_ivar_set to delegate to obj_field_set

### DIFF
--- a/shape.h
+++ b/shape.h
@@ -326,6 +326,7 @@ RSHAPE_LEN(shape_id_t shape_id)
 static inline attr_index_t
 RSHAPE_INDEX(shape_id_t shape_id)
 {
+    RUBY_ASSERT(RSHAPE_LEN(shape_id) > 0);
     return RSHAPE_LEN(shape_id) - 1;
 }
 


### PR DESCRIPTION
Most of the concerns are the same, except for `ivar_set` that need to lookup the shape by name.