### PR TITLE
Mark leaf defined instructions as leaf

### DIFF
--- a/tool/ruby_vm/views/_leaf_helpers.erb
+++ b/tool/ruby_vm/views/_leaf_helpers.erb
@@ -25,7 +25,7 @@ leafness_of_defined(rb_num_t op_type)
       case DEFINED_YIELD:
       case DEFINED_REF:
       case DEFINED_ZSUPER:
-        return false;
+        return true;
       case DEFINED_CONST:
       case DEFINED_CONST_FROM:
         /* has rb_autoload_load(); */


### PR DESCRIPTION
For example, `defined?(yield)` never calls a method, so it's leaf.

Fixes: c2bfb4e93c674347b7eb09a30856e3d75f74cf4d