### PR TITLE
[DOC] hash.c - fix 3 class doc typos

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -6912,7 +6912,7 @@ static const rb_data_type_t env_data_type = {
  *  A \Hash object maps each of its unique keys to a specific value.
  *
  *  A hash has certain similarities to an Array, but:
-
+ *
  *  - An array index is always an integer.
  *  - A hash key can be (almost) any object.
  *
@@ -7313,7 +7313,7 @@ static const rb_data_type_t env_data_type = {
  *  - #keys: Returns an array containing all keys in +self+.
  *  - #rassoc: Returns a 2-element array consisting of the key and value
  *    of the first-found entry having a given value.
- *  - #values: Returns an array containing all values in +self+/
+ *  - #values: Returns an array containing all values in +self+.
  *  - #values_at: Returns an array containing values for given keys.
  *
  *  ==== Methods for Assigning
@@ -7362,7 +7362,6 @@ static const rb_data_type_t env_data_type = {
  *
  *  ==== Methods for Transforming Keys and Values
  *
- *  - #flatten!: Returns +self+, flattened.
  *  - #invert: Returns a hash with the each key-value pair inverted.
  *  - #transform_keys: Returns a copy of +self+ with modified keys.
  *  - #transform_keys!: Modifies keys in +self+


### PR DESCRIPTION
```
ruby -e "puts Hash.new.respond_to?(:flatten!)" #-> false
```