### PR TITLE
Add `rb_process_status_for` to `intern/process.h`.

### DIFF
--- a/include/ruby/internal/intern/process.h
+++ b/include/ruby/internal/intern/process.h
@@ -31,6 +31,16 @@ RBIMPL_SYMBOL_EXPORT_BEGIN()
 /* process.c */
 
 /**
+ * Creates a new instance of Process::Status.
+ *
+ * @param[in] pid The process ID.
+ * @param[in] status The process status.
+ * @param[in] error Error code.
+ * @return VALUE An instance of Process::Status.
+ */
+VALUE rb_process_status_new(rb_pid_t pid, int status, int error);
+
+/**
  * Wait for the specified process to terminate, reap it, and return its status.
  *
  * @param[in] pid The process ID to wait for.

--- a/include/ruby/internal/intern/process.h
+++ b/include/ruby/internal/intern/process.h
@@ -34,8 +34,8 @@ RBIMPL_SYMBOL_EXPORT_BEGIN()
  * Creates a new instance of Process::Status.
  *
  * @param[in] pid The process ID.
- * @param[in] status The process status.
- * @param[in] error Error code.
+ * @param[in] status The "waitpid status", as returned by waitpid(2). This is NOT the exit status/exit code, see waitpid(2).
+ * @param[in] error Error code (if waitpid(2) returned -1).
  * @return VALUE An instance of Process::Status.
  */
 VALUE rb_process_status_new(rb_pid_t pid, int status, int error);

--- a/include/ruby/internal/intern/process.h
+++ b/include/ruby/internal/intern/process.h
@@ -38,7 +38,7 @@ RBIMPL_SYMBOL_EXPORT_BEGIN()
  * @param[in] error Error code (if waitpid(2) returned -1).
  * @return VALUE An instance of Process::Status.
  */
-VALUE rb_process_status_new(rb_pid_t pid, int status, int error);
+VALUE rb_process_status_for(rb_pid_t pid, int status, int error);
 
 /**
  * Wait for the specified process to terminate, reap it, and return its status.

--- a/include/ruby/internal/intern/process.h
+++ b/include/ruby/internal/intern/process.h
@@ -31,12 +31,15 @@ RBIMPL_SYMBOL_EXPORT_BEGIN()
 /* process.c */
 
 /**
- * Creates a new instance of Process::Status.
+ * Returns the Ruby value representing a waitpid(2) outcome.
  *
- * @param[in] pid The process ID.
+ * This is intended for Fiber Scheduler implementations of process_wait. The
+ * returned value should be returned from the scheduler hook.
+ *
+ * @param[in] pid The process ID returned by waitpid(2), or -1 on error.
  * @param[in] status The "waitpid status", as returned by waitpid(2). This is NOT the exit status/exit code, see waitpid(2).
- * @param[in] error Error code (if waitpid(2) returned -1).
- * @return VALUE An instance of Process::Status.
+ * @param[in] error Error code when pid is -1.
+ * @return The Ruby value representing this process wait result.
  */
 VALUE rb_process_status_for(rb_pid_t pid, int status, int error);
 

--- a/process.c
+++ b/process.c
@@ -642,7 +642,7 @@ proc_s_last_status(VALUE mod)
 }
 
 VALUE
-rb_process_status_new(rb_pid_t pid, int status, int error)
+rb_process_status_for(rb_pid_t pid, int status, int error)
 {
     VALUE last_status = rb_process_status_allocate(rb_cProcessStatus);
     struct rb_process_status *data = RTYPEDDATA_GET_DATA(last_status);
@@ -681,7 +681,7 @@ process_status_load(VALUE real_obj, VALUE load_obj)
 void
 rb_last_status_set(int status, rb_pid_t pid)
 {
-    GET_THREAD()->last_status = rb_process_status_new(pid, status, 0);
+    GET_THREAD()->last_status = rb_process_status_for(pid, status, 0);
 }
 
 static void
@@ -1112,7 +1112,7 @@ rb_process_status_wait(rb_pid_t pid, int flags)
 
     if (waitpid_state.ret == 0) return Qnil;
 
-    return rb_process_status_new(waitpid_state.ret, waitpid_state.status, waitpid_state.errnum);
+    return rb_process_status_for(waitpid_state.ret, waitpid_state.status, waitpid_state.errnum);
 }
 
 /*


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21704

This PR exposes `rb_process_status_new` by adding its declaration to `intern/process.h`.

This is needed in order to allow `Fiber::Scheduler` implementations to directly create instances of `Process::Status`, instead of having to call `Process::Status.wait`. An io_uring-based fiber scheduler could implement `process_wait` by using `io_uring_prep_waitid`, which waits for a child to exit and returns the child PID and exit status, which are then be passed to `rb_process_status_new`.

cc @ioquatix 