### PR TITLE
ZJIT: strengthen test_reset_stats

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -2127,6 +2127,7 @@ class TestZJIT < Test::Unit::TestCase
         # After reset, counters should be zero or at least much smaller
         # (some instructions might execute between reset and reading stats)
         :zjit_insn_count.then { |s| initial_stats[s] > 0 && reset_stats[s] < initial_stats[s] },
+        :compiled_iseq_count.then { |s| initial_stats[s] > 0 && reset_stats[s] < initial_stats[s] }
       ].all?
     }, stats: true
   end


### PR DESCRIPTION
Adding complied_iseq_count to assertion, it's the good choice because:

1. Always incremented during the test
2. Always reset to zero
3. Always available (defeault count)