### PR TITLE
ZJIT: Remove dead SideExitReasons

### DIFF
--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -492,8 +492,6 @@ fn gen_function(cb: &mut CodeBlock, iseq: IseqPtr, version: IseqVersionRef, func
                             debug!("ZJIT: gen_function: Failed to compile insn: {insn_id} {insn}. Generating side-exit.");
                             gen_incr_counter(&mut asm, exit_counter_for_unhandled_hir_insn(&insn));
                             let reason = match insn {
-                                Insn::ArrayMax { .. }      => SideExitReason::UnhandledHIRArrayMax,
-                                Insn::FixnumDiv { .. }     => SideExitReason::UnhandledHIRFixnumDiv,
                                 Insn::Throw { .. }         => SideExitReason::UnhandledHIRThrow,
                                 Insn::InvokeBuiltin { .. } => SideExitReason::UnhandledHIRInvokeBuiltin,
                                 _                          => SideExitReason::UnhandledHIRUnknown(insn_id),

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -504,8 +504,6 @@ pub enum SideExitReason {
     UnhandledNewarraySend(vm_opt_newarray_send_type),
     UnhandledDuparraySend(u64),
     UnknownSpecialVariable(u64),
-    UnhandledHIRArrayMax,
-    UnhandledHIRFixnumDiv,
     UnhandledHIRThrow,
     UnhandledHIRInvokeBuiltin,
     UnhandledHIRUnknown(InsnId),

--- a/zjit/src/stats.rs
+++ b/zjit/src/stats.rs
@@ -584,8 +584,6 @@ pub fn side_exit_counter(reason: crate::hir::SideExitReason) -> Counter {
         UnhandledCallType(Splat)      => exit_unhandled_splat,
         UnhandledCallType(Kwarg)      => exit_unhandled_kwarg,
         UnknownSpecialVariable(_)     => exit_unknown_special_variable,
-        UnhandledHIRArrayMax          => exit_unhandled_hir_insn,
-        UnhandledHIRFixnumDiv         => exit_unhandled_hir_insn,
         UnhandledHIRThrow             => exit_unhandled_hir_insn,
         UnhandledHIRInvokeBuiltin     => exit_unhandled_hir_insn,
         UnhandledHIRUnknown(_)        => exit_unhandled_hir_insn,


### PR DESCRIPTION
`ArrayMax` (#16411) and `FixnumDiv` (#15452) have codegen implemented
and no longer return `Err` from `gen_insn`.