### PR TITLE
Backport vcpkg related improvement to `ruby_3_4`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -113,6 +113,7 @@ jobs:
         shell: pwsh
 
       - name: Restore vcpkg artifact
+        id: restore-vcpkg
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: src\vcpkg_installed
@@ -122,13 +123,14 @@ jobs:
         run: |
           vcpkg install --vcpkg-root=C:\Users\runneradmin\scoop\apps\vcpkg\current
         working-directory: src
+        if: ${{ ! steps.restore-vcpkg.outputs.cache-hit }}
 
       - name: Save vcpkg artifact
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: src\vcpkg_installed
           key: windows-${{ matrix.os }}-vcpkg-${{ hashFiles('src/vcpkg.json') }}
-        if: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'ruby_') }}
+        if: ${{ ! steps.restore-vcpkg.outputs.cache-hit && (github.ref_name == 'master' || startsWith(github.ref_name, 'ruby_')) }}
 
       - name: setup env
         # Available Ruby versions: https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md#ruby

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -128,6 +128,7 @@ jobs:
         with:
           path: src\vcpkg_installed
           key: windows-${{ matrix.os }}-vcpkg-${{ hashFiles('src/vcpkg.json') }}
+        if: ${{ github.ref_name == 'master' || startsWith(github.ref_name, 'ruby_') }}
 
       - name: setup env
         # Available Ruby versions: https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md#ruby

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -144,8 +144,8 @@ jobs:
           set | C:\msys64\usr\bin\sort > old.env
           call %VCVARS% ${{ matrix.vcvars || '' }}
           nmake -f nul
-          set TMP=%USERPROFILE%\AppData\Local\Temp
-          set TEMP=%USERPROFILE%\AppData\Local\Temp
+          set TMP=%RUNNER_TEMP%
+          set TEMP=%RUNNER_TEMP%
           set MAKEFLAGS=l
           set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul
           set RUBY_OPT_DIR=%GITHUB_WORKSPACE:\=/%/src/vcpkg_installed/%VCPKG_DEFAULT_TRIPLET%


### PR DESCRIPTION
We gave up to tweak cache management by vcpkg.

These commits make to skip vcpkg build when `actions/cache` detect the past artifacts by vcpkg and only save the new artifacts to `actions/cache`.

And I suggest to backport to detect TEMP dir by `RUNNER_TEMP` instead by hard coded path.