### PR TITLE
Remove warning about sequence points in GCC

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3755,7 +3755,7 @@ rb_gc_register_address(VALUE *addr)
     RB_VM_LOCKING() {
         if (vm->global_object_list_size == vm->global_object_list_capa) {
             size_t new_capa = vm->global_object_list_capa ? vm->global_object_list_capa * 2 : 64;
-            vm->global_object_list = SIZED_REALLOC_N(vm->global_object_list, VALUE *, new_capa, vm->global_object_list_capa);
+            SIZED_REALLOC_N(vm->global_object_list, VALUE *, new_capa, vm->global_object_list_capa);
             vm->global_object_list_capa = new_capa;
         }
 


### PR DESCRIPTION
SIZED_REALLOC_N already assigns to its first argument, and the double assignment causes two writes to the same struct without a sequence point, which is undefined behavior.

    gc.c: In function 'rb_gc_register_address':
    gc.c:3758:36: warning: operation on 'vm->global_object_list' may be undefined [-Wsequence-point]

cc @byroot 