### PR TITLE
Directly use rb_imemo_new in imemo_fields_new_complex

### DIFF
--- a/imemo.c
+++ b/imemo.c
@@ -123,7 +123,7 @@ rb_imemo_fields_new(VALUE owner, size_t capa)
 static VALUE
 imemo_fields_new_complex(VALUE owner, size_t capa)
 {
-    VALUE fields = imemo_fields_new(owner, 1);
+    VALUE fields = rb_imemo_new(imemo_fields, owner, sizeof(struct rb_fields));
     IMEMO_OBJ_FIELDS(fields)->as.complex.table = st_init_numtable_with_size(capa);
     FL_SET_RAW(fields, OBJ_FIELD_HEAP);
     return fields;


### PR DESCRIPTION
We should not assume that a complex imemo_field takes only one additional VALUE space. This is fragile as it will break if we add additional fields to complex imemo_field.