### PR TITLE
ZJIT: Fix "malformed format string" on stats

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -221,8 +221,8 @@ class << RubyVM::ZJIT
     return if stats.empty?
 
     counters.transform_keys! { |key| key.to_s.delete_prefix(prefix) }
-    left_pad = counters.keys.map(&:size).max
-    right_pad = counters.values.map { |value| number_with_delimiter(value).size }.max
+    key_pad = counters.keys.map(&:size).max
+    value_pad = counters.values.map { |value| number_with_delimiter(value).size }.max
     total = counters.values.sum
 
     counters = counters.to_a
@@ -234,9 +234,7 @@ class << RubyVM::ZJIT
     buf << " (%.1f%% of total #{number_with_delimiter(total)})" % (100.0 * counters.map(&:last).sum / total) if limit
     buf << ":\n"
     counters.each do |key, value|
-      padded_key = key.rjust(left_pad, ' ')
-      padded_value = number_with_delimiter(value).rjust(right_pad, ' ')
-      buf << "  #{padded_key}: #{padded_value} #{'(%4.1f%%)' % (100.0 * value / total)}\n"
+      buf << "  %*s: %*s (%4.1f%%)\n" % [key_pad, key, value_pad, number_with_delimiter(value), (100.0 * value / total)]
     end
   end
 


### PR DESCRIPTION
Follow-up on https://github.com/ruby/ruby/pull/14638

The modified line fails when `padded_key` is `String#%` for not-optimized C func stats, which fails several headline benchmarks with `--zjit-stats`. This PR changes it to not include `padded_key` as part of the format string.