### PR TITLE
Resurrect sync from GitHub to git.ruby-lang.org

### DIFF
--- a/.github/workflows/check_misc.yml
+++ b/.github/workflows/check_misc.yml
@@ -35,6 +35,18 @@ jobs:
         if: ${{ github.repository == 'ruby/ruby' && github.ref == 'refs/heads/master' && github.event_name == 'push' }}
         continue-on-error: true # The next auto-style should always run
 
+      # Sync git.ruby-lang.org before pushing new commits to avoid duplicated syncs
+      - name: Sync git.ruby-lang.org
+        env:
+          RUBY_GIT_SYNC_PRIVATE_KEY: ${{ secrets.RUBY_GIT_SYNC_PRIVATE_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$RUBY_GIT_SYNC_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 git.ruby-lang.org >> ~/.ssh/known_hosts
+          ssh -i ~/.ssh/id_ed25519 git-sync@git.ruby-lang.org 'sudo -u git /home/git/git.ruby-lang.org/bin/update-ruby.sh'
+        if: ${{ github.repository == 'ruby/ruby' && github.ref == 'refs/heads/master' && github.event_name == 'push' }}
+
       - uses: ./.github/actions/setup/directories
         with:
           makeup: true


### PR DESCRIPTION
Similarly to https://bugs.ruby-lang.org/issues/21628, we need to migrate webhook.cgi's responsibility to GitHub Actions.