### PR TITLE
Rollback to minitest-5.27.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -373,7 +373,7 @@ The following default gems are updated.
 
 The following bundled gems are updated.
 
-* minitest 6.0.0
+* minitest 5.27.0
 * power_assert 3.0.1
   * 2.0.5 to [v3.0.0][power_assert-v3.0.0], [v3.0.1][power_assert-v3.0.1]
 * rake 13.3.1

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -6,7 +6,7 @@
 # - revision: revision in repository-url to test
 #   if `revision` is not given, "v"+`version` or `version` will be used.
 
-minitest            6.0.0  https://github.com/minitest/minitest
+minitest            5.27.0  https://github.com/minitest/minitest
 power_assert        3.0.1   https://github.com/ruby/power_assert
 rake                13.3.1  https://github.com/ruby/rake
 test-unit           3.7.5   https://github.com/test-unit/test-unit


### PR DESCRIPTION
Test of 6.0.0 is not working with 4.0.0 stable version.

https://github.com/ruby/actions/actions/runs/20488398805/job/58875672023#step:20:362

```
  rake aborted!
  NoMethodError: undefined method 'cov_filter=' for #<Hoe:0x00007fdb550fc840> (NoMethodError)

    self.cov_filter = %w[ tmp ]
        ^^^^^^^^^^^^^
  /home/runner/work/actions/actions/ruby-4.0.0/gems/src/minitest/Rakefile:20:in 'block in <top (required)>'
  /home/runner/work/actions/actions/ruby-4.0.0/.bundle/gems/hoe-3.20.0/lib/hoe.rb:394:in 'BasicObject#instance_eval'
  /home/runner/work/actions/actions/ruby-4.0.0/.bundle/gems/hoe-3.20.0/lib/hoe.rb:394:in 'Hoe.spec'
  /home/runner/work/actions/actions/ruby-4.0.0/gems/src/minitest/Rakefile:11:in '<top (required)>'
  /home/runner/work/actions/actions/ruby-4.0.0/.bundle/gems/rake-13.3.1/exe/rake:27:in '<top (required)>'
  (See full trace by running task with --trace)
```