### PR TITLE
ZJIT: Trace infer_types as a sub-pass of other passes

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4344,7 +4344,7 @@ impl Function {
                 }
             }
         }
-        self.infer_types();
+        crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
     fn inline(&mut self) {
@@ -4398,7 +4398,7 @@ impl Function {
                 }
             }
         }
-        self.infer_types();
+        crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
     fn load_shape(&mut self, block: BlockId, recv: InsnId) -> InsnId {
@@ -4686,7 +4686,7 @@ impl Function {
                 }
             }
         }
-        self.infer_types();
+        crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
     fn gen_patch_points_for_optimized_ccall(&mut self, block: BlockId, recv_class: VALUE, method_id: ID, cme: *const rb_callable_method_entry_struct, state: InsnId) {
@@ -5005,7 +5005,7 @@ impl Function {
                 self.push_insn_id(block, insn_id);
             }
         }
-        self.infer_types();
+        crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
     /// Convert `Send` instructions with no profile data into `SideExit` with recompile info.
@@ -5504,7 +5504,7 @@ impl Function {
             changed = true;
         }
         if changed {
-            self.infer_types();
+            crate::stats::trace_compile_phase("infer_types", || self.infer_types());
         }
     }
 


### PR DESCRIPTION
This helps us see how much time it takes in compiler tracing.

<img width="667" height="132" alt="Screenshot 2026-04-10 at 11 54 59 AM" src="https://github.com/user-attachments/assets/959c4118-b7b9-4dba-a77e-bf4f7fa0d249" />
