### PR TITLE
enumerator.c: guard `eargs` in `append_method` and `arith_seq_inspect`

### DIFF
--- a/enumerator.c
+++ b/enumerator.c
@@ -1222,6 +1222,7 @@ append_method(VALUE obj, VALUE str, ID default_method, VALUE default_args)
             rb_str_buf_cat2(str, ")");
         }
     }
+    RB_GC_GUARD(eargs);
 
     return str;
 }
@@ -4387,6 +4388,7 @@ arith_seq_inspect(VALUE self)
             rb_str_buf_cat2(str, ")");
         }
     }
+    RB_GC_GUARD(eargs);
 
     rb_str_buf_cat2(str, ")");
 


### PR DESCRIPTION
Add `RB_GC_GUARD(eargs)` in `append_method` and
`arith_seq_inspect`.

Both functions derive `argv` from `RARRAY_CONST_PTR(eargs)`, then
continue using that raw pointer across calls such as `rb_hash_foreach`
and `rb_inspect`.
The args array is still reachable,
but those references can be updated if compaction moves it. Keeping
`eargs` visible in the C machine context until after the last `argv` use
makes GC pin the array while the raw pointer is live.

On an `-O3` Ruby 4.0.2 arm64 build, `eargs` is optimized into a
short-lived register while the derived `argv` pointer remains live across
`rb_inspect`.

## Reproducer

Checked with:

```text
ruby 4.0.2 (2026-03-17 revision d3da9fec82) +PRISM [arm64-darwin25]
```

It is a stress reproducer, not a
deterministic test; the crash is timing-sensitive and may not reproduce
on every run or environment.

```ruby
STDOUT.sync = true
Thread.report_on_exception = false

GC.auto_compact = true if GC.respond_to?(:auto_compact=)
begin
  GC.stress = :immediate
rescue ArgumentError, TypeError
  GC.stress = true
end

def compact_now
  GC.compact if GC.respond_to?(:compact)
  GC.start(full_mark: true, immediate_sweep: true)
end

Thread.new { loop { compact_now } }
Thread.new { loop { Array.new(200) { "x" * 1024 }.shuffle! } }

deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) +
  (ENV["POC_SECONDS"] || "60").to_f

case ENV.fetch("POC_CASE", "arith")
when "arith"
  while Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
    1.step(10, 2).inspect
  end
when "append"
  klass = Class.new do
    def initialize(tag)
      @tag = tag
    end

    def inspect
      100.times { "x" * 10_000 }
      compact_now
      "EVIL#{@tag}"
    end
  end

  enum = (1..100).to_enum(:each_cons, klass.new(1), klass.new(2), klass.new(3))
  while Process.clock_gettime(Process::CLOCK_MONOTONIC) < deadline
    enum.inspect
  end
else
  abort "unknown POC_CASE"
end
```

Run with:

```sh
POC_SECONDS=60 POC_CASE=arith ruby poc.rb
POC_SECONDS=60 POC_CASE=append ruby poc.rb
```

Observed locally:

- `POC_CASE=arith`: three 20-second runs crashed with SIGSEGV and
  `arith_seq_inspect -> rb_inspect` in the C stack.
- `POC_CASE=append`: three 20-second runs crashed with SIGSEGV and
  `append_method -> rb_inspect` in the C stack. Earlier local runs also
  reproduced this path as SIGBUS, so the exact signal can vary.
