### PR TITLE
Bump RDoc

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -39,7 +39,7 @@ ostruct             0.6.3   https://github.com/ruby/ostruct
 pstore              0.2.0   https://github.com/ruby/pstore
 benchmark           0.4.1   https://github.com/ruby/benchmark
 logger              1.7.0   https://github.com/ruby/logger
-rdoc                6.14.2  https://github.com/ruby/rdoc
+rdoc                6.15.0  https://github.com/ruby/rdoc ac2a6fbf62b584a8325a665a9e7b368388bc7df6
 win32ole            1.9.2   https://github.com/ruby/win32ole
 irb                 1.15.2  https://github.com/ruby/irb d43c3d764ae439706aa1b26a3ec299cc45eaed5b
 reline              0.6.2   https://github.com/ruby/reline


### PR DESCRIPTION
[RDoc 6.15.0](https://github.com/ruby/rdoc/releases/tag/v6.15.0) has some bug fixes and an enhancement that'll directly help docs.ruby-lang.org's search experience.