### PR TITLE
Rollback to test-unit-3.7.3

### DIFF
--- a/.github/workflows/bundled_gems.yml
+++ b/.github/workflows/bundled_gems.yml
@@ -59,6 +59,7 @@ jobs:
         id: bundled_gems
         run: |
           ruby -i~ tool/update-bundled_gems.rb gems/bundled_gems >> $GITHUB_OUTPUT
+        if: ${{ env.UPDATE_NEWS_ENABLED == 'true' }}
 
       - name: Update spec/bundler/support/builders.rb
         run: |
@@ -66,6 +67,7 @@ jobs:
           rake_version = File.read("gems/bundled_gems")[/^rake\s+(\S+)/, 1]
           print ARGF.read.sub(/^ *def rake_version\s*\K".*?"/) {rake_version.dump}
         shell: ruby -i~ {0} spec/bundler/support/builders.rb
+        if: ${{ env.UPDATE_NEWS_ENABLED == 'true' }}
 
       - name: Maintain updated gems list in NEWS
         run: |

--- a/NEWS.md
+++ b/NEWS.md
@@ -378,8 +378,8 @@ The following bundled gems are updated.
   * 2.0.5 to [v3.0.0][power_assert-v3.0.0], [v3.0.1][power_assert-v3.0.1]
 * rake 13.3.1
   * 13.2.1 to [v13.3.0][rake-v13.3.0], [v13.3.1][rake-v13.3.1]
-* test-unit 3.7.5
-  * 3.6.7 to [3.6.8][test-unit-3.6.8], [3.6.9][test-unit-3.6.9], [3.7.0][test-unit-3.7.0], [3.7.1][test-unit-3.7.1], [3.7.2][test-unit-3.7.2], [3.7.3][test-unit-3.7.3], [3.7.4][test-unit-3.7.4], [3.7.5][test-unit-3.7.5]
+* test-unit 3.7.3
+  * 3.6.7 to [3.6.8][test-unit-3.6.8], [3.6.9][test-unit-3.6.9], [3.7.0][test-unit-3.7.0], [3.7.1][test-unit-3.7.1], [3.7.2][test-unit-3.7.2], [3.7.3][test-unit-3.7.3]
 * rexml 3.4.4
 * rss 0.3.2
   * 0.3.1 to [0.3.2][rss-0.3.2]
@@ -755,8 +755,6 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 [test-unit-3.7.1]: https://github.com/test-unit/test-unit/releases/tag/3.7.1
 [test-unit-3.7.2]: https://github.com/test-unit/test-unit/releases/tag/3.7.2
 [test-unit-3.7.3]: https://github.com/test-unit/test-unit/releases/tag/3.7.3
-[test-unit-3.7.4]: https://github.com/test-unit/test-unit/releases/tag/3.7.4
-[test-unit-3.7.5]: https://github.com/test-unit/test-unit/releases/tag/3.7.5
 [rss-0.3.2]: https://github.com/ruby/rss/releases/tag/0.3.2
 [net-ftp-v0.3.9]: https://github.com/ruby/net-ftp/releases/tag/v0.3.9
 [net-imap-v0.5.9]: https://github.com/ruby/net-imap/releases/tag/v0.5.9

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -9,7 +9,7 @@
 minitest            6.0.0  https://github.com/minitest/minitest
 power_assert        3.0.1   https://github.com/ruby/power_assert
 rake                13.3.1  https://github.com/ruby/rake
-test-unit           3.7.5   https://github.com/test-unit/test-unit
+test-unit           3.7.3   https://github.com/test-unit/test-unit
 rexml               3.4.4   https://github.com/ruby/rexml
 rss                 0.3.2   https://github.com/ruby/rss
 net-ftp             0.3.9   https://github.com/ruby/net-ftp


### PR DESCRIPTION
Rollback to test-unit 3.7.3. 3.7.5 is not working with rbs-3.10.0

https://github.com/ruby/ruby/actions/runs/20480628393/job/58853288287#step:22:353

```
  D:/a/ruby/ruby/src/.bundle/gems/test-unit-3.7.5/lib/test/unit/testcase.rb:641:in 'block (2 levels) in Test::Unit::TestCase#run': failed to allocate memory (NoMemoryError)
```