### PR TITLE
Remove warning when generating $(arch)-fake.rb

### DIFF
--- a/template/fake.rb.in
+++ b/template/fake.rb.in
@@ -49,6 +49,7 @@ class Object
   else%><%=v.inspect%><%end%>
 % }
 end
+v=$VERBOSE;$VERBOSE=nil;module Ruby; end;$VERBOSE=v
 module Ruby
   constants.each {|n| remove_const n}
 % arg['versions'].each {|n, v|


### PR DESCRIPTION
This happens if BASERUBY is Ruby 3.4.

    $ rm -f *-fake.rb && make test-precheck RUBYOPT=-w >/dev/null
    build/arm64-darwin24-fake.rb:28: warning: ::Ruby is reserved for Ruby 3.5