### PR TITLE
Lower shrink spec guard in anticipation of 3.4.6 release

### DIFF
--- a/spec/ruby/language/regexp/character_classes_spec.rb
+++ b/spec/ruby/language/regexp/character_classes_spec.rb
@@ -562,7 +562,7 @@ describe "Regexp with character classes" do
     "\u{16EE}".match(/[[:word:]]/).to_a.should == ["\u{16EE}"]
   end
 
-  ruby_bug "#19417", ""..."3.5" do
+  ruby_bug "#19417", ""..."3.4.6" do
     it "matches Unicode join control characters with [[:word:]]" do
       "\u{200C}".match(/[[:word:]]/).to_a.should == ["\u{200C}"]
       "\u{200D}".match(/[[:word:]]/).to_a.should == ["\u{200D}"]


### PR DESCRIPTION
Fix for this bug was merged into ruby_3_4 in 5a42d267bfabc86f86cae2e83de24b1b86bc316a
and should go out in the next 3.4.x release.
