### PR TITLE
YJIT: Drop yjit-bench CI job

### DIFF
--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -101,18 +101,12 @@ jobs:
           - test_task: 'test-bundled-gems'
             configure: '--enable-yjit=dev'
 
-          - test_task: 'yjit-bench'
-            configure: '--enable-yjit=dev'
-            yjit_bench_opts: '--yjit-stats'
-            continue-on-test_task: true
-
     env:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
       RUN_OPTS: ${{ matrix.yjit_opts }}
       YJIT_BENCH_OPTS: ${{ matrix.yjit_bench_opts }}
       SPECOPTS: ${{ matrix.specopts }}
       RUBY_DEBUG: ci
-      BUNDLE_JOBS: 8 # for yjit-bench
       RUST_BACKTRACE: 1
 
     runs-on: ubuntu-22.04
@@ -207,13 +201,6 @@ jobs:
           LAUNCHABLE_STDOUT: ${{ steps.launchable.outputs.stdout_report_path }}
           LAUNCHABLE_STDERR: ${{ steps.launchable.outputs.stderr_report_path }}
         continue-on-error: ${{ matrix.continue-on-test_task || false }}
-
-      - name: Show ${{ github.event.pull_request.base.ref }} GitHub URL for yjit-bench comparison
-        run: echo "https://github.com/${BASE_REPO}/commit/${BASE_SHA}"
-        env:
-          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-        if: ${{ matrix.test_task == 'yjit-bench' && startsWith(github.event_name, 'pull') }}
 
       - uses: ./.github/actions/slack
         with:

--- a/yjit/yjit.mk
+++ b/yjit/yjit.mk
@@ -31,19 +31,6 @@ ifneq ($(YJIT_SUPPORT),no)
 $(RUST_LIB): $(YJIT_SRC_FILES)
 endif
 
-# By using YJIT_BENCH_OPTS instead of RUN_OPTS, you can skip passing the options to `make install`
-YJIT_BENCH_OPTS = $(RUN_OPTS) --enable-gems
-YJIT_BENCH = benchmarks/railsbench/benchmark.rb
-
-# Run yjit-bench's ./run_once.sh for CI
-yjit-bench: install update-yjit-bench PHONY
-	$(Q) cd $(srcdir)/yjit-bench && PATH=$(prefix)/bin:$$PATH \
-		./run_once.sh $(YJIT_BENCH_OPTS) $(YJIT_BENCH)
-
-update-yjit-bench:
-	$(Q) $(tooldir)/git-refresh -C $(srcdir) --branch main \
-		https://github.com/Shopify/yjit-bench yjit-bench $(GIT_OPTS)
-
 RUST_VERSION = +1.58.0
 
 # Gives quick feedback about YJIT. Not a replacement for a full test run.


### PR DESCRIPTION
I don't think we actively utilize https://github.com/ruby/ruby/pull/6403 today.