### PR TITLE
sync_default_gems.rb: Support `log.showSignature` case

### DIFF
--- a/tool/sync_default_gems.rb
+++ b/tool/sync_default_gems.rb
@@ -454,6 +454,10 @@ module SyncDefaultGems
     puts subject, "\n", log
   end
 
+  def log_format(format, args, &block)
+    IO.popen(%W[git log --no-show-signature --format=#{format}] + args, "rb", &block)
+  end
+
   # Returns commit list as array of [commit_hash, subject].
   def commits_in_ranges(gem, repo, default_branch, ranges)
     # If -a is given, discover all commits since the last picked commit
@@ -461,7 +465,7 @@ module SyncDefaultGems
       # \r? needed in the regex in case the commit has windows-style line endings (because e.g. we're running
       # tests on Windows)
       pattern = "https://github\.com/#{Regexp.quote(repo)}/commit/([0-9a-f]+)\r?$"
-      log = IO.popen(%W"git log -E --grep=#{pattern} -n1 --format=%B", "rb", &:read)
+      log = log_format('%B', %W"-E --grep=#{pattern} -n1", &:read)
       ranges = ["#{log[%r[#{pattern}\n\s*(?i:co-authored-by:.*)*\s*\Z], 1]}..#{gem}/#{default_branch}"]
     end
 
@@ -471,7 +475,7 @@ module SyncDefaultGems
         range = "#{range}~1..#{range}"
       end
 
-      IO.popen(%W"git log --format=%H,%s #{range} --", "rb") do |f|
+      log_format('%H,%s', %W"#{range} --") do |f|
         f.read.split("\n").reverse.map{|commit| commit.split(',', 2)}
       end
     end
@@ -626,7 +630,7 @@ module SyncDefaultGems
     end or return nil
 
     # Amend the commit if RDoc references need to be replaced
-    head = `git log --format=%H -1 HEAD`.chomp
+    head = log_format('%H', %W"-1 HEAD", &:read).chomp
     system(*%w"git reset --quiet HEAD~ --")
     amend = replace_rdoc_ref_all
     system(*%W"git reset --quiet #{head} --")

--- a/tool/test/test_sync_default_gems.rb
+++ b/tool/test/test_sync_default_gems.rb
@@ -90,12 +90,29 @@ module Test_SyncDefaultGems
       @target = nil
       pend "No git" unless system("git --version", out: IO::NULL)
       @testdir = Dir.mktmpdir("sync")
-      @git_config = %W"HOME GIT_CONFIG_GLOBAL".each_with_object({}) {|k, c| c[k] = ENV[k]}
+      user, email = "Ruby", "test@ruby-lang.org"
+      @git_config = %W"HOME USER GIT_CONFIG_GLOBAL GNUPGHOME".each_with_object({}) {|k, c| c[k] = ENV[k]}
       ENV["HOME"] = @testdir
+      ENV["USER"] = user
+      ENV["GNUPGHOME"] = @testdir + '/.gnupg'
+      expire = EnvUtil.apply_timeout_scale(30).to_i
+      # Generate a new unprotected key with default parameters that
+      # expires after 30 seconds.
+      if @gpgsign = system(*%w"gpg --quiet --batch --passphrase", "",
+                           "--quick-generate-key", email, *%W"default default seconds=#{expire}")
+        # Fetch the generated public key.
+        signingkey = IO.popen(%W"gpg --quiet --list-public-key #{email}", &:read)[/^pub .*\n +\K\h+/]
+      end
       ENV["GIT_CONFIG_GLOBAL"] = @testdir + "/gitconfig"
-      git(*%W"config --global user.email test@ruby-lang.org")
-      git(*%W"config --global user.name", "Ruby")
+      git(*%W"config --global user.email", email)
+      git(*%W"config --global user.name", user)
       git(*%W"config --global init.defaultBranch default")
+      if signingkey
+        git(*%W"config --global user.signingkey", signingkey)
+        git(*%W"config --global commit.gpgsign true")
+        git(*%W"config --global gpg.program gpg")
+        git(*%W"config --global log.showSignature true")
+      end
       @target = "sync-test"
       SyncDefaultGems::REPOSITORIES[@target] = ["ruby/#{@target}", "default"]
       @sha = {}
@@ -129,6 +146,9 @@ module Test_SyncDefaultGems
 
     def teardown
       if @target
+        if @gpgsign
+          system(*%W"gpgconf --kill all")
+        end
         Dir.chdir(@origdir)
         SyncDefaultGems::REPOSITORIES.delete(@target)
         ENV.update(@git_config)
@@ -168,7 +188,7 @@ module Test_SyncDefaultGems
     end
 
     def top_commit(dir, format: "%H")
-      IO.popen(%W[git log --format=#{format} -1], chdir: dir, &:read)&.chomp
+      IO.popen(%W[git log --no-show-signature --format=#{format} -1], chdir: dir, &:read)&.chomp
     end
 
     def assert_sync(commits = true, success: true, editor: nil)


### PR DESCRIPTION
When `log.showSignature` is set to `true`, `git log` output contains unexpected `gpg` outputs in addition to the output specified with `--format` options.