### PR TITLE
[DOC] Remove now inaccurate comment about blocking

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -514,7 +514,6 @@ ractor_create(rb_execution_context_t *ec, VALUE self, VALUE loc, VALUE name, VAL
     rb_ractor_t *r = RACTOR_PTR(rv);
     ractor_init(r, name, loc);
 
-    // can block here
     r->pub.id = ractor_next_id();
     RUBY_DEBUG_LOG("r:%u", r->pub.id);
 


### PR DESCRIPTION
Originally ractor_next_id used a VM_LOCK, but now it is an atomic and won't block.