### PR TITLE
Simplify `NEWOBJ_OF` macros

### DIFF
--- a/array.c
+++ b/array.c
@@ -697,7 +697,7 @@ ary_alloc_embed(VALUE klass, long capa)
 static VALUE
 ary_alloc_heap(VALUE klass)
 {
-    NEWOBJ_OF(ary, struct RArray, klass, T_ARRAY | FL_WB_PROTECTED, sizeof(struct RArray), 0);
+    NEWOBJ_OF(ary, struct RArray, klass, T_ARRAY | FL_WB_PROTECTED, sizeof(struct RArray));
 
     ary->as.heap.len = 0;
     ary->as.heap.aux.capa = 0;
@@ -800,7 +800,7 @@ ec_ary_alloc_embed(rb_execution_context_t *ec, VALUE klass, long capa)
 {
     size_t size = ary_embed_size(capa);
     RUBY_ASSERT(rb_gc_size_allocatable_p(size));
-    NEWOBJ_OF(ary, struct RArray, klass,
+    EC_NEWOBJ_OF(ary, struct RArray, klass,
             T_ARRAY | RARRAY_EMBED_FLAG | FL_WB_PROTECTED,
             size, ec);
     /* Created array is:
@@ -813,7 +813,7 @@ ec_ary_alloc_embed(rb_execution_context_t *ec, VALUE klass, long capa)
 static VALUE
 ec_ary_alloc_heap(rb_execution_context_t *ec, VALUE klass)
 {
-    NEWOBJ_OF(ary, struct RArray, klass,
+    EC_NEWOBJ_OF(ary, struct RArray, klass,
             T_ARRAY | FL_WB_PROTECTED,
             sizeof(struct RArray), ec);
 

--- a/array.c
+++ b/array.c
@@ -691,7 +691,7 @@ ary_alloc_embed(VALUE klass, long capa)
     *   FL_SET_EMBED((VALUE)ary);
     *   ARY_SET_EMBED_LEN((VALUE)ary, 0);
     */
-    return rb_newobj_of(klass, T_ARRAY | RARRAY_EMBED_FLAG, 0, size);
+    return rb_newobj_of(klass, T_ARRAY | RARRAY_EMBED_FLAG, size);
 }
 
 static VALUE
@@ -804,13 +804,13 @@ ec_ary_alloc_embed(rb_execution_context_t *ec, VALUE klass, long capa)
     *   FL_SET_EMBED((VALUE)ary);
     *   ARY_SET_EMBED_LEN((VALUE)ary, 0);
     */
-    return rb_ec_newobj_of(ec, klass, T_ARRAY | RARRAY_EMBED_FLAG, 0, true, size);
+    return rb_ec_newobj_of(ec, klass, T_ARRAY | RARRAY_EMBED_FLAG, size);
 }
 
 static VALUE
 ec_ary_alloc_heap(rb_execution_context_t *ec, VALUE klass)
 {
-    VALUE ary = rb_ec_newobj_of(ec, klass, T_ARRAY, 0, true, sizeof(struct RArray));
+    VALUE ary = rb_ec_newobj_of(ec, klass, T_ARRAY, sizeof(struct RArray));
     RARRAY(ary)->as.heap.len = 0;
     RARRAY(ary)->as.heap.aux.capa = 0;
     RARRAY(ary)->as.heap.ptr = NULL;

--- a/array.c
+++ b/array.c
@@ -691,13 +691,13 @@ ary_alloc_embed(VALUE klass, long capa)
     *   FL_SET_EMBED((VALUE)ary);
     *   ARY_SET_EMBED_LEN((VALUE)ary, 0);
     */
-    return rb_newobj_of(klass, T_ARRAY | RARRAY_EMBED_FLAG, 0, true, size);
+    return rb_newobj_of(klass, T_ARRAY | RARRAY_EMBED_FLAG, 0, size);
 }
 
 static VALUE
 ary_alloc_heap(VALUE klass)
 {
-    NEWOBJ_OF(ary, struct RArray, klass, T_ARRAY | FL_WB_PROTECTED, sizeof(struct RArray));
+    NEWOBJ_OF(ary, struct RArray, klass, T_ARRAY, sizeof(struct RArray));
 
     ary->as.heap.len = 0;
     ary->as.heap.aux.capa = 0;
@@ -800,28 +800,21 @@ ec_ary_alloc_embed(rb_execution_context_t *ec, VALUE klass, long capa)
 {
     size_t size = ary_embed_size(capa);
     RUBY_ASSERT(rb_gc_size_allocatable_p(size));
-    EC_NEWOBJ_OF(ary, struct RArray, klass,
-            T_ARRAY | RARRAY_EMBED_FLAG | FL_WB_PROTECTED,
-            size, ec);
-    /* Created array is:
-     *   FL_SET_EMBED((VALUE)ary);
-     *   ARY_SET_EMBED_LEN((VALUE)ary, 0);
-     */
-    return (VALUE)ary;
+   /* Created array is:
+    *   FL_SET_EMBED((VALUE)ary);
+    *   ARY_SET_EMBED_LEN((VALUE)ary, 0);
+    */
+    return rb_ec_newobj_of(ec, klass, T_ARRAY | RARRAY_EMBED_FLAG, 0, true, size);
 }
 
 static VALUE
 ec_ary_alloc_heap(rb_execution_context_t *ec, VALUE klass)
 {
-    EC_NEWOBJ_OF(ary, struct RArray, klass,
-            T_ARRAY | FL_WB_PROTECTED,
-            sizeof(struct RArray), ec);
-
-    ary->as.heap.len = 0;
-    ary->as.heap.aux.capa = 0;
-    ary->as.heap.ptr = NULL;
-
-    return (VALUE)ary;
+    VALUE ary = rb_ec_newobj_of(ec, klass, T_ARRAY, 0, true, sizeof(struct RArray));
+    RARRAY(ary)->as.heap.len = 0;
+    RARRAY(ary)->as.heap.aux.capa = 0;
+    RARRAY(ary)->as.heap.ptr = NULL;
+    return ary;
 }
 
 static VALUE

--- a/bignum.c
+++ b/bignum.c
@@ -3068,7 +3068,7 @@ bignew_1(VALUE klass, size_t len, int sign)
         RUBY_ASSERT(rb_gc_size_allocatable_p(size));
         NEWOBJ_OF(big, struct RBignum, klass,
                 T_BIGNUM | BIGNUM_EMBED_FLAG | FL_WB_PROTECTED,
-                size, 0);
+                size);
         bigv = (VALUE)big;
         BIGNUM_SET_SIGN(bigv, sign);
         BIGNUM_SET_LEN(bigv, len);
@@ -3076,7 +3076,7 @@ bignew_1(VALUE klass, size_t len, int sign)
     }
     else {
         NEWOBJ_OF(big, struct RBignum, klass,
-                T_BIGNUM | FL_WB_PROTECTED, sizeof(struct RBignum), 0);
+                T_BIGNUM | FL_WB_PROTECTED, sizeof(struct RBignum));
         bigv = (VALUE)big;
         BIGNUM_SET_SIGN(bigv, sign);
         big->as.heap.digits = ALLOC_N(BDIGIT, len);

--- a/bignum.c
+++ b/bignum.c
@@ -3066,17 +3066,14 @@ bignew_1(VALUE klass, size_t len, int sign)
     if (big_embeddable_p(len)) {
         size_t size = big_embed_size(len);
         RUBY_ASSERT(rb_gc_size_allocatable_p(size));
-        NEWOBJ_OF(big, struct RBignum, klass,
-                T_BIGNUM | BIGNUM_EMBED_FLAG | FL_WB_PROTECTED,
-                size);
+        NEWOBJ_OF(big, struct RBignum, klass, T_BIGNUM | BIGNUM_EMBED_FLAG, size);
         bigv = (VALUE)big;
         BIGNUM_SET_SIGN(bigv, sign);
         BIGNUM_SET_LEN(bigv, len);
         (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)big->as.ary, len * sizeof(BDIGIT));
     }
     else {
-        NEWOBJ_OF(big, struct RBignum, klass,
-                T_BIGNUM | FL_WB_PROTECTED, sizeof(struct RBignum));
+        NEWOBJ_OF(big, struct RBignum, klass, T_BIGNUM, sizeof(struct RBignum));
         bigv = (VALUE)big;
         BIGNUM_SET_SIGN(bigv, sign);
         big->as.heap.digits = ALLOC_N(BDIGIT, len);

--- a/class.c
+++ b/class.c
@@ -666,7 +666,7 @@ class_alloc0(enum ruby_value_type type, VALUE klass, bool boxable)
 
     RUBY_ASSERT(type == T_CLASS || type == T_ICLASS || type == T_MODULE);
 
-    VALUE flags = type | FL_SHAREABLE | FL_WB_PROTECTED;
+    VALUE flags = type | FL_SHAREABLE;
     if (boxable) flags |= RCLASS_BOXABLE;
 
     NEWOBJ_OF(obj, struct RClass, klass, flags, alloc_size);

--- a/class.c
+++ b/class.c
@@ -669,7 +669,7 @@ class_alloc0(enum ruby_value_type type, VALUE klass, bool boxable)
     VALUE flags = type | FL_SHAREABLE | FL_WB_PROTECTED;
     if (boxable) flags |= RCLASS_BOXABLE;
 
-    NEWOBJ_OF(obj, struct RClass, klass, flags, alloc_size, 0);
+    NEWOBJ_OF(obj, struct RClass, klass, flags, alloc_size);
 
     obj->object_id = 0;
 

--- a/complex.c
+++ b/complex.c
@@ -370,7 +370,7 @@ inline static VALUE
 nucomp_s_new_internal(VALUE klass, VALUE real, VALUE imag)
 {
     NEWOBJ_OF(obj, struct RComplex, klass,
-            T_COMPLEX | FL_WB_PROTECTED, sizeof(struct RComplex), 0);
+            T_COMPLEX | FL_WB_PROTECTED, sizeof(struct RComplex));
 
     RCOMPLEX_SET_REAL(obj, real);
     RCOMPLEX_SET_IMAG(obj, imag);

--- a/complex.c
+++ b/complex.c
@@ -369,8 +369,7 @@ k_numeric_p(VALUE x)
 inline static VALUE
 nucomp_s_new_internal(VALUE klass, VALUE real, VALUE imag)
 {
-    NEWOBJ_OF(obj, struct RComplex, klass,
-            T_COMPLEX | FL_WB_PROTECTED, sizeof(struct RComplex));
+    NEWOBJ_OF(obj, struct RComplex, klass, T_COMPLEX, sizeof(struct RComplex));
 
     RCOMPLEX_SET_REAL(obj, real);
     RCOMPLEX_SET_IMAG(obj, imag);

--- a/gc.c
+++ b/gc.c
@@ -1032,7 +1032,7 @@ gc_newobj_hook(VALUE obj)
 }
 
 VALUE
-rb_ec_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
+rb_newobj(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
 {
     GC_ASSERT((flags & FL_WB_PROTECTED) == 0);
     rb_ractor_t *cr = rb_ec_ractor_ptr(ec);
@@ -1061,9 +1061,21 @@ rb_ec_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t
 }
 
 VALUE
-rb_newobj_of(VALUE klass, VALUE flags, shape_id_t shape_id, size_t size)
+rb_ec_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flags, size_t size)
 {
-    return rb_ec_newobj_of(GET_EC(), klass, flags, shape_id, true, size);
+    return rb_newobj(ec, klass, flags, ROOT_SHAPE_ID, true, size);
+}
+
+VALUE
+rb_newobj_of_with_shape(VALUE klass, VALUE flags, shape_id_t shape_id, size_t size)
+{
+    return rb_newobj(GET_EC(), klass, flags, shape_id, true, size);
+}
+
+VALUE
+rb_newobj_of(VALUE klass, VALUE flags, size_t size)
+{
+    return rb_newobj(GET_EC(), klass, flags, ROOT_SHAPE_ID, true, size);
 }
 
 VALUE
@@ -1078,7 +1090,7 @@ rb_class_allocate_instance(VALUE klass)
 
     // There might be a NEWOBJ tracepoint callback, and it may set fields.
     // So the shape must be passed to `NEWOBJ_OF`.
-    VALUE obj = rb_newobj_of(klass, T_OBJECT, rb_shape_root(rb_gc_heap_id_for_size(size)), size);
+    VALUE obj = rb_newobj_of_with_shape(klass, T_OBJECT, rb_shape_root(rb_gc_heap_id_for_size(size)), size);
 
 #if RUBY_DEBUG
     RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));
@@ -1120,7 +1132,7 @@ rb_data_object_wrap(VALUE klass, void *datap, RUBY_DATA_FUNC dmark, RUBY_DATA_FU
 {
     RUBY_ASSERT_ALWAYS(dfree != (RUBY_DATA_FUNC)1);
     if (klass) rb_data_object_check(klass);
-    VALUE obj = rb_ec_newobj_of(GET_EC(), klass, T_DATA, ROOT_SHAPE_ID, !dmark, sizeof(struct RTypedData));
+    VALUE obj = rb_newobj(GET_EC(), klass, T_DATA, ROOT_SHAPE_ID, !dmark, sizeof(struct RTypedData));
 
     rb_gc_register_pinning_obj(obj);
 
@@ -1150,7 +1162,7 @@ typed_data_alloc(VALUE klass, VALUE typed_flag, void *datap, const rb_data_type_
     RBIMPL_NONNULL_ARG(type);
     if (klass) rb_data_object_check(klass);
     bool wb_protected = (type->flags & RUBY_FL_WB_PROTECTED) || !type->function.dmark;
-    VALUE obj = rb_ec_newobj_of(GET_EC(), klass, T_DATA | RUBY_TYPED_FL_IS_TYPED_DATA, ROOT_SHAPE_ID, wb_protected, size);
+    VALUE obj = rb_newobj(GET_EC(), klass, T_DATA | RUBY_TYPED_FL_IS_TYPED_DATA, ROOT_SHAPE_ID, wb_protected, size);
 
     rb_gc_register_pinning_obj(obj);
 

--- a/gc.c
+++ b/gc.c
@@ -1079,8 +1079,7 @@ rb_class_allocate_instance(VALUE klass)
     // There might be a NEWOBJ tracepoint callback, and it may set fields.
     // So the shape must be passed to `NEWOBJ_OF`.
     VALUE flags = T_OBJECT | FL_WB_PROTECTED;
-    NEWOBJ_OF_WITH_SHAPE(o, struct RObject, klass, flags, rb_shape_root(rb_gc_heap_id_for_size(size)), size, 0);
-    VALUE obj = (VALUE)o;
+    VALUE obj = rb_newobj_of(klass, flags, rb_shape_root(rb_gc_heap_id_for_size(size)), true, size);
 
 #if RUBY_DEBUG
     RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));

--- a/gc.c
+++ b/gc.c
@@ -1061,9 +1061,9 @@ rb_ec_newobj_of(rb_execution_context_t *ec, VALUE klass, VALUE flags, shape_id_t
 }
 
 VALUE
-rb_newobj_of(VALUE klass, VALUE flags, shape_id_t shape_id, bool wb_protected, size_t size)
+rb_newobj_of(VALUE klass, VALUE flags, shape_id_t shape_id, size_t size)
 {
-    return rb_ec_newobj_of(GET_EC(), klass, flags, shape_id, wb_protected, size);
+    return rb_ec_newobj_of(GET_EC(), klass, flags, shape_id, true, size);
 }
 
 VALUE
@@ -1078,8 +1078,7 @@ rb_class_allocate_instance(VALUE klass)
 
     // There might be a NEWOBJ tracepoint callback, and it may set fields.
     // So the shape must be passed to `NEWOBJ_OF`.
-    VALUE flags = T_OBJECT | FL_WB_PROTECTED;
-    VALUE obj = rb_newobj_of(klass, flags, rb_shape_root(rb_gc_heap_id_for_size(size)), true, size);
+    VALUE obj = rb_newobj_of(klass, T_OBJECT, rb_shape_root(rb_gc_heap_id_for_size(size)), size);
 
 #if RUBY_DEBUG
     RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));
@@ -1121,7 +1120,7 @@ rb_data_object_wrap(VALUE klass, void *datap, RUBY_DATA_FUNC dmark, RUBY_DATA_FU
 {
     RUBY_ASSERT_ALWAYS(dfree != (RUBY_DATA_FUNC)1);
     if (klass) rb_data_object_check(klass);
-    VALUE obj = rb_newobj_of(klass, T_DATA, ROOT_SHAPE_ID, !dmark, sizeof(struct RTypedData));
+    VALUE obj = rb_ec_newobj_of(GET_EC(), klass, T_DATA, ROOT_SHAPE_ID, !dmark, sizeof(struct RTypedData));
 
     rb_gc_register_pinning_obj(obj);
 
@@ -1151,7 +1150,7 @@ typed_data_alloc(VALUE klass, VALUE typed_flag, void *datap, const rb_data_type_
     RBIMPL_NONNULL_ARG(type);
     if (klass) rb_data_object_check(klass);
     bool wb_protected = (type->flags & RUBY_FL_WB_PROTECTED) || !type->function.dmark;
-    VALUE obj = rb_newobj_of(klass, T_DATA | RUBY_TYPED_FL_IS_TYPED_DATA, ROOT_SHAPE_ID, wb_protected, size);
+    VALUE obj = rb_ec_newobj_of(GET_EC(), klass, T_DATA | RUBY_TYPED_FL_IS_TYPED_DATA, ROOT_SHAPE_ID, wb_protected, size);
 
     rb_gc_register_pinning_obj(obj);
 

--- a/hash.c
+++ b/hash.c
@@ -1422,7 +1422,7 @@ static VALUE
 hash_alloc_flags(VALUE klass, VALUE flags, VALUE ifnone, bool st)
 {
     const size_t size = sizeof(struct RHash) + (st ? sizeof(st_table) : sizeof(ar_table));
-    VALUE hash = rb_newobj_of(klass, T_HASH | flags, 0, true, size);
+    VALUE hash = rb_newobj_of(klass, T_HASH | flags, 0, size);
     return rb_hash_set_ifnone(hash, ifnone);
 }
 
@@ -1493,7 +1493,7 @@ rb_hash_alloc_fixed_size(VALUE klass, st_index_t size)
     }
     else {
         size_t slot_size = sizeof(struct RHash) + offsetof(ar_table, pairs) + size * sizeof(ar_table_pair);
-        ret = rb_newobj_of(klass, T_HASH, 0, true, slot_size);
+        ret = rb_newobj_of(klass, T_HASH, 0, slot_size);
     }
 
     RHASH_SET_IFNONE(ret, Qnil);

--- a/hash.c
+++ b/hash.c
@@ -1422,7 +1422,7 @@ static VALUE
 hash_alloc_flags(VALUE klass, VALUE flags, VALUE ifnone, bool st)
 {
     const size_t size = sizeof(struct RHash) + (st ? sizeof(st_table) : sizeof(ar_table));
-    VALUE hash = rb_newobj_of(klass, T_HASH | flags, 0, size);
+    VALUE hash = rb_newobj_of(klass, T_HASH | flags, size);
     return rb_hash_set_ifnone(hash, ifnone);
 }
 
@@ -1493,7 +1493,7 @@ rb_hash_alloc_fixed_size(VALUE klass, st_index_t size)
     }
     else {
         size_t slot_size = sizeof(struct RHash) + offsetof(ar_table, pairs) + size * sizeof(ar_table_pair);
-        ret = rb_newobj_of(klass, T_HASH, 0, slot_size);
+        ret = rb_newobj_of(klass, T_HASH, slot_size);
     }
 
     RHASH_SET_IFNONE(ret, Qnil);

--- a/imemo.c
+++ b/imemo.c
@@ -43,17 +43,15 @@ rb_imemo_name(enum imemo_type type)
 VALUE
 rb_imemo_new(enum imemo_type type, VALUE v0, size_t size, bool is_shareable)
 {
-    VALUE flags = T_IMEMO | FL_WB_PROTECTED | (type << FL_USHIFT) | (is_shareable ? FL_SHAREABLE : 0);
-    NEWOBJ_OF(obj, void, v0, flags, size);
-
-    return (VALUE)obj;
+    VALUE flags = T_IMEMO | (type << FL_USHIFT) | (is_shareable ? FL_SHAREABLE : 0);
+    return rb_newobj_of(v0, flags, 0, size);
 }
 
 VALUE
 rb_imemo_tmpbuf_new(void)
 {
     VALUE flags = T_IMEMO | (imemo_tmpbuf << FL_USHIFT);
-    NEWOBJ_OF(obj, rb_imemo_tmpbuf_t, 0, flags, sizeof(rb_imemo_tmpbuf_t));
+    UNPROTECTED_NEWOBJ_OF(obj, rb_imemo_tmpbuf_t, 0, flags, sizeof(rb_imemo_tmpbuf_t));
 
     rb_gc_register_pinning_obj((VALUE)obj);
 

--- a/imemo.c
+++ b/imemo.c
@@ -44,7 +44,7 @@ VALUE
 rb_imemo_new(enum imemo_type type, VALUE v0, size_t size, bool is_shareable)
 {
     VALUE flags = T_IMEMO | FL_WB_PROTECTED | (type << FL_USHIFT) | (is_shareable ? FL_SHAREABLE : 0);
-    NEWOBJ_OF(obj, void, v0, flags, size, 0);
+    NEWOBJ_OF(obj, void, v0, flags, size);
 
     return (VALUE)obj;
 }
@@ -53,7 +53,7 @@ VALUE
 rb_imemo_tmpbuf_new(void)
 {
     VALUE flags = T_IMEMO | (imemo_tmpbuf << FL_USHIFT);
-    NEWOBJ_OF(obj, rb_imemo_tmpbuf_t, 0, flags, sizeof(rb_imemo_tmpbuf_t), NULL);
+    NEWOBJ_OF(obj, rb_imemo_tmpbuf_t, 0, flags, sizeof(rb_imemo_tmpbuf_t));
 
     rb_gc_register_pinning_obj((VALUE)obj);
 

--- a/imemo.c
+++ b/imemo.c
@@ -44,7 +44,7 @@ VALUE
 rb_imemo_new(enum imemo_type type, VALUE v0, size_t size, bool is_shareable)
 {
     VALUE flags = T_IMEMO | (type << FL_USHIFT) | (is_shareable ? FL_SHAREABLE : 0);
-    return rb_newobj_of(v0, flags, 0, size);
+    return rb_newobj_of(v0, flags, size);
 }
 
 VALUE

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -120,10 +120,10 @@ const char *rb_raw_obj_info(char *const buff, const size_t buff_size, VALUE obj)
 struct rb_execution_context_struct; /* in vm_core.h */
 struct rb_objspace; /* in vm_core.h */
 
-#define NEWOBJ_OF_WITH_SHAPE(var, T, c, f, shape_id, s, ec) \
+#define EC_NEWOBJ_OF_WITH_SHAPE(var, T, c, f, shape_id, s, ec) \
     T *(var) = (T *)rb_ec_newobj_of((ec ? ec : GET_EC()), (c), (f) & ~FL_WB_PROTECTED, shape_id, (f) & FL_WB_PROTECTED, s)
-
-#define NEWOBJ_OF(var, T, c, f, s, ec) NEWOBJ_OF_WITH_SHAPE(var, T, c, f, 0 /* ROOT_SHAPE_ID */, s, ec)
+#define EC_NEWOBJ_OF(var, T, c, f, s, ec) EC_NEWOBJ_OF_WITH_SHAPE(var, T, c, f, 0 /* ROOT_SHAPE_ID */, s, ec)
+#define NEWOBJ_OF(var, T, c, f, s) EC_NEWOBJ_OF_WITH_SHAPE(var, T, c, f, 0 /* ROOT_SHAPE_ID */, s, NULL)
 
 #ifndef RB_GC_OBJECT_METADATA_ENTRY_DEFINED
 # define RB_GC_OBJECT_METADATA_ENTRY_DEFINED

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -120,10 +120,11 @@ const char *rb_raw_obj_info(char *const buff, const size_t buff_size, VALUE obj)
 struct rb_execution_context_struct; /* in vm_core.h */
 struct rb_objspace; /* in vm_core.h */
 
-#define EC_NEWOBJ_OF_WITH_SHAPE(var, T, c, f, shape_id, s, ec) \
-    T *(var) = (T *)rb_ec_newobj_of((ec ? ec : GET_EC()), (c), (f) & ~FL_WB_PROTECTED, shape_id, (f) & FL_WB_PROTECTED, s)
-#define EC_NEWOBJ_OF(var, T, c, f, s, ec) EC_NEWOBJ_OF_WITH_SHAPE(var, T, c, f, 0 /* ROOT_SHAPE_ID */, s, ec)
-#define NEWOBJ_OF(var, T, c, f, s) EC_NEWOBJ_OF_WITH_SHAPE(var, T, c, f, 0 /* ROOT_SHAPE_ID */, s, NULL)
+#define EC_NEWOBJ_OF(var, T, c, f, s, ec)  \
+    T *(var) = (T *)rb_ec_newobj_of((ec), (c), (f), 0 /* ROOT_SHAPE_ID */, true, s)
+#define NEWOBJ_OF(var, T, c, f, s) EC_NEWOBJ_OF(var, T, c, f, s, GET_EC())
+#define UNPROTECTED_NEWOBJ_OF(var, T, c, f, s) \
+    T *(var) = (T *)rb_ec_newobj_of((GET_EC()), (c), (f), 0, false, s)
 
 #ifndef RB_GC_OBJECT_METADATA_ENTRY_DEFINED
 # define RB_GC_OBJECT_METADATA_ENTRY_DEFINED
@@ -244,7 +245,7 @@ VALUE rb_gc_disable_no_rest(void);
 
 /* gc.c (export) */
 const char *rb_objspace_data_type_name(VALUE obj);
-VALUE rb_newobj_of(VALUE, VALUE, uint32_t /* shape_id_t */, bool, size_t);
+VALUE rb_newobj_of(VALUE, VALUE, uint32_t /* shape_id_t */, size_t);
 VALUE rb_ec_newobj_of(struct rb_execution_context_struct *, VALUE, VALUE, uint32_t /* shape_id_t */, bool, size_t);
 size_t rb_obj_memsize_of(VALUE);
 struct rb_gc_object_metadata_entry *rb_gc_object_metadata(VALUE obj);

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -121,10 +121,10 @@ struct rb_execution_context_struct; /* in vm_core.h */
 struct rb_objspace; /* in vm_core.h */
 
 #define EC_NEWOBJ_OF(var, T, c, f, s, ec)  \
-    T *(var) = (T *)rb_ec_newobj_of((ec), (c), (f), 0 /* ROOT_SHAPE_ID */, true, s)
+    T *(var) = (T *)rb_ec_newobj_of((ec), (c), (f), s)
 #define NEWOBJ_OF(var, T, c, f, s) EC_NEWOBJ_OF(var, T, c, f, s, GET_EC())
 #define UNPROTECTED_NEWOBJ_OF(var, T, c, f, s) \
-    T *(var) = (T *)rb_ec_newobj_of((GET_EC()), (c), (f), 0, false, s)
+    T *(var) = (T *)rb_newobj((GET_EC()), (c), (f), 0 /* ROOT_SHAPE_ID */, false, s)
 
 #ifndef RB_GC_OBJECT_METADATA_ENTRY_DEFINED
 # define RB_GC_OBJECT_METADATA_ENTRY_DEFINED
@@ -245,8 +245,9 @@ VALUE rb_gc_disable_no_rest(void);
 
 /* gc.c (export) */
 const char *rb_objspace_data_type_name(VALUE obj);
-VALUE rb_newobj_of(VALUE, VALUE, uint32_t /* shape_id_t */, size_t);
-VALUE rb_ec_newobj_of(struct rb_execution_context_struct *, VALUE, VALUE, uint32_t /* shape_id_t */, bool, size_t);
+VALUE rb_newobj(struct rb_execution_context_struct *, VALUE, VALUE, uint32_t /* shape_id_t */, bool, size_t);
+VALUE rb_newobj_of(VALUE, VALUE, size_t);
+VALUE rb_ec_newobj_of(struct rb_execution_context_struct *, VALUE, VALUE, size_t);
 size_t rb_obj_memsize_of(VALUE);
 struct rb_gc_object_metadata_entry *rb_gc_object_metadata(VALUE obj);
 void rb_gc_mark_values(long n, const VALUE *values);

--- a/io.c
+++ b/io.c
@@ -1110,7 +1110,7 @@ ruby_dup(int orig)
 static VALUE
 io_alloc(VALUE klass)
 {
-    NEWOBJ_OF(io, struct RFile, klass, T_FILE, sizeof(struct RFile));
+    UNPROTECTED_NEWOBJ_OF(io, struct RFile, klass, T_FILE, sizeof(struct RFile));
 
     io->fptr = 0;
 

--- a/io.c
+++ b/io.c
@@ -1110,7 +1110,7 @@ ruby_dup(int orig)
 static VALUE
 io_alloc(VALUE klass)
 {
-    NEWOBJ_OF(io, struct RFile, klass, T_FILE, sizeof(struct RFile), 0);
+    NEWOBJ_OF(io, struct RFile, klass, T_FILE, sizeof(struct RFile));
 
     io->fptr = 0;
 

--- a/numeric.c
+++ b/numeric.c
@@ -910,7 +910,7 @@ num_negative_p(VALUE num)
 VALUE
 rb_float_new_in_heap(double d)
 {
-    NEWOBJ_OF(flt, struct RFloat, rb_cFloat, T_FLOAT | FL_WB_PROTECTED, sizeof(struct RFloat), 0);
+    NEWOBJ_OF(flt, struct RFloat, rb_cFloat, T_FLOAT | FL_WB_PROTECTED, sizeof(struct RFloat));
 
 #if SIZEOF_DOUBLE <= SIZEOF_VALUE
     flt->float_value = d;

--- a/numeric.c
+++ b/numeric.c
@@ -910,7 +910,7 @@ num_negative_p(VALUE num)
 VALUE
 rb_float_new_in_heap(double d)
 {
-    NEWOBJ_OF(flt, struct RFloat, rb_cFloat, T_FLOAT | FL_WB_PROTECTED, sizeof(struct RFloat));
+    NEWOBJ_OF(flt, struct RFloat, rb_cFloat, T_FLOAT, sizeof(struct RFloat));
 
 #if SIZEOF_DOUBLE <= SIZEOF_VALUE
     flt->float_value = d;

--- a/ractor.c
+++ b/ractor.c
@@ -2016,7 +2016,7 @@ move_enter(VALUE obj, struct obj_traverse_replace_data *data)
         VALUE type = RB_BUILTIN_TYPE(obj);
         size_t slot_size = rb_gc_obj_slot_size(obj);
         type |= wb_protected_types[type] ? FL_WB_PROTECTED : 0;
-        NEWOBJ_OF(moved, struct RBasic, 0, type, slot_size, 0);
+        NEWOBJ_OF(moved, struct RBasic, 0, type, slot_size);
         MEMZERO(&moved[1], char, slot_size - sizeof(*moved));
         data->replacement = (VALUE)moved;
         return traverse_cont;

--- a/ractor.c
+++ b/ractor.c
@@ -2015,9 +2015,8 @@ move_enter(VALUE obj, struct obj_traverse_replace_data *data)
     else {
         VALUE type = RB_BUILTIN_TYPE(obj);
         size_t slot_size = rb_gc_obj_slot_size(obj);
-        type |= wb_protected_types[type] ? FL_WB_PROTECTED : 0;
-        NEWOBJ_OF(moved, struct RBasic, 0, type, slot_size);
-        MEMZERO(&moved[1], char, slot_size - sizeof(*moved));
+        VALUE moved = rb_ec_newobj_of(GET_EC(), 0, type, 0, wb_protected_types[type], slot_size);
+        MEMZERO(((struct RBasic *)moved) + 1, char, slot_size - sizeof(struct RBasic));
         data->replacement = (VALUE)moved;
         return traverse_cont;
     }

--- a/ractor.c
+++ b/ractor.c
@@ -2015,7 +2015,7 @@ move_enter(VALUE obj, struct obj_traverse_replace_data *data)
     else {
         VALUE type = RB_BUILTIN_TYPE(obj);
         size_t slot_size = rb_gc_obj_slot_size(obj);
-        VALUE moved = rb_ec_newobj_of(GET_EC(), 0, type, 0, wb_protected_types[type], slot_size);
+        VALUE moved = rb_newobj(GET_EC(), 0, type, 0, wb_protected_types[type], slot_size);
         MEMZERO(((struct RBasic *)moved) + 1, char, slot_size - sizeof(struct RBasic));
         data->replacement = (VALUE)moved;
         return traverse_cont;

--- a/rational.c
+++ b/rational.c
@@ -405,7 +405,7 @@ inline static VALUE
 nurat_s_new_internal(VALUE klass, VALUE num, VALUE den)
 {
     NEWOBJ_OF(obj, struct RRational, klass, T_RATIONAL | FL_WB_PROTECTED,
-            sizeof(struct RRational), 0);
+            sizeof(struct RRational));
 
     RATIONAL_SET_NUM((VALUE)obj, num);
     RATIONAL_SET_DEN((VALUE)obj, den);

--- a/rational.c
+++ b/rational.c
@@ -404,8 +404,7 @@ f_lcm(VALUE x, VALUE y)
 inline static VALUE
 nurat_s_new_internal(VALUE klass, VALUE num, VALUE den)
 {
-    NEWOBJ_OF(obj, struct RRational, klass, T_RATIONAL | FL_WB_PROTECTED,
-            sizeof(struct RRational));
+    NEWOBJ_OF(obj, struct RRational, klass, T_RATIONAL, sizeof(struct RRational));
 
     RATIONAL_SET_NUM((VALUE)obj, num);
     RATIONAL_SET_DEN((VALUE)obj, den);

--- a/re.c
+++ b/re.c
@@ -968,8 +968,7 @@ static VALUE
 match_alloc(VALUE klass)
 {
     size_t alloc_size = sizeof(struct RMatch) + sizeof(rb_matchext_t);
-    VALUE flags = T_MATCH | FL_WB_PROTECTED;
-    NEWOBJ_OF(match, struct RMatch, klass, flags, alloc_size);
+    NEWOBJ_OF(match, struct RMatch, klass, T_MATCH, alloc_size);
 
     match->str = Qfalse;
     match->regexp = Qfalse;
@@ -3403,7 +3402,7 @@ rb_reg_initialize_str(VALUE obj, VALUE str, int options, onig_errmsg_buffer err,
 VALUE
 rb_reg_s_alloc(VALUE klass)
 {
-    NEWOBJ_OF(re, struct RRegexp, klass, T_REGEXP | FL_WB_PROTECTED, sizeof(struct RRegexp));
+    NEWOBJ_OF(re, struct RRegexp, klass, T_REGEXP, sizeof(struct RRegexp));
 
     re->ptr = 0;
     RB_OBJ_WRITE(re, &re->src, 0);

--- a/re.c
+++ b/re.c
@@ -969,7 +969,7 @@ match_alloc(VALUE klass)
 {
     size_t alloc_size = sizeof(struct RMatch) + sizeof(rb_matchext_t);
     VALUE flags = T_MATCH | FL_WB_PROTECTED;
-    NEWOBJ_OF(match, struct RMatch, klass, flags, alloc_size, 0);
+    NEWOBJ_OF(match, struct RMatch, klass, flags, alloc_size);
 
     match->str = Qfalse;
     match->regexp = Qfalse;
@@ -3403,7 +3403,7 @@ rb_reg_initialize_str(VALUE obj, VALUE str, int options, onig_errmsg_buffer err,
 VALUE
 rb_reg_s_alloc(VALUE klass)
 {
-    NEWOBJ_OF(re, struct RRegexp, klass, T_REGEXP | FL_WB_PROTECTED, sizeof(struct RRegexp), 0);
+    NEWOBJ_OF(re, struct RRegexp, klass, T_REGEXP | FL_WB_PROTECTED, sizeof(struct RRegexp));
 
     re->ptr = 0;
     RB_OBJ_WRITE(re, &re->src, 0);

--- a/string.c
+++ b/string.c
@@ -1026,7 +1026,7 @@ str_alloc_embed(VALUE klass, size_t capa)
     RUBY_ASSERT(rb_gc_size_allocatable_p(size));
 
     NEWOBJ_OF(str, struct RString, klass,
-            T_STRING | FL_WB_PROTECTED, size, 0);
+            T_STRING | FL_WB_PROTECTED, size);
 
     str->len = 0;
     str->as.embed.ary[0] = 0;
@@ -1038,7 +1038,7 @@ static inline VALUE
 str_alloc_heap(VALUE klass)
 {
     NEWOBJ_OF(str, struct RString, klass,
-            T_STRING | STR_NOEMBED | FL_WB_PROTECTED, sizeof(struct RString), 0);
+            T_STRING | STR_NOEMBED | FL_WB_PROTECTED, sizeof(struct RString));
 
     str->len = 0;
     str->as.heap.aux.capa = 0;
@@ -1902,7 +1902,7 @@ ec_str_alloc_embed(struct rb_execution_context_struct *ec, VALUE klass, size_t c
     RUBY_ASSERT(size > 0);
     RUBY_ASSERT(rb_gc_size_allocatable_p(size));
 
-    NEWOBJ_OF(str, struct RString, klass,
+    EC_NEWOBJ_OF(str, struct RString, klass,
             T_STRING | FL_WB_PROTECTED, size, ec);
 
     str->len = 0;
@@ -1913,7 +1913,7 @@ ec_str_alloc_embed(struct rb_execution_context_struct *ec, VALUE klass, size_t c
 static inline VALUE
 ec_str_alloc_heap(struct rb_execution_context_struct *ec, VALUE klass)
 {
-    NEWOBJ_OF(str, struct RString, klass,
+    EC_NEWOBJ_OF(str, struct RString, klass,
             T_STRING | STR_NOEMBED | FL_WB_PROTECTED, sizeof(struct RString), ec);
 
     str->as.heap.aux.capa = 0;

--- a/string.c
+++ b/string.c
@@ -1025,8 +1025,7 @@ str_alloc_embed(VALUE klass, size_t capa)
     RUBY_ASSERT(size > 0);
     RUBY_ASSERT(rb_gc_size_allocatable_p(size));
 
-    NEWOBJ_OF(str, struct RString, klass,
-            T_STRING | FL_WB_PROTECTED, size);
+    NEWOBJ_OF(str, struct RString, klass, T_STRING, size);
 
     str->len = 0;
     str->as.embed.ary[0] = 0;
@@ -1037,8 +1036,7 @@ str_alloc_embed(VALUE klass, size_t capa)
 static inline VALUE
 str_alloc_heap(VALUE klass)
 {
-    NEWOBJ_OF(str, struct RString, klass,
-            T_STRING | STR_NOEMBED | FL_WB_PROTECTED, sizeof(struct RString));
+    NEWOBJ_OF(str, struct RString, klass, T_STRING | STR_NOEMBED, sizeof(struct RString));
 
     str->len = 0;
     str->as.heap.aux.capa = 0;
@@ -1902,8 +1900,7 @@ ec_str_alloc_embed(struct rb_execution_context_struct *ec, VALUE klass, size_t c
     RUBY_ASSERT(size > 0);
     RUBY_ASSERT(rb_gc_size_allocatable_p(size));
 
-    EC_NEWOBJ_OF(str, struct RString, klass,
-            T_STRING | FL_WB_PROTECTED, size, ec);
+    EC_NEWOBJ_OF(str, struct RString, klass, T_STRING, size, ec);
 
     str->len = 0;
 
@@ -1913,8 +1910,7 @@ ec_str_alloc_embed(struct rb_execution_context_struct *ec, VALUE klass, size_t c
 static inline VALUE
 ec_str_alloc_heap(struct rb_execution_context_struct *ec, VALUE klass)
 {
-    EC_NEWOBJ_OF(str, struct RString, klass,
-            T_STRING | STR_NOEMBED | FL_WB_PROTECTED, sizeof(struct RString), ec);
+    EC_NEWOBJ_OF(str, struct RString, klass, T_STRING | STR_NOEMBED, sizeof(struct RString), ec);
 
     str->as.heap.aux.capa = 0;
     str->as.heap.ptr = NULL;

--- a/struct.c
+++ b/struct.c
@@ -837,7 +837,7 @@ struct_alloc(VALUE klass)
             flags |= RSTRUCT_GEN_FIELDS;
         }
 
-        NEWOBJ_OF(st, struct RStruct, klass, flags, embedded_size, 0);
+        NEWOBJ_OF(st, struct RStruct, klass, flags, embedded_size);
         if (RCLASS_MAX_IV_COUNT(klass) == 0) {
             if (!rb_shape_obj_has_fields((VALUE)st)
                     && embedded_size < rb_gc_obj_slot_size((VALUE)st)) {
@@ -854,7 +854,7 @@ struct_alloc(VALUE klass)
         return (VALUE)st;
     }
     else {
-        NEWOBJ_OF(st, struct RStruct, klass, flags, sizeof(struct RStruct), 0);
+        NEWOBJ_OF(st, struct RStruct, klass, flags, sizeof(struct RStruct));
 
         st->as.heap.ptr = NULL;
         st->as.heap.fields_obj = 0;

--- a/struct.c
+++ b/struct.c
@@ -827,7 +827,7 @@ struct_alloc(VALUE klass)
         embedded_size += sizeof(VALUE);
     }
 
-    VALUE flags = T_STRUCT | FL_WB_PROTECTED;
+    VALUE flags = T_STRUCT;
 
     if (n > 0 && rb_gc_size_allocatable_p(embedded_size)) {
         flags |= n << RSTRUCT_EMBED_LEN_SHIFT;

--- a/symbol.c
+++ b/symbol.c
@@ -303,7 +303,7 @@ sym_set_create(VALUE sym, void *data)
     VALUE str = dup_string_for_create(static_sym_entry->str);
 
     if (create_dynamic_symbol) {
-        NEWOBJ_OF(obj, struct RSymbol, rb_cSymbol, T_SYMBOL | FL_WB_PROTECTED, sizeof(struct RSymbol), 0);
+        NEWOBJ_OF(obj, struct RSymbol, rb_cSymbol, T_SYMBOL | FL_WB_PROTECTED, sizeof(struct RSymbol));
 
         rb_encoding *enc = rb_enc_get(str);
         rb_enc_set_index((VALUE)obj, rb_enc_to_index(enc));

--- a/symbol.c
+++ b/symbol.c
@@ -303,7 +303,7 @@ sym_set_create(VALUE sym, void *data)
     VALUE str = dup_string_for_create(static_sym_entry->str);
 
     if (create_dynamic_symbol) {
-        NEWOBJ_OF(obj, struct RSymbol, rb_cSymbol, T_SYMBOL | FL_WB_PROTECTED, sizeof(struct RSymbol));
+        NEWOBJ_OF(obj, struct RSymbol, rb_cSymbol, T_SYMBOL, sizeof(struct RSymbol));
 
         rb_encoding *enc = rb_enc_get(str);
         rb_enc_set_index((VALUE)obj, rb_enc_to_index(enc));


### PR DESCRIPTION
Most objects are WB protected and start with `ROOT_SHAPE_ID`, by assuming these defaults we can make the default allocator function/macro much simpler, and special cases easier to identify.