### PR TITLE
ZJIT: Implement dead store elimination

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4964,9 +4964,11 @@ impl Function {
         }
 
         // This helper function is used to clear the cache for matching offsets
-        // while we don't have type based alias.
+        // while we don't have type based alias analysis.
         // TBAA will primarily modify any part of this optimization that
         // currently uses this helper function.
+        // TODO: Rename this to talk about preserving valid (non-aliased values)
+        // TODO: Add more comments
         fn flush_aliasing(map: &mut HashMap<HeapKey, InsnId>, offset: i32) {
             map.retain(|HeapKey { object: _, offset: off }, _| *off != offset);
         }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5050,8 +5050,10 @@ impl Function {
                     },
                     insn => {
                         let insn_reads_memory = insn.effects_of().includes(Effect::read(abstract_heaps::Memory));
-                        let insn_uses_control_flow = insn.effects_of().includes(effects::Control);
-                        // TODO(Jacob): Once we update from extended basic blocks to normal basic blocks, we can remove the control flow check
+                        let insn_uses_control_flow = insn.effects_of().includes(Effect::write(abstract_heaps::Control));
+                        // TODO(Jacob): We should refine the control flow check
+                        // For instance, we could sink the StoreField instruction into failed guards
+                        // This allows us to preserve the dead store optimization.
                         if insn_reads_memory || insn_uses_control_flow {
                             compile_time_heap.clear();
                         }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5049,12 +5049,12 @@ impl Function {
                         flush_aliasing(&mut compile_time_heap, offset);
                     },
                     insn => {
-                        let insn_reads_memory = insn.effects_of().includes(Effect::read(abstract_heaps::Memory));
-                        let insn_uses_control_flow = insn.effects_of().includes(Effect::write(abstract_heaps::Control));
+                        let insn_can_read_memory = insn.effects_of().includes(Effect::read(abstract_heaps::Memory));
+                        let insn_can_modify_control_flow = insn.effects_of().includes(Effect::write(abstract_heaps::Control));
                         // TODO(Jacob): We should refine the control flow check
                         // For instance, we could sink the StoreField instruction into failed guards
                         // This allows us to preserve the dead store optimization.
-                        if insn_reads_memory || insn_uses_control_flow {
+                        if insn_can_read_memory || insn_can_modify_control_flow {
                             compile_time_heap.clear();
                         }
                     }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5770,6 +5770,7 @@ impl Function {
             // End strength reduction bucket
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
             (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
+            (eliminate_dead_stores) => { Counter::compile_hir_eliminate_dead_stores_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
             (clean_cfg) => { Counter::compile_hir_clean_cfg_time_ns };
             (remove_redundant_patch_points) => { Counter::compile_hir_remove_redundant_patch_points_time_ns };

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4990,6 +4990,76 @@ impl Function {
         }
     }
 
+    // This pass assumes that load_store_optimization has already run
+    // This means that we will never have cases where loads and stores are
+    // repeated with the same offset and value.
+    // However, we still may have unnecessary stores. For the purposes of this
+    // pass, unnecessary means that a store to an offset is not utilized by
+    // other HIR instructions before a second store to the same offset occurs.
+    // Removing one of these two stores does not alter program behavior.
+    fn eliminate_dead_stores(&mut self) {
+        // #[derive(PartialEq, Eq, Hash)]
+        // struct StoreHeap {
+        //     offset: i32,
+        // }
+
+        for block in self.rpo() {
+            let mut dead_stores: HashSet<InsnId> = HashSet::new();
+            let mut active_stores: HashMap<i32, InsnId> = HashMap::new();
+            let mut insns = std::mem::take(&mut self.blocks[block.0].insns);
+            // Iterate over the instructions backwards
+            // If we find a store
+            //   If it's not in current_stores, add it with StoreStatus::Used
+            //   If it is, check if we can eliminate it and add it to dead_stores based on current_stores. also update current_stores
+            //   cases:
+            //     - it's used. Reset the current_stores entry with the new store.
+            //     - it's not used. Add the new store to dead_stores and leave current_stores the same.
+            // If we find an effectful instruction, mark any stores in the heap as used
+            // If we find a load, mark the relevant store in the heap as used
+            for i in (0..insns.len()).rev() {
+                let insn_id = insns[i];
+                match self.find(insn_id) {
+                    Insn::StoreField { offset, .. } => {
+                        // We found a second store while one was tracked.
+                        // We can elide one.
+                        // TODO(Jacob): Figure out if it matters which store we eliminate
+                        if let Some(store_id) = active_stores.get(&offset) {
+                            dead_stores.insert(*store_id);
+                        }
+                        // We always track the most recent store, though we
+                        // could use the original store if we elide the most
+                        // recent one instead.
+                        // This works because the basic blocks do not have
+                        // control flow, making lifetime tracking simple. More
+                        // complex algorithms are required for dead store on a
+                        // CFG.
+                        active_stores.insert(offset, insn_id);
+                    }
+                    Insn::LoadField { offset, .. } => {
+                        // If a load is found, then any earlier store was
+                        // necessary. We know this because redundant loads and
+                        // stores were already eliminated, implying the
+                        // hypothetical StoreField we haven't found yet has a
+                        // different value than the one in active_stores.
+                        active_stores.remove(&offset);
+                    }
+                    insn => {
+                        // If the instruction has memory effects, we cannot
+                        // assume our active_stores are not loaded nor stored.
+                        if insn.effects_of().includes(effects::Memory) {
+                            active_stores.clear();
+                        }
+                    }
+
+                }
+            }
+            // TODO: Figure out if we need to handle a write barrier special case. Do these also need to be removed after removing stores?
+            // Prune away any dead stores
+            insns.retain(|i| dead_stores.contains(i));
+            self.blocks[block.0].insns = insns;
+        }
+    }
+
     /// Fold a binary operator on fixnums.
     fn fold_fixnum_bop(&mut self, insn_id: InsnId, left: InsnId, right: InsnId, f: impl FnOnce(Option<i64>, Option<i64>) -> Option<i64>) -> InsnId {
         f(self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value())
@@ -5715,6 +5785,7 @@ impl Function {
         run_pass!(convert_no_profile_sends);
         run_pass!(optimize_load_store);
         run_pass!(canonicalize);
+        run_pass!(eliminate_dead_stores);
         run_pass!(fold_constants);
         run_pass!(clean_cfg);
         run_pass!(remove_redundant_patch_points);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4998,14 +4998,23 @@ impl Function {
     // other HIR instructions before a second store to the same offset occurs.
     // Removing one of these two stores does not alter program behavior.
     fn eliminate_dead_stores(&mut self) {
-        // #[derive(PartialEq, Eq, Hash)]
-        // struct StoreHeap {
-        //     offset: i32,
-        // }
+        #[derive(PartialEq, Eq, Hash)]
+        struct StoreHeap {
+            // TODO: Is object a good name here? If not, what should it be instead?
+            object: InsnId,
+            offset: i32,
+        }
+
+        // This helper function is used while we don't have type based alias
+        // analysis. Matching offsets could result in aliased objects that need
+        // to be clear.
+        fn prune_stores(map: &mut HashMap<StoreHeap, InsnId>, offset: i32) {
+            map.retain(|StoreHeap { object: _, offset: off }, _| *off != offset);
+        }
 
         for block in self.rpo() {
             let mut dead_stores: HashSet<InsnId> = HashSet::new();
-            let mut active_stores: HashMap<i32, InsnId> = HashMap::new();
+            let mut active_stores: HashMap<StoreHeap, InsnId> = HashMap::new();
             let mut insns = std::mem::take(&mut self.blocks[block.0].insns);
             // Iterate over the instructions backwards
             // If we find a store
@@ -5019,41 +5028,45 @@ impl Function {
             for i in (0..insns.len()).rev() {
                 let insn_id = insns[i];
                 match self.find(insn_id) {
-                    Insn::StoreField { offset, .. } => {
-                        // We found a second store while one was tracked.
-                        // We can elide one.
-                        // TODO(Jacob): Figure out if it matters which store we eliminate
-                        // TODO: BUG FIX: We obviously need to keep the final store, not the first!
-                        // This is because load_store_optimization ensures each store is different.
-                        // We need to keep the last one to preserve correctness. That changes the logic around for this block below
-                        //
-                        // TODO: Refine the key of active_stores
-                        // Additionally, we can't just do offset. We need to consider the object and address the same aliasing issues
-                        // we have in load store optimization.
-                        if let Some(store_id) = active_stores.get(&offset) {
-                            dead_stores.insert(*store_id);
+                    Insn::StoreField { recv, offset, .. } => {
+                        let key = StoreHeap { object: recv, offset };
+                        // If an older store is being tracked, then there have
+                        // been no usees between stores and the first store is
+                        // dead.
+                        if active_stores.contains_key(&key) {
+                            dead_stores.insert(insn_id);
                         }
-                        // We always track the most recent store, though we
-                        // could use the original store if we elide the most
-                        // recent one instead.
-                        // This works because the basic blocks do not have
-                        // control flow, making lifetime tracking simple. More
-                        // complex algorithms are required for dead store on a
-                        // CFG.
-                        active_stores.insert(offset, insn_id);
+                        // Otherwise, we have a new store to begin tracking.
+                        // Because we don't have type based alias analysis, we
+                        // need to remove all other stores with the same offset
+                        // before adding our own.
+                        else {
+                            prune_stores(&mut active_stores, offset);
+                            active_stores.insert(key, insn_id);
+                        }
                     }
-                    Insn::LoadField { offset, .. } => {
-                        // If a load is found, then any earlier store was
-                        // necessary. We know this because redundant loads and
-                        // stores were already eliminated, implying the
-                        // hypothetical StoreField we haven't found yet has a
-                        // different value than the one in active_stores.
-                        active_stores.remove(&offset);
+                    // If a load is found, then any earlier store was
+                    // necessary. We know this because redundant loads and
+                    // stores were already eliminated, implying the
+                    // hypothetical StoreField we haven't found yet has a
+                    // different value than the one in active_stores.
+                    // The following lines are required when we have type
+                    // based alias analysis and the following call to prune
+                    // stores is no longer used.
+                    // Insn::LoadField { recv, offset, .. } => {
+                    //     let key = StoreHeap { object: recv, offset };
+                    //     active_stores.remove(&key);
+                    Insn::LoadField{ offset, .. } => {
+                        // Because we don't have type based alias analysis, we
+                        // can't just remove the (up to) one entry of the
+                        // StoreHeap key in active_stores. We need to remove all
+                        // such keys that could alias.
+                        prune_stores(&mut active_stores, offset);
                     }
                     insn => {
-                        // If the instruction has memory effects, we cannot
-                        // assume our active_stores are not loaded nor stored.
-                        if insn.effects_of().includes(effects::Memory) {
+                        // If the instruction can read memory, we cannot assume
+                        // entries of active_stores are not loaded.
+                        if insn.effects_of().includes(Effect::write(abstract_heaps::Memory)) {
                             active_stores.clear();
                         }
                     }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5062,92 +5062,92 @@ impl Function {
     // other HIR instructions before a second store to the same offset occurs.
     // Removing one of these two stores does not alter program behavior.
     // TODO: Improve comments and clean up algorithm sketch
-    fn eliminate_dead_stores(&mut self) {
-        #[derive(PartialEq, Eq, Hash)]
-        struct StoreHeap {
-            // TODO: Is object a good name here? If not, what should it be instead?
-            object: InsnId,
-            offset: i32,
-        }
+    // fn eliminate_dead_stores(&mut self) {
+    //     #[derive(PartialEq, Eq, Hash)]
+    //     struct StoreHeap {
+    //         // TODO: Is object a good name here? If not, what should it be instead?
+    //         object: InsnId,
+    //         offset: i32,
+    //     }
 
-        // This helper function is used while we don't have type based alias
-        // analysis. Matching offsets could result in aliased objects that need
-        // to be clear.
-        fn prune_stores(map: &mut HashMap<StoreHeap, InsnId>, offset: i32) {
-            map.retain(|StoreHeap { object: _, offset: off }, _| *off != offset);
-        }
+    //     // This helper function is used while we don't have type based alias
+    //     // analysis. Matching offsets could result in aliased objects that need
+    //     // to be clear.
+    //     fn prune_stores(map: &mut HashMap<StoreHeap, InsnId>, offset: i32) {
+    //         map.retain(|StoreHeap { object: _, offset: off }, _| *off != offset);
+    //     }
 
-        for block in self.rpo() {
-            // TODO: Probably convert this to a vec of tuples? Time complexity is worse but constant factors are better
-            let mut active_stores: HashMap<StoreHeap, InsnId> = HashMap::new();
-            let insns = std::mem::take(&mut self.blocks[block.0].insns);
-            let mut new_insns = vec![];
-            for insn_id in insns.iter().rev().copied() {
-                match self.find(insn_id) {
-                    Insn::StoreField { recv, offset, .. } => {
-                        let key = StoreHeap { object: self.chase_insn(recv), offset };
-                        // If an older store is being tracked, then there have
-                        // been no usees between stores and the first store is
-                        // dead and should not be emitted.
-                        if active_stores.contains_key(&key) {
-                            continue
-                        }
-                        // Otherwise, we have a new store to begin tracking.
-                        // Because we don't have type based alias analysis, we
-                        // need to remove all other stores with the same offset
-                        // before adding our own.
-                        else {
-                            prune_stores(&mut active_stores, offset);
-                            active_stores.insert(key, insn_id);
-                        }
-                    }
-                    // If a load is found, then any earlier store was
-                    // necessary. We know this because redundant loads and
-                    // stores were already eliminated, implying the
-                    // hypothetical StoreField we haven't found yet has a
-                    // different value than the one in active_stores.
-                    // The following lines are required when we have type
-                    // based alias analysis and the following call to prune
-                    // stores is no longer used.
-                    // Insn::LoadField { recv, offset, .. } => {
-                    //     let key = StoreHeap { object: self.chase_insn(recv), offset };
-                    //     active_stores.remove(&key);
-                    Insn::LoadField{ offset, .. } => {
-                        // Because we don't have type based alias analysis, we
-                        // can't just remove the (up to) one entry of the
-                        // StoreHeap key in active_stores. We need to remove all
-                        // such keys that could alias.
-                        prune_stores(&mut active_stores, offset);
-                    }
-                    Insn::WriteBarrier { .. } => {
-                        // Currently, WriteBarrier write effects are Allocator and Memory when we'd really like them to be flags.
-                        // We don't use LoadField for mark bits so we can ignore them for now.
-                        // But flags does not exist in our effects abstract heap modeling and we don't want to add special casing to effects.
-                        // This special casing in this pass here should be removed once we refine our effects system to provide greater granularity for WriteBarrier.
-                        // TODO: use TBAA
-                        let offset = RUBY_OFFSET_RBASIC_FLAGS;
-                        prune_stores(&mut active_stores, offset);
-                    },
-                    insn => {
-                        // If the instruction can read memory, we cannot assume
-                        // entries of active_stores are not loaded. This is because we use
-                        // extended basic blocks and we should probably change this to be
-                        // standard basic blocks.
-                        // TODO: Add a test for this case
-                        if insn.effects_of().includes(Effect::read(abstract_heaps::Memory)) {
-                            active_stores.clear();
-                        }
-                        else if insn.effects_of().includes(effects::Control) {
-                            active_stores.clear();
-                        }
-                    }
-                }
-                new_insns.push(insn_id);
-            }
-            new_insns.reverse();
-            self.blocks[block.0].insns = new_insns;
-        }
-    }
+    //     for block in self.rpo() {
+    //         // TODO: Probably convert this to a vec of tuples? Time complexity is worse but constant factors are better
+    //         let mut active_stores: HashMap<StoreHeap, InsnId> = HashMap::new();
+    //         let insns = std::mem::take(&mut self.blocks[block.0].insns);
+    //         let mut new_insns = vec![];
+    //         for insn_id in insns.iter().rev().copied() {
+    //             match self.find(insn_id) {
+    //                 Insn::StoreField { recv, offset, .. } => {
+    //                     let key = StoreHeap { object: self.chase_insn(recv), offset };
+    //                     // If an older store is being tracked, then there have
+    //                     // been no usees between stores and the first store is
+    //                     // dead and should not be emitted.
+    //                     if active_stores.contains_key(&key) {
+    //                         continue
+    //                     }
+    //                     // Otherwise, we have a new store to begin tracking.
+    //                     // Because we don't have type based alias analysis, we
+    //                     // need to remove all other stores with the same offset
+    //                     // before adding our own.
+    //                     else {
+    //                         prune_stores(&mut active_stores, offset);
+    //                         active_stores.insert(key, insn_id);
+    //                     }
+    //                 }
+    //                 // If a load is found, then any earlier store was
+    //                 // necessary. We know this because redundant loads and
+    //                 // stores were already eliminated, implying the
+    //                 // hypothetical StoreField we haven't found yet has a
+    //                 // different value than the one in active_stores.
+    //                 // The following lines are required when we have type
+    //                 // based alias analysis and the following call to prune
+    //                 // stores is no longer used.
+    //                 // Insn::LoadField { recv, offset, .. } => {
+    //                 //     let key = StoreHeap { object: self.chase_insn(recv), offset };
+    //                 //     active_stores.remove(&key);
+    //                 Insn::LoadField{ offset, .. } => {
+    //                     // Because we don't have type based alias analysis, we
+    //                     // can't just remove the (up to) one entry of the
+    //                     // StoreHeap key in active_stores. We need to remove all
+    //                     // such keys that could alias.
+    //                     prune_stores(&mut active_stores, offset);
+    //                 }
+    //                 Insn::WriteBarrier { .. } => {
+    //                     // Currently, WriteBarrier write effects are Allocator and Memory when we'd really like them to be flags.
+    //                     // We don't use LoadField for mark bits so we can ignore them for now.
+    //                     // But flags does not exist in our effects abstract heap modeling and we don't want to add special casing to effects.
+    //                     // This special casing in this pass here should be removed once we refine our effects system to provide greater granularity for WriteBarrier.
+    //                     // TODO: use TBAA
+    //                     let offset = RUBY_OFFSET_RBASIC_FLAGS;
+    //                     prune_stores(&mut active_stores, offset);
+    //                 },
+    //                 insn => {
+    //                     // If the instruction can read memory, we cannot assume
+    //                     // entries of active_stores are not loaded. This is because we use
+    //                     // extended basic blocks and we should probably change this to be
+    //                     // standard basic blocks.
+    //                     // TODO: Add a test for this case
+    //                     if insn.effects_of().includes(Effect::read(abstract_heaps::Memory)) {
+    //                         active_stores.clear();
+    //                     }
+    //                     else if insn.effects_of().includes(effects::Control) {
+    //                         active_stores.clear();
+    //                     }
+    //                 }
+    //             }
+    //             new_insns.push(insn_id);
+    //         }
+    //         new_insns.reverse();
+    //         self.blocks[block.0].insns = new_insns;
+    //     }
+    // }
 
     /// Fold a binary operator on fixnums.
     fn fold_fixnum_bop(&mut self, insn_id: InsnId, left: InsnId, right: InsnId, f: impl FnOnce(Option<i64>, Option<i64>) -> Option<i64>) -> InsnId {
@@ -5839,7 +5839,6 @@ impl Function {
             // End strength reduction bucket
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
             (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
-            (eliminate_dead_stores) => { Counter::compile_hir_eliminate_dead_stores_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
             (clean_cfg) => { Counter::compile_hir_clean_cfg_time_ns };
             (remove_redundant_patch_points) => { Counter::compile_hir_remove_redundant_patch_points_time_ns };
@@ -5875,7 +5874,6 @@ impl Function {
         run_pass!(convert_no_profile_sends);
         run_pass!(optimize_load_store);
         run_pass!(canonicalize);
-        // run_pass!(eliminate_dead_stores);
         run_pass!(fold_constants);
         run_pass!(clean_cfg);
         run_pass!(remove_redundant_patch_points);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4955,7 +4955,7 @@ impl Function {
     /// becomes tricky enough that splitting may be cleaner.
     ///
     /// For further reading, see the following Rails at Scale blog post.
-    /// https://railsatscale.com/2026-03-18-how-zjit-removes-redundant-object-loads-and-stores/
+    /// <https://railsatscale.com/2026-03-18-how-zjit-removes-redundant-object-loads-and-stores/>
     fn optimize_load_store(&mut self) {
         #[derive(PartialEq, Eq, Hash, Clone, Copy)]
         struct HeapKey {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5014,21 +5014,21 @@ impl Function {
         }
 
         for block in self.rpo() {
-            let mut dead_stores: HashSet<InsnId> = HashSet::new();
+            // TODO: Probably convert this to a vec of tuples? Time complexity is worse but constant factors are better
             let mut active_stores: HashMap<StoreHeap, InsnId> = HashMap::new();
-            let mut insns = std::mem::take(&mut self.blocks[block.0].insns);
-            // TODO: Figure out if we should make the pass run backwards and do it all in one sweep
-            // Or if we should do it from top to bottom for readability, but require a second pass
-            for i in (0..insns.len()).rev() {
-                let insn_id = insns[i];
+            let insns = std::mem::take(&mut self.blocks[block.0].insns);
+            let mut new_insns = vec![];
+            for insn_id_ref in insns.iter().rev() {
+                // TODO: This is ugly, clean this up
+                let insn_id = *insn_id_ref;
                 match self.find(insn_id) {
                     Insn::StoreField { recv, offset, .. } => {
                         let key = StoreHeap { object: self.chase_insn(recv), offset };
                         // If an older store is being tracked, then there have
                         // been no usees between stores and the first store is
-                        // dead.
+                        // dead and should not be emitted.
                         if active_stores.contains_key(&key) {
-                            dead_stores.insert(insn_id);
+                            continue
                         }
                         // Otherwise, we have a new store to begin tracking.
                         // Because we don't have type based alias analysis, we
@@ -5068,18 +5068,21 @@ impl Function {
                     },
                     insn => {
                         // If the instruction can read memory, we cannot assume
-                        // entries of active_stores are not loaded.
-                        if insn.effects_of().includes(Effect::write(abstract_heaps::Memory)) {
+                        // entries of active_stores are not loaded. This is because we use
+                        // extended basic blocks and we should probably change this to be
+                        // standard basic blocks.
+                        if insn.effects_of().includes(Effect::read(abstract_heaps::Memory)) {
+                            active_stores.clear();
+                        }
+                        else if insn.effects_of().includes(effects::Control) {
                             active_stores.clear();
                         }
                     }
-
                 }
+                new_insns.push(insn_id);
             }
-            // TODO: Figure out how to remove extraneous write barriers
-            // Prune away any dead stores
-            insns.retain(|i| !dead_stores.contains(i));
-            self.blocks[block.0].insns = insns;
+            new_insns.reverse();
+            self.blocks[block.0].insns = new_insns;
         }
     }
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5023,6 +5023,13 @@ impl Function {
                         // We found a second store while one was tracked.
                         // We can elide one.
                         // TODO(Jacob): Figure out if it matters which store we eliminate
+                        // TODO: BUG FIX: We obviously need to keep the final store, not the first!
+                        // This is because load_store_optimization ensures each store is different.
+                        // We need to keep the last one to preserve correctness. That changes the logic around for this block below
+                        //
+                        // TODO: Refine the key of active_stores
+                        // Additionally, we can't just do offset. We need to consider the object and address the same aliasing issues
+                        // we have in load store optimization.
                         if let Some(store_id) = active_stores.get(&offset) {
                             dead_stores.insert(*store_id);
                         }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4930,18 +4930,32 @@ impl Function {
         }
     }
 
-    // TODO: Replace hashmaps with vecs?
-    // TODO: Add comments describing load store elimination in the first pass
-    // TODO: Link to rails at scale post?
-    // TODO: Add comments describing deada store elimination in the second pass
-    // TODO: Add master comment about type based alias analysis with specific callouts referencing the overall TBAA comment
-    // TODO(Jacob): Spend time with the old noggin to answer the following questions.
-    //       1. It is possible to do DSE forwards. Is it possible to do this at the same time as load store?
-    //          If so, this would allow us to do it in one pass*. We still need to clean up the dead stores afterwards and convert them to
-    //          NOPs or something. The more I think about it, the more I think it makes sense to have a cleanup pass at the end of all other
-    //          analysis passes.
-    //       2. DSE and load-store-opt seem like duals of each other. If this is true, then they should be symmetric. Why does DSE only handle
-    //          stores? Can I convince myself that we're not missing some potential dead loads? Is this caught at an SSA level already?
+    /// Load store optimization performs two functions:
+    /// 1. Elide duplicate LoadField and StoreField instructions, and replace
+    /// redundant loads or stores with their values when possible.
+    /// 2. Remove "dead stores". A store is dead when it is never used before
+    ///    getting overwritten by a second store. If this pass proves no use,
+    ///    the first store is elided.
+    ///
+    /// These two optimizations use very similar abstract interpretations and are
+    /// currently combined into one pass. The primary difference is that load
+    /// store optimization runs forward (from top to bottom of a block) while
+    /// dead store elimination runs in reverse. A subtle secondary difference is
+    /// that our use of extended basic blocks induces an asymmetry between these
+    /// two optimizations. When scanning in reverse, dead store elimination needs
+    /// to consider the "multi-exit" nature of EBBs. Stores that appear to be
+    /// dead can sometimes have early exits that make the optimization unsound
+    /// if we don't handle this special case. Basic blocks avoid this problem.
+    ///
+    /// Note for future improvements:
+    /// Load & store optimizations currently operate at a block level, but could
+    /// be expanded to operate on methods. This likely means the two passes
+    /// should be split into their own methods as instead of "one forwards, one
+    /// backwards" we need to traverse dominator and post dominator trees and it
+    /// becomes tricky enough that splitting may be cleaner.
+    ///
+    /// For further reading, see the following Rails at Scale blog post.
+    /// https://railsatscale.com/2026-03-18-how-zjit-removes-redundant-object-loads-and-stores/
     fn optimize_load_store(&mut self) {
         #[derive(PartialEq, Eq, Hash, Clone, Copy)]
         struct HeapKey {
@@ -4949,17 +4963,16 @@ impl Function {
             offset: i32,
         }
 
-        // This helper function is used while we don't have type based alias
-        // analysis. Matching offsets could result in aliased objects that need
-        // to be clear.
-        // Any code location that uses the remove_aliasing function needs to be replaced
-        // when we implement TBAA
-        fn remove_aliasing(map: &mut HashMap<HeapKey, InsnId>, offset: i32) {
+        // This helper function is used to clear the cache for matching offsets
+        // while we don't have type based alias.
+        // TBAA will primarily modify any part of this optimization that
+        // currently uses this helper function.
+        fn flush_aliasing(map: &mut HashMap<HeapKey, InsnId>, offset: i32) {
             map.retain(|HeapKey { object: _, offset: off }, _| *off != offset);
         }
 
+        // Redundant load and store optimization
         for block in self.rpo() {
-            // First, we eliminate loads and stores
             let mut compile_time_heap: HashMap<HeapKey, InsnId> = HashMap::new();
             let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
             let mut new_insns = vec![];
@@ -4969,12 +4982,11 @@ impl Function {
                     Insn::StoreField { recv, offset, val, .. } => {
                         let key = HeapKey { object: self.chase_insn(recv), offset };
                         let heap_entry = compile_time_heap.get(&key).copied();
-                        // TODO(Jacob): Switch from actual to partial equality
                         if Some(val) == heap_entry {
                             // If the value is already stored, short circuit and don't add an instruction to the block
                             continue
                         }
-                        remove_aliasing(&mut compile_time_heap, offset);
+                        flush_aliasing(&mut compile_time_heap, offset);
                         compile_time_heap.insert(key, val);
                     },
                     Insn::LoadField { recv, offset, .. } => {
@@ -4983,7 +4995,6 @@ impl Function {
                             std::collections::hash_map::Entry::Occupied(entry) => {
                                 // If the value is stored already, we should short circuit.
                                 // However, we need to replace insn_id with its representative in the SSA union.
-                                // TODO: Show an example of why we need this with p little ascii diagram or something
                                 self.make_equal_to(insn_id, *entry.get());
                                 continue
                             }
@@ -4999,7 +5010,7 @@ impl Function {
                         // But flags does not exist in our effects abstract heap modeling and we don't want to add special casing to effects.
                         // This special casing in this pass here should be removed once we refine our effects system to provide greater granularity for WriteBarrier.
                         let offset = RUBY_OFFSET_RBASIC_FLAGS;
-                        remove_aliasing(&mut compile_time_heap, offset);
+                        flush_aliasing(&mut compile_time_heap, offset);
                     },
                     insn => {
                         // If an instruction affects memory and we haven't modeled it, the compile_time_heap is invalidated
@@ -5011,25 +5022,12 @@ impl Function {
                 new_insns.push(insn_id);
             }
 
-
-            // get the block
-            // load-store optimization
-            // reverse updated instructions
-            // DSE
-            // reverse final updated instructions
-            // return
-            //
-            // get the block
-            // load-store optimization, DSE* after (same iteration)
-            //     instead of eliding the store, mark the earlier store for removal
-            // return
-
-            // After performing scalar replacement on loads and stores where
-            // applicable, we scan in reverse to find an eliminate dead stores
+            // Set up for dead store elimination
             let mut reversed_insns = std::mem::take(&mut new_insns);
             reversed_insns.reverse();
             compile_time_heap.clear();
 
+            // Dead store elimnination
             for insn_id in reversed_insns {
                 match self.find(insn_id) {
                     Insn::StoreField { recv, offset, .. } => {
@@ -5039,21 +5037,21 @@ impl Function {
                             continue
                         }
                         else {
-                            remove_aliasing(&mut compile_time_heap, offset);
+                            flush_aliasing(&mut compile_time_heap, offset);
                             compile_time_heap.insert(key, insn_id);
                         }
                     }
                     Insn::LoadField{ offset, .. } => {
-                        remove_aliasing(&mut compile_time_heap, offset);
+                        flush_aliasing(&mut compile_time_heap, offset);
                     }
                     Insn::WriteBarrier { .. } => {
                         let offset = RUBY_OFFSET_RBASIC_FLAGS;
-                        remove_aliasing(&mut compile_time_heap, offset);
+                        flush_aliasing(&mut compile_time_heap, offset);
                     },
                     insn => {
                         let insn_reads_memory = insn.effects_of().includes(Effect::read(abstract_heaps::Memory));
                         let insn_uses_control_flow = insn.effects_of().includes(effects::Control);
-                        // TODO: Once we update from extended basic blocks to normal basic blocks, we can remove the control flow check
+                        // TODO(Jacob): Once we update from extended basic blocks to normal basic blocks, we can remove the control flow check
                         if insn_reads_memory || insn_uses_control_flow {
                             compile_time_heap.clear();
                         }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5075,7 +5075,7 @@ impl Function {
             }
             // TODO: Figure out if we need to handle a write barrier special case. Do these also need to be removed after removing stores?
             // Prune away any dead stores
-            insns.retain(|i| dead_stores.contains(i));
+            insns.retain(|i| !dead_stores.contains(i));
             self.blocks[block.0].insns = insns;
         }
     }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4930,32 +4930,60 @@ impl Function {
         }
     }
 
+    // TODO: Replace hashmaps with vecs?
+    // TODO: Add comments describing load store elimination in the first pass
+    // TODO: Link to rails at scale post?
+    // TODO: Add comments describing deada store elimination in the second pass
+    // TODO: Add master comment about type based alias analysis with specific callouts referencing the overall TBAA comment
+    // TODO(Jacob): Spend time with the old noggin to answer the following questions.
+    //       1. It is possible to do DSE forwards. Is it possible to do this at the same time as load store?
+    //          If so, this would allow us to do it in one pass*. We still need to clean up the dead stores afterwards and convert them to
+    //          NOPs or something. The more I think about it, the more I think it makes sense to have a cleanup pass at the end of all other
+    //          analysis passes.
+    //       2. DSE and load-store-opt seem like duals of each other. If this is true, then they should be symmetric. Why does DSE only handle
+    //          stores? Can I convince myself that we're not missing some potential dead loads? Is this caught at an SSA level already?
     fn optimize_load_store(&mut self) {
+        #[derive(PartialEq, Eq, Hash, Clone, Copy)]
+        struct HeapKey {
+            object: InsnId,
+            offset: i32,
+        }
+
+        // This helper function is used while we don't have type based alias
+        // analysis. Matching offsets could result in aliased objects that need
+        // to be clear.
+        // Any code location that uses the remove_aliasing function needs to be replaced
+        // when we implement TBAA
+        fn remove_aliasing(map: &mut HashMap<HeapKey, InsnId>, offset: i32) {
+            map.retain(|HeapKey { object: _, offset: off }, _| *off != offset);
+        }
+
         for block in self.rpo() {
-            let mut compile_time_heap: HashMap<(InsnId, i32), InsnId>  = HashMap::new();
+            // First, we eliminate loads and stores
+            let mut compile_time_heap: HashMap<HeapKey, InsnId> = HashMap::new();
             let old_insns = std::mem::take(&mut self.blocks[block.0].insns);
             let mut new_insns = vec![];
+
             for insn_id in old_insns {
-                let replacement_insn: InsnId = match self.find(insn_id) {
+                match self.find(insn_id) {
                     Insn::StoreField { recv, offset, val, .. } => {
-                        let key = (self.chase_insn(recv), offset);
+                        let key = HeapKey { object: self.chase_insn(recv), offset };
                         let heap_entry = compile_time_heap.get(&key).copied();
                         // TODO(Jacob): Switch from actual to partial equality
                         if Some(val) == heap_entry {
                             // If the value is already stored, short circuit and don't add an instruction to the block
                             continue
                         }
-                        // TODO(Jacob): Add TBAA to avoid removing so many entries
-                        compile_time_heap.retain(|(_, off), _| *off != offset);
+                        remove_aliasing(&mut compile_time_heap, offset);
                         compile_time_heap.insert(key, val);
-                        insn_id
                     },
                     Insn::LoadField { recv, offset, .. } => {
-                        let key = (self.chase_insn(recv), offset);
+                        let key = HeapKey { object: self.chase_insn(recv), offset };
                         match compile_time_heap.entry(key) {
                             std::collections::hash_map::Entry::Occupied(entry) => {
                                 // If the value is stored already, we should short circuit.
                                 // However, we need to replace insn_id with its representative in the SSA union.
+                                // TODO: Show an example of why we need this with p little ascii diagram or something
                                 self.make_equal_to(insn_id, *entry.get());
                                 continue
                             }
@@ -4964,28 +4992,64 @@ impl Function {
                                 compile_time_heap.insert(key, insn_id);
                             }
                         }
-                        insn_id
                     }
                     Insn::WriteBarrier { .. } => {
                         // Currently, WriteBarrier write effects are Allocator and Memory when we'd really like them to be flags.
                         // We don't use LoadField for mark bits so we can ignore them for now.
                         // But flags does not exist in our effects abstract heap modeling and we don't want to add special casing to effects.
                         // This special casing in this pass here should be removed once we refine our effects system to provide greater granularity for WriteBarrier.
-                        // TODO: use TBAA
                         let offset = RUBY_OFFSET_RBASIC_FLAGS;
-                        compile_time_heap.retain(|(_, off), _| *off != offset);
-                        insn_id
+                        remove_aliasing(&mut compile_time_heap, offset);
                     },
                     insn => {
                         // If an instruction affects memory and we haven't modeled it, the compile_time_heap is invalidated
                         if insn.effects_of().includes(Effect::write(abstract_heaps::Memory)) {
                             compile_time_heap.clear();
                         }
-                        insn_id
                     }
                 };
-                new_insns.push(replacement_insn);
+                new_insns.push(insn_id);
             }
+
+            // After performing scalar replacement on loads and stores where
+            // applicable, we scan in reverse to find an eliminate dead stores
+            let mut reversed_insns = std::mem::take(&mut new_insns);
+            reversed_insns.reverse();
+            compile_time_heap.clear();
+
+            for insn_id in reversed_insns {
+                match self.find(insn_id) {
+                    Insn::StoreField { recv, offset, .. } => {
+                        let key = HeapKey { object: self.chase_insn(recv), offset };
+                        if compile_time_heap.contains_key(&key) {
+                            // We've found a second store with no uses between. eliminate the earlier one
+                            continue
+                        }
+                        else {
+                            remove_aliasing(&mut compile_time_heap, offset);
+                            compile_time_heap.insert(key, insn_id);
+                        }
+                    }
+                    Insn::LoadField{ offset, .. } => {
+                        remove_aliasing(&mut compile_time_heap, offset);
+                    }
+                    Insn::WriteBarrier { .. } => {
+                        let offset = RUBY_OFFSET_RBASIC_FLAGS;
+                        remove_aliasing(&mut compile_time_heap, offset);
+                    },
+                    insn => {
+                        // TODO: Add test case for control flow potential bugs
+                        if insn.effects_of().includes(Effect::read(abstract_heaps::Memory)) {
+                            compile_time_heap.clear();
+                        }
+                        else if insn.effects_of().includes(effects::Control) {
+                            compile_time_heap.clear();
+                        }
+                    }
+                }
+                new_insns.push(insn_id);
+            }
+            new_insns.reverse();
             self.blocks[block.0].insns = new_insns;
         }
     }
@@ -5018,9 +5082,7 @@ impl Function {
             let mut active_stores: HashMap<StoreHeap, InsnId> = HashMap::new();
             let insns = std::mem::take(&mut self.blocks[block.0].insns);
             let mut new_insns = vec![];
-            for insn_id_ref in insns.iter().rev() {
-                // TODO: This is ugly, clean this up
-                let insn_id = *insn_id_ref;
+            for insn_id in insns.iter().rev().copied() {
                 match self.find(insn_id) {
                     Insn::StoreField { recv, offset, .. } => {
                         let key = StoreHeap { object: self.chase_insn(recv), offset };
@@ -5071,6 +5133,7 @@ impl Function {
                         // entries of active_stores are not loaded. This is because we use
                         // extended basic blocks and we should probably change this to be
                         // standard basic blocks.
+                        // TODO: Add a test for this case
                         if insn.effects_of().includes(Effect::read(abstract_heaps::Memory)) {
                             active_stores.clear();
                         }
@@ -5812,7 +5875,7 @@ impl Function {
         run_pass!(convert_no_profile_sends);
         run_pass!(optimize_load_store);
         run_pass!(canonicalize);
-        run_pass!(eliminate_dead_stores);
+        // run_pass!(eliminate_dead_stores);
         run_pass!(fold_constants);
         run_pass!(clean_cfg);
         run_pass!(remove_redundant_patch_points);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5011,6 +5011,19 @@ impl Function {
                 new_insns.push(insn_id);
             }
 
+
+            // get the block
+            // load-store optimization
+            // reverse updated instructions
+            // DSE
+            // reverse final updated instructions
+            // return
+            //
+            // get the block
+            // load-store optimization, DSE* after (same iteration)
+            //     instead of eliding the store, mark the earlier store for removal
+            // return
+
             // After performing scalar replacement on loads and stores where
             // applicable, we scan in reverse to find an eliminate dead stores
             let mut reversed_insns = std::mem::take(&mut new_insns);
@@ -5038,11 +5051,10 @@ impl Function {
                         remove_aliasing(&mut compile_time_heap, offset);
                     },
                     insn => {
-                        // TODO: Add test case for control flow potential bugs
-                        if insn.effects_of().includes(Effect::read(abstract_heaps::Memory)) {
-                            compile_time_heap.clear();
-                        }
-                        else if insn.effects_of().includes(effects::Control) {
+                        let insn_reads_memory = insn.effects_of().includes(Effect::read(abstract_heaps::Memory));
+                        let insn_uses_control_flow = insn.effects_of().includes(effects::Control);
+                        // TODO: Once we update from extended basic blocks to normal basic blocks, we can remove the control flow check
+                        if insn_reads_memory || insn_uses_control_flow {
                             compile_time_heap.clear();
                         }
                     }
@@ -5053,101 +5065,6 @@ impl Function {
             self.blocks[block.0].insns = new_insns;
         }
     }
-
-    // This pass assumes that load_store_optimization has already run
-    // This means that we will never have cases where loads and stores are
-    // repeated with the same offset and value.
-    // However, we still may have unnecessary stores. For the purposes of this
-    // pass, unnecessary means that a store to an offset is not utilized by
-    // other HIR instructions before a second store to the same offset occurs.
-    // Removing one of these two stores does not alter program behavior.
-    // TODO: Improve comments and clean up algorithm sketch
-    // fn eliminate_dead_stores(&mut self) {
-    //     #[derive(PartialEq, Eq, Hash)]
-    //     struct StoreHeap {
-    //         // TODO: Is object a good name here? If not, what should it be instead?
-    //         object: InsnId,
-    //         offset: i32,
-    //     }
-
-    //     // This helper function is used while we don't have type based alias
-    //     // analysis. Matching offsets could result in aliased objects that need
-    //     // to be clear.
-    //     fn prune_stores(map: &mut HashMap<StoreHeap, InsnId>, offset: i32) {
-    //         map.retain(|StoreHeap { object: _, offset: off }, _| *off != offset);
-    //     }
-
-    //     for block in self.rpo() {
-    //         // TODO: Probably convert this to a vec of tuples? Time complexity is worse but constant factors are better
-    //         let mut active_stores: HashMap<StoreHeap, InsnId> = HashMap::new();
-    //         let insns = std::mem::take(&mut self.blocks[block.0].insns);
-    //         let mut new_insns = vec![];
-    //         for insn_id in insns.iter().rev().copied() {
-    //             match self.find(insn_id) {
-    //                 Insn::StoreField { recv, offset, .. } => {
-    //                     let key = StoreHeap { object: self.chase_insn(recv), offset };
-    //                     // If an older store is being tracked, then there have
-    //                     // been no usees between stores and the first store is
-    //                     // dead and should not be emitted.
-    //                     if active_stores.contains_key(&key) {
-    //                         continue
-    //                     }
-    //                     // Otherwise, we have a new store to begin tracking.
-    //                     // Because we don't have type based alias analysis, we
-    //                     // need to remove all other stores with the same offset
-    //                     // before adding our own.
-    //                     else {
-    //                         prune_stores(&mut active_stores, offset);
-    //                         active_stores.insert(key, insn_id);
-    //                     }
-    //                 }
-    //                 // If a load is found, then any earlier store was
-    //                 // necessary. We know this because redundant loads and
-    //                 // stores were already eliminated, implying the
-    //                 // hypothetical StoreField we haven't found yet has a
-    //                 // different value than the one in active_stores.
-    //                 // The following lines are required when we have type
-    //                 // based alias analysis and the following call to prune
-    //                 // stores is no longer used.
-    //                 // Insn::LoadField { recv, offset, .. } => {
-    //                 //     let key = StoreHeap { object: self.chase_insn(recv), offset };
-    //                 //     active_stores.remove(&key);
-    //                 Insn::LoadField{ offset, .. } => {
-    //                     // Because we don't have type based alias analysis, we
-    //                     // can't just remove the (up to) one entry of the
-    //                     // StoreHeap key in active_stores. We need to remove all
-    //                     // such keys that could alias.
-    //                     prune_stores(&mut active_stores, offset);
-    //                 }
-    //                 Insn::WriteBarrier { .. } => {
-    //                     // Currently, WriteBarrier write effects are Allocator and Memory when we'd really like them to be flags.
-    //                     // We don't use LoadField for mark bits so we can ignore them for now.
-    //                     // But flags does not exist in our effects abstract heap modeling and we don't want to add special casing to effects.
-    //                     // This special casing in this pass here should be removed once we refine our effects system to provide greater granularity for WriteBarrier.
-    //                     // TODO: use TBAA
-    //                     let offset = RUBY_OFFSET_RBASIC_FLAGS;
-    //                     prune_stores(&mut active_stores, offset);
-    //                 },
-    //                 insn => {
-    //                     // If the instruction can read memory, we cannot assume
-    //                     // entries of active_stores are not loaded. This is because we use
-    //                     // extended basic blocks and we should probably change this to be
-    //                     // standard basic blocks.
-    //                     // TODO: Add a test for this case
-    //                     if insn.effects_of().includes(Effect::read(abstract_heaps::Memory)) {
-    //                         active_stores.clear();
-    //                     }
-    //                     else if insn.effects_of().includes(effects::Control) {
-    //                         active_stores.clear();
-    //                     }
-    //                 }
-    //             }
-    //             new_insns.push(insn_id);
-    //         }
-    //         new_insns.reverse();
-    //         self.blocks[block.0].insns = new_insns;
-    //     }
-    // }
 
     /// Fold a binary operator on fixnums.
     fn fold_fixnum_bop(&mut self, insn_id: InsnId, left: InsnId, right: InsnId, f: impl FnOnce(Option<i64>, Option<i64>) -> Option<i64>) -> InsnId {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4997,6 +4997,7 @@ impl Function {
     // pass, unnecessary means that a store to an offset is not utilized by
     // other HIR instructions before a second store to the same offset occurs.
     // Removing one of these two stores does not alter program behavior.
+    // TODO: Improve comments and clean up algorithm sketch
     fn eliminate_dead_stores(&mut self) {
         #[derive(PartialEq, Eq, Hash)]
         struct StoreHeap {
@@ -5016,15 +5017,8 @@ impl Function {
             let mut dead_stores: HashSet<InsnId> = HashSet::new();
             let mut active_stores: HashMap<StoreHeap, InsnId> = HashMap::new();
             let mut insns = std::mem::take(&mut self.blocks[block.0].insns);
-            // Iterate over the instructions backwards
-            // If we find a store
-            //   If it's not in current_stores, add it with StoreStatus::Used
-            //   If it is, check if we can eliminate it and add it to dead_stores based on current_stores. also update current_stores
-            //   cases:
-            //     - it's used. Reset the current_stores entry with the new store.
-            //     - it's not used. Add the new store to dead_stores and leave current_stores the same.
-            // If we find an effectful instruction, mark any stores in the heap as used
-            // If we find a load, mark the relevant store in the heap as used
+            // TODO: Figure out if we should make the pass run backwards and do it all in one sweep
+            // Or if we should do it from top to bottom for readability, but require a second pass
             for i in (0..insns.len()).rev() {
                 let insn_id = insns[i];
                 match self.find(insn_id) {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5029,7 +5029,7 @@ impl Function {
                 let insn_id = insns[i];
                 match self.find(insn_id) {
                     Insn::StoreField { recv, offset, .. } => {
-                        let key = StoreHeap { object: recv, offset };
+                        let key = StoreHeap { object: self.chase_insn(recv), offset };
                         // If an older store is being tracked, then there have
                         // been no usees between stores and the first store is
                         // dead.
@@ -5054,7 +5054,7 @@ impl Function {
                     // based alias analysis and the following call to prune
                     // stores is no longer used.
                     // Insn::LoadField { recv, offset, .. } => {
-                    //     let key = StoreHeap { object: recv, offset };
+                    //     let key = StoreHeap { object: self.chase_insn(recv), offset };
                     //     active_stores.remove(&key);
                     Insn::LoadField{ offset, .. } => {
                         // Because we don't have type based alias analysis, we
@@ -5063,6 +5063,15 @@ impl Function {
                         // such keys that could alias.
                         prune_stores(&mut active_stores, offset);
                     }
+                    Insn::WriteBarrier { .. } => {
+                        // Currently, WriteBarrier write effects are Allocator and Memory when we'd really like them to be flags.
+                        // We don't use LoadField for mark bits so we can ignore them for now.
+                        // But flags does not exist in our effects abstract heap modeling and we don't want to add special casing to effects.
+                        // This special casing in this pass here should be removed once we refine our effects system to provide greater granularity for WriteBarrier.
+                        // TODO: use TBAA
+                        let offset = RUBY_OFFSET_RBASIC_FLAGS;
+                        prune_stores(&mut active_stores, offset);
+                    },
                     insn => {
                         // If the instruction can read memory, we cannot assume
                         // entries of active_stores are not loaded.
@@ -5073,7 +5082,7 @@ impl Function {
 
                 }
             }
-            // TODO: Figure out if we need to handle a write barrier special case. Do these also need to be removed after removing stores?
+            // TODO: Figure out how to remove extraneous write barriers
             // Prune away any dead stores
             insns.retain(|i| !dead_stores.contains(i));
             self.blocks[block.0].insns = insns;

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5693,12 +5693,15 @@ mod hir_opt_tests {
           v33:CShape[0x1003] = Const CShape(0x1003)
           StoreField v28, :shape_id@0x1000, v33
           v14:HeapBasicObject = RefineType v28, HeapBasicObject
+          v14:HeapBasicObject = RefineType v6, HeapBasicObject
           v17:Fixnum[2] = Const Value(2)
           PatchPoint SingleRactorMode
-          StoreField v14, :@bar@0x1004, v17
+          StoreField v14, :@bar@0x1003, v17
           WriteBarrier v14, v17
           v40:CShape[0x1005] = Const CShape(0x1005)
           StoreField v14, :shape_id@0x1000, v40
+          v40:CShape[0x1004] = Const CShape(0x1004)
+          StoreField v14, :_shape_id@0x1000, v40
           CheckInterrupts
           Return v17
         ");
@@ -15355,7 +15358,29 @@ mod hir_opt_tests {
           StoreField v31, :@after@0x1003, v17
           WriteBarrier v14, v17
           v34:CShape[0x1004] = Const CShape(0x1004)
-          StoreField v14, :shape_id@0x1000, v34
+          StoreField v14, :_shape_id@0x1000, v34
+          v42:HeapBasicObject = GuardType v6, HeapBasicObject
+          v43:CShape = LoadField v42, :_shape_id@0x1000
+          v44:CShape[0x1001] = GuardBitEquals v43, CShape(0x1001)
+          StoreField v42, :@a@0x1002, v10
+          WriteBarrier v42, v10
+          v14:HeapBasicObject = RefineType v6, HeapBasicObject
+          v17:Fixnum[2] = Const Value(2)
+          PatchPoint SingleRactorMode
+          StoreField v14, :@b@0x1003, v17
+          WriteBarrier v14, v17
+          v21:HeapBasicObject = RefineType v14, HeapBasicObject
+          v24:Fixnum[3] = Const Value(3)
+          PatchPoint SingleRactorMode
+          StoreField v21, :@c@0x1004, v24
+          WriteBarrier v21, v24
+          v61:CShape[0x1005] = Const CShape(0x1005)
+          StoreField v21, :_shape_id@0x1000, v61
+          v28:HeapBasicObject = RefineType v21, HeapBasicObject
+          v31:Fixnum[4] = Const Value(4)
+          PatchPoint SingleRactorMode
+          SetIvar v28, :@d, v31
+>>>>>>> d0b810f912 (Add chase and update tests)
           CheckInterrupts
           Return v17
         ");
@@ -15897,15 +15922,37 @@ mod hir_opt_tests {
         bb7(v35:BasicObject):
           Jump bb6(v37)
           StoreField v14, :@b@0x1004, v17
+          v16:CInt64[3] = GuardBitEquals v15, CInt64(3)
+          v17:BasicObject = InvokeBlockIfunc v13, v10
+          v21:Fixnum[2] = Const Value(2)
+          v23:CPtr = GetEP 0
+          v24:CInt64 = LoadField v23, :_env_data_index_specval@0x1000
+          v25:CInt64[3] = Const CInt64(3)
+          v26:CInt64 = IntAnd v24, v25
+          v27:CInt64[3] = GuardBitEquals v26, CInt64(3)
+          v28:BasicObject = InvokeBlockIfunc v24, v21
+          CheckInterrupts
+          Return v28
+
+
+
+          PatchPoint SingleRactorMode
+          v35:HeapBasicObject = GuardType v6, HeapBasicObject
+          v36:CShape = LoadField v35, :_shape_id@0x1000
+          v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001)
+          StoreField v35, :@a@0x1002, v10
+          WriteBarrier v35, v10
+          v14:HeapBasicObject = RefineType v6, HeapBasicObject
+          v17:Fixnum[2] = Const Value(2)
+          PatchPoint SingleRactorMode
+          StoreField v14, :@b@0x1003, v17
           WriteBarrier v14, v17
-          v47:CShape[0x1005] = Const CShape(0x1005)
-          StoreField v14, :_shape_id@0x1000, v47
           v21:HeapBasicObject = RefineType v14, HeapBasicObject
           v24:Fixnum[3] = Const Value(3)
           PatchPoint SingleRactorMode
-          StoreField v21, :@c@0x1006, v24
+          StoreField v21, :@c@0x1004, v24
           WriteBarrier v21, v24
-          v54:CShape[0x1007] = Const CShape(0x1007)
+          v54:CShape[0x1005] = Const CShape(0x1005)
           StoreField v21, :_shape_id@0x1000, v54
           CheckInterrupts
           Return v24
@@ -15981,29 +16028,22 @@ mod hir_opt_tests {
           v49:HeapBasicObject = GuardType v6, HeapBasicObject
           v50:CShape = LoadField v49, :_shape_id@0x1000
           v51:CShape[0x1001] = GuardBitEquals v50, CShape(0x1001)
-          StoreField v49, :@a@0x1002, v10
           WriteBarrier v49, v10
-          v54:CShape[0x1003] = Const CShape(0x1003)
+          v54:CShape[0x1002] = Const CShape(0x1002)
           StoreField v49, :_shape_id@0x1000, v54
           v14:HeapBasicObject = RefineType v6, HeapBasicObject
           v17:Fixnum[2] = Const Value(2)
           PatchPoint SingleRactorMode
-          StoreField v14, :@a@0x1002, v17
           WriteBarrier v14, v17
           v21:HeapBasicObject = RefineType v14, HeapBasicObject
           v24:Fixnum[3] = Const Value(3)
-          PatchPoint SingleRactorMode
-          StoreField v21, :@a@0x1002, v24
           WriteBarrier v21, v24
           v28:HeapBasicObject = RefineType v21, HeapBasicObject
           v31:Fixnum[4] = Const Value(4)
-          PatchPoint SingleRactorMode
-          StoreField v28, :@a@0x1002, v31
           WriteBarrier v28, v31
           v35:HeapBasicObject = RefineType v28, HeapBasicObject
           v38:Fixnum[5] = Const Value(5)
-          PatchPoint SingleRactorMode
-          StoreField v35, :@a@0x1002, v38
+          StoreField v35, :@a@0x1003, v38
           WriteBarrier v35, v38
     ");
     }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -15335,7 +15335,7 @@ mod hir_opt_tests {
             return;
         }
         eval("OBJ.test");
-        assert_snapshot!(hir_string_proc("TEST"), @"
+        assert_snapshot!(hir_string_proc("TEST"), @r"
         fn test@<compiled>:12:
         bb1():
           EntryPoint interpreter
@@ -15380,7 +15380,6 @@ mod hir_opt_tests {
           v31:Fixnum[4] = Const Value(4)
           PatchPoint SingleRactorMode
           SetIvar v28, :@d, v31
->>>>>>> d0b810f912 (Add chase and update tests)
           CheckInterrupts
           Return v17
         ");
@@ -15877,17 +15876,31 @@ mod hir_opt_tests {
           v13:CInt64 = LoadField v12, :_env_data_index_specval@0x1000
           v14:CInt64[3] = Const CInt64(3)
           v15:CInt64 = IntAnd v13, v14
-          v16:CInt64[3] = GuardBitEquals v15, CInt64(3)
-          v17:BasicObject = InvokeBlockIfunc v13, v10
-          v21:Fixnum[2] = Const Value(2)
-          v23:CPtr = GetEP 0
-          v24:CInt64 = LoadField v23, :_env_data_index_specval@0x1000
-          v25:CInt64[3] = Const CInt64(3)
-          v26:CInt64 = IntAnd v24, v25
-          v27:CInt64[3] = GuardBitEquals v26, CInt64(3)
-          v28:BasicObject = InvokeBlockIfunc v24, v21
+          v16:CInt64[3] = Const CInt64(3)
+          v17:CBool = IsBitEqual v15, v16
+          IfTrue v17, bb5()
+          v22:BasicObject = InvokeBlock, v10 # SendFallbackReason: InvokeBlock: not yet specialized
+          Jump bb4(v22)
+        bb5():
+          v20:BasicObject = InvokeBlockIfunc v13, v10
+          Jump bb4(v20)
+        bb4(v18:BasicObject):
+          v27:Fixnum[2] = Const Value(2)
+          v29:CPtr = GetEP 0
+          v30:CInt64 = LoadField v29, :_env_data_index_specval@0x1000
+          v31:CInt64[3] = Const CInt64(3)
+          v32:CInt64 = IntAnd v30, v31
+          v33:CInt64[3] = Const CInt64(3)
+          v34:CBool = IsBitEqual v32, v33
+          IfTrue v34, bb7()
+          v39:BasicObject = InvokeBlock, v27 # SendFallbackReason: InvokeBlock: not yet specialized
+          Jump bb6(v39)
+        bb7():
+          v37:BasicObject = InvokeBlockIfunc v30, v27
+          Jump bb6(v37)
+        bb6(v35:BasicObject):
           CheckInterrupts
-          Return v28
+          Return v35
         ");
     }
 
@@ -15958,6 +15971,7 @@ mod hir_opt_tests {
           v28:BasicObject = InvokeBlockIfunc v24, v21
           CheckInterrupts
           Return v28
+          PatchPoint SingleRactorMode
           v35:HeapBasicObject = GuardType v6, HeapBasicObject
           v36:CShape = LoadField v35, :_shape_id@0x1000
           v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001)
@@ -16066,7 +16080,9 @@ mod hir_opt_tests {
           v38:Fixnum[5] = Const Value(5)
           StoreField v35, :@a@0x1003, v38
           WriteBarrier v35, v38
-    ");
+          CheckInterrupts
+          Return v38
+        ");
     }
 
     #[test]

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -15861,8 +15861,33 @@ mod hir_opt_tests {
             end
             IFuncTestList.new.map { |x| x }
         ");
-        assert_snapshot!(hir_string_proc("IFuncTestList.instance_method(:each)"), @"
+        assert_snapshot!(hir_string_proc("IFuncTestList.instance_method(:each)"), @r"
         fn each@<compiled>:5:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v10:Fixnum[1] = Const Value(1)
+          v12:CPtr = GetEP 0
+          v13:CInt64 = LoadField v12, :_env_data_index_specval@0x1000
+          v14:CInt64[3] = Const CInt64(3)
+          v15:CInt64 = IntAnd v13, v14
+          v16:CInt64[3] = GuardBitEquals v15, CInt64(3)
+          v17:BasicObject = InvokeBlockIfunc v13, v10
+          v21:Fixnum[2] = Const Value(2)
+          v23:CPtr = GetEP 0
+          v24:CInt64 = LoadField v23, :_env_data_index_specval@0x1000
+          v25:CInt64[3] = Const CInt64(3)
+          v26:CInt64 = IntAnd v24, v25
+          v27:CInt64[3] = GuardBitEquals v26, CInt64(3)
+          v28:BasicObject = InvokeBlockIfunc v24, v21
+          CheckInterrupts
+          Return v28
         ");
     }
 
@@ -15933,10 +15958,6 @@ mod hir_opt_tests {
           v28:BasicObject = InvokeBlockIfunc v24, v21
           CheckInterrupts
           Return v28
-
-
-
-          PatchPoint SingleRactorMode
           v35:HeapBasicObject = GuardType v6, HeapBasicObject
           v36:CShape = LoadField v35, :_shape_id@0x1000
           v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001)

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -15838,6 +15838,24 @@ mod hir_opt_tests {
         ");
         assert_snapshot!(hir_string_proc("IFuncTestList.instance_method(:each)"), @"
         fn each@<compiled>:5:
+        ");
+    }
+
+    #[test]
+    fn test_eliminate_dead_store_in_initialize() {
+        eval("
+            class C
+              def initialize
+                @a = 1
+                @b = 2
+                @c = 3
+              end
+            end
+
+            C.new
+        ");
+        assert_snapshot!(hir_string_proc("C.instance_method(:initialize)"), @r"
+        fn initialize@<compiled>:4:
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
@@ -15877,9 +15895,117 @@ mod hir_opt_tests {
           v39:BasicObject = InvokeBlock, v27 # SendFallbackReason: InvokeBlock: not yet specialized
           Jump bb7(v39)
         bb7(v35:BasicObject):
+          Jump bb6(v37)
+          StoreField v14, :@b@0x1004, v17
+          WriteBarrier v14, v17
+          v47:CShape[0x1005] = Const CShape(0x1005)
+          StoreField v14, :_shape_id@0x1000, v47
+          v21:HeapBasicObject = RefineType v14, HeapBasicObject
+          v24:Fixnum[3] = Const Value(3)
+          PatchPoint SingleRactorMode
+          StoreField v21, :@c@0x1006, v24
+          WriteBarrier v21, v24
+          v54:CShape[0x1007] = Const CShape(0x1007)
+          StoreField v21, :_shape_id@0x1000, v54
           CheckInterrupts
-          Return v35
+          Return v24
         ");
+    }
+
+    #[test]
+    fn test_preserve_necessary_store_in_initialize() {
+        eval("
+            class C
+              def initialize
+                @a = 1
+                @a
+              end
+            end
+
+            C.new
+        ");
+        assert_snapshot!(hir_string_proc("C.instance_method(:initialize)"), @r"
+        fn initialize@<compiled>:4:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v10:Fixnum[1] = Const Value(1)
+          PatchPoint SingleRactorMode
+          v24:HeapBasicObject = GuardType v6, HeapBasicObject
+          v25:CShape = LoadField v24, :_shape_id@0x1000
+          v26:CShape[0x1001] = GuardBitEquals v25, CShape(0x1001)
+          StoreField v24, :@a@0x1002, v10
+          WriteBarrier v24, v10
+          v29:CShape[0x1003] = Const CShape(0x1003)
+          StoreField v24, :_shape_id@0x1000, v29
+          PatchPoint SingleRactorMode
+          CheckInterrupts
+          Return v10
+        ");
+    }
+
+    #[test]
+    fn test_eliminate_many_dead_stores_in_initialize() {
+        eval("
+            class C
+              def initialize
+                @a = 1
+                @a = 2
+                @a = 3
+                @a = 4
+                @a = 5
+              end
+            end
+
+            C.new
+        ");
+        assert_snapshot!(hir_string_proc("C.instance_method(:initialize)"), @r"
+        fn initialize@<compiled>:4:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v10:Fixnum[1] = Const Value(1)
+          PatchPoint SingleRactorMode
+          v49:HeapBasicObject = GuardType v6, HeapBasicObject
+          v50:CShape = LoadField v49, :_shape_id@0x1000
+          v51:CShape[0x1001] = GuardBitEquals v50, CShape(0x1001)
+          StoreField v49, :@a@0x1002, v10
+          WriteBarrier v49, v10
+          v54:CShape[0x1003] = Const CShape(0x1003)
+          StoreField v49, :_shape_id@0x1000, v54
+          v14:HeapBasicObject = RefineType v6, HeapBasicObject
+          v17:Fixnum[2] = Const Value(2)
+          PatchPoint SingleRactorMode
+          StoreField v14, :@a@0x1002, v17
+          WriteBarrier v14, v17
+          v21:HeapBasicObject = RefineType v14, HeapBasicObject
+          v24:Fixnum[3] = Const Value(3)
+          PatchPoint SingleRactorMode
+          StoreField v21, :@a@0x1002, v24
+          WriteBarrier v21, v24
+          v28:HeapBasicObject = RefineType v21, HeapBasicObject
+          v31:Fixnum[4] = Const Value(4)
+          PatchPoint SingleRactorMode
+          StoreField v28, :@a@0x1002, v31
+          WriteBarrier v28, v31
+          v35:HeapBasicObject = RefineType v28, HeapBasicObject
+          v38:Fixnum[5] = Const Value(5)
+          PatchPoint SingleRactorMode
+          StoreField v35, :@a@0x1002, v38
+          WriteBarrier v35, v38
+    ");
     }
 
     #[test]

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5672,7 +5672,7 @@ mod hir_opt_tests {
             obj.test
             TEST = klass.instance_method(:test)
         "#);
-        assert_snapshot!(hir_string_proc("TEST"), @"
+        assert_snapshot!(hir_string_proc("TEST"), @r"
         fn test@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -5693,7 +5693,6 @@ mod hir_opt_tests {
           v33:CShape[0x1003] = Const CShape(0x1003)
           StoreField v28, :shape_id@0x1000, v33
           v14:HeapBasicObject = RefineType v28, HeapBasicObject
-          v14:HeapBasicObject = RefineType v6, HeapBasicObject
           v17:Fixnum[2] = Const Value(2)
           PatchPoint SingleRactorMode
           StoreField v14, :@bar@0x1003, v17
@@ -15878,12 +15877,13 @@ mod hir_opt_tests {
           v15:CInt64 = IntAnd v13, v14
           v16:CInt64[3] = Const CInt64(3)
           v17:CBool = IsBitEqual v15, v16
-          IfTrue v17, bb5()
-          v22:BasicObject = InvokeBlock, v10 # SendFallbackReason: InvokeBlock: not yet specialized
-          Jump bb4(v22)
+          CondBranch v17, bb5(), bb6()
         bb5():
           v20:BasicObject = InvokeBlockIfunc v13, v10
           Jump bb4(v20)
+        bb6():
+          v22:BasicObject = InvokeBlock, v10 # SendFallbackReason: InvokeBlock: not yet specialized
+          Jump bb4(v22)
         bb4(v18:BasicObject):
           v27:Fixnum[2] = Const Value(2)
           v29:CPtr = GetEP 0
@@ -15892,13 +15892,14 @@ mod hir_opt_tests {
           v32:CInt64 = IntAnd v30, v31
           v33:CInt64[3] = Const CInt64(3)
           v34:CBool = IsBitEqual v32, v33
-          IfTrue v34, bb7()
-          v39:BasicObject = InvokeBlock, v27 # SendFallbackReason: InvokeBlock: not yet specialized
-          Jump bb6(v39)
-        bb7():
+          CondBranch v34, bb8(), bb9()
+        bb8():
           v37:BasicObject = InvokeBlockIfunc v30, v27
-          Jump bb6(v37)
-        bb6(v35:BasicObject):
+          Jump bb7(v37)
+        bb9():
+          v39:BasicObject = InvokeBlock, v27 # SendFallbackReason: InvokeBlock: not yet specialized
+          Jump bb7(v39)
+        bb7(v35:BasicObject):
           CheckInterrupts
           Return v35
         ");
@@ -15977,7 +15978,7 @@ mod hir_opt_tests {
           v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001)
           StoreField v35, :@a@0x1002, v10
           WriteBarrier v35, v10
-          v14:HeapBasicObject = RefineType v6, HeapBasicObject
+          v14:HeapBasicObject = RefineType v35, HeapBasicObject
           v17:Fixnum[2] = Const Value(2)
           PatchPoint SingleRactorMode
           StoreField v14, :@b@0x1003, v17
@@ -16066,7 +16067,7 @@ mod hir_opt_tests {
           WriteBarrier v49, v10
           v54:CShape[0x1002] = Const CShape(0x1002)
           StoreField v49, :_shape_id@0x1000, v54
-          v14:HeapBasicObject = RefineType v6, HeapBasicObject
+          v14:HeapBasicObject = RefineType v49, HeapBasicObject
           v17:Fixnum[2] = Const Value(2)
           PatchPoint SingleRactorMode
           WriteBarrier v14, v17

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5690,17 +5690,13 @@ mod hir_opt_tests {
           v30:CShape[0x1001] = GuardBitEquals v29, CShape(0x1001) recompile
           StoreField v28, :@foo@0x1002, v10
           WriteBarrier v28, v10
-          v33:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v28, :shape_id@0x1000, v33
           v14:HeapBasicObject = RefineType v28, HeapBasicObject
           v17:Fixnum[2] = Const Value(2)
           PatchPoint SingleRactorMode
           StoreField v14, :@bar@0x1003, v17
           WriteBarrier v14, v17
-          v40:CShape[0x1005] = Const CShape(0x1005)
-          StoreField v14, :shape_id@0x1000, v40
           v40:CShape[0x1004] = Const CShape(0x1004)
-          StoreField v14, :_shape_id@0x1000, v40
+          StoreField v14, :shape_id@0x1000, v40
           CheckInterrupts
           Return v17
         ");
@@ -15872,7 +15868,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v10:Fixnum[1] = Const Value(1)
           v12:CPtr = GetEP 0
-          v13:CInt64 = LoadField v12, :_env_data_index_specval@0x1000
+          v13:CInt64 = LoadField v12, :VM_ENV_DATA_INDEX_SPECVAL@0x1000
           v14:CInt64[3] = Const CInt64(3)
           v15:CInt64 = IntAnd v13, v14
           v16:CInt64[3] = Const CInt64(3)
@@ -15887,7 +15883,7 @@ mod hir_opt_tests {
         bb4(v18:BasicObject):
           v27:Fixnum[2] = Const Value(2)
           v29:CPtr = GetEP 0
-          v30:CInt64 = LoadField v29, :_env_data_index_specval@0x1000
+          v30:CInt64 = LoadField v29, :VM_ENV_DATA_INDEX_SPECVAL@0x1000
           v31:CInt64[3] = Const CInt64(3)
           v32:CInt64 = IntAnd v30, v31
           v33:CInt64[3] = Const CInt64(3)
@@ -15930,52 +15926,10 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v10:Fixnum[1] = Const Value(1)
-          v12:CPtr = GetEP 0
-          v13:CInt64 = LoadField v12, :VM_ENV_DATA_INDEX_SPECVAL@0x1000
-          v14:CInt64[3] = Const CInt64(3)
-          v15:CInt64 = IntAnd v13, v14
-          v16:CInt64[3] = Const CInt64(3)
-          v17:CBool = IsBitEqual v15, v16
-          CondBranch v17, bb5(), bb6()
-        bb5():
-          v20:BasicObject = InvokeBlockIfunc v13, v10
-          Jump bb4(v20)
-        bb6():
-          v22:BasicObject = InvokeBlock, v10 # SendFallbackReason: InvokeBlock: not yet specialized
-          Jump bb4(v22)
-        bb4(v18:BasicObject):
-          v27:Fixnum[2] = Const Value(2)
-          v29:CPtr = GetEP 0
-          v30:CInt64 = LoadField v29, :VM_ENV_DATA_INDEX_SPECVAL@0x1000
-          v31:CInt64[3] = Const CInt64(3)
-          v32:CInt64 = IntAnd v30, v31
-          v33:CInt64[3] = Const CInt64(3)
-          v34:CBool = IsBitEqual v32, v33
-          CondBranch v34, bb8(), bb9()
-        bb8():
-          v37:BasicObject = InvokeBlockIfunc v30, v27
-          Jump bb7(v37)
-        bb9():
-          v39:BasicObject = InvokeBlock, v27 # SendFallbackReason: InvokeBlock: not yet specialized
-          Jump bb7(v39)
-        bb7(v35:BasicObject):
-          Jump bb6(v37)
-          StoreField v14, :@b@0x1004, v17
-          v16:CInt64[3] = GuardBitEquals v15, CInt64(3)
-          v17:BasicObject = InvokeBlockIfunc v13, v10
-          v21:Fixnum[2] = Const Value(2)
-          v23:CPtr = GetEP 0
-          v24:CInt64 = LoadField v23, :_env_data_index_specval@0x1000
-          v25:CInt64[3] = Const CInt64(3)
-          v26:CInt64 = IntAnd v24, v25
-          v27:CInt64[3] = GuardBitEquals v26, CInt64(3)
-          v28:BasicObject = InvokeBlockIfunc v24, v21
-          CheckInterrupts
-          Return v28
           PatchPoint SingleRactorMode
           v35:HeapBasicObject = GuardType v6, HeapBasicObject
-          v36:CShape = LoadField v35, :_shape_id@0x1000
-          v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001)
+          v36:CShape = LoadField v35, :shape_id@0x1000
+          v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001) recompile
           StoreField v35, :@a@0x1002, v10
           WriteBarrier v35, v10
           v14:HeapBasicObject = RefineType v35, HeapBasicObject
@@ -15989,7 +15943,7 @@ mod hir_opt_tests {
           StoreField v21, :@c@0x1004, v24
           WriteBarrier v21, v24
           v54:CShape[0x1005] = Const CShape(0x1005)
-          StoreField v21, :_shape_id@0x1000, v54
+          StoreField v21, :shape_id@0x1000, v54
           CheckInterrupts
           Return v24
         ");
@@ -16021,12 +15975,12 @@ mod hir_opt_tests {
           v10:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
           v24:HeapBasicObject = GuardType v6, HeapBasicObject
-          v25:CShape = LoadField v24, :_shape_id@0x1000
-          v26:CShape[0x1001] = GuardBitEquals v25, CShape(0x1001)
+          v25:CShape = LoadField v24, :shape_id@0x1000
+          v26:CShape[0x1001] = GuardBitEquals v25, CShape(0x1001) recompile
           StoreField v24, :@a@0x1002, v10
           WriteBarrier v24, v10
           v29:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v24, :_shape_id@0x1000, v29
+          StoreField v24, :shape_id@0x1000, v29
           PatchPoint SingleRactorMode
           CheckInterrupts
           Return v10
@@ -16062,11 +16016,11 @@ mod hir_opt_tests {
           v10:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
           v49:HeapBasicObject = GuardType v6, HeapBasicObject
-          v50:CShape = LoadField v49, :_shape_id@0x1000
-          v51:CShape[0x1001] = GuardBitEquals v50, CShape(0x1001)
+          v50:CShape = LoadField v49, :shape_id@0x1000
+          v51:CShape[0x1001] = GuardBitEquals v50, CShape(0x1001) recompile
           WriteBarrier v49, v10
           v54:CShape[0x1002] = Const CShape(0x1002)
-          StoreField v49, :_shape_id@0x1000, v54
+          StoreField v49, :shape_id@0x1000, v54
           v14:HeapBasicObject = RefineType v49, HeapBasicObject
           v17:Fixnum[2] = Const Value(2)
           PatchPoint SingleRactorMode


### PR DESCRIPTION
The following Ruby code generates the following HIR.
```ruby
class C
  def initialize
    @a = 1
    @b = 2
    @c = 3
  end
end

C.new
```

```
fn initialize@<compiled>:4:
bb1():
  EntryPoint interpreter
  v1:BasicObject = LoadSelf
  Jump bb3(v1)
bb2():
  EntryPoint JIT(0)
  v4:BasicObject = LoadArg :self@0
  Jump bb3(v4)
bb3(v6:BasicObject):
  v10:Fixnum[1] = Const Value(1)
  PatchPoint SingleRactorMode
  v35:HeapBasicObject = GuardType v6, HeapBasicObject
  v36:CShape = LoadField v35, :_shape_id@0x1000
  v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001)
  StoreField v35, :@a@0x1002, v10
  WriteBarrier v35, v10
  v40:CShape[0x1003] = Const CShape(0x1003)
  StoreField v35, :_shape_id@0x1000, v40
  v14:HeapBasicObject = RefineType v6, HeapBasicObject
  v17:Fixnum[2] = Const Value(2)
  PatchPoint SingleRactorMode
  StoreField v14, :@b@0x1004, v17
  WriteBarrier v14, v17
  v47:CShape[0x1005] = Const CShape(0x1005)
  StoreField v14, :_shape_id@0x1000, v47
  v21:HeapBasicObject = RefineType v14, HeapBasicObject
  v24:Fixnum[3] = Const Value(3)
  PatchPoint SingleRactorMode
  StoreField v21, :@c@0x1006, v24
  WriteBarrier v21, v24
  v54:CShape[0x1007] = Const CShape(0x1007)
  StoreField v21, :_shape_id@0x1000, v54
  CheckInterrupts
  Return v24
```

This PR eliminates dead stores in an optimization pass to be executed after `load_store_optimization`. At this point in the optimizer, redundant loads and stores are no longer present, but we may still have multiple stores that overwrite each other without ever being accessed.

For instance, in the following HIR, it is safe for us to remove the two highlighted `StoreField` instructions. This is because we write to the same memory region 3 times, without utilizing the first two writes. Instead, we could have just written the final time with `StoreField v21, :@c@0x1006, v24`.
(Note: we have not fixed up the SSA variable names in this example for simplicity.)

```diff
fn initialize@<compiled>:4:
bb1():
  EntryPoint interpreter
  v1:BasicObject = LoadSelf
  Jump bb3(v1)
bb2():
  EntryPoint JIT(0)
  v4:BasicObject = LoadArg :self@0
  Jump bb3(v4)
bb3(v6:BasicObject):
  v10:Fixnum[1] = Const Value(1)
  PatchPoint SingleRactorMode
  v35:HeapBasicObject = GuardType v6, HeapBasicObject
  v36:CShape = LoadField v35, :_shape_id@0x1000
  v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001)
  StoreField v35, :@a@0x1002, v10
  WriteBarrier v35, v10
  v40:CShape[0x1003] = Const CShape(0x1003)
- StoreField v35, :_shape_id@0x1000, v40
  v14:HeapBasicObject = RefineType v6, HeapBasicObject
  v17:Fixnum[2] = Const Value(2)
  PatchPoint SingleRactorMode
  StoreField v14, :@b@0x1004, v17
  WriteBarrier v14, v17
  v47:CShape[0x1005] = Const CShape(0x1005)
- StoreField v14, :_shape_id@0x1000, v47
  v21:HeapBasicObject = RefineType v14, HeapBasicObject
  v24:Fixnum[3] = Const Value(3)
  PatchPoint SingleRactorMode
  StoreField v21, :@c@0x1006, v24
  WriteBarrier v21, v24
  v54:CShape[0x1007] = Const CShape(0x1007)
  StoreField v21, :_shape_id@0x1000, v54
  CheckInterrupts
  Return v24
```