### PR TITLE
Backport GH-15908

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -129,13 +129,10 @@ module Gem::BUNDLED_GEMS # :nodoc:
     return if specs.include?(name)
 
     # Don't warn if a hyphenated gem provides this feature
-    # (e.g., benchmark-ips provides benchmark/ips, not the benchmark gem)
+    # (e.g., benchmark-ips provides benchmark/ips, benchmark/timing, etc.)
     if subfeature
-      feature_parts = feature.split("/")
-      if feature_parts.size >= 2
-        hyphenated_gem = "#{feature_parts[0]}-#{feature_parts[1]}"
-        return if specs.include?(hyphenated_gem)
-      end
+      prefix = feature.split("/").first + "-"
+      return if specs.any? { |spec, _| spec.start_with?(prefix) }
     end
 
     return if WARNED[name]

--- a/test/test_bundled_gems.rb
+++ b/test/test_bundled_gems.rb
@@ -39,6 +39,14 @@ class TestBundlerGem < Gem::TestCase
     assert_nil Gem::BUNDLED_GEMS.warning?("benchmark/ips", specs: {"benchmark-ips" => true})
   end
 
+  def test_no_warning_for_subfeatures_of_hyphenated_gem
+    # When benchmark-ips gem is in specs, requiring any "benchmark/*" subfeature
+    # should not warn, since hyphenated gems may provide multiple files
+    # (e.g., benchmark-ips provides benchmark/ips, benchmark/timing, benchmark/compare)
+    assert_nil Gem::BUNDLED_GEMS.warning?("benchmark/timing", specs: {"benchmark-ips" => true})
+    assert_nil Gem::BUNDLED_GEMS.warning?("benchmark/compare", specs: {"benchmark-ips" => true})
+  end
+
   def test_warning_without_hyphenated_gem
     # When benchmark-ips is NOT in specs, requiring "benchmark/ips" should warn
     warning = Gem::BUNDLED_GEMS.warning?("benchmark/ips", specs: {})


### PR DESCRIPTION
from https://github.com/ruby/ruby/pull/15908

We should fix to suppress logic for `benchmark-ips`.