### PR TITLE
ZJIT: Share a single JITFrame across all C method frames

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -2847,8 +2847,8 @@ zjit_materialize_frames(rb_control_frame_t *cfp)
     if (!rb_zjit_enabled_p) return;
 
     while (true) {
-        if (CFP_ZJIT_FRAME(cfp)) {
-            const zjit_jit_frame_t *jit_frame = (const zjit_jit_frame_t *)cfp->jit_return;
+        if (CFP_ZJIT_FRAME_P(cfp)) {
+            const zjit_jit_frame_t *jit_frame = CFP_ZJIT_FRAME(cfp);
             cfp->pc = jit_frame->pc;
             cfp->_iseq = (rb_iseq_t *)jit_frame->iseq;
             if (jit_frame->materialize_block_code) {
@@ -3665,8 +3665,8 @@ rb_execution_context_update(rb_execution_context_t *ec)
         while (cfp != limit_cfp) {
             const VALUE *ep = cfp->ep;
             cfp->self = rb_gc_location(cfp->self);
-            if (CFP_ZJIT_FRAME(cfp)) {
-                rb_zjit_jit_frame_update_references((zjit_jit_frame_t *)cfp->jit_return);
+            if (CFP_ZJIT_FRAME_P(cfp)) {
+                rb_zjit_jit_frame_update_references((zjit_jit_frame_t *)CFP_ZJIT_FRAME(cfp));
                 // block_code must always be relocated. For ISEQ frames, the JIT caller
                 // may have written it (gen_block_handler_specval) for passing blocks.
                 // For C frames, rb_iterate0 may have written an ifunc to block_code

--- a/zjit.c
+++ b/zjit.c
@@ -32,6 +32,15 @@ enum zjit_struct_offsets {
     ISEQ_BODY_OFFSET_PARAM = offsetof(struct rb_iseq_constant_body, param)
 };
 
+// Special JITFrame used by all C method calls. We don't control the native
+// stack layout for C frames, so cfp->jit_return points at this static frame
+// via the ZJIT_JIT_RETURN_C_FRAME sentinel instead of a per-call allocation.
+const zjit_jit_frame_t rb_zjit_c_frame = (zjit_jit_frame_t) {
+    .pc = 0,
+    .iseq = 0,
+    .materialize_block_code = false,
+};
+
 void rb_zjit_profile_disable(const rb_iseq_t *iseq);
 
 void

--- a/zjit.h
+++ b/zjit.h
@@ -27,6 +27,7 @@ typedef struct zjit_jit_frame {
 
 #if USE_ZJIT
 extern void *rb_zjit_entry;
+extern const zjit_jit_frame_t rb_zjit_c_frame;
 extern uint64_t rb_zjit_call_threshold;
 extern uint64_t rb_zjit_profile_threshold;
 void rb_zjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit_exception);
@@ -48,6 +49,21 @@ void rb_zjit_tracing_invalidate_all(void);
 void rb_zjit_invalidate_no_singleton_class(VALUE klass);
 void rb_zjit_invalidate_root_box(void);
 void rb_zjit_jit_frame_update_references(zjit_jit_frame_t *jit_frame);
+
+// Special value for cfp->jit_return that means "this is a C method frame, use
+// rb_zjit_c_frame as the JITFrame". We don't control the native stack layout
+// for C frames, so there's no per-call JITFrame storage; we set this sentinel
+// instead of a heap-allocated JITFrame pointer.
+#define ZJIT_JIT_RETURN_C_FRAME 0x1
+
+static inline const zjit_jit_frame_t *
+CFP_ZJIT_FRAME(const rb_control_frame_t *cfp)
+{
+    if ((VALUE)cfp->jit_return == ZJIT_JIT_RETURN_C_FRAME) {
+        return &rb_zjit_c_frame;
+    }
+    return (const zjit_jit_frame_t *)cfp->jit_return;
+}
 #else
 #define rb_zjit_entry 0
 static inline void rb_zjit_compile_iseq(const rb_iseq_t *iseq, rb_execution_context_t *ec, bool jit_exception) {}
@@ -62,6 +78,7 @@ static inline void rb_zjit_tracing_invalidate_all(void) {}
 static inline void rb_zjit_invalidate_no_singleton_class(VALUE klass) {}
 static inline void rb_zjit_invalidate_root_box(void) {}
 static inline void rb_zjit_jit_frame_update_references(zjit_jit_frame_t *jit_frame) {}
+static inline const zjit_jit_frame_t* CFP_ZJIT_FRAME(const rb_control_frame_t *cfp) { return NULL; }
 #endif // #if USE_ZJIT
 
 #define rb_zjit_enabled_p (rb_zjit_entry != 0)
@@ -69,24 +86,22 @@ static inline void rb_zjit_jit_frame_update_references(zjit_jit_frame_t *jit_fra
 // BADFrame. The high bit is set, so likely SEGV on linux and darwin if dereferenced.
 #define ZJIT_JIT_RETURN_POISON 0xbadfbadfbadfbadfULL
 
-// Return the JITFrame pointer from cfp->jit_return, or NULL if not present.
-// YJIT also uses jit_return (as a return address), so this must only return
-// non-NULL when ZJIT is enabled and has set jit_return to a JITFrame pointer.
-static inline void *
-CFP_ZJIT_FRAME(const rb_control_frame_t *cfp)
+// Return true if a given CFP has ZJIT's JITFrame.
+static inline bool
+CFP_ZJIT_FRAME_P(const rb_control_frame_t *cfp)
 {
-    if (!rb_zjit_enabled_p) return NULL;
+    if (!rb_zjit_enabled_p) return false;
 #if USE_ZJIT
     RUBY_ASSERT((unsigned long long)cfp->jit_return != ZJIT_JIT_RETURN_POISON);
 #endif
-    return cfp->jit_return;
+    return cfp->jit_return != NULL;
 }
 
 static inline const VALUE*
 CFP_PC(const rb_control_frame_t *cfp)
 {
-    if (CFP_ZJIT_FRAME(cfp)) {
-        return ((const zjit_jit_frame_t *)cfp->jit_return)->pc;
+    if (CFP_ZJIT_FRAME_P(cfp)) {
+        return CFP_ZJIT_FRAME(cfp)->pc;
     }
     return cfp->pc;
 }
@@ -94,8 +109,8 @@ CFP_PC(const rb_control_frame_t *cfp)
 static inline const rb_iseq_t*
 CFP_ISEQ(const rb_control_frame_t *cfp)
 {
-    if (CFP_ZJIT_FRAME(cfp)) {
-        return ((const zjit_jit_frame_t *)cfp->jit_return)->iseq;
+    if (CFP_ZJIT_FRAME_P(cfp)) {
+        return CFP_ZJIT_FRAME(cfp)->iseq;
     }
     return cfp->_iseq;
 }

--- a/zjit.h
+++ b/zjit.h
@@ -78,7 +78,7 @@ static inline void rb_zjit_tracing_invalidate_all(void) {}
 static inline void rb_zjit_invalidate_no_singleton_class(VALUE klass) {}
 static inline void rb_zjit_invalidate_root_box(void) {}
 static inline void rb_zjit_jit_frame_update_references(zjit_jit_frame_t *jit_frame) {}
-static inline const zjit_jit_frame_t* CFP_ZJIT_FRAME(const rb_control_frame_t *cfp) { return NULL; }
+static inline const zjit_jit_frame_t *CFP_ZJIT_FRAME(const rb_control_frame_t *cfp) { return NULL; }
 #endif // #if USE_ZJIT
 
 #define rb_zjit_enabled_p (rb_zjit_entry != 0)

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -315,6 +315,7 @@ fn main() {
         .allowlist_type("jit_bindgen_constants")
         .allowlist_type("zjit_struct_offsets")
         .allowlist_var("ZJIT_JIT_RETURN_POISON")
+        .allowlist_var("ZJIT_JIT_RETURN_C_FRAME")
         .allowlist_function("rb_assert_holding_vm_lock")
         .allowlist_function("rb_jit_shape_complex_p")
         .allowlist_function("rb_jit_multi_ractor_p")

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2865,8 +2865,11 @@ fn gen_push_frame(asm: &mut Assembler, argc: usize, state: &FrameState, frame: C
         // Without this, stale data from a previous frame occupying this CFP slot
         // can be used as an ifunc pointer, causing a segfault.
         asm.mov(cfp_opnd(RUBY_OFFSET_CFP_BLOCK_CODE), 0.into());
-        let jit_frame = JITFrame::new_cfunc();
-        asm.mov(cfp_opnd(RUBY_OFFSET_CFP_JIT_RETURN), Opnd::const_ptr(jit_frame));
+        // C frames share a single static JITFrame (rb_zjit_c_frame). Setting
+        // cfp->jit_return to the ZJIT_JIT_RETURN_C_FRAME sentinel tells
+        // CFP_ZJIT_FRAME() to use that shared frame, so we don't need to
+        // allocate a per-call JITFrame for C method pushes.
+        asm.mov(cfp_opnd(RUBY_OFFSET_CFP_JIT_RETURN), (ZJIT_JIT_RETURN_C_FRAME as usize).into());
     }
 
     asm.mov(cfp_opnd(RUBY_OFFSET_CFP_SELF), frame.recv);

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -234,6 +234,7 @@ pub const VM_ENV_DATA_INDEX_SPECVAL: i32 = -1;
 pub const VM_ENV_DATA_INDEX_FLAGS: u32 = 0;
 pub const VM_BLOCK_HANDLER_NONE: u32 = 0;
 pub const SHAPE_ID_NUM_BITS: u32 = 32;
+pub const ZJIT_JIT_RETURN_C_FRAME: u32 = 1;
 pub const ZJIT_JIT_RETURN_POISON: i64 = -4981057192772781345;
 pub type rb_alloc_func_t = ::std::option::Option<unsafe extern "C" fn(klass: VALUE) -> VALUE>;
 pub const RUBY_Qfalse: ruby_special_consts = 0;

--- a/zjit/src/jit_frame.rs
+++ b/zjit/src/jit_frame.rs
@@ -20,11 +20,6 @@ impl JITFrame {
         Self::alloc(JITFrame { pc, iseq, materialize_block_code })
     }
 
-    /// Create a JITFrame for a C frame (no PC, no ISEQ).
-    pub fn new_cfunc() -> *const Self {
-        Self::alloc(JITFrame { pc: std::ptr::null(), iseq: std::ptr::null(), materialize_block_code: false })
-    }
-
     /// Mark the iseq pointer for GC. Called from rb_zjit_root_mark.
     pub fn mark(&self) {
         if !self.iseq.is_null() {


### PR DESCRIPTION
This PR writes a special value (`1`) into `cfp->jit_return` for C method frames instead of allocating `JITFrame` with `pc = 0, iseq = 0` for each C method callsite. We may do callsite-specific optimizations for C methods later, but for a little while, our focus will be on ISEQ methods and stack maps.

Carved out from a patch for ISEQ frames to simplify its diff.