### PR TITLE
Disallow pending interrupts to be checked during FiberScheduler#unblock

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -9,6 +9,7 @@
 **********************************************************************/
 
 #include "vm_core.h"
+#include "eval_intern.h"
 #include "ruby/fiber/scheduler.h"
 #include "ruby/io.h"
 #include "ruby/io/buffer.h"
@@ -649,16 +650,25 @@ rb_fiber_scheduler_unblock(VALUE scheduler, VALUE blocker, VALUE fiber)
 
     // `rb_fiber_scheduler_unblock` can be called from points where `errno` is expected to be preserved. Therefore, we should save and restore it. For example `io_binwrite` calls `rb_fiber_scheduler_unblock` and if `errno` is reset to 0 by user code, it will break the error handling in `io_write`.
     // If we explicitly preserve `errno` in `io_binwrite` and other similar functions (e.g. by returning it), this code is no longer needed. I hope in the future we will be able to remove it.
+    VALUE result;
+    enum ruby_tag_type state;
     int saved_errno = errno;
 
-#ifdef RUBY_DEBUG
     rb_execution_context_t *ec = GET_EC();
-    if (RUBY_VM_INTERRUPTED(ec)) {
-        rb_bug("rb_fiber_scheduler_unblock called with pending interrupt");
-    }
-#endif
+    int old_interrupt_mask = ec->interrupt_mask;
+    ec->interrupt_mask &= PENDING_INTERRUPT_MASK;
 
-    VALUE result = rb_funcall(scheduler, id_unblock, 2, blocker, fiber);
+    EC_PUSH_TAG(ec);
+    if ((state = EC_EXEC_TAG()) == TAG_NONE) {
+        result = rb_funcall(scheduler, id_unblock, 2, blocker, fiber);
+    }
+    EC_POP_TAG();
+
+    ec->interrupt_mask = old_interrupt_mask;
+
+    if (state) {
+        EC_JUMP_TAG(ec, state);
+    }
 
     errno = saved_errno;
 
@@ -1079,15 +1089,24 @@ VALUE rb_fiber_scheduler_fiber_interrupt(VALUE scheduler, VALUE fiber, VALUE exc
     VALUE arguments[] = {
         fiber, exception
     };
-
-#ifdef RUBY_DEBUG
+    VALUE result;
+    enum ruby_tag_type state;
     rb_execution_context_t *ec = GET_EC();
-    if (RUBY_VM_INTERRUPTED(ec)) {
-        rb_bug("rb_fiber_scheduler_fiber_interrupt called with pending interrupt");
-    }
-#endif
+    int old_interrupt_mask = ec->interrupt_mask;
+    ec->interrupt_mask &= PENDING_INTERRUPT_MASK;
 
-    return rb_check_funcall(scheduler, id_fiber_interrupt, 2, arguments);
+    EC_PUSH_TAG(ec);
+    if ((state = EC_EXEC_TAG()) == TAG_NONE) {
+        result = rb_check_funcall(scheduler, id_fiber_interrupt, 2, arguments);
+    }
+    EC_POP_TAG();
+
+    ec->interrupt_mask = old_interrupt_mask;
+
+    if (state) {
+        EC_JUMP_TAG(ec, state);
+    }
+    return result;
 }
 
 /*


### PR DESCRIPTION
Ractors can send signals at any time, so the previous debug assertion can fail if a Ractor sends a signal.

```ruby
require 'async/scheduler'

scheduler = Async::Scheduler.new
Fiber.set_scheduler(scheduler)

Signal.trap(:INT) do
end

q =  Thread::Queue.new

Thread.new do
  loop do
    Ractor.new do
      Process.kill(:INT, $$)
    end.value
  end
end

Fiber.schedule do
  Fiber.schedule do
    1.upto(1000000) do |i|
      sleep 0.01
      q.pop
      q.push(1)
      puts "1 iter push/pop"
    end
  end
  Fiber.schedule do
    1.upto(1000000) do |i|
      sleep 0.01
      q.push(i)
      q.pop
      puts "1 iter push/pop#2"
    end
  end
end
```