### PR TITLE
Rewrite finalizers using weak references

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -2009,7 +2009,7 @@ finalizer_fire_ready_queue(void *data)
         RB_VM_LOCKING() {
             ccan_list_for_each(&GET_VM()->ractor.set, r, vmlr_node) {
                 if (r != cr && r->finalizer_queue && r->threads.main) {
-                    rb_ractor_interrupt_exec(r, finalizer_interrupt_exec_func, NULL, rb_interrupt_exec_flag_none);
+                    rb_threadptr_interrupt_exec(r->threads.main, finalizer_interrupt_exec_func, NULL, rb_interrupt_exec_flag_none);
                 }
             }
         }

--- a/gc.c
+++ b/gc.c
@@ -1848,6 +1848,7 @@ struct rb_weak_finalizer {
     VALUE self;        /* back-reference to this TypedData VALUE (for queue linking) */
     VALUE target;      /* weak reference to target object (NOT marked by dmark) */
     VALUE next_queued; /* next finalizer VALUE in ready-to-fire queue, or 0 */
+    rb_ractor_t *ractor; /* ractor that registered this finalizer */
     union {
         struct {
             VALUE objid;       /* object_id, captured at registration time */
@@ -1862,7 +1863,6 @@ struct rb_weak_finalizer {
 };
 
 static st_table *finalizer_table;               /* object_id -> finalizer VALUE */
-static VALUE finalizer_ready_queue;              /* linked list head (VALUE), 0 = empty */
 static rb_postponed_job_handle_t finalizer_pjob;
 static VALUE dfree_finalizer_list;               /* linked list head of deferred free weak finalizers, 0 = empty */
 
@@ -1903,13 +1903,13 @@ get_weak_final(long i, void *data)
 }
 
 static void
-finalizer_fire_ready_queue(void *data)
+finalizer_fire_ractor_queue(rb_ractor_t *r)
 {
     VALUE queue;
 
-    /* Atomically grab the queue */
-    while ((queue = finalizer_ready_queue) != 0) {
-        if (RUBY_ATOMIC_VALUE_CAS(finalizer_ready_queue, queue, 0) == queue) {
+    /* Atomically grab the ractor's queue */
+    while ((queue = r->finalizer_queue) != 0) {
+        if (RUBY_ATOMIC_VALUE_CAS(r->finalizer_queue, queue, 0) == queue) {
             break;
         }
     }
@@ -1948,6 +1948,72 @@ finalizer_fire_ready_queue(void *data)
     }
 
     rb_gc_unset_pending_interrupt();
+}
+
+static VALUE
+finalizer_interrupt_exec_func(void *data)
+{
+    finalizer_fire_ractor_queue(GET_RACTOR());
+    return Qnil;
+}
+
+static rb_ractor_t *
+finalizer_target_ractor(rb_ractor_t *r)
+{
+    while (rb_ractor_status_p(r, ractor_terminated)) {
+        rb_ractor_t *s = r->sync.successor;
+        if (!s) return NULL;
+        r = s;
+    }
+    return r;
+}
+
+void
+rb_gc_ractor_inherit_finalizer_queue(rb_ractor_t *successor, rb_ractor_t *predecessor)
+{
+    VALUE queue;
+    do {
+        queue = predecessor->finalizer_queue;
+    } while (RUBY_ATOMIC_VALUE_CAS(predecessor->finalizer_queue, queue, 0) != queue);
+
+    if (!queue) return;
+
+    VALUE tail = queue;
+    while (1) {
+        struct rb_weak_finalizer *fin = RTYPEDDATA_GET_DATA(tail);
+        if (!fin->next_queued) break;
+        tail = fin->next_queued;
+    }
+
+    struct rb_weak_finalizer *tail_fin = RTYPEDDATA_GET_DATA(tail);
+    VALUE old_head;
+    do {
+        old_head = successor->finalizer_queue;
+        tail_fin->next_queued = old_head;
+    } while (RUBY_ATOMIC_VALUE_CAS(successor->finalizer_queue, old_head, queue) != old_head);
+
+    rb_postponed_job_trigger(finalizer_pjob);
+}
+
+static void
+finalizer_fire_ready_queue(void *data)
+{
+    rb_ractor_t *cr = GET_RACTOR();
+
+    /* Fire our own queue directly */
+    finalizer_fire_ractor_queue(cr);
+
+    /* Dispatch to other ractors that have pending finalizers */
+    if (!ruby_single_main_ractor) {
+        rb_ractor_t *r;
+        RB_VM_LOCKING() {
+            ccan_list_for_each(&GET_VM()->ractor.set, r, vmlr_node) {
+                if (r != cr && r->finalizer_queue && r->threads.main) {
+                    rb_ractor_interrupt_exec(r, finalizer_interrupt_exec_func, NULL, rb_interrupt_exec_flag_none);
+                }
+            }
+        }
+    }
 }
 
 static void
@@ -1995,6 +2061,16 @@ weak_finalizer_handle_weak_references(void *ptr)
     /* Already fired or unregistered */
     if (target == Qundef) return;
 
+    if (!rb_gc_handle_weak_references_alive_p(rb_ractor_self(fin->ractor))) {
+        rb_ractor_t *new_owner = fin->ractor->sync.successor;
+        while (new_owner && !rb_gc_handle_weak_references_alive_p(rb_ractor_self(new_owner))) {
+            new_owner = new_owner->sync.successor;
+        }
+        if (!new_owner) new_owner = GET_VM()->ractor.main_ractor;
+        rb_gc_ractor_inherit_finalizer_queue(new_owner, fin->ractor);
+        fin->ractor = new_owner;
+    }
+
     if (rb_gc_handle_weak_references_alive_p(target)) {
         return; /* target still alive */
     }
@@ -2007,17 +2083,22 @@ weak_finalizer_handle_weak_references(void *ptr)
         extract_dfree_from_target(target, &fin->as.dfree.dfree, &fin->as.dfree.dfree_data);
     }
 
-    /* Target is dead: enqueue self into ready queue and trigger postponed job */
+    /* Target is dead: enqueue self into owning ractor's ready queue */
     fin->target = Qundef;
+
+    rb_ractor_t *r = finalizer_target_ractor(fin->ractor);
+    if (!r) r = fin->ractor;
 
     VALUE self = fin->self;
     VALUE old_head;
     do {
-        old_head = finalizer_ready_queue;
+        old_head = r->finalizer_queue;
         fin->next_queued = old_head;
-    } while (RUBY_ATOMIC_VALUE_CAS(finalizer_ready_queue, old_head, self) != old_head);
+    } while (RUBY_ATOMIC_VALUE_CAS(r->finalizer_queue, old_head, self) != old_head);
 
-    rb_postponed_job_trigger(finalizer_pjob);
+    if (!rb_ractor_status_p(r, ractor_terminated)) {
+        rb_postponed_job_trigger(finalizer_pjob);
+    }
 }
 
 static const rb_data_type_t weak_finalizer_type = {
@@ -2070,6 +2151,7 @@ rb_gc_register_deferred_free(VALUE obj)
     fin->self = finalizer;
     fin->target = obj;
     fin->next_queued = 0;
+    fin->ractor = GET_RACTOR();
     FL_SET_RAW(finalizer, WEAK_FINALIZER_DFREE);
 
     /* Link into dfree_finalizer_list */
@@ -2162,6 +2244,7 @@ rb_gc_copy_finalizer(VALUE dest, VALUE obj)
     fin->target = dest;
     fin->as.callback.objid = dest_objid;
     fin->next_queued = 0;
+    fin->ractor = GET_RACTOR();
     RB_OBJ_WRITE(finalizer, &fin->as.callback.callbacks, callbacks_copy);
 
     rb_gc_declare_weak_references(finalizer);
@@ -2294,6 +2377,7 @@ rb_define_finalizer(VALUE obj, VALUE block)
         fin->target = obj;
         fin->as.callback.objid = objid;
         fin->next_queued = 0;
+        fin->ractor = GET_RACTOR();
         RB_OBJ_WRITE(finalizer, &fin->as.callback.callbacks, rb_ary_new3(1, block));
 
         rb_gc_declare_weak_references(finalizer);

--- a/gc.c
+++ b/gc.c
@@ -646,10 +646,6 @@ typedef struct gc_function_map {
     void (*each_objects)(void *objspace_ptr, int (*callback)(void *, void *, size_t, void *), void *data);
     void (*each_object)(void *objspace_ptr, void (*func)(VALUE obj, void *data), void *data);
     // Finalizers
-    void (*make_zombie)(void *objspace_ptr, VALUE obj, void (*dfree)(void *), void *data);
-    VALUE (*define_finalizer)(void *objspace_ptr, VALUE obj, VALUE block);
-    void (*undefine_finalizer)(void *objspace_ptr, VALUE obj);
-    void (*copy_finalizer)(void *objspace_ptr, VALUE dest, VALUE obj);
     void (*shutdown_call_finalizer)(void *objspace_ptr);
     // Forking
     void (*before_fork)(void *objspace_ptr);
@@ -825,10 +821,6 @@ ruby_modular_gc_init(void)
     load_modular_gc_func(each_objects);
     load_modular_gc_func(each_object);
     // Finalizers
-    load_modular_gc_func(make_zombie);
-    load_modular_gc_func(define_finalizer);
-    load_modular_gc_func(undefine_finalizer);
-    load_modular_gc_func(copy_finalizer);
     load_modular_gc_func(shutdown_call_finalizer);
     // Forking
     load_modular_gc_func(before_fork);
@@ -913,10 +905,6 @@ ruby_modular_gc_init(void)
 # define rb_gc_impl_each_objects rb_gc_functions.each_objects
 # define rb_gc_impl_each_object rb_gc_functions.each_object
 // Finalizers
-# define rb_gc_impl_make_zombie rb_gc_functions.make_zombie
-# define rb_gc_impl_define_finalizer rb_gc_functions.define_finalizer
-# define rb_gc_impl_undefine_finalizer rb_gc_functions.undefine_finalizer
-# define rb_gc_impl_copy_finalizer rb_gc_functions.copy_finalizer
 # define rb_gc_impl_shutdown_call_finalizer rb_gc_functions.shutdown_call_finalizer
 // Forking
 # define rb_gc_impl_before_fork rb_gc_functions.before_fork
@@ -1151,6 +1139,11 @@ rb_data_object_wrap(VALUE klass, void *datap, RUBY_DATA_FUNC dmark, RUBY_DATA_FU
     data->dfree = dfree;
     data->data = datap;
 
+    /* Old-style Data objects never have FREE_IMMEDIATELY, register deferred free */
+    if (dfree && dfree != RUBY_DEFAULT_FREE) {
+        rb_gc_register_deferred_free(obj);
+    }
+
     return obj;
 }
 
@@ -1180,6 +1173,13 @@ typed_data_alloc(VALUE klass, VALUE typed_flag, void *datap, const rb_data_type_
     data->fields_obj = 0;
     *(VALUE *)&data->type = ((VALUE)type) | typed_flag;
     data->data = datap;
+
+    /* Register deferred free for non-immediate dfree */
+    if (type->function.dfree &&
+        type->function.dfree != RUBY_DEFAULT_FREE &&
+        !(type->flags & RUBY_TYPED_FREE_IMMEDIATELY)) {
+        rb_gc_register_deferred_free(obj);
+    }
 
     return obj;
 }
@@ -1364,8 +1364,6 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
 {
     VALUE flags = RBASIC(obj)->flags;
 
-    if (flags & FL_FINALIZE) return true;
-
     switch (flags & RUBY_T_MASK) {
       case T_IMEMO:
         return rb_gc_imemo_needs_cleanup_p(obj);
@@ -1443,19 +1441,6 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
     }
 }
 
-static void
-io_fptr_finalize(void *fptr)
-{
-    rb_io_fptr_finalize((struct rb_io *)fptr);
-}
-
-static inline void
-make_io_zombie(void *objspace, VALUE obj)
-{
-    rb_io_t *fptr = RFILE(obj)->fptr;
-    rb_gc_impl_make_zombie(objspace, obj, io_fptr_finalize, fptr);
-}
-
 static bool
 rb_data_free(void *objspace, VALUE obj)
 {
@@ -1488,9 +1473,8 @@ rb_data_free(void *objspace, VALUE obj)
                 RB_DEBUG_COUNTER_INC(obj_data_imm_free);
             }
             else {
-                rb_gc_impl_make_zombie(objspace, obj, dfree, data);
+                /* Non-immediate dfree is handled by deferred free weak ref */
                 RB_DEBUG_COUNTER_INC(obj_data_zombie);
-                return FALSE;
             }
         }
         else {
@@ -1649,10 +1633,9 @@ rb_gc_obj_free(void *objspace, VALUE obj)
         }
         break;
       case T_FILE:
+        /* fptr cleanup is handled by deferred free weak ref */
         if (RFILE(obj)->fptr) {
-            make_io_zombie(objspace, obj);
             RB_DEBUG_COUNTER_INC(obj_file_ptr);
-            return FALSE;
         }
         break;
       case T_RATIONAL:
@@ -1716,13 +1699,7 @@ rb_gc_obj_free(void *objspace, VALUE obj)
                BUILTIN_TYPE(obj), (void*)obj, RBASIC(obj)->flags);
     }
 
-    if (FL_TEST_RAW(obj, FL_FINALIZE)) {
-        rb_gc_impl_make_zombie(objspace, obj, 0, 0);
-        return FALSE;
-    }
-    else {
-        return TRUE;
-    }
+    return TRUE;
 }
 
 void
@@ -1859,6 +1836,251 @@ os_each_obj(int argc, VALUE *argv, VALUE os)
     return os_obj_of(of);
 }
 
+/* Weak-reference based finalizer implementation */
+
+#define WEAK_FINALIZER_COMPLETED FL_USER0
+#define WEAK_FINALIZER_DFREE     FL_USER1
+
+#define WEAK_FINALIZER_IS_DFREE(fin)     FL_TEST_RAW((fin)->self, WEAK_FINALIZER_DFREE)
+#define WEAK_FINALIZER_IS_CALLBACK(fin)  (!WEAK_FINALIZER_IS_DFREE(fin))
+
+struct rb_weak_finalizer {
+    VALUE self;        /* back-reference to this TypedData VALUE (for queue linking) */
+    VALUE target;      /* weak reference to target object (NOT marked by dmark) */
+    VALUE next_queued; /* next finalizer VALUE in ready-to-fire queue, or 0 */
+    union {
+        struct {
+            VALUE objid;       /* object_id, captured at registration time */
+            VALUE callbacks;   /* Ruby Array of finalizer procs */
+        } callback;
+        struct {
+            void (*dfree)(void *);  /* C-level dfree function (captured when target dies) */
+            void *dfree_data;       /* data pointer for dfree */
+            VALUE next;             /* linked list for dfree_finalizer_list */
+        } dfree;
+    } as;
+};
+
+static st_table *finalizer_table;               /* object_id -> finalizer VALUE */
+static VALUE finalizer_ready_queue;              /* linked list head (VALUE), 0 = empty */
+static rb_postponed_job_handle_t finalizer_pjob;
+static VALUE dfree_finalizer_list;               /* linked list head of deferred free weak finalizers, 0 = empty */
+
+static void
+weak_finalizer_mark(void *ptr)
+{
+    struct rb_weak_finalizer *fin = ptr;
+    if (WEAK_FINALIZER_IS_CALLBACK(fin)) {
+        rb_gc_mark(fin->as.callback.callbacks);
+    }
+}
+
+static size_t
+weak_finalizer_memsize(const void *ptr)
+{
+    return sizeof(struct rb_weak_finalizer);
+}
+
+static void
+weak_finalizer_compact(void *ptr)
+{
+    struct rb_weak_finalizer *fin = ptr;
+    fin->target = rb_gc_location(fin->target);
+    fin->self = rb_gc_location(fin->self);
+    if (WEAK_FINALIZER_IS_CALLBACK(fin)) {
+        fin->as.callback.callbacks = rb_gc_location(fin->as.callback.callbacks);
+    }
+    else if (fin->as.dfree.next) {
+        fin->as.dfree.next = rb_gc_location(fin->as.dfree.next);
+    }
+}
+
+static VALUE
+get_weak_final(long i, void *data)
+{
+    VALUE callbacks = (VALUE)data;
+    return RARRAY_AREF(callbacks, i);
+}
+
+static void
+finalizer_fire_ready_queue(void *data)
+{
+    VALUE queue;
+
+    /* Atomically grab the queue */
+    while ((queue = finalizer_ready_queue) != 0) {
+        if (RUBY_ATOMIC_VALUE_CAS(finalizer_ready_queue, queue, 0) == queue) {
+            break;
+        }
+    }
+
+    if (!queue) return;
+
+    rb_gc_set_pending_interrupt();
+
+    while (queue) {
+        struct rb_weak_finalizer *fin = RTYPEDDATA_GET_DATA(queue);
+        VALUE next = fin->next_queued;
+        fin->next_queued = 0;
+
+        if (WEAK_FINALIZER_IS_CALLBACK(fin)) {
+            /* Remove from finalizer_table */
+            st_data_t key = fin->as.callback.objid;
+            RB_VM_LOCKING() {
+                st_delete(finalizer_table, &key, NULL);
+            }
+
+            /* Fire Ruby callbacks */
+            long count = RARRAY_LEN(fin->as.callback.callbacks);
+            rb_gc_run_obj_finalizer(fin->as.callback.objid, count, get_weak_final, (void *)fin->as.callback.callbacks);
+        }
+        else {
+            /* Call C-level dfree */
+            if (fin->as.dfree.dfree) {
+                fin->as.dfree.dfree(fin->as.dfree.dfree_data);
+                fin->as.dfree.dfree = NULL;
+                fin->as.dfree.dfree_data = NULL;
+            }
+        }
+
+        FL_SET_RAW(queue, WEAK_FINALIZER_COMPLETED);
+        queue = next;
+    }
+
+    rb_gc_unset_pending_interrupt();
+}
+
+static void
+io_fptr_finalize_free(void *fptr)
+{
+    rb_io_fptr_finalize((struct rb_io *)fptr);
+}
+
+/* Extract dfree function and data pointer from a target object. */
+static void
+extract_dfree_from_target(VALUE target, void (**dfree)(void *), void **data)
+{
+    *dfree = NULL;
+    *data = NULL;
+
+    switch (BUILTIN_TYPE(target)) {
+      case T_DATA:
+        if (RTYPEDDATA_P(target)) {
+            const rb_data_type_t *type = RTYPEDDATA_TYPE(target);
+            *dfree = type->function.dfree;
+            *data = RTYPEDDATA_GET_DATA(target);
+        }
+        else {
+            *dfree = RDATA(target)->dfree;
+            *data = DATA_PTR(target);
+        }
+        break;
+      case T_FILE:
+        if (RFILE(target)->fptr) {
+            *dfree = io_fptr_finalize_free;
+            *data = RFILE(target)->fptr;
+        }
+        break;
+      default:
+        break;
+    }
+}
+
+static void
+weak_finalizer_handle_weak_references(void *ptr)
+{
+    struct rb_weak_finalizer *fin = ptr;
+    VALUE target = fin->target;
+
+    /* Already fired or unregistered */
+    if (target == Qundef) return;
+
+    if (rb_gc_handle_weak_references_alive_p(target)) {
+        return; /* target still alive */
+    }
+
+    RUBY_ASSERT(!FL_TEST_RAW(fin->self, WEAK_FINALIZER_COMPLETED));
+
+    /* For dfree finalizers, capture dfree info from the target while
+     * memory is still valid (pre-sweep). */
+    if (WEAK_FINALIZER_IS_DFREE(fin)) {
+        extract_dfree_from_target(target, &fin->as.dfree.dfree, &fin->as.dfree.dfree_data);
+    }
+
+    /* Target is dead: enqueue self into ready queue and trigger postponed job */
+    fin->target = Qundef;
+
+    VALUE self = fin->self;
+    VALUE old_head;
+    do {
+        old_head = finalizer_ready_queue;
+        fin->next_queued = old_head;
+    } while (RUBY_ATOMIC_VALUE_CAS(finalizer_ready_queue, old_head, self) != old_head);
+
+    rb_postponed_job_trigger(finalizer_pjob);
+}
+
+static const rb_data_type_t weak_finalizer_type = {
+    "weak_finalizer",
+    {
+        weak_finalizer_mark,
+        RUBY_DEFAULT_FREE,
+        weak_finalizer_memsize,
+        weak_finalizer_compact,
+        weak_finalizer_handle_weak_references,
+    },
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
+};
+
+static int
+mark_finalizer_table_i(st_data_t key, st_data_t val, st_data_t data)
+{
+    rb_gc_mark((VALUE)val);
+    return ST_CONTINUE;
+}
+
+static void
+mark_dfree_finalizer_list(void)
+{
+    VALUE *prev = &dfree_finalizer_list;
+    VALUE node = dfree_finalizer_list;
+    while (node) {
+        struct rb_weak_finalizer *fin = RTYPEDDATA_GET_DATA(node);
+        VALUE next = fin->as.dfree.next;
+
+        if (FL_TEST_RAW(node, WEAK_FINALIZER_COMPLETED)) {
+            /* Already processed, unlink */
+            *prev = next;
+            fin->as.dfree.next = 0;
+        }
+        else {
+            rb_gc_mark(node);
+            prev = &fin->as.dfree.next;
+        }
+
+        node = next;
+    }
+}
+
+void
+rb_gc_register_deferred_free(VALUE obj)
+{
+    struct rb_weak_finalizer *fin;
+    VALUE finalizer = TypedData_Make_Struct(0, struct rb_weak_finalizer, &weak_finalizer_type, fin);
+    fin->self = finalizer;
+    fin->target = obj;
+    fin->next_queued = 0;
+    FL_SET_RAW(finalizer, WEAK_FINALIZER_DFREE);
+
+    /* Link into dfree_finalizer_list */
+    RB_VM_LOCKING() {
+        RB_OBJ_WRITE(finalizer, &fin->as.dfree.next, dfree_finalizer_list);
+        dfree_finalizer_list = finalizer;
+    }
+
+    rb_gc_declare_weak_references(finalizer);
+}
+
 /*
  *  call-seq:
  *     ObjectSpace.undefine_finalizer(obj)
@@ -1878,7 +2100,17 @@ rb_undefine_finalizer(VALUE obj)
 {
     rb_check_frozen(obj);
 
-    rb_gc_impl_undefine_finalizer(rb_gc_get_objspace(), obj);
+    VALUE objid = rb_obj_id(obj);
+    st_data_t key = objid;
+    st_data_t val;
+    RB_VM_LOCKING() {
+        if (st_delete(finalizer_table, &key, &val)) {
+            struct rb_weak_finalizer *fin = RTYPEDDATA_GET_DATA((VALUE)val);
+            fin->target = Qundef;
+            fin->as.callback.callbacks = 0;
+        }
+    }
+    FL_UNSET(obj, FL_FINALIZE);
 
     return obj;
 }
@@ -1905,7 +2137,39 @@ should_be_finalizable(VALUE obj)
 void
 rb_gc_copy_finalizer(VALUE dest, VALUE obj)
 {
-    rb_gc_impl_copy_finalizer(rb_gc_get_objspace(), dest, obj);
+    if (!FL_TEST(obj, FL_FINALIZE)) return;
+
+    VALUE src_objid = rb_obj_id(obj);
+    st_data_t data;
+
+    VALUE src_finalizer = 0;
+    RB_VM_LOCKING() {
+        if (st_lookup(finalizer_table, src_objid, &data)) {
+            src_finalizer = (VALUE)data;
+        }
+    }
+    if (!src_finalizer) return;
+
+    struct rb_weak_finalizer *src_fin = RTYPEDDATA_GET_DATA(src_finalizer);
+
+    /* Create a new finalizer for dest with a copy of the callbacks */
+    VALUE dest_objid = rb_obj_id(dest);
+    VALUE callbacks_copy = rb_ary_dup(src_fin->as.callback.callbacks);
+
+    struct rb_weak_finalizer *fin;
+    VALUE finalizer = TypedData_Make_Struct(0, struct rb_weak_finalizer, &weak_finalizer_type, fin);
+    fin->self = finalizer;
+    fin->target = dest;
+    fin->as.callback.objid = dest_objid;
+    fin->next_queued = 0;
+    RB_OBJ_WRITE(finalizer, &fin->as.callback.callbacks, callbacks_copy);
+
+    rb_gc_declare_weak_references(finalizer);
+
+    RB_VM_LOCKING() {
+        st_insert(finalizer_table, dest_objid, (st_data_t)finalizer);
+    }
+    FL_SET(dest, FL_FINALIZE);
 }
 
 /*
@@ -1998,16 +2262,100 @@ rb_define_finalizer(VALUE obj, VALUE block)
     should_be_finalizable(obj);
     should_be_callable(block);
 
-    block = rb_gc_impl_define_finalizer(rb_gc_get_objspace(), obj, block);
+    VALUE objid = rb_obj_id(obj);
+    st_data_t data;
+
+    VALUE existing_finalizer = 0;
+    RB_VM_LOCKING() {
+        if (st_lookup(finalizer_table, objid, &data)) {
+            existing_finalizer = (VALUE)data;
+        }
+    }
+
+    if (existing_finalizer) {
+        /* Existing finalizer: append block (dedup check) */
+        struct rb_weak_finalizer *fin = RTYPEDDATA_GET_DATA(existing_finalizer);
+        /* rb_equal can call arbitrary Ruby code, must not hold VM lock */
+        long len = RARRAY_LEN(fin->as.callback.callbacks);
+        for (long i = 0; i < len; i++) {
+            if (rb_equal(RARRAY_AREF(fin->as.callback.callbacks, i), block)) {
+                VALUE ret = rb_ary_new3(2, INT2FIX(0), RARRAY_AREF(fin->as.callback.callbacks, i));
+                OBJ_FREEZE(ret);
+                return ret;
+            }
+        }
+        rb_ary_push(fin->as.callback.callbacks, block);
+    }
+    else {
+        /* New finalizer */
+        struct rb_weak_finalizer *fin;
+        VALUE finalizer = TypedData_Make_Struct(0, struct rb_weak_finalizer, &weak_finalizer_type, fin);
+        fin->self = finalizer;
+        fin->target = obj;
+        fin->as.callback.objid = objid;
+        fin->next_queued = 0;
+        RB_OBJ_WRITE(finalizer, &fin->as.callback.callbacks, rb_ary_new3(1, block));
+
+        rb_gc_declare_weak_references(finalizer);
+
+        RB_VM_LOCKING() {
+            st_insert(finalizer_table, objid, (st_data_t)finalizer);
+        }
+    }
+
+    FL_SET(obj, FL_FINALIZE);
 
     block = rb_ary_new3(2, INT2FIX(0), block);
     OBJ_FREEZE(block);
     return block;
 }
 
+static int
+shutdown_call_finalizer_i(st_data_t key, st_data_t val, st_data_t data)
+{
+    struct rb_weak_finalizer *fin = RTYPEDDATA_GET_DATA((VALUE)val);
+
+    long count = RARRAY_LEN(fin->as.callback.callbacks);
+    rb_gc_run_obj_finalizer(fin->as.callback.objid, count, get_weak_final, (void *)fin->as.callback.callbacks);
+
+    return ST_DELETE;
+}
+
 void
 rb_objspace_call_finalizer(void)
 {
+    /* Run all Ruby-level finalizers */
+    while (finalizer_table->num_entries) {
+        st_foreach(finalizer_table, shutdown_call_finalizer_i, 0);
+    }
+
+    /* Run dfree for all live objects that have deferred free registered */
+    VALUE node = dfree_finalizer_list;
+    while (node) {
+        struct rb_weak_finalizer *fin = RTYPEDDATA_GET_DATA(node);
+        VALUE next = fin->as.dfree.next;
+
+        if (fin->target != Qundef && fin->target != 0) {
+            /* Target is still alive — read dfree+data from it now */
+            void (*dfree)(void *) = NULL;
+            void *data = NULL;
+
+            extract_dfree_from_target(fin->target, &dfree, &data);
+
+            if (dfree && dfree != RUBY_DEFAULT_FREE) {
+                dfree(data);
+            }
+        }
+        else if (fin->as.dfree.dfree) {
+            /* Target already dead and dfree was captured */
+            fin->as.dfree.dfree(fin->as.dfree.dfree_data);
+        }
+
+        node = next;
+    }
+    dfree_finalizer_list = 0;
+
+    /* Delegate to GC impl for remaining cleanup */
     rb_gc_impl_shutdown_call_finalizer(rb_gc_get_objspace());
 }
 
@@ -3271,6 +3619,14 @@ rb_gc_mark_roots(void *objspace, const char **categoryp)
     if (categoryp) *categoryp = category; \
 } while (0)
 
+    MARK_CHECKPOINT("finalizers");
+    if (finalizer_table && finalizer_table->num_entries > 0) {
+        st_foreach(finalizer_table, mark_finalizer_table_i, 0);
+    }
+    if (dfree_finalizer_list) {
+        mark_dfree_finalizer_list();
+    }
+
     MARK_CHECKPOINT("vm");
     rb_vm_mark(vm);
 
@@ -3644,6 +4000,7 @@ void
 rb_gc_copy_attributes(VALUE dest, VALUE obj)
 {
     rb_gc_impl_copy_attributes(rb_gc_get_objspace(), dest, obj);
+    rb_gc_copy_finalizer(dest, obj);
 }
 
 int
@@ -5789,6 +6146,13 @@ Init_GC(void)
     rb_define_method(rb_mKernel, "object_id", rb_obj_id, 0);
 
     rb_define_module_function(rb_mObjSpace, "count_objects", count_objects, -1);
+
+    /* Initialize finalizer infrastructure */
+    finalizer_table = st_init_numtable();
+    finalizer_pjob = rb_postponed_job_preregister(0, finalizer_fire_ready_queue, NULL);
+    if (finalizer_pjob == POSTPONED_JOB_HANDLE_INVALID) {
+        rb_bug("Could not preregister postponed job for finalizers");
+    }
 
     rb_gc_impl_init();
 }

--- a/gc.rb
+++ b/gc.rb
@@ -151,7 +151,6 @@ module GC
   #    heap_available_slots: 539590,
   #    heap_live_slots: 422243,
   #    heap_free_slots: 117347,
-  #    heap_final_slots: 0,
   #    heap_marked_slots: 264877,
   #    heap_eden_pages: 521,
   #    total_allocated_pages: 521,
@@ -206,8 +205,6 @@ module GC
   #   The total number of slots which contain live objects.
   # - +:heap_free_slots+:
   #   The total number of slots which do not contain live objects.
-  # - +:heap_final_slots+:
-  #   The total number of slots with pending finalizers to be run.
   # - +:heap_marked_slots+:
   #   The total number of objects marked in the last \GC.
   # - +:heap_eden_pages+:

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -485,7 +485,6 @@ typedef struct rb_heap_struct {
     size_t force_incremental_marking_finish_count;
     size_t total_allocated_objects;
     size_t total_freed_objects;
-    size_t final_slots_count;
 
     /* Sweeping statistics */
     size_t freed_slots;
@@ -556,10 +555,6 @@ typedef struct rb_objspace {
     size_t empty_pages_count;
     struct heap_page *empty_pages;
 
-    struct {
-        rb_atomic_t finalizing;
-    } atomic_flags;
-
     mark_stack_t mark_stack;
     size_t marked_slots;
 
@@ -572,12 +567,7 @@ typedef struct rb_objspace {
         size_t freeable_pages;
 
         size_t allocatable_bytes;
-
-        /* final */
-        VALUE deferred_final;
     } heap_pages;
-
-    st_table *finalizer_table;
 
     struct {
         int run;
@@ -675,7 +665,6 @@ typedef struct rb_objspace {
 #endif
 
     rb_darray(VALUE) weak_references;
-    rb_postponed_job_handle_t finalize_deferred_pjob;
 
     unsigned long live_ractor_cache_count;
 
@@ -814,7 +803,6 @@ struct heap_page {
     unsigned short slot_size;
     unsigned short total_slots;
     unsigned short free_slots;
-    unsigned short final_slots;
     unsigned short pinned_slots;
     struct {
         unsigned int before_sweep : 1;
@@ -957,11 +945,8 @@ RVALUE_AGE_SET(VALUE obj, int age)
 #define heap_pages_lomem	objspace->heap_pages.range[0]
 #define heap_pages_himem	objspace->heap_pages.range[1]
 #define heap_pages_freeable_pages	objspace->heap_pages.freeable_pages
-#define heap_pages_deferred_final	objspace->heap_pages.deferred_final
 #define heaps              objspace->heaps
 #define during_gc		objspace->flags.during_gc
-#define finalizing		objspace->atomic_flags.finalizing
-#define finalizer_table 	objspace->finalizer_table
 #define ruby_gc_stressful	objspace->flags.gc_stressful
 #define ruby_gc_stress_mode     objspace->gc_stress_mode
 #if GC_DEBUG_STRESS_TO_CLASS
@@ -1050,17 +1035,6 @@ total_freed_objects(rb_objspace_t *objspace)
     for (int i = 0; i < HEAP_COUNT; i++) {
         rb_heap_t *heap = &heaps[i];
         count += heap->total_freed_objects;
-    }
-    return count;
-}
-
-static inline size_t
-total_final_slots_count(rb_objspace_t *objspace)
-{
-    size_t count = 0;
-    for (int i = 0; i < HEAP_COUNT; i++) {
-        rb_heap_t *heap = &heaps[i];
-        count += heap->final_slots_count;
     }
     return count;
 }
@@ -1169,8 +1143,6 @@ static inline void gc_prof_set_heap_info(rb_objspace_t *);
 # define gc_report if (!RGENGC_DEBUG_ENABLED(0)) {} else gc_report_body
 #endif
 PRINTF_ARGS(static void gc_report_body(int level, rb_objspace_t *objspace, const char *fmt, ...), 3, 4);
-
-static void gc_finalize_deferred(void *dmy);
 
 #if USE_TICK_T
 
@@ -2655,27 +2627,6 @@ rb_gc_impl_pointer_to_heap_p(void *objspace_ptr, const void *ptr)
     return is_pointer_to_heap(objspace_ptr, ptr);
 }
 
-#define ZOMBIE_OBJ_KEPT_FLAGS (FL_FINALIZE)
-
-void
-rb_gc_impl_make_zombie(void *objspace_ptr, VALUE obj, void (*dfree)(void *), void *data)
-{
-    rb_objspace_t *objspace = objspace_ptr;
-
-    struct RZombie *zombie = RZOMBIE(obj);
-    zombie->flags = T_ZOMBIE | (zombie->flags & ZOMBIE_OBJ_KEPT_FLAGS);
-    zombie->dfree = dfree;
-    zombie->data = data;
-    VALUE prev, next = heap_pages_deferred_final;
-    do {
-        zombie->next = prev = next;
-        next = RUBY_ATOMIC_VALUE_CAS(heap_pages_deferred_final, prev, obj);
-    } while (next != prev);
-
-    struct heap_page *page = GET_HEAP_PAGE(obj);
-    page->final_slots++;
-    page->heap->final_slots_count++;
-}
 
 typedef int each_obj_callback(void *, void *, size_t, void *);
 typedef int each_page_callback(struct heap_page *, void *);
@@ -2827,189 +2778,6 @@ objspace_each_pages(rb_objspace_t *objspace, each_page_callback *callback, void 
 }
 #endif
 
-VALUE
-rb_gc_impl_define_finalizer(void *objspace_ptr, VALUE obj, VALUE block)
-{
-    rb_objspace_t *objspace = objspace_ptr;
-    VALUE table;
-    st_data_t data;
-
-    GC_ASSERT(!OBJ_FROZEN(obj));
-
-    RBASIC(obj)->flags |= FL_FINALIZE;
-
-    unsigned int lev = RB_GC_VM_LOCK();
-
-    if (st_lookup(finalizer_table, obj, &data)) {
-        table = (VALUE)data;
-        VALUE dup_table = rb_ary_dup(table);
-
-        RB_GC_VM_UNLOCK(lev);
-        /* avoid duplicate block, table is usually small */
-        {
-            long len = RARRAY_LEN(table);
-            long i;
-
-            for (i = 0; i < len; i++) {
-                VALUE recv = RARRAY_AREF(dup_table, i);
-                if (rb_equal(recv, block)) { // can't be called with VM lock held
-                    return recv;
-                }
-            }
-        }
-        lev = RB_GC_VM_LOCK();
-        RB_GC_GUARD(dup_table);
-
-        rb_ary_push(table, block);
-    }
-    else {
-        table = rb_ary_new3(2, rb_obj_id(obj), block);
-        rb_obj_hide(table);
-        st_add_direct(finalizer_table, obj, table);
-    }
-
-    RB_GC_VM_UNLOCK(lev);
-
-    return block;
-}
-
-void
-rb_gc_impl_undefine_finalizer(void *objspace_ptr, VALUE obj)
-{
-    rb_objspace_t *objspace = objspace_ptr;
-
-    GC_ASSERT(!OBJ_FROZEN(obj));
-
-    st_data_t data = obj;
-
-    int lev = RB_GC_VM_LOCK();
-    st_delete(finalizer_table, &data, 0);
-    RB_GC_VM_UNLOCK(lev);
-
-    FL_UNSET(obj, FL_FINALIZE);
-}
-
-void
-rb_gc_impl_copy_finalizer(void *objspace_ptr, VALUE dest, VALUE obj)
-{
-    rb_objspace_t *objspace = objspace_ptr;
-    VALUE table;
-    st_data_t data;
-
-    if (!FL_TEST(obj, FL_FINALIZE)) return;
-
-    int lev = RB_GC_VM_LOCK();
-    if (RB_LIKELY(st_lookup(finalizer_table, obj, &data))) {
-        table = rb_ary_dup((VALUE)data);
-        RARRAY_ASET(table, 0, rb_obj_id(dest));
-        st_insert(finalizer_table, dest, table);
-        FL_SET(dest, FL_FINALIZE);
-    }
-    else {
-        rb_bug("rb_gc_copy_finalizer: FL_FINALIZE set but not found in finalizer_table: %s", rb_obj_info(obj));
-    }
-    RB_GC_VM_UNLOCK(lev);
-}
-
-static VALUE
-get_final(long i, void *data)
-{
-    VALUE table = (VALUE)data;
-
-    return RARRAY_AREF(table, i + 1);
-}
-
-static unsigned int
-run_final(rb_objspace_t *objspace, VALUE zombie, unsigned int lev)
-{
-    if (RZOMBIE(zombie)->dfree) {
-        RZOMBIE(zombie)->dfree(RZOMBIE(zombie)->data);
-    }
-
-    st_data_t key = (st_data_t)zombie;
-    if (FL_TEST_RAW(zombie, FL_FINALIZE)) {
-        FL_UNSET(zombie, FL_FINALIZE);
-        st_data_t table;
-        if (st_delete(finalizer_table, &key, &table)) {
-            RB_GC_VM_UNLOCK(lev);
-            rb_gc_run_obj_finalizer(RARRAY_AREF(table, 0), RARRAY_LEN(table) - 1, get_final, (void *)table);
-            lev = RB_GC_VM_LOCK();
-        }
-        else {
-            rb_bug("FL_FINALIZE flag is set, but finalizers are not found");
-        }
-    }
-    else {
-        GC_ASSERT(!st_lookup(finalizer_table, key, NULL));
-    }
-    return lev;
-}
-
-static void
-finalize_list(rb_objspace_t *objspace, VALUE zombie)
-{
-    while (zombie) {
-        VALUE next_zombie;
-        struct heap_page *page;
-        rb_asan_unpoison_object(zombie, false);
-        next_zombie = RZOMBIE(zombie)->next;
-        page = GET_HEAP_PAGE(zombie);
-
-        unsigned int lev = RB_GC_VM_LOCK();
-
-        lev = run_final(objspace, zombie, lev);
-        {
-            GC_ASSERT(BUILTIN_TYPE(zombie) == T_ZOMBIE);
-            GC_ASSERT(page->heap->final_slots_count > 0);
-            GC_ASSERT(page->final_slots > 0);
-
-            page->heap->final_slots_count--;
-            page->final_slots--;
-            page->free_slots++;
-            RVALUE_AGE_SET_BITMAP(zombie, 0);
-            heap_page_add_freeobj(objspace, page, zombie);
-            page->heap->total_freed_objects++;
-        }
-        RB_GC_VM_UNLOCK(lev);
-
-        zombie = next_zombie;
-    }
-}
-
-static void
-finalize_deferred_heap_pages(rb_objspace_t *objspace)
-{
-    VALUE zombie;
-    while ((zombie = RUBY_ATOMIC_VALUE_EXCHANGE(heap_pages_deferred_final, 0)) != 0) {
-        finalize_list(objspace, zombie);
-    }
-}
-
-static void
-finalize_deferred(rb_objspace_t *objspace)
-{
-    rb_gc_set_pending_interrupt();
-    finalize_deferred_heap_pages(objspace);
-    rb_gc_unset_pending_interrupt();
-}
-
-static void
-gc_finalize_deferred(void *dmy)
-{
-    rb_objspace_t *objspace = dmy;
-    if (RUBY_ATOMIC_EXCHANGE(finalizing, 1)) return;
-
-    finalize_deferred(objspace);
-    RUBY_ATOMIC_SET(finalizing, 0);
-}
-
-static void
-gc_finalize_deferred_register(rb_objspace_t *objspace)
-{
-    /* will enqueue a call to gc_finalize_deferred */
-    rb_postponed_job_trigger(objspace->finalize_deferred_pjob);
-}
-
 static int pop_mark_stack(mark_stack_t *stack, VALUE *data);
 
 static void
@@ -3072,22 +2840,6 @@ rb_gc_impl_shutdown_free_objects(void *objspace_ptr)
     }
 }
 
-static int
-rb_gc_impl_shutdown_call_finalizer_i(st_data_t key, st_data_t val, st_data_t _data)
-{
-    VALUE obj = (VALUE)key;
-    VALUE table = (VALUE)val;
-
-    GC_ASSERT(RB_FL_TEST(obj, FL_FINALIZE));
-    GC_ASSERT(RB_BUILTIN_TYPE(val) == T_ARRAY);
-
-    rb_gc_run_obj_finalizer(RARRAY_AREF(table, 0), RARRAY_LEN(table) - 1, get_final, (void *)table);
-
-    FL_UNSET(obj, FL_FINALIZE);
-
-    return ST_DELETE;
-}
-
 void
 rb_gc_impl_shutdown_call_finalizer(void *objspace_ptr)
 {
@@ -3099,21 +2851,6 @@ rb_gc_impl_shutdown_call_finalizer(void *objspace_ptr)
 
     /* prohibit incremental GC */
     objspace->flags.dont_incremental = 1;
-
-    if (RUBY_ATOMIC_EXCHANGE(finalizing, 1)) {
-        /* Abort incremental marking and lazy sweeping to speed up shutdown. */
-        gc_abort(objspace);
-        dont_gc_on();
-        return;
-    }
-
-    while (finalizer_table->num_entries) {
-        st_foreach(finalizer_table, rb_gc_impl_shutdown_call_finalizer_i, 0);
-    }
-
-    /* run finalizers */
-    finalize_deferred(objspace);
-    GC_ASSERT(heap_pages_deferred_final == 0);
 
     /* Abort incremental marking and lazy sweeping to speed up shutdown. */
     gc_abort(objspace);
@@ -3146,12 +2883,6 @@ rb_gc_impl_shutdown_call_finalizer(void *objspace_ptr)
     }
 
     gc_exit(objspace, gc_enter_event_finalizer, &lock_lev);
-
-    finalize_deferred_heap_pages(objspace);
-
-    st_free_table(finalizer_table);
-    finalizer_table = 0;
-    RUBY_ATOMIC_SET(finalizing, 0);
 }
 
 void
@@ -3195,13 +2926,13 @@ objspace_available_slots(rb_objspace_t *objspace)
 static size_t
 objspace_live_slots(rb_objspace_t *objspace)
 {
-    return total_allocated_objects(objspace) - total_freed_objects(objspace) - total_final_slots_count(objspace);
+    return total_allocated_objects(objspace) - total_freed_objects(objspace);
 }
 
 static size_t
 objspace_free_slots(rb_objspace_t *objspace)
 {
-    return objspace_available_slots(objspace) - objspace_live_slots(objspace) - total_final_slots_count(objspace);
+    return objspace_available_slots(objspace) - objspace_live_slots(objspace);
 }
 
 static void
@@ -3523,7 +3254,6 @@ gc_compact_finish(rb_objspace_t *objspace)
 
 struct gc_sweep_context {
     struct heap_page *page;
-    int final_slots;
     int freed_slots;
     int empty_slots;
 };
@@ -3553,9 +3283,6 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
                 gc_report(3, objspace, "page_sweep: %s is added to freelist\n", rb_obj_info(vp));
                 ctx->empty_slots++;
                 heap_page_add_freeobj(objspace, sweep_page, vp);
-                break;
-              case T_ZOMBIE:
-                /* already counted */
                 break;
               case T_NONE:
                 ctx->empty_slots++; /* already freed */
@@ -3594,15 +3321,11 @@ gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bit
                     rb_gc_event_hook(vp, RUBY_INTERNAL_EVENT_FREEOBJ);
 
                     rb_gc_obj_free_vm_weak_references(vp);
-                    if (rb_gc_obj_free(objspace, vp)) {
-                        (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)p, slot_size);
-                        heap_page_add_freeobj(objspace, sweep_page, vp);
-                        gc_report(3, objspace, "page_sweep: %s is added to freelist\n", rb_obj_info(vp));
-                        ctx->freed_slots++;
-                    }
-                    else {
-                        ctx->final_slots++;
-                    }
+                    rb_gc_obj_free(objspace, vp);
+                    (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)p, slot_size);
+                    heap_page_add_freeobj(objspace, sweep_page, vp);
+                    gc_report(3, objspace, "page_sweep: %s is added to freelist\n", rb_obj_info(vp));
+                    ctx->freed_slots++;
                 }
                 break;
             }
@@ -3669,21 +3392,17 @@ gc_sweep_page(rb_objspace_t *objspace, rb_heap_t *heap, struct gc_sweep_context 
 #if GC_PROFILE_MORE_DETAIL
     if (gc_prof_enabled(objspace)) {
         gc_profile_record *record = gc_prof_record(objspace);
-        record->removing_objects += ctx->final_slots + ctx->freed_slots;
+        record->removing_objects += ctx->freed_slots;
         record->empty_objects += ctx->empty_slots;
     }
 #endif
-    if (0) fprintf(stderr, "gc_sweep_page(%"PRIdSIZE"): total_slots: %d, freed_slots: %d, empty_slots: %d, final_slots: %d\n",
+    if (0) fprintf(stderr, "gc_sweep_page(%"PRIdSIZE"): total_slots: %d, freed_slots: %d, empty_slots: %d\n",
                    rb_gc_count(),
                    sweep_page->total_slots,
-                   ctx->freed_slots, ctx->empty_slots, ctx->final_slots);
+                   ctx->freed_slots, ctx->empty_slots);
 
     sweep_page->free_slots += ctx->freed_slots + ctx->empty_slots;
     sweep_page->heap->total_freed_objects += ctx->freed_slots;
-
-    if (heap_pages_deferred_final && !finalizing) {
-        gc_finalize_deferred_register(objspace);
-    }
 
 #if RGENGC_CHECK_MODE
     short freelist_len = 0;
@@ -3940,7 +3659,7 @@ gc_sweep_step(rb_objspace_t *objspace, rb_heap_t *heap)
 
         struct gc_sweep_context ctx = {
             .page = sweep_page,
-            .final_slots = 0,
+
             .freed_slots = 0,
             .empty_slots = 0,
         };
@@ -4597,13 +4316,6 @@ rb_gc_impl_mark_maybe(void *objspace_ptr, VALUE obj)
     }
 }
 
-static int
-pin_value(st_data_t key, st_data_t value, st_data_t data)
-{
-    rb_gc_impl_mark_and_pin((void *)data, (VALUE)value);
-
-    return ST_CONTINUE;
-}
 
 static inline void
 gc_mark_set_parent_raw(rb_objspace_t *objspace, VALUE obj, bool old_p)
@@ -4636,10 +4348,6 @@ mark_roots(rb_objspace_t *objspace, const char **categoryp)
 
     MARK_CHECKPOINT("objspace");
     gc_mark_set_parent_raw(objspace, Qundef, false);
-
-    if (finalizer_table != NULL) {
-        st_foreach(finalizer_table, pin_value, (st_data_t)objspace);
-    }
 
     if (stress_to_class) rb_gc_mark(stress_to_class);
 
@@ -5070,15 +4778,8 @@ verify_internal_consistency_i(void *page_start, void *page_end, size_t stride,
                 if (BUILTIN_TYPE(obj) == T_ZOMBIE) {
                     data->zombie_object_count++;
 
-                    if ((RBASIC(obj)->flags & ~ZOMBIE_OBJ_KEPT_FLAGS) != T_ZOMBIE) {
+                    if (RBASIC(obj)->flags != T_ZOMBIE) {
                         fprintf(stderr, "verify_internal_consistency_i: T_ZOMBIE has extra flags set: %s\n",
-                                rb_obj_info(obj));
-                        data->err_count++;
-                    }
-
-                    if (!!FL_TEST(obj, FL_FINALIZE) != !!st_is_member(finalizer_table, obj)) {
-                        fprintf(stderr, "verify_internal_consistency_i: FL_FINALIZE %s but %s finalizer_table: %s\n",
-                                FL_TEST(obj, FL_FINALIZE) ? "set" : "not set", st_is_member(finalizer_table, obj) ? "in" : "not in",
                                 rb_obj_info(obj));
                         data->err_count++;
                     }
@@ -5097,7 +4798,6 @@ gc_verify_heap_page(rb_objspace_t *objspace, struct heap_page *page, VALUE obj)
     unsigned int has_remembered_old = FALSE;
     int remembered_old_objects = 0;
     int free_objects = 0;
-    int zombie_objects = 0;
 
     short slot_size = page->slot_size;
     uintptr_t start = (uintptr_t)page->start;
@@ -5109,7 +4809,6 @@ gc_verify_heap_page(rb_objspace_t *objspace, struct heap_page *page, VALUE obj)
             enum ruby_value_type type = BUILTIN_TYPE(val);
 
             if (type == T_NONE) free_objects++;
-            if (type == T_ZOMBIE) zombie_objects++;
             if (RVALUE_PAGE_UNCOLLECTIBLE(page, val) && RVALUE_PAGE_WB_UNPROTECTED(page, val)) {
                 has_remembered_shady = TRUE;
             }
@@ -5143,9 +4842,6 @@ gc_verify_heap_page(rb_objspace_t *objspace, struct heap_page *page, VALUE obj)
         if (page->free_slots != free_objects) {
             rb_bug("page %p's free_slots should be %d, but %d", (void *)page, page->free_slots, free_objects);
         }
-    }
-    if (page->final_slots != zombie_objects) {
-        rb_bug("page %p's final_slots should be %d, but %d", (void *)page, page->final_slots, zombie_objects);
     }
 
     return remembered_old_objects;
@@ -5226,11 +4922,10 @@ gc_verify_internal_consistency_(rb_objspace_t *objspace)
     ractor_cache_flush_count(objspace, rb_gc_get_ractor_newobj_cache());
 
     if (!is_lazy_sweeping(objspace) &&
-            !finalizing &&
             !rb_gc_multi_ractor_p()) {
         if (objspace_live_slots(objspace) != data.live_object_count) {
-            fprintf(stderr, "heap_pages_final_slots: %"PRIdSIZE", total_freed_objects: %"PRIdSIZE"\n",
-                    total_final_slots_count(objspace), total_freed_objects(objspace));
+            fprintf(stderr, "total_freed_objects: %"PRIdSIZE"\n",
+                    total_freed_objects(objspace));
             rb_bug("inconsistent live slot number: expect %"PRIuSIZE", but %"PRIuSIZE".",
                    objspace_live_slots(objspace), data.live_object_count);
         }
@@ -5244,30 +4939,6 @@ gc_verify_internal_consistency_(rb_objspace_t *objspace)
         if (objspace->rgengc.uncollectible_wb_unprotected_objects != data.remembered_shady_count) {
             rb_bug("inconsistent number of wb unprotected objects: expect %"PRIuSIZE", but %"PRIuSIZE".",
                    objspace->rgengc.uncollectible_wb_unprotected_objects, data.remembered_shady_count);
-        }
-    }
-
-    if (!finalizing) {
-        size_t list_count = 0;
-
-        {
-            VALUE z = heap_pages_deferred_final;
-            while (z) {
-                list_count++;
-                z = RZOMBIE(z)->next;
-            }
-        }
-
-        if (total_final_slots_count(objspace) != data.zombie_object_count ||
-            total_final_slots_count(objspace) != list_count) {
-
-            rb_bug("inconsistent finalizing object count:\n"
-                    "  expect %"PRIuSIZE"\n"
-                    "  but    %"PRIuSIZE" zombies\n"
-                    "  heap_pages_deferred_final list has %"PRIuSIZE" items.",
-                    total_final_slots_count(objspace),
-                    data.zombie_object_count,
-                    list_count);
         }
     }
 
@@ -5578,7 +5249,7 @@ gc_compact_move(rb_objspace_t *objspace, rb_heap_t *heap, VALUE src)
     while (!try_move(objspace, dest_pool, dest_pool->free_pages, src)) {
         struct gc_sweep_context ctx = {
             .page = dest_pool->sweeping_page,
-            .final_slots = 0,
+
             .freed_slots = 0,
             .empty_slots = 0,
         };
@@ -6186,7 +5857,6 @@ rb_gc_impl_copy_attributes(void *objspace_ptr, VALUE dest, VALUE obj)
     if (RVALUE_WB_UNPROTECTED(objspace, obj)) {
         rb_gc_impl_writebarrier_unprotect(objspace, dest);
     }
-    rb_gc_impl_copy_finalizer(objspace, dest, obj);
 }
 
 const char *
@@ -6858,7 +6528,6 @@ rb_gc_impl_start(void *objspace_ptr, bool full_mark, bool immediate_mark, bool i
     }
 
     garbage_collect(objspace, reason);
-    gc_finalize_deferred(objspace);
 
     gc_config_full_mark_set(full_marking_p);
 }
@@ -6925,16 +6594,6 @@ gc_is_moveable_obj(rb_objspace_t *objspace, VALUE obj)
       case T_RATIONAL:
       case T_NODE:
       case T_CLASS:
-        if (FL_TEST_RAW(obj, FL_FINALIZE)) {
-            /* The finalizer table is a numtable. It looks up objects by address.
-             * We can't mark the keys in the finalizer table because that would
-             * prevent the objects from being collected.  This check prevents
-             * objects that are keys in the finalizer table from being moved
-             * without directly pinning them. */
-            GC_ASSERT(st_is_member(finalizer_table, obj));
-
-            return FALSE;
-        }
         GC_ASSERT(RVALUE_MARKED(objspace, obj));
         GC_ASSERT(!RVALUE_PINNED(objspace, obj));
 
@@ -7197,8 +6856,6 @@ gc_update_references(rb_objspace_t *objspace)
             }
         }
     }
-
-    gc_update_table_refs(finalizer_table);
 
     rb_gc_update_vm_references((void *)objspace);
 
@@ -7597,7 +7254,7 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(heap_available_slots, objspace_available_slots(objspace));
     SET(heap_live_slots, objspace_live_slots(objspace));
     SET(heap_free_slots, objspace_free_slots(objspace));
-    SET(heap_final_slots, total_final_slots_count(objspace));
+    SET(heap_final_slots, 0);
     SET(heap_marked_slots, objspace->marked_slots);
     SET(heap_eden_pages, heap_eden_total_pages(objspace));
     SET(total_allocated_pages, objspace->heap_pages.allocated_pages);
@@ -7698,9 +7355,9 @@ stat_one_heap(rb_objspace_t *objspace, rb_heap_t *heap, VALUE hash, VALUE key)
         rb_hash_aset(hash, gc_stat_heap_symbols[gc_stat_heap_sym_##name], SIZET2NUM(attr));
 
     SET(slot_size, heap->slot_size);
-    SET(heap_live_slots, heap->total_allocated_objects - heap->total_freed_objects - heap->final_slots_count);
+    SET(heap_live_slots, heap->total_allocated_objects - heap->total_freed_objects);
     SET(heap_free_slots, heap->total_slots - (heap->total_allocated_objects - heap->total_freed_objects));
-    SET(heap_final_slots, heap->final_slots_count);
+    SET(heap_final_slots, 0);
     SET(heap_eden_pages, heap->total_pages);
     SET(heap_eden_slots, heap->total_slots);
     SET(heap_allocatable_slots, objspace->heap_pages.allocatable_bytes / heap->slot_size);
@@ -8651,9 +8308,7 @@ gc_prof_sweep_timer_stop(rb_objspace_t *objspace)
 
 #if GC_PROFILE_MORE_DETAIL
         record->gc_sweep_time += sweep_time;
-        if (heap_pages_deferred_final) record->flags |= GPR_FLAG_HAVE_FINALIZE;
 #endif
-        if (heap_pages_deferred_final) objspace->profile.latest_gc_info |= GPR_FLAG_HAVE_FINALIZE;
     }
 }
 
@@ -8681,7 +8336,7 @@ gc_prof_set_heap_info(rb_objspace_t *objspace)
         size_t total_size = 0;
         for (int i = 0; i < HEAP_COUNT; i++) {
             rb_heap_t *heap = &heaps[i];
-            size_t heap_live = heap->total_allocated_objects - heap->total_freed_objects - heap->final_slots_count;
+            size_t heap_live = heap->total_allocated_objects - heap->total_freed_objects;
             total += heap->total_slots;
             use_size += heap_live * heap->slot_size;
             total_size += heap->total_slots * heap->slot_size;
@@ -9533,10 +9188,6 @@ rb_gc_impl_objspace_init(void *objspace_ptr)
 
     objspace->flags.measure_gc = true;
     malloc_limit = gc_params.malloc_limit_min;
-    objspace->finalize_deferred_pjob = rb_postponed_job_preregister(0, gc_finalize_deferred, objspace);
-    if (objspace->finalize_deferred_pjob == POSTPONED_JOB_HANDLE_INVALID) {
-        rb_bug("Could not preregister postponed job for GC");
-    }
 
     /* A standard RVALUE (RBasic + embedded VALUEs + debug overhead) must fit
      * in at least one pool.  In debug builds RVALUE_OVERHEAD can push this
@@ -9568,7 +9219,6 @@ rb_gc_impl_objspace_init(void *objspace_ptr)
     init_mark_stack(&objspace->mark_stack);
 
     objspace->profile.invoke_time = getrusage_time();
-    finalizer_table = st_init_numtable();
 }
 
 void

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -7123,7 +7123,6 @@ enum gc_stat_sym {
     gc_stat_sym_heap_available_slots,
     gc_stat_sym_heap_live_slots,
     gc_stat_sym_heap_free_slots,
-    gc_stat_sym_heap_final_slots,
     gc_stat_sym_heap_marked_slots,
     gc_stat_sym_heap_eden_pages,
     gc_stat_sym_total_allocated_pages,
@@ -7173,7 +7172,6 @@ setup_gc_stat_symbols(void)
         S(heap_available_slots);
         S(heap_live_slots);
         S(heap_free_slots);
-        S(heap_final_slots);
         S(heap_marked_slots);
         S(heap_eden_pages);
         S(total_allocated_pages);
@@ -7254,7 +7252,6 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(heap_available_slots, objspace_available_slots(objspace));
     SET(heap_live_slots, objspace_live_slots(objspace));
     SET(heap_free_slots, objspace_free_slots(objspace));
-    SET(heap_final_slots, 0);
     SET(heap_marked_slots, objspace->marked_slots);
     SET(heap_eden_pages, heap_eden_total_pages(objspace));
     SET(total_allocated_pages, objspace->heap_pages.allocated_pages);
@@ -7310,7 +7307,6 @@ enum gc_stat_heap_sym {
     gc_stat_heap_sym_slot_size,
     gc_stat_heap_sym_heap_live_slots,
     gc_stat_heap_sym_heap_free_slots,
-    gc_stat_heap_sym_heap_final_slots,
     gc_stat_heap_sym_heap_eden_pages,
     gc_stat_heap_sym_heap_eden_slots,
     gc_stat_heap_sym_total_allocated_pages,
@@ -7332,7 +7328,6 @@ setup_gc_stat_heap_symbols(void)
         S(slot_size);
         S(heap_live_slots);
         S(heap_free_slots);
-        S(heap_final_slots);
         S(heap_eden_pages);
         S(heap_eden_slots);
         S(heap_allocatable_slots);
@@ -7357,7 +7352,6 @@ stat_one_heap(rb_objspace_t *objspace, rb_heap_t *heap, VALUE hash, VALUE key)
     SET(slot_size, heap->slot_size);
     SET(heap_live_slots, heap->total_allocated_objects - heap->total_freed_objects);
     SET(heap_free_slots, heap->total_slots - (heap->total_allocated_objects - heap->total_freed_objects));
-    SET(heap_final_slots, 0);
     SET(heap_eden_pages, heap->total_pages);
     SET(heap_eden_slots, heap->total_slots);
     SET(heap_allocatable_slots, objspace->heap_pages.allocatable_bytes / heap->slot_size);

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -98,10 +98,6 @@ GC_IMPL_FN void rb_gc_impl_writebarrier_remember(void *objspace_ptr, VALUE obj);
 GC_IMPL_FN void rb_gc_impl_each_objects(void *objspace_ptr, int (*callback)(void *, void *, size_t, void *), void *data);
 GC_IMPL_FN void rb_gc_impl_each_object(void *objspace_ptr, void (*func)(VALUE obj, void *data), void *data);
 // Finalizers
-GC_IMPL_FN void rb_gc_impl_make_zombie(void *objspace_ptr, VALUE obj, void (*dfree)(void *), void *data);
-GC_IMPL_FN VALUE rb_gc_impl_define_finalizer(void *objspace_ptr, VALUE obj, VALUE block);
-GC_IMPL_FN void rb_gc_impl_undefine_finalizer(void *objspace_ptr, VALUE obj);
-GC_IMPL_FN void rb_gc_impl_copy_finalizer(void *objspace_ptr, VALUE dest, VALUE obj);
 GC_IMPL_FN void rb_gc_impl_shutdown_call_finalizer(void *objspace_ptr);
 // Forking
 GC_IMPL_FN void rb_gc_impl_before_fork(void *objspace_ptr);

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -25,9 +25,6 @@ struct objspace {
     size_t total_gc_time;
     size_t total_allocated_objects;
 
-    st_table *finalizer_table;
-    struct MMTk_final_job *finalizer_jobs;
-    rb_postponed_job_handle_t finalizer_postponed_job;
 
     struct ccan_list_head ractor_caches;
     unsigned long live_ractor_cache_count;
@@ -65,23 +62,6 @@ struct MMTk_ractor_cache {
     size_t obj_free_non_parallel_count;
 };
 
-struct MMTk_final_job {
-    struct MMTk_final_job *next;
-    enum {
-        MMTK_FINAL_JOB_DFREE,
-        MMTK_FINAL_JOB_FINALIZE,
-    } kind;
-    union {
-        struct {
-            void (*func)(void *);
-            void *data;
-        } dfree;
-        struct {
-            /* HACK: we store the object ID on the 0th element of this array. */
-            VALUE finalizer_array;
-        } finalize;
-    } as;
-};
 
 #ifdef RB_THREAD_LOCAL_SPECIFIER
 RB_THREAD_LOCAL_SPECIFIER struct MMTk_GCThreadTLS *rb_mmtk_gc_thread_tls;
@@ -256,37 +236,10 @@ rb_mmtk_scan_gc_roots(void)
     rb_gc_mark_roots(objspace, NULL);
 }
 
-static int
-pin_value(st_data_t key, st_data_t value, st_data_t data)
-{
-    rb_gc_impl_mark_and_pin((void *)data, (VALUE)value);
-
-    return ST_CONTINUE;
-}
-
 static void
 rb_mmtk_scan_objspace(void)
 {
-    struct objspace *objspace = rb_gc_get_objspace();
-
-    if (objspace->finalizer_table != NULL) {
-        st_foreach(objspace->finalizer_table, pin_value, (st_data_t)objspace);
-    }
-
-    struct MMTk_final_job *job = objspace->finalizer_jobs;
-    while (job != NULL) {
-        switch (job->kind) {
-          case MMTK_FINAL_JOB_DFREE:
-            break;
-          case MMTK_FINAL_JOB_FINALIZE:
-            rb_gc_impl_mark(objspace, job->as.finalize.finalizer_array);
-            break;
-          default:
-            rb_bug("rb_mmtk_scan_objspace: unknown final job type %d", job->kind);
-        }
-
-        job = job->next;
-    }
+    /* nothing to mark */
 }
 
 static void
@@ -356,72 +309,17 @@ rb_mmtk_vm_live_bytes(void)
     return 0;
 }
 
-static void
-make_final_job(struct objspace *objspace, VALUE obj, VALUE table)
-{
-    MMTK_ASSERT(RB_BUILTIN_TYPE(table) == T_ARRAY);
-
-    struct MMTk_final_job *job = xmalloc(sizeof(struct MMTk_final_job));
-    job->next = objspace->finalizer_jobs;
-    job->kind = MMTK_FINAL_JOB_FINALIZE;
-    job->as.finalize.finalizer_array = table;
-
-    objspace->finalizer_jobs = job;
-}
-
-static int
-rb_mmtk_update_finalizer_table_i(st_data_t key, st_data_t value, st_data_t data, int error)
-{
-    MMTK_ASSERT(mmtk_is_reachable((MMTk_ObjectReference)value));
-    MMTK_ASSERT(RB_BUILTIN_TYPE(value) == T_ARRAY);
-
-    struct objspace *objspace = (struct objspace *)data;
-
-    if (mmtk_is_reachable((MMTk_ObjectReference)key)) {
-        VALUE new_key_location = rb_mmtk_call_object_closure((VALUE)key, false);
-
-        MMTK_ASSERT(RB_FL_TEST(new_key_location, RUBY_FL_FINALIZE));
-
-        if (new_key_location != key) {
-            return ST_REPLACE;
-        }
-    }
-    else {
-        make_final_job(objspace, (VALUE)key, (VALUE)value);
-
-        rb_postponed_job_trigger(objspace->finalizer_postponed_job);
-
-        return ST_DELETE;
-    }
-
-    return ST_CONTINUE;
-}
-
-static int
-rb_mmtk_update_finalizer_table_replace_i(st_data_t *key, st_data_t *value, st_data_t data, int existing)
-{
-    *key = rb_mmtk_call_object_closure((VALUE)*key, false);
-
-    return ST_CONTINUE;
-}
-
-static void
-rb_mmtk_update_finalizer_table(void)
-{
-    struct objspace *objspace = rb_gc_get_objspace();
-
-    st_foreach_with_replace(
-        objspace->finalizer_table,
-        rb_mmtk_update_finalizer_table_i,
-        rb_mmtk_update_finalizer_table_replace_i,
-        (st_data_t)objspace
-    );
-}
 
 static int
 rb_mmtk_global_tables_count(void)
 {
     return RB_GC_VM_WEAK_TABLE_COUNT;
+}
+
+static void
+rb_mmtk_update_finalizer_table_noop(void)
+{
+    /* No-op: Ruby-level finalizers are now managed in gc.c via weak references */
 }
 
 static inline VALUE rb_mmtk_call_object_closure(VALUE obj, bool pin);
@@ -530,7 +428,7 @@ MMTk_RubyUpcalls ruby_upcalls = {
     rb_mmtk_vm_live_bytes,
     rb_mmtk_update_global_tables,
     rb_mmtk_global_tables_count,
-    rb_mmtk_update_finalizer_table,
+    rb_mmtk_update_finalizer_table_noop,
     rb_mmtk_special_const_p,
     rb_mmtk_mutator_thread_panic_handler,
     rb_mmtk_gc_thread_panic_handler,
@@ -562,17 +460,12 @@ rb_gc_impl_objspace_alloc(void)
     return calloc(1, sizeof(struct objspace));
 }
 
-static void gc_run_finalizers(void *data);
-
 void
 rb_gc_impl_objspace_init(void *objspace_ptr)
 {
     struct objspace *objspace = objspace_ptr;
 
     objspace->measure_gc_time = true;
-
-    objspace->finalizer_table = st_init_numtable();
-    objspace->finalizer_postponed_job = rb_postponed_job_preregister(0, gc_run_finalizers, objspace);
 
     ccan_list_head_init(&objspace->ractor_caches);
 
@@ -1174,171 +1067,11 @@ rb_gc_impl_each_object(void *objspace_ptr, void (*func)(VALUE, void *), void *da
 }
 
 // Finalizers
-static VALUE
-gc_run_finalizers_get_final(long i, void *data)
-{
-    VALUE table = (VALUE)data;
-
-    return RARRAY_AREF(table, i + 1);
-}
-
-static void
-gc_run_finalizers(void *data)
-{
-    struct objspace *objspace = data;
-
-    rb_gc_set_pending_interrupt();
-
-    while (objspace->finalizer_jobs != NULL) {
-        struct MMTk_final_job *job = objspace->finalizer_jobs;
-        objspace->finalizer_jobs = job->next;
-
-        switch (job->kind) {
-          case MMTK_FINAL_JOB_DFREE:
-            job->as.dfree.func(job->as.dfree.data);
-            break;
-          case MMTK_FINAL_JOB_FINALIZE: {
-            VALUE finalizer_array = job->as.finalize.finalizer_array;
-
-            rb_gc_run_obj_finalizer(
-                RARRAY_AREF(finalizer_array, 0),
-                RARRAY_LEN(finalizer_array) - 1,
-                gc_run_finalizers_get_final,
-                (void *)finalizer_array
-            );
-
-            RB_GC_GUARD(finalizer_array);
-            break;
-          }
-        }
-
-        xfree(job);
-    }
-
-    rb_gc_unset_pending_interrupt();
-}
-
-void
-rb_gc_impl_make_zombie(void *objspace_ptr, VALUE obj, void (*dfree)(void *), void *data)
-{
-    if (dfree == NULL) return;
-
-    struct objspace *objspace = objspace_ptr;
-
-    struct MMTk_final_job *job = xmalloc(sizeof(struct MMTk_final_job));
-    job->kind = MMTK_FINAL_JOB_DFREE;
-    job->as.dfree.func = dfree;
-    job->as.dfree.data = data;
-
-    struct MMTk_final_job *prev;
-    do {
-        job->next = objspace->finalizer_jobs;
-        prev = RUBY_ATOMIC_PTR_CAS(objspace->finalizer_jobs, job->next, job);
-    } while (prev != job->next);
-
-    if (!ruby_free_at_exit_p()) {
-        rb_postponed_job_trigger(objspace->finalizer_postponed_job);
-    }
-}
-
-VALUE
-rb_gc_impl_define_finalizer(void *objspace_ptr, VALUE obj, VALUE block)
-{
-    struct objspace *objspace = objspace_ptr;
-    VALUE table;
-    st_data_t data;
-
-    RBASIC(obj)->flags |= FL_FINALIZE;
-
-    int lev = RB_GC_VM_LOCK();
-
-    if (st_lookup(objspace->finalizer_table, obj, &data)) {
-        table = (VALUE)data;
-
-        /* avoid duplicate block, table is usually small */
-        {
-            long len = RARRAY_LEN(table);
-            long i;
-
-            for (i = 0; i < len; i++) {
-                VALUE recv = RARRAY_AREF(table, i);
-                if (rb_equal(recv, block)) {
-                    RB_GC_VM_UNLOCK(lev);
-                    return recv;
-                }
-            }
-        }
-
-        rb_ary_push(table, block);
-    }
-    else {
-        table = rb_ary_new3(2, rb_obj_id(obj), block);
-        rb_obj_hide(table);
-        st_add_direct(objspace->finalizer_table, obj, table);
-    }
-
-    RB_GC_VM_UNLOCK(lev);
-
-    return block;
-}
-
-void
-rb_gc_impl_undefine_finalizer(void *objspace_ptr, VALUE obj)
-{
-    struct objspace *objspace = objspace_ptr;
-
-    st_data_t data = obj;
-
-    int lev = RB_GC_VM_LOCK();
-    st_delete(objspace->finalizer_table, &data, 0);
-    RB_GC_VM_UNLOCK(lev);
-
-    FL_UNSET(obj, FL_FINALIZE);
-}
-
-void
-rb_gc_impl_copy_finalizer(void *objspace_ptr, VALUE dest, VALUE obj)
-{
-    struct objspace *objspace = objspace_ptr;
-    VALUE table;
-    st_data_t data;
-
-    if (!FL_TEST(obj, FL_FINALIZE)) return;
-
-    int lev = RB_GC_VM_LOCK();
-    if (RB_LIKELY(st_lookup(objspace->finalizer_table, obj, &data))) {
-        table = rb_ary_dup((VALUE)data);
-        RARRAY_ASET(table, 0, rb_obj_id(dest));
-        st_insert(objspace->finalizer_table, dest, table);
-        FL_SET(dest, FL_FINALIZE);
-    }
-    else {
-        rb_bug("rb_gc_copy_finalizer: FL_FINALIZE set but not found in finalizer_table: %s", rb_obj_info(obj));
-    }
-    RB_GC_VM_UNLOCK(lev);
-}
-
-static int
-move_finalizer_from_table_i(st_data_t key, st_data_t val, st_data_t arg)
-{
-    struct objspace *objspace = (struct objspace *)arg;
-
-    make_final_job(objspace, (VALUE)key, (VALUE)val);
-
-    return ST_DELETE;
-}
 
 void
 rb_gc_impl_shutdown_call_finalizer(void *objspace_ptr)
 {
     struct objspace *objspace = objspace_ptr;
-
-    while (objspace->finalizer_table->num_entries) {
-        st_foreach(objspace->finalizer_table, move_finalizer_from_table_i, (st_data_t)objspace);
-
-        gc_run_finalizers(objspace);
-    }
-
     unsigned int lev = RB_GC_VM_LOCK();
     {
         struct MMTk_ractor_cache *rc;
@@ -1358,8 +1091,6 @@ rb_gc_impl_shutdown_call_finalizer(void *objspace_ptr)
         mmtk_free_raw_vec_of_obj_ref(registered_candidates);
     }
     RB_GC_VM_UNLOCK(lev);
-
-    gc_run_finalizers(objspace);
 }
 
 // Forking
@@ -1626,8 +1357,6 @@ rb_gc_impl_copy_attributes(void *objspace_ptr, VALUE dest, VALUE obj)
     if (mmtk_object_wb_unprotected_p((MMTk_ObjectReference)obj)) {
         rb_gc_impl_writebarrier_unprotect(objspace_ptr, dest);
     }
-
-    rb_gc_impl_copy_finalizer(objspace_ptr, dest, obj);
 }
 
 // GC Identification

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -212,6 +212,7 @@ void rb_gc_mark_and_move(VALUE *ptr);
 
 void rb_gc_declare_weak_references(VALUE obj);
 bool rb_gc_handle_weak_references_alive_p(VALUE obj);
+void rb_gc_register_deferred_free(VALUE obj);
 
 void rb_gc_ref_update_table_values_only(st_table *tbl);
 

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -203,6 +203,7 @@ rb_execution_context_t *rb_gc_get_ec(void);
 
 void *rb_gc_ractor_cache_alloc(rb_ractor_t *ractor);
 void rb_gc_ractor_cache_free(void *cache);
+void rb_gc_ractor_inherit_finalizer_queue(rb_ractor_t *successor, rb_ractor_t *predecessor);
 
 bool rb_gc_size_allocatable_p(size_t size);
 size_t *rb_gc_heap_sizes(void);

--- a/io.c
+++ b/io.c
@@ -1115,6 +1115,8 @@ io_alloc(VALUE klass)
 
     io->fptr = 0;
 
+    rb_gc_register_deferred_free((VALUE)io);
+
     return (VALUE)io;
 }
 

--- a/ractor.c
+++ b/ractor.c
@@ -552,6 +552,7 @@ ractor_init(rb_ractor_t *r, VALUE name, VALUE loc)
     if (!SPECIAL_CONST_P(loc)) RB_OBJ_SET_SHAREABLE(loc);
     r->loc = loc;
     r->name = name;
+    r->finalizer_queue = 0;
 }
 
 void

--- a/ractor_core.h
+++ b/ractor_core.h
@@ -106,6 +106,8 @@ struct rb_ractor_struct {
     bool malloc_gc_disabled;
     bool main_ractor;
     void *newobj_cache;
+
+    VALUE finalizer_queue;  /* per-ractor linked list of ready-to-fire finalizers, 0 = empty */
 }; // rb_ractor_t is defined in vm_core.h
 
 enum ractor_wakeup_status {

--- a/ractor_sync.c
+++ b/ractor_sync.c
@@ -728,7 +728,11 @@ ractor_set_successor_once(rb_ractor_t *r, rb_ractor_t *cr)
 {
     if (r->sync.successor == NULL) {
         rb_ractor_t *successor = ATOMIC_PTR_CAS(r->sync.successor, NULL, cr);
-        return successor == NULL ? cr : successor;
+        if (successor == NULL) {
+            rb_gc_ractor_inherit_finalizer_queue(cr, r);
+            return cr;
+        }
+        return successor;
     }
 
     return r->sync.successor;

--- a/test/-ext-/tracepoint/test_tracepoint.rb
+++ b/test/-ext-/tracepoint/test_tracepoint.rb
@@ -47,7 +47,7 @@ class TestTracepointObj < Test::Unit::TestCase
     assert_operator stat2[:total_allocated_objects] - stat1[:total_allocated_objects], :>=, newobj_count
     assert_operator 1_000_000, :<=, newobj_count
 
-    assert_operator stat2[:total_freed_objects] + stat2[:heap_final_slots] - stat1[:total_freed_objects], :>=, free_count
+    assert_operator stat2[:total_freed_objects] - stat1[:total_freed_objects], :>=, free_count
     assert_operator stat2[:count] - stat1[:count], :==, gc_start_count
 
     assert_operator gc_start_count, :==, gc_end_mark_count

--- a/test/objspace/test_ractor.rb
+++ b/test/objspace/test_ractor.rb
@@ -53,6 +53,195 @@ class TestObjSpaceRactor < Test::Unit::TestCase
     RUBY
   end
 
+  def test_finalizer_fires_on_registering_ractor
+    assert_ractor(<<~'RUBY', timeout: 20, require: 'objspace')
+      ready = Ractor::Port.new
+
+      r = Ractor.new(ready) do |ready|
+        me = Ractor.current
+        result = Ractor::Port.new
+        callback = ->(_id) { result.send(Ractor.current == me) }
+        obj = Object.new
+        ObjectSpace.define_finalizer(obj, callback)
+        obj = nil
+
+        # Signal main that the object is ready to collect
+        ready.send(true)
+
+        # Wait for the finalizer to fire on this ractor
+        result.receive
+      end
+
+      ready.receive
+      GC.start
+
+      assert_equal true, r.value
+    RUBY
+  end
+
+  FINALIZER_HELPER = <<~'RUBY'
+    module FinalizerHelper
+      def self.define(port)
+        unshareable_object = Object.new
+        ->(_id) {
+          unshareable_object.inspect
+          port.send(Ractor.current)
+        }
+      end
+    end
+  RUBY
+
+  def test_finalizer_fires_on_main_when_main_is_successor
+    assert_ractor(FINALIZER_HELPER + <<~'RUBY', require: 'objspace')
+      GC.disable
+      result = Ractor::Port.new
+
+      r = Ractor.new(result) do |result|
+        callback = FinalizerHelper.define(result)
+        obj = Object.new
+        ObjectSpace.define_finalizer(obj, callback)
+        obj = nil
+      end
+
+      r.value # main becomes r's successor; r's finalizer queue splices onto main
+      GC.start
+
+      assert_equal Ractor.current, result.receive
+    RUBY
+  end
+
+  def test_finalizer_fires_on_successor_ractor
+    assert_ractor(FINALIZER_HELPER + <<~'RUBY', require: 'objspace')
+      GC.disable
+      result = Ractor::Port.new
+
+      r1 = Ractor.new(result) do |result|
+        callback = FinalizerHelper.define(result)
+        obj = Object.new
+        ObjectSpace.define_finalizer(obj, callback)
+        obj = nil
+      end
+      r1.join
+
+      r2 = Ractor.new(r1) do |r1|
+        r1.value # r2 becomes r1's successor; r1's queue splices onto r2
+        Ractor.receive # stay alive so the finalizer can fire here
+      end
+
+      GC.start
+
+      fired_on = result.receive
+      r2.send(:done)
+
+      assert_equal r2, fired_on
+    RUBY
+  end
+
+  def test_finalizer_fires_on_main_when_no_successor
+    assert_ractor(FINALIZER_HELPER + <<~'RUBY', require: 'objspace')
+      GC.disable
+      result = Ractor::Port.new
+
+      r = Ractor.new(result) do |result|
+        callback = FinalizerHelper.define(result)
+        obj = Object.new
+        ObjectSpace.define_finalizer(obj, callback)
+        obj = nil
+      end
+      r.join
+      r = nil
+
+      GC.start
+
+      assert_equal Ractor.current, result.receive
+    RUBY
+  end
+
+  def test_finalizer_queue_waits_for_successor
+    assert_ractor(FINALIZER_HELPER + <<~'RUBY', require: 'objspace')
+      GC.disable
+      result = Ractor::Port.new
+
+      r = Ractor.new(result) do |result|
+        callback = FinalizerHelper.define(result)
+        obj = Object.new
+        ObjectSpace.define_finalizer(obj, callback)
+        obj = nil
+      end
+      r.join
+
+      GC.start
+
+      r.value
+      assert_equal Ractor.current, result.receive
+    RUBY
+  end
+
+  def test_finalizer_redirects_to_alive_successor_when_orphan_ractor_gced
+    assert_ractor(FINALIZER_HELPER + <<~'RUBY', require: 'objspace')
+      GC.disable
+      result = Ractor::Port.new
+
+      r = Ractor.new(result) do |result|
+        callback = FinalizerHelper.define(result)
+        obj = Object.new
+        ObjectSpace.define_finalizer(obj, callback)
+        obj = nil
+      end
+      r.join
+
+      s = Ractor.new(r) do |r|
+        r.value
+        Ractor.receive
+      end
+
+      r = nil
+
+      GC.start
+
+      fired_on = result.receive
+      s.send(:done)
+
+      refute_equal Ractor.current, fired_on
+      assert_equal s, fired_on
+    RUBY
+  end
+
+  def test_finalizer_walks_dying_successor_chain
+    assert_ractor(FINALIZER_HELPER + <<~'RUBY', require: 'objspace')
+      GC.disable
+      result = Ractor::Port.new
+
+      r = Ractor.new(result) do |result|
+        callback = FinalizerHelper.define(result)
+        obj = Object.new
+        ObjectSpace.define_finalizer(obj, callback)
+        obj = nil
+      end
+      r.join
+
+      s = Ractor.new(r) do |r|
+        r.value
+      end
+      s.join
+
+      t = Ractor.new(s) do |s|
+        s.value
+        Ractor.receive
+      end
+
+      r = nil
+      s = nil
+
+      GC.start
+
+      fired_on = result.receive
+      t.send(:done)
+
+      assert_equal t, fired_on
+    RUBY
+  end
+
   def test_trace_object_allocations_with_ractor_tracepoint
     # Test that ObjectSpace.trace_object_allocations works globally across all Ractors
     assert_ractor(<<~'RUBY', require: 'objspace')

--- a/test/ruby/test_gc.rb
+++ b/test/ruby/test_gc.rb
@@ -206,8 +206,8 @@ class TestGc < Test::Unit::TestCase
     # marking_time + sweeping_time could differ from time by 1 because they're stored in nanoseconds
     assert_in_delta stat[:time], stat[:marking_time] + stat[:sweeping_time], 1
     assert_equal stat[:total_allocated_pages], stat[:heap_allocated_pages] + stat[:total_freed_pages]
-    assert_equal stat[:heap_available_slots], stat[:heap_live_slots] + stat[:heap_free_slots] + stat[:heap_final_slots]
-    assert_equal stat[:heap_live_slots], stat[:total_allocated_objects] - stat[:total_freed_objects] - stat[:heap_final_slots]
+    assert_equal stat[:heap_available_slots], stat[:heap_live_slots] + stat[:heap_free_slots]
+    assert_equal stat[:heap_live_slots], stat[:total_allocated_objects] - stat[:total_freed_objects]
     assert_equal stat[:heap_allocated_pages], stat[:heap_eden_pages] + stat[:heap_empty_pages]
 
     if use_rgengc?
@@ -233,7 +233,6 @@ class TestGc < Test::Unit::TestCase
       assert_equal GC.stat_heap(i, :slot_size), stat_heap[:slot_size]
       assert_operator stat_heap[:heap_live_slots], :<=, stat[:heap_live_slots]
       assert_operator stat_heap[:heap_free_slots], :<=, stat[:heap_free_slots]
-      assert_operator stat_heap[:heap_final_slots], :<=, stat[:heap_final_slots]
       assert_operator stat_heap[:heap_eden_pages], :<=, stat[:heap_eden_pages]
       assert_operator stat_heap[:heap_eden_slots], :>=, 0
       assert_operator stat_heap[:total_allocated_pages], :>=, 0
@@ -291,7 +290,6 @@ class TestGc < Test::Unit::TestCase
 
     assert_equal stat[:heap_live_slots], stat_heap_sum[:heap_live_slots]
     assert_equal stat[:heap_free_slots], stat_heap_sum[:heap_free_slots]
-    assert_equal stat[:heap_final_slots], stat_heap_sum[:heap_final_slots]
     assert_equal stat[:heap_eden_pages], stat_heap_sum[:heap_eden_pages]
     assert_equal stat[:heap_available_slots], stat_heap_sum[:heap_eden_slots]
     assert_equal stat[:total_allocated_objects], stat_heap_sum[:total_allocated_objects]

--- a/test/ruby/test_objectspace.rb
+++ b/test/ruby/test_objectspace.rb
@@ -202,6 +202,23 @@ End
     END
   end
 
+  def test_finalizer_not_called_twice
+    assert_separately([], <<~'RUBY')
+      results = []
+      1000.times do |i|
+        ObjectSpace.define_finalizer(Object.new) do
+          results << i
+          GC.start if i % 100 == 0
+        end
+      end
+
+      3.times { GC.start }
+
+      assert_include 990..1000, results.size
+      assert_equal results, results.uniq
+    RUBY
+  end
+
   def test_exception_in_finalizer
     assert_in_out_err([], "#{<<~"begin;"}\n#{<<~'end;'}", [], /finalizing \(RuntimeError\)/)
     begin;


### PR DESCRIPTION
Move finalizer logic out of the GC implementations and into the shared
gc.c layer using weak references. Each GC implementation (default, mmtk,
my wbcheck branch) previously had its own finalizer table, zombie object
mechanism, and deferred finalization queue. This is duplicated code
that's tricky to get right.

This commit changes Ruby-level finalizers (ObjectSpace.define_finalizer)
and C-extension objects with deferred frees (T_DATA without
FREE_IMMEDIATELY, and T_FILE objects) to be handled by a new finalizer
object which waits for the target object to due, and then enqueues
itself to a list to be run.

In the default GC this eliminates the need for T_ZOMBIE objects, and
allows those objects to be immediately collected. We don't need to check
for T_ZOMBIE objects when sweeping.

The trade-off is that objects requiring this deferred finalization have
an extra object associated. However these objects are relatively rare.