### PR TITLE
Add NODE FYDPTN locations

### DIFF
--- a/ast.c
+++ b/ast.c
@@ -847,6 +847,11 @@ node_locations(VALUE ast_value, const NODE *node)
         return rb_ary_new_from_args(2,
                                     location_new(nd_code_loc(node)),
                                     location_new(&RNODE_FLIP3(node)->operator_loc));
+      case NODE_FNDPTN:
+        return rb_ary_new_from_args(3,
+                                    location_new(nd_code_loc(node)),
+                                    location_new(&RNODE_FNDPTN(node)->opening_loc),
+                                    location_new(&RNODE_FNDPTN(node)->closing_loc));
       case NODE_FOR:
         return rb_ary_new_from_args(5,
                                     location_new(nd_code_loc(node)),

--- a/node_dump.c
+++ b/node_dump.c
@@ -1255,14 +1255,15 @@ dump_node(VALUE buf, VALUE indent, int comment, const NODE * node)
             F_MSG(pre_rest_arg, "pre rest argument", "NODE_SPECIAL_NO_NAME_REST (rest argument without name)");
         }
         F_NODE(args, RNODE_FNDPTN, "arguments");
-
-        LAST_NODE;
         if (NODE_NAMED_REST_P(RNODE_FNDPTN(node)->post_rest_arg)) {
             F_NODE(post_rest_arg, RNODE_FNDPTN, "post rest argument");
         }
         else {
             F_MSG(post_rest_arg, "post rest argument", "NODE_SPECIAL_NO_NAME_REST (rest argument without name)");
         }
+        F_LOC(opening_loc, RNODE_FNDPTN);
+        LAST_NODE;
+        F_LOC(closing_loc, RNODE_FNDPTN);
         return;
 
       case NODE_HSHPTN:

--- a/parse.y
+++ b/parse.y
@@ -1166,7 +1166,7 @@ static rb_node_attrasgn_t *rb_node_attrasgn_new(struct parser_params *p, NODE *n
 static rb_node_lambda_t *rb_node_lambda_new(struct parser_params *p, rb_node_args_t *nd_args, NODE *nd_body, const YYLTYPE *loc, const YYLTYPE *operator_loc, const YYLTYPE *opening_loc, const YYLTYPE *closing_loc);
 static rb_node_aryptn_t *rb_node_aryptn_new(struct parser_params *p, NODE *pre_args, NODE *rest_arg, NODE *post_args, const YYLTYPE *loc);
 static rb_node_hshptn_t *rb_node_hshptn_new(struct parser_params *p, NODE *nd_pconst, NODE *nd_pkwargs, NODE *nd_pkwrestarg, const YYLTYPE *loc);
-static rb_node_fndptn_t *rb_node_fndptn_new(struct parser_params *p, NODE *pre_rest_arg, NODE *args, NODE *post_rest_arg, const YYLTYPE *loc);
+static rb_node_fndptn_t *rb_node_fndptn_new(struct parser_params *p, NODE *pre_rest_arg, NODE *args, NODE *post_rest_arg, const YYLTYPE *loc, const YYLTYPE *opening_loc, const YYLTYPE *closing_loc);
 static rb_node_line_t *rb_node_line_new(struct parser_params *p, const YYLTYPE *loc);
 static rb_node_file_t *rb_node_file_new(struct parser_params *p, VALUE str, const YYLTYPE *loc);
 static rb_node_error_t *rb_node_error_new(struct parser_params *p, const YYLTYPE *loc);
@@ -1274,7 +1274,7 @@ static rb_node_error_t *rb_node_error_new(struct parser_params *p, const YYLTYPE
 #define NEW_LAMBDA(a,b,loc,op_loc,o_loc,c_loc) (NODE *)rb_node_lambda_new(p,a,b,loc,op_loc,o_loc,c_loc)
 #define NEW_ARYPTN(pre,r,post,loc) (NODE *)rb_node_aryptn_new(p,pre,r,post,loc)
 #define NEW_HSHPTN(c,kw,kwrest,loc) (NODE *)rb_node_hshptn_new(p,c,kw,kwrest,loc)
-#define NEW_FNDPTN(pre,a,post,loc) (NODE *)rb_node_fndptn_new(p,pre,a,post,loc)
+#define NEW_FNDPTN(pre,a,post,loc,o_loc,c_loc) (NODE *)rb_node_fndptn_new(p,pre,a,post,loc,o_loc,c_loc)
 #define NEW_LINE(loc) (NODE *)rb_node_line_new(p,loc)
 #define NEW_FILE(str,loc) (NODE *)rb_node_file_new(p,str,loc)
 #define NEW_ENCODING(loc) (NODE *)rb_node_encoding_new(p,loc)
@@ -1433,8 +1433,8 @@ static rb_node_args_t *new_args(struct parser_params*,rb_node_args_aux_t*,rb_nod
 static rb_node_args_t *new_args_tail(struct parser_params*,rb_node_kw_arg_t*,ID,ID,const YYLTYPE*);
 static NODE *new_array_pattern(struct parser_params *p, NODE *constant, NODE *pre_arg, NODE *aryptn, const YYLTYPE *loc);
 static NODE *new_array_pattern_tail(struct parser_params *p, NODE *pre_args, int has_rest, NODE *rest_arg, NODE *post_args, const YYLTYPE *loc);
-static NODE *new_find_pattern(struct parser_params *p, NODE *constant, NODE *fndptn, const YYLTYPE *loc);
-static NODE *new_find_pattern_tail(struct parser_params *p, NODE *pre_rest_arg, NODE *args, NODE *post_rest_arg, const YYLTYPE *loc);
+static NODE *new_find_pattern(struct parser_params *p, NODE *constant, NODE *fndptn, const YYLTYPE *loc, const YYLTYPE *opening_loc, const YYLTYPE *closing_loc);
+static NODE *new_find_pattern_tail(struct parser_params *p, NODE *pre_rest_arg, NODE *args, NODE *post_rest_arg, const YYLTYPE *loc, const YYLTYPE *opening_loc, const YYLTYPE *closing_loc);
 static NODE *new_hash_pattern(struct parser_params *p, NODE *constant, NODE *hshptn, const YYLTYPE *loc);
 static NODE *new_hash_pattern_tail(struct parser_params *p, NODE *kw_args, ID kw_rest_arg, const YYLTYPE *loc);
 
@@ -5450,7 +5450,7 @@ p_top_expr_body	: p_expr
                     }
                 | p_find
                     {
-                        $$ = new_find_pattern(p, 0, $1, &@$);
+                        $$ = new_find_pattern(p, 0, $1, &@$, &NULL_LOC, &NULL_LOC);
                     /*% ripper: fndptn!(Qnil, *$:1[0..2]) %*/
                     }
                 | p_args_tail
@@ -5520,7 +5520,11 @@ p_expr_basic	: p_value
                 | p_const p_lparen[p_pktbl] p_find rparen
                     {
                         pop_pktbl(p, $p_pktbl);
-                        $$ = new_find_pattern(p, $p_const, $p_find, &@$);
+                        if (nd_type_p($p_find, NODE_FNDPTN)) {
+                            RNODE_FNDPTN($p_find)->opening_loc = @2;
+                            RNODE_FNDPTN($p_find)->closing_loc = @4;
+                        }
+                        $$ = new_find_pattern(p, $p_const, $p_find, &@$, &@2, &@4);
                         nd_set_first_loc($$, @p_const.beg_pos);
                     /*% ripper: fndptn!($:p_const, *$:p_find[0..2]) %*/
                     }
@@ -5547,7 +5551,11 @@ p_expr_basic	: p_value
                 | p_const p_lbracket[p_pktbl] p_find rbracket
                     {
                         pop_pktbl(p, $p_pktbl);
-                        $$ = new_find_pattern(p, $p_const, $p_find, &@$);
+                        if (nd_type_p($p_find, NODE_FNDPTN)) {
+                            RNODE_FNDPTN($p_find)->opening_loc = @2;
+                            RNODE_FNDPTN($p_find)->closing_loc = @4;
+                        }
+                        $$ = new_find_pattern(p, $p_const, $p_find, &@$, &@2, &@4);
                         nd_set_first_loc($$, @p_const.beg_pos);
                     /*% ripper: fndptn!($:p_const, *$:p_find[0..2]) %*/
                     }
@@ -5571,7 +5579,11 @@ p_expr_basic	: p_value
                     }
                 | tLBRACK p_find rbracket
                     {
-                        $$ = new_find_pattern(p, 0, $p_find, &@$);
+                        if (nd_type_p($p_find, NODE_FNDPTN)) {
+                            RNODE_FNDPTN($p_find)->opening_loc = @1;
+                            RNODE_FNDPTN($p_find)->closing_loc = @3;
+                        }
+                        $$ = new_find_pattern(p, 0, $p_find, &@$, &@1, &@3);
                     /*% ripper: fndptn!(Qnil, *$:p_find[0..2]) %*/
                     }
                 | tLBRACK rbracket
@@ -5656,7 +5668,7 @@ p_args_tail	: p_rest
 
 p_find		: p_rest ',' p_args_post ',' p_rest
                     {
-                        $$ = new_find_pattern_tail(p, $1, $3, $5, &@$);
+                        $$ = new_find_pattern_tail(p, $1, $3, $5, &@$, &NULL_LOC, &NULL_LOC);
                     /*% ripper: [$:1, $:3, $:5] %*/
                     }
                 ;
@@ -12361,13 +12373,15 @@ rb_node_hshptn_new(struct parser_params *p, NODE *nd_pconst, NODE *nd_pkwargs, N
 }
 
 static rb_node_fndptn_t *
-rb_node_fndptn_new(struct parser_params *p, NODE *pre_rest_arg, NODE *args, NODE *post_rest_arg, const YYLTYPE *loc)
+rb_node_fndptn_new(struct parser_params *p, NODE *pre_rest_arg, NODE *args, NODE *post_rest_arg, const YYLTYPE *loc, const YYLTYPE *opening_loc, const YYLTYPE *closing_loc)
 {
     rb_node_fndptn_t *n = NODE_NEWNODE(NODE_FNDPTN, rb_node_fndptn_t, loc);
     n->nd_pconst = 0;
     n->pre_rest_arg = pre_rest_arg;
     n->args = args;
     n->post_rest_arg = post_rest_arg;
+    n->opening_loc = *opening_loc;
+    n->closing_loc = *closing_loc;
 
     return n;
 }
@@ -14548,7 +14562,7 @@ new_array_pattern_tail(struct parser_params *p, NODE *pre_args, int has_rest, NO
 }
 
 static NODE*
-new_find_pattern(struct parser_params *p, NODE *constant, NODE *fndptn, const YYLTYPE *loc)
+new_find_pattern(struct parser_params *p, NODE *constant, NODE *fndptn, const YYLTYPE *loc, const YYLTYPE *opening_loc, const YYLTYPE *closing_loc)
 {
     RNODE_FNDPTN(fndptn)->nd_pconst = constant;
 
@@ -14556,11 +14570,11 @@ new_find_pattern(struct parser_params *p, NODE *constant, NODE *fndptn, const YY
 }
 
 static NODE*
-new_find_pattern_tail(struct parser_params *p, NODE *pre_rest_arg, NODE *args, NODE *post_rest_arg, const YYLTYPE *loc)
+new_find_pattern_tail(struct parser_params *p, NODE *pre_rest_arg, NODE *args, NODE *post_rest_arg, const YYLTYPE *loc, const YYLTYPE *opening_loc, const YYLTYPE *closing_loc)
 {
     pre_rest_arg = pre_rest_arg ? pre_rest_arg : NODE_SPECIAL_NO_NAME_REST;
     post_rest_arg = post_rest_arg ? post_rest_arg : NODE_SPECIAL_NO_NAME_REST;
-    NODE *node = NEW_FNDPTN(pre_rest_arg, args, post_rest_arg, loc);
+    NODE *node = NEW_FNDPTN(pre_rest_arg, args, post_rest_arg, loc, opening_loc, closing_loc);
 
     return node;
 }

--- a/rubyparser.h
+++ b/rubyparser.h
@@ -1032,6 +1032,8 @@ typedef struct RNode_FNDPTN {
     NODE *pre_rest_arg;
     NODE *args;
     NODE *post_rest_arg;
+    rb_code_location_t opening_loc;
+    rb_code_location_t closing_loc;
 } rb_node_fndptn_t;
 
 typedef struct RNode_LINE {

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -1519,6 +1519,26 @@ dummy
       assert_locations(node.children[-1].children[0].locations, [[1, 3, 1, 8], [1, 4, 1, 7]])
     end
 
+    def test_fndptn_locations
+      node = ast_parse("[0, 1, 2] => [*, 1, *]")
+      assert_locations(node.children[-1].children[1].children[0].locations, [[1, 14, 1, 21], [1, 13, 1, 14], [1, 21, 1, 22]])
+
+      node = ast_parse("[0, 1, 2] in [*, 1, *]")
+      assert_locations(node.children[-1].children[1].children[0].locations, [[1, 14, 1, 21], [1, 13, 1, 14], [1, 21, 1, 22]])
+
+      node = ast_parse("x in Foo(*, 1, *)")
+      assert_locations(node.children[-1].children[1].children[0].locations, [[1, 5, 1, 16], [1, 8, 1, 9], [1, 16, 1, 17]])
+
+      node = ast_parse("x in Foo[*, 1, *]")
+      assert_locations(node.children[-1].children[1].children[0].locations, [[1, 5, 1, 16], [1, 8, 1, 9], [1, 16, 1, 17]])
+
+      node = ast_parse("x => *, 1, *")
+      assert_locations(node.children[-1].children[1].children[0].locations, [[1, 5, 1, 12], nil, nil])
+
+      node = ast_parse("x in *, 1, *")
+      assert_locations(node.children[-1].children[1].children[0].locations, [[1, 5, 1, 12], nil, nil])
+    end
+
     def test_for_locations
       node = ast_parse("for a in b; end")
       assert_locations(node.children[-1].locations, [[1, 0, 1, 15], [1, 0, 1, 3], [1, 6, 1, 8], nil, [1, 12, 1, 15]])


### PR DESCRIPTION
memo:
```bash
> ruby -e 'x in *, 1, *' --parser=prism --dump=parsetree
@ ProgramNode (location: (1,0)-(1,12))
+-- locals: []
+-- statements:
    @ StatementsNode (location: (1,0)-(1,12))
    +-- body: (length: 1)
        +-- @ MatchPredicateNode (location: (1,0)-(1,12))
            +-- value:
            |   @ CallNode (location: (1,0)-(1,1))
            |   +-- CallNodeFlags: variable_call, ignore_visibility
            |   +-- receiver: nil
            |   +-- call_operator_loc: nil
            |   +-- name: :x
            |   +-- message_loc: (1,0)-(1,1) = "x"
            |   +-- opening_loc: nil
            |   +-- arguments: nil
            |   +-- closing_loc: nil
            |   +-- block: nil
            +-- pattern:
            |   @ FindPatternNode (location: (1,5)-(1,12))
            |   +-- constant: nil
            |   +-- left:
            |   |   @ SplatNode (location: (1,5)-(1,6))
            |   |   +-- operator_loc: (1,5)-(1,6) = "*"
            |   |   +-- expression: nil
            |   +-- requireds: (length: 1)
            |   |   +-- @ IntegerNode (location: (1,8)-(1,9))
            |   |       +-- IntegerBaseFlags: decimal
            |   |       +-- value: 1
            |   +-- right:
            |   |   @ SplatNode (location: (1,11)-(1,12))
            |   |   +-- operator_loc: (1,11)-(1,12) = "*"
            |   |   +-- expression: nil
            |   +-- opening_loc: nil
            |   +-- closing_loc: nil
            +-- operator_loc: (1,2)-(1,4) = "in"
```