### PR TITLE
[Bug #22004] Fix short-circuited loop conditions

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -4843,6 +4843,7 @@ compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *ret, const NODE *cond,
         CHECK(ok = compile_logical(iseq, ret, RNODE_AND(cond)->nd_1st, NULL, else_label));
         cond = RNODE_AND(cond)->nd_2nd;
         if (ok == COMPILE_SINGLE) {
+            ADD_INSNL(ret, cond, jump, else_label);
             INIT_ANCHOR(ignore);
             ret = ignore;
             then_label = NEW_LABEL(nd_line(cond));
@@ -4852,6 +4853,7 @@ compile_branch_condition(rb_iseq_t *iseq, LINK_ANCHOR *ret, const NODE *cond,
         CHECK(ok = compile_logical(iseq, ret, RNODE_OR(cond)->nd_1st, then_label, NULL));
         cond = RNODE_OR(cond)->nd_2nd;
         if (ok == COMPILE_SINGLE) {
+            ADD_INSNL(ret, cond, jump, then_label);
             INIT_ANCHOR(ignore);
             ret = ignore;
             else_label = NEW_LABEL(nd_line(cond));

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -906,6 +906,10 @@ class TestISeq < Test::Unit::TestCase
     assert_ruby_status([], "BEGIN {exit}; while true && true; end")
   end
 
+  def test_short_circuited_loop_condition
+    assert_ruby_status([], "while true || true; exit; end; abort")
+  end
+
   def test_unreachable_syntax_error
     mesg = /Invalid break/
     assert_syntax_error("false and break", mesg)


### PR DESCRIPTION
[[Bug #22004]](https://bugs.ruby-lang.org/issues/22004)