### PR TITLE
fix: raise on shape capacity overflow for large ivar counts

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -487,7 +487,12 @@ shape_grow_capa(attr_index_t current_capa)
         capacities++;
     }
 
-    return (attr_index_t)rb_malloc_grow_capa(current_capa, sizeof(VALUE));
+    size_t grown_capa = rb_malloc_grow_capa(current_capa, sizeof(VALUE));
+    if (UNLIKELY(grown_capa > SHAPE_MAX_FIELDS)) {
+        rb_raise(rb_eArgError, "too many instance variables");
+    }
+
+    return (attr_index_t)grown_capa;
 }
 
 static rb_shape_t *


### PR DESCRIPTION
This pull request makes shape capacity growth raise `ArgumentError` when the grown capacity would exceed `SHAPE_MAX_FIELDS`, instead of truncating the value back into `attr_index_t`. That lets objects with very large numbers of instance variables fail cleanly instead of overflowing the ivar backing store and crashing the interpreter.


