### PR TITLE
ZJIT: Annotate Float and Integer predicates

### DIFF
--- a/benchmark/float_predicate.yml
+++ b/benchmark/float_predicate.yml
@@ -1,0 +1,12 @@
+prelude: |
+  floats = [1.0, -1.0, 0.0, Float::NAN, Float::INFINITY, -Float::INFINITY]
+
+benchmark:
+  float_nan?: floats.each { |f| f.nan? }
+  float_finite?: floats.each { |f| f.finite? }
+  float_infinite?: floats.each { |f| f.infinite? }
+  float_zero?: floats.each { |f| f.zero? }
+  float_positive?: floats.each { |f| f.positive? }
+  float_negative?: floats.each { |f| f.negative? }
+
+loop_count: 1000000

--- a/benchmark/integer_predicate.yml
+++ b/benchmark/integer_predicate.yml
@@ -1,0 +1,9 @@
+prelude: |
+  nums = (0..9).to_a
+
+benchmark:
+  integer_zero?: nums.each { |n| n.zero? }
+  integer_even?: nums.each { |n| n.even? }
+  integer_odd?: nums.each { |n| n.odd? }
+
+loop_count: 1000000

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -266,9 +266,18 @@ pub fn init() -> Annotations {
     annotate!(rb_cInteger, "[]", inline_integer_aref);
     annotate!(rb_cInteger, "to_s", types::StringExact);
     annotate!(rb_cString, "to_s", inline_string_to_s, types::StringExact);
+    annotate!(rb_cFloat, "nan?", types::BoolExact, no_gc, leaf, elidable);
+    annotate!(rb_cFloat, "finite?", types::BoolExact, no_gc, leaf, elidable);
+    annotate!(rb_cFloat, "infinite?", types::Fixnum.union(types::NilClass), no_gc, leaf, elidable);
     let thread_singleton = unsafe { rb_singleton_class(rb_cThread) };
     annotate!(thread_singleton, "current", inline_thread_current, types::BasicObject, no_gc, leaf);
 
+    annotate_builtin!(rb_cInteger, "zero?", types::BoolExact);
+    annotate_builtin!(rb_cInteger, "even?", types::BoolExact);
+    annotate_builtin!(rb_cInteger, "odd?", types::BoolExact);
+    annotate_builtin!(rb_cFloat, "zero?", types::BoolExact);
+    annotate_builtin!(rb_cFloat, "positive?", types::BoolExact);
+    annotate_builtin!(rb_cFloat, "negative?", types::BoolExact);
     annotate_builtin!(rb_mKernel, "Float", types::Float);
     annotate_builtin!(rb_mKernel, "Integer", types::Integer);
     // TODO(max): Annotate rb_mKernel#class as returning types::Class. Right now there is a subtle

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -15647,4 +15647,228 @@ mod hir_opt_tests {
           Jump bb6(v81, v114)
         ");
     }
+
+    #[test]
+    fn test_float_nan_p_annotation() {
+        eval(r#"
+            def test(x) = x.nan?
+            test(1.0)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :x@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :x@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Float@0x1008, nan?@0x1010, cme:0x1018)
+          v23:Flonum = GuardType v10, Flonum
+          v24:BoolExact = CCall v23, :Float#nan?@0x1040
+          CheckInterrupts
+          Return v24
+        ");
+    }
+
+    #[test]
+    fn test_float_finite_p_annotation() {
+        eval(r#"
+            def test(x) = x.finite?
+            test(1.0)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :x@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :x@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Float@0x1008, finite?@0x1010, cme:0x1018)
+          v23:Flonum = GuardType v10, Flonum
+          v24:BoolExact = CCall v23, :Float#finite?@0x1040
+          CheckInterrupts
+          Return v24
+        ");
+    }
+
+    #[test]
+    fn test_float_infinite_p_annotation() {
+        eval(r#"
+            def test(x) = x.infinite?
+            test(1.0)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :x@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :x@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Float@0x1008, infinite?@0x1010, cme:0x1018)
+          v23:Flonum = GuardType v10, Flonum
+          v24:NilClass|Fixnum = CCall v23, :Float#infinite?@0x1040
+          CheckInterrupts
+          Return v24
+        ");
+    }
+
+    #[test]
+    fn test_integer_even_p_annotation() {
+        eval(r#"
+            def test(x) = x.even?
+            test(2)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :x@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :x@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Integer@0x1008, even?@0x1010, cme:0x1018)
+          v22:Fixnum = GuardType v10, Fixnum
+          v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
+          CheckInterrupts
+          Return v24
+        ");
+    }
+
+    #[test]
+    fn test_integer_odd_p_annotation() {
+        eval(r#"
+            def test(x) = x.odd?
+            test(3)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :x@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :x@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Integer@0x1008, odd?@0x1010, cme:0x1018)
+          v22:Fixnum = GuardType v10, Fixnum
+          v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
+          CheckInterrupts
+          Return v24
+        ");
+    }
+
+    #[test]
+    fn test_float_zero_p_annotation() {
+        eval(r#"
+            def test(x) = x.zero?
+            test(1.0)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :x@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :x@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Float@0x1008, zero?@0x1010, cme:0x1018)
+          v22:Flonum = GuardType v10, Flonum
+          v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
+          CheckInterrupts
+          Return v24
+        ");
+    }
+
+    #[test]
+    fn test_float_positive_p_annotation() {
+        eval(r#"
+            def test(x) = x.positive?
+            test(1.0)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :x@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :x@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Float@0x1008, positive?@0x1010, cme:0x1018)
+          v22:Flonum = GuardType v10, Flonum
+          v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
+          CheckInterrupts
+          Return v24
+        ");
+    }
+
+    #[test]
+    fn test_float_negative_p_annotation() {
+        eval(r#"
+            def test(x) = x.negative?
+            test(-1.0)
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:2:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :x@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :x@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          PatchPoint MethodRedefined(Float@0x1008, negative?@0x1010, cme:0x1018)
+          v22:Flonum = GuardType v10, Flonum
+          v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
+          CheckInterrupts
+          Return v24
+        ");
+    }
 }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -3512,7 +3512,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v14:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, zero?@0x1010, cme:0x1018)
-          v24:BasicObject = InvokeBuiltin leaf <inline_expr>, v14
+          v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v14
           CheckInterrupts
           Return v24
         ");


### PR DESCRIPTION
## Summary

Adds method annotations in `zjit/src/cruby_methods.rs` for pure
numeric predicates so ZJIT can:

1. Emit the fast `CCall` path (skip frame push/pop and GC safepoint)
   for `Float#nan?`, `Float#finite?`, `Float#infinite?`.
2. Propagate `BoolExact` return type for `Integer#zero?/even?/odd?`
   and `Float#zero?/positive?/negative?` builtin predicates, so
   downstream HIR passes can reason about boolean results.

All targeted C bodies are pure (`isnan`, `isfinite`, `isinf`, fixnum
bit tests, `FLOAT_ZERO_P`, `RFLOAT_VALUE` comparisons). No allocation,
no Ruby calls, no side effects. Safe to mark `leaf`, `no_gc`,
`elidable`.

## Benchmark

Tight `while` loop, 20M iters, `--zjit-call-threshold=2`, best of 5:

| predicate         | before  | after   | speedup |
|-------------------|---------|---------|---------|
| `Float#nan?`      | 0.140 s | 0.110 s | ~21%    |
| `Float#finite?`   | 0.145 s | 0.114 s | ~21%    |
| `Float#infinite?` | 0.129 s | 0.094 s | ~27%    |

Integer and Float builtin predicates do not show a direct speedup in
isolation (the builtin leaf path was already fast), but the return
type propagation enables guard and branch elimination in downstream
HIR passes.

## Test plan

- [x] `make test-all TESTS=test/ruby/test_zjit.rb` passes (28 tests, 0 failures)
- [x] HIR dump confirms `CCall` (not `CCallWithFrame`) for Float cfunc predicates
- [x] HIR dump confirms `BoolExact` return type on `InvokeBuiltin` for annotated builtin predicates
- [x] Smoke test of all six methods returns correct values under `--zjit`