### PR TITLE
Sync Prism

### DIFF
--- a/test/prism/fixtures/string_concatination_frozen_false.txt
+++ b/test/prism/fixtures/string_concatination_frozen_false.txt
@@ -1,0 +1,5 @@
+# frozen_string_literal: false
+
+'foo' 'bar'
+
+'foo' 'bar' "baz#{bat}"

--- a/test/prism/fixtures/string_concatination_frozen_true.txt
+++ b/test/prism/fixtures/string_concatination_frozen_true.txt
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+'foo' 'bar'
+
+'foo' 'bar' "baz#{bat}"


### PR DESCRIPTION
to https://github.com/ruby/prism/commit/c89ca2af12ba20b4fd2c5ff43ebe25da1d81d8db

The diff is generated by `tool/sync_default_gems.rb prism`. They seem to come from https://github.com/ruby/prism/commit/474ad4259035c3df03f7b4b563ccd11cbac51ce6, but `ruby tool/sync_default_gems.rb prism 96eccfc70408c3d26f08f0a523be53cb3dd6d25b..d048418c964da70146fb65c49a50205cc148b7f8` doesn't succeed https://github.com/ruby/ruby/actions/runs/18298406027/job/52101460864, so this PR resorts to `tool/sync_default_gems.rb prism`.

We should improve `tool/sync_default_gems.rb` to avoid failing the sync like that, but now that we've re-enabled the gem sync at https://github.com/ruby/prism/pull/3673, let's start from the clean slate to make sure future sync doesn't fail just because it's already out-of-sync.

cc: @kddnewton 