### PR TITLE
ZJIT: Bump default --zjit-call-threshold to 30

### DIFF
--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -979,7 +979,7 @@ pub use manual_defs::*;
 pub mod test_utils {
     use std::{ptr::null, sync::Once};
 
-    use crate::{options::rb_zjit_prepare_options, state::rb_zjit_enabled_p, state::ZJITState};
+    use crate::{options::{internal_set_num_profiles, rb_zjit_call_threshold, rb_zjit_prepare_options, DEFAULT_CALL_THRESHOLD}, state::{rb_zjit_enabled_p, ZJITState}};
 
     use super::*;
 
@@ -1003,6 +1003,11 @@ pub mod test_utils {
             ruby_init_stack(&mut var as *mut VALUE as *mut _);
             rb_zjit_prepare_options(); // enable `#with_jit` on builtins
             ruby_init();
+
+            // The default rb_zjit_profile_threshold is too high, so lower it for HIR tests.
+            if rb_zjit_call_threshold == DEFAULT_CALL_THRESHOLD {
+                internal_set_num_profiles(1);
+            }
 
             // Pass command line options so the VM loads core library methods defined in
             // ruby such as from `kernel.rb`.


### PR DESCRIPTION
This PR bumps the default `--zjit-call-threshold`/`--zjit-num-profiles` to 30/5, which is the same as the default `--yjit-call-threshold` and `SEND_MAX_DEPTH` in YJIT.

This increases `ratio_in_zjit` on lobsters 52.8% → 61.9% because it eliminates most `guard_shape_failure` https://github.com/ruby/ruby/pull/14388.