### PR TITLE
Remove check for special const in rb_obj_freeze

### DIFF
--- a/object.c
+++ b/object.c
@@ -1376,10 +1376,8 @@ VALUE
 rb_obj_freeze(VALUE obj)
 {
     if (!OBJ_FROZEN(obj)) {
+        RUBY_ASSERT(!RB_SPECIAL_CONST_P(obj));
         OBJ_FREEZE(obj);
-        if (SPECIAL_CONST_P(obj)) {
-            rb_bug("special consts should be frozen.");
-        }
     }
     return obj;
 }


### PR DESCRIPTION
This was introduced a long time ago when lots of internal changes were made to special consts (cc3088ea519).