### PR TITLE
ZJIT: Inline Array#length, Array#size, and Array#empty?

### DIFF
--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -208,9 +208,9 @@ pub fn init() -> Annotations {
     annotate!(rb_cString, "==", inline_string_eq);
     annotate!(rb_cModule, "name", types::StringExact.union(types::NilClass), no_gc, leaf, elidable);
     annotate!(rb_cModule, "===", inline_module_eqq, types::BoolExact, no_gc, leaf);
-    annotate!(rb_cArray, "length", types::Fixnum, no_gc, leaf, elidable);
-    annotate!(rb_cArray, "size", types::Fixnum, no_gc, leaf, elidable);
-    annotate!(rb_cArray, "empty?", types::BoolExact, no_gc, leaf, elidable);
+    annotate!(rb_cArray, "length", inline_array_length, types::Fixnum, no_gc, leaf, elidable);
+    annotate!(rb_cArray, "size", inline_array_length, types::Fixnum, no_gc, leaf, elidable);
+    annotate!(rb_cArray, "empty?", inline_array_empty_p, types::BoolExact, no_gc, leaf, elidable);
     annotate!(rb_cArray, "reverse", types::ArrayExact, leaf, elidable);
     annotate!(rb_cArray, "join", types::StringExact);
     annotate!(rb_cArray, "[]", inline_array_aref);
@@ -333,6 +333,21 @@ fn inline_array_pop(fun: &mut hir::Function, block: hir::BlockId, recv: hir::Ins
     // We know that all Array are HeapObject, so no need to insert a GuardType(HeapObject).
     let arr = fun.push_insn(block, hir::Insn::GuardNotFrozen { recv, state });
     Some(fun.push_insn(block, hir::Insn::ArrayPop { array: arr, state }))
+}
+
+fn inline_array_length(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
+    let &[] = args else { return None; };
+    let len = fun.push_insn(block, hir::Insn::ArrayLength { array: recv });
+    Some(fun.push_insn(block, hir::Insn::BoxFixnum { val: len, state }))
+}
+
+fn inline_array_empty_p(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], _state: hir::InsnId) -> Option<hir::InsnId> {
+    let &[] = args else { return None; };
+    let len = fun.push_insn(block, hir::Insn::ArrayLength { array: recv });
+    let zero = fun.push_insn(block, hir::Insn::Const { val: hir::Const::CInt64(0) });
+    let is_zero = fun.push_insn(block, hir::Insn::IsBitEqual { left: len, right: zero });
+    let result = fun.push_insn(block, hir::Insn::BoxBool { val: is_zero });
+    Some(result)
 }
 
 fn inline_hash_aref(fun: &mut hir::Function, block: hir::BlockId, recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -2272,8 +2272,9 @@ mod hir_opt_tests {
           v13:ArrayExact = NewArray
           PatchPoint MethodRedefined(Array@0x1000, length@0x1008, cme:0x1010)
           PatchPoint NoSingletonClass(Array@0x1000)
+          v28:CInt64 = ArrayLength v13
+          v29:Fixnum = BoxFixnum v28
           IncrCounter inline_cfunc_optimized_send_count
-          v29:Fixnum = CCall Array#length@0x1038, v13
           v20:Fixnum[5] = Const Value(5)
           CheckInterrupts
           Return v20
@@ -2416,8 +2417,9 @@ mod hir_opt_tests {
           v13:ArrayExact = NewArray
           PatchPoint MethodRedefined(Array@0x1000, size@0x1008, cme:0x1010)
           PatchPoint NoSingletonClass(Array@0x1000)
+          v28:CInt64 = ArrayLength v13
+          v29:Fixnum = BoxFixnum v28
           IncrCounter inline_cfunc_optimized_send_count
-          v29:Fixnum = CCall Array#size@0x1038, v13
           v20:Fixnum[5] = Const Value(5)
           CheckInterrupts
           Return v20
@@ -3270,8 +3272,9 @@ mod hir_opt_tests {
           v18:ArrayExact = NewArray v11, v12
           PatchPoint MethodRedefined(Array@0x1000, length@0x1008, cme:0x1010)
           PatchPoint NoSingletonClass(Array@0x1000)
+          v29:CInt64 = ArrayLength v18
+          v30:Fixnum = BoxFixnum v29
           IncrCounter inline_cfunc_optimized_send_count
-          v30:Fixnum = CCall Array#length@0x1038, v18
           CheckInterrupts
           Return v30
         ");
@@ -3297,8 +3300,9 @@ mod hir_opt_tests {
           v18:ArrayExact = NewArray v11, v12
           PatchPoint MethodRedefined(Array@0x1000, size@0x1008, cme:0x1010)
           PatchPoint NoSingletonClass(Array@0x1000)
+          v29:CInt64 = ArrayLength v18
+          v30:Fixnum = BoxFixnum v29
           IncrCounter inline_cfunc_optimized_send_count
-          v30:Fixnum = CCall Array#size@0x1038, v18
           CheckInterrupts
           Return v30
         ");
@@ -4851,10 +4855,13 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Array@0x1000, empty?@0x1008, cme:0x1010)
           PatchPoint NoSingletonClass(Array@0x1000)
           v23:ArrayExact = GuardType v9, ArrayExact
+          v24:CInt64 = ArrayLength v23
+          v25:CInt64[0] = Const CInt64(0)
+          v26:CBool = IsBitEqual v24, v25
+          v27:BoolExact = BoxBool v26
           IncrCounter inline_cfunc_optimized_send_count
-          v25:BoolExact = CCall Array#empty?@0x1038, v23
           CheckInterrupts
-          Return v25
+          Return v27
         ");
     }
 
@@ -6116,8 +6123,9 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Array@0x1000, length@0x1008, cme:0x1010)
           PatchPoint NoSingletonClass(Array@0x1000)
           v23:ArrayExact = GuardType v9, ArrayExact
+          v24:CInt64 = ArrayLength v23
+          v25:Fixnum = BoxFixnum v24
           IncrCounter inline_cfunc_optimized_send_count
-          v25:Fixnum = CCall Array#length@0x1038, v23
           CheckInterrupts
           Return v25
         ");
@@ -6144,8 +6152,9 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(Array@0x1000, size@0x1008, cme:0x1010)
           PatchPoint NoSingletonClass(Array@0x1000)
           v23:ArrayExact = GuardType v9, ArrayExact
+          v24:CInt64 = ArrayLength v23
+          v25:Fixnum = BoxFixnum v24
           IncrCounter inline_cfunc_optimized_send_count
-          v25:Fixnum = CCall Array#size@0x1038, v23
           CheckInterrupts
           Return v25
         ");


### PR DESCRIPTION
Similar to `String#bytesize` and `String#empty?`, inline these Array methods by emitting HIR instructions directly instead of falling back to C function calls.

`Array#length` and `Array#size` emit ArrayLength followed by BoxFixnum. 
Array#empty? emits ArrayLength, compares with zero using IsBitEqual, and boxes the result with BoxBool.

(sorry, closing this as it has already been addressed)