### PR TITLE
ZJIT: Guard stack_topn and profile_stack against stack underflow

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -6549,7 +6549,9 @@ impl FrameState {
 
     /// Get a stack operand at idx
     fn stack_topn(&self, idx: usize) -> Result<InsnId, ParseError> {
-        let idx = self.stack.len() - idx - 1;
+        let Some(idx) = self.stack.len().checked_sub(idx + 1) else {
+            return Err(ParseError::StackUnderflow(self.clone()));
+        };
         self.stack.get(idx).ok_or_else(|| ParseError::StackUnderflow(self.clone())).copied()
     }
 
@@ -6717,10 +6719,14 @@ impl ProfileOracle {
         let iseq_insn_idx = state.insn_idx;
         let Some(operand_types) = self.payload.profile.get_operand_types(iseq_insn_idx) else { return };
         let entry = self.types.entry(iseq_insn_idx).or_default();
-        // operand_types is always going to be <= stack size (otherwise it would have an underflow
-        // at run-time) so use that to drive iteration.
+
+        // operand_types is generally <= stack size (otherwise it would underflow at run-time),
+        // but the inliner can reach this code by invoking iseq_to_hir on callee ISEQs whose
+        // profile was collected while the runtime stack held values our compile-time virtual
+        // stack does not yet carry. Skip any profile entries we cannot map without failing the
+        // whole compile.
         for (idx, insn_type_distribution) in operand_types.iter().rev().enumerate() {
-            let insn = state.stack_topn(idx + stack_offset).expect("Unexpected stack underflow in profiling");
+            let Ok(insn) = state.stack_topn(idx + stack_offset) else { break };
             entry.push((insn, TypeDistributionSummary::new(insn_type_distribution)))
         }
     }


### PR DESCRIPTION
`FrameState::stack_topn` computed its backing index as `self.stack.len() - idx - 1` before checking whether `idx` fell within bounds. When `idx` was greater than or equal to the stack length, the subtraction on `usize` underflowed and panicked, even though the function was supposed to surface the condition as a `ParseError::StackUnderflow`. The panic aborts the Ruby process, so any code path that hit this bug took the interpreter down with it rather than allowing `iseq_to_hir` to fail gracefully.

`ProfileOracle::profile_stack` then unwrapped the `stack_topn` result with `.expect("Unexpected stack underflow in profiling")`, on the premise that the number of profiled operands for an instruction can never exceed the depth of the compile-time virtual stack at that point. That invariant holds for the ISEQs ZJIT normally sees by call-threshold instrumentation, but it does not hold for every ISEQ the inliner hands to `iseq_to_hir`. Once a profiled callee with an operand mismatch reached `profile_stack`, the `expect` fired and crashed the process.

Both failures were encountered while running the liquid-render benchmark with inlining enabled, where the inliner compiles more ISEQs than the normal profiling path would.

Rework `stack_topn` to use `checked_sub` so it returns `ParseError::StackUnderflow` cleanly when the requested index is out of range, and change `profile_stack` to stop mapping profile entries at the first unmappable index instead of panicking. The compile may omit some profile-driven type information in this rare case, but the compilation completes and the rest of the pass can proceed.