### PR TITLE
Build ppc64le and s390x jobs in a separate workflow

### DIFF
--- a/.github/workflows/ubuntu-ibm.yml
+++ b/.github/workflows/ubuntu-ibm.yml
@@ -1,4 +1,4 @@
-name: Ubuntu
+name: Ubuntu IBM
 on:
   push:
     paths-ignore:
@@ -28,8 +28,6 @@ jobs:
         configure: ['']
         arch: ['']
         os:
-          - ubuntu-24.04
-          - ubuntu-24.04-arm
           # FIXME Comment out ppc64le due to failing tests on GitHub Actions
           # ppc64le
           # https://bugs.ruby-lang.org/issues/21534
@@ -40,18 +38,6 @@ jobs:
         # https://github.com/IBM/actionspz/blob/main/docs/FAQ.md#what-about-forked-repos
         upstream:
           - ${{ github.repository == 'ruby/ruby' }}
-        include:
-          - test_task: check
-            configure: 'cppflags=-DVM_CHECK_MODE'
-          - test_task: check
-            arch: i686
-          - test_task: check
-            configure: '--disable-yjit'
-          - test_task: check
-            configure: '--enable-shared --enable-load-relative'
-          - test_task: test-bundler-parallel
-            timeout: 50
-          - test_task: test-bundled-gems
         exclude:
           - os: ubuntu-24.04-ppc64le
             upstream: false
@@ -201,16 +187,6 @@ jobs:
           label: ${{ matrix.test_task }} ${{ matrix.configure }}${{ matrix.arch }}
           SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
         if: ${{ failure() }}
-
-  result:
-    if: ${{ always() }}
-    name: ${{ github.workflow }} result
-    runs-on: ubuntu-latest
-    needs: [make]
-    steps:
-      - run: exit 1
-        working-directory:
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
 
 defaults:
   run:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -24,6 +24,7 @@ jobs:
   make:
     strategy:
       matrix:
+        # We enumerate every job in matrix.include to save build time
         include:
           - test_task: check
             configure: 'cppflags=-DVM_CHECK_MODE'


### PR DESCRIPTION
## Description
IBM-sponsored environments (s390x in particular) seem to have a significantly lower capacity compared to publicly-available ones (there's a job not starting after 1h). Because it's currently part of `ubuntu.yml`, a required status check, it's preventing pull requests from being auto-merged quickly.

To address this issue, this PR removes these jobs from the required status check.

<img width="704" height="470" alt="Screenshot 2025-08-26 at 11 40 17" src="https://github.com/user-attachments/assets/01bd401c-f859-42ac-9a78-7dc348f5cdc6" />

## Note
We deliberately avoided using matrix builds and enumerated every job for `ubuntu.yml` to save CI time https://github.com/ruby/ruby/pull/10327. https://github.com/ruby/ruby/pull/13972 introduced matrix builds again for using `excludes`, but the requirement of `excludes` is very specific to IBM jobs, so separating them into a separate workflow allows us to stay away from matrix builds in `ubuntu.yml`.

https://github.com/ruby/ruby/pull/13972 also added a non-trivial amount of s390x/ppc64le-specific steps, so it deserves a separate workflow from that point of view as well.