### PR TITLE
Reuse Quick Search preprocessing in String scans

### DIFF
--- a/internal/string.h
+++ b/internal/string.h
@@ -99,6 +99,18 @@ VALUE rb_str_frozen_bare_string(VALUE);
 const char *rb_str_null_check(VALUE);
 VALUE rb_str_casecmp(VALUE str1, VALUE str2);
 
+/* Reusable state for rb_memsearch's Quick Search fallback. */
+struct rb_memsearch_qs_state {
+    VALUE qstable[256];
+    const unsigned char *needle;
+    long needle_len;
+};
+
+bool rb_memsearch_qs_usable_p(long m, rb_encoding *enc);
+void rb_memsearch_qs_prepare(struct rb_memsearch_qs_state *state, const void *x, long m);
+/* Requires a state prepared with a needle length greater than 1. */
+long rb_memsearch_qs_search(const struct rb_memsearch_qs_state *state, const void *y, long n);
+
 /* error.c */
 void rb_warn_unchilled_literal(VALUE str);
 

--- a/re.c
+++ b/re.c
@@ -183,24 +183,92 @@ rb_memsearch_ss(const unsigned char *xs, long m, const unsigned char *ys, long n
 }
 #endif
 
-static inline long
-rb_memsearch_qs(const unsigned char *xs, long m, const unsigned char *ys, long n)
-{
-    const unsigned char *x = xs, *xe = xs + m;
-    const unsigned char *y = ys;
-    VALUE i, qstable[256];
+typedef enum {
+    RB_MEMSEARCH_STRAT_TRIVIAL,
+    RB_MEMSEARCH_STRAT_SS,
+    RB_MEMSEARCH_STRAT_QS_UTF8,
+    RB_MEMSEARCH_STRAT_WCHAR,
+    RB_MEMSEARCH_STRAT_QCHAR,
+    RB_MEMSEARCH_STRAT_QS,
+} rb_memsearch_strategy_t;
 
-    /* Preprocessing */
+static rb_memsearch_strategy_t
+rb_memsearch_select(long m, rb_encoding *enc)
+{
+    int minlen;
+
+    if (m <= 1) return RB_MEMSEARCH_STRAT_TRIVIAL;
+
+    minlen = rb_enc_mbminlen(enc);
+    if (LIKELY(minlen == 1)) {
+        if (m <= SIZEOF_VALUE) {
+            return RB_MEMSEARCH_STRAT_SS;
+        }
+        else if (enc == rb_utf8_encoding()) {
+            return RB_MEMSEARCH_STRAT_QS_UTF8;
+        }
+    }
+    else if (LIKELY(minlen == 2)) {
+        return RB_MEMSEARCH_STRAT_WCHAR;
+    }
+    else if (LIKELY(minlen == 4)) {
+        return RB_MEMSEARCH_STRAT_QCHAR;
+    }
+    return RB_MEMSEARCH_STRAT_QS;
+}
+
+bool
+rb_memsearch_qs_usable_p(long m, rb_encoding *enc)
+{
+    return rb_memsearch_select(m, enc) == RB_MEMSEARCH_STRAT_QS;
+}
+
+void
+rb_memsearch_qs_prepare(struct rb_memsearch_qs_state *state, const void *x0, long m)
+{
+    const unsigned char *x = x0, *xe = x + m;
+    VALUE i;
+
+    state->needle = x0;
+    state->needle_len = m;
+
     for (i = 0; i < 256; ++i)
-        qstable[i] = m + 1;
+        state->qstable[i] = m + 1;
     for (; x < xe; ++x)
-        qstable[*x] = xe - x;
+        state->qstable[*x] = xe - x;
+}
+
+long
+rb_memsearch_qs_search(const struct rb_memsearch_qs_state *state, const void *y0, long n)
+{
+    const unsigned char *xs = state->needle, *ys = y0;
+    const unsigned char *y = ys;
+    long m = state->needle_len;
+
+    RUBY_ASSERT(m > 1);
+
+    if (m > n) return -1;
+    else if (m == n) {
+        return memcmp(xs, y0, m) == 0 ? 0 : -1;
+    }
+
+    RUBY_ASSERT(m < n);
+
     /* Searching */
-    for (; y + m <= ys + n; y += *(qstable + y[m])) {
+    for (; y + m <= ys + n; y += state->qstable[y[m]]) {
         if (*xs == *y && memcmp(xs, y, m) == 0)
             return y - ys;
     }
     return -1;
+}
+
+static inline long
+rb_memsearch_qs(const unsigned char *xs, long m, const unsigned char *ys, long n)
+{
+    struct rb_memsearch_qs_state state;
+
+    rb_memsearch_qs_prepare(&state, xs, m);
+    return rb_memsearch_qs_search(&state, ys, n);
 }
 
 static inline unsigned int
@@ -301,21 +369,22 @@ rb_memsearch(const void *x0, long m, const void *y0, long n, rb_encoding *enc)
         else
             return -1;
     }
-    else if (LIKELY(rb_enc_mbminlen(enc) == 1)) {
-        if (m <= SIZEOF_VALUE) {
-            return rb_memsearch_ss(x0, m, y0, n);
-        }
-        else if (enc == rb_utf8_encoding()){
-            return rb_memsearch_qs_utf8(x0, m, y0, n);
-        }
-    }
-    else if (LIKELY(rb_enc_mbminlen(enc) == 2)) {
+
+    switch (rb_memsearch_select(m, enc)) {
+      case RB_MEMSEARCH_STRAT_TRIVIAL:
+        break;
+      case RB_MEMSEARCH_STRAT_SS:
+        return rb_memsearch_ss(x0, m, y0, n);
+      case RB_MEMSEARCH_STRAT_QS_UTF8:
+        return rb_memsearch_qs_utf8(x0, m, y0, n);
+      case RB_MEMSEARCH_STRAT_WCHAR:
         return rb_memsearch_wchar(x0, m, y0, n);
-    }
-    else if (LIKELY(rb_enc_mbminlen(enc) == 4)) {
+      case RB_MEMSEARCH_STRAT_QCHAR:
         return rb_memsearch_qchar(x0, m, y0, n);
+      case RB_MEMSEARCH_STRAT_QS:
+        return rb_memsearch_qs(x0, m, y0, n);
     }
-    return rb_memsearch_qs(x0, m, y0, n);
+    UNREACHABLE_RETURN(-1);
 }
 
 static int

--- a/string.c
+++ b/string.c
@@ -9382,12 +9382,19 @@ rb_str_split_m(int argc, VALUE *argv, VALUE str)
         const char *substr_start = ptr;
         const char *sptr = RSTRING_PTR(spat);
         long slen = RSTRING_LEN(spat);
+        struct rb_memsearch_qs_state qs;
+        bool use_qs;
 
         if (result) result = rb_ary_new();
         mustnot_broken(str);
         enc = rb_enc_check(str, spat);
-        while (ptr < eptr &&
-               (end = rb_memsearch(sptr, slen, ptr, eptr - ptr, enc)) >= 0) {
+        use_qs = rb_memsearch_qs_usable_p(slen, enc);
+        if (use_qs) rb_memsearch_qs_prepare(&qs, sptr, slen);
+        while (ptr < eptr) {
+            end = use_qs ?
+                rb_memsearch_qs_search(&qs, ptr, eptr - ptr) :
+                rb_memsearch(sptr, slen, ptr, eptr - ptr, enc);
+            if (end < 0) break;
             /* Check we are at the start of a char */
             const char *t = rb_enc_right_char_head(ptr, ptr + end, eptr, enc);
             if (t != ptr + end) {
@@ -9398,6 +9405,7 @@ rb_str_split_m(int argc, VALUE *argv, VALUE str)
             str_mod_check(spat, sptr, slen);
             ptr += end + slen;
             substr_start = ptr;
+            if (use_qs && !result && ptr < eptr) rb_memsearch_qs_prepare(&qs, sptr, slen);
             if (!NIL_P(limit) && lim <= ++i) break;
         }
         beg = ptr - str_start;
@@ -9531,6 +9539,8 @@ rb_str_enumerate_lines(int argc, VALUE *argv, VALUE str, VALUE ary)
     const char *pend, *subptr, *subend, *rsptr, *hit, *adjusted;
     long pos, rslen;
     int rsnewline = 0;
+    struct rb_memsearch_qs_state qs;
+    bool use_qs = false;
 
     if (rb_scan_args(argc, argv, "01:", &rs, &opts) == 0)
         rs = rb_rs;
@@ -9616,8 +9626,12 @@ rb_str_enumerate_lines(int argc, VALUE *argv, VALUE str, VALUE ary)
         rslen = RSTRING_LEN(rs);
     }
 
+    use_qs = rb_memsearch_qs_usable_p(rslen, enc);
+    if (use_qs) rb_memsearch_qs_prepare(&qs, rsptr, rslen);
     while (subptr < pend) {
-        pos = rb_memsearch(rsptr, rslen, subptr, pend - subptr, enc);
+        pos = use_qs ?
+            rb_memsearch_qs_search(&qs, subptr, pend - subptr) :
+            rb_memsearch(rsptr, rslen, subptr, pend - subptr, enc);
         if (pos < 0) break;
         hit = subptr + pos;
         adjusted = rb_enc_right_char_head(subptr, hit, pend, enc);
@@ -9639,6 +9653,7 @@ rb_str_enumerate_lines(int argc, VALUE *argv, VALUE str, VALUE ary)
             str_mod_check(str, ptr, len);
         }
         subptr = hit;
+        if (use_qs && !ary && subptr < pend) rb_memsearch_qs_prepare(&qs, rsptr, rslen);
     }
 
     if (subptr != pend) {

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -1192,6 +1192,22 @@ CODE
     assert_equal(S("hello!"), res[0])
     assert_equal(S("world"),  res[1])
 
+    sep = S("abcdefghijklmnop").b
+    res = []
+    (S("aa").b + sep + S("bb").b + sep + S("cc").b).each_line(sep) {|x| res << x}
+    assert_equal([S("aa").b + sep, S("bb").b + sep, S("cc").b], res)
+
+    old_sep = S("abcdefghijklmnop").b
+    new_sep = S("qrstuvwxyzabcdef").b
+    sep = old_sep.dup
+    sep.setbyte(0, sep.getbyte(0))
+    res = []
+    (S("aa").b + old_sep + S("bb").b + new_sep + S("cc").b).each_line(sep) do |x|
+      res << x
+      new_sep.each_byte.with_index {|byte, idx| sep.setbyte(idx, byte) } if res.size == 1
+    end
+    assert_equal([S("aa").b + old_sep, S("bb").b + new_sep, S("cc").b], res)
+
     $/ = "ab"
 
     res=[]
@@ -1423,6 +1439,14 @@ CODE
     assert_include(S("foobar"), S("foo"))
     assert_not_include(S("foobar"), S("baz"))
     assert_not_include(S("foobar"), ?z)
+
+    # This shape reaches rb_memsearch_qs today: ASCII-8BIT is a
+    # non-UTF-8, minlen-1 encoding, and the needle is longer than
+    # SIZEOF_VALUE, so rb_memsearch avoids its shorter/specialized paths.
+    needle = S("abcdefghijklmnop").b
+    haystack = (S("x").b * 17) + needle + S("y").b
+    assert_include(haystack, needle)
+    assert_not_include(haystack, S("abcdefghijklmnox").b)
   end
 
   def test_index
@@ -1455,6 +1479,12 @@ CODE
     s << "yx"
     assert_index(4 * 1000, s, S("x"))
     assert_index(4 * 1000, s, S("xyx"))
+
+    # See test_include? for why this search reaches rb_memsearch_qs.
+    needle = S("abcdefghijklmnop").b
+    haystack = (S("x").b * 17) + needle + S("y").b
+    assert_index(17, haystack, needle)
+    assert_index(nil, haystack, S("abcdefghijklmnox").b)
 
     o = Object.new
     def o.to_str; "bar"; end
@@ -1873,6 +1903,16 @@ CODE
     assert_equal([S("a"), S(""), S("b"), S("c")], S("a||b|c|").split(S('|')))
     assert_equal([S("a"), S(""), S("b"), S("c"), S("")], S("a||b|c|").split(S('|'), -1))
 
+    sep = S("abcdefghijklmnop").b
+    assert_equal([S("aa").b, S("bb").b, S("cc").b],
+                 (S("aa").b + sep + S("bb").b + sep + S("cc").b).split(sep))
+
+    tail_miss = S("abcdefghijklmnox").b
+    assert_equal([S("aa").b, tail_miss],
+                 (S("aa").b + sep + tail_miss).split(sep))
+    assert_equal([S("aa").b, S("").b, S("").b],
+                 (S("aa").b + sep + sep).split(sep, -1))
+
     assert_equal([], S("").split(//, 1))
   ensure
     EnvUtil.suppress_warning {$; = fs}
@@ -1911,6 +1951,17 @@ CODE
     assert_equal([S("a"), S(""), S("b"), S("c")], result)
     result = []; S("a||b|c|").split(S('|'), -1) {|s| result << s}
     assert_equal([S("a"), S(""), S("b"), S("c"), S("")], result)
+
+    old_sep = S("abcdefghijklmnop").b
+    new_sep = S("qrstuvwxyzabcdef").b
+    sep = old_sep.dup
+    sep.setbyte(0, sep.getbyte(0))
+    result = []
+    (S("aa").b + old_sep + S("bb").b + new_sep + S("cc").b).split(sep) do |s|
+      result << s
+      new_sep.each_byte.with_index {|byte, idx| sep.setbyte(idx, byte) } if result.size == 1
+    end
+    assert_equal([S("aa").b, S("bb").b, S("cc").b], result)
 
     result = []; S("").split(//, 1) {|s| result << s}
     assert_equal([], result)


### PR DESCRIPTION
## Summary

This PR reuses Quick Search preprocessing for repeated fixed-string scans in `String#split` and `String#each_line`.

`rb_memsearch_qs` builds a 256-entry skip table before searching. That setup cost is fine for one search, but `split` and `each_line` can call string search repeatedly with the same separator while walking one receiver string. For long binary/non-UTF-8 separators that hit the Quick Search path, this meant rebuilding the same skip table for every segment.

This change splits the Quick Search path into:

* `rb_memsearch_qs_usable_p`
* `rb_memsearch_qs_prepare`
* `rb_memsearch_qs_search`

The existing `rb_memsearch_qs` wrapper still prepares and searches in one call, preserving the old call shape for ordinary one-shot searches. `String#split` and `String#each_line` now prepare once per operation when the separator is eligible, then reuse that state for each repeated scan. If a block mutates the separator bytes in place, the cached state is rebuilt before the next scan so block semantics stay compatible with the previous per-search preprocessing behavior.

## When this helps

This is aimed at Ruby code that scans a large string using the same long fixed separator many times, for example:

```ruby
boundary = "\r\n--ruby-boundary-2026\r\n".b
parts = File.binread("payload.dump").split(boundary)
```

or:

```ruby
record_separator = "\n--END-OF-RECORD--\n".b

File.binread("records.log").each_line(record_separator) do |record|
  process(record)
end
```

It is not expected to noticeably affect common short delimiters such as `",".split(",")`, because those use shorter/specialized paths where Quick Search preprocessing is not the relevant cost.

## Benchmark

I benchmarked this against a clean `origin/master` worktree and this branch, using the same benchmark-driver file:

```yaml
prelude: |
  sep = "abcdefghijklmnop".b
  str = Array.new(2_000, "x" * 16).join(sep).b
  raise unless str.split(sep).length == 2_000
benchmark:
  split_long_binary_sep: str.split(sep)
```

With `--repeat-count=10 --repeat-result=average --run-duration=3`:

```text
origin/master: 13.350k i/s, 74.93 us/i
this branch:   22.205k i/s, 45.04 us/i
```

That is about 1.66x the throughput, or about 40% less time per `String#split` call for this targeted repeated-Quick-Search case.

## Validation

```text
git diff --check
make test-all TESTS=../test/ruby/test_string.rb
```

The full `test/ruby/test_string.rb` run passed:

```text
434 tests, 7314 assertions, 0 failures, 0 errors, 0 skips
```
