### PR TITLE
Prohibit super in refined module method

### DIFF
--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -1035,6 +1035,43 @@ class TestRefinement < Test::Unit::TestCase
     RUBY
   end
 
+  def test_prohibit_super_in_refined_module_method
+    assert_separately([], <<-"end;")
+      bug22071 = '[ruby-core:125511] [Bug #22071]'
+      class BasicObject
+        def a; "B" end
+      end
+
+      module G
+        def a; "G" + super end
+      end
+
+      module F
+        include G
+        def a; "F" + super end
+      end
+
+      class A
+        def a; "A" + super end
+      end
+
+      class B < A
+        include F
+      end
+
+      module R
+       refine F do
+         def a; "R"+super end
+       end
+      end
+      using R
+
+      msg = "super in a method in a module that has been refined and that is called via super" +
+        " from a refinement method is not supported."
+      assert_raise(NoMethodError, msg, bug22071) { B.new.a }
+    end;
+  end
+
   def test_refine_after_using
     assert_separately([], <<-"end;")
       bug8880 = '[ruby-core:57079] [Bug #8880]'

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5061,6 +5061,13 @@ vm_search_super_method(const rb_control_frame_t *reg_cfp, struct rb_call_data *c
         cc = vm_cc_new(Qundef, NULL, vm_call_method_missing, cc_type_super);
         RB_OBJ_WRITE(iseq, &cd->cc, cc);
     }
+    else if (klass == rb_cBasicObject &&
+             RB_TYPE_P(me->defined_class, T_ICLASS) &&
+             RCLASS_INCLUDER(me->defined_class) == 0) {
+        rb_raise(rb_eNoMethodError,
+                 "super in a method in a module that has been refined and that is called via super"
+                 " from a refinement method is not supported.");
+    }
     else {
         cc = vm_search_method_fastpath(reg_cfp, cd, klass);
         const rb_callable_method_entry_t *cached_cme = vm_cc_cme(cc);


### PR DESCRIPTION
Before, this super could result in a call to a method in BasicObject (or a module included in or prepended to BasicObject), or a call to method_missing for the receiver's class.

This explicitly disallows the use of super in such a case, with a specific error message.

Fixes [Bug #22071]