### PR TITLE
[Bug #21629] Initialize `struct RString`

### DIFF
--- a/error.c
+++ b/error.c
@@ -2067,7 +2067,7 @@ name_err_mesg_to_str(VALUE obj)
     mesg = ptr[NAME_ERR_MESG__MESG];
     if (NIL_P(mesg)) return Qnil;
     else {
-        struct RString s_str, d_str;
+        struct RString s_str = {RBASIC_INIT}, d_str = {RBASIC_INIT};
         VALUE c, s, d = 0, args[4];
         int state = 0, singleton = 0;
         rb_encoding *usascii = rb_usascii_encoding();

--- a/include/ruby/internal/core/rbasic.h
+++ b/include/ruby/internal/core/rbasic.h
@@ -104,6 +104,9 @@ RBasic {
         klass(RBIMPL_VALUE_NULL)
     {
     }
+# define RBASIC_INIT RBasic()
+#else
+# define RBASIC_INIT {RBIMPL_VALUE_NULL}
 #endif
 };
 

--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -462,7 +462,7 @@ rbimpl_rstring_getmem(VALUE str)
     }
     else {
         /* Expecting compilers to optimize this on-stack struct away. */
-        struct RString retval;
+        struct RString retval = {RBASIC_INIT};
         retval.as.heap.len = RSTRING_EMBED_LEN(str);
         retval.as.heap.ptr = RSTRING(str)->as.embed.ary;
         return retval;

--- a/load.c
+++ b/load.c
@@ -1295,7 +1295,7 @@ rb_require_internal(VALUE fname)
 int
 ruby_require_internal(const char *fname, unsigned int len)
 {
-    struct RString fake;
+    struct RString fake = {RBASIC_INIT};
     VALUE str = rb_setup_fake_str(&fake, fname, len, 0);
     rb_execution_context_t *ec = GET_EC();
     int result = require_internal(ec, str, 0, RTEST(ruby_verbose));
@@ -1328,7 +1328,7 @@ rb_require_string_internal(VALUE fname)
 VALUE
 rb_require(const char *fname)
 {
-    struct RString fake;
+    struct RString fake = {RBASIC_INIT};
     VALUE str = rb_setup_fake_str(&fake, fname, strlen(fname), 0);
     return rb_require_string_internal(str);
 }

--- a/marshal.c
+++ b/marshal.c
@@ -1398,7 +1398,7 @@ long
 ruby_marshal_read_long(const char **buf, long len)
 {
     long x;
-    struct RString src;
+    struct RString src = {RBASIC_INIT};
     struct load_arg arg;
     memset(&arg, 0, sizeof(arg));
     arg.src = rb_setup_fake_str(&src, *buf, len, 0);

--- a/string.c
+++ b/string.c
@@ -548,14 +548,14 @@ rb_setup_fake_str(struct RString *fake_str, const char *name, long len, rb_encod
 MJIT_FUNC_EXPORTED VALUE
 rb_fstring_new(const char *ptr, long len)
 {
-    struct RString fake_str;
+    struct RString fake_str = {RBASIC_INIT};
     return register_fstring(setup_fake_str(&fake_str, ptr, len, ENCINDEX_US_ASCII), FALSE);
 }
 
 VALUE
 rb_fstring_enc_new(const char *ptr, long len, rb_encoding *enc)
 {
-    struct RString fake_str;
+    struct RString fake_str = {RBASIC_INIT};
     return register_fstring(rb_setup_fake_str(&fake_str, ptr, len, enc), FALSE);
 }
 
@@ -11961,7 +11961,7 @@ rb_str_to_interned_str(VALUE str)
 VALUE
 rb_interned_str(const char *ptr, long len)
 {
-    struct RString fake_str;
+    struct RString fake_str = {RBASIC_INIT};
     return register_fstring(setup_fake_str(&fake_str, ptr, len, ENCINDEX_US_ASCII), TRUE);
 }
 
@@ -11978,7 +11978,7 @@ rb_enc_interned_str(const char *ptr, long len, rb_encoding *enc)
         rb_enc_autoload(enc);
     }
 
-    struct RString fake_str;
+    struct RString fake_str = {RBASIC_INIT};
     return register_fstring(rb_setup_fake_str(&fake_str, ptr, len, enc), TRUE);
 }
 

--- a/symbol.c
+++ b/symbol.c
@@ -726,7 +726,7 @@ ID
 rb_intern3(const char *name, long len, rb_encoding *enc)
 {
     VALUE sym;
-    struct RString fake_str;
+    struct RString fake_str = {RBASIC_INIT};
     VALUE str = rb_setup_fake_str(&fake_str, name, len, enc);
     OBJ_FREEZE(str);
     sym = lookup_str_sym(str);
@@ -1181,7 +1181,7 @@ rb_check_symbol(volatile VALUE *namep)
 ID
 rb_check_id_cstr(const char *ptr, long len, rb_encoding *enc)
 {
-    struct RString fake_str;
+    struct RString fake_str = {RBASIC_INIT};
     const VALUE name = rb_setup_fake_str(&fake_str, ptr, len, enc);
 
     sym_check_asciionly(name, true);
@@ -1193,7 +1193,7 @@ VALUE
 rb_check_symbol_cstr(const char *ptr, long len, rb_encoding *enc)
 {
     VALUE sym;
-    struct RString fake_str;
+    struct RString fake_str = {RBASIC_INIT};
     const VALUE name = rb_setup_fake_str(&fake_str, ptr, len, enc);
 
     sym_check_asciionly(name, true);
@@ -1217,7 +1217,7 @@ FUNC_MINIMIZED(VALUE rb_sym_intern_ascii_cstr(const char *ptr));
 VALUE
 rb_sym_intern(const char *ptr, long len, rb_encoding *enc)
 {
-    struct RString fake_str;
+    struct RString fake_str = {RBASIC_INIT};
     const VALUE name = rb_setup_fake_str(&fake_str, ptr, len, enc);
     return rb_str_intern(name);
 }


### PR DESCRIPTION
Fixes for https://rubyci.s3.amazonaws.com/icc-x64/ruby-3.2/log/20260122T045544Z.fail.html.gz