### PR TITLE
Also add LSAN_OPTIONS=handle_segv=0 in assert_segv

### DIFF
--- a/test/ruby/test_rubyoptions.rb
+++ b/test/ruby/test_rubyoptions.rb
@@ -858,7 +858,7 @@ class TestRubyOptions < Test::Unit::TestCase
     env['RUBY_CRASH_REPORT'] ||= nil # default to not passing down parent setting
     # ASAN registers a segv handler which prints out "AddressSanitizer: DEADLYSIGNAL" when
     # catching sigsegv; we don't expect that output, so suppress it.
-    env.update({'ASAN_OPTIONS' => 'handle_segv=0'})
+    env.update({'ASAN_OPTIONS' => 'handle_segv=0', 'LSAN_OPTIONS' => 'handle_segv=0'})
     args.unshift(env)
 
     test_stdin = ""


### PR DESCRIPTION
Just like ASAN, when running with LSAN, we also want to set handle_segv=0 in assert_segv to make sure that the tests pass.