### PR TITLE
Prevent GC from running during `newobj_of` for internal_event_newobj.

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -991,8 +991,7 @@ newobj_of(rb_ractor_t *cr, VALUE klass, VALUE flags, bool wb_protected, size_t s
     gc_validate_pc();
 
     if (UNLIKELY(rb_gc_event_hook_required_p(RUBY_INTERNAL_EVENT_NEWOBJ))) {
-        unsigned int lev;
-        RB_VM_LOCK_ENTER_CR_LEV(cr, &lev);
+        int lev = RB_GC_VM_LOCK_NO_BARRIER();
         {
             memset((char *)obj + RVALUE_SIZE, 0, rb_gc_obj_slot_size(obj) - RVALUE_SIZE);
 
@@ -1007,7 +1006,7 @@ newobj_of(rb_ractor_t *cr, VALUE klass, VALUE flags, bool wb_protected, size_t s
             }
             if (!gc_disabled) rb_gc_enable();
         }
-        RB_VM_LOCK_LEAVE_CR_LEV(cr, &lev);
+        RB_GC_VM_UNLOCK_NO_BARRIER(lev);
     }
 
 #if RGENGC_CHECK_MODE

--- a/test/objspace/test_ractor.rb
+++ b/test/objspace/test_ractor.rb
@@ -2,10 +2,6 @@ require "test/unit"
 
 class TestObjSpaceRactor < Test::Unit::TestCase
   def test_tracing_does_not_crash
-    # https://ci.rvm.jp/results/trunk-random1@ruby-sp2-noble-docker/5954509
-    # https://ci.rvm.jp/results/trunk-random0@ruby-sp2-noble-docker/5954501
-    omit "crashes frequently on CI but not able to reproduce locally"
-
     assert_ractor(<<~RUBY, require: 'objspace')
       ObjectSpace.trace_object_allocations do
         r = Ractor.new do


### PR DESCRIPTION
If another ractor is calling for GC, we need to prevent the current one from joining the barrier. Otherwise, our half-built object will be marked.

The repro script was:

test.rb:
```ruby
require "objspace"
1000.times do
  ObjectSpace.trace_object_allocations do
    r = Ractor.new do
      _obj = 'a' * 1024
    end

    r.join
  end
end
```

$ untilfail lldb -b ./exe/ruby -o "target create ./exe/ruby" -o "run test.rb" -o continue

It would fail at `ractor_port_mark`, rp->r was a garbage value. Credit to John for finding the solution.