### PR TITLE
Fix gc_stress assertion at startup and RUBY_DEBUG in CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -93,7 +93,7 @@ jobs:
           arch: ${{ matrix.arch }}
           configure: ${{ matrix.configure }}
         run: >-
-          $SETARCH ../src/configure -C --disable-install-doc ${configure:-cppflags=-DRUBY_DEBUG}
+          $SETARCH ../src/configure -C --disable-install-doc ${configure:- --enable-debug-env cppflags=-DRUBY_DEBUG}
           ${arch:+--target=$arch-$OSTYPE --host=$arch-$OSTYPE}
 
       - run: $SETARCH make prepare-gems

--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -6415,12 +6415,12 @@ garbage_collect(rb_objspace_t *objspace, unsigned int reason)
 static int
 gc_start(rb_objspace_t *objspace, unsigned int reason)
 {
-    rb_gc_initialize_vm_context(&objspace->vm_context);
-
     unsigned int do_full_mark = !!(reason & GPR_FLAG_FULL_MARK);
 
     if (!rb_darray_size(objspace->heap_pages.sorted)) return TRUE; /* heap is not ready */
     if (!(reason & GPR_FLAG_METHOD) && !ready_to_gc(objspace)) return TRUE; /* GC is not allowed */
+
+    rb_gc_initialize_vm_context(&objspace->vm_context);
 
     GC_ASSERT(gc_mode(objspace) == gc_mode_none, "gc_mode is %s\n", gc_mode_name(gc_mode(objspace)));
     GC_ASSERT(!is_lazy_sweeping(objspace));


### PR DESCRIPTION
`rb_gc_initialize_vm_context` calls `GET_EC`, which does `VM_ASSERT(ec != NULL)`.

When Ruby is built with `RUBY_DEBUG=1` and GC stress is set to run at boot with `RUBY_DEBUG=gc_stress` then GC gets run inside `Init_BareVM` when we're setting up the main_thread.

In `gc_start` we gate the GC with some early returns that prevent us actually running a GC if the heap and objspace are not ready yet.

But currently we're attempting to initialize the gc's `vm_context` before those gates, causing the assertion to fail (because the VM isn't ready yet).

This commit moves the `vm_context` setup after the gates, so we don't attempt it before objspace and the heap are fully set up.

To repro this bug configure with `--enable-debug-env` and `cflags=-DRUBY_DEBUG` and then run

    RUBY_DEBUG=gc_stress ./ruby -v

This bug should have been caught by `test_gc_stress_at_startup`, but because none of the CI builds combine `--enable-debug-env` and `-DRUBY_DEBUG` [this gate](https://github.com/ruby/ruby/blob/master/main.c#L54) is returning false and the `RUBY_DEBUG` environment variable is silently ignored.

This means that any test like `test_gc_stress_at_startup` that starts a subprocess with a specific `RUBY_DEBUG` environment will not be behaving as intended.

This also means that `RUBY_DEBUG=ci` is not being honoured, meaning crash dumps from CI are less useful.

