### PR TITLE
ZJIT: Resurrect string key of `opt_aref_with`

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -1058,10 +1058,16 @@ class TestZJIT < Test::Unit::TestCase
 
   def test_opt_aref_with
     assert_compiles ':ok', %q{
-      def aref_with(hash) = hash["key"]
+      def test(hash) = hash["key"]
 
-      aref_with({ "key" => :ok })
-    }
+      test({ "key" => :ok })
+    }, insns: [:opt_aref_with]
+
+    assert_compiles 'nil', %q{
+      def self.[](key) = (raise if key.frozen?)
+      def test = self["frozen string literal: false"]
+      test
+    }, insns: [:opt_aref_with]
   end
 
   def test_putself

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -246,6 +246,7 @@ fn main() {
         .allowlist_function("rb_obj_as_string_result")
         .allowlist_function("rb_str_byte_substr")
         .allowlist_function("rb_str_substr_two_fixnums")
+        .allowlist_function("rb_str_resurrect")
 
         // From include/ruby/internal/intern/parse.h
         .allowlist_function("rb_backref_get")

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -724,8 +724,8 @@ pub const DEFINED_REF: defined_type = 15;
 pub const DEFINED_FUNC: defined_type = 16;
 pub const DEFINED_CONST_FROM: defined_type = 17;
 pub type defined_type = u32;
-pub const RB_INVALID_SHAPE_ID: _bindgen_ty_38 = 4294967295;
-pub type _bindgen_ty_38 = u32;
+pub const RB_INVALID_SHAPE_ID: _bindgen_ty_12 = 4294967295;
+pub type _bindgen_ty_12 = u32;
 pub type rb_iseq_param_keyword_struct = rb_iseq_constant_body__bindgen_ty_1_rb_iseq_param_keyword;
 unsafe extern "C" {
     pub fn ruby_xfree(ptr: *mut ::std::os::raw::c_void);
@@ -818,6 +818,7 @@ unsafe extern "C" {
     ) -> VALUE;
     pub fn rb_str_buf_append(dst: VALUE, src: VALUE) -> VALUE;
     pub fn rb_str_dup(str_: VALUE) -> VALUE;
+    pub fn rb_str_resurrect(str_: VALUE) -> VALUE;
     pub fn rb_str_intern(str_: VALUE) -> VALUE;
     pub fn rb_mod_name(mod_: VALUE) -> VALUE;
     pub fn rb_ivar_get(obj: VALUE, name: ID) -> VALUE;


### PR DESCRIPTION
The immediate problem this fixes is the frozen status of the key object
in the `recv[key]` call.

This also repairs an invariant that `FrameState` should always be at a
YARV instruction boundary. It's important to have this because if a
`SendWithoutBlock` is reduced to `SendWithoutBlockDirect`, the direct
variant may want to side exit, which needs a `FrameState` as described.
