### PR TITLE
Fixed the error message for `ibf_load_builtin`

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -12920,7 +12920,8 @@ ibf_load_builtin(const struct ibf_load *load, ibf_offset_t *offset)
     const struct rb_builtin_function *table = GET_VM()->builtin_function_table;
     if (table == NULL) rb_raise(rb_eArgError, "builtin function table is not provided");
     if (strncmp(table[i].name, name, len) != 0) {
-        rb_raise(rb_eArgError, "builtin function index (%d) mismatch (expect %s but %s)", i, name, table[i].name);
+        rb_raise(rb_eArgError, "builtin function index (%d) mismatch (expect %.*s but %s)",
+                 i, len, name, table[i].name);
     }
     // fprintf(stderr, "load-builtin: name:%s(%d)\n", table[i].name, table[i].argc);
 


### PR DESCRIPTION
`ibf_load_ptr` returns a pointer to the loaded data without a NUL terminator.  Like as the debug output above, the length of the loaded data must explicitly specified.