### PR TITLE
Use Ruby 3.4 for sync_default_gems.rb

### DIFF
--- a/.github/workflows/sync_default_gems.yml
+++ b/.github/workflows/sync_default_gems.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           token: ${{ github.repository == 'ruby/ruby' && secrets.MATZBOT_AUTO_UPDATE_TOKEN || secrets.GITHUB_TOKEN }}
 
+      - uses: ruby/setup-ruby@ab177d40ee5483edb974554986f56b33477e21d0 # v1.265.0
+        with:
+          ruby-version: '3.4'
+          bundler: none
+
       - name: Run tool/sync_default_gems.rb
         id: sync
         run: |


### PR DESCRIPTION
```
tool/sync_default_gems.rb:177:in `block in <module:SyncDefaultGems>': undefined local variable or method `it' for SyncDefaultGems:Module (NameError)

      it.exclude << "lib/open3/jruby_windows.rb"
      ^^
	from <internal:kernel>:90:in `tap'
	from tool/sync_default_gems.rb:176:in `<module:SyncDefaultGems>'
	from tool/sync_default_gems.rb:10:in `<main>'
```