### PR TITLE
Remove fallback implementation of Enumerable#each_slice

### DIFF
--- a/template/unicode_norm_gen.tmpl
+++ b/template/unicode_norm_gen.tmpl
@@ -22,23 +22,6 @@ class Integer
   end
 end
 
-module Enumerable
-  unless method_defined?(:each_slice)
-    def each_slice(n)
-      ary = []
-      each do |i|
-        ary << i
-        if ary.size >= n
-          yield ary
-          ary = []
-        end
-      end
-      yield ary unless ary.empty?
-      self
-    end
-  end
-end
-
 class Array
   def to_UTF8() collect {|c| c.to_UTF8}.join('') end
 


### PR DESCRIPTION
This method has been a built-in feature since Ruby 1.8.7, so this fallback implementation is no longer needed.

Ref: https://docs.ruby-lang.org/en/3.4/NEWS/NEWS-1_8_7.html