### PR TITLE
Add Module#undef_const

### DIFF
--- a/constant.h
+++ b/constant.h
@@ -15,6 +15,7 @@
 
 typedef enum {
     CONST_DEPRECATED = 0x100,
+    CONST_UNDEFINED = 0x200,
 
     CONST_VISIBILITY_MASK = 0xff,
     CONST_PUBLIC    = 0x00,
@@ -29,6 +30,8 @@ typedef enum {
 
 #define RB_CONST_DEPRECATED_P(ce) \
     ((ce)->flag & CONST_DEPRECATED)
+#define RB_CONST_UNDEFINED_P(ce) \
+    ((ce)->flag & CONST_UNDEFINED)
 
 typedef struct rb_const_entry_struct {
     rb_const_flag_t flag;

--- a/inits.c
+++ b/inits.c
@@ -80,6 +80,7 @@ rb_call_inits(void)
     CALL(Prism);
     CALL(unicode_version);
     CALL(Set);
+    CALL(undef_const_sentinel);
 
     // enable builtin loading
     CALL(builtin);

--- a/object.c
+++ b/object.c
@@ -4710,6 +4710,8 @@ InitVM_Object(void)
     rb_define_method(rb_cModule, "const_set", rb_mod_const_set, 2);
     rb_define_method(rb_cModule, "const_defined?", rb_mod_const_defined, -1);
     rb_define_method(rb_cModule, "const_source_location", rb_mod_const_source_location, -1);
+    rb_define_private_method(rb_cModule, "undef_const",
+                             rb_mod_undef_const, 1); /* in variable.c */
     rb_define_private_method(rb_cModule, "remove_const",
                              rb_mod_remove_const, 1); /* in variable.c */
     rb_define_method(rb_cModule, "const_missing",

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -1137,6 +1137,9 @@ vm_get_ev_const(rb_execution_context_t *ec, VALUE orig_klass, ID id, bool allow_
                         rb_autoload_load(klass, id);
                         goto search_continue;
                     }
+                    else if (RB_CONST_UNDEFINED_P(ce)) {
+                        return rb_const_get(klass, id);
+                    }
                     else {
                         if (is_defined) {
                             return 1;


### PR DESCRIPTION
This offers similar behavior for constants that undef_method does for methods. Just as undef_method adds a VM_METHOD_TYPE_UNDEF method entry, undef_const adds a CONST_UNDEFINED constant entry. To avoid internal API changes, an undef_const_sentinel hidden object is used as the value for CONST_UNDEFINED constant entries, and methods that only get the value for the constant entry check for the sentinel value instead of the CONST_UNDEFINED flag.

The sentinel value approach could probably be avoided, but I think it would require significant API changes. Using a hidden sentinel value also makes it fairly easy to detect leakage of the value, since if the value is leaked, method calls on it would fail as the object is hidden.

Whenever normal constant lookup would find the undefined constant, it stops the lookup and calls const_missing (just as undef_method stops the lookup and calls method_missing).

For code that checks whether a constant is defined, the undefined constant short circuits the lookup so that the constant is treated as undefined (again, similar to undef_method for methods).

This adds a rb_mod_undef_const function to the public C-API, matching the rb_mod_remove_const function.

This adds a static const_set_with_flag method to variable.c, allowing setting of constants with specific flags. This is necessary to avoid race conditions in rb_mod_undef_const, since const_set only creates constant entries with the CONST_PUBLIC flag.

Documentation for both the Ruby method and C-API function are based on the undef_method documentation, modified to apply to constants.

The expected use for this is for stopping direct access to global constants inside namespaces. For example:

```ruby
class DangerousClass; end

class SafeClass
  undef_const :DangerousClass

  DangerousClass   # NameError (const_missing behavior)

  # Does not effect use with absolute path, since the constant is not
  # undefined in Object.
  ::DangerousClass # no error
end
```

This follows all of the normal constant lookup behavior:

```ruby
DB = setup_database

module PreventDatabaseAccess
  undef_const :DB
end

class NoDatabaseAccess
  include PreventDatabaseAccess

  DB # NameError (calls NoDatabaseAccess.const_missing)
end

module Namespace1
  undef_const :DB

  module NoDatabaseAccess
    DB # NameError (finds Namespace1::DB before ::DB,
       # calls Namespace1::NoDatabaseAccess.const_missing)
  end
end

module Namespace2
  include PreventDatabaseAccess

  class Nested
    DB # No error, finds ::DB, since constant lookup does not look into
       # ancestors of Namespace2
  end
end
```