### PR TITLE
ext/-test-/tracepoint/gc_hook.c: Fix GC safety issue

### DIFF
--- a/ext/-test-/tracepoint/tracepoint.c
+++ b/ext/-test-/tracepoint/tracepoint.c
@@ -1,6 +1,8 @@
 #include "ruby/ruby.h"
 #include "ruby/debug.h"
 
+VALUE tp_mBug;
+
 struct tracepoint_track {
     size_t newobj_count;
     size_t free_count;
@@ -89,8 +91,8 @@ void Init_gc_hook(VALUE);
 void
 Init_tracepoint(void)
 {
-    VALUE mBug = rb_define_module("Bug");
-    Init_gc_hook(mBug);
-    rb_define_module_function(mBug, "tracepoint_track_objspace_events", tracepoint_track_objspace_events, 0);
-    rb_define_module_function(mBug, "tracepoint_specify_normal_and_internal_events", tracepoint_specify_normal_and_internal_events, 0);
+    tp_mBug = rb_define_module("Bug"); // GC root
+    Init_gc_hook(tp_mBug);
+    rb_define_module_function(tp_mBug, "tracepoint_track_objspace_events", tracepoint_track_objspace_events, 0);
+    rb_define_module_function(tp_mBug, "tracepoint_specify_normal_and_internal_events", tracepoint_specify_normal_and_internal_events, 0);
 }

--- a/test/-ext-/tracepoint/test_tracepoint.rb
+++ b/test/-ext-/tracepoint/test_tracepoint.rb
@@ -83,7 +83,7 @@ class TestTracepointObj < Test::Unit::TestCase
   end
 
   def test_teardown_with_active_GC_end_hook
-    assert_separately([], 'require("-test-/tracepoint"); Bug.after_gc_exit_hook = proc {}')
+    assert_separately([], 'require("-test-/tracepoint"); Bug.after_gc_exit_hook = proc {}; GC.start')
   end
 
 end


### PR DESCRIPTION
TestTracepointObj#test_teardown_with_active_GC_end_hook was failing on
some platforms due to a Proc that is not marked being passed around.
Neither rb_tracepoint_new() nor rb_postponed_job_preregister() promise
to mark their callback `void *data`.

https://rubyci.s3.amazonaws.com/osx1300arm/ruby-master/log/20250902T154504Z.fail.html.gz

Add a GC.start to make the test a better detector for this safety issue
and fix it by getting the Proc from an ivar on the rooted module.
