### PR TITLE
Cast down to socklen_t explicitly in rb_getnameinfo

### DIFF
--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -752,7 +752,7 @@ rb_getnameinfo(const struct sockaddr *sa, socklen_t salen,
     int err = 0, gni_errno = 0;
 
     if (GETNAMEINFO_WONT_BLOCK(host, serv, flags)) {
-        return getnameinfo(sa, salen, host, hostlen, serv, servlen, flags);
+        return getnameinfo(sa, salen, host, (socklen_t)hostlen, serv, (socklen_t)servlen, flags);
     }
 
 start:


### PR DESCRIPTION
Similar to 19f3793a4bd6974cd66cc058fc6d2ae733337745 / https://github.com/ruby/ruby/pull/14318 (FYI @nobu)

Fixes:

```
../../../ext/socket/raddrinfo.c:755:60: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'socklen_t' (aka 'unsigned int') [-Wshorten-64-to-32]
  755 |         return getnameinfo(sa, salen, host, hostlen, serv, servlen, flags);
      |                ~~~~~~~~~~~                                 ^~~~~~~
../../../ext/socket/raddrinfo.c:755:45: warning: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'socklen_t' (aka 'unsigned int') [-Wshorten-64-to-32]
  755 |         return getnameinfo(sa, salen, host, hostlen, serv, servlen, flags);
      |                ~~~~~~~~~~~                  ^~~~~~~
```