### PR TITLE
Use EC saved in GC for root marking

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -191,7 +191,6 @@ rb_gc_get_ractor_newobj_cache(void)
     return GET_RACTOR()->newobj_cache;
 }
 
-#if USE_MODULAR_GC
 void
 rb_gc_initialize_vm_context(struct rb_gc_vm_context *context)
 {
@@ -199,6 +198,7 @@ rb_gc_initialize_vm_context(struct rb_gc_vm_context *context)
     context->ec = GET_EC();
 }
 
+#if USE_MODULAR_GC
 void
 rb_gc_worker_thread_set_vm_context(struct rb_gc_vm_context *context)
 {
@@ -626,6 +626,7 @@ typedef struct gc_function_map {
     void (*config_set)(void *objspace_ptr, VALUE hash);
     void (*stress_set)(void *objspace_ptr, VALUE flag);
     VALUE (*stress_get)(void *objspace_ptr);
+    struct rb_gc_vm_context *(*get_vm_context)(void *objspace_ptr);
     // Object allocation
     VALUE (*new_obj)(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, bool wb_protected, size_t alloc_size);
     size_t (*obj_slot_size)(VALUE obj);
@@ -804,6 +805,7 @@ ruby_modular_gc_init(void)
     load_modular_gc_func(config_get);
     load_modular_gc_func(stress_set);
     load_modular_gc_func(stress_get);
+    load_modular_gc_func(get_vm_context);
     // Object allocation
     load_modular_gc_func(new_obj);
     load_modular_gc_func(obj_slot_size);
@@ -891,6 +893,7 @@ ruby_modular_gc_init(void)
 # define rb_gc_impl_config_set rb_gc_functions.config_set
 # define rb_gc_impl_stress_set rb_gc_functions.stress_set
 # define rb_gc_impl_stress_get rb_gc_functions.stress_get
+# define rb_gc_impl_get_vm_context rb_gc_functions.get_vm_context
 // Object allocation
 # define rb_gc_impl_new_obj rb_gc_functions.new_obj
 # define rb_gc_impl_obj_slot_size rb_gc_functions.obj_slot_size
@@ -3238,10 +3241,23 @@ gc_declarative_marking_p(const rb_data_type_t *type)
     return (type->flags & RUBY_TYPED_DECL_MARKING) != 0;
 }
 
+rb_execution_context_t *
+rb_gc_get_ec(void)
+{
+    void *objspace = rb_gc_get_objspace();
+
+    if (RB_LIKELY(rb_gc_impl_during_gc_p(objspace))) {
+        return rb_gc_impl_get_vm_context(objspace)->ec;
+    }
+    else {
+        return GET_EC();
+    }
+}
+
 void
 rb_gc_mark_roots(void *objspace, const char **categoryp)
 {
-    rb_execution_context_t *ec = GET_EC();
+    rb_execution_context_t *ec = rb_gc_get_ec();
     rb_vm_t *vm = rb_ec_vm_ptr(ec);
 
 #define MARK_CHECKPOINT(category) do { \

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -683,6 +683,8 @@ typedef struct rb_objspace {
     int sweeping_heap_count;
 
     int fork_vm_lock_lev;
+
+    struct rb_gc_vm_context vm_context;
 } rb_objspace_t;
 
 #ifndef HEAP_PAGE_ALIGN_LOG
@@ -1650,6 +1652,14 @@ rb_gc_impl_garbage_object_p(void *objspace_ptr, VALUE ptr)
     if (dead) return true;
     return is_lazy_sweeping(objspace) && GET_HEAP_PAGE(ptr)->flags.before_sweep &&
         !RVALUE_MARKED(objspace, ptr);
+}
+
+struct rb_gc_vm_context *
+rb_gc_impl_get_vm_context(void *objspace_ptr)
+{
+    rb_objspace_t *objspace = objspace_ptr;
+
+    return &objspace->vm_context;
 }
 
 static void free_stack_chunks(mark_stack_t *);
@@ -6767,6 +6777,8 @@ gc_marking_enter(rb_objspace_t *objspace)
     if (MEASURE_GC) {
         gc_clock_start(&objspace->profile.marking_start_time);
     }
+
+    rb_gc_initialize_vm_context(&objspace->vm_context);
 }
 
 static void

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -11,7 +11,6 @@
  */
 #include "ruby/ruby.h"
 
-#if USE_MODULAR_GC
 #include "ruby/thread_native.h"
 
 struct rb_gc_vm_context {
@@ -19,7 +18,6 @@ struct rb_gc_vm_context {
 
     struct rb_execution_context_struct *ec;
 };
-#endif
 
 typedef int (*vm_table_foreach_callback_func)(VALUE value, void *data);
 typedef int (*vm_table_update_callback_func)(VALUE *value, void *data);

--- a/gc/gc_impl.h
+++ b/gc/gc_impl.h
@@ -54,6 +54,7 @@ GC_IMPL_FN void rb_gc_impl_stress_set(void *objspace_ptr, VALUE flag);
 GC_IMPL_FN VALUE rb_gc_impl_stress_get(void *objspace_ptr);
 GC_IMPL_FN VALUE rb_gc_impl_config_get(void *objspace_ptr);
 GC_IMPL_FN void rb_gc_impl_config_set(void *objspace_ptr, VALUE hash);
+GC_IMPL_FN struct rb_gc_vm_context *rb_gc_impl_get_vm_context(void *objspace_ptr);
 // Object allocation
 GC_IMPL_FN VALUE rb_gc_impl_new_obj(void *objspace_ptr, void *cache_ptr, VALUE klass, VALUE flags, bool wb_protected, size_t alloc_size);
 GC_IMPL_FN size_t rb_gc_impl_obj_slot_size(VALUE obj);

--- a/gc/mmtk/mmtk.c
+++ b/gc/mmtk/mmtk.c
@@ -253,11 +253,7 @@ rb_mmtk_scan_gc_roots(void)
 {
     struct objspace *objspace = rb_gc_get_objspace();
 
-    // FIXME: Make `rb_gc_mark_roots` aware that the current thread may not have EC.
-    // See: https://github.com/ruby/mmtk/issues/22
-    rb_gc_worker_thread_set_vm_context(&objspace->vm_context);
     rb_gc_mark_roots(objspace, NULL);
-    rb_gc_worker_thread_unset_vm_context(&objspace->vm_context);
 }
 
 static int
@@ -782,6 +778,14 @@ void
 rb_gc_impl_config_set(void *objspace_ptr, VALUE hash)
 {
     // TODO
+}
+
+struct rb_gc_vm_context *
+rb_gc_impl_get_vm_context(void *objspace_ptr)
+{
+    struct objspace *objspace = objspace_ptr;
+
+    return &objspace->vm_context;
 }
 
 // Object allocation

--- a/internal/gc.h
+++ b/internal/gc.h
@@ -199,6 +199,7 @@ RUBY_ATTR_MALLOC void *rb_xmalloc_mul_add_mul(size_t, size_t, size_t, size_t);
 RUBY_ATTR_MALLOC void *rb_xcalloc_mul_add_mul(size_t, size_t, size_t, size_t);
 void rb_gc_obj_id_moved(VALUE obj);
 void rb_gc_register_pinning_obj(VALUE obj);
+rb_execution_context_t *rb_gc_get_ec(void);
 
 void *rb_gc_ractor_cache_alloc(rb_ractor_t *ractor);
 void rb_gc_ractor_cache_free(void *cache);

--- a/vm.c
+++ b/vm.c
@@ -3764,8 +3764,8 @@ rb_execution_context_mark(const rb_execution_context_t *ec)
 
     /* mark machine stack */
     if (ec->machine.stack_start && ec->machine.stack_end &&
-        ec != GET_EC() /* marked for current ec at the first stage of marking */
-        ) {
+            /* marked for current ec at the first stage of marking */
+            ec != rb_gc_get_ec()) {
         rb_gc_mark_machine_context(ec);
     }
 


### PR DESCRIPTION
Since EC is thread-local, we previously used rb_gc_worker_thread_set_vm_context in MMTk worker threads to temporarily set the EC. However, this was inelegant and also occasionally caused crashes when marking threads/fibers for the current EC since it will mark the current machine stack twice (once during root marking and once for the fiber). However, since the machine stack is actively being used, the contents may be different when marking the fiber. Since all objects on the machine stack are pinned, this may cause an unpinned object to be pinned, which is not allowed in Immix.

The following crash can be observed:

    Object 0x200fffbc7d8 is trying to pin 0x200ffc80188
      0: mmtk_ruby::handle_gc_thread_panic
      1: mmtk_ruby::set_panic_hook::{{closure}}
      2: <alloc::boxed::Box<dyn for<'a, 'b> core::ops::function::Fn<(&'a std::panic::PanicHookInfo<'b>,), Output = ()> + core::marker::Sync + core::marker::Send> as core::ops::function::Fn<(&std::panic::PanicHookInfo,)>>::call
                at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/alloc/src/boxed.rs:2254:9
      3: std::panicking::panic_with_hook
                at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/std/src/panicking.rs:833:13
      4: std::panicking::panic_handler::{closure#0}
                at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/std/src/panicking.rs:698:13
      5: std::sys::backtrace::__rust_end_short_backtrace::<std::panicking::panic_handler::{closure#0}, !>
                at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/std/src/sys/backtrace.rs:182:18
      6: __rustc::rust_begin_unwind
                at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/std/src/panicking.rs:689:5
      7: core::panicking::panic_fmt
                at /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/core/src/panicking.rs:80:14
      8: <mmtk_ruby::scanning::VMScanning as mmtk::vm::scanning::Scanning<mmtk_ruby::Ruby>>::scan_object_and_trace_edges::{{closure}}
      9: mmtk_ruby::abi::ObjectClosure::c_function_registered
      10: rb_mmtk_call_object_closure
                at gc/mmtk/mmtk.c:976:19
      11: rb_gc_impl_mark_and_pin
                at gc/mmtk/mmtk.c:1008:5
      12: rb_gc_impl_mark_and_pin
                at gc/mmtk/mmtk.c:1004:1
      13: gc_mark_maybe_internal
                at gc.c:2908:5
      14: gc_mark_maybe_internal
                at gc.c:2906:1
      15: gc_mark_maybe_each_location
                at gc.c:2939:5
      16: gc_mark_maybe_each_location
                at gc.c:2937:1
      17: each_location
                at gc.c:2924:9
      18: each_location_ptr
                at gc.c:2933:5
      19: each_location_ptr
                at gc.c:2930:1
      20: rb_gc_mark_machine_context
                at gc.c:3200:5
      21: rb_execution_context_mark
                at vm.c:3768:9
      22: cont_mark
                at cont.c:1155:5
      23: fiber_mark
                at cont.c:1284:5
      24: rb_mmtk_call_gc_mark_children
                at gc/mmtk/mmtk.c:318:5
      25: <mmtk_ruby::scanning::VMScanning as mmtk::vm::scanning::Scanning<mmtk_ruby::Ruby>>::scan_object_and_trace_edges::{{closure}}