### PR TITLE
File.dirname: return consistent encoding for `"."`

### DIFF
--- a/file.c
+++ b/file.c
@@ -5060,8 +5060,11 @@ rb_file_dirname_n(VALUE fname, int n)
             break;
         }
     }
-    if (p == name)
-        return rb_usascii_str_new2(".");
+    if (p == name) {
+        dirname = rb_str_new(".", 1);
+        rb_enc_copy(dirname, fname);
+        return dirname;
+    }
 #ifdef DOSISH_DRIVE_LETTER
     if (has_drive_letter(name) && isdirsep(*(name + 2))) {
         const char *top = skiproot(name + 2, end, enc);


### PR DESCRIPTION
[[Bug #21561]](https://bugs.ruby-lang.org/issues/21561)

It's preferable if the method is consistent in the encoding in the returned string.