### PR TITLE
[Bug #22070] Fix segfault in `Thread.each_caller_location`

### DIFF
--- a/test/ruby/test_backtrace.rb
+++ b/test/ruby/test_backtrace.rb
@@ -191,6 +191,16 @@ class TestBacktrace < Test::Unit::TestCase
     assert_equal(cl.map(&:to_s), ary.map(&:to_s))
   end
 
+  def test_each_caller_location_single_cfunc_frame
+    assert_normal_exit <<~'RUBY'
+      tap { Thread.each_caller_location(1, 1) { |loc| loc.label } }
+    RUBY
+
+    cl = nil; ary = []
+    tap { cl = caller_locations(1, 1); Thread.each_caller_location(1, 1) { |x| ary << x } }
+    assert_equal(cl.map(&:to_s), ary.map(&:to_s))
+  end
+
   def test_caller_locations_first_label
     def self.label
       caller_locations.first.label

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -751,7 +751,7 @@ rb_ec_partial_backtrace_object(const rb_execution_context_t *ec, long start_fram
                 bt_backpatch_loc(backpatch_counter, loc, CFP_ISEQ(cfp), CFP_PC(cfp));
                 RB_OBJ_WRITTEN(btobj, Qundef, CFP_ISEQ(cfp));
                 if (do_yield) {
-                    bt_yield_loc(loc - backpatch_counter, backpatch_counter, btobj);
+                    bt_yield_loc(loc - backpatch_counter + 1, backpatch_counter, btobj);
                 }
                 break;
             }


### PR DESCRIPTION
Fixes https://bugs.ruby-lang.org/issues/22070