### PR TITLE
Fix passing frozen_string_literal option to #compile_file backed by Prism

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -1916,16 +1916,30 @@ iseqw_s_compile_file_prism(int argc, VALUE *argv, VALUE self)
     rb_execution_context_t *ec = GET_EC();
     VALUE v = rb_vm_push_frame_fname(ec, file);
 
+    make_compile_option(&option, opt);
+
     pm_parse_result_t result;
     pm_parse_result_init(&result);
     result.node.coverage_enabled = 1;
+
+    switch (option.frozen_string_literal) {
+      case ISEQ_FROZEN_STRING_LITERAL_UNSET:
+        break;
+      case ISEQ_FROZEN_STRING_LITERAL_DISABLED:
+        pm_options_frozen_string_literal_set(result.options, false);
+        break;
+      case ISEQ_FROZEN_STRING_LITERAL_ENABLED:
+        pm_options_frozen_string_literal_set(result.options, true);
+        break;
+      default:
+        rb_bug("iseqw_s_compile_file_prism: invalid frozen_string_literal=%d", option.frozen_string_literal);
+        break;
+    }
 
     VALUE script_lines;
     VALUE error = pm_load_parse_file(&result, file, ruby_vm_keep_script_lines ? &script_lines : NULL);
 
     if (error == Qnil) {
-        make_compile_option(&option, opt);
-
         int error_state;
         rb_iseq_t *iseq = pm_iseq_new_with_opt(&result.node, rb_fstring_lit("<main>"),
                                                file,

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -355,6 +355,20 @@ class TestISeq < Test::Unit::TestCase
     assert_not_predicate(s4, :frozen?)
   end
 
+  def test_frozen_string_literal_compile_option_file
+    Tempfile.create(%w[fsl .rb]) do |f|
+      f.write("['foo', 'foo', \"\#{$f}foo\", \"\#{'foo'}\"]\n")
+      f.flush
+      $f = 'f'
+      s1, s2, s3, s4 = RubyVM::InstructionSequence
+        .compile_file(f.path, frozen_string_literal: true).eval
+      assert_predicate(s1, :frozen?)
+      assert_predicate(s2, :frozen?)
+      assert_not_predicate(s3, :frozen?)
+      assert_not_predicate(s4, :frozen?)
+    end
+  end
+
   # Safe call chain is not optimized when Coverage is running.
   # So we can test it only when Coverage is not running.
   def test_safe_call_chain


### PR DESCRIPTION
There is a regression in `RubyVM::InstructionSequence.compile_file` when Prism is used under the hood (i.e., `iseqw_s_compile_file_prism`). 

Given the following file (`a.rb`):

```ruby
# a.rb
"foo"
```

We can see that the `frozen_string_literal` compile flag is not recognized:

```sh
$ ./ruby -v
ruby 4.1.0dev (2026-04-21T07:40:39Z master 36a22e04b7) +PRISM [aarch64-linux]

$ ./ruby -e "puts RubyVM::InstructionSequence.compile_file('./a.rb', {frozen_string_literal: true}).eval.frozen?"
false

$ ruby -v
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +PRISM [aarch64-linux]

$ ruby -e "puts RubyVM::InstructionSequence.compile_file('./a.rb', {frozen_string_literal: true}).eval.frozen?"
true
```

This PRs adds setting the frozen_string_literal flag on the result object before parsing the file (similarly to how we do in `pm_iseq_compile_with_option`).