### PR TITLE
Fix global variable counter for alias

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -1164,7 +1164,7 @@ rb_alias_variable(ID name1, ID name2)
                 free_global_variable(var);
             }
         }
-        if (entry1) {
+        if (entry1->var != entry2->var) {
             entry2->var->counter++;
             entry1->var = entry2->var;
         }


### PR DESCRIPTION
If we alias two variable multiple times, for example like this:

```ruby
alias $foo $bar
alias $foo $bar
```

Then we will increment the counter for entry2->var->counter each time, which is not correct because we are not adding more references to entry2->var. This reports as a memory leak in RUBY_FREE_AT_EXIT because entry2->var->counter will never reach 0 and thus will never be freed.