### PR TITLE
Lock to install uutils-coreutils@0.5.0

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -83,7 +83,8 @@ jobs:
           Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
           iwr -useb get.scoop.sh | iex
           Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
-          scoop install vcpkg uutils-coreutils
+          scoop install vcpkg
+          scoop install uutils-coreutils@0.5.0
         shell: pwsh
 
       - name: Restore vcpkg artifact


### PR DESCRIPTION
Try to avoid the following error:

```
Installing 'uutils-coreutils' (0.6.0) [64bit] from 'main' bucket
Downloading https://github.com/uutils/coreutils/releases/download/0.6.0/coreutils-0.6.0-x86_64-pc-windows-msvc.zip (4.8 MB)...
Checking hash of coreutils-0.6.0-x86_64-pc-windows-msvc.zip ... ok.
Exception: C:\Users\runneradmin\scoop\apps\scoop\current\lib\core.ps1:824
Line |
 824 |          throw "Could not find '$(fname $from)'! (error $($proc.ExitCo …
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Could not find 'coreutils-0.6.0-x86_64-pc-windows-msvc'! (error 16)
Extracting coreutils-0.6.0-x86_64-pc-windows-msvc.zip ... 
```