### PR TITLE
Use rbs-integrated RDoc

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -37,7 +37,7 @@ ostruct             0.6.3   https://github.com/ruby/ostruct
 pstore              0.2.1   https://github.com/ruby/pstore
 benchmark           0.5.0   https://github.com/ruby/benchmark
 logger              1.7.0   https://github.com/ruby/logger
-rdoc                7.2.0   https://github.com/ruby/rdoc bc0baee787609f2205e8f1103f3e1d36b923184a
+rdoc                7.2.0   https://github.com/ruby/rdoc 1f93543615928b6d45357432f16ec6006e2d8b1e
 win32ole            1.9.3   https://github.com/ruby/win32ole
 irb                 1.18.0  https://github.com/ruby/irb
 reline              0.6.3   https://github.com/ruby/reline


### PR DESCRIPTION
This will allow docs.ruby-lang.org to include method rbs sigs.