### PR TITLE
Fix undefined behaviour in rb_alias_variable

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -1150,7 +1150,7 @@ rb_alias_variable(ID name1, ID name2)
     RB_VM_LOCKING() {
         entry2 = rb_global_entry(name2);
         if (!rb_id_table_lookup(gtbl, name1, &data1)) {
-            entry1 = ALLOC(struct rb_global_entry);
+            entry1 = ZALLOC(struct rb_global_entry);
             entry1->id = name1;
             rb_id_table_insert(gtbl, name1, (VALUE)entry1);
         }


### PR DESCRIPTION
entry1 is allocated using xmalloc (through ALLOC), which returns undefined memory. We never set the ractor_local field, so the value is undefined.