### PR TITLE
ZJIT: Add back return type for .class

### DIFF
--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -287,9 +287,7 @@ pub fn init() -> Annotations {
     annotate_builtin!(rb_cFloat, "negative?", types::BoolExact);
     annotate_builtin!(rb_mKernel, "Float", types::Float);
     annotate_builtin!(rb_mKernel, "Integer", types::Integer);
-    // TODO(max): Annotate rb_mKernel#class as returning types::Class. Right now there is a subtle
-    // type system bug that causes an issue if we make it return types::Class.
-    annotate_builtin!(rb_mKernel, "class", inline_kernel_class, types::HeapObject, leaf);
+    annotate_builtin!(rb_mKernel, "class", inline_kernel_class, types::Class, leaf);
     annotate_builtin!(rb_mKernel, "frozen?", types::BoolExact);
     annotate_builtin!(rb_cSymbol, "name", types::StringExact);
     annotate_builtin!(rb_cSymbol, "to_s", types::StringExact);

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -4644,9 +4644,9 @@ pub(crate) mod hir_build_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v10:HeapObject = InvokeBuiltin leaf <inline_expr>, v6
+          v10:Class = InvokeBuiltin leaf <inline_expr>, v6
           Jump bb4(v6, v10)
-        bb4(v12:BasicObject, v13:HeapObject):
+        bb4(v12:BasicObject, v13:Class):
           CheckInterrupts
           Return v13
         ");


### PR DESCRIPTION
We fixed the underlying bug in https://github.com/ruby/ruby/pull/15268
(f9c51ac5ea42382a22fb8a2cc5d7aeb78e77c962).
