### PR TITLE
ZJIT: Compile invokesuper with dynamic dispatch

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5083,6 +5083,19 @@ mod tests {
     }
 
     #[test]
+    fn test_cant_compile_super_nil_blockarg() {
+        eval("
+            def test = super(&nil)
+        ");
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          v4:NilClass = Const Value(nil)
+          SideExit UnhandledCallType(BlockArg)
+        ");
+    }
+
+    #[test]
     fn test_cant_compile_super_forward() {
         eval("
             def test(...) = super(...)


### PR DESCRIPTION
This PR starts compiling `invokesuper` with dynamic dispatch, partly taking over https://github.com/ruby/ruby/pull/14400. Non-dynamic dispatch calls are out of scope in this PR.

It also relaxes the `has_send` (renamed to `has_blockiseq`) condition in `compute_bytecode_info` to instructions with `blockiseq`, which are required to modify parent locals in those instructions without acquiring Binding.

It increases `ratio_in_zjit` on lobsters from 64.2% to 66.8%.