### PR TITLE
Align the conditions for did_you_mean

### DIFF
--- a/lib/rubygems/exceptions.rb
+++ b/lib/rubygems/exceptions.rb
@@ -21,13 +21,11 @@ class Gem::UnknownCommandError < Gem::Exception
   end
 
   def self.attach_correctable
-    return if defined?(@attached)
+    return if method_defined?(:corrections)
 
     if defined?(DidYouMean) && DidYouMean.respond_to?(:correct_error)
       DidYouMean.correct_error(Gem::UnknownCommandError, Gem::UnknownCommandSpellChecker)
     end
-
-    @attached = true
   end
 end
 

--- a/test/rubygems/test_gem_command_manager.rb
+++ b/test/rubygems/test_gem_command_manager.rb
@@ -79,7 +79,7 @@ class TestGemCommandManager < Gem::TestCase
 
     message = "Unknown command pish".dup
 
-    if defined?(DidYouMean)
+    if e.respond_to?(:corrections)
       message << "\nDid you mean?  \"push\""
     end
 


### PR DESCRIPTION
Probably due to the testing order, sometimes it looks like that `Gem::UnknownCommandError` happens to be used without registered in `DidYouMean`.