### PR TITLE
Stop installing tools using scoop

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -80,6 +80,7 @@ jobs:
 
       - name: Install tools with scoop
         run: |
+          if ((vcpkg.exe help install) -match "manifest") { exit }
           Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
           iwr -useb get.scoop.sh | iex
           Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,10 +33,9 @@ jobs:
             test_task: check
           - os: 2025-vs2026
             test_task: test-bundled-gems
-          # TODO: Debug why Windows 11 ARM is failing to build on CI
-          # - os: 11-arm
-          #   test_task: 'btest test-basic test-tool' # check and test-spec are broken yet.
-          #   target: arm64
+          - os: 11-arm
+            test_task: 'btest test-basic test-tool' # check and test-spec are broken yet.
+            target: arm64
       fail-fast: false
 
     runs-on: windows-${{ matrix.os }}
@@ -84,7 +83,8 @@ jobs:
           Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
           iwr -useb get.scoop.sh | iex
           Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
-          scoop install vcpkg uutils-coreutils
+          scoop install vcpkg
+          scoop install uutils-coreutils@0.5.0
         shell: pwsh
 
       - name: Restore vcpkg artifact

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -84,7 +84,6 @@ jobs:
           iwr -useb get.scoop.sh | iex
           Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
           scoop install vcpkg
-          scoop install uutils-coreutils@0.5.0
         shell: pwsh
 
       - name: Restore vcpkg artifact
@@ -112,11 +111,7 @@ jobs:
         # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
         # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302
         run: |
-          ::- Using sort.exe located in the same directory as comm.exe
-          ::- should probably work just fine.
-          for %%I in (comm.exe) do set "sort=%%~dp$PATH:I\sort.exe"
-
-          set | "%sort%" > old.env
+          set > old.env
           call ..\src\win32\vssetup.cmd ^
             -arch=${{ matrix.target || 'amd64' }} ^
             ${{ matrix.vcvars && '-vcvars_ver=' || '' }}${{ matrix.vcvars }}
@@ -126,9 +121,17 @@ jobs:
           set MAKEFLAGS=l
           set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul
           set RUBY_OPT_DIR=%GITHUB_WORKSPACE:\=/%/src/vcpkg_installed/%VCPKG_DEFAULT_TRIPLET%
-          set | "%sort%" > new.env
-          comm -13 old.env new.env >> %GITHUB_ENV%
+          set > new.env
+
+      - name: update env
+        shell: pwsh
+        run: |
+          $old = (Get-Content old.env); $new = (Get-Content new.env)
           del *.env
+          Compare-Object $old $new |
+            Where-Object { $_.SideIndicator -eq '=>' } |
+            Select-Object -ExpandProperty InputObject |
+            Add-Content -Path $env:GITHUB_ENV
 
       - name: baseruby version
         run: ruby -v


### PR DESCRIPTION
* uutils-coreutils doesn't install now.
* the recent default vcpkg works in manifest mode.