### PR TITLE
rb_gc_impl_heap_sizes: include RVALUE_OVERHEAD

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -2420,7 +2420,7 @@ rb_gc_impl_heap_sizes(void *objspace_ptr)
 {
     if (heap_sizes[0] == 0) {
         for (unsigned char i = 0; i < HEAP_COUNT; i++) {
-            heap_sizes[i] = heap_slot_size(i);
+            heap_sizes[i] = heap_slot_size(i) + RVALUE_OVERHEAD;
         }
     }
 


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/16282

Otherwise all the capacities in `rb_shape_tree.capacities` are off by one.