### PR TITLE
ZJIT: Add HIR for calling Cfunc with frame

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -153,7 +153,7 @@ class << RubyVM::ZJIT
     stats = self.stats
 
     # Show counters independent from exit_* or dynamic_send_*
-    print_counters_with_prefix(prefix: 'not_optimized_cfuncs_', prompt: 'unoptimized sends to C functions', buf:, stats:, limit: 20)
+    print_counters_with_prefix(prefix: 'not_inlined_cfuncs_', prompt: 'not inlined C methods', buf:, stats:, limit: 20)
 
     # Show fallback counters, ordered by the typical amount of fallbacks for the prefix at the time
     print_counters_with_prefix(prefix: 'unspecialized_def_type_', prompt: 'not optimized method types', buf:, stats:, limit: 20)

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -405,6 +405,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::GuardBlockParamProxy { level, state } => no_output!(gen_guard_block_param_proxy(jit, asm, level, &function.frame_state(state))),
         Insn::PatchPoint { invariant, state } => no_output!(gen_patch_point(jit, asm, invariant, &function.frame_state(*state))),
         Insn::CCall { cfun, args, name: _, return_type: _, elidable: _ } => gen_ccall(asm, *cfun, opnds!(args)),
+        Insn::CCallWithFrame { cfun, args, cme, name: _, state } => gen_ccall_with_frame(jit, asm, *cfun, opnds!(args), *cme, &function.frame_state(*state)),
         Insn::CCallVariadic { cfun, recv, args, name: _, cme, state } => {
             gen_ccall_variadic(jit, asm, *cfun, opnd!(recv), opnds!(args), *cme, &function.frame_state(*state))
         }
@@ -662,6 +663,41 @@ fn gen_patch_point(jit: &mut JITState, asm: &mut Assembler, invariant: &Invarian
             }
         }
     });
+}
+
+/// Generate code for a C function call that pushes a frame
+fn gen_ccall_with_frame(jit: &mut JITState, asm: &mut Assembler, cfun: *const u8, args: Vec<Opnd>, cme: *const rb_callable_method_entry_t, state: &FrameState) -> lir::Opnd {
+    gen_prepare_non_leaf_call(jit, asm, state);
+
+    gen_push_frame(asm, args.len(), state, ControlFrame {
+        recv: args[0],
+        iseq: None,
+        cme,
+        frame_type: VM_FRAME_MAGIC_CFUNC | VM_FRAME_FLAG_CFRAME | VM_ENV_FLAG_LOCAL,
+    });
+
+    asm_comment!(asm, "switch to new SP register");
+    let sp_offset = (state.stack().len() - args.len() + VM_ENV_DATA_SIZE.as_usize()) * SIZEOF_VALUE;
+    let new_sp = asm.add(SP, sp_offset.into());
+    asm.mov(SP, new_sp);
+
+    asm_comment!(asm, "switch to new CFP");
+    let new_cfp = asm.sub(CFP, RUBY_SIZEOF_CONTROL_FRAME.into());
+    asm.mov(CFP, new_cfp);
+    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
+
+    let result = asm.ccall(cfun, args);
+
+    asm_comment!(asm, "pop C frame");
+    let new_cfp = asm.add(CFP, RUBY_SIZEOF_CONTROL_FRAME.into());
+    asm.mov(CFP, new_cfp);
+    asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
+
+    asm_comment!(asm, "restore SP register for the caller");
+    let new_sp = asm.sub(SP, sp_offset.into());
+    asm.mov(SP, new_sp);
+
+    result
 }
 
 /// Lowering for [`Insn::CCall`]. This is a low-level raw call that doesn't know

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -404,12 +404,12 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::GuardBitEquals { val, expected, state } => gen_guard_bit_equals(jit, asm, opnd!(val), *expected, &function.frame_state(*state)),
         &Insn::GuardBlockParamProxy { level, state } => no_output!(gen_guard_block_param_proxy(jit, asm, level, &function.frame_state(state))),
         Insn::PatchPoint { invariant, state } => no_output!(gen_patch_point(jit, asm, invariant, &function.frame_state(*state))),
-        Insn::CCall { cfun, args, name: _, return_type: _, elidable: _ } => gen_ccall(asm, *cfun, opnds!(args)),
+        Insn::CCall { cfunc, args, name: _, return_type: _, elidable: _ } => gen_ccall(asm, *cfunc, opnds!(args)),
         Insn::CCallWithFrame { cd, state, args, .. } if args.len() + 1 > C_ARG_OPNDS.len() => // +1 for self
             gen_send_without_block(jit, asm, *cd, &function.frame_state(*state), SendFallbackReason::CCallWithFrameTooManyArgs),
-        Insn::CCallWithFrame { cfun, args, cme, state, .. } => gen_ccall_with_frame(jit, asm, *cfun, opnds!(args), *cme, &function.frame_state(*state)),
-        Insn::CCallVariadic { cfun, recv, args, name: _, cme, state } => {
-            gen_ccall_variadic(jit, asm, *cfun, opnd!(recv), opnds!(args), *cme, &function.frame_state(*state))
+        Insn::CCallWithFrame { cfunc, args, cme, state, .. } => gen_ccall_with_frame(jit, asm, *cfunc, opnds!(args), *cme, &function.frame_state(*state)),
+        Insn::CCallVariadic { cfunc, recv, args, name: _, cme, state } => {
+            gen_ccall_variadic(jit, asm, *cfunc, opnd!(recv), opnds!(args), *cme, &function.frame_state(*state))
         }
         Insn::GetIvar { self_val, id, state: _ } => gen_getivar(asm, opnd!(self_val), *id),
         Insn::SetGlobal { id, val, state } => no_output!(gen_setglobal(jit, asm, *id, opnd!(val), &function.frame_state(*state))),
@@ -668,7 +668,7 @@ fn gen_patch_point(jit: &mut JITState, asm: &mut Assembler, invariant: &Invarian
 }
 
 /// Generate code for a C function call that pushes a frame
-fn gen_ccall_with_frame(jit: &mut JITState, asm: &mut Assembler, cfun: *const u8, args: Vec<Opnd>, cme: *const rb_callable_method_entry_t, state: &FrameState) -> lir::Opnd {
+fn gen_ccall_with_frame(jit: &mut JITState, asm: &mut Assembler, cfunc: *const u8, args: Vec<Opnd>, cme: *const rb_callable_method_entry_t, state: &FrameState) -> lir::Opnd {
     gen_prepare_non_leaf_call(jit, asm, state);
 
     gen_push_frame(asm, args.len(), state, ControlFrame {
@@ -688,7 +688,7 @@ fn gen_ccall_with_frame(jit: &mut JITState, asm: &mut Assembler, cfun: *const u8
     asm.mov(CFP, new_cfp);
     asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
 
-    let result = asm.ccall(cfun, args);
+    let result = asm.ccall(cfunc, args);
 
     asm_comment!(asm, "pop C frame");
     let new_cfp = asm.add(CFP, RUBY_SIZEOF_CONTROL_FRAME.into());
@@ -704,9 +704,9 @@ fn gen_ccall_with_frame(jit: &mut JITState, asm: &mut Assembler, cfun: *const u8
 
 /// Lowering for [`Insn::CCall`]. This is a low-level raw call that doesn't know
 /// anything about the callee, so handling for e.g. GC safety is dealt with elsewhere.
-fn gen_ccall(asm: &mut Assembler, cfun: *const u8, args: Vec<Opnd>) -> lir::Opnd {
+fn gen_ccall(asm: &mut Assembler, cfunc: *const u8, args: Vec<Opnd>) -> lir::Opnd {
     gen_incr_counter(asm, Counter::inline_cfunc_optimized_send_count);
-    asm.ccall(cfun, args)
+    asm.ccall(cfunc, args)
 }
 
 /// Generate code for a variadic C function call
@@ -714,7 +714,7 @@ fn gen_ccall(asm: &mut Assembler, cfun: *const u8, args: Vec<Opnd>) -> lir::Opnd
 fn gen_ccall_variadic(
     jit: &mut JITState,
     asm: &mut Assembler,
-    cfun: *const u8,
+    cfunc: *const u8,
     recv: Opnd,
     args: Vec<Opnd>,
     cme: *const rb_callable_method_entry_t,
@@ -745,7 +745,7 @@ fn gen_ccall_variadic(
     asm.store(Opnd::mem(64, EC, RUBY_OFFSET_EC_CFP), CFP);
 
     let argv_ptr = gen_push_opnds(jit, asm, &args);
-    let result = asm.ccall(cfun, vec![args.len().into(), argv_ptr, recv]);
+    let result = asm.ccall(cfunc, vec![args.len().into(), argv_ptr, recv]);
     gen_pop_opnds(asm, &args);
 
     asm_comment!(asm, "pop C frame");

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -405,7 +405,9 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::GuardBlockParamProxy { level, state } => no_output!(gen_guard_block_param_proxy(jit, asm, level, &function.frame_state(state))),
         Insn::PatchPoint { invariant, state } => no_output!(gen_patch_point(jit, asm, invariant, &function.frame_state(*state))),
         Insn::CCall { cfun, args, name: _, return_type: _, elidable: _ } => gen_ccall(asm, *cfun, opnds!(args)),
-        Insn::CCallWithFrame { cfun, args, cme, name: _, state } => gen_ccall_with_frame(jit, asm, *cfun, opnds!(args), *cme, &function.frame_state(*state)),
+        Insn::CCallWithFrame { cd, state, args, .. } if args.len() + 1 > C_ARG_OPNDS.len() => // +1 for self
+            gen_send_without_block(jit, asm, *cd, &function.frame_state(*state), SendFallbackReason::CCallWithFrameTooManyArgs),
+        Insn::CCallWithFrame { cfun, args, cme, state, .. } => gen_ccall_with_frame(jit, asm, *cfun, opnds!(args), *cme, &function.frame_state(*state)),
         Insn::CCallVariadic { cfun, recv, args, name: _, cme, state } => {
             gen_ccall_variadic(jit, asm, *cfun, opnd!(recv), opnds!(args), *cme, &function.frame_state(*state))
         }

--- a/zjit/src/state.rs
+++ b/zjit/src/state.rs
@@ -51,8 +51,8 @@ pub struct ZJITState {
     /// Trampoline to call function_stub_hit
     function_stub_hit_trampoline: CodePtr,
 
-    /// Counter pointers for unoptimized C functions
-    unoptimized_cfunc_counter_pointers: HashMap<String, Box<u64>>,
+    /// Counter pointers for full frame C functions
+    full_frame_cfunc_counter_pointers: HashMap<String, Box<u64>>,
 
     /// Locations of side exists within generated code
     exit_locations: Option<SideExitLocations>,
@@ -97,7 +97,7 @@ impl ZJITState {
             exit_trampoline,
             function_stub_hit_trampoline,
             exit_trampoline_with_counter: exit_trampoline,
-            unoptimized_cfunc_counter_pointers: HashMap::new(),
+            full_frame_cfunc_counter_pointers: HashMap::new(),
             exit_locations,
         };
         unsafe { ZJIT_STATE = Some(zjit_state); }
@@ -162,9 +162,9 @@ impl ZJITState {
         &mut ZJITState::get_instance().send_fallback_counters
     }
 
-    /// Get a mutable reference to unoptimized cfunc counter pointers
-    pub fn get_unoptimized_cfunc_counter_pointers() -> &'static mut HashMap<String, Box<u64>> {
-        &mut ZJITState::get_instance().unoptimized_cfunc_counter_pointers
+    /// Get a mutable reference to full frame cfunc counter pointers
+    pub fn get_not_inlined_cfunc_counter_pointers() -> &'static mut HashMap<String, Box<u64>> {
+        &mut ZJITState::get_instance().full_frame_cfunc_counter_pointers
     }
 
     /// Was --zjit-save-compiled-iseqs specified?

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -148,6 +148,7 @@ make_counters! {
         send_fallback_send_without_block_cfunc_array_variadic,
         send_fallback_send_without_block_not_optimized_method_type,
         send_fallback_send_without_block_direct_too_many_args,
+        send_fallback_ccall_with_frame_too_many_args,
         send_fallback_obj_to_string_not_string,
         send_fallback_not_optimized_instruction,
     }
@@ -318,6 +319,7 @@ pub fn send_fallback_counter(reason: crate::hir::SendFallbackReason) -> Counter 
         SendWithoutBlockCfuncArrayVariadic        => send_fallback_send_without_block_cfunc_array_variadic,
         SendWithoutBlockNotOptimizedMethodType(_) => send_fallback_send_without_block_not_optimized_method_type,
         SendWithoutBlockDirectTooManyArgs         => send_fallback_send_without_block_direct_too_many_args,
+        CCallWithFrameTooManyArgs                 => send_fallback_ccall_with_frame_too_many_args,
         ObjToStringNotString                      => send_fallback_obj_to_string_not_string,
         NotOptimizedInstruction(_)                => send_fallback_not_optimized_instruction,
     }

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -470,10 +470,10 @@ pub extern "C" fn rb_zjit_stats(_ec: EcPtr, _self: VALUE, target_key: VALUE) -> 
         set_stat_f64!(hash, "ratio_in_zjit", 100.0 * zjit_insn_count as f64 / total_insn_count as f64);
     }
 
-    // Set unoptimized cfunc counters
-    let unoptimized_cfuncs = ZJITState::get_unoptimized_cfunc_counter_pointers();
-    for (signature, counter) in unoptimized_cfuncs.iter() {
-        let key_string = format!("not_optimized_cfuncs_{}", signature);
+    // Set not inlined cfunc counters
+    let not_inlined_cfuncs = ZJITState::get_not_inlined_cfunc_counter_pointers();
+    for (signature, counter) in not_inlined_cfuncs.iter() {
+        let key_string = format!("not_inlined_cfuncs_{}", signature);
         set_stat_usize!(hash, &key_string, **counter);
     }
 


### PR DESCRIPTION
 Major changes to `activerecord`:

  | Metric                 | Before            | After             | Change                     |
  |------------------------|-------------------|-------------------|----------------------------|
  | Dynamic Send Count     | 48,528,405        | 41,309,323        | -14.9% reduction           |
  | Guard Type Failures    | 5,185,117 (18.0%) | 6,246,106 (20.9%) | +20.5% increase            |
  | VM Write PC Count      | 80,727,948        | 78,078,612        | -3.3% reduction            |
  | ZJIT Instruction Ratio | 60.0%             | 59.0%             | -1.0% decrease             |
  | Side Exit Count        | 28,826,722        | 29,888,003        | +3.7% increase             |
  | Code Region Bytes      | 5,865,472         | 6,029,312         | +2.8% increase             |

This PR adds `CCallWithFrame` HIR to optimize simple cfuncs that are NOT annotated as `leaf` and `no_gc`. So it covers most of the calls currently fall under `unoptimized sends to C functions`. Therefore, this PR also renames that stat to `full frame C function calls` as they can still be optimized with other approaches.

**Before**

```
RSS: 94.0MiB
MAXRSS: 96.7MiB
Writing file /Users/hung-wulo/src/github.com/Shopify/ruby-bench/data/results-ruby-3.5.0-2025-09-29-211504.json
Average of last 10, non-warmup iters: 403ms
***ZJIT: Printing ZJIT statistics on exit***
Top-5 dynamic send types (100.0% of total 48,528,405):
  send_without_block: 32,175,141 (66.3%)
         invokesuper:  7,631,172 (15.7%)
                send:  7,476,408 (15.4%)
         invokeblock:  1,168,574 ( 2.4%)
        send_forward:     77,110 ( 0.2%)
Top-7 send fallback unspecialized def_types (100.0% of total 13,106,939):
      cfunc: 5,553,554 (42.4%)
       iseq: 4,581,123 (35.0%)
    bmethod: 2,875,890 (21.9%)
  optimized:    55,083 ( 0.4%)
      alias:    33,130 ( 0.3%)
    attrset:     8,146 ( 0.1%)
       null:        13 ( 0.0%)
Top-2 dynamic send types (100.0% of total 5,434,194):
  polymorphic: 3,115,659 (57.3%)
  no_profiles: 2,318,535 (42.7%)
Top-20 unoptimized sends to C functions (97.0% of total 5,631,422):
                        Kernel#is_a?: 2,229,046 (39.6%)
                     String#include?:   535,668 ( 9.5%)
            SQLite3::Statement#done?:   531,831 ( 9.4%)
             SQLite3::Statement#step:   531,831 ( 9.4%)
                           Hash#key?:   508,691 ( 9.0%)
                     Kernel#kind_of?:   503,973 ( 8.9%)
                       Class#current:   112,556 ( 2.0%)
                 Kernel#block_given?:    59,702 ( 1.1%)
                         Integer#<=>:    58,471 ( 1.0%)
                       Range#member?:    56,471 ( 1.0%)
                      BasicObject#!=:    44,045 ( 0.8%)
                        NilClass#===:    40,130 ( 0.7%)
                      FalseClass#===:    40,123 ( 0.7%)
       SQLite3::Statement#bind_param:    40,123 ( 0.7%)
                       TrueClass#===:    40,123 ( 0.7%)
                       Hash#include?:    30,924 ( 0.5%)
                          Kernel#dup:    29,254 ( 0.5%)
             Set#compare_by_identity:    25,171 ( 0.4%)
                      Class#allocate:    25,071 ( 0.4%)
                         String#hash:    18,555 ( 0.3%)
Top-9 unhandled YARV insns (100.0% of total 114,513):
        checkkeyword: 107,020 (93.5%)
             splatkw:   3,945 ( 3.4%)
    getclassvariable:   1,694 ( 1.5%)
         expandarray:   1,444 ( 1.3%)
       getblockparam:     168 ( 0.1%)
         getconstant:     131 ( 0.1%)
  invokesuperforward:      71 ( 0.1%)
                once:      27 ( 0.0%)
          checkmatch:      13 ( 0.0%)
Top-3 compile error reasons (100.0% of total 6,250,661):
  register_spill_on_alloc: 6,241,742 (99.9%)
  register_spill_on_ccall:     6,049 ( 0.1%)
        exception_handler:     2,870 ( 0.0%)
Top-13 side exit reasons (100.0% of total 28,826,722):
                  guard_shape_failure: 12,431,368 (43.1%)
                        compile_error:  6,250,661 (21.7%)
                   guard_type_failure:  5,185,117 (18.0%)
  block_param_proxy_not_iseq_or_ifunc:  4,209,470 (14.6%)
                      unhandled_kwarg:    579,501 ( 2.0%)
                  unhandled_yarv_insn:    114,513 ( 0.4%)
           block_param_proxy_modified:     26,894 ( 0.1%)
                   unhandled_hir_insn:     15,290 ( 0.1%)
                           patchpoint:      7,985 ( 0.0%)
                      unhandled_splat:      5,273 ( 0.0%)
               obj_to_string_fallback:        421 ( 0.0%)
                unknown_newarray_send:        228 ( 0.0%)
                            interrupt:          1 ( 0.0%)
dynamic_send_count:                   48,528,405
compiled_iseq_count:                  1,413
failed_iseq_count:                    101
compile_time:                         2,347ms
profile_time:                         13ms
gc_time:                              7ms
invalidation_time:                    1ms
vm_write_pc_count:                    80,727,948
vm_write_sp_count:                    79,545,094
vm_write_locals_count:                79,545,094
vm_write_stack_count:                 79,545,094
vm_write_to_parent_iseq_local_count:  67,116
vm_read_from_parent_iseq_local_count: 5,388,980
code_region_bytes:                    5,865,472
side_exit_count:                      28,826,722
total_insn_count:                     809,672,315
vm_insn_count:                        323,622,436
zjit_insn_count:                      486,049,879
ratio_in_zjit:                        60.0%
```

**After**

```
RSS: 94.9MiB
MAXRSS: 97.9MiB
Writing file /Users/hung-wulo/src/github.com/Shopify/ruby-bench/data/results-ruby-3.5.0-2025-09-29-211112.json
Average of last 10, non-warmup iters: 386ms
***ZJIT: Printing ZJIT statistics on exit***
Top-5 dynamic send types (100.0% of total 41,309,323):
  send_without_block: 25,489,598 (61.7%)
                send:  7,476,386 (18.1%)
         invokesuper:  7,097,655 (17.2%)
         invokeblock:  1,168,574 ( 2.8%)
        send_forward:     77,110 ( 0.2%)
Top-7 send fallback unspecialized def_types (100.0% of total 7,553,535):
       iseq: 4,581,123 (60.6%)
    bmethod: 2,875,890 (38.1%)
  optimized:    55,083 ( 0.7%)
      alias:    33,130 ( 0.4%)
    attrset:     8,146 ( 0.1%)
      cfunc:       150 ( 0.0%)
       null:        13 ( 0.0%)
Top-2 dynamic send types (100.0% of total 4,379,923):
  polymorphic: 3,115,596 (71.1%)
  no_profiles: 1,264,327 (28.9%)
Top-20 full frame C function calls (96.3% of total 4,569,705):
                        Kernel#is_a?: 1,168,155 (25.6%)
                     String#include?:   535,668 (11.7%)
             SQLite3::Statement#step:   531,831 (11.6%)
            SQLite3::Statement#done?:   531,831 (11.6%)
                           Hash#key?:   508,691 (11.1%)
                     Kernel#kind_of?:   503,973 (11.0%)
                       Class#current:   112,556 ( 2.5%)
                 Kernel#block_given?:    59,702 ( 1.3%)
                         Integer#<=>:    58,471 ( 1.3%)
                       Range#member?:    56,471 ( 1.2%)
                      BasicObject#!=:    44,045 ( 1.0%)
                        NilClass#===:    40,130 ( 0.9%)
                       TrueClass#===:    40,123 ( 0.9%)
                      FalseClass#===:    40,123 ( 0.9%)
       SQLite3::Statement#bind_param:    40,123 ( 0.9%)
                       Hash#include?:    30,924 ( 0.7%)
                          Kernel#dup:    28,955 ( 0.6%)
             Set#compare_by_identity:    25,171 ( 0.6%)
                      Class#allocate:    25,071 ( 0.5%)
                         String#hash:    18,555 ( 0.4%)
Top-9 unhandled YARV insns (100.0% of total 114,513):
        checkkeyword: 107,020 (93.5%)
             splatkw:   3,945 ( 3.4%)
    getclassvariable:   1,694 ( 1.5%)
         expandarray:   1,444 ( 1.3%)
       getblockparam:     168 ( 0.1%)
         getconstant:     131 ( 0.1%)
  invokesuperforward:      71 ( 0.1%)
                once:      27 ( 0.0%)
          checkmatch:      13 ( 0.0%)
Top-3 compile error reasons (100.0% of total 6,250,661):
  register_spill_on_alloc: 6,241,742 (99.9%)
  register_spill_on_ccall:     6,049 ( 0.1%)
        exception_handler:     2,870 ( 0.0%)
Top-13 side exit reasons (100.0% of total 29,888,003):
                  guard_shape_failure: 12,431,378 (41.6%)
                        compile_error:  6,250,661 (20.9%)
                   guard_type_failure:  6,246,106 (20.9%)
  block_param_proxy_not_iseq_or_ifunc:  4,209,470 (14.1%)
                      unhandled_kwarg:    579,485 ( 1.9%)
                  unhandled_yarv_insn:    114,513 ( 0.4%)
           block_param_proxy_modified:     26,894 ( 0.1%)
                   unhandled_hir_insn:     15,290 ( 0.1%)
                           patchpoint:      8,284 ( 0.0%)
                      unhandled_splat:      5,273 ( 0.0%)
               obj_to_string_fallback:        420 ( 0.0%)
                unknown_newarray_send:        228 ( 0.0%)
                            interrupt:          1 ( 0.0%)
dynamic_send_count:                   41,309,323
compiled_iseq_count:                  1,414
failed_iseq_count:                    101
compile_time:                         2,391ms
profile_time:                         12ms
gc_time:                              7ms
invalidation_time:                    1ms
vm_write_pc_count:                    78,078,612
vm_write_sp_count:                    76,895,759
vm_write_locals_count:                76,895,759
vm_write_stack_count:                 76,895,759
vm_write_to_parent_iseq_local_count:  67,116
vm_read_from_parent_iseq_local_count: 5,388,980
code_region_bytes:                    6,029,312
side_exit_count:                      29,888,003
total_insn_count:                     810,734,004
vm_insn_count:                        332,625,037
zjit_insn_count:                      478,108,967
ratio_in_zjit:                        59.0%
```