### PR TITLE
Clear fields on heap RStruct before allocating

### DIFF
--- a/struct.c
+++ b/struct.c
@@ -834,10 +834,13 @@ struct_alloc(VALUE klass)
     else {
         NEWOBJ_OF(st, struct RStruct, klass, flags, sizeof(struct RStruct), 0);
 
+        st->as.heap.ptr = NULL;
+        st->as.heap.fields_obj = 0;
+        st->as.heap.len = 0;
+
         st->as.heap.ptr = struct_heap_alloc((VALUE)st, n);
         rb_mem_clear((VALUE *)st->as.heap.ptr, n);
         st->as.heap.len = n;
-        st->as.heap.fields_obj = 0;
 
         return (VALUE)st;
     }


### PR DESCRIPTION
Now that we no longer explicitly set the first three elements, we need to ensure the object is in a state safe for GC before we call struct_heap_alloc, which may GC.