### PR TITLE
[Bug #14582] Fix unable to use `method-entry` and `method-return` tracing probes since 2.5

### DIFF
--- a/doc/contributing/dtrace_probes.rdoc
+++ b/doc/contributing/dtrace_probes.rdoc
@@ -57,15 +57,9 @@ with when they are fired and the arguments they take:
   filename::     the file name where the method is _being called_ (a string)
   lineno::       the line number where the method is _being called_ (an int)
 
-  *NOTE*: will only be fired if tracing is enabled, e.g. with: <code>TracePoint.new{}.enable</code>.
-  See Feature#14104[https://bugs.ruby-lang.org/issues/14104] for more details.
-
 [ruby:::method-return(classname, methodname, filename, lineno);]
   This probe is fired just after a method has returned. The arguments are the
   same as "ruby:::method-entry".
-
-  *NOTE*: will only be fired if tracing is enabled, e.g. with: <code>TracePoint.new{}.enable</code>.
-  See Feature#14104[https://bugs.ruby-lang.org/issues/14104] for more details.
 
 [ruby:::cmethod-entry(classname, methodname, filename, lineno);]
   This probe is fired just before a C method is entered. The arguments are the

--- a/insns.def
+++ b/insns.def
@@ -1172,6 +1172,10 @@ leave
         }
     }
 
+    if (VM_FRAME_TYPE(GET_CFP()) == VM_FRAME_MAGIC_METHOD) {
+        RUBY_DTRACE_METHOD_RETURN_HOOK(ec, 0, 0);
+    }
+
     if (vm_pop_frame(ec, GET_CFP(), GET_EP())) {
 #if OPT_CALL_THREADED_CODE
         rb_ec_thread_ptr(ec)->retval = val;
@@ -1679,6 +1683,10 @@ opt_invokebuiltin_delegate_leave
 
     /* leave fastpath */
     /* TracePoint/return fallbacks this insn to opt_invokebuiltin_delegate */
+    if (VM_FRAME_TYPE(GET_CFP()) == VM_FRAME_MAGIC_METHOD) {
+        RUBY_DTRACE_METHOD_RETURN_HOOK(ec, 0, 0);
+    }
+
     if (vm_pop_frame(ec, GET_CFP(), GET_EP())) {
 #if OPT_CALL_THREADED_CODE
         rb_ec_thread_ptr(ec)->retval = val;

--- a/test/dtrace/test_function_entry.rb
+++ b/test/dtrace/test_function_entry.rb
@@ -45,6 +45,57 @@ ruby$target:::method-entry
       }
     end
 
+    def test_tailcall_function_entry_without_trace_point
+      program = <<-eoruby
+      code = <<~RUBY
+        class Foo
+          def foo
+            bar
+          end
+
+          def bar
+            3 + 4
+          end
+        end
+
+        Foo.new.foo
+      RUBY
+
+      RubyVM::InstructionSequence.compile(
+        code,
+        tailcall_optimization: true,
+        trace_instruction: false
+      ).eval
+      eoruby
+
+      probe = <<-eoprobe
+ruby$target:::method-entry
+/arg0 && arg1 && arg2/
+{
+  printf("%s %s %s %d\\n", copyinstr(arg0), copyinstr(arg1), copyinstr(arg2), arg3);
+}
+      eoprobe
+
+      trap_probe(probe, program) { |d_file, rb_file, probes|
+	foo_calls = probes.map { |line| line.split }.find_all { |row|
+	  row.first == 'Foo'  && row[1] == 'foo'
+	}
+
+	bar_calls = probes.map { |line| line.split }.find_all { |row|
+	  row.first == 'Foo'  && row[1] == 'bar'
+	}
+
+  assert_equal 1, foo_calls.length, probes
+  assert_equal 1, bar_calls.length, probes
+
+  assert_equal '11', foo_calls.first[3]
+  assert_equal '<compiled>', foo_calls.first[2]
+
+  assert_equal '11', bar_calls.first[3]
+  assert_equal '<compiled>', bar_calls.first[2]
+      }
+    end
+
     def test_function_return
       probe = <<-eoprobe
 ruby$target:::method-return

--- a/test/dtrace/test_singleton_function.rb
+++ b/test/dtrace/test_singleton_function.rb
@@ -18,7 +18,28 @@ ruby$target:::method-entry
 	}
 
 	assert_equal 10, foo_calls.length, probes.inspect
-	line = '3'
+	line = '5'
+	foo_calls.each { |f| assert_equal line, f[3] }
+	foo_calls.each { |f| assert_equal rb_file, f[2] }
+      }
+    end
+
+    def test_entry_without_trace_point
+      probe = <<-eoprobe
+ruby$target:::method-entry
+/strstr(copyinstr(arg0), "Foo") != NULL/
+{
+  printf("%s %s %s %d\\n", copyinstr(arg0), copyinstr(arg1), copyinstr(arg2), arg3);
+}
+      eoprobe
+
+      trap_probe(probe, ruby_program_without_trace_point) { |d_file, rb_file, probes|
+	foo_calls = probes.map { |line| line.split }.find_all { |row|
+	  row.first == 'Foo'  && row[1] == 'foo'
+	}
+
+	assert_equal 10, foo_calls.length, probes.inspect
+	line = '4'
 	foo_calls.each { |f| assert_equal line, f[3] }
 	foo_calls.each { |f| assert_equal rb_file, f[2] }
       }
@@ -44,9 +65,38 @@ ruby$target:::method-return
       }
     end
 
+    def test_exit_without_trace_point
+      probe = <<-eoprobe
+ruby$target:::method-return
+{
+  printf("%s %s %s %d\\n", copyinstr(arg0), copyinstr(arg1), copyinstr(arg2), arg3);
+}
+      eoprobe
+
+      trap_probe(probe, ruby_program_without_trace_point) { |d_file, rb_file, probes|
+	foo_calls = probes.map { |line| line.split }.find_all { |row|
+	  row.first == 'Foo'  && row[1] == 'foo'
+	}
+
+	assert_equal 10, foo_calls.length, probes.inspect
+	line = '2'
+	foo_calls.each { |f| assert_equal line, f[3] }
+	foo_calls.each { |f| assert_equal rb_file, f[2] }
+      }
+    end
+
     def ruby_program
       <<-eoruby
       TracePoint.new{}.__enable(nil, nil, Thread.current)
+      class Foo
+	def self.foo; end
+      end
+      10.times { Foo.foo }
+      eoruby
+    end
+
+    def ruby_program_without_trace_point
+      <<-eoruby
       class Foo
 	def self.foo; end
       end

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3523,6 +3523,10 @@ vm_call_iseq_setup_tailcall(rb_execution_context_t *ec, rb_control_frame_t *cfp,
         }
     }
 
+    if (VM_FRAME_TYPE(cfp) == VM_FRAME_MAGIC_METHOD) {
+        RUBY_DTRACE_METHOD_RETURN_HOOK(ec, 0, 0);
+    }
+
     vm_pop_frame(ec, cfp, cfp->ep);
     cfp = ec->cfp;
 
@@ -3536,6 +3540,8 @@ vm_call_iseq_setup_tailcall(rb_execution_context_t *ec, rb_control_frame_t *cfp,
     for (i=0; i < ISEQ_BODY(iseq)->param.size; i++) {
         *sp++ = src_argv[i];
     }
+
+    RUBY_DTRACE_METHOD_ENTRY_HOOK(ec, me->owner, me->def->original_id);
 
     vm_push_frame(ec, iseq, VM_FRAME_MAGIC_METHOD | VM_ENV_FLAG_LOCAL | finish_flag,
                   calling->recv, calling->block_handler, (VALUE)me,


### PR DESCRIPTION
Also  emit DTrace USDT probes for tail calls.