### PR TITLE
Exclude leading logical tests for parsey

### DIFF
--- a/test/.excludes-parsey/Prism/FixturesTest.rb
+++ b/test/.excludes-parsey/Prism/FixturesTest.rb
@@ -1,0 +1,1 @@
+exclude(:"test_leading_logical.txt", "Requires Feature #20925 to be implemented on parse.y")

--- a/test/.excludes-parsey/Prism/LocalsTest.rb
+++ b/test/.excludes-parsey/Prism/LocalsTest.rb
@@ -1,0 +1,1 @@
+exclude(:"test_leading_logical.txt", "Requires Feature #20925 to be implemented on parse.y")


### PR DESCRIPTION
Prism implemented https://bugs.ruby-lang.org/issues/20925 but parse.y doesn't seem to support it yet and is failing related Prism tests on CI.

This adds excludes for the tests that are failing.