### PR TITLE
Next Ruby version is 4.0, not 3.5

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -3695,7 +3695,7 @@ const_set(VALUE klass, ID id, VALUE val)
         }
     }
     if (klass == rb_cObject && id == idRuby) {
-        rb_warn_reserved_name_at(3.5, "::Ruby");
+        rb_warn_reserved_name_at(4.0, "::Ruby");
     }
 }
 


### PR DESCRIPTION
```
❯ ruby -we 'Ruby = 1'
-e:1: warning: ::Ruby is reserved for Ruby 3.5
```

The above output is not correct version now.