### PR TITLE
mswin: configure.bat use shellsplit.cmd command line parsing

### DIFF
--- a/win32/configure.bat
+++ b/win32/configure.bat
@@ -7,6 +7,19 @@ goto :main
 set %*
 exit /b
 
+:shift
+call %~dp0shellsplit.cmd
+set "argv1=%argv2%"
+set "argv2=%argv%"
+if not defined argv1 if defined argv2 goto :shift
+exit /b
+
+:take_arg
+if defined arg exit /b
+if not defined argv2 exit /b
+if not "%argv2:~0,1%"=="-" (set "arg=%argv2%" & call :shift)
+exit /b
+
 :main
 if "%~dp0" == "%CD%\" (
     echo don't run in win32 directory.
@@ -25,6 +38,7 @@ call :set "WIN32DIR=%%WIN32DIR:/%~n0:/:=:/:%%"
 set "WIN32DIR=%WIN32DIR:~0,-3%"
 
 set configure=%~0
+set args=%*
 set target=
 set optdirs=
 set pathlist=
@@ -34,12 +48,21 @@ set debug_configure=
 echo>%config_make% # CONFIGURE
 type nul > %confargs%
 :loop
-if [%1] == [] goto :end ;
-if "%~1" == "" (shift & goto :loop)
-for /f "delims== tokens=1,*" %%I in ("%~1") do ((set "opt=%%I") && (set "arg=%%J"))
-  set "eq=="
-  if "%arg%" == "" if not "%~1" == "%opt%=%arg%" (set "eq=")
-  shift
+call :shift
+if not defined argv1 goto :end
+for /f "delims== tokens=1,*" %%I in (" %argv1% ") do ((set "opt=%%I") && (set "arg=%%J"))
+  set "opt=%opt:~1%"
+  if defined arg (
+    set "eq=="
+    set "arg=%arg:~0,-1%"
+  ) else (
+    set "eq="
+    set "opt=%opt:~0,-1%"
+  )
+  if "%opt%"=="" (
+    echo 1>&2 %configure%: assignment for empty variable name %argv1%
+    exit /b 1
+  )
   if "%opt%" == "--debug-configure" (
     echo on
     set "debug_configure=yes"
@@ -85,7 +108,7 @@ for /f "delims== tokens=1,*" %%I in ("%~1") do ((set "opt=%%I") && (set "arg=%%J
   )
 goto :loop ;
 :target
-  if "%eq%" == "" (set "arg=%~1" & shift)
+  if "%eq%" == "" call :take_arg
   if "%arg%" == "" (
     echo 1>&2 %configure%: missing argument for %opt%
     exit /b 1
@@ -105,32 +128,37 @@ goto :loop ;
   )
 goto :unknown_opt
 :name
-  if "%eq%" == "" (set "arg=%~1" & shift)
+  if "%eq%" == "" call :take_arg
   echo>> %config_make% %var% = %arg%
 goto :loopend ;
 :dir
-  if "%eq%" == "" (set "arg=%~1" & shift)
+  if "%eq%" == "" call :take_arg
   echo>> %config_make% %opt:~2% = %arg:\=/%
 goto :loopend ;
 :enable
-  echo>>%confargs%  "%opt%" \
-  if %enable% == yes (set "opt=%opt:~9%") else (set "opt=%opt:~10%")
-  if "%opt%" == "install-doc" (
+  if %enable% == yes (
+    if "%eq%" == "" call :take_arg
+    set "feature=%opt:~9%"
+  ) else (
+    set "feature=%opt:~10%"
+  )
+  if %enable% == yes if defined arg (set "enable=%arg%")
+  if "%feature%" == "install-doc" (
     echo>> %config_make% RDOCTARGET = %enable:yes=r%doc
   )
-  if "%opt%" == "install-static-library" (
+  if "%feature%" == "install-static-library" (
     echo>> %config_make% INSTALL_STATIC_LIBRARY = %enable%
   )
-  if "%opt%" == "debug-env" (
+  if "%feature%" == "debug-env" (
     echo>> %config_make% ENABLE_DEBUG_ENV = %enable%
   )
-  if "%opt%" == "devel" (
+  if "%feature%" == "devel" (
     echo>> %config_make% RUBY_DEVEL = %enable%
   )
-  if "%opt%" == "rubygems" (
-    echo>> %config_make% USE_RUBYGEMS = %enable%
+  if "%feature%" == "rubygems" (
+     echo>> %config_make% USE_RUBYGEMS = %enable%
   )
-goto :loop ;
+goto :loopend ;
 :withoutarg
   echo>>%confargs%  "%opt%" \
   if "%opt%" == "--without-baseruby" goto :nobaseruby
@@ -140,7 +168,7 @@ goto :loop ;
 goto :loop ;
 :witharg
   if "%opt%" == "--with-static-linked-ext" goto :extstatic
-  if "%eq%" == "" (set "arg=%~1" & shift)
+  if "%eq%" == "" call :take_arg
   if not "%arg%" == "" (
     echo>>%confargs%  "%opt%=%arg:$=$$%" \
   ) else (
@@ -158,7 +186,7 @@ goto :loop ;
 :ntver
   ::- For version constants, see
   ::- https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt#remarks
-  if "%eq%" == "" (set "NTVER=%~1" & shift) else (set "NTVER=%arg%")
+  if "%eq%" == "" (set "NTVER=%~1" & call :shift) else (set "NTVER=%arg%")
   if /i not "%NTVER:~0,2%" == "0x" if /i not "%NTVER:~0,13%" == "_WIN32_WINNT_" (
     for %%i in (A B C D E F G H I J K L M N O P Q R S T U V W X Y Z) do (
       call :set NTVER=%%NTVER:%%i=%%i%%
@@ -168,11 +196,11 @@ goto :loop ;
   echo>> %config_make% NTVER = %NTVER%
 goto :loopend ;
 :extout
-  if "%eq%" == "" (set "arg=%~1" & shift)
+  if "%eq%" == "" call :take_arg
   if not "%arg%" == ".ext" (echo>> %config_make% EXTOUT = %arg%)
 goto :loopend ;
 :path
-  if "%eq%" == "" (set "arg=%~1" & shift)
+  if "%eq%" == "" call :take_arg
   set "pathlist=%pathlist%%arg:\=/%;"
 goto :loopend ;
 :extstatic
@@ -236,7 +264,7 @@ goto :loop ;
   echo   --with-ntver=0xXXXX     target NT version (shouldn't use with old SDK)
   echo   --with-ntver=_WIN32_WINNT_XXXX
   echo   --with-ntver=XXXX       same as --with-ntver=_WIN32_WINNT_XXXX
-  echo Note that '[1m=,;[m' need to be enclosed within double quotes in batch file command line.
+  echo Note that parameters containing spaces must be enclosed within double quotes.
   del %confargs% %config_make%
 goto :EOF
 :unknown_opt

--- a/win32/shellsplit.cmd
+++ b/win32/shellsplit.cmd
@@ -1,0 +1,114 @@
+setlocal EnableExtensions DisableDelayedExpansion
+if not defined V set V=0
+if not defined args (
+ goto :return_arg
+)
+set INPUT=%args%
+set OUTBUF=
+set UNQ=
+set QTD=
+
+set INPUT=%INPUT:#=#35%
+set INPUT=%INPUT:@=#64%
+set "PENDING=%INPUT:"=@sep%" &:: escape double quotes and split consecutive marks
+
+::#### split into unquoted part, quoted part, remains
+:loop
+
+for /F "tokens=1,2* delims=@" %%I in (" %PENDING%") do (
+  set "UNQ=%%I"
+  set "QTD=%%J"
+  set "PENDING=%%K"
+)
+set "UNQ=%UNQ:~1%"
+
+if %V%==1 (
+  echo unquoted:
+  (echo UNQ :"%UNQ%")&(echo QTD :"%QTD%")&(echo REST:"%PENDING%")&(if defined OUTBUF echo OUTBUF:"%OUTBUF%")
+)
+
+if defined QTD     (set "QTD=%QTD:~3%")
+if defined PENDING (set "PENDING=%PENDING:~3%")
+
+if %V%==1 (
+  (echo QTD :"%QTD%")&(echo REST:"%PENDING%")
+)
+
+if not defined UNQ if defined OUTBUF (
+  set concat_next=true
+  goto :process_unquote
+)
+
+set concat_prev=
+set concat_check=
+if defined UNQ (set "concat_check=%UNQ:~0,1%")
+if not "%concat_check%"==" " (set concat_prev=true)
+
+set concat_next=
+set concat_check=
+if defined UNQ (set "concat_check=%UNQ:~-1%")
+if not "%concat_check%"==" " (set concat_next=true)
+
+if not defined concat_prev if defined OUTBUF (
+  goto :return_arg
+)
+
+::#### process unquoted part
+:process_unquote
+
+if defined UNQ if "%UNQ: =%"=="" (set UNQ=)
+if not defined UNQ goto :process_quoted
+
+for /F "tokens=1* eol=" %%I in ("%UNQ%") do (
+  set "token=%%I"
+  set "UNQ=%%J"
+)
+
+if %V%==1 (
+  (echo unq :"%token%")&(echo UNQ :"%UNQ%")
+)
+
+set "OUTBUF=%OUTBUF%%token%"
+if defined UNQ (
+  goto :return_arg
+) else (
+  if not defined concat_next (
+    goto :return_arg
+  )
+)
+
+::#### process quoted part
+:process_quoted
+
+if %V%==1 (
+  echo quoted:
+  (echo UNQ :"%UNQ%")&(echo QTD :"%QTD%")&(echo REST:"%PENDING%")&(if defined OUTBUF echo OUTBUF:"%OUTBUF%")
+)
+
+set "OUTBUF=%OUTBUF%%QTD%"
+set QTD=
+
+if not defined PENDING (
+  goto :return_arg
+)
+goto :loop
+
+::#### return splitted argv
+:return_arg
+
+set "argv=%OUTBUF%"
+if defined argv (set "argv=%argv:#64=@%")
+if defined argv (set "argv=%argv:#35=#%")
+
+if defined QTD (set QTD="%QTD%")
+
+:: special handling is required because they may contain double quotes
+
+if defined PENDING set PENDING=%PENDING:@sep="%
+set args=%UNQ%%QTD%%PENDING%
+if defined args set args=%args:#64=@%
+if defined args set args=%args:#35=#%
+
+endlocal & set "argv=%argv%" & set args=%args%
+
+exit /b

--- a/win32/test_shellsplit.cmd
+++ b/win32/test_shellsplit.cmd
@@ -1,0 +1,28 @@
+@echo off & if not [%1]==[] goto :process
+
+echo.
+echo This script demonstrates how shellsplit.cmd works.
+echo usage: %0 arg1 arg2...
+echo.
+echo Prints separated arguments as (arg1)(arg2)...
+echo - splits commandline with spaces/tabs. cmd.exe standard rule is ignored.
+echo - you can use double quotes to contain spaces/tabs into an argument.
+echo - you can not escape double quote.
+echo - solitary "" is ignored since cmd.exe variables cannot represent empty value.
+exit /b 0
+
+:process
+setlocal
+set V=0
+
+:: %* can contain meta character inside quote. do not use set "args=%*" here.
+set args=%*
+
+:loop
+call %~dp0\shellsplit.cmd
+if not defined argv goto :end
+set /p "tmp=(%argv%)"<NUL
+goto :loop
+
+:end
+endlocal & exit /b 0


### PR DESCRIPTION
Dealing with the limitations of cmd.exe's command-line parsing forces users to use workarounds, and corner cases still remain.
By implementing our own command line splitting, we conceal the complexity and ensure maintainability.

Makefile macro definition and opt-dir list now free from quoting.
now can use this from cmd.exe like
```
configure.bat --with-opt-dir=c:/src/zlib;c:/src/libffi CC="cl -std:c11" DEFS=-DOPT_THREADED_CODE=2
```

Besides spaces, `&|<>` are characters that require quoting, but I couldn't determine if mentioning them was worthwhile.