### PR TITLE
Reapply "[ruby/rubygems] Fix constants in TAR to be frozen"

### DIFF
--- a/lib/rubygems/package/tar_header.rb
+++ b/lib/rubygems/package/tar_header.rb
@@ -56,7 +56,7 @@ class Gem::Package::TarHeader
   ##
   # Pack format for a tar header
 
-  PACK_FORMAT = "a100" + # name
+  PACK_FORMAT = ("a100" + # name
                 "a8"   + # mode
                 "a8"   + # uid
                 "a8"   + # gid
@@ -71,12 +71,12 @@ class Gem::Package::TarHeader
                 "a32"  + # gname
                 "a8"   + # devmajor
                 "a8"   + # devminor
-                "a155"   # prefix
+                "a155").freeze # prefix
 
   ##
   # Unpack format for a tar header
 
-  UNPACK_FORMAT = "A100" + # name
+  UNPACK_FORMAT = ("A100" + # name
                   "A8"   + # mode
                   "A8"   + # uid
                   "A8"   + # gid
@@ -91,7 +91,7 @@ class Gem::Package::TarHeader
                   "A32"  + # gname
                   "A8"   + # devmajor
                   "A8"   + # devminor
-                  "A155"   # prefix
+                  "A155").freeze # prefix
 
   attr_reader(*FIELDS)
 

--- a/test/rubygems/test_gem_package_tar_header.rb
+++ b/test/rubygems/test_gem_package_tar_header.rb
@@ -26,25 +26,6 @@ class TestGemPackageTarHeader < Gem::Package::TarTestCase
     @tar_header = Gem::Package::TarHeader.new header
   end
 
-  def test_decode_in_ractor
-    new_header = Ractor.new(@tar_header.to_s) do |str|
-      Gem::Package::TarHeader.from StringIO.new str
-    end.value
-
-    assert_headers_equal @tar_header, new_header
-  end if defined?(Ractor) && Ractor.instance_methods.include?(:value)
-
-  def test_encode_in_ractor
-    header_bytes = @tar_header.to_s
-
-    new_header = Ractor.new(header_bytes) do |str|
-      header = Gem::Package::TarHeader.from StringIO.new str
-      header.to_s
-    end.value
-
-    assert_headers_equal header_bytes, new_header
-  end if defined?(Ractor) && Ractor.instance_methods.include?(:value)
-
   def test_self_from
     io = TempIO.new @tar_header.to_s
 

--- a/test/rubygems/test_gem_package_tar_header_ractor.rb
+++ b/test/rubygems/test_gem_package_tar_header_ractor.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+require_relative "package/tar_test_case"
+
+class TestGemPackageTarHeaderRactor < Gem::Package::TarTestCase
+  ASSERT_HEADERS_EQUAL = <<~RUBY
+    def assert_headers_equal(expected, actual)
+      expected = expected.to_s unless String === expected
+      actual = actual.to_s unless String === actual
+
+      fields = %w[
+        name 100
+        mode 8
+        uid 8
+        gid 8
+        size 12
+        mtime 12
+        checksum 8
+        typeflag 1
+        linkname 100
+        magic 6
+        version 2
+        uname 32
+        gname 32
+        devmajor 8
+        devminor 8
+        prefix 155
+      ]
+
+      offset = 0
+
+      until fields.empty? do
+        name = fields.shift
+        length = fields.shift.to_i
+
+        if name == "checksum"
+          chksum_off = offset
+          offset += length
+          next
+        end
+
+        assert_equal expected[offset, length], actual[offset, length]
+
+        offset += length
+      end
+
+      assert_equal expected[chksum_off, 8], actual[chksum_off, 8]
+    end
+  RUBY
+
+  SETUP = <<~RUBY
+    header = {
+      name: "x",
+      mode: 0o644,
+      uid: 1000,
+      gid: 10_000,
+      size: 100,
+      mtime: 12_345,
+      typeflag: "0",
+      linkname: "link",
+      uname: "user",
+      gname: "group",
+      devmajor: 1,
+      devminor: 2,
+      prefix: "y",
+    }
+
+    tar_header = Gem::Package::TarHeader.new header
+  RUBY
+
+  def test_decode_in_ractor
+    assert_ractor(ASSERT_HEADERS_EQUAL + SETUP + <<~RUBY, require: ["rubygems/package", "stringio"])
+      new_header = Ractor.new(tar_header.to_s) do |str|
+        Gem::Package::TarHeader.from StringIO.new str
+      end.value
+
+      assert_headers_equal tar_header, new_header
+    RUBY
+  end
+
+  def test_encode_in_ractor
+    assert_ractor(ASSERT_HEADERS_EQUAL + SETUP + <<~RUBY, require: ["rubygems/package", "stringio"])
+      header_bytes = tar_header.to_s
+
+      new_header_bytes = Ractor.new(header_bytes) do |str|
+        new_header = Gem::Package::TarHeader.from StringIO.new str
+        new_header.to_s
+      end.value
+
+      assert_headers_equal header_bytes, new_header_bytes
+    RUBY
+  end
+end

--- a/tool/lib/core_assertions.rb
+++ b/tool/lib/core_assertions.rb
@@ -394,7 +394,11 @@ eom
         shim_value = "class Ractor; alias value take; end" unless Ractor.method_defined?(:value)
         shim_join = "class Ractor; alias join take; end" unless Ractor.method_defined?(:join)
 
-        require = "require #{require.inspect}" if require
+        if require
+          require = [require] unless require.is_a?(Array)
+          require = require.map {|r| "require #{r.inspect}"}.join("\n")
+        end
+
         if require_relative
           dir = File.dirname(caller_locations[0,1][0].absolute_path)
           full_path = File.expand_path(require_relative, dir)


### PR DESCRIPTION
This is reminder pull-request for me. https://github.com/ruby/rubygems/pull/9041 is broken with `ruby/ruby` test suite. We may need to wrap `assert_ractor` or `assert_separately` for them.
