### PR TITLE
Fix uninitialized next_shape_id

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -4490,13 +4490,13 @@ class_fields_ivar_set(VALUE klass, VALUE fields_obj, ID id, VALUE val, bool conc
     fields_obj = original_fields_obj ? original_fields_obj : rb_imemo_fields_new(klass, 1);
 
     shape_id_t current_shape_id = RBASIC_SHAPE_ID(fields_obj);
-
+    shape_id_t next_shape_id = current_shape_id; // for too_complex
     if (UNLIKELY(rb_shape_too_complex_p(current_shape_id))) {
         goto too_complex;
     }
 
     bool new_ivar;
-    shape_id_t next_shape_id = generic_shape_ivar(fields_obj, id, &new_ivar);
+    next_shape_id = generic_shape_ivar(fields_obj, id, &new_ivar);
 
     if (UNLIKELY(rb_shape_too_complex_p(next_shape_id))) {
         fields_obj = imemo_fields_complex_from_obj(klass, fields_obj, next_shape_id);


### PR DESCRIPTION
This fixes a `-Wmaybe-uninitialized` warning introduced at https://github.com/ruby/ruby/pull/14327

```
In file included from ../internal/variable.h:16,
                 from ../internal/class.h:16,
                 from ../variable.c:23:
In function ‘RBASIC_SET_SHAPE_ID’,
    inlined from ‘class_fields_ivar_set’ at ../variable.c:4599:13,
    inlined from ‘rb_class_ivar_set’ at ../variable.c:4618:21:
../shape.h:174:28: warning: ‘next_shape_id’ may be used uninitialized [-Wmaybe-uninitialized]
  174 |     RBASIC(obj)->flags |= ((VALUE)(shape_id) << SHAPE_FLAG_SHIFT);
      |                            ^~~~~~~~~~~~~~~~~
../variable.c: In function ‘rb_class_ivar_set’:
../variable.c:4548:16: note: ‘next_shape_id’ was declared here
 4548 |     shape_id_t next_shape_id = generic_shape_ivar(fields_obj, id, &new_ivar);
      |                ^~~~~~~~~~~~~
```

FYI @byroot 