### PR TITLE
Add a macro to manage the condition of no-inline version rb_current_ec

### DIFF
--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -17,6 +17,11 @@
 #define RB_NATIVETHREAD_LOCK_INIT PTHREAD_MUTEX_INITIALIZER
 #define RB_NATIVETHREAD_COND_INIT PTHREAD_COND_INITIALIZER
 
+// TLS can not be accessed across .so on arm64 and perhaps ppc64le too.
+#if defined(__arm64__) || defined(__aarch64__) || defined(__powerpc64__)
+# define RB_THREAD_CURRENT_EC_NOINLINE
+#endif
+
 // this data should be protected by timer_th.waiting_lock
 struct rb_thread_sched_waiting {
     enum thread_sched_waiting_flag {
@@ -133,8 +138,7 @@ struct rb_thread_sched {
 #ifdef RB_THREAD_LOCAL_SPECIFIER
   NOINLINE(void rb_current_ec_set(struct rb_execution_context_struct *));
 
-  # if defined(__arm64__) || defined(__aarch64__) || defined(__powerpc64__)
-    // TLS can not be accessed across .so on arm64 and perhaps ppc64le too.
+  # ifdef RB_THREAD_CURRENT_EC_NOINLINE
     NOINLINE(struct rb_execution_context_struct *rb_current_ec(void));
   # else
     RUBY_EXTERN RB_THREAD_LOCAL_SPECIFIER struct rb_execution_context_struct *ruby_current_ec;

--- a/vm.c
+++ b/vm.c
@@ -594,7 +594,7 @@ rb_current_ec_set(rb_execution_context_t *ec)
 }
 
 
-#if defined(__arm64__) || defined(__aarch64__) || defined(__powerpc64__)
+#ifdef RB_THREAD_CURRENT_EC_NOINLINE
 rb_execution_context_t *
 rb_current_ec(void)
 {

--- a/vm_core.h
+++ b/vm_core.h
@@ -1999,7 +1999,7 @@ static inline rb_execution_context_t *
 rb_current_execution_context(bool expect_ec)
 {
 #ifdef RB_THREAD_LOCAL_SPECIFIER
-  #if defined(__arm64__) || defined(__aarch64__) || defined(__powerpc64__)
+  #ifdef RB_THREAD_CURRENT_EC_NOINLINE
     rb_execution_context_t * volatile ec = rb_current_ec();
   #else
     rb_execution_context_t * volatile ec = ruby_current_ec;


### PR DESCRIPTION
This PR comes from the https://github.com/ruby/ruby/pull/14435#pullrequestreview-3184697090.

Add the macro RB_THREAD_CURRENT_EC_NOINLINE to manage the condition to use no-inline version rb_current_ec for a better maintainability.

