### PR TITLE
Fix formatting of seconds parameter in documentation

### DIFF
--- a/process.c
+++ b/process.c
@@ -8227,7 +8227,7 @@ ruby_real_ms_time(void)
  *  - +:microsecond+: Number of microseconds as an integer.
  *  - +:millisecond+: Number of milliseconds as an integer.
  *  - +:nanosecond+: Number of nanoseconds as an integer.
- *  - +::second+: Number of seconds as an integer.
+ *  - +:second+: Number of seconds as an integer.
  *
  *  Examples:
  *


### PR DESCRIPTION
Small typo in documentation: There's an additional colon sign in the documentation for Process.clock_gettime