### PR TITLE
ZJIT: YJIT: Refactor away transmute in Rust closure FFI code

### DIFF
--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -1843,22 +1843,24 @@ pub fn get_or_create_iseq_payload(iseq: IseqPtr) -> &'static mut IseqPayload {
 pub fn for_each_iseq<F: FnMut(IseqPtr)>(mut callback: F) {
     unsafe extern "C" fn callback_wrapper(iseq: IseqPtr, data: *mut c_void) {
         // SAFETY: points to the local below
-        let callback: &mut &mut dyn FnMut(IseqPtr) -> bool = unsafe { std::mem::transmute(&mut *data) };
-        callback(iseq);
+        let callback: *mut *mut dyn FnMut(IseqPtr) -> bool = data.cast();
+        unsafe { (**callback)(iseq) };
     }
-    let mut data: &mut dyn FnMut(IseqPtr) = &mut callback;
-    unsafe { rb_jit_for_each_iseq(Some(callback_wrapper), (&mut data) as *mut _ as *mut c_void) };
+    let mut data: *mut dyn FnMut(IseqPtr) = &mut callback;
+    let data: *mut *mut dyn FnMut(IseqPtr) = &mut data;
+    unsafe { rb_jit_for_each_iseq(Some(callback_wrapper), data.cast()) };
 }
 
 /// Iterate over all on-stack ISEQs
 pub fn for_each_on_stack_iseq<F: FnMut(IseqPtr)>(mut callback: F) {
     unsafe extern "C" fn callback_wrapper(iseq: IseqPtr, data: *mut c_void) {
         // SAFETY: points to the local below
-        let callback: &mut &mut dyn FnMut(IseqPtr) -> bool = unsafe { std::mem::transmute(&mut *data) };
-        callback(iseq);
+        let callback: *mut *mut dyn FnMut(IseqPtr) -> bool = data.cast();
+        unsafe { (**callback)(iseq) };
     }
-    let mut data: &mut dyn FnMut(IseqPtr) = &mut callback;
-    unsafe { rb_jit_cont_each_iseq(Some(callback_wrapper), (&mut data) as *mut _ as *mut c_void) };
+    let mut data: *mut dyn FnMut(IseqPtr) = &mut callback;
+    let data: *mut *mut dyn FnMut(IseqPtr) = &mut data;
+    unsafe { rb_jit_cont_each_iseq(Some(callback_wrapper), data.cast()) };
 }
 
 /// Iterate over all on-stack ISEQ payloads

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -320,11 +320,12 @@ pub fn iseq_rest_param_idx(params: &IseqParameters) -> Option<i32> {
 pub fn for_each_iseq<F: FnMut(IseqPtr)>(mut callback: F) {
     unsafe extern "C" fn callback_wrapper(iseq: IseqPtr, data: *mut c_void) {
         // SAFETY: points to the local below
-        let callback: &mut &mut dyn FnMut(IseqPtr) -> bool = unsafe { std::mem::transmute(&mut *data) };
-        callback(iseq);
+        let callback: *mut *mut dyn FnMut(IseqPtr) -> bool = data.cast();
+        unsafe { (**callback)(iseq) };
     }
-    let mut data: &mut dyn FnMut(IseqPtr) = &mut callback;
-    unsafe { rb_jit_for_each_iseq(Some(callback_wrapper), (&mut data) as *mut _ as *mut c_void) };
+    let mut data: *mut dyn FnMut(IseqPtr) = &raw mut callback;
+    let data: *mut *mut dyn FnMut(IseqPtr) = &raw mut data;
+    unsafe { rb_jit_for_each_iseq(Some(callback_wrapper), data.cast()) };
 }
 
 /// Return a poison value to be set above the stack top to verify leafness.

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -1218,24 +1218,24 @@ pub mod test_utils {
     pub fn with_rubyvm<T>(mut func: impl FnMut() -> T) -> T {
         RUBY_VM_INIT.call_once(boot_rubyvm);
 
-        // Set up a callback wrapper to store a return value
-        let mut result: Option<T> = None;
-        let mut data: &mut dyn FnMut() = &mut || {
-            // Store the result externally
-            result.replace(func());
-        };
-
         // Invoke callback through rb_protect() so exceptions don't crash the process.
         // "Fun" double pointer dance to get a thin function pointer to pass through C
         unsafe extern "C" fn callback_wrapper(data: VALUE) -> VALUE {
             // SAFETY: shorter lifetime than the data local in the caller frame
-            let callback: *mut &mut dyn FnMut() = std::ptr::with_exposed_provenance_mut(data.0);
-            unsafe { (*callback)() };
+            let callback: *const *mut dyn FnMut() = std::ptr::with_exposed_provenance_mut(data.0);
+            unsafe { (**callback)() };
             Qnil
         }
 
+        // Set up a callback wrapper to store the return value
+        let mut result: Option<T> = None;
+        let mut func_wrapper = || {
+            result.replace(func());
+        };
+        let data: *mut dyn FnMut() = &raw mut func_wrapper;
+        let data: *const *mut dyn FnMut() = &raw const data;
         let mut state: c_int = 0;
-        unsafe { super::rb_protect(Some(callback_wrapper), VALUE((&raw mut data).expose_provenance()), &mut state) };
+        unsafe { super::rb_protect(Some(callback_wrapper), VALUE(data.expose_provenance()), &mut state) };
         if state != 0 {
             unsafe { rb_zjit_print_exception(); }
             assert_eq!(0, state, "Exceptional unwind in callback. Ruby exception?");

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -1232,24 +1232,24 @@ pub mod test_utils {
     pub fn with_rubyvm<T>(mut func: impl FnMut() -> T) -> T {
         RUBY_VM_INIT.call_once(boot_rubyvm);
 
-        // Set up a callback wrapper to store a return value
-        let mut result: Option<T> = None;
-        let mut data: &mut dyn FnMut() = &mut || {
-            // Store the result externally
-            result.replace(func());
-        };
-
         // Invoke callback through rb_protect() so exceptions don't crash the process.
         // "Fun" double pointer dance to get a thin function pointer to pass through C
         unsafe extern "C" fn callback_wrapper(data: VALUE) -> VALUE {
             // SAFETY: shorter lifetime than the data local in the caller frame
-            let callback: *mut &mut dyn FnMut() = std::ptr::with_exposed_provenance_mut(data.0);
-            unsafe { (*callback)() };
+            let callback: *const *mut dyn FnMut() = std::ptr::with_exposed_provenance_mut(data.0);
+            unsafe { (**callback)() };
             Qnil
         }
 
+        // Set up a callback wrapper to store the return value
+        let mut result: Option<T> = None;
+        let mut func_wrapper = || {
+            result.replace(func());
+        };
+        let data: *mut dyn FnMut() = &raw mut func_wrapper;
+        let data: *const *mut dyn FnMut() = &raw const data;
         let mut state: c_int = 0;
-        unsafe { super::rb_protect(Some(callback_wrapper), VALUE((&raw mut data).expose_provenance()), &mut state) };
+        unsafe { super::rb_protect(Some(callback_wrapper), VALUE(data.expose_provenance()), &mut state) };
         if state != 0 {
             unsafe { rb_zjit_print_exception(); }
             assert_eq!(0, state, "Exceptional unwind in callback. Ruby exception?");

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -323,11 +323,12 @@ pub fn iseq_rest_param_idx(params: &IseqParameters) -> Option<i32> {
 pub fn for_each_iseq<F: FnMut(IseqPtr)>(mut callback: F) {
     unsafe extern "C" fn callback_wrapper(iseq: IseqPtr, data: *mut c_void) {
         // SAFETY: points to the local below
-        let callback: &mut &mut dyn FnMut(IseqPtr) -> bool = unsafe { std::mem::transmute(&mut *data) };
-        callback(iseq);
+        let callback: *mut *mut dyn FnMut(IseqPtr) -> bool = data.cast();
+        unsafe { (**callback)(iseq) };
     }
-    let mut data: &mut dyn FnMut(IseqPtr) = &mut callback;
-    unsafe { rb_jit_for_each_iseq(Some(callback_wrapper), (&mut data) as *mut _ as *mut c_void) };
+    let mut data: *mut dyn FnMut(IseqPtr) = &raw mut callback;
+    let data: *mut *mut dyn FnMut(IseqPtr) = &raw mut data;
+    unsafe { rb_jit_for_each_iseq(Some(callback_wrapper), data.cast()) };
 }
 
 /// Return a poison value to be set above the stack top to verify leafness.


### PR DESCRIPTION
```
commit 9dc831c0ca42d83a8e00ec4f62e2b639dae1738e (HEAD -> jits-transmute, shopify/jits-transmute)
Author:     Alan Wu <XrXr@users.noreply.github.com>
AuthorDate: Fri Apr 10 15:17:56 2026 -0400
Commit:     Alan Wu <XrXr@users.noreply.github.com>
CommitDate: Fri Apr 10 15:42:47 2026 -0400

    ZJIT: Prefer raw pointer over references in with_ruby_vm()
    
    When references show up on in the type declaration, it's an invitation
    to think about how long the lifetime implicit lifetime is. This code
    doesn't do anything tricky lifetime-wise, so it looks better declaring
    only raw pointers.

commit 545c046e9051c48f9a86cbcb8be78768404bf4a3
Author:     Alan Wu <XrXr@users.noreply.github.com>
AuthorDate: Fri Apr 10 15:05:20 2026 -0400
Commit:     Alan Wu <XrXr@users.noreply.github.com>
CommitDate: Fri Apr 10 15:39:40 2026 -0400

    ZJIT: Replace std::mem::transmute with pointer casting
    
    As the documentation puts it, transmute is "incredibly unsafe". We can
    express what we need to with pointer casts in these closure FFI
    situations, so let's use pointer casts.

commit 4b2fc7e0d5d49c31cf0187760a230b148bab456c
Author:     Alan Wu <XrXr@users.noreply.github.com>
AuthorDate: Fri Apr 10 15:05:20 2026 -0400
Commit:     Alan Wu <XrXr@users.noreply.github.com>
CommitDate: Fri Apr 10 15:11:08 2026 -0400

    YJIT: Replace std::mem::transmute with pointer casting
    
    As the documentation puts it, transmute is "incredibly unsafe". We can
    express what we need to with pointer casts in these closure FFI
    situations, so let's use pointer casts.
```