### PR TITLE
Fix UAF in IO::Buffer#& when self or mask is an invalidated slice

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3378,14 +3378,14 @@ io_buffer_pwrite(int argc, VALUE *argv, VALUE self)
 }
 
 static inline void
-io_buffer_check_mask(const struct rb_io_buffer *buffer)
+io_buffer_check_mask_size(size_t size)
 {
-    if (buffer->size == 0)
+    if (size == 0)
         rb_raise(rb_eIOBufferMaskError, "Zero-length mask given!");
 }
 
 static void
-memory_and(unsigned char * restrict output, unsigned char * restrict base, size_t size, unsigned char * restrict mask, size_t mask_size)
+memory_and(unsigned char * restrict output, const unsigned char * restrict base, size_t size, const unsigned char * restrict mask, size_t mask_size)
 {
     for (size_t offset = 0; offset < size; offset += 1) {
         output[offset] = base[offset] & mask[offset % mask_size];
@@ -3413,13 +3413,21 @@ io_buffer_and(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask(mask_buffer);
+    const void *base;
+    size_t size;
+    io_buffer_get_bytes_for_reading(buffer, &base, &size);
 
-    VALUE output = rb_io_buffer_new(NULL, buffer->size, io_flags_for_size(buffer->size));
+    const void *mask_base;
+    size_t mask_size;
+    io_buffer_get_bytes_for_reading(mask_buffer, &mask_base, &mask_size);
+
+    io_buffer_check_mask_size(mask_size);
+
+    VALUE output = rb_io_buffer_new(NULL, size, io_flags_for_size(size));
     struct rb_io_buffer *output_buffer = NULL;
     TypedData_Get_Struct(output, struct rb_io_buffer, &rb_io_buffer_type, output_buffer);
 
-    memory_and(output_buffer->base, buffer->base, buffer->size, mask_buffer->base, mask_buffer->size);
+    memory_and(output_buffer->base, base, size, mask_base, mask_size);
 
     return output;
 }
@@ -3453,7 +3461,7 @@ io_buffer_or(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask(mask_buffer);
+    io_buffer_check_mask_size(mask_buffer->size);
 
     VALUE output = rb_io_buffer_new(NULL, buffer->size, io_flags_for_size(buffer->size));
     struct rb_io_buffer *output_buffer = NULL;
@@ -3493,7 +3501,7 @@ io_buffer_xor(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask(mask_buffer);
+    io_buffer_check_mask_size(mask_buffer->size);
 
     VALUE output = rb_io_buffer_new(NULL, buffer->size, io_flags_for_size(buffer->size));
     struct rb_io_buffer *output_buffer = NULL;
@@ -3590,7 +3598,7 @@ io_buffer_and_inplace(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask(mask_buffer);
+    io_buffer_check_mask_size(mask_buffer->size);
     io_buffer_check_overlaps(buffer, mask_buffer);
 
     void *base;
@@ -3636,7 +3644,7 @@ io_buffer_or_inplace(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask(mask_buffer);
+    io_buffer_check_mask_size(mask_buffer->size);
     io_buffer_check_overlaps(buffer, mask_buffer);
 
     void *base;
@@ -3682,7 +3690,7 @@ io_buffer_xor_inplace(VALUE self, VALUE mask)
     struct rb_io_buffer *mask_buffer = NULL;
     TypedData_Get_Struct(mask, struct rb_io_buffer, &rb_io_buffer_type, mask_buffer);
 
-    io_buffer_check_mask(mask_buffer);
+    io_buffer_check_mask_size(mask_buffer->size);
     io_buffer_check_overlaps(buffer, mask_buffer);
 
     void *base;

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -702,6 +702,24 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_equal IO::Buffer.for("\xce\xcd\xcc\xcb\xce\xcd\xcc\xcb\xce\xcd"), source.dup.not!
   end
 
+  def test_and_raises_on_freed_self
+    inner = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
+    slice = inner.slice(0, 8)
+    inner.free
+
+    mask = IO::Buffer.for("ABCDEFGH")
+    assert_raise(IO::Buffer::InvalidatedError) { slice & mask }
+  end
+
+  def test_and_raises_on_freed_mask
+    inner = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
+    mask_slice = inner.slice(0, 8)
+    inner.free
+
+    source = IO::Buffer.for("ABCDEFGH")
+    assert_raise(IO::Buffer::InvalidatedError) { source & mask_slice }
+  end
+
   def test_bit_count
     # All ones: 8 bits set per byte
     assert_equal 8,  IO::Buffer.for("\xFF").bit_count


### PR DESCRIPTION
`io_buffer_and` accessed `buffer->base` and `mask_buffer->base` directly without validating that the buffers were still live. A slice whose parent had been freed retained its stale base pointer, so calling `&` on it caused a UAF.

Use `io_buffer_get_bytes_for_reading` for both operands, which raises `IO::Buffer::InvalidatedError` before any memory access if either buffer has been invalidated.

```ruby
inner = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
slice = inner.slice(0, 8)
inner.free
slice & IO::Buffer.for("ABCDEFGH")  # => was UAF, now raises InvalidatedError
```