### PR TITLE
ZJIT: Make sure zjit-test-update works in asm tests

### DIFF
--- a/zjit/src/asm/arm64/mod.rs
+++ b/zjit/src/asm/arm64/mod.rs
@@ -1213,6 +1213,7 @@ fn cbz_cbnz(num_bits: u8, op: bool, offset: InstructionOffset, rt: u8) -> [u8; 4
 mod tests {
     use super::*;
     use insta::assert_snapshot;
+    use crate::assert_disasm_snapshot;
 
     fn compile<R>(run: R) -> CodeBlock where R: FnOnce(&mut super::CodeBlock) {
         let mut cb = super::CodeBlock::new_dummy();
@@ -1246,128 +1247,112 @@ mod tests {
     #[test]
     fn test_add_reg() {
         let cb = compile(|cb| add(cb, X0, X1, X2));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: add x0, x1, x2");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: add x0, x1, x2");
         assert_snapshot!(cb.hexdump(), @"2000028b");
     }
 
     #[test]
     fn test_add_uimm() {
         let cb = compile(|cb| add(cb, X0, X1, A64Opnd::new_uimm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: add x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: add x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c0091");
     }
 
     #[test]
     fn test_add_imm_positive() {
         let cb = compile(|cb| add(cb, X0, X1, A64Opnd::new_imm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: add x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: add x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c0091");
     }
 
     #[test]
     fn test_add_imm_negative() {
         let cb = compile(|cb| add(cb, X0, X1, A64Opnd::new_imm(-7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00d1");
     }
 
     #[test]
     fn test_adds_reg() {
         let cb = compile(|cb| adds(cb, X0, X1, X2));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, x2");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, x2");
         assert_snapshot!(cb.hexdump(), @"200002ab");
     }
 
     #[test]
     fn test_adds_uimm() {
         let cb = compile(|cb| adds(cb, X0, X1, A64Opnd::new_uimm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00b1");
     }
 
     #[test]
     fn test_adds_imm_positive() {
         let cb = compile(|cb| adds(cb, X0, X1, A64Opnd::new_imm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00b1");
     }
 
     #[test]
     fn test_adds_imm_negative() {
         let cb = compile(|cb| adds(cb, X0, X1, A64Opnd::new_imm(-7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00f1");
     }
 
     #[test]
     fn test_adr() {
         let cb = compile(|cb| adr(cb, X10, A64Opnd::new_imm(20)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: adr x10, #0x14");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: adr x10, #0x14");
         assert_snapshot!(cb.hexdump(), @"aa000010");
     }
 
     #[test]
     fn test_adrp() {
         let cb = compile(|cb| adrp(cb, X10, A64Opnd::new_imm(0x8000)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: adrp x10, #0x8000");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: adrp x10, #0x8000");
         assert_snapshot!(cb.hexdump(), @"4a000090");
     }
 
     #[test]
     fn test_and_register() {
         let cb = compile(|cb| and(cb, X0, X1, X2));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: and x0, x1, x2");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: and x0, x1, x2");
         assert_snapshot!(cb.hexdump(), @"2000028a");
     }
 
     #[test]
     fn test_and_immediate() {
         let cb = compile(|cb| and(cb, X0, X1, A64Opnd::new_uimm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: and x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: and x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"20084092");
     }
 
     #[test]
     fn test_and_32b_immediate() {
         let cb = compile(|cb| and(cb, W0, W2, A64Opnd::new_uimm(0xfffff)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: and w0, w2, #0xfffff");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: and w0, w2, #0xfffff");
         assert_snapshot!(cb.hexdump(), @"404c0012");
     }
 
     #[test]
     fn test_ands_register() {
         let cb = compile(|cb| ands(cb, X0, X1, X2));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ands x0, x1, x2");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ands x0, x1, x2");
         assert_snapshot!(cb.hexdump(), @"200002ea");
     }
 
     #[test]
     fn test_ands_immediate() {
         let cb = compile(|cb| ands(cb, X0, X1, A64Opnd::new_uimm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ands x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ands x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"200840f2");
     }
 
     #[test]
     fn test_asr() {
         let cb = compile(|cb| asr(cb, X20, X21, A64Opnd::new_uimm(10)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: asr x20, x21, #0xa");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: asr x20, x21, #0xa");
         assert_snapshot!(cb.hexdump(), @"b4fe4a93");
     }
 
@@ -1375,8 +1360,7 @@ mod tests {
     fn test_bcond() {
         let offset = InstructionOffset::from_insns(0x100);
         let cb = compile(|cb| bcond(cb, Condition::NE, offset));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: b.ne #0x400");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: b.ne #0x400");
         assert_snapshot!(cb.hexdump(), @"01200054");
     }
 
@@ -1384,8 +1368,7 @@ mod tests {
     fn test_b() {
         let offset = InstructionOffset::from_insns((1 << 25) - 1);
         let cb = compile(|cb| b(cb, offset));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: b #0x7fffffc");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: b #0x7fffffc");
         assert_snapshot!(cb.hexdump(), @"ffffff15");
     }
 
@@ -1409,8 +1392,7 @@ mod tests {
     fn test_bl() {
         let offset = InstructionOffset::from_insns(-(1 << 25));
         let cb = compile(|cb| bl(cb, offset));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: bl #0xfffffffff8000000");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: bl #0xfffffffff8000000");
         assert_snapshot!(cb.hexdump(), @"00000096");
     }
 
@@ -1433,16 +1415,14 @@ mod tests {
     #[test]
     fn test_blr() {
         let cb = compile(|cb| blr(cb, X20));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: blr x20");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: blr x20");
         assert_snapshot!(cb.hexdump(), @"80023fd6");
     }
 
     #[test]
     fn test_br() {
         let cb = compile(|cb| br(cb, X20));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: br x20");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: br x20");
         assert_snapshot!(cb.hexdump(), @"80021fd6");
     }
 
@@ -1453,8 +1433,7 @@ mod tests {
             cbz(cb, X0, offset);
             cbz(cb, W0, offset);
         });
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: cbz x0, #0xfffffffffffffffc
         0x4: cbz w0, #0
         ");
@@ -1468,8 +1447,7 @@ mod tests {
             cbnz(cb, X20, offset);
             cbnz(cb, W20, offset);
         });
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: cbnz x20, #8
         0x4: cbnz w20, #0xc
         ");
@@ -1479,160 +1457,140 @@ mod tests {
     #[test]
     fn test_brk_none() {
         let cb = compile(|cb| brk(cb, A64Opnd::None));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: brk #0xf000");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: brk #0xf000");
         assert_snapshot!(cb.hexdump(), @"00003ed4");
     }
 
     #[test]
     fn test_brk_uimm() {
         let cb = compile(|cb| brk(cb, A64Opnd::new_uimm(14)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: brk #0xe");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: brk #0xe");
         assert_snapshot!(cb.hexdump(), @"c00120d4");
     }
 
     #[test]
     fn test_cmp_register() {
         let cb = compile(|cb| cmp(cb, X10, X11));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: cmp x10, x11");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: cmp x10, x11");
         assert_snapshot!(cb.hexdump(), @"5f010beb");
     }
 
     #[test]
     fn test_cmp_immediate() {
         let cb = compile(|cb| cmp(cb, X10, A64Opnd::new_uimm(14)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: cmp x10, #0xe");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: cmp x10, #0xe");
         assert_snapshot!(cb.hexdump(), @"5f3900f1");
     }
 
     #[test]
     fn test_csel() {
         let cb = compile(|cb| csel(cb, X10, X11, X12, Condition::EQ));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: csel x10, x11, x12, eq");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: csel x10, x11, x12, eq");
         assert_snapshot!(cb.hexdump(), @"6a018c9a");
     }
 
     #[test]
     fn test_eor_register() {
         let cb = compile(|cb| eor(cb, X10, X11, X12));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: eor x10, x11, x12");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: eor x10, x11, x12");
         assert_snapshot!(cb.hexdump(), @"6a010cca");
     }
 
     #[test]
     fn test_eor_immediate() {
         let cb = compile(|cb| eor(cb, X10, X11, A64Opnd::new_uimm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: eor x10, x11, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: eor x10, x11, #7");
         assert_snapshot!(cb.hexdump(), @"6a0940d2");
     }
 
     #[test]
     fn test_eor_32b_immediate() {
         let cb = compile(|cb| eor(cb, W9, W1, A64Opnd::new_uimm(0x80000001)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: eor w9, w1, #0x80000001");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: eor w9, w1, #0x80000001");
         assert_snapshot!(cb.hexdump(), @"29040152");
     }
 
     #[test]
     fn test_ldaddal() {
         let cb = compile(|cb| ldaddal(cb, X10, X11, X12));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldaddal x10, x11, [x12]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldaddal x10, x11, [x12]");
         assert_snapshot!(cb.hexdump(), @"8b01eaf8");
     }
 
     #[test]
     fn test_ldaxr() {
         let cb = compile(|cb| ldaxr(cb, X10, X11));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldaxr x10, [x11]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldaxr x10, [x11]");
         assert_snapshot!(cb.hexdump(), @"6afd5fc8");
     }
 
     #[test]
     fn test_ldp() {
         let cb = compile(|cb| ldp(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldp x10, x11, [x12, #0xd0]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldp x10, x11, [x12, #0xd0]");
         assert_snapshot!(cb.hexdump(), @"8a2d4da9");
     }
 
     #[test]
     fn test_ldp_pre() {
         let cb = compile(|cb| ldp_pre(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldp x10, x11, [x12, #0xd0]!");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldp x10, x11, [x12, #0xd0]!");
         assert_snapshot!(cb.hexdump(), @"8a2dcda9");
     }
 
     #[test]
     fn test_ldp_post() {
         let cb = compile(|cb| ldp_post(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldp x10, x11, [x12], #0xd0");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldp x10, x11, [x12], #0xd0");
         assert_snapshot!(cb.hexdump(), @"8a2dcda8");
     }
 
     #[test]
     fn test_ldr() {
         let cb = compile(|cb| ldr(cb, X10, X11, X12));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldr x10, [x11, x12]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldr x10, [x11, x12]");
         assert_snapshot!(cb.hexdump(), @"6a696cf8");
     }
 
     #[test]
     fn test_ldr_literal() {
         let cb = compile(|cb| ldr_literal(cb, X0, 10.into()));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldr x0, #0x28");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldr x0, #0x28");
         assert_snapshot!(cb.hexdump(), @"40010058");
     }
 
     #[test]
     fn test_ldr_post() {
         let cb = compile(|cb| ldr_post(cb, X10, A64Opnd::new_mem(64, X11, 16)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldr x10, [x11], #0x10");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldr x10, [x11], #0x10");
         assert_snapshot!(cb.hexdump(), @"6a0541f8");
     }
 
     #[test]
     fn test_ldr_pre() {
         let cb = compile(|cb| ldr_pre(cb, X10, A64Opnd::new_mem(64, X11, 16)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldr x10, [x11, #0x10]!");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldr x10, [x11, #0x10]!");
         assert_snapshot!(cb.hexdump(), @"6a0d41f8");
     }
 
     #[test]
     fn test_ldrh() {
         let cb = compile(|cb| ldrh(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldrh w10, [x11, #0xc]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldrh w10, [x11, #0xc]");
         assert_snapshot!(cb.hexdump(), @"6a194079");
     }
 
     #[test]
     fn test_ldrh_pre() {
         let cb = compile(|cb| ldrh_pre(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldrh w10, [x11, #0xc]!");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldrh w10, [x11, #0xc]!");
         assert_snapshot!(cb.hexdump(), @"6acd4078");
     }
 
     #[test]
     fn test_ldrh_post() {
         let cb = compile(|cb| ldrh_post(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldrh w10, [x11], #0xc");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldrh w10, [x11], #0xc");
         assert_snapshot!(cb.hexdump(), @"6ac54078");
     }
 
@@ -1642,8 +1600,7 @@ mod tests {
             ldurh(cb, W10, A64Opnd::new_mem(64, X1, 0));
             ldurh(cb, W10, A64Opnd::new_mem(64, X1, 123));
         });
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: ldurh w10, [x1]
         0x4: ldurh w10, [x1, #0x7b]
         ");
@@ -1653,391 +1610,342 @@ mod tests {
     #[test]
     fn test_ldur_memory() {
         let cb = compile(|cb| ldur(cb, X0, A64Opnd::new_mem(64, X1, 123)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldur x0, [x1, #0x7b]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldur x0, [x1, #0x7b]");
         assert_snapshot!(cb.hexdump(), @"20b047f8");
     }
 
     #[test]
     fn test_ldur_register() {
         let cb = compile(|cb| ldur(cb, X0, X1));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldur x0, [x1]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldur x0, [x1]");
         assert_snapshot!(cb.hexdump(), @"200040f8");
     }
 
     #[test]
     fn test_ldursw() {
         let cb = compile(|cb| ldursw(cb, X10, A64Opnd::new_mem(64, X11, 123)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldursw x10, [x11, #0x7b]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldursw x10, [x11, #0x7b]");
         assert_snapshot!(cb.hexdump(), @"6ab187b8");
     }
 
     #[test]
     fn test_lsl() {
         let cb = compile(|cb| lsl(cb, X10, X11, A64Opnd::new_uimm(14)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: lsl x10, x11, #0xe");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: lsl x10, x11, #0xe");
         assert_snapshot!(cb.hexdump(), @"6ac572d3");
     }
 
     #[test]
     fn test_lsr() {
         let cb = compile(|cb| lsr(cb, X10, X11, A64Opnd::new_uimm(14)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: lsr x10, x11, #0xe");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: lsr x10, x11, #0xe");
         assert_snapshot!(cb.hexdump(), @"6afd4ed3");
     }
 
     #[test]
     fn test_mov_registers() {
         let cb = compile(|cb| mov(cb, X10, X11));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: mov x10, x11");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: mov x10, x11");
         assert_snapshot!(cb.hexdump(), @"ea030baa");
     }
 
     #[test]
     fn test_mov_immediate() {
         let cb = compile(|cb| mov(cb, X10, A64Opnd::new_uimm(0x5555555555555555)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: orr x10, xzr, #0x5555555555555555");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: orr x10, xzr, #0x5555555555555555");
         assert_snapshot!(cb.hexdump(), @"eaf300b2");
     }
 
     #[test]
     fn test_mov_32b_immediate() {
         let cb = compile(|cb| mov(cb, W10, A64Opnd::new_uimm(0x80000001)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: mov w10, #-0x7fffffff");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: mov w10, #-0x7fffffff");
         assert_snapshot!(cb.hexdump(), @"ea070132");
     }
     #[test]
     fn test_mov_into_sp() {
         let cb = compile(|cb| mov(cb, X31, X0));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: mov sp, x0");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: mov sp, x0");
         assert_snapshot!(cb.hexdump(), @"1f000091");
     }
 
     #[test]
     fn test_mov_from_sp() {
         let cb = compile(|cb| mov(cb, X0, X31));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: mov x0, sp");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: mov x0, sp");
         assert_snapshot!(cb.hexdump(), @"e0030091");
     }
 
     #[test]
     fn test_movk() {
         let cb = compile(|cb| movk(cb, X0, A64Opnd::new_uimm(123), 16));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: movk x0, #0x7b, lsl #16");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: movk x0, #0x7b, lsl #16");
         assert_snapshot!(cb.hexdump(), @"600fa0f2");
     }
 
     #[test]
     fn test_movn() {
         let cb = compile(|cb| movn(cb, X0, A64Opnd::new_uimm(123), 16));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: mov x0, #-0x7b0001");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: mov x0, #-0x7b0001");
         assert_snapshot!(cb.hexdump(), @"600fa092");
     }
 
     #[test]
     fn test_movz() {
         let cb = compile(|cb| movz(cb, X0, A64Opnd::new_uimm(123), 16));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: mov x0, #0x7b0000");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: mov x0, #0x7b0000");
         assert_snapshot!(cb.hexdump(), @"600fa0d2");
     }
 
     #[test]
     fn test_mrs() {
         let cb = compile(|cb| mrs(cb, X10, SystemRegister::NZCV));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: mrs x10, nzcv");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: mrs x10, nzcv");
         assert_snapshot!(cb.hexdump(), @"0a423bd5");
     }
 
     #[test]
     fn test_msr() {
         let cb = compile(|cb| msr(cb, SystemRegister::NZCV, X10));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: msr nzcv, x10");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: msr nzcv, x10");
         assert_snapshot!(cb.hexdump(), @"0a421bd5");
     }
 
     #[test]
     fn test_mul() {
         let cb = compile(|cb| mul(cb, X10, X11, X12));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: mul x10, x11, x12");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: mul x10, x11, x12");
         assert_snapshot!(cb.hexdump(), @"6a7d0c9b");
     }
 
     #[test]
     fn test_mvn() {
         let cb = compile(|cb| mvn(cb, X10, X11));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: mvn x10, x11");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: mvn x10, x11");
         assert_snapshot!(cb.hexdump(), @"ea032baa");
     }
 
     #[test]
     fn test_nop() {
         let cb = compile(nop);
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: nop");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: nop");
         assert_snapshot!(cb.hexdump(), @"1f2003d5");
     }
 
     #[test]
     fn test_orn() {
         let cb = compile(|cb| orn(cb, X10, X11, X12));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: orn x10, x11, x12");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: orn x10, x11, x12");
         assert_snapshot!(cb.hexdump(), @"6a012caa");
     }
 
     #[test]
     fn test_orr_register() {
         let cb = compile(|cb| orr(cb, X10, X11, X12));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: orr x10, x11, x12");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: orr x10, x11, x12");
         assert_snapshot!(cb.hexdump(), @"6a010caa");
     }
 
     #[test]
     fn test_orr_immediate() {
         let cb = compile(|cb| orr(cb, X10, X11, A64Opnd::new_uimm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: orr x10, x11, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: orr x10, x11, #7");
         assert_snapshot!(cb.hexdump(), @"6a0940b2");
     }
 
     #[test]
     fn test_orr_32b_immediate() {
         let cb = compile(|cb| orr(cb, W10, W11, A64Opnd::new_uimm(1)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: orr w10, w11, #1");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: orr w10, w11, #1");
         assert_snapshot!(cb.hexdump(), @"6a010032");
     }
 
     #[test]
     fn test_ret_none() {
         let cb = compile(|cb| ret(cb, A64Opnd::None));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ret");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ret");
         assert_snapshot!(cb.hexdump(), @"c0035fd6");
     }
 
     #[test]
     fn test_ret_register() {
         let cb = compile(|cb| ret(cb, X20));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ret x20");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ret x20");
         assert_snapshot!(cb.hexdump(), @"80025fd6");
     }
 
     #[test]
     fn test_stlxr() {
         let cb = compile(|cb| stlxr(cb, W10, X11, X12));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: stlxr w10, x11, [x12]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: stlxr w10, x11, [x12]");
         assert_snapshot!(cb.hexdump(), @"8bfd0ac8");
     }
 
     #[test]
     fn test_stp() {
         let cb = compile(|cb| stp(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12, #0xd0]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12, #0xd0]");
         assert_snapshot!(cb.hexdump(), @"8a2d0da9");
     }
 
     #[test]
     fn test_stp_pre() {
         let cb = compile(|cb| stp_pre(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12, #0xd0]!");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12, #0xd0]!");
         assert_snapshot!(cb.hexdump(), @"8a2d8da9");
     }
 
     #[test]
     fn test_stp_post() {
         let cb = compile(|cb| stp_post(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12], #0xd0");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12], #0xd0");
         assert_snapshot!(cb.hexdump(), @"8a2d8da8");
     }
 
     #[test]
     fn test_str_post() {
         let cb = compile(|cb| str_post(cb, X10, A64Opnd::new_mem(64, X11, -16)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: str x10, [x11], #0xfffffffffffffff0");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: str x10, [x11], #0xfffffffffffffff0");
         assert_snapshot!(cb.hexdump(), @"6a051ff8");
     }
 
     #[test]
     fn test_str_pre() {
         let cb = compile(|cb| str_pre(cb, X10, A64Opnd::new_mem(64, X11, -16)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: str x10, [x11, #-0x10]!");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: str x10, [x11, #-0x10]!");
         assert_snapshot!(cb.hexdump(), @"6a0d1ff8");
     }
 
     #[test]
     fn test_strh() {
         let cb = compile(|cb| strh(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: strh w10, [x11, #0xc]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: strh w10, [x11, #0xc]");
         assert_snapshot!(cb.hexdump(), @"6a190079");
     }
 
     #[test]
     fn test_strh_pre() {
         let cb = compile(|cb| strh_pre(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: strh w10, [x11, #0xc]!");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: strh w10, [x11, #0xc]!");
         assert_snapshot!(cb.hexdump(), @"6acd0078");
     }
 
     #[test]
     fn test_strh_post() {
         let cb = compile(|cb| strh_post(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: strh w10, [x11], #0xc");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: strh w10, [x11], #0xc");
         assert_snapshot!(cb.hexdump(), @"6ac50078");
     }
 
     #[test]
     fn test_stur_64_bits() {
         let cb = compile(|cb| stur(cb, X10, A64Opnd::new_mem(64, X11, 128)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: stur x10, [x11, #0x80]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: stur x10, [x11, #0x80]");
         assert_snapshot!(cb.hexdump(), @"6a0108f8");
     }
 
     #[test]
     fn test_stur_32_bits() {
         let cb = compile(|cb| stur(cb, X10, A64Opnd::new_mem(32, X11, 128)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: stur w10, [x11, #0x80]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: stur w10, [x11, #0x80]");
         assert_snapshot!(cb.hexdump(), @"6a0108b8");
     }
 
     #[test]
     fn test_sub_reg() {
         let cb = compile(|cb| sub(cb, X0, X1, X2));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, x2");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, x2");
         assert_snapshot!(cb.hexdump(), @"200002cb");
     }
 
     #[test]
     fn test_sub_uimm() {
         let cb = compile(|cb| sub(cb, X0, X1, A64Opnd::new_uimm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00d1");
     }
 
     #[test]
     fn test_sub_imm_positive() {
         let cb = compile(|cb| sub(cb, X0, X1, A64Opnd::new_imm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00d1");
     }
 
     #[test]
     fn test_sub_imm_negative() {
         let cb = compile(|cb| sub(cb, X0, X1, A64Opnd::new_imm(-7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: add x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: add x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c0091");
     }
 
     #[test]
     fn test_subs_reg() {
         let cb = compile(|cb| subs(cb, X0, X1, X2));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, x2");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, x2");
         assert_snapshot!(cb.hexdump(), @"200002eb");
     }
 
     #[test]
     fn test_subs_imm_positive() {
         let cb = compile(|cb| subs(cb, X0, X1, A64Opnd::new_imm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00f1");
     }
 
     #[test]
     fn test_subs_imm_negative() {
         let cb = compile(|cb| subs(cb, X0, X1, A64Opnd::new_imm(-7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00b1");
     }
 
     #[test]
     fn test_subs_uimm() {
         let cb = compile(|cb| subs(cb, X0, X1, A64Opnd::new_uimm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00f1");
     }
 
     #[test]
     fn test_sxtw() {
         let cb = compile(|cb| sxtw(cb, X10, W11));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: sxtw x10, w11");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: sxtw x10, w11");
         assert_snapshot!(cb.hexdump(), @"6a7d4093");
     }
 
     #[test]
     fn test_tbnz() {
         let cb = compile(|cb| tbnz(cb, X10, A64Opnd::UImm(10), A64Opnd::Imm(2)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: tbnz w10, #0xa, #8");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: tbnz w10, #0xa, #8");
         assert_snapshot!(cb.hexdump(), @"4a005037");
     }
 
     #[test]
     fn test_tbz() {
         let cb = compile(|cb| tbz(cb, X10, A64Opnd::UImm(10), A64Opnd::Imm(2)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: tbz w10, #0xa, #8");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: tbz w10, #0xa, #8");
         assert_snapshot!(cb.hexdump(), @"4a005036");
     }
 
     #[test]
     fn test_tst_register() {
         let cb = compile(|cb| tst(cb, X0, X1));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: tst x0, x1");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: tst x0, x1");
         assert_snapshot!(cb.hexdump(), @"1f0001ea");
     }
 
     #[test]
     fn test_tst_immediate() {
         let cb = compile(|cb| tst(cb, X1, A64Opnd::new_uimm(7)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: tst x1, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: tst x1, #7");
         assert_snapshot!(cb.hexdump(), @"3f0840f2");
     }
 
     #[test]
     fn test_tst_32b_immediate() {
         let cb = compile(|cb| tst(cb, W0, A64Opnd::new_uimm(0xffff)));
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: tst w0, #0xffff");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: tst w0, #0xffff");
         assert_snapshot!(cb.hexdump(), @"1f3c0072");
     }
 
@@ -2049,8 +1957,7 @@ mod tests {
         add_extended(&mut cb, X30, X30, X30);
         add_extended(&mut cb, X31, X31, X31);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: add x10, x11, x9, uxtx
             0x4: add x30, x30, x30, uxtx
             0x8: add sp, sp, xzr

--- a/zjit/src/asm/arm64/mod.rs
+++ b/zjit/src/asm/arm64/mod.rs
@@ -1246,112 +1246,128 @@ mod tests {
     #[test]
     fn test_add_reg() {
         let cb = compile(|cb| add(cb, X0, X1, X2));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add x0, x1, x2"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: add x0, x1, x2");
         assert_snapshot!(cb.hexdump(), @"2000028b");
     }
 
     #[test]
     fn test_add_uimm() {
         let cb = compile(|cb| add(cb, X0, X1, A64Opnd::new_uimm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: add x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c0091");
     }
 
     #[test]
     fn test_add_imm_positive() {
         let cb = compile(|cb| add(cb, X0, X1, A64Opnd::new_imm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: add x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c0091");
     }
 
     #[test]
     fn test_add_imm_negative() {
         let cb = compile(|cb| add(cb, X0, X1, A64Opnd::new_imm(-7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00d1");
     }
 
     #[test]
     fn test_adds_reg() {
         let cb = compile(|cb| adds(cb, X0, X1, X2));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adds x0, x1, x2"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, x2");
         assert_snapshot!(cb.hexdump(), @"200002ab");
     }
 
     #[test]
     fn test_adds_uimm() {
         let cb = compile(|cb| adds(cb, X0, X1, A64Opnd::new_uimm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adds x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00b1");
     }
 
     #[test]
     fn test_adds_imm_positive() {
         let cb = compile(|cb| adds(cb, X0, X1, A64Opnd::new_imm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adds x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00b1");
     }
 
     #[test]
     fn test_adds_imm_negative() {
         let cb = compile(|cb| adds(cb, X0, X1, A64Opnd::new_imm(-7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: subs x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00f1");
     }
 
     #[test]
     fn test_adr() {
         let cb = compile(|cb| adr(cb, X10, A64Opnd::new_imm(20)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adr x10, #0x14"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: adr x10, #0x14");
         assert_snapshot!(cb.hexdump(), @"aa000010");
     }
 
     #[test]
     fn test_adrp() {
         let cb = compile(|cb| adrp(cb, X10, A64Opnd::new_imm(0x8000)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adrp x10, #0x8000"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: adrp x10, #0x8000");
         assert_snapshot!(cb.hexdump(), @"4a000090");
     }
 
     #[test]
     fn test_and_register() {
         let cb = compile(|cb| and(cb, X0, X1, X2));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and x0, x1, x2"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: and x0, x1, x2");
         assert_snapshot!(cb.hexdump(), @"2000028a");
     }
 
     #[test]
     fn test_and_immediate() {
         let cb = compile(|cb| and(cb, X0, X1, A64Opnd::new_uimm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: and x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"20084092");
     }
 
     #[test]
     fn test_and_32b_immediate() {
         let cb = compile(|cb| and(cb, W0, W2, A64Opnd::new_uimm(0xfffff)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and w0, w2, #0xfffff"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: and w0, w2, #0xfffff");
         assert_snapshot!(cb.hexdump(), @"404c0012");
     }
 
     #[test]
     fn test_ands_register() {
         let cb = compile(|cb| ands(cb, X0, X1, X2));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ands x0, x1, x2"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ands x0, x1, x2");
         assert_snapshot!(cb.hexdump(), @"200002ea");
     }
 
     #[test]
     fn test_ands_immediate() {
         let cb = compile(|cb| ands(cb, X0, X1, A64Opnd::new_uimm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ands x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ands x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"200840f2");
     }
 
     #[test]
     fn test_asr() {
         let cb = compile(|cb| asr(cb, X20, X21, A64Opnd::new_uimm(10)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: asr x20, x21, #0xa"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: asr x20, x21, #0xa");
         assert_snapshot!(cb.hexdump(), @"b4fe4a93");
     }
 
@@ -1359,7 +1375,8 @@ mod tests {
     fn test_bcond() {
         let offset = InstructionOffset::from_insns(0x100);
         let cb = compile(|cb| bcond(cb, Condition::NE, offset));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: b.ne #0x400"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: b.ne #0x400");
         assert_snapshot!(cb.hexdump(), @"01200054");
     }
 
@@ -1367,7 +1384,8 @@ mod tests {
     fn test_b() {
         let offset = InstructionOffset::from_insns((1 << 25) - 1);
         let cb = compile(|cb| b(cb, offset));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: b #0x7fffffc"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: b #0x7fffffc");
         assert_snapshot!(cb.hexdump(), @"ffffff15");
     }
 
@@ -1391,7 +1409,8 @@ mod tests {
     fn test_bl() {
         let offset = InstructionOffset::from_insns(-(1 << 25));
         let cb = compile(|cb| bl(cb, offset));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: bl #0xfffffffff8000000"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: bl #0xfffffffff8000000");
         assert_snapshot!(cb.hexdump(), @"00000096");
     }
 
@@ -1414,14 +1433,16 @@ mod tests {
     #[test]
     fn test_blr() {
         let cb = compile(|cb| blr(cb, X20));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: blr x20"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: blr x20");
         assert_snapshot!(cb.hexdump(), @"80023fd6");
     }
 
     #[test]
     fn test_br() {
         let cb = compile(|cb| br(cb, X20));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: br x20"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: br x20");
         assert_snapshot!(cb.hexdump(), @"80021fd6");
     }
 
@@ -1432,10 +1453,11 @@ mod tests {
             cbz(cb, X0, offset);
             cbz(cb, W0, offset);
         });
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: cbz x0, #0xfffffffffffffffc
         0x4: cbz w0, #0
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"e0ffffb4e0ffff34");
     }
 
@@ -1446,150 +1468,171 @@ mod tests {
             cbnz(cb, X20, offset);
             cbnz(cb, W20, offset);
         });
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: cbnz x20, #8
         0x4: cbnz w20, #0xc
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"540000b554000035");
     }
 
     #[test]
     fn test_brk_none() {
         let cb = compile(|cb| brk(cb, A64Opnd::None));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: brk #0xf000"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: brk #0xf000");
         assert_snapshot!(cb.hexdump(), @"00003ed4");
     }
 
     #[test]
     fn test_brk_uimm() {
         let cb = compile(|cb| brk(cb, A64Opnd::new_uimm(14)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: brk #0xe"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: brk #0xe");
         assert_snapshot!(cb.hexdump(), @"c00120d4");
     }
 
     #[test]
     fn test_cmp_register() {
         let cb = compile(|cb| cmp(cb, X10, X11));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp x10, x11"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: cmp x10, x11");
         assert_snapshot!(cb.hexdump(), @"5f010beb");
     }
 
     #[test]
     fn test_cmp_immediate() {
         let cb = compile(|cb| cmp(cb, X10, A64Opnd::new_uimm(14)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp x10, #0xe"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: cmp x10, #0xe");
         assert_snapshot!(cb.hexdump(), @"5f3900f1");
     }
 
     #[test]
     fn test_csel() {
         let cb = compile(|cb| csel(cb, X10, X11, X12, Condition::EQ));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: csel x10, x11, x12, eq"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: csel x10, x11, x12, eq");
         assert_snapshot!(cb.hexdump(), @"6a018c9a");
     }
 
     #[test]
     fn test_eor_register() {
         let cb = compile(|cb| eor(cb, X10, X11, X12));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: eor x10, x11, x12"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: eor x10, x11, x12");
         assert_snapshot!(cb.hexdump(), @"6a010cca");
     }
 
     #[test]
     fn test_eor_immediate() {
         let cb = compile(|cb| eor(cb, X10, X11, A64Opnd::new_uimm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: eor x10, x11, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: eor x10, x11, #7");
         assert_snapshot!(cb.hexdump(), @"6a0940d2");
     }
 
     #[test]
     fn test_eor_32b_immediate() {
         let cb = compile(|cb| eor(cb, W9, W1, A64Opnd::new_uimm(0x80000001)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: eor w9, w1, #0x80000001"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: eor w9, w1, #0x80000001");
         assert_snapshot!(cb.hexdump(), @"29040152");
     }
 
     #[test]
     fn test_ldaddal() {
         let cb = compile(|cb| ldaddal(cb, X10, X11, X12));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldaddal x10, x11, [x12]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldaddal x10, x11, [x12]");
         assert_snapshot!(cb.hexdump(), @"8b01eaf8");
     }
 
     #[test]
     fn test_ldaxr() {
         let cb = compile(|cb| ldaxr(cb, X10, X11));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldaxr x10, [x11]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldaxr x10, [x11]");
         assert_snapshot!(cb.hexdump(), @"6afd5fc8");
     }
 
     #[test]
     fn test_ldp() {
         let cb = compile(|cb| ldp(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldp x10, x11, [x12, #0xd0]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldp x10, x11, [x12, #0xd0]");
         assert_snapshot!(cb.hexdump(), @"8a2d4da9");
     }
 
     #[test]
     fn test_ldp_pre() {
         let cb = compile(|cb| ldp_pre(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldp x10, x11, [x12, #0xd0]!"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldp x10, x11, [x12, #0xd0]!");
         assert_snapshot!(cb.hexdump(), @"8a2dcda9");
     }
 
     #[test]
     fn test_ldp_post() {
         let cb = compile(|cb| ldp_post(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldp x10, x11, [x12], #0xd0"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldp x10, x11, [x12], #0xd0");
         assert_snapshot!(cb.hexdump(), @"8a2dcda8");
     }
 
     #[test]
     fn test_ldr() {
         let cb = compile(|cb| ldr(cb, X10, X11, X12));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldr x10, [x11, x12]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldr x10, [x11, x12]");
         assert_snapshot!(cb.hexdump(), @"6a696cf8");
     }
 
     #[test]
     fn test_ldr_literal() {
         let cb = compile(|cb| ldr_literal(cb, X0, 10.into()));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldr x0, #0x28"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldr x0, #0x28");
         assert_snapshot!(cb.hexdump(), @"40010058");
     }
 
     #[test]
     fn test_ldr_post() {
         let cb = compile(|cb| ldr_post(cb, X10, A64Opnd::new_mem(64, X11, 16)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldr x10, [x11], #0x10"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldr x10, [x11], #0x10");
         assert_snapshot!(cb.hexdump(), @"6a0541f8");
     }
 
     #[test]
     fn test_ldr_pre() {
         let cb = compile(|cb| ldr_pre(cb, X10, A64Opnd::new_mem(64, X11, 16)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldr x10, [x11, #0x10]!"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldr x10, [x11, #0x10]!");
         assert_snapshot!(cb.hexdump(), @"6a0d41f8");
     }
 
     #[test]
     fn test_ldrh() {
         let cb = compile(|cb| ldrh(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldrh w10, [x11, #0xc]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldrh w10, [x11, #0xc]");
         assert_snapshot!(cb.hexdump(), @"6a194079");
     }
 
     #[test]
     fn test_ldrh_pre() {
         let cb = compile(|cb| ldrh_pre(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldrh w10, [x11, #0xc]!"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldrh w10, [x11, #0xc]!");
         assert_snapshot!(cb.hexdump(), @"6acd4078");
     }
 
     #[test]
     fn test_ldrh_post() {
         let cb = compile(|cb| ldrh_post(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldrh w10, [x11], #0xc"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldrh w10, [x11], #0xc");
         assert_snapshot!(cb.hexdump(), @"6ac54078");
     }
 
@@ -1599,352 +1642,402 @@ mod tests {
             ldurh(cb, W10, A64Opnd::new_mem(64, X1, 0));
             ldurh(cb, W10, A64Opnd::new_mem(64, X1, 123));
         });
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: ldurh w10, [x1]
         0x4: ldurh w10, [x1, #0x7b]
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"2a0040782ab04778");
     }
 
     #[test]
     fn test_ldur_memory() {
         let cb = compile(|cb| ldur(cb, X0, A64Opnd::new_mem(64, X1, 123)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldur x0, [x1, #0x7b]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldur x0, [x1, #0x7b]");
         assert_snapshot!(cb.hexdump(), @"20b047f8");
     }
 
     #[test]
     fn test_ldur_register() {
         let cb = compile(|cb| ldur(cb, X0, X1));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldur x0, [x1]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldur x0, [x1]");
         assert_snapshot!(cb.hexdump(), @"200040f8");
     }
 
     #[test]
     fn test_ldursw() {
         let cb = compile(|cb| ldursw(cb, X10, A64Opnd::new_mem(64, X11, 123)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ldursw x10, [x11, #0x7b]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ldursw x10, [x11, #0x7b]");
         assert_snapshot!(cb.hexdump(), @"6ab187b8");
     }
 
     #[test]
     fn test_lsl() {
         let cb = compile(|cb| lsl(cb, X10, X11, A64Opnd::new_uimm(14)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lsl x10, x11, #0xe"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: lsl x10, x11, #0xe");
         assert_snapshot!(cb.hexdump(), @"6ac572d3");
     }
 
     #[test]
     fn test_lsr() {
         let cb = compile(|cb| lsr(cb, X10, X11, A64Opnd::new_uimm(14)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lsr x10, x11, #0xe"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: lsr x10, x11, #0xe");
         assert_snapshot!(cb.hexdump(), @"6afd4ed3");
     }
 
     #[test]
     fn test_mov_registers() {
         let cb = compile(|cb| mov(cb, X10, X11));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov x10, x11"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: mov x10, x11");
         assert_snapshot!(cb.hexdump(), @"ea030baa");
     }
 
     #[test]
     fn test_mov_immediate() {
         let cb = compile(|cb| mov(cb, X10, A64Opnd::new_uimm(0x5555555555555555)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orr x10, xzr, #0x5555555555555555"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: orr x10, xzr, #0x5555555555555555");
         assert_snapshot!(cb.hexdump(), @"eaf300b2");
     }
 
     #[test]
     fn test_mov_32b_immediate() {
         let cb = compile(|cb| mov(cb, W10, A64Opnd::new_uimm(0x80000001)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov w10, #-0x7fffffff"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: mov w10, #-0x7fffffff");
         assert_snapshot!(cb.hexdump(), @"ea070132");
     }
     #[test]
     fn test_mov_into_sp() {
         let cb = compile(|cb| mov(cb, X31, X0));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov sp, x0"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: mov sp, x0");
         assert_snapshot!(cb.hexdump(), @"1f000091");
     }
 
     #[test]
     fn test_mov_from_sp() {
         let cb = compile(|cb| mov(cb, X0, X31));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov x0, sp"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: mov x0, sp");
         assert_snapshot!(cb.hexdump(), @"e0030091");
     }
 
     #[test]
     fn test_movk() {
         let cb = compile(|cb| movk(cb, X0, A64Opnd::new_uimm(123), 16));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movk x0, #0x7b, lsl #16"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: movk x0, #0x7b, lsl #16");
         assert_snapshot!(cb.hexdump(), @"600fa0f2");
     }
 
     #[test]
     fn test_movn() {
         let cb = compile(|cb| movn(cb, X0, A64Opnd::new_uimm(123), 16));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov x0, #-0x7b0001"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: mov x0, #-0x7b0001");
         assert_snapshot!(cb.hexdump(), @"600fa092");
     }
 
     #[test]
     fn test_movz() {
         let cb = compile(|cb| movz(cb, X0, A64Opnd::new_uimm(123), 16));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov x0, #0x7b0000"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: mov x0, #0x7b0000");
         assert_snapshot!(cb.hexdump(), @"600fa0d2");
     }
 
     #[test]
     fn test_mrs() {
         let cb = compile(|cb| mrs(cb, X10, SystemRegister::NZCV));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mrs x10, nzcv"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: mrs x10, nzcv");
         assert_snapshot!(cb.hexdump(), @"0a423bd5");
     }
 
     #[test]
     fn test_msr() {
         let cb = compile(|cb| msr(cb, SystemRegister::NZCV, X10));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: msr nzcv, x10"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: msr nzcv, x10");
         assert_snapshot!(cb.hexdump(), @"0a421bd5");
     }
 
     #[test]
     fn test_mul() {
         let cb = compile(|cb| mul(cb, X10, X11, X12));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mul x10, x11, x12"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: mul x10, x11, x12");
         assert_snapshot!(cb.hexdump(), @"6a7d0c9b");
     }
 
     #[test]
     fn test_mvn() {
         let cb = compile(|cb| mvn(cb, X10, X11));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mvn x10, x11"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: mvn x10, x11");
         assert_snapshot!(cb.hexdump(), @"ea032baa");
     }
 
     #[test]
     fn test_nop() {
         let cb = compile(nop);
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: nop");
         assert_snapshot!(cb.hexdump(), @"1f2003d5");
     }
 
     #[test]
     fn test_orn() {
         let cb = compile(|cb| orn(cb, X10, X11, X12));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orn x10, x11, x12"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: orn x10, x11, x12");
         assert_snapshot!(cb.hexdump(), @"6a012caa");
     }
 
     #[test]
     fn test_orr_register() {
         let cb = compile(|cb| orr(cb, X10, X11, X12));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orr x10, x11, x12"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: orr x10, x11, x12");
         assert_snapshot!(cb.hexdump(), @"6a010caa");
     }
 
     #[test]
     fn test_orr_immediate() {
         let cb = compile(|cb| orr(cb, X10, X11, A64Opnd::new_uimm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orr x10, x11, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: orr x10, x11, #7");
         assert_snapshot!(cb.hexdump(), @"6a0940b2");
     }
 
     #[test]
     fn test_orr_32b_immediate() {
         let cb = compile(|cb| orr(cb, W10, W11, A64Opnd::new_uimm(1)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: orr w10, w11, #1"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: orr w10, w11, #1");
         assert_snapshot!(cb.hexdump(), @"6a010032");
     }
 
     #[test]
     fn test_ret_none() {
         let cb = compile(|cb| ret(cb, A64Opnd::None));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ret"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ret");
         assert_snapshot!(cb.hexdump(), @"c0035fd6");
     }
 
     #[test]
     fn test_ret_register() {
         let cb = compile(|cb| ret(cb, X20));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ret x20"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: ret x20");
         assert_snapshot!(cb.hexdump(), @"80025fd6");
     }
 
     #[test]
     fn test_stlxr() {
         let cb = compile(|cb| stlxr(cb, W10, X11, X12));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stlxr w10, x11, [x12]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: stlxr w10, x11, [x12]");
         assert_snapshot!(cb.hexdump(), @"8bfd0ac8");
     }
 
     #[test]
     fn test_stp() {
         let cb = compile(|cb| stp(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stp x10, x11, [x12, #0xd0]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12, #0xd0]");
         assert_snapshot!(cb.hexdump(), @"8a2d0da9");
     }
 
     #[test]
     fn test_stp_pre() {
         let cb = compile(|cb| stp_pre(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stp x10, x11, [x12, #0xd0]!"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12, #0xd0]!");
         assert_snapshot!(cb.hexdump(), @"8a2d8da9");
     }
 
     #[test]
     fn test_stp_post() {
         let cb = compile(|cb| stp_post(cb, X10, X11, A64Opnd::new_mem(64, X12, 208)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stp x10, x11, [x12], #0xd0"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: stp x10, x11, [x12], #0xd0");
         assert_snapshot!(cb.hexdump(), @"8a2d8da8");
     }
 
     #[test]
     fn test_str_post() {
         let cb = compile(|cb| str_post(cb, X10, A64Opnd::new_mem(64, X11, -16)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: str x10, [x11], #0xfffffffffffffff0"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: str x10, [x11], #0xfffffffffffffff0");
         assert_snapshot!(cb.hexdump(), @"6a051ff8");
     }
 
     #[test]
     fn test_str_pre() {
         let cb = compile(|cb| str_pre(cb, X10, A64Opnd::new_mem(64, X11, -16)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: str x10, [x11, #-0x10]!"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: str x10, [x11, #-0x10]!");
         assert_snapshot!(cb.hexdump(), @"6a0d1ff8");
     }
 
     #[test]
     fn test_strh() {
         let cb = compile(|cb| strh(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: strh w10, [x11, #0xc]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: strh w10, [x11, #0xc]");
         assert_snapshot!(cb.hexdump(), @"6a190079");
     }
 
     #[test]
     fn test_strh_pre() {
         let cb = compile(|cb| strh_pre(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: strh w10, [x11, #0xc]!"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: strh w10, [x11, #0xc]!");
         assert_snapshot!(cb.hexdump(), @"6acd0078");
     }
 
     #[test]
     fn test_strh_post() {
         let cb = compile(|cb| strh_post(cb, W10, A64Opnd::new_mem(64, X11, 12)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: strh w10, [x11], #0xc"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: strh w10, [x11], #0xc");
         assert_snapshot!(cb.hexdump(), @"6ac50078");
     }
 
     #[test]
     fn test_stur_64_bits() {
         let cb = compile(|cb| stur(cb, X10, A64Opnd::new_mem(64, X11, 128)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stur x10, [x11, #0x80]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: stur x10, [x11, #0x80]");
         assert_snapshot!(cb.hexdump(), @"6a0108f8");
     }
 
     #[test]
     fn test_stur_32_bits() {
         let cb = compile(|cb| stur(cb, X10, A64Opnd::new_mem(32, X11, 128)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: stur w10, [x11, #0x80]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: stur w10, [x11, #0x80]");
         assert_snapshot!(cb.hexdump(), @"6a0108b8");
     }
 
     #[test]
     fn test_sub_reg() {
         let cb = compile(|cb| sub(cb, X0, X1, X2));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub x0, x1, x2"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, x2");
         assert_snapshot!(cb.hexdump(), @"200002cb");
     }
 
     #[test]
     fn test_sub_uimm() {
         let cb = compile(|cb| sub(cb, X0, X1, A64Opnd::new_uimm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00d1");
     }
 
     #[test]
     fn test_sub_imm_positive() {
         let cb = compile(|cb| sub(cb, X0, X1, A64Opnd::new_imm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: sub x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00d1");
     }
 
     #[test]
     fn test_sub_imm_negative() {
         let cb = compile(|cb| sub(cb, X0, X1, A64Opnd::new_imm(-7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: add x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c0091");
     }
 
     #[test]
     fn test_subs_reg() {
         let cb = compile(|cb| subs(cb, X0, X1, X2));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: subs x0, x1, x2"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, x2");
         assert_snapshot!(cb.hexdump(), @"200002eb");
     }
 
     #[test]
     fn test_subs_imm_positive() {
         let cb = compile(|cb| subs(cb, X0, X1, A64Opnd::new_imm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: subs x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00f1");
     }
 
     #[test]
     fn test_subs_imm_negative() {
         let cb = compile(|cb| subs(cb, X0, X1, A64Opnd::new_imm(-7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: adds x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: adds x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00b1");
     }
 
     #[test]
     fn test_subs_uimm() {
         let cb = compile(|cb| subs(cb, X0, X1, A64Opnd::new_uimm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: subs x0, x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: subs x0, x1, #7");
         assert_snapshot!(cb.hexdump(), @"201c00f1");
     }
 
     #[test]
     fn test_sxtw() {
         let cb = compile(|cb| sxtw(cb, X10, W11));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sxtw x10, w11"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: sxtw x10, w11");
         assert_snapshot!(cb.hexdump(), @"6a7d4093");
     }
 
     #[test]
     fn test_tbnz() {
         let cb = compile(|cb| tbnz(cb, X10, A64Opnd::UImm(10), A64Opnd::Imm(2)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tbnz w10, #0xa, #8"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: tbnz w10, #0xa, #8");
         assert_snapshot!(cb.hexdump(), @"4a005037");
     }
 
     #[test]
     fn test_tbz() {
         let cb = compile(|cb| tbz(cb, X10, A64Opnd::UImm(10), A64Opnd::Imm(2)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tbz w10, #0xa, #8"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: tbz w10, #0xa, #8");
         assert_snapshot!(cb.hexdump(), @"4a005036");
     }
 
     #[test]
     fn test_tst_register() {
         let cb = compile(|cb| tst(cb, X0, X1));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tst x0, x1"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: tst x0, x1");
         assert_snapshot!(cb.hexdump(), @"1f0001ea");
     }
 
     #[test]
     fn test_tst_immediate() {
         let cb = compile(|cb| tst(cb, X1, A64Opnd::new_uimm(7)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tst x1, #7"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: tst x1, #7");
         assert_snapshot!(cb.hexdump(), @"3f0840f2");
     }
 
     #[test]
     fn test_tst_32b_immediate() {
         let cb = compile(|cb| tst(cb, W0, A64Opnd::new_uimm(0xffff)));
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: tst w0, #0xffff"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: tst w0, #0xffff");
         assert_snapshot!(cb.hexdump(), @"1f3c0072");
     }
 
@@ -1956,11 +2049,12 @@ mod tests {
         add_extended(&mut cb, X30, X30, X30);
         add_extended(&mut cb, X31, X31, X31);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"
             0x0: add x10, x11, x9, uxtx
             0x4: add x30, x30, x30, uxtx
             0x8: add sp, sp, xzr
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"6a61298bde633e8bff633f8b");
     }
 }

--- a/zjit/src/asm/mod.rs
+++ b/zjit/src/asm/mod.rs
@@ -298,6 +298,17 @@ impl CodeBlock {
     }
 }
 
+/// Run assert_snapshot! only if cfg!(feature = "disasm").
+/// $actual can be not only `cb.disasm()` but also `disasms!(cb1, cb2, ...)`.
+#[cfg(test)]
+#[macro_export]
+macro_rules! assert_disasm_snapshot {
+    ($actual: expr, @$($tt: tt)*) => {{
+        #[cfg(feature = "disasm")]
+        assert_snapshot!($actual, @$($tt)*)
+    }};
+}
+
 /// Combine multiple cb.disasm() results to match all of them at once, which allows
 /// us to avoid running the set of zjit-test -> zjit-test-update multiple times.
 #[cfg(all(test, feature = "disasm"))]

--- a/zjit/src/asm/x86_64/tests.rs
+++ b/zjit/src/asm/x86_64/tests.rs
@@ -2,7 +2,9 @@
 
 use insta::assert_snapshot;
 
-use crate::asm::x86_64::*;
+#[cfg(feature = "disasm")]
+use crate::disasms;
+use crate::{asm::x86_64::*, hexdumps};
 
 /// Check that the bytes for an instruction sequence match a hex string
 fn check_bytes<R>(bytes: &str, run: R) where R: FnOnce(&mut super::CodeBlock) {
@@ -36,39 +38,44 @@ fn test_add() {
     let cb15 = compile(|cb| add(cb, ECX, imm_opnd(8)));
     let cb16 = compile(|cb| add(cb, ECX, imm_opnd(255)));
 
-    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add cl, 3"));
-    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add cl, bl"));
-    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add cl, spl"));
-    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add cx, bx"));
-    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add rax, rbx"));
-    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add ecx, edx"));
-    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add rdx, r14"));
-    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add qword ptr [rax], rdx"));
-    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add rdx, qword ptr [rax]"));
-    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add rdx, qword ptr [rax + 8]"));
-    cb11.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add rdx, qword ptr [rax + 0xff]"));
-    cb12.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add qword ptr [rax + 0x7f], 0xff"));
-    cb13.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add dword ptr [rax], edx"));
-    cb14.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add rsp, 8"));
-    cb15.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add ecx, 8"));
-    cb16.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add ecx, 0xff"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12, cb13, cb14, cb15, cb16), @r"
+    0x0: add cl, 3
+    0x0: add cl, bl
+    0x0: add cl, spl
+    0x0: add cx, bx
+    0x0: add rax, rbx
+    0x0: add ecx, edx
+    0x0: add rdx, r14
+    0x0: add qword ptr [rax], rdx
+    0x0: add rdx, qword ptr [rax]
+    0x0: add rdx, qword ptr [rax + 8]
+    0x0: add rdx, qword ptr [rax + 0xff]
+    0x0: add qword ptr [rax + 0x7f], 0xff
+    0x0: add dword ptr [rax], edx
+    0x0: add rsp, 8
+    0x0: add ecx, 8
+    0x0: add ecx, 0xff
+    ");
 
-    assert_snapshot!(cb01.hexdump(), @"80c103");
-    assert_snapshot!(cb02.hexdump(), @"00d9");
-    assert_snapshot!(cb03.hexdump(), @"4000e1");
-    assert_snapshot!(cb04.hexdump(), @"6601d9");
-    assert_snapshot!(cb05.hexdump(), @"4801d8");
-    assert_snapshot!(cb06.hexdump(), @"01d1");
-    assert_snapshot!(cb07.hexdump(), @"4c01f2");
-    assert_snapshot!(cb08.hexdump(), @"480110");
-    assert_snapshot!(cb09.hexdump(), @"480310");
-    assert_snapshot!(cb10.hexdump(), @"48035008");
-    assert_snapshot!(cb11.hexdump(), @"480390ff000000");
-    assert_snapshot!(cb12.hexdump(), @"4881407fff000000");
-    assert_snapshot!(cb13.hexdump(), @"0110");
-    assert_snapshot!(cb14.hexdump(), @"4883c408");
-    assert_snapshot!(cb15.hexdump(), @"83c108");
-    assert_snapshot!(cb16.hexdump(), @"81c1ff000000");
+    assert_snapshot!(hexdumps!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12, cb13, cb14, cb15, cb16), @r"
+    80c103
+    00d9
+    4000e1
+    6601d9
+    4801d8
+    01d1
+    4c01f2
+    480110
+    480310
+    48035008
+    480390ff000000
+    4881407fff000000
+    0110
+    4883c408
+    83c108
+    81c1ff000000
+    ");
 }
 
 #[test]
@@ -86,23 +93,28 @@ fn test_add_unsigned() {
     let cb7 = compile(|cb| add(cb, R8, uimm_opnd(1)));
     let cb8 = compile(|cb| add(cb, R8, uimm_opnd(i32::MAX.try_into().unwrap())));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8b, 1"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8b, 0x7f"));
-    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8w, 1"));
-    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8w, 0x7fff"));
-    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8d, 1"));
-    cb6.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8d, 0x7fffffff"));
-    cb7.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8, 1"));
-    cb8.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r8, 0x7fffffff"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2, cb3, cb4, cb5, cb6, cb7, cb8), @r"
+    0x0: add r8b, 1
+    0x0: add r8b, 0x7f
+    0x0: add r8w, 1
+    0x0: add r8w, 0x7fff
+    0x0: add r8d, 1
+    0x0: add r8d, 0x7fffffff
+    0x0: add r8, 1
+    0x0: add r8, 0x7fffffff
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"4180c001");
-    assert_snapshot!(cb2.hexdump(), @"4180c07f");
-    assert_snapshot!(cb3.hexdump(), @"664183c001");
-    assert_snapshot!(cb4.hexdump(), @"664181c0ff7f");
-    assert_snapshot!(cb5.hexdump(), @"4183c001");
-    assert_snapshot!(cb6.hexdump(), @"4181c0ffffff7f");
-    assert_snapshot!(cb7.hexdump(), @"4983c001");
-    assert_snapshot!(cb8.hexdump(), @"4981c0ffffff7f");
+    assert_snapshot!(hexdumps!(cb1, cb2, cb3, cb4, cb5, cb6, cb7, cb8), @r"
+    4180c001
+    4180c07f
+    664183c001
+    664181c0ff7f
+    4183c001
+    4181c0ffffff7f
+    4983c001
+    4981c0ffffff7f
+    ");
 }
 
 #[test]
@@ -110,11 +122,16 @@ fn test_and() {
     let cb1 = compile(|cb| and(cb, EBP, R12D));
     let cb2 = compile(|cb| and(cb, mem_opnd(64, RAX, 0), imm_opnd(0x08)));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and ebp, r12d"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and qword ptr [rax], 8"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2), @r"
+    0x0: and ebp, r12d
+    0x0: and qword ptr [rax], 8
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"4421e5");
-    assert_snapshot!(cb2.hexdump(), @"48832008");
+    assert_snapshot!(hexdumps!(cb1, cb2), @r"
+    4421e5
+    48832008
+    ");
 }
 
 #[test]
@@ -124,7 +141,8 @@ fn test_call_label() {
         call_label(cb, label_idx);
         cb.link_labels();
     });
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: call 0"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: call 0");
     assert_snapshot!(cb.hexdump(), @"e8fbffffff");
 }
 
@@ -135,21 +153,24 @@ fn test_call_ptr() {
         let ptr = cb.get_write_ptr();
         call_ptr(cb, RAX, ptr.raw_ptr(cb));
     });
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: call 0"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: call 0");
     assert_snapshot!(cb.hexdump(), @"e8fbffffff");
 }
 
 #[test]
 fn test_call_reg() {
     let cb = compile(|cb| call(cb, RAX));
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: call rax"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: call rax");
     assert_snapshot!(cb.hexdump(), @"ffd0");
 }
 
 #[test]
 fn test_call_mem() {
     let cb = compile(|cb| call(cb, mem_opnd(64, RSP, 8)));
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: call qword ptr [rsp + 8]"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: call qword ptr [rsp + 8]");
     assert_snapshot!(cb.hexdump(), @"ff542408");
 }
 
@@ -161,17 +182,22 @@ fn test_cmovcc() {
     let cb4 = compile(|cb| cmovl(cb, RBX, RBP));
     let cb5 = compile(|cb| cmovle(cb, ESI, mem_opnd(32, RSP, 4)));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmovg esi, edi"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmovg esi, dword ptr [rbp + 0xc]"));
-    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmovl eax, ecx"));
-    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmovl rbx, rbp"));
-    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmovle esi, dword ptr [rsp + 4]"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2, cb3, cb4, cb5), @r"
+    0x0: cmovg esi, edi
+    0x0: cmovg esi, dword ptr [rbp + 0xc]
+    0x0: cmovl eax, ecx
+    0x0: cmovl rbx, rbp
+    0x0: cmovle esi, dword ptr [rsp + 4]
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"0f4ff7");
-    assert_snapshot!(cb2.hexdump(), @"0f4f750c");
-    assert_snapshot!(cb3.hexdump(), @"0f4cc1");
-    assert_snapshot!(cb4.hexdump(), @"480f4cdd");
-    assert_snapshot!(cb5.hexdump(), @"0f4e742404");
+    assert_snapshot!(hexdumps!(cb1, cb2, cb3, cb4, cb5), @r"
+    0f4ff7
+    0f4f750c
+    0f4cc1
+    480f4cdd
+    0f4e742404
+    ");
 }
 
 #[test]
@@ -182,23 +208,29 @@ fn test_cmp() {
     let cb4 = compile(|cb| cmp(cb, RAX, imm_opnd(2)));
     let cb5 = compile(|cb| cmp(cb, ECX, uimm_opnd(0x8000_0000)));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp cl, dl"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp ecx, edi"));
-    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp rdx, qword ptr [r12]"));
-    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp rax, 2"));
-    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp ecx, 0x80000000"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2, cb3, cb4, cb5), @r"
+    0x0: cmp cl, dl
+    0x0: cmp ecx, edi
+    0x0: cmp rdx, qword ptr [r12]
+    0x0: cmp rax, 2
+    0x0: cmp ecx, 0x80000000
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"38d1");
-    assert_snapshot!(cb2.hexdump(), @"39f9");
-    assert_snapshot!(cb3.hexdump(), @"493b1424");
-    assert_snapshot!(cb4.hexdump(), @"4883f802");
-    assert_snapshot!(cb5.hexdump(), @"81f900000080");
+    assert_snapshot!(hexdumps!(cb1, cb2, cb3, cb4, cb5), @r"
+    38d1
+    39f9
+    493b1424
+    4883f802
+    81f900000080
+    ");
 }
 
 #[test]
 fn test_cqo() {
     let cb = compile(cqo);
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cqo"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: cqo");
     assert_snapshot!(cb.hexdump(), @"4899");
 }
 
@@ -209,13 +241,18 @@ fn test_imul() {
     // Operands flipped for encoding since multiplication is commutative
     let cb3 = compile(|cb| imul(cb, mem_opnd(64, RAX, 0), RDX));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: imul rax, rbx"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: imul rdx, qword ptr [rax]"));
-    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: imul rdx, qword ptr [rax]"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2, cb3), @r"
+    0x0: imul rax, rbx
+    0x0: imul rdx, qword ptr [rax]
+    0x0: imul rdx, qword ptr [rax]
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"480fafc3");
-    assert_snapshot!(cb2.hexdump(), @"480faf10");
-    assert_snapshot!(cb3.hexdump(), @"480faf10");
+    assert_snapshot!(hexdumps!(cb1, cb2, cb3), @r"
+    480fafc3
+    480faf10
+    480faf10
+    ");
 }
 
 #[test]
@@ -225,7 +262,8 @@ fn test_jge_label() {
         jge_label(cb, label_idx);
         cb.link_labels();
     });
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jge 0"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: jge 0");
     assert_snapshot!(cb.hexdump(), @"0f8dfaffffff");
 }
 
@@ -246,17 +284,23 @@ fn test_jmp_label() {
         cb.link_labels();
     });
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jmp 5"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jmp 0"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2), @r"
+    0x0: jmp 5
+    0x0: jmp 0
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"e900000000");
-    assert_snapshot!(cb2.hexdump(), @"e9fbffffff");
+    assert_snapshot!(hexdumps!(cb1, cb2), @r"
+    e900000000
+    e9fbffffff
+    ");
 }
 
 #[test]
 fn test_jmp_rm() {
     let cb = compile(|cb| jmp_rm(cb, R12));
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jmp r12"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: jmp r12");
     assert_snapshot!(cb.hexdump(), @"41ffe4");
 }
 
@@ -267,7 +311,8 @@ fn test_jo_label() {
         jo_label(cb, label_idx);
         cb.link_labels();
     });
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: jo 0"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: jo 0");
     assert_snapshot!(cb.hexdump(), @"0f80faffffff");
 }
 
@@ -278,15 +323,20 @@ fn test_lea() {
     let cb3 = compile(|cb| lea(cb, RAX, mem_opnd(8, RIP, 5)));
     let cb4 = compile(|cb| lea(cb, RDI, mem_opnd(8, RIP, 5)));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rdx, [rcx + 8]"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rax, [rip]"));
-    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rax, [rip + 5]"));
-    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rdi, [rip + 5]"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2, cb3, cb4), @r"
+    0x0: lea rdx, [rcx + 8]
+    0x0: lea rax, [rip]
+    0x0: lea rax, [rip + 5]
+    0x0: lea rdi, [rip + 5]
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"488d5108");
-    assert_snapshot!(cb2.hexdump(), @"488d0500000000");
-    assert_snapshot!(cb3.hexdump(), @"488d0505000000");
-    assert_snapshot!(cb4.hexdump(), @"488d3d05000000");
+    assert_snapshot!(hexdumps!(cb1, cb2, cb3, cb4), @r"
+    488d5108
+    488d0500000000
+    488d0505000000
+    488d3d05000000
+    ");
 }
 
 #[test]
@@ -320,59 +370,70 @@ fn test_mov() {
     let cb25 = compile(|cb| mov(cb, mem_opnd(64, R11, 0), R10));
     let cb26 = compile(|cb| mov(cb, mem_opnd(64, RDX, -8), imm_opnd(-12)));
 
-    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 7"));
-    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 0xfffffffd"));
-    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r15d, 3"));
-    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, ebx"));
-    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, ecx"));
-    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov edx, dword ptr [rbx + 0x80]"));
-    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rax, qword ptr [rsp + 4]"));
-    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 0x34"));
-    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0x80000000"));
-    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0xffffffffffffffff"));
-    cb11.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 0x34"));
-    cb12.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs rax, 0xffc0000000000002"));
-    cb13.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs rax, 0x80000000"));
-    cb14.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs rax, 0xffffffffffffffcc"));
-    cb15.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs rax, 0xffffffffffffffff"));
-    cb16.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov cl, r9b"));
-    cb17.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rbx, rax"));
-    cb18.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rdi, rbx"));
-    cb19.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov sil, 0xb"));
-    cb20.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov byte ptr [rsp], 0xfd"));
-    cb21.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov qword ptr [rdi + 8], 1"));
-    cb22.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov dword ptr [rax + 4], 0x11"));
-    cb23.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov dword ptr [rax + 4], 0x80000001"));
-    cb24.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov dword ptr [r8 + 0x14], ebx"));
-    cb25.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov qword ptr [r11], r10"));
-    cb26.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov qword ptr [rdx - 8], 0xfffffffffffffff4"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(
+        cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12, cb13,
+        cb14, cb15, cb16, cb17, cb18, cb19, cb20, cb21, cb22, cb23, cb24, cb25, cb26,
+    ), @r"
+    0x0: mov eax, 7
+    0x0: mov eax, 0xfffffffd
+    0x0: mov r15d, 3
+    0x0: mov eax, ebx
+    0x0: mov eax, ecx
+    0x0: mov edx, dword ptr [rbx + 0x80]
+    0x0: mov rax, qword ptr [rsp + 4]
+    0x0: mov r8d, 0x34
+    0x0: movabs r8, 0x80000000
+    0x0: movabs r8, 0xffffffffffffffff
+    0x0: mov eax, 0x34
+    0x0: movabs rax, 0xffc0000000000002
+    0x0: movabs rax, 0x80000000
+    0x0: movabs rax, 0xffffffffffffffcc
+    0x0: movabs rax, 0xffffffffffffffff
+    0x0: mov cl, r9b
+    0x0: mov rbx, rax
+    0x0: mov rdi, rbx
+    0x0: mov sil, 0xb
+    0x0: mov byte ptr [rsp], 0xfd
+    0x0: mov qword ptr [rdi + 8], 1
+    0x0: mov dword ptr [rax + 4], 0x11
+    0x0: mov dword ptr [rax + 4], 0x80000001
+    0x0: mov dword ptr [r8 + 0x14], ebx
+    0x0: mov qword ptr [r11], r10
+    0x0: mov qword ptr [rdx - 8], 0xfffffffffffffff4
+    ");
 
-    assert_snapshot!(cb01.hexdump(), @"b807000000");
-    assert_snapshot!(cb02.hexdump(), @"b8fdffffff");
-    assert_snapshot!(cb03.hexdump(), @"41bf03000000");
-    assert_snapshot!(cb04.hexdump(), @"89d8");
-    assert_snapshot!(cb05.hexdump(), @"89c8");
-    assert_snapshot!(cb06.hexdump(), @"8b9380000000");
-    assert_snapshot!(cb07.hexdump(), @"488b442404");
-    assert_snapshot!(cb08.hexdump(), @"41b834000000");
-    assert_snapshot!(cb09.hexdump(), @"49b80000008000000000");
-    assert_snapshot!(cb10.hexdump(), @"49b8ffffffffffffffff");
-    assert_snapshot!(cb11.hexdump(), @"b834000000");
-    assert_snapshot!(cb12.hexdump(), @"48b8020000000000c0ff");
-    assert_snapshot!(cb13.hexdump(), @"48b80000008000000000");
-    assert_snapshot!(cb14.hexdump(), @"48b8ccffffffffffffff");
-    assert_snapshot!(cb15.hexdump(), @"48b8ffffffffffffffff");
-    assert_snapshot!(cb16.hexdump(), @"4488c9");
-    assert_snapshot!(cb17.hexdump(), @"4889c3");
-    assert_snapshot!(cb18.hexdump(), @"4889df");
-    assert_snapshot!(cb19.hexdump(), @"40b60b");
-    assert_snapshot!(cb20.hexdump(), @"c60424fd");
-    assert_snapshot!(cb21.hexdump(), @"48c7470801000000");
-    assert_snapshot!(cb22.hexdump(), @"c7400411000000");
-    assert_snapshot!(cb23.hexdump(), @"c7400401000080");
-    assert_snapshot!(cb24.hexdump(), @"41895814");
-    assert_snapshot!(cb25.hexdump(), @"4d8913");
-    assert_snapshot!(cb26.hexdump(), @"48c742f8f4ffffff");
+    assert_snapshot!(hexdumps!(
+        cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12, cb13,
+        cb14, cb15, cb16, cb17, cb18, cb19, cb20, cb21, cb22, cb23, cb24, cb25, cb26
+    ), @r"
+    b807000000
+    b8fdffffff
+    41bf03000000
+    89d8
+    89c8
+    8b9380000000
+    488b442404
+    41b834000000
+    49b80000008000000000
+    49b8ffffffffffffffff
+    b834000000
+    48b8020000000000c0ff
+    48b80000008000000000
+    48b8ccffffffffffffff
+    48b8ffffffffffffffff
+    4488c9
+    4889c3
+    4889df
+    40b60b
+    c60424fd
+    48c7470801000000
+    c7400411000000
+    c7400401000080
+    41895814
+    4d8913
+    48c742f8f4ffffff
+    ");
 }
 
 #[test]
@@ -380,11 +441,16 @@ fn test_movabs() {
     let cb1 = compile(|cb| movabs(cb, R8, 0x34));
     let cb2 = compile(|cb| movabs(cb, R8, 0x80000000));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0x34"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0x80000000"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2), @r"
+    0x0: movabs r8, 0x34
+    0x0: movabs r8, 0x80000000
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"49b83400000000000000");
-    assert_snapshot!(cb2.hexdump(), @"49b80000008000000000");
+    assert_snapshot!(hexdumps!(cb1, cb2), @r"
+    49b83400000000000000
+    49b80000008000000000
+    ");
 }
 
 #[test]
@@ -421,49 +487,54 @@ fn test_mov_unsigned() {
     // MOV r64, imm64, will not move down into 32 bit since it does not fit into 32 bits
     let cb21 = compile(|cb| mov(cb, R8, uimm_opnd(u64::MAX)));
 
-    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov al, 1"));
-    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov al, 0xff"));
-    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov ax, 1"));
-    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov ax, 0xffff"));
-    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 1"));
-    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 0xffffffff"));
-    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 0"));
-    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 0xffffffff"));
-    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 1"));
-    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, 0xffffffff"));
-    cb11.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs rax, 0x100000000"));
-    cb12.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs rax, 0xffffffffffffffff"));
-    cb13.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0xffffffffffffffff"));
-    cb14.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8b, 1"));
-    cb15.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8b, 0xff"));
-    cb16.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8w, 1"));
-    cb17.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8w, 0xffff"));
-    cb18.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 1"));
-    cb19.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 0xffffffff"));
-    cb20.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov r8d, 1"));
-    cb21.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movabs r8, 0xffffffffffffffff"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12, cb13, cb14, cb15, cb16, cb17, cb18, cb19, cb20, cb21), @r"
+    0x0: mov al, 1
+    0x0: mov al, 0xff
+    0x0: mov ax, 1
+    0x0: mov ax, 0xffff
+    0x0: mov eax, 1
+    0x0: mov eax, 0xffffffff
+    0x0: mov r8d, 0
+    0x0: mov r8d, 0xffffffff
+    0x0: mov eax, 1
+    0x0: mov eax, 0xffffffff
+    0x0: movabs rax, 0x100000000
+    0x0: movabs rax, 0xffffffffffffffff
+    0x0: movabs r8, 0xffffffffffffffff
+    0x0: mov r8b, 1
+    0x0: mov r8b, 0xff
+    0x0: mov r8w, 1
+    0x0: mov r8w, 0xffff
+    0x0: mov r8d, 1
+    0x0: mov r8d, 0xffffffff
+    0x0: mov r8d, 1
+    0x0: movabs r8, 0xffffffffffffffff
+    ");
 
-    assert_snapshot!(cb01.hexdump(), @"b001");
-    assert_snapshot!(cb02.hexdump(), @"b0ff");
-    assert_snapshot!(cb03.hexdump(), @"66b80100");
-    assert_snapshot!(cb04.hexdump(), @"66b8ffff");
-    assert_snapshot!(cb05.hexdump(), @"b801000000");
-    assert_snapshot!(cb06.hexdump(), @"b8ffffffff");
-    assert_snapshot!(cb07.hexdump(), @"41b800000000");
-    assert_snapshot!(cb08.hexdump(), @"41b8ffffffff");
-    assert_snapshot!(cb09.hexdump(), @"b801000000");
-    assert_snapshot!(cb10.hexdump(), @"b8ffffffff");
-    assert_snapshot!(cb11.hexdump(), @"48b80000000001000000");
-    assert_snapshot!(cb12.hexdump(), @"48b8ffffffffffffffff");
-    assert_snapshot!(cb13.hexdump(), @"49b8ffffffffffffffff");
-    assert_snapshot!(cb14.hexdump(), @"41b001");
-    assert_snapshot!(cb15.hexdump(), @"41b0ff");
-    assert_snapshot!(cb16.hexdump(), @"6641b80100");
-    assert_snapshot!(cb17.hexdump(), @"6641b8ffff");
-    assert_snapshot!(cb18.hexdump(), @"41b801000000");
-    assert_snapshot!(cb19.hexdump(), @"41b8ffffffff");
-    assert_snapshot!(cb20.hexdump(), @"41b801000000");
-    assert_snapshot!(cb21.hexdump(), @"49b8ffffffffffffffff");
+    assert_snapshot!(hexdumps!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12, cb13, cb14, cb15, cb16, cb17, cb18, cb19, cb20, cb21), @r"
+    b001
+    b0ff
+    66b80100
+    66b8ffff
+    b801000000
+    b8ffffffff
+    41b800000000
+    41b8ffffffff
+    b801000000
+    b8ffffffff
+    48b80000000001000000
+    48b8ffffffffffffffff
+    49b8ffffffffffffffff
+    41b001
+    41b0ff
+    6641b80100
+    6641b8ffff
+    41b801000000
+    41b8ffffffff
+    41b801000000
+    49b8ffffffffffffffff
+    ");
 }
 
 #[test]
@@ -474,17 +545,22 @@ fn test_mov_iprel() {
     let cb4 = compile(|cb| mov(cb, RAX, mem_opnd(64, RIP, 5)));
     let cb5 = compile(|cb| mov(cb, RDI, mem_opnd(64, RIP, 5)));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, dword ptr [rip]"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov eax, dword ptr [rip + 5]"));
-    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rax, qword ptr [rip]"));
-    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rax, qword ptr [rip + 5]"));
-    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: mov rdi, qword ptr [rip + 5]"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2, cb3, cb4, cb5), @r"
+    0x0: mov eax, dword ptr [rip]
+    0x0: mov eax, dword ptr [rip + 5]
+    0x0: mov rax, qword ptr [rip]
+    0x0: mov rax, qword ptr [rip + 5]
+    0x0: mov rdi, qword ptr [rip + 5]
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"8b0500000000");
-    assert_snapshot!(cb2.hexdump(), @"8b0505000000");
-    assert_snapshot!(cb3.hexdump(), @"488b0500000000");
-    assert_snapshot!(cb4.hexdump(), @"488b0505000000");
-    assert_snapshot!(cb5.hexdump(), @"488b3d05000000");
+    assert_snapshot!(hexdumps!(cb1, cb2, cb3, cb4, cb5), @r"
+    8b0500000000
+    8b0505000000
+    488b0500000000
+    488b0505000000
+    488b3d05000000
+    ");
 }
 
 #[test]
@@ -498,23 +574,28 @@ fn test_movsx() {
     let cb7 = compile(|cb| movsx(cb, RAX, mem_opnd(8, RSP, 0)));
     let cb8 = compile(|cb| movsx(cb, RDX, mem_opnd(16, R13, 4)));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx ax, al"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx edx, al"));
-    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx rax, bl"));
-    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx ecx, ax"));
-    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx r11, cl"));
-    cb6.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsxd r10, dword ptr [rsp + 0xc]"));
-    cb7.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx rax, byte ptr [rsp]"));
-    cb8.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: movsx rdx, word ptr [r13 + 4]"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2, cb3, cb4, cb5, cb6, cb7, cb8), @r"
+    0x0: movsx ax, al
+    0x0: movsx edx, al
+    0x0: movsx rax, bl
+    0x0: movsx ecx, ax
+    0x0: movsx r11, cl
+    0x0: movsxd r10, dword ptr [rsp + 0xc]
+    0x0: movsx rax, byte ptr [rsp]
+    0x0: movsx rdx, word ptr [r13 + 4]
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"660fbec0");
-    assert_snapshot!(cb2.hexdump(), @"0fbed0");
-    assert_snapshot!(cb3.hexdump(), @"480fbec3");
-    assert_snapshot!(cb4.hexdump(), @"0fbfc8");
-    assert_snapshot!(cb5.hexdump(), @"4c0fbed9");
-    assert_snapshot!(cb6.hexdump(), @"4c6354240c");
-    assert_snapshot!(cb7.hexdump(), @"480fbe0424");
-    assert_snapshot!(cb8.hexdump(), @"490fbf5504");
+    assert_snapshot!(hexdumps!(cb1, cb2, cb3, cb4, cb5, cb6, cb7, cb8), @r"
+    660fbec0
+    0fbed0
+    480fbec3
+    0fbfc8
+    4c0fbed9
+    4c6354240c
+    480fbe0424
+    490fbf5504
+    ");
 }
 
 #[test]
@@ -532,40 +613,39 @@ fn test_nop() {
     let cb11 = compile(|cb| nop(cb, 11));
     let cb12 = compile(|cb| nop(cb, 12));
 
-    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop"));
-    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop"));
-    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop dword ptr [rax]"));
-    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop dword ptr [rax]"));
-    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop dword ptr [rax + rax]"));
-    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop word ptr [rax + rax]"));
-    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop dword ptr [rax]"));
-    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop dword ptr [rax + rax]"));
-    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: nop word ptr [rax + rax]"));
-    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12), @r"
+    0x0: nop
+    0x0: nop
+    0x0: nop dword ptr [rax]
+    0x0: nop dword ptr [rax]
+    0x0: nop dword ptr [rax + rax]
+    0x0: nop word ptr [rax + rax]
+    0x0: nop dword ptr [rax]
+    0x0: nop dword ptr [rax + rax]
+    0x0: nop word ptr [rax + rax]
     0x0: nop word ptr [rax + rax]
     0x9: nop
-    "));
-    cb11.with_disasm(|disasm| assert_snapshot!(disasm, @r"
     0x0: nop word ptr [rax + rax]
     0x9: nop
-    "));
-    cb12.with_disasm(|disasm| assert_snapshot!(disasm, @r"
     0x0: nop word ptr [rax + rax]
     0x9: nop dword ptr [rax]
-    "));
+    ");
 
-    assert_snapshot!(cb01.hexdump(), @"90");
-    assert_snapshot!(cb02.hexdump(), @"6690");
-    assert_snapshot!(cb03.hexdump(), @"0f1f00");
-    assert_snapshot!(cb04.hexdump(), @"0f1f4000");
-    assert_snapshot!(cb05.hexdump(), @"0f1f440000");
-    assert_snapshot!(cb06.hexdump(), @"660f1f440000");
-    assert_snapshot!(cb07.hexdump(), @"0f1f8000000000");
-    assert_snapshot!(cb08.hexdump(), @"0f1f840000000000");
-    assert_snapshot!(cb09.hexdump(), @"660f1f840000000000");
-    assert_snapshot!(cb10.hexdump(), @"660f1f84000000000090");
-    assert_snapshot!(cb11.hexdump(), @"660f1f8400000000006690");
-    assert_snapshot!(cb12.hexdump(), @"660f1f8400000000000f1f00");
+    assert_snapshot!(hexdumps!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12), @r"
+    90
+    6690
+    0f1f00
+    0f1f4000
+    0f1f440000
+    660f1f440000
+    0f1f8000000000
+    0f1f840000000000
+    660f1f840000000000
+    660f1f84000000000090
+    660f1f8400000000006690
+    660f1f8400000000000f1f00
+    ");
 }
 
 #[test]
@@ -588,47 +668,53 @@ fn test_not() {
     let cb16 = compile(|cb| not(cb, mem_opnd(32, RDX, -55)));
     let cb17 = compile(|cb| not(cb, mem_opnd(32, RDX, -555)));
 
-    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not ax"));
-    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not eax"));
-    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not qword ptr [r12]"));
-    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rsp + 0x12d]"));
-    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rsp]"));
-    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rsp + 3]"));
-    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rbp]"));
-    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rbp + 0xd]"));
-    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not rax"));
-    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not r11"));
-    cb11.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rax]"));
-    cb12.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rsi]"));
-    cb13.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rdi]"));
-    cb14.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rdx + 0x37]"));
-    cb15.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rdx + 0x539]"));
-    cb16.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rdx - 0x37]"));
-    cb17.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: not dword ptr [rdx - 0x22b]"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12, cb13, cb14, cb15, cb16, cb17), @r"
+    0x0: not ax
+    0x0: not eax
+    0x0: not qword ptr [r12]
+    0x0: not dword ptr [rsp + 0x12d]
+    0x0: not dword ptr [rsp]
+    0x0: not dword ptr [rsp + 3]
+    0x0: not dword ptr [rbp]
+    0x0: not dword ptr [rbp + 0xd]
+    0x0: not rax
+    0x0: not r11
+    0x0: not dword ptr [rax]
+    0x0: not dword ptr [rsi]
+    0x0: not dword ptr [rdi]
+    0x0: not dword ptr [rdx + 0x37]
+    0x0: not dword ptr [rdx + 0x539]
+    0x0: not dword ptr [rdx - 0x37]
+    0x0: not dword ptr [rdx - 0x22b]
+    ");
 
-    assert_snapshot!(cb01.hexdump(), @"66f7d0");
-    assert_snapshot!(cb02.hexdump(), @"f7d0");
-    assert_snapshot!(cb03.hexdump(), @"49f71424");
-    assert_snapshot!(cb04.hexdump(), @"f794242d010000");
-    assert_snapshot!(cb05.hexdump(), @"f71424");
-    assert_snapshot!(cb06.hexdump(), @"f7542403");
-    assert_snapshot!(cb07.hexdump(), @"f75500");
-    assert_snapshot!(cb08.hexdump(), @"f7550d");
-    assert_snapshot!(cb09.hexdump(), @"48f7d0");
-    assert_snapshot!(cb10.hexdump(), @"49f7d3");
-    assert_snapshot!(cb11.hexdump(), @"f710");
-    assert_snapshot!(cb12.hexdump(), @"f716");
-    assert_snapshot!(cb13.hexdump(), @"f717");
-    assert_snapshot!(cb14.hexdump(), @"f75237");
-    assert_snapshot!(cb15.hexdump(), @"f79239050000");
-    assert_snapshot!(cb16.hexdump(), @"f752c9");
-    assert_snapshot!(cb17.hexdump(), @"f792d5fdffff");
+    assert_snapshot!(hexdumps!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12, cb13, cb14, cb15, cb16, cb17), @r"
+    66f7d0
+    f7d0
+    49f71424
+    f794242d010000
+    f71424
+    f7542403
+    f75500
+    f7550d
+    48f7d0
+    49f7d3
+    f710
+    f716
+    f717
+    f75237
+    f79239050000
+    f752c9
+    f792d5fdffff
+    ");
 }
 
 #[test]
 fn test_or() {
     let cb = compile(|cb| or(cb, EDX, ESI));
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: or edx, esi"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: or edx, esi");
     assert_snapshot!(cb.hexdump(), @"09f2");
 }
 
@@ -645,27 +731,32 @@ fn test_pop() {
     let cb09 = compile(|cb| pop(cb, mem_opnd_sib(64, RAX, RCX, 8, 3)));
     let cb10 = compile(|cb| pop(cb, mem_opnd_sib(64, R8, RCX, 8, 3)));
 
-    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop rax"));
-    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop rbx"));
-    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop rsp"));
-    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop rbp"));
-    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop r12"));
-    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop qword ptr [rax]"));
-    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop qword ptr [r8]"));
-    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop qword ptr [r8 + 3]"));
-    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop qword ptr [rax + rcx*8 + 3]"));
-    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: pop qword ptr [r8 + rcx*8 + 3]"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10), @r"
+    0x0: pop rax
+    0x0: pop rbx
+    0x0: pop rsp
+    0x0: pop rbp
+    0x0: pop r12
+    0x0: pop qword ptr [rax]
+    0x0: pop qword ptr [r8]
+    0x0: pop qword ptr [r8 + 3]
+    0x0: pop qword ptr [rax + rcx*8 + 3]
+    0x0: pop qword ptr [r8 + rcx*8 + 3]
+    ");
 
-    assert_snapshot!(cb01.hexdump(), @"58");
-    assert_snapshot!(cb02.hexdump(), @"5b");
-    assert_snapshot!(cb03.hexdump(), @"5c");
-    assert_snapshot!(cb04.hexdump(), @"5d");
-    assert_snapshot!(cb05.hexdump(), @"415c");
-    assert_snapshot!(cb06.hexdump(), @"8f00");
-    assert_snapshot!(cb07.hexdump(), @"418f00");
-    assert_snapshot!(cb08.hexdump(), @"418f4003");
-    assert_snapshot!(cb09.hexdump(), @"8f44c803");
-    assert_snapshot!(cb10.hexdump(), @"418f44c803");
+    assert_snapshot!(hexdumps!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10), @r"
+    58
+    5b
+    5c
+    5d
+    415c
+    8f00
+    418f00
+    418f4003
+    8f44c803
+    418f44c803
+    ");
 }
 
 #[test]
@@ -679,29 +770,35 @@ fn test_push() {
     let cb7 = compile(|cb| push(cb, mem_opnd_sib(64, RAX, RCX, 8, 3)));
     let cb8 = compile(|cb| push(cb, mem_opnd_sib(64, R8, RCX, 8, 3)));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push rax"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push rbx"));
-    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push r12"));
-    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push qword ptr [rax]"));
-    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push qword ptr [r8]"));
-    cb6.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push qword ptr [r8 + 3]"));
-    cb7.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push qword ptr [rax + rcx*8 + 3]"));
-    cb8.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: push qword ptr [r8 + rcx*8 + 3]"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2, cb3, cb4, cb5, cb6, cb7, cb8), @r"
+    0x0: push rax
+    0x0: push rbx
+    0x0: push r12
+    0x0: push qword ptr [rax]
+    0x0: push qword ptr [r8]
+    0x0: push qword ptr [r8 + 3]
+    0x0: push qword ptr [rax + rcx*8 + 3]
+    0x0: push qword ptr [r8 + rcx*8 + 3]
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"50");
-    assert_snapshot!(cb2.hexdump(), @"53");
-    assert_snapshot!(cb3.hexdump(), @"4154");
-    assert_snapshot!(cb4.hexdump(), @"ff30");
-    assert_snapshot!(cb5.hexdump(), @"41ff30");
-    assert_snapshot!(cb6.hexdump(), @"41ff7003");
-    assert_snapshot!(cb7.hexdump(), @"ff74c803");
-    assert_snapshot!(cb8.hexdump(), @"41ff74c803");
+    assert_snapshot!(hexdumps!(cb1, cb2, cb3, cb4, cb5, cb6, cb7, cb8), @r"
+    50
+    53
+    4154
+    ff30
+    41ff30
+    41ff7003
+    ff74c803
+    41ff74c803
+    ");
 }
 
 #[test]
 fn test_ret() {
     let cb = compile(ret);
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: ret"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: ret");
     assert_snapshot!(cb.hexdump(), @"c3");
 }
 
@@ -713,30 +810,37 @@ fn test_sal() {
     let cb4 = compile(|cb| sal(cb, mem_opnd(32, RSP, 68), uimm_opnd(1)));
     let cb5 = compile(|cb| sal(cb, RCX, CL));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shl cx, 1"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shl ecx, 1"));
-    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shl ebp, 5"));
-    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shl dword ptr [rsp + 0x44], 1"));
-    cb5.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shl rcx, cl"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2, cb3, cb4, cb5), @r"
+    0x0: shl cx, 1
+    0x0: shl ecx, 1
+    0x0: shl ebp, 5
+    0x0: shl dword ptr [rsp + 0x44], 1
+    0x0: shl rcx, cl
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"66d1e1");
-    assert_snapshot!(cb2.hexdump(), @"d1e1");
-    assert_snapshot!(cb3.hexdump(), @"c1e505");
-    assert_snapshot!(cb4.hexdump(), @"d1642444");
-    assert_snapshot!(cb5.hexdump(), @"48d3e1");
+    assert_snapshot!(hexdumps!(cb1, cb2, cb3, cb4, cb5), @r"
+    66d1e1
+    d1e1
+    c1e505
+    d1642444
+    48d3e1
+    ");
 }
 
 #[test]
 fn test_sar() {
     let cb = compile(|cb| sar(cb, EDX, uimm_opnd(1)));
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sar edx, 1"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: sar edx, 1");
     assert_snapshot!(cb.hexdump(), @"d1fa");
 }
 
 #[test]
 fn test_shr() {
     let cb = compile(|cb| shr(cb, R14, uimm_opnd(7)));
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: shr r14, 7"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: shr r14, 7");
     assert_snapshot!(cb.hexdump(), @"49c1ee07");
 }
 
@@ -745,11 +849,16 @@ fn test_sub() {
     let cb1 = compile(|cb| sub(cb, EAX, imm_opnd(1)));
     let cb2 = compile(|cb| sub(cb, RAX, imm_opnd(2)));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub eax, 1"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub rax, 2"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2), @r"
+    0x0: sub eax, 1
+    0x0: sub rax, 2
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"83e801");
-    assert_snapshot!(cb2.hexdump(), @"4883e802");
+    assert_snapshot!(hexdumps!(cb1, cb2), @r"
+    83e801
+    4883e802
+    ");
 }
 
 #[test]
@@ -782,45 +891,50 @@ fn test_test() {
     let cb18 = compile(|cb| test(cb, mem_opnd(64, RSI, 64), imm_opnd(0x08)));
     let cb19 = compile(|cb| test(cb, RCX, imm_opnd(0x08)));
 
-    cb01.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test al, al"));
-    cb02.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test ax, ax"));
-    cb03.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test cl, 8"));
-    cb04.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test dl, 7"));
-    cb05.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test cl, 8"));
-    cb06.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test byte ptr [rdx + 8], 8"));
-    cb07.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test byte ptr [rdx + 8], 0xff"));
-    cb08.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test dx, 0xffff"));
-    cb09.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test word ptr [rdx + 8], 0xffff"));
-    cb10.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test byte ptr [rsi], 1"));
-    cb11.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test byte ptr [rsi + 0x10], 1"));
-    cb12.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test byte ptr [rsi - 0x10], 1"));
-    cb13.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test dword ptr [rsi + 0x40], eax"));
-    cb14.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test qword ptr [rdi + 0x2a], rax"));
-    cb15.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test rax, rax"));
-    cb16.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test rax, rsi"));
-    cb17.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test qword ptr [rsi + 0x40], -9"));
-    cb18.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test qword ptr [rsi + 0x40], 8"));
-    cb19.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test rcx, 8"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12, cb13, cb14, cb15, cb16, cb17, cb18, cb19), @r"
+    0x0: test al, al
+    0x0: test ax, ax
+    0x0: test cl, 8
+    0x0: test dl, 7
+    0x0: test cl, 8
+    0x0: test byte ptr [rdx + 8], 8
+    0x0: test byte ptr [rdx + 8], 0xff
+    0x0: test dx, 0xffff
+    0x0: test word ptr [rdx + 8], 0xffff
+    0x0: test byte ptr [rsi], 1
+    0x0: test byte ptr [rsi + 0x10], 1
+    0x0: test byte ptr [rsi - 0x10], 1
+    0x0: test dword ptr [rsi + 0x40], eax
+    0x0: test qword ptr [rdi + 0x2a], rax
+    0x0: test rax, rax
+    0x0: test rax, rsi
+    0x0: test qword ptr [rsi + 0x40], -9
+    0x0: test qword ptr [rsi + 0x40], 8
+    0x0: test rcx, 8
+    ");
 
-    assert_snapshot!(cb01.hexdump(), @"84c0");
-    assert_snapshot!(cb02.hexdump(), @"6685c0");
-    assert_snapshot!(cb03.hexdump(), @"f6c108");
-    assert_snapshot!(cb04.hexdump(), @"f6c207");
-    assert_snapshot!(cb05.hexdump(), @"f6c108");
-    assert_snapshot!(cb06.hexdump(), @"f6420808");
-    assert_snapshot!(cb07.hexdump(), @"f64208ff");
-    assert_snapshot!(cb08.hexdump(), @"66f7c2ffff");
-    assert_snapshot!(cb09.hexdump(), @"66f74208ffff");
-    assert_snapshot!(cb10.hexdump(), @"f60601");
-    assert_snapshot!(cb11.hexdump(), @"f6461001");
-    assert_snapshot!(cb12.hexdump(), @"f646f001");
-    assert_snapshot!(cb13.hexdump(), @"854640");
-    assert_snapshot!(cb14.hexdump(), @"4885472a");
-    assert_snapshot!(cb15.hexdump(), @"4885c0");
-    assert_snapshot!(cb16.hexdump(), @"4885f0");
-    assert_snapshot!(cb17.hexdump(), @"48f74640f7ffffff");
-    assert_snapshot!(cb18.hexdump(), @"48f7464008000000");
-    assert_snapshot!(cb19.hexdump(), @"48f7c108000000");
+    assert_snapshot!(hexdumps!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12, cb13, cb14, cb15, cb16, cb17, cb18, cb19), @r"
+    84c0
+    6685c0
+    f6c108
+    f6c207
+    f6c108
+    f6420808
+    f64208ff
+    66f7c2ffff
+    66f74208ffff
+    f60601
+    f6461001
+    f646f001
+    854640
+    4885472a
+    4885c0
+    4885f0
+    48f74640f7ffffff
+    48f7464008000000
+    48f7c108000000
+    ");
 }
 
 #[test]
@@ -830,21 +944,27 @@ fn test_xchg() {
     let cb3 = compile(|cb| xchg(cb, RCX, RBX));
     let cb4 = compile(|cb| xchg(cb, R9, R15));
 
-    cb1.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xchg rcx, rax"));
-    cb2.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xchg r13, rax"));
-    cb3.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xchg rcx, rbx"));
-    cb4.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xchg r9, r15"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(disasms!(cb1, cb2, cb3, cb4), @r"
+    0x0: xchg rcx, rax
+    0x0: xchg r13, rax
+    0x0: xchg rcx, rbx
+    0x0: xchg r9, r15
+    ");
 
-    assert_snapshot!(cb1.hexdump(), @"4891");
-    assert_snapshot!(cb2.hexdump(), @"4995");
-    assert_snapshot!(cb3.hexdump(), @"4887d9");
-    assert_snapshot!(cb4.hexdump(), @"4d87f9");
+    assert_snapshot!(hexdumps!(cb1, cb2, cb3, cb4), @r"
+    4891
+    4995
+    4887d9
+    4d87f9
+    ");
 }
 
 #[test]
 fn test_xor() {
     let cb = compile(|cb| xor(cb, EAX, EAX));
-    cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xor eax, eax"));
+    #[cfg(feature = "disasm")]
+    assert_snapshot!(cb.disasm(), @"  0x0: xor eax, eax");
     assert_snapshot!(cb.hexdump(), @"31c0");
 }
 

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1424,7 +1424,7 @@ fn merge_three_reg_mov(
 mod tests {
     #[cfg(feature = "disasm")]
     use crate::disasms_with;
-    use crate::hexdumps;
+    use crate::{assert_disasm_snapshot, hexdumps};
 
     use super::*;
     use insta::assert_snapshot;
@@ -1443,8 +1443,7 @@ mod tests {
         asm.mov(Opnd::Reg(TEMP_REGS[0]), out);
         asm.compile_with_num_regs(&mut cb, 2);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov x0, #3
             0x4: mul x0, x9, x0
             0x8: mov x1, x0
@@ -1463,8 +1462,7 @@ mod tests {
         asm.mov(sp, new_sp);
 
         asm.compile_with_num_regs(&mut cb, 2);
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: add sp, sp, #0x20
             0x4: sub sp, sp, #0x20
         ");
@@ -1480,8 +1478,7 @@ mod tests {
         asm.add_into(Opnd::Reg(X20_REG), 0x20.into());
 
         asm.compile_with_num_regs(&mut cb, 0);
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: add sp, sp, #8
             0x4: adds x20, x20, #0x20
         ");
@@ -1496,8 +1493,7 @@ mod tests {
         asm.load_into(Opnd::Reg(X1_REG), difference);
 
         asm.compile_with_num_regs(&mut cb, 1);
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov x0, #8
             0x4: subs x0, x0, x5
             0x8: mov x1, x0
@@ -1513,8 +1509,7 @@ mod tests {
         asm.cret(ret_val);
 
         asm.compile_with_num_regs(&mut cb, 1);
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: ldur x0, [x0]
             0x4: ret
         ");
@@ -1530,8 +1525,7 @@ mod tests {
         asm.compile_with_regs(&mut cb, vec![X3_REG]).unwrap();
 
         // Assert that only 2 instructions were written.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: adds x3, x0, x1
         0x4: stur x3, [x2]
         ");
@@ -1547,8 +1541,7 @@ mod tests {
 
         // Testing that we pad the string to the nearest 4-byte boundary to make
         // it easier to jump over.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: ldnp d8, d25, [x10, #-0x140]
         0x4: .byte 0x6f, 0x2c, 0x20, 0x77
         0x8: .byte 0x6f, 0x72, 0x6c, 0x64
@@ -1564,8 +1557,7 @@ mod tests {
         asm.cpush_all();
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: str x1, [sp, #-0x10]!
         0x4: str x9, [sp, #-0x10]!
         0x8: str x10, [sp, #-0x10]!
@@ -1587,8 +1579,7 @@ mod tests {
         asm.cpop_all();
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: msr nzcv, x16
         0x4: ldr x16, [sp], #0x10
         0x8: ldr x15, [sp], #0x10
@@ -1611,8 +1602,7 @@ mod tests {
         asm.frame_teardown(&[]);
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: stp x29, x30, [sp, #-0x10]!
         0x4: mov x29, sp
         0x8: mov sp, x29
@@ -1652,8 +1642,7 @@ mod tests {
             cb
         };
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(disasms_with!("\n", cb1, cb2, cb3), @r"
+        assert_disasm_snapshot!(disasms_with!("\n", cb1, cb2, cb3), @r"
         0x0: stp x29, x30, [sp, #-0x10]!
         0x4: mov x29, sp
         0x8: stp x20, x19, [sp, #-0x10]!
@@ -1700,8 +1689,7 @@ mod tests {
         asm.je(Target::CodePtr(target));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: b.eq #0x50
         0x4: nop
         0x8: nop
@@ -1722,8 +1710,7 @@ mod tests {
         asm.je(Target::CodePtr(target));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: b.ne #8
         0x4: b #0x200000
         0x8: nop
@@ -1749,8 +1736,7 @@ mod tests {
         }
 
         asm.compile_with_num_regs(&mut cb, 0);
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
             0x0: orr x0, xzr, #0x7fffffff
             0x4: add x0, sp, x0
             0x8: mov x0, #8
@@ -1785,8 +1771,7 @@ mod tests {
         asm.store(large_mem, large_mem);
 
         asm.compile_with_num_regs(&mut cb, 0);
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: sub x16, sp, #0x305
             0x4: ldur x16, [x16]
             0x8: stur x16, [x0]
@@ -1814,8 +1799,7 @@ mod tests {
         let gc_offsets = asm.arm64_emit(&mut cb).unwrap();
         assert_eq!(1, gc_offsets.len(), "VALUE source operand should be reported as gc offset");
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: ldr x16, #8
             0x4: b #0x10
             0x8: .byte 0x00, 0x10, 0x00, 0x00
@@ -1847,8 +1831,7 @@ mod tests {
         asm.store(Opnd::mem(64, SP, 0), opnd);
 
         asm.compile_with_num_regs(&mut cb, 1);
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: adr x16, #8
         0x4: mov x0, x16
         0x8: ldnp d8, d25, [x10, #-0x140]
@@ -1869,8 +1852,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         // Assert that two instructions were written: LDUR and STUR.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: ldur x0, [x21]
         0x4: stur x0, [x21]
         ");
@@ -1886,8 +1868,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         // Assert that three instructions were written: ADD, LDUR, and STUR.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: add x0, x21, #0x400
         0x4: ldur x0, [x0]
         0x8: stur x0, [x21]
@@ -1904,8 +1885,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         // Assert that three instructions were written: MOVZ, ADD, LDUR, and STUR.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov x0, #0x1001
         0x4: add x0, x21, x0, uxtx
         0x8: ldur x0, [x0]
@@ -1924,8 +1904,7 @@ mod tests {
 
         // Assert that only two instructions were written since the value is an
         // immediate.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov x0, #4
         0x4: stur x0, [x21]
         ");
@@ -1942,8 +1921,7 @@ mod tests {
 
         // Assert that five instructions were written since the value is not an
         // immediate and needs to be loaded into a register.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: ldr x0, #8
         0x4: b #0x10
         0x8: eon x0, x0, x30, ror #0
@@ -1962,8 +1940,7 @@ mod tests {
         // so this needs one register
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: orr x0, xzr, #0xffffffff
         0x4: tst w0, w0
         ");
@@ -1977,8 +1954,7 @@ mod tests {
         asm.test(w0, Opnd::UImm(0x80000001));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: tst w0, #0x80000001");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: tst w0, #0x80000001");
         assert_snapshot!(cb.hexdump(), @"1f040172");
     }
 
@@ -1990,8 +1966,7 @@ mod tests {
         asm.store(Opnd::mem(64, Opnd::Reg(X2_REG), 0), opnd);
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: orr x0, x0, x1
         0x4: stur x0, [x2]
         ");
@@ -2006,8 +1981,7 @@ mod tests {
         asm.store(Opnd::mem(64, Opnd::Reg(X2_REG), 0), opnd);
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: lsl x0, x0, #5
         0x4: stur x0, [x2]
         ");
@@ -2022,8 +1996,7 @@ mod tests {
         asm.store(Opnd::mem(64, Opnd::Reg(X2_REG), 0), opnd);
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: asr x0, x0, #5
         0x4: stur x0, [x2]
         ");
@@ -2038,8 +2011,7 @@ mod tests {
         asm.store(Opnd::mem(64, Opnd::Reg(X2_REG), 0), opnd);
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: lsr x0, x0, #5
         0x4: stur x0, [x2]
         ");
@@ -2054,8 +2026,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 0);
 
         // Assert that only one instruction was written.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: tst x0, x1");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: tst x0, x1");
         assert_snapshot!(cb.hexdump(), @"1f0001ea");
     }
 
@@ -2067,8 +2038,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 0);
 
         // Assert that only one instruction was written.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: tst x0, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: tst x0, #7");
         assert_snapshot!(cb.hexdump(), @"1f0840f2");
     }
 
@@ -2080,8 +2050,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         // Assert that a load and a test instruction were written.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov x0, #5
         0x4: tst x0, x0
         ");
@@ -2096,8 +2065,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 0);
 
         // Assert that only one instruction was written.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: tst x0, #7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: tst x0, #7");
         assert_snapshot!(cb.hexdump(), @"1f0840f2");
     }
 
@@ -2109,8 +2077,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         // Assert that a load and a test instruction were written.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov x0, #5
         0x4: tst x0, x0
         ");
@@ -2125,8 +2092,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         // Assert that a test instruction is written.
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: tst x0, #-7");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: tst x0, #-7");
         assert_snapshot!(cb.hexdump(), @"1ff47df2");
     }
 
@@ -2138,8 +2104,7 @@ mod tests {
         asm.cmp(shape_opnd, Opnd::UImm(4097));
         asm.compile_with_num_regs(&mut cb, 2);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: ldur w0, [x0, #6]
         0x4: mov x1, #0x1001
         0x8: cmp w0, w1
@@ -2155,8 +2120,7 @@ mod tests {
         asm.store(shape_opnd, Opnd::UImm(4097));
         asm.compile_with_num_regs(&mut cb, 2);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov x16, #0x1001
         0x4: sturh w16, [x0]
         ");
@@ -2171,8 +2135,7 @@ mod tests {
         asm.store(shape_opnd, Opnd::UImm(4097));
         asm.compile_with_num_regs(&mut cb, 2);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov x16, #0x1001
         0x4: stur w16, [x0, #6]
         ");
@@ -2188,8 +2151,7 @@ mod tests {
 
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: eor x0, x0, x1
             0x4: stur x0, [x2]
         ");
@@ -2227,8 +2189,7 @@ mod tests {
         asm.mov(Opnd::Reg(TEMP_REGS[0]), Opnd::mem(64, CFP, 8));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: ldur x1, [x19, #8]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: ldur x1, [x19, #8]");
         assert_snapshot!(cb.hexdump(), @"618240f8");
     }
 
@@ -2240,8 +2201,7 @@ mod tests {
         asm.mov(Opnd::Reg(TEMP_REGS[0]), Opnd::UImm(0x10000));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov x1, #0xffff
             0x4: orr x1, xzr, #0x10000
         ");
@@ -2256,8 +2216,7 @@ mod tests {
         asm.mov(Opnd::Reg(TEMP_REGS[0]), out);
         asm.compile_with_num_regs(&mut cb, 2);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov x0, #0x14
             0x4: mov x1, #0
             0x8: csel x1, x0, x1, lt
@@ -2302,8 +2261,7 @@ mod tests {
         asm.mov(Opnd::Reg(TEMP_REGS[0]), out);
         asm.compile_with_num_regs(&mut cb, 2);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: adds x0, x9, #1
             0x4: adds x1, x0, #1
         ");
@@ -2321,8 +2279,7 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov x16, #0
             0x4: blr x16
         ");
@@ -2342,8 +2299,7 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov x16, x0
             0x4: mov x0, x1
             0x8: mov x1, x16
@@ -2367,8 +2323,7 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov x16, x2
             0x4: mov x2, x3
             0x8: mov x3, x16
@@ -2394,8 +2349,7 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov x16, x0
             0x4: mov x0, x1
             0x8: mov x1, x2

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -919,6 +919,7 @@ impl Assembler
 #[cfg(test)]
 mod tests {
     use insta::assert_snapshot;
+    use crate::assert_disasm_snapshot;
     use super::*;
 
     fn setup_asm() -> (Assembler, CodeBlock) {
@@ -933,8 +934,7 @@ mod tests {
         let _ = asm.add(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: add rax, 0xff
         ");
@@ -949,8 +949,7 @@ mod tests {
         let _ = asm.add(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: add rax, r11
@@ -966,8 +965,7 @@ mod tests {
         let _ = asm.and(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: and rax, 0xff
         ");
@@ -982,8 +980,7 @@ mod tests {
         let _ = asm.and(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: and rax, r11
@@ -998,8 +995,7 @@ mod tests {
         asm.cmp(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: cmp rax, 0xff");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: cmp rax, 0xff");
         assert_snapshot!(cb.hexdump(), @"4881f8ff000000");
     }
 
@@ -1010,8 +1006,7 @@ mod tests {
         asm.cmp(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: movabs r11, 0xffffffffffff
         0xa: cmp rax, r11
         ");
@@ -1025,8 +1020,7 @@ mod tests {
         asm.cmp(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: cmp rax, -1");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: cmp rax, -1");
         assert_snapshot!(cb.hexdump(), @"4883f8ff");
     }
 
@@ -1039,8 +1033,7 @@ mod tests {
         asm.cmp(shape_opnd, Opnd::UImm(0xF000));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: cmp word ptr [rax + 6], 0xf000");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: cmp word ptr [rax + 6], 0xf000");
         assert_snapshot!(cb.hexdump(), @"6681780600f0");
     }
 
@@ -1053,8 +1046,7 @@ mod tests {
         asm.cmp(shape_opnd, Opnd::UImm(0xF000_0000));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: cmp dword ptr [rax + 4], 0xf0000000");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: cmp dword ptr [rax + 4], 0xf0000000");
         assert_snapshot!(cb.hexdump(), @"817804000000f0");
     }
 
@@ -1066,8 +1058,7 @@ mod tests {
         let _ = asm.or(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: or rax, 0xff
         ");
@@ -1082,8 +1073,7 @@ mod tests {
         let _ = asm.or(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: or rax, r11
@@ -1099,8 +1089,7 @@ mod tests {
         let _ = asm.sub(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: sub rax, 0xff
         ");
@@ -1115,8 +1104,7 @@ mod tests {
         let _ = asm.sub(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: sub rax, r11
@@ -1131,8 +1119,7 @@ mod tests {
         asm.test(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: test rax, 0xff");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: test rax, 0xff");
         assert_snapshot!(cb.hexdump(), @"48f7c0ff000000");
     }
 
@@ -1143,8 +1130,7 @@ mod tests {
         asm.test(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: movabs r11, 0xffffffffffff
         0xa: test rax, r11
         ");
@@ -1159,8 +1145,7 @@ mod tests {
         let _ = asm.xor(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: xor rax, 0xff
         ");
@@ -1175,8 +1160,7 @@ mod tests {
         let _ = asm.xor(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: xor rax, r11
@@ -1192,8 +1176,7 @@ mod tests {
         asm.mov(SP, sp); // should be merged to lea
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: lea rbx, [rbx + 8]");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: lea rbx, [rbx + 8]");
         assert_snapshot!(cb.hexdump(), @"488d5b08");
     }
 
@@ -1206,8 +1189,7 @@ mod tests {
         asm.mov(Opnd::mem(64, SP, 0), sp); // should NOT be merged to lea
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: movabs r11, 0xffffffffffff
         0xa: cmp rax, r11
         ");
@@ -1225,8 +1207,7 @@ mod tests {
         asm.mov(Opnd::Reg(RAX_REG), result);
         asm.compile_with_num_regs(&mut cb, 2);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov rax, qword ptr [rbx + 8]
         0x4: test rax, rax
         0x7: mov eax, 0x14
@@ -1245,8 +1226,7 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: add r13, 0x40");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: add r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983c540");
     }
 
@@ -1257,8 +1237,7 @@ mod tests {
         asm.add_into(CFP, Opnd::UImm(0x40));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: add r13, 0x40");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: add r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983c540");
     }
 
@@ -1270,8 +1249,7 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: sub r13, 0x40");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: sub r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983ed40");
     }
 
@@ -1282,8 +1260,7 @@ mod tests {
         asm.sub_into(CFP, Opnd::UImm(0x40));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: sub r13, 0x40");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: sub r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983ed40");
     }
 
@@ -1295,8 +1272,7 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: and r13, 0x40");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: and r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983e540");
     }
 
@@ -1308,8 +1284,7 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: or r13, 0x40");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: or r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983cd40");
     }
 
@@ -1321,8 +1296,7 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"  0x0: xor r13, 0x40");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: xor r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983f540");
     }
 
@@ -1337,8 +1311,7 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @r"
+        assert_disasm_snapshot!(cb.disasm(), @r"
         0x0: mov eax, 0
         0x5: call rax
         ");
@@ -1358,8 +1331,7 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov r11, rsi
             0x3: mov rsi, rdi
             0x6: mov rdi, r11
@@ -1383,8 +1355,7 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov r11, rsi
             0x3: mov rsi, rdi
             0x6: mov rdi, r11
@@ -1410,8 +1381,7 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov r11, rsi
             0x3: mov rsi, rdx
             0x6: mov rdx, rdi
@@ -1439,8 +1409,7 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, 3);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov eax, 1
             0x5: mov ecx, 2
             0xa: mov edx, 3
@@ -1469,8 +1438,7 @@ mod tests {
 
         asm.compile_with_num_regs(&mut cb, 1);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: cmp qword ptr [rbx + 0x10], 1
             0x5: mov edi, 4
             0xa: cmovg rdi, qword ptr [rbx]
@@ -1490,8 +1458,7 @@ mod tests {
 
         asm.compile_with_num_regs(&mut cb, 3);
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: movabs rax, 0x7f22c88d1930
             0xa: mov ecx, 4
             0xf: cmove rax, rcx
@@ -1509,8 +1476,8 @@ mod tests {
         asm.mov(shape_opnd, Opnd::Imm(0x8000_0001));
 
         asm.compile_with_num_regs(&mut cb, 0);
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov dword ptr [rax], 0x80000001
             0x6: mov dword ptr [rax], 0x80000001
         ");
@@ -1529,8 +1496,8 @@ mod tests {
         asm.frame_teardown(&[]);
 
         asm.compile_with_num_regs(&mut cb, 0);
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: push rbp
             0x1: mov rbp, rsp
             0x4: push r13
@@ -1563,8 +1530,7 @@ mod tests {
         let gc_offsets = asm.x86_emit(&mut cb).unwrap();
         assert_eq!(1, gc_offsets.len(), "VALUE source operand should be reported as gc offset");
 
-        #[cfg(feature = "disasm")]
-        assert_snapshot!(cb.disasm(), @"
+        assert_disasm_snapshot!(cb.disasm(), @"
             0x0: movabs r11, 0x1000
             0xa: mov qword ptr [rbx], r11
         ");

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -933,10 +933,11 @@ mod tests {
         let _ = asm.add(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: add rax, 0xff
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4889c04881c0ff000000");
     }
 
@@ -948,11 +949,12 @@ mod tests {
         let _ = asm.add(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: add rax, r11
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4889c049bbffffffffffff00004c01d8");
     }
 
@@ -964,10 +966,11 @@ mod tests {
         let _ = asm.and(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: and rax, 0xff
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4889c04881e0ff000000");
     }
 
@@ -979,11 +982,12 @@ mod tests {
         let _ = asm.and(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: and rax, r11
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4889c049bbffffffffffff00004c21d8");
     }
 
@@ -994,7 +998,8 @@ mod tests {
         asm.cmp(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp rax, 0xff"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: cmp rax, 0xff");
         assert_snapshot!(cb.hexdump(), @"4881f8ff000000");
     }
 
@@ -1005,10 +1010,11 @@ mod tests {
         asm.cmp(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: movabs r11, 0xffffffffffff
         0xa: cmp rax, r11
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"49bbffffffffffff00004c39d8");
     }
 
@@ -1019,7 +1025,8 @@ mod tests {
         asm.cmp(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp rax, -1"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: cmp rax, -1");
         assert_snapshot!(cb.hexdump(), @"4883f8ff");
     }
 
@@ -1032,7 +1039,8 @@ mod tests {
         asm.cmp(shape_opnd, Opnd::UImm(0xF000));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp word ptr [rax + 6], 0xf000"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: cmp word ptr [rax + 6], 0xf000");
         assert_snapshot!(cb.hexdump(), @"6681780600f0");
     }
 
@@ -1045,7 +1053,8 @@ mod tests {
         asm.cmp(shape_opnd, Opnd::UImm(0xF000_0000));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: cmp dword ptr [rax + 4], 0xf0000000"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: cmp dword ptr [rax + 4], 0xf0000000");
         assert_snapshot!(cb.hexdump(), @"817804000000f0");
     }
 
@@ -1057,10 +1066,11 @@ mod tests {
         let _ = asm.or(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: or rax, 0xff
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4889c04881c8ff000000");
     }
 
@@ -1072,11 +1082,12 @@ mod tests {
         let _ = asm.or(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: or rax, r11
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4889c049bbffffffffffff00004c09d8");
     }
 
@@ -1088,10 +1099,11 @@ mod tests {
         let _ = asm.sub(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: sub rax, 0xff
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4889c04881e8ff000000");
     }
 
@@ -1103,11 +1115,12 @@ mod tests {
         let _ = asm.sub(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: sub rax, r11
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4889c049bbffffffffffff00004c29d8");
     }
 
@@ -1118,7 +1131,8 @@ mod tests {
         asm.test(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: test rax, 0xff"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: test rax, 0xff");
         assert_snapshot!(cb.hexdump(), @"48f7c0ff000000");
     }
 
@@ -1129,10 +1143,11 @@ mod tests {
         asm.test(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 0);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: movabs r11, 0xffffffffffff
         0xa: test rax, r11
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"49bbffffffffffff00004c85d8");
     }
 
@@ -1144,10 +1159,11 @@ mod tests {
         let _ = asm.xor(Opnd::Reg(RAX_REG), Opnd::UImm(0xFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: xor rax, 0xff
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4889c04881f0ff000000");
     }
 
@@ -1159,11 +1175,12 @@ mod tests {
         let _ = asm.xor(Opnd::Reg(RAX_REG), Opnd::UImm(0xFFFF_FFFF_FFFF));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: mov rax, rax
         0x3: movabs r11, 0xffffffffffff
         0xd: xor rax, r11
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4889c049bbffffffffffff00004c31d8");
     }
 
@@ -1175,7 +1192,8 @@ mod tests {
         asm.mov(SP, sp); // should be merged to lea
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: lea rbx, [rbx + 8]"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: lea rbx, [rbx + 8]");
         assert_snapshot!(cb.hexdump(), @"488d5b08");
     }
 
@@ -1188,10 +1206,11 @@ mod tests {
         asm.mov(Opnd::mem(64, SP, 0), sp); // should NOT be merged to lea
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: movabs r11, 0xffffffffffff
         0xa: cmp rax, r11
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"49bbffffffffffff00004c39d8");
     }
 
@@ -1206,14 +1225,15 @@ mod tests {
         asm.mov(Opnd::Reg(RAX_REG), result);
         asm.compile_with_num_regs(&mut cb, 2);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: mov rax, qword ptr [rbx + 8]
         0x4: test rax, rax
         0x7: mov eax, 0x14
         0xc: mov ecx, 0
         0x11: cmovne rax, rcx
         0x15: mov rax, rax
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"488b43084885c0b814000000b900000000480f45c14889c0");
     }
 
@@ -1225,7 +1245,8 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r13, 0x40"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: add r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983c540");
     }
 
@@ -1236,7 +1257,8 @@ mod tests {
         asm.add_into(CFP, Opnd::UImm(0x40));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: add r13, 0x40"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: add r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983c540");
     }
 
@@ -1248,7 +1270,8 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub r13, 0x40"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: sub r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983ed40");
     }
 
@@ -1259,7 +1282,8 @@ mod tests {
         asm.sub_into(CFP, Opnd::UImm(0x40));
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: sub r13, 0x40"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: sub r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983ed40");
     }
 
@@ -1271,7 +1295,8 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: and r13, 0x40"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: and r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983e540");
     }
 
@@ -1283,7 +1308,8 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: or r13, 0x40"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: or r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983cd40");
     }
 
@@ -1295,7 +1321,8 @@ mod tests {
         asm.mov(CFP, sp); // should be merged to add
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"  0x0: xor r13, 0x40"));
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"  0x0: xor r13, 0x40");
         assert_snapshot!(cb.hexdump(), @"4983f540");
     }
 
@@ -1310,10 +1337,11 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @r"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @r"
         0x0: mov eax, 0
         0x5: call rax
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"b800000000ffd0");
     }
 
@@ -1330,13 +1358,14 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"
             0x0: mov r11, rsi
             0x3: mov rsi, rdi
             0x6: mov rdi, r11
             0x9: mov eax, 0
             0xe: call rax
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4989f34889fe4c89dfb800000000ffd0");
     }
 
@@ -1354,7 +1383,8 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"
             0x0: mov r11, rsi
             0x3: mov rsi, rdi
             0x6: mov rdi, r11
@@ -1363,7 +1393,7 @@ mod tests {
             0xf: mov rdx, r11
             0x12: mov eax, 0
             0x17: call rax
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4989f34889fe4c89df4989cb4889d14c89dab800000000ffd0");
     }
 
@@ -1380,14 +1410,15 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, ALLOC_REGS.len());
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"
             0x0: mov r11, rsi
             0x3: mov rsi, rdx
             0x6: mov rdx, rdi
             0x9: mov rdi, r11
             0xc: mov eax, 0
             0x11: call rax
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"4989f34889d64889fa4c89dfb800000000ffd0");
     }
 
@@ -1408,7 +1439,8 @@ mod tests {
         ]);
         asm.compile_with_num_regs(&mut cb, 3);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"
             0x0: mov eax, 1
             0x5: mov ecx, 2
             0xa: mov edx, 3
@@ -1419,7 +1451,7 @@ mod tests {
             0x1b: mov rdx, r11
             0x1e: mov eax, 0
             0x23: call rax
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"b801000000b902000000ba030000004889c74889ce4989cb4889d14c89dab800000000ffd0");
     }
 
@@ -1437,12 +1469,13 @@ mod tests {
 
         asm.compile_with_num_regs(&mut cb, 1);
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"
             0x0: cmp qword ptr [rbx + 0x10], 1
             0x5: mov edi, 4
             0xa: cmovg rdi, qword ptr [rbx]
             0xe: mov qword ptr [rbx], rdi
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"48837b1001bf04000000480f4f3b48893b");
     }
 
@@ -1458,12 +1491,12 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 3);
 
         #[cfg(feature = "disasm")]
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
+        assert_snapshot!(cb.disasm(), @"
             0x0: movabs rax, 0x7f22c88d1930
             0xa: mov ecx, 4
             0xf: cmove rax, rcx
             0x13: mov qword ptr [rbx], rax
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"48b830198dc8227f0000b904000000480f44c1488903");
     }
 
@@ -1477,10 +1510,10 @@ mod tests {
 
         asm.compile_with_num_regs(&mut cb, 0);
         #[cfg(feature = "disasm")]
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
+        assert_snapshot!(cb.disasm(), @"
             0x0: mov dword ptr [rax], 0x80000001
             0x6: mov dword ptr [rax], 0x80000001
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"c70001000080c70001000080");
     }
 
@@ -1496,7 +1529,8 @@ mod tests {
         asm.frame_teardown(&[]);
 
         asm.compile_with_num_regs(&mut cb, 0);
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"
             0x0: push rbp
             0x1: mov rbp, rsp
             0x4: push r13
@@ -1514,7 +1548,7 @@ mod tests {
             0x22: sub rsp, 0x30
             0x26: mov rsp, rbp
             0x29: pop rbp
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"554889e541555341544883ec084c8b6df8488b5df04c8b65e84889ec5dc3554889e54883ec304889ec5d");
     }
 
@@ -1529,10 +1563,11 @@ mod tests {
         let gc_offsets = asm.x86_emit(&mut cb).unwrap();
         assert_eq!(1, gc_offsets.len(), "VALUE source operand should be reported as gc offset");
 
-        cb.with_disasm(|disasm| assert_snapshot!(disasm, @"
+        #[cfg(feature = "disasm")]
+        assert_snapshot!(cb.disasm(), @"
             0x0: movabs r11, 0x1000
             0xa: mov qword ptr [rbx], r11
-        "));
+        ");
         assert_snapshot!(cb.hexdump(), @"49bb00100000000000004c891b");
     }
 }


### PR DESCRIPTION
This PR makes the following improvements on assembly tests:

* Make sure `assert_snapshot!` has nothing other than spaces before that macro on the line
    * When a snapshot spans across multiple lines, `zjit-test-update` copies code before that macro (e.g. `cb.with_disasm(|disasm|`) to those lines in the snapshot.
    * To avoid that, this PR uses `#[cfg(feature = "disasm")]` (in the previous line, not in the same line, to avoid such copies) instead of `with_disasm()`.
* Combine multiple `assert_snapshot!`s by introducing `disasms!` and `hexdumps!`
    * Like `hir_strings!`, it minimizes the number of `zjit-test` → `zjit-test-update` loops for snapshot updates.
* Add assembly assertions to tests in `zjit/src/backend/arm64/mod.rs` that are currently missing them
    * Some of them only test the code size like ` assert_eq!(16, cb.get_write_pos());` at the moment, but it's hard to understand what's changed from its failure. So it now tests the generated code instead.