### PR TITLE
Handle refinements correctly in {Method,UnboundMethod}#super_method

### DIFF
--- a/internal/class.h
+++ b/internal/class.h
@@ -646,6 +646,14 @@ RICLASS_OWNS_M_TBL_P(VALUE iclass)
     return RCLASSEXT_ICLASS_IS_ORIGIN(ext) && !RCLASSEXT_ICLASS_ORIGIN_SHARED_MTBL(ext);
 }
 
+static inline bool
+RICLASS_FOR_REFINEMENT_P(VALUE iclass)
+{
+    return BUILTIN_TYPE(iclass) == T_ICLASS &&
+            RB_TYPE_P(RBASIC(iclass)->klass, T_MODULE) &&
+            FL_TEST_RAW(RBASIC(iclass)->klass, RMODULE_IS_REFINEMENT);
+}
+
 static inline void
 RCLASS_SET_INCLUDER(VALUE iclass, VALUE klass)
 {

--- a/proc.c
+++ b/proc.c
@@ -3577,6 +3577,7 @@ method_to_proc(VALUE method)
 
 extern VALUE rb_find_defined_class_by_owner(VALUE current_class, VALUE target_owner);
 extern int rb_method_definition_eq(const rb_method_definition_t *d1, const rb_method_definition_t *d2);
+rb_cref_t * rb_vm_get_cref(const VALUE *ep);
 
 /*
  * call-seq:
@@ -3621,8 +3622,20 @@ method_super_method(VALUE method)
     // We must avoid the use of rb_callable_method_entry_with_refinements, as that will
     // implicitly use the refinements activated in of the caller of super_method.
     const rb_cref_t *cref = NULL;
-    if (data->me->def->type == VM_METHOD_TYPE_ISEQ) {
+    switch (data->me->def->type) {
+      case VM_METHOD_TYPE_ISEQ:
         cref = data->me->def->body.iseq.cref;
+        break;
+      case VM_METHOD_TYPE_BMETHOD: {
+        const rb_proc_t *proc;
+        GetProcPtr(data->me->def->body.bmethod.proc, proc);
+        const struct rb_block *block = &proc->block;
+        if (vm_block_type(block) == block_type_iseq)
+            cref = rb_vm_get_cref(block->as.captured.ep);
+        break;
+      }
+      default:
+        break;
     }
     VALUE klass = super_class;
     me = NULL;

--- a/proc.c
+++ b/proc.c
@@ -3576,6 +3576,7 @@ method_to_proc(VALUE method)
 }
 
 extern VALUE rb_find_defined_class_by_owner(VALUE current_class, VALUE target_owner);
+extern int rb_method_definition_eq(const rb_method_definition_t *d1, const rb_method_definition_t *d2);
 
 /*
  * call-seq:
@@ -3602,11 +3603,64 @@ method_super_method(VALUE method)
         mid = data->me->def->body.alias.original_me->def->original_id;
     }
     else {
-        super_class = RCLASS_SUPER(RCLASS_ORIGIN(iclass));
+        VALUE klass = iclass;
+        if (RICLASS_FOR_REFINEMENT_P(klass)) {
+            // Refined methods need this check before superclass determination
+            klass = RBASIC(klass)->klass;
+        }
+        super_class = RCLASS_SUPER(RCLASS_ORIGIN(klass));
         mid = data->me->def->original_id;
     }
     if (!super_class) return Qnil;
-    me = (rb_method_entry_t *)rb_callable_method_entry_with_refinements(super_class, mid, &iclass);
+
+    // For refined methods, skip refinements for the same definition, but consider
+    // refinements for superclass methods
+    const rb_method_definition_t *skip_def = RICLASS_FOR_REFINEMENT_P(iclass) ? data->me->def : NULL;
+
+    // Use the CREF of the Method/UnboundMethod, not the CREF of the caller of super_method.
+    // We must avoid the use of rb_callable_method_entry_with_refinements, as that will
+    // implicitly use the refinements activated in of the caller of super_method.
+    const rb_cref_t *cref = NULL;
+    if (data->me->def->type == VM_METHOD_TYPE_ISEQ) {
+        cref = data->me->def->body.iseq.cref;
+    }
+    VALUE klass = super_class;
+    me = NULL;
+    while (klass) {
+        const rb_callable_method_entry_t *cme = rb_callable_method_entry(klass, mid);
+        if (!cme) break;
+        if (cme->def->type != VM_METHOD_TYPE_REFINED) {
+            me = (rb_method_entry_t *)cme;
+            iclass = cme->defined_class;
+            break;
+        }
+        // Look through all CREF scopes for a refinement for cme->owner, mirroring
+        // the loop in search_refined_method.
+        const rb_cref_t *c;
+        for (c = cref; c; c = CREF_NEXT(c)) {
+            VALUE refs = CREF_REFINEMENTS(c);
+            if (NIL_P(refs)) continue;
+            VALUE r = rb_hash_lookup(refs, cme->owner);
+            if (NIL_P(r)) continue;
+            const rb_callable_method_entry_t *ref_cme = rb_callable_method_entry(r, mid);
+            if (!ref_cme) break;
+            if (ref_cme->def->type == VM_METHOD_TYPE_REFINED) continue;
+            if (skip_def && rb_method_definition_eq(ref_cme->def, skip_def)) continue;
+            me = (rb_method_entry_t *)ref_cme;
+            iclass = ref_cme->defined_class;
+            break;
+        }
+        if (me) break;
+        // No refined method found. Use orig_me if available, or normal method lookup
+        // in superclass otherwise.
+        const rb_method_entry_t *orig_me = cme->def->body.refined.orig_me;
+        if (orig_me) {
+            me = (rb_method_entry_t *)orig_me;
+            iclass = orig_me->defined_class ? orig_me->defined_class : cme->defined_class;
+            break;
+        }
+        klass = RCLASS_SUPER(cme->defined_class);
+    }
     if (!me) return Qnil;
     return mnew_internal(me, me->owner, iclass, data->recv, mid, rb_obj_class(method), FALSE, FALSE);
 }

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -3339,6 +3339,234 @@ class TestRefinement < Test::Unit::TestCase
     RUBY
   end
 
+  def test_method_super_method_single_refinements
+    assert_separately([], <<~RUBY)
+      class A
+        def b = "A"
+      end
+      module M
+        R = refine(A) { def b; "M" + super; end }
+      end
+      using M
+      a = A.new
+      m = a.method(:b)
+      assert_equal("MA", a.b)
+      assert_equal("MA", m.call)
+      assert_equal(M::R, m.owner)
+      assert_equal(A, m.owner.target)
+
+      m = m.super_method
+      assert_equal(A, m.owner)
+      assert_nil(m.super_method)
+    RUBY
+  end
+
+  def test_method_super_method_multiple_refinements_with_activated_refinements_during_super
+    assert_separately([], <<~RUBY)
+      class A
+        def b = "A"
+      end
+      module M
+        R = refine(A) { def b; "M" + super; end }
+      end
+      module N
+        using M
+        R = refine(A) { def b; "N" + super; end }
+      end
+      using M
+      using N
+      a = A.new
+      m = a.method(:b)
+      assert_equal("NMA", a.b)
+      assert_equal("NMA", m.call)
+      assert_equal(N::R, m.owner)
+      assert_equal(A, m.owner.target)
+
+      m = m.super_method
+      assert_equal(M::R, m.owner)
+      assert_equal(A, m.owner.target)
+
+      m = m.super_method
+      assert_equal(A, m.owner)
+      assert_nil(m.super_method)
+    RUBY
+  end
+
+  def test_method_super_method_multiple_refinements_without_activated_refinements_during_super
+    assert_separately([], <<~RUBY)
+      class A
+        def b = "A"
+      end
+      module M
+        R = refine(A) { def b; "M" + super; end }
+      end
+      module N
+        R = refine(A) { def b; "N" + super; end }
+      end
+      using M
+      using N
+      a = A.new
+      m = a.method(:b)
+      assert_equal("NA", a.b)
+      assert_equal("NA", m.call)
+      assert_equal(N::R, m.owner)
+      assert_equal(A, m.owner.target)
+
+      m = m.super_method
+      assert_equal(A, m.owner)
+      assert_nil(m.super_method)
+    RUBY
+  end
+
+  def test_unbound_method_super_method_single_refinements
+    assert_separately([], <<~RUBY)
+      class A
+        def b = "A"
+      end
+      module M
+        R = refine(A) { def b; "M" + super; end }
+      end
+      using M
+      m = A.instance_method(:b)
+      assert_equal(M::R, m.owner)
+      assert_equal(A, m.owner.target)
+
+      m = m.super_method
+      assert_equal(A, m.owner)
+      assert_nil(m.super_method)
+    RUBY
+  end
+
+  def test_method_super_method_nonrefined_finds_refined_super
+    assert_separately([], <<~RUBY)
+      class A
+        def b = "A"
+      end
+      module M
+        R = refine(A) { def b; "M" + super; end }
+      end
+      using M
+      class B < A
+        def b = "B" + super
+      end
+      b = B.new
+      m = b.method(:b)
+      assert_equal("BMA", b.b)
+      assert_equal("BMA", m.call)
+      assert_equal(B, m.owner)
+      m = m.super_method
+      assert_equal(M::R, m.owner)
+      assert_equal(A, m.owner.target)
+
+      m = m.super_method
+      assert_equal(A, m.owner)
+      assert_nil(m.super_method)
+    RUBY
+  end
+
+  def test_method_super_method_refined_finds_refined_method_in_superclass
+    assert_separately([], <<~RUBY)
+      class A
+        def b = "A"
+      end
+      class B < A
+      end
+      module M
+        R = refine(A) { def b; "M" + super; end }
+      end
+      using M
+      module N
+        R = refine(B) { def b; "N" + super; end }
+      end
+      using N
+
+      b = B.new
+      m = b.method(:b)
+      assert_equal("NMA", b.b)
+      assert_equal("NMA", m.call)
+      assert_equal(N::R, m.owner)
+      assert_equal(B, m.owner.target)
+
+      m = m.super_method
+      assert_equal(M::R, m.owner)
+      assert_equal(A, m.owner.target)
+
+      m = m.super_method
+      assert_equal(A, m.owner)
+      assert_nil(m.super_method)
+    RUBY
+  end
+
+  def test_method_super_method_uses_cref_of_method_not_cref_of_caller
+    assert_separately([], <<~RUBY)
+      class A
+        def b = "A"
+      end
+      class B < A
+      end
+      module M
+        R = refine(A) { def b; "M" + super; end }
+      end
+      module N
+        R = refine(B) do
+          using M
+          def b; "N" + super; end
+        end
+      end
+      using N
+
+      b = B.new
+      m = b.method(:b)
+      assert_equal("NMA", b.b)
+      assert_equal("NMA", m.call)
+      assert_equal(N::R, m.owner)
+      assert_equal(B, m.owner.target)
+
+      m = m.super_method
+      assert_equal(M::R, m.owner)
+      assert_equal(A, m.owner.target)
+
+      m = m.super_method
+      assert_equal(A, m.owner)
+      assert_nil(m.super_method)
+    RUBY
+  end
+
+  def test_method_super_method_only_considers_activated_refinements
+    assert_separately([], <<~RUBY)
+      class A
+        def b = "A"
+      end
+      class B < A
+        def b = "B" + super
+      end
+      module M
+        R = refine(A){def b = "M" + super}
+      end
+      module N
+        R = refine(B){def b = "N" + super}
+      end
+
+      module O
+        using M
+        using N
+
+        b = B.new
+        m = b.method(:b)
+        assert_equal("NBA", b.b)
+        assert_equal("NBA", m.call)
+        assert_equal(N::R, m.owner)
+        assert_equal(B, m.owner.target)
+
+        m = m.super_method
+        assert_equal(B, m.owner)
+        m = m.super_method
+        assert_equal(A, m.owner)
+        assert_nil(m.super_method)
+      end
+    RUBY
+  end
+
   private
 
   def eval_using(mod, s)

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -3567,6 +3567,35 @@ class TestRefinement < Test::Unit::TestCase
     RUBY
   end
 
+  def test_method_super_method_bmethod_finds_refinements
+    assert_separately([], <<~RUBY)
+      class A
+        def b = "A"
+      end
+      module M
+        R = refine(A) { def b; "M" + super; end }
+      end
+      using M
+      class B < A
+        define_method(:b) { "B" + super() }
+      end
+
+      b = B.new
+      m = b.method(:b)
+      assert_equal("BMA", b.b)
+      assert_equal("BMA", m.call)
+      assert_equal(B, m.owner)
+
+      m = m.super_method
+      assert_equal(M::R, m.owner)
+      assert_equal(A, m.owner.target)
+
+      m = m.super_method
+      assert_equal(A, m.owner)
+      assert_nil(m.super_method)
+    RUBY
+  end
+
   private
 
   def eval_using(mod, s)

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -4980,9 +4980,7 @@ vm_call_super_method(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, st
 static inline VALUE
 vm_search_normal_superclass(VALUE klass)
 {
-    if (BUILTIN_TYPE(klass) == T_ICLASS &&
-            RB_TYPE_P(RBASIC(klass)->klass, T_MODULE) &&
-        FL_TEST_RAW(RBASIC(klass)->klass, RMODULE_IS_REFINEMENT)) {
+    if (RICLASS_FOR_REFINEMENT_P(klass)) {
         klass = RBASIC(klass)->klass;
     }
     klass = RCLASS_ORIGIN(klass);


### PR DESCRIPTION
A `Method#super_method` chain should return the methods that `super` would call if the method was called normally. Previously, there were multiple problems:

* There was an infinite `super_method` loop for refined methods.

* Lookup considered the refinements activated at the call site of `super_method`, and not all the call site of `super` inside the method.

This tries to recreate the logic that `super` uses inside `super_method`. It avoids the loop. It also considers the refinements activated for the method itself, not for the caller of `super_method`, correctly handling refinements in outer scopes of the method. This requires avoiding the use of `rb_callable_method_entry_with_refinements`, which implicitly will consider refinements activated in the caller of `super_method`.

The added tests attempt to ensure that the `super_method` lookup chain matches the methods that `super` calls if you call the method.

This adds an `RICLASS_FOR_REFINEMENT_P` helper method, for logic that is used a couple times in the new code and once in `vm_search_normal_superclass`.