### PR TITLE
CI: Disable cache-bin in modgc setup-rust-toolchain

### DIFF
--- a/.github/workflows/modgc.yml
+++ b/.github/workflows/modgc.yml
@@ -106,6 +106,8 @@ jobs:
           ${arch:+--target=$arch-$OSTYPE --host=$arch-$OSTYPE}
 
       - uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          cache-bin: false
       - name: Set MMTk environment variables
         run: |
           echo 'EXCLUDES=../src/test/.excludes-mmtk' >> $GITHUB_ENV


### PR DESCRIPTION
Swatinem/rust-cache (embedded in actions-rust-lang/setup-rust-toolchain) caches ${CARGO_HOME}/bin by default. When the cache is restored from a stale or partially-populated state, the rustup proxy binaries at ~/.cargo/bin/{rustc,cargo,...} get overwritten with broken ones, leaving rustc behaving as rustup-init.

This surfaces at make time: `rustc -V` returns the rustup version (1.29.0) instead of the active toolchain (1.95.0), and `rustc --crate-name=jit ...` fails with "error: unexpected argument '--crate-name' found / Usage: rustup-init[EXE] [OPTIONS]", breaking libjit.rlib in combo YJIT+ZJIT builds.

example failure: https://github.com/ruby/ruby/actions/runs/25831100259/job/75896587532?pr=16952

The macOS runner image already preinstalls rustup, so caching ~/.cargo/bin saves only a few seconds while risking exactly this kind of poisoning. Disable it; the separate Cargo dependency cache stays on.