### PR TITLE
Add back note about regexp /x comment limitation

### DIFF
--- a/doc/_regexp.rdoc
+++ b/doc/_regexp.rdoc
@@ -1128,6 +1128,13 @@ Regexp in extended mode:
   re = /#{pattern}/x
   re.match('MCMXLIII') # => #<MatchData "MCMXLIII" 1:"CM" 2:"XL" 3:"III">
 
+Comments in regexp literals cannot include unescaped terminator
+characters:
+
+  /
+    foo # the following slash \/ must be escaped
+  /x
+
 === Interpolation Mode
 
 Modifier +o+ means that the first time a literal regexp with interpolations


### PR DESCRIPTION
It was dropped in https://github.com/ruby/ruby/commit/932dd9f10e684fa99b059054fbc934607d85b45a. Ref https://github.com/ruby/prism/issues/4097

cc @eregon