### PR TITLE
[PoC] IO::Buffer#get_string: avoid copying for readonly buffers

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3506,6 +3506,16 @@ rb_gc_mark_children(void *objspace, VALUE obj)
                 gc_mark_internal(RSTRING(obj)->as.heap.aux.shared);
             }
         }
+        else if (STR_EXTERNAL_PARENT_P(obj)) {
+            if (RB_TYPE_P(RSTRING(obj)->as.heap.aux.parent, T_STRING) && STR_EMBED_P(RSTRING(obj)->as.heap.aux.parent)) {
+                /* Embedded strings cannot be moved because this string points
+                 * into the embedded slot of the parent string. */
+                gc_mark_and_pin_internal(RSTRING(obj)->as.heap.aux.parent);
+            }
+            else {
+                gc_mark_internal(RSTRING(obj)->as.heap.aux.parent);
+            }
+        }
         break;
 
       case T_DATA: {
@@ -4420,6 +4430,9 @@ rb_gc_update_object_references(void *objspace, VALUE obj)
         {
             if (STR_SHARED_P(obj)) {
                 UPDATE_IF_MOVED(objspace, RSTRING(obj)->as.heap.aux.shared);
+            }
+            else if (STR_EXTERNAL_PARENT_P(obj)) {
+                UPDATE_IF_MOVED(objspace, RSTRING(obj)->as.heap.aux.parent);
             }
 
             /* If, after move the string is not embedded, and can fit in the

--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -238,6 +238,13 @@ struct RString {
                  * control such properties.
                  */
                 VALUE shared;
+
+                /**
+                 * Parent of the string. If the parent is also a string,
+                 * "shared" should be used, not this. This is for non-string
+                 * parents such as IO::Buffer.
+                 */
+                VALUE parent;
             } aux;
         } heap;
 

--- a/include/ruby/internal/encoding/string.h
+++ b/include/ruby/internal/encoding/string.h
@@ -87,6 +87,21 @@ VALUE rb_enc_str_new_cstr(const char *ptr, rb_encoding *enc);
 VALUE rb_enc_str_new_static(const char *ptr, long len, rb_encoding *enc);
 
 /**
+ * Identical to  rb_enc_str_new(),  except  it  does not  copy `ptr`.  Instead,
+ * `parent`  is kept alive  by  the GC for  as long as  the returned string  is
+ * reachable.
+ *
+ * @param[in]  ptr           Pointer into memory managed by `parent`.
+ * @param[in]  len           Length  of  `ptr`,  in bytes,  not  including  the
+ *                           terminating NUL character.
+ * @param[in]  enc           Encoding of `ptr`.
+ * @param[in]  parent        Ruby object that owns the memory at `ptr`.
+ * @return     An instance  of ::rb_cString,  of `enc` encoding,  whose backend
+ *             storage is the memory region of `parent`.
+ */
+VALUE rb_enc_str_new_external(const char *ptr, long len, rb_encoding *enc, VALUE parent);
+
+/**
  * Identical to rb_enc_str_new(),  except it returns a "f"string.   It can also
  * be seen as a routine  identical to rb_interned_str(), except it additionally
  * takes an encoding.

--- a/include/ruby/internal/intern/string.h
+++ b/include/ruby/internal/intern/string.h
@@ -411,6 +411,53 @@ VALUE rb_utf8_str_new_static(const char *ptr, long len);
 /** @} */
 
 /**
+ * @name External parent (zero-copy) string constructors
+ * @{
+ */
+
+/**
+ * Identical to rb_str_new(), except it does not copy `ptr`.
+ *
+ * @param[in]  ptr           Pointer into memory managed by `parent`.
+ * @param[in]  len           Length  of  `ptr`,  in bytes,  not  including  the
+ *                           terminating NUL character.
+ * @param[in]  parent        Ruby object that owns the memory at `ptr`.
+ * @return     An instance of ::rb_cString, of "binary" encoding, whose backend
+ *             storage is the memory region of `parent`.
+ */
+VALUE rb_str_new_external(const char *ptr, long len, VALUE parent);
+
+/**
+ * Identical  to  rb_str_new_external(),   except  it  generates  a  string  of
+ * "US ASCII" encoding  instead of "binary".  It can also be seen as  a routine
+ * identical to rb_usascii_str_new(), except it does not copy `ptr`.
+ *
+ * @param[in]  ptr           Pointer into memory managed by `parent`.
+ * @param[in]  len           Length  of  `ptr`,  in bytes,  not  including  the
+ *                           terminating NUL character.
+ * @param[in]  parent        Ruby object that owns the memory at `ptr`.
+ * @return     An  instance  of ::rb_cString,  of  "US  ASCII" encoding,  whose
+ *             backend storage is the memory region of `parent`.
+ */
+VALUE rb_usascii_str_new_external(const char *ptr, long len, VALUE parent);
+
+/**
+ * Identical to rb_str_new_external(),  except it generates a string of "UTF-8"
+ * encoding instead of "binary".  It can also be seen as a routine identical to
+ * rb_utf8_str_new(), except it does not copy `ptr`.
+ *
+ * @param[in]  ptr           Pointer into memory managed by `parent`.
+ * @param[in]  len           Length  of  `ptr`,  in bytes,  not  including  the
+ *                           terminating NUL character.
+ * @param[in]  parent        Ruby object that owns the memory at `ptr`.
+ * @return     An instance of ::rb_cString,  of "UTF-8" encoding, whose backend
+ *             storage is the memory region of `parent`.
+ */
+VALUE rb_utf8_str_new_external(const char *ptr, long len, VALUE parent);
+
+/** @} */
+
+/**
  * Identical to rb_interned_str(),  except it takes a Ruby's  string instead of
  * C's and preserves its encoding.  It can also be seen  as a routine identical
  * to rb_str_new_shared(), except it returns an infamous "f"string.

--- a/include/ruby/io/buffer.h
+++ b/include/ruby/io/buffer.h
@@ -61,6 +61,12 @@ enum rb_io_buffer_flags {
 
     // The buffer is backed by a file.
     RB_IO_BUFFER_FILE = 256,
+
+    // get_string has issued at least one zero-copy string from this buffer.
+    RB_IO_BUFFER_HAS_ZERO_COPY_STRINGS = 512,
+
+    // The user has called buffer.free but the OS-level release has been deferred.
+    RB_IO_BUFFER_FREED = 1024,
 };
 
 // Represents the endian of the data types.

--- a/internal/string.h
+++ b/internal/string.h
@@ -21,6 +21,7 @@
 #define STR_CHILLED                 (FL_USER2 | FL_USER3)
 #define STR_CHILLED_LITERAL         FL_USER2
 #define STR_CHILLED_SYMBOL_TO_S     FL_USER3
+#define STR_EXTERNAL_PARENT         FL_USER4
 
 enum ruby_rstring_private_flags {
     RSTRING_CHILLED = STR_CHILLED,
@@ -106,6 +107,7 @@ void rb_warn_unchilled_symbol_to_s(VALUE str);
 
 static inline bool STR_EMBED_P(VALUE str);
 static inline bool STR_SHARED_P(VALUE str);
+static inline bool STR_EXTERNAL_PARENT_P(VALUE str);
 static inline VALUE QUOTE(VALUE v);
 static inline VALUE QUOTE_ID(ID v);
 static inline bool is_ascii_string(VALUE str);
@@ -161,6 +163,12 @@ static inline bool
 STR_SHARED_P(VALUE str)
 {
     return FL_ALL_RAW(str, STR_NOEMBED | STR_SHARED);
+}
+
+static inline bool
+STR_EXTERNAL_PARENT_P(VALUE str)
+{
+    return FL_ALL_RAW(str, STR_NOEMBED | STR_EXTERNAL_PARENT);
 }
 
 static inline bool

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -868,6 +868,8 @@ io_buffer_validate_slice(VALUE source, void *base, size_t size)
 static int
 io_buffer_validate(struct rb_io_buffer *buffer)
 {
+    if (buffer->flags & RB_IO_BUFFER_FREED) return 0;
+
     if (buffer->source != Qnil) {
         // Only slices incur this overhead, unfortunately... better safe than sorry!
         return io_buffer_validate_slice(buffer->source, buffer->base, buffer->size);
@@ -974,7 +976,7 @@ rb_io_buffer_to_s(VALUE self)
     rb_str_append(result, rb_class_name(CLASS_OF(self)));
     rb_str_catf(result, " %p+%"PRIdSIZE, buffer->base, buffer->size);
 
-    if (buffer->base == NULL) {
+    if (buffer->base == NULL || (buffer->flags & RB_IO_BUFFER_FREED)) {
         rb_str_cat2(result, " NULL");
     }
 
@@ -1010,11 +1012,15 @@ rb_io_buffer_to_s(VALUE self)
         rb_str_cat2(result, " READONLY");
     }
 
+    if (buffer->flags & RB_IO_BUFFER_FREED) {
+        rb_str_cat2(result, " FREED");
+    }
+
     if (buffer->source != Qnil) {
         rb_str_cat2(result, " SLICE");
     }
 
-    if (!io_buffer_validate(buffer)) {
+    if (!(buffer->flags & RB_IO_BUFFER_FREED) && !io_buffer_validate(buffer)) {
         rb_str_cat2(result, " INVALID");
     }
 
@@ -1178,7 +1184,7 @@ rb_io_buffer_null_p(VALUE self)
     struct rb_io_buffer *buffer = NULL;
     TypedData_Get_Struct(self, struct rb_io_buffer, &rb_io_buffer_type, buffer);
 
-    return RBOOL(buffer->base == NULL);
+    return RBOOL(buffer->base == NULL || (buffer->flags & RB_IO_BUFFER_FREED));
 }
 
 /*
@@ -1520,7 +1526,12 @@ rb_io_buffer_free(VALUE self)
         rb_raise(rb_eIOBufferLockedError, "Buffer is locked!");
     }
 
-    io_buffer_free(buffer);
+    if (buffer->flags & RB_IO_BUFFER_HAS_ZERO_COPY_STRINGS) {
+        buffer->flags |= RB_IO_BUFFER_FREED;
+    }
+    else {
+        io_buffer_free(buffer);
+    }
 
     return self;
 }
@@ -1531,7 +1542,13 @@ VALUE rb_io_buffer_free_locked(VALUE self)
     TypedData_Get_Struct(self, struct rb_io_buffer, &rb_io_buffer_type, buffer);
 
     io_buffer_unlock(buffer);
-    io_buffer_free(buffer);
+
+    if (buffer->flags & RB_IO_BUFFER_HAS_ZERO_COPY_STRINGS) {
+        buffer->flags |= RB_IO_BUFFER_FREED;
+    }
+    else {
+        io_buffer_free(buffer);
+    }
 
     return self;
 }
@@ -1754,6 +1771,10 @@ rb_io_buffer_resize(VALUE self, size_t size)
 
     if (buffer->flags & RB_IO_BUFFER_LOCKED) {
         rb_raise(rb_eIOBufferLockedError, "Cannot resize locked buffer!");
+    }
+
+    if (buffer->flags & RB_IO_BUFFER_FREED) {
+        rb_raise(rb_eIOBufferAccessError, "Cannot resize buffer with outstanding zero-copy strings!");
     }
 
     if (buffer->base == NULL) {

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2717,7 +2717,14 @@ io_buffer_get_string(int argc, VALUE *argv, VALUE self)
 
     io_buffer_validate_range(buffer, offset, length);
 
-    return rb_enc_str_new((const char*)base + offset, length, encoding);
+    if (rb_io_buffer_readonly_p(self) &&
+            (buffer->flags & RB_IO_BUFFER_EXTERNAL) &&
+            RB_TYPE_P(buffer->source, T_STRING)) {
+        return rb_enc_str_new_external((const char*)base + offset, length, encoding, buffer->source);
+    }
+    else {
+        return rb_enc_str_new((const char*)base + offset, length, encoding);
+    }
 }
 
 /*

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2718,7 +2718,7 @@ io_buffer_get_string(int argc, VALUE *argv, VALUE self)
     io_buffer_validate_range(buffer, offset, length);
 
     if (rb_io_buffer_readonly_p(self) &&
-            (buffer->flags & RB_IO_BUFFER_EXTERNAL) &&
+            !(buffer->flags & (RB_IO_BUFFER_INTERNAL | RB_IO_BUFFER_MAPPED)) &&
             RB_TYPE_P(buffer->source, T_STRING)) {
         return rb_enc_str_new_external((const char*)base + offset, length, encoding, buffer->source);
     }

--- a/io_buffer.c
+++ b/io_buffer.c
@@ -2738,14 +2738,21 @@ io_buffer_get_string(int argc, VALUE *argv, VALUE self)
 
     io_buffer_validate_range(buffer, offset, length);
 
-    if (rb_io_buffer_readonly_p(self) &&
-            !(buffer->flags & (RB_IO_BUFFER_INTERNAL | RB_IO_BUFFER_MAPPED)) &&
-            RB_TYPE_P(buffer->source, T_STRING)) {
-        return rb_enc_str_new_external((const char*)base + offset, length, encoding, buffer->source);
+    if (rb_io_buffer_readonly_p(self)) {
+        bool can_zero_copy;
+
+        size_t termlen = (size_t)rb_enc_mbminlen(encoding);
+        size_t src_termlen = RB_TYPE_P(buffer->source, T_STRING) ?
+            (size_t)rb_enc_mbminlen(rb_enc_get(buffer->source)) : 0;
+        can_zero_copy = (offset + length + termlen <= buffer->size + src_termlen);
+
+        if (can_zero_copy) {
+            buffer->flags |= RB_IO_BUFFER_HAS_ZERO_COPY_STRINGS;
+            return rb_enc_str_new_external((const char*)base + offset, length, encoding, self);
+        }
     }
-    else {
-        return rb_enc_str_new((const char*)base + offset, length, encoding);
-    }
+
+    return rb_enc_str_new((const char*)base + offset, length, encoding);
 }
 
 /*

--- a/string.c
+++ b/string.c
@@ -96,9 +96,12 @@ VALUE rb_cSymbol;
  * 3:     STR_CHILLED_SYMBOL_TO_S (will be frozen in a future version)
  *            The string was allocated by the `Symbol#to_s` method.
  *            It emits a deprecation warning when mutated for the first time.
- * 4:     STR_PRECOMPUTED_HASH
+ * 4:     STR_PRECOMPUTED_HASH (only used by an embedded string)
  *            The string is embedded and has its precomputed hashcode stored
  *            after the terminator.
+ * 4:     STR_EXTERNAL_PARENT (only used by a non-embedded string)
+ *            The string is not embedded and its data pointer references memory
+ *            managed by a non-string Ruby object such as IO::Buffer.
  * 5:     STR_SHARED_ROOT
  *            Other strings may point to the contents of this string. When this
  *            flag is set, STR_SHARED must not be set.
@@ -1209,6 +1212,54 @@ VALUE
 rb_enc_str_new_static(const char *ptr, long len, rb_encoding *enc)
 {
     return str_new_static(rb_cString, ptr, len, rb_enc_to_index(enc));
+}
+
+static VALUE
+str_new_external(VALUE klass, const char *ptr, long len, int encindex, VALUE parent)
+{
+    VALUE str;
+
+    if (len < 0) {
+        rb_raise(rb_eArgError, "negative string size (or size too big)");
+    }
+
+    if (!ptr) {
+        str = str_enc_new(klass, ptr, len, rb_enc_from_index(encindex));
+    }
+    else {
+        RUBY_DTRACE_CREATE_HOOK(STRING, len);
+        str = str_alloc_heap(klass);
+        RSTRING(str)->len = len;
+        RSTRING(str)->as.heap.ptr = (char *)ptr;
+        RSTRING(str)->as.heap.aux.parent = parent;
+        RBASIC(str)->flags |= STR_NOFREE | STR_EXTERNAL_PARENT;
+        rb_enc_associate_index(str, encindex);
+    }
+    return str;
+}
+
+VALUE
+rb_str_new_external(const char *ptr, long len, VALUE parent)
+{
+    return str_new_external(rb_cString, ptr, len, 0, parent);
+}
+
+VALUE
+rb_usascii_str_new_external(const char *ptr, long len, VALUE parent)
+{
+    return str_new_external(rb_cString, ptr, len, ENCINDEX_US_ASCII, parent);
+}
+
+VALUE
+rb_utf8_str_new_external(const char *ptr, long len, VALUE parent)
+{
+    return str_new_external(rb_cString, ptr, len, ENCINDEX_UTF_8, parent);
+}
+
+VALUE
+rb_enc_str_new_external(const char *ptr, long len, rb_encoding *enc, VALUE parent)
+{
+    return str_new_external(rb_cString, ptr, len, rb_enc_to_index(enc), parent);
 }
 
 static VALUE str_cat_conv_enc_opts(VALUE newstr, long ofs, const char *ptr, long len,
@@ -2727,7 +2778,7 @@ str_make_independent_expand(VALUE str, long len, long expand, const int termlen)
         SIZED_FREE_N(oldptr, STR_HEAP_SIZE(str));
     }
     STR_SET_NOEMBED(str);
-    FL_UNSET(str, STR_SHARED|STR_NOFREE);
+    FL_UNSET(str, STR_SHARED|STR_NOFREE|STR_EXTERNAL_PARENT);
     TERM_FILL(ptr + len, termlen);
     RSTRING(str)->as.heap.ptr = ptr;
     STR_SET_LEN(str, len);

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -1065,4 +1065,112 @@ class TestIOBuffer < Test::Unit::TestCase
       buffer.hexdump(0, 1, 0)
     end
   end
+
+  def test_get_string_zero_copy_readonly
+    source = "Hello World"
+    buffer = IO::Buffer.for(source)
+    assert_predicate buffer, :readonly?
+
+    str = buffer.get_string
+    assert_equal source, str
+    assert_equal Encoding::BINARY, str.encoding
+
+    str2 = buffer.get_string(6, 5)
+    assert_equal "World", str2
+  end
+
+  def test_get_string_zero_copy_readonly_encoding
+    source = "Hello"
+    buffer = IO::Buffer.for(source)
+
+    str = buffer.get_string(0, source.bytesize, Encoding::UTF_8)
+    assert_equal source, str
+    assert_equal Encoding::UTF_8, str.encoding
+
+    str2 = buffer.get_string(0, source.bytesize, Encoding::US_ASCII)
+    assert_equal source, str2
+    assert_equal Encoding::US_ASCII, str2.encoding
+  end
+
+  def test_get_string_zero_copy_gc_safe
+    str = IO::Buffer.for(+"keep me alive").get_string
+
+    GC.compact if GC.respond_to?(:compact)
+    GC.start(full_mark: true, immediate_sweep: true)
+
+    assert_equal "keep me alive", str
+  end
+
+  def test_get_string_zero_copy_cow
+    source = "Hello"
+    buffer = IO::Buffer.for(source)
+
+    str = buffer.get_string
+    str2 = str.dup
+    str2.upcase!
+
+    assert_equal "Hello", str
+    assert_equal "HELLO", str2
+    assert_equal "Hello", buffer.get_string
+  end
+
+  def test_get_string_zero_copy_direct_mutation
+    source = "Hello"
+    buffer = IO::Buffer.for(source)
+
+    str = buffer.get_string
+    refute_predicate str, :frozen?
+    str.upcase!
+
+    assert_equal "HELLO", str
+    assert_equal "Hello", buffer.get_string
+  end
+
+  def test_get_string_writable_copies
+    buffer = IO::Buffer.new(5)
+    buffer.set_string("hello")
+    refute_predicate buffer, :readonly?
+
+    str = buffer.get_string
+    assert_equal "hello", str
+
+    buffer.set_string("world")
+    assert_equal "hello", str
+  end
+
+  def test_get_string_zero_copy_locked
+    # Use a frozen string so rb_str_tmp_frozen_acquire returns the same object,
+    # guaranteeing buffer->source == source.
+    source = "hello".dup.freeze
+    buffer = IO::Buffer.for(source)
+    assert_predicate buffer, :readonly?
+
+    str = nil
+    buffer.locked { str = buffer.get_string }
+    buffer.free
+
+    # After buffer.free clears buffer->source, str's parent must keep source alive.
+    # Use a WeakMap to detect if source is prematurely collected.
+    tracker = Object.new
+    weak = ObjectSpace::WeakMap.new
+    weak[tracker] = source
+    source = nil
+
+    GC.compact if GC.respond_to?(:compact)
+    GC.start(full_mark: true, immediate_sweep: true)
+
+    assert_equal "hello", weak[tracker], "source String must be kept alive by str"
+    assert_equal "hello", str
+  end
+
+  def test_get_string_zero_copy_compaction
+    omit "compaction is not supported on this platform" unless GC.respond_to?(:compact)
+
+    str = IO::Buffer.for(+"compact me").get_string
+
+    GC.verify_compaction_references(expand_heap: true, toward: :empty)
+    GC.start(full_mark: true, immediate_sweep: true)
+
+    assert_equal "compact me", str
+  end
 end

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -1163,6 +1163,31 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal "hello", str
   end
 
+  def test_get_string_zero_copy_slice
+    # Use a frozen string so rb_str_tmp_frozen_acquire returns the same object,
+    # guaranteeing buffer->source == source.
+    source = "hello world".dup.freeze
+    slice = IO::Buffer.for(source).slice(6, 5)
+    assert_predicate slice, :readonly?
+
+    str = slice.get_string
+    assert_equal "world", str
+    slice.free
+
+    # After slice.free clears slice->source, str's parent must keep source alive.
+    # Use a WeakMap to detect if source is prematurely collected.
+    tracker = Object.new
+    weak = ObjectSpace::WeakMap.new
+    weak[tracker] = source
+    source = nil
+
+    GC.compact if GC.respond_to?(:compact)
+    GC.start(full_mark: true, immediate_sweep: true)
+
+    assert_equal "hello world", weak[tracker], "source String must be kept alive by str via slice"
+    assert_equal "world", str
+  end
+
   def test_get_string_zero_copy_compaction
     omit "compaction is not supported on this platform" unless GC.respond_to?(:compact)
 

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -1198,4 +1198,59 @@ class TestIOBuffer < Test::Unit::TestCase
 
     assert_equal "compact me", str
   end
+
+  def test_get_string_zero_copy_mapped
+    buffer = File.open(__FILE__) {|file| IO::Buffer.map(file, 100, 0, IO::Buffer::READONLY)}
+    str = buffer.get_string(0, 30)
+    assert_equal "# frozen_string_literal: false", str
+
+    # Zero-copy string keeps the IO::Buffer alive via STR_EXTERNAL_PARENT.
+    tracker = Object.new
+    weak = ObjectSpace::WeakMap.new
+    weak[tracker] = buffer
+    buffer = nil
+
+    GC.compact if GC.respond_to?(:compact)
+    GC.start(full_mark: true, immediate_sweep: true)
+
+    assert weak[tracker], "IO::Buffer (MAPPED) must be kept alive by the zero-copy string"
+    assert_equal "# frozen_string_literal: false", str
+  end
+
+  def test_get_string_zero_copy_deferred_free
+    source = "hello world".dup.freeze
+    buffer = IO::Buffer.for(source)
+    str = buffer.get_string
+    assert_equal "hello world", str
+
+    buffer.free
+    assert_predicate buffer, :null?
+
+    assert_equal "hello world", str
+  end
+
+  def test_get_string_zero_copy_deferred_free_gc
+    source = "hello world".dup.freeze
+    buffer = IO::Buffer.for(source)
+    str = buffer.get_string
+    buffer.free
+
+    tracker = Object.new
+    weak = ObjectSpace::WeakMap.new
+    weak[tracker] = buffer
+    buffer = nil
+
+    GC.compact if GC.respond_to?(:compact)
+    GC.start(full_mark: true, immediate_sweep: true)
+
+    assert weak[tracker], "IO::Buffer must be kept alive after free while zero-copy string is alive"
+    assert_equal "hello world", str
+
+    str = nil
+
+    GC.compact if GC.respond_to?(:compact)
+    GC.start(full_mark: true, immediate_sweep: true)
+
+    assert_nil weak[tracker], "IO::Buffer must be collected (deferred free executed) after zero-copy string is released"
+  end
 end

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -2,6 +2,7 @@
 
 require 'tempfile'
 require 'rbconfig/sizeof'
+require 'weakref'
 
 class TestIOBuffer < Test::Unit::TestCase
   experimental = Warning[:experimental]
@@ -1150,17 +1151,14 @@ class TestIOBuffer < Test::Unit::TestCase
     buffer.free
 
     # After buffer.free clears buffer->source, str's parent must keep source alive.
-    # Use a WeakMap to detect if source is prematurely collected.
-    tracker = Object.new
-    weak = ObjectSpace::WeakMap.new
-    weak[tracker] = source
+    source_ref = WeakRef.new(source)
     source = nil
 
     GC.compact if GC.respond_to?(:compact)
     GC.start(full_mark: true, immediate_sweep: true)
 
-    assert_equal "hello", weak[tracker], "source String must be kept alive by str"
-    assert_equal "hello", str
+    assert source_ref.weakref_alive?, "source String must be kept alive by str"
+    assert_equal "hello", str.dup
   end
 
   def test_get_string_zero_copy_slice
@@ -1175,17 +1173,14 @@ class TestIOBuffer < Test::Unit::TestCase
     slice.free
 
     # After slice.free clears slice->source, str's parent must keep source alive.
-    # Use a WeakMap to detect if source is prematurely collected.
-    tracker = Object.new
-    weak = ObjectSpace::WeakMap.new
-    weak[tracker] = source
+    source_ref = WeakRef.new(source)
     source = nil
 
     GC.compact if GC.respond_to?(:compact)
     GC.start(full_mark: true, immediate_sweep: true)
 
-    assert_equal "hello world", weak[tracker], "source String must be kept alive by str via slice"
-    assert_equal "world", str
+    assert source_ref.weakref_alive?, "source String must be kept alive by str via slice"
+    assert_equal "world", str.dup
   end
 
   def test_get_string_zero_copy_compaction
@@ -1199,22 +1194,25 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal "compact me", str
   end
 
+  def freed(id)
+    @freed = true
+  end
+
   def test_get_string_zero_copy_mapped
     buffer = File.open(__FILE__) {|file| IO::Buffer.map(file, 100, 0, IO::Buffer::READONLY)}
     str = buffer.get_string(0, 30)
     assert_equal "# frozen_string_literal: false", str
 
     # Zero-copy string keeps the IO::Buffer alive via STR_EXTERNAL_PARENT.
-    tracker = Object.new
-    weak = ObjectSpace::WeakMap.new
-    weak[tracker] = buffer
+    @freed = false
+    ObjectSpace.define_finalizer(buffer, &method(:freed))
     buffer = nil
 
     GC.compact if GC.respond_to?(:compact)
     GC.start(full_mark: true, immediate_sweep: true)
 
-    assert weak[tracker], "IO::Buffer (MAPPED) must be kept alive by the zero-copy string"
-    assert_equal "# frozen_string_literal: false", str
+    assert !@freed, "IO::Buffer (MAPPED) must be kept alive by the zero-copy string"
+    assert_equal "# frozen_string_literal: false", str.dup
   end
 
   def test_get_string_zero_copy_deferred_free
@@ -1231,26 +1229,25 @@ class TestIOBuffer < Test::Unit::TestCase
 
   def test_get_string_zero_copy_deferred_free_gc
     source = "hello world".dup.freeze
+    @freed = false
     buffer = IO::Buffer.for(source)
+    ObjectSpace.define_finalizer(buffer, &method(:freed))
     str = buffer.get_string
     buffer.free
 
-    tracker = Object.new
-    weak = ObjectSpace::WeakMap.new
-    weak[tracker] = buffer
     buffer = nil
 
     GC.compact if GC.respond_to?(:compact)
     GC.start(full_mark: true, immediate_sweep: true)
 
-    assert weak[tracker], "IO::Buffer must be kept alive after free while zero-copy string is alive"
-    assert_equal "hello world", str
+    assert !@freed, "IO::Buffer must be kept alive after free while zero-copy string is alive"
+    assert_equal "hello world", str.dup
 
     str = nil
 
     GC.compact if GC.respond_to?(:compact)
     GC.start(full_mark: true, immediate_sweep: true)
 
-    assert_nil weak[tracker], "IO::Buffer must be collected (deferred free executed) after zero-copy string is released"
+    assert @freed, "IO::Buffer must be collected (deferred free executed) after zero-copy string is released"
   end
 end


### PR DESCRIPTION
## Summary

`IO::Buffer#get_string` on a readonly buffer previously copied the buffer's contents into a new String.  This patch makes it return a String that directly references the buffer's memory instead.

A new `STR_EXTERNAL_PARENT` flag (sharing `FL_USER4` with the embedded-only `STR_PRECOMPUTED_HASH`) stores a `VALUE parent` in `RString::heap::aux` so the GC keeps the owning buffer alive for as long as the string is reachable.

Writable buffers and locked buffers continue to copy.