### PR TITLE
ZJIT: Invalidate local variables on EP escape

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1133,7 +1133,7 @@ $(srcs_vpath)insns_info.inc: $(tooldir)/ruby_vm/views/insns_info.inc.erb $(inc_c
   $(tooldir)/ruby_vm/views/_insn_type_chars.erb $(tooldir)/ruby_vm/views/_insn_name_info.erb \
   $(tooldir)/ruby_vm/views/_insn_len_info.erb $(tooldir)/ruby_vm/views/_insn_operand_info.erb \
   $(tooldir)/ruby_vm/views/_attributes.erb $(tooldir)/ruby_vm/views/_comptime_insn_stack_increase.erb \
-  $(tooldir)/ruby_vm/views/_zjit_helpers.erb
+  $(tooldir)/ruby_vm/views/_zjit_helpers.erb $(tooldir)/ruby_vm/views/_insn_leaf_info.erb
 $(srcs_vpath)vmtc.inc: $(tooldir)/ruby_vm/views/vmtc.inc.erb $(inc_common_headers)
 $(srcs_vpath)vm.inc: $(tooldir)/ruby_vm/views/vm.inc.erb $(inc_common_headers) \
   $(tooldir)/ruby_vm/views/_insn_entry.erb $(tooldir)/ruby_vm/views/_trace_instruction.erb \

--- a/template/Makefile.in
+++ b/template/Makefile.in
@@ -679,6 +679,7 @@ $(INSNS): $(srcdir)/insns.def vm_opts.h \
 	  $(tooldir)/ruby_vm/views/_comptime_insn_stack_increase.erb \
 	  $(tooldir)/ruby_vm/views/_copyright.erb \
 	  $(tooldir)/ruby_vm/views/_insn_entry.erb \
+	  $(tooldir)/ruby_vm/views/_insn_leaf_info.erb \
 	  $(tooldir)/ruby_vm/views/_insn_len_info.erb \
 	  $(tooldir)/ruby_vm/views/_insn_name_info.erb \
 	  $(tooldir)/ruby_vm/views/_insn_operand_info.erb \

--- a/test/.excludes-zjit/TestRubyOptimization.rb
+++ b/test/.excludes-zjit/TestRubyOptimization.rb
@@ -1,1 +1,0 @@
-exclude(:test_side_effect_in_popped_splat, 'Test fails with ZJIT due to locals invalidation')

--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -196,6 +196,50 @@ class TestZJIT < Test::Unit::TestCase
     }, insns: [:setglobal]
   end
 
+  def test_getlocal_after_eval
+    assert_compiles '2', %q{
+      def test
+        a = 1
+        eval('a = 2')
+        a
+      end
+      test
+    }
+  end
+
+  def test_getlocal_after_instance_eval
+    assert_compiles '2', %q{
+      def test
+        a = 1
+        instance_eval('a = 2')
+        a
+      end
+      test
+    }
+  end
+
+  def test_getlocal_after_module_eval
+    assert_compiles '2', %q{
+      def test
+        a = 1
+        Kernel.module_eval('a = 2')
+        a
+      end
+      test
+    }
+  end
+
+  def test_getlocal_after_class_eval
+    assert_compiles '2', %q{
+      def test
+        a = 1
+        Kernel.class_eval('a = 2')
+        a
+      end
+      test
+    }
+  end
+
   def test_setlocal
     assert_compiles '3', %q{
       def test(n)
@@ -1453,8 +1497,7 @@ class TestZJIT < Test::Unit::TestCase
   end
 
   def test_bop_invalidation
-    omit 'Invalidation on BOP redefinition is not implemented yet'
-    assert_compiles '', %q{
+    assert_compiles '100', %q{
       def test
         eval(<<~RUBY)
           class Integer

--- a/tool/ruby_vm/views/_insn_leaf_info.erb
+++ b/tool/ruby_vm/views/_insn_leaf_info.erb
@@ -1,0 +1,18 @@
+MAYBE_UNUSED(static bool insn_leaf(int insn, const VALUE *opes));
+static bool
+insn_leaf(int insn, const VALUE *opes)
+{
+    switch (insn) {
+% RubyVM::Instructions.each do |insn|
+%   next if insn.is_a?(RubyVM::TraceInstructions) || insn.is_a?(RubyVM::ZJITInstructions)
+      case <%= insn.bin %>:
+        return attr_leaf_<%= insn.name %>(<%=
+          insn.operands.map.with_index do |ope, i|
+            "(#{ope[:type]})opes[#{i}]"
+          end.join(', ')
+        %>);
+% end
+      default:
+        return false;
+    }
+}

--- a/tool/ruby_vm/views/insns_info.inc.erb
+++ b/tool/ruby_vm/views/insns_info.inc.erb
@@ -21,5 +21,6 @@
 <%= render 'sp_inc_helpers' %>
 <%= render 'zjit_helpers' %>
 <%= render 'attributes' %>
+<%= render 'insn_leaf_info' %>
 <%= render 'comptime_insn_stack_increase' %>
 #endif

--- a/vm.c
+++ b/vm.c
@@ -1061,7 +1061,7 @@ vm_make_env_each(const rb_execution_context_t * const ec, rb_control_frame_t *co
     // Invalidate JIT code that assumes cfp->ep == vm_base_ptr(cfp).
     if (env->iseq) {
         rb_yjit_invalidate_ep_is_bp(env->iseq);
-        rb_zjit_invalidate_ep_is_bp(env->iseq);
+        rb_zjit_invalidate_no_ep_escape(env->iseq);
     }
 
     return (VALUE)env;

--- a/vm_eval.c
+++ b/vm_eval.c
@@ -1985,6 +1985,10 @@ eval_string_with_cref(VALUE self, VALUE src, rb_cref_t *cref, VALUE file, int li
     block.as.captured.code.iseq = cfp->iseq;
     block.type = block_type_iseq;
 
+    // EP is not escaped to the heap here, but captured and reused by another frame.
+    // ZJIT's locals are incompatible with it unlike YJIT's, so invalidate the ISEQ for ZJIT.
+    rb_zjit_invalidate_no_ep_escape(cfp->iseq);
+
     iseq = eval_make_iseq(src, file, line, &block);
     if (!iseq) {
         rb_exc_raise(ec->errinfo);

--- a/zjit.c
+++ b/zjit.c
@@ -333,6 +333,12 @@ rb_zjit_defined_ivar(VALUE obj, ID id, VALUE pushval)
     return result ? pushval : Qnil;
 }
 
+bool
+rb_zjit_insn_leaf(int insn, const VALUE *opes)
+{
+    return insn_leaf(insn, opes);
+}
+
 // Primitives used by zjit.rb. Don't put other functions below, which wouldn't use them.
 VALUE rb_zjit_assert_compiles(rb_execution_context_t *ec, VALUE self);
 VALUE rb_zjit_stats(rb_execution_context_t *ec, VALUE self, VALUE target_key);

--- a/zjit.h
+++ b/zjit.h
@@ -18,7 +18,7 @@ void rb_zjit_profile_insn(uint32_t insn, rb_execution_context_t *ec);
 void rb_zjit_profile_enable(const rb_iseq_t *iseq);
 void rb_zjit_bop_redefined(int redefined_flag, enum ruby_basic_operators bop);
 void rb_zjit_cme_invalidate(const rb_callable_method_entry_t *cme);
-void rb_zjit_invalidate_ep_is_bp(const rb_iseq_t *iseq);
+void rb_zjit_invalidate_no_ep_escape(const rb_iseq_t *iseq);
 void rb_zjit_constant_state_changed(ID id);
 void rb_zjit_iseq_mark(void *payload);
 void rb_zjit_iseq_update_references(void *payload);
@@ -31,7 +31,7 @@ static inline void rb_zjit_profile_insn(uint32_t insn, rb_execution_context_t *e
 static inline void rb_zjit_profile_enable(const rb_iseq_t *iseq) {}
 static inline void rb_zjit_bop_redefined(int redefined_flag, enum ruby_basic_operators bop) {}
 static inline void rb_zjit_cme_invalidate(const rb_callable_method_entry_t *cme) {}
-static inline void rb_zjit_invalidate_ep_is_bp(const rb_iseq_t *iseq) {}
+static inline void rb_zjit_invalidate_no_ep_escape(const rb_iseq_t *iseq) {}
 static inline void rb_zjit_constant_state_changed(ID id) {}
 static inline void rb_zjit_before_ractor_spawn(void) {}
 static inline void rb_zjit_tracing_invalidate_all(void) {}

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -358,6 +358,7 @@ fn main() {
         .allowlist_function("rb_zjit_print_exception")
         .allowlist_function("rb_zjit_singleton_class_p")
         .allowlist_function("rb_zjit_defined_ivar")
+        .allowlist_function("rb_zjit_insn_leaf")
         .allowlist_type("robject_offsets")
         .allowlist_type("rstring_offsets")
         .allowlist_var("RB_INVALID_SHAPE_ID")

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -939,6 +939,7 @@ unsafe extern "C" {
     pub fn rb_zjit_print_exception();
     pub fn rb_zjit_singleton_class_p(klass: VALUE) -> bool;
     pub fn rb_zjit_defined_ivar(obj: VALUE, id: ID, pushval: VALUE) -> VALUE;
+    pub fn rb_zjit_insn_leaf(insn: ::std::os::raw::c_int, opes: *const VALUE) -> bool;
     pub fn rb_iseq_encoded_size(iseq: *const rb_iseq_t) -> ::std::os::raw::c_uint;
     pub fn rb_iseq_pc_at_idx(iseq: *const rb_iseq_t, insn_idx: u32) -> *mut VALUE;
     pub fn rb_iseq_opcode_at_pc(iseq: *const rb_iseq_t, pc: *const VALUE) -> ::std::os::raw::c_int;


### PR DESCRIPTION
This PR implements invalidation for local variables in case EP is escaped. It fixes 9 failures on `test-spec`.

There have been TODO comments in `gen_send*` to add a patch point after these `send`s, but it's not appropriate because its `FrameState` is a before-send state and there are many other non-leaf instructions. So this PR adds a patch point before getlocal/setlocal that follows any non-leaf instruction.