### PR TITLE
Add rbs support to tool/rdoc-srcdir for make html

### DIFF
--- a/tool/rdoc-srcdir
+++ b/tool/rdoc-srcdir
@@ -9,10 +9,20 @@ File.foreach(bundled_gems) do |line|
   versions[name] = version
 end
 
-%w[tsort rdoc].each do |lib|
+%w[tsort logger rbs rdoc].each do |lib|
   path = File.join(srcdir, ".bundle/gems/#{lib}-#{versions[lib]}")
   $LOAD_PATH.unshift("#{path}/lib")
 end
+
+# Add compiled extension paths for bundled gems with C extensions.
+# These are built by `make build-ext` into .bundle/extensions/ but are not
+# on the default load path because `make html` runs with --disable-gems.
+builddir = Dir.pwd
+%w[rbs].each do |lib|
+  ext_path = Dir.glob("#{builddir}/.bundle/extensions/*/*/#{lib}-#{versions[lib]}").first
+  $LOAD_PATH.unshift(ext_path) if ext_path
+end
+
 require 'rdoc/rdoc'
 
 # Make only the output directory relative to the invoked directory.


### PR DESCRIPTION
Required change for https://github.com/ruby/rdoc/pull/1665 to work with `make html` in ruby/ruby.

RDoc PR #1665 adds RBS type signature support, which requires loading the `rbs` gem and its C extension `rbs_extension`. Currently `make html` fails because:

- `tool/rdoc-srcdir` doesn't include `rbs` or `logger` (rbs dependency) in the bundled gem load paths
- The `rbs_extension` C extension is compiled into `.bundle/extensions/` by `make build-ext`, but isn't on the load path since `make html` runs with `--disable-gems`

This PR adds `logger` and `rbs` to the gem lib path list, and adds the `.bundle/extensions/` path so the compiled C extension can be found.