### PR TITLE
Document `Thread.each_caller_location` parameters

### DIFF
--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1424,10 +1424,27 @@ rb_f_caller_locations(int argc, VALUE *argv, VALUE _)
 
 /*
  *  call-seq:
- *     Thread.each_caller_location(...) { |loc| ... } -> nil
+ *     Thread.each_caller_location(start=1, length=nil) {|loc| ... } -> nil
+ *     Thread.each_caller_location(range)               {|loc| ... } -> nil
  *
  *  Yields each frame of the current execution stack as a
  *  backtrace location object.
+ *
+ *  Similar to +Kernel#caller_locations+, but without allocating an array.
+ *  The parameters work the same way:
+ *
+ *  The optional _start_ parameter determines the number of initial stack
+ *  entries to omit from the top of the stack.
+ *
+ *  A second optional +length+ parameter can be used to limit how many entries
+ *  are yielded from the stack.
+ *
+ *  Optionally you can pass a range, which will yield the entries within the
+ *  specified range.
+ *
+ *  Unlike +Kernel#caller_locations+, this method does not allocate an array,
+ *  and is therefore more efficient when only some of the entries are needed.
+ *  The block can +break+ early to stop iterating through the stack.
  */
 static VALUE
 each_caller_location(int argc, VALUE *argv, VALUE _)


### PR DESCRIPTION
These parameters were added in #[10554](https://github.com/ruby/ruby/pull/10554) ([ticket](https://bugs.ruby-lang.org/issues/20335)), but the `call-seq` was never updated to mention them.