### PR TITLE
[4.0] RubyVM::ISeq.compile_file fixes

### DIFF
--- a/iseq.c
+++ b/iseq.c
@@ -1894,16 +1894,30 @@ iseqw_s_compile_file_prism(int argc, VALUE *argv, VALUE self)
     rb_execution_context_t *ec = GET_EC();
     VALUE v = rb_vm_push_frame_fname(ec, file);
 
+    make_compile_option(&option, opt);
+
     pm_parse_result_t result = { 0 };
     result.options.line = 1;
     result.node.coverage_enabled = 1;
+
+    switch (option.frozen_string_literal) {
+      case ISEQ_FROZEN_STRING_LITERAL_UNSET:
+        break;
+      case ISEQ_FROZEN_STRING_LITERAL_DISABLED:
+        pm_options_frozen_string_literal_set(&result.options, false);
+        break;
+      case ISEQ_FROZEN_STRING_LITERAL_ENABLED:
+        pm_options_frozen_string_literal_set(&result.options, true);
+        break;
+      default:
+        rb_bug("iseqw_s_compile_file_prism: invalid frozen_string_literal=%d", option.frozen_string_literal);
+        break;
+    }
 
     VALUE script_lines;
     VALUE error = pm_load_parse_file(&result, file, ruby_vm_keep_script_lines ? &script_lines : NULL);
 
     if (error == Qnil) {
-        make_compile_option(&option, opt);
-
         int error_state;
         rb_iseq_t *iseq = pm_iseq_new_with_opt(&result.node, rb_fstring_lit("<main>"),
                                                file,

--- a/iseq.c
+++ b/iseq.c
@@ -1779,6 +1779,8 @@ iseqw_s_compile_prism(int argc, VALUE *argv, VALUE self)
     return iseqw_s_compile_parser(argc, argv, self, true);
 }
 
+static VALUE iseqw_s_compile_file_prism(int argc, VALUE *argv, VALUE self);
+
 /*
  *  call-seq:
  *      InstructionSequence.compile_file(file[, options]) -> iseq
@@ -1802,6 +1804,10 @@ iseqw_s_compile_prism(int argc, VALUE *argv, VALUE self)
 static VALUE
 iseqw_s_compile_file(int argc, VALUE *argv, VALUE self)
 {
+    if (rb_ruby_prism_p()) {
+        return iseqw_s_compile_file_prism(argc, argv, self);
+    }
+
     VALUE file, opt = Qnil;
     VALUE parser, f, exc = Qnil, ret;
     rb_ast_t *ast;

--- a/test/ruby/test_iseq.rb
+++ b/test/ruby/test_iseq.rb
@@ -355,6 +355,20 @@ class TestISeq < Test::Unit::TestCase
     assert_not_predicate(s4, :frozen?)
   end
 
+  def test_frozen_string_literal_compile_option_file
+    Tempfile.create(%w[fsl .rb]) do |f|
+      f.write("['foo', 'foo', \"\#{$f}foo\", \"\#{'foo'}\"]\n")
+      f.flush
+      $f = 'f'
+      s1, s2, s3, s4 = RubyVM::InstructionSequence
+        .compile_file(f.path, frozen_string_literal: true).eval
+      assert_predicate(s1, :frozen?)
+      assert_predicate(s2, :frozen?)
+      assert_not_predicate(s3, :frozen?)
+      assert_not_predicate(s4, :frozen?)
+    end
+  end
+
   # Safe call chain is not optimized when Coverage is running.
   # So we can test it only when Coverage is not running.
   def test_safe_call_chain


### PR DESCRIPTION
- Fix passing frozen_string_literal option to #compile_file backed by Prism: https://github.com/ruby/ruby/pull/16779
- ISeq.compile_file was not switching on parser: https://github.com/ruby/ruby/pull/16463

