### PR TITLE
ZJIT: Clarify --zjit-disable-hir-opt job names

### DIFF
--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -39,8 +39,8 @@ jobs:
             test_all_opts: '--seed=46450'
 
           - test_task: 'check'
-            run_opts: '--zjit-call-threshold=1 --zjit-disable-hir-opt'
-            specopts: '-T --zjit-call-threshold=1 -T --zjit-disable-hir-opt'
+            run_opts: '--zjit-disable-hir-opt --zjit-call-threshold=1'
+            specopts: '-T --zjit-disable-hir-opt -T --zjit-call-threshold=1'
             configure: '--enable-zjit=dev'
             test_all_opts: '--seed=46450'
 

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -58,8 +58,8 @@ jobs:
             test_all_opts: '--seed=39471'
 
           - test_task: 'check'
-            run_opts: '--zjit-call-threshold=1 --zjit-disable-hir-opt'
-            specopts: '-T --zjit-call-threshold=1 -T --zjit-disable-hir-opt'
+            run_opts: '--zjit-disable-hir-opt --zjit-call-threshold=1'
+            specopts: '-T --zjit-disable-hir-opt -T --zjit-call-threshold=1'
             configure: '--enable-zjit=dev'
             test_all_opts: '--seed=39471'
 


### PR DESCRIPTION
Despite https://github.com/ruby/ruby/pull/14610#discussion_r2364623050, these `make check` jobs still seem identical in some places:

<img width="321" height="252" alt="Screenshot 2025-09-22 at 15 44 42" src="https://github.com/user-attachments/assets/25842871-546b-446f-a9a2-dd2d570e1644" />

I want to put `--zjit-disable-hir-opt` first to understand the difference more easily.