### PR TITLE
CI: Use `nproc` to count only on-line CPUs for GNUMAKEFLAGS

### DIFF
--- a/.github/actions/compilers/entrypoint.sh
+++ b/.github/actions/compilers/entrypoint.sh
@@ -26,7 +26,7 @@ export CONFIGURE_TTY='never'
 export RUBY_DEBUG='ci rgengc'
 export RUBY_TESTOPTS='-q --color=always --tty=no'
 export RUBY_DEBUG_COUNTER_DISABLE='1'
-export GNUMAKEFLAGS="-j$((1 + $(nproc --all)))"
+export GNUMAKEFLAGS="-j$((1 + $(nproc)))"
 
 case "x${INPUT_ENABLE_SHARED}" in
 x | xno | xfalse )

--- a/.github/actions/setup/directories/action.yml
+++ b/.github/actions/setup/directories/action.yml
@@ -110,7 +110,7 @@ runs:
 
     - if: runner.os == 'Linux'
       shell: bash
-      run: echo "GNUMAKEFLAGS=-sj$((1 + $(nproc --all)))" >> "$GITHUB_ENV"
+      run: echo "GNUMAKEFLAGS=-sj$((1 + $(nproc)))" >> "$GITHUB_ENV"
 
     # macOS' GNU make is so old that they doesn't understand `GNUMAKEFLAGS`.
     - if: runner.os == 'macOS'


### PR DESCRIPTION
Use `nproc` rather than `nproc --all`. Because the number by the `nproc` is different from the number by the `nproc --all` on GitHub Actions ppc64le/s390x. This caused the `make` command runs much more jobs than the number of on-line CPUs. The make command ran 193 jobs in parallel for 4 on-line CPUs in GitHub Actions ppc64le, and ran 9 jobs in parallel for 4 on-line CPUs in GitHub Actions s390x.

And this caused the high load average 34.58 on ppc64le, and 6.69 on s390x. These values should be less than 4.0. I believe we should use the `nproc` rather than `nproc --all`.

```
+ nproc
4
+ nproc --all
192
```

```
+ nproc
4
+ nproc --all
8
```

See https://github.com/IBM/actionspz/issues/38 for details.