### PR TITLE
ZJIT: Let fallbacks handle unknown call types

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2967,17 +2967,8 @@ fn compute_bytecode_info(iseq: *const rb_iseq_t) -> BytecodeInfo {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum CallType {
-    Splat,
     BlockArg,
-    Kwarg,
-    KwSplat,
     Tailcall,
-    Super,
-    Zsuper,
-    OptSend,
-    KwSplatMut,
-    SplatMut,
-    Forwarding,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -2995,17 +2986,8 @@ fn num_locals(iseq: *const rb_iseq_t) -> usize {
 
 /// If we can't handle the type of send (yet), bail out.
 fn unknown_call_type(flag: u32) -> Result<(), CallType> {
-    if (flag & VM_CALL_KW_SPLAT_MUT) != 0 { return Err(CallType::KwSplatMut); }
-    if (flag & VM_CALL_ARGS_SPLAT_MUT) != 0 { return Err(CallType::SplatMut); }
-    if (flag & VM_CALL_ARGS_SPLAT) != 0 { return Err(CallType::Splat); }
-    if (flag & VM_CALL_KW_SPLAT) != 0 { return Err(CallType::KwSplat); }
     if (flag & VM_CALL_ARGS_BLOCKARG) != 0 { return Err(CallType::BlockArg); }
-    if (flag & VM_CALL_KWARG) != 0 { return Err(CallType::Kwarg); }
     if (flag & VM_CALL_TAILCALL) != 0 { return Err(CallType::Tailcall); }
-    if (flag & VM_CALL_SUPER) != 0 { return Err(CallType::Super); }
-    if (flag & VM_CALL_ZSUPER) != 0 { return Err(CallType::Zsuper); }
-    if (flag & VM_CALL_OPT_SEND) != 0 { return Err(CallType::OptSend); }
-    if (flag & VM_CALL_FORWARDING) != 0 { return Err(CallType::Forwarding); }
     Ok(())
 }
 
@@ -5125,7 +5107,9 @@ mod tests {
         fn test@<compiled>:2:
         bb0(v0:BasicObject, v1:BasicObject):
           v6:ArrayExact = ToArray v1
-          SideExit UnhandledCallType(Splat)
+          v8:BasicObject = SendWithoutBlock v0, :foo, v6
+          CheckInterrupts
+          Return v8
         ");
     }
 
@@ -5150,7 +5134,9 @@ mod tests {
         fn test@<compiled>:2:
         bb0(v0:BasicObject, v1:BasicObject):
           v5:Fixnum[1] = Const Value(1)
-          SideExit UnhandledCallType(Kwarg)
+          v7:BasicObject = SendWithoutBlock v0, :foo, v5
+          CheckInterrupts
+          Return v7
         ");
     }
 
@@ -5162,7 +5148,9 @@ mod tests {
         assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:2:
         bb0(v0:BasicObject, v1:BasicObject):
-          SideExit UnhandledCallType(KwSplat)
+          v6:BasicObject = SendWithoutBlock v0, :foo, v1
+          CheckInterrupts
+          Return v6
         ");
     }
 
@@ -5251,7 +5239,9 @@ mod tests {
           v13:StaticSymbol[:b] = Const Value(VALUE(0x1008))
           v14:Fixnum[1] = Const Value(1)
           v16:BasicObject = SendWithoutBlock v12, :core#hash_merge_ptr, v11, v13, v14
-          SideExit UnhandledCallType(KwSplatMut)
+          v18:BasicObject = SendWithoutBlock v0, :foo, v16
+          CheckInterrupts
+          Return v18
         ");
     }
 
@@ -5266,7 +5256,9 @@ mod tests {
           v6:ArrayExact = ToNewArray v1
           v7:Fixnum[1] = Const Value(1)
           ArrayPush v6, v7
-          SideExit UnhandledCallType(SplatMut)
+          v11:BasicObject = SendWithoutBlock v0, :foo, v6
+          CheckInterrupts
+          Return v11
         ");
     }
 
@@ -7862,7 +7854,9 @@ mod opt_tests {
         fn test@<compiled>:3:
         bb0(v0:BasicObject):
           v4:Fixnum[1] = Const Value(1)
-          SideExit UnhandledCallType(Kwarg)
+          v6:BasicObject = SendWithoutBlock v0, :foo, v4
+          CheckInterrupts
+          Return v6
         ");
     }
 
@@ -7878,7 +7872,9 @@ mod opt_tests {
         fn test@<compiled>:3:
         bb0(v0:BasicObject):
           v4:Fixnum[1] = Const Value(1)
-          SideExit UnhandledCallType(Kwarg)
+          v6:BasicObject = SendWithoutBlock v0, :foo, v4
+          CheckInterrupts
+          Return v6
         ");
     }
 

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -108,17 +108,8 @@ make_counters! {
     }
 
     // unhanded_call_: Unhandled call types
-    unhandled_call_splat,
     unhandled_call_block_arg,
-    unhandled_call_kwarg,
-    unhandled_call_kw_splat,
     unhandled_call_tailcall,
-    unhandled_call_super,
-    unhandled_call_zsuper,
-    unhandled_call_optsend,
-    unhandled_call_kw_splat_mut,
-    unhandled_call_splat_mut,
-    unhandled_call_forwarding,
 
     // compile_error_: Compile error reasons
     compile_error_iseq_stack_too_large,
@@ -166,17 +157,8 @@ pub fn exit_counter_ptr_for_call_type(call_type: crate::hir::CallType) -> *mut u
     use crate::hir::CallType::*;
     use crate::stats::Counter::*;
     let counter = match call_type {
-        Splat      => unhandled_call_splat,
-        BlockArg   => unhandled_call_block_arg,
-        Kwarg      => unhandled_call_kwarg,
-        KwSplat    => unhandled_call_kw_splat,
-        Tailcall   => unhandled_call_tailcall,
-        Super      => unhandled_call_super,
-        Zsuper     => unhandled_call_zsuper,
-        OptSend    => unhandled_call_optsend,
-        KwSplatMut => unhandled_call_kw_splat_mut,
-        SplatMut   => unhandled_call_splat_mut,
-        Forwarding => unhandled_call_forwarding,
+        BlockArg => unhandled_call_block_arg,
+        Tailcall => unhandled_call_tailcall,
     };
     counter_ptr(counter)
 }


### PR DESCRIPTION
This PR stops giving up compilation on most call flags, except for `VM_CALL_ARGS_BLOCKARG` and `VM_CALL_TAILCALL`.

Now that we call the interpreter fallbacks correctly, we can rely on them to handle un-optimizable arguments. `VM_CALL_ARGS_BLOCKARG` needs a tweak in the number of basic block arguments, so it's left for another PR. These fallbacks are not compatible with `VM_CALL_TAILCALL`, so it's skipped as well.

It increases `ratio_in_zjit` on lobsters from 68.0% to 68.7%.