### PR TITLE
ZJIT: Compile ISEQs with forwardable parameters

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -439,6 +439,21 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 2
   end
 
+  def test_forwardable_iseq
+    assert_compiles '1', %q{
+      def test(...) = 1
+      test
+    }
+  end
+
+  def test_sendforward
+    assert_runs '[1, 2]', %q{
+      def callee(a, b) = [a, b]
+      def test(...) = callee(...)
+      test(1, 2)
+    }, insns: [:sendforward]
+  end
+
   def test_iseq_with_optional_arguments
     assert_compiles '[[1, 2], [3, 4]]', %q{
       def test(a, b = 2) = [a, b]

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -130,7 +130,6 @@ make_counters! {
     compile_error_parse_malformed_iseq,
     compile_error_parse_validation,
     compile_error_parse_not_allowed,
-    compile_error_parse_parameter_type_forwardable,
 
     // The number of times YARV instructions are executed on JIT code
     zjit_insn_count,
@@ -196,7 +195,6 @@ pub enum CompileError {
 /// Return a raw pointer to the exit counter for a given CompileError
 pub fn exit_counter_for_compile_error(compile_error: &CompileError) -> Counter {
     use crate::hir::ParseError::*;
-    use crate::hir::ParameterType::*;
     use crate::stats::CompileError::*;
     use crate::stats::Counter::*;
     match compile_error {
@@ -210,9 +208,6 @@ pub fn exit_counter_for_compile_error(compile_error: &CompileError) -> Counter {
             MalformedIseq(_)  => compile_error_parse_malformed_iseq,
             Validation(_)     => compile_error_parse_validation,
             NotAllowed        => compile_error_parse_not_allowed,
-            UnknownParameterType(parameter_type) => match parameter_type {
-                Forwardable   => compile_error_parse_parameter_type_forwardable,
-            }
         }
     }
 }


### PR DESCRIPTION
This PR stops failing compilation when ISEQ has forwardable parameters `...`.

The compiled code would then side-exit at `sendforward` anyway, but it still slightly improves `ratio_in_zjit` on lobsters from 66.4% to 66.9% by partly running the ISEQ. It's just a `ci` sitting in one of the locals, so as long as we spill locals to appropriate places at appropriate times (we do), there's nothing to worry about.