### PR TITLE
Use Oregon mirror for cygwin download

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -46,6 +46,8 @@ jobs:
         uses: cygwin/cygwin-install-action@master
         with:
           packages: ruby gcc-core make autoconf libtool libssl-devel libyaml-devel libffi-devel zlib-devel rubygems
+          site: |
+            https://cygwin.osuosl.org/
 
       - name: configure
         run: |


### PR DESCRIPTION
`https://mirrors.kernel.org/sourceware/cygwin/` is unstable in recent week. 