### PR TITLE
Add test for compile option support

### DIFF
--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -212,6 +212,26 @@ class TestISeq < Test::Unit::TestCase
     end
   end
 
+  def test_compile_file_options
+    Tempfile.create(%w"test_iseq .rb") do |f|
+      f.puts('"test"')
+      f.close
+      iseq = RubyVM::InstructionSequence.compile_file(f.path, { frozen_string_literal: false })
+      refute_predicate iseq.eval, :frozen?
+
+      iseq = RubyVM::InstructionSequence.compile_file(f.path, { frozen_string_literal: true })
+      assert_predicate iseq.eval, :frozen?
+    end
+  end
+
+  def test_compile_options
+    iseq = RubyVM::InstructionSequence.compile("'test'", nil, nil, nil, { frozen_string_literal: false })
+    refute_predicate iseq.eval, :frozen?
+
+    iseq = RubyVM::InstructionSequence.compile("'test'", nil, nil, nil, { frozen_string_literal: true })
+    assert_predicate iseq.eval, :frozen?
+  end
+
   LINE_BEFORE_METHOD = __LINE__
   def method_test_line_trace
 


### PR DESCRIPTION
The bootsnap test suite ran into a regression in `compile_file`: https://github.com/rails/bootsnap/pull/535

Apparently it has already been fixed.
