### PR TITLE
Check for VM_ENV_DATA_INDEX_FLAGS in mid-escape

### DIFF
--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -800,7 +800,12 @@ rb_vm_frame_method_entry_unchecked(const rb_control_frame_t *cfp)
     const VALUE *ep = cfp->ep;
     rb_callable_method_entry_t *me;
 
-    while (!VM_ENV_LOCAL_P_UNCHECKED(ep)) {
+    for (;;) {
+        if (UNLIKELY(!FIXNUM_P(ep[VM_ENV_DATA_INDEX_FLAGS]))) {
+            // vm_make_env_each mid-escape: flags slot holds the env object.
+            ep = ((const rb_env_t *)ep[VM_ENV_DATA_INDEX_FLAGS])->ep;
+        }
+        if (VM_ENV_LOCAL_P_UNCHECKED(ep)) break;
         if ((me = env_method_entry_unchecked(ep[VM_ENV_DATA_INDEX_ME_CREF], FALSE)) != NULL) return me;
         ep = VM_ENV_PREV_EP_UNCHECKED(ep);
     }


### PR DESCRIPTION
vm_make_env_each iterates over frames on the stack, escaping each one. This can leave the stack in an inconsistent state.

If a sampling profiler calls rb_profile_frames from a signal handler, it can observe the stack in this inconsistent state, so we need to check for it.

This was validated by calling `rb_profile_frames` at [nearly every point inside `vm_make_env_each`](https://github.com/jhawthorn/ruby/commit/f4f8a6f8b93fa805e7804cff8265d2b322a88141). This provides a reliable reproduction of the issue (± a signal arriving more unpredictably because of a compiler potentially rearranging writes).

I really wanted to fix this by removing the the interim state with the forwarding pointer in `ep[0]`, but I wasn't able to make it work. This approach should mitigate the issue for now.