### PR TITLE
[DOC] Clarify differences between Kernel.rand and Random.rand when given a Float `max`

### DIFF
--- a/random.c
+++ b/random.c
@@ -1552,9 +1552,11 @@ static VALUE rand_random(int argc, VALUE *argv, VALUE obj, rb_random_t *rnd);
  *   prng.rand(100)       # => 42
  *
  * When +max+ is a Float, +rand+ returns a random floating point number
- * between 0.0 and +max+, including 0.0 and excluding +max+.
+ * between 0.0 and +max+, including 0.0 and excluding +max+. Note that it
+ * behaves differently from Kernel.rand.
  *
  *   prng.rand(1.5)       # => 1.4600282860034115
+ *   Kernel.rand(1.5)     # => 0
  *
  * When +range+ is a Range, +rand+ returns a random number where
  * <code>range.member?(number) == true</code>.
@@ -1692,7 +1694,9 @@ rand_mt_equal(VALUE self, VALUE other)
  * Kernel.srand may be used to ensure that sequences of random numbers are
  * reproducible between different runs of a program.
  *
- * See also Random.rand.
+ * Related: Random.rand.
+ *   rand(100.0)        # => 64 (Integer because max.to_i is 100)
+ *   Random.rand(100.0) # => 30.315320967824523
  */
 
 static VALUE

--- a/random.c
+++ b/random.c
@@ -1555,8 +1555,8 @@ static VALUE rand_random(int argc, VALUE *argv, VALUE obj, rb_random_t *rnd);
  * between 0.0 and +max+, including 0.0 and excluding +max+. Note that it
  * behaves differently from Kernel.rand.
  *
- *   prng.rand(1.5)       # => 1.4600282860034115
- *   Kernel.rand(1.5)     # => 0
+ *   prng.rand(1.5)  # => 1.4600282860034115
+ *   rand(1.5)       # => 0
  *
  * When +range+ is a Range, +rand+ returns a random number where
  * <code>range.member?(number) == true</code>.


### PR DESCRIPTION
Use of `Kernel.rand` with a Float `max` argument is poorly understood by humans and LLMs. The documentation is technically correct (it "may give surprising results" and "The class method Random.rand provides the base functionality of Kernel.rand along with better handling of floating point values."), but the confusion between the two produces incorrect code when [asked for a random number below a Float](https://chatgpt.com/share/68b7b7e8-2f78-8010-9a58-ff86b7ac5f41) or even when asked about the type directly:

`In Ruby, what is the return data type of rand(100.0)?`

- [ChatGPT](https://chatgpt.com/share/68b7ae36-154c-8010-a800-00d0cf34a16e) => `Float`
- [Claude](https://claude.ai/share/189f87ae-8a68-4523-b041-ce7107bc87aa) => `Float`
- [Gemini 2.5 Flash](https://docs.google.com/document/d/1UjsbZJoMpYBvsRm0J9mtkE-EWJF2eAqwWGOg6V4cY8M/edit?usp=sharing) => `Float`
- [Gemini 2.5 Pro](https://docs.google.com/document/d/1EfnYf3AVPcnQjZDCzpE_7buxRva8uQrhoIaUBhGvFTo/edit?usp=sharing) => `Float`
- [Copilot "Think Hard"](https://copilot.microsoft.com/shares/bCL5kPPs7LVy1gUTKx3uX) => `Float`
- [Perplexity](https://www.perplexity.ai/search/18ca6983-052a-4c3d-b222-ecfdb0a09269) => `Float`

In reality:

```
rand(100.0).class          # => Integer
Random.rand(100.0).class   # => Float
```

* Kernel.rand converts the `max` Float argument to Integer and returns Integer values
* Random.rand preserves the `max` Float argument and returns Float values

If all the LLMs get it wrong, surely our documentation needs more clarity. I added examples demonstrating the behavioral differences between `Kernel.rand` and `Random.rand` when provided with a Float.

Interestingly, when asked explicitly and with Thinking enabled, ChatGPT [correctly differentiates](https://chatgpt.com/s/t_68b7b4e4c30081918e322c7f8eecf84f), but having been trained on the current docs, it's creating bugs in everyday code.