### PR TITLE
ZJIT: Add --zjit-stats=quiet option to collect stats without printing

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -27,6 +27,30 @@ class TestZJIT < Test::Unit::TestCase
     RUBY
   end
 
+  def test_stats_quiet
+    # Test that --zjit-stats=quiet collects stats but doesn't print them
+    script = <<~RUBY
+      def test = 42
+      test
+      test
+      puts RubyVM::ZJIT.stats_enabled?
+    RUBY
+
+    stats_header = "***ZJIT: Printing ZJIT statistics on exit***"
+
+    # With --zjit-stats, stats should be printed to stderr
+    out, err, status = eval_with_jit(script, stats: true)
+    assert_success(out, err, status)
+    assert_includes(err, stats_header)
+    assert_equal("true\n", out)
+
+    # With --zjit-stats=quiet, stats should NOT be printed but still enabled
+    out, err, status = eval_with_jit(script, stats: :quiet)
+    assert_success(out, err, status)
+    refute_includes(err, stats_header)
+    assert_equal("true\n", out)
+  end
+
   def test_enable_through_env
     child_env = {'RUBY_YJIT_ENABLE' => nil, 'RUBY_ZJIT_ENABLE' => '1'}
     assert_in_out_err([child_env, '-v'], '') do |stdout, stderr|
@@ -2490,7 +2514,7 @@ class TestZJIT < Test::Unit::TestCase
     if zjit
       args << "--zjit-call-threshold=#{call_threshold}"
       args << "--zjit-num-profiles=#{num_profiles}"
-      args << "--zjit-stats" if stats
+      args << "--zjit-stats#{"=#{stats}" unless stats == true}" if stats
       args << "--zjit-debug" if debug
       if allowed_iseqs
         jitlist = Tempfile.new("jitlist")

--- a/zjit.c
+++ b/zjit.c
@@ -343,6 +343,7 @@ rb_zjit_insn_leaf(int insn, const VALUE *opes)
 VALUE rb_zjit_assert_compiles(rb_execution_context_t *ec, VALUE self);
 VALUE rb_zjit_stats(rb_execution_context_t *ec, VALUE self, VALUE target_key);
 VALUE rb_zjit_stats_enabled_p(rb_execution_context_t *ec, VALUE self);
+VALUE rb_zjit_print_stats_p(rb_execution_context_t *ec, VALUE self);
 
 // Preprocessed zjit.rb generated during build
 #include "zjit.rbinc"

--- a/zjit.rb
+++ b/zjit.rb
@@ -8,7 +8,7 @@
 # for which CRuby is built.
 module RubyVM::ZJIT
   # Avoid calling a Ruby method here to avoid interfering with compilation tests
-  if Primitive.rb_zjit_stats_enabled_p
+  if Primitive.rb_zjit_print_stats_p
     at_exit { print_stats }
   end
 end


### PR DESCRIPTION
Similar to YJIT's --yjit-stats=quiet, this option allows ZJIT to collect
statistics and make them available via the Ruby API without printing them
at exit. This is useful for programmatic access to stats without the
output noise.

- Added print_stats field to Options struct
- Modified option parsing to support --zjit-stats=quiet
- Added rb_zjit_print_stats_p primitive to check if stats should be printed
- Updated zjit.rb to only register at_exit handler when print_stats is true
- Update the help text shown by `ruby --help` to indicate that
  --zjit-stats now accepts an optional =quiet parameter.
- Added test for --zjit-stats=quiet option
