### PR TITLE
Remove unnecessary `iseq` arg from `vm_get|setclass_variable` functions

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -250,7 +250,7 @@ setclassvariable
 // attr bool leaf = false; /* has rb_warning() */
 {
     vm_ensure_not_refinement_module(GET_SELF());
-    vm_setclassvariable(GET_ISEQ(), GET_CFP(), id,  val, ic);
+    vm_setclassvariable(GET_CFP(), id,  val, ic);
 }
 
 DEFINE_INSN

--- a/insns.def
+++ b/insns.def
@@ -237,8 +237,7 @@ getclassvariable
 /* "class variable access from toplevel" warning can be hooked. */
 // attr bool leaf = false; /* has rb_warning() */
 {
-    rb_control_frame_t *cfp = GET_CFP();
-    val = vm_getclassvariable(GET_ISEQ(), cfp, id, ic);
+    val = vm_getclassvariable(GET_CFP(), id, ic);
 }
 
 /* Set value of class variable id of klass as val. */

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1596,9 +1596,10 @@ update_classvariable_cache(const rb_iseq_t *iseq, VALUE klass, ID id, const rb_c
 }
 
 static inline VALUE
-vm_getclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *reg_cfp, ID id, ICVARC ic)
+vm_getclassvariable(const rb_control_frame_t *reg_cfp, ID id, ICVARC ic)
 {
     const rb_cref_t *cref;
+    const rb_iseq_t *iseq = reg_cfp->iseq;
     cref = vm_get_cref(GET_EP());
 
     if (ic->entry && ic->entry->global_cvar_state == GET_GLOBAL_CVAR_STATE() && ic->entry->cref == cref && LIKELY(rb_ractor_main_p())) {
@@ -1616,9 +1617,9 @@ vm_getclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *reg_cfp, ID
 }
 
 VALUE
-rb_vm_getclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *cfp, ID id, ICVARC ic)
+rb_vm_getclassvariable(const rb_control_frame_t *cfp, ID id, ICVARC ic)
 {
-    return vm_getclassvariable(iseq, cfp, id, ic);
+    return vm_getclassvariable(cfp, id, ic);
 }
 
 static inline void

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1623,9 +1623,10 @@ rb_vm_getclassvariable(const rb_control_frame_t *cfp, ID id, ICVARC ic)
 }
 
 static inline void
-vm_setclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *reg_cfp, ID id, VALUE val, ICVARC ic)
+vm_setclassvariable(const rb_control_frame_t *reg_cfp, ID id, VALUE val, ICVARC ic)
 {
     const rb_cref_t *cref;
+    const rb_iseq_t *iseq = reg_cfp->iseq;
     cref = vm_get_cref(GET_EP());
 
     if (ic->entry && ic->entry->global_cvar_state == GET_GLOBAL_CVAR_STATE() && ic->entry->cref == cref && LIKELY(rb_ractor_main_p())) {
@@ -1643,9 +1644,9 @@ vm_setclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *reg_cfp, ID
 }
 
 void
-rb_vm_setclassvariable(const rb_iseq_t *iseq, const rb_control_frame_t *cfp, ID id, VALUE val, ICVARC ic)
+rb_vm_setclassvariable(const rb_control_frame_t *cfp, ID id, VALUE val, ICVARC ic)
 {
-    vm_setclassvariable(iseq, cfp, id, val, ic);
+    vm_setclassvariable(cfp, id, val, ic);
 }
 
 static inline VALUE

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -10207,7 +10207,6 @@ fn gen_getclassvariable(
     let val_opnd = asm.ccall(
         rb_vm_getclassvariable as *const u8,
         vec![
-            Opnd::mem(64, CFP, RUBY_OFFSET_CFP_ISEQ),
             CFP,
             Opnd::UImm(jit.get_arg(0).as_u64()),
             Opnd::UImm(jit.get_arg(1).as_u64()),

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -10230,7 +10230,6 @@ fn gen_setclassvariable(
     asm.ccall(
         rb_vm_setclassvariable as *const u8,
         vec![
-            Opnd::mem(64, CFP, RUBY_OFFSET_CFP_ISEQ),
             CFP,
             Opnd::UImm(jit.get_arg(0).as_u64()),
             val,

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -142,7 +142,6 @@ extern "C" {
     ) -> *const rb_callable_method_entry_t;
     pub fn rb_vm_getclassvariable(cfp: CfpPtr, id: ID, ic: ICVARC) -> VALUE;
     pub fn rb_vm_setclassvariable(
-        iseq: IseqPtr,
         cfp: CfpPtr,
         id: ID,
         val: VALUE,

--- a/yjit/src/cruby.rs
+++ b/yjit/src/cruby.rs
@@ -140,7 +140,7 @@ extern "C" {
     pub fn rb_aliased_callable_method_entry(
         me: *const rb_callable_method_entry_t,
     ) -> *const rb_callable_method_entry_t;
-    pub fn rb_vm_getclassvariable(iseq: IseqPtr, cfp: CfpPtr, id: ID, ic: ICVARC) -> VALUE;
+    pub fn rb_vm_getclassvariable(cfp: CfpPtr, id: ID, ic: ICVARC) -> VALUE;
     pub fn rb_vm_setclassvariable(
         iseq: IseqPtr,
         cfp: CfpPtr,

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -148,7 +148,7 @@ unsafe extern "C" {
     pub fn rb_aliased_callable_method_entry(
         me: *const rb_callable_method_entry_t,
     ) -> *const rb_callable_method_entry_t;
-    pub fn rb_vm_getclassvariable(iseq: IseqPtr, cfp: CfpPtr, id: ID, ic: ICVARC) -> VALUE;
+    pub fn rb_vm_getclassvariable(cfp: CfpPtr, id: ID, ic: ICVARC) -> VALUE;
     pub fn rb_vm_setclassvariable(
         iseq: IseqPtr,
         cfp: CfpPtr,

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -150,7 +150,6 @@ unsafe extern "C" {
     ) -> *const rb_callable_method_entry_t;
     pub fn rb_vm_getclassvariable(cfp: CfpPtr, id: ID, ic: ICVARC) -> VALUE;
     pub fn rb_vm_setclassvariable(
-        iseq: IseqPtr,
         cfp: CfpPtr,
         id: ID,
         val: VALUE,


### PR DESCRIPTION
Since all of its callers retrieve the `iseq`'s value from the same CFP they pass to the functions, we don't need to pass the iseq separately.

As a reference, this is `GET_ISEQ`'s definition:

```
#define GET_ISEQ() (GET_CFP()->iseq)
```