### PR TITLE
[Bug #21301] Fix Time.new month-mday normalization with UTC zone

### DIFF
--- a/test/ruby/test_time.rb
+++ b/test/ruby/test_time.rb
@@ -1515,4 +1515,35 @@ class TestTime < Test::Unit::TestCase
       assert_equal("-10000-01-01T00:00:00Z", Time.utc(-10000).__send__(method))
     end
   end
+
+  def test_utc_month_mday_normalization
+    bug21301 = "[ruby-core:121801] [Bug #21301]"
+
+    # 30-day months: April 31 -> May 1
+    assert_equal(Time.utc(2025, 5, 1), Time.new(2025, 4, 31, 0, 0, 0, "UTC"), bug21301)
+    assert_equal(5, Time.new(2025, 4, 31, 0, 0, 0, "UTC").mon, bug21301)
+    assert_equal(1, Time.new(2025, 4, 31, 0, 0, 0, "UTC").mday, bug21301)
+
+    # June, September, November (other 30-day months)
+    assert_equal(Time.utc(2025, 7, 1), Time.new(2025, 6, 31, 0, 0, 0, "UTC"), bug21301)
+    assert_equal(Time.utc(2025, 10, 1), Time.new(2025, 9, 31, 0, 0, 0, "UTC"), bug21301)
+    assert_equal(Time.utc(2025, 12, 1), Time.new(2025, 11, 31, 0, 0, 0, "UTC"), bug21301)
+
+    # February in non-leap year: Feb 29 -> Mar 1
+    assert_equal(Time.utc(2025, 3, 1), Time.new(2025, 2, 29, 0, 0, 0, "UTC"), bug21301)
+
+    # February in leap year: Feb 29 is valid
+    assert_equal(Time.utc(2024, 2, 29), Time.new(2024, 2, 29, 0, 0, 0, "UTC"), bug21301)
+    assert_equal(2, Time.new(2024, 2, 29, 0, 0, 0, "UTC").mon, bug21301)
+
+    # Combined with hour=24 wraparound: April 31 24:00 -> May 2
+    assert_equal(Time.utc(2025, 5, 2), Time.new(2025, 4, 31, 24, 0, 0, "UTC"), bug21301)
+
+    # String parsing path
+    assert_equal(Time.utc(2025, 5, 1), Time.new("2025-04-31T00:00:00Z"), bug21301)
+
+    # Consistency with +00:00
+    assert_equal(Time.new(2025, 4, 31, 0, 0, 0, "+00:00").to_i,
+                 Time.new(2025, 4, 31, 0, 0, 0, "UTC").to_i, bug21301)
+  end
 end

--- a/time.c
+++ b/time.c
@@ -2461,6 +2461,34 @@ find_timezone(VALUE time, VALUE zone)
     return rb_check_funcall_default(klass, id_find_timezone, 1, &zone, Qnil);
 }
 
+/* Normalize month-mday for months with fewer than 31 days.
+ * e.g. April 31 -> May 1, Feb 29 (non-leap) -> Mar 1 */
+static void
+vtm_normalize_month_mday(struct vtm *vtm)
+{
+    switch (vtm->mon) {
+      case 2:
+        {
+            /* this drops higher bits but it's not a problem to calc leap year */
+            unsigned int mday2 = leap_year_v_p(vtm->year) ? 29 : 28;
+            if (vtm->mday > mday2) {
+                vtm->mday -= mday2;
+                vtm->mon++;
+            }
+        }
+        break;
+      case 4:
+      case 6:
+      case 9:
+      case 11:
+        if (vtm->mday == 31) {
+            vtm->mon++;
+            vtm->mday = 1;
+        }
+        break;
+    }
+}
+
 /* Turn the special case 24:00:00 of already validated vtm into
  * 00:00:00 the next day */
 static void
@@ -2559,6 +2587,7 @@ time_init_vtm(VALUE time, struct vtm vtm, VALUE zone)
     if (utc == UTC_ZONE) {
         time_set_timew(time, tobj, timegmw(&vtm));
         vtm.isdst = 0; /* No DST in UTC */
+        vtm_normalize_month_mday(&vtm);
         vtm_day_wraparound(&vtm);
         time_set_vtm(time, tobj, vtm);
         tobj->vtm.tm_got = 1;
@@ -3219,28 +3248,7 @@ time_arg(int argc, const VALUE *argv, struct vtm *vtm)
         vtm->mday = obj2ubits(v[2], 5);
     }
 
-    /* normalize month-mday */
-    switch (vtm->mon) {
-      case 2:
-        {
-            /* this drops higher bits but it's not a problem to calc leap year */
-            unsigned int mday2 = leap_year_v_p(vtm->year) ? 29 : 28;
-            if (vtm->mday > mday2) {
-                vtm->mday -= mday2;
-                vtm->mon++;
-            }
-        }
-        break;
-      case 4:
-      case 6:
-      case 9:
-      case 11:
-        if (vtm->mday == 31) {
-            vtm->mon++;
-            vtm->mday = 1;
-        }
-        break;
-    }
+    vtm_normalize_month_mday(vtm);
 
     vtm->hour = NIL_P(v[3])?0:obj2ubits(v[3], 5);
 


### PR DESCRIPTION
## Summary

`Time.new` with `"UTC"` zone skips month-mday normalization, producing invalid dates:

```ruby
Time.new(2025, 4, 31, 0, 0, 0, "UTC").to_s   #=> "2025-04-31 00:00:00 UTC" (!)
Time.new(2025, 4, 31, 0, 0, 0, "+00:00").to_s #=> "2025-05-01 00:00:00 +0000"
Time.utc(2025, 4, 31).to_s                     #=> "2025-05-01 00:00:00 UTC"
```

The internal timestamp is correct (all three agree on `to_i`), but the cached `vtm` fields (`mon`, `mday`) are wrong because the UTC path in `time_init_vtm()` sets `tm_got=1` without normalizing month-mday first.

## Fix

- Extract the existing month-mday normalization from `time_arg()` into a reusable `vtm_normalize_month_mday()` function
- Call it in the UTC branch of `time_init_vtm()` before `vtm_day_wraparound()`

This also fixes the string parsing path (`Time.new("2025-04-31T00:00:00Z")`), which flows through the same `time_init_vtm()` function.

https://bugs.ruby-lang.org/issues/21301