### PR TITLE
ZJIT: Address feedback from @tekknolagi

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -1071,6 +1071,14 @@ impl Insn {
             _ => false
         }
     }
+
+    /// Returns true if this instruction copies a value to the same location.
+    fn is_redundant_mov(&self) -> bool {
+        matches!(
+            self,
+            Insn::Mov { dest, src } | Insn::LoadInto { dest, opnd: src } if src == dest
+        )
+    }
 }
 
 /// An iterator that will yield a non-mutable reference to each operand in turn
@@ -1860,8 +1868,9 @@ impl Assembler
             _ => insn.clone()
         };
 
-        // Push the stripped instruction
-        insns.push(stripped_insn);
+        if !stripped_insn.is_redundant_mov() {
+            insns.push(stripped_insn);
+        }
     }
 
     // Get the label for a given block by extracting it from the first instruction.
@@ -2362,8 +2371,11 @@ impl Assembler
                         .map(|group| group.to_vec())
                         .collect();
 
-                    // Push all survivors on the stack, pairing adjacent pushes when possible.
-                    let needs_alignment = cfg!(target_arch = "x86_64") && survivors.len() % 2 == 1;
+                    // FrameSetup keeps the function body 16-byte aligned on x86_64.
+                    // Saving an odd number of 8-byte registers here needs one extra
+                    // padding push so the nested C call still sees aligned SP.
+                    let needs_alignment_padding =
+                        cfg!(target_arch = "x86_64") && survivor_regs.len() % 2 == 1;
                     for group in &survivor_push_groups {
                         match group.as_slice() {
                             [left, right] => new_insns.push(Insn::CPushPair(*left, *right)),
@@ -2372,8 +2384,7 @@ impl Assembler
                         }
                         new_ids.push(None);
                     }
-                    // Maintain 16-byte stack alignment for x86_64
-                    if needs_alignment {
+                    if needs_alignment_padding {
                         new_insns.push(Insn::CPush(Opnd::Reg(ALLOC_REGS[0])));
                         new_ids.push(None);
                     }
@@ -2432,7 +2443,7 @@ impl Assembler
 
                     if survivors.is_empty() {
                         if call_result_live {
-                            // No survivors to restore — move result directly to output.
+                            // No survivors to restore; move result directly to output.
                             let out = Self::rewritten_opnd(out, assignments);
                             new_insns.push(Insn::Mov { dest: out, src: C_RET_OPND });
                             new_ids.push(None);
@@ -2445,8 +2456,8 @@ impl Assembler
                             new_ids.push(None);
                         }
 
-                        // Pop alignment padding (if needed)
-                        if needs_alignment {
+                        // Pop alignment padding, if any, before restoring saved registers.
+                        if needs_alignment_padding {
                             new_insns.push(Insn::CPopInto(Opnd::Reg(ALLOC_REGS[0])));
                             new_ids.push(None);
                         }
@@ -3730,21 +3741,8 @@ impl Assembler {
         asm_local.new_block_without_id("linearized");
 
         // Get linearized instructions with branch parameters expanded into ParallelMov
-        let linearized_insns = self.linearize_instructions();
-
-        // TODO: Aaron, this could be better. We don't need to do this, FIXME
-        // Process each linearized instruction
-        for insn in linearized_insns {
-            match insn {
-                Insn::Mov { dest, src } => {
-                    if src != dest {
-                        asm_local.push_insn(insn);
-                    }
-                },
-                _ => {
-                    asm_local.push_insn(insn);
-                }
-            }
+        for insn in self.linearize_instructions() {
+            asm_local.push_insn(insn);
         }
 
         asm_local

--- a/zjit/src/bitset.rs
+++ b/zjit/src/bitset.rs
@@ -124,73 +124,126 @@ impl<T: Into<usize> + Copy> BitSet<T> {
 mod tests {
     use super::BitSet;
 
+    fn set_with_capacity(num_bits: usize) -> BitSet<usize> {
+        BitSet::with_capacity(num_bits)
+    }
+
     #[test]
     #[should_panic]
     fn get_over_capacity_panics() {
-        let set = BitSet::with_capacity(0);
-        assert!(!set.get(0usize));
+        let set = set_with_capacity(0);
+        assert!(!set.get(0));
     }
 
     #[test]
     fn with_capacity_defaults_to_zero() {
-        let set = BitSet::with_capacity(4);
-        assert!(!set.get(0usize));
-        assert!(!set.get(1usize));
-        assert!(!set.get(2usize));
-        assert!(!set.get(3usize));
+        let set = set_with_capacity(4);
+        assert!(!set.get(0));
+        assert!(!set.get(1));
+        assert!(!set.get(2));
+        assert!(!set.get(3));
     }
 
     #[test]
     fn insert_sets_bit() {
-        let mut set = BitSet::with_capacity(4);
-        assert!(set.insert(1usize));
-        assert!(set.get(1usize));
+        let mut set = set_with_capacity(4);
+        assert!(set.insert(1));
+        assert!(set.get(1));
     }
 
     #[test]
     fn insert_with_set_bit_returns_false() {
-        let mut set = BitSet::with_capacity(4);
-        assert!(set.insert(1usize));
-        assert!(!set.insert(1usize));
+        let mut set = set_with_capacity(4);
+        assert!(set.insert(1));
+        assert!(!set.insert(1));
     }
 
     #[test]
     fn insert_all_sets_all_bits() {
-        let mut set = BitSet::with_capacity(4);
+        let mut set = set_with_capacity(4);
         set.insert_all();
-        assert!(set.get(0usize));
-        assert!(set.get(1usize));
-        assert!(set.get(2usize));
-        assert!(set.get(3usize));
+        assert!(set.get(0));
+        assert!(set.get(1));
+        assert!(set.get(2));
+        assert!(set.get(3));
+    }
+
+    #[test]
+    fn remove_clears_bit() {
+        let mut set = set_with_capacity(4);
+        set.insert(1);
+
+        assert!(set.remove(1));
+        assert!(!set.get(1));
+        assert!(!set.remove(1));
     }
 
     #[test]
     #[should_panic]
     fn intersect_with_panics_with_different_num_bits() {
-        let mut left: BitSet<usize> = BitSet::with_capacity(3);
-        let right = BitSet::with_capacity(4);
+        let mut left = set_with_capacity(3);
+        let right = set_with_capacity(4);
         left.intersect_with(&right);
     }
     #[test]
     fn intersect_with_keeps_only_common_bits() {
-        let mut left = BitSet::with_capacity(3);
-        let mut right = BitSet::with_capacity(3);
-        left.insert(0usize);
-        left.insert(1usize);
-        right.insert(1usize);
-        right.insert(2usize);
+        let mut left = set_with_capacity(3);
+        let mut right = set_with_capacity(3);
+        left.insert(0);
+        left.insert(1);
+        right.insert(1);
+        right.insert(2);
         left.intersect_with(&right);
-        assert!(!left.get(0usize));
-        assert!(left.get(1usize));
-        assert!(!left.get(2usize));
+        assert!(!left.get(0));
+        assert!(left.get(1));
+        assert!(!left.get(2));
+    }
+
+    #[test]
+    fn union_with_sets_bits_from_both_inputs() {
+        let mut left = set_with_capacity(4);
+        let mut right = set_with_capacity(4);
+        left.insert(0);
+        right.insert(2);
+
+        assert!(left.union_with(&right));
+        assert!(left.get(0));
+        assert!(left.get(2));
+        assert!(!left.union_with(&right));
+    }
+
+    #[test]
+    fn difference_with_removes_overlapping_bits() {
+        let mut left = set_with_capacity(4);
+        let mut right = set_with_capacity(4);
+        left.insert(0);
+        left.insert(1);
+        right.insert(1);
+
+        assert!(left.difference_with(&right));
+        assert!(left.get(0));
+        assert!(!left.get(1));
+        assert!(!left.difference_with(&right));
+    }
+
+    #[test]
+    fn equals_compares_entries() {
+        let mut left = set_with_capacity(4);
+        let mut right = set_with_capacity(4);
+        left.insert(1);
+        right.insert(1);
+        assert!(left.equals(&right));
+
+        right.insert(2);
+        assert!(!left.equals(&right));
     }
 
     #[test]
     fn test_iter_set_bits() {
-        let mut set: BitSet<usize> = BitSet::with_capacity(10);
-        set.insert(1usize);
-        set.insert(5usize);
-        set.insert(9usize);
+        let mut set = set_with_capacity(10);
+        set.insert(1);
+        set.insert(5);
+        set.insert(9);
 
         let set_bits: Vec<usize> = set.iter_set_bits().collect();
         assert_eq!(set_bits, vec![1, 5, 9]);
@@ -198,14 +251,14 @@ mod tests {
 
     #[test]
     fn test_iter_set_bits_empty() {
-        let set: BitSet<usize> = BitSet::with_capacity(10);
+        let set = set_with_capacity(10);
         let set_bits: Vec<usize> = set.iter_set_bits().collect();
         assert_eq!(set_bits, vec![]);
     }
 
     #[test]
     fn test_iter_set_bits_all() {
-        let mut set: BitSet<usize> = BitSet::with_capacity(5);
+        let mut set = set_with_capacity(5);
         set.insert_all();
         let set_bits: Vec<usize> = set.iter_set_bits().collect();
         assert_eq!(set_bits, vec![0, 1, 2, 3, 4]);
@@ -213,11 +266,11 @@ mod tests {
 
     #[test]
     fn test_iter_set_bits_large() {
-        let mut set: BitSet<usize> = BitSet::with_capacity(200);
-        set.insert(0usize);
-        set.insert(127usize);
-        set.insert(128usize);
-        set.insert(199usize);
+        let mut set = set_with_capacity(200);
+        set.insert(0);
+        set.insert(127);
+        set.insert(128);
+        set.insert(199);
 
         let set_bits: Vec<usize> = set.iter_set_bits().collect();
         assert_eq!(set_bits, vec![0, 127, 128, 199]);

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -328,7 +328,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
 
     // Create all LIR basic blocks corresponding to HIR basic blocks
     for (rpo_idx, &block_id) in reverse_post_order.iter().enumerate() {
-        // Skip the entries superblock — it's an internal CFG artifact
+        // Skip the entries superblock; it's an internal CFG artifact
         if block_id == function.entries_block { continue; }
         let lir_block_id = asm.new_block(block_id, function.is_entry_block(block_id), rpo_idx);
         hir_to_lir[block_id.0] = Some(lir_block_id);
@@ -336,7 +336,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
 
     // Compile each basic block
     for (rpo_idx, &block_id) in reverse_post_order.iter().enumerate() {
-        // Skip the entries superblock — it's an internal CFG artifact
+        // Skip the entries superblock; it's an internal CFG artifact
         if block_id == function.entries_block { continue; }
         // Set the current block to the LIR block that corresponds to this
         // HIR block.
@@ -1901,22 +1901,22 @@ fn gen_is_a(jit: &mut JITState, asm: &mut Assembler, obj: Opnd, class: Opnd) -> 
             _ => asm.load(obj),
         };
 
-        // Immediate → definitely not String/Array/Hash
+        // Immediate: definitely not String/Array/Hash
         asm.test(val, Opnd::UImm(RUBY_IMMEDIATE_MASK as u64));
         asm.jnz(jit, result_edge(Qfalse.into()));
 
-        // Qfalse → definitely not String/Array/Hash
+        // Qfalse: definitely not String/Array/Hash
         asm.cmp(val, Qfalse.into());
         asm.je(jit, result_edge(Qfalse.into()));
 
-        // Heap object → check builtin type
+        // Heap object: check builtin type
         let flags = asm.load(Opnd::mem(VALUE_BITS, val, RUBY_OFFSET_RBASIC_FLAGS));
         let obj_builtin_type = asm.and(flags, Opnd::UImm(RUBY_T_MASK as u64));
         asm.cmp(obj_builtin_type, Opnd::UImm(builtin_type as u64));
         let result = asm.csel_e(Qtrue.into(), Qfalse.into());
         asm.jmp(result_edge(result));
 
-        // Result block — receives the value via block parameter (phi node)
+        // Result block: receives the value via block parameter (phi node)
         asm.set_current_block(result_block);
         let label = jit.get_label(asm, result_block, hir_block_id);
         asm.write_label(label);
@@ -2257,21 +2257,21 @@ fn gen_has_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, ty: Typ
             _ => asm.load(val),
         };
 
-        // Immediate → definitely not the class
+        // Immediate: definitely not the class
         asm.test(val, (RUBY_IMMEDIATE_MASK as u64).into());
         asm.jnz(jit, result_edge(Opnd::Imm(0)));
 
-        // Qfalse → definitely not the class
+        // Qfalse: definitely not the class
         asm.cmp(val, Qfalse.into());
         asm.je(jit, result_edge(Opnd::Imm(0)));
 
-        // Heap object → check klass field
+        // Heap object: check klass field
         let klass = asm.load(Opnd::mem(64, val, RUBY_OFFSET_RBASIC_KLASS));
         asm.cmp(klass, Opnd::Value(expected_class));
         let result = asm.csel_e(Opnd::UImm(1), Opnd::Imm(0));
         asm.jmp(result_edge(result));
 
-        // Result block — receives the value via block parameter (phi node)
+        // Result block: receives the value via block parameter (phi node)
         asm.set_current_block(result_block);
         let label = jit.get_label(asm, result_block, hir_block_id);
         asm.write_label(label);


### PR DESCRIPTION
I pushed the redundant move elimination to the linearization pass. I'm unsure if `resolve_parallel_mov_pass` is necessary anymore.