### PR TITLE
ZJIT: Widen HIR canonicalize to dominator scope to drop more type guards

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4993,58 +4993,67 @@ impl Function {
     }
 
     /// Dominator-scoped canonicalize: forward `Guard*` results to dominated
-    /// uses. While processing a block B, `rewrite_map` holds the guards
-    /// established on the dom-tree path from the root down to (and including)
-    /// the prefix of B already processed: i.e. every guard from a strict
-    /// dominator of B plus the guards introduced earlier in B itself. Any use
-    /// we rewrite is therefore dominated by the guard's defining position in
-    /// SSA.
-    ///
-    /// `Guard*` substitutions are unconditional within the dominator scope: a
-    /// guard's side-exit semantics guarantee the substituted value type holds
-    /// for every dominated downstream use.
-    ///
-    /// `RefineType` is intentionally skipped: its narrowing is only valid on
-    /// one `IfTrue`/`IfFalse` arm, which the dominator scope does not respect
-    /// (the dom-tree scope is a strict superset of the refine arm scope).
-    /// Cross-arm refine forwarding is left for a follow-up arm-scoped pass.
+    /// uses. `RefineType` is intentionally skipped because its narrowing is
+    /// only valid on one `IfTrue`/`IfFalse` arm, which the dominator scope
+    /// does not respect.
     ///
     /// Inspired by Cranelift's aegraph canonicalize step
     /// (<https://cfallin.org/blog/2026/04/09/aegraph/>).
     fn canonicalize(&mut self) {
-        enum Action { Visit(BlockId), Leave(usize) }
+        self.dom_scope_rewrite();
+        crate::stats::trace_compile_phase("infer_types", || self.infer_types());
+    }
+
+    /// DFS body of `canonicalize`, split out so tests can skip `infer_types`.
+    ///
+    /// Iterative encoding of this recursive DFS (iterative to keep
+    /// native-stack use O(1) on deep HIR):
+    /// ```text
+    /// fn visit(block):
+    ///     let mark = undo.len()
+    ///     for insn in block.insns: canonicalize_insn(insn)
+    ///     for child in dominators.children(block): visit(child)
+    ///     while undo.len() > mark:
+    ///         let (k, prev) = undo.pop(); rewrite_map[k] = prev
+    /// ```
+    /// Each call sees its parent's `rewrite_map`, mutates only within its
+    /// subtree, and restores before returning. Below, the per-frame `mark`
+    /// becomes `Action::Leave(mark)` and LIFO ordering drains the children
+    /// before the parent's `Leave` fires — which is why `Leave(mark)` is
+    /// pushed *before* the children below.
+    fn dom_scope_rewrite(&mut self) {
+        enum Action { Enter(BlockId), Leave(usize) }
 
         let dominators = Dominators::new(self);
-        // This pass must not allocate new insns; `rewrite_map` is sized to the
-        // current `self.insns.len()` and indexed by `InsnId.0` without bounds
-        // checks, so any new insn would OOB-panic on the next iteration.
+        // `rewrite_map` is sized to the current `insns.len()` and indexed
+        // without bounds checks, so this pass must not allocate new insns.
         let mut rewrite_map: Vec<Option<InsnId>> = vec![None; self.insns.len()];
         let mut undo: Vec<(InsnId, Option<InsnId>)> = Vec::with_capacity(self.blocks.len());
         let mut stack: Vec<Action> = Vec::with_capacity(self.blocks.len() * 2);
-        stack.push(Action::Visit(self.entries_block));
+        stack.push(Action::Enter(self.entries_block));
 
         while let Some(action) = stack.pop() {
             match action {
-                Action::Visit(block) => {
+                Action::Enter(block) => {
                     let mark = undo.len();
                     for i in 0..self.blocks[block.0].insns.len() {
                         let insn_id = self.blocks[block.0].insns[i];
                         self.canonicalize_insn(insn_id, &mut rewrite_map, &mut undo);
                     }
+                    // Push Leave before children so it pops last (LIFO).
                     stack.push(Action::Leave(mark));
                     for child in dominators.children(block) {
-                        stack.push(Action::Visit(child));
+                        stack.push(Action::Enter(child));
                     }
                 }
                 Action::Leave(mark) => {
                     for (key, prev) in undo.drain(mark..).rev() {
+                        debug_assert!(rewrite_map[key.0].is_some(), "scope leak at v{}", key.0);
                         rewrite_map[key.0] = prev;
                     }
                 }
             }
         }
-
-        crate::stats::trace_compile_phase("infer_types", || self.infer_types());
     }
 
     fn canonicalize_insn(

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -4992,54 +4992,90 @@ impl Function {
             .unwrap_or(insn_id)
     }
 
-    /// Block-local canonicalize: rewrite each operand through union-find and a
-    /// per-block map of the most recent `Guard*` for that value. Forwards
-    /// guarded values into branch-edge args (so `infer_types` narrows merge-block
-    /// parameters and `fold_constants` drops redundant CFG-join guards) and
-    /// ordinary in-block uses.
+    /// Dominator-scoped canonicalize: forward `Guard*` results to dominated
+    /// uses. While processing a block B, `rewrite_map` holds the guards
+    /// established on the dom-tree path from the root down to (and including)
+    /// the prefix of B already processed: i.e. every guard from a strict
+    /// dominator of B plus the guards introduced earlier in B itself. Any use
+    /// we rewrite is therefore dominated by the guard's defining position in
+    /// SSA.
     ///
-    /// `Guard*` substitutions are unconditional within a block: a guard's
-    /// side-exit semantics guarantee the substituted value type holds for every
-    /// downstream use in the same block.
+    /// `Guard*` substitutions are unconditional within the dominator scope: a
+    /// guard's side-exit semantics guarantee the substituted value type holds
+    /// for every dominated downstream use.
     ///
-    /// `RefineType` is intentionally skipped: its narrowing is only valid on one
-    /// branch arm, which would require dropping refine-derived rewrites at each
-    /// `IfTrue`/`IfFalse`. Cross-arm refine forwarding is left for a follow-up
-    /// dominator-scoped pass.
+    /// `RefineType` is intentionally skipped: its narrowing is only valid on
+    /// one `IfTrue`/`IfFalse` arm, which the dominator scope does not respect
+    /// (the dom-tree scope is a strict superset of the refine arm scope).
+    /// Cross-arm refine forwarding is left for a follow-up arm-scoped pass.
     ///
     /// Inspired by Cranelift's aegraph canonicalize step
     /// (<https://cfallin.org/blog/2026/04/09/aegraph/>).
     fn canonicalize(&mut self) {
-        let mut rewrite_map: HashMap<InsnId, InsnId> = HashMap::new();
-        for block in self.rpo() {
-            rewrite_map.clear();
-            for i in 0..self.blocks[block.0].insns.len() {
-                let insn_id = self.blocks[block.0].insns[i];
-                let canonical_id = self.union_find.borrow().find_const(insn_id);
+        enum Action { Visit(BlockId), Leave(usize) }
 
-                let union_find = &self.union_find;
-                self.insns[canonical_id.0].for_each_operand_mut(|operand| {
-                    let canon = union_find.borrow().find_const(*operand);
-                    *operand = rewrite_map.get(&canon).copied().unwrap_or(canon);
-                });
+        let doms = Dominators::new(self);
+        let children = doms.children();
+        // This pass must not allocate new insns; `rewrite_map` is sized to the
+        // current `self.insns.len()` and indexed by `InsnId.0` without bounds
+        // checks, so any new insn would OOB-panic on the next iteration.
+        let mut rewrite_map: Vec<Option<InsnId>> = vec![None; self.insns.len()];
+        let mut undo: Vec<(InsnId, Option<InsnId>)> = Vec::with_capacity(self.blocks.len());
+        let mut stack: Vec<Action> = Vec::with_capacity(self.blocks.len() * 2);
+        stack.push(Action::Visit(self.entries_block));
 
-                // For the binary guards only `left` is registered because their infer_type is
-                // type_of(left).
-                match &self.insns[canonical_id.0] {
-                    Insn::GuardType      { val:  src, .. }
-                    | Insn::GuardBitEquals { val:  src, .. }
-                    | Insn::GuardAnyBitSet { val:  src, .. }
-                    | Insn::GuardNoBitsSet { val:  src, .. }
-                    | Insn::GuardGreaterEq { left: src, .. }
-                    | Insn::GuardLess      { left: src, .. } => {
-                        rewrite_map.insert(*src, canonical_id);
+        while let Some(action) = stack.pop() {
+            match action {
+                Action::Visit(block) => {
+                    let mark = undo.len();
+                    for i in 0..self.blocks[block.0].insns.len() {
+                        let insn_id = self.blocks[block.0].insns[i];
+                        self.canonicalize_insn(insn_id, &mut rewrite_map, &mut undo);
                     }
-                    _ => {}
+                    stack.push(Action::Leave(mark));
+                    for &child in &children[block.0] {
+                        stack.push(Action::Visit(child));
+                    }
+                }
+                Action::Leave(mark) => {
+                    for (key, prev) in undo.drain(mark..).rev() {
+                        rewrite_map[key.0] = prev;
+                    }
                 }
             }
         }
 
         crate::stats::trace_compile_phase("infer_types", || self.infer_types());
+    }
+
+    fn canonicalize_insn(
+        &mut self,
+        insn_id: InsnId,
+        rewrite_map: &mut [Option<InsnId>],
+        undo: &mut Vec<(InsnId, Option<InsnId>)>,
+    ) {
+        let canonical_id = self.union_find.borrow().find_const(insn_id);
+
+        let union_find = &self.union_find;
+        self.insns[canonical_id.0].for_each_operand_mut(|operand| {
+            let canon = union_find.borrow().find_const(*operand);
+            *operand = rewrite_map[canon.0].unwrap_or(canon);
+        });
+
+        // For the binary guards only `left` is registered because their infer_type is
+        // type_of(left).
+        match &self.insns[canonical_id.0] {
+            Insn::GuardType      { val:  src, .. }
+            | Insn::GuardBitEquals { val:  src, .. }
+            | Insn::GuardAnyBitSet { val:  src, .. }
+            | Insn::GuardNoBitsSet { val:  src, .. }
+            | Insn::GuardGreaterEq { left: src, .. }
+            | Insn::GuardLess      { left: src, .. } => {
+                let prev = rewrite_map[src.0].replace(canonical_id);
+                undo.push((*src, prev));
+            }
+            _ => {}
+        }
     }
 
     /// Use type information left by `infer_types` to fold away operations that can be evaluated at compile-time.
@@ -8678,6 +8714,20 @@ impl Dominators {
             if self.idom(block) == block { return false; }
             block = self.idom(block);
         }
+    }
+
+    /// Dominator-tree children for each block, indexed by `BlockId.0`.
+    /// Unreachable blocks and the root's self-loop contribute no child.
+    pub fn children(&self) -> Vec<Vec<BlockId>> {
+        let mut children = vec![Vec::new(); self.idoms.len()];
+        for (i, &idom) in self.idoms.iter().enumerate() {
+            if idom == IDOM_NONE { continue; }
+            let b = BlockId(i);
+            // The root idoms itself; skip so it doesn't become its own child.
+            if idom == b { continue; }
+            children[idom.0].push(b);
+        }
+        children
     }
 
     /// Compute the full dominator set for `block` by walking the idom chain to the root.

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5014,8 +5014,7 @@ impl Function {
     fn canonicalize(&mut self) {
         enum Action { Visit(BlockId), Leave(usize) }
 
-        let doms = Dominators::new(self);
-        let children = doms.children();
+        let dominators = Dominators::new(self);
         // This pass must not allocate new insns; `rewrite_map` is sized to the
         // current `self.insns.len()` and indexed by `InsnId.0` without bounds
         // checks, so any new insn would OOB-panic on the next iteration.
@@ -5033,7 +5032,7 @@ impl Function {
                         self.canonicalize_insn(insn_id, &mut rewrite_map, &mut undo);
                     }
                     stack.push(Action::Leave(mark));
-                    for &child in &children[block.0] {
+                    for child in dominators.children(block) {
                         stack.push(Action::Visit(child));
                     }
                 }
@@ -8618,14 +8617,35 @@ fn compile_jit_entry_state(fun: &mut Function, jit_entry_block: BlockId, jit_ent
     (self_param, entry_state)
 }
 
-pub struct Dominators {
-    /// Immediate dominator for each block, indexed by BlockId.
-    /// idom(root) = root (self-loop is sentinel), idom[unreachable] == IDOM_NONE.
-    idoms: Vec<BlockId>,
+/// Sentinel for "no block": unreachable idom, end of child/sibling list.
+const NONE_BLOCK: BlockId = BlockId(usize::MAX);
+
+/// Dom-tree node. Tree shape (parent / first-child / next-sibling) plus an
+/// interval-encoded preorder numbering for O(1) `is_dominated_by`.
+#[derive(Clone, Copy)]
+struct DomTreeNode {
+    /// `NONE_BLOCK` for unreachable; root holds a self-loop sentinel.
+    idom: BlockId,
+    child: BlockId,
+    sibling: BlockId,
+    /// `0` marks unreachable; reachable blocks get `1..=N`.
+    dom_pre: u32,
+    /// Max `dom_pre` over this subtree. `[dom_pre, dom_pre_max]` is the
+    /// preorder interval of the subtree, so dominance is one range test.
+    dom_pre_max: u32,
 }
 
-/// Sentinel value for "no idom computed yet".
-const IDOM_NONE: BlockId = BlockId(usize::MAX);
+/// Dominator tree, modeled after Cranelift's `DominatorTree`: a single
+/// `Vec<DomTreeNode>` with intrusive child/sibling links plus an interval
+/// encoding of preorder numbers for O(1) dominance queries.
+///
+/// Refs:
+/// - Cranelift: <https://github.com/bytecodealliance/wasmtime/blob/main/cranelift/codegen/src/dominator_tree.rs>
+/// - Cooper, Harvey & Kennedy, "A Simple, Fast Dominance Algorithm" (2001):
+///   <https://www.cs.tufts.edu/~nr/cs257/archive/keith-cooper/dom14.pdf>
+pub struct Dominators {
+    nodes: Vec<DomTreeNode>,
+}
 
 impl Dominators {
     pub fn new(f: &Function) -> Self {
@@ -8633,9 +8653,10 @@ impl Dominators {
         Self::with_cfi(f, &mut cfi)
     }
 
-    /// Compute immediate dominators using the "engineered algorithm" from
-    /// Cooper, Harvey & Kennedy, "A Simple, Fast Dominance Algorithm" (2001),
-    /// Figure 3: <https://www.cs.tufts.edu/~nr/cs257/archive/keith-cooper/dom14.pdf>
+    /// Three passes:
+    ///   1. Cooper-Harvey-Kennedy "engineered algorithm" computes idoms.
+    ///   2. Reverse-RPO prepend builds each parent's child list (RPO-ascending).
+    ///   3. DFS assigns preorder numbers and propagates subtree maxima.
     pub fn with_cfi(f: &Function, cfi: &mut ControlFlowInfo) -> Self {
         let rpo = f.rpo();
         let num_blocks = f.blocks.len();
@@ -8646,8 +8667,8 @@ impl Dominators {
             rpo_order[block.0] = idx;
         }
 
-        // Initialize idom: root's idom is itself, everything else is undefined.
-        let mut idoms = vec![IDOM_NONE; num_blocks];
+        // Pass 1: Cooper-Harvey-Kennedy idom computation.
+        let mut idoms = vec![NONE_BLOCK; num_blocks];
         let root = f.entries_block;
         idoms[root.0] = root;
 
@@ -8657,21 +8678,19 @@ impl Dominators {
             for &block in &rpo {
                 if block == root { continue; }
 
-                // Find the first predecessor that already has an idom computed.
                 let preds: Vec<BlockId> = cfi.predecessors(block).collect();
-                let mut new_idom = IDOM_NONE;
+                let mut new_idom = NONE_BLOCK;
                 for &p in &preds {
-                    if idoms[p.0] != IDOM_NONE {
+                    if idoms[p.0] != NONE_BLOCK {
                         new_idom = p;
                         break;
                     }
                 }
-                if new_idom == IDOM_NONE { continue; }
+                if new_idom == NONE_BLOCK { continue; }
 
-                // Intersect with remaining processed predecessors.
                 for &p in &preds {
                     if p == new_idom { continue; }
-                    if idoms[p.0] != IDOM_NONE {
+                    if idoms[p.0] != NONE_BLOCK {
                         new_idom = Self::intersect(&idoms, &rpo_order, p, new_idom);
                     }
                 }
@@ -8683,7 +8702,35 @@ impl Dominators {
             }
         }
 
-        Self { idoms }
+        let mut nodes = Vec::with_capacity(num_blocks);
+        for i in 0..num_blocks {
+            nodes.push(DomTreeNode {
+                idom: idoms[i],
+                child: NONE_BLOCK,
+                sibling: NONE_BLOCK,
+                dom_pre: 0,
+                dom_pre_max: 0,
+            });
+        }
+
+        // Pass 2: reverse-RPO prepend leaves each child list RPO-ascending.
+        for &block in rpo.iter().rev() {
+            let parent = nodes[block.0].idom;
+            if parent == NONE_BLOCK { continue; }
+            // Skip root's self-loop sentinel so it isn't its own child.
+            if parent == block { continue; }
+            nodes[block.0].sibling = nodes[parent.0].child;
+            nodes[parent.0].child = block;
+        }
+
+        let mut tree = Dominators { nodes };
+
+        // Pass 3.
+        if num_blocks > 0 {
+            tree.assign_preorder(root);
+        }
+
+        tree
     }
 
     /// Walk up the dominator tree from two fingers until they meet.
@@ -8700,34 +8747,55 @@ impl Dominators {
         b1
     }
 
-    /// Return the immediate dominator of `block`.
+    /// Iterative DFS (avoids stack overflow on deep CFGs): preorder on enter,
+    /// subtree max on leave.
+    fn assign_preorder(&mut self, root: BlockId) {
+        enum Step { Enter(BlockId), Leave(BlockId) }
+        let mut counter: u32 = 0;
+        let mut stack = vec![Step::Enter(root)];
+        while let Some(step) = stack.pop() {
+            match step {
+                Step::Enter(b) => {
+                    // `dom_pre == 0` is the "unreachable" sentinel; wrap would corrupt it.
+                    counter = counter.checked_add(1).expect("dom-tree preorder counter overflowed u32");
+                    self.nodes[b.0].dom_pre = counter;
+                    stack.push(Step::Leave(b));
+                    let mut c = self.nodes[b.0].child;
+                    while c != NONE_BLOCK {
+                        stack.push(Step::Enter(c));
+                        c = self.nodes[c.0].sibling;
+                    }
+                }
+                Step::Leave(b) => {
+                    let mut max = self.nodes[b.0].dom_pre;
+                    let mut c = self.nodes[b.0].child;
+                    while c != NONE_BLOCK {
+                        max = max.max(self.nodes[c.0].dom_pre_max);
+                        c = self.nodes[c.0].sibling;
+                    }
+                    self.nodes[b.0].dom_pre_max = max;
+                }
+            }
+        }
+    }
+
+    /// Root → self; unreachable → `NONE_BLOCK`.
     pub fn idom(&self, block: BlockId) -> BlockId {
-        self.idoms[block.0]
+        self.nodes[block.0].idom
     }
 
-    /// Return true if `left` is dominated by `right`.
+    /// O(1): `left`'s preorder must fall in `right`'s `[dom_pre, dom_pre_max]`.
     pub fn is_dominated_by(&self, left: BlockId, right: BlockId) -> bool {
-        if self.idom(left) == IDOM_NONE { return false; }
-        let mut block = left;
-        loop {
-            if block == right { return true; }
-            if self.idom(block) == block { return false; }
-            block = self.idom(block);
-        }
+        let l = &self.nodes[left.0];
+        let r = &self.nodes[right.0];
+        l.dom_pre != 0
+            && r.dom_pre <= l.dom_pre
+            && l.dom_pre <= r.dom_pre_max
     }
 
-    /// Dominator-tree children for each block, indexed by `BlockId.0`.
-    /// Unreachable blocks and the root's self-loop contribute no child.
-    pub fn children(&self) -> Vec<Vec<BlockId>> {
-        let mut children = vec![Vec::new(); self.idoms.len()];
-        for (i, &idom) in self.idoms.iter().enumerate() {
-            if idom == IDOM_NONE { continue; }
-            let b = BlockId(i);
-            // The root idoms itself; skip so it doesn't become its own child.
-            if idom == b { continue; }
-            children[idom.0].push(b);
-        }
-        children
+    /// Dom-tree children of `block`, RPO-ascending.
+    pub fn children(&self, block: BlockId) -> ChildIter<'_> {
+        ChildIter { dominators: self, next: self.nodes[block.0].child }
     }
 
     /// Compute the full dominator set for `block` by walking the idom chain to the root.
@@ -8735,7 +8803,7 @@ impl Dominators {
     /// production code should use `idom()` or `is_dominated_by()` instead.
     pub fn dominators(&self, block: BlockId) -> Vec<BlockId> {
         let mut doms = Vec::new();
-        if self.idom(block) != IDOM_NONE {
+        if self.idom(block) != NONE_BLOCK {
             let mut b = block;
             loop {
                 doms.push(b);
@@ -8745,6 +8813,23 @@ impl Dominators {
         }
         doms.sort();
         doms
+    }
+}
+
+pub struct ChildIter<'a> {
+    dominators: &'a Dominators,
+    next: BlockId,
+}
+
+impl<'a> Iterator for ChildIter<'a> {
+    type Item = BlockId;
+    fn next(&mut self) -> Option<BlockId> {
+        if self.next == NONE_BLOCK {
+            return None;
+        }
+        let cur = self.next;
+        self.next = self.dominators.nodes[cur.0].sibling;
+        Some(cur)
     }
 }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -15959,6 +15959,133 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_dedup_guard_type_across_dominator_chain() {
+        let src = "
+            def test(n)
+              return -1 if n < 0
+              return  0 if n == 0
+              n * 2
+            end
+            test(1); test(0); test(-1)
+        ";
+        eval(src);
+        let hir = hir_string("test");
+        assert_eq!(hir.matches("GuardType").count(), 1, "{hir}");
+    }
+
+    #[test]
+    fn test_dedup_guard_type_through_nested_conditionals() {
+        let src = "
+            def test(n, a)
+              return -1 if n < 0
+              if a
+                n + 1
+              else
+                n + 2
+              end
+            end
+            test(1, true); test(1, false); test(-1, true)
+        ";
+        eval(src);
+        let hir = hir_string("test");
+        assert_eq!(hir.matches("GuardType").count(), 1, "{hir}");
+    }
+
+    #[test]
+    fn test_no_dedup_when_not_dominated() {
+        let src = "
+            def test(cond, a)
+              if cond
+                a + 1
+              else
+                a + 2
+              end
+            end
+            test(true, 1); test(false, 1)
+        ";
+        eval(src);
+        let hir = hir_string("test");
+        assert_eq!(hir.matches("GuardType").count(), 2, "{hir}");
+    }
+
+    #[test]
+    fn test_dedup_guard_type_in_loop_body() {
+        // `m = n + 0` is a pre-header use of `n` so a `GuardType n` lands
+        // before the loop body, which the body's use of `n` must then reuse.
+        let src = "
+            def test(n)
+              m = n + 0
+              i = 0
+              while i < 3
+                i = i + n
+              end
+              m + i
+            end
+            test(1); test(2)
+        ";
+        eval(src);
+        let hir = hir_string("test");
+        assert_eq!(hir.matches("GuardType").count(), 1, "{hir}");
+    }
+
+    #[test]
+    fn test_dedup_guard_type_across_dominator_chain_snapshot() {
+        // Snapshot variant: locks in *which* insn the surviving `GuardType`
+        // forwards, since count alone misses wrong-target rewrites.
+        eval("
+            def test(n)
+              return -1 if n < 0
+              return  0 if n == 0
+              n * 2
+            end
+            test(1); test(0); test(-1)
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v15:Fixnum[0] = Const Value(0)
+          PatchPoint MethodRedefined(Integer@0x1008, <@0x1010, cme:0x1018)
+          v70:Fixnum = GuardType v10, Fixnum
+          v71:BoolExact = FixnumLt v70, v15
+          CheckInterrupts
+          v21:CBool = Test v71
+          CondBranch v21, bb6(), bb4(v9, v70)
+        bb6():
+          v26:Fixnum[-1] = Const Value(-1)
+          CheckInterrupts
+          Return v26
+        bb4(v31:BasicObject, v32:Fixnum):
+          v37:Fixnum[0] = Const Value(0)
+          PatchPoint MethodRedefined(Integer@0x1008, ==@0x1040, cme:0x1048)
+          v75:BoolExact = FixnumEq v32, v37
+          CheckInterrupts
+          v43:CBool = Test v75
+          CondBranch v43, bb7(), bb5(v31, v32)
+        bb7():
+          v48:Fixnum[0] = Const Value(0)
+          CheckInterrupts
+          Return v48
+        bb5(v53:BasicObject, v54:Fixnum):
+          v59:Fixnum[2] = Const Value(2)
+          PatchPoint MethodRedefined(Integer@0x1008, *@0x1070, cme:0x1078)
+          v79:Fixnum = FixnumMult v54, v59
+          CheckInterrupts
+          Return v79
+        ");
+    }
+
+    #[test]
     fn test_infer_types_across_non_maximal_basic_blocks() {
         // Previous worklist-based type inference only worked for maximal SSA. This is a regression
         // test for hanging.

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -5890,12 +5890,12 @@ pub(crate) mod hir_build_tests {
 
         function.seal_entries();
 
-        let children = Dominators::new(&function).children();
+        let dominators = Dominators::new(&function);
 
-        assert_eq!(children[entries.0], vec![bb0]);
-        assert_eq!(children[bb0.0], vec![bb1]);
-        assert_eq!(children[bb1.0], vec![bb2]);
-        assert_eq!(children[bb2.0], Vec::<BlockId>::new());
+        assert_eq!(dominators.children(entries).collect::<Vec<_>>(), vec![bb0]);
+        assert_eq!(dominators.children(bb0).collect::<Vec<_>>(), vec![bb1]);
+        assert_eq!(dominators.children(bb1).collect::<Vec<_>>(), vec![bb2]);
+        assert_eq!(dominators.children(bb2).collect::<Vec<_>>(), Vec::<BlockId>::new());
     }
 
     #[test]
@@ -5919,13 +5919,13 @@ pub(crate) mod hir_build_tests {
 
         function.seal_entries();
 
-        let children = Dominators::new(&function).children();
+        let dominators = Dominators::new(&function);
 
-        assert_eq!(children[entries.0], vec![bb0]);
-        assert_eq!(children[bb0.0], vec![bb1, bb2, bb3]);
-        assert_eq!(children[bb1.0], Vec::<BlockId>::new());
-        assert_eq!(children[bb2.0], Vec::<BlockId>::new());
-        assert_eq!(children[bb3.0], Vec::<BlockId>::new());
+        assert_eq!(dominators.children(entries).collect::<Vec<_>>(), vec![bb0]);
+        assert_eq!(dominators.children(bb0).collect::<Vec<_>>(), vec![bb1, bb2, bb3]);
+        assert_eq!(dominators.children(bb1).collect::<Vec<_>>(), Vec::<BlockId>::new());
+        assert_eq!(dominators.children(bb2).collect::<Vec<_>>(), Vec::<BlockId>::new());
+        assert_eq!(dominators.children(bb3).collect::<Vec<_>>(), Vec::<BlockId>::new());
     }
 
     #[test]
@@ -5946,12 +5946,12 @@ pub(crate) mod hir_build_tests {
 
         function.seal_entries();
 
-        let children = Dominators::new(&function).children();
+        let dominators = Dominators::new(&function);
 
-        assert_eq!(children[entries.0], vec![bb0, bb1, bb2]);
-        assert_eq!(children[bb0.0], Vec::<BlockId>::new());
-        assert_eq!(children[bb1.0], Vec::<BlockId>::new());
-        assert_eq!(children[bb2.0], Vec::<BlockId>::new());
+        assert_eq!(dominators.children(entries).collect::<Vec<_>>(), vec![bb0, bb1, bb2]);
+        assert_eq!(dominators.children(bb0).collect::<Vec<_>>(), Vec::<BlockId>::new());
+        assert_eq!(dominators.children(bb1).collect::<Vec<_>>(), Vec::<BlockId>::new());
+        assert_eq!(dominators.children(bb2).collect::<Vec<_>>(), Vec::<BlockId>::new());
     }
 
     #[test]
@@ -5973,12 +5973,178 @@ pub(crate) mod hir_build_tests {
 
         function.seal_entries();
 
-        let children = Dominators::new(&function).children();
+        let dominators = Dominators::new(&function);
 
-        assert_eq!(children[entries.0], vec![bb0]);
-        assert_eq!(children[bb0.0], vec![bb1]);
-        assert_eq!(children[bb1.0], Vec::<BlockId>::new());
-        assert_eq!(children[bb2.0], Vec::<BlockId>::new());
+        assert_eq!(dominators.children(entries).collect::<Vec<_>>(), vec![bb0]);
+        assert_eq!(dominators.children(bb0).collect::<Vec<_>>(), vec![bb1]);
+        assert_eq!(dominators.children(bb1).collect::<Vec<_>>(), Vec::<BlockId>::new());
+        assert_eq!(dominators.children(bb2).collect::<Vec<_>>(), Vec::<BlockId>::new());
+    }
+
+    /// Reference impl: idom-chain walk, independent of `is_dominated_by`.
+    fn is_dominated_by_chain_walk(dominators: &Dominators, left: BlockId, right: BlockId) -> bool {
+        if dominators.idom(left) == NONE_BLOCK {
+            return false;
+        }
+        let mut b = left;
+        loop {
+            if b == right {
+                return true;
+            }
+            if dominators.idom(b) == b {
+                return false;
+            }
+            b = dominators.idom(b);
+        }
+    }
+
+    fn diamond() -> (Function, [BlockId; 4]) {
+        let mut function = Function::new(std::ptr::null());
+        let bb0 = function.entry_block;
+        let bb1 = function.new_block(0);
+        let bb2 = function.new_block(0);
+        let bb3 = function.new_block(0);
+        let val = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
+        let _ = function.push_insn(bb0, Insn::CondBranch { val, if_true: edge(bb1), if_false: edge(bb2) });
+        function.push_insn(bb1, Insn::Jump(edge(bb3)));
+        function.push_insn(bb2, Insn::Jump(edge(bb3)));
+        let retval = function.push_insn(bb3, Insn::Const { val: Const::CBool(true) });
+        function.push_insn(bb3, Insn::Return { val: retval });
+        function.seal_entries();
+        (function, [bb0, bb1, bb2, bb3])
+    }
+
+    /// bb0 -> bb1 -> bb2 -> bb1, bb2 -> bb3 (back-edge).
+    fn loop_cfg() -> (Function, [BlockId; 4]) {
+        let mut function = Function::new(std::ptr::null());
+        let bb0 = function.entry_block;
+        let bb1 = function.new_block(0);
+        let bb2 = function.new_block(0);
+        let bb3 = function.new_block(0);
+        function.push_insn(bb0, Insn::Jump(edge(bb1)));
+        function.push_insn(bb1, Insn::Jump(edge(bb2)));
+        let cond = function.push_insn(bb2, Insn::Const { val: Const::Value(Qfalse) });
+        let _ = function.push_insn(bb2, Insn::CondBranch { val: cond, if_true: edge(bb1), if_false: edge(bb3) });
+        let retval = function.push_insn(bb3, Insn::Const { val: Const::CBool(true) });
+        function.push_insn(bb3, Insn::Return { val: retval });
+        function.seal_entries();
+        (function, [bb0, bb1, bb2, bb3])
+    }
+
+    #[test]
+    fn test_dom_tree_is_dominated_by_o1_correctness() {
+        let mut cases: Vec<Function> = Vec::new();
+        {
+            // linear: bb0 -> bb1 -> bb2
+            let mut function = Function::new(std::ptr::null());
+            let bb0 = function.entry_block;
+            let bb1 = function.new_block(0);
+            let bb2 = function.new_block(0);
+            function.push_insn(bb0, Insn::Jump(edge(bb1)));
+            function.push_insn(bb1, Insn::Jump(edge(bb2)));
+            let retval = function.push_insn(bb2, Insn::Const { val: Const::CBool(true) });
+            function.push_insn(bb2, Insn::Return { val: retval });
+            function.seal_entries();
+            cases.push(function);
+        }
+        cases.push(diamond().0);
+        cases.push(loop_cfg().0);
+        {
+            // unreachable: bb2 is not reachable from entry.
+            let mut function = Function::new(std::ptr::null());
+            let bb0 = function.entry_block;
+            let bb1 = function.new_block(0);
+            let bb2 = function.new_block(0);
+            function.push_insn(bb0, Insn::Jump(edge(bb1)));
+            let retval = function.push_insn(bb1, Insn::Const { val: Const::CBool(true) });
+            function.push_insn(bb1, Insn::Return { val: retval });
+            let v = function.push_insn(bb2, Insn::Const { val: Const::CBool(false) });
+            function.push_insn(bb2, Insn::Return { val: v });
+            function.seal_entries();
+            cases.push(function);
+        }
+        {
+            // multi-entry: two jit entries merging at bb2.
+            let mut function = Function::new(std::ptr::null());
+            let bb0 = function.entry_block;
+            let bb1 = function.new_block(0);
+            function.jit_entry_blocks.push(bb1);
+            let bb2 = function.new_block(0);
+            function.push_insn(bb0, Insn::Jump(edge(bb2)));
+            function.push_insn(bb1, Insn::Jump(edge(bb2)));
+            let retval = function.push_insn(bb2, Insn::Const { val: Const::CBool(true) });
+            function.push_insn(bb2, Insn::Return { val: retval });
+            function.seal_entries();
+            cases.push(function);
+        }
+
+        for function in &cases {
+            let dominators = Dominators::new(function);
+            let n = function.blocks.len();
+            for i in 0..n {
+                for j in 0..n {
+                    let left = BlockId(i);
+                    let right = BlockId(j);
+                    assert_eq!(
+                        dominators.is_dominated_by(left, right),
+                        is_dominated_by_chain_walk(&dominators, left, right),
+                        "is_dominated_by({:?}, {:?}) disagrees with chain walk",
+                        left, right,
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_dom_tree_preorder_invariant() {
+        let (function, _) = diamond();
+        let dominators = Dominators::new(&function);
+        let n = function.blocks.len();
+        for i in 0..n {
+            let parent = BlockId(i);
+            if dominators.idom(parent) == NONE_BLOCK {
+                continue;
+            }
+            let pre = dominators.nodes[parent.0].dom_pre;
+            let pre_max = dominators.nodes[parent.0].dom_pre_max;
+            assert!(pre >= 1);
+            assert!(pre_max >= pre);
+            for j in 0..n {
+                let other = BlockId(j);
+                if dominators.idom(other) == NONE_BLOCK {
+                    continue;
+                }
+                let other_pre = dominators.nodes[other.0].dom_pre;
+                let in_subtree = is_dominated_by_chain_walk(&dominators, other, parent);
+                let in_interval = pre <= other_pre && other_pre <= pre_max;
+                assert_eq!(in_subtree, in_interval,
+                    "subtree membership for {:?} under {:?} disagrees with interval",
+                    other, parent);
+            }
+        }
+    }
+
+    #[test]
+    fn test_dom_tree_child_iter_rpo_order() {
+        let (function, _) = diamond();
+        let rpo = function.rpo();
+        let rpo_idx: HashMap<BlockId, usize> = rpo
+            .iter()
+            .enumerate()
+            .map(|(i, &b)| (b, i))
+            .collect();
+        let dominators = Dominators::new(&function);
+        for &parent in &rpo {
+            let kids: Vec<BlockId> = dominators.children(parent).collect();
+            for w in kids.windows(2) {
+                assert!(
+                    rpo_idx[&w[0]] < rpo_idx[&w[1]],
+                    "children of {:?} not in RPO order: {:?}",
+                    parent, kids,
+                );
+            }
+        }
     }
  }
 

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -5873,6 +5873,113 @@ pub(crate) mod hir_build_tests {
 
         assert!(!dominators.is_dominated_by(bb1, bb2));
     }
+
+    #[test]
+    fn test_dominator_children_linear() {
+        let mut function = Function::new(std::ptr::null());
+
+        let entries = function.entries_block;
+        let bb0 = function.entry_block;
+        let bb1 = function.new_block(0);
+        let bb2 = function.new_block(0);
+
+        function.push_insn(bb0, Insn::Jump(edge(bb1)));
+        function.push_insn(bb1, Insn::Jump(edge(bb2)));
+        let retval = function.push_insn(bb2, Insn::Const { val: Const::CBool(true) });
+        function.push_insn(bb2, Insn::Return { val: retval });
+
+        function.seal_entries();
+
+        let children = Dominators::new(&function).children();
+
+        assert_eq!(children[entries.0], vec![bb0]);
+        assert_eq!(children[bb0.0], vec![bb1]);
+        assert_eq!(children[bb1.0], vec![bb2]);
+        assert_eq!(children[bb2.0], Vec::<BlockId>::new());
+    }
+
+    #[test]
+    fn test_dominator_children_diamond() {
+        let mut function = Function::new(std::ptr::null());
+
+        let entries = function.entries_block;
+        let bb0 = function.entry_block;
+        let bb1 = function.new_block(0);
+        let bb2 = function.new_block(0);
+        let bb3 = function.new_block(0);
+
+        let val = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
+        let _ = function.push_insn(bb0, Insn::CondBranch { val, if_true: edge(bb1), if_false: edge(bb2) });
+
+        function.push_insn(bb1, Insn::Jump(edge(bb3)));
+        function.push_insn(bb2, Insn::Jump(edge(bb3)));
+
+        let retval = function.push_insn(bb3, Insn::Const { val: Const::CBool(true) });
+        function.push_insn(bb3, Insn::Return { val: retval });
+
+        function.seal_entries();
+
+        let children = Dominators::new(&function).children();
+
+        assert_eq!(children[entries.0], vec![bb0]);
+        assert_eq!(children[bb0.0], vec![bb1, bb2, bb3]);
+        assert_eq!(children[bb1.0], Vec::<BlockId>::new());
+        assert_eq!(children[bb2.0], Vec::<BlockId>::new());
+        assert_eq!(children[bb3.0], Vec::<BlockId>::new());
+    }
+
+    #[test]
+    fn test_dominator_children_with_jit_entries() {
+        let mut function = Function::new(std::ptr::null());
+
+        let entries = function.entries_block;
+        let bb0 = function.entry_block;
+        let bb1 = function.new_block(0);
+        function.jit_entry_blocks.push(bb1);
+        let bb2 = function.new_block(0);
+
+        function.push_insn(bb0, Insn::Jump(edge(bb2)));
+        function.push_insn(bb1, Insn::Jump(edge(bb2)));
+
+        let retval = function.push_insn(bb2, Insn::Const { val: Const::CBool(true) });
+        function.push_insn(bb2, Insn::Return { val: retval });
+
+        function.seal_entries();
+
+        let children = Dominators::new(&function).children();
+
+        assert_eq!(children[entries.0], vec![bb0, bb1, bb2]);
+        assert_eq!(children[bb0.0], Vec::<BlockId>::new());
+        assert_eq!(children[bb1.0], Vec::<BlockId>::new());
+        assert_eq!(children[bb2.0], Vec::<BlockId>::new());
+    }
+
+    #[test]
+    fn test_dominator_children_unreachable() {
+        let mut function = Function::new(std::ptr::null());
+
+        let entries = function.entries_block;
+        let bb0 = function.entry_block;
+        let bb1 = function.new_block(0);
+        let bb2 = function.new_block(0);
+
+        function.push_insn(bb0, Insn::Jump(edge(bb1)));
+        let retval = function.push_insn(bb1, Insn::Const { val: Const::CBool(true) });
+        function.push_insn(bb1, Insn::Return { val: retval });
+
+        // bb2 is unreachable but needs a terminator for validity.
+        let v = function.push_insn(bb2, Insn::Const { val: Const::CBool(false) });
+        function.push_insn(bb2, Insn::Return { val: v });
+
+        function.seal_entries();
+
+        let children = Dominators::new(&function).children();
+
+        assert_eq!(children[entries.0], vec![bb0]);
+        assert_eq!(children[bb0.0], vec![bb1]);
+        assert_eq!(children[bb1.0], Vec::<BlockId>::new());
+        assert_eq!(children[bb2.0], Vec::<BlockId>::new());
+    }
  }
 
  /// Test loop information computation.

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -6146,6 +6146,117 @@ pub(crate) mod hir_build_tests {
             }
         }
     }
+
+    fn return_val(function: &Function, ret: InsnId) -> InsnId {
+        match &function.insns[ret.0] {
+            Insn::Return { val } => *val,
+            other => panic!("expected Return, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn canonicalize_forwards_guard_use_within_block() {
+        let mut function = Function::new(std::ptr::null());
+        let bb0 = function.entry_block;
+
+        let v_state = function.push_insn(bb0, Insn::Const { val: Const::CBool(true) });
+        let v_val   = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
+        let v_guard = function.push_insn(bb0, Insn::GuardType {
+            val: v_val, guard_type: types::Fixnum, state: v_state,
+        });
+        let ret = function.push_insn(bb0, Insn::Return { val: v_val });
+
+        function.seal_entries();
+        function.dom_scope_rewrite();
+
+        assert_eq!(return_val(&function, ret), v_guard);
+    }
+
+    #[test]
+    fn canonicalize_forwards_across_dominated_block() {
+        let mut function = Function::new(std::ptr::null());
+        let bb0 = function.entry_block;
+        let bb1 = function.new_block(0);
+
+        let v_state = function.push_insn(bb0, Insn::Const { val: Const::CBool(true) });
+        let v_val   = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
+        let v_guard = function.push_insn(bb0, Insn::GuardType {
+            val: v_val, guard_type: types::Fixnum, state: v_state,
+        });
+        function.push_insn(bb0, Insn::Jump(edge(bb1)));
+        let ret = function.push_insn(bb1, Insn::Return { val: v_val });
+
+        function.seal_entries();
+        function.dom_scope_rewrite();
+
+        assert_eq!(return_val(&function, ret), v_guard);
+    }
+
+    // bb0 -> {bb1, bb2} -> bb3. bb1's guard must not leak into sibling bb2.
+    #[test]
+    fn canonicalize_does_not_forward_to_sibling_block() {
+        let mut function = Function::new(std::ptr::null());
+        let bb0 = function.entry_block;
+        let bb1 = function.new_block(0);
+        let bb2 = function.new_block(0);
+        let bb3 = function.new_block(0);
+
+        let v_state = function.push_insn(bb0, Insn::Const { val: Const::CBool(true) });
+        let v_val   = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
+        let v_cond  = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
+        function.push_insn(bb0, Insn::CondBranch {
+            val: v_cond, if_true: edge(bb1), if_false: edge(bb2),
+        });
+
+        function.push_insn(bb1, Insn::GuardType {
+            val: v_val, guard_type: types::Fixnum, state: v_state,
+        });
+        function.push_insn(bb1, Insn::Jump(edge(bb3)));
+
+        let ret_in_sibling = function.push_insn(bb2, Insn::Return { val: v_val });
+        function.push_insn(bb3, Insn::Unreachable);
+
+        function.seal_entries();
+        function.dom_scope_rewrite();
+
+        assert_eq!(return_val(&function, ret_in_sibling), v_val);
+    }
+
+    // Nested guards on the same value: bb0 installs g0, bb1 installs g1 over g0.
+    // A use of g0 inside bb1 must forward to g1; back in sibling bb2, g0 stays.
+    #[test]
+    fn canonicalize_nested_guards_on_same_value_restore_parent_binding() {
+        let mut function = Function::new(std::ptr::null());
+        let bb0 = function.entry_block;
+        let bb1 = function.new_block(0);
+        let bb2 = function.new_block(0);
+
+        let v_state = function.push_insn(bb0, Insn::Const { val: Const::CBool(true) });
+        let v_val   = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
+        let v_cond  = function.push_insn(bb0, Insn::Const { val: Const::Value(Qfalse) });
+        let g0 = function.push_insn(bb0, Insn::GuardType {
+            val: v_val, guard_type: types::Fixnum, state: v_state,
+        });
+        function.push_insn(bb0, Insn::CondBranch {
+            val: v_cond, if_true: edge(bb1), if_false: edge(bb2),
+        });
+
+        let g1 = function.push_insn(bb1, Insn::GuardBitEquals {
+            val: v_val,
+            expected: Const::Value(Qfalse),
+            reason: SideExitReason::GuardSuperMethodEntry,
+            state: v_state,
+            recompile: None,
+        });
+        let ret_inner = function.push_insn(bb1, Insn::Return { val: g0 });
+        let ret_sibling = function.push_insn(bb2, Insn::Return { val: g0 });
+
+        function.seal_entries();
+        function.dom_scope_rewrite();
+
+        assert_eq!(return_val(&function, ret_inner), g1);
+        assert_eq!(return_val(&function, ret_sibling), g0);
+    }
  }
 
  /// Test loop information computation.


### PR DESCRIPTION
## Summary

Follow-up to GH-16828, which made `canonicalize` rewrite operands through a block-local `rewrite_map` of the most recent `Guard*` result. That pass cleared the map at every block boundary, so a guard established in a dominator block was not forwarded into dominated blocks and `early-return` shaped code kept emitting redundant `GuardType` for the same SSA value:

```ruby
  def early_return(n)
    return -1 if n < 0    # bb0: GuardType n
    return  0 if n == 0   # bb2: GuardType n  (redundant; bb0 dominates)
    n * 2                 # bb4: GuardType n  (redundant; bb0 dominates)
  end
```

This widens the scope to the dominator tree. While processing block B, `rewrite_map` holds the guards established on the dom-tree path from the root down to (and including) the prefix of B already processed. Any use rewritten under that invariant is dominated by the guard's defining position in SSA, so the substitution is unconditional in dom scope just as the previous pass was unconditional in block scope.

## Implementation

- Iterative DFS over the dominator tree (Visit / Leave actions), rooted at `entries_block` so `entry_block` and `jit_entry_blocks` end up as dom-tree siblings — guards from one entry never leak into another.
- `rewrite_map` is a `Vec<Option<InsnId>>` indexed by `InsnId.0` (no hashing on the hot path). An undo log records the previous value on each `Guard*` insertion and replays it on Leave, restoring the map to exactly the state visible to B's parent.
- Inspired by Cranelift's scoped hashmap technique (<https://cfallin.org/blog/2026/04/09/aegraph/>).

## Limitations

`RefineType` remains intentionally skipped: its narrowing is valid only within one `IfTrue`/`IfFalse` arm, and the dom-tree scope is a strict superset of the refine arm scope. Cross-arm refine forwarding needs an arm-scoped pass and is left as a follow-up.

## Benchmarks

Benchmarks (arm64 Linux devcontainer, warmup=10 / bench=20):

  ```
    Throughput (n=5 runs, master/staged ratio ± stddev)
      lobsters    1.031 ± 0.044   (≈ +3.1%, within noise)
      railsbench  1.002 ± 0.031   (≈ +0.2%, within noise)

    --zjit-stats counters             lobsters / railsbench
      code_region_bytes               −0.6%  / −0.6%   (redundant dom-chain guards eliminated)
      guard_type_count (raw)          +23.1% / −6.1%   (iter-count drift; per-iter −5%) ⚠
      side_exit_count  (raw)          +30.3% / −1.5%   (tracks guard_type) ⚠
      compile_hir_time                +5.2%  / +3.4%   (canonicalize: 60ms / 26ms; compile_time +0.5%)
      invalidation_time               +2.6%  / +12.5%  (abs 8ms / 3.6ms — sub-ms noise)
  ```

Closes: https://github.com/Shopify/ruby/issues/983