### PR TITLE
Micro-optimize `Object#class`

### DIFF
--- a/benchmark/object_class.yml
+++ b/benchmark/object_class.yml
@@ -1,0 +1,40 @@
+prelude: |
+  def get_class(obj)
+    i = 10_000
+    while i > 0
+      i -= 1
+      # 100 times per loop
+      obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class;
+      obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class;
+      obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class;
+      obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class;
+      obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class;
+      obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class;
+      obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class;
+      obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class;
+      obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class;
+      obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class;
+      obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class; obj.class;
+    end
+  end
+
+  class Obj
+  end
+  obj = Obj.new
+
+  singleton = Obj.new
+  def singleton.bar
+  end
+
+  extended = Obj.new
+  2.times do
+    extended.extend Module.new
+  end
+
+  immediate = 1.4
+benchmark:
+  obj: get_class(obj)
+  extended: get_class(extended)
+  singleton: get_class(singleton)
+  immediate: get_class(immediate)
+loop_count: 1000

--- a/class.c
+++ b/class.c
@@ -62,8 +62,8 @@
  * 0:    RCLASS_IS_ROOT
  *           The class has been added to the VM roots. Will always be marked and pinned.
  *           This is done for classes defined from C to allow storing them in global variables.
- * 1:    RMODULE_IS_REFINEMENT
- *           Module is used for refinements.
+ * 1:    <reserved>
+ *          Ensures that RUBY_FL_SINGLETON is never set on a T_MODULE. See `rb_class_real`.
  * 2:    RCLASS_PRIME_CLASSEXT_PRIME_WRITABLE
  *           This module's prime classext is the only classext and writable from any namespaces.
  *           If unset, the prime classext is writable only from the root namespace.
@@ -71,6 +71,8 @@
  *           Module has been initialized.
  * 4:    RCLASS_NAMESPACEABLE
  *           Is a builtin class that may be namespaced. It larger than a normal class.
+ * 5:    RMODULE_IS_REFINEMENT
+ *           Module is used for refinements.
  */
 
 #define METACLASS_OF(k) RBASIC(k)->klass

--- a/kernel.rb
+++ b/kernel.rb
@@ -17,7 +17,7 @@ module Kernel
   #
   def class
     Primitive.attr! :leaf
-    Primitive.cexpr! 'rb_obj_class(self)'
+    Primitive.cexpr! 'rb_obj_class_must(self)'
   end
 
   #

--- a/object.c
+++ b/object.c
@@ -278,23 +278,23 @@ rb_obj_not_equal(VALUE obj1, VALUE obj2)
     return rb_obj_not(result);
 }
 
-VALUE
-rb_class_real(VALUE cl)
-{
-    while (cl &&
-        (RCLASS_SINGLETON_P(cl) || BUILTIN_TYPE(cl) == T_ICLASS)) {
-        cl = RCLASS_SUPER(cl);
-    }
-    return cl;
-}
-
 static inline VALUE
 fake_class_p(VALUE klass)
 {
-    RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS) || RB_TYPE_P(klass, T_ICLASS));
-    STATIC_ASSERT(t_iclass_overlap, !(T_CLASS & T_ICLASS));
+    RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS) || RB_TYPE_P(klass, T_MODULE) || RB_TYPE_P(klass, T_ICLASS));
+    STATIC_ASSERT(t_iclass_overlap_t_class, !(T_CLASS & T_ICLASS));
+    STATIC_ASSERT(t_iclass_overlap_t_module, !(T_MODULE & T_ICLASS));
 
     return FL_TEST_RAW(klass, T_ICLASS | FL_SINGLETON);
+}
+
+VALUE
+rb_class_real(VALUE cl)
+{
+    while (RB_UNLIKELY(cl && fake_class_p(cl))) {
+        cl = RCLASS_SUPER(cl);
+    }
+    return cl;
 }
 
 VALUE

--- a/object.c
+++ b/object.c
@@ -288,10 +288,23 @@ rb_class_real(VALUE cl)
     return cl;
 }
 
+static inline VALUE
+fake_class_p(VALUE klass)
+{
+    RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS) || RB_TYPE_P(klass, T_ICLASS));
+    STATIC_ASSERT(t_iclass_overlap, !(T_CLASS & T_ICLASS));
+
+    return FL_TEST_RAW(klass, T_ICLASS | FL_SINGLETON);
+}
+
 VALUE
 rb_obj_class(VALUE obj)
 {
-    return rb_class_real(CLASS_OF(obj));
+    VALUE cl = CLASS_OF(obj);
+    while (RB_UNLIKELY(cl && fake_class_p(cl))) {
+        cl = RCLASS_SUPER(cl);
+    }
+    return cl;
 }
 
 /*

--- a/object.c
+++ b/object.c
@@ -289,11 +289,21 @@ fake_class_p(VALUE klass)
     return FL_TEST_RAW(klass, T_ICLASS | FL_SINGLETON);
 }
 
+static inline VALUE
+class_real(VALUE cl)
+{
+    RUBY_ASSERT(cl);
+    while (RB_UNLIKELY(fake_class_p(cl))) {
+        cl = RCLASS_SUPER(cl);
+    }
+    return cl;
+}
+
 VALUE
 rb_class_real(VALUE cl)
 {
-    while (RB_UNLIKELY(cl && fake_class_p(cl))) {
-        cl = RCLASS_SUPER(cl);
+    if (cl) {
+        cl = class_real(cl);
     }
     return cl;
 }
@@ -302,8 +312,8 @@ VALUE
 rb_obj_class(VALUE obj)
 {
     VALUE cl = CLASS_OF(obj);
-    while (RB_UNLIKELY(cl && fake_class_p(cl))) {
-        cl = RCLASS_SUPER(cl);
+    if (cl) {
+        cl = class_real(cl);
     }
     return cl;
 }
@@ -311,12 +321,7 @@ rb_obj_class(VALUE obj)
 VALUE
 rb_obj_class_must(VALUE obj)
 {
-    VALUE cl = CLASS_OF(obj);
-    RUBY_ASSERT(cl);
-    while (RB_UNLIKELY(fake_class_p(cl))) {
-        cl = RCLASS_SUPER(cl);
-    }
-    return cl;
+    return class_real(CLASS_OF(obj));
 }
 
 /*

--- a/object.c
+++ b/object.c
@@ -281,6 +281,7 @@ rb_obj_not_equal(VALUE obj1, VALUE obj2)
 static inline VALUE
 fake_class_p(VALUE klass)
 {
+    RUBY_ASSERT(klass);
     RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS) || RB_TYPE_P(klass, T_MODULE) || RB_TYPE_P(klass, T_ICLASS));
     STATIC_ASSERT(t_iclass_overlap_t_class, !(T_CLASS & T_ICLASS));
     STATIC_ASSERT(t_iclass_overlap_t_module, !(T_MODULE & T_ICLASS));
@@ -302,6 +303,17 @@ rb_obj_class(VALUE obj)
 {
     VALUE cl = CLASS_OF(obj);
     while (RB_UNLIKELY(cl && fake_class_p(cl))) {
+        cl = RCLASS_SUPER(cl);
+    }
+    return cl;
+}
+
+VALUE
+rb_obj_class_must(VALUE obj)
+{
+    VALUE cl = CLASS_OF(obj);
+    RUBY_ASSERT(cl);
+    while (RB_UNLIKELY(fake_class_p(cl))) {
         cl = RCLASS_SUPER(cl);
     }
     return cl;


### PR DESCRIPTION
Since `BUILTIN_TYPE` and `RCLASS_SINGLETON_P` are both stored in `RBasic.flags`, we can combine these two checks in a single bitmask.

This rely on `T_ICLASS` and `T_CLASS` not overlapping, and assume `klass` is always either of these types.

Just combining the masks brings a small but consistent 1.08x speedup on the simple case benchmark.

```
compare-ruby: ruby 3.5.0dev (2025-08-30T01:45:42Z obj-class 01a57bd6cd) +YJIT +PRISM [arm64-darwin24]
built-ruby: ruby 3.5.0dev (2025-08-30T09:56:24Z obj-class 2685f8dbb4) +YJIT +PRISM [arm64-darwin24]

|           |compare-ruby|built-ruby|
|:----------|-----------:|---------:|
|obj        |     444.410|   478.895|
|           |           -|     1.08x|
|extended   |     135.139|   140.206|
|           |           -|     1.04x|
|singleton  |     165.155|   155.832|
|           |       1.06x|         -|
|immediate  |     380.103|   432.090|
|           |           -|     1.14x|
```

But with the RB_UNLIKELY compiler hint, it's much more significant, however the singleton and enxtended cases are slowed down.
However we can assume the simple case is way more common than the other two.

```
compare-ruby: ruby 3.5.0dev (2025-08-30T01:45:42Z obj-class 01a57bd6cd) +YJIT +PRISM [arm64-darwin24]
built-ruby: ruby 3.5.0dev (2025-08-30T09:51:01Z obj-class 12d01a1b02) +YJIT +PRISM [arm64-darwin24]

|           |compare-ruby|built-ruby|
|:----------|-----------:|---------:|
|obj        |     444.951|   556.191|
|           |           -|     1.25x|
|extended   |     136.836|   113.871|
|           |       1.20x|         -|
|singleton  |     166.335|   167.747|
|           |           -|     1.01x|
|immediate  |     379.642|   509.515|
|           |           -|     1.34x|
```

And since the logic is very similar, I was able to reuse `fake_class_p` in `rb_class_real` simply by ensuring `T_MODULE` never has `FL_SINGLETON` set.

Then, when we're calling from Ruby's `Kernel#class` method, we know for sure `RBasic.klass` can't possibly be `0`, so if we add a specialized function that skips the null check, we can speed the method some more:

```
compare-ruby: ruby 3.5.0dev (2025-08-30T01:45:42Z obj-class 01a57bd6cd) +YJIT +PRISM [arm64-darwin24]
built-ruby: ruby 3.5.0dev (2025-08-30T10:21:10Z obj-class b67c16c477) +YJIT +PRISM [arm64-darwin24]
# Iteration per second (i/s)

|           |compare-ruby|built-ruby|
|:----------|-----------:|---------:|
|obj        |     445.217|   642.446|
|           |           -|     1.44x|
|extended   |     136.826|   117.974|
|           |       1.16x|         -|
|singleton  |     166.269|   166.695|
|           |           -|     1.00x|
|immediate  |     380.243|   515.775|
|           |           -|     1.36x|
```

In a followup, It could be worth exploring the possibility of ensuring `T_ICLASS` always had `FL_SINGLETON` set, as it would allow reducing `fake_class_p` to a single bit check. But not sure it would make much of a difference.

Another thing worth exploring would be YJIT codegen.