### PR TITLE
Introduce RMATCH_{BEG,END,NREGS} helpers

### DIFF
--- a/depend
+++ b/depend
@@ -4878,6 +4878,7 @@ enum.$(OBJEXT): {$(VPATH)}internal/core/rclass.h
 enum.$(OBJEXT): {$(VPATH)}internal/core/rdata.h
 enum.$(OBJEXT): {$(VPATH)}internal/core/rfile.h
 enum.$(OBJEXT): {$(VPATH)}internal/core/rhash.h
+enum.$(OBJEXT): {$(VPATH)}internal/core/rmatch.h
 enum.$(OBJEXT): {$(VPATH)}internal/core/robject.h
 enum.$(OBJEXT): {$(VPATH)}internal/core/rregexp.h
 enum.$(OBJEXT): {$(VPATH)}internal/core/rstring.h
@@ -4968,6 +4969,8 @@ enum.$(OBJEXT): {$(VPATH)}internal/xmalloc.h
 enum.$(OBJEXT): {$(VPATH)}missing.h
 enum.$(OBJEXT): {$(VPATH)}onigmo.h
 enum.$(OBJEXT): {$(VPATH)}oniguruma.h
+enum.$(OBJEXT): {$(VPATH)}re.h
+enum.$(OBJEXT): {$(VPATH)}regex.h
 enum.$(OBJEXT): {$(VPATH)}ruby_assert.h
 enum.$(OBJEXT): {$(VPATH)}shape.h
 enum.$(OBJEXT): {$(VPATH)}st.h
@@ -8965,6 +8968,7 @@ marshal.$(OBJEXT): {$(VPATH)}internal/core/rclass.h
 marshal.$(OBJEXT): {$(VPATH)}internal/core/rdata.h
 marshal.$(OBJEXT): {$(VPATH)}internal/core/rfile.h
 marshal.$(OBJEXT): {$(VPATH)}internal/core/rhash.h
+marshal.$(OBJEXT): {$(VPATH)}internal/core/rmatch.h
 marshal.$(OBJEXT): {$(VPATH)}internal/core/robject.h
 marshal.$(OBJEXT): {$(VPATH)}internal/core/rregexp.h
 marshal.$(OBJEXT): {$(VPATH)}internal/core/rstring.h
@@ -9060,6 +9064,8 @@ marshal.$(OBJEXT): {$(VPATH)}missing.h
 marshal.$(OBJEXT): {$(VPATH)}node.h
 marshal.$(OBJEXT): {$(VPATH)}onigmo.h
 marshal.$(OBJEXT): {$(VPATH)}oniguruma.h
+marshal.$(OBJEXT): {$(VPATH)}re.h
+marshal.$(OBJEXT): {$(VPATH)}regex.h
 marshal.$(OBJEXT): {$(VPATH)}ruby_assert.h
 marshal.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 marshal.$(OBJEXT): {$(VPATH)}rubyparser.h
@@ -10952,6 +10958,7 @@ parse.$(OBJEXT): {$(VPATH)}internal/core/rclass.h
 parse.$(OBJEXT): {$(VPATH)}internal/core/rdata.h
 parse.$(OBJEXT): {$(VPATH)}internal/core/rfile.h
 parse.$(OBJEXT): {$(VPATH)}internal/core/rhash.h
+parse.$(OBJEXT): {$(VPATH)}internal/core/rmatch.h
 parse.$(OBJEXT): {$(VPATH)}internal/core/robject.h
 parse.$(OBJEXT): {$(VPATH)}internal/core/rregexp.h
 parse.$(OBJEXT): {$(VPATH)}internal/core/rstring.h
@@ -11054,6 +11061,7 @@ parse.$(OBJEXT): {$(VPATH)}parser_st.h
 parse.$(OBJEXT): {$(VPATH)}probes.dmyh
 parse.$(OBJEXT): {$(VPATH)}probes.h
 parse.$(OBJEXT): {$(VPATH)}ractor.h
+parse.$(OBJEXT): {$(VPATH)}re.h
 parse.$(OBJEXT): {$(VPATH)}regenc.h
 parse.$(OBJEXT): {$(VPATH)}regex.h
 parse.$(OBJEXT): {$(VPATH)}ruby_assert.h
@@ -15946,6 +15954,7 @@ ruby_parser.$(OBJEXT): {$(VPATH)}internal/core/rclass.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/core/rdata.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/core/rfile.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/core/rhash.h
+ruby_parser.$(OBJEXT): {$(VPATH)}internal/core/rmatch.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/core/robject.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/core/rregexp.h
 ruby_parser.$(OBJEXT): {$(VPATH)}internal/core/rstring.h
@@ -16037,6 +16046,8 @@ ruby_parser.$(OBJEXT): {$(VPATH)}missing.h
 ruby_parser.$(OBJEXT): {$(VPATH)}node.h
 ruby_parser.$(OBJEXT): {$(VPATH)}onigmo.h
 ruby_parser.$(OBJEXT): {$(VPATH)}oniguruma.h
+ruby_parser.$(OBJEXT): {$(VPATH)}re.h
+ruby_parser.$(OBJEXT): {$(VPATH)}regex.h
 ruby_parser.$(OBJEXT): {$(VPATH)}ruby_assert.h
 ruby_parser.$(OBJEXT): {$(VPATH)}ruby_parser.c
 ruby_parser.$(OBJEXT): {$(VPATH)}rubyparser.h
@@ -19345,6 +19356,7 @@ variable.$(OBJEXT): {$(VPATH)}internal/core/rclass.h
 variable.$(OBJEXT): {$(VPATH)}internal/core/rdata.h
 variable.$(OBJEXT): {$(VPATH)}internal/core/rfile.h
 variable.$(OBJEXT): {$(VPATH)}internal/core/rhash.h
+variable.$(OBJEXT): {$(VPATH)}internal/core/rmatch.h
 variable.$(OBJEXT): {$(VPATH)}internal/core/robject.h
 variable.$(OBJEXT): {$(VPATH)}internal/core/rregexp.h
 variable.$(OBJEXT): {$(VPATH)}internal/core/rstring.h
@@ -19439,6 +19451,8 @@ variable.$(OBJEXT): {$(VPATH)}onigmo.h
 variable.$(OBJEXT): {$(VPATH)}oniguruma.h
 variable.$(OBJEXT): {$(VPATH)}ractor.h
 variable.$(OBJEXT): {$(VPATH)}ractor_core.h
+variable.$(OBJEXT): {$(VPATH)}re.h
+variable.$(OBJEXT): {$(VPATH)}regex.h
 variable.$(OBJEXT): {$(VPATH)}ruby_assert.h
 variable.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 variable.$(OBJEXT): {$(VPATH)}rubyparser.h
@@ -19839,6 +19853,7 @@ vm.$(OBJEXT): {$(VPATH)}internal/core/rclass.h
 vm.$(OBJEXT): {$(VPATH)}internal/core/rdata.h
 vm.$(OBJEXT): {$(VPATH)}internal/core/rfile.h
 vm.$(OBJEXT): {$(VPATH)}internal/core/rhash.h
+vm.$(OBJEXT): {$(VPATH)}internal/core/rmatch.h
 vm.$(OBJEXT): {$(VPATH)}internal/core/robject.h
 vm.$(OBJEXT): {$(VPATH)}internal/core/rregexp.h
 vm.$(OBJEXT): {$(VPATH)}internal/core/rstring.h
@@ -19941,6 +19956,8 @@ vm.$(OBJEXT): {$(VPATH)}probes.h
 vm.$(OBJEXT): {$(VPATH)}probes_helper.h
 vm.$(OBJEXT): {$(VPATH)}ractor.h
 vm.$(OBJEXT): {$(VPATH)}ractor_core.h
+vm.$(OBJEXT): {$(VPATH)}re.h
+vm.$(OBJEXT): {$(VPATH)}regex.h
 vm.$(OBJEXT): {$(VPATH)}ruby_assert.h
 vm.$(OBJEXT): {$(VPATH)}ruby_atomic.h
 vm.$(OBJEXT): {$(VPATH)}rubyparser.h

--- a/ext/ripper/depend
+++ b/ext/ripper/depend
@@ -474,6 +474,7 @@ ripper.o: $(hdrdir)/ruby/internal/core/rclass.h
 ripper.o: $(hdrdir)/ruby/internal/core/rdata.h
 ripper.o: $(hdrdir)/ruby/internal/core/rfile.h
 ripper.o: $(hdrdir)/ruby/internal/core/rhash.h
+ripper.o: $(hdrdir)/ruby/internal/core/rmatch.h
 ripper.o: $(hdrdir)/ruby/internal/core/robject.h
 ripper.o: $(hdrdir)/ruby/internal/core/rregexp.h
 ripper.o: $(hdrdir)/ruby/internal/core/rstring.h
@@ -566,6 +567,7 @@ ripper.o: $(hdrdir)/ruby/missing.h
 ripper.o: $(hdrdir)/ruby/onigmo.h
 ripper.o: $(hdrdir)/ruby/oniguruma.h
 ripper.o: $(hdrdir)/ruby/ractor.h
+ripper.o: $(hdrdir)/ruby/re.h
 ripper.o: $(hdrdir)/ruby/regex.h
 ripper.o: $(hdrdir)/ruby/ruby.h
 ripper.o: $(hdrdir)/ruby/st.h

--- a/internal/re.h
+++ b/internal/re.h
@@ -10,6 +10,25 @@
  */
 #include "ruby/internal/stdbool.h"     /* for bool */
 #include "ruby/ruby.h"          /* for VALUE */
+#include "ruby/re.h"            /* for struct RMatch and struct re_registers */
+
+static inline long
+RMATCH_BEG(VALUE match, int i)
+{
+    return RMATCH(match)->regs.beg[i];
+}
+
+static inline long
+RMATCH_END(VALUE match, int i)
+{
+    return RMATCH(match)->regs.end[i];
+}
+
+static inline int
+RMATCH_NREGS(VALUE match)
+{
+    return RMATCH(match)->regs.num_regs;
+}
 
 /* re.c */
 VALUE rb_reg_s_alloc(VALUE klass);

--- a/internal/re.h
+++ b/internal/re.h
@@ -12,16 +12,28 @@
 #include "ruby/ruby.h"          /* for VALUE */
 #include "ruby/re.h"            /* for struct RMatch and struct re_registers */
 
+static inline OnigPosition *
+RMATCH_BEG_PTR(VALUE match)
+{
+    return RMATCH(match)->regs.beg;
+}
+
+static inline OnigPosition *
+RMATCH_END_PTR(VALUE match)
+{
+    return RMATCH(match)->regs.end;
+}
+
 static inline long
 RMATCH_BEG(VALUE match, int i)
 {
-    return RMATCH(match)->regs.beg[i];
+    return RMATCH_BEG_PTR(match)[i];
 }
 
 static inline long
 RMATCH_END(VALUE match, int i)
 {
-    return RMATCH(match)->regs.end[i];
+    return RMATCH_END_PTR(match)[i];
 }
 
 static inline int

--- a/re.c
+++ b/re.c
@@ -1004,7 +1004,6 @@ static void
 update_char_offset(VALUE match)
 {
     struct RMatch *rm = RMATCH(match);
-    struct re_registers *regs;
     int i, num_regs, num_pos;
     long c;
     char *s, *p, *q;
@@ -1015,8 +1014,7 @@ update_char_offset(VALUE match)
     if (rm->char_offset_num_allocated)
         return;
 
-    regs = &rm->regs;
-    num_regs = rm->regs.num_regs;
+    num_regs = RMATCH_NREGS(match);
 
     if (rm->char_offset_num_allocated < num_regs) {
         SIZED_REALLOC_N(rm->char_offset, struct rmatch_offset, num_regs, rm->char_offset_num_allocated);
@@ -1026,8 +1024,8 @@ update_char_offset(VALUE match)
     enc = rb_enc_get(RMATCH(match)->str);
     if (rb_enc_mbmaxlen(enc) == 1) {
         for (i = 0; i < num_regs; i++) {
-            rm->char_offset[i].beg = BEG(i);
-            rm->char_offset[i].end = END(i);
+            rm->char_offset[i].beg = RMATCH_BEG(match, i);
+            rm->char_offset[i].end = RMATCH_END(match, i);
         }
         return;
     }
@@ -1035,10 +1033,10 @@ update_char_offset(VALUE match)
     pairs = RB_ALLOCV_N(pair_t, pairs_obj, num_regs * 2);
     num_pos = 0;
     for (i = 0; i < num_regs; i++) {
-        if (BEG(i) < 0)
+        if (RMATCH_BEG(match, i) < 0)
             continue;
-        pairs[num_pos++].byte_pos = BEG(i);
-        pairs[num_pos++].byte_pos = END(i);
+        pairs[num_pos++].byte_pos = RMATCH_BEG(match, i);
+        pairs[num_pos++].byte_pos = RMATCH_END(match, i);
     }
     qsort(pairs, num_pos, sizeof(pair_t), pair_byte_cmp);
 
@@ -1053,17 +1051,17 @@ update_char_offset(VALUE match)
 
     for (i = 0; i < num_regs; i++) {
         pair_t key, *found;
-        if (BEG(i) < 0) {
+        if (RMATCH_BEG(match, i) < 0) {
             rm->char_offset[i].beg = -1;
             rm->char_offset[i].end = -1;
             continue;
         }
 
-        key.byte_pos = BEG(i);
+        key.byte_pos = RMATCH_BEG(match, i);
         found = bsearch(&key, pairs, num_pos, sizeof(pair_t), pair_byte_cmp);
         rm->char_offset[i].beg = found->char_pos;
 
-        key.byte_pos = END(i);
+        key.byte_pos = RMATCH_END(match, i);
         found = bsearch(&key, pairs, num_pos, sizeof(pair_t), pair_byte_cmp);
         rm->char_offset[i].end = found->char_pos;
     }
@@ -3637,7 +3635,7 @@ match_integer_at(int argc, VALUE *argv, VALUE match)
 
     int base = 10;
     VALUE idx;
-    long nth;
+    int nth;
 
     argc = rb_check_arity(argc, 1, 2);
     if (FIXNUM_P(idx = argv[0])) {
@@ -3651,10 +3649,10 @@ match_integer_at(int argc, VALUE *argv, VALUE match)
         rb_raise(rb_eArgError, "invalid radix %d", base);
     }
 
-    if (nth >= regs->num_regs) return Qnil;
-    if (nth < 0 && (nth += regs->num_regs) <= 0) return Qnil;
+    if (nth >= RMATCH_NREGS(match)) return Qnil;
+    if (nth < 0 && (nth += RMATCH_NREGS(match)) <= 0) return Qnil;
 
-    long start = BEG(nth), end = END(nth);
+    long start = RMATCH_BEG(match, nth), end = RMATCH_END(match, nth);
     if (start < 0) return Qnil;
     RUBY_ASSERT(start <= end, "%ld > %ld", start, end);
 

--- a/re.c
+++ b/re.c
@@ -1179,7 +1179,7 @@ static VALUE
 match_size(VALUE match)
 {
     match_check(match);
-    return INT2FIX(RMATCH_REGS(match)->num_regs);
+    return INT2FIX(RMATCH_NREGS(match));
 }
 
 static int name_to_backref_number(const struct re_registers *, VALUE, const char*, const char*);
@@ -1193,9 +1193,9 @@ name_to_backref_error(VALUE name)
 }
 
 static void
-backref_number_check(struct re_registers *regs, int i)
+backref_number_check(VALUE match, int i)
 {
-    if (i < 0 || regs->num_regs <= i)
+    if (i < 0 || RMATCH_NREGS(match) <= i)
         rb_raise(rb_eIndexError, "index %d out of matches", i);
 }
 
@@ -1245,12 +1245,11 @@ static VALUE
 match_offset(VALUE match, VALUE n)
 {
     int i = match_backref_number(match, n);
-    struct re_registers *regs = RMATCH_REGS(match);
 
     match_check(match);
-    backref_number_check(regs, i);
+    backref_number_check(match, i);
 
-    if (BEG(i) < 0)
+    if (RMATCH_BEG(match, i) < 0)
         return rb_assoc_new(Qnil, Qnil);
 
     update_char_offset(match);
@@ -1280,14 +1279,13 @@ static VALUE
 match_byteoffset(VALUE match, VALUE n)
 {
     int i = match_backref_number(match, n);
-    struct re_registers *regs = RMATCH_REGS(match);
 
     match_check(match);
-    backref_number_check(regs, i);
+    backref_number_check(match, i);
 
-    if (BEG(i) < 0)
+    if (RMATCH_BEG(match, i) < 0)
         return rb_assoc_new(Qnil, Qnil);
-    return rb_assoc_new(LONG2NUM(BEG(i)), LONG2NUM(END(i)));
+    return rb_assoc_new(LONG2NUM(RMATCH_BEG(match, i)), LONG2NUM(RMATCH_END(match, i)));
 }
 
 
@@ -1304,14 +1302,13 @@ static VALUE
 match_bytebegin(VALUE match, VALUE n)
 {
     int i = match_backref_number(match, n);
-    struct re_registers *regs = RMATCH_REGS(match);
 
     match_check(match);
-    backref_number_check(regs, i);
+    backref_number_check(match, i);
 
-    if (BEG(i) < 0)
+    if (RMATCH_BEG(match, i) < 0)
         return Qnil;
-    return LONG2NUM(BEG(i));
+    return LONG2NUM(RMATCH_BEG(match, i));
 }
 
 
@@ -1328,14 +1325,13 @@ static VALUE
 match_byteend(VALUE match, VALUE n)
 {
     int i = match_backref_number(match, n);
-    struct re_registers *regs = RMATCH_REGS(match);
 
     match_check(match);
-    backref_number_check(regs, i);
+    backref_number_check(match, i);
 
-    if (BEG(i) < 0)
+    if (RMATCH_BEG(match, i) < 0)
         return Qnil;
-    return LONG2NUM(END(i));
+    return LONG2NUM(RMATCH_END(match, i));
 }
 
 
@@ -1352,12 +1348,11 @@ static VALUE
 match_begin(VALUE match, VALUE n)
 {
     int i = match_backref_number(match, n);
-    struct re_registers *regs = RMATCH_REGS(match);
 
     match_check(match);
-    backref_number_check(regs, i);
+    backref_number_check(match, i);
 
-    if (BEG(i) < 0)
+    if (RMATCH_BEG(match, i) < 0)
         return Qnil;
 
     update_char_offset(match);
@@ -1378,12 +1373,11 @@ static VALUE
 match_end(VALUE match, VALUE n)
 {
     int i = match_backref_number(match, n);
-    struct re_registers *regs = RMATCH_REGS(match);
 
     match_check(match);
-    backref_number_check(regs, i);
+    backref_number_check(match, i);
 
-    if (BEG(i) < 0)
+    if (RMATCH_BEG(match, i) < 0)
         return Qnil;
 
     update_char_offset(match);
@@ -1420,11 +1414,10 @@ static VALUE
 match_nth(VALUE match, VALUE n)
 {
     int i = match_backref_number(match, n);
-    struct re_registers *regs = RMATCH_REGS(match);
 
-    backref_number_check(regs, i);
+    backref_number_check(match, i);
 
-    long start = BEG(i), end = END(i);
+    long start = RMATCH_BEG(match, i), end = RMATCH_END(match, i);
     if (start < 0)
         return Qnil;
 
@@ -1464,12 +1457,11 @@ static VALUE
 match_nth_length(VALUE match, VALUE n)
 {
     int i = match_backref_number(match, n);
-    struct re_registers *regs = RMATCH_REGS(match);
 
     match_check(match);
-    backref_number_check(regs, i);
+    backref_number_check(match, i);
 
-    if (BEG(i) < 0)
+    if (RMATCH_BEG(match, i) < 0)
         return Qnil;
 
     update_char_offset(match);
@@ -1495,11 +1487,8 @@ rb_match_unbusy(VALUE match)
 int
 rb_match_count(VALUE match)
 {
-    struct re_registers *regs;
     if (NIL_P(match)) return -1;
-    regs = RMATCH_REGS(match);
-    if (!regs) return -1;
-    return regs->num_regs;
+    return RMATCH_NREGS(match);
 }
 
 static void
@@ -1892,18 +1881,17 @@ rb_reg_start_with_p(VALUE re, VALUE str)
 VALUE
 rb_reg_nth_defined(int nth, VALUE match)
 {
-    struct re_registers *regs;
     if (NIL_P(match)) return Qnil;
     match_check(match);
-    regs = RMATCH_REGS(match);
-    if (nth >= regs->num_regs) {
+    int num_regs = RMATCH_NREGS(match);
+    if (nth >= num_regs) {
         return Qnil;
     }
     if (nth < 0) {
-        nth += regs->num_regs;
+        nth += num_regs;
         if (nth <= 0) return Qnil;
     }
-    return RBOOL(BEG(nth) != -1);
+    return RBOOL(RMATCH_BEG(match, nth) != -1);
 }
 
 VALUE
@@ -1911,21 +1899,20 @@ rb_reg_nth_match(int nth, VALUE match)
 {
     VALUE str;
     long start, end, len;
-    struct re_registers *regs;
 
     if (NIL_P(match)) return Qnil;
     match_check(match);
-    regs = RMATCH_REGS(match);
-    if (nth >= regs->num_regs) {
+    int num_regs = RMATCH_NREGS(match);
+    if (nth >= num_regs) {
         return Qnil;
     }
     if (nth < 0) {
-        nth += regs->num_regs;
+        nth += num_regs;
         if (nth <= 0) return Qnil;
     }
-    start = BEG(nth);
+    start = RMATCH_BEG(match, nth);
     if (start == -1) return Qnil;
-    end = END(nth);
+    end = RMATCH_END(match, nth);
     len = end - start;
     str = rb_str_subseq(RMATCH(match)->str, start, len);
     return str;
@@ -1959,13 +1946,11 @@ VALUE
 rb_reg_match_pre(VALUE match)
 {
     VALUE str;
-    struct re_registers *regs;
 
     if (NIL_P(match)) return Qnil;
     match_check(match);
-    regs = RMATCH_REGS(match);
-    if (BEG(0) == -1) return Qnil;
-    str = rb_str_subseq(RMATCH(match)->str, 0, BEG(0));
+    if (RMATCH_BEG(match, 0) == -1) return Qnil;
+    str = rb_str_subseq(RMATCH(match)->str, 0, RMATCH_BEG(match, 0));
     return str;
 }
 
@@ -1993,14 +1978,12 @@ rb_reg_match_post(VALUE match)
 {
     VALUE str;
     long pos;
-    struct re_registers *regs;
 
     if (NIL_P(match)) return Qnil;
     match_check(match);
-    regs = RMATCH_REGS(match);
-    if (BEG(0) == -1) return Qnil;
+    if (RMATCH_BEG(match, 0) == -1) return Qnil;
     str = RMATCH(match)->str;
-    pos = END(0);
+    pos = RMATCH_END(match, 0);
     str = rb_str_subseq(str, pos, RSTRING_LEN(str) - pos);
     return str;
 }
@@ -2009,14 +1992,12 @@ static int
 match_last_index(VALUE match)
 {
     int i;
-    struct re_registers *regs;
 
     if (NIL_P(match)) return -1;
     match_check(match);
-    regs = RMATCH_REGS(match);
-    if (BEG(0) == -1) return -1;
+    if (RMATCH_BEG(match, 0) == -1) return -1;
 
-    for (i=regs->num_regs-1; BEG(i) == -1 && i > 0; i--)
+    for (i = RMATCH_NREGS(match) - 1; RMATCH_BEG(match, i) == -1 && i > 0; i--)
         ;
     return i;
 }
@@ -2026,8 +2007,8 @@ rb_reg_match_last(VALUE match)
 {
     int i = match_last_index(match);
     if (i <= 0) return Qnil;
-    struct re_registers *regs = RMATCH_REGS(match);
-    return rb_str_subseq(RMATCH(match)->str, BEG(i), END(i) - BEG(i));
+    long start = RMATCH_BEG(match, i);
+    return rb_str_subseq(RMATCH(match)->str, start, RMATCH_END(match, i) - start);
 }
 
 VALUE
@@ -2065,22 +2046,22 @@ last_paren_match_getter(ID _x, VALUE *_y)
 static VALUE
 match_array(VALUE match, int start)
 {
-    struct re_registers *regs;
     VALUE ary;
     VALUE target;
     int i;
 
     match_check(match);
-    regs = RMATCH_REGS(match);
-    ary = rb_ary_new2(regs->num_regs);
+    int num_regs = RMATCH_NREGS(match);
+    ary = rb_ary_new2(num_regs);
     target = RMATCH(match)->str;
 
-    for (i=start; i<regs->num_regs; i++) {
-        if (regs->beg[i] == -1) {
+    for (i = start; i < num_regs; i++) {
+        long beg = RMATCH_BEG(match, i);
+        if (beg == -1) {
             rb_ary_push(ary, Qnil);
         }
         else {
-            VALUE str = rb_str_subseq(target, regs->beg[i], regs->end[i]-regs->beg[i]);
+            VALUE str = rb_str_subseq(target, beg, RMATCH_END(match, i) - beg);
             rb_ary_push(ary, str);
         }
     }
@@ -2165,7 +2146,7 @@ namev_to_backref_number(const struct re_registers *regs, VALUE re, VALUE name)
 static VALUE
 match_ary_subseq(VALUE match, long beg, long len, VALUE result)
 {
-    long olen = RMATCH_REGS(match)->num_regs;
+    long olen = RMATCH_NREGS(match);
     long j, end = olen < beg+len ? olen : beg+len;
     if (NIL_P(result)) result = rb_ary_new_capa(len);
     if (len == 0) return result;
@@ -2183,7 +2164,7 @@ static VALUE
 match_ary_aref(VALUE match, VALUE idx, VALUE result)
 {
     long beg, len;
-    int num_regs = RMATCH_REGS(match)->num_regs;
+    int num_regs = RMATCH_NREGS(match);
 
     /* check if idx is Range */
     switch (rb_range_beg_len(idx, &beg, &len, (long)num_regs, !NIL_P(result))) {
@@ -2261,7 +2242,7 @@ match_aref(int argc, VALUE *argv, VALUE match)
     else {
         long beg = NUM2LONG(idx);
         long len = NUM2LONG(length);
-        long num_regs = RMATCH_REGS(match)->num_regs;
+        long num_regs = RMATCH_NREGS(match);
         if (len < 0) {
             return Qnil;
         }
@@ -2601,8 +2582,7 @@ match_inspect(VALUE match)
     VALUE cname = rb_class_path(rb_obj_class(match));
     VALUE str;
     int i;
-    struct re_registers *regs = RMATCH_REGS(match);
-    int num_regs = regs->num_regs;
+    int num_regs = RMATCH_NREGS(match);
     struct backref_name_tag *names;
     VALUE names_obj = Qnil;
     VALUE regexp = RMATCH(match)->regexp;

--- a/re.c
+++ b/re.c
@@ -3553,16 +3553,15 @@ rb_reg_equal(VALUE re1, VALUE re2)
 static VALUE
 match_hash(VALUE match)
 {
-    const struct re_registers *regs;
     st_index_t hashval;
 
     match_check(match);
     hashval = rb_hash_start(rb_str_hash(RMATCH(match)->str));
     hashval = rb_hash_uint(hashval, reg_hash(match_regexp(match)));
-    regs = RMATCH_REGS(match);
-    hashval = rb_hash_uint(hashval, regs->num_regs);
-    hashval = rb_hash_uint(hashval, rb_memhash(regs->beg, regs->num_regs * sizeof(*regs->beg)));
-    hashval = rb_hash_uint(hashval, rb_memhash(regs->end, regs->num_regs * sizeof(*regs->end)));
+    int num_regs = RMATCH_NREGS(match);
+    hashval = rb_hash_uint(hashval, num_regs);
+    hashval = rb_hash_uint(hashval, rb_memhash(RMATCH_BEG_PTR(match), num_regs * sizeof(OnigPosition)));
+    hashval = rb_hash_uint(hashval, rb_memhash(RMATCH_END_PTR(match), num_regs * sizeof(OnigPosition)));
     hashval = rb_hash_end(hashval);
     return ST2FIX(hashval);
 }
@@ -3579,18 +3578,15 @@ match_hash(VALUE match)
 static VALUE
 match_equal(VALUE match1, VALUE match2)
 {
-    const struct re_registers *regs1, *regs2;
-
     if (match1 == match2) return Qtrue;
     if (!RB_TYPE_P(match2, T_MATCH)) return Qfalse;
     if (!RMATCH(match1)->regexp || !RMATCH(match2)->regexp) return Qfalse;
     if (!rb_str_equal(RMATCH(match1)->str, RMATCH(match2)->str)) return Qfalse;
     if (!rb_reg_equal(match_regexp(match1), match_regexp(match2))) return Qfalse;
-    regs1 = RMATCH_REGS(match1);
-    regs2 = RMATCH_REGS(match2);
-    if (regs1->num_regs != regs2->num_regs) return Qfalse;
-    if (memcmp(regs1->beg, regs2->beg, regs1->num_regs * sizeof(*regs1->beg))) return Qfalse;
-    if (memcmp(regs1->end, regs2->end, regs1->num_regs * sizeof(*regs1->end))) return Qfalse;
+    int num_regs = RMATCH_NREGS(match1);
+    if (num_regs != RMATCH_NREGS(match2)) return Qfalse;
+    if (memcmp(RMATCH_BEG_PTR(match1), RMATCH_BEG_PTR(match2), num_regs * sizeof(OnigPosition))) return Qfalse;
+    if (memcmp(RMATCH_END_PTR(match1), RMATCH_END_PTR(match2), num_regs * sizeof(OnigPosition))) return Qfalse;
     return Qtrue;
 }
 

--- a/string.c
+++ b/string.c
@@ -60,9 +60,6 @@
 # define HAVE_CRYPT_R 1
 #endif
 
-#define BEG(no) (regs->beg[(no)])
-#define END(no) (regs->end[(no)])
-
 #undef rb_str_new
 #undef rb_usascii_str_new
 #undef rb_utf8_str_new
@@ -6273,8 +6270,8 @@ rb_str_sub_bang(int argc, VALUE *argv, VALUE str)
             match0 = pat;
         }
         else {
-            beg0 = BEG(0);
-            end0 = END(0);
+            beg0 = RMATCH_BEG(match, 0);
+            end0 = RMATCH_END(match, 0);
             if (iter) match0 = rb_reg_nth_match(0, match);
         }
 
@@ -6419,8 +6416,8 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
             match0 = pat;
         }
         else {
-            beg0 = BEG(0);
-            end0 = END(0);
+            beg0 = RMATCH_BEG(match, 0);
+            end0 = RMATCH_END(match, 0);
             if (mode == ITER) match0 = rb_reg_nth_match(0, match);
         }
 
@@ -10645,17 +10642,14 @@ scan_once(VALUE str, VALUE pat, long *start, int set_backref_str)
     VALUE result = Qnil;
     long end, pos = rb_pat_search(pat, str, *start, set_backref_str);
     if (pos >= 0) {
-        VALUE match;
-        struct re_registers *regs;
+        VALUE match = Qnil;
         if (BUILTIN_TYPE(pat) == T_STRING) {
-            regs = NULL;
             end = pos + RSTRING_LEN(pat);
         }
         else {
             match = rb_backref_get();
-            regs = RMATCH_REGS(match);
-            pos = BEG(0);
-            end = END(0);
+            pos = RMATCH_BEG(match, 0);
+            end = RMATCH_END(match, 0);
         }
 
         if (pos == end) {
@@ -10673,16 +10667,17 @@ scan_once(VALUE str, VALUE pat, long *start, int set_backref_str)
             *start = end;
         }
 
-        if (!regs || regs->num_regs == 1) {
+        if (NIL_P(match) || RMATCH_NREGS(match) == 1) {
             result = rb_str_subseq(str, pos, end - pos);
             return result;
         }
         else {
-            result = rb_ary_new2(regs->num_regs);
-            for (int i = 1; i < regs->num_regs; i++) {
+            int num_regs = RMATCH_NREGS(match);
+            result = rb_ary_new2(num_regs);
+            for (int i = 1; i < num_regs; i++) {
                 VALUE s = Qnil;
-                if (BEG(i) >= 0) {
-                    s = rb_str_subseq(str, BEG(i), END(i)-BEG(i));
+                if (RMATCH_BEG(match, i) >= 0) {
+                    s = rb_str_subseq(str, RMATCH_BEG(match, i), RMATCH_END(match, i) - RMATCH_BEG(match, i));
                 }
 
                 rb_ary_push(result, s);

--- a/string.c
+++ b/string.c
@@ -4620,8 +4620,7 @@ rb_str_index_m(int argc, VALUE *argv, VALUE str)
 
         if (rb_reg_search(sub, str, pos, 0) >= 0) {
             VALUE match = rb_backref_get();
-            struct re_registers *regs = RMATCH_REGS(match);
-            pos = rb_str_sublen(str, BEG(0));
+            pos = rb_str_sublen(str, RMATCH_BEG(match, 0));
             return LONG2NUM(pos);
         }
     }
@@ -4747,8 +4746,7 @@ rb_str_byteindex_m(int argc, VALUE *argv, VALUE str)
     if (RB_TYPE_P(sub, T_REGEXP)) {
         if (rb_reg_search(sub, str, pos, 0) >= 0) {
             VALUE match = rb_backref_get();
-            struct re_registers *regs = RMATCH_REGS(match);
-            pos = BEG(0);
+            pos = RMATCH_BEG(match, 0);
             return LONG2NUM(pos);
         }
     }
@@ -4879,8 +4877,7 @@ rb_str_rindex_m(int argc, VALUE *argv, VALUE str)
 
         if (rb_reg_search(sub, str, pos, 1) >= 0) {
             VALUE match = rb_backref_get();
-            struct re_registers *regs = RMATCH_REGS(match);
-            pos = rb_str_sublen(str, BEG(0));
+            pos = rb_str_sublen(str, RMATCH_BEG(match, 0));
             return LONG2NUM(pos);
         }
     }
@@ -5037,8 +5034,7 @@ rb_str_byterindex_m(int argc, VALUE *argv, VALUE str)
     if (RB_TYPE_P(sub, T_REGEXP)) {
         if (rb_reg_search(sub, str, pos, 1) >= 0) {
             VALUE match = rb_backref_get();
-            struct re_registers *regs = RMATCH_REGS(match);
-            pos = BEG(0);
+            pos = RMATCH_BEG(match, 0);
             return LONG2NUM(pos);
         }
     }
@@ -5915,26 +5911,25 @@ rb_str_subpat_set(VALUE str, VALUE re, VALUE backref, VALUE val)
     VALUE match;
     long start, end, len;
     rb_encoding *enc;
-    struct re_registers *regs;
 
     if (rb_reg_search(re, str, 0, 0) < 0) {
         rb_raise(rb_eIndexError, "regexp not matched");
     }
     match = rb_backref_get();
     nth = rb_reg_backref_number(match, backref);
-    regs = RMATCH_REGS(match);
-    if ((nth >= regs->num_regs) || ((nth < 0) && (-nth >= regs->num_regs))) {
+    int num_regs = RMATCH_NREGS(match);
+    if ((nth >= num_regs) || ((nth < 0) && (-nth >= num_regs))) {
         rb_raise(rb_eIndexError, "index %d out of regexp", nth);
     }
     if (nth < 0) {
-        nth += regs->num_regs;
+        nth += num_regs;
     }
 
-    start = BEG(nth);
+    start = RMATCH_BEG(match, nth);
     if (start == -1) {
         rb_raise(rb_eIndexError, "regexp group %d not matched", nth);
     }
-    end = END(nth);
+    end = RMATCH_END(match, nth);
     len = end - start;
     StringValue(val);
     enc = rb_enc_check_str(str, val);
@@ -6069,14 +6064,14 @@ rb_str_slice_bang(int argc, VALUE *argv, VALUE str)
     if (RB_TYPE_P(indx, T_REGEXP)) {
         if (rb_reg_search(indx, str, 0, 0) < 0) return Qnil;
         VALUE match = rb_backref_get();
-        struct re_registers *regs = RMATCH_REGS(match);
+        int num_regs = RMATCH_NREGS(match);
         int nth = 0;
         if (argc > 1 && (nth = rb_reg_backref_number(match, argv[1])) < 0) {
-            if ((nth += regs->num_regs) <= 0) return Qnil;
+            if ((nth += num_regs) <= 0) return Qnil;
         }
-        else if (nth >= regs->num_regs) return Qnil;
-        beg = BEG(nth);
-        len = END(nth) - beg;
+        else if (nth >= num_regs) return Qnil;
+        beg = RMATCH_BEG(match, nth);
+        len = RMATCH_END(match, nth) - beg;
         goto subseq;
     }
     else if (argc == 2) {
@@ -9337,18 +9332,16 @@ rb_str_split_m(int argc, VALUE *argv, VALUE str)
         if (result) result = rb_ary_new();
         long len = RSTRING_LEN(str);
         long start = beg;
-        long idx;
+        int idx;
         int last_null = 0;
-        struct re_registers *regs;
         VALUE match = 0;
 
         for (; rb_reg_search(spat, str, start, 0) >= 0;
              (match ? (rb_match_unbusy(match), rb_backref_set(match)) : (void)0)) {
             match = rb_backref_get();
             if (!result) rb_match_busy(match);
-            regs = RMATCH_REGS(match);
-            end = BEG(0);
-            if (start == end && BEG(0) == END(0)) {
+            end = RMATCH_BEG(match, 0);
+            if (start == end && RMATCH_BEG(match, 0) == RMATCH_END(match, 0)) {
                 if (!ptr) {
                     SPLIT_STR(0, 0);
                     break;
@@ -9368,13 +9361,13 @@ rb_str_split_m(int argc, VALUE *argv, VALUE str)
             }
             else {
                 SPLIT_STR(beg, end-beg);
-                beg = start = END(0);
+                beg = start = RMATCH_END(match, 0);
             }
             last_null = 0;
 
-            for (idx=1; idx < regs->num_regs; idx++) {
-                if (BEG(idx) == -1) continue;
-                SPLIT_STR(BEG(idx), END(idx)-BEG(idx));
+            for (idx = 1; idx < RMATCH_NREGS(match); idx++) {
+                if (RMATCH_BEG(match, idx) == -1) continue;
+                SPLIT_STR(RMATCH_BEG(match, idx), RMATCH_END(match, idx) - RMATCH_BEG(match, idx));
             }
             if (!NIL_P(limit) && lim <= ++i) break;
         }
@@ -11255,10 +11248,9 @@ rb_str_partition(VALUE str, VALUE sep)
             goto failed;
         }
         VALUE match = rb_backref_get();
-        struct re_registers *regs = RMATCH_REGS(match);
 
-        pos = BEG(0);
-        sep = rb_str_subseq(str, pos, END(0) - pos);
+        pos = RMATCH_BEG(match, 0);
+        sep = rb_str_subseq(str, pos, RMATCH_END(match, 0) - pos);
     }
     else {
         pos = rb_str_index(str, sep, 0);
@@ -11292,10 +11284,9 @@ rb_str_rpartition(VALUE str, VALUE sep)
             goto failed;
         }
         VALUE match = rb_backref_get();
-        struct re_registers *regs = RMATCH_REGS(match);
 
-        pos = BEG(0);
-        sep = rb_str_subseq(str, pos, END(0) - pos);
+        pos = RMATCH_BEG(match, 0);
+        sep = rb_str_subseq(str, pos, RMATCH_END(match, 0) - pos);
     }
     else {
         pos = rb_str_sublen(str, pos);


### PR DESCRIPTION
These are internal-only helpers which can be used instead of the RMATCH_REGS struct directly. RMATCH_REGS is just a pointer offset from the RMatch VALUE itself, so this should not significantly affect codegen.

The motivation for this is that it's both simpler, and should move us towards being able to replace the storage for RMATCH, and to be able to store the positions embedded instead of in separate malloc memory.