### PR TITLE
ZJIT: x64: Prefer 7-byte sign extending `mov` over 10-byte `movabs`

### DIFF
--- a/zjit/src/asm/x86_64/mod.rs
+++ b/zjit/src/asm/x86_64/mod.rs
@@ -102,6 +102,10 @@ impl X86Reg {
             reg_no: self.reg_no
         }
     }
+
+    pub fn rex_needed(&self) -> bool {
+        self.reg_no > 7 || self.num_bits == 8 && self.reg_no >= 4
+    }
 }
 
 impl X86Opnd {
@@ -110,7 +114,7 @@ impl X86Opnd {
             X86Opnd::None => false,
             X86Opnd::Imm(_) => false,
             X86Opnd::UImm(_) => false,
-            X86Opnd::Reg(reg) => reg.reg_no > 7 || reg.num_bits == 8 && reg.reg_no >= 4,
+            X86Opnd::Reg(reg) => reg.rex_needed(),
             X86Opnd::Mem(mem) => mem.base_reg_no > 7 || (mem.idx_reg_no.unwrap_or(0) > 7),
             X86Opnd::IPRel(_) => false
         }
@@ -923,60 +927,43 @@ pub fn lea(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
 
 /// mov - Data move operation
 pub fn mov(cb: &mut CodeBlock, dst: X86Opnd, src: X86Opnd) {
+    fn emit_reg_imm(cb: &mut CodeBlock, reg: X86Reg, imm: X86Imm) {
+        // In case the source immediate could be zero extended to be 64
+        // bit, we can use the 32-bit operands version of the instruction.
+        // For example, we can turn mov(rax, 0x34) into the equivalent
+        // mov(eax, 0x34).
+        if (reg.num_bits == 64) && u32::try_from(imm.value).is_ok() {
+            if reg.rex_needed() {
+                write_rex(cb, false, 0, 0, reg.reg_no);
+            }
+            write_opcode(cb, 0xB8, reg);
+            cb.write_int(imm.value as u64, 32);
+        } else if reg.num_bits == 64 && imm.num_bits <= 32 {
+            // Use 32-to-64 bit sign-extension when possible
+            write_rm(cb, false, true /* REX.w */, X86Opnd::None, X86Opnd::Reg(reg), Some(0) /* /0 */, &[0xc7]);
+            cb.write_int(imm.value as u64, 32);
+        } else {
+            if reg.num_bits == 16 {
+                cb.write_byte(0x66);
+            }
+
+            if reg.rex_needed() || reg.num_bits == 64 {
+                write_rex(cb, reg.num_bits == 64, 0, 0, reg.reg_no);
+            }
+
+            write_opcode(cb, if reg.num_bits == 8 { 0xb0 } else { 0xb8 }, reg);
+            cb.write_int(imm.value as u64, reg.num_bits.into());
+        }
+    }
     match (dst, src) {
         // R + Imm
-        (X86Opnd::Reg(reg), X86Opnd::Imm(imm)) => {
-            assert!(imm.num_bits <= reg.num_bits);
-
-            // In case the source immediate could be zero extended to be 64
-            // bit, we can use the 32-bit operands version of the instruction.
-            // For example, we can turn mov(rax, 0x34) into the equivalent
-            // mov(eax, 0x34).
-            if (reg.num_bits == 64) && (imm.value > 0) && (imm.num_bits <= 32) {
-                if dst.rex_needed() {
-                    write_rex(cb, false, 0, 0, reg.reg_no);
-                }
-                write_opcode(cb, 0xB8, reg);
-                cb.write_int(imm.value as u64, 32);
-            } else {
-                if reg.num_bits == 16 {
-                    cb.write_byte(0x66);
-                }
-
-                if dst.rex_needed() || reg.num_bits == 64 {
-                    write_rex(cb, reg.num_bits == 64, 0, 0, reg.reg_no);
-                }
-
-                write_opcode(cb, if reg.num_bits == 8 { 0xb0 } else { 0xb8 }, reg);
-                cb.write_int(imm.value as u64, reg.num_bits.into());
-            }
-        },
+        (X86Opnd::Reg(reg), X86Opnd::Imm(imm)) => emit_reg_imm(cb, reg, imm),
         // R + UImm
         (X86Opnd::Reg(reg), X86Opnd::UImm(uimm)) => {
-            assert!(uimm.num_bits <= reg.num_bits);
-
-            // In case the source immediate could be zero extended to be 64
-            // bit, we can use the 32-bit operands version of the instruction.
-            // For example, we can turn mov(rax, 0x34) into the equivalent
-            // mov(eax, 0x34).
-            if (reg.num_bits == 64) && (uimm.value <= u32::MAX.into()) {
-                if dst.rex_needed() {
-                    write_rex(cb, false, 0, 0, reg.reg_no);
-                }
-                write_opcode(cb, 0xB8, reg);
-                cb.write_int(uimm.value, 32);
-            } else {
-                if reg.num_bits == 16 {
-                    cb.write_byte(0x66);
-                }
-
-                if dst.rex_needed() || reg.num_bits == 64 {
-                    write_rex(cb, reg.num_bits == 64, 0, 0, reg.reg_no);
-                }
-
-                write_opcode(cb, if reg.num_bits == 8 { 0xb0 } else { 0xb8 }, reg);
-                cb.write_int(uimm.value, reg.num_bits.into());
-            }
+            // u64->i64 type cast is a bit pattern no-op
+            let value: u64 = uimm.value;
+            let value = value as i64;
+            emit_reg_imm(cb, reg, X86Imm { num_bits: imm_num_bits(value), value });
         },
         // M + Imm
         (X86Opnd::Mem(mem), X86Opnd::Imm(imm)) => {

--- a/zjit/src/asm/x86_64/tests.rs
+++ b/zjit/src/asm/x86_64/tests.rs
@@ -373,13 +373,13 @@ fn test_mov() {
     0x0: mov edx, dword ptr [rbx + 0x80]
     0x0: mov rax, qword ptr [rsp + 4]
     0x0: mov r8d, 0x34
-    0x0: movabs r8, 0x80000000
-    0x0: movabs r8, 0xffffffffffffffff
+    0x0: mov r8d, 0x80000000
+    0x0: mov r8, 0xffffffffffffffff
     0x0: mov eax, 0x34
     0x0: movabs rax, 0xffc0000000000002
-    0x0: movabs rax, 0x80000000
-    0x0: movabs rax, 0xffffffffffffffcc
-    0x0: movabs rax, 0xffffffffffffffff
+    0x0: mov eax, 0x80000000
+    0x0: mov rax, 0xffffffffffffffcc
+    0x0: mov rax, 0xffffffffffffffff
     0x0: mov cl, r9b
     0x0: mov rbx, rax
     0x0: mov rdi, rbx
@@ -405,13 +405,13 @@ fn test_mov() {
     8b9380000000
     488b442404
     41b834000000
-    49b80000008000000000
-    49b8ffffffffffffffff
+    41b800000080
+    49c7c0ffffffff
     b834000000
     48b8020000000000c0ff
-    48b80000008000000000
-    48b8ccffffffffffffff
-    48b8ffffffffffffffff
+    b800000080
+    48c7c0ccffffff
+    48c7c0ffffffff
     4488c9
     4889c3
     4889df
@@ -488,8 +488,8 @@ fn test_mov_unsigned() {
     0x0: mov eax, 1
     0x0: mov eax, 0xffffffff
     0x0: movabs rax, 0x100000000
-    0x0: movabs rax, 0xffffffffffffffff
-    0x0: movabs r8, 0xffffffffffffffff
+    0x0: mov rax, 0xffffffffffffffff
+    0x0: mov r8, 0xffffffffffffffff
     0x0: mov r8b, 1
     0x0: mov r8b, 0xff
     0x0: mov r8w, 1
@@ -497,7 +497,7 @@ fn test_mov_unsigned() {
     0x0: mov r8d, 1
     0x0: mov r8d, 0xffffffff
     0x0: mov r8d, 1
-    0x0: movabs r8, 0xffffffffffffffff
+    0x0: mov r8, 0xffffffffffffffff
     ");
 
     assert_snapshot!(hexdumps!(cb01, cb02, cb03, cb04, cb05, cb06, cb07, cb08, cb09, cb10, cb11, cb12, cb13, cb14, cb15, cb16, cb17, cb18, cb19, cb20, cb21), @"
@@ -512,8 +512,8 @@ fn test_mov_unsigned() {
     b801000000
     b8ffffffff
     48b80000000001000000
-    48b8ffffffffffffffff
-    49b8ffffffffffffffff
+    48c7c0ffffffff
+    49c7c0ffffffff
     41b001
     41b0ff
     6641b80100
@@ -521,7 +521,7 @@ fn test_mov_unsigned() {
     41b801000000
     41b8ffffffff
     41b801000000
-    49b8ffffffffffffffff
+    49c7c0ffffffff
     ");
 }
 


### PR DESCRIPTION
Relevant for small negative immediates. Previously:

    # Insn: v16 SetLocal l1, EP@3, v10
    mov rsi, qword ptr [r13 + 0x20]
    mov rsi, qword ptr [rsi - 8]
    and rsi, 0xfffffffffffffffc
    # call rb_vm_env_write
    push rdi
    push rdi
    mov rdx, rdi
    mov rdi, rsi
    movabs rsi, 0xfffffffffffffffd

---

+patch/master code_region_bytes ratio = 12,029,952 / 12,136,448 ~= 0.991 on a default 25 iteration run of `lobsters` on ruby/ruby-bench.