### PR TITLE
ZJIT: Skip redundant patch point rewrites on no-EP-escape invalidation

### DIFF
--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -216,7 +216,7 @@ pub extern "C" fn rb_zjit_invalidate_no_ep_escape(iseq: IseqPtr) {
         invariants.ep_escape_iseqs.insert(iseq);
 
         // If the ISEQ has been compiled assuming it doesn't escape EP, invalidate the JIT code.
-        if let Some(patch_points) = invariants.no_ep_escape_iseq_patch_points.get(&iseq) {
+        if let Some(patch_points) = invariants.no_ep_escape_iseq_patch_points.remove(&iseq) {
             debug!("EP is escaped: {}", iseq_name(iseq));
 
             // Invalidate the patch points for this ISEQ


### PR DESCRIPTION
`rb_zjit_invalidate_no_ep_escape` is called by the interpreter whenever there's an env heap-promotion event for an ISEQ (e.g., binding captures, proc/lambda closures, and `eval` block captures). Since the interpreter can't see ZJIT's state, it invokes the callback unconditionally.

When this callback fires, ZJIT walks all of the ISEQ's patch points and overwrites each with a side-exit jump, marks the compiled version as `Invalidated`, and resets jit_func so the interpreter takes over for that ISEQ permanently. Notably, `rb_zjit_invalidate_no_ep_escape` is still going to trigger even though the ISEQ is already running in the interpreter so there should be nothing to invalidate.

If the ISEQ has patch points, they're all walked and rewritten on the first `rb_zjit_invalidate_no_ep_escape` call, but the interpreter, unaware, fires `rb_zjit_invalidate_no_ep_escape` for each escape event during that ISEQ's execution. The patch point rewriting is an idempotent process, so the subsequent patch point rewriting is redundant. This PR avoids that redundant processing by checking for the ISEQ's membership in the `ep_escape_iseqs` set and returns early if we've already processed this ISEQ. For any ISEQ without patch points, this PR only saves an extra `HashMap` lookup (no need to read `Invariants#no_ep_escape_iseq_patch_points`).

---

I ran the _lobsters_ benchmarks from [ruby-bench](https://github.com/ruby/ruby-bench/tree/184b1a9f79b21c12c4aaa6be3bad23a1ebe4b439). I ran the benchmarks on an M4 Pro MacBook Pro that was running other software as well, so take the numbers with a grain of salt. However, I did perform repeated runs and cranked the iteration count to try to amortize system effects. The _ruby-master_ branch at the time was a440f23c708cf0e1ac97497fd16f6dc893e45bbd.

`--warmup=80 --bench=120`. Per-config n = 120 bench iterations.

| config        | mean (ms) | median | σ    | speedup |
|---------------|-----------|--------|------|---------|
| ruby-master   | 428.6     | 424.2  | 17.5 | 1.000×  |
| With this fix | 412.8     | 412.2  | 8.5  | 1.038×  |

baseline vs fix: t = 8.87, df ≈ 173, p < 0.001.

The gains here are modest, but statistically significant. What I found more interesting was the reduction in variance. All of this would need verification in a proper benchmarking environment.

To dig in a bit more, I built an instrumented build to calculate how many times we'd be able to short-circuit. Running _lobsters_ with `WARMUP_ITRS=80 MIN_BENCH_ITRS=120 MIN_BENCH_TIME=0`, I measured:

| metric | total | per iter |
|---|---|---|
| Callbacks invoked | 786,892 | 3,934 |
| First-time per `IseqPtr` (`HashSet::insert` returned `true`) | 687 | 3.4 |
| Redundant (already in `ep_escape_iseqs`) | 786,205 | 3,931 |
| With patch points to walk (`has_patches=true`) | 3,000 | 15 |
| With no patch points (`has_patches=false`) | 783,884 | 3,919 |
| Unique `IseqPtr`s observed escaping at least once | 323 | — |
  
The difference in 323 `IseqPtr` vs 687 is because `IseqPtr` addresses can be reused after GC: `Invariants::forget_iseq` removes an ISEQ's entry when CRuby frees the ISEQ, so a new ISEQ later allocated at the same address counts as another first-time escape.

---

I prototyped a follow-up commit that avoided acquiring the VM lock entirely on redundant calls. However, on the single-Ractor _lobsters_ benchmark it produced no statistically significant gain as the VM barrier short-circuits when there is only one Ractor. I also ran _knucleotide-ractor_, which is a multi-Ractor benchmark. It produced a slightly larger point-estimate speedup than this PR alone, but the V1-vs-V2 difference also wasn't statistically significant at this sample size. I suspect this change could be important in a multi-Ractor Rails application given the high callback rate on hot paths, but we don't have that today so I dropped it.

<details>
<summary>Prototyped VM lock skip patch (for context)</summary>

```diff
From 7aa4bd65234f8710d5a526d7c4f647edbc05bba1 Mon Sep 17 00:00:00 2001
From: Kevin Menard <kevin@nirvdrum.com>
Date: Mon, 4 May 2026 16:18:29 -0400
Subject: [PATCH] ZJIT: Avoid the VM lock for already-invalidated EP escapes

---
 zjit/src/invariants.rs | 39 ++++++++++++++++++++++++++++++++-------
 zjit/src/payload.rs    |  9 +++++++++
 2 files changed, 41 insertions(+), 7 deletions(-)

diff --git a/zjit/src/invariants.rs b/zjit/src/invariants.rs
index 6f8cdb955d..fd599a20c1 100644
--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -5,7 +5,7 @@ use std::{collections::{HashMap, HashSet}, mem};
 use crate::{backend::lir::{Assembler, asm_comment}, cruby::{ID, IseqPtr, RedefinitionFlag, VALUE, iseq_name, rb_callable_method_entry_t, rb_gc_location, ruby_basic_operators, src_loc, with_vm_lock}, hir::Invariant, options::debug, state::{ZJITState, zjit_enabled_p, trace_invalidation}, virtualmem::CodePtr};
 use crate::payload::{IseqVersionRef, get_or_create_iseq_payload};
 use crate::codegen::invalidate_iseq_version;
-use crate::cruby::rb_iseq_reset_jit_func;
+use crate::cruby::{rb_iseq_get_zjit_payload, rb_iseq_reset_jit_func};
 use crate::stats::with_time_stat;
 use crate::stats::Counter::invalidation_time_ns;
 use crate::gc::remove_gc_offsets;
@@ -210,13 +210,29 @@ pub extern "C" fn rb_zjit_invalidate_no_ep_escape(iseq: IseqPtr) {
         return;
     }
 
+    // Lock-free fast path: While the ep_escape_iseqs check within the lock works
+    // well for single Ractor applications, it's better if we don't acquire the VM lock
+    // if we know we've already invalidated the ISEQ. Here, we read an atomic flag stored
+    // on the ISEQ's payload and bail before acquiring the VM lock. The flag is set under
+    // the VM lock at the end of the slow path below, so a stale `false` read here just
+    // falls through to the lock and is double-checked by ep_escape_iseqs.insert inside it.
+    let payload_ptr = unsafe { rb_iseq_get_zjit_payload(iseq) };
+    if !payload_ptr.is_null() {
+        let payload = payload_ptr as *const crate::payload::IseqPayload;
+        let already_invalidated = unsafe {
+            (*payload).was_invalidated_for_ep_escape.load(std::sync::atomic::Ordering::Acquire)
+        };
+        if already_invalidated {
+            return;
+        }
+    }
+
     with_vm_lock(src_loc!(), || {
-        // Remember that this ISEQ may escape EP. If we have already processed
-        // an EP escape for this ISEQ, the JIT version was already invalidated
-        // and any patch points were already patched out. Redoing that work
-        // would just re-walk the same patch points and overwrite them with
-        // identical jumps. CRuby calls this on every env heap-promotion,
-        // regardless of whether ZJIT has anything left to invalidate.
+        // Remember that this ISEQ may escape EP. The ep_escape_iseqs check handles
+        // the race between the lock-free read above and arriving here: if
+        // another thread completed the slow path between our atomic load and
+        // our lock acquisition, the ISEQ is already in the set and we exit
+        // cleanly without redoing the work.
         let invariants = ZJITState::get_invariants();
         if !invariants.ep_escape_iseqs.insert(iseq) {
             return;
@@ -251,6 +267,15 @@ pub extern "C" fn rb_zjit_invalidate_no_ep_escape(iseq: IseqPtr) {
 
             cb.mark_all_executable();
         }
+
+        // Publish to the lock-free fast path that subsequent calls can skip
+        // the VM lock entirely. Use Release so prior writes (the patch-point
+        // walk, version status flip, jit_func reset) are visible to any
+        // thread that observes this store via Acquire above. We get/create
+        // the payload here because the ISEQ may not yet have one if it never
+        // JIT-compiled.
+        let payload = crate::payload::get_or_create_iseq_payload(iseq);
+        payload.was_invalidated_for_ep_escape.store(true, std::sync::atomic::Ordering::Release);
     });
 }
 
diff --git a/zjit/src/payload.rs b/zjit/src/payload.rs
index 010972bdae..0097aca919 100644
--- a/zjit/src/payload.rs
+++ b/zjit/src/payload.rs
@@ -1,5 +1,6 @@
 use std::ffi::c_void;
 use std::ptr::NonNull;
+use std::sync::atomic::AtomicBool;
 use crate::codegen::IseqCallRef;
 use crate::stats::CompileError;
 use crate::{cruby::*, profile::IseqProfile, virtualmem::CodePtr};
@@ -16,6 +17,13 @@ pub struct IseqPayload {
     /// Whether a previous compilation of this ISEQ was invalidated due to
     /// singleton class creation (violation of [`crate::hir::Invariant::NoSingletonClass`]).
     pub was_invalidated_for_singleton_class_creation: bool,
+    /// Whether `rb_zjit_invalidate_no_ep_escape` has already processed this
+    /// ISEQ. Atomic so that the callback's fast path can read it without
+    /// holding the VM lock; written under the VM lock at the end of the slow
+    /// path. Once true, the JIT version (if any) has been invalidated and the
+    /// ISEQ has been demoted to the interpreter, so subsequent escape events
+    /// for this ISEQ are no-ops and do not need to enter the slow path.
+    pub was_invalidated_for_ep_escape: AtomicBool,
 }
 
 impl IseqPayload {
@@ -24,6 +32,7 @@ impl IseqPayload {
             profile: IseqProfile::new(),
             versions: vec![],
             was_invalidated_for_singleton_class_creation: false,
+            was_invalidated_for_ep_escape: AtomicBool::new(false),
         }
     }
 }
-- 
2.51.2


```
</details>
