### PR TITLE
shape.h: store ancestor_index as an offset

### DIFF
--- a/shape.c
+++ b/shape.c
@@ -37,11 +37,26 @@ static ID id_object_id;
 
 // Should be on its own cache line
 static RUBY_ALIGNAS(128) rb_atomic_t redblack_cache_size;
+
+struct redblack_node {
+    ID key;
+    rb_shape_t *value;
+    redblack_id_t l;
+    redblack_id_t r;
+};
+typedef struct redblack_node redblack_node_t;
+
 static redblack_node_t *redblack_cache;
 
 #define LEAF 0
 #define BLACK 0x0
 #define RED 0x1
+
+static inline redblack_node_t *
+redblack_node(redblack_id_t id)
+{
+    return id ? &redblack_cache[id - 1] : LEAF;
+}
 
 static redblack_node_t *
 redblack_left(redblack_node_t *node)
@@ -51,7 +66,7 @@ redblack_left(redblack_node_t *node)
     }
     else {
         RUBY_ASSERT(node->l < redblack_cache_size);
-        redblack_node_t *left = &redblack_cache[node->l - 1];
+        redblack_node_t *left = redblack_node(node->l);
         return left;
     }
 }
@@ -64,13 +79,13 @@ redblack_right(redblack_node_t *node)
     }
     else {
         RUBY_ASSERT(node->r < redblack_cache_size);
-        redblack_node_t *right = &redblack_cache[node->r - 1];
+        redblack_node_t *right = redblack_node(node->r);
         return right;
     }
 }
 
 static redblack_node_t *
-redblack_find(redblack_node_t *tree, ID key)
+redblack_find0(redblack_node_t *tree, ID key)
 {
     if (tree == LEAF) {
         return LEAF;
@@ -84,13 +99,19 @@ redblack_find(redblack_node_t *tree, ID key)
         }
         else {
             if (key < tree->key) {
-                return redblack_find(redblack_left(tree), key);
+                return redblack_find0(redblack_left(tree), key);
             }
             else {
-                return redblack_find(redblack_right(tree), key);
+                return redblack_find0(redblack_right(tree), key);
             }
         }
     }
+}
+
+static redblack_node_t *
+redblack_find(redblack_id_t tree_id, ID key)
+{
+    return redblack_find0(redblack_node(tree_id), key);
 }
 
 static inline rb_shape_t *
@@ -276,16 +297,16 @@ redblack_force_black(redblack_node_t *node)
     return node;
 }
 
-static redblack_node_t *
+static redblack_id_t
 redblack_insert(redblack_node_t *tree, ID key, rb_shape_t *value)
 {
     redblack_node_t *root = redblack_insert_aux(tree, key, value);
 
     if (redblack_red_p(root)) {
-        return redblack_force_black(root);
+        return redblack_id_for(redblack_force_black(root));
     }
     else {
-        return root;
+        return redblack_id_for(root);
     }
 }
 #endif
@@ -465,12 +486,10 @@ static redblack_node_t *
 redblack_cache_ancestors(rb_shape_t *shape)
 {
     if (!(shape->ancestor_index || shape->parent_id == INVALID_SHAPE_ID)) {
-        redblack_node_t *parent_index;
-
-        parent_index = redblack_cache_ancestors(RSHAPE(shape->parent_id));
+        redblack_node_t *parent_index_node = redblack_cache_ancestors(RSHAPE(shape->parent_id));
 
         if (shape->type == SHAPE_IVAR) {
-            shape->ancestor_index = redblack_insert(parent_index, shape->edge_name, shape);
+            shape->ancestor_index = redblack_insert(parent_index_node, shape->edge_name, shape);
 
 #if RUBY_DEBUG
             if (shape->ancestor_index) {
@@ -481,11 +500,11 @@ redblack_cache_ancestors(rb_shape_t *shape)
 #endif
         }
         else {
-            shape->ancestor_index = parent_index;
+            shape->ancestor_index = redblack_id_for(parent_index_node);
         }
     }
 
-    return shape->ancestor_index;
+    return redblack_node(shape->ancestor_index);
 }
 #else
 static redblack_node_t *

--- a/shape.h
+++ b/shape.h
@@ -75,8 +75,6 @@ typedef uint32_t redblack_id_t;
 #define ROOT_TOO_COMPLEX_SHAPE_ID       (ROOT_SHAPE_ID | SHAPE_ID_FL_TOO_COMPLEX)
 #define ROOT_TOO_COMPLEX_WITH_OBJ_ID    (ROOT_SHAPE_WITH_OBJ_ID | SHAPE_ID_FL_TOO_COMPLEX | SHAPE_ID_FL_HAS_OBJECT_ID)
 
-typedef struct redblack_node redblack_node_t;
-
 enum shape_type {
     SHAPE_ROOT,
     SHAPE_IVAR,
@@ -86,7 +84,7 @@ enum shape_type {
 struct rb_shape {
     VALUE edges; // id_table from ID (ivar) to next shape
     ID edge_name; // ID (ivar) for transition from parent to rb_shape
-    redblack_node_t *ancestor_index;
+    redblack_id_t ancestor_index;
     shape_id_t parent_id;
     attr_index_t next_field_index; // Fields are either ivars or internal properties like `object_id`
     attr_index_t capacity; // Total capacity of the object with this shape
@@ -94,13 +92,6 @@ struct rb_shape {
 };
 
 typedef struct rb_shape rb_shape_t;
-
-struct redblack_node {
-    ID key;
-    rb_shape_t *value;
-    redblack_id_t l;
-    redblack_id_t r;
-};
 
 enum shape_flags {
     SHAPE_FL_FROZEN             = 1 << 0,

--- a/shape.h
+++ b/shape.h
@@ -77,6 +77,12 @@ typedef uint32_t redblack_id_t;
 
 typedef struct redblack_node redblack_node_t;
 
+enum shape_type {
+    SHAPE_ROOT,
+    SHAPE_IVAR,
+    SHAPE_OBJ_ID,
+};
+
 struct rb_shape {
     VALUE edges; // id_table from ID (ivar) to next shape
     ID edge_name; // ID (ivar) for transition from parent to rb_shape
@@ -84,7 +90,7 @@ struct rb_shape {
     shape_id_t parent_id;
     attr_index_t next_field_index; // Fields are either ivars or internal properties like `object_id`
     attr_index_t capacity; // Total capacity of the object with this shape
-    uint8_t type;
+    enum shape_type type : 8;
 };
 
 typedef struct rb_shape rb_shape_t;
@@ -94,12 +100,6 @@ struct redblack_node {
     rb_shape_t *value;
     redblack_id_t l;
     redblack_id_t r;
-};
-
-enum shape_type {
-    SHAPE_ROOT,
-    SHAPE_IVAR,
-    SHAPE_OBJ_ID,
 };
 
 enum shape_flags {


### PR DESCRIPTION
This shrinks the `rb_shape_t` struct from 40B to 32B.

Also declare `rb_shape_t.type` as an 8B enum.