### PR TITLE
Never increment `max_iv_count` on Object / BasicObject.

### DIFF
--- a/class.c
+++ b/class.c
@@ -868,10 +868,7 @@ rb_class_new(VALUE super)
     rb_check_inheritable(super);
     VALUE klass = rb_class_boot(super);
 
-    if (super != rb_cObject && super != rb_cBasicObject) {
-        RCLASS_SET_MAX_IV_COUNT(klass, RCLASS_MAX_IV_COUNT(super));
-    }
-
+    RCLASS_SET_MAX_IV_COUNT(klass, RCLASS_MAX_IV_COUNT(super));
     RUBY_ASSERT(getenv("RUBY_BOX") || RCLASS_PRIME_CLASSEXT_WRITABLE_P(klass));
 
     return klass;
@@ -1418,8 +1415,10 @@ Init_class_hierarchy(void)
     rb_cBasicObject = boot_defclass("BasicObject", 0);
     RCLASS_SET_ALLOCATOR(rb_cBasicObject, rb_class_allocate_instance);
     FL_SET_RAW(rb_cBasicObject, RCLASS_ALLOCATOR_DEFINED);
+    RCLASS_SET_EXPECT_NO_IVAR(rb_cBasicObject);
+
     rb_cObject = boot_defclass("Object", rb_cBasicObject);
-    rb_vm_register_global_object(rb_cObject);
+    RCLASS_SET_EXPECT_NO_IVAR(rb_cObject);
 
     /* resolve class name ASAP for order-independence */
     rb_set_class_path_string(rb_cObject, rb_cObject, rb_fstring_lit("Object"));

--- a/gc.c
+++ b/gc.c
@@ -3480,17 +3480,6 @@ rb_gc_mark_children(void *objspace, VALUE obj)
                 gc_mark_internal(ptr[i]);
             }
         }
-
-        attr_index_t fields_count = (attr_index_t)len;
-        if (fields_count) {
-            VALUE klass = RBASIC_CLASS(obj);
-
-            // Increment max_iv_count if applicable, used to determine size pool allocation
-            if (RCLASS_MAX_IV_COUNT(klass) < fields_count) {
-                RCLASS_SET_MAX_IV_COUNT(klass, fields_count);
-            }
-        }
-
         break;
       }
 

--- a/internal/class.h
+++ b/internal/class.h
@@ -91,6 +91,7 @@ struct rb_classext_struct {
     bool iclass_is_origin : 1;
     bool iclass_origin_shared_mtbl : 1;
     bool superclasses_with_self : 1;
+    bool expect_no_ivar : 1;
     VALUE classpath;
 };
 typedef struct rb_classext_struct rb_classext_t;
@@ -731,7 +732,22 @@ RCLASS_SET_ATTACHED_OBJECT(VALUE klass, VALUE attached_object)
 static inline void
 RCLASS_SET_MAX_IV_COUNT(VALUE klass, attr_index_t count)
 {
+    RUBY_ASSERT(klass != rb_cObject);
+    RUBY_ASSERT(klass != rb_cBasicObject);
+
     RCLASS_MAX_IV_COUNT(klass) = count;
+}
+
+static inline void
+RCLASS_SET_EXPECT_NO_IVAR(VALUE klass)
+{
+    RCLASS_EXT_PRIME(klass)->expect_no_ivar = true;
+}
+
+static inline bool
+RCLASS_EXPECT_NO_IVAR(VALUE klass)
+{
+    return RCLASS_EXT_PRIME(klass)->expect_no_ivar;
 }
 
 static inline void

--- a/object.c
+++ b/object.c
@@ -2224,6 +2224,7 @@ rb_class_initialize(int argc, VALUE *argv, VALUE klass)
         }
     }
     rb_class_set_super(klass, super);
+    RCLASS_SET_MAX_IV_COUNT(klass, RCLASS_MAX_IV_COUNT(super));
     RCLASS_SET_ALLOCATOR(klass, RCLASS_ALLOCATOR(super));
     rb_make_metaclass(klass, RBASIC(super)->klass);
     rb_class_inherited(super, klass);

--- a/shape.c
+++ b/shape.c
@@ -822,7 +822,7 @@ shape_get_next(rb_shape_t *shape, enum shape_type shape_type, VALUE klass, ID id
     }
 
     // Check if we should update max_iv_count on the object's class
-    if (new_shape->next_field_index > RCLASS_MAX_IV_COUNT(klass)) {
+    if (new_shape->next_field_index > RCLASS_MAX_IV_COUNT(klass) && !RCLASS_EXPECT_NO_IVAR(klass)) {
         RCLASS_SET_MAX_IV_COUNT(klass, new_shape->next_field_index);
     }
 
@@ -1468,6 +1468,12 @@ rb_shape_exhaust(int argc, VALUE *argv, VALUE self)
     return Qnil;
 }
 
+static VALUE
+rb_shape_class_max_iv_count(VALUE self, VALUE klass)
+{
+    return INT2NUM(RCLASS_MAX_IV_COUNT(klass));
+}
+
 static VALUE shape_to_h(rb_shape_t *shape);
 
 static enum rb_id_table_iterator_result collect_keys_and_values(ID key, VALUE value, void *ref)
@@ -1658,5 +1664,6 @@ Init_shape(void)
     rb_define_singleton_method(rb_cShape, "root_shape", rb_shape_root_shape, 0);
     rb_define_singleton_method(rb_cShape, "shapes_available", rb_shape_shapes_available, 0);
     rb_define_singleton_method(rb_cShape, "exhaust_shapes", rb_shape_exhaust, -1);
+    rb_define_singleton_method(rb_cShape, "class_max_iv_count", rb_shape_class_max_iv_count, 1);
 #endif
 }

--- a/test/ruby/test_shapes.rb
+++ b/test/ruby/test_shapes.rb
@@ -131,6 +131,48 @@ class TestShapes < Test::Unit::TestCase
     assert_operator obj["variation_count"], :<, RubyVM::Shape::SHAPE_MAX_VARIATIONS
   end
 
+  def test_max_iv_count
+    klass = Class.new
+    object = klass.new
+
+    assert_equal 0, RubyVM::Shape.class_max_iv_count(klass)
+    8.times do |i|
+      object.instance_variable_set("@ivar_#{i}", i)
+    end
+    assert_equal 8, RubyVM::Shape.class_max_iv_count(klass)
+
+    subklass = Class.new(klass)
+    assert_equal 8, RubyVM::Shape.class_max_iv_count(subklass)
+  end
+
+  def test_max_iv_count_on_Object
+    object = Object.new
+
+    assert_equal 0, RubyVM::Shape.class_max_iv_count(Object)
+    8.times do |i|
+      object.instance_variable_set("@ivar_#{i}", i)
+    end
+    assert_equal 0, RubyVM::Shape.class_max_iv_count(Object)
+  end
+
+  def test_max_iv_count_on_BasicObject
+    object = BasicObject.new
+
+    assert_equal 0, RubyVM::Shape.class_max_iv_count(BasicObject)
+    8.times do |i|
+      Object.instance_method(:instance_variable_set).bind_call(object, "@ivar_#{i}", i)
+    end
+    assert_equal 0, RubyVM::Shape.class_max_iv_count(BasicObject)
+
+    subklass = Class.new(BasicObject)
+    object = subklass.new
+    assert_equal 0, RubyVM::Shape.class_max_iv_count(subklass)
+    8.times do |i|
+      Object.instance_method(:instance_variable_set).bind_call(object, "@ivar_#{i}", i)
+    end
+    assert_equal 8, RubyVM::Shape.class_max_iv_count(subklass)
+  end
+
   def test_too_many_ivs_on_obj
     assert_separately([], "#{<<~"begin;"}\n#{<<~'end;'}")
     begin;

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6045,8 +6045,8 @@ vm_define_method(const rb_execution_context_t *ec, VALUE obj, ID id, VALUE iseqv
 
     rb_add_method_iseq(klass, id, (const rb_iseq_t *)iseqval, cref, visi);
     // Set max_iv_count on klasses based on number of ivar sets that are in the initialize method
-    if (id == idInitialize && klass != rb_cObject && RB_TYPE_P(klass, T_CLASS) &&
-        !RCLASS_SINGLETON_P(klass) &&
+    if (id == idInitialize && RB_TYPE_P(klass, T_CLASS) &&
+        !RCLASS_SINGLETON_P(klass) && !RCLASS_EXPECT_NO_IVAR(klass) &&
         (rb_get_alloc_func(klass) == rb_class_allocate_instance)) {
         RCLASS_SET_MAX_IV_COUNT(klass, rb_estimate_iv_count(klass, (const rb_iseq_t *)iseqval));
     }


### PR DESCRIPTION
Otherwise some code defining ivars on a naked object early during program boot can cause all objects to be larger than needed.

This seem like it was always the intention, but wasn't quite properly prevented.

Also stop updating `max_iv_count` during GC marking as it is redundant.