### PR TITLE
[PoC] Lazy substrings: add RSTRING_START(), enable SHARABLE_MIDDLE_SUBSTRING

### DIFF
--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -73,7 +73,7 @@ struct strscanner
     CLEAR_NAMED_CAPTURES(s);\
 } while (0)
 
-#define S_PBEG(s)  (RSTRING_PTR((s)->str))
+#define S_PBEG(s)  (RSTRING_RAW_PTR((s)->str))
 #define S_LEN(s)  (RSTRING_LEN((s)->str))
 #define S_PEND(s)  (S_PBEG(s) + S_LEN(s))
 #define CURPTR(s) (S_PBEG(s) + (s)->curr)
@@ -770,14 +770,14 @@ strscan_do_scan(VALUE self, VALUE pattern, int succptr, int getstr, int headonly
         if (headonly) {
             strscan_enc_check(p->str, pattern);
 
-            if (memcmp(CURPTR(p), RSTRING_PTR(pattern), RSTRING_LEN(pattern)) != 0) {
+            if (memcmp(CURPTR(p), RSTRING_RAW_PTR(pattern), RSTRING_LEN(pattern)) != 0) {
                 return Qnil;
             }
             set_registers(p, 0, RSTRING_LEN(pattern));
         }
         else {
             rb_encoding *enc = rb_enc_check(p->str, pattern);
-            long pos = rb_memsearch(RSTRING_PTR(pattern), RSTRING_LEN(pattern),
+            long pos = rb_memsearch(RSTRING_RAW_PTR(pattern), RSTRING_LEN(pattern),
                                     CURPTR(p), S_RESTLEN(p), enc);
             if (pos == -1) {
                 return Qnil;

--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -450,9 +450,18 @@ RBIMPL_ATTR_ARTIFICIAL()
 static inline char *
 RSTRING_END(VALUE str)
 {
-    char *ptr = RB_FL_TEST_RAW(str, RSTRING_NOEMBED) ?
-        RSTRING(str)->as.heap.ptr :
-        RSTRING(str)->as.embed.ary;
+    char *ptr;
+    if (RB_FL_TEST_RAW(str, RSTRING_NOEMBED)) {
+        if (RB_FL_TEST_RAW(str, RUBY_ELTS_SHARED)) {
+            ptr = rbimpl_str_ensure_terminator(str);
+        }
+        else {
+            ptr = RSTRING(str)->as.heap.ptr;
+        }
+    }
+    else {
+        ptr = RSTRING(str)->as.embed.ary;
+    }
     long len = RSTRING_LEN(str);
 
     if (RUBY_DEBUG && RB_UNLIKELY(!ptr)) {

--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -352,6 +352,17 @@ void rb_check_safe_str(VALUE);
  * @param[in]  func           The function name where encountered NULL pointer.
  */
 void rb_debug_rstring_null_ptr(const char *func);
+
+/**
+ * @private
+ *
+ * Implementation  helper  for  RSTRING_PTR().  Ensures  the string has  a null
+ * terminator after its content.
+ *
+ * @param[in]  str  A shared heap string that may lack a null terminator.
+ * @return     Pointer to the (now null-terminated) string contents.
+ */
+char *rbimpl_str_ptr_guarantee_null_term(VALUE str);
 RBIMPL_SYMBOL_EXPORT_END()
 
 RBIMPL_ATTR_PURE_UNLESS_DEBUG()
@@ -371,10 +382,33 @@ RSTRING_LEN(VALUE str)
 
 RBIMPL_ATTR_ARTIFICIAL()
 /**
- * Queries the contents pointer of the string.
+ * Queries  the raw contents pointer  of  the string  without guaranteeing null
+ * termination.
  *
  * @param[in]  str  String in question.
  * @return     Pointer to its contents.
+ * @pre        `str` must be an instance of ::RString.
+ */
+static inline char *
+RSTRING_START(VALUE str)
+{
+    char *ptr = RB_FL_TEST_RAW(str, RSTRING_NOEMBED) ?
+        RSTRING(str)->as.heap.ptr :
+        RSTRING(str)->as.embed.ary;
+
+    if (RUBY_DEBUG && RB_UNLIKELY(! ptr)) {
+        rb_debug_rstring_null_ptr("RSTRING_START");
+    }
+
+    return ptr;
+}
+
+RBIMPL_ATTR_ARTIFICIAL()
+/**
+ * Queries the contents pointer of the string.
+ *
+ * @param[in]  str  String in question.
+ * @return     Pointer to its null-terminated contents.
  * @pre        `str` must be an instance of ::RString.
  */
 static inline char *
@@ -392,6 +426,14 @@ RSTRING_PTR(VALUE str)
          * during GC (see  what obj_info() does).  rb_warn()  needs to allocate
          * Ruby objects.  That is not possible at this moment. */
         rb_debug_rstring_null_ptr("RSTRING_PTR");
+    }
+
+    /* Heap strings  may  lack  a null terminator  (SHARABLE_MIDDLE_SUBSTRING).
+     * rbimpl_str_ptr_guarantee_null_term()   checks   all  termlen  bytes  and
+     * returns immediately for already-terminated strings. */
+    if (RB_FL_TEST_RAW(str, RSTRING_NOEMBED) &&
+                RB_FL_TEST_RAW(str, RUBY_ELTS_SHARED)) {
+        ptr = rbimpl_str_ptr_guarantee_null_term(str);
     }
 
     return ptr;

--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -413,9 +413,18 @@ RBIMPL_ATTR_ARTIFICIAL()
 static inline char *
 RSTRING_PTR(VALUE str)
 {
-    char *ptr = RB_FL_TEST_RAW(str, RSTRING_NOEMBED) ?
-        RSTRING(str)->as.heap.ptr :
-        RSTRING(str)->as.embed.ary;
+    char *ptr;
+    if (RB_FL_TEST_RAW(str, RSTRING_NOEMBED)) {
+        if (RB_FL_TEST_RAW(str, RUBY_ELTS_SHARED)) {
+            ptr = rbimpl_str_ensure_terminator(str);
+        }
+        else {
+            ptr = RSTRING(str)->as.heap.ptr;
+        }
+    }
+    else {
+        ptr = RSTRING(str)->as.embed.ary;
+    }
 
     if (RUBY_DEBUG && RB_UNLIKELY(! ptr)) {
         /* :BEWARE: @shyouhei thinks  that currently, there are  rooms for this
@@ -425,14 +434,6 @@ RSTRING_PTR(VALUE str)
          * during GC (see  what obj_info() does).  rb_warn()  needs to allocate
          * Ruby objects.  That is not possible at this moment. */
         rb_debug_rstring_null_ptr("RSTRING_PTR");
-    }
-
-    /* Heap strings  may  lack  a null terminator  (SHARABLE_MIDDLE_SUBSTRING).
-     * rbimpl_str_ptr_guarantee_null_term()   checks   all  termlen  bytes  and
-     * returns immediately for already-terminated strings. */
-    if (RB_FL_TEST_RAW(str, RSTRING_NOEMBED) &&
-                RB_FL_TEST_RAW(str, RUBY_ELTS_SHARED)) {
-        ptr = rbimpl_str_ptr_guarantee_null_term(str);
     }
 
     return ptr;

--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -387,16 +387,25 @@ RBIMPL_ATTR_ARTIFICIAL()
  * @param[in]  str  String in question.
  * @return     Pointer to its contents.
  * @pre        `str` must be an instance of ::RString.
+ *
+ * @warning    The   returned   pointer  is  invalidated   if  the  string   is
+ *             subsequently   unshared.   Operations   such  as   RSTRING_PTR()
+ *             and   RSTRING_END()  may  unshare  the  string  and   reallocate
+ *             its  buffer,  making  this  pointer  dangling.  Only  call  this
+ *             function  after  all  unsharing   operations   on   `str`   have
+ *             completed,  or  when  `str`  is  known  to  be  independent.  To
+ *             obtain   the  end  pointer   without  risking  invalidation, use
+ *             `RSTRING_RAW_PTR(str) + RSTRING_LEN(str)`.
  */
 static inline char *
-RSTRING_START(VALUE str)
+RSTRING_RAW_PTR(VALUE str)
 {
     char *ptr = RB_FL_TEST_RAW(str, RSTRING_NOEMBED) ?
         RSTRING(str)->as.heap.ptr :
         RSTRING(str)->as.embed.ary;
 
     if (RUBY_DEBUG && RB_UNLIKELY(! ptr)) {
-        rb_debug_rstring_null_ptr("RSTRING_START");
+        rb_debug_rstring_null_ptr("RSTRING_RAW_PTR");
     }
 
     return ptr;

--- a/include/ruby/internal/core/rstring.h
+++ b/include/ruby/internal/core/rstring.h
@@ -356,13 +356,12 @@ void rb_debug_rstring_null_ptr(const char *func);
 /**
  * @private
  *
- * Implementation  helper  for  RSTRING_PTR().  Ensures  the string has  a null
- * terminator after its content.
+ * Ensures the string has a null terminator after its content.
  *
  * @param[in]  str  A shared heap string that may lack a null terminator.
  * @return     Pointer to the (now null-terminated) string contents.
  */
-char *rbimpl_str_ptr_guarantee_null_term(VALUE str);
+char *rbimpl_str_ensure_terminator(VALUE str);
 RBIMPL_SYMBOL_EXPORT_END()
 
 RBIMPL_ATTR_PURE_UNLESS_DEBUG()

--- a/internal/string.h
+++ b/internal/string.h
@@ -119,6 +119,7 @@ void rb_str_tmp_frozen_release(VALUE str, VALUE tmp);
 VALUE rb_setup_fake_str(struct RString *fake_str, const char *name, long len, rb_encoding *enc);
 RUBY_SYMBOL_EXPORT_END
 
+void rb_free_ephemeral_term_table(void);
 VALUE rb_fstring_new(const char *ptr, long len);
 void rb_gc_free_fstring(VALUE obj);
 bool rb_obj_is_fstring_table(VALUE obj);

--- a/internal/string.h
+++ b/internal/string.h
@@ -224,7 +224,7 @@ rb_str_eql_internal(const VALUE str1, const VALUE str2)
 
     if (len != RSTRING_LEN(str2)) return Qfalse;
     if (!rb_str_comparable(str1, str2)) return Qfalse;
-    if ((ptr1 = RSTRING_PTR(str1)) == (ptr2 = RSTRING_PTR(str2)))
+    if ((ptr1 = RSTRING_RAW_PTR(str1)) == (ptr2 = RSTRING_RAW_PTR(str2)))
         return Qtrue;
     if (memcmp(ptr1, ptr2, len) == 0)
         return Qtrue;

--- a/re.c
+++ b/re.c
@@ -1788,7 +1788,7 @@ rb_reg_adjust_startpos(VALUE re, VALUE str, long pos, int reverse)
     }
 
     if (pos > 0 && ONIGENC_MBC_MAXLEN(enc) != 1 && pos < RSTRING_LEN(str)) {
-         string = (UChar*)RSTRING_PTR(str);
+         string = (UChar*)RSTRING_RAW_PTR(str);
 
          if (range > 0) {
               p = onigenc_get_right_adjust_char_head(enc, string, string + pos, string + RSTRING_LEN(str));
@@ -1811,9 +1811,8 @@ static OnigPosition
 reg_onig_search(regex_t *reg, VALUE str, struct re_registers *regs, void *args_ptr)
 {
     struct reg_onig_search_args *args = (struct reg_onig_search_args *)args_ptr;
-    const char *ptr;
-    long len;
-    RSTRING_GETMEM(str, ptr, len);
+    const char *ptr = RSTRING_RAW_PTR(str);
+    long len = RSTRING_LEN(str);
 
     return onig_search(
         reg,
@@ -1903,9 +1902,8 @@ rb_reg_search(VALUE re, VALUE str, long pos, int reverse)
 static OnigPosition
 reg_onig_match(regex_t *reg, VALUE str, struct re_registers *regs, void *_)
 {
-    const char *ptr;
-    long len;
-    RSTRING_GETMEM(str, ptr, len);
+    const char *ptr = RSTRING_RAW_PTR(str);
+    long len = RSTRING_LEN(str);
 
     return onig_match(
         reg,
@@ -4617,7 +4615,8 @@ do_regsub(VALUE str, VALUE src, VALUE regexp, int num_regs, const OnigPosition *
     long n;
 #define ASCGET(s,e,cl) (acompat ? (*(cl)=1,ISASCII((s)[0])?(s)[0]:-1) : rb_enc_ascget((s), (e), (cl), str_enc))
 
-    RSTRING_GETMEM(str, s, n);
+    s = RSTRING_RAW_PTR(str);
+    n = RSTRING_LEN(str);
     p = s;
     e = s + n;
 
@@ -4671,7 +4670,7 @@ do_regsub(VALUE str, VALUE src, VALUE regexp, int num_regs, const OnigPosition *
                     name_end += c == -1 ? mbclen(name_end, e, str_enc) : clen;
                 }
                 if (name_end < e) {
-                    VALUE n = rb_str_subseq(str, (long)(name - RSTRING_PTR(str)),
+                    VALUE n = rb_str_subseq(str, (long)(name - RSTRING_RAW_PTR(str)),
                                             (long)(name_end - name));
                     struct re_registers tmp = {
                         .allocated = num_regs,
@@ -4699,11 +4698,11 @@ do_regsub(VALUE str, VALUE src, VALUE regexp, int num_regs, const OnigPosition *
             break;
 
           case '`':
-            rb_enc_str_buf_cat(val, RSTRING_PTR(src), beg[0], src_enc);
+            rb_enc_str_buf_cat(val, RSTRING_RAW_PTR(src), beg[0], src_enc);
             continue;
 
           case '\'':
-            rb_enc_str_buf_cat(val, RSTRING_PTR(src)+end[0], RSTRING_LEN(src)-end[0], src_enc);
+            rb_enc_str_buf_cat(val, RSTRING_RAW_PTR(src)+end[0], RSTRING_LEN(src)-end[0], src_enc);
             continue;
 
           case '+':

--- a/string.c
+++ b/string.c
@@ -44,6 +44,7 @@
 #include "ruby/encoding.h"
 #include "ruby/re.h"
 #include "ruby/thread.h"
+#include "ruby/thread_native.h"
 #include "ruby/util.h"
 #include "ruby/ractor.h"
 #include "ruby_assert.h"
@@ -1754,9 +1755,35 @@ rb_str_tmp_new(long len)
     return str_new(0, 0, len);
 }
 
+/*
+ * Global table for null-terminated copies of shared middle substrings created
+ * without the GVL.
+ */
+static rb_nativethread_lock_t ephemeral_term_lock;
+static st_table *ephemeral_term_table;
+static rb_atomic_t ephemeral_term_count;
+
+static void
+ephemeral_term_cleanup(VALUE str)
+{
+    /* Skip the mutex when the table is empty. */
+    if (RUBY_ATOMIC_LOAD(ephemeral_term_count) == 0) return;
+
+    st_data_t key = (st_data_t)str;
+    st_data_t buf;
+    rb_nativethread_lock_lock(&ephemeral_term_lock);
+    bool deleted = st_delete(ephemeral_term_table, &key, &buf);
+    if (deleted) RUBY_ATOMIC_DEC(ephemeral_term_count);
+    rb_nativethread_lock_unlock(&ephemeral_term_lock);
+    if (deleted) ruby_mimfree((void *)buf);
+}
+
 void
 rb_str_free(VALUE str)
 {
+    /* Clean up any ephemeral null-termination buffer for this string. */
+    ephemeral_term_cleanup(str);
+
     if (STR_EMBED_P(str)) {
         RB_DEBUG_COUNTER_INC(obj_str_embed);
     }
@@ -2977,18 +3004,38 @@ rbimpl_str_ensure_terminator(VALUE str)
 {
     RUBY_ASSERT(FL_TEST_RAW(str, STR_NOEMBED | STR_SHARED));
 
-    if (!ruby_thread_has_gvl_p()) {
-        /* We don't hold the GVL. Calling str_make_independent_expand without
-         * it would modify shared object state without synchronization.
-         * Return the raw pointer; null-termination is not guaranteed. */
-        return RSTRING(str)->as.heap.ptr;
-    }
-
     int termlen = TERM_LEN(str);
     long len = RSTRING_LEN(str);
     char *ptr = RSTRING(str)->as.heap.ptr;
 
     if (zero_filled(ptr + len, termlen)) return ptr;
+
+    if (!ruby_thread_has_gvl_p()) {
+        /* Allocate a null-terminated copy outside the GC heap and
+         * cache it in ephemeral_term_table, keyed by this string's VALUE.
+         * The copy is freed when the string is freed (rb_str_free). */
+        char *result;
+        rb_nativethread_lock_lock(&ephemeral_term_lock);
+        if (st_lookup(ephemeral_term_table, (st_data_t)str, (st_data_t *)&result)) {
+            rb_nativethread_lock_unlock(&ephemeral_term_lock);
+            return result;
+        }
+        result = ruby_mimmalloc((size_t)len + (size_t)termlen);
+        if (!result) {
+            rb_nativethread_lock_unlock(&ephemeral_term_lock);
+            /* OOM for a small allocation is catastrophic and we cannot raise a
+             * Ruby exception without the GVL. */
+            rb_bug("Cannot allocate ephemeral null-termination buffer for "
+                   "RSTRING_PTR called without GVL: out of memory");
+        }
+        memcpy(result, ptr, (size_t)len);
+        memset(result + len, 0, (size_t)termlen);
+        st_insert(ephemeral_term_table, (st_data_t)str, (st_data_t)result);
+        RUBY_ATOMIC_INC(ephemeral_term_count);
+        rb_nativethread_lock_unlock(&ephemeral_term_lock);
+        return result;
+    }
+
     str_make_independent_expand(str, len, 0L, termlen);
     return RSTRING_START(str);
 }
@@ -10957,7 +11004,6 @@ rb_str_oct(VALUE str)
 }
 
 #ifndef HAVE_CRYPT_R
-# include "ruby/thread_native.h"
 # include "ruby/atomic.h"
 
 static struct {
@@ -12905,6 +12951,9 @@ fstring_set_class_i(VALUE *str, void *data)
 void
 Init_String(void)
 {
+    rb_nativethread_lock_initialize(&ephemeral_term_lock);
+    ephemeral_term_table = st_init_numtable();
+
     rb_cString  = rb_define_class("String", rb_cObject);
 
     rb_concurrent_set_foreach_with_replace(fstring_table_obj, fstring_set_class_i, NULL);

--- a/string.c
+++ b/string.c
@@ -179,8 +179,8 @@ VALUE rb_cSymbol;
 
 #define STR_SET_SHARED(str, shared_str) do { \
     if (!FL_TEST(str, STR_FAKESTR)) { \
-        RUBY_ASSERT(RSTRING_START(shared_str) <= RSTRING_START(str)); \
-        RUBY_ASSERT(RSTRING_START(str) <= RSTRING_START(shared_str) + RSTRING_LEN(shared_str)); \
+        RUBY_ASSERT(RSTRING_RAW_PTR(shared_str) <= RSTRING_RAW_PTR(str)); \
+        RUBY_ASSERT(RSTRING_RAW_PTR(str) <= RSTRING_RAW_PTR(shared_str) + RSTRING_LEN(shared_str)); \
         RB_OBJ_WRITE((str), &RSTRING(str)->as.heap.aux.shared, (shared_str)); \
         FL_SET((str), STR_SHARED); \
         rb_gc_register_pinning_obj(str); \
@@ -1463,7 +1463,7 @@ str_replace_shared_without_enc(VALUE str2, VALUE str)
     char *ptr;
     long len;
 
-    ptr = RSTRING_START(str);
+    ptr = RSTRING_RAW_PTR(str);
     len = RSTRING_LEN(str);
     if (str_embed_capa(str2) >= len + termlen) {
         char *ptr2 = RSTRING(str2)->as.embed.ary;
@@ -1876,7 +1876,7 @@ str_shared_replace(VALUE str, VALUE str2)
 
         STR_SET_NOEMBED(str);
         FL_UNSET(str, STR_SHARED);
-        RSTRING(str)->as.heap.ptr = RSTRING_START(str2);
+        RSTRING(str)->as.heap.ptr = RSTRING_RAW_PTR(str2);
 
         if (FL_TEST(str2, STR_SHARED)) {
             VALUE shared = RSTRING(str2)->as.heap.aux.shared;
@@ -1926,7 +1926,7 @@ str_replace(VALUE str, VALUE str2)
         RUBY_ASSERT(OBJ_FROZEN(shared));
         STR_SET_NOEMBED(str);
         STR_SET_LEN(str, len);
-        RSTRING(str)->as.heap.ptr = RSTRING_START(str2);
+        RSTRING(str)->as.heap.ptr = RSTRING_RAW_PTR(str2);
         STR_SET_SHARED(str, shared);
         rb_enc_cr_str_exact_copy(str, str2);
     }
@@ -2005,7 +2005,7 @@ str_duplicate_setup_heap(VALUE klass, VALUE str, VALUE dup)
     RUBY_ASSERT(!STR_SHARED_P(root));
     RUBY_ASSERT(RB_OBJ_FROZEN_RAW(root));
 
-    RSTRING(dup)->as.heap.ptr = RSTRING_START(str);
+    RSTRING(dup)->as.heap.ptr = RSTRING_RAW_PTR(str);
     FL_SET_RAW(dup, RSTRING_NOEMBED);
     STR_SET_SHARED(dup, root);
     flags |= RSTRING_NOEMBED | STR_SHARED;
@@ -2761,7 +2761,7 @@ str_make_independent_expand(VALUE str, long len, long expand, const int termlen)
     }
 
     ptr = ALLOC_N(char, (size_t)capa + termlen);
-    oldptr = RSTRING_START(str);
+    oldptr = RSTRING_RAW_PTR(str);
     if (oldptr) {
         memcpy(ptr, oldptr, len);
     }
@@ -2894,7 +2894,7 @@ str_fill_term(VALUE str, char *s, long len, int termlen)
         TERM_FILL(s + len, termlen);
         return s;
     }
-    return RSTRING_START(str);
+    return RSTRING_RAW_PTR(str);
 }
 
 void
@@ -2929,7 +2929,7 @@ rb_str_change_terminator_length(VALUE str, const int oldtermlen, const int terml
 static char *
 str_null_check(VALUE str, int *w)
 {
-    char *s = RSTRING_START(str);
+    char *s = RSTRING_RAW_PTR(str);
     long len = RSTRING_LEN(str);
     int minlen = 1;
 
@@ -3010,7 +3010,7 @@ str_to_cstr(VALUE str)
 char *
 rb_str_fill_terminator(VALUE str, const int newminlen)
 {
-    char *s = RSTRING_START(str);
+    char *s = RSTRING_RAW_PTR(str);
     long len = RSTRING_LEN(str);
     return str_fill_term(str, s, len, newminlen);
 }
@@ -3053,7 +3053,7 @@ rbimpl_str_ensure_terminator(VALUE str)
     }
 
     str_make_independent_expand(str, len, 0L, termlen);
-    return RSTRING_START(str);
+    return RSTRING_RAW_PTR(str);
 }
 
 VALUE

--- a/string.c
+++ b/string.c
@@ -3235,12 +3235,11 @@ str_subseq(VALUE str, long beg, long len)
         return str2;
     }
 
-    str2 = str_alloc_heap(rb_cString);
-    if (str_embed_capa(str2) >= len + termlen) {
+    if (STR_EMBEDDABLE_P(len, termlen)) {
+        str2 = str_alloc_embed(rb_cString, len + termlen);
         char *ptr2 = RSTRING(str2)->as.embed.ary;
-        STR_SET_EMBED(str2);
-        memcpy(ptr2, RSTRING_PTR(str) + beg, len);
-        TERM_FILL(ptr2+len, termlen);
+        memcpy(ptr2, RSTRING_RAW_PTR(str) + beg, len);
+        TERM_FILL(ptr2 + len, termlen);
 
         STR_SET_LEN(str2, len);
         if (ENC_CODERANGE(str) == ENC_CODERANGE_7BIT) {
@@ -3248,18 +3247,19 @@ str_subseq(VALUE str, long beg, long len)
         }
 
         RB_GC_GUARD(str);
+        return str2;
     }
-    else {
-        str_replace_shared(str2, str);
-        RUBY_ASSERT(!STR_EMBED_P(str2));
-        if (ENC_CODERANGE(str) != ENC_CODERANGE_7BIT) {
-            ENC_CODERANGE_CLEAR(str2);
-        }
 
-        RSTRING(str2)->as.heap.ptr += beg;
-        if (RSTRING_LEN(str2) > len) {
-            STR_SET_LEN(str2, len);
-        }
+    str2 = str_alloc_heap(rb_cString);
+    str_replace_shared(str2, str);
+    RUBY_ASSERT(!STR_EMBED_P(str2));
+    if (ENC_CODERANGE(str) != ENC_CODERANGE_7BIT) {
+        ENC_CODERANGE_CLEAR(str2);
+    }
+
+    RSTRING(str2)->as.heap.ptr += beg;
+    if (RSTRING_LEN(str2) > len) {
+        STR_SET_LEN(str2, len);
     }
 
     return str2;

--- a/string.c
+++ b/string.c
@@ -3039,10 +3039,8 @@ rbimpl_str_ensure_terminator(VALUE str)
         result = ruby_mimmalloc((size_t)len + (size_t)termlen);
         if (!result) {
             rb_nativethread_lock_unlock(&ephemeral_term_lock);
-            /* OOM for a small allocation is catastrophic and we cannot raise a
-             * Ruby exception without the GVL. */
-            rb_bug("Cannot allocate ephemeral null-termination buffer for "
-                   "RSTRING_PTR called without GVL: out of memory");
+            fprintf(stderr, "[FATAL] failed to allocate memory\n");
+            exit(EXIT_FAILURE);
         }
         memcpy(result, ptr, (size_t)len);
         memset(result + len, 0, (size_t)termlen);

--- a/string.c
+++ b/string.c
@@ -913,7 +913,7 @@ rb_enc_cr_str_copy_for_substr(VALUE dest, VALUE src)
         break;
       case ENC_CODERANGE_VALID:
         if (!rb_enc_asciicompat(STR_ENC_GET(src)) ||
-            search_nonascii(RSTRING_PTR(dest), RSTRING_END(dest)))
+            search_nonascii(RSTRING_START(dest), RSTRING_END(dest)))
             ENC_CODERANGE_SET(dest, ENC_CODERANGE_VALID);
         else
             ENC_CODERANGE_SET(dest, ENC_CODERANGE_7BIT);
@@ -3099,7 +3099,7 @@ str_offset(const char *p, const char *e, long nth, rb_encoding *enc, int singleb
 long
 rb_str_offset(VALUE str, long pos)
 {
-    return str_offset(RSTRING_PTR(str), RSTRING_END(str), pos,
+    return str_offset(RSTRING_START(str), RSTRING_END(str), pos,
                       STR_ENC_GET(str), single_byte_optimizable(str));
 }
 
@@ -4630,7 +4630,7 @@ rb_str_index_m(int argc, VALUE *argv, VALUE str)
     }
 
     if (RB_TYPE_P(sub, T_REGEXP)) {
-        pos = str_offset(RSTRING_PTR(str), RSTRING_END(str), pos,
+        pos = str_offset(RSTRING_START(str), RSTRING_END(str), pos,
                          enc, single_byte_optimizable(str));
 
         if (rb_reg_search(sub, str, pos, 0) >= 0) {
@@ -4886,7 +4886,7 @@ rb_str_rindex_m(int argc, VALUE *argv, VALUE str)
 
     if (RB_TYPE_P(sub, T_REGEXP)) {
         /* enc = rb_enc_check(str, sub); */
-        pos = str_offset(RSTRING_PTR(str), RSTRING_END(str), pos,
+        pos = str_offset(RSTRING_START(str), RSTRING_END(str), pos,
                          enc, single_byte_optimizable(str));
 
         if (rb_reg_search(sub, str, pos, 1) >= 0) {
@@ -5904,12 +5904,12 @@ rb_str_update(VALUE str, long beg, long len, VALUE val)
     if (len > slen - beg) {
         len = slen - beg;
     }
-    p = str_nth(RSTRING_PTR(str), RSTRING_END(str), beg, enc, singlebyte);
+    p = str_nth(RSTRING_START(str), RSTRING_END(str), beg, enc, singlebyte);
     if (!p) p = RSTRING_END(str);
     e = str_nth(p, RSTRING_END(str), len, enc, singlebyte);
     if (!e) e = RSTRING_END(str);
     /* error check */
-    beg = p - RSTRING_PTR(str);	/* physical position */
+    beg = p - RSTRING_START(str);	/* physical position */
     len = e - p;		/* physical length */
     rb_str_update_0(str, beg, len, val);
     rb_enc_associate(str, enc);
@@ -11104,8 +11104,7 @@ static VALUE
 rb_str_ord(VALUE s)
 {
     unsigned int c;
-
-    c = rb_enc_codepoint(RSTRING_PTR(s), RSTRING_END(s), STR_ENC_GET(s));
+    c = rb_enc_codepoint(RSTRING_START(s), RSTRING_END(s), STR_ENC_GET(s));
     return UINT2NUM(c);
 }
 /*

--- a/string.c
+++ b/string.c
@@ -1833,7 +1833,7 @@ str_shared_replace(VALUE str, VALUE str2)
 
         STR_SET_NOEMBED(str);
         FL_UNSET(str, STR_SHARED);
-        RSTRING(str)->as.heap.ptr = RSTRING_PTR(str2);
+        RSTRING(str)->as.heap.ptr = RSTRING_START(str2);
 
         if (FL_TEST(str2, STR_SHARED)) {
             VALUE shared = RSTRING(str2)->as.heap.aux.shared;
@@ -1883,7 +1883,7 @@ str_replace(VALUE str, VALUE str2)
         RUBY_ASSERT(OBJ_FROZEN(shared));
         STR_SET_NOEMBED(str);
         STR_SET_LEN(str, len);
-        RSTRING(str)->as.heap.ptr = RSTRING_PTR(str2);
+        RSTRING(str)->as.heap.ptr = RSTRING_START(str2);
         STR_SET_SHARED(str, shared);
         rb_enc_cr_str_exact_copy(str, str2);
     }

--- a/string.c
+++ b/string.c
@@ -178,8 +178,8 @@ VALUE rb_cSymbol;
 
 #define STR_SET_SHARED(str, shared_str) do { \
     if (!FL_TEST(str, STR_FAKESTR)) { \
-        RUBY_ASSERT(RSTRING_PTR(shared_str) <= RSTRING_PTR(str)); \
-        RUBY_ASSERT(RSTRING_PTR(str) <= RSTRING_PTR(shared_str) + RSTRING_LEN(shared_str)); \
+        RUBY_ASSERT(RSTRING_START(shared_str) <= RSTRING_START(str)); \
+        RUBY_ASSERT(RSTRING_START(str) <= RSTRING_START(shared_str) + RSTRING_LEN(shared_str)); \
         RB_OBJ_WRITE((str), &RSTRING(str)->as.heap.aux.shared, (shared_str)); \
         FL_SET((str), STR_SHARED); \
         rb_gc_register_pinning_obj(str); \
@@ -1462,18 +1462,18 @@ str_replace_shared_without_enc(VALUE str2, VALUE str)
     char *ptr;
     long len;
 
-    RSTRING_GETMEM(str, ptr, len);
+    ptr = RSTRING_START(str);
+    len = RSTRING_LEN(str);
     if (str_embed_capa(str2) >= len + termlen) {
         char *ptr2 = RSTRING(str2)->as.embed.ary;
         STR_SET_EMBED(str2);
-        memcpy(ptr2, RSTRING_PTR(str), len);
+        memcpy(ptr2, ptr, len);
         TERM_FILL(ptr2+len, termlen);
     }
     else {
         VALUE root;
         if (STR_SHARED_P(str)) {
             root = RSTRING(str)->as.heap.aux.shared;
-            RSTRING_GETMEM(str, ptr, len);
         }
         else {
             root = rb_str_new_frozen(str);

--- a/string.c
+++ b/string.c
@@ -2973,7 +2973,7 @@ rb_str_fill_terminator(VALUE str, const int newminlen)
 }
 
 char *
-rbimpl_str_ptr_guarantee_null_term(VALUE str)
+rbimpl_str_ensure_terminator(VALUE str)
 {
     RUBY_ASSERT(FL_TEST_RAW(str, STR_NOEMBED | STR_SHARED));
 

--- a/string.c
+++ b/string.c
@@ -2978,9 +2978,9 @@ rbimpl_str_ensure_terminator(VALUE str)
     RUBY_ASSERT(FL_TEST_RAW(str, STR_NOEMBED | STR_SHARED));
 
     if (!ruby_thread_has_gvl_p()) {
-        /* We are inside the GC and cannot allocate.  Return the raw pointer;
-         * any null-termination guarantee is relaxed in this context (the
-         * pointer is only used for diagnostic display, not C-string APIs). */
+        /* We don't hold the GVL. Calling str_make_independent_expand without
+         * it would modify shared object state without synchronization.
+         * Return the raw pointer; null-termination is not guaranteed. */
         return RSTRING(str)->as.heap.ptr;
     }
 
@@ -2989,7 +2989,8 @@ rbimpl_str_ensure_terminator(VALUE str)
     char *ptr = RSTRING(str)->as.heap.ptr;
 
     if (zero_filled(ptr + len, termlen)) return ptr;
-    return str_fill_term(str, ptr, len, termlen);
+    str_make_independent_expand(str, len, 0L, termlen);
+    return RSTRING_START(str);
 }
 
 VALUE

--- a/string.c
+++ b/string.c
@@ -914,7 +914,7 @@ rb_enc_cr_str_copy_for_substr(VALUE dest, VALUE src)
         break;
       case ENC_CODERANGE_VALID:
         if (!rb_enc_asciicompat(STR_ENC_GET(src)) ||
-            search_nonascii(RSTRING_START(dest), RSTRING_END(dest)))
+            search_nonascii(RSTRING_PTR(dest), RSTRING_END(dest)))
             ENC_CODERANGE_SET(dest, ENC_CODERANGE_VALID);
         else
             ENC_CODERANGE_SET(dest, ENC_CODERANGE_7BIT);
@@ -3147,7 +3147,7 @@ str_offset(const char *p, const char *e, long nth, rb_encoding *enc, int singleb
 long
 rb_str_offset(VALUE str, long pos)
 {
-    return str_offset(RSTRING_START(str), RSTRING_END(str), pos,
+    return str_offset(RSTRING_PTR(str), RSTRING_END(str), pos,
                       STR_ENC_GET(str), single_byte_optimizable(str));
 }
 
@@ -4678,7 +4678,7 @@ rb_str_index_m(int argc, VALUE *argv, VALUE str)
     }
 
     if (RB_TYPE_P(sub, T_REGEXP)) {
-        pos = str_offset(RSTRING_START(str), RSTRING_END(str), pos,
+        pos = str_offset(RSTRING_PTR(str), RSTRING_END(str), pos,
                          enc, single_byte_optimizable(str));
 
         if (rb_reg_search(sub, str, pos, 0) >= 0) {
@@ -4934,7 +4934,7 @@ rb_str_rindex_m(int argc, VALUE *argv, VALUE str)
 
     if (RB_TYPE_P(sub, T_REGEXP)) {
         /* enc = rb_enc_check(str, sub); */
-        pos = str_offset(RSTRING_START(str), RSTRING_END(str), pos,
+        pos = str_offset(RSTRING_PTR(str), RSTRING_END(str), pos,
                          enc, single_byte_optimizable(str));
 
         if (rb_reg_search(sub, str, pos, 1) >= 0) {
@@ -5952,12 +5952,12 @@ rb_str_update(VALUE str, long beg, long len, VALUE val)
     if (len > slen - beg) {
         len = slen - beg;
     }
-    p = str_nth(RSTRING_START(str), RSTRING_END(str), beg, enc, singlebyte);
+    p = str_nth(RSTRING_PTR(str), RSTRING_END(str), beg, enc, singlebyte);
     if (!p) p = RSTRING_END(str);
     e = str_nth(p, RSTRING_END(str), len, enc, singlebyte);
     if (!e) e = RSTRING_END(str);
     /* error check */
-    beg = p - RSTRING_START(str);	/* physical position */
+    beg = p - RSTRING_PTR(str);	/* physical position */
     len = e - p;		/* physical length */
     rb_str_update_0(str, beg, len, val);
     rb_enc_associate(str, enc);
@@ -11151,7 +11151,8 @@ static VALUE
 rb_str_ord(VALUE s)
 {
     unsigned int c;
-    c = rb_enc_codepoint(RSTRING_START(s), RSTRING_END(s), STR_ENC_GET(s));
+
+    c = rb_enc_codepoint(RSTRING_PTR(s), RSTRING_END(s), STR_ENC_GET(s));
     return UINT2NUM(c);
 }
 /*

--- a/string.c
+++ b/string.c
@@ -205,7 +205,7 @@ zero_filled(const char *s, int n)
 }
 
 #if !defined SHARABLE_MIDDLE_SUBSTRING
-# define SHARABLE_MIDDLE_SUBSTRING 0
+# define SHARABLE_MIDDLE_SUBSTRING 1
 #endif
 
 static inline bool
@@ -1962,7 +1962,7 @@ str_duplicate_setup_heap(VALUE klass, VALUE str, VALUE dup)
     RUBY_ASSERT(!STR_SHARED_P(root));
     RUBY_ASSERT(RB_OBJ_FROZEN_RAW(root));
 
-    RSTRING(dup)->as.heap.ptr = RSTRING_PTR(str);
+    RSTRING(dup)->as.heap.ptr = RSTRING_START(str);
     FL_SET_RAW(dup, RSTRING_NOEMBED);
     STR_SET_SHARED(dup, root);
     flags |= RSTRING_NOEMBED | STR_SHARED;
@@ -2718,7 +2718,7 @@ str_make_independent_expand(VALUE str, long len, long expand, const int termlen)
     }
 
     ptr = ALLOC_N(char, (size_t)capa + termlen);
-    oldptr = RSTRING_PTR(str);
+    oldptr = RSTRING_START(str);
     if (oldptr) {
         memcpy(ptr, oldptr, len);
     }
@@ -2851,7 +2851,7 @@ str_fill_term(VALUE str, char *s, long len, int termlen)
         TERM_FILL(s + len, termlen);
         return s;
     }
-    return RSTRING_PTR(str);
+    return RSTRING_START(str);
 }
 
 void
@@ -2886,7 +2886,7 @@ rb_str_change_terminator_length(VALUE str, const int oldtermlen, const int terml
 static char *
 str_null_check(VALUE str, int *w)
 {
-    char *s = RSTRING_PTR(str);
+    char *s = RSTRING_START(str);
     long len = RSTRING_LEN(str);
     int minlen = 1;
 
@@ -2967,9 +2967,29 @@ str_to_cstr(VALUE str)
 char *
 rb_str_fill_terminator(VALUE str, const int newminlen)
 {
-    char *s = RSTRING_PTR(str);
+    char *s = RSTRING_START(str);
     long len = RSTRING_LEN(str);
     return str_fill_term(str, s, len, newminlen);
+}
+
+char *
+rbimpl_str_ptr_guarantee_null_term(VALUE str)
+{
+    RUBY_ASSERT(FL_TEST_RAW(str, STR_NOEMBED | STR_SHARED));
+
+    if (!ruby_thread_has_gvl_p()) {
+        /* We are inside the GC and cannot allocate.  Return the raw pointer;
+         * any null-termination guarantee is relaxed in this context (the
+         * pointer is only used for diagnostic display, not C-string APIs). */
+        return RSTRING(str)->as.heap.ptr;
+    }
+
+    int termlen = TERM_LEN(str);
+    long len = RSTRING_LEN(str);
+    char *ptr = RSTRING(str)->as.heap.ptr;
+
+    if (zero_filled(ptr + len, termlen)) return ptr;
+    return str_fill_term(str, ptr, len, termlen);
 }
 
 VALUE

--- a/string.c
+++ b/string.c
@@ -1778,6 +1778,22 @@ ephemeral_term_cleanup(VALUE str)
     if (deleted) ruby_mimfree((void *)buf);
 }
 
+static int
+ephemeral_term_free_i(st_data_t str, st_data_t buf, st_data_t arg)
+{
+    ruby_mimfree((void *)buf);
+    return ST_CONTINUE;
+}
+
+void
+rb_free_ephemeral_term_table(void)
+{
+    st_foreach(ephemeral_term_table, ephemeral_term_free_i, 0);
+    RUBY_ATOMIC_SET(ephemeral_term_count, 0);
+    st_free_table(ephemeral_term_table);
+    ephemeral_term_table = NULL;
+}
+
 void
 rb_str_free(VALUE str)
 {

--- a/test/ruby/test_string.rb
+++ b/test/ruby/test_string.rb
@@ -3496,23 +3496,39 @@ CODE
   end
 
   def test_shared_middle_string_terminator
-    ten = "0123456789"
-    hundred = ten * 10
-    str = "#{hundred}\0#{hundred}".freeze
-
     require 'objspace'
+    thousand = "0123456789" * 100
+    str = "#{thousand}\0#{thousand}".freeze
 
-    substr = str.byteslice(0, hundred.bytesize)
-    assert_equal hundred, substr
+    # str[1000] == '\0' satisfies the 1-byte terminator naturally.
+    substr = str.byteslice(0, thousand.bytesize)
+    assert_equal thousand, substr
     assert_includes ObjectSpace.dump(substr), ' "shared":true,'
 
-    # Larger terminator
-    substr.force_encoding(Encoding::UTF_16BE)
-    assert_equal hundred.dup.force_encoding(Encoding::UTF_16BE), substr
-    refute_includes ObjectSpace.dump(substr), ' "shared":true,'
+    # str[1001] == '0' != '\0': no natural terminator, but still shared under
+    # SHARABLE_MIDDLE_SUBSTRING; ensure_terminator handles it lazily on RSTRING_PTR.
+    substr = str.byteslice(0, thousand.bytesize + 1)
+    assert_equal thousand + "\0", substr
+    assert_includes ObjectSpace.dump(substr), ' "shared":true,'
+  end
 
-    substr = str.byteslice(0, hundred.bytesize + 1)
-    assert_equal hundred + "\0", substr
+  def test_embedded_middle_string_terminator
+    require 'objspace'
+    hundred = "0123456789" * 10
+    str = "#{hundred}\0#{hundred}".freeze
+    substr = str.byteslice(0, hundred.bytesize)
+    assert_equal hundred, substr
+    assert_includes ObjectSpace.dump(substr), ' "embedded":true,'
+  end
+
+  def test_shared_middle_string_larger_terminator
+    require 'objspace'
+    thousand = "0123456789" * 100
+    str = "#{thousand}\0#{thousand}".freeze
+    substr = str.byteslice(0, thousand.bytesize)
+    assert_includes ObjectSpace.dump(substr), ' "shared":true,'
+    substr.force_encoding(Encoding::UTF_16BE)
+    assert_equal thousand.dup.force_encoding(Encoding::UTF_16BE), substr
     refute_includes ObjectSpace.dump(substr), ' "shared":true,'
   end
 

--- a/vm.c
+++ b/vm.c
@@ -3425,6 +3425,7 @@ ruby_vm_destruct(rb_vm_t *vm)
         if (rb_free_at_exit) {
             rb_free_encoded_insn_data();
             rb_free_global_enc_table();
+            rb_free_ephemeral_term_table();
             rb_free_loaded_builtin_table();
             rb_free_global_symbol_table();
 


### PR DESCRIPTION
### Summary

This is a PoC for enabling `SHARABLE_MIDDLE_SUBSTRING=1` (proposed in https://bugs.ruby-lang.org/issues/19315), which allows zero-copy shared substrings for arbitrary ranges (not just tail ranges).

The key challenge is that a shared middle substring may not have a null terminator at `ptr[len]`, so `RSTRING_PTR()` must lazily ensure termination before returning the pointer. This PoC implements that guarantee.

### Thinking

`RSTRING_GETMEM` internally calls `RSTRING_PTR()`, so callers that only need the pointer+length (no null termination) also pay the overhead. A `RSTRING_GETMEM_START` variant could be added to allow gradual migration of internal callers, while keeping `RSTRING_GETMEM` for backward compatibility with C extensions.

### Testing

Existing tests pass without modification. No new test cases are added in this PoC; proper coverage for middle-shared substrings and multi-byte terminators should be added before merging.