### PR TITLE
Omit unknown DNS issue of macOS 26.1 beta

### DIFF
--- a/test/resolv/test_dns.rb
+++ b/test/resolv/test_dns.rb
@@ -525,6 +525,8 @@ class TestResolvDNS < Test::Unit::TestCase
       if RUBY_PLATFORM.match?(/mingw/)
         # cannot repo locally
         omit 'Timeout Error on MinGW CI'
+      elsif macos?(26,1)
+        omit 'Timeout Error on macOS 26.1+'
       else
         raise Timeout::Error
       end


### PR DESCRIPTION
It's only happened with macOS 26.1 beta.

```
TestResolvDNS#test_no_server:
Test::Unit::ProxyError: Timeout::Error
    /path/to/ruby/test/resolv/test_dns.rb:531:in 'TestResolvDNS#test_no_server'
```

