### PR TITLE
Hide ractor traversal object hash

### DIFF
--- a/ractor.c
+++ b/ractor.c
@@ -1270,6 +1270,7 @@ obj_traverse_rec(struct obj_traverse_data *data)
 {
     if (UNLIKELY(!data->rec)) {
         data->rec_hash = rb_ident_hash_new();
+        rb_obj_hide(data->rec_hash);
         data->rec = RHASH_ST_TABLE(data->rec_hash);
     }
     return data->rec;


### PR DESCRIPTION
This could contain other hidden objects, and so needs to be hidden itself so as to not be seen by ObjectSpace.each_object

```
1000.times { ObjectSpace.each_object(Hash){|o| puts o.inspect; ObjectSpace.reachable_objects_from(Class) } }'
```

    :in 'Hash#inspect': method 'inspect' called on hidden T_ARRAY object (0x00007f284bffba00 flags=0x10000000012a907) (NotImplementedError)
        from -e:1:in 'block (2 levels) in <main>'
        from -e:1:in 'ObjectSpace.each_object'
        from -e:1:in 'block in <main>'
        from -e:1:in 'Integer#times'
        from -e:1:in '<main>'