### PR TITLE
Miscellaneous shapes cleanup

### DIFF
--- a/ext/objspace/objspace_dump.c
+++ b/ext/objspace/objspace_dump.c
@@ -820,7 +820,7 @@ shape_id_i(shape_id_t shape_id, void *data)
 
     if (RSHAPE_TYPE(shape_id) != SHAPE_ROOT) {
         dump_append(dc, ", \"parent_id\":");
-        dump_append_lu(dc, RSHAPE_PARENT_RAW_ID(shape_id));
+        dump_append_lu(dc, RSHAPE_PARENT_OFFSET(shape_id));
     }
 
     dump_append(dc, ", \"depth\":");

--- a/internal/class.h
+++ b/internal/class.h
@@ -46,6 +46,7 @@ struct rb_classext_struct {
     const rb_box_t *box;
     VALUE super;
     VALUE fields_obj; // Fields are either ivar or other internal properties stored inline
+    VALUE classpath;
     struct rb_id_table *m_tbl;
     struct rb_id_table *const_tbl;
     struct rb_id_table *callable_m_tbl;
@@ -92,7 +93,6 @@ struct rb_classext_struct {
     bool iclass_origin_shared_mtbl : 1;
     bool superclasses_with_self : 1;
     bool expect_no_ivar : 1;
-    VALUE classpath;
 };
 typedef struct rb_classext_struct rb_classext_t;
 

--- a/object.c
+++ b/object.c
@@ -328,8 +328,8 @@ rb_obj_singleton_class(VALUE obj)
 void
 rb_obj_copy_ivar(VALUE dest, VALUE obj)
 {
-    RUBY_ASSERT(!RB_TYPE_P(obj, T_CLASS) && !RB_TYPE_P(obj, T_MODULE));
-    RUBY_ASSERT(BUILTIN_TYPE(dest) == BUILTIN_TYPE(obj));
+    RUBY_ASSERT(RB_TYPE_P(obj, T_OBJECT));
+    RUBY_ASSERT(RB_TYPE_P(dest, T_OBJECT));
 
     unsigned long src_num_ivs = rb_ivar_count(obj);
     if (!src_num_ivs) {

--- a/shape.c
+++ b/shape.c
@@ -374,19 +374,7 @@ static const rb_data_type_t shape_tree_type = {
  */
 
 static inline shape_id_t
-RSHAPE_FLAGS(shape_id_t shape_id)
-{
-    return shape_id & SHAPE_ID_FLAGS_MASK;
-}
-
-static inline shape_id_t
-RSHAPE_OFFSET(shape_id_t shape_id)
-{
-    return shape_id & SHAPE_ID_OFFSET_MASK;
-}
-
-static inline shape_id_t
-raw_shape_id(rb_shape_t *shape)
+shape_offset(rb_shape_t *shape)
 {
     RUBY_ASSERT(shape);
     return (shape_id_t)(shape - rb_shape_tree.shape_list);
@@ -484,7 +472,7 @@ rb_shape_alloc_with_parent_id(ID edge_name, shape_id_t parent_id)
 static rb_shape_t *
 rb_shape_alloc(ID edge_name, rb_shape_t *parent, enum shape_type type)
 {
-    rb_shape_t *shape = rb_shape_alloc_with_parent_id(edge_name, raw_shape_id(parent));
+    rb_shape_t *shape = rb_shape_alloc_with_parent_id(edge_name, shape_offset(parent));
     if (!shape) return NULL;
 
     shape->type = (uint8_t)type;
@@ -717,7 +705,7 @@ rb_shape_transition_object_id(shape_id_t original_shape_id)
     bool dont_care;
     rb_shape_t *shape = get_next_shape_internal(RSHAPE(original_shape_id), id_object_id, SHAPE_OBJ_ID, &dont_care, true);
     if (!shape) {
-        return ROOT_TOO_COMPLEX_WITH_OBJ_ID | (original_shape_id & SHAPE_ID_FLAGS_MASK);
+        return ROOT_TOO_COMPLEX_WITH_OBJ_ID | RSHAPE_FLAGS(original_shape_id);
     }
 
     RUBY_ASSERT(shape);
@@ -760,7 +748,7 @@ rb_shape_get_next_iv_shape(shape_id_t shape_id, ID id)
     if (!next_shape) {
         return INVALID_SHAPE_ID;
     }
-    return raw_shape_id(next_shape);
+    return shape_offset(next_shape);
 }
 
 static bool
@@ -906,7 +894,7 @@ rb_obj_shape_transition_remove_ivar(VALUE obj, ID id, shape_id_t *removed_shape_
     rb_shape_t *new_shape = remove_shape_recursive(obj, RSHAPE(original_shape_id), id, &removed_shape);
 
     if (removed_shape) {
-        *removed_shape_id = raw_shape_id(removed_shape);
+        *removed_shape_id = shape_offset(removed_shape);
     }
 
     if (new_shape) {
@@ -985,13 +973,13 @@ rb_shape_get_iv_index_with_hint(shape_id_t shape_id, ID id, attr_index_t *value,
         if (shape_hint == shape) {
             // We've found a common ancestor so use the index hint
             *value = index_hint;
-            *shape_id_hint = raw_shape_id(shape);
+            *shape_id_hint = shape_offset(shape);
             return true;
         }
         if (shape->edge_name == id) {
             // We found the matching id before a common ancestor
             *value = shape->next_field_index - 1;
-            *shape_id_hint = raw_shape_id(shape);
+            *shape_id_hint = shape_offset(shape);
             return true;
         }
 
@@ -1363,7 +1351,7 @@ shape_id_t_to_rb_cShape(shape_id_t shape_id)
 
     VALUE obj = rb_struct_new(rb_cShape,
             INT2NUM(shape_id),
-            INT2NUM(shape_id & SHAPE_ID_OFFSET_MASK),
+            INT2NUM(RSHAPE_OFFSET(shape_id)),
             INT2NUM(shape->parent_id),
             rb_shape_edge_name(shape),
             INT2NUM(shape->next_field_index),
@@ -1377,7 +1365,7 @@ shape_id_t_to_rb_cShape(shape_id_t shape_id)
 static enum rb_id_table_iterator_result
 rb_edges_to_hash(ID key, VALUE value, void *ref)
 {
-    rb_hash_aset(*(VALUE *)ref, parse_key(key), shape_id_t_to_rb_cShape(raw_shape_id((rb_shape_t *)value)));
+    rb_hash_aset(*(VALUE *)ref, parse_key(key), shape_id_t_to_rb_cShape(shape_offset((rb_shape_t *)value)));
     return ID_TABLE_CONTINUE;
 }
 
@@ -1499,7 +1487,7 @@ shape_to_h(rb_shape_t *shape)
 {
     VALUE rb_shape = rb_hash_new();
 
-    rb_hash_aset(rb_shape, ID2SYM(rb_intern("id")), INT2NUM(raw_shape_id(shape)));
+    rb_hash_aset(rb_shape, ID2SYM(rb_intern("id")), INT2NUM(shape_offset(shape)));
     rb_hash_aset(rb_shape, ID2SYM(rb_intern("edges")), edges(shape->edges));
 
     if (shape == rb_shape_get_root_shape()) {
@@ -1603,17 +1591,17 @@ Init_default_shapes(void)
     rb_shape_t *root = rb_shape_alloc_with_parent_id(0, INVALID_SHAPE_ID);
     root->capacity = 0;
     root->type = SHAPE_ROOT;
-    RUBY_ASSERT(raw_shape_id(root) == ROOT_SHAPE_ID);
-    RUBY_ASSERT(!(raw_shape_id(root) & SHAPE_ID_HAS_IVAR_MASK));
+    RUBY_ASSERT(shape_offset(root) == ROOT_SHAPE_ID);
+    RUBY_ASSERT(!(shape_offset(root) & SHAPE_ID_HAS_IVAR_MASK));
 
     bool dontcare;
     rb_shape_t *root_with_obj_id = get_next_shape_internal(root, id_object_id, SHAPE_OBJ_ID, &dontcare, true);
     RUBY_ASSERT(root_with_obj_id);
-    RUBY_ASSERT(raw_shape_id(root_with_obj_id) == ROOT_SHAPE_WITH_OBJ_ID);
+    RUBY_ASSERT(shape_offset(root_with_obj_id) == ROOT_SHAPE_WITH_OBJ_ID);
     RUBY_ASSERT(root_with_obj_id->type == SHAPE_OBJ_ID);
     RUBY_ASSERT(root_with_obj_id->edge_name == id_object_id);
     RUBY_ASSERT(root_with_obj_id->next_field_index == 1);
-    RUBY_ASSERT(!(raw_shape_id(root_with_obj_id) & SHAPE_ID_HAS_IVAR_MASK));
+    RUBY_ASSERT(!(shape_offset(root_with_obj_id) & SHAPE_ID_HAS_IVAR_MASK));
     (void)root_with_obj_id;
 }
 

--- a/shape.c
+++ b/shape.c
@@ -374,6 +374,18 @@ static const rb_data_type_t shape_tree_type = {
  */
 
 static inline shape_id_t
+RSHAPE_FLAGS(shape_id_t shape_id)
+{
+    return shape_id & SHAPE_ID_FLAGS_MASK;
+}
+
+static inline shape_id_t
+RSHAPE_OFFSET(shape_id_t shape_id)
+{
+    return shape_id & SHAPE_ID_OFFSET_MASK;
+}
+
+static inline shape_id_t
 raw_shape_id(rb_shape_t *shape)
 {
     RUBY_ASSERT(shape);
@@ -385,7 +397,7 @@ shape_id(rb_shape_t *shape, shape_id_t previous_shape_id)
 {
     RUBY_ASSERT(shape);
     shape_id_t raw_id = (shape_id_t)(shape - rb_shape_tree.shape_list);
-    return raw_id | (previous_shape_id & SHAPE_ID_FLAGS_MASK);
+    return raw_id | RSHAPE_FLAGS(previous_shape_id);
 }
 
 #if RUBY_DEBUG
@@ -1073,9 +1085,8 @@ rb_shape_id_offset(void)
     return sizeof(uintptr_t) - SHAPE_ID_NUM_BITS / sizeof(uintptr_t);
 }
 
-// Rebuild a similar shape with the same ivars but starting from
-// a different SHAPE_T_OBJECT, and don't cary over non-canonical transitions
-// such as SHAPE_OBJ_ID.
+// Rebuild a similar shape with the same ivars but without "non-canonical"
+// edges such as SHAPE_OBJ_ID.
 static rb_shape_t *
 shape_rebuild(rb_shape_t *initial_shape, rb_shape_t *dest_shape)
 {
@@ -1113,13 +1124,22 @@ rb_shape_rebuild(shape_id_t initial_shape_id, shape_id_t dest_shape_id)
     RUBY_ASSERT(!rb_shape_too_complex_p(initial_shape_id));
     RUBY_ASSERT(!rb_shape_too_complex_p(dest_shape_id));
 
-    rb_shape_t *next_shape = shape_rebuild(RSHAPE(initial_shape_id), RSHAPE(dest_shape_id));
-    if (next_shape) {
-        return shape_id(next_shape, initial_shape_id);
+    shape_id_t next_shape_id;
+    // The shape has a SHAPE_OBJ_ID edge, it needs to be rebuilt.
+    if (dest_shape_id & SHAPE_ID_FL_HAS_OBJECT_ID) {
+        rb_shape_t *next_shape = shape_rebuild(RSHAPE(initial_shape_id), RSHAPE(dest_shape_id));
+        if (next_shape) {
+            next_shape_id = shape_id(next_shape, initial_shape_id & ~SHAPE_ID_FL_NON_CANONICAL_MASK);
+        }
+        else {
+            return rb_shape_transition_complex(initial_shape_id | (dest_shape_id & ~SHAPE_ID_FL_NON_CANONICAL_MASK));
+        }
     }
     else {
-        return rb_shape_transition_complex(initial_shape_id | (dest_shape_id & SHAPE_ID_FL_HAS_OBJECT_ID));
+        // Happy path, we have nothing to do other than change the flags.
+        next_shape_id = RSHAPE_OFFSET(dest_shape_id) | RSHAPE_FLAGS(initial_shape_id);
     }
+    return next_shape_id;
 }
 
 void

--- a/shape.h
+++ b/shape.h
@@ -23,9 +23,10 @@ STATIC_ASSERT(shape_id_num_bits, SHAPE_ID_NUM_BITS == sizeof(shape_id_t) * CHAR_
 // shape_id_t bits:
 //      0-18 SHAPE_ID_OFFSET_MASK
 //              index in rb_shape_tree.shape_list. Allow to access `rb_shape_t *`.
+//              This is the part that describe how fields are laid out in memory.
 //      19-22 SHAPE_ID_HEAP_INDEX_MASK
 //              index in rb_shape_tree.capacities. Allow to access slot size.
-//              Always 0 except for T_OBJECT.
+//              Currently always 0 except for T_OBJECT.
 //      23 SHAPE_ID_FL_FROZEN
 //              Whether the object is frozen or not.
 //      24 SHAPE_ID_FL_HAS_OBJECT_ID
@@ -169,13 +170,23 @@ RBASIC_SET_SHAPE_ID(VALUE obj, shape_id_t shape_id)
     RUBY_ASSERT(rb_shape_verify_consistency(obj, shape_id));
 }
 
+static inline shape_id_t
+RSHAPE_FLAGS(shape_id_t shape_id)
+{
+    return shape_id & SHAPE_ID_FLAGS_MASK;
+}
+
+static inline shape_id_t
+RSHAPE_OFFSET(shape_id_t shape_id)
+{
+    return shape_id & SHAPE_ID_OFFSET_MASK;
+}
+
 static inline rb_shape_t *
 RSHAPE(shape_id_t shape_id)
 {
-    uint32_t offset = (shape_id & SHAPE_ID_OFFSET_MASK);
-    RUBY_ASSERT(offset != INVALID_SHAPE_ID);
-
-    return &rb_shape_tree.shape_list[offset];
+    RUBY_ASSERT(shape_id != INVALID_SHAPE_ID);
+    return &rb_shape_tree.shape_list[RSHAPE_OFFSET(shape_id)];
 }
 
 int32_t rb_shape_id_offset(void);
@@ -239,7 +250,7 @@ rb_shape_root(size_t heap_id)
 }
 
 static inline shape_id_t
-RSHAPE_PARENT_RAW_ID(shape_id_t shape_id)
+RSHAPE_PARENT_OFFSET(shape_id_t shape_id)
 {
     return RSHAPE(shape_id)->parent_id;
 }
@@ -247,8 +258,8 @@ RSHAPE_PARENT_RAW_ID(shape_id_t shape_id)
 static inline bool
 RSHAPE_DIRECT_CHILD_P(shape_id_t parent_id, shape_id_t child_id)
 {
-    return (parent_id & SHAPE_ID_FLAGS_MASK) == (child_id & SHAPE_ID_FLAGS_MASK) &&
-        RSHAPE(child_id)->parent_id == (parent_id & SHAPE_ID_OFFSET_MASK);
+    return (RSHAPE_FLAGS(parent_id) == RSHAPE_FLAGS(child_id) &&
+        RSHAPE_PARENT_OFFSET(child_id) == RSHAPE_OFFSET(parent_id));
 }
 
 static inline enum shape_type

--- a/shape.h
+++ b/shape.h
@@ -57,8 +57,8 @@ enum shape_id_mask {
 
 // The interpreter doesn't care about frozen status or slot size when reading ivars.
 // So we normalize shape_id by clearing these bits to improve cache hits.
-// JITs however might care about it.
-#define SHAPE_ID_READ_ONLY_MASK (~(SHAPE_ID_FL_FROZEN | SHAPE_ID_HEAP_INDEX_MASK))
+// JITs however might care about some of it.
+#define SHAPE_ID_READ_ONLY_MASK (~(SHAPE_ID_FL_FROZEN | SHAPE_ID_HEAP_INDEX_MASK | SHAPE_ID_FL_HAS_OBJECT_ID))
 
 typedef uint32_t redblack_id_t;
 


### PR DESCRIPTION
`rb_shape_rebuild` now skip walking up the shape tree unless the object has an id.

More consistent naming around "shape offset", some older code was calling it "raw_shape_id".

Also ignore obj_id flag when reading ivars as It doesn't impact ivar lookup, because OBJ_ID fields change
the offset.