### PR TITLE
Make `rb_enc_str_coderange` inlinable by default

### DIFF
--- a/include/ruby/internal/encoding/string.h
+++ b/include/ruby/internal/encoding/string.h
@@ -264,6 +264,14 @@ VALUE rb_str_conv_enc(VALUE str, rb_encoding *from, rb_encoding *to);
 VALUE rb_str_conv_enc_opts(VALUE str, rb_encoding *from, rb_encoding *to, int ecflags, VALUE ecopts);
 
 /**
+ * @private
+ *
+ * This is an implementation detail of rb_enc_str_coderange().  Don't use this
+ * directly.
+ **/
+int rbimpl_enc_str_coderange_scan(VALUE str);
+
+/**
  * Scans the passed string to collect  its code range.  Because a Ruby's string
  * is mutable, its contents  change from time to time; so  does its code range.
  * A  long-lived string  tends  to fall  back to  ::RUBY_ENC_CODERANGE_UNKNOWN.
@@ -273,6 +281,27 @@ VALUE rb_str_conv_enc_opts(VALUE str, rb_encoding *from, rb_encoding *to, int ec
  * @return      An enum ::ruby_coderange_type.
  */
 int rb_enc_str_coderange(VALUE str);
+
+/**
+ * Scans the passed string to collect  its code range.  Because a Ruby's string
+ * is mutable, its contents  change from time to time; so  does its code range.
+ * A  long-lived string  tends  to fall  back to  ::RUBY_ENC_CODERANGE_UNKNOWN.
+ * This API scans it and re-assigns a fine-grained code range constant.
+ *
+ * @param[out]  str  A string.
+ * @return      An enum ::ruby_coderange_type.
+ */
+static inline int
+rb_enc_str_coderange_inline(VALUE str)
+{
+    int cr = ENC_CODERANGE(str);
+    if (cr == ENC_CODERANGE_UNKNOWN) {
+        cr = rbimpl_enc_str_coderange_scan(str);
+    }
+    return cr;
+}
+
+#define rb_enc_str_coderange rb_enc_str_coderange_inline
 
 /**
  * Scans the passed string until it finds something odd.  Returns the number of

--- a/re.c
+++ b/re.c
@@ -1584,21 +1584,11 @@ reg_enc_error(VALUE re, VALUE str)
              rb_enc_inspect_name(rb_enc_get(str)));
 }
 
-static inline int
-str_coderange(VALUE str)
-{
-    int cr = ENC_CODERANGE(str);
-    if (cr == ENC_CODERANGE_UNKNOWN) {
-        cr = rb_enc_str_coderange(str);
-    }
-    return cr;
-}
-
 static rb_encoding*
 rb_reg_prepare_enc(VALUE re, VALUE str, int warn)
 {
     rb_encoding *enc = 0;
-    int cr = str_coderange(str);
+    int cr = rb_enc_str_coderange(str);
 
     if (cr == ENC_CODERANGE_BROKEN) {
         rb_raise(rb_eArgError,
@@ -3276,7 +3266,7 @@ rb_reg_preprocess_dregexp(VALUE ary, int options)
         src_enc = rb_enc_get(str);
         if (options & ARG_ENCODING_NONE &&
                 src_enc != ascii8bit) {
-            if (str_coderange(str) != ENC_CODERANGE_7BIT)
+            if (rb_enc_str_coderange(str) != ENC_CODERANGE_7BIT)
                 rb_raise(rb_eRegexpError, "/.../n has a non escaped non ASCII character in non ASCII-8BIT script");
             else
                 src_enc = ascii8bit;
@@ -3397,7 +3387,7 @@ rb_reg_initialize_str(VALUE obj, VALUE str, int options, onig_errmsg_buffer err,
     if (options & ARG_ENCODING_NONE) {
         rb_encoding *ascii8bit = rb_ascii8bit_encoding();
         if (enc != ascii8bit) {
-            if (str_coderange(str) != ENC_CODERANGE_7BIT) {
+            if (rb_enc_str_coderange(str) != ENC_CODERANGE_7BIT) {
                 errcpy(err, "/.../n has a non escaped non ASCII character in non ASCII-8BIT script");
                 return -1;
             }

--- a/string.c
+++ b/string.c
@@ -942,16 +942,25 @@ rb_enc_str_coderange_scan(VALUE str, rb_encoding *enc)
 }
 
 int
+rbimpl_enc_str_coderange_scan(VALUE str)
+{
+    int cr = enc_coderange_scan(str, get_encoding(str));
+    ENC_CODERANGE_SET(str, cr);
+    return cr;
+}
+
+#undef rb_enc_str_coderange
+int
 rb_enc_str_coderange(VALUE str)
 {
     int cr = ENC_CODERANGE(str);
 
     if (cr == ENC_CODERANGE_UNKNOWN) {
-        cr = enc_coderange_scan(str, get_encoding(str));
-        ENC_CODERANGE_SET(str, cr);
+        cr = rbimpl_enc_str_coderange_scan(str);
     }
     return cr;
 }
+#define rb_enc_str_coderange rb_enc_str_coderange_inline
 
 static inline bool
 rb_enc_str_asciicompat(VALUE str)

--- a/tool/leaked-globals
+++ b/tool/leaked-globals
@@ -96,7 +96,7 @@ Pipe.new(NM + ARGV).each do |line|
     next
   when /\Aruby_static_id_/
     next unless so
-  when /\A(?:RUBY_|ruby_|rb_)/
+  when /\A(?:RUBY_|ruby_|rb_|rbimpl_)/
     next unless so and /_(threadptr|ec)_/ =~ n
   when *SYMBOLS_IN_EMPTYLIB
     next


### PR DESCRIPTION
This is a generalization of the optimization done in re.c as part of d0fbdb005cecd8513aeacb234365d71f9a9b521e.

Code that deal with coderange can benefit significantly from avoiding that function call, assuming coderange is often already known.

Ref: https://github.com/ruby/json/pull/974