### PR TITLE
[DRAFT] perf: gsub - Improve when re-scans occurs

### DIFF
--- a/benchmark/string_gsub.yml
+++ b/benchmark/string_gsub.yml
@@ -1,5 +1,6 @@
 prelude: |
   # frozen_string_literal: true
+  def cached(str); str.valid_encoding?; str.freeze; end
   STR = ((("a" * 31) + "<") * 1000).freeze
   STR_UNICODE = ((("a" * 30) + "\u2028") * 1000).freeze
   ESCAPED_CHARS_BINARY = {
@@ -21,6 +22,34 @@ prelude: |
   ESCAPE_PATTERN = Regexp.union(ESCAPED_CHARS.keys)
 
   NO_MATCH_SHARED_STRING = ("a" * 100_000).freeze
+
+  UTF8_FRAGMENT = cached("<section class=\"entry\"><h3>\u898b\u672c - Exemple - Beispiel</h3>" \
+                         "<p>\u30c6\u30ad\u30b9\u30c8: caf\u00e9, na\u00efve, gr\u00fc\u00dfe \u{2605}</p></section>\n")
+
+  def build_utf8_html(script_match)
+    body = +"<!doctype html><html><head><title>Example Page</title></head><body>\n"
+    body << UTF8_FRAGMENT while body.bytesize < 128 * 1024
+    body << "<script src=\"//assets.example.test/generated/example-loader.js\"></script>\n" if script_match
+    body << UTF8_FRAGMENT * 8
+    body << "</body></html>\n"
+    cached(body)
+  end
+
+  SPARSE_UTF8_HTML = build_utf8_html(true)
+  SPARSE_UTF8_NO_MATCH_HTML = build_utf8_html(false)
+  SCRIPT_TAG_PATTERN = %r{<script[^>]+?assets\.example\.test[^<]+?example-loader[^<]+?</script>}
+  MANY_ASCII_TAGS_IN_UTF8 = cached(((UTF8_FRAGMENT * 4) + "<span></span>\n") * 128)
+  MANY_ASCII_TAGS_PATTERN = /<\/?span>/
+  ZERO_WIDTH_UTF8 = cached(((UTF8_FRAGMENT * 2) + "plain ascii\n") * 128)
+  BACKREF_UTF8 = cached(((UTF8_FRAGMENT * 2) + "id=12345\n") * 128)
+  PATHOLOGICAL_ASCII_NEEDLE = "a" * 4096
+  PATHOLOGICAL_ASCII_MATCHES = cached((("\u00e9" + PATHOLOGICAL_ASCII_NEEDLE) * 1024) + "\u00e9")
+  binary_chunk = cached(("a" * 63).b + "\xff".b)
+  BINARY_NEEDLE = "NEEDLE".b.freeze
+  BINARY_SPARSE_STRING_MATCH = cached(binary_chunk * 2048 + BINARY_NEEDLE + binary_chunk * 64)
+  HASH_REPLACEMENTS = {"<span>" => "<b>", "</span>" => "</b>"}.freeze
+  REPL_ISO_8859_5 = "\u0420\u0443\u0441\u0441\u043a\u0438\u0439".encode("ISO-8859-5").freeze
+  ENCODING_SWITCH_SOURCE = cached("hll\u00ebllo" * 1000)
 
 benchmark:
   gsub_no_match_shared: |
@@ -52,3 +81,15 @@ benchmark:
     str = STR_UNICODE.b
     str.gsub!(BINARY_PATTERN, ESCAPED_CHARS_BINARY)
     str.force_encoding(Encoding::UTF_8)
+
+  sparse_utf8_script_delete: 'str = SPARSE_UTF8_HTML.dup; str.gsub!(SCRIPT_TAG_PATTERN, ""); str'
+  sparse_utf8_script_no_match: 'str = SPARSE_UTF8_NO_MATCH_HTML.dup; str.gsub!(SCRIPT_TAG_PATTERN, ""); str'
+  many_ascii_matches_in_utf8_delete: 'str = MANY_ASCII_TAGS_IN_UTF8.dup; str.gsub!(MANY_ASCII_TAGS_PATTERN, ""); str'
+  nonascii_matches_removed: 'str = STR_UNICODE.dup; str.gsub!(/\u2028/, ""); str'
+  zero_width_utf8_insert: 'str = ZERO_WIDTH_UTF8.dup; str.gsub!(/(?=<p>)/, "!"); str'
+  hash_replacement_utf8: 'str = MANY_ASCII_TAGS_IN_UTF8.dup; str.gsub!(MANY_ASCII_TAGS_PATTERN, HASH_REPLACEMENTS); str'
+  block_replacement_utf8: 'str = MANY_ASCII_TAGS_IN_UTF8.dup; str.gsub!(MANY_ASCII_TAGS_PATTERN) { "" }; str'
+  backref_replacement_utf8: 'str = BACKREF_UTF8.dup; str.gsub!(/(id=)(\d+)/, "\\1[\\2]"); str'
+  encoding_switch_replacement: 'str = ENCODING_SWITCH_SOURCE.dup; str.valid_encoding?; str.gsub!(/\u00eb/, REPL_ISO_8859_5); str'
+  binary_string_pattern_delete: 'str = BINARY_SPARSE_STRING_MATCH.dup; str.gsub!(BINARY_NEEDLE, "".b); str'
+  pathological_ascii_string_matches: 'str = PATHOLOGICAL_ASCII_MATCHES.dup; str.gsub!(PATHOLOGICAL_ASCII_NEEDLE, ""); str'

--- a/string.c
+++ b/string.c
@@ -6363,6 +6363,7 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
     char *sp, *cp;
     int need_backref_str = -1;
     rb_encoding *str_enc;
+    int str_cr, copy_str_cr, use_cached_str_cr, matched_has_nonascii = 0;
 
     switch (argc) {
       case 1:
@@ -6404,6 +6405,11 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
     slen = RSTRING_LEN(str);
     cp = sp;
     str_enc = STR_ENC_GET(str);
+    str_cr = RSTRING_LEN(str) ? ENC_CODERANGE(str) : ENC_CODERANGE_7BIT;
+    use_cached_str_cr = mode == STR &&
+        (str_cr == ENC_CODERANGE_7BIT || ENCODING_GET(str) == ENCODING_GET(repl) ||
+         RSTRING_LEN(repl) == 0 || rb_enc_str_coderange(repl) == ENC_CODERANGE_7BIT);
+    copy_str_cr = use_cached_str_cr ? str_cr : ENC_CODERANGE_UNKNOWN;
     rb_enc_associate(dest, str_enc);
     ENC_CODERANGE_SET(dest, rb_enc_asciicompat(str_enc) ? ENC_CODERANGE_7BIT : ENC_CODERANGE_VALID);
 
@@ -6455,7 +6461,12 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
 
         len = beg0 - offset;	/* copy pre-match substr */
         if (len) {
-            rb_enc_str_buf_cat(dest, cp, len, str_enc);
+            rb_enc_cr_str_buf_cat(dest, cp, len, rb_enc_to_index(str_enc), copy_str_cr, NULL);
+        }
+
+        if (use_cached_str_cr && str_cr != ENC_CODERANGE_7BIT && !matched_has_nonascii && end0 > beg0 &&
+            search_nonascii(sp + beg0, sp + end0)) {
+            matched_has_nonascii = 1;
         }
 
         rb_str_buf_append(dest, val);
@@ -6469,7 +6480,7 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
              */
             if (RSTRING_LEN(str) <= end0) break;
             len = rb_enc_fast_mbclen(RSTRING_PTR(str)+end0, RSTRING_END(str), str_enc);
-            rb_enc_str_buf_cat(dest, RSTRING_PTR(str)+end0, len, str_enc);
+            rb_enc_cr_str_buf_cat(dest, RSTRING_PTR(str)+end0, len, rb_enc_to_index(str_enc), copy_str_cr, NULL);
             offset = end0 + len;
         }
         cp = RSTRING_PTR(str) + offset;
@@ -6485,7 +6496,11 @@ str_gsub(int argc, VALUE *argv, VALUE str, int bang)
     } while (beg >= 0);
 
     if (RSTRING_LEN(str) > offset) {
-        rb_enc_str_buf_cat(dest, cp, RSTRING_LEN(str) - offset, str_enc);
+        rb_enc_cr_str_buf_cat(dest, cp, RSTRING_LEN(str) - offset, rb_enc_to_index(str_enc), copy_str_cr, NULL);
+    }
+    if (use_cached_str_cr && str_cr != ENC_CODERANGE_7BIT && str_cr != ENC_CODERANGE_UNKNOWN && matched_has_nonascii) {
+        ENC_CODERANGE_CLEAR(dest);
+        rb_enc_str_coderange(dest);
     }
     rb_pat_search0(pat, str, last, 1, &match);
     if (bang) {
@@ -13023,4 +13038,3 @@ Init_String(void)
 
     rb_define_method(rb_cSymbol, "encoding", sym_encoding, 0);
 }
-

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1342,6 +1342,29 @@ CODE
     assert_equal S("\u{3042 3042 3042}!foo!"), S("\u{3042 3042 3042}/foo/").gsub("/", "!"), bug9849
   end
 
+  def test_gsub_preserves_coderange_cache
+    repl = "Русский".force_encoding(Encoding::ISO_8859_5)
+    expected = ("hll".b + repl.b + "llo".b).force_encoding(Encoding::ISO_8859_5)
+    apply = ->(s, method, *args, &block) { result = s.public_send(method, *args, &block); method == :gsub! ? s : result }
+
+    [:gsub, :gsub!].each do |method|
+      s = "ab".b
+      result = apply.call(s, method, /b/n) { s.setbyte(0, 0xe9); "" }
+      assert_equal([[0xe9], Encoding::ASCII_8BIT, true, false],
+                   [result.bytes, result.encoding, result.valid_encoding?, result.ascii_only?])
+
+      s = "éb"
+      result = apply.call(s, method, /b/) { s.setbyte(0, "a".ord); s.setbyte(1, "a".ord); "" }
+      assert_equal(["aa", true], [result, result.ascii_only?])
+
+      s = S("hllëllo")
+      assert_predicate(s, :valid_encoding?) # cache the receiver coderange
+      result = apply.call(s, method, /ë/, repl)
+      assert_equal([expected, Encoding::ISO_8859_5, true],
+                   [result, result.encoding, result.valid_encoding?])
+    end
+  end
+
   def test_gsub!
     a = S("hello")
     b = a.dup


### PR DESCRIPTION
## Background

I noticed that `String#gsub` and `String#gsub!` can spend a lot of time
re-scanning copied receiver fragments for coderange information while building
the result string.

We have a use case where we run `gsub!` on large HTML strings to remove sparse
matches. Most of the result is copied directly from the original string, and the
string often already has a cached coderange from earlier encoding checks.

For example:

```ruby
html.valid_encoding?
html.gsub!(SCRIPT_TAG_PATTERN, "")
```

I dug into `str_gsub` and found that copied receiver fragments
are appended with `rb_enc_str_buf_cat`, which does not receive coderange
information for the copied range. This means `gsub` can repeatedly scan large
copied ranges even when the receiver coderange is already known.

## Proposal:

Use the receiver coderange for copied receiver fragments in `str_gsub` when it
is safe to do so.

In this code, the receiver is the original string passed to `gsub`, the
replacement is the string inserted for each match, and `dest` is the final string
being built. This patch only changes the coderange passed for copied receiver
fragments. It does not force the final `dest` coderange to match the receiver.

```diff
+    str_cr = RSTRING_LEN(str) ? ENC_CODERANGE(str) : ENC_CODERANGE_7BIT;
+    use_cached_str_cr = mode == STR &&
+        (str_cr == ENC_CODERANGE_7BIT || ENCODING_GET(str) == ENCODING_GET(repl) ||
+         RSTRING_LEN(repl) == 0 || rb_enc_str_coderange(repl) == ENC_CODERANGE_7BIT);
+    copy_str_cr = use_cached_str_cr ? str_cr : ENC_CODERANGE_UNKNOWN;
```

```diff
-            rb_enc_str_buf_cat(dest, cp, len, str_enc);
+            rb_enc_cr_str_buf_cat(dest, cp, len, rb_enc_to_index(str_enc), copy_str_cr, NULL);
```

### Justification:

The copied receiver fragments keep the receiver's encoding and are copied from
the receiver bytes between matches. The replacement is appended separately with
`rb_str_buf_append`, which still computes and combines the replacement
coderange.

For simple string replacement mode, the receiver's cached coderange can be reused
for copied receiver fragments when:

- the receiver is 7-bit, because every copied receiver fragment is also 7-bit
- the receiver and replacement have the same encoding
- the replacement is empty
- the replacement is 7-bit

For example, if the receiver is 7-bit and the replacement is not, the copied
receiver fragments are still appended as 7-bit. Appending the replacement can
then change `dest` to `VALID` or to the replacement encoding, as it does today.

The patch avoids the unsafe cases by falling back to unknown coderange
information:

- block and hash replacements keep `copy_str_cr` as `ENC_CODERANGE_UNKNOWN`
  because the replacement value is dynamic and the receiver can be mutated from
  Ruby code
- if the receiver coderange is unknown, copied fragments are still passed as
  unknown and `rb_enc_cr_str_buf_cat` scans them as before
- if both the receiver and replacement can contain non-ASCII bytes with
  different encodings, copied fragments are passed as unknown unless the
  replacement is empty or 7-bit

When matched text containing non-ASCII bytes is removed, the patch clears and
recomputes the destination coderange at the end. This avoids keeping a stale
`VALID` coderange when deleting the only non-ASCII content makes the result
ASCII-only.

#### Upsides:

- Better performance for sparse replacements on large strings. The HTML-like
  delete benchmark improved 2.25x and the binary sparse replacement benchmark
  improved 14.43x in this local run.
- Better performance for several existing escaping-style benchmarks, which
  improved between 1.12x and 1.20x in this local run.

#### Tradeoffs:

- Worse performance for a pathological case that removes many large ASCII
  matches from a UTF-8 string with non-ASCII bytes between matches. That case was
  1.10x slower in this local run.

### Results:

One local benchmark-driver run:

| Benchmark | Control | Experiment | Speedup | Slowdown |
|---|---:|---:|---:|---:|
| `gsub_no_match_shared` | 168.739k | 395.691k | 2.34x | - |
| `escape` | 2.227k | 2.557k | 1.15x | - |
| `escape_bin` | 4.123k | 4.598k | 1.12x | - |
| `escape_utf8` | 2.227k | 2.671k | 1.20x | - |
| `escape_utf8_bin` | 4.818k | 5.376k | 1.12x | - |
| `sparse_utf8_script_delete` | 3.350k | 7.543k | 2.25x | - |
| `sparse_utf8_script_no_match` | 15.228k | 16.063k | 1.05x | - |
| `many_ascii_matches_in_utf8_delete` | 6.575k | 14.375k | 2.19x | - |
| `nonascii_matches_removed` | 7.123k | 9.264k | 1.30x | - |
| `zero_width_utf8_insert` | 3.450k | 4.105k | 1.19x | - |
| `hash_replacement_utf8` | 5.987k | 6.306k | 1.05x | - |
| `block_replacement_utf8` | 5.712k | 5.625k | - | 1.02x |
| `backref_replacement_utf8` | 9.128k | 13.736k | 1.50x | - |
| `encoding_switch_replacement` | 6.633k | 8.011k | 1.21x | - |
| `binary_string_pattern_delete` | 4.645k | 67.007k | 14.43x | - |
| `pathological_ascii_string_matches` | 501.007 | 453.939 | - | 1.10x |

#### Methodology:

- Apple M4 Pro, macOS 26.3.1.
- Used built-in benchmark tooling
- Experiment: built ruby 4.1.0dev from this branch
