### PR TITLE
Drop rbs require in rdoc-srcdir

### DIFF
--- a/tool/rdoc-srcdir
+++ b/tool/rdoc-srcdir
@@ -2,7 +2,6 @@
 
 require 'rubygems'
 require 'rdoc/rdoc'
-require 'rbs'
 
 # Make only the output directory relative to the invoked directory.
 invoked = Dir.pwd


### PR DESCRIPTION
This is currently blocking Ruby's doc generation:
https://github.com/ruby/actions/actions/runs/25895616458/job/76107951475

Related to https://github.com/ruby/ruby/pull/16760

We'll need to make rbs work for the process so we can adopt the rbs-integrated RDoc. But for now let's drop it to unblock doc generation.