### PR TITLE
Pass -w to lsof

### DIFF
--- a/tool/lib/leakchecker.rb
+++ b/tool/lib/leakchecker.rb
@@ -112,7 +112,7 @@ class LeakChecker
       }
       unless fd_leaked.empty?
         unless @@try_lsof == false
-          @@try_lsof |= system(*%W[lsof -a -d #{fd_leaked.minmax.uniq.join("-")} -p #$$], out: Test::Unit::Runner.output)
+          @@try_lsof |= system(*%W[lsof -w -a -d #{fd_leaked.minmax.uniq.join("-")} -p #$$], out: Test::Unit::Runner.output)
         end
       end
       h.each {|fd, list|


### PR DESCRIPTION
On my system when I run `test-all` after running some docker containers I get a bunch of warnings like:

```
lsof: WARNING: can't stat() overlay file system /var/lib/docker/overlay2/acfc8a683756c80fb400afb28ec59abfd319de0c5ebe2e09033505af5d035d9a/merged
      Output information may be incomplete.
```

`-w` hides these