### PR TITLE
ZJIT: Convert ZJIT HIR Extended basic blocks to traditional basic blocks

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -172,7 +172,7 @@ pub extern "C" fn rb_zjit_iseq_gen_entry_point(iseq: IseqPtr, ec: EcPtr, jit_exc
             // We assert only `jit_exception: false` cases until we support exception handlers.
             if ZJITState::assert_compiles_enabled() && !jit_exception {
                 let iseq_location = iseq_get_location(iseq, 0);
-                panic!("Failed to compile: {iseq_location}");
+                panic!("Failed to compile: {iseq_location}: {err:?}");
             }
 
             // For --zjit-stats, generate an entry that just increments exit_compilation_failure and exits
@@ -394,7 +394,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
         }
 
         // Compile each basic block
-        for (rpo_idx, &block_id) in reverse_post_order.iter().enumerate() {
+        for &block_id in reverse_post_order.iter() {
             // Skip the entries superblock — it's an internal CFG artifact
             if block_id == function.entries_block { continue; }
             // Set the current block to the LIR block that corresponds to this
@@ -437,11 +437,6 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
             for (insn_idx, &insn_id) in block.insns().enumerate() {
                 let insn = function.find(insn_id);
 
-                // IfTrue and IfFalse should never be terminators
-                if matches!(insn, Insn::IfTrue {..} | Insn::IfFalse {..}) {
-                    assert!(!insn.is_terminator(), "IfTrue/IfFalse should not be terminators");
-                }
-
                 match insn {
                     Insn::IfFalse { val, target } => {
 
@@ -449,50 +444,26 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
 
                         let lir_target = hir_to_lir[target.target.0].unwrap();
 
-                        let fall_through_target = asm.new_block(block_id, false, rpo_idx);
-
                         let branch_edge = lir::BranchEdge {
                             target: lir_target,
                             args: target.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()
                         };
 
-                        let fall_through_edge = lir::BranchEdge {
-                            target: fall_through_target,
-                            args: vec![]
-                        };
-
-                        gen_if_false(&mut asm, val_opnd, branch_edge, fall_through_edge);
+                        gen_if_false(&mut asm, val_opnd, branch_edge);
                         assert!(asm.current_block().insns.last().unwrap().is_terminator());
-
-                        asm.set_current_block(fall_through_target);
-
-                        let label = jit.get_label(&mut asm, fall_through_target, block_id);
-                        asm.write_label(label);
                     },
                     Insn::IfTrue { val, target } => {
                         let val_opnd = jit.get_opnd(val);
 
                         let lir_target = hir_to_lir[target.target.0].unwrap();
 
-                        let fall_through_target = asm.new_block(block_id, false, rpo_idx);
-
                         let branch_edge = lir::BranchEdge {
                             target: lir_target,
                             args: target.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()
                         };
 
-                        let fall_through_edge = lir::BranchEdge {
-                            target: fall_through_target,
-                            args: vec![]
-                        };
-
-                        gen_if_true(&mut asm, val_opnd, branch_edge, fall_through_edge);
+                        gen_if_true(&mut asm, val_opnd, branch_edge);
                         assert!(asm.current_block().insns.last().unwrap().is_terminator());
-
-                        asm.set_current_block(fall_through_target);
-
-                        let label = jit.get_label(&mut asm, fall_through_target, block_id);
-                        asm.write_label(label);
                     }
                     Insn::Jump(target) => {
                         let lir_target = hir_to_lir[target.target.0].unwrap();
@@ -1474,19 +1445,17 @@ fn gen_jump(asm: &mut Assembler, branch: lir::BranchEdge) {
 }
 
 /// Compile a conditional branch to a basic block
-fn gen_if_true(asm: &mut Assembler, val: lir::Opnd, branch: lir::BranchEdge, fall_through: lir::BranchEdge) {
+fn gen_if_true(asm: &mut Assembler, val: lir::Opnd, branch: lir::BranchEdge) {
     // If val is not zero, move on to the next instruction.
     asm.test(val, val);
     asm.push_insn(lir::Insn::Jnz(Target::Block(branch)));
-    asm.jmp(Target::Block(fall_through));
 }
 
 /// Compile a conditional branch to a basic block
-fn gen_if_false(asm: &mut Assembler, val: lir::Opnd, branch: lir::BranchEdge, fall_through: lir::BranchEdge) {
+fn gen_if_false(asm: &mut Assembler, val: lir::Opnd, branch: lir::BranchEdge) {
     // If val is zero, move on to the next instruction.
     asm.test(val, val);
     asm.push_insn(lir::Insn::Jz(Target::Block(branch)));
-    asm.jmp(Target::Block(fall_through));
 }
 
 /// Compile a dynamic dispatch with block

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -438,31 +438,25 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                 let insn = function.find(insn_id);
 
                 match insn {
-                    Insn::IfFalse { val, target } => {
-
+                    Insn::CondBranch { val, if_true, if_false } => {
                         let val_opnd = jit.get_opnd(val);
+                        let true_target = hir_to_lir[if_true.target.0].unwrap();
+                        let false_target = hir_to_lir[if_false.target.0].unwrap();
 
-                        let lir_target = hir_to_lir[target.target.0].unwrap();
-
-                        let branch_edge = lir::BranchEdge {
-                            target: lir_target,
-                            args: target.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()
+                        let true_branch = lir::BranchEdge {
+                            target: true_target,
+                            args: if_true.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()
                         };
 
-                        gen_if_false(&mut asm, val_opnd, branch_edge);
-                        assert!(asm.current_block().insns.last().unwrap().is_terminator());
-                    },
-                    Insn::IfTrue { val, target } => {
-                        let val_opnd = jit.get_opnd(val);
-
-                        let lir_target = hir_to_lir[target.target.0].unwrap();
-
-                        let branch_edge = lir::BranchEdge {
-                            target: lir_target,
-                            args: target.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()
+                        let false_branch = lir::BranchEdge {
+                            target: false_target,
+                            args: if_false.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()
                         };
 
-                        gen_if_true(&mut asm, val_opnd, branch_edge);
+                        asm.test(val_opnd, val_opnd);
+                        asm.push_insn(lir::Insn::Jnz(Target::Block(true_branch)));
+                        asm.jmp(Target::Block(false_branch));
+
                         assert!(asm.current_block().insns.last().unwrap().is_terminator());
                     }
                     Insn::Jump(target) => {
@@ -471,7 +465,7 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                             target: lir_target,
                             args: target.args.iter().map(|insn_id| jit.get_opnd(*insn_id)).collect()
                         };
-                        gen_jump(&mut asm, branch_edge);
+                        asm.jmp(Target::Block(branch_edge));
                         assert!(asm.current_block().insns.last().unwrap().is_terminator());
 
                         // Jump should always be the last instruction in an HIR block
@@ -750,7 +744,7 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         &Insn::ArrayMax { ref elements, state } => gen_array_max(jit, asm, opnds!(elements), &function.frame_state(state)),
         &Insn::ArrayMin { ref elements, state } => gen_array_min(jit, asm, opnds!(elements), &function.frame_state(state)),
         &Insn::Throw { state, .. } => return Err(state),
-        &Insn::IfFalse { .. } | Insn::IfTrue { .. }
+        &Insn::CondBranch { .. }
         | &Insn::Jump { .. } | Insn::Entries { .. } => unreachable!(),
     };
 
@@ -1436,26 +1430,6 @@ fn gen_param(asm: &mut Assembler, _idx: usize) -> lir::Opnd {
     let vreg = asm.new_block_param(VALUE_BITS);
     asm.current_block().add_parameter(vreg);
     vreg
-}
-
-/// Compile a jump to a basic block
-fn gen_jump(asm: &mut Assembler, branch: lir::BranchEdge) {
-    // Jump to the basic block
-    asm.jmp(Target::Block(branch));
-}
-
-/// Compile a conditional branch to a basic block
-fn gen_if_true(asm: &mut Assembler, val: lir::Opnd, branch: lir::BranchEdge) {
-    // If val is not zero, move on to the next instruction.
-    asm.test(val, val);
-    asm.push_insn(lir::Insn::Jnz(Target::Block(branch)));
-}
-
-/// Compile a conditional branch to a basic block
-fn gen_if_false(asm: &mut Assembler, val: lir::Opnd, branch: lir::BranchEdge) {
-    // If val is zero, move on to the next instruction.
-    asm.test(val, val);
-    asm.push_insn(lir::Insn::Jz(Target::Block(branch)));
 }
 
 /// Compile a dynamic dispatch with block

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -1475,18 +1475,18 @@ fn gen_jump(asm: &mut Assembler, branch: lir::BranchEdge) {
 
 /// Compile a conditional branch to a basic block
 fn gen_if_true(asm: &mut Assembler, val: lir::Opnd, branch: lir::BranchEdge, fall_through: lir::BranchEdge) {
-    // If val is zero, move on to the next instruction.
+    // If val is not zero, move on to the next instruction.
     asm.test(val, val);
-    asm.push_insn(lir::Insn::Jz(Target::Block(fall_through)));
-    asm.jmp(Target::Block(branch));
+    asm.push_insn(lir::Insn::Jnz(Target::Block(branch)));
+    asm.jmp(Target::Block(fall_through));
 }
 
 /// Compile a conditional branch to a basic block
 fn gen_if_false(asm: &mut Assembler, val: lir::Opnd, branch: lir::BranchEdge, fall_through: lir::BranchEdge) {
-    // If val is not zero, move on to the next instruction.
+    // If val is zero, move on to the next instruction.
     asm.test(val, val);
-    asm.push_insn(lir::Insn::Jnz(Target::Block(fall_through)));
-    asm.jmp(Target::Block(branch));
+    asm.push_insn(lir::Insn::Jz(Target::Block(branch)));
+    asm.jmp(Target::Block(fall_through));
 }
 
 /// Compile a dynamic dispatch with block

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2695,6 +2695,11 @@ impl Function {
             Insn::Jump(edge) => vec![edge.target],
             Insn::Entries { targets } => targets,
             Insn::Unreachable | Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. } => vec![],
+            // Blocks that don't end with terminators are technically errors,
+            // every block in the CFG should end with a terminator. But we
+            // want to be able to iterate over poorly constructed CFG when
+            // debugging, so we'll return an empty vec.  The validation
+            // routines check for terminators, so we should catch CFG errors there.
             _ => vec![]
         }
     }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5721,20 +5721,6 @@ impl Function {
             Ok(())
         };
 
-        // The `rpo` function calls `successors`, and `successors` will blow up
-        // if a block doesn't end with a terminator.  First we'll iterate
-        // through all blocks (regardless of reachability) and assert that they
-        // end with a terminator.  Then we should be safe to use `rpo`.
-        for (idx, block) in self.blocks.iter().enumerate() {
-            let insns = &block.insns;
-            if let Some(insn_id) = insns.last() {
-                let last = self.find(*insn_id);
-                if !last.is_terminator() {
-                    return Err(ValidationError::BlockHasNoTerminator(BlockId(idx)));
-                }
-            }
-        }
-
         for block_id in self.rpo() {
             let insns = &self.blocks[block_id.0].insns;
             for (idx, insn_id) in insns.iter().enumerate() {
@@ -5750,11 +5736,18 @@ impl Function {
                     }
                     _ => {}
                 }
+
                 if insn.is_terminator() {
                     // Blow up if we have a terminator that isn't at the end
                     // of the block.
                     if idx != insns.len() - 1 {
                         return Err(ValidationError::TerminatorNotAtEnd(block_id, *insn_id, idx))
+                    }
+                }
+                // If the last instruction isn't a terminator, return an error
+                if idx == insns.len() - 1 {
+                    if !insn.is_terminator() {
+                        return Err(ValidationError::BlockHasNoTerminator(block_id));
                     }
                 }
             }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7131,7 +7131,6 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let not_nil_false = fun.push_insn(block, Insn::RefineType { val, new_type: not_nil_false_type });
                     state.replace(val, not_nil_false);
                     queue.push_back((state.clone(), target, target_idx, local_inval));
-
                 }
                 YARVINSN_branchif | YARVINSN_branchif_without_ints => {
                     if opcode == YARVINSN_branchif {

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7,11 +7,11 @@
 #![allow(clippy::match_like_matches_macro)]
 use crate::{
     backend::lir::C_ARG_OPNDS,
-    cast::IntoUsize, codegen::{local_idx_to_ep_offset, max_iseq_versions}, cruby::*, invariants::{self}, payload::{get_or_create_iseq_payload, IseqPayload}, options::{debug, get_option, DumpHIR}, state::ZJITState, json::Json,
+    cast::IntoUsize, codegen::{local_idx_to_ep_offset, max_iseq_versions}, cruby::*, invariants::{self}, payload::{get_or_create_iseq_payload, IseqPayload}, options::{get_option, DumpHIR}, state::ZJITState, json::Json,
     state,
 };
 use std::{
-    cell::RefCell, collections::{BTreeSet, HashMap, HashSet, VecDeque}, ffi::{c_void, c_uint, c_int, CStr}, fmt::Display, mem::{align_of, size_of}, ptr, slice::Iter,
+    cell::RefCell, collections::{HashMap, HashSet, VecDeque}, ffi::{c_void, c_uint, c_int, CStr}, fmt::Display, mem::{align_of, size_of}, ptr, slice::Iter,
     sync::atomic::Ordering,
 };
 use crate::hir_type::{Type, types};
@@ -952,9 +952,8 @@ pub enum Insn {
     /// Unconditional jump
     Jump(BranchEdge),
 
-    /// Conditional branch instructions
-    IfTrue { val: InsnId, target: BranchEdge },
-    IfFalse { val: InsnId, target: BranchEdge },
+    /// Conditional branch
+    CondBranch { val: InsnId, if_true: BranchEdge, if_false: BranchEdge },
 
     /// Call a C function without pushing a frame
     /// `name` and `owner` are for printing purposes only
@@ -1328,10 +1327,10 @@ macro_rules! for_each_operand_impl {
             Insn::Jump(BranchEdge { args, .. }) => {
                 $visit_many!(args);
             }
-            Insn::IfTrue { val, target: BranchEdge { args, .. } }
-            | Insn::IfFalse { val, target: BranchEdge { args, .. } } => {
+            Insn::CondBranch { val, if_true: BranchEdge { args: true_args, .. }, if_false: BranchEdge { args: false_args, .. } } => {
                 $visit_one!(val);
-                $visit_many!(args);
+                $visit_many!(true_args);
+                $visit_many!(false_args);
             }
             Insn::ArrayDup { val, state }
             | Insn::Throw { val, state, .. }
@@ -1468,7 +1467,7 @@ impl Insn {
         match self {
             Insn::Jump(_)
             | Insn::Entries { .. }
-            | Insn::IfTrue { .. } | Insn::IfFalse { .. } | Insn::EntryPoint { .. } | Insn::Return { .. }
+            | Insn::CondBranch { .. } | Insn::EntryPoint { .. } | Insn::Return { .. }
             | Insn::PatchPoint { .. } | Insn::SetIvar { .. } | Insn::SetClassVar { .. } | Insn::ArrayExtend { .. }
             | Insn::ArrayPush { .. } | Insn::SideExit { .. } | Insn::SetGlobal { .. }
             | Insn::SetLocal { .. } | Insn::Throw { .. } | Insn::IncrCounter(_) | Insn::IncrCounterPtr { .. }
@@ -1482,7 +1481,7 @@ impl Insn {
     /// Return true if the instruction ends a basic block and false otherwise.
     pub fn is_terminator(&self) -> bool {
         match self {
-            Insn::Jump(_) | Insn::Entries { .. } | Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. } => true,
+            Insn::Unreachable | Insn::CondBranch { .. } | Insn::Jump(_) | Insn::Entries { .. } | Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. } => true,
             _ => false,
         }
     }
@@ -1490,7 +1489,7 @@ impl Insn {
     /// Return true if the instruction is a jump (has successor blocks in the CFG).
     pub fn is_jump(&self) -> bool {
         match self {
-            Insn::IfTrue { .. } | Insn::IfFalse { .. } | Insn::Jump(_) | Insn::Entries { .. } => true,
+            Insn::CondBranch { .. } | Insn::Jump(_) | Insn::Entries { .. } => true,
             _ => false,
         }
     }
@@ -1616,8 +1615,7 @@ impl Insn {
             Insn::GetBlockParam { .. } => effects::Any,
             Insn::Snapshot { .. } => effects::Empty,
             Insn::Jump(_) => effects::Any,
-            Insn::IfTrue { .. } => effects::Any,
-            Insn::IfFalse { .. } => effects::Any,
+            Insn::CondBranch { .. } => effects::Any,
             Insn::CCall { elidable, .. } => {
                 if *elidable {
                     Effect::write(abstract_heaps::Allocator)
@@ -1949,8 +1947,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::UnboxFixnum { val } => write!(f, "UnboxFixnum {val}"),
             Insn::FixnumAref { recv, index } => write!(f, "FixnumAref {recv}, {index}"),
             Insn::Jump(target) => { write!(f, "Jump {target}") }
-            Insn::IfTrue { val, target } => { write!(f, "IfTrue {val}, {target}") }
-            Insn::IfFalse { val, target } => { write!(f, "IfFalse {val}, {target}") }
+            Insn::CondBranch { val, if_true, if_false } => { write!(f, "CondBranch {val}, {if_true}, {if_false}") },
             Insn::SendDirect { recv, cd, iseq, args, block, .. } => {
                 let blockiseq = block.map(|bh| match bh { BlockHandler::BlockIseq(iseq) => iseq, BlockHandler::BlockArg => unreachable!() });
                 write!(f, "SendDirect {recv}, {:p}, :{} ({:?})", self.ptr_map.map_ptr(&blockiseq), ruby_call_method_name(*cd), self.ptr_map.map_ptr(iseq))?;
@@ -2694,19 +2691,27 @@ impl Function {
         let insns = &self.blocks[block.0].insns;
         let last = self.find(*insns.last().unwrap());
         match last {
-            Insn::Jump(_) => {
-                if insns.len() >= 2 && matches!(self.find(insns[insns.len() - 2]), Insn::IfTrue { .. } | Insn::IfFalse { .. }) {
-                    2
-                } else {
-                    1
-                }
-            }
+            Insn::CondBranch { .. } => 2,
+            Insn::Jump(_) => 1,
             Insn::Entries { targets } => targets.len(),
-            Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. } => 0,
-            _ => unreachable!("block doesn't end with a jump or terminator")
+            Insn::Unreachable | Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. } => 0,
+            _ => 0
+            // _ => unreachable!("block doesn't end with a jump or terminator")
         }
     }
 
+    fn successors(&self, block: BlockId) -> Vec<BlockId> {
+        let insns = &self.blocks[block.0].insns;
+        let last = self.find(*insns.last().unwrap());
+        match last {
+            Insn::CondBranch { if_true, if_false, .. } => vec![if_true.target, if_false.target],
+            Insn::Jump(edge) => vec![edge.target],
+            Insn::Entries { targets } => targets,
+            Insn::Unreachable | Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. } => vec![],
+            _ => vec![]
+            // _ => unreachable!("block doesn't end with a jump or terminator")
+        }
+    }
 
     /// Return a reference to the Block at the given index.
     pub fn block(&self, block_id: BlockId) -> &Block {
@@ -2847,7 +2852,7 @@ impl Function {
             Insn::Param => unimplemented!("params should not be present in block.insns"),
             Insn::LoadArg { val_type, .. } => *val_type,
             Insn::SetGlobal { .. } | Insn::Jump(_) | Insn::Entries { .. } | Insn::EntryPoint { .. }
-            | Insn::IfTrue { .. } | Insn::IfFalse { .. } | Insn::Return { .. } | Insn::Throw { .. }
+            | Insn::CondBranch { .. } | Insn::Return { .. } | Insn::Throw { .. }
             | Insn::PatchPoint { .. } | Insn::SetIvar { .. } | Insn::SetClassVar { .. } | Insn::ArrayExtend { .. }
             | Insn::ArrayPush { .. } | Insn::SideExit { .. } | Insn::SetLocal { .. }
             | Insn::IncrCounter(_) | Insn::IncrCounterPtr { .. }
@@ -3052,35 +3057,33 @@ impl Function {
                     let insn_id = self.blocks[block.0].insns[i];
                     // Instructions without output, including branch instructions, can't be targets
                     // of make_equal_to, so we don't need find() here.
-                    let insn_type = match &self.insns[insn_id.0] {
-                        &Insn::IfTrue { val, target: BranchEdge { target, ref args } } => {
+                    // Clone the insn so we don't hold a borrow on self.insns
+                    // across calls to set_type() below.
+                    let insn_type = match self.insns[insn_id.0].clone() {
+                        Insn::CondBranch { val, if_true, if_false } => {
                             assert!(!self.type_of(val).bit_equal(types::Empty));
                             if self.type_of(val).could_be(Type::from_cbool(true)) {
-                                reachable.insert(target);
+                                reachable.insert(if_true.target);
                                 // Snapshot arg types before any param updates so phi-style
                                 // updates happen in parallel (the args of a self-loop may name
                                 // params of `target` itself).
-                                let arg_types: Vec<Type> = args.iter().map(|a| self.type_of(*a)).collect();
+                                let arg_types: Vec<Type> = if_true.args.iter().map(|a| self.type_of(*a)).collect();
                                 for (idx, arg_type) in arg_types.into_iter().enumerate() {
-                                    let param = self.blocks[target.0].params[idx];
+                                    let param = self.blocks[if_true.target.0].params[idx];
                                     changed |= set_type(self, param, self.type_of(param).union(arg_type));
                                 }
                             }
-                            continue;
-                        }
-                        &Insn::IfFalse { val, target: BranchEdge { target, ref args } } => {
-                            assert!(!self.type_of(val).bit_equal(types::Empty));
                             if self.type_of(val).could_be(Type::from_cbool(false)) {
-                                reachable.insert(target);
-                                let arg_types: Vec<Type> = args.iter().map(|a| self.type_of(*a)).collect();
+                                reachable.insert(if_false.target);
+                                let arg_types: Vec<Type> = if_false.args.iter().map(|a| self.type_of(*a)).collect();
                                 for (idx, arg_type) in arg_types.into_iter().enumerate() {
-                                    let param = self.blocks[target.0].params[idx];
+                                    let param = self.blocks[if_false.target.0].params[idx];
                                     changed |= set_type(self, param, self.type_of(param).union(arg_type));
                                 }
                             }
                             continue;
                         }
-                        &Insn::Jump(BranchEdge { target, ref args }) => {
+                        Insn::Jump(BranchEdge { target, args }) => {
                             reachable.insert(target);
                             let arg_types: Vec<Type> = args.iter().map(|a| self.type_of(*a)).collect();
                             for (idx, arg_type) in arg_types.into_iter().enumerate() {
@@ -3090,7 +3093,7 @@ impl Function {
                             continue;
                         }
                         Insn::Entries { targets } => {
-                            for &target in targets {
+                            for target in targets {
                                 reachable.insert(target);
                             }
                             continue;
@@ -5265,16 +5268,12 @@ impl Function {
                     Insn::Test { val } if self.type_of(val).is_known_truthy() => {
                         self.new_insn(Insn::Const { val: Const::CBool(true) })
                     }
-                    Insn::IfTrue { val, target } if self.is_a(val, Type::from_cbool(true)) => {
-                        self.new_insn(Insn::Jump(target))
+                    Insn::CondBranch { val, if_true, .. } if self.is_a(val, Type::from_cbool(true)) => {
+                        self.new_insn(Insn::Jump(if_true))
                     }
-                    Insn::IfFalse { val, target } if self.is_a(val, Type::from_cbool(false)) => {
-                        self.new_insn(Insn::Jump(target))
+                    Insn::CondBranch { val, if_false, .. } if self.is_a(val, Type::from_cbool(false)) => {
+                        self.new_insn(Insn::Jump(if_false))
                     }
-                    // If we know that the branch condition is never going to cause a branch,
-                    // completely drop the branch from the block.
-                    Insn::IfTrue { val, .. } if self.is_a(val, Type::from_cbool(false)) => continue,
-                    Insn::IfFalse { val, .. } if self.is_a(val, Type::from_cbool(true)) => continue,
                     _ => insn_id,
                 };
                 // If we're adding a new instruction, mark the two equivalent in the union-find and
@@ -5362,22 +5361,8 @@ impl Function {
         // * blocks pointed to by blocks that get absorbed retain the same number of in-edges
         let mut num_in_edges = vec![0; self.blocks.len()];
         for block in self.rpo() {
-            for &insn in &self.blocks[block.0].insns {
-                // Instructions without output, including branch instructions, can't be targets of
-                // make_equal_to, so we don't need find() here.
-                match &self.insns[insn.0] {
-                    Insn::IfTrue { target: BranchEdge { target, .. }, .. }
-                    | Insn::IfFalse { target: BranchEdge { target, .. }, .. }
-                    | Insn::Jump(BranchEdge { target, .. }) => {
-                        num_in_edges[target.0] += 1;
-                    }
-                    Insn::Entries { targets } => {
-                        for target in targets {
-                            num_in_edges[target.0] += 1;
-                        }
-                    }
-                    _ => {}
-                }
+            for target in self.successors(block) {
+                num_in_edges[target.0] += 1;
             }
         }
         let mut changed = false;
@@ -5489,22 +5474,8 @@ impl Function {
             }
             if !seen.insert(block) { continue; }
             stack.push((block, Action::VisitSelf));
-            for insn_id in &self.blocks[block.0].insns {
-                // Instructions without output, including branch instructions, can't be targets of
-                // make_equal_to, so we don't need find() here.
-                match &self.insns[insn_id.0] {
-                    Insn::IfTrue { target, .. } | Insn::IfFalse { target, .. } | Insn::Jump(target) => {
-                        stack.push((target.target, Action::VisitEdges));
-                    }
-                    Insn::Entries { targets } => {
-                        for target in targets {
-                            stack.push((*target, Action::VisitEdges));
-                        }
-                    }
-                    _ => {
-                        debug_assert!(!self.find(*insn_id).is_jump(), "Instruction {:?} should not be in union-find; it has no output", insn_id);
-                    }
-                }
+            for target in self.successors(block) {
+                stack.push((target, Action::VisitEdges));
             }
         }
         result
@@ -5752,50 +5723,51 @@ impl Function {
     /// 2. Every terminator must be in the last position.
     /// 3. Every block must have a terminator.
     fn validate_block_terminators_and_jumps(&self) -> Result<(), ValidationError> {
+        let check_edge = |block_id: BlockId, edge: &BranchEdge| -> Result<(), ValidationError> {
+            let target_len = self.blocks[edge.target.0].params.len();
+            let args_len = edge.args.len();
+            if target_len != args_len {
+                return Err(ValidationError::MismatchedBlockArity(block_id, target_len, args_len));
+            }
+            Ok(())
+        };
+
+        // The `rpo` function calls `successors`, and `successors` will blow up
+        // if a block doesn't end with a terminator.  First we'll iterate
+        // through all blocks (regardless of reachability) and assert that they
+        // end with a terminator.  Then we should be safe to use `rpo`.
+        for (idx, block) in self.blocks.iter().enumerate() {
+            let insns = &block.insns;
+            if let Some(insn_id) = insns.last() {
+                let last = self.find(*insn_id);
+                if !last.is_terminator() {
+                    return Err(ValidationError::BlockHasNoTerminator(BlockId(idx)));
+                }
+            }
+        }
+
         for block_id in self.rpo() {
-            let mut block_has_terminator = false;
             let insns = &self.blocks[block_id.0].insns;
             for (idx, insn_id) in insns.iter().enumerate() {
                 let insn = self.find(*insn_id);
+                // Validate arity for all branch edges
                 match &insn {
-                    Insn::Jump(BranchEdge{target, args})
-                    | Insn::IfTrue { val: _, target: BranchEdge{target, args} }
-                    | Insn::IfFalse { val: _, target: BranchEdge{target, args}} => {
-                        let target_block = &self.blocks[target.0];
-                        let target_len = target_block.params.len();
-                        let args_len = args.len();
-                        if target_len != args_len {
-                            return Err(ValidationError::MismatchedBlockArity(block_id, target_len, args_len))
-                        }
+                    Insn::Jump(edge) => {
+                        check_edge(block_id, edge)?;
+                    }
+                    Insn::CondBranch { if_true, if_false, .. } => {
+                        check_edge(block_id, if_true)?;
+                        check_edge(block_id, if_false)?;
                     }
                     _ => {}
                 }
                 if insn.is_terminator() {
-                    block_has_terminator = true;
-
-                    match &insn {
-                        Insn::IfTrue { val: _, target: BranchEdge{ .. } }
-                        | Insn::IfFalse { val: _, target: BranchEdge{ .. }} => {
-                            // IfTrue / IfFalse should always be second to last
-                            if idx != insns.len() - 2 {
-                                return Err(ValidationError::TerminatorNotAtEnd(block_id, *insn_id, idx))
-                            }
-                            // The instruction after IfTrue/IfFalse must be a Jump
-                            if !matches!(self.find(insns[idx + 1]), Insn::Jump(_)) {
-                                return Err(ValidationError::TerminatorNotAtEnd(block_id, *insn_id, idx))
-                            }
-                        }
-                        _ => {
-                            // Jump etc should always be last
-                            if idx != insns.len() - 1 {
-                                return Err(ValidationError::TerminatorNotAtEnd(block_id, *insn_id, idx))
-                            }
-                        }
+                    // Blow up if we have a terminator that isn't at the end
+                    // of the block.
+                    if idx != insns.len() - 1 {
+                        return Err(ValidationError::TerminatorNotAtEnd(block_id, *insn_id, idx))
                     }
                 }
-            }
-            if !block_has_terminator {
-                return Err(ValidationError::BlockHasNoTerminator(block_id));
             }
         }
         Ok(())
@@ -5829,25 +5801,25 @@ impl Function {
             }
             for &insn_id in &self.blocks[block.0].insns {
                 let insn_id = self.union_find.borrow().find_const(insn_id);
-                match self.find(insn_id) {
-                    Insn::Jump(target) | Insn::IfTrue { target, .. } | Insn::IfFalse { target, .. } => {
-                        let Some(block_in) = assigned_in[target.target.0].as_mut() else {
-                            return Err(ValidationError::JumpTargetNotInRPO(target.target));
-                        };
-                        // jump target's block_in was modified, we need to queue the block for processing.
-                        if block_in.intersect_with(&assigned) {
-                            worklist.push_back(target.target);
-                        }
+                let insn = self.find(insn_id);
+                let mut propagate = |target: BlockId| -> Result<(), ValidationError> {
+                    let Some(block_in) = assigned_in[target.0].as_mut() else {
+                        return Err(ValidationError::JumpTargetNotInRPO(target));
+                    };
+                    if block_in.intersect_with(&assigned) {
+                        worklist.push_back(target);
+                    }
+                    Ok(())
+                };
+                match insn {
+                    Insn::Jump(edge) => propagate(edge.target)?,
+                    Insn::CondBranch { if_true, if_false, .. } => {
+                        propagate(if_true.target)?;
+                        propagate(if_false.target)?;
                     }
                     Insn::Entries { ref targets } => {
                         for &target in targets {
-                            let Some(block_in) = assigned_in[target.0].as_mut() else {
-                                return Err(ValidationError::JumpTargetNotInRPO(target));
-                            };
-                            // jump target's block_in was modified, we need to queue the block for processing.
-                            if block_in.intersect_with(&assigned) {
-                                worklist.push_back(target);
-                            }
+                            propagate(target)?;
                         }
                     }
                     insn if insn.has_output() => {
@@ -6105,8 +6077,7 @@ impl Function {
                 }
             }
             Insn::BoxBool { val }
-            | Insn::IfTrue { val, .. }
-            | Insn::IfFalse { val, .. } => {
+            | Insn::CondBranch { val, .. } => {
                 self.assert_subtype(insn_id, val, types::CBool)
             }
             Insn::BoxFixnum { val, .. } => self.assert_subtype(insn_id, val, types::CInt64),
@@ -7162,16 +7133,13 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let nil_false = fun.push_insn(block, Insn::RefineType { val, new_type: nil_false_type });
                     let mut iffalse_state = state.clone();
                     iffalse_state.replace(val, nil_false);
-                    let _branch_id = fun.push_insn(block, Insn::IfFalse {
-                        val: test_id,
-                        target: BranchEdge { target, args: iffalse_state.as_args(self_param) }
-                    });
-
                     let fall_through = fun.new_block(insn_idx);
 
-                    fun.push_insn(block, Insn::Jump(
-                            BranchEdge { target: fall_through, args: vec![] }
-                    ));
+                    fun.push_insn(block, Insn::CondBranch {
+                        val: test_id,
+                        if_true: BranchEdge { target: fall_through, args: vec![] },
+                        if_false: BranchEdge { target, args: iffalse_state.as_args(self_param) }
+                    });
 
                     block = fall_through;
 
@@ -7194,16 +7162,14 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let not_nil_false = fun.push_insn(block, Insn::RefineType { val, new_type: not_nil_false_type });
                     let mut iftrue_state = state.clone();
                     iftrue_state.replace(val, not_nil_false);
-                    let _branch_id = fun.push_insn(block, Insn::IfTrue {
-                        val: test_id,
-                        target: BranchEdge { target, args: iftrue_state.as_args(self_param) }
-                    });
 
                     let fall_through = fun.new_block(insn_idx);
 
-                    let _fall_through_id = fun.push_insn(block, Insn::Jump(
-                            BranchEdge { target: fall_through, args: vec![] }
-                    ));
+                    fun.push_insn(block, Insn::CondBranch {
+                        val: test_id,
+                        if_true: BranchEdge { target, args: iftrue_state.as_args(self_param) },
+                        if_false: BranchEdge { target: fall_through, args: vec![] }
+                    });
 
                     block = fall_through;
 
@@ -7224,16 +7190,14 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let nil = fun.push_insn(block, Insn::Const { val: Const::Value(Qnil) });
                     let mut iftrue_state = state.clone();
                     iftrue_state.replace(val, nil);
-                    let _branch_id = fun.push_insn(block, Insn::IfTrue {
-                        val: test_id,
-                        target: BranchEdge { target, args: iftrue_state.as_args(self_param) }
-                    });
 
                     let fall_through = fun.new_block(insn_idx);
 
-                    let _fall_through_id = fun.push_insn(block, Insn::Jump(
-                            BranchEdge { target: fall_through, args: vec![] }
-                    ));
+                    fun.push_insn(block, Insn::CondBranch {
+                        val: test_id,
+                        if_true: BranchEdge { target, args: iftrue_state.as_args(self_param) },
+                        if_false: BranchEdge { target: fall_through, args: vec![] }
+                    });
 
                     block = fall_through;
                     let new_type = types::NotNil;
@@ -7261,17 +7225,12 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     // Skip CheckInterrupts since the #new call will do it very soon anyway.
                     let target_idx = insn_idx_at_offset(insn_idx, dst);
                     let target = insn_idx_to_block[&target_idx];
-                    let _branch_id = fun.push_insn(block, Insn::IfFalse {
-                        val: test_id,
-                        target: BranchEdge { target, args: state.as_args(self_param) }
-                    });
-
                     let fall_through = fun.new_block(insn_idx);
-
-                    let _fall_through_id = fun.push_insn(block, Insn::Jump(
-                            BranchEdge { target: fall_through, args: vec![] }
-                    ));
-
+                    fun.push_insn(block, Insn::CondBranch {
+                        val: test_id,
+                        if_true: BranchEdge { target: fall_through, args: vec![] },
+                        if_false: BranchEdge { target, args: state.as_args(self_param) }
+                    });
                     block = fall_through;
                     queue.push_back((state.clone(), target, target_idx, local_inval));
 
@@ -7430,8 +7389,11 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let flags = fun.load_ep_flags(block, ep);
                     let is_modified = fun.push_insn(block, Insn::IsBlockParamModified { flags });
 
-                    fun.push_insn(block, Insn::IfTrue { val: is_modified, target: BranchEdge { target: modified_block, args: vec![] }});
-                    fun.push_insn(block, Insn::Jump(BranchEdge { target: unmodified_block, args: vec![] }));
+                    fun.push_insn(block, Insn::CondBranch {
+                        val: is_modified,
+                        if_true: BranchEdge { target: modified_block, args: vec![] },
+                        if_false: BranchEdge { target: unmodified_block, args: vec![] }
+                    });
 
                     // Push modified block: load the block local via EP.
                     let modified_val = fun.get_local_from_ep(modified_block, ep, ep_offset, level, types::BasicObject);
@@ -7536,16 +7498,15 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                                             left: block_handler,
                                             right: none_handler,
                                         });
-                                        fun.push_insn(current_block, Insn::IfTrue {
-                                            val: is_none,
-                                            target: BranchEdge { target: profiled_block, args: vec![] },
-                                        });
 
                                         let next_block = fun.new_block(branch_insn_idx);
 
-                                        fun.push_insn(current_block, Insn::Jump(
-                                            BranchEdge { target: next_block, args: vec![] },
-                                        ));
+                                        fun.push_insn(current_block, Insn::CondBranch {
+                                            val: is_none,
+                                            if_true: BranchEdge { target: profiled_block, args: vec![] },
+                                            if_false: BranchEdge { target: next_block, args: vec![] },
+                                        });
+
                                         current_block = next_block;
 
                                         let val = fun.push_insn(profiled_block, Insn::Const { val: Const::Value(Qnil) });
@@ -7569,14 +7530,12 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                                             left: tag_bits,
                                             right: tag_mask,
                                         });
-                                        fun.push_insn(current_block, Insn::IfTrue {
-                                            val: is_iseq_or_ifunc,
-                                            target: BranchEdge { target: profiled_block, args: vec![] },
-                                        });
                                         let next_block = fun.new_block(branch_insn_idx);
-                                        fun.push_insn(current_block, Insn::Jump(
-                                            BranchEdge { target: next_block, args: vec![] },
-                                        ));
+                                        fun.push_insn(current_block, Insn::CondBranch {
+                                            val: is_iseq_or_ifunc,
+                                            if_true: BranchEdge { target: profiled_block, args: vec![] },
+                                            if_false: BranchEdge { target: next_block, args: vec![] },
+                                        });
                                         current_block = next_block;
 
                                         // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
@@ -7616,14 +7575,11 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let flags = fun.load_ep_flags(block, ep);
                     let is_modified = fun.push_insn(block, Insn::IsBlockParamModified { flags });
 
-                    fun.push_insn(block, Insn::IfTrue {
+                    fun.push_insn(block, Insn::CondBranch {
                         val: is_modified,
-                        target: BranchEdge { target: modified_block, args: vec![] },
+                        if_true: BranchEdge { target: modified_block, args: vec![] },
+                        if_false: BranchEdge { target: unmodified_block, args: vec![] }
                     });
-                    fun.push_insn(block, Insn::Jump(BranchEdge {
-                        target: unmodified_block,
-                        args: vec![],
-                    }));
 
                     // Push modified block: read Proc from EP.
                     let modified_val = fun.get_local_from_ep(modified_block, ep, ep_offset, level, types::BasicObject);
@@ -7880,11 +7836,12 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                                 let iftrue_block =
                                     new_branch_block(&mut fun, cd, argc as usize, opcode, expected, branch_insn_idx, &exit_state, locals_count, stack_count, join_block);
                                 let target = BranchEdge { target: iftrue_block, args: entry_args.clone() };
-                                fun.push_insn(block, Insn::IfTrue { val: has_type, target });
                                 let fall_through = fun.new_block(insn_idx);
-                                fun.push_insn(block, Insn::Jump(
-                                        BranchEdge { target: fall_through, args: vec![] }
-                                ));
+                                fun.push_insn(block, Insn::CondBranch {
+                                    val: has_type,
+                                    if_true: target,
+                                    if_false: BranchEdge { target: fall_through, args: vec![] }
+                                });
                                 block = fall_through;
                             }
                             // Continue compilation from the join block at the next instruction.
@@ -8152,11 +8109,13 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         let join_block = fun.new_block(insn_idx);
                         let join_param = fun.push_insn(join_block, Insn::Param);
                         let ifunc_block = fun.new_block(insn_idx);
-                        fun.push_insn(block, Insn::IfTrue { val: is_ifunc_match, target: BranchEdge { target: ifunc_block, args: vec![] } });
                         let fall_through = fun.new_block(insn_idx);
-                        fun.push_insn(block, Insn::Jump(
-                                BranchEdge { target: fall_through, args: vec![] }
-                        ));
+
+                        fun.push_insn(block, Insn::CondBranch {
+                            val: is_ifunc_match,
+                            if_true: BranchEdge { target: ifunc_block, args: vec![] },
+                            if_false: BranchEdge { target: fall_through, args: vec![] },
+                        });
 
                         block = fall_through;
 
@@ -8235,9 +8194,13 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             let has_shape_and_type = fun.push_insn(block, Insn::IsBitEqual { left: masked, right: expected_rbasic_flags });
                             let iftrue_block = fun.new_block(insn_idx);
                             let target = BranchEdge { target: iftrue_block, args: vec![] };
-                            fun.push_insn(block, Insn::IfTrue { val: has_shape_and_type, target });
                             let fall_through = fun.new_block(insn_idx);
-                            fun.push_insn(block, Insn::Jump(BranchEdge { target: fall_through, args: vec![] }));
+
+                            fun.push_insn(block, Insn::CondBranch { val: has_shape_and_type,
+                                if_true: target,
+                                if_false: BranchEdge { target: fall_through, args: vec![] }
+                            });
+
                             block = fall_through;
                             let result = fun.load_ivar(iftrue_block, self_param, profiled_type, id, exit_id);
                             fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
@@ -8479,15 +8442,15 @@ fn compile_entry_block(fun: &mut Function, jit_entry_insns: &[u32], insn_idx_to_
             val: Const::CPtr(unsafe { rb_iseq_pc_at_idx(fun.iseq, jit_entry_insn) } as *const u8),
         });
         let test_id = fun.push_insn(entry_block, Insn::IsBitEqual { left: pc, right: expected_pc });
-        fun.push_insn(entry_block, Insn::IfTrue {
-            val: test_id,
-            target: BranchEdge { target: target_block, args: entry_state.as_args(self_param) },
-        });
+
         // TODO: is this the right insn index??
         let fall_through = fun.new_block(jit_entry_insn);
-        let _fall_through_id = fun.push_insn(entry_block, Insn::Jump(
-                BranchEdge { target: fall_through, args: vec![] }
-        ));
+
+        fun.push_insn(entry_block, Insn::CondBranch {
+            val: test_id,
+            if_true: BranchEdge { target: target_block, args: entry_state.as_args(self_param) },
+            if_false: BranchEdge { target: fall_through, args: vec![] }
+        });
         entry_block = fall_through;
     }
 
@@ -8741,34 +8704,10 @@ impl<'a> ControlFlowInfo<'a> {
     pub fn new(function: &'a Function) -> Self {
         let mut successor_map: HashMap<BlockId, Vec<BlockId>> = HashMap::new();
         let mut predecessor_map: HashMap<BlockId, Vec<BlockId>> = HashMap::new();
-        let uf = function.union_find.borrow();
 
         for block_id in function.rpo() {
-            let block = &function.blocks[block_id.0];
-
-            // Since ZJIT uses extended basic blocks, one must check all instructions
-            // for their ability to jump to another basic block, rather than just
-            // the instructions at the end of a given basic block.
-            //
-            // Use BTreeSet to avoid duplicates and maintain an ordering. Also
-            // `BTreeSet<BlockId>` provides conversion trivially back to an `Vec<BlockId>`.
-            // Ordering is important so that the expect tests that serialize the predecessors
-            // and successors don't fail intermittently.
-            // todo(aidenfoxivey): Use `BlockSet` in lieu of `BTreeSet<BlockId>`
-            let mut successors: BTreeSet<BlockId> = BTreeSet::new();
-            for &insn_id in &block.insns {
-                let insn_id = uf.find_const(insn_id);
-                match &function.insns[insn_id.0] {
-                    Insn::Entries { targets } => {
-                        successors.extend(targets);
-                    }
-                    insn => {
-                        if let Some(target) = Self::extract_jump_target(insn) {
-                            successors.insert(target);
-                        }
-                    }
-                }
-            }
+            let mut successors = function.successors(block_id);
+            successors.dedup();
 
             // Update predecessors for successor blocks.
             for &succ_id in &successors {
@@ -8779,8 +8718,7 @@ impl<'a> ControlFlowInfo<'a> {
             }
 
             // Store successors for this block.
-            // Convert successors from a `BTreeSet<BlockId>` to a `Vec<BlockId>`.
-            successor_map.insert(block_id, successors.iter().copied().collect());
+            successor_map.insert(block_id, successors);
         }
 
         Self {
@@ -8804,16 +8742,6 @@ impl<'a> ControlFlowInfo<'a> {
 
     pub fn successors(&self, block: BlockId) -> impl Iterator<Item = BlockId> {
         self.successor_map.get(&block).into_iter().flatten().copied()
-    }
-
-    /// Helper function to extract the target of a jump instruction.
-    fn extract_jump_target(insn: &Insn) -> Option<BlockId> {
-        match insn {
-            Insn::Jump(target)
-            | Insn::IfTrue { target, .. }
-            | Insn::IfFalse { target, .. } => Some(target.target),
-            _ => None,
-        }
     }
 }
 
@@ -8965,8 +8893,8 @@ mod rpo_tests {
         let entry = function.entry_block;
         let exit = function.new_block(0);
         function.push_insn(entry, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
-        let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
-        function.push_insn(entry, Insn::Return { val });
+        let val = function.push_insn(exit, Insn::Const { val: Const::Value(Qnil) });
+        function.push_insn(exit, Insn::Return { val });
         function.seal_entries();
         assert_eq!(function.rpo(), vec![entries, entry, exit]);
     }
@@ -8980,10 +8908,13 @@ mod rpo_tests {
         let exit = function.new_block(0);
         function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
-        function.push_insn(entry, Insn::IfTrue { val, target: BranchEdge { target: side, args: vec![] } });
-        function.push_insn(entry, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
-        let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
-        function.push_insn(entry, Insn::Return { val });
+        function.push_insn(entry, Insn::CondBranch {
+            val,
+            if_true: BranchEdge { target: side, args: vec![] },
+            if_false: BranchEdge { target: exit, args: vec![] }
+        });
+        let val = function.push_insn(exit, Insn::Const { val: Const::Value(Qnil) });
+        function.push_insn(exit, Insn::Return { val });
         function.seal_entries();
         assert_eq!(function.rpo(), vec![entries, entry, side, exit]);
     }
@@ -8997,10 +8928,13 @@ mod rpo_tests {
         let exit = function.new_block(0);
         function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
-        function.push_insn(entry, Insn::IfFalse { val, target: BranchEdge { target: side, args: vec![] } });
-        function.push_insn(entry, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
-        let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
-        function.push_insn(entry, Insn::Return { val });
+        function.push_insn(entry, Insn::CondBranch {
+            val,
+            if_true: BranchEdge { target: exit, args: vec![] },
+            if_false: BranchEdge { target: side, args: vec![] },
+        });
+        let val = function.push_insn(exit, Insn::Const { val: Const::Value(Qnil) });
+        function.push_insn(exit, Insn::Return { val });
         function.seal_entries();
         assert_eq!(function.rpo(), vec![entries, entry, side, exit]);
     }
@@ -9046,6 +8980,7 @@ mod validation_tests {
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
         let insn_id = function.push_insn(entry, Insn::Return { val });
         function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
+        function.push_insn(entry, Insn::Unreachable);
         function.seal_entries();
         assert_matches_err(function.validate(), ValidationError::TerminatorNotAtEnd(entry, insn_id, 1));
     }
@@ -9056,11 +8991,14 @@ mod validation_tests {
         let entry = function.entry_block;
         let side = function.new_block(0);
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
-        function.push_insn(entry, Insn::IfTrue { val, target: BranchEdge { target: side, args: vec![val, val, val] } });
         let fall_through = function.new_block(1);
-        function.push_insn(entry, Insn::Jump(
-                BranchEdge { target: fall_through, args: vec![] }
-        ));
+        function.push_insn(fall_through, Insn::Unreachable);
+        function.push_insn(side, Insn::Unreachable);
+        function.push_insn(entry, Insn::CondBranch {
+            val,
+            if_true: BranchEdge { target: side, args: vec![val, val, val] },
+            if_false: BranchEdge { target: fall_through, args: vec![] }
+        });
         function.seal_entries();
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(entry, 0, 3));
     }
@@ -9071,11 +9009,14 @@ mod validation_tests {
         let entry = function.entry_block;
         let side = function.new_block(0);
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
-        function.push_insn(entry, Insn::IfFalse { val, target: BranchEdge { target: side, args: vec![val, val, val] } });
         let fall_through = function.new_block(1);
-        function.push_insn(entry, Insn::Jump(
-                BranchEdge { target: fall_through, args: vec![] }
-        ));
+        function.push_insn(fall_through, Insn::Unreachable);
+        function.push_insn(side, Insn::Unreachable);
+        function.push_insn(entry, Insn::CondBranch {
+            val,
+            if_true: BranchEdge { target: fall_through, args: vec![] },
+            if_false: BranchEdge { target: side, args: vec![val, val, val] },
+        });
         function.seal_entries();
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(entry, 0, 3));
     }
@@ -9087,6 +9028,7 @@ mod validation_tests {
         let side = function.new_block(0);
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(entry, Insn::Jump ( BranchEdge { target: side, args: vec![val, val, val] } ));
+        function.push_insn(side, Insn::Unreachable);
         function.seal_entries();
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(entry, 0, 3));
     }
@@ -9098,6 +9040,7 @@ mod validation_tests {
         // Create an instruction without making it belong to anything.
         let dangling = function.new_insn(Insn::Const{val: Const::CBool(true)});
         let val = function.push_insn(function.entry_block, Insn::ArrayDup { val: dangling, state: InsnId(0usize) });
+        function.push_insn(function.entry_block, Insn::Unreachable);
         function.seal_entries();
         assert_matches_err(function.validate_definite_assignment(), ValidationError::OperandNotDefined(entry, val, dangling));
     }
@@ -9110,6 +9053,7 @@ mod validation_tests {
         // Ret is a non-output instruction.
         let ret = function.push_insn(function.entry_block, Insn::Return { val: const_ });
         let val = function.push_insn(function.entry_block, Insn::ArrayDup { val: ret, state: InsnId(0usize) });
+        function.push_insn(function.entry_block, Insn::Unreachable);
         function.seal_entries();
         assert_matches_err(function.validate_definite_assignment(), ValidationError::OperandNotDefined(entry, val, ret));
     }
@@ -9124,9 +9068,15 @@ mod validation_tests {
         let v0 = function.push_insn(side, Insn::Const { val: Const::Value(VALUE::fixnum_from_usize(3)) });
         function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
         let val1 = function.push_insn(entry, Insn::Const { val: Const::CBool(false) });
-        function.push_insn(entry, Insn::IfFalse { val: val1, target: BranchEdge { target: side, args: vec![] } });
-        function.push_insn(entry, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
+        function.push_insn(entry, Insn::CondBranch {
+            val: val1,
+            if_true: BranchEdge { target: exit, args: vec![] },
+            if_false: BranchEdge { target: side, args: vec![] },
+        });
         let val2 = function.push_insn(exit, Insn::ArrayDup { val: v0, state: v0 });
+        let const_ = function.push_insn(exit, Insn::Const{val: Const::CBool(true)});
+        function.push_insn(exit, Insn::Return { val: const_ });
+
         function.seal_entries();
         crate::cruby::with_rubyvm(|| {
             function.infer_types();
@@ -9144,9 +9094,14 @@ mod validation_tests {
         let v0 = function.push_insn(entry, Insn::Const { val: Const::Value(VALUE::fixnum_from_usize(3)) });
         function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
         let val = function.push_insn(entry, Insn::Const { val: Const::CBool(false) });
-        function.push_insn(entry, Insn::IfFalse { val, target: BranchEdge { target: side, args: vec![] } });
-        function.push_insn(entry, Insn::Jump(BranchEdge { target: exit, args: vec![] }));
+        function.push_insn(entry, Insn::CondBranch {
+            val,
+            if_true: BranchEdge { target: exit, args: vec![] },
+            if_false: BranchEdge { target: side, args: vec![] }
+        });
         let _val = function.push_insn(exit, Insn::ArrayDup { val: v0, state: v0 });
+        let const_ = function.push_insn(exit, Insn::Const{val: Const::CBool(true)});
+        function.push_insn(exit, Insn::Return { val: const_ });
         function.seal_entries();
         crate::cruby::with_rubyvm(|| {
             function.infer_types();
@@ -9213,6 +9168,7 @@ mod infer_tests {
     fn test_const() {
         let mut function = Function::new(std::ptr::null());
         let val = function.push_insn(function.entry_block, Insn::Const { val: Const::Value(Qnil) });
+        function.push_insn(function.entry_block, Insn::Unreachable);
         assert_bit_equal(function.infer_type(val), types::NilClass);
     }
 
@@ -9222,6 +9178,7 @@ mod infer_tests {
             let mut function = Function::new(std::ptr::null());
             let nil = function.push_insn(function.entry_block, Insn::Const { val: Const::Value(Qnil) });
             let val = function.push_insn(function.entry_block, Insn::Test { val: nil });
+            function.push_insn(function.entry_block, Insn::Unreachable);
             function.seal_entries();
             function.infer_types();
             assert_bit_equal(function.type_of(val), Type::from_cbool(false));
@@ -9234,6 +9191,7 @@ mod infer_tests {
             let mut function = Function::new(std::ptr::null());
             let false_ = function.push_insn(function.entry_block, Insn::Const { val: Const::Value(Qfalse) });
             let val = function.push_insn(function.entry_block, Insn::Test { val: false_ });
+            function.push_insn(function.entry_block, Insn::Unreachable);
             function.seal_entries();
             function.infer_types();
             assert_bit_equal(function.type_of(val), Type::from_cbool(false));
@@ -9246,6 +9204,7 @@ mod infer_tests {
             let mut function = Function::new(std::ptr::null());
             let true_ = function.push_insn(function.entry_block, Insn::Const { val: Const::Value(Qtrue) });
             let val = function.push_insn(function.entry_block, Insn::Test { val: true_ });
+            function.push_insn(function.entry_block, Insn::Unreachable);
             function.seal_entries();
             function.infer_types();
             assert_bit_equal(function.type_of(val), Type::from_cbool(true));
@@ -9278,15 +9237,19 @@ mod infer_tests {
         let v0 = function.push_insn(side, Insn::Const { val: Const::Value(VALUE::fixnum_from_usize(3)) });
         function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![v0] }));
         let val = function.push_insn(entry, Insn::Const { val: Const::CBool(false) });
-        function.push_insn(entry, Insn::IfFalse { val, target: BranchEdge { target: side, args: vec![] } });
         let v1 = function.push_insn(entry, Insn::Const { val: Const::Value(VALUE::fixnum_from_usize(4)) });
-        function.push_insn(entry, Insn::Jump(BranchEdge { target: exit, args: vec![v1] }));
+        function.push_insn(entry, Insn::CondBranch {
+            val,
+            if_true: BranchEdge { target: exit, args: vec![v1] },
+            if_false: BranchEdge { target: side, args: vec![] },
+        });
         let param = function.push_insn(exit, Insn::Param);
+        function.push_insn(exit, Insn::Unreachable);
         function.seal_entries();
         crate::cruby::with_rubyvm(|| {
             function.infer_types();
         });
-        assert_bit_equal(function.type_of(param), types::Fixnum);
+        assert_bit_equal(function.type_of(param), Type::fixnum(3));
     }
 
     #[test]
@@ -9345,14 +9308,18 @@ mod infer_tests {
         let v0 = function.push_insn(side, Insn::Const { val: Const::Value(Qtrue) });
         function.push_insn(side, Insn::Jump(BranchEdge { target: exit, args: vec![v0] }));
         let val = function.push_insn(entry, Insn::Const { val: Const::CBool(false) });
-        function.push_insn(entry, Insn::IfFalse { val, target: BranchEdge { target: side, args: vec![] } });
         let v1 = function.push_insn(entry, Insn::Const { val: Const::Value(Qfalse) });
-        function.push_insn(entry, Insn::Jump(BranchEdge { target: exit, args: vec![v1] }));
+        function.push_insn(entry, Insn::CondBranch {
+            val,
+            if_true: BranchEdge { target: exit, args: vec![v1] },
+            if_false: BranchEdge { target: side, args: vec![] },
+        });
         let param = function.push_insn(exit, Insn::Param);
+        function.push_insn(exit, Insn::Unreachable);
         function.seal_entries();
         crate::cruby::with_rubyvm(|| {
             function.infer_types();
-            assert_bit_equal(function.type_of(param), types::TrueClass.union(types::FalseClass));
+            assert_bit_equal(function.type_of(param), types::TrueClass);
         });
     }
 }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2690,6 +2690,24 @@ impl Function {
         self.blocks.pop();
     }
 
+    fn num_successors(&self, block: BlockId) -> usize {
+        let insns = &self.blocks[block.0].insns;
+        let last = self.find(*insns.last().unwrap());
+        match last {
+            Insn::Jump(_) => {
+                if insns.len() >= 2 && matches!(self.find(insns[insns.len() - 2]), Insn::IfTrue { .. } | Insn::IfFalse { .. }) {
+                    2
+                } else {
+                    1
+                }
+            }
+            Insn::Entries { targets } => targets.len(),
+            Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. } => 0,
+            _ => unreachable!("block doesn't end with a jump or terminator")
+        }
+    }
+
+
     /// Return a reference to the Block at the given index.
     pub fn block(&self, block_id: BlockId) -> &Block {
         &self.blocks[block_id.0]
@@ -5307,6 +5325,9 @@ impl Function {
     }
 
     fn absorb_dst_block(&mut self, num_in_edges: &[u32], block: BlockId) -> bool {
+        if self.num_successors(block) > 1 {
+            return false;
+        }
         let Some(terminator_id) = self.blocks[block.0].insns.last()
             else { return false };
         let Insn::Jump(BranchEdge { target, args }) = self.find(*terminator_id)
@@ -5749,12 +5770,28 @@ impl Function {
                     }
                     _ => {}
                 }
-                if !insn.is_terminator() {
-                    continue;
-                }
-                block_has_terminator = true;
-                if idx != insns.len() - 1 {
-                    return Err(ValidationError::TerminatorNotAtEnd(block_id, *insn_id, idx));
+                if insn.is_terminator() {
+                    block_has_terminator = true;
+
+                    match &insn {
+                        Insn::IfTrue { val: _, target: BranchEdge{ .. } }
+                        | Insn::IfFalse { val: _, target: BranchEdge{ .. }} => {
+                            // IfTrue / IfFalse should always be second to last
+                            if idx != insns.len() - 2 {
+                                return Err(ValidationError::TerminatorNotAtEnd(block_id, *insn_id, idx))
+                            }
+                            // The instruction after IfTrue/IfFalse must be a Jump
+                            if !matches!(self.find(insns[idx + 1]), Insn::Jump(_)) {
+                                return Err(ValidationError::TerminatorNotAtEnd(block_id, *insn_id, idx))
+                            }
+                        }
+                        _ => {
+                            // Jump etc should always be last
+                            if idx != insns.len() - 1 {
+                                return Err(ValidationError::TerminatorNotAtEnd(block_id, *insn_id, idx))
+                            }
+                        }
+                    }
                 }
             }
             if !block_has_terminator {
@@ -7129,10 +7166,20 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         val: test_id,
                         target: BranchEdge { target, args: iffalse_state.as_args(self_param) }
                     });
+
+                    let fall_through = fun.new_block(insn_idx);
+
+                    fun.push_insn(block, Insn::Jump(
+                            BranchEdge { target: fall_through, args: vec![] }
+                    ));
+
+                    block = fall_through;
+
                     let not_nil_false_type = types::Truthy;
                     let not_nil_false = fun.push_insn(block, Insn::RefineType { val, new_type: not_nil_false_type });
                     state.replace(val, not_nil_false);
                     queue.push_back((state.clone(), target, target_idx, local_inval));
+
                 }
                 YARVINSN_branchif | YARVINSN_branchif_without_ints => {
                     if opcode == YARVINSN_branchif {
@@ -7151,6 +7198,15 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         val: test_id,
                         target: BranchEdge { target, args: iftrue_state.as_args(self_param) }
                     });
+
+                    let fall_through = fun.new_block(insn_idx);
+
+                    let _fall_through_id = fun.push_insn(block, Insn::Jump(
+                            BranchEdge { target: fall_through, args: vec![] }
+                    ));
+
+                    block = fall_through;
+
                     let nil_false_type = types::Falsy;
                     let nil_false = fun.push_insn(block, Insn::RefineType { val, new_type: nil_false_type });
                     state.replace(val, nil_false);
@@ -7172,6 +7228,14 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         val: test_id,
                         target: BranchEdge { target, args: iftrue_state.as_args(self_param) }
                     });
+
+                    let fall_through = fun.new_block(insn_idx);
+
+                    let _fall_through_id = fun.push_insn(block, Insn::Jump(
+                            BranchEdge { target: fall_through, args: vec![] }
+                    ));
+
+                    block = fall_through;
                     let new_type = types::NotNil;
                     let not_nil = fun.push_insn(block, Insn::RefineType { val, new_type });
                     state.replace(val, not_nil);
@@ -7201,6 +7265,14 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         val: test_id,
                         target: BranchEdge { target, args: state.as_args(self_param) }
                     });
+
+                    let fall_through = fun.new_block(insn_idx);
+
+                    let _fall_through_id = fun.push_insn(block, Insn::Jump(
+                            BranchEdge { target: fall_through, args: vec![] }
+                    ));
+
+                    block = fall_through;
                     queue.push_back((state.clone(), target, target_idx, local_inval));
 
                     // Move on to the fast path
@@ -7452,20 +7524,30 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             .map(|&kind| (kind, fun.new_block(branch_insn_idx)))
                             .collect::<Vec<_>>();
 
+                            let mut current_block = unmodified_block;
+
                             for &(kind, profiled_block) in &profiled_blocks {
                                 match kind {
                                     ProfiledBlockHandlerFamily::Nil => {
-                                        let none_handler = fun.push_insn(unmodified_block, Insn::Const {
+                                        let none_handler = fun.push_insn(current_block, Insn::Const {
                                             val: Const::CInt64(VM_BLOCK_HANDLER_NONE.into()),
                                         });
-                                        let is_none = fun.push_insn(unmodified_block, Insn::IsBitEqual {
+                                        let is_none = fun.push_insn(current_block, Insn::IsBitEqual {
                                             left: block_handler,
                                             right: none_handler,
                                         });
-                                        fun.push_insn(unmodified_block, Insn::IfTrue {
+                                        fun.push_insn(current_block, Insn::IfTrue {
                                             val: is_none,
                                             target: BranchEdge { target: profiled_block, args: vec![] },
                                         });
+
+                                        let next_block = fun.new_block(branch_insn_idx);
+
+                                        fun.push_insn(current_block, Insn::Jump(
+                                            BranchEdge { target: next_block, args: vec![] },
+                                        ));
+                                        current_block = next_block;
+
                                         let val = fun.push_insn(profiled_block, Insn::Const { val: Const::Value(Qnil) });
                                         let mut args = vec![val];
                                         if let Some(local) = original_local { args.push(local); }
@@ -7478,19 +7560,25 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                                         //   VM_BH_ISEQ_BLOCK_P(): block_handler & 0x03 == 0x01
                                         //   VM_BH_IFUNC_P():      block_handler & 0x03 == 0x03
                                         // So to check for either of those cases we can use: val & 0x1 == 0x1
-                                        let tag_mask = fun.push_insn(unmodified_block, Insn::Const { val: Const::CInt64(0x1) });
-                                        let tag_bits = fun.push_insn(unmodified_block, Insn::IntAnd {
+                                        let tag_mask = fun.push_insn(current_block, Insn::Const { val: Const::CInt64(0x1) });
+                                        let tag_bits = fun.push_insn(current_block, Insn::IntAnd {
                                             left: block_handler,
                                             right: tag_mask,
                                         });
-                                        let is_iseq_or_ifunc = fun.push_insn(unmodified_block, Insn::IsBitEqual {
+                                        let is_iseq_or_ifunc = fun.push_insn(current_block, Insn::IsBitEqual {
                                             left: tag_bits,
                                             right: tag_mask,
                                         });
-                                        fun.push_insn(unmodified_block, Insn::IfTrue {
+                                        fun.push_insn(current_block, Insn::IfTrue {
                                             val: is_iseq_or_ifunc,
                                             target: BranchEdge { target: profiled_block, args: vec![] },
                                         });
+                                        let next_block = fun.new_block(branch_insn_idx);
+                                        fun.push_insn(current_block, Insn::Jump(
+                                            BranchEdge { target: next_block, args: vec![] },
+                                        ));
+                                        current_block = next_block;
+
                                         // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                                         let val = fun.push_insn(profiled_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
                                         let mut args = vec![val];
@@ -7500,7 +7588,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                                 }
                             }
 
-                            fun.push_insn(unmodified_block, Insn::SideExit { state: exit_id, reason: SideExitReason::BlockParamProxyProfileNotCovered, recompile: None });
+                            fun.push_insn(current_block, Insn::SideExit { state: exit_id, reason: SideExitReason::BlockParamProxyProfileNotCovered, recompile: None });
                         }
                     }
 
@@ -7793,6 +7881,11 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                                     new_branch_block(&mut fun, cd, argc as usize, opcode, expected, branch_insn_idx, &exit_state, locals_count, stack_count, join_block);
                                 let target = BranchEdge { target: iftrue_block, args: entry_args.clone() };
                                 fun.push_insn(block, Insn::IfTrue { val: has_type, target });
+                                let fall_through = fun.new_block(insn_idx);
+                                fun.push_insn(block, Insn::Jump(
+                                        BranchEdge { target: fall_through, args: vec![] }
+                                ));
+                                block = fall_through;
                             }
                             // Continue compilation from the join block at the next instruction.
                             // Make a copy of the current state without the args (pop the receiver
@@ -8060,6 +8153,13 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         let join_param = fun.push_insn(join_block, Insn::Param);
                         let ifunc_block = fun.new_block(insn_idx);
                         fun.push_insn(block, Insn::IfTrue { val: is_ifunc_match, target: BranchEdge { target: ifunc_block, args: vec![] } });
+                        let fall_through = fun.new_block(insn_idx);
+                        fun.push_insn(block, Insn::Jump(
+                                BranchEdge { target: fall_through, args: vec![] }
+                        ));
+
+                        block = fall_through;
+
                         let ifunc_result = fun.push_insn(ifunc_block, Insn::InvokeBlockIfunc {
                             cd,
                             block_handler,
@@ -8136,6 +8236,9 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             let iftrue_block = fun.new_block(insn_idx);
                             let target = BranchEdge { target: iftrue_block, args: vec![] };
                             fun.push_insn(block, Insn::IfTrue { val: has_shape_and_type, target });
+                            let fall_through = fun.new_block(insn_idx);
+                            fun.push_insn(block, Insn::Jump(BranchEdge { target: fall_through, args: vec![] }));
+                            block = fall_through;
                             let result = fun.load_ivar(iftrue_block, self_param, profiled_type, id, exit_id);
                             fun.push_insn(iftrue_block, Insn::Jump(BranchEdge { target: join_block, args: vec![result] }));
                         }
@@ -8348,7 +8451,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
     fun.profiles = Some(profiles);
     if let Err(err) = crate::stats::trace_compile_phase("validate", || fun.validate()) {
-        debug!("ZJIT: {err:?}: Initial HIR:\n{}", FunctionPrinter::without_snapshot(&fun));
+        eprintln!("ZJIT: {err:?}: Initial HIR:\n{}", FunctionPrinter::without_snapshot(&fun));
         return Err(ParseError::Validation(err));
     }
     Ok(fun)
@@ -8356,7 +8459,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
 /// Compile an entry_block for the interpreter
 fn compile_entry_block(fun: &mut Function, jit_entry_insns: &[u32], insn_idx_to_block: &HashMap<u32, BlockId>) {
-    let entry_block = fun.entry_block;
+    let mut entry_block = fun.entry_block;
     let (self_param, entry_state) = compile_entry_state(fun);
     let mut pc: Option<InsnId> = None;
     let &all_opts_passed_insn_idx = jit_entry_insns.last().unwrap();
@@ -8380,6 +8483,12 @@ fn compile_entry_block(fun: &mut Function, jit_entry_insns: &[u32], insn_idx_to_
             val: test_id,
             target: BranchEdge { target: target_block, args: entry_state.as_args(self_param) },
         });
+        // TODO: is this the right insn index??
+        let fall_through = fun.new_block(jit_entry_insn);
+        let _fall_through_id = fun.push_insn(entry_block, Insn::Jump(
+                BranchEdge { target: fall_through, args: vec![] }
+        ));
+        entry_block = fall_through;
     }
 
     // Terminate the block with a jump to the block with all optionals passed
@@ -8948,6 +9057,10 @@ mod validation_tests {
         let side = function.new_block(0);
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(entry, Insn::IfTrue { val, target: BranchEdge { target: side, args: vec![val, val, val] } });
+        let fall_through = function.new_block(1);
+        function.push_insn(entry, Insn::Jump(
+                BranchEdge { target: fall_through, args: vec![] }
+        ));
         function.seal_entries();
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(entry, 0, 3));
     }
@@ -8959,6 +9072,10 @@ mod validation_tests {
         let side = function.new_block(0);
         let val = function.push_insn(entry, Insn::Const { val: Const::Value(Qnil) });
         function.push_insn(entry, Insn::IfFalse { val, target: BranchEdge { target: side, args: vec![val, val, val] } });
+        let fall_through = function.new_block(1);
+        function.push_insn(entry, Insn::Jump(
+                BranchEdge { target: fall_through, args: vec![] }
+        ));
         function.seal_entries();
         assert_matches_err(function.validate(), ValidationError::MismatchedBlockArity(entry, 0, 3));
     }

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -8409,7 +8409,8 @@ fn compile_entry_block(fun: &mut Function, jit_entry_insns: &[u32], insn_idx_to_
     let &all_opts_passed_insn_idx = jit_entry_insns.last().unwrap();
 
     // Check-and-jump for each missing optional PC
-    for &jit_entry_insn in jit_entry_insns.iter() {
+    let mut iter = jit_entry_insns.iter().peekable();
+    while let Some(&jit_entry_insn) = iter.next() {
         if jit_entry_insn == all_opts_passed_insn_idx {
             continue;
         }
@@ -8424,8 +8425,8 @@ fn compile_entry_block(fun: &mut Function, jit_entry_insns: &[u32], insn_idx_to_
         });
         let test_id = fun.push_insn(entry_block, Insn::IsBitEqual { left: pc, right: expected_pc });
 
-        // TODO: is this the right insn index??
-        let fall_through = fun.new_block(jit_entry_insn);
+        let next_insn_idx = **iter.peek().expect("last entry is skipped so there is always a next");
+        let fall_through = fun.new_block(next_insn_idx);
 
         fun.push_insn(entry_block, Insn::CondBranch {
             val: test_id,

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2696,7 +2696,6 @@ impl Function {
             Insn::Entries { targets } => targets,
             Insn::Unreachable | Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. } => vec![],
             _ => vec![]
-            // _ => unreachable!("block doesn't end with a jump or terminator")
         }
     }
 

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2687,19 +2687,6 @@ impl Function {
         self.blocks.pop();
     }
 
-    fn num_successors(&self, block: BlockId) -> usize {
-        let insns = &self.blocks[block.0].insns;
-        let last = self.find(*insns.last().unwrap());
-        match last {
-            Insn::CondBranch { .. } => 2,
-            Insn::Jump(_) => 1,
-            Insn::Entries { targets } => targets.len(),
-            Insn::Unreachable | Insn::Return { .. } | Insn::SideExit { .. } | Insn::Throw { .. } => 0,
-            _ => 0
-            // _ => unreachable!("block doesn't end with a jump or terminator")
-        }
-    }
-
     fn successors(&self, block: BlockId) -> Vec<BlockId> {
         let insns = &self.blocks[block.0].insns;
         let last = self.find(*insns.last().unwrap());
@@ -5324,9 +5311,6 @@ impl Function {
     }
 
     fn absorb_dst_block(&mut self, num_in_edges: &[u32], block: BlockId) -> bool {
-        if self.num_successors(block) > 1 {
-            return false;
-        }
         let Some(terminator_id) = self.blocks[block.0].insns.last()
             else { return false };
         let Insn::Jump(BranchEdge { target, args }) = self.find(*terminator_id)

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -8398,7 +8398,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
     fun.profiles = Some(profiles);
     if let Err(err) = crate::stats::trace_compile_phase("validate", || fun.validate()) {
-        eprintln!("ZJIT: {err:?}: Initial HIR:\n{}", FunctionPrinter::without_snapshot(&fun));
+        debug!("ZJIT: {err:?}: Initial HIR:\n{}", FunctionPrinter::without_snapshot(&fun));
         return Err(ParseError::Validation(err));
     }
     Ok(fun)

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::match_like_matches_macro)]
 use crate::{
     backend::lir::C_ARG_OPNDS,
-    cast::IntoUsize, codegen::{local_idx_to_ep_offset, max_iseq_versions}, cruby::*, invariants::{self}, payload::{get_or_create_iseq_payload, IseqPayload}, options::{get_option, DumpHIR}, state::ZJITState, json::Json,
+    cast::IntoUsize, codegen::{local_idx_to_ep_offset, max_iseq_versions}, cruby::*, invariants::{self}, payload::{get_or_create_iseq_payload, IseqPayload}, options::{debug, get_option, DumpHIR}, state::ZJITState, json::Json,
     state,
 };
 use std::{
@@ -3022,14 +3022,22 @@ impl Function {
 
         // Assign `new_type` to `insn` if it differs from the recorded type.
         // Returns `true` if a write actually happened, `false` if the type
-        // was already equal.
-        let set_type = |this: &mut Function, insn: InsnId, new_type: Type| -> bool {
-            if this.type_of(insn).bit_equal(new_type) {
-                return false;
-            }
-            this.insn_types[insn.0] = new_type;
-            true
-        };
+        // Macro instead of closure so the borrow checker sees individual field
+        // accesses rather than an `&mut self` borrow that conflicts with
+        // `&self.insns` held by an outer match.
+        macro_rules! set_type {
+            ($insn:expr, $new_type:expr) => {{
+                let insn = $insn;
+                let new_type = $new_type;
+                let old_type = self.insn_types[self.union_find.borrow_mut().find(insn).0];
+                if old_type.bit_equal(new_type) {
+                    false
+                } else {
+                    self.insn_types[insn.0] = new_type;
+                    true
+                }
+            }};
+        }
 
         let mut reachable = BlockSet::with_capacity(self.blocks.len());
         reachable.insert(self.entries_block);
@@ -3044,12 +3052,10 @@ impl Function {
                     let insn_id = self.blocks[block.0].insns[i];
                     // Instructions without output, including branch instructions, can't be targets
                     // of make_equal_to, so we don't need find() here.
-                    // Clone the insn so we don't hold a borrow on self.insns
-                    // across calls to set_type() below.
-                    let insn_type = match self.insns[insn_id.0].clone() {
+                    let insn_type = match &self.insns[insn_id.0] {
                         Insn::CondBranch { val, if_true, if_false } => {
-                            assert!(!self.type_of(val).bit_equal(types::Empty));
-                            if self.type_of(val).could_be(Type::from_cbool(true)) {
+                            assert!(!self.type_of(*val).bit_equal(types::Empty));
+                            if self.type_of(*val).could_be(Type::from_cbool(true)) {
                                 reachable.insert(if_true.target);
                                 // Snapshot arg types before any param updates so phi-style
                                 // updates happen in parallel (the args of a self-loop may name
@@ -3057,30 +3063,30 @@ impl Function {
                                 let arg_types: Vec<Type> = if_true.args.iter().map(|a| self.type_of(*a)).collect();
                                 for (idx, arg_type) in arg_types.into_iter().enumerate() {
                                     let param = self.blocks[if_true.target.0].params[idx];
-                                    changed |= set_type(self, param, self.type_of(param).union(arg_type));
+                                    changed |= set_type!(param, self.type_of(param).union(arg_type));
                                 }
                             }
-                            if self.type_of(val).could_be(Type::from_cbool(false)) {
+                            if self.type_of(*val).could_be(Type::from_cbool(false)) {
                                 reachable.insert(if_false.target);
                                 let arg_types: Vec<Type> = if_false.args.iter().map(|a| self.type_of(*a)).collect();
                                 for (idx, arg_type) in arg_types.into_iter().enumerate() {
                                     let param = self.blocks[if_false.target.0].params[idx];
-                                    changed |= set_type(self, param, self.type_of(param).union(arg_type));
+                                    changed |= set_type!(param, self.type_of(param).union(arg_type));
                                 }
                             }
                             continue;
                         }
-                        Insn::Jump(BranchEdge { target, args }) => {
+                        &Insn::Jump(BranchEdge { target, ref args }) => {
                             reachable.insert(target);
                             let arg_types: Vec<Type> = args.iter().map(|a| self.type_of(*a)).collect();
                             for (idx, arg_type) in arg_types.into_iter().enumerate() {
                                 let param = self.blocks[target.0].params[idx];
-                                changed |= set_type(self, param, self.type_of(param).union(arg_type));
+                                changed |= set_type!(param, self.type_of(param).union(arg_type));
                             }
                             continue;
                         }
                         Insn::Entries { targets } => {
-                            for target in targets {
+                            for &target in targets {
                                 reachable.insert(target);
                             }
                             continue;
@@ -3088,7 +3094,7 @@ impl Function {
                         insn if insn.has_output() => self.infer_type(insn_id),
                         _ => continue,
                     };
-                    changed |= set_type(self, insn_id, insn_type);
+                    changed |= set_type!(insn_id, insn_type);
                 }
             }
             if !changed {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -15584,7 +15584,7 @@ mod hir_opt_tests {
 
         // After profiling via the side exit, rebuilding HIR should now
         // have a SendDirect for greet_recompile instead of SideExit.
-        assert_snapshot!(hir_string("test_no_profile_recompile"), @"
+        assert_snapshot!(hir_string("test_no_profile_recompile"), @r"
         fn test_no_profile_recompile@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -15643,7 +15643,7 @@ mod hir_opt_tests {
         eval("3.times { test_final_version(false) }");
 
         // On the final version, greet_final should be a Send fallback, not a SideExit.
-        assert_snapshot!(hir_string("test_final_version"), @"
+        assert_snapshot!(hir_string("test_final_version"), @r"
         fn test_final_version@<compiled>:4:
         bb1():
           EntryPoint interpreter

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -53,8 +53,8 @@ mod hir_opt_tests {
         bb3(v8:BasicObject, v9:NilClass):
           v13:TrueClass = Const Value(true)
           CheckInterrupts
-          v25:Fixnum[3] = Const Value(3)
-          Return v25
+          v26:Fixnum[3] = Const Value(3)
+          Return v26
         ");
     }
 
@@ -85,8 +85,8 @@ mod hir_opt_tests {
         bb3(v8:BasicObject, v9:NilClass):
           v13:FalseClass = Const Value(false)
           CheckInterrupts
-          v35:Fixnum[4] = Const Value(4)
-          Return v35
+          v36:Fixnum[4] = Const Value(4)
+          Return v36
         ");
     }
 
@@ -755,10 +755,10 @@ mod hir_opt_tests {
           v10:Fixnum[1] = Const Value(1)
           v12:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
-          v42:TrueClass = Const Value(true)
+          v43:TrueClass = Const Value(true)
           CheckInterrupts
-          v24:Fixnum[3] = Const Value(3)
-          Return v24
+          v25:Fixnum[3] = Const Value(3)
+          Return v25
         ");
     }
 
@@ -787,10 +787,10 @@ mod hir_opt_tests {
           v10:Fixnum[1] = Const Value(1)
           v12:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1000, <=@0x1008, cme:0x1010)
-          v58:TrueClass = Const Value(true)
+          v60:TrueClass = Const Value(true)
           CheckInterrupts
-          v37:Fixnum[3] = Const Value(3)
-          Return v37
+          v39:Fixnum[3] = Const Value(3)
+          Return v39
         ");
     }
 
@@ -819,10 +819,10 @@ mod hir_opt_tests {
           v10:Fixnum[2] = Const Value(2)
           v12:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, >@0x1008, cme:0x1010)
-          v42:TrueClass = Const Value(true)
+          v43:TrueClass = Const Value(true)
           CheckInterrupts
-          v24:Fixnum[3] = Const Value(3)
-          Return v24
+          v25:Fixnum[3] = Const Value(3)
+          Return v25
         ");
     }
 
@@ -851,10 +851,10 @@ mod hir_opt_tests {
           v10:Fixnum[2] = Const Value(2)
           v12:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, >=@0x1008, cme:0x1010)
-          v58:TrueClass = Const Value(true)
+          v60:TrueClass = Const Value(true)
           CheckInterrupts
-          v37:Fixnum[3] = Const Value(3)
-          Return v37
+          v39:Fixnum[3] = Const Value(3)
+          Return v39
         ");
     }
 
@@ -883,10 +883,10 @@ mod hir_opt_tests {
           v10:Fixnum[1] = Const Value(1)
           v12:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1000, ==@0x1008, cme:0x1010)
-          v42:FalseClass = Const Value(false)
+          v43:FalseClass = Const Value(false)
           CheckInterrupts
-          v33:Fixnum[4] = Const Value(4)
-          Return v33
+          v34:Fixnum[4] = Const Value(4)
+          Return v34
         ");
     }
 
@@ -915,10 +915,10 @@ mod hir_opt_tests {
           v10:Fixnum[2] = Const Value(2)
           v12:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1000, ==@0x1008, cme:0x1010)
-          v42:TrueClass = Const Value(true)
+          v43:TrueClass = Const Value(true)
           CheckInterrupts
-          v24:Fixnum[3] = Const Value(3)
-          Return v24
+          v25:Fixnum[3] = Const Value(3)
+          Return v25
         ");
     }
 
@@ -948,10 +948,10 @@ mod hir_opt_tests {
           v12:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1000, !=@0x1008, cme:0x1010)
           PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
-          v43:TrueClass = Const Value(true)
+          v44:TrueClass = Const Value(true)
           CheckInterrupts
-          v24:Fixnum[3] = Const Value(3)
-          Return v24
+          v25:Fixnum[3] = Const Value(3)
+          Return v25
         ");
     }
 
@@ -981,10 +981,10 @@ mod hir_opt_tests {
           v12:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1000, !=@0x1008, cme:0x1010)
           PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
-          v43:FalseClass = Const Value(false)
+          v44:FalseClass = Const Value(false)
           CheckInterrupts
-          v33:Fixnum[4] = Const Value(4)
-          Return v33
+          v34:Fixnum[4] = Const Value(4)
+          Return v34
         ");
     }
 
@@ -4449,15 +4449,15 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, C)
-          v43:Class[C@0x1008] = Const Value(VALUE(0x1008))
+          v44:Class[C@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(C@0x1008, new@0x1009, cme:0x1010)
-          v46:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
+          v47:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, initialize@0x1038, cme:0x1040)
-          v50:NilClass = Const Value(nil)
+          v51:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v46
+          Return v47
         ");
     }
 
@@ -4485,16 +4485,16 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, C)
-          v46:Class[C@0x1008] = Const Value(VALUE(0x1008))
+          v47:Class[C@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(C@0x1008, new@0x1009, cme:0x1010)
-          v49:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
+          v50:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, initialize@0x1038, cme:0x1040)
-          v52:BasicObject = SendDirect v49, 0x1068, :initialize (0x1078), v15
+          v53:BasicObject = SendDirect v50, 0x1068, :initialize (0x1078), v15
           CheckInterrupts
-          Return v49
+          Return v50
         ");
     }
 
@@ -4517,15 +4517,15 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Object)
-          v43:Class[Object@0x1008] = Const Value(VALUE(0x1008))
+          v44:Class[Object@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(Object@0x1008, new@0x1009, cme:0x1010)
-          v46:ObjectExact = ObjectAllocClass Object:VALUE(0x1008)
+          v47:ObjectExact = ObjectAllocClass Object:VALUE(0x1008)
           PatchPoint NoSingletonClass(Object@0x1008)
           PatchPoint MethodRedefined(Object@0x1008, initialize@0x1038, cme:0x1040)
-          v50:NilClass = Const Value(nil)
+          v51:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v46
+          Return v47
         ");
     }
 
@@ -4548,15 +4548,15 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, BasicObject)
-          v43:Class[BasicObject@0x1008] = Const Value(VALUE(0x1008))
+          v44:Class[BasicObject@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(BasicObject@0x1008, new@0x1009, cme:0x1010)
-          v46:BasicObjectExact = ObjectAllocClass BasicObject:VALUE(0x1008)
+          v47:BasicObjectExact = ObjectAllocClass BasicObject:VALUE(0x1008)
           PatchPoint NoSingletonClass(BasicObject@0x1008)
           PatchPoint MethodRedefined(BasicObject@0x1008, initialize@0x1038, cme:0x1040)
-          v50:NilClass = Const Value(nil)
+          v51:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v46
+          Return v47
         ");
     }
 
@@ -4579,16 +4579,16 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Hash)
-          v43:Class[Hash@0x1008] = Const Value(VALUE(0x1008))
+          v44:Class[Hash@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(Hash@0x1008, new@0x1009, cme:0x1010)
-          v46:HashExact = ObjectAllocClass Hash:VALUE(0x1008)
-          v47:Fixnum[0] = Const Value(0)
+          v47:HashExact = ObjectAllocClass Hash:VALUE(0x1008)
+          v48:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, initialize@0x1038, cme:0x1040)
-          v51:BasicObject = SendDirect v46, 0x1068, :initialize (0x1078), v47
+          v52:BasicObject = SendDirect v47, 0x1068, :initialize (0x1078), v48
           CheckInterrupts
-          Return v46
+          Return v47
         ");
         assert_snapshot!(inspect("test"), @"{}");
     }
@@ -4612,14 +4612,14 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Array)
-          v46:Class[Array@0x1008] = Const Value(VALUE(0x1008))
+          v47:Class[Array@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Array@0x1008, new@0x1009, cme:0x1010)
           PatchPoint MethodRedefined(Class@0x1038, new@0x1009, cme:0x1010)
-          v56:BasicObject = CCallVariadic v46, :Array.new@0x1040, v15
+          v53:BasicObject = CCallVariadic v47, :Array.new@0x1040, v15
           CheckInterrupts
-          Return v56
+          Return v53
         ");
     }
 
@@ -4642,14 +4642,14 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Set)
-          v43:Class[Set@0x1008] = Const Value(VALUE(0x1008))
+          v44:Class[Set@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(Set@0x1008, new@0x1009, cme:0x1010)
-          v17:HeapBasicObject = ObjectAlloc v43
+          v18:HeapBasicObject = ObjectAlloc v44
           PatchPoint NoSingletonClass(Set@0x1008)
           PatchPoint MethodRedefined(Set@0x1008, initialize@0x1038, cme:0x1040)
-          v49:SetExact = GuardType v17, SetExact
-          v50:BasicObject = CCallVariadic v49, :Set#initialize@0x1068
+          v50:SetExact = GuardType v18, SetExact
+          v51:BasicObject = CCallVariadic v50, :Set#initialize@0x1068
           CheckInterrupts
           Return v49
         ");
@@ -4674,13 +4674,13 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, String)
-          v43:Class[String@0x1008] = Const Value(VALUE(0x1008))
+          v44:Class[String@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(String@0x1008, new@0x1009, cme:0x1010)
           PatchPoint MethodRedefined(Class@0x1038, new@0x1009, cme:0x1010)
-          v53:BasicObject = CCallVariadic v43, :String.new@0x1040
+          v50:BasicObject = CCallVariadic v44, :String.new@0x1040
           CheckInterrupts
-          Return v53
+          Return v50
         ");
     }
 
@@ -4703,17 +4703,17 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Regexp)
-          v47:Class[Regexp@0x1008] = Const Value(VALUE(0x1008))
+          v48:Class[Regexp@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           v15:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
           v16:StringExact = StringCopy v15
           PatchPoint MethodRedefined(Regexp@0x1008, new@0x1018, cme:0x1020)
-          v50:RegexpExact = ObjectAllocClass Regexp:VALUE(0x1008)
+          v51:RegexpExact = ObjectAllocClass Regexp:VALUE(0x1008)
           PatchPoint NoSingletonClass(Regexp@0x1008)
           PatchPoint MethodRedefined(Regexp@0x1008, initialize@0x1048, cme:0x1050)
-          v54:BasicObject = CCallVariadic v50, :Regexp#initialize@0x1078, v16
+          v55:BasicObject = CCallVariadic v51, :Regexp#initialize@0x1078, v16
           CheckInterrupts
-          Return v50
+          Return v51
         ");
     }
 
@@ -4890,13 +4890,15 @@ mod hir_opt_tests {
           v18:CUInt64 = LoadField v17, :_ep_flags@0x1001
           v19:CBool = IsBlockParamModified v18
           IfTrue v19, bb4()
-          v24:CInt64 = LoadField v17, :_env_data_index_specval@0x1002
+          Jump bb5()
+        bb4():
+          v22:BasicObject = LoadField v17, :block@0x1002
+          Jump bb6(v22, v22)
+        bb5():
+          v24:CInt64 = LoadField v17, :_env_data_index_specval@0x1003
           v25:CInt64 = GuardAnyBitSet v24, CUInt64(1)
           v26:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v26, v10)
-        bb4():
-          v22:BasicObject = LoadField v17, :block@0x1010
-          Jump bb6(v22, v22)
         bb6(v15:BasicObject, v16:BasicObject):
           SideExit NoProfileSend recompile
         ");
@@ -4931,23 +4933,27 @@ mod hir_opt_tests {
           v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
           v20:CBool = IsBlockParamModified v19
           IfTrue v20, bb4()
-          v25:BasicObject = GetBlockParam :block, l0, EP@4
-          Jump bb6(v25)
+          Jump bb5()
         bb4():
           v23:BasicObject = LoadField v18, :block@0x1002
           Jump bb6(v23)
+        bb5():
+          v25:BasicObject = GetBlockParam :block, l0, EP@4
+          Jump bb6(v25)
         bb6(v17:BasicObject):
           v33:CPtr = GetEP 0
           v34:CUInt64 = LoadField v33, :_ep_flags@0x1001
           v35:CBool = IsBlockParamModified v34
           IfTrue v35, bb7()
+          Jump bb8()
+        bb7():
+          v38:BasicObject = LoadField v33, :block@0x1002
+          Jump bb9(v38, v38)
+        bb8():
           v40:CInt64 = LoadField v33, :_env_data_index_specval@0x1003
           v41:CInt64 = GuardAnyBitSet v40, CUInt64(1)
           v42:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb9(v42, v17)
-        bb7():
-          v38:BasicObject = LoadField v33, :block@0x1002
-          Jump bb9(v38, v38)
         bb9(v31:BasicObject, v32:BasicObject):
           SideExit NoProfileSend recompile
         ");
@@ -4980,23 +4986,27 @@ mod hir_opt_tests {
           v15:CUInt64 = LoadField v14, :_ep_flags@0x1000
           v16:CBool = IsBlockParamModified v15
           IfTrue v16, bb4()
-          v21:BasicObject = GetBlockParam :block, l1, EP@3
-          Jump bb6(v21)
+          Jump bb5()
         bb4():
           v19:BasicObject = LoadField v14, :block@0x1001
           Jump bb6(v19)
+        bb5():
+          v21:BasicObject = GetBlockParam :block, l1, EP@3
+          Jump bb6(v21)
         bb6(v13:BasicObject):
           v28:CPtr = GetEP 1
           v29:CUInt64 = LoadField v28, :_ep_flags@0x1000
           v30:CBool = IsBlockParamModified v29
           IfTrue v30, bb7()
+          Jump bb8()
+        bb7():
+          v33:BasicObject = LoadField v28, :block@0x1001
+          Jump bb9(v33)
+        bb8():
           v35:CInt64 = LoadField v28, :_env_data_index_specval@0x1002
           v36:CInt64 = GuardAnyBitSet v35, CUInt64(1)
           v37:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb9(v37)
-        bb7():
-          v33:BasicObject = LoadField v28, :block@0x1001
-          Jump bb9(v33)
         bb9(v27:BasicObject):
           SideExit NoProfileSend recompile
         ");
@@ -5033,28 +5043,34 @@ mod hir_opt_tests {
           v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
           v20:CBool = IsBlockParamModified v19
           IfTrue v20, bb4()
-          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1002
+          Jump bb5()
+        bb4():
+          v23:BasicObject = LoadField v18, :block@0x1002
+          Jump bb6(v23, v23)
+        bb5():
+          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
           v26:CInt64[1] = Const CInt64(1)
           v27:CInt64 = IntAnd v25, v26
           v28:CBool = IsBitEqual v27, v26
           IfTrue v28, bb7()
-          v32:CInt64[0] = Const CInt64(0)
-          v33:CBool = IsBitEqual v25, v32
-          IfTrue v33, bb8()
-          SideExit BlockParamProxyProfileNotCovered
-        bb4():
-          v23:BasicObject = LoadField v18, :block@0x1003
-          Jump bb6(v23, v23)
+          Jump bb9()
         bb7():
-          v30:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v30, v10)
+          v31:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v31, v10)
+        bb9():
+          v33:CInt64[0] = Const CInt64(0)
+          v34:CBool = IsBitEqual v25, v33
+          IfTrue v34, bb8()
+          Jump bb10()
         bb8():
-          v35:NilClass = Const Value(nil)
-          Jump bb6(v35, v10)
+          v37:NilClass = Const Value(nil)
+          Jump bb6(v37, v10)
         bb6(v16:BasicObject, v17:BasicObject):
-          v39:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Complex argument passing
+          v41:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v39
+          Return v41
+        bb10():
+          SideExit BlockParamProxyProfileNotCovered
         ");
     }
 
@@ -5081,11 +5097,13 @@ mod hir_opt_tests {
           v16:CUInt64 = LoadField v15, :_ep_flags@0x1001
           v17:CBool = IsBlockParamModified v16
           IfTrue v17, bb4()
-          v22:BasicObject = GetBlockParam :block, l0, EP@3
-          Jump bb6(v22)
+          Jump bb5()
         bb4():
           v20:BasicObject = LoadField v15, :block@0x1002
           Jump bb6(v20)
+        bb5():
+          v22:BasicObject = GetBlockParam :block, l0, EP@3
+          Jump bb6(v22)
         bb6(v14:BasicObject):
           CheckInterrupts
           Return v14
@@ -5116,11 +5134,13 @@ mod hir_opt_tests {
           v12:CUInt64 = LoadField v11, :_ep_flags@0x1000
           v13:CBool = IsBlockParamModified v12
           IfTrue v13, bb4()
-          v18:BasicObject = GetBlockParam :block, l1, EP@3
-          Jump bb6(v18)
+          Jump bb5()
         bb4():
           v16:BasicObject = LoadField v11, :block@0x1001
           Jump bb6(v16)
+        bb5():
+          v18:BasicObject = GetBlockParam :block, l1, EP@3
+          Jump bb6(v18)
         bb6(v10:BasicObject):
           CheckInterrupts
           Return v10
@@ -6419,9 +6439,9 @@ mod hir_opt_tests {
         bb3(v8:BasicObject, v9:NilClass):
           v13:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          v23:Fixnum[1] = RefineType v13, NotNil
+          v24:Fixnum[1] = RefineType v13, NotNil
           PatchPoint MethodRedefined(Integer@0x1000, itself@0x1008, cme:0x1010)
-          Return v23
+          Return v24
         ");
     }
 
@@ -7260,19 +7280,21 @@ mod hir_opt_tests {
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
           IfFalse v16, bb4(v9, v17)
-          v19:Truthy = RefineType v10, Truthy
-          v21:FalseClass = Const Value(false)
+          Jump bb6()
+        bb4(v26:BasicObject, v27:Falsy):
+          v30:NilClass = Const Value(nil)
+          Jump bb5(v26, v27, v30)
+        bb6():
+          v20:Truthy = RefineType v10, Truthy
+          v22:FalseClass = Const Value(false)
           CheckInterrupts
-          Jump bb5(v9, v19, v21)
-        bb4(v25:BasicObject, v26:Falsy):
-          v29:NilClass = Const Value(nil)
-          Jump bb5(v25, v26, v29)
-        bb5(v31:BasicObject, v32:BasicObject, v33:Falsy):
+          Jump bb5(v9, v20, v22)
+        bb5(v32:BasicObject, v33:BasicObject, v34:Falsy):
           PatchPoint MethodRedefined(NilClass@0x1008, !@0x1010, cme:0x1018)
-          v45:NilClass = GuardType v33, NilClass
-          v46:TrueClass = Const Value(true)
+          v46:NilClass = GuardType v34, NilClass
+          v47:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v46
+          Return v47
         ");
     }
 
@@ -7591,20 +7613,24 @@ mod hir_opt_tests {
           v17:CInt64 = IntAnd v12, v14
           v18:CBool = IsBitEqual v17, v16
           IfTrue v18, bb5()
-          v22:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v23:CPtr[CPtr(0x1002)] = Const CPtr(0x1002)
-          v24 = RefineType v23, CUInt64
-          v25:CInt64 = IntAnd v12, v22
-          v26:CBool = IsBitEqual v25, v24
-          IfTrue v26, bb6()
-          v30:BasicObject = GetIvar v11, :@foo
-          Jump bb4(v30)
+          Jump bb6()
         bb5():
-          v20:BasicObject = LoadField v11, :@foo@0x1003
-          Jump bb4(v20)
+          v21:BasicObject = LoadField v11, :@foo@0x1002
+          Jump bb4(v21)
         bb6():
-          v28:BasicObject = LoadField v11, :@foo@0x1004
-          Jump bb4(v28)
+          v23:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v24:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
+          v25 = RefineType v24, CUInt64
+          v26:CInt64 = IntAnd v12, v23
+          v27:CBool = IsBitEqual v26, v25
+          IfTrue v27, bb7()
+          Jump bb8()
+        bb7():
+          v30:BasicObject = LoadField v11, :@foo@0x1004
+          Jump bb4(v30)
+        bb8():
+          v32:BasicObject = GetIvar v11, :@foo
+          Jump bb4(v32)
         bb4(v13:BasicObject):
           CheckInterrupts
           Return v13
@@ -7948,28 +7974,33 @@ mod hir_opt_tests {
           v17:CInt64 = IntAnd v12, v14
           v18:CBool = IsBitEqual v17, v16
           IfTrue v18, bb5()
-          v22:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v23:CPtr[CPtr(0x1002)] = Const CPtr(0x1002)
-          v24 = RefineType v23, CUInt64
-          v25:CInt64 = IntAnd v12, v22
-          v26:CBool = IsBitEqual v25, v24
-          IfTrue v26, bb6()
-          v31:BasicObject = GetIvar v11, :@foo
-          Jump bb4(v31)
+          Jump bb6()
         bb5():
-          v20:BasicObject = LoadField v11, :@foo@0x1003
-          Jump bb4(v20)
+          v21:CPtr = LoadField v11, :_as_heap@0x1002
+          v22:BasicObject = LoadField v21, :@foo@0x1003
+          Jump bb4(v22)
         bb6():
-          v28:CPtr = LoadField v11, :_as_heap@0x1004
-          v29:BasicObject = LoadField v28, :@foo@0x1000
-          Jump bb4(v29)
+          v24:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v25:CPtr[CPtr(0x1004)] = Const CPtr(0x1004)
+          v26 = RefineType v25, CUInt64
+          v27:CInt64 = IntAnd v12, v24
+          v28:CBool = IsBitEqual v27, v26
+          IfTrue v28, bb7()
+          Jump bb8()
+        bb7():
+          v31:CPtr = LoadField v11, :_as_heap@0x1002
+          v32:BasicObject = LoadField v31, :@foo@0x1000
+          Jump bb4(v32)
+        bb8():
+          v34:BasicObject = GetIvar v11, :@foo
+          Jump bb4(v34)
         bb4(v13:BasicObject):
-          v34:Fixnum[1] = Const Value(1)
+          v37:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v45:Fixnum = GuardType v13, Fixnum
-          v46:Fixnum = FixnumAdd v45, v34
+          v48:Fixnum = GuardType v13, Fixnum
+          v49:Fixnum = FixnumAdd v48, v37
           CheckInterrupts
-          Return v46
+          Return v49
         ");
     }
 
@@ -8025,31 +8056,36 @@ mod hir_opt_tests {
           v17:CInt64 = IntAnd v12, v14
           v18:CBool = IsBitEqual v17, v16
           IfTrue v18, bb5()
-          v23:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v24:CPtr[CPtr(0x1002)] = Const CPtr(0x1002)
-          v25 = RefineType v24, CUInt64
-          v26:CInt64 = IntAnd v12, v23
-          v27:CBool = IsBitEqual v26, v25
-          IfTrue v27, bb6()
-          v44:CShape = LoadField v11, :_shape_id@0x1003
-          v45:CShape[0x1004] = GuardBitEquals v44, CShape(0x1004)
-          v46:CPtr = LoadField v11, :_as_heap@0x1005
-          v47:BasicObject = LoadField v46, :@foo@0x1000
-          Jump bb4(v47)
+          Jump bb6()
         bb5():
-          v20:CPtr = LoadField v11, :_as_heap@0x1005
-          v21:BasicObject = LoadField v20, :@foo@0x1000
-          Jump bb4(v21)
+          v21:CPtr = LoadField v11, :_as_heap@0x1002
+          v22:BasicObject = LoadField v21, :@foo@0x1000
+          Jump bb4(v22)
         bb6():
-          v29:BasicObject = LoadField v11, :@foo@0x1006
-          Jump bb4(v29)
+          v24:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v25:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
+          v26 = RefineType v25, CUInt64
+          v27:CInt64 = IntAnd v12, v24
+          v28:CBool = IsBitEqual v27, v26
+          IfTrue v28, bb7()
+          Jump bb8()
+        bb7():
+          v31:CPtr = LoadField v11, :_as_heap@0x1002
+          v32:BasicObject = LoadField v31, :@foo@0x1004
+          Jump bb4(v32)
+        bb8():
+          v47:CShape = LoadField v11, :_shape_id@0x1005
+          v48:CShape[0x1006] = GuardBitEquals v47, CShape(0x1006)
+          v49:CPtr = LoadField v11, :_as_heap@0x1002
+          v50:BasicObject = LoadField v49, :@foo@0x1000
+          Jump bb4(v50)
         bb4(v13:BasicObject):
-          v34:Fixnum[1] = Const Value(1)
+          v37:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v50:Fixnum = GuardType v13, Fixnum
-          v51:Fixnum = FixnumAdd v50, v34
+          v53:Fixnum = GuardType v13, Fixnum
+          v54:Fixnum = FixnumAdd v53, v37
           CheckInterrupts
-          Return v51
+          Return v54
         ");
     }
 
@@ -8097,27 +8133,31 @@ mod hir_opt_tests {
           v17:CInt64 = IntAnd v12, v14
           v18:CBool = IsBitEqual v17, v16
           IfTrue v18, bb5()
-          v22:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v23:CPtr[CPtr(0x1002)] = Const CPtr(0x1002)
-          v24 = RefineType v23, CUInt64
-          v25:CInt64 = IntAnd v12, v22
-          v26:CBool = IsBitEqual v25, v24
-          IfTrue v26, bb6()
-          v30:BasicObject = GetIvar v11, :@foo
-          Jump bb4(v30)
+          Jump bb6()
         bb5():
-          v20:BasicObject = LoadField v11, :@foo@0x1003
-          Jump bb4(v20)
+          v21:BasicObject = LoadField v11, :@foo@0x1002
+          Jump bb4(v21)
         bb6():
-          v28:BasicObject = LoadField v11, :@foo@0x1003
-          Jump bb4(v28)
+          v23:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v24:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
+          v25 = RefineType v24, CUInt64
+          v26:CInt64 = IntAnd v12, v23
+          v27:CBool = IsBitEqual v26, v25
+          IfTrue v27, bb7()
+          Jump bb8()
+        bb7():
+          v30:BasicObject = LoadField v11, :@foo@0x1002
+          Jump bb4(v30)
+        bb8():
+          v32:BasicObject = GetIvar v11, :@foo
+          Jump bb4(v32)
         bb4(v13:BasicObject):
-          v33:Fixnum[1] = Const Value(1)
+          v35:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v44:Fixnum = GuardType v13, Fixnum
-          v45:Fixnum = FixnumAdd v44, v33
+          v46:Fixnum = GuardType v13, Fixnum
+          v47:Fixnum = FixnumAdd v46, v35
           CheckInterrupts
-          Return v45
+          Return v47
         ");
     }
 
@@ -8163,23 +8203,27 @@ mod hir_opt_tests {
           v17:CInt64 = IntAnd v12, v14
           v18:CBool = IsBitEqual v17, v16
           IfTrue v18, bb5()
-          v23:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v24:CPtr[CPtr(0x1002)] = Const CPtr(0x1002)
-          v25 = RefineType v24, CUInt64
-          v26:CInt64 = IntAnd v12, v23
-          v27:CBool = IsBitEqual v26, v25
-          IfTrue v27, bb6()
-          v33:BasicObject = GetIvar v11, :@a
-          Jump bb4(v33)
+          Jump bb6()
         bb5():
-          v20:RubyValue = LoadField v11, :_fields_obj@0x1003
-          v21:BasicObject = LoadField v20, :@a@0x1003
-          Jump bb4(v21)
+          v21:RubyValue = LoadField v11, :_fields_obj@0x1002
+          v22:BasicObject = LoadField v21, :@a@0x1002
+          Jump bb4(v22)
         bb6():
+          v24:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v25:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
+          v26 = RefineType v25, CUInt64
+          v27:CInt64 = IntAnd v12, v24
+          v28:CBool = IsBitEqual v27, v26
+          IfTrue v28, bb7()
+          Jump bb8()
+        bb7():
           PatchPoint RootBoxOnly
-          v30:RubyValue = LoadField v11, :_fields_obj@0x1004
-          v31:BasicObject = LoadField v30, :@a@0x1003
-          Jump bb4(v31)
+          v32:RubyValue = LoadField v11, :_fields_obj@0x1004
+          v33:BasicObject = LoadField v32, :@a@0x1002
+          Jump bb4(v33)
+        bb8():
+          v35:BasicObject = GetIvar v11, :@a
+          Jump bb4(v35)
         bb4(v13:BasicObject):
           CheckInterrupts
           Return v13
@@ -8228,17 +8272,19 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
           IfTrue v15, bb5(v9, v10, v10)
-          v24:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v24)
+          Jump bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           v20:ObjectSubclass[class_exact:C] = RefineType v18, ObjectSubclass[class_exact:C]
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v37:BasicObject = GetIvar v20, :@foo
-          Jump bb4(v16, v17, v37)
-        bb4(v26:BasicObject, v27:BasicObject, v28:BasicObject):
+          v38:BasicObject = GetIvar v20, :@foo
+          Jump bb4(v16, v17, v38)
+        bb6():
+          v25:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v25)
+        bb4(v27:BasicObject, v28:BasicObject, v29:BasicObject):
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -8377,13 +8423,15 @@ mod hir_opt_tests {
           v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
           v20:CBool = IsBlockParamModified v19
           IfTrue v20, bb4()
-          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1002
+          Jump bb5()
+        bb4():
+          v23:BasicObject = LoadField v18, :block@0x1002
+          Jump bb6(v23, v23)
+        bb5():
+          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
           v26:CInt64 = GuardAnyBitSet v25, CUInt64(1)
           v27:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v27, v10)
-        bb4():
-          v23:BasicObject = LoadField v18, :block@0x1010
-          Jump bb6(v23, v23)
         bb6(v16:BasicObject, v17:BasicObject):
           v30:BasicObject = Send v14, &block, :map, v16 # SendFallbackReason: Complex argument passing
           CheckInterrupts
@@ -8416,13 +8464,15 @@ mod hir_opt_tests {
           v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
           v20:CBool = IsBlockParamModified v19
           IfTrue v20, bb4()
-          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1002
+          Jump bb5()
+        bb4():
+          v23:BasicObject = LoadField v18, :block@0x1002
+          Jump bb6(v23, v23)
+        bb5():
+          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
           v26:CInt64[0] = GuardBitEquals v25, CInt64(0)
           v27:NilClass = Const Value(nil)
           Jump bb6(v27, v10)
-        bb4():
-          v23:BasicObject = LoadField v18, :block@0x1003
-          Jump bb6(v23, v23)
         bb6(v16:BasicObject, v17:BasicObject):
           v30:BasicObject = Send v14, &block, :map, v16 # SendFallbackReason: Complex argument passing
           CheckInterrupts
@@ -8456,13 +8506,15 @@ mod hir_opt_tests {
           v14:CUInt64 = LoadField v13, :_ep_flags@0x1000
           v15:CBool = IsBlockParamModified v14
           IfTrue v15, bb4()
-          v20:CInt64 = LoadField v13, :_env_data_index_specval@0x1001
+          Jump bb5()
+        bb4():
+          v18:BasicObject = LoadField v13, :block@0x1001
+          Jump bb6(v18)
+        bb5():
+          v20:CInt64 = LoadField v13, :_env_data_index_specval@0x1002
           v21:CInt64 = GuardAnyBitSet v20, CUInt64(1)
           v22:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v22)
-        bb4():
-          v18:BasicObject = LoadField v13, :block@0x1010
-          Jump bb6(v18)
         bb6(v12:BasicObject):
           v25:BasicObject = Send v10, &block, :map, v12 # SendFallbackReason: Complex argument passing
           CheckInterrupts
@@ -11951,13 +12003,15 @@ mod hir_opt_tests {
           v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
           v20:CBool = IsBlockParamModified v19
           IfTrue v20, bb4()
-          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1002
+          Jump bb5()
+        bb4():
+          v23:BasicObject = LoadField v18, :block@0x1002
+          Jump bb6(v23, v23)
+        bb5():
+          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
           v26:CInt64 = GuardAnyBitSet v25, CUInt64(1)
           v27:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v27, v10)
-        bb4():
-          v23:BasicObject = LoadField v18, :block@0x1010
-          Jump bb6(v23, v23)
         bb6(v16:BasicObject, v17:BasicObject):
           v30:BasicObject = Send v14, &block, :map, v16 # SendFallbackReason: Complex argument passing
           CheckInterrupts
@@ -13353,16 +13407,16 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint NoSingletonClass(C@0x1000)
           PatchPoint MethodRedefined(C@0x1000, class@0x1008, cme:0x1010)
-          v43:ObjectSubclass[class_exact:C] = GuardType v6, ObjectSubclass[class_exact:C]
-          v46:Class[C@0x1000] = Const Value(VALUE(0x1000))
+          v44:ObjectSubclass[class_exact:C] = GuardType v6, ObjectSubclass[class_exact:C]
+          v47:Class[C@0x1000] = Const Value(VALUE(0x1000))
           v13:StaticSymbol[:_lex_actions] = Const Value(VALUE(0x1038))
           v15:TrueClass = Const Value(true)
           PatchPoint MethodRedefined(Class@0x1040, respond_to?@0x1048, cme:0x1050)
           PatchPoint MethodRedefined(Class@0x1040, _lex_actions@0x1078, cme:0x1080)
-          v51:TrueClass = Const Value(true)
+          v52:TrueClass = Const Value(true)
           CheckInterrupts
-          v26:StaticSymbol[:CORRECT] = Const Value(VALUE(0x10a8))
-          Return v26
+          v27:StaticSymbol[:CORRECT] = Const Value(VALUE(0x10a8))
+          Return v27
         ");
     }
 
@@ -13520,23 +13574,23 @@ mod hir_opt_tests {
          CheckInterrupts
          SetLocal :formatted, l0, EP@3, v16
          PatchPoint SingleRactorMode
-         v60:HeapBasicObject = GuardType v15, HeapBasicObject
-         v61:CShape = LoadField v60, :_shape_id@0x1003
-         v62:CShape[0x1004] = GuardBitEquals v61, CShape(0x1004)
-         StoreField v60, :@formatted@0x1005, v16
-         WriteBarrier v60, v16
-         v65:CShape[0x1006] = Const CShape(0x1006)
-         StoreField v60, :_shape_id@0x1003, v65
-         v47:Class[VMFrozenCore] = Const Value(VALUE(0x1008))
+         v61:HeapBasicObject = GuardType v15, HeapBasicObject
+         v62:CShape = LoadField v61, :_shape_id@0x1003
+         v63:CShape[0x1004] = GuardBitEquals v62, CShape(0x1004)
+         StoreField v61, :@formatted@0x1005, v16
+         WriteBarrier v61, v16
+         v66:CShape[0x1006] = Const CShape(0x1006)
+         StoreField v61, :_shape_id@0x1003, v66
+         v48:Class[VMFrozenCore] = Const Value(VALUE(0x1008))
          PatchPoint MethodRedefined(Class@0x1010, lambda@0x1018, cme:0x1020)
-         v69:BasicObject = CCallWithFrame v47, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
-         v50:CPtr = GetEP 0
-         v51:BasicObject = LoadField v50, :a@0x1001
-         v52:BasicObject = LoadField v50, :_b@0x1002
-         v53:BasicObject = LoadField v50, :_c@0x1058
-         v54:BasicObject = LoadField v50, :formatted@0x1059
+         v70:BasicObject = CCallWithFrame v48, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
+         v51:CPtr = GetEP 0
+         v52:BasicObject = LoadField v51, :a@0x1001
+         v53:BasicObject = LoadField v51, :_b@0x1002
+         v54:BasicObject = LoadField v51, :_c@0x1058
+         v55:BasicObject = LoadField v51, :formatted@0x1059
          CheckInterrupts
-         Return v69
+         Return v70
        ");
     }
 
@@ -14566,32 +14620,34 @@ mod hir_opt_tests {
           v6:CPtr[CPtr(0x1002)] = Const CPtr(0x1002)
           v7:CBool = IsBitEqual v5, v6
           IfTrue v7, bb3(v1, v3, v4)
+          Jump bb6()
+        bb6():
           Jump bb5(v1, v3, v4)
         bb2():
           EntryPoint JIT(0)
-          v11:BasicObject = LoadArg :self@0
-          v12:BasicObject = LoadArg :needle@1
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v11, v12, v13)
-        bb3(v20:BasicObject, v21:BasicObject, v22:BasicObject):
-          v25:Fixnum[0] = Const Value(0)
-          Jump bb5(v20, v21, v25)
+          v12:BasicObject = LoadArg :self@0
+          v13:BasicObject = LoadArg :needle@1
+          v14:NilClass = Const Value(nil)
+          Jump bb3(v12, v13, v14)
+        bb3(v21:BasicObject, v22:BasicObject, v23:BasicObject):
+          v26:Fixnum[0] = Const Value(0)
+          Jump bb5(v21, v22, v26)
         bb4():
           EntryPoint JIT(1)
-          v16:BasicObject = LoadArg :self@0
-          v17:BasicObject = LoadArg :needle@1
-          v18:BasicObject = LoadArg :offset@2
-          Jump bb5(v16, v17, v18)
-        bb5(v28:BasicObject, v29:BasicObject, v30:BasicObject):
+          v17:BasicObject = LoadArg :self@0
+          v18:BasicObject = LoadArg :needle@1
+          v19:BasicObject = LoadArg :offset@2
+          Jump bb5(v17, v18, v19)
+        bb5(v29:BasicObject, v30:BasicObject, v31:BasicObject):
           PatchPoint MethodRedefined(String@0x1008, byteindex@0x1010, cme:0x1018)
-          v44:CPtr = GetEP 0
-          v45:RubyValue = LoadField v44, :_ep_method_entry@0x1040
-          v46:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v45, Value(VALUE(0x1048))
-          v47:RubyValue = LoadField v44, :_ep_specval@0x1050
-          v48:FalseClass = GuardBitEquals v47, Value(false)
-          v49:BasicObject = CCallVariadic v28, :String#byteindex@0x1058, v29, v30
+          v45:CPtr = GetEP 0
+          v46:RubyValue = LoadField v45, :_ep_method_entry@0x1040
+          v47:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v46, Value(VALUE(0x1048))
+          v48:RubyValue = LoadField v45, :_ep_specval@0x1050
+          v49:FalseClass = GuardBitEquals v48, Value(false)
+          v50:BasicObject = CCallVariadic v29, :String#byteindex@0x1058, v30, v31
           CheckInterrupts
-          Return v49
+          Return v50
         ");
     }
 
@@ -14724,25 +14780,27 @@ mod hir_opt_tests {
           v5:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v6:CBool = IsBitEqual v4, v5
           IfTrue v6, bb3(v1, v3)
+          Jump bb6()
+        bb6():
           Jump bb5(v1, v3)
         bb2():
           EntryPoint JIT(0)
-          v10:BasicObject = LoadArg :self@0
-          v11:NilClass = Const Value(nil)
-          Jump bb3(v10, v11)
-        bb3(v17:BasicObject, v18:BasicObject):
-          v21:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v22:StringExact = StringCopy v21
-          Jump bb5(v17, v22)
+          v11:BasicObject = LoadArg :self@0
+          v12:NilClass = Const Value(nil)
+          Jump bb3(v11, v12)
+        bb3(v18:BasicObject, v19:BasicObject):
+          v22:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v23:StringExact = StringCopy v22
+          Jump bb5(v18, v23)
         bb4():
           EntryPoint JIT(1)
-          v14:BasicObject = LoadArg :self@0
-          v15:BasicObject = LoadArg :content@1
-          Jump bb5(v14, v15)
-        bb5(v25:BasicObject, v26:BasicObject):
-          v32:BasicObject = InvokeSuper v25, 0x1010, v26 # SendFallbackReason: super: complex argument passing to `super` call
+          v15:BasicObject = LoadArg :self@0
+          v16:BasicObject = LoadArg :content@1
+          Jump bb5(v15, v16)
+        bb5(v26:BasicObject, v27:BasicObject):
+          v33:BasicObject = InvokeSuper v26, 0x1010, v27 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 
@@ -14783,14 +14841,16 @@ mod hir_opt_tests {
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
           IfFalse v16, bb6(v9, v17)
-          v19:Truthy = RefineType v10, Truthy
+          Jump bb7()
+        bb6(v46:BasicObject, v47:Falsy):
+          v51:Fixnum[6] = Const Value(6)
           CheckInterrupts
-          v38:Fixnum[3] = Const Value(3)
-          Return v38
-        bb6(v43:BasicObject, v44:Falsy):
-          v48:Fixnum[6] = Const Value(6)
+          Return v51
+        bb7():
+          v20:Truthy = RefineType v10, Truthy
           CheckInterrupts
-          Return v48
+          v41:Fixnum[3] = Const Value(3)
+          Return v41
         ");
     }
 
@@ -14828,27 +14888,31 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
           IfTrue v15, bb5(v9, v10, v10)
-          v24:CBool = HasType v10, ObjectSubclass[class_exact:D]
-          IfTrue v24, bb6(v9, v10, v10)
-          v33:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
+          Jump bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v55:Fixnum[3] = Const Value(3)
-          Jump bb4(v16, v17, v55)
-        bb6(v25:BasicObject, v26:BasicObject, v27:BasicObject):
+          v57:Fixnum[3] = Const Value(3)
+          Jump bb4(v16, v17, v57)
+        bb6():
+          v25:CBool = HasType v10, ObjectSubclass[class_exact:D]
+          IfTrue v25, bb7(v9, v10, v10)
+          Jump bb8()
+        bb7(v26:BasicObject, v27:BasicObject, v28:BasicObject):
           PatchPoint NoSingletonClass(D@0x1040)
           PatchPoint MethodRedefined(D@0x1040, foo@0x1010, cme:0x1048)
-          v56:Fixnum[4] = Const Value(4)
-          Jump bb4(v25, v26, v56)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
-          v40:Fixnum[2] = Const Value(2)
+          v58:Fixnum[4] = Const Value(4)
+          Jump bb4(v26, v27, v58)
+        bb8():
+          v35:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v35)
+        bb4(v37:BasicObject, v38:BasicObject, v39:BasicObject):
+          v42:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v59:Fixnum = GuardType v37, Fixnum
-          v60:Fixnum = FixnumAdd v59, v40
+          v61:Fixnum = GuardType v39, Fixnum
+          v62:Fixnum = FixnumAdd v61, v42
           CheckInterrupts
-          Return v60
+          Return v62
         ");
     }
 
@@ -14880,22 +14944,26 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
           IfTrue v15, bb5(v9, v10, v10)
-          v24:CBool = HasType v10, Fixnum
-          IfTrue v24, bb6(v9, v10, v10)
-          v33:BasicObject = Send v10, :itself # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
+          Jump bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           v20:ObjectSubclass[class_exact:C] = RefineType v18, ObjectSubclass[class_exact:C]
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, itself@0x1010, cme:0x1018)
           Jump bb4(v16, v17, v20)
-        bb6(v25:BasicObject, v26:BasicObject, v27:BasicObject):
-          v29:Fixnum = RefineType v27, Fixnum
+        bb6():
+          v25:CBool = HasType v10, Fixnum
+          IfTrue v25, bb7(v9, v10, v10)
+          Jump bb8()
+        bb7(v26:BasicObject, v27:BasicObject, v28:BasicObject):
+          v30:Fixnum = RefineType v28, Fixnum
           PatchPoint MethodRedefined(Integer@0x1040, itself@0x1010, cme:0x1018)
-          Jump bb4(v25, v26, v29)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          Jump bb4(v26, v27, v30)
+        bb8():
+          v35:BasicObject = Send v10, :itself # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v35)
+        bb4(v37:BasicObject, v38:BasicObject, v39:BasicObject):
           CheckInterrupts
-          Return v37
+          Return v39
         ");
     }
 
@@ -14933,23 +15001,27 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, Fixnum
           IfTrue v15, bb5(v9, v10, v10)
-          v24:CBool = HasType v10, Bignum
-          IfTrue v24, bb6(v9, v10, v10)
-          v33:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
+          Jump bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           v20:Fixnum = RefineType v18, Fixnum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v46:StringExact = CCallVariadic v20, :Integer#to_s@0x1040
-          Jump bb4(v16, v17, v46)
-        bb6(v25:BasicObject, v26:BasicObject, v27:BasicObject):
-          v29:Bignum = RefineType v27, Bignum
+          v48:StringExact = CCallVariadic v20, :Integer#to_s@0x1040
+          Jump bb4(v16, v17, v48)
+        bb6():
+          v25:CBool = HasType v10, Bignum
+          IfTrue v25, bb7(v9, v10, v10)
+          Jump bb8()
+        bb7(v26:BasicObject, v27:BasicObject, v28:BasicObject):
+          v30:Bignum = RefineType v28, Bignum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v49:StringExact = CCallVariadic v29, :Integer#to_s@0x1040
-          Jump bb4(v25, v26, v49)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          v51:StringExact = CCallVariadic v30, :Integer#to_s@0x1040
+          Jump bb4(v26, v27, v51)
+        bb8():
+          v35:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v35)
+        bb4(v37:BasicObject, v38:BasicObject, v39:BasicObject):
           CheckInterrupts
-          Return v37
+          Return v39
         ");
     }
 
@@ -14984,23 +15056,27 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, Flonum
           IfTrue v15, bb5(v9, v10, v10)
-          v24:CBool = HasType v10, HeapFloat
-          IfTrue v24, bb6(v9, v10, v10)
-          v33:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
+          Jump bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           v20:Flonum = RefineType v18, Flonum
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v46:BasicObject = CCallWithFrame v20, :Float#to_s@0x1040
-          Jump bb4(v16, v17, v46)
-        bb6(v25:BasicObject, v26:BasicObject, v27:BasicObject):
-          v29:HeapFloat = RefineType v27, HeapFloat
+          v48:BasicObject = CCallWithFrame v20, :Float#to_s@0x1040
+          Jump bb4(v16, v17, v48)
+        bb6():
+          v25:CBool = HasType v10, HeapFloat
+          IfTrue v25, bb7(v9, v10, v10)
+          Jump bb8()
+        bb7(v26:BasicObject, v27:BasicObject, v28:BasicObject):
+          v30:HeapFloat = RefineType v28, HeapFloat
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v49:BasicObject = CCallWithFrame v29, :Float#to_s@0x1040
-          Jump bb4(v25, v26, v49)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          v51:BasicObject = CCallWithFrame v30, :Float#to_s@0x1040
+          Jump bb4(v26, v27, v51)
+        bb8():
+          v35:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v35)
+        bb4(v37:BasicObject, v38:BasicObject, v39:BasicObject):
           CheckInterrupts
-          Return v37
+          Return v39
         ");
     }
 
@@ -15035,23 +15111,27 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, StaticSymbol
           IfTrue v15, bb5(v9, v10, v10)
-          v24:CBool = HasType v10, DynamicSymbol
-          IfTrue v24, bb6(v9, v10, v10)
-          v33:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
+          Jump bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           v20:StaticSymbol = RefineType v18, StaticSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v48:StringExact = InvokeBuiltin leaf <inline_expr>, v20
-          Jump bb4(v16, v17, v48)
-        bb6(v25:BasicObject, v26:BasicObject, v27:BasicObject):
-          v29:DynamicSymbol = RefineType v27, DynamicSymbol
+          v50:StringExact = InvokeBuiltin leaf <inline_expr>, v20
+          Jump bb4(v16, v17, v50)
+        bb6():
+          v25:CBool = HasType v10, DynamicSymbol
+          IfTrue v25, bb7(v9, v10, v10)
+          Jump bb8()
+        bb7(v26:BasicObject, v27:BasicObject, v28:BasicObject):
+          v30:DynamicSymbol = RefineType v28, DynamicSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v49:StringExact = InvokeBuiltin leaf <inline_expr>, v29
-          Jump bb4(v25, v26, v49)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          v51:StringExact = InvokeBuiltin leaf <inline_expr>, v30
+          Jump bb4(v26, v27, v51)
+        bb8():
+          v35:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v35)
+        bb4(v37:BasicObject, v38:BasicObject, v39:BasicObject):
           CheckInterrupts
-          Return v37
+          Return v39
         ");
     }
 
@@ -15090,16 +15170,18 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
           IfTrue v15, bb5(v9, v10, v10)
-          v24:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v24)
+          Jump bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v38:Fixnum[3] = Const Value(3)
-          Jump bb4(v16, v17, v38)
-        bb4(v26:BasicObject, v27:BasicObject, v28:BasicObject):
+          v39:Fixnum[3] = Const Value(3)
+          Jump bb4(v16, v17, v39)
+        bb6():
+          v25:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v25)
+        bb4(v27:BasicObject, v28:BasicObject, v29:BasicObject):
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -15207,48 +15289,54 @@ mod hir_opt_tests {
           v8:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
           v9:CBool = IsBitEqual v7, v8
           IfTrue v9, bb3(v1, v3, v4, v5, v6)
-          v11:CPtr[CPtr(0x1004)] = Const CPtr(0x1004)
-          v12:CBool = IsBitEqual v7, v11
-          IfTrue v12, bb5(v1, v3, v4, v5, v6)
+          Jump bb9()
+        bb9():
+          v12:CPtr[CPtr(0x1004)] = Const CPtr(0x1004)
+          v13:CBool = IsBitEqual v7, v12
+          IfTrue v13, bb5(v1, v3, v4, v5, v6)
+          Jump bb10()
+        bb10():
           Jump bb7(v1, v3, v4, v5, v6)
         bb2():
           EntryPoint JIT(0)
-          v16:BasicObject = LoadArg :self@0
-          v17:BasicObject = LoadArg :list@1
-          v18:NilClass = Const Value(nil)
-          v19:NilClass = Const Value(nil)
+          v18:BasicObject = LoadArg :self@0
+          v19:BasicObject = LoadArg :list@1
           v20:NilClass = Const Value(nil)
-          Jump bb3(v16, v17, v18, v19, v20)
-        bb3(v36:BasicObject, v37:BasicObject, v38:BasicObject, v39:BasicObject, v40:NilClass):
-          v43:NilClass = Const Value(nil)
-          SetLocal :sep, l0, EP@5, v43
-          Jump bb5(v36, v37, v43, v39, v40)
+          v21:NilClass = Const Value(nil)
+          v22:NilClass = Const Value(nil)
+          Jump bb3(v18, v19, v20, v21, v22)
+        bb3(v38:BasicObject, v39:BasicObject, v40:BasicObject, v41:BasicObject, v42:NilClass):
+          v45:NilClass = Const Value(nil)
+          SetLocal :sep, l0, EP@5, v45
+          Jump bb5(v38, v39, v45, v41, v42)
         bb4():
           EntryPoint JIT(1)
-          v23:BasicObject = LoadArg :self@0
-          v24:BasicObject = LoadArg :list@1
-          v25:BasicObject = LoadArg :sep@2
-          v26:NilClass = Const Value(nil)
-          v27:NilClass = Const Value(nil)
-          Jump bb5(v23, v24, v25, v26, v27)
-        bb5(v47:BasicObject, v48:BasicObject, v49:BasicObject, v50:BasicObject, v51:NilClass):
-          v54:StaticSymbol[:each] = Const Value(VALUE(0x1008))
-          SetLocal :iter_method, l0, EP@4, v54
-          Jump bb7(v47, v48, v49, v54, v51)
+          v25:BasicObject = LoadArg :self@0
+          v26:BasicObject = LoadArg :list@1
+          v27:BasicObject = LoadArg :sep@2
+          v28:NilClass = Const Value(nil)
+          v29:NilClass = Const Value(nil)
+          Jump bb5(v25, v26, v27, v28, v29)
+        bb5(v49:BasicObject, v50:BasicObject, v51:BasicObject, v52:BasicObject, v53:NilClass):
+          v56:StaticSymbol[:each] = Const Value(VALUE(0x1008))
+          SetLocal :iter_method, l0, EP@4, v56
+          Jump bb7(v49, v50, v51, v56, v53)
         bb6():
           EntryPoint JIT(2)
-          v30:BasicObject = LoadArg :self@0
-          v31:BasicObject = LoadArg :list@1
-          v32:BasicObject = LoadArg :sep@2
-          v33:BasicObject = LoadArg :iter_method@3
-          v34:NilClass = Const Value(nil)
-          Jump bb7(v30, v31, v32, v33, v34)
-        bb7(v58:BasicObject, v59:BasicObject, v60:BasicObject, v61:BasicObject, v62:NilClass):
+          v32:BasicObject = LoadArg :self@0
+          v33:BasicObject = LoadArg :list@1
+          v34:BasicObject = LoadArg :sep@2
+          v35:BasicObject = LoadArg :iter_method@3
+          v36:NilClass = Const Value(nil)
+          Jump bb7(v32, v33, v34, v35, v36)
+        bb7(v60:BasicObject, v61:BasicObject, v62:BasicObject, v63:BasicObject, v64:NilClass):
           CheckInterrupts
-          v68:CBool = Test v60
-          v69:Truthy = RefineType v60, Truthy
-          IfTrue v68, bb8(v58, v59, v69, v61, v62)
-          v71:Falsy = RefineType v60, Falsy
+          v70:CBool = Test v62
+          v71:Truthy = RefineType v62, Truthy
+          IfTrue v70, bb8(v60, v61, v71, v63, v64)
+          Jump bb11()
+        bb11():
+          v74:Falsy = RefineType v62, Falsy
           PatchPoint MethodRedefined(Object@0x1010, lambda@0x1018, cme:0x1020)
           v118:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v58, ObjectSubclass[class_exact*:Object@VALUE(0x1010)]
           v119:BasicObject = CCallWithFrame v118, :Kernel#lambda@0x1048, block=0x1050
@@ -15261,20 +15349,20 @@ mod hir_opt_tests {
         bb8(v83:BasicObject, v84:BasicObject, v85:BasicObject, v86:BasicObject, v87:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1060, CONST)
-          v115:HashExact[VALUE(0x1068)] = Const Value(VALUE(0x1068))
-          SetLocal :kwsplat, l0, EP@3, v115
-          v96:CPtr = GetEP 0
-          v97:BasicObject = LoadField v96, :list@0x1001
+          v118:HashExact[VALUE(0x1068)] = Const Value(VALUE(0x1068))
+          SetLocal :kwsplat, l0, EP@3, v118
           v99:CPtr = GetEP 0
-          v100:BasicObject = LoadField v99, :iter_method@0x1058
-          v102:BasicObject = Send v97, 0x1070, :__send__, v100 # SendFallbackReason: Send: unsupported method type Optimized
-          v103:CPtr = GetEP 0
-          v104:BasicObject = LoadField v103, :list@0x1001
-          v105:BasicObject = LoadField v103, :sep@0x1002
-          v106:BasicObject = LoadField v103, :iter_method@0x1058
-          v107:BasicObject = LoadField v103, :kwsplat@0x1059
+          v100:BasicObject = LoadField v99, :list@0x1001
+          v102:CPtr = GetEP 0
+          v103:BasicObject = LoadField v102, :iter_method@0x1058
+          v105:BasicObject = Send v100, 0x1070, :__send__, v103 # SendFallbackReason: Send: unsupported method type Optimized
+          v106:CPtr = GetEP 0
+          v107:BasicObject = LoadField v106, :list@0x1001
+          v108:BasicObject = LoadField v106, :sep@0x1002
+          v109:BasicObject = LoadField v106, :iter_method@0x1058
+          v110:BasicObject = LoadField v106, :kwsplat@0x1059
           CheckInterrupts
-          Return v102
+          Return v105
         ");
     }
 
@@ -15298,30 +15386,34 @@ mod hir_opt_tests {
           v15:TrueClass|NilClass = Defined yield, v13
           v17:CBool = Test v15
           IfFalse v17, bb4(v8, v9)
-          v35:Fixnum[0] = Const Value(0)
-          Jump bb8(v8, v35)
-        bb4(v23:BasicObject, v24:NilClass):
-          v28:BasicObject = InvokeBuiltin <inline_expr>, v23
+          Jump bb9()
+        bb4(v24:BasicObject, v25:NilClass):
+          v29:BasicObject = InvokeBuiltin <inline_expr>, v24
           CheckInterrupts
-          Return v28
-        bb8(v48:BasicObject, v49:Fixnum):
-          v84:Array = RefineType v48, Array
-          v85:CInt64 = ArrayLength v84
-          v86:Fixnum = BoxFixnum v85
-          v87:BoolExact = FixnumGe v49, v86
-          v54:CBool = Test v87
-          IfFalse v54, bb7(v48, v49)
-          CheckInterrupts
-          Return v48
-        bb7(v67:BasicObject, v68:Fixnum):
-          v88:Array = RefineType v67, Array
-          v89:CInt64 = UnboxFixnum v68
-          v90:BasicObject = ArrayAref v88, v89
-          v74:BasicObject = InvokeBlock, v90 # SendFallbackReason: InvokeBlock: not yet specialized
-          v91:Fixnum[1] = Const Value(1)
-          v92:Fixnum = FixnumAdd v68, v91
+          Return v29
+        bb9():
+          v36:Fixnum[0] = Const Value(0)
+          Jump bb8(v8, v36)
+        bb8(v49:BasicObject, v50:Fixnum):
+          v86:Array = RefineType v49, Array
+          v87:CInt64 = ArrayLength v86
+          v88:Fixnum = BoxFixnum v87
+          v89:BoolExact = FixnumGe v50, v88
+          v55:CBool = Test v89
+          IfFalse v55, bb7(v49, v50)
+          Jump bb10()
+        bb7(v69:BasicObject, v70:Fixnum):
+          v90:Array = RefineType v69, Array
+          v91:CInt64 = UnboxFixnum v70
+          v92:BasicObject = ArrayAref v90, v91
+          v76:BasicObject = InvokeBlock, v92 # SendFallbackReason: InvokeBlock: not yet specialized
+          v93:Fixnum[1] = Const Value(1)
+          v94:Fixnum = FixnumAdd v70, v93
           PatchPoint NoEPEscape(each)
-          Jump bb8(v67, v92)
+          Jump bb8(v69, v94)
+        bb10():
+          CheckInterrupts
+          Return v49
         ");
     }
 
@@ -15539,7 +15631,7 @@ mod hir_opt_tests {
 
         // After profiling via the side exit, rebuilding HIR should now
         // have a SendDirect for greet_recompile instead of SideExit.
-        assert_snapshot!(hir_string("test_no_profile_recompile"), @r"
+        assert_snapshot!(hir_string("test_no_profile_recompile"), @"
         fn test_no_profile_recompile@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -15557,18 +15649,20 @@ mod hir_opt_tests {
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
           IfFalse v16, bb4(v9, v17)
-          v19:Truthy = RefineType v10, Truthy
-          v23:Fixnum[42] = Const Value(42)
-          PatchPoint MethodRedefined(Object@0x1008, greet_recompile@0x1010, cme:0x1018)
-          v43:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)]
-          v44:BasicObject = SendDirect v43, 0x1040, :greet_recompile (0x1050), v23
+          Jump bb5()
+        bb4(v31:BasicObject, v32:Falsy):
+          v36:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v37:StringExact = StringCopy v36
           CheckInterrupts
-          Return v44
-        bb4(v30:BasicObject, v31:Falsy):
-          v35:StringExact[VALUE(0x1058)] = Const Value(VALUE(0x1058))
-          v36:StringExact = StringCopy v35
+          Return v37
+        bb5():
+          v20:Truthy = RefineType v10, Truthy
+          v24:Fixnum[42] = Const Value(42)
+          PatchPoint MethodRedefined(Object@0x1010, greet_recompile@0x1018, cme:0x1020)
+          v44:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1010)]
+          v45:BasicObject = SendDirect v44, 0x1048, :greet_recompile (0x1058), v24
           CheckInterrupts
-          Return v36
+          Return v45
         ");
     }
 
@@ -15597,7 +15691,7 @@ mod hir_opt_tests {
         eval("3.times { test_final_version(false) }");
 
         // On the final version, greet_final should be a Send fallback, not a SideExit.
-        assert_snapshot!(hir_string("test_final_version"), @r"
+        assert_snapshot!(hir_string("test_final_version"), @"
         fn test_final_version@<compiled>:4:
         bb1():
           EntryPoint interpreter
@@ -15615,16 +15709,18 @@ mod hir_opt_tests {
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
           IfFalse v16, bb4(v9, v17)
-          v19:Truthy = RefineType v10, Truthy
-          v23:Fixnum[42] = Const Value(42)
-          v25:BasicObject = Send v9, :greet_final, v23 # SendFallbackReason: SendWithoutBlock: no profile data available
+          Jump bb5()
+        bb4(v31:BasicObject, v32:Falsy):
+          v36:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v37:StringExact = StringCopy v36
           CheckInterrupts
-          Return v25
-        bb4(v30:BasicObject, v31:Falsy):
-          v35:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v36:StringExact = StringCopy v35
+          Return v37
+        bb5():
+          v20:Truthy = RefineType v10, Truthy
+          v24:Fixnum[42] = Const Value(42)
+          v26:BasicObject = Send v9, :greet_final, v24 # SendFallbackReason: SendWithoutBlock: no profile data available
           CheckInterrupts
-          Return v36
+          Return v26
         ");
     }
 
@@ -15659,28 +15755,32 @@ mod hir_opt_tests {
           v16:CInt64[3] = Const CInt64(3)
           v17:CBool = IsBitEqual v15, v16
           IfTrue v17, bb5()
-          v22:BasicObject = InvokeBlock, v10 # SendFallbackReason: InvokeBlock: not yet specialized
-          Jump bb4(v22)
+          Jump bb6()
         bb5():
-          v20:BasicObject = InvokeBlockIfunc v13, v10
-          Jump bb4(v20)
+          v21:BasicObject = InvokeBlockIfunc v13, v10
+          Jump bb4(v21)
+        bb6():
+          v23:BasicObject = InvokeBlock, v10 # SendFallbackReason: InvokeBlock: not yet specialized
+          Jump bb4(v23)
         bb4(v18:BasicObject):
-          v27:Fixnum[2] = Const Value(2)
-          v29:CPtr = GetEP 0
-          v30:CInt64 = LoadField v29, :_env_data_index_specval@0x1000
-          v31:CInt64[3] = Const CInt64(3)
-          v32:CInt64 = IntAnd v30, v31
-          v33:CInt64[3] = Const CInt64(3)
-          v34:CBool = IsBitEqual v32, v33
-          IfTrue v34, bb7()
-          v39:BasicObject = InvokeBlock, v27 # SendFallbackReason: InvokeBlock: not yet specialized
-          Jump bb6(v39)
-        bb7():
-          v37:BasicObject = InvokeBlockIfunc v30, v27
-          Jump bb6(v37)
-        bb6(v35:BasicObject):
+          v28:Fixnum[2] = Const Value(2)
+          v30:CPtr = GetEP 0
+          v31:CInt64 = LoadField v30, :_env_data_index_specval@0x1000
+          v32:CInt64[3] = Const CInt64(3)
+          v33:CInt64 = IntAnd v31, v32
+          v34:CInt64[3] = Const CInt64(3)
+          v35:CBool = IsBitEqual v33, v34
+          IfTrue v35, bb8()
+          Jump bb9()
+        bb8():
+          v39:BasicObject = InvokeBlockIfunc v31, v28
+          Jump bb7(v39)
+        bb9():
+          v41:BasicObject = InvokeBlock, v28 # SendFallbackReason: InvokeBlock: not yet specialized
+          Jump bb7(v41)
+        bb7(v36:BasicObject):
           CheckInterrupts
-          Return v35
+          Return v36
         ");
     }
 
@@ -15822,59 +15922,67 @@ mod hir_opt_tests {
         bb6(v19:BasicObject, v20:Fixnum):
           v24:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
-          v110:BoolExact = FixnumLt v20, v24
+          v114:BoolExact = FixnumLt v20, v24
           CheckInterrupts
-          v30:CBool = Test v110
+          v30:CBool = Test v114
           IfTrue v30, bb4(v19, v20)
-          v35:NilClass = Const Value(nil)
-          CheckInterrupts
-          Return v35
-        bb4(v40:BasicObject, v41:Fixnum):
+          Jump bb7()
+        bb4(v41:BasicObject, v42:Fixnum):
           PatchPoint SingleRactorMode
-          v46:HeapBasicObject = GuardType v40, HeapBasicObject
-          v47:CUInt64 = LoadField v46, :_rbasic_flags@0x1038
-          v49:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v50:CPtr[CPtr(0x1039)] = Const CPtr(0x1039)
-          v51 = RefineType v50, CUInt64
-          v52:CInt64 = IntAnd v47, v49
-          v53:CBool = IsBitEqual v52, v51
-          IfTrue v53, bb8()
-          v57:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v58:CPtr[CPtr(0x103a)] = Const CPtr(0x103a)
-          v59 = RefineType v58, CUInt64
-          v60:CInt64 = IntAnd v47, v57
-          v61:CBool = IsBitEqual v60, v59
-          IfTrue v61, bb9()
-          v97:CShape = LoadField v46, :_shape_id@0x103b
-          v98:CShape[0x103c] = GuardBitEquals v97, CShape(0x103c)
-          v99:BasicObject = LoadField v46, :@levar@0x103d
-          Jump bb7(v99)
-        bb8():
-          v55:BasicObject = LoadField v46, :@levar@0x103d
-          Jump bb7(v55)
+          v47:HeapBasicObject = GuardType v41, HeapBasicObject
+          v48:CUInt64 = LoadField v47, :_rbasic_flags@0x1038
+          v50:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v51:CPtr[CPtr(0x1039)] = Const CPtr(0x1039)
+          v52 = RefineType v51, CUInt64
+          v53:CInt64 = IntAnd v48, v50
+          v54:CBool = IsBitEqual v53, v52
+          IfTrue v54, bb9()
+          Jump bb10()
         bb9():
-          v63:NilClass = Const Value(nil)
-          Jump bb7(v63)
-        bb7(v48:BasicObject):
+          v57:BasicObject = LoadField v47, :@levar@0x103a
+          Jump bb8(v57)
+        bb10():
+          v59:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v60:CPtr[CPtr(0x103b)] = Const CPtr(0x103b)
+          v61 = RefineType v60, CUInt64
+          v62:CInt64 = IntAnd v48, v59
+          v63:CBool = IsBitEqual v62, v61
+          IfTrue v63, bb11()
+          Jump bb12()
+        bb11():
+          v66:NilClass = Const Value(nil)
+          Jump bb8(v66)
+        bb12():
+          v101:CShape = LoadField v47, :_shape_id@0x103c
+          v102:CShape[0x103d] = GuardBitEquals v101, CShape(0x103d)
+          v103:BasicObject = LoadField v47, :@levar@0x103a
+          Jump bb8(v103)
+        bb8(v49:BasicObject):
           CheckInterrupts
-          v69:CBool = Test v48
-          IfTrue v69, bb5(v46, v41)
+          v72:CBool = Test v49
+          IfTrue v72, bb5(v47, v42)
+          Jump bb13()
+        bb13():
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
-          v101:CShape = LoadField v46, :_shape_id@0x103b
-          v102:CShape[0x103e] = GuardBitEquals v101, CShape(0x103e)
-          StoreField v46, :@levar@0x103d, v41
-          WriteBarrier v46, v41
-          v105:CShape[0x103c] = Const CShape(0x103c)
-          StoreField v46, :_shape_id@0x103b, v105
-          v79:HeapBasicObject = RefineType v46, HeapBasicObject
-          Jump bb5(v79, v41)
-        bb5(v81:HeapBasicObject, v82:Fixnum):
+          v105:CShape = LoadField v47, :_shape_id@0x103c
+          v106:CShape[0x103e] = GuardBitEquals v105, CShape(0x103e)
+          StoreField v47, :@levar@0x103a, v42
+          WriteBarrier v47, v42
+          v109:CShape[0x103d] = Const CShape(0x103d)
+          StoreField v47, :_shape_id@0x103c, v109
+          v83:HeapBasicObject = RefineType v47, HeapBasicObject
+          Jump bb5(v83, v42)
+        bb5(v85:HeapBasicObject, v86:Fixnum):
           PatchPoint NoEPEscape(set_value_loop)
-          v89:Fixnum[1] = Const Value(1)
+          v93:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, +@0x103f, cme:0x1040)
-          v114:Fixnum = FixnumAdd v82, v89
-          Jump bb6(v81, v114)
+          v118:Fixnum = FixnumAdd v86, v93
+          Jump bb6(v85, v118)
+        bb7():
+          v36:NilClass = Const Value(nil)
+          CheckInterrupts
+          Return v36
         ");
     }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -53,8 +53,8 @@ mod hir_opt_tests {
         bb3(v8:BasicObject, v9:NilClass):
           v13:TrueClass = Const Value(true)
           CheckInterrupts
-          v26:Fixnum[3] = Const Value(3)
-          Return v26
+          v25:Fixnum[3] = Const Value(3)
+          Return v25
         ");
     }
 
@@ -85,8 +85,8 @@ mod hir_opt_tests {
         bb3(v8:BasicObject, v9:NilClass):
           v13:FalseClass = Const Value(false)
           CheckInterrupts
-          v36:Fixnum[4] = Const Value(4)
-          Return v36
+          v35:Fixnum[4] = Const Value(4)
+          Return v35
         ");
     }
 
@@ -755,10 +755,10 @@ mod hir_opt_tests {
           v10:Fixnum[1] = Const Value(1)
           v12:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
-          v43:TrueClass = Const Value(true)
+          v42:TrueClass = Const Value(true)
           CheckInterrupts
-          v25:Fixnum[3] = Const Value(3)
-          Return v25
+          v24:Fixnum[3] = Const Value(3)
+          Return v24
         ");
     }
 
@@ -787,10 +787,10 @@ mod hir_opt_tests {
           v10:Fixnum[1] = Const Value(1)
           v12:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1000, <=@0x1008, cme:0x1010)
-          v60:TrueClass = Const Value(true)
+          v58:TrueClass = Const Value(true)
           CheckInterrupts
-          v39:Fixnum[3] = Const Value(3)
-          Return v39
+          v37:Fixnum[3] = Const Value(3)
+          Return v37
         ");
     }
 
@@ -819,10 +819,10 @@ mod hir_opt_tests {
           v10:Fixnum[2] = Const Value(2)
           v12:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, >@0x1008, cme:0x1010)
-          v43:TrueClass = Const Value(true)
+          v42:TrueClass = Const Value(true)
           CheckInterrupts
-          v25:Fixnum[3] = Const Value(3)
-          Return v25
+          v24:Fixnum[3] = Const Value(3)
+          Return v24
         ");
     }
 
@@ -851,10 +851,10 @@ mod hir_opt_tests {
           v10:Fixnum[2] = Const Value(2)
           v12:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, >=@0x1008, cme:0x1010)
-          v60:TrueClass = Const Value(true)
+          v58:TrueClass = Const Value(true)
           CheckInterrupts
-          v39:Fixnum[3] = Const Value(3)
-          Return v39
+          v37:Fixnum[3] = Const Value(3)
+          Return v37
         ");
     }
 
@@ -883,10 +883,10 @@ mod hir_opt_tests {
           v10:Fixnum[1] = Const Value(1)
           v12:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1000, ==@0x1008, cme:0x1010)
-          v43:FalseClass = Const Value(false)
+          v42:FalseClass = Const Value(false)
           CheckInterrupts
-          v34:Fixnum[4] = Const Value(4)
-          Return v34
+          v33:Fixnum[4] = Const Value(4)
+          Return v33
         ");
     }
 
@@ -915,10 +915,10 @@ mod hir_opt_tests {
           v10:Fixnum[2] = Const Value(2)
           v12:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1000, ==@0x1008, cme:0x1010)
-          v43:TrueClass = Const Value(true)
+          v42:TrueClass = Const Value(true)
           CheckInterrupts
-          v25:Fixnum[3] = Const Value(3)
-          Return v25
+          v24:Fixnum[3] = Const Value(3)
+          Return v24
         ");
     }
 
@@ -948,10 +948,10 @@ mod hir_opt_tests {
           v12:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1000, !=@0x1008, cme:0x1010)
           PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
-          v44:TrueClass = Const Value(true)
+          v43:TrueClass = Const Value(true)
           CheckInterrupts
-          v25:Fixnum[3] = Const Value(3)
-          Return v25
+          v24:Fixnum[3] = Const Value(3)
+          Return v24
         ");
     }
 
@@ -981,10 +981,10 @@ mod hir_opt_tests {
           v12:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1000, !=@0x1008, cme:0x1010)
           PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
-          v44:FalseClass = Const Value(false)
+          v43:FalseClass = Const Value(false)
           CheckInterrupts
-          v34:Fixnum[4] = Const Value(4)
-          Return v34
+          v33:Fixnum[4] = Const Value(4)
+          Return v33
         ");
     }
 
@@ -4449,15 +4449,15 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, C)
-          v44:Class[C@0x1008] = Const Value(VALUE(0x1008))
+          v43:Class[C@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(C@0x1008, new@0x1009, cme:0x1010)
-          v47:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
+          v46:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, initialize@0x1038, cme:0x1040)
-          v51:NilClass = Const Value(nil)
+          v50:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v47
+          Return v46
         ");
     }
 
@@ -4485,16 +4485,16 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, C)
-          v47:Class[C@0x1008] = Const Value(VALUE(0x1008))
+          v46:Class[C@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(C@0x1008, new@0x1009, cme:0x1010)
-          v50:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
+          v49:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, initialize@0x1038, cme:0x1040)
-          v53:BasicObject = SendDirect v50, 0x1068, :initialize (0x1078), v15
+          v52:BasicObject = SendDirect v49, 0x1068, :initialize (0x1078), v15
           CheckInterrupts
-          Return v50
+          Return v49
         ");
     }
 
@@ -4517,15 +4517,15 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Object)
-          v44:Class[Object@0x1008] = Const Value(VALUE(0x1008))
+          v43:Class[Object@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(Object@0x1008, new@0x1009, cme:0x1010)
-          v47:ObjectExact = ObjectAllocClass Object:VALUE(0x1008)
+          v46:ObjectExact = ObjectAllocClass Object:VALUE(0x1008)
           PatchPoint NoSingletonClass(Object@0x1008)
           PatchPoint MethodRedefined(Object@0x1008, initialize@0x1038, cme:0x1040)
-          v51:NilClass = Const Value(nil)
+          v50:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v47
+          Return v46
         ");
     }
 
@@ -4548,15 +4548,15 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, BasicObject)
-          v44:Class[BasicObject@0x1008] = Const Value(VALUE(0x1008))
+          v43:Class[BasicObject@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(BasicObject@0x1008, new@0x1009, cme:0x1010)
-          v47:BasicObjectExact = ObjectAllocClass BasicObject:VALUE(0x1008)
+          v46:BasicObjectExact = ObjectAllocClass BasicObject:VALUE(0x1008)
           PatchPoint NoSingletonClass(BasicObject@0x1008)
           PatchPoint MethodRedefined(BasicObject@0x1008, initialize@0x1038, cme:0x1040)
-          v51:NilClass = Const Value(nil)
+          v50:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v47
+          Return v46
         ");
     }
 
@@ -4579,16 +4579,16 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Hash)
-          v44:Class[Hash@0x1008] = Const Value(VALUE(0x1008))
+          v43:Class[Hash@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(Hash@0x1008, new@0x1009, cme:0x1010)
-          v47:HashExact = ObjectAllocClass Hash:VALUE(0x1008)
-          v48:Fixnum[0] = Const Value(0)
+          v46:HashExact = ObjectAllocClass Hash:VALUE(0x1008)
+          v47:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, initialize@0x1038, cme:0x1040)
-          v52:BasicObject = SendDirect v47, 0x1068, :initialize (0x1078), v48
+          v51:BasicObject = SendDirect v46, 0x1068, :initialize (0x1078), v47
           CheckInterrupts
-          Return v47
+          Return v46
         ");
         assert_snapshot!(inspect("test"), @"{}");
     }
@@ -4612,14 +4612,14 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Array)
-          v47:Class[Array@0x1008] = Const Value(VALUE(0x1008))
+          v46:Class[Array@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Array@0x1008, new@0x1009, cme:0x1010)
           PatchPoint MethodRedefined(Class@0x1038, new@0x1009, cme:0x1010)
-          v53:BasicObject = CCallVariadic v47, :Array.new@0x1040, v15
+          v52:BasicObject = CCallVariadic v46, :Array.new@0x1040, v15
           CheckInterrupts
-          Return v53
+          Return v52
         ");
     }
 
@@ -4642,14 +4642,14 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Set)
-          v44:Class[Set@0x1008] = Const Value(VALUE(0x1008))
+          v43:Class[Set@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(Set@0x1008, new@0x1009, cme:0x1010)
-          v18:HeapBasicObject = ObjectAlloc v44
+          v17:HeapBasicObject = ObjectAlloc v43
           PatchPoint NoSingletonClass(Set@0x1008)
           PatchPoint MethodRedefined(Set@0x1008, initialize@0x1038, cme:0x1040)
-          v50:SetExact = GuardType v18, SetExact
-          v51:BasicObject = CCallVariadic v50, :Set#initialize@0x1068
+          v49:SetExact = GuardType v17, SetExact
+          v50:BasicObject = CCallVariadic v49, :Set#initialize@0x1068
           CheckInterrupts
           Return v49
         ");
@@ -4674,13 +4674,13 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, String)
-          v44:Class[String@0x1008] = Const Value(VALUE(0x1008))
+          v43:Class[String@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(String@0x1008, new@0x1009, cme:0x1010)
           PatchPoint MethodRedefined(Class@0x1038, new@0x1009, cme:0x1010)
-          v50:BasicObject = CCallVariadic v44, :String.new@0x1040
+          v53:BasicObject = CCallVariadic v43, :String.new@0x1040
           CheckInterrupts
-          Return v50
+          Return v53
         ");
     }
 
@@ -4703,17 +4703,17 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Regexp)
-          v48:Class[Regexp@0x1008] = Const Value(VALUE(0x1008))
+          v47:Class[Regexp@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           v15:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
           v16:StringExact = StringCopy v15
           PatchPoint MethodRedefined(Regexp@0x1008, new@0x1018, cme:0x1020)
-          v51:RegexpExact = ObjectAllocClass Regexp:VALUE(0x1008)
+          v50:RegexpExact = ObjectAllocClass Regexp:VALUE(0x1008)
           PatchPoint NoSingletonClass(Regexp@0x1008)
           PatchPoint MethodRedefined(Regexp@0x1008, initialize@0x1048, cme:0x1050)
-          v55:BasicObject = CCallVariadic v51, :Regexp#initialize@0x1078, v16
+          v54:BasicObject = CCallVariadic v50, :Regexp#initialize@0x1078, v16
           CheckInterrupts
-          Return v51
+          Return v50
         ");
     }
 
@@ -4889,16 +4889,15 @@ mod hir_opt_tests {
           v17:CPtr = GetEP 0
           v18:CUInt64 = LoadField v17, :_ep_flags@0x1001
           v19:CBool = IsBlockParamModified v18
-          IfTrue v19, bb4()
-          Jump bb5()
+          CondBranch v19, bb4(), bb5()
         bb4():
-          v22:BasicObject = LoadField v17, :block@0x1002
-          Jump bb6(v22, v22)
+          v21:BasicObject = LoadField v17, :block@0x1002
+          Jump bb6(v21, v21)
         bb5():
-          v24:CInt64 = LoadField v17, :_env_data_index_specval@0x1003
-          v25:CInt64 = GuardAnyBitSet v24, CUInt64(1)
-          v26:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v26, v10)
+          v23:CInt64 = LoadField v17, :_env_data_index_specval@0x1003
+          v24:CInt64 = GuardAnyBitSet v23, CUInt64(1)
+          v25:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v25, v10)
         bb6(v15:BasicObject, v16:BasicObject):
           SideExit NoProfileSend recompile
         ");
@@ -4932,29 +4931,27 @@ mod hir_opt_tests {
           v18:CPtr = GetEP 0
           v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
           v20:CBool = IsBlockParamModified v19
-          IfTrue v20, bb4()
-          Jump bb5()
+          CondBranch v20, bb4(), bb5()
         bb4():
-          v23:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v23)
+          v22:BasicObject = LoadField v18, :block@0x1002
+          Jump bb6(v22)
         bb5():
-          v25:BasicObject = GetBlockParam :block, l0, EP@4
-          Jump bb6(v25)
+          v24:BasicObject = GetBlockParam :block, l0, EP@4
+          Jump bb6(v24)
         bb6(v17:BasicObject):
-          v33:CPtr = GetEP 0
-          v34:CUInt64 = LoadField v33, :_ep_flags@0x1001
-          v35:CBool = IsBlockParamModified v34
-          IfTrue v35, bb7()
-          Jump bb8()
+          v32:CPtr = GetEP 0
+          v33:CUInt64 = LoadField v32, :_ep_flags@0x1001
+          v34:CBool = IsBlockParamModified v33
+          CondBranch v34, bb7(), bb8()
         bb7():
-          v38:BasicObject = LoadField v33, :block@0x1002
-          Jump bb9(v38, v38)
+          v36:BasicObject = LoadField v32, :block@0x1002
+          Jump bb9(v36, v36)
         bb8():
-          v40:CInt64 = LoadField v33, :_env_data_index_specval@0x1003
-          v41:CInt64 = GuardAnyBitSet v40, CUInt64(1)
-          v42:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb9(v42, v17)
-        bb9(v31:BasicObject, v32:BasicObject):
+          v38:CInt64 = LoadField v32, :_env_data_index_specval@0x1003
+          v39:CInt64 = GuardAnyBitSet v38, CUInt64(1)
+          v40:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb9(v40, v17)
+        bb9(v30:BasicObject, v31:BasicObject):
           SideExit NoProfileSend recompile
         ");
     }
@@ -4985,29 +4982,27 @@ mod hir_opt_tests {
           v14:CPtr = GetEP 1
           v15:CUInt64 = LoadField v14, :_ep_flags@0x1000
           v16:CBool = IsBlockParamModified v15
-          IfTrue v16, bb4()
-          Jump bb5()
+          CondBranch v16, bb4(), bb5()
         bb4():
-          v19:BasicObject = LoadField v14, :block@0x1001
-          Jump bb6(v19)
+          v18:BasicObject = LoadField v14, :block@0x1001
+          Jump bb6(v18)
         bb5():
-          v21:BasicObject = GetBlockParam :block, l1, EP@3
-          Jump bb6(v21)
+          v20:BasicObject = GetBlockParam :block, l1, EP@3
+          Jump bb6(v20)
         bb6(v13:BasicObject):
-          v28:CPtr = GetEP 1
-          v29:CUInt64 = LoadField v28, :_ep_flags@0x1000
-          v30:CBool = IsBlockParamModified v29
-          IfTrue v30, bb7()
-          Jump bb8()
+          v27:CPtr = GetEP 1
+          v28:CUInt64 = LoadField v27, :_ep_flags@0x1000
+          v29:CBool = IsBlockParamModified v28
+          CondBranch v29, bb7(), bb8()
         bb7():
-          v33:BasicObject = LoadField v28, :block@0x1001
-          Jump bb9(v33)
+          v31:BasicObject = LoadField v27, :block@0x1001
+          Jump bb9(v31)
         bb8():
-          v35:CInt64 = LoadField v28, :_env_data_index_specval@0x1002
-          v36:CInt64 = GuardAnyBitSet v35, CUInt64(1)
-          v37:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb9(v37)
-        bb9(v27:BasicObject):
+          v33:CInt64 = LoadField v27, :_env_data_index_specval@0x1002
+          v34:CInt64 = GuardAnyBitSet v33, CUInt64(1)
+          v35:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb9(v35)
+        bb9(v26:BasicObject):
           SideExit NoProfileSend recompile
         ");
     }
@@ -5042,33 +5037,30 @@ mod hir_opt_tests {
           v18:CPtr = GetEP 0
           v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
           v20:CBool = IsBlockParamModified v19
-          IfTrue v20, bb4()
-          Jump bb5()
+          CondBranch v20, bb4(), bb5()
         bb4():
-          v23:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v23, v23)
+          v22:BasicObject = LoadField v18, :block@0x1002
+          Jump bb6(v22, v22)
         bb5():
-          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
-          v26:CInt64[1] = Const CInt64(1)
-          v27:CInt64 = IntAnd v25, v26
-          v28:CBool = IsBitEqual v27, v26
-          IfTrue v28, bb7()
-          Jump bb9()
+          v24:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
+          v25:CInt64[1] = Const CInt64(1)
+          v26:CInt64 = IntAnd v24, v25
+          v27:CBool = IsBitEqual v26, v25
+          CondBranch v27, bb7(), bb9()
         bb7():
-          v31:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v31, v10)
+          v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v29, v10)
         bb9():
-          v33:CInt64[0] = Const CInt64(0)
-          v34:CBool = IsBitEqual v25, v33
-          IfTrue v34, bb8()
-          Jump bb10()
+          v31:CInt64[0] = Const CInt64(0)
+          v32:CBool = IsBitEqual v24, v31
+          CondBranch v32, bb8(), bb10()
         bb8():
-          v37:NilClass = Const Value(nil)
-          Jump bb6(v37, v10)
+          v34:NilClass = Const Value(nil)
+          Jump bb6(v34, v10)
         bb6(v16:BasicObject, v17:BasicObject):
-          v41:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Complex argument passing
+          v38:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v41
+          Return v38
         bb10():
           SideExit BlockParamProxyProfileNotCovered
         ");
@@ -5096,14 +5088,13 @@ mod hir_opt_tests {
           v15:CPtr = GetEP 0
           v16:CUInt64 = LoadField v15, :_ep_flags@0x1001
           v17:CBool = IsBlockParamModified v16
-          IfTrue v17, bb4()
-          Jump bb5()
+          CondBranch v17, bb4(), bb5()
         bb4():
-          v20:BasicObject = LoadField v15, :block@0x1002
-          Jump bb6(v20)
+          v19:BasicObject = LoadField v15, :block@0x1002
+          Jump bb6(v19)
         bb5():
-          v22:BasicObject = GetBlockParam :block, l0, EP@3
-          Jump bb6(v22)
+          v21:BasicObject = GetBlockParam :block, l0, EP@3
+          Jump bb6(v21)
         bb6(v14:BasicObject):
           CheckInterrupts
           Return v14
@@ -5133,14 +5124,13 @@ mod hir_opt_tests {
           v11:CPtr = GetEP 1
           v12:CUInt64 = LoadField v11, :_ep_flags@0x1000
           v13:CBool = IsBlockParamModified v12
-          IfTrue v13, bb4()
-          Jump bb5()
+          CondBranch v13, bb4(), bb5()
         bb4():
-          v16:BasicObject = LoadField v11, :block@0x1001
-          Jump bb6(v16)
+          v15:BasicObject = LoadField v11, :block@0x1001
+          Jump bb6(v15)
         bb5():
-          v18:BasicObject = GetBlockParam :block, l1, EP@3
-          Jump bb6(v18)
+          v17:BasicObject = GetBlockParam :block, l1, EP@3
+          Jump bb6(v17)
         bb6(v10:BasicObject):
           CheckInterrupts
           Return v10
@@ -6439,9 +6429,9 @@ mod hir_opt_tests {
         bb3(v8:BasicObject, v9:NilClass):
           v13:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          v24:Fixnum[1] = RefineType v13, NotNil
+          v23:Fixnum[1] = RefineType v13, NotNil
           PatchPoint MethodRedefined(Integer@0x1000, itself@0x1008, cme:0x1010)
-          Return v24
+          Return v23
         ");
     }
 
@@ -7279,22 +7269,21 @@ mod hir_opt_tests {
           CheckInterrupts
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
-          IfFalse v16, bb4(v9, v17)
-          Jump bb6()
-        bb4(v26:BasicObject, v27:Falsy):
-          v30:NilClass = Const Value(nil)
-          Jump bb5(v26, v27, v30)
+          CondBranch v16, bb6(), bb4(v9, v17)
         bb6():
-          v20:Truthy = RefineType v10, Truthy
-          v22:FalseClass = Const Value(false)
+          v19:Truthy = RefineType v10, Truthy
+          v21:FalseClass = Const Value(false)
           CheckInterrupts
-          Jump bb5(v9, v20, v22)
-        bb5(v32:BasicObject, v33:BasicObject, v34:Falsy):
+          Jump bb5(v9, v19, v21)
+        bb4(v25:BasicObject, v26:Falsy):
+          v29:NilClass = Const Value(nil)
+          Jump bb5(v25, v26, v29)
+        bb5(v31:BasicObject, v32:BasicObject, v33:Falsy):
           PatchPoint MethodRedefined(NilClass@0x1008, !@0x1010, cme:0x1018)
-          v46:NilClass = GuardType v34, NilClass
-          v47:TrueClass = Const Value(true)
+          v45:NilClass = GuardType v33, NilClass
+          v46:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v47
+          Return v46
         ");
     }
 
@@ -7612,25 +7601,23 @@ mod hir_opt_tests {
           v16 = RefineType v15, CUInt64
           v17:CInt64 = IntAnd v12, v14
           v18:CBool = IsBitEqual v17, v16
-          IfTrue v18, bb5()
-          Jump bb6()
+          CondBranch v18, bb5(), bb6()
         bb5():
-          v21:BasicObject = LoadField v11, :@foo@0x1002
-          Jump bb4(v21)
+          v20:BasicObject = LoadField v11, :@foo@0x1002
+          Jump bb4(v20)
         bb6():
-          v23:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v24:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
-          v25 = RefineType v24, CUInt64
-          v26:CInt64 = IntAnd v12, v23
-          v27:CBool = IsBitEqual v26, v25
-          IfTrue v27, bb7()
-          Jump bb8()
+          v22:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v23:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
+          v24 = RefineType v23, CUInt64
+          v25:CInt64 = IntAnd v12, v22
+          v26:CBool = IsBitEqual v25, v24
+          CondBranch v26, bb7(), bb8()
         bb7():
-          v30:BasicObject = LoadField v11, :@foo@0x1004
-          Jump bb4(v30)
+          v28:BasicObject = LoadField v11, :@foo@0x1004
+          Jump bb4(v28)
         bb8():
-          v32:BasicObject = GetIvar v11, :@foo
-          Jump bb4(v32)
+          v30:BasicObject = GetIvar v11, :@foo
+          Jump bb4(v30)
         bb4(v13:BasicObject):
           CheckInterrupts
           Return v13
@@ -7973,34 +7960,31 @@ mod hir_opt_tests {
           v16 = RefineType v15, CUInt64
           v17:CInt64 = IntAnd v12, v14
           v18:CBool = IsBitEqual v17, v16
-          IfTrue v18, bb5()
-          Jump bb6()
+          CondBranch v18, bb5(), bb6()
         bb5():
-          v21:CPtr = LoadField v11, :_as_heap@0x1002
-          v22:BasicObject = LoadField v21, :@foo@0x1003
-          Jump bb4(v22)
+          v20:BasicObject = LoadField v11, :@foo@0x1002
+          Jump bb4(v20)
         bb6():
-          v24:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v25:CPtr[CPtr(0x1004)] = Const CPtr(0x1004)
-          v26 = RefineType v25, CUInt64
-          v27:CInt64 = IntAnd v12, v24
-          v28:CBool = IsBitEqual v27, v26
-          IfTrue v28, bb7()
-          Jump bb8()
+          v22:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v23:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
+          v24 = RefineType v23, CUInt64
+          v25:CInt64 = IntAnd v12, v22
+          v26:CBool = IsBitEqual v25, v24
+          CondBranch v26, bb7(), bb8()
         bb7():
-          v31:CPtr = LoadField v11, :_as_heap@0x1002
-          v32:BasicObject = LoadField v31, :@foo@0x1000
-          Jump bb4(v32)
+          v28:CPtr = LoadField v11, :_as_heap@0x1004
+          v29:BasicObject = LoadField v28, :@foo@0x1000
+          Jump bb4(v29)
         bb8():
-          v34:BasicObject = GetIvar v11, :@foo
-          Jump bb4(v34)
+          v31:BasicObject = GetIvar v11, :@foo
+          Jump bb4(v31)
         bb4(v13:BasicObject):
-          v37:Fixnum[1] = Const Value(1)
+          v34:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v48:Fixnum = GuardType v13, Fixnum
-          v49:Fixnum = FixnumAdd v48, v37
+          v45:Fixnum = GuardType v13, Fixnum
+          v46:Fixnum = FixnumAdd v45, v34
           CheckInterrupts
-          Return v49
+          Return v46
         ");
     }
 
@@ -8055,37 +8039,34 @@ mod hir_opt_tests {
           v16 = RefineType v15, CUInt64
           v17:CInt64 = IntAnd v12, v14
           v18:CBool = IsBitEqual v17, v16
-          IfTrue v18, bb5()
-          Jump bb6()
+          CondBranch v18, bb5(), bb6()
         bb5():
-          v21:CPtr = LoadField v11, :_as_heap@0x1002
-          v22:BasicObject = LoadField v21, :@foo@0x1000
-          Jump bb4(v22)
+          v20:CPtr = LoadField v11, :_as_heap@0x1002
+          v21:BasicObject = LoadField v20, :@foo@0x1000
+          Jump bb4(v21)
         bb6():
-          v24:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v25:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
-          v26 = RefineType v25, CUInt64
-          v27:CInt64 = IntAnd v12, v24
-          v28:CBool = IsBitEqual v27, v26
-          IfTrue v28, bb7()
-          Jump bb8()
+          v23:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v24:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
+          v25 = RefineType v24, CUInt64
+          v26:CInt64 = IntAnd v12, v23
+          v27:CBool = IsBitEqual v26, v25
+          CondBranch v27, bb7(), bb8()
         bb7():
-          v31:CPtr = LoadField v11, :_as_heap@0x1002
-          v32:BasicObject = LoadField v31, :@foo@0x1004
-          Jump bb4(v32)
+          v29:BasicObject = LoadField v11, :@foo@0x1004
+          Jump bb4(v29)
         bb8():
-          v47:CShape = LoadField v11, :_shape_id@0x1005
-          v48:CShape[0x1006] = GuardBitEquals v47, CShape(0x1006)
-          v49:CPtr = LoadField v11, :_as_heap@0x1002
-          v50:BasicObject = LoadField v49, :@foo@0x1000
-          Jump bb4(v50)
+          v44:CShape = LoadField v11, :_shape_id@0x1005
+          v45:CShape[0x1006] = GuardBitEquals v44, CShape(0x1006)
+          v46:CPtr = LoadField v11, :_as_heap@0x1002
+          v47:BasicObject = LoadField v46, :@foo@0x1000
+          Jump bb4(v47)
         bb4(v13:BasicObject):
-          v37:Fixnum[1] = Const Value(1)
+          v34:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v53:Fixnum = GuardType v13, Fixnum
-          v54:Fixnum = FixnumAdd v53, v37
+          v50:Fixnum = GuardType v13, Fixnum
+          v51:Fixnum = FixnumAdd v50, v34
           CheckInterrupts
-          Return v54
+          Return v51
         ");
     }
 
@@ -8132,32 +8113,30 @@ mod hir_opt_tests {
           v16 = RefineType v15, CUInt64
           v17:CInt64 = IntAnd v12, v14
           v18:CBool = IsBitEqual v17, v16
-          IfTrue v18, bb5()
-          Jump bb6()
+          CondBranch v18, bb5(), bb6()
         bb5():
-          v21:BasicObject = LoadField v11, :@foo@0x1002
-          Jump bb4(v21)
+          v20:BasicObject = LoadField v11, :@foo@0x1002
+          Jump bb4(v20)
         bb6():
-          v23:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v24:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
-          v25 = RefineType v24, CUInt64
-          v26:CInt64 = IntAnd v12, v23
-          v27:CBool = IsBitEqual v26, v25
-          IfTrue v27, bb7()
-          Jump bb8()
+          v22:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v23:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
+          v24 = RefineType v23, CUInt64
+          v25:CInt64 = IntAnd v12, v22
+          v26:CBool = IsBitEqual v25, v24
+          CondBranch v26, bb7(), bb8()
         bb7():
-          v30:BasicObject = LoadField v11, :@foo@0x1002
-          Jump bb4(v30)
+          v28:BasicObject = LoadField v11, :@foo@0x1002
+          Jump bb4(v28)
         bb8():
-          v32:BasicObject = GetIvar v11, :@foo
-          Jump bb4(v32)
+          v30:BasicObject = GetIvar v11, :@foo
+          Jump bb4(v30)
         bb4(v13:BasicObject):
-          v35:Fixnum[1] = Const Value(1)
+          v33:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v46:Fixnum = GuardType v13, Fixnum
-          v47:Fixnum = FixnumAdd v46, v35
+          v44:Fixnum = GuardType v13, Fixnum
+          v45:Fixnum = FixnumAdd v44, v33
           CheckInterrupts
-          Return v47
+          Return v45
         ");
     }
 
@@ -8202,28 +8181,26 @@ mod hir_opt_tests {
           v16 = RefineType v15, CUInt64
           v17:CInt64 = IntAnd v12, v14
           v18:CBool = IsBitEqual v17, v16
-          IfTrue v18, bb5()
-          Jump bb6()
+          CondBranch v18, bb5(), bb6()
         bb5():
-          v21:RubyValue = LoadField v11, :_fields_obj@0x1002
-          v22:BasicObject = LoadField v21, :@a@0x1002
-          Jump bb4(v22)
+          v20:RubyValue = LoadField v11, :_fields_obj@0x1002
+          v21:BasicObject = LoadField v20, :@a@0x1002
+          Jump bb4(v21)
         bb6():
-          v24:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v25:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
-          v26 = RefineType v25, CUInt64
-          v27:CInt64 = IntAnd v12, v24
-          v28:CBool = IsBitEqual v27, v26
-          IfTrue v28, bb7()
-          Jump bb8()
+          v23:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v24:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
+          v25 = RefineType v24, CUInt64
+          v26:CInt64 = IntAnd v12, v23
+          v27:CBool = IsBitEqual v26, v25
+          CondBranch v27, bb7(), bb8()
         bb7():
           PatchPoint RootBoxOnly
-          v32:RubyValue = LoadField v11, :_fields_obj@0x1004
-          v33:BasicObject = LoadField v32, :@a@0x1002
-          Jump bb4(v33)
+          v30:RubyValue = LoadField v11, :_fields_obj@0x1004
+          v31:BasicObject = LoadField v30, :@a@0x1002
+          Jump bb4(v31)
         bb8():
-          v35:BasicObject = GetIvar v11, :@a
-          Jump bb4(v35)
+          v33:BasicObject = GetIvar v11, :@a
+          Jump bb4(v33)
         bb4(v13:BasicObject):
           CheckInterrupts
           Return v13
@@ -8271,20 +8248,19 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          IfTrue v15, bb5(v9, v10, v10)
-          Jump bb6()
+          CondBranch v15, bb5(v9, v10, v10), bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           v20:ObjectSubclass[class_exact:C] = RefineType v18, ObjectSubclass[class_exact:C]
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v38:BasicObject = GetIvar v20, :@foo
-          Jump bb4(v16, v17, v38)
+          v37:BasicObject = GetIvar v20, :@foo
+          Jump bb4(v16, v17, v37)
         bb6():
-          v25:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v25)
-        bb4(v27:BasicObject, v28:BasicObject, v29:BasicObject):
+          v24:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v24)
+        bb4(v26:BasicObject, v27:BasicObject, v28:BasicObject):
           CheckInterrupts
-          Return v29
+          Return v28
         ");
     }
 
@@ -8422,20 +8398,19 @@ mod hir_opt_tests {
           v18:CPtr = GetEP 0
           v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
           v20:CBool = IsBlockParamModified v19
-          IfTrue v20, bb4()
-          Jump bb5()
+          CondBranch v20, bb4(), bb5()
         bb4():
-          v23:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v23, v23)
+          v22:BasicObject = LoadField v18, :block@0x1002
+          Jump bb6(v22, v22)
         bb5():
-          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
-          v26:CInt64 = GuardAnyBitSet v25, CUInt64(1)
-          v27:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v27, v10)
+          v24:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
+          v25:CInt64 = GuardAnyBitSet v24, CUInt64(1)
+          v26:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v26, v10)
         bb6(v16:BasicObject, v17:BasicObject):
-          v30:BasicObject = Send v14, &block, :map, v16 # SendFallbackReason: Complex argument passing
+          v29:BasicObject = Send v14, &block, :map, v16 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v30
+          Return v29
         ");
     }
 
@@ -8463,20 +8438,19 @@ mod hir_opt_tests {
           v18:CPtr = GetEP 0
           v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
           v20:CBool = IsBlockParamModified v19
-          IfTrue v20, bb4()
-          Jump bb5()
+          CondBranch v20, bb4(), bb5()
         bb4():
-          v23:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v23, v23)
+          v22:BasicObject = LoadField v18, :block@0x1002
+          Jump bb6(v22, v22)
         bb5():
-          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
-          v26:CInt64[0] = GuardBitEquals v25, CInt64(0)
-          v27:NilClass = Const Value(nil)
-          Jump bb6(v27, v10)
+          v24:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
+          v25:CInt64[0] = GuardBitEquals v24, CInt64(0)
+          v26:NilClass = Const Value(nil)
+          Jump bb6(v26, v10)
         bb6(v16:BasicObject, v17:BasicObject):
-          v30:BasicObject = Send v14, &block, :map, v16 # SendFallbackReason: Complex argument passing
+          v29:BasicObject = Send v14, &block, :map, v16 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v30
+          Return v29
         ");
     }
 
@@ -8505,20 +8479,19 @@ mod hir_opt_tests {
           v13:CPtr = GetEP 1
           v14:CUInt64 = LoadField v13, :_ep_flags@0x1000
           v15:CBool = IsBlockParamModified v14
-          IfTrue v15, bb4()
-          Jump bb5()
+          CondBranch v15, bb4(), bb5()
         bb4():
-          v18:BasicObject = LoadField v13, :block@0x1001
-          Jump bb6(v18)
+          v17:BasicObject = LoadField v13, :block@0x1001
+          Jump bb6(v17)
         bb5():
-          v20:CInt64 = LoadField v13, :_env_data_index_specval@0x1002
-          v21:CInt64 = GuardAnyBitSet v20, CUInt64(1)
-          v22:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v22)
+          v19:CInt64 = LoadField v13, :_env_data_index_specval@0x1002
+          v20:CInt64 = GuardAnyBitSet v19, CUInt64(1)
+          v21:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v21)
         bb6(v12:BasicObject):
-          v25:BasicObject = Send v10, &block, :map, v12 # SendFallbackReason: Complex argument passing
+          v24:BasicObject = Send v10, &block, :map, v12 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v25
+          Return v24
         ");
     }
 
@@ -12002,20 +11975,19 @@ mod hir_opt_tests {
           v18:CPtr = GetEP 0
           v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
           v20:CBool = IsBlockParamModified v19
-          IfTrue v20, bb4()
-          Jump bb5()
+          CondBranch v20, bb4(), bb5()
         bb4():
-          v23:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v23, v23)
+          v22:BasicObject = LoadField v18, :block@0x1002
+          Jump bb6(v22, v22)
         bb5():
-          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
-          v26:CInt64 = GuardAnyBitSet v25, CUInt64(1)
-          v27:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v27, v10)
+          v24:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
+          v25:CInt64 = GuardAnyBitSet v24, CUInt64(1)
+          v26:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v26, v10)
         bb6(v16:BasicObject, v17:BasicObject):
-          v30:BasicObject = Send v14, &block, :map, v16 # SendFallbackReason: Complex argument passing
+          v29:BasicObject = Send v14, &block, :map, v16 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v30
+          Return v29
         ");
     }
 
@@ -13407,16 +13379,16 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint NoSingletonClass(C@0x1000)
           PatchPoint MethodRedefined(C@0x1000, class@0x1008, cme:0x1010)
-          v44:ObjectSubclass[class_exact:C] = GuardType v6, ObjectSubclass[class_exact:C]
-          v47:Class[C@0x1000] = Const Value(VALUE(0x1000))
+          v43:ObjectSubclass[class_exact:C] = GuardType v6, ObjectSubclass[class_exact:C]
+          v46:Class[C@0x1000] = Const Value(VALUE(0x1000))
           v13:StaticSymbol[:_lex_actions] = Const Value(VALUE(0x1038))
           v15:TrueClass = Const Value(true)
           PatchPoint MethodRedefined(Class@0x1040, respond_to?@0x1048, cme:0x1050)
           PatchPoint MethodRedefined(Class@0x1040, _lex_actions@0x1078, cme:0x1080)
-          v52:TrueClass = Const Value(true)
+          v51:TrueClass = Const Value(true)
           CheckInterrupts
-          v27:StaticSymbol[:CORRECT] = Const Value(VALUE(0x10a8))
-          Return v27
+          v26:StaticSymbol[:CORRECT] = Const Value(VALUE(0x10a8))
+          Return v26
         ");
     }
 
@@ -13574,23 +13546,23 @@ mod hir_opt_tests {
          CheckInterrupts
          SetLocal :formatted, l0, EP@3, v16
          PatchPoint SingleRactorMode
-         v61:HeapBasicObject = GuardType v15, HeapBasicObject
-         v62:CShape = LoadField v61, :_shape_id@0x1003
-         v63:CShape[0x1004] = GuardBitEquals v62, CShape(0x1004)
-         StoreField v61, :@formatted@0x1005, v16
-         WriteBarrier v61, v16
-         v66:CShape[0x1006] = Const CShape(0x1006)
-         StoreField v61, :_shape_id@0x1003, v66
-         v48:Class[VMFrozenCore] = Const Value(VALUE(0x1008))
+         v60:HeapBasicObject = GuardType v15, HeapBasicObject
+         v61:CShape = LoadField v60, :_shape_id@0x1003
+         v62:CShape[0x1004] = GuardBitEquals v61, CShape(0x1004)
+         StoreField v60, :@formatted@0x1005, v16
+         WriteBarrier v60, v16
+         v65:CShape[0x1006] = Const CShape(0x1006)
+         StoreField v60, :_shape_id@0x1003, v65
+         v47:Class[VMFrozenCore] = Const Value(VALUE(0x1008))
          PatchPoint MethodRedefined(Class@0x1010, lambda@0x1018, cme:0x1020)
-         v70:BasicObject = CCallWithFrame v48, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
-         v51:CPtr = GetEP 0
-         v52:BasicObject = LoadField v51, :a@0x1001
-         v53:BasicObject = LoadField v51, :_b@0x1002
-         v54:BasicObject = LoadField v51, :_c@0x1058
-         v55:BasicObject = LoadField v51, :formatted@0x1059
+         v69:BasicObject = CCallWithFrame v47, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
+         v50:CPtr = GetEP 0
+         v51:BasicObject = LoadField v50, :a@0x1001
+         v52:BasicObject = LoadField v50, :_b@0x1002
+         v53:BasicObject = LoadField v50, :_c@0x1058
+         v54:BasicObject = LoadField v50, :formatted@0x1059
          CheckInterrupts
-         Return v70
+         Return v69
        ");
     }
 
@@ -14619,35 +14591,34 @@ mod hir_opt_tests {
           v5:CPtr = LoadPC
           v6:CPtr[CPtr(0x1002)] = Const CPtr(0x1002)
           v7:CBool = IsBitEqual v5, v6
-          IfTrue v7, bb3(v1, v3, v4)
-          Jump bb6()
+          CondBranch v7, bb3(v1, v3, v4), bb6()
         bb6():
           Jump bb5(v1, v3, v4)
         bb2():
           EntryPoint JIT(0)
-          v12:BasicObject = LoadArg :self@0
-          v13:BasicObject = LoadArg :needle@1
-          v14:NilClass = Const Value(nil)
-          Jump bb3(v12, v13, v14)
-        bb3(v21:BasicObject, v22:BasicObject, v23:BasicObject):
-          v26:Fixnum[0] = Const Value(0)
-          Jump bb5(v21, v22, v26)
+          v11:BasicObject = LoadArg :self@0
+          v12:BasicObject = LoadArg :needle@1
+          v13:NilClass = Const Value(nil)
+          Jump bb3(v11, v12, v13)
+        bb3(v20:BasicObject, v21:BasicObject, v22:BasicObject):
+          v25:Fixnum[0] = Const Value(0)
+          Jump bb5(v20, v21, v25)
         bb4():
           EntryPoint JIT(1)
-          v17:BasicObject = LoadArg :self@0
-          v18:BasicObject = LoadArg :needle@1
-          v19:BasicObject = LoadArg :offset@2
-          Jump bb5(v17, v18, v19)
-        bb5(v29:BasicObject, v30:BasicObject, v31:BasicObject):
+          v16:BasicObject = LoadArg :self@0
+          v17:BasicObject = LoadArg :needle@1
+          v18:BasicObject = LoadArg :offset@2
+          Jump bb5(v16, v17, v18)
+        bb5(v28:BasicObject, v29:BasicObject, v30:BasicObject):
           PatchPoint MethodRedefined(String@0x1008, byteindex@0x1010, cme:0x1018)
-          v45:CPtr = GetEP 0
-          v46:RubyValue = LoadField v45, :_ep_method_entry@0x1040
-          v47:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v46, Value(VALUE(0x1048))
-          v48:RubyValue = LoadField v45, :_ep_specval@0x1050
-          v49:FalseClass = GuardBitEquals v48, Value(false)
-          v50:BasicObject = CCallVariadic v29, :String#byteindex@0x1058, v30, v31
+          v44:CPtr = GetEP 0
+          v45:RubyValue = LoadField v44, :_ep_method_entry@0x1040
+          v46:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v45, Value(VALUE(0x1048))
+          v47:RubyValue = LoadField v44, :_ep_specval@0x1050
+          v48:FalseClass = GuardBitEquals v47, Value(false)
+          v49:BasicObject = CCallVariadic v28, :String#byteindex@0x1058, v29, v30
           CheckInterrupts
-          Return v50
+          Return v49
         ");
     }
 
@@ -14779,28 +14750,27 @@ mod hir_opt_tests {
           v4:CPtr = LoadPC
           v5:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v6:CBool = IsBitEqual v4, v5
-          IfTrue v6, bb3(v1, v3)
-          Jump bb6()
+          CondBranch v6, bb3(v1, v3), bb6()
         bb6():
           Jump bb5(v1, v3)
         bb2():
           EntryPoint JIT(0)
-          v11:BasicObject = LoadArg :self@0
-          v12:NilClass = Const Value(nil)
-          Jump bb3(v11, v12)
-        bb3(v18:BasicObject, v19:BasicObject):
-          v22:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v23:StringExact = StringCopy v22
-          Jump bb5(v18, v23)
+          v10:BasicObject = LoadArg :self@0
+          v11:NilClass = Const Value(nil)
+          Jump bb3(v10, v11)
+        bb3(v17:BasicObject, v18:BasicObject):
+          v21:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v22:StringExact = StringCopy v21
+          Jump bb5(v17, v22)
         bb4():
           EntryPoint JIT(1)
-          v15:BasicObject = LoadArg :self@0
-          v16:BasicObject = LoadArg :content@1
-          Jump bb5(v15, v16)
-        bb5(v26:BasicObject, v27:BasicObject):
-          v33:BasicObject = InvokeSuper v26, 0x1010, v27 # SendFallbackReason: super: complex argument passing to `super` call
+          v14:BasicObject = LoadArg :self@0
+          v15:BasicObject = LoadArg :content@1
+          Jump bb5(v14, v15)
+        bb5(v25:BasicObject, v26:BasicObject):
+          v32:BasicObject = InvokeSuper v25, 0x1010, v26 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
-          Return v33
+          Return v32
         ");
     }
 
@@ -14840,17 +14810,16 @@ mod hir_opt_tests {
           CheckInterrupts
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
-          IfFalse v16, bb6(v9, v17)
-          Jump bb7()
-        bb6(v46:BasicObject, v47:Falsy):
-          v51:Fixnum[6] = Const Value(6)
-          CheckInterrupts
-          Return v51
+          CondBranch v16, bb7(), bb6(v9, v17)
         bb7():
-          v20:Truthy = RefineType v10, Truthy
+          v19:Truthy = RefineType v10, Truthy
           CheckInterrupts
-          v41:Fixnum[3] = Const Value(3)
-          Return v41
+          v38:Fixnum[3] = Const Value(3)
+          Return v38
+        bb6(v43:BasicObject, v44:Falsy):
+          v48:Fixnum[6] = Const Value(6)
+          CheckInterrupts
+          Return v48
         ");
     }
 
@@ -14887,32 +14856,30 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          IfTrue v15, bb5(v9, v10, v10)
-          Jump bb6()
+          CondBranch v15, bb5(v9, v10, v10), bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v57:Fixnum[3] = Const Value(3)
-          Jump bb4(v16, v17, v57)
+          v55:Fixnum[3] = Const Value(3)
+          Jump bb4(v16, v17, v55)
         bb6():
-          v25:CBool = HasType v10, ObjectSubclass[class_exact:D]
-          IfTrue v25, bb7(v9, v10, v10)
-          Jump bb8()
-        bb7(v26:BasicObject, v27:BasicObject, v28:BasicObject):
+          v24:CBool = HasType v10, ObjectSubclass[class_exact:D]
+          CondBranch v24, bb7(v9, v10, v10), bb8()
+        bb7(v25:BasicObject, v26:BasicObject, v27:BasicObject):
           PatchPoint NoSingletonClass(D@0x1040)
           PatchPoint MethodRedefined(D@0x1040, foo@0x1010, cme:0x1048)
-          v58:Fixnum[4] = Const Value(4)
-          Jump bb4(v26, v27, v58)
+          v56:Fixnum[4] = Const Value(4)
+          Jump bb4(v25, v26, v56)
         bb8():
-          v35:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v35)
-        bb4(v37:BasicObject, v38:BasicObject, v39:BasicObject):
-          v42:Fixnum[2] = Const Value(2)
+          v33:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v33)
+        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          v40:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v61:Fixnum = GuardType v39, Fixnum
-          v62:Fixnum = FixnumAdd v61, v42
+          v59:Fixnum = GuardType v37, Fixnum
+          v60:Fixnum = FixnumAdd v59, v40
           CheckInterrupts
-          Return v62
+          Return v60
         ");
     }
 
@@ -14943,27 +14910,25 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          IfTrue v15, bb5(v9, v10, v10)
-          Jump bb6()
+          CondBranch v15, bb5(v9, v10, v10), bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           v20:ObjectSubclass[class_exact:C] = RefineType v18, ObjectSubclass[class_exact:C]
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, itself@0x1010, cme:0x1018)
           Jump bb4(v16, v17, v20)
         bb6():
-          v25:CBool = HasType v10, Fixnum
-          IfTrue v25, bb7(v9, v10, v10)
-          Jump bb8()
-        bb7(v26:BasicObject, v27:BasicObject, v28:BasicObject):
-          v30:Fixnum = RefineType v28, Fixnum
+          v24:CBool = HasType v10, Fixnum
+          CondBranch v24, bb7(v9, v10, v10), bb8()
+        bb7(v25:BasicObject, v26:BasicObject, v27:BasicObject):
+          v29:Fixnum = RefineType v27, Fixnum
           PatchPoint MethodRedefined(Integer@0x1040, itself@0x1010, cme:0x1018)
-          Jump bb4(v26, v27, v30)
+          Jump bb4(v25, v26, v29)
         bb8():
-          v35:BasicObject = Send v10, :itself # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v35)
-        bb4(v37:BasicObject, v38:BasicObject, v39:BasicObject):
+          v33:BasicObject = Send v10, :itself # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v33)
+        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
           CheckInterrupts
-          Return v39
+          Return v37
         ");
     }
 
@@ -15000,28 +14965,26 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, Fixnum
-          IfTrue v15, bb5(v9, v10, v10)
-          Jump bb6()
+          CondBranch v15, bb5(v9, v10, v10), bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           v20:Fixnum = RefineType v18, Fixnum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v48:StringExact = CCallVariadic v20, :Integer#to_s@0x1040
-          Jump bb4(v16, v17, v48)
+          v46:StringExact = CCallVariadic v20, :Integer#to_s@0x1040
+          Jump bb4(v16, v17, v46)
         bb6():
-          v25:CBool = HasType v10, Bignum
-          IfTrue v25, bb7(v9, v10, v10)
-          Jump bb8()
-        bb7(v26:BasicObject, v27:BasicObject, v28:BasicObject):
-          v30:Bignum = RefineType v28, Bignum
+          v24:CBool = HasType v10, Bignum
+          CondBranch v24, bb7(v9, v10, v10), bb8()
+        bb7(v25:BasicObject, v26:BasicObject, v27:BasicObject):
+          v29:Bignum = RefineType v27, Bignum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v51:StringExact = CCallVariadic v30, :Integer#to_s@0x1040
-          Jump bb4(v26, v27, v51)
+          v49:StringExact = CCallVariadic v29, :Integer#to_s@0x1040
+          Jump bb4(v25, v26, v49)
         bb8():
-          v35:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v35)
-        bb4(v37:BasicObject, v38:BasicObject, v39:BasicObject):
+          v33:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v33)
+        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
           CheckInterrupts
-          Return v39
+          Return v37
         ");
     }
 
@@ -15055,28 +15018,26 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, Flonum
-          IfTrue v15, bb5(v9, v10, v10)
-          Jump bb6()
+          CondBranch v15, bb5(v9, v10, v10), bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           v20:Flonum = RefineType v18, Flonum
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v48:BasicObject = CCallWithFrame v20, :Float#to_s@0x1040
-          Jump bb4(v16, v17, v48)
+          v46:BasicObject = CCallWithFrame v20, :Float#to_s@0x1040
+          Jump bb4(v16, v17, v46)
         bb6():
-          v25:CBool = HasType v10, HeapFloat
-          IfTrue v25, bb7(v9, v10, v10)
-          Jump bb8()
-        bb7(v26:BasicObject, v27:BasicObject, v28:BasicObject):
-          v30:HeapFloat = RefineType v28, HeapFloat
+          v24:CBool = HasType v10, HeapFloat
+          CondBranch v24, bb7(v9, v10, v10), bb8()
+        bb7(v25:BasicObject, v26:BasicObject, v27:BasicObject):
+          v29:HeapFloat = RefineType v27, HeapFloat
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v51:BasicObject = CCallWithFrame v30, :Float#to_s@0x1040
-          Jump bb4(v26, v27, v51)
+          v49:BasicObject = CCallWithFrame v29, :Float#to_s@0x1040
+          Jump bb4(v25, v26, v49)
         bb8():
-          v35:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v35)
-        bb4(v37:BasicObject, v38:BasicObject, v39:BasicObject):
+          v33:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v33)
+        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
           CheckInterrupts
-          Return v39
+          Return v37
         ");
     }
 
@@ -15110,28 +15071,26 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, StaticSymbol
-          IfTrue v15, bb5(v9, v10, v10)
-          Jump bb6()
+          CondBranch v15, bb5(v9, v10, v10), bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           v20:StaticSymbol = RefineType v18, StaticSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v50:StringExact = InvokeBuiltin leaf <inline_expr>, v20
-          Jump bb4(v16, v17, v50)
+          v48:StringExact = InvokeBuiltin leaf <inline_expr>, v20
+          Jump bb4(v16, v17, v48)
         bb6():
-          v25:CBool = HasType v10, DynamicSymbol
-          IfTrue v25, bb7(v9, v10, v10)
-          Jump bb8()
-        bb7(v26:BasicObject, v27:BasicObject, v28:BasicObject):
-          v30:DynamicSymbol = RefineType v28, DynamicSymbol
+          v24:CBool = HasType v10, DynamicSymbol
+          CondBranch v24, bb7(v9, v10, v10), bb8()
+        bb7(v25:BasicObject, v26:BasicObject, v27:BasicObject):
+          v29:DynamicSymbol = RefineType v27, DynamicSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v51:StringExact = InvokeBuiltin leaf <inline_expr>, v30
-          Jump bb4(v26, v27, v51)
+          v49:StringExact = InvokeBuiltin leaf <inline_expr>, v29
+          Jump bb4(v25, v26, v49)
         bb8():
-          v35:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v35)
-        bb4(v37:BasicObject, v38:BasicObject, v39:BasicObject):
+          v33:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v33)
+        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
           CheckInterrupts
-          Return v39
+          Return v37
         ");
     }
 
@@ -15169,19 +15128,18 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          IfTrue v15, bb5(v9, v10, v10)
-          Jump bb6()
+          CondBranch v15, bb5(v9, v10, v10), bb6()
         bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v39:Fixnum[3] = Const Value(3)
-          Jump bb4(v16, v17, v39)
+          v38:Fixnum[3] = Const Value(3)
+          Jump bb4(v16, v17, v38)
         bb6():
-          v25:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v25)
-        bb4(v27:BasicObject, v28:BasicObject, v29:BasicObject):
+          v24:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v10, v24)
+        bb4(v26:BasicObject, v27:BasicObject, v28:BasicObject):
           CheckInterrupts
-          Return v29
+          Return v28
         ");
     }
 
@@ -15288,55 +15246,52 @@ mod hir_opt_tests {
           v7:CPtr = LoadPC
           v8:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
           v9:CBool = IsBitEqual v7, v8
-          IfTrue v9, bb3(v1, v3, v4, v5, v6)
-          Jump bb9()
+          CondBranch v9, bb3(v1, v3, v4, v5, v6), bb9()
         bb9():
-          v12:CPtr[CPtr(0x1004)] = Const CPtr(0x1004)
-          v13:CBool = IsBitEqual v7, v12
-          IfTrue v13, bb5(v1, v3, v4, v5, v6)
-          Jump bb10()
+          v11:CPtr[CPtr(0x1004)] = Const CPtr(0x1004)
+          v12:CBool = IsBitEqual v7, v11
+          CondBranch v12, bb5(v1, v3, v4, v5, v6), bb10()
         bb10():
           Jump bb7(v1, v3, v4, v5, v6)
         bb2():
           EntryPoint JIT(0)
-          v18:BasicObject = LoadArg :self@0
-          v19:BasicObject = LoadArg :list@1
+          v16:BasicObject = LoadArg :self@0
+          v17:BasicObject = LoadArg :list@1
+          v18:NilClass = Const Value(nil)
+          v19:NilClass = Const Value(nil)
           v20:NilClass = Const Value(nil)
-          v21:NilClass = Const Value(nil)
-          v22:NilClass = Const Value(nil)
-          Jump bb3(v18, v19, v20, v21, v22)
-        bb3(v38:BasicObject, v39:BasicObject, v40:BasicObject, v41:BasicObject, v42:NilClass):
-          v45:NilClass = Const Value(nil)
-          SetLocal :sep, l0, EP@5, v45
-          Jump bb5(v38, v39, v45, v41, v42)
+          Jump bb3(v16, v17, v18, v19, v20)
+        bb3(v36:BasicObject, v37:BasicObject, v38:BasicObject, v39:BasicObject, v40:NilClass):
+          v43:NilClass = Const Value(nil)
+          SetLocal :sep, l0, EP@5, v43
+          Jump bb5(v36, v37, v43, v39, v40)
         bb4():
           EntryPoint JIT(1)
-          v25:BasicObject = LoadArg :self@0
-          v26:BasicObject = LoadArg :list@1
-          v27:BasicObject = LoadArg :sep@2
-          v28:NilClass = Const Value(nil)
-          v29:NilClass = Const Value(nil)
-          Jump bb5(v25, v26, v27, v28, v29)
-        bb5(v49:BasicObject, v50:BasicObject, v51:BasicObject, v52:BasicObject, v53:NilClass):
-          v56:StaticSymbol[:each] = Const Value(VALUE(0x1008))
-          SetLocal :iter_method, l0, EP@4, v56
-          Jump bb7(v49, v50, v51, v56, v53)
+          v23:BasicObject = LoadArg :self@0
+          v24:BasicObject = LoadArg :list@1
+          v25:BasicObject = LoadArg :sep@2
+          v26:NilClass = Const Value(nil)
+          v27:NilClass = Const Value(nil)
+          Jump bb5(v23, v24, v25, v26, v27)
+        bb5(v47:BasicObject, v48:BasicObject, v49:BasicObject, v50:BasicObject, v51:NilClass):
+          v54:StaticSymbol[:each] = Const Value(VALUE(0x1008))
+          SetLocal :iter_method, l0, EP@4, v54
+          Jump bb7(v47, v48, v49, v54, v51)
         bb6():
           EntryPoint JIT(2)
-          v32:BasicObject = LoadArg :self@0
-          v33:BasicObject = LoadArg :list@1
-          v34:BasicObject = LoadArg :sep@2
-          v35:BasicObject = LoadArg :iter_method@3
-          v36:NilClass = Const Value(nil)
-          Jump bb7(v32, v33, v34, v35, v36)
-        bb7(v60:BasicObject, v61:BasicObject, v62:BasicObject, v63:BasicObject, v64:NilClass):
+          v30:BasicObject = LoadArg :self@0
+          v31:BasicObject = LoadArg :list@1
+          v32:BasicObject = LoadArg :sep@2
+          v33:BasicObject = LoadArg :iter_method@3
+          v34:NilClass = Const Value(nil)
+          Jump bb7(v30, v31, v32, v33, v34)
+        bb7(v58:BasicObject, v59:BasicObject, v60:BasicObject, v61:BasicObject, v62:NilClass):
           CheckInterrupts
-          v70:CBool = Test v62
-          v71:Truthy = RefineType v62, Truthy
-          IfTrue v70, bb8(v60, v61, v71, v63, v64)
-          Jump bb11()
+          v68:CBool = Test v60
+          v69:Truthy = RefineType v60, Truthy
+          CondBranch v68, bb8(v58, v59, v69, v61, v62), bb11()
         bb11():
-          v74:Falsy = RefineType v62, Falsy
+          v71:Falsy = RefineType v60, Falsy
           PatchPoint MethodRedefined(Object@0x1010, lambda@0x1018, cme:0x1020)
           v118:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v58, ObjectSubclass[class_exact*:Object@VALUE(0x1010)]
           v119:BasicObject = CCallWithFrame v118, :Kernel#lambda@0x1048, block=0x1050
@@ -15349,20 +15304,20 @@ mod hir_opt_tests {
         bb8(v83:BasicObject, v84:BasicObject, v85:BasicObject, v86:BasicObject, v87:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1060, CONST)
-          v118:HashExact[VALUE(0x1068)] = Const Value(VALUE(0x1068))
-          SetLocal :kwsplat, l0, EP@3, v118
+          v115:HashExact[VALUE(0x1068)] = Const Value(VALUE(0x1068))
+          SetLocal :kwsplat, l0, EP@3, v115
+          v96:CPtr = GetEP 0
+          v97:BasicObject = LoadField v96, :list@0x1001
           v99:CPtr = GetEP 0
-          v100:BasicObject = LoadField v99, :list@0x1001
-          v102:CPtr = GetEP 0
-          v103:BasicObject = LoadField v102, :iter_method@0x1058
-          v105:BasicObject = Send v100, 0x1070, :__send__, v103 # SendFallbackReason: Send: unsupported method type Optimized
-          v106:CPtr = GetEP 0
-          v107:BasicObject = LoadField v106, :list@0x1001
-          v108:BasicObject = LoadField v106, :sep@0x1002
-          v109:BasicObject = LoadField v106, :iter_method@0x1058
-          v110:BasicObject = LoadField v106, :kwsplat@0x1059
+          v100:BasicObject = LoadField v99, :iter_method@0x1058
+          v102:BasicObject = Send v97, 0x1070, :__send__, v100 # SendFallbackReason: Send: unsupported method type Optimized
+          v103:CPtr = GetEP 0
+          v104:BasicObject = LoadField v103, :list@0x1001
+          v105:BasicObject = LoadField v103, :sep@0x1002
+          v106:BasicObject = LoadField v103, :iter_method@0x1058
+          v107:BasicObject = LoadField v103, :kwsplat@0x1059
           CheckInterrupts
-          Return v105
+          Return v102
         ");
     }
 
@@ -15385,35 +15340,33 @@ mod hir_opt_tests {
           v13:NilClass = Const Value(nil)
           v15:TrueClass|NilClass = Defined yield, v13
           v17:CBool = Test v15
-          IfFalse v17, bb4(v8, v9)
-          Jump bb9()
-        bb4(v24:BasicObject, v25:NilClass):
-          v29:BasicObject = InvokeBuiltin <inline_expr>, v24
-          CheckInterrupts
-          Return v29
+          CondBranch v17, bb9(), bb4(v8, v9)
         bb9():
-          v36:Fixnum[0] = Const Value(0)
-          Jump bb8(v8, v36)
-        bb8(v49:BasicObject, v50:Fixnum):
-          v86:Array = RefineType v49, Array
-          v87:CInt64 = ArrayLength v86
-          v88:Fixnum = BoxFixnum v87
-          v89:BoolExact = FixnumGe v50, v88
-          v55:CBool = Test v89
-          IfFalse v55, bb7(v49, v50)
-          Jump bb10()
-        bb7(v69:BasicObject, v70:Fixnum):
-          v90:Array = RefineType v69, Array
-          v91:CInt64 = UnboxFixnum v70
-          v92:BasicObject = ArrayAref v90, v91
-          v76:BasicObject = InvokeBlock, v92 # SendFallbackReason: InvokeBlock: not yet specialized
-          v93:Fixnum[1] = Const Value(1)
-          v94:Fixnum = FixnumAdd v70, v93
-          PatchPoint NoEPEscape(each)
-          Jump bb8(v69, v94)
+          v35:Fixnum[0] = Const Value(0)
+          Jump bb8(v8, v35)
+        bb8(v48:BasicObject, v49:Fixnum):
+          v84:Array = RefineType v48, Array
+          v85:CInt64 = ArrayLength v84
+          v86:Fixnum = BoxFixnum v85
+          v87:BoolExact = FixnumGe v49, v86
+          v54:CBool = Test v87
+          CondBranch v54, bb10(), bb7(v48, v49)
         bb10():
           CheckInterrupts
-          Return v49
+          Return v48
+        bb7(v67:BasicObject, v68:Fixnum):
+          v88:Array = RefineType v67, Array
+          v89:CInt64 = UnboxFixnum v68
+          v90:BasicObject = ArrayAref v88, v89
+          v74:BasicObject = InvokeBlock, v90 # SendFallbackReason: InvokeBlock: not yet specialized
+          v91:Fixnum[1] = Const Value(1)
+          v92:Fixnum = FixnumAdd v68, v91
+          PatchPoint NoEPEscape(each)
+          Jump bb8(v67, v92)
+        bb4(v23:BasicObject, v24:NilClass):
+          v28:BasicObject = InvokeBuiltin <inline_expr>, v23
+          CheckInterrupts
+          Return v28
         ");
     }
 
@@ -15648,21 +15601,20 @@ mod hir_opt_tests {
           CheckInterrupts
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
-          IfFalse v16, bb4(v9, v17)
-          Jump bb5()
-        bb4(v31:BasicObject, v32:Falsy):
-          v36:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v37:StringExact = StringCopy v36
-          CheckInterrupts
-          Return v37
+          CondBranch v16, bb5(), bb4(v9, v17)
         bb5():
-          v20:Truthy = RefineType v10, Truthy
-          v24:Fixnum[42] = Const Value(42)
-          PatchPoint MethodRedefined(Object@0x1010, greet_recompile@0x1018, cme:0x1020)
-          v44:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1010)]
-          v45:BasicObject = SendDirect v44, 0x1048, :greet_recompile (0x1058), v24
+          v19:Truthy = RefineType v10, Truthy
+          v23:Fixnum[42] = Const Value(42)
+          PatchPoint MethodRedefined(Object@0x1008, greet_recompile@0x1010, cme:0x1018)
+          v43:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)]
+          v44:BasicObject = SendDirect v43, 0x1040, :greet_recompile (0x1050), v23
           CheckInterrupts
-          Return v45
+          Return v44
+        bb4(v30:BasicObject, v31:Falsy):
+          v35:StringExact[VALUE(0x1058)] = Const Value(VALUE(0x1058))
+          v36:StringExact = StringCopy v35
+          CheckInterrupts
+          Return v36
         ");
     }
 
@@ -15708,19 +15660,18 @@ mod hir_opt_tests {
           CheckInterrupts
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
-          IfFalse v16, bb4(v9, v17)
-          Jump bb5()
-        bb4(v31:BasicObject, v32:Falsy):
-          v36:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v37:StringExact = StringCopy v36
-          CheckInterrupts
-          Return v37
+          CondBranch v16, bb5(), bb4(v9, v17)
         bb5():
-          v20:Truthy = RefineType v10, Truthy
-          v24:Fixnum[42] = Const Value(42)
-          v26:BasicObject = Send v9, :greet_final, v24 # SendFallbackReason: SendWithoutBlock: no profile data available
+          v19:Truthy = RefineType v10, Truthy
+          v23:Fixnum[42] = Const Value(42)
+          v25:BasicObject = Send v9, :greet_final, v23 # SendFallbackReason: SendWithoutBlock: no profile data available
           CheckInterrupts
-          Return v26
+          Return v25
+        bb4(v30:BasicObject, v31:Falsy):
+          v35:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v36:StringExact = StringCopy v35
+          CheckInterrupts
+          Return v36
         ");
     }
 
@@ -15754,33 +15705,31 @@ mod hir_opt_tests {
           v15:CInt64 = IntAnd v13, v14
           v16:CInt64[3] = Const CInt64(3)
           v17:CBool = IsBitEqual v15, v16
-          IfTrue v17, bb5()
-          Jump bb6()
+          CondBranch v17, bb5(), bb6()
         bb5():
-          v21:BasicObject = InvokeBlockIfunc v13, v10
-          Jump bb4(v21)
+          v20:BasicObject = InvokeBlockIfunc v13, v10
+          Jump bb4(v20)
         bb6():
-          v23:BasicObject = InvokeBlock, v10 # SendFallbackReason: InvokeBlock: not yet specialized
-          Jump bb4(v23)
+          v22:BasicObject = InvokeBlock, v10 # SendFallbackReason: InvokeBlock: not yet specialized
+          Jump bb4(v22)
         bb4(v18:BasicObject):
-          v28:Fixnum[2] = Const Value(2)
-          v30:CPtr = GetEP 0
-          v31:CInt64 = LoadField v30, :_env_data_index_specval@0x1000
-          v32:CInt64[3] = Const CInt64(3)
-          v33:CInt64 = IntAnd v31, v32
-          v34:CInt64[3] = Const CInt64(3)
-          v35:CBool = IsBitEqual v33, v34
-          IfTrue v35, bb8()
-          Jump bb9()
+          v27:Fixnum[2] = Const Value(2)
+          v29:CPtr = GetEP 0
+          v30:CInt64 = LoadField v29, :_env_data_index_specval@0x1000
+          v31:CInt64[3] = Const CInt64(3)
+          v32:CInt64 = IntAnd v30, v31
+          v33:CInt64[3] = Const CInt64(3)
+          v34:CBool = IsBitEqual v32, v33
+          CondBranch v34, bb8(), bb9()
         bb8():
-          v39:BasicObject = InvokeBlockIfunc v31, v28
-          Jump bb7(v39)
+          v37:BasicObject = InvokeBlockIfunc v30, v27
+          Jump bb7(v37)
         bb9():
-          v41:BasicObject = InvokeBlock, v28 # SendFallbackReason: InvokeBlock: not yet specialized
-          Jump bb7(v41)
-        bb7(v36:BasicObject):
+          v39:BasicObject = InvokeBlock, v27 # SendFallbackReason: InvokeBlock: not yet specialized
+          Jump bb7(v39)
+        bb7(v35:BasicObject):
           CheckInterrupts
-          Return v36
+          Return v35
         ");
     }
 
@@ -15922,67 +15871,63 @@ mod hir_opt_tests {
         bb6(v19:BasicObject, v20:Fixnum):
           v24:Fixnum[10] = Const Value(10)
           PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
-          v114:BoolExact = FixnumLt v20, v24
+          v110:BoolExact = FixnumLt v20, v24
           CheckInterrupts
-          v30:CBool = Test v114
-          IfTrue v30, bb4(v19, v20)
-          Jump bb7()
-        bb4(v41:BasicObject, v42:Fixnum):
+          v30:CBool = Test v110
+          CondBranch v30, bb4(v19, v20), bb7()
+        bb4(v40:BasicObject, v41:Fixnum):
           PatchPoint SingleRactorMode
-          v47:HeapBasicObject = GuardType v41, HeapBasicObject
-          v48:CUInt64 = LoadField v47, :_rbasic_flags@0x1038
-          v50:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v51:CPtr[CPtr(0x1039)] = Const CPtr(0x1039)
-          v52 = RefineType v51, CUInt64
-          v53:CInt64 = IntAnd v48, v50
-          v54:CBool = IsBitEqual v53, v52
-          IfTrue v54, bb9()
-          Jump bb10()
+          v46:HeapBasicObject = GuardType v40, HeapBasicObject
+          v47:CUInt64 = LoadField v46, :_rbasic_flags@0x1038
+          v49:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v50:CPtr[CPtr(0x1039)] = Const CPtr(0x1039)
+          v51 = RefineType v50, CUInt64
+          v52:CInt64 = IntAnd v47, v49
+          v53:CBool = IsBitEqual v52, v51
+          CondBranch v53, bb9(), bb10()
         bb9():
-          v57:BasicObject = LoadField v47, :@levar@0x103a
-          Jump bb8(v57)
+          v55:BasicObject = LoadField v46, :@levar@0x103a
+          Jump bb8(v55)
         bb10():
-          v59:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v60:CPtr[CPtr(0x103b)] = Const CPtr(0x103b)
-          v61 = RefineType v60, CUInt64
-          v62:CInt64 = IntAnd v48, v59
-          v63:CBool = IsBitEqual v62, v61
-          IfTrue v63, bb11()
-          Jump bb12()
+          v57:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v58:CPtr[CPtr(0x103b)] = Const CPtr(0x103b)
+          v59 = RefineType v58, CUInt64
+          v60:CInt64 = IntAnd v47, v57
+          v61:CBool = IsBitEqual v60, v59
+          CondBranch v61, bb11(), bb12()
         bb11():
-          v66:NilClass = Const Value(nil)
-          Jump bb8(v66)
+          v63:NilClass = Const Value(nil)
+          Jump bb8(v63)
         bb12():
-          v101:CShape = LoadField v47, :_shape_id@0x103c
-          v102:CShape[0x103d] = GuardBitEquals v101, CShape(0x103d)
-          v103:BasicObject = LoadField v47, :@levar@0x103a
-          Jump bb8(v103)
-        bb8(v49:BasicObject):
+          v97:CShape = LoadField v46, :_shape_id@0x103c
+          v98:CShape[0x103d] = GuardBitEquals v97, CShape(0x103d)
+          v99:BasicObject = LoadField v46, :@levar@0x103a
+          Jump bb8(v99)
+        bb8(v48:BasicObject):
           CheckInterrupts
-          v72:CBool = Test v49
-          IfTrue v72, bb5(v47, v42)
-          Jump bb13()
+          v69:CBool = Test v48
+          CondBranch v69, bb5(v46, v41), bb13()
         bb13():
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
-          v105:CShape = LoadField v47, :_shape_id@0x103c
-          v106:CShape[0x103e] = GuardBitEquals v105, CShape(0x103e)
-          StoreField v47, :@levar@0x103a, v42
-          WriteBarrier v47, v42
-          v109:CShape[0x103d] = Const CShape(0x103d)
-          StoreField v47, :_shape_id@0x103c, v109
-          v83:HeapBasicObject = RefineType v47, HeapBasicObject
-          Jump bb5(v83, v42)
-        bb5(v85:HeapBasicObject, v86:Fixnum):
+          v101:CShape = LoadField v46, :_shape_id@0x103c
+          v102:CShape[0x103e] = GuardBitEquals v101, CShape(0x103e)
+          StoreField v46, :@levar@0x103a, v41
+          WriteBarrier v46, v41
+          v105:CShape[0x103d] = Const CShape(0x103d)
+          StoreField v46, :_shape_id@0x103c, v105
+          v79:HeapBasicObject = RefineType v46, HeapBasicObject
+          Jump bb5(v79, v41)
+        bb5(v81:HeapBasicObject, v82:Fixnum):
           PatchPoint NoEPEscape(set_value_loop)
-          v93:Fixnum[1] = Const Value(1)
+          v89:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, +@0x103f, cme:0x1040)
-          v118:Fixnum = FixnumAdd v86, v93
-          Jump bb6(v85, v118)
+          v114:Fixnum = FixnumAdd v82, v89
+          Jump bb6(v81, v114)
         bb7():
-          v36:NilClass = Const Value(nil)
+          v35:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v36
+          Return v35
         ");
     }
 

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -296,27 +296,26 @@ pub(crate) mod hir_build_tests {
           v4:CPtr = LoadPC
           v5:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v6:CBool = IsBitEqual v4, v5
-          IfTrue v6, bb3(v1, v3)
-          Jump bb6()
+          CondBranch v6, bb3(v1, v3), bb6()
         bb6():
           Jump bb5(v1, v3)
         bb2():
           EntryPoint JIT(0)
-          v11:BasicObject = LoadArg :self@0
-          v12:NilClass = Const Value(nil)
-          Jump bb3(v11, v12)
-        bb3(v18:BasicObject, v19:BasicObject):
-          v22:Fixnum[1] = Const Value(1)
-          Jump bb5(v18, v22)
+          v10:BasicObject = LoadArg :self@0
+          v11:NilClass = Const Value(nil)
+          Jump bb3(v10, v11)
+        bb3(v17:BasicObject, v18:BasicObject):
+          v21:Fixnum[1] = Const Value(1)
+          Jump bb5(v17, v21)
         bb4():
           EntryPoint JIT(1)
-          v15:BasicObject = LoadArg :self@0
-          v16:BasicObject = LoadArg :x@1
-          Jump bb5(v15, v16)
-        bb5(v25:BasicObject, v26:BasicObject):
-          v30:Fixnum[123] = Const Value(123)
+          v14:BasicObject = LoadArg :self@0
+          v15:BasicObject = LoadArg :x@1
+          Jump bb5(v14, v15)
+        bb5(v24:BasicObject, v25:BasicObject):
+          v29:Fixnum[123] = Const Value(123)
           CheckInterrupts
-          Return v30
+          Return v29
         ");
     }
 
@@ -375,17 +374,16 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v23:CBool = Test v20
           v24:Truthy = RefineType v20, Truthy
-          IfTrue v23, bb4(v9, v10, v14, v10)
-          Jump bb5()
-        bb4(v37:BasicObject, v38:BasicObject, v39:NilClass, v40:BasicObject):
-          v45:Fixnum[1] = Const Value(1)
+          CondBranch v23, bb4(v9, v10, v14, v10), bb5()
+        bb4(v36:BasicObject, v37:BasicObject, v38:NilClass, v39:BasicObject):
+          v44:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v45
+          Return v44
         bb5():
-          v27:Falsy = RefineType v20, Falsy
-          v32:Fixnum[2] = Const Value(2)
+          v26:Falsy = RefineType v20, Falsy
+          v31:Fixnum[2] = Const Value(2)
           CheckInterrupts
-          Return v32
+          Return v31
         ");
     }
 
@@ -423,17 +421,16 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v22:CBool = Test v19
           v23:Truthy = RefineType v19, Truthy
-          IfTrue v22, bb4(v9, v10, v10)
-          Jump bb5()
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
-          v42:Fixnum[1] = Const Value(1)
+          CondBranch v22, bb4(v9, v10, v10), bb5()
+        bb4(v34:BasicObject, v35:BasicObject, v36:BasicObject):
+          v41:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v42
+          Return v41
         bb5():
-          v26:Falsy = RefineType v19, Falsy
-          v30:Fixnum[2] = Const Value(2)
+          v25:Falsy = RefineType v19, Falsy
+          v29:Fixnum[2] = Const Value(2)
           CheckInterrupts
-          Return v30
+          Return v29
         ");
     }
 
@@ -469,17 +466,16 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v18:CBool = Test v15
           v19:Truthy = RefineType v15, Truthy
-          IfTrue v18, bb4(v6)
-          Jump bb5()
-        bb4(v30:BasicObject):
-          v34:Fixnum[1] = Const Value(1)
+          CondBranch v18, bb4(v6), bb5()
+        bb4(v29:BasicObject):
+          v33:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v34
+          Return v33
         bb5():
-          v22:Falsy = RefineType v15, Falsy
-          v25:Fixnum[2] = Const Value(2)
+          v21:Falsy = RefineType v15, Falsy
+          v24:Fixnum[2] = Const Value(2)
           CheckInterrupts
-          Return v25
+          Return v24
         ");
     }
 
@@ -1169,29 +1165,28 @@ pub(crate) mod hir_build_tests {
           v5:CPtr = LoadPC
           v6:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v7:CBool = IsBitEqual v5, v6
-          IfTrue v7, bb3(v1, v3, v4)
-          Jump bb6()
+          CondBranch v7, bb3(v1, v3, v4), bb6()
         bb6():
           Jump bb5(v1, v3, v4)
         bb2():
           EntryPoint JIT(0)
-          v12:BasicObject = LoadArg :self@0
+          v11:BasicObject = LoadArg :self@0
+          v12:NilClass = Const Value(nil)
           v13:NilClass = Const Value(nil)
-          v14:NilClass = Const Value(nil)
-          Jump bb3(v12, v13, v14)
-        bb3(v21:BasicObject, v22:BasicObject, v23:NilClass):
-          v27:Fixnum[1] = Const Value(1)
-          Jump bb5(v21, v27, v27)
+          Jump bb3(v11, v12, v13)
+        bb3(v20:BasicObject, v21:BasicObject, v22:NilClass):
+          v26:Fixnum[1] = Const Value(1)
+          Jump bb5(v20, v26, v26)
         bb4():
           EntryPoint JIT(1)
-          v17:BasicObject = LoadArg :self@0
-          v18:BasicObject = LoadArg :a@1
-          v19:NilClass = Const Value(nil)
-          Jump bb5(v17, v18, v19)
-        bb5(v32:BasicObject, v33:BasicObject, v34:NilClass|Fixnum):
-          v40:ArrayExact = NewArray v33, v34
+          v16:BasicObject = LoadArg :self@0
+          v17:BasicObject = LoadArg :a@1
+          v18:NilClass = Const Value(nil)
+          Jump bb5(v16, v17, v18)
+        bb5(v31:BasicObject, v32:BasicObject, v33:NilClass|Fixnum):
+          v39:ArrayExact = NewArray v32, v33
           CheckInterrupts
-          Return v40
+          Return v39
         ");
     }
 
@@ -1213,28 +1208,27 @@ pub(crate) mod hir_build_tests {
           v5:CPtr = LoadPC
           v6:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v7:CBool = IsBitEqual v5, v6
-          IfTrue v7, bb3(v1, v3, v4)
-          Jump bb6()
+          CondBranch v7, bb3(v1, v3, v4), bb6()
         bb6():
           Jump bb5(v1, v3, v4)
         bb2():
           EntryPoint JIT(0)
-          v12:BasicObject = LoadArg :self@0
+          v11:BasicObject = LoadArg :self@0
+          v12:NilClass = Const Value(nil)
           v13:NilClass = Const Value(nil)
-          v14:NilClass = Const Value(nil)
-          Jump bb3(v12, v13, v14)
-        bb3(v21:BasicObject, v22:BasicObject, v23:NilClass):
+          Jump bb3(v11, v12, v13)
+        bb3(v20:BasicObject, v21:BasicObject, v22:NilClass):
           SideExit UnhandledYARVInsn(trace_putobject_INT2FIX_1_)
         bb4():
           EntryPoint JIT(1)
-          v17:BasicObject = LoadArg :self@0
-          v18:BasicObject = LoadArg :a@1
-          v19:NilClass = Const Value(nil)
-          Jump bb5(v17, v18, v19)
-        bb5(v28:BasicObject, v29:BasicObject, v30:NilClass):
-          v36:ArrayExact = NewArray v29, v30
+          v16:BasicObject = LoadArg :self@0
+          v17:BasicObject = LoadArg :a@1
+          v18:NilClass = Const Value(nil)
+          Jump bb5(v16, v17, v18)
+        bb5(v27:BasicObject, v28:BasicObject, v29:NilClass):
+          v35:ArrayExact = NewArray v28, v29
           CheckInterrupts
-          Return v36
+          Return v35
         ");
     }
 
@@ -1253,25 +1247,24 @@ pub(crate) mod hir_build_tests {
           v4:CPtr = LoadPC
           v5:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v6:CBool = IsBitEqual v4, v5
-          IfTrue v6, bb3(v1, v3)
-          Jump bb6()
+          CondBranch v6, bb3(v1, v3), bb6()
         bb6():
           Jump bb5(v1, v3)
         bb2():
           EntryPoint JIT(0)
-          v11:BasicObject = LoadArg :self@0
-          v12:NilClass = Const Value(nil)
-          Jump bb3(v11, v12)
-        bb3(v18:BasicObject, v19:BasicObject):
+          v10:BasicObject = LoadArg :self@0
+          v11:NilClass = Const Value(nil)
+          Jump bb3(v10, v11)
+        bb3(v17:BasicObject, v18:BasicObject):
           SideExit UnhandledYARVInsn(definemethod)
         bb4():
           EntryPoint JIT(1)
-          v15:BasicObject = LoadArg :self@0
-          v16:BasicObject = LoadArg :a@1
-          Jump bb5(v15, v16)
-        bb5(v24:BasicObject, v25:BasicObject):
+          v14:BasicObject = LoadArg :self@0
+          v15:BasicObject = LoadArg :a@1
+          Jump bb5(v14, v15)
+        bb5(v23:BasicObject, v24:BasicObject):
           CheckInterrupts
-          Return v25
+          Return v24
         ");
     }
 
@@ -1354,17 +1347,16 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v13:CBool = Test v10
           v14:NilClass = RefineType v10, Falsy
-          IfFalse v13, bb4(v6)
-          Jump bb5()
-        bb4(v25:BasicObject):
-          v29:Fixnum[4] = Const Value(4)
-          CheckInterrupts
-          Return v29
+          CondBranch v13, bb5(), bb4(v6)
         bb5():
-          v17:TrueClass = RefineType v10, Truthy
-          v20:Fixnum[3] = Const Value(3)
+          v16:TrueClass = RefineType v10, Truthy
+          v19:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v20
+          Return v19
+        bb4(v24:BasicObject):
+          v28:Fixnum[4] = Const Value(4)
+          CheckInterrupts
+          Return v28
         ");
     }
 
@@ -1473,17 +1465,16 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
-          IfFalse v16, bb4(v9, v17)
-          Jump bb5()
-        bb4(v28:BasicObject, v29:Falsy):
-          v33:Fixnum[4] = Const Value(4)
-          CheckInterrupts
-          Return v33
+          CondBranch v16, bb5(), bb4(v9, v17)
         bb5():
-          v20:Truthy = RefineType v10, Truthy
-          v23:Fixnum[3] = Const Value(3)
+          v19:Truthy = RefineType v10, Truthy
+          v22:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v23
+          Return v22
+        bb4(v27:BasicObject, v28:Falsy):
+          v32:Fixnum[4] = Const Value(4)
+          CheckInterrupts
+          Return v32
         ");
     }
 
@@ -1518,19 +1509,18 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v19:CBool = Test v12
           v20:Falsy = RefineType v12, Falsy
-          IfFalse v19, bb4(v11, v20, v13)
-          Jump bb6()
-        bb4(v31:BasicObject, v32:Falsy, v33:NilClass):
-          v37:Fixnum[4] = Const Value(4)
-          Jump bb5(v31, v32, v37)
+          CondBranch v19, bb6(), bb4(v11, v20, v13)
         bb6():
-          v23:Truthy = RefineType v12, Truthy
-          v26:Fixnum[3] = Const Value(3)
+          v22:Truthy = RefineType v12, Truthy
+          v25:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Jump bb5(v11, v23, v26)
-        bb5(v40:BasicObject, v41:BasicObject, v42:Fixnum):
+          Jump bb5(v11, v22, v25)
+        bb4(v30:BasicObject, v31:Falsy, v32:NilClass):
+          v36:Fixnum[4] = Const Value(4)
+          Jump bb5(v30, v31, v36)
+        bb5(v39:BasicObject, v40:BasicObject, v41:Fixnum):
           CheckInterrupts
-          Return v42
+          Return v41
         ");
     }
 
@@ -1863,17 +1853,16 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v38:CBool = Test v35
           v39:Truthy = RefineType v35, Truthy
-          IfTrue v38, bb4(v26, v27, v28)
-          Jump bb6()
-        bb4(v52:BasicObject, v53:BasicObject, v54:BasicObject):
-          v59:Fixnum[1] = Const Value(1)
-          v62:BasicObject = Send v53, :+, v59 # SendFallbackReason: Uncategorized(opt_plus)
-          v67:Fixnum[1] = Const Value(1)
-          v70:BasicObject = Send v54, :-, v67 # SendFallbackReason: Uncategorized(opt_minus)
-          Jump bb5(v52, v62, v70)
+          CondBranch v38, bb4(v26, v27, v28), bb6()
+        bb4(v51:BasicObject, v52:BasicObject, v53:BasicObject):
+          v58:Fixnum[1] = Const Value(1)
+          v61:BasicObject = Send v52, :+, v58 # SendFallbackReason: Uncategorized(opt_plus)
+          v66:Fixnum[1] = Const Value(1)
+          v69:BasicObject = Send v53, :-, v66 # SendFallbackReason: Uncategorized(opt_minus)
+          Jump bb5(v51, v61, v69)
         bb6():
-          v42:Falsy = RefineType v35, Falsy
-          v44:NilClass = Const Value(nil)
+          v41:Falsy = RefineType v35, Falsy
+          v43:NilClass = Const Value(nil)
           CheckInterrupts
           Return v27
         ");
@@ -1937,17 +1926,16 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v19:CBool[true] = Test v13
           v20 = RefineType v13, Falsy
-          IfFalse v19, bb4(v8, v20)
-          Jump bb5()
-        bb4(v31, v32):
-          v36 = Const Value(4)
-          CheckInterrupts
-          Return v36
+          CondBranch v19, bb5(), bb4(v8, v20)
         bb5():
-          v23:TrueClass = RefineType v13, Truthy
-          v26:Fixnum[3] = Const Value(3)
+          v22:TrueClass = RefineType v13, Truthy
+          v25:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v26
+          Return v25
+        bb4(v30, v31):
+          v35 = Const Value(4)
+          CheckInterrupts
+          Return v35
         ");
     }
 
@@ -2497,16 +2485,15 @@ pub(crate) mod hir_build_tests {
           v36:CPtr = GetEP 0
           v37:CUInt64 = LoadField v36, :_ep_flags@0x1004
           v38:CBool = IsBlockParamModified v37
-          IfTrue v38, bb4()
-          Jump bb5()
+          CondBranch v38, bb4(), bb5()
         bb4():
-          v41:BasicObject = LoadField v36, :&@0x1005
-          Jump bb6(v41, v41)
+          v40:BasicObject = LoadField v36, :&@0x1005
+          Jump bb6(v40, v40)
         bb5():
-          v43:CInt64 = LoadField v36, :_env_data_index_specval@0x1006
-          v44:CInt64 = GuardAnyBitSet v43, CUInt64(1)
-          v45:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v45, v21)
+          v42:CInt64 = LoadField v36, :_env_data_index_specval@0x1006
+          v43:CInt64 = GuardAnyBitSet v42, CUInt64(1)
+          v44:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v44, v21)
         bb6(v34:BasicObject, v35:BasicObject):
           SideExit SplatKwNotProfiled
         ");
@@ -2533,19 +2520,18 @@ pub(crate) mod hir_build_tests {
           v10:BasicObject = GetConstantPath 0x1000
           v12:NilClass = Const Value(nil)
           v15:CBool = IsMethodCFunc v10, :new
-          IfFalse v15, bb4(v6, v12, v10)
-          Jump bb6()
-        bb4(v24:BasicObject, v25:NilClass, v26:BasicObject):
-          v29:BasicObject = Send v26, :new # SendFallbackReason: Uncategorized(opt_send_without_block)
-          Jump bb5(v24, v29, v25)
+          CondBranch v15, bb6(), bb4(v6, v12, v10)
         bb6():
-          v18:HeapBasicObject = ObjectAlloc v10
-          v20:BasicObject = Send v18, :initialize # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v17:HeapBasicObject = ObjectAlloc v10
+          v19:BasicObject = Send v17, :initialize # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Jump bb5(v6, v18, v20)
-        bb5(v32:BasicObject, v33:BasicObject, v34:BasicObject):
+          Jump bb5(v6, v17, v19)
+        bb4(v23:BasicObject, v24:NilClass, v25:BasicObject):
+          v28:BasicObject = Send v25, :new # SendFallbackReason: Uncategorized(opt_send_without_block)
+          Jump bb5(v23, v28, v24)
+        bb5(v31:BasicObject, v32:BasicObject, v33:BasicObject):
           CheckInterrupts
-          Return v33
+          Return v32
         ");
     }
 
@@ -3419,14 +3405,13 @@ pub(crate) mod hir_build_tests {
           v15:CPtr = GetEP 0
           v16:CUInt64 = LoadField v15, :_ep_flags@0x1001
           v17:CBool = IsBlockParamModified v16
-          IfTrue v17, bb4()
-          Jump bb5()
+          CondBranch v17, bb4(), bb5()
         bb4():
-          v20:BasicObject = LoadField v15, :block@0x1002
-          Jump bb6(v20)
+          v19:BasicObject = LoadField v15, :block@0x1002
+          Jump bb6(v19)
         bb5():
-          v22:BasicObject = GetBlockParam :block, l0, EP@3
-          Jump bb6(v22)
+          v21:BasicObject = GetBlockParam :block, l0, EP@3
+          Jump bb6(v21)
         bb6(v14:BasicObject):
           CheckInterrupts
           Return v14
@@ -3456,20 +3441,19 @@ pub(crate) mod hir_build_tests {
           v17:CPtr = GetEP 0
           v18:CUInt64 = LoadField v17, :_ep_flags@0x1001
           v19:CBool = IsBlockParamModified v18
-          IfTrue v19, bb4()
-          Jump bb5()
+          CondBranch v19, bb4(), bb5()
         bb4():
-          v22:BasicObject = LoadField v17, :block@0x1002
-          Jump bb6(v22, v22)
+          v21:BasicObject = LoadField v17, :block@0x1002
+          Jump bb6(v21, v21)
         bb5():
-          v24:CInt64 = LoadField v17, :_env_data_index_specval@0x1003
-          v25:CInt64 = GuardAnyBitSet v24, CUInt64(1)
-          v26:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v26, v10)
+          v23:CInt64 = LoadField v17, :_env_data_index_specval@0x1003
+          v24:CInt64 = GuardAnyBitSet v23, CUInt64(1)
+          v25:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v25, v10)
         bb6(v15:BasicObject, v16:BasicObject):
-          v29:BasicObject = Send v9, &block, :tap, v15 # SendFallbackReason: Uncategorized(send)
+          v28:BasicObject = Send v9, &block, :tap, v15 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v29
+          Return v28
         ");
     }
 
@@ -3501,32 +3485,30 @@ pub(crate) mod hir_build_tests {
           v18:CPtr = GetEP 0
           v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
           v20:CBool = IsBlockParamModified v19
-          IfTrue v20, bb4()
-          Jump bb5()
+          CondBranch v20, bb4(), bb5()
         bb4():
-          v23:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v23)
+          v22:BasicObject = LoadField v18, :block@0x1002
+          Jump bb6(v22)
         bb5():
-          v25:BasicObject = GetBlockParam :block, l0, EP@4
-          Jump bb6(v25)
+          v24:BasicObject = GetBlockParam :block, l0, EP@4
+          Jump bb6(v24)
         bb6(v17:BasicObject):
-          v33:CPtr = GetEP 0
-          v34:CUInt64 = LoadField v33, :_ep_flags@0x1001
-          v35:CBool = IsBlockParamModified v34
-          IfTrue v35, bb7()
-          Jump bb8()
+          v32:CPtr = GetEP 0
+          v33:CUInt64 = LoadField v32, :_ep_flags@0x1001
+          v34:CBool = IsBlockParamModified v33
+          CondBranch v34, bb7(), bb8()
         bb7():
-          v38:BasicObject = LoadField v33, :block@0x1002
-          Jump bb9(v38, v38)
+          v36:BasicObject = LoadField v32, :block@0x1002
+          Jump bb9(v36, v36)
         bb8():
-          v40:CInt64 = LoadField v33, :_env_data_index_specval@0x1003
-          v41:CInt64 = GuardAnyBitSet v40, CUInt64(1)
-          v42:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb9(v42, v17)
-        bb9(v31:BasicObject, v32:BasicObject):
-          v45:BasicObject = Send v11, &block, :tap, v31 # SendFallbackReason: Uncategorized(send)
+          v38:CInt64 = LoadField v32, :_env_data_index_specval@0x1003
+          v39:CInt64 = GuardAnyBitSet v38, CUInt64(1)
+          v40:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb9(v40, v17)
+        bb9(v30:BasicObject, v31:BasicObject):
+          v43:BasicObject = Send v11, &block, :tap, v30 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v45
+          Return v43
         ");
     }
 
@@ -3556,32 +3538,30 @@ pub(crate) mod hir_build_tests {
           v14:CPtr = GetEP 1
           v15:CUInt64 = LoadField v14, :_ep_flags@0x1000
           v16:CBool = IsBlockParamModified v15
-          IfTrue v16, bb4()
-          Jump bb5()
+          CondBranch v16, bb4(), bb5()
         bb4():
-          v19:BasicObject = LoadField v14, :block@0x1001
-          Jump bb6(v19)
+          v18:BasicObject = LoadField v14, :block@0x1001
+          Jump bb6(v18)
         bb5():
-          v21:BasicObject = GetBlockParam :block, l1, EP@3
-          Jump bb6(v21)
+          v20:BasicObject = GetBlockParam :block, l1, EP@3
+          Jump bb6(v20)
         bb6(v13:BasicObject):
-          v28:CPtr = GetEP 1
-          v29:CUInt64 = LoadField v28, :_ep_flags@0x1000
-          v30:CBool = IsBlockParamModified v29
-          IfTrue v30, bb7()
-          Jump bb8()
+          v27:CPtr = GetEP 1
+          v28:CUInt64 = LoadField v27, :_ep_flags@0x1000
+          v29:CBool = IsBlockParamModified v28
+          CondBranch v29, bb7(), bb8()
         bb7():
-          v33:BasicObject = LoadField v28, :block@0x1001
-          Jump bb9(v33)
+          v31:BasicObject = LoadField v27, :block@0x1001
+          Jump bb9(v31)
         bb8():
-          v35:CInt64 = LoadField v28, :_env_data_index_specval@0x1002
-          v36:CInt64 = GuardAnyBitSet v35, CUInt64(1)
-          v37:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb9(v37)
-        bb9(v27:BasicObject):
-          v40:BasicObject = Send v8, &block, :tap, v27 # SendFallbackReason: Uncategorized(send)
+          v33:CInt64 = LoadField v27, :_env_data_index_specval@0x1002
+          v34:CInt64 = GuardAnyBitSet v33, CUInt64(1)
+          v35:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb9(v35)
+        bb9(v26:BasicObject):
+          v38:BasicObject = Send v8, &block, :tap, v26 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v40
+          Return v38
         ");
     }
 
@@ -3615,33 +3595,30 @@ pub(crate) mod hir_build_tests {
           v18:CPtr = GetEP 0
           v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
           v20:CBool = IsBlockParamModified v19
-          IfTrue v20, bb4()
-          Jump bb5()
+          CondBranch v20, bb4(), bb5()
         bb4():
-          v23:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v23, v23)
+          v22:BasicObject = LoadField v18, :block@0x1002
+          Jump bb6(v22, v22)
         bb5():
-          v25:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
-          v26:CInt64[1] = Const CInt64(1)
-          v27:CInt64 = IntAnd v25, v26
-          v28:CBool = IsBitEqual v27, v26
-          IfTrue v28, bb7()
-          Jump bb9()
+          v24:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
+          v25:CInt64[1] = Const CInt64(1)
+          v26:CInt64 = IntAnd v24, v25
+          v27:CBool = IsBitEqual v26, v25
+          CondBranch v27, bb7(), bb9()
         bb7():
-          v31:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v31, v10)
+          v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v29, v10)
         bb9():
-          v33:CInt64[0] = Const CInt64(0)
-          v34:CBool = IsBitEqual v25, v33
-          IfTrue v34, bb8()
-          Jump bb10()
+          v31:CInt64[0] = Const CInt64(0)
+          v32:CBool = IsBitEqual v24, v31
+          CondBranch v32, bb8(), bb10()
         bb8():
-          v37:NilClass = Const Value(nil)
-          Jump bb6(v37, v10)
+          v34:NilClass = Const Value(nil)
+          Jump bb6(v34, v10)
         bb6(v16:BasicObject, v17:BasicObject):
-          v41:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Uncategorized(send)
+          v38:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v41
+          Return v38
         bb10():
           SideExit BlockParamProxyProfileNotCovered
         ");
@@ -3670,14 +3647,13 @@ pub(crate) mod hir_build_tests {
           v11:CPtr = GetEP 1
           v12:CUInt64 = LoadField v11, :_ep_flags@0x1000
           v13:CBool = IsBlockParamModified v12
-          IfTrue v13, bb4()
-          Jump bb5()
+          CondBranch v13, bb4(), bb5()
         bb4():
-          v16:BasicObject = LoadField v11, :block@0x1001
-          Jump bb6(v16)
+          v15:BasicObject = LoadField v11, :block@0x1001
+          Jump bb6(v15)
         bb5():
-          v18:BasicObject = GetBlockParam :block, l1, EP@3
-          Jump bb6(v18)
+          v17:BasicObject = GetBlockParam :block, l1, EP@3
+          Jump bb6(v17)
         bb6(v10:BasicObject):
           CheckInterrupts
           Return v10
@@ -3776,16 +3752,15 @@ pub(crate) mod hir_build_tests {
           v21:CPtr = GetEP 0
           v22:CUInt64 = LoadField v21, :_ep_flags@0x1002
           v23:CBool = IsBlockParamModified v22
-          IfTrue v23, bb4()
-          Jump bb5()
+          CondBranch v23, bb4(), bb5()
         bb4():
-          v26:BasicObject = LoadField v21, :b@0x1003
-          Jump bb6(v26, v26)
+          v25:BasicObject = LoadField v21, :b@0x1003
+          Jump bb6(v25, v25)
         bb5():
-          v28:CInt64 = LoadField v21, :_env_data_index_specval@0x1004
-          v29:CInt64 = GuardAnyBitSet v28, CUInt64(1)
-          v30:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v30, v13)
+          v27:CInt64 = LoadField v21, :_env_data_index_specval@0x1004
+          v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
+          v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v29, v13)
         bb6(v19:BasicObject, v20:BasicObject):
           SideExit SplatKwNotProfiled
         ");
@@ -3826,21 +3801,20 @@ pub(crate) mod hir_build_tests {
           v36:CPtr = GetEP 0
           v37:CUInt64 = LoadField v36, :_ep_flags@0x1004
           v38:CBool = IsBlockParamModified v37
-          IfTrue v38, bb4()
-          Jump bb5()
+          CondBranch v38, bb4(), bb5()
         bb4():
-          v41:BasicObject = LoadField v36, :&@0x1005
-          Jump bb6(v41, v41)
+          v40:BasicObject = LoadField v36, :&@0x1005
+          Jump bb6(v40, v40)
         bb5():
-          v43:CInt64 = LoadField v36, :_env_data_index_specval@0x1006
-          v44:CInt64[0] = GuardBitEquals v43, CInt64(0)
-          v45:NilClass = Const Value(nil)
-          Jump bb6(v45, v21)
+          v42:CInt64 = LoadField v36, :_env_data_index_specval@0x1006
+          v43:CInt64[0] = GuardBitEquals v42, CInt64(0)
+          v44:NilClass = Const Value(nil)
+          Jump bb6(v44, v21)
         bb6(v34:BasicObject, v35:BasicObject):
-          v48:NilClass = GuardType v20, NilClass
-          v50:BasicObject = Send v17, &block, :foo, v18, v29, v48, v34 # SendFallbackReason: Uncategorized(send)
+          v47:NilClass = GuardType v20, NilClass
+          v49:BasicObject = Send v17, &block, :foo, v18, v29, v47, v34 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v50
+          Return v49
         ");
     }
 
@@ -3871,21 +3845,20 @@ pub(crate) mod hir_build_tests {
           v21:CPtr = GetEP 0
           v22:CUInt64 = LoadField v21, :_ep_flags@0x1002
           v23:CBool = IsBlockParamModified v22
-          IfTrue v23, bb4()
-          Jump bb5()
+          CondBranch v23, bb4(), bb5()
         bb4():
-          v26:BasicObject = LoadField v21, :b@0x1003
-          Jump bb6(v26, v26)
+          v25:BasicObject = LoadField v21, :b@0x1003
+          Jump bb6(v25, v25)
         bb5():
-          v28:CInt64 = LoadField v21, :_env_data_index_specval@0x1004
-          v29:CInt64 = GuardAnyBitSet v28, CUInt64(1)
-          v30:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v30, v13)
+          v27:CInt64 = LoadField v21, :_env_data_index_specval@0x1004
+          v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
+          v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v29, v13)
         bb6(v19:BasicObject, v20:BasicObject):
-          v33:HashExact = GuardType v12, HashExact
-          v35:BasicObject = Send v11, &block, :foo, v33, v19 # SendFallbackReason: Uncategorized(send)
+          v32:HashExact = GuardType v12, HashExact
+          v34:BasicObject = Send v11, &block, :foo, v32, v19 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v35
+          Return v34
         ");
     }
 
@@ -3916,21 +3889,20 @@ pub(crate) mod hir_build_tests {
           v21:CPtr = GetEP 0
           v22:CUInt64 = LoadField v21, :_ep_flags@0x1002
           v23:CBool = IsBlockParamModified v22
-          IfTrue v23, bb4()
-          Jump bb5()
+          CondBranch v23, bb4(), bb5()
         bb4():
-          v26:BasicObject = LoadField v21, :b@0x1003
-          Jump bb6(v26, v26)
+          v25:BasicObject = LoadField v21, :b@0x1003
+          Jump bb6(v25, v25)
         bb5():
-          v28:CInt64 = LoadField v21, :_env_data_index_specval@0x1004
-          v29:CInt64 = GuardAnyBitSet v28, CUInt64(1)
-          v30:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v30, v13)
+          v27:CInt64 = LoadField v21, :_env_data_index_specval@0x1004
+          v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
+          v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v29, v13)
         bb6(v19:BasicObject, v20:BasicObject):
-          v33:HashExact = GuardType v12, HashExact
-          v35:BasicObject = Send v11, &block, :foo, v33, v19 # SendFallbackReason: Uncategorized(send)
+          v32:HashExact = GuardType v12, HashExact
+          v34:BasicObject = Send v11, &block, :foo, v32, v19 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v35
+          Return v34
         ");
     }
 
@@ -3971,16 +3943,15 @@ pub(crate) mod hir_build_tests {
           v36:CPtr = GetEP 0
           v37:CUInt64 = LoadField v36, :_ep_flags@0x1004
           v38:CBool = IsBlockParamModified v37
-          IfTrue v38, bb4()
-          Jump bb5()
+          CondBranch v38, bb4(), bb5()
         bb4():
-          v41:BasicObject = LoadField v36, :&@0x1005
-          Jump bb6(v41, v41)
+          v40:BasicObject = LoadField v36, :&@0x1005
+          Jump bb6(v40, v40)
         bb5():
-          v43:CInt64 = LoadField v36, :_env_data_index_specval@0x1006
-          v44:CInt64[0] = GuardBitEquals v43, CInt64(0)
-          v45:NilClass = Const Value(nil)
-          Jump bb6(v45, v21)
+          v42:CInt64 = LoadField v36, :_env_data_index_specval@0x1006
+          v43:CInt64[0] = GuardBitEquals v42, CInt64(0)
+          v44:NilClass = Const Value(nil)
+          Jump bb6(v44, v21)
         bb6(v34:BasicObject, v35:BasicObject):
           SideExit SplatKwPolymorphic
         ");
@@ -4015,16 +3986,15 @@ pub(crate) mod hir_build_tests {
           v21:CPtr = GetEP 0
           v22:CUInt64 = LoadField v21, :_ep_flags@0x1002
           v23:CBool = IsBlockParamModified v22
-          IfTrue v23, bb4()
-          Jump bb5()
+          CondBranch v23, bb4(), bb5()
         bb4():
-          v26:BasicObject = LoadField v21, :block@0x1003
-          Jump bb6(v26, v26)
+          v25:BasicObject = LoadField v21, :block@0x1003
+          Jump bb6(v25, v25)
         bb5():
-          v28:CInt64 = LoadField v21, :_env_data_index_specval@0x1004
-          v29:CInt64 = GuardAnyBitSet v28, CUInt64(1)
-          v30:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v30, v13)
+          v27:CInt64 = LoadField v21, :_env_data_index_specval@0x1004
+          v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
+          v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v29, v13)
         bb6(v19:BasicObject, v20:BasicObject):
           SideExit SplatKwNotNilOrHash
         ");
@@ -4499,15 +4469,14 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v17:CBool = IsNil v10
           v18:NilClass = Const Value(nil)
-          IfTrue v17, bb4(v9, v18, v18)
-          Jump bb5()
+          CondBranch v17, bb4(v9, v18, v18), bb5()
         bb5():
-          v21:NotNil = RefineType v10, NotNil
-          v23:BasicObject = Send v21, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
-          Jump bb4(v9, v21, v23)
-        bb4(v25:BasicObject, v26:BasicObject, v27:BasicObject):
+          v20:NotNil = RefineType v10, NotNil
+          v22:BasicObject = Send v20, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
+          Jump bb4(v9, v20, v22)
+        bb4(v24:BasicObject, v25:BasicObject, v26:BasicObject):
           CheckInterrupts
-          Return v27
+          Return v26
         ");
     }
 
@@ -4541,26 +4510,24 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
-          IfFalse v16, bb4(v9, v17)
-          Jump bb6()
-        bb4(v37:BasicObject, v38:Falsy):
-          v42:Fixnum[4] = Const Value(4)
-          Jump bb5(v37, v38, v42)
+          CondBranch v16, bb6(), bb4(v9, v17)
         bb6():
-          v20:Truthy = RefineType v10, Truthy
+          v19:Truthy = RefineType v10, Truthy
           CheckInterrupts
-          v26:CBool[false] = IsNil v20
-          v27:NilClass = Const Value(nil)
-          IfTrue v26, bb5(v9, v27, v27)
-          Jump bb7()
-        bb5(v44:BasicObject, v45:Falsy, v46:Fixnum[4]):
-          CheckInterrupts
-          Return v46
+          v25:CBool[false] = IsNil v19
+          v26:NilClass = Const Value(nil)
+          CondBranch v25, bb5(v9, v26, v26), bb7()
         bb7():
-          v30:Truthy = RefineType v20, NotNil
-          v32:BasicObject = Send v30, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v28:Truthy = RefineType v19, NotNil
+          v30:BasicObject = Send v28, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v32
+          Return v30
+        bb4(v35:BasicObject, v36:Falsy):
+          v40:Fixnum[4] = Const Value(4)
+          Jump bb5(v35, v36, v40)
+        bb5(v42:BasicObject, v43:Falsy, v44:Fixnum[4]):
+          CheckInterrupts
+          Return v44
         ");
     }
 
@@ -4600,39 +4567,36 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
-          IfFalse v16, bb6(v9, v17)
-          Jump bb7()
-        bb6(v46:BasicObject, v47:Falsy):
-          v51:Fixnum[6] = Const Value(6)
-          CheckInterrupts
-          Return v51
+          CondBranch v16, bb7(), bb6(v9, v17)
         bb7():
-          v20:Truthy = RefineType v10, Truthy
+          v19:Truthy = RefineType v10, Truthy
           CheckInterrupts
-          v25:CBool[true] = Test v20
-          v26 = RefineType v20, Falsy
-          IfFalse v25, bb5(v9, v26)
-          Jump bb8()
-        bb5(v56, v57):
-          v61 = Const Value(5)
-          CheckInterrupts
-          Return v61
+          v24:CBool[true] = Test v19
+          v25 = RefineType v19, Falsy
+          CondBranch v24, bb8(), bb5(v9, v25)
         bb8():
-          v29:Truthy = RefineType v20, Truthy
+          v27:Truthy = RefineType v19, Truthy
           CheckInterrupts
-          v34:CBool[true] = Test v29
-          v35 = RefineType v29, Falsy
-          IfFalse v34, bb4(v9, v35)
-          Jump bb9()
-        bb4(v66, v67):
-          v71 = Const Value(4)
-          CheckInterrupts
-          Return v71
+          v32:CBool[true] = Test v27
+          v33 = RefineType v27, Falsy
+          CondBranch v32, bb9(), bb4(v9, v33)
         bb9():
-          v38:Truthy = RefineType v29, Truthy
-          v41:Fixnum[3] = Const Value(3)
+          v35:Truthy = RefineType v27, Truthy
+          v38:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v41
+          Return v38
+        bb4(v63, v64):
+          v68 = Const Value(4)
+          CheckInterrupts
+          Return v68
+        bb5(v53, v54):
+          v58 = Const Value(5)
+          CheckInterrupts
+          Return v58
+        bb6(v43:BasicObject, v44:Falsy):
+          v48:Fixnum[6] = Const Value(6)
+          CheckInterrupts
+          Return v48
         ");
     }
 
@@ -4722,31 +4686,29 @@ pub(crate) mod hir_build_tests {
           v35:CPtr = GetEP 0
           v36:CUInt64 = LoadField v35, :_ep_flags@0x1004
           v37:CBool = IsBlockParamModified v36
-          IfTrue v37, bb5()
-          Jump bb6()
+          CondBranch v37, bb5(), bb6()
         bb5():
-          v40:BasicObject = LoadField v35, :block@0x1005
-          Jump bb7(v40, v40)
+          v39:BasicObject = LoadField v35, :block@0x1005
+          Jump bb7(v39, v39)
         bb6():
-          v42:CInt64 = LoadField v35, :_env_data_index_specval@0x1006
-          v43:CInt64 = GuardAnyBitSet v42, CUInt64(1)
-          v44:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb7(v44, v22)
+          v41:CInt64 = LoadField v35, :_env_data_index_specval@0x1006
+          v42:CInt64 = GuardAnyBitSet v41, CUInt64(1)
+          v43:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb7(v43, v22)
         bb7(v33:BasicObject, v34:BasicObject):
           CheckInterrupts
-          v48:CBool = Test v33
-          v49:Falsy = RefineType v33, Falsy
-          IfFalse v48, bb4(v18, v19, v20, v21, v34, v27)
-          Jump bb8()
-        bb4(v65:BasicObject, v66:BasicObject, v67:BasicObject, v68:BasicObject, v69:BasicObject, v70:BasicObject):
-          CheckInterrupts
-          Return v70
+          v47:CBool = Test v33
+          v48:Falsy = RefineType v33, Falsy
+          CondBranch v47, bb8(), bb4(v18, v19, v20, v21, v34, v27)
         bb8():
-          v52:Truthy = RefineType v33, Truthy
-          v56:BasicObject = InvokeBlock, v27 # SendFallbackReason: InvokeBlock: not yet specialized
-          v59:BasicObject = InvokeBuiltin dir_s_close, v18, v27
+          v50:Truthy = RefineType v33, Truthy
+          v54:BasicObject = InvokeBlock, v27 # SendFallbackReason: InvokeBlock: not yet specialized
+          v57:BasicObject = InvokeBuiltin dir_s_close, v18, v27
           CheckInterrupts
-          Return v56
+          Return v54
+        bb4(v63:BasicObject, v64:BasicObject, v65:BasicObject, v66:BasicObject, v67:BasicObject, v68:BasicObject):
+          CheckInterrupts
+          Return v68
         ");
     }
 
@@ -4880,17 +4842,16 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v26:CBool = Test v22
           v27:Truthy = RefineType v22, Truthy
-          IfTrue v26, bb4(v9, v10, v14, v10, v17, v19, v27)
-          Jump bb5()
-        bb4(v42:BasicObject, v43:BasicObject, v44:NilClass, v45:BasicObject, v46:Fixnum[0], v47:Fixnum[1], v48:Truthy):
+          CondBranch v26, bb4(v9, v10, v14, v10, v17, v19, v27), bb5()
+        bb4(v41:BasicObject, v42:BasicObject, v43:NilClass, v44:BasicObject, v45:Fixnum[0], v46:Fixnum[1], v47:Truthy):
           CheckInterrupts
-          Return v48
+          Return v47
         bb5():
-          v30:Falsy = RefineType v22, Falsy
-          v33:Fixnum[2] = Const Value(2)
-          v36:BasicObject = Send v10, :[]=, v17, v19, v33 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v29:Falsy = RefineType v22, Falsy
+          v32:Fixnum[2] = Const Value(2)
+          v35:BasicObject = Send v10, :[]=, v17, v19, v32 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v33
+          Return v32
         ");
     }
 
@@ -5260,17 +5221,16 @@ pub(crate) mod hir_build_tests {
           CheckInterrupts
           v20:CBool = Test v17
           v21:TrueClass = RefineType v17, Truthy
-          IfTrue v20, bb4(v12, v13, v14)
-          Jump bb5()
+          CondBranch v20, bb4(v12, v13, v14), bb5()
         bb5():
-          v24:FalseClass = RefineType v17, Falsy
-          v26:Fixnum[1] = Const Value(1)
-          v28:Fixnum[1] = Const Value(1)
-          v31:BasicObject = Send v26, :+, v28 # SendFallbackReason: Uncategorized(opt_plus)
-          Jump bb4(v12, v31, v14)
-        bb4(v34:BasicObject, v35:BasicObject, v36:BasicObject):
+          v23:FalseClass = RefineType v17, Falsy
+          v25:Fixnum[1] = Const Value(1)
+          v27:Fixnum[1] = Const Value(1)
+          v30:BasicObject = Send v25, :+, v27 # SendFallbackReason: Uncategorized(opt_plus)
+          Jump bb4(v12, v30, v14)
+        bb4(v33:BasicObject, v34:BasicObject, v35:BasicObject):
           CheckInterrupts
-          Return v35
+          Return v34
         ");
     }
 
@@ -5390,37 +5350,35 @@ pub(crate) mod hir_build_tests {
           v15:TrueClass|NilClass = Defined yield, v13
           v17:CBool = Test v15
           v18:NilClass = RefineType v15, Falsy
-          IfFalse v17, bb4(v8, v9)
-          Jump bb9()
-        bb4(v24:BasicObject, v25:NilClass):
-          v29:BasicObject = InvokeBuiltin <inline_expr>, v24
-          Jump bb5(v24, v25, v29)
-        bb5(v41:BasicObject, v42:NilClass, v43:BasicObject):
-          CheckInterrupts
-          Return v43
+          CondBranch v17, bb9(), bb4(v8, v9)
         bb9():
-          v21:TrueClass = RefineType v15, Truthy
+          v20:TrueClass = RefineType v15, Truthy
           Jump bb6(v8, v9)
-        bb6(v31:BasicObject, v32:NilClass):
-          v36:Fixnum[0] = Const Value(0)
-          Jump bb8(v31, v36)
-        bb8(v49:BasicObject, v50:Fixnum):
-          v53:BoolExact = InvokeBuiltin rb_jit_ary_at_end, v49, v50
-          v55:CBool = Test v53
-          v56:FalseClass = RefineType v53, Falsy
-          IfFalse v55, bb7(v49, v50)
-          Jump bb10()
-        bb7(v69:BasicObject, v70:Fixnum):
-          v74:BasicObject = InvokeBuiltin rb_jit_ary_at, v69, v70
-          v76:BasicObject = InvokeBlock, v74 # SendFallbackReason: InvokeBlock: not yet specialized
-          v80:Fixnum = InvokeBuiltin rb_jit_fixnum_inc, v69, v70
-          PatchPoint NoEPEscape(each)
-          Jump bb8(v69, v80)
+        bb6(v30:BasicObject, v31:NilClass):
+          v35:Fixnum[0] = Const Value(0)
+          Jump bb8(v30, v35)
+        bb8(v48:BasicObject, v49:Fixnum):
+          v52:BoolExact = InvokeBuiltin rb_jit_ary_at_end, v48, v49
+          v54:CBool = Test v52
+          v55:FalseClass = RefineType v52, Falsy
+          CondBranch v54, bb10(), bb7(v48, v49)
         bb10():
-          v59:TrueClass = RefineType v53, Truthy
-          v61:NilClass = Const Value(nil)
+          v57:TrueClass = RefineType v52, Truthy
+          v59:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v49
+          Return v48
+        bb7(v67:BasicObject, v68:Fixnum):
+          v72:BasicObject = InvokeBuiltin rb_jit_ary_at, v67, v68
+          v74:BasicObject = InvokeBlock, v72 # SendFallbackReason: InvokeBlock: not yet specialized
+          v78:Fixnum = InvokeBuiltin rb_jit_fixnum_inc, v67, v68
+          PatchPoint NoEPEscape(each)
+          Jump bb8(v67, v78)
+        bb4(v23:BasicObject, v24:NilClass):
+          v28:BasicObject = InvokeBuiltin <inline_expr>, v23
+          Jump bb5(v23, v24, v28)
+        bb5(v40:BasicObject, v41:NilClass, v42:BasicObject):
+          CheckInterrupts
+          Return v42
         ");
     }
 
@@ -5612,8 +5570,7 @@ pub(crate) mod hir_build_tests {
         let bb3 = function.new_block(0);
 
         let v1 = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb0, Insn::IfTrue { val: v1, target: edge(bb2)});
-        function.push_insn(bb0, Insn::Jump(edge(bb1)));
+        let _ = function.push_insn(bb0, Insn::CondBranch { val: v1, if_true: edge(bb2), if_false: edge(bb1) });
         function.push_insn(bb1, Insn::Jump(edge(bb3)));
         function.push_insn(bb2, Insn::Jump(edge(bb3)));
 
@@ -5639,8 +5596,7 @@ pub(crate) mod hir_build_tests {
 
          // Construct two separate jump instructions.
          let v1 = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
-         let _ = function.push_insn(bb0, Insn::IfTrue { val: v1, target: edge(bb1)});
-         function.push_insn(bb0, Insn::Jump(edge(bb1)));
+         let _ = function.push_insn(bb0, Insn::CondBranch { val: v1, if_true: edge(bb1), if_false: edge(bb1)});
 
          let retval = function.push_insn(bb1, Insn::Const { val: Const::CBool(true) });
          function.push_insn(bb1, Insn::Return { val: retval });
@@ -5720,8 +5676,7 @@ pub(crate) mod hir_build_tests {
         let bb3 = function.new_block(0);
 
         let val = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb0, Insn::IfTrue { val, target: edge(bb1)});
-        function.push_insn(bb0, Insn::Jump(edge(bb2)));
+        let _ = function.push_insn(bb0, Insn::CondBranch { val, if_true: edge(bb1), if_false: edge(bb2) });
 
         function.push_insn(bb2, Insn::Jump(edge(bb3)));
         function.push_insn(bb1, Insn::Jump(edge(bb3)));
@@ -5734,15 +5689,14 @@ pub(crate) mod hir_build_tests {
         fn <manual>:
         bb1():
           v0:Any = Const Value(false)
-          IfTrue v0, bb2()
-          Jump bb3()
+          CondBranch v0, bb2(), bb3()
         bb2():
           Jump bb4()
         bb3():
           Jump bb4()
         bb4():
-          v5:Any = Const CBool(true)
-          Return v5
+          v4:Any = Const CBool(true)
+          Return v4
         ");
 
         let dominators = Dominators::new(&function);
@@ -5770,14 +5724,12 @@ pub(crate) mod hir_build_tests {
         function.push_insn(bb0, Insn::Jump(edge(bb1)));
 
         let v0 = function.push_insn(bb1, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb1, Insn::IfTrue { val: v0, target: edge(bb2)});
-        function.push_insn(bb1, Insn::Jump(edge(bb4)));
+        let _ = function.push_insn(bb1, Insn::CondBranch { val: v0, if_true: edge(bb2), if_false: edge(bb4) });
 
         function.push_insn(bb2, Insn::Jump(edge(bb3)));
 
         let v1 = function.push_insn(bb3, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb3, Insn::IfTrue { val: v1, target: edge(bb5)});
-        function.push_insn(bb3, Insn::Jump(edge(bb7)));
+        let _ = function.push_insn(bb3, Insn::CondBranch { val: v1, if_true: edge(bb5), if_false: edge(bb7) });
 
         function.push_insn(bb4, Insn::Jump(edge(bb5)));
 
@@ -5795,14 +5747,12 @@ pub(crate) mod hir_build_tests {
           Jump bb2()
         bb2():
           v1:Any = Const Value(false)
-          IfTrue v1, bb3()
-          Jump bb5()
+          CondBranch v1, bb3(), bb5()
         bb3():
           Jump bb4()
         bb4():
-          v5:Any = Const Value(false)
-          IfTrue v5, bb6()
-          Jump bb8()
+          v4:Any = Const Value(false)
+          CondBranch v4, bb6(), bb8()
         bb5():
           Jump bb6()
         bb6():
@@ -5810,8 +5760,8 @@ pub(crate) mod hir_build_tests {
         bb7():
           Jump bb8()
         bb8():
-          v11:Any = Const CBool(true)
-          Return v11
+          v9:Any = Const CBool(true)
+          Return v9
         ");
 
         let dominators = Dominators::new(&function);
@@ -5839,20 +5789,17 @@ pub(crate) mod hir_build_tests {
         let bb5 = function.new_block(0);
 
         let v0 = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb0, Insn::IfTrue { val: v0, target: edge(bb1)});
-        function.push_insn(bb0, Insn::Jump(edge(bb4)));
+        let _ = function.push_insn(bb0, Insn::CondBranch { val: v0, if_true: edge(bb1), if_false: edge(bb4) });
 
         let v1 = function.push_insn(bb1, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb1, Insn::IfTrue { val: v1, target: edge(bb2)});
-        function.push_insn(bb1, Insn::Jump(edge(bb3)));
+        let _ = function.push_insn(bb1, Insn::CondBranch { val: v1, if_true: edge(bb2), if_false: edge(bb3) });
 
         function.push_insn(bb2, Insn::Jump(edge(bb3)));
 
         function.push_insn(bb4, Insn::Jump(edge(bb5)));
 
         let v2 = function.push_insn(bb5, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb5, Insn::IfTrue { val: v2, target: edge(bb3)});
-        function.push_insn(bb5, Insn::Jump(edge(bb4)));
+        let _ = function.push_insn(bb5, Insn::CondBranch { val: v2, if_true: edge(bb3), if_false: edge(bb4) });
 
         let retval = function.push_insn(bb3, Insn::Const { val: Const::CBool(true) });
         function.push_insn(bb3, Insn::Return { val: retval });
@@ -5862,23 +5809,20 @@ pub(crate) mod hir_build_tests {
         fn <manual>:
         bb1():
           v0:Any = Const Value(false)
-          IfTrue v0, bb2()
-          Jump bb5()
+          CondBranch v0, bb2(), bb5()
         bb2():
-          v3:Any = Const Value(false)
-          IfTrue v3, bb3()
-          Jump bb4()
+          v2:Any = Const Value(false)
+          CondBranch v2, bb3(), bb4()
         bb3():
           Jump bb4()
         bb5():
           Jump bb6()
         bb6():
-          v8:Any = Const Value(false)
-          IfTrue v8, bb4()
-          Jump bb5()
+          v6:Any = Const Value(false)
+          CondBranch v6, bb4(), bb5()
         bb4():
-          v11:Any = Const CBool(true)
-          Return v11
+          v8:Any = Const CBool(true)
+          Return v8
         ");
 
         let dominators = Dominators::new(&function);
@@ -5943,26 +5887,31 @@ mod loop_info_tests {
 
     #[test]
     fn test_loop_depth() {
-        // ┌─────┐
-        // │ bb0 │
-        // └──┬──┘
-        //    │
-        // ┌──▼──┐      ┌─────┐
-        // │ bb2 ◄──────┼ bb1 ◄─┐
-        // └──┬──┘      └─────┘ │
-        //    └─────────────────┘
+        //    ┌─────┐
+        //    │ bb0 │
+        //    └──┬──┘
+        //       │
+        //    ┌──▼──┐      ┌─────┐
+        //  ┌►│ bb2 ├─────►│ bb1 │
+        //  │ └──┬──┘  T   └──┬──┘
+        //  │   F│            │
+        //  │ ┌──▼──┐         │
+        //  │ │ bb3 │         │
+        //  │ └─────┘         │
+        //  └─────────────────┘
         let mut function = Function::new(std::ptr::null());
 
         let bb0 = function.entry_block;
         let bb1 = function.new_block(0);
         let bb2 = function.new_block(0);
+        let bb3 = function.new_block(0);
 
         function.push_insn(bb0, Insn::Jump(edge(bb2)));
 
-        let val = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb2, Insn::IfTrue { val, target: edge(bb1)});
-        let retval = function.push_insn(bb2, Insn::Const { val: Const::CBool(true) });
-        let _ = function.push_insn(bb2, Insn::Return { val: retval });
+        let val = function.push_insn(bb2, Insn::Const { val: Const::Value(Qfalse) });
+        let _ = function.push_insn(bb2, Insn::CondBranch { val, if_true: edge(bb1), if_false: edge(bb3) });
+        let retval = function.push_insn(bb3, Insn::Const { val: Const::CBool(true) });
+        let _ = function.push_insn(bb3, Insn::Return { val: retval });
 
         function.push_insn(bb1, Insn::Jump(edge(bb2)));
 
@@ -5975,13 +5924,14 @@ mod loop_info_tests {
         fn <manual>:
         bb1():
           Jump bb3()
-          v1:Any = Const Value(false)
         bb3():
-          IfTrue v1, bb2()
-          v3:Any = Const CBool(true)
-          Return v3
+          v1:Any = Const Value(false)
+          CondBranch v1, bb2(), bb4()
         bb2():
           Jump bb3()
+        bb4():
+          v3:Any = Const CBool(true)
+          Return v3
         ");
 
         assert!(loop_info.is_loop_header(bb2));
@@ -6023,12 +5973,10 @@ mod loop_info_tests {
         function.push_insn(bb1, Insn::Jump(edge(bb2)));
 
         let cond = function.push_insn(bb2, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb2, Insn::IfTrue { val: cond, target: edge(bb1) });
-        function.push_insn(bb2, Insn::Jump(edge(bb3)));
+        let _ = function.push_insn(bb2, Insn::CondBranch { val: cond, if_true: edge(bb1), if_false: edge(bb3) });
 
         let cond = function.push_insn(bb3, Insn::Const { val: Const::Value(Qtrue) });
-        let _ = function.push_insn(bb3, Insn::IfTrue { val: cond, target: edge(bb0) });
-        function.push_insn(bb3, Insn::Jump(edge(bb4)));
+        let _ = function.push_insn(bb3, Insn::CondBranch { val: cond, if_true: edge(bb0), if_false: edge(bb4) });
 
         let retval = function.push_insn(bb4, Insn::Const { val: Const::CBool(true) });
         let _ = function.push_insn(bb4, Insn::Return { val: retval });
@@ -6046,15 +5994,13 @@ mod loop_info_tests {
           Jump bb3()
         bb3():
           v2:Any = Const Value(false)
-          IfTrue v2, bb2()
-          Jump bb4()
+          CondBranch v2, bb2(), bb4()
         bb4():
-          v5:Any = Const Value(true)
-          IfTrue v5, bb1()
-          Jump bb5()
+          v4:Any = Const Value(true)
+          CondBranch v4, bb1(), bb5()
         bb5():
-          v8:Any = Const CBool(true)
-          Return v8
+          v6:Any = Const CBool(true)
+          Return v6
         ");
 
         assert!(loop_info.is_loop_header(bb0));
@@ -6102,21 +6048,17 @@ mod loop_info_tests {
         let bb6 = function.new_block(0);
 
         let cond = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb0, Insn::IfTrue { val: cond, target: edge(bb1) });
-        function.push_insn(bb0, Insn::Jump(edge(bb3)));
+        let _ = function.push_insn(bb0, Insn::CondBranch { val: cond, if_true: edge(bb1), if_false: edge(bb3) });
 
         function.push_insn(bb1, Insn::Jump(edge(bb2)));
 
-        let _ = function.push_insn(bb2, Insn::IfTrue { val: cond, target: edge(bb1) });
-        function.push_insn(bb2, Insn::Jump(edge(bb5)));
+        let _ = function.push_insn(bb2, Insn::CondBranch { val: cond, if_true: edge(bb1), if_false: edge(bb5) });
 
         function.push_insn(bb3, Insn::Jump(edge(bb4)));
 
-        let _ = function.push_insn(bb4, Insn::IfTrue { val: cond, target: edge(bb3) });
-        function.push_insn(bb4, Insn::Jump(edge(bb5)));
+        let _ = function.push_insn(bb4, Insn::CondBranch { val: cond, if_true: edge(bb3), if_false: edge(bb5) });
 
-        let _ = function.push_insn(bb5, Insn::IfTrue { val: cond, target: edge(bb0) });
-        function.push_insn(bb5, Insn::Jump(edge(bb6)));
+        let _ = function.push_insn(bb5, Insn::CondBranch { val: cond, if_true: edge(bb0), if_false: edge(bb6) });
 
         let retval = function.push_insn(bb6, Insn::Const { val: Const::CBool(true) });
         let _ = function.push_insn(bb6, Insn::Return { val: retval });
@@ -6130,24 +6072,20 @@ mod loop_info_tests {
         fn <manual>:
         bb1():
           v0:Any = Const Value(false)
-          IfTrue v0, bb2()
-          Jump bb4()
+          CondBranch v0, bb2(), bb4()
         bb2():
           Jump bb3()
         bb3():
-          IfTrue v0, bb2()
-          Jump bb6()
+          CondBranch v0, bb2(), bb6()
         bb4():
           Jump bb5()
         bb5():
-          IfTrue v0, bb4()
-          Jump bb6()
+          CondBranch v0, bb4(), bb6()
         bb6():
-          IfTrue v0, bb1()
-          Jump bb7()
+          CondBranch v0, bb1(), bb7()
         bb7():
-          v11:Any = Const CBool(true)
-          Return v11
+          v7:Any = Const CBool(true)
+          Return v7
         ");
 
         assert!(loop_info.is_loop_header(bb0));
@@ -6258,16 +6196,16 @@ mod loop_info_tests {
         let bb3 = function.new_block(0);
         let bb4 = function.new_block(0);
         let bb5 = function.new_block(0);
+        let bb6 = function.new_block(0);
 
         let cond = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
         let _ = function.push_insn(bb0, Insn::Jump(edge(bb1)));
         let _ = function.push_insn(bb1, Insn::Jump(edge(bb2)));
         let _ = function.push_insn(bb2, Insn::Jump(edge(bb3)));
-        let _ = function.push_insn(bb3, Insn::Jump(edge(bb4)));
-        let _ = function.push_insn(bb3, Insn::IfTrue {val: cond, target: edge(bb2)});
-        let _ = function.push_insn(bb4, Insn::Jump(edge(bb5)));
-        let _ = function.push_insn(bb4, Insn::IfTrue {val: cond, target: edge(bb1)});
-        let _ = function.push_insn(bb5, Insn::IfTrue {val: cond, target: edge(bb0)});
+        let _ = function.push_insn(bb3, Insn::CondBranch {val: cond, if_true: edge(bb2), if_false: edge(bb4) });
+        let _ = function.push_insn(bb4, Insn::CondBranch {val: cond, if_true: edge(bb1), if_false: edge(bb5) });
+        let _ = function.push_insn(bb5, Insn::CondBranch {val: cond, if_true: edge(bb0), if_false: edge(bb6) });
+        function.push_insn(bb6, Insn::Unreachable);
 
         function.seal_entries();
         assert_snapshot!(format!("{}", FunctionPrinter::without_snapshot(&function)), @"
@@ -6280,13 +6218,13 @@ mod loop_info_tests {
         bb3():
           Jump bb4()
         bb4():
-          Jump bb5()
-          IfTrue v0, bb3()
+          CondBranch v0, bb3(), bb5()
         bb5():
-          Jump bb6()
-          IfTrue v0, bb2()
+          CondBranch v0, bb2(), bb6()
         bb6():
-          IfTrue v0, bb1()
+          CondBranch v0, bb1(), bb7()
+        bb7():
+          Unreachable
         ");
 
         let cfi = ControlFlowInfo::new(&function);
@@ -6333,9 +6271,10 @@ mod iongraph_tests {
 
         let retval = function.push_insn(bb0, Insn::Const { val: Const::CBool(true) });
         function.push_insn(bb0, Insn::Return { val: retval });
+        function.seal_entries();
 
         let json = function.to_iongraph_pass("simple");
-        assert_snapshot!(json.to_string(), @r#"{"name":"simple", "mir":{"blocks":[{"ptr":4096, "id":0, "loopDepth":0, "attributes":[], "predecessors":[], "successors":[], "instructions":[]}]}, "lir":{"blocks":[]}}"#);
+        assert_snapshot!(json.to_string(), @r#"{"name":"simple", "mir":{"blocks":[{"ptr":4096, "id":0, "loopDepth":0, "attributes":[], "predecessors":[], "successors":[1], "instructions":[{"ptr":4098, "id":2, "opcode":"Entries bb1", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4097, "id":1, "loopDepth":0, "attributes":[], "predecessors":[0], "successors":[], "instructions":[{"ptr":4096, "id":0, "opcode":"Const CBool(true)", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":"Any"}, {"ptr":4097, "id":1, "opcode":"Return v0", "attributes":[], "inputs":[0], "uses":[], "memInputs":[], "type":""}]}]}, "lir":{"blocks":[]}}"#);
     }
 
     #[test]
@@ -6349,8 +6288,9 @@ mod iongraph_tests {
         let retval = function.push_insn(bb1, Insn::Const { val: Const::CBool(false) });
         function.push_insn(bb1, Insn::Return { val: retval });
 
+        function.seal_entries();
         let json = function.to_iongraph_pass("two_blocks");
-        assert_snapshot!(json.to_string(), @r#"{"name":"two_blocks", "mir":{"blocks":[{"ptr":4096, "id":0, "loopDepth":0, "attributes":[], "predecessors":[], "successors":[], "instructions":[]}]}, "lir":{"blocks":[]}}"#);
+        assert_snapshot!(json.to_string(), @r#"{"name":"two_blocks", "mir":{"blocks":[{"ptr":4096, "id":0, "loopDepth":0, "attributes":[], "predecessors":[], "successors":[1], "instructions":[{"ptr":4099, "id":3, "opcode":"Entries bb1", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4097, "id":1, "loopDepth":0, "attributes":[], "predecessors":[0], "successors":[2], "instructions":[{"ptr":4096, "id":0, "opcode":"Jump bb2()", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4098, "id":2, "loopDepth":0, "attributes":[], "predecessors":[1], "successors":[], "instructions":[{"ptr":4097, "id":1, "opcode":"Const CBool(false)", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":"Any"}, {"ptr":4098, "id":2, "opcode":"Return v1", "attributes":[], "inputs":[1], "uses":[], "memInputs":[], "type":""}]}]}, "lir":{"blocks":[]}}"#);
     }
 
     #[test]
@@ -6361,8 +6301,9 @@ mod iongraph_tests {
         let val1 = function.push_insn(bb0, Insn::Const { val: Const::CBool(true) });
         function.push_insn(bb0, Insn::Return { val: val1 });
 
+        function.seal_entries();
         let json = function.to_iongraph_pass("multiple_instructions");
-        assert_snapshot!(json.to_string(), @r#"{"name":"multiple_instructions", "mir":{"blocks":[{"ptr":4096, "id":0, "loopDepth":0, "attributes":[], "predecessors":[], "successors":[], "instructions":[]}]}, "lir":{"blocks":[]}}"#);
+        assert_snapshot!(json.to_string(), @r#"{"name":"multiple_instructions", "mir":{"blocks":[{"ptr":4096, "id":0, "loopDepth":0, "attributes":[], "predecessors":[], "successors":[1], "instructions":[{"ptr":4098, "id":2, "opcode":"Entries bb1", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4097, "id":1, "loopDepth":0, "attributes":[], "predecessors":[0], "successors":[], "instructions":[{"ptr":4096, "id":0, "opcode":"Const CBool(true)", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":"Any"}, {"ptr":4097, "id":1, "opcode":"Return v0", "attributes":[], "inputs":[0], "uses":[], "memInputs":[], "type":""}]}]}, "lir":{"blocks":[]}}"#);
     }
 
     #[test]
@@ -6370,18 +6311,20 @@ mod iongraph_tests {
         let mut function = Function::new(std::ptr::null());
         let bb0 = function.entry_block;
         let bb1 = function.new_block(0);
+        let bb2 = function.new_block(0);
 
         let cond = function.push_insn(bb0, Insn::Const { val: Const::CBool(true) });
-        function.push_insn(bb0, Insn::IfTrue { val: cond, target: edge(bb1) });
+        function.push_insn(bb0, Insn::CondBranch { val: cond, if_true: edge(bb1), if_false: edge(bb2) });
 
-        let retval1 = function.push_insn(bb0, Insn::Const { val: Const::CBool(false) });
-        function.push_insn(bb0, Insn::Return { val: retval1 });
+        let retval1 = function.push_insn(bb2, Insn::Const { val: Const::CBool(false) });
+        function.push_insn(bb2, Insn::Return { val: retval1 });
 
         let retval2 = function.push_insn(bb1, Insn::Const { val: Const::CBool(true) });
         function.push_insn(bb1, Insn::Return { val: retval2 });
 
+        function.seal_entries();
         let json = function.to_iongraph_pass("conditional_branch");
-        assert_snapshot!(json.to_string(), @r#"{"name":"conditional_branch", "mir":{"blocks":[{"ptr":4096, "id":0, "loopDepth":0, "attributes":[], "predecessors":[], "successors":[], "instructions":[]}]}, "lir":{"blocks":[]}}"#);
+        assert_snapshot!(json.to_string(), @r#"{"name":"conditional_branch", "mir":{"blocks":[{"ptr":4096, "id":0, "loopDepth":0, "attributes":[], "predecessors":[], "successors":[1], "instructions":[{"ptr":4102, "id":6, "opcode":"Entries bb1", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4097, "id":1, "loopDepth":0, "attributes":[], "predecessors":[0], "successors":[2, 3], "instructions":[{"ptr":4096, "id":0, "opcode":"Const CBool(true)", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":"Any"}, {"ptr":4097, "id":1, "opcode":"CondBranch v0, bb2(), bb3()", "attributes":[], "inputs":[0], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4098, "id":2, "loopDepth":0, "attributes":[], "predecessors":[1], "successors":[], "instructions":[{"ptr":4100, "id":4, "opcode":"Const CBool(true)", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":"Any"}, {"ptr":4101, "id":5, "opcode":"Return v4", "attributes":[], "inputs":[4], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4099, "id":3, "loopDepth":0, "attributes":[], "predecessors":[1], "successors":[], "instructions":[{"ptr":4098, "id":2, "opcode":"Const CBool(false)", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":"Any"}, {"ptr":4099, "id":3, "opcode":"Return v2", "attributes":[], "inputs":[2], "uses":[], "memInputs":[], "type":""}]}]}, "lir":{"blocks":[]}}"#);
     }
 
     #[test]
@@ -6391,18 +6334,20 @@ mod iongraph_tests {
         let bb0 = function.entry_block;
         let bb1 = function.new_block(0);
         let bb2 = function.new_block(0);
+        let bb3 = function.new_block(0);
 
         function.push_insn(bb0, Insn::Jump(edge(bb2)));
 
-        let val = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
-        let _ = function.push_insn(bb2, Insn::IfTrue { val, target: edge(bb1)});
-        let retval = function.push_insn(bb2, Insn::Const { val: Const::CBool(true) });
-        let _ = function.push_insn(bb2, Insn::Return { val: retval });
+        let val = function.push_insn(bb2, Insn::Const { val: Const::Value(Qfalse) });
+        let _ = function.push_insn(bb2, Insn::CondBranch { val, if_true: edge(bb1), if_false: edge(bb3) });
+        let retval = function.push_insn(bb3, Insn::Const { val: Const::CBool(true) });
+        let _ = function.push_insn(bb3, Insn::Return { val: retval });
 
         function.push_insn(bb1, Insn::Jump(edge(bb2)));
 
+        function.seal_entries();
         let json = function.to_iongraph_pass("loop_structure");
-        assert_snapshot!(json.to_string(), @r#"{"name":"loop_structure", "mir":{"blocks":[{"ptr":4096, "id":0, "loopDepth":0, "attributes":[], "predecessors":[], "successors":[], "instructions":[]}]}, "lir":{"blocks":[]}}"#);
+        assert_snapshot!(json.to_string(), @r#"{"name":"loop_structure", "mir":{"blocks":[{"ptr":4096, "id":0, "loopDepth":0, "attributes":[], "predecessors":[], "successors":[1], "instructions":[{"ptr":4102, "id":6, "opcode":"Entries bb1", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4097, "id":1, "loopDepth":0, "attributes":[], "predecessors":[0], "successors":[3], "instructions":[{"ptr":4096, "id":0, "opcode":"Jump bb3()", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4099, "id":3, "loopDepth":1, "attributes":["loopheader"], "predecessors":[1, 2], "successors":[2, 4], "instructions":[{"ptr":4097, "id":1, "opcode":"Const Value(false)", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":"Any"}, {"ptr":4098, "id":2, "opcode":"CondBranch v1, bb2(), bb4()", "attributes":[], "inputs":[1], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4098, "id":2, "loopDepth":1, "attributes":["backedge"], "predecessors":[3], "successors":[3], "instructions":[{"ptr":4101, "id":5, "opcode":"Jump bb3()", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4100, "id":4, "loopDepth":0, "attributes":[], "predecessors":[3], "successors":[], "instructions":[{"ptr":4099, "id":3, "opcode":"Const CBool(true)", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":"Any"}, {"ptr":4100, "id":4, "opcode":"Return v3", "attributes":[], "inputs":[3], "uses":[], "memInputs":[], "type":""}]}]}, "lir":{"blocks":[]}}"#);
     }
 
     #[test]
@@ -6413,8 +6358,7 @@ mod iongraph_tests {
         let bb2 = function.new_block(0);
 
         let cond = function.push_insn(bb0, Insn::Const { val: Const::CBool(true) });
-        function.push_insn(bb0, Insn::IfTrue { val: cond, target: edge(bb1) });
-        function.push_insn(bb0, Insn::Jump(edge(bb2)));
+        function.push_insn(bb0, Insn::CondBranch { val: cond, if_true: edge(bb1), if_false: edge(bb2) });
 
         let retval1 = function.push_insn(bb1, Insn::Const { val: Const::CBool(true) });
         function.push_insn(bb1, Insn::Return { val: retval1 });
@@ -6422,7 +6366,8 @@ mod iongraph_tests {
         let retval2 = function.push_insn(bb2, Insn::Const { val: Const::CBool(false) });
         function.push_insn(bb2, Insn::Return { val: retval2 });
 
+        function.seal_entries();
         let json = function.to_iongraph_pass("multiple_successors");
-        assert_snapshot!(json.to_string(), @r#"{"name":"multiple_successors", "mir":{"blocks":[{"ptr":4096, "id":0, "loopDepth":0, "attributes":[], "predecessors":[], "successors":[], "instructions":[]}]}, "lir":{"blocks":[]}}"#);
+        assert_snapshot!(json.to_string(), @r#"{"name":"multiple_successors", "mir":{"blocks":[{"ptr":4096, "id":0, "loopDepth":0, "attributes":[], "predecessors":[], "successors":[1], "instructions":[{"ptr":4102, "id":6, "opcode":"Entries bb1", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4097, "id":1, "loopDepth":0, "attributes":[], "predecessors":[0], "successors":[2, 3], "instructions":[{"ptr":4096, "id":0, "opcode":"Const CBool(true)", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":"Any"}, {"ptr":4097, "id":1, "opcode":"CondBranch v0, bb2(), bb3()", "attributes":[], "inputs":[0], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4098, "id":2, "loopDepth":0, "attributes":[], "predecessors":[1], "successors":[], "instructions":[{"ptr":4098, "id":2, "opcode":"Const CBool(true)", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":"Any"}, {"ptr":4099, "id":3, "opcode":"Return v2", "attributes":[], "inputs":[2], "uses":[], "memInputs":[], "type":""}]}, {"ptr":4099, "id":3, "loopDepth":0, "attributes":[], "predecessors":[1], "successors":[], "instructions":[{"ptr":4100, "id":4, "opcode":"Const CBool(false)", "attributes":[], "inputs":[], "uses":[], "memInputs":[], "type":"Any"}, {"ptr":4101, "id":5, "opcode":"Return v4", "attributes":[], "inputs":[4], "uses":[], "memInputs":[], "type":""}]}]}, "lir":{"blocks":[]}}"#);
     }
  }

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -297,24 +297,26 @@ pub(crate) mod hir_build_tests {
           v5:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v6:CBool = IsBitEqual v4, v5
           IfTrue v6, bb3(v1, v3)
+          Jump bb6()
+        bb6():
           Jump bb5(v1, v3)
         bb2():
           EntryPoint JIT(0)
-          v10:BasicObject = LoadArg :self@0
-          v11:NilClass = Const Value(nil)
-          Jump bb3(v10, v11)
-        bb3(v17:BasicObject, v18:BasicObject):
-          v21:Fixnum[1] = Const Value(1)
-          Jump bb5(v17, v21)
+          v11:BasicObject = LoadArg :self@0
+          v12:NilClass = Const Value(nil)
+          Jump bb3(v11, v12)
+        bb3(v18:BasicObject, v19:BasicObject):
+          v22:Fixnum[1] = Const Value(1)
+          Jump bb5(v18, v22)
         bb4():
           EntryPoint JIT(1)
-          v14:BasicObject = LoadArg :self@0
-          v15:BasicObject = LoadArg :x@1
-          Jump bb5(v14, v15)
-        bb5(v24:BasicObject, v25:BasicObject):
-          v29:Fixnum[123] = Const Value(123)
+          v15:BasicObject = LoadArg :self@0
+          v16:BasicObject = LoadArg :x@1
+          Jump bb5(v15, v16)
+        bb5(v25:BasicObject, v26:BasicObject):
+          v30:Fixnum[123] = Const Value(123)
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -374,14 +376,16 @@ pub(crate) mod hir_build_tests {
           v23:CBool = Test v20
           v24:Truthy = RefineType v20, Truthy
           IfTrue v23, bb4(v9, v10, v14, v10)
-          v26:Falsy = RefineType v20, Falsy
-          v31:Fixnum[2] = Const Value(2)
+          Jump bb5()
+        bb4(v37:BasicObject, v38:BasicObject, v39:NilClass, v40:BasicObject):
+          v45:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v31
-        bb4(v36:BasicObject, v37:BasicObject, v38:NilClass, v39:BasicObject):
-          v44:Fixnum[1] = Const Value(1)
+          Return v45
+        bb5():
+          v27:Falsy = RefineType v20, Falsy
+          v32:Fixnum[2] = Const Value(2)
           CheckInterrupts
-          Return v44
+          Return v32
         ");
     }
 
@@ -420,14 +424,16 @@ pub(crate) mod hir_build_tests {
           v22:CBool = Test v19
           v23:Truthy = RefineType v19, Truthy
           IfTrue v22, bb4(v9, v10, v10)
-          v25:Falsy = RefineType v19, Falsy
-          v29:Fixnum[2] = Const Value(2)
+          Jump bb5()
+        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          v42:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v29
-        bb4(v34:BasicObject, v35:BasicObject, v36:BasicObject):
-          v41:Fixnum[1] = Const Value(1)
+          Return v42
+        bb5():
+          v26:Falsy = RefineType v19, Falsy
+          v30:Fixnum[2] = Const Value(2)
           CheckInterrupts
-          Return v41
+          Return v30
         ");
     }
 
@@ -464,14 +470,16 @@ pub(crate) mod hir_build_tests {
           v18:CBool = Test v15
           v19:Truthy = RefineType v15, Truthy
           IfTrue v18, bb4(v6)
-          v21:Falsy = RefineType v15, Falsy
-          v24:Fixnum[2] = Const Value(2)
+          Jump bb5()
+        bb4(v30:BasicObject):
+          v34:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v24
-        bb4(v29:BasicObject):
-          v33:Fixnum[1] = Const Value(1)
+          Return v34
+        bb5():
+          v22:Falsy = RefineType v15, Falsy
+          v25:Fixnum[2] = Const Value(2)
           CheckInterrupts
-          Return v33
+          Return v25
         ");
     }
 
@@ -1162,26 +1170,28 @@ pub(crate) mod hir_build_tests {
           v6:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v7:CBool = IsBitEqual v5, v6
           IfTrue v7, bb3(v1, v3, v4)
+          Jump bb6()
+        bb6():
           Jump bb5(v1, v3, v4)
         bb2():
           EntryPoint JIT(0)
-          v11:BasicObject = LoadArg :self@0
-          v12:NilClass = Const Value(nil)
+          v12:BasicObject = LoadArg :self@0
           v13:NilClass = Const Value(nil)
-          Jump bb3(v11, v12, v13)
-        bb3(v20:BasicObject, v21:BasicObject, v22:NilClass):
-          v26:Fixnum[1] = Const Value(1)
-          Jump bb5(v20, v26, v26)
+          v14:NilClass = Const Value(nil)
+          Jump bb3(v12, v13, v14)
+        bb3(v21:BasicObject, v22:BasicObject, v23:NilClass):
+          v27:Fixnum[1] = Const Value(1)
+          Jump bb5(v21, v27, v27)
         bb4():
           EntryPoint JIT(1)
-          v16:BasicObject = LoadArg :self@0
-          v17:BasicObject = LoadArg :a@1
-          v18:NilClass = Const Value(nil)
-          Jump bb5(v16, v17, v18)
-        bb5(v31:BasicObject, v32:BasicObject, v33:NilClass|Fixnum):
-          v39:ArrayExact = NewArray v32, v33
+          v17:BasicObject = LoadArg :self@0
+          v18:BasicObject = LoadArg :a@1
+          v19:NilClass = Const Value(nil)
+          Jump bb5(v17, v18, v19)
+        bb5(v32:BasicObject, v33:BasicObject, v34:NilClass|Fixnum):
+          v40:ArrayExact = NewArray v33, v34
           CheckInterrupts
-          Return v39
+          Return v40
         ");
     }
 
@@ -1204,25 +1214,27 @@ pub(crate) mod hir_build_tests {
           v6:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v7:CBool = IsBitEqual v5, v6
           IfTrue v7, bb3(v1, v3, v4)
+          Jump bb6()
+        bb6():
           Jump bb5(v1, v3, v4)
         bb2():
           EntryPoint JIT(0)
-          v11:BasicObject = LoadArg :self@0
-          v12:NilClass = Const Value(nil)
+          v12:BasicObject = LoadArg :self@0
           v13:NilClass = Const Value(nil)
-          Jump bb3(v11, v12, v13)
-        bb3(v20:BasicObject, v21:BasicObject, v22:NilClass):
+          v14:NilClass = Const Value(nil)
+          Jump bb3(v12, v13, v14)
+        bb3(v21:BasicObject, v22:BasicObject, v23:NilClass):
           SideExit UnhandledYARVInsn(trace_putobject_INT2FIX_1_)
         bb4():
           EntryPoint JIT(1)
-          v16:BasicObject = LoadArg :self@0
-          v17:BasicObject = LoadArg :a@1
-          v18:NilClass = Const Value(nil)
-          Jump bb5(v16, v17, v18)
-        bb5(v27:BasicObject, v28:BasicObject, v29:NilClass):
-          v35:ArrayExact = NewArray v28, v29
+          v17:BasicObject = LoadArg :self@0
+          v18:BasicObject = LoadArg :a@1
+          v19:NilClass = Const Value(nil)
+          Jump bb5(v17, v18, v19)
+        bb5(v28:BasicObject, v29:BasicObject, v30:NilClass):
+          v36:ArrayExact = NewArray v29, v30
           CheckInterrupts
-          Return v35
+          Return v36
         ");
     }
 
@@ -1242,22 +1254,24 @@ pub(crate) mod hir_build_tests {
           v5:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v6:CBool = IsBitEqual v4, v5
           IfTrue v6, bb3(v1, v3)
+          Jump bb6()
+        bb6():
           Jump bb5(v1, v3)
         bb2():
           EntryPoint JIT(0)
-          v10:BasicObject = LoadArg :self@0
-          v11:NilClass = Const Value(nil)
-          Jump bb3(v10, v11)
-        bb3(v17:BasicObject, v18:BasicObject):
+          v11:BasicObject = LoadArg :self@0
+          v12:NilClass = Const Value(nil)
+          Jump bb3(v11, v12)
+        bb3(v18:BasicObject, v19:BasicObject):
           SideExit UnhandledYARVInsn(definemethod)
         bb4():
           EntryPoint JIT(1)
-          v14:BasicObject = LoadArg :self@0
-          v15:BasicObject = LoadArg :a@1
-          Jump bb5(v14, v15)
-        bb5(v23:BasicObject, v24:BasicObject):
+          v15:BasicObject = LoadArg :self@0
+          v16:BasicObject = LoadArg :a@1
+          Jump bb5(v15, v16)
+        bb5(v24:BasicObject, v25:BasicObject):
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -1341,14 +1355,16 @@ pub(crate) mod hir_build_tests {
           v13:CBool = Test v10
           v14:NilClass = RefineType v10, Falsy
           IfFalse v13, bb4(v6)
-          v16:TrueClass = RefineType v10, Truthy
-          v19:Fixnum[3] = Const Value(3)
+          Jump bb5()
+        bb4(v25:BasicObject):
+          v29:Fixnum[4] = Const Value(4)
           CheckInterrupts
-          Return v19
-        bb4(v24:BasicObject):
-          v28:Fixnum[4] = Const Value(4)
+          Return v29
+        bb5():
+          v17:TrueClass = RefineType v10, Truthy
+          v20:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v28
+          Return v20
         ");
     }
 
@@ -1458,14 +1474,16 @@ pub(crate) mod hir_build_tests {
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
           IfFalse v16, bb4(v9, v17)
-          v19:Truthy = RefineType v10, Truthy
-          v22:Fixnum[3] = Const Value(3)
+          Jump bb5()
+        bb4(v28:BasicObject, v29:Falsy):
+          v33:Fixnum[4] = Const Value(4)
           CheckInterrupts
-          Return v22
-        bb4(v27:BasicObject, v28:Falsy):
-          v32:Fixnum[4] = Const Value(4)
+          Return v33
+        bb5():
+          v20:Truthy = RefineType v10, Truthy
+          v23:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v32
+          Return v23
         ");
     }
 
@@ -1501,16 +1519,18 @@ pub(crate) mod hir_build_tests {
           v19:CBool = Test v12
           v20:Falsy = RefineType v12, Falsy
           IfFalse v19, bb4(v11, v20, v13)
-          v22:Truthy = RefineType v12, Truthy
-          v25:Fixnum[3] = Const Value(3)
+          Jump bb6()
+        bb4(v31:BasicObject, v32:Falsy, v33:NilClass):
+          v37:Fixnum[4] = Const Value(4)
+          Jump bb5(v31, v32, v37)
+        bb6():
+          v23:Truthy = RefineType v12, Truthy
+          v26:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Jump bb5(v11, v22, v25)
-        bb4(v30:BasicObject, v31:Falsy, v32:NilClass):
-          v36:Fixnum[4] = Const Value(4)
-          Jump bb5(v30, v31, v36)
-        bb5(v39:BasicObject, v40:BasicObject, v41:Fixnum):
+          Jump bb5(v11, v23, v26)
+        bb5(v40:BasicObject, v41:BasicObject, v42:Fixnum):
           CheckInterrupts
-          Return v41
+          Return v42
         ");
     }
 
@@ -1844,16 +1864,18 @@ pub(crate) mod hir_build_tests {
           v38:CBool = Test v35
           v39:Truthy = RefineType v35, Truthy
           IfTrue v38, bb4(v26, v27, v28)
-          v41:Falsy = RefineType v35, Falsy
-          v43:NilClass = Const Value(nil)
+          Jump bb6()
+        bb4(v52:BasicObject, v53:BasicObject, v54:BasicObject):
+          v59:Fixnum[1] = Const Value(1)
+          v62:BasicObject = Send v53, :+, v59 # SendFallbackReason: Uncategorized(opt_plus)
+          v67:Fixnum[1] = Const Value(1)
+          v70:BasicObject = Send v54, :-, v67 # SendFallbackReason: Uncategorized(opt_minus)
+          Jump bb5(v52, v62, v70)
+        bb6():
+          v42:Falsy = RefineType v35, Falsy
+          v44:NilClass = Const Value(nil)
           CheckInterrupts
           Return v27
-        bb4(v51:BasicObject, v52:BasicObject, v53:BasicObject):
-          v58:Fixnum[1] = Const Value(1)
-          v61:BasicObject = Send v52, :+, v58 # SendFallbackReason: Uncategorized(opt_plus)
-          v66:Fixnum[1] = Const Value(1)
-          v69:BasicObject = Send v53, :-, v66 # SendFallbackReason: Uncategorized(opt_minus)
-          Jump bb5(v51, v61, v69)
         ");
     }
 
@@ -1916,14 +1938,16 @@ pub(crate) mod hir_build_tests {
           v19:CBool[true] = Test v13
           v20 = RefineType v13, Falsy
           IfFalse v19, bb4(v8, v20)
-          v22:TrueClass = RefineType v13, Truthy
-          v25:Fixnum[3] = Const Value(3)
+          Jump bb5()
+        bb4(v31, v32):
+          v36 = Const Value(4)
           CheckInterrupts
-          Return v25
-        bb4(v30, v31):
-          v35 = Const Value(4)
+          Return v36
+        bb5():
+          v23:TrueClass = RefineType v13, Truthy
+          v26:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v35
+          Return v26
         ");
     }
 
@@ -2510,16 +2534,18 @@ pub(crate) mod hir_build_tests {
           v12:NilClass = Const Value(nil)
           v15:CBool = IsMethodCFunc v10, :new
           IfFalse v15, bb4(v6, v12, v10)
-          v17:HeapBasicObject = ObjectAlloc v10
-          v19:BasicObject = Send v17, :initialize # SendFallbackReason: Uncategorized(opt_send_without_block)
+          Jump bb6()
+        bb4(v24:BasicObject, v25:NilClass, v26:BasicObject):
+          v29:BasicObject = Send v26, :new # SendFallbackReason: Uncategorized(opt_send_without_block)
+          Jump bb5(v24, v29, v25)
+        bb6():
+          v18:HeapBasicObject = ObjectAlloc v10
+          v20:BasicObject = Send v18, :initialize # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Jump bb5(v6, v17, v19)
-        bb4(v23:BasicObject, v24:NilClass, v25:BasicObject):
-          v28:BasicObject = Send v25, :new # SendFallbackReason: Uncategorized(opt_send_without_block)
-          Jump bb5(v23, v28, v24)
-        bb5(v31:BasicObject, v32:BasicObject, v33:BasicObject):
+          Jump bb5(v6, v18, v20)
+        bb5(v32:BasicObject, v33:BasicObject, v34:BasicObject):
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 
@@ -3600,20 +3626,24 @@ pub(crate) mod hir_build_tests {
           v27:CInt64 = IntAnd v25, v26
           v28:CBool = IsBitEqual v27, v26
           IfTrue v28, bb7()
-          v32:CInt64[0] = Const CInt64(0)
-          v33:CBool = IsBitEqual v25, v32
-          IfTrue v33, bb8()
-          SideExit BlockParamProxyProfileNotCovered
+          Jump bb9()
         bb7():
-          v30:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v30, v10)
+          v31:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v31, v10)
+        bb9():
+          v33:CInt64[0] = Const CInt64(0)
+          v34:CBool = IsBitEqual v25, v33
+          IfTrue v34, bb8()
+          Jump bb10()
         bb8():
-          v35:NilClass = Const Value(nil)
-          Jump bb6(v35, v10)
+          v37:NilClass = Const Value(nil)
+          Jump bb6(v37, v10)
         bb6(v16:BasicObject, v17:BasicObject):
-          v39:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Uncategorized(send)
+          v41:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v39
+          Return v41
+        bb10():
+          SideExit BlockParamProxyProfileNotCovered
         ");
     }
 
@@ -4470,12 +4500,14 @@ pub(crate) mod hir_build_tests {
           v17:CBool = IsNil v10
           v18:NilClass = Const Value(nil)
           IfTrue v17, bb4(v9, v18, v18)
-          v20:NotNil = RefineType v10, NotNil
-          v22:BasicObject = Send v20, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
-          Jump bb4(v9, v20, v22)
-        bb4(v24:BasicObject, v25:BasicObject, v26:BasicObject):
+          Jump bb5()
+        bb5():
+          v21:NotNil = RefineType v10, NotNil
+          v23:BasicObject = Send v21, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
+          Jump bb4(v9, v21, v23)
+        bb4(v25:BasicObject, v26:BasicObject, v27:BasicObject):
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -4510,21 +4542,25 @@ pub(crate) mod hir_build_tests {
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
           IfFalse v16, bb4(v9, v17)
-          v19:Truthy = RefineType v10, Truthy
+          Jump bb6()
+        bb4(v37:BasicObject, v38:Falsy):
+          v42:Fixnum[4] = Const Value(4)
+          Jump bb5(v37, v38, v42)
+        bb6():
+          v20:Truthy = RefineType v10, Truthy
           CheckInterrupts
-          v25:CBool[false] = IsNil v19
-          v26:NilClass = Const Value(nil)
-          IfTrue v25, bb5(v9, v26, v26)
-          v28:Truthy = RefineType v19, NotNil
-          v30:BasicObject = Send v28, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v26:CBool[false] = IsNil v20
+          v27:NilClass = Const Value(nil)
+          IfTrue v26, bb5(v9, v27, v27)
+          Jump bb7()
+        bb5(v44:BasicObject, v45:Falsy, v46:Fixnum[4]):
           CheckInterrupts
-          Return v30
-        bb4(v35:BasicObject, v36:Falsy):
-          v40:Fixnum[4] = Const Value(4)
-          Jump bb5(v35, v36, v40)
-        bb5(v42:BasicObject, v43:Falsy, v44:Fixnum[4]):
+          Return v46
+        bb7():
+          v30:Truthy = RefineType v20, NotNil
+          v32:BasicObject = Send v30, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v44
+          Return v32
         ");
     }
 
@@ -4565,32 +4601,38 @@ pub(crate) mod hir_build_tests {
           v16:CBool = Test v10
           v17:Falsy = RefineType v10, Falsy
           IfFalse v16, bb6(v9, v17)
-          v19:Truthy = RefineType v10, Truthy
+          Jump bb7()
+        bb6(v46:BasicObject, v47:Falsy):
+          v51:Fixnum[6] = Const Value(6)
           CheckInterrupts
-          v24:CBool[true] = Test v19
-          v25 = RefineType v19, Falsy
-          IfFalse v24, bb5(v9, v25)
-          v27:Truthy = RefineType v19, Truthy
+          Return v51
+        bb7():
+          v20:Truthy = RefineType v10, Truthy
           CheckInterrupts
-          v32:CBool[true] = Test v27
-          v33 = RefineType v27, Falsy
-          IfFalse v32, bb4(v9, v33)
-          v35:Truthy = RefineType v27, Truthy
-          v38:Fixnum[3] = Const Value(3)
+          v25:CBool[true] = Test v20
+          v26 = RefineType v20, Falsy
+          IfFalse v25, bb5(v9, v26)
+          Jump bb8()
+        bb5(v56, v57):
+          v61 = Const Value(5)
           CheckInterrupts
-          Return v38
-        bb6(v43:BasicObject, v44:Falsy):
-          v48:Fixnum[6] = Const Value(6)
+          Return v61
+        bb8():
+          v29:Truthy = RefineType v20, Truthy
           CheckInterrupts
-          Return v48
-        bb5(v53, v54):
-          v58 = Const Value(5)
+          v34:CBool[true] = Test v29
+          v35 = RefineType v29, Falsy
+          IfFalse v34, bb4(v9, v35)
+          Jump bb9()
+        bb4(v66, v67):
+          v71 = Const Value(4)
           CheckInterrupts
-          Return v58
-        bb4(v63, v64):
-          v68 = Const Value(4)
+          Return v71
+        bb9():
+          v38:Truthy = RefineType v29, Truthy
+          v41:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v68
+          Return v41
         ");
     }
 
@@ -4695,14 +4737,16 @@ pub(crate) mod hir_build_tests {
           v48:CBool = Test v33
           v49:Falsy = RefineType v33, Falsy
           IfFalse v48, bb4(v18, v19, v20, v21, v34, v27)
-          v51:Truthy = RefineType v33, Truthy
-          v55:BasicObject = InvokeBlock, v27 # SendFallbackReason: InvokeBlock: not yet specialized
-          v58:BasicObject = InvokeBuiltin dir_s_close, v18, v27
+          Jump bb8()
+        bb4(v65:BasicObject, v66:BasicObject, v67:BasicObject, v68:BasicObject, v69:BasicObject, v70:BasicObject):
           CheckInterrupts
-          Return v55
-        bb4(v64:BasicObject, v65:BasicObject, v66:BasicObject, v67:BasicObject, v68:BasicObject, v69:BasicObject):
+          Return v70
+        bb8():
+          v52:Truthy = RefineType v33, Truthy
+          v56:BasicObject = InvokeBlock, v27 # SendFallbackReason: InvokeBlock: not yet specialized
+          v59:BasicObject = InvokeBuiltin dir_s_close, v18, v27
           CheckInterrupts
-          Return v69
+          Return v56
         ");
     }
 
@@ -4837,14 +4881,16 @@ pub(crate) mod hir_build_tests {
           v26:CBool = Test v22
           v27:Truthy = RefineType v22, Truthy
           IfTrue v26, bb4(v9, v10, v14, v10, v17, v19, v27)
-          v29:Falsy = RefineType v22, Falsy
-          v32:Fixnum[2] = Const Value(2)
-          v35:BasicObject = Send v10, :[]=, v17, v19, v32 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          Jump bb5()
+        bb4(v42:BasicObject, v43:BasicObject, v44:NilClass, v45:BasicObject, v46:Fixnum[0], v47:Fixnum[1], v48:Truthy):
           CheckInterrupts
-          Return v32
-        bb4(v41:BasicObject, v42:BasicObject, v43:NilClass, v44:BasicObject, v45:Fixnum[0], v46:Fixnum[1], v47:Truthy):
+          Return v48
+        bb5():
+          v30:Falsy = RefineType v22, Falsy
+          v33:Fixnum[2] = Const Value(2)
+          v36:BasicObject = Send v10, :[]=, v17, v19, v33 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v47
+          Return v33
         ");
     }
 
@@ -5215,14 +5261,16 @@ pub(crate) mod hir_build_tests {
           v20:CBool = Test v17
           v21:TrueClass = RefineType v17, Truthy
           IfTrue v20, bb4(v12, v13, v14)
-          v23:FalseClass = RefineType v17, Falsy
-          v25:Fixnum[1] = Const Value(1)
-          v27:Fixnum[1] = Const Value(1)
-          v30:BasicObject = Send v25, :+, v27 # SendFallbackReason: Uncategorized(opt_plus)
-          Jump bb4(v12, v30, v14)
-        bb4(v33:BasicObject, v34:BasicObject, v35:BasicObject):
+          Jump bb5()
+        bb5():
+          v24:FalseClass = RefineType v17, Falsy
+          v26:Fixnum[1] = Const Value(1)
+          v28:Fixnum[1] = Const Value(1)
+          v31:BasicObject = Send v26, :+, v28 # SendFallbackReason: Uncategorized(opt_plus)
+          Jump bb4(v12, v31, v14)
+        bb4(v34:BasicObject, v35:BasicObject, v36:BasicObject):
           CheckInterrupts
-          Return v34
+          Return v35
         ");
     }
 
@@ -5343,32 +5391,36 @@ pub(crate) mod hir_build_tests {
           v17:CBool = Test v15
           v18:NilClass = RefineType v15, Falsy
           IfFalse v17, bb4(v8, v9)
-          v20:TrueClass = RefineType v15, Truthy
+          Jump bb9()
+        bb4(v24:BasicObject, v25:NilClass):
+          v29:BasicObject = InvokeBuiltin <inline_expr>, v24
+          Jump bb5(v24, v25, v29)
+        bb5(v41:BasicObject, v42:NilClass, v43:BasicObject):
+          CheckInterrupts
+          Return v43
+        bb9():
+          v21:TrueClass = RefineType v15, Truthy
           Jump bb6(v8, v9)
-        bb4(v23:BasicObject, v24:NilClass):
-          v28:BasicObject = InvokeBuiltin <inline_expr>, v23
-          Jump bb5(v23, v24, v28)
-        bb5(v40:BasicObject, v41:NilClass, v42:BasicObject):
-          CheckInterrupts
-          Return v42
-        bb6(v30:BasicObject, v31:NilClass):
-          v35:Fixnum[0] = Const Value(0)
-          Jump bb8(v30, v35)
-        bb8(v48:BasicObject, v49:Fixnum):
-          v52:BoolExact = InvokeBuiltin rb_jit_ary_at_end, v48, v49
-          v54:CBool = Test v52
-          v55:FalseClass = RefineType v52, Falsy
-          IfFalse v54, bb7(v48, v49)
-          v57:TrueClass = RefineType v52, Truthy
-          v59:NilClass = Const Value(nil)
-          CheckInterrupts
-          Return v48
-        bb7(v67:BasicObject, v68:Fixnum):
-          v72:BasicObject = InvokeBuiltin rb_jit_ary_at, v67, v68
-          v74:BasicObject = InvokeBlock, v72 # SendFallbackReason: InvokeBlock: not yet specialized
-          v78:Fixnum = InvokeBuiltin rb_jit_fixnum_inc, v67, v68
+        bb6(v31:BasicObject, v32:NilClass):
+          v36:Fixnum[0] = Const Value(0)
+          Jump bb8(v31, v36)
+        bb8(v49:BasicObject, v50:Fixnum):
+          v53:BoolExact = InvokeBuiltin rb_jit_ary_at_end, v49, v50
+          v55:CBool = Test v53
+          v56:FalseClass = RefineType v53, Falsy
+          IfFalse v55, bb7(v49, v50)
+          Jump bb10()
+        bb7(v69:BasicObject, v70:Fixnum):
+          v74:BasicObject = InvokeBuiltin rb_jit_ary_at, v69, v70
+          v76:BasicObject = InvokeBlock, v74 # SendFallbackReason: InvokeBlock: not yet specialized
+          v80:Fixnum = InvokeBuiltin rb_jit_fixnum_inc, v69, v70
           PatchPoint NoEPEscape(each)
-          Jump bb8(v67, v78)
+          Jump bb8(v69, v80)
+        bb10():
+          v59:TrueClass = RefineType v53, Truthy
+          v61:NilClass = Const Value(nil)
+          CheckInterrupts
+          Return v49
         ");
     }
 


### PR DESCRIPTION
This PR changes the basic blocks used in HIR from extended basic blocks to traditional basic blocks.  This means all basic blocks in HIR are guaranteed to end with some kind of control flow (jump / return), and there are no mid-block control flow instructions.

This PR introduces a new instruction called `CondBranch` that replaces `IfTrue` and `IfFalse`.  The new instruction has `if_true` and `if_false` arms.  `CondBranch` is a terminator instruction, so it ends blocks.  All HIR blocks will now end with a terminator instruction, and no blocks will have "mid-block" control flow.