### PR TITLE
ZJIT: Fix C-call preparation for backref/specialobject

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -707,11 +707,11 @@ fn gen_insn(cb: &mut CodeBlock, jit: &mut JITState, asm: &mut Assembler, functio
         Insn::SetIvar { self_val, id, ic, val, state } => no_output!(gen_setivar(jit, asm, opnd!(self_val), *id, *ic, opnd!(val), &function.frame_state(*state))),
         Insn::FixnumBitCheck { val, index } => gen_fixnum_bit_check(asm, opnd!(val), *index),
         Insn::SideExit { state, reason, recompile } => no_output!(gen_side_exit(jit, asm, reason, *recompile, &function.frame_state(*state))),
-        Insn::PutSpecialObject { value_type } => gen_putspecialobject(asm, *value_type),
+        Insn::PutSpecialObject { value_type, state } => gen_putspecialobject(jit, asm, *value_type, &function.frame_state(*state)),
         Insn::AnyToString { val, str, state } => gen_anytostring(asm, opnd!(val), opnd!(str), &function.frame_state(*state)),
         Insn::Defined { op_type, obj, pushval, v, lep_level, state } => gen_defined(jit, asm, *op_type, *obj, *pushval, opnd!(v), *lep_level, &function.frame_state(*state)),
         Insn::CheckMatch { target, pattern, flag, state } => gen_checkmatch(jit, asm, opnd!(target), opnd!(pattern), *flag, &function.frame_state(*state)),
-        Insn::GetSpecialSymbol { symbol_type, state: _ } => gen_getspecial_symbol(asm, *symbol_type),
+        Insn::GetSpecialSymbol { symbol_type, state } => gen_getspecial_symbol(asm, *symbol_type, &function.frame_state(*state)),
         Insn::GetSpecialNumber { nth, state } => gen_getspecial_number(asm, *nth, &function.frame_state(*state)),
         &Insn::IncrCounter(counter) => no_output!(gen_incr_counter(asm, counter)),
         Insn::IncrCounterPtr { counter_ptr } => no_output!(gen_incr_counter_ptr(asm, *counter_ptr)),
@@ -1219,7 +1219,13 @@ fn gen_side_exit(jit: &mut JITState, asm: &mut Assembler, reason: &SideExitReaso
 }
 
 /// Emit a special object lookup
-fn gen_putspecialobject(asm: &mut Assembler, value_type: SpecialObjectType) -> Opnd {
+fn gen_putspecialobject(jit: &JITState, asm: &mut Assembler, value_type: SpecialObjectType, state: &FrameState) -> Opnd {
+    // rb_vm_get_special_object for CBASE/CONST_BASE can call rb_singleton_class,
+    // which allocates (may trigger GC) and can raise TypeError on non-class
+    // receivers (e.g. `123.instance_eval { Const = 1 }`). Treat as non-leaf so
+    // the PC is saved for GC and stack/locals are spilled for rescue.
+    gen_prepare_non_leaf_call(jit, asm, state);
+
     // Get the EP of the current CFP and load it into a register
     let ep_opnd = Opnd::mem(64, CFP, RUBY_OFFSET_CFP_EP);
     let ep_reg = asm.load(ep_opnd);
@@ -1227,9 +1233,12 @@ fn gen_putspecialobject(asm: &mut Assembler, value_type: SpecialObjectType) -> O
     asm_ccall!(asm, rb_vm_get_special_object, ep_reg, Opnd::UImm(u64::from(value_type)))
 }
 
-fn gen_getspecial_symbol(asm: &mut Assembler, symbol_type: SpecialBackrefSymbol) -> Opnd {
-    // Fetch a "special" backref based on the symbol type
+fn gen_getspecial_symbol(asm: &mut Assembler, symbol_type: SpecialBackrefSymbol, state: &FrameState) -> Opnd {
+    // rb_backref_get reaches rb_vm_svar_lep, which calls CFP_PC/CFP_ISEQ on the
+    // current frame, so the PC must be saved before the call.
+    gen_prepare_leaf_call_with_gc(asm, state);
 
+    // Fetch a "special" backref based on the symbol type
     let backref = asm_ccall!(asm, rb_backref_get,);
 
     match symbol_type {
@@ -1249,11 +1258,12 @@ fn gen_getspecial_symbol(asm: &mut Assembler, symbol_type: SpecialBackrefSymbol)
 }
 
 fn gen_getspecial_number(asm: &mut Assembler, nth: u64, state: &FrameState) -> Opnd {
-    // Fetch the N-th match from the last backref based on type shifted by 1
-
-    let backref = asm_ccall!(asm, rb_backref_get,);
-
+    // rb_backref_get reaches rb_vm_svar_lep, which calls CFP_PC/CFP_ISEQ on the
+    // current frame, so the PC must be saved before the call.
     gen_prepare_leaf_call_with_gc(asm, state);
+
+    // Fetch the N-th match from the last backref based on type shifted by 1
+    let backref = asm_ccall!(asm, rb_backref_get,);
 
     asm_ccall!(asm, rb_reg_nth_match, Opnd::Imm((nth >> 1).try_into().unwrap()), backref)
 }

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -4205,6 +4205,52 @@ fn test_getspecial_multiple_groups() {
     assert_snapshot!(assert_compiles(r#"test("123-456")"#), @r#""456""#);
 }
 
+// In a JIT-to-JIT call, gen_push_frame writes JIT_RETURN_POISON to the
+// callee's cfp->jit_return (runtime_checks builds). On the *first* such
+// call the function stub trampoline clears jit_return to NULL, so the
+// crash only manifests on the second JIT-to-JIT hit when the stub has
+// been patched to jump directly to the callee's JIT entry. Putting $& as
+// the first C call in the callee keeps the poison live until
+// gen_getspecial_symbol calls rb_backref_get → rb_vm_svar_lep → CFP_PC →
+// CFP_ZJIT_FRAME, which dereferences the poison without the prep fix.
+#[test]
+fn test_getspecial_symbol_in_jit_to_jit_callee() {
+    eval(r#"
+        def callee = $&
+        def caller_method = callee
+
+        # Warm up callee so it JITs
+        callee
+        callee
+
+        # First call to caller_method profiles; second JITs caller_method
+        # and runs through the function-stub-hit path which clears
+        # jit_return. The third call goes through the patched stub with
+        # POISON intact, hitting the bug.
+        caller_method
+        caller_method
+    "#);
+    assert_contains_opcode("callee", YARVINSN_getspecial);
+    assert_snapshot!(assert_compiles("caller_method"), @"nil");
+}
+
+// Same JIT-to-JIT setup, exercising gen_getspecial_number ($N).
+#[test]
+fn test_getspecial_number_in_jit_to_jit_callee() {
+    eval(r#"
+        def callee = $1
+        def caller_method = callee
+
+        callee
+        callee
+
+        caller_method
+        caller_method
+    "#);
+    assert_contains_opcode("callee", YARVINSN_getspecial);
+    assert_snapshot!(assert_compiles("caller_method"), @"nil");
+}
+
 #[test]
 fn test_profile_under_nested_jit_call() {
     assert_snapshot!(inspect("

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -856,7 +856,7 @@ pub enum Insn {
     ToRegexp { opt: usize, values: Vec<InsnId>, state: InsnId },
 
     /// Put special object (VMCORE, CBASE, etc.) based on value_type
-    PutSpecialObject { value_type: SpecialObjectType },
+    PutSpecialObject { value_type: SpecialObjectType, state: InsnId },
 
     /// Call `to_a` on `val` if the method is defined, or make a new array `[val]` otherwise.
     ToArray { val: InsnId, state: InsnId },
@@ -1205,7 +1205,6 @@ macro_rules! for_each_operand_impl {
             | Insn::GetEP { .. }
             | Insn::LoadSelf
             | Insn::BreakPoint | Insn::Unreachable
-            | Insn::PutSpecialObject { .. }
             | Insn::IncrCounter(_)
             | Insn::IncrCounterPtr { .. } => {}
 
@@ -1222,6 +1221,7 @@ macro_rules! for_each_operand_impl {
             }
             Insn::PatchPoint { state, .. }
             | Insn::CheckInterrupts { state }
+            | Insn::PutSpecialObject { state, .. }
             | Insn::GetBlockParam { state, .. }
             | Insn::GetConstantPath { state, .. } => {
                 $visit_one!(state);
@@ -2224,7 +2224,7 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
                     write!(f, "SideExit {reason}")
                 }
             }
-            Insn::PutSpecialObject { value_type } => write!(f, "PutSpecialObject {value_type}"),
+            Insn::PutSpecialObject { value_type, .. } => write!(f, "PutSpecialObject {value_type}"),
             Insn::Throw { throw_state, val, .. } => {
                 write!(f, "Throw ")?;
                 match throw_state & VM_THROW_STATE_MASK {
@@ -6830,7 +6830,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let insn = if value_type == SpecialObjectType::VMCore {
                         Insn::Const { val: Const::Value(unsafe { rb_mRubyVMFrozenCore }) }
                     } else {
-                        Insn::PutSpecialObject { value_type }
+                        Insn::PutSpecialObject { value_type, state: exit_id }
                     };
                     state.stack_push(fun.push_insn(block, insn));
                 }


### PR DESCRIPTION
This PR fixes missing/misplaced `gen_prepare_leaf_call_with_gc` for backref and specialobject.