### PR TITLE
Add YJIT test for outdated comment

### DIFF
--- a/test/ruby/test_struct.rb
+++ b/test/ruby/test_struct.rb
@@ -41,8 +41,14 @@ module TestStruct
     end
   end
 
+  MAX_EMBEDDED_MEMBERS = (
+    GC::INTERNAL_CONSTANTS[:RVARGC_MAX_ALLOCATE_SIZE] -
+    GC::INTERNAL_CONSTANTS[:RBASIC_SIZE] -
+    GC::INTERNAL_CONSTANTS[:RVALUE_OVERHEAD]
+  ) / RbConfig::SIZEOF["void*"]
+
   def test_larger_than_largest_pool
-    count = (GC::INTERNAL_CONSTANTS[:RVARGC_MAX_ALLOCATE_SIZE] / RbConfig::SIZEOF["void*"]) + 1
+    count = MAX_EMBEDDED_MEMBERS + 1
     list = Array(0..count)
     klass = @Struct.new(*list.map { |i| :"a_#{i}"})
     struct = klass.new(*list)

--- a/test/ruby/test_yjit.rb
+++ b/test/ruby/test_yjit.rb
@@ -644,6 +644,40 @@ class TestYJIT < Test::Unit::TestCase
     RUBY
   end
 
+  STRUCT_MAX_EMBEDDED_MEMBERS = (
+    GC::INTERNAL_CONSTANTS[:RVARGC_MAX_ALLOCATE_SIZE] -
+    GC::INTERNAL_CONSTANTS[:RBASIC_SIZE] -
+    GC::INTERNAL_CONSTANTS[:RVALUE_OVERHEAD]
+  ) / RbConfig::SIZEOF["void*"]
+
+  def test_spilled_struct_aref
+    omit("FIXME: https://github.com/Shopify/ruby/issues/977")
+    assert_compiles(<<~RUBY)
+      LargeStruct = Struct.new(:foo, :bar, *(#{STRUCT_MAX_EMBEDDED_MEMBERS} - 2).times.map { :"m_\#{it}" })
+
+      def foo(obj)
+        foo = obj.foo
+        raise "Expected 1, got: \#{foo}" unless foo == 1
+        bar = obj.bar
+        raise "Expected 2, got: \#{bar}" unless bar == 2
+      end
+
+      embedded_struct = LargeStruct.new(1, 2)
+      # Bump RCLASS_MAX_IV_COUNT for LargeStruct
+      embedded_struct.instance_variable_set(:@test, 1)
+
+      # Next allocation reserves space for the imemo/fields reference.
+      heap_struct = LargeStruct.new(1, 2)
+
+      RubyVM::YJIT.reset_stats!
+
+      foo(embedded_struct)
+      foo(embedded_struct)
+      foo(heap_struct)
+      foo(heap_struct)
+    RUBY
+  end
+
   def test_struct_aset
     assert_compiles(<<~RUBY)
       def foo(obj)

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -8987,9 +8987,9 @@ fn gen_struct_aref(
         handle_opt_send_shift_stack(asm, argc);
     }
 
-    // All structs from the same Struct class should have the same
+    // All structs from the same Struct class and shape_id should have the same
     // length. So if our comptime_recv is embedded all runtime
-    // structs of the same class should be as well, and the same is
+    // structs of the same class and shape_id should be as well, and the same is
     // true of the converse.
     let embedded = unsafe { FL_TEST_RAW(comptime_recv, VALUE(RSTRUCT_EMBED_LEN_MASK)) };
 


### PR DESCRIPTION
As of Ruby 4.0, the YJIT comment isn't quite correct because we now store the reference to the `imemo/fields` object inline.

Which means that a Struct of precisely 78 members (max embeddable on 64bit archs) can cohexist in embedded and heap shapes as demonstrated by the added tests.

If the comment was correct I would expect we could easily crash YJIT, but I'm unable to, so I suspect there is a guard I'm not seeing that already handle that.

cc @eregon @tekknolagi I just stumbled on this, I'm actually surprised it doesn't crash, but can't figure out how? Do any of you know?

I think we should add a test case for that corner case and update the comment, but I'd need help for that.
