### PR TITLE
Allow non-zero exit status in `bundle config gemfile` unset spec

### DIFF
--- a/spec/bundler/commands/config_spec.rb
+++ b/spec/bundler/commands/config_spec.rb
@@ -605,7 +605,7 @@ RSpec.describe "setting gemfile via config" do
       bundle "config set gemfile foo/bar_gemfile"
 
       bundle "config unset gemfile"
-      bundle "config get gemfile"
+      bundle "config get gemfile", raise_on_error: false
 
       expect(out).to include("You have not configured a value for `gemfile`")
       expect(File.read(bundled_app(".bundle/config"))).not_to include("BUNDLE_GEMFILE")


### PR DESCRIPTION
Fixes the followings:

* https://github.com/ruby/ruby/actions/runs/25544666960
* https://github.com/ruby/ruby/actions/runs/25544666998
* https://github.com/ruby/ruby/actions/runs/25544667071