### PR TITLE
ZJIT: Merge `make check` jobs

### DIFF
--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -32,28 +32,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - test_task: 'zjit-check'
+          - test_task: 'check'
+            configure: '--enable-zjit=dev'
+            run_opts: '--zjit-call-threshold=1'
+            specopts: '-T --zjit-call-threshold=1'
+
+          - test_task: 'zjit-check' # zjit-test + quick feedback of test_zjit.rb
             configure: '--enable-yjit=dev --enable-zjit'
             rust_version: "1.85.0"
 
-          - test_task: 'ruby' # build test for combo build
+          - test_task: 'ruby'
+            hint: 'combo build test'
             configure: '--enable-yjit --enable-zjit'
-
-          - test_task: 'zjit-test-all'
-            configure: '--enable-zjit=dev'
-            testopts: '--seed=11831'
-
-          - test_task: 'test'
-            configure: '--enable-zjit=dev'
-            zjit_opts: '--zjit-call-threshold=1'
-
-          - test_task: 'test-spec'
-            configure: '--enable-zjit=dev'
-            specopts: '-T --zjit-call-threshold=1'
 
     env:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
-      RUN_OPTS: ${{ matrix.zjit_opts }}
+      RUN_OPTS: ${{ matrix.run_opts }}
       SPECOPTS: ${{ matrix.specopts }}
       TESTOPTS: ${{ matrix.testopts }}
 
@@ -117,6 +111,7 @@ jobs:
           RUN_OPTS="$RUN_OPTS"
           SPECOPTS="$SPECOPTS"
           TESTOPTS="$TESTOPTS"
+          TEST_EXCLUDES="$TEST_EXCLUDES"
         timeout-minutes: 60
         env:
           RUBY_TESTOPTS: '-q --tty=no'
@@ -124,6 +119,7 @@ jobs:
           SYNTAX_SUGGEST_TIMEOUT: '5'
           PRECHECK_BUNDLED_GEMS: 'no'
           TESTS: ${{ matrix.tests }}
+          TEST_EXCLUDES: '--excludes-dir=../src/test/.excludes-zjit --name=!/memory_leak/'
         continue-on-error: ${{ matrix.continue-on-test_task || false }}
 
   result:

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -51,30 +51,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - test_task: 'check'
+            configure: '--enable-zjit=dev'
+            run_opts: '--zjit-call-threshold=1'
+            specopts: '-T --zjit-call-threshold=1'
+
+          - test_task: 'zjit-check' # zjit-test + quick feedback of test_zjit.rb
+            configure: '--enable-yjit --enable-zjit=dev'
+            rust_version: '1.85.0'
+
           - test_task: 'zjit-bindgen'
             hint: 'To fix: use patch in logs'
             configure: '--enable-zjit=dev --with-gcc=clang-14'
             libclang_path: '/usr/lib/llvm-14/lib/libclang.so.1'
 
-          - test_task: 'zjit-check'
-            configure: '--enable-yjit --enable-zjit=dev'
-            rust_version: '1.85.0'
-
-          - test_task: 'zjit-test-all'
-            configure: '--enable-zjit=dev'
-            testopts: '--seed=18140'
-
-          - test_task: 'test'
-            configure: '--enable-zjit=dev'
-            zjit_opts: '--zjit-call-threshold=1'
-
-          - test_task: 'test-spec'
-            configure: '--enable-zjit=dev'
-            specopts: '-T --zjit-call-threshold=1'
-
     env:
       GITPULLOPTIONS: --no-tags origin ${{ github.ref }}
-      RUN_OPTS: ${{ matrix.zjit_opts }}
+      RUN_OPTS: ${{ matrix.run_opts }}
       YJIT_BENCH_OPTS: ${{ matrix.yjit_bench_opts }}
       SPECOPTS: ${{ matrix.specopts }}
       TESTOPTS: ${{ matrix.testopts }}
@@ -156,12 +149,13 @@ jobs:
         run: >-
           make -s ${{ matrix.test_task }} ${TESTS:+TESTS="$TESTS"}
           RUN_OPTS="$RUN_OPTS" MSPECOPT=--debug SPECOPTS="$SPECOPTS"
-          TESTOPTS="$TESTOPTS"
+          TESTOPTS="$TESTOPTS" TEST_EXCLUDES="$TEST_EXCLUDES"
           ZJIT_BINDGEN_DIFF_OPTS="$ZJIT_BINDGEN_DIFF_OPTS"
         timeout-minutes: 90
         env:
           RUBY_TESTOPTS: '-q --tty=no'
           TEST_BUNDLED_GEMS_ALLOW_FAILURES: ''
+          TEST_EXCLUDES: '--excludes-dir=../src/test/.excludes-zjit --name=!/memory_leak/'
           PRECHECK_BUNDLED_GEMS: 'no'
           SYNTAX_SUGGEST_TIMEOUT: '5'
           ZJIT_BINDGEN_DIFF_OPTS: '--exit-code'


### PR DESCRIPTION
This PR merges `make test`, `make test-all`, and `make test-spec` jobs into single `make check` job for ZJIT CI.

It also sorts the other of jobs in `matrix.include` to make them look more consistent and experiments with removing `--seed=11831`. If it becomes unstable again, I'll resurrect the test option.