### PR TITLE
Allow IO#each_codepoint to work with unetc even when encoding conversion is active

### DIFF
--- a/io.c
+++ b/io.c
@@ -4947,7 +4947,7 @@ rb_io_each_codepoint(VALUE io)
             fptr->cbuf.off += n;
             fptr->cbuf.len -= n;
             rb_yield(UINT2NUM(c));
-            rb_io_check_byte_readable(fptr);
+            rb_io_check_char_readable(fptr);
         }
     }
     NEED_NEWLINE_DECORATOR_ON_READ_CHECK(fptr);

--- a/test/ruby/test_io.rb
+++ b/test/ruby/test_io.rb
@@ -467,6 +467,24 @@ class TestIO < Test::Unit::TestCase
     }
   end
 
+  def test_each_codepoint_with_ungetc
+    bug21562 = '[ruby-core:123176] [Bug #21562]'
+    with_read_pipe("") {|p|
+      p.binmode
+      p.ungetc("aa")
+      a = ""
+      p.each_codepoint { |c| a << c }
+      assert_equal("aa", a, bug21562)
+    }
+    with_read_pipe("") {|p|
+      p.set_encoding("ascii-8bit", universal_newline: true)
+      p.ungetc("aa")
+      a = ""
+      p.each_codepoint { |c| a << c }
+      assert_equal("aa", a, bug21562)
+    }
+  end
+
   def test_rubydev33072
     t = make_tempfile
     path = t.path


### PR DESCRIPTION
Using IO#each_codepoint together with IO#ungetc causes an unwanted exception when encoding conversion is active.

```
C:\>ruby -e "open('NUL', 'rt') { |f| f.ungetc('aa'); f.each_codepoint { |c| p c }}"
97
-e:1:in 'IO#each_codepoint': byte oriented read for character buffered IO (IOError)
        from -e:1:in 'block in <main>'
        from -e:1:in 'Kernel#open'
        from -e:1:in '<main>'
```

This PR allows calling IO#each_codepoint after IO#ungetc even when encoding conversion is enabled.
Fixes [Bug #21562]