### PR TITLE
Removed unnecessary setup for `make bundled_gems_spec-run`

### DIFF
--- a/spec/bundled_gems_spec.rb
+++ b/spec/bundled_gems_spec.rb
@@ -22,7 +22,6 @@ RSpec.configure do |config|
     Gem.ruby = ENV["RUBY"] if ENV["RUBY"]
 
     require_relative "bundler/support/rubygems_ext"
-    Spec::Rubygems.test_setup
     Spec::Helpers.install_dev_bundler
     FileUtils.mkdir_p Spec::Path.gem_path
   end


### PR DESCRIPTION
It's not working with `TMPDIR` separation. In my investigation, we don't need to install dependencies in example file.