### PR TITLE
Fix use of uninitialized memory in strings

### DIFF
--- a/spec/ruby/optional/capi/string_spec.rb
+++ b/spec/ruby/optional/capi/string_spec.rb
@@ -191,11 +191,19 @@ describe "C-API String function" do
     end
 
     it "returns a new String object filled with \\0 bytes" do
-      s = @s.rb_str_tmp_new(4)
-      s.encoding.should == Encoding::BINARY
-      s.bytesize.should == 4
-      s.size.should == 4
-      s.should == "\x00\x00\x00\x00"
+      lens = [4]
+
+      ruby_version_is "3.5" do
+        lens << 100
+      end
+
+      lens.each do |len|
+        s = @s.rb_str_tmp_new(len)
+        s.encoding.should == Encoding::BINARY
+        s.bytesize.should == len
+        s.size.should == len
+        s.should == "\x00" * len
+      end
     end
   end
 

--- a/string.c
+++ b/string.c
@@ -1066,6 +1066,9 @@ str_enc_new(VALUE klass, const char *ptr, long len, rb_encoding *enc)
     if (ptr) {
         memcpy(RSTRING_PTR(str), ptr, len);
     }
+    else {
+        memset(RSTRING_PTR(str), 0, len);
+    }
 
     STR_SET_LEN(str, len);
     TERM_FILL(RSTRING_PTR(str) + len, termlen);


### PR DESCRIPTION
Strings created from the C API with a len but no ptr have a buffer allocated and the length set, but the buffer is not zero'd. This causes use of uninitialized memory and allows reading memory that previously existed there.

For example, the rb_str_tmp_new spec fails when we create a string with a large length greater than 24 bytes (since we zero the first 24 bytes of the slot).