### PR TITLE
ZJIT: Specialize monomorphic getivar on recompile

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3331,14 +3331,17 @@ impl Function {
         self.resolve_receiver_type_from_profile(recv, insn_idx)
     }
 
-    fn polymorphic_summary(&self, profiles: &ProfileOracle, recv: InsnId, insn_idx: YarvInsnIdx) -> Option<TypeDistributionSummary> {
+    fn polymorphic_summary(&self, profiles: &ProfileOracle, recv: InsnId, insn_idx: YarvInsnIdx, include_monomorphic: bool) -> Option<TypeDistributionSummary> {
         let Some(entries) = profiles.types.get(&insn_idx) else {
             return None;
         };
         let recv = self.chase_insn(recv);
         for (entry_insn, entry_type_summary) in entries {
             if self.union_find.borrow().find_const(*entry_insn) == recv {
-                if entry_type_summary.is_polymorphic() || entry_type_summary.is_skewed_polymorphic() {
+                let usable = entry_type_summary.is_polymorphic()
+                    || entry_type_summary.is_skewed_polymorphic()
+                    || (include_monomorphic && entry_type_summary.is_monomorphic());
+                if usable {
                     return Some(entry_type_summary.clone());
                 }
                 return None;
@@ -4405,9 +4408,8 @@ impl Function {
                         }
                         if self.policy.no_side_exits {
                             // On the final version, skip GetIvar shape specialization.
-                            // iseq_to_hir already generates polymorphic branches with a
-                            // GetIvar C call fallback for getinstancevariable, so we don't
-                            // need to wrap it again here.
+                            // iseq_to_hir already generates side-exit-free branches with a
+                            // GetIvar C call fallback for getinstancevariable.
                             self.push_insn_id(block, insn_id); continue;
                         }
                         let self_val = self.load_ivar_guard_type(block, self_val, recv_type, state);
@@ -7825,7 +7827,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         let stack_count = state.stack.len();
                         let recv = state.stack_topn(argc as usize)?;  // args are on top
                         let entry_args = state.as_args(self_param);
-                        if let Some(summary) = fun.polymorphic_summary(&profiles, recv, exit_state.insn_idx) {
+                        if let Some(summary) = fun.polymorphic_summary(&profiles, recv, exit_state.insn_idx, false) {
                             let join_block = insn_idx_to_block.get(&insn_idx).copied().unwrap_or_else(|| fun.new_block(insn_idx));
                             // Dedup by expected type so immediate/heap variants
                             // under the same Ruby class can still get separate branches.
@@ -8167,7 +8169,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
                         break;  // End the block
                     }
-                    if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_state.insn_idx) {
+                    if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_state.insn_idx, fun.policy.no_side_exits) {
                         self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id });
                         let rbasic_flags = fun.load_rbasic_flags(block, self_param);
                         let join_block = insn_idx_to_block.get(&insn_idx).copied().unwrap_or_else(|| fun.new_block(insn_idx));

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3331,17 +3331,38 @@ impl Function {
         self.resolve_receiver_type_from_profile(recv, insn_idx)
     }
 
-    fn polymorphic_summary(&self, profiles: &ProfileOracle, recv: InsnId, insn_idx: YarvInsnIdx, include_monomorphic: bool) -> Option<TypeDistributionSummary> {
+    fn polymorphic_summary(&self, profiles: &ProfileOracle, recv: InsnId, insn_idx: YarvInsnIdx) -> Option<TypeDistributionSummary> {
         let Some(entries) = profiles.types.get(&insn_idx) else {
             return None;
         };
         let recv = self.chase_insn(recv);
         for (entry_insn, entry_type_summary) in entries {
             if self.union_find.borrow().find_const(*entry_insn) == recv {
-                let usable = entry_type_summary.is_polymorphic()
-                    || entry_type_summary.is_skewed_polymorphic()
-                    || (include_monomorphic && entry_type_summary.is_monomorphic());
-                if usable {
+                if entry_type_summary.is_polymorphic() || entry_type_summary.is_skewed_polymorphic() {
+                    return Some(entry_type_summary.clone());
+                }
+                return None;
+            }
+        }
+        None
+    }
+
+    /// Like [`Self::polymorphic_summary`], but on the no_side_exits final
+    /// version also accepts a monomorphic profile. iseq_to_hir's
+    /// getinstancevariable handler uses the resulting summary to generate
+    /// side-exit-free inline shape-guarded branches with a GetIvar C call
+    /// fallback, replacing optimize_getivar's GuardBitEquals + side exit shape
+    /// guard fast path (which can no longer recompile).
+    fn getivar_shape_summary(&self, profiles: &ProfileOracle, recv: InsnId, insn_idx: YarvInsnIdx) -> Option<TypeDistributionSummary> {
+        let summary = self.polymorphic_summary(profiles, recv, insn_idx);
+        if summary.is_some() || !self.policy.no_side_exits {
+            return summary;
+        }
+        let entries = profiles.types.get(&insn_idx)?;
+        let recv = self.chase_insn(recv);
+        for (entry_insn, entry_type_summary) in entries {
+            if self.union_find.borrow().find_const(*entry_insn) == recv {
+                if entry_type_summary.is_monomorphic() {
                     return Some(entry_type_summary.clone());
                 }
                 return None;
@@ -4407,9 +4428,11 @@ impl Function {
                             self.push_insn_id(block, insn_id); continue;
                         }
                         if self.policy.no_side_exits {
-                            // On the final version, skip GetIvar shape specialization.
-                            // iseq_to_hir already generates side-exit-free branches with a
-                            // GetIvar C call fallback for getinstancevariable.
+                            // GuardBitEquals would side-exit on a shape miss with no way
+                            // to recompile. iseq_to_hir already generated side-exit-free
+                            // inline branches for shape-specializable sites (see
+                            // getivar_shape_summary); leave the bare GetIvar as the
+                            // C call fallback.
                             self.push_insn_id(block, insn_id); continue;
                         }
                         let self_val = self.load_ivar_guard_type(block, self_val, recv_type, state);
@@ -7827,7 +7850,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         let stack_count = state.stack.len();
                         let recv = state.stack_topn(argc as usize)?;  // args are on top
                         let entry_args = state.as_args(self_param);
-                        if let Some(summary) = fun.polymorphic_summary(&profiles, recv, exit_state.insn_idx, false) {
+                        if let Some(summary) = fun.polymorphic_summary(&profiles, recv, exit_state.insn_idx) {
                             let join_block = insn_idx_to_block.get(&insn_idx).copied().unwrap_or_else(|| fun.new_block(insn_idx));
                             // Dedup by expected type so immediate/heap variants
                             // under the same Ruby class can still get separate branches.
@@ -8169,7 +8192,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         fun.push_insn(block, Insn::SideExit { state: exit_id, reason: SideExitReason::UnhandledYARVInsn(opcode), recompile: None });
                         break;  // End the block
                     }
-                    if let Some(summary) = fun.polymorphic_summary(&profiles, self_param, exit_state.insn_idx, fun.policy.no_side_exits) {
+                    if let Some(summary) = fun.getivar_shape_summary(&profiles, self_param, exit_state.insn_idx) {
                         self_param = fun.push_insn(block, Insn::GuardType { val: self_param, guard_type: types::HeapBasicObject, state: exit_id });
                         let rbasic_flags = fun.load_rbasic_flags(block, self_param);
                         let join_block = insn_idx_to_block.get(&insn_idx).copied().unwrap_or_else(|| fun.new_block(insn_idx));

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -7625,6 +7625,80 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_getivar_monomorphic_on_recompile() {
+        // Trigger recompilation via a no-profile send rather than the getivar's
+        // own shape guard, so the getivar profile stays monomorphic. On the
+        // recompiled version, iseq_to_hir should still wrap the monomorphic
+        // getivar with an inline shape-guarded fast path plus a GetIvar C call
+        // fallback, instead of falling through to a bare GetIvar.
+        eval("
+            def unprofiled_recompile_helper(x) = x.to_s
+            class C
+              def initialize
+                @foo = 42
+              end
+              def read_foo(flag)
+                unprofiled_recompile_helper(42) if flag
+                @foo
+              end
+            end
+            c = C.new
+            # Profile + compile read_foo. The send is unprofiled -> SideExit.
+            c.read_foo(false)
+            c.read_foo(false)
+            # Hit the SideExit enough times for it to profile the send and
+            # invalidate v1 (num_profiles=5 by default).
+            5.times { c.read_foo(true) }
+        ");
+        assert_snapshot!(hir_string_proc("C.new.method(:read_foo)"), @"
+        fn read_foo@<compiled>:8:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :flag@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :flag@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          CheckInterrupts
+          v16:CBool = Test v10
+          v17:Falsy = RefineType v10, Falsy
+          CondBranch v16, bb5(), bb4(v9, v17)
+        bb5():
+          v19:Truthy = RefineType v10, Truthy
+          v22:Fixnum[42] = Const Value(42)
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, unprofiled_recompile_helper@0x1010, cme:0x1018)
+          v53:ObjectSubclass[class_exact:C] = GuardType v9, ObjectSubclass[class_exact:C]
+          v54:BasicObject = SendDirect v53, 0x1040, :unprofiled_recompile_helper (0x1050), v22
+          Jump bb4(v53, v19)
+        bb4(v27:BasicObject, v28:BasicObject):
+          PatchPoint SingleRactorMode
+          v33:HeapBasicObject = GuardType v27, HeapBasicObject
+          v34:CUInt64 = LoadField v33, :RBASIC_FLAGS@0x1058
+          v36:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v37:CPtr[CPtr(0x1059)] = Const CPtr(0x1059)
+          v38 = RefineType v37, CUInt64
+          v39:CInt64 = IntAnd v34, v36
+          v40:CBool = IsBitEqual v39, v38
+          CondBranch v40, bb7(), bb8()
+        bb7():
+          v42:BasicObject = LoadField v33, :@foo@0x105a
+          Jump bb6(v42)
+        bb8():
+          v44:BasicObject = GetIvar v33, :@foo
+          Jump bb6(v44)
+        bb6(v35:BasicObject):
+          CheckInterrupts
+          Return v35
+        ");
+    }
+
+    #[test]
     fn test_definedivar_shape_guard_recompile() {
         // Call with one shape to compile, then call with a different shape to
         // trigger shape guard exits and recompilation. On the recompiled version,


### PR DESCRIPTION
ref: https://github.com/Shopify/ruby/issues/984

This PR compiles monomorphic getivar into an optimized load followed by a fallback, instead of using a fallback in all cases, like polymorphic getivar already does.