### PR TITLE
ZJIT: Split Class, prefer profile information

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -3323,10 +3323,18 @@ impl Function {
     /// - `StaticallyKnown` if the receiver's exact class is known at compile-time
     /// - Result of [`Self::resolve_receiver_type_from_profile`] if we need to check profile data
     fn resolve_receiver_type(&self, recv: InsnId, recv_type: Type, insn_idx: YarvInsnIdx) -> ReceiverTypeResolution {
-        if let Some(class) = recv_type.runtime_exact_ruby_class() {
-            return ReceiverTypeResolution::StaticallyKnown { class };
+        match self.resolve_receiver_type_from_profile(recv, insn_idx) {
+            ReceiverTypeResolution::NoProfile => {
+                // Use known type information as a fallback because it doesn't have shape
+                // information (and we can generally eliminate duplicate guards).
+                if let Some(class) = recv_type.runtime_exact_ruby_class() {
+                    ReceiverTypeResolution::StaticallyKnown { class }
+                } else {
+                    ReceiverTypeResolution::NoProfile
+                }
+            }
+            resolution => resolution,
         }
-        self.resolve_receiver_type_from_profile(recv, insn_idx)
     }
 
     fn polymorphic_summary(&self, profiles: &ProfileOracle, recv: InsnId, insn_idx: YarvInsnIdx) -> Option<TypeDistributionSummary> {

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -222,13 +222,13 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v14:Fixnum[0] = Const Value(0)
           PatchPoint MethodRedefined(Integer@0x1008, *@0x1010, cme:0x1018)
-          v35:Fixnum = GuardType v10, Fixnum
-          v44:Fixnum[0] = Const Value(0)
-          v45:Fixnum[0] = Const Value(0)
-          PatchPoint MethodRedefined(Integer@0x1008, +@0x1040, cme:0x1048)
+          v36:Fixnum = GuardType v10, Fixnum
           v46:Fixnum[0] = Const Value(0)
+          v47:Fixnum[0] = Const Value(0)
+          PatchPoint MethodRedefined(Integer@0x1008, +@0x1040, cme:0x1048)
+          v48:Fixnum[0] = Const Value(0)
           CheckInterrupts
-          Return v46
+          Return v48
         ");
     }
 
@@ -608,9 +608,9 @@ mod hir_opt_tests {
           v10:Fixnum[4] = Const Value(4)
           v12:Fixnum[-7] = Const Value(-7)
           PatchPoint MethodRedefined(Integer@0x1000, &@0x1008, cme:0x1010)
-          v24:Fixnum[0] = Const Value(0)
+          v25:Fixnum[0] = Const Value(0)
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -637,9 +637,9 @@ mod hir_opt_tests {
           v10:Fixnum[-4] = Const Value(-4)
           v12:Fixnum[7] = Const Value(7)
           PatchPoint MethodRedefined(Integer@0x1000, &@0x1008, cme:0x1010)
-          v24:Fixnum[4] = Const Value(4)
+          v25:Fixnum[4] = Const Value(4)
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -666,9 +666,9 @@ mod hir_opt_tests {
           v10:Fixnum[4] = Const Value(4)
           v12:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, |@0x1008, cme:0x1010)
-          v24:Fixnum[5] = Const Value(5)
+          v25:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -695,9 +695,9 @@ mod hir_opt_tests {
           v10:Fixnum[-4] = Const Value(-4)
           v12:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1000, |@0x1008, cme:0x1010)
-          v24:Fixnum[-3] = Const Value(-3)
+          v25:Fixnum[-3] = Const Value(-3)
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -724,9 +724,9 @@ mod hir_opt_tests {
           v10:Fixnum[4] = Const Value(4)
           v12:Fixnum[-1] = Const Value(-1)
           PatchPoint MethodRedefined(Integer@0x1000, |@0x1008, cme:0x1010)
-          v24:Fixnum[-1] = Const Value(-1)
+          v25:Fixnum[-1] = Const Value(-1)
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -1904,10 +1904,10 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v14:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
-          v27:Fixnum = FixnumAdd v14, v26
+          v27:Fixnum = GuardType v10, Fixnum
+          v28:Fixnum = FixnumAdd v14, v27
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -2104,10 +2104,10 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           v14:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, <@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
-          v27:BoolExact = FixnumLt v14, v26
+          v27:Fixnum = GuardType v10, Fixnum
+          v28:BoolExact = FixnumLt v14, v27
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -3209,7 +3209,7 @@ mod hir_opt_tests {
           v29:ModuleExact[M@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(Module@0x1010)
           PatchPoint MethodRedefined(Module@0x1010, name@0x1018, cme:0x1020)
-          v33:StringExact|NilClass = CCall v29, :Module#name@0x1048
+          v34:StringExact|NilClass = CCall v29, :Module#name@0x1048
           PatchPoint NoEPEscape(test)
           v21:Fixnum[1] = Const Value(1)
           CheckInterrupts
@@ -3577,9 +3577,9 @@ mod hir_opt_tests {
           v20:ModuleExact[M@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(Module@0x1010)
           PatchPoint MethodRedefined(Module@0x1010, class@0x1018, cme:0x1020)
-          v25:ClassSubclass[Module@0x1010] = Const Value(VALUE(0x1010))
+          v26:ClassSubclass[Module@0x1010] = Const Value(VALUE(0x1010))
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -4454,7 +4454,7 @@ mod hir_opt_tests {
           v46:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, initialize@0x1038, cme:0x1040)
-          v50:NilClass = Const Value(nil)
+          v51:NilClass = Const Value(nil)
           CheckInterrupts
           Return v46
         ");
@@ -4491,7 +4491,7 @@ mod hir_opt_tests {
           v49:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, initialize@0x1038, cme:0x1040)
-          v52:BasicObject = SendDirect v49, 0x1068, :initialize (0x1078), v15
+          v53:BasicObject = SendDirect v49, 0x1068, :initialize (0x1078), v15
           CheckInterrupts
           Return v49
         ");
@@ -4522,7 +4522,7 @@ mod hir_opt_tests {
           v46:ObjectExact = ObjectAllocClass Object:VALUE(0x1008)
           PatchPoint NoSingletonClass(Object@0x1008)
           PatchPoint MethodRedefined(Object@0x1008, initialize@0x1038, cme:0x1040)
-          v50:NilClass = Const Value(nil)
+          v51:NilClass = Const Value(nil)
           CheckInterrupts
           Return v46
         ");
@@ -4553,7 +4553,7 @@ mod hir_opt_tests {
           v46:BasicObjectExact = ObjectAllocClass BasicObject:VALUE(0x1008)
           PatchPoint NoSingletonClass(BasicObject@0x1008)
           PatchPoint MethodRedefined(BasicObject@0x1008, initialize@0x1038, cme:0x1040)
-          v50:NilClass = Const Value(nil)
+          v51:NilClass = Const Value(nil)
           CheckInterrupts
           Return v46
         ");
@@ -4585,7 +4585,7 @@ mod hir_opt_tests {
           v47:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, initialize@0x1038, cme:0x1040)
-          v51:BasicObject = SendDirect v46, 0x1068, :initialize (0x1078), v47
+          v52:BasicObject = SendDirect v46, 0x1068, :initialize (0x1078), v47
           CheckInterrupts
           Return v46
         ");
@@ -4616,9 +4616,9 @@ mod hir_opt_tests {
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Array@0x1008, new@0x1009, cme:0x1010)
           PatchPoint MethodRedefined(Class@0x1038, new@0x1009, cme:0x1010)
-          v52:BasicObject = CCallVariadic v46, :Array.new@0x1040, v15
+          v53:BasicObject = CCallVariadic v46, :Array.new@0x1040, v15
           CheckInterrupts
-          Return v52
+          Return v53
         ");
     }
 
@@ -4677,9 +4677,9 @@ mod hir_opt_tests {
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(String@0x1008, new@0x1009, cme:0x1010)
           PatchPoint MethodRedefined(Class@0x1038, new@0x1009, cme:0x1010)
-          v53:BasicObject = CCallVariadic v43, :String.new@0x1040
+          v54:BasicObject = CCallVariadic v43, :String.new@0x1040
           CheckInterrupts
-          Return v53
+          Return v54
         ");
     }
 
@@ -4710,7 +4710,7 @@ mod hir_opt_tests {
           v50:RegexpExact = ObjectAllocClass Regexp:VALUE(0x1008)
           PatchPoint NoSingletonClass(Regexp@0x1008)
           PatchPoint MethodRedefined(Regexp@0x1008, initialize@0x1048, cme:0x1050)
-          v54:BasicObject = CCallVariadic v50, :Regexp#initialize@0x1078, v16
+          v55:BasicObject = CCallVariadic v50, :Regexp#initialize@0x1078, v16
           CheckInterrupts
           Return v50
         ");
@@ -4738,9 +4738,9 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1000, C)
           v20:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Class@0x1010, allocate@0x1018, cme:0x1020)
-          v23:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
+          v24:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
           CheckInterrupts
-          Return v23
+          Return v24
         ");
     }
 
@@ -4798,9 +4798,9 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1000, SC)
           v20:ClassSubclass[Class@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Class@0x1010, allocate@0x1018, cme:0x1020)
-          v23:BasicObject = CCallWithFrame v20, :Class.allocate@0x1048
+          v24:BasicObject = CCallWithFrame v20, :Class.allocate@0x1048
           CheckInterrupts
-          Return v23
+          Return v24
         ");
     }
 
@@ -6367,8 +6367,8 @@ mod hir_opt_tests {
           v28:ArrayExact = GuardType v10, ArrayExact
           PatchPoint NoSingletonClass(Array@0x1010)
           PatchPoint MethodRedefined(Array@0x1010, to_s@0x1018, cme:0x1020)
-          v33:BasicObject = CCallWithFrame v28, :Array#to_s@0x1048
-          v20:String = AnyToString v28, str: v33
+          v34:BasicObject = CCallWithFrame v28, :Array#to_s@0x1048
+          v20:String = AnyToString v28, str: v34
           v22:StringExact = StringConcat v14, v20
           CheckInterrupts
           Return v22
@@ -6458,12 +6458,12 @@ mod hir_opt_tests {
           v12:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Array@0x1010)
           PatchPoint MethodRedefined(Array@0x1010, []@0x1018, cme:0x1020)
-          v34:CInt64[0] = Const CInt64(0)
-          v28:CInt64 = ArrayLength v23
-          v29:CInt64[0] = GuardLess v34, v28
-          v33:BasicObject = ArrayAref v23, v29
+          v35:CInt64[0] = Const CInt64(0)
+          v29:CInt64 = ArrayLength v23
+          v30:CInt64[0] = GuardLess v35, v29
+          v34:BasicObject = ArrayAref v23, v30
           CheckInterrupts
-          Return v33
+          Return v34
         ");
        // TODO(max): Check the result of `S[0] = 5; test` using `inspect` to make sure that we
        // actually do the load at run-time.
@@ -8443,9 +8443,9 @@ mod hir_opt_tests {
           v11:ArrayExact = ArrayDup v10
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, map@0x1010, cme:0x1018)
-          v21:BasicObject = SendDirect v11, 0x1040, :map (0x1050)
+          v22:BasicObject = SendDirect v11, 0x1040, :map (0x1050)
           CheckInterrupts
-          Return v21
+          Return v22
         ");
     }
 
@@ -8484,7 +8484,7 @@ mod hir_opt_tests {
           v41:ArrayExact[VALUE(0x1018)] = Const Value(VALUE(0x1018))
           PatchPoint NoSingletonClass(Array@0x1020)
           PatchPoint MethodRedefined(Array@0x1020, zip@0x1028, cme:0x1030)
-          v45:BasicObject = CCallVariadic v38, :Array#zip@0x1058, v41
+          v46:BasicObject = CCallVariadic v38, :Array#zip@0x1058, v41
           PatchPoint NoEPEscape(test)
           v24:CPtr = LoadSP
           v25:BasicObject = LoadField v24, :result@0x1060
@@ -8733,11 +8733,11 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, foo@0x1018, cme:0x1020)
-          v25:CShape = LoadField v20, :shape_id@0x1048
-          v26:CShape[0x1049] = GuardBitEquals v25, CShape(0x1049)
-          v27:NilClass = Const Value(nil)
+          v26:CShape = LoadField v20, :shape_id@0x1048
+          v27:CShape[0x1049] = GuardBitEquals v26, CShape(0x1049)
+          v28:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -8769,11 +8769,11 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, foo@0x1018, cme:0x1020)
-          v25:CShape = LoadField v20, :shape_id@0x1048
-          v26:CShape[0x1049] = GuardBitEquals v25, CShape(0x1049)
-          v27:NilClass = Const Value(nil)
+          v26:CShape = LoadField v20, :shape_id@0x1048
+          v27:CShape[0x1049] = GuardBitEquals v26, CShape(0x1049)
+          v28:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -9336,8 +9336,8 @@ mod hir_opt_tests {
           v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v28:Fixnum = GuardType v10, Fixnum
           PatchPoint MethodRedefined(Integer@0x1010, to_s@0x1018, cme:0x1020)
-          v32:StringExact = CCallVariadic v28, :Integer#to_s@0x1048
-          v22:StringExact = StringConcat v14, v32
+          v33:StringExact = CCallVariadic v28, :Integer#to_s@0x1048
+          v22:StringExact = StringConcat v14, v33
           CheckInterrupts
           Return v22
         ");
@@ -9582,9 +9582,9 @@ mod hir_opt_tests {
           v12:StaticSymbol[:a] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(Hash@0x1018)
           PatchPoint MethodRedefined(Hash@0x1018, []@0x1020, cme:0x1028)
-          v27:BasicObject = HashAref v23, v12
+          v28:BasicObject = HashAref v23, v12
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -9713,11 +9713,11 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1000, Thread)
           v20:ClassSubclass[Thread@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Class@0x1010, current@0x1018, cme:0x1020)
-          v23:CPtr = LoadEC
-          v24:CPtr = LoadField v23, :thread_ptr@0x1048
-          v25:BasicObject = LoadField v24, :self@0x1049
+          v24:CPtr = LoadEC
+          v25:CPtr = LoadField v24, :thread_ptr@0x1048
+          v26:BasicObject = LoadField v25, :self@0x1049
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -12402,9 +12402,9 @@ mod hir_opt_tests {
           v14:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1010, cme:0x1018)
-          v31:TrueClass = Const Value(true)
+          v32:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v31
+          Return v32
         ");
     }
 
@@ -12434,9 +12434,9 @@ mod hir_opt_tests {
           v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, ==@0x1018, cme:0x1020)
-          v27:FalseClass = Const Value(false)
+          v28:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -12467,9 +12467,9 @@ mod hir_opt_tests {
           v14:StringExact = StringCopy v13
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1010, cme:0x1018)
-          v26:BoolExact = StringEqual v11, v14
+          v27:BoolExact = StringEqual v11, v14
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -12500,9 +12500,9 @@ mod hir_opt_tests {
           v14:StringExact = StringCopy v13
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, ==@0x1018, cme:0x1020)
-          v26:BoolExact = StringEqual v11, v14
+          v27:BoolExact = StringEqual v11, v14
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -12532,9 +12532,9 @@ mod hir_opt_tests {
           v12:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1010, cme:0x1018)
-          v25:TrueClass = Const Value(true)
+          v26:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -12564,9 +12564,9 @@ mod hir_opt_tests {
           v12:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, ==@0x1018, cme:0x1020)
-          v25:FalseClass = Const Value(false)
+          v26:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -12606,13 +12606,13 @@ mod hir_opt_tests {
           v28:StringExact = StringCopy v27
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
-          v49:StringExact = StringAppend v17, v28
+          v50:StringExact = StringAppend v17, v28
           PatchPoint NoEPEscape(test)
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1040, cme:0x1048)
-          v53:BoolExact = StringEqual v17, v22
+          v55:BoolExact = StringEqual v17, v22
           CheckInterrupts
-          Return v53
+          Return v55
         ");
     }
 
@@ -12674,10 +12674,10 @@ mod hir_opt_tests {
           v15:StringExact = StringCopy v14
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, ==@0x1018, cme:0x1020)
-          v28:String = GuardType v10, String
-          v29:BoolExact = StringEqual v15, v28
+          v29:String = GuardType v10, String
+          v30:BoolExact = StringEqual v15, v29
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -12971,9 +12971,9 @@ mod hir_opt_tests {
           v27:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoEPEscape(test)
           PatchPoint MethodRedefined(Class@0x1018, ===@0x1020, cme:0x1028)
-          v30:BoolExact = IsA v10, v27
+          v31:BoolExact = IsA v10, v27
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -13002,9 +13002,9 @@ mod hir_opt_tests {
           v27:ModuleSubclass[Kernel@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoEPEscape(test)
           PatchPoint MethodRedefined(Module@0x1018, ===@0x1020, cme:0x1028)
-          v30:BoolExact = CCall v27, :Module#===@0x1050, v10
+          v31:BoolExact = CCall v27, :Module#===@0x1050, v10
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -13262,9 +13262,9 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1000, Integer)
           v22:ClassSubclass[Integer@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Integer@0x1008, is_a?@0x1009, cme:0x1010)
-          v26:TrueClass = Const Value(true)
+          v27:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -13290,9 +13290,9 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1000, String)
           v22:ClassSubclass[String@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Integer@0x1010, is_a?@0x1018, cme:0x1020)
-          v26:FalseClass = Const Value(false)
+          v27:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -13322,9 +13322,9 @@ mod hir_opt_tests {
           v25:ClassSubclass[Array@0x1018] = Const Value(VALUE(0x1018))
           PatchPoint NoSingletonClass(C@0x1020)
           PatchPoint MethodRedefined(C@0x1020, is_a?@0x1028, cme:0x1030)
-          v30:TrueClass = Const Value(true)
+          v31:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -13354,9 +13354,9 @@ mod hir_opt_tests {
           v25:ClassSubclass[C@0x1018] = Const Value(VALUE(0x1018))
           PatchPoint NoSingletonClass(C@0x1018)
           PatchPoint MethodRedefined(C@0x1018, is_a?@0x1019, cme:0x1020)
-          v30:TrueClass = Const Value(true)
+          v31:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -13384,9 +13384,9 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1010, Symbol)
           v25:ClassSubclass[Symbol@0x1018] = Const Value(VALUE(0x1018))
           PatchPoint MethodRedefined(Symbol@0x1018, is_a?@0x1019, cme:0x1020)
-          v29:TrueClass = Const Value(true)
+          v30:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -13510,7 +13510,7 @@ mod hir_opt_tests {
           v15:TrueClass = Const Value(true)
           PatchPoint MethodRedefined(Class@0x1040, respond_to?@0x1048, cme:0x1050)
           PatchPoint MethodRedefined(Class@0x1040, _lex_actions@0x1078, cme:0x1080)
-          v51:TrueClass = Const Value(true)
+          v52:TrueClass = Const Value(true)
           CheckInterrupts
           v26:StaticSymbol[:CORRECT] = Const Value(VALUE(0x10a8))
           Return v26
@@ -13543,9 +13543,9 @@ mod hir_opt_tests {
           v25:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
           v28:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Class@0x1040, name@0x1048, cme:0x1050)
-          v31:StringExact|NilClass = CCall v28, :Module#name@0x1078
+          v32:StringExact|NilClass = CCall v28, :Module#name@0x1078
           CheckInterrupts
-          Return v31
+          Return v32
         ");
     }
 
@@ -13598,9 +13598,9 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v10:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(Integer@0x1000, class@0x1008, cme:0x1010)
-          v21:ClassSubclass[Integer@0x1000] = Const Value(VALUE(0x1000))
+          v22:ClassSubclass[Integer@0x1000] = Const Value(VALUE(0x1000))
           CheckInterrupts
-          Return v21
+          Return v22
         ");
     }
 
@@ -13653,9 +13653,9 @@ mod hir_opt_tests {
           v12:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Array@0x1010)
           PatchPoint MethodRedefined(Array@0x1010, []@0x1018, cme:0x1020)
-          v36:ModuleExact[VALUE(0x1048)] = Const Value(VALUE(0x1048))
+          v37:ModuleExact[VALUE(0x1048)] = Const Value(VALUE(0x1048))
           CheckInterrupts
-          Return v36
+          Return v37
         ");
     }
 
@@ -13704,14 +13704,14 @@ mod hir_opt_tests {
          SetIvar v15, :@formatted, v16
          v47:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
          PatchPoint MethodRedefined(Class@0x1010, lambda@0x1018, cme:0x1020)
-         v62:BasicObject = CCallWithFrame v47, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
+         v63:BasicObject = CCallWithFrame v47, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
          v50:CPtr = GetEP 0
          v51:BasicObject = LoadField v50, :a@0x1001
          v52:BasicObject = LoadField v50, :_b@0x1002
          v53:BasicObject = LoadField v50, :_c@0x1058
          v54:BasicObject = LoadField v50, :formatted@0x1059
          CheckInterrupts
-         Return v62
+         Return v63
        ");
     }
 
@@ -13748,9 +13748,9 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestFrozen@0x1010)
           PatchPoint MethodRedefined(TestFrozen@0x1010, a@0x1018, cme:0x1020)
-          v29:Fixnum[1] = Const Value(1)
+          v30:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -13789,9 +13789,9 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestMultiIvars@0x1010)
           PatchPoint MethodRedefined(TestMultiIvars@0x1010, b@0x1018, cme:0x1020)
-          v29:Fixnum[20] = Const Value(20)
+          v30:Fixnum[20] = Const Value(20)
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -13828,9 +13828,9 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestFrozenStr@0x1010)
           PatchPoint MethodRedefined(TestFrozenStr@0x1010, name@0x1018, cme:0x1020)
-          v29:StringExact[VALUE(0x1048)] = Const Value(VALUE(0x1048))
+          v30:StringExact[VALUE(0x1048)] = Const Value(VALUE(0x1048))
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -13867,9 +13867,9 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestFrozenNil@0x1010)
           PatchPoint MethodRedefined(TestFrozenNil@0x1010, value@0x1018, cme:0x1020)
-          v29:NilClass = Const Value(nil)
+          v30:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -13906,11 +13906,11 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestUnfrozen@0x1010)
           PatchPoint MethodRedefined(TestUnfrozen@0x1010, a@0x1018, cme:0x1020)
-          v25:CShape = LoadField v20, :shape_id@0x1048
-          v26:CShape[0x1049] = GuardBitEquals v25, CShape(0x1049)
-          v27:BasicObject = LoadField v20, :@a@0x104a
+          v26:CShape = LoadField v20, :shape_id@0x1048
+          v27:CShape[0x1049] = GuardBitEquals v26, CShape(0x1049)
+          v28:BasicObject = LoadField v20, :@a@0x104a
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -13947,9 +13947,9 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestAttrReader@0x1010)
           PatchPoint MethodRedefined(TestAttrReader@0x1010, value@0x1018, cme:0x1020)
-          v29:Fixnum[42] = Const Value(42)
+          v30:Fixnum[42] = Const Value(42)
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -13986,9 +13986,9 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestFrozenSym@0x1010)
           PatchPoint MethodRedefined(TestFrozenSym@0x1010, sym@0x1018, cme:0x1020)
-          v29:StaticSymbol[:hello] = Const Value(VALUE(0x1048))
+          v30:StaticSymbol[:hello] = Const Value(VALUE(0x1048))
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -14025,9 +14025,9 @@ mod hir_opt_tests {
           v20:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestFrozenBool@0x1010)
           PatchPoint MethodRedefined(TestFrozenBool@0x1010, flag@0x1018, cme:0x1020)
-          v29:TrueClass = Const Value(true)
+          v30:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -14106,15 +14106,15 @@ mod hir_opt_tests {
           v27:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(TestNestedAccess@0x1010)
           PatchPoint MethodRedefined(TestNestedAccess@0x1010, x@0x1018, cme:0x1020)
-          v51:Fixnum[100] = Const Value(100)
+          v53:Fixnum[100] = Const Value(100)
           PatchPoint StableConstantNames(0x1048, NESTED_FROZEN)
-          v33:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v34:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(TestNestedAccess@0x1010, y@0x1050, cme:0x1058)
-          v53:Fixnum[200] = Const Value(200)
+          v55:Fixnum[200] = Const Value(200)
           PatchPoint MethodRedefined(Integer@0x1080, +@0x1088, cme:0x1090)
-          v54:Fixnum[300] = Const Value(300)
+          v56:Fixnum[300] = Const Value(300)
           CheckInterrupts
-          Return v54
+          Return v56
         ");
     }
 
@@ -14141,10 +14141,10 @@ mod hir_opt_tests {
           v20:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, bytesize@0x1018, cme:0x1020)
-          v24:CInt64 = LoadField v20, :len@0x1048
-          v25:Fixnum = BoxFixnum v24
+          v25:CInt64 = LoadField v20, :len@0x1048
+          v26:Fixnum = BoxFixnum v25
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -15606,7 +15606,7 @@ mod hir_opt_tests {
           v26:Fixnum[5] = Const Value(5)
           PatchPoint NoEPEscape(initialize)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v64:Fixnum[6] = Const Value(6)
+          v65:Fixnum[6] = Const Value(6)
           PatchPoint SingleRactorMode
           WriteBarrier v23, v16
           CheckInterrupts
@@ -15914,9 +15914,9 @@ mod hir_opt_tests {
           v21:Fixnum[2] = Const Value(2)
           v40:Fixnum = FixnumSub v35, v21
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1040, cme:0x1048)
-          v43:Fixnum = FixnumAdd v36, v40
+          v44:Fixnum = FixnumAdd v36, v40
           CheckInterrupts
-          Return v43
+          Return v44
         ");
     }
 
@@ -16528,20 +16528,20 @@ mod hir_opt_tests {
           v138:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C]
           v139:BasicObject = LoadField v138, :var@0x1040
           PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
-          v178:Fixnum = GuardType v139, Fixnum
-          v179:Fixnum = FixnumAdd v17, v178
+          v179:Fixnum = GuardType v139, Fixnum
+          v180:Fixnum = FixnumAdd v17, v179
           PatchPoint NoEPEscape(test)
-          v183:Fixnum = FixnumAdd v179, v178
-          v187:Fixnum = FixnumAdd v183, v178
-          v191:Fixnum = FixnumAdd v187, v178
-          v195:Fixnum = FixnumAdd v191, v178
-          v199:Fixnum = FixnumAdd v195, v178
-          v203:Fixnum = FixnumAdd v199, v178
-          v207:Fixnum = FixnumAdd v203, v178
-          v211:Fixnum = FixnumAdd v207, v178
-          v215:Fixnum = FixnumAdd v211, v178
+          v185:Fixnum = FixnumAdd v180, v179
+          v190:Fixnum = FixnumAdd v185, v179
+          v195:Fixnum = FixnumAdd v190, v179
+          v200:Fixnum = FixnumAdd v195, v179
+          v205:Fixnum = FixnumAdd v200, v179
+          v210:Fixnum = FixnumAdd v205, v179
+          v215:Fixnum = FixnumAdd v210, v179
+          v220:Fixnum = FixnumAdd v215, v179
+          v225:Fixnum = FixnumAdd v220, v179
           CheckInterrupts
-          Return v215
+          Return v225
         ");
     }
 
@@ -16568,10 +16568,10 @@ mod hir_opt_tests {
           v21:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(Array@0x1010)
           PatchPoint MethodRedefined(Array@0x1010, length@0x1018, cme:0x1020)
-          v25:CInt64 = ArrayLength v21
-          v26:Fixnum = BoxFixnum v25
+          v26:CInt64 = ArrayLength v21
+          v27:Fixnum = BoxFixnum v26
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -16598,10 +16598,10 @@ mod hir_opt_tests {
           v21:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(Array@0x1010)
           PatchPoint MethodRedefined(Array@0x1010, length@0x1018, cme:0x1020)
-          v27:CInt64[4] = Const CInt64(4)
-          v26:Fixnum = BoxFixnum v27
+          v28:CInt64[4] = Const CInt64(4)
+          v27:Fixnum = BoxFixnum v28
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 }

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -3265,7 +3265,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, C)
-          v18:Class[C@0x1008] = Const Value(VALUE(0x1008))
+          v18:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           CheckInterrupts
           Return v18
         ");
@@ -3290,13 +3290,13 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, String)
-          v26:Class[String@0x1008] = Const Value(VALUE(0x1008))
+          v26:ClassSubclass[String@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint StableConstantNames(0x1010, Class)
-          v29:Class[Class@0x1018] = Const Value(VALUE(0x1018))
+          v29:ClassSubclass[Class@0x1018] = Const Value(VALUE(0x1018))
           PatchPoint StableConstantNames(0x1020, Module)
-          v32:Class[Module@0x1028] = Const Value(VALUE(0x1028))
+          v32:ClassSubclass[Module@0x1028] = Const Value(VALUE(0x1028))
           PatchPoint StableConstantNames(0x1030, BasicObject)
-          v35:Class[BasicObject@0x1038] = Const Value(VALUE(0x1038))
+          v35:ClassSubclass[BasicObject@0x1038] = Const Value(VALUE(0x1038))
           v18:ArrayExact = NewArray v26, v29, v32, v35
           CheckInterrupts
           Return v18
@@ -3324,7 +3324,7 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1000, Enumerable)
           v22:ModuleExact[Enumerable@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint StableConstantNames(0x1010, Kernel)
-          v25:ModuleExact[Kernel@0x1018] = Const Value(VALUE(0x1018))
+          v25:ModuleSubclass[Kernel@0x1018] = Const Value(VALUE(0x1018))
           v14:ArrayExact = NewArray v22, v25
           CheckInterrupts
           Return v14
@@ -3577,7 +3577,7 @@ mod hir_opt_tests {
           v20:ModuleExact[M@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(Module@0x1010)
           PatchPoint MethodRedefined(Module@0x1010, class@0x1018, cme:0x1020)
-          v25:Class[Module@0x1010] = Const Value(VALUE(0x1010))
+          v25:ClassSubclass[Module@0x1010] = Const Value(VALUE(0x1010))
           CheckInterrupts
           Return v25
         ");
@@ -4391,7 +4391,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Kernel)
-          v18:ModuleExact[Kernel@0x1008] = Const Value(VALUE(0x1008))
+          v18:ModuleSubclass[Kernel@0x1008] = Const Value(VALUE(0x1008))
           CheckInterrupts
           Return v18
         ");
@@ -4422,7 +4422,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Foo::Bar::C)
-          v18:Class[Foo::Bar::C@0x1008] = Const Value(VALUE(0x1008))
+          v18:ClassSubclass[Foo::Bar::C@0x1008] = Const Value(VALUE(0x1008))
           CheckInterrupts
           Return v18
         ");
@@ -4448,7 +4448,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, C)
-          v43:Class[C@0x1008] = Const Value(VALUE(0x1008))
+          v43:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(C@0x1008, new@0x1009, cme:0x1010)
           v46:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
@@ -4484,7 +4484,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, C)
-          v46:Class[C@0x1008] = Const Value(VALUE(0x1008))
+          v46:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(C@0x1008, new@0x1009, cme:0x1010)
@@ -4516,7 +4516,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Object)
-          v43:Class[Object@0x1008] = Const Value(VALUE(0x1008))
+          v43:ClassSubclass[Object@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(Object@0x1008, new@0x1009, cme:0x1010)
           v46:ObjectExact = ObjectAllocClass Object:VALUE(0x1008)
@@ -4547,7 +4547,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, BasicObject)
-          v43:Class[BasicObject@0x1008] = Const Value(VALUE(0x1008))
+          v43:ClassSubclass[BasicObject@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(BasicObject@0x1008, new@0x1009, cme:0x1010)
           v46:BasicObjectExact = ObjectAllocClass BasicObject:VALUE(0x1008)
@@ -4578,7 +4578,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Hash)
-          v43:Class[Hash@0x1008] = Const Value(VALUE(0x1008))
+          v43:ClassSubclass[Hash@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(Hash@0x1008, new@0x1009, cme:0x1010)
           v46:HashExact = ObjectAllocClass Hash:VALUE(0x1008)
@@ -4611,7 +4611,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Array)
-          v46:Class[Array@0x1008] = Const Value(VALUE(0x1008))
+          v46:ClassSubclass[Array@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           v15:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Array@0x1008, new@0x1009, cme:0x1010)
@@ -4641,7 +4641,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Set)
-          v43:Class[Set@0x1008] = Const Value(VALUE(0x1008))
+          v43:ClassSubclass[Set@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(Set@0x1008, new@0x1009, cme:0x1010)
           v17:HeapBasicObject = ObjectAlloc v43
@@ -4673,7 +4673,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, String)
-          v43:Class[String@0x1008] = Const Value(VALUE(0x1008))
+          v43:ClassSubclass[String@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           PatchPoint MethodRedefined(String@0x1008, new@0x1009, cme:0x1010)
           PatchPoint MethodRedefined(Class@0x1038, new@0x1009, cme:0x1010)
@@ -4702,7 +4702,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Regexp)
-          v47:Class[Regexp@0x1008] = Const Value(VALUE(0x1008))
+          v47:ClassSubclass[Regexp@0x1008] = Const Value(VALUE(0x1008))
           v12:NilClass = Const Value(nil)
           v15:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
           v16:StringExact = StringCopy v15
@@ -4736,7 +4736,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, C)
-          v20:Class[C@0x1008] = Const Value(VALUE(0x1008))
+          v20:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Class@0x1010, allocate@0x1018, cme:0x1020)
           v23:ObjectSubclass[class_exact:C] = ObjectAllocClass C:VALUE(0x1008)
           CheckInterrupts
@@ -4766,7 +4766,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, C)
-          v22:Class[C@0x1008] = Const Value(VALUE(0x1008))
+          v22:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           v12:Fixnum[1] = Const Value(1)
           v14:BasicObject = Send v22, :allocate, v12 # SendFallbackReason: SendWithoutBlock: unsupported method type Cfunc
           CheckInterrupts
@@ -4796,7 +4796,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, SC)
-          v20:Class[Class@0x1008] = Const Value(VALUE(0x1008))
+          v20:ClassSubclass[Class@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Class@0x1010, allocate@0x1018, cme:0x1020)
           v23:BasicObject = CCallWithFrame v20, :Class.allocate@0x1048
           CheckInterrupts
@@ -6829,7 +6829,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Foo)
-          v22:Class[Foo@0x1008] = Const Value(VALUE(0x1008))
+          v22:ClassSubclass[Foo@0x1008] = Const Value(VALUE(0x1008))
           v12:Fixnum[100] = Const Value(100)
           PatchPoint MethodRedefined(Class@0x1010, identity@0x1018, cme:0x1020)
           CheckInterrupts
@@ -9711,7 +9711,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Thread)
-          v20:Class[Thread@0x1008] = Const Value(VALUE(0x1008))
+          v20:ClassSubclass[Thread@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Class@0x1010, current@0x1018, cme:0x1020)
           v23:CPtr = LoadEC
           v24:CPtr = LoadField v23, :thread_ptr@0x1048
@@ -12968,7 +12968,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, String)
-          v27:Class[String@0x1010] = Const Value(VALUE(0x1010))
+          v27:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoEPEscape(test)
           PatchPoint MethodRedefined(Class@0x1018, ===@0x1020, cme:0x1028)
           v30:BoolExact = IsA v10, v27
@@ -12999,7 +12999,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Kernel)
-          v27:ModuleExact[Kernel@0x1010] = Const Value(VALUE(0x1010))
+          v27:ModuleSubclass[Kernel@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoEPEscape(test)
           PatchPoint MethodRedefined(Module@0x1018, ===@0x1020, cme:0x1028)
           v30:BoolExact = CCall v27, :Module#===@0x1050, v10
@@ -13030,7 +13030,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, String)
-          v25:Class[String@0x1010] = Const Value(VALUE(0x1010))
+          v25:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, is_a?@0x1011, cme:0x1018)
           v29:StringExact = GuardType v10, StringExact
@@ -13062,7 +13062,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Kernel)
-          v25:ModuleExact[Kernel@0x1010] = Const Value(VALUE(0x1010))
+          v25:ModuleSubclass[Kernel@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, is_a?@0x1020, cme:0x1028)
           v29:StringExact = GuardType v10, StringExact
@@ -13097,7 +13097,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Integer)
-          v29:Class[Integer@0x1010] = Const Value(VALUE(0x1010))
+          v29:ClassSubclass[Integer@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, is_a?@0x1020, cme:0x1028)
           v33:StringExact = GuardType v10, StringExact
@@ -13132,7 +13132,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Integer)
-          v31:Class[Integer@0x1010] = Const Value(VALUE(0x1010))
+          v31:ClassSubclass[Integer@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoEPEscape(test)
           PatchPoint MethodRedefined(Class@0x1018, ===@0x1020, cme:0x1028)
           v23:Fixnum[5] = Const Value(5)
@@ -13163,7 +13163,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, String)
-          v25:Class[String@0x1010] = Const Value(VALUE(0x1010))
+          v25:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, kind_of?@0x1011, cme:0x1018)
           v29:StringExact = GuardType v10, StringExact
@@ -13195,7 +13195,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Kernel)
-          v25:ModuleExact[Kernel@0x1010] = Const Value(VALUE(0x1010))
+          v25:ModuleSubclass[Kernel@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, kind_of?@0x1020, cme:0x1028)
           v29:StringExact = GuardType v10, StringExact
@@ -13230,7 +13230,7 @@ mod hir_opt_tests {
         bb3(v9:BasicObject, v10:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Integer)
-          v29:Class[Integer@0x1010] = Const Value(VALUE(0x1010))
+          v29:ClassSubclass[Integer@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, kind_of?@0x1020, cme:0x1028)
           v33:StringExact = GuardType v10, StringExact
@@ -13260,7 +13260,7 @@ mod hir_opt_tests {
           v10:Fixnum[5] = Const Value(5)
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, Integer)
-          v22:Class[Integer@0x1008] = Const Value(VALUE(0x1008))
+          v22:ClassSubclass[Integer@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Integer@0x1008, is_a?@0x1009, cme:0x1010)
           v26:TrueClass = Const Value(true)
           CheckInterrupts
@@ -13288,7 +13288,7 @@ mod hir_opt_tests {
           v10:Fixnum[5] = Const Value(5)
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1000, String)
-          v22:Class[String@0x1008] = Const Value(VALUE(0x1008))
+          v22:ClassSubclass[String@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Integer@0x1010, is_a?@0x1018, cme:0x1020)
           v26:FalseClass = Const Value(false)
           CheckInterrupts
@@ -13319,7 +13319,7 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1000, O)
           v22:ArraySubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint StableConstantNames(0x1010, Array)
-          v25:Class[Array@0x1018] = Const Value(VALUE(0x1018))
+          v25:ClassSubclass[Array@0x1018] = Const Value(VALUE(0x1018))
           PatchPoint NoSingletonClass(C@0x1020)
           PatchPoint MethodRedefined(C@0x1020, is_a?@0x1028, cme:0x1030)
           v30:TrueClass = Const Value(true)
@@ -13351,7 +13351,7 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1000, O)
           v22:ObjectSubclass[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint StableConstantNames(0x1010, C)
-          v25:Class[C@0x1018] = Const Value(VALUE(0x1018))
+          v25:ClassSubclass[C@0x1018] = Const Value(VALUE(0x1018))
           PatchPoint NoSingletonClass(C@0x1018)
           PatchPoint MethodRedefined(C@0x1018, is_a?@0x1019, cme:0x1020)
           v30:TrueClass = Const Value(true)
@@ -13382,7 +13382,7 @@ mod hir_opt_tests {
           PatchPoint StableConstantNames(0x1000, O)
           v22:StaticSymbol[:my_static_symbol] = Const Value(VALUE(0x1008))
           PatchPoint StableConstantNames(0x1010, Symbol)
-          v25:Class[Symbol@0x1018] = Const Value(VALUE(0x1018))
+          v25:ClassSubclass[Symbol@0x1018] = Const Value(VALUE(0x1018))
           PatchPoint MethodRedefined(Symbol@0x1018, is_a?@0x1019, cme:0x1020)
           v29:TrueClass = Const Value(true)
           CheckInterrupts
@@ -13505,7 +13505,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1000)
           PatchPoint MethodRedefined(C@0x1000, class@0x1008, cme:0x1010)
           v43:ObjectSubclass[class_exact:C] = GuardType v6, ObjectSubclass[class_exact:C]
-          v46:Class[C@0x1000] = Const Value(VALUE(0x1000))
+          v46:ClassSubclass[C@0x1000] = Const Value(VALUE(0x1000))
           v13:StaticSymbol[:_lex_actions] = Const Value(VALUE(0x1038))
           v15:TrueClass = Const Value(true)
           PatchPoint MethodRedefined(Class@0x1040, respond_to?@0x1048, cme:0x1050)
@@ -13541,7 +13541,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, class@0x1010, cme:0x1018)
           v25:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v28:Class[C@0x1008] = Const Value(VALUE(0x1008))
+          v28:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Class@0x1040, name@0x1048, cme:0x1050)
           v31:StringExact|NilClass = CCall v28, :Module#name@0x1078
           CheckInterrupts
@@ -13573,7 +13573,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, class@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v26:Class[C@0x1008] = Const Value(VALUE(0x1008))
+          v26:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           CheckInterrupts
           Return v26
         ");
@@ -13598,7 +13598,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v10:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(Integer@0x1000, class@0x1008, cme:0x1010)
-          v21:Class[Integer@0x1000] = Const Value(VALUE(0x1000))
+          v21:ClassSubclass[Integer@0x1000] = Const Value(VALUE(0x1000))
           CheckInterrupts
           Return v21
         ");
@@ -13623,7 +13623,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           PatchPoint MethodRedefined(Object@0x1000, class@0x1008, cme:0x1010)
           v18:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
-          v21:Class[Object@0x1038] = Const Value(VALUE(0x1038))
+          v21:ClassSubclass[Object@0x1038] = Const Value(VALUE(0x1038))
           CheckInterrupts
           Return v21
         ");
@@ -13702,7 +13702,7 @@ mod hir_opt_tests {
          SetLocal :formatted, l0, EP@3, v16
          PatchPoint SingleRactorMode
          SetIvar v15, :@formatted, v16
-         v47:Class[VMFrozenCore] = Const Value(VALUE(0x1008))
+         v47:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
          PatchPoint MethodRedefined(Class@0x1010, lambda@0x1018, cme:0x1020)
          v62:BasicObject = CCallWithFrame v47, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
          v50:CPtr = GetEP 0

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -2384,11 +2384,11 @@ pub(crate) mod hir_build_tests {
           v7:BasicObject = LoadArg :a@1
           Jump bb3(v6, v7)
         bb3(v9:BasicObject, v10:BasicObject):
-          v15:Class[VMFrozenCore] = Const Value(VALUE(0x1008))
+          v15:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
           v17:HashExact = NewHash
           PatchPoint NoEPEscape(test)
           v22:BasicObject = Send v15, :core#hash_merge_kwd, v17, v10 # SendFallbackReason: Uncategorized(opt_send_without_block)
-          v24:Class[VMFrozenCore] = Const Value(VALUE(0x1008))
+          v24:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
           v27:StaticSymbol[:b] = Const Value(VALUE(0x1010))
           v29:Fixnum[1] = Const Value(1)
           v31:BasicObject = Send v24, :core#hash_merge_ptr, v22, v27, v29 # SendFallbackReason: Uncategorized(opt_send_without_block)
@@ -4360,7 +4360,7 @@ pub(crate) mod hir_build_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v10:Class[VMFrozenCore] = Const Value(VALUE(0x1000))
+          v10:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1000))
           v12:BasicObject = PutSpecialObject CBase
           v14:StaticSymbol[:aliased] = Const Value(VALUE(0x1008))
           v16:StaticSymbol[:__callee__] = Const Value(VALUE(0x1010))

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -50,10 +50,10 @@ mod snapshot_tests {
           v12:Fixnum[2] = Const Value(2)
           v13:Any = Snapshot FrameState { pc: 0x1008, stack: [v10, v12], locals: [] }
           PatchPoint MethodRedefined(Integer@0x1010, +@0x1018, cme:0x1020)
-          v33:Fixnum[6] = Const Value(6)
-          v21:Any = Snapshot FrameState { pc: 0x1048, stack: [v33], locals: [] }
+          v35:Fixnum[6] = Const Value(6)
+          v21:Any = Snapshot FrameState { pc: 0x1048, stack: [v35], locals: [] }
           CheckInterrupts
-          Return v33
+          Return v35
         ");
     }
 

--- a/zjit/src/hir_type/gen_hir_type.rb
+++ b/zjit/src/hir_type/gen_hir_type.rb
@@ -75,8 +75,8 @@ $inexact_c_names = {
 
 # Define a new type that can be subclassed (most of them).
 # If c_name is given, mark the rb_cXYZ object as equivalent to this exact type.
-def base_type name, c_name: nil
-  type = $object.subtype name
+def base_type name, base: $object, c_name: nil
+  type = base.subtype name
   exact = type.subtype(name+"Exact")
   subclass = type.subtype(name+"Subclass")
   if c_name
@@ -111,7 +111,7 @@ base_type "Regexp", c_name: "rb_cRegexp"
 module_class, _ = base_type "Module", c_name: "rb_cModule"
 # Class cannot be subclassed by doing `class Sub < Class`,
 # but every metaclass is a subclass of `Class`. It's not final.
-module_class.subtype "Class"
+base_type "Class", base: module_class, c_name: "rb_cClass"
 
 numeric, _ = base_type "Numeric", c_name: "rb_cNumeric"
 

--- a/zjit/src/hir_type/hir_type.inc.rs
+++ b/zjit/src/hir_type/hir_type.inc.rs
@@ -9,7 +9,7 @@ mod bits {
   pub const BasicObjectSubclass: u64 = 1u64 << 3;
   pub const Bignum: u64 = 1u64 << 4;
   pub const BoolExact: u64 = FalseClass | TrueClass;
-  pub const BuiltinExact: u64 = ArrayExact | BasicObjectExact | FalseClass | Float | HashExact | Integer | ModuleExact | NilClass | NumericExact | ObjectExact | RangeExact | RegexpExact | SetExact | StringExact | Symbol | TrueClass;
+  pub const BuiltinExact: u64 = ArrayExact | BasicObjectExact | ClassExact | FalseClass | Float | HashExact | Integer | ModuleExact | NilClass | NumericExact | ObjectExact | RangeExact | RegexpExact | SetExact | StringExact | Symbol | TrueClass;
   pub const CAttrIndex: u64 = 1u64 << 5;
   pub const CBool: u64 = 1u64 << 6;
   pub const CDouble: u64 = 1u64 << 7;
@@ -29,54 +29,56 @@ mod bits {
   pub const CUnsigned: u64 = CAttrIndex | CShape | CUInt16 | CUInt32 | CUInt64 | CUInt8;
   pub const CValue: u64 = CBool | CDouble | CInt | CNull | CPtr;
   pub const CallableMethodEntry: u64 = 1u64 << 19;
-  pub const Class: u64 = 1u64 << 20;
-  pub const DynamicSymbol: u64 = 1u64 << 21;
+  pub const Class: u64 = ClassExact | ClassSubclass;
+  pub const ClassExact: u64 = 1u64 << 20;
+  pub const ClassSubclass: u64 = 1u64 << 21;
+  pub const DynamicSymbol: u64 = 1u64 << 22;
   pub const Empty: u64 = 0u64;
-  pub const FalseClass: u64 = 1u64 << 22;
+  pub const FalseClass: u64 = 1u64 << 23;
   pub const Falsy: u64 = FalseClass | NilClass;
-  pub const Fixnum: u64 = 1u64 << 23;
+  pub const Fixnum: u64 = 1u64 << 24;
   pub const Float: u64 = Flonum | HeapFloat;
-  pub const Flonum: u64 = 1u64 << 24;
+  pub const Flonum: u64 = 1u64 << 25;
   pub const Hash: u64 = HashExact | HashSubclass;
-  pub const HashExact: u64 = 1u64 << 25;
-  pub const HashSubclass: u64 = 1u64 << 26;
+  pub const HashExact: u64 = 1u64 << 26;
+  pub const HashSubclass: u64 = 1u64 << 27;
   pub const HeapBasicObject: u64 = BasicObject & !Immediate;
-  pub const HeapFloat: u64 = 1u64 << 27;
+  pub const HeapFloat: u64 = 1u64 << 28;
   pub const HeapObject: u64 = Object & !Immediate;
   pub const Immediate: u64 = FalseClass | Fixnum | Flonum | NilClass | StaticSymbol | TrueClass | Undef;
   pub const Integer: u64 = Bignum | Fixnum;
   pub const Module: u64 = Class | ModuleExact | ModuleSubclass;
-  pub const ModuleExact: u64 = 1u64 << 28;
-  pub const ModuleSubclass: u64 = 1u64 << 29;
-  pub const NilClass: u64 = 1u64 << 30;
+  pub const ModuleExact: u64 = 1u64 << 29;
+  pub const ModuleSubclass: u64 = 1u64 << 30;
+  pub const NilClass: u64 = 1u64 << 31;
   pub const NotNil: u64 = BasicObject & !NilClass;
   pub const Numeric: u64 = Float | Integer | NumericExact | NumericSubclass;
-  pub const NumericExact: u64 = 1u64 << 31;
-  pub const NumericSubclass: u64 = 1u64 << 32;
+  pub const NumericExact: u64 = 1u64 << 32;
+  pub const NumericSubclass: u64 = 1u64 << 33;
   pub const Object: u64 = Array | FalseClass | Hash | Module | NilClass | Numeric | ObjectExact | ObjectSubclass | Range | Regexp | Set | String | Symbol | TrueClass;
-  pub const ObjectExact: u64 = 1u64 << 33;
-  pub const ObjectSubclass: u64 = 1u64 << 34;
+  pub const ObjectExact: u64 = 1u64 << 34;
+  pub const ObjectSubclass: u64 = 1u64 << 35;
   pub const Range: u64 = RangeExact | RangeSubclass;
-  pub const RangeExact: u64 = 1u64 << 35;
-  pub const RangeSubclass: u64 = 1u64 << 36;
+  pub const RangeExact: u64 = 1u64 << 36;
+  pub const RangeSubclass: u64 = 1u64 << 37;
   pub const Regexp: u64 = RegexpExact | RegexpSubclass;
-  pub const RegexpExact: u64 = 1u64 << 37;
-  pub const RegexpSubclass: u64 = 1u64 << 38;
+  pub const RegexpExact: u64 = 1u64 << 38;
+  pub const RegexpSubclass: u64 = 1u64 << 39;
   pub const RubyValue: u64 = BasicObject | CallableMethodEntry | Undef;
   pub const Set: u64 = SetExact | SetSubclass;
-  pub const SetExact: u64 = 1u64 << 39;
-  pub const SetSubclass: u64 = 1u64 << 40;
-  pub const StaticSymbol: u64 = 1u64 << 41;
+  pub const SetExact: u64 = 1u64 << 40;
+  pub const SetSubclass: u64 = 1u64 << 41;
+  pub const StaticSymbol: u64 = 1u64 << 42;
   pub const String: u64 = StringExact | StringSubclass;
-  pub const StringExact: u64 = 1u64 << 42;
-  pub const StringSubclass: u64 = 1u64 << 43;
-  pub const Subclass: u64 = ArraySubclass | BasicObjectSubclass | HashSubclass | ModuleSubclass | NumericSubclass | ObjectSubclass | RangeSubclass | RegexpSubclass | SetSubclass | StringSubclass;
+  pub const StringExact: u64 = 1u64 << 43;
+  pub const StringSubclass: u64 = 1u64 << 44;
+  pub const Subclass: u64 = ArraySubclass | BasicObjectSubclass | ClassSubclass | HashSubclass | ModuleSubclass | NumericSubclass | ObjectSubclass | RangeSubclass | RegexpSubclass | SetSubclass | StringSubclass;
   pub const Symbol: u64 = DynamicSymbol | StaticSymbol;
-  pub const TrueClass: u64 = 1u64 << 44;
+  pub const TrueClass: u64 = 1u64 << 45;
   pub const Truthy: u64 = BasicObject & !Falsy;
-  pub const TypedTData: u64 = 1u64 << 45;
-  pub const Undef: u64 = 1u64 << 46;
-  pub const AllBitPatterns: [(&str, u64); 76] = [
+  pub const TypedTData: u64 = 1u64 << 46;
+  pub const Undef: u64 = 1u64 << 47;
+  pub const AllBitPatterns: [(&str, u64); 78] = [
     ("Any", Any),
     ("RubyValue", RubyValue),
     ("Immediate", Immediate),
@@ -127,6 +129,8 @@ mod bits {
     ("FalseClass", FalseClass),
     ("DynamicSymbol", DynamicSymbol),
     ("Class", Class),
+    ("ClassSubclass", ClassSubclass),
+    ("ClassExact", ClassExact),
     ("CallableMethodEntry", CallableMethodEntry),
     ("CValue", CValue),
     ("CInt", CInt),
@@ -154,7 +158,7 @@ mod bits {
     ("ArrayExact", ArrayExact),
     ("Empty", Empty),
   ];
-  pub const NumTypeBits: u64 = 47;
+  pub const NumTypeBits: u64 = 48;
 }
 pub mod types {
   use super::*;
@@ -188,6 +192,8 @@ pub mod types {
   pub const CValue: Type = Type::from_bits(bits::CValue);
   pub const CallableMethodEntry: Type = Type::from_bits(bits::CallableMethodEntry);
   pub const Class: Type = Type::from_bits(bits::Class);
+  pub const ClassExact: Type = Type::from_bits(bits::ClassExact);
+  pub const ClassSubclass: Type = Type::from_bits(bits::ClassSubclass);
   pub const DynamicSymbol: Type = Type::from_bits(bits::DynamicSymbol);
   pub const Empty: Type = Type::from_bits(bits::Empty);
   pub const FalseClass: Type = Type::from_bits(bits::FalseClass);
@@ -234,7 +240,7 @@ pub mod types {
   pub const Truthy: Type = Type::from_bits(bits::Truthy);
   pub const TypedTData: Type = Type::from_bits(bits::TypedTData);
   pub const Undef: Type = Type::from_bits(bits::Undef);
-  pub const ExactBitsAndClass: [(u64, *const VALUE); 16] = [
+  pub const ExactBitsAndClass: [(u64, *const VALUE); 17] = [
     (bits::ObjectExact, &raw const crate::cruby::rb_cObject),
     (bits::BasicObjectExact, &raw const crate::cruby::rb_cBasicObject),
     (bits::StringExact, &raw const crate::cruby::rb_cString),
@@ -244,6 +250,7 @@ pub mod types {
     (bits::SetExact, &raw const crate::cruby::rb_cSet),
     (bits::RegexpExact, &raw const crate::cruby::rb_cRegexp),
     (bits::ModuleExact, &raw const crate::cruby::rb_cModule),
+    (bits::ClassExact, &raw const crate::cruby::rb_cClass),
     (bits::NumericExact, &raw const crate::cruby::rb_cNumeric),
     (bits::Integer, &raw const crate::cruby::rb_cInteger),
     (bits::Float, &raw const crate::cruby::rb_cFloat),
@@ -252,8 +259,9 @@ pub mod types {
     (bits::TrueClass, &raw const crate::cruby::rb_cTrueClass),
     (bits::FalseClass, &raw const crate::cruby::rb_cFalseClass),
   ];
-  pub const SubclassBitsAndClass: [(u64, *const VALUE); 16] = [
+  pub const SubclassBitsAndClass: [(u64, *const VALUE); 17] = [
     (bits::ArraySubclass, &raw const crate::cruby::rb_cArray),
+    (bits::ClassSubclass, &raw const crate::cruby::rb_cClass),
     (bits::FalseClass, &raw const crate::cruby::rb_cFalseClass),
     (bits::Integer, &raw const crate::cruby::rb_cInteger),
     (bits::HashSubclass, &raw const crate::cruby::rb_cHash),
@@ -270,8 +278,9 @@ pub mod types {
     (bits::ObjectSubclass, &raw const crate::cruby::rb_cObject),
     (bits::BasicObjectSubclass, &raw const crate::cruby::rb_cBasicObject),
   ];
-  pub const InexactBitsAndClass: [(u64, *const VALUE); 16] = [
+  pub const InexactBitsAndClass: [(u64, *const VALUE); 17] = [
     (bits::Array, &raw const crate::cruby::rb_cArray),
+    (bits::Class, &raw const crate::cruby::rb_cClass),
     (bits::FalseClass, &raw const crate::cruby::rb_cFalseClass),
     (bits::Integer, &raw const crate::cruby::rb_cInteger),
     (bits::Hash, &raw const crate::cruby::rb_cHash),

--- a/zjit/src/hir_type/mod.rs
+++ b/zjit/src/hir_type/mod.rs
@@ -2,14 +2,13 @@
 
 #![allow(non_upper_case_globals)]
 use crate::cruby;
-use crate::cruby::{rb_block_param_proxy, Qfalse, Qnil, Qtrue, RUBY_T_ARRAY, RUBY_T_CLASS, RUBY_T_HASH, RUBY_T_MODULE, RUBY_T_STRING, VALUE};
-use crate::cruby::{rb_cInteger, rb_cFloat, rb_cArray, rb_cHash, rb_cString, rb_cSymbol, rb_cRange, rb_cModule, rb_zjit_singleton_class_p};
+use crate::cruby::{rb_block_param_proxy, Qfalse, Qnil, Qtrue, RUBY_T_ARRAY, RUBY_T_HASH, RUBY_T_STRING, VALUE};
+use crate::cruby::{rb_cInteger, rb_cFloat, rb_cArray, rb_cHash, rb_cString, rb_cSymbol, rb_cRange, rb_zjit_singleton_class_p};
 use crate::cruby::ClassRelationship;
 use crate::cruby::get_class_name;
 use crate::cruby::get_module_name;
 use crate::cruby::ruby_sym_to_rust_string;
 use crate::cruby::rb_mRubyVMFrozenCore;
-use crate::cruby::rb_obj_class;
 use crate::hir::{Const, PtrPrintMap};
 use crate::profile::ProfiledType;
 
@@ -178,18 +177,6 @@ fn is_range_exact(val: VALUE) -> bool {
     val.class_of() == unsafe { rb_cRange }
 }
 
-fn is_module_exact(val: VALUE) -> bool {
-    if val.builtin_type() != RUBY_T_MODULE {
-        return false;
-    }
-
-    // For Class and Module instances, `class_of` will return the singleton class of the object.
-    // Using `rb_obj_class` will give us the actual class of the module so we can check if the
-    // object is an instance of Module, or an instance of Module subclass.
-    let klass = unsafe { rb_obj_class(val) };
-    klass == unsafe { rb_cModule }
-}
-
 impl Type {
     /// Create a `Type` from the given integer.
     pub const fn fixnum(val: i64) -> Type {
@@ -221,9 +208,6 @@ impl Type {
             if is_array_exact(val) { bits::ArrayExact }
             else if is_hash_exact(val) { bits::HashExact }
             else if is_string_exact(val) { bits::StringExact }
-            // Singleton classes
-            else if is_module_exact(val) { bits::ModuleExact }
-            else if val.builtin_type() == RUBY_T_CLASS { bits::Class }
             // Classes that have an immediate/heap split
             else if val.class_of() == unsafe { rb_cInteger } { bits::Bignum }
             else if val.class_of() == unsafe { rb_cFloat } { bits::HeapFloat }


### PR DESCRIPTION
This PR is in two parts:

* Fix a small bug/inconsistency in the HIR type system around handling Class
* Prefer profile data over statically known types when doing type specialization

Class bug:

In https://github.com/ruby/ruby/pull/16706 Alan made Class not final (reasonable) because singleton classes are subclasses of Class. He didn't use `base_type` because it didn't support a custom base and that would have made `Class < Object` instead of the `Class < Module` and because it would create an empty type ClassExact.

Unfortunately `base_type` also does some other stuff like adding the class to the "inexact"/"exact"/"subclass" lists, which are important for ingesting objects and classes into the HIR type system. This lets us get rid of the kludges we had previously with `is_module_subtype` and checking the builtin type against `RUBY_T_CLASS` because we now represent singletons as "class subclasses".

So now most classes will look like `ClassSubclass` because they are singletons, but our type system is internally consistent.

Profile changes:

Previously we preferred static type information (if available) to reading from the profile data. However, this could lead to weird issues where we know the type (i.e. the class) statically, but not the shape. Instead, prefer reading from the profile data all the time and rely on `canonicalize` and `fold_constants` to eliminate redundant checks. This mostly does not change HIR except for a couple of intermediate stages (which bumps the vNNN numbers up).