### PR TITLE
Support rbs-integrated RDoc

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -37,7 +37,7 @@ ostruct             0.6.3   https://github.com/ruby/ostruct
 pstore              0.2.1   https://github.com/ruby/pstore
 benchmark           0.5.0   https://github.com/ruby/benchmark
 logger              1.7.0   https://github.com/ruby/logger
-rdoc                7.2.0   https://github.com/ruby/rdoc bc0baee787609f2205e8f1103f3e1d36b923184a
+rdoc                7.2.0   https://github.com/ruby/rdoc c5eec14b521b339932565c27979a086128660720
 win32ole            1.9.3   https://github.com/ruby/win32ole
 irb                 1.17.0  https://github.com/ruby/irb cfd0b917d3feb01adb7d413b19faeb0309900599
 reline              0.6.3   https://github.com/ruby/reline

--- a/tool/rdoc-srcdir
+++ b/tool/rdoc-srcdir
@@ -9,10 +9,20 @@ File.foreach(bundled_gems) do |line|
   versions[name] = version
 end
 
-%w[tsort rdoc].each do |lib|
+%w[tsort logger rbs rdoc].each do |lib|
   path = File.join(srcdir, ".bundle/gems/#{lib}-#{versions[lib]}")
   $LOAD_PATH.unshift("#{path}/lib")
 end
+
+# Add compiled extension paths for bundled gems with C extensions.
+# These are built by `make build-ext` into .bundle/extensions/ but are not
+# on the default load path because `make html` runs with --disable-gems.
+builddir = Dir.pwd
+%w[rbs].each do |lib|
+  ext_path = Dir.glob("#{builddir}/.bundle/extensions/*/*/#{lib}-#{versions[lib]}").first
+  $LOAD_PATH.unshift(ext_path) if ext_path
+end
+
 require 'rdoc/rdoc'
 
 # Make only the output directory relative to the invoked directory.


### PR DESCRIPTION
## Summary

Revives the `tool/rdoc-srcdir` half of this PR after [`2748759889`](https://github.com/ruby/ruby/commit/2748759889) (_Update default gemspecs so that default gems can run_) replaced the version-aware load-path injection (originally added in #16712) with `require 'rubygems'; require 'rdoc/rdoc'`. That switch relies on rubygems resolving `rdoc` through the running ruby's default gemset, which is rooted at the BASERUBY's install prefix via [`Gem.default_dir`](https://github.com/ruby/ruby/blob/master/lib/rubygems/defaults.rb#L37) — not `$(srcdir)/.bundle/`. When the build ruby has an `rdoc` default gem that differs from the version pinned in [`gems/bundled_gems`](https://github.com/ruby/ruby/blob/master/gems/bundled_gems), `make html` silently generates documentation with the wrong rdoc, regardless of what this checkout has pinned.

## Commits

- **Use rdoc and rbs from `gems/bundled_gems` in `tool/rdoc-srcdir`** — restores the `$LOAD_PATH.unshift` block for `tsort` and `rdoc` (removed by [`2748759889`](https://github.com/ruby/ruby/commit/2748759889)), extends it to cover `logger` and `rbs`, and prepends the compiled `rbs_extension` path under `.bundle/extensions/<platform>/<abi>/rbs-<version>/` populated by `make build-ext`. The C extension is outside the running rubygems' view because it lives in the in-tree `.bundle/`, not in the BASERUBY's gemset.

- **Bump rdoc to pull in RBS integration** — bumps the pinned `rdoc` SHA in `gems/bundled_gems` to [ruby/rdoc@c5eec14b](https://github.com/ruby/rdoc/commit/c5eec14b521b339932565c27979a086128660720), the merge commit of ruby/rdoc#1665 (_Display RBS type signatures in documentation_). PR #1665 reads type information from inline `#:` annotations and `.rbs` files (including the RBS stdlib via [`RBS::EnvironmentLoader`](https://github.com/ruby/rdoc/blob/c5eec14b/lib/rdoc/rbs_helper.rb#L42)), and renders it in HTML and RI output with type names linked to their documentation pages.