### PR TITLE
Update rbs sha to the latest aaa-3.9.x

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -18,7 +18,7 @@ net-pop             0.1.2   https://github.com/ruby/net-pop
 net-smtp            0.5.1   https://github.com/ruby/net-smtp
 matrix              0.4.3   https://github.com/ruby/matrix
 prime               0.1.4   https://github.com/ruby/prime
-rbs                 3.9.4   https://github.com/ruby/rbs 368bf4b1ab52a9335e2022618ac4545a4d9cacdf
+rbs                 3.9.4   https://github.com/ruby/rbs aa22d7ea0c992de7557c3e346c9100b8aa36d945
 typeprof            0.30.1  https://github.com/ruby/typeprof
 debug               1.11.0  https://github.com/ruby/debug
 racc                1.8.1   https://github.com/ruby/racc


### PR DESCRIPTION
No diff in rbs, but it points to the revision merged to https://github.com/ruby/rbs/compare/aaa-3.9.x instead of the revision used in my PR https://github.com/ruby/rbs/pull/2646.