### PR TITLE
scheduler: rewind CFP after EC_PUSH_TAG on non-local jumps

### DIFF
--- a/scheduler.c
+++ b/scheduler.c
@@ -680,9 +680,13 @@ rb_fiber_scheduler_unblock(VALUE scheduler, VALUE blocker, VALUE fiber)
     int saved_interrupt_mask = ec->interrupt_mask;
     ec->interrupt_mask |= PENDING_INTERRUPT_MASK;
 
+    rb_control_frame_t *volatile cfp = ec->cfp;
     EC_PUSH_TAG(ec);
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
         result = rb_funcall(scheduler, id_unblock, 2, blocker, fiber);
+    }
+    else {
+        rb_vm_rewind_cfp(ec, cfp);
     }
     EC_POP_TAG();
 
@@ -1145,9 +1149,13 @@ VALUE rb_fiber_scheduler_fiber_interrupt(VALUE scheduler, VALUE fiber, VALUE exc
     int saved_interrupt_mask = ec->interrupt_mask;
     ec->interrupt_mask |= PENDING_INTERRUPT_MASK;
 
+    rb_control_frame_t *volatile cfp = ec->cfp;
     EC_PUSH_TAG(ec);
     if ((state = EC_EXEC_TAG()) == TAG_NONE) {
         result = rb_check_funcall(scheduler, id_fiber_interrupt, 2, arguments);
+    }
+    else {
+        rb_vm_rewind_cfp(ec, cfp);
     }
     EC_POP_TAG();
 


### PR DESCRIPTION
## Summary

`rb_fiber_scheduler_unblock` and `rb_fiber_scheduler_fiber_interrupt` both use `EC_PUSH_TAG` to protect Ruby calls from propagating non-local jumps (exceptions, `throw`, etc.), but were missing the CFP rewind that `rb_protect` performs in the same situation.

Without capturing `ec->cfp` before pushing the tag and calling `rb_vm_rewind_cfp(ec, cfp)` in the non-`TAG_NONE` branch, stale control frames can remain on the EC's CFP stack after a longjmp, potentially leading to stack corruption or incorrect backtraces.

The fix mirrors the structure used by `rb_protect` exactly:

```c
rb_control_frame_t *volatile cfp = ec->cfp;
EC_PUSH_TAG(ec);
if ((state = EC_EXEC_TAG()) == TAG_NONE) {
    // ... call Ruby ...
}
else {
    rb_vm_rewind_cfp(ec, cfp);
}
EC_POP_TAG();
```

The `volatile` qualifier on `cfp` is necessary because the variable crosses a `setjmp` boundary.

Made with [Cursor](https://cursor.com)