### PR TITLE
Avoid eager `String#gsub!` copy on no match

### DIFF
--- a/benchmark/string_gsub.yml
+++ b/benchmark/string_gsub.yml
@@ -20,8 +20,19 @@ prelude: |
   }
   ESCAPE_PATTERN = Regexp.union(ESCAPED_CHARS.keys)
 
+  NO_MATCH_SHARED_STRING = ("a" * 100_000).freeze
 
 benchmark:
+  gsub_no_match_shared: |
+    str = NO_MATCH_SHARED_STRING.dup
+    str.gsub!("z", "x")
+    str
+
+  sub_no_match_shared: |
+    str = NO_MATCH_SHARED_STRING.dup
+    str.sub!("z", "x")
+    str
+
   escape: |
     str = STR.dup
     str.gsub!(ESCAPE_PATTERN, ESCAPED_CHARS)

--- a/string.c
+++ b/string.c
@@ -6397,6 +6397,7 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
         if (bang) return Qnil;	/* no match, no substitution */
         return str_duplicate(rb_cString, str);
     }
+    if (bang) str_modify_keep_cr(str);
 
     offset = 0;
     blen = RSTRING_LEN(str) + 30; /* len + margin */
@@ -6518,7 +6519,7 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
 static VALUE
 rb_str_gsub_bang(int argc, VALUE *argv, VALUE str)
 {
-    str_modify_keep_cr(str);
+    str_modifiable(str);
     return str_gsub(argc, argv, str, 1);
 }
 


### PR DESCRIPTION
## Background

I noticed that `String#gsub!` prepares the receiver for mutation before it knows whether the pattern matches. For shared strings, this can detach and copy the backing buffer even when `gsub!` ultimately returns `nil`.

`String#sub!` checks up front that the receiver is modifiable, searches for the first match, and only prepares the
string storage for mutation after a match is found.

```ruby
require "objspace"

src = ("a" * 100_000).freeze

s = src.dup
p ObjectSpace.memsize_of(s) # -> 40
p s.gsub!("z", "x") # -> nil
p ObjectSpace.memsize_of(s) # -> 100041

s = src.dup
p ObjectSpace.memsize_of(s) # -> 40
p s.sub!("z", "x") # -> nil
p ObjectSpace.memsize_of(s) # -> 40
```

## Proposal:

Move the mutation preparation step in `String#gsub!` until after the first successful match, while keeping the up-front modifiability check.

```diff
static VALUE
rb_str_gsub_bang(int argc, VALUE *argv, VALUE str)
{
-    str_modify_keep_cr(str);
+    str_modifiable(str);
    return str_gsub(argc, argv, str, 1);
}
```

```diff
beg = rb_pat_search0(pat, str, 0, need_backref_str, &match);

if (beg < 0) {
    if (bang) return Qnil;
    return str_duplicate(rb_cString, str);
}
+if (bang) str_modify_keep_cr(str);
```

### Justification:

`str_modify_keep_cr(str)` does more than check whether a string may be modified. It can also make the string independent, which detaches/copies shared backing storage. This is unneeded if there is no match on the string.

This change matches the approach already used by `String#sub!`.

### Tradeoffs:

Successful `gsub!` calls now do a `str_modifiable(str)` then `str_modify_keep_cr(str)` after the first match. A tiny matched-string benchmark is included to watch this regression risk. In repeated local runs, the result was noisy with what looks to be no impact.

### Results:

Over five local benchmark-driver runs:

| Benchmark | Control | Experiment | Speedup | Slowdown |
|---|---:|---:|---:|---:|
| `gsub_no_match_shared` | 260.879k | 607.977k | 2.33x | 0.43x |
| `sub_no_match_shared` | 604.615k | 604.244k | 1.00x | 1.00x |
| `gsub_match_tiny` | 5.930M | 5.965M | 1.01x | 0.99x |

The allocation shape changes in the example at the start:

```text
old gsub before=40
old gsub after=100041

new gsub before=40
new gsub after=40
```

#### Methodology:
- Apple M4 Pro, macOS 26.3.
- Used built-in benchmark tooling