### PR TITLE
iseq.c: rb_estimate_iv_count handle no superclass

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -3027,7 +3027,9 @@ rb_estimate_iv_count(VALUE klass, const rb_iseq_t * initialize_iseq)
     attr_index_t count = (attr_index_t)iv_names.num_entries;
 
     VALUE superclass = rb_class_superclass(klass);
-    count += RCLASS_MAX_IV_COUNT(superclass);
+    if (!NIL_P(superclass)) { // BasicObject doesn't have a superclass
+        count += RCLASS_MAX_IV_COUNT(superclass);
+    }
 
     set_free_embedded_table(&iv_names);
 

--- a/test/ruby/test_super.rb
+++ b/test/ruby/test_super.rb
@@ -760,6 +760,20 @@ class TestSuper < Test::Unit::TestCase
     assert_equal 2, inherited.test # it may read index=1 while it should be index=2
   end
 
+  def test_define_initialize_in_basic_object
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      class ::BasicObject
+        alias_method :initialize, :initialize
+        def initialize
+          @bug = "[Bug #21992]"
+        end
+      end
+
+      assert_not_nil Object.new
+    end;
+  end
+
   def test_super_in_basic_object
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;


### PR DESCRIPTION
[[Bug #21992]](https://bugs.ruby-lang.org/issues/21992)

When redefining `BasicObject#initialize` there's no super class to access.