### PR TITLE
Preserve usable slot size when RVALUE_OVERHEAD is non-zero

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -196,18 +196,6 @@ static RB_THREAD_LOCAL_SPECIFIER int malloc_increase_local;
     SLOT(32) SLOT(64) SLOT(128) SLOT(256) SLOT(512)
 #endif
 
-/* Precomputed reciprocals for fast slot index calculation.
- * For slot size d: reciprocal = ceil(2^48 / d).
- * Then offset / d == (uint32_t)((offset * reciprocal) >> 48)
- * for all offset < HEAP_PAGE_SIZE. */
-#define SLOT_RECIPROCAL_SHIFT 48
-#define SLOT_RECIPROCAL(size) (((1ULL << SLOT_RECIPROCAL_SHIFT) + (size) - 1) / (size))
-
-static const uint64_t heap_slot_reciprocal_table[HEAP_COUNT] = {
-#define SLOT(size) SLOT_RECIPROCAL(size),
-    EACH_POOL_SLOT_SIZE(SLOT)
-#undef SLOT
-};
 typedef struct ractor_newobj_heap_cache {
     struct free_slot *freelist;
     struct heap_page *using_page;
@@ -711,11 +699,23 @@ size_t rb_gc_impl_obj_slot_size(VALUE obj);
 #define RVALUE_SLOT_SIZE (sizeof(struct RBasic) + sizeof(VALUE[RBIMPL_RVALUE_EMBED_LEN_MAX]) + RVALUE_OVERHEAD)
 
 static const size_t pool_slot_sizes[HEAP_COUNT] = {
-#define SLOT(size) size,
+#define SLOT(size) ((size) + RVALUE_OVERHEAD),
     EACH_POOL_SLOT_SIZE(SLOT)
 #undef SLOT
 };
 
+/* Precomputed reciprocals for fast slot index calculation.
+ * For slot size d: reciprocal = ceil(2^48 / d).
+ * Then offset / d == (uint32_t)((offset * reciprocal) >> 48)
+ * for all offset < HEAP_PAGE_SIZE. */
+#define SLOT_RECIPROCAL_SHIFT 48
+#define SLOT_RECIPROCAL(size) (((1ULL << SLOT_RECIPROCAL_SHIFT) + (size) - 1) / (size))
+
+static const uint64_t heap_slot_reciprocal_table[HEAP_COUNT] = {
+#define SLOT(size) SLOT_RECIPROCAL((size) + RVALUE_OVERHEAD),
+    EACH_POOL_SLOT_SIZE(SLOT)
+#undef SLOT
+};
 
 #if SIZEOF_VALUE >= 8
 static uint8_t size_to_heap_idx[1024 / 8 + 1];


### PR DESCRIPTION
We made a mistake calculating slot sizes during the heap slot sizes refactor. Previously BASE_SLOT_SIZE included RVALUE_OVERHEAD, this was lost during the refactor to use the SLOT macro.

The result of this was that when Ruby was compiled with -DRUBY_DEBUG it was assumed that the last word of each slot was RVALUE_OVERHEAD. Because this hadn't been taken into account at allocation time, all slots were effectively one word shorter.

This PR adds RVALUE_OVERHEAD to the size calcualted in the SLOT macro directly, so it will be added on to the physically allocated size at allocation time.