### PR TITLE
Fix `--disable-multiarch` option being ignored in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3580,7 +3580,8 @@ AS_CASE(["$target_os"],
 
 AC_ARG_ENABLE(multiarch,
 	      AS_HELP_STRING([--enable-multiarch], [enable multiarch compatible directories]),
-	      [multiarch=], [unset multiarch])
+	      [AS_CASE([$enableval], [no], [unset multiarch], [multiarch=])],
+	      [unset multiarch])
 AS_IF([test ${multiarch+set}], [
    AC_DEFINE(ENABLE_MULTIARCH)
 ])


### PR DESCRIPTION
## Summary

`./configure --disable-multiarch` was silently ignored, and multiarch remained enabled.

## Root Cause

`AC_ARG_ENABLE` in `configure.ac` runs its action-if-given argument for **both**
`--enable-multiarch` and `--disable-multiarch`. The original code unconditionally
set `multiarch` to an empty string regardless of `$enableval`:

```m4
AC_ARG_ENABLE(multiarch,
    AS_HELP_STRING([--enable-multiarch], [enable multiarch compatible directories]),
    [multiarch=], [unset multiarch])
```

The subsequent check uses the shell parameter expansion `${multiarch+set}`, which
evaluates to `set` whenever the variable is defined — even when it holds an empty
string. As a result, passing `--disable-multiarch` set `multiarch=""`, which was
then treated as enabled.

## Fix

Inspect `$enableval` inside the action-if-given block and `unset` the variable when
the user passes `--disable-multiarch`:

```m4
AC_ARG_ENABLE(multiarch,
    AS_HELP_STRING([--enable-multiarch], [enable multiarch compatible directories]),
    [AS_CASE([$enableval], [no], [unset multiarch], [multiarch=])],
    [unset multiarch])
```

## Behavior before fix

| Invocation                    | `multiarch` variable | ENABLE_MULTIARCH defined? |
|-------------------------------|----------------------|---------------------------|
| (no option)                   | unset                | no                        |
| `--enable-multiarch`          | `""` (set)           | yes                       |
| `--disable-multiarch`         | `""` (set) ← bug     | yes ← bug                 |

## Behavior after fix

| Invocation                    | `multiarch` variable | ENABLE_MULTIARCH defined? |
|-------------------------------|----------------------|---------------------------|
| (no option)                   | unset                | no                        |
| `--enable-multiarch`          | `""` (set)           | yes                       |
| `--disable-multiarch`         | unset                | no                        |

## Installation path example

Assuming `--prefix=/usr/local` and `config_target=x86_64-linux-gnu`.

`tool/rbinstall.rb` checks `RbConfig::CONFIG["libdirname"]`. When multiarch is
enabled, `libdirname` is set to `"archlibdir"` (configure.ac:4544), which causes
rbinstall.rb to derive an arch-specific `archbindir` by inserting the target triple
before the last component of `bindir` (rbinstall.rb:381). Executables are installed
into `archbindir`, and symlinks are created in `bindir` pointing to them
(rbinstall.rb:977-983).

| Invocation                         | Executable location                        | `bindir` entry               |
|------------------------------------|--------------------------------------------|------------------------------|
| `--disable-multiarch` (before fix) | `/usr/local/x86_64-linux-gnu/bin/ruby`     | symlink → `../x86_64-linux-gnu/bin/ruby` |
| `--disable-multiarch` (after fix)  | `/usr/local/bin/ruby`                      | (direct install, no symlink) |
| `--enable-multiarch`               | `/usr/local/x86_64-linux-gnu/bin/ruby`     | symlink → `../x86_64-linux-gnu/bin/ruby` |
