### PR TITLE
ZJIT: Make exception allocation faster

### DIFF
--- a/error.c
+++ b/error.c
@@ -3577,12 +3577,6 @@ syserr_eqq(VALUE self, VALUE exc)
  */
 
 static VALUE
-exception_alloc(VALUE klass)
-{
-    return rb_class_allocate_instance(klass);
-}
-
-static VALUE
 exception_dumper(VALUE exc)
 {
     // TODO: Currently, the instance variables "bt" and "bt_locations"
@@ -3628,7 +3622,6 @@ void
 Init_Exception(void)
 {
     rb_eException   = rb_define_class("Exception", rb_cObject);
-    rb_define_alloc_func(rb_eException, exception_alloc);
     rb_marshal_define_compat(rb_eException, rb_eException, exception_dumper, exception_loader);
     rb_define_singleton_method(rb_eException, "exception", rb_class_new_instance, -1);
     rb_define_singleton_method(rb_eException, "to_tty?", exc_s_to_tty_p, 0);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -8160,6 +8160,96 @@ mod opt_tests {
     }
 
     #[test]
+    fn test_opt_new_basic_object() {
+        eval("
+            def test = BasicObject.new
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, BasicObject)
+          v34:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v6:NilClass = Const Value(nil)
+          PatchPoint MethodRedefined(BasicObject@0x1008, new@0x1010, cme:0x1018)
+          v37:HeapObject[class_exact:BasicObject] = ObjectAllocClass VALUE(0x1008)
+          PatchPoint MethodRedefined(BasicObject@0x1008, initialize@0x1040, cme:0x1048)
+          v39:NilClass = CCall initialize@0x1070, v37
+          CheckInterrupts
+          CheckInterrupts
+          Return v37
+        ");
+    }
+
+    #[test]
+    fn test_opt_new_object() {
+        eval("
+            def test = Object.new
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, Object)
+          v34:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v6:NilClass = Const Value(nil)
+          PatchPoint MethodRedefined(Object@0x1008, new@0x1010, cme:0x1018)
+          v37:HeapObject[class_exact:Object] = ObjectAllocClass VALUE(0x1008)
+          PatchPoint MethodRedefined(Object@0x1008, initialize@0x1040, cme:0x1048)
+          v39:NilClass = CCall initialize@0x1070, v37
+          CheckInterrupts
+          CheckInterrupts
+          Return v37
+        ");
+    }
+
+    #[test]
+    fn test_opt_new_exception() {
+        eval("
+            def test = Exception.new
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, Exception)
+          v34:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v6:NilClass = Const Value(nil)
+          PatchPoint MethodRedefined(Exception@0x1008, new@0x1010, cme:0x1018)
+          v37:HeapObject[class_exact:Exception] = ObjectAllocClass VALUE(0x1008)
+          v12:BasicObject = SendWithoutBlock v37, :initialize
+          CheckInterrupts
+          CheckInterrupts
+          Return v37
+        ");
+    }
+
+    #[test]
+    fn test_opt_new_standard_error() {
+        eval("
+            def test = StandardError.new
+            test
+        ");
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:2:
+        bb0(v0:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, StandardError)
+          v34:Class[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v6:NilClass = Const Value(nil)
+          PatchPoint MethodRedefined(StandardError@0x1008, new@0x1010, cme:0x1018)
+          v37:HeapObject[class_exact:StandardError] = ObjectAllocClass VALUE(0x1008)
+          v12:BasicObject = SendWithoutBlock v37, :initialize
+          CheckInterrupts
+          CheckInterrupts
+          Return v37
+        ");
+    }
+
+    #[test]
     fn test_opt_length() {
         eval("
             def test(a,b) = [a,b].length

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1929,7 +1929,8 @@ impl Function {
                         // a singleton class, or has a custom allocator, ObjectAlloc might raise an
                         // exception or run arbitrary code.
                         //
-                        // We also need to check if the class is initialized or a singleton before trying to read the allocator, otherwise it might raise.
+                        // We also need to check if the class is initialized or a singleton before
+                        // trying to read the allocator, otherwise it might raise.
                         if !unsafe { rb_zjit_class_initialized_p(class) } {
                             self.push_insn_id(block, insn_id); continue;
                         }


### PR DESCRIPTION
- **Make rb_eException directly use default allocator**
- **ZJIT: Wrap comment**
- **ZJIT: Add tests for modified Exception allocator**

Just noticed this as I was looking around allocators.
