### PR TITLE
Explicitly declare VM instruction dependencies

### DIFF
--- a/tool/ruby_vm/models/instructions.rb
+++ b/tool/ruby_vm/models/instructions.rb
@@ -12,11 +12,12 @@
 require_relative 'bare_instruction'
 require_relative 'operands_unification'
 require_relative 'instructions_unification'
+require_relative 'trace_instruction'
+require_relative 'zjit_instruction'
 
 RubyVM::Instructions = RubyVM::BareInstruction.all +
                        RubyVM::OperandsUnification.all +
-                       RubyVM::InstructionsUnification.all
-
-require_relative 'trace_instruction'
-require_relative 'zjit_instruction'
+                       RubyVM::InstructionsUnification.all +
+                       RubyVM::TraceInstruction.all +
+                       RubyVM::ZJITInstruction.all
 RubyVM::Instructions.freeze

--- a/tool/ruby_vm/models/trace_instruction.rb
+++ b/tool/ruby_vm/models/trace_instruction.rb
@@ -58,17 +58,13 @@ class RubyVM::TraceInstruction
     return false
   end
 
-  def zjit_profile?
-    return false
-  end
-
   private
 
-  @instances = RubyVM::Instructions.map {|i| new i }
+  @instances = (RubyVM::BareInstruction.all +
+                RubyVM::OperandsUnification.all +
+                RubyVM::InstructionsUnification.all).map {|i| new(i) }
 
   def self.all
     @instances
   end
-
-  RubyVM::Instructions.push(*all)
 end

--- a/tool/ruby_vm/models/zjit_instruction.rb
+++ b/tool/ruby_vm/models/zjit_instruction.rb
@@ -48,11 +48,9 @@ class RubyVM::ZJITInstruction
     return false
   end
 
-  @instances = RubyVM::Instructions.filter(&:zjit_profile?).map {|i| new(i) }
+  @instances = RubyVM::BareInstruction.all.filter(&:zjit_profile?).map {|i| new(i) }
 
   def self.all
     @instances
   end
-
-  RubyVM::Instructions.push(*all)
 end


### PR DESCRIPTION
instead of mutating RubyVM::Instructions and letting the order of `require` impact its behavior.

Now that we have both RubyVM::TraceInstruction and RubyVM::ZJITInstruction, it feels too much of a tight coupling to rely on `require` to be ordered properly. `require` calling `RubyVM::Instructions.push(*all)` seems like a surprising side effect.