### PR TITLE
Use `ec->interrupt_mask` to prevent interrupts. (#14588)

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -16575,6 +16575,7 @@ scheduler.$(OBJEXT): {$(VPATH)}config.h
 scheduler.$(OBJEXT): {$(VPATH)}constant.h
 scheduler.$(OBJEXT): {$(VPATH)}defines.h
 scheduler.$(OBJEXT): {$(VPATH)}encoding.h
+scheduler.$(OBJEXT): {$(VPATH)}eval_intern.h
 scheduler.$(OBJEXT): {$(VPATH)}fiber/scheduler.h
 scheduler.$(OBJEXT): {$(VPATH)}id.h
 scheduler.$(OBJEXT): {$(VPATH)}id_table.h


### PR DESCRIPTION
Disallow pending interrupts to be checked during `FiberScheduler#unblock`.

Ractors can send signals at any time, so the previous debug assertion can fail if a Ractor sends a signal.

Backport of https://github.com/ruby/ruby/pull/14588