### PR TITLE
Make T_MATCH objects able to go through the GC cleanup_p fastpath

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1392,6 +1392,7 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
       case T_FLOAT:
       case T_RATIONAL:
       case T_COMPLEX:
+      case T_MATCH:
         break;
 
       case T_FILE:
@@ -1400,7 +1401,6 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
       case T_ICLASS:
       case T_MODULE:
       case T_REGEXP:
-      case T_MATCH:
         return true;
     }
 
@@ -1434,6 +1434,10 @@ rb_gc_obj_needs_cleanup_p(VALUE obj)
 
       case T_HASH:
         if (flags & RHASH_ST_TABLE_FLAG) return true;
+        return rb_shape_has_fields(shape_id);
+
+      case T_MATCH:
+        if ((flags & (RMATCH_ONIG | RMATCH_OFFSETS_EXTERNAL)) || USE_DEBUG_COUNTER) return true;
         return rb_shape_has_fields(shape_id);
 
       case T_BIGNUM:

--- a/internal/re.h
+++ b/internal/re.h
@@ -13,6 +13,7 @@
 #include "ruby/re.h"            /* for struct RMatch and struct re_registers */
 
 #define RMATCH_ONIG FL_USER1
+#define RMATCH_OFFSETS_EXTERNAL FL_USER2
 
 static inline OnigPosition *
 RMATCH_BEG_PTR(VALUE match)

--- a/re.c
+++ b/re.c
@@ -1083,6 +1083,7 @@ update_char_offset(VALUE match)
     if (rm->char_offset_num_allocated < num_regs) {
         SIZED_REALLOC_N(rm->char_offset, struct rmatch_offset, num_regs, rm->char_offset_num_allocated);
         rm->char_offset_num_allocated = num_regs;
+        FL_SET_RAW(match, RMATCH_OFFSETS_EXTERNAL);
     }
 
     enc = rb_enc_get(RMATCH(match)->str);
@@ -1159,6 +1160,7 @@ match_init_copy(VALUE obj, VALUE orig)
         if (rm->char_offset_num_allocated < rm->num_regs) {
             SIZED_REALLOC_N(rm->char_offset, struct rmatch_offset, rm->num_regs, rm->char_offset_num_allocated);
             rm->char_offset_num_allocated = rm->num_regs;
+            FL_SET_RAW(obj, RMATCH_OFFSETS_EXTERNAL);
         }
         MEMCPY(rm->char_offset, RMATCH(orig)->char_offset,
                struct rmatch_offset, rm->num_regs);


### PR DESCRIPTION
I think it's likely they will go through this path as well.

Bitflag for external offsets allocation is jhawthorn's idea, since size always equals num_regs if it's allocated.