### PR TITLE
Make `rb_load_entrypoint` accept two arguments directly

### DIFF
--- a/box.c
+++ b/box.c
@@ -860,8 +860,7 @@ rb_box_load(int argc, VALUE *argv, VALUE box)
 
     rb_vm_frame_flag_set_box_require(GET_EC());
 
-    VALUE args = rb_ary_new_from_args(2, fname, wrap);
-    return rb_load_entrypoint(args);
+    return rb_load_entrypoint(fname, wrap);
 }
 
 static VALUE

--- a/internal/load.h
+++ b/internal/load.h
@@ -12,7 +12,7 @@
 
 /* load.c */
 VALUE rb_get_expanded_load_path(void);
-VALUE rb_load_entrypoint(VALUE args);
+VALUE rb_load_entrypoint(VALUE fname, VALUE wrap);
 VALUE rb_require_relative_entrypoint(VALUE fname);
 int rb_require_internal(VALUE fname);
 NORETURN(void rb_load_fail(VALUE, const char*));

--- a/load.c
+++ b/load.c
@@ -875,8 +875,8 @@ rb_load_protect(VALUE fname, int wrap, int *pstate)
     if (state != TAG_NONE) *pstate = state;
 }
 
-static VALUE
-load_entrypoint_internal(VALUE fname, VALUE wrap)
+VALUE
+rb_load_entrypoint(VALUE fname, VALUE wrap)
 {
     VALUE path, orig_fname;
 
@@ -895,18 +895,6 @@ load_entrypoint_internal(VALUE fname, VALUE wrap)
     RUBY_DTRACE_HOOK(LOAD_RETURN, RSTRING_PTR(orig_fname));
 
     return Qtrue;
-}
-
-VALUE
-rb_load_entrypoint(VALUE args)
-{
-    VALUE fname, wrap;
-    if (RARRAY_LEN(args) != 2) {
-        rb_bug("invalid arguments: %ld", RARRAY_LEN(args));
-    }
-    fname = rb_ary_entry(args, 0);
-    wrap = rb_ary_entry(args, 1);
-    return load_entrypoint_internal(fname, wrap);
 }
 
 /*
@@ -944,7 +932,7 @@ rb_f_load(int argc, VALUE *argv, VALUE _)
 {
     VALUE fname, wrap;
     rb_scan_args(argc, argv, "11", &fname, &wrap);
-    return load_entrypoint_internal(fname, wrap);
+    return rb_load_entrypoint(fname, wrap);
 }
 
 static char *


### PR DESCRIPTION
`rb_load_entrypoint` is used only by `rb_box_load`; it checks that the argument has two-elements (implicitly assuming it is an array), extracts its contents, and then simply discards the argument.