### PR TITLE
Fix IO::Buffer#each_byte bounds check

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2334,6 +2334,10 @@ io_buffer_each_byte(int argc, VALUE *argv, VALUE self)
     size_t offset, count;
     io_buffer_extract_offset_count(RB_IO_BUFFER_DATA_TYPE_U8, size, argc, argv, &offset, &count);
 
+    if (size_sum_is_bigger_than(offset, count, size)) {
+        rb_raise(rb_eArgError, "Specified offset+count is bigger than the buffer size!");
+    }
+
     for (size_t i = 0; i < count; i++) {
         unsigned char *value = (unsigned char *)base + i + offset;
         rb_yield(RB_INT2FIX(*value));

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -494,6 +494,14 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal string.bytes[3, 5], buffer.each_byte(3, 5).to_a
   end
 
+  def test_each_byte_bounds_error
+    buffer = IO::Buffer.for("A")
+
+    assert_raise(ArgumentError) { buffer.each_byte(0, 2).to_a }
+    assert_raise(ArgumentError) { buffer.each_byte(1, 1).to_a }
+    assert_raise(ArgumentError) { buffer.each_byte(SIZE_MAX, 0).to_a }
+  end
+
   def test_zero_length_each_byte
     buffer = IO::Buffer.new(0)
 


### PR DESCRIPTION
## Summary

`IO::Buffer#each_byte` accepted an explicit `count` without validating that `offset + count` stayed within the buffer size.

This adds the missing bounds check before yielding bytes, preventing reads past the end of the buffer.

## Tests

- `make -j8`
- `make test-all TESTS='test/ruby/test_io_buffer.rb'`
