### PR TITLE
ZJIT: Count writes to the VM frame

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -58,6 +58,11 @@ class << RubyVM::ZJIT
       :gc_time_ns,
       :invalidation_time_ns,
 
+      :vm_write_pc_count,
+      :vm_write_sp_count,
+      :vm_write_locals_count,
+      :vm_write_stack_count,
+
       :code_region_bytes,
       :side_exit_count,
       :total_insn_count,

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -150,6 +150,12 @@ make_counters! {
     send_fallback_optimized,
     send_fallback_missing,
     send_fallback_refined,
+
+    // Writes to the VM frame
+    vm_write_pc_count,
+    vm_write_sp_count,
+    vm_write_locals_count,
+    vm_write_stack_count,
 }
 
 /// Increase a counter by a specified amount


### PR DESCRIPTION
This is a) a lot of memory traffic and b) is another good proxy for our
ability to strength reduce method calls.
