### PR TITLE
Extract bundled-gem C extensions before configuring exts

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -346,7 +346,8 @@ $(EXTS_MK): ext/configure-ext.mk $(srcdir)/template/exts.mk.tmpl \
 	    $(srcdir)/template/exts.mk.tmpl --gnumake=$(gnumake) --configure-exts=ext/configure-ext.mk
 
 ext/configure-ext.mk: $(PREP) all-incs $(MKFILES) $(RBCONFIG) $(LIBRUBY) \
-		$(srcdir)/template/configure-ext.mk.tmpl update-default-gemspecs
+		$(srcdir)/template/configure-ext.mk.tmpl update-default-gemspecs \
+		$(HAVE_BASERUBY:yes=extract-gems)
 	$(ECHO) generating makefiles $@
 	$(Q)$(MAKEDIRS) $(@D)
 	$(Q)$(MINIRUBY) $(tooldir)/generic_erb.rb -o $@ -c \

--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -37,7 +37,7 @@ ostruct             0.6.3   https://github.com/ruby/ostruct
 pstore              0.2.1   https://github.com/ruby/pstore
 benchmark           0.5.0   https://github.com/ruby/benchmark
 logger              1.7.0   https://github.com/ruby/logger
-rdoc                7.2.0   https://github.com/ruby/rdoc bc0baee787609f2205e8f1103f3e1d36b923184a
+rdoc                7.2.0   https://github.com/ruby/rdoc 1f93543615928b6d45357432f16ec6006e2d8b1e
 win32ole            1.9.3   https://github.com/ruby/win32ole
 irb                 1.18.0  https://github.com/ruby/irb
 reline              0.6.3   https://github.com/ruby/reline


### PR DESCRIPTION
To support rbs-integrated RDoc, we need to make sure rbs is built properly and available. This PR does that as well as bumping RDoc.

Did a smoke-test at [my fork](https://github.com/st0012/actions/actions/runs/25978792739/job/76363687335). So this time it should work 🤞 