### PR TITLE
Improve performance of `String#codepoints` with ASCII hot path in multi-byte strings.

### DIFF
--- a/benchmark/string_codepoints.yml
+++ b/benchmark/string_codepoints.yml
@@ -1,0 +1,9 @@
+prelude: |
+  mixed_ascii64 = ("a" * 63 + "\u{100}") * 2048
+  mixed_ascii256 = ("a" * 255 + "\u{100}") * 512
+  utf8_2byte = "\u{100}" * 65536
+
+benchmark:
+  codepoints_mixed_ascii64: mixed_ascii64.codepoints
+  codepoints_mixed_ascii256: mixed_ascii256.codepoints
+  codepoints_utf8_2byte: utf8_2byte.codepoints

--- a/string.c
+++ b/string.c
@@ -9774,6 +9774,7 @@ rb_str_enumerate_codepoints(VALUE str, VALUE ary)
     unsigned int c;
     const char *ptr, *end;
     rb_encoding *enc;
+    int enc_asciicompat;
 
     if (single_byte_optimizable(str))
         return rb_str_enumerate_bytes(str, ary);
@@ -9782,9 +9783,15 @@ rb_str_enumerate_codepoints(VALUE str, VALUE ary)
     ptr = RSTRING_PTR(str);
     end = RSTRING_END(str);
     enc = STR_ENC_GET(str);
+    enc_asciicompat = rb_enc_asciicompat(enc);
 
     while (ptr < end) {
-        c = rb_enc_codepoint_len(ptr, end, &n, enc);
+        /* Fast path: ASCII byte in an ASCII-compatible encoding is its own codepoint;
+         * skip rb_enc_codepoint_len and return the byte directly.
+         */
+        n = 1;
+        c = (enc_asciicompat && ISASCII(*ptr)) ?
+            (unsigned char)*ptr : rb_enc_codepoint_len(ptr, end, &n, enc);
         ENUM_ELEM(ary, UINT2NUM(c));
         ptr += n;
     }


### PR DESCRIPTION
## Background

`String#codepoints` already has a fast path for strings that are single-byte optimizable:

```c
if (single_byte_optimizable(str))
    return rb_str_enumerate_bytes(str, ary);
```

Mostly-ASCII UTF-8 strings with at least one non-ASCII character do not take that fast path. They go through the generic codepoint decoder for every character, including ASCII bytes:

## Proposal:

Cache whether the string encoding is ASCII-compatible, and use a local ASCII-byte fast path inside `rb_str_enumerate_codepoints`:

```c
enc_asciicompat = rb_enc_asciicompat(enc);

while (ptr < end) {
    n = 1;
    c = (enc_asciicompat && ISASCII(*ptr)) ?
        (unsigned char)*ptr : rb_enc_codepoint_len(ptr, end, &n, enc);
    ENUM_ELEM(ary, UINT2NUM(c));
    ptr += n;
}
```

### Justification:

This improves the common mixed case where a string is mostly ASCII, but not ASCII-only (such as utf-8).

For example:

```ruby
mixed_ascii256 = ("a" * 255 + "\u{100}") * 512
mixed_ascii256.codepoints
```

Before this change, every ASCII `a` still called `rb_enc_codepoint_len`. After this change, those bytes are handled directly as codepoint `97` with `(unsigned char)*ptr`, while the non-ASCII `\u{100}` still falls back to the existing decoder.

### Tradeoffs:

This adds one branch in the non-single-byte codepoints loop. Cases where the branch is never taken, such as an all-non-ASCII UTF-8 string, can be slightly slower. I did not see any notable slowdowns in my benchmarks.

### Results:

| Benchmark | Control | Experiment | Speedup | Slowdown |
|---|---|---|---|---|
| codepoints_mixed_ascii64 | 910.18 i/s | 1767.12 i/s | 1.94x | 0.52x |
| codepoints_mixed_ascii256 | 986.86 i/s | 1834.20 i/s | 1.86x | 0.54x |
| codepoints_utf8_2byte | 2061.16 i/s | 2030.58 i/s | 0.99x | 1.02x |

#### Methodology:
- Apple M4 Pro macOS 26.3
- Used built in benchmark tooling


### Sidenotes:
I originally looked at removing the `single_byte_optimizable` call as the new optimization as it should cover the same case. However this caused perf regressions in `ASCII-8BIT` and highlighted an bizarre behaviour with invalid ASCII-ish encodings that seems contradictory according to the [Ruby Spec](https://github.com/ruby/ruby/blob/b0a4f3ab53c6bfb8baf2cb18f031d73881c73868/spec/ruby/core/string/codepoints_spec.rb#L13) and the [Ruby Docs](https://docs.ruby-lang.org/en/master/String.html#method-i-codepoints).
- The Ruby Docs describe codepoints as `codepoints: Returns an array of the integer ordinals in self.` however `String#ord` raises an `ArgumentError` on invalid ASCII strings.
- The Ruby Spec has a test named `"raises an ArgumentError when no block is given if self has an invalid encoding"` which does not hold with invalid ASCII encodings.


```
irb(main):001> s = "\xFF".force_encoding("US-ASCII")
irb(main):002> s.valid_encoding? # False
irb(main):003> s.ord # 'String#ord': invalid byte sequence in US-ASCII (ArgumentError)
irb(main):004> s.codepoints # [255]
```