### PR TITLE
ZJIT: Emit run-time check for write barrier

### DIFF
--- a/zjit/Cargo.lock
+++ b/zjit/Cargo.lock
@@ -3,23 +3,28 @@
 version = 4
 
 [[package]]
-name = "capstone"
-version = "0.13.0"
+name = "bitflags"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015ef5d5ca1743e3f94af9509ba6bd2886523cfee46e48d15c2ef5216fd4ac9a"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "capstone"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f442ae0f2f3f1b923334b4a5386c95c69c1cfa072bafa23d6fae6d9682eb1dd4"
 dependencies = [
  "capstone-sys",
- "libc",
+ "static_assertions",
 ]
 
 [[package]]
 name = "capstone-sys"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2267cb8d16a1e4197863ec4284ffd1aec26fe7e57c58af46b02590a0235809a0"
+checksum = "a4e8087cab6731295f5a2a2bd82989ba4f41d3a428aab2e7c98d8f4db38aac05"
 dependencies = [
  "cc",
- "libc",
 ]
 
 [[package]]
@@ -32,26 +37,84 @@ dependencies = [
 ]
 
 [[package]]
-name = "dissimilar"
-version = "1.0.10"
+name = "cfg-if"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8975ffdaa0ef3661bfe02dbdcc06c9f829dfafe6a3c474de366a8d5e44276921"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "expect-test"
-version = "1.5.1"
+name = "console"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63af43ff4431e848fb47472a920f14fa71c24de13255a5692e93d4e90302acb0"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
- "dissimilar",
+ "encode_unicode",
+ "libc",
  "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.169"
+name = "encode_unicode"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "insta"
+version = "1.46.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
+name = "jit"
+version = "0.1.0"
+
+[[package]]
+name = "libc"
+version = "0.2.180"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "once_cell"
@@ -60,15 +123,163 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "tempfile"
+version = "3.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
 name = "zjit"
 version = "0.0.1"
 dependencies = [
  "capstone",
- "expect-test",
+ "insta",
+ "jit",
 ]

--- a/zjit/Cargo.toml
+++ b/zjit/Cargo.toml
@@ -8,7 +8,7 @@ publish = false         # Don't publish to crates.io
 [dependencies]
 # No required dependencies to simplify build process.
 # Optional For development and testing purposes.
-capstone = { version = "0.13.0", optional = true }
+capstone = { version = "0.14.0", optional = true }
 jit = { version = "0.1.0", path = "../jit" }
 
 [dev-dependencies]

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -167,6 +167,8 @@ fn main() {
         .allowlist_var("rb_cClass")
         .allowlist_var("rb_cRegexp")
         .allowlist_var("rb_cISeq")
+        .allowlist_var("rb_cRubyVM")
+        .allowlist_function("rb_const_get")
 
         .allowlist_type("ruby_fl_type")
         .allowlist_type("ruby_fl_ushift")

--- a/zjit/src/asm/arm64/mod.rs
+++ b/zjit/src/asm/arm64/mod.rs
@@ -1666,7 +1666,7 @@ mod tests {
     #[test]
     fn test_mov_immediate() {
         let cb = compile(|cb| mov(cb, X10, A64Opnd::new_uimm(0x5555555555555555)));
-        assert_disasm_snapshot!(cb.disasm(), @"  0x0: orr x10, xzr, #0x5555555555555555");
+        assert_disasm_snapshot!(cb.disasm(), @"  0x0: mov x10, #0x5555555555555555");
         assert_snapshot!(cb.hexdump(), @"eaf300b2");
     }
 

--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1902,7 +1902,7 @@ mod tests {
         0x0: ldnp d8, d25, [x10, #-0x140]
         0x4: .byte 0x6f, 0x2c, 0x20, 0x77
         0x8: .byte 0x6f, 0x72, 0x6c, 0x64
-        0xc: .byte 0x21, 0x00, 0x00, 0x00
+        0xc: udf #0x21
         ");
         assert_snapshot!(cb.hexdump(), @"48656c6c6f2c20776f726c6421000000");
     }
@@ -2053,7 +2053,7 @@ mod tests {
 
         asm.compile_with_num_regs(&mut cb, 0);
         assert_disasm_snapshot!(cb.disasm(), @r"
-            0x0: orr x0, xzr, #0x7fffffff
+            0x0: mov x0, #0x7fffffff
             0x4: add x0, sp, x0
             0x8: mov x0, #8
             0xc: movk x0, #1, lsl #16
@@ -2069,7 +2069,7 @@ mod tests {
             0x34: movk x0, #0xffff, lsl #32
             0x38: movk x0, #0xffff, lsl #48
             0x3c: add x0, sp, x0
-            0x40: orr x0, xzr, #0xffffffff80000000
+            0x40: mov x0, #-0x80000000
             0x44: add x0, sp, x0
         ");
         assert_snapshot!(cb.hexdump(), @"e07b40b2e063208b000180d22000a0f2e063208b000083d2e063208be0230891e02308d1e0ff8292e063208b00ff9fd2c0ffbff2e0ffdff2e0fffff2e063208be08361b2e063208b");
@@ -2137,8 +2137,8 @@ mod tests {
         assert_disasm_snapshot!(cb.disasm(), @"
             0x0: ldr x16, #8
             0x4: b #0x10
-            0x8: .byte 0x00, 0x10, 0x00, 0x00
-            0xc: .byte 0x00, 0x00, 0x00, 0x00
+            0x8: udf #0x1000
+            0xc: udf #0
             0x10: stur x16, [x21]
         ");
         assert_snapshot!(cb.hexdump(), @"50000058030000140010000000000000b00200f8");
@@ -2200,7 +2200,7 @@ mod tests {
         0x8: ldnp d8, d25, [x10, #-0x140]
         0xc: .byte 0x6f, 0x2c, 0x20, 0x77
         0x10: .byte 0x6f, 0x72, 0x6c, 0x64
-        0x14: .byte 0x21, 0x00, 0x00, 0x00
+        0x14: udf #0x21
         0x18: stur x0, [x21]
         ");
         assert_snapshot!(cb.hexdump(), @"50000010e00310aa48656c6c6f2c20776f726c6421000000a00200f8");
@@ -2304,7 +2304,7 @@ mod tests {
         asm.compile_with_num_regs(&mut cb, 1);
 
         assert_disasm_snapshot!(cb.disasm(), @r"
-        0x0: orr x0, xzr, #0xffffffff
+        0x0: mov x0, #0xffffffff
         0x4: tst w0, w0
         ");
         assert_snapshot!(cb.hexdump(), @"e07f40b21f00006a");
@@ -2566,7 +2566,7 @@ mod tests {
 
         assert_disasm_snapshot!(cb.disasm(), @"
             0x0: mov x1, #0xffff
-            0x4: orr x1, xzr, #0x10000
+            0x4: mov x1, #0x10000
         ");
         assert_snapshot!(cb.hexdump(), @"e1ff9fd2e10370b2");
     }

--- a/zjit/src/bitset.rs
+++ b/zjit/src/bitset.rs
@@ -37,6 +37,16 @@ impl<T: Into<usize> + Copy> BitSet<T> {
         }
     }
 
+    /// Clear a bit. Returns whether the bit was previously set.
+    pub fn remove(&mut self, idx: T) -> bool {
+        debug_assert!(idx.into() < self.num_bits);
+        let entry_idx = idx.into() / ENTRY_NUM_BITS;
+        let bit_idx = idx.into() % ENTRY_NUM_BITS;
+        let was_set = (self.entries[entry_idx] & (1 << bit_idx)) != 0;
+        self.entries[entry_idx] &= !(1 << bit_idx);
+        was_set
+    }
+
     pub fn get(&self, idx: T) -> bool {
         debug_assert!(idx.into() < self.num_bits);
         let entry_idx = idx.into() / ENTRY_NUM_BITS;

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -482,10 +482,10 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::ToRegexp { opt, values, state } => gen_toregexp(jit, asm, *opt, opnds!(values), &function.frame_state(*state)),
         Insn::Param => unreachable!("block.insns should not have Insn::Param"),
         Insn::Snapshot { .. } => return Ok(()), // we don't need to do anything for this instruction at the moment
-        &Insn::Send { cd, blockiseq, state, reason, .. } => gen_send(jit, asm, cd, blockiseq, &function.frame_state(state), reason),
+        &Insn::Send { cd, blockiseq: None, state, reason, .. } => gen_send_without_block(jit, asm, cd, &function.frame_state(state), reason),
+        &Insn::Send { cd, blockiseq: Some(blockiseq), state, reason, .. } => gen_send(jit, asm, cd, blockiseq, &function.frame_state(state), reason),
         &Insn::SendForward { cd, blockiseq, state, reason, .. } => gen_send_forward(jit, asm, cd, blockiseq, &function.frame_state(state), reason),
         Insn::SendDirect { cme, iseq, recv, args, kw_bits, blockiseq, state, .. } => gen_send_iseq_direct(cb, jit, asm, *cme, *iseq, opnd!(recv), opnds!(args), *kw_bits, &function.frame_state(*state), *blockiseq),
-        &Insn::SendWithoutBlock { cd, state, reason, .. } => gen_send_without_block(jit, asm, cd, &function.frame_state(state), reason),
         &Insn::InvokeSuper { cd, blockiseq, state, reason, .. } => gen_invokesuper(jit, asm, cd, blockiseq, &function.frame_state(state), reason),
         &Insn::InvokeSuperForward { cd, blockiseq, state, reason, .. } => gen_invokesuperforward(jit, asm, cd, blockiseq, &function.frame_state(state), reason),
         &Insn::InvokeBlock { cd, state, reason, .. } => gen_invokeblock(jit, asm, cd, &function.frame_state(state), reason),
@@ -536,10 +536,10 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::GuardType { val, guard_type, state } => gen_guard_type(jit, asm, opnd!(val), *guard_type, &function.frame_state(*state)),
         Insn::GuardTypeNot { val, guard_type, state } => gen_guard_type_not(jit, asm, opnd!(val), *guard_type, &function.frame_state(*state)),
         &Insn::GuardBitEquals { val, expected, reason, state } => gen_guard_bit_equals(jit, asm, opnd!(val), expected, reason, &function.frame_state(state)),
-        &Insn::GuardAnyBitSet { val, mask, reason, state } => gen_guard_any_bit_set(jit, asm, opnd!(val), mask, reason, &function.frame_state(state)),
-        &Insn::GuardNoBitsSet { val, mask, reason, state } => gen_guard_no_bits_set(jit, asm, opnd!(val), mask, reason, &function.frame_state(state)),
+        &Insn::GuardAnyBitSet { val, mask, reason, state, .. } => gen_guard_any_bit_set(jit, asm, opnd!(val), mask, reason, &function.frame_state(state)),
+        &Insn::GuardNoBitsSet { val, mask, reason, state, .. } => gen_guard_no_bits_set(jit, asm, opnd!(val), mask, reason, &function.frame_state(state)),
         &Insn::GuardLess { left, right, state } => gen_guard_less(jit, asm, opnd!(left), opnd!(right), &function.frame_state(state)),
-        &Insn::GuardGreaterEq { left, right, state } => gen_guard_greater_eq(jit, asm, opnd!(left), opnd!(right), &function.frame_state(state)),
+        &Insn::GuardGreaterEq { left, right, state, .. } => gen_guard_greater_eq(jit, asm, opnd!(left), opnd!(right), &function.frame_state(state)),
         Insn::PatchPoint { invariant, state } => no_output!(gen_patch_point(jit, asm, invariant, &function.frame_state(*state))),
         Insn::CCall { cfunc, recv, args, name, return_type: _, elidable: _ } => gen_ccall(asm, *cfunc, *name, opnd!(recv), opnds!(args)),
         // Give up CCallWithFrame for 7+ args since asm.ccall() supports at most 6 args (recv + args).
@@ -557,7 +557,8 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::GetLocal { ep_offset, level, use_sp, .. } => gen_getlocal(asm, ep_offset, level, use_sp),
         &Insn::IsBlockParamModified { level } => gen_is_block_param_modified(asm, level),
         &Insn::GetBlockParam { ep_offset, level, state } => gen_getblockparam(jit, asm, ep_offset, level, &function.frame_state(state)),
-        &Insn::SetLocal { ep, val, ep_offset, level } => no_output!(gen_setlocal(asm, opnd!(ep), opnd!(val), ep_offset, level )),
+        &Insn::SetLocal { ep, val, ep_offset, level } => no_output!(gen_setlocal(asm, opnd!(ep), opnd!(val), ep_offset, level)),
+        Insn::GetConstant { klass, id, allow_nil, state } => gen_getconstant(jit, asm, opnd!(klass), *id, opnd!(allow_nil), &function.frame_state(*state)),
         Insn::GetConstantPath { ic, state } => gen_get_constant_path(jit, asm, *ic, &function.frame_state(*state)),
         Insn::GetClassVar { id, ic, state } => gen_getclassvar(jit, asm, *id, *ic, &function.frame_state(*state)),
         Insn::SetClassVar { id, val, ic, state } => no_output!(gen_setclassvar(jit, asm, *id, opnd!(val), *ic, &function.frame_state(*state))),
@@ -672,15 +673,13 @@ fn gen_defined(jit: &JITState, asm: &mut Assembler, op_type: usize, obj: VALUE, 
             //
             // Similar to gen_is_block_given
             let local_iseq = unsafe { rb_get_iseq_body_local_iseq(jit.iseq) };
-            if unsafe { rb_get_iseq_body_type(local_iseq) } == ISEQ_TYPE_METHOD {
-                let lep = gen_get_lep(jit, asm);
-                let block_handler = asm.load(Opnd::mem(64, lep, SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL));
-                let pushval = asm.load(pushval.into());
-                asm.cmp(block_handler, VM_BLOCK_HANDLER_NONE.into());
-                asm.csel_e(Qnil.into(), pushval)
-            } else {
-                Qnil.into()
-            }
+            assert_eq!(unsafe { rb_get_iseq_body_type(local_iseq) }, ISEQ_TYPE_METHOD,
+                       "defined?(yield) in non-method iseq should be handled by HIR construction");
+            let lep = gen_get_lep(jit, asm);
+            let block_handler = asm.load(Opnd::mem(64, lep, SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL));
+            let pushval = asm.load(pushval.into());
+            asm.cmp(block_handler, VM_BLOCK_HANDLER_NONE.into());
+            asm.csel_e(Qnil.into(), pushval)
         }
         _ => {
             // Save the PC and SP because the callee may allocate or call #respond_to?
@@ -800,6 +799,17 @@ fn gen_get_constant_path(jit: &JITState, asm: &mut Assembler, ic: *const iseq_in
     gen_prepare_non_leaf_call(jit, asm, state);
 
     asm_ccall!(asm, rb_vm_opt_getconstant_path, EC, CFP, Opnd::const_ptr(ic))
+}
+
+fn gen_getconstant(jit: &mut JITState, asm: &mut Assembler, klass: Opnd, id: ID, allow_nil: Opnd, state: &FrameState) -> Opnd {
+    unsafe extern "C" {
+        fn rb_vm_get_ev_const(ec: EcPtr, klass: VALUE, id: ID, allow_nil: VALUE) -> VALUE;
+    }
+
+    // Constant lookup can raise and run arbitrary Ruby code via const_missing.
+    gen_prepare_non_leaf_call(jit, asm, state);
+
+    asm_ccall!(asm, rb_vm_get_ev_const, EC, klass, id.0.into(), allow_nil)
 }
 
 fn gen_fixnum_bit_check(asm: &mut Assembler, val: Opnd, index: u8) -> Opnd {
@@ -3083,35 +3093,5 @@ impl IseqCall {
 }
 
 #[cfg(test)]
-mod tests {
-    use crate::codegen::MAX_ISEQ_VERSIONS;
-    use crate::cruby::test_utils::*;
-    use crate::payload::*;
-
-    #[test]
-    fn test_max_iseq_versions() {
-        eval(&format!("
-            TEST = -1
-            def test = TEST
-
-            # compile and invalidate MAX+1 times
-            i = 0
-            while i < {MAX_ISEQ_VERSIONS} + 1
-              test; test # compile a version
-
-              Object.send(:remove_const, :TEST)
-              TEST = i
-
-              i += 1
-            end
-        "));
-
-        // It should not exceed MAX_ISEQ_VERSIONS
-        let iseq = get_method_iseq("self", "test");
-        let payload = get_or_create_iseq_payload(iseq);
-        assert_eq!(payload.versions.len(), MAX_ISEQ_VERSIONS);
-
-        // The last call should not discard the JIT code
-        assert!(matches!(unsafe { payload.versions.last().unwrap().as_ref() }.status, IseqStatus::Compiled(_)));
-    }
-}
+#[path = "codegen_tests.rs"]
+mod tests;

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -557,7 +557,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::GetLocal { ep_offset, level, use_sp, .. } => gen_getlocal(asm, ep_offset, level, use_sp),
         &Insn::IsBlockParamModified { level } => gen_is_block_param_modified(asm, level),
         &Insn::GetBlockParam { ep_offset, level, state } => gen_getblockparam(jit, asm, ep_offset, level, &function.frame_state(state)),
-        &Insn::SetLocal { val, ep_offset, level, state } => no_output!(gen_setlocal(asm, opnd!(val), function.type_of(val), ep_offset, level, &function.frame_state(state))),
+        &Insn::SetLocal { val, ep_offset, level } => no_output!(gen_setlocal(jit, asm, opnd!(val), function.type_of(val), ep_offset, level )),
         Insn::GetConstantPath { ic, state } => gen_get_constant_path(jit, asm, *ic, &function.frame_state(*state)),
         Insn::GetClassVar { id, ic, state } => gen_getclassvar(jit, asm, *id, *ic, &function.frame_state(*state)),
         Insn::SetClassVar { id, val, ic, state } => no_output!(gen_setclassvar(jit, asm, *id, opnd!(val), *ic, &function.frame_state(*state))),
@@ -730,32 +730,15 @@ fn gen_getlocal(asm: &mut Assembler, local_ep_offset: u32, level: u32, use_sp: b
 /// Set a local variable from a higher scope or the heap. `local_ep_offset` is in number of VALUEs.
 /// We generate this instruction with level=0 only when the local variable is on the heap, so we
 /// can't optimize the level=0 case using the SP register.
-fn gen_setlocal(asm: &mut Assembler, val: Opnd, val_type: Type, local_ep_offset: u32, level: u32, state: &FrameState) {
+// TODO(Jacob): remove superfluous arguments from function
+fn gen_setlocal(jit: &mut JITState, asm: &mut Assembler, val: Opnd, val_type: Type, local_ep_offset: u32, level: u32) {
     let local_ep_offset = c_int::try_from(local_ep_offset).unwrap_or_else(|_| panic!("Could not convert local_ep_offset {local_ep_offset} to i32"));
     if level > 0 {
         gen_incr_counter(asm, Counter::vm_write_to_parent_iseq_local_count);
     }
     let ep = gen_get_ep(asm, level);
-
-    // When we've proved that we're writing an immediate,
-    // we can skip the write barrier.
-    if val_type.is_immediate() {
-        let offset = -(SIZEOF_VALUE_I32 * local_ep_offset);
-        asm.mov(Opnd::mem(64, ep, offset), val);
-    } else {
-        // Side exit if the write barrier is required.
-        // TODO(Jacob): Convert to guard, and maybe fix up other getblock case that uses this
-        // TODO(Jacob): Figure out what modified `VM_ENV_FLAG_WB_REQUIRED`
-        let ep = gen_get_ep(asm, level);
-        let flags = Opnd::mem(VALUE_BITS, ep, SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32));
-        // asm.test(flags, VM_ENV_FLAG_WB_REQUIRED.into());
-        // asm.jnz(side_exit(jit, state, SideExitReason::WriteBarrierRequired));
-        // TODO(Jacob): Remove the write barrier check that is somehow buried in these next few lines
-        // We're potentially writing a reference to an IMEMO/env object,
-        // so take care of the write barrier with a function.
-        let local_index = -local_ep_offset;
-        asm_ccall!(asm, rb_vm_env_write, ep, local_index.into(), val);
-    }
+    let offset = -(SIZEOF_VALUE_I32 * local_ep_offset);
+    asm.mov(Opnd::mem(64, ep, offset), val);
 }
 
 /// Returns 1 (as CBool) when VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM is set; returns 0 otherwise.

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -748,8 +748,8 @@ fn gen_setlocal(jit: &mut JITState, asm: &mut Assembler, val: Opnd, val_type: Ty
         // TODO(Jacob): Figure out what modified `VM_ENV_FLAG_WB_REQUIRED`
         let ep = gen_get_ep(asm, level);
         let flags = Opnd::mem(VALUE_BITS, ep, SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32));
-        asm.test(flags, VM_ENV_FLAG_WB_REQUIRED.into());
-        asm.jnz(side_exit(jit, state, SideExitReason::WriteBarrierRequired));
+        // asm.test(flags, VM_ENV_FLAG_WB_REQUIRED.into());
+        // asm.jnz(side_exit(jit, state, SideExitReason::WriteBarrierRequired));
         // TODO(Jacob): Remove the write barrier check that is somehow buried in these next few lines
         // We're potentially writing a reference to an IMEMO/env object,
         // so take care of the write barrier with a function.

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -557,7 +557,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::GetLocal { ep_offset, level, use_sp, .. } => gen_getlocal(asm, ep_offset, level, use_sp),
         &Insn::IsBlockParamModified { level } => gen_is_block_param_modified(asm, level),
         &Insn::GetBlockParam { ep_offset, level, state } => gen_getblockparam(jit, asm, ep_offset, level, &function.frame_state(state)),
-        &Insn::SetLocal { val, ep_offset, level, state } => no_output!(gen_setlocal(jit, asm, opnd!(val), function.type_of(val), ep_offset, level, &function.frame_state(state))),
+        &Insn::SetLocal { val, ep_offset, level, state } => no_output!(gen_setlocal(asm, opnd!(val), function.type_of(val), ep_offset, level, &function.frame_state(state))),
         Insn::GetConstantPath { ic, state } => gen_get_constant_path(jit, asm, *ic, &function.frame_state(*state)),
         Insn::GetClassVar { id, ic, state } => gen_getclassvar(jit, asm, *id, *ic, &function.frame_state(*state)),
         Insn::SetClassVar { id, val, ic, state } => no_output!(gen_setclassvar(jit, asm, *id, opnd!(val), *ic, &function.frame_state(*state))),
@@ -730,7 +730,7 @@ fn gen_getlocal(asm: &mut Assembler, local_ep_offset: u32, level: u32, use_sp: b
 /// Set a local variable from a higher scope or the heap. `local_ep_offset` is in number of VALUEs.
 /// We generate this instruction with level=0 only when the local variable is on the heap, so we
 /// can't optimize the level=0 case using the SP register.
-fn gen_setlocal(jit: &mut JITState, asm: &mut Assembler, val: Opnd, val_type: Type, local_ep_offset: u32, level: u32, state: &FrameState) {
+fn gen_setlocal(asm: &mut Assembler, val: Opnd, val_type: Type, local_ep_offset: u32, level: u32, state: &FrameState) {
     let local_ep_offset = c_int::try_from(local_ep_offset).unwrap_or_else(|_| panic!("Could not convert local_ep_offset {local_ep_offset} to i32"));
     if level > 0 {
         gen_incr_counter(asm, Counter::vm_write_to_parent_iseq_local_count);

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -1,0 +1,4977 @@
+#![cfg(test)]
+
+use crate::codegen::MAX_ISEQ_VERSIONS;
+use crate::cruby::*;
+use crate::hir::tests::hir_build_tests::assert_contains_opcode;
+use crate::payload::*;
+use insta::assert_snapshot;
+
+#[test]
+fn test_call_itself() {
+    assert_snapshot!(inspect("
+        def test = 42.itself
+        test
+        test
+    "), @"42");
+}
+
+#[test]
+fn test_nil() {
+    assert_snapshot!(inspect("
+        def test = nil
+        test
+        test
+    "), @"nil");
+}
+
+#[test]
+fn test_putobject() {
+    assert_snapshot!(inspect("
+        def test = 1
+        test
+        test
+    "), @"1");
+}
+
+#[test]
+fn test_putstring() {
+    eval(r##"
+        def test = "#{""}"
+        test
+    "##);
+    assert_contains_opcode("test", YARVINSN_putstring);
+    assert_snapshot!(inspect(r##"test"##), @r#""""#);
+}
+
+#[test]
+fn test_putchilledstring() {
+    eval(r#"
+        def test = ""
+        test
+    "#);
+    assert_contains_opcode("test", YARVINSN_putchilledstring);
+    assert_snapshot!(inspect(r#"test"#), @r#""""#);
+}
+
+#[test]
+fn test_leave_param() {
+    assert_snapshot!(inspect("
+        def test(n) = n
+        test(5)
+        test(5)
+    "), @"5");
+}
+
+#[test]
+fn test_getglobal_with_warning() {
+    eval(r#"
+        Warning[:deprecated] = true
+
+        module Warning
+          def warn(message)
+            raise
+          end
+        end
+
+        def test
+          $=
+        rescue
+          "rescued"
+        end
+        $VERBOSE = true
+        test
+    "#);
+    assert_contains_opcode("test", YARVINSN_getglobal);
+    assert_snapshot!(inspect(r#"test"#), @r#""rescued""#);
+}
+
+#[test]
+fn test_setglobal() {
+    eval("
+        def test
+          $a = 1
+          $a
+        end
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_setglobal);
+    assert_snapshot!(inspect("test"), @"1");
+}
+
+#[test]
+fn test_string_intern() {
+    eval(r#"
+        def test
+          :"foo#{123}"
+        end
+        test
+    "#);
+    assert_contains_opcode("test", YARVINSN_intern);
+    assert_snapshot!(inspect(r#"test"#), @":foo123");
+}
+
+#[test]
+fn test_duphash() {
+    eval("
+        def test
+          {a: 1}
+        end
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_duphash);
+    assert_snapshot!(inspect("test"), @"{a: 1}");
+}
+
+#[test]
+fn test_pushtoarray() {
+    eval("
+        def test
+          [*[], 1, 2, 3]
+        end
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_pushtoarray);
+    assert_snapshot!(inspect("test"), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_splatarray_new_array() {
+    eval("
+        def test a
+          [*a, 3]
+        end
+        test [1, 2]
+    ");
+    assert_contains_opcode("test", YARVINSN_splatarray);
+    assert_snapshot!(inspect("test [1, 2]"), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_splatarray_existing_array() {
+    eval("
+        def foo v
+          [1, 2, v]
+        end
+        def test a
+          foo(*a)
+        end
+        test [3]
+    ");
+    assert_contains_opcode("test", YARVINSN_splatarray);
+    assert_snapshot!(inspect("test [3]"), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_concattoarray() {
+    eval("
+        def test(*a)
+          [1, 2, *a]
+        end
+        test 3
+    ");
+    assert_contains_opcode("test", YARVINSN_concattoarray);
+    assert_snapshot!(inspect("test 3"), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_definedivar() {
+    eval("
+        def test
+          v0 = defined?(@a)
+          @a = nil
+          v1 = defined?(@a)
+          remove_instance_variable :@a
+          v2 = defined?(@a)
+          [v0, v1, v2]
+        end
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_definedivar);
+    assert_snapshot!(inspect("test"), @r#"[nil, "instance-variable", nil]"#);
+}
+
+#[test]
+fn test_setglobal_with_trace_var_exception() {
+    eval(r#"
+        def test
+          $a = 1
+        rescue
+          "rescued"
+        end
+        trace_var(:$a) { raise }
+        test
+    "#);
+    assert_contains_opcode("test", YARVINSN_setglobal);
+    assert_snapshot!(inspect(r#"test"#), @r#""rescued""#);
+}
+
+#[test]
+fn test_getlocal_after_eval() {
+    assert_snapshot!(inspect("
+        def test
+          a = 1
+          eval('a = 2')
+          a
+        end
+        test
+        test
+    "), @"2");
+}
+
+#[test]
+fn test_getlocal_after_instance_eval() {
+    assert_snapshot!(inspect("
+        def test
+          a = 1
+          instance_eval('a = 2')
+          a
+        end
+        test
+        test
+    "), @"2");
+}
+
+#[test]
+fn test_getlocal_after_module_eval() {
+    assert_snapshot!(inspect("
+        def test
+          a = 1
+          Kernel.module_eval('a = 2')
+          a
+        end
+        test
+        test
+    "), @"2");
+}
+
+#[test]
+fn test_getlocal_after_class_eval() {
+    assert_snapshot!(inspect("
+        def test
+          a = 1
+          Kernel.class_eval('a = 2')
+          a
+        end
+        test
+        test
+    "), @"2");
+}
+
+#[test]
+fn test_setlocal() {
+    assert_snapshot!(inspect("
+        def test(n)
+          m = n
+          m
+        end
+        test(3)
+        test(3)
+    "), @"3");
+}
+
+#[test]
+fn test_return_nonparam_local() {
+    assert_snapshot!(inspect("
+        def foo(a)
+          if false
+            x = nil
+          end
+          x
+        end
+        def test = foo(1)
+        test
+        test
+    "), @"nil");
+}
+
+#[test]
+fn test_nonparam_local_nil_in_jit_call() {
+    assert_snapshot!(inspect(r#"
+        def f(a)
+          a ||= 1
+          if false; b = 1; end
+          eval("-> { p 'x#{b}' }")
+        end
+
+        4.times.map { f(1).call }
+    "#), @r#"["x", "x", "x", "x"]"#);
+}
+
+#[test]
+fn test_kwargs_with_exit_and_local_invalidation() {
+    assert_snapshot!(inspect(r#"
+        def a(b:, c:)
+          if c == :b
+            return -> {}
+          end
+          Class # invalidate locals
+
+          raise "c is :b!" if c == :b
+        end
+
+        def test
+          # note opposite order of kwargs
+          a(c: :c, b: :b)
+        end
+
+        4.times { test }
+        :ok
+    "#), @":ok");
+}
+
+#[test]
+fn test_kwargs_with_max_direct_send_arg_count() {
+    assert_snapshot!(inspect("
+        def kwargs(five, six, a:, b:, c:, d:, e:, f:)
+          [a, b, c, d, five, six, e, f]
+        end
+
+        5.times.flat_map do
+          [
+            kwargs(5, 6, d: 4, c: 3, a: 1, b: 2, e: 7, f: 8),
+            kwargs(5, 6, d: 4, c: 3, b: 2, a: 1, e: 7, f: 8)
+          ]
+        end.uniq
+    "), @"[[1, 2, 3, 4, 5, 6, 7, 8]]");
+}
+
+#[test]
+fn test_setlocal_on_eval() {
+    assert_snapshot!(inspect("
+        @b = binding
+        eval('a = 1', @b)
+        eval('a', @b)
+    "), @"1");
+}
+
+#[test]
+fn test_optional_arguments() {
+    assert_snapshot!(inspect("
+        def test(a, b = 2, c = 3)
+          [a, b, c]
+        end
+        [test(1), test(10, 20), test(100, 200, 300)]
+    "), @"[[1, 2, 3], [10, 20, 3], [100, 200, 300]]");
+}
+
+#[test]
+fn test_optional_arguments_setlocal() {
+    assert_snapshot!(inspect("
+        def test(a = (b = 2))
+          [a, b]
+        end
+        [test, test(1)]
+    "), @"[[2, 2], [1, nil]]");
+}
+
+#[test]
+fn test_optional_arguments_cyclic() {
+    assert_snapshot!(inspect("
+        test = proc { |a=a| a }
+        [test.call, test.call(1)]
+    "), @"[nil, 1]");
+}
+
+#[test]
+fn test_getblockparamproxy() {
+    eval("
+        def test(&block)
+          0.then(&block)
+        end
+        test { 1 }
+    ");
+    assert_contains_opcode("test", YARVINSN_getblockparamproxy);
+    assert_snapshot!(inspect("test { 1 }"), @"1");
+}
+
+#[test]
+fn test_getblockparam() {
+    eval("
+        def test(&blk)
+          blk
+        end
+        test { 2 }.call
+    ");
+    assert_contains_opcode("test", YARVINSN_getblockparam);
+    assert_snapshot!(inspect("test { 2 }.call"), @"2");
+}
+
+#[test]
+fn test_getblockparam_proxy_side_exit_restores_block_local() {
+    eval("
+        def test(&block)
+          b = block
+          raise \"test\" unless block
+          b ? 2 : 3
+        end
+        test {}
+    ");
+    assert_contains_opcode("test", YARVINSN_getblockparam);
+    assert_snapshot!(inspect("test {}"), @"2");
+}
+
+#[test]
+fn test_getblockparam_used_twice_in_args() {
+    eval("
+        def f(*args) = args
+        def test(&blk)
+          b = blk
+          f(*[1], blk)
+          blk
+        end
+        test {1}.call
+    ");
+    assert_contains_opcode("test", YARVINSN_getblockparam);
+    assert_snapshot!(inspect("test {1}.call"), @"1");
+}
+
+#[test]
+fn test_optimized_method_call_proc_call() {
+    eval("
+        def test(p)
+          p.call(1)
+        end
+        test(proc { |x| x * 2 })
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_send_without_block);
+    assert_snapshot!(inspect("test(proc { |x| x * 2 })"), @"2");
+}
+
+#[test]
+fn test_optimized_method_call_proc_aref() {
+    eval("
+        def test(p)
+          p[2]
+        end
+        test(proc { |x| x * 2 })
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_aref);
+    assert_snapshot!(inspect("test(proc { |x| x * 2 })"), @"4");
+}
+
+#[test]
+fn test_optimized_method_call_proc_yield() {
+    eval("
+        def test(p)
+          p.yield(3)
+        end
+        test(proc { |x| x * 2 })
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_send_without_block);
+    assert_snapshot!(inspect("test(proc { |x| x * 2 })"), @"6");
+}
+
+#[test]
+fn test_optimized_method_call_proc_kw_splat() {
+    eval("
+        def test(p, h)
+          p.call(**h)
+        end
+        test(proc { |**kw| kw[:a] + kw[:b] }, { a: 1, b: 2 })
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_send_without_block);
+    assert_snapshot!(inspect("test(proc { |**kw| kw[:a] + kw[:b] }, { a: 1, b: 2 })"), @"3");
+}
+
+#[test]
+fn test_optimized_method_call_proc_call_splat() {
+    assert_snapshot!(inspect("
+        p = proc { |x| x + 1 }
+        def test(p)
+          ary = [42]
+          p.call(*ary)
+        end
+        test(p)
+        test(p)
+    "), @"43");
+}
+
+#[test]
+fn test_optimized_method_call_proc_call_kwarg() {
+    assert_snapshot!(inspect("
+        p = proc { |a:| a }
+        def test(p)
+          p.call(a: 1)
+        end
+        test(p)
+        test(p)
+    "), @"1");
+}
+
+#[test]
+fn test_setlocal_on_eval_with_spill() {
+    assert_snapshot!(inspect("
+        @b = binding
+        eval('a = 1; itself', @b)
+        eval('a', @b)
+    "), @"1");
+}
+
+#[test]
+fn test_nested_local_access() {
+    assert_snapshot!(inspect("
+        1.times do |l2|
+          1.times do |l1|
+            define_method(:test) do
+              l1 = 1
+              l2 = 2
+              l3 = 3
+              [l1, l2, l3]
+            end
+          end
+        end
+
+        test
+        test
+        test
+    "), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_send_with_local_written_by_blockiseq() {
+    assert_snapshot!(inspect("
+        def test
+          l1 = nil
+          l2 = nil
+          tap do |_|
+            l1 = 1
+            tap do |_|
+              l2 = 2
+            end
+          end
+
+          [l1, l2]
+        end
+
+        test
+        test
+    "), @"[1, 2]");
+}
+
+#[test]
+fn test_send_without_block() {
+    assert_snapshot!(inspect("
+        def foo = 1
+        def bar(a) = a - 1
+        def baz(a, b) = a - b
+
+        def test1 = foo
+        def test2 = bar(3)
+        def test3 = baz(4, 1)
+
+        [test1, test2, test3]
+    "), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_send_with_six_args() {
+    assert_snapshot!(inspect("
+        def foo(a1, a2, a3, a4, a5, a6)
+          [a1, a2, a3, a4, a5, a6]
+        end
+
+        def test
+          foo(1, 2, 3, 4, 5, 6)
+        end
+
+        test # profile send
+        test
+    "), @"[1, 2, 3, 4, 5, 6]");
+}
+
+#[test]
+fn test_send_optional_arguments() {
+    assert_snapshot!(inspect("
+        def test(a, b = 2) = [a, b]
+        def entry = [test(1), test(3, 4)]
+        entry
+        entry
+    "), @"[[1, 2], [3, 4]]");
+}
+
+#[test]
+fn test_send_nil_block_arg() {
+    assert_snapshot!(inspect("
+        def test = block_given?
+        def entry = test(&nil)
+        test
+        test
+    "), @"false");
+}
+
+#[test]
+fn test_send_symbol_block_arg() {
+    assert_snapshot!(inspect("
+        def test = [1, 2].map(&:to_s)
+        test
+        test
+    "), @r#"["1", "2"]"#);
+}
+
+#[test]
+fn test_send_variadic_with_block() {
+    assert_snapshot!(inspect("
+        A = [1, 2, 3]
+        B = [\"a\", \"b\", \"c\"]
+
+        def test
+          result = []
+          A.zip(B) { |x, y| result << [x, y] }
+          result
+        end
+
+        test; test
+    "), @r#"[[1, "a"], [2, "b"], [3, "c"]]"#);
+}
+
+#[test]
+fn test_send_kwarg_optional() {
+    assert_snapshot!(inspect("
+        def test(a: 1, b: 2) = [a, b]
+        def entry = test
+        entry
+        entry
+    "), @"[1, 2]");
+}
+
+#[test]
+fn test_send_kwarg_optional_too_many() {
+    assert_snapshot!(inspect("
+        def test(a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10) = [a, b, c, d, e, f, g, h, i, j]
+        def entry = test
+        entry
+        entry
+    "), @"[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]");
+}
+
+#[test]
+fn test_send_kwarg_required_and_optional() {
+    assert_snapshot!(inspect("
+        def test(a:, b: 2) = [a, b]
+        def entry = test(a: 3)
+        entry
+        entry
+    "), @"[3, 2]");
+}
+
+#[test]
+fn test_send_kwarg_to_hash() {
+    assert_snapshot!(inspect("
+        def test(hash) = hash
+        def entry = test(a: 3)
+        entry
+        entry
+    "), @"{a: 3}");
+}
+
+#[test]
+fn test_send_kwarg_to_ccall() {
+    assert_snapshot!(inspect(r#"
+        def test(s) = s.each_line(chomp: true).to_a
+        def entry = test(%(a\nb\nc))
+        entry
+        entry
+    "#), @r#"["a", "b", "c"]"#);
+}
+
+#[test]
+fn test_send_kwarg_and_block_to_ccall() {
+    assert_snapshot!(inspect(r#"
+        def test(s)
+          a = []
+          s.each_line(chomp: true) { |l| a << l }
+          a
+        end
+        def entry = test(%(a\nb\nc))
+        entry
+        entry
+    "#), @r#"["a", "b", "c"]"#);
+}
+
+#[test]
+fn test_send_kwarg_with_too_many_args_to_c_call() {
+    assert_snapshot!(inspect(r#"
+        def test(a:, b:, c:, d:, e:) = sprintf("%s %s %s %s %s", a, b, c, d, kwargs: e)
+        def entry = test(e: :e, d: :d, c: :c, a: :a, b: :b)
+        entry
+        entry
+    "#), @r#""a b c d {kwargs: :e}""#);
+}
+
+#[test]
+fn test_send_kwsplat() {
+    assert_snapshot!(inspect("
+        def test(a:) = a
+        def entry = test(**{a: 3})
+        entry
+        entry
+    "), @"3");
+}
+
+#[test]
+fn test_send_kwrest() {
+    assert_snapshot!(inspect("
+        def test(**kwargs) = kwargs
+        def entry = test(a: 3)
+        entry
+        entry
+    "), @"{a: 3}");
+}
+
+#[test]
+fn test_send_req_kwreq() {
+    assert_snapshot!(inspect("
+        def test(a, c:) = [a, c]
+        def entry = test(1, c: 3)
+        entry
+        entry
+    "), @"[1, 3]");
+}
+
+#[test]
+fn test_send_req_opt_kwreq() {
+    assert_snapshot!(inspect("
+        def test(a, b = 2, c:) = [a, b, c]
+        def entry = [test(1, c: 3), test(-1, -2, c: -3)]
+        entry
+        entry
+    "), @"[[1, 2, 3], [-1, -2, -3]]");
+}
+
+#[test]
+fn test_send_req_opt_kwreq_kwopt() {
+    assert_snapshot!(inspect("
+        def test(a, b = 2, c:, d: 4) = [a, b, c, d]
+        def entry = [test(1, c: 3), test(-1, -2, d: -4, c: -3)]
+        entry
+        entry
+    "), @"[[1, 2, 3, 4], [-1, -2, -3, -4]]");
+}
+
+#[test]
+fn test_send_unexpected_keyword() {
+    assert_snapshot!(inspect("
+        def test(a: 1) = a*2
+        def entry
+          test(z: 2)
+        rescue ArgumentError
+          :error
+        end
+
+        entry
+        entry
+    "), @":error");
+}
+
+#[test]
+fn test_pos_optional_with_maybe_too_many_args() {
+    assert_snapshot!(inspect("
+        def target(a = 1, b = 2, c = 3, d = 4, e = 5, f:) = [a, b, c, d, e, f]
+        def test = [target(f: 6), target(10, 20, 30, f: 6), target(10, 20, 30, 40, 50, f: 60)]
+        test
+        test
+    "), @"[[1, 2, 3, 4, 5, 6], [10, 20, 30, 4, 5, 6], [10, 20, 30, 40, 50, 60]]");
+}
+
+#[test]
+fn test_send_kwarg_partial_optional() {
+    assert_snapshot!(inspect("
+        def test(a: 1, b: 2, c: 3) = [a, b, c]
+        def entry = [test, test(b: 20), test(c: 30, a: 10)]
+        entry
+        entry
+    "), @"[[1, 2, 3], [1, 20, 3], [10, 2, 30]]");
+}
+
+#[test]
+fn test_send_kwarg_optional_a_lot() {
+    assert_snapshot!(inspect("
+        def test(a: 1, b: 2, c: 3, d: 4, e: 5, f: 6) = [a, b, c, d, e, f]
+        def entry = [test, test(d: 7, f: 9, e: 8), test(f: 12, e: 10, d: 8, c: 6, b: 4, a: 2)]
+        entry
+        entry
+    "), @"[[1, 2, 3, 4, 5, 6], [1, 2, 3, 7, 8, 9], [2, 4, 6, 8, 10, 12]]");
+}
+
+#[test]
+fn test_send_kwarg_non_constant_default() {
+    assert_snapshot!(inspect("
+        def make_default = 2
+        def test(a: 1, b: make_default) = [a, b]
+        def entry = [test, test(a: 10)]
+        entry
+        entry
+    "), @"[[1, 2], [10, 2]]");
+}
+
+#[test]
+fn test_send_kwarg_optional_static_with_side_exit() {
+    assert_snapshot!(inspect("
+        def callee(a: 1, b: 2)
+          x = binding.local_variable_get(:a)
+          [a, b, x]
+        end
+
+        def entry
+          callee(a: 10)
+        end
+
+        entry
+        entry
+    "), @"[10, 2, 10]");
+}
+
+#[test]
+fn test_send_all_arg_types() {
+    assert_snapshot!(inspect("
+        def test(a, b = :opt, c, d:, e: :kwo) = [a, b, c, d, e, block_given?]
+        def entry = test(:req, :post, d: :kwr) {}
+        entry
+        entry
+    "), @"[:req, :opt, :post, :kwr, :kwo, true]");
+}
+
+#[test]
+fn test_send_ccall_variadic_with_different_receiver_classes() {
+    assert_snapshot!(inspect(r#"
+        def test(obj) = obj.start_with?("a")
+        [test("abc"), test(:abc)]
+    "#), @"[true, true]");
+}
+
+#[test]
+fn test_forwardable_iseq() {
+    assert_snapshot!(inspect("
+        def test(...) = 1
+        test
+        test
+    "), @"1");
+}
+
+#[test]
+fn test_sendforward() {
+    eval("
+        def callee(a, b) = [a, b]
+        def test(...) = callee(...)
+        test(1, 2)
+    ");
+    assert_contains_opcode("test", YARVINSN_sendforward);
+    assert_snapshot!(inspect("test(1, 2)"), @"[1, 2]");
+}
+
+#[test]
+fn test_iseq_with_optional_arguments() {
+    assert_snapshot!(inspect("
+        def test(a, b = 2) = [a, b]
+        [test(1), test(3, 4)]
+    "), @"[[1, 2], [3, 4]]");
+}
+
+#[test]
+fn test_invokesuper() {
+    assert_snapshot!(inspect("
+        class Foo
+          def foo(a) = a + 1
+          def bar(a) = a + 10
+        end
+
+        class Bar < Foo
+          def foo(a) = super(a) + 2
+          def bar(a) = super + 20
+        end
+
+        bar = Bar.new
+        [bar.foo(3), bar.bar(30)]
+    "), @"[6, 60]");
+}
+
+#[test]
+fn test_invokesuper_to_iseq() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo
+            "A"
+          end
+        end
+
+        class B < A
+          def foo
+            ["B", super]
+          end
+        end
+
+        def test
+          B.new.foo
+        end
+
+        test  # profile invokesuper
+        test  # compile + run compiled code
+    "#), @r#"["B", "A"]"#);
+}
+
+#[test]
+fn test_invokesuper_with_args() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo(x)
+            x * 2
+          end
+        end
+
+        class B < A
+          def foo(x)
+            ["B", super(x) + 1]
+          end
+        end
+
+        def test
+          B.new.foo(5)
+        end
+
+        test  # profile invokesuper
+        test  # compile + run compiled code
+    "#), @r#"["B", 11]"#);
+}
+
+#[test]
+fn test_invokesuper_with_args_to_rest_param() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo(x, *rest)
+            [x, rest]
+          end
+        end
+
+        class B < A
+          def foo(x, y, z)
+            ["B", *super(x, y, z)]
+          end
+        end
+
+        def test
+          B.new.foo("a", "b", "c")
+        end
+
+        test  # profile invokesuper
+        test  # compile + run compiled code
+    "#), @r#"["B", "a", ["b", "c"]]"#);
+}
+
+#[test]
+fn test_invokesuper_with_block() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo
+            block_given? ? yield : "no_block"
+          end
+        end
+
+        class B < A
+          def foo
+            ["B", super { "from_block" }]
+          end
+        end
+
+        def test
+          B.new.foo
+        end
+
+        test  # profile invokesuper
+        test  # compile + run compiled code
+    "#), @r#"["B", "from_block"]"#);
+}
+
+#[test]
+fn test_invokesuper_to_cfunc_no_args() {
+    assert_snapshot!(inspect(r#"
+        class MyString < String
+          def length
+            ["MyString", super]
+          end
+        end
+
+        def test
+          MyString.new("abc").length
+        end
+
+        test  # profile invokesuper
+        test  # compile + run compiled code
+    "#), @r#"["MyString", 3]"#);
+}
+
+#[test]
+fn test_invokesuper_to_cfunc_simple_args() {
+    assert_snapshot!(inspect(r#"
+        class MyString < String
+          def include?(other)
+            ["MyString", super(other)]
+          end
+        end
+
+        def test
+          MyString.new("abc").include?("bc")
+        end
+
+        test  # profile invokesuper
+        test  # compile + run compiled code
+    "#), @r#"["MyString", true]"#);
+}
+
+#[test]
+fn test_invokesuper_to_cfunc_with_optional_arg() {
+    assert_snapshot!(inspect(r#"
+        class MyString < String
+          def byteindex(needle, offset = 0)
+            ["MyString", super(needle, offset)]
+          end
+        end
+
+        def test
+          MyString.new("hello world").byteindex("world")
+        end
+
+        test  # profile invokesuper
+        test  # compile + run compiled code
+    "#), @r#"["MyString", 6]"#);
+}
+
+#[test]
+fn test_invokesuper_to_cfunc_varargs() {
+    assert_snapshot!(inspect(r#"
+        class MyString < String
+          def end_with?(str)
+            ["MyString", super(str)]
+          end
+        end
+
+        def test
+          MyString.new("abc").end_with?("bc")
+        end
+
+        test  # profile invokesuper
+        test  # compile + run compiled code
+    "#), @r#"["MyString", true]"#);
+}
+
+#[test]
+fn test_invokesuper_multilevel() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo
+            "A"
+          end
+        end
+
+        class B < A
+          def foo
+            ["B", super]
+          end
+        end
+
+        class C < B
+          def foo
+            ["C", super]
+          end
+        end
+
+        def test
+          C.new.foo
+        end
+
+        test  # profile invokesuper
+        test  # compile + run compiled code
+    "#), @r#"["C", ["B", "A"]]"#);
+}
+
+#[test]
+fn test_invokesuper_forwards_block_implicitly() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo
+            block_given? ? yield : "no_block"
+          end
+        end
+
+        class B < A
+          def foo
+            ["B", super]  # should forward the block from caller
+          end
+        end
+
+        def test
+          B.new.foo { "forwarded_block" }
+        end
+
+        test  # profile invokesuper
+        test  # compile + run compiled code
+    "#), @r#"["B", "forwarded_block"]"#);
+}
+
+#[test]
+fn test_invokesuper_forwards_block_implicitly_with_args() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo(x)
+            [x, (block_given? ? yield : "no_block")]
+          end
+        end
+
+        class B < A
+          def foo(x)
+            ["B", super(x)]  # explicit args, but block should still be forwarded
+          end
+        end
+
+        def test
+          B.new.foo("arg_value") { "forwarded" }
+        end
+
+        test  # profile
+        test  # compile + run compiled code
+    "#), @r#"["B", ["arg_value", "forwarded"]]"#);
+}
+
+#[test]
+fn test_invokesuper_forwards_block_implicitly_no_block_given() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo
+            block_given? ? yield : "no_block"
+          end
+        end
+
+        class B < A
+          def foo
+            ["B", super]  # no block given by caller
+          end
+        end
+
+        def test
+          B.new.foo  # called without a block
+        end
+
+        test  # profile
+        test  # compile + run compiled code
+    "#), @r#"["B", "no_block"]"#);
+}
+
+#[test]
+fn test_invokesuper_forwards_block_implicitly_multilevel() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo
+            block_given? ? yield : "no_block"
+          end
+        end
+
+        class B < A
+          def foo
+            ["B", super]  # forwards block to A
+          end
+        end
+
+        class C < B
+          def foo
+            ["C", super]  # forwards block to B, which forwards to A
+          end
+        end
+
+        def test
+          C.new.foo { "deep_block" }
+        end
+
+        test  # profile
+        test  # compile + run compiled code
+    "#), @r#"["C", ["B", "deep_block"]]"#);
+}
+
+#[test]
+fn test_invokesuper_forwards_block_param() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo
+            block_given? ? yield : "no_block"
+          end
+        end
+
+        class B < A
+          def foo(&block)
+            ["B", super]  # should forward &block implicitly
+          end
+        end
+
+        def test
+          B.new.foo { "block_param_forwarded" }
+        end
+
+        test  # profile
+        test  # compile + run compiled code
+    "#), @r#"["B", "block_param_forwarded"]"#);
+}
+
+#[test]
+fn test_invokesuper_with_blockarg() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo
+            block_given? ? yield : "no block"
+          end
+        end
+
+        class B < A
+          def foo(&blk)
+            other_block = proc { "different block" }
+            ["B", super(&other_block)]
+          end
+        end
+
+        def test
+          B.new.foo { "passed block" }
+        end
+
+        test  # profile
+        test  # compile + run compiled code
+    "#), @r#"["B", "different block"]"#);
+}
+
+#[test]
+fn test_invokesuper_with_symbol_to_proc() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo(items, &blk)
+            items.map(&blk)
+          end
+        end
+
+        class B < A
+          def foo(items)
+            ["B", super(items, &:succ)]
+          end
+        end
+
+        def test
+          B.new.foo([2, 4, 6])
+        end
+
+        test  # profile
+        test  # compile + run compiled code
+    "#), @r#"["B", [3, 5, 7]]"#);
+}
+
+#[test]
+fn test_invokesuper_with_splat() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo(a, b, c)
+            a + b + c
+          end
+        end
+
+        class B < A
+          def foo(*args)
+            ["B", super(*args)]
+          end
+        end
+
+        def test
+          B.new.foo(1, 2, 3)
+        end
+
+        test  # profile
+        test  # compile + run compiled code
+    "#), @r#"["B", 6]"#);
+}
+
+#[test]
+fn test_invokesuper_with_kwargs() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo(x:, y:)
+            "x=#{x}, y=#{y}"
+          end
+        end
+
+        class B < A
+          def foo(x:, y:)
+            ["B", super(x: x, y: y)]
+          end
+        end
+
+        def test
+          B.new.foo(x: 1, y: 2)
+        end
+
+        test  # profile
+        test  # compile + run compiled code
+    "#), @r#"["B", "x=1, y=2"]"#);
+}
+
+#[test]
+fn test_invokesuper_with_kw_splat() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo(x:, y:)
+            "x=#{x}, y=#{y}"
+          end
+        end
+
+        class B < A
+          def foo(**kwargs)
+            ["B", super(**kwargs)]
+          end
+        end
+
+        def test
+          B.new.foo(x: 1, y: 2)
+        end
+
+        test  # profile
+        test  # compile + run compiled code
+    "#), @r#"["B", "x=1, y=2"]"#);
+}
+
+#[test]
+fn test_invokesuper_with_include() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo
+            "A"
+          end
+        end
+
+        class B < A
+          def foo
+            ["B", super]
+          end
+        end
+
+        def test
+          B.new.foo
+        end
+
+        test  # profile invokesuper (super -> A#foo)
+        test  # compile with super -> A#foo
+
+        # Now include a module in B that defines foo - super should go to M#foo instead
+        module M
+          def foo
+            "M"
+          end
+        end
+        B.include(M)
+
+        test  # should call M#foo, not A#foo
+    "#), @r#"["B", "M"]"#);
+}
+
+#[test]
+fn test_invokesuper_with_prepend() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo
+            "A"
+          end
+        end
+
+        class B < A
+          def foo
+            ["B", super]
+          end
+        end
+
+        def test
+          B.new.foo
+        end
+
+        test  # profile invokesuper (super -> A#foo)
+        test  # compile with super -> A#foo
+
+        # Now prepend a module that defines foo - super should go to M#foo instead
+        module M
+          def foo
+            "M"
+          end
+        end
+        A.prepend(M)
+
+        test  # should call M#foo, not A#foo
+    "#), @r#"["B", "M"]"#);
+}
+
+#[test]
+fn test_invokesuper_with_keyword_args() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo(attributes = {})
+            @attributes = attributes
+          end
+        end
+
+        class B < A
+          def foo(content = '')
+            super(content: content)
+          end
+        end
+
+        def test
+          B.new.foo("image data")
+        end
+
+        test
+        test
+    "#), @r#"{content: "image data"}"#);
+}
+
+#[test]
+fn test_invokesuper_with_optional_keyword_args() {
+    assert_snapshot!(inspect("
+        class Parent
+          def foo(a, b: 2, c: 3) = [a, b, c]
+        end
+
+        class Child < Parent
+          def foo(a) = super(a)
+        end
+
+        def test = Child.new.foo(1)
+
+        test
+        test
+    "), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_invokesuperforward() {
+    assert_snapshot!(inspect("
+        class A
+          def foo(a,b,c) = [a,b,c]
+        end
+
+        class B < A
+          def foo(...) = super
+        end
+
+        def test
+          B.new.foo(1, 2, 3)
+        end
+
+        test
+        test
+    "), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_invokesuperforward_with_args_kwargs_and_block() {
+    assert_snapshot!(inspect("
+        class A
+          def foo(*args, **kwargs, &block)
+            [args, kwargs, block&.call]
+          end
+        end
+
+        class B < A
+          def foo(...) = super
+        end
+
+        def test
+          B.new.foo(1, 2, x: 3) { 4 }
+        end
+
+        test
+        test
+    "), @"[[1, 2], {x: 3}, 4]");
+}
+
+#[test]
+fn test_send_with_non_constant_keyword_default() {
+    assert_snapshot!(inspect("
+        def dbl(x = 1) = x * 2
+
+        def foo(a: dbl, b: dbl(2), c: dbl(2 ** 3))
+          [a, b, c]
+        end
+
+        def test
+          [
+            foo,
+            foo(a: 10),
+            foo(b: 20),
+            foo(c: 30),
+            foo(a: 10, b: 20, c: 30)
+          ]
+        end
+
+        test
+        test
+    "), @"[[2, 4, 16], [10, 4, 16], [2, 20, 16], [2, 4, 30], [10, 20, 30]]");
+}
+
+#[test]
+fn test_send_with_non_constant_keyword_default_not_evaluated_when_provided() {
+    assert_snapshot!(inspect("
+        def foo(a: raise, b: raise, c: raise)
+          [a, b, c]
+        end
+
+        def test
+          foo(a: 1, b: 2, c: 3)
+        end
+
+        test
+        test
+    "), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_send_with_non_constant_keyword_default_evaluated_when_not_provided() {
+    assert_snapshot!(inspect(r#"
+        def raise_a = raise "a"
+        def raise_b = raise "b"
+        def raise_c = raise "c"
+
+        def foo(a: raise_a, b: raise_b, c: raise_c)
+          [a, b, c]
+        end
+
+        def test_a
+          foo(b: 2, c: 3)
+        rescue RuntimeError => e
+          e.message
+        end
+
+        def test_b
+          foo(a: 1, c: 3)
+        rescue RuntimeError => e
+          e.message
+        end
+
+        def test_c
+          foo(a: 1, b: 2)
+        rescue RuntimeError => e
+          e.message
+        end
+
+        def test
+          [test_a, test_b, test_c]
+        end
+
+        test
+        test
+    "#), @r#"["a", "b", "c"]"#);
+}
+
+#[test]
+fn test_send_with_non_constant_keyword_default_jit_to_jit() {
+    assert_snapshot!(inspect("
+        def make_default(x) = x * 2
+
+        def callee(a: make_default(1), b: make_default(2), c: make_default(3))
+          [a, b, c]
+        end
+
+        def caller_method
+          callee
+        end
+
+        # Warm up callee first so it gets JITted
+        callee
+        callee
+
+        # Now warm up caller - this creates JIT-to-JIT call
+        caller_method
+        caller_method
+    "), @"[2, 4, 6]");
+}
+
+#[test]
+fn test_send_with_non_constant_keyword_default_side_exit() {
+    assert_snapshot!(inspect("
+        def make_b = 2
+
+        def callee(a: 1, b: make_b, c: 3)
+          x = binding.local_variable_get(:a)
+          y = binding.local_variable_get(:b)
+          z = binding.local_variable_get(:c)
+          [x, y, z]
+        end
+
+        def test
+          callee(a: 10, c: 30)
+        end
+
+        test
+        test
+    "), @"[10, 2, 30]");
+}
+
+#[test]
+fn test_send_with_non_constant_keyword_default_evaluation_order() {
+    assert_snapshot!(inspect(r#"
+        def log(x)
+          $order << x
+          x
+        end
+
+        def foo(a: log("a"), b: log("b"), c: log("c"))
+          [a, b, c]
+        end
+
+        def test
+          results = []
+
+          $order = []
+          foo
+          results << $order.dup
+
+          $order = []
+          foo(a: "A")
+          results << $order.dup
+
+          $order = []
+          foo(b: "B")
+          results << $order.dup
+
+          $order = []
+          foo(c: "C")
+          results << $order.dup
+
+          results
+        end
+
+        test
+        test
+    "#), @r#"[["a", "b", "c"], ["b", "c"], ["a", "c"], ["a", "b"]]"#);
+}
+
+#[test]
+fn test_send_with_too_many_non_constant_keyword_defaults() {
+    assert_snapshot!(inspect("
+        def many_kwargs( k1: 1, k2: 2, k3: 3, k4: 4, k5: 5, k6: 6, k7: 7, k8: 8, k9: 9, k10: 10, k11: 11, k12: 12, k13: 13, k14: 14, k15: 15, k16: 16, k17: 17, k18: 18, k19: 19, k20: 20, k21: 21, k22: 22, k23: 23, k24: 24, k25: 25, k26: 26, k27: 27, k28: 28, k29: 29, k30: 30, k31: 31, k32: 32, k33: 33, k34: k33 + 1) = k1 + k34
+        def t = many_kwargs
+        t
+        t
+    "), @"35");
+}
+
+#[test]
+fn test_invokebuiltin_delegate() {
+    assert_snapshot!(inspect("
+        def test = [].clone(freeze: true)
+        r = test
+        r2 = test
+        [r2, r2.frozen?]
+    "), @"[[], true]");
+}
+
+#[test]
+fn test_opt_plus_const() {
+    assert_snapshot!(inspect("
+        def test = 1 + 2
+        test # profile opt_plus
+        test
+    "), @"3");
+}
+
+#[test]
+fn test_opt_plus_fixnum() {
+    assert_snapshot!(inspect("
+        def test(a, b) = a + b
+        test(0, 1) # profile opt_plus
+        test(1, 2)
+    "), @"3");
+}
+
+#[test]
+fn test_opt_plus_chain() {
+    assert_snapshot!(inspect("
+        def test(a, b, c) = a + b + c
+        test(0, 1, 2) # profile opt_plus
+        test(1, 2, 3)
+    "), @"6");
+}
+
+#[test]
+fn test_opt_plus_left_imm() {
+    assert_snapshot!(inspect("
+        def test(a) = 1 + a
+        test(1) # profile opt_plus
+        test(2)
+    "), @"3");
+}
+
+#[test]
+fn test_opt_plus_type_guard_exit() {
+    assert_snapshot!(inspect("
+        def test(a) = 1 + a
+        test(1) # profile opt_plus
+        [test(2), test(2.0)]
+    "), @"[3, 3.0]");
+}
+
+#[test]
+fn test_opt_plus_type_guard_exit_with_locals() {
+    assert_snapshot!(inspect("
+        def test(a)
+          local = 3
+          1 + a + local
+        end
+        test(1) # profile opt_plus
+        [test(2), test(2.0)]
+    "), @"[6, 6.0]");
+}
+
+#[test]
+fn test_opt_plus_type_guard_nested_exit() {
+    assert_snapshot!(inspect("
+        def side_exit(n) = 1 + n
+        def jit_frame(n) = 1 + side_exit(n)
+        def entry(n) = jit_frame(n)
+        entry(2) # profile send
+        [entry(2), entry(2.0)]
+    "), @"[4, 4.0]");
+}
+
+#[test]
+fn test_opt_plus_type_guard_nested_exit_with_locals() {
+    assert_snapshot!(inspect("
+        def side_exit(n)
+          local = 2
+          1 + n + local
+        end
+        def jit_frame(n)
+          local = 3
+          1 + side_exit(n) + local
+        end
+        def entry(n) = jit_frame(n)
+        entry(2) # profile send
+        [entry(2), entry(2.0)]
+    "), @"[9, 9.0]");
+}
+
+#[test]
+fn test_opt_minus() {
+    assert_snapshot!(inspect("
+        def test(a, b) = a - b
+        test(2, 1) # profile opt_minus
+        test(6, 4)
+    "), @"2");
+}
+
+#[test]
+fn test_opt_mult() {
+    assert_snapshot!(inspect("
+        def test(a, b) = a * b
+        test(1, 2) # profile opt_mult
+        test(2, 3)
+    "), @"6");
+}
+
+#[test]
+fn test_opt_mult_overflow() {
+    assert_snapshot!(inspect("
+        def test(a, b)
+          a * b
+        end
+        test(1, 1) # profile opt_mult
+
+        r1 = test(2, 3)
+        r2 = test(2, -3)
+        r3 = test(2 << 40, 2 << 41)
+        r4 = test(2 << 40, -2 << 41)
+        r5 = test(1 << 62, 1 << 62)
+
+        [r1, r2, r3, r4, r5]
+    "), @"[6, -6, 9671406556917033397649408, -9671406556917033397649408, 21267647932558653966460912964485513216]");
+}
+
+#[test]
+fn test_opt_eq() {
+    eval("
+        def test(a, b) = a == b
+        test(0, 2) # profile opt_eq
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_eq);
+    assert_snapshot!(inspect("[test(1, 1), test(0, 1)]"), @"[true, false]");
+}
+
+#[test]
+fn test_opt_eq_with_minus_one() {
+    eval("
+        def test(a) = a == -1
+        test(1) # profile opt_eq
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_eq);
+    assert_snapshot!(inspect("[test(0), test(-1)]"), @"[false, true]");
+}
+
+#[test]
+fn test_opt_neq_dynamic() {
+    eval("
+        def test(a, b) = a != b
+        test(0, 2) # profile opt_neq
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_neq);
+    assert_snapshot!(inspect("[test(1, 1), test(0, 1)]"), @"[false, true]");
+}
+
+#[test]
+fn test_opt_neq_fixnum() {
+    assert_snapshot!(inspect("
+        def test(a, b) = a != b
+        test(0, 2) # profile opt_neq
+        [test(1, 1), test(0, 1)]
+    "), @"[false, true]");
+}
+
+#[test]
+fn test_opt_lt() {
+    eval("
+        def test(a, b) = a < b
+        test(2, 3) # profile opt_lt
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_lt);
+    assert_snapshot!(inspect("[test(0, 1), test(0, 0), test(1, 0)]"), @"[true, false, false]");
+}
+
+#[test]
+fn test_opt_lt_with_literal_lhs() {
+    eval("
+        def test(n) = 2 < n
+        test(2) # profile opt_lt
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_lt);
+    assert_snapshot!(inspect("[test(1), test(2), test(3)]"), @"[false, false, true]");
+}
+
+#[test]
+fn test_opt_le() {
+    eval("
+        def test(a, b) = a <= b
+        test(2, 3) # profile opt_le
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_le);
+    assert_snapshot!(inspect("[test(0, 1), test(0, 0), test(1, 0)]"), @"[true, true, false]");
+}
+
+#[test]
+fn test_opt_gt() {
+    eval("
+        def test(a, b) = a > b
+        test(2, 3) # profile opt_gt
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_gt);
+    assert_snapshot!(inspect("[test(0, 1), test(0, 0), test(1, 0)]"), @"[false, false, true]");
+}
+
+#[test]
+fn test_opt_empty_p() {
+    eval("
+        def test(x) = x.empty?
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_empty_p);
+    assert_snapshot!(inspect("[test([1]), test(\"1\"), test({})]"), @"[false, false, true]");
+}
+
+#[test]
+fn test_opt_succ() {
+    eval("
+        def test(obj) = obj.succ
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_succ);
+    assert_snapshot!(inspect(r#"[test(-1), test("A")]"#), @r#"[0, "B"]"#);
+}
+
+#[test]
+fn test_opt_and() {
+    eval("
+        def test(x, y) = x & y
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_and);
+    assert_snapshot!(inspect("[test(0b1101, 3), test([3, 2, 1, 4], [8, 1, 2, 3])]"), @"[1, [3, 2, 1]]");
+}
+
+#[test]
+fn test_opt_or() {
+    eval("
+        def test(x, y) = x | y
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_or);
+    assert_snapshot!(inspect("[test(0b1000, 3), test([3, 2, 1], [1, 2, 3])]"), @"[11, [3, 2, 1]]");
+}
+
+#[test]
+fn test_fixnum_and() {
+    eval("
+        def test(a, b) = a & b
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_and);
+    assert_snapshot!(inspect("
+        [
+                  test(5, 3),
+                  test(0b011, 0b110),
+                  test(-0b011, 0b110)
+                ]
+    "), @"[1, 2, 4]");
+}
+
+#[test]
+fn test_fixnum_and_side_exit() {
+    eval("
+        def test(a, b) = a & b
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_and);
+    assert_snapshot!(inspect("
+        [
+                  test(2, 2),
+                  test(0b011, 0b110),
+                  test(true, false)
+                ]
+    "), @"[2, 2, false]");
+}
+
+#[test]
+fn test_fixnum_or() {
+    eval("
+        def test(a, b) = a | b
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_or);
+    assert_snapshot!(inspect("
+        [
+                  test(5, 3),
+                  test(1, 2),
+                  test(1, -4)
+                ]
+    "), @"[7, 3, -3]");
+}
+
+#[test]
+fn test_fixnum_or_side_exit() {
+    eval("
+        def test(a, b) = a | b
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_or);
+    assert_snapshot!(inspect("
+        [
+                  test(1, 2),
+                  test(2, 2),
+                  test(true, false)
+                ]
+    "), @"[3, 2, true]");
+}
+
+#[test]
+fn test_fixnum_xor() {
+    assert_snapshot!(inspect("
+        def test(a, b) = a ^ b
+        [
+          test(5, 3),
+          test(-5, 3),
+          test(1, 2)
+        ]
+    "), @"[6, -8, 3]");
+}
+
+#[test]
+fn test_fixnum_xor_side_exit() {
+    assert_snapshot!(inspect("
+        def test(a, b) = a ^ b
+        [
+          test(5, 3),
+          test(5, 3),
+          test(true, false)
+        ]
+    "), @"[6, 6, true]");
+}
+
+#[test]
+fn test_fixnum_mul() {
+    eval("
+        C = 3
+        def test(n) = C * n
+        test(4)
+        test(4)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_mult);
+    assert_snapshot!(inspect("test(4)"), @"12");
+}
+
+#[test]
+fn test_fixnum_div() {
+    eval("
+        C = 48
+        def test(n) = C / n
+        test(4)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_div);
+    assert_snapshot!(inspect("test(4)"), @"12");
+}
+
+#[test]
+fn test_fixnum_floor() {
+    eval("
+        C = 3
+        def test(n) = C / n
+        test(4)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_div);
+    assert_snapshot!(inspect("test(4)"), @"0");
+}
+
+#[test]
+fn test_opt_not() {
+    eval("
+        def test(obj) = !obj
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_not);
+    assert_snapshot!(inspect("[test(nil), test(false), test(0)]"), @"[true, true, false]");
+}
+
+#[test]
+fn test_opt_regexpmatch2() {
+    eval("
+        def test(haystack) = /needle/ =~ haystack
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_regexpmatch2);
+    assert_snapshot!(inspect(r#"[test("kneedle"), test("")]"#), @"[1, nil]");
+}
+
+#[test]
+fn test_opt_ge() {
+    eval("
+        def test(a, b) = a >= b
+        test(2, 3) # profile opt_ge
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_ge);
+    assert_snapshot!(inspect("[test(0, 1), test(0, 0), test(1, 0)]"), @"[false, true, true]");
+}
+
+#[test]
+fn test_opt_new_does_not_push_frame() {
+    eval("
+        class Foo
+          attr_reader :backtrace
+          def initialize
+            @backtrace = caller
+          end
+        end
+        def test = Foo.new
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_new);
+    assert_snapshot!(inspect("
+        foo = test
+        foo.backtrace.find { |frame| frame.include?('Class#new') }
+    "), @"nil");
+}
+
+#[test]
+fn test_opt_new_with_redefined() {
+    eval(r#"
+        class Foo
+          def self.new = "foo"
+          def initialize = raise("unreachable")
+        end
+        def test = Foo.new
+        test
+    "#);
+    assert_contains_opcode("test", YARVINSN_opt_new);
+    assert_snapshot!(inspect(r#"test"#), @r#""foo""#);
+}
+
+#[test]
+fn test_opt_new_invalidate_new() {
+    eval(r#"
+        class Foo; end
+        def test = Foo.new
+        test
+    "#);
+    assert_contains_opcode("test", YARVINSN_opt_new);
+    assert_snapshot!(inspect(r#"
+        result = [test.class.name]
+        def Foo.new = "foo"
+        result << test
+    "#), @r#"["Foo", "foo"]"#);
+}
+
+#[test]
+fn test_opt_newarray_send_include_p() {
+    eval("
+        def test(x)
+            [:y, 1, Object.new].include?(x)
+        end
+        test(1)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+    assert_snapshot!(inspect("[test(1), test(\"n\")]"), @"[true, false]");
+}
+
+#[test]
+fn test_opt_newarray_send_include_p_redefined() {
+    eval("
+        class Array
+            alias_method :old_include?, :include?
+            def include?(x)
+                old_include?(x) ? :true : :false
+            end
+        end
+        def test(x)
+            [:y, 1, Object.new].include?(x)
+        end
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+    assert_snapshot!(inspect("
+        def test(x)
+            [:y, 1, Object.new].include?(x)
+        end
+        test(1)
+        [test(1), test(\"n\")]
+    "), @"[:true, :false]");
+}
+
+#[test]
+fn test_opt_duparray_send_include_p() {
+    eval("
+        def test(x)
+            [:y, 1].include?(x)
+        end
+        test(1)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_duparray_send);
+    assert_snapshot!(inspect("[test(1), test(\"n\")]"), @"[true, false]");
+}
+
+#[test]
+fn test_opt_duparray_send_include_p_redefined() {
+    eval("
+        class Array
+            alias_method :old_include?, :include?
+            def include?(x)
+                old_include?(x) ? :true : :false
+            end
+        end
+        def test(x)
+            [:y, 1].include?(x)
+        end
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_duparray_send);
+    assert_snapshot!(inspect("
+        def test(x)
+            [:y, 1].include?(x)
+        end
+        test(1)
+        [test(1), test(\"n\")]
+    "), @"[:true, :false]");
+}
+
+#[test]
+fn test_opt_newarray_send_pack_buffer() {
+    eval(r#"
+        def test(num, buffer)
+            [num].pack('C', buffer:)
+        end
+        test(65, "")
+    "#);
+    assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+    assert_snapshot!(inspect(r#"
+        buf = ""
+        [test(65, buf), test(66, buf), test(67, buf), buf]
+    "#), @r#"["ABC", "ABC", "ABC", "ABC"]"#);
+}
+
+#[test]
+fn test_opt_newarray_send_pack_buffer_redefined() {
+    eval(r#"
+        class Array
+            alias_method :old_pack, :pack
+            def pack(fmt, buffer: nil)
+                old_pack(fmt, buffer: buffer)
+                "b"
+            end
+        end
+        def test(num, buffer)
+            [num].pack('C', buffer:)
+        end
+    "#);
+    assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+    assert_snapshot!(inspect(r#"
+        def test(num, buffer)
+            [num].pack('C', buffer:)
+        end
+        buf = ""
+        test(65, buf)
+        buf = ""
+        [test(65, buf), buf]
+    "#), @r#"["b", "A"]"#);
+}
+
+#[test]
+fn test_opt_newarray_send_hash() {
+    eval("
+        def test(x)
+            [1, 2, x].hash
+        end
+        test(20)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+    assert_snapshot!(inspect("test(20).class"), @"Integer");
+}
+
+#[test]
+fn test_opt_newarray_send_hash_redefined() {
+    eval("
+        Array.class_eval { def hash = 42 }
+        def test(x)
+            [1, 2, x].hash
+        end
+        test(20)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+    assert_snapshot!(inspect("test(20)"), @"42");
+}
+
+#[test]
+fn test_opt_newarray_send_max() {
+    eval("
+        def test(a,b) = [a,b].max
+        test(10, 20)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+    assert_snapshot!(inspect("[test(10, 20), test(40, 30)]"), @"[20, 40]");
+}
+
+#[test]
+fn test_opt_newarray_send_max_redefined() {
+    eval("
+        class Array
+            alias_method :old_max, :max
+            def max
+                old_max * 2
+            end
+        end
+        def test(a,b) = [a,b].max
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_newarray_send);
+    assert_snapshot!(inspect("
+        def test(a,b) = [a,b].max
+        test(15, 30)
+        [test(15, 30), test(45, 35)]
+    "), @"[60, 90]");
+}
+
+#[test]
+fn test_new_hash_empty() {
+    eval("
+        def test = {}
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_newhash);
+    assert_snapshot!(inspect("test"), @"{}");
+}
+
+#[test]
+fn test_new_hash_nonempty() {
+    eval(r#"
+        def test
+            key = "key"
+            value = "value"
+            num = 42
+            result = 100
+            {key => value, num => result}
+        end
+        test
+    "#);
+    assert_contains_opcode("test", YARVINSN_newhash);
+    assert_snapshot!(inspect(r#"test"#), @r#"{"key" => "value", 42 => 100}"#);
+}
+
+#[test]
+fn test_new_hash_single_key_value() {
+    eval(r#"
+        def test = {"key" => "value"}
+        test
+    "#);
+    assert_contains_opcode("test", YARVINSN_newhash);
+    assert_snapshot!(inspect(r#"test"#), @r#"{"key" => "value"}"#);
+}
+
+#[test]
+fn test_new_hash_with_computation() {
+    eval(r#"
+        def test(a, b)
+            {"sum" => a + b, "product" => a * b}
+        end
+        test(2, 3)
+    "#);
+    assert_contains_opcode("test", YARVINSN_newhash);
+    assert_snapshot!(inspect(r#"test(2, 3)"#), @r#"{"sum" => 5, "product" => 6}"#);
+}
+
+#[test]
+fn test_new_hash_with_user_defined_hash_method() {
+    assert_snapshot!(inspect(r#"
+        class CustomKey
+            attr_reader :val
+            def initialize(val)
+                @val = val
+            end
+            def hash
+                @val.hash
+            end
+            def eql?(other)
+                other.is_a?(CustomKey) && @val == other.val
+            end
+        end
+        def test
+            key = CustomKey.new("key")
+            hash = {key => "value"}
+            hash[key] == "value"
+        end
+        test
+        test
+    "#), @"true");
+}
+
+#[test]
+fn test_new_hash_with_user_hash_method_exception() {
+    assert_snapshot!(inspect(r#"
+        class BadKey
+            def hash
+                raise "Hash method failed!"
+            end
+        end
+        def test
+            key = BadKey.new
+            {key => "value"}
+        end
+        begin
+            test
+        rescue => e
+            e.class
+        end
+        begin
+            test
+        rescue => e
+            e.class
+        end
+    "#), @"RuntimeError");
+}
+
+#[test]
+fn test_new_hash_with_user_eql_method_exception() {
+    assert_snapshot!(inspect(r#"
+        class BadKey
+            def hash
+                42
+            end
+            def eql?(other)
+                raise "Eql method failed!"
+            end
+        end
+        def test
+            key1 = BadKey.new
+            key2 = BadKey.new
+            {key1 => "value1", key2 => "value2"}
+        end
+        begin
+            test
+        rescue => e
+            e.class
+        end
+        begin
+            test
+        rescue => e
+            e.class
+        end
+    "#), @"RuntimeError");
+}
+
+#[test]
+fn test_opt_hash_freeze() {
+    eval("
+        def test = {}.freeze
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_hash_freeze);
+    assert_snapshot!(inspect("
+        result = [test]
+        class Hash
+          def freeze = 5
+        end
+        result << test
+    "), @"[{}, 5]");
+}
+
+#[test]
+fn test_opt_hash_freeze_rewritten() {
+    eval("
+        class Hash
+            def freeze = 5
+        end
+        def test = {}.freeze
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_hash_freeze);
+    assert_snapshot!(inspect("test"), @"5");
+}
+
+#[test]
+fn test_opt_aset_hash() {
+    eval("
+        def test(h, k, v)
+            h[k] = v
+        end
+        test({}, :key, 42)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_aset);
+    assert_snapshot!(inspect("h = {}; test(h, :key, 42); h[:key]"), @"42");
+}
+
+#[test]
+fn test_opt_aset_hash_returns_value() {
+    assert_snapshot!(inspect("
+        def test(h, k, v)
+            h[k] = v
+        end
+        test({}, :key, 100)
+        test({}, :key, 100)
+    "), @"100");
+}
+
+#[test]
+fn test_opt_aset_hash_string_key() {
+    assert_snapshot!(inspect(r#"
+        def test(h, k, v)
+            h[k] = v
+        end
+        h = {}
+        test(h, "foo", "bar")
+        test(h, "foo", "bar")
+        h["foo"]
+    "#), @r#""bar""#);
+}
+
+#[test]
+fn test_opt_aset_hash_subclass() {
+    assert_snapshot!(inspect("
+        class MyHash < Hash; end
+        def test(h, k, v)
+            h[k] = v
+        end
+        h = MyHash.new
+        test(h, :key, 42)
+        test(h, :key, 42)
+        h[:key]
+    "), @"42");
+}
+
+#[test]
+fn test_opt_aset_hash_too_few_args() {
+    assert_snapshot!(inspect(r#"
+        def test(h)
+            h.[]= 123
+        rescue ArgumentError
+            "ArgumentError"
+        end
+        test({})
+        test({})
+    "#), @r#""ArgumentError""#);
+}
+
+#[test]
+fn test_opt_aset_hash_too_many_args() {
+    assert_snapshot!(inspect(r#"
+        def test(h)
+            h[:a, :b] = :c
+        rescue ArgumentError
+            "ArgumentError"
+        end
+        test({})
+        test({})
+    "#), @r#""ArgumentError""#);
+}
+
+#[test]
+fn test_opt_ary_freeze() {
+    eval("
+        def test = [].freeze
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_ary_freeze);
+    assert_snapshot!(inspect("
+        result = [test]
+        class Array
+          def freeze = 5
+        end
+        result << test
+    "), @"[[], 5]");
+}
+
+#[test]
+fn test_opt_ary_freeze_rewritten() {
+    eval("
+        class Array
+            def freeze = 5
+        end
+        def test = [].freeze
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_ary_freeze);
+    assert_snapshot!(inspect("test"), @"5");
+}
+
+#[test]
+fn test_opt_str_freeze() {
+    eval("
+        def test = ''.freeze
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_str_freeze);
+    assert_snapshot!(inspect(r#"
+        result = [test]
+        class String
+          def freeze = 5
+        end
+        result << test
+    "#), @r#"["", 5]"#);
+}
+
+#[test]
+fn test_opt_str_freeze_rewritten() {
+    eval("
+        class String
+            def freeze = 5
+        end
+        def test = ''.freeze
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_str_freeze);
+    assert_snapshot!(inspect("test"), @"5");
+}
+
+#[test]
+fn test_opt_str_uminus() {
+    eval("
+        def test = -''
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_str_uminus);
+    assert_snapshot!(inspect(r#"
+        result = [test]
+        class String
+          def -@ = 5
+        end
+        result << test
+    "#), @r#"["", 5]"#);
+}
+
+#[test]
+fn test_opt_str_uminus_rewritten() {
+    eval("
+        class String
+            def -@ = 5
+        end
+        def test = -''
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_str_uminus);
+    assert_snapshot!(inspect("test"), @"5");
+}
+
+#[test]
+fn test_new_array_empty() {
+    eval("
+        def test = []
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_newarray);
+    assert_snapshot!(inspect("test"), @"[]");
+}
+
+#[test]
+fn test_new_array_nonempty() {
+    assert_snapshot!(inspect("
+        def a = 5
+        def test = [a]
+        test
+        test
+    "), @"[5]");
+}
+
+#[test]
+fn test_new_array_order() {
+    assert_snapshot!(inspect("
+        def a = 3
+        def b = 2
+        def c = 1
+        def test = [a, b, c]
+        test
+        test
+    "), @"[3, 2, 1]");
+}
+
+#[test]
+fn test_array_dup() {
+    assert_snapshot!(inspect("
+        def test = [1,2,3]
+        test
+        test
+    "), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_array_fixnum_aref() {
+    eval("
+        def test(x) = [1,2,3][x]
+        test(2)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_aref);
+    assert_snapshot!(inspect("test(2)"), @"3");
+}
+
+#[test]
+fn test_array_fixnum_aref_negative_index() {
+    eval("
+        def test(x) = [1,2,3][x]
+        test(-1)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_aref);
+    assert_snapshot!(inspect("test(-1)"), @"3");
+}
+
+#[test]
+fn test_array_fixnum_aref_out_of_bounds_positive() {
+    eval("
+        def test(x) = [1,2,3][x]
+        test(10)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_aref);
+    assert_snapshot!(inspect("test(10)"), @"nil");
+}
+
+#[test]
+fn test_array_fixnum_aref_out_of_bounds_negative() {
+    eval("
+        def test(x) = [1,2,3][x]
+        test(-10)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_aref);
+    assert_snapshot!(inspect("test(-10)"), @"nil");
+}
+
+#[test]
+fn test_array_fixnum_aref_array_subclass() {
+    eval("
+        class MyArray < Array; end
+        def test(arr, idx) = arr[idx]
+        test(MyArray[1,2,3], 2)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_aref);
+    assert_snapshot!(inspect("test(MyArray[1,2,3], 2)"), @"3");
+}
+
+#[test]
+fn test_array_aref_non_fixnum_index() {
+    assert_snapshot!(inspect(r#"
+        def test(arr, idx) = arr[idx]
+        test([1,2,3], 1)
+        test([1,2,3], 1)
+        begin
+            test([1,2,3], "1")
+        rescue => e
+            e.class
+        end
+    "#), @"TypeError");
+}
+
+#[test]
+fn test_array_fixnum_aset() {
+    eval("
+        def test(arr, idx)
+            arr[idx] = 7
+        end
+        test([1,2,3], 2)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_aset);
+    assert_snapshot!(inspect("arr = [1,2,3]; test(arr, 2); arr"), @"[1, 2, 7]");
+}
+
+#[test]
+fn test_array_fixnum_aset_returns_value() {
+    eval("
+        def test(arr, idx)
+            arr[idx] = 7
+        end
+        test([1,2,3], 2)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_aset);
+    assert_snapshot!(inspect("test([1,2,3], 2)"), @"7");
+}
+
+#[test]
+fn test_array_fixnum_aset_out_of_bounds() {
+    assert_snapshot!(inspect("
+        def test(arr)
+            arr[5] = 7
+        end
+        arr = [1,2,3]
+        test(arr)
+        arr = [1,2,3]
+        test(arr)
+        arr
+    "), @"[1, 2, 3, nil, nil, 7]");
+}
+
+#[test]
+fn test_array_fixnum_aset_negative_index() {
+    assert_snapshot!(inspect("
+        def test(arr)
+            arr[-1] = 7
+        end
+        arr = [1,2,3]
+        test(arr)
+        arr = [1,2,3]
+        test(arr)
+        arr
+    "), @"[1, 2, 7]");
+}
+
+#[test]
+fn test_array_fixnum_aset_shared() {
+    assert_snapshot!(inspect("
+        def test(arr, idx, val)
+            arr[idx] = val
+        end
+        arr = (0..50).to_a
+        test(arr, 0, -1)
+        test(arr, 1, -2)
+        shared = arr[10, 20]
+        test(shared, 0, 999)
+        [arr[10], shared[0], arr[0], arr[1]]
+    "), @"[10, 999, -1, -2]");
+}
+
+#[test]
+fn test_array_fixnum_aset_frozen() {
+    assert_snapshot!(inspect("
+        def test(arr, idx, val)
+            arr[idx] = val
+        end
+        arr = [1,2,3]
+        test(arr, 1, 9)
+        test(arr, 1, 9)
+        arr.freeze
+        begin
+            test(arr, 1, 9)
+        rescue => e
+            e.class
+        end
+    "), @"FrozenError");
+}
+
+#[test]
+fn test_array_fixnum_aset_array_subclass() {
+    eval("
+        class MyArray < Array; end
+        def test(arr, idx)
+            arr[idx] = 7
+        end
+        test(MyArray.new, 0)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_aset);
+    assert_snapshot!(inspect("arr = MyArray.new; test(arr, 0); arr[0]"), @"7");
+}
+
+#[test]
+fn test_array_aset_non_fixnum_index() {
+    assert_snapshot!(inspect(r#"
+        def test(arr, idx)
+            arr[idx] = 7
+        end
+        test([1,2,3], 0)
+        test([1,2,3], 0)
+        begin
+            test([1,2,3], "0")
+        rescue => e
+            e.class
+        end
+    "#), @"TypeError");
+}
+
+#[test]
+fn test_empty_array_pop() {
+    assert_snapshot!(inspect("
+        def test(arr) = arr.pop
+        test([])
+        test([])
+    "), @"nil");
+}
+
+#[test]
+fn test_array_pop_no_arg() {
+    assert_snapshot!(inspect("
+        def test(arr) = arr.pop
+        test([32, 33, 42])
+        test([32, 33, 42])
+    "), @"42");
+}
+
+#[test]
+fn test_array_pop_arg() {
+    assert_snapshot!(inspect("
+        def test(arr) = arr.pop(2)
+        test([32, 33, 42])
+        test([32, 33, 42])
+    "), @"[33, 42]");
+}
+
+#[test]
+fn test_new_range_inclusive() {
+    assert_snapshot!(inspect("
+        def test(a, b) = a..b
+        test(1, 5)
+        test(1, 5)
+    "), @"1..5");
+}
+
+#[test]
+fn test_new_range_exclusive() {
+    assert_snapshot!(inspect("
+        def test(a, b) = a...b
+        test(1, 5)
+        test(1, 5)
+    "), @"1...5");
+}
+
+#[test]
+fn test_new_range_with_literal() {
+    assert_snapshot!(inspect("
+        def test(n) = n..10
+        test(3)
+        test(3)
+    "), @"3..10");
+}
+
+#[test]
+fn test_new_range_fixnum_both_literals_inclusive() {
+    eval("
+        def test()
+          a = 2
+          (1..a)
+        end
+    ");
+    assert_contains_opcode("test", YARVINSN_newrange);
+    assert_snapshot!(inspect("test; test"), @"1..2");
+}
+
+#[test]
+fn test_new_range_fixnum_both_literals_exclusive() {
+    eval("
+        def test()
+          a = 2
+          (1...a)
+        end
+    ");
+    assert_contains_opcode("test", YARVINSN_newrange);
+    assert_snapshot!(inspect("test; test"), @"1...2");
+}
+
+#[test]
+fn test_new_range_fixnum_low_literal_inclusive() {
+    eval("
+        def test(a) = (1..a)
+    ");
+    assert_contains_opcode("test", YARVINSN_newrange);
+    assert_snapshot!(inspect("test(2); test(3)"), @"1..3");
+}
+
+#[test]
+fn test_new_range_fixnum_low_literal_exclusive() {
+    eval("
+        def test(a) = (1...a)
+    ");
+    assert_contains_opcode("test", YARVINSN_newrange);
+    assert_snapshot!(inspect("test(2); test(3)"), @"1...3");
+}
+
+#[test]
+fn test_new_range_fixnum_high_literal_inclusive() {
+    eval("
+        def test(a) = (a..10)
+    ");
+    assert_contains_opcode("test", YARVINSN_newrange);
+    assert_snapshot!(inspect("test(2); test(3)"), @"3..10");
+}
+
+#[test]
+fn test_new_range_fixnum_high_literal_exclusive() {
+    eval("
+        def test(a) = (a...10)
+    ");
+    assert_contains_opcode("test", YARVINSN_newrange);
+    assert_snapshot!(inspect("test(2); test(3)"), @"3...10");
+}
+
+#[test]
+fn test_if() {
+    assert_snapshot!(inspect("
+        def test(n)
+          if n < 5
+            0
+          end
+        end
+        test(3)
+        [test(3), test(7)]
+    "), @"[0, nil]");
+}
+
+#[test]
+fn test_if_else() {
+    assert_snapshot!(inspect("
+        def test(n)
+          if n < 5
+            0
+          else
+            1
+          end
+        end
+        test(3)
+        [test(3), test(7)]
+    "), @"[0, 1]");
+}
+
+#[test]
+fn test_if_else_params() {
+    assert_snapshot!(inspect("
+        def test(n, a, b)
+          if n < 5
+            a
+          else
+            b
+          end
+        end
+        test(3, 1, 2)
+        [test(3, 1, 2), test(7, 10, 20)]
+    "), @"[1, 20]");
+}
+
+#[test]
+fn test_if_else_nested() {
+    assert_snapshot!(inspect("
+        def test(a, b, c, d, e)
+          if 2 < a
+            if a < 4
+              b
+            else
+              c
+            end
+          else
+            if a < 0
+              d
+            else
+              e
+            end
+          end
+        end
+        test(-1, 1, 2, 3, 4)
+        [
+          test(-1,  1,  2,  3,  4),
+          test( 0,  5,  6,  7,  8),
+          test( 3,  9, 10, 11, 12),
+          test( 5, 13, 14, 15, 16),
+        ]
+    "), @"[3, 8, 9, 14]");
+}
+
+#[test]
+fn test_if_else_chained() {
+    assert_snapshot!(inspect("
+        def test(a)
+          (if 2 < a then 1 else 2 end) + (if a < 4 then 10 else 20 end)
+        end
+        test(0)
+        [test(0), test(3), test(5)]
+    "), @"[12, 11, 21]");
+}
+
+#[test]
+fn test_if_elsif_else() {
+    assert_snapshot!(inspect("
+        def test(n)
+          if n < 5
+            0
+          elsif 8 < n
+            1
+          else
+            2
+          end
+        end
+        test(3)
+        [test(3), test(7), test(9)]
+    "), @"[0, 2, 1]");
+}
+
+#[test]
+fn test_ternary_operator() {
+    assert_snapshot!(inspect("
+        def test(n, a, b)
+          n < 5 ? a : b
+        end
+        test(3, 1, 2)
+        [test(3, 1, 2), test(7, 10, 20)]
+    "), @"[1, 20]");
+}
+
+#[test]
+fn test_ternary_operator_nested() {
+    assert_snapshot!(inspect("
+        def test(n, a, b)
+          (n < 5 ? a : b) + 1
+        end
+        test(3, 1, 2)
+        [test(3, 1, 2), test(7, 10, 20)]
+    "), @"[2, 21]");
+}
+
+#[test]
+fn test_while_loop() {
+    assert_snapshot!(inspect("
+        def test(n)
+          i = 0
+          while i < n
+            i = i + 1
+          end
+          i
+        end
+        test(10)
+        test(10)
+    "), @"10");
+}
+
+#[test]
+fn test_while_loop_chain() {
+    assert_snapshot!(inspect("
+        def test(n)
+          i = 0
+          while i < n
+            i = i + 1
+          end
+          while i < n * 10
+            i = i * 3
+          end
+          i
+        end
+        test(5)
+        [test(5), test(10)]
+    "), @"[135, 270]");
+}
+
+#[test]
+fn test_while_loop_nested() {
+    assert_snapshot!(inspect("
+        def test(n, m)
+          i = 0
+          while i < n
+            j = 0
+            while j < m
+              j += 2
+            end
+            i += j
+          end
+          i
+        end
+        test(0, 0)
+        [test(0, 0), test(1, 3), test(10, 5)]
+    "), @"[0, 4, 12]");
+}
+
+#[test]
+fn test_while_loop_if_else() {
+    assert_snapshot!(inspect("
+        def test(n)
+          i = 0
+          while i < n
+            if n >= 10
+              return -1
+            else
+              i = i + 1
+            end
+          end
+          i
+        end
+        test(9)
+        [test(9), test(10)]
+    "), @"[9, -1]");
+}
+
+#[test]
+fn test_if_while_loop() {
+    assert_snapshot!(inspect("
+        def test(n)
+          i = 0
+          if n < 10
+            while i < n
+              i += 1
+            end
+          else
+            while i < n
+              i += 3
+            end
+          end
+          i
+        end
+        test(9)
+        [test(9), test(10)]
+    "), @"[9, 12]");
+}
+
+#[test]
+fn test_live_reg_past_ccall() {
+    assert_snapshot!(inspect("
+        def callee = 1
+        def test = callee + callee
+        test
+        test
+    "), @"2");
+}
+
+#[test]
+fn test_method_call() {
+    assert_snapshot!(inspect("
+        def callee(a, b)
+          a - b
+        end
+        def test
+          callee(4, 2) + 10
+        end
+        test
+        test
+    "), @"12");
+}
+
+#[test]
+fn test_recursive_fact() {
+    assert_snapshot!(inspect("
+        def fact(n)
+          if n == 0
+            return 1
+          end
+          return n * fact(n-1)
+        end
+        fact(0)
+        [fact(0), fact(3), fact(6)]
+    "), @"[1, 6, 720]");
+}
+
+#[test]
+fn test_recursive_fib() {
+    assert_snapshot!(inspect("
+        def fib(n)
+          if n < 2
+            return n
+          end
+          return fib(n-1) + fib(n-2)
+        end
+        fib(0)
+        [fib(0), fib(3), fib(4)]
+    "), @"[0, 2, 3]");
+}
+
+#[test]
+fn test_spilled_basic_block_args() {
+    assert_snapshot!(inspect("
+        def test(n1, n2)
+          n3 = 3
+          n4 = 4
+          n5 = 5
+          n6 = 6
+          n7 = 7
+          n8 = 8
+          n9 = 9
+          n10 = 10
+          if n1 < n2
+            n1 + n2 + n3 + n4 + n5 + n6 + n7 + n8 + n9 + n10
+          end
+        end
+        test(1, 2)
+        test(1, 2)
+    "), @"55");
+}
+
+#[test]
+fn test_putself() {
+    assert_snapshot!(inspect("
+        class Integer
+          def minus(a)
+            self - a
+          end
+        end
+        5.minus(2)
+        5.minus(2)
+    "), @"3");
+}
+
+#[test]
+fn test_getinstancevariable_nil() {
+    assert_snapshot!(inspect("
+        def test() = @foo
+        test()
+        test()
+    "), @"nil");
+}
+
+#[test]
+fn test_getinstancevariable() {
+    assert_snapshot!(inspect("
+        @foo = 3
+        def test() = @foo
+        test()
+        test()
+    "), @"3");
+}
+
+#[test]
+fn test_getinstancevariable_miss() {
+    assert_snapshot!(inspect("
+        class C
+          def foo
+            @foo
+          end
+          def foo_then_bar
+            @foo = 1
+            @bar = 2
+          end
+          def bar_then_foo
+            @bar = 3
+            @foo = 4
+          end
+        end
+        o1 = C.new
+        o1.foo_then_bar
+        result = []
+        result << o1.foo
+        result << o1.foo
+        o2 = C.new
+        o2.bar_then_foo
+        result << o2.foo
+        result
+    "), @"[1, 1, 4]");
+}
+
+#[test]
+fn test_setinstancevariable() {
+    assert_snapshot!(inspect("
+        def test() = @foo = 1
+        test()
+        test()
+        @foo
+    "), @"1");
+}
+
+#[test]
+fn test_getclassvariable() {
+    assert_snapshot!(inspect("
+        class Foo
+          def self.test = @@x
+        end
+        Foo.class_variable_set(:@@x, 42)
+        Foo.test()
+        Foo.test()
+    "), @"42");
+}
+
+#[test]
+fn test_getclassvariable_raises() {
+    assert_snapshot!(inspect(r#"
+        class Foo
+          def self.test = @@x
+        end
+        begin
+          Foo.test
+          Foo.test
+        rescue NameError => e
+          e.message
+        end
+    "#), @r#""uninitialized class variable @@x in Foo""#);
+}
+
+#[test]
+fn test_setclassvariable() {
+    assert_snapshot!(inspect("
+        class Foo
+          def self.test = @@x = 42
+        end
+        Foo.test()
+        Foo.test()
+        Foo.class_variable_get(:@@x)
+    "), @"42");
+}
+
+#[test]
+fn test_setclassvariable_raises() {
+    assert_snapshot!(inspect(r#"
+        class Foo
+          def self.test = @@x = 42
+          freeze
+        end
+        begin
+          Foo.test
+          Foo.test
+        rescue FrozenError => e
+          e.message
+        end
+    "#), @r#""can't modify frozen Class: Foo""#);
+}
+
+#[test]
+fn test_attr_reader() {
+    eval("
+        class C
+          attr_reader :foo
+          def initialize
+            @foo = 4
+          end
+        end
+        def test(c) = c.foo
+        test(C.new)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_send_without_block);
+    assert_snapshot!(inspect("c = C.new; [test(c), test(c)]"), @"[4, 4]");
+}
+
+#[test]
+fn test_attr_accessor_getivar() {
+    eval("
+        class C
+          attr_accessor :foo
+          def initialize
+            @foo = 4
+          end
+        end
+        def test(c) = c.foo
+        test(C.new)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_send_without_block);
+    assert_snapshot!(inspect("c = C.new; [test(c), test(c)]"), @"[4, 4]");
+}
+
+#[test]
+fn test_attr_accessor_setivar() {
+    eval("
+        class C
+          attr_accessor :foo
+          def initialize
+            @foo = 4
+          end
+        end
+        def test(c)
+          c.foo = 5
+          c.foo
+        end
+        test(C.new)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_send_without_block);
+    assert_snapshot!(inspect("c = C.new; [test(c), test(c)]"), @"[5, 5]");
+}
+
+#[test]
+fn test_attr_writer() {
+    eval("
+        class C
+          attr_writer :foo
+          def initialize
+            @foo = 4
+          end
+          def get_foo = @foo
+        end
+        def test(c)
+          c.foo = 5
+          c.get_foo
+        end
+        test(C.new)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_send_without_block);
+    assert_snapshot!(inspect("c = C.new; [test(c), test(c)]"), @"[5, 5]");
+}
+
+#[test]
+fn test_getconstant() {
+    eval("
+        class Foo
+          CONST = 1
+        end
+        def test(klass)
+          klass::CONST
+        end
+        test(Foo)
+    ");
+    assert_contains_opcode("test", YARVINSN_getconstant);
+    assert_snapshot!(inspect("test(Foo)"), @"1");
+}
+
+#[test]
+fn test_expandarray_no_splat() {
+    eval("
+        def test(o)
+          a, b = o
+          [a, b]
+        end
+        test [3, 4]
+    ");
+    assert_contains_opcode("test", YARVINSN_expandarray);
+    assert_snapshot!(inspect("test [3, 4]"), @"[3, 4]");
+}
+
+#[test]
+fn test_expandarray_splat() {
+    eval("
+        def test(o)
+          a, *b = o
+          [a, b]
+        end
+        test [3, 4]
+    ");
+    assert_contains_opcode("test", YARVINSN_expandarray);
+    assert_snapshot!(inspect("test [3, 4]"), @"[3, [4]]");
+}
+
+#[test]
+fn test_expandarray_splat_post() {
+    eval("
+        def test(o)
+          a, *b, c = o
+          [a, b, c]
+        end
+        test [3, 4, 5]
+    ");
+    assert_contains_opcode("test", YARVINSN_expandarray);
+    assert_snapshot!(inspect("test [3, 4, 5]"), @"[3, [4], 5]");
+}
+
+#[test]
+fn test_constant_invalidation() {
+    eval("
+        class C; end
+        def test = C
+        test
+        test
+        C = 123
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_getconstant_path);
+    assert_snapshot!(inspect("test"), @"123");
+}
+
+#[test]
+fn test_constant_path_invalidation() {
+    eval("
+        module A
+          module B; end
+        end
+        module Foo
+          C = 'Foo::C'
+        end
+        A::B = Foo
+        def test = A::B::C
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_getconstant_path);
+    assert_snapshot!(inspect(r#"
+        module A
+          module B; end
+        end
+        module Foo
+          C = "Foo::C"
+        end
+        module Bar
+          C = "Bar::C"
+        end
+        A::B = Foo
+        def test = A::B::C
+        result = []
+        result << test
+        result << test
+        A::B = Bar
+        result << test
+        result
+    "#), @r#"["Foo::C", "Foo::C", "Bar::C"]"#);
+}
+
+#[test]
+fn test_dupn() {
+    eval("
+        def test(array) = (array[1, 2] ||= :rhs)
+        test([1, 1])
+    ");
+    assert_contains_opcode("test", YARVINSN_dupn);
+    assert_snapshot!(inspect("
+        one = [1, 1]
+        start_empty = []
+        [test(one), one, test(start_empty), start_empty]
+    "), @"[[1], [1, 1], :rhs, [nil, :rhs]]");
+}
+
+#[test]
+fn test_bop_invalidation() {
+    assert_snapshot!(inspect(r#"
+        def test
+          eval("class Integer; def +(_) = 100; end")
+          1 + 2
+        end
+        test
+        test
+    "#), @"100");
+}
+
+#[test]
+fn test_defined_with_defined_values() {
+    eval("
+        class Foo; end
+        def bar; end
+        $ruby = 1
+        def test = [defined?(Foo), defined?(bar), defined?($ruby)]
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_defined);
+    assert_snapshot!(inspect("test"), @r#"["constant", "method", "global-variable"]"#);
+}
+
+#[test]
+fn test_defined_with_undefined_values() {
+    eval("
+        def test = [defined?(FooUndef), defined?(bar_undef), defined?($ruby_undef)]
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_defined);
+    assert_snapshot!(inspect("test"), @"[nil, nil, nil]");
+}
+
+#[test]
+fn test_defined_with_method_call() {
+    eval(r#"
+        def test = [defined?("x".reverse(1)), defined?("x".reverse(1).reverse)]
+        test
+    "#);
+    assert_contains_opcode("test", YARVINSN_defined);
+    assert_snapshot!(inspect(r#"test"#), @r#"["method", nil]"#);
+}
+
+#[test]
+fn test_defined_method_raise() {
+    assert_snapshot!(inspect(r#"
+        class C
+          def assert_equal expected, actual
+            if expected != actual
+              raise "NO"
+            end
+          end
+          def test_defined_method
+            assert_equal(nil, defined?("x".reverse(1).reverse))
+          end
+        end
+        c = C.new
+        result = []
+        result << c.test_defined_method
+        result << c.test_defined_method
+        result << c.test_defined_method
+        result
+    "#), @"[nil, nil, nil]");
+}
+
+#[test]
+fn test_defined_yield() {
+    eval("
+        def test = defined?(yield)
+    ");
+    assert_contains_opcode("test", YARVINSN_defined);
+    assert_snapshot!(inspect("[test, test, test{}]"), @r#"[nil, nil, "yield"]"#);
+}
+
+#[test]
+fn test_defined_yield_from_block() {
+    assert_snapshot!(inspect("
+        def test
+          yield_self { yield_self { defined?(yield) } }
+        end
+        [test, test, test{}]
+    "), @r#"[nil, nil, "yield"]"#);
+}
+
+#[test]
+fn test_block_given_p() {
+    assert_snapshot!(inspect("
+        def test = block_given?
+        [test, test, test{}]
+    "), @"[false, false, true]");
+}
+
+#[test]
+fn test_block_given_p_from_block() {
+    assert_snapshot!(inspect("
+        def test
+          yield_self { yield_self { block_given? } }
+        end
+        [test, test, test{}]
+    "), @"[false, false, true]");
+}
+
+#[test]
+fn test_invokeblock_without_block_after_jit_call() {
+    assert_snapshot!(inspect(r#"
+        def test(*arr, &b)
+          arr.class
+          yield
+        end
+        test { }
+        begin
+          test
+        rescue => e
+          e.message
+        end
+    "#), @r#""no block given (yield)""#);
+}
+
+#[test]
+fn test_putspecialobject_vm_core_and_cbase() {
+    eval("
+        def test
+          alias bar test
+          10
+        end
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_putspecialobject);
+    assert_snapshot!(inspect("bar"), @"10");
+}
+
+#[test]
+fn test_putspecialobject_const_base() {
+    assert_snapshot!(inspect("
+        Foo = 1
+        def test = Foo
+        test
+        test
+    "), @"1");
+}
+
+#[test]
+fn test_branchnil() {
+    eval("
+        def test(x)
+          x&.succ
+        end
+        test(0)
+    ");
+    assert_contains_opcode("test", YARVINSN_branchnil);
+    assert_snapshot!(inspect("[test(1), test(nil)]"), @"[2, nil]");
+}
+
+#[test]
+fn test_nil_nil() {
+    eval("
+        def test = nil.nil?
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test"), @"true");
+}
+
+#[test]
+fn test_non_nil_nil() {
+    eval("
+        def test = 1.nil?
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test"), @"false");
+}
+
+#[test]
+fn test_getspecial_last_match() {
+    eval(r#"
+        def test(str)
+          str =~ /hello/
+          $&
+        end
+        test("hello world")
+    "#);
+    assert_contains_opcode("test", YARVINSN_getspecial);
+    assert_snapshot!(inspect(r#"test("hello world")"#), @r#""hello""#);
+}
+
+#[test]
+fn test_getspecial_match_pre() {
+    eval(r#"
+        def test(str)
+          str =~ /world/
+          $`
+        end
+        test("hello world")
+    "#);
+    assert_contains_opcode("test", YARVINSN_getspecial);
+    assert_snapshot!(inspect(r#"test("hello world")"#), @r#""hello ""#);
+}
+
+#[test]
+fn test_getspecial_match_post() {
+    eval(r#"
+        def test(str)
+          str =~ /hello/
+          $'
+        end
+        test("hello world")
+    "#);
+    assert_contains_opcode("test", YARVINSN_getspecial);
+    assert_snapshot!(inspect(r#"test("hello world")"#), @r#"" world""#);
+}
+
+#[test]
+fn test_getspecial_match_last_group() {
+    eval(r#"
+        def test(str)
+          str =~ /(hello) (world)/
+          $+
+        end
+        test("hello world")
+    "#);
+    assert_contains_opcode("test", YARVINSN_getspecial);
+    assert_snapshot!(inspect(r#"test("hello world")"#), @r#""world""#);
+}
+
+#[test]
+fn test_getspecial_numbered_match_1() {
+    eval(r#"
+        def test(str)
+          str =~ /(hello) (world)/
+          $1
+        end
+        test("hello world")
+    "#);
+    assert_contains_opcode("test", YARVINSN_getspecial);
+    assert_snapshot!(inspect(r#"test("hello world")"#), @r#""hello""#);
+}
+
+#[test]
+fn test_getspecial_numbered_match_2() {
+    eval(r#"
+        def test(str)
+          str =~ /(hello) (world)/
+          $2
+        end
+        test("hello world")
+    "#);
+    assert_contains_opcode("test", YARVINSN_getspecial);
+    assert_snapshot!(inspect(r#"test("hello world")"#), @r#""world""#);
+}
+
+#[test]
+fn test_getspecial_numbered_match_nonexistent() {
+    eval(r#"
+        def test(str)
+          str =~ /(hello)/
+          $2
+        end
+        test("hello world")
+    "#);
+    assert_contains_opcode("test", YARVINSN_getspecial);
+    assert_snapshot!(inspect(r#"test("hello world")"#), @"nil");
+}
+
+#[test]
+fn test_getspecial_no_match() {
+    eval(r#"
+        def test(str)
+          str =~ /xyz/
+          $&
+        end
+        test("hello world")
+    "#);
+    assert_contains_opcode("test", YARVINSN_getspecial);
+    assert_snapshot!(inspect(r#"test("hello world")"#), @"nil");
+}
+
+#[test]
+fn test_getspecial_complex_pattern() {
+    eval(r#"
+        def test(str)
+          str =~ /(\d+)/
+          $1
+        end
+        test("abc123def")
+    "#);
+    assert_contains_opcode("test", YARVINSN_getspecial);
+    assert_snapshot!(inspect(r#"test("abc123def")"#), @r#""123""#);
+}
+
+#[test]
+fn test_getspecial_multiple_groups() {
+    eval(r#"
+        def test(str)
+          str =~ /(\d+)-(\d+)/
+          $2
+        end
+        test("123-456")
+    "#);
+    assert_contains_opcode("test", YARVINSN_getspecial);
+    assert_snapshot!(inspect(r#"test("123-456")"#), @r#""456""#);
+}
+
+#[test]
+fn test_profile_under_nested_jit_call() {
+    assert_snapshot!(inspect("
+        def profile
+          1 + 2
+        end
+        def jit_call(flag)
+          if flag
+            profile
+          end
+        end
+        def entry(flag)
+          jit_call(flag)
+        end
+        [entry(false), entry(false), entry(true)]
+    "), @"[nil, nil, 3]");
+}
+
+#[test]
+fn test_bop_redefined() {
+    assert_snapshot!(inspect("
+        def test
+          1 + 2
+        end
+        test
+        [test, Integer.class_eval { def +(_) = 100 }, test]
+    "), @"[3, :+, 100]");
+}
+
+#[test]
+fn test_bop_redefined_with_adjacent_patch_points() {
+    assert_snapshot!(inspect("
+        def test
+          1 + 2 + 3 + 4 + 5
+        end
+        test
+        [test, Integer.class_eval { def +(_) = 100 }, test]
+    "), @"[15, :+, 100]");
+}
+
+#[test]
+fn test_method_redefined_with_top_self() {
+    assert_snapshot!(inspect(r#"
+        def foo
+          "original"
+        end
+        def test = foo
+        test; test
+        result1 = test
+        def foo
+          "redefined"
+        end
+        result2 = test
+        [result1, result2]
+    "#), @r#"["original", "redefined"]"#);
+}
+
+#[test]
+fn test_method_redefined_with_module() {
+    assert_snapshot!(inspect(r#"
+        module Foo
+          def self.foo = "original"
+        end
+        def test = Foo.foo
+        test
+        result1 = test
+        def Foo.foo = "redefined"
+        result2 = test
+        [result1, result2]
+    "#), @r#"["original", "redefined"]"#);
+}
+
+#[test]
+fn test_module_name_with_guard_passes() {
+    assert_snapshot!(inspect(r#"
+        def test(mod)
+          mod.name
+        end
+        test(String)
+        test(Integer)
+    "#), @r#""Integer""#);
+}
+
+#[test]
+fn test_module_name_with_guard_side_exit() {
+    assert_snapshot!(inspect(r#"
+        class MyClass
+          def name = "Bar"
+        end
+        def test(mod)
+          mod.name
+        end
+        results = []
+        results << test(String)
+        results << test(Integer)
+        results << test(MyClass.new)
+        results
+    "#), @r#"["String", "Integer", "Bar"]"#);
+}
+
+#[test]
+fn test_objtostring_calls_to_s_on_non_strings() {
+    assert_snapshot!(inspect(r##"
+        results = []
+        class Foo
+          def to_s
+            "foo"
+          end
+        end
+        def test(str)
+          "#{str}"
+        end
+        results << test(Foo.new)
+        results << test(Foo.new)
+        results
+    "##), @r#"["foo", "foo"]"#);
+}
+
+#[test]
+fn test_objtostring_rewrite_does_not_call_to_s_on_strings() {
+    assert_snapshot!(inspect(r##"
+        results = []
+        class String
+          def to_s
+            "bad"
+          end
+        end
+        def test(foo)
+          "#{foo}"
+        end
+        results << test("foo")
+        results << test("foo")
+        results
+    "##), @r#"["foo", "foo"]"#);
+}
+
+#[test]
+fn test_objtostring_rewrite_does_not_call_to_s_on_string_subclasses() {
+    assert_snapshot!(inspect(r##"
+        results = []
+        class StringSubclass < String
+          def to_s
+            "bad"
+          end
+        end
+        foo = StringSubclass.new("foo")
+        def test(str)
+          "#{str}"
+        end
+        results << test(foo)
+        results << test(foo)
+        results
+    "##), @r#"["foo", "foo"]"#);
+}
+
+#[test]
+fn test_objtostring_profiled_string_fastpath() {
+    assert_snapshot!(inspect(r##"
+        def test(str)
+          "#{str}"
+        end
+        test('foo'); test('foo')
+    "##), @r#""foo""#);
+}
+
+#[test]
+fn test_objtostring_profiled_string_subclass_fastpath() {
+    assert_snapshot!(inspect(r##"
+        class MyString < String; end
+        def test(str)
+          "#{str}"
+        end
+        foo = MyString.new("foo")
+        test(foo); test(foo)
+    "##), @r#""foo""#);
+}
+
+#[test]
+fn test_objtostring_profiled_string_fastpath_exits_on_nonstring() {
+    assert_snapshot!(inspect(r##"
+        def test(str)
+          "#{str}"
+        end
+        test('foo')
+        test(1)
+    "##), @r#""1""#);
+}
+
+#[test]
+fn test_objtostring_profiled_nonstring_calls_to_s() {
+    assert_snapshot!(inspect(r##"
+        def test(str)
+          "#{str}"
+        end
+        test([1,2,3]);
+        test([1,2,3]);
+    "##), @r#""[1, 2, 3]""#);
+}
+
+#[test]
+fn test_objtostring_profiled_nonstring_guard_exits_when_string() {
+    assert_snapshot!(inspect(r##"
+        def test(str)
+          "#{str}"
+        end
+        test([1,2,3]);
+        test('foo');
+    "##), @r#""foo""#);
+}
+
+#[test]
+fn test_string_bytesize_with_guard() {
+    assert_snapshot!(inspect("
+        def test(str)
+          str.bytesize
+        end
+        test('hello')
+        test('world')
+    "), @"5");
+}
+
+#[test]
+fn test_string_bytesize_multibyte() {
+    assert_snapshot!(inspect(r#"
+        def test(s)
+          s.bytesize
+        end
+        test("💎")
+        test("💎")
+    "#), @"4");
+}
+
+#[test]
+fn test_nil_value_nil_opt_with_guard() {
+    eval("
+        def test(val) = val.nil?
+        test(nil)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(nil)"), @"true");
+}
+
+#[test]
+fn test_nil_value_nil_opt_with_guard_side_exit() {
+    eval("
+        def test(val) = val.nil?
+        test(nil)
+        test(nil)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(1)"), @"false");
+}
+
+#[test]
+fn test_true_nil_opt_with_guard() {
+    eval("
+        def test(val) = val.nil?
+        test(true)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(true)"), @"false");
+}
+
+#[test]
+fn test_true_nil_opt_with_guard_side_exit() {
+    eval("
+        def test(val) = val.nil?
+        test(true)
+        test(true)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(nil)"), @"true");
+}
+
+#[test]
+fn test_false_nil_opt_with_guard() {
+    eval("
+        def test(val) = val.nil?
+        test(false)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(false)"), @"false");
+}
+
+#[test]
+fn test_false_nil_opt_with_guard_side_exit() {
+    eval("
+        def test(val) = val.nil?
+        test(false)
+        test(false)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(nil)"), @"true");
+}
+
+#[test]
+fn test_integer_nil_opt_with_guard() {
+    eval("
+        def test(val) = val.nil?
+        test(1)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(2)"), @"false");
+}
+
+#[test]
+fn test_integer_nil_opt_with_guard_side_exit() {
+    eval("
+        def test(val) = val.nil?
+        test(1)
+        test(2)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(nil)"), @"true");
+}
+
+#[test]
+fn test_float_nil_opt_with_guard() {
+    eval("
+        def test(val) = val.nil?
+        test(1.0)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(2.0)"), @"false");
+}
+
+#[test]
+fn test_float_nil_opt_with_guard_side_exit() {
+    eval("
+        def test(val) = val.nil?
+        test(1.0)
+        test(2.0)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(nil)"), @"true");
+}
+
+#[test]
+fn test_symbol_nil_opt_with_guard() {
+    eval("
+        def test(val) = val.nil?
+        test(:foo)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(:bar)"), @"false");
+}
+
+#[test]
+fn test_symbol_nil_opt_with_guard_side_exit() {
+    eval("
+        def test(val) = val.nil?
+        test(:foo)
+        test(:bar)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(nil)"), @"true");
+}
+
+#[test]
+fn test_class_nil_opt_with_guard() {
+    eval("
+        def test(val) = val.nil?
+        test(String)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(Integer)"), @"false");
+}
+
+#[test]
+fn test_class_nil_opt_with_guard_side_exit() {
+    eval("
+        def test(val) = val.nil?
+        test(String)
+        test(Integer)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(nil)"), @"true");
+}
+
+#[test]
+fn test_module_nil_opt_with_guard() {
+    eval("
+        def test(val) = val.nil?
+        test(Enumerable)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(Kernel)"), @"false");
+}
+
+#[test]
+fn test_module_nil_opt_with_guard_side_exit() {
+    eval("
+        def test(val) = val.nil?
+        test(Enumerable)
+        test(Kernel)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_nil_p);
+    assert_snapshot!(inspect("test(nil)"), @"true");
+}
+
+#[test]
+fn test_basic_object_guard_works_with_immediate() {
+    assert_snapshot!(inspect("
+        class Foo; end
+        def test(val) = val.class
+        test(Foo.new)
+        test(Foo.new)
+        test(nil)
+    "), @"NilClass");
+}
+
+#[test]
+fn test_basic_object_guard_works_with_false() {
+    assert_snapshot!(inspect("
+        class Foo; end
+        def test(val) = val.class
+        test(Foo.new)
+        test(Foo.new)
+        test(false)
+    "), @"FalseClass");
+}
+
+#[test]
+fn test_string_concat() {
+    eval(r##"
+        def test = "#{1}#{2}#{3}"
+        test
+    "##);
+    assert_contains_opcode("test", YARVINSN_concatstrings);
+    assert_snapshot!(inspect(r##"test"##), @r#""123""#);
+}
+
+#[test]
+fn test_string_concat_empty() {
+    eval(r##"
+        def test = "#{}"
+        test
+    "##);
+    assert_contains_opcode("test", YARVINSN_concatstrings);
+    assert_snapshot!(inspect(r##"test"##), @r#""""#);
+}
+
+#[test]
+fn test_regexp_interpolation() {
+    eval(r##"
+        def test = /#{1}#{2}#{3}/
+        test
+    "##);
+    assert_contains_opcode("test", YARVINSN_toregexp);
+    assert_snapshot!(inspect(r##"test"##), @"/123/");
+}
+
+#[test]
+fn test_new_range_non_leaf() {
+    assert_snapshot!(inspect("
+        def jit_entry(v) = make_range_then_exit(v)
+        def make_range_then_exit(v)
+          range = (v..1)
+          super rescue range
+        end
+        jit_entry(0)
+        jit_entry(0)
+        jit_entry(0/1r)
+    "), @"(0/1)..1");
+}
+
+#[test]
+fn test_raise_in_second_argument() {
+    assert_snapshot!(inspect("
+        def write(hash, key)
+          hash[key] = raise rescue true
+          hash
+        end
+        write({}, :warmup)
+        write({}, :ok)
+    "), @"{ok: true}");
+}
+
+#[test]
+fn test_struct_set() {
+    assert_snapshot!(inspect("
+        C = Struct.new(:foo).new(1)
+        def test
+          C.foo = Object.new
+          42
+        end
+        r = [test, test]
+        C.freeze
+        r << begin
+          test
+        rescue FrozenError
+          :frozen_error
+        end
+    "), @"[42, 42, :frozen_error]");
+}
+
+#[test]
+fn test_opt_case_dispatch() {
+    eval("
+        def test(x)
+          case x
+          when :foo
+            true
+          else
+            false
+          end
+        end
+        test(:warmup)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_case_dispatch);
+    assert_snapshot!(inspect("[test(:foo), test(1)]"), @"[true, false]");
+}
+
+#[test]
+fn test_stack_overflow() {
+    assert_snapshot!(inspect("
+        def recurse(n)
+          return if n == 0
+          recurse(n-1)
+          nil
+        end
+        recurse(2)
+        recurse(2)
+        begin
+          recurse(20_000)
+        rescue SystemStackError
+        end
+    "), @"nil");
+}
+
+#[test]
+fn test_invokeblock() {
+    eval("
+        def test
+          yield
+        end
+        test { 41 }
+    ");
+    assert_contains_opcode("test", YARVINSN_invokeblock);
+    assert_snapshot!(inspect("test { 42 }"), @"42");
+}
+
+#[test]
+fn test_invokeblock_with_args() {
+    eval("
+        def test(x, y)
+          yield x, y
+        end
+        test(1, 2) { |a, b| a + b }
+    ");
+    assert_contains_opcode("test", YARVINSN_invokeblock);
+    assert_snapshot!(inspect("test(1, 2) { |a, b| a + b }"), @"3");
+}
+
+#[test]
+fn test_invokeblock_no_block_given() {
+    eval("
+        def test
+          yield rescue :error
+        end
+        test { }
+    ");
+    assert_contains_opcode("test", YARVINSN_invokeblock);
+    assert_snapshot!(inspect("test"), @":error");
+}
+
+#[test]
+fn test_invokeblock_multiple_yields() {
+    eval("
+        def test
+          yield 1
+          yield 2
+          yield 3
+        end
+        test { |x| x }
+    ");
+    assert_contains_opcode("test", YARVINSN_invokeblock);
+    assert_snapshot!(inspect("
+        results = []
+        test { |x| results << x }
+        results
+    "), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_ccall_variadic_with_multiple_args() {
+    eval("
+        def test
+          a = []
+          a.push(1, 2, 3)
+          a
+        end
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_send_without_block);
+    assert_snapshot!(inspect("test"), @"[1, 2, 3]");
+}
+
+#[test]
+fn test_ccall_variadic_with_no_args() {
+    eval("
+        def test
+          a = [1]
+          a.push
+        end
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_send_without_block);
+    assert_snapshot!(inspect("test"), @"[1]");
+}
+
+#[test]
+fn test_ccall_variadic_with_no_args_causing_argument_error() {
+    eval("
+        def test
+          format
+        rescue ArgumentError
+          :error
+        end
+        test
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_send_without_block);
+    assert_snapshot!(inspect("test"), @":error");
+}
+
+#[test]
+fn test_allocating_in_hir_c_method_is() {
+    eval("
+        def a(f) = test(f)
+        def test(f) = (f.new if f)
+        def second = third
+        def third = nil
+        a(nil)
+        a(nil)
+        class Foo
+        def self.new = :k
+        end
+        second
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_new);
+    assert_snapshot!(inspect("a(Foo)"), @":k");
+}
+
+#[test]
+fn test_singleton_class_invalidation_annotated_ccall() {
+    assert_snapshot!(inspect("
+        def define_singleton(obj, define)
+          if define
+            [nil].reverse_each do
+              class << obj
+                def ==(_)
+                  true
+                end
+              end
+            end
+          end
+          false
+        end
+        def test(define)
+          obj = BasicObject.new
+          obj == define_singleton(obj, define)
+        end
+        result = []
+        result << test(false)
+        result << test(true)
+        result
+    "), @"[false, true]");
+}
+
+#[test]
+fn test_singleton_class_invalidation_optimized_variadic_ccall() {
+    assert_snapshot!(inspect("
+        def define_singleton(arr, define)
+          if define
+            [nil].reverse_each do
+              class << arr
+                def push(x)
+                  super(x * 1000)
+                end
+              end
+            end
+          end
+          1
+        end
+        def test(define)
+          arr = []
+          val = define_singleton(arr, define)
+          arr.push(val)
+          arr[0]
+        end
+        result = []
+        result << test(false)
+        result << test(true)
+        result
+    "), @"[1, 1000]");
+}
+
+#[test]
+fn test_is_a_string_special_case() {
+    assert_snapshot!(inspect(r#"
+        def test(x)
+          x.is_a?(String)
+        end
+        test("foo")
+        [test("bar"), test(1), test(false), test(:foo), test([]), test({})]
+    "#), @"[true, false, false, false, false, false]");
+}
+
+#[test]
+fn test_is_a_array_special_case() {
+    assert_snapshot!(inspect("
+        def test(x)
+          x.is_a?(Array)
+        end
+        test([])
+        [test([1,2,3]), test([]), test(1), test(false), test(:foo), test('foo'), test({})]
+    "), @"[true, true, false, false, false, false, false]");
+}
+
+#[test]
+fn test_is_a_hash_special_case() {
+    assert_snapshot!(inspect("
+        def test(x)
+          x.is_a?(Hash)
+        end
+        test({})
+        [test({:a => 'b'}), test({}), test(1), test(false), test(:foo), test([]), test('foo')]
+    "), @"[true, true, false, false, false, false, false]");
+}
+
+#[test]
+fn test_is_a_hash_subclass() {
+    assert_snapshot!(inspect("
+        class MyHash < Hash
+        end
+        def test(x)
+          x.is_a?(Hash)
+        end
+        test({})
+        test(MyHash.new)
+    "), @"true");
+}
+
+#[test]
+fn test_is_a_normal_case() {
+    assert_snapshot!(inspect(r#"
+        class MyClass
+        end
+        def test(x)
+          x.is_a?(MyClass)
+        end
+        test("a")
+        [test(MyClass.new), test("a")]
+    "#), @"[true, false]");
+}
+
+#[test]
+fn test_fixnum_div_zero() {
+    eval("
+        def test(n)
+          n / 0
+        rescue ZeroDivisionError => e
+          e.message
+        end
+        test(0)
+    ");
+    assert_contains_opcode("test", YARVINSN_opt_div);
+    assert_snapshot!(inspect(r#"test(0)"#), @r#""divided by 0""#);
+}
+
+#[test]
+fn test_invokesuper_with_local_written_by_blockiseq() {
+    assert_snapshot!(inspect(r#"
+        class A
+          def foo = "A"
+        end
+        class B < A
+          def foo
+            x = nil
+            [nil].each do |_|
+              x = super
+            end
+            x
+          end
+        end
+        def test = B.new.foo
+        test
+        test
+    "#), @r#""A""#);
+}
+
+#[test]
+fn test_max_iseq_versions() {
+    eval(&format!("
+        TEST = -1
+        def test = TEST
+
+        # compile and invalidate MAX+1 times
+        i = 0
+        while i < {MAX_ISEQ_VERSIONS} + 1
+          test; test # compile a version
+
+          Object.send(:remove_const, :TEST)
+          TEST = i
+
+          i += 1
+        end
+    "));
+
+    // It should not exceed MAX_ISEQ_VERSIONS
+    let iseq = get_method_iseq("self", "test");
+    let payload = get_or_create_iseq_payload(iseq);
+    assert_eq!(payload.versions.len(), MAX_ISEQ_VERSIONS);
+
+    // The last call should not discard the JIT code
+    assert!(matches!(unsafe { payload.versions.last().unwrap().as_ref() }.status, IseqStatus::Compiled(_)));
+}
+
+#[test]
+fn test_optional_arguments_side_exit() {
+    assert_snapshot!(inspect("
+        def test(a = (def foo = nil)) = a
+        test
+        [test, (undef :foo), test(1)]
+    "), @"[:foo, nil, 1]");
+}
+
+#[test]
+fn test_call_a_forwardable_method() {
+    assert_snapshot!(inspect("
+        def test_root = forwardable
+        def forwardable(...) = Array.[](...)
+        test_root
+        test_root
+    "), @"[]");
+}
+
+#[test]
+fn test_send_on_heap_object_in_spilled_arg() {
+    assert_snapshot!(inspect("
+        def entry(a1, a2, a3, a4, a5, a6, a7, a8, a9)
+          a9.itself.class
+        end
+        entry(1, 2, 3, 4, 5, 6, 7, 8, {})
+        entry(1, 2, 3, 4, 5, 6, 7, 8, {})
+    "), @"Hash");
+}
+
+#[test]
+fn test_send_splat() {
+    assert_snapshot!(inspect("
+        def test(a, b) = [a, b]
+        def entry(arr) = test(*arr)
+        entry([1, 2])
+        entry([1, 2])
+    "), @"[1, 2]");
+}
+
+#[test]
+fn test_send_kwarg() {
+    assert_snapshot!(inspect("
+        def test(a:, b:) = [a, b]
+        def entry = test(b: 2, a: 1)
+        entry
+        entry
+    "), @"[1, 2]");
+}
+
+#[test]
+fn test_spilled_method_args() {
+    assert_snapshot!(inspect("
+        def foo(n1, n2, n3, n4, n5, n6, n7, n8, n9, n10)
+          n1 + n2 + n3 + n4 + n5 + n6 + n7 + n8 + n9 + n10
+        end
+        def test
+          foo(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        end
+        test
+        test
+    "), @"55");
+}
+
+#[test]
+fn test_spilled_method_args_first_and_last() {
+    assert_snapshot!(inspect("
+        def a(n1,n2,n3,n4,n5,n6,n7,n8,n9) = n1+n9
+        a(2,0,0,0,0,0,0,0,-1)
+        a(2,0,0,0,0,0,0,0,-1)
+    "), @"1");
+}
+
+#[test]
+fn test_spilled_method_args_last() {
+    assert_snapshot!(inspect("
+        def a(n1,n2,n3,n4,n5,n6,n7,n8) = n8
+        a(1,1,1,1,1,1,1,0)
+        a(1,1,1,1,1,1,1,0)
+    "), @"0");
+}
+
+#[test]
+fn test_spilled_method_args_self() {
+    assert_snapshot!(inspect("
+        def a(n1,n2,n3,n4,n5,n6,n7,n8) = self
+        a(1,0,0,0,0,0,0,0).to_s
+        a(1,0,0,0,0,0,0,0).to_s
+    "), @r#""main""#);
+}
+
+#[test]
+fn test_spilled_param_new_array() {
+    assert_snapshot!(inspect("
+        def a(n1,n2,n3,n4,n5,n6,n7,n8) = [n8]
+        a(0,0,0,0,0,0,0, :ok)
+        a(0,0,0,0,0,0,0, :ok)
+    "), @"[:ok]");
+}
+
+#[test]
+fn test_forty_param_method() {
+    assert_snapshot!(inspect("
+        def foo(_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,_,n40) = n40
+        foo(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1)
+        foo(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1)
+    "), @"1");
+}
+
+#[test]
+fn test_toplevel_local_after_eval() {
+    assert_snapshot!(inspect("
+        a = 1
+        b = 2
+        eval('b = 3')
+        c = 4
+        [a, b, c]
+    "), @"[1, 3, 4]");
+}
+
+#[test]
+fn test_send_exit_with_uninitialized_locals() {
+    assert_snapshot!(inspect("
+        def entry(init)
+          function_stub_exit(init)
+        end
+
+        def function_stub_exit(init)
+          uninitialized_local = 1 if init
+          uninitialized_local
+        end
+
+        entry(true)
+        entry(false)
+    "), @"nil");
+}
+
+#[test]
+fn test_invokebuiltin_dir_glob() {
+    assert_snapshot!(inspect(r#"
+        def test = Dir.glob(".")
+        test
+        test
+    "#), @r#"["."]"#);
+}
+
+#[test]
+fn test_profiled_fact() {
+    assert_snapshot!(inspect("
+        def fact(n)
+          if n == 0
+            return 1
+          end
+          return n * fact(n-1)
+        end
+        fact(1)
+        [fact(0), fact(3), fact(6)]
+    "), @"[1, 6, 720]");
+}
+
+#[test]
+fn test_profiled_fib() {
+    assert_snapshot!(inspect("
+        def fib(n)
+          if n < 2
+            return n
+          end
+          return fib(n-1) + fib(n-2)
+        end
+        fib(3)
+        [fib(0), fib(3), fib(4)]
+    "), @"[0, 2, 3]");
+}
+
+#[test]
+fn test_single_ractor_mode_invalidation() {
+    assert_snapshot!(inspect(r#"
+        C = Object.new
+
+        def test
+          C
+        rescue Ractor::IsolationError
+          "errored but not crashed"
+        end
+
+        test
+        test
+
+        Ractor.new {
+          test
+        }.value
+    "#), @r#""errored but not crashed""#);
+}
+
+#[test]
+fn test_ivar_attr_reader_optimization_with_multi_ractor_mode() {
+    assert_snapshot!(inspect("
+        class Foo
+          class << self
+            attr_accessor :bar
+
+            def get_bar
+              bar
+            rescue Ractor::IsolationError
+              42
+            end
+          end
+        end
+
+        Foo.bar = []
+
+        def test
+          Foo.get_bar
+        end
+
+        test
+        test
+
+        Ractor.new { test }.value
+    "), @"42");
+}
+
+#[test]
+fn test_ivar_get_with_multi_ractor_mode() {
+    assert_snapshot!(inspect("
+        class Foo
+          def self.set_bar
+            @bar = []
+          end
+
+          def self.bar
+            @bar
+          rescue Ractor::IsolationError
+            42
+          end
+        end
+
+        Foo.set_bar
+
+        def test
+          Foo.bar
+        end
+
+        test
+        test
+
+        Ractor.new { test }.value
+    "), @"42");
+}
+
+#[test]
+fn test_ivar_get_with_already_multi_ractor_mode() {
+    assert_snapshot!(inspect("
+        class Foo
+          def self.set_bar
+            @bar = []
+          end
+
+          def self.bar
+            @bar
+          rescue Ractor::IsolationError
+            42
+          end
+        end
+
+        Foo.set_bar
+        r = Ractor.new {
+          Ractor.receive
+          Foo.bar
+        }
+
+        Foo.bar
+        Foo.bar
+
+        r << :go
+        r.value
+    "), @"42");
+}
+
+#[test]
+fn test_ivar_set_with_multi_ractor_mode() {
+    assert_snapshot!(inspect("
+        class Foo
+          def self.bar
+            _foo = 1
+            _bar = 2
+            begin
+              @bar = _foo + _bar
+            rescue Ractor::IsolationError
+              42
+            end
+          end
+        end
+
+        def test
+          Foo.bar
+        end
+
+        test
+        test
+
+        Ractor.new { test }.value
+    "), @"42");
+}
+
+#[test]
+fn test_global_tracepoint() {
+    assert_snapshot!(inspect("
+        def foo = 1
+
+        foo
+        foo
+
+        called = false
+
+        tp = TracePoint.new(:return) { |event|
+          if event.method_id == :foo
+            called = true
+          end
+        }
+        tp.enable do
+          foo
+        end
+        called
+    "), @"true");
+}
+
+#[test]
+fn test_local_tracepoint() {
+    assert_snapshot!(inspect("
+        def foo = 1
+
+        foo
+        foo
+
+        called = false
+
+        tp = TracePoint.new(:return) { |_| called = true }
+        tp.enable(target: method(:foo)) do
+          foo
+        end
+        called
+    "), @"true");
+}

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -585,6 +585,7 @@ pub const BUILTIN_ATTR_LEAF: rb_builtin_attr = 1;
 pub const BUILTIN_ATTR_SINGLE_NOARG_LEAF: rb_builtin_attr = 2;
 pub const BUILTIN_ATTR_INLINE_BLOCK: rb_builtin_attr = 4;
 pub const BUILTIN_ATTR_C_TRACE: rb_builtin_attr = 8;
+pub const BUILTIN_ATTR_WITHOUT_INTERRUPTS: rb_builtin_attr = 16;
 pub type rb_builtin_attr = u32;
 pub type rb_jit_func_t = ::std::option::Option<
     unsafe extern "C" fn(
@@ -1078,6 +1079,39 @@ impl rb_iseq_constant_body_rb_iseq_parameters__bindgen_ty_1 {
         }
     }
     #[inline]
+    pub fn accepts_no_block(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_accepts_no_block(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(14usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn accepts_no_block_raw(this: *const Self) -> ::std::os::raw::c_uint {
+        unsafe {
+            ::std::mem::transmute(<__BindgenBitfieldUnit<[u8; 2usize]>>::raw_get(
+                ::std::ptr::addr_of!((*this)._bitfield_1),
+                14usize,
+                1u8,
+            ) as u32)
+        }
+    }
+    #[inline]
+    pub unsafe fn set_accepts_no_block_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<[u8; 2usize]>>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                14usize,
+                1u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
     pub fn new_bitfield_1(
         has_lead: ::std::os::raw::c_uint,
         has_opt: ::std::os::raw::c_uint,
@@ -1093,6 +1127,7 @@ impl rb_iseq_constant_body_rb_iseq_parameters__bindgen_ty_1 {
         anon_kwrest: ::std::os::raw::c_uint,
         use_block: ::std::os::raw::c_uint,
         forwardable: ::std::os::raw::c_uint,
+        accepts_no_block: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
         let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
@@ -1150,6 +1185,10 @@ impl rb_iseq_constant_body_rb_iseq_parameters__bindgen_ty_1 {
         __bindgen_bitfield_unit.set(13usize, 1u8, {
             let forwardable: u32 = unsafe { ::std::mem::transmute(forwardable) };
             forwardable as u64
+        });
+        __bindgen_bitfield_unit.set(14usize, 1u8, {
+            let accepts_no_block: u32 = unsafe { ::std::mem::transmute(accepts_no_block) };
+            accepts_no_block as u64
         });
         __bindgen_bitfield_unit
     }
@@ -1564,181 +1603,189 @@ pub const YARVINSN_jump: ruby_vminsn_type = 72;
 pub const YARVINSN_branchif: ruby_vminsn_type = 73;
 pub const YARVINSN_branchunless: ruby_vminsn_type = 74;
 pub const YARVINSN_branchnil: ruby_vminsn_type = 75;
-pub const YARVINSN_once: ruby_vminsn_type = 76;
-pub const YARVINSN_opt_case_dispatch: ruby_vminsn_type = 77;
-pub const YARVINSN_opt_plus: ruby_vminsn_type = 78;
-pub const YARVINSN_opt_minus: ruby_vminsn_type = 79;
-pub const YARVINSN_opt_mult: ruby_vminsn_type = 80;
-pub const YARVINSN_opt_div: ruby_vminsn_type = 81;
-pub const YARVINSN_opt_mod: ruby_vminsn_type = 82;
-pub const YARVINSN_opt_eq: ruby_vminsn_type = 83;
-pub const YARVINSN_opt_neq: ruby_vminsn_type = 84;
-pub const YARVINSN_opt_lt: ruby_vminsn_type = 85;
-pub const YARVINSN_opt_le: ruby_vminsn_type = 86;
-pub const YARVINSN_opt_gt: ruby_vminsn_type = 87;
-pub const YARVINSN_opt_ge: ruby_vminsn_type = 88;
-pub const YARVINSN_opt_ltlt: ruby_vminsn_type = 89;
-pub const YARVINSN_opt_and: ruby_vminsn_type = 90;
-pub const YARVINSN_opt_or: ruby_vminsn_type = 91;
-pub const YARVINSN_opt_aref: ruby_vminsn_type = 92;
-pub const YARVINSN_opt_aset: ruby_vminsn_type = 93;
-pub const YARVINSN_opt_length: ruby_vminsn_type = 94;
-pub const YARVINSN_opt_size: ruby_vminsn_type = 95;
-pub const YARVINSN_opt_empty_p: ruby_vminsn_type = 96;
-pub const YARVINSN_opt_succ: ruby_vminsn_type = 97;
-pub const YARVINSN_opt_not: ruby_vminsn_type = 98;
-pub const YARVINSN_opt_regexpmatch2: ruby_vminsn_type = 99;
-pub const YARVINSN_invokebuiltin: ruby_vminsn_type = 100;
-pub const YARVINSN_opt_invokebuiltin_delegate: ruby_vminsn_type = 101;
-pub const YARVINSN_opt_invokebuiltin_delegate_leave: ruby_vminsn_type = 102;
-pub const YARVINSN_getlocal_WC_0: ruby_vminsn_type = 103;
-pub const YARVINSN_getlocal_WC_1: ruby_vminsn_type = 104;
-pub const YARVINSN_setlocal_WC_0: ruby_vminsn_type = 105;
-pub const YARVINSN_setlocal_WC_1: ruby_vminsn_type = 106;
-pub const YARVINSN_putobject_INT2FIX_0_: ruby_vminsn_type = 107;
-pub const YARVINSN_putobject_INT2FIX_1_: ruby_vminsn_type = 108;
-pub const YARVINSN_trace_nop: ruby_vminsn_type = 109;
-pub const YARVINSN_trace_getlocal: ruby_vminsn_type = 110;
-pub const YARVINSN_trace_setlocal: ruby_vminsn_type = 111;
-pub const YARVINSN_trace_getblockparam: ruby_vminsn_type = 112;
-pub const YARVINSN_trace_setblockparam: ruby_vminsn_type = 113;
-pub const YARVINSN_trace_getblockparamproxy: ruby_vminsn_type = 114;
-pub const YARVINSN_trace_getspecial: ruby_vminsn_type = 115;
-pub const YARVINSN_trace_setspecial: ruby_vminsn_type = 116;
-pub const YARVINSN_trace_getinstancevariable: ruby_vminsn_type = 117;
-pub const YARVINSN_trace_setinstancevariable: ruby_vminsn_type = 118;
-pub const YARVINSN_trace_getclassvariable: ruby_vminsn_type = 119;
-pub const YARVINSN_trace_setclassvariable: ruby_vminsn_type = 120;
-pub const YARVINSN_trace_opt_getconstant_path: ruby_vminsn_type = 121;
-pub const YARVINSN_trace_getconstant: ruby_vminsn_type = 122;
-pub const YARVINSN_trace_setconstant: ruby_vminsn_type = 123;
-pub const YARVINSN_trace_getglobal: ruby_vminsn_type = 124;
-pub const YARVINSN_trace_setglobal: ruby_vminsn_type = 125;
-pub const YARVINSN_trace_putnil: ruby_vminsn_type = 126;
-pub const YARVINSN_trace_putself: ruby_vminsn_type = 127;
-pub const YARVINSN_trace_putobject: ruby_vminsn_type = 128;
-pub const YARVINSN_trace_putspecialobject: ruby_vminsn_type = 129;
-pub const YARVINSN_trace_putstring: ruby_vminsn_type = 130;
-pub const YARVINSN_trace_putchilledstring: ruby_vminsn_type = 131;
-pub const YARVINSN_trace_concatstrings: ruby_vminsn_type = 132;
-pub const YARVINSN_trace_anytostring: ruby_vminsn_type = 133;
-pub const YARVINSN_trace_toregexp: ruby_vminsn_type = 134;
-pub const YARVINSN_trace_intern: ruby_vminsn_type = 135;
-pub const YARVINSN_trace_newarray: ruby_vminsn_type = 136;
-pub const YARVINSN_trace_pushtoarraykwsplat: ruby_vminsn_type = 137;
-pub const YARVINSN_trace_duparray: ruby_vminsn_type = 138;
-pub const YARVINSN_trace_duphash: ruby_vminsn_type = 139;
-pub const YARVINSN_trace_expandarray: ruby_vminsn_type = 140;
-pub const YARVINSN_trace_concatarray: ruby_vminsn_type = 141;
-pub const YARVINSN_trace_concattoarray: ruby_vminsn_type = 142;
-pub const YARVINSN_trace_pushtoarray: ruby_vminsn_type = 143;
-pub const YARVINSN_trace_splatarray: ruby_vminsn_type = 144;
-pub const YARVINSN_trace_splatkw: ruby_vminsn_type = 145;
-pub const YARVINSN_trace_newhash: ruby_vminsn_type = 146;
-pub const YARVINSN_trace_newrange: ruby_vminsn_type = 147;
-pub const YARVINSN_trace_pop: ruby_vminsn_type = 148;
-pub const YARVINSN_trace_dup: ruby_vminsn_type = 149;
-pub const YARVINSN_trace_dupn: ruby_vminsn_type = 150;
-pub const YARVINSN_trace_swap: ruby_vminsn_type = 151;
-pub const YARVINSN_trace_opt_reverse: ruby_vminsn_type = 152;
-pub const YARVINSN_trace_topn: ruby_vminsn_type = 153;
-pub const YARVINSN_trace_setn: ruby_vminsn_type = 154;
-pub const YARVINSN_trace_adjuststack: ruby_vminsn_type = 155;
-pub const YARVINSN_trace_defined: ruby_vminsn_type = 156;
-pub const YARVINSN_trace_definedivar: ruby_vminsn_type = 157;
-pub const YARVINSN_trace_checkmatch: ruby_vminsn_type = 158;
-pub const YARVINSN_trace_checkkeyword: ruby_vminsn_type = 159;
-pub const YARVINSN_trace_checktype: ruby_vminsn_type = 160;
-pub const YARVINSN_trace_defineclass: ruby_vminsn_type = 161;
-pub const YARVINSN_trace_definemethod: ruby_vminsn_type = 162;
-pub const YARVINSN_trace_definesmethod: ruby_vminsn_type = 163;
-pub const YARVINSN_trace_send: ruby_vminsn_type = 164;
-pub const YARVINSN_trace_sendforward: ruby_vminsn_type = 165;
-pub const YARVINSN_trace_opt_send_without_block: ruby_vminsn_type = 166;
-pub const YARVINSN_trace_opt_new: ruby_vminsn_type = 167;
-pub const YARVINSN_trace_objtostring: ruby_vminsn_type = 168;
-pub const YARVINSN_trace_opt_ary_freeze: ruby_vminsn_type = 169;
-pub const YARVINSN_trace_opt_hash_freeze: ruby_vminsn_type = 170;
-pub const YARVINSN_trace_opt_str_freeze: ruby_vminsn_type = 171;
-pub const YARVINSN_trace_opt_nil_p: ruby_vminsn_type = 172;
-pub const YARVINSN_trace_opt_str_uminus: ruby_vminsn_type = 173;
-pub const YARVINSN_trace_opt_duparray_send: ruby_vminsn_type = 174;
-pub const YARVINSN_trace_opt_newarray_send: ruby_vminsn_type = 175;
-pub const YARVINSN_trace_invokesuper: ruby_vminsn_type = 176;
-pub const YARVINSN_trace_invokesuperforward: ruby_vminsn_type = 177;
-pub const YARVINSN_trace_invokeblock: ruby_vminsn_type = 178;
-pub const YARVINSN_trace_leave: ruby_vminsn_type = 179;
-pub const YARVINSN_trace_throw: ruby_vminsn_type = 180;
-pub const YARVINSN_trace_jump: ruby_vminsn_type = 181;
-pub const YARVINSN_trace_branchif: ruby_vminsn_type = 182;
-pub const YARVINSN_trace_branchunless: ruby_vminsn_type = 183;
-pub const YARVINSN_trace_branchnil: ruby_vminsn_type = 184;
-pub const YARVINSN_trace_once: ruby_vminsn_type = 185;
-pub const YARVINSN_trace_opt_case_dispatch: ruby_vminsn_type = 186;
-pub const YARVINSN_trace_opt_plus: ruby_vminsn_type = 187;
-pub const YARVINSN_trace_opt_minus: ruby_vminsn_type = 188;
-pub const YARVINSN_trace_opt_mult: ruby_vminsn_type = 189;
-pub const YARVINSN_trace_opt_div: ruby_vminsn_type = 190;
-pub const YARVINSN_trace_opt_mod: ruby_vminsn_type = 191;
-pub const YARVINSN_trace_opt_eq: ruby_vminsn_type = 192;
-pub const YARVINSN_trace_opt_neq: ruby_vminsn_type = 193;
-pub const YARVINSN_trace_opt_lt: ruby_vminsn_type = 194;
-pub const YARVINSN_trace_opt_le: ruby_vminsn_type = 195;
-pub const YARVINSN_trace_opt_gt: ruby_vminsn_type = 196;
-pub const YARVINSN_trace_opt_ge: ruby_vminsn_type = 197;
-pub const YARVINSN_trace_opt_ltlt: ruby_vminsn_type = 198;
-pub const YARVINSN_trace_opt_and: ruby_vminsn_type = 199;
-pub const YARVINSN_trace_opt_or: ruby_vminsn_type = 200;
-pub const YARVINSN_trace_opt_aref: ruby_vminsn_type = 201;
-pub const YARVINSN_trace_opt_aset: ruby_vminsn_type = 202;
-pub const YARVINSN_trace_opt_length: ruby_vminsn_type = 203;
-pub const YARVINSN_trace_opt_size: ruby_vminsn_type = 204;
-pub const YARVINSN_trace_opt_empty_p: ruby_vminsn_type = 205;
-pub const YARVINSN_trace_opt_succ: ruby_vminsn_type = 206;
-pub const YARVINSN_trace_opt_not: ruby_vminsn_type = 207;
-pub const YARVINSN_trace_opt_regexpmatch2: ruby_vminsn_type = 208;
-pub const YARVINSN_trace_invokebuiltin: ruby_vminsn_type = 209;
-pub const YARVINSN_trace_opt_invokebuiltin_delegate: ruby_vminsn_type = 210;
-pub const YARVINSN_trace_opt_invokebuiltin_delegate_leave: ruby_vminsn_type = 211;
-pub const YARVINSN_trace_getlocal_WC_0: ruby_vminsn_type = 212;
-pub const YARVINSN_trace_getlocal_WC_1: ruby_vminsn_type = 213;
-pub const YARVINSN_trace_setlocal_WC_0: ruby_vminsn_type = 214;
-pub const YARVINSN_trace_setlocal_WC_1: ruby_vminsn_type = 215;
-pub const YARVINSN_trace_putobject_INT2FIX_0_: ruby_vminsn_type = 216;
-pub const YARVINSN_trace_putobject_INT2FIX_1_: ruby_vminsn_type = 217;
-pub const YARVINSN_zjit_getblockparamproxy: ruby_vminsn_type = 218;
-pub const YARVINSN_zjit_getinstancevariable: ruby_vminsn_type = 219;
-pub const YARVINSN_zjit_setinstancevariable: ruby_vminsn_type = 220;
-pub const YARVINSN_zjit_definedivar: ruby_vminsn_type = 221;
-pub const YARVINSN_zjit_send: ruby_vminsn_type = 222;
-pub const YARVINSN_zjit_opt_send_without_block: ruby_vminsn_type = 223;
-pub const YARVINSN_zjit_objtostring: ruby_vminsn_type = 224;
-pub const YARVINSN_zjit_opt_nil_p: ruby_vminsn_type = 225;
-pub const YARVINSN_zjit_invokesuper: ruby_vminsn_type = 226;
-pub const YARVINSN_zjit_invokeblock: ruby_vminsn_type = 227;
-pub const YARVINSN_zjit_opt_plus: ruby_vminsn_type = 228;
-pub const YARVINSN_zjit_opt_minus: ruby_vminsn_type = 229;
-pub const YARVINSN_zjit_opt_mult: ruby_vminsn_type = 230;
-pub const YARVINSN_zjit_opt_div: ruby_vminsn_type = 231;
-pub const YARVINSN_zjit_opt_mod: ruby_vminsn_type = 232;
-pub const YARVINSN_zjit_opt_eq: ruby_vminsn_type = 233;
-pub const YARVINSN_zjit_opt_neq: ruby_vminsn_type = 234;
-pub const YARVINSN_zjit_opt_lt: ruby_vminsn_type = 235;
-pub const YARVINSN_zjit_opt_le: ruby_vminsn_type = 236;
-pub const YARVINSN_zjit_opt_gt: ruby_vminsn_type = 237;
-pub const YARVINSN_zjit_opt_ge: ruby_vminsn_type = 238;
-pub const YARVINSN_zjit_opt_ltlt: ruby_vminsn_type = 239;
-pub const YARVINSN_zjit_opt_and: ruby_vminsn_type = 240;
-pub const YARVINSN_zjit_opt_or: ruby_vminsn_type = 241;
-pub const YARVINSN_zjit_opt_aref: ruby_vminsn_type = 242;
-pub const YARVINSN_zjit_opt_aset: ruby_vminsn_type = 243;
-pub const YARVINSN_zjit_opt_length: ruby_vminsn_type = 244;
-pub const YARVINSN_zjit_opt_size: ruby_vminsn_type = 245;
-pub const YARVINSN_zjit_opt_empty_p: ruby_vminsn_type = 246;
-pub const YARVINSN_zjit_opt_succ: ruby_vminsn_type = 247;
-pub const YARVINSN_zjit_opt_not: ruby_vminsn_type = 248;
-pub const YARVINSN_zjit_opt_regexpmatch2: ruby_vminsn_type = 249;
-pub const VM_INSTRUCTION_SIZE: ruby_vminsn_type = 250;
+pub const YARVINSN_jump_without_ints: ruby_vminsn_type = 76;
+pub const YARVINSN_branchif_without_ints: ruby_vminsn_type = 77;
+pub const YARVINSN_branchunless_without_ints: ruby_vminsn_type = 78;
+pub const YARVINSN_branchnil_without_ints: ruby_vminsn_type = 79;
+pub const YARVINSN_once: ruby_vminsn_type = 80;
+pub const YARVINSN_opt_case_dispatch: ruby_vminsn_type = 81;
+pub const YARVINSN_opt_plus: ruby_vminsn_type = 82;
+pub const YARVINSN_opt_minus: ruby_vminsn_type = 83;
+pub const YARVINSN_opt_mult: ruby_vminsn_type = 84;
+pub const YARVINSN_opt_div: ruby_vminsn_type = 85;
+pub const YARVINSN_opt_mod: ruby_vminsn_type = 86;
+pub const YARVINSN_opt_eq: ruby_vminsn_type = 87;
+pub const YARVINSN_opt_neq: ruby_vminsn_type = 88;
+pub const YARVINSN_opt_lt: ruby_vminsn_type = 89;
+pub const YARVINSN_opt_le: ruby_vminsn_type = 90;
+pub const YARVINSN_opt_gt: ruby_vminsn_type = 91;
+pub const YARVINSN_opt_ge: ruby_vminsn_type = 92;
+pub const YARVINSN_opt_ltlt: ruby_vminsn_type = 93;
+pub const YARVINSN_opt_and: ruby_vminsn_type = 94;
+pub const YARVINSN_opt_or: ruby_vminsn_type = 95;
+pub const YARVINSN_opt_aref: ruby_vminsn_type = 96;
+pub const YARVINSN_opt_aset: ruby_vminsn_type = 97;
+pub const YARVINSN_opt_length: ruby_vminsn_type = 98;
+pub const YARVINSN_opt_size: ruby_vminsn_type = 99;
+pub const YARVINSN_opt_empty_p: ruby_vminsn_type = 100;
+pub const YARVINSN_opt_succ: ruby_vminsn_type = 101;
+pub const YARVINSN_opt_not: ruby_vminsn_type = 102;
+pub const YARVINSN_opt_regexpmatch2: ruby_vminsn_type = 103;
+pub const YARVINSN_invokebuiltin: ruby_vminsn_type = 104;
+pub const YARVINSN_opt_invokebuiltin_delegate: ruby_vminsn_type = 105;
+pub const YARVINSN_opt_invokebuiltin_delegate_leave: ruby_vminsn_type = 106;
+pub const YARVINSN_getlocal_WC_0: ruby_vminsn_type = 107;
+pub const YARVINSN_getlocal_WC_1: ruby_vminsn_type = 108;
+pub const YARVINSN_setlocal_WC_0: ruby_vminsn_type = 109;
+pub const YARVINSN_setlocal_WC_1: ruby_vminsn_type = 110;
+pub const YARVINSN_putobject_INT2FIX_0_: ruby_vminsn_type = 111;
+pub const YARVINSN_putobject_INT2FIX_1_: ruby_vminsn_type = 112;
+pub const YARVINSN_trace_nop: ruby_vminsn_type = 113;
+pub const YARVINSN_trace_getlocal: ruby_vminsn_type = 114;
+pub const YARVINSN_trace_setlocal: ruby_vminsn_type = 115;
+pub const YARVINSN_trace_getblockparam: ruby_vminsn_type = 116;
+pub const YARVINSN_trace_setblockparam: ruby_vminsn_type = 117;
+pub const YARVINSN_trace_getblockparamproxy: ruby_vminsn_type = 118;
+pub const YARVINSN_trace_getspecial: ruby_vminsn_type = 119;
+pub const YARVINSN_trace_setspecial: ruby_vminsn_type = 120;
+pub const YARVINSN_trace_getinstancevariable: ruby_vminsn_type = 121;
+pub const YARVINSN_trace_setinstancevariable: ruby_vminsn_type = 122;
+pub const YARVINSN_trace_getclassvariable: ruby_vminsn_type = 123;
+pub const YARVINSN_trace_setclassvariable: ruby_vminsn_type = 124;
+pub const YARVINSN_trace_opt_getconstant_path: ruby_vminsn_type = 125;
+pub const YARVINSN_trace_getconstant: ruby_vminsn_type = 126;
+pub const YARVINSN_trace_setconstant: ruby_vminsn_type = 127;
+pub const YARVINSN_trace_getglobal: ruby_vminsn_type = 128;
+pub const YARVINSN_trace_setglobal: ruby_vminsn_type = 129;
+pub const YARVINSN_trace_putnil: ruby_vminsn_type = 130;
+pub const YARVINSN_trace_putself: ruby_vminsn_type = 131;
+pub const YARVINSN_trace_putobject: ruby_vminsn_type = 132;
+pub const YARVINSN_trace_putspecialobject: ruby_vminsn_type = 133;
+pub const YARVINSN_trace_putstring: ruby_vminsn_type = 134;
+pub const YARVINSN_trace_putchilledstring: ruby_vminsn_type = 135;
+pub const YARVINSN_trace_concatstrings: ruby_vminsn_type = 136;
+pub const YARVINSN_trace_anytostring: ruby_vminsn_type = 137;
+pub const YARVINSN_trace_toregexp: ruby_vminsn_type = 138;
+pub const YARVINSN_trace_intern: ruby_vminsn_type = 139;
+pub const YARVINSN_trace_newarray: ruby_vminsn_type = 140;
+pub const YARVINSN_trace_pushtoarraykwsplat: ruby_vminsn_type = 141;
+pub const YARVINSN_trace_duparray: ruby_vminsn_type = 142;
+pub const YARVINSN_trace_duphash: ruby_vminsn_type = 143;
+pub const YARVINSN_trace_expandarray: ruby_vminsn_type = 144;
+pub const YARVINSN_trace_concatarray: ruby_vminsn_type = 145;
+pub const YARVINSN_trace_concattoarray: ruby_vminsn_type = 146;
+pub const YARVINSN_trace_pushtoarray: ruby_vminsn_type = 147;
+pub const YARVINSN_trace_splatarray: ruby_vminsn_type = 148;
+pub const YARVINSN_trace_splatkw: ruby_vminsn_type = 149;
+pub const YARVINSN_trace_newhash: ruby_vminsn_type = 150;
+pub const YARVINSN_trace_newrange: ruby_vminsn_type = 151;
+pub const YARVINSN_trace_pop: ruby_vminsn_type = 152;
+pub const YARVINSN_trace_dup: ruby_vminsn_type = 153;
+pub const YARVINSN_trace_dupn: ruby_vminsn_type = 154;
+pub const YARVINSN_trace_swap: ruby_vminsn_type = 155;
+pub const YARVINSN_trace_opt_reverse: ruby_vminsn_type = 156;
+pub const YARVINSN_trace_topn: ruby_vminsn_type = 157;
+pub const YARVINSN_trace_setn: ruby_vminsn_type = 158;
+pub const YARVINSN_trace_adjuststack: ruby_vminsn_type = 159;
+pub const YARVINSN_trace_defined: ruby_vminsn_type = 160;
+pub const YARVINSN_trace_definedivar: ruby_vminsn_type = 161;
+pub const YARVINSN_trace_checkmatch: ruby_vminsn_type = 162;
+pub const YARVINSN_trace_checkkeyword: ruby_vminsn_type = 163;
+pub const YARVINSN_trace_checktype: ruby_vminsn_type = 164;
+pub const YARVINSN_trace_defineclass: ruby_vminsn_type = 165;
+pub const YARVINSN_trace_definemethod: ruby_vminsn_type = 166;
+pub const YARVINSN_trace_definesmethod: ruby_vminsn_type = 167;
+pub const YARVINSN_trace_send: ruby_vminsn_type = 168;
+pub const YARVINSN_trace_sendforward: ruby_vminsn_type = 169;
+pub const YARVINSN_trace_opt_send_without_block: ruby_vminsn_type = 170;
+pub const YARVINSN_trace_opt_new: ruby_vminsn_type = 171;
+pub const YARVINSN_trace_objtostring: ruby_vminsn_type = 172;
+pub const YARVINSN_trace_opt_ary_freeze: ruby_vminsn_type = 173;
+pub const YARVINSN_trace_opt_hash_freeze: ruby_vminsn_type = 174;
+pub const YARVINSN_trace_opt_str_freeze: ruby_vminsn_type = 175;
+pub const YARVINSN_trace_opt_nil_p: ruby_vminsn_type = 176;
+pub const YARVINSN_trace_opt_str_uminus: ruby_vminsn_type = 177;
+pub const YARVINSN_trace_opt_duparray_send: ruby_vminsn_type = 178;
+pub const YARVINSN_trace_opt_newarray_send: ruby_vminsn_type = 179;
+pub const YARVINSN_trace_invokesuper: ruby_vminsn_type = 180;
+pub const YARVINSN_trace_invokesuperforward: ruby_vminsn_type = 181;
+pub const YARVINSN_trace_invokeblock: ruby_vminsn_type = 182;
+pub const YARVINSN_trace_leave: ruby_vminsn_type = 183;
+pub const YARVINSN_trace_throw: ruby_vminsn_type = 184;
+pub const YARVINSN_trace_jump: ruby_vminsn_type = 185;
+pub const YARVINSN_trace_branchif: ruby_vminsn_type = 186;
+pub const YARVINSN_trace_branchunless: ruby_vminsn_type = 187;
+pub const YARVINSN_trace_branchnil: ruby_vminsn_type = 188;
+pub const YARVINSN_trace_jump_without_ints: ruby_vminsn_type = 189;
+pub const YARVINSN_trace_branchif_without_ints: ruby_vminsn_type = 190;
+pub const YARVINSN_trace_branchunless_without_ints: ruby_vminsn_type = 191;
+pub const YARVINSN_trace_branchnil_without_ints: ruby_vminsn_type = 192;
+pub const YARVINSN_trace_once: ruby_vminsn_type = 193;
+pub const YARVINSN_trace_opt_case_dispatch: ruby_vminsn_type = 194;
+pub const YARVINSN_trace_opt_plus: ruby_vminsn_type = 195;
+pub const YARVINSN_trace_opt_minus: ruby_vminsn_type = 196;
+pub const YARVINSN_trace_opt_mult: ruby_vminsn_type = 197;
+pub const YARVINSN_trace_opt_div: ruby_vminsn_type = 198;
+pub const YARVINSN_trace_opt_mod: ruby_vminsn_type = 199;
+pub const YARVINSN_trace_opt_eq: ruby_vminsn_type = 200;
+pub const YARVINSN_trace_opt_neq: ruby_vminsn_type = 201;
+pub const YARVINSN_trace_opt_lt: ruby_vminsn_type = 202;
+pub const YARVINSN_trace_opt_le: ruby_vminsn_type = 203;
+pub const YARVINSN_trace_opt_gt: ruby_vminsn_type = 204;
+pub const YARVINSN_trace_opt_ge: ruby_vminsn_type = 205;
+pub const YARVINSN_trace_opt_ltlt: ruby_vminsn_type = 206;
+pub const YARVINSN_trace_opt_and: ruby_vminsn_type = 207;
+pub const YARVINSN_trace_opt_or: ruby_vminsn_type = 208;
+pub const YARVINSN_trace_opt_aref: ruby_vminsn_type = 209;
+pub const YARVINSN_trace_opt_aset: ruby_vminsn_type = 210;
+pub const YARVINSN_trace_opt_length: ruby_vminsn_type = 211;
+pub const YARVINSN_trace_opt_size: ruby_vminsn_type = 212;
+pub const YARVINSN_trace_opt_empty_p: ruby_vminsn_type = 213;
+pub const YARVINSN_trace_opt_succ: ruby_vminsn_type = 214;
+pub const YARVINSN_trace_opt_not: ruby_vminsn_type = 215;
+pub const YARVINSN_trace_opt_regexpmatch2: ruby_vminsn_type = 216;
+pub const YARVINSN_trace_invokebuiltin: ruby_vminsn_type = 217;
+pub const YARVINSN_trace_opt_invokebuiltin_delegate: ruby_vminsn_type = 218;
+pub const YARVINSN_trace_opt_invokebuiltin_delegate_leave: ruby_vminsn_type = 219;
+pub const YARVINSN_trace_getlocal_WC_0: ruby_vminsn_type = 220;
+pub const YARVINSN_trace_getlocal_WC_1: ruby_vminsn_type = 221;
+pub const YARVINSN_trace_setlocal_WC_0: ruby_vminsn_type = 222;
+pub const YARVINSN_trace_setlocal_WC_1: ruby_vminsn_type = 223;
+pub const YARVINSN_trace_putobject_INT2FIX_0_: ruby_vminsn_type = 224;
+pub const YARVINSN_trace_putobject_INT2FIX_1_: ruby_vminsn_type = 225;
+pub const YARVINSN_zjit_getblockparamproxy: ruby_vminsn_type = 226;
+pub const YARVINSN_zjit_getinstancevariable: ruby_vminsn_type = 227;
+pub const YARVINSN_zjit_setinstancevariable: ruby_vminsn_type = 228;
+pub const YARVINSN_zjit_definedivar: ruby_vminsn_type = 229;
+pub const YARVINSN_zjit_send: ruby_vminsn_type = 230;
+pub const YARVINSN_zjit_opt_send_without_block: ruby_vminsn_type = 231;
+pub const YARVINSN_zjit_objtostring: ruby_vminsn_type = 232;
+pub const YARVINSN_zjit_opt_nil_p: ruby_vminsn_type = 233;
+pub const YARVINSN_zjit_invokesuper: ruby_vminsn_type = 234;
+pub const YARVINSN_zjit_invokeblock: ruby_vminsn_type = 235;
+pub const YARVINSN_zjit_opt_plus: ruby_vminsn_type = 236;
+pub const YARVINSN_zjit_opt_minus: ruby_vminsn_type = 237;
+pub const YARVINSN_zjit_opt_mult: ruby_vminsn_type = 238;
+pub const YARVINSN_zjit_opt_div: ruby_vminsn_type = 239;
+pub const YARVINSN_zjit_opt_mod: ruby_vminsn_type = 240;
+pub const YARVINSN_zjit_opt_eq: ruby_vminsn_type = 241;
+pub const YARVINSN_zjit_opt_neq: ruby_vminsn_type = 242;
+pub const YARVINSN_zjit_opt_lt: ruby_vminsn_type = 243;
+pub const YARVINSN_zjit_opt_le: ruby_vminsn_type = 244;
+pub const YARVINSN_zjit_opt_gt: ruby_vminsn_type = 245;
+pub const YARVINSN_zjit_opt_ge: ruby_vminsn_type = 246;
+pub const YARVINSN_zjit_opt_ltlt: ruby_vminsn_type = 247;
+pub const YARVINSN_zjit_opt_and: ruby_vminsn_type = 248;
+pub const YARVINSN_zjit_opt_or: ruby_vminsn_type = 249;
+pub const YARVINSN_zjit_opt_aref: ruby_vminsn_type = 250;
+pub const YARVINSN_zjit_opt_aset: ruby_vminsn_type = 251;
+pub const YARVINSN_zjit_opt_length: ruby_vminsn_type = 252;
+pub const YARVINSN_zjit_opt_size: ruby_vminsn_type = 253;
+pub const YARVINSN_zjit_opt_empty_p: ruby_vminsn_type = 254;
+pub const YARVINSN_zjit_opt_succ: ruby_vminsn_type = 255;
+pub const YARVINSN_zjit_opt_not: ruby_vminsn_type = 256;
+pub const YARVINSN_zjit_opt_regexpmatch2: ruby_vminsn_type = 257;
+pub const VM_INSTRUCTION_SIZE: ruby_vminsn_type = 258;
 pub type ruby_vminsn_type = u32;
 pub type rb_iseq_callback = ::std::option::Option<
     unsafe extern "C" fn(arg1: *const rb_iseq_t, arg2: *mut ::std::os::raw::c_void),
@@ -1951,6 +1998,7 @@ unsafe extern "C" {
     pub fn rb_ivar_set(obj: VALUE, name: ID, val: VALUE) -> VALUE;
     pub fn rb_ivar_defined(obj: VALUE, name: ID) -> VALUE;
     pub fn rb_attr_get(obj: VALUE, name: ID) -> VALUE;
+    pub fn rb_const_get(space: VALUE, name: ID) -> VALUE;
     pub fn rb_class_allocate_instance(klass: VALUE) -> VALUE;
     pub fn rb_obj_equal(obj1: VALUE, obj2: VALUE) -> VALUE;
     pub fn rb_reg_new_ary(ary: VALUE, options: ::std::os::raw::c_int) -> VALUE;
@@ -1973,6 +2021,7 @@ unsafe extern "C" {
         id: ID,
     ) -> *const rb_callable_method_entry_t;
     pub static mut rb_cISeq: VALUE;
+    pub static mut rb_cRubyVM: VALUE;
     pub static mut rb_mRubyVMFrozenCore: VALUE;
     pub static mut rb_block_param_proxy: VALUE;
     pub fn rb_vm_ep_local_ep(ep: *const VALUE) -> *const VALUE;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -19,7 +19,7 @@ use crate::profile::{TypeDistributionSummary, ProfiledType};
 use crate::stats::Counter;
 use SendFallbackReason::*;
 
-mod tests;
+pub(crate) mod tests;
 mod opt_tests;
 
 /// An index of an [`Insn`] in a [`Function`]. This is a popular
@@ -656,6 +656,9 @@ pub enum SendFallbackReason {
     SingletonClassSeen,
     /// The super call is passed a block that the optimizer does not support.
     SuperCallWithBlock,
+    /// When the `super` is in a block, finding the running CME for guarding requires a loop. Not
+    /// supported for now.
+    SuperFromBlock,
     /// The profiled super class cannot be found.
     SuperClassNotFound,
     /// The `super` call uses a complex argument pattern that the optimizer does not support.
@@ -708,6 +711,7 @@ impl Display for SendFallbackReason {
             ComplexArgPass => write!(f, "Complex argument passing"),
             UnexpectedKeywordArgs => write!(f, "Unexpected Keyword Args"),
             SingletonClassSeen => write!(f, "Singleton class previously created for receiver class"),
+            SuperFromBlock => write!(f, "super: call from within a block"),
             SuperCallWithBlock => write!(f, "super: call made with a block"),
             SuperClassNotFound => write!(f, "super: profiled class cannot be found"),
             SuperComplexArgsPass => write!(f, "super: complex argument passing to `super` call"),
@@ -804,6 +808,7 @@ pub enum Insn {
     FixnumAref { recv: InsnId, index: InsnId },
     // TODO(max): In iseq body types that are not ISEQ_TYPE_METHOD, rewrite to Constant false.
     Defined { op_type: usize, obj: VALUE, pushval: VALUE, v: InsnId, state: InsnId },
+    GetConstant { klass: InsnId, id: ID, allow_nil: InsnId, state: InsnId },
     GetConstantPath { ic: *const iseq_inline_constant_cache, state: InsnId },
     /// Kernel#block_given? but without pushing a frame. Similar to [`Insn::Defined`] with
     /// `DEFINED_YIELD`
@@ -884,7 +889,7 @@ pub enum Insn {
 
     /// Call a C function that pushes a frame
     CCallWithFrame {
-        cd: *const rb_call_data, // cd for falling back to SendWithoutBlock
+        cd: *const rb_call_data, // cd for falling back to Send
         cfunc: *const u8,
         recv: InsnId,
         args: Vec<InsnId>,
@@ -912,17 +917,10 @@ pub enum Insn {
 
     /// Un-optimized fallback implementation (dynamic dispatch) for send-ish instructions
     /// Ignoring keyword arguments etc for now
-    SendWithoutBlock {
-        recv: InsnId,
-        cd: *const rb_call_data,
-        args: Vec<InsnId>,
-        state: InsnId,
-        reason: SendFallbackReason,
-    },
     Send {
         recv: InsnId,
         cd: *const rb_call_data,
-        blockiseq: IseqPtr,
+        blockiseq: Option<IseqPtr>,
         args: Vec<InsnId>,
         state: InsnId,
         reason: SendFallbackReason,
@@ -1012,7 +1010,7 @@ pub enum Insn {
     FixnumLShift { left: InsnId, right: InsnId, state: InsnId },
     FixnumRShift { left: InsnId, right: InsnId },
 
-    // Distinct from `SendWithoutBlock` with `mid:to_s` because does not have a patch point for String to_s being redefined
+    // Distinct from `Send` with `mid:to_s` because does not have a patch point for String to_s being redefined
     ObjToString { val: InsnId, cd: *const rb_call_data, state: InsnId },
     AnyToString { val: InsnId, str: InsnId, state: InsnId },
 
@@ -1028,11 +1026,11 @@ pub enum Insn {
     /// Side-exit if val is not the expected Const.
     GuardBitEquals { val: InsnId, expected: Const, reason: SideExitReason, state: InsnId },
     /// Side-exit if (val & mask) == 0
-    GuardAnyBitSet { val: InsnId, mask: Const, reason: SideExitReason, state: InsnId },
+    GuardAnyBitSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId },
     /// Side-exit if (val & mask) != 0
-    GuardNoBitsSet { val: InsnId, mask: Const, reason: SideExitReason, state: InsnId },
+    GuardNoBitsSet { val: InsnId, mask: Const, mask_name: Option<ID>, reason: SideExitReason, state: InsnId },
     /// Side-exit if left is not greater than or equal to right (both operands are C long).
-    GuardGreaterEq { left: InsnId, right: InsnId, state: InsnId },
+    GuardGreaterEq { left: InsnId, right: InsnId, reason: SideExitReason, state: InsnId },
     /// Side-exit if left is not less than right (both operands are C long).
     GuardLess { left: InsnId, right: InsnId, state: InsnId },
 
@@ -1140,6 +1138,7 @@ impl Insn {
             Insn::UnboxFixnum { .. } => effects::Any,
             Insn::FixnumAref { .. } => effects::Empty,
             Insn::Defined { .. } => effects::Any,
+            Insn::GetConstant { .. } => effects::Any,
             Insn::GetConstantPath { .. } => effects::Any,
             Insn::IsBlockGiven { .. } => Effect::read_write(abstract_heaps::Other, abstract_heaps::Empty),
             Insn::FixnumBitCheck { .. } => effects::Any,
@@ -1186,7 +1185,6 @@ impl Insn {
                 }
             },
             Insn::CCallVariadic { .. } => effects::Any,
-            Insn::SendWithoutBlock { .. } => effects::Any,
             Insn::Send { .. } => effects::Any,
             Insn::SendForward { .. } => effects::Any,
             Insn::InvokeSuper { .. } => effects::Any,
@@ -1448,14 +1446,6 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::Jump(target) => { write!(f, "Jump {target}") }
             Insn::IfTrue { val, target } => { write!(f, "IfTrue {val}, {target}") }
             Insn::IfFalse { val, target } => { write!(f, "IfFalse {val}, {target}") }
-            Insn::SendWithoutBlock { recv, cd, args, reason, .. } => {
-                write!(f, "SendWithoutBlock {recv}, :{}", ruby_call_method_name(*cd))?;
-                for arg in args {
-                    write!(f, ", {arg}")?;
-                }
-                write!(f, " # SendFallbackReason: {reason}")?;
-                Ok(())
-            }
             Insn::SendDirect { recv, cd, iseq, args, blockiseq, .. } => {
                 write!(f, "SendDirect {recv}, {:p}, :{} ({:?})", self.ptr_map.map_ptr(blockiseq), ruby_call_method_name(*cd), self.ptr_map.map_ptr(iseq))?;
                 for arg in args {
@@ -1467,7 +1457,11 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 // For tests, we want to check HIR snippets textually. Addresses change
                 // between runs, making tests fail. Instead, pick an arbitrary hex value to
                 // use as a "pointer" so we can check the rest of the HIR.
-                write!(f, "Send {recv}, {:p}, :{}", self.ptr_map.map_ptr(blockiseq), ruby_call_method_name(*cd))?;
+                if let Some(blockiseq) = *blockiseq {
+                    write!(f, "Send {recv}, {:p}, :{}", self.ptr_map.map_ptr(blockiseq), ruby_call_method_name(*cd))?;
+                } else {
+                    write!(f, "Send {recv}, :{}", ruby_call_method_name(*cd))?;
+                }
                 for arg in args {
                     write!(f, ", {arg}")?;
                 }
@@ -1551,7 +1545,9 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::HasType { val, expected, .. } => { write!(f, "HasType {val}, {}", expected.print(self.ptr_map)) },
             Insn::GuardTypeNot { val, guard_type, .. } => { write!(f, "GuardTypeNot {val}, {}", guard_type.print(self.ptr_map)) },
             Insn::GuardBitEquals { val, expected, .. } => { write!(f, "GuardBitEquals {val}, {}", expected.print(self.ptr_map)) },
+            Insn::GuardAnyBitSet { val, mask, mask_name: Some(name), .. } => { write!(f, "GuardAnyBitSet {val}, {name}={}", mask.print(self.ptr_map)) },
             Insn::GuardAnyBitSet { val, mask, .. } => { write!(f, "GuardAnyBitSet {val}, {}", mask.print(self.ptr_map)) },
+            Insn::GuardNoBitsSet { val, mask, mask_name: Some(name), .. } => { write!(f, "GuardNoBitsSet {val}, {name}={}", mask.print(self.ptr_map)) },
             Insn::GuardNoBitsSet { val, mask, .. } => { write!(f, "GuardNoBitsSet {val}, {}", mask.print(self.ptr_map)) },
             Insn::GuardLess { left, right, .. } => write!(f, "GuardLess {left}, {right}"),
             Insn::GuardGreaterEq { left, right, .. } => write!(f, "GuardGreaterEq {left}, {right}"),
@@ -1561,6 +1557,9 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 write!(f, "GetBlockParam {name}l{level}, EP@{ep_offset}")
             },
             Insn::PatchPoint { invariant, .. } => { write!(f, "PatchPoint {}", invariant.print(self.ptr_map)) },
+            Insn::GetConstant { klass, id, allow_nil, .. } => {
+                write!(f, "GetConstant {klass}, :{}, {allow_nil}", id.contents_lossy())
+            }
             Insn::GetConstantPath { ic, .. } => { write!(f, "GetConstantPath {:p}", self.ptr_map.map_ptr(ic)) },
             Insn::IsBlockGiven { lep } => { write!(f, "IsBlockGiven {lep}") },
             Insn::FixnumBitCheck {val, index} => { write!(f, "FixnumBitCheck {val}, {index}") },
@@ -2237,9 +2236,9 @@ impl Function {
             &GuardType { val, guard_type, state } => GuardType { val: find!(val), guard_type, state },
             &GuardTypeNot { val, guard_type, state } => GuardTypeNot { val: find!(val), guard_type, state },
             &GuardBitEquals { val, expected, reason, state } => GuardBitEquals { val: find!(val), expected, reason, state },
-            &GuardAnyBitSet { val, mask, reason, state } => GuardAnyBitSet { val: find!(val), mask, reason, state },
-            &GuardNoBitsSet { val, mask, reason, state } => GuardNoBitsSet { val: find!(val), mask, reason, state },
-            &GuardGreaterEq { left, right, state } => GuardGreaterEq { left: find!(left), right: find!(right), state },
+            &GuardAnyBitSet { val, mask, mask_name, reason, state } => GuardAnyBitSet { val: find!(val), mask, mask_name, reason, state },
+            &GuardNoBitsSet { val, mask, mask_name, reason, state } => GuardNoBitsSet { val: find!(val), mask, mask_name, reason, state },
+            &GuardGreaterEq { left, right, reason, state } => GuardGreaterEq { left: find!(left), right: find!(right), reason, state },
             &GuardLess { left, right, state } => GuardLess { left: find!(left), right: find!(right), state },
             &IsBlockGiven { lep } => IsBlockGiven { lep: find!(lep) },
             &GetBlockParam { level, ep_offset, state } => GetBlockParam { level, ep_offset, state: find!(state) },
@@ -2268,13 +2267,6 @@ impl Function {
                 val: find!(val),
                 str: find!(str),
                 state,
-            },
-            &SendWithoutBlock { recv, cd, ref args, state, reason } => SendWithoutBlock {
-                recv: find!(recv),
-                cd,
-                args: find_vec!(args),
-                state,
-                reason,
             },
             &SendDirect { recv, cd, cme, iseq, ref args, kw_bits, blockiseq, state } => SendDirect {
                 recv: find!(recv),
@@ -2355,6 +2347,7 @@ impl Function {
             },
             &Defined { op_type, obj, pushval, v, state } => Defined { op_type, obj, pushval, v: find!(v), state: find!(state) },
             &DefinedIvar { self_val, pushval, id, state } => DefinedIvar { self_val: find!(self_val), pushval, id, state },
+            &GetConstant { klass, id, allow_nil, state } => GetConstant { klass: find!(klass), id, allow_nil: find!(allow_nil), state },
             &NewArray { ref elements, state } => NewArray { elements: find_vec!(elements), state: find!(state) },
             &NewHash { ref elements, state } => NewHash { elements: find_vec!(elements), state: find!(state) },
             &NewRange { low, high, flag, state } => NewRange { low: find!(low), high: find!(high), flag, state: find!(state) },
@@ -2395,7 +2388,6 @@ impl Function {
             match self.insns.get_mut(insn_id.0).unwrap() {
                 Send { reason, .. }
                 | SendForward { reason, .. }
-                | SendWithoutBlock { reason, .. }
                 | InvokeSuper { reason, .. }
                 | InvokeSuperForward { reason, .. }
                 | InvokeBlock { reason, .. }
@@ -2515,7 +2507,6 @@ impl Function {
             Insn::FixnumLShift { .. } => types::Fixnum,
             Insn::FixnumRShift { .. } => types::Fixnum,
             Insn::PutSpecialObject { .. } => types::BasicObject,
-            Insn::SendWithoutBlock { .. } => types::BasicObject,
             Insn::SendDirect { .. } => types::BasicObject,
             Insn::Send { .. } => types::BasicObject,
             Insn::SendForward { .. } => types::BasicObject,
@@ -2526,6 +2517,7 @@ impl Function {
             Insn::InvokeBuiltin { return_type, .. } => return_type.unwrap_or(types::BasicObject),
             Insn::Defined { pushval, .. } => Type::from_value(*pushval).union(types::NilClass),
             Insn::DefinedIvar { pushval, .. } => Type::from_value(*pushval).union(types::NilClass),
+            Insn::GetConstant { .. } => types::BasicObject,
             Insn::GetConstantPath { .. } => types::BasicObject,
             Insn::IsBlockGiven { .. } => types::BoolExact,
             Insn::FixnumBitCheck { .. } => types::BoolExact,
@@ -2602,59 +2594,72 @@ impl Function {
         self.copy_param_types();
 
         let mut reachable = BlockSet::with_capacity(self.blocks.len());
-        for entry_block in self.entry_blocks() {
-            reachable.insert(entry_block);
+
+        // Maintain both a worklist and a fast membership check to avoid linear search
+        let mut worklist: VecDeque<BlockId> = VecDeque::with_capacity(self.blocks.len());
+        let mut in_worklist = BlockSet::with_capacity(self.blocks.len());
+        macro_rules! worklist_add {
+            ($block:expr) => {
+                if in_worklist.insert($block) {
+                    worklist.push_back($block);
+                }
+            };
         }
 
-        // Walk the graph, computing types until fixpoint
-        let rpo = self.rpo();
-        loop {
-            let mut changed = false;
-            for &block in &rpo {
-                if !reachable.get(block) { continue; }
-                for insn_id in &self.blocks[block.0].insns {
-                    let insn_type = match self.find(*insn_id) {
-                        Insn::IfTrue { val, target: BranchEdge { target, args } } => {
-                            assert!(!self.type_of(val).bit_equal(types::Empty));
-                            if self.type_of(val).could_be(Type::from_cbool(true)) {
-                                reachable.insert(target);
-                                for (idx, arg) in args.iter().enumerate() {
-                                    let param = self.blocks[target.0].params[idx];
-                                    self.insn_types[param.0] = self.type_of(param).union(self.type_of(*arg));
-                                }
-                            }
-                            continue;
-                        }
-                        Insn::IfFalse { val, target: BranchEdge { target, args } } => {
-                            assert!(!self.type_of(val).bit_equal(types::Empty));
-                            if self.type_of(val).could_be(Type::from_cbool(false)) {
-                                reachable.insert(target);
-                                for (idx, arg) in args.iter().enumerate() {
-                                    let param = self.blocks[target.0].params[idx];
-                                    self.insn_types[param.0] = self.type_of(param).union(self.type_of(*arg));
-                                }
-                            }
-                            continue;
-                        }
-                        Insn::Jump(BranchEdge { target, args }) => {
-                            reachable.insert(target);
-                            for (idx, arg) in args.iter().enumerate() {
-                                let param = self.blocks[target.0].params[idx];
-                                self.insn_types[param.0] = self.type_of(param).union(self.type_of(*arg));
-                            }
-                            continue;
-                        }
-                        insn if insn.has_output() => self.infer_type(*insn_id),
-                        _ => continue,
-                    };
-                    if !self.type_of(*insn_id).bit_equal(insn_type) {
-                        self.insn_types[insn_id.0] = insn_type;
-                        changed = true;
+        for entry_block in self.entry_blocks() {
+            reachable.insert(entry_block);
+            worklist_add!(entry_block);
+        }
+
+        // Helper to propagate types along a branch edge and enqueue the target if anything changed
+        macro_rules! enqueue {
+            ($self:ident, $target:expr) => {
+                let newly_reachable = reachable.insert($target.target);
+                let mut target_changed = newly_reachable;
+                for (idx, arg) in $target.args.iter().enumerate() {
+                    let param = $self.blocks[$target.target.0].params[idx];
+                    let new = self.insn_types[param.0].union(self.insn_types[arg.0]);
+                    if !self.insn_types[param.0].bit_equal(new) {
+                        self.insn_types[param.0] = new;
+                        target_changed = true;
                     }
                 }
-            }
-            if !changed {
-                break;
+                if target_changed {
+                    worklist_add!($target.target);
+                }
+            };
+        }
+
+        // Walk the graph, computing types until worklist is empty
+        while let Some(block) = worklist.pop_front() {
+            in_worklist.remove(block);
+            if !reachable.get(block) { continue; }
+            for insn_id in &self.blocks[block.0].insns {
+                let insn_type = match self.find(*insn_id) {
+                    Insn::IfTrue { val, target } => {
+                        assert!(!self.type_of(val).bit_equal(types::Empty));
+                        if self.type_of(val).could_be(Type::from_cbool(true)) {
+                            enqueue!(self, target);
+                        }
+                        continue;
+                    }
+                    Insn::IfFalse { val, target } => {
+                        assert!(!self.type_of(val).bit_equal(types::Empty));
+                        if self.type_of(val).could_be(Type::from_cbool(false)) {
+                            enqueue!(self, target);
+                        }
+                        continue;
+                    }
+                    Insn::Jump(target) => {
+                        enqueue!(self, target);
+                        continue;
+                    }
+                    insn if insn.has_output() => self.infer_type(*insn_id),
+                    _ => continue,
+                };
+                if !self.type_of(*insn_id).bit_equal(insn_type) {
+                    self.insn_types[insn_id.0] = insn_type;
+                }
             }
         }
     }
@@ -3005,15 +3010,15 @@ impl Function {
 
     pub fn guard_not_frozen(&mut self, block: BlockId, recv: InsnId, state: InsnId) {
         let flags = self.load_rbasic_flags(block, recv);
-        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_FL_FREEZE as u64), reason: SideExitReason::GuardNotFrozen, state });
+        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_FL_FREEZE as u64), mask_name: Some(ID!(RUBY_FL_FREEZE)), reason: SideExitReason::GuardNotFrozen, state });
     }
 
     pub fn guard_not_shared(&mut self, block: BlockId, recv: InsnId, state: InsnId) {
         let flags = self.load_rbasic_flags(block, recv);
-        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_ELTS_SHARED as u64), reason: SideExitReason::GuardNotShared, state });
+        self.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(RUBY_ELTS_SHARED as u64), mask_name: Some(ID!(RUBY_ELTS_SHARED)), reason: SideExitReason::GuardNotShared, state });
     }
 
-    /// Rewrite eligible Send/SendWithoutBlock opcodes into SendDirect
+    /// Rewrite eligible Send opcodes into SendDirect
     /// opcodes if we know the target ISEQ statically. This removes run-time method lookups and
     /// opens the door for inlining.
     /// Also try and inline constant caches, specialize object allocations, and more.
@@ -3024,11 +3029,12 @@ impl Function {
             assert!(self.blocks[block.0].insns.is_empty());
             for insn_id in old_insns {
                 match self.find(insn_id) {
-                    Insn::SendWithoutBlock { recv, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(freeze) && args.is_empty() =>
+                    Insn::Send { recv, blockiseq: None, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(freeze) && args.is_empty() =>
                         self.try_rewrite_freeze(block, insn_id, recv, state),
-                    Insn::SendWithoutBlock { recv, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(minusat) && args.is_empty() =>
+                    Insn::Send { recv, blockiseq: None, args, state, cd, .. } if ruby_call_method_id(cd) == ID!(minusat) && args.is_empty() =>
                         self.try_rewrite_uminus(block, insn_id, recv, state),
-                    Insn::SendWithoutBlock { mut recv, cd, args, state, .. } => {
+                    Insn::Send { mut recv, cd, state, blockiseq, args, .. } => {
+                        let has_block = blockiseq.is_some();
                         let frame_state = self.frame_state(state);
                         let (klass, profiled_type) = match self.resolve_receiver_type(recv, self.type_of(recv), frame_state.insn_idx) {
                             ReceiverTypeResolution::StaticallyKnown { class } => (class, None),
@@ -3037,21 +3043,24 @@ impl Function {
                             ReceiverTypeResolution::SkewedMegamorphic { .. }
                             | ReceiverTypeResolution::Megamorphic => {
                                 if get_option!(stats) {
-                                    self.set_dynamic_send_reason(insn_id, SendWithoutBlockMegamorphic);
+                                    let reason = if has_block { SendMegamorphic } else { SendWithoutBlockMegamorphic };
+                                    self.set_dynamic_send_reason(insn_id, reason);
                                 }
                                 self.push_insn_id(block, insn_id);
                                 continue;
                             }
                             ReceiverTypeResolution::Polymorphic => {
                                 if get_option!(stats) {
-                                    self.set_dynamic_send_reason(insn_id, SendWithoutBlockPolymorphic);
+                                    let reason = if has_block { SendPolymorphic } else { SendWithoutBlockPolymorphic };
+                                    self.set_dynamic_send_reason(insn_id, reason);
                                 }
                                 self.push_insn_id(block, insn_id);
                                 continue;
                             }
                             ReceiverTypeResolution::NoProfile => {
                                 if get_option!(stats) {
-                                    self.set_dynamic_send_reason(insn_id, SendWithoutBlockNoProfiles);
+                                    let reason = if has_block { SendNoProfiles } else { SendWithoutBlockNoProfiles };
+                                    self.set_dynamic_send_reason(insn_id, reason);
                                 }
                                 self.push_insn_id(block, insn_id);
                                 continue;
@@ -3065,7 +3074,8 @@ impl Function {
                         // Do method lookup
                         let mut cme = unsafe { rb_callable_method_entry(klass, mid) };
                         if cme.is_null() {
-                            self.set_dynamic_send_reason(insn_id, SendWithoutBlockNotOptimizedMethodType(MethodType::Null));
+                            let reason = if has_block { SendNotOptimizedMethodType(MethodType::Null) } else { SendWithoutBlockNotOptimizedMethodType(MethodType::Null) };
+                            self.set_dynamic_send_reason(insn_id, reason);
                             self.push_insn_id(block, insn_id); continue;
                         }
                         // Load an overloaded cme if applicable. See vm_search_cc().
@@ -3077,7 +3087,8 @@ impl Function {
                             (METHOD_VISI_PRIVATE, true) => {}
                             (METHOD_VISI_PROTECTED, true) => {}
                             _ => {
-                                self.set_dynamic_send_reason(insn_id, SendWithoutBlockNotOptimizedNeedPermission);
+                                let reason = if has_block { SendNotOptimizedNeedPermission } else { SendWithoutBlockNotOptimizedNeedPermission };
+                                self.set_dynamic_send_reason(insn_id, reason);
                                 self.push_insn_id(block, insn_id); continue;
                             }
                         }
@@ -3100,7 +3111,7 @@ impl Function {
                             // Only specialize positional-positional calls
                             // TODO(max): Handle other kinds of parameter passing
                             let iseq = unsafe { get_def_iseq_ptr((*cme).def) };
-                            if !can_direct_send(self, block, iseq, ci, insn_id, args.as_slice(), None) {
+                            if !can_direct_send(self, block, iseq, ci, insn_id, args.as_slice(), blockiseq) {
                                 self.push_insn_id(block, insn_id); continue;
                             }
 
@@ -3123,9 +3134,9 @@ impl Function {
                                 self.push_insn_id(block, insn_id); continue;
                             };
 
-                            let send_direct = self.push_insn(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, blockiseq: None });
+                            let send_direct = self.push_insn(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, blockiseq });
                             self.make_equal_to(insn_id, send_direct);
-                        } else if def_type == VM_METHOD_TYPE_BMETHOD {
+                        } else if !has_block && def_type == VM_METHOD_TYPE_BMETHOD {
                             let procv = unsafe { rb_get_def_bmethod_proc((*cme).def) };
                             let proc = unsafe { rb_jit_get_proc_ptr(procv) };
                             let proc_block = unsafe { &(*proc).block };
@@ -3166,7 +3177,7 @@ impl Function {
 
                             let send_direct = self.push_insn(block, Insn::SendDirect { recv, cd, cme, iseq, args: processed_args, kw_bits, state: send_state, blockiseq: None });
                             self.make_equal_to(insn_id, send_direct);
-                        } else if def_type == VM_METHOD_TYPE_IVAR && args.is_empty() {
+                        } else if !has_block && def_type == VM_METHOD_TYPE_IVAR && args.is_empty() {
                             // Check if we're accessing ivars of a Class or Module object as they require single-ractor mode.
                             // We omit gen_prepare_non_leaf_call on gen_getivar, so it's unsafe to raise for multi-ractor mode.
                             if self.is_metaclass(klass) && !self.assume_single_ractor_mode(block, state) {
@@ -3186,7 +3197,7 @@ impl Function {
 
                             let getivar = self.push_insn(block, Insn::GetIvar { self_val: recv, id, ic: std::ptr::null(), state });
                             self.make_equal_to(insn_id, getivar);
-                        } else if let (VM_METHOD_TYPE_ATTRSET, &[val]) = (def_type, args.as_slice()) {
+                        } else if let (false, VM_METHOD_TYPE_ATTRSET, &[val]) = (has_block, def_type, args.as_slice()) {
                             // Check if we're accessing ivars of a Class or Module object as they require single-ractor mode.
                             // We omit gen_prepare_non_leaf_call on gen_getivar, so it's unsafe to raise for multi-ractor mode.
                             if self.is_metaclass(klass) && !self.assume_single_ractor_mode(block, state) {
@@ -3201,7 +3212,7 @@ impl Function {
 
                             self.push_insn(block, Insn::SetIvar { self_val: recv, id, ic: std::ptr::null(), val, state });
                             self.make_equal_to(insn_id, val);
-                        } else if def_type == VM_METHOD_TYPE_OPTIMIZED {
+                        } else if !has_block && def_type == VM_METHOD_TYPE_OPTIMIZED {
                             let opt_type: OptimizedMethodType = unsafe { get_cme_def_body_optimized_type(cme) }.into();
                             match (opt_type, args.as_slice()) {
                                 (OptimizedMethodType::Call, _) => {
@@ -3288,115 +3299,8 @@ impl Function {
                                 },
                             };
                         } else {
-                            self.set_dynamic_send_reason(insn_id, SendWithoutBlockNotOptimizedMethodType(MethodType::from(def_type)));
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-                    }
-                    Insn::Send { mut recv, cd, state, blockiseq, args, .. } => {
-                        let frame_state = self.frame_state(state);
-                        let (klass, profiled_type) = match self.resolve_receiver_type(recv, self.type_of(recv), frame_state.insn_idx) {
-                            ReceiverTypeResolution::StaticallyKnown { class } => (class, None),
-                            ReceiverTypeResolution::Monomorphic { profiled_type }
-                            | ReceiverTypeResolution::SkewedPolymorphic { profiled_type } => (profiled_type.class(), Some(profiled_type)),
-                            ReceiverTypeResolution::SkewedMegamorphic { .. }
-                            | ReceiverTypeResolution::Megamorphic => {
-                                if get_option!(stats) {
-                                    self.set_dynamic_send_reason(insn_id, SendMegamorphic);
-                                }
-                                self.push_insn_id(block, insn_id);
-                                continue;
-                            }
-                            ReceiverTypeResolution::Polymorphic => {
-                                if get_option!(stats) {
-                                    self.set_dynamic_send_reason(insn_id, SendPolymorphic);
-                                }
-                                self.push_insn_id(block, insn_id);
-                                continue;
-                            }
-                            ReceiverTypeResolution::NoProfile => {
-                                if get_option!(stats) {
-                                    self.set_dynamic_send_reason(insn_id, SendNoProfiles);
-                                }
-                                self.push_insn_id(block, insn_id);
-                                continue;
-                            }
-                        };
-                        let ci = unsafe { get_call_data_ci(cd) }; // info about the call site
-
-                        let flags = unsafe { rb_vm_ci_flag(ci) };
-
-                        let mid = unsafe { vm_ci_mid(ci) };
-                        // Do method lookup
-                        let mut cme = unsafe { rb_callable_method_entry(klass, mid) };
-                        if cme.is_null() {
-                            self.set_dynamic_send_reason(insn_id, SendNotOptimizedMethodType(MethodType::Null));
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-                        // Load an overloaded cme if applicable. See vm_search_cc().
-                        // It allows you to use a faster ISEQ if possible.
-                        cme = unsafe { rb_check_overloaded_cme(cme, ci) };
-                        let visibility = unsafe { METHOD_ENTRY_VISI(cme) };
-                        match (visibility, flags & VM_CALL_FCALL != 0) {
-                            (METHOD_VISI_PUBLIC, _) => {}
-                            (METHOD_VISI_PRIVATE, true) => {}
-                            (METHOD_VISI_PROTECTED, true) => {}
-                            _ => {
-                                self.set_dynamic_send_reason(insn_id, SendNotOptimizedNeedPermission);
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-                        }
-                        let mut def_type = unsafe { get_cme_def_type(cme) };
-                        while def_type == VM_METHOD_TYPE_ALIAS {
-                            cme = unsafe { rb_aliased_callable_method_entry(cme) };
-                            def_type = unsafe { get_cme_def_type(cme) };
-                        }
-
-                        // If the call site info indicates that the `Function` has overly complex arguments, then do not optimize into a `SendDirect`.
-                        // Optimized methods(`VM_METHOD_TYPE_OPTIMIZED`) handle their own argument constraints (e.g., kw_splat for Proc call).
-                        if def_type != VM_METHOD_TYPE_OPTIMIZED && unspecializable_call_type(flags) {
-                            self.count_complex_call_features(block, flags);
-                            self.set_dynamic_send_reason(insn_id, ComplexArgPass);
-                            self.push_insn_id(block, insn_id); continue;
-                        }
-
-                        if def_type == VM_METHOD_TYPE_ISEQ {
-                            let iseq = unsafe { get_def_iseq_ptr((*cme).def) };
-                            if !can_direct_send(self, block, iseq, ci, insn_id, args.as_slice(), Some(blockiseq)) {
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-
-                            // Check singleton class assumption first, before emitting other patchpoints
-                            if !self.assume_no_singleton_classes(block, klass, state) {
-                                self.set_dynamic_send_reason(insn_id, SingletonClassSeen);
-                                self.push_insn_id(block, insn_id); continue;
-                            }
-
-                            // Add PatchPoint for method redefinition
-                            self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass, method: mid, cme }, state });
-
-                            // Add GuardType for profiled receiver
-                            if let Some(profiled_type) = profiled_type {
-                                recv = self.push_insn(block, Insn::GuardType { val: recv, guard_type: Type::from_profiled_type(profiled_type), state });
-                            }
-
-                            let Ok((send_state, processed_args, kw_bits)) = self.prepare_direct_send_args(block, &args, ci, iseq, state)
-                                .inspect_err(|&reason| self.set_dynamic_send_reason(insn_id, reason)) else {
-                                self.push_insn_id(block, insn_id); continue;
-                            };
-
-                            let send_direct = self.push_insn(block, Insn::SendDirect {
-                                recv,
-                                cd,
-                                cme,
-                                iseq,
-                                args: processed_args,
-                                kw_bits,
-                                blockiseq: Some(blockiseq),
-                                state: send_state,
-                            });
-                            self.make_equal_to(insn_id, send_direct);
-                        } else {
-                            self.set_dynamic_send_reason(insn_id, SendNotOptimizedMethodType(MethodType::from(def_type)));
+                            let reason = if has_block { SendNotOptimizedMethodType(MethodType::from(def_type)) } else { SendWithoutBlockNotOptimizedMethodType(MethodType::from(def_type)) };
+                            self.set_dynamic_send_reason(insn_id, reason);
                             self.push_insn_id(block, insn_id); continue;
                         }
                     }
@@ -3419,7 +3323,7 @@ impl Function {
                     }
                     Insn::ObjToString { val, cd, state, .. } => {
                         if self.is_a(val, types::String) {
-                            // behaves differently from `SendWithoutBlock` with `mid:to_s` because ObjToString should not have a patch point for String to_s being redefined
+                            // behaves differently from `Send` with `mid:to_s` because ObjToString should not have a patch point for String to_s being redefined
                             self.make_equal_to(insn_id, val); continue;
                         }
 
@@ -3436,7 +3340,7 @@ impl Function {
                             self.make_equal_to(insn_id, guard);
                         } else {
                             let recv = self.push_insn(block, Insn::GuardType { val, guard_type: Type::from_profiled_type(recv_type), state});
-                            let send_to_s = self.push_insn(block, Insn::SendWithoutBlock { recv, cd, args: vec![], state, reason: ObjToStringNotString });
+                            let send_to_s = self.push_insn(block, Insn::Send { recv, cd, blockiseq: None, args: vec![], state, reason: ObjToStringNotString });
                             self.make_equal_to(insn_id, send_to_s);
                         }
                     }
@@ -3540,6 +3444,15 @@ impl Function {
                             continue;
                         }
 
+                        let frame_state = self.frame_state(state);
+
+                        // Don't handle super in a block since that needs a loop to find the running CME.
+                        if frame_state.iseq != unsafe { rb_get_iseq_body_local_iseq(frame_state.iseq) } {
+                            self.push_insn_id(block, insn_id);
+                            self.set_dynamic_send_reason(insn_id, SuperFromBlock);
+                            continue;
+                        }
+
                         let ci = unsafe { get_call_data_ci(cd) };
                         let flags = unsafe { rb_vm_ci_flag(ci) };
                         assert!(flags & VM_CALL_FCALL != 0);
@@ -3550,8 +3463,6 @@ impl Function {
                             self.set_dynamic_send_reason(insn_id, SuperComplexArgsPass);
                             continue;
                         }
-
-                        let frame_state = self.frame_state(state);
 
                         // Get the profiled CME from the current method.
                         let Some(profiles) = self.profiles.as_ref() else {
@@ -4045,7 +3956,7 @@ impl Function {
         self.push_insn(block, Insn::IncrCounterPtr { counter_ptr });
     }
 
-    /// Optimize Send/SendWithoutBlock that land in a C method to a direct CCall without
+    /// Optimize Send that land in a C method to a direct CCall without
     /// runtime lookup.
     fn optimize_c_calls(&mut self) {
         if unsafe { rb_zjit_method_tracing_currently_enabled() } {
@@ -4118,7 +4029,11 @@ impl Function {
                 return Err(());
             }
 
-            let blockiseq = if blockiseq.is_null() { None } else { Some(blockiseq) };
+            let blockiseq = match blockiseq {
+                None => unreachable!("went to reduce_send_without_block_to_ccall"),
+                Some(p) if p.is_null() => None,
+                Some(blockiseq) => Some(blockiseq),
+            };
 
             let cfunc = unsafe { get_cme_def_body_cfunc(cme) };
             // Find the `argc` (arity) of the C method, which describes the parameters it expects
@@ -4215,7 +4130,7 @@ impl Function {
             }
         }
 
-        // Try to reduce a SendWithoutBlock insn to a CCall/CCallWithFrame
+        // Try to reduce a Send insn with blockiseq: None to a CCall/CCallWithFrame
         fn reduce_send_without_block_to_ccall(
             fun: &mut Function,
             block: BlockId,
@@ -4223,7 +4138,7 @@ impl Function {
             send: Insn,
             send_insn_id: InsnId,
         ) -> Result<(), ()> {
-            let Insn::SendWithoutBlock { mut recv, cd, args, state, .. } = send else {
+            let Insn::Send { mut recv, cd, args, state, .. } = send else {
                 return Err(());
             };
 
@@ -4453,7 +4368,7 @@ impl Function {
             for insn_id in old_insns {
                 let send = self.find(insn_id);
                 match send {
-                    send @ Insn::SendWithoutBlock { recv, .. } => {
+                    send @ Insn::Send { recv, blockiseq: None, .. } => {
                         let recv_type = self.type_of(recv);
                         if reduce_send_without_block_to_ccall(self, block, recv_type, send, insn_id).is_ok() {
                             continue;
@@ -4774,7 +4689,7 @@ impl Function {
                 worklist.push_back(val);
                 worklist.push_back(state);
             }
-            &Insn::GuardGreaterEq { left, right, state } => {
+            &Insn::GuardGreaterEq { left, right, state, .. } => {
                 worklist.push_back(left);
                 worklist.push_back(right);
                 worklist.push_back(state);
@@ -4856,7 +4771,6 @@ impl Function {
             }
             &Insn::Send { recv, ref args, state, .. }
             | &Insn::SendForward { recv, ref args, state, .. }
-            | &Insn::SendWithoutBlock { recv, ref args, state, .. }
             | &Insn::CCallVariadic { recv, ref args, state, .. }
             | &Insn::CCallWithFrame { recv, ref args, state, .. }
             | &Insn::SendDirect { recv, ref args, state, .. }
@@ -4878,6 +4792,11 @@ impl Function {
             }
             &Insn::GetIvar { self_val, state, .. } | &Insn::DefinedIvar { self_val, state, .. } => {
                 worklist.push_back(self_val);
+                worklist.push_back(state);
+            }
+            &Insn::GetConstant { klass, allow_nil, state, .. } => {
+                worklist.push_back(klass);
+                worklist.push_back(allow_nil);
                 worklist.push_back(state);
             }
             &Insn::SetIvar { self_val, val, state, .. } => {
@@ -5506,9 +5425,12 @@ impl Function {
                 self.assert_subtype(insn_id, left, types::BasicObject)?;
                 self.assert_subtype(insn_id, right, types::BasicObject)
             }
+            Insn::GetConstant { klass, allow_nil, .. } => {
+                self.assert_subtype(insn_id, klass, types::BasicObject)?;
+                self.assert_subtype(insn_id, allow_nil, types::BoolExact)
+            }
             // Instructions with recv and a Vec of Ruby objects
-            Insn::SendWithoutBlock { recv, ref args, .. }
-            | Insn::SendDirect { recv, ref args, .. }
+            Insn::SendDirect { recv, ref args, .. }
             | Insn::Send { recv, ref args, .. }
             | Insn::SendForward { recv, ref args, .. }
             | Insn::InvokeSuper { recv, ref args, .. }
@@ -6086,14 +6008,12 @@ pub fn jit_entry_insns(iseq: IseqPtr) -> Vec<u32> {
 
 struct BytecodeInfo {
     jump_targets: Vec<u32>,
-    has_blockiseq: bool,
 }
 
 fn compute_bytecode_info(iseq: *const rb_iseq_t, opt_table: &[u32]) -> BytecodeInfo {
     let iseq_size = unsafe { get_iseq_encoded_size(iseq) };
     let mut insn_idx = 0;
     let mut jump_targets: HashSet<u32> = opt_table.iter().copied().collect();
-    let mut has_blockiseq = false;
     while insn_idx < iseq_size {
         // Get the current pc and opcode
         let pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx) };
@@ -6104,7 +6024,8 @@ fn compute_bytecode_info(iseq: *const rb_iseq_t, opt_table: &[u32]) -> BytecodeI
             .unwrap();
         insn_idx += insn_len(opcode as usize);
         match opcode {
-            YARVINSN_branchunless | YARVINSN_jump | YARVINSN_branchif | YARVINSN_branchnil => {
+            YARVINSN_branchunless | YARVINSN_jump | YARVINSN_branchif | YARVINSN_branchnil
+            | YARVINSN_branchunless_without_ints | YARVINSN_jump_without_ints | YARVINSN_branchif_without_ints | YARVINSN_branchnil_without_ints => {
                 let offset = get_arg(pc, 0).as_i64();
                 jump_targets.insert(insn_idx_at_offset(insn_idx, offset));
             }
@@ -6117,18 +6038,12 @@ fn compute_bytecode_info(iseq: *const rb_iseq_t, opt_table: &[u32]) -> BytecodeI
                     jump_targets.insert(insn_idx);
                 }
             }
-            YARVINSN_send | YARVINSN_invokesuper => {
-                let blockiseq: IseqPtr = get_arg(pc, 1).as_iseq();
-                if !blockiseq.is_null() {
-                    has_blockiseq = true;
-                }
-            }
             _ => {}
         }
     }
     let mut result = jump_targets.into_iter().collect::<Vec<_>>();
     result.sort();
-    BytecodeInfo { jump_targets: result, has_blockiseq }
+    BytecodeInfo { jump_targets: result }
 }
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -6223,6 +6138,10 @@ fn invalidates_locals(opcode: u32, operands: *const VALUE) -> bool {
         | YARVINSN_branchunless
         | YARVINSN_branchif
         | YARVINSN_branchnil
+        | YARVINSN_jump_without_ints
+        | YARVINSN_branchunless_without_ints
+        | YARVINSN_branchif_without_ints
+        | YARVINSN_branchnil_without_ints
         | YARVINSN_leave => false,
         // TODO(max): Read the invokebuiltin target from operands and determine if it's leaf
         _ => unsafe { !rb_zjit_insn_leaf(opcode as i32, operands) }
@@ -6243,7 +6162,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
     // Compute a map of PC->Block by finding jump targets
     let jit_entry_insns = jit_entry_insns(iseq);
-    let BytecodeInfo { jump_targets, has_blockiseq } = compute_bytecode_info(iseq, &jit_entry_insns);
+    let BytecodeInfo { jump_targets } = compute_bytecode_info(iseq, &jit_entry_insns);
 
     // Make all empty basic blocks. The ordering of the BBs matters for getting fallthrough jumps
     // in good places, but it's not necessary for correctness. TODO: Higher quality scheduling during lowering.
@@ -6275,7 +6194,11 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
     // Check if the EP is escaped for the ISEQ from the beginning. We give up
     // optimizing locals in that case because they're shared with other frames.
-    let ep_escaped = iseq_escapes_ep(iseq);
+    let ep_starts_escaped = iseq_escapes_ep(iseq);
+    // Check if the EP has been escaped at some point in the ISEQ. If it has, then we assume that
+    // its EP is shared with other frames.
+    let ep_has_been_escaped = crate::invariants::iseq_escapes_ep(iseq);
+    let ep_escaped = ep_starts_escaped || ep_has_been_escaped;
 
     // Iteratively fill out basic blocks using a queue.
     // TODO(max): Basic block arguments at edges
@@ -6586,7 +6509,18 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let obj = get_arg(pc, 1);
                     let pushval = get_arg(pc, 2);
                     let v = state.stack_pop()?;
-                    state.stack_push(fun.push_insn(block, Insn::Defined { op_type, obj, pushval, v, state: exit_id }));
+                    let local_iseq = unsafe { rb_get_iseq_body_local_iseq(iseq) };
+                    let insn = if op_type == DEFINED_YIELD as usize && unsafe { rb_get_iseq_body_type(local_iseq) } != ISEQ_TYPE_METHOD {
+                        // `yield` goes to the block handler stowed in the "local" iseq which is
+                        // the current iseq or a parent. Only the "method" iseq type can be passed a
+                        // block handler. (e.g. `yield` in the top level script is a syntax error.)
+                        //
+                        // Similar to gen_is_block_given
+                        Insn::Const { val: Const::Value(Qnil) }
+                    } else {
+                        Insn::Defined { op_type, obj, pushval, v, state: exit_id }
+                    };
+                    state.stack_push(fun.push_insn(block, insn));
                 }
                 YARVINSN_definedivar => {
                     // (ID id, IVC ic, VALUE pushval)
@@ -6608,7 +6542,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     // Use FrameState to get kw_bits when possible, just like getlocal_WC_0.
                     let val = if !local_inval {
                         state.getlocal(ep_offset)
-                    } else if ep_escaped || has_blockiseq {
+                    } else if ep_escaped {
                         fun.push_insn(block, Insn::GetLocal { ep_offset, level: 0, use_sp: false, rest_param: false })
                     } else {
                         let exit_id = fun.push_insn(block, Insn::Snapshot { state: exit_state.without_locals() });
@@ -6618,13 +6552,23 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     };
                     state.stack_push(fun.push_insn(block, Insn::FixnumBitCheck { val, index }));
                 }
+                YARVINSN_getconstant => {
+                    let id = ID(get_arg(pc, 0).as_u64());
+                    let allow_nil = state.stack_pop()?;
+                    let klass = state.stack_pop()?;
+                    let result = fun.push_insn(block, Insn::GetConstant { klass, id, allow_nil, state: exit_id });
+                    state.stack_push(result);
+                }
                 YARVINSN_opt_getconstant_path => {
                     let ic = get_arg(pc, 0).as_ptr();
+                    // TODO: Remove this extra Snapshot and pass `exit_id` to `GetConstantPath` instead.
                     let snapshot = fun.push_insn(block, Insn::Snapshot { state: exit_state });
                     state.stack_push(fun.push_insn(block, Insn::GetConstantPath { ic, state: snapshot }));
                 }
-                YARVINSN_branchunless => {
-                    fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
+                YARVINSN_branchunless | YARVINSN_branchunless_without_ints => {
+                    if opcode == YARVINSN_branchunless {
+                        fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
+                    }
                     let offset = get_arg(pc, 0).as_i64();
                     let val = state.stack_pop()?;
                     let test_id = fun.push_insn(block, Insn::Test { val });
@@ -6643,8 +6587,10 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     state.replace(val, not_nil_false);
                     queue.push_back((state.clone(), target, target_idx, local_inval));
                 }
-                YARVINSN_branchif => {
-                    fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
+                YARVINSN_branchif | YARVINSN_branchif_without_ints => {
+                    if opcode == YARVINSN_branchif {
+                        fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
+                    }
                     let offset = get_arg(pc, 0).as_i64();
                     let val = state.stack_pop()?;
                     let test_id = fun.push_insn(block, Insn::Test { val });
@@ -6663,8 +6609,10 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     state.replace(val, nil_false);
                     queue.push_back((state.clone(), target, target_idx, local_inval));
                 }
-                YARVINSN_branchnil => {
-                    fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
+                YARVINSN_branchnil | YARVINSN_branchnil_without_ints => {
+                    if opcode == YARVINSN_branchnil {
+                        fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
+                    }
                     let offset = get_arg(pc, 0).as_i64();
                     let val = state.stack_pop()?;
                     let test_id = fun.push_insn(block, Insn::IsNil { val });
@@ -6713,9 +6661,11 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     state.stack_setn(argc, insn_id);
                     state.stack_setn(argc + 1, insn_id);
                 }
-                YARVINSN_jump => {
+                YARVINSN_jump | YARVINSN_jump_without_ints => {
                     let offset = get_arg(pc, 0).as_i64();
-                    fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
+                    if opcode == YARVINSN_jump {
+                        fun.push_insn(block, Insn::CheckInterrupts { state: exit_id });
+                    }
                     let target_idx = insn_idx_at_offset(insn_idx, offset);
                     let target = insn_idx_to_block[&target_idx];
                     let _branch_id = fun.push_insn(block, Insn::Jump(
@@ -6731,7 +6681,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         // In case of JIT-to-JIT send locals might never end up in EP memory.
                         let val = state.getlocal(ep_offset);
                         state.stack_push(val);
-                    } else if ep_escaped || has_blockiseq { // TODO: figure out how to drop has_blockiseq here
+                    } else if ep_escaped {
                         // Read the local using EP
                         let val = fun.push_insn(block, Insn::GetLocal { ep_offset, level: 0, use_sp: false, rest_param: false });
                         state.setlocal(ep_offset, val); // remember the result to spill on side-exits
@@ -6754,12 +6704,12 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     const level: u32 = 0;
                     let val = state.stack_pop()?;
                     // In ZJIT, Insn::SetLocal only needs to be executed when ep is escaped
-                    if ep_escaped || has_blockiseq { // TODO: figure out how to drop has_blockiseq here
+                    if ep_escaped {
                         // Write the local using EP
                         let ep = fun.push_insn(block, Insn::GetEP { level });
                         let exit_id = fun.push_insn(block, Insn::Snapshot { state: exit_state.without_locals() }); // skip spilling locals
                         let flags = fun.push_insn(block, Insn::LoadField { recv: ep, id: ID!(_env_data_index_flags), offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32), return_type: types::CInt64 });
-                        fun.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(VM_ENV_FLAG_WB_REQUIRED.into()), reason: SideExitReason::WriteBarrierRequired, state: exit_id });
+                        fun.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(VM_ENV_FLAG_WB_REQUIRED.into()), mask_name: Some(ID!(VM_ENV_FLAG_WB_REQUIRED)), reason: SideExitReason::WriteBarrierRequired, state: exit_id });
                         fun.push_insn(block, Insn::SetLocal { val, ep, ep_offset, level });
                     } else if local_inval {
                         // If there has been any non-leaf call since JIT entry or the last patch point,
@@ -6779,7 +6729,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     const level: u32 = 1;
                     let ep = fun.push_insn(block, Insn::GetEP { level });
                     let flags = fun.push_insn(block, Insn::LoadField { recv: ep, id: ID!(_env_data_index_flags), offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32), return_type: types::CInt64 });
-                    fun.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(VM_ENV_FLAG_WB_REQUIRED.into()), reason: SideExitReason::WriteBarrierRequired, state: exit_id });
+                    fun.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(VM_ENV_FLAG_WB_REQUIRED.into()), mask_name: Some(ID!(VM_ENV_FLAG_WB_REQUIRED)), reason: SideExitReason::WriteBarrierRequired, state: exit_id });
                     fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep, ep_offset, level });
                 }
                 YARVINSN_getlocal => {
@@ -6792,7 +6742,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let level = get_arg(pc, 1).as_u32();
                     let ep = fun.push_insn(block, Insn::GetEP { level });
                     let flags = fun.push_insn(block, Insn::LoadField { recv: ep, id: ID!(_env_data_index_flags), offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32), return_type: types::CInt64 });
-                    fun.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(VM_ENV_FLAG_WB_REQUIRED.into()), reason: SideExitReason::WriteBarrierRequired, state: exit_id });
+                    fun.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(VM_ENV_FLAG_WB_REQUIRED.into()), mask_name: Some(ID!(VM_ENV_FLAG_WB_REQUIRED)), reason: SideExitReason::WriteBarrierRequired, state: exit_id });
                     fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep, ep_offset, level });
                 }
                 YARVINSN_getblockparamproxy => {
@@ -6807,7 +6757,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
                     let ep = fun.push_insn(block, Insn::GetEP { level });
                     let flags = fun.push_insn(block, Insn::LoadField { recv: ep, id: ID!(_env_data_index_flags), offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32), return_type: types::CInt64 });
-                    fun.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM.into()), reason: SideExitReason::BlockParamProxyModified, state: exit_id });
+                    fun.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM.into()), mask_name: Some(ID!(VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM)), reason: SideExitReason::BlockParamProxyModified, state: exit_id });
 
                     let block_handler = fun.push_insn(block, Insn::LoadField { recv: ep, id: ID!(_env_data_index_specval), offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL, return_type: types::CInt64 });
 
@@ -6825,7 +6775,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             const _: () = assert!(RUBY_SYMBOL_FLAG & 1 == 0, "guard below rejects symbol block handlers");
 
                             // Bail out if the block handler is neither ISEQ nor ifunc
-                            fun.push_insn(block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), reason: SideExitReason::BlockParamProxyNotIseqOrIfunc, state: exit_id });
+                            fun.push_insn(block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyNotIseqOrIfunc, state: exit_id });
                             // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                             state.stack_push(fun.push_insn(block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) }));
                         }
@@ -6984,7 +6934,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
                     let args = state.stack_pop_n(argc as usize)?;
                     let recv = state.stack_pop()?;
-                    let send = fun.push_insn(block, Insn::SendWithoutBlock { recv, cd, args, state: exit_id, reason: Uncategorized(opcode) });
+                    let send = fun.push_insn(block, Insn::Send { recv, cd, blockiseq: None, args, state: exit_id, reason: Uncategorized(opcode) });
                     state.stack_push(send);
                 }
                 YARVINSN_opt_hash_freeze => {
@@ -7107,7 +7057,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             let recv = state.stack_pop().unwrap();
                             let refined_recv = fun.push_insn(block, Insn::RefineType { val: recv, new_type });
                             state.replace(recv, refined_recv);
-                            let send = fun.push_insn(block, Insn::SendWithoutBlock { recv: refined_recv, cd, args, state: snapshot, reason: Uncategorized(opcode) });
+                            let send = fun.push_insn(block, Insn::Send { recv: refined_recv, cd, blockiseq: None, args, state: snapshot, reason: Uncategorized(opcode) });
                             state.stack_push(send);
                             fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: state.as_args(self_param) }));
                             block
@@ -7140,7 +7090,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             let args = state.stack_pop_n(argc as usize)?;
                             let recv = state.stack_pop()?;
                             let reason = SendWithoutBlockPolymorphicFallback;
-                            let send = fun.push_insn(block, Insn::SendWithoutBlock { recv, cd, args, state: exit_id, reason });
+                            let send = fun.push_insn(block, Insn::Send { recv, cd, blockiseq: None, args, state: exit_id, reason });
                             state.stack_push(send);
                             fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: state.as_args(self_param) }));
                             break;  // End the block
@@ -7149,7 +7099,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
                     let args = state.stack_pop_n(argc as usize)?;
                     let recv = state.stack_pop()?;
-                    let send = fun.push_insn(block, Insn::SendWithoutBlock { recv, cd, args, state: exit_id, reason: Uncategorized(opcode) });
+                    let send = fun.push_insn(block, Insn::Send { recv, cd, blockiseq: None, args, state: exit_id, reason: Uncategorized(opcode) });
                     state.stack_push(send);
                 }
                 YARVINSN_send => {
@@ -7167,7 +7117,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
                     let args = state.stack_pop_n(argc as usize + usize::from(block_arg))?;
                     let recv = state.stack_pop()?;
-                    let send = fun.push_insn(block, Insn::Send { recv, cd, blockiseq, args, state: exit_id, reason: Uncategorized(opcode) });
+                    let send = fun.push_insn(block, Insn::Send { recv, cd, blockiseq: Some(blockiseq), args, state: exit_id, reason: Uncategorized(opcode) });
                     state.stack_push(send);
 
                     if !blockiseq.is_null() {
@@ -7460,7 +7410,8 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let val = state.stack_pop()?;
                     let array = fun.push_insn(block, Insn::GuardType { val, guard_type: types::ArrayExact, state: exit_id, });
                     let length = fun.push_insn(block, Insn::ArrayLength { array });
-                    fun.push_insn(block, Insn::GuardBitEquals { val: length, expected: Const::CInt64(num as i64), reason: SideExitReason::ExpandArray, state: exit_id });
+                    let expected = fun.push_insn(block, Insn::Const { val: Const::CInt64(num as i64) });
+                    fun.push_insn(block, Insn::GuardGreaterEq { left: length, right: expected, reason: SideExitReason::ExpandArray, state: exit_id });
                     for i in (0..num).rev() {
                         // We do not emit a length guard here because in-bounds is already
                         // ensured by the expandarray length check above.

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -512,6 +512,7 @@ pub enum SideExitReason {
     FixnumModByZero,
     FixnumDivByZero,
     BoxFixnumOverflow,
+    WriteBarrierRequired,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -849,7 +850,7 @@ pub enum Insn {
     /// Get the block parameter as a Proc.
     GetBlockParam { level: u32, ep_offset: u32, state: InsnId },
     /// Set a local variable in a higher scope or the heap
-    SetLocal { level: u32, ep_offset: u32, val: InsnId },
+    SetLocal { level: u32, ep_offset: u32, val: InsnId, state: InsnId },
     GetSpecialSymbol { symbol_type: SpecialBackrefSymbol, state: InsnId },
     GetSpecialNumber { nth: u64, state: InsnId },
 
@@ -1629,7 +1630,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             &Insn::IsBlockParamModified { level } => {
                 write!(f, "IsBlockParamModified l{level}")
             },
-            &Insn::SetLocal { val, level, ep_offset } => {
+            &Insn::SetLocal { val, level, ep_offset, .. } => {
                 let name = get_local_var_name_for_printer(self.iseq, level, ep_offset).map_or(String::new(), |x| format!("{x}, "));
                 write!(f, "SetLocal {name}l{level}, EP@{ep_offset}, {val}")
             },
@@ -2375,7 +2376,7 @@ impl Function {
             &SetIvar { self_val, id, ic, val, state } => SetIvar { self_val: find!(self_val), id, ic, val: find!(val), state },
             &GetClassVar { id, ic, state } => GetClassVar { id, ic, state },
             &SetClassVar { id, val, ic, state } => SetClassVar { id, val: find!(val), ic, state },
-            &SetLocal { val, ep_offset, level } => SetLocal { val: find!(val), ep_offset, level },
+            &SetLocal { val, ep_offset, level, state } => SetLocal { val: find!(val), ep_offset, level, state },
             &GetSpecialSymbol { symbol_type, state } => GetSpecialSymbol { symbol_type, state },
             &GetSpecialNumber { nth, state } => GetSpecialNumber { nth, state },
             &ToArray { val, state } => ToArray { val: find!(val), state },
@@ -6753,7 +6754,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let val = state.stack_pop()?;
                     if ep_escaped || has_blockiseq { // TODO: figure out how to drop has_blockiseq here
                         // Write the local using EP
-                        fun.push_insn(block, Insn::SetLocal { val, ep_offset, level: 0 });
+                        fun.push_insn(block, Insn::SetLocal { val, ep_offset, level: 0, state: exit_id });
                     } else if local_inval {
                         // If there has been any non-leaf call since JIT entry or the last patch point,
                         // add a patch point to make sure locals have not been escaped.
@@ -6770,7 +6771,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                 }
                 YARVINSN_setlocal_WC_1 => {
                     let ep_offset = get_arg(pc, 0).as_u32();
-                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep_offset, level: 1 });
+                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep_offset, level: 1, state: exit_id });
                 }
                 YARVINSN_getlocal => {
                     let ep_offset = get_arg(pc, 0).as_u32();
@@ -6780,7 +6781,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                 YARVINSN_setlocal => {
                     let ep_offset = get_arg(pc, 0).as_u32();
                     let level = get_arg(pc, 1).as_u32();
-                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep_offset, level });
+                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep_offset, level, state: exit_id });
                 }
                 YARVINSN_getblockparamproxy => {
                     let level = get_arg(pc, 1).as_u32();

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -850,7 +850,7 @@ pub enum Insn {
     /// Get the block parameter as a Proc.
     GetBlockParam { level: u32, ep_offset: u32, state: InsnId },
     /// Set a local variable in a higher scope or the heap
-    SetLocal { level: u32, ep_offset: u32, val: InsnId },
+    SetLocal { level: u32, ep_offset: u32, ep: InsnId, val: InsnId },
     GetSpecialSymbol { symbol_type: SpecialBackrefSymbol, state: InsnId },
     GetSpecialNumber { nth: u64, state: InsnId },
 
@@ -2376,7 +2376,7 @@ impl Function {
             &SetIvar { self_val, id, ic, val, state } => SetIvar { self_val: find!(self_val), id, ic, val: find!(val), state },
             &GetClassVar { id, ic, state } => GetClassVar { id, ic, state },
             &SetClassVar { id, val, ic, state } => SetClassVar { id, val: find!(val), ic, state },
-            &SetLocal { val, ep_offset, level } => SetLocal { val: find!(val), ep_offset, level },
+            &SetLocal { val, ep_offset, level, ep } => SetLocal { val: find!(val), ep_offset, level, ep },
             &GetSpecialSymbol { symbol_type, state } => GetSpecialSymbol { symbol_type, state },
             &GetSpecialNumber { nth, state } => GetSpecialNumber { nth, state },
             &ToArray { val, state } => ToArray { val: find!(val), state },
@@ -6752,14 +6752,18 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                 YARVINSN_setlocal_WC_0 => {
                     // TODO(Jacob): Modify this to use guards
                     let ep_offset = get_arg(pc, 0).as_u32();
+                    const level: u32 = 0;
+                    let ep = fun.push_insn(block, Insn::GetEP { level });
                     let val = state.stack_pop()?;
                     if ep_escaped || has_blockiseq { // TODO: figure out how to drop has_blockiseq here
                         // Write the local using EP
-                        fun.push_insn(block, Insn::SetLocal { val, ep_offset, level: 0 });
+                        fun.push_insn(block, Insn::SetLocal { val, ep, ep_offset, level });
                     } else if local_inval {
                         // If there has been any non-leaf call since JIT entry or the last patch point,
                         // add a patch point to make sure locals have not been escaped.
                         let exit_id = fun.push_insn(block, Insn::Snapshot { state: exit_state.without_locals() }); // skip spilling locals
+                        let flags = fun.push_insn(block, Insn::LoadField { recv: ep, id: ID!(_env_data_index_flags), offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32), return_type: types::CInt64 });
+                        fun.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(VM_ENV_FLAG_WB_REQUIRED.into()), reason: SideExitReason::WriteBarrierRequired, state: exit_id });
                         fun.push_insn(block, Insn::PatchPoint { invariant: Invariant::NoEPEscape(iseq), state: exit_id });
                         local_inval = false;
                     }
@@ -6773,7 +6777,11 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                 YARVINSN_setlocal_WC_1 => {
                     // TODO(Jacob): Modify this to use guards
                     let ep_offset = get_arg(pc, 0).as_u32();
-                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep_offset, level: 1 });
+                    const level: u32 = 1;
+                    let ep = fun.push_insn(block, Insn::GetEP { level });
+                    let flags = fun.push_insn(block, Insn::LoadField { recv: ep, id: ID!(_env_data_index_flags), offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32), return_type: types::CInt64 });
+                    fun.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(VM_ENV_FLAG_WB_REQUIRED.into()), reason: SideExitReason::WriteBarrierRequired, state: exit_id });
+                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep, ep_offset, level });
                 }
                 YARVINSN_getlocal => {
                     let ep_offset = get_arg(pc, 0).as_u32();
@@ -6788,7 +6796,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let ep = fun.push_insn(block, Insn::GetEP { level });
                     let flags = fun.push_insn(block, Insn::LoadField { recv: ep, id: ID!(_env_data_index_flags), offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32), return_type: types::CInt64 });
                     fun.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(VM_ENV_FLAG_WB_REQUIRED.into()), reason: SideExitReason::WriteBarrierRequired, state: exit_id });
-                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep_offset, level });
+                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep, ep_offset, level });
                 }
                 YARVINSN_getblockparamproxy => {
                     let level = get_arg(pc, 1).as_u32();

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6752,11 +6752,11 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                 YARVINSN_setlocal_WC_0 => {
                     let ep_offset = get_arg(pc, 0).as_u32();
                     const level: u32 = 0;
-                    let ep = fun.push_insn(block, Insn::GetEP { level });
                     let val = state.stack_pop()?;
                     // In ZJIT, Insn::SetLocal only needs to be executed when ep is escaped
                     if ep_escaped || has_blockiseq { // TODO: figure out how to drop has_blockiseq here
                         // Write the local using EP
+                        let ep = fun.push_insn(block, Insn::GetEP { level });
                         let exit_id = fun.push_insn(block, Insn::Snapshot { state: exit_state.without_locals() }); // skip spilling locals
                         let flags = fun.push_insn(block, Insn::LoadField { recv: ep, id: ID!(_env_data_index_flags), offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32), return_type: types::CInt64 });
                         fun.push_insn(block, Insn::GuardNoBitsSet { val: flags, mask: Const::CUInt64(VM_ENV_FLAG_WB_REQUIRED.into()), reason: SideExitReason::WriteBarrierRequired, state: exit_id });

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6781,6 +6781,8 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                 YARVINSN_setlocal => {
                     let ep_offset = get_arg(pc, 0).as_u32();
                     let level = get_arg(pc, 1).as_u32();
+                    // TODO(Jacob): Add guard here
+                    // TODO(Jacob): Figure out if we should change ALL of the setlocals and what the differences are
                     fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep_offset, level, state: exit_id });
                 }
                 YARVINSN_getblockparamproxy => {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -823,11 +823,11 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:BasicObject):
           PatchPoint NoSingletonClass(C@0x1000)
           PatchPoint MethodRedefined(C@0x1000, fun_new_map@0x1008, cme:0x1010)
-          v23:ArraySubclass[class_exact:C] = GuardType v9, ArraySubclass[class_exact:C]
-          v24:BasicObject = CCallWithFrame v23, :C#fun_new_map@0x1038, block=0x1040
+          v22:ArraySubclass[class_exact:C] = GuardType v9, ArraySubclass[class_exact:C]
+          v23:BasicObject = SendDirect v22, 0x1038, :fun_new_map (0x1048)
           v15:BasicObject = GetLocal :o, l0, EP@3
           CheckInterrupts
-          Return v24
+          Return v23
         ");
     }
 
@@ -884,7 +884,7 @@ mod hir_opt_tests {
           EntryPoint JIT(0)
           Jump bb2(v4)
         bb2(v6:BasicObject):
-          v11:BasicObject = SendWithoutBlock v6, :foo # SendFallbackReason: SendWithoutBlock: unsupported method type Null
+          v11:BasicObject = Send v6, :foo # SendFallbackReason: SendWithoutBlock: unsupported method type Null
           CheckInterrupts
           Return v11
         ");
@@ -1126,7 +1126,7 @@ mod hir_opt_tests {
           v28:Fixnum[30] = Const Value(30)
           v30:Fixnum[40] = Const Value(40)
           v32:Fixnum[50] = Const Value(50)
-          v34:BasicObject = SendWithoutBlock v6, :target, v24, v26, v28, v30, v32 # SendFallbackReason: Argument count does not match parameter count
+          v34:BasicObject = Send v6, :target, v24, v26, v28, v30, v32 # SendFallbackReason: Argument count does not match parameter count
           v37:ArrayExact = NewArray v45, v49, v34
           CheckInterrupts
           Return v37
@@ -2662,7 +2662,7 @@ mod hir_opt_tests {
         bb2(v6:BasicObject):
           v10:Fixnum[1] = Const Value(1)
           v12:Fixnum[0] = Const Value(0)
-          v14:BasicObject = SendWithoutBlock v10, :itself, v12 # SendFallbackReason: SendWithoutBlock: unsupported method type Cfunc
+          v14:BasicObject = Send v10, :itself, v12 # SendFallbackReason: SendWithoutBlock: unsupported method type Cfunc
           CheckInterrupts
           Return v14
         ");
@@ -2926,18 +2926,14 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:Fixnum[1] = Const Value(1)
-          v15:CPtr = GetEP 0
-          v17:CInt64 = LoadField v15, :_env_data_index_flags@0x1000
-          v18:CInt64 = GuardNoBitsSet v17, CUInt64(8)
-          SetLocal :a, l0, EP@3, v13
-          PatchPoint NoSingletonClass(Object@0x1008)
-          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
-          v35:HeapObject[class_exact*:Object@VALUE(0x1008)] = GuardType v8, HeapObject[class_exact*:Object@VALUE(0x1008)]
+          PatchPoint NoSingletonClass(Object@0x1000)
+          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
+          v31:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v8, HeapObject[class_exact*:Object@VALUE(0x1000)]
           IncrCounter inline_iseq_optimized_send_count
-          v24:BasicObject = GetLocal :a, l0, EP@3
-          v28:BasicObject = GetLocal :a, l0, EP@3
+          v19:BasicObject = GetLocal :a, l0, EP@3
+          PatchPoint NoEPEscape(test)
           CheckInterrupts
-          Return v28
+          Return v19
         ");
     }
 
@@ -2961,7 +2957,7 @@ mod hir_opt_tests {
         bb2(v6:BasicObject):
           v11:Fixnum[1] = Const Value(1)
           IncrCounter complex_arg_pass_param_rest
-          v13:BasicObject = SendWithoutBlock v6, :foo, v11 # SendFallbackReason: Complex argument passing
+          v13:BasicObject = Send v6, :foo, v11 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v13
         ");
@@ -2986,7 +2982,7 @@ mod hir_opt_tests {
         bb2(v6:BasicObject):
           v11:Fixnum[10] = Const Value(10)
           IncrCounter complex_arg_pass_param_post
-          v13:BasicObject = SendWithoutBlock v6, :foo, v11 # SendFallbackReason: Complex argument passing
+          v13:BasicObject = Send v6, :foo, v11 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v13
         ");
@@ -3225,7 +3221,7 @@ mod hir_opt_tests {
           v33:Fixnum[40] = Const Value(40)
           v35:Fixnum[50] = Const Value(50)
           v37:Fixnum[60] = Const Value(60)
-          v39:BasicObject = SendWithoutBlock v6, :target, v27, v29, v31, v33, v35, v37 # SendFallbackReason: Too many arguments for LIR
+          v39:BasicObject = Send v6, :target, v27, v29, v31, v33, v35, v37 # SendFallbackReason: Too many arguments for LIR
           v41:ArrayExact = NewArray v49, v53, v39
           CheckInterrupts
           Return v41
@@ -3280,7 +3276,7 @@ mod hir_opt_tests {
         bb2(v6:BasicObject):
           v11:Fixnum[1] = Const Value(1)
           IncrCounter complex_arg_pass_param_kwrest
-          v13:BasicObject = SendWithoutBlock v6, :foo, v11 # SendFallbackReason: Complex argument passing
+          v13:BasicObject = Send v6, :foo, v11 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v13
         ");
@@ -3335,7 +3331,7 @@ mod hir_opt_tests {
           v11:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v12:HashExact = HashDup v11
           IncrCounter complex_arg_pass_caller_kw_splat
-          v14:BasicObject = SendWithoutBlock v6, :foo, v12 # SendFallbackReason: Complex argument passing
+          v14:BasicObject = Send v6, :foo, v12 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v14
         ");
@@ -3360,7 +3356,7 @@ mod hir_opt_tests {
           Jump bb2(v4)
         bb2(v6:BasicObject):
           IncrCounter complex_arg_pass_param_kwrest
-          v11:BasicObject = SendWithoutBlock v6, :foo # SendFallbackReason: Complex argument passing
+          v11:BasicObject = Send v6, :foo # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v11
         ");
@@ -3387,7 +3383,7 @@ mod hir_opt_tests {
           v12:StringExact = StringCopy v11
           v14:Fixnum[1] = Const Value(1)
           IncrCounter complex_arg_pass_caller_kwarg
-          v16:BasicObject = SendWithoutBlock v6, :sprintf, v12, v14 # SendFallbackReason: Complex argument passing
+          v16:BasicObject = Send v6, :sprintf, v12, v14 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v16
         ");
@@ -3418,18 +3414,14 @@ mod hir_opt_tests {
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:NilClass):
           v16:ArrayExact = NewArray
-          v18:CPtr = GetEP 0
-          v20:CInt64 = LoadField v18, :_env_data_index_flags@0x1000
-          v21:CInt64 = GuardNoBitsSet v20, CUInt64(8)
-          SetLocal :a, l0, EP@3, v16
-          v26:TrueClass = Const Value(true)
+          v21:TrueClass = Const Value(true)
           IncrCounter complex_arg_pass_caller_kwarg
-          v28:BasicObject = Send v11, 0x1008, :each_line, v26 # SendFallbackReason: Complex argument passing
-          v29:BasicObject = GetLocal :s, l0, EP@4
-          v30:BasicObject = GetLocal :a, l0, EP@3
-          v34:BasicObject = GetLocal :a, l0, EP@3
+          v23:BasicObject = Send v11, 0x1000, :each_line, v21 # SendFallbackReason: Complex argument passing
+          v24:BasicObject = GetLocal :s, l0, EP@4
+          v25:BasicObject = GetLocal :a, l0, EP@3
+          PatchPoint NoEPEscape(test)
           CheckInterrupts
-          Return v34
+          Return v25
         ");
     }
 
@@ -3688,7 +3680,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Hash@0x1008, new@0x1009, cme:0x1010)
           v46:HashExact = ObjectAllocClass Hash:VALUE(0x1008)
           IncrCounter complex_arg_pass_param_block
-          v20:BasicObject = SendWithoutBlock v46, :initialize # SendFallbackReason: Complex argument passing
+          v20:BasicObject = Send v46, :initialize # SendFallbackReason: Complex argument passing
           CheckInterrupts
           CheckInterrupts
           Return v46
@@ -3894,11 +3886,11 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:BasicObject):
           v14:CPtr = GetEP 0
           v15:CInt64 = LoadField v14, :_env_data_index_flags@0x1000
-          v16:CInt64 = GuardNoBitsSet v15, CUInt64(512)
+          v16:CInt64 = GuardNoBitsSet v15, VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM=CUInt64(512)
           v17:CInt64 = LoadField v14, :_env_data_index_specval@0x1001
           v18:CInt64 = GuardAnyBitSet v17, CUInt64(1)
           v19:HeapObject[BlockParamProxy] = Const Value(VALUE(0x1008))
-          v21:BasicObject = Send v8, 0x1010, :tap, v19 # SendFallbackReason: Uncategorized(send)
+          v21:BasicObject = Send v8, 0x1000, :tap, v19 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
           Return v21
         ");
@@ -4209,7 +4201,7 @@ mod hir_opt_tests {
           v16:ArrayExact = NewArray
           v22:ArrayExact = ToArray v16
           IncrCounter complex_arg_pass_caller_splat
-          v24:BasicObject = SendWithoutBlock v11, :call, v22 # SendFallbackReason: Complex argument passing
+          v24:BasicObject = Send v11, :call, v22 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v24
         ");
@@ -4224,7 +4216,7 @@ mod hir_opt_tests {
             end
             test p
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb0():
           EntryPoint interpreter
@@ -4237,7 +4229,7 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:BasicObject):
           v14:Fixnum[1] = Const Value(1)
           IncrCounter complex_arg_pass_caller_kwarg
-          v16:BasicObject = SendWithoutBlock v9, :call, v14 # SendFallbackReason: Complex argument passing
+          v16:BasicObject = Send v9, :call, v14 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v16
         ");
@@ -4654,7 +4646,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Hash@0x1000)
           PatchPoint MethodRedefined(Hash@0x1000, dup@0x1008, cme:0x1010)
           v22:BasicObject = CCallWithFrame v10, :Kernel#dup@0x1038
-          v14:BasicObject = SendWithoutBlock v22, :freeze # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v14:BasicObject = Send v22, :freeze # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v14
         ");
@@ -4677,7 +4669,7 @@ mod hir_opt_tests {
         bb2(v6:BasicObject):
           v10:HashExact = NewHash
           v12:NilClass = Const Value(nil)
-          v14:BasicObject = SendWithoutBlock v10, :freeze, v12 # SendFallbackReason: SendWithoutBlock: unsupported method type Cfunc
+          v14:BasicObject = Send v10, :freeze, v12 # SendFallbackReason: SendWithoutBlock: unsupported method type Cfunc
           CheckInterrupts
           Return v14
         ");
@@ -4747,7 +4739,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Array@0x1000)
           PatchPoint MethodRedefined(Array@0x1000, dup@0x1008, cme:0x1010)
           v22:BasicObject = CCallWithFrame v10, :Kernel#dup@0x1038
-          v14:BasicObject = SendWithoutBlock v22, :freeze # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v14:BasicObject = Send v22, :freeze # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v14
         ");
@@ -4770,7 +4762,7 @@ mod hir_opt_tests {
         bb2(v6:BasicObject):
           v10:ArrayExact = NewArray
           v12:NilClass = Const Value(nil)
-          v14:BasicObject = SendWithoutBlock v10, :freeze, v12 # SendFallbackReason: SendWithoutBlock: unsupported method type Cfunc
+          v14:BasicObject = Send v10, :freeze, v12 # SendFallbackReason: SendWithoutBlock: unsupported method type Cfunc
           CheckInterrupts
           Return v14
         ");
@@ -4841,7 +4833,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, dup@0x1010, cme:0x1018)
           v23:BasicObject = CCallWithFrame v11, :String#dup@0x1040
-          v15:BasicObject = SendWithoutBlock v23, :freeze # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v15:BasicObject = Send v23, :freeze # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v15
         ");
@@ -4865,7 +4857,7 @@ mod hir_opt_tests {
           v10:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v11:StringExact = StringCopy v10
           v13:NilClass = Const Value(nil)
-          v15:BasicObject = SendWithoutBlock v11, :freeze, v13 # SendFallbackReason: SendWithoutBlock: unsupported method type Cfunc
+          v15:BasicObject = Send v11, :freeze, v13 # SendFallbackReason: SendWithoutBlock: unsupported method type Cfunc
           CheckInterrupts
           Return v15
         ");
@@ -4936,7 +4928,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, dup@0x1010, cme:0x1018)
           v23:BasicObject = CCallWithFrame v11, :String#dup@0x1040
-          v15:BasicObject = SendWithoutBlock v23, :-@ # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v15:BasicObject = Send v23, :-@ # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v15
         ");
@@ -5362,7 +5354,7 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:BasicObject):
           v16:Fixnum[1] = Const Value(1)
           v18:Fixnum[10] = Const Value(10)
-          v22:BasicObject = SendWithoutBlock v9, :[]=, v16, v18 # SendFallbackReason: Uncategorized(opt_aset)
+          v22:BasicObject = Send v9, :[]=, v16, v18 # SendFallbackReason: Uncategorized(opt_aset)
           CheckInterrupts
           Return v18
         ");
@@ -5498,7 +5490,7 @@ mod hir_opt_tests {
           Jump bb2(v4)
         bb2(v6:BasicObject):
           v11:Fixnum[100] = Const Value(100)
-          v13:BasicObject = SendWithoutBlock v6, :identity, v11 # SendFallbackReason: Bmethod: Proc object is not defined by an ISEQ
+          v13:BasicObject = Send v6, :identity, v11 # SendFallbackReason: Bmethod: Proc object is not defined by an ISEQ
           CheckInterrupts
           Return v13
         ");
@@ -6370,7 +6362,7 @@ mod hir_opt_tests {
           EntryPoint JIT(0)
           Jump bb2(v4)
         bb2(v6:BasicObject):
-          v11:BasicObject = SendWithoutBlock v6, :foo # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v11:BasicObject = Send v6, :foo # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v11
         ");
@@ -6417,7 +6409,7 @@ mod hir_opt_tests {
           IfTrue v14, bb4(v8, v9, v9)
           v23:CBool = HasType v9, HeapObject[class_exact:C]
           IfTrue v23, bb5(v8, v9, v9)
-          v32:BasicObject = SendWithoutBlock v9, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          v32:BasicObject = Send v9, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
           Jump bb3(v8, v9, v32)
         bb4(v15:BasicObject, v16:BasicObject, v17:BasicObject):
           v19:HeapObject[class_exact:C] = RefineType v17, HeapObject[class_exact:C]
@@ -6496,9 +6488,9 @@ mod hir_opt_tests {
           v11:ArrayExact = ArrayDup v10
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, map@0x1010, cme:0x1018)
-          v21:BasicObject = CCallWithFrame v11, :Array#map@0x1040, block=0x1048
+          v20:BasicObject = SendDirect v11, 0x1040, :map (0x1050)
           CheckInterrupts
-          Return v21
+          Return v20
         ");
     }
 
@@ -6529,23 +6521,19 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:ArrayExact = NewArray
-          v15:CPtr = GetEP 0
-          v17:CInt64 = LoadField v15, :_env_data_index_flags@0x1000
-          v18:CInt64 = GuardNoBitsSet v17, CUInt64(8)
-          SetLocal :result, l0, EP@3, v13
           PatchPoint SingleRactorMode
-          PatchPoint StableConstantNames(0x1008, A)
-          v40:ArrayExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
+          PatchPoint StableConstantNames(0x1000, A)
+          v36:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint SingleRactorMode
-          PatchPoint StableConstantNames(0x1018, B)
-          v43:ArrayExact[VALUE(0x1020)] = Const Value(VALUE(0x1020))
-          PatchPoint NoSingletonClass(Array@0x1028)
-          PatchPoint MethodRedefined(Array@0x1028, zip@0x1030, cme:0x1038)
-          v47:BasicObject = CCallVariadic v40, :zip@0x1060, v43
-          v29:BasicObject = GetLocal :result, l0, EP@3
-          v33:BasicObject = GetLocal :result, l0, EP@3
+          PatchPoint StableConstantNames(0x1010, B)
+          v39:ArrayExact[VALUE(0x1018)] = Const Value(VALUE(0x1018))
+          PatchPoint NoSingletonClass(Array@0x1020)
+          PatchPoint MethodRedefined(Array@0x1020, zip@0x1028, cme:0x1030)
+          v43:BasicObject = CCallVariadic v36, :zip@0x1058, v39
+          v24:BasicObject = GetLocal :result, l0, EP@3
+          PatchPoint NoEPEscape(test)
           CheckInterrupts
-          Return v33
+          Return v24
         ");
     }
 
@@ -6569,12 +6557,12 @@ mod hir_opt_tests {
           v13:ArrayExact = NewArray
           v15:CPtr = GetEP 0
           v16:CInt64 = LoadField v15, :_env_data_index_flags@0x1000
-          v17:CInt64 = GuardNoBitsSet v16, CUInt64(512)
+          v17:CInt64 = GuardNoBitsSet v16, VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM=CUInt64(512)
           v18:CInt64 = LoadField v15, :_env_data_index_specval@0x1001
           v19:CInt64 = GuardAnyBitSet v18, CUInt64(1)
           v20:HeapObject[BlockParamProxy] = Const Value(VALUE(0x1008))
           IncrCounter complex_arg_pass_caller_blockarg
-          v22:BasicObject = Send v13, 0x1010, :map, v20 # SendFallbackReason: Complex argument passing
+          v22:BasicObject = Send v13, 0x1000, :map, v20 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v22
         ");
@@ -6600,12 +6588,12 @@ mod hir_opt_tests {
           v13:ArrayExact = NewArray
           v15:CPtr = GetEP 0
           v16:CInt64 = LoadField v15, :_env_data_index_flags@0x1000
-          v17:CInt64 = GuardNoBitsSet v16, CUInt64(512)
+          v17:CInt64 = GuardNoBitsSet v16, VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM=CUInt64(512)
           v18:CInt64 = LoadField v15, :_env_data_index_specval@0x1001
           v19:CInt64[0] = GuardBitEquals v18, CInt64(0)
           v20:NilClass = Const Value(nil)
           IncrCounter complex_arg_pass_caller_blockarg
-          v22:BasicObject = Send v13, 0x1008, :map, v20 # SendFallbackReason: Complex argument passing
+          v22:BasicObject = Send v13, 0x1000, :map, v20 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v22
         ");
@@ -6634,12 +6622,12 @@ mod hir_opt_tests {
           v10:ArrayExact = NewArray
           v12:CPtr = GetEP 1
           v13:CInt64 = LoadField v12, :_env_data_index_flags@0x1000
-          v14:CInt64 = GuardNoBitsSet v13, CUInt64(512)
+          v14:CInt64 = GuardNoBitsSet v13, VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM=CUInt64(512)
           v15:CInt64 = LoadField v12, :_env_data_index_specval@0x1001
           v16:CInt64 = GuardAnyBitSet v15, CUInt64(1)
           v17:HeapObject[BlockParamProxy] = Const Value(VALUE(0x1008))
           IncrCounter complex_arg_pass_caller_blockarg
-          v19:BasicObject = Send v10, 0x1010, :map, v17 # SendFallbackReason: Complex argument passing
+          v19:BasicObject = Send v10, 0x1000, :map, v17 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v19
         ");
@@ -6996,7 +6984,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(C@0x1000, foo=@0x1008, cme:0x1010)
           v29:HeapObject[class_exact:C] = GuardType v11, HeapObject[class_exact:C]
           v30:CUInt64 = LoadField v29, :_rbasic_flags@0x1038
-          v31:CUInt64 = GuardNoBitsSet v30, CUInt64(2048)
+          v31:CUInt64 = GuardNoBitsSet v30, RUBY_FL_FREEZE=CUInt64(2048)
           StoreField v29, :foo=@0x1039, v12
           WriteBarrier v29, v12
           CheckInterrupts
@@ -7029,7 +7017,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(C@0x1000, foo=@0x1008, cme:0x1010)
           v29:HeapObject[class_exact:C] = GuardType v11, HeapObject[class_exact:C]
           v30:CUInt64 = LoadField v29, :_rbasic_flags@0x1038
-          v31:CUInt64 = GuardNoBitsSet v30, CUInt64(2048)
+          v31:CUInt64 = GuardNoBitsSet v30, RUBY_FL_FREEZE=CUInt64(2048)
           v32:CPtr = LoadField v29, :_as_heap@0x1039
           StoreField v32, :foo=@0x103a, v12
           WriteBarrier v29, v12
@@ -7650,9 +7638,9 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Array@0x1000, []=@0x1008, cme:0x1010)
           v31:ArrayExact = GuardType v9, ArrayExact
           v32:CUInt64 = LoadField v31, :_rbasic_flags@0x1038
-          v33:CUInt64 = GuardNoBitsSet v32, CUInt64(2048)
+          v33:CUInt64 = GuardNoBitsSet v32, RUBY_FL_FREEZE=CUInt64(2048)
           v34:CUInt64 = LoadField v31, :_rbasic_flags@0x1038
-          v35:CUInt64 = GuardNoBitsSet v34, CUInt64(4096)
+          v35:CUInt64 = GuardNoBitsSet v34, RUBY_ELTS_SHARED=CUInt64(4096)
           v36:CInt64[1] = UnboxFixnum v16
           v37:CInt64 = ArrayLength v31
           v38:CInt64[1] = GuardLess v36, v37
@@ -7692,9 +7680,9 @@ mod hir_opt_tests {
           v35:ArrayExact = GuardType v13, ArrayExact
           v36:Fixnum = GuardType v14, Fixnum
           v37:CUInt64 = LoadField v35, :_rbasic_flags@0x1038
-          v38:CUInt64 = GuardNoBitsSet v37, CUInt64(2048)
+          v38:CUInt64 = GuardNoBitsSet v37, RUBY_FL_FREEZE=CUInt64(2048)
           v39:CUInt64 = LoadField v35, :_rbasic_flags@0x1038
-          v40:CUInt64 = GuardNoBitsSet v39, CUInt64(4096)
+          v40:CUInt64 = GuardNoBitsSet v39, RUBY_ELTS_SHARED=CUInt64(4096)
           v41:CInt64 = UnboxFixnum v36
           v42:CInt64 = ArrayLength v35
           v43:CInt64 = GuardLess v41, v42
@@ -8020,7 +8008,7 @@ mod hir_opt_tests {
           v36:CInt64[0] = Const CInt64(0)
           v37:CInt64 = GuardGreaterEq v35, v36
           v38:CUInt64 = LoadField v30, :_rbasic_flags@0x1039
-          v39:CUInt64 = GuardNoBitsSet v38, CUInt64(2048)
+          v39:CUInt64 = GuardNoBitsSet v38, RUBY_FL_FREEZE=CUInt64(2048)
           v40:Fixnum = StringSetbyteFixnum v30, v31, v32
           IncrCounter inline_cfunc_optimized_send_count
           CheckInterrupts
@@ -8062,7 +8050,7 @@ mod hir_opt_tests {
           v36:CInt64[0] = Const CInt64(0)
           v37:CInt64 = GuardGreaterEq v35, v36
           v38:CUInt64 = LoadField v30, :_rbasic_flags@0x1039
-          v39:CUInt64 = GuardNoBitsSet v38, CUInt64(2048)
+          v39:CUInt64 = GuardNoBitsSet v38, RUBY_FL_FREEZE=CUInt64(2048)
           v40:Fixnum = StringSetbyteFixnum v30, v31, v32
           IncrCounter inline_cfunc_optimized_send_count
           CheckInterrupts
@@ -8594,7 +8582,7 @@ mod hir_opt_tests {
           v12:Fixnum[3] = Const Value(3)
           v14:Fixnum[3] = Const Value(3)
           v16:Fixnum[3] = Const Value(3)
-          v18:BasicObject = SendWithoutBlock v10, :foo, v12, v14, v16 # SendFallbackReason: Argument count does not match parameter count
+          v18:BasicObject = Send v10, :foo, v12, v14, v16 # SendFallbackReason: Argument count does not match parameter count
           CheckInterrupts
           Return v18
         ");
@@ -8644,7 +8632,7 @@ mod hir_opt_tests {
           Jump bb2(v4)
         bb2(v6:BasicObject):
           v10:Fixnum[0] = Const Value(0)
-          v12:BasicObject = SendWithoutBlock v10, :foo # SendFallbackReason: Argument count does not match parameter count
+          v12:BasicObject = Send v10, :foo # SendFallbackReason: Argument count does not match parameter count
           CheckInterrupts
           Return v12
         ");
@@ -8667,7 +8655,7 @@ mod hir_opt_tests {
         bb2(v6:BasicObject):
           v10:Fixnum[4] = Const Value(4)
           v12:Fixnum[1] = Const Value(1)
-          v14:BasicObject = SendWithoutBlock v10, :succ, v12 # SendFallbackReason: SendWithoutBlock: unsupported method type Cfunc
+          v14:BasicObject = Send v10, :succ, v12 # SendFallbackReason: SendWithoutBlock: unsupported method type Cfunc
           CheckInterrupts
           Return v14
         ");
@@ -8821,7 +8809,7 @@ mod hir_opt_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v17:BasicObject = SendWithoutBlock v11, :^ # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v17:BasicObject = Send v11, :^ # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v17
         ");
@@ -9496,17 +9484,17 @@ mod hir_opt_tests {
           v13:ArrayExact = NewArray
           v19:ArrayExact = ToArray v13
           IncrCounter complex_arg_pass_caller_splat
-          v21:BasicObject = SendWithoutBlock v8, :foo, v19 # SendFallbackReason: Complex argument passing
+          v21:BasicObject = Send v8, :foo, v19 # SendFallbackReason: Complex argument passing
           v25:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v26:StringExact = StringCopy v25
           PatchPoint NoEPEscape(test)
           v31:ArrayExact = ToArray v13
           IncrCounter complex_arg_pass_caller_splat
-          v33:BasicObject = SendWithoutBlock v26, :display, v31 # SendFallbackReason: Complex argument passing
+          v33:BasicObject = Send v26, :display, v31 # SendFallbackReason: Complex argument passing
           PatchPoint NoEPEscape(test)
           v41:ArrayExact = ToArray v13
           IncrCounter complex_arg_pass_caller_splat
-          v43:BasicObject = SendWithoutBlock v8, :itself, v41 # SendFallbackReason: Complex argument passing
+          v43:BasicObject = Send v8, :itself, v41 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v43
         ");
@@ -10307,7 +10295,7 @@ mod hir_opt_tests {
           IncrCounter complex_arg_pass_param_rest
           IncrCounter complex_arg_pass_param_block
           IncrCounter complex_arg_pass_param_kwrest
-          v13:BasicObject = SendWithoutBlock v6, :fancy, v11 # SendFallbackReason: Complex argument passing
+          v13:BasicObject = Send v6, :fancy, v11 # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v13
         ");
@@ -10331,7 +10319,7 @@ mod hir_opt_tests {
           Jump bb2(v4)
         bb2(v6:BasicObject):
           IncrCounter complex_arg_pass_param_forwardable
-          v11:BasicObject = SendWithoutBlock v6, :forwardable # SendFallbackReason: Complex argument passing
+          v11:BasicObject = Send v6, :forwardable # SendFallbackReason: Complex argument passing
           CheckInterrupts
           Return v11
         ");
@@ -10570,7 +10558,7 @@ mod hir_opt_tests {
          CheckInterrupts
          v30:CPtr = GetEP 0
          v32:CInt64 = LoadField v30, :_env_data_index_flags@0x1000
-         v33:CInt64 = GuardNoBitsSet v32, CUInt64(8)
+         v33:CInt64 = GuardNoBitsSet v32, VM_ENV_FLAG_WB_REQUIRED=CUInt64(8)
          SetLocal :formatted, l0, EP@3, v15
          PatchPoint SingleRactorMode
          v61:HeapBasicObject = GuardType v14, HeapBasicObject
@@ -11069,7 +11057,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Obj)
           v21:HeapObject[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v13:BasicObject = SendWithoutBlock v21, :secret # SendFallbackReason: SendWithoutBlock: method private or protected and no FCALL
+          v13:BasicObject = Send v21, :secret # SendFallbackReason: SendWithoutBlock: method private or protected and no FCALL
           CheckInterrupts
           Return v13
         ");
@@ -11123,7 +11111,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Obj)
           v21:BasicObjectExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v13:BasicObject = SendWithoutBlock v21, :initialize # SendFallbackReason: SendWithoutBlock: method private or protected and no FCALL
+          v13:BasicObject = Send v21, :initialize # SendFallbackReason: SendWithoutBlock: method private or protected and no FCALL
           CheckInterrupts
           Return v13
         ");
@@ -11150,7 +11138,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Obj)
           v21:ObjectExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v13:BasicObject = SendWithoutBlock v21, :toplevel_method # SendFallbackReason: SendWithoutBlock: method private or protected and no FCALL
+          v13:BasicObject = Send v21, :toplevel_method # SendFallbackReason: SendWithoutBlock: method private or protected and no FCALL
           CheckInterrupts
           Return v13
         ");
@@ -11208,7 +11196,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Obj)
           v21:HeapObject[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v13:BasicObject = SendWithoutBlock v21, :secret # SendFallbackReason: SendWithoutBlock: method private or protected and no FCALL
+          v13:BasicObject = Send v21, :secret # SendFallbackReason: SendWithoutBlock: method private or protected and no FCALL
           CheckInterrupts
           Return v13
         ");
@@ -11247,7 +11235,7 @@ mod hir_opt_tests {
           EntryPoint JIT(0)
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:BasicObject):
-          v15:BasicObject = SendWithoutBlock v9, :length # SendFallbackReason: Singleton class previously created for receiver class
+          v15:BasicObject = Send v9, :length # SendFallbackReason: Singleton class previously created for receiver class
           CheckInterrupts
           Return v15
         ");
@@ -11593,7 +11581,7 @@ mod hir_opt_tests {
           v18:BasicObject = GetLocal :blk, l0, EP@4
           v21:CPtr = GetEP 0
           v23:CInt64 = LoadField v21, :_env_data_index_flags@0x1048
-          v24:CInt64 = GuardNoBitsSet v23, CUInt64(8)
+          v24:CInt64 = GuardNoBitsSet v23, VM_ENV_FLAG_WB_REQUIRED=CUInt64(8)
           SetLocal :other_block, l0, EP@3, v40
           v29:BasicObject = GetLocal :other_block, l0, EP@3
           v31:BasicObject = InvokeSuper v10, 0x1050, v29 # SendFallbackReason: super: complex argument passing to `super` call
@@ -11774,7 +11762,7 @@ mod hir_opt_tests {
           IfTrue v14, bb4(v8, v9, v9)
           v23:CBool = HasType v9, HeapObject[class_exact:D]
           IfTrue v23, bb5(v8, v9, v9)
-          v32:BasicObject = SendWithoutBlock v9, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          v32:BasicObject = Send v9, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
           Jump bb3(v8, v9, v32)
         bb4(v15:BasicObject, v16:BasicObject, v17:BasicObject):
           PatchPoint NoSingletonClass(C@0x1000)
@@ -11826,7 +11814,7 @@ mod hir_opt_tests {
           IfTrue v14, bb4(v8, v9, v9)
           v23:CBool = HasType v9, Fixnum
           IfTrue v23, bb5(v8, v9, v9)
-          v32:BasicObject = SendWithoutBlock v9, :itself # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          v32:BasicObject = Send v9, :itself # SendFallbackReason: SendWithoutBlock: polymorphic fallback
           Jump bb3(v8, v9, v32)
         bb4(v15:BasicObject, v16:BasicObject, v17:BasicObject):
           v19:HeapObject[class_exact:C] = RefineType v17, HeapObject[class_exact:C]

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -2941,15 +2941,18 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:Fixnum[1] = Const Value(1)
+          v15:CPtr = GetEP 0
+          v17:CInt64 = LoadField v15, :_env_data_index_flags@0x1000
+          v18:CInt64 = GuardNoBitsSet v17, CUInt64(8)
           SetLocal :a, l0, EP@3, v13
-          PatchPoint NoSingletonClass(Object@0x1000)
-          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v31:HeapObject[class_exact*:Object@VALUE(0x1000)] = GuardType v8, HeapObject[class_exact*:Object@VALUE(0x1000)]
+          PatchPoint NoSingletonClass(Object@0x1008)
+          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
+          v35:HeapObject[class_exact*:Object@VALUE(0x1008)] = GuardType v8, HeapObject[class_exact*:Object@VALUE(0x1008)]
           IncrCounter inline_iseq_optimized_send_count
-          v20:BasicObject = GetLocal :a, l0, EP@3
           v24:BasicObject = GetLocal :a, l0, EP@3
+          v28:BasicObject = GetLocal :a, l0, EP@3
           CheckInterrupts
-          Return v24
+          Return v28
         ");
     }
 
@@ -3430,15 +3433,18 @@ mod hir_opt_tests {
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:NilClass):
           v16:ArrayExact = NewArray
+          v18:CPtr = GetEP 0
+          v20:CInt64 = LoadField v18, :_env_data_index_flags@0x1000
+          v21:CInt64 = GuardNoBitsSet v20, CUInt64(8)
           SetLocal :a, l0, EP@3, v16
-          v22:TrueClass = Const Value(true)
+          v26:TrueClass = Const Value(true)
           IncrCounter complex_arg_pass_caller_kwarg
-          v24:BasicObject = Send v11, 0x1000, :each_line, v22 # SendFallbackReason: Complex argument passing
-          v25:BasicObject = GetLocal :s, l0, EP@4
-          v26:BasicObject = GetLocal :a, l0, EP@3
+          v28:BasicObject = Send v11, 0x1008, :each_line, v26 # SendFallbackReason: Complex argument passing
+          v29:BasicObject = GetLocal :s, l0, EP@4
           v30:BasicObject = GetLocal :a, l0, EP@3
+          v34:BasicObject = GetLocal :a, l0, EP@3
           CheckInterrupts
-          Return v30
+          Return v34
         ");
     }
 
@@ -6538,20 +6544,23 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:ArrayExact = NewArray
+          v15:CPtr = GetEP 0
+          v17:CInt64 = LoadField v15, :_env_data_index_flags@0x1000
+          v18:CInt64 = GuardNoBitsSet v17, CUInt64(8)
           SetLocal :result, l0, EP@3, v13
           PatchPoint SingleRactorMode
-          PatchPoint StableConstantNames(0x1000, A)
-          v36:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          PatchPoint StableConstantNames(0x1008, A)
+          v40:ArrayExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
           PatchPoint SingleRactorMode
-          PatchPoint StableConstantNames(0x1010, B)
-          v39:ArrayExact[VALUE(0x1018)] = Const Value(VALUE(0x1018))
-          PatchPoint NoSingletonClass(Array@0x1020)
-          PatchPoint MethodRedefined(Array@0x1020, zip@0x1028, cme:0x1030)
-          v43:BasicObject = CCallVariadic v36, :zip@0x1058, v39
-          v25:BasicObject = GetLocal :result, l0, EP@3
+          PatchPoint StableConstantNames(0x1018, B)
+          v43:ArrayExact[VALUE(0x1020)] = Const Value(VALUE(0x1020))
+          PatchPoint NoSingletonClass(Array@0x1028)
+          PatchPoint MethodRedefined(Array@0x1028, zip@0x1030, cme:0x1038)
+          v47:BasicObject = CCallVariadic v40, :zip@0x1060, v43
           v29:BasicObject = GetLocal :result, l0, EP@3
+          v33:BasicObject = GetLocal :result, l0, EP@3
           CheckInterrupts
-          Return v29
+          Return v33
         ");
     }
 
@@ -10577,25 +10586,28 @@ mod hir_opt_tests {
          Jump bb2(v8, v9, v10, v11, v12)
        bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:BasicObject, v18:NilClass):
          CheckInterrupts
+         v30:CPtr = GetEP 0
+         v32:CInt64 = LoadField v30, :_env_data_index_flags@0x1000
+         v33:CInt64 = GuardNoBitsSet v32, CUInt64(8)
          SetLocal :formatted, l0, EP@3, v15
          PatchPoint SingleRactorMode
-         v57:HeapBasicObject = GuardType v14, HeapBasicObject
-         v58:CShape = LoadField v57, :_shape_id@0x1000
-         v59:CShape[0x1001] = GuardBitEquals v58, CShape(0x1001)
-         StoreField v57, :@formatted@0x1002, v15
-         WriteBarrier v57, v15
-         v62:CShape[0x1003] = Const CShape(0x1003)
-         StoreField v57, :_shape_id@0x1000, v62
-         v46:Class[VMFrozenCore] = Const Value(VALUE(0x1008))
+         v61:HeapBasicObject = GuardType v14, HeapBasicObject
+         v62:CShape = LoadField v61, :_shape_id@0x1001
+         v63:CShape[0x1002] = GuardBitEquals v62, CShape(0x1002)
+         StoreField v61, :@formatted@0x1003, v15
+         WriteBarrier v61, v15
+         v66:CShape[0x1004] = Const CShape(0x1004)
+         StoreField v61, :_shape_id@0x1001, v66
+         v50:Class[VMFrozenCore] = Const Value(VALUE(0x1008))
          PatchPoint NoSingletonClass(Class@0x1010)
          PatchPoint MethodRedefined(Class@0x1010, lambda@0x1018, cme:0x1020)
-         v67:BasicObject = CCallWithFrame v46, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
-         v49:BasicObject = GetLocal :a, l0, EP@6
-         v50:BasicObject = GetLocal :_b, l0, EP@5
-         v51:BasicObject = GetLocal :_c, l0, EP@4
-         v52:BasicObject = GetLocal :formatted, l0, EP@3
+         v71:BasicObject = CCallWithFrame v50, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
+         v53:BasicObject = GetLocal :a, l0, EP@6
+         v54:BasicObject = GetLocal :_b, l0, EP@5
+         v55:BasicObject = GetLocal :_c, l0, EP@4
+         v56:BasicObject = GetLocal :formatted, l0, EP@3
          CheckInterrupts
-         Return v67
+         Return v71
        ");
     }
 
@@ -11594,14 +11606,17 @@ mod hir_opt_tests {
         bb2(v10:BasicObject, v11:BasicObject, v12:NilClass):
           PatchPoint NoSingletonClass(B@0x1000)
           PatchPoint MethodRedefined(B@0x1000, proc@0x1008, cme:0x1010)
-          v35:HeapObject[class_exact:B] = GuardType v10, HeapObject[class_exact:B]
-          v36:BasicObject = CCallWithFrame v35, :Kernel#proc@0x1038, block=0x1040
+          v39:HeapObject[class_exact:B] = GuardType v10, HeapObject[class_exact:B]
+          v40:BasicObject = CCallWithFrame v39, :Kernel#proc@0x1038, block=0x1040
           v18:BasicObject = GetLocal :blk, l0, EP@4
-          SetLocal :other_block, l0, EP@3, v36
-          v25:BasicObject = GetLocal :other_block, l0, EP@3
-          v27:BasicObject = InvokeSuper v10, 0x1048, v25 # SendFallbackReason: super: complex argument passing to `super` call
+          v21:CPtr = GetEP 0
+          v23:CInt64 = LoadField v21, :_env_data_index_flags@0x1048
+          v24:CInt64 = GuardNoBitsSet v23, CUInt64(8)
+          SetLocal :other_block, l0, EP@3, v40
+          v29:BasicObject = GetLocal :other_block, l0, EP@3
+          v31:BasicObject = InvokeSuper v10, 0x1050, v29 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
-          Return v27
+          Return v31
         ");
     }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -52,10 +52,10 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:TrueClass = Const Value(true)
           CheckInterrupts
-          v22:TrueClass = RefineType v13, Truthy
-          v25:Fixnum[3] = Const Value(3)
+          v23:TrueClass = RefineType v13, Truthy
+          v26:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -85,10 +85,10 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:FalseClass = Const Value(false)
           CheckInterrupts
-          v20:FalseClass = RefineType v13, Falsy
-          v35:Fixnum[4] = Const Value(4)
+          v21:FalseClass = RefineType v13, Falsy
+          v36:Fixnum[4] = Const Value(4)
           CheckInterrupts
-          Return v35
+          Return v36
         ");
     }
 
@@ -1486,10 +1486,10 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:Fixnum[2] = Const Value(2)
-          v17:Fixnum[1] = Const Value(1)
-          v25:RangeExact = NewRangeFixnum v17 NewRangeInclusive v13
+          v18:Fixnum[1] = Const Value(1)
+          v26:RangeExact = NewRangeFixnum v18 NewRangeInclusive v13
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -1516,10 +1516,10 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:Fixnum[2] = Const Value(2)
-          v17:Fixnum[1] = Const Value(1)
-          v25:RangeExact = NewRangeFixnum v17 NewRangeExclusive v13
+          v18:Fixnum[1] = Const Value(1)
+          v26:RangeExact = NewRangeFixnum v18 NewRangeExclusive v13
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -1653,9 +1653,9 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:ArrayExact = NewArray
-          v17:Fixnum[5] = Const Value(5)
+          v18:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -1746,9 +1746,9 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:RangeExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v17:Fixnum[5] = Const Value(5)
+          v18:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -1778,10 +1778,13 @@ mod hir_opt_tests {
           v16:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v17:StringExact = StringCopy v16
           v19:RangeExact = NewRange v14 NewRangeInclusive v17
+          v21:CPtr = GetEP 0
+          v23:CInt64 = LoadField v21, :_env_data_index_flags@0x1010
+          v24:CInt64 = GuardNoBitsSet v23, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v25:Fixnum[0] = Const Value(0)
+          v28:Fixnum[0] = Const Value(0)
           CheckInterrupts
-          Return v25
+          Return v28
         ");
     }
 
@@ -1808,9 +1811,9 @@ mod hir_opt_tests {
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:NilClass):
           v17:ArrayExact = NewArray v11
-          v21:Fixnum[5] = Const Value(5)
+          v22:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v21
+          Return v22
         ");
     }
 
@@ -1835,10 +1838,13 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:HashExact = NewHash
+          v15:CPtr = GetEP 0
+          v17:CInt64 = LoadField v15, :_env_data_index_flags@0x1000
+          v18:CInt64 = GuardNoBitsSet v17, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v19:Fixnum[5] = Const Value(5)
+          v22:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v19
+          Return v22
         ");
     }
 
@@ -1867,10 +1873,13 @@ mod hir_opt_tests {
           v19:StaticSymbol[:a] = Const Value(VALUE(0x1000))
           v22:StaticSymbol[:b] = Const Value(VALUE(0x1008))
           v25:HashExact = NewHash v19: v13, v22: v14
+          v27:CPtr = GetEP 0
+          v29:CInt64 = LoadField v27, :_env_data_index_flags@0x1010
+          v30:CInt64 = GuardNoBitsSet v29, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v31:Fixnum[5] = Const Value(5)
+          v34:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v31
+          Return v34
         ");
     }
 
@@ -1897,9 +1906,9 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v14:ArrayExact = ArrayDup v13
-          v18:Fixnum[5] = Const Value(5)
+          v19:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v18
+          Return v19
         ");
     }
 
@@ -1925,9 +1934,9 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v14:HashExact = HashDup v13
-          v18:Fixnum[5] = Const Value(5)
+          v19:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v18
+          Return v19
         ");
     }
 
@@ -1952,9 +1961,9 @@ mod hir_opt_tests {
           v6:NilClass = Const Value(nil)
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
-          v16:Fixnum[5] = Const Value(5)
+          v17:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v16
+          Return v17
         ");
     }
 
@@ -1981,9 +1990,9 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v14:StringExact = StringCopy v13
-          v18:Fixnum[5] = Const Value(5)
+          v19:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v18
+          Return v19
         ");
     }
 
@@ -2430,10 +2439,13 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Array@0x1000)
           PatchPoint MethodRedefined(Array@0x1000, itself@0x1008, cme:0x1010)
           IncrCounter inline_cfunc_optimized_send_count
+          v17:CPtr = GetEP 0
+          v19:CInt64 = LoadField v17, :_env_data_index_flags@0x1038
+          v20:CInt64 = GuardNoBitsSet v19, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v21:Fixnum[1] = Const Value(1)
+          v24:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v21
+          Return v24
         ");
     }
 
@@ -2461,15 +2473,18 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, M)
-          v29:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v32:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(Module@0x1010)
           PatchPoint MethodRedefined(Module@0x1010, name@0x1018, cme:0x1020)
           IncrCounter inline_cfunc_optimized_send_count
-          v34:StringExact|NilClass = CCall v29, :Module#name@0x1048
+          v37:StringExact|NilClass = CCall v32, :Module#name@0x1048
+          v18:CPtr = GetEP 0
+          v20:CInt64 = LoadField v18, :_env_data_index_flags@0x1050
+          v21:CInt64 = GuardNoBitsSet v20, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v22:Fixnum[1] = Const Value(1)
+          v25:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v22
+          Return v25
         ");
     }
 
@@ -2801,9 +2816,9 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, first@0x1010, cme:0x1018)
           IncrCounter inline_iseq_optimized_send_count
-          v31:BasicObject = InvokeBuiltin leaf <inline_expr>, v17
+          v32:BasicObject = InvokeBuiltin leaf <inline_expr>, v17
           CheckInterrupts
-          Return v31
+          Return v32
         ");
     }
 
@@ -4187,7 +4202,7 @@ mod hir_opt_tests {
             end
             test p
         ");
-        assert_snapshot!(hir_string("test"), @"
+        assert_snapshot!(hir_string("test"), @r"
         fn test@<compiled>:4:
         bb0():
           EntryPoint interpreter
@@ -4201,11 +4216,11 @@ mod hir_opt_tests {
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:NilClass):
           v16:ArrayExact = NewArray
-          v22:ArrayExact = ToArray v16
+          v23:ArrayExact = ToArray v16
           IncrCounter complex_arg_pass_caller_splat
-          v24:BasicObject = SendWithoutBlock v11, :call, v22 # SendFallbackReason: Complex argument passing
+          v25:BasicObject = SendWithoutBlock v11, :call, v23 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -5101,9 +5116,9 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:NilClass = Const Value(nil)
           CheckInterrupts
-          v21:NilClass = Const Value(nil)
+          v22:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v21
+          Return v22
         ");
     }
 
@@ -5130,11 +5145,11 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          v23:Fixnum[1] = RefineType v13, NotNil
+          v24:Fixnum[1] = RefineType v13, NotNil
           PatchPoint MethodRedefined(Integer@0x1000, itself@0x1008, cme:0x1010)
           IncrCounter inline_cfunc_optimized_send_count
           CheckInterrupts
-          Return v23
+          Return v24
         ");
     }
 
@@ -7281,18 +7296,18 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v14:ArrayExact = ArrayDup v13
-          v19:Fixnum[0] = Const Value(0)
+          v20:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v30:CInt64[0] = UnboxFixnum v19
-          v31:CInt64 = ArrayLength v14
-          v32:CInt64[0] = GuardLess v30, v31
-          v33:CInt64[0] = Const CInt64(0)
-          v34:CInt64[0] = GuardGreaterEq v32, v33
-          v35:BasicObject = ArrayAref v14, v34
+          v31:CInt64[0] = UnboxFixnum v20
+          v32:CInt64 = ArrayLength v14
+          v33:CInt64[0] = GuardLess v31, v32
+          v34:CInt64[0] = Const CInt64(0)
+          v35:CInt64[0] = GuardGreaterEq v33, v34
+          v36:BasicObject = ArrayAref v14, v35
           IncrCounter inline_cfunc_optimized_send_count
           CheckInterrupts
-          Return v35
+          Return v36
         ");
     }
 
@@ -7391,13 +7406,13 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v14:HashExact = HashDup v13
-          v19:Fixnum[1] = Const Value(1)
+          v20:Fixnum[1] = Const Value(1)
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, []@0x1010, cme:0x1018)
-          v30:BasicObject = HashAref v14, v19
+          v31:BasicObject = HashAref v14, v20
           IncrCounter inline_cfunc_optimized_send_count
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -7512,15 +7527,18 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:HashExact = NewHash
+          v15:CPtr = GetEP 0
+          v17:CInt64 = LoadField v15, :_env_data_index_flags@0x1000
+          v18:CInt64 = GuardNoBitsSet v17, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v22:Fixnum[1] = Const Value(1)
-          v24:Fixnum[3] = Const Value(3)
-          PatchPoint NoSingletonClass(Hash@0x1000)
-          PatchPoint MethodRedefined(Hash@0x1000, []=@0x1008, cme:0x1010)
-          HashAset v13, v22, v24
+          v25:Fixnum[1] = Const Value(1)
+          v27:Fixnum[3] = Const Value(3)
+          PatchPoint NoSingletonClass(Hash@0x1008)
+          PatchPoint MethodRedefined(Hash@0x1008, []=@0x1010, cme:0x1018)
+          HashAset v13, v25, v27
           IncrCounter inline_cfunc_optimized_send_count
           CheckInterrupts
-          Return v24
+          Return v27
         ");
     }
 
@@ -9485,21 +9503,21 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:ArrayExact = NewArray
-          v19:ArrayExact = ToArray v13
+          v20:ArrayExact = ToArray v13
           IncrCounter complex_arg_pass_caller_splat
-          v21:BasicObject = SendWithoutBlock v8, :foo, v19 # SendFallbackReason: Complex argument passing
-          v25:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v26:StringExact = StringCopy v25
+          v22:BasicObject = SendWithoutBlock v8, :foo, v20 # SendFallbackReason: Complex argument passing
+          v26:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v27:StringExact = StringCopy v26
           PatchPoint NoEPEscape(test)
-          v31:ArrayExact = ToArray v13
+          v32:ArrayExact = ToArray v13
           IncrCounter complex_arg_pass_caller_splat
-          v33:BasicObject = SendWithoutBlock v26, :display, v31 # SendFallbackReason: Complex argument passing
+          v34:BasicObject = SendWithoutBlock v27, :display, v32 # SendFallbackReason: Complex argument passing
           PatchPoint NoEPEscape(test)
-          v41:ArrayExact = ToArray v13
+          v42:ArrayExact = ToArray v13
           IncrCounter complex_arg_pass_caller_splat
-          v43:BasicObject = SendWithoutBlock v8, :itself, v41 # SendFallbackReason: Complex argument passing
+          v44:BasicObject = SendWithoutBlock v8, :itself, v42 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v43
+          Return v44
         ");
     }
 
@@ -11525,16 +11543,16 @@ mod hir_opt_tests {
         bb3(v15:BasicObject, v16:BasicObject, v17:BasicObject):
           EntryPoint JIT(1)
           Jump bb4(v15, v16, v17)
-        bb4(v27:BasicObject, v28:BasicObject, v29:BasicObject):
+        bb4(v28:BasicObject, v29:BasicObject, v30:BasicObject):
           PatchPoint MethodRedefined(String@0x1010, byteindex@0x1018, cme:0x1020)
-          v42:CPtr = GetLEP
-          v43:RubyValue = LoadField v42, :_ep_method_entry@0x1048
-          v44:CallableMethodEntry[VALUE(0x1050)] = GuardBitEquals v43, Value(VALUE(0x1050))
-          v45:RubyValue = LoadField v42, :_ep_specval@0x1058
-          v46:FalseClass = GuardBitEquals v45, Value(false)
-          v47:BasicObject = CCallVariadic v27, :String#byteindex@0x1060, v28, v29
+          v43:CPtr = GetLEP
+          v44:RubyValue = LoadField v43, :_ep_method_entry@0x1048
+          v45:CallableMethodEntry[VALUE(0x1050)] = GuardBitEquals v44, Value(VALUE(0x1050))
+          v46:RubyValue = LoadField v43, :_ep_specval@0x1058
+          v47:FalseClass = GuardBitEquals v46, Value(false)
+          v48:BasicObject = CCallVariadic v28, :String#byteindex@0x1060, v29, v30
           CheckInterrupts
-          Return v47
+          Return v48
         ");
     }
 
@@ -11670,10 +11688,10 @@ mod hir_opt_tests {
         bb3(v13:BasicObject, v14:BasicObject):
           EntryPoint JIT(1)
           Jump bb4(v13, v14)
-        bb4(v24:BasicObject, v25:BasicObject):
-          v31:BasicObject = InvokeSuper v24, 0x1018, v25 # SendFallbackReason: super: complex argument passing to `super` call
+        bb4(v25:BasicObject, v26:BasicObject):
+          v32:BasicObject = InvokeSuper v25, 0x1018, v26 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
-          Return v31
+          Return v32
         ");
     }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -52,10 +52,10 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:TrueClass = Const Value(true)
           CheckInterrupts
-          v23:TrueClass = RefineType v13, Truthy
-          v26:Fixnum[3] = Const Value(3)
+          v22:TrueClass = RefineType v13, Truthy
+          v25:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v26
+          Return v25
         ");
     }
 
@@ -85,10 +85,10 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:FalseClass = Const Value(false)
           CheckInterrupts
-          v21:FalseClass = RefineType v13, Falsy
-          v36:Fixnum[4] = Const Value(4)
+          v20:FalseClass = RefineType v13, Falsy
+          v35:Fixnum[4] = Const Value(4)
           CheckInterrupts
-          Return v36
+          Return v35
         ");
     }
 
@@ -1486,10 +1486,10 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:Fixnum[2] = Const Value(2)
-          v18:Fixnum[1] = Const Value(1)
-          v26:RangeExact = NewRangeFixnum v18 NewRangeInclusive v13
+          v17:Fixnum[1] = Const Value(1)
+          v25:RangeExact = NewRangeFixnum v17 NewRangeInclusive v13
           CheckInterrupts
-          Return v26
+          Return v25
         ");
     }
 
@@ -1516,10 +1516,10 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:Fixnum[2] = Const Value(2)
-          v18:Fixnum[1] = Const Value(1)
-          v26:RangeExact = NewRangeFixnum v18 NewRangeExclusive v13
+          v17:Fixnum[1] = Const Value(1)
+          v25:RangeExact = NewRangeFixnum v17 NewRangeExclusive v13
           CheckInterrupts
-          Return v26
+          Return v25
         ");
     }
 
@@ -1653,9 +1653,9 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:ArrayExact = NewArray
-          v18:Fixnum[5] = Const Value(5)
+          v17:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v18
+          Return v17
         ");
     }
 
@@ -1746,9 +1746,9 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:RangeExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v18:Fixnum[5] = Const Value(5)
+          v17:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v18
+          Return v17
         ");
     }
 
@@ -1779,9 +1779,9 @@ mod hir_opt_tests {
           v17:StringExact = StringCopy v16
           v19:RangeExact = NewRange v14 NewRangeInclusive v17
           PatchPoint NoEPEscape(test)
-          v25:Fixnum[0] = Const Value(0)
+          v24:Fixnum[0] = Const Value(0)
           CheckInterrupts
-          Return v25
+          Return v24
         ");
     }
 
@@ -1808,9 +1808,9 @@ mod hir_opt_tests {
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:NilClass):
           v17:ArrayExact = NewArray v11
-          v22:Fixnum[5] = Const Value(5)
+          v21:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v22
+          Return v21
         ");
     }
 
@@ -1836,9 +1836,9 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:HashExact = NewHash
           PatchPoint NoEPEscape(test)
-          v19:Fixnum[5] = Const Value(5)
+          v18:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v19
+          Return v18
         ");
     }
 
@@ -1868,9 +1868,9 @@ mod hir_opt_tests {
           v22:StaticSymbol[:b] = Const Value(VALUE(0x1008))
           v25:HashExact = NewHash v19: v13, v22: v14
           PatchPoint NoEPEscape(test)
-          v31:Fixnum[5] = Const Value(5)
+          v30:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v31
+          Return v30
         ");
     }
 
@@ -1897,9 +1897,9 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v14:ArrayExact = ArrayDup v13
-          v19:Fixnum[5] = Const Value(5)
+          v18:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v19
+          Return v18
         ");
     }
 
@@ -1925,9 +1925,9 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v14:HashExact = HashDup v13
-          v19:Fixnum[5] = Const Value(5)
+          v18:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v19
+          Return v18
         ");
     }
 
@@ -1952,9 +1952,9 @@ mod hir_opt_tests {
           v6:NilClass = Const Value(nil)
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
-          v17:Fixnum[5] = Const Value(5)
+          v16:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v17
+          Return v16
         ");
     }
 
@@ -1981,9 +1981,9 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v14:StringExact = StringCopy v13
-          v19:Fixnum[5] = Const Value(5)
+          v18:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v19
+          Return v18
         ");
     }
 
@@ -2431,9 +2431,9 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Array@0x1000, itself@0x1008, cme:0x1010)
           IncrCounter inline_cfunc_optimized_send_count
           PatchPoint NoEPEscape(test)
-          v21:Fixnum[1] = Const Value(1)
+          v20:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v21
+          Return v20
         ");
     }
 
@@ -2461,15 +2461,15 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, M)
-          v29:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v28:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(Module@0x1010)
           PatchPoint MethodRedefined(Module@0x1010, name@0x1018, cme:0x1020)
           IncrCounter inline_cfunc_optimized_send_count
-          v34:StringExact|NilClass = CCall v29, :Module#name@0x1048
+          v33:StringExact|NilClass = CCall v28, :Module#name@0x1048
           PatchPoint NoEPEscape(test)
-          v22:Fixnum[1] = Const Value(1)
+          v21:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v22
+          Return v21
         ");
     }
 
@@ -2801,9 +2801,9 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, first@0x1010, cme:0x1018)
           IncrCounter inline_iseq_optimized_send_count
-          v32:BasicObject = InvokeBuiltin leaf <inline_expr>, v17
+          v31:BasicObject = InvokeBuiltin leaf <inline_expr>, v17
           CheckInterrupts
-          Return v32
+          Return v31
         ");
     }
 
@@ -4207,11 +4207,11 @@ mod hir_opt_tests {
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:NilClass):
           v16:ArrayExact = NewArray
-          v23:ArrayExact = ToArray v16
+          v22:ArrayExact = ToArray v16
           IncrCounter complex_arg_pass_caller_splat
-          v25:BasicObject = SendWithoutBlock v11, :call, v23 # SendFallbackReason: Complex argument passing
+          v24:BasicObject = SendWithoutBlock v11, :call, v22 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v25
+          Return v24
         ");
     }
 
@@ -5107,9 +5107,9 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:NilClass = Const Value(nil)
           CheckInterrupts
-          v22:NilClass = Const Value(nil)
+          v21:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v22
+          Return v21
         ");
     }
 
@@ -5136,11 +5136,11 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          v24:Fixnum[1] = RefineType v13, NotNil
+          v23:Fixnum[1] = RefineType v13, NotNil
           PatchPoint MethodRedefined(Integer@0x1000, itself@0x1008, cme:0x1010)
           IncrCounter inline_cfunc_optimized_send_count
           CheckInterrupts
-          Return v24
+          Return v23
         ");
     }
 
@@ -7290,18 +7290,18 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v14:ArrayExact = ArrayDup v13
-          v20:Fixnum[0] = Const Value(0)
+          v19:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v31:CInt64[0] = UnboxFixnum v20
-          v32:CInt64 = ArrayLength v14
-          v33:CInt64[0] = GuardLess v31, v32
-          v34:CInt64[0] = Const CInt64(0)
-          v35:CInt64[0] = GuardGreaterEq v33, v34
-          v36:BasicObject = ArrayAref v14, v35
+          v30:CInt64[0] = UnboxFixnum v19
+          v31:CInt64 = ArrayLength v14
+          v32:CInt64[0] = GuardLess v30, v31
+          v33:CInt64[0] = Const CInt64(0)
+          v34:CInt64[0] = GuardGreaterEq v32, v33
+          v35:BasicObject = ArrayAref v14, v34
           IncrCounter inline_cfunc_optimized_send_count
           CheckInterrupts
-          Return v36
+          Return v35
         ");
     }
 
@@ -7400,13 +7400,13 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v14:HashExact = HashDup v13
-          v20:Fixnum[1] = Const Value(1)
+          v19:Fixnum[1] = Const Value(1)
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, []@0x1010, cme:0x1018)
-          v31:BasicObject = HashAref v14, v20
+          v30:BasicObject = HashAref v14, v19
           IncrCounter inline_cfunc_optimized_send_count
           CheckInterrupts
-          Return v31
+          Return v30
         ");
     }
 
@@ -7522,14 +7522,14 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           v13:HashExact = NewHash
           PatchPoint NoEPEscape(test)
-          v22:Fixnum[1] = Const Value(1)
-          v24:Fixnum[3] = Const Value(3)
+          v21:Fixnum[1] = Const Value(1)
+          v23:Fixnum[3] = Const Value(3)
           PatchPoint NoSingletonClass(Hash@0x1000)
           PatchPoint MethodRedefined(Hash@0x1000, []=@0x1008, cme:0x1010)
-          HashAset v13, v22, v24
+          HashAset v13, v21, v23
           IncrCounter inline_cfunc_optimized_send_count
           CheckInterrupts
-          Return v24
+          Return v23
         ");
     }
 
@@ -9494,21 +9494,21 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:ArrayExact = NewArray
-          v20:ArrayExact = ToArray v13
+          v19:ArrayExact = ToArray v13
           IncrCounter complex_arg_pass_caller_splat
-          v22:BasicObject = SendWithoutBlock v8, :foo, v20 # SendFallbackReason: Complex argument passing
-          v26:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v27:StringExact = StringCopy v26
+          v21:BasicObject = SendWithoutBlock v8, :foo, v19 # SendFallbackReason: Complex argument passing
+          v25:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v26:StringExact = StringCopy v25
           PatchPoint NoEPEscape(test)
-          v32:ArrayExact = ToArray v13
+          v31:ArrayExact = ToArray v13
           IncrCounter complex_arg_pass_caller_splat
-          v34:BasicObject = SendWithoutBlock v27, :display, v32 # SendFallbackReason: Complex argument passing
+          v33:BasicObject = SendWithoutBlock v26, :display, v31 # SendFallbackReason: Complex argument passing
           PatchPoint NoEPEscape(test)
-          v42:ArrayExact = ToArray v13
+          v41:ArrayExact = ToArray v13
           IncrCounter complex_arg_pass_caller_splat
-          v44:BasicObject = SendWithoutBlock v8, :itself, v42 # SendFallbackReason: Complex argument passing
+          v43:BasicObject = SendWithoutBlock v8, :itself, v41 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v44
+          Return v43
         ");
     }
 
@@ -11537,16 +11537,16 @@ mod hir_opt_tests {
         bb3(v15:BasicObject, v16:BasicObject, v17:BasicObject):
           EntryPoint JIT(1)
           Jump bb4(v15, v16, v17)
-        bb4(v28:BasicObject, v29:BasicObject, v30:BasicObject):
+        bb4(v27:BasicObject, v28:BasicObject, v29:BasicObject):
           PatchPoint MethodRedefined(String@0x1010, byteindex@0x1018, cme:0x1020)
-          v43:CPtr = GetLEP
-          v44:RubyValue = LoadField v43, :_ep_method_entry@0x1048
-          v45:CallableMethodEntry[VALUE(0x1050)] = GuardBitEquals v44, Value(VALUE(0x1050))
-          v46:RubyValue = LoadField v43, :_ep_specval@0x1058
-          v47:FalseClass = GuardBitEquals v46, Value(false)
-          v48:BasicObject = CCallVariadic v28, :String#byteindex@0x1060, v29, v30
+          v42:CPtr = GetLEP
+          v43:RubyValue = LoadField v42, :_ep_method_entry@0x1048
+          v44:CallableMethodEntry[VALUE(0x1050)] = GuardBitEquals v43, Value(VALUE(0x1050))
+          v45:RubyValue = LoadField v42, :_ep_specval@0x1058
+          v46:FalseClass = GuardBitEquals v45, Value(false)
+          v47:BasicObject = CCallVariadic v27, :String#byteindex@0x1060, v28, v29
           CheckInterrupts
-          Return v48
+          Return v47
         ");
     }
 
@@ -11685,10 +11685,10 @@ mod hir_opt_tests {
         bb3(v13:BasicObject, v14:BasicObject):
           EntryPoint JIT(1)
           Jump bb4(v13, v14)
-        bb4(v25:BasicObject, v26:BasicObject):
-          v32:BasicObject = InvokeSuper v25, 0x1018, v26 # SendFallbackReason: super: complex argument passing to `super` call
+        bb4(v24:BasicObject, v25:BasicObject):
+          v31:BasicObject = InvokeSuper v24, 0x1018, v25 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
-          Return v32
+          Return v31
         ");
     }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -1778,13 +1778,10 @@ mod hir_opt_tests {
           v16:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v17:StringExact = StringCopy v16
           v19:RangeExact = NewRange v14 NewRangeInclusive v17
-          v21:CPtr = GetEP 0
-          v23:CInt64 = LoadField v21, :_env_data_index_flags@0x1010
-          v24:CInt64 = GuardNoBitsSet v23, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v28:Fixnum[0] = Const Value(0)
+          v25:Fixnum[0] = Const Value(0)
           CheckInterrupts
-          Return v28
+          Return v25
         ");
     }
 
@@ -1838,13 +1835,10 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:HashExact = NewHash
-          v15:CPtr = GetEP 0
-          v17:CInt64 = LoadField v15, :_env_data_index_flags@0x1000
-          v18:CInt64 = GuardNoBitsSet v17, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v22:Fixnum[5] = Const Value(5)
+          v19:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v22
+          Return v19
         ");
     }
 
@@ -1873,13 +1867,10 @@ mod hir_opt_tests {
           v19:StaticSymbol[:a] = Const Value(VALUE(0x1000))
           v22:StaticSymbol[:b] = Const Value(VALUE(0x1008))
           v25:HashExact = NewHash v19: v13, v22: v14
-          v27:CPtr = GetEP 0
-          v29:CInt64 = LoadField v27, :_env_data_index_flags@0x1010
-          v30:CInt64 = GuardNoBitsSet v29, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v34:Fixnum[5] = Const Value(5)
+          v31:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v34
+          Return v31
         ");
     }
 
@@ -2439,13 +2430,10 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Array@0x1000)
           PatchPoint MethodRedefined(Array@0x1000, itself@0x1008, cme:0x1010)
           IncrCounter inline_cfunc_optimized_send_count
-          v17:CPtr = GetEP 0
-          v19:CInt64 = LoadField v17, :_env_data_index_flags@0x1038
-          v20:CInt64 = GuardNoBitsSet v19, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v24:Fixnum[1] = Const Value(1)
+          v21:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v24
+          Return v21
         ");
     }
 
@@ -2473,18 +2461,15 @@ mod hir_opt_tests {
         bb2(v8:BasicObject, v9:NilClass):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, M)
-          v32:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v29:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(Module@0x1010)
           PatchPoint MethodRedefined(Module@0x1010, name@0x1018, cme:0x1020)
           IncrCounter inline_cfunc_optimized_send_count
-          v37:StringExact|NilClass = CCall v32, :Module#name@0x1048
-          v18:CPtr = GetEP 0
-          v20:CInt64 = LoadField v18, :_env_data_index_flags@0x1050
-          v21:CInt64 = GuardNoBitsSet v20, CUInt64(8)
+          v34:StringExact|NilClass = CCall v29, :Module#name@0x1048
           PatchPoint NoEPEscape(test)
-          v25:Fixnum[1] = Const Value(1)
+          v22:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v25
+          Return v22
         ");
     }
 
@@ -7536,18 +7521,15 @@ mod hir_opt_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:HashExact = NewHash
-          v15:CPtr = GetEP 0
-          v17:CInt64 = LoadField v15, :_env_data_index_flags@0x1000
-          v18:CInt64 = GuardNoBitsSet v17, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v25:Fixnum[1] = Const Value(1)
-          v27:Fixnum[3] = Const Value(3)
-          PatchPoint NoSingletonClass(Hash@0x1008)
-          PatchPoint MethodRedefined(Hash@0x1008, []=@0x1010, cme:0x1018)
-          HashAset v13, v25, v27
+          v22:Fixnum[1] = Const Value(1)
+          v24:Fixnum[3] = Const Value(3)
+          PatchPoint NoSingletonClass(Hash@0x1000)
+          PatchPoint MethodRedefined(Hash@0x1000, []=@0x1008, cme:0x1010)
+          HashAset v13, v22, v24
           IncrCounter inline_cfunc_optimized_send_count
           CheckInterrupts
-          Return v27
+          Return v24
         ");
     }
 

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -151,7 +151,7 @@ mod snapshot_tests {
           v23:Fixnum[7] = Const Value(7)
           v25:Fixnum[8] = Const Value(8)
           v26:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v11, v13, v15, v17, v19, v21, v23, v25], locals: [] }
-          v27:BasicObject = SendWithoutBlock v6, :foo, v11, v13, v15, v17, v19, v21, v23, v25 # SendFallbackReason: Too many arguments for LIR
+          v27:BasicObject = Send v6, :foo, v11, v13, v15, v17, v19, v21, v23, v25 # SendFallbackReason: Too many arguments for LIR
           v28:Any = Snapshot FrameState { pc: 0x1010, stack: [v27], locals: [] }
           PatchPoint NoTracePoint
           CheckInterrupts
@@ -641,7 +641,7 @@ pub mod hir_build_tests {
         bb2(v6:BasicObject):
           v10:Fixnum[1] = Const Value(1)
           v12:Fixnum[2] = Const Value(2)
-          v15:BasicObject = SendWithoutBlock v10, :+, v12 # SendFallbackReason: Uncategorized(opt_plus)
+          v15:BasicObject = Send v10, :+, v12 # SendFallbackReason: Uncategorized(opt_plus)
           CheckInterrupts
           Return v15
         ");
@@ -893,21 +893,21 @@ pub mod hir_build_tests {
           v10:BasicObject = GetLocal :l2, l2, EP@4
           v12:CPtr = GetEP 1
           v13:CInt64 = LoadField v12, :_env_data_index_flags@0x1000
-          v14:CInt64 = GuardNoBitsSet v13, CUInt64(8)
+          v14:CInt64 = GuardNoBitsSet v13, VM_ENV_FLAG_WB_REQUIRED=CUInt64(8)
           SetLocal :l1, l1, EP@3, v10
           v18:BasicObject = GetLocal :l1, l1, EP@3
           v20:BasicObject = GetLocal :l2, l2, EP@4
-          v23:BasicObject = SendWithoutBlock v18, :+, v20 # SendFallbackReason: Uncategorized(opt_plus)
+          v23:BasicObject = Send v18, :+, v20 # SendFallbackReason: Uncategorized(opt_plus)
           v25:CPtr = GetEP 2
           v26:CInt64 = LoadField v25, :_env_data_index_flags@0x1000
-          v27:CInt64 = GuardNoBitsSet v26, CUInt64(8)
+          v27:CInt64 = GuardNoBitsSet v26, VM_ENV_FLAG_WB_REQUIRED=CUInt64(8)
           SetLocal :l2, l2, EP@4, v23
           v31:BasicObject = GetLocal :l2, l2, EP@4
           v33:BasicObject = GetLocal :l3, l3, EP@5
-          v36:BasicObject = SendWithoutBlock v31, :+, v33 # SendFallbackReason: Uncategorized(opt_plus)
+          v36:BasicObject = Send v31, :+, v33 # SendFallbackReason: Uncategorized(opt_plus)
           v39:CPtr = GetEP 3
           v40:CInt64 = LoadField v39, :_env_data_index_flags@0x1000
-          v41:CInt64 = GuardNoBitsSet v40, CUInt64(8)
+          v41:CInt64 = GuardNoBitsSet v40, VM_ENV_FLAG_WB_REQUIRED=CUInt64(8)
           SetLocal :l3, l3, EP@5, v36
           CheckInterrupts
           Return v36
@@ -1231,7 +1231,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :+, v12 # SendFallbackReason: Uncategorized(opt_plus)
+          v19:BasicObject = Send v11, :+, v12 # SendFallbackReason: Uncategorized(opt_plus)
           CheckInterrupts
           Return v19
         ");
@@ -1256,7 +1256,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :-, v12 # SendFallbackReason: Uncategorized(opt_minus)
+          v19:BasicObject = Send v11, :-, v12 # SendFallbackReason: Uncategorized(opt_minus)
           CheckInterrupts
           Return v19
         ");
@@ -1281,7 +1281,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :*, v12 # SendFallbackReason: Uncategorized(opt_mult)
+          v19:BasicObject = Send v11, :*, v12 # SendFallbackReason: Uncategorized(opt_mult)
           CheckInterrupts
           Return v19
         ");
@@ -1306,7 +1306,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :/, v12 # SendFallbackReason: Uncategorized(opt_div)
+          v19:BasicObject = Send v11, :/, v12 # SendFallbackReason: Uncategorized(opt_div)
           CheckInterrupts
           Return v19
         ");
@@ -1331,7 +1331,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :%, v12 # SendFallbackReason: Uncategorized(opt_mod)
+          v19:BasicObject = Send v11, :%, v12 # SendFallbackReason: Uncategorized(opt_mod)
           CheckInterrupts
           Return v19
         ");
@@ -1356,7 +1356,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :==, v12 # SendFallbackReason: Uncategorized(opt_eq)
+          v19:BasicObject = Send v11, :==, v12 # SendFallbackReason: Uncategorized(opt_eq)
           CheckInterrupts
           Return v19
         ");
@@ -1381,7 +1381,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :!=, v12 # SendFallbackReason: Uncategorized(opt_neq)
+          v19:BasicObject = Send v11, :!=, v12 # SendFallbackReason: Uncategorized(opt_neq)
           CheckInterrupts
           Return v19
         ");
@@ -1406,7 +1406,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :<, v12 # SendFallbackReason: Uncategorized(opt_lt)
+          v19:BasicObject = Send v11, :<, v12 # SendFallbackReason: Uncategorized(opt_lt)
           CheckInterrupts
           Return v19
         ");
@@ -1431,7 +1431,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :<=, v12 # SendFallbackReason: Uncategorized(opt_le)
+          v19:BasicObject = Send v11, :<=, v12 # SendFallbackReason: Uncategorized(opt_le)
           CheckInterrupts
           Return v19
         ");
@@ -1456,7 +1456,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :>, v12 # SendFallbackReason: Uncategorized(opt_gt)
+          v19:BasicObject = Send v11, :>, v12 # SendFallbackReason: Uncategorized(opt_gt)
           CheckInterrupts
           Return v19
         ");
@@ -1496,7 +1496,7 @@ pub mod hir_build_tests {
           Jump bb4(v10, v16, v20)
         bb4(v26:BasicObject, v27:BasicObject, v28:BasicObject):
           v32:Fixnum[0] = Const Value(0)
-          v35:BasicObject = SendWithoutBlock v28, :>, v32 # SendFallbackReason: Uncategorized(opt_gt)
+          v35:BasicObject = Send v28, :>, v32 # SendFallbackReason: Uncategorized(opt_gt)
           CheckInterrupts
           v38:CBool = Test v35
           v39:Truthy = RefineType v35, Truthy
@@ -1507,9 +1507,9 @@ pub mod hir_build_tests {
           Return v27
         bb3(v51:BasicObject, v52:BasicObject, v53:BasicObject):
           v58:Fixnum[1] = Const Value(1)
-          v61:BasicObject = SendWithoutBlock v52, :+, v58 # SendFallbackReason: Uncategorized(opt_plus)
+          v61:BasicObject = Send v52, :+, v58 # SendFallbackReason: Uncategorized(opt_plus)
           v66:Fixnum[1] = Const Value(1)
-          v69:BasicObject = SendWithoutBlock v53, :-, v66 # SendFallbackReason: Uncategorized(opt_minus)
+          v69:BasicObject = Send v53, :-, v66 # SendFallbackReason: Uncategorized(opt_minus)
           Jump bb4(v51, v61, v69)
         ");
     }
@@ -1533,7 +1533,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :>=, v12 # SendFallbackReason: Uncategorized(opt_ge)
+          v19:BasicObject = Send v11, :>=, v12 # SendFallbackReason: Uncategorized(opt_ge)
           CheckInterrupts
           Return v19
         ");
@@ -1602,7 +1602,7 @@ pub mod hir_build_tests {
         bb2(v6:BasicObject):
           v11:Fixnum[2] = Const Value(2)
           v13:Fixnum[3] = Const Value(3)
-          v15:BasicObject = SendWithoutBlock v6, :bar, v11, v13 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v15:BasicObject = Send v6, :bar, v11, v13 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v15
         ");
@@ -1689,7 +1689,7 @@ pub mod hir_build_tests {
           v18:StringExact = StringCopy v17
           v20:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
           v21:StringExact = StringCopy v20
-          v23:BasicObject = SendWithoutBlock v6, :unknown_method, v12, v15, v18, v21 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v23:BasicObject = Send v6, :unknown_method, v12, v15, v18, v21 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v23
         ");
@@ -1712,7 +1712,7 @@ pub mod hir_build_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:BasicObject):
           v15:ArrayExact = ToArray v9
-          v17:BasicObject = SendWithoutBlock v8, :foo, v15 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v17:BasicObject = Send v8, :foo, v15 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v17
         ");
@@ -1757,7 +1757,7 @@ pub mod hir_build_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:BasicObject):
           v14:Fixnum[1] = Const Value(1)
-          v16:BasicObject = SendWithoutBlock v8, :foo, v14 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v16:BasicObject = Send v8, :foo, v14 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v16
         ");
@@ -1779,7 +1779,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:BasicObject):
-          v15:BasicObject = SendWithoutBlock v8, :foo, v9 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v15:BasicObject = Send v8, :foo, v9 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v15
         ");
@@ -1914,7 +1914,7 @@ pub mod hir_build_tests {
         bb2(v8:BasicObject, v9:BasicObject):
           v15:BasicObject = InvokeSuperForward v8, 0x1000, v9 # SendFallbackReason: Uncategorized(invokesuperforward)
           v17:Fixnum[1] = Const Value(1)
-          v20:BasicObject = SendWithoutBlock v15, :+, v17 # SendFallbackReason: Uncategorized(opt_plus)
+          v20:BasicObject = Send v15, :+, v17 # SendFallbackReason: Uncategorized(opt_plus)
           CheckInterrupts
           Return v20
         ");
@@ -1984,12 +1984,12 @@ pub mod hir_build_tests {
           v14:Class[VMFrozenCore] = Const Value(VALUE(0x1000))
           v16:HashExact = NewHash
           PatchPoint NoEPEscape(test)
-          v21:BasicObject = SendWithoutBlock v14, :core#hash_merge_kwd, v16, v9 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v21:BasicObject = Send v14, :core#hash_merge_kwd, v16, v9 # SendFallbackReason: Uncategorized(opt_send_without_block)
           v23:Class[VMFrozenCore] = Const Value(VALUE(0x1000))
           v26:StaticSymbol[:b] = Const Value(VALUE(0x1008))
           v28:Fixnum[1] = Const Value(1)
-          v30:BasicObject = SendWithoutBlock v23, :core#hash_merge_ptr, v21, v26, v28 # SendFallbackReason: Uncategorized(opt_send_without_block)
-          v32:BasicObject = SendWithoutBlock v8, :foo, v30 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v30:BasicObject = Send v23, :core#hash_merge_ptr, v21, v26, v28 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v32:BasicObject = Send v8, :foo, v30 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v32
         ");
@@ -2014,7 +2014,7 @@ pub mod hir_build_tests {
           v15:ArrayExact = ToNewArray v9
           v17:Fixnum[1] = Const Value(1)
           ArrayPush v15, v17
-          v21:BasicObject = SendWithoutBlock v8, :foo, v15 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v21:BasicObject = Send v8, :foo, v15 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v21
         ");
@@ -2067,7 +2067,7 @@ pub mod hir_build_tests {
           PatchPoint NoEPEscape(test)
           v33:CPtr = GetEP 0
           v34:CInt64 = LoadField v33, :_env_data_index_flags@0x1000
-          v35:CInt64 = GuardNoBitsSet v34, CUInt64(512)
+          v35:CInt64 = GuardNoBitsSet v34, VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM=CUInt64(512)
           v36:CInt64 = LoadField v33, :_env_data_index_specval@0x1001
           v37:CInt64 = GuardAnyBitSet v36, CUInt64(1)
           v38:HeapObject[BlockParamProxy] = Const Value(VALUE(0x1008))
@@ -2097,11 +2097,11 @@ pub mod hir_build_tests {
           v16:CBool = IsMethodCFunc v11, :new
           IfFalse v16, bb3(v6, v13, v11)
           v18:HeapBasicObject = ObjectAlloc v11
-          v20:BasicObject = SendWithoutBlock v18, :initialize # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v20:BasicObject = Send v18, :initialize # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Jump bb4(v6, v18, v20)
         bb3(v24:BasicObject, v25:NilClass, v26:BasicObject):
-          v29:BasicObject = SendWithoutBlock v26, :new # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v29:BasicObject = Send v26, :new # SendFallbackReason: Uncategorized(opt_send_without_block)
           Jump bb4(v24, v29, v25)
         bb4(v32:BasicObject, v33:BasicObject, v34:BasicObject):
           CheckInterrupts
@@ -2214,7 +2214,7 @@ pub mod hir_build_tests {
           v12:NilClass = Const Value(nil)
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
-          v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v25:BasicObject = Send v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
           SideExit UnhandledNewarraySend(MIN)
         ");
     }
@@ -2246,13 +2246,13 @@ pub mod hir_build_tests {
           v12:NilClass = Const Value(nil)
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
-          v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v25:BasicObject = Send v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_HASH)
           v32:Fixnum = ArrayHash v15, v16
           PatchPoint NoEPEscape(test)
           v38:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v39:ArrayExact = ArrayDup v38
-          v41:BasicObject = SendWithoutBlock v14, :puts, v39 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v41:BasicObject = Send v14, :puts, v39 # SendFallbackReason: Uncategorized(opt_send_without_block)
           PatchPoint NoEPEscape(test)
           CheckInterrupts
           Return v32
@@ -2288,7 +2288,7 @@ pub mod hir_build_tests {
           v12:NilClass = Const Value(nil)
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
-          v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v25:BasicObject = Send v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_HASH))
         ");
     }
@@ -2320,7 +2320,7 @@ pub mod hir_build_tests {
           v12:NilClass = Const Value(nil)
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
-          v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v25:BasicObject = Send v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
           v31:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v32:StringExact = StringCopy v31
           SideExit UnhandledNewarraySend(PACK)
@@ -2354,7 +2354,7 @@ pub mod hir_build_tests {
           v12:NilClass = Const Value(nil)
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
-          v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v25:BasicObject = Send v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
           v29:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v30:StringExact = StringCopy v29
           v36:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
@@ -2398,7 +2398,7 @@ pub mod hir_build_tests {
           v12:NilClass = Const Value(nil)
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
-          v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v25:BasicObject = Send v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
           v29:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v30:StringExact = StringCopy v29
           v36:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
@@ -2435,13 +2435,13 @@ pub mod hir_build_tests {
           v12:NilClass = Const Value(nil)
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
-          v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v25:BasicObject = Send v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_INCLUDE_P)
           v33:BoolExact = ArrayInclude v15, v16 | v16
           PatchPoint NoEPEscape(test)
           v39:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           v40:ArrayExact = ArrayDup v39
-          v42:BasicObject = SendWithoutBlock v14, :puts, v40 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v42:BasicObject = Send v14, :puts, v40 # SendFallbackReason: Uncategorized(opt_send_without_block)
           PatchPoint NoEPEscape(test)
           CheckInterrupts
           Return v33
@@ -2482,7 +2482,7 @@ pub mod hir_build_tests {
           v12:NilClass = Const Value(nil)
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
-          v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v25:BasicObject = Send v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_INCLUDE_P))
         ");
     }
@@ -2561,7 +2561,7 @@ pub mod hir_build_tests {
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
           v18:ArrayExact = NewArray v11, v12
-          v21:BasicObject = SendWithoutBlock v18, :length # SendFallbackReason: Uncategorized(opt_length)
+          v21:BasicObject = Send v18, :length # SendFallbackReason: Uncategorized(opt_length)
           CheckInterrupts
           Return v21
         ");
@@ -2586,7 +2586,7 @@ pub mod hir_build_tests {
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
           v18:ArrayExact = NewArray v11, v12
-          v21:BasicObject = SendWithoutBlock v18, :size # SendFallbackReason: Uncategorized(opt_size)
+          v21:BasicObject = Send v18, :size # SendFallbackReason: Uncategorized(opt_size)
           CheckInterrupts
           Return v21
         ");
@@ -2957,7 +2957,7 @@ pub mod hir_build_tests {
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
           v16:NilClass = Const Value(nil)
           v20:Fixnum[1] = Const Value(1)
-          v24:BasicObject = SendWithoutBlock v11, :[]=, v12, v20 # SendFallbackReason: Uncategorized(opt_aset)
+          v24:BasicObject = Send v11, :[]=, v12, v20 # SendFallbackReason: Uncategorized(opt_aset)
           CheckInterrupts
           Return v20
         ");
@@ -2981,7 +2981,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :[], v12 # SendFallbackReason: Uncategorized(opt_aref)
+          v19:BasicObject = Send v11, :[], v12 # SendFallbackReason: Uncategorized(opt_aref)
           CheckInterrupts
           Return v19
         ");
@@ -3004,7 +3004,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:BasicObject):
-          v15:BasicObject = SendWithoutBlock v9, :empty? # SendFallbackReason: Uncategorized(opt_empty_p)
+          v15:BasicObject = Send v9, :empty? # SendFallbackReason: Uncategorized(opt_empty_p)
           CheckInterrupts
           Return v15
         ");
@@ -3027,7 +3027,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:BasicObject):
-          v15:BasicObject = SendWithoutBlock v9, :succ # SendFallbackReason: Uncategorized(opt_succ)
+          v15:BasicObject = Send v9, :succ # SendFallbackReason: Uncategorized(opt_succ)
           CheckInterrupts
           Return v15
         ");
@@ -3051,7 +3051,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :&, v12 # SendFallbackReason: Uncategorized(opt_and)
+          v19:BasicObject = Send v11, :&, v12 # SendFallbackReason: Uncategorized(opt_and)
           CheckInterrupts
           Return v19
         ");
@@ -3075,7 +3075,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :|, v12 # SendFallbackReason: Uncategorized(opt_or)
+          v19:BasicObject = Send v11, :|, v12 # SendFallbackReason: Uncategorized(opt_or)
           CheckInterrupts
           Return v19
         ");
@@ -3098,7 +3098,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:BasicObject):
-          v15:BasicObject = SendWithoutBlock v9, :! # SendFallbackReason: Uncategorized(opt_not)
+          v15:BasicObject = Send v9, :! # SendFallbackReason: Uncategorized(opt_not)
           CheckInterrupts
           Return v15
         ");
@@ -3122,7 +3122,7 @@ pub mod hir_build_tests {
           EntryPoint JIT(0)
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:BasicObject, v12:BasicObject):
-          v19:BasicObject = SendWithoutBlock v11, :=~, v12 # SendFallbackReason: Uncategorized(opt_regexpmatch2)
+          v19:BasicObject = Send v11, :=~, v12 # SendFallbackReason: Uncategorized(opt_regexpmatch2)
           CheckInterrupts
           Return v19
         ");
@@ -3152,7 +3152,7 @@ pub mod hir_build_tests {
           v12:BasicObject = PutSpecialObject CBase
           v14:StaticSymbol[:aliased] = Const Value(VALUE(0x1008))
           v16:StaticSymbol[:__callee__] = Const Value(VALUE(0x1010))
-          v18:BasicObject = SendWithoutBlock v10, :core#set_method_alias, v12, v14, v16 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v18:BasicObject = Send v10, :core#set_method_alias, v12, v14, v16 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v18
         ");
@@ -3254,7 +3254,7 @@ pub mod hir_build_tests {
           v17:NilClass = Const Value(nil)
           IfTrue v16, bb3(v8, v17, v17)
           v19:NotNil = RefineType v9, NotNil
-          v21:BasicObject = SendWithoutBlock v19, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v21:BasicObject = Send v19, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
           Jump bb3(v8, v19, v21)
         bb3(v23:BasicObject, v24:BasicObject, v25:BasicObject):
           CheckInterrupts
@@ -3296,7 +3296,7 @@ pub mod hir_build_tests {
           v25:NilClass = Const Value(nil)
           IfTrue v24, bb4(v8, v25, v25)
           v27:Truthy = RefineType v18, NotNil
-          v29:BasicObject = SendWithoutBlock v27, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v29:BasicObject = Send v27, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v29
         bb3(v34:BasicObject, v35:Falsy):
@@ -3444,7 +3444,7 @@ pub mod hir_build_tests {
           PatchPoint NoEPEscape(open)
           v30:CPtr = GetEP 0
           v31:CInt64 = LoadField v30, :_env_data_index_flags@0x1000
-          v32:CInt64 = GuardNoBitsSet v31, CUInt64(512)
+          v32:CInt64 = GuardNoBitsSet v31, VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM=CUInt64(512)
           v33:CInt64 = LoadField v30, :_env_data_index_specval@0x1001
           v34:CInt64 = GuardAnyBitSet v33, CUInt64(1)
           v35:HeapObject[BlockParamProxy] = Const Value(VALUE(0x1008))
@@ -3577,14 +3577,14 @@ pub mod hir_build_tests {
           v13:NilClass = Const Value(nil)
           v16:Fixnum[0] = Const Value(0)
           v18:Fixnum[1] = Const Value(1)
-          v21:BasicObject = SendWithoutBlock v9, :[], v16, v18 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v21:BasicObject = Send v9, :[], v16, v18 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           v25:CBool = Test v21
           v26:Truthy = RefineType v21, Truthy
           IfTrue v25, bb3(v8, v9, v13, v9, v16, v18, v26)
           v28:Falsy = RefineType v21, Falsy
           v31:Fixnum[2] = Const Value(2)
-          v34:BasicObject = SendWithoutBlock v9, :[]=, v16, v18, v31 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v34:BasicObject = Send v9, :[]=, v16, v18, v31 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
           Return v31
         bb3(v40:BasicObject, v41:BasicObject, v42:NilClass, v43:BasicObject, v44:Fixnum[0], v45:Fixnum[1], v46:Truthy):
@@ -3843,11 +3843,12 @@ pub mod hir_build_tests {
         bb2(v12:BasicObject, v13:BasicObject, v14:NilClass, v15:NilClass):
           v21:ArrayExact = GuardType v13, ArrayExact
           v22:CInt64 = ArrayLength v21
-          v23:CInt64[2] = GuardBitEquals v22, CInt64(2)
-          v24:CInt64[1] = Const CInt64(1)
-          v25:BasicObject = ArrayAref v21, v24
-          v26:CInt64[0] = Const CInt64(0)
-          v27:BasicObject = ArrayAref v21, v26
+          v23:CInt64[2] = Const CInt64(2)
+          v24:CInt64 = GuardGreaterEq v22, v23
+          v25:CInt64[1] = Const CInt64(1)
+          v26:BasicObject = ArrayAref v21, v25
+          v27:CInt64[0] = Const CInt64(0)
+          v28:BasicObject = ArrayAref v21, v27
           PatchPoint NoEPEscape(test)
           CheckInterrupts
           Return v13
@@ -3937,7 +3938,7 @@ pub mod hir_build_tests {
           v21:FalseClass = RefineType v15, Falsy
           v23:Fixnum[1] = Const Value(1)
           v25:Fixnum[1] = Const Value(1)
-          v28:BasicObject = SendWithoutBlock v23, :+, v25 # SendFallbackReason: Uncategorized(opt_plus)
+          v28:BasicObject = Send v23, :+, v25 # SendFallbackReason: Uncategorized(opt_plus)
           Jump bb3(v10, v28, v12)
         bb3(v31:BasicObject, v32:BasicObject, v33:BasicObject):
           CheckInterrupts

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -2263,12 +2263,10 @@ pub mod hir_build_tests {
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_HASH)
           v33:Fixnum = ArrayHash v15, v16
           v35:CPtr = GetEP 0
-          v37:CInt64 = LoadField v35, :_env_data_index_flags@0x1000
-          v38:CInt64 = GuardNoBitsSet v37, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v43:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v44:ArrayExact = ArrayDup v43
-          v46:BasicObject = SendWithoutBlock v14, :puts, v44 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v40:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v41:ArrayExact = ArrayDup v40
+          v43:BasicObject = SendWithoutBlock v14, :puts, v41 # SendFallbackReason: Uncategorized(opt_send_without_block)
           PatchPoint NoEPEscape(test)
           CheckInterrupts
           Return v33
@@ -2462,12 +2460,10 @@ pub mod hir_build_tests {
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_INCLUDE_P)
           v34:BoolExact = ArrayInclude v15, v16 | v16
           v36:CPtr = GetEP 0
-          v38:CInt64 = LoadField v36, :_env_data_index_flags@0x1000
-          v39:CInt64 = GuardNoBitsSet v38, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v44:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v45:ArrayExact = ArrayDup v44
-          v47:BasicObject = SendWithoutBlock v14, :puts, v45 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v41:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v42:ArrayExact = ArrayDup v41
+          v44:BasicObject = SendWithoutBlock v14, :puts, v42 # SendFallbackReason: Uncategorized(opt_send_without_block)
           PatchPoint NoEPEscape(test)
           CheckInterrupts
           Return v34
@@ -3223,14 +3219,12 @@ pub mod hir_build_tests {
           PatchPoint SingleRactorMode
           v26:BasicObject = GetIvar v12, :@c
           v29:CPtr = GetEP 0
-          v31:CInt64 = LoadField v29, :_env_data_index_flags@0x1000
-          v32:CInt64 = GuardNoBitsSet v31, CUInt64(8)
           PatchPoint NoEPEscape(reverse_odd)
-          v35:CPtr = GetEP 0
-          v37:CPtr = GetEP 0
-          v43:ArrayExact = NewArray v20, v23, v26
+          v32:CPtr = GetEP 0
+          v34:CPtr = GetEP 0
+          v40:ArrayExact = NewArray v20, v23, v26
           CheckInterrupts
-          Return v43
+          Return v40
 
         fn reverse_even@<compiled>:8:
         bb0():
@@ -3258,15 +3252,13 @@ pub mod hir_build_tests {
           PatchPoint SingleRactorMode
           v32:BasicObject = GetIvar v14, :@d
           v35:CPtr = GetEP 0
-          v37:CInt64 = LoadField v35, :_env_data_index_flags@0x1000
-          v38:CInt64 = GuardNoBitsSet v37, CUInt64(8)
           PatchPoint NoEPEscape(reverse_even)
-          v41:CPtr = GetEP 0
-          v43:CPtr = GetEP 0
-          v45:CPtr = GetEP 0
-          v52:ArrayExact = NewArray v23, v26, v29, v32
+          v38:CPtr = GetEP 0
+          v40:CPtr = GetEP 0
+          v42:CPtr = GetEP 0
+          v49:ArrayExact = NewArray v23, v26, v29, v32
           CheckInterrupts
-          Return v52
+          Return v49
         ");
     }
 
@@ -3480,27 +3472,25 @@ pub mod hir_build_tests {
         bb2(v16:BasicObject, v17:BasicObject, v18:BasicObject, v19:BasicObject, v20:BasicObject, v21:NilClass):
           v25:BasicObject = InvokeBuiltin dir_s_open, v16, v17, v18
           v27:CPtr = GetEP 0
-          v29:CInt64 = LoadField v27, :_env_data_index_flags@0x1000
-          v30:CInt64 = GuardNoBitsSet v29, CUInt64(8)
           PatchPoint NoEPEscape(open)
-          v34:CPtr = GetEP 0
-          v35:CInt64 = LoadField v34, :_env_data_index_flags@0x1000
-          v36:CInt64 = GuardNoBitsSet v35, CUInt64(512)
-          v37:CInt64 = LoadField v34, :_env_data_index_specval@0x1001
-          v38:CInt64 = GuardAnyBitSet v37, CUInt64(1)
-          v39:HeapObject[BlockParamProxy] = Const Value(VALUE(0x1008))
+          v31:CPtr = GetEP 0
+          v32:CInt64 = LoadField v31, :_env_data_index_flags@0x1000
+          v33:CInt64 = GuardNoBitsSet v32, CUInt64(512)
+          v34:CInt64 = LoadField v31, :_env_data_index_specval@0x1001
+          v35:CInt64 = GuardAnyBitSet v34, CUInt64(1)
+          v36:HeapObject[BlockParamProxy] = Const Value(VALUE(0x1008))
           CheckInterrupts
-          v42:CBool[true] = Test v39
-          v43 = RefineType v39, Falsy
-          IfFalse v42, bb3(v16, v17, v18, v19, v20, v25)
-          v45:HeapObject[BlockParamProxy] = RefineType v39, Truthy
-          v49:BasicObject = InvokeBlock, v25 # SendFallbackReason: Uncategorized(invokeblock)
-          v52:BasicObject = InvokeBuiltin dir_s_close, v16, v25
+          v39:CBool[true] = Test v36
+          v40 = RefineType v36, Falsy
+          IfFalse v39, bb3(v16, v17, v18, v19, v20, v25)
+          v42:HeapObject[BlockParamProxy] = RefineType v36, Truthy
+          v46:BasicObject = InvokeBlock, v25 # SendFallbackReason: Uncategorized(invokeblock)
+          v49:BasicObject = InvokeBuiltin dir_s_close, v16, v25
           CheckInterrupts
-          Return v49
-        bb3(v58, v59, v60, v61, v62, v63):
+          Return v46
+        bb3(v55, v56, v57, v58, v59, v60):
           CheckInterrupts
-          Return v63
+          Return v60
         ");
     }
 
@@ -3890,10 +3880,8 @@ pub mod hir_build_tests {
           v26:CInt64[0] = Const CInt64(0)
           v27:BasicObject = ArrayAref v21, v26
           v29:CPtr = GetEP 0
-          v31:CInt64 = LoadField v29, :_env_data_index_flags@0x1000
-          v32:CInt64 = GuardNoBitsSet v31, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v35:CPtr = GetEP 0
+          v32:CPtr = GetEP 0
           CheckInterrupts
           Return v13
         ");

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -256,14 +256,15 @@ pub mod hir_build_tests {
           Jump bb2(v9, v10)
         bb2(v16:BasicObject, v17:BasicObject):
           v20:Fixnum[1] = Const Value(1)
+          v22:CPtr = GetEP 0
           Jump bb4(v16, v20)
         bb3(v13:BasicObject, v14:BasicObject):
           EntryPoint JIT(1)
           Jump bb4(v13, v14)
-        bb4(v23:BasicObject, v24:BasicObject):
-          v28:Fixnum[123] = Const Value(123)
+        bb4(v24:BasicObject, v25:BasicObject):
+          v29:Fixnum[123] = Const Value(123)
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -853,6 +854,7 @@ pub mod hir_build_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:Fixnum[1] = Const Value(1)
+          v15:CPtr = GetEP 0
           CheckInterrupts
           Return v13
         ");
@@ -891,17 +893,26 @@ pub mod hir_build_tests {
           Jump bb2(v4)
         bb2(v6:BasicObject):
           v10:BasicObject = GetLocal :l2, l2, EP@4
+          v12:CPtr = GetEP 1
+          v13:CInt64 = LoadField v12, :_env_data_index_flags@0x1000
+          v14:CInt64 = GuardNoBitsSet v13, CUInt64(8)
           SetLocal :l1, l1, EP@3, v10
-          v15:BasicObject = GetLocal :l1, l1, EP@3
-          v17:BasicObject = GetLocal :l2, l2, EP@4
-          v20:BasicObject = SendWithoutBlock v15, :+, v17 # SendFallbackReason: Uncategorized(opt_plus)
-          SetLocal :l2, l2, EP@4, v20
-          v25:BasicObject = GetLocal :l2, l2, EP@4
-          v27:BasicObject = GetLocal :l3, l3, EP@5
-          v30:BasicObject = SendWithoutBlock v25, :+, v27 # SendFallbackReason: Uncategorized(opt_plus)
-          SetLocal :l3, l3, EP@5, v30
+          v18:BasicObject = GetLocal :l1, l1, EP@3
+          v20:BasicObject = GetLocal :l2, l2, EP@4
+          v23:BasicObject = SendWithoutBlock v18, :+, v20 # SendFallbackReason: Uncategorized(opt_plus)
+          v25:CPtr = GetEP 2
+          v26:CInt64 = LoadField v25, :_env_data_index_flags@0x1000
+          v27:CInt64 = GuardNoBitsSet v26, CUInt64(8)
+          SetLocal :l2, l2, EP@4, v23
+          v31:BasicObject = GetLocal :l2, l2, EP@4
+          v33:BasicObject = GetLocal :l3, l3, EP@5
+          v36:BasicObject = SendWithoutBlock v31, :+, v33 # SendFallbackReason: Uncategorized(opt_plus)
+          v39:CPtr = GetEP 3
+          v40:CInt64 = LoadField v39, :_env_data_index_flags@0x1000
+          v41:CInt64 = GuardNoBitsSet v40, CUInt64(8)
+          SetLocal :l3, l3, EP@5, v36
           CheckInterrupts
-          Return v30
+          Return v36
         "
         );
     }
@@ -931,15 +942,17 @@ pub mod hir_build_tests {
           Jump bb2(v10, v11, v12)
         bb2(v19:BasicObject, v20:BasicObject, v21:NilClass):
           v25:Fixnum[1] = Const Value(1)
+          v28:CPtr = GetEP 0
+          v30:CPtr = GetEP 0
           Jump bb4(v19, v25, v25)
         bb3(v15:BasicObject, v16:BasicObject):
           EntryPoint JIT(1)
           v17:NilClass = Const Value(nil)
           Jump bb4(v15, v16, v17)
-        bb4(v30:BasicObject, v31:BasicObject, v32:NilClass|Fixnum):
-          v38:ArrayExact = NewArray v31, v32
+        bb4(v32:BasicObject, v33:BasicObject, v34:NilClass|Fixnum):
+          v40:ArrayExact = NewArray v33, v34
           CheckInterrupts
-          Return v38
+          Return v40
         ");
     }
 
@@ -1192,14 +1205,16 @@ pub mod hir_build_tests {
           IfFalse v18, bb3(v10, v19, v12)
           v21:Truthy = RefineType v11, Truthy
           v24:Fixnum[3] = Const Value(3)
+          v26:CPtr = GetEP 0
           CheckInterrupts
           Jump bb4(v10, v21, v24)
-        bb3(v29:BasicObject, v30:Falsy, v31:NilClass):
-          v35:Fixnum[4] = Const Value(4)
-          Jump bb4(v29, v30, v35)
-        bb4(v38:BasicObject, v39:BasicObject, v40:Fixnum):
+        bb3(v30:BasicObject, v31:Falsy, v32:NilClass):
+          v36:Fixnum[4] = Const Value(4)
+          v38:CPtr = GetEP 0
+          Jump bb4(v30, v31, v36)
+        bb4(v40:BasicObject, v41:BasicObject, v42:Fixnum):
           CheckInterrupts
-          Return v40
+          Return v42
         ");
     }
 
@@ -1482,26 +1497,30 @@ pub mod hir_build_tests {
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:NilClass, v12:NilClass):
           v16:Fixnum[0] = Const Value(0)
-          v20:Fixnum[10] = Const Value(10)
+          v18:CPtr = GetEP 0
+          v21:Fixnum[10] = Const Value(10)
+          v23:CPtr = GetEP 0
           CheckInterrupts
-          Jump bb4(v10, v16, v20)
-        bb4(v26:BasicObject, v27:BasicObject, v28:BasicObject):
-          v32:Fixnum[0] = Const Value(0)
-          v35:BasicObject = SendWithoutBlock v28, :>, v32 # SendFallbackReason: Uncategorized(opt_gt)
+          Jump bb4(v10, v16, v21)
+        bb4(v28:BasicObject, v29:BasicObject, v30:BasicObject):
+          v34:Fixnum[0] = Const Value(0)
+          v37:BasicObject = SendWithoutBlock v30, :>, v34 # SendFallbackReason: Uncategorized(opt_gt)
           CheckInterrupts
-          v38:CBool = Test v35
-          v39:Truthy = RefineType v35, Truthy
-          IfTrue v38, bb3(v26, v27, v28)
-          v41:Falsy = RefineType v35, Falsy
-          v43:NilClass = Const Value(nil)
+          v40:CBool = Test v37
+          v41:Truthy = RefineType v37, Truthy
+          IfTrue v40, bb3(v28, v29, v30)
+          v43:Falsy = RefineType v37, Falsy
+          v45:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v27
-        bb3(v51:BasicObject, v52:BasicObject, v53:BasicObject):
-          v58:Fixnum[1] = Const Value(1)
-          v61:BasicObject = SendWithoutBlock v52, :+, v58 # SendFallbackReason: Uncategorized(opt_plus)
-          v66:Fixnum[1] = Const Value(1)
-          v69:BasicObject = SendWithoutBlock v53, :-, v66 # SendFallbackReason: Uncategorized(opt_minus)
-          Jump bb4(v51, v61, v69)
+          Return v29
+        bb3(v53:BasicObject, v54:BasicObject, v55:BasicObject):
+          v60:Fixnum[1] = Const Value(1)
+          v63:BasicObject = SendWithoutBlock v54, :+, v60 # SendFallbackReason: Uncategorized(opt_plus)
+          v65:CPtr = GetEP 0
+          v69:Fixnum[1] = Const Value(1)
+          v72:BasicObject = SendWithoutBlock v55, :-, v69 # SendFallbackReason: Uncategorized(opt_minus)
+          v74:CPtr = GetEP 0
+          Jump bb4(v53, v63, v72)
         ");
     }
 
@@ -1555,18 +1574,19 @@ pub mod hir_build_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:TrueClass = Const Value(true)
+          v15:CPtr = GetEP 0
           CheckInterrupts
-          v19:CBool[true] = Test v13
-          v20 = RefineType v13, Falsy
-          IfFalse v19, bb3(v8, v20)
-          v22:TrueClass = RefineType v13, Truthy
-          v25:Fixnum[3] = Const Value(3)
+          v20:CBool[true] = Test v13
+          v21 = RefineType v13, Falsy
+          IfFalse v20, bb3(v8, v21)
+          v23:TrueClass = RefineType v13, Truthy
+          v26:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v25
-        bb3(v30, v31):
-          v35 = Const Value(4)
+          Return v26
+        bb3(v31, v32):
+          v36 = Const Value(4)
           CheckInterrupts
-          Return v35
+          Return v36
         ");
     }
 
@@ -2206,6 +2226,7 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v27:CPtr = GetEP 0
           SideExit UnhandledNewarraySend(MIN)
         ");
     }
@@ -2238,15 +2259,19 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v27:CPtr = GetEP 0
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_HASH)
-          v32:Fixnum = ArrayHash v15, v16
+          v33:Fixnum = ArrayHash v15, v16
+          v35:CPtr = GetEP 0
+          v37:CInt64 = LoadField v35, :_env_data_index_flags@0x1000
+          v38:CInt64 = GuardNoBitsSet v37, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v39:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v40:ArrayExact = ArrayDup v39
-          v42:BasicObject = SendWithoutBlock v14, :puts, v40 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v43:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v44:ArrayExact = ArrayDup v43
+          v46:BasicObject = SendWithoutBlock v14, :puts, v44 # SendFallbackReason: Uncategorized(opt_send_without_block)
           PatchPoint NoEPEscape(test)
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 
@@ -2280,6 +2305,7 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v27:CPtr = GetEP 0
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_HASH))
         ");
     }
@@ -2312,8 +2338,9 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
-          v31:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v32:StringExact = StringCopy v31
+          v27:CPtr = GetEP 0
+          v32:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v33:StringExact = StringCopy v32
           SideExit UnhandledNewarraySend(PACK)
         ");
     }
@@ -2346,16 +2373,18 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
-          v29:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v30:StringExact = StringCopy v29
-          v36:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v37:StringExact = StringCopy v36
-          v39:BasicObject = GetLocal :buf, l0, EP@3
+          v27:CPtr = GetEP 0
+          v30:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v31:StringExact = StringCopy v30
+          v33:CPtr = GetEP 0
+          v38:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v39:StringExact = StringCopy v38
+          v41:BasicObject = GetLocal :buf, l0, EP@3
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_PACK)
-          v42:String = ArrayPackBuffer v15, v16, fmt: v37, buf: v39
+          v44:String = ArrayPackBuffer v15, v16, fmt: v39, buf: v41
           PatchPoint NoEPEscape(test)
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -2390,11 +2419,13 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
-          v29:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v30:StringExact = StringCopy v29
-          v36:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v37:StringExact = StringCopy v36
-          v39:BasicObject = GetLocal :buf, l0, EP@3
+          v27:CPtr = GetEP 0
+          v30:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v31:StringExact = StringCopy v30
+          v33:CPtr = GetEP 0
+          v38:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v39:StringExact = StringCopy v38
+          v41:BasicObject = GetLocal :buf, l0, EP@3
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_PACK))
         ");
     }
@@ -2427,15 +2458,19 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v27:CPtr = GetEP 0
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_INCLUDE_P)
-          v33:BoolExact = ArrayInclude v15, v16 | v16
+          v34:BoolExact = ArrayInclude v15, v16 | v16
+          v36:CPtr = GetEP 0
+          v38:CInt64 = LoadField v36, :_env_data_index_flags@0x1000
+          v39:CInt64 = GuardNoBitsSet v38, CUInt64(8)
           PatchPoint NoEPEscape(test)
-          v40:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v41:ArrayExact = ArrayDup v40
-          v43:BasicObject = SendWithoutBlock v14, :puts, v41 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v44:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v45:ArrayExact = ArrayDup v44
+          v47:BasicObject = SendWithoutBlock v14, :puts, v45 # SendFallbackReason: Uncategorized(opt_send_without_block)
           PatchPoint NoEPEscape(test)
           CheckInterrupts
-          Return v33
+          Return v34
         ");
     }
 
@@ -2474,6 +2509,7 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
+          v27:CPtr = GetEP 0
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_INCLUDE_P))
         ");
     }
@@ -3186,10 +3222,15 @@ pub mod hir_build_tests {
           v23:BasicObject = GetIvar v12, :@b
           PatchPoint SingleRactorMode
           v26:BasicObject = GetIvar v12, :@c
+          v29:CPtr = GetEP 0
+          v31:CInt64 = LoadField v29, :_env_data_index_flags@0x1000
+          v32:CInt64 = GuardNoBitsSet v31, CUInt64(8)
           PatchPoint NoEPEscape(reverse_odd)
-          v38:ArrayExact = NewArray v20, v23, v26
+          v35:CPtr = GetEP 0
+          v37:CPtr = GetEP 0
+          v43:ArrayExact = NewArray v20, v23, v26
           CheckInterrupts
-          Return v38
+          Return v43
 
         fn reverse_even@<compiled>:8:
         bb0():
@@ -3216,10 +3257,16 @@ pub mod hir_build_tests {
           v29:BasicObject = GetIvar v14, :@c
           PatchPoint SingleRactorMode
           v32:BasicObject = GetIvar v14, :@d
+          v35:CPtr = GetEP 0
+          v37:CInt64 = LoadField v35, :_env_data_index_flags@0x1000
+          v38:CInt64 = GuardNoBitsSet v37, CUInt64(8)
           PatchPoint NoEPEscape(reverse_even)
-          v46:ArrayExact = NewArray v23, v26, v29, v32
+          v41:CPtr = GetEP 0
+          v43:CPtr = GetEP 0
+          v45:CPtr = GetEP 0
+          v52:ArrayExact = NewArray v23, v26, v29, v32
           CheckInterrupts
-          Return v46
+          Return v52
         ");
     }
 
@@ -3432,25 +3479,28 @@ pub mod hir_build_tests {
           Jump bb2(v9, v10, v11, v12, v13, v14)
         bb2(v16:BasicObject, v17:BasicObject, v18:BasicObject, v19:BasicObject, v20:BasicObject, v21:NilClass):
           v25:BasicObject = InvokeBuiltin dir_s_open, v16, v17, v18
+          v27:CPtr = GetEP 0
+          v29:CInt64 = LoadField v27, :_env_data_index_flags@0x1000
+          v30:CInt64 = GuardNoBitsSet v29, CUInt64(8)
           PatchPoint NoEPEscape(open)
-          v31:CPtr = GetEP 0
-          v32:CInt64 = LoadField v31, :_env_data_index_flags@0x1000
-          v33:CInt64 = GuardNoBitsSet v32, CUInt64(512)
-          v34:CInt64 = LoadField v31, :_env_data_index_specval@0x1001
-          v35:CInt64 = GuardAnyBitSet v34, CUInt64(1)
-          v36:HeapObject[BlockParamProxy] = Const Value(VALUE(0x1008))
+          v34:CPtr = GetEP 0
+          v35:CInt64 = LoadField v34, :_env_data_index_flags@0x1000
+          v36:CInt64 = GuardNoBitsSet v35, CUInt64(512)
+          v37:CInt64 = LoadField v34, :_env_data_index_specval@0x1001
+          v38:CInt64 = GuardAnyBitSet v37, CUInt64(1)
+          v39:HeapObject[BlockParamProxy] = Const Value(VALUE(0x1008))
           CheckInterrupts
-          v39:CBool[true] = Test v36
-          v40 = RefineType v36, Falsy
-          IfFalse v39, bb3(v16, v17, v18, v19, v20, v25)
-          v42:HeapObject[BlockParamProxy] = RefineType v36, Truthy
-          v46:BasicObject = InvokeBlock, v25 # SendFallbackReason: Uncategorized(invokeblock)
-          v49:BasicObject = InvokeBuiltin dir_s_close, v16, v25
+          v42:CBool[true] = Test v39
+          v43 = RefineType v39, Falsy
+          IfFalse v42, bb3(v16, v17, v18, v19, v20, v25)
+          v45:HeapObject[BlockParamProxy] = RefineType v39, Truthy
+          v49:BasicObject = InvokeBlock, v25 # SendFallbackReason: Uncategorized(invokeblock)
+          v52:BasicObject = InvokeBuiltin dir_s_close, v16, v25
           CheckInterrupts
-          Return v46
-        bb3(v55, v56, v57, v58, v59, v60):
+          Return v49
+        bb3(v58, v59, v60, v61, v62, v63):
           CheckInterrupts
-          Return v60
+          Return v63
         ");
     }
 
@@ -3839,7 +3889,11 @@ pub mod hir_build_tests {
           v25:BasicObject = ArrayAref v21, v24
           v26:CInt64[0] = Const CInt64(0)
           v27:BasicObject = ArrayAref v21, v26
+          v29:CPtr = GetEP 0
+          v31:CInt64 = LoadField v29, :_env_data_index_flags@0x1000
+          v32:CInt64 = GuardNoBitsSet v31, CUInt64(8)
           PatchPoint NoEPEscape(test)
+          v35:CPtr = GetEP 0
           CheckInterrupts
           Return v13
         ");
@@ -3929,10 +3983,11 @@ pub mod hir_build_tests {
           v23:Fixnum[1] = Const Value(1)
           v25:Fixnum[1] = Const Value(1)
           v28:BasicObject = SendWithoutBlock v23, :+, v25 # SendFallbackReason: Uncategorized(opt_plus)
+          v30:CPtr = GetEP 0
           Jump bb3(v10, v28, v12)
-        bb3(v31:BasicObject, v32:BasicObject, v33:BasicObject):
+        bb3(v32:BasicObject, v33:BasicObject, v34:BasicObject):
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -256,15 +256,14 @@ pub mod hir_build_tests {
           Jump bb2(v9, v10)
         bb2(v16:BasicObject, v17:BasicObject):
           v20:Fixnum[1] = Const Value(1)
-          v22:CPtr = GetEP 0
           Jump bb4(v16, v20)
         bb3(v13:BasicObject, v14:BasicObject):
           EntryPoint JIT(1)
           Jump bb4(v13, v14)
-        bb4(v24:BasicObject, v25:BasicObject):
-          v29:Fixnum[123] = Const Value(123)
+        bb4(v23:BasicObject, v24:BasicObject):
+          v28:Fixnum[123] = Const Value(123)
           CheckInterrupts
-          Return v29
+          Return v28
         ");
     }
 
@@ -854,7 +853,6 @@ pub mod hir_build_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:Fixnum[1] = Const Value(1)
-          v15:CPtr = GetEP 0
           CheckInterrupts
           Return v13
         ");
@@ -942,17 +940,15 @@ pub mod hir_build_tests {
           Jump bb2(v10, v11, v12)
         bb2(v19:BasicObject, v20:BasicObject, v21:NilClass):
           v25:Fixnum[1] = Const Value(1)
-          v28:CPtr = GetEP 0
-          v30:CPtr = GetEP 0
           Jump bb4(v19, v25, v25)
         bb3(v15:BasicObject, v16:BasicObject):
           EntryPoint JIT(1)
           v17:NilClass = Const Value(nil)
           Jump bb4(v15, v16, v17)
-        bb4(v32:BasicObject, v33:BasicObject, v34:NilClass|Fixnum):
-          v40:ArrayExact = NewArray v33, v34
+        bb4(v30:BasicObject, v31:BasicObject, v32:NilClass|Fixnum):
+          v38:ArrayExact = NewArray v31, v32
           CheckInterrupts
-          Return v40
+          Return v38
         ");
     }
 
@@ -1205,16 +1201,14 @@ pub mod hir_build_tests {
           IfFalse v18, bb3(v10, v19, v12)
           v21:Truthy = RefineType v11, Truthy
           v24:Fixnum[3] = Const Value(3)
-          v26:CPtr = GetEP 0
           CheckInterrupts
           Jump bb4(v10, v21, v24)
-        bb3(v30:BasicObject, v31:Falsy, v32:NilClass):
-          v36:Fixnum[4] = Const Value(4)
-          v38:CPtr = GetEP 0
-          Jump bb4(v30, v31, v36)
-        bb4(v40:BasicObject, v41:BasicObject, v42:Fixnum):
+        bb3(v29:BasicObject, v30:Falsy, v31:NilClass):
+          v35:Fixnum[4] = Const Value(4)
+          Jump bb4(v29, v30, v35)
+        bb4(v38:BasicObject, v39:BasicObject, v40:Fixnum):
           CheckInterrupts
-          Return v42
+          Return v40
         ");
     }
 
@@ -1497,30 +1491,26 @@ pub mod hir_build_tests {
           Jump bb2(v6, v7, v8)
         bb2(v10:BasicObject, v11:NilClass, v12:NilClass):
           v16:Fixnum[0] = Const Value(0)
-          v18:CPtr = GetEP 0
-          v21:Fixnum[10] = Const Value(10)
-          v23:CPtr = GetEP 0
+          v20:Fixnum[10] = Const Value(10)
           CheckInterrupts
-          Jump bb4(v10, v16, v21)
-        bb4(v28:BasicObject, v29:BasicObject, v30:BasicObject):
-          v34:Fixnum[0] = Const Value(0)
-          v37:BasicObject = SendWithoutBlock v30, :>, v34 # SendFallbackReason: Uncategorized(opt_gt)
+          Jump bb4(v10, v16, v20)
+        bb4(v26:BasicObject, v27:BasicObject, v28:BasicObject):
+          v32:Fixnum[0] = Const Value(0)
+          v35:BasicObject = SendWithoutBlock v28, :>, v32 # SendFallbackReason: Uncategorized(opt_gt)
           CheckInterrupts
-          v40:CBool = Test v37
-          v41:Truthy = RefineType v37, Truthy
-          IfTrue v40, bb3(v28, v29, v30)
-          v43:Falsy = RefineType v37, Falsy
-          v45:NilClass = Const Value(nil)
+          v38:CBool = Test v35
+          v39:Truthy = RefineType v35, Truthy
+          IfTrue v38, bb3(v26, v27, v28)
+          v41:Falsy = RefineType v35, Falsy
+          v43:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v29
-        bb3(v53:BasicObject, v54:BasicObject, v55:BasicObject):
-          v60:Fixnum[1] = Const Value(1)
-          v63:BasicObject = SendWithoutBlock v54, :+, v60 # SendFallbackReason: Uncategorized(opt_plus)
-          v65:CPtr = GetEP 0
-          v69:Fixnum[1] = Const Value(1)
-          v72:BasicObject = SendWithoutBlock v55, :-, v69 # SendFallbackReason: Uncategorized(opt_minus)
-          v74:CPtr = GetEP 0
-          Jump bb4(v53, v63, v72)
+          Return v27
+        bb3(v51:BasicObject, v52:BasicObject, v53:BasicObject):
+          v58:Fixnum[1] = Const Value(1)
+          v61:BasicObject = SendWithoutBlock v52, :+, v58 # SendFallbackReason: Uncategorized(opt_plus)
+          v66:Fixnum[1] = Const Value(1)
+          v69:BasicObject = SendWithoutBlock v53, :-, v66 # SendFallbackReason: Uncategorized(opt_minus)
+          Jump bb4(v51, v61, v69)
         ");
     }
 
@@ -1574,19 +1564,18 @@ pub mod hir_build_tests {
           Jump bb2(v5, v6)
         bb2(v8:BasicObject, v9:NilClass):
           v13:TrueClass = Const Value(true)
-          v15:CPtr = GetEP 0
           CheckInterrupts
-          v20:CBool[true] = Test v13
-          v21 = RefineType v13, Falsy
-          IfFalse v20, bb3(v8, v21)
-          v23:TrueClass = RefineType v13, Truthy
-          v26:Fixnum[3] = Const Value(3)
+          v19:CBool[true] = Test v13
+          v20 = RefineType v13, Falsy
+          IfFalse v19, bb3(v8, v20)
+          v22:TrueClass = RefineType v13, Truthy
+          v25:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v26
-        bb3(v31, v32):
-          v36 = Const Value(4)
+          Return v25
+        bb3(v30, v31):
+          v35 = Const Value(4)
           CheckInterrupts
-          Return v36
+          Return v35
         ");
     }
 
@@ -2226,7 +2215,6 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
-          v27:CPtr = GetEP 0
           SideExit UnhandledNewarraySend(MIN)
         ");
     }
@@ -2259,17 +2247,15 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
-          v27:CPtr = GetEP 0
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_HASH)
-          v33:Fixnum = ArrayHash v15, v16
-          v35:CPtr = GetEP 0
+          v32:Fixnum = ArrayHash v15, v16
           PatchPoint NoEPEscape(test)
-          v40:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v41:ArrayExact = ArrayDup v40
-          v43:BasicObject = SendWithoutBlock v14, :puts, v41 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v38:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v39:ArrayExact = ArrayDup v38
+          v41:BasicObject = SendWithoutBlock v14, :puts, v39 # SendFallbackReason: Uncategorized(opt_send_without_block)
           PatchPoint NoEPEscape(test)
           CheckInterrupts
-          Return v33
+          Return v32
         ");
     }
 
@@ -2303,7 +2289,6 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
-          v27:CPtr = GetEP 0
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_HASH))
         ");
     }
@@ -2336,9 +2321,8 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
-          v27:CPtr = GetEP 0
-          v32:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v33:StringExact = StringCopy v32
+          v31:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v32:StringExact = StringCopy v31
           SideExit UnhandledNewarraySend(PACK)
         ");
     }
@@ -2371,18 +2355,16 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
-          v27:CPtr = GetEP 0
-          v30:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v31:StringExact = StringCopy v30
-          v33:CPtr = GetEP 0
-          v38:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v39:StringExact = StringCopy v38
-          v41:BasicObject = GetLocal :buf, l0, EP@3
+          v29:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v30:StringExact = StringCopy v29
+          v36:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v37:StringExact = StringCopy v36
+          v39:BasicObject = GetLocal :buf, l0, EP@3
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_PACK)
-          v44:String = ArrayPackBuffer v15, v16, fmt: v39, buf: v41
+          v42:String = ArrayPackBuffer v15, v16, fmt: v37, buf: v39
           PatchPoint NoEPEscape(test)
           CheckInterrupts
-          Return v31
+          Return v30
         ");
     }
 
@@ -2417,13 +2399,11 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
-          v27:CPtr = GetEP 0
-          v30:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v31:StringExact = StringCopy v30
-          v33:CPtr = GetEP 0
-          v38:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v39:StringExact = StringCopy v38
-          v41:BasicObject = GetLocal :buf, l0, EP@3
+          v29:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v30:StringExact = StringCopy v29
+          v36:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v37:StringExact = StringCopy v36
+          v39:BasicObject = GetLocal :buf, l0, EP@3
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_PACK))
         ");
     }
@@ -2456,17 +2436,15 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
-          v27:CPtr = GetEP 0
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_INCLUDE_P)
-          v34:BoolExact = ArrayInclude v15, v16 | v16
-          v36:CPtr = GetEP 0
+          v33:BoolExact = ArrayInclude v15, v16 | v16
           PatchPoint NoEPEscape(test)
-          v41:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v42:ArrayExact = ArrayDup v41
-          v44:BasicObject = SendWithoutBlock v14, :puts, v42 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v39:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v40:ArrayExact = ArrayDup v39
+          v42:BasicObject = SendWithoutBlock v14, :puts, v40 # SendFallbackReason: Uncategorized(opt_send_without_block)
           PatchPoint NoEPEscape(test)
           CheckInterrupts
-          Return v34
+          Return v33
         ");
     }
 
@@ -2505,7 +2483,6 @@ pub mod hir_build_tests {
           Jump bb2(v8, v9, v10, v11, v12)
         bb2(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass):
           v25:BasicObject = SendWithoutBlock v15, :+, v16 # SendFallbackReason: Uncategorized(opt_plus)
-          v27:CPtr = GetEP 0
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_INCLUDE_P))
         ");
     }
@@ -3218,13 +3195,10 @@ pub mod hir_build_tests {
           v23:BasicObject = GetIvar v12, :@b
           PatchPoint SingleRactorMode
           v26:BasicObject = GetIvar v12, :@c
-          v29:CPtr = GetEP 0
           PatchPoint NoEPEscape(reverse_odd)
-          v32:CPtr = GetEP 0
-          v34:CPtr = GetEP 0
-          v40:ArrayExact = NewArray v20, v23, v26
+          v37:ArrayExact = NewArray v20, v23, v26
           CheckInterrupts
-          Return v40
+          Return v37
 
         fn reverse_even@<compiled>:8:
         bb0():
@@ -3251,14 +3225,10 @@ pub mod hir_build_tests {
           v29:BasicObject = GetIvar v14, :@c
           PatchPoint SingleRactorMode
           v32:BasicObject = GetIvar v14, :@d
-          v35:CPtr = GetEP 0
           PatchPoint NoEPEscape(reverse_even)
-          v38:CPtr = GetEP 0
-          v40:CPtr = GetEP 0
-          v42:CPtr = GetEP 0
-          v49:ArrayExact = NewArray v23, v26, v29, v32
+          v45:ArrayExact = NewArray v23, v26, v29, v32
           CheckInterrupts
-          Return v49
+          Return v45
         ");
     }
 
@@ -3471,26 +3441,25 @@ pub mod hir_build_tests {
           Jump bb2(v9, v10, v11, v12, v13, v14)
         bb2(v16:BasicObject, v17:BasicObject, v18:BasicObject, v19:BasicObject, v20:BasicObject, v21:NilClass):
           v25:BasicObject = InvokeBuiltin dir_s_open, v16, v17, v18
-          v27:CPtr = GetEP 0
           PatchPoint NoEPEscape(open)
-          v31:CPtr = GetEP 0
-          v32:CInt64 = LoadField v31, :_env_data_index_flags@0x1000
-          v33:CInt64 = GuardNoBitsSet v32, CUInt64(512)
-          v34:CInt64 = LoadField v31, :_env_data_index_specval@0x1001
-          v35:CInt64 = GuardAnyBitSet v34, CUInt64(1)
-          v36:HeapObject[BlockParamProxy] = Const Value(VALUE(0x1008))
+          v30:CPtr = GetEP 0
+          v31:CInt64 = LoadField v30, :_env_data_index_flags@0x1000
+          v32:CInt64 = GuardNoBitsSet v31, CUInt64(512)
+          v33:CInt64 = LoadField v30, :_env_data_index_specval@0x1001
+          v34:CInt64 = GuardAnyBitSet v33, CUInt64(1)
+          v35:HeapObject[BlockParamProxy] = Const Value(VALUE(0x1008))
           CheckInterrupts
-          v39:CBool[true] = Test v36
-          v40 = RefineType v36, Falsy
-          IfFalse v39, bb3(v16, v17, v18, v19, v20, v25)
-          v42:HeapObject[BlockParamProxy] = RefineType v36, Truthy
-          v46:BasicObject = InvokeBlock, v25 # SendFallbackReason: Uncategorized(invokeblock)
-          v49:BasicObject = InvokeBuiltin dir_s_close, v16, v25
+          v38:CBool[true] = Test v35
+          v39 = RefineType v35, Falsy
+          IfFalse v38, bb3(v16, v17, v18, v19, v20, v25)
+          v41:HeapObject[BlockParamProxy] = RefineType v35, Truthy
+          v45:BasicObject = InvokeBlock, v25 # SendFallbackReason: Uncategorized(invokeblock)
+          v48:BasicObject = InvokeBuiltin dir_s_close, v16, v25
           CheckInterrupts
-          Return v46
-        bb3(v55, v56, v57, v58, v59, v60):
+          Return v45
+        bb3(v54, v55, v56, v57, v58, v59):
           CheckInterrupts
-          Return v60
+          Return v59
         ");
     }
 
@@ -3879,9 +3848,7 @@ pub mod hir_build_tests {
           v25:BasicObject = ArrayAref v21, v24
           v26:CInt64[0] = Const CInt64(0)
           v27:BasicObject = ArrayAref v21, v26
-          v29:CPtr = GetEP 0
           PatchPoint NoEPEscape(test)
-          v32:CPtr = GetEP 0
           CheckInterrupts
           Return v13
         ");
@@ -3971,11 +3938,10 @@ pub mod hir_build_tests {
           v23:Fixnum[1] = Const Value(1)
           v25:Fixnum[1] = Const Value(1)
           v28:BasicObject = SendWithoutBlock v23, :+, v25 # SendFallbackReason: Uncategorized(opt_plus)
-          v30:CPtr = GetEP 0
           Jump bb3(v10, v28, v12)
-        bb3(v32:BasicObject, v33:BasicObject, v34:BasicObject):
+        bb3(v31:BasicObject, v32:BasicObject, v33:BasicObject):
           CheckInterrupts
-          Return v33
+          Return v32
         ");
     }
 

--- a/zjit/src/hir_effect/gen_hir_effect.rb
+++ b/zjit/src/hir_effect/gen_hir_effect.rb
@@ -24,20 +24,20 @@ class Effect
 end
 
 # Helper to generate graphviz.
-def to_graphviz_rec effect
+def to_graphviz_rec effect, f
   effect.subeffects.each {|subeffect|
-    puts effect.name + "->" + subeffect.name + ";"
+    f.puts effect.name + "->" + subeffect.name + ";"
   }
-  effect.subeffect.each {|subeffect|
-    to_graphviz_rec subeffect
+  effect.subeffects.each {|subeffect|
+    to_graphviz_rec subeffect, f
   }
 end
 
 # Generate graphviz.
-def to_graphviz effect
-  puts "digraph G {"
-  to_graphviz_rec effect
-  puts "}"
+def to_graphviz effect, f
+  f.puts "digraph G {"
+  to_graphviz_rec effect, f
+  f.puts "}"
 end
 
 # ===== Start generating the effect DAG =====
@@ -117,3 +117,8 @@ $bits.keys.sort.map {|effect_name|
     puts "  pub const #{effect_name}: Effect = Effect::promote(abstract_heaps::#{effect_name});"
 }
 puts "}"
+
+File.open("zjit_effects.dot", "w") do |f|
+  to_graphviz(any, f)
+end
+

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -160,6 +160,8 @@ make_counters! {
         profile_time_ns,
         gc_time_ns,
         invalidation_time_ns,
+
+        side_exit_size,
     }
 
     // Exit counters that are summed as side_exit_count
@@ -254,6 +256,7 @@ make_counters! {
         send_fallback_send_cfunc_variadic,
         send_fallback_send_cfunc_array_variadic,
         send_fallback_super_call_with_block,
+        send_fallback_super_from_block,
         send_fallback_super_class_not_found,
         send_fallback_super_complex_args_pass,
         send_fallback_super_fallback_no_profile,
@@ -633,6 +636,7 @@ pub fn send_fallback_counter(reason: crate::hir::SendFallbackReason) -> Counter 
         CCallWithFrameTooManyArgs                 => send_fallback_ccall_with_frame_too_many_args,
         ObjToStringNotString                      => send_fallback_obj_to_string_not_string,
         SuperCallWithBlock                        => send_fallback_super_call_with_block,
+        SuperFromBlock                            => send_fallback_super_from_block,
         SuperClassNotFound                        => send_fallback_super_class_not_found,
         SuperComplexArgsPass                      => send_fallback_super_complex_args_pass,
         SuperNoProfiles                           => send_fallback_super_fallback_no_profile,

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -213,6 +213,7 @@ make_counters! {
         exit_block_param_proxy_not_nil,
         exit_block_param_wb_required,
         exit_too_many_keyword_parameters,
+        exit_write_barrier_required,
     }
 
     // Send fallback counters that are summed as dynamic_send_count
@@ -572,6 +573,7 @@ pub fn side_exit_counter(reason: crate::hir::SideExitReason) -> Counter {
         BlockParamProxyNotNil         => exit_block_param_proxy_not_nil,
         BlockParamWbRequired          => exit_block_param_wb_required,
         TooManyKeywordParameters      => exit_too_many_keyword_parameters,
+        WriteBarrierRequired          => exit_write_barrier_required,
         PatchPoint(Invariant::BOPRedefined { .. })
                                       => exit_patchpoint_bop_redefined,
         PatchPoint(Invariant::MethodRedefined { .. })

--- a/zjit/zjit.mk
+++ b/zjit/zjit.mk
@@ -20,14 +20,14 @@ BUILD_ZJIT_LIBS = $(TOP_BUILD_DIR)/$(ZJIT_LIBS)
 
 # In a ZJIT-only build (no YJIT)
 ifneq ($(strip $(ZJIT_LIBS)),)
-$(BUILD_ZJIT_LIBS): $(ZJIT_SRC_FILES)
+$(BUILD_ZJIT_LIBS): $(ZJIT_SRC_FILES) target/.rustc-version
 	$(ECHO) 'building Rust ZJIT (release mode)'
 	$(gnumake_recursive)$(Q) $(RUSTC) $(ZJIT_RUSTC_ARGS)
 else ifneq ($(strip $(RLIB_DIR)),) # combo build
 # Absolute path to avoid VPATH ambiguity
 ZJIT_RLIB = $(TOP_BUILD_DIR)/$(RLIB_DIR)/libzjit.rlib
 
-$(ZJIT_RLIB): $(ZJIT_SRC_FILES)
+$(ZJIT_RLIB): $(ZJIT_SRC_FILES) target/.rustc-version
 	$(ECHO) 'building $(@F)'
 	$(gnumake_recursive)$(Q) $(RUSTC) '-L$(@D)' --extern=jit $(ZJIT_RUSTC_ARGS)
 


### PR DESCRIPTION
This PR moves logic out of `Insn::SetLocal` and into `YARVINSN_setlocal`, `YARVINSN_setlocal_WC_0`, and `YARVINSN_setlocal_WC_1` using @39bytes's new `GetEP` and `GuardNoBitsSet` instructions. The overall effect of this change is to replace setlocal side exits with guards.

Co-authored with @jhawthorn