### PR TITLE
ZJIT: Add stats for cfuncs that are not optimized

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -43,7 +43,7 @@ class << RubyVM::ZJIT
     print_counters_with_prefix(prefix: 'dynamic_send_type_', prompt: 'dynamic send types', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'unspecialized_def_type_', prompt: 'send fallback unspecialized def_types', buf:, stats:, limit: 20)
     print_counters_with_prefix(prefix: 'send_fallback_', prompt: 'dynamic send types', buf:, stats:, limit: 20)
-    print_counters_with_prefix(prefix: 'not_optimized_cfuncs_', prompt: 'Unoptimized C functions', buf:, stats:, limit: 20)
+    print_counters_with_prefix(prefix: 'not_optimized_cfuncs_', prompt: 'unoptimized sends to C functions', buf:, stats:, limit: 20)
 
     # Show exit counters, ordered by the typical amount of exits for the prefix at the time
     print_counters_with_prefix(prefix: 'unhandled_yarv_insn_', prompt: 'unhandled YARV insns', buf:, stats:, limit: 20)

--- a/zjit/src/state.rs
+++ b/zjit/src/state.rs
@@ -8,6 +8,7 @@ use crate::asm::CodeBlock;
 use crate::options::get_option;
 use crate::stats::{Counters, ExitCounters};
 use crate::virtualmem::CodePtr;
+use std::collections::HashMap;
 
 #[allow(non_upper_case_globals)]
 #[unsafe(no_mangle)]
@@ -46,6 +47,9 @@ pub struct ZJITState {
 
     /// Trampoline to call function_stub_hit
     function_stub_hit_trampoline: CodePtr,
+
+    /// Counter pointers for unoptimized C functions
+    unoptimized_cfunc_counter_pointers: HashMap<String, Box<u64>>,
 }
 
 /// Private singleton instance of the codegen globals
@@ -80,6 +84,7 @@ impl ZJITState {
             exit_trampoline,
             function_stub_hit_trampoline,
             exit_trampoline_with_counter: exit_trampoline,
+            unoptimized_cfunc_counter_pointers: HashMap::new(),
         };
         unsafe { ZJIT_STATE = Some(zjit_state); }
 
@@ -136,6 +141,11 @@ impl ZJITState {
     /// Get a mutable reference to side-exit counters
     pub fn get_exit_counters() -> &'static mut ExitCounters {
         &mut ZJITState::get_instance().exit_counters
+    }
+
+    /// Get a mutable reference to unoptimized cfunc counter pointers
+    pub fn get_unoptimized_cfunc_counter_pointers() -> &'static mut HashMap<String, Box<u64>> {
+        &mut ZJITState::get_instance().unoptimized_cfunc_counter_pointers
     }
 
     /// Was --zjit-save-compiled-iseqs specified?


### PR DESCRIPTION
From `lobsters`

```
Top-20 Unoptimized C functions (73.0% of total 15,276,688):
                               Kernel#is_a?: 2,052,363 (13.4%)
                              Class#current: 1,892,623 (12.4%)
                                String#to_s:   975,973 ( 6.4%)
                                  Hash#key?:   677,623 ( 4.4%)
                              String#empty?:   636,468 ( 4.2%)
                              TrueClass#===:   457,232 ( 3.0%)
                                   Hash#[]=:   455,908 ( 3.0%)
                             FalseClass#===:   448,798 ( 2.9%)
         ActiveSupport::OrderedOptions#_get:   377,468 ( 2.5%)
                            Kernel#kind_of?:   339,551 ( 2.2%)
                                 Kernel#dup:   329,371 ( 2.2%)
                                  String#==:   324,286 ( 2.1%)
                            String#include?:   297,528 ( 1.9%)
                                    Hash#[]:   294,561 ( 1.9%)
                             Array#include?:   287,145 ( 1.9%)
                        Kernel#block_given?:   283,633 ( 1.9%)
                             BasicObject#!=:   278,874 ( 1.8%)
                                Hash#delete:   250,951 ( 1.6%)
                               Set#include?:   246,447 ( 1.6%)
                               NilClass#===:   242,776 ( 1.6%)
```

From `liquid-render`

```
Top-20 Unoptimized C functions (99.8% of total 5,195,549):
                          Hash#key?: 2,459,048 (47.3%)
                        String#to_s: 1,119,758 (21.6%)
                       Set#include?:   799,469 (15.4%)
                       Kernel#is_a?:   214,223 ( 4.1%)
                         Integer#<<:   171,073 ( 3.3%)
                          Integer#/:   127,622 ( 2.5%)
          CGI::EscapeExt#escapeHTML:    56,971 ( 1.1%)
                         Regexp#===:    50,008 ( 1.0%)
                      String#empty?:    43,990 ( 0.8%)
                         String#===:    36,838 ( 0.7%)
                          String#==:    21,309 ( 0.4%)
                      Time#strftime:    21,251 ( 0.4%)
                       String#strip:    15,271 ( 0.3%)
                        String#scan:    13,753 ( 0.3%)
                          String#+@:    12,603 ( 0.2%)
                     Array#include?:     8,059 ( 0.2%)
                           String#+:     5,295 ( 0.1%)
                         String#dup:     4,606 ( 0.1%)
                          String#-@:     3,213 ( 0.1%)
                     Class#generate:     3,011 ( 0.1%)
```