### PR TITLE
In gc_marks_finish, use avg_slot_size when allowing heaps to expand

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -5509,7 +5509,13 @@ gc_marks_finish(rb_objspace_t *objspace)
             }
 
             if (full_marking) {
-                heap_allocatable_bytes_expand(objspace, NULL, sweep_slots, total_slots, heaps[0].slot_size);
+                /* Use weighted average slot size since total_slots spans all heaps */
+                size_t total_heap_bytes = 0;
+                for (int i = 0; i < HEAP_COUNT; i++) {
+                    total_heap_bytes += heaps[i].total_slots * heaps[i].slot_size;
+                }
+                size_t avg_slot_size = total_slots > 0 ? total_heap_bytes / total_slots : heaps[0].slot_size;
+                heap_allocatable_bytes_expand(objspace, NULL, sweep_slots, total_slots, avg_slot_size);
             }
         }
 


### PR DESCRIPTION
Before, the heaps could be underprovisioned because it was always using the smallest slot size in its calculation.