### PR TITLE
Remove setting v1, v2, v3 when creating a new object

### DIFF
--- a/array.c
+++ b/array.c
@@ -695,6 +695,11 @@ ary_alloc_heap(VALUE klass)
     NEWOBJ_OF(ary, struct RArray, klass,
                      T_ARRAY | (RGENGC_WB_PROTECTED_ARRAY ? FL_WB_PROTECTED : 0),
                      sizeof(struct RArray), 0);
+
+    ary->as.heap.len = 0;
+    ary->as.heap.aux.capa = 0;
+    ary->as.heap.ptr = NULL;
+
     return (VALUE)ary;
 }
 
@@ -808,6 +813,11 @@ ec_ary_alloc_heap(rb_execution_context_t *ec, VALUE klass)
     NEWOBJ_OF(ary, struct RArray, klass,
             T_ARRAY | (RGENGC_WB_PROTECTED_ARRAY ? FL_WB_PROTECTED : 0),
             sizeof(struct RArray), ec);
+
+    ary->as.heap.len = 0;
+    ary->as.heap.aux.capa = 0;
+    ary->as.heap.ptr = NULL;
+
     return (VALUE)ary;
 }
 

--- a/bignum.c
+++ b/bignum.c
@@ -3055,7 +3055,9 @@ bignew_1(VALUE klass, size_t len, int sign)
 VALUE
 rb_big_new(size_t len, int sign)
 {
-    return bignew(len, sign != 0);
+    VALUE obj = bignew(len, sign != 0);
+    memset(BIGNUM_DIGITS(obj), 0, len * sizeof(BDIGIT));
+    return obj;
 }
 
 VALUE

--- a/class.c
+++ b/class.c
@@ -682,6 +682,8 @@ class_alloc0(enum ruby_value_type type, VALUE klass, bool namespaceable)
 
     NEWOBJ_OF(obj, struct RClass, klass, flags, alloc_size, 0);
 
+    obj->object_id = 0;
+
     memset(RCLASS_EXT_PRIME(obj), 0, sizeof(rb_classext_t));
 
     /* ZALLOC

--- a/gc.c
+++ b/gc.c
@@ -1016,9 +1016,9 @@ newobj_of(rb_ractor_t *cr, VALUE klass, VALUE flags, bool wb_protected, size_t s
 # endif
 
     memset(
-        (void *)(obj + RVALUE_SIZE),
+        (void *)(obj + sizeof(struct RBasic)),
         GC_DEBUG_SLOT_FILL_SPECIAL_VALUE,
-        rb_gc_obj_slot_size(obj) - RVALUE_SIZE
+        rb_gc_obj_slot_size(obj) - sizeof(struct RBasic)
     );
 #endif
 

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2096,16 +2096,6 @@ heap_prepare(rb_objspace_t *objspace, rb_heap_t *heap)
     GC_ASSERT(heap->free_pages != NULL);
 }
 
-static inline VALUE
-newobj_fill(VALUE obj, VALUE v1, VALUE v2, VALUE v3)
-{
-    VALUE *p = (VALUE *)(obj + sizeof(struct RBasic));
-    p[0] = v1;
-    p[1] = v2;
-    p[2] = v3;
-    return obj;
-}
-
 #if GC_DEBUG
 static inline const char*
 rb_gc_impl_source_location_cstr(int *ptr)
@@ -2146,8 +2136,6 @@ newobj_init(VALUE klass, VALUE flags, int wb_protected, rb_objspace_t *objspace,
 #endif
 
 #if RGENGC_CHECK_MODE
-    newobj_fill(obj, 0, 0, 0);
-
     int lev = RB_GC_VM_LOCK_NO_BARRIER();
     {
         check_rvalue_consistency(objspace, obj);
@@ -2469,7 +2457,7 @@ newobj_slowpath_wb_unprotected(VALUE klass, VALUE flags, rb_objspace_t *objspace
 }
 
 VALUE
-rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, bool wb_protected, size_t alloc_size)
+rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, bool wb_protected, size_t alloc_size)
 {
     VALUE obj;
     rb_objspace_t *objspace = objspace_ptr;
@@ -2500,7 +2488,7 @@ rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags
           newobj_slowpath_wb_unprotected(klass, flags, objspace, cache, heap_idx);
     }
 
-    return newobj_fill(obj, v1, v2, v3);
+    return obj;
 }
 
 static int

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -55,7 +55,7 @@ GC_IMPL_FN VALUE rb_gc_impl_stress_get(void *objspace_ptr);
 GC_IMPL_FN VALUE rb_gc_impl_config_get(void *objspace_ptr);
 GC_IMPL_FN void rb_gc_impl_config_set(void *objspace_ptr, VALUE hash);
 // Object allocation
-GC_IMPL_FN VALUE rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, bool wb_protected, size_t alloc_size);
+GC_IMPL_FN VALUE rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, bool wb_protected, size_t alloc_size);
 GC_IMPL_FN size_t rb_gc_impl_obj_slot_size(VALUE obj);
 GC_IMPL_FN size_t rb_gc_impl_heap_id_for_size(void *objspace_ptr, size_t size);
 GC_IMPL_FN bool rb_gc_impl_size_allocatable_p(size_t size);

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -598,7 +598,7 @@ rb_gc_impl_config_set(void *objspace_ptr, VALUE hash)
 // Object allocation
 
 VALUE
-rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, VALUE v1, VALUE v2, VALUE v3, bool wb_protected, size_t alloc_size)
+rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, bool wb_protected, size_t alloc_size)
 {
 #define MMTK_ALLOCATION_SEMANTICS_DEFAULT 0
     struct objspace *objspace = objspace_ptr;
@@ -622,9 +622,6 @@ rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags
     alloc_obj[-1] = alloc_size;
     alloc_obj[0] = flags;
     alloc_obj[1] = klass;
-    if (alloc_size > 16) alloc_obj[2] = v1;
-    if (alloc_size > 24) alloc_obj[3] = v2;
-    if (alloc_size > 32) alloc_obj[4] = v3;
 
     mmtk_post_alloc(ractor_cache->mutator, (void*)alloc_obj, alloc_size + 8, MMTK_ALLOCATION_SEMANTICS_DEFAULT);
 

--- a/imemo.c
+++ b/imemo.c
@@ -54,6 +54,9 @@ rb_imemo_tmpbuf_new(void)
     VALUE flags = T_IMEMO | (imemo_tmpbuf << FL_USHIFT);
     NEWOBJ_OF(obj, rb_imemo_tmpbuf_t, 0, flags, sizeof(rb_imemo_tmpbuf_t), NULL);
 
+    obj->ptr = NULL;
+    obj->cnt = 0;
+
     return (VALUE)obj;
 }
 

--- a/iseq.h
+++ b/iseq.h
@@ -175,7 +175,12 @@ ISEQ_COMPILE_DATA_CLEAR(rb_iseq_t *iseq)
 static inline rb_iseq_t *
 iseq_imemo_alloc(void)
 {
-    return IMEMO_NEW(rb_iseq_t, imemo_iseq, 0);
+    rb_iseq_t *iseq = IMEMO_NEW(rb_iseq_t, imemo_iseq, 0);
+
+    // Clear out the whole iseq except for the flags.
+    memset((char *)iseq + sizeof(VALUE), 0, sizeof(rb_iseq_t) - sizeof(VALUE));
+
+    return iseq;
 }
 
 VALUE rb_iseq_ibf_dump(const rb_iseq_t *iseq, VALUE opt);

--- a/string.c
+++ b/string.c
@@ -1006,6 +1006,8 @@ str_alloc_embed(VALUE klass, size_t capa)
     NEWOBJ_OF(str, struct RString, klass,
             T_STRING | (RGENGC_WB_PROTECTED_STRING ? FL_WB_PROTECTED : 0), size, 0);
 
+    str->len = 0;
+
     return (VALUE)str;
 }
 
@@ -1014,6 +1016,10 @@ str_alloc_heap(VALUE klass)
 {
     NEWOBJ_OF(str, struct RString, klass,
             T_STRING | STR_NOEMBED | (RGENGC_WB_PROTECTED_STRING ? FL_WB_PROTECTED : 0), sizeof(struct RString), 0);
+
+    str->len = 0;
+    str->as.heap.aux.capa = 0;
+    str->as.heap.ptr = NULL;
 
     return (VALUE)str;
 }
@@ -1866,6 +1872,8 @@ ec_str_alloc_embed(struct rb_execution_context_struct *ec, VALUE klass, size_t c
     NEWOBJ_OF(str, struct RString, klass,
             T_STRING | (RGENGC_WB_PROTECTED_STRING ? FL_WB_PROTECTED : 0), size, ec);
 
+    str->len = 0;
+
     return (VALUE)str;
 }
 
@@ -1874,6 +1882,9 @@ ec_str_alloc_heap(struct rb_execution_context_struct *ec, VALUE klass)
 {
     NEWOBJ_OF(str, struct RString, klass,
             T_STRING | STR_NOEMBED | (RGENGC_WB_PROTECTED_STRING ? FL_WB_PROTECTED : 0), sizeof(struct RString), ec);
+
+    str->as.heap.aux.capa = 0;
+    str->as.heap.ptr = NULL;
 
     return (VALUE)str;
 }

--- a/string.c
+++ b/string.c
@@ -1007,6 +1007,7 @@ str_alloc_embed(VALUE klass, size_t capa)
             T_STRING | (RGENGC_WB_PROTECTED_STRING ? FL_WB_PROTECTED : 0), size, 0);
 
     str->len = 0;
+    str->as.embed.ary[0] = 0;
 
     return (VALUE)str;
 }

--- a/struct.c
+++ b/struct.c
@@ -837,6 +837,7 @@ struct_alloc(VALUE klass)
         st->as.heap.ptr = struct_heap_alloc((VALUE)st, n);
         rb_mem_clear((VALUE *)st->as.heap.ptr, n);
         st->as.heap.len = n;
+        st->as.heap.fields_obj = 0;
 
         return (VALUE)st;
     }


### PR DESCRIPTION
Setting v1, v2, v3 when we allocate an object assumes that we always allocate 40 byte objects. By removing v1, v2, v3, we can make the base slot size another size.