### PR TITLE
[Bug #22063] Reject NaN Regexp timeout values

### DIFF
--- a/re.c
+++ b/re.c
@@ -12,6 +12,7 @@
 #include "ruby/internal/config.h"
 
 #include <ctype.h>
+
 #include "encindex.h"
 #include "hrtime.h"
 #include "internal.h"

--- a/re.c
+++ b/re.c
@@ -12,7 +12,6 @@
 #include "ruby/internal/config.h"
 
 #include <ctype.h>
-
 #include "encindex.h"
 #include "hrtime.h"
 #include "internal.h"
@@ -3971,7 +3970,7 @@ static void
 set_timeout(rb_hrtime_t *hrt, VALUE timeout)
 {
     double timeout_d = NIL_P(timeout) ? 0.0 : NUM2DBL(timeout);
-    if (!NIL_P(timeout) && timeout_d <= 0) {
+    if (!NIL_P(timeout) && !(timeout_d > 0)) {
         rb_raise(rb_eArgError, "invalid timeout: %"PRIsVALUE, timeout);
     }
     double2hrtime(hrt, timeout_d);

--- a/test/ruby/test_regexp.rb
+++ b/test/ruby/test_regexp.rb
@@ -2035,6 +2035,7 @@ class TestRegexp < Test::Unit::TestCase
       Regexp.timeout = 1e300
       assert_equal(((1<<64)-1) / 1000000000.0, Regexp.timeout)
 
+      assert_raise(ArgumentError) { Regexp.timeout = Float::NAN }
       assert_raise(ArgumentError) { Regexp.timeout = 0 }
       assert_raise(ArgumentError) { Regexp.timeout = -1 }
 
@@ -2127,6 +2128,7 @@ class TestRegexp < Test::Unit::TestCase
 
       assert_equal(((1<<64)-1) / 1000000000.0, Regexp.new("foo", timeout: 1e300).timeout)
 
+      assert_raise(ArgumentError) { Regexp.new("foo", timeout: Float::NAN) }
       assert_raise(ArgumentError) { Regexp.new("foo", timeout: 0) }
       assert_raise(ArgumentError) { Regexp.new("foo", timeout: -1) }
     end;


### PR DESCRIPTION
Reject NaN Regexp timeout values

Bug: https://bugs.ruby-lang.org/issues/22063

## Summary

- reject `Float::NAN` in regexp timeout validation
- cover both `Regexp.timeout=` and `Regexp.new(..., timeout:)`

## Validation

- `./ruby --disable-gems -e 'begin; Regexp.new("foo", timeout: Float::NAN); rescue => e; puts [e.class, e.message].join(": "); end; begin; Regexp.timeout = Float::NAN; rescue => e; puts [e.class, e.message].join(": "); end'`
- `make test-all TESTS='test/ruby/test_regexp.rb --name=/timeout_corner_cases/'`
- `make test-all TESTS='test/ruby/test_regexp.rb'`
- `git diff --check`
