### PR TITLE
New alloc_func Interface

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1074,7 +1074,7 @@ rb_gc_register_pinning_obj(VALUE obj)
 static inline void
 rb_data_object_check(VALUE klass)
 {
-    if (klass != rb_cObject && (rb_get_alloc_func(klass) == rb_class_allocate_instance)) {
+    if (klass != rb_cObject && (rb_get_raw_alloc_func(klass) == rb_class_allocate_instance)) {
         rb_undef_alloc_func(klass);
         rb_warn("undefining the allocator of T_DATA class %"PRIsVALUE, klass);
     }

--- a/internal/vm.h
+++ b/internal/vm.h
@@ -99,6 +99,10 @@ struct rb_iseq_struct;
 const struct rb_callcache *rb_vm_search_method_slowpath(const struct rb_callinfo *ci, VALUE klass);
 
 /* vm_method.c */
+typedef VALUE (*rb_copy_alloc_func_t)(VALUE klass, VALUE other);
+rb_alloc_func_t rb_get_raw_alloc_func(VALUE klass);
+void rb_define_copy_alloc_func(VALUE klass, rb_copy_alloc_func_t func);
+void rb_init_alloc_func(VALUE klass);
 int rb_ec_obj_respond_to(struct rb_execution_context_struct *ec, VALUE obj, ID id, int priv);
 
 /* vm_dump.c */

--- a/marshal.c
+++ b/marshal.c
@@ -137,7 +137,7 @@ void
 rb_marshal_define_compat(VALUE newclass, VALUE oldclass, VALUE (*dumper)(VALUE), VALUE (*loader)(VALUE, VALUE))
 {
     marshal_compat_t *compat;
-    rb_alloc_func_t allocator = rb_get_alloc_func(newclass);
+    rb_alloc_func_t allocator = rb_get_raw_alloc_func(newclass);
 
     if (!allocator) {
         rb_raise(rb_eTypeError, "no allocator");
@@ -946,7 +946,7 @@ w_object(VALUE obj, struct dump_arg *arg, int limit)
         hasiv = has_ivars(obj, (encname = encoding_name(obj, arg)), &ivobj);
         {
             st_data_t compat_data;
-            rb_alloc_func_t allocator = rb_get_alloc_func(RBASIC(obj)->klass);
+            rb_alloc_func_t allocator = rb_get_raw_alloc_func(RBASIC(obj)->klass);
             if (st_lookup(compat_allocator_tbl,
                           (st_data_t)allocator,
                           &compat_data)) {
@@ -1660,7 +1660,7 @@ r_fixup_compat(VALUE v, struct load_arg *arg)
     st_data_t key = (st_data_t)v;
     if (arg->compat_tbl && st_delete(arg->compat_tbl, &key, &data)) {
         VALUE real_obj = (VALUE)data;
-        rb_alloc_func_t allocator = rb_get_alloc_func(CLASS_OF(real_obj));
+        rb_alloc_func_t allocator = rb_get_raw_alloc_func(CLASS_OF(real_obj));
         if (st_lookup(compat_allocator_tbl, (st_data_t)allocator, &data)) {
             marshal_compat_t *compat = (marshal_compat_t*)data;
             compat->loader(real_obj, v);
@@ -1815,7 +1815,7 @@ obj_alloc_by_klass(VALUE klass, struct load_arg *arg, VALUE *oldclass)
     st_data_t data;
     rb_alloc_func_t allocator;
 
-    allocator = rb_get_alloc_func(klass);
+    allocator = rb_get_raw_alloc_func(klass);
     if (st_lookup(compat_allocator_tbl, (st_data_t)allocator, &data)) {
         marshal_compat_t *compat = (marshal_compat_t*)data;
         VALUE real_obj = rb_obj_alloc(klass);
@@ -2197,7 +2197,7 @@ r_object_for(struct load_arg *arg, bool partial, int *ivp, VALUE extmod, int typ
             }
             v = load_funcall(arg, klass, s_load, 1, &data);
             v = r_entry(v, arg);
-            if (st_lookup(compat_allocator_tbl, (st_data_t)rb_get_alloc_func(klass), &d)) {
+            if (st_lookup(compat_allocator_tbl, (st_data_t)rb_get_raw_alloc_func(klass), &d)) {
                 marshal_compat_t *compat = (marshal_compat_t*)d;
                 v = compat->loader(klass, v);
             }

--- a/object.c
+++ b/object.c
@@ -571,9 +571,19 @@ rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze)
 }
 
 static VALUE
+obj_alloc_copy(VALUE obj)
+{
+    VALUE klass = rb_obj_class(obj);
+    if (klass && RCLASS_EXT_PRIME(klass)->copy_allocator) {
+        return RCLASS_COPY_ALLOCATOR(klass)(klass, obj);
+    }
+    return rb_obj_alloc(klass);
+}
+
+static VALUE
 mutable_obj_clone(VALUE obj, VALUE kwfreeze)
 {
-    VALUE clone = rb_obj_alloc(rb_obj_class(obj));
+    VALUE clone = obj_alloc_copy(obj);
     return rb_obj_clone_setup(obj, clone, kwfreeze);
 }
 
@@ -640,7 +650,7 @@ rb_obj_dup(VALUE obj)
     if (special_object_p(obj)) {
         return obj;
     }
-    dup = rb_obj_alloc(rb_obj_class(obj));
+    dup = obj_alloc_copy(obj);
     return rb_obj_dup_setup(obj, dup);
 }
 
@@ -2307,7 +2317,12 @@ class_call_alloc_func(rb_alloc_func_t allocator, VALUE klass)
 
     RUBY_DTRACE_CREATE_HOOK(OBJECT, rb_class2name(klass));
 
-    obj = (*allocator)(klass);
+    if (RCLASS_EXT_PRIME(klass)->copy_allocator) {
+        obj = (*((rb_copy_alloc_func_t)allocator))(klass, Qundef);
+    }
+    else {
+        obj = (*allocator)(klass);
+    }
 
     if (UNLIKELY(RBASIC_CLASS(obj) != klass)) {
         if (rb_obj_class(obj) != rb_class_real(klass)) {

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5892,7 +5892,7 @@ vm_declare_class(ID id, rb_num_t flags, VALUE cbase, VALUE super)
     /* new class declaration */
     VALUE s = VM_DEFINECLASS_HAS_SUPERCLASS_P(flags) ? super : rb_cObject;
     VALUE c = declare_under(id, cbase, rb_define_class_id(id, s));
-    rb_define_alloc_func(c, rb_get_alloc_func(c));
+    rb_init_alloc_func(c);
     rb_class_inherited(s, c);
     return c;
 }


### PR DESCRIPTION
[Bug #21818]

Currently exceptions can be sent across ractors, but because of a limitation in the API, the exception backtrace is duped as an empty backtrace.

The problem is that backtraces are embedded objects, hence the classic `rb_class_alloc(klass)` API is insufficient because we need to know the size of the Backtrace object we're duping to instantiate the copy.

This is solved by introducing a replacement for `rb_define_alloc_func` which takes a function that receive both the class and the object being copied.

When used for an initial allocation, the copied object is set to Qundef.