### PR TITLE
ZJIT: Revert VM_CALL_ARGS_SPLAT and VM_CALL_KWARG support

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -454,6 +454,22 @@ class TestZJIT < Test::Unit::TestCase
     }
   end
 
+  def test_send_splat
+    assert_runs '[1, 2]', %q{
+      def test(a, b) = [a, b]
+      def entry(arr) = test(*arr)
+      entry([1, 2])
+    }
+  end
+
+  def test_send_kwarg
+    assert_runs '[1, 2]', %q{
+      def test(a:, b:) = [a, b]
+      def entry = test(a: 1, b: 2)
+      entry
+    }
+  end
+
   def test_forwardable_iseq
     assert_compiles '1', %q{
       def test(...) = 1

--- a/zjit.rb
+++ b/zjit.rb
@@ -40,7 +40,6 @@ class << RubyVM::ZJIT
     stats = self.stats
 
     # Show exit reasons, ordered by the typical amount of exits for the prefix at the time
-    print_counters_with_prefix(prefix: 'unhandled_call_', prompt: 'unhandled call types', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'unhandled_yarv_insn_', prompt: 'unhandled YARV insns', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'compile_error_', prompt: 'compile error reasons', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'exit_', prompt: 'side exit reasons', buf:, stats:, limit: 20)

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -93,6 +93,8 @@ make_counters! {
         exit_compile_error,
         exit_unknown_newarray_send,
         exit_unhandled_tailcall,
+        exit_unhandled_splat,
+        exit_unhandled_kwarg,
         exit_unknown_special_variable,
         exit_unhandled_hir_insn,
         exit_unhandled_yarv_insn,
@@ -162,17 +164,6 @@ pub fn exit_counter_ptr_for_opcode(opcode: u32) -> *mut u64 {
     unsafe { exit_counters.get_unchecked_mut(opcode as usize) }
 }
 
-/// Return a raw pointer to the exit counter for a given call type
-pub fn exit_counter_ptr_for_call_type(call_type: crate::hir::CallType) -> *mut u64 {
-    use crate::hir::CallType::*;
-    use crate::stats::Counter::*;
-    let counter = match call_type {
-        BlockArg => unhandled_call_block_arg,
-        Tailcall => unhandled_call_tailcall,
-    };
-    counter_ptr(counter)
-}
-
 /// Reason why ZJIT failed to produce any JIT code
 #[derive(Clone, Debug, PartialEq)]
 pub enum CompileError {
@@ -206,10 +197,13 @@ pub fn exit_counter_for_compile_error(compile_error: &CompileError) -> Counter {
 
 pub fn exit_counter_ptr(reason: crate::hir::SideExitReason) -> *mut u64 {
     use crate::hir::SideExitReason::*;
+    use crate::hir::CallType::*;
     use crate::stats::Counter::*;
     let counter = match reason {
         UnknownNewarraySend(_)        => exit_unknown_newarray_send,
-        UnhandledTailCall             => exit_unhandled_tailcall,
+        UnhandledCallType(Tailcall)   => exit_unhandled_tailcall,
+        UnhandledCallType(Splat)      => exit_unhandled_splat,
+        UnhandledCallType(Kwarg)      => exit_unhandled_kwarg,
         UnknownSpecialVariable(_)     => exit_unknown_special_variable,
         UnhandledHIRInsn(_)           => exit_unhandled_hir_insn,
         UnhandledYARVInsn(_)          => exit_unhandled_yarv_insn,


### PR DESCRIPTION
This PR partially reverts https://github.com/ruby/ruby/pull/14518. 

`VM_CALL_ARGS_SPLAT` breaks binarytrees, graphql, graphql-native, hexapdf, mail, and ruby-lsp, and `VM_CALL_KWARG` breaks rubocop, shipit, lobsters. So it filters out those call types for now.

They are currently a relatively small source of exits, so the counters are renamed from the `unhandled_call_` to the global `exit_` counters.