### PR TITLE
[Feature #13677] Add host to addrinfo resolution errors

### DIFF
--- a/ext/socket/init.c
+++ b/ext/socket/init.c
@@ -38,7 +38,7 @@ static VALUE sym_wait_readable;
 static ID id_error_code;
 
 void
-rsock_raise_resolution_error(const char *reason, int error)
+rsock_raise_resolution_error_for_host(const char *reason, int error, VALUE host)
 {
 #ifdef EAI_SYSTEM
     int e;
@@ -53,6 +53,9 @@ rsock_raise_resolution_error(const char *reason, int error)
 #else
     VALUE msg = rb_sprintf("%s: %s", reason, gai_strerror(error));
 #endif
+    if (RTEST(host)) {
+       rb_str_concat(msg, rb_sprintf(" for `%s`", RSTRING_PTR(host)));
+    }
 
     StringValue(msg);
     VALUE self = rb_class_new_instance(1, &msg, rb_eResolution);

--- a/ext/socket/init.c
+++ b/ext/socket/init.c
@@ -45,17 +45,25 @@ rsock_raise_resolution_error_for_host(const char *reason, int error, VALUE host)
     if (error == EAI_SYSTEM && (e = errno) != 0)
         rb_syserr_fail(e, reason);
 #endif
+
+    VALUE msg;
+
 #ifdef _WIN32
     rb_encoding *enc = rb_default_internal_encoding();
-    VALUE msg = rb_sprintf("%s: ", reason);
+    if (RTEST(host)) {
+        msg = rb_sprintf("%s '%"PRIsVALUE"': ", reason, host);
+    } else {
+        msg = rb_sprintf("%s: ", reason);
+    }
     if (!enc) enc = rb_default_internal_encoding();
     rb_str_concat(msg, rb_w32_conv_from_wchar(gai_strerrorW(error), enc));
 #else
-    VALUE msg = rb_sprintf("%s: %s", reason, gai_strerror(error));
-#endif
     if (RTEST(host)) {
-       rb_str_catf(msg, " for '%"PRIsVALUE"'", host);
+        msg = rb_sprintf("%s '%"PRIsVALUE"': %s", reason, host, gai_strerror(error));
+    } else {
+        msg = rb_sprintf("%s: %s", reason, gai_strerror(error));
     }
+#endif
 
     StringValue(msg);
     VALUE self = rb_class_new_instance(1, &msg, rb_eResolution);

--- a/ext/socket/init.c
+++ b/ext/socket/init.c
@@ -54,7 +54,7 @@ rsock_raise_resolution_error_for_host(const char *reason, int error, VALUE host)
     VALUE msg = rb_sprintf("%s: %s", reason, gai_strerror(error));
 #endif
     if (RTEST(host)) {
-       rb_str_concat(msg, rb_sprintf(" for `%s`", RSTRING_PTR(host)));
+       rb_str_catf(msg, " for '%"PRIsVALUE"'", host);
     }
 
     StringValue(msg);

--- a/ext/socket/init.c
+++ b/ext/socket/init.c
@@ -45,6 +45,7 @@ rsock_raise_resolution_error_for_host(const char *reason, int error, VALUE host)
     if (error == EAI_SYSTEM && (e = errno) != 0)
         rb_syserr_fail(e, reason);
 #endif
+
 #ifdef _WIN32
     rb_encoding *enc = rb_default_internal_encoding();
     VALUE msg = rb_sprintf("%s: ", reason);
@@ -53,8 +54,9 @@ rsock_raise_resolution_error_for_host(const char *reason, int error, VALUE host)
 #else
     VALUE msg = rb_sprintf("%s: %s", reason, gai_strerror(error));
 #endif
+
     if (RTEST(host)) {
-       rb_str_catf(msg, " for '%"PRIsVALUE"'", host);
+        rb_str_catf(msg, " %+"PRIsVALUE, host);
     }
 
     StringValue(msg);

--- a/ext/socket/ipsocket.c
+++ b/ext/socket/ipsocket.c
@@ -727,7 +727,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
             }
 
             if (raddrinfo_pthread_create(&threads[i], fork_safe_do_fast_fallback_getaddrinfo, arg->getaddrinfo_entries[i]) != 0) {
-                rsock_raise_resolution_error("getaddrinfo(3)", EAI_AGAIN);
+                rsock_raise_resolution_error_for_host("getaddrinfo(3)", EAI_AGAIN, arg->remote.host);
             }
         }
 
@@ -762,7 +762,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                         serv = arg->remote.serv;
                     }
                     if (last_error.type == RESOLUTION_ERROR) {
-                        rsock_raise_resolution_error(syscall, last_error.ecode);
+                        rsock_raise_resolution_error_for_host(syscall, last_error.ecode, host);
                     } else {
                         rsock_syserr_fail_host_port(last_error.ecode, syscall, host, serv);
                     }
@@ -805,7 +805,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                         serv = arg->remote.serv;
                     }
                     if (last_error.type == RESOLUTION_ERROR) {
-                        rsock_raise_resolution_error(syscall, last_error.ecode);
+                        rsock_raise_resolution_error_for_host(syscall, last_error.ecode, host);
                     } else {
                         rsock_syserr_fail_host_port(last_error.ecode, syscall, host, serv);
                     }
@@ -841,7 +841,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                             serv = arg->remote.serv;
                         }
                         if (last_error.type == RESOLUTION_ERROR) {
-                            rsock_raise_resolution_error(syscall, last_error.ecode);
+                            rsock_raise_resolution_error_for_host(syscall, last_error.ecode, host);
                         } else {
                             rsock_syserr_fail_host_port(last_error.ecode, syscall, host, serv);
                         }
@@ -934,7 +934,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                     serv = arg->remote.serv;
                 }
                 if (last_error.type == RESOLUTION_ERROR) {
-                    rsock_raise_resolution_error(syscall, last_error.ecode);
+                    rsock_raise_resolution_error_for_host(syscall, last_error.ecode, host);
                 } else {
                     rsock_syserr_fail_host_port(last_error.ecode, syscall, host, serv);
                 }
@@ -1033,7 +1033,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                             serv = arg->remote.serv;
                         }
                         if (last_error.type == RESOLUTION_ERROR) {
-                            rsock_raise_resolution_error(syscall, last_error.ecode);
+                            rsock_raise_resolution_error_for_host(syscall, last_error.ecode, host);
                         } else {
                             rsock_syserr_fail_host_port(last_error.ecode, syscall, host, serv);
                         }
@@ -1071,7 +1071,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                             serv = arg->remote.serv;
                         }
                         if (last_error.type == RESOLUTION_ERROR) {
-                            rsock_raise_resolution_error(syscall, last_error.ecode);
+                            rsock_raise_resolution_error_for_host(syscall, last_error.ecode, host);
                         } else {
                             rsock_syserr_fail_host_port(last_error.ecode, syscall, host, serv);
                         }
@@ -1217,7 +1217,7 @@ init_fast_fallback_inetsock_internal(VALUE v)
                     serv = arg->remote.serv;
                 }
                 if (last_error.type == RESOLUTION_ERROR) {
-                    rsock_raise_resolution_error(syscall, last_error.ecode);
+                    rsock_raise_resolution_error_for_host(syscall, last_error.ecode, host);
                 } else {
                     rsock_syserr_fail_host_port(last_error.ecode, syscall, host, serv);
                 }

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -1069,7 +1069,7 @@ rsock_getaddrinfo(VALUE host, VALUE port, struct addrinfo *hints, int socktype_h
         if (hostp && hostp[strlen(hostp)-1] == '\n') {
             rb_raise(rb_eSocket, "newline at the end of hostname");
         }
-        rsock_raise_resolution_error("getaddrinfo", error);
+        rsock_raise_resolution_error_for_host("getaddrinfo", error, host);
     }
 
     return res;

--- a/ext/socket/raddrinfo.c
+++ b/ext/socket/raddrinfo.c
@@ -1070,7 +1070,7 @@ rsock_getaddrinfo(VALUE host, VALUE port, struct addrinfo *hints, int socktype_h
         if (hostp && hostp[strlen(hostp)-1] == '\n') {
             rb_raise(rb_eSocket, "newline at the end of hostname");
         }
-        rsock_raise_resolution_error("getaddrinfo", error);
+        rsock_raise_resolution_error_for_host("getaddrinfo", error, host);
     }
 
     return res;

--- a/ext/socket/rubysocket.h
+++ b/ext/socket/rubysocket.h
@@ -308,7 +308,8 @@ VALUE rsock_sockaddr_string_value_with_addrinfo(volatile VALUE *v, VALUE *ai_ret
 
 VALUE rb_check_sockaddr_string_type(VALUE);
 
-NORETURN(void rsock_raise_resolution_error(const char *, int));
+NORETURN(void rsock_raise_resolution_error_for_host(const char *, int, VALUE));
+#define rsock_raise_resolution_error(reason, error) rsock_raise_resolution_error_for_host((reason), (error), 0)
 
 int rsock_family_arg(VALUE domain);
 int rsock_socktype_arg(VALUE type);

--- a/test/socket/test_addrinfo.rb
+++ b/test/socket/test_addrinfo.rb
@@ -46,7 +46,7 @@ class TestSocketAddrinfo < Test::Unit::TestCase
       Addrinfo.ip("127.0.0.1\000x")
     end
 
-    assert_raise_with_message(Socket::ResolutionError, / for 'unknown'$/) do
+    assert_raise_with_message(Socket::ResolutionError, /^getaddrinfo 'unknown':/) do
       Addrinfo.ip("unknown")
     end
   end

--- a/test/socket/test_addrinfo.rb
+++ b/test/socket/test_addrinfo.rb
@@ -46,7 +46,7 @@ class TestSocketAddrinfo < Test::Unit::TestCase
       Addrinfo.ip("127.0.0.1\000x")
     end
 
-    assert_raise_with_message(Socket::ResolutionError, /not known for `unknown`$/) do
+    assert_raise_with_message(Socket::ResolutionError, / for 'unknown'$/) do
       Addrinfo.ip("unknown")
     end
   end

--- a/test/socket/test_addrinfo.rb
+++ b/test/socket/test_addrinfo.rb
@@ -45,6 +45,10 @@ class TestSocketAddrinfo < Test::Unit::TestCase
     assert_raise(ArgumentError) do
       Addrinfo.ip("127.0.0.1\000x")
     end
+
+    assert_raise_with_message(Socket::ResolutionError, /not known for `unknown`$/) do
+      Addrinfo.ip("unknown")
+    end
   end
 
   def test_addrinfo_tcp

--- a/test/socket/test_addrinfo.rb
+++ b/test/socket/test_addrinfo.rb
@@ -46,7 +46,7 @@ class TestSocketAddrinfo < Test::Unit::TestCase
       Addrinfo.ip("127.0.0.1\000x")
     end
 
-    assert_raise_with_message(Socket::ResolutionError, / for 'unknown'$/) do
+    assert_raise_with_message(Socket::ResolutionError, /^getaddrinfo: .+ "unknown"$/) do
       Addrinfo.ip("unknown")
     end
   end

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -762,7 +762,7 @@ class TestSocket < Test::Unit::TestCase
   end
 
   def test_tcp_socket_resolution_error_with_host
-    assert_raise_with_message(Socket::ResolutionError, / for 'unknown'$/) do
+    assert_raise_with_message(Socket::ResolutionError, /^getaddrinfo(\(3\))? 'unknown':/) do
       TCPSocket.new("unknown", 80)
     end
   end

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -761,6 +761,12 @@ class TestSocket < Test::Unit::TestCase
     end
   end
 
+  def test_tcp_socket_resolution_error_with_host
+    assert_raise_with_message(Socket::ResolutionError, /not known for `unknown`$/) do
+      TCPSocket.new("unknown", 80)
+    end
+  end
+
   def test_tcp_socket_v6_hostname_resolved_earlier
     opts = %w[-rsocket -W1]
     assert_separately opts, <<~RUBY

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -762,7 +762,7 @@ class TestSocket < Test::Unit::TestCase
   end
 
   def test_tcp_socket_resolution_error_with_host
-    assert_raise_with_message(Socket::ResolutionError, /not known for `unknown`$/) do
+    assert_raise_with_message(Socket::ResolutionError, / for 'unknown'$/) do
       TCPSocket.new("unknown", 80)
     end
   end

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -772,7 +772,7 @@ class TestSocket < Test::Unit::TestCase
   end
 
   def test_tcp_socket_resolution_error_with_host
-    assert_raise_with_message(Socket::ResolutionError, /not known for `unknown`$/) do
+    assert_raise_with_message(Socket::ResolutionError, / for 'unknown'$/) do
       TCPSocket.new("unknown", 80)
     end
   end

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -772,7 +772,7 @@ class TestSocket < Test::Unit::TestCase
   end
 
   def test_tcp_socket_resolution_error_with_host
-    assert_raise_with_message(Socket::ResolutionError, / for 'unknown'$/) do
+    assert_raise_with_message(Socket::ResolutionError, /^getaddrinfo(\(3\))?: .+ "unknown"$/) do
       TCPSocket.new("unknown", 80)
     end
   end

--- a/test/socket/test_socket.rb
+++ b/test/socket/test_socket.rb
@@ -771,6 +771,12 @@ class TestSocket < Test::Unit::TestCase
     end
   end
 
+  def test_tcp_socket_resolution_error_with_host
+    assert_raise_with_message(Socket::ResolutionError, /not known for `unknown`$/) do
+      TCPSocket.new("unknown", 80)
+    end
+  end
+
   def test_tcp_socket_v6_hostname_resolved_earlier
     opts = %w[-rsocket -W1]
     assert_separately opts, <<~RUBY


### PR DESCRIPTION
hostname is added as a suffix to getaddrinfo error messages. for example, a "name or service not known" error message becomes "name or service not known for `invalidthost.com`.

* Before: `getaddrinfo: Name or service not known (Socket::ResolutionError)`
* After: `getaddrinfo: Name or service not known "unknown.domain" (Socket::ResolutionError)`

Issue: https://bugs.ruby-lang.org/issues/13677