### PR TITLE
YJIT: Add more information to an assert message in jit_guard_known_class

### DIFF
--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -5027,7 +5027,7 @@ fn jit_guard_known_klass(
             assert_eq!(sample_instance.class_of(), rb_cString, "context says class is exactly ::String")
         };
     } else {
-        assert!(!val_type.is_imm(), "{insn_opnd:?} should not be immutable, but was {val_type:?} for {sample_instance:?}");
+        assert!(!val_type.is_imm(), "{insn_opnd:?} should be a heap object, but was {val_type:?} for {sample_instance:?}");
 
         // Check that the receiver is a heap object
         // Note: if we get here, the class doesn't have immediate instances.


### PR DESCRIPTION
This PR updates an assertion failure message to help us debug https://bugs.ruby-lang.org/issues/21565 further.

It seems like a compile-time `sample_instance` and the `Context` don't agree on each other. To see what's happening, I want to print both `sample_instance` (likely just a random pointer, but I just want to make sure it's not an immediate we don't handle) and the `val_type` in the `Context`. 

To ensure the consistency between `known_klass` and `sample_instance`, I refactored it to extract `known_klass` from `sample_instance` as well.