### PR TITLE
Use `ec->interrupt_mask` to prevent interrupts.

### DIFF
--- a/depend
+++ b/depend
@@ -15019,6 +15019,7 @@ scheduler.$(OBJEXT): {$(VPATH)}config.h
 scheduler.$(OBJEXT): {$(VPATH)}constant.h
 scheduler.$(OBJEXT): {$(VPATH)}defines.h
 scheduler.$(OBJEXT): {$(VPATH)}encoding.h
+scheduler.$(OBJEXT): {$(VPATH)}eval_intern.h
 scheduler.$(OBJEXT): {$(VPATH)}fiber/scheduler.h
 scheduler.$(OBJEXT): {$(VPATH)}id.h
 scheduler.$(OBJEXT): {$(VPATH)}id_table.h


### PR DESCRIPTION
The following program can segfault without this change:

```ruby
require 'async/scheduler'

scheduler = Async::Scheduler.new
Fiber.set_scheduler(scheduler)

Signal.trap(:USR1) do
end

q = Thread::Queue.new

Thread.new do
  loop do
    Ractor.new do
      Process.kill(:USR1, $$)
    end.join
  end
end

Fiber.schedule do
  Fiber.schedule do
    1.upto(1000000) do |i|
      sleep 0.01
      q.pop
      q.push(1)
      puts "1 iter push/pop"
    end
  end
  Fiber.schedule do
    1.upto(1000000) do |i|
      sleep 0.01
      q.push(i)
      q.pop
      puts "1 iter push/pop#2"
    end
  end
  Fiber.schedule do
    gets
    exit!
  end
end
```

The segfault is deliberate due to `rb_bug` but without that, the program could probably hang indefinitely. I tried to write a test for this but it's too hard.

cc @luke-gruber 