### PR TITLE
gc_validate_pc(): Exclude imemos; add a test and a hint in assert message

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -2813,6 +2813,28 @@ class TestZJIT < Test::Unit::TestCase
     }, insns: [:opt_send_without_block]
   end
 
+  def test_allocating_in_hir_c_method_is
+    assert_compiles ":k", %q{
+      # Put opt_new in a frame JIT code sets up that doesn't set cfp->pc
+      def a(f) = test(f)
+      def test(f) = (f.new if f)
+      # A parallel couple methods that will set PC at the same stack height
+      def second = third
+      def third = nil
+
+      a(nil)
+      a(nil)
+
+      class Foo
+        def self.new = :k
+      end
+
+      second
+
+      a(Foo)
+    }, call_threshold: 2, insns: [:opt_new]
+  end
+
   private
 
   # Assert that every method call in `test_script` can be compiled by ZJIT
@@ -2826,13 +2848,14 @@ class TestZJIT < Test::Unit::TestCase
   # allows ZJIT to skip compiling methods.
   def assert_runs(expected, test_script, insns: [], assert_compiles: false, **opts)
     pipe_fd = 3
+    disasm_method = :test
 
     script = <<~RUBY
       ret_val = (_test_proc = -> { #{('RubyVM::ZJIT.assert_compiles; ' if assert_compiles)}#{test_script.lstrip} }).call
       result = {
         ret_val:,
         #{ unless insns.empty?
-          'insns: RubyVM::InstructionSequence.of(method(:test)).to_a'
+           "insns: RubyVM::InstructionSequence.of(method(#{disasm_method.inspect})).to_a"
         end}
       }
       IO.open(#{pipe_fd}).write(Marshal.dump(result))
@@ -2846,7 +2869,12 @@ class TestZJIT < Test::Unit::TestCase
 
     unless insns.empty?
       iseq = result.fetch(:insns)
-      assert_equal("YARVInstructionSequence/SimpleDataFormat", iseq.first, "failed to get iseq disassembly")
+      assert_equal(
+        "YARVInstructionSequence/SimpleDataFormat",
+        iseq.first,
+        "Failed to get ISEQ disassembly. " \
+        "Make sure to put code directly under the '#{disasm_method}' method."
+      )
       iseq_insns = iseq.last
 
       expected_insns = Set.new(insns)


### PR DESCRIPTION
The validation is relevant only for traceable userland ruby objects ruby code could interact with. ZJIT's use of `rb_vm_method_cfunc_is()` allocates a CC imemo and was failing this validation when it was actually fine. Relax the check.