### PR TITLE
ZJIT: Canonicalize --zjit-log-compiled-iseqs filename

### DIFF
--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -59,7 +59,7 @@ pub struct Options {
     pub allowed_iseqs: Option<HashSet<String>>,
 
     /// Path to a file where compiled ISEQs will be saved.
-    pub log_compiled_iseqs: Option<String>,
+    pub log_compiled_iseqs: Option<std::path::PathBuf>,
 }
 
 impl Default for Options {
@@ -242,7 +242,8 @@ fn parse_option(str_ptr: *const std::os::raw::c_char) -> Option<()> {
                 .open(opt_val)
                 .map_err(|e| eprintln!("Failed to open file '{}': {}", opt_val, e))
                 .ok();
-            options.log_compiled_iseqs = Some(opt_val.into());
+            let opt_val = std::fs::canonicalize(opt_val).unwrap_or_else(|_| opt_val.into());
+            options.log_compiled_iseqs = Some(opt_val);
         }
 
         _ => return None, // Option name not recognized

--- a/zjit/src/state.rs
+++ b/zjit/src/state.rs
@@ -155,12 +155,12 @@ impl ZJITState {
         let mut file = match std::fs::OpenOptions::new().create(true).append(true).open(filename) {
             Ok(f) => f,
             Err(e) => {
-                eprintln!("ZJIT: Failed to create file '{}': {}", filename, e);
+                eprintln!("ZJIT: Failed to create file '{}': {}", filename.display(), e);
                 return;
             }
         };
         if let Err(e) = writeln!(file, "{}", iseq_name) {
-            eprintln!("ZJIT: Failed to write to file '{}': {}", filename, e);
+            eprintln!("ZJIT: Failed to write to file '{}': {}", filename.display(), e);
         }
     }
 


### PR DESCRIPTION
This fixes issues related to the process changing directory and not
having only a relative path.

Thanks, Alan.
