### PR TITLE
vm_core.h: rb_vm_struct make global_object_list an array

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3743,11 +3743,14 @@ rb_gc_register_address(VALUE *addr)
 
     VALUE obj = *addr;
 
-    struct global_object_list *tmp = ALLOC(struct global_object_list);
     RB_VM_LOCKING() {
-        tmp->next = vm->global_object_list;
-        tmp->varptr = addr;
-        vm->global_object_list = tmp;
+        if (vm->global_object_list_size == vm->global_object_list_capa) {
+            size_t new_capa = vm->global_object_list_capa ? vm->global_object_list_capa * 2 : 64;
+            vm->global_object_list = SIZED_REALLOC_N(vm->global_object_list, VALUE *, new_capa, vm->global_object_list_capa);
+            vm->global_object_list_capa = new_capa;
+        }
+
+        vm->global_object_list[vm->global_object_list_size++] = addr;
     }
 
     /*
@@ -3766,23 +3769,18 @@ void
 rb_gc_unregister_address(VALUE *addr)
 {
     rb_vm_t *vm = GET_VM();
-    struct global_object_list *tmp;
     RB_VM_LOCKING() {
-        tmp = vm->global_object_list;
-        if (tmp->varptr == addr) {
-            vm->global_object_list = tmp->next;
-            SIZED_FREE(tmp);
-        }
-        else {
-            while (tmp->next) {
-                if (tmp->next->varptr == addr) {
-                    struct global_object_list *t = tmp->next;
-
-                    tmp->next = tmp->next->next;
-                    SIZED_FREE(t);
-                    break;
-                }
-                tmp = tmp->next;
+        size_t index;
+        for (index = 0; index < vm->global_object_list_size; index++) {
+            if (addr == vm->global_object_list[index]) {
+                MEMMOVE(
+                    vm->global_object_list[index],
+                    &vm->global_object_list[index + 1],
+                    VALUE *,
+                    vm->global_object_list_size - index - 1
+                );
+                vm->global_object_list_size--;
+                break;
             }
         }
     }

--- a/vm.c
+++ b/vm.c
@@ -3345,8 +3345,8 @@ rb_vm_mark(void *ptr)
             rb_gc_mark(rb_ractor_self(r));
         }
 
-        for (struct global_object_list *list = vm->global_object_list; list; list = list->next) {
-            rb_gc_mark_maybe(*list->varptr);
+        for (size_t index = 0; index < vm->global_object_list_size; index++) {
+            rb_gc_mark_maybe(*vm->global_object_list[index]);
         }
 
         rb_gc_mark_movable(vm->self);
@@ -3452,11 +3452,7 @@ ruby_vm_destruct(rb_vm_t *vm)
         st_free_embedded_table(&vm->ci_table);
         RB_ALTSTACK_FREE(vm->main_altstack);
 
-        struct global_object_list *next;
-        for (struct global_object_list *list = vm->global_object_list; list; list = next) {
-            next = list->next;
-            xfree(list);
-        }
+        SIZED_FREE_N(vm->global_object_list, vm->global_object_list_capa);
 
         if (objspace) {
             if (rb_free_at_exit) {
@@ -3541,6 +3537,7 @@ vm_memsize(const void *ptr)
         vm_memsize_builtin_function_table(vm->builtin_function_table) +
         (rb_id_table_memsize(&vm->negative_cme_table) - sizeof(struct rb_id_table)) +
         (rb_st_memsize(&vm->overloaded_cme_table) - sizeof(struct st_table)) +
+        (vm->global_object_list_capa * sizeof(*vm->global_object_list)) +
         vm_memsize_constant_cache()
     );
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -679,11 +679,6 @@ typedef struct rb_hook_list_struct {
 // see builtin.h for definition
 typedef const struct rb_builtin_function *RB_BUILTIN;
 
-struct global_object_list {
-    VALUE *varptr;
-    struct global_object_list *next;
-};
-
 typedef struct rb_vm_struct {
     VALUE self;
 
@@ -770,7 +765,9 @@ typedef struct rb_vm_struct {
 
     /* object management */
     VALUE mark_object_ary;
-    struct global_object_list *global_object_list;
+    VALUE **global_object_list;
+    size_t global_object_list_size;
+    size_t global_object_list_capa;
     const VALUE special_exceptions[ruby_special_error_count];
 
     /* Ruby Box */


### PR DESCRIPTION
Instead of a linked list. Should be both more compact and faster to iterate.

Also fix reporting its memory size.