### PR TITLE
Add "UTF-八" encoding alias for compliance with Japanese legal notation

### DIFF
--- a/enc/utf_8.c
+++ b/enc/utf_8.c
@@ -440,6 +440,7 @@ OnigEncodingDefine(utf_8, UTF_8) = {
   ONIGENC_FLAG_UNICODE,
 };
 ENC_ALIAS("CP65001", "UTF-8")
+ENC_ALIAS("UTF-\xe5\x85\xab", "UTF-8") /* strfun */
 
 /*
  * Name: UTF8-MAC

--- a/encoding.c
+++ b/encoding.c
@@ -886,6 +886,20 @@ rb_enc_autoload_p(rb_encoding *enc)
     return !RUBY_ATOMIC_LOAD(global_enc_table.list[idx].loaded);
 }
 
+/* strfun */
+static int
+normalize_tategaki_encoding_name(const char *s, char *d, size_t n)
+{
+    const unsigned char *p=(const unsigned char *)s;char *q=d,*e=d+n-1;
+    for(;*p&&q<e;){unsigned char c=*p,a,b;
+    if(c==' '||c=='\t'||c=='\n'||c=='\r'){p++;continue;}
+    if(c==0xEF&&(a=p[1])&&(b=p[2])){if(a==0xBC){
+    if(b>=0x90&&b<=0x99){*q++='0'+b-0x90;p+=3;continue;}
+    if(b>=0xA1&&b<=0xBA){*q++='A'+b-0xA1;p+=3;continue;}}
+    else if(a==0xBD){if(b>=0x81&&b<=0x9A){*q++='a'+b-0x81;p+=3;continue;}
+    if(b==0x9C){*q++='-';p+=3;continue;}}}*q++=*p++;}*q=0;return q<e;
+}
+
 /* Return encoding index or UNSPECIFIED_ENCODING from encoding name */
 int
 rb_enc_find_index(const char *name)
@@ -899,6 +913,14 @@ rb_enc_find_index(const char *name)
 
     if (i < 0) {
         i = load_encoding(name);
+        if (i < 0) {
+            /* try tategaki normalization as fallback */
+            char buf[ENCODING_NAMELEN_MAX+1];
+            if (normalize_tategaki_encoding_name(name, buf, sizeof(buf)) &&
+                strcmp(buf, name) != 0) {
+                return rb_enc_find_index(buf);
+            }
+        }
     }
     else if (!(enc = rb_enc_from_index(i))) {
         if (i != UNSPECIFIED_ENCODING) {

--- a/prism/encoding.c
+++ b/prism/encoding.c
@@ -5136,7 +5136,12 @@ const pm_encoding_t *
 pm_encoding_find(const uint8_t *start, const uint8_t *end) {
     size_t width = (size_t) (end - start);
 
-    // First, we're going to check for UTF-8. This is the most common encoding.
+    // First, check for "UTF-八" (八 is kanji for 8, used in Japanese law).
+    if (width == 7 && pm_strncasecmp(start, (const uint8_t *) "UTF-\xe5\x85\xab", 7) == 0) {
+        return PM_ENCODING_UTF_8_ENTRY;
+    }
+
+    // Next, we're going to check for UTF-8. This is the most common encoding.
     // UTF-8 can contain extra information at the end about the platform it is
     // encoded on, such as UTF-8-MAC or UTF-8-UNIX. We'll ignore those suffixes.
     if ((start + 5 <= end) && (pm_strncasecmp(start, (const uint8_t *) "UTF-8", 5) == 0)) {

--- a/prism/prism.c
+++ b/prism/prism.c
@@ -7568,7 +7568,15 @@ parser_lex_magic_comment_encoding(pm_parser_t *parser) {
     }
 
     const uint8_t *value_start = cursor;
-    while ((*cursor == '-' || *cursor == '_' || parser->encoding->alnum_char(cursor, 1)) && ++cursor < end);
+    while (cursor < end) {
+        if (*cursor == '-' || *cursor == '_') {
+            cursor++;
+        } else {
+            size_t w = parser->encoding->alnum_char(cursor, (size_t) (end - cursor));
+            if (w == 0) break;
+            cursor += w;
+        }
+    }
 
     if (!parser_lex_magic_comment_encoding_value(parser, value_start, cursor)) {
         // If we were unable to parse the encoding value, then we've got an


### PR DESCRIPTION
Japanese legal texts require Arabic numerals to be written using kanji numerals. As a result, the encoding name "UTF-8" is rendered as "UTF-八" in official government notices, including the notice issued by the Digital Agency and the Ministry of Internal Affairs and Communications (令和8年デジタル庁・総務省告示第12号) which defines character encoding for local government information systems.

This commit adds "UTF-八" as an encoding alias for UTF-8 in both the runtime encoding table and the Prism parser's magic comment handling. Additionally, fullwidth character normalization is supported in encoding name lookup, enabling vertically typeset encoding names such as:

```ruby
    # encoding: UTF-八

    "hello".encode("Ｕ
                    Ｔ
                    Ｆ
                    ｜
                    八")
```

Reference: https://www.digital.go.jp/assets/contents/node/basic_page/field_ref_resources/d12bde7e-a950-493b-987c-0f8d4bbd1b6b/66117898/20260324_laws_notice_text_02.pdf