### PR TITLE
Revert "Use rbs-integrated RDoc (#16940)"

### DIFF
--- a/gems/bundled_gems
+++ b/gems/bundled_gems
@@ -37,7 +37,7 @@ ostruct             0.6.3   https://github.com/ruby/ostruct
 pstore              0.2.1   https://github.com/ruby/pstore
 benchmark           0.5.0   https://github.com/ruby/benchmark
 logger              1.7.0   https://github.com/ruby/logger
-rdoc                7.2.0   https://github.com/ruby/rdoc 1f93543615928b6d45357432f16ec6006e2d8b1e
+rdoc                7.2.0   https://github.com/ruby/rdoc bc0baee787609f2205e8f1103f3e1d36b923184a
 win32ole            1.9.3   https://github.com/ruby/win32ole
 irb                 1.18.0  https://github.com/ruby/irb
 reline              0.6.3   https://github.com/ruby/reline


### PR DESCRIPTION
Reverts ruby/ruby#16940, which pinned `rdoc` to commit [`1f93543`](https://github.com/ruby/rdoc/commit/1f93543615928b6d45357432f16ec6006e2d8b1e) on the [`ruby/rdoc`](https://github.com/ruby/rdoc) main branch in [gems/bundled_gems](https://github.com/ruby/ruby/blob/master/gems/bundled_gems). This restores the previous pin to [`bc0baee`](https://github.com/ruby/rdoc/commit/bc0baee787609f2205e8f1103f3e1d36b923184a).