### PR TITLE
ZJIT: Support compiling ISEQs for opt_pc = 0

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -327,10 +327,19 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 2, allowed_iseqs: 'entry@-e:2'
   end
 
-  def test_optional_arguments
-    assert_compiles '[1, 2]', %q{
+  def test_send_optional_arguments
+    assert_compiles '[[1, 2], [3, 4]]', %q{
       def test(a, b = 2) = [a, b]
-      test(1)
+      def entry = [test(1), test(3, 4)]
+      entry
+      entry
+    }, call_threshold: 2
+  end
+
+  def test_iseq_with_optional_arguments
+    assert_compiles '[[1, 2], [3, 4]]', %q{
+      def test(a, b = 2) = [a, b]
+      [test(1), test(3, 4)]
     }
   end
 

--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -327,6 +327,13 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 2, allowed_iseqs: 'entry@-e:2'
   end
 
+  def test_optional_arguments
+    assert_compiles '[1, 2]', %q{
+      def test(a, b = 2) = [a, b]
+      test(1)
+    }
+  end
+
   def test_invokebuiltin
     omit 'Test fails at the moment due to not handling optional parameters'
     assert_compiles '["."]', %q{

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -101,6 +101,7 @@ make_counters! {
         exit_callee_side_exit,
         exit_obj_to_string_fallback,
         exit_interrupt,
+        exit_optional_arguments,
     }
 
     // unhanded_call_: Unhandled call types
@@ -126,7 +127,6 @@ make_counters! {
     compile_error_parse_malformed_iseq,
     compile_error_parse_validation,
     compile_error_parse_not_allowed,
-    compile_error_parse_parameter_type_optional,
     compile_error_parse_parameter_type_forwardable,
 
     // The number of times YARV instructions are executed on JIT code
@@ -208,7 +208,6 @@ pub fn exit_counter_for_compile_error(compile_error: &CompileError) -> Counter {
             Validation(_)     => compile_error_parse_validation,
             NotAllowed        => compile_error_parse_not_allowed,
             UnknownParameterType(parameter_type) => match parameter_type {
-                Optional      => compile_error_parse_parameter_type_optional,
                 Forwardable   => compile_error_parse_parameter_type_forwardable,
             }
         }


### PR DESCRIPTION
This PR adds support for compiling ISEQs with optional arguments for the case that no optional arguments are supplied. It's out of scope in this PR to support other cases, which are much more involved to implement.

It makes optional arguments a less significant source of exits, bumping `ratio_in_zjit` from 62.1% to 63.9% on lobsters.

### Before
```
Top-5 compile error reasons (100.0% of total 1,924,289):
     parse_parameter_type_optional: 1,159,711 (60.3%)
           register_spill_on_alloc:   366,525 (19.0%)
  parse_parameter_type_forwardable:   253,437 (13.2%)
           register_spill_on_ccall:   124,237 ( 6.5%)
                 exception_handler:    20,379 ( 1.1%)
Top-10 side exit reasons (100.0% of total 4,960,850):
           compile_error: 1,924,289 (38.8%)
     unhandled_yarv_insn: 1,719,939 (34.7%)
      guard_type_failure:   393,821 ( 7.9%)
     guard_shape_failure:   355,090 ( 7.2%)
     unhandled_call_type:   270,202 ( 5.4%)
              patchpoint:   149,380 ( 3.0%)
   unknown_newarray_send:   124,975 ( 2.5%)
      unhandled_hir_insn:    16,011 ( 0.3%)
  obj_to_string_fallback:     7,127 ( 0.1%)
               interrupt:        16 ( 0.0%)
```

### After
```
Top-4 compile error reasons (100.0% of total 1,105,567):
           register_spill_on_alloc: 655,167 (59.3%)
  parse_parameter_type_forwardable: 253,437 (22.9%)
           register_spill_on_ccall: 176,590 (16.0%)
                 exception_handler:  20,373 ( 1.8%)
Top-11 side exit reasons (100.0% of total 4,738,638):
     unhandled_yarv_insn: 1,776,178 (37.5%)
           compile_error: 1,105,567 (23.3%)
      optional_arguments:   492,629 (10.4%)
      guard_type_failure:   412,168 ( 8.7%)
     guard_shape_failure:   366,404 ( 7.7%)
     unhandled_call_type:   281,617 ( 5.9%)
              patchpoint:   155,620 ( 3.3%)
   unknown_newarray_send:   125,081 ( 2.6%)
      unhandled_hir_insn:    16,011 ( 0.3%)
  obj_to_string_fallback:     7,349 ( 0.2%)
               interrupt:        14 ( 0.0%)
```