### PR TITLE
Make `RubyVM::AST.of` return a parent node of NODE_SCOPE

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -9221,6 +9221,7 @@ compile_builtin_mandatory_only_method(rb_iseq_t *iseq, const NODE *node, const N
     rb_node_init(RNODE(&scope_node), NODE_SCOPE);
     scope_node.nd_tbl = tbl;
     scope_node.nd_body = mandatory_node(iseq, node);
+    scope_node.nd_parent = NULL;
     scope_node.nd_args = &args_node;
 
     VALUE ast_value = rb_ruby_ast_new(RNODE(&scope_node));

--- a/iseq.c
+++ b/iseq.c
@@ -634,6 +634,18 @@ new_arena(void)
     return new_arena;
 }
 
+static int
+prepare_node_id(const NODE *node)
+{
+    if (!node) return -1;
+
+    if (nd_type(node) == NODE_SCOPE && RNODE_SCOPE(node)->nd_parent) {
+        return nd_node_id(RNODE_SCOPE(node)->nd_parent);
+    }
+
+    return nd_node_id(node);
+}
+
 static VALUE
 prepare_iseq_build(rb_iseq_t *iseq,
                    VALUE name, VALUE path, VALUE realpath, int first_lineno, const rb_code_location_t *code_location, const int node_id,
@@ -1031,7 +1043,7 @@ rb_iseq_new_with_opt(VALUE ast_value, VALUE name, VALUE path, VALUE realpath,
         script_lines = ISEQ_BODY(parent)->variable.script_lines;
     }
 
-    prepare_iseq_build(iseq, name, path, realpath, first_lineno, node ? &node->nd_loc : NULL, node ? nd_node_id(node) : -1,
+    prepare_iseq_build(iseq, name, path, realpath, first_lineno, node ? &node->nd_loc : NULL, prepare_node_id(node),
                        parent, isolated_depth, type, script_lines, option);
 
     rb_iseq_compile_node(iseq, node);

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -248,6 +248,7 @@ typedef struct RNode_SCOPE {
 
     rb_ast_id_table_t *nd_tbl;
     struct RNode *nd_body;
+    struct RNode *nd_parent;
     struct RNode_ARGS *nd_args;
 } rb_node_scope_t;
 

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -801,7 +801,7 @@ dummy
     node_proc = RubyVM::AbstractSyntaxTree.of(proc, keep_script_lines: true)
     node_method = RubyVM::AbstractSyntaxTree.of(method, keep_script_lines: true)
 
-    assert_equal("{ 1 + 2 }", node_proc.source)
+    assert_equal("Proc.new { 1 + 2 }", node_proc.source)
     assert_equal("def test_keep_script_lines_for_of\n", node_method.source.lines.first)
   end
 
@@ -878,7 +878,7 @@ dummy
     omit if ParserSupport.prism_enabled? || ParserSupport.prism_enabled_in_subprocess?
 
     assert_in_out_err(["-e", "def foo; end; pp RubyVM::AbstractSyntaxTree.of(method(:foo)).type"],
-                      "", [":SCOPE"], [])
+                      "", [":DEFN"], [])
   end
 
   def test_error_tolerant

--- a/vm.c
+++ b/vm.c
@@ -1541,6 +1541,7 @@ rb_binding_add_dynavars(VALUE bindval, rb_binding_t *bind, int dyncount, const I
     rb_node_init(RNODE(&tmp_node), NODE_SCOPE);
     tmp_node.nd_tbl = dyns;
     tmp_node.nd_body = 0;
+    tmp_node.nd_parent = NULL;
     tmp_node.nd_args = 0;
 
     VALUE ast_value = rb_ruby_ast_new(RNODE(&tmp_node));


### PR DESCRIPTION
This change makes `RubyVM::AST.of` and `.node_id_for_backtrace_location` return a parent node of NODE_SCOPE (such as NODE_DEFN) instead of the NODE_SCOPE node itself.
(In future, we may remove NODE_SCOPE, which is a bit hacky AST node.)

This is preparation for [Feature #21543].