### PR TITLE
Use `inputs.archname` instead of `snapshot-*` for Ruby 4.0

### DIFF
--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           set -x
           curl -sSL "${RUBY_PATCH_URL}" -o ruby.patch
-          cd snapshot-*/
+          cd "${{ inputs.archname }}/"
           git apply ../ruby.patch
         shell: bash
         env:
@@ -71,26 +71,26 @@ jobs:
         run: |
           echo "JOBS=-j$((1 + $(sysctl -n hw.activecpu)))" >> $GITHUB_ENV
       - name: configure
-        run: cd snapshot-*/ && ./configure --with-openssl-dir=$(brew --prefix openssl@1.1) --with-readline-dir=$(brew --prefix readline) --with-libyaml-dir=$(brew --prefix libyaml)
+        run: cd "${{ inputs.archname }}/" && ./configure --with-openssl-dir=$(brew --prefix openssl@1.1) --with-readline-dir=$(brew --prefix readline) --with-libyaml-dir=$(brew --prefix libyaml)
       - name: make
-        run: cd snapshot-*/ && make $JOBS
+        run: cd "${{ inputs.archname }}/" && make $JOBS
       - name: Reinstall Homebrew Ruby
         run: brew install ruby
         if: inputs.rebuild-homebrew-ruby && matrix.os == 'macos-15-intel' && (matrix.test_task == 'test-bundled-gems' || matrix.test_task == 'test-bundler-parallel')
       - name: Tests
-        run: cd snapshot-*/ && make $JOBS -s ${{ matrix.test_task }}
+        run: cd "${{ inputs.archname }}/" && make $JOBS -s ${{ matrix.test_task }}
         env:
           RUBY_TESTOPTS: "-q --tty=no"
           RUBY_DEBUG_TEST_NO_REMOTE: "1"
       # leaked-globals since 2.7
       - name: Leaked Globals
-        run: cd snapshot-*/ && make -s leaked-globals
+        run: cd "${{ inputs.archname }}/" && make -s leaked-globals
         if: matrix.test_task == 'check'
       - name: make install without root privilege
-        run: cd snapshot-*/ && make $JOBS install DESTDIR="/tmp/destdir"
+        run: cd "${{ inputs.archname }}/" && make $JOBS install DESTDIR="/tmp/destdir"
         if: matrix.test_task == 'check'
       - name: make install
-        run: cd snapshot-*/ && sudo make $JOBS install
+        run: cd "${{ inputs.archname }}/" && sudo make $JOBS install
         if: matrix.test_task == 'check'
       - name: ruby -v
         run: /usr/local/bin/ruby -v

--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -35,6 +35,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
+      ARCHNAME: ${{ inputs.archname }}
       TEST_BUNDLED_GEMS_ALLOW_FAILURES: ${{ inputs.allow-failures }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -47,7 +48,7 @@ jobs:
         run: |
           set -x
           curl -sSL "${RUBY_PATCH_URL}" -o ruby.patch
-          cd "${{ inputs.archname }}/"
+          cd "$ARCHNAME/"
           git apply ../ruby.patch
         shell: bash
         env:
@@ -71,26 +72,26 @@ jobs:
         run: |
           echo "JOBS=-j$((1 + $(sysctl -n hw.activecpu)))" >> $GITHUB_ENV
       - name: configure
-        run: cd "${{ inputs.archname }}/" && ./configure --with-openssl-dir=$(brew --prefix openssl@1.1) --with-readline-dir=$(brew --prefix readline) --with-libyaml-dir=$(brew --prefix libyaml)
+        run: cd "$ARCHNAME/" && ./configure --with-openssl-dir=$(brew --prefix openssl@1.1) --with-readline-dir=$(brew --prefix readline) --with-libyaml-dir=$(brew --prefix libyaml)
       - name: make
-        run: cd "${{ inputs.archname }}/" && make $JOBS
+        run: cd "$ARCHNAME/" && make $JOBS
       - name: Reinstall Homebrew Ruby
         run: brew install ruby
         if: inputs.rebuild-homebrew-ruby && matrix.os == 'macos-15-intel' && (matrix.test_task == 'test-bundled-gems' || matrix.test_task == 'test-bundler-parallel')
       - name: Tests
-        run: cd "${{ inputs.archname }}/" && make $JOBS -s ${{ matrix.test_task }}
+        run: cd "$ARCHNAME/" && make $JOBS -s ${{ matrix.test_task }}
         env:
           RUBY_TESTOPTS: "-q --tty=no"
           RUBY_DEBUG_TEST_NO_REMOTE: "1"
       # leaked-globals since 2.7
       - name: Leaked Globals
-        run: cd "${{ inputs.archname }}/" && make -s leaked-globals
+        run: cd "$ARCHNAME/" && make -s leaked-globals
         if: matrix.test_task == 'check'
       - name: make install without root privilege
-        run: cd "${{ inputs.archname }}/" && make $JOBS install DESTDIR="/tmp/destdir"
+        run: cd "$ARCHNAME/" && make $JOBS install DESTDIR="/tmp/destdir"
         if: matrix.test_task == 'check'
       - name: make install
-        run: cd "${{ inputs.archname }}/" && sudo make $JOBS install
+        run: cd "$ARCHNAME/" && sudo make $JOBS install
         if: matrix.test_task == 'check'
       - name: ruby -v
         run: /usr/local/bin/ruby -v

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -62,6 +62,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
+      ARCHNAME: ${{ inputs.archname }}
       TEST_BUNDLED_GEMS_ALLOW_FAILURES: ${{ inputs.allow-failures }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -74,7 +75,7 @@ jobs:
         run: |
           set -x
           curl -sSL "${RUBY_PATCH_URL}" -o ruby.patch
-          cd "${{ inputs.archname }}/"
+          cd "$ARCHNAME/"
           git apply ../ruby.patch
         shell: bash
         env:
@@ -154,13 +155,13 @@ jobs:
         run: |
           echo "JOBS=-j$((1 + $(nproc --all)))" >> $GITHUB_ENV
       - name: configure
-        run: cd "${{ inputs.archname }}/" && ./configure
+        run: cd "$ARCHNAME/" && ./configure
       - name: make
-        run: cd "${{ inputs.archname }}/" && make $JOBS
+        run: cd "$ARCHNAME/" && make $JOBS
       - name: Save stats of HOME
         run: |
           set -euxo pipefail
-          cd "${{ inputs.archname }}/"
+          cd "$ARCHNAME/"
           cat >test.rb <<'EOF'
           require 'pathname'
           require 'digest'
@@ -187,7 +188,7 @@ jobs:
           make runruby
           rm -f test.rb
       - name: Tests
-        run: cd "${{ inputs.archname }}/" && make $JOBS -s ${{ matrix.test_task }}
+        run: cd "$ARCHNAME/" && make $JOBS -s ${{ matrix.test_task }}
         env:
           RUBY_TESTOPTS: "-q --tty=no"
       # not sure why ~/.gnupg is remained
@@ -198,7 +199,7 @@ jobs:
       - name: Diff stats of HOME
         run: |
           set -euxo pipefail
-          cd "${{ inputs.archname }}/"
+          cd "$ARCHNAME/"
           cat >test.rb <<'EOF'
           require 'pathname'
           require 'digest'
@@ -227,13 +228,13 @@ jobs:
           diff -u /tmp/stat-before-tests.txt /tmp/stat-after-tests.txt
       # leaked-globals since 2.7
       - name: Leaked Globals
-        run: cd "${{ inputs.archname }}/" && make -s leaked-globals
+        run: cd "$ARCHNAME/" && make -s leaked-globals
         if: matrix.test_task == 'check'
       - name: make install without root privilege
-        run: cd "${{ inputs.archname }}/" && make $JOBS install DESTDIR="/tmp/destdir"
+        run: cd "$ARCHNAME/" && make $JOBS install DESTDIR="/tmp/destdir"
         if: matrix.test_task == 'check'
       - name: make install
-        run: cd "${{ inputs.archname }}/" && sudo make $JOBS install
+        run: cd "$ARCHNAME/" && sudo make $JOBS install
         if: matrix.test_task == 'check'
       - name: ruby -v
         env:
@@ -256,7 +257,7 @@ jobs:
         if: failure() && github.event_name == 'schedule'
       - name: Get ruby/ruby sha
         id: ruby_sha
-        run: cd "${{ inputs.archname }}/" && ./ruby -e 'puts "sha=#{RUBY_REVISION}"' >> $GITHUB_OUTPUT
+        run: cd "$ARCHNAME/" && ./ruby -e 'puts "sha=#{RUBY_REVISION}"' >> $GITHUB_OUTPUT
         if: failure() && inputs.notify-ruby-sha && github.event_name == 'schedule'
       - uses: ruby/action-slack@54175162371f1f7c8eb94d7c8644ee2479fcd375 # v3.2.2
         with:

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           set -x
           curl -sSL "${RUBY_PATCH_URL}" -o ruby.patch
-          cd snapshot-*/
+          cd "${{ inputs.archname }}/"
           git apply ../ruby.patch
         shell: bash
         env:
@@ -154,13 +154,13 @@ jobs:
         run: |
           echo "JOBS=-j$((1 + $(nproc --all)))" >> $GITHUB_ENV
       - name: configure
-        run: cd snapshot-*/ && ./configure
+        run: cd "${{ inputs.archname }}/" && ./configure
       - name: make
-        run: cd snapshot-*/ && make $JOBS
+        run: cd "${{ inputs.archname }}/" && make $JOBS
       - name: Save stats of HOME
         run: |
           set -euxo pipefail
-          cd snapshot-*/
+          cd "${{ inputs.archname }}/"
           cat >test.rb <<'EOF'
           require 'pathname'
           require 'digest'
@@ -187,7 +187,7 @@ jobs:
           make runruby
           rm -f test.rb
       - name: Tests
-        run: cd snapshot-*/ && make $JOBS -s ${{ matrix.test_task }}
+        run: cd "${{ inputs.archname }}/" && make $JOBS -s ${{ matrix.test_task }}
         env:
           RUBY_TESTOPTS: "-q --tty=no"
       # not sure why ~/.gnupg is remained
@@ -198,7 +198,7 @@ jobs:
       - name: Diff stats of HOME
         run: |
           set -euxo pipefail
-          cd snapshot-*/
+          cd "${{ inputs.archname }}/"
           cat >test.rb <<'EOF'
           require 'pathname'
           require 'digest'
@@ -227,13 +227,13 @@ jobs:
           diff -u /tmp/stat-before-tests.txt /tmp/stat-after-tests.txt
       # leaked-globals since 2.7
       - name: Leaked Globals
-        run: cd snapshot-*/ && make -s leaked-globals
+        run: cd "${{ inputs.archname }}/" && make -s leaked-globals
         if: matrix.test_task == 'check'
       - name: make install without root privilege
-        run: cd snapshot-*/ && make $JOBS install DESTDIR="/tmp/destdir"
+        run: cd "${{ inputs.archname }}/" && make $JOBS install DESTDIR="/tmp/destdir"
         if: matrix.test_task == 'check'
       - name: make install
-        run: cd snapshot-*/ && sudo make $JOBS install
+        run: cd "${{ inputs.archname }}/" && sudo make $JOBS install
         if: matrix.test_task == 'check'
       - name: ruby -v
         env:
@@ -256,7 +256,7 @@ jobs:
         if: failure() && github.event_name == 'schedule'
       - name: Get ruby/ruby sha
         id: ruby_sha
-        run: cd snapshot-*/ && ./ruby -e 'puts "sha=#{RUBY_REVISION}"' >> $GITHUB_OUTPUT
+        run: cd "${{ inputs.archname }}/" && ./ruby -e 'puts "sha=#{RUBY_REVISION}"' >> $GITHUB_OUTPUT
         if: failure() && inputs.notify-ruby-sha && github.event_name == 'schedule'
       - uses: ruby/action-slack@54175162371f1f7c8eb94d7c8644ee2479fcd375 # v3.2.2
         with:


### PR DESCRIPTION
for reusing them from `draft-release.yml`