### PR TITLE
ZJIT: Fix getlocal with level=0 reading stale EP data

### DIFF
--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -5632,3 +5632,19 @@ fn test_loop_terminates() {
         end
     "#), @"3");
 }
+
+// Regression test: getlocal with level=0 after setlocal_WC_0 was loading stale EP
+// memory, causing Array#pack with buffer: keyword to receive the wrong buffer VALUE.
+// See https://github.com/ruby/ruby/pull/16736
+#[test]
+fn test_getlocal_level_zero_after_setlocal_wc_0() {
+    assert_snapshot!(inspect(r#"
+        def test
+          b = +"x"
+          v = 2
+          [v].pack("C*", buffer: b)
+          b.size
+        end
+        test
+    "#), @"2");
+}

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7363,8 +7363,18 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                 YARVINSN_getlocal => {
                     let ep_offset = get_arg(pc, 0).as_u32();
                     let level = get_arg(pc, 1).as_u32();
-                    let ep = fun.push_insn(block, Insn::GetEP { level });
-                    state.stack_push(fun.get_local_from_ep(block, ep, ep_offset, level, types::BasicObject));
+                    if level == 0 && !local_inval {
+                        // Same optimization as getlocal_WC_0: use FrameState
+                        let val = state.getlocal(ep_offset);
+                        state.stack_push(val);
+                    } else {
+                        let ep = fun.push_insn(block, Insn::GetEP { level });
+                        let val = fun.get_local_from_ep(block, ep, ep_offset, level, types::BasicObject);
+                        if level == 0 {
+                            state.setlocal(ep_offset, val);
+                        }
+                        state.stack_push(val);
+                    }
                 }
                 YARVINSN_setlocal => {
                     let ep_offset = get_arg(pc, 0).as_u32();

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -2900,10 +2900,8 @@ pub(crate) mod hir_build_tests {
           v31:StringExact = StringCopy v30
           v37:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
           v38:StringExact = StringCopy v37
-          v40:CPtr = GetEP 0
-          v41:BasicObject = LoadField v40, :buf@0x1018
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_PACK)
-          v44:String = ArrayPackBuffer v16, v17, fmt: v38, buf: v41
+          v42:String = ArrayPackBuffer v16, v17, fmt: v38, buf: v31
           PatchPoint NoEPEscape(test)
           CheckInterrupts
           Return v31
@@ -2949,8 +2947,6 @@ pub(crate) mod hir_build_tests {
           v31:StringExact = StringCopy v30
           v37:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
           v38:StringExact = StringCopy v37
-          v40:CPtr = GetEP 0
-          v41:BasicObject = LoadField v40, :buf@0x1018
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_PACK))
         ");
     }


### PR DESCRIPTION
## Summary

`YARVINSN_getlocal` with `level=0` always loaded from EP memory, but
`setlocal_WC_0` only updates the JIT FrameState without writing to EP.
When the Ruby compiler emits `getlocal` (non-WC variant) for a level=0
local after `setlocal_WC_0`, the EP load returned stale data.

The fix: when `level == 0` and locals are not invalidated, use the
FrameState value. This matches what `getlocal_WC_0` already does.

## Repro

```ruby
def test
  b = +"x"
  v = 2
  [v].pack("C*", buffer: b)
  b.size  # expected 2, got 1
end
```

Under `--zjit-call-threshold=1`, `b` was set via `setlocal_WC_0`
(FrameState only), then read via `getlocal b@0, 0` (EP load). The EP
still had nil/stale data, so `pack` received the wrong buffer VALUE.

This also fixes the flaky `btest` failure for `pack("E*", buffer:)`
with Float values that has been appearing in CI under
`--zjit-call-threshold=1`.

## Test plan

- [x] `make btest RUN_OPTS="--zjit-call-threshold=1"`: 2048/2048 PASS (was 2047)
- [x] `make zjit-test`: 1596 passed, 0 failed
- [x] `make test-all TESTS=test/ruby/test_zjit.rb`: 28 tests, 0 failures