### PR TITLE
Fix assertion in rb_gc_impl_mark_weak

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -4505,7 +4505,7 @@ rb_gc_impl_mark_weak(void *objspace_ptr, VALUE *ptr)
 {
     rb_objspace_t *objspace = objspace_ptr;
 
-    GC_ASSERT(objspace->rgengc.parent_object == 0 || FL_TEST(objspace->rgengc.parent_object, FL_WB_PROTECTED));
+    GC_ASSERT(objspace->rgengc.parent_object == 0 || !RVALUE_WB_UNPROTECTED(objspace, objspace->rgengc.parent_object));
 
     VALUE obj = *ptr;
 


### PR DESCRIPTION
The FL_WB_PROTECTED flag is no longer used and is not set on objects, so that assertion cannot be true. Instead, we should use RVALUE_WB_UNPROTECTED.