### PR TITLE
[DOC] Fix wrong hash key in calling_methods.rdoc example

### DIFF
--- a/doc/syntax/calling_methods.rdoc
+++ b/doc/syntax/calling_methods.rdoc
@@ -425,7 +425,7 @@ as keyword arguments:
 
   name = Name.new('Jane Doe')
   p(**name)
-  # Prints: {name: "Jane", last: "Doe"}
+  # Prints: {first: "Jane", last: "Doe"}
 
 Unlike <code>*</code> operator, <code>**</code> raises an error when used on an
 object that doesn't respond to <code>#to_hash</code>. The one exception is


### PR DESCRIPTION
The code example in the "Unpacking Keyword Arguments" section has a
`to_hash` method that returns `{first: ..., last: ...}`, but the
comment showing the output incorrectly uses `name` instead of `first`.

```diff
- # Prints: {name: "Jane", last: "Doe"}
+ # Prints: {first: "Jane", last: "Doe"}
```