### PR TITLE
Fixing the indication of test case failures in test-bundled-gems.rb

### DIFF
--- a/tool/test-bundled-gems.rb
+++ b/tool/test-bundled-gems.rb
@@ -129,7 +129,7 @@ File.foreach("#{gem_dir}/bundled_gems") do |line|
       puts colorize.decorate(mesg, "skip")
     else
       failed << gem
-      exit_code = $?.exitstatus if $?.exitstatus
+      exit_code = 1
     end
   end
 end


### PR DESCRIPTION
Even when a test case abnormally terminated due to a signal, test-bundled-gems.rb could still return an exit code of 0.
Because of this, CI might not detect failures even when test cases terminated abnormally.

This PR changes test-bundled-gems.rb statically returns 1 when test case ends with failure.