### PR TITLE
dir.c: fix dirent leak on glob_opendir realloc failure

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -2803,8 +2803,10 @@ glob_opendir(ruby_glob_entries_t *ent, DIR *dirp, int flags, rb_encoding *enc)
             }
             if (count >= capacity) {
                 capacity += 256;
-                if (!(newp = GLOB_REALLOC_N(ent->sort.entries, capacity)))
+                if (!(newp = GLOB_REALLOC_N(ent->sort.entries, capacity))) {
+                    GLOB_FREE(rdp);
                     goto nomem;
+                }
                 ent->sort.entries = newp;
             }
             ent->sort.entries[count++] = rdp;


### PR DESCRIPTION
In `glob_opendir()`, each directory entry is copied before the entries array is grown.  If growing `ent->sort.entries` fails, he function jumps to the `nomem` label before the copied entry is stored in the array.

`glob_dir_finish()` only frees entries already recorded in `ent->sort.entries`, so the current `rdp` is leaked on that error path.

PR adds fix: we free `rdp` before jumping to `nomem`.

Found by Linux Verification Center (linuxtesting.org) with SVACE.