### PR TITLE
ZJIT: Put exit reasons later in stats_string

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -39,12 +39,14 @@ class << RubyVM::ZJIT
     buf = +"***ZJIT: Printing ZJIT statistics on exit***\n"
     stats = self.stats
 
-    # Show exit reasons, ordered by the typical amount of exits for the prefix at the time
+    # Show non-exit counters
+    print_counters_with_prefix(prefix: 'dynamic_send_type_', prompt: 'dynamic send types', buf:, stats:, limit: 20)
+    print_counters_with_prefix(prefix: 'send_fallback_', prompt: 'send fallback def_types', buf:, stats:, limit: 20)
+
+    # Show exit counters, ordered by the typical amount of exits for the prefix at the time
     print_counters_with_prefix(prefix: 'unhandled_yarv_insn_', prompt: 'unhandled YARV insns', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'compile_error_', prompt: 'compile error reasons', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'exit_', prompt: 'side exit reasons', buf:, stats:, limit: 20)
-    print_counters_with_prefix(prefix: 'dynamic_send_type_', prompt: 'dynamic send types', buf:, stats:, limit: 20)
-    print_counters_with_prefix(prefix: 'send_fallback_', prompt: 'send fallback def_types', buf:, stats:, limit: 20)
 
     # Show the most important stats ratio_in_zjit at the end
     print_counters([


### PR DESCRIPTION
This PR reorders stats in `stats_string` a little.

It feels like "side exit reasons" is buried in the middle of prefixed counters, but I want to keep it at the bottom of prefixed counters since it's still the most important one out of them, and it's generally easier to see later logs on a terminal.