### PR TITLE
Bump RDoc to latest master (bc0baee)

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -37,7 +37,7 @@ ostruct             0.6.3   https://github.com/ruby/ostruct
 pstore              0.2.1   https://github.com/ruby/pstore
 benchmark           0.5.0   https://github.com/ruby/benchmark
 logger              1.7.0   https://github.com/ruby/logger
-rdoc                7.2.0   https://github.com/ruby/rdoc 4913d56243f2577c639ba305fd36c40d55c34f1a
+rdoc                7.2.0   https://github.com/ruby/rdoc bc0baee787609f2205e8f1103f3e1d36b923184a
 win32ole            1.9.3   https://github.com/ruby/win32ole
 irb                 1.17.0  https://github.com/ruby/irb cfd0b917d3feb01adb7d413b19faeb0309900599
 reline              0.6.3   https://github.com/ruby/reline


### PR DESCRIPTION
## Summary

Bumps the pinned RDoc commit in `gems/bundled_gems` from [`4913d56`](https://github.com/ruby/rdoc/commit/4913d56243f2577c639ba305fd36c40d55c34f1a) to [`bc0baee`](https://github.com/ruby/rdoc/commit/bc0baee787609f2205e8f1103f3e1d36b923184a).

### Changes in range

[Compare view](https://github.com/ruby/rdoc/compare/4913d56243f2577c639ba305fd36c40d55c34f1a...bc0baee787609f2205e8f1103f3e1d36b923184a) — 9 commits, all backward-compatible:

- ruby/rdoc#1676 — Preserve `#` prefix for unresolved cross-references
- ruby/rdoc#1627 — Fix Markdown blockquote parsing
- ruby/rdoc#1686 — Fix CSS to prevent method name overflow
- 6× dependabot bumps for GitHub Actions only (`actions/github-script`, `ruby/setup-ruby`, `step-security/harden-runner`, `actions/upload-pages-artifact`)

Follows the same pattern as the previous bump in #16713.