### PR TITLE
Migrate `tarball-test` workflow from `ruby/actions`

### DIFF
--- a/.github/actions/make-snapshot/action.yml
+++ b/.github/actions/make-snapshot/action.yml
@@ -1,6 +1,9 @@
 name: 'make-snapshot'
 description: 'Make snapshot tarballs'
 inputs:
+  archname:
+    description: 'archname passed to tool/make-snapshot (e.g. snapshot-master)'
+    required: true
   version:
     description: 'Target Version'
     required: false
@@ -54,15 +57,16 @@ runs:
       shell: bash
     - name: Make snapshot
       env:
+        ARCHNAME: ${{ inputs.archname }}
         SRCDIR: ${{ inputs.srcdir }}
         GENERATE_TAR_BZ2: ${{ inputs.generate-tar-bz2 }}
         VERSION: ${{ inputs.version }}
       run: |
         [ -z "$SRCDIR" ] && SRCDIR=ruby
         if [ -n "$GENERATE_TAR_BZ2" ]; then
-          ruby "$SRCDIR/tool/make-snapshot" -archname=$archname -srcdir="$SRCDIR" pkg $VERSION
+          ruby "$SRCDIR/tool/make-snapshot" "-archname=$ARCHNAME" -srcdir="$SRCDIR" pkg $VERSION
         else
-          ruby "$SRCDIR/tool/make-snapshot" -archname=$archname -srcdir="$SRCDIR" -packages=gzip,xz,zip pkg $VERSION
+          ruby "$SRCDIR/tool/make-snapshot" "-archname=$ARCHNAME" -srcdir="$SRCDIR" -packages=gzip,xz,zip pkg $VERSION
         fi
       shell: bash
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/actions/make-snapshot/action.yml
+++ b/.github/actions/make-snapshot/action.yml
@@ -34,11 +34,14 @@ runs:
       shell: bash
     - name: Fetch branches and notes (clone mode)
       if: inputs.srcdir == ''
+      env:
+        SHALLOW_SINCE: ${{ inputs.shallow-since }}
+        FETCH_BRANCH: ${{ inputs.fetch-branch }}
       run: |
         set -x
         cd ruby
-        git fetch --shallow-since='${{ inputs.shallow-since }}'
-        [ -n "${{ inputs.fetch-branch }}" ] && git fetch origin '+${{ inputs.fetch-branch }}:${{ inputs.fetch-branch }}'
+        git fetch --shallow-since="$SHALLOW_SINCE"
+        [ -n "$FETCH_BRANCH" ] && git fetch origin "+$FETCH_BRANCH:$FETCH_BRANCH"
         git fetch origin '+refs/notes/commits:refs/notes/commits'
         git fetch origin '+refs/notes/log-fix:refs/notes/log-fix'
       shell: bash
@@ -50,13 +53,16 @@ runs:
         git fetch origin '+refs/notes/log-fix:refs/notes/log-fix' || :
       shell: bash
     - name: Make snapshot
+      env:
+        SRCDIR: ${{ inputs.srcdir }}
+        GENERATE_TAR_BZ2: ${{ inputs.generate-tar-bz2 }}
+        VERSION: ${{ inputs.version }}
       run: |
-        SRCDIR="${{ inputs.srcdir }}"
         [ -z "$SRCDIR" ] && SRCDIR=ruby
-        if [ -n "${{ inputs.generate-tar-bz2 }}" ]; then
-          ruby "$SRCDIR/tool/make-snapshot" -archname=$archname -srcdir="$SRCDIR" pkg ${{ inputs.version }}
+        if [ -n "$GENERATE_TAR_BZ2" ]; then
+          ruby "$SRCDIR/tool/make-snapshot" -archname=$archname -srcdir="$SRCDIR" pkg $VERSION
         else
-          ruby "$SRCDIR/tool/make-snapshot" -archname=$archname -srcdir="$SRCDIR" -packages=gzip,xz,zip pkg ${{ inputs.version }}
+          ruby "$SRCDIR/tool/make-snapshot" -archname=$archname -srcdir="$SRCDIR" -packages=gzip,xz,zip pkg $VERSION
         fi
       shell: bash
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/actions/make-snapshot/action.yml
+++ b/.github/actions/make-snapshot/action.yml
@@ -1,0 +1,69 @@
+name: 'make-snapshot'
+description: 'Make snapshot tarballs'
+inputs:
+  version:
+    description: 'Target Version'
+    required: false
+  shallow-since:
+    description: 'git fetch --shallow-since'
+    required: true
+    default: '2018-12-25 00:00:00'
+  fetch-branch:
+    description: 'fetch branch'
+    required: false
+  generate-tar-bz2:
+    description: 'Generate .tar.bz2'
+    required: false
+  srcdir:
+    description: 'srcdir for tool/make-snapshot. Empty = clone ruby/ruby into ./ruby.'
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install libraries
+      run: |
+        set -x
+        sudo apt-get update -q || :
+        sudo apt-get install --no-install-recommends -q -y build-essential git bison autoconf ruby p7zip-full curl
+      shell: bash
+    - name: Checkout ruby/ruby for tool/make-snapshot
+      if: inputs.srcdir == ''
+      run: git clone --single-branch --depth=1 https://github.com/ruby/ruby ruby
+      shell: bash
+    - name: Fetch branches and notes (clone mode)
+      if: inputs.srcdir == ''
+      run: |
+        set -x
+        cd ruby
+        git fetch --shallow-since='${{ inputs.shallow-since }}'
+        [ -n "${{ inputs.fetch-branch }}" ] && git fetch origin '+${{ inputs.fetch-branch }}:${{ inputs.fetch-branch }}'
+        git fetch origin '+refs/notes/commits:refs/notes/commits'
+        git fetch origin '+refs/notes/log-fix:refs/notes/log-fix'
+      shell: bash
+    - name: Fetch notes (local srcdir mode)
+      if: inputs.srcdir != ''
+      working-directory: ${{ inputs.srcdir }}
+      run: |
+        git fetch origin '+refs/notes/commits:refs/notes/commits' || :
+        git fetch origin '+refs/notes/log-fix:refs/notes/log-fix' || :
+      shell: bash
+    - name: Make snapshot
+      run: |
+        SRCDIR="${{ inputs.srcdir }}"
+        [ -z "$SRCDIR" ] && SRCDIR=ruby
+        if [ -n "${{ inputs.generate-tar-bz2 }}" ]; then
+          ruby "$SRCDIR/tool/make-snapshot" -archname=$archname -srcdir="$SRCDIR" pkg ${{ inputs.version }}
+        else
+          ruby "$SRCDIR/tool/make-snapshot" -archname=$archname -srcdir="$SRCDIR" -packages=gzip,xz,zip pkg ${{ inputs.version }}
+        fi
+      shell: bash
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: Packages
+        path: pkg
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: Info
+        path: pkg/info

--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -1,0 +1,109 @@
+name: tarball-macos (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      archname:
+        description: 'archname (e.g. snapshot-master, snapshot-ruby_3_3)'
+        required: true
+        type: string
+      allow-failures:
+        description: 'TEST_BUNDLED_GEMS_ALLOW_FAILURES value'
+        required: false
+        type: string
+        default: ''
+      patch-url:
+        description: 'Patch URL forwarded from workflow_dispatch'
+        required: false
+        type: string
+        default: ''
+      rebuild-homebrew-ruby:
+        description: 'Uninstall and reinstall Homebrew Ruby on macos-15-intel'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  macos:
+    strategy:
+      matrix:
+        test_task: [check, test-bundled-gems]
+        os: [macos-14, macos-15, macos-15-intel]
+        include:
+          - os: macos-14
+            test_task: test-bundler-parallel
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    env:
+      TEST_BUNDLED_GEMS_ALLOW_FAILURES: ${{ inputs.allow-failures }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Packages
+          path: pkg
+      - name: Extract
+        run: tar xf pkg/*.tar.xz
+      - name: Apply patch
+        run: |
+          set -x
+          curl -sSL "${RUBY_PATCH_URL}" -o ruby.patch
+          cd snapshot-*/
+          git apply ../ruby.patch
+        shell: bash
+        env:
+          RUBY_PATCH_URL: ${{ inputs.patch-url }}
+        if: inputs.patch-url != ''
+      - name: Install libraries
+        run: |
+          with_retry () {
+            "$@" || { sleep 5 && "$@"; } || { sleep 60 && "$@"; }
+          }
+          set -x
+          with_retry brew install gmp libffi openssl@1.1 zlib autoconf automake libtool readline libyaml
+      - name: Uninstall Homebrew Ruby
+        run: |
+          for formula in $(brew list 2>/dev/null | grep '^ruby'); do
+            brew uninstall --force "$formula"
+          done
+          sudo rm -rf /usr/local/lib/ruby
+        if: inputs.rebuild-homebrew-ruby && matrix.os == 'macos-15-intel'
+      - name: Set ENV
+        run: |
+          echo "JOBS=-j$((1 + $(sysctl -n hw.activecpu)))" >> $GITHUB_ENV
+      - name: configure
+        run: cd snapshot-*/ && ./configure --with-openssl-dir=$(brew --prefix openssl@1.1) --with-readline-dir=$(brew --prefix readline) --with-libyaml-dir=$(brew --prefix libyaml)
+      - name: make
+        run: cd snapshot-*/ && make $JOBS
+      - name: Reinstall Homebrew Ruby
+        run: brew install ruby
+        if: inputs.rebuild-homebrew-ruby && matrix.os == 'macos-15-intel' && (matrix.test_task == 'test-bundled-gems' || matrix.test_task == 'test-bundler-parallel')
+      - name: Tests
+        run: cd snapshot-*/ && make $JOBS -s ${{ matrix.test_task }}
+        env:
+          RUBY_TESTOPTS: "-q --tty=no"
+          RUBY_DEBUG_TEST_NO_REMOTE: "1"
+      # leaked-globals since 2.7
+      - name: Leaked Globals
+        run: cd snapshot-*/ && make -s leaked-globals
+        if: matrix.test_task == 'check'
+      - name: make install without root privilege
+        run: cd snapshot-*/ && make $JOBS install DESTDIR="/tmp/destdir"
+        if: matrix.test_task == 'check'
+      - name: make install
+        run: cd snapshot-*/ && sudo make $JOBS install
+        if: matrix.test_task == 'check'
+      - name: ruby -v
+        run: /usr/local/bin/ruby -v
+        if: matrix.test_task == 'check'
+      - uses: ruby/action-slack@54175162371f1f7c8eb94d7c8644ee2479fcd375 # v3.2.2
+        with:
+          payload: |
+            {
+              "attachments": [{
+                "text": "${{ job.status }}: ${{ matrix.os }} / ${{ matrix.test_task }} <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>",
+                "color": "danger"
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SNAPSHOT_SLACK_WEBHOOK_URL }}
+        if: failure()

--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -27,11 +27,11 @@ jobs:
   macos:
     strategy:
       matrix:
-        test_task: [check, test-bundled-gems]
-        os: [macos-14, macos-15, macos-15-intel]
+        test_task: [check, test-bundled-gems, test-bundler-parallel]
+        os: [macos-14, macos-15]
         include:
-          - os: macos-14
-            test_task: test-bundler-parallel
+          - os: macos-15-intel
+            test_task: check
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -106,4 +106,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SNAPSHOT_SLACK_WEBHOOK_URL }}
-        if: failure()
+        if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/tarball-non-development.yml
+++ b/.github/workflows/tarball-non-development.yml
@@ -1,0 +1,70 @@
+name: tarball-non-development (reusable)
+
+on:
+  workflow_call: {}
+
+jobs:
+  non_development:
+    runs-on: ubuntu-24.04
+    env:
+      ruby_prefix: /tmp/ruby-snapshot
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Packages
+          path: pkg
+      - name: Extract
+        run: tar xf pkg/*.tar.xz
+      - name: Substitute patchlevel
+        run: |
+          set -x
+          cd snapshot-*/
+          sed -i.orig 's/^\( *# *define  *RUBY_PATCHLEVEL\)  *-.*/\1 0/' version.h
+          diff -u version.h.orig version.h || :
+          rm -f version.h.orig
+      - name: Install libraries
+        run: |
+          set -x
+          sudo apt-get update -q || :
+          sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev bison- autoconf-
+      - name: Set ENV
+        run: |
+          echo "JOBS=-j$((1 + $(nproc --all)))" >> $GITHUB_ENV
+      - name: configure
+        run: cd snapshot-*/ && ./configure --prefix="${ruby_prefix}"
+      - name: make
+        run: cd snapshot-*/ && make $JOBS
+      - name: Leaked Globals
+        run: cd snapshot-*/ && make -s leaked-globals
+      - name: make install
+        run: cd snapshot-*/ && make $JOBS install
+      - name: Set PATH
+        run: echo "PATH=${ruby_prefix}/bin:$PATH" >> $GITHUB_ENV
+      - name: Check patchlevel
+        id: check-patchlevel
+        run: |
+          exec "${ruby_prefix}/bin/ruby" -vx "$0"
+          #!ruby
+          puts "RUBY_PATCHLEVEL=#{RUBY_PATCHLEVEL.inspect}"
+          abort unless RUBY_PATCHLEVEL >= 0
+        working-directory: ${{ env.ruby_prefix }}
+        continue-on-error: true
+      - name: Check LOADPATH
+        id: check-loadpath
+        run: |
+          exec ${ruby_prefix}/bin/ruby -vx "$0"
+          #!ruby
+          paths = $:.grep(/\+/)
+          pp paths
+          abort unless paths.empty?
+        working-directory: ${{ env.ruby_prefix }}
+        continue-on-error: true
+      - name: Check pathnames
+        id: check-pathnames
+        run: |
+          ! find -name '*+*' | grep +
+        working-directory: ${{ env.ruby_prefix }}
+        continue-on-error: true
+      - name: result
+        run: false
+        if: ${{ contains(steps.*.outcome, 'failure') }}

--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -25,40 +25,46 @@ permissions:
 jobs:
   tarball:
     runs-on: ubuntu-latest
+    # Cherry-pick to maintenance branches by changing only env.BRANCH below;
+    # archname / branch-label / Materialize all derive from it.
+    env:
+      BRANCH: master
+    outputs:
+      branch: ${{ env.BRANCH }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       # tool/make-snapshot derives the branch name from HEAD and looks up
       # the upstream during ChangeLog generation. Detached checkouts
-      # (pull_request, merge_group) lack a local master with tracking, so
-      # pin one to HEAD and connect it to origin/master.
-      - name: Materialize local master branch
+      # (pull_request, merge_group) lack a local branch with tracking, so
+      # pin one to HEAD and connect it to the matching origin ref.
+      - name: Materialize local branch
         run: |
-          git fetch --no-tags --depth=1 origin +refs/heads/master:refs/remotes/origin/master
-          git checkout -B master HEAD
-          git branch --set-upstream-to=origin/master master
+          git fetch --no-tags --depth=1 origin "+refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+          git checkout -B "$BRANCH" HEAD
+          git branch --set-upstream-to="origin/$BRANCH" "$BRANCH"
       - uses: ./.github/actions/make-snapshot
         with:
-          archname: snapshot-master
+          archname: snapshot-${{ env.BRANCH }}
           srcdir: '.'
 
   ubuntu:
     needs: tarball
     uses: ./.github/workflows/tarball-ubuntu.yml
     with:
-      archname: snapshot-master
+      archname: snapshot-${{ needs.tarball.outputs.branch }}
       allow-failures: power_assert
       remove-gnupg: true
       notify-ruby-sha: true
-      branch-label: master
+      branch-label: ${{ needs.tarball.outputs.branch }}
     secrets: inherit
 
   macos:
     needs: tarball
     uses: ./.github/workflows/tarball-macos.yml
     with:
-      archname: snapshot-master
+      archname: snapshot-${{ needs.tarball.outputs.branch }}
       allow-failures: power_assert
     secrets: inherit
 
@@ -66,7 +72,7 @@ jobs:
     needs: tarball
     uses: ./.github/workflows/tarball-windows.yml
     with:
-      archname: snapshot-master
+      archname: snapshot-${{ needs.tarball.outputs.branch }}
       mode: modern
     secrets: inherit
 

--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -12,6 +12,8 @@ on:
     # Do not use paths-ignore for required status checks
     # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
   merge_group:
+  schedule:
+    - cron: '30 18 * * *' # Daily at 18:30 UTC
 
 concurrency:
   group: ${{ github.workflow }} / ${{ startsWith(github.event_name, 'pull') && github.ref_name || github.sha }}

--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -1,0 +1,66 @@
+name: tarball-test
+on:
+  push:
+    paths-ignore:
+      - 'doc/**'
+      - '**/man/*'
+      - '**.md'
+      - '**.rdoc'
+      - '**/.document'
+      - '.*.yml'
+  pull_request:
+    # Do not use paths-ignore for required status checks
+    # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }} / ${{ startsWith(github.event_name, 'pull') && github.ref_name || github.sha }}
+  cancel-in-progress: ${{ startsWith(github.event_name, 'pull') }}
+
+permissions:
+  contents: read
+
+jobs:
+  tarball:
+    runs-on: ubuntu-latest
+    env:
+      archname: snapshot-master
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/make-snapshot
+        with:
+          srcdir: '.'
+
+  ubuntu:
+    needs: tarball
+    uses: ./.github/workflows/tarball-ubuntu.yml
+    with:
+      archname: snapshot-master
+      allow-failures: power_assert
+      remove-gnupg: true
+      notify-ruby-sha: true
+      branch-label: master
+    secrets: inherit
+
+  macos:
+    needs: tarball
+    uses: ./.github/workflows/tarball-macos.yml
+    with:
+      archname: snapshot-master
+      allow-failures: power_assert
+    secrets: inherit
+
+  windows:
+    needs: tarball
+    uses: ./.github/workflows/tarball-windows.yml
+    with:
+      archname: snapshot-master
+      mode: modern
+    secrets: inherit
+
+  non_development:
+    needs: tarball
+    uses: ./.github/workflows/tarball-non-development.yml
+    secrets: inherit

--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -29,6 +29,15 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+      # tool/make-snapshot derives the branch name from HEAD and looks up
+      # the upstream during ChangeLog generation. Detached checkouts
+      # (pull_request, merge_group) lack a local master with tracking, so
+      # pin one to HEAD and connect it to origin/master.
+      - name: Materialize local master branch
+        run: |
+          git fetch --no-tags --depth=1 origin +refs/heads/master:refs/remotes/origin/master
+          git checkout -B master HEAD
+          git branch --set-upstream-to=origin/master master
       - uses: ./.github/actions/make-snapshot
         with:
           srcdir: '.'

--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -25,8 +25,6 @@ permissions:
 jobs:
   tarball:
     runs-on: ubuntu-latest
-    env:
-      archname: snapshot-master
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -42,6 +40,7 @@ jobs:
           git branch --set-upstream-to=origin/master master
       - uses: ./.github/actions/make-snapshot
         with:
+          archname: snapshot-master
           srcdir: '.'
 
   ubuntu:

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -1,0 +1,271 @@
+name: tarball-ubuntu (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      archname:
+        description: 'archname (e.g. snapshot-master, snapshot-ruby_3_3)'
+        required: true
+        type: string
+      allow-failures:
+        description: 'TEST_BUNDLED_GEMS_ALLOW_FAILURES value'
+        required: false
+        type: string
+        default: ''
+      patch-url:
+        description: 'Patch URL forwarded from workflow_dispatch'
+        required: false
+        type: string
+        default: ''
+      apt-mode:
+        description: '"none" | "git-only" | "ruby-and-git" — controls per-test_task apt install handling'
+        required: false
+        type: string
+        default: 'none'
+      setup-host-ruby:
+        description: 'Install Ruby 3.2 via ruby/setup-ruby for test-bundled-gems'
+        required: false
+        type: boolean
+        default: true
+      remove-gnupg:
+        description: 'Forcely remove ~/.gnupg after tests'
+        required: false
+        type: boolean
+        default: false
+      fixed-dirs-extra:
+        description: 'Create $HOME/.local/share, $HOME/.ssh on top of minimal fixed dirs'
+        required: false
+        type: boolean
+        default: true
+      ruby-bin:
+        description: 'Path to ruby for post-install version check'
+        required: false
+        type: string
+        default: '/usr/local/bin/ruby'
+      notify-ruby-sha:
+        description: 'Post ruby SHA failure notification to SIMPLER_ALERTS_URL'
+        required: false
+        type: boolean
+        default: false
+      branch-label:
+        description: 'Branch label for SIMPLER_ALERTS_URL notification. Defaults to "master".'
+        required: false
+        type: string
+        default: 'master'
+
+jobs:
+  ubuntu:
+    strategy:
+      matrix:
+        test_task: [check, test-bundler-parallel, test-bundled-gems]
+        os: [ubuntu-24.04, ubuntu-22.04]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    env:
+      TEST_BUNDLED_GEMS_ALLOW_FAILURES: ${{ inputs.allow-failures }}
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Packages
+          path: pkg
+      - name: Extract
+        run: tar xf pkg/*.tar.xz
+      - name: Apply patch
+        run: |
+          set -x
+          curl -sSL "${RUBY_PATCH_URL}" -o ruby.patch
+          cd snapshot-*/
+          git apply ../ruby.patch
+        shell: bash
+        env:
+          RUBY_PATCH_URL: ${{ inputs.patch-url }}
+        if: inputs.patch-url != ''
+      - name: Install libraries (apt-mode=none)
+        run: |
+          set -x
+          sudo apt-get update -q
+          sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev bison- autoconf-
+        if: inputs.apt-mode == 'none'
+      - name: Install libraries (apt-mode=git-only)
+        run: |
+          set -x
+          sudo apt-get update -q || :
+          # postfix `-` means `uninstall`
+          APT_INSTALL_GIT=git-
+          case "${{ matrix.test_task }}" in
+            test-bundled-gems)
+              # test-bundled-gems-fetch requires git
+              unset APT_INSTALL_GIT
+              ;;
+            test-bundler*)
+              # avoid Bundler::Source::Git::GitNotInstalledError
+              unset APT_INSTALL_GIT
+              ;;
+            *)
+              ;;
+          esac
+          sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev bison- autoconf- $APT_INSTALL_GIT
+        if: inputs.apt-mode == 'git-only'
+      - name: Install libraries (apt-mode=ruby-and-git)
+        run: |
+          set -x
+          sudo apt-get update -q || :
+          # postfix `-` means `uninstall`
+          APT_INSTALL_RUBY=ruby-
+          APT_INSTALL_GIT=git-
+          case "${{ matrix.test_task }}" in
+            test-bundled-gems)
+              # test-bundled-gems requires executable host ruby
+              APT_INSTALL_RUBY=ruby
+              # test-bundled-gems-fetch requires git
+              unset APT_INSTALL_GIT
+              ;;
+            test-bundler*)
+              # avoid Bundler::Source::Git::GitNotInstalledError
+              unset APT_INSTALL_GIT
+              ;;
+            *)
+              ;;
+          esac
+          sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev bison- autoconf- $APT_INSTALL_RUBY $APT_INSTALL_GIT
+        if: inputs.apt-mode == 'ruby-and-git'
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        with:
+          ruby-version: 3.2
+        # test-bundled-gems requires executable host ruby
+        if: inputs.setup-host-ruby && matrix.test_task == 'test-bundled-gems'
+      - name: Fixed world writable dirs
+        run: |
+          mkdir -p $HOME/.local
+          mkdir -p $HOME/.cache/gem/specs
+          mkdir -p $HOME/.bundle/cache
+          chmod a-w $HOME/.bundle
+          # chmod a-w $HOME
+          # allow to write $HOME and check stats of HOME around tests (see below)
+          chmod -v a-w $HOME/.config
+          sudo chmod -R a-w /usr/share
+          sudo bash -c 'IFS=:; for d in '"$PATH"'; do chmod -v a-w $d; done' || :
+      - name: Fixed world writable dirs (extra)
+        run: |
+          mkdir -p $HOME/.local/share
+          mkdir -p $HOME/.ssh
+        if: inputs.fixed-dirs-extra
+      - name: Set ENV
+        run: |
+          echo "JOBS=-j$((1 + $(nproc --all)))" >> $GITHUB_ENV
+      - name: configure
+        run: cd snapshot-*/ && ./configure
+      - name: make
+        run: cd snapshot-*/ && make $JOBS
+      - name: Save stats of HOME
+        run: |
+          set -euxo pipefail
+          cd snapshot-*/
+          cat >test.rb <<'EOF'
+          require 'pathname'
+          require 'digest'
+          out = []
+          [
+            Dir.home,
+          ].each do |dir|
+            Pathname(dir).each_child do |pn|
+              st = pn.stat
+              if st.file?
+                content = Digest::SHA1.hexdigest(pn.read)
+              elsif st.directory? && st.nlink <= 10
+                content = pn.children.map(&:basename).map(&:to_s).sort
+              end
+              out << [pn.to_s, "%o"%st.mode, st.nlink, st.uid, st.gid, st.size, content].to_s
+            rescue
+              out << [pn.to_s, $!.inspect].to_s
+            end
+          end
+          File.open("/tmp/stat-before-tests.txt", "w") do |io|
+            io.puts out.sort
+          end
+          EOF
+          make runruby
+          rm -f test.rb
+      - name: Tests
+        run: cd snapshot-*/ && make $JOBS -s ${{ matrix.test_task }}
+        env:
+          RUBY_TESTOPTS: "-q --tty=no"
+      # not sure why ~/.gnupg is remained
+      # see tool/test/test_sync_default_gems.rb
+      - name: Forcely remove test directory
+        run: rm -rf $HOME/.gnupg
+        if: inputs.remove-gnupg
+      - name: Diff stats of HOME
+        run: |
+          set -euxo pipefail
+          cd snapshot-*/
+          cat >test.rb <<'EOF'
+          require 'pathname'
+          require 'digest'
+          out = []
+          [
+            Dir.home,
+          ].each do |dir|
+            Pathname(dir).each_child do |pn|
+              st = pn.stat
+              if st.file?
+                content = Digest::SHA1.hexdigest(pn.read)
+              elsif st.directory? && st.nlink <= 10
+                content = pn.children.map(&:basename).map(&:to_s).sort
+              end
+              out << [pn.to_s, "%o"%st.mode, st.nlink, st.uid, st.gid, st.size, content].to_s
+            rescue
+              out << [pn.to_s, $!.inspect].to_s
+            end
+          end
+          File.open("/tmp/stat-after-tests.txt", "w") do |io|
+            io.puts out.sort
+          end
+          EOF
+          make runruby
+          rm -f test.rb
+          diff -u /tmp/stat-before-tests.txt /tmp/stat-after-tests.txt
+      # leaked-globals since 2.7
+      - name: Leaked Globals
+        run: cd snapshot-*/ && make -s leaked-globals
+        if: matrix.test_task == 'check'
+      - name: make install without root privilege
+        run: cd snapshot-*/ && make $JOBS install DESTDIR="/tmp/destdir"
+        if: matrix.test_task == 'check'
+      - name: make install
+        run: cd snapshot-*/ && sudo make $JOBS install
+        if: matrix.test_task == 'check'
+      - name: ruby -v
+        run: ${{ inputs.ruby-bin }} -v
+        if: matrix.test_task == 'check'
+      - name: Show .local
+        run: find $HOME/.local -ls
+      - uses: ruby/action-slack@54175162371f1f7c8eb94d7c8644ee2479fcd375 # v3.2.2
+        with:
+          payload: |
+            {
+              "attachments": [{
+                "text": "${{ job.status }}: ${{ matrix.os }} / ${{ matrix.test_task }} <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>",
+                "color": "danger"
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SNAPSHOT_SLACK_WEBHOOK_URL }}
+        if: failure()
+      - name: Get ruby/ruby sha
+        id: ruby_sha
+        run: cd snapshot-*/ && ./ruby -e 'puts "sha=#{RUBY_REVISION}"' >> $GITHUB_OUTPUT
+        if: failure() && inputs.notify-ruby-sha
+      - uses: ruby/action-slack@54175162371f1f7c8eb94d7c8644ee2479fcd375 # v3.2.2
+        with:
+          payload: |
+            {
+              "ci": "GitHub Actions",
+              "env": "snapshot: ${{ matrix.os }} / ${{ matrix.test_task }}",
+              "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "commit": "${{ steps.ruby_sha.outputs.sha }}",
+              "branch": "${{ inputs.branch-label }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }}
+        if: failure() && inputs.notify-ruby-sha

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -236,7 +236,9 @@ jobs:
         run: cd snapshot-*/ && sudo make $JOBS install
         if: matrix.test_task == 'check'
       - name: ruby -v
-        run: ${{ inputs.ruby-bin }} -v
+        env:
+          RUBY_BIN: ${{ inputs.ruby-bin }}
+        run: '"$RUBY_BIN" -v'
         if: matrix.test_task == 'check'
       - name: Show .local
         run: find $HOME/.local -ls

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -253,11 +253,11 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SNAPSHOT_SLACK_WEBHOOK_URL }}
-        if: failure()
+        if: failure() && github.event_name == 'schedule'
       - name: Get ruby/ruby sha
         id: ruby_sha
         run: cd snapshot-*/ && ./ruby -e 'puts "sha=#{RUBY_REVISION}"' >> $GITHUB_OUTPUT
-        if: failure() && inputs.notify-ruby-sha
+        if: failure() && inputs.notify-ruby-sha && github.event_name == 'schedule'
       - uses: ruby/action-slack@54175162371f1f7c8eb94d7c8644ee2479fcd375 # v3.2.2
         with:
           payload: |
@@ -270,4 +270,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }}
-        if: failure() && inputs.notify-ruby-sha
+        if: failure() && inputs.notify-ruby-sha && github.event_name == 'schedule'

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -28,7 +28,7 @@ on:
         type: boolean
         default: true
       remove-gnupg:
-        description: 'Forcely remove ~/.gnupg after tests'
+        description: 'Forcibly remove ~/.gnupg after tests'
         required: false
         type: boolean
         default: false
@@ -192,7 +192,7 @@ jobs:
           RUBY_TESTOPTS: "-q --tty=no"
       # not sure why ~/.gnupg is remained
       # see tool/test/test_sync_default_gems.rb
-      - name: Forcely remove test directory
+      - name: Forcibly remove test directory
         run: rm -rf $HOME/.gnupg
         if: inputs.remove-gnupg
       - name: Diff stats of HOME

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -80,11 +80,12 @@ jobs:
         run: |
           set -x
           curl -sSL "${RUBY_PATCH_URL}" -o ruby.patch
-          cd ${{ inputs.archname }}/
+          cd "$ARCHNAME"
           git apply ../ruby.patch
         shell: bash
         env:
           RUBY_PATCH_URL: ${{ inputs.patch-url }}
+          ARCHNAME: ${{ inputs.archname }}
         if: inputs.patch-url != ''
         working-directory:
 
@@ -96,9 +97,11 @@ jobs:
       - name: setup env (modern)
         # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
         # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302
+        env:
+          ARCHNAME: ${{ inputs.archname }}
         run: |
           set > old.env
-          call ..\${{ inputs.archname }}\win32\vssetup.cmd
+          call ..\%ARCHNAME%\win32\vssetup.cmd
           set TMP=%USERPROFILE%\AppData\Local\Temp
           set TEMP=%USERPROFILE%\AppData\Local\Temp
           set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul
@@ -133,8 +136,10 @@ jobs:
             if not %%~nI == readline mklink %%~nxI %%I
           )
       - name: Configure
+        env:
+          ARCHNAME: ${{ inputs.archname }}
         run: >-
-          ../${{ inputs.archname }}/win32/configure.bat --disable-install-doc
+          ../%ARCHNAME%/win32/configure.bat --disable-install-doc
           --with-opt-dir=C:/vcpkg/installed/x64-windows
       - run: nmake incs
       - run: nmake extract-extlibs

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -1,0 +1,169 @@
+name: tarball-windows (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      archname:
+        description: 'archname (e.g. snapshot-master)'
+        required: true
+        type: string
+      patch-url:
+        description: 'Patch URL forwarded from workflow_dispatch'
+        required: false
+        type: string
+        default: ''
+      mode:
+        description: '"modern" (vssetup + 2022/2025-vs2026) or "legacy" (vs2022 + vcvars 14.2 + test-all/test-spec split)'
+        required: false
+        type: string
+        default: 'modern'
+
+jobs:
+  windows:
+    strategy:
+      matrix:
+        include: ${{ fromJSON(inputs.mode == 'legacy'
+          && '[{"os":"2022","vs":2022,"vcvars":"10.0.22621.0 -vcvars_ver=14.2","test_task":"check"}]'
+          || '[{"os":"2022","test_task":"check"},{"os":"2025-vs2026","test_task":"check"}]') }}
+      fail-fast: false
+    runs-on: windows-${{ matrix.os }}
+    defaults:
+      run:
+        shell: cmd
+        working-directory: build
+    name: Windows ${{ matrix.os }} (${{ matrix.test_task }})
+    env:
+      GITPULLOPTIONS: --no-tags origin ${{github.ref}}
+      PATCH: C:\msys64\usr\bin\patch.exe
+      OS_VER: windows-${{ matrix.os }}
+      # see https://github.com/ruby/ruby/commit/9ff4399decef0036897d3cfb9ac2c710dea913ca
+      OPENSSL_MODULES: C:\vcpkg\installed\x64-windows\bin
+    steps:
+      - run: md build
+        working-directory:
+
+      - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
+        with:
+          ruby-version: '3.1'
+          bundler: none
+          windows-toolchain: none
+
+      - uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
+        id: setup-msys2
+        with:
+          update: true
+          install: >-
+            patch
+      - name: patch path
+        shell: msys2 {0}
+        run: echo PATCH=$(cygpath -wa $(command -v patch)) >> $GITHUB_ENV
+        if: ${{ steps.setup-msys2.outcome == 'success' }}
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: C:\vcpkg\installed
+          key: ${{ runner.os }}-vcpkg-installed-${{ env.OS_VER }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-installed-${{ env.OS_VER }}-
+            ${{ runner.os }}-vcpkg-installed-
+      - name: Install libraries with vcpkg
+        run: |
+          vcpkg --triplet x64-windows install libffi libyaml openssl readline zlib
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Packages
+          path: pkg
+      - name: Extract
+        run: 7z x pkg/*.zip
+        working-directory:
+      - name: Apply patch
+        run: |
+          set -x
+          curl -sSL "${RUBY_PATCH_URL}" -o ruby.patch
+          cd ${{ inputs.archname }}/
+          git apply ../ruby.patch
+        shell: bash
+        env:
+          RUBY_PATCH_URL: ${{ inputs.patch-url }}
+        if: inputs.patch-url != ''
+        working-directory:
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: snapshot-*/.downloaded-cache
+          key: downloaded-cache
+
+      - name: setup env (modern)
+        # %TEMP% is inconsistent with %TMP% and test-all expects they are consistent.
+        # https://github.com/actions/virtual-environments/issues/712#issuecomment-613004302
+        run: |
+          set > old.env
+          call ..\${{ inputs.archname }}\win32\vssetup.cmd
+          set TMP=%USERPROFILE%\AppData\Local\Temp
+          set TEMP=%USERPROFILE%\AppData\Local\Temp
+          set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul
+          set > new.env
+        if: inputs.mode == 'modern'
+      - name: setup env (legacy)
+        run: |
+          if not "%VCVARS%" == "" goto :vcset
+            set VCVARS="C:\Program Files (x86)\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+            if not exist %VCVARS% set VCVARS="C:\Program Files\Microsoft Visual Studio\${{ matrix.vs }}\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          :vcset
+          set > old.env
+          call %VCVARS% ${{ matrix.vcvars }}
+          set TMP=%USERPROFILE%\AppData\Local\Temp
+          set TEMP=%USERPROFILE%\AppData\Local\Temp
+          set /a TEST_JOBS=(15 * %NUMBER_OF_PROCESSORS% / 10) > nul
+          set > new.env
+        if: inputs.mode == 'legacy'
+
+      - name: update env
+        shell: pwsh
+        run: |
+          $old = (Get-Content old.env); $new = (Get-Content new.env)
+          del *.env
+          Compare-Object $old $new |
+            Where-Object { $_.SideIndicator -eq '=>' } |
+            Select-Object -ExpandProperty InputObject |
+            Add-Content -Path $env:GITHUB_ENV
+      - name: link libraries
+        run: |
+          for %%I in (C:\vcpkg\installed\x64-windows\bin\*.dll) do (
+            if not %%~nI == readline mklink %%~nxI %%I
+          )
+      - name: Configure
+        run: >-
+          ../${{ inputs.archname }}/win32/configure.bat --disable-install-doc
+          --with-opt-dir=C:/vcpkg/installed/x64-windows
+      - run: nmake incs
+      - run: nmake extract-extlibs
+      - run: nmake
+        env:
+          YACC: win_bison
+
+      - name: ruby -v
+        run: |
+          .\ruby -v
+
+      - run: nmake test
+        timeout-minutes: 5
+
+      - run: nmake ${{ matrix.test_task }}
+        env:
+          RUBY_TESTOPTS: -j${{env.TEST_JOBS}}
+        timeout-minutes: 70
+        continue-on-error: ${{ matrix.continue-on-error || false }}
+
+      - uses: ruby/action-slack@54175162371f1f7c8eb94d7c8644ee2479fcd375 # v3.2.2
+        with:
+          payload: |
+            {
+              "attachments": [{
+                "text": "${{ job.status }}: ${{ env.OS_VER }} / ${{ matrix.test_task }} <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>",
+                "color": "danger"
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SNAPSHOT_SLACK_WEBHOOK_URL }}
+        if: failure()

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -171,4 +171,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SNAPSHOT_SLACK_WEBHOOK_URL }}
-        if: failure()
+        if: failure() && github.event_name == 'schedule'


### PR DESCRIPTION
Migrate the daily snapshot tarball pipeline from `ruby/actions` into this repository and per-OS tests run on every push and pull request. We should maintain all QC test suite in one repository.