### PR TITLE
Add assertion to rb_gc_impl_writebarrier

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -6044,6 +6044,7 @@ rb_gc_impl_writebarrier(void *objspace_ptr, VALUE a, VALUE b)
 
     if (SPECIAL_CONST_P(b)) return;
 
+    GC_ASSERT(!during_gc);
     GC_ASSERT(RB_BUILTIN_TYPE(a) != T_NONE);
     GC_ASSERT(RB_BUILTIN_TYPE(a) != T_MOVED);
     GC_ASSERT(RB_BUILTIN_TYPE(a) != T_ZOMBIE);


### PR DESCRIPTION
We should only be executing WBs when GC is not running. We ran into this issue when debugging 3cd2407045a67838cf2ab949e5164676b6870958.