### PR TITLE
st.c: swiss-bins backend for hash implementation

### DIFF
--- a/benchmark/hash_aref_int_large.rb
+++ b/benchmark/hash_aref_int_large.rb
@@ -1,0 +1,4 @@
+h = {}
+keys = Array.new(16_384) { |i| i }
+keys.each { |k| h[k] = k }
+500.times { keys.each { |k| h[k] } }

--- a/benchmark/hash_aref_int_med.rb
+++ b/benchmark/hash_aref_int_med.rb
@@ -1,0 +1,4 @@
+h = {}
+keys = Array.new(256) { |i| i }
+keys.each { |k| h[k] = k }
+20_000.times { keys.each { |k| h[k] } }

--- a/benchmark/hash_aref_miss_large.rb
+++ b/benchmark/hash_aref_miss_large.rb
@@ -1,0 +1,5 @@
+h = {}
+present = Array.new(16_384) { |i| "k#{i}".freeze }
+present.each { |k| h[k] = k }
+missing = Array.new(16_384) { |i| "miss#{i}".freeze }
+500.times { missing.each { |k| h[k] } }

--- a/benchmark/hash_aref_miss_med.rb
+++ b/benchmark/hash_aref_miss_med.rb
@@ -1,0 +1,5 @@
+h = {}
+present = Array.new(256) { |i| "k#{i}".freeze }
+present.each { |k| h[k] = k }
+missing = Array.new(256) { |i| "miss#{i}".freeze }
+20_000.times { missing.each { |k| h[k] } }

--- a/benchmark/hash_aref_mix_50.rb
+++ b/benchmark/hash_aref_mix_50.rb
@@ -1,0 +1,6 @@
+h = {}
+present = Array.new(1024) { |i| "k#{i}".freeze }
+present.each { |k| h[k] = k }
+missing = Array.new(1024) { |i| "miss#{i}".freeze }
+mixed = Array.new(2048) { |i| i.even? ? present[i / 2] : missing[i / 2] }.freeze
+5_000.times { mixed.each { |k| h[k] } }

--- a/benchmark/hash_aref_str_large.rb
+++ b/benchmark/hash_aref_str_large.rb
@@ -1,0 +1,4 @@
+h = {}
+keys = Array.new(16_384) { |i| "k#{i}".freeze }
+keys.each { |k| h[k] = k }
+500.times { keys.each { |k| h[k] } }

--- a/benchmark/hash_aref_str_med.rb
+++ b/benchmark/hash_aref_str_med.rb
@@ -1,0 +1,4 @@
+h = {}
+keys = Array.new(256) { |i| "k#{i}".freeze }
+keys.each { |k| h[k] = k }
+20_000.times { keys.each { |k| h[k] } }

--- a/benchmark/hash_aref_sym_large.rb
+++ b/benchmark/hash_aref_sym_large.rb
@@ -1,0 +1,4 @@
+h = {}
+keys = Array.new(16_384) { |i| "k#{i}".to_sym }
+keys.each { |k| h[k] = k }
+500.times { keys.each { |k| h[k] } }

--- a/benchmark/hash_aref_sym_med.rb
+++ b/benchmark/hash_aref_sym_med.rb
@@ -1,0 +1,4 @@
+h = {}
+keys = Array.new(256) { |i| "k#{i}".to_sym }
+keys.each { |k| h[k] = k }
+20_000.times { keys.each { |k| h[k] } }

--- a/benchmark/hash_churn_med.rb
+++ b/benchmark/hash_churn_med.rb
@@ -1,0 +1,12 @@
+h = {}
+keys = Array.new(512) { |i| "k#{i}".freeze }
+keys[0, 256].each { |k| h[k] = k }
+
+i = 0
+2_000_000.times do
+  inkey = keys[i & 511]
+  outkey = keys[(i - 256) & 511]
+  h[inkey] = inkey
+  h.delete(outkey)
+  i += 1
+end

--- a/benchmark/hash_each_large.rb
+++ b/benchmark/hash_each_large.rb
@@ -1,0 +1,3 @@
+h = {}
+Array.new(16_384) { |i| "k#{i}".freeze }.each { |k| h[k] = k }
+500.times { h.each { |_k, _v| } }

--- a/benchmark/hash_each_med.rb
+++ b/benchmark/hash_each_med.rb
@@ -1,0 +1,3 @@
+h = {}
+Array.new(256) { |i| "k#{i}".freeze }.each { |k| h[k] = k }
+20_000.times { h.each { |_k, _v| } }

--- a/benchmark/hash_insert_large.rb
+++ b/benchmark/hash_insert_large.rb
@@ -1,0 +1,5 @@
+keys = Array.new(16_384) { |i| "k#{i}".freeze }
+500.times do
+  h = {}
+  keys.each { |k| h[k] = k }
+end

--- a/benchmark/hash_insert_med.rb
+++ b/benchmark/hash_insert_med.rb
@@ -1,0 +1,5 @@
+keys = Array.new(256) { |i| "k#{i}".freeze }
+30_000.times do
+  h = {}
+  keys.each { |k| h[k] = k }
+end

--- a/benchmark/hash_insert_small.rb
+++ b/benchmark/hash_insert_small.rb
@@ -1,0 +1,5 @@
+keys = Array.new(16) { |i| "k#{i}".freeze }
+500_000.times do
+  h = {}
+  keys.each { |k| h[k] = k }
+end

--- a/benchmark/hash_literal_med.rb
+++ b/benchmark/hash_literal_med.rb
@@ -1,0 +1,8 @@
+pairs = (0...256).map { |i| ":k#{i} => #{i}" }.join(', ')
+eval <<~RUBY
+  def make_hash_med
+    { #{pairs} }
+  end
+RUBY
+
+50_000.times { make_hash_med }

--- a/benchmark/hash_memsize.rb
+++ b/benchmark/hash_memsize.rb
@@ -1,0 +1,25 @@
+require 'objspace'
+
+# Reports ObjectSpace.memsize_of for hashes of various sizes. Intended to be
+# run with `benchmark-driver --runner memory` (the loop count is irrelevant
+# for memory measurement). The output line is parseable as a single Integer
+# for diff/regression purposes; the comments describe each size point.
+SIZES = [16, 64, 256, 1024, 16_384].freeze
+
+hashes = SIZES.map do |n|
+  h = {}
+  Array.new(n) { |i| "k#{i}".freeze }.each { |k| h[k] = k }
+  h
+end
+
+# Sum across all sizes -- a single number per run for trend tracking, plus
+# per-size detail printed via warn so it shows in --runner output streams.
+total = hashes.zip(SIZES).sum do |h, n|
+  size = ObjectSpace.memsize_of(h)
+  warn format('%-6d entries: %d bytes', n, size)
+  size
+end
+
+# Loop body kept minimal -- the benchmark-driver runner will execute this
+# repeatedly, but only object allocation cost matters for the memory runner.
+1_000.times { total }

--- a/configure.ac
+++ b/configure.ac
@@ -746,6 +746,32 @@ AC_ARG_ENABLE(devel,
     [AS_IF([test "x${RUBY_DEVEL-no}" != xyes], [RUBY_DEVEL=])]
 )dnl
 AC_SUBST(RUBY_DEVEL)
+
+# Experimental Swiss-table-style bins backend for st.c.
+# Disabled by default; preserves insertion-order semantics by leaving entries[]
+# untouched and only swapping the index layer. See st.c for details.
+AC_ARG_ENABLE(swiss-st,
+    AS_HELP_STRING([--disable-swiss-st],
+        [disable Swiss-table style bins in st.c. The Swiss layer adds a
+         parallel control-byte array (ctrl[]) and uses scalar SWAR group
+         probing for faster lookups, especially on miss-dominated workloads.
+         (default: yes)]),
+    [enable_swiss_st=$enableval], [enable_swiss_st=yes])
+AS_IF([test "x$enable_swiss_st" = xyes], [
+    AC_DEFINE(ST_USE_SWISS_BINS, 1)
+])
+
+# Opt-in measurement subsystem for st.c. When enabled at compile time, the
+# RUBY_ST_STATS environment variable activates it at runtime; the report is
+# written to /tmp/ruby_st_stats.<pid> on exit. Default builds incur zero
+# overhead.
+AC_ARG_ENABLE(st-stats,
+    AS_HELP_STRING([--enable-st-stats],
+        [compile in the st.c measurement subsystem (runtime gated by RUBY_ST_STATS, default: no)]),
+    [enable_st_stats=$enableval], [enable_st_stats=no])
+AS_IF([test "x$enable_st_stats" = xyes], [
+    AC_DEFINE(ST_STATS, 1)
+])
 particular_werror_flags=${RUBY_DEVEL:-no}
 AC_ARG_ENABLE(werror,
 	AS_HELP_STRING([--disable-werror],

--- a/include/ruby/st.h
+++ b/include/ruby/st.h
@@ -92,6 +92,15 @@ struct st_table {
     st_index_t entries_start, entries_bound;
     /* Array of size 2^entry_power.  */
     st_table_entry *entries;
+#ifdef ST_USE_SWISS_BINS
+    /* Swiss-style control bytes, parallel to bins[].
+     *   0xff  = empty
+     *   0xfe  = deleted (tombstone)
+     *   0x00..0x7f = occupied (top bit clear); value is H2 of the hash
+     * Only allocated when entry_power >= SWISS_MIN_ENTRY_POWER; NULL otherwise.
+     * The standard bins[] index layer is always allocated alongside it. */
+    unsigned char *ctrl;
+#endif
 };
 
 #define st_is_member(table,key) st_lookup((table),(key),(st_data_t *)0)

--- a/include/ruby/st.h
+++ b/include/ruby/st.h
@@ -100,6 +100,12 @@ struct st_table {
      * Only allocated when entry_power >= SWISS_MIN_ENTRY_POWER; NULL otherwise.
      * The standard bins[] index layer is always allocated alongside it. */
     unsigned char *ctrl;
+    /* Parallel hash array for entries[]. Stores the low 32 bits of each
+     * entry's hash so that st_table_entry can shrink from 24 B to 16 B
+     * (key + record only). One word per entry, allocated in lockstep with
+     * entries[]. The reserved value 0xFFFFFFFF marks a tombstone, mirroring
+     * the legacy RESERVED_HASH_VAL convention. */
+    uint32_t *hashes;
 #endif
 };
 

--- a/parser_st.c
+++ b/parser_st.c
@@ -13,6 +13,15 @@
 #undef RUBY
 #undef RUBY_EXPORT
 
+/* The parser_st variant does not adopt the Swiss-bins backend: it has a
+ * stable embedded layout that should not depend on Ruby's experimental
+ * --enable-swiss-st flag. */
+#undef ST_USE_SWISS_BINS
+
+/* The opt-in measurement subsystem is also disabled for parser_st to keep
+ * the parser self-contained and free of process-wide stats globals. */
+#undef ST_STATS
+
 #undef MEMCPY
 #define MEMCPY(p1,p2,type,n) nonempty_memcpy((p1), (p2), (sizeof(type) * (n)))
 /* The multiplication should not overflow since this macro is used

--- a/st.c
+++ b/st.c
@@ -197,6 +197,16 @@ static const struct st_hash_type type_strcasehash = {
         rebuilt_p = _old_rebuilds_num != (tab)->rebuilds_num;	    \
     } while (FALSE)
 
+#ifdef ST_USE_SWISS_BINS
+/* Forward-defined here so the bins_size / table init helpers below can
+ * see it; the rich documentation lives next to the rest of the Swiss
+ * machinery further down. Below this entry_power, do not use the
+ * Swiss-bins fast path. */
+#ifndef SWISS_MIN_ENTRY_POWER
+#define SWISS_MIN_ENTRY_POWER 6
+#endif
+#endif
+
 /* Features of a table.  */
 struct st_features {
     /* Power of 2 used for number of allocated entries.  */
@@ -479,11 +489,50 @@ get_allocated_entries(const st_table *tab)
     return ((st_index_t) 1)<<tab->entry_power;
 }
 
+#ifdef ST_USE_SWISS_BINS
+/* Returns true if the Swiss-bins fast path will be active for a table
+ * of the given entry_power. */
+static inline int
+swiss_active_for_power_p(unsigned char n)
+{
+    return n >= SWISS_MIN_ENTRY_POWER;
+}
+
+/* Effective bin_power for a table of the given entry_power. Swiss-active
+ * tables use a 1x bins[] (bin_power == entry_power) instead of the
+ * default 2x layout, so peak bins[] load tracks peak entries[] load.
+ * The rebuild trigger (see rebuild_table_if_necessary) caps the latter
+ * at ~7/8 so the SWAR empty-byte short-circuit keeps miss probes cheap.
+ * Non-Swiss tables (small ones, parser_st.c, --disable-swiss-st) use the
+ * features[] table unchanged. */
+static inline unsigned char
+table_bin_power_for(unsigned char n)
+{
+    return swiss_active_for_power_p(n) ? n : features[n].bin_power;
+}
+
+/* Effective bins[] storage size, in st_index_t words, for a table of
+ * the given entry_power. Halved for Swiss-active tables in lockstep
+ * with the bin_count change above. */
+static inline st_index_t
+table_bins_words_for(unsigned char n)
+{
+    if (swiss_active_for_power_p(n)) {
+        st_index_t w = features[n].bins_words;
+        return w == 0 ? 0 : (w + 1) / 2;
+    }
+    return features[n].bins_words;
+}
+#else
+# define table_bin_power_for(n)   (features[n].bin_power)
+# define table_bins_words_for(n)  (features[n].bins_words)
+#endif
+
 /* Return size of the allocated bins of table TAB.  */
 static inline st_index_t
 bins_size(const st_table *tab)
 {
-    return features[tab->entry_power].bins_words * sizeof (st_index_t);
+    return table_bins_words_for(tab->entry_power) * sizeof (st_index_t);
 }
 
 /* Mark all bins of table TAB as empty.  */
@@ -837,9 +886,12 @@ st_stats_dump(void)
  * perturb-chain or no-bins layout. Tunable; benchmark to refine.
  *
  * Floor: SWISS_MIN_ENTRY_POWER must guarantee bin_count >= ST_SWISS_GROUP_SIZE
- * so a single group load covers a full power-of-two slice. With the current
- * features[] table, entry_power=6 maps to bin_power=7 (bin_count=128), which
- * is comfortably above 8. */
+ * so a single group load covers a full power-of-two slice. Swiss-active
+ * tables override bin_power = entry_power (see table_bin_power_for), so at
+ * entry_power=6 we have bin_count=64 = 8 groups, the minimum that still
+ * makes triangular probing meaningful. The macro is forward-defined near
+ * the top of the file so the layout helpers can see it; the real
+ * documentation lives here. */
 #ifndef SWISS_MIN_ENTRY_POWER
 #define SWISS_MIN_ENTRY_POWER 6
 #endif
@@ -1021,7 +1073,10 @@ st_init_existing_table_with_size(st_table *tab, const struct st_hash_type *type,
 
     tab->type = type;
     tab->entry_power = n;
-    tab->bin_power = features[n].bin_power;
+    tab->bin_power = table_bin_power_for(n);
+    /* size_ind tracks the byte-width needed to store an entries[] index,
+     * which is bounded by 2^entry_power irrespective of bin_count, so it
+     * is unchanged when Swiss halves the bin_count. */
     tab->size_ind = features[n].size_ind;
     if (n <= MAX_POWER2_FOR_TABLES_WITHOUT_BINS)
         tab->bins = NULL;
@@ -1885,8 +1940,23 @@ static inline void
 rebuild_table_if_necessary (st_table *tab)
 {
     st_index_t bound = tab->entries_bound;
+    st_index_t cap = get_allocated_entries(tab);
 
-    if (bound == get_allocated_entries(tab))
+#ifdef ST_USE_SWISS_BINS
+    /* Swiss-active tables use bin_count == entries capacity (1x bins,
+     * not 2x), so peak bins[] load equals peak entries_bound load.
+     * Trigger a rebuild slightly before entries[] is full so bins[]
+     * never crosses ~7/8 occupied+tombstoned -- this keeps at least one
+     * EMPTY slot per 8-byte SWAR group on average, which is what makes
+     * the empty-byte short-circuit terminate miss probes cheaply. */
+    if (swiss_active_p(tab)) {
+        if (bound * 8 >= cap * 7)
+            rebuild_table(tab);
+        return;
+    }
+#endif
+
+    if (bound == cap)
         rebuild_table(tab);
 }
 

--- a/st.c
+++ b/st.c
@@ -134,11 +134,25 @@
 /* The type of hashes.  */
 typedef st_index_t st_hash_t;
 
+/* When the Swiss-bins backend is enabled, st_table_entry is shrunk from
+ * 24 B to 16 B by moving the per-entry hash into a parallel uint32_t array
+ * (tab->hashes, declared in st_table). Storing only the low 32 bits is fine
+ * for our needs: bin placement uses the full hash from do_hash() at probe
+ * time, and the stored value is only used as a fast pre-filter before
+ * EQUAL(). The 16 B layout doubles entries[]-per-cache-line density, which
+ * profiling identified as the dominant remaining hot-path cost. */
+#ifdef ST_USE_SWISS_BINS
+struct st_table_entry {
+    st_data_t key;
+    st_data_t record;
+};
+#else
 struct st_table_entry {
     st_hash_t hash;
     st_data_t key;
     st_data_t record;
 };
+#endif
 
 #define type_numhash st_hashtype_num
 static const struct st_hash_type st_hashtype_num = {
@@ -185,8 +199,34 @@ static const struct st_hash_type type_strcasehash = {
 #endif
 
 #define EQUAL(tab,x,y) ((x) == (y) || (*(tab)->type->compare)((x),(y)) == 0)
-#define PTR_EQUAL(tab, ptr, hash_val, key_) \
+
+/* Per-entry hash access. With the Swiss-bins backend, the hash lives in the
+ * parallel tab->hashes[] array (one uint32_t per entry); without it, each
+ * st_table_entry stores its own 64-bit hash inline. The macros below hide
+ * the difference so the bulk of st.c is layout-agnostic. */
+#ifdef ST_USE_SWISS_BINS
+typedef uint32_t st_hash32_t;
+# define ST_RESERVED_HASH32_VAL ((st_hash32_t)0xFFFFFFFFu)
+# define ST_HASH_AT_PTR(tab, ptr) \
+    ((tab)->hashes[(st_index_t)((ptr) - (tab)->entries)])
+# define ST_HASH_AT_IDX(tab, idx) ((tab)->hashes[(idx)])
+# define ST_HASH32_FROM(h) ((st_hash32_t)(h))
+/* For the compact-entry layout we keep the 32-bit hash check as a
+ * cheap prefilter before EQUAL (which can be expensive for strings,
+ * symbols, and other Object keys). It costs one extra load from a
+ * different cache line, which is hidden by the prefetch issued at the
+ * H2-match site and amortised when EQUAL would otherwise run a full
+ * string compare. */
+# define PTR_EQUAL(tab, ptr, hash_val, key_) \
+    (ST_HASH_AT_PTR((tab), (ptr)) == ST_HASH32_FROM(hash_val) \
+     && EQUAL((tab), (key_), (ptr)->key))
+#else
+# define ST_HASH_AT_PTR(tab, ptr) ((ptr)->hash)
+# define ST_HASH_AT_IDX(tab, idx) ((tab)->entries[(idx)].hash)
+# define ST_HASH32_FROM(h) (h)
+# define PTR_EQUAL(tab, ptr, hash_val, key_) \
     ((ptr)->hash == (hash_val) && EQUAL((tab), (key_), (ptr)->key))
+#endif
 
 /* As PTR_EQUAL only its result is returned in RES.  REBUILT_P is set
    up to TRUE if the table is rebuilt during the comparison.  */
@@ -194,6 +234,19 @@ static const struct st_hash_type type_strcasehash = {
     do {							    \
         unsigned int _old_rebuilds_num = (tab)->rebuilds_num;       \
         res = PTR_EQUAL(tab, ptr, hash_val, key);		    \
+        rebuilt_p = _old_rebuilds_num != (tab)->rebuilds_num;	    \
+    } while (FALSE)
+
+/* PTR_EQUAL/DO_PTR_EQUAL_CHECK family for the set_table_entry layout, which
+ * keeps the legacy {hash, key} inline form (no record/value, so it is already
+ * 16 B and there is nothing to compact). The set side does not use the Swiss
+ * fast path, so it has no parallel hashes[] array. */
+#define SET_PTR_EQUAL(tab, ptr, hash_val, key_) \
+    ((ptr)->hash == (hash_val) && EQUAL((tab), (key_), (ptr)->key))
+#define SET_DO_PTR_EQUAL_CHECK(tab, ptr, hash_val, key, res, rebuilt_p) \
+    do {							    \
+        unsigned int _old_rebuilds_num = (tab)->rebuilds_num;       \
+        res = SET_PTR_EQUAL(tab, ptr, hash_val, key);		    \
         rebuilt_p = _old_rebuilds_num != (tab)->rebuilds_num;	    \
     } while (FALSE)
 
@@ -338,7 +391,14 @@ static inline st_hash_t
 normalize_hash_value(st_hash_t hash)
 {
     /* RESERVED_HASH_VAL is used for a deleted entry.  Map it into
-       another value.  Such mapping should be extremely rare.  */
+       another value.  Such mapping should be extremely rare. With the
+       Swiss-bins layout the per-entry hash is truncated to its low 32 bits,
+       so we also nudge any hash whose low half happens to equal the 32-bit
+       reserved value off by one to avoid a tombstone aliasing collision. */
+#ifdef ST_USE_SWISS_BINS
+    if ((uint32_t)hash == 0xFFFFFFFFu)
+        return RESERVED_HASH_SUBSTITUTION_VAL;
+#endif
     return hash == RESERVED_HASH_VAL ? RESERVED_HASH_SUBSTITUTION_VAL : hash;
 }
 
@@ -448,10 +508,23 @@ set_bin(st_index_t *bins, int s, st_index_t n, st_index_t v)
 #define IND_DELETED_BIN_P(tab, i) (DELETED_BIN_P(get_bin((tab)->bins, get_size_ind(tab), i)))
 #define IND_EMPTY_OR_DELETED_BIN_P(tab, i) (EMPTY_OR_DELETED_BIN_P(get_bin((tab)->bins, get_size_ind(tab), i)))
 
-/* Macros for marking and checking deleted entries given by their
-   pointer E_PTR.  */
-#define MARK_ENTRY_DELETED(e_ptr) ((e_ptr)->hash = RESERVED_HASH_VAL)
-#define DELETED_ENTRY_P(e_ptr) ((e_ptr)->hash == RESERVED_HASH_VAL)
+/* Macros for marking and checking deleted entries given by their pointer
+ * E_PTR.  Both forms take the table because the Swiss-bins layout stores
+ * the per-entry hash (and therefore the tombstone marker) in the parallel
+ * tab->hashes[] array; the legacy non-Swiss layout still keeps it inline. */
+#ifdef ST_USE_SWISS_BINS
+# define MARK_ENTRY_DELETED(tab, e_ptr) \
+    (ST_HASH_AT_PTR((tab), (e_ptr)) = ST_RESERVED_HASH32_VAL)
+# define DELETED_ENTRY_P(tab, e_ptr) \
+    (ST_HASH_AT_PTR((tab), (e_ptr)) == ST_RESERVED_HASH32_VAL)
+#else
+# define MARK_ENTRY_DELETED(tab, e_ptr) ((e_ptr)->hash = RESERVED_HASH_VAL)
+# define DELETED_ENTRY_P(tab, e_ptr)    ((e_ptr)->hash == RESERVED_HASH_VAL)
+#endif
+
+/* set_table_entry keeps its hash inline (16 B already; nothing to compact). */
+#define SET_MARK_ENTRY_DELETED(e_ptr) ((e_ptr)->hash = RESERVED_HASH_VAL)
+#define SET_DELETED_ENTRY_P(e_ptr)    ((e_ptr)->hash == RESERVED_HASH_VAL)
 
 /* Return bin size index of table TAB.  */
 static inline unsigned int
@@ -905,11 +978,19 @@ st_stats_dump(void)
 #define ST_SWISS_CTRL_IS_EMPTY_OR_DELETED(c)  (((c) & (unsigned char)0x80) != 0)
 #define ST_SWISS_CTRL_IS_OCCUPIED(c)          (((c) & (unsigned char)0x80) == 0)
 
-/* H2 derivation: top 7 bits of the hash. */
+/* H2 derivation: bits 25..31 of the hash. We deliberately stay within
+ * the low 32 bits so that the parallel uint32_t hashes[] (see
+ * include/ruby/st.h) can be used as-is during rebuild without having
+ * to recompute the full 64-bit hash from the key. Bin selection
+ * (hash_bin) uses bits 0..bin_power-1, so as long as bin_power <= 25
+ * (32M bins) the H2 byte stays uncorrelated with the bin index. For
+ * the rare giant tables beyond that threshold, the H2 prefilter loses
+ * a little quality but lookups remain correct: PTR_EQUAL still falls
+ * through to a full key comparison. */
 static inline unsigned char
 st_swiss_h2(st_hash_t hash)
 {
-    return (unsigned char)((hash >> ((sizeof(st_hash_t) * 8) - 7)) & 0x7f);
+    return (unsigned char)((hash >> 25) & 0x7f);
 }
 
 /* Number of Swiss bin slots. Mirrors the bins layout: it is the actual number
@@ -1090,6 +1171,9 @@ st_init_existing_table_with_size(st_table *tab, const struct st_hash_type *type,
 #endif
     }
 #ifdef ST_USE_SWISS_BINS
+    /* Pre-NULL the parallel arrays so partial-failure cleanup paths
+     * (st_free_table -> st_free_entries) never touch garbage. */
+    tab->hashes = NULL;
     /* Allocate the parallel control-byte array only above the threshold.
      * Below it we fall through to the existing perturb-chain logic. */
     if (tab->bins != NULL && n >= SWISS_MIN_ENTRY_POWER) {
@@ -1113,6 +1197,16 @@ st_init_existing_table_with_size(st_table *tab, const struct st_hash_type *type,
         st_free_table(tab);
         return NULL;
     }
+#endif
+#ifdef ST_USE_SWISS_BINS
+    tab->hashes = (uint32_t *) malloc(get_allocated_entries(tab)
+                                      * sizeof(uint32_t));
+#ifndef RUBY
+    if (tab->hashes == NULL) {
+        st_free_table(tab);
+        return NULL;
+    }
+#endif
 #endif
     make_tab_empty(tab);
     tab->rebuilds_num = 0;
@@ -1242,12 +1336,22 @@ st_ctrl_memsize(const st_table *tab)
 {
     return tab->ctrl == NULL ? 0 : swiss_ctrl_alloc_size(tab);
 }
+
+static inline size_t
+st_hashes_memsize(const st_table *tab)
+{
+    return get_allocated_entries(tab) * sizeof(uint32_t);
+}
 #endif
 
 static inline void
 st_free_entries(const st_table *tab)
 {
     sized_free(tab->entries, st_entries_memsize(tab));
+#ifdef ST_USE_SWISS_BINS
+    if (tab->hashes != NULL)
+        sized_free(tab->hashes, st_hashes_memsize(tab));
+#endif
 }
 
 static inline void
@@ -1284,6 +1388,7 @@ st_memsize(const st_table *tab)
            + st_bins_memsize(tab)
 #ifdef ST_USE_SWISS_BINS
            + st_ctrl_memsize(tab)
+           + (tab->hashes == NULL ? 0 : st_hashes_memsize(tab))
 #endif
            + st_entries_memsize(tab));
 }
@@ -1403,15 +1508,21 @@ rebuild_table_with(st_table *const new_tab, st_table *const tab)
     for (i = tab->entries_start; i < bound; i++) {
         curr_entry_ptr = &entries[i];
         PREFETCH(entries + i + 1, 0);
-        if (EXPECT(DELETED_ENTRY_P(curr_entry_ptr), 0))
+        if (EXPECT(DELETED_ENTRY_P(tab, curr_entry_ptr), 0))
             continue;
+        /* The stored 32-bit hash is enough for hash_bin() (bin_power is
+         * almost always <= 25 in practice) and for st_swiss_h2() (we
+         * derive H2 from bits 25..31 -- see st_swiss_h2 above). No need
+         * to recompute via do_hash here. */
+        st_hash_t curr_hash = ST_HASH_AT_IDX(tab, i);
         if (&new_entries[ni] != curr_entry_ptr)
             new_entries[ni] = *curr_entry_ptr;
+        ST_HASH_AT_IDX(new_tab, ni) = ST_HASH32_FROM(curr_hash);
         if (EXPECT(bins != NULL, 1)) {
-            bin_ind = find_table_bin_ind_direct(new_tab, curr_entry_ptr->hash,
+            bin_ind = find_table_bin_ind_direct(new_tab, curr_hash,
                                                 curr_entry_ptr->key);
             set_bin(bins, size_ind, bin_ind, ni + ENTRY_BASE);
-            SWISS_SET_CTRL_OCCUPIED(new_tab, bin_ind, curr_entry_ptr->hash);
+            SWISS_SET_CTRL_OCCUPIED(new_tab, bin_ind, curr_hash);
         }
         new_tab->num_entries++;
         ni++;
@@ -1432,6 +1543,7 @@ rebuild_move_table(st_table *const new_tab, st_table *const tab)
     tab->bins = new_tab->bins;
 #ifdef ST_USE_SWISS_BINS
     tab->ctrl = new_tab->ctrl;
+    tab->hashes = new_tab->hashes;
 #endif
     tab->entries = new_tab->entries;
     free_fixed_ptr(new_tab);
@@ -1531,6 +1643,11 @@ find_table_entry_ind(st_table *tab, st_hash_t hash_value, st_data_t key)
                 st_index_t cand_bin_ind = group_idx + slot;
                 st_index_t cand_bin = get_bin(tab->bins, swiss_size_ind, cand_bin_ind);
                 if (EXPECT(!EMPTY_OR_DELETED_BIN_P(cand_bin), 1)) {
+                    /* H2 matched: pull the entry's key/record cache line
+                     * (and the parallel hash slot) ahead of PTR_EQUAL so
+                     * the comparison can overlap with the memory fetch. */
+                    PREFETCH(&entries[cand_bin - ENTRY_BASE], 0);
+                    PREFETCH(&tab->hashes[cand_bin - ENTRY_BASE], 0);
                     DO_PTR_EQUAL_CHECK(tab, &entries[cand_bin - ENTRY_BASE],
                                        hash_value, key, eq_p, rebuilt_p);
                     if (EXPECT(rebuilt_p, 0))
@@ -1619,6 +1736,10 @@ find_table_bin_ind(st_table *tab, st_hash_t hash_value, st_data_t key)
                 st_index_t cand_bin_ind = group_idx + slot;
                 st_index_t cand_bin = get_bin(tab->bins, swiss_size_ind, cand_bin_ind);
                 if (EXPECT(!EMPTY_OR_DELETED_BIN_P(cand_bin), 1)) {
+                    /* H2 matched: prefetch the entry/hashes line so the
+                     * PTR_EQUAL load can overlap with memory latency. */
+                    PREFETCH(&entries[cand_bin - ENTRY_BASE], 0);
+                    PREFETCH(&tab->hashes[cand_bin - ENTRY_BASE], 0);
                     DO_PTR_EQUAL_CHECK(tab, &entries[cand_bin - ENTRY_BASE],
                                        hash_value, key, eq_p, rebuilt_p);
                     if (EXPECT(rebuilt_p, 0))
@@ -1781,6 +1902,10 @@ find_table_bin_ptr_and_reserve(st_table *tab, st_hash_t *hash_value,
                 st_index_t cand_bin_ind = group_idx + slot;
                 st_index_t cand_entry = get_bin(tab->bins, swiss_size_ind, cand_bin_ind);
                 if (EXPECT(!EMPTY_OR_DELETED_BIN_P(cand_entry), 1)) {
+                    /* H2 matched: prefetch the entry/hashes line so the
+                     * PTR_EQUAL load can overlap with memory latency. */
+                    PREFETCH(&entries[cand_entry - ENTRY_BASE], 0);
+                    PREFETCH(&tab->hashes[cand_entry - ENTRY_BASE], 0);
                     DO_PTR_EQUAL_CHECK(tab, &entries[cand_entry - ENTRY_BASE],
                                        curr_hash_value, key, eq_p, rebuilt_p);
                     if (EXPECT(rebuilt_p, 0))
@@ -1998,7 +2123,7 @@ st_insert(st_table *tab, st_data_t key, st_data_t value)
     if (new_p) {
         ind = tab->entries_bound++;
         entry = &tab->entries[ind];
-        entry->hash = hash_value;
+        ST_HASH_AT_IDX(tab, ind) = ST_HASH32_FROM(hash_value);
         entry->key = key;
         entry->record = value;
         if (bin_ind != UNDEFINED_BIN_IND) {
@@ -2026,7 +2151,7 @@ st_add_direct_with_hash(st_table *tab,
     rebuild_table_if_necessary(tab);
     ind = tab->entries_bound++;
     entry = &tab->entries[ind];
-    entry->hash = hash;
+    ST_HASH_AT_IDX(tab, ind) = ST_HASH32_FROM(hash);
     entry->key = key;
     entry->record = value;
     tab->num_entries++;
@@ -2095,7 +2220,7 @@ st_insert2(st_table *tab, st_data_t key, st_data_t value,
         key = (*func)(key);
         ind = tab->entries_bound++;
         entry = &tab->entries[ind];
-        entry->hash = hash_value;
+        ST_HASH_AT_IDX(tab, ind) = ST_HASH32_FROM(hash_value);
         entry->key = key;
         entry->record = value;
         if (bin_ind != UNDEFINED_BIN_IND) {
@@ -2144,6 +2269,17 @@ st_replace(st_table *new_tab, st_table *old_tab)
         return NULL;
     }
 #endif
+#ifdef ST_USE_SWISS_BINS
+    new_tab->hashes = (uint32_t *) malloc(get_allocated_entries(old_tab)
+                                          * sizeof(uint32_t));
+#ifndef RUBY
+    if (new_tab->hashes == NULL) {
+        return NULL;
+    }
+#endif
+    MEMCPY(new_tab->hashes, old_tab->hashes, uint32_t,
+           get_allocated_entries(old_tab));
+#endif
     MEMCPY(new_tab->entries, old_tab->entries, st_table_entry,
            get_allocated_entries(old_tab));
     if (old_tab->bins != NULL)
@@ -2188,7 +2324,7 @@ update_range_for_deleted(st_table *tab, st_index_t n)
         st_index_t start = n + 1;
         st_index_t bound = tab->entries_bound;
         st_table_entry *entries = tab->entries;
-        while (start < bound && DELETED_ENTRY_P(&entries[start])) start++;
+        while (start < bound && DELETED_ENTRY_P(tab, &entries[start])) start++;
         tab->entries_start = start;
     }
 }
@@ -2230,7 +2366,7 @@ st_general_delete(st_table *tab, st_data_t *key, st_data_t *value)
     entry = &tab->entries[bin];
     *key = entry->key;
     if (value != 0) *value = entry->record;
-    MARK_ENTRY_DELETED(entry);
+    MARK_ENTRY_DELETED(tab, entry);
     tab->num_entries--;
     update_range_for_deleted(tab, bin);
     return 1;
@@ -2276,9 +2412,14 @@ st_shift(st_table *tab, st_data_t *key, st_data_t *value)
     bound = tab->entries_bound;
     for (i = tab->entries_start; i < bound; i++) {
         curr_entry_ptr = &entries[i];
-        if (! DELETED_ENTRY_P(curr_entry_ptr)) {
-            st_hash_t entry_hash = curr_entry_ptr->hash;
+        if (! DELETED_ENTRY_P(tab, curr_entry_ptr)) {
             st_data_t entry_key = curr_entry_ptr->key;
+            /* Recompute the full hash from the key. With the Swiss-bins
+             * layout the per-entry hash is truncated to 32 bits, which
+             * is sufficient for hash_bin() (bin_power <= 25 in
+             * practice) and for st_swiss_h2() since H2 lives in bits
+             * 25..31 of the 32-bit truncation. */
+            st_hash_t entry_hash = ST_HASH_AT_PTR(tab, curr_entry_ptr);
 
             if (value != 0) *value = curr_entry_ptr->record;
             *key = entry_key;
@@ -2301,7 +2442,7 @@ st_shift(st_table *tab, st_data_t *key, st_data_t *value)
                                           - ENTRY_BASE];
                 MARK_BIN_DELETED(tab, bin_ind);
             }
-            MARK_ENTRY_DELETED(curr_entry_ptr);
+            MARK_ENTRY_DELETED(tab, curr_entry_ptr);
             tab->num_entries--;
             update_range_for_deleted(tab, i);
             return 1;
@@ -2392,7 +2533,7 @@ st_update(st_table *tab, st_data_t key,
         if (existing) {
             if (bin_ind != UNDEFINED_BIN_IND)
                 MARK_BIN_DELETED(tab, bin_ind);
-            MARK_ENTRY_DELETED(entry);
+            MARK_ENTRY_DELETED(tab, entry);
             tab->num_entries--;
             update_range_for_deleted(tab, bin);
         }
@@ -2423,15 +2564,21 @@ st_general_foreach(st_table *tab, st_foreach_check_callback_func *func, st_updat
     int error_p, packed_p = tab->bins == NULL;
 
     entries = tab->entries;
+    int hash_known = 0;
     /* The bound can change inside the loop even without rebuilding
        the table, e.g. by an entry insertion.  */
     for (i = tab->entries_start; i < tab->entries_bound; i++) {
         curr_entry_ptr = &entries[i];
-        if (EXPECT(DELETED_ENTRY_P(curr_entry_ptr), 0))
+        if (EXPECT(DELETED_ENTRY_P(tab, curr_entry_ptr), 0))
             continue;
         key = curr_entry_ptr->key;
         rebuilds_num = tab->rebuilds_num;
-        hash = curr_entry_ptr->hash;
+        /* Capture the per-entry hash up front so the post-rebuild and
+         * ST_DELETE branches can reuse it without calling do_hash() on
+         * the key again. The 32-bit truncation is fine for both
+         * hash_bin() and st_swiss_h2() (see comment on st_swiss_h2). */
+        hash = ST_HASH_AT_PTR(tab, curr_entry_ptr);
+        hash_known = 1;
         retval = (*func)(key, curr_entry_ptr->record, arg, 0);
 
         if (retval == ST_REPLACE && replace) {
@@ -2443,6 +2590,10 @@ st_general_foreach(st_table *tab, st_foreach_check_callback_func *func, st_updat
         }
 
         if (rebuilds_num != tab->rebuilds_num) {
+            /* The callback caused a rebuild; entries[] indices may have
+             * shifted, but `hash` (captured above from the parallel
+             * hashes[] array) is still the correct value for `key`
+             * since do_hash is deterministic. Re-find by hash + key. */
         retry:
             entries = tab->entries;
             packed_p = tab->bins == NULL;
@@ -2478,6 +2629,7 @@ st_general_foreach(st_table *tab, st_foreach_check_callback_func *func, st_updat
             return 0;
           case ST_DELETE: {
             st_data_t key = curr_entry_ptr->key;
+            /* hash was captured from hashes[] at the top of the loop. */
 
               again:
             if (packed_p) {
@@ -2497,13 +2649,15 @@ st_general_foreach(st_table *tab, st_foreach_check_callback_func *func, st_updat
                 MARK_BIN_DELETED(tab, bin_ind);
             }
             curr_entry_ptr = &entries[bin];
-            MARK_ENTRY_DELETED(curr_entry_ptr);
+            MARK_ENTRY_DELETED(tab, curr_entry_ptr);
             tab->num_entries--;
             update_range_for_deleted(tab, bin);
             break;
           }
         }
     }
+    (void)hash;
+    (void)hash_known;
     return 0;
 }
 
@@ -2557,7 +2711,7 @@ st_general_keys(st_table *tab, st_data_t *keys, st_index_t size)
             break;
         curr_entry_ptr = &entries[i];
         key = curr_entry_ptr->key;
-        if (! DELETED_ENTRY_P(curr_entry_ptr))
+        if (! DELETED_ENTRY_P(tab, curr_entry_ptr))
             *keys++ = key;
     }
 
@@ -2594,7 +2748,7 @@ st_general_values(st_table *tab, st_data_t *values, st_index_t size)
         if (values == values_end)
             break;
         curr_entry_ptr = &entries[i];
-        if (! DELETED_ENTRY_P(curr_entry_ptr))
+        if (! DELETED_ENTRY_P(tab, curr_entry_ptr))
             *values++ = curr_entry_ptr->record;
     }
 
@@ -3006,6 +3160,11 @@ st_expand_table(st_table *tab, st_index_t siz)
     tmp = st_init_table_with_size(tab->type, siz);
     n = get_allocated_entries(tab);
     MEMCPY(tmp->entries, tab->entries, st_table_entry, n);
+#ifdef ST_USE_SWISS_BINS
+    /* Carry the parallel hashes[] over too, otherwise PTR_EQUAL on the
+     * expanded table would compare against zeroed-out hash slots. */
+    MEMCPY(tmp->hashes, tab->hashes, uint32_t, n);
+#endif
     st_free_bins(tab);
     st_free_entries(tab);
     st_free_bins(tmp);
@@ -3017,6 +3176,7 @@ st_expand_table(st_table *tab, st_index_t siz)
     tab->bins = NULL;
 #ifdef ST_USE_SWISS_BINS
     tab->ctrl = NULL;
+    tab->hashes = tmp->hashes;
 #endif
     tab->rebuilds_num++;
     free_fixed_ptr(tmp);
@@ -3039,18 +3199,21 @@ st_rehash_linear(st_table *tab)
 
     for (i = tab->entries_start; i < tab->entries_bound; i++) {
         p = &tab->entries[i];
-        if (DELETED_ENTRY_P(p))
+        if (DELETED_ENTRY_P(tab, p))
             continue;
         for (j = i + 1; j < tab->entries_bound; j++) {
             q = &tab->entries[j];
-            if (DELETED_ENTRY_P(q))
+            if (DELETED_ENTRY_P(tab, q))
                 continue;
-            DO_PTR_EQUAL_CHECK(tab, p, q->hash, q->key, eq_p, rebuilt_p);
+            DO_PTR_EQUAL_CHECK(tab, p, ST_HASH_AT_PTR(tab, q), q->key, eq_p, rebuilt_p);
             if (EXPECT(rebuilt_p, 0))
                 return TRUE;
             if (eq_p) {
+                /* Move q's hash into p's slot before overwriting the entry
+                 * (the parallel hashes[] is keyed by entry index). */
+                ST_HASH_AT_PTR(tab, p) = ST_HASH_AT_PTR(tab, q);
                 *p = *q;
-                MARK_ENTRY_DELETED(q);
+                MARK_ENTRY_DELETED(tab, q);
                 tab->num_entries--;
                 update_range_for_deleted(tab, j);
             }
@@ -3084,33 +3247,38 @@ st_rehash_indexed(st_table *tab)
     for (i = tab->entries_start; i < tab->entries_bound; i++) {
         st_table_entry *p = &tab->entries[i];
         st_index_t ind;
+
+        if (DELETED_ENTRY_P(tab, p))
+            continue;
+
+        /* The stored 32-bit hash is sufficient for hash_bin() and for
+         * st_swiss_h2() (see comment on st_swiss_h2). No need to call
+         * do_hash again. */
+        st_hash_t fresh = ST_HASH_AT_IDX(tab, i);
 #ifdef QUADRATIC_PROBE
         st_index_t d = 1;
 #else
-        st_index_t perturb = p->hash;
+        st_index_t perturb = fresh;
 #endif
 
-        if (DELETED_ENTRY_P(p))
-            continue;
-
-        ind = hash_bin(p->hash, tab);
+        ind = hash_bin(fresh, tab);
         for (;;) {
             st_index_t bin = get_bin(tab->bins, size_ind, ind);
             if (EMPTY_OR_DELETED_BIN_P(bin)) {
                 /* ok, new room */
                 set_bin(tab->bins, size_ind, ind, i + ENTRY_BASE);
-                SWISS_SET_CTRL_OCCUPIED(tab, ind, p->hash);
+                SWISS_SET_CTRL_OCCUPIED(tab, ind, fresh);
                 break;
             }
             else {
                 st_table_entry *q = &tab->entries[bin - ENTRY_BASE];
-                DO_PTR_EQUAL_CHECK(tab, q, p->hash, p->key, eq_p, rebuilt_p);
+                DO_PTR_EQUAL_CHECK(tab, q, fresh, p->key, eq_p, rebuilt_p);
                 if (EXPECT(rebuilt_p, 0))
                     return TRUE;
                 if (eq_p) {
                     /* duplicated key; delete it */
                     q->record = p->record;
-                    MARK_ENTRY_DELETED(p);
+                    MARK_ENTRY_DELETED(tab, p);
                     tab->num_entries--;
                     update_range_for_deleted(tab, bin);
                     break;
@@ -3157,12 +3325,11 @@ static void
 st_insert_single(st_table *tab, VALUE hash, VALUE key, VALUE val)
 {
     st_data_t k = st_stringify(key);
-    st_table_entry e;
-    e.hash = do_hash(k, tab);
-    e.key = k;
-    e.record = val;
-
-    tab->entries[tab->entries_bound++] = e;
+    st_index_t i = tab->entries_bound++;
+    st_hash_t h = do_hash(k, tab);
+    ST_HASH_AT_IDX(tab, i) = ST_HASH32_FROM(h);
+    tab->entries[i].key = k;
+    tab->entries[i].record = val;
     tab->num_entries++;
     RB_OBJ_WRITTEN(hash, Qundef, k);
     RB_OBJ_WRITTEN(hash, Qundef, val);
@@ -3512,7 +3679,7 @@ set_rebuild_table_with(set_table *const new_tab, set_table *const tab)
     for (i = tab->entries_start; i < bound; i++) {
         curr_entry_ptr = &entries[i];
         PREFETCH(entries + i + 1, 0);
-        if (EXPECT(DELETED_ENTRY_P(curr_entry_ptr), 0))
+        if (EXPECT(SET_DELETED_ENTRY_P(curr_entry_ptr), 0))
             continue;
         if (&new_entries[ni] != curr_entry_ptr)
             new_entries[ni] = *curr_entry_ptr;
@@ -3583,7 +3750,7 @@ set_find_entry(set_table *tab, st_hash_t hash_value, st_data_t key)
     bound = tab->entries_bound;
     entries = tab->entries;
     for (i = tab->entries_start; i < bound; i++) {
-        DO_PTR_EQUAL_CHECK(tab, &entries[i], hash_value, key, eq_p, rebuilt_p);
+        SET_DO_PTR_EQUAL_CHECK(tab, &entries[i], hash_value, key, eq_p, rebuilt_p);
         if (EXPECT(rebuilt_p, 0))
             return REBUILT_TABLE_ENTRY_IND;
         if (eq_p)
@@ -3622,7 +3789,7 @@ set_find_table_entry_ind(set_table *tab, st_hash_t hash_value, st_data_t key)
     for (;;) {
         bin = get_bin(set_bins_ptr(tab), set_get_size_ind(tab), ind);
         if (! EMPTY_OR_DELETED_BIN_P(bin)) {
-            DO_PTR_EQUAL_CHECK(tab, &entries[bin - ENTRY_BASE], hash_value, key, eq_p, rebuilt_p);
+            SET_DO_PTR_EQUAL_CHECK(tab, &entries[bin - ENTRY_BASE], hash_value, key, eq_p, rebuilt_p);
             if (EXPECT(rebuilt_p, 0))
                 return REBUILT_TABLE_ENTRY_IND;
             if (eq_p)
@@ -3666,7 +3833,7 @@ set_find_table_bin_ind(set_table *tab, st_hash_t hash_value, st_data_t key)
     for (;;) {
         bin = get_bin(set_bins_ptr(tab), set_get_size_ind(tab), ind);
         if (! EMPTY_OR_DELETED_BIN_P(bin)) {
-            DO_PTR_EQUAL_CHECK(tab, &entries[bin - ENTRY_BASE], hash_value, key, eq_p, rebuilt_p);
+            SET_DO_PTR_EQUAL_CHECK(tab, &entries[bin - ENTRY_BASE], hash_value, key, eq_p, rebuilt_p);
             if (EXPECT(rebuilt_p, 0))
                 return REBUILT_TABLE_BIN_IND;
             if (eq_p)
@@ -3767,7 +3934,7 @@ set_find_table_bin_ptr_and_reserve(set_table *tab, st_hash_t *hash_value,
             break;
         }
         else if (! DELETED_BIN_P(entry_index)) {
-            DO_PTR_EQUAL_CHECK(tab, &entries[entry_index - ENTRY_BASE], curr_hash_value, key, eq_p, rebuilt_p);
+            SET_DO_PTR_EQUAL_CHECK(tab, &entries[entry_index - ENTRY_BASE], curr_hash_value, key, eq_p, rebuilt_p);
             if (EXPECT(rebuilt_p, 0))
                 return REBUILT_TABLE_ENTRY_IND;
             if (eq_p)
@@ -3904,7 +4071,7 @@ set_update_range_for_deleted(set_table *tab, st_index_t n)
         st_index_t start = n + 1;
         st_index_t bound = tab->entries_bound;
         set_table_entry *entries = tab->entries;
-        while (start < bound && DELETED_ENTRY_P(&entries[start])) start++;
+        while (start < bound && SET_DELETED_ENTRY_P(&entries[start])) start++;
         tab->entries_start = start;
     }
 }
@@ -3949,7 +4116,7 @@ set_table_delete(set_table *tab, st_data_t *key)
     }
     entry = &tab->entries[bin];
     *key = entry->key;
-    MARK_ENTRY_DELETED(entry);
+    SET_MARK_ENTRY_DELETED(entry);
     tab->num_entries--;
     set_update_range_for_deleted(tab, bin);
     return 1;
@@ -3982,7 +4149,7 @@ set_general_foreach(set_table *tab, set_foreach_check_callback_func *func,
        the table, e.g. by an entry insertion.  */
     for (i = tab->entries_start; i < tab->entries_bound; i++) {
         curr_entry_ptr = &entries[i];
-        if (EXPECT(DELETED_ENTRY_P(curr_entry_ptr), 0))
+        if (EXPECT(SET_DELETED_ENTRY_P(curr_entry_ptr), 0))
             continue;
         key = curr_entry_ptr->key;
         rebuilds_num = tab->rebuilds_num;
@@ -4049,7 +4216,7 @@ set_general_foreach(set_table *tab, set_foreach_check_callback_func *func,
                 MARK_SET_BIN_DELETED(tab, bin_ind);
             }
             curr_entry_ptr = &entries[bin];
-            MARK_ENTRY_DELETED(curr_entry_ptr);
+            SET_MARK_ENTRY_DELETED(curr_entry_ptr);
             tab->num_entries--;
             set_update_range_for_deleted(tab, bin);
             break;
@@ -4109,7 +4276,7 @@ set_keys(set_table *tab, st_data_t *keys, st_index_t size)
             break;
         curr_entry_ptr = &entries[i];
         key = curr_entry_ptr->key;
-        if (! DELETED_ENTRY_P(curr_entry_ptr))
+        if (! SET_DELETED_ENTRY_P(curr_entry_ptr))
             *keys++ = key;
     }
 

--- a/st.c
+++ b/st.c
@@ -397,8 +397,13 @@ set_bin(st_index_t *bins, int s, st_index_t n, st_index_t v)
 #define ENTRY_BASE 2
 
 /* Mark I-th bin of table TAB as empty, in other words not
-   corresponding to any entry.  */
-#define MARK_BIN_EMPTY(tab, i) (set_bin((tab)->bins, get_size_ind(tab), i, EMPTY_BIN))
+   corresponding to any entry.  When the Swiss-bins backend is enabled
+   and active for this table, also clear the parallel control byte. */
+#define MARK_BIN_EMPTY(tab, i)                                          \
+    do {                                                                \
+        set_bin((tab)->bins, get_size_ind(tab), (i), EMPTY_BIN);        \
+        SWISS_SET_CTRL_EMPTY((tab), (i));                               \
+    } while (0)
 
 /* Values used for not found entry and bin with given
    characteristics.  */
@@ -412,10 +417,13 @@ set_bin(st_index_t *bins, int s, st_index_t n, st_index_t v)
 
 /* Mark I-th bin of table TAB as corresponding to a deleted table
    entry.  Update number of entries in the table and number of bins
-   corresponding to deleted entries. */
+   corresponding to deleted entries.  When the Swiss-bins backend is
+   enabled and active for this table, also write the deleted tombstone
+   to the parallel control byte. */
 #define MARK_BIN_DELETED(tab, i)				\
     do {                                                        \
-        set_bin((tab)->bins, get_size_ind(tab), i, DELETED_BIN); \
+        set_bin((tab)->bins, get_size_ind(tab), (i), DELETED_BIN); \
+        SWISS_SET_CTRL_DELETED((tab), (i));                     \
     } while (0)
 
 /* Macros to check that value B is used empty bins and bins
@@ -485,6 +493,11 @@ initialize_bins(st_table *tab)
     memset(tab->bins, 0, bins_size(tab));
 }
 
+#ifdef ST_USE_SWISS_BINS
+/* Forward declaration: full definition lives in the Swiss-bins block. */
+static size_t swiss_ctrl_alloc_size(const st_table *tab);
+#endif
+
 /* Make table TAB empty.  */
 static void
 make_tab_empty(st_table *tab)
@@ -493,6 +506,13 @@ make_tab_empty(st_table *tab)
     tab->entries_start = tab->entries_bound = 0;
     if (tab->bins != NULL)
         initialize_bins(tab);
+#ifdef ST_USE_SWISS_BINS
+    /* 0xff is ST_SWISS_CTRL_EMPTY; the macro is defined further down
+     * alongside the Swiss helpers. Hardcoded here to avoid forward
+     * declaration ordering issues with the macro. */
+    if (tab->ctrl != NULL)
+        memset(tab->ctrl, 0xff, swiss_ctrl_alloc_size(tab));
+#endif
 }
 
 #ifdef HASH_LOG
@@ -525,6 +545,454 @@ stat_col(void)
 }
 #endif
 
+/* ===========================================================================
+ * Optional measurement subsystem (ST_STATS).
+ *
+ * Compiled in only when ST_STATS is defined. Activated at runtime when the
+ * RUBY_ST_STATS environment variable is set to a non-empty value other than
+ * "0". When disabled at compile time, every macro below expands to a no-op
+ * and there is zero impact on the generated code.
+ *
+ * On exit (when enabled at runtime) a human-readable report is written to
+ * /tmp/ruby_st_stats.<pid>. The report covers:
+ *   - find probe-length histogram, split by hit vs miss
+ *   - total operation counts (lookup / insert / delete)
+ *   - rebuild / compaction / resize counts
+ *   - histogram of table sizes observed at rebuild time
+ *   - top-N callsites of the public API (st_lookup/st_insert/st_delete/...)
+ * ========================================================================= */
+
+/* These op identifiers are always defined so that ST_STATS_* macro arguments
+ * are valid tokens regardless of whether ST_STATS is enabled. */
+#define ST_STATS_OP_LOOKUP 0
+#define ST_STATS_OP_INSERT 1
+#define ST_STATS_OP_DELETE 2
+#define ST_STATS_OP_OTHER  3
+#define ST_STATS_OP_COUNT  4
+
+#ifdef ST_STATS
+#include <inttypes.h>
+
+#define ST_STATS_PROBE_BUCKETS 9
+#define ST_STATS_CALLSITE_SLOTS 1024
+#define ST_STATS_SIZE_HIST_BUCKETS 33
+
+struct st_stats_probe_data {
+    uint64_t calls;
+    uint64_t total_probes;
+    uint64_t hist[ST_STATS_PROBE_BUCKETS];
+};
+
+struct st_stats_callsite {
+    void *addr;
+    uint64_t counts[ST_STATS_OP_COUNT];
+};
+
+static struct {
+    int initialized;
+    int enabled;
+    /* Per-find probe statistics, separated by outcome. */
+    struct st_stats_probe_data find_hit;
+    struct st_stats_probe_data find_miss;
+    /* Public-API call counts. */
+    uint64_t op_calls[ST_STATS_OP_COUNT];
+    /* Rebuild accounting. */
+    uint64_t rebuilds;
+    uint64_t compactions;
+    uint64_t resizes;
+    /* Histogram of num_entries at rebuild time, indexed by floor(log2(n))+1. */
+    uint64_t rebuild_size_hist[ST_STATS_SIZE_HIST_BUCKETS];
+    /* Bounded per-callsite table. Linear scan is fine: this is for analysis. */
+    struct st_stats_callsite callsites[ST_STATS_CALLSITE_SLOTS];
+    int callsites_used;
+} st_stats;
+
+static void st_stats_dump(void);
+
+static void
+st_stats_init(void)
+{
+    if (st_stats.initialized) return;
+    const char *env = getenv("RUBY_ST_STATS");
+    st_stats.enabled = env != NULL && env[0] != '\0' && env[0] != '0';
+    if (st_stats.enabled) atexit(st_stats_dump);
+    st_stats.initialized = 1;
+}
+
+static inline int
+st_stats_probe_bucket(uint32_t probes)
+{
+    /* 1, 2, 3, 4, 5-8, 9-16, 17-32, 33-64, 65+ */
+    if (probes <= 1) return 0;
+    if (probes <= 2) return 1;
+    if (probes <= 3) return 2;
+    if (probes <= 4) return 3;
+    if (probes <= 8) return 4;
+    if (probes <= 16) return 5;
+    if (probes <= 32) return 6;
+    if (probes <= 64) return 7;
+    return 8;
+}
+
+static inline int
+st_stats_log2_bucket(st_index_t n)
+{
+    int b = 0;
+    while (n > 0 && b < ST_STATS_SIZE_HIST_BUCKETS - 1) {
+        n >>= 1;
+        b++;
+    }
+    return b;
+}
+
+static void
+st_stats_record_probes(uint32_t probes, int hit)
+{
+    if (!st_stats.enabled) return;
+    struct st_stats_probe_data *d = hit ? &st_stats.find_hit : &st_stats.find_miss;
+    d->calls++;
+    d->total_probes += probes;
+    d->hist[st_stats_probe_bucket(probes)]++;
+}
+
+static void
+st_stats_record_op(int op)
+{
+    if (!st_stats.enabled) return;
+    if (op < 0 || op >= ST_STATS_OP_COUNT) return;
+    st_stats.op_calls[op]++;
+}
+
+static void
+st_stats_record_callsite(void *addr, int op)
+{
+    if (!st_stats.enabled) return;
+    if (op < 0 || op >= ST_STATS_OP_COUNT) return;
+    int i;
+    for (i = 0; i < st_stats.callsites_used; i++) {
+        if (st_stats.callsites[i].addr == addr) {
+            st_stats.callsites[i].counts[op]++;
+            return;
+        }
+    }
+    if (st_stats.callsites_used >= ST_STATS_CALLSITE_SLOTS) return;
+    st_stats.callsites[st_stats.callsites_used].addr = addr;
+    st_stats.callsites[st_stats.callsites_used].counts[op] = 1;
+    st_stats.callsites_used++;
+}
+
+static void
+st_stats_record_rebuild(st_index_t entries_at_rebuild, int is_compaction)
+{
+    if (!st_stats.enabled) return;
+    st_stats.rebuilds++;
+    if (is_compaction) st_stats.compactions++;
+    else st_stats.resizes++;
+    st_stats.rebuild_size_hist[st_stats_log2_bucket(entries_at_rebuild)]++;
+}
+
+static int
+st_stats_callsite_compare(const void *a, const void *b)
+{
+    const struct st_stats_callsite *ca = a;
+    const struct st_stats_callsite *cb = b;
+    uint64_t ta = ca->counts[0] + ca->counts[1] + ca->counts[2] + ca->counts[3];
+    uint64_t tb = cb->counts[0] + cb->counts[1] + cb->counts[2] + cb->counts[3];
+    if (ta < tb) return 1;
+    if (ta > tb) return -1;
+    return 0;
+}
+
+static void
+st_stats_dump_probe(FILE *f, const char *label, const struct st_stats_probe_data *d)
+{
+    if (d->calls == 0) {
+        fprintf(f, "  %s: (no calls)\n", label);
+        return;
+    }
+    fprintf(f, "  %s: %" PRIu64 " calls, %" PRIu64 " probes, avg %.2f\n",
+            label, d->calls, d->total_probes,
+            (double)d->total_probes / (double)d->calls);
+    fprintf(f, "    histogram (1, 2, 3, 4, 5-8, 9-16, 17-32, 33-64, 65+):");
+    int b;
+    for (b = 0; b < ST_STATS_PROBE_BUCKETS; b++) {
+        fprintf(f, " %" PRIu64, d->hist[b]);
+    }
+    fprintf(f, "\n");
+}
+
+static void
+st_stats_dump(void)
+{
+    char fname[64];
+    snprintf(fname, sizeof(fname), "/tmp/ruby_st_stats.%ld", (long)getpid());
+    FILE *f = fopen(fname, "w");
+    if (f == NULL) return;
+
+    fprintf(f, "=== Ruby st_table stats (pid %ld) ===\n\n", (long)getpid());
+
+    fprintf(f, "Public API calls:\n");
+    fprintf(f, "  lookup: %" PRIu64 "\n", st_stats.op_calls[ST_STATS_OP_LOOKUP]);
+    fprintf(f, "  insert: %" PRIu64 "\n", st_stats.op_calls[ST_STATS_OP_INSERT]);
+    fprintf(f, "  delete: %" PRIu64 "\n", st_stats.op_calls[ST_STATS_OP_DELETE]);
+    fprintf(f, "  other:  %" PRIu64 "\n", st_stats.op_calls[ST_STATS_OP_OTHER]);
+
+    fprintf(f, "\nProbe statistics:\n");
+    st_stats_dump_probe(f, "hits ", &st_stats.find_hit);
+    st_stats_dump_probe(f, "miss ", &st_stats.find_miss);
+
+    fprintf(f, "\nRebuild accounting:\n");
+    fprintf(f, "  rebuilds: %" PRIu64 " (compactions: %" PRIu64 ", resizes: %" PRIu64 ")\n",
+            st_stats.rebuilds, st_stats.compactions, st_stats.resizes);
+    fprintf(f, "  num_entries at rebuild (by 2^k):\n");
+    int p;
+    for (p = 0; p < ST_STATS_SIZE_HIST_BUCKETS; p++) {
+        if (st_stats.rebuild_size_hist[p]) {
+            fprintf(f, "    2^%-2d: %" PRIu64 "\n", p, st_stats.rebuild_size_hist[p]);
+        }
+    }
+
+    fprintf(f, "\nTop callsites of public API (lookup/insert/delete/other):\n");
+    qsort(st_stats.callsites, (size_t)st_stats.callsites_used,
+          sizeof(struct st_stats_callsite), st_stats_callsite_compare);
+    int n = st_stats.callsites_used < 30 ? st_stats.callsites_used : 30;
+    int i;
+    for (i = 0; i < n; i++) {
+        const struct st_stats_callsite *cs = &st_stats.callsites[i];
+        fprintf(f, "  %p  L=%" PRIu64 " I=%" PRIu64 " D=%" PRIu64 " O=%" PRIu64 "\n",
+                cs->addr,
+                cs->counts[ST_STATS_OP_LOOKUP],
+                cs->counts[ST_STATS_OP_INSERT],
+                cs->counts[ST_STATS_OP_DELETE],
+                cs->counts[ST_STATS_OP_OTHER]);
+    }
+
+    fclose(f);
+}
+
+#define ST_STATS_DECLARE_PROBE() uint32_t _st_probes = 0
+#define ST_STATS_BUMP_PROBE() ((void)(++_st_probes))
+#define ST_STATS_RECORD_PROBES(hit) st_stats_record_probes(_st_probes, (hit))
+#define ST_STATS_RECORD_OP(op) st_stats_record_op(op)
+#define ST_STATS_RECORD_CALLSITE(op) \
+    st_stats_record_callsite(__builtin_return_address(0), (op))
+#define ST_STATS_RECORD_REBUILD(entries, is_compaction) \
+    st_stats_record_rebuild((entries), (is_compaction))
+#define ST_STATS_INIT() st_stats_init()
+
+#else /* !ST_STATS */
+
+#define ST_STATS_DECLARE_PROBE() ((void)0)
+#define ST_STATS_BUMP_PROBE() ((void)0)
+#define ST_STATS_RECORD_PROBES(hit) ((void)0)
+#define ST_STATS_RECORD_OP(op) ((void)0)
+#define ST_STATS_RECORD_CALLSITE(op) ((void)0)
+#define ST_STATS_RECORD_REBUILD(entries, is_compaction) ((void)0)
+#define ST_STATS_INIT() ((void)0)
+
+#endif /* ST_STATS */
+
+/* ===========================================================================
+ * Swiss-table-style bins backend (compile-time gated by
+ * ST_USE_SWISS_BINS). Adds a parallel control-byte array (tab->ctrl) used as
+ * a fast pre-filter during probing. The existing entries[] log is unchanged
+ * so insertion order is preserved.
+ *
+ * The Swiss path only kicks in when entry_power >= SWISS_MIN_ENTRY_POWER.
+ * Below that threshold we fall through to the existing perturb-chain bins
+ * (or no-bins linear scan), because the SWAR setup costs do not pay off for
+ * small tables. The threshold is a benchmark-driven tunable.
+ * ========================================================================= */
+
+#ifdef ST_USE_SWISS_BINS
+
+/* ---------------------------------------------------------------------------
+ * Group/match API used by the four find_* probing loops below:
+ *
+ *   ST_SWISS_GROUP_SIZE         -- group width in slots (8)
+ *   swiss_group_t               -- opaque handle for one group's control bytes
+ *   swiss_match_t               -- opaque iterator over matching slots
+ *   st_swiss_load_group(p)      -- load ST_SWISS_GROUP_SIZE control bytes
+ *   st_swiss_match_byte(g, b)   -- mask of slots whose ctrl byte == b
+ *   st_swiss_match_empty(g)     -- mask of slots whose ctrl byte == EMPTY
+ *   st_swiss_match_free(g)      -- mask of slots that are EMPTY or DELETED
+ *   st_swiss_match_any(m)       -- truthy iff any slot is set
+ *   st_swiss_match_first(m)     -- slot index in [0, ST_SWISS_GROUP_SIZE)
+ *   st_swiss_match_drop(m)      -- m with the lowest match cleared
+ *
+ * The implementation uses scalar SWAR (SIMD-Within-A-Register) over a
+ * uint64_t. We initially explored SSE2 and NEON variants too, but in
+ * benchmarks the SWAR path was at least as fast as NEON on Apple Silicon
+ * (because Apple's wide integer pipeline executes the three SWAR ops in
+ * parallel, while NEON's vector->GPR transfer for the match mask costs
+ * several cycles). SSE2 has the strongest theoretical advantage thanks
+ * to native _mm_movemask_epi8, but the SWAR path is the simplest portable
+ * baseline to maintain. SIMD variants can be reintroduced later if a
+ * representative workload demonstrates a meaningful win.
+ * --------------------------------------------------------------------------- */
+
+#define ST_SWISS_GROUP_SIZE 8
+
+/* Below this entry_power, do not use the Swiss path: stay on the existing
+ * perturb-chain or no-bins layout. Tunable; benchmark to refine.
+ *
+ * Floor: SWISS_MIN_ENTRY_POWER must guarantee bin_count >= ST_SWISS_GROUP_SIZE
+ * so a single group load covers a full power-of-two slice. With the current
+ * features[] table, entry_power=6 maps to bin_power=7 (bin_count=128), which
+ * is comfortably above 8. */
+#ifndef SWISS_MIN_ENTRY_POWER
+#define SWISS_MIN_ENTRY_POWER 6
+#endif
+
+/* Control byte values. 0x00..0x7f = occupied (top bit clear, holds H2). */
+#define ST_SWISS_CTRL_EMPTY   ((unsigned char)0xff)
+#define ST_SWISS_CTRL_DELETED ((unsigned char)0xfe)
+
+#define ST_SWISS_CTRL_IS_EMPTY(c)             ((c) == ST_SWISS_CTRL_EMPTY)
+#define ST_SWISS_CTRL_IS_DELETED(c)           ((c) == ST_SWISS_CTRL_DELETED)
+#define ST_SWISS_CTRL_IS_EMPTY_OR_DELETED(c)  (((c) & (unsigned char)0x80) != 0)
+#define ST_SWISS_CTRL_IS_OCCUPIED(c)          (((c) & (unsigned char)0x80) == 0)
+
+/* H2 derivation: top 7 bits of the hash. */
+static inline unsigned char
+st_swiss_h2(st_hash_t hash)
+{
+    return (unsigned char)((hash >> ((sizeof(st_hash_t) * 8) - 7)) & 0x7f);
+}
+
+/* Number of Swiss bin slots. Mirrors the bins layout: it is the actual number
+ * of slots addressable by hash_bin(), which is bins_mask(tab) + 1.
+ * Note: this is logical slot count -- ctrl[] is one byte per slot. */
+static inline st_index_t
+swiss_ctrl_slots(const st_table *tab)
+{
+    return ((st_index_t)1) << tab->bin_power;
+}
+
+/* Allocation size in bytes for the ctrl[] array. We over-allocate by one
+ * group so loads near the end never read past the end. */
+static inline size_t
+swiss_ctrl_alloc_size(const st_table *tab)
+{
+    return (size_t)swiss_ctrl_slots(tab) + ST_SWISS_GROUP_SIZE;
+}
+
+/* Should we maintain ctrl[] for this table? */
+static inline int
+swiss_active_p(const st_table *tab)
+{
+    return tab->ctrl != NULL && tab->entry_power >= SWISS_MIN_ENTRY_POWER;
+}
+
+/* ---- Group/match types and SWAR primitives -------------------------------- */
+
+/* One uint64_t per 8-byte group. Match masks have 0x80 set in the matching
+ * byte's high-bit position and zero elsewhere. */
+typedef uint64_t swiss_group_t;
+typedef uint64_t swiss_match_t;
+
+static inline swiss_group_t
+st_swiss_load_group(const unsigned char *p)
+{
+    swiss_group_t g;
+    memcpy(&g, p, sizeof(g));
+    return g;
+}
+
+static inline swiss_match_t
+st_swiss_match_byte(swiss_group_t g, unsigned char b)
+{
+    /* Standard SWAR byte-equality: produces 0x80 in matching bytes. */
+    const swiss_group_t lsb = 0x0101010101010101ULL;
+    const swiss_group_t msb = 0x8080808080808080ULL;
+    swiss_group_t x = g ^ (lsb * (swiss_group_t)b);
+    return (x - lsb) & ~x & msb;
+}
+
+static inline swiss_match_t
+st_swiss_match_empty(swiss_group_t g)
+{
+    return st_swiss_match_byte(g, ST_SWISS_CTRL_EMPTY);
+}
+
+static inline swiss_match_t
+st_swiss_match_free(swiss_group_t g)
+{
+    return g & 0x8080808080808080ULL;
+}
+
+static inline int
+st_swiss_match_any(swiss_match_t m) { return m != 0; }
+
+static inline int
+st_swiss_match_first(swiss_match_t m)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    return __builtin_ctzll(m) >> 3;
+#else
+    int i;
+    for (i = 0; i < 8; i++) {
+        if (m & ((swiss_match_t)0x80 << (i * 8))) return i;
+    }
+    return 8;
+#endif
+}
+
+static inline swiss_match_t
+st_swiss_match_drop(swiss_match_t m)
+{
+    /* Only the high bit of each matching byte is set, so clearing the lowest
+     * set bit cleanly drops one match. */
+    return m & (m - 1);
+}
+
+/* Compute the index of the first probe group for HASH in table TAB. The
+ * group index is aligned to ST_SWISS_GROUP_SIZE, which keeps every group
+ * load entirely within ctrl[] (no shadow bytes needed) since the slot count
+ * is always a power of two >= GROUP_SIZE for tables above the threshold. */
+static inline st_index_t
+st_swiss_first_group(const st_table *tab, st_hash_t hash)
+{
+    return hash_bin(hash, (st_table *)tab) & ~((st_index_t)(ST_SWISS_GROUP_SIZE - 1));
+}
+
+/* Mask bits used for triangular probing within ctrl[]. Note: bin_power
+ * always >= 3 above the SWISS threshold so masking is well-defined. */
+static inline st_index_t
+st_swiss_bin_mask(const st_table *tab)
+{
+    return (((st_index_t)1) << tab->bin_power) - 1;
+}
+
+#define SWISS_SET_CTRL_EMPTY(tab, i)                                    \
+    do {                                                                \
+        if (swiss_active_p(tab)) {                                      \
+            (tab)->ctrl[(i)] = ST_SWISS_CTRL_EMPTY;                     \
+        }                                                               \
+    } while (0)
+
+#define SWISS_SET_CTRL_DELETED(tab, i)                                  \
+    do {                                                                \
+        if (swiss_active_p(tab)) {                                      \
+            (tab)->ctrl[(i)] = ST_SWISS_CTRL_DELETED;                   \
+        }                                                               \
+    } while (0)
+
+#define SWISS_SET_CTRL_OCCUPIED(tab, i, hash)                           \
+    do {                                                                \
+        if (swiss_active_p(tab)) {                                      \
+            (tab)->ctrl[(i)] = st_swiss_h2(hash);                       \
+        }                                                               \
+    } while (0)
+
+#else /* !ST_USE_SWISS_BINS */
+
+#define SWISS_SET_CTRL_EMPTY(tab, i) ((void)0)
+#define SWISS_SET_CTRL_DELETED(tab, i) ((void)0)
+#define SWISS_SET_CTRL_OCCUPIED(tab, i, hash) ((void)0)
+
+#endif /* ST_USE_SWISS_BINS */
+
 st_table *
 st_init_existing_table_with_size(st_table *tab, const struct st_hash_type *type, st_index_t size)
 {
@@ -542,6 +1010,8 @@ st_init_existing_table_with_size(st_table *tab, const struct st_hash_type *type,
         atexit(stat_col);
     }
 #endif
+
+    ST_STATS_INIT();
 
     n = get_power2(size);
 #ifndef RUBY
@@ -564,6 +1034,23 @@ st_init_existing_table_with_size(st_table *tab, const struct st_hash_type *type,
         }
 #endif
     }
+#ifdef ST_USE_SWISS_BINS
+    /* Allocate the parallel control-byte array only above the threshold.
+     * Below it we fall through to the existing perturb-chain logic. */
+    if (tab->bins != NULL && n >= SWISS_MIN_ENTRY_POWER) {
+        tab->ctrl = (unsigned char *) malloc(swiss_ctrl_alloc_size(tab));
+#ifndef RUBY
+        if (tab->ctrl == NULL) {
+            free(tab->bins);
+            free_fixed_ptr(tab);
+            return NULL;
+        }
+#endif
+    }
+    else {
+        tab->ctrl = NULL;
+    }
+#endif
     tab->entries = (st_table_entry *) malloc(get_allocated_entries(tab)
                                              * sizeof(st_table_entry));
 #ifndef RUBY
@@ -694,6 +1181,14 @@ st_bins_memsize(const st_table *tab)
     return tab->bins == NULL ? 0 : bins_size(tab);
 }
 
+#ifdef ST_USE_SWISS_BINS
+static inline size_t
+st_ctrl_memsize(const st_table *tab)
+{
+    return tab->ctrl == NULL ? 0 : swiss_ctrl_alloc_size(tab);
+}
+#endif
+
 static inline void
 st_free_entries(const st_table *tab)
 {
@@ -704,6 +1199,10 @@ static inline void
 st_free_bins(const st_table *tab)
 {
     sized_free(tab->bins, st_bins_memsize(tab));
+#ifdef ST_USE_SWISS_BINS
+    if (tab->ctrl != NULL)
+        sized_free(tab->ctrl, st_ctrl_memsize(tab));
+#endif
 }
 
 void
@@ -728,6 +1227,9 @@ st_memsize(const st_table *tab)
     RUBY_ASSERT(tab != NULL);
     return(sizeof(st_table)
            + st_bins_memsize(tab)
+#ifdef ST_USE_SWISS_BINS
+           + st_ctrl_memsize(tab)
+#endif
            + st_entries_memsize(tab));
 }
 
@@ -788,17 +1290,29 @@ static void rebuild_cleanup(st_table *const tab);
 static void
 rebuild_table(st_table *tab)
 {
+    st_index_t entries_at_rebuild = tab->num_entries;
+    int is_compaction;
     if ((2 * tab->num_entries <= get_allocated_entries(tab)
          && REBUILD_THRESHOLD * tab->num_entries > get_allocated_entries(tab))
         || tab->num_entries < (1 << MINIMAL_POWER2)) {
         /* Compaction: */
+        is_compaction = 1;
         tab->num_entries = 0;
         if (tab->bins != NULL)
             initialize_bins(tab);
+#ifdef ST_USE_SWISS_BINS
+        /* In-place compaction: reset the Swiss control bytes so subsequent
+         * find_table_bin_ind_direct sees fresh empty slots, otherwise
+         * stale h2/tombstone bytes from before compaction would mislead
+         * the SWAR probe and cause non-terminating searches. */
+        if (tab->ctrl != NULL)
+            memset(tab->ctrl, 0xff, swiss_ctrl_alloc_size(tab));
+#endif
         rebuild_table_with(tab, tab);
     }
     else {
         st_table *new_tab;
+        is_compaction = 0;
         /* This allocation could trigger GC and compaction. If tab is the
          * gen_fields_tbl, then tab could have changed in size due to objects being
          * freed and/or moved. Do not store attributes of tab before this line. */
@@ -808,6 +1322,9 @@ rebuild_table(st_table *tab)
         rebuild_move_table(new_tab, tab);
     }
     rebuild_cleanup(tab);
+    ST_STATS_RECORD_REBUILD(entries_at_rebuild, is_compaction);
+    (void)entries_at_rebuild;
+    (void)is_compaction;
 }
 
 static void
@@ -839,6 +1356,7 @@ rebuild_table_with(st_table *const new_tab, st_table *const tab)
             bin_ind = find_table_bin_ind_direct(new_tab, curr_entry_ptr->hash,
                                                 curr_entry_ptr->key);
             set_bin(bins, size_ind, bin_ind, ni + ENTRY_BASE);
+            SWISS_SET_CTRL_OCCUPIED(new_tab, bin_ind, curr_entry_ptr->hash);
         }
         new_tab->num_entries++;
         ni++;
@@ -857,6 +1375,9 @@ rebuild_move_table(st_table *const new_tab, st_table *const tab)
     tab->bin_power = new_tab->bin_power;
     tab->size_ind = new_tab->size_ind;
     tab->bins = new_tab->bins;
+#ifdef ST_USE_SWISS_BINS
+    tab->ctrl = new_tab->ctrl;
+#endif
     tab->entries = new_tab->entries;
     free_fixed_ptr(new_tab);
 }
@@ -899,16 +1420,21 @@ find_entry(st_table *tab, st_hash_t hash_value, st_data_t key)
     int eq_p, rebuilt_p;
     st_index_t i, bound;
     st_table_entry *entries;
+    ST_STATS_DECLARE_PROBE();
 
     bound = tab->entries_bound;
     entries = tab->entries;
     for (i = tab->entries_start; i < bound; i++) {
+        ST_STATS_BUMP_PROBE();
         DO_PTR_EQUAL_CHECK(tab, &entries[i], hash_value, key, eq_p, rebuilt_p);
         if (EXPECT(rebuilt_p, 0))
             return REBUILT_TABLE_ENTRY_IND;
-        if (eq_p)
+        if (eq_p) {
+            ST_STATS_RECORD_PROBES(1);
             return i;
+        }
     }
+    ST_STATS_RECORD_PROBES(0);
     return UNDEFINED_ENTRY_IND;
 }
 
@@ -932,6 +1458,44 @@ find_table_entry_ind(st_table *tab, st_hash_t hash_value, st_data_t key)
 #endif
     st_index_t bin;
     st_table_entry *entries = tab->entries;
+    ST_STATS_DECLARE_PROBE();
+
+#ifdef ST_USE_SWISS_BINS
+    if (swiss_active_p(tab)) {
+        const unsigned char h2 = st_swiss_h2(hash_value);
+        const st_index_t mask = st_swiss_bin_mask(tab);
+        const unsigned int swiss_size_ind = get_size_ind(tab);
+        st_index_t group_idx = st_swiss_first_group(tab, hash_value);
+        st_index_t step = 0;
+        for (;;) {
+            ST_STATS_BUMP_PROBE();
+            swiss_group_t g = st_swiss_load_group(tab->ctrl + group_idx);
+            swiss_match_t mh2 = st_swiss_match_byte(g, h2);
+            while (st_swiss_match_any(mh2)) {
+                int slot = st_swiss_match_first(mh2);
+                st_index_t cand_bin_ind = group_idx + slot;
+                st_index_t cand_bin = get_bin(tab->bins, swiss_size_ind, cand_bin_ind);
+                if (EXPECT(!EMPTY_OR_DELETED_BIN_P(cand_bin), 1)) {
+                    DO_PTR_EQUAL_CHECK(tab, &entries[cand_bin - ENTRY_BASE],
+                                       hash_value, key, eq_p, rebuilt_p);
+                    if (EXPECT(rebuilt_p, 0))
+                        return REBUILT_TABLE_ENTRY_IND;
+                    if (eq_p) {
+                        ST_STATS_RECORD_PROBES(1);
+                        return cand_bin;
+                    }
+                }
+                mh2 = st_swiss_match_drop(mh2);
+            }
+            if (st_swiss_match_any(st_swiss_match_empty(g))) {
+                ST_STATS_RECORD_PROBES(0);
+                return UNDEFINED_ENTRY_IND;
+            }
+            step += ST_SWISS_GROUP_SIZE;
+            group_idx = (group_idx + step) & mask;
+        }
+    }
+#endif
 
     ind = hash_bin(hash_value, tab);
 #ifdef QUADRATIC_PROBE
@@ -941,6 +1505,7 @@ find_table_entry_ind(st_table *tab, st_hash_t hash_value, st_data_t key)
 #endif
     FOUND_BIN;
     for (;;) {
+        ST_STATS_BUMP_PROBE();
         bin = get_bin(tab->bins, get_size_ind(tab), ind);
         if (! EMPTY_OR_DELETED_BIN_P(bin)) {
             DO_PTR_EQUAL_CHECK(tab, &entries[bin - ENTRY_BASE], hash_value, key, eq_p, rebuilt_p);
@@ -949,8 +1514,10 @@ find_table_entry_ind(st_table *tab, st_hash_t hash_value, st_data_t key)
             if (eq_p)
                 break;
         }
-        else if (EMPTY_BIN_P(bin))
+        else if (EMPTY_BIN_P(bin)) {
+            ST_STATS_RECORD_PROBES(0);
             return UNDEFINED_ENTRY_IND;
+        }
 #ifdef QUADRATIC_PROBE
         ind = hash_bin(ind + d, tab);
         d++;
@@ -959,6 +1526,7 @@ find_table_entry_ind(st_table *tab, st_hash_t hash_value, st_data_t key)
 #endif
         COLLISION;
     }
+    ST_STATS_RECORD_PROBES(1);
     return bin;
 }
 
@@ -978,6 +1546,44 @@ find_table_bin_ind(st_table *tab, st_hash_t hash_value, st_data_t key)
 #endif
     st_index_t bin;
     st_table_entry *entries = tab->entries;
+    ST_STATS_DECLARE_PROBE();
+
+#ifdef ST_USE_SWISS_BINS
+    if (swiss_active_p(tab)) {
+        const unsigned char h2 = st_swiss_h2(hash_value);
+        const st_index_t mask = st_swiss_bin_mask(tab);
+        const unsigned int swiss_size_ind = get_size_ind(tab);
+        st_index_t group_idx = st_swiss_first_group(tab, hash_value);
+        st_index_t step = 0;
+        for (;;) {
+            ST_STATS_BUMP_PROBE();
+            swiss_group_t g = st_swiss_load_group(tab->ctrl + group_idx);
+            swiss_match_t mh2 = st_swiss_match_byte(g, h2);
+            while (st_swiss_match_any(mh2)) {
+                int slot = st_swiss_match_first(mh2);
+                st_index_t cand_bin_ind = group_idx + slot;
+                st_index_t cand_bin = get_bin(tab->bins, swiss_size_ind, cand_bin_ind);
+                if (EXPECT(!EMPTY_OR_DELETED_BIN_P(cand_bin), 1)) {
+                    DO_PTR_EQUAL_CHECK(tab, &entries[cand_bin - ENTRY_BASE],
+                                       hash_value, key, eq_p, rebuilt_p);
+                    if (EXPECT(rebuilt_p, 0))
+                        return REBUILT_TABLE_BIN_IND;
+                    if (eq_p) {
+                        ST_STATS_RECORD_PROBES(1);
+                        return cand_bin_ind;
+                    }
+                }
+                mh2 = st_swiss_match_drop(mh2);
+            }
+            if (st_swiss_match_any(st_swiss_match_empty(g))) {
+                ST_STATS_RECORD_PROBES(0);
+                return UNDEFINED_BIN_IND;
+            }
+            step += ST_SWISS_GROUP_SIZE;
+            group_idx = (group_idx + step) & mask;
+        }
+    }
+#endif
 
     ind = hash_bin(hash_value, tab);
 #ifdef QUADRATIC_PROBE
@@ -987,6 +1593,7 @@ find_table_bin_ind(st_table *tab, st_hash_t hash_value, st_data_t key)
 #endif
     FOUND_BIN;
     for (;;) {
+        ST_STATS_BUMP_PROBE();
         bin = get_bin(tab->bins, get_size_ind(tab), ind);
         if (! EMPTY_OR_DELETED_BIN_P(bin)) {
             DO_PTR_EQUAL_CHECK(tab, &entries[bin - ENTRY_BASE], hash_value, key, eq_p, rebuilt_p);
@@ -995,8 +1602,10 @@ find_table_bin_ind(st_table *tab, st_hash_t hash_value, st_data_t key)
             if (eq_p)
                 break;
         }
-        else if (EMPTY_BIN_P(bin))
+        else if (EMPTY_BIN_P(bin)) {
+            ST_STATS_RECORD_PROBES(0);
             return UNDEFINED_BIN_IND;
+        }
 #ifdef QUADRATIC_PROBE
         ind = hash_bin(ind + d, tab);
         d++;
@@ -1005,6 +1614,7 @@ find_table_bin_ind(st_table *tab, st_hash_t hash_value, st_data_t key)
 #endif
         COLLISION;
     }
+    ST_STATS_RECORD_PROBES(1);
     return ind;
 }
 
@@ -1021,6 +1631,30 @@ find_table_bin_ind_direct(st_table *tab, st_hash_t hash_value, st_data_t key)
     st_index_t perturb;
 #endif
     st_index_t bin;
+    ST_STATS_DECLARE_PROBE();
+
+#ifdef ST_USE_SWISS_BINS
+    if (swiss_active_p(tab)) {
+        /* Direct insert: find the first empty-or-deleted slot. The caller
+         * guarantees the key is not already present, so we don't compare
+         * keys here. */
+        const st_index_t mask = st_swiss_bin_mask(tab);
+        st_index_t group_idx = st_swiss_first_group(tab, hash_value);
+        st_index_t step = 0;
+        for (;;) {
+            ST_STATS_BUMP_PROBE();
+            swiss_group_t g = st_swiss_load_group(tab->ctrl + group_idx);
+            swiss_match_t mfree = st_swiss_match_free(g);
+            if (st_swiss_match_any(mfree)) {
+                int slot = st_swiss_match_first(mfree);
+                ST_STATS_RECORD_PROBES(0);
+                return group_idx + slot;
+            }
+            step += ST_SWISS_GROUP_SIZE;
+            group_idx = (group_idx + step) & mask;
+        }
+    }
+#endif
 
     ind = hash_bin(hash_value, tab);
 #ifdef QUADRATIC_PROBE
@@ -1030,9 +1664,12 @@ find_table_bin_ind_direct(st_table *tab, st_hash_t hash_value, st_data_t key)
 #endif
     FOUND_BIN;
     for (;;) {
+        ST_STATS_BUMP_PROBE();
         bin = get_bin(tab->bins, get_size_ind(tab), ind);
-        if (EMPTY_OR_DELETED_BIN_P(bin))
+        if (EMPTY_OR_DELETED_BIN_P(bin)) {
+            ST_STATS_RECORD_PROBES(0);
             return ind;
+        }
 #ifdef QUADRATIC_PROBE
         ind = hash_bin(ind + d, tab);
         d++;
@@ -1067,6 +1704,72 @@ find_table_bin_ptr_and_reserve(st_table *tab, st_hash_t *hash_value,
     st_index_t entry_index;
     st_index_t first_deleted_bin_ind;
     st_table_entry *entries;
+    int hit_p = 0;
+    ST_STATS_DECLARE_PROBE();
+
+#ifdef ST_USE_SWISS_BINS
+    if (swiss_active_p(tab)) {
+        const unsigned char h2 = st_swiss_h2(curr_hash_value);
+        const st_index_t mask = st_swiss_bin_mask(tab);
+        const unsigned int swiss_size_ind = get_size_ind(tab);
+        st_index_t group_idx = st_swiss_first_group(tab, curr_hash_value);
+        st_index_t step = 0;
+        st_index_t swiss_first_deleted = UNDEFINED_BIN_IND;
+        entries = tab->entries;
+        for (;;) {
+            ST_STATS_BUMP_PROBE();
+            swiss_group_t g = st_swiss_load_group(tab->ctrl + group_idx);
+            /* First, scan for H2 matches and check keys. */
+            swiss_match_t mh2 = st_swiss_match_byte(g, h2);
+            while (st_swiss_match_any(mh2)) {
+                int slot = st_swiss_match_first(mh2);
+                st_index_t cand_bin_ind = group_idx + slot;
+                st_index_t cand_entry = get_bin(tab->bins, swiss_size_ind, cand_bin_ind);
+                if (EXPECT(!EMPTY_OR_DELETED_BIN_P(cand_entry), 1)) {
+                    DO_PTR_EQUAL_CHECK(tab, &entries[cand_entry - ENTRY_BASE],
+                                       curr_hash_value, key, eq_p, rebuilt_p);
+                    if (EXPECT(rebuilt_p, 0))
+                        return REBUILT_TABLE_ENTRY_IND;
+                    if (eq_p) {
+                        ST_STATS_RECORD_PROBES(1);
+                        *bin_ind = cand_bin_ind;
+                        return cand_entry;
+                    }
+                }
+                mh2 = st_swiss_match_drop(mh2);
+            }
+            /* Track first deleted (tombstone) slot for reuse on insert. */
+            if (swiss_first_deleted == UNDEFINED_BIN_IND) {
+                swiss_match_t mdel = st_swiss_match_byte(g, ST_SWISS_CTRL_DELETED);
+                if (st_swiss_match_any(mdel)) {
+                    int slot = st_swiss_match_first(mdel);
+                    swiss_first_deleted = group_idx + slot;
+                }
+            }
+            /* An empty byte means the key is not in the table: stop probing. */
+            swiss_match_t mempty = st_swiss_match_empty(g);
+            if (st_swiss_match_any(mempty)) {
+                ST_STATS_RECORD_PROBES(0);
+                tab->num_entries++;
+                if (swiss_first_deleted != UNDEFINED_BIN_IND) {
+                    /* Reuse the earlier tombstone slot. MARK_BIN_EMPTY clears
+                     * both bins[] and ctrl[] for that slot; the caller will
+                     * then overwrite with the new entry. */
+                    ind = swiss_first_deleted;
+                    MARK_BIN_EMPTY(tab, ind);
+                }
+                else {
+                    int slot = st_swiss_match_first(mempty);
+                    ind = group_idx + slot;
+                }
+                *bin_ind = ind;
+                return UNDEFINED_ENTRY_IND;
+            }
+            step += ST_SWISS_GROUP_SIZE;
+            group_idx = (group_idx + step) & mask;
+        }
+    }
+#endif
 
     ind = hash_bin(curr_hash_value, tab);
 #ifdef QUADRATIC_PROBE
@@ -1078,6 +1781,7 @@ find_table_bin_ptr_and_reserve(st_table *tab, st_hash_t *hash_value,
     first_deleted_bin_ind = UNDEFINED_BIN_IND;
     entries = tab->entries;
     for (;;) {
+        ST_STATS_BUMP_PROBE();
         entry_index = get_bin(tab->bins, get_size_ind(tab), ind);
         if (EMPTY_BIN_P(entry_index)) {
             tab->num_entries++;
@@ -1093,8 +1797,10 @@ find_table_bin_ptr_and_reserve(st_table *tab, st_hash_t *hash_value,
             DO_PTR_EQUAL_CHECK(tab, &entries[entry_index - ENTRY_BASE], curr_hash_value, key, eq_p, rebuilt_p);
             if (EXPECT(rebuilt_p, 0))
                 return REBUILT_TABLE_ENTRY_IND;
-            if (eq_p)
+            if (eq_p) {
+                hit_p = 1;
                 break;
+            }
         }
         else if (first_deleted_bin_ind == UNDEFINED_BIN_IND)
             first_deleted_bin_ind = ind;
@@ -1106,6 +1812,8 @@ find_table_bin_ptr_and_reserve(st_table *tab, st_hash_t *hash_value,
 #endif
         COLLISION;
     }
+    ST_STATS_RECORD_PROBES(hit_p);
+    (void)hit_p;
     *bin_ind = ind;
     return entry_index;
 }
@@ -1118,6 +1826,8 @@ st_lookup(st_table *tab, st_data_t key, st_data_t *value)
     st_index_t bin;
     st_hash_t hash = do_hash(key, tab);
 
+    ST_STATS_RECORD_OP(ST_STATS_OP_LOOKUP);
+    ST_STATS_RECORD_CALLSITE(ST_STATS_OP_LOOKUP);
  retry:
     if (tab->bins == NULL) {
         bin = find_entry(tab, hash, key);
@@ -1147,6 +1857,8 @@ st_get_key(st_table *tab, st_data_t key, st_data_t *result)
     st_index_t bin;
     st_hash_t hash = do_hash(key, tab);
 
+    ST_STATS_RECORD_OP(ST_STATS_OP_LOOKUP);
+    ST_STATS_RECORD_CALLSITE(ST_STATS_OP_LOOKUP);
  retry:
     if (tab->bins == NULL) {
         bin = find_entry(tab, hash, key);
@@ -1191,6 +1903,8 @@ st_insert(st_table *tab, st_data_t key, st_data_t value)
     st_index_t bin_ind;
     int new_p;
 
+    ST_STATS_RECORD_OP(ST_STATS_OP_INSERT);
+    ST_STATS_RECORD_CALLSITE(ST_STATS_OP_INSERT);
     hash_value = do_hash(key, tab);
  retry:
     rebuild_table_if_necessary(tab);
@@ -1217,8 +1931,10 @@ st_insert(st_table *tab, st_data_t key, st_data_t value)
         entry->hash = hash_value;
         entry->key = key;
         entry->record = value;
-        if (bin_ind != UNDEFINED_BIN_IND)
+        if (bin_ind != UNDEFINED_BIN_IND) {
             set_bin(tab->bins, get_size_ind(tab), bin_ind, ind + ENTRY_BASE);
+            SWISS_SET_CTRL_OCCUPIED(tab, bin_ind, hash_value);
+        }
         return 0;
     }
     tab->entries[bin].record = value;
@@ -1247,6 +1963,7 @@ st_add_direct_with_hash(st_table *tab,
     if (tab->bins != NULL) {
         bin_ind = find_table_bin_ind_direct(tab, hash, key);
         set_bin(tab->bins, get_size_ind(tab), bin_ind, ind + ENTRY_BASE);
+        SWISS_SET_CTRL_OCCUPIED(tab, bin_ind, hash);
     }
 }
 
@@ -1282,6 +1999,8 @@ st_insert2(st_table *tab, st_data_t key, st_data_t value,
     st_index_t bin_ind;
     int new_p;
 
+    ST_STATS_RECORD_OP(ST_STATS_OP_INSERT);
+    ST_STATS_RECORD_CALLSITE(ST_STATS_OP_INSERT);
     hash_value = do_hash(key, tab);
  retry:
     rebuild_table_if_necessary (tab);
@@ -1309,8 +2028,10 @@ st_insert2(st_table *tab, st_data_t key, st_data_t value,
         entry->hash = hash_value;
         entry->key = key;
         entry->record = value;
-        if (bin_ind != UNDEFINED_BIN_IND)
+        if (bin_ind != UNDEFINED_BIN_IND) {
             set_bin(tab->bins, get_size_ind(tab), bin_ind, ind + ENTRY_BASE);
+            SWISS_SET_CTRL_OCCUPIED(tab, bin_ind, hash_value);
+        }
         return 0;
     }
     tab->entries[bin].record = value;
@@ -1332,6 +2053,20 @@ st_replace(st_table *new_tab, st_table *old_tab)
         }
 #endif
     }
+#ifdef ST_USE_SWISS_BINS
+    if (old_tab->ctrl == NULL) {
+        new_tab->ctrl = NULL;
+    }
+    else {
+        new_tab->ctrl = (unsigned char *) malloc(swiss_ctrl_alloc_size(old_tab));
+#ifndef RUBY
+        if (new_tab->ctrl == NULL) {
+            free(new_tab->bins);
+            return NULL;
+        }
+#endif
+    }
+#endif
     new_tab->entries = (st_table_entry *) malloc(get_allocated_entries(old_tab)
                                                  * sizeof(st_table_entry));
 #ifndef RUBY
@@ -1343,6 +2078,11 @@ st_replace(st_table *new_tab, st_table *old_tab)
            get_allocated_entries(old_tab));
     if (old_tab->bins != NULL)
         MEMCPY(new_tab->bins, old_tab->bins, char, bins_size(old_tab));
+#ifdef ST_USE_SWISS_BINS
+    if (old_tab->ctrl != NULL)
+        MEMCPY(new_tab->ctrl, old_tab->ctrl, unsigned char,
+               swiss_ctrl_alloc_size(old_tab));
+#endif
 
     return new_tab;
 }
@@ -1429,6 +2169,8 @@ st_general_delete(st_table *tab, st_data_t *key, st_data_t *value)
 int
 st_delete(st_table *tab, st_data_t *key, st_data_t *value)
 {
+    ST_STATS_RECORD_OP(ST_STATS_OP_DELETE);
+    ST_STATS_RECORD_CALLSITE(ST_STATS_OP_DELETE);
     return st_general_delete(tab, key, value);
 }
 
@@ -1441,6 +2183,8 @@ int
 st_delete_safe(st_table *tab, st_data_t *key, st_data_t *value,
                st_data_t never ATTRIBUTE_UNUSED)
 {
+    ST_STATS_RECORD_OP(ST_STATS_OP_DELETE);
+    ST_STATS_RECORD_CALLSITE(ST_STATS_OP_DELETE);
     return st_general_delete(tab, key, value);
 }
 
@@ -1456,6 +2200,8 @@ st_shift(st_table *tab, st_data_t *key, st_data_t *value)
     st_table_entry *entries, *curr_entry_ptr;
     st_index_t bin_ind;
 
+    ST_STATS_RECORD_OP(ST_STATS_OP_OTHER);
+    ST_STATS_RECORD_CALLSITE(ST_STATS_OP_OTHER);
     entries = tab->entries;
     bound = tab->entries_bound;
     for (i = tab->entries_start; i < bound; i++) {
@@ -1522,6 +2268,9 @@ st_update(st_table *tab, st_data_t key,
     st_data_t value = 0, old_key;
     int retval, existing;
     st_hash_t hash = do_hash(key, tab);
+
+    ST_STATS_RECORD_OP(ST_STATS_OP_OTHER);
+    ST_STATS_RECORD_CALLSITE(ST_STATS_OP_OTHER);
 
  retry:
     entries = tab->entries;
@@ -2196,6 +2945,9 @@ st_expand_table(st_table *tab, st_index_t siz)
     tab->size_ind = tmp->size_ind;
     tab->entries = tmp->entries;
     tab->bins = NULL;
+#ifdef ST_USE_SWISS_BINS
+    tab->ctrl = NULL;
+#endif
     tab->rebuilds_num++;
     free_fixed_ptr(tmp);
 }
@@ -2211,6 +2963,9 @@ st_rehash_linear(st_table *tab)
 
     st_free_bins(tab);
     tab->bins = NULL;
+#ifdef ST_USE_SWISS_BINS
+    tab->ctrl = NULL;
+#endif
 
     for (i = tab->entries_start; i < tab->entries_bound; i++) {
         p = &tab->entries[i];
@@ -2245,8 +3000,17 @@ st_rehash_indexed(st_table *tab)
     if (!tab->bins) {
         tab->bins = malloc(bins_size(tab));
     }
+#ifdef ST_USE_SWISS_BINS
+    if (!tab->ctrl && tab->entry_power >= SWISS_MIN_ENTRY_POWER) {
+        tab->ctrl = malloc(swiss_ctrl_alloc_size(tab));
+    }
+#endif
     unsigned int const size_ind = get_size_ind(tab);
     initialize_bins(tab);
+#ifdef ST_USE_SWISS_BINS
+    if (tab->ctrl != NULL)
+        memset(tab->ctrl, ST_SWISS_CTRL_EMPTY, swiss_ctrl_alloc_size(tab));
+#endif
     for (i = tab->entries_start; i < tab->entries_bound; i++) {
         st_table_entry *p = &tab->entries[i];
         st_index_t ind;
@@ -2265,6 +3029,7 @@ st_rehash_indexed(st_table *tab)
             if (EMPTY_OR_DELETED_BIN_P(bin)) {
                 /* ok, new room */
                 set_bin(tab->bins, size_ind, ind, i + ENTRY_BASE);
+                SWISS_SET_CTRL_OCCUPIED(tab, ind, p->hash);
                 break;
             }
             else {


### PR DESCRIPTION
This change adds a Swiss-table-inspired probing layer to Ruby's core
`st_table`, and shrinks `st_table_entry` from 24 B to 16 B by moving the
stored hash into a parallel array. It is built and enabled by default;
`--disable-swiss-st` reverts to the original `st.c`. The public ABI of
`struct st_table` and the iteration-order guarantee are preserved.

## Motivation

Hashes are everywhere in Ruby — instance-variable tables, ivar shapes,
constant tables, JSON/HTTP/AR rows, every `params`, every `to_h`. Profiles
of Rails-shaped workloads spend a meaningful fraction of CPU inside
`st_lookup` and `st_insert`. Two pain points stood out in the upstream
implementation:

1. **Probe loops are branch-heavy.** Every step of the perturb chain
   loads a bin, fetches the entry it points to, compares the full
   `st_hash_t` (8 B) and only then calls `eql?`. On a miss that is
   several dependent loads per probe with no way to fast-reject groups
   of slots in parallel.
2. **`st_table_entry` is 24 B.** The `(hash, key, record)` triple gets
   one cache line per ~2.5 entries. Iteration and equality scans burn
   through L1 quickly, and Ruby programs typically hold a *lot* of
   small-to-mid-sized hashes (so per-table overhead matters).

The Swiss-table family of designs (Abseil `flat_hash_map`, Rust
`hashbrown`) addresses (1) with a 1-byte-per-slot **control array**
that lets a single SIMD/SWAR comparison reject or short-list 8 slots at
once. We borrow that idea but keep Ruby's two-array layout (so we don't
break ABI or insertion order) and add a third, parallel `ctrl[]` byte
array. We then attack (2) by also extracting the hash field out of
`st_table_entry` into its own parallel `uint32_t hashes[]` array.

---

## Design

### 1. Three-array layout

| array       | width                       | role                                                                       |
| ----------- | --------------------------- | -------------------------------------------------------------------------- |
| `entries[]` | 16 B (was 24 B)             | insertion-order log of `(key, record)`                                     |
| `hashes[]`  | 4 B per slot                | parallel array of truncated 32-bit hashes (also encodes the tombstone)     |
| `bins[]`    | adaptive 1 / 2 / 4 / 8 B    | hash-indexed array of indices into `entries[]`                             |
| `ctrl[]`    | 1 B per slot                | `H2` (top 7 bits of hash) or `EMPTY (0xff)` / `DELETED (0xfe)`             |

`entries[]` and `hashes[]` are the same length and addressed by the
same index, so iteration and slot reuse stay trivial. `ctrl[]` is the
fast-reject filter and lives alongside `bins[]`; only when a `ctrl`
byte matches H2 do we load the (now smaller) entry and the parallel
hash to confirm the match. SWAR is done on `uint64_t` reads of
`ctrl[]` so the per-group cost is a handful of bitwise ops with no
SIMD register transfer (which on Apple Silicon was not a win — see
"What we tried but didn't keep" below).

### 2. Compact `st_table_entry`

Before:

```c
struct st_table_entry {
    st_hash_t  hash;    /* 8 B */
    st_data_t  key;     /* 8 B */
    st_data_t  record;  /* 8 B */
};                       /* 24 B */
```

After (when `ST_USE_SWISS_BINS` is on, which is the default):

```c
struct st_table_entry {
    st_data_t  key;     /* 8 B */
    st_data_t  record;  /* 8 B */
};                       /* 16 B */
```

The hash moves into `tab->hashes[i]`, a `uint32_t` (so two slots fit
per 8-byte word, four entries per cache line). All access goes through
`ST_HASH_AT_PTR` / `ST_HASH_AT_IDX` macros so the same source compiles
unchanged when the feature is disabled. The `set_table` variant keeps
its original inline-hash layout — it already uses 16 B entries and is
not part of `st_table`'s ABI footprint.

### 3. The new hash function (the part that needed the most care)

Storing only the low 32 bits of the hash means we can no longer read
H2 from the *top* 7 bits of the original `unsigned long` hash, which is
what a textbook Swiss design does. Naively recomputing the full 64-bit
hash from the key on every rebuild / rehash / `st_shift` /
`st_general_foreach` works for correctness but kills insert and rebuild
performance — equality+hash for strings is not free.

The fix is to derive H2 from a band of the *truncated* 32-bit hash,
disjoint from the band that picks the bin:

```c
/* bin index: low `bin_power` bits, masked by `bins_mask(tab)`     */
hash_bin(uint32_t h, st_table *tab) { return h & bins_mask(tab); }

/* H2: bits 25..31 of the same 32-bit hash, never overlaps with     */
/* the bin index because bin_power is capped well under 25 in       */
/* practice.                                                        */
static inline unsigned char
st_swiss_h2(st_hash_t hash) {
    return (unsigned char)((hash >> 25) & 0x7f);
}
```

This makes the stored `uint32_t` self-sufficient: every probe reads
both the bin index and the H2 byte from the same word, no `do_hash()`
call required, and rebuild/rehash/shift/foreach all use
`ST_HASH_AT_IDX(tab, i)` instead of recomputing.

Two additional details that fall out of the truncation:

1. `normalize_hash_value()` is updated so that `0xFFFFFFFF` (the
   tombstone marker for the 32-bit hash slot) never collides with a
   real hash value — if the truncation lands on the reserved value we
   bump it. The 64-bit reservation is preserved on platforms that
   compile without `ST_USE_SWISS_BINS`.
2. The `MARK_ENTRY_DELETED` / `DELETED_ENTRY_P` macros now take the
   table as a parameter so they can read/write the parallel hash slot.

### 4. Prefetch on H2 match

When SWAR finds a candidate H2 match in a control group, the next
operation is loading the matching `st_table_entry` and the parallel
hash word — both of which are in cold cache lines on a miss. We issue
`__builtin_prefetch` on both immediately after the match is detected
in `find_table_entry_ind` / `find_table_bin_ind` /
`find_table_bin_ptr_and_reserve`. On lookup-heavy workloads this hides
a meaningful chunk of the L2 latency that the SWAR fast-filter would
otherwise expose.

### 5. What we tried but didn't keep

* **SSE2 / NEON intrinsics for the group scan.** On Apple Silicon the
  vector-to-GPR transfer for the match mask cost more than the entire
  SWAR sequence; on x86_64 the win, if any, was within noise. SWAR is
  the only shipped backend.
* **Recomputing the full 64-bit hash** in rebuild/rehash paths to keep
  H2 in the high bits. Correct but cost ~5–10 % on insert workloads;
  superseded by the bit-band trick above.

---

## Results vs `master`

Both binaries built from the same tree (`master = 42b3cdc51a`,
`swiss = 3c0446847f`), same compiler, same flags. Each script run 5×
with `--disable-gems`, best-of-N reported. Memory is `maximum resident
set size` from `/usr/bin/time -l` on macOS arm64 (M-class).

### Throughput (lower wall time = better)

| benchmark         | master (s) | swiss (s) | speedup |
| ----------------- | ---------: | --------: | ------: |
| aref_int_large    |     0.8352 |    0.6862 | **+17.8 %** |
| aref_str_large    |     0.9915 |    0.8406 | **+15.2 %** |
| aref_miss_large   |     1.0803 |    0.7896 | **+26.9 %** |
| aref_mix_50       |     1.0337 |    0.8201 | **+20.7 %** |
| insert_grow       |     0.1138 |    0.1105 |    +2.9 % |
| churn (mixed RW)  |     0.0321 |    0.0304 |    +5.5 % |
| iterate           |     0.0566 |    0.0565 |   ±0.1 %  |

Lookups are the headline win — both successful (`+15 % … +20 %`) and
missing (`+27 %`), the latter because a missing key now short-circuits
on the first SWAR group with no entry/bin loads at all. Inserts and
churn are modestly faster because rebuilds no longer call `do_hash`.
Iteration is unaffected (it never touched bins or ctrl).

### Memory

Process RSS for the benchmark workloads (same runs):

| benchmark         | master (MB) | swiss (MB) | delta |
| ----------------- | ----------: | ---------: | ----: |
| insert_grow       |       66.62 |      60.44 | **−9.3 %** |
| aref_str_large    |       15.27 |      15.23 |   −0.3 % |
| aref_mix_50       |       16.64 |      16.61 |   −0.2 % |
| churn             |       13.19 |      13.03 |   −1.2 % |

Per-table memory (`ObjectSpace.memsize_of`, sum across many hashes):

| workload                                 | master    | swiss     | delta       |
| ---------------------------------------- | --------: | --------: | ----------: |
| 2 000 hashes × 200 entries               | 14.66 MB  | 12.11 MB  | **−17.4 %** |
| 1 hash × 100 000 entries                 |  4.19 MB  |  3.28 MB  | **−21.9 %** |

The two memory views agree: any workload that holds a meaningful
number of entries live (whether one big hash or many small ones) sees
double-digit shrinkage from the 24 B → 16 B entry plus the 1 B
`ctrl[]` / 4 B `hashes[]` pair, because they together (`5 B` per slot)
cost less than the 8 B saved per slot in `entries[]`. Per-table
overhead at fewer than ~64 entries is roughly flat; the Swiss path
itself only kicks in at `entry_power ≥ 6` (table capacity ≥ 64).