### PR TITLE
ZJIT: Avoid mutating string in zjit stats

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -101,7 +101,7 @@ class << RubyVM::ZJIT
     counters = stats.select { |key, value| key.start_with?(prefix) && value > 0 }
     return if stats.empty?
 
-    counters.transform_keys! { |key| key.to_s.delete_prefix!(prefix) }
+    counters.transform_keys! { |key| key.to_s.delete_prefix(prefix) }
     left_pad = counters.keys.map(&:size).max
     right_pad = counters.values.map { |value| number_with_delimiter(value).size }.max
     total = counters.values.sum


### PR DESCRIPTION
GitHub runs with a Symbol patch that causes a frozen string error when running `--zjit-stats`

```rb
Class Symbol
  alias_method :to_s, :name
end
```

I remember hearing that Shopify runs a similar patch, and that we might try to make this the default behavior in Ruby some day.

Any chance we can avoid mutating the string here in case it's frozen? That does mean we'll end up making some extra strings when it's not frozen, but I think that's OK for printing stats.