### PR TITLE
ZJIT: Re-apply attr_writer inlining

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -1642,7 +1642,7 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 2, insns: [:opt_send_without_block]
   end
 
-  def test_attr_accessor
+  def test_attr_accessor_getivar
     assert_compiles '[4, 4]', %q{
       class C
         attr_accessor :foo
@@ -1653,6 +1653,47 @@ class TestZJIT < Test::Unit::TestCase
       end
 
       def test(c) = c.foo
+      c = C.new
+      [test(c), test(c)]
+    }, call_threshold: 2, insns: [:opt_send_without_block]
+  end
+
+  def test_attr_accessor_setivar
+    assert_compiles '[5, 5]', %q{
+      class C
+        attr_accessor :foo
+
+        def initialize
+          @foo = 4
+        end
+      end
+
+      def test(c)
+        c.foo = 5
+        c.foo
+      end
+
+      c = C.new
+      [test(c), test(c)]
+    }, call_threshold: 2, insns: [:opt_send_without_block]
+  end
+
+  def test_attr_writer
+    assert_compiles '[5, 5]', %q{
+      class C
+        attr_writer :foo
+
+        def initialize
+          @foo = 4
+        end
+
+        def get_foo = @foo
+      end
+
+      def test(c)
+        c.foo = 5
+        c.get_foo
+      end
       c = C.new
       [test(c), test(c)]
     }, call_threshold: 2, insns: [:opt_send_without_block]

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1986,7 +1986,7 @@ impl Function {
                             }
                             let getivar = self.push_insn(block, Insn::GetIvar { self_val: recv, id, state });
                             self.make_equal_to(insn_id, getivar);
-                        } else if let (VM_METHOD_TYPE_ATTRSET, [setter_rhs]) = (def_type, args.as_slice()) {
+                        } else if let (VM_METHOD_TYPE_ATTRSET, [val]) = (def_type, args.as_slice()) {
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                             if let Some(profiled_type) = profiled_type {
                                 recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });
@@ -2001,7 +2001,6 @@ impl Function {
                                     self.push_insn(block, Insn::PatchPoint { invariant: Invariant::SingleRactorMode, state });
                                 }
                             }
-                            let val = args[0];
                             self.push_insn(block, Insn::SetIvar { self_val: recv, id, val, state });
                             self.make_equal_to(insn_id, val);
                         } else {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1986,7 +1986,7 @@ impl Function {
                             }
                             let getivar = self.push_insn(block, Insn::GetIvar { self_val: recv, id, state });
                             self.make_equal_to(insn_id, getivar);
-                        } else if def_type == VM_METHOD_TYPE_ATTRSET && args.len() == 1 {
+                        } else if let (VM_METHOD_TYPE_ATTRSET, [setter_rhs]) = (def_type, args.as_slice()) {
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                             if let Some(profiled_type) = profiled_type {
                                 recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1986,7 +1986,7 @@ impl Function {
                             }
                             let getivar = self.push_insn(block, Insn::GetIvar { self_val: recv, id, state });
                             self.make_equal_to(insn_id, getivar);
-                        } else if let (VM_METHOD_TYPE_ATTRSET, [val]) = (def_type, args.as_slice()) {
+                        } else if let (VM_METHOD_TYPE_ATTRSET, &[val]) = (def_type, args.as_slice()) {
                             self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
                             if let Some(profiled_type) = profiled_type {
                                 recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1986,6 +1986,24 @@ impl Function {
                             }
                             let getivar = self.push_insn(block, Insn::GetIvar { self_val: recv, id, state });
                             self.make_equal_to(insn_id, getivar);
+                        } else if def_type == VM_METHOD_TYPE_ATTRSET && args.len() == 1 {
+                            self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
+                            if let Some(profiled_type) = profiled_type {
+                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });
+                            }
+                            let id = unsafe { get_cme_def_body_attr_id(cme) };
+
+                            // Check if we're accessing ivars of a Class or Module object as they require single-ractor mode.
+                            // We omit gen_prepare_non_leaf_call on gen_setivar, so it's unsafe to raise for multi-ractor mode.
+                            if unsafe { rb_zjit_singleton_class_p(klass) } {
+                                let attached = unsafe { rb_class_attached_object(klass) };
+                                if unsafe { RB_TYPE_P(attached, RUBY_T_CLASS) || RB_TYPE_P(attached, RUBY_T_MODULE) } {
+                                    self.push_insn(block, Insn::PatchPoint { invariant: Invariant::SingleRactorMode, state });
+                                }
+                            }
+                            let val = args[0];
+                            self.push_insn(block, Insn::SetIvar { self_val: recv, id, val, state });
+                            self.make_equal_to(insn_id, val);
                         } else {
                             if let Insn::SendWithoutBlock { def_type: insn_def_type, .. } = &mut self.insns[insn_id.0] {
                                 *insn_def_type = Some(MethodType::from(def_type));
@@ -12131,6 +12149,68 @@ mod opt_tests {
           v25:NilClass = Const Value(nil)
           CheckInterrupts
           Return v25
+        ");
+    }
+
+    #[test]
+    fn test_inline_attr_accessor_set() {
+        eval("
+            class C
+              attr_accessor :foo
+            end
+
+            def test(o) = o.foo = 5
+            test C.new
+            test C.new
+        ");
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:6:
+        bb0():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:BasicObject = GetLocal l0, SP@4
+          Jump bb2(v1, v2)
+        bb1(v5:BasicObject, v6:BasicObject):
+          EntryPoint JIT(0)
+          Jump bb2(v5, v6)
+        bb2(v8:BasicObject, v9:BasicObject):
+          v14:Fixnum[5] = Const Value(5)
+          PatchPoint MethodRedefined(C@0x1000, foo=@0x1008, cme:0x1010)
+          v23:HeapObject[class_exact:C] = GuardType v9, HeapObject[class_exact:C]
+          SetIvar v23, :@foo, v14
+          CheckInterrupts
+          Return v14
+        ");
+    }
+
+    #[test]
+    fn test_inline_attr_writer_set() {
+        eval("
+            class C
+              attr_writer :foo
+            end
+
+            def test(o) = o.foo = 5
+            test C.new
+            test C.new
+        ");
+        assert_snapshot!(hir_string("test"), @r"
+        fn test@<compiled>:6:
+        bb0():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:BasicObject = GetLocal l0, SP@4
+          Jump bb2(v1, v2)
+        bb1(v5:BasicObject, v6:BasicObject):
+          EntryPoint JIT(0)
+          Jump bb2(v5, v6)
+        bb2(v8:BasicObject, v9:BasicObject):
+          v14:Fixnum[5] = Const Value(5)
+          PatchPoint MethodRedefined(C@0x1000, foo=@0x1008, cme:0x1010)
+          v23:HeapObject[class_exact:C] = GuardType v9, HeapObject[class_exact:C]
+          SetIvar v23, :@foo, v14
+          CheckInterrupts
+          Return v14
         ");
     }
 }


### PR DESCRIPTION
This re-applies https://github.com/ruby/ruby/pull/14629 / 40bb47665d3ff57e0f2eb5a9fd9e0109617015c9 by reverting https://github.com/ruby/ruby/pull/14673 /  d4393772b89dab4f33c118a284d92dc80cd63c39.
