### PR TITLE
ZJIT: Drop redundant type guards via block-local HIR canonicalize

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -148,6 +148,7 @@ class << RubyVM::ZJIT
       :compile_hir_time_ns,
       :compile_hir_build_time_ns,
       :compile_hir_strength_reduce_time_ns,
+      :compile_hir_canonicalize_time_ns,
       :compile_hir_fold_constants_time_ns,
       :compile_hir_clean_cfg_time_ns,
       :compile_hir_eliminate_dead_code_time_ns,

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4970,11 +4970,8 @@ impl Function {
                     *operand = rewrite_map.get(&canon).copied().unwrap_or(canon);
                 });
 
-                // GuardTypeNot is excluded: its infer_type is BasicObject
-                // (HIR has no negated-type representation), so registering
-                // would widen downstream uses' inferred types. For the
-                // binary guards only `left` is registered because their
-                // infer_type is type_of(left).
+                // For the binary guards only `left` is registered because their infer_type is
+                // type_of(left).
                 match &self.insns[canonical_id.0] {
                     Insn::GuardType      { val:  src, .. }
                     | Insn::GuardBitEquals { val:  src, .. }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4144,6 +4144,9 @@ impl Function {
                 }
             }
         }
+        crate::stats::trace_compile_phase("canonicalize", ||
+            crate::stats::with_time_stat(Counter::compile_hir_canonicalize_time_ns, || self.canonicalize())
+        );
         crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
@@ -4198,6 +4201,9 @@ impl Function {
                 }
             }
         }
+        crate::stats::trace_compile_phase("canonicalize", ||
+            crate::stats::with_time_stat(Counter::compile_hir_canonicalize_time_ns, || self.canonicalize())
+        );
         crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
@@ -4486,6 +4492,9 @@ impl Function {
                 }
             }
         }
+        crate::stats::trace_compile_phase("canonicalize", ||
+            crate::stats::with_time_stat(Counter::compile_hir_canonicalize_time_ns, || self.canonicalize())
+        );
         crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
@@ -4816,6 +4825,9 @@ impl Function {
                 self.push_insn_id(block, insn_id);
             }
         }
+        crate::stats::trace_compile_phase("canonicalize", ||
+            crate::stats::with_time_stat(Counter::compile_hir_canonicalize_time_ns, || self.canonicalize())
+        );
         crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
@@ -4927,45 +4939,54 @@ impl Function {
             .unwrap_or(insn_id)
     }
 
-    /// Forward each branch-edge arg through the most recent `GuardType` of that
-    /// value within the same block. Lets a follow-up `infer_types` narrow merge-block
-    /// parameter types so `fold_constants` can drop redundant guards at CFG joins.
-    fn forward_guarded_values_to_jumps(&mut self) {
-        let mut changed = false;
-        let mut latest_guard: HashMap<InsnId, InsnId> = HashMap::new();
+    /// Block-local canonicalize: rewrite each operand through union-find and a
+    /// per-block map of the most recent `Guard*` for that value. Forwards
+    /// guarded values into branch-edge args (so `infer_types` narrows merge-block
+    /// parameters and `fold_constants` drops redundant CFG-join guards) and
+    /// ordinary in-block uses.
+    ///
+    /// `Guard*` substitutions are unconditional within a block: a guard's
+    /// side-exit semantics guarantee the substituted value type holds for every
+    /// downstream use in the same block.
+    ///
+    /// `RefineType` is intentionally skipped: its narrowing is only valid on one
+    /// branch arm, which would require dropping refine-derived rewrites at each
+    /// `IfTrue`/`IfFalse`. Cross-arm refine forwarding is left for a follow-up
+    /// dominator-scoped pass.
+    ///
+    /// Inspired by Cranelift's aegraph canonicalize step
+    /// (<https://cfallin.org/blog/2026/04/09/aegraph/>).
+    fn canonicalize(&mut self) {
+        let mut rewrite_map: HashMap<InsnId, InsnId> = HashMap::new();
         for block in self.rpo() {
-            latest_guard.clear();
+            rewrite_map.clear();
             for i in 0..self.blocks[block.0].insns.len() {
                 let insn_id = self.blocks[block.0].insns[i];
-                match self.find(insn_id) {
-                    Insn::GuardType { val, .. } => {
-                        latest_guard.insert(val, insn_id);
-                    }
-                    Insn::Jump(BranchEdge { ref args, .. })
-                    | Insn::IfTrue { target: BranchEdge { ref args, .. }, .. }
-                    | Insn::IfFalse { target: BranchEdge { ref args, .. }, .. } => {
-                        if !args.iter().any(|arg| latest_guard.contains_key(arg)) {
-                            continue;
-                        }
-                        let new_args: Vec<InsnId> = args.iter()
-                            .map(|arg| latest_guard.get(arg).copied().unwrap_or(*arg))
-                            .collect();
-                        match &mut self.insns[insn_id.0] {
-                            Insn::Jump(BranchEdge { args, .. })
-                            | Insn::IfTrue { target: BranchEdge { args, .. }, .. }
-                            | Insn::IfFalse { target: BranchEdge { args, .. }, .. } => {
-                                *args = new_args;
-                                changed = true;
-                            }
-                            _ => unreachable!("find preserves terminator variant"),
-                        }
+                let canonical_id = self.union_find.borrow().find_const(insn_id);
+
+                let union_find = &self.union_find;
+                self.insns[canonical_id.0].for_each_operand_mut(|operand| {
+                    let canon = union_find.borrow().find_const(*operand);
+                    *operand = rewrite_map.get(&canon).copied().unwrap_or(canon);
+                });
+
+                // GuardTypeNot is excluded: its infer_type is BasicObject
+                // (HIR has no negated-type representation), so registering
+                // would widen downstream uses' inferred types. For the
+                // binary guards only `left` is registered because their
+                // infer_type is type_of(left).
+                match &self.insns[canonical_id.0] {
+                    Insn::GuardType      { val:  src, .. }
+                    | Insn::GuardBitEquals { val:  src, .. }
+                    | Insn::GuardAnyBitSet { val:  src, .. }
+                    | Insn::GuardNoBitsSet { val:  src, .. }
+                    | Insn::GuardGreaterEq { left: src, .. }
+                    | Insn::GuardLess      { left: src, .. } => {
+                        rewrite_map.insert(*src, canonical_id);
                     }
                     _ => {}
                 }
             }
-        }
-        if changed {
-            crate::stats::trace_compile_phase("infer_types", || self.infer_types());
         }
     }
 
@@ -5357,6 +5378,9 @@ impl Function {
             changed = true;
         }
         if changed {
+            crate::stats::trace_compile_phase("canonicalize", ||
+                crate::stats::with_time_stat(Counter::compile_hir_canonicalize_time_ns, || self.canonicalize())
+            );
             crate::stats::trace_compile_phase("infer_types", || self.infer_types());
         }
     }
@@ -5622,7 +5646,7 @@ impl Function {
             (convert_no_profile_sends) => { Counter::compile_hir_strength_reduce_time_ns };
             // End strength reduction bucket
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
-            (forward_guarded_values_to_jumps) => { Counter::compile_hir_forward_guarded_values_to_jumps_time_ns };
+            (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
             (clean_cfg) => { Counter::compile_hir_clean_cfg_time_ns };
             (remove_redundant_patch_points) => { Counter::compile_hir_remove_redundant_patch_points_time_ns };
@@ -5657,7 +5681,8 @@ impl Function {
         run_pass!(optimize_c_calls);
         run_pass!(convert_no_profile_sends);
         run_pass!(optimize_load_store);
-        run_pass!(forward_guarded_values_to_jumps);
+        run_pass!(canonicalize);
+        crate::stats::trace_compile_phase("infer_types", || self.infer_types());
         run_pass!(fold_constants);
         run_pass!(clean_cfg);
         run_pass!(remove_redundant_patch_points);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5646,7 +5646,6 @@ impl Function {
             (convert_no_profile_sends) => { Counter::compile_hir_strength_reduce_time_ns };
             // End strength reduction bucket
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
-            (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
             (clean_cfg) => { Counter::compile_hir_clean_cfg_time_ns };
             (remove_redundant_patch_points) => { Counter::compile_hir_remove_redundant_patch_points_time_ns };
@@ -5681,8 +5680,6 @@ impl Function {
         run_pass!(optimize_c_calls);
         run_pass!(convert_no_profile_sends);
         run_pass!(optimize_load_store);
-        run_pass!(canonicalize);
-        crate::stats::trace_compile_phase("infer_types", || self.infer_types());
         run_pass!(fold_constants);
         run_pass!(clean_cfg);
         run_pass!(remove_redundant_patch_points);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4927,6 +4927,48 @@ impl Function {
             .unwrap_or(insn_id)
     }
 
+    /// Forward each branch-edge arg through the most recent `GuardType` of that
+    /// value within the same block. Lets a follow-up `infer_types` narrow merge-block
+    /// parameter types so `fold_constants` can drop redundant guards at CFG joins.
+    fn forward_guarded_values_to_jumps(&mut self) {
+        let mut changed = false;
+        let mut latest_guard: HashMap<InsnId, InsnId> = HashMap::new();
+        for block in self.rpo() {
+            latest_guard.clear();
+            for i in 0..self.blocks[block.0].insns.len() {
+                let insn_id = self.blocks[block.0].insns[i];
+                match self.find(insn_id) {
+                    Insn::GuardType { val, .. } => {
+                        latest_guard.insert(val, insn_id);
+                    }
+                    Insn::Jump(BranchEdge { ref args, .. })
+                    | Insn::IfTrue { target: BranchEdge { ref args, .. }, .. }
+                    | Insn::IfFalse { target: BranchEdge { ref args, .. }, .. } => {
+                        if !args.iter().any(|arg| latest_guard.contains_key(arg)) {
+                            continue;
+                        }
+                        let new_args: Vec<InsnId> = args.iter()
+                            .map(|arg| latest_guard.get(arg).copied().unwrap_or(*arg))
+                            .collect();
+                        match &mut self.insns[insn_id.0] {
+                            Insn::Jump(BranchEdge { args, .. })
+                            | Insn::IfTrue { target: BranchEdge { args, .. }, .. }
+                            | Insn::IfFalse { target: BranchEdge { args, .. }, .. } => {
+                                *args = new_args;
+                                changed = true;
+                            }
+                            _ => unreachable!("find preserves terminator variant"),
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        if changed {
+            crate::stats::trace_compile_phase("infer_types", || self.infer_types());
+        }
+    }
+
     /// Use type information left by `infer_types` to fold away operations that can be evaluated at compile-time.
     ///
     /// It can fold fixnum math, truthiness tests, and branches with constant conditionals.
@@ -5580,6 +5622,7 @@ impl Function {
             (convert_no_profile_sends) => { Counter::compile_hir_strength_reduce_time_ns };
             // End strength reduction bucket
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
+            (forward_guarded_values_to_jumps) => { Counter::compile_hir_forward_guarded_values_to_jumps_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
             (clean_cfg) => { Counter::compile_hir_clean_cfg_time_ns };
             (remove_redundant_patch_points) => { Counter::compile_hir_remove_redundant_patch_points_time_ns };
@@ -5614,6 +5657,7 @@ impl Function {
         run_pass!(optimize_c_calls);
         run_pass!(convert_no_profile_sends);
         run_pass!(optimize_load_store);
+        run_pass!(forward_guarded_values_to_jumps);
         run_pass!(fold_constants);
         run_pass!(clean_cfg);
         run_pass!(remove_redundant_patch_points);

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -9606,7 +9606,7 @@ mod hir_opt_tests {
           v33:ArrayExact = GuardType v10, ArrayExact
           v34:CUInt64 = LoadField v33, :_rbasic_flags@0x1040
           v35:CUInt64 = GuardNoBitsSet v34, RUBY_FL_FREEZE=CUInt64(2048)
-          v37:CUInt64 = GuardNoBitsSet v35, RUBY_ELTS_SHARED=CUInt64(4096)
+          v37:CUInt64 = GuardNoBitsSet v34, RUBY_ELTS_SHARED=CUInt64(4096)
           v46:CInt64[1] = Const CInt64(1)
           v39:CInt64 = ArrayLength v33
           v40:CInt64[1] = GuardLess v46, v39
@@ -9649,7 +9649,7 @@ mod hir_opt_tests {
           v38:Fixnum = GuardType v15, Fixnum
           v39:CUInt64 = LoadField v37, :_rbasic_flags@0x1040
           v40:CUInt64 = GuardNoBitsSet v39, RUBY_FL_FREEZE=CUInt64(2048)
-          v42:CUInt64 = GuardNoBitsSet v40, RUBY_ELTS_SHARED=CUInt64(4096)
+          v42:CUInt64 = GuardNoBitsSet v39, RUBY_ELTS_SHARED=CUInt64(4096)
           v43:CInt64 = UnboxFixnum v38
           v44:CInt64 = ArrayLength v37
           v45:CInt64 = GuardLess v43, v44
@@ -9874,7 +9874,7 @@ mod hir_opt_tests {
           v23:Array = GuardType v6, Array
           v24:CUInt64 = LoadField v23, :_rbasic_flags@0x1049
           v25:CUInt64 = GuardNoBitsSet v24, RUBY_FL_FREEZE=CUInt64(2048)
-          v27:CUInt64 = GuardNoBitsSet v25, RUBY_ELTS_SHARED=CUInt64(4096)
+          v27:CUInt64 = GuardNoBitsSet v24, RUBY_ELTS_SHARED=CUInt64(4096)
           v28:BasicObject = ArrayPop v23
           CheckInterrupts
           Return v28

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -4651,7 +4651,7 @@ mod hir_opt_tests {
           v49:SetExact = GuardType v17, SetExact
           v50:BasicObject = CCallVariadic v49, :Set#initialize@0x1068
           CheckInterrupts
-          Return v17
+          Return v49
         ");
     }
 
@@ -15257,7 +15257,7 @@ mod hir_opt_tests {
           v78:BasicObject = LoadField v75, :iter_method@0x1058
           v79:BasicObject = LoadField v75, :kwsplat@0x1059
           SetLocal :sep, l0, EP@5, v119
-          Jump bb8(v58, v76, v119, v78, v79)
+          Jump bb8(v118, v76, v119, v78, v79)
         bb8(v83:BasicObject, v84:BasicObject, v85:BasicObject, v86:BasicObject, v87:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1060, CONST)
@@ -15720,6 +15720,69 @@ mod hir_opt_tests {
           CheckInterrupts
           Return v43
         ");
+    }
+
+    #[test]
+    fn test_dedup_guard_type_across_cfg_join() {
+        eval("
+            def test(n, cond)
+              if cond
+                a = n + 1
+              else
+                a = n + 2
+              end
+              n + a
+            end
+            test(1, true); test(1, false)
+        ");
+        let hir = hir_string("test");
+        let guard_count = hir.matches("GuardType").count();
+        assert_eq!(
+            guard_count, 2,
+            "expected 2 GuardType instructions after cross-block dedup, found {guard_count}\n\nHIR:\n{hir}"
+        );
+    }
+
+    #[test]
+    fn test_forward_guard_through_conditional_branch() {
+        eval("
+            def test(n, a, b)
+              if a
+                if b
+                  n + 1
+                else
+                  n + 2
+                end
+              else
+                n + 3
+              end
+            end
+            test(1, true, true); test(1, true, false); test(1, false, false)
+        ");
+        let hir = hir_string("test");
+        let guard_count = hir.matches("GuardType").count();
+        assert!(
+            guard_count <= 3,
+            "expected at most 3 GuardType instructions (one per leaf branch) after forwarding through conditional branches, found {guard_count}\n\nHIR:\n{hir}"
+        );
+    }
+
+    #[test]
+    fn test_no_forward_when_no_guard_in_branches() {
+        let src = "
+            def test(n, cond)
+              a = if cond then 1 else 2 end
+              n + a
+            end
+            test(1, true); test(1, false)
+        ";
+        eval(src);
+        let hir = hir_string("test");
+        let guard_count = hir.matches("GuardType").count();
+        assert_eq!(
+            guard_count, 1,
+            "expected 1 GuardType (merge block only), found {guard_count}\n\nHIR:\n{hir}"
+        );
     }
 
     #[test]

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -1129,7 +1129,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(CustomEq@0x1008)
           PatchPoint MethodRedefined(CustomEq@0x1008, !=@0x1010, cme:0x1018)
           v30:ObjectSubclass[class_exact:CustomEq] = GuardType v10, ObjectSubclass[class_exact:CustomEq]
-          v31:BoolExact = CCallWithFrame v30, :BasicObject#!=@0x1040, v10
+          v31:BoolExact = CCallWithFrame v30, :BasicObject#!=@0x1040, v30
           v21:NilClass = Const Value(nil)
           CheckInterrupts
           Return v21
@@ -1752,7 +1752,7 @@ mod hir_opt_tests {
           v28:Fixnum[30] = Const Value(30)
           v30:Fixnum[40] = Const Value(40)
           v32:Fixnum[50] = Const Value(50)
-          v34:BasicObject = Send v6, :target, v24, v26, v28, v30, v32 # SendFallbackReason: Argument count does not match parameter count
+          v34:BasicObject = Send v44, :target, v24, v26, v28, v30, v32 # SendFallbackReason: Argument count does not match parameter count
           v37:ArrayExact = NewArray v45, v48, v34
           CheckInterrupts
           Return v37
@@ -4046,7 +4046,7 @@ mod hir_opt_tests {
           v33:Fixnum[40] = Const Value(40)
           v35:Fixnum[50] = Const Value(50)
           v37:Fixnum[60] = Const Value(60)
-          v39:BasicObject = Send v6, :target, v27, v29, v31, v33, v35, v37 # SendFallbackReason: Too many arguments for LIR
+          v39:BasicObject = Send v48, :target, v27, v29, v31, v33, v35, v37 # SendFallbackReason: Too many arguments for LIR
           v41:ArrayExact = NewArray v49, v52, v39
           CheckInterrupts
           Return v41
@@ -5683,7 +5683,7 @@ mod hir_opt_tests {
           WriteBarrier v28, v10
           v33:CShape[0x1003] = Const CShape(0x1003)
           StoreField v28, :_shape_id@0x1000, v33
-          v14:HeapBasicObject = RefineType v6, HeapBasicObject
+          v14:HeapBasicObject = RefineType v28, HeapBasicObject
           v17:Fixnum[2] = Const Value(2)
           PatchPoint SingleRactorMode
           StoreField v14, :@bar@0x1004, v17
@@ -6359,7 +6359,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Array@0x1010)
           PatchPoint MethodRedefined(Array@0x1010, to_s@0x1018, cme:0x1020)
           v33:BasicObject = CCallWithFrame v28, :Array#to_s@0x1048
-          v20:String = AnyToString v10, str: v33
+          v20:String = AnyToString v28, str: v33
           v22:StringExact = StringConcat v14, v20
           CheckInterrupts
           Return v22
@@ -9606,7 +9606,7 @@ mod hir_opt_tests {
           v33:ArrayExact = GuardType v10, ArrayExact
           v34:CUInt64 = LoadField v33, :_rbasic_flags@0x1040
           v35:CUInt64 = GuardNoBitsSet v34, RUBY_FL_FREEZE=CUInt64(2048)
-          v37:CUInt64 = GuardNoBitsSet v34, RUBY_ELTS_SHARED=CUInt64(4096)
+          v37:CUInt64 = GuardNoBitsSet v35, RUBY_ELTS_SHARED=CUInt64(4096)
           v46:CInt64[1] = Const CInt64(1)
           v39:CInt64 = ArrayLength v33
           v40:CInt64[1] = GuardLess v46, v39
@@ -9649,7 +9649,7 @@ mod hir_opt_tests {
           v38:Fixnum = GuardType v15, Fixnum
           v39:CUInt64 = LoadField v37, :_rbasic_flags@0x1040
           v40:CUInt64 = GuardNoBitsSet v39, RUBY_FL_FREEZE=CUInt64(2048)
-          v42:CUInt64 = GuardNoBitsSet v39, RUBY_ELTS_SHARED=CUInt64(4096)
+          v42:CUInt64 = GuardNoBitsSet v40, RUBY_ELTS_SHARED=CUInt64(4096)
           v43:CInt64 = UnboxFixnum v38
           v44:CInt64 = ArrayLength v37
           v45:CInt64 = GuardLess v43, v44
@@ -9874,7 +9874,7 @@ mod hir_opt_tests {
           v23:Array = GuardType v6, Array
           v24:CUInt64 = LoadField v23, :_rbasic_flags@0x1049
           v25:CUInt64 = GuardNoBitsSet v24, RUBY_FL_FREEZE=CUInt64(2048)
-          v27:CUInt64 = GuardNoBitsSet v24, RUBY_ELTS_SHARED=CUInt64(4096)
+          v27:CUInt64 = GuardNoBitsSet v25, RUBY_ELTS_SHARED=CUInt64(4096)
           v28:BasicObject = ArrayPop v23
           CheckInterrupts
           Return v28
@@ -10089,7 +10089,7 @@ mod hir_opt_tests {
           v33:CInt64 = AdjustBounds v32, v31
           v34:CInt64[0] = Const CInt64(0)
           v35:CInt64 = GuardGreaterEq v33, v34
-          v36:Fixnum = StringGetbyte v28, v33
+          v36:Fixnum = StringGetbyte v28, v35
           CheckInterrupts
           Return v36
         ");
@@ -14643,7 +14643,7 @@ mod hir_opt_tests {
           SetLocal :other_block, l0, EP@3, v40
           v27:CPtr = GetEP 0
           v28:BasicObject = LoadField v27, :other_block@0x1051
-          v30:BasicObject = InvokeSuper v11, 0x1058, v28 # SendFallbackReason: super: complex argument passing to `super` call
+          v30:BasicObject = InvokeSuper v39, 0x1058, v28 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
           Return v30
         ");
@@ -15360,7 +15360,7 @@ mod hir_opt_tests {
           WriteBarrier v35, v13
           v40:CShape[0x1003] = Const CShape(0x1003)
           StoreField v35, :_shape_id@0x1000, v40
-          v20:HeapBasicObject = RefineType v8, HeapBasicObject
+          v20:HeapBasicObject = RefineType v35, HeapBasicObject
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
           WriteBarrier v20, v13
@@ -15408,7 +15408,7 @@ mod hir_opt_tests {
           WriteBarrier v49, v16
           v54:CShape[0x1003] = Const CShape(0x1003)
           StoreField v49, :_shape_id@0x1000, v54
-          v23:HeapBasicObject = RefineType v10, HeapBasicObject
+          v23:HeapBasicObject = RefineType v49, HeapBasicObject
           v26:Fixnum[5] = Const Value(5)
           PatchPoint NoEPEscape(initialize)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
@@ -15456,7 +15456,7 @@ mod hir_opt_tests {
           WriteBarrier v43, v13
           v48:CShape[0x1003] = Const CShape(0x1003)
           StoreField v43, :_shape_id@0x1000, v48
-          v20:HeapBasicObject = RefineType v8, HeapBasicObject
+          v20:HeapBasicObject = RefineType v43, HeapBasicObject
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
           WriteBarrier v20, v13

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -171,7 +171,7 @@ make_counters! {
         compile_hir_build_time_ns,
         compile_hir_strength_reduce_time_ns,
         compile_hir_optimize_load_store_time_ns,
-        compile_hir_forward_guarded_values_to_jumps_time_ns,
+        compile_hir_canonicalize_time_ns,
         compile_hir_fold_constants_time_ns,
         compile_hir_clean_cfg_time_ns,
         compile_hir_remove_redundant_patch_points_time_ns,

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -171,6 +171,7 @@ make_counters! {
         compile_hir_build_time_ns,
         compile_hir_strength_reduce_time_ns,
         compile_hir_optimize_load_store_time_ns,
+        compile_hir_forward_guarded_values_to_jumps_time_ns,
         compile_hir_fold_constants_time_ns,
         compile_hir_clean_cfg_time_ns,
         compile_hir_remove_redundant_patch_points_time_ns,


### PR DESCRIPTION
## Summary

`GuardType` narrows only its result id, not the original input. 
A later guard on the same input therefore looks unfoldable to `fold_constants` even though the side-exit semantics already prove the narrower type.
Canonicalize rewrites later uses to the most recent `Guard*` result, making the redundant guard foldable.
For example, in this CFG-join shape:

 ```ruby
  def test(n, cond)                                                                                                           
    if cond   
      a = n + 1
    else                                                                                                                      
      a = n + 2
    end                                                                                                                       
    n + a   # `n` gets a redundant Fixnum guard here
  end
 ```

This PR adds a block-local HIR `canonicalize` pass that walks each block in RPO and rewrites every operand through union-find plus a per-block `rewrite_map` keyed on the most recent `Guard*` for that value. 
After canonicalization, `infer_types` can narrow merge-block parameter types and `fold_constants` can then drop the redundant guards in both shapes above.

Inspired by Cranelift's canonicalize https://cfallin.org/blog/2026/04/09/aegraph/

Fixes: https://github.com/Shopify/ruby/issues/978

## Benchmarks

Bench (arm64 linux devcontainer, ruby/ruby-bench, warmup=10 bench=20)

```
  Throughput              master/staged
    lobsters              1.021 (+2.1%, within ±3-6% noise)
    railsbench            1.012 (+1.2%, within ±3-4% noise)

  --zjit-stats            lobsters / railsbench
    code_region_bytes     -1.1%   / -1.0%   (redundant CFG-join guards still removed)
    guard_type_count      -29.4%  / +30.1%  (railsbench likely single-run noise) ⚠
    compile_hir_time      +14.6%  / +13.7%  (canonicalize_time: 67ms / 31ms)
    invalidation_time      ±0%    /  ±0%
```
