### PR TITLE
Explicitly use a ruby version for prism to parse the code as

### DIFF
--- a/depend
+++ b/depend
@@ -1415,6 +1415,7 @@ compile.$(OBJEXT): $(top_srcdir)/prism/util/pm_strncasecmp.h
 compile.$(OBJEXT): $(top_srcdir)/prism/util/pm_strpbrk.h
 compile.$(OBJEXT): $(top_srcdir)/prism/version.h
 compile.$(OBJEXT): $(top_srcdir)/prism_compile.c
+compile.$(OBJEXT): $(top_srcdir)/version.h
 compile.$(OBJEXT): {$(VPATH)}assert.h
 compile.$(OBJEXT): {$(VPATH)}atomic.h
 compile.$(OBJEXT): {$(VPATH)}backward/2/assume.h
@@ -1605,6 +1606,7 @@ compile.$(OBJEXT): {$(VPATH)}prism_compile.h
 compile.$(OBJEXT): {$(VPATH)}ractor.h
 compile.$(OBJEXT): {$(VPATH)}re.h
 compile.$(OBJEXT): {$(VPATH)}regex.h
+compile.$(OBJEXT): {$(VPATH)}revision.h
 compile.$(OBJEXT): {$(VPATH)}ruby_assert.h
 compile.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 compile.$(OBJEXT): {$(VPATH)}rubyparser.h

--- a/prism_compile.c
+++ b/prism_compile.c
@@ -1,4 +1,5 @@
 #include "prism.h"
+#include "version.h"
 
 /**
  * This compiler defines its own concept of the location of a node. We do this
@@ -11352,6 +11353,8 @@ pm_parse_file(pm_parse_result_t *result, VALUE filepath, VALUE *script_lines)
     pm_options_filepath_set(&result->options, RSTRING_PTR(filepath));
     RB_GC_GUARD(filepath);
 
+    pm_options_version_for_current_ruby_set(&result->options);
+
     pm_parser_init(&result->parser, pm_string_source(&result->input), pm_string_length(&result->input), &result->options);
     pm_node_t *node = pm_parse(&result->parser);
 
@@ -11409,6 +11412,8 @@ pm_parse_string(pm_parse_result_t *result, VALUE source, VALUE filepath, VALUE *
     result->node.filepath_encoding = rb_enc_get(filepath);
     pm_options_filepath_set(&result->options, RSTRING_PTR(filepath));
     RB_GC_GUARD(filepath);
+
+    pm_options_version_for_current_ruby_set(&result->options);
 
     pm_parser_init(&result->parser, pm_string_source(&result->input), pm_string_length(&result->input), &result->options);
     pm_node_t *node = pm_parse(&result->parser);
@@ -11490,6 +11495,13 @@ pm_parse_stdin(pm_parse_result_t *result)
     rb_reset_argf_lineno(0);
 
     return pm_parse_process(result, node, NULL);
+}
+
+#define PM_VERSION_FOR_RELEASE(major, minor) PM_VERSION_FOR_RELEASE_IMPL(major, minor)
+#define PM_VERSION_FOR_RELEASE_IMPL(major, minor) PM_OPTIONS_VERSION_CRUBY_##major##_##minor
+
+void pm_options_version_for_current_ruby_set(pm_options_t *options) {
+    options->version = PM_VERSION_FOR_RELEASE(RUBY_VERSION_MAJOR, RUBY_VERSION_MINOR);
 }
 
 #undef NEW_ISEQ

--- a/prism_compile.h
+++ b/prism_compile.h
@@ -94,6 +94,7 @@ VALUE pm_parse_file(pm_parse_result_t *result, VALUE filepath, VALUE *script_lin
 VALUE pm_load_parse_file(pm_parse_result_t *result, VALUE filepath, VALUE *script_lines);
 VALUE pm_parse_string(pm_parse_result_t *result, VALUE source, VALUE filepath, VALUE *script_lines);
 VALUE pm_parse_stdin(pm_parse_result_t *result);
+void pm_options_version_for_current_ruby_set(pm_options_t *options);
 void pm_parse_result_free(pm_parse_result_t *result);
 
 rb_iseq_t *pm_iseq_new(pm_scope_node_t *node, VALUE name, VALUE path, VALUE realpath, const rb_iseq_t *parent, enum rb_iseq_type, int *error_state);


### PR DESCRIPTION
Prism can parse multiple versions of ruby. Because of that branch release managers are ok with simply bumping prism to its latest version.

However, if no version is specified, it will parse as the latest known version, which can be ahead of the maintenance branch. So we need to explicitly pass a version to not accidentally introduce new syntax to maintenance branches.

Since prism and ruby are developed independently from each other, the version can't be derived from `RUBY_VERSION`, since by the time that the next ruby version is bumped, prism does not yet know about that new ruby version. So I check for development versions and simply use LATEST there.

I believe this is what you were talking about in https://github.com/ruby/ruby/pull/14358#issuecomment-3229656013 @xrxr. For now, there is still no 3.5-specific syntax.

