### PR TITLE
Fix Method/UnboundMethod for refinement psuedo-zsuper methods

### DIFF
--- a/proc.c
+++ b/proc.c
@@ -1853,6 +1853,8 @@ mnew_missing_by_name(VALUE klass, VALUE obj, VALUE *name, int scope, VALUE mclas
     return mnew_missing(klass, obj, SYM2ID(vid), mclass);
 }
 
+VALUE rb_zsuper_to_super(int argc, VALUE *argv, VALUE self);
+
 static VALUE
 mnew_internal(const rb_method_entry_t *me, VALUE klass, VALUE iclass,
               VALUE obj, ID id, VALUE mclass, int scope, int error)
@@ -1878,8 +1880,9 @@ mnew_internal(const rb_method_entry_t *me, VALUE klass, VALUE iclass,
             rb_print_inaccessible(klass, id, visi);
         }
     }
-    if (me->def->type == VM_METHOD_TYPE_ZSUPER) {
-        if (me->defined_class) {
+    if (me->def->type == VM_METHOD_TYPE_ZSUPER ||
+            (me->def->type == VM_METHOD_TYPE_CFUNC && me->def->body.cfunc.func == (rb_cfunc_t)rb_zsuper_to_super)) {
+        if (me->def->type == VM_METHOD_TYPE_ZSUPER && me->defined_class) {
             VALUE klass = RCLASS_SUPER(RCLASS_ORIGIN(me->defined_class));
             id = me->def->original_id;
             me = (rb_method_entry_t *)rb_callable_method_entry_with_refinements(klass, id, &iclass);
@@ -3071,7 +3074,11 @@ original_method_entry(VALUE mod, ID id)
 
     while ((me = rb_method_entry(mod, id)) != 0) {
         const rb_method_definition_t *def = me->def;
-        if (def->type != VM_METHOD_TYPE_ZSUPER) break;
+
+        if (def->type != VM_METHOD_TYPE_ZSUPER &&
+            (def->type != VM_METHOD_TYPE_CFUNC ||
+             def->body.cfunc.func != (rb_cfunc_t)rb_zsuper_to_super)) break;
+
         mod = RCLASS_SUPER(me->owner);
         id = def->original_id;
     }

--- a/test/ruby/test_refinement.rb
+++ b/test/ruby/test_refinement.rb
@@ -1675,6 +1675,33 @@ class TestRefinement < Test::Unit::TestCase
     end
   end
 
+  def test_zsuper_refinement_method_arity_and_parameters
+    assert_separately([], <<-"end;")
+      class A
+        private def a(b) = b
+      end
+
+      class B < A
+        public :a
+      end
+
+      module R
+        refine A do
+          public :a
+        end
+      end
+      using R
+
+      m = B.instance_method(:a)
+      assert_equal(1, m.arity)
+      assert_equal([[:req, :b]], m.parameters)
+
+      m = A.instance_method(:a)
+      assert_equal(1, m.arity)
+      assert_equal([[:req, :b]], m.parameters)
+    end;
+  end
+
   def test_instance_methods
     bug8881 = '[ruby-core:57080] [Bug #8881]'
     assert_not_include(Foo.instance_methods(false), :z, bug8881)

--- a/vm_method.c
+++ b/vm_method.c
@@ -1370,8 +1370,8 @@ check_override_opt_method(VALUE klass, VALUE mid)
     }
 }
 
-static VALUE
-zsuper_to_super(int argc, VALUE *argv, VALUE self)
+VALUE
+rb_zsuper_to_super(int argc, VALUE *argv, VALUE self)
 {
     return rb_call_super_kw(argc, argv, RB_PASS_CALLED_KEYWORDS);
 }
@@ -1486,7 +1486,7 @@ rb_method_entry_make(VALUE klass, ID mid, VALUE defined_class, rb_method_visibil
         def = rb_method_definition_create(type, original_id);
         if (turn_zsuper_to_super) {
           def->type = VM_METHOD_TYPE_CFUNC;
-          def->body.cfunc.func = (rb_cfunc_t)zsuper_to_super;
+          def->body.cfunc.func = (rb_cfunc_t)rb_zsuper_to_super;
           def->body.cfunc.invoker = ractor_safe_call_cfunc_m1;
           def->body.cfunc.argc = -1;
         }


### PR DESCRIPTION
fafb55877aaf34592278eb3ef9ba3f61473d0a56 fixed issues with refinement zsuper methods by converting them to a cfunc that calls super. This changes Method creation to recognize the cfunc used and skip those methods just as regular zsuper methods are skipped. This makes refinement zsuper function the same way as subclass zsuper in regards to Method/UnboundMethod.