### PR TITLE
ZJIT: Surface documentation

### DIFF
--- a/doc/zjit.md
+++ b/doc/zjit.md
@@ -24,6 +24,10 @@ To run code snippets with ZJIT:
 You can also try https://www.rubyexplorer.xyz/ to view Ruby YARV disasm output with syntax highlighting
 in a way that can be easily shared with other team members.
 
+## Documentation
+
+You can generate and open the source level documentation in your browser using `cargo doc --open --document-private-items`.
+
 ## Testing
 
 Make sure you have a `--enable-zjit=dev` build, and install the following tools:

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -1,3 +1,5 @@
+//! Model for creating generating textual assembler code.
+
 use std::collections::BTreeMap;
 use std::fmt;
 use std::ops::Range;

--- a/zjit/src/backend/mod.rs
+++ b/zjit/src/backend/mod.rs
@@ -1,3 +1,5 @@
+//! A multi-platform assembler generation backend.
+
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 

--- a/zjit/src/bitset.rs
+++ b/zjit/src/bitset.rs
@@ -1,3 +1,5 @@
+//! Optimized bitset implementation.
+
 type Entry = u128;
 
 const ENTRY_NUM_BITS: usize = Entry::BITS as usize;

--- a/zjit/src/cast.rs
+++ b/zjit/src/cast.rs
@@ -1,3 +1,5 @@
+//! Optimized [usize] casting trait.
+
 /// Trait for casting to [usize] that allows you to say `.as_usize()`.
 /// Implementation conditional on the cast preserving the numeric value on
 /// all inputs and being inexpensive.

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1,3 +1,5 @@
+//! This module is for native code generation.
+
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 use std::ffi::{c_int, c_long, c_void};

--- a/zjit/src/distribution.rs
+++ b/zjit/src/distribution.rs
@@ -4,7 +4,7 @@
 #[derive(Debug, Clone)]
 pub struct Distribution<T: Copy + PartialEq + Default, const N: usize> {
     /// buckets and counts have the same length
-    /// buckets[0] is always the most common item
+    /// `buckets[0]` is always the most common item
     buckets: [T; N],
     counts: [usize; N],
     /// if there is no more room, increment the fallback

--- a/zjit/src/distribution.rs
+++ b/zjit/src/distribution.rs
@@ -1,3 +1,5 @@
+//! Type frequency distribution tracker.
+
 /// This implementation was inspired by the type feedback module from Google's S6, which was
 /// written in C++ for use with Python. This is a new implementation in Rust created for use with
 /// Ruby instead of Python.

--- a/zjit/src/gc.rs
+++ b/zjit/src/gc.rs
@@ -219,7 +219,7 @@ pub fn remove_gc_offsets(payload_ptr: *mut IseqPayload, removed_range: &Range<Co
     });
 }
 
-/// Return true if given Range<CodePtr> ranges overlap with each other
+/// Return true if given `Range<CodePtr>` ranges overlap with each other
 fn ranges_overlap<T>(left: &Range<T>, right: &Range<T>) -> bool where T: PartialOrd {
     left.start < right.end && right.start < left.end
 }

--- a/zjit/src/gc.rs
+++ b/zjit/src/gc.rs
@@ -1,4 +1,4 @@
-// This module is responsible for marking/moving objects on GC.
+//! This module is responsible for marking/moving objects on GC.
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -1,3 +1,5 @@
+//! High-level intermediate representation types.
+
 #![allow(non_upper_case_globals)]
 use crate::cruby::{Qfalse, Qnil, Qtrue, VALUE, RUBY_T_ARRAY, RUBY_T_STRING, RUBY_T_HASH, RUBY_T_CLASS, RUBY_T_MODULE};
 use crate::cruby::{rb_cInteger, rb_cFloat, rb_cArray, rb_cHash, rb_cString, rb_cSymbol, rb_cObject, rb_cTrueClass, rb_cFalseClass, rb_cNilClass, rb_cRange, rb_cSet, rb_cRegexp, rb_cClass, rb_cModule, rb_zjit_singleton_class_p};

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -63,7 +63,7 @@ impl Invariants {
         Self::update_iseq_references(&mut self.no_ep_escape_iseqs);
     }
 
-    /// Update ISEQ references in a given HashSet<IseqPtr>
+    /// Update ISEQ references in a given `HashSet<IseqPtr>`
     fn update_iseq_references(iseqs: &mut HashSet<IseqPtr>) {
         let mut moved: Vec<IseqPtr> = Vec::with_capacity(iseqs.len());
 

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -1,3 +1,5 @@
+//! Code invalidation and patching for speculative optimizations.
+
 use std::{collections::{HashMap, HashSet}, mem};
 
 use crate::{backend::lir::{asm_comment, Assembler}, cruby::{rb_callable_method_entry_t, rb_gc_location, ruby_basic_operators, src_loc, with_vm_lock, IseqPtr, RedefinitionFlag, ID, VALUE}, gc::IseqPayload, hir::Invariant, options::debug, state::{zjit_enabled_p, ZJITState}, virtualmem::CodePtr};

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -1,3 +1,5 @@
+//! Configurable options for ZJIT.
+
 use std::{ffi::{CStr, CString}, ptr::null};
 use std::os::raw::{c_char, c_int, c_uint};
 use crate::cruby::*;

--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -1,3 +1,5 @@
+//! Profiler for runtime information.
+
 // We use the YARV bytecode constants which have a CRuby-style name
 #![allow(non_upper_case_globals)]
 

--- a/zjit/src/state.rs
+++ b/zjit/src/state.rs
@@ -1,3 +1,5 @@
+//! Runtime state of ZJIT.
+
 use crate::codegen::{gen_exit_trampoline, gen_exit_trampoline_with_counter, gen_function_stub_hit_trampoline};
 use crate::cruby::{self, rb_bug_panic_hook, rb_vm_insn_count, EcPtr, Qnil, VALUE, VM_INSTRUCTION_SIZE};
 use crate::cruby_methods;

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -1,3 +1,5 @@
+//! Counters and associated methods for events when ZJIT is run.
+
 use std::time::Instant;
 
 use crate::{cruby::*, hir::ParseError, options::get_option, state::{zjit_enabled_p, ZJITState}};


### PR DESCRIPTION
<img width="1316" height="1046" alt="Screenshot 2025-09-03 at 3 41 12 PM" src="https://github.com/user-attachments/assets/5c25358a-4e3c-4964-940b-179cab9b1779" />

Surfaces existing written source level documentation for those who want to view types or use the `cargo doc` web search tooling.