### PR TITLE
Populate ivar caches for types other than T_OBJECT

### DIFF
--- a/benchmark/vm_ivar_set_on_instance.yml
+++ b/benchmark/vm_ivar_set_on_instance.yml
@@ -1,16 +1,44 @@
 prelude: |
   class TheClass
     def initialize
+      @levar = 1
       @v0 = 1
       @v1 = 2
       @v3 = 3
-      @levar = 1
     end
 
     def set_value_loop
-      # 1M
+      # 100k
       i = 0
-      while i < 1000000
+      while i < 100_000
+        # 10 times to de-emphasize loop overhead
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        i += 1
+      end
+    end
+  end
+
+  class Generic < Time
+    def initialize
+      @levar = 1
+      @v0 = 1
+      @v1 = 2
+      @v3 = 3
+    end
+
+    def set_value_loop
+      # 100k
+      i = 0
+      while i < 100_000
         # 10 times to de-emphasize loop overhead
         @levar = i
         @levar = i
@@ -28,8 +56,39 @@ prelude: |
   end
 
   obj = TheClass.new
+  gen_obj = Generic.new
+
+  class SomeClass
+    @levar = 1
+    @v0 = 1
+    @v1 = 2
+    @v3 = 3
+
+    def self.set_value_loop
+      # 100k
+      i = 0
+      while i < 100_000
+        # 10 times to de-emphasize loop overhead
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        @levar = i
+        i += 1
+      end
+    end
+  end
 
 benchmark:
   vm_ivar_set_on_instance: |
     obj.set_value_loop
+  vm_ivar_set_on_generic: |
+    gen_obj.set_value_loop
+  vm_ivar_set_on_class: |
+    SomeClass.set_value_loop
 loop_count: 100

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -51,7 +51,8 @@ void rb_obj_init_too_complex(VALUE obj, st_table *table);
 void rb_evict_ivars_to_hash(VALUE obj);
 VALUE rb_obj_field_get(VALUE obj, shape_id_t target_shape_id);
 void rb_ivar_set_internal(VALUE obj, ID id, VALUE val);
-void rb_obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val);
+attr_index_t rb_ivar_set_index(VALUE obj, ID id, VALUE val);
+attr_index_t rb_obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* variable.c (export) */
@@ -67,6 +68,5 @@ VALUE rb_gvar_set(ID, VALUE);
 VALUE rb_gvar_defined(ID);
 void rb_const_warn_if_deprecated(const rb_const_entry_t *, VALUE, ID);
 void rb_ensure_iv_list_size(VALUE obj, uint32_t current_len, uint32_t newsize);
-attr_index_t rb_obj_ivar_set(VALUE obj, ID id, VALUE val);
 
 #endif /* INTERNAL_VARIABLE_H */

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -388,6 +388,61 @@ class TestVariable < Test::Unit::TestCase
     end
   end
 
+  class RemoveIvar
+    class << self
+      attr_reader :ivar
+
+      def add_ivar
+        @ivar = 1
+      end
+    end
+
+    attr_reader :ivar
+
+    def add_ivar
+      @ivar = 1
+    end
+  end
+
+  def add_and_remove_ivar(obj)
+    assert_nil obj.ivar
+    assert_equal 1, obj.add_ivar
+    assert_equal 1, obj.instance_variable_get(:@ivar)
+    assert_equal 1, obj.ivar
+
+    obj.remove_instance_variable(:@ivar)
+    assert_nil obj.ivar
+
+    assert_raise NameError do
+      obj.remove_instance_variable(:@ivar)
+    end
+  end
+
+  def test_remove_instance_variables_object
+    obj = RemoveIvar.new
+    add_and_remove_ivar(obj)
+    add_and_remove_ivar(obj)
+  end
+
+  def test_remove_instance_variables_class
+    add_and_remove_ivar(RemoveIvar)
+    add_and_remove_ivar(RemoveIvar)
+  end
+
+  class RemoveIvarGeneric < Array
+    attr_reader :ivar
+
+    def add_ivar
+      @ivar = 1
+    end
+  end
+
+  def test_remove_instance_variables_generic
+    obj = RemoveIvarGeneric.new
+    add_and_remove_ivar(obj)
+    add_and_remove_ivar(obj)
+  end
+
   class ExIvar < Hash
     def initialize
       @a = 1


### PR DESCRIPTION
`vm_setinstancevariable` had a codepath to try to match the inline cache for types other than T_OBJECT, but the cache population path in `vm_setivar_slowpath` was exclusive to T_OBJECT, so `vm_setivar_default` would never match anything.

This commit improves `vm_setivar_slowpath` so that it is capable of filling the cache for all types, and adds a `vm_setivar_class` codepath for `T_CLASS` and `T_MODULE`.

`vm_setivar`, `vm_setivar_default` and `vm_setivar_class` could be unified, but based on the very explicit `NOINLINE` I assume they were split to minimize codesize.

```
compare-ruby: ruby 3.5.0dev (2025-08-27T14:58:58Z merge-vm-setivar-d.. 5b749d8e53) +PRISM [arm64-darwin24]
built-ruby: ruby 3.5.0dev (2025-08-27T16:30:31Z setivar-cache-gene.. 4fe78ff296) +PRISM [arm64-darwin24]
# Iteration per second (i/s)

|                         |compare-ruby|built-ruby|
|:------------------------|-----------:|---------:|
|vm_ivar_set_on_instance  |     161.809|   164.688|
|                         |           -|     1.02x|
|vm_ivar_set_on_generic   |      58.769|   115.638|
|                         |           -|     1.97x|
|vm_ivar_set_on_class     |      70.034|   141.042|
|                         |           -|     2.01x|
```