### PR TITLE
Deprecate `Pathname::SEPARATOR_PAT` instead of making it private

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -251,8 +251,6 @@ jobs:
       - name: Run ruby-bench
         run: ruby run_benchmarks.rb -e "ruby::../build/install/bin/ruby" ${{ matrix.bench_opts }}
         working-directory: ruby-bench
-        env:
-          BUNDLER_VERSION: 0
 
       - uses: ./.github/actions/slack
         with:

--- a/.github/workflows/zjit-macos.yml
+++ b/.github/workflows/zjit-macos.yml
@@ -225,8 +225,6 @@ jobs:
       - name: Run ruby-bench
         run: ruby run_benchmarks.rb -e "zjit::../build/install/bin/ruby ${{ matrix.ruby_opts }}" ${{ matrix.bench_opts }}
         working-directory: ruby-bench
-        env:
-          BUNDLER_VERSION: 0
 
       - uses: ./.github/actions/slack
         with:

--- a/.github/workflows/zjit-ubuntu.yml
+++ b/.github/workflows/zjit-ubuntu.yml
@@ -279,8 +279,6 @@ jobs:
       - name: Run ruby-bench
         run: ruby run_benchmarks.rb -e "zjit::../build/install/bin/ruby ${{ matrix.ruby_opts }}" ${{ matrix.bench_opts }}
         working-directory: ruby-bench
-        env:
-          BUNDLER_VERSION: 0
 
       - uses: ./.github/actions/slack
         with:

--- a/depend
+++ b/depend
@@ -11143,6 +11143,7 @@ parser_st.$(OBJEXT): {$(VPATH)}st.c
 pathname.$(OBJEXT): $(hdrdir)/ruby.h
 pathname.$(OBJEXT): $(hdrdir)/ruby/ruby.h
 pathname.$(OBJEXT): $(top_srcdir)/internal/compilers.h
+pathname.$(OBJEXT): $(top_srcdir)/internal/error.h
 pathname.$(OBJEXT): $(top_srcdir)/internal/file.h
 pathname.$(OBJEXT): $(top_srcdir)/internal/serial.h
 pathname.$(OBJEXT): $(top_srcdir)/internal/static_assert.h

--- a/pathname.c
+++ b/pathname.c
@@ -1,5 +1,6 @@
 #include "ruby.h"
 #include "internal.h"
+#include "internal/error.h"     /* for rb_warn_deprecated_to_remove_at */
 #include "internal/file.h"
 #include "internal/string.h"
 #include "internal/vm.h"
@@ -358,6 +359,26 @@ InitVM_pathname(void)
     rb_define_private_method(rb_cPathname, "has_trailing_separator?", has_trailing_separator, 1);
     rb_define_private_method(rb_cPathname, "add_trailing_separator", add_trailing_separator, 1);
     rb_define_private_method(rb_cPathname, "del_trailing_separator", del_trailing_separator, 1);
+
+    {
+        /* NOTE: Used in bundler up to version 4.0.11. Remove this
+         * later. */
+        static const char fullname[] = "Pathname::SEPARATOR_PAT";
+        static const char source[] =
+#if alt_separator
+            "[/\\\\]"
+#else
+            "/"
+#endif
+            "(?# internal and deprecated constant kept only for old Bundler; do not use)";
+        const char *const name = fullname + rb_strlen_lit("Pathname::");
+
+        VALUE pat = rb_reg_new(source, sizeof(source)-1, 0);
+        OBJ_FREEZE(pat);
+        rb_define_const(rb_cPathname, name, pat);
+        rb_deprecate_constant(rb_cPathname, name);
+        rb_warn_deprecated_to_remove_at(4.2, fullname, NULL);
+    }
 
     rb_provide("pathname.so");
 }


### PR DESCRIPTION
It has been used in bundler for the last 10 years: https://github.com/ruby/rubygems/commit/0e8b29fac744a2cb11e7e42904234930266dd9cd

Let's deprecate first and give remove later to give people time to update.

For example, I have commited lockfiles. Currently there is no released bundler that doesn't use this constant, so my workflows fail when running against ruby-head (and still, I would not want to have to immediatly update bundler because of this).

It's similar to to the CI workaround with `BUNDLER_VERSION: 0` here

Followup to https://github.com/ruby/ruby/pull/16895