### PR TITLE
Make it clearer how encodings are loaded via enc_register_at

### DIFF
--- a/encoding.c
+++ b/encoding.c
@@ -152,6 +152,8 @@ enc_list_update(int index, rb_raw_encoding *encoding)
         RBASIC_CLEAR_CLASS(new_list);
         /* initialize encoding data */
         rb_ary_store(new_list, index, enc_new(encoding));
+        rb_ary_freeze(new_list);
+        FL_SET_RAW(new_list, RUBY_FL_SHAREABLE);
         RUBY_ATOMIC_VALUE_SET(rb_encoding_list, new_list);
     }
 }

--- a/encoding.c
+++ b/encoding.c
@@ -837,38 +837,27 @@ enc_autoload_body(rb_encoding *enc)
 
     GLOBAL_ENC_TABLE_LOCKING(enc_table) {
         base = enc_table->list[ENC_TO_ENCINDEX(enc)].base;
-        if (base) {
-            do {
-                if (i >= enc_table->count) {
-                    i = -1;
-                    break;
-                }
-            } while (enc_table->list[i].enc != base && (++i, 1));
-        }
     }
 
-
-    if (i != -1) {
-        if (base) {
-            bool do_register = true;
-            if (rb_enc_autoload_p(base)) {
-                if (rb_enc_autoload(base) < 0) {
-                    do_register = false;
-                    i = -1;
-                }
-            }
-
-            if (do_register) {
-                GLOBAL_ENC_TABLE_LOCKING(enc_table) {
-                    i = ENC_TO_ENCINDEX(enc);
-                    enc_load_from_base(enc_table, i, base);
-                    RUBY_ASSERT(((rb_raw_encoding *)enc)->ruby_encoding_index == i);
-                }
+    if (base) {
+        bool do_register = true;
+        if (rb_enc_autoload_p(base)) {
+            if (rb_enc_autoload(base) < 0) {
+                do_register = false;
+                i = -1;
             }
         }
-        else {
-            i = -2;
+
+        if (do_register) {
+            GLOBAL_ENC_TABLE_LOCKING(enc_table) {
+                i = ENC_TO_ENCINDEX(enc);
+                enc_load_from_base(enc_table, i, base);
+                RUBY_ASSERT(((rb_raw_encoding *)enc)->ruby_encoding_index == i);
+            }
         }
+    }
+    else {
+        i = -2;
     }
 
     return i;


### PR DESCRIPTION
Previously we would sometimes call `enc_register_at` several times in order to update the encoding values after the base encoding may have been loaded.

This updates `enc_register_at` to only be used via `enc_register`, when an actual new encoding at a new index is being registered.

Other callers (which in all cases found the index by the name matching) now call `enc_load_from_base` which is only responsibly for loading the encoding from the base values.