### PR TITLE
Workaround for directly loading Gem::Version

### DIFF
--- a/lib/rubygems/version.rb
+++ b/lib/rubygems/version.rb
@@ -150,6 +150,9 @@
 # For the last example, single-digit versions are automatically extended with
 # a zero to give a sensible result.
 
+# Workaround for directly loading Gem::Version in some cases
+module Gem; end
+
 class Gem::Version
   include Comparable
 


### PR DESCRIPTION
Fix for https://github.com/ruby/ruby/actions/runs/21352921118/job/61453585401