### PR TITLE
Backport fetch_changesets to ruby_3_4

### DIFF
--- a/.github/workflows/post_push.yml
+++ b/.github/workflows/post_push.yml
@@ -22,6 +22,13 @@ jobs:
           RUBY_GIT_SYNC_PRIVATE_KEY: ${{ secrets.RUBY_GIT_SYNC_PRIVATE_KEY }}
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/ruby_') }}
 
+      - name: Fetch changesets on bugs.ruby-lang.org
+        run: |
+          curl "https://bugs.ruby-lang.org/sys/fetch_changesets?key=${REDMINE_SYS_API_KEY}" -s --fail-with-body -w '* status: %{http_code}\n'
+        env:
+          REDMINE_SYS_API_KEY: ${{ secrets.REDMINE_SYS_API_KEY }}
+        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/ruby_') }}
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - uses: ./.github/actions/slack


### PR DESCRIPTION
To centralize post-push hooks in GitHub Actions, I moved the `/sys/fetch_changesets` API call from post-receive.sh https://github.com/ruby/git.ruby-lang.org/commit/8d24ac65b5aeb44f7a3212410d6911be621223d4 to post_push.yml https://github.com/ruby/ruby/compare/ac01ac11f951336702b347c81855aa60ff27c177...9ae3e20953edc20d8e21075e13c877ae42f47fa2.

This PR backports that change to ruby_3_4.