### PR TITLE
Ensure version from bundled_gems is used in tool/rdoc-srcdir

### DIFF
--- a/tool/rdoc-srcdir
+++ b/tool/rdoc-srcdir
@@ -1,7 +1,16 @@
 #!ruby -W0
 
+srcdir = File.dirname(__dir__)
+bundled_gems = File.join(srcdir, "gems/bundled_gems")
+versions = {}
+File.foreach(bundled_gems) do |line|
+  next if line.start_with?("#") || line.strip.empty?
+  name, version, = line.split
+  versions[name] = version
+end
+
 %w[tsort rdoc].each do |lib|
-  path = Dir.glob("#{File.dirname(__dir__)}/.bundle/gems/#{lib}-*").first
+  path = File.join(srcdir, ".bundle/gems/#{lib}-#{versions[lib]}")
   $LOAD_PATH.unshift("#{path}/lib")
 end
 require 'rdoc/rdoc'


### PR DESCRIPTION
- `tool/rdoc-srcdir` used `Dir.glob(...).first` to find bundled gems (rdoc, tsort), which picks alphabetically. When multiple versions coexist in `.bundle/gems/` (e.g. `rdoc-7.1.0` and `rdoc-7.2.0`), it selects the wrong (older) one.
- Fix by reading the declared version from `gems/bundled_gems` and constructing the exact path, so the correct version is always loaded.