### PR TITLE
YJIT: Stop sharing rb_vm_send among different instructions

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6095,25 +6095,26 @@ VALUE
 rb_vm_send(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, CALL_DATA cd, ISEQ blockiseq)
 {
     stack_check(ec);
+    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), cd->ci, blockiseq, false);
+    VALUE val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_method);
+    VM_EXEC(ec, val);
+    return val;
+}
+
+VALUE
+rb_vm_sendforward(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, CALL_DATA cd, ISEQ blockiseq)
+{
+    stack_check(ec);
 
     struct rb_forwarding_call_data adjusted_cd;
     struct rb_callinfo adjusted_ci;
 
-    VALUE bh;
-    VALUE val;
+    VALUE bh = vm_caller_setup_fwd_args(GET_EC(), GET_CFP(), cd, blockiseq, false, &adjusted_cd, &adjusted_ci);
 
-    if (vm_ci_flag(cd->ci) & VM_CALL_FORWARDING) {
-        bh = vm_caller_setup_fwd_args(GET_EC(), GET_CFP(), cd, blockiseq, false, &adjusted_cd, &adjusted_ci);
+    VALUE val = vm_sendish(ec, GET_CFP(), &adjusted_cd.cd, bh, mexp_search_method);
 
-        val = vm_sendish(ec, GET_CFP(), &adjusted_cd.cd, bh, mexp_search_method);
-
-        if (cd->cc != adjusted_cd.cd.cc && vm_cc_markable(adjusted_cd.cd.cc)) {
-            RB_OBJ_WRITE(GET_ISEQ(), &cd->cc, adjusted_cd.cd.cc);
-        }
-    }
-    else {
-        bh = vm_caller_setup_arg_block(ec, GET_CFP(), cd->ci, blockiseq, false);
-        val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_method);
+    if (cd->cc != adjusted_cd.cd.cc && vm_cc_markable(adjusted_cd.cd.cc)) {
+        RB_OBJ_WRITE(GET_ISEQ(), &cd->cc, adjusted_cd.cd.cc);
     }
 
     VM_EXEC(ec, val);


### PR DESCRIPTION
`rb_vm_send` is created as a fallback for `send` instruction. It was not meant to be used for other send-ish instructions.

When https://github.com/ruby/ruby/pull/10510 added another send-ish instruction `sendforward`, `sendforward` reused `rb_vm_send` as its fallback, forcing it to support multiple instructions. This PR splits the shared fallback into separate functions, which allows it to skip reading `ci` to check which instruction it's used for.