### PR TITLE
Fix perf. of RCLASS_EXT_WRITABLE

### DIFF
--- a/internal/class.h
+++ b/internal/class.h
@@ -322,7 +322,7 @@ RCLASS_PRIME_CLASSEXT_WRITABLE_P(VALUE klass)
 {
     VM_ASSERT(klass != 0, "klass should be a valid object");
     VM_ASSERT_BOXABLE_TYPE(klass);
-    return FL_TEST(klass, RCLASS_PRIME_CLASSEXT_WRITABLE);
+    return FL_TEST_RAW(klass, RCLASS_PRIME_CLASSEXT_WRITABLE);
 }
 
 static inline void
@@ -331,10 +331,10 @@ RCLASS_SET_PRIME_CLASSEXT_WRITABLE(VALUE klass, bool writable)
     VM_ASSERT(klass != 0, "klass should be a valid object");
     VM_ASSERT_BOXABLE_TYPE(klass);
     if (writable) {
-        FL_SET(klass, RCLASS_PRIME_CLASSEXT_WRITABLE);
+        FL_SET_RAW(klass, RCLASS_PRIME_CLASSEXT_WRITABLE);
     }
     else {
-        FL_UNSET(klass, RCLASS_PRIME_CLASSEXT_WRITABLE);
+        FL_UNSET_RAW(klass, RCLASS_PRIME_CLASSEXT_WRITABLE);
     }
 }
 


### PR DESCRIPTION
FL_TEST -> FL_TEST_RAW
FL_SET  -> FL_SET_RAW

I was seeing bad performance on the ruby-bench getivar-module benchmark when using yjit. This was with other changes in a branch, but changes totally unrelated to accessing ivars on a class or using boxes. The change to RCLASS_PRIME_CLASSEXT_WRITABLE_P was the one that made the difference, but I changed a couple of other FL_SET uses as well. This change reduced the benchmark runs from 60ms to 40ms.