### PR TITLE
CI: Launchable: Fix errors at actions/setup-python on ppc64le/s390x

### DIFF
--- a/.github/actions/launchable/setup/action.yml
+++ b/.github/actions/launchable/setup/action.yml
@@ -92,14 +92,38 @@ runs:
       uses: actions/setup-python@871daa956ca9ea99f3c3e30acb424b7960676734 # v5.0.0
       with:
         python-version: "3.x"
-      if: steps.enable-launchable.outputs.enable-launchable
+      if: >-
+        ${{ steps.enable-launchable.outputs.enable-launchable
+        && !endsWith(inputs.os, 'ppc64le') && !endsWith(inputs.os, 's390x') }}
 
     - name: Set up Java
       uses: actions/setup-java@7a445ee88d4e23b52c33fdc7601e40278616c7f8 # v4.0.0
       with:
         distribution: 'temurin'
         java-version: '17'
-      if: steps.enable-launchable.outputs.enable-launchable
+      if: >-
+        ${{ steps.enable-launchable.outputs.enable-launchable
+        && !endsWith(inputs.os, 'ppc64le') && !endsWith(inputs.os, 's390x') }}
+
+    - name: Set up Java ppc64le
+      uses: actions/setup-java@7a445ee88d4e23b52c33fdc7601e40278616c7f8 # v4.0.0
+      with:
+        distribution: 'semeru'
+        architecture: 'ppc64le'
+        java-version: '17'
+      if: >-
+        ${{ steps.enable-launchable.outputs.enable-launchable
+        && endsWith(inputs.os, 'ppc64le') }}
+
+    - name: Set up Java s390x
+      uses: actions/setup-java@7a445ee88d4e23b52c33fdc7601e40278616c7f8 # v4.0.0
+      with:
+        distribution: 'semeru'
+        architecture: 's390x'
+        java-version: '17'
+      if: >-
+        ${{ steps.enable-launchable.outputs.enable-launchable
+        && endsWith(inputs.os, 's390x') }}
 
     - name: Set global vars
       id: global
@@ -142,7 +166,13 @@ runs:
       # Since updated PATH variable will be available in only subsequent actions, we need to add the path beforehand.
       # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
       run: echo "$(python -msite --user-base)/bin" >> $GITHUB_PATH
-      if: steps.enable-launchable.outputs.enable-launchable && startsWith(inputs.os, 'macos')
+      if: >-
+        ${{
+        steps.enable-launchable.outputs.enable-launchable
+        && (startsWith(inputs.os, 'macos')
+          || endsWith(inputs.os, 'ppc64le')
+          || endsWith(inputs.os, 's390x'))
+        }}
 
     - name: Set up Launchable
       id: setup-launchable


### PR DESCRIPTION
This PR is working in progress to fix the following errors.

https://github.com/ruby/ruby/actions/runs/18229870239

> The version '3.x' with architecture 's390x' was not found for Ubuntu 24.04.
> The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

> The version '3.x' with architecture 'ppc64' was not found for Ubuntu 24.04.
> The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
