### PR TITLE
vm_callinfo.h: stop uselessly incrementing attr_index

### DIFF
--- a/vm_callinfo.h
+++ b/vm_callinfo.h
@@ -459,7 +459,7 @@ vm_unpack_shape_and_index(const uint64_t cache_value, shape_id_t *shape_id, attr
         .pack = cache_value,
     };
     *shape_id = cache.unpack.shape_id;
-    *index = cache.unpack.index - 1;
+    *index = cache.unpack.index;
 }
 
 static inline void
@@ -514,7 +514,7 @@ vm_pack_shape_and_index(shape_id_t shape_id, attr_index_t index)
     union rb_attr_index_cache cache = {
         .unpack = {
             .shape_id = shape_id,
-            .index = index + 1,
+            .index = index,
         }
     };
     return cache.pack;


### PR DESCRIPTION
There might have been a reason for this, but it's likely long gone.