### PR TITLE
Fix cdhash induced crash in `iseq_data_to_ary`

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -12204,7 +12204,7 @@ iseq_build_from_ary_body(rb_iseq_t *iseq, LINK_ANCHOR *const anchor,
                                 VALUE sym = RARRAY_AREF(op, i+1);
                                 LABEL *label =
                                   register_label(iseq, labels_table, sym);
-                                rb_hash_aset(map, key, (VALUE)label | 1);
+                                cdhash_aset(map, key, (VALUE)label);
                             }
                             RB_GC_GUARD(op);
                             RB_OBJ_SET_SHAREABLE(map); // allow mutation while compiling

--- a/iseq.c
+++ b/iseq.c
@@ -3340,7 +3340,7 @@ static int
 cdhash_each(VALUE key, VALUE value, VALUE ary)
 {
     rb_ary_push(ary, obj_resurrect(key));
-    rb_ary_push(ary, value);
+    rb_ary_push(ary, INT2FIX(value));
     return ST_CONTINUE;
 }
 
@@ -3581,11 +3581,11 @@ iseq_data_to_ary(const rb_iseq_t *iseq)
                 break;
               case TS_CDHASH:
                 {
-                    VALUE hash = *seq;
+                    VALUE cdhash = *seq;
                     VALUE val = rb_ary_new();
                     int i;
 
-                    rb_hash_foreach(hash, cdhash_each, val);
+                    st_foreach(rb_imemo_cdhash_tbl(cdhash), cdhash_each, val);
 
                     for (i=0; i<RARRAY_LEN(val); i+=2) {
                         VALUE pos = FIX2INT(rb_ary_entry(val, i+1));


### PR DESCRIPTION
Followup: https://github.com/ruby/ruby/pull/17016

`cdhash` is no longer a RHash, also its values are no longer boxed.

Unclear how this passed CI on my branch...

FYI @nobu 