### PR TITLE
ZJIT: Propagate and count CompileError on exits

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -34,13 +34,18 @@ class << RubyVM::ZJIT
     buf = +"***ZJIT: Printing ZJIT statistics on exit***\n"
     stats = self.stats
 
-    print_counters_with_prefix(prefix: 'failed_', prompt: 'compilation failure reasons', buf:, stats:)
+    # Show exit reasons, ordered by the typical amount of exits for the prefix at the time
     print_counters_with_prefix(prefix: 'unhandled_call_', prompt: 'unhandled call types', buf:, stats:, limit: 20)
+    print_counters_with_prefix(prefix: 'unhandled_yarv_insn_', prompt: 'unhandled YARV insns', buf:, stats:, limit: 20)
+    print_counters_with_prefix(prefix: 'compile_error_', prompt: 'compile error reasons', buf:, stats:, limit: 20)
+    print_counters_with_prefix(prefix: 'exit_', prompt: 'side exit reasons', buf:, stats:, limit: 20)
+
+    # Show the most important stats ratio_in_zjit at the end
     print_counters([
       :dynamic_send_count,
 
       :compiled_iseq_count,
-      :compilation_failure,
+      :failed_iseq_count,
 
       :compile_time_ns,
       :profile_time_ns,
@@ -54,8 +59,6 @@ class << RubyVM::ZJIT
       :zjit_insn_count,
       :ratio_in_zjit,
     ], buf:, stats:)
-    print_counters_with_prefix(prefix: 'unhandled_yarv_insn_', prompt: 'unhandled YARV insns', buf:, stats:, limit: 20)
-    print_counters_with_prefix(prefix: 'exit_', prompt: 'side exit reasons', buf:, stats:, limit: 20)
 
     buf
   end

--- a/zjit/src/gc.rs
+++ b/zjit/src/gc.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::{ffi::c_void, ops::Range};
 use crate::codegen::IseqCall;
+use crate::stats::CompileError;
 use crate::{cruby::*, profile::IseqProfile, state::ZJITState, stats::with_time_stat, virtualmem::CodePtr};
 use crate::stats::Counter::gc_time_ns;
 
@@ -38,7 +39,7 @@ impl IseqPayload {
 pub enum IseqStatus {
     /// CodePtr has the JIT code address of the first block
     Compiled(CodePtr),
-    CantCompile,
+    CantCompile(CompileError),
     NotCompiled,
 }
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -12,7 +12,7 @@ use std::{
 use crate::hir_type::{Type, types};
 use crate::bitset::BitSet;
 use crate::profile::{TypeDistributionSummary, ProfiledType};
-use crate::stats::{incr_counter, Counter};
+use crate::stats::Counter;
 
 /// An index of an [`Insn`] in a [`Function`]. This is a popular
 /// type since this effectively acts as a pointer to an [`Insn`].
@@ -1058,7 +1058,7 @@ impl<T: Copy + Into<usize> + PartialEq> UnionFind<T> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ValidationError {
     BlockHasNoTerminator(BlockId),
     // The terminator and its actual position
@@ -2823,7 +2823,7 @@ pub enum CallType {
     Forwarding,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ParameterType {
     Optional,
     /// For example, `foo(...)`. Interaction of JIT
@@ -2831,7 +2831,7 @@ pub enum ParameterType {
     Forwardable,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ParseError {
     StackUnderflow(FrameState),
     UnknownParameterType(ParameterType),
@@ -3619,7 +3619,6 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
     fun.profiles = Some(profiles);
     if let Err(e) = fun.validate() {
-        incr_counter!(failed_hir_compile_validate);
         return Err(ParseError::Validation(e));
     }
     Ok(fun)


### PR DESCRIPTION
This PR propagates compile-error reasons all the way up and counts them at run-time instead of at compile time.

I also changed the order of `print_counters_with_prefix` since `unhandled_yarv_insn_` isn't that important compared to `compile_error_` at the moment, and placing `exit_` from the rest didn't seem useful. ([past discussion](https://github.com/ruby/ruby/pull/14398#discussion_r2310654651))

### Example

On lobsters,

```
***ZJIT: Printing ZJIT statistics on exit***
Top-6 unhandled call types (100.0% of total 187,316):
     block_arg: 97,210 (51.9%)
         kwarg: 63,056 (33.7%)
         splat: 14,235 ( 7.6%)
      kw_splat: 12,372 ( 6.6%)
     splat_mut:    279 ( 0.1%)
  kw_splat_mut:    164 ( 0.1%)
Top-17 unhandled YARV insns (100.0% of total 1,467,641):
         invokesuper: 588,816 (40.1%)
         invokeblock: 336,957 (23.0%)
  getblockparamproxy: 310,670 (21.2%)
        checkkeyword:  88,575 ( 6.0%)
         expandarray:  79,860 ( 5.4%)
   opt_case_dispatch:  47,572 ( 3.2%)
    getclassvariable:   9,910 ( 0.7%)
       getblockparam:   3,387 ( 0.2%)
         sendforward:     772 ( 0.1%)
         getconstant:     452 ( 0.0%)
          checkmatch:     351 ( 0.0%)
   opt_duparray_send:     133 ( 0.0%)
  invokesuperforward:     115 ( 0.0%)
                once:      23 ( 0.0%)
        definemethod:      20 ( 0.0%)
         defineclass:      14 ( 0.0%)
    setclassvariable:      14 ( 0.0%)
Top-4 compile error reasons (100.0% of total 1,922,353):
     parse_parameter_type_optional: 1,170,078 (60.9%)
           register_spill_on_alloc:   369,952 (19.2%)
  parse_parameter_type_forwardable:   256,154 (13.3%)
           register_spill_on_ccall:   126,169 ( 6.6%)
Top-10 side exit reasons (100.0% of total 7,179,512):
     guard_shape_failure: 2,245,518 (31.3%)
           compile_error: 1,922,353 (26.8%)
     unhandled_yarv_insn: 1,467,641 (20.4%)
      guard_type_failure: 1,091,232 (15.2%)
              patchpoint:   232,895 ( 3.2%)
     unhandled_call_type:   187,316 ( 2.6%)
      unhandled_hir_insn:    15,955 ( 0.2%)
   unknown_newarray_send:     9,374 ( 0.1%)
  obj_to_string_fallback:     7,201 ( 0.1%)
               interrupt:        27 ( 0.0%)
dynamic_send_count:  10,019,054
compiled_iseq_count: 6,393
failed_iseq_count:   963
compile_time:        5,726ms
profile_time:        59ms
gc_time:             66ms
invalidation_time:   11ms
code_region_bytes:   7,454,720
side_exit_count:     7,179,512
total_insn_count:    169,506,517
vm_insn_count:       80,033,095
zjit_insn_count:     89,473,422
ratio_in_zjit:       52.8%
```