### PR TITLE
ZJIT: Introduce SCRATCH2 for IncrCounter on arm64

### DIFF
--- a/zjit/src/asm/arm64/opnd.rs
+++ b/zjit/src/asm/arm64/opnd.rs
@@ -112,6 +112,7 @@ pub const X14_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 14 };
 pub const X15_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 15 };
 pub const X16_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 16 };
 pub const X17_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 17 };
+pub const X18_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 18 };
 
 // callee-save registers
 pub const X19_REG: A64Reg = A64Reg { num_bits: 64, reg_no: 19 };
@@ -145,9 +146,9 @@ pub const X12: A64Opnd = A64Opnd::Reg(X12_REG);
 pub const X13: A64Opnd = A64Opnd::Reg(X13_REG);
 pub const X14: A64Opnd = A64Opnd::Reg(X14_REG);
 pub const X15: A64Opnd = A64Opnd::Reg(X15_REG);
-pub const X16: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 16 });
-pub const X17: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 17 });
-pub const X18: A64Opnd = A64Opnd::Reg(A64Reg { num_bits: 64, reg_no: 18 });
+pub const X16: A64Opnd = A64Opnd::Reg(X16_REG);
+pub const X17: A64Opnd = A64Opnd::Reg(X17_REG);
+pub const X18: A64Opnd = A64Opnd::Reg(X18_REG);
 pub const X19: A64Opnd = A64Opnd::Reg(X19_REG);
 pub const X20: A64Opnd = A64Opnd::Reg(X20_REG);
 pub const X21: A64Opnd = A64Opnd::Reg(X21_REG);

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -836,8 +836,6 @@ impl Assembler
 
                 // Atomically increment a counter at a given memory location
                 Insn::IncrCounter { mem, value } => {
-                    assert!(matches!(mem, Opnd::Mem(_)));
-                    assert!(matches!(value, Opnd::UImm(_) | Opnd::Imm(_) ) );
                     write_lock_prefix(cb);
                     add(cb, mem.into(), value.into());
                 },


### PR DESCRIPTION
This PR addresses Max's suggestion at https://github.com/ruby/ruby/pull/14357#discussion_r2302699921.

Adding `SCRATCH2` allows `arm64_emit` to emit `IncrCounter` without relying on `arm64_split`, which lets `compile_side_exits` remove the `cfg!(target_arch = "aarch64")` branch. I don't think taking `Opnd::const_ptr` in `IncrCounter` as Max suggested isn't worth it, which will duplicate more code in `arm64_emit`, so it still takes `Opnd::Mem`.

It generally doesn't seem like a good idea to waste a register when you can save it with no run-time overhead, especially when it's for `--zjit-stats`. But at the same time, it seems useful to remove an extra register pressure that the other architecture doesn't have for the same LIR instruction.

`x18` is a platform register. Since we control the use of every register in JIT code, it seems safe to use it as an extra caller-saved register. We don't seem to have any more caller-saved registers.