### PR TITLE
docs: Fix formatting in windows.md for icon file inclusion

### DIFF
--- a/doc/windows.md
+++ b/doc/windows.md
@@ -285,6 +285,7 @@ Any icon files(`*.ico`) in the build directory, directories specified with
 _icondirs_ make variable and `win32` directory under the ruby
 source directory will be included in DLL or executable files, according
 to their base names.
+
     $(RUBY_INSTALL_NAME).ico or ruby.ico   --> $(RUBY_INSTALL_NAME).exe
     $(RUBYW_INSTALL_NAME).ico or rubyw.ico --> $(RUBYW_INSTALL_NAME).exe
     the others                             --> $(RUBY_SO_NAME).dll


### PR DESCRIPTION
On github, the preview is incorrect due to missing newline