### PR TITLE
Remove unused variable warning

### DIFF
--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -1592,7 +1592,6 @@ q.pop
 
   # [Bug #21342]
   def test_unlock_locked_mutex_with_collected_fiber
-    bug21127 = '[ruby-core:120930] [Bug #21127]'
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;
       5.times do


### PR DESCRIPTION
    $ make test/ruby/test_thread.rb RUBYOPT=-w >/dev/null
    test/ruby/test_thread.rb:1595: warning: assigned but unused variable - bug21127