### PR TITLE
YJIT: getinstancevariable cache indexes for types other than T_OBJECT

### DIFF
--- a/benchmark/vm_ivar_get.yml
+++ b/benchmark/vm_ivar_get.yml
@@ -1,17 +1,75 @@
 prelude: |
   class Example
     def initialize
+      @levar = 1
       @v0 = 1
       @v1 = 2
       @v3 = 3
-      @levar = 1
     end
 
     def get_value_loop
       sum = 0
 
       i = 0
-      while i < 1000000
+      while i < 100_000
+        # 10 times to de-emphasize loop overhead
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        i += 1
+      end
+
+      return sum
+    end
+
+    @levar = 1
+    @v0 = 1
+    @v1 = 2
+    @v3 = 3
+
+    def self.get_value_loop
+      sum = 0
+
+      i = 0
+      while i < 100_000
+        # 10 times to de-emphasize loop overhead
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        sum += @levar
+        i += 1
+      end
+
+      return sum
+    end
+  end
+
+  class GenExample < Time
+    def initialize
+      @levar = 1
+      @v0 = 1
+      @v1 = 2
+      @v3 = 3
+    end
+
+    def get_value_loop
+      sum = 0
+
+      i = 0
+      while i < 100_000
         # 10 times to de-emphasize loop overhead
         sum += @levar
         sum += @levar
@@ -31,7 +89,12 @@ prelude: |
   end
 
   obj = Example.new
+  gen = GenExample.new
 benchmark:
-  vm_ivar_get: |
+  vm_ivar_get_on_obj: |
     obj.get_value_loop
+  vm_ivar_get_on_class: |
+    Example.get_value_loop
+  vm_ivar_get_on_generic: |
+    gen.get_value_loop
 loop_count: 100

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -54,6 +54,7 @@ void rb_ivar_set_internal(VALUE obj, ID id, VALUE val);
 attr_index_t rb_ivar_set_index(VALUE obj, ID id, VALUE val);
 attr_index_t rb_obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val);
 VALUE rb_ivar_get_at(VALUE obj, attr_index_t index, ID id);
+VALUE rb_ivar_get_at_no_ractor_check(VALUE obj, attr_index_t index);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* variable.c (export) */

--- a/internal/variable.h
+++ b/internal/variable.h
@@ -53,6 +53,7 @@ VALUE rb_obj_field_get(VALUE obj, shape_id_t target_shape_id);
 void rb_ivar_set_internal(VALUE obj, ID id, VALUE val);
 attr_index_t rb_ivar_set_index(VALUE obj, ID id, VALUE val);
 attr_index_t rb_obj_field_set(VALUE obj, shape_id_t target_shape_id, ID field_name, VALUE val);
+VALUE rb_ivar_get_at(VALUE obj, attr_index_t index, ID id);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* variable.c (export) */

--- a/shape.h
+++ b/shape.h
@@ -24,6 +24,7 @@ STATIC_ASSERT(shape_id_num_bits, SHAPE_ID_NUM_BITS == sizeof(shape_id_t) * CHAR_
 //              index in rb_shape_tree.shape_list. Allow to access `rb_shape_t *`.
 //      19-21 SHAPE_ID_HEAP_INDEX_MASK
 //              index in rb_shape_tree.capacities. Allow to access slot size.
+//              Always 0 except for T_OBJECT.
 //      22 SHAPE_ID_FL_FROZEN
 //              Whether the object is frozen or not.
 //      23 SHAPE_ID_FL_HAS_OBJECT_ID

--- a/variable.c
+++ b/variable.c
@@ -1494,6 +1494,26 @@ rb_ivar_get_at(VALUE obj, attr_index_t index, ID id)
 }
 
 VALUE
+rb_ivar_get_at_no_ractor_check(VALUE obj, attr_index_t index)
+{
+    // Used by JITs, but never for T_OBJECT.
+
+    VALUE fields_obj;
+    switch (BUILTIN_TYPE(obj)) {
+      case T_OBJECT:
+        UNREACHABLE_RETURN(Qundef);
+      case T_CLASS:
+      case T_MODULE:
+        fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(obj);
+        break;
+      default:
+        fields_obj = rb_obj_fields_no_ractor_check(obj);
+        break;
+    }
+    return rb_imemo_fields_ptr(fields_obj)[index];
+}
+
+VALUE
 rb_attr_get(VALUE obj, ID id)
 {
     return rb_ivar_lookup(obj, id, Qnil);

--- a/variable.c
+++ b/variable.c
@@ -1464,6 +1464,36 @@ rb_ivar_get(VALUE obj, ID id)
 }
 
 VALUE
+rb_ivar_get_at(VALUE obj, attr_index_t index, ID id)
+{
+    RUBY_ASSERT(rb_is_instance_id(id));
+    // Used by JITs, but never for T_OBJECT.
+
+    switch (BUILTIN_TYPE(obj)) {
+      case T_OBJECT:
+        UNREACHABLE_RETURN(Qundef);
+      case T_CLASS:
+      case T_MODULE:
+        {
+            VALUE fields_obj = RCLASS_WRITABLE_FIELDS_OBJ(obj);
+            VALUE val = rb_imemo_fields_ptr(fields_obj)[index];
+
+            if (UNLIKELY(!rb_ractor_main_p()) && !rb_ractor_shareable_p(val)) {
+                rb_raise(rb_eRactorIsolationError,
+                        "can not get unshareable values from instance variables of classes/modules from non-main Ractors");
+            }
+
+            return val;
+        }
+      default:
+        {
+            VALUE fields_obj = rb_obj_fields(obj, id);
+            return rb_imemo_fields_ptr(fields_obj)[index];
+        }
+    }
+}
+
+VALUE
 rb_attr_get(VALUE obj, ID id)
 {
     return rb_ivar_lookup(obj, id, Qnil);

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -313,6 +313,7 @@ fn main() {
 
         // From yjit.c
         .allowlist_function("rb_object_shape_count")
+        .allowlist_function("rb_ivar_get_at")
         .allowlist_function("rb_iseq_(get|set)_yjit_payload")
         .allowlist_function("rb_iseq_pc_at_idx")
         .allowlist_function("rb_iseq_opcode_at_pc")

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -314,6 +314,7 @@ fn main() {
         // From yjit.c
         .allowlist_function("rb_object_shape_count")
         .allowlist_function("rb_ivar_get_at")
+        .allowlist_function("rb_ivar_get_at_no_ractor_check")
         .allowlist_function("rb_iseq_(get|set)_yjit_payload")
         .allowlist_function("rb_iseq_pc_at_idx")
         .allowlist_function("rb_iseq_opcode_at_pc")

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2947,11 +2947,13 @@ fn gen_get_ivar(
             } else {
                 asm_comment!(asm, "call rb_ivar_get_at()");
 
-                if !assume_single_ractor_mode(jit, asm) {
+                if assume_single_ractor_mode(jit, asm) {
+                    asm.ccall(rb_ivar_get_at_no_ractor_check as *const u8, vec![recv, Opnd::UImm((ivar_index as u32).into())])
+                } else {
                     // The function could raise RactorIsolationError.
                     jit_prepare_non_leaf_call(jit, asm);
+                    asm.ccall(rb_ivar_get_at as *const u8, vec![recv, Opnd::UImm((ivar_index as u32).into()), Opnd::UImm(ivar_name)])
                 }
-                asm.ccall(rb_ivar_get_at as *const u8, vec![recv, Opnd::UImm((ivar_index as u32).into()), Opnd::UImm(ivar_name)])
             };
 
             // Push the ivar on the stack

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2947,8 +2947,10 @@ fn gen_get_ivar(
             } else {
                 asm_comment!(asm, "call rb_ivar_get_at()");
 
-                // The function could raise RactorIsolationError.
-                jit_prepare_non_leaf_call(jit, asm);
+                if !assume_single_ractor_mode(jit, asm) {
+                    // The function could raise RactorIsolationError.
+                    jit_prepare_non_leaf_call(jit, asm);
+                }
                 asm.ccall(rb_ivar_get_at as *const u8, vec![recv, Opnd::UImm((ivar_index as u32).into()), Opnd::UImm(ivar_name)])
             };
 

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1115,6 +1115,7 @@ extern "C" {
     pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_transition_add_ivar_no_warnings(obj: VALUE, id: ID) -> shape_id_t;
+    pub fn rb_ivar_get_at(obj: VALUE, index: attr_index_t, id: ID) -> VALUE;
     pub fn rb_gvar_get(arg1: ID) -> VALUE;
     pub fn rb_gvar_set(arg1: ID, arg2: VALUE) -> VALUE;
     pub fn rb_ensure_iv_list_size(obj: VALUE, current_len: u32, newsize: u32);

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1116,6 +1116,7 @@ extern "C" {
     pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_transition_add_ivar_no_warnings(obj: VALUE, id: ID) -> shape_id_t;
     pub fn rb_ivar_get_at(obj: VALUE, index: attr_index_t, id: ID) -> VALUE;
+    pub fn rb_ivar_get_at_no_ractor_check(obj: VALUE, index: attr_index_t) -> VALUE;
     pub fn rb_gvar_get(arg1: ID) -> VALUE;
     pub fn rb_gvar_set(arg1: ID, arg2: VALUE) -> VALUE;
     pub fn rb_ensure_iv_list_size(obj: VALUE, current_len: u32, newsize: u32);


### PR DESCRIPTION
Based on https://github.com/ruby/ruby/pull/14383

While accessing the ivars of other types is too complicated to realistically generate the ASM for it, we can at least provide the ivar index as to not have to lookup the shape tree every time.

```
compare-ruby: ruby 3.5.0dev (2025-08-27T14:58:58Z merge-vm-setivar-d.. 5b749d8e53) +YJIT +PRISM [arm64-darwin24]
built-ruby: ruby 3.5.0dev (2025-08-28T21:23:38Z yjit-get-exivar 3cc21b76d4) +YJIT +PRISM [arm64-darwin24]

|                           |compare-ruby|built-ruby|
|:--------------------------|-----------:|---------:|
|vm_ivar_get_on_obj         |     975.981|   975.772|
|                           |       1.00x|         -|
|vm_ivar_get_on_class       |     136.214|   470.912|
|                           |           -|     3.46x|
|vm_ivar_get_on_generic     |     148.315|   299.122|
|                           |           -|     2.02x|
```

~~NB: I was expecting a larger improvement, but I suspect preparing for a non-leaf call adds a massive overhead? Still I think it's simple enough to be worth implementing.~~

