### PR TITLE
Add field in RObject for too complex hash case

### DIFF
--- a/include/ruby/internal/core/robject.h
+++ b/include/ruby/internal/core/robject.h
@@ -99,6 +99,11 @@ struct RObject {
             VALUE *fields;
         } heap;
 
+        /* When an object is too complex, it uses a st_table to store instance
+         * variable name to value mappings.
+         */
+        st_table *hash;
+
         /* Embedded instance variables. When an object is small enough, it
          * uses this area to store the instance variables.
          *

--- a/shape.h
+++ b/shape.h
@@ -364,17 +364,17 @@ ROBJECT_FIELDS_HASH(VALUE obj)
     RUBY_ASSERT(rb_shape_obj_too_complex_p(obj));
     RUBY_ASSERT(FL_TEST_RAW(obj, ROBJECT_HEAP));
 
-    return (st_table *)ROBJECT(obj)->as.heap.fields;
+    return ROBJECT(obj)->as.hash;
 }
 
 static inline void
-ROBJECT_SET_FIELDS_HASH(VALUE obj, const st_table *tbl)
+ROBJECT_SET_FIELDS_HASH(VALUE obj, st_table *tbl)
 {
     RBIMPL_ASSERT_TYPE(obj, RUBY_T_OBJECT);
     RUBY_ASSERT(rb_shape_obj_too_complex_p(obj));
     RUBY_ASSERT(FL_TEST_RAW(obj, ROBJECT_HEAP));
 
-    ROBJECT(obj)->as.heap.fields = (VALUE *)tbl;
+    ROBJECT(obj)->as.hash = tbl;
 }
 
 static inline uint32_t


### PR DESCRIPTION
Avoids the need to cast fields into a st_table.