### PR TITLE
ZJIT: Hold the GC more correctly in `Invariants`

### DIFF
--- a/depend
+++ b/depend
@@ -5797,6 +5797,7 @@ gc.$(OBJEXT): {$(VPATH)}vm_debug.h
 gc.$(OBJEXT): {$(VPATH)}vm_opts.h
 gc.$(OBJEXT): {$(VPATH)}vm_sync.h
 gc.$(OBJEXT): {$(VPATH)}yjit.h
+gc.$(OBJEXT): {$(VPATH)}zjit.h
 goruby.$(OBJEXT): $(CCAN_DIR)/check_type/check_type.h
 goruby.$(OBJEXT): $(CCAN_DIR)/container_of/container_of.h
 goruby.$(OBJEXT): $(CCAN_DIR)/list/list.h

--- a/gc.c
+++ b/gc.c
@@ -127,6 +127,7 @@
 #include "vm_callinfo.h"
 #include "ractor_core.h"
 #include "yjit.h"
+#include "zjit.h"
 
 #include "builtin.h"
 #include "shape.h"
@@ -4104,6 +4105,14 @@ rb_gc_update_vm_references(void *objspace)
 
     if (rb_yjit_enabled_p) {
         rb_yjit_root_update_references();
+    }
+#endif
+
+#if USE_ZJIT
+    void rb_zjit_root_update_references(void); // in Rust
+
+    if (rb_zjit_enabled_p) {
+        rb_zjit_root_update_references();
     }
 #endif
 }

--- a/iseq.c
+++ b/iseq.c
@@ -175,6 +175,9 @@ rb_iseq_free(const rb_iseq_t *iseq)
             rb_yjit_live_iseq_count--;
         }
 #endif
+#if USE_ZJIT
+        rb_zjit_iseq_free(iseq);
+#endif
         ruby_xfree((void *)body->iseq_encoded);
         ruby_xfree((void *)body->insns_info.body);
         ruby_xfree((void *)body->insns_info.positions);

--- a/vm_method.c
+++ b/vm_method.c
@@ -859,6 +859,17 @@ rb_free_method_entry_vm_weak_references(const rb_method_entry_t *me)
 void
 rb_free_method_entry(const rb_method_entry_t *me)
 {
+#if USE_ZJIT
+    if (METHOD_ENTRY_CACHED(me)) {
+        rb_zjit_cme_free((const rb_callable_method_entry_t *)me);
+    }
+#endif
+
+#if USE_YJIT
+    // YJIT rb_yjit_root_mark() roots CMEs in `Invariants`,
+    // to remove from `Invariants` here.
+#endif
+
     rb_method_definition_release(me->def);
 }
 

--- a/zjit.h
+++ b/zjit.h
@@ -22,6 +22,7 @@ void rb_zjit_invalidate_no_ep_escape(const rb_iseq_t *iseq);
 void rb_zjit_constant_state_changed(ID id);
 void rb_zjit_iseq_mark(void *payload);
 void rb_zjit_iseq_update_references(void *payload);
+void rb_zjit_iseq_free(const rb_iseq_t *iseq);
 void rb_zjit_before_ractor_spawn(void);
 void rb_zjit_tracing_invalidate_all(void);
 #else

--- a/zjit.h
+++ b/zjit.h
@@ -18,6 +18,7 @@ void rb_zjit_profile_insn(uint32_t insn, rb_execution_context_t *ec);
 void rb_zjit_profile_enable(const rb_iseq_t *iseq);
 void rb_zjit_bop_redefined(int redefined_flag, enum ruby_basic_operators bop);
 void rb_zjit_cme_invalidate(const rb_callable_method_entry_t *cme);
+void rb_zjit_cme_free(const rb_callable_method_entry_t *cme);
 void rb_zjit_invalidate_no_ep_escape(const rb_iseq_t *iseq);
 void rb_zjit_constant_state_changed(ID id);
 void rb_zjit_iseq_mark(void *payload);

--- a/zjit/src/gc.rs
+++ b/zjit/src/gc.rs
@@ -139,6 +139,16 @@ pub extern "C" fn rb_zjit_iseq_free(iseq: IseqPtr) {
     invariants.forget_iseq(iseq);
 }
 
+/// GC callback for finalizing a CME
+#[unsafe(no_mangle)]
+pub extern "C" fn rb_zjit_cme_free(cme: *const rb_callable_method_entry_struct) {
+    if !ZJITState::has_instance() {
+        return;
+    }
+    let invariants = ZJITState::get_invariants();
+    invariants.forget_cme(cme);
+}
+
 /// GC callback for updating object references after all object moves
 #[unsafe(no_mangle)]
 pub extern "C" fn rb_zjit_root_update_references() {

--- a/zjit/src/gc.rs
+++ b/zjit/src/gc.rs
@@ -128,6 +128,17 @@ pub extern "C" fn rb_zjit_iseq_update_references(payload: *mut c_void) {
     with_time_stat(gc_time_ns, || iseq_update_references(payload));
 }
 
+/// GC callback for finalizing an ISEQ
+#[unsafe(no_mangle)]
+pub extern "C" fn rb_zjit_iseq_free(iseq: IseqPtr) {
+    if !ZJITState::has_instance() {
+        return;
+    }
+    // TODO(Shopify/ruby#682): Free `IseqPayload`
+    let invariants = ZJITState::get_invariants();
+    invariants.forget_iseq(iseq);
+}
+
 /// GC callback for updating object references after all object moves
 #[unsafe(no_mangle)]
 pub extern "C" fn rb_zjit_root_update_references() {

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::{HashMap, HashSet}, mem};
 
-use crate::{backend::lir::{asm_comment, Assembler}, cruby::{iseq_name, rb_callable_method_entry_t, rb_gc_location, ruby_basic_operators, src_loc, with_vm_lock, IseqPtr, RedefinitionFlag, ID, VALUE}, gc::IseqPayload, hir::Invariant, options::debug, state::{zjit_enabled_p, ZJITState}, virtualmem::CodePtr};
+use crate::{backend::lir::{asm_comment, Assembler}, cruby::{iseq_name, rb_callable_method_entry_t, rb_gc_location, ruby_basic_operators, src_loc, with_vm_lock, IseqPtr, RedefinitionFlag, ID}, gc::IseqPayload, hir::Invariant, options::debug, state::{zjit_enabled_p, ZJITState}, virtualmem::CodePtr};
 use crate::stats::with_time_stat;
 use crate::stats::Counter::invalidation_time_ns;
 use crate::gc::remove_gc_offsets;
@@ -70,38 +70,23 @@ impl Invariants {
 
     /// Update ISEQ references in Invariants::ep_escape_iseqs
     fn update_ep_escape_iseqs(&mut self) {
-        let mut moved: Vec<IseqPtr> = Vec::with_capacity(self.ep_escape_iseqs.len());
-
-        self.ep_escape_iseqs.retain(|&old_iseq| {
-            let new_iseq = unsafe { rb_gc_location(VALUE(old_iseq as usize)) }.0 as IseqPtr;
-            if old_iseq != new_iseq {
-                moved.push(new_iseq);
-            }
-            old_iseq == new_iseq
-        });
-
-        for new_iseq in moved {
-            self.ep_escape_iseqs.insert(new_iseq);
-        }
+        let updated = std::mem::take(&mut self.ep_escape_iseqs)
+            .into_iter()
+            .map(|iseq| unsafe { rb_gc_location(iseq.into()) }.as_iseq())
+            .collect();
+        self.ep_escape_iseqs = updated;
     }
 
     /// Update ISEQ references in Invariants::no_ep_escape_iseq_patch_points
     fn update_no_ep_escape_iseq_patch_points(&mut self) {
-        let mut moved: Vec<(IseqPtr, HashSet<PatchPoint>)> = Vec::with_capacity(self.no_ep_escape_iseq_patch_points.len());
-        let iseqs: Vec<IseqPtr> = self.no_ep_escape_iseq_patch_points.keys().cloned().collect();
-
-        for old_iseq in iseqs {
-            let new_iseq = unsafe { rb_gc_location(VALUE(old_iseq as usize)) }.0 as IseqPtr;
-            if old_iseq != new_iseq {
-                let patch_points = self.no_ep_escape_iseq_patch_points.remove(&old_iseq).unwrap();
-                // Do not insert patch points to no_ep_escape_iseq_patch_points yet to avoid corrupting keys that had a different ISEQ
-                moved.push((new_iseq, patch_points));
-            }
-        }
-
-        for (new_iseq, patch_points) in moved {
-            self.no_ep_escape_iseq_patch_points.insert(new_iseq, patch_points);
-        }
+        let updated = std::mem::take(&mut self.no_ep_escape_iseq_patch_points)
+            .into_iter()
+            .map(|(iseq, patch_points)| {
+                let new_iseq = unsafe { rb_gc_location(iseq.into()) };
+                (new_iseq.as_iseq(), patch_points)
+            })
+            .collect();
+        self.no_ep_escape_iseq_patch_points = updated;
     }
 }
 

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -66,6 +66,7 @@ impl Invariants {
     pub fn update_references(&mut self) {
         self.update_ep_escape_iseqs();
         self.update_no_ep_escape_iseq_patch_points();
+        self.update_cme_patch_points();
     }
 
     /// Forget an ISEQ when freeing it. We need to because a) if the address is reused, we'd be
@@ -98,6 +99,17 @@ impl Invariants {
             })
             .collect();
         self.no_ep_escape_iseq_patch_points = updated;
+    }
+
+    fn update_cme_patch_points(&mut self) {
+        let updated_cme_patch_points = std::mem::take(&mut self.cme_patch_points)
+            .into_iter()
+            .map(|(cme, patch_points)| {
+                let new_cme = unsafe { rb_gc_location(cme.into()) };
+                (new_cme.as_cme(), patch_points)
+            })
+            .collect();
+        self.cme_patch_points = updated_cme_patch_points;
     }
 }
 

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -80,6 +80,11 @@ impl Invariants {
         self.no_ep_escape_iseq_patch_points.remove(&iseq);
     }
 
+    /// Forget a CME when freeing it. See [Self::forget_iseq] for reasoning.
+    pub fn forget_cme(&mut self, cme: *const rb_callable_method_entry_t) {
+        self.cme_patch_points.remove(&cme);
+    }
+
     /// Update ISEQ references in Invariants::ep_escape_iseqs
     fn update_ep_escape_iseqs(&mut self) {
         let updated = std::mem::take(&mut self.ep_escape_iseqs)


### PR DESCRIPTION
* ## ZJIT: Remove dead CMEs from `Invariants`


* ## ZJIT: Actually call rb_zjit_root_update_references()

Previously unused.

* ## ZJIT: Reference update `Invariant::cme_patch_points`


* ## ZJIT: Forget about dead ISEQs in `Invariants`

Without this, we crash during reference update.

* ## ZJIT: Standardize to `Iterator::map` in `Invariants::update_references`

The old code was doing a manual HashSet/HashMap rebuild, and there isn't
a clear performance advantage over `Iterator::map`. So let's use `map`
since it looks clearer and it's easier to see that everything was indeed
updated. This also adds assertions the old code did not have by way
of as_iseq() and as_cme().