### PR TITLE
ZJIT: Recompile ISEQ on guard_shape_failure exits for setivar/definedivar

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4610,9 +4610,13 @@ impl Function {
                             self.count(block, Counter::definedivar_fallback_complex);
                             self.push_insn_id(block, insn_id); continue;
                         }
+                        if self.policy.no_side_exits {
+                            // On the final version, keep the DefinedIvar fallback instead of another shape guard.
+                            self.push_insn_id(block, insn_id); continue;
+                        }
                         let self_val = self.load_ivar_guard_type(block, self_val, recv_type, state);
                         let shape = self.load_shape(block, self_val);
-                        self.guard_shape(block, shape, recv_type.shape(), state, None);
+                        self.guard_shape(block, shape, recv_type.shape(), state, Some(Recompile::ProfileSelf));
                         let mut ivar_index: attr_index_t = 0;
                         let replacement = if unsafe { rb_shape_get_iv_index(recv_type.shape().0, id, &mut ivar_index) } {
                             self.push_insn(block, Insn::Const { val: Const::Value(pushval) })
@@ -4624,7 +4628,7 @@ impl Function {
                         };
                         self.make_equal_to(insn_id, replacement);
                     }
-                    Insn::SetIvar { self_val, id, val, state, ic: _ } => {
+                    Insn::SetIvar { self_val, id, val, state, ic } => {
                         let frame_state = self.frame_state(state);
                         let Some(recv_type) = self.profiled_type_of_at(self_val, frame_state.insn_idx) else {
                             // No (monomorphic/skewed polymorphic) profile info
@@ -4650,6 +4654,10 @@ impl Function {
                         if recv_type.shape().is_frozen() {
                             // Can't set ivars on frozen objects
                             self.count(block, Counter::setivar_fallback_frozen);
+                            self.push_insn_id(block, insn_id); continue;
+                        }
+                        if self.policy.no_side_exits {
+                            // On the final version, keep the SetIvar fallback instead of another shape guard.
                             self.push_insn_id(block, insn_id); continue;
                         }
                         let mut ivar_index: attr_index_t = 0;
@@ -4684,7 +4692,10 @@ impl Function {
                         }
                         let self_val = self.load_ivar_guard_type(block, self_val, recv_type, state);
                         let shape = self.load_shape(block, self_val);
-                        self.guard_shape(block, shape, recv_type.shape(), state, None);
+                        // TODO: attr_writer SetIvar has a null inline cache and may not target CFP self.
+                        // Support it with a recompile strategy that profiles the receiver operand.
+                        let recompile = if ic.is_null() { None } else { Some(Recompile::ProfileSelf) };
+                        self.guard_shape(block, shape, recv_type.shape(), state, recompile);
                         // Current shape contains this ivar
                         let (ivar_storage, offset) = if recv_type.flags().is_embedded() {
                             // See ROBJECT_FIELDS() from include/ruby/internal/core/robject.h

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4692,8 +4692,9 @@ impl Function {
                         }
                         let self_val = self.load_ivar_guard_type(block, self_val, recv_type, state);
                         let shape = self.load_shape(block, self_val);
-                        // TODO: attr_writer SetIvar has a null inline cache and may not target CFP self.
-                        // Support it with a recompile strategy that profiles the receiver operand.
+                        // TODO: attr_writer SetIvar has a null inline cache and may target a receiver
+                        // operand other than CFP self. Support it with a reprofile strategy that
+                        // profiles the receiver operand even after the send insn has finished profiling.
                         let recompile = if ic.is_null() { None } else { Some(Recompile::ProfileSelf) };
                         self.guard_shape(block, shape, recv_type.shape(), state, recompile);
                         // Current shape contains this ivar

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4611,6 +4611,8 @@ impl Function {
                             self.push_insn_id(block, insn_id); continue;
                         }
                         if self.policy.no_side_exits {
+                            // TODO: Support polymorphic DefinedIvar shape-specialized paths.
+                            // https://github.com/Shopify/ruby/issues/980
                             // On the final version, keep the DefinedIvar fallback instead of another shape guard.
                             self.push_insn_id(block, insn_id); continue;
                         }
@@ -4657,6 +4659,8 @@ impl Function {
                             self.push_insn_id(block, insn_id); continue;
                         }
                         if self.policy.no_side_exits {
+                            // TODO: Support polymorphic SetIvar shape-specialized paths.
+                            // https://github.com/Shopify/ruby/issues/927
                             // On the final version, keep the SetIvar fallback instead of another shape guard.
                             self.push_insn_id(block, insn_id); continue;
                         }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -7612,6 +7612,136 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_definedivar_shape_guard_recompile() {
+        // Call with one shape to compile, then call with a different shape to
+        // trigger shape guard exits and recompilation. On the recompiled version,
+        // DefinedIvar stays as a C call fallback to avoid more shape guard exits.
+        eval("
+            class C
+              def initialize(extra = false)
+                @bar = 0 if extra  # changes the shape
+                @foo = 42
+              end
+              def has_foo = defined?(@foo)
+            end
+
+            c = C.new
+            c.has_foo  # profile
+            c.has_foo  # compile (version 1 with shape guard)
+            d = C.new(true)  # same class, different shape
+            100.times { d.has_foo }  # trigger shape guard exits -> recompile
+            100.times { c.has_foo }  # run recompiled version (version 2)
+        ");
+        assert_snapshot!(hir_string_proc("C.new.method(:has_foo)"), @"
+        fn has_foo@<compiled>:7:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v10:StringExact|NilClass = DefinedIvar v6, :@foo
+          CheckInterrupts
+          Return v10
+        ");
+    }
+
+    #[test]
+    fn test_setivar_shape_guard_recompile() {
+        // Call with one shape to compile, then call with a different shape to
+        // trigger shape guard exits and recompilation. On the recompiled version,
+        // SetIvar stays as a C call fallback to avoid more shape guard exits.
+        eval("
+            class C
+              def initialize(extra = false)
+                @bar = 0 if extra  # changes the shape
+                @foo = 42
+              end
+              def foo = @foo = 5
+            end
+
+            c = C.new
+            c.foo  # profile
+            c.foo  # compile (version 1 with shape guard)
+            d = C.new(true)  # same class, different shape
+            100.times { d.foo }  # trigger shape guard exits -> recompile
+            100.times { c.foo }  # run recompiled version (version 2)
+        ");
+        assert_snapshot!(hir_string_proc("C.new.method(:foo)"), @"
+        fn foo@<compiled>:7:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          v10:Fixnum[5] = Const Value(5)
+          PatchPoint SingleRactorMode
+          SetIvar v6, :@foo, v10
+          CheckInterrupts
+          Return v10
+        ");
+    }
+
+    #[test]
+    fn test_setivar_shape_guard_attr_writer_no_recompile() {
+        // attr_writer SetIvar has no inline cache and may target a receiver
+        // operand other than CFP self, so don't recompile here yet.
+        eval("
+            class C
+              attr_writer :foo
+              def initialize(extra = false)
+                @bar = 0 if extra  # changes the shape
+                @foo = 42
+              end
+            end
+
+            class D
+              def write(obj)
+                obj.foo = 5
+              end
+            end
+
+            c = C.new
+            d = D.new
+            d.write(c)  # profile
+            d.write(c)  # compile (version 1 with shape guard)
+            e = C.new(true)  # same class, different shape
+            100.times { d.write(e) }  # shape guard exits, but no recompile
+        ");
+        assert_snapshot!(hir_string_proc("D.new.method(:write)"), @"
+        fn write@<compiled>:12:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :obj@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :obj@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v17:Fixnum[5] = Const Value(5)
+          PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
+          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v31:CShape = LoadField v28, :_shape_id@0x1040
+          v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
+          StoreField v28, :@foo@0x1042, v17
+          WriteBarrier v28, v17
+          CheckInterrupts
+          Return v17
+        ");
+    }
+
+    #[test]
     fn test_optimize_getivar_on_module_embedded() {
         eval("
             module M
@@ -13520,23 +13650,17 @@ mod hir_opt_tests {
          CheckInterrupts
          SetLocal :formatted, l0, EP@3, v16
          PatchPoint SingleRactorMode
-         v60:HeapBasicObject = GuardType v15, HeapBasicObject
-         v61:CShape = LoadField v60, :_shape_id@0x1003
-         v62:CShape[0x1004] = GuardBitEquals v61, CShape(0x1004)
-         StoreField v60, :@formatted@0x1005, v16
-         WriteBarrier v60, v16
-         v65:CShape[0x1006] = Const CShape(0x1006)
-         StoreField v60, :_shape_id@0x1003, v65
+         SetIvar v15, :@formatted, v16
          v47:Class[VMFrozenCore] = Const Value(VALUE(0x1008))
          PatchPoint MethodRedefined(Class@0x1010, lambda@0x1018, cme:0x1020)
-         v69:BasicObject = CCallWithFrame v47, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
+         v62:BasicObject = CCallWithFrame v47, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
          v50:CPtr = GetEP 0
          v51:BasicObject = LoadField v50, :a@0x1001
          v52:BasicObject = LoadField v50, :_b@0x1002
          v53:BasicObject = LoadField v50, :_c@0x1058
          v54:BasicObject = LoadField v50, :formatted@0x1059
          CheckInterrupts
-         Return v69
+         Return v62
        ");
     }
 


### PR DESCRIPTION
Closes: https://github.com/Shopify/ruby/issues/972

Profile self when setivar and definedivar shape guards fail, matching getivar's recompilation behavior.
On the final ISEQ version, keep the generic SetIvar/DefinedIvar fallback instead of emitting another shape guard that would keep side exiting. Polymorphic support for `SetIvar`, `DefinedIvar` will be handled separetely (https://github.com/Shopify/ruby/issues/927).

This increases zjit ratio in lobsters from 87.9% to 88.5%.

## Benchmark
### lobsters
Summary:
```diff
-Top-19 side exit reasons (100.0% of total 9,150,635):
+Top-19 side exit reasons (100.0% of total 8,680,640):
                    guard_type_failure: ...
-                  guard_shape_failure:   583,880 ( 6.4%)
+                  guard_shape_failure:     1,270 ( 0.0%)
                    unhandled_hir_insn: ...
                    compile_error: ...
 
-ratio_in_zjit:                                     87.9%
+ratio_in_zjit:                                     88.5%

```

Full stats details below:
<details>

<summary>before patch</summary>

```
  Top-19 side exit reasons (100.0% of total 9,150,635):
                   guard_type_failure: 7,592,690 (83.0%)
                  guard_shape_failure:   583,880 ( 6.4%)
                   unhandled_hir_insn:   256,606 ( 2.8%)
                        compile_error:   223,111 ( 2.4%)
          patchpoint_method_redefined:   117,003 ( 1.3%)
      block_param_proxy_fallback_miss:   112,551 ( 1.2%)
                      no_profile_send:    93,251 ( 1.0%)
            block_param_proxy_not_nil:    75,195 ( 0.8%)
     patchpoint_stable_constant_names:    43,493 ( 0.5%)
                  unhandled_block_arg:    14,107 ( 0.2%)
  block_param_proxy_not_iseq_or_ifunc:    13,392 ( 0.1%)
               fixnum_lshift_overflow:    10,165 ( 0.1%)
                   guard_less_failure:     9,537 ( 0.1%)
        patchpoint_no_singleton_class:     4,104 ( 0.0%)
             guard_greater_eq_failure:       941 ( 0.0%)
             guard_super_method_entry:       428 ( 0.0%)
                  unhandled_yarv_insn:       104 ( 0.0%)
                            interrupt:        61 ( 0.0%)
               obj_to_string_fallback:        16 ( 0.0%)
                             send_count: 183,622,411
                     dynamic_send_count:  22,650,575 (12.3%)
                   optimized_send_count: 160,971,836 (87.7%)
                  dynamic_setivar_count:   3,567,311 ( 1.9%)
                  dynamic_getivar_count:  11,745,066 ( 6.4%)
              dynamic_definedivar_count:     504,802 ( 0.3%)
              iseq_optimized_send_count:  54,192,276 (29.5%)
      inline_cfunc_optimized_send_count:  75,420,858 (41.1%)
       inline_iseq_optimized_send_count:   6,318,138 ( 3.4%)
non_variadic_cfunc_optimized_send_count:  14,036,950 ( 7.6%)
    variadic_cfunc_optimized_send_count:  11,003,614 ( 6.0%)
compiled_iseq_count:                               6,111
compiled_side_exit_count:                         79,180
failed_iseq_count:                                     3
compile_time:                                    2,331ms
compile_side_exit_time:                            117ms
compile_side_exit_time_ratio:                       5.0%
compile_hir_time:                                  633ms
compile_hir_build_time:                            209ms
compile_hir_strength_reduce_time:                  265ms
compile_hir_fold_constants_time:                    31ms
compile_hir_clean_cfg_time:                         17ms
compile_hir_eliminate_dead_code_time:               28ms
compile_lir_time:                                1,556ms
profile_time:                                       40ms
gc_time:                                            40ms
invalidation_time:                                  19ms
vm_write_pc_count:                           135,610,232
vm_write_sp_count:                           135,610,232
vm_write_locals_count:                       130,140,340
vm_write_stack_count:                        130,140,340
vm_write_to_parent_iseq_local_count:             687,475
guard_type_count:                            151,080,294
guard_type_exit_ratio:                              5.0%
guard_shape_count:                            41,313,573
guard_shape_exit_ratio:                             1.4%
load_field_count:                            213,046,913
store_field_count:                            19,440,452
side_exit_size:                               13,460,352
code_region_bytes:                            33,243,136
side_exit_size_ratio:                              40.5%
zjit_alloc_bytes:                             22,250,975
total_mem_bytes:                              55,494,111
side_exit_count:                               9,150,635
total_insn_count:                          1,004,538,016
vm_insn_count:                               121,319,975
zjit_insn_count:                             883,218,041
ratio_in_zjit:                                     87.9%

```

</details>

<details>

<summary>after patch</summary>

```
  Top-19 side exit reasons (100.0% of total 8,680,640):
                   guard_type_failure: 7,690,720 (88.6%)
                   unhandled_hir_insn:   256,619 ( 3.0%)
                        compile_error:   223,148 ( 2.6%)
          patchpoint_method_redefined:   117,018 ( 1.3%)
      block_param_proxy_fallback_miss:   112,821 ( 1.3%)
                      no_profile_send:    93,332 ( 1.1%)
            block_param_proxy_not_nil:    75,195 ( 0.9%)
     patchpoint_stable_constant_names:    43,840 ( 0.5%)
        patchpoint_no_singleton_class:    17,552 ( 0.2%)
                  unhandled_block_arg:    14,473 ( 0.2%)
  block_param_proxy_not_iseq_or_ifunc:    13,392 ( 0.2%)
               fixnum_lshift_overflow:    10,165 ( 0.1%)
                   guard_less_failure:     9,537 ( 0.1%)
                  guard_shape_failure:     1,270 ( 0.0%)
             guard_greater_eq_failure:       941 ( 0.0%)
             guard_super_method_entry:       428 ( 0.0%)
                  unhandled_yarv_insn:       104 ( 0.0%)
                            interrupt:        56 ( 0.0%)
               obj_to_string_fallback:        29 ( 0.0%)
                             send_count: 184,227,231
                     dynamic_send_count:  22,724,765 (12.3%)
                   optimized_send_count: 161,502,466 (87.7%)
                  dynamic_setivar_count:   4,217,523 ( 2.3%)
                  dynamic_getivar_count:  11,804,566 ( 6.4%)
              dynamic_definedivar_count:   1,290,278 ( 0.7%)
              iseq_optimized_send_count:  54,428,274 (29.5%)
      inline_cfunc_optimized_send_count:  75,665,244 (41.1%)
       inline_iseq_optimized_send_count:   6,374,351 ( 3.5%)
non_variadic_cfunc_optimized_send_count:  14,029,153 ( 7.6%)
    variadic_cfunc_optimized_send_count:  11,005,444 ( 6.0%)
compiled_iseq_count:                                 6,160
compiled_side_exit_count:                           81,050
failed_iseq_count:                                       3
compile_time:                                      2,445ms
compile_side_exit_time:                              123ms
compile_side_exit_time_ratio:                         5.1%
compile_hir_time:                                    656ms
compile_hir_build_time:                              220ms
compile_hir_strength_reduce_time:                    274ms
compile_hir_fold_constants_time:                      32ms
compile_hir_clean_cfg_time:                           17ms
compile_hir_eliminate_dead_code_time:                 29ms
compile_lir_time:                                  1,639ms
profile_time:                                         46ms
gc_time:                                              41ms
invalidation_time:                                    20ms
vm_write_pc_count:                             138,505,724
vm_write_sp_count:                             138,505,724
vm_write_locals_count:                         132,960,981
vm_write_stack_count:                          132,960,981
vm_write_to_parent_iseq_local_count:               687,619
guard_type_count:                              150,114,204
guard_type_exit_ratio:                                5.1%
guard_shape_count:                              39,218,847
guard_shape_exit_ratio:                               0.0%
load_field_count:                              211,038,264
store_field_count:                              15,929,557
side_exit_size:                                 13,769,600
code_region_bytes:                              33,914,880
side_exit_size_ratio:                                40.6%
zjit_alloc_bytes:                               22,924,623
total_mem_bytes:                                56,839,503
side_exit_count:                                 8,680,640
total_insn_count:                            1,004,152,028
vm_insn_count:                                 115,703,976
zjit_insn_count:                               888,448,052
ratio_in_zjit:                                       88.5%

```

</details>