### PR TITLE
YJIT/ZJIT: don't assume `attr_index_t` is u16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.1"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99322078b2c076829a1db959d49da554fabc4342257fc0ba5a070a1eb3a01cd8"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -2975,7 +2975,7 @@ fn gen_get_ivar(
 
     let ivar_index = unsafe {
         let shape_id = comptime_receiver.shape_id_of();
-        let mut ivar_index: u16 = 0;
+        let mut ivar_index: attr_index_t = 0;
         if rb_shape_get_iv_index(shape_id, ivar_name, &mut ivar_index) {
             Some(ivar_index as usize)
         } else {
@@ -3171,7 +3171,7 @@ fn gen_set_ivar(
     let shape_too_complex = comptime_receiver.shape_too_complex();
     let ivar_index = if !comptime_receiver.special_const_p() && !shape_too_complex {
         let shape_id = comptime_receiver.shape_id_of();
-        let mut ivar_index: u16 = 0;
+        let mut ivar_index: attr_index_t = 0;
         if unsafe { rb_shape_get_iv_index(shape_id, ivar_name, &mut ivar_index) } {
             Some(ivar_index as usize)
         } else {
@@ -3461,7 +3461,7 @@ fn gen_definedivar(
 
     let shape_id = comptime_receiver.shape_id_of();
     let ivar_exists = unsafe {
-        let mut ivar_index: u16 = 0;
+        let mut ivar_index: attr_index_t = 0;
         rb_shape_get_iv_index(shape_id, ivar_name, &mut ivar_index)
     };
 

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -614,6 +614,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::Const { val: Const::CUInt16(val) } => gen_const_uint16(val),
         &Insn::Const { val: Const::CUInt32(val) } => gen_const_uint32(val),
         &Insn::Const { val: Const::CUInt64(val) } => Opnd::UImm(val),
+        &Insn::Const { val: Const::CAttrIndex(val) } => gen_const_attr_index_t(val),
         &Insn::Const { val: Const::CShape(val) } => {
             assert_eq!(SHAPE_ID_NUM_BITS, 32);
             gen_const_uint32(val.0)
@@ -1452,6 +1453,10 @@ fn gen_const_uint16(val: u16) -> lir::Opnd {
 }
 
 fn gen_const_uint32(val: u32) -> lir::Opnd {
+    Opnd::UImm(val as u64)
+}
+
+fn gen_const_attr_index_t(val: attr_index_t) -> lir::Opnd {
     Opnd::UImm(val as u64)
 }
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -311,6 +311,7 @@ pub enum Const {
     CUInt8(u8),
     CUInt16(u16),
     CUInt32(u32),
+    CAttrIndex(attr_index_t),
     CShape(ShapeId),
     CUInt64(u64),
     CPtr(*const u8),
@@ -3079,6 +3080,7 @@ impl Function {
             Insn::Const { val: Const::CUInt8(val) } => Type::from_cint(types::CUInt8, *val as i64),
             Insn::Const { val: Const::CUInt16(val) } => Type::from_cint(types::CUInt16, *val as i64),
             Insn::Const { val: Const::CUInt32(val) } => Type::from_cint(types::CUInt32, *val as i64),
+            Insn::Const { val: Const::CAttrIndex(val) } => Type::from_cint(types::CAttrIndex, *val as i64),
             Insn::Const { val: Const::CShape(val) } => Type::from_cint(types::CShape, val.0 as i64),
             Insn::Const { val: Const::CUInt64(val) } => Type::from_cint(types::CUInt64, *val as i64),
             Insn::Const { val: Const::CPtr(val) } => Type::from_cptr(*val),
@@ -4440,10 +4442,10 @@ impl Function {
         })
     }
 
-    fn load_ivar_c_call(&mut self, block: BlockId, recv: InsnId, ivar_index: u16) -> InsnId {
+    fn load_ivar_c_call(&mut self, block: BlockId, recv: InsnId, ivar_index: attr_index_t) -> InsnId {
         // NOTE: it's fine to use rb_ivar_get_at_no_ractor_check because
         // getinstancevariable does assume_single_ractor_mode()
-        let ivar_index_insn = self.push_insn(block, Insn::Const { val: Const::CUInt16(ivar_index) });
+        let ivar_index_insn = self.push_insn(block, Insn::Const { val: Const::CAttrIndex(ivar_index) });
         self.push_insn(block, Insn::CCall {
             cfunc: rb_ivar_get_at_no_ractor_check as *const u8,
             recv,
@@ -4454,7 +4456,7 @@ impl Function {
             elidable: true })
     }
 
-    fn load_ivar_heap(&mut self, block: BlockId,  recv: InsnId, id: ID, ivar_index: u16) -> InsnId {
+    fn load_ivar_heap(&mut self, block: BlockId,  recv: InsnId, id: ID, ivar_index: attr_index_t) -> InsnId {
         // See ROBJECT_FIELDS() from include/ruby/internal/core/robject.h
         let ptr = self.push_insn(block, Insn::LoadField {
             recv, id: ID!(_as_heap),
@@ -4468,7 +4470,7 @@ impl Function {
         })
     }
 
-    fn load_ivar_embedded(&mut self, block: BlockId, recv: InsnId, id: ID, ivar_index: u16) -> InsnId {
+    fn load_ivar_embedded(&mut self, block: BlockId, recv: InsnId, id: ID, ivar_index: attr_index_t) -> InsnId {
         // See ROBJECT_FIELDS() from include/ruby/internal/core/robject.h
         let offset = ROBJECT_OFFSET_AS_ARY as i32
             + (SIZEOF_VALUE * ivar_index.to_usize()) as i32;
@@ -4478,7 +4480,7 @@ impl Function {
         })
     }
 
-    fn load_ivar_from_fields(&mut self, block: BlockId, recv: InsnId, is_embedded: bool, id: ID, ivar_index: u16) -> InsnId {
+    fn load_ivar_from_fields(&mut self, block: BlockId, recv: InsnId, is_embedded: bool, id: ID, ivar_index: attr_index_t) -> InsnId {
         if is_embedded {
             return self.load_ivar_embedded(block, recv, id, ivar_index);
         } else {
@@ -4507,7 +4509,7 @@ impl Function {
         // Too-complex shapes use hash tables; rb_shape_get_iv_index doesn't support them.
         // Callers must filter these out before calling load_ivar.
         assert!(!recv_type.shape().is_too_complex(), "load_ivar called with too-complex shape");
-        let mut ivar_index: u16 = 0;
+        let mut ivar_index: attr_index_t = 0;
         if ! unsafe { rb_shape_get_iv_index(recv_type.shape().0, id, &mut ivar_index) } {
             // If there is no IVAR index, then the ivar was undefined when we
             // entered the compiler.  That means we can just return nil for this
@@ -4611,7 +4613,7 @@ impl Function {
                         let self_val = self.load_ivar_guard_type(block, self_val, recv_type, state);
                         let shape = self.load_shape(block, self_val);
                         self.guard_shape(block, shape, recv_type.shape(), state, None);
-                        let mut ivar_index: u16 = 0;
+                        let mut ivar_index: attr_index_t = 0;
                         let replacement = if unsafe { rb_shape_get_iv_index(recv_type.shape().0, id, &mut ivar_index) } {
                             self.push_insn(block, Insn::Const { val: Const::Value(pushval) })
                         } else {
@@ -4650,7 +4652,7 @@ impl Function {
                             self.count(block, Counter::setivar_fallback_frozen);
                             self.push_insn_id(block, insn_id); continue;
                         }
-                        let mut ivar_index: u16 = 0;
+                        let mut ivar_index: attr_index_t = 0;
                         let mut next_shape_id = recv_type.shape();
                         if !unsafe { rb_shape_get_iv_index(recv_type.shape().0, id, &mut ivar_index) } {
                             // Current shape does not contain this ivar; do a shape transition.
@@ -6294,6 +6296,7 @@ impl Function {
                     Const::CUInt8(_) => self.assert_subtype(insn_id, val, types::CUInt8),
                     Const::CUInt16(_) => self.assert_subtype(insn_id, val, types::CUInt16),
                     Const::CUInt32(_) => self.assert_subtype(insn_id, val, types::CUInt32),
+                    Const::CAttrIndex(_) => self.assert_subtype(insn_id, val, types::CAttrIndex),
                     Const::CShape(_) => self.assert_subtype(insn_id, val, types::CShape),
                     Const::CUInt64(_) => self.assert_subtype(insn_id, val, types::CUInt64),
                     Const::CBool(_) => self.assert_subtype(insn_id, val, types::CBool),

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -7773,7 +7773,7 @@ mod hir_opt_tests {
           v17:HeapBasicObject = GuardType v6, HeapBasicObject
           v18:CShape = LoadField v17, :_shape_id@0x1000
           v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001)
-          v20:CUInt16[0] = Const CUInt16(0)
+          v20:CAttrIndex[0] = Const CAttrIndex(0)
           v21:BasicObject = CCall v17, :rb_ivar_get_at_no_ractor_check@0x1008, v20
           CheckInterrupts
           Return v21

--- a/zjit/src/hir_type/gen_hir_type.rb
+++ b/zjit/src/hir_type/gen_hir_type.rb
@@ -155,6 +155,7 @@ unsigned = cvalue_int.subtype "CUnsigned"
   unsigned.subtype "CUInt#{width}"
 }
 unsigned.subtype "CShape"
+unsigned.subtype "CAttrIndex"
 
 # Assign individual bits to type leaves and union bit patterns to nodes with subtypes
 num_bits = 0

--- a/zjit/src/hir_type/hir_type.inc.rs
+++ b/zjit/src/hir_type/hir_type.inc.rs
@@ -10,72 +10,73 @@ mod bits {
   pub const Bignum: u64 = 1u64 << 4;
   pub const BoolExact: u64 = FalseClass | TrueClass;
   pub const BuiltinExact: u64 = ArrayExact | BasicObjectExact | FalseClass | Float | HashExact | Integer | ModuleExact | NilClass | NumericExact | ObjectExact | RangeExact | RegexpExact | SetExact | StringExact | Symbol | TrueClass;
-  pub const CBool: u64 = 1u64 << 5;
-  pub const CDouble: u64 = 1u64 << 6;
+  pub const CAttrIndex: u64 = 1u64 << 5;
+  pub const CBool: u64 = 1u64 << 6;
+  pub const CDouble: u64 = 1u64 << 7;
   pub const CInt: u64 = CSigned | CUnsigned;
-  pub const CInt16: u64 = 1u64 << 7;
-  pub const CInt32: u64 = 1u64 << 8;
-  pub const CInt64: u64 = 1u64 << 9;
-  pub const CInt8: u64 = 1u64 << 10;
-  pub const CNull: u64 = 1u64 << 11;
-  pub const CPtr: u64 = 1u64 << 12;
-  pub const CShape: u64 = 1u64 << 13;
+  pub const CInt16: u64 = 1u64 << 8;
+  pub const CInt32: u64 = 1u64 << 9;
+  pub const CInt64: u64 = 1u64 << 10;
+  pub const CInt8: u64 = 1u64 << 11;
+  pub const CNull: u64 = 1u64 << 12;
+  pub const CPtr: u64 = 1u64 << 13;
+  pub const CShape: u64 = 1u64 << 14;
   pub const CSigned: u64 = CInt16 | CInt32 | CInt64 | CInt8;
-  pub const CUInt16: u64 = 1u64 << 14;
-  pub const CUInt32: u64 = 1u64 << 15;
-  pub const CUInt64: u64 = 1u64 << 16;
-  pub const CUInt8: u64 = 1u64 << 17;
-  pub const CUnsigned: u64 = CShape | CUInt16 | CUInt32 | CUInt64 | CUInt8;
+  pub const CUInt16: u64 = 1u64 << 15;
+  pub const CUInt32: u64 = 1u64 << 16;
+  pub const CUInt64: u64 = 1u64 << 17;
+  pub const CUInt8: u64 = 1u64 << 18;
+  pub const CUnsigned: u64 = CAttrIndex | CShape | CUInt16 | CUInt32 | CUInt64 | CUInt8;
   pub const CValue: u64 = CBool | CDouble | CInt | CNull | CPtr;
-  pub const CallableMethodEntry: u64 = 1u64 << 18;
-  pub const Class: u64 = 1u64 << 19;
-  pub const DynamicSymbol: u64 = 1u64 << 20;
+  pub const CallableMethodEntry: u64 = 1u64 << 19;
+  pub const Class: u64 = 1u64 << 20;
+  pub const DynamicSymbol: u64 = 1u64 << 21;
   pub const Empty: u64 = 0u64;
-  pub const FalseClass: u64 = 1u64 << 21;
+  pub const FalseClass: u64 = 1u64 << 22;
   pub const Falsy: u64 = FalseClass | NilClass;
-  pub const Fixnum: u64 = 1u64 << 22;
+  pub const Fixnum: u64 = 1u64 << 23;
   pub const Float: u64 = Flonum | HeapFloat;
-  pub const Flonum: u64 = 1u64 << 23;
+  pub const Flonum: u64 = 1u64 << 24;
   pub const Hash: u64 = HashExact | HashSubclass;
-  pub const HashExact: u64 = 1u64 << 24;
-  pub const HashSubclass: u64 = 1u64 << 25;
+  pub const HashExact: u64 = 1u64 << 25;
+  pub const HashSubclass: u64 = 1u64 << 26;
   pub const HeapBasicObject: u64 = BasicObject & !Immediate;
-  pub const HeapFloat: u64 = 1u64 << 26;
+  pub const HeapFloat: u64 = 1u64 << 27;
   pub const HeapObject: u64 = Object & !Immediate;
   pub const Immediate: u64 = FalseClass | Fixnum | Flonum | NilClass | StaticSymbol | TrueClass | Undef;
   pub const Integer: u64 = Bignum | Fixnum;
   pub const Module: u64 = Class | ModuleExact | ModuleSubclass;
-  pub const ModuleExact: u64 = 1u64 << 27;
-  pub const ModuleSubclass: u64 = 1u64 << 28;
-  pub const NilClass: u64 = 1u64 << 29;
+  pub const ModuleExact: u64 = 1u64 << 28;
+  pub const ModuleSubclass: u64 = 1u64 << 29;
+  pub const NilClass: u64 = 1u64 << 30;
   pub const NotNil: u64 = BasicObject & !NilClass;
   pub const Numeric: u64 = Float | Integer | NumericExact | NumericSubclass;
-  pub const NumericExact: u64 = 1u64 << 30;
-  pub const NumericSubclass: u64 = 1u64 << 31;
+  pub const NumericExact: u64 = 1u64 << 31;
+  pub const NumericSubclass: u64 = 1u64 << 32;
   pub const Object: u64 = Array | FalseClass | Hash | Module | NilClass | Numeric | ObjectExact | ObjectSubclass | Range | Regexp | Set | String | Symbol | TrueClass;
-  pub const ObjectExact: u64 = 1u64 << 32;
-  pub const ObjectSubclass: u64 = 1u64 << 33;
+  pub const ObjectExact: u64 = 1u64 << 33;
+  pub const ObjectSubclass: u64 = 1u64 << 34;
   pub const Range: u64 = RangeExact | RangeSubclass;
-  pub const RangeExact: u64 = 1u64 << 34;
-  pub const RangeSubclass: u64 = 1u64 << 35;
+  pub const RangeExact: u64 = 1u64 << 35;
+  pub const RangeSubclass: u64 = 1u64 << 36;
   pub const Regexp: u64 = RegexpExact | RegexpSubclass;
-  pub const RegexpExact: u64 = 1u64 << 36;
-  pub const RegexpSubclass: u64 = 1u64 << 37;
+  pub const RegexpExact: u64 = 1u64 << 37;
+  pub const RegexpSubclass: u64 = 1u64 << 38;
   pub const RubyValue: u64 = BasicObject | CallableMethodEntry | Undef;
   pub const Set: u64 = SetExact | SetSubclass;
-  pub const SetExact: u64 = 1u64 << 38;
-  pub const SetSubclass: u64 = 1u64 << 39;
-  pub const StaticSymbol: u64 = 1u64 << 40;
+  pub const SetExact: u64 = 1u64 << 39;
+  pub const SetSubclass: u64 = 1u64 << 40;
+  pub const StaticSymbol: u64 = 1u64 << 41;
   pub const String: u64 = StringExact | StringSubclass;
-  pub const StringExact: u64 = 1u64 << 41;
-  pub const StringSubclass: u64 = 1u64 << 42;
+  pub const StringExact: u64 = 1u64 << 42;
+  pub const StringSubclass: u64 = 1u64 << 43;
   pub const Subclass: u64 = ArraySubclass | BasicObjectSubclass | HashSubclass | ModuleSubclass | NumericSubclass | ObjectSubclass | RangeSubclass | RegexpSubclass | SetSubclass | StringSubclass;
   pub const Symbol: u64 = DynamicSymbol | StaticSymbol;
-  pub const TrueClass: u64 = 1u64 << 43;
+  pub const TrueClass: u64 = 1u64 << 44;
   pub const Truthy: u64 = BasicObject & !Falsy;
-  pub const TypedTData: u64 = 1u64 << 44;
-  pub const Undef: u64 = 1u64 << 45;
-  pub const AllBitPatterns: [(&str, u64); 75] = [
+  pub const TypedTData: u64 = 1u64 << 45;
+  pub const Undef: u64 = 1u64 << 46;
+  pub const AllBitPatterns: [(&str, u64); 76] = [
     ("Any", Any),
     ("RubyValue", RubyValue),
     ("Immediate", Immediate),
@@ -144,6 +145,7 @@ mod bits {
     ("CInt16", CInt16),
     ("CDouble", CDouble),
     ("CBool", CBool),
+    ("CAttrIndex", CAttrIndex),
     ("Bignum", Bignum),
     ("BasicObjectSubclass", BasicObjectSubclass),
     ("BasicObjectExact", BasicObjectExact),
@@ -152,7 +154,7 @@ mod bits {
     ("ArrayExact", ArrayExact),
     ("Empty", Empty),
   ];
-  pub const NumTypeBits: u64 = 46;
+  pub const NumTypeBits: u64 = 47;
 }
 pub mod types {
   use super::*;
@@ -166,6 +168,7 @@ pub mod types {
   pub const Bignum: Type = Type::from_bits(bits::Bignum);
   pub const BoolExact: Type = Type::from_bits(bits::BoolExact);
   pub const BuiltinExact: Type = Type::from_bits(bits::BuiltinExact);
+  pub const CAttrIndex: Type = Type::from_bits(bits::CAttrIndex);
   pub const CBool: Type = Type::from_bits(bits::CBool);
   pub const CDouble: Type = Type::from_bits(bits::CDouble);
   pub const CInt: Type = Type::from_bits(bits::CInt);

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -269,6 +269,7 @@ impl Type {
             Const::CUInt8(v) => Self::from_cint(types::CUInt8, v as i64),
             Const::CUInt16(v) => Self::from_cint(types::CUInt16, v as i64),
             Const::CUInt32(v) => Self::from_cint(types::CUInt32, v as i64),
+            Const::CAttrIndex(v) => Self::from_cint(types::CAttrIndex, v as i64),
             Const::CShape(v) => Self::from_cint(types::CShape, v.0 as i64),
             Const::CUInt64(v) => Self::from_cint(types::CUInt64, v as i64),
             Const::CPtr(v) => Self::from_cptr(v),


### PR DESCRIPTION
Extracted from: https://github.com/ruby/ruby/pull/16817

It's likely that it will be u8 soon.