### PR TITLE
Fix tempfile leaking in TestRequire

### DIFF
--- a/test/ruby/test_require.rb
+++ b/test/ruby/test_require.rb
@@ -857,7 +857,7 @@ class TestRequire < Test::Unit::TestCase
         def to_path = @path
       end
 
-      def create_ruby_file = Tempfile.create(["test", ".rb"]).path
+      def create_ruby_file = Tempfile.open(["test", ".rb"]).path
 
       require MyString.new(create_ruby_file)
       $LOADED_FEATURES.unshift(create_ruby_file)


### PR DESCRIPTION
The test introduced in 928fea3 is leaking files because the Tempfile is not cleaned when the process exits. We see this in the output:

    Children under /var/folders/51/_yzlsvf96v9729jtj8_mcp7w0000gn/T/rubytest.7lbdlp:
    * -rw------- 1 0 2025-09-10 10:09:51 -0400 test20250910-13775-g4op87.rb
    * -rw------- 1 0 2025-09-10 10:09:51 -0400 test20250910-13775-pu621v.rb
    * -rw------- 1 0 2025-09-10 10:09:51 -0400 test20250910-13775-4xv688.rb
    * -rw------- 1 0 2025-09-10 10:09:51 -0400 test20250910-13775-1rvp4b.rb