### PR TITLE
Add RubyVM::AST::Node#parent (only for NODE_SCOPE)

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -747,6 +747,21 @@ ast_node_children(rb_execution_context_t *ec, VALUE self)
     return node_children(data->ast_value, data->node);
 }
 
+static VALUE
+ast_node_parent(rb_execution_context_t *ec, VALUE self)
+{
+    struct ASTNodeData *data;
+    TypedData_Get_Struct(self, struct ASTNodeData, &rb_node_type, data);
+
+    const NODE *node = data->node;
+    if (nd_type(node) == NODE_SCOPE) {
+        return NEW_CHILD(data->ast_value, RNODE_SCOPE(node)->nd_parent);
+    }
+    else {
+        rb_raise(rb_eNotImpError, "not NODE_SCOPE");
+    }
+}
+
 static int
 null_loc_p(rb_code_location_t *loc)
 {

--- a/ast.rb
+++ b/ast.rb
@@ -218,6 +218,15 @@ module RubyVM::AbstractSyntaxTree
     end
 
     #  call-seq:
+    #     node.parent -> node
+    #
+    #  Returns the parent AST node.
+    #  Currently, it works only when the node is NODE_SCOPE.
+    def parent
+      Primitive.ast_node_parent
+    end
+
+    #  call-seq:
     #     node.inspect -> string
     #
     #  Returns debugging information about this node as a string.

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -248,6 +248,7 @@ typedef struct RNode_SCOPE {
 
     rb_ast_id_table_t *nd_tbl;
     struct RNode *nd_body;
+    struct RNode *nd_parent;
     struct RNode_ARGS *nd_args;
 } rb_node_scope_t;
 

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -526,6 +526,27 @@ class TestAst < Test::Unit::TestCase
     assert_nil(RubyVM::AbstractSyntaxTree.of(c.instance_method(:foo)))
   end
 
+  DUMMY_METHOD_FOR_TEST_PARENT = __LINE__ + 1
+  def dummy_method_for_test_parent
+  end
+
+  def test_parent
+    omit if ParserSupport.prism_enabled?
+
+    scope_node = RubyVM::AbstractSyntaxTree.of(method(:dummy_method_for_test_parent))
+    assert_equal(:SCOPE, scope_node.type)
+    def_node = scope_node.parent
+    assert_equal(DUMMY_METHOD_FOR_TEST_PARENT, def_node.first_lineno)
+
+    toplevel_node = RubyVM::AbstractSyntaxTree.parse("0")
+    assert_equal(:SCOPE, toplevel_node.type)
+    assert_nil(toplevel_node.parent)
+
+    int_node = toplevel_node.children[2]
+    assert_equal(:INTEGER, int_node.type)
+    assert_raise(NotImplementedError) { int_node.parent }
+  end
+
   def test_scope_local_variables
     node = RubyVM::AbstractSyntaxTree.parse("_x = 0")
     lv, _, body = *node.children


### PR DESCRIPTION
`RubyVM::AST.of(Method object)` returns a NODE_SCOPE node of the method. This internal API allows to get a reference to the outer NODE_DEFN (or NODE_DEFS) node.

This is preparation for [Feature #21543].