### PR TITLE
ZJIT: Handle `opt_case_dispatch` insn

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -2240,6 +2240,24 @@ class TestZJIT < Test::Unit::TestCase
     }
   end
 
+  def test_opt_case_dispatch
+    assert_compiles '[true, false]', %q{
+      def test(x)
+        case x
+        when :foo
+          true
+        else
+          false
+        end
+      end
+
+      results = []
+      results << test(:foo)
+      results << test(1)
+      results
+    }, insns: [:opt_case_dispatch]
+  end
+
   private
 
   # Assert that every method call in `test_script` can be compiled by ZJIT

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3274,6 +3274,12 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     });
                     queue.push_back((state.clone(), target, target_idx));
                 }
+                YARVINSN_opt_case_dispatch => {
+                    // TODO: Some keys are visible at compile time, so in the future we can
+                    // compile jump targets for certain cases
+                    // Pop the key from the stack and fallback to the === branches for now
+                    state.stack_pop()?;
+                }
                 YARVINSN_opt_new => {
                     let exit_id = fun.push_insn(block, Insn::Snapshot { state: exit_state });
                     fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });


### PR DESCRIPTION
`opt_case_dispatch` is not easy to implement because:
- Its `hash` attribute is a Ruby hash with `obj hashed key -> insn offset` pairs
- It also takes a `key`, which in most cases is a runtime value but for some immediate types can be known at compile time too
- For ZJIT, this means that at HIR compilation we need to expand `hash`, generate the jump targets with the offsets, and pass `key -> jump targets` pairs to codegen. Or we can also just handle the cases where the `key` can be known at compile time, which is what YJIT does for specific benchmarks (https://github.com/Shopify/ruby/issues/723#issuecomment-3247042186).

Given that `vm_case_dispatch`'s execution time in the profiling I did is `0.0%`, I don't think it's worth doing any of these now.

And because Ruby also generates all the fallback instructions (`===` branches), we can just handle the YARV instruction by popping the value off the stack and let the fallback do the work, which is what I do in this PR.

Stats on `liquid-render` benchmark

**Before**

```
Top-6 unhandled YARV insns (100.0% of total 845,820):
         invokeblock: 557,171 (65.9%)
    getclassvariable: 260,912 (30.8%)
         invokesuper:  22,266 ( 2.6%)
   opt_case_dispatch:   3,857 ( 0.5%)
  getblockparamproxy:   1,477 ( 0.2%)
                once:     137 ( 0.0%)
```

**After**

```
Top-5 unhandled YARV insns (100.0% of total 841,963):
         invokeblock: 557,171 (66.2%)
    getclassvariable: 260,912 (31.0%)
         invokesuper:  22,266 ( 2.6%)
  getblockparamproxy:   1,477 ( 0.2%)
                once:     137 ( 0.0%)
```
