### PR TITLE
compile.c: repack `struct ibf_header`

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -12533,8 +12533,10 @@ static const char IBF_ENDIAN_MARK =
 
 struct ibf_header {
     char magic[4]; /* YARB */
-    uint32_t major_version;
-    uint32_t minor_version;
+    uint8_t major_version;
+    uint8_t minor_version;
+    uint8_t endian;
+    uint8_t wordsize;           /* assume no 2048-bit CPU */
     uint32_t size;
     uint32_t extra_size;
 
@@ -12542,8 +12544,6 @@ struct ibf_header {
     uint32_t global_object_list_size;
     ibf_offset_t iseq_list_offset;
     ibf_offset_t global_object_list_offset;
-    uint8_t endian;
-    uint8_t wordsize;           /* assume no 2048-bit CPU */
 };
 
 struct ibf_dump_buffer {


### PR DESCRIPTION
`uint8_t` is more than enough to store major and minor versions.