### PR TITLE
ZJIT: Stop using def_ids! for HIR dump purposes

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -21,7 +21,7 @@ use crate::stats::{counter_ptr, with_time_stat, trace_compile_phase, Counter, Co
 use crate::{asm::CodeBlock, cruby::*, options::debug, virtualmem::CodePtr};
 use crate::backend::lir::{self, Assembler, C_ARG_OPNDS, C_RET_OPND, CFP, EC, NATIVE_STACK_PTR, Opnd, SP, SideExit, SideExitRecompile, Target, asm_ccall, asm_comment};
 use crate::hir::{iseq_to_hir, BlockId, Invariant, RangeType, SideExitReason::{self, *}, SpecialBackrefSymbol, SpecialObjectType};
-use crate::hir::{BlockHandler, Const, FrameState, Function, Insn, InsnId, Recompile, SendFallbackReason};
+use crate::hir::{BlockHandler, Const, FieldName, FrameState, Function, Insn, InsnId, Recompile, SendFallbackReason};
 use crate::hir_type::{types, Type};
 use crate::options::{get_option, PerfMap};
 use crate::cast::IntoUsize;
@@ -1338,16 +1338,16 @@ fn gen_load_self() -> Opnd {
     Opnd::mem(64, CFP, RUBY_OFFSET_CFP_SELF)
 }
 
-fn gen_load_field(asm: &mut Assembler, recv: Opnd, id: ID, offset: i32, return_type: Type) -> Opnd {
+fn gen_load_field(asm: &mut Assembler, recv: Opnd, id: FieldName, offset: i32, return_type: Type) -> Opnd {
     gen_incr_counter(asm, Counter::load_field_count);
-    asm_comment!(asm, "Load field id={} offset={}", id.contents_lossy(), offset);
+    asm_comment!(asm, "Load field id={id} offset={offset}");
     let recv = asm.load_mem(recv);
     asm.load(Opnd::mem(return_type.num_bits(), recv, offset))
 }
 
-fn gen_store_field(asm: &mut Assembler, recv: Opnd, id: ID, offset: i32, val: Opnd, val_type: Type) {
+fn gen_store_field(asm: &mut Assembler, recv: Opnd, id: FieldName, offset: i32, val: Opnd, val_type: Type) {
     gen_incr_counter(asm, Counter::store_field_count);
-    asm_comment!(asm, "Store field id={} offset={}", id.contents_lossy(), offset);
+    asm_comment!(asm, "Store field id={id} offset={offset}");
     let recv = asm.load_mem(recv);
     asm.store(Opnd::mem(val_type.num_bits(), recv, offset), val);
 }

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -1593,22 +1593,9 @@ pub(crate) mod ids {
         name: freeze
         name: minusat            content: b"-@"
         name: aref               content: b"[]"
-        name: len
-        name: _as_heap
-        name: _fields_obj
-        name: thread_ptr
-        name: self_              content: b"self"
         name: rb_ivar_get_at_no_ractor_check
-        name: _shape_id
-        name: _env_data_index_flags
-        name: _env_data_index_specval
-        name: _ep_method_entry
-        name: _ep_specval
-        name: _ep_flags
-        name: _rbasic_flags
         name: RUBY_FL_FREEZE
         name: RUBY_ELTS_SHARED
-        name: VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM
         name: RubyVM
         name: ZJIT
         name: induce_side_exit_bang       content: b"induce_side_exit!"

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -12,7 +12,7 @@ use crate::cruby::*;
 use std::collections::HashMap;
 use std::ffi::c_void;
 use crate::hir_type::{types, Type};
-use crate::hir;
+use crate::hir::{self, FieldName};
 
 // Array iteration builtin functions (defined in array.c)
 unsafe extern "C" {
@@ -322,13 +322,13 @@ fn inline_thread_current(fun: &mut hir::Function, block: hir::BlockId, _recv: hi
     let ec = fun.push_insn(block, hir::Insn::LoadEC);
     let thread_ptr = fun.push_insn(block, hir::Insn::LoadField {
         recv: ec,
-        id: ID!(thread_ptr),
+        id: FieldName::thread_ptr,
         offset: RUBY_OFFSET_EC_THREAD_PTR as i32,
         return_type: types::CPtr,
     });
     let thread_self = fun.push_insn(block, hir::Insn::LoadField {
         recv: thread_ptr,
-        id: ID!(self_),
+        id: FieldName::SelfParam,
         offset: RUBY_OFFSET_THREAD_SELF as i32,
         // TODO(max): Add Thread type. But Thread.current is not guaranteed to be an exact Thread.
         // You can make subclasses...
@@ -462,7 +462,7 @@ fn inline_string_bytesize(fun: &mut hir::Function, block: hir::BlockId, recv: hi
         let recv = fun.coerce_to(block, recv, types::String, state);
         let len = fun.push_insn(block, hir::Insn::LoadField {
             recv,
-            id: ID!(len),
+            id: FieldName::len,
             offset: RUBY_OFFSET_RSTRING_LEN as i32,
             return_type: types::CInt64,
         });
@@ -486,7 +486,7 @@ fn inline_string_getbyte(fun: &mut hir::Function, block: hir::BlockId, recv: hir
         let unboxed_index = fun.push_insn(block, hir::Insn::UnboxFixnum { val: index });
         let len = fun.push_insn(block, hir::Insn::LoadField {
             recv,
-            id: ID!(len),
+            id: FieldName::len,
             offset: RUBY_OFFSET_RSTRING_LEN as i32,
             return_type: types::CInt64,
         });
@@ -514,7 +514,7 @@ fn inline_string_setbyte(fun: &mut hir::Function, block: hir::BlockId, recv: hir
         let unboxed_index = fun.push_insn(block, hir::Insn::UnboxFixnum { val: index });
         let len = fun.push_insn(block, hir::Insn::LoadField {
             recv,
-            id: ID!(len),
+            id: FieldName::len,
             offset: RUBY_OFFSET_RSTRING_LEN as i32,
             return_type: types::CInt64,
         });
@@ -537,7 +537,7 @@ fn inline_string_empty_p(fun: &mut hir::Function, block: hir::BlockId, recv: hir
     let &[] = args else { return None; };
     let len = fun.push_insn(block, hir::Insn::LoadField {
         recv,
-        id: ID!(len),
+        id: FieldName::len,
         offset: RUBY_OFFSET_RSTRING_LEN as i32,
         return_type: types::CInt64,
     });

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -788,6 +788,44 @@ pub enum BlockHandler {
     BlockArg,
 }
 
+/// Identifier used by LoadField/StoreField/LoadArg for HIR dumps. Variants
+/// without an associated value name internal VM fields that we used to intern
+/// as CRuby IDs just to print them; the `Id` variant carries a real CRuby ID
+/// (e.g. local variable, ivar, struct field name).
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FieldName {
+    VM_ENV_DATA_INDEX_ME_CREF,
+    VM_ENV_DATA_INDEX_SPECVAL,
+    VM_ENV_DATA_INDEX_FLAGS,
+    RBASIC_FLAGS,
+    shape_id,
+    as_heap,
+    fields_obj,
+    thread_ptr,
+    len,
+    SelfParam,
+    Id(ID),
+}
+
+impl std::fmt::Display for FieldName {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        use FieldName::*;
+        match self {
+            Id(id) if id_is_empty(*id) => f.write_str("<empty>"),
+            Id(id) => f.write_str(&id.contents_lossy()),
+            SelfParam => f.write_str("self"),
+            _ => write!(f, "{self:?}"),
+        }
+    }
+}
+
+impl From<ID> for FieldName {
+    fn from(id: ID) -> Self {
+        FieldName::Id(id)
+    }
+}
+
 /// An instruction in the SSA IR. The output of an instruction is referred to by the index of
 /// the instruction ([`InsnId`]). SSA form enables this, and [`UnionFind`] ([`Function::find`])
 /// helps with editing.
@@ -798,7 +836,7 @@ pub enum Insn {
     Param,
     /// Load a function argument from the calling convention.
     /// Used in JIT entry blocks. idx is the calling convention index, id is for display.
-    LoadArg { idx: u32, id: ID, val_type: Type },
+    LoadArg { idx: u32, id: FieldName, val_type: Type },
 
     /// Synthetic terminator for the entries superblock. Targets all entry blocks
     /// so that CFG analyses see a single root. Not lowered to machine code.
@@ -920,10 +958,10 @@ pub enum Insn {
     LoadSP,
     /// Load cfp->self
     LoadSelf,
-    LoadField { recv: InsnId, id: ID, offset: i32, return_type: Type },
+    LoadField { recv: InsnId, id: FieldName, offset: i32, return_type: Type },
     /// Write `val` at an offset of `recv`.
     /// When writing a Ruby object to a Ruby object, one must use GuardNotFrozen (or equivalent) before and WriteBarrier after.
-    StoreField { recv: InsnId, id: ID, offset: i32, val: InsnId },
+    StoreField { recv: InsnId, id: FieldName, offset: i32, val: InsnId },
     WriteBarrier { recv: InsnId, val: InsnId },
 
     /// Check whether VM_FRAME_FLAG_MODIFIED_BLOCK_PARAM is set in the (already loaded) environment flags.
@@ -1779,7 +1817,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
         match &self.inner {
             Insn::Const { val } => { write!(f, "Const {}", val.print(self.ptr_map)) }
             Insn::Param => { write!(f, "Param") }
-            Insn::LoadArg { idx, id, .. } => { write!(f, "LoadArg :{}@{idx}", id.contents_lossy()) }
+            Insn::LoadArg { idx, id, .. } => { write!(f, "LoadArg :{id}@{idx}") }
             Insn::Entries { targets } => {
                 write!(f, "Entries")?;
                 let mut prefix = " ";
@@ -2154,14 +2192,9 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             &Insn::GetEP { level } => write!(f, "GetEP {level}"),
             Insn::LoadSelf => write!(f, "LoadSelf"),
             &Insn::LoadField { recv, id, offset, return_type: _ } => {
-                let field_name = if id_is_empty(id) {
-                    std::borrow::Cow::Borrowed("<empty>")
-                } else {
-                    id.contents_lossy()
-                };
-                write!(f, "LoadField {recv}, :{}@{:#x}", field_name, self.ptr_map.map_offset(offset))
+                write!(f, "LoadField {recv}, :{id}@{:#x}", self.ptr_map.map_offset(offset))
             }
-            &Insn::StoreField { recv, id, offset, val } => write!(f, "StoreField {recv}, :{}@{:#x}, {val}", id.contents_lossy(), self.ptr_map.map_offset(offset)),
+            &Insn::StoreField { recv, id, offset, val } => write!(f, "StoreField {recv}, :{id}@{:#x}, {val}", self.ptr_map.map_offset(offset)),
             &Insn::WriteBarrier { recv, val } => write!(f, "WriteBarrier {recv}, {val}"),
             Insn::SetIvar { self_val, id, val, .. } => write!(f, "SetIvar {self_val}, :{}, {val}", id.contents_lossy()),
             Insn::GetGlobal { id, .. } => write!(f, "GetGlobal :{}", id.contents_lossy()),
@@ -3455,11 +3488,11 @@ impl Function {
         // a (u32, u32) inside a u64 at RUBY_OFFSET_RBASIC_FLAGS (offset 0). It's fine to load the
         // shape alongside the flags, but make sure not to *store* the shape accidentally by
         // writing a u64.
-        self.push_insn(block, Insn::LoadField { recv, id: ID!(_rbasic_flags), offset: RUBY_OFFSET_RBASIC_FLAGS, return_type: types::CUInt64 })
+        self.push_insn(block, Insn::LoadField { recv, id: FieldName::RBASIC_FLAGS, offset: RUBY_OFFSET_RBASIC_FLAGS, return_type: types::CUInt64 })
     }
 
     fn load_ep_flags(&mut self, block: BlockId, ep: InsnId) -> InsnId {
-        self.push_insn(block, Insn::LoadField { recv: ep, id: ID!(_ep_flags), offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32), return_type: types::CUInt64 })
+        self.push_insn(block, Insn::LoadField { recv: ep, id: FieldName::VM_ENV_DATA_INDEX_FLAGS, offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32), return_type: types::CUInt64 })
     }
 
     pub fn guard_not_frozen(&mut self, block: BlockId, recv: InsnId, state: InsnId) {
@@ -3487,7 +3520,7 @@ impl Function {
 
         self.push_insn(block, Insn::LoadField {
             recv: ep,
-            id: local_id,
+            id: local_id.into(),
             offset,
             return_type,
         })
@@ -3507,7 +3540,7 @@ impl Function {
 
         self.push_insn(block, Insn::LoadField {
             recv: sp,
-            id: local_id,
+            id: local_id.into(),
             offset,
             return_type,
         })
@@ -3780,17 +3813,17 @@ impl Function {
                                         let offset = RUBY_OFFSET_RSTRUCT_AS_ARY + (SIZEOF_VALUE_I32 * index);
                                         (recv, offset)
                                     } else {
-                                        let as_heap = self.push_insn(block, Insn::LoadField { recv, id: ID!(_as_heap), offset: RUBY_OFFSET_RSTRUCT_AS_HEAP_PTR, return_type: types::CPtr });
+                                        let as_heap = self.push_insn(block, Insn::LoadField { recv, id: FieldName::as_heap, offset: RUBY_OFFSET_RSTRUCT_AS_HEAP_PTR, return_type: types::CPtr });
                                         let offset = SIZEOF_VALUE_I32 * index;
                                         (as_heap, offset)
                                     };
 
                                     let replacement = if let (OptimizedMethodType::StructAset, &[val]) = (opt_type, args.as_slice()) {
-                                        self.push_insn(block, Insn::StoreField { recv: target, id: mid, offset, val });
+                                        self.push_insn(block, Insn::StoreField { recv: target, id: mid.into(), offset, val });
                                         self.push_insn(block, Insn::WriteBarrier { recv, val });
                                         val
                                     } else { // StructAref
-                                        self.push_insn(block, Insn::LoadField { recv: target, id: mid, offset, return_type: types::BasicObject })
+                                        self.push_insn(block, Insn::LoadField { recv: target, id: mid.into(), offset, return_type: types::BasicObject })
                                     };
                                     self.make_equal_to(insn_id, replacement);
                                 },
@@ -3908,11 +3941,11 @@ impl Function {
                             let level = get_lvar_level(fun.iseq);
                             let lep = fun.push_insn(block, Insn::GetEP { level });
                             // Load ep[VM_ENV_DATA_INDEX_ME_CREF]
-                            let method_entry = fun.push_insn(block, Insn::LoadField { recv: lep, id: ID!(_ep_method_entry), offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_ME_CREF, return_type: types::RubyValue });
+                            let method_entry = fun.push_insn(block, Insn::LoadField { recv: lep, id: FieldName::VM_ENV_DATA_INDEX_ME_CREF, offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_ME_CREF, return_type: types::RubyValue });
                             // Guard that it matches the expected CME
                             fun.push_insn(block, Insn::GuardBitEquals { val: method_entry, expected: Const::Value(current_cme.into()), reason: SideExitReason::GuardSuperMethodEntry, state, recompile: None });
 
-                            let block_handler = fun.push_insn(block, Insn::LoadField { recv: lep, id: ID!(_ep_specval), offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL, return_type: types::RubyValue });
+                            let block_handler = fun.push_insn(block, Insn::LoadField { recv: lep, id: FieldName::VM_ENV_DATA_INDEX_SPECVAL, offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL, return_type: types::RubyValue });
                             fun.push_insn(block, Insn::GuardBitEquals {
                                 val: block_handler,
                                 expected: Const::Value(VALUE(VM_BLOCK_HANDLER_NONE as usize)),
@@ -4228,7 +4261,7 @@ impl Function {
     fn load_shape(&mut self, block: BlockId, recv: InsnId) -> InsnId {
         self.push_insn(block, Insn::LoadField {
             recv,
-            id: ID!(_shape_id),
+            id: FieldName::shape_id,
             offset: unsafe { rb_shape_id_offset() } as i32,
             return_type: types::CShape
         })
@@ -4261,13 +4294,13 @@ impl Function {
     fn load_ivar_heap(&mut self, block: BlockId,  recv: InsnId, id: ID, ivar_index: attr_index_t) -> InsnId {
         // See ROBJECT_FIELDS() from include/ruby/internal/core/robject.h
         let ptr = self.push_insn(block, Insn::LoadField {
-            recv, id: ID!(_as_heap),
+            recv, id: FieldName::as_heap,
             offset: ROBJECT_OFFSET_AS_HEAP_FIELDS as i32,
             return_type: types::CPtr,
         });
         let offset = SIZEOF_VALUE_I32 * ivar_index as i32;
         self.push_insn(block, Insn::LoadField {
-            recv: ptr, id, offset,
+            recv: ptr, id: id.into(), offset,
             return_type: types::BasicObject,
         })
     }
@@ -4277,7 +4310,7 @@ impl Function {
         let offset = ROBJECT_OFFSET_AS_ARY as i32
             + (SIZEOF_VALUE * ivar_index.to_usize()) as i32;
         self.push_insn(block, Insn::LoadField {
-            recv, id, offset,
+            recv, id: id.into(), offset,
             return_type: types::BasicObject,
         })
     }
@@ -4328,7 +4361,7 @@ impl Function {
             }
             // Root box only: load directly from prime classext
             let fields_obj = self.push_insn(block, Insn::LoadField {
-                recv: self_val, id: ID!(_fields_obj),
+                recv: self_val, id: FieldName::fields_obj,
                 offset: RCLASS_OFFSET_PRIME_FIELDS_OBJ as i32,
                 return_type: types::RubyValue,
             });
@@ -4337,7 +4370,7 @@ impl Function {
         if recv_type.flags().is_typed_data() {
             // Typed T_DATA: load from fields_obj at fixed offset in RTypedData
             let fields_obj = self.push_insn(block, Insn::LoadField {
-                recv: self_val, id: ID!(_fields_obj),
+                recv: self_val, id: FieldName::fields_obj,
                 offset: RTYPEDDATA_OFFSET_FIELDS_OBJ as i32,
                 return_type: types::RubyValue,
             });
@@ -4509,17 +4542,17 @@ impl Function {
                             let offset = ROBJECT_OFFSET_AS_ARY as i32 + (SIZEOF_VALUE * ivar_index.to_usize()) as i32;
                             (self_val, offset)
                         } else {
-                            let as_heap = self.push_insn(block, Insn::LoadField { recv: self_val, id: ID!(_as_heap), offset: ROBJECT_OFFSET_AS_HEAP_FIELDS as i32, return_type: types::CPtr });
+                            let as_heap = self.push_insn(block, Insn::LoadField { recv: self_val, id: FieldName::as_heap, offset: ROBJECT_OFFSET_AS_HEAP_FIELDS as i32, return_type: types::CPtr });
                             let offset = SIZEOF_VALUE_I32 * ivar_index as i32;
                             (as_heap, offset)
                         };
-                        self.push_insn(block, Insn::StoreField { recv: ivar_storage, id, offset, val });
+                        self.push_insn(block, Insn::StoreField { recv: ivar_storage, id: id.into(), offset, val });
                         self.push_insn(block, Insn::WriteBarrier { recv: self_val, val });
                         if next_shape_id != recv_type.shape() {
                             // Write the new shape ID
                             let shape_id = self.push_insn(block, Insn::Const { val: Const::CShape(next_shape_id) });
                             let shape_id_offset = unsafe { rb_shape_id_offset() };
-                            self.push_insn(block, Insn::StoreField { recv: self_val, id: ID!(_shape_id), offset: shape_id_offset, val: shape_id });
+                            self.push_insn(block, Insn::StoreField { recv: self_val, id: FieldName::shape_id, offset: shape_id_offset, val: shape_id });
                         }
                     }
                     _ => { self.push_insn_id(block, insn_id); }
@@ -7318,7 +7351,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let ep = fun.push_insn(block, Insn::GetEP { level });
                     let flags = fun.push_insn(block, Insn::LoadField {
                         recv: ep,
-                        id: ID!(_env_data_index_flags),
+                        id: FieldName::VM_ENV_DATA_INDEX_FLAGS,
                         offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32),
                         return_type: types::CInt64,
                     });
@@ -7328,7 +7361,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let modified = fun.push_insn(block, Insn::IntOr { left: flags, right: modified_flag });
                     fun.push_insn(block, Insn::StoreField {
                         recv: ep,
-                        id: ID!(_env_data_index_flags),
+                        id: FieldName::VM_ENV_DATA_INDEX_FLAGS,
                         offset: SIZEOF_VALUE_I32 * (VM_ENV_DATA_INDEX_FLAGS as i32),
                         val: modified,
                     });
@@ -7386,7 +7419,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
                     // Push unmodified block: inspect the current block handler to
                     // decide whether this path returns `nil` or `BlockParamProxy`.
-                    let block_handler = fun.push_insn(unmodified_block, Insn::LoadField { recv: ep, id: ID!(_env_data_index_specval), offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL, return_type: types::CInt64 });
+                    let block_handler = fun.push_insn(unmodified_block, Insn::LoadField { recv: ep, id: FieldName::VM_ENV_DATA_INDEX_SPECVAL, offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL, return_type: types::CInt64 });
                     let original_local = if level == 0 { Some(state.getlocal(ep_offset)) } else { None };
                     // `block_handler & 1 == 1` accepts both ISEQ (0b01) and ifunc
                     // (0b11) handlers. Keep a compile-time check that this shortcut
@@ -8077,7 +8110,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         let lep = fun.push_insn(block, Insn::GetEP { level });
                         let block_handler = fun.push_insn(block, Insn::LoadField {
                             recv: lep,
-                            id: ID!(_env_data_index_specval),
+                            id: FieldName::VM_ENV_DATA_INDEX_SPECVAL,
                             offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL,
                             return_type: types::CInt64,
                         });
@@ -8527,7 +8560,7 @@ fn compile_jit_entry_state(fun: &mut Function, jit_entry_block: BlockId, jit_ent
     };
 
     let mut arg_idx: u32 = 0;
-    let self_param = fun.push_insn(jit_entry_block, Insn::LoadArg { idx: arg_idx, id: ID!(self_), val_type: types::BasicObject });
+    let self_param = fun.push_insn(jit_entry_block, Insn::LoadArg { idx: arg_idx, id: FieldName::SelfParam, val_type: types::BasicObject });
     arg_idx += 1;
     let mut entry_state = FrameState::new(iseq);
     let mut ep: Option<InsnId> = None;
@@ -8553,7 +8586,7 @@ fn compile_jit_entry_state(fun: &mut Function, jit_entry_block: BlockId, jit_ent
             ));
         } else if local_idx < param_size {
             let id = unsafe { rb_zjit_local_id(iseq, local_idx.try_into().unwrap()) };
-            entry_state.locals.push(fun.push_insn(jit_entry_block, Insn::LoadArg { idx: arg_idx, id, val_type: types::BasicObject }));
+            entry_state.locals.push(fun.push_insn(jit_entry_block, Insn::LoadArg { idx: arg_idx, id: id.into(), val_type: types::BasicObject }));
             arg_idx += 1;
         } else {
             entry_state.locals.push(fun.push_insn(jit_entry_block, Insn::Const { val: Const::Value(Qnil) }));

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -4887,14 +4887,14 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v17:CPtr = GetEP 0
-          v18:CUInt64 = LoadField v17, :_ep_flags@0x1001
+          v18:CUInt64 = LoadField v17, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v19:CBool = IsBlockParamModified v18
           CondBranch v19, bb4(), bb5()
         bb4():
           v21:BasicObject = LoadField v17, :block@0x1002
           Jump bb6(v21, v21)
         bb5():
-          v23:CInt64 = LoadField v17, :_env_data_index_specval@0x1003
+          v23:CInt64 = LoadField v17, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
           v24:CInt64 = GuardAnyBitSet v23, CUInt64(1)
           v25:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v25, v10)
@@ -4929,7 +4929,7 @@ mod hir_opt_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
           v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
+          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v20:CBool = IsBlockParamModified v19
           CondBranch v20, bb4(), bb5()
         bb4():
@@ -4940,14 +4940,14 @@ mod hir_opt_tests {
           Jump bb6(v24)
         bb6(v17:BasicObject):
           v32:CPtr = GetEP 0
-          v33:CUInt64 = LoadField v32, :_ep_flags@0x1001
+          v33:CUInt64 = LoadField v32, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v34:CBool = IsBlockParamModified v33
           CondBranch v34, bb7(), bb8()
         bb7():
           v36:BasicObject = LoadField v32, :block@0x1002
           Jump bb9(v36, v36)
         bb8():
-          v38:CInt64 = LoadField v32, :_env_data_index_specval@0x1003
+          v38:CInt64 = LoadField v32, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
           v39:CInt64 = GuardAnyBitSet v38, CUInt64(1)
           v40:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb9(v40, v17)
@@ -4980,7 +4980,7 @@ mod hir_opt_tests {
           Jump bb3(v5, v6)
         bb3(v8:BasicObject, v9:NilClass):
           v14:CPtr = GetEP 1
-          v15:CUInt64 = LoadField v14, :_ep_flags@0x1000
+          v15:CUInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000
           v16:CBool = IsBlockParamModified v15
           CondBranch v16, bb4(), bb5()
         bb4():
@@ -4991,14 +4991,14 @@ mod hir_opt_tests {
           Jump bb6(v20)
         bb6(v13:BasicObject):
           v27:CPtr = GetEP 1
-          v28:CUInt64 = LoadField v27, :_ep_flags@0x1000
+          v28:CUInt64 = LoadField v27, :VM_ENV_DATA_INDEX_FLAGS@0x1000
           v29:CBool = IsBlockParamModified v28
           CondBranch v29, bb7(), bb8()
         bb7():
           v31:BasicObject = LoadField v27, :block@0x1001
           Jump bb9(v31)
         bb8():
-          v33:CInt64 = LoadField v27, :_env_data_index_specval@0x1002
+          v33:CInt64 = LoadField v27, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
           v34:CInt64 = GuardAnyBitSet v33, CUInt64(1)
           v35:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb9(v35)
@@ -5035,14 +5035,14 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v14:Fixnum[0] = Const Value(0)
           v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
+          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v20:CBool = IsBlockParamModified v19
           CondBranch v20, bb4(), bb5()
         bb4():
           v22:BasicObject = LoadField v18, :block@0x1002
           Jump bb6(v22, v22)
         bb5():
-          v24:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
+          v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
           v25:CInt64[1] = Const CInt64(1)
           v26:CInt64 = IntAnd v24, v25
           v27:CBool = IsBitEqual v26, v25
@@ -5086,7 +5086,7 @@ mod hir_opt_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CPtr = GetEP 0
-          v16:CUInt64 = LoadField v15, :_ep_flags@0x1001
+          v16:CUInt64 = LoadField v15, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v17:CBool = IsBlockParamModified v16
           CondBranch v17, bb4(), bb5()
         bb4():
@@ -5122,7 +5122,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v11:CPtr = GetEP 1
-          v12:CUInt64 = LoadField v11, :_ep_flags@0x1000
+          v12:CUInt64 = LoadField v11, :VM_ENV_DATA_INDEX_FLAGS@0x1000
           v13:CBool = IsBlockParamModified v12
           CondBranch v13, bb4(), bb5()
         bb4():
@@ -5162,10 +5162,10 @@ mod hir_opt_tests {
           v14:NilClass = Const Value(nil)
           SetLocal :block, l0, EP@3, v14
           v18:CPtr = GetEP 0
-          v19:CInt64 = LoadField v18, :_env_data_index_flags@0x1001
+          v19:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v20:CInt64[512] = Const CInt64(512)
           v21:CInt64 = IntOr v19, v20
-          StoreField v18, :_env_data_index_flags@0x1001, v21
+          StoreField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001, v21
           CheckInterrupts
           Return v14
         ");
@@ -5194,10 +5194,10 @@ mod hir_opt_tests {
           v10:NilClass = Const Value(nil)
           SetLocal :block, l1, EP@3, v10
           v14:CPtr = GetEP 1
-          v15:CInt64 = LoadField v14, :_env_data_index_flags@0x1000
+          v15:CInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000
           v16:CInt64[512] = Const CInt64(512)
           v17:CInt64 = IntOr v15, v16
-          StoreField v14, :_env_data_index_flags@0x1000, v17
+          StoreField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000, v17
           CheckInterrupts
           Return v10
         ");
@@ -5269,7 +5269,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v16:HeapBasicObject = GuardType v6, HeapBasicObject
-          v17:CShape = LoadField v16, :_shape_id@0x1000
+          v17:CShape = LoadField v16, :shape_id@0x1000
           v18:CShape[0x1001] = GuardBitEquals v17, CShape(0x1001)
           v19:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           CheckInterrupts
@@ -5295,7 +5295,7 @@ mod hir_opt_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v16:HeapBasicObject = GuardType v6, HeapBasicObject
-          v17:CShape = LoadField v16, :_shape_id@0x1000
+          v17:CShape = LoadField v16, :shape_id@0x1000
           v18:CShape[0x1001] = GuardBitEquals v17, CShape(0x1001)
           v19:NilClass = Const Value(nil)
           CheckInterrupts
@@ -5613,7 +5613,7 @@ mod hir_opt_tests {
           v10:Fixnum[5] = Const Value(5)
           PatchPoint SingleRactorMode
           v21:HeapBasicObject = GuardType v6, HeapBasicObject
-          v22:CShape = LoadField v21, :_shape_id@0x1000
+          v22:CShape = LoadField v21, :shape_id@0x1000
           v23:CShape[0x1001] = GuardBitEquals v22, CShape(0x1001)
           StoreField v21, :@foo@0x1002, v10
           WriteBarrier v21, v10
@@ -5642,12 +5642,12 @@ mod hir_opt_tests {
           v10:Fixnum[5] = Const Value(5)
           PatchPoint SingleRactorMode
           v21:HeapBasicObject = GuardType v6, HeapBasicObject
-          v22:CShape = LoadField v21, :_shape_id@0x1000
+          v22:CShape = LoadField v21, :shape_id@0x1000
           v23:CShape[0x1001] = GuardBitEquals v22, CShape(0x1001)
           StoreField v21, :@foo@0x1002, v10
           WriteBarrier v21, v10
           v26:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v21, :_shape_id@0x1000, v26
+          StoreField v21, :shape_id@0x1000, v26
           CheckInterrupts
           Return v10
         ");
@@ -5687,19 +5687,19 @@ mod hir_opt_tests {
           v10:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
           v28:HeapBasicObject = GuardType v6, HeapBasicObject
-          v29:CShape = LoadField v28, :_shape_id@0x1000
+          v29:CShape = LoadField v28, :shape_id@0x1000
           v30:CShape[0x1001] = GuardBitEquals v29, CShape(0x1001)
           StoreField v28, :@foo@0x1002, v10
           WriteBarrier v28, v10
           v33:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v28, :_shape_id@0x1000, v33
+          StoreField v28, :shape_id@0x1000, v33
           v14:HeapBasicObject = RefineType v28, HeapBasicObject
           v17:Fixnum[2] = Const Value(2)
           PatchPoint SingleRactorMode
           StoreField v14, :@bar@0x1004, v17
           WriteBarrier v14, v17
           v40:CShape[0x1005] = Const CShape(0x1005)
-          StoreField v14, :_shape_id@0x1000, v40
+          StoreField v14, :shape_id@0x1000, v40
           CheckInterrupts
           Return v17
         ");
@@ -7508,7 +7508,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v26:CShape = LoadField v23, :_shape_id@0x1040
+          v26:CShape = LoadField v23, :shape_id@0x1040
           v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041)
           v28:BasicObject = LoadField v23, :@foo@0x1042
           CheckInterrupts
@@ -7595,7 +7595,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v12:CUInt64 = LoadField v11, :_rbasic_flags@0x1000
+          v12:CUInt64 = LoadField v11, :RBASIC_FLAGS@0x1000
           v14:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
           v15:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v16 = RefineType v15, CUInt64
@@ -7745,7 +7745,7 @@ mod hir_opt_tests {
           v17:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
           v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v31:CShape = LoadField v28, :_shape_id@0x1040
+          v31:CShape = LoadField v28, :shape_id@0x1040
           v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
           StoreField v28, :@foo@0x1042, v17
           WriteBarrier v28, v17
@@ -7776,10 +7776,10 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v17:Module = GuardType v6, Module
-          v18:CShape = LoadField v17, :_shape_id@0x1000
+          v18:CShape = LoadField v17, :shape_id@0x1000
           v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001)
           PatchPoint RootBoxOnly
-          v21:RubyValue = LoadField v17, :_fields_obj@0x1002
+          v21:RubyValue = LoadField v17, :fields_obj@0x1002
           v22:BasicObject = LoadField v21, :@foo@0x1003
           CheckInterrupts
           Return v22
@@ -7848,10 +7848,10 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v17:Class = GuardType v6, Class
-          v18:CShape = LoadField v17, :_shape_id@0x1000
+          v18:CShape = LoadField v17, :shape_id@0x1000
           v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001)
           PatchPoint RootBoxOnly
-          v21:RubyValue = LoadField v17, :_fields_obj@0x1002
+          v21:RubyValue = LoadField v17, :fields_obj@0x1002
           v22:BasicObject = LoadField v21, :@foo@0x1003
           CheckInterrupts
           Return v22
@@ -7913,7 +7913,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v17:HeapBasicObject = GuardType v6, HeapBasicObject
-          v18:CShape = LoadField v17, :_shape_id@0x1000
+          v18:CShape = LoadField v17, :shape_id@0x1000
           v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001)
           v20:CAttrIndex[0] = Const CAttrIndex(0)
           v21:BasicObject = CCall v17, :rb_ivar_get_at_no_ractor_check@0x1008, v20
@@ -7948,9 +7948,9 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v17:TypedTData = GuardType v6, TypedTData
-          v18:CShape = LoadField v17, :_shape_id@0x1000
+          v18:CShape = LoadField v17, :shape_id@0x1000
           v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001)
-          v20:RubyValue = LoadField v17, :_fields_obj@0x1002
+          v20:RubyValue = LoadField v17, :fields_obj@0x1002
           v21:BasicObject = LoadField v20, :@a@0x1002
           CheckInterrupts
           Return v21
@@ -8084,7 +8084,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v12:CUInt64 = LoadField v11, :_rbasic_flags@0x1000
+          v12:CUInt64 = LoadField v11, :RBASIC_FLAGS@0x1000
           v14:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
           v15:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v16 = RefineType v15, CUInt64
@@ -8102,7 +8102,7 @@ mod hir_opt_tests {
           v26:CBool = IsBitEqual v25, v24
           CondBranch v26, bb7(), bb8()
         bb7():
-          v28:CPtr = LoadField v11, :_as_heap@0x1004
+          v28:CPtr = LoadField v11, :as_heap@0x1004
           v29:BasicObject = LoadField v28, :@foo@0x1000
           Jump bb4(v29)
         bb8():
@@ -8163,7 +8163,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v12:CUInt64 = LoadField v11, :_rbasic_flags@0x1000
+          v12:CUInt64 = LoadField v11, :RBASIC_FLAGS@0x1000
           v14:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
           v15:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v16 = RefineType v15, CUInt64
@@ -8171,7 +8171,7 @@ mod hir_opt_tests {
           v18:CBool = IsBitEqual v17, v16
           CondBranch v18, bb5(), bb6()
         bb5():
-          v20:CPtr = LoadField v11, :_as_heap@0x1002
+          v20:CPtr = LoadField v11, :as_heap@0x1002
           v21:BasicObject = LoadField v20, :@foo@0x1000
           Jump bb4(v21)
         bb6():
@@ -8185,9 +8185,9 @@ mod hir_opt_tests {
           v29:BasicObject = LoadField v11, :@foo@0x1004
           Jump bb4(v29)
         bb8():
-          v44:CShape = LoadField v11, :_shape_id@0x1005
+          v44:CShape = LoadField v11, :shape_id@0x1005
           v45:CShape[0x1006] = GuardBitEquals v44, CShape(0x1006)
-          v46:CPtr = LoadField v11, :_as_heap@0x1002
+          v46:CPtr = LoadField v11, :as_heap@0x1002
           v47:BasicObject = LoadField v46, :@foo@0x1000
           Jump bb4(v47)
         bb4(v13:BasicObject):
@@ -8237,7 +8237,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v12:CUInt64 = LoadField v11, :_rbasic_flags@0x1000
+          v12:CUInt64 = LoadField v11, :RBASIC_FLAGS@0x1000
           v14:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
           v15:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v16 = RefineType v15, CUInt64
@@ -8305,7 +8305,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           v11:HeapBasicObject = GuardType v6, HeapBasicObject
-          v12:CUInt64 = LoadField v11, :_rbasic_flags@0x1000
+          v12:CUInt64 = LoadField v11, :RBASIC_FLAGS@0x1000
           v14:CUInt64[0xffffffff0000005f] = Const CUInt64(0xffffffff0000005f)
           v15:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
           v16 = RefineType v15, CUInt64
@@ -8313,7 +8313,7 @@ mod hir_opt_tests {
           v18:CBool = IsBitEqual v17, v16
           CondBranch v18, bb5(), bb6()
         bb5():
-          v20:RubyValue = LoadField v11, :_fields_obj@0x1002
+          v20:RubyValue = LoadField v11, :fields_obj@0x1002
           v21:BasicObject = LoadField v20, :@a@0x1002
           Jump bb4(v21)
         bb6():
@@ -8325,7 +8325,7 @@ mod hir_opt_tests {
           CondBranch v27, bb7(), bb8()
         bb7():
           PatchPoint RootBoxOnly
-          v30:RubyValue = LoadField v11, :_fields_obj@0x1004
+          v30:RubyValue = LoadField v11, :fields_obj@0x1004
           v31:BasicObject = LoadField v30, :@a@0x1002
           Jump bb4(v31)
         bb8():
@@ -8526,14 +8526,14 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v14:ArrayExact = NewArray
           v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
+          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v20:CBool = IsBlockParamModified v19
           CondBranch v20, bb4(), bb5()
         bb4():
           v22:BasicObject = LoadField v18, :block@0x1002
           Jump bb6(v22, v22)
         bb5():
-          v24:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
+          v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
           v25:CInt64 = GuardAnyBitSet v24, CUInt64(1)
           v26:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v26, v10)
@@ -8566,14 +8566,14 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v14:ArrayExact = NewArray
           v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
+          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v20:CBool = IsBlockParamModified v19
           CondBranch v20, bb4(), bb5()
         bb4():
           v22:BasicObject = LoadField v18, :block@0x1002
           Jump bb6(v22, v22)
         bb5():
-          v24:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
+          v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
           v25:CInt64[0] = GuardBitEquals v24, CInt64(0)
           v26:NilClass = Const Value(nil)
           Jump bb6(v26, v10)
@@ -8607,14 +8607,14 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v10:ArrayExact = NewArray
           v13:CPtr = GetEP 1
-          v14:CUInt64 = LoadField v13, :_ep_flags@0x1000
+          v14:CUInt64 = LoadField v13, :VM_ENV_DATA_INDEX_FLAGS@0x1000
           v15:CBool = IsBlockParamModified v14
           CondBranch v15, bb4(), bb5()
         bb4():
           v17:BasicObject = LoadField v13, :block@0x1001
           Jump bb6(v17)
         bb5():
-          v19:CInt64 = LoadField v13, :_env_data_index_specval@0x1002
+          v19:CInt64 = LoadField v13, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
           v20:CInt64 = GuardAnyBitSet v19, CUInt64(1)
           v21:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v21)
@@ -8744,7 +8744,7 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, foo@0x1018, cme:0x1020)
-          v25:CShape = LoadField v20, :_shape_id@0x1048
+          v25:CShape = LoadField v20, :shape_id@0x1048
           v26:CShape[0x1049] = GuardBitEquals v25, CShape(0x1049)
           v27:NilClass = Const Value(nil)
           CheckInterrupts
@@ -8780,7 +8780,7 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, foo@0x1018, cme:0x1020)
-          v25:CShape = LoadField v20, :_shape_id@0x1048
+          v25:CShape = LoadField v20, :shape_id@0x1048
           v26:CShape[0x1049] = GuardBitEquals v25, CShape(0x1049)
           v27:NilClass = Const Value(nil)
           CheckInterrupts
@@ -8816,7 +8816,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v26:CShape = LoadField v23, :_shape_id@0x1040
+          v26:CShape = LoadField v23, :shape_id@0x1040
           v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041)
           v28:NilClass = Const Value(nil)
           CheckInterrupts
@@ -8852,7 +8852,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v26:CShape = LoadField v23, :_shape_id@0x1040
+          v26:CShape = LoadField v23, :shape_id@0x1040
           v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041)
           v28:NilClass = Const Value(nil)
           CheckInterrupts
@@ -8888,12 +8888,12 @@ mod hir_opt_tests {
           v17:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
           v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v31:CShape = LoadField v28, :_shape_id@0x1040
+          v31:CShape = LoadField v28, :shape_id@0x1040
           v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
           StoreField v28, :@foo@0x1042, v17
           WriteBarrier v28, v17
           v35:CShape[0x1043] = Const CShape(0x1043)
-          StoreField v28, :_shape_id@0x1040, v35
+          StoreField v28, :shape_id@0x1040, v35
           CheckInterrupts
           Return v17
         ");
@@ -8927,12 +8927,12 @@ mod hir_opt_tests {
           v17:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
           v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v31:CShape = LoadField v28, :_shape_id@0x1040
+          v31:CShape = LoadField v28, :shape_id@0x1040
           v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
           StoreField v28, :@foo@0x1042, v17
           WriteBarrier v28, v17
           v35:CShape[0x1043] = Const CShape(0x1043)
-          StoreField v28, :_shape_id@0x1040, v35
+          StoreField v28, :shape_id@0x1040, v35
           CheckInterrupts
           Return v17
         ");
@@ -8994,7 +8994,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v24:CPtr = LoadField v23, :_as_heap@0x1040
+          v24:CPtr = LoadField v23, :as_heap@0x1040
           v25:BasicObject = LoadField v24, :foo@0x1041
           CheckInterrupts
           Return v25
@@ -9063,7 +9063,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
           v31:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C]
-          v32:CUInt64 = LoadField v31, :_rbasic_flags@0x1040
+          v32:CUInt64 = LoadField v31, :RBASIC_FLAGS@0x1040
           v33:CUInt64 = GuardNoBitsSet v32, RUBY_FL_FREEZE=CUInt64(2048)
           StoreField v31, :foo=@0x1041, v13
           WriteBarrier v31, v13
@@ -9100,9 +9100,9 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
           v31:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C]
-          v32:CUInt64 = LoadField v31, :_rbasic_flags@0x1040
+          v32:CUInt64 = LoadField v31, :RBASIC_FLAGS@0x1040
           v33:CUInt64 = GuardNoBitsSet v32, RUBY_FL_FREEZE=CUInt64(2048)
-          v34:CPtr = LoadField v31, :_as_heap@0x1041
+          v34:CPtr = LoadField v31, :as_heap@0x1041
           StoreField v34, :foo=@0x1042, v13
           WriteBarrier v31, v13
           CheckInterrupts
@@ -9759,7 +9759,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []=@0x1010, cme:0x1018)
           v33:ArrayExact = GuardType v10, ArrayExact
-          v34:CUInt64 = LoadField v33, :_rbasic_flags@0x1040
+          v34:CUInt64 = LoadField v33, :RBASIC_FLAGS@0x1040
           v35:CUInt64 = GuardNoBitsSet v34, RUBY_FL_FREEZE=CUInt64(2048)
           v37:CUInt64 = GuardNoBitsSet v34, RUBY_ELTS_SHARED=CUInt64(4096)
           v46:CInt64[1] = Const CInt64(1)
@@ -9802,7 +9802,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Array@0x1008, []=@0x1010, cme:0x1018)
           v37:ArrayExact = GuardType v14, ArrayExact
           v38:Fixnum = GuardType v15, Fixnum
-          v39:CUInt64 = LoadField v37, :_rbasic_flags@0x1040
+          v39:CUInt64 = LoadField v37, :RBASIC_FLAGS@0x1040
           v40:CUInt64 = GuardNoBitsSet v39, RUBY_FL_FREEZE=CUInt64(2048)
           v42:CUInt64 = GuardNoBitsSet v39, RUBY_ELTS_SHARED=CUInt64(4096)
           v43:CInt64 = UnboxFixnum v38
@@ -9881,7 +9881,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, <<@0x1010, cme:0x1018)
           v27:ArrayExact = GuardType v10, ArrayExact
-          v28:CUInt64 = LoadField v27, :_rbasic_flags@0x1040
+          v28:CUInt64 = LoadField v27, :RBASIC_FLAGS@0x1040
           v29:CUInt64 = GuardNoBitsSet v28, RUBY_FL_FREEZE=CUInt64(2048)
           ArrayPush v27, v15
           CheckInterrupts
@@ -9915,7 +9915,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, push@0x1010, cme:0x1018)
           v26:ArrayExact = GuardType v10, ArrayExact
-          v27:CUInt64 = LoadField v26, :_rbasic_flags@0x1040
+          v27:CUInt64 = LoadField v26, :RBASIC_FLAGS@0x1040
           v28:CUInt64 = GuardNoBitsSet v27, RUBY_FL_FREEZE=CUInt64(2048)
           ArrayPush v26, v15
           CheckInterrupts
@@ -9982,12 +9982,12 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Array@0x1008, <<@0x1010, cme:0x1018)
           v23:CPtr = GetEP 0
-          v24:RubyValue = LoadField v23, :_ep_method_entry@0x1040
+          v24:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
           v25:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v24, Value(VALUE(0x1048))
-          v26:RubyValue = LoadField v23, :_ep_specval@0x1050
+          v26:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
           v27:FalseClass = GuardBitEquals v26, Value(false)
           v28:Array = GuardType v9, Array
-          v29:CUInt64 = LoadField v28, :_rbasic_flags@0x1051
+          v29:CUInt64 = LoadField v28, :RBASIC_FLAGS@0x1051
           v30:CUInt64 = GuardNoBitsSet v29, RUBY_FL_FREEZE=CUInt64(2048)
           ArrayPush v28, v10
           CheckInterrupts
@@ -10017,17 +10017,17 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Array@0x1000, pop@0x1008, cme:0x1010)
           v18:CPtr = GetEP 0
-          v19:RubyValue = LoadField v18, :_ep_method_entry@0x1038
+          v19:RubyValue = LoadField v18, :VM_ENV_DATA_INDEX_ME_CREF@0x1038
           v20:CallableMethodEntry[VALUE(0x1040)] = GuardBitEquals v19, Value(VALUE(0x1040))
-          v21:RubyValue = LoadField v18, :_ep_specval@0x1048
+          v21:RubyValue = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1048
           v22:FalseClass = GuardBitEquals v21, Value(false)
           v30:CPtr = GetEP 0
-          v31:RubyValue = LoadField v30, :_ep_method_entry@0x1038
+          v31:RubyValue = LoadField v30, :VM_ENV_DATA_INDEX_ME_CREF@0x1038
           v32:CallableMethodEntry[VALUE(0x1040)] = GuardBitEquals v31, Value(VALUE(0x1040))
-          v33:RubyValue = LoadField v30, :_ep_specval@0x1048
+          v33:RubyValue = LoadField v30, :VM_ENV_DATA_INDEX_SPECVAL@0x1048
           v34:FalseClass = GuardBitEquals v33, Value(false)
           v23:Array = GuardType v6, Array
-          v24:CUInt64 = LoadField v23, :_rbasic_flags@0x1049
+          v24:CUInt64 = LoadField v23, :RBASIC_FLAGS@0x1049
           v25:CUInt64 = GuardNoBitsSet v24, RUBY_FL_FREEZE=CUInt64(2048)
           v27:CUInt64 = GuardNoBitsSet v24, RUBY_ELTS_SHARED=CUInt64(4096)
           v28:BasicObject = ArrayPop v23
@@ -10061,14 +10061,14 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
           v23:CPtr = GetEP 0
-          v24:RubyValue = LoadField v23, :_ep_method_entry@0x1040
+          v24:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
           v25:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v24, Value(VALUE(0x1048))
-          v26:RubyValue = LoadField v23, :_ep_specval@0x1050
+          v26:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
           v27:FalseClass = GuardBitEquals v26, Value(false)
           v38:CPtr = GetEP 0
-          v39:RubyValue = LoadField v38, :_ep_method_entry@0x1040
+          v39:RubyValue = LoadField v38, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
           v40:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v39, Value(VALUE(0x1048))
-          v41:RubyValue = LoadField v38, :_ep_specval@0x1050
+          v41:RubyValue = LoadField v38, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
           v42:FalseClass = GuardBitEquals v41, Value(false)
           v28:Array = GuardType v9, Array
           v29:Fixnum = GuardType v10, Fixnum
@@ -10109,9 +10109,9 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
           v23:CPtr = GetEP 0
-          v24:RubyValue = LoadField v23, :_ep_method_entry@0x1040
+          v24:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
           v25:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v24, Value(VALUE(0x1048))
-          v26:RubyValue = LoadField v23, :_ep_specval@0x1050
+          v26:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
           v27:FalseClass = GuardBitEquals v26, Value(false)
           v28:BasicObject = CCallVariadic v9, :Array#[]@0x1058, v10
           CheckInterrupts
@@ -10328,7 +10328,7 @@ mod hir_opt_tests {
           v38:CInt64 = AdjustBounds v37, v36
           v39:CInt64[0] = Const CInt64(0)
           v40:CInt64 = GuardGreaterEq v38, v39
-          v41:CUInt64 = LoadField v32, :_rbasic_flags@0x1041
+          v41:CUInt64 = LoadField v32, :RBASIC_FLAGS@0x1041
           v42:CUInt64 = GuardNoBitsSet v41, RUBY_FL_FREEZE=CUInt64(2048)
           v43:Fixnum = StringSetbyteFixnum v32, v33, v34
           CheckInterrupts
@@ -10375,7 +10375,7 @@ mod hir_opt_tests {
           v38:CInt64 = AdjustBounds v37, v36
           v39:CInt64[0] = Const CInt64(0)
           v40:CInt64 = GuardGreaterEq v38, v39
-          v41:CUInt64 = LoadField v32, :_rbasic_flags@0x1041
+          v41:CUInt64 = LoadField v32, :RBASIC_FLAGS@0x1041
           v42:CUInt64 = GuardNoBitsSet v41, RUBY_FL_FREEZE=CUInt64(2048)
           v43:Fixnum = StringSetbyteFixnum v32, v33, v34
           CheckInterrupts
@@ -12103,14 +12103,14 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v14:ArrayExact = NewArray
           v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
+          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v20:CBool = IsBlockParamModified v19
           CondBranch v20, bb4(), bb5()
         bb4():
           v22:BasicObject = LoadField v18, :block@0x1002
           Jump bb6(v22, v22)
         bb5():
-          v24:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
+          v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
           v25:CInt64 = GuardAnyBitSet v24, CUInt64(1)
           v26:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v26, v10)
@@ -13881,7 +13881,7 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestUnfrozen@0x1010)
           PatchPoint MethodRedefined(TestUnfrozen@0x1010, a@0x1018, cme:0x1020)
-          v25:CShape = LoadField v20, :_shape_id@0x1048
+          v25:CShape = LoadField v20, :shape_id@0x1048
           v26:CShape[0x1049] = GuardBitEquals v25, CShape(0x1049)
           v27:BasicObject = LoadField v20, :@a@0x104a
           CheckInterrupts
@@ -14039,7 +14039,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(TestDynamic@0x1008)
           PatchPoint MethodRedefined(TestDynamic@0x1008, val@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:TestDynamic] = GuardType v10, ObjectSubclass[class_exact:TestDynamic]
-          v26:CShape = LoadField v23, :_shape_id@0x1040
+          v26:CShape = LoadField v23, :shape_id@0x1040
           v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041)
           v28:BasicObject = LoadField v23, :@val@0x1042
           CheckInterrupts
@@ -14447,9 +14447,9 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(A@0x1000, foo@0x1008, cme:0x1010)
           v18:CPtr = GetEP 0
-          v19:RubyValue = LoadField v18, :_ep_method_entry@0x1038
+          v19:RubyValue = LoadField v18, :VM_ENV_DATA_INDEX_ME_CREF@0x1038
           v20:CallableMethodEntry[VALUE(0x1040)] = GuardBitEquals v19, Value(VALUE(0x1040))
-          v21:RubyValue = LoadField v18, :_ep_specval@0x1048
+          v21:RubyValue = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1048
           v22:FalseClass = GuardBitEquals v21, Value(false)
           v23:BasicObject = SendDirect v6, 0x1050, :foo (0x1060)
           CheckInterrupts
@@ -14519,9 +14519,9 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint MethodRedefined(A@0x1008, foo@0x1010, cme:0x1018)
           v28:CPtr = GetEP 0
-          v29:RubyValue = LoadField v28, :_ep_method_entry@0x1040
+          v29:RubyValue = LoadField v28, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
           v30:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v29, Value(VALUE(0x1048))
-          v31:RubyValue = LoadField v28, :_ep_specval@0x1050
+          v31:RubyValue = LoadField v28, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
           v32:FalseClass = GuardBitEquals v31, Value(false)
           v33:BasicObject = SendDirect v9, 0x1058, :foo (0x1068), v10
           v18:Fixnum[1] = Const Value(1)
@@ -14644,9 +14644,9 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Hash@0x1000, size@0x1008, cme:0x1010)
           v18:CPtr = GetEP 0
-          v19:RubyValue = LoadField v18, :_ep_method_entry@0x1038
+          v19:RubyValue = LoadField v18, :VM_ENV_DATA_INDEX_ME_CREF@0x1038
           v20:CallableMethodEntry[VALUE(0x1040)] = GuardBitEquals v19, Value(VALUE(0x1040))
-          v21:RubyValue = LoadField v18, :_ep_specval@0x1048
+          v21:RubyValue = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1048
           v22:FalseClass = GuardBitEquals v21, Value(false)
           v23:Fixnum = CCall v6, :Hash#size@0x1050
           CheckInterrupts
@@ -14678,9 +14678,9 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(BasicObject@0x1000, initialize@0x1008, cme:0x1010)
           v18:CPtr = GetEP 0
-          v19:RubyValue = LoadField v18, :_ep_method_entry@0x1038
+          v19:RubyValue = LoadField v18, :VM_ENV_DATA_INDEX_ME_CREF@0x1038
           v20:CallableMethodEntry[VALUE(0x1040)] = GuardBitEquals v19, Value(VALUE(0x1040))
-          v21:RubyValue = LoadField v18, :_ep_specval@0x1048
+          v21:RubyValue = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1048
           v22:FalseClass = GuardBitEquals v21, Value(false)
           v23:NilClass = Const Value(nil)
           CheckInterrupts
@@ -14736,9 +14736,9 @@ mod hir_opt_tests {
         bb5(v28:BasicObject, v29:BasicObject, v30:BasicObject):
           PatchPoint MethodRedefined(String@0x1008, byteindex@0x1010, cme:0x1018)
           v44:CPtr = GetEP 0
-          v45:RubyValue = LoadField v44, :_ep_method_entry@0x1040
+          v45:RubyValue = LoadField v44, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
           v46:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v45, Value(VALUE(0x1048))
-          v47:RubyValue = LoadField v44, :_ep_specval@0x1050
+          v47:RubyValue = LoadField v44, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
           v48:FalseClass = GuardBitEquals v47, Value(false)
           v49:BasicObject = CCallVariadic v28, :String#byteindex@0x1058, v29, v30
           CheckInterrupts
@@ -15324,13 +15324,13 @@ mod hir_opt_tests {
           v14:HeapBasicObject = RefineType v6, HeapBasicObject
           v17:Fixnum[2] = Const Value(2)
           PatchPoint SingleRactorMode
-          v29:CShape = LoadField v14, :_shape_id@0x1000
+          v29:CShape = LoadField v14, :shape_id@0x1000
           v30:CShape[0x1001] = GuardBitEquals v29, CShape(0x1001)
-          v31:CPtr = LoadField v14, :_as_heap@0x1002
+          v31:CPtr = LoadField v14, :as_heap@0x1002
           StoreField v31, :@after@0x1003, v17
           WriteBarrier v14, v17
           v34:CShape[0x1004] = Const CShape(0x1004)
-          StoreField v14, :_shape_id@0x1000, v34
+          StoreField v14, :shape_id@0x1000, v34
           CheckInterrupts
           Return v17
         ");
@@ -15523,12 +15523,12 @@ mod hir_opt_tests {
           v13:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
           v35:HeapBasicObject = GuardType v8, HeapBasicObject
-          v36:CShape = LoadField v35, :_shape_id@0x1000
+          v36:CShape = LoadField v35, :shape_id@0x1000
           v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001)
           StoreField v35, :@a@0x1002, v13
           WriteBarrier v35, v13
           v40:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v35, :_shape_id@0x1000, v40
+          StoreField v35, :shape_id@0x1000, v40
           v20:HeapBasicObject = RefineType v35, HeapBasicObject
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
@@ -15571,12 +15571,12 @@ mod hir_opt_tests {
           v16:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
           v49:HeapBasicObject = GuardType v10, HeapBasicObject
-          v50:CShape = LoadField v49, :_shape_id@0x1000
+          v50:CShape = LoadField v49, :shape_id@0x1000
           v51:CShape[0x1001] = GuardBitEquals v50, CShape(0x1001)
           StoreField v49, :@a@0x1002, v16
           WriteBarrier v49, v16
           v54:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v49, :_shape_id@0x1000, v54
+          StoreField v49, :shape_id@0x1000, v54
           v23:HeapBasicObject = RefineType v49, HeapBasicObject
           v26:Fixnum[5] = Const Value(5)
           PatchPoint NoEPEscape(initialize)
@@ -15619,12 +15619,12 @@ mod hir_opt_tests {
           v13:Fixnum[1] = Const Value(1)
           PatchPoint SingleRactorMode
           v43:HeapBasicObject = GuardType v8, HeapBasicObject
-          v44:CShape = LoadField v43, :_shape_id@0x1000
+          v44:CShape = LoadField v43, :shape_id@0x1000
           v45:CShape[0x1001] = GuardBitEquals v44, CShape(0x1001)
           StoreField v43, :@a@0x1002, v13
           WriteBarrier v43, v13
           v48:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v43, :_shape_id@0x1000, v48
+          StoreField v43, :shape_id@0x1000, v48
           v20:HeapBasicObject = RefineType v43, HeapBasicObject
           PatchPoint NoEPEscape(initialize)
           PatchPoint SingleRactorMode
@@ -15824,7 +15824,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v10:Fixnum[1] = Const Value(1)
           v12:CPtr = GetEP 0
-          v13:CInt64 = LoadField v12, :_env_data_index_specval@0x1000
+          v13:CInt64 = LoadField v12, :VM_ENV_DATA_INDEX_SPECVAL@0x1000
           v14:CInt64[3] = Const CInt64(3)
           v15:CInt64 = IntAnd v13, v14
           v16:CInt64[3] = Const CInt64(3)
@@ -15839,7 +15839,7 @@ mod hir_opt_tests {
         bb4(v18:BasicObject):
           v27:Fixnum[2] = Const Value(2)
           v29:CPtr = GetEP 0
-          v30:CInt64 = LoadField v29, :_env_data_index_specval@0x1000
+          v30:CInt64 = LoadField v29, :VM_ENV_DATA_INDEX_SPECVAL@0x1000
           v31:CInt64[3] = Const CInt64(3)
           v32:CInt64 = IntAnd v30, v31
           v33:CInt64[3] = Const CInt64(3)
@@ -16002,7 +16002,7 @@ mod hir_opt_tests {
         bb4(v40:BasicObject, v41:Fixnum):
           PatchPoint SingleRactorMode
           v46:HeapBasicObject = GuardType v40, HeapBasicObject
-          v47:CUInt64 = LoadField v46, :_rbasic_flags@0x1038
+          v47:CUInt64 = LoadField v46, :RBASIC_FLAGS@0x1038
           v49:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
           v50:CPtr[CPtr(0x1039)] = Const CPtr(0x1039)
           v51 = RefineType v50, CUInt64
@@ -16023,7 +16023,7 @@ mod hir_opt_tests {
           v63:NilClass = Const Value(nil)
           Jump bb8(v63)
         bb12():
-          v97:CShape = LoadField v46, :_shape_id@0x103c
+          v97:CShape = LoadField v46, :shape_id@0x103c
           v98:CShape[0x103d] = GuardBitEquals v97, CShape(0x103d)
           v99:BasicObject = LoadField v46, :@levar@0x103a
           Jump bb8(v99)
@@ -16034,12 +16034,12 @@ mod hir_opt_tests {
         bb13():
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
-          v101:CShape = LoadField v46, :_shape_id@0x103c
+          v101:CShape = LoadField v46, :shape_id@0x103c
           v102:CShape[0x103e] = GuardBitEquals v101, CShape(0x103e)
           StoreField v46, :@levar@0x103a, v41
           WriteBarrier v46, v41
           v105:CShape[0x103d] = Const CShape(0x103d)
-          StoreField v46, :_shape_id@0x103c, v105
+          StoreField v46, :shape_id@0x103c, v105
           v79:HeapBasicObject = RefineType v46, HeapBasicObject
           Jump bb5(v79, v41)
         bb5(v81:HeapBasicObject, v82:Fixnum):

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -2419,7 +2419,7 @@ pub(crate) mod hir_build_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v16:ArrayExact = ToNewArray v10
           v18:Fixnum[1] = Const Value(1)
-          v20:CUInt64 = LoadField v16, :_rbasic_flags@0x1001
+          v20:CUInt64 = LoadField v16, :RBASIC_FLAGS@0x1001
           v21:CUInt64 = GuardNoBitsSet v20, RUBY_FL_FREEZE=CUInt64(2048)
           ArrayPush v16, v18
           v24:BasicObject = Send v9, :foo, v16 # SendFallbackReason: Uncategorized(opt_send_without_block)
@@ -2483,14 +2483,14 @@ pub(crate) mod hir_build_tests {
           v29:ArrayExact = ToArray v19
           PatchPoint NoEPEscape(test)
           v36:CPtr = GetEP 0
-          v37:CUInt64 = LoadField v36, :_ep_flags@0x1004
+          v37:CUInt64 = LoadField v36, :VM_ENV_DATA_INDEX_FLAGS@0x1004
           v38:CBool = IsBlockParamModified v37
           CondBranch v38, bb4(), bb5()
         bb4():
           v40:BasicObject = LoadField v36, :&@0x1005
           Jump bb6(v40, v40)
         bb5():
-          v42:CInt64 = LoadField v36, :_env_data_index_specval@0x1006
+          v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
           v43:CInt64 = GuardAnyBitSet v42, CUInt64(1)
           v44:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v44, v21)
@@ -3403,7 +3403,7 @@ pub(crate) mod hir_build_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v15:CPtr = GetEP 0
-          v16:CUInt64 = LoadField v15, :_ep_flags@0x1001
+          v16:CUInt64 = LoadField v15, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v17:CBool = IsBlockParamModified v16
           CondBranch v17, bb4(), bb5()
         bb4():
@@ -3439,14 +3439,14 @@ pub(crate) mod hir_build_tests {
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
           v17:CPtr = GetEP 0
-          v18:CUInt64 = LoadField v17, :_ep_flags@0x1001
+          v18:CUInt64 = LoadField v17, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v19:CBool = IsBlockParamModified v18
           CondBranch v19, bb4(), bb5()
         bb4():
           v21:BasicObject = LoadField v17, :block@0x1002
           Jump bb6(v21, v21)
         bb5():
-          v23:CInt64 = LoadField v17, :_env_data_index_specval@0x1003
+          v23:CInt64 = LoadField v17, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
           v24:CInt64 = GuardAnyBitSet v23, CUInt64(1)
           v25:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v25, v10)
@@ -3483,7 +3483,7 @@ pub(crate) mod hir_build_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
           v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
+          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v20:CBool = IsBlockParamModified v19
           CondBranch v20, bb4(), bb5()
         bb4():
@@ -3494,14 +3494,14 @@ pub(crate) mod hir_build_tests {
           Jump bb6(v24)
         bb6(v17:BasicObject):
           v32:CPtr = GetEP 0
-          v33:CUInt64 = LoadField v32, :_ep_flags@0x1001
+          v33:CUInt64 = LoadField v32, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v34:CBool = IsBlockParamModified v33
           CondBranch v34, bb7(), bb8()
         bb7():
           v36:BasicObject = LoadField v32, :block@0x1002
           Jump bb9(v36, v36)
         bb8():
-          v38:CInt64 = LoadField v32, :_env_data_index_specval@0x1003
+          v38:CInt64 = LoadField v32, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
           v39:CInt64 = GuardAnyBitSet v38, CUInt64(1)
           v40:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb9(v40, v17)
@@ -3536,7 +3536,7 @@ pub(crate) mod hir_build_tests {
           Jump bb3(v5, v6)
         bb3(v8:BasicObject, v9:NilClass):
           v14:CPtr = GetEP 1
-          v15:CUInt64 = LoadField v14, :_ep_flags@0x1000
+          v15:CUInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000
           v16:CBool = IsBlockParamModified v15
           CondBranch v16, bb4(), bb5()
         bb4():
@@ -3547,14 +3547,14 @@ pub(crate) mod hir_build_tests {
           Jump bb6(v20)
         bb6(v13:BasicObject):
           v27:CPtr = GetEP 1
-          v28:CUInt64 = LoadField v27, :_ep_flags@0x1000
+          v28:CUInt64 = LoadField v27, :VM_ENV_DATA_INDEX_FLAGS@0x1000
           v29:CBool = IsBlockParamModified v28
           CondBranch v29, bb7(), bb8()
         bb7():
           v31:BasicObject = LoadField v27, :block@0x1001
           Jump bb9(v31)
         bb8():
-          v33:CInt64 = LoadField v27, :_env_data_index_specval@0x1002
+          v33:CInt64 = LoadField v27, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
           v34:CInt64 = GuardAnyBitSet v33, CUInt64(1)
           v35:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb9(v35)
@@ -3593,14 +3593,14 @@ pub(crate) mod hir_build_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v14:Fixnum[0] = Const Value(0)
           v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :_ep_flags@0x1001
+          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v20:CBool = IsBlockParamModified v19
           CondBranch v20, bb4(), bb5()
         bb4():
           v22:BasicObject = LoadField v18, :block@0x1002
           Jump bb6(v22, v22)
         bb5():
-          v24:CInt64 = LoadField v18, :_env_data_index_specval@0x1003
+          v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
           v25:CInt64[1] = Const CInt64(1)
           v26:CInt64 = IntAnd v24, v25
           v27:CBool = IsBitEqual v26, v25
@@ -3645,7 +3645,7 @@ pub(crate) mod hir_build_tests {
           Jump bb3(v4)
         bb3(v6:BasicObject):
           v11:CPtr = GetEP 1
-          v12:CUInt64 = LoadField v11, :_ep_flags@0x1000
+          v12:CUInt64 = LoadField v11, :VM_ENV_DATA_INDEX_FLAGS@0x1000
           v13:CBool = IsBlockParamModified v12
           CondBranch v13, bb4(), bb5()
         bb4():
@@ -3685,10 +3685,10 @@ pub(crate) mod hir_build_tests {
           v14:NilClass = Const Value(nil)
           SetLocal :block, l0, EP@3, v14
           v18:CPtr = GetEP 0
-          v19:CInt64 = LoadField v18, :_env_data_index_flags@0x1001
+          v19:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v20:CInt64[512] = Const CInt64(512)
           v21:CInt64 = IntOr v19, v20
-          StoreField v18, :_env_data_index_flags@0x1001, v21
+          StoreField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001, v21
           CheckInterrupts
           Return v14
         ");
@@ -3717,10 +3717,10 @@ pub(crate) mod hir_build_tests {
           v10:NilClass = Const Value(nil)
           SetLocal :block, l1, EP@3, v10
           v14:CPtr = GetEP 1
-          v15:CInt64 = LoadField v14, :_env_data_index_flags@0x1000
+          v15:CInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000
           v16:CInt64[512] = Const CInt64(512)
           v17:CInt64 = IntOr v15, v16
-          StoreField v14, :_env_data_index_flags@0x1000, v17
+          StoreField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000, v17
           CheckInterrupts
           Return v10
         ");
@@ -3750,14 +3750,14 @@ pub(crate) mod hir_build_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v21:CPtr = GetEP 0
-          v22:CUInt64 = LoadField v21, :_ep_flags@0x1002
+          v22:CUInt64 = LoadField v21, :VM_ENV_DATA_INDEX_FLAGS@0x1002
           v23:CBool = IsBlockParamModified v22
           CondBranch v23, bb4(), bb5()
         bb4():
           v25:BasicObject = LoadField v21, :b@0x1003
           Jump bb6(v25, v25)
         bb5():
-          v27:CInt64 = LoadField v21, :_env_data_index_specval@0x1004
+          v27:CInt64 = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
           v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
           v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v29, v13)
@@ -3799,14 +3799,14 @@ pub(crate) mod hir_build_tests {
           v29:ArrayExact = ToArray v19
           PatchPoint NoEPEscape(test)
           v36:CPtr = GetEP 0
-          v37:CUInt64 = LoadField v36, :_ep_flags@0x1004
+          v37:CUInt64 = LoadField v36, :VM_ENV_DATA_INDEX_FLAGS@0x1004
           v38:CBool = IsBlockParamModified v37
           CondBranch v38, bb4(), bb5()
         bb4():
           v40:BasicObject = LoadField v36, :&@0x1005
           Jump bb6(v40, v40)
         bb5():
-          v42:CInt64 = LoadField v36, :_env_data_index_specval@0x1006
+          v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
           v43:CInt64[0] = GuardBitEquals v42, CInt64(0)
           v44:NilClass = Const Value(nil)
           Jump bb6(v44, v21)
@@ -3843,14 +3843,14 @@ pub(crate) mod hir_build_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v21:CPtr = GetEP 0
-          v22:CUInt64 = LoadField v21, :_ep_flags@0x1002
+          v22:CUInt64 = LoadField v21, :VM_ENV_DATA_INDEX_FLAGS@0x1002
           v23:CBool = IsBlockParamModified v22
           CondBranch v23, bb4(), bb5()
         bb4():
           v25:BasicObject = LoadField v21, :b@0x1003
           Jump bb6(v25, v25)
         bb5():
-          v27:CInt64 = LoadField v21, :_env_data_index_specval@0x1004
+          v27:CInt64 = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
           v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
           v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v29, v13)
@@ -3887,14 +3887,14 @@ pub(crate) mod hir_build_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v21:CPtr = GetEP 0
-          v22:CUInt64 = LoadField v21, :_ep_flags@0x1002
+          v22:CUInt64 = LoadField v21, :VM_ENV_DATA_INDEX_FLAGS@0x1002
           v23:CBool = IsBlockParamModified v22
           CondBranch v23, bb4(), bb5()
         bb4():
           v25:BasicObject = LoadField v21, :b@0x1003
           Jump bb6(v25, v25)
         bb5():
-          v27:CInt64 = LoadField v21, :_env_data_index_specval@0x1004
+          v27:CInt64 = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
           v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
           v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v29, v13)
@@ -3941,14 +3941,14 @@ pub(crate) mod hir_build_tests {
           v29:ArrayExact = ToArray v19
           PatchPoint NoEPEscape(test)
           v36:CPtr = GetEP 0
-          v37:CUInt64 = LoadField v36, :_ep_flags@0x1004
+          v37:CUInt64 = LoadField v36, :VM_ENV_DATA_INDEX_FLAGS@0x1004
           v38:CBool = IsBlockParamModified v37
           CondBranch v38, bb4(), bb5()
         bb4():
           v40:BasicObject = LoadField v36, :&@0x1005
           Jump bb6(v40, v40)
         bb5():
-          v42:CInt64 = LoadField v36, :_env_data_index_specval@0x1006
+          v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
           v43:CInt64[0] = GuardBitEquals v42, CInt64(0)
           v44:NilClass = Const Value(nil)
           Jump bb6(v44, v21)
@@ -3984,14 +3984,14 @@ pub(crate) mod hir_build_tests {
           Jump bb3(v7, v8, v9)
         bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
           v21:CPtr = GetEP 0
-          v22:CUInt64 = LoadField v21, :_ep_flags@0x1002
+          v22:CUInt64 = LoadField v21, :VM_ENV_DATA_INDEX_FLAGS@0x1002
           v23:CBool = IsBlockParamModified v22
           CondBranch v23, bb4(), bb5()
         bb4():
           v25:BasicObject = LoadField v21, :block@0x1003
           Jump bb6(v25, v25)
         bb5():
-          v27:CInt64 = LoadField v21, :_env_data_index_specval@0x1004
+          v27:CInt64 = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
           v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
           v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb6(v29, v13)
@@ -4077,7 +4077,7 @@ pub(crate) mod hir_build_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v15:ArrayExact = ToNewArray v10
           v17:Fixnum[1] = Const Value(1)
-          v19:CUInt64 = LoadField v15, :_rbasic_flags@0x1001
+          v19:CUInt64 = LoadField v15, :RBASIC_FLAGS@0x1001
           v20:CUInt64 = GuardNoBitsSet v19, RUBY_FL_FREEZE=CUInt64(2048)
           ArrayPush v15, v17
           CheckInterrupts
@@ -4109,7 +4109,7 @@ pub(crate) mod hir_build_tests {
           v17:Fixnum[1] = Const Value(1)
           v19:Fixnum[2] = Const Value(2)
           v21:Fixnum[3] = Const Value(3)
-          v23:CUInt64 = LoadField v15, :_rbasic_flags@0x1001
+          v23:CUInt64 = LoadField v15, :RBASIC_FLAGS@0x1001
           v24:CUInt64 = GuardNoBitsSet v23, RUBY_FL_FREEZE=CUInt64(2048)
           ArrayPush v15, v17
           ArrayPush v15, v19
@@ -4684,14 +4684,14 @@ pub(crate) mod hir_build_tests {
           v27:BasicObject = InvokeBuiltin dir_s_open, v18, v19, v20
           PatchPoint NoEPEscape(open)
           v35:CPtr = GetEP 0
-          v36:CUInt64 = LoadField v35, :_ep_flags@0x1004
+          v36:CUInt64 = LoadField v35, :VM_ENV_DATA_INDEX_FLAGS@0x1004
           v37:CBool = IsBlockParamModified v36
           CondBranch v37, bb5(), bb6()
         bb5():
           v39:BasicObject = LoadField v35, :block@0x1005
           Jump bb7(v39, v39)
         bb6():
-          v41:CInt64 = LoadField v35, :_env_data_index_specval@0x1006
+          v41:CInt64 = LoadField v35, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
           v42:CInt64 = GuardAnyBitSet v41, CUInt64(1)
           v43:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
           Jump bb7(v43, v22)


### PR DESCRIPTION
This PR introduces `FieldName` enum that is used for `LoadField` identifiers in HIR dump.

Currently, we intern `ID`s (`def_ids!` uses `rb_intern2`) for HIR dump purposes. Since these IDs are not used by CRuby, we shouldn't insert these IDs into CRuby's symbol table, which would consume extra memory.

Also this PR prefers the use of canonical names for the index used by CRuby, e.g. `VM_ENV_DATA_INDEX_FLAGS`. Previously, we used inconsistent names for these things, so we ended up having multiple names for the same thing: `_ep_specval`/`_env_data_index_specval` and `_ep_flags`/`_env_data_index_flags`, which leads to confusion.