### PR TITLE
Delay GVL handoff on blocking operation

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -41,7 +41,7 @@ benchmark           0.5.0   https://github.com/ruby/benchmark
 logger              1.7.0   https://github.com/ruby/logger
 rdoc                6.17.0  https://github.com/ruby/rdoc
 win32ole            1.9.2   https://github.com/ruby/win32ole
-irb                 1.15.3  https://github.com/ruby/irb
+irb                 1.15.3  https://github.com/ruby/irb       1ceeae13d2a84ea6f105d568529f3cd256ffb16d
 reline              0.6.3   https://github.com/ruby/reline
 readline            0.0.4   https://github.com/ruby/readline
 fiddle              1.1.8   https://github.com/ruby/fiddle

--- a/test/-ext-/thread/test_instrumentation_api.rb
+++ b/test/-ext-/thread/test_instrumentation_api.rb
@@ -105,7 +105,10 @@ class TestThreadInstrumentation < Test::Unit::TestCase
 
     timeline = timeline_for(thread, full_timeline)
     assert_consistent_timeline(timeline)
-    assert_equal %i(started ready resumed suspended ready resumed suspended exited), timeline
+
+    # assert_equal %i(started ready resumed suspended ready resumed suspended exited), timeline
+    assert (%i(started ready resumed suspended ready resumed suspended exited) == timeline) ||
+           (%i(started ready resumed                         suspended exited) == timeline)
   ensure
     r&.close
     w&.close

--- a/test/-ext-/thread/test_instrumentation_api.rb
+++ b/test/-ext-/thread/test_instrumentation_api.rb
@@ -181,7 +181,8 @@ class TestThreadInstrumentation < Test::Unit::TestCase
 
       timeline = timeline_for(thread, full_timeline)
       assert_consistent_timeline(timeline)
-      assert_equal %i(started ready resumed suspended ready resumed suspended exited), timeline
+      assert (%i(started ready resumed suspended ready resumed suspended exited) == timeline) ||
+             (%i(started ready resumed suspended ready                   exited) == timeline)
     RUBY
   end
 

--- a/thread_none.c
+++ b/thread_none.c
@@ -26,11 +26,14 @@ thread_sched_to_running(struct rb_thread_sched *sched, rb_thread_t *th)
 }
 
 static void
-thread_sched_to_waiting(struct rb_thread_sched *sched, rb_thread_t *th)
+thread_sched_to_waiting(struct rb_thread_sched *sched, rb_thread_t *th, bool dummy_switch_immediate)
 {
 }
 
-#define thread_sched_to_dead thread_sched_to_waiting
+static void
+thread_sched_to_dead(struct rb_thread_sched *sched, rb_thread_t *th)
+{
+}
 
 static void
 thread_sched_yield(struct rb_thread_sched *sched, rb_thread_t *th)

--- a/thread_pthread.h
+++ b/thread_pthread.h
@@ -72,6 +72,7 @@ struct rb_thread_sched_item {
     struct rb_thread_sched_waiting waiting_reason;
 
     bool finished;
+    bool waiting;
     bool malloc_stack;
     void *context_stack;
     struct coroutine_context *context;


### PR DESCRIPTION
When a thread invokes the blocking operation such as I/O, the interpreter currently tries to pass the GVL to another thread immediately. However, if the blocking operation completes in a sufficiently short amount of time, the cost of context switching, especially on multi-core machines outweigh the benefit.

This patch introduces delayed GVL passing for blocking operations.

Scenario1: Short blocking operation

(1) `thread_sched_to_waiting_common()` does not immediately
    schedule another ready thread, but instead set the `waiting` flag.
(2) When the blocking operation finishes,
    `thread_sched_to_running_common()` is called without a context switching
    and `sched->running` is not changed.
    Clear the `waiting` flag and keep going.

Scenario2: Long blocking operation

(1) Same as above.
(2) The timer thread checks the running threads to provide
    timeslice every 10ms and finds the thread (th) performing
    blocking operation.
(3) The timer thread switches the running thread from th to another
    ready thread.
(4) When the blocking operation (on th) finishes,
    `thread_sched_to_running_common()` is called and `sched->running`
    should be another thread (or be NULL) GVL.

fix https://bugs.ruby-lang.org/issues/21685 (and the idea is from discussions)