### PR TITLE
ZJIT: Prefer T_* guard over checking RBasic::klass

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2546,6 +2546,23 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, guard
     } else if guard_type.is_immediate() {
         // All immediate types' guard should have been handled above
         panic!("unexpected immediate guard type: {guard_type}");
+    } else if let Some(builtin_type) = guard_type.builtin_type_equivalent() {
+        let side = side_exit(jit, state, GuardType(guard_type));
+
+        // Check special constant
+        asm.test(val, Opnd::UImm(RUBY_IMMEDIATE_MASK as u64));
+        asm.jnz(jit, side.clone());
+
+        // Check false
+        asm.cmp(val, Qfalse.into());
+        asm.je(jit, side.clone());
+
+        // Mask and check the builtin type
+        let val = asm.load_mem(val);
+        let flags = asm.load(Opnd::mem(VALUE_BITS, val, RUBY_OFFSET_RBASIC_FLAGS));
+        let tag   = asm.and(flags, Opnd::UImm(RUBY_T_MASK as u64));
+        asm.cmp(tag, Opnd::UImm(builtin_type as u64));
+        asm.jne(jit, side);
     } else if let Some(expected_class) = guard_type.runtime_exact_ruby_class() {
         asm_comment!(asm, "guard exact class for non-immediate types");
 
@@ -2585,23 +2602,6 @@ fn gen_guard_type(jit: &mut JITState, asm: &mut Assembler, val: lir::Opnd, guard
         let expected = RUBY_T_DATA.to_usize() | RUBY_TYPED_FL_IS_TYPED_DATA.to_usize();
         let masked = asm.and(flags, mask.into());
         asm.cmp(masked, expected.into());
-        asm.jne(jit, side);
-    } else if let Some(builtin_type) = guard_type.builtin_type_equivalent() {
-        let side = side_exit(jit, state, GuardType(guard_type));
-
-        // Check special constant
-        asm.test(val, Opnd::UImm(RUBY_IMMEDIATE_MASK as u64));
-        asm.jnz(jit, side.clone());
-
-        // Check false
-        asm.cmp(val, Qfalse.into());
-        asm.je(jit, side.clone());
-
-        // Mask and check the builtin type
-        let val = asm.load_mem(val);
-        let flags = asm.load(Opnd::mem(VALUE_BITS, val, RUBY_OFFSET_RBASIC_FLAGS));
-        let tag   = asm.and(flags, Opnd::UImm(RUBY_T_MASK as u64));
-        asm.cmp(tag, Opnd::UImm(builtin_type as u64));
         asm.jne(jit, side);
     } else if guard_type.bit_equal(types::HeapBasicObject) {
         let side_exit = side_exit(jit, state, GuardType(guard_type));


### PR DESCRIPTION
After a8f3c34556bac709587ded4e0e4dad08932d5900 ("ZJIT: Add missing guard
on ivar access on T_{DATA,CLASS,MODULE}"), speed on getivar-module.rb in
ruby-bench regressed in speed to about 1/8. It turns out that the new
guard for Class was implemented as a guard over `RBasic::klass`, and the
one extra register pressure for the `rb_cClass` has regalloc spilling
and reloading a local each loop iteration, which is catastrophic for
performance.

`GuardType vN, Class` can be implemented as a check for T_CLASS in
RBasic::flags. It's less register pressure since the numeric value for
T_CLASS is small enough to fit in a native instruction immediate and it
also doesn't add GC marking work.

builtin_type_equivalent() is exactly as wide, so it's correct at any
position in the gen_guard_type() decision tree. Put it before the
runtime_exact_ruby_class() check.

This change recovers most of the speed on getivar-module.rb. Though the
old, incorrect guard still runs slightly faster since it checks less
things.
