### PR TITLE
ZJIT: Fix SEGV in struct accessor after polymorphic type dispatch

### DIFF
--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -4672,6 +4672,27 @@ fn test_struct_aref_polymorphic_with_symbol() {
     "), @r#""world""#);
 }
 
+// A loop counter that starts at 0 and increments by 1 must not be constant-folded.
+// After polymorphic opt_aref inlining for Array, the loop variable's phi node can
+// retain the narrow Fixnum[0] type from its initial value, causing fold_constants
+// to replace `i + 1` with the constant 1, producing an infinite loop.
+#[test]
+fn test_loop_counter_not_folded() {
+    set_call_threshold(5);
+    assert_snapshot!(inspect(r#"
+        def test(target, base)
+          i = 0
+          while target[i]&.== base[i]
+            i += 1
+          end
+          i
+        end
+        4.times { test(["a", "b", "c"], ["a", "b", "d"]) }
+        # After JIT, empty target must terminate (not infinite-loop)
+        [test(["a","b","c"], ["a","b","d"]), test([], ["y"])]
+    "#), @"[2, 0]");
+}
+
 #[test]
 fn test_struct_set() {
     assert_snapshot!(inspect("

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -4651,6 +4651,27 @@ fn test_raise_in_second_argument() {
     "), @"{ok: true}");
 }
 
+// When a polymorphic call site (e.g., .name on both Symbol and Struct) is split
+// into per-type branches, the struct accessor branch must use the profiled type
+// for the struct class to determine embedding, not the dominant profiled type
+// (which may be Symbol). Using the wrong profiled type's flags caused ZJIT to
+// generate heap-access code for an embedded struct, crashing with a NULL deref.
+#[test]
+fn test_struct_aref_polymorphic_with_symbol() {
+    // Need threshold 5: 3 Symbol calls + 1 Item call to get SkewedPolymorphic
+    // (3/4 = 0.75 >= SKEW_THRESHOLD), then call 5 triggers compilation.
+    set_call_threshold(5);
+    assert_snapshot!(inspect("
+        Item = Struct.new(:name)
+        def test(x) = x.name
+        test(:foo)              # call 1: profile as Symbol
+        test(:bar)              # call 2: profile as Symbol
+        test(:baz)              # call 3: profile as Symbol (>= 75% skew)
+        test(Item.new('hello')) # call 4: profile as Item
+        test(Item.new('world')) # call 5: triggers compilation + runs JIT code
+    "), @r#""world""#);
+}
+
 #[test]
 fn test_struct_set() {
     assert_snapshot!(inspect("

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7852,81 +7852,45 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         break;
                     }
 
-                    {
-                        fn new_branch_block(
-                            fun: &mut Function,
-                            cd: *const rb_call_data,
-                            argc: usize,
-                            opcode: u32,
-                            new_type: Type,
-                            insn_idx: u32,
-                            exit_state: &FrameState,
-                            locals_count: usize,
-                            stack_count: usize,
-                            join_block: BlockId,
-                        ) -> BlockId {
-                            let block = fun.new_block(insn_idx);
-                            let self_param = fun.push_insn(block, Insn::Param);
-                            let mut state = exit_state.clone();
-                            state.locals.clear();
-                            state.stack.clear();
-                            state.locals.extend((0..locals_count).map(|_| fun.push_insn(block, Insn::Param)));
-                            state.stack.extend((0..stack_count).map(|_| fun.push_insn(block, Insn::Param)));
-                            let snapshot = fun.push_insn(block, Insn::Snapshot { state: state.clone() });
-                            let args = state.stack_pop_n(argc).unwrap();
-                            let recv = state.stack_pop().unwrap();
-                            let refined_recv = fun.push_insn(block, Insn::RefineType { val: recv, new_type });
-                            state.replace(recv, refined_recv);
-                            let send = fun.push_insn(block, Insn::Send { recv: refined_recv, cd, block: None, args, state: snapshot, reason: Uncategorized(opcode) });
-                            state.stack_push(send);
-                            fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: state.as_args(self_param) }));
-                            block
-                        }
-                        let branch_insn_idx = exit_state.insn_idx as u32;
-                        let locals_count = state.locals.len();
-                        let stack_count = state.stack.len();
-                        let recv = state.stack_topn(argc as usize)?;  // args are on top
-                        let entry_args = state.as_args(self_param);
-                        if let Some(summary) = fun.polymorphic_summary(&profiles, recv, exit_state.insn_idx) {
-                            let join_block = insn_idx_to_block.get(&insn_idx).copied().unwrap_or_else(|| fun.new_block(insn_idx));
-                            // Dedup by expected type so immediate/heap variants
-                            // under the same Ruby class can still get separate branches.
-                            let mut seen_types = Vec::with_capacity(summary.buckets().len());
-                            for &profiled_type in summary.buckets() {
-                                if profiled_type.is_empty() { break; }
-                                let expected = Type::from_profiled_type(profiled_type);
-                                if seen_types.iter().any(|ty: &Type| ty.bit_equal(expected)) {
-                                    continue;
-                                }
-                                seen_types.push(expected);
-                                let has_type = fun.push_insn(block, Insn::HasType { val: recv, expected });
-                                let iftrue_block =
-                                    new_branch_block(&mut fun, cd, argc as usize, opcode, expected, branch_insn_idx, &exit_state, locals_count, stack_count, join_block);
-                                let target = BranchEdge { target: iftrue_block, args: entry_args.clone() };
-                                fun.push_insn(block, Insn::IfTrue { val: has_type, target });
-                            }
-                            // Continue compilation from the join block at the next instruction.
-                            // Make a copy of the current state without the args (pop the receiver
-                            // and push the result) because we just use the locals/stack sizes to
-                            // make the right number of Params
-                            let mut join_state = state.clone();
-                            join_state.stack_pop_n(argc as usize)?;
-                            queue.push_back((join_state, join_block, insn_idx, local_inval));
-                            // In the fallthrough case, do a generic interpreter send and then join.
-                            let args = state.stack_pop_n(argc as usize)?;
-                            let recv = state.stack_pop()?;
-                            let reason = SendWithoutBlockPolymorphicFallback;
-                            let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, state: exit_id, reason });
-                            state.stack_push(send);
-                            fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: state.as_args(self_param) }));
-                            break;  // End the block
-                        }
-                    }
-
+                    let branch_insn_idx = exit_state.insn_idx as u32;
                     let args = state.stack_pop_n(argc as usize)?;
                     let recv = state.stack_pop()?;
-                    let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, state: exit_id, reason: Uncategorized(opcode) });
-                    state.stack_push(send);
+
+                    if let Some(summary) = fun.polymorphic_summary(&profiles, recv, exit_state.insn_idx) {
+                        let join_block = insn_idx_to_block.get(&insn_idx).copied().unwrap_or_else(|| fun.new_block(insn_idx));
+                        let join_param = fun.push_insn(join_block, Insn::Param);
+                        // Dedup by expected type so immediate/heap variants
+                        // under the same Ruby class can still get separate branches.
+                        let mut seen_types = Vec::with_capacity(summary.buckets().len());
+                        for &profiled_type in summary.buckets() {
+                            if profiled_type.is_empty() { break; }
+                            let expected = Type::from_profiled_type(profiled_type);
+                            if seen_types.iter().any(|ty: &Type| ty.bit_equal(expected)) {
+                                continue;
+                            }
+                            seen_types.push(expected);
+                            let has_type = fun.push_insn(block, Insn::HasType { val: recv, expected });
+                            let iftrue_block = fun.new_block(branch_insn_idx);
+                            let target = BranchEdge { target: iftrue_block, args: vec![] };
+                            fun.push_insn(block, Insn::IfTrue { val: has_type, target });
+
+                            let refined_recv = fun.push_insn(iftrue_block, Insn::RefineType { val: recv, new_type: expected });
+                            let send = fun.push_insn(iftrue_block, Insn::Send { recv: refined_recv, cd, block: None, args: args.clone(), state: exit_id, reason: Uncategorized(opcode) });
+                            fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));
+                        }
+                        // In the fallthrough case, do a generic interpreter send and then join.
+                        let reason = SendWithoutBlockPolymorphicFallback;
+                        let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, state: exit_id, reason });
+                        fun.push_insn(block, Insn::Jump(BranchEdge { target: join_block, args: vec![send] }));
+
+                        // Continue compilation in the join_block
+                        block = join_block;
+                        state.stack_push(join_param);
+                    } else {
+                        // Maybe monomorphic; handled in type_specialize
+                        let send = fun.push_insn(block, Insn::Send { recv, cd, block: None, args, state: exit_id, reason: Uncategorized(opcode) });
+                        state.stack_push(send);
+                    }
                 }
                 YARVINSN_send => {
                     let cd: *const rb_call_data = get_arg(pc, 0).as_ptr();

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5257,6 +5257,15 @@ impl Function {
 
     /// Fold a binary operator on fixnums.
     fn fold_fixnum_bop(&mut self, insn_id: InsnId, left: InsnId, right: InsnId, f: impl FnOnce(Option<i64>, Option<i64>) -> Option<i64>) -> InsnId {
+        // Don't fold if an operand is a block parameter (potential loop phi).
+        // The parameter's type may be overly narrow (e.g. Fixnum[0] from the
+        // initial value) because infer_types may not have fully converged when
+        // intermediate passes modify the graph.
+        let left_resolved = self.union_find.borrow().find_const(left);
+        let right_resolved = self.union_find.borrow().find_const(right);
+        if matches!(self.insns[left_resolved.0], Insn::Param) || matches!(self.insns[right_resolved.0], Insn::Param) {
+            return insn_id;
+        }
         f(self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value())
             .filter(|&n| n >= (RUBY_FIXNUM_MIN as i64) && n <= RUBY_FIXNUM_MAX as i64)
             .map(|n| self.new_insn(Insn::Const { val: Const::Value(VALUE::fixnum_from_isize(n as isize)) }))

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3895,7 +3895,12 @@ impl Function {
                                         }
                                     }
                                     // Get the profiled type to check if the fields is embedded or heap allocated.
-                                    let Some(is_embedded) = self.profiled_type_of_at(recv, frame_state.insn_idx).map(|t| t.flags().is_struct_embedded()) else {
+                                    // Filter by klass so that in polymorphic dispatch branches (after
+                                    // RefineType), we don't use the dominant profiled type from a
+                                    // different class (e.g. Symbol flags for a Struct receiver).
+                                    let Some(is_embedded) = self.profiled_type_of_at(recv, frame_state.insn_idx)
+                                        .filter(|t| t.class() == klass)
+                                        .map(|t| t.flags().is_struct_embedded()) else {
                                         // No (monomorphic/skewed polymorphic) profile info
                                         let reason = if has_block { SendNoProfiles } else { SendWithoutBlockNoProfiles };
                                         self.set_dynamic_send_reason(insn_id, reason);

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -7912,19 +7912,19 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :o@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          IfTrue v15, bb5(v9, v10, v10)
-          v24:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v24)
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
-          v20:ObjectSubclass[class_exact:C] = RefineType v18, ObjectSubclass[class_exact:C]
+          v16:CBool = HasType v10, ObjectSubclass[class_exact:C]
+          IfTrue v16, bb5()
+          v21:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v21)
+        bb5():
+          v18:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v37:BasicObject = GetIvar v20, :@foo
-          Jump bb4(v16, v17, v37)
-        bb4(v26:BasicObject, v27:BasicObject, v28:BasicObject):
+          v30:BasicObject = GetIvar v18, :@foo
+          Jump bb4(v30)
+        bb4(v15:BasicObject):
           CheckInterrupts
-          Return v28
+          Return v15
         ");
     }
 
@@ -14501,29 +14501,29 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :o@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          IfTrue v15, bb5(v9, v10, v10)
-          v24:CBool = HasType v10, ObjectSubclass[class_exact:D]
-          IfTrue v24, bb6(v9, v10, v10)
-          v33:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
+          v16:CBool = HasType v10, ObjectSubclass[class_exact:C]
+          IfTrue v16, bb5()
+          v21:CBool = HasType v10, ObjectSubclass[class_exact:D]
+          IfTrue v21, bb6()
+          v26:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v26)
+        bb5():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v55:Fixnum[3] = Const Value(3)
-          Jump bb4(v16, v17, v55)
-        bb6(v25:BasicObject, v26:BasicObject, v27:BasicObject):
+          v44:Fixnum[3] = Const Value(3)
+          Jump bb4(v44)
+        bb6():
           PatchPoint NoSingletonClass(D@0x1040)
           PatchPoint MethodRedefined(D@0x1040, foo@0x1010, cme:0x1048)
-          v56:Fixnum[4] = Const Value(4)
-          Jump bb4(v25, v26, v56)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
-          v40:Fixnum[2] = Const Value(2)
+          v45:Fixnum[4] = Const Value(4)
+          Jump bb4(v45)
+        bb4(v15:BasicObject):
+          v29:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v59:Fixnum = GuardType v37, Fixnum
-          v60:Fixnum = FixnumAdd v59, v40
+          v48:Fixnum = GuardType v15, Fixnum
+          v49:Fixnum = FixnumAdd v48, v29
           CheckInterrupts
-          Return v60
+          Return v49
         ");
     }
 
@@ -14553,24 +14553,24 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :o@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          IfTrue v15, bb5(v9, v10, v10)
-          v24:CBool = HasType v10, Fixnum
-          IfTrue v24, bb6(v9, v10, v10)
-          v33:BasicObject = Send v10, :itself # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
-          v20:ObjectSubclass[class_exact:C] = RefineType v18, ObjectSubclass[class_exact:C]
+          v16:CBool = HasType v10, ObjectSubclass[class_exact:C]
+          IfTrue v16, bb5()
+          v21:CBool = HasType v10, Fixnum
+          IfTrue v21, bb6()
+          v26:BasicObject = Send v10, :itself # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v26)
+        bb5():
+          v18:ObjectSubclass[class_exact:C] = RefineType v10, ObjectSubclass[class_exact:C]
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, itself@0x1010, cme:0x1018)
-          Jump bb4(v16, v17, v20)
-        bb6(v25:BasicObject, v26:BasicObject, v27:BasicObject):
-          v29:Fixnum = RefineType v27, Fixnum
+          Jump bb4(v18)
+        bb6():
+          v23:Fixnum = RefineType v10, Fixnum
           PatchPoint MethodRedefined(Integer@0x1040, itself@0x1010, cme:0x1018)
-          Jump bb4(v25, v26, v29)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          Jump bb4(v23)
+        bb4(v15:BasicObject):
           CheckInterrupts
-          Return v37
+          Return v15
         ");
     }
 
@@ -14606,25 +14606,25 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :x@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, Fixnum
-          IfTrue v15, bb5(v9, v10, v10)
-          v24:CBool = HasType v10, Bignum
-          IfTrue v24, bb6(v9, v10, v10)
-          v33:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
-          v20:Fixnum = RefineType v18, Fixnum
+          v16:CBool = HasType v10, Fixnum
+          IfTrue v16, bb5()
+          v21:CBool = HasType v10, Bignum
+          IfTrue v21, bb6()
+          v26:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v26)
+        bb5():
+          v18:Fixnum = RefineType v10, Fixnum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v46:StringExact = CCallVariadic v20, :Integer#to_s@0x1040
-          Jump bb4(v16, v17, v46)
-        bb6(v25:BasicObject, v26:BasicObject, v27:BasicObject):
-          v29:Bignum = RefineType v27, Bignum
+          v35:StringExact = CCallVariadic v18, :Integer#to_s@0x1040
+          Jump bb4(v35)
+        bb6():
+          v23:Bignum = RefineType v10, Bignum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v49:StringExact = CCallVariadic v29, :Integer#to_s@0x1040
-          Jump bb4(v25, v26, v49)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          v38:StringExact = CCallVariadic v23, :Integer#to_s@0x1040
+          Jump bb4(v38)
+        bb4(v15:BasicObject):
           CheckInterrupts
-          Return v37
+          Return v15
         ");
     }
 
@@ -14657,25 +14657,25 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :x@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, Flonum
-          IfTrue v15, bb5(v9, v10, v10)
-          v24:CBool = HasType v10, HeapFloat
-          IfTrue v24, bb6(v9, v10, v10)
-          v33:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
-          v20:Flonum = RefineType v18, Flonum
+          v16:CBool = HasType v10, Flonum
+          IfTrue v16, bb5()
+          v21:CBool = HasType v10, HeapFloat
+          IfTrue v21, bb6()
+          v26:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v26)
+        bb5():
+          v18:Flonum = RefineType v10, Flonum
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v46:BasicObject = CCallWithFrame v20, :Float#to_s@0x1040
-          Jump bb4(v16, v17, v46)
-        bb6(v25:BasicObject, v26:BasicObject, v27:BasicObject):
-          v29:HeapFloat = RefineType v27, HeapFloat
+          v35:BasicObject = CCallWithFrame v18, :Float#to_s@0x1040
+          Jump bb4(v35)
+        bb6():
+          v23:HeapFloat = RefineType v10, HeapFloat
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v49:BasicObject = CCallWithFrame v29, :Float#to_s@0x1040
-          Jump bb4(v25, v26, v49)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          v38:BasicObject = CCallWithFrame v23, :Float#to_s@0x1040
+          Jump bb4(v38)
+        bb4(v15:BasicObject):
           CheckInterrupts
-          Return v37
+          Return v15
         ");
     }
 
@@ -14708,25 +14708,25 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :x@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, StaticSymbol
-          IfTrue v15, bb5(v9, v10, v10)
-          v24:CBool = HasType v10, DynamicSymbol
-          IfTrue v24, bb6(v9, v10, v10)
-          v33:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
-          v20:StaticSymbol = RefineType v18, StaticSymbol
+          v16:CBool = HasType v10, StaticSymbol
+          IfTrue v16, bb5()
+          v21:CBool = HasType v10, DynamicSymbol
+          IfTrue v21, bb6()
+          v26:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v26)
+        bb5():
+          v18:StaticSymbol = RefineType v10, StaticSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v48:StringExact = InvokeBuiltin leaf <inline_expr>, v20
-          Jump bb4(v16, v17, v48)
-        bb6(v25:BasicObject, v26:BasicObject, v27:BasicObject):
-          v29:DynamicSymbol = RefineType v27, DynamicSymbol
+          v37:StringExact = InvokeBuiltin leaf <inline_expr>, v18
+          Jump bb4(v37)
+        bb6():
+          v23:DynamicSymbol = RefineType v10, DynamicSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v49:StringExact = InvokeBuiltin leaf <inline_expr>, v29
-          Jump bb4(v25, v26, v49)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          v38:StringExact = InvokeBuiltin leaf <inline_expr>, v23
+          Jump bb4(v38)
+        bb4(v15:BasicObject):
           CheckInterrupts
-          Return v37
+          Return v15
         ");
     }
 
@@ -14763,18 +14763,18 @@ mod hir_opt_tests {
           v7:BasicObject = LoadArg :o@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          IfTrue v15, bb5(v9, v10, v10)
-          v24:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v24)
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
+          v16:CBool = HasType v10, ObjectSubclass[class_exact:C]
+          IfTrue v16, bb5()
+          v21:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v21)
+        bb5():
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v38:Fixnum[3] = Const Value(3)
-          Jump bb4(v16, v17, v38)
-        bb4(v26:BasicObject, v27:BasicObject, v28:BasicObject):
+          v31:Fixnum[3] = Const Value(3)
+          Jump bb4(v31)
+        bb4(v15:BasicObject):
           CheckInterrupts
-          Return v28
+          Return v15
         ");
     }
 


### PR DESCRIPTION
This fixes a crash that can be reproduced with `make test-tool RUN_OPTS="--zjit-call-threshold=1" TESTS="testunit/test_sorting"`, which seems to be introduced by https://github.com/ruby/ruby/pull/16634.