### PR TITLE
ZJIT, YJIT: Make the workflow names consistent with file names

### DIFF
--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -1,4 +1,4 @@
-name: YJIT macOS Arm64
+name: YJIT macOS
 on:
   push:
     branches:

--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -1,4 +1,4 @@
-name: ZJIT macOS Arm64
+name: ZJIT macOS
 on:
   push:
     branches:


### PR DESCRIPTION
This PR makes the workflow names of `yjit-macos.yml` and `zjit-macos.yml` consistent with their file names like other workflows.

It's true that part of the point of having `*jit-macos.yml` is to test the arm64 backend, but it feels weird that only one of the architectures is named in the workflows, and the workflow names are so long that it makes it hard to read the details of the job in some UI.