### PR TITLE
Remove discard qualifiers warning with C23 strchr

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -6487,7 +6487,7 @@ env_rassoc(VALUE dmy, VALUE obj)
 
         while (*env) {
             const char *p = *env;
-            char *s = strchr(p, '=');
+            const char *s = strchr(p, '=');
             if (s++) {
                 long len = strlen(s);
                 if (RSTRING_LEN(obj) == len && strncmp(s, RSTRING_PTR(obj), len) == 0) {
@@ -6707,7 +6707,7 @@ env_shift(VALUE _)
         char **env = GET_ENVIRON(environ);
         if (*env) {
             const char *p = *env;
-            char *s = strchr(p, '=');
+            const char *s = strchr(p, '=');
             if (s) {
                 key = env_str_new(p, s-p, enc);
                 VALUE val = env_str_new2(getenv(RSTRING_PTR(key)), enc);

--- a/load.c
+++ b/load.c
@@ -1712,7 +1712,7 @@ rb_ext_resolve_symbol(const char* fname, const char* symbol)
     VALUE handle;
     VALUE resolved;
     VALUE path;
-    char *ext;
+    const char *ext;
     VALUE fname_str = rb_str_new_cstr(fname);
     const rb_box_t *box = rb_loading_box();
 

--- a/ruby.c
+++ b/ruby.c
@@ -1373,7 +1373,7 @@ proc_0_option(ruby_cmdline_options_t *opt, const char *s)
 static void
 proc_encoding_option(ruby_cmdline_options_t *opt, const char *s, const char *opt_name)
 {
-    char *p;
+    const char *p;
 # define set_encoding_part(type) \
     if (!(p = strchr(s, ':'))) {                        \
         set_##type##_encoding_once(opt, s, 0);          \


### PR DESCRIPTION
C23 has qualifier-preserving standard library functions, so calling strchr with a `const char *` will return a `const char *`. We can change the type of the local variables because we don't mutate the strings.