### PR TITLE
CI: Fail the dump crash log step for visual reminder

### DIFF
--- a/.github/workflows/yjit-macos.yml
+++ b/.github/workflows/yjit-macos.yml
@@ -169,9 +169,12 @@ jobs:
         if: ${{ matrix.test_task == 'check' && matrix.skipped_tests }}
         continue-on-error: ${{ matrix.continue-on-skipped_tests || false }}
 
-      - if: ${{ failure() }}
+      - name: Dump crash logs
+        if: ${{ failure() }}
         continue-on-error: true
-        run: tail --verbose --lines=+1 rb_crash_*.txt
+        run: |
+          tail --verbose --lines=+1 rb_crash_*.txt
+          exit 1
 
       - uses: ./.github/actions/slack
         with:

--- a/.github/workflows/yjit-ubuntu.yml
+++ b/.github/workflows/yjit-ubuntu.yml
@@ -214,7 +214,9 @@ jobs:
       - name: Dump crash logs
         if: ${{ failure() }}
         continue-on-error: true
-        run: tail --verbose --lines=+1 rb_crash_*.txt
+        run: |
+          tail --verbose --lines=+1 rb_crash_*.txt
+          exit 1
 
       - uses: ./.github/actions/slack
         with:

--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -136,7 +136,9 @@ jobs:
       - name: Dump crash logs
         if: ${{ failure() }}
         continue-on-error: true
-        run: tail --verbose --lines=+1 rb_crash_*.txt
+        run: |
+          tail --verbose --lines=+1 rb_crash_*.txt
+          exit 1
 
       - uses: ./.github/actions/slack
         with:

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -178,7 +178,9 @@ jobs:
       - name: Dump crash logs
         if: ${{ failure() }}
         continue-on-error: true
-        run: tail --verbose --lines=+1 rb_crash_*.txt
+        run: |
+          tail --verbose --lines=+1 rb_crash_*.txt
+          exit 1
 
       - uses: ./.github/actions/slack
         with:


### PR DESCRIPTION
I forgot that this step existed and thought crash reporting wasn't
working when they were simply moved to a different step. Failing these
should give a nice visual hint.
