### PR TITLE
Skip auto-request-review on Cargo.lock

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -11,7 +11,9 @@ files:
   'defs/jit.mk': [team:jit]
   'tool/zjit_bisect.rb': [team:jit]
   'doc/jit/*': [team:jit]
-  # Skip github workflow files because the team don't necessarily need to review dependabot updates for GitHub Actions. It's noisy in notifications, and they're auto-merged anyway.
+  # Skip files updated by dependabot. It's noisy in notifications, and they're auto-merged anyway.
+  'yjit/Cargo.lock': []
+  'zjit/Cargo.lock': []
   '.github/workflows/yjit-*.yml': []
   '.github/workflows/zjit-*.yml': []
 options:


### PR DESCRIPTION
This PR stops requesting a review from @ruby/jit for updates in `yjit/Cargo.lock` or `zjit/Cargo.lock`.

PRs like https://github.com/ruby/ruby/pull/16738 get auto-merged, so I don't want to get notifications for such PRs.