### PR TITLE
Use monotonic counters for tracking malloc/free

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -495,11 +495,29 @@ enum gc_mode {
     gc_mode_compacting,
 };
 
+#if SIZEOF_SIZE_T >= 8
+typedef size_t gc_counter_t;
+#else
+typedef uint64_t gc_counter_t;
+#endif
+
+struct gc_malloc_bytes {
+    gc_counter_t malloc;
+    gc_counter_t free;
+
+    /* Snapshots of `malloc` / `free` taken at the end of the last GC */
+    gc_counter_t malloc_at_last_gc;
+    gc_counter_t free_at_last_gc;
+};
+
 typedef struct rb_objspace {
     struct {
-        size_t increase;
+        struct gc_malloc_bytes counters;
 #if RGENGC_ESTIMATE_OLDMALLOC
-        size_t oldmalloc_increase;
+        struct gc_malloc_bytes oldcounters;
+#endif
+#if SIZEOF_SIZE_T < 8
+        rb_nativethread_lock_t lock;
 #endif
     } malloc_counters;
 
@@ -943,8 +961,69 @@ RVALUE_AGE_SET(VALUE obj, int age)
 }
 
 #define malloc_limit		objspace->malloc_params.limit
-#define malloc_increase 	objspace->malloc_counters.increase
+#define malloc_increase 	gc_malloc_counters_increase_unsigned(objspace, &objspace->malloc_counters.counters)
 #define malloc_allocated_size 	objspace->malloc_params.allocated_size
+
+/* We don't need a lock if the system is 64-bit, we can do native 64-bit operations in a single instruction */
+#if SIZEOF_SIZE_T >= 8
+# define MALLOC_COUNTERS_LOCK(o)   ((void)0)
+# define MALLOC_COUNTERS_UNLOCK(o) ((void)0)
+# define MALLOC_COUNTER_ADD(field, delta) \
+    RUBY_ATOMIC_SIZE_ADD((field), (size_t)(delta))
+#else
+# define MALLOC_COUNTERS_LOCK(o)   rb_native_mutex_lock(&(o)->malloc_counters.lock)
+# define MALLOC_COUNTERS_UNLOCK(o) rb_native_mutex_unlock(&(o)->malloc_counters.lock)
+/* Caller must hold MALLOC_COUNTERS_LOCK. */
+# define MALLOC_COUNTER_ADD(field, delta) ((field) += (gc_counter_t)(delta))
+#endif
+
+static inline int64_t
+gc_malloc_counters_increase(rb_objspace_t *objspace, const struct gc_malloc_bytes *c)
+{
+    MALLOC_COUNTERS_LOCK(objspace);
+    gc_counter_t malloc_delta = c->malloc - c->malloc_at_last_gc;
+    gc_counter_t free_delta = c->free - c->free_at_last_gc;
+    MALLOC_COUNTERS_UNLOCK(objspace);
+
+    if (malloc_delta >= free_delta) {
+        return (int64_t)(malloc_delta - free_delta);
+    }
+    else {
+        return -(int64_t)(free_delta - malloc_delta);
+    }
+}
+
+static inline size_t
+gc_malloc_counters_increase_unsigned(rb_objspace_t *objspace, const struct gc_malloc_bytes *c)
+{
+    int64_t inc = gc_malloc_counters_increase(objspace, c);
+    if (inc <= 0) return 0;
+#if SIZEOF_SIZE_T < 8
+    if ((uint64_t)inc > SIZE_MAX) return SIZE_MAX;
+#endif
+    return (size_t)inc;
+}
+
+static inline int64_t
+gc_malloc_counters_snapshot(rb_objspace_t *objspace, struct gc_malloc_bytes *c)
+{
+    MALLOC_COUNTERS_LOCK(objspace);
+    gc_counter_t malloc_now = c->malloc;
+    gc_counter_t free_now = c->free;
+    gc_counter_t malloc_delta = malloc_now - c->malloc_at_last_gc;
+    gc_counter_t free_delta = free_now - c->free_at_last_gc;
+    c->malloc_at_last_gc = malloc_now;
+    c->free_at_last_gc = free_now;
+    MALLOC_COUNTERS_UNLOCK(objspace);
+
+    if (malloc_delta >= free_delta) {
+        return (int64_t)(malloc_delta - free_delta);
+    }
+    else {
+        return -(int64_t)(free_delta - malloc_delta);
+    }
+}
+
 #define heap_pages_lomem	objspace->heap_pages.range[0]
 #define heap_pages_himem	objspace->heap_pages.range[1]
 #define heap_pages_freeable_pages	objspace->heap_pages.freeable_pages
@@ -4924,10 +5003,12 @@ gc_check_after_marks_i(st_data_t k, st_data_t v, st_data_t ptr)
 static void
 gc_marks_check(rb_objspace_t *objspace, st_foreach_callback_func *checker_func, const char *checker_name)
 {
-    size_t saved_malloc_increase = objspace->malloc_params.increase;
+    MALLOC_COUNTERS_LOCK(objspace);
+    struct gc_malloc_bytes saved_malloc = objspace->malloc_counters.counters;
 #if RGENGC_ESTIMATE_OLDMALLOC
-    size_t saved_oldmalloc_increase = objspace->malloc_counters.oldmalloc_increase;
+    struct gc_malloc_bytes saved_oldmalloc = objspace->malloc_counters.oldcounters;
 #endif
+    MALLOC_COUNTERS_UNLOCK(objspace);
     VALUE already_disabled = rb_objspace_gc_disable(objspace);
 
     objspace->rgengc.allrefs_table = objspace_allrefs(objspace);
@@ -4947,10 +5028,12 @@ gc_marks_check(rb_objspace_t *objspace, st_foreach_callback_func *checker_func, 
     objspace->rgengc.allrefs_table = 0;
 
     if (already_disabled == Qfalse) rb_objspace_gc_enable(objspace);
-    objspace->malloc_params.increase = saved_malloc_increase;
+    MALLOC_COUNTERS_LOCK(objspace);
+    objspace->malloc_counters.counters = saved_malloc;
 #if RGENGC_ESTIMATE_OLDMALLOC
-    objspace->malloc_counters.oldmalloc_increase = saved_oldmalloc_increase;
+    objspace->malloc_counters.oldcounters = saved_oldmalloc;
 #endif
+    MALLOC_COUNTERS_UNLOCK(objspace);
 }
 #endif /* RGENGC_CHECK_MODE >= 4 */
 
@@ -6310,11 +6393,14 @@ gc_reset_malloc_info(rb_objspace_t *objspace, bool full_mark)
 {
     gc_prof_set_malloc_info(objspace);
     {
-        size_t inc = RUBY_ATOMIC_SIZE_EXCHANGE(malloc_increase, 0);
+        int64_t inc = gc_malloc_counters_snapshot(objspace, &objspace->malloc_counters.counters);
         size_t old_limit = malloc_limit;
 
-        if (inc > malloc_limit) {
-            malloc_limit = (size_t)(inc * gc_params.malloc_limit_growth_factor);
+        /* A net-negative `inc` (more freed than malloc'd since last GC) is
+         * treated the same as "allocated less than malloc_limit".
+         * This matches what we were doing pre-monotonic counters, but is it right? */
+        if (inc > 0 && (size_t)inc > malloc_limit) {
+            malloc_limit = (size_t)((size_t)inc * gc_params.malloc_limit_growth_factor);
             if (malloc_limit > gc_params.malloc_limit_max) {
                 malloc_limit = gc_params.malloc_limit_max;
             }
@@ -6341,7 +6427,11 @@ gc_reset_malloc_info(rb_objspace_t *objspace, bool full_mark)
     /* reset oldmalloc info */
 #if RGENGC_ESTIMATE_OLDMALLOC
     if (!full_mark) {
-        if (objspace->malloc_counters.oldmalloc_increase > objspace->rgengc.oldmalloc_increase_limit) {
+        /* Don't snapshot on minor GC: oldmalloc_increase is meant to
+         * accumulate across minor GCs and only reset at major GC. */
+        int64_t oldmalloc_increase = gc_malloc_counters_increase(objspace, &objspace->malloc_counters.oldcounters);
+        if (oldmalloc_increase > 0 &&
+            (uint64_t)oldmalloc_increase > objspace->rgengc.oldmalloc_increase_limit) {
             gc_needs_major_flags |= GPR_FLAG_MAJOR_BY_OLDMALLOC;
             objspace->rgengc.oldmalloc_increase_limit =
               (size_t)(objspace->rgengc.oldmalloc_increase_limit * gc_params.oldmalloc_limit_growth_factor);
@@ -6351,16 +6441,16 @@ gc_reset_malloc_info(rb_objspace_t *objspace, bool full_mark)
             }
         }
 
-        if (0) fprintf(stderr, "%"PRIdSIZE"\t%d\t%"PRIuSIZE"\t%"PRIuSIZE"\t%"PRIdSIZE"\n",
+        if (0) fprintf(stderr, "%"PRIdSIZE"\t%d\t%"PRId64"\t%"PRIuSIZE"\t%"PRIdSIZE"\n",
                        rb_gc_count(),
                        gc_needs_major_flags,
-                       objspace->malloc_counters.oldmalloc_increase,
+                       oldmalloc_increase,
                        objspace->rgengc.oldmalloc_increase_limit,
                        gc_params.oldmalloc_limit_max);
     }
     else {
-        /* major GC */
-        objspace->malloc_counters.oldmalloc_increase = 0;
+        /* major GC: re-baseline the oldmalloc counter */
+        (void)gc_malloc_counters_snapshot(objspace, &objspace->malloc_counters.oldcounters);
 
         if ((objspace->profile.latest_gc_info & GPR_FLAG_MAJOR_BY_OLDMALLOC) == 0) {
             objspace->rgengc.oldmalloc_increase_limit =
@@ -7591,7 +7681,7 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(total_freed_pages, objspace->heap_pages.freed_pages);
     SET(total_allocated_objects, total_allocated_objects(objspace));
     SET(total_freed_objects, total_freed_objects(objspace));
-    SET(malloc_increase_bytes, malloc_increase);
+    SET(malloc_increase_bytes, gc_malloc_counters_increase_unsigned(objspace, &objspace->malloc_counters.counters));
     SET(malloc_increase_bytes_limit, malloc_limit);
     SET(minor_gc_count, objspace->profile.minor_gc_count);
     SET(major_gc_count, objspace->profile.major_gc_count);
@@ -7603,7 +7693,7 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(old_objects, objspace->rgengc.old_objects);
     SET(old_objects_limit, objspace->rgengc.old_objects_limit);
 #if RGENGC_ESTIMATE_OLDMALLOC
-    SET(oldmalloc_increase_bytes, objspace->malloc_counters.oldmalloc_increase);
+    SET(oldmalloc_increase_bytes, gc_malloc_counters_increase_unsigned(objspace, &objspace->malloc_counters.oldcounters));
     SET(oldmalloc_increase_bytes_limit, objspace->rgengc.oldmalloc_increase_limit);
 #endif
 
@@ -8044,16 +8134,22 @@ static void
 malloc_increase_commit(rb_objspace_t *objspace, size_t new_size, size_t old_size)
 {
     if (new_size > old_size) {
-        RUBY_ATOMIC_SIZE_ADD(malloc_increase, new_size - old_size);
+        size_t delta = new_size - old_size;
+        MALLOC_COUNTERS_LOCK(objspace);
+        MALLOC_COUNTER_ADD(objspace->malloc_counters.counters.malloc, delta);
 #if RGENGC_ESTIMATE_OLDMALLOC
-        RUBY_ATOMIC_SIZE_ADD(objspace->malloc_counters.oldmalloc_increase, new_size - old_size);
+        MALLOC_COUNTER_ADD(objspace->malloc_counters.oldcounters.malloc, delta);
 #endif
+        MALLOC_COUNTERS_UNLOCK(objspace);
     }
-    else {
-        atomic_sub_nounderflow(&malloc_increase, old_size - new_size);
+    else if (old_size > new_size) {
+        size_t delta = old_size - new_size;
+        MALLOC_COUNTERS_LOCK(objspace);
+        MALLOC_COUNTER_ADD(objspace->malloc_counters.counters.free, delta);
 #if RGENGC_ESTIMATE_OLDMALLOC
-        atomic_sub_nounderflow(&objspace->malloc_counters.oldmalloc_increase, old_size - new_size);
+        MALLOC_COUNTER_ADD(objspace->malloc_counters.oldcounters.free, delta);
 #endif
+        MALLOC_COUNTERS_UNLOCK(objspace);
     }
 }
 
@@ -9390,6 +9486,10 @@ rb_gc_impl_objspace_free(void *objspace_ptr)
 
     rb_darray_free_without_gc(objspace->weak_references);
 
+#if SIZEOF_SIZE_T < 8
+    rb_native_mutex_destroy(&objspace->malloc_counters.lock);
+#endif
+
     free(objspace);
 }
 
@@ -9520,6 +9620,9 @@ rb_gc_impl_objspace_init(void *objspace_ptr)
 
     objspace->flags.measure_gc = true;
     malloc_limit = gc_params.malloc_limit_min;
+#if SIZEOF_SIZE_T < 8
+    rb_native_mutex_initialize(&objspace->malloc_counters.lock);
+#endif
     objspace->finalize_deferred_pjob = rb_postponed_job_preregister(0, gc_finalize_deferred, objspace);
     if (objspace->finalize_deferred_pjob == POSTPONED_JOB_HANDLE_INVALID) {
         rb_bug("Could not preregister postponed job for GC");

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -4031,6 +4031,13 @@ gc_sweep_finish(rb_objspace_t *objspace)
         }
     }
 
+    (void)gc_malloc_counters_snapshot(objspace, &objspace->malloc_counters.counters);
+#if RGENGC_ESTIMATE_OLDMALLOC
+    if (objspace->profile.latest_gc_info & GPR_FLAG_MAJOR_MASK) {
+        (void)gc_malloc_counters_snapshot(objspace, &objspace->malloc_counters.oldcounters);
+    }
+#endif
+
     rb_gc_event_hook(0, RUBY_INTERNAL_EVENT_GC_END_SWEEP);
     gc_mode_transition(objspace, gc_mode_none);
 
@@ -6464,7 +6471,7 @@ gc_reset_malloc_info(rb_objspace_t *objspace, bool full_mark)
 {
     gc_prof_set_malloc_info(objspace);
     {
-        int64_t inc = gc_malloc_counters_snapshot(objspace, &objspace->malloc_counters.counters);
+        int64_t inc = gc_malloc_counters_increase(objspace, &objspace->malloc_counters.counters);
         size_t old_limit = malloc_limit;
 
         /* A net-negative `inc` (more freed than malloc'd since last GC) is
@@ -6520,9 +6527,6 @@ gc_reset_malloc_info(rb_objspace_t *objspace, bool full_mark)
                        gc_params.oldmalloc_limit_max);
     }
     else {
-        /* major GC: re-baseline the oldmalloc counter */
-        (void)gc_malloc_counters_snapshot(objspace, &objspace->malloc_counters.oldcounters);
-
         if ((objspace->profile.latest_gc_info & GPR_FLAG_MAJOR_BY_OLDMALLOC) == 0) {
             objspace->rgengc.oldmalloc_increase_limit =
               (size_t)(objspace->rgengc.oldmalloc_increase_limit / ((gc_params.oldmalloc_limit_growth_factor - 1)/10 + 1));

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -23,6 +23,7 @@
 
 #include "ruby/ruby.h"
 #include "ruby/atomic.h"
+#include "ruby_atomic.h"
 #include "ruby/debug.h"
 #include "ruby/thread.h"
 #include "ruby/util.h"
@@ -498,7 +499,16 @@ enum gc_mode {
 #if SIZEOF_SIZE_T >= 8
 typedef size_t gc_counter_t;
 #else
-typedef uint64_t gc_counter_t;
+typedef RBIMPL_ALIGNAS(8) uint64_t gc_counter_t;
+#endif
+
+#if SIZEOF_SIZE_T >= 8
+# define MALLOC_COUNTERS_ATOMIC_NATIVE 1
+#elif defined(HAVE_GCC_ATOMIC_BUILTINS_64) || defined(_WIN32) || \
+      (defined(__sun) && defined(HAVE_ATOMIC_H) && (defined(_LP64) || defined(_I32LPx)))
+# define MALLOC_COUNTERS_ATOMIC_U64 1
+#else
+# define MALLOC_COUNTERS_NEED_LOCK 1
 #endif
 
 struct gc_malloc_bytes {
@@ -516,7 +526,7 @@ typedef struct rb_objspace {
 #if RGENGC_ESTIMATE_OLDMALLOC
         struct gc_malloc_bytes oldcounters;
 #endif
-#if SIZEOF_SIZE_T < 8
+#ifdef MALLOC_COUNTERS_NEED_LOCK
         rb_nativethread_lock_t lock;
 #endif
     } malloc_counters;
@@ -964,26 +974,68 @@ RVALUE_AGE_SET(VALUE obj, int age)
 #define malloc_increase 	gc_malloc_counters_increase_unsigned(objspace, &objspace->malloc_counters.counters)
 #define malloc_allocated_size 	objspace->malloc_params.allocated_size
 
-/* We don't need a lock if the system is 64-bit, we can do native 64-bit operations in a single instruction */
-#if SIZEOF_SIZE_T >= 8
-# define MALLOC_COUNTERS_LOCK(o)   ((void)0)
-# define MALLOC_COUNTERS_UNLOCK(o) ((void)0)
-# define MALLOC_COUNTER_ADD(field, delta) \
-    RUBY_ATOMIC_SIZE_ADD((field), (size_t)(delta))
-#else
+#ifdef MALLOC_COUNTERS_NEED_LOCK
 # define MALLOC_COUNTERS_LOCK(o)   rb_native_mutex_lock(&(o)->malloc_counters.lock)
 # define MALLOC_COUNTERS_UNLOCK(o) rb_native_mutex_unlock(&(o)->malloc_counters.lock)
-/* Caller must hold MALLOC_COUNTERS_LOCK. */
-# define MALLOC_COUNTER_ADD(field, delta) ((field) += (gc_counter_t)(delta))
+#else
+# define MALLOC_COUNTERS_LOCK(o)   ((void)0)
+# define MALLOC_COUNTERS_UNLOCK(o) ((void)0)
 #endif
+
+static inline void
+gc_counter_add(gc_counter_t *p, size_t delta)
+{
+#if defined(MALLOC_COUNTERS_ATOMIC_NATIVE)
+    RUBY_ATOMIC_SIZE_ADD(*p, delta);
+#elif defined(MALLOC_COUNTERS_ATOMIC_U64)
+    rbimpl_atomic_u64_fetch_add_relaxed((volatile rbimpl_atomic_uint64_t *)p, (uint64_t)delta);
+#else
+    *p += (gc_counter_t)delta;
+#endif
+}
+
+static inline gc_counter_t
+gc_counter_load_relaxed(const gc_counter_t *p)
+{
+#if defined(MALLOC_COUNTERS_ATOMIC_U64)
+    return (gc_counter_t)rbimpl_atomic_u64_load_relaxed((const volatile rbimpl_atomic_uint64_t *)p);
+#else
+    return *p;
+#endif
+}
+
+static inline gc_counter_t
+gc_counter_load_acquire(const gc_counter_t *p)
+{
+#if defined(MALLOC_COUNTERS_ATOMIC_U64)
+    return (gc_counter_t)rbimpl_atomic_u64_load_acquire((const volatile rbimpl_atomic_uint64_t *)p);
+#else
+    return *p;
+#endif
+}
+
+static inline void
+gc_counter_store_release(gc_counter_t *p, gc_counter_t v)
+{
+#if defined(MALLOC_COUNTERS_ATOMIC_U64)
+    rbimpl_atomic_u64_set_release((volatile rbimpl_atomic_uint64_t *)p, (uint64_t)v);
+#else
+    *p = v;
+#endif
+}
 
 static inline int64_t
 gc_malloc_counters_increase(rb_objspace_t *objspace, const struct gc_malloc_bytes *c)
 {
     MALLOC_COUNTERS_LOCK(objspace);
-    gc_counter_t malloc_delta = c->malloc - c->malloc_at_last_gc;
-    gc_counter_t free_delta = c->free - c->free_at_last_gc;
+    gc_counter_t malloc_at = gc_counter_load_acquire(&c->malloc_at_last_gc);
+    gc_counter_t free_at   = gc_counter_load_acquire(&c->free_at_last_gc);
+    gc_counter_t malloc_now = gc_counter_load_relaxed(&c->malloc);
+    gc_counter_t free_now   = gc_counter_load_relaxed(&c->free);
     MALLOC_COUNTERS_UNLOCK(objspace);
+
+    gc_counter_t malloc_delta = malloc_now - malloc_at;
+    gc_counter_t free_delta   = free_now   - free_at;
 
     if (malloc_delta >= free_delta) {
         return (int64_t)(malloc_delta - free_delta);
@@ -1008,13 +1060,16 @@ static inline int64_t
 gc_malloc_counters_snapshot(rb_objspace_t *objspace, struct gc_malloc_bytes *c)
 {
     MALLOC_COUNTERS_LOCK(objspace);
-    gc_counter_t malloc_now = c->malloc;
-    gc_counter_t free_now = c->free;
-    gc_counter_t malloc_delta = malloc_now - c->malloc_at_last_gc;
-    gc_counter_t free_delta = free_now - c->free_at_last_gc;
-    c->malloc_at_last_gc = malloc_now;
-    c->free_at_last_gc = free_now;
+    gc_counter_t malloc_now = gc_counter_load_relaxed(&c->malloc);
+    gc_counter_t free_now   = gc_counter_load_relaxed(&c->free);
+    gc_counter_t malloc_at  = gc_counter_load_relaxed(&c->malloc_at_last_gc);
+    gc_counter_t free_at    = gc_counter_load_relaxed(&c->free_at_last_gc);
+    gc_counter_store_release(&c->malloc_at_last_gc, malloc_now);
+    gc_counter_store_release(&c->free_at_last_gc,   free_now);
     MALLOC_COUNTERS_UNLOCK(objspace);
+
+    gc_counter_t malloc_delta = malloc_now - malloc_at;
+    gc_counter_t free_delta   = free_now   - free_at;
 
     if (malloc_delta >= free_delta) {
         return (int64_t)(malloc_delta - free_delta);
@@ -5004,9 +5059,19 @@ static void
 gc_marks_check(rb_objspace_t *objspace, st_foreach_callback_func *checker_func, const char *checker_name)
 {
     MALLOC_COUNTERS_LOCK(objspace);
-    struct gc_malloc_bytes saved_malloc = objspace->malloc_counters.counters;
+    struct gc_malloc_bytes saved_malloc = {
+        .malloc            = gc_counter_load_relaxed(&objspace->malloc_counters.counters.malloc),
+        .free              = gc_counter_load_relaxed(&objspace->malloc_counters.counters.free),
+        .malloc_at_last_gc = gc_counter_load_relaxed(&objspace->malloc_counters.counters.malloc_at_last_gc),
+        .free_at_last_gc   = gc_counter_load_relaxed(&objspace->malloc_counters.counters.free_at_last_gc),
+    };
 #if RGENGC_ESTIMATE_OLDMALLOC
-    struct gc_malloc_bytes saved_oldmalloc = objspace->malloc_counters.oldcounters;
+    struct gc_malloc_bytes saved_oldmalloc = {
+        .malloc            = gc_counter_load_relaxed(&objspace->malloc_counters.oldcounters.malloc),
+        .free              = gc_counter_load_relaxed(&objspace->malloc_counters.oldcounters.free),
+        .malloc_at_last_gc = gc_counter_load_relaxed(&objspace->malloc_counters.oldcounters.malloc_at_last_gc),
+        .free_at_last_gc   = gc_counter_load_relaxed(&objspace->malloc_counters.oldcounters.free_at_last_gc),
+    };
 #endif
     MALLOC_COUNTERS_UNLOCK(objspace);
     VALUE already_disabled = rb_objspace_gc_disable(objspace);
@@ -5029,9 +5094,15 @@ gc_marks_check(rb_objspace_t *objspace, st_foreach_callback_func *checker_func, 
 
     if (already_disabled == Qfalse) rb_objspace_gc_enable(objspace);
     MALLOC_COUNTERS_LOCK(objspace);
-    objspace->malloc_counters.counters = saved_malloc;
+    gc_counter_store_release(&objspace->malloc_counters.counters.malloc,            saved_malloc.malloc);
+    gc_counter_store_release(&objspace->malloc_counters.counters.free,              saved_malloc.free);
+    gc_counter_store_release(&objspace->malloc_counters.counters.malloc_at_last_gc, saved_malloc.malloc_at_last_gc);
+    gc_counter_store_release(&objspace->malloc_counters.counters.free_at_last_gc,   saved_malloc.free_at_last_gc);
 #if RGENGC_ESTIMATE_OLDMALLOC
-    objspace->malloc_counters.oldcounters = saved_oldmalloc;
+    gc_counter_store_release(&objspace->malloc_counters.oldcounters.malloc,            saved_oldmalloc.malloc);
+    gc_counter_store_release(&objspace->malloc_counters.oldcounters.free,              saved_oldmalloc.free);
+    gc_counter_store_release(&objspace->malloc_counters.oldcounters.malloc_at_last_gc, saved_oldmalloc.malloc_at_last_gc);
+    gc_counter_store_release(&objspace->malloc_counters.oldcounters.free_at_last_gc,   saved_oldmalloc.free_at_last_gc);
 #endif
     MALLOC_COUNTERS_UNLOCK(objspace);
 }
@@ -7677,12 +7748,8 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(sweeping_time, (size_t)ns_to_ms(objspace->profile.sweeping_time_ns));
 
     {
-        /* Monotonic totals; snapshot the pair under one lock so they're
-         * consistent with each other on 32-bit. */
-        MALLOC_COUNTERS_LOCK(objspace);
-        uint64_t total_malloc = objspace->malloc_counters.counters.malloc;
-        uint64_t total_free   = objspace->malloc_counters.counters.free;
-        MALLOC_COUNTERS_UNLOCK(objspace);
+        uint64_t total_malloc = (uint64_t)gc_counter_load_relaxed(&objspace->malloc_counters.counters.malloc);
+        uint64_t total_free   = (uint64_t)gc_counter_load_relaxed(&objspace->malloc_counters.counters.free);
         SET64(total_malloc_bytes, total_malloc);
         SET64(total_free_bytes, total_free);
     }
@@ -8160,18 +8227,18 @@ malloc_increase_commit(rb_objspace_t *objspace, size_t new_size, size_t old_size
     if (new_size > old_size) {
         size_t delta = new_size - old_size;
         MALLOC_COUNTERS_LOCK(objspace);
-        MALLOC_COUNTER_ADD(objspace->malloc_counters.counters.malloc, delta);
+        gc_counter_add(&objspace->malloc_counters.counters.malloc, delta);
 #if RGENGC_ESTIMATE_OLDMALLOC
-        MALLOC_COUNTER_ADD(objspace->malloc_counters.oldcounters.malloc, delta);
+        gc_counter_add(&objspace->malloc_counters.oldcounters.malloc, delta);
 #endif
         MALLOC_COUNTERS_UNLOCK(objspace);
     }
     else if (old_size > new_size) {
         size_t delta = old_size - new_size;
         MALLOC_COUNTERS_LOCK(objspace);
-        MALLOC_COUNTER_ADD(objspace->malloc_counters.counters.free, delta);
+        gc_counter_add(&objspace->malloc_counters.counters.free, delta);
 #if RGENGC_ESTIMATE_OLDMALLOC
-        MALLOC_COUNTER_ADD(objspace->malloc_counters.oldcounters.free, delta);
+        gc_counter_add(&objspace->malloc_counters.oldcounters.free, delta);
 #endif
         MALLOC_COUNTERS_UNLOCK(objspace);
     }
@@ -9510,7 +9577,7 @@ rb_gc_impl_objspace_free(void *objspace_ptr)
 
     rb_darray_free_without_gc(objspace->weak_references);
 
-#if SIZEOF_SIZE_T < 8
+#ifdef MALLOC_COUNTERS_NEED_LOCK
     rb_native_mutex_destroy(&objspace->malloc_counters.lock);
 #endif
 
@@ -9644,7 +9711,7 @@ rb_gc_impl_objspace_init(void *objspace_ptr)
 
     objspace->flags.measure_gc = true;
     malloc_limit = gc_params.malloc_limit_min;
-#if SIZEOF_SIZE_T < 8
+#ifdef MALLOC_COUNTERS_NEED_LOCK
     rb_native_mutex_initialize(&objspace->malloc_counters.lock);
 #endif
     objspace->finalize_deferred_pjob = rb_postponed_job_preregister(0, gc_finalize_deferred, objspace);

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -7761,10 +7761,6 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(heap_eden_pages, heap_eden_total_pages(objspace));
     SET(total_allocated_pages, objspace->heap_pages.allocated_pages);
     SET(total_freed_pages, objspace->heap_pages.freed_pages);
-    /* These two may allocate Bignums on small-FIXNUM_MAX platforms — keep
-     * them above the slot snapshot below. */
-    SET(total_allocated_objects, total_allocated_objects(objspace));
-    SET(total_freed_objects, total_freed_objects(objspace));
     SET(malloc_increase_bytes, gc_malloc_counters_increase_unsigned(objspace, &objspace->malloc_counters.counters));
     SET(malloc_increase_bytes_limit, malloc_limit);
     SET(minor_gc_count, objspace->profile.minor_gc_count);
@@ -7781,6 +7777,9 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(oldmalloc_increase_bytes_limit, objspace->rgengc.oldmalloc_increase_limit);
 #endif
 
+    ractor_cache_flush_count(objspace, rb_gc_get_ractor_newobj_cache());
+    SET(total_allocated_objects, total_allocated_objects(objspace));
+    SET(total_freed_objects, total_freed_objects(objspace));
     SET(heap_available_slots, objspace_available_slots(objspace));
     SET(heap_live_slots, objspace_live_slots(objspace));
     SET(heap_free_slots, objspace_free_slots(objspace));

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -7676,20 +7676,6 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(marking_time, (size_t)ns_to_ms(objspace->profile.marking_time_ns));
     SET(sweeping_time, (size_t)ns_to_ms(objspace->profile.sweeping_time_ns));
 
-    /* implementation dependent counters */
-    SET(heap_allocated_pages, rb_darray_size(objspace->heap_pages.sorted));
-    SET(heap_empty_pages, objspace->empty_pages_count)
-    SET(heap_allocatable_bytes, objspace->heap_pages.allocatable_bytes);
-    SET(heap_available_slots, objspace_available_slots(objspace));
-    SET(heap_live_slots, objspace_live_slots(objspace));
-    SET(heap_free_slots, objspace_free_slots(objspace));
-    SET(heap_final_slots, total_final_slots_count(objspace));
-    SET(heap_marked_slots, objspace->marked_slots);
-    SET(heap_eden_pages, heap_eden_total_pages(objspace));
-    SET(total_allocated_pages, objspace->heap_pages.allocated_pages);
-    SET(total_freed_pages, objspace->heap_pages.freed_pages);
-    SET(total_allocated_objects, total_allocated_objects(objspace));
-    SET(total_freed_objects, total_freed_objects(objspace));
     {
         /* Monotonic totals; snapshot the pair under one lock so they're
          * consistent with each other on 32-bit. */
@@ -7700,6 +7686,18 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
         SET64(total_malloc_bytes, total_malloc);
         SET64(total_free_bytes, total_free);
     }
+
+    /* implementation dependent counters (small / fixnum-safe) */
+    SET(heap_allocated_pages, rb_darray_size(objspace->heap_pages.sorted));
+    SET(heap_empty_pages, objspace->empty_pages_count)
+    SET(heap_allocatable_bytes, objspace->heap_pages.allocatable_bytes);
+    SET(heap_eden_pages, heap_eden_total_pages(objspace));
+    SET(total_allocated_pages, objspace->heap_pages.allocated_pages);
+    SET(total_freed_pages, objspace->heap_pages.freed_pages);
+    /* These two may allocate Bignums on small-FIXNUM_MAX platforms — keep
+     * them above the slot snapshot below. */
+    SET(total_allocated_objects, total_allocated_objects(objspace));
+    SET(total_freed_objects, total_freed_objects(objspace));
     SET(malloc_increase_bytes, gc_malloc_counters_increase_unsigned(objspace, &objspace->malloc_counters.counters));
     SET(malloc_increase_bytes_limit, malloc_limit);
     SET(minor_gc_count, objspace->profile.minor_gc_count);
@@ -7715,6 +7713,12 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(oldmalloc_increase_bytes, gc_malloc_counters_increase_unsigned(objspace, &objspace->malloc_counters.oldcounters));
     SET(oldmalloc_increase_bytes_limit, objspace->rgengc.oldmalloc_increase_limit);
 #endif
+
+    SET(heap_available_slots, objspace_available_slots(objspace));
+    SET(heap_live_slots, objspace_live_slots(objspace));
+    SET(heap_free_slots, objspace_free_slots(objspace));
+    SET(heap_final_slots, total_final_slots_count(objspace));
+    SET(heap_marked_slots, objspace->marked_slots);
 
 #if RGENGC_PROFILE
     SET(total_generated_normal_object_count, objspace->profile.total_generated_normal_object_count);

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -7550,6 +7550,8 @@ enum gc_stat_sym {
     gc_stat_sym_total_freed_pages,
     gc_stat_sym_total_allocated_objects,
     gc_stat_sym_total_freed_objects,
+    gc_stat_sym_total_malloc_bytes,
+    gc_stat_sym_total_free_bytes,
     gc_stat_sym_malloc_increase_bytes,
     gc_stat_sym_malloc_increase_bytes_limit,
     gc_stat_sym_minor_gc_count,
@@ -7600,6 +7602,8 @@ setup_gc_stat_symbols(void)
         S(total_freed_pages);
         S(total_allocated_objects);
         S(total_freed_objects);
+        S(total_malloc_bytes);
+        S(total_free_bytes);
         S(malloc_increase_bytes);
         S(malloc_increase_bytes_limit);
         S(minor_gc_count);
@@ -7661,6 +7665,11 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
         return SIZET2NUM(attr); \
     else if (hash != Qnil) \
         rb_hash_aset(hash, gc_stat_symbols[gc_stat_sym_##name], SIZET2NUM(attr));
+#define SET64(name, attr) \
+    if (key == gc_stat_symbols[gc_stat_sym_##name]) \
+        return ULL2NUM(attr); \
+    else if (hash != Qnil) \
+        rb_hash_aset(hash, gc_stat_symbols[gc_stat_sym_##name], ULL2NUM(attr));
 
     SET(count, objspace->profile.count);
     SET(time, (size_t)ns_to_ms(objspace->profile.marking_time_ns + objspace->profile.sweeping_time_ns)); // TODO: UINT64T2NUM
@@ -7681,6 +7690,16 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(total_freed_pages, objspace->heap_pages.freed_pages);
     SET(total_allocated_objects, total_allocated_objects(objspace));
     SET(total_freed_objects, total_freed_objects(objspace));
+    {
+        /* Monotonic totals; snapshot the pair under one lock so they're
+         * consistent with each other on 32-bit. */
+        MALLOC_COUNTERS_LOCK(objspace);
+        uint64_t total_malloc = objspace->malloc_counters.counters.malloc;
+        uint64_t total_free   = objspace->malloc_counters.counters.free;
+        MALLOC_COUNTERS_UNLOCK(objspace);
+        SET64(total_malloc_bytes, total_malloc);
+        SET64(total_free_bytes, total_free);
+    }
     SET(malloc_increase_bytes, gc_malloc_counters_increase_unsigned(objspace, &objspace->malloc_counters.counters));
     SET(malloc_increase_bytes_limit, malloc_limit);
     SET(minor_gc_count, objspace->profile.minor_gc_count);
@@ -7706,6 +7725,7 @@ rb_gc_impl_stat(void *objspace_ptr, VALUE hash_or_sym)
     SET(total_remembered_shady_object_count, objspace->profile.total_remembered_shady_object_count);
 #endif /* RGENGC_PROFILE */
 #undef SET
+#undef SET64
 
     if (!NIL_P(key)) {
         // Matched key should return above

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -496,18 +496,10 @@ enum gc_mode {
     gc_mode_compacting,
 };
 
-#if SIZEOF_SIZE_T >= 8
-typedef size_t gc_counter_t;
-#else
-typedef RBIMPL_ALIGNAS(8) uint64_t gc_counter_t;
-#endif
+typedef rbimpl_atomic_uint64_t gc_counter_t;
 
-#if SIZEOF_SIZE_T >= 8
-# define MALLOC_COUNTERS_ATOMIC_NATIVE 1
-#elif defined(HAVE_GCC_ATOMIC_BUILTINS_64) || defined(_WIN32) || \
-      (defined(__sun) && defined(HAVE_ATOMIC_H) && (defined(_LP64) || defined(_I32LPx)))
-# define MALLOC_COUNTERS_ATOMIC_U64 1
-#else
+#if !defined(HAVE_GCC_ATOMIC_BUILTINS_64) && !defined(_WIN32) && \
+    !(defined(__sun) && defined(HAVE_ATOMIC_H) && (defined(_LP64) || defined(_I32LPx)))
 # define MALLOC_COUNTERS_NEED_LOCK 1
 #endif
 
@@ -985,42 +977,40 @@ RVALUE_AGE_SET(VALUE obj, int age)
 static inline void
 gc_counter_add(gc_counter_t *p, size_t delta)
 {
-#if defined(MALLOC_COUNTERS_ATOMIC_NATIVE)
-    RUBY_ATOMIC_SIZE_ADD(*p, delta);
-#elif defined(MALLOC_COUNTERS_ATOMIC_U64)
-    rbimpl_atomic_u64_fetch_add_relaxed((volatile rbimpl_atomic_uint64_t *)p, (uint64_t)delta);
-#else
+#ifdef MALLOC_COUNTERS_NEED_LOCK
     *p += (gc_counter_t)delta;
+#else
+    rbimpl_atomic_u64_fetch_add_relaxed(p, (uint64_t)delta);
 #endif
 }
 
 static inline gc_counter_t
 gc_counter_load_relaxed(const gc_counter_t *p)
 {
-#if defined(MALLOC_COUNTERS_ATOMIC_U64)
-    return (gc_counter_t)rbimpl_atomic_u64_load_relaxed((const volatile rbimpl_atomic_uint64_t *)p);
-#else
+#ifdef MALLOC_COUNTERS_NEED_LOCK
     return *p;
+#else
+    return rbimpl_atomic_u64_load_relaxed(p);
 #endif
 }
 
 static inline gc_counter_t
 gc_counter_load_acquire(const gc_counter_t *p)
 {
-#if defined(MALLOC_COUNTERS_ATOMIC_U64)
-    return (gc_counter_t)rbimpl_atomic_u64_load_acquire((const volatile rbimpl_atomic_uint64_t *)p);
-#else
+#ifdef MALLOC_COUNTERS_NEED_LOCK
     return *p;
+#else
+    return rbimpl_atomic_u64_load_acquire(p);
 #endif
 }
 
 static inline void
 gc_counter_store_release(gc_counter_t *p, gc_counter_t v)
 {
-#if defined(MALLOC_COUNTERS_ATOMIC_U64)
-    rbimpl_atomic_u64_set_release((volatile rbimpl_atomic_uint64_t *)p, (uint64_t)v);
-#else
+#ifdef MALLOC_COUNTERS_NEED_LOCK
     *p = v;
+#else
+    rbimpl_atomic_u64_set_release(p, v);
 #endif
 }
 

--- a/imemo.c
+++ b/imemo.c
@@ -129,6 +129,7 @@ VALUE
 rb_imemo_cdhash_new(size_t size, const struct st_hash_type *type)
 {
     struct rb_imemo_cdhash *memo = IMEMO_NEW(struct rb_imemo_cdhash, imemo_cdhash, 0);
+    memo->tbl.num_entries = 0;
     st_init_existing_table_with_size(&memo->tbl, type, size);
     return (VALUE)memo;
 }

--- a/ruby_atomic.h
+++ b/ruby_atomic.h
@@ -70,4 +70,44 @@ rbimpl_atomic_u64_set_relaxed(volatile rbimpl_atomic_uint64_t *address, uint64_t
 }
 #define ATOMIC_U64_SET_RELAXED(var, val) rbimpl_atomic_u64_set_relaxed(&(var), val)
 
+static inline uint64_t
+rbimpl_atomic_u64_fetch_add_relaxed(volatile rbimpl_atomic_uint64_t *value, uint64_t addend)
+{
+#if defined(HAVE_GCC_ATOMIC_BUILTINS_64)
+    return __atomic_fetch_add(value, addend, __ATOMIC_RELAXED);
+#elif defined(_WIN32)
+    return (uint64_t)InterlockedExchangeAdd64((LONG64 *)value, (LONG64)addend);
+#elif defined(__sun) && defined(HAVE_ATOMIC_H) && (defined(_LP64) || defined(_I32LPx))
+    return atomic_add_64_nv(value, addend) - addend;
+#else
+    // TODO: stdatomic
+    uint64_t prev = *value;
+    *value = prev + addend;
+    return prev;
+#endif
+}
+#define ATOMIC_U64_FETCH_ADD_RELAXED(var, val) rbimpl_atomic_u64_fetch_add_relaxed(&(var), val)
+
+static inline uint64_t
+rbimpl_atomic_u64_load_acquire(const volatile rbimpl_atomic_uint64_t *value)
+{
+#if defined(HAVE_GCC_ATOMIC_BUILTINS_64)
+    return __atomic_load_n(value, __ATOMIC_ACQUIRE);
+#else
+    return rbimpl_atomic_u64_load_relaxed(value);
+#endif
+}
+#define ATOMIC_U64_LOAD_ACQUIRE(var) rbimpl_atomic_u64_load_acquire(&(var))
+
+static inline void
+rbimpl_atomic_u64_set_release(volatile rbimpl_atomic_uint64_t *address, uint64_t value)
+{
+#if defined(HAVE_GCC_ATOMIC_BUILTINS_64)
+    __atomic_store_n(address, value, __ATOMIC_RELEASE);
+#else
+    rbimpl_atomic_u64_set_relaxed(address, value);
+#endif
+}
+#define ATOMIC_U64_SET_RELEASE(var, val) rbimpl_atomic_u64_set_release(&(var), val)
+
 #endif


### PR DESCRIPTION
This PR replaces the single `objspace->malloc_counters.{increase,oldmalloc_increase}` `size_t` fields with pairs of monotonically-increasing counters. 

Snapshots of these counters are taken at each GC, so that the live malloc_increase is computed as

        (malloc - malloc_at_last_gc) - (free - free_at_last_gc)

We update the baselines at each GC. Minor GC's update `malloc` and `free` associated with young objects only (counters). Major GC's update based on "oldcounters" as well.

The malloc/free counters are 64 bits wide which should provide ample headroom (~9 exabytes!). We use `size_t` on 64-bit and `uint64_t` on 32-bit, wrapped by a `gc_counter_t` struct.

However, because updating a `uint64_t` is a multi-instruction operation on 32 bit, we have to introduce a lock to the `malloc_counters` struct to avoid racing.

We introduced 2 new macros `MALLOC_COUNTERS_LOCK` and `MALLOC_COUNTERS_UNLOCK` that use `rb_nativethread_lock_t`.

The lock is initialized in `rb_gc_impl_objspace_init` and destroyed in `rb_gc_impl_objspace_free`. We chose this because it mirrors existing finalizer_lock pattern in wbcheck.

On 64 bit platforms aligned 64 bit loads are atomic, and writes are already using `RUBY_ATOMIC_SIZE_ADD` so the locks are not needed and the macros do nothing.

## Benchmarks

8 years ago, Eric Wong implemented a change like this in [Bug 14767](https://bugs.ruby-lang.org/issues/14767) but reverted it shortly after due to performance and RSS concerns in some benchmarks. Given that this patch touches the allocation fast path it's important to make sure that we haven't regressed behaviour or RSS.

This patch does not replicate the benchmark regressions seen in the original patch. Instead we show a consistent (but small) improvement over the base commit in all the benchmarks tested during the original ticket.

```
ubuntu@ip-172-31-42-127:~/ruby$ taskset -c 1 make benchmark ARGS=benchmark/array_sample* COMPARE_RUBY=$HOME/.rubies/ruby-master-fast/bin/ruby
/usr/bin/ruby --disable=gems -rrubygems -I./benchmark/lib ./benchmark/benchmark-driver/exe/benchmark-driver \
            --executables="compare-ruby::/home/ubuntu/.rubies/ruby-master-fast/bin/ruby -I.ext/common --disable-gem" \
            --executables="built-ruby::./miniruby -I./lib -I. -I.ext/common  ./tool/runruby.rb --extout=.ext  -- --disable-gems --disable-gem" \
            --output=markdown --output-compare -v benchmark/array_sample*
compare-ruby: ruby 4.1.0dev (2026-05-14T09:26:58Z master 69857ea9d8) +PRISM [x86_64-linux]
built-ruby: ruby 4.1.0dev (2026-05-14T22:54:52Z mvh-monotonic-coun.. d8e8aaca26) +PRISM [x86_64-linux]
warming up..
# Iteration per second (i/s)

|                         |compare-ruby|built-ruby|
|:------------------------|-----------:|---------:|
|ary.sample               |     21.202M|   21.420M|
|                         |           -|     1.01x|
|ary.sample(2)            |      5.542M|    5.601M|
|                         |           -|     1.01x|
|array_sample_100k_10     |     101.821|   103.691|
|                         |           -|     1.02x|
|array_sample_100k_11     |      76.301|    77.411|
|                         |           -|     1.01x|
|array_sample_100k__100   |      13.628|    13.956|
|                         |           -|     1.02x|
|array_sample_100k__1k    |       1.416|     1.442|
|                         |           -|     1.02x|
|array_sample_100k__6k    |       0.420|     0.434|
|                         |           -|     1.03x|
|array_sample_100k___10k  |       0.289|     0.296|
|                         |           -|     1.02x|
|array_sample_100k___50k  |       0.075|     0.076|
|                         |           -|     1.00x|
```

We also ran the Headline benchmarks from the ruby-bench suite:

```
master: ruby 4.1.0dev (2026-05-14T09:26:58Z master 69857ea9d8) +YJIT +PRISM [x86_64-linux]
experiment: ruby 4.1.0dev (2026-05-14T22:54:52Z mvh-monotonic-coun.. d8e8aaca26) +YJIT +PRISM [x86_64-linux]

--------------  -------------  ---------  ---------------  ---------  ------------------  -----------------  ---------------------
bench             master (ms)  RSS (MiB)  experiment (ms)  RSS (MiB)  experiment 1st itr  master/experiment  RSS master/experiment
activerecord     148.6 ± 7.1%       84.7     147.1 ± 7.7%       86.2               1.003              1.010                  0.983
chunky-png       614.9 ± 0.1%       72.9     611.6 ± 0.1%       81.0               1.004              1.005                  0.900
erubi-rails      940.5 ± 2.0%      124.8     916.1 ± 3.4%      124.6               0.988              1.027                  1.001
hexapdf         1803.5 ± 3.6%      213.4    1768.4 ± 3.2%      191.1               0.977              1.020                  1.116
liquid-c          57.1 ± 7.1%       66.5      57.5 ± 6.7%       67.5               1.014              0.993                  0.985
liquid-compile    45.9 ± 9.1%       48.7      46.2 ± 8.0%       48.6               1.002              0.994                  1.002
liquid-render     76.7 ± 5.2%       60.2      78.3 ± 4.9%       58.0               1.002              0.980                  1.037
lobsters         837.8 ± 1.4%      351.5     843.1 ± 3.2%      334.4               0.936              0.994                  1.051
mail             114.3 ± 4.6%       65.5     114.9 ± 4.6%       67.2               1.004              0.994                  0.976
psych-load      1636.0 ± 1.4%       32.5    1642.3 ± 1.3%       32.3               0.997              0.996                  1.005
railsbench      1615.0 ± 0.1%      134.2    1626.6 ± 1.1%      139.0               0.998              0.993                  0.966
rubocop         148.0 ± 15.1%      140.8    146.4 ± 15.5%      139.8               1.000              1.011                  1.007
ruby-lsp         142.1 ± 3.1%       71.7     143.2 ± 2.6%       72.8               1.018              0.993                  0.985
sequel            63.5 ± 0.9%       45.9      63.5 ± 5.1%       52.5               0.978              0.999                  0.874
shipit          1234.3 ± 1.7%      196.5    1201.6 ± 3.3%      192.5               1.037              1.027                  1.021
--------------  -------------  ---------  ---------------  ---------  ------------------  -----------------  ---------------------

Legend:
- experiment 1st itr: ratio of master/experiment time for the first benchmarking iteration.
- master/experiment: ratio of master/experiment time. Higher is better for experiment. Above 1 represents a speedup.
- RSS master/experiment: ratio of master/experiment RSS. Higher is better for experiment. Above 1 means lower memory usage.
```

These results show small statistically insignificant changes in both directions. None are consistently outside the margin of error.

For example: 
 
- Apparent wins: shipit 1.037, erubi-rails 1.027, hexapdf 1.020. However variance is ±1.7-3.6%, so all comfortably inside noise.
 - Apparent losses: liquid-render 0.980, raisbench 0.993, but a 1.1% variance
 - rubocop ±15.1%/15.5% variance, so again, the 0.7% regression is noise. 
 
 Median ratio is ~1.0. No benchmark shows a regression that's both directional and outside its own stderr.
