### PR TITLE
ZJIT: Remove WriteBarrier if load-store eliminated corresponding StoreField

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -607,7 +607,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::LoadSelf => gen_load_self(),
         &Insn::LoadField { recv, id, offset, return_type } => gen_load_field(asm, opnd!(recv), id, offset, return_type),
         &Insn::StoreField { recv, id, offset, val } => no_output!(gen_store_field(asm, opnd!(recv), id, offset, opnd!(val), function.type_of(val))),
-        &Insn::WriteBarrier { recv, val } => no_output!(gen_write_barrier(asm, opnd!(recv), opnd!(val), function.type_of(val))),
+        &Insn::WriteBarrier { recv, val, store: _ } => no_output!(gen_write_barrier(asm, opnd!(recv), opnd!(val), function.type_of(val))),
         &Insn::IsBlockGiven { lep } => gen_is_block_given(asm, opnd!(lep)),
         Insn::ArrayInclude { elements, target, state } => gen_array_include(jit, asm, opnds!(elements), opnd!(target), &function.frame_state(*state)),
         Insn::ArrayPackBuffer { elements, fmt, buffer, state } => gen_array_pack_buffer(jit, asm, opnds!(elements), opnd!(fmt), opnd!(buffer), &function.frame_state(*state)),

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -381,8 +381,8 @@ fn inline_array_aset(fun: &mut hir::Function, block: hir::BlockId, recv: hir::In
             use crate::hir::SideExitReason;
             let index = fun.push_insn(block, hir::Insn::GuardGreaterEq { left: index, right: zero, reason: SideExitReason::GuardGreaterEq, state });
 
-            let _ = fun.push_insn(block, hir::Insn::ArrayAset { array: recv, index, val });
-            fun.push_insn(block, hir::Insn::WriteBarrier { recv, val });
+            let store = fun.push_insn(block, hir::Insn::ArrayAset { array: recv, index, val });
+            fun.push_insn(block, hir::Insn::WriteBarrier { recv, val, store });
             return Some(val);
         }
     }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -872,7 +872,9 @@ pub enum Insn {
     /// Write `val` at an offset of `recv`.
     /// When writing a Ruby object to a Ruby object, one must use GuardNotFrozen (or equivalent) before and WriteBarrier after.
     StoreField { recv: InsnId, id: ID, offset: i32, val: InsnId },
-    WriteBarrier { recv: InsnId, val: InsnId },
+    /// Fire a GC write barrier for writing `val` into `recv`. Hold onto a reference to the
+    /// corresponding `StoreField` instruction to make eliding write barriers easier.
+    WriteBarrier { recv: InsnId, val: InsnId, store: InsnId },
 
     /// Check whether VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM is set in the environment flags.
     /// Returns CBool (0/1).
@@ -1329,10 +1331,14 @@ macro_rules! for_each_operand_impl {
             Insn::LoadField { recv, .. } => {
                 $visit_one!(recv);
             }
-            Insn::StoreField { recv, val, .. }
-            | Insn::WriteBarrier { recv, val } => {
+            Insn::StoreField { recv, val, .. } => {
                 $visit_one!(recv);
                 $visit_one!(val);
+            }
+            Insn::WriteBarrier { recv, val, store } => {
+                $visit_one!(recv);
+                $visit_one!(val);
+                $visit_one!(store);
             }
             Insn::GetGlobal { state, .. }
             | Insn::GetSpecialSymbol { state, .. }
@@ -1997,7 +2003,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                 write!(f, "LoadField {recv}, :{}@{:#x}", field_name, self.ptr_map.map_offset(offset))
             }
             &Insn::StoreField { recv, id, offset, val } => write!(f, "StoreField {recv}, :{}@{:#x}, {val}", id.contents_lossy(), self.ptr_map.map_offset(offset)),
-            &Insn::WriteBarrier { recv, val } => write!(f, "WriteBarrier {recv}, {val}"),
+            &Insn::WriteBarrier { recv, val, .. } => write!(f, "WriteBarrier {recv}, {val}"),
             Insn::SetIvar { self_val, id, val, .. } => write!(f, "SetIvar {self_val}, :{}, {val}", id.contents_lossy()),
             Insn::GetGlobal { id, .. } => write!(f, "GetGlobal :{}", id.contents_lossy()),
             Insn::SetGlobal { id, val, .. } => write!(f, "SetGlobal :{}, {val}", id.contents_lossy()),
@@ -2780,7 +2786,8 @@ impl Function {
             &GetIvar { self_val, id, ic, state } => GetIvar { self_val: find!(self_val), id, ic, state },
             &LoadField { recv, id, offset, return_type } => LoadField { recv: find!(recv), id, offset, return_type },
             &StoreField { recv, id, offset, val } => StoreField { recv: find!(recv), id, offset, val: find!(val) },
-            &WriteBarrier { recv, val } => WriteBarrier { recv: find!(recv), val: find!(val) },
+            // NB: no find!() for store because it doesn't have an output so it wouldn't be in the union-find.
+            &WriteBarrier { recv, val, store } => WriteBarrier { recv: find!(recv), val: find!(val), store },
             &SetIvar { self_val, id, ic, val, state } => SetIvar { self_val: find!(self_val), id, ic, val: find!(val), state },
             &GetClassVar { id, ic, state } => GetClassVar { id, ic, state },
             &SetClassVar { id, val, ic, state } => SetClassVar { id, val: find!(val), ic, state },
@@ -3745,8 +3752,8 @@ impl Function {
                                     };
 
                                     let replacement = if let (OptimizedMethodType::StructAset, &[val]) = (opt_type, args.as_slice()) {
-                                        self.push_insn(block, Insn::StoreField { recv: target, id: mid, offset, val });
-                                        self.push_insn(block, Insn::WriteBarrier { recv, val });
+                                        let store = self.push_insn(block, Insn::StoreField { recv: target, id: mid, offset, val });
+                                        self.push_insn(block, Insn::WriteBarrier { recv, val, store });
                                         val
                                     } else { // StructAref
                                         self.push_insn(block, Insn::LoadField { recv: target, id: mid, offset, return_type: types::BasicObject })
@@ -4445,8 +4452,8 @@ impl Function {
                             let offset = SIZEOF_VALUE_I32 * ivar_index as i32;
                             (as_heap, offset)
                         };
-                        self.push_insn(block, Insn::StoreField { recv: ivar_storage, id, offset, val });
-                        self.push_insn(block, Insn::WriteBarrier { recv: self_val, val });
+                        let store = self.push_insn(block, Insn::StoreField { recv: ivar_storage, id, offset, val });
+                        self.push_insn(block, Insn::WriteBarrier { recv: self_val, val, store });
                         if next_shape_id != recv_type.shape() {
                             // Write the new shape ID
                             let shape_id = self.push_insn(block, Insn::Const { val: Const::CShape(next_shape_id) });
@@ -4953,6 +4960,7 @@ impl Function {
         for block in self.rpo() {
             let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
             let mut new_insns = vec![];
+            let mut deleted_stores = vec![];
             for insn_id in old_insns {
                 let replacement_insn: InsnId = match self.find(insn_id) {
                     Insn::StoreField { recv, offset, val, .. } => {
@@ -4961,6 +4969,7 @@ impl Function {
                         // TODO(Jacob): Switch from actual to partial equality
                         if Some(val) == heap_entry {
                             // If the value is already stored, short circuit and don't add an instruction to the block
+                            deleted_stores.push(insn_id);
                             continue
                         }
                         // TODO(Jacob): Add TBAA to avoid removing so many entries
@@ -4984,7 +4993,12 @@ impl Function {
                         }
                         insn_id
                     }
-                    Insn::WriteBarrier { .. } => {
+                    Insn::WriteBarrier { store, .. } => {
+                        if deleted_stores.contains(&store) {
+                            // We dropped the corresponding store instruction; don't fire the write
+                            // barrier for no reason.
+                            continue;
+                        }
                         // Currently, WriteBarrier write effects are Allocator and Memory when we'd really like them to be flags.
                         // We don't use LoadField for mark bits so we can ignore them for now.
                         // But flags does not exist in our effects abstract heap modeling and we don't want to add special casing to effects.
@@ -5810,6 +5824,9 @@ impl Function {
                             }
                         }
                     }
+                    insn if matches!(insn, Insn::StoreField { .. } | Insn::ArrayAset { .. }) => {
+                        assigned.insert(insn_id);
+                    }
                     insn if insn.has_output() => {
                         assigned.insert(insn_id);
                     }
@@ -5832,6 +5849,9 @@ impl Function {
                     }
                     Ok(())
                 })?;
+                if matches!(self.insns[insn_id.0], Insn::StoreField { .. } | Insn::ArrayAset { .. }) {
+                    assigned.insert(insn_id);
+                }
                 if self.insns[insn_id.0].has_output() {
                     assigned.insert(insn_id);
                 }
@@ -5859,6 +5879,9 @@ impl Function {
                     }
                     Ok(())
                 })?;
+                if matches!(self.insns[insn_id.0], Insn::StoreField { .. } | Insn::ArrayAset { .. }) {
+                    assigned.insert(insn_id);
+                }
                 if self.insns[insn_id.0].has_output() {
                     assigned.insert(insn_id);
                 }
@@ -5952,7 +5975,7 @@ impl Function {
             Insn::SetIvar { self_val: left, val: right, .. }
             | Insn::NewRange { low: left, high: right, .. }
             | Insn::AnyToString { val: left, str: right, .. }
-            | Insn::WriteBarrier { recv: left, val: right } => {
+            | Insn::WriteBarrier { recv: left, val: right, store: _ } => {
                 self.assert_subtype(insn_id, left, types::BasicObject)?;
                 self.assert_subtype(insn_id, right, types::BasicObject)
             }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -14272,10 +14272,8 @@ mod hir_opt_tests {
           WriteBarrier v35, v13
           v40:CShape[0x1003] = Const CShape(0x1003)
           StoreField v35, :_shape_id@0x1000, v40
-          v20:HeapBasicObject = RefineType v8, HeapBasicObject
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
-          WriteBarrier v20, v13
           CheckInterrupts
           Return v13
         ");
@@ -14320,13 +14318,11 @@ mod hir_opt_tests {
           WriteBarrier v49, v16
           v54:CShape[0x1003] = Const CShape(0x1003)
           StoreField v49, :_shape_id@0x1000, v54
-          v23:HeapBasicObject = RefineType v10, HeapBasicObject
           v26:Fixnum[5] = Const Value(5)
           PatchPoint NoEPEscape(initialize)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
           v64:Fixnum[6] = Const Value(6)
           PatchPoint SingleRactorMode
-          WriteBarrier v23, v16
           CheckInterrupts
           Return v16
         ");
@@ -14368,12 +14364,8 @@ mod hir_opt_tests {
           WriteBarrier v43, v13
           v48:CShape[0x1003] = Const CShape(0x1003)
           StoreField v43, :_shape_id@0x1000, v48
-          v20:HeapBasicObject = RefineType v8, HeapBasicObject
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
-          WriteBarrier v20, v13
-          v28:HeapBasicObject = RefineType v20, HeapBasicObject
-          WriteBarrier v28, v13
           CheckInterrupts
           Return v13
         ");


### PR DESCRIPTION
We don't need these extra write barriers. Track the InsnId of the corresponding StoreField/ArrayAset instruction on the WriteBarrier and keep track of which ones were deleted in load-store elimination.
