### PR TITLE
Fix -Wcomment warnings from rbs

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -18,7 +18,7 @@ net-pop             0.1.2   https://github.com/ruby/net-pop
 net-smtp            0.5.1   https://github.com/ruby/net-smtp
 matrix              0.4.3   https://github.com/ruby/matrix
 prime               0.1.4   https://github.com/ruby/prime
-rbs                 3.9.4   https://github.com/ruby/rbs fba1f778b7eff01dde5e3d886e850f7eea018f2b
+rbs                 3.9.4   https://github.com/ruby/rbs 368bf4b1ab52a9335e2022618ac4545a4d9cacdf
 typeprof            0.30.1  https://github.com/ruby/typeprof
 debug               1.11.0  https://github.com/ruby/debug
 racc                1.8.1   https://github.com/ruby/racc


### PR DESCRIPTION
This PR fixes the following warning by pushing https://github.com/ruby/rbs/pull/2646 to the rbs branch used by `gems/bundled_gems`.

```
../../../../../../.bundle/gems/rbs-3.9.4/ext/rbs_extension/main.c: In function ‘Init_rbs_extension’:
../../../../../../.bundle/gems/rbs-3.9.4/ext/rbs_extension/main.c:24:3: warning: multi-line comment [-Wcomment]
   24 |   // grep -o 'INTERN("\([^"]*\)")' ext/rbs_extension/parser.c \
      |   ^
```

FYI @soutaro 