### PR TITLE
ZJIT: Revert documentation indent

### DIFF
--- a/zjit/src/profile.rs
+++ b/zjit/src/profile.rs
@@ -150,7 +150,8 @@ impl Flags {
 /// opt_send_without_block/opt_plus/... should store:
 /// * the class of the receiver, so we can do method lookup
 /// * the shape of the receiver, so we can optimize ivar lookup
-///   with those two, pieces of information, we can also determine when an object is an immediate:
+///
+/// with those two, pieces of information, we can also determine when an object is an immediate:
 /// * Integer + IS_IMMEDIATE == Fixnum
 /// * Float + IS_IMMEDIATE == Flonum
 /// * Symbol + IS_IMMEDIATE == StaticSymbol


### PR DESCRIPTION
```
~/s/r/zjit (afi/fix-doc)> cargo doc --open --document-private-items
   Compiling zjit v0.0.1 (/Users/aidenfoxivey/src/ruby/zjit)
    Checking jit v0.1.0 (/Users/aidenfoxivey/src/ruby/jit)
 Documenting jit v0.1.0 (/Users/aidenfoxivey/src/ruby/jit)
 Documenting zjit v0.0.1 (/Users/aidenfoxivey/src/ruby/zjit)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.44s
     Opening /Users/aidenfoxivey/src/ruby/target/doc/zjit/index.html
```

Looks like it works appropriately.