### PR TITLE
ZJIT: Prepare getglobal for non-leaf call

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -78,6 +78,27 @@ class TestZJIT < Test::Unit::TestCase
     }
   end
 
+  def test_getglobal_with_warning
+    assert_compiles('"rescued"', %q{
+      Warning[:deprecated] = true
+
+      module Warning
+        def warn(message)
+          raise
+        end
+      end
+
+      def test
+        $=
+      rescue
+        "rescued"
+      end
+
+      $VERBOSE = true
+      test
+    }, insns: [:getglobal])
+  end
+
   def test_setglobal
     assert_compiles '1', %q{
       def test


### PR DESCRIPTION
Depending on the user's warning level, getting certain global variables may lead to calling `Warning#warn`, which can be redefined by the user.

This fixes another `bootstraptest/test_yjit.rb` failure.