### PR TITLE
win32/configure.bat accept empty prefix

### DIFF
--- a/win32/configure.bat
+++ b/win32/configure.bat
@@ -133,7 +133,8 @@ goto :unknown_opt
 goto :loopend ;
 :dir
   if "%eq%" == "" call :take_arg
-  echo>> %config_make% %opt:~2% = %arg:\=/%
+  if defined arg set "arg=%arg:\=/%"
+  echo>> %config_make% %opt:~2% = %arg%
 goto :loopend ;
 :enable
   if %enable% == yes (


### PR DESCRIPTION
Currently, running `win32/configure.bat --prefix=` outputs `prefix = \=/` in the Makefile.
Fix this to prevent invalid values from being output.

Other similar processes have not been changed, as specifying an empty string would be meaningless.