### PR TITLE
Fix gdb rb_ps helper

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -979,7 +979,7 @@ end
 
 define print_lineno
   set $cfp = $arg0
-  set $iseq = $cfp->iseq
+  set $iseq = rb_get_cfp_iseq($cfp)
   set $pos = $cfp->pc - $iseq->body->iseq_encoded
   if $pos != 0
     set $pos = $pos - 1
@@ -1060,7 +1060,7 @@ define print_id
   else
     set $serial = (rb_id_serial_t)$id
   end
-  if $serial && $serial <= ruby_global_symbols.last_id
+  if $serial && $serial < ruby_global_symbols.next_id
     set $idx = $serial / ID_ENTRY_UNIT
     set $ids = (struct RArray *)ruby_global_symbols.ids
     set $flags = $ids->basic.flags
@@ -1083,7 +1083,7 @@ define print_id
           set $aryptr = $ary->as.heap.ptr
           set $arylen = $ary->as.heap.len
         end
-        set $result = $aryptr[($serial % ID_ENTRY_UNIT) * ID_ENTRY_SIZE + $t]
+        set $result = $aryptr[($serial % ID_ENTRY_UNIT) + $t]
         if $result != RUBY_Qnil
           print_string $result
         else
@@ -1117,16 +1117,17 @@ define rb_ps_thread
   set $cfp = $ps_thread_th->ec->cfp
   set $cfpend = (rb_control_frame_t *)($ps_thread_th->ec->vm_stack + $ps_thread_th->ec->vm_stack_size)-1
   while $cfp < $cfpend
-    if $cfp->iseq
-      if !((VALUE)$cfp->iseq & RUBY_IMMEDIATE_MASK) && (((imemo_ifunc << RUBY_FL_USHIFT) | RUBY_T_IMEMO)==$cfp->iseq->flags & ((RUBY_IMEMO_MASK << RUBY_FL_USHIFT) | RUBY_T_MASK))
+    if $cfp->_iseq
+      set $iseq = rb_get_cfp_iseq($cfp)
+      if !((VALUE)$iseq & RUBY_IMMEDIATE_MASK) && (((imemo_ifunc << RUBY_FL_USHIFT) | RUBY_T_IMEMO)==$iseq->flags & ((RUBY_IMEMO_MASK << RUBY_FL_USHIFT) | RUBY_T_MASK))
         printf "%d:ifunc ", $cfpend-$cfp
         set print symbol-filename on
-        output/a $cfp->iseq.body
+        output/a $iseq.body
         set print symbol-filename off
         printf "\n"
       else
       if $cfp->pc
-        set $location = $cfp->iseq->body->location
+        set $location = $iseq->body->location
         printf "%d:", $cfpend-$cfp
         print_pathobj $location.pathobj
         printf ":"

--- a/vm_core.h
+++ b/vm_core.h
@@ -920,7 +920,7 @@ struct rb_block {
 typedef struct rb_control_frame_struct {
     const VALUE *pc;        // cfp[0]
     VALUE *sp;              // cfp[1]
-    const rb_iseq_t *_iseq; // cfp[2] -- use rb_cfp_iseq(cfp) to read
+    const rb_iseq_t *_iseq; // cfp[2] -- use CFP_ISEQ(cfp) to read
     VALUE self;             // cfp[3] / block[0]
     const VALUE *ep;        // cfp[4] / block[1]
     const void *block_code; // cfp[5] / block[2] -- iseq, ifunc, or forwarded block handler

--- a/vm_insnhelper.h
+++ b/vm_insnhelper.h
@@ -116,7 +116,7 @@ enum vm_regan_acttype {
 // instruction sequence C struct
 // Uses cfp->_iseq directly because the interpreter always has a valid _iseq
 // field (it's written on exit from JIT code). Code in vm_insnhelper.c that
-// may be called as a ZJIT fallback should use rb_cfp_iseq() instead.
+// may be called as a ZJIT fallback should use CFP_ISEQ() instead.
 #define GET_ISEQ() (GET_CFP()->_iseq)
 
 /**********************************************************/


### PR DESCRIPTION
Over time the .gdbinit initializer has drifted from the codebase and the rb_ps helper no longer works. This PR fixes it. The changes that caused it to break were:

* 226f37059ec5f3ea3a1417e0bab630c64dbc8ac3 renamed cfp->iseq to cfp->_iseq.
* 6c24904a690eb7c4e20c3fa8c3751acc03454100 switched from storing the last_id to storing the next_id.
* f7ae32ed3b5b93247f9f62a58e3dd129098d0b27 removed ID_ENTRY_SIZE.
