### PR TITLE
ZJIT, YJIT: Drop "// From xxx.h" comments in bindgen

### DIFF
--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -65,35 +65,24 @@ fn main() {
         // Import YARV bytecode instruction constants
         .allowlist_type("ruby_vminsn_type")
 
-        // From include/ruby/internal/special_consts.h
         .allowlist_type("ruby_special_consts")
-
-        // From include/ruby/internal/intern/string.h
         .allowlist_function("rb_utf8_str_new")
         .allowlist_function("rb_str_buf_append")
         .allowlist_function("rb_str_dup")
-
-        // From encindex.h
         .allowlist_type("ruby_preserved_encindex")
-
-        // From include/ruby/ruby.h
         .allowlist_function("rb_class2name")
 
         // This struct is public to Ruby C extensions
-        // From include/ruby/internal/core/rbasic.h
         .allowlist_type("RBasic")
 
-        // From include/ruby/internal/core/rstring.h
         .allowlist_type("ruby_rstring_flags")
 
-        // From internal.h
         // This function prints info about a value and is useful for debugging
         .allowlist_function("rb_obj_info_dump")
 
         // For crashing
         .allowlist_function("rb_bug")
 
-        // From shape.h
         .allowlist_function("rb_obj_shape_id")
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")
@@ -103,36 +92,20 @@ fn main() {
         .allowlist_function("rb_yjit_shape_index")
         .allowlist_var("SHAPE_ID_NUM_BITS")
         .allowlist_var("SHAPE_ID_HAS_IVAR_MASK")
-
-        // From ruby/internal/eval.h
         .allowlist_function("rb_funcall")
-
-        // From ruby/internal/intern/object.h
         .allowlist_function("rb_obj_is_kind_of")
         .allowlist_function("rb_obj_frozen_p")
-
-        // From ruby/internal/encoding/encoding.h
         .allowlist_type("ruby_encoding_consts")
-
-        // From include/hash.h
         .allowlist_function("rb_hash_new")
-
-        // From internal/hash.h
         .allowlist_function("rb_hash_new_with_size")
         .allowlist_function("rb_hash_resurrect")
         .allowlist_function("rb_hash_stlike_foreach")
         .allowlist_function("rb_to_hash_type")
-
-        // From include/ruby/st.h
         .allowlist_type("st_retval")
-
-        // From include/ruby/internal/intern/hash.h
         .allowlist_function("rb_hash_aset")
         .allowlist_function("rb_hash_aref")
         .allowlist_function("rb_hash_bulk_insert")
         .allowlist_function("rb_hash_stlike_lookup")
-
-        // From include/ruby/internal/intern/array.h
         .allowlist_function("rb_ary_new_capa")
         .allowlist_function("rb_ary_store")
         .allowlist_function("rb_ary_resurrect")
@@ -142,26 +115,17 @@ fn main() {
         .allowlist_function("rb_ary_push")
         .allowlist_function("rb_ary_unshift_m")
         .allowlist_function("rb_yjit_rb_ary_subseq_length")
-
-        // From internal/array.h
         .allowlist_function("rb_ec_ary_new_from_values")
         .allowlist_function("rb_ary_tmp_new_from_values")
-
-        // From include/ruby/internal/intern/class.h
         .allowlist_function("rb_class_attached_object")
         .allowlist_function("rb_singleton_class")
-
-        // From include/ruby/internal/core/rclass.h
         .allowlist_function("rb_class_get_superclass")
-
-        // From include/ruby/internal/gc.h
         .allowlist_function("rb_gc_mark")
         .allowlist_function("rb_gc_mark_movable")
         .allowlist_function("rb_gc_location")
         .allowlist_function("rb_gc_writebarrier")
 
         // VALUE variables for Ruby class objects
-        // From include/ruby/internal/globals.h
         .allowlist_var("rb_cBasicObject")
         .allowlist_var("rb_cModule")
         .allowlist_var("rb_cNilClass")
@@ -178,84 +142,53 @@ fn main() {
         .allowlist_var("rb_cHash")
         .allowlist_var("rb_cClass")
 
-        // From include/ruby/internal/fl_type.h
         .allowlist_type("ruby_fl_type")
         .allowlist_type("ruby_fl_ushift")
-
-        // From include/ruby/internal/core/robject.h
         .allowlist_type("ruby_robject_flags")
-
-        // From include/ruby/internal/core/rarray.h
         .allowlist_type("ruby_rarray_flags")
         .allowlist_type("ruby_rarray_consts")
-
-        // From include/ruby/internal/core/rclass.h
         .allowlist_type("ruby_rmodule_flags")
-
-        // From ruby/internal/globals.h
         .allowlist_var("rb_mKernel")
-
-        // From vm_callinfo.h
         .allowlist_type("vm_call_flag_bits")
         .allowlist_type("rb_call_data")
         .blocklist_type("rb_callcache.*")      // Not used yet - opaque to make it easy to import rb_call_data
         .opaque_type("rb_callcache.*")
         .allowlist_type("rb_callinfo")
-
-        // From vm_insnhelper.h
         .allowlist_var("VM_ENV_DATA_INDEX_ME_CREF")
         .allowlist_var("rb_block_param_proxy")
-
-        // From include/ruby/internal/intern/range.h
         .allowlist_function("rb_range_new")
-
-        // From include/ruby/internal/symbol.h
         .allowlist_function("rb_intern")
         .allowlist_function("rb_intern2")
         .allowlist_function("rb_id2sym")
         .allowlist_function("rb_id2name")
         .allowlist_function("rb_sym2id")
         .allowlist_function("rb_str_intern")
-
-        // From internal/numeric.h
         .allowlist_function("rb_fix_aref")
         .allowlist_function("rb_float_plus")
         .allowlist_function("rb_float_minus")
         .allowlist_function("rb_float_mul")
         .allowlist_function("rb_float_div")
-
-        // From internal/string.h
         .allowlist_type("ruby_rstring_private_flags")
         .allowlist_function("rb_ec_str_resurrect")
         .allowlist_function("rb_str_concat_literals")
         .allowlist_function("rb_obj_as_string_result")
         .allowlist_function("rb_str_byte_substr")
         .allowlist_function("rb_str_substr_two_fixnums")
-
-        // From include/ruby/internal/intern/parse.h
         .allowlist_function("rb_backref_get")
-
-        // From include/ruby/internal/intern/re.h
         .allowlist_function("rb_reg_last_match")
         .allowlist_function("rb_reg_match_pre")
         .allowlist_function("rb_reg_match_post")
         .allowlist_function("rb_reg_match_last")
         .allowlist_function("rb_reg_nth_match")
-
-        // From internal/re.h
         .allowlist_function("rb_reg_new_ary")
 
         // `ruby_value_type` is a C enum and this stops it from
         // prefixing all the members with the name of the type
         .prepend_enum_name(false)
         .translate_enum_integer_types(true) // so we get fixed width Rust types for members
-        // From include/ruby/internal/value_type.h
         .allowlist_type("ruby_value_type") // really old C extension API
 
-        // From include/ruby/internal/hash.h
         .allowlist_type("ruby_rhash_flags") // really old C extension API
-
-        // From method.h
         .allowlist_type("rb_method_visibility_t")
         .allowlist_type("rb_method_type_t")
         .allowlist_type("method_optimized_type")
@@ -266,11 +199,7 @@ fn main() {
         .blocklist_type("rb_method_cfunc_t")
         .blocklist_type("rb_method_definition_.*") // Large struct with a bitfield and union of many types - don't import (yet?)
         .opaque_type("rb_method_definition_.*")
-
-        // From numeric.c
         .allowlist_function("rb_float_new")
-
-        // From vm_core.h
         .allowlist_var("rb_cRubyVM")
         .allowlist_var("rb_mRubyVMFrozenCore")
         .allowlist_var("VM_BLOCK_HANDLER_NONE")
@@ -309,8 +238,6 @@ fn main() {
         .allowlist_type("vm_check_match_type")
         .allowlist_type("vm_opt_newarray_send_type")
         .allowlist_type("rb_iseq_type")
-
-        // From yjit.c
         .allowlist_function("rb_object_shape_count")
         .allowlist_function("rb_ivar_get_at")
         .allowlist_function("rb_ivar_get_at_no_ractor_check")
@@ -347,8 +274,6 @@ fn main() {
         .allowlist_function("rb_yjit_set_exception_return")
         .allowlist_function("rb_yjit_str_concat_codepoint")
         .allowlist_type("rstring_offsets")
-
-        // From jit.c
         .allowlist_function("rb_assert_holding_vm_lock")
         .allowlist_function("rb_jit_shape_too_complex_p")
         .allowlist_function("rb_jit_multi_ractor_p")
@@ -356,58 +281,35 @@ fn main() {
         .allowlist_function("rb_jit_vm_unlock")
         .allowlist_function("rb_jit_for_each_iseq")
         .allowlist_type("robject_offsets")
-
-        // from vm_sync.h
         .allowlist_function("rb_vm_barrier")
 
         // Not sure why it's picking these up, but don't.
         .blocklist_type("FILE")
         .blocklist_type("_IO_.*")
 
-        // From internal/compile.h
         .allowlist_function("rb_vm_insn_decode")
-
-        // from internal/cont.h
         .allowlist_function("rb_jit_cont_each_iseq")
-
-        // From iseq.h
         .allowlist_function("rb_vm_insn_addr2opcode")
         .allowlist_function("rb_iseqw_to_iseq")
         .allowlist_function("rb_iseq_label")
         .allowlist_function("rb_iseq_line_no")
         .allowlist_type("defined_type")
-
-        // From builtin.h
         .allowlist_type("rb_builtin_function.*")
-
-        // From internal/variable.h
         .allowlist_function("rb_gvar_(get|set)")
         .allowlist_function("rb_ensure_iv_list_size")
-
-        // From include/ruby/internal/intern/variable.h
         .allowlist_function("rb_attr_get")
         .allowlist_function("rb_ivar_defined")
         .allowlist_function("rb_ivar_get")
         .allowlist_function("rb_mod_name")
         .allowlist_function("rb_const_get")
-
-        // From internal/vm.h
         .allowlist_var("rb_vm_insn_count")
-
-        // From include/ruby/internal/intern/vm.h
         .allowlist_function("rb_get_alloc_func")
-
-        // From internal/object.h
         .allowlist_function("rb_class_allocate_instance")
         .allowlist_function("rb_obj_equal")
         .allowlist_function("rb_class_new_instance_pass_kw")
         .allowlist_function("rb_obj_alloc")
-
-        // From gc.h and internal/gc.h
         .allowlist_function("rb_obj_info")
         .allowlist_function("ruby_xfree")
-
-        // From include/ruby/debug.h
         .allowlist_function("rb_profile_frames")
 
         // Functions used for code generation
@@ -491,7 +393,6 @@ fn main() {
         // We define VALUE manually, don't import it
         .blocklist_type("VALUE")
 
-        // From iseq.h
         .opaque_type("rb_iseq_t")
         .blocklist_type("rb_iseq_t")
 

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -69,32 +69,21 @@ fn main() {
         // Import YARV bytecode instruction constants
         .allowlist_type("ruby_vminsn_type")
 
-        // From include/ruby/internal/special_consts.h
         .allowlist_type("ruby_special_consts")
-
-        // From include/ruby/internal/intern/string.h
         .allowlist_function("rb_utf8_str_new")
         .allowlist_function("rb_str_buf_append")
         .allowlist_function("rb_str_dup")
-
-        // From encindex.h
         .allowlist_type("ruby_preserved_encindex")
-
-        // From include/ruby/ruby.h
         .allowlist_function("rb_class2name")
 
         // This struct is public to Ruby C extensions
-        // From include/ruby/internal/core/rbasic.h
         .allowlist_type("RBasic")
 
-        // From include/ruby/internal/core/rstring.h
         .allowlist_type("ruby_rstring_flags")
 
-        // From internal.h
         // This function prints info about a value and is useful for debugging
         .allowlist_function("rb_obj_info_dump")
 
-        // For testing
         .allowlist_function("ruby_init")
         .allowlist_function("ruby_init_stack")
         .allowlist_function("ruby_options")
@@ -106,40 +95,25 @@ fn main() {
         // For crashing
         .allowlist_function("rb_bug")
 
-        // From shape.h
         .allowlist_function("rb_obj_shape_id")
         .allowlist_function("rb_shape_id_offset")
         .allowlist_function("rb_shape_get_iv_index")
         .allowlist_function("rb_shape_transition_add_ivar_no_warnings")
         .allowlist_var("SHAPE_ID_NUM_BITS")
-
-        // From ruby/internal/intern/object.h
         .allowlist_function("rb_obj_is_kind_of")
         .allowlist_function("rb_obj_frozen_p")
         .allowlist_function("rb_class_inherited_p")
-
-        // From ruby/internal/encoding/encoding.h
         .allowlist_type("ruby_encoding_consts")
-
-        // From include/hash.h
         .allowlist_function("rb_hash_new")
-
-        // From internal/hash.h
         .allowlist_function("rb_hash_new_with_size")
         .allowlist_function("rb_hash_resurrect")
         .allowlist_function("rb_hash_stlike_foreach")
         .allowlist_function("rb_to_hash_type")
-
-        // From include/ruby/st.h
         .allowlist_type("st_retval")
-
-        // From include/ruby/internal/intern/hash.h
         .allowlist_function("rb_hash_aset")
         .allowlist_function("rb_hash_aref")
         .allowlist_function("rb_hash_bulk_insert")
         .allowlist_function("rb_hash_stlike_lookup")
-
-        // From include/ruby/internal/intern/array.h
         .allowlist_function("rb_ary_new_capa")
         .allowlist_function("rb_ary_store")
         .allowlist_function("rb_ary_resurrect")
@@ -149,20 +123,12 @@ fn main() {
         .allowlist_function("rb_ary_dup")
         .allowlist_function("rb_ary_push")
         .allowlist_function("rb_ary_unshift_m")
-
-        // From internal/array.h
         .allowlist_function("rb_ec_ary_new_from_values")
         .allowlist_function("rb_ary_tmp_new_from_values")
-
-        // From include/ruby/internal/intern/class.h
         .allowlist_function("rb_class_attached_object")
         .allowlist_function("rb_singleton_class")
         .allowlist_function("rb_define_class")
-
-        // From include/ruby/internal/core/rclass.h
         .allowlist_function("rb_class_get_superclass")
-
-        // From include/ruby/internal/gc.h
         .allowlist_function("rb_gc_mark")
         .allowlist_function("rb_gc_mark_movable")
         .allowlist_function("rb_gc_location")
@@ -170,7 +136,6 @@ fn main() {
         .allowlist_function("rb_gc_writebarrier_remember")
 
         // VALUE variables for Ruby class objects
-        // From include/ruby/internal/globals.h
         .allowlist_var("rb_cBasicObject")
         .allowlist_var("rb_cObject")
         .allowlist_var("rb_cModule")
@@ -192,38 +157,21 @@ fn main() {
         .allowlist_var("rb_cRegexp")
         .allowlist_var("rb_cISeq")
 
-        // From include/ruby/internal/fl_type.h
         .allowlist_type("ruby_fl_type")
         .allowlist_type("ruby_fl_ushift")
-
-        // From include/ruby/internal/core/robject.h
         .allowlist_type("ruby_robject_flags")
-
-        // From include/ruby/internal/core/rarray.h
         .allowlist_type("ruby_rarray_flags")
         .allowlist_type("ruby_rarray_consts")
-
-        // From include/ruby/internal/core/rclass.h
         .allowlist_type("ruby_rmodule_flags")
-
-        // From ruby/internal/globals.h
         .allowlist_var("rb_mKernel")
-
-        // From vm_callinfo.h
         .allowlist_type("vm_call_flag_bits")
         .allowlist_type("rb_call_data")
         .blocklist_type("rb_callcache.*")      // Not used yet - opaque to make it easy to import rb_call_data
         .opaque_type("rb_callcache.*")
         .allowlist_type("rb_callinfo")
-
-        // From vm_insnhelper.h
         .allowlist_var("VM_ENV_DATA_INDEX_ME_CREF")
         .allowlist_var("rb_block_param_proxy")
-
-        // From include/ruby/internal/intern/range.h
         .allowlist_function("rb_range_new")
-
-        // From include/ruby/internal/symbol.h
         .allowlist_function("rb_intern")
         .allowlist_function("rb_intern2")
         .allowlist_function("rb_id2sym")
@@ -231,38 +179,26 @@ fn main() {
         .allowlist_function("rb_str_intern")
         .allowlist_function("rb_id2str")
         .allowlist_function("rb_sym2str")
-
-        // From internal/numeric.h
         .allowlist_function("rb_fix_aref")
         .allowlist_function("rb_float_plus")
         .allowlist_function("rb_float_minus")
         .allowlist_function("rb_float_mul")
         .allowlist_function("rb_float_div")
-
-        // From internal/string.h
         .allowlist_type("ruby_rstring_private_flags")
         .allowlist_function("rb_ec_str_resurrect")
         .allowlist_function("rb_str_concat_literals")
         .allowlist_function("rb_obj_as_string_result")
         .allowlist_function("rb_str_byte_substr")
         .allowlist_function("rb_str_substr_two_fixnums")
-
-        // From include/ruby/internal/intern/parse.h
         .allowlist_function("rb_backref_get")
-
-        // From include/ruby/internal/intern/re.h
         .allowlist_function("rb_reg_last_match")
         .allowlist_function("rb_reg_match_pre")
         .allowlist_function("rb_reg_match_post")
         .allowlist_function("rb_reg_match_last")
         .allowlist_function("rb_reg_nth_match")
-
-        // From internal/re.h
         .allowlist_function("rb_reg_new_ary")
         .allowlist_var("ARG_ENCODING_FIXED")
         .allowlist_var("ARG_ENCODING_NONE")
-
-        // From include/ruby/onigmo.h
         .allowlist_var("ONIG_OPTION_IGNORECASE")
         .allowlist_var("ONIG_OPTION_EXTEND")
         .allowlist_var("ONIG_OPTION_MULTILINE")
@@ -271,13 +207,9 @@ fn main() {
         // prefixing all the members with the name of the type
         .prepend_enum_name(false)
         .translate_enum_integer_types(true) // so we get fixed width Rust types for members
-        // From include/ruby/internal/value_type.h
         .allowlist_type("ruby_value_type") // really old C extension API
 
-        // From include/ruby/internal/hash.h
         .allowlist_type("ruby_rhash_flags") // really old C extension API
-
-        // From method.h
         .allowlist_type("rb_method_visibility_t")
         .allowlist_type("rb_method_type_t")
         .allowlist_type("method_optimized_type")
@@ -288,11 +220,7 @@ fn main() {
         .blocklist_type("rb_method_cfunc_t")
         .blocklist_type("rb_method_definition_.*") // Large struct with a bitfield and union of many types - don't import (yet?)
         .opaque_type("rb_method_definition_.*")
-
-        // From numeric.c
         .allowlist_function("rb_float_new")
-
-        // From vm_core.h
         .allowlist_var("rb_mRubyVMFrozenCore")
         .allowlist_var("VM_BLOCK_HANDLER_NONE")
         .allowlist_type("vm_frame_env_flags")
@@ -331,8 +259,6 @@ fn main() {
         .allowlist_type("vm_opt_newarray_send_type")
         .allowlist_type("rb_iseq_type")
         .allowlist_type("rb_event_flag_t")
-
-        // From zjit.c
         .allowlist_function("rb_object_shape_count")
         .allowlist_function("rb_iseq_(get|set)_zjit_payload")
         .allowlist_function("rb_iseq_pc_at_idx")
@@ -362,8 +288,6 @@ fn main() {
         .allowlist_type("robject_offsets")
         .allowlist_type("rstring_offsets")
         .allowlist_var("RB_INVALID_SHAPE_ID")
-
-        // From jit.c
         .allowlist_function("rb_assert_holding_vm_lock")
         .allowlist_function("rb_jit_shape_too_complex_p")
         .allowlist_function("rb_jit_multi_ractor_p")
@@ -372,59 +296,36 @@ fn main() {
         .allowlist_function("rb_jit_for_each_iseq")
         .allowlist_function("rb_iseq_reset_jit_func")
         .allowlist_type("robject_offsets")
-
-        // from vm_sync.h
         .allowlist_function("rb_vm_barrier")
 
         // Not sure why it's picking these up, but don't.
         .blocklist_type("FILE")
         .blocklist_type("_IO_.*")
 
-        // From internal/compile.h
         .allowlist_function("rb_vm_insn_decode")
-
-        // from internal/cont.h
         .allowlist_function("rb_jit_cont_each_iseq")
-
-        // From iseq.h
         .allowlist_function("rb_vm_insn_addr2opcode")
         .allowlist_function("rb_iseqw_to_iseq")
         .allowlist_function("rb_iseq_label")
         .allowlist_function("rb_iseq_line_no")
         .allowlist_function("rb_iseq_defined_string")
         .allowlist_type("defined_type")
-
-        // From builtin.h
         .allowlist_type("rb_builtin_function.*")
-
-        // From internal/variable.h
         .allowlist_function("rb_gvar_(get|set)")
         .allowlist_function("rb_ensure_iv_list_size")
-
-        // From include/ruby/internal/intern/variable.h
         .allowlist_function("rb_attr_get")
         .allowlist_function("rb_ivar_defined")
         .allowlist_function("rb_ivar_get")
         .allowlist_function("rb_ivar_set")
         .allowlist_function("rb_mod_name")
-
-        // From internal/vm.h
         .allowlist_var("rb_vm_insn_count")
-
-        // From include/ruby/internal/intern/vm.h
         .allowlist_function("rb_get_alloc_func")
-
-        // From internal/object.h
         .allowlist_function("rb_class_allocate_instance")
         .allowlist_function("rb_obj_equal")
         .allowlist_function("rb_class_new_instance_pass_kw")
         .allowlist_function("rb_obj_alloc")
-
-        // From gc.h and internal/gc.h
         .allowlist_function("rb_obj_info")
         .allowlist_function("ruby_xfree")
-
-        // From include/ruby/debug.h
         .allowlist_function("rb_profile_frames")
 
         // Functions used for code generation
@@ -505,7 +406,6 @@ fn main() {
         .blocklist_type("VALUE")
         .blocklist_type("ID")
 
-        // From iseq.h
         .opaque_type("rb_iseq_t")
         .blocklist_type("rb_iseq_t")
 


### PR DESCRIPTION
This PR removes `// From xxx.h` comments from `main.rs` for bindgen.

While they makes it harder to add entries to bindgen, they don't really explain why they need to be imported. It doesn't seem to help us maintain the code. It turns out other team members don't appreciate them either, so let's just remove them.