### PR TITLE
Backport post_push.yml workflow to ruby_3_2

### DIFF
--- a/.github/workflows/post_push.yml
+++ b/.github/workflows/post_push.yml
@@ -1,0 +1,30 @@
+name: Post-push
+on:
+  push:
+    branches:
+      - master
+      - 'ruby_*_*'
+jobs:
+  hooks:
+    name: Post-push hooks
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'ruby/ruby' }}
+    steps:
+      - name: Sync git.ruby-lang.org
+        run: |
+          mkdir -p ~/.ssh
+          echo "$RUBY_GIT_SYNC_PRIVATE_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 git.ruby-lang.org >> ~/.ssh/known_hosts
+          ssh -i ~/.ssh/id_ed25519 git-sync@git.ruby-lang.org "sudo -u git /home/git/git.ruby-lang.org/bin/update-ruby.sh $GITHUB_REF"
+        env:
+          GITHUB_REF: ${{ github.ref }}
+          RUBY_GIT_SYNC_PRIVATE_KEY: ${{ secrets.RUBY_GIT_SYNC_PRIVATE_KEY }}
+        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/ruby_') }}
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - uses: ./.github/actions/slack
+        with:
+          SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }} # ruby-lang slack: ruby/simpler-alerts-bot
+        if: ${{ failure() }}


### PR DESCRIPTION
This PR backports part of [post_push.yml](https://github.com/ruby/ruby/blob/000165a51cb845c5af4b735a8ca42994708551af/.github/workflows/post_push.yml) (originally added in https://github.com/ruby/ruby/pull/14765) to resurrect sync from GitHub to git.ruby-lang.org, which used to be handled by webhook.cgi.