### PR TITLE
Add write barriers to memory_view registry

### DIFF
--- a/memory_view.c
+++ b/memory_view.c
@@ -65,7 +65,7 @@ const rb_data_type_t rb_memory_view_exported_object_registry_data_type = {
         exported_object_registry_free,
         0,
     },
-    0, 0, RUBY_TYPED_FREE_IMMEDIATELY
+    0, 0, RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED
 };
 
 static int
@@ -101,6 +101,7 @@ register_exported_object(VALUE obj)
 {
     RB_VM_LOCKING() {
         st_update(exported_object_table, (st_data_t)obj, exported_object_add_ref, 0);
+        RB_OBJ_WRITTEN(rb_memory_view_exported_object_registry, Qundef, obj);
     }
 }
 


### PR DESCRIPTION
This is one of the few objects at boot which is not WB_PROTECTED. I think there's only ever one, so it likely doesn't matter, but it should be straightforward enough to add.

Verified by wbcheck