### PR TITLE
Use BUILTIN_TYPE in rb_obj_gen_fields_p

### DIFF
--- a/shape.h
+++ b/shape.h
@@ -441,7 +441,7 @@ rb_shape_obj_has_fields(VALUE obj)
 static inline bool
 rb_obj_gen_fields_p(VALUE obj)
 {
-    switch (TYPE(obj)) {
+    switch (BUILTIN_TYPE(obj)) {
         case T_NONE:
         case T_OBJECT:
         case T_CLASS:


### PR DESCRIPTION
We know this is not called on special constants so it should be safe.