### PR TITLE
ZJIT: Print module name in HIR Type display

### DIFF
--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -1471,6 +1471,19 @@ pub fn get_class_name(class: VALUE) -> String {
     name
 }
 
+// Return the module name for a given module or class. For anonymous modules, returns "nil" since
+// rb_mod_name returns Qnil.
+pub fn get_module_name(module: VALUE) -> String {
+    // type checks for rb_mod_name()
+    assert!(unsafe { RB_TYPE_P(module, RUBY_T_MODULE) || RB_TYPE_P(module, RUBY_T_CLASS) }, "Expected class or module");
+    let name = unsafe { rb_mod_name(module) };
+    if name == Qnil {
+        "nil".to_string()
+    } else {
+        ruby_str_to_rust_string(name)
+    }
+}
+
 
 #[cfg(test)]
 mod class_name_tests {

--- a/zjit/src/cruby.rs
+++ b/zjit/src/cruby.rs
@@ -1471,16 +1471,16 @@ pub fn get_class_name(class: VALUE) -> String {
     name
 }
 
-// Return the module name for a given module or class. For anonymous modules, returns "nil" since
+// Return the module name for a given module or class. For anonymous modules, returns None since
 // rb_mod_name returns Qnil.
-pub fn get_module_name(module: VALUE) -> String {
+pub fn get_module_name(module: VALUE) -> Option<String> {
     // type checks for rb_mod_name()
     assert!(unsafe { RB_TYPE_P(module, RUBY_T_MODULE) || RB_TYPE_P(module, RUBY_T_CLASS) }, "Expected class or module");
     let name = unsafe { rb_mod_name(module) };
     if name == Qnil {
-        "nil".to_string()
+        None
     } else {
-        ruby_str_to_rust_string(name)
+        Some(ruby_str_to_rust_string(name))
     }
 }
 

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -13641,6 +13641,39 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_print_nil_module_name() {
+        eval(r#"
+            X = [Module.new].freeze
+            def test = X[0]
+            test
+        "#);
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          Jump bb3(v1)
+        bb2():
+          EntryPoint JIT(0)
+          v4:BasicObject = LoadArg :self@0
+          Jump bb3(v4)
+        bb3(v6:BasicObject):
+          PatchPoint SingleRactorMode
+          PatchPoint StableConstantNames(0x1000, X)
+          v23:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v12:Fixnum[0] = Const Value(0)
+          PatchPoint NoSingletonClass(Array@0x1010)
+          PatchPoint MethodRedefined(Array@0x1010, []@0x1018, cme:0x1020)
+          v34:CInt64[0] = Const CInt64(0)
+          v28:CInt64 = ArrayLength v23
+          v29:CInt64[0] = GuardLess v34, v28
+          v35:ModuleExact[nil@0x1048] = Const Value(VALUE(0x1048))
+          CheckInterrupts
+          Return v35
+        ");
+    }
+
+    #[test]
     fn no_load_from_ep_right_after_entrypoint() {
       let formatted = eval("
           def read_nil_local(a, _b, _c)

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -13667,7 +13667,7 @@ mod hir_opt_tests {
           v34:CInt64[0] = Const CInt64(0)
           v28:CInt64 = ArrayLength v23
           v29:CInt64[0] = GuardLess v34, v28
-          v35:ModuleExact[nil@0x1048] = Const Value(VALUE(0x1048))
+          v35:ModuleExact[VALUE(0x1048)] = Const Value(VALUE(0x1048))
           CheckInterrupts
           Return v35
         ");

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -3207,7 +3207,7 @@ mod hir_opt_tests {
         bb3(v8:BasicObject, v9:NilClass):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, M)
-          v29:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v29:ModuleExact[M@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(Module@0x1010)
           PatchPoint MethodRedefined(Module@0x1010, name@0x1018, cme:0x1020)
           v33:StringExact|NilClass = CCall v29, :Module#name@0x1048
@@ -3323,9 +3323,9 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Enumerable)
-          v22:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v22:ModuleExact[Enumerable@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint StableConstantNames(0x1010, Kernel)
-          v25:ModuleExact[VALUE(0x1018)] = Const Value(VALUE(0x1018))
+          v25:ModuleExact[Kernel@0x1018] = Const Value(VALUE(0x1018))
           v14:ArrayExact = NewArray v22, v25
           CheckInterrupts
           Return v14
@@ -3353,7 +3353,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, MY_MODULE)
-          v18:ModuleSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v18:ModuleSubclass[MY_MODULE@0x1008] = Const Value(VALUE(0x1008))
           CheckInterrupts
           Return v18
         ");
@@ -3575,7 +3575,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, M)
-          v20:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v20:ModuleExact[M@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(Module@0x1010)
           PatchPoint MethodRedefined(Module@0x1010, class@0x1018, cme:0x1020)
           v25:Class[Module@0x1010] = Const Value(VALUE(0x1010))
@@ -4392,7 +4392,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Kernel)
-          v18:ModuleExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v18:ModuleExact[Kernel@0x1008] = Const Value(VALUE(0x1008))
           CheckInterrupts
           Return v18
         ");
@@ -13010,7 +13010,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Kernel)
-          v27:ModuleExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
+          v27:ModuleExact[Kernel@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoEPEscape(test)
           PatchPoint MethodRedefined(Module@0x1018, ===@0x1020, cme:0x1028)
           v30:BoolExact = CCall v27, :Module#===@0x1050, v10
@@ -13073,7 +13073,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Kernel)
-          v25:ModuleExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
+          v25:ModuleExact[Kernel@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, is_a?@0x1020, cme:0x1028)
           v29:StringExact = GuardType v10, StringExact
@@ -13206,7 +13206,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Kernel)
-          v25:ModuleExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
+          v25:ModuleExact[Kernel@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, kind_of?@0x1020, cme:0x1028)
           v29:StringExact = GuardType v10, StringExact

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -6,6 +6,7 @@ use crate::cruby::{rb_block_param_proxy, Qfalse, Qnil, Qtrue, RUBY_T_ARRAY, RUBY
 use crate::cruby::{rb_cInteger, rb_cFloat, rb_cArray, rb_cHash, rb_cString, rb_cSymbol, rb_cRange, rb_cModule, rb_zjit_singleton_class_p};
 use crate::cruby::ClassRelationship;
 use crate::cruby::get_class_name;
+use crate::cruby::get_module_name;
 use crate::cruby::ruby_sym_to_rust_string;
 use crate::cruby::rb_mRubyVMFrozenCore;
 use crate::cruby::rb_obj_class;
@@ -80,6 +81,8 @@ fn write_spec(f: &mut std::fmt::Formatter, printer: &TypePrinter) -> std::fmt::R
         Specialization::Object(val) if ty.is_subtype(types::Symbol) => write!(f, "[:{}]", ruby_sym_to_rust_string(val)),
         Specialization::Object(val) if ty.is_subtype(types::Class) =>
             write!(f, "[{}@{:p}]", get_class_name(val), printer.ptr_map.map_ptr(val.0 as *const std::ffi::c_void)),
+        Specialization::Object(val) if ty.is_subtype(types::Module) =>
+            write!(f, "[{}@{:p}]", get_module_name(val), printer.ptr_map.map_ptr(val.0 as *const std::ffi::c_void)),
         Specialization::Object(val) => write!(f, "[{}]", val.print(printer.ptr_map)),
         // TODO(max): Ensure singleton classes never have Type specialization
         Specialization::Type(val) if unsafe { rb_zjit_singleton_class_p(val) } =>

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -81,8 +81,14 @@ fn write_spec(f: &mut std::fmt::Formatter, printer: &TypePrinter) -> std::fmt::R
         Specialization::Object(val) if ty.is_subtype(types::Symbol) => write!(f, "[:{}]", ruby_sym_to_rust_string(val)),
         Specialization::Object(val) if ty.is_subtype(types::Class) =>
             write!(f, "[{}@{:p}]", get_class_name(val), printer.ptr_map.map_ptr(val.0 as *const std::ffi::c_void)),
-        Specialization::Object(val) if ty.is_subtype(types::Module) =>
-            write!(f, "[{}@{:p}]", get_module_name(val), printer.ptr_map.map_ptr(val.0 as *const std::ffi::c_void)),
+        Specialization::Object(val) if ty.is_subtype(types::Module) => {
+            if let Some(name) = get_module_name(val) {
+                write!(f, "[{}@{:p}]", name, printer.ptr_map.map_ptr(val.0 as *const std::ffi::c_void))
+            } else {
+                // Same as generic Specialization::Object
+                write!(f, "[{}]", val.print(printer.ptr_map))
+            }
+        }
         Specialization::Object(val) => write!(f, "[{}]", val.print(printer.ptr_map)),
         // TODO(max): Ensure singleton classes never have Type specialization
         Specialization::Type(val) if unsafe { rb_zjit_singleton_class_p(val) } =>


### PR DESCRIPTION
Go from `ModuleExact[VALUE(0x1008)]` to `ModuleExact[Enumerable@0x1008]` if the module's name isn't `nil`.