### PR TITLE
Add Redmine ticket link comments to auto review PR

### DIFF
--- a/tool/auto_review_pr.rb
+++ b/tool/auto_review_pr.rb
@@ -38,6 +38,9 @@ class AutoReviewPR
   UPSTREAM_COMMENT_PREFIX = 'The following files are maintained in the following upstream repositories:'
   UPSTREAM_COMMENT_SUFFIX = 'Please file a pull request to the above instead. Thank you!'
 
+  REDMINE_TICKET_PATTERN = /\[(Bug|Feature|Misc)\s*#(\d+)\]/
+  REDMINE_COMMENT_PREFIX = 'This pull request references the following Redmine tickets:'
+
   FORK_COMMENT_PREFIX = 'It looks like this pull request was filed from a branch in ruby/ruby.'
   FORK_COMMENT_BODY = <<~COMMENT
     #{FORK_COMMENT_PREFIX}
@@ -59,6 +62,7 @@ class AutoReviewPR
     existing_comments = fetch_existing_comments(pr_number)
     review_non_fork_branch(pr_number, existing_comments)
     review_upstream_repos(pr_number, existing_comments)
+    review_redmine_links(pr_number, existing_comments)
   end
 
   private
@@ -118,6 +122,32 @@ class AutoReviewPR
     end
 
     post_comment(pr_number, format_upstream_comment(upstream_repos))
+  end
+
+  def review_redmine_links(pr_number, existing_comments)
+    if already_commented?(existing_comments, REDMINE_COMMENT_PREFIX)
+      puts "Skipped: The PR ##{pr_number} already has a Redmine links comment."
+      return
+    end
+
+    pr = @client.get("/repos/#{REPO}/pulls/#{pr_number}")
+    text = "#{pr[:title]}\n#{pr[:body]}"
+
+    tickets = text.scan(REDMINE_TICKET_PATTERN).uniq
+    if tickets.empty?
+      puts "Skipped: The PR ##{pr_number} doesn't reference any Redmine tickets."
+      return
+    end
+
+    post_comment(pr_number, format_redmine_comment(tickets))
+  end
+
+  def format_redmine_comment(tickets)
+    comment = +"#{REDMINE_COMMENT_PREFIX}\n\n"
+    tickets.each do |type, number|
+      comment << "* [#{type} ##{number}](https://bugs.ruby-lang.org/issues/#{number})\n"
+    end
+    comment
   end
 
   def format_upstream_comment(upstream_repos)

--- a/tool/auto_review_pr.rb
+++ b/tool/auto_review_pr.rb
@@ -60,9 +60,10 @@ class AutoReviewPR
 
   def review(pr_number)
     existing_comments = fetch_existing_comments(pr_number)
-    review_non_fork_branch(pr_number, existing_comments)
+    pr = @client.get("/repos/#{REPO}/pulls/#{pr_number}")
+    review_non_fork_branch(pr_number, pr, existing_comments)
     review_upstream_repos(pr_number, existing_comments)
-    review_redmine_links(pr_number, existing_comments)
+    review_redmine_links(pr_number, pr, existing_comments)
   end
 
   private
@@ -82,13 +83,12 @@ class AutoReviewPR
   end
 
   # Suggest re-filing from a fork if the PR branch is in ruby/ruby itself
-  def review_non_fork_branch(pr_number, existing_comments)
+  def review_non_fork_branch(pr_number, pr, existing_comments)
     if already_commented?(existing_comments, FORK_COMMENT_PREFIX)
       puts "Skipped: The PR ##{pr_number} already has a fork branch comment."
       return
     end
 
-    pr = @client.get("/repos/#{REPO}/pulls/#{pr_number}")
     head_repo = pr.dig(:head, :repo, :full_name)
     if head_repo != REPO
       puts "Skipped: The PR ##{pr_number} is already from a fork (#{head_repo})."
@@ -124,13 +124,12 @@ class AutoReviewPR
     post_comment(pr_number, format_upstream_comment(upstream_repos))
   end
 
-  def review_redmine_links(pr_number, existing_comments)
+  def review_redmine_links(pr_number, pr, existing_comments)
     if already_commented?(existing_comments, REDMINE_COMMENT_PREFIX)
       puts "Skipped: The PR ##{pr_number} already has a Redmine links comment."
       return
     end
 
-    pr = @client.get("/repos/#{REPO}/pulls/#{pr_number}")
     text = "#{pr[:title]}\n#{pr[:body]}"
 
     tickets = text.scan(REDMINE_TICKET_PATTERN).uniq


### PR DESCRIPTION
I often find myself manually copying and pasting `https://bugs.ruby-lang.org/issues/22003` into my browser when a PR title or body contains `[Bug #22003]`.

To save that effort, this adds an auto-comment that links directly to the corresponding bugs.ruby-lang.org issue whenever a Redmine ticket reference like `[Bug #22003]`, `[Feature #12345]`, or `[Misc #67890]` appears in a pull request.