### PR TITLE
ZJIT: Fix a counter name for JITFrame writes

### DIFF
--- a/zjit.rb
+++ b/zjit.rb
@@ -157,7 +157,7 @@ class << RubyVM::ZJIT
       :gc_time_ns,
       :invalidation_time_ns,
 
-      :vm_write_pc_count,
+      :vm_write_jit_frame_count,
       :vm_write_sp_count,
       :vm_write_locals_count,
       :vm_write_stack_count,

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2710,8 +2710,8 @@ fn gen_save_pc_for_gc(asm: &mut Assembler, state: &FrameState) {
     let opcode: usize = state.get_opcode().try_into().unwrap();
     let next_pc: *const VALUE = unsafe { state.pc.offset(insn_len(opcode) as isize) };
 
-    gen_incr_counter(asm, Counter::vm_write_pc_count);
-    asm_comment!(asm, "save PC to CFP");
+    gen_incr_counter(asm, Counter::vm_write_jit_frame_count);
+    asm_comment!(asm, "save JITFrame to CFP");
     if let Some(pc) = PC_POISON {
         asm.mov(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_PC), Opnd::const_ptr(pc));
     }

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -440,7 +440,7 @@ make_counters! {
     complex_arg_pass_caller_forwarding,
 
     // Writes to the VM frame
-    vm_write_pc_count,
+    vm_write_jit_frame_count,
     vm_write_sp_count,
     vm_write_locals_count,
     vm_write_stack_count,


### PR DESCRIPTION
Follow-up on https://github.com/ruby/ruby/pull/16262

We don't write `cfp->pc` anymore, so this PR renames `vm_write_pc_count` to `vm_write_jit_frame_count`.