### PR TITLE
Fix concurrent autoloads of encodings inside Ractors

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -357,6 +357,12 @@ enc_register_at(struct enc_table *enc_table, int index, const char *name, rb_enc
     struct rb_encoding_entry *ent = &enc_table->list[index];
     rb_raw_encoding *encoding;
 
+    if (ent->loaded) {
+        RUBY_ASSERT(ent->base == base_encoding);
+        RUBY_ASSERT(!strcmp(name, ent->name));
+        return index;
+    }
+
     if (!valid_encoding_name_p(name)) return -1;
     if (!ent->name) {
         ent->name = name = strdup(name);
@@ -408,7 +414,9 @@ enc_from_index(struct enc_table *enc_table, int index)
     if (UNLIKELY(index < 0 || enc_table->count <= (index &= ENC_INDEX_MASK))) {
         return 0;
     }
-    return enc_table->list[index].enc;
+    rb_encoding *enc = enc_table->list[index].enc;
+    RUBY_ASSERT(ENC_TO_ENCINDEX(enc) == index);
+    return enc;
 }
 
 rb_encoding *
@@ -827,7 +835,7 @@ enc_autoload_body(rb_encoding *enc)
                 GLOBAL_ENC_TABLE_LOCKING(enc_table) {
                     i = enc->ruby_encoding_index;
                     enc_register_at(enc_table, i & ENC_INDEX_MASK, rb_enc_name(enc), base);
-                    ((rb_raw_encoding *)enc)->ruby_encoding_index = i;
+                    RUBY_ASSERT(((rb_raw_encoding *)enc)->ruby_encoding_index == i);
                 }
             }
 

--- a/encoding.c
+++ b/encoding.c
@@ -375,14 +375,20 @@ enc_register_at(struct enc_table *enc_table, int index, const char *name, rb_enc
         encoding = xmalloc(sizeof(rb_encoding));
     }
 
+    rb_raw_encoding tmp_encoding;
     if (base_encoding) {
-        *encoding = *base_encoding;
+        tmp_encoding = *base_encoding;
     }
     else {
-        memset(encoding, 0, sizeof(*ent->enc));
+        memset(&tmp_encoding, 0, sizeof(*ent->enc));
     }
-    encoding->name = name;
-    encoding->ruby_encoding_index = index;
+    tmp_encoding.name = name;
+    tmp_encoding.ruby_encoding_index = index;
+
+    // FIXME: If encoding already existed, it may be concurrently accessed
+    // It's technically invalid to write to this memory as it's read, but as all
+    // values are set up it _probably_ works.
+    *encoding = tmp_encoding;
     ent->enc = encoding;
     st_insert(enc_table->names, (st_data_t)name, (st_data_t)index);
 


### PR DESCRIPTION
We're still seeing concurrent autoloads of encodings crashing on CI. Ex. https://ci.rvm.jp/results/trunk@ruby-sp3/5954164

I think there were two issues:

* I believe we could enter `enc_register_at` multiple times with the same encoding, after trying to autoload the parent. We can avoid this by bailing out if the encoding is already loaded.
* When we do `*encoding = *base_encoding`, `encoding->ruby_encoding_index` could briefly be set to the base encoding's index (!!!), rather than the existing registered index, before being set back a couple lines later

cc @luke-gruber @etiennebarrie @byroot 

I'd like to do a larger rafactor here, but I'd like to make this smaller change first to see if that fixes CI and to be sure we've correctly identified the problem.