### PR TITLE
Fixing __has_include(<stdckdint.h>) compilation error

### DIFF
--- a/missing/dtoa.c
+++ b/missing/dtoa.c
@@ -210,10 +210,14 @@
 #include <locale.h>
 #endif
 
-#if defined(HAVE_STDCKDINT_H) || !defined(__has_include)
-#elif __has_include(<stdckdint.h>)
+#if !defined(HAVE_STDCKDINT_H)
+#if defined(__has_include)
+#if __has_include(<stdckdint.h>)
 # define HAVE_STDCKDINT_H 1
 #endif
+#endif
+#endif
+
 #ifdef HAVE_STDCKDINT_H
 # include <stdckdint.h>
 #endif


### PR DESCRIPTION
The very thing the conditional for `__has_include` is trying to handle, is causing compilation to break.

This file was brought into the ruby/bigdecimal project, and is failing to compile on a platform which doesnt have `__has_include` support in the compiler.

Compile log can be found in this comment:
https://github.com/ruby/bigdecimal/pull/531#issuecomment-4337861950