### PR TITLE
Use build-mode: none for CodeQL C/C++ scanning

### DIFF
--- a/.github/workflows/check_sast.yml
+++ b/.github/workflows/check_sast.yml
@@ -64,9 +64,6 @@ jobs:
       || (github.event_name == 'push' && github.event.pull_request.user.login == 'dependabot[bot]')
       )}}
 
-    env:
-      enable_install_doc: no
-
     strategy:
       fail-fast: false
       matrix:
@@ -80,29 +77,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install libraries
-        if: ${{ contains(matrix.os, 'macos') }}
-        uses: ./.github/actions/setup/macos
-
-      - name: Install libraries
-        if : ${{ matrix.os == 'ubuntu-latest' }}
-        uses: ./.github/actions/setup/ubuntu
-
-      - uses: ./.github/actions/setup/directories
-
-      - name: Remove an obsolete rubygems vendored file
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: sudo rm /usr/lib/ruby/vendor_ruby/rubygems/defaults/operating_system.rb
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
         with:
           languages: ${{ matrix.language }}
-          trap-caching: false
-          debug: true
-
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1
+          build-mode: none
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1

--- a/.github/workflows/check_sast.yml
+++ b/.github/workflows/check_sast.yml
@@ -54,7 +54,7 @@ jobs:
     permissions:
       actions: read # for github/codeql-action/init to get workflow details
       contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/autobuild to send a status report
+      security-events: write # for github/codeql-action/upload-sarif to send a status report
     # CodeQL fails to run pull requests from dependabot due to missing write access to upload results.
     if: >-
       ${{!(false
@@ -111,6 +111,17 @@ jobs:
           input: sarif-results/${{ matrix.language }}.sarif
           output: sarif-results/${{ matrix.language }}.sarif
         if: ${{ matrix.language == 'ruby' }}
+        continue-on-error: true
+
+      - name: filter-sarif
+        uses: advanced-security/filter-sarif@2da736ff05ef065cb2894ac6892e47b5eac2c3c0 # v1.1.0.1.1
+        with:
+          patterns: |
+            +**/*.c
+            +**/*.h
+          input: sarif-results/${{ matrix.language }}.sarif
+          output: sarif-results/${{ matrix.language }}.sarif
+        if: ${{ matrix.language == 'cpp' }}
         continue-on-error: true
 
       - name: Upload SARIF


### PR DESCRIPTION
Remove the autobuild step and build-related setup steps since CodeQL now supports scanning C/C++ without builds.