### PR TITLE
ZJIT: Run test-basic as well

### DIFF
--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -43,7 +43,7 @@ jobs:
             configure: '--enable-zjit=dev'
             testopts: '--seed=11831'
 
-          - test_task: 'btest'
+          - test_task: 'test'
             configure: '--enable-zjit=dev'
             zjit_opts: '--zjit-call-threshold=1'
 

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -64,7 +64,7 @@ jobs:
             configure: '--enable-zjit=dev'
             testopts: '--seed=18140'
 
-          - test_task: 'btest'
+          - test_task: 'test'
             configure: '--enable-zjit=dev'
             zjit_opts: '--zjit-call-threshold=1'
 


### PR DESCRIPTION
This PR lets CI test `make test` instead of `make btest`.

`make test` (part of `make check`) runs `make btest-ruby` (superset of `make btest`, which also runs the runner with a built Ruby), `make test-knownbug`, and `make test-basic`. They all seem to pass, so we can test more.