### PR TITLE
Bump irb to 1.18.0 and debug to latest master

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -18,7 +18,7 @@ matrix              0.4.3   https://github.com/ruby/matrix
 prime               0.1.4   https://github.com/ruby/prime
 rbs                 4.0.2   https://github.com/ruby/rbs 36a7e8e38df9efd33db83c3f30f0308bdeb84bd9
 typeprof            0.31.1  https://github.com/ruby/typeprof
-debug               1.11.1  https://github.com/ruby/debug 2897edad6d2c2eeb49ffe915192c54572dbe6c82
+debug               1.11.1  https://github.com/ruby/debug 9dc2024a5a05116b3d38afbc5579d9503d8913f3
 racc                1.8.1   https://github.com/ruby/racc
 mutex_m             0.3.0   https://github.com/ruby/mutex_m
 getoptlong          0.2.1   https://github.com/ruby/getoptlong
@@ -39,7 +39,7 @@ benchmark           0.5.0   https://github.com/ruby/benchmark
 logger              1.7.0   https://github.com/ruby/logger
 rdoc                7.2.0   https://github.com/ruby/rdoc bc0baee787609f2205e8f1103f3e1d36b923184a
 win32ole            1.9.3   https://github.com/ruby/win32ole
-irb                 1.17.0  https://github.com/ruby/irb cfd0b917d3feb01adb7d413b19faeb0309900599
+irb                 1.18.0  https://github.com/ruby/irb
 reline              0.6.3   https://github.com/ruby/reline
 readline            0.0.4   https://github.com/ruby/readline
 fiddle              1.1.8   https://github.com/ruby/fiddle


### PR DESCRIPTION
## Why

Bumping `irb` to 1.18.0 alone breaks `test-bundled-gems` because [ruby/irb#1189](https://github.com/ruby/irb/pull/1189) (included in 1.18.0) now applies cyan highlighting to method names — which also affects `Struct` member names in `colored_inspect` output that `debug`'s `ColorTest` exercises.

The matching fix on the `debug` side is [ruby/debug@9dc2024](https://github.com/ruby/debug/commit/9dc2024a5a05116b3d38afbc5579d9503d8913f3) ("Update color test for IRB struct member name coloring"), which is on `master` but has not yet been released. This PR bumps both gems together so the bundled-gems test suite passes.

## Changes

### `irb` 1.17.0 → 1.18.0

Highlights from the [v1.18.0 release](https://github.com/ruby/irb/releases/tag/v1.18.0):

- Completely migrate to Prism ([ruby/irb#1160](https://github.com/ruby/irb/pull/1160))
- Add startup banner with Ruby logo, version info, and tips ([ruby/irb#1183](https://github.com/ruby/irb/pull/1183)), with a `--nobanner` option to suppress it ([ruby/irb#1200](https://github.com/ruby/irb/pull/1200))
- Display command description in doc dialog on tab completion ([ruby/irb#1180](https://github.com/ruby/irb/pull/1180))
- Highlight the method name in method calls ([ruby/irb#1189](https://github.com/ruby/irb/pull/1189)) — source of the `colored_inspect` change above
- Make `ls` command work for `BasicObject`s ([ruby/irb#1177](https://github.com/ruby/irb/pull/1177))
- Fix IRB crash when typing string literals with control/meta sequences ([ruby/irb#1182](https://github.com/ruby/irb/pull/1182))

Full diff: [v1.17.0...v1.18.0](https://github.com/ruby/irb/compare/v1.17.0...v1.18.0).

### `debug` → latest master ([9dc2024](https://github.com/ruby/debug/commit/9dc2024a5a05116b3d38afbc5579d9503d8913f3))

Updates the pinned SHA from `2897edad` to `9dc2024a`. Version remains at 1.11.1. Three commits in this range:

- [1de33e7](https://github.com/ruby/debug/commit/1de33e7) — fix: deadlock using IRB integration on Rails applications
- [95997c2](https://github.com/ruby/debug/commit/95997c2) — Fix showing help message on wrong options
- [9dc2024](https://github.com/ruby/debug/commit/9dc2024) — Update color test for IRB struct member name coloring

Full diff: [2897edad...9dc2024a](https://github.com/ruby/debug/compare/2897edad6d2c2eeb49ffe915192c54572dbe6c82...9dc2024a5a05116b3d38afbc5579d9503d8913f3).