### PR TITLE
Use LSAN_OPTIONS instead of ASAN_OPTIONS in mkmf

### DIFF
--- a/lib/mkmf.rb
+++ b/lib/mkmf.rb
@@ -419,7 +419,7 @@ MESSAGE
 
     # disable ASAN leak reporting - conftest programs almost always don't bother
     # to free their memory.
-    envs['ASAN_OPTIONS'] = "detect_leaks=0" unless ENV.key?('ASAN_OPTIONS')
+    envs['LSAN_OPTIONS'] = "detect_leaks=0" unless ENV.key?('LSAN_OPTIONS')
 
     return envs, expand[commands]
   end


### PR DESCRIPTION
Newer versions of clang's LSAN uses LSAN_OPTIONS environment variable instead of ASAN_OPTIONS.