### PR TITLE
[DOC] Remove reference to `F` format specifier

### DIFF
--- a/doc/language/format_specifications.rdoc
+++ b/doc/language/format_specifications.rdoc
@@ -168,7 +168,7 @@ if the integer is longer than the precision:
   sprintf('%.d', 0)  # => ""
   sprintf('%.0d', 0) # => ""
 
-For the +a+/+A+, +e+/+E+, +f+/+F+ specifiers, the precision specifies
+For the +a+/+A+, +e+/+E+, +f+ specifiers, the precision specifies
 the number of digits after the decimal point to be written:
 
   sprintf('%.2f', 3.14159)  # => "3.14"


### PR DESCRIPTION
There is no such thing:

```rb
irb(main):001> sprintf("%F", 123)
(irb):1:in 'Kernel#sprintf': malformed format string - %F (ArgumentError)
```