### PR TITLE
Allow to get a NODE_SCOPE node of dummy stack frame of ArgumentError

### DIFF
--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -365,6 +365,50 @@ class TestAst < Test::Unit::TestCase
     assert_equal node.node_id, node_id
   end
 
+  def add(x, y)
+  end
+
+  def test_node_id_for_backtrace_location_of_method_definition
+    omit if ParserSupport.prism_enabled?
+
+    begin
+      add(1)
+    rescue ArgumentError => exc
+      loc = exc.backtrace_locations.first
+      node_id = RubyVM::AbstractSyntaxTree.node_id_for_backtrace_location(loc)
+      node = RubyVM::AbstractSyntaxTree.of(method(:add))
+      assert_equal node.node_id, node_id
+    end
+  end
+
+  def test_node_id_for_backtrace_location_of_lambda
+    omit if ParserSupport.prism_enabled?
+
+    v = -> {}
+    begin
+      v.call(1)
+    rescue ArgumentError => exc
+      loc = exc.backtrace_locations.first
+      node_id = RubyVM::AbstractSyntaxTree.node_id_for_backtrace_location(loc)
+      node = RubyVM::AbstractSyntaxTree.of(v)
+      assert_equal node.node_id, node_id
+    end
+  end
+
+  def test_node_id_for_backtrace_location_of_lambda_method
+    omit if ParserSupport.prism_enabled?
+
+    v = lambda {}
+    begin
+      v.call(1)
+    rescue ArgumentError => exc
+      loc = exc.backtrace_locations.first
+      node_id = RubyVM::AbstractSyntaxTree.node_id_for_backtrace_location(loc)
+      node = RubyVM::AbstractSyntaxTree.of(v)
+      assert_equal node.node_id, node_id
+    end
+  end
+
   def test_node_id_for_backtrace_location_raises_argument_error
     bug19262 = '[ruby-core:111435]'
 

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -44,7 +44,7 @@ calc_pos(const rb_iseq_t *iseq, const VALUE *pc, int *lineno, int *node_id)
         }
         if (lineno) *lineno = ISEQ_BODY(iseq)->location.first_lineno;
 #ifdef USE_ISEQ_NODE_ID
-        if (node_id) *node_id = -1;
+        if (node_id) *node_id = ISEQ_BODY(iseq)->location.node_id;
 #endif
         return 1;
     }
@@ -400,7 +400,7 @@ location_path_m(VALUE self)
 static int
 location_node_id(rb_backtrace_location_t *loc)
 {
-    if (loc->iseq && loc->pc) {
+    if (loc->iseq) {
         return calc_node_id(loc->iseq, loc->pc);
     }
     return -1;


### PR DESCRIPTION
Previously, it was not possible to obtain a node of the callee's `Thread::Backtrace::Location` for cases like "wrong number of arguments" by using `RubyVM::AST.of`. This change allows that retrieval.

This is preparation for [Feature #21543].