### PR TITLE
Protect th->keeping_mutexes when freeing mutex + thread concurrently

### DIFF
--- a/thread.c
+++ b/thread.c
@@ -446,14 +446,15 @@ rb_threadptr_join_list_wakeup(rb_thread_t *thread)
     }
 }
 
-// This lock is for protecting thread->keeping_mutexes when mutex and thread are concurrently freed
-static void keeping_mutexes_lock_lock(void);
-static void keeping_mutexes_lock_unlock(void);
+// This lock protects thread->keeping_mutexes when a mutex and its owning
+// thread are concurrently freed.
+static void keeping_mutexes_lock_lock(rb_thread_t *th);
+static void keeping_mutexes_lock_unlock(rb_thread_t *th);
 
 void
 rb_threadptr_unlock_all_locking_mutexes(rb_thread_t *th)
 {
-    keeping_mutexes_lock_lock();
+    keeping_mutexes_lock_lock(th);
     {
         while (th->keeping_mutexes) {
             rb_mutex_t *mutex = th->keeping_mutexes;
@@ -461,16 +462,17 @@ rb_threadptr_unlock_all_locking_mutexes(rb_thread_t *th)
             th->keeping_mutexes = next;
             mutex->next_mutex = NULL;
 
-            keeping_mutexes_lock_unlock();
+            keeping_mutexes_lock_unlock(th);
 
             // rb_warn("mutex #<%p> was not unlocked by thread #<%p>", (void *)mutex, (void*)th);
             VM_ASSERT(mutex->ec_serial);
             const char *error_message = rb_mutex_unlock_th(mutex, th, 0, false);
             if (error_message) rb_bug("invalid keeping_mutexes: %s", error_message);
-            keeping_mutexes_lock_lock();
+            if (!next) return;
+            keeping_mutexes_lock_lock(th);
         }
     }
-    keeping_mutexes_lock_unlock();
+    keeping_mutexes_lock_unlock(th);
 }
 
 void
@@ -552,6 +554,7 @@ thread_cleanup_func(void *th_ptr, int atfork)
     }
 
     rb_native_mutex_destroy(&th->interrupt_lock);
+    rb_native_mutex_destroy(&th->keeping_mutexes_lock);
 }
 
 void
@@ -901,6 +904,7 @@ thread_create_core(VALUE thval, struct thread_create_params *params)
     RBASIC_CLEAR_CLASS(th->pending_interrupt_mask_stack);
 
     rb_native_mutex_initialize(&th->interrupt_lock);
+    rb_native_mutex_initialize(&th->keeping_mutexes_lock);
 
     RUBY_DEBUG_LOG("r:%u th:%u", rb_ractor_id(th->ractor), rb_th_serial(th));
 
@@ -4997,7 +5001,6 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
     thread_sched_atfork(TH_SCHED(th));
     ubf_list_atfork();
     rb_signal_atfork();
-    keeping_mutexes_lock_initialize();
 
     // OK. Only this thread accesses:
     ccan_list_for_each(&vm->ractor.set, r, vmlr_node) {
@@ -5015,6 +5018,7 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
 
     /* may be held by any thread in parent */
     rb_native_mutex_initialize(&th->interrupt_lock);
+    rb_native_mutex_initialize(&th->keeping_mutexes_lock);
     ccan_list_head_init(&th->interrupt_exec_tasks);
 
     vm->fork_gen++;
@@ -5037,6 +5041,7 @@ terminate_atfork_i(rb_thread_t *th, const rb_thread_t *current_th)
         th->scheduler = Qnil;
 
         rb_native_mutex_initialize(&th->interrupt_lock);
+        rb_native_mutex_initialize(&th->keeping_mutexes_lock);
         rb_mutex_abandon_keeping_mutexes(th);
         rb_mutex_abandon_locking_mutex(th);
         thread_cleanup_func(th, TRUE);
@@ -5688,6 +5693,7 @@ Init_Thread_Mutex(void)
 
     rb_native_mutex_initialize(&th->vm->workqueue_lock);
     rb_native_mutex_initialize(&th->interrupt_lock);
+    rb_native_mutex_initialize(&th->keeping_mutexes_lock);
 }
 
 /*

--- a/thread.c
+++ b/thread.c
@@ -446,18 +446,31 @@ rb_threadptr_join_list_wakeup(rb_thread_t *thread)
     }
 }
 
+// This lock is for protecting thread->keeping_mutexes when mutex and thread are concurrently freed
+static void keeping_mutexes_lock_lock(void);
+static void keeping_mutexes_lock_unlock(void);
+
 void
 rb_threadptr_unlock_all_locking_mutexes(rb_thread_t *th)
 {
-    while (th->keeping_mutexes) {
-        rb_mutex_t *mutex = th->keeping_mutexes;
-        th->keeping_mutexes = mutex->next_mutex;
+    keeping_mutexes_lock_lock();
+    {
+        while (th->keeping_mutexes) {
+            rb_mutex_t *mutex = th->keeping_mutexes;
+            rb_mutex_t *next = mutex->next_mutex;
+            th->keeping_mutexes = next;
+            mutex->next_mutex = NULL;
 
-        // rb_warn("mutex #<%p> was not unlocked by thread #<%p>", (void *)mutex, (void*)th);
-        VM_ASSERT(mutex->ec_serial);
-        const char *error_message = rb_mutex_unlock_th(mutex, th, 0);
-        if (error_message) rb_bug("invalid keeping_mutexes: %s", error_message);
+            keeping_mutexes_lock_unlock();
+
+            // rb_warn("mutex #<%p> was not unlocked by thread #<%p>", (void *)mutex, (void*)th);
+            VM_ASSERT(mutex->ec_serial);
+            const char *error_message = rb_mutex_unlock_th(mutex, th, 0, false);
+            if (error_message) rb_bug("invalid keeping_mutexes: %s", error_message);
+            keeping_mutexes_lock_lock();
+        }
     }
+    keeping_mutexes_lock_unlock();
 }
 
 void
@@ -4984,6 +4997,7 @@ rb_thread_atfork_internal(rb_thread_t *th, void (*atfork)(rb_thread_t *, const r
     thread_sched_atfork(TH_SCHED(th));
     ubf_list_atfork();
     rb_signal_atfork();
+    keeping_mutexes_lock_initialize();
 
     // OK. Only this thread accesses:
     ccan_list_for_each(&vm->ractor.set, r, vmlr_node) {

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -95,51 +95,44 @@ rb_mutex_num_waiting(rb_mutex_t *mutex)
     return n;
 }
 
-static rb_nativethread_lock_t keeping_mutexes_lock;
-#ifdef RUBY_THREAD_PTHREAD_H
-static pthread_t keeping_mutexes_lock_owner;
-#endif
-
 static inline void
-ASSERT_keeping_mutexes_lock_locked(void)
+ASSERT_keeping_mutexes_lock_locked(rb_thread_t *th)
 {
 #ifdef RUBY_THREAD_PTHREAD_H
-    VM_ASSERT(pthread_self() == keeping_mutexes_lock_owner);
+    VM_ASSERT(pthread_self() == th->keeping_mutexes_lock_owner);
+#else
+    (void)th;
 #endif
 }
 
 static inline void
-ASSERT_keeping_mutexes_lock_unlocked(void)
+ASSERT_keeping_mutexes_lock_unlocked(rb_thread_t *th)
 {
 #ifdef RUBY_THREAD_PTHREAD_H
-    VM_ASSERT(pthread_self() != keeping_mutexes_lock_owner);
+    VM_ASSERT(pthread_self() != th->keeping_mutexes_lock_owner);
+#else
+    (void)th;
 #endif
 }
 
 static void
-keeping_mutexes_lock_lock(void)
+keeping_mutexes_lock_lock(rb_thread_t *th)
 {
-    ASSERT_keeping_mutexes_lock_unlocked();
-    rb_native_mutex_lock(&keeping_mutexes_lock);
+    ASSERT_keeping_mutexes_lock_unlocked(th);
+    rb_native_mutex_lock(&th->keeping_mutexes_lock);
 #ifdef RUBY_THREAD_PTHREAD_H
-    keeping_mutexes_lock_owner = pthread_self();
+    th->keeping_mutexes_lock_owner = pthread_self();
 #endif
 }
 
 static void
-keeping_mutexes_lock_unlock(void)
+keeping_mutexes_lock_unlock(rb_thread_t *th)
 {
-    ASSERT_keeping_mutexes_lock_locked();
+    ASSERT_keeping_mutexes_lock_locked(th);
 #ifdef RUBY_THREAD_PTHREAD_H
-    keeping_mutexes_lock_owner = 0;
+    th->keeping_mutexes_lock_owner = 0;
 #endif
-    rb_native_mutex_unlock(&keeping_mutexes_lock);
-}
-
-static void
-keeping_mutexes_lock_initialize(void)
-{
-    rb_native_mutex_initialize(&keeping_mutexes_lock);
+    rb_native_mutex_unlock(&th->keeping_mutexes_lock);
 }
 
 rb_thread_t* rb_fiber_threadptr(const rb_fiber_t *fiber);
@@ -219,7 +212,7 @@ static void
 thread_mutex_insert(rb_thread_t *thread, rb_mutex_t *mutex)
 {
     RUBY_ASSERT(!mutex->next_mutex);
-    keeping_mutexes_lock_lock();
+    keeping_mutexes_lock_lock(thread);
     {
         if (thread->keeping_mutexes) {
             mutex->next_mutex = thread->keeping_mutexes;
@@ -227,13 +220,13 @@ thread_mutex_insert(rb_thread_t *thread, rb_mutex_t *mutex)
 
         thread->keeping_mutexes = mutex;
     }
-    keeping_mutexes_lock_unlock();
+    keeping_mutexes_lock_unlock(thread);
 }
 
 static void
 thread_mutex_remove(rb_thread_t *thread, rb_mutex_t *mutex)
 {
-    keeping_mutexes_lock_lock();
+    keeping_mutexes_lock_lock(thread);
     {
         rb_mutex_t **keeping_mutexes = &thread->keeping_mutexes;
 
@@ -247,7 +240,7 @@ thread_mutex_remove(rb_thread_t *thread, rb_mutex_t *mutex)
             mutex->next_mutex = NULL;
         }
     }
-    keeping_mutexes_lock_unlock();
+    keeping_mutexes_lock_unlock(thread);
 }
 
 static void
@@ -592,12 +585,12 @@ rb_mut_unlock(rb_execution_context_t *ec, VALUE self)
 static void
 rb_mutex_abandon_keeping_mutexes(rb_thread_t *th)
 {
-    keeping_mutexes_lock_lock();
+    keeping_mutexes_lock_lock(th);
     {
         rb_mutex_abandon_all(th->keeping_mutexes);
         th->keeping_mutexes = NULL;
     }
-    keeping_mutexes_lock_unlock();
+    keeping_mutexes_lock_unlock(th);
 }
 
 static void
@@ -1607,8 +1600,6 @@ Init_thread_sync(void)
 
     rb_provide("monitor.so");
     rb_provide("thread.rb");
-
-    keeping_mutexes_lock_initialize();
 }
 
 #include "thread_sync.rbinc"

--- a/thread_sync.c
+++ b/thread_sync.c
@@ -80,7 +80,7 @@ static void rb_mutex_abandon_all(rb_mutex_t *mutexes);
 static void rb_mutex_abandon_keeping_mutexes(rb_thread_t *th);
 static void rb_mutex_abandon_locking_mutex(rb_thread_t *th);
 #endif
-static const char* rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_serial_t ec_serial);
+static const char* rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_serial_t ec_serial, bool unlink_from_keeping);
 
 static size_t
 rb_mutex_num_waiting(rb_mutex_t *mutex)
@@ -93,6 +93,53 @@ rb_mutex_num_waiting(rb_mutex_t *mutex)
     }
 
     return n;
+}
+
+static rb_nativethread_lock_t keeping_mutexes_lock;
+#ifdef RUBY_THREAD_PTHREAD_H
+static pthread_t keeping_mutexes_lock_owner;
+#endif
+
+static inline void
+ASSERT_keeping_mutexes_lock_locked(void)
+{
+#ifdef RUBY_THREAD_PTHREAD_H
+    VM_ASSERT(pthread_self() == keeping_mutexes_lock_owner);
+#endif
+}
+
+static inline void
+ASSERT_keeping_mutexes_lock_unlocked(void)
+{
+#ifdef RUBY_THREAD_PTHREAD_H
+    VM_ASSERT(pthread_self() != keeping_mutexes_lock_owner);
+#endif
+}
+
+static void
+keeping_mutexes_lock_lock(void)
+{
+    ASSERT_keeping_mutexes_lock_unlocked();
+    rb_native_mutex_lock(&keeping_mutexes_lock);
+#ifdef RUBY_THREAD_PTHREAD_H
+    keeping_mutexes_lock_owner = pthread_self();
+#endif
+}
+
+static void
+keeping_mutexes_lock_unlock(void)
+{
+    ASSERT_keeping_mutexes_lock_locked();
+#ifdef RUBY_THREAD_PTHREAD_H
+    keeping_mutexes_lock_owner = 0;
+#endif
+    rb_native_mutex_unlock(&keeping_mutexes_lock);
+}
+
+static void
+keeping_mutexes_lock_initialize(void)
+{
+    rb_native_mutex_initialize(&keeping_mutexes_lock);
 }
 
 rb_thread_t* rb_fiber_threadptr(const rb_fiber_t *fiber);
@@ -108,7 +155,7 @@ mutex_free(void *ptr)
 {
     rb_mutex_t *mutex = ptr;
     if (mutex_locked_p(mutex)) {
-        const char *err = rb_mutex_unlock_th(mutex, mutex->th, 0);
+        const char *err = rb_mutex_unlock_th(mutex, mutex->th, 0, true);
         if (err) rb_bug("%s", err);
     }
     ruby_xfree(ptr);
@@ -172,27 +219,35 @@ static void
 thread_mutex_insert(rb_thread_t *thread, rb_mutex_t *mutex)
 {
     RUBY_ASSERT(!mutex->next_mutex);
-    if (thread->keeping_mutexes) {
-        mutex->next_mutex = thread->keeping_mutexes;
-    }
+    keeping_mutexes_lock_lock();
+    {
+        if (thread->keeping_mutexes) {
+            mutex->next_mutex = thread->keeping_mutexes;
+        }
 
-    thread->keeping_mutexes = mutex;
+        thread->keeping_mutexes = mutex;
+    }
+    keeping_mutexes_lock_unlock();
 }
 
 static void
 thread_mutex_remove(rb_thread_t *thread, rb_mutex_t *mutex)
 {
-    rb_mutex_t **keeping_mutexes = &thread->keeping_mutexes;
+    keeping_mutexes_lock_lock();
+    {
+        rb_mutex_t **keeping_mutexes = &thread->keeping_mutexes;
 
-    while (*keeping_mutexes && *keeping_mutexes != mutex) {
-        // Move to the next mutex in the list:
-        keeping_mutexes = &(*keeping_mutexes)->next_mutex;
-    }
+        while (*keeping_mutexes && *keeping_mutexes != mutex) {
+            // Move to the next mutex in the list:
+            keeping_mutexes = &(*keeping_mutexes)->next_mutex;
+        }
 
-    if (*keeping_mutexes) {
-        *keeping_mutexes = mutex->next_mutex;
-        mutex->next_mutex = NULL;
+        if (*keeping_mutexes) {
+            *keeping_mutexes = mutex->next_mutex;
+            mutex->next_mutex = NULL;
+        }
     }
+    keeping_mutexes_lock_unlock();
 }
 
 static void
@@ -441,7 +496,7 @@ rb_mutex_owned_p(VALUE self)
 }
 
 static const char *
-rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_serial_t ec_serial)
+rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_serial_t ec_serial, bool unlink_from_keeping)
 {
     RUBY_DEBUG_LOG("%p", mutex);
 
@@ -455,7 +510,9 @@ rb_mutex_unlock_th(rb_mutex_t *mutex, rb_thread_t *th, rb_serial_t ec_serial)
     struct sync_waiter *cur = 0, *next;
 
     mutex->ec_serial = 0;
-    thread_mutex_remove(th, mutex);
+    if (unlink_from_keeping) {
+        thread_mutex_remove(th, mutex);
+    }
 
     ccan_list_for_each_safe(&mutex->waitq, cur, next, node) {
         ccan_list_del_init(&cur->node);
@@ -492,7 +549,7 @@ do_mutex_unlock(struct mutex_args *args)
     rb_mutex_t *mutex = args->mutex;
     rb_thread_t *th = rb_ec_thread_ptr(args->ec);
 
-    err = rb_mutex_unlock_th(mutex, th, rb_ec_serial(args->ec));
+    err = rb_mutex_unlock_th(mutex, th, rb_ec_serial(args->ec), true);
     if (err) rb_raise(rb_eThreadError, "%s", err);
 }
 
@@ -535,8 +592,12 @@ rb_mut_unlock(rb_execution_context_t *ec, VALUE self)
 static void
 rb_mutex_abandon_keeping_mutexes(rb_thread_t *th)
 {
-    rb_mutex_abandon_all(th->keeping_mutexes);
-    th->keeping_mutexes = NULL;
+    keeping_mutexes_lock_lock();
+    {
+        rb_mutex_abandon_all(th->keeping_mutexes);
+        th->keeping_mutexes = NULL;
+    }
+    keeping_mutexes_lock_unlock();
 }
 
 static void
@@ -1546,6 +1607,8 @@ Init_thread_sync(void)
 
     rb_provide("monitor.so");
     rb_provide("thread.rb");
+
+    keeping_mutexes_lock_initialize();
 }
 
 #include "thread_sync.rbinc"

--- a/vm_core.h
+++ b/vm_core.h
@@ -1190,6 +1190,14 @@ typedef struct rb_thread_struct {
     struct rb_unblock_callback unblock;
     VALUE locking_mutex;
     struct rb_mutex_struct *keeping_mutexes;
+
+    // Protects `keeping_mutexes` against concurrent modification when a mutex
+    // and its owning thread are freed at the same time.
+    rb_nativethread_lock_t keeping_mutexes_lock;
+#ifdef RUBY_THREAD_PTHREAD_H
+    pthread_t keeping_mutexes_lock_owner;
+#endif
+
     struct ccan_list_head interrupt_exec_tasks;
 
     struct rb_waiting_list *join_list;


### PR DESCRIPTION
When freeing a mutex, we unlink any locked mutex from its th->keeping_mutexes. When we free a thread, we unlink all mutexes from its th->keeping_mutexes. If we free concurrently from 2+ threads, we need to protect th->keeping_mutexes from corruption.