### PR TITLE
ZJIT: Repurpose ExitCounters for unhandled YARV insns

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -53,8 +53,8 @@ class << RubyVM::ZJIT
       :zjit_insn_count,
       :ratio_in_zjit,
     ], buf:, stats:)
+    print_counters_with_prefix(prefix: 'unhandled_yarv_insn_', prompt: 'unhandled YARV insns', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'exit_', prompt: 'side exit reasons', buf:, stats:, limit: 20)
-    print_counters_with_prefix(prefix: 'specific_exit_', prompt: 'specific side exit reasons', buf:, stats:, limit: 20)
 
     buf
   end
@@ -96,7 +96,6 @@ class << RubyVM::ZJIT
     left_pad = counters.keys.map(&:size).max
     right_pad = counters.values.map { |value| number_with_delimiter(value).size }.max
     total = counters.values.sum
-    count = counters.size
 
     counters = counters.to_a
     counters.sort_by! { |_, value| -value }
@@ -104,7 +103,7 @@ class << RubyVM::ZJIT
 
     buf << "Top-#{counters.size} " if limit
     buf << "#{prompt}"
-    buf << " (%.1f%% of all #{count})" % (100.0 * counters.map(&:last).sum / total) if limit
+    buf << " (%.1f%% of total #{number_with_delimiter(total)})" % (100.0 * counters.map(&:last).sum / total) if limit
     buf << ":\n"
     counters.each do |key, value|
       padded_key = key.rjust(left_pad, ' ')

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -274,7 +274,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, function: &Function) -> Optio
             let insn = function.find(insn_id);
             if let Err(last_snapshot) = gen_insn(cb, &mut jit, &mut asm, function, insn_id, &insn) {
                 debug!("ZJIT: gen_function: Failed to compile insn: {insn_id} {insn}. Generating side-exit.");
-                gen_side_exit(&mut jit, &mut asm, &SideExitReason::UnhandledInstruction(insn_id), &function.frame_state(last_snapshot));
+                gen_side_exit(&mut jit, &mut asm, &SideExitReason::UnhandledHIRInsn(insn_id), &function.frame_state(last_snapshot));
                 // Don't bother generating code after a side-exit. We won't run it.
                 // TODO(max): Generate ud2 or equivalent.
                 break;


### PR DESCRIPTION
This PR renames the following side-exit reasons because it's not clear whether they are failing at HIR or LIR:

* `UnknownOpcode` => `UnhandledYARVInsn`
* `UnhandledInstruction` => `UnhandledHIRInsn`

which are also more consistent with their original names `YARVINSN_*` and `hir::Insn::*`.

It also repurposes `ExitCounters` to count only exits for `UnhandledYARVInsn` so that you can look at overall side-exit reasons first and then break down its `unhandled_yarv_insn`, which is a more reasonable workflow.

### Example

On lobsters,

```
Top-17 unhandled YARV insns (100.0% of total 1,740,199):
         invokesuper: 612,320 (35.2%)
  getblockparamproxy: 556,271 (32.0%)
         invokeblock: 339,194 (19.5%)
        checkkeyword:  88,575 ( 5.1%)
         expandarray:  80,198 ( 4.6%)
   opt_case_dispatch:  48,082 ( 2.8%)
    getclassvariable:   9,905 ( 0.6%)
       getblockparam:   3,393 ( 0.2%)
         getconstant:     816 ( 0.0%)
         sendforward:     774 ( 0.0%)
          checkmatch:     351 ( 0.0%)
   opt_duparray_send:     133 ( 0.0%)
  invokesuperforward:     115 ( 0.0%)
                once:      23 ( 0.0%)
        definemethod:      21 ( 0.0%)
         defineclass:      14 ( 0.0%)
    setclassvariable:      14 ( 0.0%)
Top-10 side exit reasons (100.0% of total 5,365,652):
     compilation_failure: 1,921,990 (35.8%)
     unhandled_yarv_insn: 1,740,199 (32.4%)
      guard_type_failure: 1,158,441 (21.6%)
              patchpoint:   233,487 ( 4.4%)
       unknown_call_type:   225,102 ( 4.2%)
   unknown_newarray_send:    63,092 ( 1.2%)
      unhandled_hir_insn:    15,956 ( 0.3%)
  obj_to_string_fallback:     7,274 ( 0.1%)
  unhandled_defined_type:        84 ( 0.0%)
               interrupt:        27 ( 0.0%)
```