### PR TITLE
Refine use of `Pathname::SEPARATOR_PAT`

### DIFF
--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -312,12 +312,12 @@ class Pathname
 
   if File::ALT_SEPARATOR
     # Separator list string.
-    SEPARATOR_LIST = "#{Regexp.quote File::ALT_SEPARATOR}#{Regexp.quote File::SEPARATOR}"
+    SEPARATOR_LIST = Regexp.quote "#{File::ALT_SEPARATOR}#{File::SEPARATOR}"
     # Regexp that matches a separator.
     SEPARATOR_PAT = /[#{SEPARATOR_LIST}]/
   else
-    SEPARATOR_LIST = "#{Regexp.quote File::SEPARATOR}"
-    SEPARATOR_PAT = /#{Regexp.quote File::SEPARATOR}/
+    SEPARATOR_LIST = Regexp.quote File::SEPARATOR
+    SEPARATOR_PAT = /#{SEPARATOR_LIST}/
   end
 
   if File.dirname('A:') == 'A:.' # DOSish drive letter
@@ -383,7 +383,7 @@ class Pathname
   def prepend_prefix(prefix, relpath) # :nodoc:
     if relpath.empty?
       File.dirname(prefix)
-    elsif /#{SEPARATOR_PAT}/o.match?(prefix)
+    elsif SEPARATOR_PAT.match?(prefix)
       prefix = File.dirname(prefix)
       prefix = File.join(prefix, "") if File.basename(prefix + 'a') != 'a'
       prefix + relpath
@@ -434,7 +434,7 @@ class Pathname
       end
     end
     pre.tr!(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
-    if /#{SEPARATOR_PAT}/o.match?(File.basename(pre))
+    if SEPARATOR_PAT.match?(File.basename(pre))
       names.shift while names[0] == '..'
     end
     self.class.new(prepend_prefix(pre, File.join(*names)))
@@ -483,7 +483,7 @@ class Pathname
       names.unshift base if base != '.'
     end
     pre.tr!(File::ALT_SEPARATOR, File::SEPARATOR) if File::ALT_SEPARATOR
-    if /#{SEPARATOR_PAT}/o.match?(File.basename(pre))
+    if SEPARATOR_PAT.match?(File.basename(pre))
       names.shift while names[0] == '..'
     end
     if names.empty?
@@ -528,7 +528,7 @@ class Pathname
   # pathnames which points to roots such as <tt>/usr/..</tt>.
   #
   def root?
-    chop_basename(@path) == nil && /#{SEPARATOR_PAT}/o.match?(@path)
+    chop_basename(@path) == nil && SEPARATOR_PAT.match?(@path)
   end
 
   # Predicate method for testing whether a path is absolute.
@@ -698,7 +698,7 @@ class Pathname
       basename_list2.shift
     end
     r1 = chop_basename(prefix1)
-    if !r1 && (r1 = /#{SEPARATOR_PAT}/o.match?(File.basename(prefix1)))
+    if !r1 && (r1 = SEPARATOR_PAT.match?(File.basename(prefix1)))
       while !basename_list2.empty? && basename_list2.first == '..'
         index_list2.shift
         basename_list2.shift


### PR DESCRIPTION
- Remove unnecessary string interpolations.
- `/#{SEPARATOR_PAT}/o` is always same as `SEPARATOR_PAT` Regexp.