### PR TITLE
Refactor shape transition functions

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -384,7 +384,7 @@ rb_gc_rebuild_shape(VALUE obj, size_t heap_id)
 {
     RUBY_ASSERT(RB_TYPE_P(obj, T_OBJECT));
 
-    return (uint32_t)rb_shape_transition_heap(obj, heap_id);
+    return (uint32_t)rb_obj_shape_transition_heap(obj, heap_id);
 }
 
 void rb_vm_update_references(void *ptr);
@@ -2163,7 +2163,7 @@ object_id0(VALUE obj)
         return object_id_get(obj, shape_id);
     }
 
-    shape_id_t object_id_shape_id = rb_shape_transition_object_id(obj);
+    shape_id_t object_id_shape_id = rb_obj_shape_transition_object_id(obj);
 
     id = generate_next_object_id();
     rb_obj_field_set(obj, object_id_shape_id, 0, id);

--- a/object.c
+++ b/object.c
@@ -501,7 +501,7 @@ rb_obj_clone_setup(VALUE obj, VALUE clone, VALUE kwfreeze)
         }
 
         if (RB_OBJ_FROZEN(obj)) {
-            shape_id_t next_shape_id = rb_shape_transition_frozen(clone);
+            shape_id_t next_shape_id = rb_obj_shape_transition_frozen(clone);
             RBASIC_SET_SHAPE_ID(clone, next_shape_id);
         }
         break;

--- a/shape.c
+++ b/shape.c
@@ -697,28 +697,19 @@ get_next_shape_internal(rb_shape_t *shape, ID id, enum shape_type shape_type, bo
     return res;
 }
 
-static inline shape_id_t transition_complex(shape_id_t shape_id);
-
-static shape_id_t
-shape_transition_object_id(shape_id_t original_shape_id)
+shape_id_t
+rb_shape_transition_object_id(shape_id_t original_shape_id)
 {
     RUBY_ASSERT(!rb_shape_has_object_id(original_shape_id));
 
     bool dont_care;
     rb_shape_t *shape = get_next_shape_internal(RSHAPE(original_shape_id), id_object_id, SHAPE_OBJ_ID, &dont_care, true);
     if (!shape) {
-        shape = RSHAPE(ROOT_SHAPE_WITH_OBJ_ID);
-        return transition_complex(shape_id(shape, original_shape_id) | SHAPE_ID_FL_HAS_OBJECT_ID);
+        return ROOT_TOO_COMPLEX_WITH_OBJ_ID | (original_shape_id & SHAPE_ID_FLAGS_MASK);
     }
 
     RUBY_ASSERT(shape);
     return shape_id(shape, original_shape_id) | SHAPE_ID_FL_HAS_OBJECT_ID;
-}
-
-shape_id_t
-rb_shape_transition_object_id(VALUE obj)
-{
-    return shape_transition_object_id(RBASIC_SHAPE_ID(obj));
 }
 
 shape_id_t
@@ -735,54 +726,6 @@ rb_shape_object_id(shape_id_t original_shape_id)
     }
 
     return shape_id(shape, original_shape_id) | SHAPE_ID_FL_HAS_OBJECT_ID;
-}
-
-static inline shape_id_t
-transition_complex(shape_id_t shape_id)
-{
-    shape_id_t next_shape_id = ROOT_TOO_COMPLEX_SHAPE_ID;
-
-    if (rb_shape_has_object_id(shape_id)) {
-        next_shape_id = ROOT_TOO_COMPLEX_WITH_OBJ_ID;
-    }
-
-    uint8_t heap_index = rb_shape_heap_index(shape_id);
-    if (heap_index) {
-        next_shape_id |= rb_shape_root(heap_index - 1);
-    }
-
-    RUBY_ASSERT(rb_shape_has_object_id(shape_id) == rb_shape_has_object_id(next_shape_id));
-
-    return next_shape_id;
-}
-
-shape_id_t
-rb_shape_transition_frozen(VALUE obj)
-{
-    RUBY_ASSERT(RB_OBJ_FROZEN(obj));
-
-    shape_id_t shape_id = rb_obj_shape_id(obj);
-    return shape_id | SHAPE_ID_FL_FROZEN;
-}
-
-shape_id_t
-rb_shape_transition_complex(VALUE obj)
-{
-    return transition_complex(RBASIC_SHAPE_ID(obj));
-}
-
-shape_id_t
-rb_shape_transition_heap(VALUE obj, size_t heap_index)
-{
-     return (RBASIC_SHAPE_ID(obj) & (~SHAPE_ID_HEAP_INDEX_MASK)) | rb_shape_root(heap_index);
-}
-
-void
-rb_set_boxed_class_shape_id(VALUE obj, shape_id_t shape_id)
-{
-    RBASIC_SET_SHAPE_ID(RCLASS_WRITABLE_ENSURE_FIELDS_OBJ(obj), shape_id);
-    // FIXME: How to do multi-shape?
-    RBASIC_SET_SHAPE_ID(obj, shape_id);
 }
 
 /*
@@ -938,7 +881,7 @@ remove_shape_recursive(VALUE obj, rb_shape_t *shape, ID id, rb_shape_t **removed
 }
 
 shape_id_t
-rb_shape_transition_remove_ivar(VALUE obj, ID id, shape_id_t *removed_shape_id)
+rb_obj_shape_transition_remove_ivar(VALUE obj, ID id, shape_id_t *removed_shape_id)
 {
     shape_id_t original_shape_id = RBASIC_SHAPE_ID(obj);
     RUBY_ASSERT(!shape_frozen_p(original_shape_id));
@@ -960,7 +903,7 @@ rb_shape_transition_remove_ivar(VALUE obj, ID id, shape_id_t *removed_shape_id)
     else if (removed_shape) {
         // We found the shape to remove, but couldn't create a new variation.
         // We must transition to TOO_COMPLEX.
-        shape_id_t next_shape_id = transition_complex(original_shape_id);
+        shape_id_t next_shape_id = rb_shape_transition_complex(original_shape_id);
         RUBY_ASSERT(rb_shape_has_object_id(next_shape_id) == rb_shape_has_object_id(original_shape_id));
         return next_shape_id;
     }
@@ -968,7 +911,7 @@ rb_shape_transition_remove_ivar(VALUE obj, ID id, shape_id_t *removed_shape_id)
 }
 
 shape_id_t
-rb_shape_transition_add_ivar(VALUE obj, ID id)
+rb_obj_shape_transition_add_ivar(VALUE obj, ID id)
 {
     shape_id_t original_shape_id = RBASIC_SHAPE_ID(obj);
     RUBY_ASSERT(!shape_frozen_p(original_shape_id));
@@ -979,12 +922,12 @@ rb_shape_transition_add_ivar(VALUE obj, ID id)
         return shape_id(next_shape, original_shape_id);
     }
     else {
-        return transition_complex(original_shape_id);
+        return rb_shape_transition_complex(original_shape_id);
     }
 }
 
 shape_id_t
-rb_shape_transition_add_ivar_no_warnings(VALUE klass, shape_id_t original_shape_id, ID id)
+rb_shape_transition_add_ivar_no_warnings(shape_id_t original_shape_id, ID id, VALUE klass)
 {
     RUBY_ASSERT(!shape_frozen_p(original_shape_id));
 
@@ -993,7 +936,7 @@ rb_shape_transition_add_ivar_no_warnings(VALUE klass, shape_id_t original_shape_
         return shape_id(next_shape, original_shape_id);
     }
     else {
-        return transition_complex(original_shape_id);
+        return rb_shape_transition_complex(original_shape_id);
     }
 }
 
@@ -1175,7 +1118,7 @@ rb_shape_rebuild(shape_id_t initial_shape_id, shape_id_t dest_shape_id)
         return shape_id(next_shape, initial_shape_id);
     }
     else {
-        return transition_complex(initial_shape_id | (dest_shape_id & SHAPE_ID_FL_HAS_OBJECT_ID));
+        return rb_shape_transition_complex(initial_shape_id | (dest_shape_id & SHAPE_ID_FL_HAS_OBJECT_ID));
     }
 }
 

--- a/shape.h
+++ b/shape.h
@@ -169,22 +169,6 @@ RBASIC_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
     RUBY_ASSERT(rb_shape_verify_consistency(obj, shape_id));
 }
 
-void rb_set_boxed_class_shape_id(VALUE obj, shape_id_t shape_id);
-
-static inline void
-RB_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
-{
-    switch (BUILTIN_TYPE(obj)) {
-      case T_CLASS:
-      case T_MODULE:
-        rb_set_boxed_class_shape_id(obj, shape_id);
-        break;
-      default:
-        RBASIC_SET_SHAPE_ID(obj, shape_id);
-        break;
-    }
-}
-
 static inline rb_shape_t *
 RSHAPE(shape_id_t shape_id)
 {
@@ -205,15 +189,9 @@ bool rb_shape_find_ivar(shape_id_t shape_id, ID id, shape_id_t *ivar_shape);
 typedef int rb_shape_foreach_transition_callback(shape_id_t shape_id, void *data);
 bool rb_shape_foreach_field(shape_id_t shape_id, rb_shape_foreach_transition_callback func, void *data);
 
-shape_id_t rb_shape_transition_frozen(VALUE obj);
-shape_id_t rb_shape_transition_complex(VALUE obj);
-shape_id_t rb_shape_transition_remove_ivar(VALUE obj, ID id, shape_id_t *removed_shape_id);
-shape_id_t rb_shape_transition_add_ivar(VALUE obj, ID id);
-shape_id_t rb_shape_transition_add_ivar_no_warnings(VALUE klass, shape_id_t original_shape_id, ID id);
-shape_id_t rb_shape_transition_object_id(VALUE obj);
-shape_id_t rb_shape_transition_heap(VALUE obj, size_t heap_index);
-shape_id_t rb_shape_object_id(shape_id_t original_shape_id);
+shape_id_t rb_shape_transition_add_ivar_no_warnings(shape_id_t shape_id, ID id, VALUE klass);
 
+shape_id_t rb_shape_object_id(shape_id_t original_shape_id);
 shape_id_t rb_shape_rebuild(shape_id_t initial_shape_id, shape_id_t dest_shape_id);
 void rb_shape_copy_fields(VALUE dest, VALUE *dest_buf, shape_id_t dest_shape_id, VALUE *src_buf, shape_id_t src_shape_id);
 void rb_shape_copy_complex_ivars(VALUE dest, VALUE obj, shape_id_t src_shape_id, st_table *fields_table);
@@ -452,6 +430,67 @@ rb_obj_using_gen_fields_table_p(VALUE obj)
 
     return rb_obj_gen_fields_p(obj);
 }
+
+static inline shape_id_t
+rb_shape_transition_frozen(shape_id_t shape_id)
+{
+    return shape_id | SHAPE_ID_FL_FROZEN;
+}
+
+static inline shape_id_t
+rb_shape_transition_complex(shape_id_t shape_id)
+{
+    shape_id_t next_shape_id = ROOT_TOO_COMPLEX_SHAPE_ID;
+
+    if (rb_shape_has_object_id(shape_id)) {
+        next_shape_id = ROOT_TOO_COMPLEX_WITH_OBJ_ID;
+    }
+
+    uint8_t heap_index = rb_shape_heap_index(shape_id);
+    if (heap_index) {
+        next_shape_id |= rb_shape_root(heap_index - 1);
+    }
+
+    RUBY_ASSERT(rb_shape_has_object_id(shape_id) == rb_shape_has_object_id(next_shape_id));
+
+    return next_shape_id;
+}
+
+static inline shape_id_t
+rb_shape_transition_heap(shape_id_t shape_id, size_t heap_index)
+{
+    return (shape_id & (~SHAPE_ID_HEAP_INDEX_MASK)) | rb_shape_root(heap_index);
+}
+
+shape_id_t rb_shape_transition_object_id(shape_id_t shape_id);
+
+static inline shape_id_t
+rb_obj_shape_transition_frozen(VALUE obj)
+{
+    RUBY_ASSERT(RB_OBJ_FROZEN(obj));
+    return rb_shape_transition_frozen(RBASIC_SHAPE_ID(obj));
+}
+
+static inline shape_id_t
+rb_obj_shape_transition_complex(VALUE obj)
+{
+    return rb_shape_transition_complex(RBASIC_SHAPE_ID(obj));
+}
+
+static inline shape_id_t
+rb_obj_shape_transition_heap(VALUE obj, size_t heap_index)
+{
+    return rb_shape_transition_heap(RBASIC_SHAPE_ID(obj), heap_index);
+}
+
+static inline shape_id_t
+rb_obj_shape_transition_object_id(VALUE obj)
+{
+    return rb_shape_transition_object_id(RBASIC_SHAPE_ID(obj));
+}
+
+shape_id_t rb_obj_shape_transition_remove_ivar(VALUE obj, ID id, shape_id_t *removed_shape_id);
+shape_id_t rb_obj_shape_transition_add_ivar(VALUE obj, ID id);
 
 // For ext/objspace
 RUBY_SYMBOL_EXPORT_BEGIN

--- a/variable.c
+++ b/variable.c
@@ -1582,7 +1582,7 @@ static shape_id_t
 obj_transition_too_complex(VALUE obj, st_table *table)
 {
     RUBY_ASSERT(!rb_shape_obj_too_complex_p(obj));
-    shape_id_t shape_id = rb_shape_transition_complex(obj);
+    shape_id_t shape_id = rb_obj_shape_transition_complex(obj);
 
     switch (BUILTIN_TYPE(obj)) {
       case T_OBJECT:
@@ -1686,7 +1686,7 @@ rb_ivar_delete(VALUE obj, ID id, VALUE undef)
 
     shape_id_t old_shape_id = RBASIC_SHAPE_ID(fields_obj);
     shape_id_t removed_shape_id;
-    shape_id_t next_shape_id = rb_shape_transition_remove_ivar(fields_obj, id, &removed_shape_id);
+    shape_id_t next_shape_id = rb_obj_shape_transition_remove_ivar(fields_obj, id, &removed_shape_id);
 
     if (UNLIKELY(rb_shape_too_complex_p(next_shape_id))) {
         if (UNLIKELY(!rb_shape_too_complex_p(old_shape_id))) {
@@ -1894,7 +1894,7 @@ generic_shape_ivar(VALUE obj, ID id, bool *new_ivar_out)
             }
 
             new_ivar = true;
-            target_shape_id = rb_shape_transition_add_ivar(obj, id);
+            target_shape_id = rb_obj_shape_transition_add_ivar(obj, id);
         }
     }
 
@@ -2016,9 +2016,20 @@ void rb_obj_freeze_inline(VALUE x)
             RB_FL_UNSET_RAW(x, FL_USER2 | FL_USER3); // STR_CHILLED
         }
 
-        RB_SET_SHAPE_ID(x, rb_shape_transition_frozen(x));
+        shape_id_t shape_id = rb_obj_shape_transition_frozen(x);
+        switch (BUILTIN_TYPE(x)) {
+          case T_CLASS:
+          case T_MODULE:
+            RBASIC_SET_SHAPE_ID(RCLASS_WRITABLE_ENSURE_FIELDS_OBJ(x), shape_id);
+            // FIXME: How to do multi-shape?
+            RBASIC_SET_SHAPE_ID(x, shape_id);
+            break;
+          default:
+            RBASIC_SET_SHAPE_ID(x, shape_id);
+            break;
+        }
 
-        if (RBASIC_CLASS(x)) {
+        if (RBASIC_CLASS(x) && RCLASS_SINGLETON_P(RBASIC_CLASS(x))) {
             rb_freeze_singleton_class(x);
         }
     }

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -3187,7 +3187,7 @@ fn gen_set_ivar(
         let current_shape_id = comptime_receiver.shape_id_of();
         // We don't need to check about imemo_fields here because we're definitely looking at a T_OBJECT.
         let klass = unsafe { rb_obj_class(comptime_receiver) };
-        let next_shape_id = unsafe { rb_shape_transition_add_ivar_no_warnings(klass, current_shape_id, ivar_name) };
+        let next_shape_id = unsafe { rb_shape_transition_add_ivar_no_warnings(current_shape_id, ivar_name, klass) };
 
         // If the VM ran out of shapes, or this class generated too many leaf,
         // it may be de-optimized into OBJ_TOO_COMPLEX_SHAPE (hash-table).

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1115,9 +1115,9 @@ extern "C" {
     pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_transition_add_ivar_no_warnings(
-        klass: VALUE,
-        original_shape_id: shape_id_t,
+        shape_id: shape_id_t,
         id: ID,
+        klass: VALUE,
     ) -> shape_id_t;
     pub fn rb_ivar_get_at(obj: VALUE, index: attr_index_t, id: ID) -> VALUE;
     pub fn rb_ivar_get_at_no_ractor_check(obj: VALUE, index: attr_index_t) -> VALUE;

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2097,9 +2097,9 @@ unsafe extern "C" {
     pub fn rb_obj_shape_id(obj: VALUE) -> shape_id_t;
     pub fn rb_shape_get_iv_index(shape_id: shape_id_t, id: ID, value: *mut attr_index_t) -> bool;
     pub fn rb_shape_transition_add_ivar_no_warnings(
-        klass: VALUE,
-        original_shape_id: shape_id_t,
+        shape_id: shape_id_t,
         id: ID,
+        klass: VALUE,
     ) -> shape_id_t;
     pub fn rb_const_lookup(klass: VALUE, id: ID) -> *mut rb_const_entry_t;
     pub fn rb_ivar_get_at_no_ractor_check(obj: VALUE, index: attr_index_t) -> VALUE;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4660,7 +4660,7 @@ impl Function {
                             let class = recv_type.class();
                             // We're only looking at T_OBJECT so ignore all of the imemo stuff.
                             assert!(recv_type.flags().is_t_object());
-                            next_shape_id = ShapeId(unsafe { rb_shape_transition_add_ivar_no_warnings(class, current_shape_id.0, id) });
+                            next_shape_id = ShapeId(unsafe { rb_shape_transition_add_ivar_no_warnings(current_shape_id.0, id, class) });
                             // If the VM ran out of shapes, or this class generated too many leaf,
                             // it may be de-optimized into OBJ_TOO_COMPLEX_SHAPE (hash-table).
                             let new_shape_too_complex = unsafe { rb_jit_shape_too_complex_p(next_shape_id.0) };


### PR DESCRIPTION
Expose both `rb_obj_shape_` functions that take a `VALUE` and `rb_shape_` functions that take a `shape_id`.

Make common transition functions such as `complex` and `frozen` inlineable.

Also get rid of RB_SET_SHAPE_ID and rb_set_boxed_class_shape_id.