### PR TITLE
Win32 resolv reads UseDomainNameDevolution (REG_DWORD) as string, emits "Broken registry" warning

### DIFF
--- a/ext/win32/lib/win32/resolv.rb
+++ b/ext/win32/lib/win32/resolv.rb
@@ -43,7 +43,7 @@ module Win32
 #====================================================================
   module Resolv
     begin
-      require 'win32/registry'
+      require 'win32/registry' unless defined?(Win32::Registry)
       module SZ
         refine Registry do
           # ad hoc workaround for broken registry
@@ -83,7 +83,7 @@ module Win32
 
           unless nvdom.empty?
             @search = [ nvdom ]
-            udmnd = get_item_property(TCPIP_NT, 'UseDomainNameDevolution').to_i
+            udmnd = get_item_property_i(TCPIP_NT, 'UseDomainNameDevolution')
             if udmnd != 0
               if /^\w+\./ =~ nvdom
                 devo = $'
@@ -137,6 +137,18 @@ module Win32
           cmd = "Get-ItemProperty -Path 'HKLM:\\#{path}' -Name '#{name}' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty '#{name}'"
           output, _ = Open3.capture2('powershell', '-Command', cmd)
           output.strip
+        end
+      end
+
+      def get_item_property_i(path, name)
+        if defined?(Win32::Registry)
+          Registry::HKEY_LOCAL_MACHINE.open(path) do |reg|
+            reg.read_i(name)
+          rescue Registry::Error
+            0
+          end
+        else
+          get_item_property(path, name).to_i
         end
       end
     end


### PR DESCRIPTION
On Windows, ext/win32/lib/win32/resolv.rb reads the registry value UseDomainNameDevolution via the string path (read_s). On normal systems this key is REG_DWORD, so the code emits:

Broken registry, ...\UseDomainNameDevolution was REG_DWORD, ignored

The registry is valid; the warning is caused by a type mismatch in the code.

Environment:
- Ruby branch: ruby_3_4
- File: ext/win32/lib/win32/resolv.rb
- Downstream observed in CINC 19.2.12 packaging Ruby 3.4.x on Windows
- Registry key type:
  HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\UseDomainNameDevolution = REG_DWORD (for example value 1)

Actual behavior:
- Warning is emitted saying registry is broken when key is REG_DWORD.
- This issue causes CINC bootstrap failure on Windows devices.

Expected behavior:
- No warning for valid REG_DWORD type.
- UseDomainNameDevolution should be read as integer and honoured.

Root cause:
- get_item_property uses reg.read_s for non-expand reads.
- get_info calls get_item_property(..., "UseDomainNameDevolution").to_i.
- The refined read_s warns for any non-REG_SZ value.

Proposed fix (minimal):
1. Add an integer accessor helper for registry values.
2. Use that helper for UseDomainNameDevolution.
3. Keep existing string behaviour for string-valued keys.
