### PR TITLE
`RGENGC_OBJ_INFO` compilation check

### DIFF
--- a/.github/workflows/compilers.yml
+++ b/.github/workflows/compilers.yml
@@ -281,7 +281,6 @@ jobs:
       - { uses: './.github/actions/compilers', name: 'GC_PROFILE_MORE_DETAIL',         with: { cppflags: '-DGC_PROFILE_MORE_DETAIL' } }
       - { uses: './.github/actions/compilers', name: 'MALLOC_ALLOCATED_SIZE_CHECK',    with: { cppflags: '-DMALLOC_ALLOCATED_SIZE_CHECK' } }
       - { uses: './.github/actions/compilers', name: 'RGENGC_ESTIMATE_OLDMALLOC',      with: { cppflags: '-DRGENGC_ESTIMATE_OLDMALLOC' } }
-      - { uses: './.github/actions/compilers', name: 'RGENGC_OBJ_INFO',                with: { cppflags: '-DRGENGC_OBJ_INFO' } }
       - { uses: './.github/actions/compilers', name: 'RGENGC_PROFILE',                 with: { cppflags: '-DRGENGC_PROFILE' } }
 
   compileC:


### PR DESCRIPTION
- Compile `RGENGC_OBJ_INFO` case statically
  Make this macro condition as compile-time constant instead of a preprocess-time constant, and compile the body always.
- Remove `RGENGC_OBJ_INFO` compilations check
  Now it is always compiled (and will be optimized away).
