### PR TITLE
Move rb_gc_update_set_refs into gc.c

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -3927,10 +3927,34 @@ rb_gc_update_tbl_refs(st_table *ptr)
     gc_update_table_refs(ptr);
 }
 
-void
-rb_gc_update_set_refs(st_table *ptr)
+static int
+rb_gc_update_set_refs_i(st_data_t key, st_data_t value, st_data_t argp, int error)
 {
-    gc_update_set_refs(ptr);
+    if (rb_gc_location((VALUE)key) != (VALUE)key) {
+        return ST_REPLACE;
+    }
+
+    return ST_CONTINUE;
+}
+
+static int
+rb_gc_update_set_refs_replace_i(st_data_t *key, st_data_t *value, st_data_t argp, int existing)
+{
+    if (rb_gc_location((VALUE)*key) != (VALUE)*key) {
+        *key = rb_gc_location((VALUE)*key);
+    }
+
+    return ST_CONTINUE;
+}
+
+void
+rb_gc_update_set_refs(st_table *tbl)
+{
+    if (!tbl || tbl->num_entries == 0) return;
+
+    if (st_foreach_with_replace(tbl, rb_gc_update_set_refs_i, rb_gc_update_set_refs_replace_i, 0)) {
+        rb_raise(rb_eRuntimeError, "hash modified during iteration");
+    }
 }
 
 static void

--- a/gc/gc.h
+++ b/gc/gc.h
@@ -240,36 +240,6 @@ gc_update_table_refs(st_table *tbl)
     }
 }
 
-static int
-rb_set_foreach_replace(st_data_t key, st_data_t value, st_data_t argp, int error)
-{
-    if (rb_gc_location((VALUE)key) != (VALUE)key) {
-        return ST_REPLACE;
-    }
-
-    return ST_CONTINUE;
-}
-
-static int
-rb_set_replace_ref(st_data_t *key, st_data_t *value, st_data_t argp, int existing)
-{
-    if (rb_gc_location((VALUE)*key) != (VALUE)*key) {
-        *key = rb_gc_location((VALUE)*key);
-    }
-
-    return ST_CONTINUE;
-}
-
-static void
-gc_update_set_refs(st_table *tbl)
-{
-    if (!tbl || tbl->num_entries == 0) return;
-
-    if (st_foreach_with_replace(tbl, rb_set_foreach_replace, rb_set_replace_ref, 0)) {
-        rb_raise(rb_eRuntimeError, "hash modified during iteration");
-    }
-}
-
 static inline size_t
 xmalloc2_size(const size_t count, const size_t elsize)
 {


### PR DESCRIPTION
The code is in gc/gc.h but it is not used outside of gc.c, so we can move it there.