### PR TITLE
pathname: Add `absolute_path?` and `relative_path?`

### DIFF
--- a/pathname.c
+++ b/pathname.c
@@ -168,7 +168,7 @@ path_root_p(VALUE self)
  *   Pathname('C:.').absolute?   # => false  # Elsewhere.
  *
  * Note that this differs from the standard definition of an absolute
- * path on Windows.
+ * path on Windows.  For that purpose, use #absolute_path? instead.
  *
  * The opposite of #relative?.
  */
@@ -183,6 +183,33 @@ path_absolute_p(VALUE self)
         if (len >= 2 && ISALPHA(ptr[0]) && (ptr[1] == ':')) return Qtrue;
     }
     return RBOOL(isdirsep(ptr[0]));
+}
+
+/*
+ * call-seq:
+ *   absolute_path? -> true or false
+ *
+ * Returns whether +self+ contains an absolute path; see
+ * File.absolute_path?.
+ *
+ * What an "absolute path" means is OS-dependent:
+ *
+ *   Pathname('/home').absolute_path?   # => false  # On Windows.
+ *   Pathname('/home').absolute_path?   # => true   # Elsewhere.
+ *   Pathname('C:/').absolute_path?     # => true   # On Windows.
+ *   Pathname('C:/').absolute_path?     # => false  # Elsewhere.
+ *
+ *   Pathname('lib').absolute_path?     # => false
+ *   Pathname('C:Users').absolute_path? # => false
+ *   Pathname('./bin').absolute_path?   # => false
+ *
+ * The opposite of #relative_path?.
+ */
+static VALUE
+path_absolute_path_p(VALUE self)
+{
+    VALUE path = get_strpath(self);
+    return RBOOL(rb_is_absolute_path(RSTRING_PTR(path)));
 }
 
 /* :nodoc: */
@@ -357,6 +384,7 @@ InitVM_pathname(void)
     rb_define_method(rb_cPathname, "sub", path_sub, -1);
     rb_define_method(rb_cPathname, "sub_ext", path_sub_ext, 1);
     rb_define_method(rb_cPathname, "root?", path_root_p, 0);
+    rb_define_method(rb_cPathname, "absolute_path?", path_absolute_path_p, 0);
     rb_define_method(rb_cPathname, "absolute?", path_absolute_p, 0);
 
     rb_define_private_method(rb_cPathname, "same_paths?", same_paths, 2);

--- a/pathname.c
+++ b/pathname.c
@@ -154,7 +154,8 @@ path_root_p(VALUE self)
  * call-seq:
  *   absolute? -> true or false
  *
- * Returns whether +self+ contains an absolute path:
+ * Returns +true+ if +self+ contains a path that is not relative from
+ * the current working directory (of the current drive on Windows):
  *
  *   Pathname('/home').absolute? # => true
  *   Pathname('lib').absolute?   # => false
@@ -163,7 +164,13 @@ path_root_p(VALUE self)
  *
  *   Pathname('C:/').absolute?   # => true   # On Windows.
  *   Pathname('C:/').absolute?   # => false  # Elsewhere.
+ *   Pathname('C:.').absolute?   # => true   # On Windows.
+ *   Pathname('C:.').absolute?   # => false  # Elsewhere.
  *
+ * Note that this differs from the standard definition of an absolute
+ * path on Windows.
+ *
+ * The opposite of #relative?.
  */
 static VALUE
 path_absolute_p(VALUE self)

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -110,6 +110,8 @@
 # - #join
 # - #parent
 # - #root?
+# - #absolute_path?
+# - #relative_path?
 # - #absolute?
 # - #relative?
 # - #relative_path_from
@@ -560,11 +562,33 @@ class Pathname
   #   Pathname('C:.').relative?   # => true   # Elsewhere.
   #
   # Note that this differs from the standard definition of a relative
-  # path on Windows.
+  # path on Windows.  For that purpose, Use #relative_path?.
   #
   # The opposite of #absolute?.
   def relative?
     !absolute?
+  end
+
+  # call-seq:
+  #  relative_path? -> true or false
+  #
+  # Returns whether +self+ contains a non-absolute path; see
+  # File.absolute_path?.
+  #
+  # What an "absolute path" means is OS-dependent:
+  #
+  #   Pathname('/home').relative_path?   # => true   # On Windows.
+  #   Pathname('/home').relative_path?   # => false  # Elsewhere.
+  #   Pathname('C:/').relative_path?     # => false  # On Windows.
+  #   Pathname('C:/').relative_path?     # => true   # Elsewhere.
+  #
+  #   Pathname('lib').relative_path?     # => true
+  #   Pathname('C:Users').relative_path? # => true
+  #   Pathname('./bin').relative_path?   # => true
+  #
+  # The opposite of #absolute_path?.
+  def relative_path?
+    !absolute_path?
   end
 
   #

--- a/pathname_builtin.rb
+++ b/pathname_builtin.rb
@@ -542,17 +542,27 @@ class Pathname
     end
   end
 
-  # The opposite of Pathname#absolute?
+  # call-seq:
   #
-  # It returns +false+ if the pathname begins with a slash.
+  #   relative? -> true or false
   #
-  #   p = Pathname.new('/im/sure')
-  #   p.relative?
-  #       #=> false
+  # Returns +true+ if +self+ contains a path that is relative from the
+  # current working directory (of the current drive on Windows):
   #
-  #   p = Pathname.new('not/so/sure')
-  #   p.relative?
-  #       #=> true
+  #   Pathname('/home').relative? # => false
+  #   Pathname('lib').relative?   # => true
+  #
+  # The result is OS-dependent for some paths:
+  #
+  #   Pathname('C:/').relative?   # => false  # On Windows.
+  #   Pathname('C:/').relative?   # => true   # Elsewhere.
+  #   Pathname('C:.').relative?   # => false  # On Windows.
+  #   Pathname('C:.').relative?   # => true   # Elsewhere.
+  #
+  # Note that this differs from the standard definition of a relative
+  # path on Windows.
+  #
+  # The opposite of #absolute?.
   def relative?
     !absolute?
   end

--- a/test/pathname/test_pathname.rb
+++ b/test/pathname/test_pathname.rb
@@ -289,6 +289,35 @@ class TestPathname < Test::Unit::TestCase
     defassert(:relative?, false, '//a/b/c')
   end
 
+  def relative_path?(path)
+    path = Pathname.new(path)
+    relative = path.relative_path?
+    absolute = path.absolute_path?
+    assert_equal(!relative, absolute)
+    relative
+  end
+
+  defassert(:relative_path?, true, '')
+  defassert(:relative_path?, DOSISH_DRIVE_LETTER, '/')
+  defassert(:relative_path?, DOSISH_DRIVE_LETTER, '/a')
+  defassert(:relative_path?, DOSISH_DRIVE_LETTER, '/..')
+  defassert(:relative_path?, true, 'a')
+  defassert(:relative_path?, true, 'a/b')
+
+  defassert(:relative_path?, true, 'A:.')
+  defassert(:relative_path?, true, 'A:')
+  defassert(:relative_path?, !DOSISH_DRIVE_LETTER, 'A:/')
+  defassert(:relative_path?, !DOSISH_DRIVE_LETTER, 'A:/a')
+
+  if DOSISH_UNC
+    defassert(:relative_path?, false, '//')
+    defassert(:relative_path?, false, '//a')
+    defassert(:relative_path?, false, '//a/')
+    defassert(:relative_path?, false, '//a/b')
+    defassert(:relative_path?, false, '//a/b/')
+    defassert(:relative_path?, false, '//a/b/c')
+  end
+
   def relative_path_from(dest_directory, base_directory)
     Pathname.new(dest_directory).relative_path_from(base_directory).to_s
   end


### PR DESCRIPTION
The term "absolute path" in `Pathname#absolute?` and `Pathname#relative?` methods differs from the typical definition on Windows.
Add `Pathname#absolute_path?` that is consistent with `File.absolute_path?` and the opposite `Pathname#relative_path?`.
