### PR TITLE
Lazy load error_highlight, did_you_mean, and syntax_suggest

### DIFF
--- a/builtin.c
+++ b/builtin.c
@@ -1,5 +1,7 @@
 #include "internal.h"
 #include "internal/box.h"
+#include "internal/string.h"
+#include "internal/variable.h"
 #include "vm_core.h"
 #include "iseq.h"
 #include "builtin.h"
@@ -91,14 +93,17 @@ rb_define_gem_modules(VALUE flags_value, VALUE _)
 
     if (flags->gem) {
         rb_define_module("Gem");
+        // Make the error decoration gems autoload on first constant access.
+        // gem_prelude.rb loads them for error display via an
+        // Exception#detailed_message hook.
         if (flags->error_highlight) {
-            rb_define_module("ErrorHighlight");
+            rb_autoload_str(rb_cObject, rb_intern("ErrorHighlight"), rb_fstring_cstr("error_highlight"));
         }
         if (flags->did_you_mean) {
-            rb_define_module("DidYouMean");
+            rb_autoload_str(rb_cObject, rb_intern("DidYouMean"), rb_fstring_cstr("did_you_mean"));
         }
         if (flags->syntax_suggest) {
-            rb_define_module("SyntaxSuggest");
+            rb_autoload_str(rb_cObject, rb_intern("SyntaxSuggest"), rb_fstring_cstr("syntax_suggest"));
         }
     }
 

--- a/builtin.c
+++ b/builtin.c
@@ -94,8 +94,8 @@ rb_define_gem_modules(VALUE flags_value, VALUE _)
     if (flags->gem) {
         rb_define_module("Gem");
         // Make the error decoration gems autoload on first constant access.
-        // gem_prelude.rb loads them for error display via an
-        // Exception#detailed_message hook.
+        // error.c loads them for error display on the first error
+        // (or eagerly via Process.warmup).
         if (flags->error_highlight) {
             rb_autoload_str(rb_cObject, rb_intern("ErrorHighlight"), rb_fstring_cstr("error_highlight"));
         }

--- a/depend
+++ b/depend
@@ -5417,6 +5417,8 @@ error.$(OBJEXT): {$(VPATH)}missing.h
 error.$(OBJEXT): {$(VPATH)}node.h
 error.$(OBJEXT): {$(VPATH)}onigmo.h
 error.$(OBJEXT): {$(VPATH)}oniguruma.h
+error.$(OBJEXT): {$(VPATH)}ractor.h
+error.$(OBJEXT): {$(VPATH)}ractor_core.h
 error.$(OBJEXT): {$(VPATH)}ruby_assert.h
 error.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 error.$(OBJEXT): {$(VPATH)}rubyparser.h

--- a/depend
+++ b/depend
@@ -5417,8 +5417,6 @@ error.$(OBJEXT): {$(VPATH)}missing.h
 error.$(OBJEXT): {$(VPATH)}node.h
 error.$(OBJEXT): {$(VPATH)}onigmo.h
 error.$(OBJEXT): {$(VPATH)}oniguruma.h
-error.$(OBJEXT): {$(VPATH)}ractor.h
-error.$(OBJEXT): {$(VPATH)}ractor_core.h
 error.$(OBJEXT): {$(VPATH)}ruby_assert.h
 error.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 error.$(OBJEXT): {$(VPATH)}rubyparser.h

--- a/depend
+++ b/depend
@@ -1028,6 +1028,7 @@ builtin.$(OBJEXT): $(top_srcdir)/internal/sanitizers.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/serial.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/set_table.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/static_assert.h
+builtin.$(OBJEXT): $(top_srcdir)/internal/string.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/struct.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/variable.h
 builtin.$(OBJEXT): $(top_srcdir)/internal/vm.h
@@ -1084,6 +1085,7 @@ builtin.$(OBJEXT): {$(VPATH)}builtin_binary.rbbin
 builtin.$(OBJEXT): {$(VPATH)}config.h
 builtin.$(OBJEXT): {$(VPATH)}constant.h
 builtin.$(OBJEXT): {$(VPATH)}defines.h
+builtin.$(OBJEXT): {$(VPATH)}encindex.h
 builtin.$(OBJEXT): {$(VPATH)}encoding.h
 builtin.$(OBJEXT): {$(VPATH)}id.h
 builtin.$(OBJEXT): {$(VPATH)}id_table.h

--- a/error.c
+++ b/error.c
@@ -50,7 +50,6 @@
 #include "internal/vm.h"
 #include "ruby_assert.h"
 #include "vm_core.h"
-#include "ractor_core.h"
 #include "yjit.h"
 #include "zjit.h"
 
@@ -1764,7 +1763,8 @@ exc_message(VALUE exc)
 
 // Whether error_highlight, did_you_mean, and syntax_suggest have already
 // been loaded (lazily on the first error, or eagerly via Process.warmup).
-static bool decoration_gems_loaded = false;
+// Ractors run in parallel, so the load is claimed by an atomic exchange.
+static rb_atomic_t decoration_gems_loaded = 0;
 
 static VALUE
 load_decoration_gem(VALUE feature)
@@ -1797,13 +1797,14 @@ require_decoration_gems(void)
 }
 
 // Load the decoration gems on the first error display instead of at boot.
+// In non-main Ractors rb_require_string delegates the require to the main
+// Ractor, so this works from any Ractor.
 // Returns whether the caller should re-dispatch to pick up the
 // detailed_message decorators the gems prepend.
 static bool
 lazy_load_decoration_gems(VALUE exc)
 {
-    if (decoration_gems_loaded || !rb_ractor_main_p()) return false;
-    decoration_gems_loaded = true;
+    if (ATOMIC_EXCHANGE(decoration_gems_loaded, 1)) return false;
 
     // When entered through super from a decorator already sitting above
     // this method, the caller decorates the result; re-dispatching would
@@ -1820,8 +1821,7 @@ lazy_load_decoration_gems(VALUE exc)
 void
 rb_eager_load_detailed_message_extension(void)
 {
-    if (decoration_gems_loaded || !rb_ractor_main_p()) return;
-    decoration_gems_loaded = true;
+    if (ATOMIC_EXCHANGE(decoration_gems_loaded, 1)) return;
 
     require_decoration_gems();
 }

--- a/error.c
+++ b/error.c
@@ -47,8 +47,10 @@
 #include "ruby/encoding.h"
 #include "ruby/st.h"
 #include "ruby/util.h"
+#include "internal/vm.h"
 #include "ruby_assert.h"
 #include "vm_core.h"
+#include "ractor_core.h"
 #include "yjit.h"
 #include "zjit.h"
 
@@ -1760,6 +1762,42 @@ exc_message(VALUE exc)
     return rb_funcallv(exc, idTo_s, 0, 0);
 }
 
+static VALUE
+load_decoration_gem(VALUE feature)
+{
+    // The C-level require bypasses Kernel#require monkeypatches;
+    // displaying an error must not invoke or depend on them.
+    return rb_require_string(feature);
+}
+
+// Load error_highlight, did_you_mean, and syntax_suggest on the first
+// error display instead of at boot. rb_define_gem_modules registers an
+// autoload entry for each enabled gem; disabled gems have no entry and
+// are skipped. Returns whether the caller should re-dispatch to pick up
+// the detailed_message decorators the gems prepend.
+static bool
+lazy_load_decoration_gems(VALUE exc)
+{
+    static bool done = false;
+    if (done || !rb_ractor_main_p()) return false;
+    done = true;
+
+    // When entered through super from a decorator already sitting above
+    // this method, the caller decorates the result; re-dispatching would
+    // decorate it twice.
+    bool redispatch = rb_method_basic_definition_p(CLASS_OF(exc), id_detailed_message);
+
+    static const char *const gems[] = {"ErrorHighlight", "DidYouMean", "SyntaxSuggest"};
+    for (size_t i = 0; i < numberof(gems); i++) {
+        VALUE feature = rb_autoload_p(rb_cObject, rb_intern(gems[i]));
+        if (NIL_P(feature)) continue;
+        int state;
+        rb_protect(load_decoration_gem, feature, &state);
+        if (state) rb_set_errinfo(Qnil);
+    }
+    return redispatch;
+}
+
 /*
  * call-seq:
  *   detailed_message(highlight: false, **kwargs) -> string
@@ -1808,6 +1846,10 @@ exc_message(VALUE exc)
 static VALUE
 exc_detailed_message(int argc, VALUE *argv, VALUE exc)
 {
+    if (lazy_load_decoration_gems(exc)) {
+        return rb_funcallv_kw(exc, id_detailed_message, argc, argv, RB_PASS_CALLED_KEYWORDS);
+    }
+
     VALUE opt;
 
     rb_scan_args(argc, argv, "0:", &opt);

--- a/error.c
+++ b/error.c
@@ -1762,6 +1762,10 @@ exc_message(VALUE exc)
     return rb_funcallv(exc, idTo_s, 0, 0);
 }
 
+// Whether error_highlight, did_you_mean, and syntax_suggest have already
+// been loaded (lazily on the first error, or eagerly via Process.warmup).
+static bool decoration_gems_loaded = false;
+
 static VALUE
 load_decoration_gem(VALUE feature)
 {
@@ -1770,23 +1774,12 @@ load_decoration_gem(VALUE feature)
     return rb_require_string(feature);
 }
 
-// Load error_highlight, did_you_mean, and syntax_suggest on the first
-// error display instead of at boot. rb_define_gem_modules registers an
-// autoload entry for each enabled gem; disabled gems have no entry and
-// are skipped. Returns whether the caller should re-dispatch to pick up
-// the detailed_message decorators the gems prepend.
-static bool
-lazy_load_decoration_gems(VALUE exc)
+// Require error_highlight, did_you_mean, and syntax_suggest.
+// rb_define_gem_modules registers an autoload entry for each enabled gem;
+// disabled gems have no entry and are skipped.
+static void
+require_decoration_gems(void)
 {
-    static bool done = false;
-    if (done || !rb_ractor_main_p()) return false;
-    done = true;
-
-    // When entered through super from a decorator already sitting above
-    // this method, the caller decorates the result; re-dispatching would
-    // decorate it twice.
-    bool redispatch = rb_method_basic_definition_p(CLASS_OF(exc), id_detailed_message);
-
     static const char *const gems[] = {"ErrorHighlight", "DidYouMean", "SyntaxSuggest"};
     for (size_t i = 0; i < numberof(gems); i++) {
         VALUE feature = rb_autoload_p(rb_cObject, rb_intern(gems[i]));
@@ -1795,7 +1788,36 @@ lazy_load_decoration_gems(VALUE exc)
         rb_protect(load_decoration_gem, feature, &state);
         if (state) rb_set_errinfo(Qnil);
     }
+}
+
+// Load the decoration gems on the first error display instead of at boot.
+// Returns whether the caller should re-dispatch to pick up the
+// detailed_message decorators the gems prepend.
+static bool
+lazy_load_decoration_gems(VALUE exc)
+{
+    if (decoration_gems_loaded || !rb_ractor_main_p()) return false;
+    decoration_gems_loaded = true;
+
+    // When entered through super from a decorator already sitting above
+    // this method, the caller decorates the result; re-dispatching would
+    // decorate it twice.
+    bool redispatch = rb_method_basic_definition_p(CLASS_OF(exc), id_detailed_message);
+
+    require_decoration_gems();
     return redispatch;
+}
+
+// Load the decoration gems eagerly, e.g. from Process.warmup before a
+// pre-forking server forks, so the prepended detailed_message decorators
+// land in shared memory and do not bust method caches at runtime.
+void
+rb_eager_load_detailed_message_extension(void)
+{
+    if (decoration_gems_loaded || !rb_ractor_main_p()) return;
+    decoration_gems_loaded = true;
+
+    require_decoration_gems();
 }
 
 /*

--- a/error.c
+++ b/error.c
@@ -1780,14 +1780,20 @@ load_decoration_gem(VALUE feature)
 static void
 require_decoration_gems(void)
 {
+    // Loading must not disturb the caller's $!: it is called while
+    // displaying an exception. rb_protect does not preserve errinfo, so
+    // save and restore it around the requires, leaving $! untouched
+    // whether or not a require raises.
+    VALUE saved_errinfo = rb_errinfo();
     static const char *const gems[] = {"ErrorHighlight", "DidYouMean", "SyntaxSuggest"};
     for (size_t i = 0; i < numberof(gems); i++) {
         VALUE feature = rb_autoload_p(rb_cObject, rb_intern(gems[i]));
         if (NIL_P(feature)) continue;
         int state;
         rb_protect(load_decoration_gem, feature, &state);
-        if (state) rb_set_errinfo(Qnil);
+        (void)state;
     }
+    rb_set_errinfo(saved_errinfo);
 }
 
 // Load the decoration gems on the first error display instead of at boot.

--- a/gem_prelude.rb
+++ b/gem_prelude.rb
@@ -21,7 +21,7 @@ rescue LoadError
 end if defined?(DidYouMean)
 
 begin
-  require 'syntax_suggest/core_ext'
+  require 'syntax_suggest'
 rescue LoadError
   warn "`syntax_suggest' was not loaded."
 end if defined?(SyntaxSuggest)

--- a/gem_prelude.rb
+++ b/gem_prelude.rb
@@ -7,21 +7,3 @@ rescue LoadError => e
 else
   require 'bundled_gems'
 end if defined?(Gem)
-
-begin
-  require 'error_highlight'
-rescue LoadError
-  warn "`error_highlight' was not loaded."
-end if defined?(ErrorHighlight)
-
-begin
-  require 'did_you_mean'
-rescue LoadError
-  warn "`did_you_mean' was not loaded."
-end if defined?(DidYouMean)
-
-begin
-  require 'syntax_suggest'
-rescue LoadError
-  warn "`syntax_suggest' was not loaded."
-end if defined?(SyntaxSuggest)

--- a/internal/error.h
+++ b/internal/error.h
@@ -189,6 +189,7 @@ void rb_bug_without_die(const char *fmt, ...);
 NORETURN(void rb_no_implicit_conversion(VALUE val, const char *tname));
 NORETURN(void rb_cant_convert(VALUE val, const char *tname));
 NORETURN(void rb_cant_convert_invalid_return(VALUE val, const char *tname, const char *method_name, VALUE ret));
+void rb_eager_load_detailed_message_extension(void);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 /* error.c (export) */

--- a/process.c
+++ b/process.c
@@ -8713,11 +8713,18 @@ static VALUE rb_mProcID_Syscall;
  *  * Frees all empty heap pages and increments the allocatable pages counter
  *    by the number of pages freed.
  *  * Invoke +malloc_trim+ if available to free empty malloc pages.
+ *  * Eagerly loads the +error_highlight+, +did_you_mean+, and +syntax_suggest+
+ *    gems, which are otherwise loaded lazily on the first error display.
  */
 
 static VALUE
 proc_warmup(VALUE _)
 {
+    // Load the error decoration gems now so that their detailed_message
+    // decorators land in shared memory before a pre-forking server forks,
+    // instead of being loaded lazily on the first error at runtime.
+    rb_eager_load_detailed_message_extension();
+
     RB_VM_LOCKING() {
         rb_gc_prepare_heap();
     }

--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -869,7 +869,7 @@ class TestBox < Test::Unit::TestCase
       assert_match EXPERIMENTAL_WARNING_LINE_PATTERNS[1], error[1]
 
       assert_includes output.grep(/^before:/).join("\n"), '/bundled_gems.rb'
-      assert_includes output.grep(/^before:/).join("\n"), '/error_highlight.rb'
+      refute_includes output.grep(/^before:/).join("\n"), '/error_highlight.rb'
       assert_includes output.grep(/^after:/).join("\n"), '/bundled_gems.rb'
       assert_includes output.grep(/^after:/).join("\n"), '/error_highlight.rb'
     end

--- a/test/ruby/test_process.rb
+++ b/test/ruby/test_process.rb
@@ -2786,6 +2786,18 @@ EOS
     end;
   end
 
+  def test_warmup_eager_loads_error_decoration_gems
+    assert_separately(["--enable=gems"], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      features = ["error_highlight", "did_you_mean", "syntax_suggest"]
+      assert_empty($LOADED_FEATURES.grep(/\/(#{features.join("|")})\.rb\z/))
+      Process.warmup
+      features.each do |feature|
+        assert_includes($LOADED_FEATURES.map { File.basename(it, ".rb") }, feature)
+      end
+    end;
+  end
+
   def test_concurrent_group_and_pid_wait
     # Use a pair of pipes that will make long_pid exit when this test exits, to avoid
     # leaking temp processes.

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -401,6 +401,23 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  def test_detailed_message_in_ractor
+    # gem_prelude defers loading error_highlight, did_you_mean, and
+    # syntax_suggest until the first error display, which is not possible
+    # in non-main Ractors. Exception#detailed_message must still return
+    # the plain message there. [Feature #21951]
+    assert_ractor(<<~'RUBY', args: ["--enable=gems"], ignore_stderr: true)
+      message = Ractor.new do
+        begin
+          raise "boom"
+        rescue => e
+          e.detailed_message(highlight: false)
+        end
+      end.value
+      assert_include(message, "boom")
+    RUBY
+  end
+
   def assert_make_shareable(obj)
     refute Ractor.shareable?(obj), "object was already shareable"
     Ractor.make_shareable(obj)

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -402,19 +402,20 @@ class TestRactor < Test::Unit::TestCase
   end
 
   def test_detailed_message_in_ractor
-    # gem_prelude defers loading error_highlight, did_you_mean, and
-    # syntax_suggest until the first error display, which is not possible
-    # in non-main Ractors. Exception#detailed_message must still return
-    # the plain message there. [Feature #21951]
+    # The error decoration gems (error_highlight, did_you_mean, and
+    # syntax_suggest) are loaded lazily on the first error display. In a
+    # non-main Ractor the require is delegated to the main Ractor, so the
+    # decorations must appear there too. [Feature #21951]
     assert_ractor(<<~'RUBY', args: ["--enable=gems"], ignore_stderr: true)
       message = Ractor.new do
         begin
-          raise "boom"
-        rescue => e
+          1.timess
+        rescue NoMethodError => e
           e.detailed_message(highlight: false)
         end
       end.value
-      assert_include(message, "boom")
+      assert_include(message, "timess")
+      assert_include(message, "Did you mean?")
     RUBY
   end
 


### PR DESCRIPTION
Defer requiring these gems from boot time to first Exception#detailed_message call. They only enhance error display, so loading them eagerly is unnecessary overhead.

On macOS, `ruby -e1` boot time drops from 114ms to 30ms (with user-installed gems), matching `--disable-*` flag performance.