### PR TITLE
Concurrent_set now able to handle concurrent deletions from multiple threads

### DIFF
--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -251,7 +251,7 @@ concurrent_set_try_resize_locked(VALUE old_set_obj, VALUE *set_obj_ptr, VALUE ne
         // Insert key into new_set.
         struct concurrent_set_probe probe;
         int idx = concurrent_set_probe_start(&probe, new_set, hash);
-        int start_idx = idx;
+        MAYBE_UNUSED(int start_idx) = idx;
 
         while (true) {
             struct concurrent_set_entry *entry = &new_set->entries[idx];
@@ -329,7 +329,6 @@ concurrent_set_try_resize(VALUE old_set_obj, VALUE *set_obj_ptr)
         // May cause GC and therefore deletes, so must happen first.
         VALUE new_set_obj = rb_concurrent_set_new(old_set->funcs, new_capacity, old_set->key_type);
         // Deletes from sweep thread must not happen during resize and sweep thread can't take VM lock so it takes the resize lock.
-        // Re-entry is necessary because
         resize_lock_lock();
         {
             concurrent_set_try_resize_locked(old_set_obj, set_obj_ptr, new_set_obj, old_capacity);
@@ -647,13 +646,13 @@ rb_concurrent_set_delete_by_identity_locked(VALUE set_obj, VALUE key)
     struct concurrent_set_probe probe;
     int idx = concurrent_set_probe_start(&probe, set, hash);
     bool hash_cleared = false;
-    VALUE prev_hash = 0;
+    MAYBE_UNUSED(VALUE prev_hash) = 0;
 
     while (true) {
         struct concurrent_set_entry *entry = &set->entries[idx];
         VALUE raw_key = rbimpl_atomic_value_load(&entry->key, RBIMPL_ATOMIC_ACQUIRE);
         VALUE loaded_hash_raw = rbimpl_atomic_value_load(&entry->hash, RBIMPL_ATOMIC_ACQUIRE);
-        VALUE loaded_hash = loaded_hash_raw & CONCURRENT_SET_HASH_MASK;
+        MAYBE_UNUSED(VALUE loaded_hash) = loaded_hash_raw & CONCURRENT_SET_HASH_MASK;
         bool continuation = raw_key & CONCURRENT_SET_CONTINUATION_BIT;
         VALUE curr_key = raw_key & CONCURRENT_SET_KEY_MASK;
 
@@ -728,27 +727,17 @@ VALUE
 rb_concurrent_set_delete_by_identity(VALUE *set_obj_ptr, VALUE key)
 {
     VALUE result;
-    VALUE set_obj = rbimpl_atomic_value_load(set_obj_ptr, RBIMPL_ATOMIC_ACQUIRE);
 
     if (cur_thread_needs_resize_lock_during_delete()) {
-        while (1) {
-            resize_lock_lock();
-            {
-                VALUE current_set_obj = rbimpl_atomic_value_load(set_obj_ptr, RBIMPL_ATOMIC_ACQUIRE);
-                if (current_set_obj != set_obj) {
-                    set_obj = current_set_obj;
-                    // retry - resize happened
-                }
-                else {
-                    result = rb_concurrent_set_delete_by_identity_locked(set_obj, key);
-                    resize_lock_unlock();
-                    break;
-                }
-            }
-            resize_lock_unlock();
+        resize_lock_lock();
+        {
+            VALUE set_obj = rbimpl_atomic_value_load(set_obj_ptr, RBIMPL_ATOMIC_ACQUIRE);
+            result = rb_concurrent_set_delete_by_identity_locked(set_obj, key);
         }
+        resize_lock_unlock();
     }
     else {
+        VALUE set_obj = rbimpl_atomic_value_load(set_obj_ptr, RBIMPL_ATOMIC_ACQUIRE);
         result = rb_concurrent_set_delete_by_identity_locked(set_obj, key);
     }
     return result;

--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -717,7 +717,8 @@ rb_concurrent_set_delete_by_identity_locked(VALUE set_obj, VALUE key)
     }
 }
 
-static bool cur_thread_needs_resize_lock_during_delete(void)
+static bool
+cur_thread_needs_resize_lock_during_delete(void)
 {
     return !ruby_native_thread_p();
 }
@@ -793,11 +794,20 @@ rb_concurrent_set_foreach_with_replace_locked(VALUE set_obj, int (*callback)(VAL
 void
 rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data)
 {
-    RB_VM_LOCKING() {
-        resize_lock_lock();
-        {
-            rb_concurrent_set_foreach_with_replace_locked(set_obj, callback, data);
-        }
-        resize_lock_unlock();
+    unsigned int lev;
+    bool native_thread = false;
+    // FIXME: Right now, MMTk calls this function in a worker thread, which is not safe. Until they
+    // fix that, we'll work around that by not attempting a VM lock, which would crash MMTk.
+    if (ruby_native_thread_p()) {
+        native_thread = true;
+        RB_VM_LOCK_ENTER_LEV(&lev);
+    }
+    resize_lock_lock();
+    {
+        rb_concurrent_set_foreach_with_replace_locked(set_obj, callback, data);
+    }
+    resize_lock_unlock();
+    if (native_thread) {
+        RB_VM_LOCK_LEAVE_LEV(&lev);
     }
 }

--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -719,7 +719,7 @@ rb_concurrent_set_delete_by_identity_locked(VALUE set_obj, VALUE key)
 
 static bool cur_thread_needs_resize_lock_during_delete(void)
 {
-    return false; // some threads will require this in future (eg: sweep thread)
+    return !ruby_native_thread_p();
 }
 
 // This can be called concurrently by a ruby GC thread and another thread

--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -279,7 +279,7 @@ concurrent_set_try_resize_locked(VALUE old_set_obj, VALUE *set_obj_ptr, VALUE ne
     RB_GC_GUARD(old_set_obj);
 }
 
-static rb_nativethread_lock_t resize_lock = RB_NATIVETHREAD_LOCK_INIT;
+static rb_nativethread_lock_t resize_lock;
 
 static inline void
 resize_lock_lock(void)
@@ -291,6 +291,12 @@ static inline void
 resize_lock_unlock(void)
 {
     rb_native_mutex_unlock(&resize_lock);
+}
+
+void
+rb_concurrent_set_initialize(void)
+{
+    rb_native_mutex_initialize(&resize_lock);
 }
 
 static void

--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -4,14 +4,24 @@
 #include "ruby/atomic.h"
 #include "vm_sync.h"
 
-#define CONCURRENT_SET_CONTINUATION_BIT ((VALUE)1 << (sizeof(VALUE) * CHAR_BIT - 1))
-#define CONCURRENT_SET_HASH_MASK (~CONCURRENT_SET_CONTINUATION_BIT)
+// insertion probes have gone past this slot. Set on the key, so T_STRING and T_SYMBOL VALUEs normally have this bit unset
+#define CONCURRENT_SET_CONTINUATION_BIT ((VALUE)0x2)
+#define CONCURRENT_SET_KEY_MASK (~CONCURRENT_SET_CONTINUATION_BIT)
+// This slot's hash can be reclaimed if and only if the key is EMPTY and it doesn't have a continuation bit. If the key is something
+// else, this bit on the hash has no meaning and is ignored.
+#define CONCURRENT_SET_HASH_RECLAIMABLE_BIT ((VALUE)1 << (sizeof(VALUE) * CHAR_BIT - 1))
+#define CONCURRENT_SET_HASH_MASK (~CONCURRENT_SET_HASH_RECLAIMABLE_BIT)
+
+#define CONCURRENT_SET_DEBUG 0
+#define CONCURRENT_SET_DEBUG_STATS 0
+#define CONCURRENT_SET_DEBUG_DUPLICATES 0
+#define CONCURRENT_SET_DEBUG_BAD_HASH_FN 0
 
 enum concurrent_set_special_values {
-    CONCURRENT_SET_EMPTY,
-    CONCURRENT_SET_DELETED,
-    CONCURRENT_SET_MOVED,
-    CONCURRENT_SET_SPECIAL_VALUE_COUNT
+    CONCURRENT_SET_EMPTY = 0,
+    CONCURRENT_SET_TOMBSTONE = 1,
+    CONCURRENT_SET_MOVED = 5, // continuation bit is 0x02, so 0x05 doesn't have bits in conflict with it
+    CONCURRENT_SET_SPECIAL_VALUE_COUNT = 6 // hash table keys have a value >= this
 };
 
 struct concurrent_set_entry {
@@ -22,38 +32,53 @@ struct concurrent_set_entry {
 struct concurrent_set {
     rb_atomic_t size;
     unsigned int capacity;
-    unsigned int deleted_entries;
+    rb_atomic_t deleted_entries;
     const struct rb_concurrent_set_funcs *funcs;
     struct concurrent_set_entry *entries;
+    int key_type;
+#if CONCURRENT_SET_DEBUG_STATS
+    rb_atomic_t find_count;
+    rb_atomic_t find_probe_total;
+    rb_atomic_t find_probe_max;
+    rb_atomic_t insert_count;
+    rb_atomic_t insert_probe_total;
+    rb_atomic_t insert_probe_max;
+#endif
 };
 
-static void
-concurrent_set_mark_continuation(struct concurrent_set_entry *entry, VALUE curr_hash_and_flags)
+static bool
+concurrent_set_mark_continuation(struct concurrent_set_entry *entry, VALUE raw_key)
 {
-    if (curr_hash_and_flags & CONCURRENT_SET_CONTINUATION_BIT) return;
+    if (raw_key & CONCURRENT_SET_CONTINUATION_BIT) return true;
 
-    RUBY_ASSERT((curr_hash_and_flags & CONCURRENT_SET_HASH_MASK) != 0);
+    VALUE new_key = raw_key | CONCURRENT_SET_CONTINUATION_BIT; // NOTE: raw_key can be CONCURRENT_SET_EMPTY
+    VALUE prev_key = rbimpl_atomic_value_cas(&entry->key, raw_key, new_key, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_ACQUIRE);
 
-    VALUE new_hash = curr_hash_and_flags | CONCURRENT_SET_CONTINUATION_BIT;
-    VALUE prev_hash = rbimpl_atomic_value_cas(&entry->hash, curr_hash_and_flags, new_hash, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
-
-    // At the moment we only expect to be racing concurrently against another
-    // thread also setting the continuation bit.
-    // In the future if deletion is concurrent this will need adjusting
-    RUBY_ASSERT(prev_hash == curr_hash_and_flags || prev_hash == new_hash);
-    (void)prev_hash;
+    if (prev_key == raw_key || prev_key == new_key) {
+        return true;
+    }
+    else if ((prev_key & CONCURRENT_SET_KEY_MASK) == CONCURRENT_SET_TOMBSTONE) {
+        return true;
+    }
+    else {
+        // * key could have been made EMPTY, and anything could have happened to this slot since then. Need to retry.
+        // * key could have been moved during resize
+        return false;
+    }
 }
 
 static VALUE
 concurrent_set_hash(const struct concurrent_set *set, VALUE key)
 {
     VALUE hash = set->funcs->hash(key);
+#if CONCURRENT_SET_DEBUG_BAD_HASH_FN
+    hash = hash % 1024;
+    if (hash == 0) hash = 1;
+#endif
     hash &= CONCURRENT_SET_HASH_MASK;
-    if (hash == 0) {
-        hash ^= CONCURRENT_SET_HASH_MASK;
-    }
+    if (hash == 0) hash = ~(VALUE)0 & CONCURRENT_SET_HASH_MASK;
     RUBY_ASSERT(hash != 0);
-    RUBY_ASSERT(!(hash & CONCURRENT_SET_CONTINUATION_BIT));
+    RUBY_ASSERT(!(hash & CONCURRENT_SET_HASH_RECLAIMABLE_BIT));
     return hash;
 }
 
@@ -91,18 +116,29 @@ static const rb_data_type_t concurrent_set_type = {
         .dsize = concurrent_set_size,
     },
     /* Hack: NOT WB_PROTECTED on purpose (see above) */
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_EMBEDDABLE
+    /* NOTE: don't make embedded due to compaction */
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY
 };
 
 VALUE
-rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity)
+rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity, int key_type)
 {
     struct concurrent_set *set;
     VALUE obj = TypedData_Make_Struct(0, struct concurrent_set, &concurrent_set_type, set);
     set->funcs = funcs;
     set->entries = ZALLOC_N(struct concurrent_set_entry, capacity);
     set->capacity = capacity;
+    (void)key_type;
+#if CONCURRENT_SET_DEBUG
+    set->key_type = key_type;
+#endif
     return obj;
+}
+
+void *
+rb_concurrent_set_get_data(VALUE set_obj)
+{
+    return RTYPEDDATA_GET_DATA(set_obj);
 }
 
 rb_atomic_t
@@ -112,6 +148,50 @@ rb_concurrent_set_size(VALUE set_obj)
 
     return RUBY_ATOMIC_LOAD(set->size);
 }
+
+unsigned int
+rb_concurrent_set_capacity(VALUE set_obj)
+{
+    struct concurrent_set *set = RTYPEDDATA_GET_DATA(set_obj);
+
+    return set->capacity;
+}
+
+void
+rb_concurrent_set_probe_stats(VALUE set_obj,
+                              rb_atomic_t *find_count, rb_atomic_t *find_probe_total, rb_atomic_t *find_probe_max,
+                              rb_atomic_t *insert_count, rb_atomic_t *insert_probe_total, rb_atomic_t *insert_probe_max)
+{
+#if CONCURRENT_SET_DEBUG_STATS
+    struct concurrent_set *set = RTYPEDDATA_GET_DATA(set_obj);
+    *find_count = RUBY_ATOMIC_LOAD(set->find_count);
+    *find_probe_total = RUBY_ATOMIC_LOAD(set->find_probe_total);
+    *find_probe_max = RUBY_ATOMIC_LOAD(set->find_probe_max);
+    *insert_count = RUBY_ATOMIC_LOAD(set->insert_count);
+    *insert_probe_total = RUBY_ATOMIC_LOAD(set->insert_probe_total);
+    *insert_probe_max = RUBY_ATOMIC_LOAD(set->insert_probe_max);
+#else
+    *find_count = 0;
+    *find_probe_total = 0;
+    *find_probe_max = 0;
+    *insert_count = 0;
+    *insert_probe_total = 0;
+    *insert_probe_max = 0;
+#endif
+}
+
+#if CONCURRENT_SET_DEBUG_STATS
+static void
+concurrent_set_atomic_max(rb_atomic_t *target, rb_atomic_t val)
+{
+    rb_atomic_t cur = RUBY_ATOMIC_LOAD(*target);
+    while (val > cur) {
+        rb_atomic_t prev = rbimpl_atomic_cas(target, cur, val, RBIMPL_ATOMIC_RELAXED, RBIMPL_ATOMIC_RELAXED);
+        if (prev == cur) break;
+        cur = prev;
+    }
+}
+#endif
 
 struct concurrent_set_probe {
     int idx;
@@ -138,67 +218,59 @@ concurrent_set_probe_next(struct concurrent_set_probe *probe)
 }
 
 static void
-concurrent_set_try_resize_without_locking(VALUE old_set_obj, VALUE *set_obj_ptr)
+concurrent_set_try_resize_locked(VALUE old_set_obj, VALUE *set_obj_ptr, VALUE new_set_obj, int old_capacity)
 {
-    // Check if another thread has already resized.
-    if (rbimpl_atomic_value_load(set_obj_ptr, RBIMPL_ATOMIC_ACQUIRE) != old_set_obj) {
-        return;
-    }
-
     struct concurrent_set *old_set = RTYPEDDATA_GET_DATA(old_set_obj);
-
-    // This may overcount by up to the number of threads concurrently attempting to insert
-    // GC may also happen between now and the set being rebuilt
-    int expected_size = rbimpl_atomic_load(&old_set->size, RBIMPL_ATOMIC_RELAXED) - old_set->deleted_entries;
-
-    // NOTE: new capacity must make sense with load factor, don't change one without checking the other.
     struct concurrent_set_entry *old_entries = old_set->entries;
-    int old_capacity = old_set->capacity;
-    int new_capacity = old_capacity * 2;
-    if (new_capacity > expected_size * 8) {
-        new_capacity = old_capacity / 2;
-    }
-    else if (new_capacity > expected_size * 4) {
-        new_capacity = old_capacity;
-    }
-
-    // May cause GC and therefore deletes, so must happen first.
-    VALUE new_set_obj = rb_concurrent_set_new(old_set->funcs, new_capacity);
     struct concurrent_set *new_set = RTYPEDDATA_GET_DATA(new_set_obj);
 
     for (int i = 0; i < old_capacity; i++) {
         struct concurrent_set_entry *old_entry = &old_entries[i];
-        VALUE key = rbimpl_atomic_value_exchange(&old_entry->key, CONCURRENT_SET_MOVED, RBIMPL_ATOMIC_ACQUIRE);
-        RUBY_ASSERT(key != CONCURRENT_SET_MOVED);
+        VALUE prev_key_raw = rbimpl_atomic_value_exchange(&old_entry->key, CONCURRENT_SET_MOVED, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE prev_key = prev_key_raw & CONCURRENT_SET_KEY_MASK;
+        RUBY_ASSERT(prev_key != CONCURRENT_SET_MOVED);
 
-        if (key < CONCURRENT_SET_SPECIAL_VALUE_COUNT) continue;
-        if (!RB_SPECIAL_CONST_P(key) && rb_objspace_garbage_object_p(key)) continue;
+        if (prev_key < CONCURRENT_SET_SPECIAL_VALUE_COUNT) continue;
 
-        VALUE hash = rbimpl_atomic_value_load(&old_entry->hash, RBIMPL_ATOMIC_RELAXED) & CONCURRENT_SET_HASH_MASK;
-        RUBY_ASSERT(hash != 0);
-        RUBY_ASSERT(hash == concurrent_set_hash(old_set, key));
+        if (!RB_SPECIAL_CONST_P(prev_key) && rb_objspace_garbage_object_p(prev_key)) continue;
+
+#if CONCURRENT_SET_DEBUG
+        if (new_set->key_type == T_STRING) {
+            RUBY_ASSERT(BUILTIN_TYPE(prev_key) == T_STRING);
+            RUBY_ASSERT(FL_TEST(prev_key, RSTRING_FSTR));
+        }
+        else {
+            RUBY_ASSERT(STATIC_SYM_P(prev_key));
+        }
+#endif
+
+        VALUE hash = rbimpl_atomic_value_load(&old_entry->hash, RBIMPL_ATOMIC_ACQUIRE) & CONCURRENT_SET_HASH_MASK;
+        if (hash == 0) continue;
+        RUBY_ASSERT(concurrent_set_hash(old_set, prev_key) == hash);
 
         // Insert key into new_set.
         struct concurrent_set_probe probe;
         int idx = concurrent_set_probe_start(&probe, new_set, hash);
+        int start_idx = idx;
 
         while (true) {
             struct concurrent_set_entry *entry = &new_set->entries[idx];
 
-            if (entry->hash == CONCURRENT_SET_EMPTY) {
+            if (entry->hash == 0) {
                 RUBY_ASSERT(entry->key == CONCURRENT_SET_EMPTY);
 
                 new_set->size++;
                 RUBY_ASSERT(new_set->size <= new_set->capacity / 2);
 
-                entry->key = key;
+                entry->key = prev_key; // no continuation bit
                 entry->hash = hash;
                 break;
             }
 
             RUBY_ASSERT(entry->key >= CONCURRENT_SET_SPECIAL_VALUE_COUNT);
-            entry->hash |= CONCURRENT_SET_CONTINUATION_BIT;
+            entry->key |= CONCURRENT_SET_CONTINUATION_BIT;
             idx = concurrent_set_probe_next(&probe);
+            RUBY_ASSERT(idx != start_idx);
         }
     }
 
@@ -207,12 +279,58 @@ concurrent_set_try_resize_without_locking(VALUE old_set_obj, VALUE *set_obj_ptr)
     RB_GC_GUARD(old_set_obj);
 }
 
+static rb_nativethread_lock_t resize_lock = RB_NATIVETHREAD_LOCK_INIT;
+
+static inline void
+resize_lock_lock(void)
+{
+    rb_native_mutex_lock(&resize_lock);
+}
+
+static inline void
+resize_lock_unlock(void)
+{
+    rb_native_mutex_unlock(&resize_lock);
+}
+
 static void
 concurrent_set_try_resize(VALUE old_set_obj, VALUE *set_obj_ptr)
 {
-    RB_VM_LOCKING() {
-        concurrent_set_try_resize_without_locking(old_set_obj, set_obj_ptr);
+    unsigned int lev;
+    RB_VM_LOCK_ENTER_LEV(&lev);
+    {
+        // Check if another thread has already resized.
+        if (rbimpl_atomic_value_load(set_obj_ptr, RBIMPL_ATOMIC_ACQUIRE) != old_set_obj) {
+            RB_VM_LOCK_LEAVE_LEV(&lev);
+            return;
+        }
+        struct concurrent_set *old_set = RTYPEDDATA_GET_DATA(old_set_obj);
+
+        // This may overcount by up to the number of threads concurrently attempting to insert
+        // GC may also happen between now and the set being rebuilt
+        int expected_size = rbimpl_atomic_load(&old_set->size, RBIMPL_ATOMIC_RELAXED) - old_set->deleted_entries;
+
+        // NOTE: new capacity must make sense with load factor, don't change one without checking the other.
+        int old_capacity = old_set->capacity;
+        int new_capacity = old_capacity * 2;
+        if (new_capacity > expected_size * 8) {
+            new_capacity = old_capacity / 2;
+        }
+        else if (new_capacity > expected_size * 4) {
+            new_capacity = old_capacity;
+        }
+
+        // May cause GC and therefore deletes, so must happen first.
+        VALUE new_set_obj = rb_concurrent_set_new(old_set->funcs, new_capacity, old_set->key_type);
+        // Deletes from sweep thread must not happen during resize and sweep thread can't take VM lock so it takes the resize lock.
+        // Re-entry is necessary because
+        resize_lock_lock();
+        {
+            concurrent_set_try_resize_locked(old_set_obj, set_obj_ptr, new_set_obj, old_capacity);
+        }
+        resize_lock_unlock();
     }
+    RB_VM_LOCK_LEAVE_LEV(&lev);
 }
 
 VALUE
@@ -242,29 +360,39 @@ rb_concurrent_set_find(VALUE *set_obj_ptr, VALUE key)
 
     while (true) {
         struct concurrent_set_entry *entry = &set->entries[idx];
-        VALUE curr_hash_and_flags = rbimpl_atomic_value_load(&entry->hash, RBIMPL_ATOMIC_ACQUIRE);
-        VALUE curr_hash = curr_hash_and_flags & CONCURRENT_SET_HASH_MASK;
-        bool continuation = curr_hash_and_flags & CONCURRENT_SET_CONTINUATION_BIT;
+        VALUE curr_hash = rbimpl_atomic_value_load(&entry->hash, RBIMPL_ATOMIC_ACQUIRE) & CONCURRENT_SET_HASH_MASK;
 
-        if (curr_hash_and_flags == CONCURRENT_SET_EMPTY) {
+        if (curr_hash == 0) {
+#if CONCURRENT_SET_DEBUG_STATS
+            rbimpl_atomic_fetch_add(&set->find_count, 1, RBIMPL_ATOMIC_RELAXED);
+            rbimpl_atomic_fetch_add(&set->find_probe_total, probe.d, RBIMPL_ATOMIC_RELAXED);
+            concurrent_set_atomic_max(&set->find_probe_max, probe.d);
+#endif
             return 0;
         }
 
+        VALUE raw_key = rbimpl_atomic_value_load(&entry->key, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE curr_key = raw_key & CONCURRENT_SET_KEY_MASK;
+        bool continuation = raw_key & CONCURRENT_SET_CONTINUATION_BIT;
+
         if (curr_hash != hash) {
             if (!continuation) {
+#if CONCURRENT_SET_DEBUG_STATS
+                rbimpl_atomic_fetch_add(&set->find_count, 1, RBIMPL_ATOMIC_RELAXED);
+                rbimpl_atomic_fetch_add(&set->find_probe_total, probe.d, RBIMPL_ATOMIC_RELAXED);
+                concurrent_set_atomic_max(&set->find_probe_max, probe.d);
+#endif
                 return 0;
             }
             idx = concurrent_set_probe_next(&probe);
             continue;
         }
 
-        VALUE curr_key = rbimpl_atomic_value_load(&entry->key, RBIMPL_ATOMIC_ACQUIRE);
-
         switch (curr_key) {
           case CONCURRENT_SET_EMPTY:
-            // In-progress insert: hash written but key not yet
+            // In-progress insert: hash written but key not yet.
             break;
-          case CONCURRENT_SET_DELETED:
+          case CONCURRENT_SET_TOMBSTONE:
             break;
           case CONCURRENT_SET_MOVED:
             // Wait
@@ -280,11 +408,21 @@ rb_concurrent_set_find(VALUE *set_obj_ptr, VALUE key)
 
             if (set->funcs->cmp(key, curr_key)) {
                 // We've found a match.
+#if CONCURRENT_SET_DEBUG_STATS
+                rbimpl_atomic_fetch_add(&set->find_count, 1, RBIMPL_ATOMIC_RELAXED);
+                rbimpl_atomic_fetch_add(&set->find_probe_total, probe.d, RBIMPL_ATOMIC_RELAXED);
+                concurrent_set_atomic_max(&set->find_probe_max, probe.d);
+#endif
                 RB_GC_GUARD(set_obj);
                 return curr_key;
             }
 
             if (!continuation) {
+#if CONCURRENT_SET_DEBUG_STATS
+                rbimpl_atomic_fetch_add(&set->find_count, 1, RBIMPL_ATOMIC_RELAXED);
+                rbimpl_atomic_fetch_add(&set->find_probe_total, probe.d, RBIMPL_ATOMIC_RELAXED);
+                concurrent_set_atomic_max(&set->find_probe_max, probe.d);
+#endif
                 return 0;
             }
 
@@ -312,7 +450,7 @@ rb_concurrent_set_find_or_insert(VALUE *set_obj_ptr, VALUE key, void *data)
     RUBY_ASSERT(set_obj);
 
     struct concurrent_set *set = RTYPEDDATA_GET_DATA(set_obj);
-    key = set->funcs->create(key, data);
+    key = set->funcs->create(key, data); // this can join GC (takes VM Lock)
     VALUE hash = concurrent_set_hash(set, key);
 
     struct concurrent_set_probe probe;
@@ -333,33 +471,40 @@ start_search:
 
     while (true) {
         struct concurrent_set_entry *entry = &set->entries[idx];
-        VALUE curr_hash_and_flags = rbimpl_atomic_value_load(&entry->hash, RBIMPL_ATOMIC_ACQUIRE);
-        VALUE curr_hash = curr_hash_and_flags & CONCURRENT_SET_HASH_MASK;
-        bool continuation = curr_hash_and_flags & CONCURRENT_SET_CONTINUATION_BIT;
-
-        if (curr_hash_and_flags == CONCURRENT_SET_EMPTY) {
+        bool can_continue_probing;
+        VALUE raw_hash = rbimpl_atomic_value_load(&entry->hash, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE curr_hash = raw_hash & CONCURRENT_SET_HASH_MASK;
+        if (raw_hash == 0) {
             // Reserve this slot for our hash value
-            curr_hash_and_flags = rbimpl_atomic_value_cas(&entry->hash, CONCURRENT_SET_EMPTY, hash, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
-            if (curr_hash_and_flags != CONCURRENT_SET_EMPTY) {
+            raw_hash = rbimpl_atomic_value_cas(&entry->hash, 0, hash, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
+            if (raw_hash != 0) {
                 // Lost race, retry same slot to check winner's hash
                 continue;
             }
-
-            // CAS succeeded, so these are the values stored
-            curr_hash_and_flags = hash;
+            raw_hash = hash;
             curr_hash = hash;
-
             // Fall through to try to claim key
         }
 
-        if (curr_hash != hash) {
-            goto probe_next;
-        }
-
-        VALUE curr_key = rbimpl_atomic_value_load(&entry->key, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE raw_key = rbimpl_atomic_value_load(&entry->key, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE curr_key = raw_key & CONCURRENT_SET_KEY_MASK;
+        bool continuation = raw_key & CONCURRENT_SET_CONTINUATION_BIT;
 
         switch (curr_key) {
           case CONCURRENT_SET_EMPTY: {
+            if ((raw_hash & CONCURRENT_SET_HASH_RECLAIMABLE_BIT) && !continuation) {
+                // Reclaim this reclaimable slot by clearing the reclaimable bit
+                VALUE prev_hash = rbimpl_atomic_value_cas(&entry->hash, raw_hash, hash, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
+                if (prev_hash != raw_hash) {
+                    // Lost race, retry same slot
+                    continue;
+                }
+                curr_hash = hash;
+                raw_hash = hash;
+            }
+            if (curr_hash != hash) {
+                goto probe_next;
+            }
             rb_atomic_t prev_size = rbimpl_atomic_fetch_add(&set->size, 1, RBIMPL_ATOMIC_RELAXED);
 
             // Load_factor reached at 75% full. ex: prev_size: 32, capacity: 64, load_factor: 50%.
@@ -370,9 +515,38 @@ start_search:
                 goto retry;
             }
 
-            VALUE prev_key = rbimpl_atomic_value_cas(&entry->key, CONCURRENT_SET_EMPTY, key, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
-            if (prev_key == CONCURRENT_SET_EMPTY) {
-                RUBY_ASSERT(rb_concurrent_set_find(set_obj_ptr, key) == key);
+            VALUE prev_raw_key = rbimpl_atomic_value_cas(&entry->key, raw_key, key | (continuation ? CONCURRENT_SET_CONTINUATION_BIT : 0), RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
+            if (prev_raw_key == raw_key) {
+#if CONCURRENT_SET_DEBUG_STATS
+                rbimpl_atomic_fetch_add(&set->insert_count, 1, RBIMPL_ATOMIC_RELAXED);
+                rbimpl_atomic_fetch_add(&set->insert_probe_total, probe.d, RBIMPL_ATOMIC_RELAXED);
+                concurrent_set_atomic_max(&set->insert_probe_max, probe.d);
+#endif
+#if CONCURRENT_SET_DEBUG_DUPLICATES
+                {
+                    // Probe further to verify no duplicate of our key exists
+                    struct concurrent_set_probe dup_probe = probe;
+                    int dup_idx = concurrent_set_probe_next(&dup_probe);
+                    int dup_idx_start = dup_idx;
+                    while (true) {
+                        struct concurrent_set_entry *dup_entry = &set->entries[dup_idx];
+                        VALUE dup_raw_key = rbimpl_atomic_value_load(&dup_entry->key, RBIMPL_ATOMIC_ACQUIRE);
+                        VALUE dup_key = dup_raw_key & CONCURRENT_SET_KEY_MASK;
+
+                        if (dup_key == CONCURRENT_SET_EMPTY) break;
+                        if (dup_key == CONCURRENT_SET_MOVED) break;
+
+                        if (dup_key >= CONCURRENT_SET_SPECIAL_VALUE_COUNT && dup_key == key) {
+                            rb_bug("concurrent_set_find_or_insert: duplicate key %p found at index %d after inserting at index %d",
+                                   (void *)key, dup_idx, idx);
+                        }
+                        int next_dup_idx = concurrent_set_probe_next(&dup_probe);
+                        if (dup_idx < dup_idx_start && next_dup_idx >= dup_idx_start) break;
+                        if (next_dup_idx == dup_idx_start) break;
+                        dup_idx = next_dup_idx;
+                    }
+                }
+#endif
                 RB_GC_GUARD(set_obj);
                 return key;
             }
@@ -380,36 +554,45 @@ start_search:
                 // Entry was not inserted.
                 rbimpl_atomic_sub(&set->size, 1, RBIMPL_ATOMIC_RELAXED);
 
-                // Another thread won the race, try again at the same location.
+                // * Another thread with the same hash could have won the race, try again at the same location, we might find it.
+                // * A resize could also be underway, and `prev_raw_key` could be CONCURRENT_SET_MOVED.
+                // * The continuation bit could also have been set on the key just now, in which case we'll retry
                 continue;
             }
           }
-          case CONCURRENT_SET_DELETED:
+          case CONCURRENT_SET_TOMBSTONE:
             break;
           case CONCURRENT_SET_MOVED:
             // Wait
             RB_VM_LOCKING();
             goto retry;
           default:
-            // We're never GC during our search
+            if (curr_hash != hash) {
+                goto probe_next;
+            }
             // If the continuation bit wasn't set at the start of our search,
-            // any concurrent find with the same hash value would also look at
+            // any concurrent find_or_insert with the same hash value would also look at
             // this location and try to swap curr_key
             if (UNLIKELY(!RB_SPECIAL_CONST_P(curr_key) && rb_objspace_garbage_object_p(curr_key))) {
                 if (continuation) {
                     goto probe_next;
                 }
                 {
-                    VALUE prev = rbimpl_atomic_value_cas(&entry->key, curr_key, CONCURRENT_SET_EMPTY, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
-                    if (prev == curr_key) {
+                    VALUE prev = rbimpl_atomic_value_cas(&entry->key, raw_key, CONCURRENT_SET_EMPTY, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
+                    if (prev == raw_key) {
                         rbimpl_atomic_sub(&set->size, 1, RBIMPL_ATOMIC_RELAXED);
                     }
                 }
-                continue;
+                continue; // try to reclaim same slot, because the hash is the same and it's now EMPTY
             }
 
             if (set->funcs->cmp(key, curr_key)) {
                 // We've found a live match.
+#if CONCURRENT_SET_DEBUG_STATS
+                rbimpl_atomic_fetch_add(&set->insert_count, 1, RBIMPL_ATOMIC_RELAXED);
+                rbimpl_atomic_fetch_add(&set->insert_probe_total, probe.d, RBIMPL_ATOMIC_RELAXED);
+                concurrent_set_atomic_max(&set->insert_probe_max, probe.d);
+#endif
                 RB_GC_GUARD(set_obj);
 
                 // We created key using set->funcs->create, but we didn't end
@@ -423,8 +606,10 @@ start_search:
         }
 
       probe_next:
-        RUBY_ASSERT(curr_hash_and_flags != CONCURRENT_SET_EMPTY);
-        concurrent_set_mark_continuation(entry, curr_hash_and_flags);
+        can_continue_probing =  concurrent_set_mark_continuation(entry, raw_key);
+        if (!can_continue_probing) {
+            continue;
+        }
         idx = concurrent_set_probe_next(&probe);
     }
 }
@@ -434,22 +619,20 @@ concurrent_set_delete_entry_locked(struct concurrent_set *set, struct concurrent
 {
     ASSERT_vm_locking_with_barrier();
 
-    if (entry->hash & CONCURRENT_SET_CONTINUATION_BIT) {
-        entry->hash = CONCURRENT_SET_CONTINUATION_BIT;
-        entry->key = CONCURRENT_SET_DELETED;
+    if (entry->key & CONCURRENT_SET_CONTINUATION_BIT) {
+        entry->key = CONCURRENT_SET_TOMBSTONE | CONCURRENT_SET_CONTINUATION_BIT;
         set->deleted_entries++;
     }
     else {
-        entry->hash = CONCURRENT_SET_EMPTY;
+        entry->hash = 0;
         entry->key = CONCURRENT_SET_EMPTY;
         set->size--;
     }
 }
 
-VALUE
-rb_concurrent_set_delete_by_identity(VALUE set_obj, VALUE key)
+static VALUE
+rb_concurrent_set_delete_by_identity_locked(VALUE set_obj, VALUE key)
 {
-    ASSERT_vm_locking_with_barrier();
 
     struct concurrent_set *set = RTYPEDDATA_GET_DATA(set_obj);
 
@@ -457,25 +640,70 @@ rb_concurrent_set_delete_by_identity(VALUE set_obj, VALUE key)
 
     struct concurrent_set_probe probe;
     int idx = concurrent_set_probe_start(&probe, set, hash);
+    bool hash_cleared = false;
+    VALUE prev_hash = 0;
 
     while (true) {
         struct concurrent_set_entry *entry = &set->entries[idx];
-        VALUE curr_key = entry->key;
+        VALUE raw_key = rbimpl_atomic_value_load(&entry->key, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE loaded_hash_raw = rbimpl_atomic_value_load(&entry->hash, RBIMPL_ATOMIC_ACQUIRE);
+        VALUE loaded_hash = loaded_hash_raw & CONCURRENT_SET_HASH_MASK;
+        bool continuation = raw_key & CONCURRENT_SET_CONTINUATION_BIT;
+        VALUE curr_key = raw_key & CONCURRENT_SET_KEY_MASK;
 
         switch (curr_key) {
           case CONCURRENT_SET_EMPTY:
-            // We didn't find our entry to delete.
-            return 0;
-          case CONCURRENT_SET_DELETED:
+            if (!continuation) {
+                return 0;
+            }
+            break;
+          case CONCURRENT_SET_TOMBSTONE:
             break;
           case CONCURRENT_SET_MOVED:
             rb_bug("rb_concurrent_set_delete_by_identity: moved entry");
             break;
           default:
             if (key == curr_key) {
-                RUBY_ASSERT((entry->hash & CONCURRENT_SET_HASH_MASK) == hash);
-                concurrent_set_delete_entry_locked(set, entry);
-                return curr_key;
+                VALUE new_key;
+                RUBY_ASSERT(hash_cleared || loaded_hash == hash);
+                if (continuation) {
+                    new_key = CONCURRENT_SET_TOMBSTONE | CONCURRENT_SET_CONTINUATION_BIT;
+                }
+                else {
+                    new_key = CONCURRENT_SET_EMPTY;
+                }
+
+                if (!hash_cleared) {
+                    // Hashes only change here and they get reclaimed in find_or_insert
+                    prev_hash = rbimpl_atomic_value_cas(&entry->hash, loaded_hash_raw, hash | CONCURRENT_SET_HASH_RECLAIMABLE_BIT, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_RELAXED);
+                    RUBY_ASSERT(prev_hash == hash || prev_hash == (hash | CONCURRENT_SET_HASH_RECLAIMABLE_BIT));
+                    hash_cleared = true;
+                }
+                VALUE prev_key = rbimpl_atomic_value_cas(&entry->key, raw_key, new_key, RBIMPL_ATOMIC_RELEASE, RBIMPL_ATOMIC_ACQUIRE);
+                if (prev_key == raw_key) {
+                    if (continuation) {
+                        rbimpl_atomic_add(&set->deleted_entries, 1, RBIMPL_ATOMIC_RELAXED);
+                    }
+                    else {
+                        rbimpl_atomic_sub(&set->size, 1, RBIMPL_ATOMIC_RELAXED);
+                    }
+                    return curr_key;
+                }
+                else if (!continuation && prev_key == (raw_key | CONCURRENT_SET_CONTINUATION_BIT)) {
+                    continue; // try again, the continuation bit was just set on this key so we can tombstone it
+                }
+                else if ((prev_key & CONCURRENT_SET_KEY_MASK) == CONCURRENT_SET_EMPTY || (prev_key & CONCURRENT_SET_KEY_MASK) == CONCURRENT_SET_TOMBSTONE) {
+                    return curr_key; // the key was deleted by another thread
+                }
+                else {
+                    // the key was changed to EMPTY by being garbage during find_or_insert and then a new key was put at the same slot. It's okay
+                    // that the hash was marked reclaimable above.
+                    RUBY_ASSERT(prev_hash != 0);
+                    return curr_key;
+                }
+            }
+            else if (!continuation) {
+                return 0;
             }
             break;
         }
@@ -484,8 +712,44 @@ rb_concurrent_set_delete_by_identity(VALUE set_obj, VALUE key)
     }
 }
 
-void
-rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data)
+static bool cur_thread_needs_resize_lock_during_delete(void)
+{
+    return false; // some threads will require this in future (eg: sweep thread)
+}
+
+// This can be called concurrently by a ruby GC thread and another thread
+VALUE
+rb_concurrent_set_delete_by_identity(VALUE *set_obj_ptr, VALUE key)
+{
+    VALUE result;
+    VALUE set_obj = rbimpl_atomic_value_load(set_obj_ptr, RBIMPL_ATOMIC_ACQUIRE);
+
+    if (cur_thread_needs_resize_lock_during_delete()) {
+        while (1) {
+            resize_lock_lock();
+            {
+                VALUE current_set_obj = rbimpl_atomic_value_load(set_obj_ptr, RBIMPL_ATOMIC_ACQUIRE);
+                if (current_set_obj != set_obj) {
+                    set_obj = current_set_obj;
+                    // retry - resize happened
+                }
+                else {
+                    result = rb_concurrent_set_delete_by_identity_locked(set_obj, key);
+                    resize_lock_unlock();
+                    break;
+                }
+            }
+            resize_lock_unlock();
+        }
+    }
+    else {
+        result = rb_concurrent_set_delete_by_identity_locked(set_obj, key);
+    }
+    return result;
+}
+
+static void
+rb_concurrent_set_foreach_with_replace_locked(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data)
 {
     ASSERT_vm_locking_with_barrier();
 
@@ -493,26 +757,50 @@ rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key
 
     for (unsigned int i = 0; i < set->capacity; i++) {
         struct concurrent_set_entry *entry = &set->entries[i];
-        VALUE key = entry->key;
+        VALUE raw_key = entry->key;
+        bool continuation = raw_key & CONCURRENT_SET_CONTINUATION_BIT;
+        VALUE key = raw_key & CONCURRENT_SET_KEY_MASK;
 
         switch (key) {
           case CONCURRENT_SET_EMPTY:
-          case CONCURRENT_SET_DELETED:
+          case CONCURRENT_SET_TOMBSTONE:
             continue;
           case CONCURRENT_SET_MOVED:
             rb_bug("rb_concurrent_set_foreach_with_replace: moved entry");
             break;
           default: {
-            int ret = callback(&entry->key, data);
+            VALUE cb_key = key;
+            int ret = callback(&cb_key, data);
             switch (ret) {
               case ST_STOP:
                 return;
               case ST_DELETE:
                 concurrent_set_delete_entry_locked(set, entry);
                 break;
+              case ST_CONTINUE:
+                if (cb_key != key) {
+                    // Key was replaced by callback
+                    entry->key = cb_key | (continuation ? CONCURRENT_SET_CONTINUATION_BIT : 0);
+                }
+                break;
+              case ST_REPLACE:
+                rb_bug("unexpected concurrent_set callback return value: ST_REPLACE");
             }
             break;
           }
         }
+    }
+}
+
+// VM Barrier must be taken.
+void
+rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data)
+{
+    RB_VM_LOCKING() {
+        resize_lock_lock();
+        {
+            rb_concurrent_set_foreach_with_replace_locked(set_obj, callback, data);
+        }
+        resize_lock_unlock();
     }
 }

--- a/concurrent_set.c
+++ b/concurrent_set.c
@@ -746,7 +746,9 @@ rb_concurrent_set_delete_by_identity(VALUE *set_obj_ptr, VALUE key)
 static void
 rb_concurrent_set_foreach_with_replace_locked(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data)
 {
-    ASSERT_vm_locking_with_barrier();
+    if (!ruby_vm_during_cleanup) {
+        ASSERT_vm_locking_with_barrier();
+    }
 
     struct concurrent_set *set = RTYPEDDATA_GET_DATA(set_obj);
 

--- a/depend
+++ b/depend
@@ -18363,6 +18363,7 @@ thread.$(OBJEXT): $(top_srcdir)/internal/bits.h
 thread.$(OBJEXT): $(top_srcdir)/internal/box.h
 thread.$(OBJEXT): $(top_srcdir)/internal/class.h
 thread.$(OBJEXT): $(top_srcdir)/internal/compilers.h
+thread.$(OBJEXT): $(top_srcdir)/internal/concurrent_set.h
 thread.$(OBJEXT): $(top_srcdir)/internal/cont.h
 thread.$(OBJEXT): $(top_srcdir)/internal/error.h
 thread.$(OBJEXT): $(top_srcdir)/internal/eval.h
@@ -19683,6 +19684,7 @@ vm.$(OBJEXT): $(top_srcdir)/internal/compar.h
 vm.$(OBJEXT): $(top_srcdir)/internal/compile.h
 vm.$(OBJEXT): $(top_srcdir)/internal/compilers.h
 vm.$(OBJEXT): $(top_srcdir)/internal/complex.h
+vm.$(OBJEXT): $(top_srcdir)/internal/concurrent_set.h
 vm.$(OBJEXT): $(top_srcdir)/internal/cont.h
 vm.$(OBJEXT): $(top_srcdir)/internal/encoding.h
 vm.$(OBJEXT): $(top_srcdir)/internal/error.h

--- a/internal/concurrent_set.h
+++ b/internal/concurrent_set.h
@@ -17,5 +17,6 @@ VALUE rb_concurrent_set_find(VALUE *set_obj_ptr, VALUE key);
 VALUE rb_concurrent_set_find_or_insert(VALUE *set_obj_ptr, VALUE key, void *data);
 VALUE rb_concurrent_set_delete_by_identity(VALUE *set_obj, VALUE key);
 void rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data);
+void rb_concurrent_set_initialize(void);
 
 #endif

--- a/internal/concurrent_set.h
+++ b/internal/concurrent_set.h
@@ -11,11 +11,11 @@ struct rb_concurrent_set_funcs {
     void (*free)(VALUE key);
 };
 
-VALUE rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity);
+VALUE rb_concurrent_set_new(const struct rb_concurrent_set_funcs *funcs, int capacity, int key_type);
 rb_atomic_t rb_concurrent_set_size(VALUE set_obj);
 VALUE rb_concurrent_set_find(VALUE *set_obj_ptr, VALUE key);
 VALUE rb_concurrent_set_find_or_insert(VALUE *set_obj_ptr, VALUE key, void *data);
-VALUE rb_concurrent_set_delete_by_identity(VALUE set_obj, VALUE key);
+VALUE rb_concurrent_set_delete_by_identity(VALUE *set_obj, VALUE key);
 void rb_concurrent_set_foreach_with_replace(VALUE set_obj, int (*callback)(VALUE *key, void *data), void *data);
 
 #endif

--- a/string.c
+++ b/string.c
@@ -564,7 +564,7 @@ static const struct rb_concurrent_set_funcs fstring_concurrent_set_funcs = {
 void
 Init_fstring_table(void)
 {
-    fstring_table_obj = rb_concurrent_set_new(&fstring_concurrent_set_funcs, 8192);
+    fstring_table_obj = rb_concurrent_set_new(&fstring_concurrent_set_funcs, 8192, T_STRING);
     rb_gc_register_address(&fstring_table_obj);
 }
 
@@ -614,7 +614,7 @@ rb_gc_free_fstring(VALUE obj)
     RUBY_ASSERT(OBJ_FROZEN(obj));
     RUBY_ASSERT(!FL_TEST(obj, STR_SHARED));
 
-    rb_concurrent_set_delete_by_identity(fstring_table_obj, obj);
+    rb_concurrent_set_delete_by_identity(&fstring_table_obj, obj);
 
     RB_DEBUG_COUNTER_INC(obj_str_fstr);
 

--- a/symbol.c
+++ b/symbol.c
@@ -1093,6 +1093,8 @@ rb_sym_all_symbols(void)
     VALUE ary;
 
     GLOBAL_SYMBOLS_LOCKING(symbols) {
+        rb_vm_barrier();
+
         ary = rb_ary_new2(rb_concurrent_set_size(symbols->sym_set));
         rb_concurrent_set_foreach_with_replace(symbols->sym_set, symbols_i, (void *)ary);
     }

--- a/symbol.c
+++ b/symbol.c
@@ -415,7 +415,7 @@ Init_sym(void)
 {
     rb_symbols_t *symbols = &ruby_global_symbols;
 
-    symbols->sym_set = rb_concurrent_set_new(&sym_set_funcs, 1024);
+    symbols->sym_set = rb_concurrent_set_new(&sym_set_funcs, 1024, T_SYMBOL);
     symbols->ids = rb_ary_hidden_new(0);
 
     Init_op_tbl();
@@ -950,7 +950,7 @@ rb_gc_free_dsymbol(VALUE sym)
     VALUE str = RSYMBOL(sym)->fstr;
 
     if (str) {
-        rb_concurrent_set_delete_by_identity(ruby_global_symbols.sym_set, sym);
+        rb_concurrent_set_delete_by_identity(&ruby_global_symbols.sym_set, sym);
 
         RSYMBOL(sym)->fstr = 0;
     }

--- a/thread.c
+++ b/thread.c
@@ -76,6 +76,7 @@
 #include "hrtime.h"
 #include "internal.h"
 #include "internal/class.h"
+#include "internal/concurrent_set.h"
 #include "internal/cont.h"
 #include "internal/error.h"
 #include "internal/eval.h"
@@ -5033,6 +5034,7 @@ void rb_fiber_atfork(rb_thread_t *);
 void
 rb_thread_atfork(void)
 {
+    rb_concurrent_set_initialize();
     rb_thread_t *th = GET_THREAD();
     rb_threadptr_pending_interrupt_clear(th);
     rb_thread_atfork_internal(th, terminate_atfork_i);

--- a/vm.c
+++ b/vm.c
@@ -15,6 +15,7 @@
 #include "internal/box.h"
 #include "internal/class.h"
 #include "internal/compile.h"
+#include "internal/concurrent_set.h"
 #include "internal/cont.h"
 #include "internal/error.h"
 #include "internal/encoding.h"
@@ -3641,6 +3642,7 @@ vm_default_params_setup(rb_vm_t *vm)
 static void
 vm_init2(rb_vm_t *vm)
 {
+    rb_concurrent_set_initialize();
     rb_vm_living_threads_init(vm);
     vm->thread_report_on_exception = 1;
     vm->src_encoding_index = -1;


### PR DESCRIPTION
Right now only one thread (the Ruby thread that GCs) actually calls this at any given time, but we're looking to change that soon by adding parallel sweeping. The symbol and fstring global hash tables can now handle concurrent deletions from multiple threads at once without locking. One caveat to this is if a table is in the middle of a rebuild. In that case, the deleting thread needs to wait until the rebuild has finished.