### PR TITLE
Use flag to determine when imemo_memo.u3 is a VALUE

### DIFF
--- a/enum.c
+++ b/enum.c
@@ -127,7 +127,7 @@ static VALUE
 enum_grep0(VALUE obj, VALUE pat, VALUE test)
 {
     VALUE ary = rb_ary_new();
-    struct MEMO *memo = rb_imemo_memo_new(pat, ary, test);
+    struct MEMO *memo = rb_imemo_memo_new_value(pat, ary, test);
     rb_block_call_func_t fn;
     if (rb_block_given_p()) {
         fn = grep_iter_i;
@@ -207,27 +207,32 @@ enum_grep_v(VALUE obj, VALUE pat)
     return enum_grep0(obj, pat, Qfalse);
 }
 
-#define COUNT_BIGNUM IMEMO_FL_USER0
-#define MEMO_V3_SET(m, v) RB_OBJ_WRITE((m), &(m)->u3.value, (v))
+static inline void
+MEMO_V3_SET(struct MEMO *m, VALUE v)
+{
+    RB_OBJ_WRITE(m, &m->u3.value, v);
+    m->flags |= MEMO_U3_IS_VALUE;
+}
 
 static void
 imemo_count_up(struct MEMO *memo)
 {
-    if (memo->flags & COUNT_BIGNUM) {
+    if (memo->flags & MEMO_U3_IS_VALUE) {
+        RUBY_ASSERT(RB_TYPE_P(memo->u3.value, T_BIGNUM));
         MEMO_V3_SET(memo, rb_int_succ(memo->u3.value));
     }
     else if (++memo->u3.cnt == 0) {
         /* overflow */
         unsigned long buf[2] = {0, 1};
         MEMO_V3_SET(memo, rb_big_unpack(buf, 2));
-        memo->flags |= COUNT_BIGNUM;
     }
 }
 
 static VALUE
 imemo_count_value(struct MEMO *memo)
 {
-    if (memo->flags & COUNT_BIGNUM) {
+    if (memo->flags & MEMO_U3_IS_VALUE) {
+        RUBY_ASSERT(RB_TYPE_P(memo->u3.value, T_BIGNUM));
         return memo->u3.value;
     }
     else {
@@ -1084,7 +1089,7 @@ enum_inject(int argc, VALUE *argv, VALUE obj)
         return ary_inject_op(obj, init, op);
     }
 
-    memo = rb_imemo_memo_new(init, Qnil, op);
+    memo = rb_imemo_memo_new_value(init, Qnil, op);
     rb_block_call(obj, id_each, 0, 0, iter, (VALUE)memo);
     if (UNDEF_P(memo->v1)) return Qnil;
     return memo->v1;

--- a/imemo.c
+++ b/imemo.c
@@ -101,15 +101,26 @@ rb_free_tmp_buffer(volatile VALUE *store)
 }
 
 struct MEMO *
-rb_imemo_memo_new(VALUE a, VALUE b, VALUE c)
+rb_imemo_memo_new(VALUE a, VALUE b, long c)
 {
     struct MEMO *memo = IMEMO_NEW(struct MEMO, imemo_memo, 0);
 
-    rb_gc_register_pinning_obj((VALUE)memo);
+    *((VALUE *)&memo->v1) = a;
+    *((VALUE *)&memo->v2) = b;
+    memo->u3.cnt = c;
+
+    return memo;
+}
+
+struct MEMO *
+rb_imemo_memo_new_value(VALUE a, VALUE b, VALUE c)
+{
+    struct MEMO *memo = IMEMO_NEW(struct MEMO, imemo_memo, 0);
 
     *((VALUE *)&memo->v1) = a;
     *((VALUE *)&memo->v2) = b;
     *((VALUE *)&memo->u3.value) = c;
+    memo->flags |= MEMO_U3_IS_VALUE;
 
     return memo;
 }
@@ -478,8 +489,8 @@ rb_imemo_mark_and_move(VALUE obj, bool reference_updating)
 
         rb_gc_mark_and_move((VALUE *)&memo->v1);
         rb_gc_mark_and_move((VALUE *)&memo->v2);
-        if (!reference_updating) {
-            rb_gc_mark_maybe(memo->u3.value);
+        if (FL_TEST_RAW(obj, MEMO_U3_IS_VALUE)) {
+            rb_gc_mark_and_move((VALUE *)&memo->u3.value);
         }
 
         break;

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -97,6 +97,10 @@ struct rb_imemo_tmpbuf_struct {
     size_t size; /* buffer size in bytes */
 };
 
+/* Set on imemo_memo when u3 holds a VALUE that GC must mark.
+ * When unset, u3 is a non-VALUE (cnt/state). */
+#define MEMO_U3_IS_VALUE IMEMO_FL_USER0
+
 /*! MEMO
  *
  * @see imemo_type
@@ -132,7 +136,8 @@ typedef struct rb_imemo_tmpbuf_struct rb_imemo_tmpbuf_t;
 #endif
 VALUE rb_imemo_new(enum imemo_type type, VALUE v0, size_t size, bool is_shareable);
 VALUE rb_imemo_tmpbuf_new(void);
-struct MEMO *rb_imemo_memo_new(VALUE a, VALUE b, VALUE c);
+struct MEMO *rb_imemo_memo_new(VALUE a, VALUE b, long c);
+struct MEMO *rb_imemo_memo_new_value(VALUE a, VALUE b, VALUE c);
 struct vm_ifunc *rb_vm_ifunc_new(rb_block_call_func_t func, const void *data, int min_argc, int max_argc);
 static inline enum imemo_type imemo_type(VALUE imemo);
 static inline int imemo_type_p(VALUE imemo, enum imemo_type imemo_type);

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -109,7 +109,6 @@ struct MEMO {
         long cnt;
         long state;
         const VALUE value;
-        void (*func)(void);
     } u3;
 };
 


### PR DESCRIPTION
We always know when `MEMO.u3.value` contains a VALUE and even fire a write barrier for it. We should use this when marking, support compaction, and no longer need conservative marking.

Also remove unused `MEMO.u3.func`