### PR TITLE
ZJIT: Disable profiling in compile_iseq

### DIFF
--- a/zjit.c
+++ b/zjit.c
@@ -165,9 +165,6 @@ rb_zjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit
     RB_VM_LOCKING() {
         rb_vm_barrier();
 
-        // Convert ZJIT instructions back to bare instructions
-        rb_zjit_profile_disable(iseq);
-
         // Compile a block version starting at the current instruction
         uint8_t *rb_zjit_iseq_gen_entry_point(const rb_iseq_t *iseq, rb_execution_context_t *ec); // defined in Rust
         uintptr_t code_ptr = (uintptr_t)rb_zjit_iseq_gen_entry_point(iseq, ec);

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1369,6 +1369,9 @@ pub fn local_size_and_idx_to_bp_offset(local_size: usize, local_idx: usize) -> i
 
 /// Convert ISEQ into High-level IR
 fn compile_iseq(iseq: IseqPtr) -> Option<Function> {
+    // Convert ZJIT instructions back to bare instructions
+    unsafe { crate::cruby::rb_zjit_profile_disable(iseq) };
+
     // Reject ISEQs with very large temp stacks.
     // We cannot encode too large offsets to access locals in arm64.
     let stack_max = unsafe { rb_get_iseq_body_stack_max(iseq) };


### PR DESCRIPTION
This catches both the interpreter-JIT and JIT-JIT cases.

Fixes https://github.com/Shopify/ruby/issues/719
