### PR TITLE
Implements [Feature #21556] Add true? and false? methods to NilClass, TrueClass, FalseClass, and String

### DIFF
--- a/object.c
+++ b/object.c
@@ -4529,6 +4529,8 @@ InitVM_Object(void)
     rb_define_method(rb_cNilClass, "|", false_or, 1);
     rb_define_method(rb_cNilClass, "^", false_xor, 1);
     rb_define_method(rb_cNilClass, "===", case_equal, 1);
+    rb_define_method(rb_cNilClass, "true?", rb_false, 0);
+    rb_define_method(rb_cNilClass, "false?", rb_false, 0);
 
     rb_define_method(rb_cNilClass, "nil?", rb_true, 0);
     rb_undef_alloc_func(rb_cNilClass);
@@ -4614,6 +4616,8 @@ InitVM_Object(void)
     rb_define_method(rb_cTrueClass, "===", case_equal, 1);
     rb_undef_alloc_func(rb_cTrueClass);
     rb_undef_method(CLASS_OF(rb_cTrueClass), "new");
+    rb_define_method(rb_cTrueClass, "true?", rb_true, 0);
+    rb_define_method(rb_cTrueClass, "false?", rb_false, 0);
 
     rb_cFalseClass = rb_define_class("FalseClass", rb_cObject);
     rb_cFalseClass_to_s = rb_fstring_enc_lit("false", rb_usascii_encoding());
@@ -4626,6 +4630,8 @@ InitVM_Object(void)
     rb_define_method(rb_cFalseClass, "===", case_equal, 1);
     rb_undef_alloc_func(rb_cFalseClass);
     rb_undef_method(CLASS_OF(rb_cFalseClass), "new");
+    rb_define_method(rb_cFalseClass, "true?", rb_false, 0);
+    rb_define_method(rb_cFalseClass, "false?", rb_true, 0);
 }
 
 #include "kernel.rbinc"

--- a/spec/ruby/core/false/false_spec.rb
+++ b/spec/ruby/core/false/false_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+
+describe "FalseClass#false?" do
+  it "returns true" do
+    false.false?.should == true
+  end
+end

--- a/spec/ruby/core/false/true_spec.rb
+++ b/spec/ruby/core/false/true_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+
+describe "FalseClass#true?" do
+  it "returns false" do
+    false.true?.should == false
+  end
+end

--- a/spec/ruby/core/nil/false_spec.rb
+++ b/spec/ruby/core/nil/false_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#false?" do
+  it "returns false" do
+    nil.false?.should == false
+  end
+end

--- a/spec/ruby/core/nil/true_spec.rb
+++ b/spec/ruby/core/nil/true_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+
+describe "NilClass#true?" do
+  it "returns false" do
+    nil.true?.should == false
+  end
+end

--- a/spec/ruby/core/string/false_spec.rb
+++ b/spec/ruby/core/string/false_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "String#false?" do
+  it "'false' returns true" do
+    "false".false?.should == true
+  end
+
+  it "'true' returns false" do
+    "true".false?.should == false
+  end
+
+  it "'' returns false" do
+    "".false?.should == false
+  end
+  
+  it "anything else returns false" do
+    "anything else".false?.should == false
+  end
+end

--- a/spec/ruby/core/string/true_spec.rb
+++ b/spec/ruby/core/string/true_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+
+describe "String#true?" do
+  it "'true' returns true" do
+    "true".true?.should == true
+  end
+
+  it "'false' returns false" do
+    "false".true?.should == false
+  end
+
+  it "'' returns false" do
+    "".true?.should == false
+  end
+  
+  it "anything else returns false" do
+    "anything else".true?.should == false
+  end
+end

--- a/spec/ruby/core/true/false_spec.rb
+++ b/spec/ruby/core/true/false_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+
+describe "TrueClass#false?" do
+  it "returns false" do
+    true.false?.should == false
+  end
+end

--- a/spec/ruby/core/true/true_spec.rb
+++ b/spec/ruby/core/true/true_spec.rb
@@ -1,0 +1,7 @@
+require_relative '../../spec_helper'
+
+describe "TrueClass#true?" do
+  it "returns true" do
+    true.true?.should == true
+  end
+end

--- a/string.c
+++ b/string.c
@@ -1970,6 +1970,32 @@ rb_str_dup_m(VALUE str)
     }
 }
 
+/*
+ *  call-seq:
+ *    true? -> true or false
+ *
+ *  Returns +true+ if +str+ is +true+, +false+ otherwise.
+ */
+VALUE
+rb_str_true_p(VALUE str)
+{
+    VALUE target = rb_str_new_cstr("true");
+    return rb_str_equal(str, target);
+}
+
+/*
+ *  call-seq:
+ *    false? -> true or false
+ *
+ *  Returns +true+ if +str+ is +false+, +false+ otherwise.
+ */
+VALUE
+rb_str_false_p(VALUE str)
+{
+    VALUE target = rb_str_new_cstr("false");
+    return rb_str_equal(str, target);
+}
+
 VALUE
 rb_str_resurrect(VALUE str)
 {
@@ -12733,6 +12759,8 @@ Init_String(void)
     rb_define_method(rb_cString, "-@", str_uminus, 0);
     rb_define_method(rb_cString, "dup", rb_str_dup_m, 0);
     rb_define_alias(rb_cString, "dedup", "-@");
+    rb_define_method(rb_cString, "true?", rb_str_true_p, 0);
+    rb_define_method(rb_cString, "false?", rb_str_false_p, 0);
 
     rb_define_method(rb_cString, "to_i", rb_str_to_i, -1);
     rb_define_method(rb_cString, "to_f", rb_str_to_f, 0);

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -930,6 +930,20 @@ CODE
     end
   end
 
+  def test_true?
+    assert_true(S("true").true?)
+    assert_false(S("false").true?)
+    assert_false(S("").true?)
+    assert_false(S("abc").true?)
+  end
+
+  def test_false?
+    assert_true(S("false").false?)
+    assert_false(S("true").false?)
+    assert_false(S("").false?)
+    assert_false(S("abc").false?)
+  end
+
   class StringWithIVSet < String
     def set_iv
       @foo = 1


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21556

Sometimes we need to check for an exact true or false value. This can be a string or a boolean value.

Usually, what I do to solve this is something like value.to_s == true, this way covering for strings, booleans, and nil values.

The idea of these new methods is to check for the exact value, whether it is a String, a Boolean, or even a Nil value.

This is the result obtained:

```Ruby
# String

'true'.true? # true
'false'.true? # false
''.true? # false

'true'.false? # false
'false'.false? # true
''.false? # false

# Boolean

true.true? # true
true.false? # false

false.true? # false
false.false? # true

# Nil

nil.true? # false
nil.false? # false
```

