### PR TITLE
Assume `chdir(2)` isn't called and cache `rb_dir_getwd_ospath()`

### DIFF
--- a/benchmark/dir_pwd.yml
+++ b/benchmark/dir_pwd.yml
@@ -1,0 +1,5 @@
+prelude: |
+  # frozen_string_literal: true
+benchmark:
+  pwd: Dir.pwd
+  expand_path: File.expand_path("../../foo.txt")

--- a/dir.c
+++ b/dir.c
@@ -504,6 +504,7 @@ fnmatch(
 }
 
 VALUE rb_cDir;
+static VALUE cwd_ospath;
 static VALUE sym_directory, sym_link, sym_file, sym_unknown;
 
 #if defined(DT_BLK) || defined(S_IFBLK)
@@ -1241,6 +1242,7 @@ nogvl_chdir(void *ptr)
 static void
 dir_chdir0(VALUE path)
 {
+    cwd_ospath = 0;
     if (IO_WITHOUT_GVL_INT(nogvl_chdir, (void*)RSTRING_PTR(path)) < 0)
         rb_sys_fail_path(path);
 }
@@ -1607,8 +1609,11 @@ getcwd_xfree(VALUE arg)
 VALUE
 rb_dir_getwd_ospath(void)
 {
+    if (cwd_ospath) {
+        return cwd_ospath;
+    }
     char *path = ruby_getcwd();
-    return rb_ensure(getcwd_to_str, (VALUE)path, getcwd_xfree, (VALUE)path);
+    return cwd_ospath = rb_str_freeze(rb_ensure(getcwd_to_str, (VALUE)path, getcwd_xfree, (VALUE)path));
 }
 #endif
 
@@ -1617,7 +1622,7 @@ rb_dir_getwd(void)
 {
     rb_encoding *fs = rb_filesystem_encoding();
     int fsenc = rb_enc_to_index(fs);
-    VALUE cwd = rb_dir_getwd_ospath();
+    VALUE cwd = rb_str_dup(rb_dir_getwd_ospath());
 
     switch (fsenc) {
       case ENCINDEX_US_ASCII:
@@ -4008,6 +4013,7 @@ Init_Dir(void)
 
     rb_gc_register_address(&chdir_lock.path);
     rb_gc_register_address(&chdir_lock.thread);
+    rb_gc_register_address(&cwd_ospath);
 
     rb_cDir = rb_define_class("Dir", rb_cObject);
 

--- a/file.c
+++ b/file.c
@@ -3593,11 +3593,11 @@ has_drive_letter(const char *buf)
 }
 
 #ifndef _WIN32
-static char*
+static VALUE
 getcwdofdrv(int drv)
 {
     char drive[4];
-    char *drvcwd, *oldcwd;
+    VALUE drvcwd, oldcwd;
 
     drive[0] = drv;
     drive[1] = ':';
@@ -3607,15 +3607,14 @@ getcwdofdrv(int drv)
        of a particular drive is to change chdir() to that drive,
        so save the old cwd before chdir()
     */
-    oldcwd = ruby_getcwd();
+    oldcwd = rb_dir_getwd_ospath();
     if (chdir(drive) == 0) {
-        drvcwd = ruby_getcwd();
-        chdir(oldcwd);
-        xfree(oldcwd);
+        drvcwd = rb_dir_getwd_ospath();
+        chdir(RSTRING_PTR(oldcwd));
     }
     else {
         /* perhaps the drive is not exist. we return only drive letter */
-        drvcwd = strdup(drive);
+        drvcwd = rb_str_new(drive, 2);
     }
     return drvcwd;
 }
@@ -3976,16 +3975,15 @@ ospath_new(const char *ptr, long len, rb_encoding *fsenc)
 }
 
 static char *
-append_fspath(VALUE result, VALUE fname, char *dir, rb_encoding **enc, rb_encoding *fsenc)
+append_fspath(VALUE result, VALUE fname, VALUE dir, rb_encoding **enc, rb_encoding *fsenc)
 {
-    char *buf, *cwdp = dir;
+    char *buf, *cwdp = RSTRING_PTR(dir);
     VALUE dirname = Qnil;
-    size_t dirlen = strlen(dir), buflen = rb_str_capacity(result);
+    size_t dirlen = RSTRING_LEN(dir), buflen = rb_str_capacity(result);
 
     if (NORMALIZE_UTF8PATH || *enc != fsenc) {
-        dirname = ospath_new(dir, dirlen, fsenc);
+        dirname = ospath_new(cwdp, dirlen, fsenc);
         if (!rb_enc_compatible(fname, dirname)) {
-            xfree(dir);
             /* rb_enc_check must raise because the two encodings are not
              * compatible. */
             rb_enc_check(fname, dirname);
@@ -4005,9 +4003,9 @@ append_fspath(VALUE result, VALUE fname, char *dir, rb_encoding **enc, rb_encodi
     rb_str_resize(result, buflen);
     buf = RSTRING_PTR(result);
     memcpy(buf, cwdp, dirlen);
-    xfree(dir);
     if (!NIL_P(dirname)) rb_str_resize(dirname, 0);
     rb_enc_associate(result, *enc);
+    RB_GC_GUARD(dir);
     return buf + dirlen;
 }
 
@@ -4103,7 +4101,7 @@ rb_file_expand_path_internal(VALUE fname, VALUE dname, int abs_mode, int long_na
             p = pend;
         }
         else {
-            char *e = append_fspath(result, fname, ruby_getcwd(), &enc, fsenc);
+            char *e = append_fspath(result, fname, rb_dir_getwd_ospath(), &enc, fsenc);
             BUFINIT();
             p = e;
         }


### PR DESCRIPTION
[Feature #21987]

The cache is reset when `Dir.chdir` is invoked.

```
compare-ruby: ruby 4.1.0dev (2026-04-09T12:24:09Z master c919778017) +PRISM [arm64-darwin25]
built-ruby: ruby 4.1.0dev (2026-04-09T16:39:56Z cache-pwd 9946d0eb07) +PRISM [arm64-darwin25]
```

|             |compare-ruby|built-ruby|
|:------------|-----------:|---------:|
|pwd          |    104.703k|   89.698M|
|             |           -|   856.69x|
|expand_path  |    100.734k|    1.098M|
|             |           -|    10.90x|