### PR TITLE
ZJIT: Also count fallback sends to ISEQs we can't direct send to

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -481,6 +481,7 @@ pub enum MethodType {
     Optimized,
     Missing,
     Refined,
+    Null,
 }
 
 impl From<u32> for MethodType {
@@ -1852,6 +1853,9 @@ impl Function {
                         // Do method lookup
                         let mut cme = unsafe { rb_callable_method_entry(klass, mid) };
                         if cme.is_null() {
+                            if let Insn::SendWithoutBlock { def_type: insn_def_type, .. } = &mut self.insns[insn_id.0] {
+                                *insn_def_type = Some(MethodType::Null);
+                            }
                             self.push_insn_id(block, insn_id); continue;
                         }
                         // Load an overloaded cme if applicable. See vm_search_cc().

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -150,6 +150,7 @@ make_counters! {
     send_fallback_optimized,
     send_fallback_missing,
     send_fallback_refined,
+    send_fallback_null,
 
     // Writes to the VM frame
     vm_write_pc_count,
@@ -259,6 +260,7 @@ pub fn send_fallback_counter(def_type: crate::hir::MethodType) -> Counter {
         Optimized => send_fallback_optimized,
         Missing => send_fallback_missing,
         Refined => send_fallback_refined,
+        Null => send_fallback_null,
     }
 }
 


### PR DESCRIPTION
Make sure these parameter types are counted in the fallback def_types.
