### PR TITLE
Fix Box resolution crash with IFUNC frames

### DIFF
--- a/test/ruby/test_box.rb
+++ b/test/ruby/test_box.rb
@@ -877,6 +877,27 @@ class TestBox < Test::Unit::TestCase
     end;
   end
 
+  def test_symbol_to_proc_with_escaped_binding
+    assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)
+    begin;
+      # Regression test for [BUG] Local ep without cme/box, flags: 66660087.
+      # binding() may escape TOP env and propagate LOCAL to IFUNC frames.
+      assert_nothing_raised do
+        using Module.new {
+          refine ::Binding do
+            def eval_methods
+              ::Kernel.instance_method(:methods).bind_call(receiver)
+            end
+          end
+        }
+
+        result = binding.eval_methods.map(&:to_s)
+        assert_kind_of Array, result
+        assert result.all? { |x| x.is_a?(String) }
+      end
+    end;
+  end
+
   def test_loading_extension_libs_in_main_box_1
     pend if /mswin|mingw/ =~ RUBY_PLATFORM # timeout on windows environments
     assert_separately([ENV_ENABLE_BOX], __FILE__, __LINE__, "#{<<~"begin;"}\n#{<<~'end;'}", ignore_stderr: true)

--- a/vm.c
+++ b/vm.c
@@ -117,7 +117,6 @@ VM_EP_RUBY_LEP(const rb_execution_context_t *ec, const rb_control_frame_t *curre
     const rb_control_frame_t *cfp = current_cfp;
 
     if (VM_ENV_FRAME_TYPE_P(ep, VM_FRAME_MAGIC_IFUNC)) {
-        ep = VM_EP_LEP(current_cfp->ep);
         /**
          * Returns CFUNC frame only in this case.
          *
@@ -145,7 +144,20 @@ VM_EP_RUBY_LEP(const rb_execution_context_t *ec, const rb_control_frame_t *curre
          * We expect that `chunk_i` works as expected by the implementation of `#chunk`
          * without any overwritten definitions from boxes.
          * So the definitions on IFUNC frames should be equal to the caller CFUNC.
+         *
+         * NOTE: We traverse the cfp chain directly instead of using VM_EP_LEP.
+         * When an IFUNC env is escaped to the heap (e.g., due to a surrounding
+         * `binding` call), the env may acquire VM_ENV_FLAG_LOCAL, causing VM_EP_LEP
+         * to return the IFUNC ep itself rather than the enclosing CFUNC ep.
          */
+        while (VM_ENV_FRAME_TYPE_P(ep, VM_FRAME_MAGIC_IFUNC)) {
+            cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);
+            VM_BOX_ASSERT(RUBY_VM_VALID_CONTROL_FRAME_P(cfp, eocfp), "Valid control frame expected for IFUNC caller");
+            if (!RUBY_VM_VALID_CONTROL_FRAME_P(cfp, eocfp)) {
+                return NULL;
+            }
+            ep = cfp->ep;
+        }
         VM_ASSERT(VM_ENV_FRAME_TYPE_P(ep, VM_FRAME_MAGIC_CFUNC));
         return ep;
     }


### PR DESCRIPTION
[Bug #21977](https://bugs.ruby-lang.org/issues/21977)
When `RUBY_BOX=1` is set, combining `binding` with `Symbol#to_proc` causes a crash (`[BUG] BUG: Local ep without cme/box`).

This occurs because escaping an `IFUNC` frame via `binding` adds the `VM_ENV_FLAG_LOCAL` flag. `VM_EP_RUBY_LEP` previously relied on `VM_EP_LEP`, which blindly stopped at this flag. This caused it to return the `IFUNC` itself instead of its caller, and since `IFUNC` lacks `cme/box` data, the Box resolution crashed.

This commit fixes the issue by traversing `current_cfp` backwards to skip `IFUNC` frames directly, instead of relying on `VM_EP_LEP` and the local flag.