### PR TITLE
Fix malloc_gc_disabled in Ractor lock

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -71,7 +71,11 @@ ractor_lock(rb_ractor_t *r, const char *file, int line)
 
     ASSERT_ractor_unlocking(r);
     rb_native_mutex_lock(&r->sync.lock);
-    r->malloc_gc_disabled = true;
+
+    if (rb_current_execution_context(false)) {
+        VM_ASSERT(!GET_RACTOR()->malloc_gc_disabled);
+        GET_RACTOR()->malloc_gc_disabled = true;
+    }
 
 #if RACTOR_CHECK_MODE > 0
     if (rb_current_execution_context(false) != NULL) {
@@ -101,9 +105,11 @@ ractor_unlock(rb_ractor_t *r, const char *file, int line)
     r->sync.locked_by = Qnil;
 #endif
 
-    VM_ASSERT(r->malloc_gc_disabled);
+    if (rb_current_execution_context(false)) {
+        VM_ASSERT(GET_RACTOR()->malloc_gc_disabled);
+        GET_RACTOR()->malloc_gc_disabled = false;
+    }
 
-    r->malloc_gc_disabled = false;
     rb_native_mutex_unlock(&r->sync.lock);
 
     RUBY_DEBUG_LOG2(file, line, "r:%u%s", r->pub.id, rb_current_ractor_raw(false) == r ? " (self)" : "");


### PR DESCRIPTION
We should disable GC for malloc for the current Ractor instead of the locked Ractor because it's the current Ractor that could run code that mallocs.

cc. @jhawthorn 