### PR TITLE
ZJIT: More recognizable JIT return poison, assert only when RUBY_DEBUG

### DIFF
--- a/zjit.h
+++ b/zjit.h
@@ -66,10 +66,8 @@ static inline void rb_zjit_jit_frame_update_references(zjit_jit_frame_t *jit_fra
 
 #define rb_zjit_enabled_p (rb_zjit_entry != 0)
 
-enum zjit_poison_values {
-    // Poison value used on frame push when runtime checks are enabled
-    ZJIT_JIT_RETURN_POISON = 2,
-};
+// BADFrame. The high bit is set, so likely SEGV on linux and darwin if dereferenced.
+#define ZJIT_JIT_RETURN_POISON 0xbadfbadfbadfbadfULL
 
 // Return the JITFrame pointer from cfp->jit_return, or NULL if not present.
 // YJIT also uses jit_return (as a return address), so this must only return
@@ -79,7 +77,7 @@ CFP_ZJIT_FRAME(const rb_control_frame_t *cfp)
 {
     if (!rb_zjit_enabled_p) return NULL;
 #if USE_ZJIT
-    RUBY_ASSERT_ALWAYS(cfp->jit_return != (void *)ZJIT_JIT_RETURN_POISON);
+    RUBY_ASSERT((unsigned long long)cfp->jit_return != ZJIT_JIT_RETURN_POISON);
 #endif
     return cfp->jit_return;
 }

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -314,7 +314,7 @@ fn main() {
         .allowlist_function("rb_zjit_insn_leaf")
         .allowlist_type("jit_bindgen_constants")
         .allowlist_type("zjit_struct_offsets")
-        .allowlist_type("zjit_poison_values")
+        .allowlist_var("ZJIT_JIT_RETURN_POISON")
         .allowlist_function("rb_assert_holding_vm_lock")
         .allowlist_function("rb_jit_shape_too_complex_p")
         .allowlist_function("rb_jit_multi_ractor_p")

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -234,6 +234,7 @@ pub const VM_ENV_DATA_INDEX_SPECVAL: i32 = -1;
 pub const VM_ENV_DATA_INDEX_FLAGS: u32 = 0;
 pub const VM_BLOCK_HANDLER_NONE: u32 = 0;
 pub const SHAPE_ID_NUM_BITS: u32 = 32;
+pub const ZJIT_JIT_RETURN_POISON: i64 = -4981057192772781345;
 pub type rb_alloc_func_t = ::std::option::Option<unsafe extern "C" fn(klass: VALUE) -> VALUE>;
 pub const RUBY_Qfalse: ruby_special_consts = 0;
 pub const RUBY_Qnil: ruby_special_consts = 4;
@@ -1919,8 +1920,6 @@ pub struct zjit_jit_frame {
     pub iseq: *const rb_iseq_t,
     pub materialize_block_code: bool,
 }
-pub const ZJIT_JIT_RETURN_POISON: zjit_poison_values = 2;
-pub type zjit_poison_values = u32;
 pub const ISEQ_BODY_OFFSET_PARAM: zjit_struct_offsets = 16;
 pub type zjit_struct_offsets = u32;
 pub const ROBJECT_OFFSET_AS_HEAP_FIELDS: jit_bindgen_constants = 16;


### PR DESCRIPTION
A good poison value gives a recognizable fault address if someone
erroneously dereferences. Asserting the pointer is not poison shouldn't
be necessary, so move it to RUBY_DEBUG builds.

---

FYI the poison looks like `DF BA DF BA DF BA DF BA` in little endian memory dumps.