### PR TITLE
Replace subclasses linked list with weakref array

### DIFF
--- a/class.c
+++ b/class.c
@@ -80,10 +80,6 @@
 #define METACLASS_OF(k) RBASIC(k)->klass
 #define SET_METACLASS_OF(k, cls) RBASIC_SET_CLASS(k, cls)
 
-static void rb_class_remove_from_super_subclasses(VALUE klass);
-static void rb_class_remove_from_module_subclasses(VALUE klass);
-static void rb_class_classext_free_subclasses(rb_classext_t *ext);
-
 rb_classext_t *
 rb_class_unlink_classext(VALUE klass, const rb_box_t *box)
 {
@@ -103,11 +99,6 @@ rb_class_classext_free(VALUE klass, rb_classext_t *ext, bool is_prime)
 
     if (!RCLASSEXT_SHARED_CONST_TBL(ext) && (tbl = RCLASSEXT_CONST_TBL(ext)) != NULL) {
         rb_free_const_table(tbl);
-    }
-
-    if (is_prime) {
-        rb_class_remove_from_super_subclasses(klass);
-        rb_class_classext_free_subclasses(ext);
     }
 
     if (RCLASSEXT_SUPERCLASSES_WITH_SELF(ext)) {
@@ -134,11 +125,6 @@ rb_iclass_classext_free(VALUE klass, rb_classext_t *ext, bool is_prime)
 
     if (RCLASSEXT_CALLABLE_M_TBL(ext) != NULL) {
         rb_id_table_free(RCLASSEXT_CALLABLE_M_TBL(ext));
-    }
-
-    if (is_prime) {
-        rb_class_remove_from_super_subclasses(klass);
-        rb_class_remove_from_module_subclasses(klass);
     }
 
     if (!is_prime) { // the prime classext will be freed with RClass
@@ -406,23 +392,25 @@ rb_class_duplicate_classext(rb_classext_t *orig, VALUE klass, const rb_box_t *bo
          *
          * Subclasses are only in the prime classext, so read from orig.
          */
-        rb_subclass_entry_t *subclass_entry = RCLASSEXT_SUBCLASSES(orig);
-        if (subclass_entry) subclass_entry = subclass_entry->next; // skip dummy head
-        while (subclass_entry) {
-            VALUE iclass = subclass_entry->klass;
+        VALUE subs_v = RCLASSEXT_SUBCLASSES(orig);
+        if (subs_v) {
+            struct rb_subclasses *subs = (struct rb_subclasses *)subs_v;
+            VALUE *entries = rb_imemo_subclasses_entries(subs_v);
+            for (uint32_t i = 0; i < subs->count; i++) {
+                VALUE iclass = entries[i];
+                if (!iclass) continue;
 
-            /* every node in the subclass list should be an ICLASS built from this module */
-            VM_ASSERT(iclass);
-            VM_ASSERT(RB_TYPE_P(iclass, T_ICLASS));
-            VM_ASSERT(RBASIC_CLASS(iclass) == klass);
+                /* every node in the subclass list should be an ICLASS built from this module */
+                VM_ASSERT(RB_TYPE_P(iclass, T_ICLASS));
+                VM_ASSERT(RBASIC_CLASS(iclass) == klass);
 
-            if (FL_TEST_RAW(iclass, RCLASS_BOXABLE)) {
-                // Non-boxable ICLASSes (included by classes in main/user boxes) can't
-                // hold per-box classexts, and their includer classes also can't, so
-                // method lookup through them always uses the prime classext.
-                class_duplicate_iclass_classext(iclass, ext, box);
+                if (FL_TEST_RAW(iclass, RCLASS_BOXABLE)) {
+                    // Non-boxable ICLASSes (included by classes in main/user boxes) can't
+                    // hold per-box classexts, and their includer classes also can't, so
+                    // method lookup through them always uses the prime classext.
+                    class_duplicate_iclass_classext(iclass, ext, box);
+                }
             }
-            subclass_entry = subclass_entry->next;
         }
     }
 
@@ -481,36 +469,47 @@ rb_class_variation_count(VALUE klass)
     return RCLASS_VARIATION_COUNT(klass);
 }
 
-static rb_subclass_entry_t *
+static void
 push_subclass_entry_to_list(VALUE super, VALUE klass)
 {
-    rb_subclass_entry_t *entry, *head;
-
     RUBY_ASSERT(
             (RB_TYPE_P(super, T_MODULE) && RB_TYPE_P(klass, T_ICLASS)) ||
             (RB_TYPE_P(super, T_CLASS) && RB_TYPE_P(klass, T_CLASS)) ||
             (RB_TYPE_P(klass, T_ICLASS) && !NIL_P(RCLASS_REFINED_CLASS(klass)))
             );
 
-    entry = ZALLOC(rb_subclass_entry_t);
-    entry->klass = klass;
-
     RB_VM_LOCKING() {
-        head = RCLASS_WRITABLE_SUBCLASSES(super);
-        if (!head) {
-            head = ZALLOC(rb_subclass_entry_t);
-            RCLASS_SET_SUBCLASSES(super, head);
-        }
-        entry->next = head->next;
-        entry->prev = head;
+        VALUE subs_v = RCLASS_SUBCLASSES(super);
+        struct rb_subclasses *subs = (struct rb_subclasses *)subs_v;
 
-        if (head->next) {
-            head->next->prev = entry;
+        if (!subs || subs->count == subs->capacity) {
+            VALUE *old_entries = subs ? rb_imemo_subclasses_entries(subs_v) : NULL;
+            uint32_t live = 0;
+            for (uint32_t i = 0; subs && i < subs->count; i++) {
+                if (old_entries[i]) live++;
+            }
+
+            uint32_t cap = subs ? subs->capacity : 2;
+            if (live * 2 >= cap) cap *= 2;
+
+            VALUE new_v = rb_imemo_subclasses_new(cap);
+            struct rb_subclasses *new_subs = (struct rb_subclasses *)new_v;
+            VALUE *new_entries = rb_imemo_subclasses_entries(new_v);
+            for (uint32_t i = 0; subs && i < subs->count; i++) {
+                VALUE entry = old_entries[i];
+                if (entry) {
+                    new_entries[new_subs->count++] = entry;
+                    RB_OBJ_WRITTEN(new_v, Qundef, entry);
+                }
+            }
+            RCLASS_SET_SUBCLASSES(super, new_v);
+            subs_v = new_v;
+            subs = new_subs;
         }
-        head->next = entry;
+
+        rb_imemo_subclasses_entries(subs_v)[subs->count++] = klass;
+        RB_OBJ_WRITTEN(subs_v, Qundef, klass);
     }
-
-    return entry;
 }
 
 void
@@ -519,8 +518,7 @@ rb_class_subclass_add(VALUE super, VALUE klass)
     if (super && !UNDEF_P(super)) {
         RUBY_ASSERT(RB_TYPE_P(super, T_CLASS) || RB_TYPE_P(super, T_MODULE));
         RUBY_ASSERT(RB_TYPE_P(klass, T_CLASS) || RB_TYPE_P(klass, T_ICLASS));
-        rb_subclass_entry_t *entry = push_subclass_entry_to_list(super, klass);
-        RCLASS_EXT_PRIME(klass)->subclass_entry = entry;
+        push_subclass_entry_to_list(super, klass);
     }
 }
 
@@ -530,112 +528,32 @@ rb_module_add_to_subclasses_list(VALUE module, VALUE iclass)
     if (module && !UNDEF_P(module)) {
         RUBY_ASSERT(RB_TYPE_P(module, T_MODULE));
         RUBY_ASSERT(RB_TYPE_P(iclass, T_ICLASS));
-        rb_subclass_entry_t *entry = push_subclass_entry_to_list(module, iclass);
-        RCLASS_EXT_PRIME(iclass)->module_subclass_entry = entry;
-    }
-}
-
-static void
-rb_subclass_entry_remove(rb_subclass_entry_t *entry)
-{
-    if (entry) {
-        rb_subclass_entry_t *prev = entry->prev, *next = entry->next;
-
-        if (prev) {
-            prev->next = next;
-        }
-        if (next) {
-            next->prev = prev;
-        }
-
-        xfree(entry);
-    }
-}
-
-static void
-rb_class_remove_from_super_subclasses(VALUE klass)
-{
-    rb_classext_t *ext = RCLASS_EXT_PRIME(klass);
-    rb_subclass_entry_t *entry = RCLASSEXT_SUBCLASS_ENTRY(ext);
-
-    if (!entry) return;
-    rb_subclass_entry_remove(entry);
-    RCLASSEXT_SUBCLASS_ENTRY(ext) = NULL;
-}
-
-static void
-rb_class_remove_from_module_subclasses(VALUE klass)
-{
-    rb_classext_t *ext = RCLASS_EXT_PRIME(klass);
-    rb_subclass_entry_t *entry = RCLASSEXT_MODULE_SUBCLASS_ENTRY(ext);
-
-    if (!entry) return;
-    rb_subclass_entry_remove(entry);
-    RCLASSEXT_MODULE_SUBCLASS_ENTRY(ext) = NULL;
-}
-
-static void
-rb_class_classext_free_subclasses(rb_classext_t *ext)
-{
-    rb_subclass_entry_t *head = RCLASSEXT_SUBCLASSES(ext);
-
-    if (head) {
-        // Detach all children's back-pointers before freeing the list,
-        // so they don't try to unlink from a freed entry later.
-        rb_subclass_entry_t *entry = head->next; // skip dummy head
-        while (entry) {
-            if (entry->klass) {
-                rb_classext_t *child_ext = RCLASS_EXT_PRIME(entry->klass);
-                if (RCLASSEXT_SUBCLASS_ENTRY(child_ext) == entry) {
-                    RCLASSEXT_SUBCLASS_ENTRY(child_ext) = NULL;
-                }
-                if (RCLASSEXT_MODULE_SUBCLASS_ENTRY(child_ext) == entry) {
-                    RCLASSEXT_MODULE_SUBCLASS_ENTRY(child_ext) = NULL;
-                }
-            }
-            entry = entry->next;
-        }
-
-        entry = head;
-        while (entry) {
-            rb_subclass_entry_t *next = entry->next;
-            xfree(entry);
-            entry = next;
-        }
-        RCLASSEXT_SUBCLASSES(ext) = NULL;
+        push_subclass_entry_to_list(module, iclass);
     }
 }
 
 void
 rb_class_foreach_subclass(VALUE klass, void (*f)(VALUE, VALUE), VALUE arg)
 {
-    rb_subclass_entry_t *tmp;
-    rb_subclass_entry_t *cur = RCLASS_SUBCLASSES_FIRST(klass);
-    /* do not be tempted to simplify this loop into a for loop, the order of
-       operations is important here if `f` modifies the linked list */
-    while (cur) {
-        VALUE curklass = cur->klass;
-        tmp = cur->next;
-        // do not trigger GC during f, otherwise the cur will become
-        // a dangling pointer if the subclass is collected
-        f(curklass, arg);
-        cur = tmp;
-    }
-}
+    VALUE subs_v = RCLASS_SUBCLASSES(klass);
+    if (!subs_v) return;
 
-static void
-class_detach_subclasses(VALUE klass, VALUE arg)
-{
-    rb_class_remove_from_super_subclasses(klass);
+    struct rb_subclasses *subs = (struct rb_subclasses *)subs_v;
+    VALUE *entries = rb_imemo_subclasses_entries(subs_v);
+    for (uint32_t i = 0; i < subs->count; i++) {
+        VALUE curklass = entries[i];
+        if (curklass) {
+            f(curklass, arg);
+        }
+    }
 }
 
 static void
 class_switch_superclass(VALUE super, VALUE klass)
 {
-    RB_VM_LOCKING() {
-        class_detach_subclasses(klass, Qnil);
-        rb_class_subclass_add(super, klass);
-    }
+    // No need to remove from old super's subclasses list — the GC
+    // will nullify the weak reference when appropriate.
+    rb_class_subclass_add(super, klass);
 }
 
 /**
@@ -1695,29 +1613,34 @@ rb_include_module(VALUE klass, VALUE module)
         rb_raise(rb_eArgError, "cyclic include detected");
 
     if (RB_TYPE_P(klass, T_MODULE)) {
-        rb_subclass_entry_t *iclass = RCLASS_SUBCLASSES_FIRST(klass);
-        while (iclass) {
-            int do_include = 1;
-            VALUE check_class = iclass->klass;
-            /* During lazy sweeping, iclass->klass could be a dead object that
-             * has not yet been swept. */
-            if (!rb_objspace_garbage_object_p(check_class)) {
-                while (check_class) {
-                    RUBY_ASSERT(!rb_objspace_garbage_object_p(check_class));
+        VALUE subs_v = RCLASS_SUBCLASSES(klass);
+        if (subs_v) {
+            struct rb_subclasses *subs = (struct rb_subclasses *)subs_v;
+            VALUE *entries = rb_imemo_subclasses_entries(subs_v);
+            for (uint32_t i = 0; i < subs->count; i++) {
+                VALUE check_class = entries[i];
+                if (!check_class) continue;
 
-                    if (RB_TYPE_P(check_class, T_ICLASS) &&
-                            (METACLASS_OF(check_class) == module)) {
-                        do_include = 0;
+                int do_include = 1;
+                /* During lazy sweeping, the entry could be a dead object that
+                 * has not yet been swept. */
+                if (!rb_objspace_garbage_object_p(check_class)) {
+                    VALUE walk = check_class;
+                    while (walk) {
+                        RUBY_ASSERT(!rb_objspace_garbage_object_p(walk));
+
+                        if (RB_TYPE_P(walk, T_ICLASS) &&
+                                (METACLASS_OF(walk) == module)) {
+                            do_include = 0;
+                        }
+                        walk = RCLASS_SUPER(walk);
                     }
-                    check_class = RCLASS_SUPER(check_class);
-                }
 
-                if (do_include) {
-                    include_modules_at(iclass->klass, RCLASS_ORIGIN(iclass->klass), module, TRUE);
+                    if (do_include) {
+                        include_modules_at(check_class, RCLASS_ORIGIN(check_class), module, TRUE);
+                    }
                 }
             }
-
-            iclass = iclass->next;
         }
     }
 }
@@ -1950,29 +1873,32 @@ rb_prepend_module(VALUE klass, VALUE module)
         rb_vm_check_redefinition_by_prepend(klass);
     }
     if (RB_TYPE_P(klass, T_MODULE)) {
-        rb_subclass_entry_t *iclass = RCLASS_SUBCLASSES_FIRST(klass);
+        VALUE subs_v = RCLASS_SUBCLASSES(klass);
         VALUE klass_origin = RCLASS_ORIGIN(klass);
         struct rb_id_table *klass_m_tbl = RCLASS_M_TBL(klass);
         struct rb_id_table *klass_origin_m_tbl = RCLASS_M_TBL(klass_origin);
-        while (iclass) {
-            /* During lazy sweeping, iclass->klass could be a dead object that
-             * has not yet been swept. */
-            if (!rb_objspace_garbage_object_p(iclass->klass)) {
-                const VALUE subclass = iclass->klass;
-                if (klass_had_no_origin && klass_origin_m_tbl == RCLASS_M_TBL(subclass)) {
-                    // backfill an origin iclass to handle refinements and future prepends
-                    rb_id_table_foreach(RCLASS_M_TBL(subclass), clear_module_cache_i, (void *)subclass);
-                    RCLASS_WRITE_M_TBL(subclass, klass_m_tbl);
-                    VALUE origin = rb_include_class_new(klass_origin, RCLASS_SUPER(subclass));
-                    rb_class_set_super(subclass, origin);
-                    RCLASS_SET_INCLUDER(origin, RCLASS_INCLUDER(subclass));
-                    RCLASS_WRITE_ORIGIN(subclass, origin);
-                    RICLASS_SET_ORIGIN_SHARED_MTBL(origin);
+        if (subs_v) {
+            struct rb_subclasses *subs = (struct rb_subclasses *)subs_v;
+            VALUE *entries = rb_imemo_subclasses_entries(subs_v);
+            for (uint32_t i = 0; i < subs->count; i++) {
+                const VALUE subclass = entries[i];
+                if (!subclass) continue;
+                /* During lazy sweeping, the entry could be a dead object that
+                 * has not yet been swept. */
+                if (!rb_objspace_garbage_object_p(subclass)) {
+                    if (klass_had_no_origin && klass_origin_m_tbl == RCLASS_M_TBL(subclass)) {
+                        // backfill an origin iclass to handle refinements and future prepends
+                        rb_id_table_foreach(RCLASS_M_TBL(subclass), clear_module_cache_i, (void *)subclass);
+                        RCLASS_WRITE_M_TBL(subclass, klass_m_tbl);
+                        VALUE origin = rb_include_class_new(klass_origin, RCLASS_SUPER(subclass));
+                        rb_class_set_super(subclass, origin);
+                        RCLASS_SET_INCLUDER(origin, RCLASS_INCLUDER(subclass));
+                        RCLASS_WRITE_ORIGIN(subclass, origin);
+                        RICLASS_SET_ORIGIN_SHARED_MTBL(origin);
+                    }
+                    include_modules_at(subclass, subclass, module, FALSE);
                 }
-                include_modules_at(subclass, subclass, module, FALSE);
             }
-
-            iclass = iclass->next;
         }
     }
 }

--- a/ext/objspace/objspace.c
+++ b/ext/objspace/objspace.c
@@ -459,6 +459,7 @@ count_imemo_objects(int argc, VALUE *argv, VALUE self)
         INIT_IMEMO_TYPE_ID(imemo_callcache);
         INIT_IMEMO_TYPE_ID(imemo_constcache);
         INIT_IMEMO_TYPE_ID(imemo_fields);
+        INIT_IMEMO_TYPE_ID(imemo_subclasses);
 #undef INIT_IMEMO_TYPE_ID
     }
 

--- a/gc.c
+++ b/gc.c
@@ -1294,13 +1294,28 @@ rb_gc_handle_weak_references(VALUE obj)
         break;
 
       case T_IMEMO: {
-        GC_ASSERT(imemo_type(obj) == imemo_callcache);
-
-        struct rb_callcache *cc = (struct rb_callcache *)obj;
-        if (cc->klass != Qundef &&
-            (!rb_gc_handle_weak_references_alive_p(cc->klass) ||
-             !rb_gc_handle_weak_references_alive_p((VALUE)cc->cme_))) {
-            vm_cc_invalidate(cc);
+        switch (imemo_type(obj)) {
+          case imemo_callcache: {
+            struct rb_callcache *cc = (struct rb_callcache *)obj;
+            if (cc->klass != Qundef &&
+                (!rb_gc_handle_weak_references_alive_p(cc->klass) ||
+                 !rb_gc_handle_weak_references_alive_p((VALUE)cc->cme_))) {
+                vm_cc_invalidate(cc);
+            }
+            break;
+          }
+          case imemo_subclasses: {
+            struct rb_subclasses *subs = (struct rb_subclasses *)obj;
+            VALUE *entries = rb_imemo_subclasses_entries(obj);
+            for (uint32_t i = 0; i < subs->count; i++) {
+                if (entries[i] && !rb_gc_handle_weak_references_alive_p(entries[i])) {
+                    entries[i] = 0;
+                }
+            }
+            break;
+          }
+          default:
+            rb_bug("rb_gc_handle_weak_references: unexpected imemo type");
         }
 
         break;
@@ -1329,6 +1344,9 @@ rb_gc_imemo_needs_cleanup_p(VALUE obj)
       case imemo_iseq:
       case imemo_callinfo:
         return true;
+
+      case imemo_subclasses:
+        return FL_TEST_RAW(obj, IMEMO_SUBCLASSES_HEAP);
 
       case imemo_tmpbuf:
         return ((rb_imemo_tmpbuf_t *)obj)->ptr != NULL;
@@ -3333,6 +3351,9 @@ gc_mark_classext_module(rb_classext_t *ext, bool prime, VALUE box_value, void *a
     }
     mark_m_tbl(objspace, RCLASSEXT_CALLABLE_M_TBL(ext));
     gc_mark_internal(RCLASSEXT_CC_TBL(ext));
+    if (RCLASSEXT_SUBCLASSES(ext)) {
+        gc_mark_internal(RCLASSEXT_SUBCLASSES(ext));
+    }
     gc_mark_internal(RCLASSEXT_CLASSPATH(ext));
 }
 
@@ -3353,6 +3374,9 @@ gc_mark_classext_iclass(rb_classext_t *ext, bool prime, VALUE box_value, void *a
     }
     mark_m_tbl(objspace, RCLASSEXT_CALLABLE_M_TBL(ext));
     gc_mark_internal(RCLASSEXT_CC_TBL(ext));
+    if (RCLASSEXT_SUBCLASSES(ext)) {
+        gc_mark_internal(RCLASSEXT_SUBCLASSES(ext));
+    }
 }
 
 #define TYPED_DATA_REFS_OFFSET_LIST(d) (size_t *)(uintptr_t)RTYPEDDATA_TYPE(d)->function.dmark
@@ -3989,18 +4013,6 @@ update_const_tbl(void *objspace, struct rb_id_table *tbl)
 }
 
 static void
-update_subclasses(void *objspace, rb_classext_t *ext)
-{
-    rb_subclass_entry_t *entry = RCLASSEXT_SUBCLASSES(ext);
-    if (!entry) return;
-    while (entry) {
-        if (entry->klass)
-            UPDATE_IF_MOVED(objspace, entry->klass);
-        entry = entry->next;
-    }
-}
-
-static void
 update_superclasses(rb_objspace_t *objspace, rb_classext_t *ext)
 {
     if (RCLASSEXT_SUPERCLASSES_WITH_SELF(ext)) {
@@ -4041,7 +4053,9 @@ update_classext(rb_classext_t *ext, bool is_prime, VALUE box_value, void *arg)
     UPDATE_IF_MOVED(objspace, RCLASSEXT_CC_TBL(ext));
     UPDATE_IF_MOVED(objspace, RCLASSEXT_CVC_TBL(ext));
     update_superclasses(objspace, ext);
-    update_subclasses(objspace, ext);
+    if (RCLASSEXT_SUBCLASSES(ext)) {
+        UPDATE_IF_MOVED(objspace, RCLASSEXT_SUBCLASSES(ext));
+    }
 
     update_classext_values(objspace, ext, false);
 }
@@ -4059,7 +4073,9 @@ update_iclass_classext(rb_classext_t *ext, bool is_prime, VALUE box_value, void 
     update_m_tbl(objspace, RCLASSEXT_CALLABLE_M_TBL(ext));
     UPDATE_IF_MOVED(objspace, RCLASSEXT_CC_TBL(ext));
     UPDATE_IF_MOVED(objspace, RCLASSEXT_CVC_TBL(ext));
-    update_subclasses(objspace, ext);
+    if (RCLASSEXT_SUBCLASSES(ext)) {
+        UPDATE_IF_MOVED(objspace, RCLASSEXT_SUBCLASSES(ext));
+    }
 
     update_classext_values(objspace, ext, true);
 }

--- a/imemo.c
+++ b/imemo.c
@@ -31,6 +31,7 @@ rb_imemo_name(enum imemo_type type)
         IMEMO_NAME(tmpbuf);
         IMEMO_NAME(cvar_entry);
         IMEMO_NAME(fields);
+        IMEMO_NAME(subclasses);
 #undef IMEMO_NAME
     }
     rb_bug("unreachable");
@@ -215,6 +216,32 @@ rb_imemo_fields_clear(VALUE fields_obj)
     RBASIC_CLEAR_CLASS(fields_obj);
 }
 
+VALUE
+rb_imemo_subclasses_new(uint32_t capacity)
+{
+    size_t embed_size = offsetof(struct rb_subclasses, as) + capacity * sizeof(VALUE);
+    struct rb_subclasses *subs;
+
+    if (rb_gc_size_allocatable_p(embed_size)) {
+        subs = (struct rb_subclasses *)rb_imemo_new(imemo_subclasses, 0, embed_size, true);
+        subs->count = 0;
+        subs->capacity = capacity;
+        memset(subs->as.embed, 0, capacity * sizeof(VALUE));
+        rb_gc_declare_weak_references((VALUE)subs);
+    }
+    else {
+        subs = (struct rb_subclasses *)rb_imemo_new(imemo_subclasses, 0, sizeof(struct rb_subclasses), true);
+        subs->as.external = NULL;
+        subs->count = 0;
+        subs->capacity = 0;
+        FL_SET_RAW((VALUE)subs, IMEMO_SUBCLASSES_HEAP);
+        rb_gc_declare_weak_references((VALUE)subs);
+        subs->as.external = ZALLOC_N(VALUE, capacity);
+        subs->capacity = capacity;
+    }
+    return (VALUE)subs;
+}
+
 /* =========================================================================
  * memsize
  * ========================================================================= */
@@ -263,6 +290,13 @@ rb_imemo_memsize(VALUE obj)
             size += st_memsize(IMEMO_OBJ_FIELDS(obj)->as.complex.table);
         }
         break;
+      case imemo_subclasses: {
+        if (FL_TEST_RAW(obj, IMEMO_SUBCLASSES_HEAP)) {
+            struct rb_subclasses *subs = (struct rb_subclasses *)obj;
+            size += subs->capacity * sizeof(VALUE);
+        }
+        break;
+      }
       default:
         rb_bug("unreachable");
     }
@@ -506,6 +540,18 @@ rb_imemo_mark_and_move(VALUE obj, bool reference_updating)
           rb_gc_mark_and_move((VALUE *)&ent->cref);
           break;
       }
+      case imemo_subclasses: {
+        if (reference_updating) {
+            struct rb_subclasses *subs = (struct rb_subclasses *)obj;
+            VALUE *entries = rb_imemo_subclasses_entries(obj);
+            for (uint32_t i = 0; i < subs->count; i++) {
+                if (entries[i]) {
+                    entries[i] = rb_gc_location(entries[i]);
+                }
+            }
+        }
+        break;
+      }
       case imemo_fields: {
         rb_gc_mark_and_move((VALUE *)&RBASIC(obj)->klass);
 
@@ -641,6 +687,13 @@ rb_imemo_free(VALUE obj)
         imemo_fields_free(IMEMO_OBJ_FIELDS(obj));
         RB_DEBUG_COUNTER_INC(obj_imemo_fields);
         break;
+      case imemo_subclasses: {
+        if (FL_TEST_RAW(obj, IMEMO_SUBCLASSES_HEAP)) {
+            struct rb_subclasses *subs = (struct rb_subclasses *)obj;
+            SIZED_FREE_N(subs->as.external, subs->capacity);
+        }
+        break;
+      }
       default:
         rb_bug("unreachable");
     }

--- a/internal/class.h
+++ b/internal/class.h
@@ -27,13 +27,6 @@
 # undef RCLASS_SUPER
 #endif
 
-struct rb_subclass_entry {
-    VALUE klass;
-    struct rb_subclass_entry *next;
-    struct rb_subclass_entry *prev;
-};
-typedef struct rb_subclass_entry rb_subclass_entry_t;
-
 struct rb_cvar_class_tbl_entry {
     VALUE imemo_flags;
     uint32_t index;
@@ -54,21 +47,10 @@ struct rb_classext_struct {
     VALUE cvc_tbl;
     VALUE *superclasses;
     /**
-     * The head of the subclasses linked list. This is a dummy entry (klass == 0)
-     * whose `next` points to the first real entry. Only used in prime classext.
+     * imemo_subclasses VALUE tracking this class's subclasses.
+     * Only used in prime classext. Lazily allocated on first subclass addition.
      */
-    struct rb_subclass_entry *subclasses;
-    /**
-     * Back-pointer to this class's entry in its superclass's subclasses list.
-     * Used for O(1) removal when the class is freed.
-     */
-    struct rb_subclass_entry *subclass_entry;
-    /**
-     * In the case that this is an `ICLASS`, `module_subclass_entry` points to the
-     * entry in the module's `subclasses` list that indicates that the klass has been
-     * included. Used for O(1) removal.
-     */
-    struct rb_subclass_entry *module_subclass_entry;
+    VALUE subclasses;
 
     const VALUE origin_;
     const VALUE refined_class;
@@ -151,8 +133,6 @@ static inline rb_classext_t * RCLASS_EXT_WRITABLE(VALUE obj);
 #define RCLASSEXT_SUPERCLASS_DEPTH(ext) (ext->superclass_depth)
 #define RCLASSEXT_SUPERCLASSES(ext) (ext->superclasses)
 #define RCLASSEXT_SUBCLASSES(ext) (ext->subclasses)
-#define RCLASSEXT_SUBCLASS_ENTRY(ext) (ext->subclass_entry)
-#define RCLASSEXT_MODULE_SUBCLASS_ENTRY(ext) (ext->module_subclass_entry)
 #define RCLASSEXT_ORIGIN(ext) (ext->origin_)
 #define RCLASSEXT_REFINED_CLASS(ext) (ext->refined_class)
 // class.allocator/singleton_class.attached_object are not accessed directly via RCLASSEXT_*
@@ -190,7 +170,6 @@ static inline void RCLASSEXT_SET_INCLUDER(rb_classext_t *ext, VALUE klass, VALUE
  */
 #define RCLASS_CVC_TBL(c) (RCLASS_EXT_READABLE(c)->cvc_tbl)
 #define RCLASS_SUBCLASSES(c) (RCLASS_EXT_PRIME(c)->subclasses)
-#define RCLASS_SUBCLASSES_FIRST(c) (RCLASS_EXT_PRIME(c)->subclasses ? RCLASS_EXT_PRIME(c)->subclasses->next : NULL)
 #define RCLASS_ORIGIN(c) (RCLASS_EXT_READABLE(c)->origin_)
 #define RICLASS_IS_ORIGIN_P(c) (RCLASS_EXT_READABLE(c)->iclass_is_origin)
 #define RCLASS_PERMANENT_CLASSPATH_P(c) (RCLASS_EXT_READABLE(c)->permanent_classpath)
@@ -229,7 +208,7 @@ static inline void RCLASS_SET_CVC_TBL(VALUE klass, VALUE table);
 static inline void RCLASS_WRITE_CVC_TBL(VALUE klass, VALUE table);
 
 static inline void RCLASS_WRITE_SUPERCLASSES(VALUE klass, size_t depth, VALUE *superclasses, bool with_self);
-static inline void RCLASS_SET_SUBCLASSES(VALUE klass, rb_subclass_entry_t *head);
+static inline void RCLASS_SET_SUBCLASSES(VALUE klass, VALUE subclasses);
 
 static inline void RCLASS_SET_ORIGIN(VALUE klass, VALUE origin);
 static inline void RCLASS_WRITE_ORIGIN(VALUE klass, VALUE origin);
@@ -686,10 +665,10 @@ RCLASS_WRITE_SUPERCLASSES(VALUE klass, size_t depth, VALUE *superclasses, bool w
 }
 
 static inline void
-RCLASS_SET_SUBCLASSES(VALUE klass, rb_subclass_entry_t *head)
+RCLASS_SET_SUBCLASSES(VALUE klass, VALUE subclasses)
 {
     rb_classext_t *ext = RCLASS_EXT_PRIME(klass);
-    RCLASSEXT_SUBCLASSES(ext) = head;
+    RB_OBJ_WRITE(klass, &RCLASSEXT_SUBCLASSES(ext), subclasses);
 }
 
 static inline void

--- a/internal/imemo.h
+++ b/internal/imemo.h
@@ -42,6 +42,7 @@ enum imemo_type {
     imemo_callcache      = 11,
     imemo_constcache     = 12,
     imemo_fields         = 13,
+    imemo_subclasses     = 14,
 };
 
 /* CREF (Class REFerence) is defined in method.h */
@@ -249,7 +250,27 @@ STATIC_ASSERT(imemo_fields_complex_offset, offsetof(struct RObject, as.heap.fiel
 
 #define IMEMO_OBJ_FIELDS(fields) ((struct rb_fields *)fields)
 
+#define IMEMO_SUBCLASSES_HEAP IMEMO_FL_USER0
+
+struct rb_subclasses {
+    VALUE flags;
+    uint32_t count;
+    uint32_t capacity;
+    union {
+        VALUE *external;
+        VALUE embed[1];
+    } as;
+};
+
+static inline VALUE *
+rb_imemo_subclasses_entries(VALUE v)
+{
+    struct rb_subclasses *s = (struct rb_subclasses *)v;
+    return FL_TEST_RAW(v, IMEMO_SUBCLASSES_HEAP) ? s->as.external : s->as.embed;
+}
+
 VALUE rb_imemo_fields_new(VALUE owner, /* shape_id_t */ uint32_t shape_id, bool shareable);
+VALUE rb_imemo_subclasses_new(uint32_t capacity);
 VALUE rb_imemo_fields_new_complex(VALUE owner, /* shape_id_t */ uint32_t shape_id, size_t capa, bool shareable);
 VALUE rb_imemo_fields_new_complex_tbl(VALUE owner, /* shape_id_t */ uint32_t shape_id, st_table *tbl, bool shareable);
 VALUE rb_imemo_fields_clone(VALUE fields_obj);

--- a/vm_method.c
+++ b/vm_method.c
@@ -439,7 +439,7 @@ clear_method_cache_by_id_in_class(VALUE klass, ID mid)
     RB_VM_LOCKING() {
         rb_vm_barrier();
 
-        if (LIKELY(RCLASS_SUBCLASSES_FIRST(klass) == NULL) &&
+        if (LIKELY(!RCLASS_SUBCLASSES(klass)) &&
             !FL_TEST_RAW(klass, RCLASS_HAS_SUBCLASSES) &&
             // Non-refinement ICLASSes (from module inclusion) previously had
             // subclasses reparented onto them, so they need the tree path for

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -361,6 +361,7 @@ pub const imemo_callinfo: imemo_type = 10;
 pub const imemo_callcache: imemo_type = 11;
 pub const imemo_constcache: imemo_type = 12;
 pub const imemo_fields: imemo_type = 13;
+pub const imemo_subclasses: imemo_type = 14;
 pub type imemo_type = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -444,6 +444,7 @@ pub const imemo_callinfo: imemo_type = 10;
 pub const imemo_callcache: imemo_type = 11;
 pub const imemo_constcache: imemo_type = 12;
 pub const imemo_fields: imemo_type = 13;
+pub const imemo_subclasses: imemo_type = 14;
 pub type imemo_type = u32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This converts the previous subclasses linked list to a new imemo type which is a weakref array. 

The primary motivation for this is to allow classes to be freed concurrently, which this accomplishes by removing the linked-list removal.

It's probably also possible to achieve this by locking or other techniques on the existing linked list design, but this is simpler and should also use a little less memory.

The concern with this weakref approach is that we have to examine these objects after marking and before sweeping. Because this object is only created for classes with subclasses (with `require "rails/all"` there are ~500 of these), and it can benefit from generational GC, I hope this is reasonable.