### PR TITLE
ZJIT: NewRangeFixnum instruction

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -807,6 +807,60 @@ class TestZJIT < Test::Unit::TestCase
     }
   end
 
+  def test_new_range_fixnum_both_literals_inclusive
+    assert_compiles '1..2', %q{
+      def test()
+        (1..2)
+      end
+      test; test
+    }, call_threshold: 2
+  end
+
+  def test_new_range_fixnum_both_literals_exclusive
+    assert_compiles '1...2', %q{
+      def test()
+        (1...2)
+      end
+      test; test
+    }, call_threshold: 2
+  end
+
+  def test_new_range_fixnum_low_literal_inclusive
+    assert_compiles '1..3', %q{
+      def test(a)
+        (1..a)
+      end
+      test(2); test(3)
+    }, call_threshold: 2
+  end
+
+  def test_new_range_fixnum_low_literal_exclusive
+    assert_compiles '1...3', %q{
+      def test(a)
+        (1...a)
+      end
+      test(2); test(3)
+    }, call_threshold: 2
+  end
+
+  def test_new_range_fixnum_high_literal_inclusive
+    assert_compiles '3..10', %q{
+      def test(a)
+        (a..10)
+      end
+      test(2); test(3)
+    }, call_threshold: 2
+  end
+
+  def test_new_range_fixnum_high_literal_exclusive
+    assert_compiles '3...10', %q{
+      def test(a)
+        (a...10)
+      end
+      test(2); test(3)
+    }, call_threshold: 2
+  end
+
   def test_if
     assert_compiles '[0, nil]', %q{
       def test(n)

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -342,6 +342,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::NewArray { elements, state } => gen_new_array(asm, opnds!(elements), &function.frame_state(*state)),
         Insn::NewHash { elements, state } => gen_new_hash(jit, asm, elements, &function.frame_state(*state)),
         Insn::NewRange { low, high, flag, state } => gen_new_range(jit, asm, opnd!(low), opnd!(high), *flag, &function.frame_state(*state)),
+        Insn::NewRangeFixnum { low, high, flag } => gen_new_range_fixnum(jit, asm, opnd!(low), opnd!(high), *flag),
         Insn::ArrayDup { val, state } => gen_array_dup(asm, opnd!(val), &function.frame_state(*state)),
         Insn::StringCopy { val, chilled, state } => gen_string_copy(asm, opnd!(val), *chilled, &function.frame_state(*state)),
         // concatstrings shouldn't have 0 strings
@@ -1132,6 +1133,17 @@ fn gen_new_range(
 
     // Call rb_range_new(low, high, flag)
     asm_ccall!(asm, rb_range_new, low, high, (flag as i64).into())
+}
+
+fn gen_new_range_fixnum(
+    jit: &JITState,
+    asm: &mut Assembler,
+    low: lir::Opnd,
+    high: lir::Opnd,
+    flag: RangeType,
+    // no FrameState param: this is leaf/pure and never deopts here
+) -> lir::Opnd {
+    asm_ccall!(asm, rb_range_new, low, high, (flag as i64).into()) // What should I use here? Idk.
 }
 
 /// Compile code that exits from JIT code with a return value

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1963,7 +1963,7 @@ impl Function {
                         let high_is_fix = self.is_a(high, types::Fixnum);
 
                         if low_is_fix && high_is_fix {
-                            // Both statically fixnum → specialize directly
+                            // Both statically fixnum => specialize directly
                             let repl = self.push_insn(block, Insn::NewRangeFixnum { low, high, flag, state });
                             self.make_equal_to(insn_id, repl);
                             self.insn_types[repl.0] = self.infer_type(repl);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6549,6 +6549,44 @@ mod opt_tests {
     }
 
     #[test]
+    fn test_optimize_new_range_fixnum_inclusive_literals() {
+        eval(r#"
+            def test()
+              (1..2)
+            end
+            test; test
+        "#);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:Fixnum[1] = Const Value(1)
+          v2:Fixnum[2] = Const Value(2)
+          v3:RangeExact = NewRangeFixnum v1 NewRangeInclusive v2
+          CheckInterrupts
+          Return v3
+        ");
+    }
+
+    #[test]
+    fn test_optimize_new_range_fixnum_exclusive_literals() {
+        eval(r#"
+            def test()
+              (1..2)
+            end
+            test; test
+        "#);
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:3:
+        bb0(v0:BasicObject):
+          v1:Fixnum[1] = Const Value(1)
+          v2:Fixnum[2] = Const Value(2)
+          v3:RangeExact = NewRangeFixnum v1 NewRangeExclusive v2
+          CheckInterrupts
+          Return v3
+        ");
+    }
+
+    #[test]
     fn test_eliminate_new_array() {
         eval("
             def test()

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6643,7 +6643,7 @@ mod opt_tests {
     }
 
     #[test]
-    fn test_optimize_range_fixnum_inclusive_high_profiled() {
+    fn test_optimize_range_fixnum_inclusive_high_guarded() {
         eval(r#"
             def test(a)
               (1..a)
@@ -6662,7 +6662,7 @@ mod opt_tests {
     }
 
     #[test]
-    fn test_optimize_range_fixnum_exclusive_high_profiled() {
+    fn test_optimize_range_fixnum_exclusive_high_guarded() {
         eval(r#"
             def test(a)
               (1...a)
@@ -6681,7 +6681,7 @@ mod opt_tests {
     }
 
     #[test]
-    fn test_optimize_range_fixnum_inclusive_low_profiled() {
+    fn test_optimize_range_fixnum_inclusive_low_guarded() {
         eval(r#"
             def test(a)
               (a..10)
@@ -6700,7 +6700,7 @@ mod opt_tests {
     }
 
     #[test]
-    fn test_optimize_range_fixnum_exclusive_low_profiled() {
+    fn test_optimize_range_fixnum_exclusive_low_guarded() {
         eval(r#"
             def test(a)
               (a...10)

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2130,12 +2130,8 @@ impl Function {
                 }
                 worklist.push_back(state);
             }
-            &Insn::NewRange { low, high, state, .. } => {
-                worklist.push_back(low);
-                worklist.push_back(high);
-                worklist.push_back(state);
-            }
-            &Insn::NewRangeFixnum { low, high, state, .. } => {
+            &Insn::NewRange { low, high, state, .. }
+            | &Insn::NewRangeFixnum { low, high, state, .. } => {
                 worklist.push_back(low);
                 worklist.push_back(high);
                 worklist.push_back(state);
@@ -6610,12 +6606,12 @@ mod opt_tests {
 
     #[test]
     fn test_optimize_range_fixnum_inclusive_literals() {
-        eval(r#"
+        eval("
             def test()
               (1..2)
             end
             test; test
-        "#);
+        ");
         assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb0(v0:BasicObject):
@@ -6627,12 +6623,12 @@ mod opt_tests {
 
     #[test]
     fn test_optimize_range_fixnum_exclusive_literals() {
-        eval(r#"
+        eval("
             def test()
               (1...2)
             end
             test; test
-        "#);
+        ");
         assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb0(v0:BasicObject):
@@ -6644,12 +6640,12 @@ mod opt_tests {
 
     #[test]
     fn test_optimize_range_fixnum_inclusive_high_guarded() {
-        eval(r#"
+        eval("
             def test(a)
               (1..a)
             end
             test(2); test(3)
-        "#);
+        ");
         assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb0(v0:BasicObject, v1:BasicObject):
@@ -6663,12 +6659,12 @@ mod opt_tests {
 
     #[test]
     fn test_optimize_range_fixnum_exclusive_high_guarded() {
-        eval(r#"
+        eval("
             def test(a)
               (1...a)
             end
             test(2); test(3)
-        "#);
+        ");
         assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb0(v0:BasicObject, v1:BasicObject):
@@ -6682,12 +6678,12 @@ mod opt_tests {
 
     #[test]
     fn test_optimize_range_fixnum_inclusive_low_guarded() {
-        eval(r#"
+        eval("
             def test(a)
               (a..10)
             end
             test(2); test(3)
-        "#);
+        ");
         assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb0(v0:BasicObject, v1:BasicObject):
@@ -6701,12 +6697,12 @@ mod opt_tests {
 
     #[test]
     fn test_optimize_range_fixnum_exclusive_low_guarded() {
-        eval(r#"
+        eval("
             def test(a)
               (a...10)
             end
             test(2); test(3)
-        "#);
+        ");
         assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:3:
         bb0(v0:BasicObject, v1:BasicObject):

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1968,13 +1968,13 @@ impl Function {
                             self.make_equal_to(insn_id, repl);
                             self.insn_types[repl.0] = self.infer_type(repl);
                         } else if low_is_fix {
-                            // Only left is fixnum → guard right
+                            // Only left is fixnum => guard right
                             let high_fix = self.coerce_to_fixnum(block, high, state);
                             let repl = self.push_insn(block, Insn::NewRangeFixnum { low, high: high_fix, flag, state });
                             self.make_equal_to(insn_id, repl);
                             self.insn_types[repl.0] = self.infer_type(repl);
                         } else if high_is_fix {
-                            // Only right is fixnum → guard left
+                            // Only right is fixnum => guard left
                             let low_fix = self.coerce_to_fixnum(block, low, state);
                             let repl = self.push_insn(block, Insn::NewRangeFixnum { low: low_fix, high, flag, state });
                             self.make_equal_to(insn_id, repl);


### PR DESCRIPTION
### Context
Closes Shopify/ruby#710

### Changes

**HIR**  
- Added a new instruction `NewRangeFixnum` that mirrors `NewRange` but is specialized for Fixnum endpoints.  
- Marked as leaf and effect-free (unlike `NewRange`, which may call `<=>`).

**Codegen**  
- Added `gen_new_range_fixnum`, wired to the new instruction.  
- Uses `gen_prepare_call_with_gc(asm, state)` since range allocation may trigger GC, but does not call Ruby methods.  
- Emits a direct call to `rb_range_new`.

**Optimization**  
- Added `optimize_ranges` pass: conservatively rewrites `NewRange` into `NewRangeFixnum` when one or both ends are statically Fixnum literals (with guards added for the dynamic side if needed).  
- This covers the simple literal/guardable cases that can be proven cheaply.

At this point I haven’t added rewrites for parameter–parameter ranges.  
From looking at how `opt_plus` works, it seems to rely on profiling info, but I don’t fully understand whether that same info is available for `newrange`.  
Since I’m still new to this codebase (and to low-level Rust in general), I decided to keep the optimization conservative for now and get maintainer feedback before broadening it.