### PR TITLE
ZJIT: Avoid SendDirect when callee ISeq cannot compile

### DIFF
--- a/test/ruby/test_zjit.rb
+++ b/test/ruby/test_zjit.rb
@@ -164,6 +164,50 @@ class TestZJIT < Test::Unit::TestCase
     }, call_threshold: 2, allowed_iseqs: 'entry@-e:2'
   end
 
+  def test_send_direct_disallowed_callee_uses_fallback
+    script = <<~RUBY
+      def fast_string_to_time(string)
+        return unless string.include?("-")
+        if is_utc?
+          target(string, in: "UTC")
+        else
+          target(string)
+        end
+      end
+
+      def is_utc?
+        default_timezone == :utc
+      end
+
+      def default_timezone
+        :utc
+      end
+
+      def target(year = nil, mon = nil, mday = nil, hour = nil, min = nil, sec = nil, zone = nil, in: nil, precision: 9)
+        [year.class, binding.local_variable_get(:in), precision]
+      end
+
+      20.times { fast_string_to_time("2023-05-08 10:21:10.510629") }
+      puts :ok
+    RUBY
+
+    out, err, status = eval_with_jit(
+      script,
+      call_threshold: 3,
+      allowed_iseqs: <<~LIST,
+        fast_string_to_time@-e:2
+        is_utc?@-e:11
+        default_timezone@-e:15
+      LIST
+      extra_args: ['--zjit-dump-hir']
+    )
+
+    assert_success(out, err, status)
+    assert_includes(out, "ok\n")
+    assert_includes(out, "fn fast_string_to_time@-e:2:")
+    refute_match(/SendDirect .*:target/, out)
+  end
+
   def test_opt_new_with_custom_allocator
     assert_compiles '"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"', %q{
       require "digest"

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -689,6 +689,8 @@ pub enum SendFallbackReason {
     SuperPolymorphic,
     /// The `super` target call uses a complex argument pattern that the optimizer does not support.
     SuperTargetComplexArgsPass,
+    /// The `--zjit-allowed-iseqs` flag was supplied and this ISeq did not belong to the "allowed" set.
+    FilteredOut,
     /// Initial fallback reason for every instruction, which should be mutated to
     /// a more actionable reason when an attempt to specialize the instruction fails.
     Uncategorized(ruby_vminsn_type),
@@ -736,6 +738,7 @@ impl Display for SendFallbackReason {
             SuperPolymorphic => write!(f, "super: polymorphic call site"),
             SuperTargetNotFound => write!(f, "super: profiled target method cannot be found"),
             SuperTargetComplexArgsPass => write!(f, "super: complex argument passing to `super` target call"),
+            FilteredOut => write!(f, "Send: target ISeq filtered out"),
             Uncategorized(insn) => write!(f, "Uncategorized({})", insn_name(*insn as usize)),
         }
     }
@@ -3234,6 +3237,12 @@ impl Function {
                             // Only specialize positional-positional calls
                             // TODO(max): Handle other kinds of parameter passing
                             let iseq = unsafe { get_def_iseq_ptr((*cme).def) };
+
+                            if !ZJITState::can_compile_iseq(iseq) {
+                                self.set_dynamic_send_reason(insn_id, FilteredOut);
+                                self.push_insn_id(block, insn_id); continue;
+                            }
+
                             if !can_direct_send(self, block, iseq, ci, insn_id, args.as_slice(), blockiseq) {
                                 self.push_insn_id(block, insn_id); continue;
                             }
@@ -3272,6 +3281,11 @@ impl Function {
                             }
                             let capture = unsafe { proc_block.as_.captured.as_ref() };
                             let iseq = unsafe { *capture.code.iseq.as_ref() };
+
+                            if !ZJITState::can_compile_iseq(iseq) {
+                                self.set_dynamic_send_reason(insn_id, FilteredOut);
+                                self.push_insn_id(block, insn_id); continue;
+                            }
 
                             if !can_direct_send(self, block, iseq, ci, insn_id, args.as_slice(), None) {
                                 self.push_insn_id(block, insn_id); continue;
@@ -3639,6 +3653,13 @@ impl Function {
                             // Check if the super method's parameters support direct send.
                             // If not, we can't do direct dispatch.
                             let super_iseq = unsafe { get_def_iseq_ptr((*super_cme).def) };
+
+                            if !ZJITState::can_compile_iseq(super_iseq) {
+                                self.push_insn_id(block, insn_id);
+                                self.set_dynamic_send_reason(insn_id, FilteredOut);
+                                continue;
+                            }
+
                             // TODO: pass Option<blockiseq> to can_direct_send when we start specializing `super { ... }`.
                             if !can_direct_send(self, block, super_iseq, ci, insn_id, args.as_slice(), None) {
                                 self.push_insn_id(block, insn_id);

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -278,6 +278,7 @@ make_counters! {
         send_fallback_super_target_not_found,
         send_fallback_super_target_complex_args_pass,
         send_fallback_cannot_send_direct,
+        send_fallback_filtered_out,
         send_fallback_uncategorized,
     }
 
@@ -660,6 +661,7 @@ pub fn send_fallback_counter(reason: crate::hir::SendFallbackReason) -> Counter 
         SuperPolymorphic                          => send_fallback_super_polymorphic,
         SuperTargetNotFound                       => send_fallback_super_target_not_found,
         SuperTargetComplexArgsPass                => send_fallback_super_target_complex_args_pass,
+        FilteredOut                               => send_fallback_filtered_out,
         Uncategorized(_)                          => send_fallback_uncategorized,
     }
 }


### PR DESCRIPTION
While using `zjit_bisect` on the _lobsters_ benchmark in [ruby-bench](https://github.com/ruby/ruby-bench), trying to track down the segfault fixed in #16251, I ended up in an odd situation where the bisect encountered an application exception and halted rather than crash with the segfault I expected. Running ZJIT with `--zjit-allowed-iseqs` with this specific list of methods did indeed result in an application exception and any modification I made to that list made the exception go away; it had to be this specific set of three methods to error out.

I spent a couple of days debugging this and narrowed it down to a confluence of events. I think at some level it has to do with a constructor that has optional positional arguments followed by kwargs and the way we jump into the method. On top of that, we have a `SendDirect` to an ISEQ that cannot be compiled, and I suspect something isn't being cleaned up correctly when we side-exit. Currently, "cannot be compiled" means it's not in the `--zjit-allowed-iseqs` list, so I think this only impacts that narrow use case.

I really wanted to make sure this wasn't something that could occur during typical side-exits in ZJIT. I probed this from many different angles and couldn't induce the behavior outside of `--zjit-allow-iseqs`. But, I also can't conclusively say what's leading to the stack corruption. I could spend more time chasing that down, but I'm not sure it's all that valuable. We shouldn't try to `SendDirect` to an ISEQ we know _a priori_ that we cannot compile.

The test case here was drawn directly from the _lobsters_ code, but eliminates any usage of Rails. We can rename methods if folks would like. I confirmed this test fails with _master_ and passes with this PR applied.