### PR TITLE
Remove unused variable warning in imemo_fields_free

### DIFF
--- a/imemo.c
+++ b/imemo.c
@@ -560,10 +560,7 @@ static inline void
 imemo_fields_free(struct rb_fields *fields)
 {
     if (FL_TEST_RAW((VALUE)fields, OBJ_FIELD_HEAP)) {
-#if RUBY_DEBUG
-        shape_id_t shape_id = RBASIC_SHAPE_ID((VALUE)fields);
-        RUBY_ASSERT(rb_shape_complex_p(shape_id));
-#endif
+        RUBY_ASSERT(rb_shape_complex_p(RBASIC_SHAPE_ID((VALUE)fields)));
         st_free_table(fields->as.complex.table);
     }
 }


### PR DESCRIPTION
When not in debug mode, this causes a warning:

```
$ touch imemo.c && make imemo.o
compiling ../../imemo.c
../../imemo.c:563:20: warning: unused variable 'shape_id' [-Wunused-variable]
  563 |         shape_id_t shape_id = RBASIC_SHAPE_ID((VALUE)fields);
      |                    ^~~~~~~~
1 warning generated.
```

cc @byroot 