### PR TITLE
[DRAFT] perf: Use sparse sweep path for mostly-live bitmaps

### DIFF
--- a/gc/default/default.c
+++ b/gc/default/default.c
@@ -17,6 +17,9 @@
 
 #ifdef BUILDING_MODULAR_GC
 # define nlz_int64(x) (x == 0 ? 64 : (unsigned int)__builtin_clzll((unsigned long long)x))
+# define ntz_intptr(x) \
+    ((x) == 0 ? (int)(sizeof(uintptr_t) * CHAR_BIT) : \
+     (int)__builtin_ctzll((unsigned long long)(x)))
 #else
 # include "internal/bits.h"
 #endif
@@ -3529,86 +3532,85 @@ struct gc_sweep_context {
 };
 
 static inline void
-gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t p, bits_t bitset, struct gc_sweep_context *ctx)
+gc_sweep_plane(rb_objspace_t *objspace, rb_heap_t *heap, uintptr_t base, bits_t bitset, struct gc_sweep_context *ctx)
 {
     struct heap_page *sweep_page = ctx->page;
     short slot_size = sweep_page->slot_size;
 
+    /* Callers guarantee bitset != 0 on entry. */
     do {
+        uintptr_t p = base + (uintptr_t)ntz_intptr(bitset) * slot_size;
         VALUE vp = (VALUE)p;
         GC_ASSERT(vp % sizeof(VALUE) == 0);
 
         rb_asan_unpoison_object(vp, false);
-        if (bitset & 1) {
-            switch (BUILTIN_TYPE(vp)) {
-              case T_MOVED:
-                if (objspace->flags.during_compacting) {
-                    /* The sweep cursor shouldn't have made it to any
-                     * T_MOVED slots while the compact flag is enabled.
-                     * The sweep cursor and compact cursor move in
-                     * opposite directions, and when they meet references will
-                     * get updated and "during_compacting" should get disabled */
-                    rb_bug("T_MOVED shouldn't be seen until compaction is finished");
-                }
-                gc_report(3, objspace, "page_sweep: %s is added to freelist\n", rb_obj_info(vp));
-                ctx->empty_slots++;
-                heap_page_add_freeobj(objspace, sweep_page, vp);
-                break;
-              case T_ZOMBIE:
-                /* already counted */
-                break;
-              case T_NONE:
-                ctx->empty_slots++; /* already freed */
-                break;
+        switch (BUILTIN_TYPE(vp)) {
+          case T_MOVED:
+            if (objspace->flags.during_compacting) {
+                /* The sweep cursor shouldn't have made it to any
+                 * T_MOVED slots while the compact flag is enabled.
+                 * The sweep cursor and compact cursor move in
+                 * opposite directions, and when they meet references will
+                 * get updated and "during_compacting" should get disabled */
+                rb_bug("T_MOVED shouldn't be seen until compaction is finished");
+            }
+            gc_report(3, objspace, "page_sweep: %s is added to freelist\n", rb_obj_info(vp));
+            ctx->empty_slots++;
+            heap_page_add_freeobj(objspace, sweep_page, vp);
+            break;
+          case T_ZOMBIE:
+            /* already counted */
+            break;
+          case T_NONE:
+            ctx->empty_slots++; /* already freed */
+            break;
 
-              default:
+          default:
 #if RGENGC_CHECK_MODE
-                if (!is_full_marking(objspace)) {
-                    if (RVALUE_OLD_P(objspace, vp)) rb_bug("page_sweep: %p - old while minor GC.", (void *)p);
-                    if (RVALUE_REMEMBERED(objspace, vp)) rb_bug("page_sweep: %p - remembered.", (void *)p);
-                }
+            if (!is_full_marking(objspace)) {
+                if (RVALUE_OLD_P(objspace, vp)) rb_bug("page_sweep: %p - old while minor GC.", (void *)p);
+                if (RVALUE_REMEMBERED(objspace, vp)) rb_bug("page_sweep: %p - remembered.", (void *)p);
+            }
 #endif
 
 #if RGENGC_CHECK_MODE
 #define CHECK(x) if (x(objspace, vp) != FALSE) rb_bug("obj_free: " #x "(%s) != FALSE", rb_obj_info(vp))
-                CHECK(RVALUE_WB_UNPROTECTED);
-                CHECK(RVALUE_MARKED);
-                CHECK(RVALUE_MARKING);
-                CHECK(RVALUE_UNCOLLECTIBLE);
+            CHECK(RVALUE_WB_UNPROTECTED);
+            CHECK(RVALUE_MARKED);
+            CHECK(RVALUE_MARKING);
+            CHECK(RVALUE_UNCOLLECTIBLE);
 #undef CHECK
 #endif
 
-                if (!rb_gc_obj_needs_cleanup_p(vp)) {
-                    if (RB_UNLIKELY(objspace->hook_events & RUBY_INTERNAL_EVENT_FREEOBJ)) {
-                        rb_gc_event_hook(vp, RUBY_INTERNAL_EVENT_FREEOBJ);
-                    }
+            if (!rb_gc_obj_needs_cleanup_p(vp)) {
+                if (RB_UNLIKELY(objspace->hook_events & RUBY_INTERNAL_EVENT_FREEOBJ)) {
+                    rb_gc_event_hook(vp, RUBY_INTERNAL_EVENT_FREEOBJ);
+                }
 
+                (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)p, slot_size);
+                heap_page_add_freeobj(objspace, sweep_page, vp);
+                gc_report(3, objspace, "page_sweep: %s (fast path) added to freelist\n", rb_obj_info(vp));
+                ctx->freed_slots++;
+            }
+            else {
+                gc_report(2, objspace, "page_sweep: free %p\n", (void *)p);
+
+                rb_gc_event_hook(vp, RUBY_INTERNAL_EVENT_FREEOBJ);
+
+                rb_gc_obj_free_vm_weak_references(vp);
+                if (rb_gc_obj_free(objspace, vp)) {
                     (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)p, slot_size);
                     heap_page_add_freeobj(objspace, sweep_page, vp);
-                    gc_report(3, objspace, "page_sweep: %s (fast path) added to freelist\n", rb_obj_info(vp));
+                    gc_report(3, objspace, "page_sweep: %s is added to freelist\n", rb_obj_info(vp));
                     ctx->freed_slots++;
                 }
                 else {
-                    gc_report(2, objspace, "page_sweep: free %p\n", (void *)p);
-
-                    rb_gc_event_hook(vp, RUBY_INTERNAL_EVENT_FREEOBJ);
-
-                    rb_gc_obj_free_vm_weak_references(vp);
-                    if (rb_gc_obj_free(objspace, vp)) {
-                        (void)VALGRIND_MAKE_MEM_UNDEFINED((void*)p, slot_size);
-                        heap_page_add_freeobj(objspace, sweep_page, vp);
-                        gc_report(3, objspace, "page_sweep: %s is added to freelist\n", rb_obj_info(vp));
-                        ctx->freed_slots++;
-                    }
-                    else {
-                        ctx->final_slots++;
-                    }
+                    ctx->final_slots++;
                 }
-                break;
             }
+            break;
         }
-        p += slot_size;
-        bitset >>= 1;
+        bitset &= bitset - 1;
     } while (bitset);
 }
 


### PR DESCRIPTION
## Background

I noticed that Ruby GC sweep can spend time walking live slots inside a heap page bitmap word even though the bitmap already tells us which slots actually need sweep handling.

In `gc_sweep_page`, Ruby computes an inverted mark bitmap word:

```c
bitset = ~bits[i];
```

At that point, a `1` bit means the slot is unmarked and needs sweep handling, while a `0` bit means the slot is marked/live and can be skipped. The existing sweep loop advances one slot at a time until `bitset` becomes zero. This is correct, but on mostly-live bitmap words it can step through many live slots just to reach the next dead slot.

```
do {
    VALUE vp = (VALUE)p;

    if (bitset & 1) {
        /* sweep this slot */
    }

    p += slot_size;
    bitset >>= 1;
} while (bitset);
```

## Proposal

Classify each sweep bitmap word before entering the sweep loop.

The classifier estimates how many live-slot iterations the old loop would do before the last dead slot in the word:

```c
old_loops = bit_length(bitset);
dead_slots = popcount(bitset);
skippable = old_loops - dead_slots;
```

If `skippable` is large enough, use a sparse sweep path that jumps directly to the next dead slot with `ntz_intptr(bitset)`. Otherwise, use the dense path, which uses the original loop.

The current default threshold is `8` skippable slots.

## Justification

The original implementation did not use a classifier and saw notable regressions from sweeps where the `ntz_intptr` call was mostly redundant.

The dense path avoids paying `ntz_intptr` on bitmap words where there is little or nothing to skip. The sparse path pays that cost only when there are enough live slots to plausibly make it worthwhile.

## Upsides

- Better sweep time on mostly-live bitmap words.
- The dense path remains close to the original sweep loop for dead-heavy words.

## Tradeoffs

- Adds a small classifier cost per non-empty bitmap word.

## Results

I ran the `ruby-bench` headline set with `harness-gc`, comparing the default build against `skippable = 8`.

Aggregate sweep time improved by about 13.6% for `skippable = 8`. I also tried other classifiers, 4, 16, and 32. 16 was close but `split8` was the best.

## Methodology

- Apple M4 Pro, macOS.
- Used `ruby-bench` headline benchmarks with `harness-gc`.
- Used 3 warmup iterations and 5 measured iterations.