### PR TITLE
Introduce `IO::Buffer#bit_count`.

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3731,7 +3731,7 @@ io_buffer_not_inplace(VALUE self)
 }
 
 static size_t
-memory_popcount(const unsigned char *base, size_t size)
+memory_bit_count(const unsigned char *base, size_t size)
 {
     size_t count = 0;
 
@@ -3753,20 +3753,20 @@ memory_popcount(const unsigned char *base, size_t size)
 }
 
 /*
- *  call-seq: popcount([offset, [length]]) -> integer
+ *  call-seq: bit_count([offset, [length]]) -> integer
  *
  *  Returns the number of set bits (1s) in the buffer, also known as the
  *  Hamming weight or population count. An optional +offset+ and +length+
  *  can be provided to count bits in a subrange of the buffer.
  *
- *    IO::Buffer.for("\xFF\x00\x0F").popcount
+ *    IO::Buffer.for("\xFF\x00\x0F").bit_count
  *    # => 12
  *
- *    IO::Buffer.for("\xFF\x00\x0F").popcount(1, 2)
+ *    IO::Buffer.for("\xFF\x00\x0F").bit_count(1, 2)
  *    # => 4
  */
 static VALUE
-io_buffer_popcount(int argc, VALUE *argv, VALUE self)
+io_buffer_bit_count(int argc, VALUE *argv, VALUE self)
 {
     rb_check_arity(argc, 0, 2);
 
@@ -3779,7 +3779,7 @@ io_buffer_popcount(int argc, VALUE *argv, VALUE self)
     size_t size;
     io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
-    size_t count = memory_popcount((const unsigned char *)base + offset, length);
+    size_t count = memory_bit_count((const unsigned char *)base + offset, length);
 
     return SIZET2NUM(count);
 }
@@ -4039,7 +4039,7 @@ Init_IO_Buffer(void)
     rb_define_method(rb_cIOBuffer, "xor!", io_buffer_xor_inplace, 1);
     rb_define_method(rb_cIOBuffer, "not!", io_buffer_not_inplace, 0);
 
-    rb_define_method(rb_cIOBuffer, "popcount", io_buffer_popcount, -1);
+    rb_define_method(rb_cIOBuffer, "bit_count", io_buffer_bit_count, -1);
 
     // IO operations:
     rb_define_method(rb_cIOBuffer, "read", io_buffer_read, -1);

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3730,6 +3730,60 @@ io_buffer_not_inplace(VALUE self)
     return self;
 }
 
+static size_t
+memory_popcount(const unsigned char *base, size_t size)
+{
+    size_t count = 0;
+
+    // Process 8 bytes at a time for efficiency:
+    const uint64_t *base64 = (const uint64_t *)base;
+    size_t count64 = size / 8;
+    for (size_t i = 0; i < count64; i += 1) {
+        count += rb_popcount64(base64[i]);
+    }
+
+    // Process any remaining bytes:
+    size_t remaining = size % 8;
+    const unsigned char *tail = base + (count64 * 8);
+    for (size_t i = 0; i < remaining; i += 1) {
+        count += rb_popcount32(tail[i]);
+    }
+
+    return count;
+}
+
+/*
+ *  call-seq: popcount([offset, [length]]) -> integer
+ *
+ *  Returns the number of set bits (1s) in the buffer, also known as the
+ *  Hamming weight or population count. An optional +offset+ and +length+
+ *  can be provided to count bits in a subrange of the buffer.
+ *
+ *    IO::Buffer.for("\xFF\x00\x0F").popcount
+ *    # => 12
+ *
+ *    IO::Buffer.for("\xFF\x00\x0F").popcount(1, 2)
+ *    # => 4
+ */
+static VALUE
+io_buffer_popcount(int argc, VALUE *argv, VALUE self)
+{
+    rb_check_arity(argc, 0, 2);
+
+    size_t offset, length;
+    struct rb_io_buffer *buffer = io_buffer_extract_offset_length(self, argc, argv, &offset, &length);
+
+    io_buffer_validate_range(buffer, offset, length);
+
+    const void *base;
+    size_t size;
+    io_buffer_get_bytes_for_reading(buffer, &base, &size);
+
+    size_t count = memory_popcount((const unsigned char *)base + offset, length);
+
+    return SIZET2NUM(count);
+}
+
 /*
  *  Document-class: IO::Buffer
  *
@@ -3984,6 +4038,8 @@ Init_IO_Buffer(void)
     rb_define_method(rb_cIOBuffer, "or!", io_buffer_or_inplace, 1);
     rb_define_method(rb_cIOBuffer, "xor!", io_buffer_xor_inplace, 1);
     rb_define_method(rb_cIOBuffer, "not!", io_buffer_not_inplace, 0);
+
+    rb_define_method(rb_cIOBuffer, "popcount", io_buffer_popcount, -1);
 
     // IO operations:
     rb_define_method(rb_cIOBuffer, "read", io_buffer_read, -1);

--- a/spec/ruby/core/io/buffer/bit_count_spec.rb
+++ b/spec/ruby/core/io/buffer/bit_count_spec.rb
@@ -1,63 +1,63 @@
 require_relative '../../../spec_helper'
 
 ruby_version_is "4.1" do
-  describe "IO::Buffer#popcount" do
+  describe "IO::Buffer#bit_count" do
     it "counts all set bits in the whole buffer" do
       IO::Buffer.for(+"\xFF\x00\x0F") do |buffer|
-        buffer.popcount.should == 12
+        buffer.bit_count.should == 12
       end
     end
 
     it "returns 0 for a buffer of all zero bytes" do
       IO::Buffer.for(+"\x00\x00\x00") do |buffer|
-        buffer.popcount.should == 0
+        buffer.bit_count.should == 0
       end
     end
 
     it "returns 8 * size for a buffer of all 0xFF bytes" do
       IO::Buffer.for(+"\xFF" * 9) do |buffer|
-        buffer.popcount.should == 72
+        buffer.bit_count.should == 72
       end
     end
 
     it "returns 0 for an empty buffer" do
-      IO::Buffer.new(0).popcount.should == 0
+      IO::Buffer.new(0).bit_count.should == 0
     end
 
     it "accepts an offset to start counting from (length defaults to remaining bytes)" do
       IO::Buffer.for(+"\xFF\x00\x0F") do |buffer|
-        buffer.popcount(0).should == 12  # offset=0 => entire buffer
-        buffer.popcount(1).should == 4   # offset=1 => 0x00 + 0x0F
-        buffer.popcount(2).should == 4   # offset=2 => 0x0F only
+        buffer.bit_count(0).should == 12  # offset=0 => entire buffer
+        buffer.bit_count(1).should == 4   # offset=1 => 0x00 + 0x0F
+        buffer.bit_count(2).should == 4   # offset=2 => 0x0F only
       end
     end
 
     it "accepts an offset and length to restrict the counted region" do
       IO::Buffer.for(+"\xFF\x00\x0F") do |buffer|
-        buffer.popcount(0, 1).should == 8  # just 0xFF
-        buffer.popcount(1, 1).should == 0  # just 0x00
-        buffer.popcount(2, 1).should == 4  # just 0x0F
-        buffer.popcount(1, 2).should == 4  # 0x00 + 0x0F
+        buffer.bit_count(0, 1).should == 8  # just 0xFF
+        buffer.bit_count(1, 1).should == 0  # just 0x00
+        buffer.bit_count(2, 1).should == 4  # just 0x0F
+        buffer.bit_count(1, 2).should == 4  # 0x00 + 0x0F
       end
     end
 
     it "handles 8-byte aligned buffers efficiently" do
       IO::Buffer.for(+"\xAA" * 8) do |buffer|
         # 0xAA = 10101010 => 4 bits per byte => 32 total
-        buffer.popcount.should == 32
+        buffer.bit_count.should == 32
       end
     end
 
     it "raises ArgumentError when offset + length exceeds buffer size" do
       IO::Buffer.for(+"\xFF") do |buffer|
-        -> { buffer.popcount(0, 2) }.should raise_error(ArgumentError)
-        -> { buffer.popcount(1, 1) }.should raise_error(ArgumentError)
+        -> { buffer.bit_count(0, 2) }.should raise_error(ArgumentError)
+        -> { buffer.bit_count(1, 1) }.should raise_error(ArgumentError)
       end
     end
 
     it "returns an Integer" do
       IO::Buffer.for(+"\xFF") do |buffer|
-        buffer.popcount.should be_kind_of(Integer)
+        buffer.bit_count.should be_kind_of(Integer)
       end
     end
   end

--- a/spec/ruby/core/io/buffer/popcount_spec.rb
+++ b/spec/ruby/core/io/buffer/popcount_spec.rb
@@ -1,62 +1,64 @@
 require_relative '../../../spec_helper'
 
-describe "IO::Buffer#popcount" do
-  it "counts all set bits in the whole buffer" do
-    IO::Buffer.for(+"\xFF\x00\x0F") do |buffer|
-      buffer.popcount.should == 12
+ruby_version_is "4.1" do
+  describe "IO::Buffer#popcount" do
+    it "counts all set bits in the whole buffer" do
+      IO::Buffer.for(+"\xFF\x00\x0F") do |buffer|
+        buffer.popcount.should == 12
+      end
     end
-  end
 
-  it "returns 0 for a buffer of all zero bytes" do
-    IO::Buffer.for(+"\x00\x00\x00") do |buffer|
-      buffer.popcount.should == 0
+    it "returns 0 for a buffer of all zero bytes" do
+      IO::Buffer.for(+"\x00\x00\x00") do |buffer|
+        buffer.popcount.should == 0
+      end
     end
-  end
 
-  it "returns 8 * size for a buffer of all 0xFF bytes" do
-    IO::Buffer.for(+"\xFF" * 9) do |buffer|
-      buffer.popcount.should == 72
+    it "returns 8 * size for a buffer of all 0xFF bytes" do
+      IO::Buffer.for(+"\xFF" * 9) do |buffer|
+        buffer.popcount.should == 72
+      end
     end
-  end
 
-  it "returns 0 for an empty buffer" do
-    IO::Buffer.new(0).popcount.should == 0
-  end
-
-  it "accepts an offset to start counting from (length defaults to remaining bytes)" do
-    IO::Buffer.for(+"\xFF\x00\x0F") do |buffer|
-      buffer.popcount(0).should == 12  # offset=0 => entire buffer
-      buffer.popcount(1).should == 4   # offset=1 => 0x00 + 0x0F
-      buffer.popcount(2).should == 4   # offset=2 => 0x0F only
+    it "returns 0 for an empty buffer" do
+      IO::Buffer.new(0).popcount.should == 0
     end
-  end
 
-  it "accepts an offset and length to restrict the counted region" do
-    IO::Buffer.for(+"\xFF\x00\x0F") do |buffer|
-      buffer.popcount(0, 1).should == 8  # just 0xFF
-      buffer.popcount(1, 1).should == 0  # just 0x00
-      buffer.popcount(2, 1).should == 4  # just 0x0F
-      buffer.popcount(1, 2).should == 4  # 0x00 + 0x0F
+    it "accepts an offset to start counting from (length defaults to remaining bytes)" do
+      IO::Buffer.for(+"\xFF\x00\x0F") do |buffer|
+        buffer.popcount(0).should == 12  # offset=0 => entire buffer
+        buffer.popcount(1).should == 4   # offset=1 => 0x00 + 0x0F
+        buffer.popcount(2).should == 4   # offset=2 => 0x0F only
+      end
     end
-  end
 
-  it "handles 8-byte aligned buffers efficiently" do
-    IO::Buffer.for(+"\xAA" * 8) do |buffer|
-      # 0xAA = 10101010 => 4 bits per byte => 32 total
-      buffer.popcount.should == 32
+    it "accepts an offset and length to restrict the counted region" do
+      IO::Buffer.for(+"\xFF\x00\x0F") do |buffer|
+        buffer.popcount(0, 1).should == 8  # just 0xFF
+        buffer.popcount(1, 1).should == 0  # just 0x00
+        buffer.popcount(2, 1).should == 4  # just 0x0F
+        buffer.popcount(1, 2).should == 4  # 0x00 + 0x0F
+      end
     end
-  end
 
-  it "raises ArgumentError when offset + length exceeds buffer size" do
-    IO::Buffer.for(+"\xFF") do |buffer|
-      -> { buffer.popcount(0, 2) }.should raise_error(ArgumentError)
-      -> { buffer.popcount(1, 1) }.should raise_error(ArgumentError)
+    it "handles 8-byte aligned buffers efficiently" do
+      IO::Buffer.for(+"\xAA" * 8) do |buffer|
+        # 0xAA = 10101010 => 4 bits per byte => 32 total
+        buffer.popcount.should == 32
+      end
     end
-  end
 
-  it "returns an Integer" do
-    IO::Buffer.for(+"\xFF") do |buffer|
-      buffer.popcount.should be_kind_of(Integer)
+    it "raises ArgumentError when offset + length exceeds buffer size" do
+      IO::Buffer.for(+"\xFF") do |buffer|
+        -> { buffer.popcount(0, 2) }.should raise_error(ArgumentError)
+        -> { buffer.popcount(1, 1) }.should raise_error(ArgumentError)
+      end
+    end
+
+    it "returns an Integer" do
+      IO::Buffer.for(+"\xFF") do |buffer|
+        buffer.popcount.should be_kind_of(Integer)
+      end
     end
   end
 end

--- a/spec/ruby/core/io/buffer/popcount_spec.rb
+++ b/spec/ruby/core/io/buffer/popcount_spec.rb
@@ -1,0 +1,62 @@
+require_relative '../../../spec_helper'
+
+describe "IO::Buffer#popcount" do
+  it "counts all set bits in the whole buffer" do
+    IO::Buffer.for(+"\xFF\x00\x0F") do |buffer|
+      buffer.popcount.should == 12
+    end
+  end
+
+  it "returns 0 for a buffer of all zero bytes" do
+    IO::Buffer.for(+"\x00\x00\x00") do |buffer|
+      buffer.popcount.should == 0
+    end
+  end
+
+  it "returns 8 * size for a buffer of all 0xFF bytes" do
+    IO::Buffer.for(+"\xFF" * 9) do |buffer|
+      buffer.popcount.should == 72
+    end
+  end
+
+  it "returns 0 for an empty buffer" do
+    IO::Buffer.new(0).popcount.should == 0
+  end
+
+  it "accepts an offset to start counting from (length defaults to remaining bytes)" do
+    IO::Buffer.for(+"\xFF\x00\x0F") do |buffer|
+      buffer.popcount(0).should == 12  # offset=0 => entire buffer
+      buffer.popcount(1).should == 4   # offset=1 => 0x00 + 0x0F
+      buffer.popcount(2).should == 4   # offset=2 => 0x0F only
+    end
+  end
+
+  it "accepts an offset and length to restrict the counted region" do
+    IO::Buffer.for(+"\xFF\x00\x0F") do |buffer|
+      buffer.popcount(0, 1).should == 8  # just 0xFF
+      buffer.popcount(1, 1).should == 0  # just 0x00
+      buffer.popcount(2, 1).should == 4  # just 0x0F
+      buffer.popcount(1, 2).should == 4  # 0x00 + 0x0F
+    end
+  end
+
+  it "handles 8-byte aligned buffers efficiently" do
+    IO::Buffer.for(+"\xAA" * 8) do |buffer|
+      # 0xAA = 10101010 => 4 bits per byte => 32 total
+      buffer.popcount.should == 32
+    end
+  end
+
+  it "raises ArgumentError when offset + length exceeds buffer size" do
+    IO::Buffer.for(+"\xFF") do |buffer|
+      -> { buffer.popcount(0, 2) }.should raise_error(ArgumentError)
+      -> { buffer.popcount(1, 1) }.should raise_error(ArgumentError)
+    end
+  end
+
+  it "returns an Integer" do
+    IO::Buffer.for(+"\xFF") do |buffer|
+      buffer.popcount.should be_kind_of(Integer)
+    end
+  end
+end

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -694,34 +694,34 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal IO::Buffer.for("\xce\xcd\xcc\xcb\xce\xcd\xcc\xcb\xce\xcd"), source.dup.not!
   end
 
-  def test_popcount
+  def test_bit_count
     # All ones: 8 bits set per byte
-    assert_equal 8,  IO::Buffer.for("\xFF").popcount
+    assert_equal 8,  IO::Buffer.for("\xFF").bit_count
     # All zeros: no bits set
-    assert_equal 0,  IO::Buffer.for("\x00").popcount
+    assert_equal 0,  IO::Buffer.for("\x00").bit_count
     # Mixed: 0xFF (8) + 0x00 (0) + 0x0F (4) = 12
-    assert_equal 12, IO::Buffer.for("\xFF\x00\x0F").popcount
+    assert_equal 12, IO::Buffer.for("\xFF\x00\x0F").bit_count
     # Subrange: offset=0, length=1 => 0xFF => 8
-    assert_equal 8,  IO::Buffer.for("\xFF\x00\x0F").popcount(0, 1)
+    assert_equal 8,  IO::Buffer.for("\xFF\x00\x0F").bit_count(0, 1)
     # Subrange: offset=1, length=1 => 0x00 => 0
-    assert_equal 0,  IO::Buffer.for("\xFF\x00\x0F").popcount(1, 1)
+    assert_equal 0,  IO::Buffer.for("\xFF\x00\x0F").bit_count(1, 1)
     # Subrange: offset=2, length=1 => 0x0F => 4
-    assert_equal 4,  IO::Buffer.for("\xFF\x00\x0F").popcount(2, 1)
+    assert_equal 4,  IO::Buffer.for("\xFF\x00\x0F").bit_count(2, 1)
     # Subrange: offset=1, length=2 => 0x00 + 0x0F = 4
-    assert_equal 4,  IO::Buffer.for("\xFF\x00\x0F").popcount(1, 2)
+    assert_equal 4,  IO::Buffer.for("\xFF\x00\x0F").bit_count(1, 2)
     # Empty buffer: 0
-    assert_equal 0,  IO::Buffer.new(0).popcount
+    assert_equal 0,  IO::Buffer.new(0).bit_count
     # 8-byte aligned: 8 bytes of 0xFF => 64 bits
-    assert_equal 64, IO::Buffer.for("\xFF" * 8).popcount
+    assert_equal 64, IO::Buffer.for("\xFF" * 8).bit_count
     # Cross 8-byte boundary: 9 bytes of 0xFF => 72 bits
-    assert_equal 72, IO::Buffer.for("\xFF" * 9).popcount
+    assert_equal 72, IO::Buffer.for("\xFF" * 9).bit_count
     # offset=0 with no length => defaults to full buffer:
-    assert_equal 12, IO::Buffer.for("\xFF\x00\x0F").popcount(0)
+    assert_equal 12, IO::Buffer.for("\xFF\x00\x0F").bit_count(0)
     # offset=1 with no length => 0x00 + 0x0F = 4:
-    assert_equal 4,  IO::Buffer.for("\xFF\x00\x0F").popcount(1)
+    assert_equal 4,  IO::Buffer.for("\xFF\x00\x0F").bit_count(1)
     # Out-of-range raises
-    assert_raise(ArgumentError) { IO::Buffer.for("\xFF").popcount(0, 2) }
-    assert_raise(ArgumentError) { IO::Buffer.for("\xFF").popcount(1, 1) }
+    assert_raise(ArgumentError) { IO::Buffer.for("\xFF").bit_count(0, 2) }
+    assert_raise(ArgumentError) { IO::Buffer.for("\xFF").bit_count(1, 1) }
   end
 
   def test_shared

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -694,6 +694,36 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal IO::Buffer.for("\xce\xcd\xcc\xcb\xce\xcd\xcc\xcb\xce\xcd"), source.dup.not!
   end
 
+  def test_popcount
+    # All ones: 8 bits set per byte
+    assert_equal 8,  IO::Buffer.for("\xFF").popcount
+    # All zeros: no bits set
+    assert_equal 0,  IO::Buffer.for("\x00").popcount
+    # Mixed: 0xFF (8) + 0x00 (0) + 0x0F (4) = 12
+    assert_equal 12, IO::Buffer.for("\xFF\x00\x0F").popcount
+    # Subrange: offset=0, length=1 => 0xFF => 8
+    assert_equal 8,  IO::Buffer.for("\xFF\x00\x0F").popcount(0, 1)
+    # Subrange: offset=1, length=1 => 0x00 => 0
+    assert_equal 0,  IO::Buffer.for("\xFF\x00\x0F").popcount(1, 1)
+    # Subrange: offset=2, length=1 => 0x0F => 4
+    assert_equal 4,  IO::Buffer.for("\xFF\x00\x0F").popcount(2, 1)
+    # Subrange: offset=1, length=2 => 0x00 + 0x0F = 4
+    assert_equal 4,  IO::Buffer.for("\xFF\x00\x0F").popcount(1, 2)
+    # Empty buffer: 0
+    assert_equal 0,  IO::Buffer.new(0).popcount
+    # 8-byte aligned: 8 bytes of 0xFF => 64 bits
+    assert_equal 64, IO::Buffer.for("\xFF" * 8).popcount
+    # Cross 8-byte boundary: 9 bytes of 0xFF => 72 bits
+    assert_equal 72, IO::Buffer.for("\xFF" * 9).popcount
+    # offset=0 with no length => defaults to full buffer:
+    assert_equal 12, IO::Buffer.for("\xFF\x00\x0F").popcount(0)
+    # offset=1 with no length => 0x00 + 0x0F = 4:
+    assert_equal 4,  IO::Buffer.for("\xFF\x00\x0F").popcount(1)
+    # Out-of-range raises
+    assert_raise(ArgumentError) { IO::Buffer.for("\xFF").popcount(0, 2) }
+    assert_raise(ArgumentError) { IO::Buffer.for("\xFF").popcount(1, 1) }
+  end
+
   def test_shared
     message = "Hello World"
     buffer = IO::Buffer.new(64, IO::Buffer::MAPPED | IO::Buffer::SHARED)


### PR DESCRIPTION
Introduce `IO::Buffer#bit_count([offset, [length]])`.

## Example Usage (zero copy String bit_count)

```
# Map an existing string into an IO::Buffer and use bit_count.

string = "Hello, World!"
puts "String:          #{string.inspect}"
puts "Bytes:           #{string.bytes.map { |b| "%08b" % b }.join(" ")}"
puts

IO::Buffer.for(string) do |buffer|
  puts "Buffer:          #{buffer.inspect}"
  puts

  puts "bit_count (all):  #{buffer.bit_count}"
  puts

  # Count bits in each individual byte to show the per-byte breakdown:
  string.bytesize.times do |i|
    byte   = string.getbyte(i)
    bits   = "%08b" % byte
    count  = buffer.bit_count(i, 1)
    puts "  [#{i}] 0x%02X  #{bits}  bit_count=#{count}  (#{string[i].inspect})" % byte
  end
  puts

  # Subrange example: just "World"
  offset = string.index("World")
  length = "World".bytesize
  puts "bit_count(#{offset}, #{length}) \"World\":  #{buffer.bit_count(offset, length)}"
end
```

### Output

```
String:          "Hello, World!"
Bytes:           01001000 01100101 01101100 01101100 01101111 00101100 00100000 01010111 01101111 01110010 01101100 01100100 00100001

./test.rb:8: warning: IO::Buffer is experimental and both the Ruby and C interface may change in the future!
Buffer:          #<IO::Buffer 0x000000012090a658+13 EXTERNAL SLICE>
0x00000000  48 65 6c 6c 6f 2c 20 57 6f 72 6c 64 21          Hello, World!

bit_count (all):  48

  [0] 0x48  01001000  bit_count=2  ("H")
  [1] 0x65  01100101  bit_count=4  ("e")
  [2] 0x6C  01101100  bit_count=4  ("l")
  [3] 0x6C  01101100  bit_count=4  ("l")
  [4] 0x6F  01101111  bit_count=6  ("o")
  [5] 0x2C  00101100  bit_count=3  (",")
  [6] 0x20  00100000  bit_count=1  (" ")
  [7] 0x57  01010111  bit_count=5  ("W")
  [8] 0x6F  01101111  bit_count=6  ("o")
  [9] 0x72  01110010  bit_count=4  ("r")
  [10] 0x6C  01101100  bit_count=4  ("l")
  [11] 0x64  01100100  bit_count=3  ("d")
  [12] 0x21  00100001  bit_count=2  ("!")

bit_count(7, 5) "World":  22
```

cc @tenderlove 