### PR TITLE
[Bug #22057] test-bundler: add `--enable-gems` explicitly

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1687,7 +1687,7 @@ BUNDLER_SPECS =
 PREPARE_BUNDLER = $(TEST_RUNNABLE)-test-bundler-prepare
 test-bundler: $(TEST_RUNNABLE)-test-bundler
 yes-test-bundler: $(PREPARE_BUNDLER)
-	$(gnumake_recursive)$(XRUBY) \
+	$(gnumake_recursive)$(XRUBY) --enable-gems \
 		-r./$(arch)-fake \
 		-r$(tooldir)/lib/_tmpdir \
 		-I$(srcdir)/spec/bundler -I$(srcdir)/spec/lib \


### PR DESCRIPTION
This is because `make test-bundler-parallel` command, which runs successfully via turbo_tests, does not have `--disable-gems` option specified.

`--disable-gems` is currently set in `RUN_OPTS`. Removing it would affect not only test-bundler but the entire test suite, so I have configured it specifically for this command instead.

This patch will fix an error in `./spec/bundler/bundler/cli_common_spec.rb` when executing `make test-bundler`.