### PR TITLE
[DOC] Remove unnecessary backticks from ZJIT docs

### DIFF
--- a/doc/jit/zjit.md
+++ b/doc/jit/zjit.md
@@ -365,7 +365,6 @@ Note that this disables profiling. To inject interpreter profiles into ZJIT, con
 ```bash
 ./miniruby --zjit --zjit-dump-hir -e "30.times { 1 + 1 }"
 ```
-```
 
 ### Viewing HIR in Iongraph
 


### PR DESCRIPTION
The Markdown formatting was broken, so I removed it.