### PR TITLE
Fix UAF in IO::Buffer#~ when self is an invalidated slice

### DIFF
--- a/io_buffer.c
+++ b/io_buffer.c
@@ -3554,11 +3554,15 @@ io_buffer_not(VALUE self)
     struct rb_io_buffer *buffer = NULL;
     TypedData_Get_Struct(self, struct rb_io_buffer, &rb_io_buffer_type, buffer);
 
-    VALUE output = rb_io_buffer_new(NULL, buffer->size, io_flags_for_size(buffer->size));
+    const void *base;
+    size_t size;
+    io_buffer_get_bytes_for_reading(buffer, &base, &size);
+
+    VALUE output = rb_io_buffer_new(NULL, size, io_flags_for_size(size));
     struct rb_io_buffer *output_buffer = NULL;
     TypedData_Get_Struct(output, struct rb_io_buffer, &rb_io_buffer_type, output_buffer);
 
-    memory_not(output_buffer->base, buffer->base, buffer->size);
+    memory_not(output_buffer->base, base, size);
 
     return output;
 }

--- a/test/ruby/test_io_buffer.rb
+++ b/test/ruby/test_io_buffer.rb
@@ -711,6 +711,7 @@ class TestIOBuffer < Test::Unit::TestCase
     assert_raise(IO::Buffer::InvalidatedError) { slice & mask }
     assert_raise(IO::Buffer::InvalidatedError) { slice | mask }
     assert_raise(IO::Buffer::InvalidatedError) { slice ^ mask }
+    assert_raise(IO::Buffer::InvalidatedError) { ~slice }
   end
 
   def test_operators_raise_on_freed_mask


### PR DESCRIPTION
Same fix as #16964, applied to `IO::Buffer#~`.

`io_buffer_not` accessed `buffer->base` directly without validating that the buffer was still live. A slice whose parent had been freed retained its stale base pointer, so calling `~` on it caused a UAF.

Use `io_buffer_get_bytes_for_reading`, which raises `IO::Buffer::InvalidatedError` before any memory access if the buffer has been invalidated.

```ruby
inner = IO::Buffer.new(IO::Buffer::PAGE_SIZE)
slice = inner.slice(0, 8)
inner.free
~slice  # => was UAF, now raises InvalidatedError
```