### PR TITLE
[3.2] iseq.c: rb_estimate_iv_count handle no superclass

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -2554,7 +2554,9 @@ rb_estimate_iv_count(VALUE klass, const rb_iseq_t * initialize_iseq)
     attr_index_t count = (attr_index_t)rb_id_table_size(iv_names);
 
     VALUE superclass = rb_class_superclass(klass);
-    count += RCLASS_EXT(superclass)->max_iv_count;
+    if (!NIL_P(superclass)) { // BasicObject doesn't have a superclass
+        count += RCLASS_EXT(superclass)->max_iv_count;
+    }
 
     rb_id_table_free(iv_names);
 

--- a/test/ruby/test_super.rb
+++ b/test/ruby/test_super.rb
@@ -726,4 +726,33 @@ class TestSuper < Test::Unit::TestCase
     inherited = inherited_class.new
     assert_equal 2, inherited.test # it may read index=1 while it should be index=2
   end
+
+  def test_define_initialize_in_basic_object
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      class ::BasicObject
+        alias_method :initialize, :initialize
+        def initialize
+          @bug = "[Bug #21992]"
+        end
+      end
+
+      assert_not_nil Object.new
+    end;
+  end
+
+  def test_super_in_basic_object
+    assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
+    begin;
+      class ::BasicObject
+        def no_super
+          super()
+        rescue ::NameError
+          :ok
+        end
+      end
+
+      assert_equal :ok, "[Bug #21694]".no_super
+    end;
+  end
 end


### PR DESCRIPTION
[Bug #21992]

When redefining `BasicObject#initialize` there's no super class to access.