### PR TITLE
ZJIT: Migrate to insta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,19 +32,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "dissimilar"
-version = "1.0.10"
+name = "console"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
-name = "expect-test"
-version = "1.5.1"
+name = "encode_unicode"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "insta"
+version = "1.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
- "dissimilar",
+ "console",
  "once_cell",
+ "similar",
 ]
 
 [[package]]
@@ -54,6 +67,12 @@ dependencies = [
  "yjit",
  "zjit",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -74,6 +93,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "similar"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "yjit"
 version = "0.1.0"
 dependencies = [
@@ -85,5 +183,5 @@ name = "zjit"
 version = "0.0.1"
 dependencies = [
  "capstone",
- "expect-test",
+ "insta",
 ]

--- a/zjit/Cargo.toml
+++ b/zjit/Cargo.toml
@@ -11,7 +11,7 @@ publish = false         # Don't publish to crates.io
 capstone = { version = "0.13.0", optional = true }
 
 [dev-dependencies]
-expect-test = "1.5.1"
+insta = "1.43.1"
 
 # NOTE: Development builds select a set of these via configure.ac
 # For debugging, `make V=1` shows exact cargo invocation.

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3882,15 +3882,7 @@ mod infer_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use expect_test::{expect, Expect};
-
-    #[track_caller]
-    fn assert_method_hir(method: &str, hir: Expect) {
-        let iseq = crate::cruby::with_rubyvm(|| get_method_iseq("self", method));
-        unsafe { crate::cruby::rb_zjit_profile_disable(iseq) };
-        let function = iseq_to_hir(iseq).unwrap();
-        assert_function_hir(function, hir);
-    }
+    use insta::assert_snapshot;
 
     fn iseq_contains_opcode(iseq: IseqPtr, expected_opcode: u32) -> bool {
         let iseq_size = unsafe { get_iseq_encoded_size(iseq) };
@@ -3912,31 +3904,32 @@ mod tests {
     }
 
     #[track_caller]
-    fn assert_method_hir_with_opcodes(method: &str, opcodes: &[u32], hir: Expect) {
+    fn assert_contains_opcode(method: &str, opcode: u32) {
+        let iseq = crate::cruby::with_rubyvm(|| get_method_iseq("self", method));
+        unsafe { crate::cruby::rb_zjit_profile_disable(iseq) };
+        assert!(iseq_contains_opcode(iseq, opcode), "iseq {method} does not contain {}", insn_name(opcode as usize));
+    }
+
+    #[track_caller]
+    fn assert_contains_opcodes(method: &str, opcodes: &[u32]) {
         let iseq = crate::cruby::with_rubyvm(|| get_method_iseq("self", method));
         unsafe { crate::cruby::rb_zjit_profile_disable(iseq) };
         for &opcode in opcodes {
             assert!(iseq_contains_opcode(iseq, opcode), "iseq {method} does not contain {}", insn_name(opcode as usize));
         }
+    }
+
+    #[track_caller]
+    fn hir_string(method: &str) -> String {
+        let iseq = crate::cruby::with_rubyvm(|| get_method_iseq("self", method));
+        unsafe { crate::cruby::rb_zjit_profile_disable(iseq) };
         let function = iseq_to_hir(iseq).unwrap();
-        assert_function_hir(function, hir);
+        hir_string_function(&function)
     }
 
     #[track_caller]
-    fn assert_method_hir_with_opcode(method: &str, opcode: u32, hir: Expect) {
-        assert_method_hir_with_opcodes(method, &[opcode], hir)
-    }
-
-    #[track_caller]
-    pub fn assert_function_hir(function: Function, expected_hir: Expect) {
-        let actual_hir = format!("{}", FunctionPrinter::without_snapshot(&function));
-        expected_hir.assert_eq(&actual_hir);
-    }
-
-    #[track_caller]
-    pub fn assert_function_hir_with_frame_state(function: Function, expected_hir: Expect) {
-        let actual_hir = format!("{}", FunctionPrinter::with_snapshot(&function));
-        expected_hir.assert_eq(&actual_hir);
+    fn hir_string_function(function: &Function) -> String {
+        format!("{}", FunctionPrinter::without_snapshot(&function))
     }
 
     #[track_caller]
@@ -3957,226 +3950,244 @@ mod tests {
     #[test]
     fn test_putobject() {
         eval("def test = 123");
-        assert_method_hir_with_opcode("test", YARVINSN_putobject, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject):
-              v2:Fixnum[123] = Const Value(123)
-              CheckInterrupts
-              Return v2
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_putobject);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject):
+          v2:Fixnum[123] = Const Value(123)
+          CheckInterrupts
+          Return v2
+        ");
     }
 
     #[test]
     fn test_new_array() {
         eval("def test = []");
-        assert_method_hir_with_opcode("test", YARVINSN_newarray, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject):
-              v3:ArrayExact = NewArray
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_newarray);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject):
+          v3:ArrayExact = NewArray
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
     fn test_new_array_with_element() {
         eval("def test(a) = [a]");
-        assert_method_hir_with_opcode("test", YARVINSN_newarray, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v4:ArrayExact = NewArray v1
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_newarray);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v4:ArrayExact = NewArray v1
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
     fn test_new_array_with_elements() {
         eval("def test(a, b) = [a, b]");
-        assert_method_hir_with_opcode("test", YARVINSN_newarray, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:ArrayExact = NewArray v1, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_newarray);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:ArrayExact = NewArray v1, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
     fn test_new_range_inclusive_with_one_element() {
         eval("def test(a) = (a..10)");
-        assert_method_hir_with_opcode("test", YARVINSN_newrange, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v3:Fixnum[10] = Const Value(10)
-              v5:RangeExact = NewRange v1 NewRangeInclusive v3
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_newrange);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:Fixnum[10] = Const Value(10)
+          v5:RangeExact = NewRange v1 NewRangeInclusive v3
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
     fn test_new_range_inclusive_with_two_elements() {
         eval("def test(a, b) = (a..b)");
-        assert_method_hir_with_opcode("test", YARVINSN_newrange, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:RangeExact = NewRange v1 NewRangeInclusive v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_newrange);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:RangeExact = NewRange v1 NewRangeInclusive v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
     fn test_new_range_exclusive_with_one_element() {
         eval("def test(a) = (a...10)");
-        assert_method_hir_with_opcode("test", YARVINSN_newrange, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v3:Fixnum[10] = Const Value(10)
-              v5:RangeExact = NewRange v1 NewRangeExclusive v3
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_newrange);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:Fixnum[10] = Const Value(10)
+          v5:RangeExact = NewRange v1 NewRangeExclusive v3
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
     fn test_new_range_exclusive_with_two_elements() {
         eval("def test(a, b) = (a...b)");
-        assert_method_hir_with_opcode("test", YARVINSN_newrange, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:RangeExact = NewRange v1 NewRangeExclusive v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_newrange);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:RangeExact = NewRange v1 NewRangeExclusive v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
     fn test_array_dup() {
         eval("def test = [1, 2, 3]");
-        assert_method_hir_with_opcode("test", YARVINSN_duparray, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject):
-              v2:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:ArrayExact = ArrayDup v2
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_duparray);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject):
+          v2:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:ArrayExact = ArrayDup v2
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
     fn test_hash_dup() {
         eval("def test = {a: 1, b: 2}");
-        assert_method_hir_with_opcode("test", YARVINSN_duphash, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject):
-              v2:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:HashExact = HashDup v2
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_duphash);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject):
+          v2:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:HashExact = HashDup v2
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
     fn test_new_hash_empty() {
         eval("def test = {}");
-        assert_method_hir_with_opcode("test", YARVINSN_newhash, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject):
-              v3:HashExact = NewHash
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_newhash);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject):
+          v3:HashExact = NewHash
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
     fn test_new_hash_with_elements() {
         eval("def test(aval, bval) = {a: aval, b: bval}");
-        assert_method_hir_with_opcode("test", YARVINSN_newhash, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v4:StaticSymbol[:a] = Const Value(VALUE(0x1000))
-              v5:StaticSymbol[:b] = Const Value(VALUE(0x1008))
-              v7:HashExact = NewHash v4: v1, v5: v2
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_newhash);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v4:StaticSymbol[:a] = Const Value(VALUE(0x1000))
+          v5:StaticSymbol[:b] = Const Value(VALUE(0x1008))
+          v7:HashExact = NewHash v4: v1, v5: v2
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
     fn test_string_copy() {
         eval("def test = \"hello\"");
-        assert_method_hir_with_opcode("test", YARVINSN_putchilledstring, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject):
-              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:StringExact = StringCopy v2
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_putchilledstring);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject):
+          v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:StringExact = StringCopy v2
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
     fn test_bignum() {
         eval("def test = 999999999999999999999999999999999999");
-        assert_method_hir_with_opcode("test", YARVINSN_putobject, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject):
-              v2:Bignum[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              CheckInterrupts
-              Return v2
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_putobject);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject):
+          v2:Bignum[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          CheckInterrupts
+          Return v2
+        ");
     }
 
     #[test]
     fn test_flonum() {
         eval("def test = 1.5");
-        assert_method_hir_with_opcode("test", YARVINSN_putobject, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject):
-              v2:Flonum[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              CheckInterrupts
-              Return v2
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_putobject);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject):
+          v2:Flonum[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          CheckInterrupts
+          Return v2
+        ");
     }
 
     #[test]
     fn test_heap_float() {
         eval("def test = 1.7976931348623157e+308");
-        assert_method_hir_with_opcode("test", YARVINSN_putobject, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject):
-              v2:HeapFloat[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              CheckInterrupts
-              Return v2
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_putobject);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject):
+          v2:HeapFloat[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          CheckInterrupts
+          Return v2
+        ");
     }
 
     #[test]
     fn test_static_sym() {
         eval("def test = :foo");
-        assert_method_hir_with_opcode("test", YARVINSN_putobject, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject):
-              v2:StaticSymbol[:foo] = Const Value(VALUE(0x1000))
-              CheckInterrupts
-              Return v2
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_putobject);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject):
+          v2:StaticSymbol[:foo] = Const Value(VALUE(0x1000))
+          CheckInterrupts
+          Return v2
+        ");
     }
 
     #[test]
     fn test_opt_plus() {
         eval("def test = 1+2");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_plus, expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v3:Fixnum[2] = Const Value(2)
-              v5:BasicObject = SendWithoutBlock v2, :+, v3
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_plus);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v3:Fixnum[2] = Const Value(2)
+          v5:BasicObject = SendWithoutBlock v2, :+, v3
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4184,14 +4195,15 @@ mod tests {
         eval("
             def test = {}.freeze
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_hash_freeze, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:BasicObject = SendWithoutBlock v3, :freeze
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_hash_freeze);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:BasicObject = SendWithoutBlock v3, :freeze
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -4199,14 +4211,15 @@ mod tests {
         eval("
             def test = [].freeze
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_ary_freeze, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:BasicObject = SendWithoutBlock v3, :freeze
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_ary_freeze);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:BasicObject = SendWithoutBlock v3, :freeze
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -4214,14 +4227,15 @@ mod tests {
         eval("
             def test = ''.freeze
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_str_freeze, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:BasicObject = SendWithoutBlock v3, :freeze
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_str_freeze);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:BasicObject = SendWithoutBlock v3, :freeze
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -4229,14 +4243,15 @@ mod tests {
         eval("
             def test = -''
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_str_uminus, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:BasicObject = SendWithoutBlock v3, :-@
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_str_uminus);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:BasicObject = SendWithoutBlock v3, :-@
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -4247,14 +4262,15 @@ mod tests {
               a
             end
         ");
-        assert_method_hir_with_opcodes("test", &[YARVINSN_getlocal_WC_0, YARVINSN_setlocal_WC_0], expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v3:Fixnum[1] = Const Value(1)
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_contains_opcodes("test", &[YARVINSN_getlocal_WC_0, YARVINSN_setlocal_WC_0]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v3:Fixnum[1] = Const Value(1)
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -4275,26 +4291,26 @@ mod tests {
             end
           end
         ");
-        assert_method_hir_with_opcodes(
+        assert_contains_opcodes(
             "test",
             &[YARVINSN_getlocal_WC_1, YARVINSN_setlocal_WC_1,
-              YARVINSN_getlocal, YARVINSN_setlocal],
-            expect![[r#"
-                fn block (3 levels) in <compiled>@<compiled>:10:
-                bb0(v0:BasicObject):
-                  v2:BasicObject = GetLocal l2, EP@4
-                  SetLocal l1, EP@3, v2
-                  v4:BasicObject = GetLocal l1, EP@3
-                  v5:BasicObject = GetLocal l2, EP@4
-                  v7:BasicObject = SendWithoutBlock v4, :+, v5
-                  SetLocal l2, EP@4, v7
-                  v9:BasicObject = GetLocal l2, EP@4
-                  v10:BasicObject = GetLocal l3, EP@5
-                  v12:BasicObject = SendWithoutBlock v9, :+, v10
-                  SetLocal l3, EP@5, v12
-                  CheckInterrupts
-                  Return v12
-            "#]]
+              YARVINSN_getlocal, YARVINSN_setlocal]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn block (3 levels) in <compiled>@<compiled>:10:
+        bb0(v0:BasicObject):
+          v2:BasicObject = GetLocal l2, EP@4
+          SetLocal l1, EP@3, v2
+          v4:BasicObject = GetLocal l1, EP@3
+          v5:BasicObject = GetLocal l2, EP@4
+          v7:BasicObject = SendWithoutBlock v4, :+, v5
+          SetLocal l2, EP@4, v7
+          v9:BasicObject = GetLocal l2, EP@4
+          v10:BasicObject = GetLocal l3, EP@5
+          v12:BasicObject = SendWithoutBlock v9, :+, v10
+          SetLocal l3, EP@5, v12
+          CheckInterrupts
+          Return v12
+        "
         );
     }
 
@@ -4303,13 +4319,14 @@ mod tests {
         eval("
             def test = defined?(@foo)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_definedivar, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:BasicObject = DefinedIvar v0, :@foo
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_definedivar);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:BasicObject = DefinedIvar v0, :@foo
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -4317,18 +4334,19 @@ mod tests {
         eval("
             def test = return defined?(SeaChange), defined?(favourite), defined?($ruby)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_defined, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:NilClass = Const Value(nil)
-              v4:StringExact|NilClass = Defined constant, v2
-              v6:StringExact|NilClass = Defined func, v0
-              v7:NilClass = Const Value(nil)
-              v9:StringExact|NilClass = Defined global-variable, v7
-              v11:ArrayExact = NewArray v4, v6, v9
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_defined);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:NilClass = Const Value(nil)
+          v4:StringExact|NilClass = Defined constant, v2
+          v6:StringExact|NilClass = Defined func, v0
+          v7:NilClass = Const Value(nil)
+          v9:StringExact|NilClass = Defined global-variable, v7
+          v11:ArrayExact = NewArray v4, v6, v9
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -4342,20 +4360,21 @@ mod tests {
               end
             end
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_leave, expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject):
-              CheckInterrupts
-              v5:CBool = Test v1
-              IfFalse v5, bb1(v0, v1)
-              v7:Fixnum[3] = Const Value(3)
-              CheckInterrupts
-              Return v7
-            bb1(v11:BasicObject, v12:BasicObject):
-              v14:Fixnum[4] = Const Value(4)
-              CheckInterrupts
-              Return v14
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_leave);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject):
+          CheckInterrupts
+          v5:CBool = Test v1
+          IfFalse v5, bb1(v0, v1)
+          v7:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Return v7
+        bb1(v11:BasicObject, v12:BasicObject):
+          v14:Fixnum[4] = Const Value(4)
+          CheckInterrupts
+          Return v14
+        ");
     }
 
     #[test]
@@ -4370,23 +4389,23 @@ mod tests {
               result
             end
         ");
-        assert_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v2:NilClass = Const Value(nil)
-              CheckInterrupts
-              v6:CBool = Test v1
-              IfFalse v6, bb1(v0, v1, v2)
-              v8:Fixnum[3] = Const Value(3)
-              CheckInterrupts
-              Jump bb2(v0, v1, v8)
-            bb1(v12:BasicObject, v13:BasicObject, v14:NilClass):
-              v16:Fixnum[4] = Const Value(4)
-              Jump bb2(v12, v13, v16)
-            bb2(v18:BasicObject, v19:BasicObject, v20:Fixnum):
-              CheckInterrupts
-              Return v20
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v2:NilClass = Const Value(nil)
+          CheckInterrupts
+          v6:CBool = Test v1
+          IfFalse v6, bb1(v0, v1, v2)
+          v8:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Jump bb2(v0, v1, v8)
+        bb1(v12:BasicObject, v13:BasicObject, v14:NilClass):
+          v16:Fixnum[4] = Const Value(4)
+          Jump bb2(v12, v13, v16)
+        bb2(v18:BasicObject, v19:BasicObject, v20:Fixnum):
+          CheckInterrupts
+          Return v20
+        ");
     }
 
     #[test]
@@ -4395,13 +4414,14 @@ mod tests {
             def test(a, b) = a + b
             test(1, 2); test(1, 2)
         ");
-        assert_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :+, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_plus);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :+, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4410,13 +4430,14 @@ mod tests {
             def test(a, b) = a - b
             test(1, 2); test(1, 2)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_minus, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :-, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_minus);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :-, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4425,13 +4446,14 @@ mod tests {
             def test(a, b) = a * b
             test(1, 2); test(1, 2)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_mult, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :*, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_mult);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :*, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4440,13 +4462,14 @@ mod tests {
             def test(a, b) = a / b
             test(1, 2); test(1, 2)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_div, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :/, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_div);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :/, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4455,13 +4478,14 @@ mod tests {
             def test(a, b) = a % b
             test(1, 2); test(1, 2)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_mod, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :%, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_mod);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :%, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4470,13 +4494,14 @@ mod tests {
             def test(a, b) = a == b
             test(1, 2); test(1, 2)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_eq, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :==, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_eq);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :==, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4485,13 +4510,14 @@ mod tests {
             def test(a, b) = a != b
             test(1, 2); test(1, 2)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_neq, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :!=, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_neq);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :!=, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4500,13 +4526,14 @@ mod tests {
             def test(a, b) = a < b
             test(1, 2); test(1, 2)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_lt, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :<, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_lt);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :<, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4515,13 +4542,14 @@ mod tests {
             def test(a, b) = a <= b
             test(1, 2); test(1, 2)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_le, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :<=, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_le);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :<=, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4530,13 +4558,14 @@ mod tests {
             def test(a, b) = a > b
             test(1, 2); test(1, 2)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_gt, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :>, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_gt);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :>, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4553,31 +4582,31 @@ mod tests {
             end
             test
         ");
-        assert_method_hir("test",  expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v2:NilClass = Const Value(nil)
-              v4:Fixnum[0] = Const Value(0)
-              v5:Fixnum[10] = Const Value(10)
-              CheckInterrupts
-              Jump bb2(v0, v4, v5)
-            bb2(v9:BasicObject, v10:BasicObject, v11:BasicObject):
-              v13:Fixnum[0] = Const Value(0)
-              v15:BasicObject = SendWithoutBlock v11, :>, v13
-              CheckInterrupts
-              v18:CBool = Test v15
-              IfTrue v18, bb1(v9, v10, v11)
-              v20:NilClass = Const Value(nil)
-              CheckInterrupts
-              Return v10
-            bb1(v24:BasicObject, v25:BasicObject, v26:BasicObject):
-              v28:Fixnum[1] = Const Value(1)
-              v30:BasicObject = SendWithoutBlock v25, :+, v28
-              v31:Fixnum[1] = Const Value(1)
-              v33:BasicObject = SendWithoutBlock v26, :-, v31
-              Jump bb2(v24, v30, v33)
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v2:NilClass = Const Value(nil)
+          v4:Fixnum[0] = Const Value(0)
+          v5:Fixnum[10] = Const Value(10)
+          CheckInterrupts
+          Jump bb2(v0, v4, v5)
+        bb2(v9:BasicObject, v10:BasicObject, v11:BasicObject):
+          v13:Fixnum[0] = Const Value(0)
+          v15:BasicObject = SendWithoutBlock v11, :>, v13
+          CheckInterrupts
+          v18:CBool = Test v15
+          IfTrue v18, bb1(v9, v10, v11)
+          v20:NilClass = Const Value(nil)
+          CheckInterrupts
+          Return v10
+        bb1(v24:BasicObject, v25:BasicObject, v26:BasicObject):
+          v28:Fixnum[1] = Const Value(1)
+          v30:BasicObject = SendWithoutBlock v25, :+, v28
+          v31:Fixnum[1] = Const Value(1)
+          v33:BasicObject = SendWithoutBlock v26, :-, v31
+          Jump bb2(v24, v30, v33)
+        ");
     }
 
     #[test]
@@ -4586,13 +4615,14 @@ mod tests {
             def test(a, b) = a >= b
             test(1, 2); test(1, 2)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_ge, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :>=, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_ge);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :>=, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4607,22 +4637,22 @@ mod tests {
               end
             end
         ");
-        assert_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v3:TrueClass = Const Value(true)
-              CheckInterrupts
-              v6:CBool[true] = Test v3
-              IfFalse v6, bb1(v0, v3)
-              v8:Fixnum[3] = Const Value(3)
-              CheckInterrupts
-              Return v8
-            bb1(v12, v13):
-              v15 = Const Value(4)
-              CheckInterrupts
-              Return v15
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v3:TrueClass = Const Value(true)
+          CheckInterrupts
+          v6:CBool[true] = Test v3
+          IfFalse v6, bb1(v0, v3)
+          v8:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Return v8
+        bb1(v12, v13):
+          v15 = Const Value(4)
+          CheckInterrupts
+          Return v15
+        ");
     }
 
     #[test]
@@ -4635,15 +4665,16 @@ mod tests {
               bar(2, 3)
             end
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_send_without_block, expect![[r#"
-            fn test@<compiled>:6:
-            bb0(v0:BasicObject):
-              v2:Fixnum[2] = Const Value(2)
-              v3:Fixnum[3] = Const Value(3)
-              v5:BasicObject = SendWithoutBlock v0, :bar, v2, v3
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_send_without_block);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:6:
+        bb0(v0:BasicObject):
+          v2:Fixnum[2] = Const Value(2)
+          v3:Fixnum[3] = Const Value(3)
+          v5:BasicObject = SendWithoutBlock v0, :bar, v2, v3
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -4656,13 +4687,14 @@ mod tests {
             end
             test([1,2,3])
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_send, expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v4:BasicObject = Send v1, 0x1000, :each
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_send);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v4:BasicObject = Send v1, 0x1000, :each
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -4672,18 +4704,19 @@ mod tests {
               :"foo#{123}"
             end
         "#);
-        assert_method_hir_with_opcode("test", YARVINSN_intern, expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v3:Fixnum[123] = Const Value(123)
-              v5:BasicObject = ObjToString v3
-              v7:String = AnyToString v3, str: v5
-              v9:StringExact = StringConcat v2, v7
-              v11:Symbol = StringIntern v9
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_intern);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v3:Fixnum[123] = Const Value(123)
+          v5:BasicObject = ObjToString v3
+          v7:String = AnyToString v3, str: v5
+          v9:StringExact = StringConcat v2, v7
+          v11:Symbol = StringIntern v9
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -4691,21 +4724,21 @@ mod tests {
         eval("def test = unknown_method([0], [1], '2', '2')");
 
         // The 2 string literals have the same address because they're deduped.
-        assert_method_hir("test",  expect![[r#"
-            fn test@<compiled>:1:
-            bb0(v0:BasicObject):
-              v2:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:ArrayExact = ArrayDup v2
-              v5:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              v7:ArrayExact = ArrayDup v5
-              v8:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
-              v10:StringExact = StringCopy v8
-              v11:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
-              v13:StringExact = StringCopy v11
-              v15:BasicObject = SendWithoutBlock v0, :unknown_method, v4, v7, v10, v13
-              CheckInterrupts
-              Return v15
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:1:
+        bb0(v0:BasicObject):
+          v2:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:ArrayExact = ArrayDup v2
+          v5:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v7:ArrayExact = ArrayDup v5
+          v8:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
+          v10:StringExact = StringCopy v8
+          v11:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
+          v13:StringExact = StringCopy v11
+          v15:BasicObject = SendWithoutBlock v0, :unknown_method, v4, v7, v10, v13
+          CheckInterrupts
+          Return v15
+        ");
     }
 
     #[test]
@@ -4713,12 +4746,12 @@ mod tests {
         eval("
             def test(a) = foo(*a)
         ");
-        assert_method_hir("test",  expect![[r#"
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:2:
             bb0(v0:BasicObject, v1:BasicObject):
               v4:ArrayExact = ToArray v1
               SideExit UnknownCallType
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -4726,11 +4759,11 @@ mod tests {
         eval("
             def test(a) = foo(&a)
         ");
-        assert_method_hir("test",  expect![[r#"
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:2:
             bb0(v0:BasicObject, v1:BasicObject):
               SideExit UnknownCallType
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -4738,12 +4771,12 @@ mod tests {
         eval("
             def test(a) = foo(a: 1)
         ");
-        assert_method_hir("test",  expect![[r#"
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:2:
             bb0(v0:BasicObject, v1:BasicObject):
               v3:Fixnum[1] = Const Value(1)
               SideExit UnknownCallType
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -4751,11 +4784,11 @@ mod tests {
         eval("
             def test(a) = foo(**a)
         ");
-        assert_method_hir("test",  expect![[r#"
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:2:
             bb0(v0:BasicObject, v1:BasicObject):
               SideExit UnknownCallType
-        "#]]);
+        "#);
     }
 
     // TODO(max): Figure out how to generate a call with TAILCALL flag
@@ -4765,11 +4798,11 @@ mod tests {
         eval("
             def test = super()
         ");
-        assert_method_hir("test",  expect![[r#"
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:2:
             bb0(v0:BasicObject):
               SideExit UnknownOpcode(invokesuper)
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -4777,11 +4810,11 @@ mod tests {
         eval("
             def test = super
         ");
-        assert_method_hir("test",  expect![[r#"
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:2:
             bb0(v0:BasicObject):
               SideExit UnknownOpcode(invokesuper)
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -4805,7 +4838,7 @@ mod tests {
         eval("
             def test(a) = foo **a, b: 1
         ");
-        assert_method_hir("test",  expect![[r#"
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:2:
             bb0(v0:BasicObject, v1:BasicObject):
               v3:Class[VMFrozenCore] = Const Value(VALUE(0x1000))
@@ -4816,7 +4849,7 @@ mod tests {
               v10:Fixnum[1] = Const Value(1)
               v12:BasicObject = SendWithoutBlock v8, :core#hash_merge_ptr, v7, v9, v10
               SideExit UnknownCallType
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -4824,14 +4857,14 @@ mod tests {
         eval("
             def test(*) = foo *, 1
         ");
-        assert_method_hir("test",  expect![[r#"
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:2:
             bb0(v0:BasicObject, v1:ArrayExact):
               v4:ArrayExact = ToNewArray v1
               v5:Fixnum[1] = Const Value(1)
               ArrayPush v4, v5
               SideExit UnknownCallType
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -4848,20 +4881,21 @@ mod tests {
             class C; end
             def test = C.new
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_new, expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v3:BasicObject = GetConstantPath 0x1000
-              v4:NilClass = Const Value(nil)
-              CheckInterrupts
-              Jump bb1(v0, v4, v3)
-            bb1(v8:BasicObject, v9:NilClass, v10:BasicObject):
-              v13:BasicObject = SendWithoutBlock v10, :new
-              Jump bb2(v8, v13, v9)
-            bb2(v15:BasicObject, v16:BasicObject, v17:NilClass):
-              CheckInterrupts
-              Return v16
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_new);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v3:BasicObject = GetConstantPath 0x1000
+          v4:NilClass = Const Value(nil)
+          CheckInterrupts
+          Jump bb1(v0, v4, v3)
+        bb1(v8:BasicObject, v9:NilClass, v10:BasicObject):
+          v13:BasicObject = SendWithoutBlock v10, :new
+          Jump bb2(v8, v13, v9)
+        bb2(v15:BasicObject, v16:BasicObject, v17:NilClass):
+          CheckInterrupts
+          Return v16
+        ");
     }
 
     #[test]
@@ -4870,14 +4904,15 @@ mod tests {
             def test = [].max
         ");
         // TODO(max): Rewrite to nil
-        assert_method_hir_with_opcode("test", YARVINSN_opt_newarray_send, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_MAX)
-              v4:BasicObject = ArrayMax
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_MAX)
+          v4:BasicObject = ArrayMax
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -4885,14 +4920,15 @@ mod tests {
         eval("
             def test(a,b) = [a,b].max
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_newarray_send, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_MAX)
-              v6:BasicObject = ArrayMax v1, v2
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_MAX)
+          v6:BasicObject = ArrayMax v1, v2
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -4905,14 +4941,15 @@ mod tests {
               result
             end
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_newarray_send, expect![[r#"
+        assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
               v3:NilClass = Const Value(nil)
               v4:NilClass = Const Value(nil)
               v7:BasicObject = SendWithoutBlock v1, :+, v2
               SideExit UnknownNewarraySend(MIN)
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -4925,14 +4962,15 @@ mod tests {
               result
             end
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_newarray_send, expect![[r#"
+        assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
               v3:NilClass = Const Value(nil)
               v4:NilClass = Const Value(nil)
               v7:BasicObject = SendWithoutBlock v1, :+, v2
               SideExit UnknownNewarraySend(HASH)
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -4945,7 +4983,8 @@ mod tests {
               result
             end
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_newarray_send, expect![[r#"
+        assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
               v3:NilClass = Const Value(nil)
@@ -4954,7 +4993,7 @@ mod tests {
               v8:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
               v10:StringExact = StringCopy v8
               SideExit UnknownNewarraySend(PACK)
-        "#]]);
+        "#);
     }
 
     // TODO(max): Add a test for VM_OPT_NEWARRAY_SEND_PACK_BUFFER
@@ -4969,14 +5008,15 @@ mod tests {
               result
             end
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_newarray_send, expect![[r#"
+        assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
               v3:NilClass = Const Value(nil)
               v4:NilClass = Const Value(nil)
               v7:BasicObject = SendWithoutBlock v1, :+, v2
               SideExit UnknownNewarraySend(INCLUDE_P)
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -4984,14 +5024,15 @@ mod tests {
         eval("
             def test(a,b) = [a,b].length
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_length, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:ArrayExact = NewArray v1, v2
-              v7:BasicObject = SendWithoutBlock v5, :length
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_length);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:ArrayExact = NewArray v1, v2
+          v7:BasicObject = SendWithoutBlock v5, :length
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
@@ -4999,14 +5040,15 @@ mod tests {
         eval("
             def test(a,b) = [a,b].size
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_size, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:ArrayExact = NewArray v1, v2
-              v7:BasicObject = SendWithoutBlock v5, :size
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_size);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:ArrayExact = NewArray v1, v2
+          v7:BasicObject = SendWithoutBlock v5, :size
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
@@ -5015,13 +5057,14 @@ mod tests {
             def test = @foo
             test
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_getinstancevariable, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:BasicObject = GetIvar v0, :@foo
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_getinstancevariable);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:BasicObject = GetIvar v0, :@foo
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -5030,14 +5073,15 @@ mod tests {
             def test = @foo = 1
             test
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_setinstancevariable, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              SetIvar v0, :@foo, v2
-              CheckInterrupts
-              Return v2
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_setinstancevariable);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          SetIvar v0, :@foo, v2
+          CheckInterrupts
+          Return v2
+        ");
     }
 
     #[test]
@@ -5046,14 +5090,15 @@ mod tests {
             def test = $foo = 1
             test
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_setglobal, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              SetGlobal :$foo, v2
-              CheckInterrupts
-              Return v2
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_setglobal);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          SetGlobal :$foo, v2
+          CheckInterrupts
+          Return v2
+        ");
     }
 
     #[test]
@@ -5062,13 +5107,14 @@ mod tests {
             def test = $foo
             test
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_getglobal, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:BasicObject = GetGlobal :$foo
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_getglobal);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:BasicObject = GetGlobal :$foo
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -5076,13 +5122,14 @@ mod tests {
         eval("
             def test(a) = [*a]
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_splatarray, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v4:ArrayExact = ToNewArray v1
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_splatarray);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v4:ArrayExact = ToNewArray v1
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -5090,16 +5137,17 @@ mod tests {
         eval("
             def test(a) = [1, *a]
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_concattoarray, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v3:Fixnum[1] = Const Value(1)
-              v5:ArrayExact = NewArray v3
-              v7:ArrayExact = ToArray v1
-              ArrayExtend v5, v7
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_concattoarray);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:Fixnum[1] = Const Value(1)
+          v5:ArrayExact = NewArray v3
+          v7:ArrayExact = ToArray v1
+          ArrayExtend v5, v7
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -5107,15 +5155,16 @@ mod tests {
         eval("
             def test(a) = [*a, 1]
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_pushtoarray, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v4:ArrayExact = ToNewArray v1
-              v5:Fixnum[1] = Const Value(1)
-              ArrayPush v4, v5
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_pushtoarray);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v4:ArrayExact = ToNewArray v1
+          v5:Fixnum[1] = Const Value(1)
+          ArrayPush v4, v5
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -5123,19 +5172,20 @@ mod tests {
         eval("
             def test(a) = [*a, 1, 2, 3]
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_pushtoarray, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v4:ArrayExact = ToNewArray v1
-              v5:Fixnum[1] = Const Value(1)
-              v6:Fixnum[2] = Const Value(2)
-              v7:Fixnum[3] = Const Value(3)
-              ArrayPush v4, v5
-              ArrayPush v4, v6
-              ArrayPush v4, v7
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_pushtoarray);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v4:ArrayExact = ToNewArray v1
+          v5:Fixnum[1] = Const Value(1)
+          v6:Fixnum[2] = Const Value(2)
+          v7:Fixnum[3] = Const Value(3)
+          ArrayPush v4, v5
+          ArrayPush v4, v6
+          ArrayPush v4, v7
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -5143,15 +5193,16 @@ mod tests {
         eval("
             def test(a, b) = a[b] = 1
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_aset, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v4:NilClass = Const Value(nil)
-              v5:Fixnum[1] = Const Value(1)
-              v7:BasicObject = SendWithoutBlock v1, :[]=, v2, v5
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_aset);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v4:NilClass = Const Value(nil)
+          v5:Fixnum[1] = Const Value(1)
+          v7:BasicObject = SendWithoutBlock v1, :[]=, v2, v5
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -5159,13 +5210,14 @@ mod tests {
         eval("
             def test(a, b) = a[b]
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_aref, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :[], v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_aref);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :[], v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -5173,21 +5225,15 @@ mod tests {
         eval("
             def test(a) = a['string lit triggers aref_with']
         ");
-
-        let iseq = crate::cruby::with_rubyvm(|| get_method_iseq("self", "test"));
-        assert!(iseq_contains_opcode(iseq, YARVINSN_opt_aref_with));
-        let function = iseq_to_hir(iseq).unwrap();
-        assert_function_hir_with_frame_state(function, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v2:Any = Snapshot FrameState { pc: 0x1000, stack: [], locals: [v1] }
-              v3:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              v4:Any = Snapshot FrameState { pc: 0x1010, stack: [v1, v3], locals: [v1] }
-              v5:BasicObject = SendWithoutBlock v1, :[], v3
-              v6:Any = Snapshot FrameState { pc: 0x1018, stack: [v5], locals: [v1] }
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_aref_with);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v5:BasicObject = SendWithoutBlock v1, :[], v3
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -5195,13 +5241,14 @@ mod tests {
         eval("
             def test(x) = x.empty?
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_empty_p, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v4:BasicObject = SendWithoutBlock v1, :empty?
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_empty_p);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v4:BasicObject = SendWithoutBlock v1, :empty?
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -5209,13 +5256,14 @@ mod tests {
         eval("
             def test(x) = x.succ
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_succ, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v4:BasicObject = SendWithoutBlock v1, :succ
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_succ);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v4:BasicObject = SendWithoutBlock v1, :succ
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -5223,13 +5271,14 @@ mod tests {
         eval("
             def test(x, y) = x & y
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_and, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :&, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_and);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :&, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -5237,13 +5286,14 @@ mod tests {
         eval("
             def test(x, y) = x | y
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_or, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :|, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_or);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :|, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -5251,13 +5301,14 @@ mod tests {
         eval("
             def test(x) = !x
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_not, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v4:BasicObject = SendWithoutBlock v1, :!
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_not);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v4:BasicObject = SendWithoutBlock v1, :!
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -5265,13 +5316,14 @@ mod tests {
         eval("
             def test(regexp, matchee) = regexp =~ matchee
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_opt_regexpmatch2, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :=~, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_opt_regexpmatch2);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :=~, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -5283,17 +5335,18 @@ mod tests {
               alias aliased __callee__
             end
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_putspecialobject, expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Class[VMFrozenCore] = Const Value(VALUE(0x1000))
-              v3:BasicObject = PutSpecialObject CBase
-              v4:StaticSymbol[:aliased] = Const Value(VALUE(0x1008))
-              v5:StaticSymbol[:__callee__] = Const Value(VALUE(0x1010))
-              v7:BasicObject = SendWithoutBlock v2, :core#set_method_alias, v3, v4, v5
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_putspecialobject);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Class[VMFrozenCore] = Const Value(VALUE(0x1000))
+          v3:BasicObject = PutSpecialObject CBase
+          v4:StaticSymbol[:aliased] = Const Value(VALUE(0x1008))
+          v5:StaticSymbol[:__callee__] = Const Value(VALUE(0x1010))
+          v7:BasicObject = SendWithoutBlock v2, :core#set_method_alias, v3, v4, v5
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
@@ -5309,34 +5362,36 @@ mod tests {
               [a, b, c, d]
             end
         ");
-        assert_method_hir_with_opcode("reverse_odd", YARVINSN_opt_reverse, expect![[r#"
-            fn reverse_odd@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v2:NilClass = Const Value(nil)
-              v3:NilClass = Const Value(nil)
-              v6:BasicObject = GetIvar v0, :@a
-              v8:BasicObject = GetIvar v0, :@b
-              v10:BasicObject = GetIvar v0, :@c
-              v12:ArrayExact = NewArray v6, v8, v10
-              CheckInterrupts
-              Return v12
-        "#]]);
-        assert_method_hir_with_opcode("reverse_even", YARVINSN_opt_reverse, expect![[r#"
-            fn reverse_even@<compiled>:8:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v2:NilClass = Const Value(nil)
-              v3:NilClass = Const Value(nil)
-              v4:NilClass = Const Value(nil)
-              v7:BasicObject = GetIvar v0, :@a
-              v9:BasicObject = GetIvar v0, :@b
-              v11:BasicObject = GetIvar v0, :@c
-              v13:BasicObject = GetIvar v0, :@d
-              v15:ArrayExact = NewArray v7, v9, v11, v13
-              CheckInterrupts
-              Return v15
-        "#]]);
+        assert_contains_opcode("reverse_odd", YARVINSN_opt_reverse);
+        assert_snapshot!(hir_string("reverse_odd"), @r"
+        fn reverse_odd@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v2:NilClass = Const Value(nil)
+          v3:NilClass = Const Value(nil)
+          v6:BasicObject = GetIvar v0, :@a
+          v8:BasicObject = GetIvar v0, :@b
+          v10:BasicObject = GetIvar v0, :@c
+          v12:ArrayExact = NewArray v6, v8, v10
+          CheckInterrupts
+          Return v12
+        ");
+        assert_contains_opcode("reverse_even", YARVINSN_opt_reverse);
+        assert_snapshot!(hir_string("reverse_even"), @r"
+        fn reverse_even@<compiled>:8:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v2:NilClass = Const Value(nil)
+          v3:NilClass = Const Value(nil)
+          v4:NilClass = Const Value(nil)
+          v7:BasicObject = GetIvar v0, :@a
+          v9:BasicObject = GetIvar v0, :@b
+          v11:BasicObject = GetIvar v0, :@c
+          v13:BasicObject = GetIvar v0, :@d
+          v15:ArrayExact = NewArray v7, v9, v11, v13
+          CheckInterrupts
+          Return v15
+        ");
     }
 
     #[test]
@@ -5344,44 +5399,47 @@ mod tests {
         eval("
         def test(x) = x&.itself
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_branchnil, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              CheckInterrupts
-              v5:CBool = IsNil v1
-              IfTrue v5, bb1(v0, v1, v1)
-              v8:BasicObject = SendWithoutBlock v1, :itself
-              Jump bb1(v0, v1, v8)
-            bb1(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-              CheckInterrupts
-              Return v12
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_branchnil);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          CheckInterrupts
+          v5:CBool = IsNil v1
+          IfTrue v5, bb1(v0, v1, v1)
+          v8:BasicObject = SendWithoutBlock v1, :itself
+          Jump bb1(v0, v1, v8)
+        bb1(v10:BasicObject, v11:BasicObject, v12:BasicObject):
+          CheckInterrupts
+          Return v12
+        ");
     }
 
     #[test]
     fn test_invokebuiltin_delegate_annotated() {
-        assert_method_hir_with_opcode("Float", YARVINSN_opt_invokebuiltin_delegate_leave, expect![[r#"
-            fn Float@<internal:kernel>:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject, v3:BasicObject):
-              v6:Float = InvokeBuiltin rb_f_float, v0, v1, v2
-              Jump bb1(v0, v1, v2, v3, v6)
-            bb1(v8:BasicObject, v9:BasicObject, v10:BasicObject, v11:BasicObject, v12:Float):
-              CheckInterrupts
-              Return v12
-        "#]]);
+        assert_contains_opcode("Float", YARVINSN_opt_invokebuiltin_delegate_leave);
+        assert_snapshot!(hir_string("Float"), @r"
+        fn Float@<internal:kernel>:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject, v3:BasicObject):
+          v6:Float = InvokeBuiltin rb_f_float, v0, v1, v2
+          Jump bb1(v0, v1, v2, v3, v6)
+        bb1(v8:BasicObject, v9:BasicObject, v10:BasicObject, v11:BasicObject, v12:Float):
+          CheckInterrupts
+          Return v12
+        ");
     }
 
     #[test]
     fn test_invokebuiltin_cexpr_annotated() {
-        assert_method_hir_with_opcode("class", YARVINSN_opt_invokebuiltin_delegate_leave, expect![[r#"
-            fn class@<internal:kernel>:
-            bb0(v0:BasicObject):
-              v3:Class = InvokeBuiltin _bi20, v0
-              Jump bb1(v0, v3)
-            bb1(v5:BasicObject, v6:Class):
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_contains_opcode("class", YARVINSN_opt_invokebuiltin_delegate_leave);
+        assert_snapshot!(hir_string("class"), @r"
+        fn class@<internal:kernel>:
+        bb0(v0:BasicObject):
+          v3:Class = InvokeBuiltin _bi20, v0
+          Jump bb1(v0, v3)
+        bb1(v5:BasicObject, v6:Class):
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -5390,13 +5448,13 @@ mod tests {
         let iseq = crate::cruby::with_rubyvm(|| get_method_iseq("Dir", "open"));
         assert!(iseq_contains_opcode(iseq, YARVINSN_opt_invokebuiltin_delegate), "iseq Dir.open does not contain invokebuiltin");
         let function = iseq_to_hir(iseq).unwrap();
-        assert_function_hir(function, expect![[r#"
+        assert_snapshot!(hir_string_function(&function), @r#"
             fn open@<internal:dir>:
             bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject, v3:BasicObject, v4:BasicObject):
               v5:NilClass = Const Value(nil)
               v8:BasicObject = InvokeBuiltin dir_s_open, v0, v1, v2
               SideExit UnknownOpcode(getblockparamproxy)
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -5404,15 +5462,15 @@ mod tests {
         let iseq = crate::cruby::with_rubyvm(|| get_method_iseq("GC", "enable"));
         assert!(iseq_contains_opcode(iseq, YARVINSN_opt_invokebuiltin_delegate_leave), "iseq GC.enable does not contain invokebuiltin");
         let function = iseq_to_hir(iseq).unwrap();
-        assert_function_hir(function, expect![[r#"
-            fn enable@<internal:gc>:
-            bb0(v0:BasicObject):
-              v3:BasicObject = InvokeBuiltin gc_enable, v0
-              Jump bb1(v0, v3)
-            bb1(v5:BasicObject, v6:BasicObject):
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string_function(&function), @r"
+        fn enable@<internal:gc>:
+        bb0(v0:BasicObject):
+          v3:BasicObject = InvokeBuiltin gc_enable, v0
+          Jump bb1(v0, v3)
+        bb1(v5:BasicObject, v6:BasicObject):
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -5420,14 +5478,14 @@ mod tests {
         let iseq = crate::cruby::with_rubyvm(|| get_method_iseq("GC", "start"));
         assert!(iseq_contains_opcode(iseq, YARVINSN_invokebuiltin), "iseq GC.start does not contain invokebuiltin");
         let function = iseq_to_hir(iseq).unwrap();
-        assert_function_hir(function, expect![[r#"
-            fn start@<internal:gc>:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject, v3:BasicObject, v4:BasicObject):
-              v6:FalseClass = Const Value(false)
-              v8:BasicObject = InvokeBuiltin gc_start_internal, v0, v1, v2, v3, v6
-              CheckInterrupts
-              Return v8
-        "#]]);
+        assert_snapshot!(hir_string_function(&function), @r"
+        fn start@<internal:gc>:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject, v3:BasicObject, v4:BasicObject):
+          v6:FalseClass = Const Value(false)
+          v8:BasicObject = InvokeBuiltin gc_start_internal, v0, v1, v2, v3, v6
+          CheckInterrupts
+          Return v8
+        ");
     }
 
     #[test]
@@ -5435,24 +5493,25 @@ mod tests {
         eval("
             def test(x) = (x[0, 1] ||= 2)
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_dupn, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v3:NilClass = Const Value(nil)
-              v4:Fixnum[0] = Const Value(0)
-              v5:Fixnum[1] = Const Value(1)
-              v7:BasicObject = SendWithoutBlock v1, :[], v4, v5
-              CheckInterrupts
-              v10:CBool = Test v7
-              IfTrue v10, bb1(v0, v1, v3, v1, v4, v5, v7)
-              v12:Fixnum[2] = Const Value(2)
-              v14:BasicObject = SendWithoutBlock v1, :[]=, v4, v5, v12
-              CheckInterrupts
-              Return v12
-            bb1(v18:BasicObject, v19:BasicObject, v20:NilClass, v21:BasicObject, v22:Fixnum[0], v23:Fixnum[1], v24:BasicObject):
-              CheckInterrupts
-              Return v24
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_dupn);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:NilClass = Const Value(nil)
+          v4:Fixnum[0] = Const Value(0)
+          v5:Fixnum[1] = Const Value(1)
+          v7:BasicObject = SendWithoutBlock v1, :[], v4, v5
+          CheckInterrupts
+          v10:CBool = Test v7
+          IfTrue v10, bb1(v0, v1, v3, v1, v4, v5, v7)
+          v12:Fixnum[2] = Const Value(2)
+          v14:BasicObject = SendWithoutBlock v1, :[]=, v4, v5, v12
+          CheckInterrupts
+          Return v12
+        bb1(v18:BasicObject, v19:BasicObject, v20:NilClass, v21:BasicObject, v22:Fixnum[0], v23:Fixnum[1], v24:BasicObject):
+          CheckInterrupts
+          Return v24
+        ");
     }
 
     #[test]
@@ -5460,17 +5519,18 @@ mod tests {
         eval("
             def test = \"#{1}\"
         ");
-        assert_method_hir_with_opcode("test", YARVINSN_objtostring, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v3:Fixnum[1] = Const Value(1)
-              v5:BasicObject = ObjToString v3
-              v7:String = AnyToString v3, str: v5
-              v9:StringExact = StringConcat v2, v7
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_objtostring);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v3:Fixnum[1] = Const Value(1)
+          v5:BasicObject = ObjToString v3
+          v7:String = AnyToString v3, str: v5
+          v9:StringExact = StringConcat v2, v7
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -5478,22 +5538,23 @@ mod tests {
         eval(r##"
             def test = "#{1}#{2}#{3}"
         "##);
-        assert_method_hir_with_opcode("test", YARVINSN_concatstrings, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v4:BasicObject = ObjToString v2
-              v6:String = AnyToString v2, str: v4
-              v7:Fixnum[2] = Const Value(2)
-              v9:BasicObject = ObjToString v7
-              v11:String = AnyToString v7, str: v9
-              v12:Fixnum[3] = Const Value(3)
-              v14:BasicObject = ObjToString v12
-              v16:String = AnyToString v12, str: v14
-              v18:StringExact = StringConcat v6, v11, v16
-              CheckInterrupts
-              Return v18
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_concatstrings);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v4:BasicObject = ObjToString v2
+          v6:String = AnyToString v2, str: v4
+          v7:Fixnum[2] = Const Value(2)
+          v9:BasicObject = ObjToString v7
+          v11:String = AnyToString v7, str: v9
+          v12:Fixnum[3] = Const Value(3)
+          v14:BasicObject = ObjToString v12
+          v16:String = AnyToString v12, str: v14
+          v18:StringExact = StringConcat v6, v11, v16
+          CheckInterrupts
+          Return v18
+        ");
     }
 
     #[test]
@@ -5501,17 +5562,18 @@ mod tests {
         eval(r##"
             def test = "#{}"
         "##);
-        assert_method_hir_with_opcode("test", YARVINSN_concatstrings, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v3:NilClass = Const Value(nil)
-              v5:BasicObject = ObjToString v3
-              v7:String = AnyToString v3, str: v5
-              v9:StringExact = StringConcat v2, v7
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_concatstrings);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v3:NilClass = Const Value(nil)
+          v5:BasicObject = ObjToString v3
+          v7:String = AnyToString v3, str: v5
+          v9:StringExact = StringConcat v2, v7
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -5519,22 +5581,23 @@ mod tests {
         eval(r##"
             def test = /#{1}#{2}#{3}/
         "##);
-        assert_method_hir_with_opcode("test", YARVINSN_toregexp, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v4:BasicObject = ObjToString v2
-              v6:String = AnyToString v2, str: v4
-              v7:Fixnum[2] = Const Value(2)
-              v9:BasicObject = ObjToString v7
-              v11:String = AnyToString v7, str: v9
-              v12:Fixnum[3] = Const Value(3)
-              v14:BasicObject = ObjToString v12
-              v16:String = AnyToString v12, str: v14
-              v18:RegexpExact = ToRegexp v6, v11, v16
-              CheckInterrupts
-              Return v18
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_toregexp);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v4:BasicObject = ObjToString v2
+          v6:String = AnyToString v2, str: v4
+          v7:Fixnum[2] = Const Value(2)
+          v9:BasicObject = ObjToString v7
+          v11:String = AnyToString v7, str: v9
+          v12:Fixnum[3] = Const Value(3)
+          v14:BasicObject = ObjToString v12
+          v16:String = AnyToString v12, str: v14
+          v18:RegexpExact = ToRegexp v6, v11, v16
+          CheckInterrupts
+          Return v18
+        ");
     }
 
     #[test]
@@ -5542,19 +5605,20 @@ mod tests {
         eval(r##"
             def test = /#{1}#{2}/mixn
         "##);
-        assert_method_hir_with_opcode("test", YARVINSN_toregexp, expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v4:BasicObject = ObjToString v2
-              v6:String = AnyToString v2, str: v4
-              v7:Fixnum[2] = Const Value(2)
-              v9:BasicObject = ObjToString v7
-              v11:String = AnyToString v7, str: v9
-              v13:RegexpExact = ToRegexp v6, v11, MULTILINE|IGNORECASE|EXTENDED|NOENCODING
-              CheckInterrupts
-              Return v13
-        "#]]);
+        assert_contains_opcode("test", YARVINSN_toregexp);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v4:BasicObject = ObjToString v2
+          v6:String = AnyToString v2, str: v4
+          v7:Fixnum[2] = Const Value(2)
+          v9:BasicObject = ObjToString v7
+          v11:String = AnyToString v7, str: v9
+          v13:RegexpExact = ToRegexp v6, v11, MULTILINE|IGNORECASE|EXTENDED|NOENCODING
+          CheckInterrupts
+          Return v13
+        ");
     }
 
     #[test]
@@ -5563,35 +5627,36 @@ mod tests {
             define_method(:throw_return) { return 1 }
             define_method(:throw_break) { break 2 }
         ");
-        assert_method_hir_with_opcode("throw_return", YARVINSN_throw, expect![[r#"
+        assert_contains_opcode("throw_return", YARVINSN_throw);
+        assert_snapshot!(hir_string("throw_return"), @r#"
             fn block in <compiled>@<compiled>:2:
             bb0(v0:BasicObject):
               v2:Fixnum[1] = Const Value(1)
               Throw TAG_RETURN, v2
-        "#]]);
-        assert_method_hir_with_opcode("throw_break", YARVINSN_throw, expect![[r#"
+        "#);
+        assert_contains_opcode("throw_break", YARVINSN_throw);
+        assert_snapshot!(hir_string("throw_break"), @r#"
             fn block in <compiled>@<compiled>:3:
             bb0(v0:BasicObject):
               v2:Fixnum[2] = Const Value(2)
               Throw TAG_BREAK, v2
-        "#]]);
+        "#);
     }
 }
 
 #[cfg(test)]
 mod graphviz_tests {
     use super::*;
-    use expect_test::{expect, Expect};
+    use insta::assert_snapshot;
 
     #[track_caller]
-    fn assert_optimized_graphviz(method: &str, expected: Expect) {
+    fn hir_string(method: &str) -> String {
         let iseq = crate::cruby::with_rubyvm(|| get_method_iseq("self", method));
         unsafe { crate::cruby::rb_zjit_profile_disable(iseq) };
         let mut function = iseq_to_hir(iseq).unwrap();
         function.optimize();
         function.validate().unwrap();
-        let actual = format!("{}", FunctionGraphvizPrinter::new(&function));
-        expected.assert_eq(&actual);
+        format!("{}", FunctionGraphvizPrinter::new(&function))
     }
 
     #[test]
@@ -5601,21 +5666,21 @@ mod graphviz_tests {
 
             test(1, 2)
         "#);
-        assert_optimized_graphviz("test", expect![[r#"
-            digraph G { # test@&lt;compiled&gt;:2
-            node [shape=plaintext];
-            mode=hier; overlap=false; splines=true;
-              bb0 [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
-            <TR><TD ALIGN="LEFT" PORT="params" BGCOLOR="gray">bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject)&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v9">PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, 29)&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v10">v10:Fixnum = GuardType v1, Fixnum&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v11">v11:Fixnum = GuardType v2, Fixnum&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v12">v12:Fixnum = FixnumOr v10, v11&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v7">CheckInterrupts&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v8">Return v12&nbsp;</TD></TR>
-            </TABLE>>];
-            }
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r#"
+        digraph G { # test@&lt;compiled&gt;:2
+        node [shape=plaintext];
+        mode=hier; overlap=false; splines=true;
+          bb0 [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+        <TR><TD ALIGN="LEFT" PORT="params" BGCOLOR="gray">bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject)&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v9">PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, 29)&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v10">v10:Fixnum = GuardType v1, Fixnum&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v11">v11:Fixnum = GuardType v2, Fixnum&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v12">v12:Fixnum = FixnumOr v10, v11&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v7">CheckInterrupts&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v8">Return v12&nbsp;</TD></TR>
+        </TABLE>>];
+        }
+        "#);
     }
 
     #[test]
@@ -5632,45 +5697,44 @@ mod graphviz_tests {
             test(1)
             test("x")
         "#);
-        assert_optimized_graphviz("test", expect![[r#"
-            digraph G { # test@&lt;compiled&gt;:3
-            node [shape=plaintext];
-            mode=hier; overlap=false; splines=true;
-              bb0 [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
-            <TR><TD ALIGN="LEFT" PORT="params" BGCOLOR="gray">bb0(v0:BasicObject, v1:BasicObject)&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v4">CheckInterrupts&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v5">v5:CBool = Test v1&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v6">IfFalse v5, bb1(v0, v1)&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v7">v7:Fixnum[3] = Const Value(3)&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v9">CheckInterrupts&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v10">Return v7&nbsp;</TD></TR>
-            </TABLE>>];
-              bb0:v6 -> bb1:params;
-              bb1 [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
-            <TR><TD ALIGN="LEFT" PORT="params" BGCOLOR="gray">bb1(v11:BasicObject, v12:BasicObject)&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v14">v14:Fixnum[4] = Const Value(4)&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v16">CheckInterrupts&nbsp;</TD></TR>
-            <TR><TD ALIGN="left" PORT="v17">Return v14&nbsp;</TD></TR>
-            </TABLE>>];
-            }
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r#"
+        digraph G { # test@&lt;compiled&gt;:3
+        node [shape=plaintext];
+        mode=hier; overlap=false; splines=true;
+          bb0 [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+        <TR><TD ALIGN="LEFT" PORT="params" BGCOLOR="gray">bb0(v0:BasicObject, v1:BasicObject)&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v4">CheckInterrupts&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v5">v5:CBool = Test v1&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v6">IfFalse v5, bb1(v0, v1)&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v7">v7:Fixnum[3] = Const Value(3)&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v9">CheckInterrupts&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v10">Return v7&nbsp;</TD></TR>
+        </TABLE>>];
+          bb0:v6 -> bb1:params;
+          bb1 [label=<<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+        <TR><TD ALIGN="LEFT" PORT="params" BGCOLOR="gray">bb1(v11:BasicObject, v12:BasicObject)&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v14">v14:Fixnum[4] = Const Value(4)&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v16">CheckInterrupts&nbsp;</TD></TR>
+        <TR><TD ALIGN="left" PORT="v17">Return v14&nbsp;</TD></TR>
+        </TABLE>>];
+        }
+        "#);
     }
 }
 
 #[cfg(test)]
 mod opt_tests {
     use super::*;
-    use super::tests::assert_function_hir;
-    use expect_test::{expect, Expect};
+    use insta::assert_snapshot;
 
     #[track_caller]
-    fn assert_optimized_method_hir(method: &str, hir: Expect) {
+    fn hir_string(method: &str) -> String {
         let iseq = crate::cruby::with_rubyvm(|| get_method_iseq("self", method));
         unsafe { crate::cruby::rb_zjit_profile_disable(iseq) };
         let mut function = iseq_to_hir(iseq).unwrap();
         function.optimize();
         function.validate().unwrap();
-        assert_function_hir(function, hir);
+        format!("{}", FunctionPrinter::without_snapshot(&function))
     }
 
     #[test]
@@ -5685,15 +5749,15 @@ mod opt_tests {
               end
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v3:TrueClass = Const Value(true)
-              CheckInterrupts
-              v8:Fixnum[3] = Const Value(3)
-              CheckInterrupts
-              Return v8
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v3:TrueClass = Const Value(true)
+          CheckInterrupts
+          v8:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Return v8
+        ");
     }
 
     #[test]
@@ -5708,15 +5772,15 @@ mod opt_tests {
               end
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v3:FalseClass = Const Value(false)
-              CheckInterrupts
-              v15:Fixnum[4] = Const Value(4)
-              CheckInterrupts
-              Return v15
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v3:FalseClass = Const Value(false)
+          CheckInterrupts
+          v15:Fixnum[4] = Const Value(4)
+          CheckInterrupts
+          Return v15
+        ");
     }
 
     #[test]
@@ -5726,19 +5790,19 @@ mod opt_tests {
               1 + 2 + 3
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v3:Fixnum[2] = Const Value(2)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
-              v16:Fixnum[3] = Const Value(3)
-              v6:Fixnum[3] = Const Value(3)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
-              v17:Fixnum[6] = Const Value(6)
-              CheckInterrupts
-              Return v17
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v3:Fixnum[2] = Const Value(2)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
+          v16:Fixnum[3] = Const Value(3)
+          v6:Fixnum[3] = Const Value(3)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
+          v17:Fixnum[6] = Const Value(6)
+          CheckInterrupts
+          Return v17
+        ");
     }
 
     #[test]
@@ -5748,19 +5812,19 @@ mod opt_tests {
               5 - 3 - 1
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[5] = Const Value(5)
-              v3:Fixnum[3] = Const Value(3)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MINUS)
-              v16:Fixnum[2] = Const Value(2)
-              v6:Fixnum[1] = Const Value(1)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MINUS)
-              v17:Fixnum[1] = Const Value(1)
-              CheckInterrupts
-              Return v17
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[5] = Const Value(5)
+          v3:Fixnum[3] = Const Value(3)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MINUS)
+          v16:Fixnum[2] = Const Value(2)
+          v6:Fixnum[1] = Const Value(1)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MINUS)
+          v17:Fixnum[1] = Const Value(1)
+          CheckInterrupts
+          Return v17
+        ");
     }
 
     #[test]
@@ -5770,16 +5834,16 @@ mod opt_tests {
               0 - 1073741825
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[0] = Const Value(0)
-              v3:Fixnum[1073741825] = Const Value(1073741825)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MINUS)
-              v11:Fixnum[-1073741825] = Const Value(-1073741825)
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[0] = Const Value(0)
+          v3:Fixnum[1073741825] = Const Value(1073741825)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MINUS)
+          v11:Fixnum[-1073741825] = Const Value(-1073741825)
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -5789,16 +5853,16 @@ mod opt_tests {
               6 * 7
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[6] = Const Value(6)
-              v3:Fixnum[7] = Const Value(7)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MULT)
-              v11:Fixnum[42] = Const Value(42)
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[6] = Const Value(6)
+          v3:Fixnum[7] = Const Value(7)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MULT)
+          v11:Fixnum[42] = Const Value(42)
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -5809,22 +5873,22 @@ mod opt_tests {
             end
             test 1; test 2
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v3:Fixnum[0] = Const Value(0)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MULT)
-              v15:Fixnum = GuardType v1, Fixnum
-              v22:Fixnum[0] = Const Value(0)
-              v6:Fixnum[0] = Const Value(0)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MULT)
-              v18:Fixnum = GuardType v1, Fixnum
-              v23:Fixnum[0] = Const Value(0)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
-              v24:Fixnum[0] = Const Value(0)
-              CheckInterrupts
-              Return v24
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:Fixnum[0] = Const Value(0)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MULT)
+          v15:Fixnum = GuardType v1, Fixnum
+          v22:Fixnum[0] = Const Value(0)
+          v6:Fixnum[0] = Const Value(0)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MULT)
+          v18:Fixnum = GuardType v1, Fixnum
+          v23:Fixnum[0] = Const Value(0)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
+          v24:Fixnum[0] = Const Value(0)
+          CheckInterrupts
+          Return v24
+        ");
     }
 
     #[test]
@@ -5838,18 +5902,18 @@ mod opt_tests {
               end
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v3:Fixnum[2] = Const Value(2)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
-              v22:TrueClass = Const Value(true)
-              CheckInterrupts
-              v10:Fixnum[3] = Const Value(3)
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v3:Fixnum[2] = Const Value(2)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
+          v22:TrueClass = Const Value(true)
+          CheckInterrupts
+          v10:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -5863,23 +5927,23 @@ mod opt_tests {
               end
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v3:Fixnum[2] = Const Value(2)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LE)
-              v32:TrueClass = Const Value(true)
-              CheckInterrupts
-              v10:Fixnum[2] = Const Value(2)
-              v11:Fixnum[2] = Const Value(2)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LE)
-              v34:TrueClass = Const Value(true)
-              CheckInterrupts
-              v18:Fixnum[3] = Const Value(3)
-              CheckInterrupts
-              Return v18
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v3:Fixnum[2] = Const Value(2)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LE)
+          v32:TrueClass = Const Value(true)
+          CheckInterrupts
+          v10:Fixnum[2] = Const Value(2)
+          v11:Fixnum[2] = Const Value(2)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LE)
+          v34:TrueClass = Const Value(true)
+          CheckInterrupts
+          v18:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Return v18
+        ");
     }
 
     #[test]
@@ -5893,18 +5957,18 @@ mod opt_tests {
               end
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[2] = Const Value(2)
-              v3:Fixnum[1] = Const Value(1)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_GT)
-              v22:TrueClass = Const Value(true)
-              CheckInterrupts
-              v10:Fixnum[3] = Const Value(3)
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[2] = Const Value(2)
+          v3:Fixnum[1] = Const Value(1)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_GT)
+          v22:TrueClass = Const Value(true)
+          CheckInterrupts
+          v10:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -5918,23 +5982,23 @@ mod opt_tests {
               end
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[2] = Const Value(2)
-              v3:Fixnum[1] = Const Value(1)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_GE)
-              v32:TrueClass = Const Value(true)
-              CheckInterrupts
-              v10:Fixnum[2] = Const Value(2)
-              v11:Fixnum[2] = Const Value(2)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_GE)
-              v34:TrueClass = Const Value(true)
-              CheckInterrupts
-              v18:Fixnum[3] = Const Value(3)
-              CheckInterrupts
-              Return v18
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[2] = Const Value(2)
+          v3:Fixnum[1] = Const Value(1)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_GE)
+          v32:TrueClass = Const Value(true)
+          CheckInterrupts
+          v10:Fixnum[2] = Const Value(2)
+          v11:Fixnum[2] = Const Value(2)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_GE)
+          v34:TrueClass = Const Value(true)
+          CheckInterrupts
+          v18:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Return v18
+        ");
     }
 
     #[test]
@@ -5948,18 +6012,18 @@ mod opt_tests {
               end
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v3:Fixnum[2] = Const Value(2)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
-              v22:FalseClass = Const Value(false)
-              CheckInterrupts
-              v16:Fixnum[4] = Const Value(4)
-              CheckInterrupts
-              Return v16
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v3:Fixnum[2] = Const Value(2)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
+          v22:FalseClass = Const Value(false)
+          CheckInterrupts
+          v16:Fixnum[4] = Const Value(4)
+          CheckInterrupts
+          Return v16
+        ");
     }
 
     #[test]
@@ -5973,18 +6037,18 @@ mod opt_tests {
               end
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[2] = Const Value(2)
-              v3:Fixnum[2] = Const Value(2)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
-              v22:TrueClass = Const Value(true)
-              CheckInterrupts
-              v10:Fixnum[3] = Const Value(3)
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[2] = Const Value(2)
+          v3:Fixnum[2] = Const Value(2)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
+          v22:TrueClass = Const Value(true)
+          CheckInterrupts
+          v10:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -5998,19 +6062,19 @@ mod opt_tests {
               end
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v3:Fixnum[2] = Const Value(2)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_NEQ)
-              v23:TrueClass = Const Value(true)
-              CheckInterrupts
-              v10:Fixnum[3] = Const Value(3)
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v3:Fixnum[2] = Const Value(2)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_NEQ)
+          v23:TrueClass = Const Value(true)
+          CheckInterrupts
+          v10:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -6024,19 +6088,19 @@ mod opt_tests {
               end
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[2] = Const Value(2)
-              v3:Fixnum[2] = Const Value(2)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_NEQ)
-              v23:FalseClass = Const Value(false)
-              CheckInterrupts
-              v16:Fixnum[4] = Const Value(4)
-              CheckInterrupts
-              Return v16
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[2] = Const Value(2)
+          v3:Fixnum[2] = Const Value(2)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_NEQ)
+          v23:FalseClass = Const Value(false)
+          CheckInterrupts
+          v16:Fixnum[4] = Const Value(4)
+          CheckInterrupts
+          Return v16
+        ");
     }
 
     #[test]
@@ -6047,16 +6111,16 @@ mod opt_tests {
             end
             test(2); test(3)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v3:Fixnum[1] = Const Value(1)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
-              v10:Fixnum = GuardType v1, Fixnum
-              v11:Fixnum = FixnumAdd v10, v3
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:Fixnum[1] = Const Value(1)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
+          v10:Fixnum = GuardType v1, Fixnum
+          v11:Fixnum = FixnumAdd v10, v3
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -6069,38 +6133,38 @@ mod opt_tests {
             def block(&b) = nil
         ");
 
-        assert_optimized_method_hir("rest", expect![[r#"
-            fn rest@<compiled>:2:
-            bb0(v0:BasicObject, v1:ArrayExact):
-              CheckInterrupts
-              Return v1
-        "#]]);
+        assert_snapshot!(hir_string("rest"), @r"
+        fn rest@<compiled>:2:
+        bb0(v0:BasicObject, v1:ArrayExact):
+          CheckInterrupts
+          Return v1
+        ");
         // extra hidden param for the set of specified keywords
-        assert_optimized_method_hir("kw", expect![[r#"
-            fn kw@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              CheckInterrupts
-              Return v1
-        "#]]);
-        assert_optimized_method_hir("kw_rest", expect![[r#"
-            fn kw_rest@<compiled>:4:
-            bb0(v0:BasicObject, v1:BasicObject):
-              CheckInterrupts
-              Return v1
-        "#]]);
-        assert_optimized_method_hir("block", expect![[r#"
-            fn block@<compiled>:6:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v3:NilClass = Const Value(nil)
-              CheckInterrupts
-              Return v3
-        "#]]);
-        assert_optimized_method_hir("post", expect![[r#"
-            fn post@<compiled>:5:
-            bb0(v0:BasicObject, v1:ArrayExact, v2:BasicObject):
-              CheckInterrupts
-              Return v2
-        "#]]);
+        assert_snapshot!(hir_string("kw"), @r"
+        fn kw@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          CheckInterrupts
+          Return v1
+        ");
+        assert_snapshot!(hir_string("kw_rest"), @r"
+        fn kw_rest@<compiled>:4:
+        bb0(v0:BasicObject, v1:BasicObject):
+          CheckInterrupts
+          Return v1
+        ");
+        assert_snapshot!(hir_string("block"), @r"
+        fn block@<compiled>:6:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:NilClass = Const Value(nil)
+          CheckInterrupts
+          Return v3
+        ");
+        assert_snapshot!(hir_string("post"), @r"
+        fn post@<compiled>:5:
+        bb0(v0:BasicObject, v1:ArrayExact, v2:BasicObject):
+          CheckInterrupts
+          Return v2
+        ");
     }
 
     #[test]
@@ -6113,15 +6177,15 @@ mod opt_tests {
             end
             test; test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:5:
-            bb0(v0:BasicObject):
-              PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-              v8:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
-              v9:BasicObject = SendWithoutBlockDirect v8, :foo (0x1038)
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:5:
+        bb0(v0:BasicObject):
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v8:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
+          v9:BasicObject = SendWithoutBlockDirect v8, :foo (0x1038)
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -6135,13 +6199,13 @@ mod opt_tests {
             test; test
             undef :foo
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:5:
-            bb0(v0:BasicObject):
-              v3:BasicObject = SendWithoutBlock v0, :foo
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:5:
+        bb0(v0:BasicObject):
+          v3:BasicObject = SendWithoutBlock v0, :foo
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -6155,15 +6219,15 @@ mod opt_tests {
             end
             test; test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:6:
-            bb0(v0:BasicObject):
-              PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-              v8:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
-              v9:BasicObject = SendWithoutBlockDirect v8, :foo (0x1038)
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:6:
+        bb0(v0:BasicObject):
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v8:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
+          v9:BasicObject = SendWithoutBlockDirect v8, :foo (0x1038)
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -6174,16 +6238,16 @@ mod opt_tests {
             end
             test; test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[3] = Const Value(3)
-              PatchPoint MethodRedefined(Object@0x1000, Integer@0x1008, cme:0x1010)
-              v9:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
-              v10:BasicObject = SendWithoutBlockDirect v9, :Integer (0x1038), v2
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[3] = Const Value(3)
+          PatchPoint MethodRedefined(Object@0x1000, Integer@0x1008, cme:0x1010)
+          v9:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
+          v10:BasicObject = SendWithoutBlockDirect v9, :Integer (0x1038), v2
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -6196,17 +6260,17 @@ mod opt_tests {
             end
             test; test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:5:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v3:Fixnum[2] = Const Value(2)
-              PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-              v10:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
-              v11:BasicObject = SendWithoutBlockDirect v10, :foo (0x1038), v2, v3
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:5:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v3:Fixnum[2] = Const Value(2)
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v10:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
+          v11:BasicObject = SendWithoutBlockDirect v10, :foo (0x1038), v2, v3
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -6222,18 +6286,18 @@ mod opt_tests {
             end
             test; test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:7:
-            bb0(v0:BasicObject):
-              PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-              v10:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
-              v11:BasicObject = SendWithoutBlockDirect v10, :foo (0x1038)
-              PatchPoint MethodRedefined(Object@0x1000, bar@0x1040, cme:0x1048)
-              v13:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
-              v14:BasicObject = SendWithoutBlockDirect v13, :bar (0x1038)
-              CheckInterrupts
-              Return v14
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:7:
+        bb0(v0:BasicObject):
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v10:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
+          v11:BasicObject = SendWithoutBlockDirect v10, :foo (0x1038)
+          PatchPoint MethodRedefined(Object@0x1000, bar@0x1040, cme:0x1048)
+          v13:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
+          v14:BasicObject = SendWithoutBlockDirect v13, :bar (0x1038)
+          CheckInterrupts
+          Return v14
+        ");
     }
 
     #[test]
@@ -6247,13 +6311,13 @@ mod opt_tests {
             def test(a, b) = a + b
             test(1,2); test(3,4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:7:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:BasicObject = SendWithoutBlock v1, :+, v2
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:7:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:BasicObject = SendWithoutBlock v1, :+, v2
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -6262,16 +6326,16 @@ mod opt_tests {
             def test(a, b) = a + b
             test(1,2); test(3,4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
-              v10:Fixnum = GuardType v1, Fixnum
-              v11:Fixnum = GuardType v2, Fixnum
-              v12:Fixnum = FixnumAdd v10, v11
-              CheckInterrupts
-              Return v12
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
+          v10:Fixnum = GuardType v1, Fixnum
+          v11:Fixnum = GuardType v2, Fixnum
+          v12:Fixnum = FixnumAdd v10, v11
+          CheckInterrupts
+          Return v12
+        ");
     }
 
     #[test]
@@ -6280,16 +6344,16 @@ mod opt_tests {
             def test(a) = a + 1
             test(1); test(3)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v3:Fixnum[1] = Const Value(1)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
-              v10:Fixnum = GuardType v1, Fixnum
-              v11:Fixnum = FixnumAdd v10, v3
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:Fixnum[1] = Const Value(1)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
+          v10:Fixnum = GuardType v1, Fixnum
+          v11:Fixnum = FixnumAdd v10, v3
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -6298,16 +6362,16 @@ mod opt_tests {
             def test(a) = 1 + a
             test(1); test(3)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v3:Fixnum[1] = Const Value(1)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
-              v10:Fixnum = GuardType v1, Fixnum
-              v11:Fixnum = FixnumAdd v3, v10
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:Fixnum[1] = Const Value(1)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
+          v10:Fixnum = GuardType v1, Fixnum
+          v11:Fixnum = FixnumAdd v3, v10
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -6316,16 +6380,16 @@ mod opt_tests {
             def test(a, b) = a < b
             test(1,2); test(3,4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
-              v10:Fixnum = GuardType v1, Fixnum
-              v11:Fixnum = GuardType v2, Fixnum
-              v12:BoolExact = FixnumLt v10, v11
-              CheckInterrupts
-              Return v12
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
+          v10:Fixnum = GuardType v1, Fixnum
+          v11:Fixnum = GuardType v2, Fixnum
+          v12:BoolExact = FixnumLt v10, v11
+          CheckInterrupts
+          Return v12
+        ");
     }
 
     #[test]
@@ -6334,16 +6398,16 @@ mod opt_tests {
             def test(a) = a < 1
             test(1); test(3)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v3:Fixnum[1] = Const Value(1)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
-              v10:Fixnum = GuardType v1, Fixnum
-              v11:BoolExact = FixnumLt v10, v3
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:Fixnum[1] = Const Value(1)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
+          v10:Fixnum = GuardType v1, Fixnum
+          v11:BoolExact = FixnumLt v10, v3
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -6352,16 +6416,16 @@ mod opt_tests {
             def test(a) = 1 < a
             test(1); test(3)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v3:Fixnum[1] = Const Value(1)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
-              v10:Fixnum = GuardType v1, Fixnum
-              v11:BoolExact = FixnumLt v3, v10
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:Fixnum[1] = Const Value(1)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
+          v10:Fixnum = GuardType v1, Fixnum
+          v11:BoolExact = FixnumLt v3, v10
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -6373,15 +6437,15 @@ mod opt_tests {
             end
             test; test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v4:ArrayExact = NewArray
-              v5:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v4:ArrayExact = NewArray
+          v5:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -6393,14 +6457,14 @@ mod opt_tests {
             end
             test; test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v3:RangeExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v3:RangeExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -6412,19 +6476,19 @@ mod opt_tests {
             end
             test; test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v4:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_UMINUS)
-              v6:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              v8:StringExact = StringCopy v6
-              v10:RangeExact = NewRange v4 NewRangeInclusive v8
-              v11:Fixnum[0] = Const Value(0)
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v4:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_UMINUS)
+          v6:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v8:StringExact = StringCopy v6
+          v10:RangeExact = NewRange v4 NewRangeInclusive v8
+          v11:Fixnum[0] = Const Value(0)
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -6436,15 +6500,15 @@ mod opt_tests {
             end
             test(1); test(2)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v2:NilClass = Const Value(nil)
-              v5:ArrayExact = NewArray v1
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v2:NilClass = Const Value(nil)
+          v5:ArrayExact = NewArray v1
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6455,15 +6519,15 @@ mod opt_tests {
               5
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v4:HashExact = NewHash
-              v5:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v4:HashExact = NewHash
+          v5:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -6474,17 +6538,17 @@ mod opt_tests {
               5
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v3:NilClass = Const Value(nil)
-              v5:StaticSymbol[:a] = Const Value(VALUE(0x1000))
-              v6:StaticSymbol[:b] = Const Value(VALUE(0x1008))
-              v8:HashExact = NewHash v5: v1, v6: v2
-              v9:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v3:NilClass = Const Value(nil)
+          v5:StaticSymbol[:a] = Const Value(VALUE(0x1000))
+          v6:StaticSymbol[:b] = Const Value(VALUE(0x1008))
+          v8:HashExact = NewHash v5: v1, v6: v2
+          v9:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -6496,16 +6560,16 @@ mod opt_tests {
             end
             test; test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v5:ArrayExact = ArrayDup v3
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v5:ArrayExact = ArrayDup v3
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6516,16 +6580,16 @@ mod opt_tests {
               5
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v3:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v5:HashExact = HashDup v3
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v3:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v5:HashExact = HashDup v3
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6537,13 +6601,13 @@ mod opt_tests {
             end
             test; test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v3:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v3:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -6555,16 +6619,16 @@ mod opt_tests {
             end
             test; test
         "#);
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v5:StringExact = StringCopy v3
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v5:StringExact = StringCopy v3
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6576,16 +6640,16 @@ mod opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
-              v11:Fixnum = GuardType v1, Fixnum
-              v12:Fixnum = GuardType v2, Fixnum
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_PLUS)
+          v11:Fixnum = GuardType v1, Fixnum
+          v12:Fixnum = GuardType v2, Fixnum
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6597,16 +6661,16 @@ mod opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MINUS)
-              v11:Fixnum = GuardType v1, Fixnum
-              v12:Fixnum = GuardType v2, Fixnum
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MINUS)
+          v11:Fixnum = GuardType v1, Fixnum
+          v12:Fixnum = GuardType v2, Fixnum
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6618,16 +6682,16 @@ mod opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MULT)
-              v11:Fixnum = GuardType v1, Fixnum
-              v12:Fixnum = GuardType v2, Fixnum
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MULT)
+          v11:Fixnum = GuardType v1, Fixnum
+          v12:Fixnum = GuardType v2, Fixnum
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6639,17 +6703,17 @@ mod opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_DIV)
-              v11:Fixnum = GuardType v1, Fixnum
-              v12:Fixnum = GuardType v2, Fixnum
-              v13:Fixnum = FixnumDiv v11, v12
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_DIV)
+          v11:Fixnum = GuardType v1, Fixnum
+          v12:Fixnum = GuardType v2, Fixnum
+          v13:Fixnum = FixnumDiv v11, v12
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6661,17 +6725,17 @@ mod opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MOD)
-              v11:Fixnum = GuardType v1, Fixnum
-              v12:Fixnum = GuardType v2, Fixnum
-              v13:Fixnum = FixnumMod v11, v12
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_MOD)
+          v11:Fixnum = GuardType v1, Fixnum
+          v12:Fixnum = GuardType v2, Fixnum
+          v13:Fixnum = FixnumMod v11, v12
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6683,16 +6747,16 @@ mod opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
-              v11:Fixnum = GuardType v1, Fixnum
-              v12:Fixnum = GuardType v2, Fixnum
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LT)
+          v11:Fixnum = GuardType v1, Fixnum
+          v12:Fixnum = GuardType v2, Fixnum
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6704,16 +6768,16 @@ mod opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LE)
-              v11:Fixnum = GuardType v1, Fixnum
-              v12:Fixnum = GuardType v2, Fixnum
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_LE)
+          v11:Fixnum = GuardType v1, Fixnum
+          v12:Fixnum = GuardType v2, Fixnum
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6725,16 +6789,16 @@ mod opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_GT)
-              v11:Fixnum = GuardType v1, Fixnum
-              v12:Fixnum = GuardType v2, Fixnum
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_GT)
+          v11:Fixnum = GuardType v1, Fixnum
+          v12:Fixnum = GuardType v2, Fixnum
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6746,16 +6810,16 @@ mod opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_GE)
-              v11:Fixnum = GuardType v1, Fixnum
-              v12:Fixnum = GuardType v2, Fixnum
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_GE)
+          v11:Fixnum = GuardType v1, Fixnum
+          v12:Fixnum = GuardType v2, Fixnum
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6767,16 +6831,16 @@ mod opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
-              v11:Fixnum = GuardType v1, Fixnum
-              v12:Fixnum = GuardType v2, Fixnum
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
+          v11:Fixnum = GuardType v1, Fixnum
+          v12:Fixnum = GuardType v2, Fixnum
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6788,17 +6852,17 @@ mod opt_tests {
             end
             test(1, 2); test(3, 4)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_NEQ)
-              v12:Fixnum = GuardType v1, Fixnum
-              v13:Fixnum = GuardType v2, Fixnum
-              v6:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_NEQ)
+          v12:Fixnum = GuardType v1, Fixnum
+          v13:Fixnum = GuardType v2, Fixnum
+          v6:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -6809,14 +6873,14 @@ mod opt_tests {
               5
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v3:BasicObject = GetConstantPath 0x1000
-              v4:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v3:BasicObject = GetConstantPath 0x1000
+          v4:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -6826,15 +6890,15 @@ mod opt_tests {
             test(0) # profile
             test(1)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              PatchPoint MethodRedefined(Integer@0x1000, itself@0x1008, cme:0x1010)
-              v9:Fixnum = GuardType v1, Fixnum
-              v10:BasicObject = CCall itself@0x1038, v9
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          PatchPoint MethodRedefined(Integer@0x1000, itself@0x1008, cme:0x1010)
+          v9:Fixnum = GuardType v1, Fixnum
+          v10:BasicObject = CCall itself@0x1038, v9
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -6842,15 +6906,15 @@ mod opt_tests {
         eval("
             def test = [].itself
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:ArrayExact = NewArray
-              PatchPoint MethodRedefined(Array@0x1000, itself@0x1008, cme:0x1010)
-              v10:BasicObject = CCall itself@0x1038, v3
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:ArrayExact = NewArray
+          PatchPoint MethodRedefined(Array@0x1000, itself@0x1008, cme:0x1010)
+          v10:BasicObject = CCall itself@0x1038, v3
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -6861,17 +6925,17 @@ mod opt_tests {
               1
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v4:ArrayExact = NewArray
-              PatchPoint MethodRedefined(Array@0x1000, itself@0x1008, cme:0x1010)
-              v12:BasicObject = CCall itself@0x1038, v4
-              v7:Fixnum[1] = Const Value(1)
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v4:ArrayExact = NewArray
+          PatchPoint MethodRedefined(Array@0x1000, itself@0x1008, cme:0x1010)
+          v12:BasicObject = CCall itself@0x1038, v4
+          v7:Fixnum[1] = Const Value(1)
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
@@ -6884,19 +6948,19 @@ mod opt_tests {
             end
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:4:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, M)
-              v13:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              PatchPoint MethodRedefined(Module@0x1010, name@0x1018, cme:0x1020)
-              v15:StringExact|NilClass = CCall name@0x1048, v13
-              v7:Fixnum[1] = Const Value(1)
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:4:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, M)
+          v13:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          PatchPoint MethodRedefined(Module@0x1010, name@0x1018, cme:0x1020)
+          v15:StringExact|NilClass = CCall name@0x1048, v13
+          v7:Fixnum[1] = Const Value(1)
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
@@ -6907,17 +6971,17 @@ mod opt_tests {
               5
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v4:ArrayExact = NewArray
-              PatchPoint MethodRedefined(Array@0x1000, length@0x1008, cme:0x1010)
-              v12:Fixnum = CCall length@0x1038, v4
-              v7:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v4:ArrayExact = NewArray
+          PatchPoint MethodRedefined(Array@0x1000, length@0x1008, cme:0x1010)
+          v12:Fixnum = CCall length@0x1038, v4
+          v7:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
@@ -6927,15 +6991,15 @@ mod opt_tests {
             def test = C
             test # Warm the constant cache
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, C)
-              v9:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, C)
+          v9:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -6944,25 +7008,25 @@ mod opt_tests {
             def test = [String, Class, Module, BasicObject]
             test # Warm the constant cache
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, String)
-              v17:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1010, Class)
-              v20:Class[VALUE(0x1018)] = Const Value(VALUE(0x1018))
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1020, Module)
-              v23:Class[VALUE(0x1028)] = Const Value(VALUE(0x1028))
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1030, BasicObject)
-              v26:Class[VALUE(0x1038)] = Const Value(VALUE(0x1038))
-              v11:ArrayExact = NewArray v17, v20, v23, v26
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, String)
+          v17:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1010, Class)
+          v20:Class[VALUE(0x1018)] = Const Value(VALUE(0x1018))
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1020, Module)
+          v23:Class[VALUE(0x1028)] = Const Value(VALUE(0x1028))
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1030, BasicObject)
+          v26:Class[VALUE(0x1038)] = Const Value(VALUE(0x1038))
+          v11:ArrayExact = NewArray v17, v20, v23, v26
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -6971,19 +7035,19 @@ mod opt_tests {
             def test = [Enumerable, Kernel]
             test # Warm the constant cache
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, Enumerable)
-              v13:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1010, Kernel)
-              v16:ModuleExact[VALUE(0x1018)] = Const Value(VALUE(0x1018))
-              v7:ArrayExact = NewArray v13, v16
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, Enumerable)
+          v13:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1010, Kernel)
+          v16:ModuleExact[VALUE(0x1018)] = Const Value(VALUE(0x1018))
+          v7:ArrayExact = NewArray v13, v16
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
@@ -6994,15 +7058,15 @@ mod opt_tests {
             def test = MY_MODULE
             test # Warm the constant cache
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:4:
-            bb0(v0:BasicObject):
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, MY_MODULE)
-              v9:BasicObject[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:4:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, MY_MODULE)
+          v9:BasicObject[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -7013,17 +7077,17 @@ mod opt_tests {
               5
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v1:NilClass = Const Value(nil)
-              v4:ArrayExact = NewArray
-              PatchPoint MethodRedefined(Array@0x1000, size@0x1008, cme:0x1010)
-              v12:Fixnum = CCall size@0x1038, v4
-              v7:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:NilClass = Const Value(nil)
+          v4:ArrayExact = NewArray
+          PatchPoint MethodRedefined(Array@0x1000, size@0x1008, cme:0x1010)
+          v12:Fixnum = CCall size@0x1038, v4
+          v7:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
@@ -7034,15 +7098,15 @@ mod opt_tests {
             test rescue 0
         ");
         // Not specialized
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v3:Fixnum[0] = Const Value(0)
-              v5:BasicObject = SendWithoutBlock v2, :itself, v3
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v3:Fixnum[0] = Const Value(0)
+          v5:BasicObject = SendWithoutBlock v2, :itself, v3
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -7050,15 +7114,15 @@ mod opt_tests {
         eval("
             def test(x) = 1.zero?
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v3:Fixnum[1] = Const Value(1)
-              PatchPoint MethodRedefined(Integer@0x1000, zero?@0x1008, cme:0x1010)
-              v10:BasicObject = SendWithoutBlockDirect v3, :zero? (0x1038)
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v3:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Integer@0x1000, zero?@0x1008, cme:0x1010)
+          v10:BasicObject = SendWithoutBlockDirect v3, :zero? (0x1038)
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -7069,17 +7133,17 @@ mod opt_tests {
               a.first
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject, v1:BasicObject):
-              v2:NilClass = Const Value(nil)
-              v4:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v6:ArrayExact = ArrayDup v4
-              PatchPoint MethodRedefined(Array@0x1008, first@0x1010, cme:0x1018)
-              v13:BasicObject = SendWithoutBlockDirect v6, :first (0x1040)
-              CheckInterrupts
-              Return v13
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject, v1:BasicObject):
+          v2:NilClass = Const Value(nil)
+          v4:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v6:ArrayExact = ArrayDup v4
+          PatchPoint MethodRedefined(Array@0x1008, first@0x1010, cme:0x1018)
+          v13:BasicObject = SendWithoutBlockDirect v6, :first (0x1040)
+          CheckInterrupts
+          Return v13
+        ");
     }
 
     #[test]
@@ -7090,17 +7154,17 @@ mod opt_tests {
             test
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, M)
-              v11:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              PatchPoint MethodRedefined(Module@0x1010, class@0x1018, cme:0x1020)
-              v13:BasicObject = SendWithoutBlockDirect v11, :class (0x1048)
-              CheckInterrupts
-              Return v13
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, M)
+          v11:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          PatchPoint MethodRedefined(Module@0x1010, class@0x1018, cme:0x1020)
+          v13:BasicObject = SendWithoutBlockDirect v11, :class (0x1048)
+          CheckInterrupts
+          Return v13
+        ");
     }
 
     #[test]
@@ -7118,15 +7182,15 @@ mod opt_tests {
             test c
         ");
 
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:8:
-            bb0(v0:BasicObject, v1:BasicObject):
-              PatchPoint MethodRedefined(C@0x1000, foo@0x1008, cme:0x1010)
-              v9:HeapObject[class_exact:C] = GuardType v1, HeapObject[class_exact:C]
-              v10:BasicObject = SendWithoutBlockDirect v9, :foo (0x1038)
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:8:
+        bb0(v0:BasicObject, v1:BasicObject):
+          PatchPoint MethodRedefined(C@0x1000, foo@0x1008, cme:0x1010)
+          v9:HeapObject[class_exact:C] = GuardType v1, HeapObject[class_exact:C]
+          v10:BasicObject = SendWithoutBlockDirect v9, :foo (0x1038)
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -7137,14 +7201,14 @@ mod opt_tests {
             test
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v4:BasicObject = SendWithoutBlock v0, :foo, v2
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v4:BasicObject = SendWithoutBlock v0, :foo, v2
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -7155,13 +7219,13 @@ mod opt_tests {
             test
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v3:BasicObject = Send v0, 0x1000, :foo
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v3:BasicObject = Send v0, 0x1000, :foo
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7172,14 +7236,14 @@ mod opt_tests {
             test
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              v4:BasicObject = SendWithoutBlock v0, :foo, v2
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          v4:BasicObject = SendWithoutBlock v0, :foo, v2
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -7190,12 +7254,12 @@ mod opt_tests {
             test
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject):
               v2:Fixnum[1] = Const Value(1)
               SideExit UnknownCallType
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -7206,12 +7270,12 @@ mod opt_tests {
             test
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
+        assert_snapshot!(hir_string("test"), @r#"
             fn test@<compiled>:3:
             bb0(v0:BasicObject):
               v2:Fixnum[1] = Const Value(1)
               SideExit UnknownCallType
-        "#]]);
+        "#);
     }
 
     #[test]
@@ -7221,16 +7285,16 @@ mod opt_tests {
             test
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:StringExact = StringCopy v2
-              PatchPoint MethodRedefined(String@0x1008, bytesize@0x1010, cme:0x1018)
-              v11:Fixnum = CCall bytesize@0x1040, v4
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:StringExact = StringCopy v2
+          PatchPoint MethodRedefined(String@0x1008, bytesize@0x1010, cme:0x1018)
+          v11:Fixnum = CCall bytesize@0x1040, v4
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -7238,13 +7302,13 @@ mod opt_tests {
         eval("
             def test = Kernel
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:BasicObject = GetConstantPath 0x1000
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:BasicObject = GetConstantPath 0x1000
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7254,13 +7318,13 @@ mod opt_tests {
             test
             Kernel = 5
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:BasicObject = GetConstantPath 0x1000
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:BasicObject = GetConstantPath 0x1000
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7269,15 +7333,15 @@ mod opt_tests {
             def test = Kernel
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, Kernel)
-              v9:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, Kernel)
+          v9:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -7292,15 +7356,15 @@ mod opt_tests {
             def test = Foo::Bar::C
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:8:
-            bb0(v0:BasicObject):
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, Foo::Bar::C)
-              v9:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:8:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, Foo::Bar::C)
+          v9:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -7310,18 +7374,18 @@ mod opt_tests {
             def test = C.new
             test
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, C)
-              v24:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              v4:NilClass = Const Value(nil)
-              CheckInterrupts
-              v13:BasicObject = SendWithoutBlock v24, :new
-              CheckInterrupts
-              Return v13
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, C)
+          v24:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v4:NilClass = Const Value(nil)
+          CheckInterrupts
+          v13:BasicObject = SendWithoutBlock v24, :new
+          CheckInterrupts
+          Return v13
+        ");
     }
 
     #[test]
@@ -7335,19 +7399,19 @@ mod opt_tests {
             def test = C.new 1
             test
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:7:
-            bb0(v0:BasicObject):
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, C)
-              v26:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              v4:NilClass = Const Value(nil)
-              v5:Fixnum[1] = Const Value(1)
-              CheckInterrupts
-              v15:BasicObject = SendWithoutBlock v26, :new, v5
-              CheckInterrupts
-              Return v15
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:7:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, C)
+          v26:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v4:NilClass = Const Value(nil)
+          v5:Fixnum[1] = Const Value(1)
+          CheckInterrupts
+          v15:BasicObject = SendWithoutBlock v26, :new, v5
+          CheckInterrupts
+          Return v15
+        ");
     }
 
     #[test]
@@ -7355,15 +7419,15 @@ mod opt_tests {
         eval("
             def test(a,b) = [a,b].length
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:ArrayExact = NewArray v1, v2
-              PatchPoint MethodRedefined(Array@0x1000, length@0x1008, cme:0x1010)
-              v12:Fixnum = CCall length@0x1038, v5
-              CheckInterrupts
-              Return v12
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:ArrayExact = NewArray v1, v2
+          PatchPoint MethodRedefined(Array@0x1000, length@0x1008, cme:0x1010)
+          v12:Fixnum = CCall length@0x1038, v5
+          CheckInterrupts
+          Return v12
+        ");
     }
 
     #[test]
@@ -7371,15 +7435,15 @@ mod opt_tests {
         eval("
             def test(a,b) = [a,b].size
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              v5:ArrayExact = NewArray v1, v2
-              PatchPoint MethodRedefined(Array@0x1000, size@0x1008, cme:0x1010)
-              v12:Fixnum = CCall size@0x1038, v5
-              CheckInterrupts
-              Return v12
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          v5:ArrayExact = NewArray v1, v2
+          PatchPoint MethodRedefined(Array@0x1000, size@0x1008, cme:0x1010)
+          v12:Fixnum = CCall size@0x1038, v5
+          CheckInterrupts
+          Return v12
+        ");
     }
 
     #[test]
@@ -7387,13 +7451,13 @@ mod opt_tests {
         eval("
             def test = @foo
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:BasicObject = GetIvar v0, :@foo
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:BasicObject = GetIvar v0, :@foo
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7401,14 +7465,14 @@ mod opt_tests {
         eval("
             def test = @foo = 1
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              SetIvar v0, :@foo, v2
-              CheckInterrupts
-              Return v2
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          SetIvar v0, :@foo, v2
+          CheckInterrupts
+          Return v2
+        ");
     }
 
     #[test]
@@ -7416,14 +7480,14 @@ mod opt_tests {
         eval("
             def test = {}.freeze
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(HASH_REDEFINED_OP_FLAG, BOP_FREEZE)
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(HASH_REDEFINED_OP_FLAG, BOP_FREEZE)
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7434,14 +7498,14 @@ mod opt_tests {
             end
             def test = {}.freeze
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:5:
-            bb0(v0:BasicObject):
-              v3:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:BasicObject = SendWithoutBlock v3, :freeze
-              CheckInterrupts
-              Return v4
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:5:
+        bb0(v0:BasicObject):
+          v3:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:BasicObject = SendWithoutBlock v3, :freeze
+          CheckInterrupts
+          Return v4
+        ");
     }
 
     #[test]
@@ -7449,15 +7513,15 @@ mod opt_tests {
         eval("
             def test = {}.freeze.freeze
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(HASH_REDEFINED_OP_FLAG, BOP_FREEZE)
-              PatchPoint BOPRedefined(HASH_REDEFINED_OP_FLAG, BOP_FREEZE)
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(HASH_REDEFINED_OP_FLAG, BOP_FREEZE)
+          PatchPoint BOPRedefined(HASH_REDEFINED_OP_FLAG, BOP_FREEZE)
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7465,15 +7529,15 @@ mod opt_tests {
         eval("
             def test = {}.dup.freeze
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:HashExact = NewHash
-              v5:BasicObject = SendWithoutBlock v3, :dup
-              v7:BasicObject = SendWithoutBlock v5, :freeze
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:HashExact = NewHash
+          v5:BasicObject = SendWithoutBlock v3, :dup
+          v7:BasicObject = SendWithoutBlock v5, :freeze
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
@@ -7481,15 +7545,15 @@ mod opt_tests {
         eval("
             def test = {}.freeze(nil)
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:HashExact = NewHash
-              v4:NilClass = Const Value(nil)
-              v6:BasicObject = SendWithoutBlock v3, :freeze, v4
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:HashExact = NewHash
+          v4:NilClass = Const Value(nil)
+          v6:BasicObject = SendWithoutBlock v3, :freeze, v4
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -7497,14 +7561,14 @@ mod opt_tests {
         eval("
             def test = [].freeze
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7512,15 +7576,15 @@ mod opt_tests {
         eval("
             def test = [].freeze.freeze
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7528,15 +7592,15 @@ mod opt_tests {
         eval("
             def test = [].dup.freeze
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:ArrayExact = NewArray
-              v5:BasicObject = SendWithoutBlock v3, :dup
-              v7:BasicObject = SendWithoutBlock v5, :freeze
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:ArrayExact = NewArray
+          v5:BasicObject = SendWithoutBlock v3, :dup
+          v7:BasicObject = SendWithoutBlock v5, :freeze
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
@@ -7544,15 +7608,15 @@ mod opt_tests {
         eval("
             def test = [].freeze(nil)
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:ArrayExact = NewArray
-              v4:NilClass = Const Value(nil)
-              v6:BasicObject = SendWithoutBlock v3, :freeze, v4
-              CheckInterrupts
-              Return v6
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:ArrayExact = NewArray
+          v4:NilClass = Const Value(nil)
+          v6:BasicObject = SendWithoutBlock v3, :freeze, v4
+          CheckInterrupts
+          Return v6
+        ");
     }
 
     #[test]
@@ -7560,14 +7624,14 @@ mod opt_tests {
         eval("
             def test = ''.freeze
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_FREEZE)
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_FREEZE)
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7575,15 +7639,15 @@ mod opt_tests {
         eval("
             def test = ''.freeze.freeze
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_FREEZE)
-              PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_FREEZE)
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_FREEZE)
+          PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_FREEZE)
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7591,16 +7655,16 @@ mod opt_tests {
         eval("
             def test = ''.dup.freeze
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:StringExact = StringCopy v2
-              v6:BasicObject = SendWithoutBlock v4, :dup
-              v8:BasicObject = SendWithoutBlock v6, :freeze
-              CheckInterrupts
-              Return v8
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:StringExact = StringCopy v2
+          v6:BasicObject = SendWithoutBlock v4, :dup
+          v8:BasicObject = SendWithoutBlock v6, :freeze
+          CheckInterrupts
+          Return v8
+        ");
     }
 
     #[test]
@@ -7608,16 +7672,16 @@ mod opt_tests {
         eval("
             def test = ''.freeze(nil)
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:StringExact = StringCopy v2
-              v5:NilClass = Const Value(nil)
-              v7:BasicObject = SendWithoutBlock v4, :freeze, v5
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:StringExact = StringCopy v2
+          v5:NilClass = Const Value(nil)
+          v7:BasicObject = SendWithoutBlock v4, :freeze, v5
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
@@ -7625,14 +7689,14 @@ mod opt_tests {
         eval("
             def test = -''
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_UMINUS)
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_UMINUS)
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7640,15 +7704,15 @@ mod opt_tests {
         eval("
             def test = -''.freeze
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_FREEZE)
-              PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_UMINUS)
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_FREEZE)
+          PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_UMINUS)
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7656,16 +7720,16 @@ mod opt_tests {
         eval("
             def test = -''.dup
         ");
-        assert_optimized_method_hir("test",  expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:StringExact = StringCopy v2
-              v6:BasicObject = SendWithoutBlock v4, :dup
-              v8:BasicObject = SendWithoutBlock v6, :-@
-              CheckInterrupts
-              Return v8
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:StringExact = StringCopy v2
+          v6:BasicObject = SendWithoutBlock v4, :dup
+          v8:BasicObject = SendWithoutBlock v6, :-@
+          CheckInterrupts
+          Return v8
+        ");
     }
 
     #[test]
@@ -7673,16 +7737,16 @@ mod opt_tests {
         eval(r##"
             def test = "#{('foo')}"
         "##);
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v3:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              v5:StringExact = StringCopy v3
-              v11:StringExact = StringConcat v2, v5
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v3:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v5:StringExact = StringCopy v3
+          v11:StringExact = StringConcat v2, v5
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -7690,17 +7754,17 @@ mod opt_tests {
         eval(r##"
             def test = "#{1}"
         "##);
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v3:Fixnum[1] = Const Value(1)
-              v5:BasicObject = ObjToString v3
-              v7:String = AnyToString v3, str: v5
-              v9:StringExact = StringConcat v2, v7
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v3:Fixnum[1] = Const Value(1)
+          v5:BasicObject = ObjToString v3
+          v7:String = AnyToString v3, str: v5
+          v9:StringExact = StringConcat v2, v7
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -7712,14 +7776,14 @@ mod opt_tests {
             end
         ");
 
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v3:NilClass = Const Value(nil)
-              CheckInterrupts
-              CheckInterrupts
-              Return v3
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v3:NilClass = Const Value(nil)
+          CheckInterrupts
+          CheckInterrupts
+          Return v3
+        ");
     }
 
     #[test]
@@ -7731,16 +7795,16 @@ mod opt_tests {
             end
         ");
 
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v3:Fixnum[1] = Const Value(1)
-              CheckInterrupts
-              PatchPoint MethodRedefined(Integer@0x1000, itself@0x1008, cme:0x1010)
-              v19:BasicObject = CCall itself@0x1038, v3
-              CheckInterrupts
-              Return v19
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v3:Fixnum[1] = Const Value(1)
+          CheckInterrupts
+          PatchPoint MethodRedefined(Integer@0x1000, itself@0x1008, cme:0x1010)
+          v19:BasicObject = CCall itself@0x1038, v3
+          CheckInterrupts
+          Return v19
+        ");
     }
 
     #[test]
@@ -7748,17 +7812,17 @@ mod opt_tests {
         eval(r##"
             def test = [4,5,6].freeze[1]
         "##);
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
-              v5:Fixnum[1] = Const Value(1)
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_AREF)
-              v13:Fixnum[5] = Const Value(5)
-              CheckInterrupts
-              Return v13
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
+          v5:Fixnum[1] = Const Value(1)
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_AREF)
+          v13:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v13
+        ");
     }
 
     #[test]
@@ -7766,17 +7830,17 @@ mod opt_tests {
         eval(r##"
             def test = [4,5,6].freeze[-3]
         "##);
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
-              v5:Fixnum[-3] = Const Value(-3)
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_AREF)
-              v13:Fixnum[4] = Const Value(4)
-              CheckInterrupts
-              Return v13
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
+          v5:Fixnum[-3] = Const Value(-3)
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_AREF)
+          v13:Fixnum[4] = Const Value(4)
+          CheckInterrupts
+          Return v13
+        ");
     }
 
     #[test]
@@ -7784,17 +7848,17 @@ mod opt_tests {
         eval(r##"
             def test = [4,5,6].freeze[-10]
         "##);
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
-              v5:Fixnum[-10] = Const Value(-10)
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_AREF)
-              v13:NilClass = Const Value(nil)
-              CheckInterrupts
-              Return v13
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
+          v5:Fixnum[-10] = Const Value(-10)
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_AREF)
+          v13:NilClass = Const Value(nil)
+          CheckInterrupts
+          Return v13
+        ");
     }
 
     #[test]
@@ -7802,17 +7866,17 @@ mod opt_tests {
         eval(r##"
             def test = [4,5,6].freeze[10]
         "##);
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
-              v5:Fixnum[10] = Const Value(10)
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_AREF)
-              v13:NilClass = Const Value(nil)
-              CheckInterrupts
-              Return v13
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
+          v5:Fixnum[10] = Const Value(10)
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_AREF)
+          v13:NilClass = Const Value(nil)
+          CheckInterrupts
+          Return v13
+        ");
     }
 
     #[test]
@@ -7823,16 +7887,16 @@ mod opt_tests {
             end
             def test = [4,5,6].freeze[10]
         "##);
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:5:
-            bb0(v0:BasicObject):
-              v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
-              v5:Fixnum[10] = Const Value(10)
-              v7:BasicObject = SendWithoutBlock v3, :[], v5
-              CheckInterrupts
-              Return v7
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:5:
+        bb0(v0:BasicObject):
+          v3:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_FREEZE)
+          v5:Fixnum[10] = Const Value(10)
+          v7:BasicObject = SendWithoutBlock v3, :[], v5
+          CheckInterrupts
+          Return v7
+        ");
     }
 
     #[test]
@@ -7843,16 +7907,16 @@ mod opt_tests {
             end
             def test = [4,5,6].max
         "##);
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:5:
-            bb0(v0:BasicObject):
-              v2:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              v4:ArrayExact = ArrayDup v2
-              PatchPoint MethodRedefined(Array@0x1008, max@0x1010, cme:0x1018)
-              v11:BasicObject = SendWithoutBlockDirect v4, :max (0x1040)
-              CheckInterrupts
-              Return v11
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:5:
+        bb0(v0:BasicObject):
+          v2:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:ArrayExact = ArrayDup v2
+          PatchPoint MethodRedefined(Array@0x1008, max@0x1010, cme:0x1018)
+          v11:BasicObject = SendWithoutBlockDirect v4, :max (0x1040)
+          CheckInterrupts
+          Return v11
+        ");
     }
 
     #[test]
@@ -7865,15 +7929,15 @@ mod opt_tests {
             test
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:4:
-            bb0(v0:BasicObject):
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, MY_SET)
-              v9:SetExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:4:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, MY_SET)
+          v9:SetExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -7881,13 +7945,13 @@ mod opt_tests {
         eval("
             def test = /a/
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:RegexpExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-              CheckInterrupts
-              Return v2
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:RegexpExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          CheckInterrupts
+          Return v2
+        ");
     }
 
     #[test]
@@ -7895,15 +7959,15 @@ mod opt_tests {
         eval("
             def test = nil.nil?
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:NilClass = Const Value(nil)
-              PatchPoint MethodRedefined(NilClass@0x1000, nil?@0x1008, cme:0x1010)
-              v9:TrueClass = CCall nil?@0x1038, v2
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:NilClass = Const Value(nil)
+          PatchPoint MethodRedefined(NilClass@0x1000, nil?@0x1008, cme:0x1010)
+          v9:TrueClass = CCall nil?@0x1038, v2
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -7914,15 +7978,15 @@ mod opt_tests {
               1
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:NilClass = Const Value(nil)
-              PatchPoint MethodRedefined(NilClass@0x1000, nil?@0x1008, cme:0x1010)
-              v5:Fixnum[1] = Const Value(1)
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:NilClass = Const Value(nil)
+          PatchPoint MethodRedefined(NilClass@0x1000, nil?@0x1008, cme:0x1010)
+          v5:Fixnum[1] = Const Value(1)
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -7930,15 +7994,15 @@ mod opt_tests {
         eval("
             def test = 1.nil?
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              PatchPoint MethodRedefined(Integer@0x1000, nil?@0x1008, cme:0x1010)
-              v9:FalseClass = CCall nil?@0x1038, v2
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Integer@0x1000, nil?@0x1008, cme:0x1010)
+          v9:FalseClass = CCall nil?@0x1038, v2
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -7949,15 +8013,15 @@ mod opt_tests {
               2
             end
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              v2:Fixnum[1] = Const Value(1)
-              PatchPoint MethodRedefined(Integer@0x1000, nil?@0x1008, cme:0x1010)
-              v5:Fixnum[2] = Const Value(2)
-              CheckInterrupts
-              Return v5
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v2:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Integer@0x1000, nil?@0x1008, cme:0x1010)
+          v5:Fixnum[2] = Const Value(2)
+          CheckInterrupts
+          Return v5
+        ");
     }
 
     #[test]
@@ -7967,15 +8031,15 @@ mod opt_tests {
 
             test(nil)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              PatchPoint MethodRedefined(NilClass@0x1000, nil?@0x1008, cme:0x1010)
-              v9:NilClass = GuardType v1, NilClass
-              v10:TrueClass = CCall nil?@0x1038, v9
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          PatchPoint MethodRedefined(NilClass@0x1000, nil?@0x1008, cme:0x1010)
+          v9:NilClass = GuardType v1, NilClass
+          v10:TrueClass = CCall nil?@0x1038, v9
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -7985,15 +8049,15 @@ mod opt_tests {
 
             test(false)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              PatchPoint MethodRedefined(FalseClass@0x1000, nil?@0x1008, cme:0x1010)
-              v9:FalseClass = GuardType v1, FalseClass
-              v10:FalseClass = CCall nil?@0x1038, v9
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          PatchPoint MethodRedefined(FalseClass@0x1000, nil?@0x1008, cme:0x1010)
+          v9:FalseClass = GuardType v1, FalseClass
+          v10:FalseClass = CCall nil?@0x1038, v9
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -8003,15 +8067,15 @@ mod opt_tests {
 
             test(true)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              PatchPoint MethodRedefined(TrueClass@0x1000, nil?@0x1008, cme:0x1010)
-              v9:TrueClass = GuardType v1, TrueClass
-              v10:FalseClass = CCall nil?@0x1038, v9
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          PatchPoint MethodRedefined(TrueClass@0x1000, nil?@0x1008, cme:0x1010)
+          v9:TrueClass = GuardType v1, TrueClass
+          v10:FalseClass = CCall nil?@0x1038, v9
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -8021,15 +8085,15 @@ mod opt_tests {
 
             test(:foo)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              PatchPoint MethodRedefined(Symbol@0x1000, nil?@0x1008, cme:0x1010)
-              v9:StaticSymbol = GuardType v1, StaticSymbol
-              v10:FalseClass = CCall nil?@0x1038, v9
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          PatchPoint MethodRedefined(Symbol@0x1000, nil?@0x1008, cme:0x1010)
+          v9:StaticSymbol = GuardType v1, StaticSymbol
+          v10:FalseClass = CCall nil?@0x1038, v9
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -8039,15 +8103,15 @@ mod opt_tests {
 
             test(1)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              PatchPoint MethodRedefined(Integer@0x1000, nil?@0x1008, cme:0x1010)
-              v9:Fixnum = GuardType v1, Fixnum
-              v10:FalseClass = CCall nil?@0x1038, v9
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          PatchPoint MethodRedefined(Integer@0x1000, nil?@0x1008, cme:0x1010)
+          v9:Fixnum = GuardType v1, Fixnum
+          v10:FalseClass = CCall nil?@0x1038, v9
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -8057,15 +8121,15 @@ mod opt_tests {
 
             test(1.0)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              PatchPoint MethodRedefined(Float@0x1000, nil?@0x1008, cme:0x1010)
-              v9:Flonum = GuardType v1, Flonum
-              v10:FalseClass = CCall nil?@0x1038, v9
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          PatchPoint MethodRedefined(Float@0x1000, nil?@0x1008, cme:0x1010)
+          v9:Flonum = GuardType v1, Flonum
+          v10:FalseClass = CCall nil?@0x1038, v9
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -8075,15 +8139,15 @@ mod opt_tests {
 
             test('foo')
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject):
-              PatchPoint MethodRedefined(String@0x1000, nil?@0x1008, cme:0x1010)
-              v9:StringExact = GuardType v1, StringExact
-              v10:FalseClass = CCall nil?@0x1038, v9
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject):
+          PatchPoint MethodRedefined(String@0x1000, nil?@0x1008, cme:0x1010)
+          v9:StringExact = GuardType v1, StringExact
+          v10:FalseClass = CCall nil?@0x1038, v9
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -8093,16 +8157,16 @@ mod opt_tests {
 
             test(1, 2)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, 28)
-              v10:Fixnum = GuardType v1, Fixnum
-              v11:Fixnum = GuardType v2, Fixnum
-              v12:Fixnum = FixnumAnd v10, v11
-              CheckInterrupts
-              Return v12
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, 28)
+          v10:Fixnum = GuardType v1, Fixnum
+          v11:Fixnum = GuardType v2, Fixnum
+          v12:Fixnum = FixnumAnd v10, v11
+          CheckInterrupts
+          Return v12
+        ");
     }
 
     #[test]
@@ -8112,16 +8176,16 @@ mod opt_tests {
 
             test(1, 2)
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:2:
-            bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
-              PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, 29)
-              v10:Fixnum = GuardType v1, Fixnum
-              v11:Fixnum = GuardType v2, Fixnum
-              v12:Fixnum = FixnumOr v10, v11
-              CheckInterrupts
-              Return v12
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject, v1:BasicObject, v2:BasicObject):
+          PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, 29)
+          v10:Fixnum = GuardType v1, Fixnum
+          v11:Fixnum = GuardType v2, Fixnum
+          v12:Fixnum = FixnumOr v10, v11
+          CheckInterrupts
+          Return v12
+        ");
     }
 
     #[test]
@@ -8133,15 +8197,15 @@ mod opt_tests {
             test; test
         ");
 
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:3:
-            bb0(v0:BasicObject):
-              PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-              v8:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
-              v9:BasicObject = SendWithoutBlockDirect v8, :foo (0x1038)
-              CheckInterrupts
-              Return v9
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v8:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v0, HeapObject[class_exact*:Object@VALUE(0x1000)]
+          v9:BasicObject = SendWithoutBlockDirect v8, :foo (0x1038)
+          CheckInterrupts
+          Return v9
+        ");
     }
 
     #[test]
@@ -8156,17 +8220,17 @@ mod opt_tests {
             test
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:7:
-            bb0(v0:BasicObject):
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, O)
-              v11:BasicObject[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              PatchPoint MethodRedefined(C@0x1010, foo@0x1018, cme:0x1020)
-              v13:BasicObject = GetIvar v11, :@foo
-              CheckInterrupts
-              Return v13
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:7:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, O)
+          v11:BasicObject[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          PatchPoint MethodRedefined(C@0x1010, foo@0x1018, cme:0x1020)
+          v13:BasicObject = GetIvar v11, :@foo
+          CheckInterrupts
+          Return v13
+        ");
     }
 
     #[test]
@@ -8181,17 +8245,17 @@ mod opt_tests {
             test
             test
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:7:
-            bb0(v0:BasicObject):
-              PatchPoint SingleRactorMode
-              PatchPoint StableConstantNames(0x1000, O)
-              v11:BasicObject[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-              PatchPoint MethodRedefined(C@0x1010, foo@0x1018, cme:0x1020)
-              v13:BasicObject = GetIvar v11, :@foo
-              CheckInterrupts
-              Return v13
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:7:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, O)
+          v11:BasicObject[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          PatchPoint MethodRedefined(C@0x1010, foo@0x1018, cme:0x1020)
+          v13:BasicObject = GetIvar v11, :@foo
+          CheckInterrupts
+          Return v13
+        ");
     }
 
     #[test]
@@ -8205,15 +8269,15 @@ mod opt_tests {
             test C.new
             test C.new
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:6:
-            bb0(v0:BasicObject, v1:BasicObject):
-              PatchPoint MethodRedefined(C@0x1000, foo@0x1008, cme:0x1010)
-              v9:HeapObject[class_exact:C] = GuardType v1, HeapObject[class_exact:C]
-              v10:BasicObject = GetIvar v9, :@foo
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:6:
+        bb0(v0:BasicObject, v1:BasicObject):
+          PatchPoint MethodRedefined(C@0x1000, foo@0x1008, cme:0x1010)
+          v9:HeapObject[class_exact:C] = GuardType v1, HeapObject[class_exact:C]
+          v10:BasicObject = GetIvar v9, :@foo
+          CheckInterrupts
+          Return v10
+        ");
     }
 
     #[test]
@@ -8227,14 +8291,14 @@ mod opt_tests {
             test C.new
             test C.new
         ");
-        assert_optimized_method_hir("test", expect![[r#"
-            fn test@<compiled>:6:
-            bb0(v0:BasicObject, v1:BasicObject):
-              PatchPoint MethodRedefined(C@0x1000, foo@0x1008, cme:0x1010)
-              v9:HeapObject[class_exact:C] = GuardType v1, HeapObject[class_exact:C]
-              v10:BasicObject = GetIvar v9, :@foo
-              CheckInterrupts
-              Return v10
-        "#]]);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:6:
+        bb0(v0:BasicObject, v1:BasicObject):
+          PatchPoint MethodRedefined(C@0x1000, foo@0x1008, cme:0x1010)
+          v9:HeapObject[class_exact:C] = GuardType v1, HeapObject[class_exact:C]
+          v10:BasicObject = GetIvar v9, :@foo
+          CheckInterrupts
+          Return v10
+        ");
     }
 }


### PR DESCRIPTION
Migrate from expect-test to insta snapshot testing library. While expect-test
is very small and has a limited surface, it does not handle nextest well; it
while doing inline snapshot updates, it races other test processes to update
the file, leading to frequent "Failed to process macro invocation" errors.

insta handles this by doing batches; it writes to temporary files which can
then be committed in a batch using `cargo insta review` or
`INSTA_UPDATE=always`.
