### PR TITLE
ZJIT: Count CCallWithFrame as optimized_send_count

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -172,6 +172,7 @@ class << RubyVM::ZJIT
       :optimized_send_count,
       :iseq_optimized_send_count,
       :inline_cfunc_optimized_send_count,
+      :non_variadic_cfunc_optimized_send_count,
       :variadic_cfunc_optimized_send_count,
     ], buf:, stats:, right_align: true, base: :send_count)
     print_counters([

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -670,6 +670,8 @@ fn gen_patch_point(jit: &mut JITState, asm: &mut Assembler, invariant: &Invarian
 
 /// Generate code for a C function call that pushes a frame
 fn gen_ccall_with_frame(jit: &mut JITState, asm: &mut Assembler, cfunc: *const u8, args: Vec<Opnd>, cme: *const rb_callable_method_entry_t, state: &FrameState) -> lir::Opnd {
+    gen_incr_counter(asm, Counter::non_variadic_cfunc_optimized_send_count);
+
     gen_prepare_non_leaf_call(jit, asm, state);
 
     gen_push_frame(asm, args.len(), state, ControlFrame {

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -157,6 +157,7 @@ make_counters! {
     optimized_send {
         iseq_optimized_send_count,
         inline_cfunc_optimized_send_count,
+        non_variadic_cfunc_optimized_send_count,
         variadic_cfunc_optimized_send_count,
     }
 


### PR DESCRIPTION
`CCallWithFrame` https://github.com/ruby/ruby/pull/14661 is not dynamic dispatch, so when that specialization is applied, the number of calls removed from `dynamic_send_count` should be added into the other group, `optimized_send_count`.