### PR TITLE
ZJIT: Run canonicalize before fold_constants

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5007,6 +5007,8 @@ impl Function {
                 }
             }
         }
+
+        crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
     /// Use type information left by `infer_types` to fold away operations that can be evaluated at compile-time.
@@ -5612,7 +5614,6 @@ impl Function {
             // End strength reduction bucket
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
             (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
-            (infer_types) => { Counter::compile_hir_infer_types_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
             (clean_cfg) => { Counter::compile_hir_clean_cfg_time_ns };
             (remove_redundant_patch_points) => { Counter::compile_hir_remove_redundant_patch_points_time_ns };
@@ -5648,7 +5649,6 @@ impl Function {
         run_pass!(convert_no_profile_sends);
         run_pass!(optimize_load_store);
         run_pass!(canonicalize);
-        run_pass!(infer_types);
         run_pass!(fold_constants);
         run_pass!(clean_cfg);
         run_pass!(remove_redundant_patch_points);

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4162,9 +4162,6 @@ impl Function {
                 }
             }
         }
-        crate::stats::trace_compile_phase("canonicalize", ||
-            crate::stats::with_time_stat(Counter::compile_hir_canonicalize_time_ns, || self.canonicalize())
-        );
         crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
@@ -4219,9 +4216,6 @@ impl Function {
                 }
             }
         }
-        crate::stats::trace_compile_phase("canonicalize", ||
-            crate::stats::with_time_stat(Counter::compile_hir_canonicalize_time_ns, || self.canonicalize())
-        );
         crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
@@ -4526,9 +4520,6 @@ impl Function {
                 }
             }
         }
-        crate::stats::trace_compile_phase("canonicalize", ||
-            crate::stats::with_time_stat(Counter::compile_hir_canonicalize_time_ns, || self.canonicalize())
-        );
         crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
@@ -4859,9 +4850,6 @@ impl Function {
                 self.push_insn_id(block, insn_id);
             }
         }
-        crate::stats::trace_compile_phase("canonicalize", ||
-            crate::stats::with_time_stat(Counter::compile_hir_canonicalize_time_ns, || self.canonicalize())
-        );
         crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
@@ -5372,9 +5360,6 @@ impl Function {
             changed = true;
         }
         if changed {
-            crate::stats::trace_compile_phase("canonicalize", ||
-                crate::stats::with_time_stat(Counter::compile_hir_canonicalize_time_ns, || self.canonicalize())
-            );
             crate::stats::trace_compile_phase("infer_types", || self.infer_types());
         }
     }
@@ -5626,6 +5611,8 @@ impl Function {
             (convert_no_profile_sends) => { Counter::compile_hir_strength_reduce_time_ns };
             // End strength reduction bucket
             (optimize_load_store) => { Counter::compile_hir_optimize_load_store_time_ns };
+            (canonicalize) => { Counter::compile_hir_canonicalize_time_ns };
+            (infer_types) => { Counter::compile_hir_infer_types_time_ns };
             (fold_constants) => { Counter::compile_hir_fold_constants_time_ns };
             (clean_cfg) => { Counter::compile_hir_clean_cfg_time_ns };
             (remove_redundant_patch_points) => { Counter::compile_hir_remove_redundant_patch_points_time_ns };
@@ -5660,6 +5647,8 @@ impl Function {
         run_pass!(optimize_c_calls);
         run_pass!(convert_no_profile_sends);
         run_pass!(optimize_load_store);
+        run_pass!(canonicalize);
+        run_pass!(infer_types);
         run_pass!(fold_constants);
         run_pass!(clean_cfg);
         run_pass!(remove_redundant_patch_points);

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -9761,7 +9761,7 @@ mod hir_opt_tests {
           v33:ArrayExact = GuardType v10, ArrayExact
           v34:CUInt64 = LoadField v33, :_rbasic_flags@0x1040
           v35:CUInt64 = GuardNoBitsSet v34, RUBY_FL_FREEZE=CUInt64(2048)
-          v37:CUInt64 = GuardNoBitsSet v34, RUBY_ELTS_SHARED=CUInt64(4096)
+          v37:CUInt64 = GuardNoBitsSet v35, RUBY_ELTS_SHARED=CUInt64(4096)
           v46:CInt64[1] = Const CInt64(1)
           v39:CInt64 = ArrayLength v33
           v40:CInt64[1] = GuardLess v46, v39
@@ -9804,7 +9804,7 @@ mod hir_opt_tests {
           v38:Fixnum = GuardType v15, Fixnum
           v39:CUInt64 = LoadField v37, :_rbasic_flags@0x1040
           v40:CUInt64 = GuardNoBitsSet v39, RUBY_FL_FREEZE=CUInt64(2048)
-          v42:CUInt64 = GuardNoBitsSet v39, RUBY_ELTS_SHARED=CUInt64(4096)
+          v42:CUInt64 = GuardNoBitsSet v40, RUBY_ELTS_SHARED=CUInt64(4096)
           v43:CInt64 = UnboxFixnum v38
           v44:CInt64 = ArrayLength v37
           v45:CInt64 = GuardLess v43, v44
@@ -10029,7 +10029,7 @@ mod hir_opt_tests {
           v23:Array = GuardType v6, Array
           v24:CUInt64 = LoadField v23, :_rbasic_flags@0x1049
           v25:CUInt64 = GuardNoBitsSet v24, RUBY_FL_FREEZE=CUInt64(2048)
-          v27:CUInt64 = GuardNoBitsSet v24, RUBY_ELTS_SHARED=CUInt64(4096)
+          v27:CUInt64 = GuardNoBitsSet v25, RUBY_ELTS_SHARED=CUInt64(4096)
           v28:BasicObject = ArrayPop v23
           CheckInterrupts
           Return v28
@@ -16461,4 +16461,62 @@ mod hir_opt_tests {
         ");
     }
 
+    #[test]
+    fn test_elide_repeated_heap_object_guards() {
+        eval(r#"
+            C = Struct.new(:var)
+            def test(obj)
+              sum = 0
+              sum += obj.var
+              sum += obj.var
+              sum += obj.var
+              sum += obj.var
+              sum += obj.var
+              sum += obj.var
+              sum += obj.var
+              sum += obj.var
+              sum += obj.var
+              sum += obj.var
+              sum
+            end
+            test(C.new(3))
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:4:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :obj@0x1000
+          v4:NilClass = Const Value(nil)
+          Jump bb3(v1, v3, v4)
+        bb2():
+          EntryPoint JIT(0)
+          v7:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :obj@1
+          v9:NilClass = Const Value(nil)
+          Jump bb3(v7, v8, v9)
+        bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
+          v17:Fixnum[0] = Const Value(0)
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, var@0x1010, cme:0x1018)
+          v138:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C]
+          v139:BasicObject = LoadField v138, :var@0x1040
+          PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
+          v178:Fixnum = GuardType v139, Fixnum
+          v179:Fixnum = FixnumAdd v17, v178
+          PatchPoint NoEPEscape(test)
+          v183:Fixnum = FixnumAdd v179, v178
+          v187:Fixnum = FixnumAdd v183, v178
+          v191:Fixnum = FixnumAdd v187, v178
+          v195:Fixnum = FixnumAdd v191, v178
+          v199:Fixnum = FixnumAdd v195, v178
+          v203:Fixnum = FixnumAdd v199, v178
+          v207:Fixnum = FixnumAdd v203, v178
+          v211:Fixnum = FixnumAdd v207, v178
+          v215:Fixnum = FixnumAdd v211, v178
+          CheckInterrupts
+          Return v215
+        ");
+    }
 }

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -172,6 +172,7 @@ make_counters! {
         compile_hir_strength_reduce_time_ns,
         compile_hir_optimize_load_store_time_ns,
         compile_hir_canonicalize_time_ns,
+        compile_hir_infer_types_time_ns,
         compile_hir_fold_constants_time_ns,
         compile_hir_clean_cfg_time_ns,
         compile_hir_remove_redundant_patch_points_time_ns,

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -172,7 +172,6 @@ make_counters! {
         compile_hir_strength_reduce_time_ns,
         compile_hir_optimize_load_store_time_ns,
         compile_hir_canonicalize_time_ns,
-        compile_hir_infer_types_time_ns,
         compile_hir_fold_constants_time_ns,
         compile_hir_clean_cfg_time_ns,
         compile_hir_remove_redundant_patch_points_time_ns,


### PR DESCRIPTION
This helps get rid of repeated type guards in a loop such as structaref
or structaset benchmark. @dak2 originally had this in his PR but it
wasn't tested so I removed it. This brings it back with a test that
catches it.
