### PR TITLE
Don't call gc_mark from IO::buffer compact

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -4393,6 +4393,7 @@ static void
 gc_mark(rb_objspace_t *objspace, VALUE obj)
 {
     GC_ASSERT(during_gc);
+    GC_ASSERT(!objspace->flags.during_reference_updating);
 
     rgengc_check_relation(objspace, obj);
     if (!gc_mark_set(objspace, obj)) return; /* already marked */


### PR DESCRIPTION
Previously on our mark_and_move we were calling `rb_gc_mark`, which isn't safe to call at compaction time. Also adds an assertion so that this won't happen elsewhere.

This also adds some ASAN poisoning to `objspace->parent_object` which how we detected that this was a problem.