### PR TITLE
Remove CREF rewriting for cloned classes/modules

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,11 @@ Note that each entry is kept to a minimum, see links for details.
 
 ## Language changes
 
+* `Module#clone` and `Module#dup` no longer rewrite the lexical scope of
+  copied methods. Constants and class variables resolve through the
+  original class, consistent with inheritance and mixins.
+  [[Feature #21981]]
+
 ## Core classes updates
 
 Note: We're only listing outstanding class updates.
@@ -170,6 +175,7 @@ A lot of work has gone into making Ractors more stable, performant, and usable. 
 [Feature #21853]: https://bugs.ruby-lang.org/issues/21853
 [Feature #21861]: https://bugs.ruby-lang.org/issues/21861
 [Feature #21932]: https://bugs.ruby-lang.org/issues/21932
+[Feature #21981]: https://bugs.ruby-lang.org/issues/21981
 [RubyGems-v4.0.4]: https://github.com/rubygems/rubygems/releases/tag/v4.0.4
 [RubyGems-v4.0.5]: https://github.com/rubygems/rubygems/releases/tag/v4.0.5
 [RubyGems-v4.0.6]: https://github.com/rubygems/rubygems/releases/tag/v4.0.6

--- a/class.c
+++ b/class.c
@@ -394,7 +394,6 @@ rb_class_duplicate_classext(rb_classext_t *orig, VALUE klass, const rb_box_t *bo
      * * variation count
      */
     RCLASSEXT_PERMANENT_CLASSPATH(ext) = RCLASSEXT_PERMANENT_CLASSPATH(orig);
-    RCLASSEXT_CLONED(ext) = RCLASSEXT_CLONED(orig);
     RCLASSEXT_CLASSPATH(ext) = RCLASSEXT_CLASSPATH(orig);
 
     /* For the usual T_CLASS/T_MODULE, iclass flags are always false */
@@ -880,27 +879,20 @@ rb_class_s_alloc(VALUE klass)
 }
 
 static void
-clone_method(VALUE old_klass, VALUE new_klass, ID mid, const rb_method_entry_t *me)
+clone_method(VALUE new_klass, ID mid, const rb_method_entry_t *me)
 {
-    if (me->def->type == VM_METHOD_TYPE_ISEQ) {
-        rb_cref_t *new_cref = rb_vm_rewrite_cref(me->def->body.iseq.cref, old_klass, new_klass);
-        rb_add_method_iseq(new_klass, mid, me->def->body.iseq.iseqptr, new_cref, METHOD_ENTRY_VISI(me));
-    }
-    else {
-        rb_method_entry_set(new_klass, mid, me, METHOD_ENTRY_VISI(me));
-    }
+    rb_method_entry_set(new_klass, mid, me, METHOD_ENTRY_VISI(me));
 }
 
 struct clone_method_arg {
     VALUE new_klass;
-    VALUE old_klass;
 };
 
 static enum rb_id_table_iterator_result
 clone_method_i(ID key, VALUE value, void *data)
 {
     const struct clone_method_arg *arg = (struct clone_method_arg *)data;
-    clone_method(arg->old_klass, arg->new_klass, key, (const rb_method_entry_t *)value);
+    clone_method(arg->new_klass, key, (const rb_method_entry_t *)value);
     return ID_TABLE_CONTINUE;
 }
 
@@ -1046,12 +1038,6 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
 
     rb_class_set_initialized(clone);
 
-    /* cloned flag is refer at constant inline cache
-     * see vm_get_const_key_cref() in vm_insnhelper.c
-     */
-    RCLASS_SET_CLONED(clone, true);
-    RCLASS_SET_CLONED(orig, true);
-
     if (!RCLASS_SINGLETON_P(CLASS_OF(clone))) {
         RBASIC_SET_CLASS(clone, rb_singleton_class_clone(orig));
         rb_singleton_class_attached(METACLASS_OF(clone), (VALUE)clone);
@@ -1062,7 +1048,6 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
     copy_tables(clone, orig);
     if (RCLASS_M_TBL(orig)) {
         struct clone_method_arg arg;
-        arg.old_klass = orig;
         arg.new_klass = clone;
         class_initialize_method_table(clone);
         rb_id_table_foreach(RCLASS_M_TBL(orig), clone_method_i, &arg);
@@ -1124,7 +1109,6 @@ rb_mod_init_copy(VALUE clone, VALUE orig)
             copy_tables(clone_origin, orig_origin);
             if (RCLASS_M_TBL(orig_origin)) {
                 struct clone_method_arg arg;
-                arg.old_klass = orig;
                 arg.new_klass = clone;
                 class_initialize_method_table(clone_origin);
                 rb_id_table_foreach(RCLASS_M_TBL(orig_origin), clone_method_i, &arg);
@@ -1196,7 +1180,6 @@ rb_singleton_class_clone_and_attach(VALUE obj, VALUE attach)
         }
         {
             struct clone_method_arg arg;
-            arg.old_klass = klass;
             arg.new_klass = clone;
             rb_id_table_foreach(RCLASS_M_TBL(klass), clone_method_i, &arg);
         }

--- a/internal/class.h
+++ b/internal/class.h
@@ -87,7 +87,6 @@ struct rb_classext_struct {
     attr_index_t max_iv_count;
     uint8_t variation_count;
     bool permanent_classpath : 1;
-    bool cloned : 1;
     bool shared_const_tbl : 1;
     bool iclass_is_origin : 1;
     bool iclass_origin_shared_mtbl : 1;
@@ -159,7 +158,6 @@ static inline rb_classext_t * RCLASS_EXT_WRITABLE(VALUE obj);
 // class.allocator/singleton_class.attached_object are not accessed directly via RCLASSEXT_*
 #define RCLASSEXT_INCLUDER(ext) (ext->as.iclass.includer)
 #define RCLASSEXT_PERMANENT_CLASSPATH(ext) (ext->permanent_classpath)
-#define RCLASSEXT_CLONED(ext) (ext->cloned)
 #define RCLASSEXT_SHARED_CONST_TBL(ext) (ext->shared_const_tbl)
 #define RCLASSEXT_ICLASS_IS_ORIGIN(ext) (ext->iclass_is_origin)
 #define RCLASSEXT_ICLASS_ORIGIN_SHARED_MTBL(ext) (ext->iclass_origin_shared_mtbl)
@@ -196,7 +194,6 @@ static inline void RCLASSEXT_SET_INCLUDER(rb_classext_t *ext, VALUE klass, VALUE
 #define RCLASS_ORIGIN(c) (RCLASS_EXT_READABLE(c)->origin_)
 #define RICLASS_IS_ORIGIN_P(c) (RCLASS_EXT_READABLE(c)->iclass_is_origin)
 #define RCLASS_PERMANENT_CLASSPATH_P(c) (RCLASS_EXT_READABLE(c)->permanent_classpath)
-#define RCLASS_CLONED_P(c) (RCLASS_EXT_READABLE(c)->cloned)
 #define RCLASS_CLASSPATH(c) (RCLASS_EXT_READABLE(c)->classpath)
 
 // Superclasses can't be changed after initialization
@@ -247,7 +244,6 @@ static inline VALUE RCLASS_SET_ATTACHED_OBJECT(VALUE klass, VALUE attached_objec
 
 static inline void RCLASS_SET_INCLUDER(VALUE iclass, VALUE klass);
 static inline void RCLASS_SET_MAX_IV_COUNT(VALUE klass, attr_index_t count);
-static inline void RCLASS_SET_CLONED(VALUE klass, bool cloned);
 static inline void RCLASS_SET_CLASSPATH(VALUE klass, VALUE classpath, bool permanent);
 static inline void RCLASS_WRITE_CLASSPATH(VALUE klass, VALUE classpath, bool permanent);
 
@@ -748,12 +744,6 @@ static inline bool
 RCLASS_EXPECT_NO_IVAR(VALUE klass)
 {
     return RCLASS_EXT_PRIME(klass)->expect_no_ivar;
-}
-
-static inline void
-RCLASS_SET_CLONED(VALUE klass, bool cloned)
-{
-    RCLASSEXT_CLONED(RCLASS_EXT_PRIME(klass)) = cloned;
 }
 
 static inline bool

--- a/test/ruby/test_class.rb
+++ b/test/ruby/test_class.rb
@@ -435,6 +435,7 @@ class TestClass < Test::Unit::TestCase
   end
 
   class CloneTest
+    TEST = :C0
     def foo; TEST; end
   end
 
@@ -448,8 +449,8 @@ class TestClass < Test::Unit::TestCase
   end
 
   def test_constant_access_from_method_in_cloned_class
-    assert_equal :C1, CloneTest1.new.foo, '[Bug #15877]'
-    assert_equal :C2, CloneTest2.new.foo, '[Bug #15877]'
+    assert_equal :C0, CloneTest1.new.foo, 'originally [Bug #15877], but behaviour changed'
+    assert_equal :C0, CloneTest2.new.foo, 'originally [Bug #15877], but behaviour changed'
   end
 
   def test_invalid_superclass

--- a/test/ruby/test_module.rb
+++ b/test/ruby/test_module.rb
@@ -2822,7 +2822,7 @@ class TestModule < Test::Unit::TestCase
 
     b = a.dup
     b.new.a = 'B'
-    assert_equal 'A', a.new.a, '[ruby-core:17019]'
+    assert_equal 'B', a.new.a, '[ruby-core:17019] behaviour changed: cvar resolves through original CREF'
   end
 
   Bug6891 = '[ruby-core:47241]'
@@ -3265,6 +3265,7 @@ class TestModule < Test::Unit::TestCase
   end
 
   module CloneTestM0
+    TEST = :M0
     def foo; TEST; end
   end
 
@@ -3288,8 +3289,8 @@ class TestModule < Test::Unit::TestCase
     assert_equal 1, m::C, '[ruby-core:47834]'
     assert_equal 1, m.m, '[ruby-core:47834]'
 
-    assert_equal :M1, CloneTestC1.new.foo, '[Bug #15877]'
-    assert_equal :M2, CloneTestC2.new.foo, '[Bug #15877]'
+    assert_equal :M0, CloneTestC1.new.foo, 'originally [Bug #15877], but behaviour changed'
+    assert_equal :M0, CloneTestC2.new.foo, 'originally [Bug #15877], but behaviour changed'
   end
 
   def test_clone_freeze

--- a/test/ruby/test_variable.rb
+++ b/test/ruby/test_variable.rb
@@ -50,6 +50,11 @@ class TestVariable < Test::Unit::TestCase
   end
 
   Zeus = Gods.clone
+  class Zeus
+    def ruler5
+      @@rule
+    end
+  end
 
   def test_cloned_allows_setting_cvar
     Zeus.class_variable_set(:@@rule, "Athena")
@@ -58,8 +63,12 @@ class TestVariable < Test::Unit::TestCase
     zeus = Zeus.new.ruler0
 
     assert_equal "Cronus", god
-    assert_equal "Athena", zeus
-    assert_not_equal god.object_id, zeus.object_id
+    assert_equal "Cronus", zeus
+
+    assert_equal "Athena", Zeus.new.ruler5
+
+    assert_equal "Cronus", Gods.class_variable_get(:@@rule)
+    assert_equal "Athena", Zeus.class_variable_get(:@@rule)
   end
 
   def test_singleton_class_included_class_variable

--- a/vm.c
+++ b/vm.c
@@ -353,12 +353,6 @@ vm_cref_new(VALUE klass, rb_method_visibility_t visi, int module_func, rb_cref_t
     return vm_cref_new0(klass, visi, module_func, prev_cref, pushed_by_eval, FALSE, singleton);
 }
 
-static rb_cref_t *
-vm_cref_new_use_prev(VALUE klass, rb_method_visibility_t visi, int module_func, rb_cref_t *prev_cref, int pushed_by_eval)
-{
-    return vm_cref_new0(klass, visi, module_func, prev_cref, pushed_by_eval, TRUE, FALSE);
-}
-
 static int
 ref_delete_symkey(VALUE key, VALUE value, VALUE unused)
 {

--- a/vm_core.h
+++ b/vm_core.h
@@ -2026,8 +2026,6 @@ void rb_vm_register_special_exception_str(enum ruby_special_exceptions sp, VALUE
 
 void rb_gc_mark_machine_context(const rb_execution_context_t *ec);
 
-rb_cref_t *rb_vm_rewrite_cref(rb_cref_t *node, VALUE old_klass, VALUE new_klass);
-
 const rb_callable_method_entry_t *rb_vm_frame_method_entry(const rb_control_frame_t *cfp);
 const rb_callable_method_entry_t *rb_vm_frame_method_entry_unchecked(const rb_control_frame_t *cfp);
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -989,8 +989,7 @@ vm_get_const_key_cref(const VALUE *ep)
     const rb_cref_t *key_cref = cref;
 
     while (cref) {
-        if (CREF_DYNAMIC(cref) ||
-                RCLASS_CLONED_P(CREF_CLASS(cref))) {
+        if (CREF_DYNAMIC(cref)) {
             return key_cref;
         }
         cref = CREF_NEXT(cref);
@@ -998,39 +997,6 @@ vm_get_const_key_cref(const VALUE *ep)
 
     /* no dynamic singleton class or cloned class found */
     return NULL;
-}
-
-rb_cref_t *
-rb_vm_rewrite_cref(rb_cref_t *cref, VALUE old_klass, VALUE new_klass)
-{
-    rb_cref_t *new_cref_head = NULL;
-    rb_cref_t *new_cref_tail = NULL;
-
-    #define ADD_NEW_CREF(new_cref) \
-        if (new_cref_tail) { \
-            RB_OBJ_WRITE(new_cref_tail, &new_cref_tail->next, new_cref); \
-        } \
-        else { \
-            new_cref_head = new_cref; \
-        } \
-        new_cref_tail = new_cref;
-
-    while (cref) {
-        rb_cref_t *new_cref;
-        if (CREF_CLASS(cref) == old_klass) {
-            new_cref = vm_cref_new_use_prev(new_klass, METHOD_VISI_UNDEF, FALSE, cref, FALSE);
-            ADD_NEW_CREF(new_cref);
-            return new_cref_head;
-        }
-        new_cref = vm_cref_new_use_prev(CREF_CLASS(cref), METHOD_VISI_UNDEF, FALSE, cref, FALSE);
-        cref = CREF_NEXT(cref);
-        ADD_NEW_CREF(new_cref);
-    }
-
-    #undef ADD_NEW_CREF
-
-    // Could we just reuse the original cref?
-    return new_cref_head;
 }
 
 static rb_cref_t *


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/21981

When a class or module is cloned, Ruby currently rewrites the CREF chain of each copied method so that it points at the new class instead of the original. I don't think this should happen, and methods on a cloned class should retain their original lexical scope.

This behaviour was introduced in Ruby 1.9 to fix `[Bug #7107]`, which was reporting that a constant in the original class wasn't available. I think it was done this way because of Ruby's implementation at that time rather than a design choice. This had further changes and fixes in `[Bug #10885]`, `[Bug #15877]` which were crashes or inconsistencies (stale cache). I'd like us to revisit the design of this behaviour so that it's more intuitive and consistent.

``` ruby
class C
  A = 1
  def a; A; end
end

D = C.clone
D.const_set(:A, 2)

p C.new.a  # => 1
p D.new.a  # => 2, but I think it should be 1
```

In most all other cases in Ruby, methods keep their original lexical scope for constant references: inheritance, mixins, `define_method(..., klass.instance_method(...))`, etc. Cloning a class should behave the same.

I think cloning a class is fairly rare, and setting constants on the cloned class more so, but this could be a compatibility issue. This affects `@@class_variables` as well as `CONSTANTS`. FWIW, truffleruby doesn't seem to have this behaviour (which makes sense, part of why I want to remove it is that it's awkward for JIT compiling 😅).