### PR TITLE
load.c: Fix dest and src of MEMMOVE

### DIFF
--- a/load.c
+++ b/load.c
@@ -268,7 +268,7 @@ features_index_add_single_callback(st_data_t *key, st_data_t *value, st_data_t r
             if (pos >= 0) {
                 long *ptr = rb_darray_data_ptr(feature_indexes);
                 long len = rb_darray_size(feature_indexes);
-                MEMMOVE(ptr + pos, ptr + pos + 1, long, len - pos - 1);
+                MEMMOVE(ptr + pos + 1, ptr + pos, long, len - pos - 1);
                 ptr[pos] = FIX2LONG(offset);
             }
         }

--- a/test/ruby/test_require.rb
+++ b/test/ruby/test_require.rb
@@ -1035,4 +1035,18 @@ class TestRequire < Test::Unit::TestCase
       end
     RUBY
   end
+
+  def test_bug_21568
+    load_path = $LOAD_PATH.dup
+    loaded_featrures = $LOADED_FEATURES.dup
+
+    $LOAD_PATH.clear
+    $LOADED_FEATURES.replace(["foo.so", "a/foo.rb", "b/foo.rb"])
+
+    assert_nothing_raised(LoadError) { require "foo" }
+
+  ensure
+    $LOAD_PATH.replace(load_path) if load_path
+    $LOADED_FEATURES.replace loaded_featrures
+  end
 end


### PR DESCRIPTION
When multiple files with the same name are required, the features_index hash stores the indexes in `$LOADED_FEATURES` array into a darray. The dest and src arguments for `MEMMOVE` were wrongly reversed when inserting a new index in the darray.

[Bug #21568]