### PR TITLE
Improve performance of String#scrub by skipping ASCII runs with `search_nonascii`

### DIFF
--- a/benchmark/string_scrub.yml
+++ b/benchmark/string_scrub.yml
@@ -1,0 +1,48 @@
+prelude: |
+
+  STRING_SIZE = 1024
+  def duplicate_to_length(str, target_length)
+    return "" if target_length <= 0
+    return str[0, target_length] if str.length >= target_length
+
+    (str * ((target_length / str.length) + 1))[0, target_length]
+  end
+  base = "Hello \u{1f600} world! \u{00e9}\u{00f1}"
+  padding = duplicate_to_length(base, STRING_SIZE)
+
+  valid_utf8 = (padding.b + "OK".b).force_encoding("UTF-8")
+  valid_utf8.valid_encoding?
+  unknown_but_valid_utf8 = valid_utf8.dup.b.force_encoding("UTF-8")
+  invalid_utf8 = (padding.b + "\x80\xFF".b).force_encoding("UTF-8")
+  invalid_utf8.valid_encoding?
+  unknown_but_invalid_utf8 = (padding.b + "\x80\xFF".b).force_encoding("UTF-8")
+
+  worst_case_utf8 = duplicate_to_length("\u{1f600}\u{00e9}\u{00f1}", STRING_SIZE).b.force_encoding("UTF-8")
+
+  unknown_but_valid_utf8_worst_case = worst_case_utf8.dup.b.force_encoding("UTF-8")
+  unknown_but_invalid_utf8_worst_case = (worst_case_utf8.b + "\x80\xFF".b).force_encoding("UTF-8")
+
+benchmark:
+  scrub_known_valid: |
+    string = valid_utf8.dup
+    string.scrub!
+
+  scrub_known_invalid: |
+    string = invalid_utf8.dup
+    string.scrub!
+
+  scrub_unknown_but_valid_coderange: |
+    string = unknown_but_valid_utf8.dup
+    string.scrub!
+
+  scrub_unknown_and_invalid_coderange: |
+    string = unknown_but_invalid_utf8.dup
+    string.scrub!
+
+  scrub_unknown_but_valid_coderange_worst_case: |
+    string = unknown_but_valid_utf8_worst_case.dup
+    string.scrub!
+
+  scrub_unknown_and_invalid_coderange_worst_case: |
+    string = unknown_but_invalid_utf8_worst_case.dup
+    string.scrub!

--- a/string.c
+++ b/string.c
@@ -11843,10 +11843,17 @@ enc_str_scrub(rb_encoding *enc, VALUE str, VALUE repl, int cr)
             else if (MBCLEN_CHARFOUND_P(ret)) {
                 cr = ENC_CODERANGE_VALID;
                 p += MBCLEN_CHARFOUND_LEN(ret);
-                p = search_nonascii(p, e);
-                if (!p) {
-                    p = e;
-                    break;
+                /*
+                 * After a valid multibyte character, skip the following ASCII run.
+                 * If the next byte is already non-ASCII, search_nonascii would only
+                 * rediscover p after its word-at-a-time setup.
+                 */
+                if (p < e && ISASCII(*p)) {
+                    p = search_nonascii(p, e);
+                    if (!p) {
+                        p = e;
+                        break;
+                    }
                 }
             }
             else if (MBCLEN_INVALID_P(ret)) {

--- a/string.c
+++ b/string.c
@@ -11843,6 +11843,11 @@ enc_str_scrub(rb_encoding *enc, VALUE str, VALUE repl, int cr)
             else if (MBCLEN_CHARFOUND_P(ret)) {
                 cr = ENC_CODERANGE_VALID;
                 p += MBCLEN_CHARFOUND_LEN(ret);
+                p = search_nonascii(p, e);
+                if (!p) {
+                    p = e;
+                    break;
+                }
             }
             else if (MBCLEN_INVALID_P(ret)) {
                 /*


### PR DESCRIPTION
## Background
I identified that `String#scrub` and `String#scrub!` were slower than expected when dealing with very large strings with an unknown encoding. We have a use case where we run scrub on HTML pages and the following code change resulted in ~20x performance improvement.
Before:
```ruby
string.force_encoding("UTF-8")
string.scrub!
```
After:
```ruby
string.force_encoding("UTF-8")
string.scrub! unless string.valid_encoding?
```
I was curious about what caused the performance difference between `String#scrub!` and `String#valid_encoding?` when the string is valid utf-8. I decided to dig into the internal implementation of String#scrub and found the opportunity for a performance improvement, see the following suggestion.
## Proposal:
```c
// string.c:11838 (Ruby 4.1.0)
p = search_nonascii(p, e);
if (!p) {
    p = e;
}
// Enter scrub loop.
while (p < e) {
    int ret = rb_enc_precise_mbclen(p, e, enc);
    if (MBCLEN_NEEDMORE_P(ret)) {
        break;
    }
    else if (MBCLEN_CHARFOUND_P(ret)) {
        cr = ENC_CODERANGE_VALID;
        p += MBCLEN_CHARFOUND_LEN(ret);
+       p = search_nonascii(p, e);
+       if (!p) {
+           p = e;
+           break;
+       }
    }
    // MBCLEN_INVALID_P handling unchanged.
```
This patch does not change any observable behaviour, all tests pass.
### Justification:
This adds the pattern used in `String#valid_encoding?` to `String#scrub` which allows us to use `search_nonascii` to skip ascii characters after encountering a multi-byte sequence. This is implemented for `String#valid_encoding?` in string.c:799 (Ruby 4.1.0). 
`search_nonascii` returns a pointer to the address of the next non-ascii character.

#### Upsides:
- Better performance (3-45x) when we have some ascii within the text that we are attempting to scrub. Testing with HTML examples showed 15x-40x speedups depending on the density of multibyte characters.
- A version of this is implemented right now where it saved 1% average processing time and 1.5% at P90 over many requests.
#### Tradeoffs:
- Worse performance (0.7x) if the text is entirely multibyte with no-ascii characters.

### Results:
| Benchmark                                      | Control    | Experiment | Speedup    |
| :--------------------------------------------- | ---------: | ---------: | :--------- |
| scrub_known_valid                              |    29.075M |    29.708M | 1.0x      |
| scrub_known_invalid                            |   247.926k |   740.033k | 2.9x      |
| scrub_unknown_but_valid_coderange              |   274.488k |   889.488k | 3.2x      |
| scrub_unknown_and_invalid_coderange            |   269.232k |   739.194k | 2.8x      |
| scrub_unknown_but_valid_coderange_worst_case   |   234.635k |   164.706k | 0.7x      |
| scrub_unknown_and_invalid_coderange_worst_case |   239.335k |   162.561k | 0.7x      |
| scrub_japanese_html                            |     187.47 |    2927.00 | 15.6x     |
| scrub_english_html                             |     510.22 |   22694.00 | 44.5x     |

#### Methodology:
- Apple M4 Pro macOS 26.3
- Used built in benchmark tooling
- non-HTML benchmark Strings were all ~1KB
- Benchmarked Japanese & English HTML pages pulled from real sites. (I didn't include them as they were large ~2MB)