### PR TITLE
ZJIT: Add stat for `def_type` of send fallbacks

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -44,6 +44,7 @@ class << RubyVM::ZJIT
     print_counters_with_prefix(prefix: 'compile_error_', prompt: 'compile error reasons', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'exit_', prompt: 'side exit reasons', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'dynamic_send_type_', prompt: 'dynamic send types', buf:, stats:, limit: 20)
+    print_counters_with_prefix(prefix: 'send_fallback_', prompt: 'send fallback def_types', buf:, stats:, limit: 20)
 
     # Show the most important stats ratio_in_zjit at the end
     print_counters([

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -135,6 +135,20 @@ make_counters! {
     dynamic_send_type_send,
     dynamic_send_type_invokeblock,
     dynamic_send_type_invokesuper,
+
+    // Method call def_type related to fallback to dynamic dispatch
+    send_fallback_iseq,
+    send_fallback_cfunc,
+    send_fallback_attrset,
+    send_fallback_ivar,
+    send_fallback_bmethod,
+    send_fallback_zsuper,
+    send_fallback_alias,
+    send_fallback_undef,
+    send_fallback_not_implemented,
+    send_fallback_optimized,
+    send_fallback_missing,
+    send_fallback_refined,
 }
 
 /// Increase a counter by a specified amount
@@ -219,6 +233,26 @@ pub fn exit_counter_ptr(reason: crate::hir::SideExitReason) -> *mut u64 {
         BlockParamProxyNotIseqOrIfunc => exit_block_param_proxy_not_iseq_or_ifunc,
     };
     counter_ptr(counter)
+}
+
+pub fn send_fallback_counter(def_type: crate::hir::MethodType) -> Counter {
+    use crate::hir::MethodType::*;
+    use crate::stats::Counter::*;
+
+    match def_type {
+        Iseq => send_fallback_iseq,
+        Cfunc => send_fallback_cfunc,
+        Attrset => send_fallback_attrset,
+        Ivar => send_fallback_ivar,
+        Bmethod => send_fallback_bmethod,
+        Zsuper => send_fallback_zsuper,
+        Alias => send_fallback_alias,
+        Undefined => send_fallback_undef,
+        NotImplemented => send_fallback_not_implemented,
+        Optimized => send_fallback_optimized,
+        Missing => send_fallback_missing,
+        Refined => send_fallback_refined,
+    }
 }
 
 /// Primitive called in zjit.rb. Zero out all the counters.


### PR DESCRIPTION
I thought about creating a new HIR like `SendWithoutBlockFailedToOptimize` that can carry very specific reasons later. But it'll mean adding it to every branch matching `SendWithoutBlock` and may make code unnecessarily complicated.

So I take the easier path for now:

```
Top-4 send fallback def_types (100.0% of total 21,375,357):
      cfunc: 20,164,487 (94.3%)
  optimized:  1,197,897 ( 5.6%)
    attrset:     12,953 ( 0.1%)
      alias:         20 ( 0.0%)
```