### PR TITLE
Bump Prism version to 1.5.1

### DIFF
--- a/lib/prism/prism.gemspec
+++ b/lib/prism/prism.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "prism"
-  spec.version = "1.5.0"
+  spec.version = "1.5.1"
   spec.authors = ["Shopify"]
   spec.email = ["ruby@shopify.com"]
 

--- a/prism/extension.h
+++ b/prism/extension.h
@@ -1,7 +1,7 @@
 #ifndef PRISM_EXT_NODE_H
 #define PRISM_EXT_NODE_H
 
-#define EXPECTED_PRISM_VERSION "1.5.0"
+#define EXPECTED_PRISM_VERSION "1.5.1"
 
 #include <ruby.h>
 #include <ruby/encoding.h>

--- a/prism/templates/lib/prism/serialize.rb.erb
+++ b/prism/templates/lib/prism/serialize.rb.erb
@@ -14,7 +14,7 @@ module Prism
 
     # The patch version of prism that we are expecting to find in the serialized
     # strings.
-    PATCH_VERSION = 0
+    PATCH_VERSION = 1
 
     # Deserialize the dumped output from a request to parse or parse_file.
     #

--- a/prism/version.h
+++ b/prism/version.h
@@ -19,11 +19,11 @@
 /**
  * The patch version of the Prism library as an int.
  */
-#define PRISM_VERSION_PATCH 0
+#define PRISM_VERSION_PATCH 1
 
 /**
  * The version of the Prism library as a constant string.
  */
-#define PRISM_VERSION "1.5.0"
+#define PRISM_VERSION "1.5.1"
 
 #endif


### PR DESCRIPTION
The 1.5.0~1.5.1 diff has been included in the 1.5.0 bump https://github.com/ruby/ruby/pull/14532 as a workaround, so this is just a version-only change to make sure it's consistent with the version on rubygems.org.