### PR TITLE
[Bug #21849] Fix Ripper.lex splitting tstring_content on invalid interpolation

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -6766,6 +6766,7 @@ none		: /* none */
 
 static int regx_options(struct parser_params*);
 static int tokadd_string(struct parser_params*,int,int,int,long*,rb_encoding**,rb_encoding**);
+static enum yytokentype parser_peek_variable_name(struct parser_params *p);
 static void tokaddmbc(struct parser_params *p, int c, rb_encoding *enc);
 static enum yytokentype parse_string(struct parser_params*,rb_strterm_literal_t*);
 static enum yytokentype here_document(struct parser_params*,rb_strterm_heredoc_t*);
@@ -8391,7 +8392,11 @@ tokadd_string(struct parser_params *p,
         }
         else if ((func & STR_FUNC_EXPAND) && c == '#' && !lex_eol_p(p)) {
             unsigned char c2 = *p->lex.pcur;
-            if (c2 == '$' || c2 == '@' || c2 == '{') {
+            if (c2 == '{') {
+                pushback(p, c);
+                break;
+            }
+            if ((c2 == '$' || c2 == '@') && parser_peek_variable_name(p)) {
                 pushback(p, c);
                 break;
             }

--- a/test/ripper/test_scanner_events.rb
+++ b/test/ripper/test_scanner_events.rb
@@ -623,6 +623,12 @@ class TestRipper::ScannerEvents < Test::Unit::TestCase
     assert_equal ["a\nb\nc"],
                  scan('tstring_content', ":'a\nb\nc'"),
                  "bug#4544"
+    assert_equal ['x#$%'],
+                 scan('tstring_content', '"x#$%"'),
+                 "[Bug #21849] invalid gvar after #$ should not split token"
+    assert_equal ['x#@%y'],
+                 scan('tstring_content', '"x#@%y"'),
+                 "[Bug #21849] invalid ivar after #@ should not split token"
   end
 
   def test_tstring_end


### PR DESCRIPTION
## Summary

`Ripper.lex('"x#$%"')` incorrectly emits two `tstring_content` tokens (`"x"` + `"#$%"`) instead of one (`"x#$%"`). Same issue for `#@` with invalid following characters.

```ruby
# Before (two tokens):
Ripper.lex('"x#$%"')
#=> [... [:on_tstring_content, "x"], [:on_tstring_content, "#$%"], ...]

# After (single token, matches Prism):
Ripper.lex('"x#$%"')
#=> [... [:on_tstring_content, "x#$%"], ...]
```

## Root cause

In `tokadd_string()`, the lexer breaks out of the scanning loop on any `#$` or `#@` without checking if the following character forms a valid variable name. The caller (`parser_peek_variable_name`) then correctly rejects it, but by then the token is already split.

## Fix

Split the `#{`/`#$`/`#@` check: `#{` always breaks (embedded expression), but `#$` and `#@` now only break when `parser_peek_variable_name()` confirms a valid variable follows. Valid interpolations (`#$_`, `#$!`, `#@foo`) are unaffected.

https://bugs.ruby-lang.org/issues/21849