### PR TITLE
Avoid atomic exchange in rb_free_tmp_buffer

### DIFF
--- a/imemo.c
+++ b/imemo.c
@@ -89,6 +89,7 @@ rb_alloc_tmp_buffer_with_count(volatile VALUE *store, size_t size, size_t cnt)
 void
 rb_free_tmp_buffer(volatile VALUE *store)
 {
+    if (!*store) return;
     rb_imemo_tmpbuf_t *s = (rb_imemo_tmpbuf_t*)ATOMIC_VALUE_EXCHANGE(*store, 0);
     if (s) {
         void *ptr = ATOMIC_PTR_EXCHANGE(s->ptr, 0);


### PR DESCRIPTION
Usually RB_ALLOCV_N uses alloca for small allocations, and in that case the value is 0, and we should not need to atomic exchange it back to 0.

I'm actually not sure why we need atomic operations here anyways. `store` should point at a VALUE on our stack. It was introduced in ec10c033a7f6ba4819b7a65eb31eba432028f28a