### PR TITLE
ZJIT: Add specific dynamic send type counters

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -44,6 +44,7 @@ class << RubyVM::ZJIT
     print_counters_with_prefix(prefix: 'unhandled_yarv_insn_', prompt: 'unhandled YARV insns', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'compile_error_', prompt: 'compile error reasons', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'exit_', prompt: 'side exit reasons', buf:, stats:, limit: 20)
+    print_counters_with_prefix(prefix: 'dynamic_send_type_', prompt: 'dynamic send types', buf:, stats:, limit: 20)
 
     # Show the most important stats ratio_in_zjit at the end
     print_counters([

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -137,6 +137,10 @@ make_counters! {
 
     // The number of times we do a dynamic dispatch from JIT code
     dynamic_send_count,
+    dynamic_send_type_send_without_block,
+    dynamic_send_type_send,
+    dynamic_send_type_invokeblock,
+    dynamic_send_type_invokesuper,
 }
 
 /// Increase a counter by a specified amount


### PR DESCRIPTION
Example:

```
Top-4 dynamic send types (100.0% of total 37,786,075):
  send_without_block: 31,286,046 (82.8%)
                send:  6,204,474 (16.4%)
         invokeblock:    274,220 ( 0.7%)
         invokesuper:     21,335 ( 0.1%)
```