### PR TITLE
[DOC] Add Japanese and data to IO.read

### DIFF
--- a/io.c
+++ b/io.c
@@ -12248,11 +12248,11 @@ seek_before_access(VALUE argp)
  *  With only argument +path+ given, reads in text mode and returns the entire content
  *  of the file at the given path:
  *
- *    File.new('t.txt').read
+ *    File.read('t.txt')
  *    # => "First line\nSecond line\n\nFourth line\nFifth line\n"
- *    File.new('t.ja').read
+ *    File.read('t.ja')
  *    # => "こんにちは"
- *    File.new('t.dat').read
+ *    File.read('t.dat')
  *    # => "\xFE\xFF\x99\x90\x99\x91\x99\x92\x99\x93\x99\x94"
  *
  *  On Windows, text mode can terminate reading and leave bytes in the file
@@ -12261,35 +12261,35 @@ seek_before_access(VALUE argp)
  *
  *  With argument +length+, returns +length+ bytes if available:
  *
- *    File.new('t.txt').read(7)
+ *    File.read('t.txt', 7)
  *    # => "First l"
- *    File.new('t.ja').read(7)
+ *    File.read('t.ja', 7)
  *    # => "\xE3\x81\x93\xE3\x82\x93\xE3"
- *    File.new('t.dat').read(7)
+ *    File.read('t.dat', 7)
  *    # => "\xFE\xFF\x99\x90\x99\x91\x99"
  *
  *  Returns all bytes if +length+ is larger than the files size:
  *
- *    File.new('t.txt').read(700)
+ *    File.read('t.txt', 700)
  *    # => "First line\r\nSecond line\r\n\r\nFourth line\r\nFifth line\r\n"
- *    File.new('t.ja').read(700)
+ *    File.read('t.ja', 700)
  *    # => "\xE3\x81\x93\xE3\x82\x93\xE3\x81\xAB\xE3\x81\xA1\xE3\x81\xAF"
- *    File.new('t.dat').read(700)
+ *    File.read('t.dat', 700)
  *    # => "\xFE\xFF\x99\x90\x99\x91\x99\x92\x99\x93\x99\x94"
  *
  *  With arguments +length+ and +offset+, returns +length+ bytes
  *  if available, beginning at the given +offset+:
  *
- *    IO.read('t.txt', 10, 2)
+ *    File.read('t.txt', 10, 2)
  *    # => "rst line\r\n"
- *    IO.read('t.ja', 10, 2)
+ *    File.read('t.ja', 10, 2)
  *    # => "\x93\xE3\x82\x93\xE3\x81\xAB\xE3\x81\xA1"
- *    IO.read('t.dat', 10, 2)
+ *    File.read('t.dat', 10, 2)
  *    # => "\x99\x90\x99\x91\x99\x92\x99\x93\x99\x94"
  *
  *  Returns +nil+ if +offset+ is past the end of the stream:
  *
- *    IO.read('t.txt', 10, 200)
+ *    File.read('t.txt', 10, 200)
  *    # => nil
  *
  *  Optional keyword arguments +opts+ specify:

--- a/io.c
+++ b/io.c
@@ -12248,8 +12248,12 @@ seek_before_access(VALUE argp)
  *  With only argument +path+ given, reads in text mode and returns the entire content
  *  of the file at the given path:
  *
- *    IO.read('t.txt')
- *    # => "First line\nSecond line\n\nThird line\nFourth line\n"
+ *    File.new('t.txt').read
+ *    # => "First line\nSecond line\n\nFourth line\nFifth line\n"
+ *    File.new('t.ja').read
+ *    # => "こんにちは"
+ *    File.new('t.dat').read
+ *    # => "\xFE\xFF\x99\x90\x99\x91\x99\x92\x99\x93\x99\x94"
  *
  *  On Windows, text mode can terminate reading and leave bytes in the file
  *  unread when encountering certain special bytes. Consider using
@@ -12257,15 +12261,36 @@ seek_before_access(VALUE argp)
  *
  *  With argument +length+, returns +length+ bytes if available:
  *
- *    IO.read('t.txt', 7) # => "First l"
- *    IO.read('t.txt', 700)
+ *    File.new('t.txt').read(7)
+ *    # => "First l"
+ *    File.new('t.ja').read(7)
+ *    # => "\xE3\x81\x93\xE3\x82\x93\xE3"
+ *    File.new('t.dat').read(7)
+ *    # => "\xFE\xFF\x99\x90\x99\x91\x99"
+ *
+ *  Returns all bytes if +length+ is larger than the files size:
+ *
+ *    File.new('t.txt').read(700)
  *    # => "First line\r\nSecond line\r\n\r\nFourth line\r\nFifth line\r\n"
+ *    File.new('t.ja').read(700)
+ *    # => "\xE3\x81\x93\xE3\x82\x93\xE3\x81\xAB\xE3\x81\xA1\xE3\x81\xAF"
+ *    File.new('t.dat').read(700)
+ *    # => "\xFE\xFF\x99\x90\x99\x91\x99\x92\x99\x93\x99\x94"
  *
  *  With arguments +length+ and +offset+, returns +length+ bytes
  *  if available, beginning at the given +offset+:
  *
- *    IO.read('t.txt', 10, 2)   # => "rst line\nS"
- *    IO.read('t.txt', 10, 200) # => nil
+ *    IO.read('t.txt', 10, 2)
+ *    # => "rst line\r\n"
+ *    IO.read('t.ja', 10, 2)
+ *    # => "\x93\xE3\x82\x93\xE3\x81\xAB\xE3\x81\xA1"
+ *    IO.read('t.dat', 10, 2)
+ *    # => "\x99\x90\x99\x91\x99\x92\x99\x93\x99\x94"
+ *
+ *  Returns +nil+ if +offset+ is past the end of the stream:
+ *
+ *    IO.read('t.txt', 10, 200)
+ *    # => nil
  *
  *  Optional keyword arguments +opts+ specify:
  *


### PR DESCRIPTION
This method is byte-oriented, and so should have examples with multi-byte characters and binary data.

Also, I think examples of an IO singleton method should use File, not IO.