### PR TITLE
Stack-allocate small re_registers

### DIFF
--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -1011,6 +1011,18 @@ class TestRegexp < Test::Unit::TestCase
     end;
   end
 
+  def test_regsub_no_memory_leak_many_captures
+    assert_no_memory_leak([], "#{<<~"begin;"}", "#{<<~"end;"}", rss: true)
+      code = proc do
+        "aaaaaaaaaaa".gsub(/(a)(b)?(c)?(d)?(e)?(f)?(g)?(h)?/, "")
+      end
+
+      1_000.times(&code)
+    begin;
+      100_000.times(&code)
+    end;
+  end
+
   def test_ignorecase
     v = assert_deprecated_warning(/variable \$= is no longer effective/) { $= }
     assert_equal(false, v)


### PR DESCRIPTION
In rb_reg_search_set_match we would previously always xmalloc two arrays for the beg and end registers. Very often these allocations are few, and for that case we can use stack-allocated memory instead.

After, if the match is successful, we need to copy the registers onto a MatchData. If the existing MatchData fits we memcpy the new match over, otherwise we free the existing MatchData's pointers and replace them with our new ones.

```
❯ make benchmark ITEM=vm_regexp
/home/jhawthorn/.rubies/ruby-4.0.0/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="compare-ruby::/home/jhawthorn/.rubies/ruby-4.0.0/bin/ruby --disable=gems -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            --output=markdown --output-compare -v $(find ./benchmark -maxdepth 1 -name 'vm_regexp' -o -name '*vm_regexp*.yml' -o -name '*vm_regexp*.rb' | sort)
compare-ruby: ruby 4.0.0 (2025-12-25 revision 553f1675f3) +PRISM [x86_64-linux]
built-ruby: ruby 4.1.0dev (2026-02-17T06:09:22Z reg_search_stack_a.. 439c4496cc) +PRISM [x86_64-linux]
# Iteration per second (i/s)

|                  |compare-ruby|built-ruby|
|:-----------------|-----------:|---------:|
|vm_regexp         |     11.154M|   14.095M|
|                  |           -|     1.26x|
|vm_regexp_invert  |     11.144M|   14.301M|
|                  |           -|     1.28x|
```

I implemented this aiming to improve the speed of a regex `gsub` which had no match:

```
Benchmark 1: /home/jhawthorn/.rubies/ruby-base/bin/ruby --disable-gems --enable-frozen-string-literal -e 'str = "foo"; 20_000_000.times { str.gsub(/x/, "") }'
  Time (mean ± σ):      2.027 s ±  0.022 s    [User: 2.023 s, System: 0.004 s]
  Range (min … max):    1.999 s …  2.073 s    10 runs

Benchmark 2: /home/jhawthorn/.rubies/ruby-test/bin/ruby --disable-gems --enable-frozen-string-literal -e 'str = "foo"; 20_000_000.times { str.gsub(/x/, "") }'
  Time (mean ± σ):      1.139 s ±  0.010 s    [User: 1.134 s, System: 0.004 s]
  Range (min … max):    1.131 s …  1.158 s    10 runs

Summary
  /home/jhawthorn/.rubies/ruby-test/bin/ruby --disable-gems --enable-frozen-string-literal -e 'str = "foo"; 20_000_000.times { str.gsub(/x/, "") }' ran
    1.78 ± 0.03 times faster than /home/jhawthorn/.rubies/ruby-base/bin/ruby --disable-gems --enable-frozen-string-literal -e 'str = "foo"; 20_000_000.times { str.gsub(/x/, "") }'
```

I would like to (eventually) allocate the `struct re_registers` as fully embedded within the `T_MATCH` itself, but that requires more reorganization (and figuring out how `struct re_registers` is used directly in gems other than strscan).