### PR TITLE
[Bug #21828] Suppress bundled gems warning for subfeatures found outside stdlib

### DIFF
--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -133,6 +133,13 @@ module Gem::BUNDLED_GEMS # :nodoc:
     if subfeature
       prefix = feature.split("/").first + "-"
       return if specs.any? { |spec, _| spec.start_with?(prefix) }
+
+      # Don't warn if the feature is found outside the standard library
+      # (e.g., benchmark-ips's lib dir is on $LOAD_PATH but not in specs)
+      resolved = $LOAD_PATH.resolve_feature_path(feature) rescue nil
+      if resolved
+        return unless resolved[1].start_with?(LIBDIR) || resolved[1].start_with?(ARCHDIR)
+      end
     end
 
     return if WARNED[name]

--- a/test/test_bundled_gems.rb
+++ b/test/test_bundled_gems.rb
@@ -61,11 +61,12 @@ class TestBundlerGem < Gem::TestCase
     Dir.mktmpdir do |dir|
       FileUtils.mkdir_p(File.join(dir, "benchmark"))
       File.write(File.join(dir, "benchmark", "ips.rb"), "")
+      original_load_path = $LOAD_PATH.dup
       $LOAD_PATH.unshift(dir)
       begin
         assert_nil Gem::BUNDLED_GEMS.warning?("benchmark/ips", specs: {})
       ensure
-        $LOAD_PATH.shift
+        $LOAD_PATH.replace(original_load_path)
       end
     end
   end

--- a/test/test_bundled_gems.rb
+++ b/test/test_bundled_gems.rb
@@ -53,4 +53,20 @@ class TestBundlerGem < Gem::TestCase
     assert warning
     assert_match(/benchmark/, warning)
   end
+
+  def test_no_warning_for_subfeature_found_outside_stdlib
+    # When a subfeature like "benchmark/ips" is found on $LOAD_PATH
+    # from a non-standard-library location (e.g., benchmark-ips gem's lib dir),
+    # don't warn even if the gem is not in specs (Bug #21828)
+    Dir.mktmpdir do |dir|
+      FileUtils.mkdir_p(File.join(dir, "benchmark"))
+      File.write(File.join(dir, "benchmark", "ips.rb"), "")
+      $LOAD_PATH.unshift(dir)
+      begin
+        assert_nil Gem::BUNDLED_GEMS.warning?("benchmark/ips", specs: {})
+      ensure
+        $LOAD_PATH.shift
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixup `[Bug #21828]`