### PR TITLE
Fix node used for a call with a block

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -8453,6 +8453,8 @@ compile_iter(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
 {
     const int line = nd_line(node);
     const NODE *line_node = node;
+    const NODE *iter;
+    enum node_type iter_type;
     const rb_iseq_t *prevblock = ISEQ_COMPILE_DATA(iseq)->current_block;
     LABEL *retry_label = NEW_LABEL(line);
     LABEL *retry_end_l = NEW_LABEL(line);
@@ -8471,7 +8473,20 @@ compile_iter(rb_iseq_t *iseq, LINK_ANCHOR *const ret, const NODE *const node, in
         ISEQ_COMPILE_DATA(iseq)->current_block = child_iseq =
             NEW_CHILD_ISEQ(RNODE_ITER(node)->nd_body, make_name_for_block(iseq),
                            ISEQ_TYPE_BLOCK, line);
-        CHECK(COMPILE(ret, "iter caller", RNODE_ITER(node)->nd_iter));
+
+        iter = RNODE_ITER(node)->nd_iter;
+        iter_type = nd_type(iter);
+        switch (iter_type) {
+          case NODE_CALL:
+          case NODE_OPCALL:
+          case NODE_QCALL:
+          case NODE_FCALL:
+          case NODE_VCALL:
+            CHECK(compile_call(iseq, ret, iter, iter_type, line_node, 0, false));
+            break;
+          default:
+            CHECK(COMPILE(ret, "iter caller", iter));
+        }
     }
 
     {

--- a/lib/error_highlight/base.rb
+++ b/lib/error_highlight/base.rb
@@ -235,18 +235,21 @@ module ErrorHighlight
         spot_op_cdecl
 
       when :DEFN
-        raise NotImplementedError if @point_type != :name
         spot_defn
 
       when :DEFS
-        raise NotImplementedError if @point_type != :name
         spot_defs
 
       when :LAMBDA
         spot_lambda
 
       when :ITER
-        spot_iter
+        case @point_type
+        when :name
+          spot_iter_for_name
+        when :args
+          spot_iter_for_args
+        end
 
       when :call_node
         case @point_type
@@ -290,28 +293,13 @@ module ErrorHighlight
         prism_spot_constant_path_operator_write
 
       when :def_node
-        case @point_type
-        when :name
-          prism_spot_def_for_name
-        when :args
-          raise NotImplementedError
-        end
+        prism_spot_def_for_name
 
       when :lambda_node
-        case @point_type
-        when :name
-          prism_spot_lambda_for_name
-        when :args
-          raise NotImplementedError
-        end
+        prism_spot_lambda_for_name
 
       when :block_node
-        case @point_type
-        when :name
-          prism_spot_block_for_name
-        when :args
-          raise NotImplementedError
-        end
+        prism_spot_block_for_name
 
       end
 
@@ -689,11 +677,20 @@ module ErrorHighlight
     end
 
     # Example:
+    #   no_such_method { ... }
+    #   ^^^^^^^^^^^^^^
+    def spot_iter_for_name
+      nd_fcall, = @node.children
+      @node = nd_fcall
+      spot
+    end
+
+    # Example:
     #   lambda { ... }
     #          ^
     #   define_method :foo do
     #                      ^^
-    def spot_iter
+    def spot_iter_for_args
       _nd_fcall, nd_scope = @node.children
       fetch_line(nd_scope.first_lineno)
       if @snippet.match(/\G(?:do\b|\{)/, nd_scope.first_column)

--- a/lib/error_highlight/core_ext.rb
+++ b/lib/error_highlight/core_ext.rb
@@ -7,7 +7,7 @@ module ErrorHighlight
         locs = self.backtrace_locations
         return "" if locs.size < 2
         callee_loc, caller_loc = locs
-        callee_spot = ErrorHighlight.spot(self, backtrace_location: callee_loc, point_type: :name)
+        callee_spot = ErrorHighlight.spot(self, backtrace_location: callee_loc, point_type: :args)
         caller_spot = ErrorHighlight.spot(self, backtrace_location: caller_loc, point_type: :name)
         if caller_spot && callee_spot &&
             caller_loc.path == callee_loc.path &&

--- a/test/ruby/test_ast.rb
+++ b/test/ruby/test_ast.rb
@@ -376,6 +376,46 @@ class TestAst < Test::Unit::TestCase
     assert_equal node.node_id, node_id
   end
 
+  def test_node_id_for_backtrace_location_of_block_fcall
+    omit if ParserSupport.prism_enabled?
+
+    begin
+      foo(1, 2, kw: :arg) { 42 }
+    rescue NameError => exc
+      loc = exc.backtrace_locations.first
+      node_id = RubyVM::AbstractSyntaxTree.node_id_for_backtrace_location(loc)
+      node = RubyVM::AbstractSyntaxTree.of(loc, keep_script_lines: true)
+      assert_equal node.node_id, node_id
+
+      assert_equal :ITER, node.type
+      assert_equal :FCALL, node.children[0].type
+      assert_equal "foo(1, 2, kw: :arg) { 42 }", node.source
+      assert_equal "foo(1, 2, kw: :arg)", node.children[0].source # The FCALL does not cover the block
+    else
+      flunk "expected block call to raise NameError"
+    end
+  end
+
+  def test_node_id_for_backtrace_location_of_block_call
+    omit if ParserSupport.prism_enabled?
+
+    begin
+      self.foo(1, 2, kw: :arg) { 42 }
+    rescue NameError => exc
+      loc = exc.backtrace_locations.first
+      node_id = RubyVM::AbstractSyntaxTree.node_id_for_backtrace_location(loc)
+      node = RubyVM::AbstractSyntaxTree.of(loc, keep_script_lines: true)
+      assert_equal node.node_id, node_id
+
+      assert_equal :ITER, node.type
+      assert_equal :CALL, node.children[0].type
+      assert_equal "self.foo(1, 2, kw: :arg) { 42 }", node.source
+      assert_equal "self.foo(1, 2, kw: :arg)", node.children[0].source # The CALL does not cover the block
+    else
+      flunk "expected block call to raise NameError"
+    end
+  end
+
   def add(x, y)
   end
 

--- a/test/ruby/test_syntax.rb
+++ b/test/ruby/test_syntax.rb
@@ -1123,7 +1123,7 @@ eom
   end
 
   def test_lineno_operation_brace_block
-    expected = __LINE__ + 1
+    expected = __LINE__ + 2
     actual = caller_lineno\
     {}
     assert_equal(expected, actual)


### PR DESCRIPTION
* Use the ITER node_id for a call with a block, otherwise it would cover other arguments but not the block.

https://bugs.ruby-lang.org/issues/22020