### PR TITLE
Abandon `ruby` target on the others than GNU make

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4699,21 +4699,7 @@ AC_CONFIG_FILES(Makefile:template/Makefile.in, [
 
 	echo; echo '$(srcdir)/$(CONFIGURE):RUBY_M4_INCLUDED \
 	$(empty)'
-    } > $tmpmk && AS_IF([! grep '^ruby:' $tmpmk > /dev/null], [
-	AS_IF([test "${gnumake}" = yes], [
-	    tmpgmk=confgmk$$.tmp
-	    {
-		echo "include $tmpmk"
-		echo "-include uncommon.mk"
-	    } > $tmpgmk
-	], [
-	    tmpgmk=$tmpmk
-	]) &&
-	test -z "`${MAKE-make} -f $tmpgmk info-program | grep '^PROGRAM=ruby$'`" &&
-	echo 'ruby: $(PROGRAM);' >> $tmpmk
-	rm -f uncommon.mk # remove stale uncommon.mk, it should be updated by GNUmakefile
-	test "$tmpmk" = "$tmpgmk" || rm -f "$tmpgmk"
-    ]) && mv -f $tmpmk Makefile],
+    } > $tmpmk && mv -f $tmpmk Makefile],
 [EXEEXT='$EXEEXT' MAKE='${MAKE-make}' gnumake='$gnumake' GIT='$GIT' YJIT_SUPPORT='$YJIT_SUPPORT'])
 
 AC_ARG_WITH([ruby-pc],

--- a/defs/gmake.mk
+++ b/defs/gmake.mk
@@ -161,6 +161,10 @@ endif
 
 config.status: $(wildcard config.cache)
 
+ifneq (ruby,$(PROGRAM))
+ruby: $(PROGRAM);
+endif
+
 STUBPROGRAM = rubystub$(EXEEXT)
 IGNOREDPATTERNS = %~ .% %.orig %.rej \#%\#
 SCRIPTBINDIR := $(if $(EXEEXT),,exec/)

--- a/win32/Makefile.sub
+++ b/win32/Makefile.sub
@@ -540,6 +540,7 @@ ECHO_END =
 all: $(srcdir)/win32/Makefile.sub $(win_srcdir)/Makefile.sub $(srcdir)/common.mk $(srcdir)/depend
 prog: config
 
+# The default non-transformed names without $(EXEEXT).
 ruby: $(PROGRAM)
 rubyw: $(WPROGRAM)
 stub: $(STUBPROGRAM)


### PR DESCRIPTION
The default non-transformed name, `ruby` target was added for the case of `--program-transform-name` and similars, but it was occasionally added even when no such option is used.