### PR TITLE
YJIT: Rename `make yjit-smoke-test` to `make yjit-check`

### DIFF
--- a/doc/yjit/yjit.md
+++ b/doc/yjit/yjit.md
@@ -388,7 +388,7 @@ There are multiple test suites:
 - `make test-all`
 - `make test-spec`
 - `make check` runs all of the above
-- `make yjit-smoke-test` runs quick checks to see that YJIT is working correctly
+- `make yjit-check` runs quick checks to see that YJIT is working correctly
 
 The tests can be run in parallel like this:
 

--- a/yjit/yjit.mk
+++ b/yjit/yjit.mk
@@ -34,8 +34,8 @@ endif
 RUST_VERSION = +1.58.0
 
 # Gives quick feedback about YJIT. Not a replacement for a full test run.
-.PHONY: yjit-smoke-test
-yjit-smoke-test:
+.PHONY: yjit-check
+yjit-check:
 ifneq ($(strip $(CARGO)),)
 	$(CARGO) test --all-features -q --manifest-path='$(top_srcdir)/yjit/Cargo.toml'
 endif


### PR DESCRIPTION
for consistency with ZJIT. It's easier to remember if they have similar names.