### PR TITLE
Avoid array resize in rb_obj_instance_variables

### DIFF
--- a/variable.c
+++ b/variable.c
@@ -2437,9 +2437,7 @@ ivar_i(ID key, VALUE v, st_data_t a)
 VALUE
 rb_obj_instance_variables(VALUE obj)
 {
-    VALUE ary;
-
-    ary = rb_ary_new();
+    VALUE ary = rb_ary_new_capa(rb_ivar_count(obj));
     rb_ivar_foreach(obj, ivar_i, ary);
     return ary;
 }


### PR DESCRIPTION
We know (an estimate of) the ivar count upfront (+/- hidden internal fields), from the shape, so we should reserve the expected length upfront.

I don't think the performance of `rb_obj_instance_variables` is especially important, but I need to make another change to `rb_ivar_foreach` and want to be able to benchmark it more accurately.