### PR TITLE
Split test_freeze_inside_sort! and reduce comparator count

### DIFF
--- a/test/ruby/test_array.rb
+++ b/test/ruby/test_array.rb
@@ -1846,19 +1846,21 @@ class TestArray < Test::Unit::TestCase
     assert_equal([1, 2, 3, 4], a)
   end
 
-  def test_freeze_inside_sort!
+  def test_freeze_inside_sort_bang
     array = [1, 2, 3, 4, 5]
     frozen_array = nil
     assert_raise(FrozenError) do
       count = 0
       array.sort! do |a, b|
-        array.freeze if (count += 1) == 6
+        array.freeze if (count += 1) == 3
         frozen_array ||= array.map.to_a if array.frozen?
         b <=> a
       end
     end
     assert_equal(frozen_array, array)
+  end
 
+  def test_freeze_inside_sort_bang_non_numeric_block
     object = Object.new
     array = [1, 2, 3, 4, 5]
     object.define_singleton_method(:>){|_| array.freeze; true}
@@ -1867,7 +1869,9 @@ class TestArray < Test::Unit::TestCase
         object
       end
     end
+  end
 
+  def test_freeze_inside_sort_bang_non_numeric_no_block
     object = Object.new
     array = [object, object]
     object.define_singleton_method(:>){|_| array.freeze; true}


### PR DESCRIPTION
The first sub-test froze on the 6th comparator call. CRuby's insertion sort makes 10 comparisons reversing [1,2,3,4,5], but TimSort(JRuby, TruffleRuby) detects the descending run in 4 and never reaches 6 and the freeze line does nothing. Changed to 3 so the array is still frozen mid-sort but the test can be run on TimSort implementations too. 

Separately, three independent paths (block + numeric, block + non-numeric, no-block + non-numeric) were bundled into one method even though the tests had independent setup. Split into:

```
test_freeze_inside_sort_bang
test_freeze_inside_sort_bang_non_numeric_block
test_freeze_inside_sort_bang_non_numeric_no_block
```