### PR TITLE
Add NODE ENSURE locations

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -834,6 +834,11 @@ node_locations(VALUE ast_value, const NODE *node)
         return rb_ary_new_from_args(2,
                                     location_new(nd_code_loc(node)),
                                     location_new(&RNODE_DOT3(node)->operator_loc));
+      case NODE_ENSURE:
+        return rb_ary_new_from_args(3,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_ENSURE(node)->ensure_keyword_loc),
+                                    location_new(&RNODE_ENSURE(node)->end_keyword_loc));
       case NODE_EVSTR:
         return rb_ary_new_from_args(3,
                                     location_new(nd_code_loc(node)),

--- a/node_dump.c
+++ b/node_dump.c
@@ -439,8 +439,10 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
         ANN("format: begin; [nd_head]; ensure; [nd_ensr]; end");
         ANN("example: begin; foo; ensure; bar; end");
         F_NODE(nd_head, RNODE_ENSURE, "body");
-        LAST_NODE;
         F_NODE(nd_ensr, RNODE_ENSURE, "ensure clause");
+        F_LOC(ensure_keyword_loc, RNODE_ENSURE);
+        LAST_NODE;
+        F_LOC(end_keyword_loc, RNODE_ENSURE);
         return;
 
       case NODE_AND:

--- a/parse.y
+++ b/parse.y
@@ -315,6 +315,7 @@ struct lex_context {
     unsigned int in_def: 1;
     unsigned int in_class: 1;
     unsigned int has_trailing_semicolon: 1;
+    YYLTYPE ensure_keyword_loc;
     BITFIELD(enum rb_parser_shareability, shareable_constant_value, 2);
     BITFIELD(enum rescue_context, in_rescue, 2);
     unsigned int cant_return: 1;
@@ -1080,7 +1081,7 @@ static rb_node_retry_t *rb_node_retry_new(struct parser_params *p, const YYLTYPE
 static rb_node_begin_t *rb_node_begin_new(struct parser_params *p, NODE *nd_body, const YYLTYPE *loc);
 static rb_node_rescue_t *rb_node_rescue_new(struct parser_params *p, NODE *nd_head, NODE *nd_resq, NODE *nd_else, const YYLTYPE *loc);
 static rb_node_resbody_t *rb_node_resbody_new(struct parser_params *p, NODE *nd_args, NODE *nd_exc_var, NODE *nd_body, NODE *nd_next, const YYLTYPE *loc);
-static rb_node_ensure_t *rb_node_ensure_new(struct parser_params *p, NODE *nd_head, NODE *nd_ensr, const YYLTYPE *loc);
+static rb_node_ensure_t *rb_node_ensure_new(struct parser_params *p, NODE *nd_head, NODE *nd_ensr, const YYLTYPE *loc, const YYLTYPE *ensure_keyword_loc, const YYLTYPE *end_keyword_loc);
 static rb_node_and_t *rb_node_and_new(struct parser_params *p, NODE *nd_1st, NODE *nd_2nd, const YYLTYPE *loc, const YYLTYPE *operator_loc);
 static rb_node_or_t *rb_node_or_new(struct parser_params *p, NODE *nd_1st, NODE *nd_2nd, const YYLTYPE *loc, const YYLTYPE *operator_loc);
 static rb_node_masgn_t *rb_node_masgn_new(struct parser_params *p, NODE *nd_head, NODE *nd_args, const YYLTYPE *loc);
@@ -1188,7 +1189,7 @@ static rb_node_error_t *rb_node_error_new(struct parser_params *p, const YYLTYPE
 #define NEW_BEGIN(b,loc) (NODE *)rb_node_begin_new(p,b,loc)
 #define NEW_RESCUE(b,res,e,loc) (NODE *)rb_node_rescue_new(p,b,res,e,loc)
 #define NEW_RESBODY(a,v,ex,n,loc) (NODE *)rb_node_resbody_new(p,a,v,ex,n,loc)
-#define NEW_ENSURE(b,en,loc) (NODE *)rb_node_ensure_new(p,b,en,loc)
+#define NEW_ENSURE(b,en,loc,ens_loc,end_loc) (NODE *)rb_node_ensure_new(p,b,en,loc,ens_loc,end_loc)
 #define NEW_AND(f,s,loc,op_loc) (NODE *)rb_node_and_new(p,f,s,loc,op_loc)
 #define NEW_OR(f,s,loc,op_loc) (NODE *)rb_node_or_new(p,f,s,loc,op_loc)
 #define NEW_MASGN(l,r,loc)   rb_node_masgn_new(p,l,r,loc)
@@ -4374,6 +4375,9 @@ primary		: inline_primary
               k_end
                 {
                     CMDARG_POP();
+                    if ($3 && nd_type_p($3, NODE_ENSURE)) {
+                        RNODE_ENSURE($3)->end_keyword_loc = @k_end;
+                    }
                     set_line_body($3, @1.end_pos.lineno);
                     $$ = NEW_BEGIN($3, &@$);
                     nd_set_line($$, @1.end_pos.lineno);
@@ -4816,6 +4820,7 @@ k_ensure	: keyword_ensure
                     {
                         token_info_warn(p, "ensure", p->token_info, 1, &@$);
                         $$ = p->ctxt;
+                        p->ctxt.ensure_keyword_loc = @keyword_ensure;
                     }
                 ;
 
@@ -11366,11 +11371,13 @@ rb_node_resbody_new(struct parser_params *p, NODE *nd_args, NODE *nd_exc_var, NO
 }
 
 static rb_node_ensure_t *
-rb_node_ensure_new(struct parser_params *p, NODE *nd_head, NODE *nd_ensr, const YYLTYPE *loc)
+rb_node_ensure_new(struct parser_params *p, NODE *nd_head, NODE *nd_ensr, const YYLTYPE *loc, const YYLTYPE *ensure_keyword_loc, const YYLTYPE *end_keyword_loc)
 {
     rb_node_ensure_t *n = NODE_NEWNODE(NODE_ENSURE, rb_node_ensure_t, loc);
     n->nd_head = nd_head;
     n->nd_ensr = nd_ensr;
+    n->ensure_keyword_loc = *ensure_keyword_loc;
+    n->end_keyword_loc = *end_keyword_loc;
 
     return n;
 }
@@ -14831,7 +14838,7 @@ new_bodystmt(struct parser_params *p, NODE *head, NODE *rescue, NODE *rescue_els
         nd_set_line(result, rescue->nd_loc.beg_pos.lineno);
     }
     if (ensure) {
-        result = NEW_ENSURE(result, ensure, loc);
+        result = NEW_ENSURE(result, ensure, loc, &p->ctxt.ensure_keyword_loc, &NULL_LOC);
     }
     fixpos(result, head);
     return result;

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -404,6 +404,8 @@ typedef struct RNode_ENSURE {
 
     struct RNode *nd_head;
     struct RNode *nd_ensr;
+    rb_code_location_t ensure_keyword_loc;
+    rb_code_location_t end_keyword_loc;
 } rb_node_ensure_t;
 
 typedef struct {

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1734,6 +1734,14 @@ dummy
       assert_locations(node.children[-1].children[-1].children[-1].locations, [[1, 9, 1, 20], [1, 9, 1, 14], [1, 14, 1, 15], [1, 19, 1, 20]])
     end
 
+    def test_ensure_locations
+      node = ast_parse("begin; ensure; end")
+      assert_locations(node.children[-1].locations, [[1, 5, 1, 14], [1, 7, 1, 13], [1, 15, 1, 18]])
+
+      node = ast_parse("begin; foo; ensure; bar; end")
+      assert_locations(node.children[-1].locations, [[1, 5, 1, 24], [1, 12, 1, 18], [1, 25, 1, 28]])
+    end
+
     private
     def ast_parse(src, **options)
       begin


### PR DESCRIPTION
memo:
```bash
> ruby -e 'begin; ensure; end' --parser=prism --dump=parsetree
@ ProgramNode (location: (1,0)-(1,18))
+-- locals: []
+-- statements:
    @ StatementsNode (location: (1,0)-(1,18))
    +-- body: (length: 1)
        +-- @ BeginNode (location: (1,0)-(1,18))
            +-- begin_keyword_loc: (1,0)-(1,5) = "begin"
            +-- statements: nil
            +-- rescue_clause: nil
            +-- else_clause: nil
            +-- ensure_clause:
            |   @ EnsureNode (location: (1,7)-(1,18))
            |   +-- ensure_keyword_loc: (1,7)-(1,13) = "ensure"
            |   +-- statements: nil
            |   +-- end_keyword_loc: (1,15)-(1,18) = "end"
            +-- end_keyword_loc: (1,15)-(1,18) = "end"
```