### PR TITLE
Fix random timeout in test_thread_join_during_finalizers on Windows

### DIFF
--- a/test/ruby/test_thread.rb
+++ b/test/ruby/test_thread.rb
@@ -1667,7 +1667,7 @@ q.pop
 
   # [Bug #21926]
   def test_thread_join_during_finalizers
-    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}", timeout: 30)
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}", timeout: 60)
     begin;
       require 'open3'
 
@@ -1690,7 +1690,7 @@ q.pop
         end
       end
 
-      50.times { ProcessWrapper.new }
+      20.times { ProcessWrapper.new }
       GC.stress = true
       1000.times { Object.new }
     end;


### PR DESCRIPTION
`TestThread#test_thread_join_during_finalizers` https://github.com/ruby/ruby/pull/16307 seems to be kind of flaky on Windows CI https://github.com/ruby/ruby/actions/runs/23923855443/job/69776218335?pr=16649:

```
    1) Error:
  TestThread#test_thread_join_during_finalizers:
  Test::Unit::ProxyError: execution of Test::Unit::CoreAssertions#assert_separately expired timeout (30 sec)
  pid 9920 exit 0
  | 
       D:/a/ruby/ruby/src/test/ruby/test_thread.rb:1670:in 'TestThread#test_thread_join_during_finalizers'
```

This PR attempts to make it less flaky.