### PR TITLE
Ensure Symbol#to_proc respects caller's Ruby::Box context

### DIFF
--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -877,6 +877,30 @@ class TestBox < Test::Unit::TestCase
     end;
   end
 
+  def test_symbol_to_proc_uses_current_box
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      box = Ruby::Box.new
+
+      normal, via_sym_proc = box.eval(<<~'RUBY')
+        class Array
+          def box_only_method
+            :ok
+          end
+        end
+
+        normal = [[1]].flat_map { |ary| ary.box_only_method }
+        via_sym_proc = [[1]].flat_map(&:box_only_method)
+        [normal, via_sym_proc]
+      RUBY
+
+      assert_equal [:ok], normal
+      assert_equal [:ok], via_sym_proc
+
+      assert_raise(NoMethodError) { [1].box_only_method }
+    end;
+  end
+
   def test_loading_extension_libs_in_main_box_1
     pend if /mswin|mingw/ =~ RUBY_PLATFORM # timeout on windows environments
     assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)

--- a/vm.c
+++ b/vm.c
@@ -670,6 +670,8 @@ static void add_opt_method_entry(const rb_method_entry_t *me);
 #define VM_ASSERT_TYPE3(obj, type1, type2, type3) \
     VM_ASSERT(RB_TYPE_3_P(obj, type1, type2, type3), #obj ": %s", rb_obj_info(obj))
 
+static const rb_box_t * current_box_on_cfp(const rb_execution_context_t *ec, const rb_control_frame_t *cfp);
+
 #include "vm_insnhelper.c"
 
 #include "vm_exec.c"

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5197,7 +5197,48 @@ rb_vm_yield_with_cfunc(rb_execution_context_t *ec, const struct rb_captured_bloc
 static VALUE
 vm_yield_with_symbol(rb_execution_context_t *ec,  VALUE symbol, int argc, const VALUE *argv, int kw_splat, VALUE block_handler)
 {
-    return rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, rb_vm_bh_to_procval(ec, block_handler));
+    VALUE passed_proc = rb_vm_bh_to_procval(ec, block_handler);
+
+    if (!rb_box_available()) {
+        return rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, passed_proc);
+    }
+
+    const rb_control_frame_t *reg_cfp = ec->cfp;
+    const rb_control_frame_t *ruby_cfp = rb_vm_get_ruby_level_next_cfp(ec, reg_cfp);
+    const rb_box_t *box = NULL;
+
+    /*
+     * Traverse the frames until a user-defined Box (Optional Box) is found.
+     * Frames for built-in methods like <internal:xxx> run in the Root or Main Box,
+     * so we can safely skip them with this condition without doing string comparisons.
+     */
+    while (ruby_cfp) {
+        box = current_box_on_cfp(ec, ruby_cfp);
+        if (BOX_OPTIONAL_P(box)) {
+            break;
+        }
+        ruby_cfp = rb_vm_get_ruby_level_next_cfp(ec, RUBY_VM_PREVIOUS_CONTROL_FRAME(ruby_cfp));
+    }
+
+    // Fallback to the normal call if no user-defined Box (Optional Box) is found
+    if (!ruby_cfp || !box) {
+        return rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, passed_proc);
+    }
+
+    VALUE filename = rb_iseq_path(CFP_ISEQ(ruby_cfp));
+    const rb_iseq_t *iseq = rb_iseq_new(Qnil, filename, filename, Qnil, 0, ISEQ_TYPE_TOP);
+    VALUE val;
+
+    vm_push_frame(ec, iseq, VM_FRAME_MAGIC_TOP | VM_ENV_FLAG_LOCAL | VM_FRAME_FLAG_FINISH,
+                  Qnil, GC_GUARDED_PTR(box),
+                  (VALUE)vm_cref_new_toplevel(ec), /* cref or me */
+                  0, reg_cfp->sp, 0, 0);
+
+    val = rb_sym_proc_call(SYM2ID(symbol), argc, argv, kw_splat, passed_proc);
+
+    rb_vm_pop_frame(ec);
+
+    return val;
 }
 
 static inline int

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5210,7 +5210,6 @@ vm_yield_with_symbol(rb_execution_context_t *ec,  VALUE symbol, int argc, const 
     /*
      * Traverse the frames until a user-defined Box (Optional Box) is found.
      * Frames for built-in methods like <internal:xxx> run in the Root or Main Box,
-     * so we can safely skip them with this condition without doing string comparisons.
      */
     while (ruby_cfp) {
         box = current_box_on_cfp(ec, ruby_cfp);


### PR DESCRIPTION
Ensure Symbol#to_proc respects caller's Ruby::Box context

[Bug #22015](https://bugs.ruby-lang.org/issues/22015)
During a normal method call, the VM creates a control frame, and the Ruby::Box associated with that frame determines the execution context.
However, Symbol#to_proc does not automatically create a frame.
Therefore, we need to manually push a frame associated with the appropriate Box context.

When determining the Box to associate with this new frame, we cannot simply look at the closest Ruby-level control frame.
This is because some built-in methods (like `Enumerable#map`) are implemented in Ruby (e.g., `<internal:enum>`).
These built-in Ruby frames belong to the default Root or Main Box, which would obscure the actual user-defined Box context we need to capture.

To fix this properly, we now traverse the frames and check their inherent Box states.
Since built-in Ruby frames always run in the Root or Main Box, we safely skip them by continuing our traversal until we find a user-defined Box (an Optional Box, indicated by `BOX_OPTIONAL_P`).
