### PR TITLE
Suppress warning from net/http.rb in ruby 3.1

### DIFF
--- a/tool/downloader.rb
+++ b/tool/downloader.rb
@@ -6,7 +6,9 @@
 require 'fileutils'
 require 'open-uri'
 require 'pathname'
+verbose, $VERBOSE = $VERBOSE, nil
 require 'net/https'
+$VERBOSE = verbose
 
 class Downloader
   def self.find(dlname)


### PR DESCRIPTION
When `-F` option is given to strip comments in bundled_gems file, `$;` is set to the regexp.

On the other hand, old net/http.rb contained old CVS keyword expansion that is `split` with the default separator, and non-nil `$;` causes a warning.

```ruby
    Revision = %q$Revision$.split[1]
```