### PR TITLE
ZJIT: Prefer *const u8 for consts

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -965,8 +965,8 @@ fn gen_const_value(val: VALUE) -> lir::Opnd {
 }
 
 /// Compile Const::CPtr
-fn gen_const_cptr(val: *mut u8) -> lir::Opnd {
-    Opnd::UImm(val as u64)
+fn gen_const_cptr(val: *const u8) -> lir::Opnd {
+    Opnd::const_ptr(val)
 }
 
 /// Compile a basic block argument

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -270,7 +270,7 @@ pub enum Const {
     CUInt16(u16),
     CUInt32(u32),
     CUInt64(u64),
-    CPtr(*mut u8),
+    CPtr(*const u8),
     CDouble(f64),
 }
 
@@ -4139,7 +4139,7 @@ fn compile_entry_block(entry_block: BlockId, first_block: BlockId, fun: &mut Fun
     let opt_num = unsafe { get_iseq_body_param_opt_num(iseq) };
     if !jit_entry && opt_num > 0 {
         let pc = fun.push_insn(entry_block, Insn::LoadPC);
-        let no_opts_pc = fun.push_insn(entry_block, Insn::Const { val: Const::CPtr(unsafe { rb_iseq_pc_at_idx(iseq, 0) } as *mut u8) });
+        let no_opts_pc = fun.push_insn(entry_block, Insn::Const { val: Const::CPtr(unsafe { rb_iseq_pc_at_idx(iseq, 0) } as *const u8) });
         let test_id = fun.push_insn(entry_block, Insn::IsBitEqual { left: pc, right: no_opts_pc });
 
         // Jump to the first_block if no optional arguments are supplied

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -95,7 +95,7 @@ fn write_spec(f: &mut std::fmt::Formatter, printer: &TypePrinter) -> std::fmt::R
         Specialization::Int(val) if ty.is_subtype(types::CUInt16) => write!(f, "[{}]", val >> 48),
         Specialization::Int(val) if ty.is_subtype(types::CUInt32) => write!(f, "[{}]", val >> 32),
         Specialization::Int(val) if ty.is_subtype(types::CUInt64) => write!(f, "[{}]", val),
-        Specialization::Int(val) if ty.is_subtype(types::CPtr) => write!(f, "[{}]", Const::CPtr(val as *mut u8).print(printer.ptr_map)),
+        Specialization::Int(val) if ty.is_subtype(types::CPtr) => write!(f, "[{}]", Const::CPtr(val as *const u8).print(printer.ptr_map)),
         Specialization::Int(val) => write!(f, "[{val}]"),
         Specialization::Double(val) => write!(f, "[{val}]"),
     }
@@ -282,7 +282,7 @@ impl Type {
         Type { bits: ty.bits, spec: Specialization::Int(val as u64) }
     }
 
-    pub fn from_cptr(val: *mut u8) -> Type {
+    pub fn from_cptr(val: *const u8) -> Type {
         Type { bits: bits::CPtr, spec: Specialization::Int(val as u64) }
     }
 


### PR DESCRIPTION
A small follow-up on https://github.com/ruby/ruby/pull/14643