### PR TITLE
ZJIT: Fix disasm tests on release build

### DIFF
--- a/zjit/src/asm/arm64/mod.rs
+++ b/zjit/src/asm/arm64/mod.rs
@@ -1247,112 +1247,112 @@ mod tests {
     fn test_add_reg() {
         let cb = compile(|cb| add(cb, X0, X1, X2));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add x0, x1, x2"));
-        assert_snapshot!(cb.string(), @"2000028b");
+        assert_snapshot!(cb.hexdump(), @"2000028b");
     }
 
     #[test]
     fn test_add_uimm() {
         let cb = compile(|cb| add(cb, X0, X1, A64Opnd::new_uimm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"201c0091");
+        assert_snapshot!(cb.hexdump(), @"201c0091");
     }
 
     #[test]
     fn test_add_imm_positive() {
         let cb = compile(|cb| add(cb, X0, X1, A64Opnd::new_imm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"201c0091");
+        assert_snapshot!(cb.hexdump(), @"201c0091");
     }
 
     #[test]
     fn test_add_imm_negative() {
         let cb = compile(|cb| add(cb, X0, X1, A64Opnd::new_imm(-7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"201c00d1");
+        assert_snapshot!(cb.hexdump(), @"201c00d1");
     }
 
     #[test]
     fn test_adds_reg() {
         let cb = compile(|cb| adds(cb, X0, X1, X2));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adds x0, x1, x2"));
-        assert_snapshot!(cb.string(), @"200002ab");
+        assert_snapshot!(cb.hexdump(), @"200002ab");
     }
 
     #[test]
     fn test_adds_uimm() {
         let cb = compile(|cb| adds(cb, X0, X1, A64Opnd::new_uimm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adds x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"201c00b1");
+        assert_snapshot!(cb.hexdump(), @"201c00b1");
     }
 
     #[test]
     fn test_adds_imm_positive() {
         let cb = compile(|cb| adds(cb, X0, X1, A64Opnd::new_imm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adds x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"201c00b1");
+        assert_snapshot!(cb.hexdump(), @"201c00b1");
     }
 
     #[test]
     fn test_adds_imm_negative() {
         let cb = compile(|cb| adds(cb, X0, X1, A64Opnd::new_imm(-7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: subs x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"201c00f1");
+        assert_snapshot!(cb.hexdump(), @"201c00f1");
     }
 
     #[test]
     fn test_adr() {
         let cb = compile(|cb| adr(cb, X10, A64Opnd::new_imm(20)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adr x10, #0x14"));
-        assert_snapshot!(cb.string(), @"aa000010");
+        assert_snapshot!(cb.hexdump(), @"aa000010");
     }
 
     #[test]
     fn test_adrp() {
         let cb = compile(|cb| adrp(cb, X10, A64Opnd::new_imm(0x8000)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adrp x10, #0x8000"));
-        assert_snapshot!(cb.string(), @"4a000090");
+        assert_snapshot!(cb.hexdump(), @"4a000090");
     }
 
     #[test]
     fn test_and_register() {
         let cb = compile(|cb| and(cb, X0, X1, X2));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and x0, x1, x2"));
-        assert_snapshot!(cb.string(), @"2000028a");
+        assert_snapshot!(cb.hexdump(), @"2000028a");
     }
 
     #[test]
     fn test_and_immediate() {
         let cb = compile(|cb| and(cb, X0, X1, A64Opnd::new_uimm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"20084092");
+        assert_snapshot!(cb.hexdump(), @"20084092");
     }
 
     #[test]
     fn test_and_32b_immediate() {
         let cb = compile(|cb| and(cb, W0, W2, A64Opnd::new_uimm(0xfffff)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and w0, w2, #0xfffff"));
-        assert_snapshot!(cb.string(), @"404c0012");
+        assert_snapshot!(cb.hexdump(), @"404c0012");
     }
 
     #[test]
     fn test_ands_register() {
         let cb = compile(|cb| ands(cb, X0, X1, X2));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ands x0, x1, x2"));
-        assert_snapshot!(cb.string(), @"200002ea");
+        assert_snapshot!(cb.hexdump(), @"200002ea");
     }
 
     #[test]
     fn test_ands_immediate() {
         let cb = compile(|cb| ands(cb, X0, X1, A64Opnd::new_uimm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ands x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"200840f2");
+        assert_snapshot!(cb.hexdump(), @"200840f2");
     }
 
     #[test]
     fn test_asr() {
         let cb = compile(|cb| asr(cb, X20, X21, A64Opnd::new_uimm(10)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: asr x20, x21, #0xa"));
-        assert_snapshot!(cb.string(), @"b4fe4a93");
+        assert_snapshot!(cb.hexdump(), @"b4fe4a93");
     }
 
     #[test]
@@ -1360,7 +1360,7 @@ mod tests {
         let offset = InstructionOffset::from_insns(0x100);
         let cb = compile(|cb| bcond(cb, Condition::NE, offset));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: b.ne #0x400"));
-        assert_snapshot!(cb.string(), @"01200054");
+        assert_snapshot!(cb.hexdump(), @"01200054");
     }
 
     #[test]
@@ -1368,7 +1368,7 @@ mod tests {
         let offset = InstructionOffset::from_insns((1 << 25) - 1);
         let cb = compile(|cb| b(cb, offset));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: b #0x7fffffc"));
-        assert_snapshot!(cb.string(), @"ffffff15");
+        assert_snapshot!(cb.hexdump(), @"ffffff15");
     }
 
     #[test]
@@ -1392,7 +1392,7 @@ mod tests {
         let offset = InstructionOffset::from_insns(-(1 << 25));
         let cb = compile(|cb| bl(cb, offset));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: bl #0xfffffffff8000000"));
-        assert_snapshot!(cb.string(), @"00000096");
+        assert_snapshot!(cb.hexdump(), @"00000096");
     }
 
     #[test]
@@ -1415,14 +1415,14 @@ mod tests {
     fn test_blr() {
         let cb = compile(|cb| blr(cb, X20));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: blr x20"));
-        assert_snapshot!(cb.string(), @"80023fd6");
+        assert_snapshot!(cb.hexdump(), @"80023fd6");
     }
 
     #[test]
     fn test_br() {
         let cb = compile(|cb| br(cb, X20));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: br x20"));
-        assert_snapshot!(cb.string(), @"80021fd6");
+        assert_snapshot!(cb.hexdump(), @"80021fd6");
     }
 
     #[test]
@@ -1436,7 +1436,7 @@ mod tests {
         0x0: cbz x0, #0xfffffffffffffffc
         0x4: cbz w0, #0
         "));
-        assert_snapshot!(cb.string(), @"e0ffffb4e0ffff34");
+        assert_snapshot!(cb.hexdump(), @"e0ffffb4e0ffff34");
     }
 
     #[test]
@@ -1450,147 +1450,147 @@ mod tests {
         0x0: cbnz x20, #8
         0x4: cbnz w20, #0xc
         "));
-        assert_snapshot!(cb.string(), @"540000b554000035");
+        assert_snapshot!(cb.hexdump(), @"540000b554000035");
     }
 
     #[test]
     fn test_brk_none() {
         let cb = compile(|cb| brk(cb, A64Opnd::None));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: brk #0xf000"));
-        assert_snapshot!(cb.string(), @"00003ed4");
+        assert_snapshot!(cb.hexdump(), @"00003ed4");
     }
 
     #[test]
     fn test_brk_uimm() {
         let cb = compile(|cb| brk(cb, A64Opnd::new_uimm(14)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: brk #0xe"));
-        assert_snapshot!(cb.string(), @"c00120d4");
+        assert_snapshot!(cb.hexdump(), @"c00120d4");
     }
 
     #[test]
     fn test_cmp_register() {
         let cb = compile(|cb| cmp(cb, X10, X11));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp x10, x11"));
-        assert_snapshot!(cb.string(), @"5f010beb");
+        assert_snapshot!(cb.hexdump(), @"5f010beb");
     }
 
     #[test]
     fn test_cmp_immediate() {
         let cb = compile(|cb| cmp(cb, X10, A64Opnd::new_uimm(14)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp x10, #0xe"));
-        assert_snapshot!(cb.string(), @"5f3900f1");
+        assert_snapshot!(cb.hexdump(), @"5f3900f1");
     }
 
     #[test]
     fn test_csel() {
         let cb = compile(|cb| csel(cb, X10, X11, X12, Condition::EQ));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: csel x10, x11, x12, eq"));
-        assert_snapshot!(cb.string(), @"6a018c9a");
+        assert_snapshot!(cb.hexdump(), @"6a018c9a");
     }
 
     #[test]
     fn test_eor_register() {
         let cb = compile(|cb| eor(cb, X10, X11, X12));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: eor x10, x11, x12"));
-        assert_snapshot!(cb.string(), @"6a010cca");
+        assert_snapshot!(cb.hexdump(), @"6a010cca");
     }
 
     #[test]
     fn test_eor_immediate() {
         let cb = compile(|cb| eor(cb, X10, X11, A64Opnd::new_uimm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: eor x10, x11, #7"));
-        assert_snapshot!(cb.string(), @"6a0940d2");
+        assert_snapshot!(cb.hexdump(), @"6a0940d2");
     }
 
     #[test]
     fn test_eor_32b_immediate() {
         let cb = compile(|cb| eor(cb, W9, W1, A64Opnd::new_uimm(0x80000001)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: eor w9, w1, #0x80000001"));
-        assert_snapshot!(cb.string(), @"29040152");
+        assert_snapshot!(cb.hexdump(), @"29040152");
     }
 
     #[test]
     fn test_ldaddal() {
         let cb = compile(|cb| ldaddal(cb, X10, X11, X12));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldaddal x10, x11, [x12]"));
-        assert_snapshot!(cb.string(), @"8b01eaf8");
+        assert_snapshot!(cb.hexdump(), @"8b01eaf8");
     }
 
     #[test]
     fn test_ldaxr() {
         let cb = compile(|cb| ldaxr(cb, X10, X11));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldaxr x10, [x11]"));
-        assert_snapshot!(cb.string(), @"6afd5fc8");
+        assert_snapshot!(cb.hexdump(), @"6afd5fc8");
     }
 
     #[test]
     fn test_ldp() {
         let cb = compile(|cb| ldp(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldp x10, x11, [x12, #0xd0]"));
-        assert_snapshot!(cb.string(), @"8a2d4da9");
+        assert_snapshot!(cb.hexdump(), @"8a2d4da9");
     }
 
     #[test]
     fn test_ldp_pre() {
         let cb = compile(|cb| ldp_pre(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldp x10, x11, [x12, #0xd0]!"));
-        assert_snapshot!(cb.string(), @"8a2dcda9");
+        assert_snapshot!(cb.hexdump(), @"8a2dcda9");
     }
 
     #[test]
     fn test_ldp_post() {
         let cb = compile(|cb| ldp_post(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldp x10, x11, [x12], #0xd0"));
-        assert_snapshot!(cb.string(), @"8a2dcda8");
+        assert_snapshot!(cb.hexdump(), @"8a2dcda8");
     }
 
     #[test]
     fn test_ldr() {
         let cb = compile(|cb| ldr(cb, X10, X11, X12));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldr x10, [x11, x12]"));
-        assert_snapshot!(cb.string(), @"6a696cf8");
+        assert_snapshot!(cb.hexdump(), @"6a696cf8");
     }
 
     #[test]
     fn test_ldr_literal() {
         let cb = compile(|cb| ldr_literal(cb, X0, 10.into()));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldr x0, #0x28"));
-        assert_snapshot!(cb.string(), @"40010058");
+        assert_snapshot!(cb.hexdump(), @"40010058");
     }
 
     #[test]
     fn test_ldr_post() {
         let cb = compile(|cb| ldr_post(cb, X10, A64Opnd::new_mem(64, X11, 16)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldr x10, [x11], #0x10"));
-        assert_snapshot!(cb.string(), @"6a0541f8");
+        assert_snapshot!(cb.hexdump(), @"6a0541f8");
     }
 
     #[test]
     fn test_ldr_pre() {
         let cb = compile(|cb| ldr_pre(cb, X10, A64Opnd::new_mem(64, X11, 16)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldr x10, [x11, #0x10]!"));
-        assert_snapshot!(cb.string(), @"6a0d41f8");
+        assert_snapshot!(cb.hexdump(), @"6a0d41f8");
     }
 
     #[test]
     fn test_ldrh() {
         let cb = compile(|cb| ldrh(cb, W10, A64Opnd::new_mem(64, X11, 12)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldrh w10, [x11, #0xc]"));
-        assert_snapshot!(cb.string(), @"6a194079");
+        assert_snapshot!(cb.hexdump(), @"6a194079");
     }
 
     #[test]
     fn test_ldrh_pre() {
         let cb = compile(|cb| ldrh_pre(cb, W10, A64Opnd::new_mem(64, X11, 12)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldrh w10, [x11, #0xc]!"));
-        assert_snapshot!(cb.string(), @"6acd4078");
+        assert_snapshot!(cb.hexdump(), @"6acd4078");
     }
 
     #[test]
     fn test_ldrh_post() {
         let cb = compile(|cb| ldrh_post(cb, W10, A64Opnd::new_mem(64, X11, 12)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldrh w10, [x11], #0xc"));
-        assert_snapshot!(cb.string(), @"6ac54078");
+        assert_snapshot!(cb.hexdump(), @"6ac54078");
     }
 
     #[test]
@@ -1603,349 +1603,349 @@ mod tests {
         0x0: ldurh w10, [x1]
         0x4: ldurh w10, [x1, #0x7b]
         "));
-        assert_snapshot!(cb.string(), @"2a0040782ab04778");
+        assert_snapshot!(cb.hexdump(), @"2a0040782ab04778");
     }
 
     #[test]
     fn test_ldur_memory() {
         let cb = compile(|cb| ldur(cb, X0, A64Opnd::new_mem(64, X1, 123)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldur x0, [x1, #0x7b]"));
-        assert_snapshot!(cb.string(), @"20b047f8");
+        assert_snapshot!(cb.hexdump(), @"20b047f8");
     }
 
     #[test]
     fn test_ldur_register() {
         let cb = compile(|cb| ldur(cb, X0, X1));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldur x0, [x1]"));
-        assert_snapshot!(cb.string(), @"200040f8");
+        assert_snapshot!(cb.hexdump(), @"200040f8");
     }
 
     #[test]
     fn test_ldursw() {
         let cb = compile(|cb| ldursw(cb, X10, A64Opnd::new_mem(64, X11, 123)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldursw x10, [x11, #0x7b]"));
-        assert_snapshot!(cb.string(), @"6ab187b8");
+        assert_snapshot!(cb.hexdump(), @"6ab187b8");
     }
 
     #[test]
     fn test_lsl() {
         let cb = compile(|cb| lsl(cb, X10, X11, A64Opnd::new_uimm(14)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lsl x10, x11, #0xe"));
-        assert_snapshot!(cb.string(), @"6ac572d3");
+        assert_snapshot!(cb.hexdump(), @"6ac572d3");
     }
 
     #[test]
     fn test_lsr() {
         let cb = compile(|cb| lsr(cb, X10, X11, A64Opnd::new_uimm(14)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lsr x10, x11, #0xe"));
-        assert_snapshot!(cb.string(), @"6afd4ed3");
+        assert_snapshot!(cb.hexdump(), @"6afd4ed3");
     }
 
     #[test]
     fn test_mov_registers() {
         let cb = compile(|cb| mov(cb, X10, X11));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov x10, x11"));
-        assert_snapshot!(cb.string(), @"ea030baa");
+        assert_snapshot!(cb.hexdump(), @"ea030baa");
     }
 
     #[test]
     fn test_mov_immediate() {
         let cb = compile(|cb| mov(cb, X10, A64Opnd::new_uimm(0x5555555555555555)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orr x10, xzr, #0x5555555555555555"));
-        assert_snapshot!(cb.string(), @"eaf300b2");
+        assert_snapshot!(cb.hexdump(), @"eaf300b2");
     }
 
     #[test]
     fn test_mov_32b_immediate() {
         let cb = compile(|cb| mov(cb, W10, A64Opnd::new_uimm(0x80000001)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov w10, #-0x7fffffff"));
-        assert_snapshot!(cb.string(), @"ea070132");
+        assert_snapshot!(cb.hexdump(), @"ea070132");
     }
     #[test]
     fn test_mov_into_sp() {
         let cb = compile(|cb| mov(cb, X31, X0));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov sp, x0"));
-        assert_snapshot!(cb.string(), @"1f000091");
+        assert_snapshot!(cb.hexdump(), @"1f000091");
     }
 
     #[test]
     fn test_mov_from_sp() {
         let cb = compile(|cb| mov(cb, X0, X31));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov x0, sp"));
-        assert_snapshot!(cb.string(), @"e0030091");
+        assert_snapshot!(cb.hexdump(), @"e0030091");
     }
 
     #[test]
     fn test_movk() {
         let cb = compile(|cb| movk(cb, X0, A64Opnd::new_uimm(123), 16));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movk x0, #0x7b, lsl #16"));
-        assert_snapshot!(cb.string(), @"600fa0f2");
+        assert_snapshot!(cb.hexdump(), @"600fa0f2");
     }
 
     #[test]
     fn test_movn() {
         let cb = compile(|cb| movn(cb, X0, A64Opnd::new_uimm(123), 16));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov x0, #-0x7b0001"));
-        assert_snapshot!(cb.string(), @"600fa092");
+        assert_snapshot!(cb.hexdump(), @"600fa092");
     }
 
     #[test]
     fn test_movz() {
         let cb = compile(|cb| movz(cb, X0, A64Opnd::new_uimm(123), 16));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov x0, #0x7b0000"));
-        assert_snapshot!(cb.string(), @"600fa0d2");
+        assert_snapshot!(cb.hexdump(), @"600fa0d2");
     }
 
     #[test]
     fn test_mrs() {
         let cb = compile(|cb| mrs(cb, X10, SystemRegister::NZCV));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mrs x10, nzcv"));
-        assert_snapshot!(cb.string(), @"0a423bd5");
+        assert_snapshot!(cb.hexdump(), @"0a423bd5");
     }
 
     #[test]
     fn test_msr() {
         let cb = compile(|cb| msr(cb, SystemRegister::NZCV, X10));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: msr nzcv, x10"));
-        assert_snapshot!(cb.string(), @"0a421bd5");
+        assert_snapshot!(cb.hexdump(), @"0a421bd5");
     }
 
     #[test]
     fn test_mul() {
         let cb = compile(|cb| mul(cb, X10, X11, X12));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mul x10, x11, x12"));
-        assert_snapshot!(cb.string(), @"6a7d0c9b");
+        assert_snapshot!(cb.hexdump(), @"6a7d0c9b");
     }
 
     #[test]
     fn test_mvn() {
         let cb = compile(|cb| mvn(cb, X10, X11));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mvn x10, x11"));
-        assert_snapshot!(cb.string(), @"ea032baa");
+        assert_snapshot!(cb.hexdump(), @"ea032baa");
     }
 
     #[test]
     fn test_nop() {
         let cb = compile(nop);
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop"));
-        assert_snapshot!(cb.string(), @"1f2003d5");
+        assert_snapshot!(cb.hexdump(), @"1f2003d5");
     }
 
     #[test]
     fn test_orn() {
         let cb = compile(|cb| orn(cb, X10, X11, X12));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orn x10, x11, x12"));
-        assert_snapshot!(cb.string(), @"6a012caa");
+        assert_snapshot!(cb.hexdump(), @"6a012caa");
     }
 
     #[test]
     fn test_orr_register() {
         let cb = compile(|cb| orr(cb, X10, X11, X12));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orr x10, x11, x12"));
-        assert_snapshot!(cb.string(), @"6a010caa");
+        assert_snapshot!(cb.hexdump(), @"6a010caa");
     }
 
     #[test]
     fn test_orr_immediate() {
         let cb = compile(|cb| orr(cb, X10, X11, A64Opnd::new_uimm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orr x10, x11, #7"));
-        assert_snapshot!(cb.string(), @"6a0940b2");
+        assert_snapshot!(cb.hexdump(), @"6a0940b2");
     }
 
     #[test]
     fn test_orr_32b_immediate() {
         let cb = compile(|cb| orr(cb, W10, W11, A64Opnd::new_uimm(1)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orr w10, w11, #1"));
-        assert_snapshot!(cb.string(), @"6a010032");
+        assert_snapshot!(cb.hexdump(), @"6a010032");
     }
 
     #[test]
     fn test_ret_none() {
         let cb = compile(|cb| ret(cb, A64Opnd::None));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ret"));
-        assert_snapshot!(cb.string(), @"c0035fd6");
+        assert_snapshot!(cb.hexdump(), @"c0035fd6");
     }
 
     #[test]
     fn test_ret_register() {
         let cb = compile(|cb| ret(cb, X20));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ret x20"));
-        assert_snapshot!(cb.string(), @"80025fd6");
+        assert_snapshot!(cb.hexdump(), @"80025fd6");
     }
 
     #[test]
     fn test_stlxr() {
         let cb = compile(|cb| stlxr(cb, W10, X11, X12));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stlxr w10, x11, [x12]"));
-        assert_snapshot!(cb.string(), @"8bfd0ac8");
+        assert_snapshot!(cb.hexdump(), @"8bfd0ac8");
     }
 
     #[test]
     fn test_stp() {
         let cb = compile(|cb| stp(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stp x10, x11, [x12, #0xd0]"));
-        assert_snapshot!(cb.string(), @"8a2d0da9");
+        assert_snapshot!(cb.hexdump(), @"8a2d0da9");
     }
 
     #[test]
     fn test_stp_pre() {
         let cb = compile(|cb| stp_pre(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stp x10, x11, [x12, #0xd0]!"));
-        assert_snapshot!(cb.string(), @"8a2d8da9");
+        assert_snapshot!(cb.hexdump(), @"8a2d8da9");
     }
 
     #[test]
     fn test_stp_post() {
         let cb = compile(|cb| stp_post(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stp x10, x11, [x12], #0xd0"));
-        assert_snapshot!(cb.string(), @"8a2d8da8");
+        assert_snapshot!(cb.hexdump(), @"8a2d8da8");
     }
 
     #[test]
     fn test_str_post() {
         let cb = compile(|cb| str_post(cb, X10, A64Opnd::new_mem(64, X11, -16)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: str x10, [x11], #0xfffffffffffffff0"));
-        assert_snapshot!(cb.string(), @"6a051ff8");
+        assert_snapshot!(cb.hexdump(), @"6a051ff8");
     }
 
     #[test]
     fn test_str_pre() {
         let cb = compile(|cb| str_pre(cb, X10, A64Opnd::new_mem(64, X11, -16)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: str x10, [x11, #-0x10]!"));
-        assert_snapshot!(cb.string(), @"6a0d1ff8");
+        assert_snapshot!(cb.hexdump(), @"6a0d1ff8");
     }
 
     #[test]
     fn test_strh() {
         let cb = compile(|cb| strh(cb, W10, A64Opnd::new_mem(64, X11, 12)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: strh w10, [x11, #0xc]"));
-        assert_snapshot!(cb.string(), @"6a190079");
+        assert_snapshot!(cb.hexdump(), @"6a190079");
     }
 
     #[test]
     fn test_strh_pre() {
         let cb = compile(|cb| strh_pre(cb, W10, A64Opnd::new_mem(64, X11, 12)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: strh w10, [x11, #0xc]!"));
-        assert_snapshot!(cb.string(), @"6acd0078");
+        assert_snapshot!(cb.hexdump(), @"6acd0078");
     }
 
     #[test]
     fn test_strh_post() {
         let cb = compile(|cb| strh_post(cb, W10, A64Opnd::new_mem(64, X11, 12)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: strh w10, [x11], #0xc"));
-        assert_snapshot!(cb.string(), @"6ac50078");
+        assert_snapshot!(cb.hexdump(), @"6ac50078");
     }
 
     #[test]
     fn test_stur_64_bits() {
         let cb = compile(|cb| stur(cb, X10, A64Opnd::new_mem(64, X11, 128)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stur x10, [x11, #0x80]"));
-        assert_snapshot!(cb.string(), @"6a0108f8");
+        assert_snapshot!(cb.hexdump(), @"6a0108f8");
     }
 
     #[test]
     fn test_stur_32_bits() {
         let cb = compile(|cb| stur(cb, X10, A64Opnd::new_mem(32, X11, 128)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stur w10, [x11, #0x80]"));
-        assert_snapshot!(cb.string(), @"6a0108b8");
+        assert_snapshot!(cb.hexdump(), @"6a0108b8");
     }
 
     #[test]
     fn test_sub_reg() {
         let cb = compile(|cb| sub(cb, X0, X1, X2));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub x0, x1, x2"));
-        assert_snapshot!(cb.string(), @"200002cb");
+        assert_snapshot!(cb.hexdump(), @"200002cb");
     }
 
     #[test]
     fn test_sub_uimm() {
         let cb = compile(|cb| sub(cb, X0, X1, A64Opnd::new_uimm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"201c00d1");
+        assert_snapshot!(cb.hexdump(), @"201c00d1");
     }
 
     #[test]
     fn test_sub_imm_positive() {
         let cb = compile(|cb| sub(cb, X0, X1, A64Opnd::new_imm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"201c00d1");
+        assert_snapshot!(cb.hexdump(), @"201c00d1");
     }
 
     #[test]
     fn test_sub_imm_negative() {
         let cb = compile(|cb| sub(cb, X0, X1, A64Opnd::new_imm(-7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"201c0091");
+        assert_snapshot!(cb.hexdump(), @"201c0091");
     }
 
     #[test]
     fn test_subs_reg() {
         let cb = compile(|cb| subs(cb, X0, X1, X2));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: subs x0, x1, x2"));
-        assert_snapshot!(cb.string(), @"200002eb");
+        assert_snapshot!(cb.hexdump(), @"200002eb");
     }
 
     #[test]
     fn test_subs_imm_positive() {
         let cb = compile(|cb| subs(cb, X0, X1, A64Opnd::new_imm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: subs x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"201c00f1");
+        assert_snapshot!(cb.hexdump(), @"201c00f1");
     }
 
     #[test]
     fn test_subs_imm_negative() {
         let cb = compile(|cb| subs(cb, X0, X1, A64Opnd::new_imm(-7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adds x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"201c00b1");
+        assert_snapshot!(cb.hexdump(), @"201c00b1");
     }
 
     #[test]
     fn test_subs_uimm() {
         let cb = compile(|cb| subs(cb, X0, X1, A64Opnd::new_uimm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: subs x0, x1, #7"));
-        assert_snapshot!(cb.string(), @"201c00f1");
+        assert_snapshot!(cb.hexdump(), @"201c00f1");
     }
 
     #[test]
     fn test_sxtw() {
         let cb = compile(|cb| sxtw(cb, X10, W11));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sxtw x10, w11"));
-        assert_snapshot!(cb.string(), @"6a7d4093");
+        assert_snapshot!(cb.hexdump(), @"6a7d4093");
     }
 
     #[test]
     fn test_tbnz() {
         let cb = compile(|cb| tbnz(cb, X10, A64Opnd::UImm(10), A64Opnd::Imm(2)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tbnz w10, #0xa, #8"));
-        assert_snapshot!(cb.string(), @"4a005037");
+        assert_snapshot!(cb.hexdump(), @"4a005037");
     }
 
     #[test]
     fn test_tbz() {
         let cb = compile(|cb| tbz(cb, X10, A64Opnd::UImm(10), A64Opnd::Imm(2)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tbz w10, #0xa, #8"));
-        assert_snapshot!(cb.string(), @"4a005036");
+        assert_snapshot!(cb.hexdump(), @"4a005036");
     }
 
     #[test]
     fn test_tst_register() {
         let cb = compile(|cb| tst(cb, X0, X1));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tst x0, x1"));
-        assert_snapshot!(cb.string(), @"1f0001ea");
+        assert_snapshot!(cb.hexdump(), @"1f0001ea");
     }
 
     #[test]
     fn test_tst_immediate() {
         let cb = compile(|cb| tst(cb, X1, A64Opnd::new_uimm(7)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tst x1, #7"));
-        assert_snapshot!(cb.string(), @"3f0840f2");
+        assert_snapshot!(cb.hexdump(), @"3f0840f2");
     }
 
     #[test]
     fn test_tst_32b_immediate() {
         let cb = compile(|cb| tst(cb, W0, A64Opnd::new_uimm(0xffff)));
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tst w0, #0xffff"));
-        assert_snapshot!(cb.string(), @"1f3c0072");
+        assert_snapshot!(cb.hexdump(), @"1f3c0072");
     }
 
     #[test]
@@ -1961,6 +1961,6 @@ mod tests {
             0x4: add x30, x30, x30, uxtx
             0x8: add sp, sp, xzr
         "));
-        assert_snapshot!(cb.string(), @"6a61298bde633e8bff633f8b");
+        assert_snapshot!(cb.hexdump(), @"6a61298bde633e8bff633f8b");
     }
 }

--- a/zjit/src/asm/arm64/mod.rs
+++ b/zjit/src/asm/arm64/mod.rs
@@ -1246,112 +1246,112 @@ mod tests {
     #[test]
     fn test_add_reg() {
         let cb = compile(|cb| add(cb, X0, X1, X2));
-        assert_snapshot!(cb.disasm(), @"  0x0: add x0, x1, x2");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add x0, x1, x2"));
         assert_snapshot!(cb.string(), @"2000028b");
     }
 
     #[test]
     fn test_add_uimm() {
         let cb = compile(|cb| add(cb, X0, X1, A64Opnd::new_uimm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: add x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add x0, x1, #7"));
         assert_snapshot!(cb.string(), @"201c0091");
     }
 
     #[test]
     fn test_add_imm_positive() {
         let cb = compile(|cb| add(cb, X0, X1, A64Opnd::new_imm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: add x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add x0, x1, #7"));
         assert_snapshot!(cb.string(), @"201c0091");
     }
 
     #[test]
     fn test_add_imm_negative() {
         let cb = compile(|cb| add(cb, X0, X1, A64Opnd::new_imm(-7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub x0, x1, #7"));
         assert_snapshot!(cb.string(), @"201c00d1");
     }
 
     #[test]
     fn test_adds_reg() {
         let cb = compile(|cb| adds(cb, X0, X1, X2));
-        assert_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, x2");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adds x0, x1, x2"));
         assert_snapshot!(cb.string(), @"200002ab");
     }
 
     #[test]
     fn test_adds_uimm() {
         let cb = compile(|cb| adds(cb, X0, X1, A64Opnd::new_uimm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adds x0, x1, #7"));
         assert_snapshot!(cb.string(), @"201c00b1");
     }
 
     #[test]
     fn test_adds_imm_positive() {
         let cb = compile(|cb| adds(cb, X0, X1, A64Opnd::new_imm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adds x0, x1, #7"));
         assert_snapshot!(cb.string(), @"201c00b1");
     }
 
     #[test]
     fn test_adds_imm_negative() {
         let cb = compile(|cb| adds(cb, X0, X1, A64Opnd::new_imm(-7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: subs x0, x1, #7"));
         assert_snapshot!(cb.string(), @"201c00f1");
     }
 
     #[test]
     fn test_adr() {
         let cb = compile(|cb| adr(cb, X10, A64Opnd::new_imm(20)));
-        assert_snapshot!(cb.disasm(), @"  0x0: adr x10, #0x14");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adr x10, #0x14"));
         assert_snapshot!(cb.string(), @"aa000010");
     }
 
     #[test]
     fn test_adrp() {
         let cb = compile(|cb| adrp(cb, X10, A64Opnd::new_imm(0x8000)));
-        assert_snapshot!(cb.disasm(), @"  0x0: adrp x10, #0x8000");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adrp x10, #0x8000"));
         assert_snapshot!(cb.string(), @"4a000090");
     }
 
     #[test]
     fn test_and_register() {
         let cb = compile(|cb| and(cb, X0, X1, X2));
-        assert_snapshot!(cb.disasm(), @"  0x0: and x0, x1, x2");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and x0, x1, x2"));
         assert_snapshot!(cb.string(), @"2000028a");
     }
 
     #[test]
     fn test_and_immediate() {
         let cb = compile(|cb| and(cb, X0, X1, A64Opnd::new_uimm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: and x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and x0, x1, #7"));
         assert_snapshot!(cb.string(), @"20084092");
     }
 
     #[test]
     fn test_and_32b_immediate() {
         let cb = compile(|cb| and(cb, W0, W2, A64Opnd::new_uimm(0xfffff)));
-        assert_snapshot!(cb.disasm(), @"  0x0: and w0, w2, #0xfffff");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and w0, w2, #0xfffff"));
         assert_snapshot!(cb.string(), @"404c0012");
     }
 
     #[test]
     fn test_ands_register() {
         let cb = compile(|cb| ands(cb, X0, X1, X2));
-        assert_snapshot!(cb.disasm(), @"  0x0: ands x0, x1, x2");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ands x0, x1, x2"));
         assert_snapshot!(cb.string(), @"200002ea");
     }
 
     #[test]
     fn test_ands_immediate() {
         let cb = compile(|cb| ands(cb, X0, X1, A64Opnd::new_uimm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: ands x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ands x0, x1, #7"));
         assert_snapshot!(cb.string(), @"200840f2");
     }
 
     #[test]
     fn test_asr() {
         let cb = compile(|cb| asr(cb, X20, X21, A64Opnd::new_uimm(10)));
-        assert_snapshot!(cb.disasm(), @"  0x0: asr x20, x21, #0xa");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: asr x20, x21, #0xa"));
         assert_snapshot!(cb.string(), @"b4fe4a93");
     }
 
@@ -1359,7 +1359,7 @@ mod tests {
     fn test_bcond() {
         let offset = InstructionOffset::from_insns(0x100);
         let cb = compile(|cb| bcond(cb, Condition::NE, offset));
-        assert_snapshot!(cb.disasm(), @"  0x0: b.ne #0x400");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: b.ne #0x400"));
         assert_snapshot!(cb.string(), @"01200054");
     }
 
@@ -1367,7 +1367,7 @@ mod tests {
     fn test_b() {
         let offset = InstructionOffset::from_insns((1 << 25) - 1);
         let cb = compile(|cb| b(cb, offset));
-        assert_snapshot!(cb.disasm(), @"  0x0: b #0x7fffffc");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: b #0x7fffffc"));
         assert_snapshot!(cb.string(), @"ffffff15");
     }
 
@@ -1391,7 +1391,7 @@ mod tests {
     fn test_bl() {
         let offset = InstructionOffset::from_insns(-(1 << 25));
         let cb = compile(|cb| bl(cb, offset));
-        assert_snapshot!(cb.disasm(), @"  0x0: bl #0xfffffffff8000000");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: bl #0xfffffffff8000000"));
         assert_snapshot!(cb.string(), @"00000096");
     }
 
@@ -1414,14 +1414,14 @@ mod tests {
     #[test]
     fn test_blr() {
         let cb = compile(|cb| blr(cb, X20));
-        assert_snapshot!(cb.disasm(), @"  0x0: blr x20");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: blr x20"));
         assert_snapshot!(cb.string(), @"80023fd6");
     }
 
     #[test]
     fn test_br() {
         let cb = compile(|cb| br(cb, X20));
-        assert_snapshot!(cb.disasm(), @"  0x0: br x20");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: br x20"));
         assert_snapshot!(cb.string(), @"80021fd6");
     }
 
@@ -1432,10 +1432,10 @@ mod tests {
             cbz(cb, X0, offset);
             cbz(cb, W0, offset);
         });
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: cbz x0, #0xfffffffffffffffc
         0x4: cbz w0, #0
-        ");
+        "));
         assert_snapshot!(cb.string(), @"e0ffffb4e0ffff34");
     }
 
@@ -1446,150 +1446,150 @@ mod tests {
             cbnz(cb, X20, offset);
             cbnz(cb, W20, offset);
         });
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: cbnz x20, #8
         0x4: cbnz w20, #0xc
-        ");
+        "));
         assert_snapshot!(cb.string(), @"540000b554000035");
     }
 
     #[test]
     fn test_brk_none() {
         let cb = compile(|cb| brk(cb, A64Opnd::None));
-        assert_snapshot!(cb.disasm(), @"  0x0: brk #0xf000");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: brk #0xf000"));
         assert_snapshot!(cb.string(), @"00003ed4");
     }
 
     #[test]
     fn test_brk_uimm() {
         let cb = compile(|cb| brk(cb, A64Opnd::new_uimm(14)));
-        assert_snapshot!(cb.disasm(), @"  0x0: brk #0xe");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: brk #0xe"));
         assert_snapshot!(cb.string(), @"c00120d4");
     }
 
     #[test]
     fn test_cmp_register() {
         let cb = compile(|cb| cmp(cb, X10, X11));
-        assert_snapshot!(cb.disasm(), @"  0x0: cmp x10, x11");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp x10, x11"));
         assert_snapshot!(cb.string(), @"5f010beb");
     }
 
     #[test]
     fn test_cmp_immediate() {
         let cb = compile(|cb| cmp(cb, X10, A64Opnd::new_uimm(14)));
-        assert_snapshot!(cb.disasm(), @"  0x0: cmp x10, #0xe");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp x10, #0xe"));
         assert_snapshot!(cb.string(), @"5f3900f1");
     }
 
     #[test]
     fn test_csel() {
         let cb = compile(|cb| csel(cb, X10, X11, X12, Condition::EQ));
-        assert_snapshot!(cb.disasm(), @"  0x0: csel x10, x11, x12, eq");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: csel x10, x11, x12, eq"));
         assert_snapshot!(cb.string(), @"6a018c9a");
     }
 
     #[test]
     fn test_eor_register() {
         let cb = compile(|cb| eor(cb, X10, X11, X12));
-        assert_snapshot!(cb.disasm(), @"  0x0: eor x10, x11, x12");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: eor x10, x11, x12"));
         assert_snapshot!(cb.string(), @"6a010cca");
     }
 
     #[test]
     fn test_eor_immediate() {
         let cb = compile(|cb| eor(cb, X10, X11, A64Opnd::new_uimm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: eor x10, x11, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: eor x10, x11, #7"));
         assert_snapshot!(cb.string(), @"6a0940d2");
     }
 
     #[test]
     fn test_eor_32b_immediate() {
         let cb = compile(|cb| eor(cb, W9, W1, A64Opnd::new_uimm(0x80000001)));
-        assert_snapshot!(cb.disasm(), @"  0x0: eor w9, w1, #0x80000001");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: eor w9, w1, #0x80000001"));
         assert_snapshot!(cb.string(), @"29040152");
     }
 
     #[test]
     fn test_ldaddal() {
         let cb = compile(|cb| ldaddal(cb, X10, X11, X12));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldaddal x10, x11, [x12]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldaddal x10, x11, [x12]"));
         assert_snapshot!(cb.string(), @"8b01eaf8");
     }
 
     #[test]
     fn test_ldaxr() {
         let cb = compile(|cb| ldaxr(cb, X10, X11));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldaxr x10, [x11]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldaxr x10, [x11]"));
         assert_snapshot!(cb.string(), @"6afd5fc8");
     }
 
     #[test]
     fn test_ldp() {
         let cb = compile(|cb| ldp(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldp x10, x11, [x12, #0xd0]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldp x10, x11, [x12, #0xd0]"));
         assert_snapshot!(cb.string(), @"8a2d4da9");
     }
 
     #[test]
     fn test_ldp_pre() {
         let cb = compile(|cb| ldp_pre(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldp x10, x11, [x12, #0xd0]!");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldp x10, x11, [x12, #0xd0]!"));
         assert_snapshot!(cb.string(), @"8a2dcda9");
     }
 
     #[test]
     fn test_ldp_post() {
         let cb = compile(|cb| ldp_post(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldp x10, x11, [x12], #0xd0");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldp x10, x11, [x12], #0xd0"));
         assert_snapshot!(cb.string(), @"8a2dcda8");
     }
 
     #[test]
     fn test_ldr() {
         let cb = compile(|cb| ldr(cb, X10, X11, X12));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldr x10, [x11, x12]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldr x10, [x11, x12]"));
         assert_snapshot!(cb.string(), @"6a696cf8");
     }
 
     #[test]
     fn test_ldr_literal() {
         let cb = compile(|cb| ldr_literal(cb, X0, 10.into()));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldr x0, #0x28");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldr x0, #0x28"));
         assert_snapshot!(cb.string(), @"40010058");
     }
 
     #[test]
     fn test_ldr_post() {
         let cb = compile(|cb| ldr_post(cb, X10, A64Opnd::new_mem(64, X11, 16)));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldr x10, [x11], #0x10");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldr x10, [x11], #0x10"));
         assert_snapshot!(cb.string(), @"6a0541f8");
     }
 
     #[test]
     fn test_ldr_pre() {
         let cb = compile(|cb| ldr_pre(cb, X10, A64Opnd::new_mem(64, X11, 16)));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldr x10, [x11, #0x10]!");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldr x10, [x11, #0x10]!"));
         assert_snapshot!(cb.string(), @"6a0d41f8");
     }
 
     #[test]
     fn test_ldrh() {
         let cb = compile(|cb| ldrh(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldrh w10, [x11, #0xc]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldrh w10, [x11, #0xc]"));
         assert_snapshot!(cb.string(), @"6a194079");
     }
 
     #[test]
     fn test_ldrh_pre() {
         let cb = compile(|cb| ldrh_pre(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldrh w10, [x11, #0xc]!");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldrh w10, [x11, #0xc]!"));
         assert_snapshot!(cb.string(), @"6acd4078");
     }
 
     #[test]
     fn test_ldrh_post() {
         let cb = compile(|cb| ldrh_post(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldrh w10, [x11], #0xc");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldrh w10, [x11], #0xc"));
         assert_snapshot!(cb.string(), @"6ac54078");
     }
 
@@ -1599,352 +1599,352 @@ mod tests {
             ldurh(cb, W10, A64Opnd::new_mem(64, X1, 0));
             ldurh(cb, W10, A64Opnd::new_mem(64, X1, 123));
         });
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: ldurh w10, [x1]
         0x4: ldurh w10, [x1, #0x7b]
-        ");
+        "));
         assert_snapshot!(cb.string(), @"2a0040782ab04778");
     }
 
     #[test]
     fn test_ldur_memory() {
         let cb = compile(|cb| ldur(cb, X0, A64Opnd::new_mem(64, X1, 123)));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldur x0, [x1, #0x7b]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldur x0, [x1, #0x7b]"));
         assert_snapshot!(cb.string(), @"20b047f8");
     }
 
     #[test]
     fn test_ldur_register() {
         let cb = compile(|cb| ldur(cb, X0, X1));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldur x0, [x1]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldur x0, [x1]"));
         assert_snapshot!(cb.string(), @"200040f8");
     }
 
     #[test]
     fn test_ldursw() {
         let cb = compile(|cb| ldursw(cb, X10, A64Opnd::new_mem(64, X11, 123)));
-        assert_snapshot!(cb.disasm(), @"  0x0: ldursw x10, [x11, #0x7b]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldursw x10, [x11, #0x7b]"));
         assert_snapshot!(cb.string(), @"6ab187b8");
     }
 
     #[test]
     fn test_lsl() {
         let cb = compile(|cb| lsl(cb, X10, X11, A64Opnd::new_uimm(14)));
-        assert_snapshot!(cb.disasm(), @"  0x0: lsl x10, x11, #0xe");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lsl x10, x11, #0xe"));
         assert_snapshot!(cb.string(), @"6ac572d3");
     }
 
     #[test]
     fn test_lsr() {
         let cb = compile(|cb| lsr(cb, X10, X11, A64Opnd::new_uimm(14)));
-        assert_snapshot!(cb.disasm(), @"  0x0: lsr x10, x11, #0xe");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lsr x10, x11, #0xe"));
         assert_snapshot!(cb.string(), @"6afd4ed3");
     }
 
     #[test]
     fn test_mov_registers() {
         let cb = compile(|cb| mov(cb, X10, X11));
-        assert_snapshot!(cb.disasm(), @"  0x0: mov x10, x11");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov x10, x11"));
         assert_snapshot!(cb.string(), @"ea030baa");
     }
 
     #[test]
     fn test_mov_immediate() {
         let cb = compile(|cb| mov(cb, X10, A64Opnd::new_uimm(0x5555555555555555)));
-        assert_snapshot!(cb.disasm(), @"  0x0: orr x10, xzr, #0x5555555555555555");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orr x10, xzr, #0x5555555555555555"));
         assert_snapshot!(cb.string(), @"eaf300b2");
     }
 
     #[test]
     fn test_mov_32b_immediate() {
         let cb = compile(|cb| mov(cb, W10, A64Opnd::new_uimm(0x80000001)));
-        assert_snapshot!(cb.disasm(), @"  0x0: mov w10, #-0x7fffffff");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov w10, #-0x7fffffff"));
         assert_snapshot!(cb.string(), @"ea070132");
     }
     #[test]
     fn test_mov_into_sp() {
         let cb = compile(|cb| mov(cb, X31, X0));
-        assert_snapshot!(cb.disasm(), @"  0x0: mov sp, x0");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov sp, x0"));
         assert_snapshot!(cb.string(), @"1f000091");
     }
 
     #[test]
     fn test_mov_from_sp() {
         let cb = compile(|cb| mov(cb, X0, X31));
-        assert_snapshot!(cb.disasm(), @"  0x0: mov x0, sp");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov x0, sp"));
         assert_snapshot!(cb.string(), @"e0030091");
     }
 
     #[test]
     fn test_movk() {
         let cb = compile(|cb| movk(cb, X0, A64Opnd::new_uimm(123), 16));
-        assert_snapshot!(cb.disasm(), @"  0x0: movk x0, #0x7b, lsl #16");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movk x0, #0x7b, lsl #16"));
         assert_snapshot!(cb.string(), @"600fa0f2");
     }
 
     #[test]
     fn test_movn() {
         let cb = compile(|cb| movn(cb, X0, A64Opnd::new_uimm(123), 16));
-        assert_snapshot!(cb.disasm(), @"  0x0: mov x0, #-0x7b0001");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov x0, #-0x7b0001"));
         assert_snapshot!(cb.string(), @"600fa092");
     }
 
     #[test]
     fn test_movz() {
         let cb = compile(|cb| movz(cb, X0, A64Opnd::new_uimm(123), 16));
-        assert_snapshot!(cb.disasm(), @"  0x0: mov x0, #0x7b0000");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov x0, #0x7b0000"));
         assert_snapshot!(cb.string(), @"600fa0d2");
     }
 
     #[test]
     fn test_mrs() {
         let cb = compile(|cb| mrs(cb, X10, SystemRegister::NZCV));
-        assert_snapshot!(cb.disasm(), @"  0x0: mrs x10, nzcv");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mrs x10, nzcv"));
         assert_snapshot!(cb.string(), @"0a423bd5");
     }
 
     #[test]
     fn test_msr() {
         let cb = compile(|cb| msr(cb, SystemRegister::NZCV, X10));
-        assert_snapshot!(cb.disasm(), @"  0x0: msr nzcv, x10");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: msr nzcv, x10"));
         assert_snapshot!(cb.string(), @"0a421bd5");
     }
 
     #[test]
     fn test_mul() {
         let cb = compile(|cb| mul(cb, X10, X11, X12));
-        assert_snapshot!(cb.disasm(), @"  0x0: mul x10, x11, x12");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mul x10, x11, x12"));
         assert_snapshot!(cb.string(), @"6a7d0c9b");
     }
 
     #[test]
     fn test_mvn() {
         let cb = compile(|cb| mvn(cb, X10, X11));
-        assert_snapshot!(cb.disasm(), @"  0x0: mvn x10, x11");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mvn x10, x11"));
         assert_snapshot!(cb.string(), @"ea032baa");
     }
 
     #[test]
     fn test_nop() {
         let cb = compile(nop);
-        assert_snapshot!(cb.disasm(), @"  0x0: nop");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop"));
         assert_snapshot!(cb.string(), @"1f2003d5");
     }
 
     #[test]
     fn test_orn() {
         let cb = compile(|cb| orn(cb, X10, X11, X12));
-        assert_snapshot!(cb.disasm(), @"  0x0: orn x10, x11, x12");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orn x10, x11, x12"));
         assert_snapshot!(cb.string(), @"6a012caa");
     }
 
     #[test]
     fn test_orr_register() {
         let cb = compile(|cb| orr(cb, X10, X11, X12));
-        assert_snapshot!(cb.disasm(), @"  0x0: orr x10, x11, x12");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orr x10, x11, x12"));
         assert_snapshot!(cb.string(), @"6a010caa");
     }
 
     #[test]
     fn test_orr_immediate() {
         let cb = compile(|cb| orr(cb, X10, X11, A64Opnd::new_uimm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: orr x10, x11, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orr x10, x11, #7"));
         assert_snapshot!(cb.string(), @"6a0940b2");
     }
 
     #[test]
     fn test_orr_32b_immediate() {
         let cb = compile(|cb| orr(cb, W10, W11, A64Opnd::new_uimm(1)));
-        assert_snapshot!(cb.disasm(), @"  0x0: orr w10, w11, #1");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orr w10, w11, #1"));
         assert_snapshot!(cb.string(), @"6a010032");
     }
 
     #[test]
     fn test_ret_none() {
         let cb = compile(|cb| ret(cb, A64Opnd::None));
-        assert_snapshot!(cb.disasm(), @"  0x0: ret");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ret"));
         assert_snapshot!(cb.string(), @"c0035fd6");
     }
 
     #[test]
     fn test_ret_register() {
         let cb = compile(|cb| ret(cb, X20));
-        assert_snapshot!(cb.disasm(), @"  0x0: ret x20");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ret x20"));
         assert_snapshot!(cb.string(), @"80025fd6");
     }
 
     #[test]
     fn test_stlxr() {
         let cb = compile(|cb| stlxr(cb, W10, X11, X12));
-        assert_snapshot!(cb.disasm(), @"  0x0: stlxr w10, x11, [x12]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stlxr w10, x11, [x12]"));
         assert_snapshot!(cb.string(), @"8bfd0ac8");
     }
 
     #[test]
     fn test_stp() {
         let cb = compile(|cb| stp(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        assert_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12, #0xd0]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stp x10, x11, [x12, #0xd0]"));
         assert_snapshot!(cb.string(), @"8a2d0da9");
     }
 
     #[test]
     fn test_stp_pre() {
         let cb = compile(|cb| stp_pre(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        assert_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12, #0xd0]!");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stp x10, x11, [x12, #0xd0]!"));
         assert_snapshot!(cb.string(), @"8a2d8da9");
     }
 
     #[test]
     fn test_stp_post() {
         let cb = compile(|cb| stp_post(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        assert_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12], #0xd0");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stp x10, x11, [x12], #0xd0"));
         assert_snapshot!(cb.string(), @"8a2d8da8");
     }
 
     #[test]
     fn test_str_post() {
         let cb = compile(|cb| str_post(cb, X10, A64Opnd::new_mem(64, X11, -16)));
-        assert_snapshot!(cb.disasm(), @"  0x0: str x10, [x11], #0xfffffffffffffff0");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: str x10, [x11], #0xfffffffffffffff0"));
         assert_snapshot!(cb.string(), @"6a051ff8");
     }
 
     #[test]
     fn test_str_pre() {
         let cb = compile(|cb| str_pre(cb, X10, A64Opnd::new_mem(64, X11, -16)));
-        assert_snapshot!(cb.disasm(), @"  0x0: str x10, [x11, #-0x10]!");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: str x10, [x11, #-0x10]!"));
         assert_snapshot!(cb.string(), @"6a0d1ff8");
     }
 
     #[test]
     fn test_strh() {
         let cb = compile(|cb| strh(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        assert_snapshot!(cb.disasm(), @"  0x0: strh w10, [x11, #0xc]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: strh w10, [x11, #0xc]"));
         assert_snapshot!(cb.string(), @"6a190079");
     }
 
     #[test]
     fn test_strh_pre() {
         let cb = compile(|cb| strh_pre(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        assert_snapshot!(cb.disasm(), @"  0x0: strh w10, [x11, #0xc]!");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: strh w10, [x11, #0xc]!"));
         assert_snapshot!(cb.string(), @"6acd0078");
     }
 
     #[test]
     fn test_strh_post() {
         let cb = compile(|cb| strh_post(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        assert_snapshot!(cb.disasm(), @"  0x0: strh w10, [x11], #0xc");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: strh w10, [x11], #0xc"));
         assert_snapshot!(cb.string(), @"6ac50078");
     }
 
     #[test]
     fn test_stur_64_bits() {
         let cb = compile(|cb| stur(cb, X10, A64Opnd::new_mem(64, X11, 128)));
-        assert_snapshot!(cb.disasm(), @"  0x0: stur x10, [x11, #0x80]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stur x10, [x11, #0x80]"));
         assert_snapshot!(cb.string(), @"6a0108f8");
     }
 
     #[test]
     fn test_stur_32_bits() {
         let cb = compile(|cb| stur(cb, X10, A64Opnd::new_mem(32, X11, 128)));
-        assert_snapshot!(cb.disasm(), @"  0x0: stur w10, [x11, #0x80]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stur w10, [x11, #0x80]"));
         assert_snapshot!(cb.string(), @"6a0108b8");
     }
 
     #[test]
     fn test_sub_reg() {
         let cb = compile(|cb| sub(cb, X0, X1, X2));
-        assert_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, x2");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub x0, x1, x2"));
         assert_snapshot!(cb.string(), @"200002cb");
     }
 
     #[test]
     fn test_sub_uimm() {
         let cb = compile(|cb| sub(cb, X0, X1, A64Opnd::new_uimm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub x0, x1, #7"));
         assert_snapshot!(cb.string(), @"201c00d1");
     }
 
     #[test]
     fn test_sub_imm_positive() {
         let cb = compile(|cb| sub(cb, X0, X1, A64Opnd::new_imm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub x0, x1, #7"));
         assert_snapshot!(cb.string(), @"201c00d1");
     }
 
     #[test]
     fn test_sub_imm_negative() {
         let cb = compile(|cb| sub(cb, X0, X1, A64Opnd::new_imm(-7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: add x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add x0, x1, #7"));
         assert_snapshot!(cb.string(), @"201c0091");
     }
 
     #[test]
     fn test_subs_reg() {
         let cb = compile(|cb| subs(cb, X0, X1, X2));
-        assert_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, x2");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: subs x0, x1, x2"));
         assert_snapshot!(cb.string(), @"200002eb");
     }
 
     #[test]
     fn test_subs_imm_positive() {
         let cb = compile(|cb| subs(cb, X0, X1, A64Opnd::new_imm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: subs x0, x1, #7"));
         assert_snapshot!(cb.string(), @"201c00f1");
     }
 
     #[test]
     fn test_subs_imm_negative() {
         let cb = compile(|cb| subs(cb, X0, X1, A64Opnd::new_imm(-7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adds x0, x1, #7"));
         assert_snapshot!(cb.string(), @"201c00b1");
     }
 
     #[test]
     fn test_subs_uimm() {
         let cb = compile(|cb| subs(cb, X0, X1, A64Opnd::new_uimm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: subs x0, x1, #7"));
         assert_snapshot!(cb.string(), @"201c00f1");
     }
 
     #[test]
     fn test_sxtw() {
         let cb = compile(|cb| sxtw(cb, X10, W11));
-        assert_snapshot!(cb.disasm(), @"  0x0: sxtw x10, w11");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sxtw x10, w11"));
         assert_snapshot!(cb.string(), @"6a7d4093");
     }
 
     #[test]
     fn test_tbnz() {
         let cb = compile(|cb| tbnz(cb, X10, A64Opnd::UImm(10), A64Opnd::Imm(2)));
-        assert_snapshot!(cb.disasm(), @"  0x0: tbnz w10, #0xa, #8");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tbnz w10, #0xa, #8"));
         assert_snapshot!(cb.string(), @"4a005037");
     }
 
     #[test]
     fn test_tbz() {
         let cb = compile(|cb| tbz(cb, X10, A64Opnd::UImm(10), A64Opnd::Imm(2)));
-        assert_snapshot!(cb.disasm(), @"  0x0: tbz w10, #0xa, #8");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tbz w10, #0xa, #8"));
         assert_snapshot!(cb.string(), @"4a005036");
     }
 
     #[test]
     fn test_tst_register() {
         let cb = compile(|cb| tst(cb, X0, X1));
-        assert_snapshot!(cb.disasm(), @"  0x0: tst x0, x1");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tst x0, x1"));
         assert_snapshot!(cb.string(), @"1f0001ea");
     }
 
     #[test]
     fn test_tst_immediate() {
         let cb = compile(|cb| tst(cb, X1, A64Opnd::new_uimm(7)));
-        assert_snapshot!(cb.disasm(), @"  0x0: tst x1, #7");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tst x1, #7"));
         assert_snapshot!(cb.string(), @"3f0840f2");
     }
 
     #[test]
     fn test_tst_32b_immediate() {
         let cb = compile(|cb| tst(cb, W0, A64Opnd::new_uimm(0xffff)));
-        assert_snapshot!(cb.disasm(), @"  0x0: tst w0, #0xffff");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tst w0, #0xffff"));
         assert_snapshot!(cb.string(), @"1f3c0072");
     }
 
@@ -1956,11 +1956,11 @@ mod tests {
         add_extended(&mut cb, X30, X30, X30);
         add_extended(&mut cb, X31, X31, X31);
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: add x10, x11, x9, uxtx
             0x4: add x30, x30, x30, uxtx
             0x8: add sp, sp, xzr
-        ");
+        "));
         assert_snapshot!(cb.string(), @"6a61298bde633e8bff633f8b");
     }
 }

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -282,17 +282,16 @@ impl CodeBlock {
         self.mem_block.borrow_mut().mark_all_executable();
     }
 
-    /// Return the disasm of generated code for testing
+    /// Call a func with the disasm of generated code for testing
+    #[allow(unused_variables)]
     #[cfg(test)]
-    pub fn disasm(&self) -> String {
+    pub fn with_disasm<T>(&self, func: T) where T: Fn(String) {
         #[cfg(feature = "disasm")]
         {
             let start_addr = self.get_ptr(0).raw_addr(self);
             let end_addr = self.get_write_ptr().raw_addr(self);
-            crate::disasm::disasm_addr_range(self, start_addr, end_addr)
+            func(crate::disasm::disasm_addr_range(self, start_addr, end_addr));
         }
-        #[cfg(not(feature = "disasm"))]
-        unreachable!("zjit-test should enable disasm feature")
     }
 
     /// Return the hex dump of generated code for testing

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -296,7 +296,7 @@ impl CodeBlock {
 
     /// Return the hex dump of generated code for testing
     #[cfg(test)]
-    pub fn string(&self) -> String {
+    pub fn hexdump(&self) -> String {
         format!("{:x}", self)
     }
 }

--- a/zjit/src/asm/x86_64/tests.rs
+++ b/zjit/src/asm/x86_64/tests.rs
@@ -53,22 +53,22 @@ fn test_add() {
     cb15.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add ecx, 8"));
     cb16.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add ecx, 0xff"));
 
-    assert_snapshot!(cb01.string(), @"80c103");
-    assert_snapshot!(cb02.string(), @"00d9");
-    assert_snapshot!(cb03.string(), @"4000e1");
-    assert_snapshot!(cb04.string(), @"6601d9");
-    assert_snapshot!(cb05.string(), @"4801d8");
-    assert_snapshot!(cb06.string(), @"01d1");
-    assert_snapshot!(cb07.string(), @"4c01f2");
-    assert_snapshot!(cb08.string(), @"480110");
-    assert_snapshot!(cb09.string(), @"480310");
-    assert_snapshot!(cb10.string(), @"48035008");
-    assert_snapshot!(cb11.string(), @"480390ff000000");
-    assert_snapshot!(cb12.string(), @"4881407fff000000");
-    assert_snapshot!(cb13.string(), @"0110");
-    assert_snapshot!(cb14.string(), @"4883c408");
-    assert_snapshot!(cb15.string(), @"83c108");
-    assert_snapshot!(cb16.string(), @"81c1ff000000");
+    assert_snapshot!(cb01.hexdump(), @"80c103");
+    assert_snapshot!(cb02.hexdump(), @"00d9");
+    assert_snapshot!(cb03.hexdump(), @"4000e1");
+    assert_snapshot!(cb04.hexdump(), @"6601d9");
+    assert_snapshot!(cb05.hexdump(), @"4801d8");
+    assert_snapshot!(cb06.hexdump(), @"01d1");
+    assert_snapshot!(cb07.hexdump(), @"4c01f2");
+    assert_snapshot!(cb08.hexdump(), @"480110");
+    assert_snapshot!(cb09.hexdump(), @"480310");
+    assert_snapshot!(cb10.hexdump(), @"48035008");
+    assert_snapshot!(cb11.hexdump(), @"480390ff000000");
+    assert_snapshot!(cb12.hexdump(), @"4881407fff000000");
+    assert_snapshot!(cb13.hexdump(), @"0110");
+    assert_snapshot!(cb14.hexdump(), @"4883c408");
+    assert_snapshot!(cb15.hexdump(), @"83c108");
+    assert_snapshot!(cb16.hexdump(), @"81c1ff000000");
 }
 
 #[test]
@@ -95,14 +95,14 @@ fn test_add_unsigned() {
     cb7.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8, 1"));
     cb8.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8, 0x7fffffff"));
 
-    assert_snapshot!(cb1.string(), @"4180c001");
-    assert_snapshot!(cb2.string(), @"4180c07f");
-    assert_snapshot!(cb3.string(), @"664183c001");
-    assert_snapshot!(cb4.string(), @"664181c0ff7f");
-    assert_snapshot!(cb5.string(), @"4183c001");
-    assert_snapshot!(cb6.string(), @"4181c0ffffff7f");
-    assert_snapshot!(cb7.string(), @"4983c001");
-    assert_snapshot!(cb8.string(), @"4981c0ffffff7f");
+    assert_snapshot!(cb1.hexdump(), @"4180c001");
+    assert_snapshot!(cb2.hexdump(), @"4180c07f");
+    assert_snapshot!(cb3.hexdump(), @"664183c001");
+    assert_snapshot!(cb4.hexdump(), @"664181c0ff7f");
+    assert_snapshot!(cb5.hexdump(), @"4183c001");
+    assert_snapshot!(cb6.hexdump(), @"4181c0ffffff7f");
+    assert_snapshot!(cb7.hexdump(), @"4983c001");
+    assert_snapshot!(cb8.hexdump(), @"4981c0ffffff7f");
 }
 
 #[test]
@@ -113,8 +113,8 @@ fn test_and() {
     cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and ebp, r12d"));
     cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and qword ptr [rax], 8"));
 
-    assert_snapshot!(cb1.string(), @"4421e5");
-    assert_snapshot!(cb2.string(), @"48832008");
+    assert_snapshot!(cb1.hexdump(), @"4421e5");
+    assert_snapshot!(cb2.hexdump(), @"48832008");
 }
 
 #[test]
@@ -125,7 +125,7 @@ fn test_call_label() {
         cb.link_labels();
     });
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: call 0"));
-    assert_snapshot!(cb.string(), @"e8fbffffff");
+    assert_snapshot!(cb.hexdump(), @"e8fbffffff");
 }
 
 #[test]
@@ -136,21 +136,21 @@ fn test_call_ptr() {
         call_ptr(cb, RAX, ptr.raw_ptr(cb));
     });
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: call 0"));
-    assert_snapshot!(cb.string(), @"e8fbffffff");
+    assert_snapshot!(cb.hexdump(), @"e8fbffffff");
 }
 
 #[test]
 fn test_call_reg() {
     let cb = compile(|cb| call(cb, RAX));
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: call rax"));
-    assert_snapshot!(cb.string(), @"ffd0");
+    assert_snapshot!(cb.hexdump(), @"ffd0");
 }
 
 #[test]
 fn test_call_mem() {
     let cb = compile(|cb| call(cb, mem_opnd(64, RSP, 8)));
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: call qword ptr [rsp + 8]"));
-    assert_snapshot!(cb.string(), @"ff542408");
+    assert_snapshot!(cb.hexdump(), @"ff542408");
 }
 
 #[test]
@@ -167,11 +167,11 @@ fn test_cmovcc() {
     cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmovl rbx, rbp"));
     cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmovle esi, dword ptr [rsp + 4]"));
 
-    assert_snapshot!(cb1.string(), @"0f4ff7");
-    assert_snapshot!(cb2.string(), @"0f4f750c");
-    assert_snapshot!(cb3.string(), @"0f4cc1");
-    assert_snapshot!(cb4.string(), @"480f4cdd");
-    assert_snapshot!(cb5.string(), @"0f4e742404");
+    assert_snapshot!(cb1.hexdump(), @"0f4ff7");
+    assert_snapshot!(cb2.hexdump(), @"0f4f750c");
+    assert_snapshot!(cb3.hexdump(), @"0f4cc1");
+    assert_snapshot!(cb4.hexdump(), @"480f4cdd");
+    assert_snapshot!(cb5.hexdump(), @"0f4e742404");
 }
 
 #[test]
@@ -188,18 +188,18 @@ fn test_cmp() {
     cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp rax, 2"));
     cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp ecx, 0x80000000"));
 
-    assert_snapshot!(cb1.string(), @"38d1");
-    assert_snapshot!(cb2.string(), @"39f9");
-    assert_snapshot!(cb3.string(), @"493b1424");
-    assert_snapshot!(cb4.string(), @"4883f802");
-    assert_snapshot!(cb5.string(), @"81f900000080");
+    assert_snapshot!(cb1.hexdump(), @"38d1");
+    assert_snapshot!(cb2.hexdump(), @"39f9");
+    assert_snapshot!(cb3.hexdump(), @"493b1424");
+    assert_snapshot!(cb4.hexdump(), @"4883f802");
+    assert_snapshot!(cb5.hexdump(), @"81f900000080");
 }
 
 #[test]
 fn test_cqo() {
     let cb = compile(cqo);
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cqo"));
-    assert_snapshot!(cb.string(), @"4899");
+    assert_snapshot!(cb.hexdump(), @"4899");
 }
 
 #[test]
@@ -213,9 +213,9 @@ fn test_imul() {
     cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: imul rdx, qword ptr [rax]"));
     cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: imul rdx, qword ptr [rax]"));
 
-    assert_snapshot!(cb1.string(), @"480fafc3");
-    assert_snapshot!(cb2.string(), @"480faf10");
-    assert_snapshot!(cb3.string(), @"480faf10");
+    assert_snapshot!(cb1.hexdump(), @"480fafc3");
+    assert_snapshot!(cb2.hexdump(), @"480faf10");
+    assert_snapshot!(cb3.hexdump(), @"480faf10");
 }
 
 #[test]
@@ -226,7 +226,7 @@ fn test_jge_label() {
         cb.link_labels();
     });
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jge 0"));
-    assert_snapshot!(cb.string(), @"0f8dfaffffff");
+    assert_snapshot!(cb.hexdump(), @"0f8dfaffffff");
 }
 
 #[test]
@@ -249,15 +249,15 @@ fn test_jmp_label() {
     cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jmp 5"));
     cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jmp 0"));
 
-    assert_snapshot!(cb1.string(), @"e900000000");
-    assert_snapshot!(cb2.string(), @"e9fbffffff");
+    assert_snapshot!(cb1.hexdump(), @"e900000000");
+    assert_snapshot!(cb2.hexdump(), @"e9fbffffff");
 }
 
 #[test]
 fn test_jmp_rm() {
     let cb = compile(|cb| jmp_rm(cb, R12));
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jmp r12"));
-    assert_snapshot!(cb.string(), @"41ffe4");
+    assert_snapshot!(cb.hexdump(), @"41ffe4");
 }
 
 #[test]
@@ -268,7 +268,7 @@ fn test_jo_label() {
         cb.link_labels();
     });
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jo 0"));
-    assert_snapshot!(cb.string(), @"0f80faffffff");
+    assert_snapshot!(cb.hexdump(), @"0f80faffffff");
 }
 
 #[test]
@@ -283,10 +283,10 @@ fn test_lea() {
     cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rax, [rip + 5]"));
     cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rdi, [rip + 5]"));
 
-    assert_snapshot!(cb1.string(), @"488d5108");
-    assert_snapshot!(cb2.string(), @"488d0500000000");
-    assert_snapshot!(cb3.string(), @"488d0505000000");
-    assert_snapshot!(cb4.string(), @"488d3d05000000");
+    assert_snapshot!(cb1.hexdump(), @"488d5108");
+    assert_snapshot!(cb2.hexdump(), @"488d0500000000");
+    assert_snapshot!(cb3.hexdump(), @"488d0505000000");
+    assert_snapshot!(cb4.hexdump(), @"488d3d05000000");
 }
 
 #[test]
@@ -347,32 +347,32 @@ fn test_mov() {
     cb25.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov qword ptr [r11], r10"));
     cb26.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov qword ptr [rdx - 8], 0xfffffffffffffff4"));
 
-    assert_snapshot!(cb01.string(), @"b807000000");
-    assert_snapshot!(cb02.string(), @"b8fdffffff");
-    assert_snapshot!(cb03.string(), @"41bf03000000");
-    assert_snapshot!(cb04.string(), @"89d8");
-    assert_snapshot!(cb05.string(), @"89c8");
-    assert_snapshot!(cb06.string(), @"8b9380000000");
-    assert_snapshot!(cb07.string(), @"488b442404");
-    assert_snapshot!(cb08.string(), @"41b834000000");
-    assert_snapshot!(cb09.string(), @"49b80000008000000000");
-    assert_snapshot!(cb10.string(), @"49b8ffffffffffffffff");
-    assert_snapshot!(cb11.string(), @"b834000000");
-    assert_snapshot!(cb12.string(), @"48b8020000000000c0ff");
-    assert_snapshot!(cb13.string(), @"48b80000008000000000");
-    assert_snapshot!(cb14.string(), @"48b8ccffffffffffffff");
-    assert_snapshot!(cb15.string(), @"48b8ffffffffffffffff");
-    assert_snapshot!(cb16.string(), @"4488c9");
-    assert_snapshot!(cb17.string(), @"4889c3");
-    assert_snapshot!(cb18.string(), @"4889df");
-    assert_snapshot!(cb19.string(), @"40b60b");
-    assert_snapshot!(cb20.string(), @"c60424fd");
-    assert_snapshot!(cb21.string(), @"48c7470801000000");
-    assert_snapshot!(cb22.string(), @"c7400411000000");
-    assert_snapshot!(cb23.string(), @"c7400401000080");
-    assert_snapshot!(cb24.string(), @"41895814");
-    assert_snapshot!(cb25.string(), @"4d8913");
-    assert_snapshot!(cb26.string(), @"48c742f8f4ffffff");
+    assert_snapshot!(cb01.hexdump(), @"b807000000");
+    assert_snapshot!(cb02.hexdump(), @"b8fdffffff");
+    assert_snapshot!(cb03.hexdump(), @"41bf03000000");
+    assert_snapshot!(cb04.hexdump(), @"89d8");
+    assert_snapshot!(cb05.hexdump(), @"89c8");
+    assert_snapshot!(cb06.hexdump(), @"8b9380000000");
+    assert_snapshot!(cb07.hexdump(), @"488b442404");
+    assert_snapshot!(cb08.hexdump(), @"41b834000000");
+    assert_snapshot!(cb09.hexdump(), @"49b80000008000000000");
+    assert_snapshot!(cb10.hexdump(), @"49b8ffffffffffffffff");
+    assert_snapshot!(cb11.hexdump(), @"b834000000");
+    assert_snapshot!(cb12.hexdump(), @"48b8020000000000c0ff");
+    assert_snapshot!(cb13.hexdump(), @"48b80000008000000000");
+    assert_snapshot!(cb14.hexdump(), @"48b8ccffffffffffffff");
+    assert_snapshot!(cb15.hexdump(), @"48b8ffffffffffffffff");
+    assert_snapshot!(cb16.hexdump(), @"4488c9");
+    assert_snapshot!(cb17.hexdump(), @"4889c3");
+    assert_snapshot!(cb18.hexdump(), @"4889df");
+    assert_snapshot!(cb19.hexdump(), @"40b60b");
+    assert_snapshot!(cb20.hexdump(), @"c60424fd");
+    assert_snapshot!(cb21.hexdump(), @"48c7470801000000");
+    assert_snapshot!(cb22.hexdump(), @"c7400411000000");
+    assert_snapshot!(cb23.hexdump(), @"c7400401000080");
+    assert_snapshot!(cb24.hexdump(), @"41895814");
+    assert_snapshot!(cb25.hexdump(), @"4d8913");
+    assert_snapshot!(cb26.hexdump(), @"48c742f8f4ffffff");
 }
 
 #[test]
@@ -383,8 +383,8 @@ fn test_movabs() {
     cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0x34"));
     cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0x80000000"));
 
-    assert_snapshot!(cb1.string(), @"49b83400000000000000");
-    assert_snapshot!(cb2.string(), @"49b80000008000000000");
+    assert_snapshot!(cb1.hexdump(), @"49b83400000000000000");
+    assert_snapshot!(cb2.hexdump(), @"49b80000008000000000");
 }
 
 #[test]
@@ -443,27 +443,27 @@ fn test_mov_unsigned() {
     cb20.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 1"));
     cb21.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0xffffffffffffffff"));
 
-    assert_snapshot!(cb01.string(), @"b001");
-    assert_snapshot!(cb02.string(), @"b0ff");
-    assert_snapshot!(cb03.string(), @"66b80100");
-    assert_snapshot!(cb04.string(), @"66b8ffff");
-    assert_snapshot!(cb05.string(), @"b801000000");
-    assert_snapshot!(cb06.string(), @"b8ffffffff");
-    assert_snapshot!(cb07.string(), @"41b800000000");
-    assert_snapshot!(cb08.string(), @"41b8ffffffff");
-    assert_snapshot!(cb09.string(), @"b801000000");
-    assert_snapshot!(cb10.string(), @"b8ffffffff");
-    assert_snapshot!(cb11.string(), @"48b80000000001000000");
-    assert_snapshot!(cb12.string(), @"48b8ffffffffffffffff");
-    assert_snapshot!(cb13.string(), @"49b8ffffffffffffffff");
-    assert_snapshot!(cb14.string(), @"41b001");
-    assert_snapshot!(cb15.string(), @"41b0ff");
-    assert_snapshot!(cb16.string(), @"6641b80100");
-    assert_snapshot!(cb17.string(), @"6641b8ffff");
-    assert_snapshot!(cb18.string(), @"41b801000000");
-    assert_snapshot!(cb19.string(), @"41b8ffffffff");
-    assert_snapshot!(cb20.string(), @"41b801000000");
-    assert_snapshot!(cb21.string(), @"49b8ffffffffffffffff");
+    assert_snapshot!(cb01.hexdump(), @"b001");
+    assert_snapshot!(cb02.hexdump(), @"b0ff");
+    assert_snapshot!(cb03.hexdump(), @"66b80100");
+    assert_snapshot!(cb04.hexdump(), @"66b8ffff");
+    assert_snapshot!(cb05.hexdump(), @"b801000000");
+    assert_snapshot!(cb06.hexdump(), @"b8ffffffff");
+    assert_snapshot!(cb07.hexdump(), @"41b800000000");
+    assert_snapshot!(cb08.hexdump(), @"41b8ffffffff");
+    assert_snapshot!(cb09.hexdump(), @"b801000000");
+    assert_snapshot!(cb10.hexdump(), @"b8ffffffff");
+    assert_snapshot!(cb11.hexdump(), @"48b80000000001000000");
+    assert_snapshot!(cb12.hexdump(), @"48b8ffffffffffffffff");
+    assert_snapshot!(cb13.hexdump(), @"49b8ffffffffffffffff");
+    assert_snapshot!(cb14.hexdump(), @"41b001");
+    assert_snapshot!(cb15.hexdump(), @"41b0ff");
+    assert_snapshot!(cb16.hexdump(), @"6641b80100");
+    assert_snapshot!(cb17.hexdump(), @"6641b8ffff");
+    assert_snapshot!(cb18.hexdump(), @"41b801000000");
+    assert_snapshot!(cb19.hexdump(), @"41b8ffffffff");
+    assert_snapshot!(cb20.hexdump(), @"41b801000000");
+    assert_snapshot!(cb21.hexdump(), @"49b8ffffffffffffffff");
 }
 
 #[test]
@@ -480,11 +480,11 @@ fn test_mov_iprel() {
     cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rax, qword ptr [rip + 5]"));
     cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rdi, qword ptr [rip + 5]"));
 
-    assert_snapshot!(cb1.string(), @"8b0500000000");
-    assert_snapshot!(cb2.string(), @"8b0505000000");
-    assert_snapshot!(cb3.string(), @"488b0500000000");
-    assert_snapshot!(cb4.string(), @"488b0505000000");
-    assert_snapshot!(cb5.string(), @"488b3d05000000");
+    assert_snapshot!(cb1.hexdump(), @"8b0500000000");
+    assert_snapshot!(cb2.hexdump(), @"8b0505000000");
+    assert_snapshot!(cb3.hexdump(), @"488b0500000000");
+    assert_snapshot!(cb4.hexdump(), @"488b0505000000");
+    assert_snapshot!(cb5.hexdump(), @"488b3d05000000");
 }
 
 #[test]
@@ -507,14 +507,14 @@ fn test_movsx() {
     cb7.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx rax, byte ptr [rsp]"));
     cb8.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx rdx, word ptr [r13 + 4]"));
 
-    assert_snapshot!(cb1.string(), @"660fbec0");
-    assert_snapshot!(cb2.string(), @"0fbed0");
-    assert_snapshot!(cb3.string(), @"480fbec3");
-    assert_snapshot!(cb4.string(), @"0fbfc8");
-    assert_snapshot!(cb5.string(), @"4c0fbed9");
-    assert_snapshot!(cb6.string(), @"4c6354240c");
-    assert_snapshot!(cb7.string(), @"480fbe0424");
-    assert_snapshot!(cb8.string(), @"490fbf5504");
+    assert_snapshot!(cb1.hexdump(), @"660fbec0");
+    assert_snapshot!(cb2.hexdump(), @"0fbed0");
+    assert_snapshot!(cb3.hexdump(), @"480fbec3");
+    assert_snapshot!(cb4.hexdump(), @"0fbfc8");
+    assert_snapshot!(cb5.hexdump(), @"4c0fbed9");
+    assert_snapshot!(cb6.hexdump(), @"4c6354240c");
+    assert_snapshot!(cb7.hexdump(), @"480fbe0424");
+    assert_snapshot!(cb8.hexdump(), @"490fbf5504");
 }
 
 #[test]
@@ -554,18 +554,18 @@ fn test_nop() {
     0x9: nop dword ptr [rax]
     "));
 
-    assert_snapshot!(cb01.string(), @"90");
-    assert_snapshot!(cb02.string(), @"6690");
-    assert_snapshot!(cb03.string(), @"0f1f00");
-    assert_snapshot!(cb04.string(), @"0f1f4000");
-    assert_snapshot!(cb05.string(), @"0f1f440000");
-    assert_snapshot!(cb06.string(), @"660f1f440000");
-    assert_snapshot!(cb07.string(), @"0f1f8000000000");
-    assert_snapshot!(cb08.string(), @"0f1f840000000000");
-    assert_snapshot!(cb09.string(), @"660f1f840000000000");
-    assert_snapshot!(cb10.string(), @"660f1f84000000000090");
-    assert_snapshot!(cb11.string(), @"660f1f8400000000006690");
-    assert_snapshot!(cb12.string(), @"660f1f8400000000000f1f00");
+    assert_snapshot!(cb01.hexdump(), @"90");
+    assert_snapshot!(cb02.hexdump(), @"6690");
+    assert_snapshot!(cb03.hexdump(), @"0f1f00");
+    assert_snapshot!(cb04.hexdump(), @"0f1f4000");
+    assert_snapshot!(cb05.hexdump(), @"0f1f440000");
+    assert_snapshot!(cb06.hexdump(), @"660f1f440000");
+    assert_snapshot!(cb07.hexdump(), @"0f1f8000000000");
+    assert_snapshot!(cb08.hexdump(), @"0f1f840000000000");
+    assert_snapshot!(cb09.hexdump(), @"660f1f840000000000");
+    assert_snapshot!(cb10.hexdump(), @"660f1f84000000000090");
+    assert_snapshot!(cb11.hexdump(), @"660f1f8400000000006690");
+    assert_snapshot!(cb12.hexdump(), @"660f1f8400000000000f1f00");
 }
 
 #[test]
@@ -606,30 +606,30 @@ fn test_not() {
     cb16.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rdx - 0x37]"));
     cb17.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rdx - 0x22b]"));
 
-    assert_snapshot!(cb01.string(), @"66f7d0");
-    assert_snapshot!(cb02.string(), @"f7d0");
-    assert_snapshot!(cb03.string(), @"49f71424");
-    assert_snapshot!(cb04.string(), @"f794242d010000");
-    assert_snapshot!(cb05.string(), @"f71424");
-    assert_snapshot!(cb06.string(), @"f7542403");
-    assert_snapshot!(cb07.string(), @"f75500");
-    assert_snapshot!(cb08.string(), @"f7550d");
-    assert_snapshot!(cb09.string(), @"48f7d0");
-    assert_snapshot!(cb10.string(), @"49f7d3");
-    assert_snapshot!(cb11.string(), @"f710");
-    assert_snapshot!(cb12.string(), @"f716");
-    assert_snapshot!(cb13.string(), @"f717");
-    assert_snapshot!(cb14.string(), @"f75237");
-    assert_snapshot!(cb15.string(), @"f79239050000");
-    assert_snapshot!(cb16.string(), @"f752c9");
-    assert_snapshot!(cb17.string(), @"f792d5fdffff");
+    assert_snapshot!(cb01.hexdump(), @"66f7d0");
+    assert_snapshot!(cb02.hexdump(), @"f7d0");
+    assert_snapshot!(cb03.hexdump(), @"49f71424");
+    assert_snapshot!(cb04.hexdump(), @"f794242d010000");
+    assert_snapshot!(cb05.hexdump(), @"f71424");
+    assert_snapshot!(cb06.hexdump(), @"f7542403");
+    assert_snapshot!(cb07.hexdump(), @"f75500");
+    assert_snapshot!(cb08.hexdump(), @"f7550d");
+    assert_snapshot!(cb09.hexdump(), @"48f7d0");
+    assert_snapshot!(cb10.hexdump(), @"49f7d3");
+    assert_snapshot!(cb11.hexdump(), @"f710");
+    assert_snapshot!(cb12.hexdump(), @"f716");
+    assert_snapshot!(cb13.hexdump(), @"f717");
+    assert_snapshot!(cb14.hexdump(), @"f75237");
+    assert_snapshot!(cb15.hexdump(), @"f79239050000");
+    assert_snapshot!(cb16.hexdump(), @"f752c9");
+    assert_snapshot!(cb17.hexdump(), @"f792d5fdffff");
 }
 
 #[test]
 fn test_or() {
     let cb = compile(|cb| or(cb, EDX, ESI));
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: or edx, esi"));
-    assert_snapshot!(cb.string(), @"09f2");
+    assert_snapshot!(cb.hexdump(), @"09f2");
 }
 
 #[test]
@@ -656,16 +656,16 @@ fn test_pop() {
     cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop qword ptr [rax + rcx*8 + 3]"));
     cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop qword ptr [r8 + rcx*8 + 3]"));
 
-    assert_snapshot!(cb01.string(), @"58");
-    assert_snapshot!(cb02.string(), @"5b");
-    assert_snapshot!(cb03.string(), @"5c");
-    assert_snapshot!(cb04.string(), @"5d");
-    assert_snapshot!(cb05.string(), @"415c");
-    assert_snapshot!(cb06.string(), @"8f00");
-    assert_snapshot!(cb07.string(), @"418f00");
-    assert_snapshot!(cb08.string(), @"418f4003");
-    assert_snapshot!(cb09.string(), @"8f44c803");
-    assert_snapshot!(cb10.string(), @"418f44c803");
+    assert_snapshot!(cb01.hexdump(), @"58");
+    assert_snapshot!(cb02.hexdump(), @"5b");
+    assert_snapshot!(cb03.hexdump(), @"5c");
+    assert_snapshot!(cb04.hexdump(), @"5d");
+    assert_snapshot!(cb05.hexdump(), @"415c");
+    assert_snapshot!(cb06.hexdump(), @"8f00");
+    assert_snapshot!(cb07.hexdump(), @"418f00");
+    assert_snapshot!(cb08.hexdump(), @"418f4003");
+    assert_snapshot!(cb09.hexdump(), @"8f44c803");
+    assert_snapshot!(cb10.hexdump(), @"418f44c803");
 }
 
 #[test]
@@ -688,21 +688,21 @@ fn test_push() {
     cb7.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push qword ptr [rax + rcx*8 + 3]"));
     cb8.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push qword ptr [r8 + rcx*8 + 3]"));
 
-    assert_snapshot!(cb1.string(), @"50");
-    assert_snapshot!(cb2.string(), @"53");
-    assert_snapshot!(cb3.string(), @"4154");
-    assert_snapshot!(cb4.string(), @"ff30");
-    assert_snapshot!(cb5.string(), @"41ff30");
-    assert_snapshot!(cb6.string(), @"41ff7003");
-    assert_snapshot!(cb7.string(), @"ff74c803");
-    assert_snapshot!(cb8.string(), @"41ff74c803");
+    assert_snapshot!(cb1.hexdump(), @"50");
+    assert_snapshot!(cb2.hexdump(), @"53");
+    assert_snapshot!(cb3.hexdump(), @"4154");
+    assert_snapshot!(cb4.hexdump(), @"ff30");
+    assert_snapshot!(cb5.hexdump(), @"41ff30");
+    assert_snapshot!(cb6.hexdump(), @"41ff7003");
+    assert_snapshot!(cb7.hexdump(), @"ff74c803");
+    assert_snapshot!(cb8.hexdump(), @"41ff74c803");
 }
 
 #[test]
 fn test_ret() {
     let cb = compile(ret);
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ret"));
-    assert_snapshot!(cb.string(), @"c3");
+    assert_snapshot!(cb.hexdump(), @"c3");
 }
 
 #[test]
@@ -719,25 +719,25 @@ fn test_sal() {
     cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shl dword ptr [rsp + 0x44], 1"));
     cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shl rcx, cl"));
 
-    assert_snapshot!(cb1.string(), @"66d1e1");
-    assert_snapshot!(cb2.string(), @"d1e1");
-    assert_snapshot!(cb3.string(), @"c1e505");
-    assert_snapshot!(cb4.string(), @"d1642444");
-    assert_snapshot!(cb5.string(), @"48d3e1");
+    assert_snapshot!(cb1.hexdump(), @"66d1e1");
+    assert_snapshot!(cb2.hexdump(), @"d1e1");
+    assert_snapshot!(cb3.hexdump(), @"c1e505");
+    assert_snapshot!(cb4.hexdump(), @"d1642444");
+    assert_snapshot!(cb5.hexdump(), @"48d3e1");
 }
 
 #[test]
 fn test_sar() {
     let cb = compile(|cb| sar(cb, EDX, uimm_opnd(1)));
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sar edx, 1"));
-    assert_snapshot!(cb.string(), @"d1fa");
+    assert_snapshot!(cb.hexdump(), @"d1fa");
 }
 
 #[test]
 fn test_shr() {
     let cb = compile(|cb| shr(cb, R14, uimm_opnd(7)));
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shr r14, 7"));
-    assert_snapshot!(cb.string(), @"49c1ee07");
+    assert_snapshot!(cb.hexdump(), @"49c1ee07");
 }
 
 #[test]
@@ -748,8 +748,8 @@ fn test_sub() {
     cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub eax, 1"));
     cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub rax, 2"));
 
-    assert_snapshot!(cb1.string(), @"83e801");
-    assert_snapshot!(cb2.string(), @"4883e802");
+    assert_snapshot!(cb1.hexdump(), @"83e801");
+    assert_snapshot!(cb2.hexdump(), @"4883e802");
 }
 
 #[test]
@@ -802,25 +802,25 @@ fn test_test() {
     cb18.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test qword ptr [rsi + 0x40], 8"));
     cb19.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test rcx, 8"));
 
-    assert_snapshot!(cb01.string(), @"84c0");
-    assert_snapshot!(cb02.string(), @"6685c0");
-    assert_snapshot!(cb03.string(), @"f6c108");
-    assert_snapshot!(cb04.string(), @"f6c207");
-    assert_snapshot!(cb05.string(), @"f6c108");
-    assert_snapshot!(cb06.string(), @"f6420808");
-    assert_snapshot!(cb07.string(), @"f64208ff");
-    assert_snapshot!(cb08.string(), @"66f7c2ffff");
-    assert_snapshot!(cb09.string(), @"66f74208ffff");
-    assert_snapshot!(cb10.string(), @"f60601");
-    assert_snapshot!(cb11.string(), @"f6461001");
-    assert_snapshot!(cb12.string(), @"f646f001");
-    assert_snapshot!(cb13.string(), @"854640");
-    assert_snapshot!(cb14.string(), @"4885472a");
-    assert_snapshot!(cb15.string(), @"4885c0");
-    assert_snapshot!(cb16.string(), @"4885f0");
-    assert_snapshot!(cb17.string(), @"48f74640f7ffffff");
-    assert_snapshot!(cb18.string(), @"48f7464008000000");
-    assert_snapshot!(cb19.string(), @"48f7c108000000");
+    assert_snapshot!(cb01.hexdump(), @"84c0");
+    assert_snapshot!(cb02.hexdump(), @"6685c0");
+    assert_snapshot!(cb03.hexdump(), @"f6c108");
+    assert_snapshot!(cb04.hexdump(), @"f6c207");
+    assert_snapshot!(cb05.hexdump(), @"f6c108");
+    assert_snapshot!(cb06.hexdump(), @"f6420808");
+    assert_snapshot!(cb07.hexdump(), @"f64208ff");
+    assert_snapshot!(cb08.hexdump(), @"66f7c2ffff");
+    assert_snapshot!(cb09.hexdump(), @"66f74208ffff");
+    assert_snapshot!(cb10.hexdump(), @"f60601");
+    assert_snapshot!(cb11.hexdump(), @"f6461001");
+    assert_snapshot!(cb12.hexdump(), @"f646f001");
+    assert_snapshot!(cb13.hexdump(), @"854640");
+    assert_snapshot!(cb14.hexdump(), @"4885472a");
+    assert_snapshot!(cb15.hexdump(), @"4885c0");
+    assert_snapshot!(cb16.hexdump(), @"4885f0");
+    assert_snapshot!(cb17.hexdump(), @"48f74640f7ffffff");
+    assert_snapshot!(cb18.hexdump(), @"48f7464008000000");
+    assert_snapshot!(cb19.hexdump(), @"48f7c108000000");
 }
 
 #[test]
@@ -835,17 +835,17 @@ fn test_xchg() {
     cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xchg rcx, rbx"));
     cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xchg r9, r15"));
 
-    assert_snapshot!(cb1.string(), @"4891");
-    assert_snapshot!(cb2.string(), @"4995");
-    assert_snapshot!(cb3.string(), @"4887d9");
-    assert_snapshot!(cb4.string(), @"4d87f9");
+    assert_snapshot!(cb1.hexdump(), @"4891");
+    assert_snapshot!(cb2.hexdump(), @"4995");
+    assert_snapshot!(cb3.hexdump(), @"4887d9");
+    assert_snapshot!(cb4.hexdump(), @"4d87f9");
 }
 
 #[test]
 fn test_xor() {
     let cb = compile(|cb| xor(cb, EAX, EAX));
     cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xor eax, eax"));
-    assert_snapshot!(cb.string(), @"31c0");
+    assert_snapshot!(cb.hexdump(), @"31c0");
 }
 
 #[test]

--- a/zjit/src/asm/x86_64/tests.rs
+++ b/zjit/src/asm/x86_64/tests.rs
@@ -36,22 +36,22 @@ fn test_add() {
     let cb15 = compile(|cb| add(cb, ECX, imm_opnd(8)));
     let cb16 = compile(|cb| add(cb, ECX, imm_opnd(255)));
 
-    assert_snapshot!(cb01.disasm(), @"  0x0: add cl, 3");
-    assert_snapshot!(cb02.disasm(), @"  0x0: add cl, bl");
-    assert_snapshot!(cb03.disasm(), @"  0x0: add cl, spl");
-    assert_snapshot!(cb04.disasm(), @"  0x0: add cx, bx");
-    assert_snapshot!(cb05.disasm(), @"  0x0: add rax, rbx");
-    assert_snapshot!(cb06.disasm(), @"  0x0: add ecx, edx");
-    assert_snapshot!(cb07.disasm(), @"  0x0: add rdx, r14");
-    assert_snapshot!(cb08.disasm(), @"  0x0: add qword ptr [rax], rdx");
-    assert_snapshot!(cb09.disasm(), @"  0x0: add rdx, qword ptr [rax]");
-    assert_snapshot!(cb10.disasm(), @"  0x0: add rdx, qword ptr [rax + 8]");
-    assert_snapshot!(cb11.disasm(), @"  0x0: add rdx, qword ptr [rax + 0xff]");
-    assert_snapshot!(cb12.disasm(), @"  0x0: add qword ptr [rax + 0x7f], 0xff");
-    assert_snapshot!(cb13.disasm(), @"  0x0: add dword ptr [rax], edx");
-    assert_snapshot!(cb14.disasm(), @"  0x0: add rsp, 8");
-    assert_snapshot!(cb15.disasm(), @"  0x0: add ecx, 8");
-    assert_snapshot!(cb16.disasm(), @"  0x0: add ecx, 0xff");
+    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add cl, 3"));
+    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add cl, bl"));
+    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add cl, spl"));
+    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add cx, bx"));
+    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add rax, rbx"));
+    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add ecx, edx"));
+    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add rdx, r14"));
+    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add qword ptr [rax], rdx"));
+    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add rdx, qword ptr [rax]"));
+    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add rdx, qword ptr [rax + 8]"));
+    cb11.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add rdx, qword ptr [rax + 0xff]"));
+    cb12.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add qword ptr [rax + 0x7f], 0xff"));
+    cb13.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add dword ptr [rax], edx"));
+    cb14.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add rsp, 8"));
+    cb15.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add ecx, 8"));
+    cb16.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add ecx, 0xff"));
 
     assert_snapshot!(cb01.string(), @"80c103");
     assert_snapshot!(cb02.string(), @"00d9");
@@ -86,14 +86,14 @@ fn test_add_unsigned() {
     let cb7 = compile(|cb| add(cb, R8, uimm_opnd(1)));
     let cb8 = compile(|cb| add(cb, R8, uimm_opnd(i32::MAX.try_into().unwrap())));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: add r8b, 1");
-    assert_snapshot!(cb2.disasm(), @"  0x0: add r8b, 0x7f");
-    assert_snapshot!(cb3.disasm(), @"  0x0: add r8w, 1");
-    assert_snapshot!(cb4.disasm(), @"  0x0: add r8w, 0x7fff");
-    assert_snapshot!(cb5.disasm(), @"  0x0: add r8d, 1");
-    assert_snapshot!(cb6.disasm(), @"  0x0: add r8d, 0x7fffffff");
-    assert_snapshot!(cb7.disasm(), @"  0x0: add r8, 1");
-    assert_snapshot!(cb8.disasm(), @"  0x0: add r8, 0x7fffffff");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8b, 1"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8b, 0x7f"));
+    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8w, 1"));
+    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8w, 0x7fff"));
+    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8d, 1"));
+    cb6.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8d, 0x7fffffff"));
+    cb7.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8, 1"));
+    cb8.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8, 0x7fffffff"));
 
     assert_snapshot!(cb1.string(), @"4180c001");
     assert_snapshot!(cb2.string(), @"4180c07f");
@@ -110,8 +110,8 @@ fn test_and() {
     let cb1 = compile(|cb| and(cb, EBP, R12D));
     let cb2 = compile(|cb| and(cb, mem_opnd(64, RAX, 0), imm_opnd(0x08)));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: and ebp, r12d");
-    assert_snapshot!(cb2.disasm(), @"  0x0: and qword ptr [rax], 8");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and ebp, r12d"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and qword ptr [rax], 8"));
 
     assert_snapshot!(cb1.string(), @"4421e5");
     assert_snapshot!(cb2.string(), @"48832008");
@@ -124,7 +124,7 @@ fn test_call_label() {
         call_label(cb, label_idx);
         cb.link_labels();
     });
-    assert_snapshot!(cb.disasm(), @"  0x0: call 0");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: call 0"));
     assert_snapshot!(cb.string(), @"e8fbffffff");
 }
 
@@ -135,21 +135,21 @@ fn test_call_ptr() {
         let ptr = cb.get_write_ptr();
         call_ptr(cb, RAX, ptr.raw_ptr(cb));
     });
-    assert_snapshot!(cb.disasm(), @"  0x0: call 0");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: call 0"));
     assert_snapshot!(cb.string(), @"e8fbffffff");
 }
 
 #[test]
 fn test_call_reg() {
     let cb = compile(|cb| call(cb, RAX));
-    assert_snapshot!(cb.disasm(), @"  0x0: call rax");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: call rax"));
     assert_snapshot!(cb.string(), @"ffd0");
 }
 
 #[test]
 fn test_call_mem() {
     let cb = compile(|cb| call(cb, mem_opnd(64, RSP, 8)));
-    assert_snapshot!(cb.disasm(), @"  0x0: call qword ptr [rsp + 8]");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: call qword ptr [rsp + 8]"));
     assert_snapshot!(cb.string(), @"ff542408");
 }
 
@@ -161,11 +161,11 @@ fn test_cmovcc() {
     let cb4 = compile(|cb| cmovl(cb, RBX, RBP));
     let cb5 = compile(|cb| cmovle(cb, ESI, mem_opnd(32, RSP, 4)));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: cmovg esi, edi");
-    assert_snapshot!(cb2.disasm(), @"  0x0: cmovg esi, dword ptr [rbp + 0xc]");
-    assert_snapshot!(cb3.disasm(), @"  0x0: cmovl eax, ecx");
-    assert_snapshot!(cb4.disasm(), @"  0x0: cmovl rbx, rbp");
-    assert_snapshot!(cb5.disasm(), @"  0x0: cmovle esi, dword ptr [rsp + 4]");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmovg esi, edi"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmovg esi, dword ptr [rbp + 0xc]"));
+    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmovl eax, ecx"));
+    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmovl rbx, rbp"));
+    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmovle esi, dword ptr [rsp + 4]"));
 
     assert_snapshot!(cb1.string(), @"0f4ff7");
     assert_snapshot!(cb2.string(), @"0f4f750c");
@@ -182,11 +182,11 @@ fn test_cmp() {
     let cb4 = compile(|cb| cmp(cb, RAX, imm_opnd(2)));
     let cb5 = compile(|cb| cmp(cb, ECX, uimm_opnd(0x8000_0000)));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: cmp cl, dl");
-    assert_snapshot!(cb2.disasm(), @"  0x0: cmp ecx, edi");
-    assert_snapshot!(cb3.disasm(), @"  0x0: cmp rdx, qword ptr [r12]");
-    assert_snapshot!(cb4.disasm(), @"  0x0: cmp rax, 2");
-    assert_snapshot!(cb5.disasm(), @"  0x0: cmp ecx, 0x80000000");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp cl, dl"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp ecx, edi"));
+    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp rdx, qword ptr [r12]"));
+    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp rax, 2"));
+    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp ecx, 0x80000000"));
 
     assert_snapshot!(cb1.string(), @"38d1");
     assert_snapshot!(cb2.string(), @"39f9");
@@ -198,7 +198,7 @@ fn test_cmp() {
 #[test]
 fn test_cqo() {
     let cb = compile(cqo);
-    assert_snapshot!(cb.disasm(), @"  0x0: cqo");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cqo"));
     assert_snapshot!(cb.string(), @"4899");
 }
 
@@ -209,9 +209,9 @@ fn test_imul() {
     // Operands flipped for encoding since multiplication is commutative
     let cb3 = compile(|cb| imul(cb, mem_opnd(64, RAX, 0), RDX));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: imul rax, rbx");
-    assert_snapshot!(cb2.disasm(), @"  0x0: imul rdx, qword ptr [rax]");
-    assert_snapshot!(cb3.disasm(), @"  0x0: imul rdx, qword ptr [rax]");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: imul rax, rbx"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: imul rdx, qword ptr [rax]"));
+    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: imul rdx, qword ptr [rax]"));
 
     assert_snapshot!(cb1.string(), @"480fafc3");
     assert_snapshot!(cb2.string(), @"480faf10");
@@ -225,7 +225,7 @@ fn test_jge_label() {
         jge_label(cb, label_idx);
         cb.link_labels();
     });
-    assert_snapshot!(cb.disasm(), @"  0x0: jge 0");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jge 0"));
     assert_snapshot!(cb.string(), @"0f8dfaffffff");
 }
 
@@ -246,8 +246,8 @@ fn test_jmp_label() {
         cb.link_labels();
     });
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: jmp 5");
-    assert_snapshot!(cb2.disasm(), @"  0x0: jmp 0");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jmp 5"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jmp 0"));
 
     assert_snapshot!(cb1.string(), @"e900000000");
     assert_snapshot!(cb2.string(), @"e9fbffffff");
@@ -256,7 +256,7 @@ fn test_jmp_label() {
 #[test]
 fn test_jmp_rm() {
     let cb = compile(|cb| jmp_rm(cb, R12));
-    assert_snapshot!(cb.disasm(), @"  0x0: jmp r12");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jmp r12"));
     assert_snapshot!(cb.string(), @"41ffe4");
 }
 
@@ -267,7 +267,7 @@ fn test_jo_label() {
         jo_label(cb, label_idx);
         cb.link_labels();
     });
-    assert_snapshot!(cb.disasm(), @"  0x0: jo 0");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jo 0"));
     assert_snapshot!(cb.string(), @"0f80faffffff");
 }
 
@@ -278,10 +278,10 @@ fn test_lea() {
     let cb3 = compile(|cb| lea(cb, RAX, mem_opnd(8, RIP, 5)));
     let cb4 = compile(|cb| lea(cb, RDI, mem_opnd(8, RIP, 5)));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: lea rdx, [rcx + 8]");
-    assert_snapshot!(cb2.disasm(), @"  0x0: lea rax, [rip]");
-    assert_snapshot!(cb3.disasm(), @"  0x0: lea rax, [rip + 5]");
-    assert_snapshot!(cb4.disasm(), @"  0x0: lea rdi, [rip + 5]");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rdx, [rcx + 8]"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rax, [rip]"));
+    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rax, [rip + 5]"));
+    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rdi, [rip + 5]"));
 
     assert_snapshot!(cb1.string(), @"488d5108");
     assert_snapshot!(cb2.string(), @"488d0500000000");
@@ -320,32 +320,32 @@ fn test_mov() {
     let cb25 = compile(|cb| mov(cb, mem_opnd(64, R11, 0), R10));
     let cb26 = compile(|cb| mov(cb, mem_opnd(64, RDX, -8), imm_opnd(-12)));
 
-    assert_snapshot!(cb01.disasm(), @"  0x0: mov eax, 7");
-    assert_snapshot!(cb02.disasm(), @"  0x0: mov eax, 0xfffffffd");
-    assert_snapshot!(cb03.disasm(), @"  0x0: mov r15d, 3");
-    assert_snapshot!(cb04.disasm(), @"  0x0: mov eax, ebx");
-    assert_snapshot!(cb05.disasm(), @"  0x0: mov eax, ecx");
-    assert_snapshot!(cb06.disasm(), @"  0x0: mov edx, dword ptr [rbx + 0x80]");
-    assert_snapshot!(cb07.disasm(), @"  0x0: mov rax, qword ptr [rsp + 4]");
-    assert_snapshot!(cb08.disasm(), @"  0x0: mov r8d, 0x34");
-    assert_snapshot!(cb09.disasm(), @"  0x0: movabs r8, 0x80000000");
-    assert_snapshot!(cb10.disasm(), @"  0x0: movabs r8, 0xffffffffffffffff");
-    assert_snapshot!(cb11.disasm(), @"  0x0: mov eax, 0x34");
-    assert_snapshot!(cb12.disasm(), @"  0x0: movabs rax, 0xffc0000000000002");
-    assert_snapshot!(cb13.disasm(), @"  0x0: movabs rax, 0x80000000");
-    assert_snapshot!(cb14.disasm(), @"  0x0: movabs rax, 0xffffffffffffffcc");
-    assert_snapshot!(cb15.disasm(), @"  0x0: movabs rax, 0xffffffffffffffff");
-    assert_snapshot!(cb16.disasm(), @"  0x0: mov cl, r9b");
-    assert_snapshot!(cb17.disasm(), @"  0x0: mov rbx, rax");
-    assert_snapshot!(cb18.disasm(), @"  0x0: mov rdi, rbx");
-    assert_snapshot!(cb19.disasm(), @"  0x0: mov sil, 0xb");
-    assert_snapshot!(cb20.disasm(), @"  0x0: mov byte ptr [rsp], 0xfd");
-    assert_snapshot!(cb21.disasm(), @"  0x0: mov qword ptr [rdi + 8], 1");
-    assert_snapshot!(cb22.disasm(), @"  0x0: mov dword ptr [rax + 4], 0x11");
-    assert_snapshot!(cb23.disasm(), @"  0x0: mov dword ptr [rax + 4], 0x80000001");
-    assert_snapshot!(cb24.disasm(), @"  0x0: mov dword ptr [r8 + 0x14], ebx");
-    assert_snapshot!(cb25.disasm(), @"  0x0: mov qword ptr [r11], r10");
-    assert_snapshot!(cb26.disasm(), @"  0x0: mov qword ptr [rdx - 8], 0xfffffffffffffff4");
+    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 7"));
+    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 0xfffffffd"));
+    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r15d, 3"));
+    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, ebx"));
+    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, ecx"));
+    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov edx, dword ptr [rbx + 0x80]"));
+    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rax, qword ptr [rsp + 4]"));
+    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 0x34"));
+    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0x80000000"));
+    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0xffffffffffffffff"));
+    cb11.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 0x34"));
+    cb12.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs rax, 0xffc0000000000002"));
+    cb13.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs rax, 0x80000000"));
+    cb14.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs rax, 0xffffffffffffffcc"));
+    cb15.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs rax, 0xffffffffffffffff"));
+    cb16.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov cl, r9b"));
+    cb17.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rbx, rax"));
+    cb18.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rdi, rbx"));
+    cb19.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov sil, 0xb"));
+    cb20.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov byte ptr [rsp], 0xfd"));
+    cb21.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov qword ptr [rdi + 8], 1"));
+    cb22.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov dword ptr [rax + 4], 0x11"));
+    cb23.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov dword ptr [rax + 4], 0x80000001"));
+    cb24.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov dword ptr [r8 + 0x14], ebx"));
+    cb25.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov qword ptr [r11], r10"));
+    cb26.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov qword ptr [rdx - 8], 0xfffffffffffffff4"));
 
     assert_snapshot!(cb01.string(), @"b807000000");
     assert_snapshot!(cb02.string(), @"b8fdffffff");
@@ -380,8 +380,8 @@ fn test_movabs() {
     let cb1 = compile(|cb| movabs(cb, R8, 0x34));
     let cb2 = compile(|cb| movabs(cb, R8, 0x80000000));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: movabs r8, 0x34");
-    assert_snapshot!(cb2.disasm(), @"  0x0: movabs r8, 0x80000000");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0x34"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0x80000000"));
 
     assert_snapshot!(cb1.string(), @"49b83400000000000000");
     assert_snapshot!(cb2.string(), @"49b80000008000000000");
@@ -421,27 +421,27 @@ fn test_mov_unsigned() {
     // MOV r64, imm64, will not move down into 32 bit since it does not fit into 32 bits
     let cb21 = compile(|cb| mov(cb, R8, uimm_opnd(u64::MAX)));
 
-    assert_snapshot!(cb01.disasm(), @"  0x0: mov al, 1");
-    assert_snapshot!(cb02.disasm(), @"  0x0: mov al, 0xff");
-    assert_snapshot!(cb03.disasm(), @"  0x0: mov ax, 1");
-    assert_snapshot!(cb04.disasm(), @"  0x0: mov ax, 0xffff");
-    assert_snapshot!(cb05.disasm(), @"  0x0: mov eax, 1");
-    assert_snapshot!(cb06.disasm(), @"  0x0: mov eax, 0xffffffff");
-    assert_snapshot!(cb07.disasm(), @"  0x0: mov r8d, 0");
-    assert_snapshot!(cb08.disasm(), @"  0x0: mov r8d, 0xffffffff");
-    assert_snapshot!(cb09.disasm(), @"  0x0: mov eax, 1");
-    assert_snapshot!(cb10.disasm(), @"  0x0: mov eax, 0xffffffff");
-    assert_snapshot!(cb11.disasm(), @"  0x0: movabs rax, 0x100000000");
-    assert_snapshot!(cb12.disasm(), @"  0x0: movabs rax, 0xffffffffffffffff");
-    assert_snapshot!(cb13.disasm(), @"  0x0: movabs r8, 0xffffffffffffffff");
-    assert_snapshot!(cb14.disasm(), @"  0x0: mov r8b, 1");
-    assert_snapshot!(cb15.disasm(), @"  0x0: mov r8b, 0xff");
-    assert_snapshot!(cb16.disasm(), @"  0x0: mov r8w, 1");
-    assert_snapshot!(cb17.disasm(), @"  0x0: mov r8w, 0xffff");
-    assert_snapshot!(cb18.disasm(), @"  0x0: mov r8d, 1");
-    assert_snapshot!(cb19.disasm(), @"  0x0: mov r8d, 0xffffffff");
-    assert_snapshot!(cb20.disasm(), @"  0x0: mov r8d, 1");
-    assert_snapshot!(cb21.disasm(), @"  0x0: movabs r8, 0xffffffffffffffff");
+    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov al, 1"));
+    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov al, 0xff"));
+    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov ax, 1"));
+    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov ax, 0xffff"));
+    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 1"));
+    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 0xffffffff"));
+    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 0"));
+    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 0xffffffff"));
+    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 1"));
+    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 0xffffffff"));
+    cb11.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs rax, 0x100000000"));
+    cb12.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs rax, 0xffffffffffffffff"));
+    cb13.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0xffffffffffffffff"));
+    cb14.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8b, 1"));
+    cb15.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8b, 0xff"));
+    cb16.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8w, 1"));
+    cb17.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8w, 0xffff"));
+    cb18.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 1"));
+    cb19.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 0xffffffff"));
+    cb20.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 1"));
+    cb21.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0xffffffffffffffff"));
 
     assert_snapshot!(cb01.string(), @"b001");
     assert_snapshot!(cb02.string(), @"b0ff");
@@ -474,11 +474,11 @@ fn test_mov_iprel() {
     let cb4 = compile(|cb| mov(cb, RAX, mem_opnd(64, RIP, 5)));
     let cb5 = compile(|cb| mov(cb, RDI, mem_opnd(64, RIP, 5)));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: mov eax, dword ptr [rip]");
-    assert_snapshot!(cb2.disasm(), @"  0x0: mov eax, dword ptr [rip + 5]");
-    assert_snapshot!(cb3.disasm(), @"  0x0: mov rax, qword ptr [rip]");
-    assert_snapshot!(cb4.disasm(), @"  0x0: mov rax, qword ptr [rip + 5]");
-    assert_snapshot!(cb5.disasm(), @"  0x0: mov rdi, qword ptr [rip + 5]");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, dword ptr [rip]"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, dword ptr [rip + 5]"));
+    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rax, qword ptr [rip]"));
+    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rax, qword ptr [rip + 5]"));
+    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rdi, qword ptr [rip + 5]"));
 
     assert_snapshot!(cb1.string(), @"8b0500000000");
     assert_snapshot!(cb2.string(), @"8b0505000000");
@@ -498,14 +498,14 @@ fn test_movsx() {
     let cb7 = compile(|cb| movsx(cb, RAX, mem_opnd(8, RSP, 0)));
     let cb8 = compile(|cb| movsx(cb, RDX, mem_opnd(16, R13, 4)));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: movsx ax, al");
-    assert_snapshot!(cb2.disasm(), @"  0x0: movsx edx, al");
-    assert_snapshot!(cb3.disasm(), @"  0x0: movsx rax, bl");
-    assert_snapshot!(cb4.disasm(), @"  0x0: movsx ecx, ax");
-    assert_snapshot!(cb5.disasm(), @"  0x0: movsx r11, cl");
-    assert_snapshot!(cb6.disasm(), @"  0x0: movsxd r10, dword ptr [rsp + 0xc]");
-    assert_snapshot!(cb7.disasm(), @"  0x0: movsx rax, byte ptr [rsp]");
-    assert_snapshot!(cb8.disasm(), @"  0x0: movsx rdx, word ptr [r13 + 4]");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx ax, al"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx edx, al"));
+    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx rax, bl"));
+    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx ecx, ax"));
+    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx r11, cl"));
+    cb6.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsxd r10, dword ptr [rsp + 0xc]"));
+    cb7.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx rax, byte ptr [rsp]"));
+    cb8.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx rdx, word ptr [r13 + 4]"));
 
     assert_snapshot!(cb1.string(), @"660fbec0");
     assert_snapshot!(cb2.string(), @"0fbed0");
@@ -532,27 +532,27 @@ fn test_nop() {
     let cb11 = compile(|cb| nop(cb, 11));
     let cb12 = compile(|cb| nop(cb, 12));
 
-    assert_snapshot!(cb01.disasm(), @"  0x0: nop");
-    assert_snapshot!(cb02.disasm(), @"  0x0: nop");
-    assert_snapshot!(cb03.disasm(), @"  0x0: nop dword ptr [rax]");
-    assert_snapshot!(cb04.disasm(), @"  0x0: nop dword ptr [rax]");
-    assert_snapshot!(cb05.disasm(), @"  0x0: nop dword ptr [rax + rax]");
-    assert_snapshot!(cb06.disasm(), @"  0x0: nop word ptr [rax + rax]");
-    assert_snapshot!(cb07.disasm(), @"  0x0: nop dword ptr [rax]");
-    assert_snapshot!(cb08.disasm(), @"  0x0: nop dword ptr [rax + rax]");
-    assert_snapshot!(cb09.disasm(), @"  0x0: nop word ptr [rax + rax]");
-    assert_snapshot!(cb10.disasm(), @r"
+    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop"));
+    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop"));
+    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop dword ptr [rax]"));
+    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop dword ptr [rax]"));
+    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop dword ptr [rax + rax]"));
+    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop word ptr [rax + rax]"));
+    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop dword ptr [rax]"));
+    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop dword ptr [rax + rax]"));
+    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop word ptr [rax + rax]"));
+    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @r"
     0x0: nop word ptr [rax + rax]
     0x9: nop
-    ");
-    assert_snapshot!(cb11.disasm(), @r"
+    "));
+    cb11.with_disasm(|disasm| assert_snapshot!(disasm, @r"
     0x0: nop word ptr [rax + rax]
     0x9: nop
-    ");
-    assert_snapshot!(cb12.disasm(), @r"
+    "));
+    cb12.with_disasm(|disasm| assert_snapshot!(disasm, @r"
     0x0: nop word ptr [rax + rax]
     0x9: nop dword ptr [rax]
-    ");
+    "));
 
     assert_snapshot!(cb01.string(), @"90");
     assert_snapshot!(cb02.string(), @"6690");
@@ -588,23 +588,23 @@ fn test_not() {
     let cb16 = compile(|cb| not(cb, mem_opnd(32, RDX, -55)));
     let cb17 = compile(|cb| not(cb, mem_opnd(32, RDX, -555)));
 
-    assert_snapshot!(cb01.disasm(), @"  0x0: not ax");
-    assert_snapshot!(cb02.disasm(), @"  0x0: not eax");
-    assert_snapshot!(cb03.disasm(), @"  0x0: not qword ptr [r12]");
-    assert_snapshot!(cb04.disasm(), @"  0x0: not dword ptr [rsp + 0x12d]");
-    assert_snapshot!(cb05.disasm(), @"  0x0: not dword ptr [rsp]");
-    assert_snapshot!(cb06.disasm(), @"  0x0: not dword ptr [rsp + 3]");
-    assert_snapshot!(cb07.disasm(), @"  0x0: not dword ptr [rbp]");
-    assert_snapshot!(cb08.disasm(), @"  0x0: not dword ptr [rbp + 0xd]");
-    assert_snapshot!(cb09.disasm(), @"  0x0: not rax");
-    assert_snapshot!(cb10.disasm(), @"  0x0: not r11");
-    assert_snapshot!(cb11.disasm(), @"  0x0: not dword ptr [rax]");
-    assert_snapshot!(cb12.disasm(), @"  0x0: not dword ptr [rsi]");
-    assert_snapshot!(cb13.disasm(), @"  0x0: not dword ptr [rdi]");
-    assert_snapshot!(cb14.disasm(), @"  0x0: not dword ptr [rdx + 0x37]");
-    assert_snapshot!(cb15.disasm(), @"  0x0: not dword ptr [rdx + 0x539]");
-    assert_snapshot!(cb16.disasm(), @"  0x0: not dword ptr [rdx - 0x37]");
-    assert_snapshot!(cb17.disasm(), @"  0x0: not dword ptr [rdx - 0x22b]");
+    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not ax"));
+    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not eax"));
+    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not qword ptr [r12]"));
+    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rsp + 0x12d]"));
+    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rsp]"));
+    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rsp + 3]"));
+    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rbp]"));
+    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rbp + 0xd]"));
+    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not rax"));
+    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not r11"));
+    cb11.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rax]"));
+    cb12.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rsi]"));
+    cb13.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rdi]"));
+    cb14.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rdx + 0x37]"));
+    cb15.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rdx + 0x539]"));
+    cb16.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rdx - 0x37]"));
+    cb17.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rdx - 0x22b]"));
 
     assert_snapshot!(cb01.string(), @"66f7d0");
     assert_snapshot!(cb02.string(), @"f7d0");
@@ -628,7 +628,7 @@ fn test_not() {
 #[test]
 fn test_or() {
     let cb = compile(|cb| or(cb, EDX, ESI));
-    assert_snapshot!(cb.disasm(), @"  0x0: or edx, esi");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: or edx, esi"));
     assert_snapshot!(cb.string(), @"09f2");
 }
 
@@ -645,16 +645,16 @@ fn test_pop() {
     let cb09 = compile(|cb| pop(cb, mem_opnd_sib(64, RAX, RCX, 8, 3)));
     let cb10 = compile(|cb| pop(cb, mem_opnd_sib(64, R8, RCX, 8, 3)));
 
-    assert_snapshot!(cb01.disasm(), @"  0x0: pop rax");
-    assert_snapshot!(cb02.disasm(), @"  0x0: pop rbx");
-    assert_snapshot!(cb03.disasm(), @"  0x0: pop rsp");
-    assert_snapshot!(cb04.disasm(), @"  0x0: pop rbp");
-    assert_snapshot!(cb05.disasm(), @"  0x0: pop r12");
-    assert_snapshot!(cb06.disasm(), @"  0x0: pop qword ptr [rax]");
-    assert_snapshot!(cb07.disasm(), @"  0x0: pop qword ptr [r8]");
-    assert_snapshot!(cb08.disasm(), @"  0x0: pop qword ptr [r8 + 3]");
-    assert_snapshot!(cb09.disasm(), @"  0x0: pop qword ptr [rax + rcx*8 + 3]");
-    assert_snapshot!(cb10.disasm(), @"  0x0: pop qword ptr [r8 + rcx*8 + 3]");
+    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop rax"));
+    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop rbx"));
+    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop rsp"));
+    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop rbp"));
+    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop r12"));
+    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop qword ptr [rax]"));
+    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop qword ptr [r8]"));
+    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop qword ptr [r8 + 3]"));
+    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop qword ptr [rax + rcx*8 + 3]"));
+    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop qword ptr [r8 + rcx*8 + 3]"));
 
     assert_snapshot!(cb01.string(), @"58");
     assert_snapshot!(cb02.string(), @"5b");
@@ -679,14 +679,14 @@ fn test_push() {
     let cb7 = compile(|cb| push(cb, mem_opnd_sib(64, RAX, RCX, 8, 3)));
     let cb8 = compile(|cb| push(cb, mem_opnd_sib(64, R8, RCX, 8, 3)));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: push rax");
-    assert_snapshot!(cb2.disasm(), @"  0x0: push rbx");
-    assert_snapshot!(cb3.disasm(), @"  0x0: push r12");
-    assert_snapshot!(cb4.disasm(), @"  0x0: push qword ptr [rax]");
-    assert_snapshot!(cb5.disasm(), @"  0x0: push qword ptr [r8]");
-    assert_snapshot!(cb6.disasm(), @"  0x0: push qword ptr [r8 + 3]");
-    assert_snapshot!(cb7.disasm(), @"  0x0: push qword ptr [rax + rcx*8 + 3]");
-    assert_snapshot!(cb8.disasm(), @"  0x0: push qword ptr [r8 + rcx*8 + 3]");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push rax"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push rbx"));
+    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push r12"));
+    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push qword ptr [rax]"));
+    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push qword ptr [r8]"));
+    cb6.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push qword ptr [r8 + 3]"));
+    cb7.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push qword ptr [rax + rcx*8 + 3]"));
+    cb8.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push qword ptr [r8 + rcx*8 + 3]"));
 
     assert_snapshot!(cb1.string(), @"50");
     assert_snapshot!(cb2.string(), @"53");
@@ -701,7 +701,7 @@ fn test_push() {
 #[test]
 fn test_ret() {
     let cb = compile(ret);
-    assert_snapshot!(cb.disasm(), @"  0x0: ret");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ret"));
     assert_snapshot!(cb.string(), @"c3");
 }
 
@@ -713,11 +713,11 @@ fn test_sal() {
     let cb4 = compile(|cb| sal(cb, mem_opnd(32, RSP, 68), uimm_opnd(1)));
     let cb5 = compile(|cb| sal(cb, RCX, CL));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: shl cx, 1");
-    assert_snapshot!(cb2.disasm(), @"  0x0: shl ecx, 1");
-    assert_snapshot!(cb3.disasm(), @"  0x0: shl ebp, 5");
-    assert_snapshot!(cb4.disasm(), @"  0x0: shl dword ptr [rsp + 0x44], 1");
-    assert_snapshot!(cb5.disasm(), @"  0x0: shl rcx, cl");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shl cx, 1"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shl ecx, 1"));
+    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shl ebp, 5"));
+    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shl dword ptr [rsp + 0x44], 1"));
+    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shl rcx, cl"));
 
     assert_snapshot!(cb1.string(), @"66d1e1");
     assert_snapshot!(cb2.string(), @"d1e1");
@@ -729,14 +729,14 @@ fn test_sal() {
 #[test]
 fn test_sar() {
     let cb = compile(|cb| sar(cb, EDX, uimm_opnd(1)));
-    assert_snapshot!(cb.disasm(), @"  0x0: sar edx, 1");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sar edx, 1"));
     assert_snapshot!(cb.string(), @"d1fa");
 }
 
 #[test]
 fn test_shr() {
     let cb = compile(|cb| shr(cb, R14, uimm_opnd(7)));
-    assert_snapshot!(cb.disasm(), @"  0x0: shr r14, 7");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shr r14, 7"));
     assert_snapshot!(cb.string(), @"49c1ee07");
 }
 
@@ -745,8 +745,8 @@ fn test_sub() {
     let cb1 = compile(|cb| sub(cb, EAX, imm_opnd(1)));
     let cb2 = compile(|cb| sub(cb, RAX, imm_opnd(2)));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: sub eax, 1");
-    assert_snapshot!(cb2.disasm(), @"  0x0: sub rax, 2");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub eax, 1"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub rax, 2"));
 
     assert_snapshot!(cb1.string(), @"83e801");
     assert_snapshot!(cb2.string(), @"4883e802");
@@ -782,25 +782,25 @@ fn test_test() {
     let cb18 = compile(|cb| test(cb, mem_opnd(64, RSI, 64), imm_opnd(0x08)));
     let cb19 = compile(|cb| test(cb, RCX, imm_opnd(0x08)));
 
-    assert_snapshot!(cb01.disasm(), @"  0x0: test al, al");
-    assert_snapshot!(cb02.disasm(), @"  0x0: test ax, ax");
-    assert_snapshot!(cb03.disasm(), @"  0x0: test cl, 8");
-    assert_snapshot!(cb04.disasm(), @"  0x0: test dl, 7");
-    assert_snapshot!(cb05.disasm(), @"  0x0: test cl, 8");
-    assert_snapshot!(cb06.disasm(), @"  0x0: test byte ptr [rdx + 8], 8");
-    assert_snapshot!(cb07.disasm(), @"  0x0: test byte ptr [rdx + 8], 0xff");
-    assert_snapshot!(cb08.disasm(), @"  0x0: test dx, 0xffff");
-    assert_snapshot!(cb09.disasm(), @"  0x0: test word ptr [rdx + 8], 0xffff");
-    assert_snapshot!(cb10.disasm(), @"  0x0: test byte ptr [rsi], 1");
-    assert_snapshot!(cb11.disasm(), @"  0x0: test byte ptr [rsi + 0x10], 1");
-    assert_snapshot!(cb12.disasm(), @"  0x0: test byte ptr [rsi - 0x10], 1");
-    assert_snapshot!(cb13.disasm(), @"  0x0: test dword ptr [rsi + 0x40], eax");
-    assert_snapshot!(cb14.disasm(), @"  0x0: test qword ptr [rdi + 0x2a], rax");
-    assert_snapshot!(cb15.disasm(), @"  0x0: test rax, rax");
-    assert_snapshot!(cb16.disasm(), @"  0x0: test rax, rsi");
-    assert_snapshot!(cb17.disasm(), @"  0x0: test qword ptr [rsi + 0x40], -9");
-    assert_snapshot!(cb18.disasm(), @"  0x0: test qword ptr [rsi + 0x40], 8");
-    assert_snapshot!(cb19.disasm(), @"  0x0: test rcx, 8");
+    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test al, al"));
+    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test ax, ax"));
+    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test cl, 8"));
+    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test dl, 7"));
+    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test cl, 8"));
+    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test byte ptr [rdx + 8], 8"));
+    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test byte ptr [rdx + 8], 0xff"));
+    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test dx, 0xffff"));
+    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test word ptr [rdx + 8], 0xffff"));
+    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test byte ptr [rsi], 1"));
+    cb11.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test byte ptr [rsi + 0x10], 1"));
+    cb12.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test byte ptr [rsi - 0x10], 1"));
+    cb13.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test dword ptr [rsi + 0x40], eax"));
+    cb14.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test qword ptr [rdi + 0x2a], rax"));
+    cb15.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test rax, rax"));
+    cb16.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test rax, rsi"));
+    cb17.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test qword ptr [rsi + 0x40], -9"));
+    cb18.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test qword ptr [rsi + 0x40], 8"));
+    cb19.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test rcx, 8"));
 
     assert_snapshot!(cb01.string(), @"84c0");
     assert_snapshot!(cb02.string(), @"6685c0");
@@ -830,10 +830,10 @@ fn test_xchg() {
     let cb3 = compile(|cb| xchg(cb, RCX, RBX));
     let cb4 = compile(|cb| xchg(cb, R9, R15));
 
-    assert_snapshot!(cb1.disasm(), @"  0x0: xchg rcx, rax");
-    assert_snapshot!(cb2.disasm(), @"  0x0: xchg r13, rax");
-    assert_snapshot!(cb3.disasm(), @"  0x0: xchg rcx, rbx");
-    assert_snapshot!(cb4.disasm(), @"  0x0: xchg r9, r15");
+    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xchg rcx, rax"));
+    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xchg r13, rax"));
+    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xchg rcx, rbx"));
+    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xchg r9, r15"));
 
     assert_snapshot!(cb1.string(), @"4891");
     assert_snapshot!(cb2.string(), @"4995");
@@ -844,7 +844,7 @@ fn test_xchg() {
 #[test]
 fn test_xor() {
     let cb = compile(|cb| xor(cb, EAX, EAX));
-    assert_snapshot!(cb.disasm(), @"  0x0: xor eax, eax");
+    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xor eax, eax"));
     assert_snapshot!(cb.string(), @"31c0");
 }
 

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1441,11 +1441,11 @@ mod tests {
         asm.mov(Opnd::Reg(TEMP_REGS[0]), out);
         asm.compile_with_num_regs(&mut cb, 2);
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov x0, #3
             0x4: mul x0, x9, x0
             0x8: mov x1, x0
-        ");
+        "));
         assert_snapshot!(cb.string(), @"600080d2207d009be10300aa");
     }
 
@@ -1460,10 +1460,10 @@ mod tests {
         asm.mov(sp, new_sp);
 
         asm.compile_with_num_regs(&mut cb, 2);
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: add sp, sp, #0x20
             0x4: sub sp, sp, #0x20
-        ");
+        "));
         assert_snapshot!(cb.string(), @"ff830091ff8300d1");
     }
 
@@ -1476,10 +1476,10 @@ mod tests {
         asm.add_into(Opnd::Reg(X20_REG), 0x20.into());
 
         asm.compile_with_num_regs(&mut cb, 0);
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: add sp, sp, #8
             0x4: adds x20, x20, #0x20
-        ");
+        "));
         assert_snapshot!(cb.string(), @"ff230091948200b1");
     }
 
@@ -1491,11 +1491,11 @@ mod tests {
         asm.load_into(Opnd::Reg(X1_REG), difference);
 
         asm.compile_with_num_regs(&mut cb, 1);
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov x0, #8
             0x4: subs x0, x0, x5
             0x8: mov x1, x0
-        ");
+        "));
         assert_snapshot!(cb.string(), @"000180d2000005ebe10300aa");
     }
 
@@ -1507,10 +1507,10 @@ mod tests {
         asm.cret(ret_val);
 
         asm.compile_with_num_regs(&mut cb, 1);
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: ldur x0, [x0]
             0x4: ret
-        ");
+        "));
         assert_snapshot!(cb.string(), @"000040f8c0035fd6");
     }
 
@@ -1572,7 +1572,7 @@ mod tests {
             asm.frame_setup(THREE_REGS, 3);
             asm.frame_teardown(THREE_REGS);
             asm.compile_with_num_regs(&mut cb, 0);
-            assert_snapshot!(cb.disasm(), @"
+            cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
                 0x0: stp x29, x30, [sp, #-0x10]!
                 0x4: mov x29, sp
                 0x8: stp x20, x19, [sp, #-0x10]!
@@ -1582,7 +1582,7 @@ mod tests {
                 0x18: ldur x21, [x29, #-0x18]
                 0x1c: mov sp, x29
                 0x20: ldp x29, x30, [sp], #0x10
-            ");
+            "));
             assert_snapshot!(cb.string(), @"fd7bbfa9fd030091f44fbfa9f5831ff8ff8300d1b44f7fa9b5835ef8bf030091fd7bc1a8");
         }
 
@@ -1592,7 +1592,7 @@ mod tests {
             asm.frame_setup(THREE_REGS, 4);
             asm.frame_teardown(THREE_REGS);
             asm.compile_with_num_regs(&mut cb, 0);
-            assert_snapshot!(cb.disasm(), @"
+            cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
                 0x0: stp x29, x30, [sp, #-0x10]!
                 0x4: mov x29, sp
                 0x8: stp x20, x19, [sp, #-0x10]!
@@ -1602,7 +1602,7 @@ mod tests {
                 0x18: ldur x21, [x29, #-0x18]
                 0x1c: mov sp, x29
                 0x20: ldp x29, x30, [sp], #0x10
-            ");
+            "));
             assert_snapshot!(cb.string(), @"fd7bbfa9fd030091f44fbfa9f5831ff8ffc300d1b44f7fa9b5835ef8bf030091fd7bc1a8");
         }
 
@@ -1613,7 +1613,7 @@ mod tests {
             asm.frame_setup(FOUR_REGS, 3);
             asm.frame_teardown(FOUR_REGS);
             asm.compile_with_num_regs(&mut cb, 0);
-            assert_snapshot!(cb.disasm(), @"
+            cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
                 0x0: stp x29, x30, [sp, #-0x10]!
                 0x4: mov x29, sp
                 0x8: stp x20, x19, [sp, #-0x10]!
@@ -1623,7 +1623,7 @@ mod tests {
                 0x18: ldp x22, x21, [x29, #-0x20]
                 0x1c: mov sp, x29
                 0x20: ldp x29, x30, [sp], #0x10
-            ");
+            "));
             assert_snapshot!(cb.string(), @"fd7bbfa9fd030091f44fbfa9f657bfa9ff8300d1b44f7fa9b6577ea9bf030091fd7bc1a8");
         }
     }
@@ -1664,7 +1664,7 @@ mod tests {
         }
 
         asm.compile_with_num_regs(&mut cb, 0);
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
             0x0: orr x0, xzr, #0x7fffffff
             0x4: add x0, sp, x0
             0x8: mov x0, #8
@@ -1683,7 +1683,7 @@ mod tests {
             0x3c: add x0, sp, x0
             0x40: orr x0, xzr, #0xffffffff80000000
             0x44: add x0, sp, x0
-        ");
+        "));
         assert_snapshot!(cb.string(), @"e07b40b2e063208b000180d22000a0f2e063208b000083d2e063208be0230891e02308d1e0ff8292e063208b00ff9fd2c0ffbff2e0ffdff2e0fffff2e063208be08361b2e063208b");
     }
 
@@ -1699,7 +1699,7 @@ mod tests {
         asm.store(large_mem, large_mem);
 
         asm.compile_with_num_regs(&mut cb, 0);
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: sub x16, sp, #0x305
             0x4: ldur x16, [x16]
             0x8: stur x16, [x0]
@@ -1710,7 +1710,7 @@ mod tests {
             0x1c: ldur x16, [x16]
             0x20: sub x17, sp, #0x305
             0x24: stur x16, [x17]
-        ");
+        "));
         assert_snapshot!(cb.string(), @"f0170cd1100240f8100000f8100040f8f1170cd1300200f8f0170cd1100240f8f1170cd1300200f8");
     }
 
@@ -1727,13 +1727,13 @@ mod tests {
         let gc_offsets = asm.arm64_emit(&mut cb).unwrap();
         assert_eq!(1, gc_offsets.len(), "VALUE source operand should be reported as gc offset");
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: ldr x16, #8
             0x4: b #0x10
             0x8: .byte 0x00, 0x10, 0x00, 0x00
             0xc: .byte 0x00, 0x00, 0x00, 0x00
             0x10: stur x16, [x21]
-        ");
+        "));
         assert_snapshot!(cb.string(), @"50000058030000140010000000000000b00200f8");
     }
 
@@ -1979,10 +1979,10 @@ mod tests {
 
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: eor x0, x0, x1
             0x4: stur x0, [x2]
-        ");
+        "));
         assert_snapshot!(cb.string(), @"000001ca400000f8");
     }
 
@@ -2017,7 +2017,7 @@ mod tests {
         asm.mov(Opnd::Reg(TEMP_REGS[0]), Opnd::mem(64, CFP, 8));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: ldur x1, [x19, #8]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldur x1, [x19, #8]"));
         assert_snapshot!(cb.string(), @"618240f8");
     }
 
@@ -2029,10 +2029,10 @@ mod tests {
         asm.mov(Opnd::Reg(TEMP_REGS[0]), Opnd::UImm(0x10000));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov x1, #0xffff
             0x4: orr x1, xzr, #0x10000
-        ");
+        "));
         assert_snapshot!(cb.string(), @"e1ff9fd2e10370b2");
     }
 
@@ -2044,11 +2044,11 @@ mod tests {
         asm.mov(Opnd::Reg(TEMP_REGS[0]), out);
         asm.compile_with_num_regs(&mut cb, 2);
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov x0, #0x14
             0x4: mov x1, #0
             0x8: csel x1, x0, x1, lt
-        ");
+        "));
         assert_snapshot!(cb.string(), @"800280d2010080d201b0819a");
     }
 
@@ -2087,10 +2087,10 @@ mod tests {
         asm.mov(Opnd::Reg(TEMP_REGS[0]), out);
         asm.compile_with_num_regs(&mut cb, 2);
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: adds x0, x9, #1
             0x4: adds x1, x0, #1
-        ");
+        "));
         assert_snapshot!(cb.string(), @"200500b1010400b1");
     }
 
@@ -2105,10 +2105,10 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov x16, #0
             0x4: blr x16
-        ");
+        "));
         assert_snapshot!(cb.string(), @"100080d200023fd6");
     }
 
@@ -2125,13 +2125,13 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov x16, x0
             0x4: mov x0, x1
             0x8: mov x1, x16
             0xc: mov x16, #0
             0x10: blr x16
-        ");
+        "));
         assert_snapshot!(cb.string(), @"f00300aae00301aae10310aa100080d200023fd6");
     }
 
@@ -2149,7 +2149,7 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov x16, x2
             0x4: mov x2, x3
             0x8: mov x3, x16
@@ -2158,7 +2158,7 @@ mod tests {
             0x14: mov x1, x16
             0x18: mov x16, #0
             0x1c: blr x16
-        ");
+        "));
         assert_snapshot!(cb.string(), @"f00302aae20303aae30310aaf00300aae00301aae10310aa100080d200023fd6");
     }
 
@@ -2175,14 +2175,14 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov x16, x0
             0x4: mov x0, x1
             0x8: mov x1, x2
             0xc: mov x2, x16
             0x10: mov x16, #0
             0x14: blr x16
-        ");
+        "));
         assert_snapshot!(cb.string(), @"f00300aae00301aae10302aae20310aa100080d200023fd6");
     }
 }

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1446,7 +1446,7 @@ mod tests {
             0x4: mul x0, x9, x0
             0x8: mov x1, x0
         "));
-        assert_snapshot!(cb.string(), @"600080d2207d009be10300aa");
+        assert_snapshot!(cb.hexdump(), @"600080d2207d009be10300aa");
     }
 
     #[test]
@@ -1464,7 +1464,7 @@ mod tests {
             0x0: add sp, sp, #0x20
             0x4: sub sp, sp, #0x20
         "));
-        assert_snapshot!(cb.string(), @"ff830091ff8300d1");
+        assert_snapshot!(cb.hexdump(), @"ff830091ff8300d1");
     }
 
     #[test]
@@ -1480,7 +1480,7 @@ mod tests {
             0x0: add sp, sp, #8
             0x4: adds x20, x20, #0x20
         "));
-        assert_snapshot!(cb.string(), @"ff230091948200b1");
+        assert_snapshot!(cb.hexdump(), @"ff230091948200b1");
     }
 
     #[test]
@@ -1496,7 +1496,7 @@ mod tests {
             0x4: subs x0, x0, x5
             0x8: mov x1, x0
         "));
-        assert_snapshot!(cb.string(), @"000180d2000005ebe10300aa");
+        assert_snapshot!(cb.hexdump(), @"000180d2000005ebe10300aa");
     }
 
     #[test]
@@ -1511,7 +1511,7 @@ mod tests {
             0x0: ldur x0, [x0]
             0x4: ret
         "));
-        assert_snapshot!(cb.string(), @"000040f8c0035fd6");
+        assert_snapshot!(cb.hexdump(), @"000040f8c0035fd6");
     }
 
     #[test]
@@ -1583,7 +1583,7 @@ mod tests {
                 0x1c: mov sp, x29
                 0x20: ldp x29, x30, [sp], #0x10
             "));
-            assert_snapshot!(cb.string(), @"fd7bbfa9fd030091f44fbfa9f5831ff8ff8300d1b44f7fa9b5835ef8bf030091fd7bc1a8");
+            assert_snapshot!(cb.hexdump(), @"fd7bbfa9fd030091f44fbfa9f5831ff8ff8300d1b44f7fa9b5835ef8bf030091fd7bc1a8");
         }
 
         // Test 3 preserved regs (odd), even slot_count
@@ -1603,7 +1603,7 @@ mod tests {
                 0x1c: mov sp, x29
                 0x20: ldp x29, x30, [sp], #0x10
             "));
-            assert_snapshot!(cb.string(), @"fd7bbfa9fd030091f44fbfa9f5831ff8ffc300d1b44f7fa9b5835ef8bf030091fd7bc1a8");
+            assert_snapshot!(cb.hexdump(), @"fd7bbfa9fd030091f44fbfa9f5831ff8ffc300d1b44f7fa9b5835ef8bf030091fd7bc1a8");
         }
 
         // Test 4 preserved regs (even), odd slot_count
@@ -1624,7 +1624,7 @@ mod tests {
                 0x1c: mov sp, x29
                 0x20: ldp x29, x30, [sp], #0x10
             "));
-            assert_snapshot!(cb.string(), @"fd7bbfa9fd030091f44fbfa9f657bfa9ff8300d1b44f7fa9b6577ea9bf030091fd7bc1a8");
+            assert_snapshot!(cb.hexdump(), @"fd7bbfa9fd030091f44fbfa9f657bfa9ff8300d1b44f7fa9b6577ea9bf030091fd7bc1a8");
         }
     }
 
@@ -1684,7 +1684,7 @@ mod tests {
             0x40: orr x0, xzr, #0xffffffff80000000
             0x44: add x0, sp, x0
         "));
-        assert_snapshot!(cb.string(), @"e07b40b2e063208b000180d22000a0f2e063208b000083d2e063208be0230891e02308d1e0ff8292e063208b00ff9fd2c0ffbff2e0ffdff2e0fffff2e063208be08361b2e063208b");
+        assert_snapshot!(cb.hexdump(), @"e07b40b2e063208b000180d22000a0f2e063208b000083d2e063208be0230891e02308d1e0ff8292e063208b00ff9fd2c0ffbff2e0ffdff2e0fffff2e063208be08361b2e063208b");
     }
 
     #[test]
@@ -1711,7 +1711,7 @@ mod tests {
             0x20: sub x17, sp, #0x305
             0x24: stur x16, [x17]
         "));
-        assert_snapshot!(cb.string(), @"f0170cd1100240f8100000f8100040f8f1170cd1300200f8f0170cd1100240f8f1170cd1300200f8");
+        assert_snapshot!(cb.hexdump(), @"f0170cd1100240f8100000f8100040f8f1170cd1300200f8f0170cd1100240f8f1170cd1300200f8");
     }
 
     #[test]
@@ -1734,7 +1734,7 @@ mod tests {
             0xc: .byte 0x00, 0x00, 0x00, 0x00
             0x10: stur x16, [x21]
         "));
-        assert_snapshot!(cb.string(), @"50000058030000140010000000000000b00200f8");
+        assert_snapshot!(cb.hexdump(), @"50000058030000140010000000000000b00200f8");
     }
 
     #[test]
@@ -1983,7 +1983,7 @@ mod tests {
             0x0: eor x0, x0, x1
             0x4: stur x0, [x2]
         "));
-        assert_snapshot!(cb.string(), @"000001ca400000f8");
+        assert_snapshot!(cb.hexdump(), @"000001ca400000f8");
     }
 
     #[test]
@@ -2018,7 +2018,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldur x1, [x19, #8]"));
-        assert_snapshot!(cb.string(), @"618240f8");
+        assert_snapshot!(cb.hexdump(), @"618240f8");
     }
 
     #[test]
@@ -2033,7 +2033,7 @@ mod tests {
             0x0: mov x1, #0xffff
             0x4: orr x1, xzr, #0x10000
         "));
-        assert_snapshot!(cb.string(), @"e1ff9fd2e10370b2");
+        assert_snapshot!(cb.hexdump(), @"e1ff9fd2e10370b2");
     }
 
     #[test]
@@ -2049,7 +2049,7 @@ mod tests {
             0x4: mov x1, #0
             0x8: csel x1, x0, x1, lt
         "));
-        assert_snapshot!(cb.string(), @"800280d2010080d201b0819a");
+        assert_snapshot!(cb.hexdump(), @"800280d2010080d201b0819a");
     }
 
     #[test]
@@ -2091,7 +2091,7 @@ mod tests {
             0x0: adds x0, x9, #1
             0x4: adds x1, x0, #1
         "));
-        assert_snapshot!(cb.string(), @"200500b1010400b1");
+        assert_snapshot!(cb.hexdump(), @"200500b1010400b1");
     }
 
     #[test]
@@ -2109,7 +2109,7 @@ mod tests {
             0x0: mov x16, #0
             0x4: blr x16
         "));
-        assert_snapshot!(cb.string(), @"100080d200023fd6");
+        assert_snapshot!(cb.hexdump(), @"100080d200023fd6");
     }
 
     #[test]
@@ -2132,7 +2132,7 @@ mod tests {
             0xc: mov x16, #0
             0x10: blr x16
         "));
-        assert_snapshot!(cb.string(), @"f00300aae00301aae10310aa100080d200023fd6");
+        assert_snapshot!(cb.hexdump(), @"f00300aae00301aae10310aa100080d200023fd6");
     }
 
     #[test]
@@ -2159,7 +2159,7 @@ mod tests {
             0x18: mov x16, #0
             0x1c: blr x16
         "));
-        assert_snapshot!(cb.string(), @"f00302aae20303aae30310aaf00300aae00301aae10310aa100080d200023fd6");
+        assert_snapshot!(cb.hexdump(), @"f00302aae20303aae30310aaf00300aae00301aae10310aa100080d200023fd6");
     }
 
     #[test]
@@ -2183,6 +2183,6 @@ mod tests {
             0x10: mov x16, #0
             0x14: blr x16
         "));
-        assert_snapshot!(cb.string(), @"f00300aae00301aae10302aae20310aa100080d200023fd6");
+        assert_snapshot!(cb.hexdump(), @"f00300aae00301aae10302aae20310aa100080d200023fd6");
     }
 }

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -934,10 +934,10 @@ mod tests {
         let _ = asm.add(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: mov rax, rax
         0x3: add rax, 0xff
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4889c04881c0ff000000");
     }
 
@@ -949,11 +949,11 @@ mod tests {
         let _ = asm.add(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: add rax, r11
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4889c049bbffffffffffff00004c01d8");
     }
 
@@ -965,10 +965,10 @@ mod tests {
         let _ = asm.and(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: mov rax, rax
         0x3: and rax, 0xff
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4889c04881e0ff000000");
     }
 
@@ -980,11 +980,11 @@ mod tests {
         let _ = asm.and(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: and rax, r11
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4889c049bbffffffffffff00004c21d8");
     }
 
@@ -995,7 +995,7 @@ mod tests {
         asm.cmp(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: cmp rax, 0xff");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp rax, 0xff"));
         assert_snapshot!(cb.string(), @"4881f8ff000000");
     }
 
@@ -1006,10 +1006,10 @@ mod tests {
         asm.cmp(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: movabs r11, 0xffffffffffff
         0xa: cmp rax, r11
-        ");
+        "));
         assert_snapshot!(cb.string(), @"49bbffffffffffff00004c39d8");
     }
 
@@ -1020,7 +1020,7 @@ mod tests {
         asm.cmp(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: cmp rax, -1");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp rax, -1"));
         assert_snapshot!(cb.string(), @"4883f8ff");
     }
 
@@ -1033,7 +1033,7 @@ mod tests {
         asm.cmp(shape_opnd, Opnd::UImm(0xF000));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: cmp word ptr [rax + 6], 0xf000");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp word ptr [rax + 6], 0xf000"));
         assert_snapshot!(cb.string(), @"6681780600f0");
     }
 
@@ -1046,7 +1046,7 @@ mod tests {
         asm.cmp(shape_opnd, Opnd::UImm(0xF000_0000));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: cmp dword ptr [rax + 4], 0xf0000000");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp dword ptr [rax + 4], 0xf0000000"));
         assert_snapshot!(cb.string(), @"817804000000f0");
     }
 
@@ -1058,10 +1058,10 @@ mod tests {
         let _ = asm.or(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: mov rax, rax
         0x3: or rax, 0xff
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4889c04881c8ff000000");
     }
 
@@ -1073,11 +1073,11 @@ mod tests {
         let _ = asm.or(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: or rax, r11
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4889c049bbffffffffffff00004c09d8");
     }
 
@@ -1089,10 +1089,10 @@ mod tests {
         let _ = asm.sub(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: mov rax, rax
         0x3: sub rax, 0xff
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4889c04881e8ff000000");
     }
 
@@ -1104,11 +1104,11 @@ mod tests {
         let _ = asm.sub(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: sub rax, r11
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4889c049bbffffffffffff00004c29d8");
     }
 
@@ -1119,7 +1119,7 @@ mod tests {
         asm.test(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: test rax, 0xff");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test rax, 0xff"));
         assert_snapshot!(cb.string(), @"48f7c0ff000000");
     }
 
@@ -1130,10 +1130,10 @@ mod tests {
         asm.test(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: movabs r11, 0xffffffffffff
         0xa: test rax, r11
-        ");
+        "));
         assert_snapshot!(cb.string(), @"49bbffffffffffff00004c85d8");
     }
 
@@ -1145,10 +1145,10 @@ mod tests {
         let _ = asm.xor(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: mov rax, rax
         0x3: xor rax, 0xff
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4889c04881f0ff000000");
     }
 
@@ -1160,11 +1160,11 @@ mod tests {
         let _ = asm.xor(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: xor rax, r11
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4889c049bbffffffffffff00004c31d8");
     }
 
@@ -1176,7 +1176,7 @@ mod tests {
         asm.mov(SP, sp); // should be merged to lea
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: lea rbx, [rbx + 8]");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rbx, [rbx + 8]"));
         assert_snapshot!(cb.string(), @"488d5b08");
     }
 
@@ -1189,10 +1189,10 @@ mod tests {
         asm.mov(Opnd::mem(64, SP, 0), sp); // should NOT be merged to lea
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: movabs r11, 0xffffffffffff
         0xa: cmp rax, r11
-        ");
+        "));
         assert_snapshot!(cb.string(), @"49bbffffffffffff00004c39d8");
     }
 
@@ -1207,14 +1207,14 @@ mod tests {
         asm.mov(Opnd::Reg(RAX_REG), result);
         asm.compile_with_num_regs(&mut cb, 2);
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: mov rax, qword ptr [rbx + 8]
         0x4: test rax, rax
         0x7: mov eax, 0x14
         0xc: mov ecx, 0
         0x11: cmovne rax, rcx
         0x15: mov rax, rax
-        ");
+        "));
         assert_snapshot!(cb.string(), @"488b43084885c0b814000000b900000000480f45c14889c0");
     }
 
@@ -1226,7 +1226,7 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: add r13, 0x40");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r13, 0x40"));
         assert_snapshot!(cb.string(), @"4983c540");
     }
 
@@ -1237,7 +1237,7 @@ mod tests {
         asm.add_into(CFP, Opnd::UImm(0x40));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: add r13, 0x40");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r13, 0x40"));
         assert_snapshot!(cb.string(), @"4983c540");
     }
 
@@ -1249,7 +1249,7 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: sub r13, 0x40");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub r13, 0x40"));
         assert_snapshot!(cb.string(), @"4983ed40");
     }
 
@@ -1260,7 +1260,7 @@ mod tests {
         asm.sub_into(CFP, Opnd::UImm(0x40));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: sub r13, 0x40");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub r13, 0x40"));
         assert_snapshot!(cb.string(), @"4983ed40");
     }
 
@@ -1272,7 +1272,7 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: and r13, 0x40");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and r13, 0x40"));
         assert_snapshot!(cb.string(), @"4983e540");
     }
 
@@ -1284,7 +1284,7 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: or r13, 0x40");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: or r13, 0x40"));
         assert_snapshot!(cb.string(), @"4983cd40");
     }
 
@@ -1296,7 +1296,7 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @"  0x0: xor r13, 0x40");
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xor r13, 0x40"));
         assert_snapshot!(cb.string(), @"4983f540");
     }
 
@@ -1311,10 +1311,10 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        assert_snapshot!(cb.disasm(), @r"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
         0x0: mov eax, 0
         0x5: call rax
-        ");
+        "));
         assert_snapshot!(cb.string(), @"b800000000ffd0");
     }
 
@@ -1331,13 +1331,13 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov r11, rsi
             0x3: mov rsi, rdi
             0x6: mov rdi, r11
             0x9: mov eax, 0
             0xe: call rax
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4989f34889fe4c89dfb800000000ffd0");
     }
 
@@ -1355,7 +1355,7 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov r11, rsi
             0x3: mov rsi, rdi
             0x6: mov rdi, r11
@@ -1364,7 +1364,7 @@ mod tests {
             0xf: mov rdx, r11
             0x12: mov eax, 0
             0x17: call rax
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4989f34889fe4c89df4989cb4889d14c89dab800000000ffd0");
     }
 
@@ -1381,14 +1381,14 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov r11, rsi
             0x3: mov rsi, rdx
             0x6: mov rdx, rdi
             0x9: mov rdi, r11
             0xc: mov eax, 0
             0x11: call rax
-        ");
+        "));
         assert_snapshot!(cb.string(), @"4989f34889d64889fa4c89dfb800000000ffd0");
     }
 
@@ -1409,7 +1409,7 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, 3);
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov eax, 1
             0x5: mov ecx, 2
             0xa: mov edx, 3
@@ -1420,7 +1420,7 @@ mod tests {
             0x1b: mov rdx, r11
             0x1e: mov eax, 0
             0x23: call rax
-        ");
+        "));
         assert_snapshot!(cb.string(), @"b801000000b902000000ba030000004889c74889ce4989cb4889d14c89dab800000000ffd0");
     }
 
@@ -1438,12 +1438,12 @@ mod tests {
 
         asm.compile_with_num_regs(&mut cb, 1);
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: cmp qword ptr [rbx + 0x10], 1
             0x5: mov edi, 4
             0xa: cmovg rdi, qword ptr [rbx]
             0xe: mov qword ptr [rbx], rdi
-        ");
+        "));
         assert_snapshot!(cb.string(), @"48837b1001bf04000000480f4f3b48893b");
     }
 
@@ -1458,12 +1458,13 @@ mod tests {
 
         asm.compile_with_num_regs(&mut cb, 3);
 
-        assert_snapshot!(cb.disasm(), @"
+        #[cfg(feature = "disasm")]
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: movabs rax, 0x7f22c88d1930
             0xa: mov ecx, 4
             0xf: cmove rax, rcx
             0x13: mov qword ptr [rbx], rax
-        ");
+        "));
         assert_snapshot!(cb.string(), @"48b830198dc8227f0000b904000000480f44c1488903");
     }
 
@@ -1476,10 +1477,11 @@ mod tests {
         asm.mov(shape_opnd, Opnd::Imm(0x8000_0001));
 
         asm.compile_with_num_regs(&mut cb, 0);
-        assert_snapshot!(cb.disasm(), @"
+        #[cfg(feature = "disasm")]
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: mov dword ptr [rax], 0x80000001
             0x6: mov dword ptr [rax], 0x80000001
-        ");
+        "));
         assert_snapshot!(cb.string(), @"c70001000080c70001000080");
     }
 
@@ -1495,7 +1497,7 @@ mod tests {
         asm.frame_teardown(&[]);
 
         asm.compile_with_num_regs(&mut cb, 0);
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: push rbp
             0x1: mov rbp, rsp
             0x4: push r13
@@ -1513,7 +1515,7 @@ mod tests {
             0x22: sub rsp, 0x30
             0x26: mov rsp, rbp
             0x29: pop rbp
-        ");
+        "));
         assert_snapshot!(cb.string(), @"554889e541555341544883ec084c8b6df8488b5df04c8b65e84889ec5dc3554889e54883ec304889ec5d");
     }
 
@@ -1528,10 +1530,10 @@ mod tests {
         let gc_offsets = asm.x86_emit(&mut cb).unwrap();
         assert_eq!(1, gc_offsets.len(), "VALUE source operand should be reported as gc offset");
 
-        assert_snapshot!(cb.disasm(), @"
+        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
             0x0: movabs r11, 0x1000
             0xa: mov qword ptr [rbx], r11
-        ");
+        "));
         assert_snapshot!(cb.string(), @"49bb00100000000000004c891b");
     }
 }

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -938,7 +938,7 @@ mod tests {
         0x0: mov rax, rax
         0x3: add rax, 0xff
         "));
-        assert_snapshot!(cb.string(), @"4889c04881c0ff000000");
+        assert_snapshot!(cb.hexdump(), @"4889c04881c0ff000000");
     }
 
     #[test]
@@ -954,7 +954,7 @@ mod tests {
         0x3: movabs r11, 0xffffffffffff
         0xd: add rax, r11
         "));
-        assert_snapshot!(cb.string(), @"4889c049bbffffffffffff00004c01d8");
+        assert_snapshot!(cb.hexdump(), @"4889c049bbffffffffffff00004c01d8");
     }
 
     #[test]
@@ -969,7 +969,7 @@ mod tests {
         0x0: mov rax, rax
         0x3: and rax, 0xff
         "));
-        assert_snapshot!(cb.string(), @"4889c04881e0ff000000");
+        assert_snapshot!(cb.hexdump(), @"4889c04881e0ff000000");
     }
 
     #[test]
@@ -985,7 +985,7 @@ mod tests {
         0x3: movabs r11, 0xffffffffffff
         0xd: and rax, r11
         "));
-        assert_snapshot!(cb.string(), @"4889c049bbffffffffffff00004c21d8");
+        assert_snapshot!(cb.hexdump(), @"4889c049bbffffffffffff00004c21d8");
     }
 
     #[test]
@@ -996,7 +996,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 0);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp rax, 0xff"));
-        assert_snapshot!(cb.string(), @"4881f8ff000000");
+        assert_snapshot!(cb.hexdump(), @"4881f8ff000000");
     }
 
     #[test]
@@ -1010,7 +1010,7 @@ mod tests {
         0x0: movabs r11, 0xffffffffffff
         0xa: cmp rax, r11
         "));
-        assert_snapshot!(cb.string(), @"49bbffffffffffff00004c39d8");
+        assert_snapshot!(cb.hexdump(), @"49bbffffffffffff00004c39d8");
     }
 
     #[test]
@@ -1021,7 +1021,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 0);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp rax, -1"));
-        assert_snapshot!(cb.string(), @"4883f8ff");
+        assert_snapshot!(cb.hexdump(), @"4883f8ff");
     }
 
     #[test]
@@ -1034,7 +1034,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 0);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp word ptr [rax + 6], 0xf000"));
-        assert_snapshot!(cb.string(), @"6681780600f0");
+        assert_snapshot!(cb.hexdump(), @"6681780600f0");
     }
 
     #[test]
@@ -1047,7 +1047,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 0);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp dword ptr [rax + 4], 0xf0000000"));
-        assert_snapshot!(cb.string(), @"817804000000f0");
+        assert_snapshot!(cb.hexdump(), @"817804000000f0");
     }
 
     #[test]
@@ -1062,7 +1062,7 @@ mod tests {
         0x0: mov rax, rax
         0x3: or rax, 0xff
         "));
-        assert_snapshot!(cb.string(), @"4889c04881c8ff000000");
+        assert_snapshot!(cb.hexdump(), @"4889c04881c8ff000000");
     }
 
     #[test]
@@ -1078,7 +1078,7 @@ mod tests {
         0x3: movabs r11, 0xffffffffffff
         0xd: or rax, r11
         "));
-        assert_snapshot!(cb.string(), @"4889c049bbffffffffffff00004c09d8");
+        assert_snapshot!(cb.hexdump(), @"4889c049bbffffffffffff00004c09d8");
     }
 
     #[test]
@@ -1093,7 +1093,7 @@ mod tests {
         0x0: mov rax, rax
         0x3: sub rax, 0xff
         "));
-        assert_snapshot!(cb.string(), @"4889c04881e8ff000000");
+        assert_snapshot!(cb.hexdump(), @"4889c04881e8ff000000");
     }
 
     #[test]
@@ -1109,7 +1109,7 @@ mod tests {
         0x3: movabs r11, 0xffffffffffff
         0xd: sub rax, r11
         "));
-        assert_snapshot!(cb.string(), @"4889c049bbffffffffffff00004c29d8");
+        assert_snapshot!(cb.hexdump(), @"4889c049bbffffffffffff00004c29d8");
     }
 
     #[test]
@@ -1120,7 +1120,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 0);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test rax, 0xff"));
-        assert_snapshot!(cb.string(), @"48f7c0ff000000");
+        assert_snapshot!(cb.hexdump(), @"48f7c0ff000000");
     }
 
     #[test]
@@ -1134,7 +1134,7 @@ mod tests {
         0x0: movabs r11, 0xffffffffffff
         0xa: test rax, r11
         "));
-        assert_snapshot!(cb.string(), @"49bbffffffffffff00004c85d8");
+        assert_snapshot!(cb.hexdump(), @"49bbffffffffffff00004c85d8");
     }
 
     #[test]
@@ -1149,7 +1149,7 @@ mod tests {
         0x0: mov rax, rax
         0x3: xor rax, 0xff
         "));
-        assert_snapshot!(cb.string(), @"4889c04881f0ff000000");
+        assert_snapshot!(cb.hexdump(), @"4889c04881f0ff000000");
     }
 
     #[test]
@@ -1165,7 +1165,7 @@ mod tests {
         0x3: movabs r11, 0xffffffffffff
         0xd: xor rax, r11
         "));
-        assert_snapshot!(cb.string(), @"4889c049bbffffffffffff00004c31d8");
+        assert_snapshot!(cb.hexdump(), @"4889c049bbffffffffffff00004c31d8");
     }
 
     #[test]
@@ -1177,7 +1177,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rbx, [rbx + 8]"));
-        assert_snapshot!(cb.string(), @"488d5b08");
+        assert_snapshot!(cb.hexdump(), @"488d5b08");
     }
 
     #[test]
@@ -1193,7 +1193,7 @@ mod tests {
         0x0: movabs r11, 0xffffffffffff
         0xa: cmp rax, r11
         "));
-        assert_snapshot!(cb.string(), @"49bbffffffffffff00004c39d8");
+        assert_snapshot!(cb.hexdump(), @"49bbffffffffffff00004c39d8");
     }
 
     #[test]
@@ -1215,7 +1215,7 @@ mod tests {
         0x11: cmovne rax, rcx
         0x15: mov rax, rax
         "));
-        assert_snapshot!(cb.string(), @"488b43084885c0b814000000b900000000480f45c14889c0");
+        assert_snapshot!(cb.hexdump(), @"488b43084885c0b814000000b900000000480f45c14889c0");
     }
 
     #[test]
@@ -1227,7 +1227,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r13, 0x40"));
-        assert_snapshot!(cb.string(), @"4983c540");
+        assert_snapshot!(cb.hexdump(), @"4983c540");
     }
 
     #[test]
@@ -1238,7 +1238,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r13, 0x40"));
-        assert_snapshot!(cb.string(), @"4983c540");
+        assert_snapshot!(cb.hexdump(), @"4983c540");
     }
 
     #[test]
@@ -1250,7 +1250,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub r13, 0x40"));
-        assert_snapshot!(cb.string(), @"4983ed40");
+        assert_snapshot!(cb.hexdump(), @"4983ed40");
     }
 
     #[test]
@@ -1261,7 +1261,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub r13, 0x40"));
-        assert_snapshot!(cb.string(), @"4983ed40");
+        assert_snapshot!(cb.hexdump(), @"4983ed40");
     }
 
     #[test]
@@ -1273,7 +1273,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and r13, 0x40"));
-        assert_snapshot!(cb.string(), @"4983e540");
+        assert_snapshot!(cb.hexdump(), @"4983e540");
     }
 
     #[test]
@@ -1285,7 +1285,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: or r13, 0x40"));
-        assert_snapshot!(cb.string(), @"4983cd40");
+        assert_snapshot!(cb.hexdump(), @"4983cd40");
     }
 
     #[test]
@@ -1297,7 +1297,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xor r13, 0x40"));
-        assert_snapshot!(cb.string(), @"4983f540");
+        assert_snapshot!(cb.hexdump(), @"4983f540");
     }
 
     #[test]
@@ -1315,7 +1315,7 @@ mod tests {
         0x0: mov eax, 0
         0x5: call rax
         "));
-        assert_snapshot!(cb.string(), @"b800000000ffd0");
+        assert_snapshot!(cb.hexdump(), @"b800000000ffd0");
     }
 
     #[test]
@@ -1338,7 +1338,7 @@ mod tests {
             0x9: mov eax, 0
             0xe: call rax
         "));
-        assert_snapshot!(cb.string(), @"4989f34889fe4c89dfb800000000ffd0");
+        assert_snapshot!(cb.hexdump(), @"4989f34889fe4c89dfb800000000ffd0");
     }
 
     #[test]
@@ -1365,7 +1365,7 @@ mod tests {
             0x12: mov eax, 0
             0x17: call rax
         "));
-        assert_snapshot!(cb.string(), @"4989f34889fe4c89df4989cb4889d14c89dab800000000ffd0");
+        assert_snapshot!(cb.hexdump(), @"4989f34889fe4c89df4989cb4889d14c89dab800000000ffd0");
     }
 
     #[test]
@@ -1389,7 +1389,7 @@ mod tests {
             0xc: mov eax, 0
             0x11: call rax
         "));
-        assert_snapshot!(cb.string(), @"4989f34889d64889fa4c89dfb800000000ffd0");
+        assert_snapshot!(cb.hexdump(), @"4989f34889d64889fa4c89dfb800000000ffd0");
     }
 
     #[test]
@@ -1421,7 +1421,7 @@ mod tests {
             0x1e: mov eax, 0
             0x23: call rax
         "));
-        assert_snapshot!(cb.string(), @"b801000000b902000000ba030000004889c74889ce4989cb4889d14c89dab800000000ffd0");
+        assert_snapshot!(cb.hexdump(), @"b801000000b902000000ba030000004889c74889ce4989cb4889d14c89dab800000000ffd0");
     }
 
     #[test]
@@ -1444,7 +1444,7 @@ mod tests {
             0xa: cmovg rdi, qword ptr [rbx]
             0xe: mov qword ptr [rbx], rdi
         "));
-        assert_snapshot!(cb.string(), @"48837b1001bf04000000480f4f3b48893b");
+        assert_snapshot!(cb.hexdump(), @"48837b1001bf04000000480f4f3b48893b");
     }
 
     #[test]
@@ -1465,7 +1465,7 @@ mod tests {
             0xf: cmove rax, rcx
             0x13: mov qword ptr [rbx], rax
         "));
-        assert_snapshot!(cb.string(), @"48b830198dc8227f0000b904000000480f44c1488903");
+        assert_snapshot!(cb.hexdump(), @"48b830198dc8227f0000b904000000480f44c1488903");
     }
 
     #[test]
@@ -1482,7 +1482,7 @@ mod tests {
             0x0: mov dword ptr [rax], 0x80000001
             0x6: mov dword ptr [rax], 0x80000001
         "));
-        assert_snapshot!(cb.string(), @"c70001000080c70001000080");
+        assert_snapshot!(cb.hexdump(), @"c70001000080c70001000080");
     }
 
     #[test]
@@ -1516,7 +1516,7 @@ mod tests {
             0x26: mov rsp, rbp
             0x29: pop rbp
         "));
-        assert_snapshot!(cb.string(), @"554889e541555341544883ec084c8b6df8488b5df04c8b65e84889ec5dc3554889e54883ec304889ec5d");
+        assert_snapshot!(cb.hexdump(), @"554889e541555341544883ec084c8b6df8488b5df04c8b65e84889ec5dc3554889e54883ec304889ec5d");
     }
 
     #[test]
@@ -1534,6 +1534,6 @@ mod tests {
             0x0: movabs r11, 0x1000
             0xa: mov qword ptr [rbx], r11
         "));
-        assert_snapshot!(cb.string(), @"49bb00100000000000004c891b");
+        assert_snapshot!(cb.hexdump(), @"49bb00100000000000004c891b");
     }
 }


### PR DESCRIPTION
This PR fixes `make zjit-test` on builds that don't have the `disasm` feature.