### PR TITLE
gc.c: Simplify the `newobj_of` API

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1032,7 +1032,7 @@ gc_newobj_hook(VALUE obj)
 }
 
 VALUE
-rb_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
+rb_ec_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
 {
     GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
     rb_ractor_t *cr = rb_ec_ractor_ptr(ec);
@@ -1058,6 +1058,12 @@ rb_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t sh
 #endif
 
     return obj;
+}
+
+VALUE
+rb_newobj_of(VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
+{
+    return rb_ec_newobj_of(GET_EC(), klass, flags, shape_id, wb_protected, size);
 }
 
 VALUE
@@ -1116,7 +1122,7 @@ rb_data_object_wrap(VALUE klass, void *datap, RUBY_DATA_FUNC dmark, RUBY_DATA_FU
 {
     RUBY_ASSERT_ALWAYS(dfree != (RUBY_DATA_FUNC)1);
     if (klass) rb_data_object_check(klass);
-    VALUE obj = rb_newobj_of(GET_EC(), klass, T_DATA, ROOT_SHAPE_ID, !dmark, sizeof(struct RTypedData));
+    VALUE obj = rb_newobj_of(klass, T_DATA, ROOT_SHAPE_ID, !dmark, sizeof(struct RTypedData));
 
     rb_gc_register_pinning_obj(obj);
 
@@ -1146,7 +1152,7 @@ typed_data_alloc(VALUE klass, VALUE typed_flag, void *datap, const rb_data_type_
     RBIMPL_NONNULL_ARG(type);
     if (klass) rb_data_object_check(klass);
     bool wb_protected = (type->flags & RUBY_FL_WB_PROTECTED) || !type->function.dmark;
-    VALUE obj = rb_newobj_of(GET_EC(), klass, T_DATA | RUBY_TYPED_FL_IS_TYPED_DATA, ROOT_SHAPE_ID, wb_protected, size);
+    VALUE obj = rb_newobj_of(klass, T_DATA | RUBY_TYPED_FL_IS_TYPED_DATA, ROOT_SHAPE_ID, wb_protected, size);
 
     rb_gc_register_pinning_obj(obj);
 

--- a/gc.c
+++ b/gc.c
@@ -251,7 +251,6 @@ rb_gc_get_objspace(void)
     return GET_VM()->gc.objspace;
 }
 
-
 void
 rb_gc_ractor_newobj_cache_foreach(void (*func)(void *cache, void *data), void *data)
 {
@@ -1032,9 +1031,11 @@ gc_newobj_hook(VALUE obj)
     RB_GC_VM_UNLOCK_NO_BARRIER(lev);
 }
 
-static inline VALUE
-newobj_of(rb_ractor_t *cr, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
+VALUE
+rb_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
 {
+    GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
+    rb_ractor_t *cr = rb_ec_ractor_ptr(ec);
     VALUE obj = rb_gc_impl_new_obj(rb_gc_get_objspace(), cr->newobj_cache, klass, flags, wb_protected, size);
     RBASIC_SET_SHAPE_ID_NO_CHECKS(obj, shape_id);
 
@@ -1057,20 +1058,6 @@ newobj_of(rb_ractor_t *cr, VALUE klass, VALUE flags, shape_id_t shape_id, bool w
 #endif
 
     return obj;
-}
-
-VALUE
-rb_wb_unprotected_newobj_of(VALUE klass, VALUE flags, shape_id_t shape_id, size_t size)
-{
-    GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
-    return newobj_of(GET_RACTOR(), klass, flags, shape_id, FALSE, size);
-}
-
-VALUE
-rb_wb_protected_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape_id, size_t size)
-{
-    GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
-    return newobj_of(rb_ec_ractor_ptr(ec), klass, flags, shape_id, TRUE, size);
 }
 
 VALUE
@@ -1129,7 +1116,7 @@ rb_data_object_wrap(VALUE klass, void *datap, RUBY_DATA_FUNC dmark, RUBY_DATA_FU
 {
     RUBY_ASSERT_ALWAYS(dfree != (RUBY_DATA_FUNC)1);
     if (klass) rb_data_object_check(klass);
-    VALUE obj = newobj_of(GET_RACTOR(), klass, T_DATA, ROOT_SHAPE_ID, !dmark, sizeof(struct RTypedData));
+    VALUE obj = rb_newobj_of(GET_EC(), klass, T_DATA, ROOT_SHAPE_ID, !dmark, sizeof(struct RTypedData));
 
     rb_gc_register_pinning_obj(obj);
 
@@ -1159,7 +1146,7 @@ typed_data_alloc(VALUE klass, VALUE typed_flag, void *datap, const rb_data_type_
     RBIMPL_NONNULL_ARG(type);
     if (klass) rb_data_object_check(klass);
     bool wb_protected = (type->flags & RUBY_FL_WB_PROTECTED) || !type->function.dmark;
-    VALUE obj = newobj_of(GET_RACTOR(), klass, T_DATA | RUBY_TYPED_FL_IS_TYPED_DATA, ROOT_SHAPE_ID, wb_protected, size);
+    VALUE obj = rb_newobj_of(GET_EC(), klass, T_DATA | RUBY_TYPED_FL_IS_TYPED_DATA, ROOT_SHAPE_ID, wb_protected, size);
 
     rb_gc_register_pinning_obj(obj);
 

--- a/hash.c
+++ b/hash.c
@@ -1421,14 +1421,9 @@ compact_after_delete(VALUE hash)
 static VALUE
 hash_alloc_flags(VALUE klass, VALUE flags, VALUE ifnone, bool st)
 {
-    const VALUE wb = (RGENGC_WB_PROTECTED_HASH ? FL_WB_PROTECTED : 0);
     const size_t size = sizeof(struct RHash) + (st ? sizeof(st_table) : sizeof(ar_table));
-
-    NEWOBJ_OF(hash, struct RHash, klass, T_HASH | wb | flags, size, 0);
-
-    RHASH_SET_IFNONE((VALUE)hash, ifnone);
-
-    return (VALUE)hash;
+    VALUE hash = rb_newobj_of(klass, T_HASH | flags, 0, RGENGC_WB_PROTECTED_HASH, size);
+    return rb_hash_set_ifnone(hash, ifnone);
 }
 
 static VALUE
@@ -1498,7 +1493,7 @@ rb_hash_alloc_fixed_size(VALUE klass, st_index_t size)
     }
     else {
         size_t slot_size = sizeof(struct RHash) + offsetof(ar_table, pairs) + size * sizeof(ar_table_pair);
-        ret = rb_newobj_of(GET_EC(), klass, T_HASH, 0, RGENGC_WB_PROTECTED_HASH, slot_size);
+        ret = rb_newobj_of(klass, T_HASH, 0, RGENGC_WB_PROTECTED_HASH, slot_size);
     }
 
     RHASH_SET_IFNONE(ret, Qnil);

--- a/hash.c
+++ b/hash.c
@@ -1498,7 +1498,7 @@ rb_hash_alloc_fixed_size(VALUE klass, st_index_t size)
     }
     else {
         size_t slot_size = sizeof(struct RHash) + offsetof(ar_table, pairs) + size * sizeof(ar_table_pair);
-        ret = rb_wb_protected_newobj_of(GET_EC(), klass, T_HASH, 0, slot_size);
+        ret = rb_newobj_of(GET_EC(), klass, T_HASH, 0, RGENGC_WB_PROTECTED_HASH, slot_size);
     }
 
     RHASH_SET_IFNONE(ret, Qnil);

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -121,7 +121,7 @@ struct rb_execution_context_struct; /* in vm_core.h */
 struct rb_objspace; /* in vm_core.h */
 
 #define NEWOBJ_OF_WITH_SHAPE(var, T, c, f, shape_id, s, ec) \
-    T *(var) = (T *)rb_newobj_of((ec ? ec : GET_EC()), (c), (f) & ~FL_WB_PROTECTED, shape_id, (f) & FL_WB_PROTECTED, s)
+    T *(var) = (T *)rb_ec_newobj_of((ec ? ec : GET_EC()), (c), (f) & ~FL_WB_PROTECTED, shape_id, (f) & FL_WB_PROTECTED, s)
 
 #define NEWOBJ_OF(var, T, c, f, s, ec) NEWOBJ_OF_WITH_SHAPE(var, T, c, f, 0 /* ROOT_SHAPE_ID */, s, ec)
 
@@ -244,7 +244,8 @@ VALUE rb_gc_disable_no_rest(void);
 
 /* gc.c (export) */
 const char *rb_objspace_data_type_name(VALUE obj);
-VALUE rb_newobj_of(struct rb_execution_context_struct *, VALUE, VALUE, uint32_t /* shape_id_t */, bool, size_t);
+VALUE rb_newobj_of(VALUE, VALUE, uint32_t /* shape_id_t */, bool, size_t);
+VALUE rb_ec_newobj_of(struct rb_execution_context_struct *, VALUE, VALUE, uint32_t /* shape_id_t */, bool, size_t);
 size_t rb_obj_memsize_of(VALUE);
 struct rb_gc_object_metadata_entry *rb_gc_object_metadata(VALUE obj);
 void rb_gc_mark_values(long n, const VALUE *values);

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -121,9 +121,7 @@ struct rb_execution_context_struct; /* in vm_core.h */
 struct rb_objspace; /* in vm_core.h */
 
 #define NEWOBJ_OF_WITH_SHAPE(var, T, c, f, shape_id, s, ec) \
-    T *(var) = (T *)(((f) & FL_WB_PROTECTED) ? \
-            rb_wb_protected_newobj_of((ec ? ec : GET_EC()), (c), (f) & ~FL_WB_PROTECTED, shape_id, s) : \
-            rb_wb_unprotected_newobj_of((c), (f), shape_id, s))
+    T *(var) = (T *)rb_newobj_of((ec ? ec : GET_EC()), (c), (f) & ~FL_WB_PROTECTED, shape_id, (f) & FL_WB_PROTECTED, s)
 
 #define NEWOBJ_OF(var, T, c, f, s, ec) NEWOBJ_OF_WITH_SHAPE(var, T, c, f, 0 /* ROOT_SHAPE_ID */, s, ec)
 
@@ -246,8 +244,7 @@ VALUE rb_gc_disable_no_rest(void);
 
 /* gc.c (export) */
 const char *rb_objspace_data_type_name(VALUE obj);
-VALUE rb_wb_protected_newobj_of(struct rb_execution_context_struct *, VALUE, VALUE, uint32_t /* shape_id_t */, size_t);
-VALUE rb_wb_unprotected_newobj_of(VALUE, VALUE, uint32_t /* shape_id_t */, size_t);
+VALUE rb_newobj_of(struct rb_execution_context_struct *, VALUE, VALUE, uint32_t /* shape_id_t */, bool, size_t);
 size_t rb_obj_memsize_of(VALUE);
 struct rb_gc_object_metadata_entry *rb_gc_object_metadata(VALUE obj);
 void rb_gc_mark_values(long n, const VALUE *values);


### PR DESCRIPTION
It is much simpler to pass `wb_protected` as a boolean.