### PR TITLE
configure: check some warning options only with clang

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -288,6 +288,11 @@ AS_CASE(["/${rb_CC} "],
     RUBY_CHECK_PROG_FOR_CC([OBJDUMP], [clang], [${llvm_prefix}objdump])
     RUBY_CHECK_PROG_FOR_CC([RANLIB],  [clang], [${llvm_prefix}ranlib])
     RUBY_CHECK_PROG_FOR_CC([STRIP],   [clang], [${llvm_prefix}strip])
+
+    # These -Wno-* flags silence clang-specific diagnostics that don't exist
+    # in GCC.  GCC silently accepts unknown -Wno-* flags but later emits noisy
+    # "unrecognized command-line option" notes whenever another warning fires.
+    clang_warnflags="-Wno-constant-logical-operand -Wno-parentheses-equality -Wno-self-assign"
 ])
 AS_UNSET(rb_CC)
 AS_UNSET(rb_dummy)
@@ -787,13 +792,10 @@ AS_CASE(["$GCC:${warnflags+set}:${extra_warnflags:+set}:"],
 		 -Wimplicit-fallthrough=0 \
 		 -Wmissing-noreturn \
 		 -Wno-cast-function-type \
-		 -Wno-constant-logical-operand \
 		 -Wno-long-long \
 		 -Wno-missing-field-initializers \
 		 -Wno-overlength-strings \
 		 -Wno-packed-bitfield-compat \
-		 -Wno-parentheses-equality \
-		 -Wno-self-assign \
 		 -Wno-tautological-compare \
 		 -Wno-unused-parameter \
 		 -Wno-unused-value \
@@ -801,6 +803,7 @@ AS_CASE(["$GCC:${warnflags+set}:${extra_warnflags:+set}:"],
 		 -Wsuggest-attribute=noreturn \
 		 -Wunused-variable \
 		 -diag-disable=175,188,1684,2259,2312 \
+		 $clang_warnflags \
 		 $extra_warnflags \
 		 ; do
 	AS_IF([test "$particular_werror_flags" != yes], [


### PR DESCRIPTION
GCC doesn't emit any warning when the -Wno- form is used, so we can't check reliably if the warning option is available:

> When an unrecognized warning option is requested (e.g., -Wunknown-warning), GCC gives an error stating that the option is not recognized. However, if the -Wno- form is used, the behavior is slightly different: no diagnostic is produced for -Wno-unknown-warning unless other diagnostics are being produced. This allows the use of new -Wno- options with old compilers, but if something goes wrong, the compiler warns that an unrecognized option is present.
> https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#:~:text=When%20an%20unrecognized,option%20is%20present.

cc @nobu 

---

Example:
```console
$ cat test.c
int test(int argc, char *argv[]) {
    int unused;
    return 0;
}
```

Before:
```console
$ make test.o
compiling ../../test.c
../../test.c: In function 'test':
../../test.c:2:9: warning: unused variable 'unused' [-Wunused-variable]
    2 |     int unused;
      |         ^~~~~~
At top level:
cc1: note: unrecognized command-line option '-Wno-self-assign' may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option '-Wno-parentheses-equality' may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option '-Wno-constant-logical-operand' may have been intended to silence earlier diagnostics
```

After:
```console
$ make test.o
compiling ../../test.c
../../test.c: In function 'test':
../../test.c:2:9: warning: unused variable 'unused' [-Wunused-variable]
    2 |     int unused;
      |         ^~~~~~
```