### PR TITLE
Enable RGENGC_CHECK_MODE when RUBY_DEBUG

### DIFF
--- a/gc/gc.h
+++ b/gc/gc.h
@@ -128,7 +128,7 @@ RBIMPL_WARNING_IGNORED(-Wunused-function)
  * 5: show all references
  */
 #ifndef RGENGC_CHECK_MODE
-# define RGENGC_CHECK_MODE  0
+# define RGENGC_CHECK_MODE (RUBY_DEBUG ? 1 : 0)
 #endif
 
 #ifndef GC_ASSERT


### PR DESCRIPTION
We already enable GC_ASSERT assertions when RUBY_DEBUG is enabled. However, some assertions are hidden behind a preprocessor check on RGENGC_CHECK_MODE. These assertions will not be ran even if RUBY_DEBUG is enabled. This commit sets RGENGC_CHECK_MODE to 1 if RUBY_DEBUG is enabled.