### PR TITLE
ZJIT: Fix exit tracing so that recompiles still happen

### DIFF
--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2678,8 +2678,11 @@ impl Assembler
             }
         }
 
-        /// Compile the main side-exit code. This function takes only SideExit so
-        /// that it can be safely deduplicated by using SideExit as a dedup key.
+        /// Compile the main side-exit code.  The side exit will optionally record a traced exit
+        /// stack, optionally trigger recompilation, and then return to the interpreter. Shared
+        /// exits pass no trace reason so they can still be deduplicated by SideExit.
+        /// IOW, we should never pass a trace reason if we expect the exit to be
+        /// deduplicated.
         fn compile_exit(asm: &mut Assembler, exit: &SideExit, trace_reason: Option<SideExitReason>) {
             // Save VM state before the ccall so that
             // rb_profile_frames sees valid cfp->pc and the

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2661,14 +2661,7 @@ impl Assembler
             asm.cret(Opnd::UImm(Qundef.as_u64()));
         }
 
-        /// Compile the main side-exit code. This function takes only SideExit so
-        /// that it can be safely deduplicated by using SideExit as a dedup key.
-        fn compile_exit(asm: &mut Assembler, exit: &SideExit) {
-            compile_exit_save_state(asm, exit);
-            // If this side exit should trigger recompilation, call the recompile
-            // function after saving VM state. The ccall must happen after
-            // compile_exit_save_state because it clobbers caller-saved registers
-            // that may hold stack/local operands we need to save.
+        fn compile_exit_recompile(asm: &mut Assembler, exit: &SideExit) {
             if let Some(recompile) = &exit.recompile {
                 if cfg!(feature = "runtime_checks") {
                     // Clear jit_return to fully materialize the frame. This must happen
@@ -2692,6 +2685,17 @@ impl Assembler
                     })
                 );
             }
+        }
+
+        /// Compile the main side-exit code. This function takes only SideExit so
+        /// that it can be safely deduplicated by using SideExit as a dedup key.
+        fn compile_exit(asm: &mut Assembler, exit: &SideExit) {
+            compile_exit_save_state(asm, exit);
+            // If this side exit should trigger recompilation, call the recompile
+            // function after saving VM state. The ccall must happen after
+            // compile_exit_save_state because it clobbers caller-saved registers
+            // that may hold stack/local operands we need to save.
+            compile_exit_recompile(asm, exit);
             compile_exit_return(asm);
         }
 
@@ -2778,6 +2782,7 @@ impl Assembler
                             .unwrap_or_else(|_| std::ffi::CString::new("unknown").unwrap());
                         let reason_ptr = reason_cstr.into_raw() as *const u8;
                         asm_ccall!(self, rb_zjit_record_exit_stack, Opnd::const_ptr(reason_ptr));
+                        compile_exit_recompile(self, &exit);
                         compile_exit_return(self);
                     } else {
                         // If the side exit has already been compiled, jump to it.

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -2663,15 +2663,6 @@ impl Assembler
 
         fn compile_exit_recompile(asm: &mut Assembler, exit: &SideExit) {
             if let Some(recompile) = &exit.recompile {
-                if cfg!(feature = "runtime_checks") {
-                    // Clear jit_return to fully materialize the frame. This must happen
-                    // before any C call in the exit path (e.g. exit_recompile)
-                    // because that C call can trigger GC, which walks the stack and would
-                    // hit the CFP_JIT_RETURN assertion if jit_return still holds the
-                    // runtime_checks poison value (JIT_RETURN_POISON).
-                    asm_comment!(asm, "clear cfp->jit_return");
-                    asm.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), 0.into());
-                }
 
                 use crate::codegen::exit_recompile;
                 asm_comment!(asm, "profile and maybe recompile");
@@ -2689,12 +2680,30 @@ impl Assembler
 
         /// Compile the main side-exit code. This function takes only SideExit so
         /// that it can be safely deduplicated by using SideExit as a dedup key.
-        fn compile_exit(asm: &mut Assembler, exit: &SideExit) {
+        fn compile_exit(asm: &mut Assembler, exit: &SideExit, trace_reason: Option<SideExitReason>) {
+            // Save VM state before the ccall so that
+            // rb_profile_frames sees valid cfp->pc and the
+            // ccall doesn't clobber caller-saved registers
+            // holding stack/local operands.
             compile_exit_save_state(asm, exit);
-            // If this side exit should trigger recompilation, call the recompile
-            // function after saving VM state. The ccall must happen after
-            // compile_exit_save_state because it clobbers caller-saved registers
-            // that may hold stack/local operands we need to save.
+            if trace_reason.is_some() || exit.recompile.is_some() {
+                if cfg!(feature = "runtime_checks") {
+                    // Clear jit_return to fully materialize the frame. This must happen
+                    // before any C call in the exit path because that C call can trigger
+                    // GC, which walks the stack and would hit the CFP_JIT_RETURN assertion
+                    // if jit_return still holds the runtime_checks poison value
+                    // (JIT_RETURN_POISON).
+                    asm_comment!(asm, "clear cfp->jit_return");
+                    asm.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), 0.into());
+                }
+            }
+            if let Some(reason) = trace_reason {
+                // Leak a CString with the reason so it's available at runtime
+                let reason_cstr = std::ffi::CString::new(reason.to_string())
+                    .unwrap_or_else(|_| std::ffi::CString::new("unknown").unwrap());
+                let reason_ptr = reason_cstr.into_raw() as *const u8;
+                asm_ccall!(asm, rb_zjit_record_exit_stack, Opnd::const_ptr(reason_ptr));
+            }
             compile_exit_recompile(asm, exit);
             compile_exit_return(asm);
         }
@@ -2772,18 +2781,7 @@ impl Assembler
                     }
 
                     if should_record_exit {
-                        // Save VM state before the ccall so that
-                        // rb_profile_frames sees valid cfp->pc and the
-                        // ccall doesn't clobber caller-saved registers
-                        // holding stack/local operands.
-                        compile_exit_save_state(self, &exit);
-                        // Leak a CString with the reason so it's available at runtime
-                        let reason_cstr = std::ffi::CString::new(reason.to_string())
-                            .unwrap_or_else(|_| std::ffi::CString::new("unknown").unwrap());
-                        let reason_ptr = reason_cstr.into_raw() as *const u8;
-                        asm_ccall!(self, rb_zjit_record_exit_stack, Opnd::const_ptr(reason_ptr));
-                        compile_exit_recompile(self, &exit);
-                        compile_exit_return(self);
+                        compile_exit(self, &exit, Some(reason));
                     } else {
                         // If the side exit has already been compiled, jump to it.
                         // Otherwise, let it fall through and compile the exit next.
@@ -2803,7 +2801,7 @@ impl Assembler
                     let new_exit = self.new_label("side_exit");
                     self.write_label(new_exit.clone());
                     asm_comment!(self, "Exit: {pc}");
-                    compile_exit(self, &exit);
+                    compile_exit(self, &exit, None);
                     compiled_exits.insert(exit, new_exit.unwrap_label());
                     new_exit
                 };

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -2099,7 +2099,13 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::GuardType { val, guard_type, .. } => { write!(f, "GuardType {val}, {}", guard_type.print(self.ptr_map)) },
             Insn::RefineType { val, new_type, .. } => { write!(f, "RefineType {val}, {}", new_type.print(self.ptr_map)) },
             Insn::HasType { val, expected, .. } => { write!(f, "HasType {val}, {}", expected.print(self.ptr_map)) },
-            Insn::GuardBitEquals { val, expected, .. } => { write!(f, "GuardBitEquals {val}, {}", expected.print(self.ptr_map)) },
+            Insn::GuardBitEquals { val, expected, recompile, .. } => {
+                write!(f, "GuardBitEquals {val}, {}", expected.print(self.ptr_map))?;
+                if recompile.is_some() {
+                    write!(f, " recompile")?;
+                }
+                return Ok(())
+            },
             Insn::GuardAnyBitSet { val, mask, mask_name: Some(name), .. } => { write!(f, "GuardAnyBitSet {val}, {name}={}", mask.print(self.ptr_map)) },
             Insn::GuardAnyBitSet { val, mask, .. } => { write!(f, "GuardAnyBitSet {val}, {}", mask.print(self.ptr_map)) },
             Insn::GuardNoBitsSet { val, mask, mask_name: Some(name), .. } => { write!(f, "GuardNoBitsSet {val}, {name}={}", mask.print(self.ptr_map)) },

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -5269,7 +5269,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v16:HeapBasicObject = GuardType v6, HeapBasicObject
           v17:CShape = LoadField v16, :shape_id@0x1000
-          v18:CShape[0x1001] = GuardBitEquals v17, CShape(0x1001)
+          v18:CShape[0x1001] = GuardBitEquals v17, CShape(0x1001) recompile
           v19:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           CheckInterrupts
           Return v19
@@ -5295,7 +5295,7 @@ mod hir_opt_tests {
         bb3(v6:BasicObject):
           v16:HeapBasicObject = GuardType v6, HeapBasicObject
           v17:CShape = LoadField v16, :shape_id@0x1000
-          v18:CShape[0x1001] = GuardBitEquals v17, CShape(0x1001)
+          v18:CShape[0x1001] = GuardBitEquals v17, CShape(0x1001) recompile
           v19:NilClass = Const Value(nil)
           CheckInterrupts
           Return v19
@@ -5613,7 +5613,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           v21:HeapBasicObject = GuardType v6, HeapBasicObject
           v22:CShape = LoadField v21, :shape_id@0x1000
-          v23:CShape[0x1001] = GuardBitEquals v22, CShape(0x1001)
+          v23:CShape[0x1001] = GuardBitEquals v22, CShape(0x1001) recompile
           StoreField v21, :@foo@0x1002, v10
           WriteBarrier v21, v10
           CheckInterrupts
@@ -5642,7 +5642,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           v21:HeapBasicObject = GuardType v6, HeapBasicObject
           v22:CShape = LoadField v21, :shape_id@0x1000
-          v23:CShape[0x1001] = GuardBitEquals v22, CShape(0x1001)
+          v23:CShape[0x1001] = GuardBitEquals v22, CShape(0x1001) recompile
           StoreField v21, :@foo@0x1002, v10
           WriteBarrier v21, v10
           v26:CShape[0x1003] = Const CShape(0x1003)
@@ -5687,7 +5687,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           v28:HeapBasicObject = GuardType v6, HeapBasicObject
           v29:CShape = LoadField v28, :shape_id@0x1000
-          v30:CShape[0x1001] = GuardBitEquals v29, CShape(0x1001)
+          v30:CShape[0x1001] = GuardBitEquals v29, CShape(0x1001) recompile
           StoreField v28, :@foo@0x1002, v10
           WriteBarrier v28, v10
           v33:CShape[0x1003] = Const CShape(0x1003)
@@ -7498,7 +7498,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
           v26:CShape = LoadField v23, :shape_id@0x1040
-          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041)
+          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
           v28:BasicObject = LoadField v23, :@foo@0x1042
           CheckInterrupts
           Return v28
@@ -7766,7 +7766,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           v17:Module = GuardType v6, Module
           v18:CShape = LoadField v17, :shape_id@0x1000
-          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001)
+          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
           PatchPoint RootBoxOnly
           v21:RubyValue = LoadField v17, :fields_obj@0x1002
           v22:BasicObject = LoadField v21, :@foo@0x1003
@@ -7838,7 +7838,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           v17:Class = GuardType v6, Class
           v18:CShape = LoadField v17, :shape_id@0x1000
-          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001)
+          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
           PatchPoint RootBoxOnly
           v21:RubyValue = LoadField v17, :fields_obj@0x1002
           v22:BasicObject = LoadField v21, :@foo@0x1003
@@ -7903,7 +7903,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           v17:HeapBasicObject = GuardType v6, HeapBasicObject
           v18:CShape = LoadField v17, :shape_id@0x1000
-          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001)
+          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
           v20:CAttrIndex[0] = Const CAttrIndex(0)
           v21:BasicObject = CCall v17, :rb_ivar_get_at_no_ractor_check@0x1008, v20
           CheckInterrupts
@@ -7938,7 +7938,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           v17:TypedTData = GuardType v6, TypedTData
           v18:CShape = LoadField v17, :shape_id@0x1000
-          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001)
+          v19:CShape[0x1001] = GuardBitEquals v18, CShape(0x1001) recompile
           v20:RubyValue = LoadField v17, :fields_obj@0x1002
           v21:BasicObject = LoadField v20, :@a@0x1002
           CheckInterrupts
@@ -8175,7 +8175,7 @@ mod hir_opt_tests {
           Jump bb4(v29)
         bb8():
           v44:CShape = LoadField v11, :shape_id@0x1005
-          v45:CShape[0x1006] = GuardBitEquals v44, CShape(0x1006)
+          v45:CShape[0x1006] = GuardBitEquals v44, CShape(0x1006) recompile
           v46:CPtr = LoadField v11, :as_heap@0x1002
           v47:BasicObject = LoadField v46, :@foo@0x1000
           Jump bb4(v47)
@@ -8734,7 +8734,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, foo@0x1018, cme:0x1020)
           v26:CShape = LoadField v20, :shape_id@0x1048
-          v27:CShape[0x1049] = GuardBitEquals v26, CShape(0x1049)
+          v27:CShape[0x1049] = GuardBitEquals v26, CShape(0x1049) recompile
           v28:NilClass = Const Value(nil)
           CheckInterrupts
           Return v28
@@ -8770,7 +8770,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, foo@0x1018, cme:0x1020)
           v26:CShape = LoadField v20, :shape_id@0x1048
-          v27:CShape[0x1049] = GuardBitEquals v26, CShape(0x1049)
+          v27:CShape[0x1049] = GuardBitEquals v26, CShape(0x1049) recompile
           v28:NilClass = Const Value(nil)
           CheckInterrupts
           Return v28
@@ -8806,7 +8806,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
           v26:CShape = LoadField v23, :shape_id@0x1040
-          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041)
+          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
           v28:NilClass = Const Value(nil)
           CheckInterrupts
           Return v28
@@ -8842,7 +8842,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
           v26:CShape = LoadField v23, :shape_id@0x1040
-          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041)
+          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
           v28:NilClass = Const Value(nil)
           CheckInterrupts
           Return v28
@@ -13907,7 +13907,7 @@ mod hir_opt_tests {
           PatchPoint NoSingletonClass(TestUnfrozen@0x1010)
           PatchPoint MethodRedefined(TestUnfrozen@0x1010, a@0x1018, cme:0x1020)
           v26:CShape = LoadField v20, :shape_id@0x1048
-          v27:CShape[0x1049] = GuardBitEquals v26, CShape(0x1049)
+          v27:CShape[0x1049] = GuardBitEquals v26, CShape(0x1049) recompile
           v28:BasicObject = LoadField v20, :@a@0x104a
           CheckInterrupts
           Return v28
@@ -14065,7 +14065,7 @@ mod hir_opt_tests {
           PatchPoint MethodRedefined(TestDynamic@0x1008, val@0x1010, cme:0x1018)
           v23:ObjectSubclass[class_exact:TestDynamic] = GuardType v10, ObjectSubclass[class_exact:TestDynamic]
           v26:CShape = LoadField v23, :shape_id@0x1040
-          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041)
+          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
           v28:BasicObject = LoadField v23, :@val@0x1042
           CheckInterrupts
           Return v28
@@ -15549,7 +15549,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           v35:HeapBasicObject = GuardType v8, HeapBasicObject
           v36:CShape = LoadField v35, :shape_id@0x1000
-          v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001)
+          v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001) recompile
           StoreField v35, :@a@0x1002, v13
           WriteBarrier v35, v13
           v40:CShape[0x1003] = Const CShape(0x1003)
@@ -15597,7 +15597,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           v49:HeapBasicObject = GuardType v10, HeapBasicObject
           v50:CShape = LoadField v49, :shape_id@0x1000
-          v51:CShape[0x1001] = GuardBitEquals v50, CShape(0x1001)
+          v51:CShape[0x1001] = GuardBitEquals v50, CShape(0x1001) recompile
           StoreField v49, :@a@0x1002, v16
           WriteBarrier v49, v16
           v54:CShape[0x1003] = Const CShape(0x1003)
@@ -15645,7 +15645,7 @@ mod hir_opt_tests {
           PatchPoint SingleRactorMode
           v43:HeapBasicObject = GuardType v8, HeapBasicObject
           v44:CShape = LoadField v43, :shape_id@0x1000
-          v45:CShape[0x1001] = GuardBitEquals v44, CShape(0x1001)
+          v45:CShape[0x1001] = GuardBitEquals v44, CShape(0x1001) recompile
           StoreField v43, :@a@0x1002, v13
           WriteBarrier v43, v13
           v48:CShape[0x1003] = Const CShape(0x1003)
@@ -16049,7 +16049,7 @@ mod hir_opt_tests {
           Jump bb8(v63)
         bb12():
           v97:CShape = LoadField v46, :shape_id@0x103c
-          v98:CShape[0x103d] = GuardBitEquals v97, CShape(0x103d)
+          v98:CShape[0x103d] = GuardBitEquals v97, CShape(0x103d) recompile
           v99:BasicObject = LoadField v46, :@levar@0x103a
           Jump bb8(v99)
         bb8(v48:BasicObject):
@@ -16060,7 +16060,7 @@ mod hir_opt_tests {
           PatchPoint NoEPEscape(set_value_loop)
           PatchPoint SingleRactorMode
           v101:CShape = LoadField v46, :shape_id@0x103c
-          v102:CShape[0x103e] = GuardBitEquals v101, CShape(0x103e)
+          v102:CShape[0x103e] = GuardBitEquals v101, CShape(0x103e) recompile
           StoreField v46, :@levar@0x103a, v41
           WriteBarrier v46, v41
           v105:CShape[0x103d] = Const CShape(0x103d)


### PR DESCRIPTION
Before this commit, exit tracing would not allow recompiles to happen. Exit tracing works by installing custom exit handlers in order to trace exit locations.  Recompilation also works by installing custom exit handlers.  Exit tracing didn't take in to account that the particular exit might want to recompile, so recompiles weren't happening when exit tracing was enabled.

We can see the consequences with the following code:

```ruby
class C
  def initialize(extra)
    @attribute_types = nil
    @a = 1 if extra >= 1
    @b = 1 if extra >= 2
  end

  def attribute_types
    @attribute_types ||= 123
  end
end

a = C.new(1)
b = C.new(2)
c = C.new(0)

5_000.times { a.attribute_types }

50_000.times do
  b.attribute_types
  c.attribute_types
end
```

The `attribute_types` method is initially compiled as a monomorphic ivar read.  We expect recompilation to occur and it _should_ get recompiled as a polymorphic ivar read.

Before this patch, if you run miniruby like this:

```
./miniruby --zjit --zjit-trace-compiles --zjit-trace-exits --zjit-trace-invalidation --zjit-dump-hir --zjit-max-versions=10 test.rb
```

The output HIR will be like this (I've omitted a bunch of BBs to make it readable):

```
Optimized HIR:
fn attribute_types@../test.rb:9:
bb3(v6:BasicObject):
  PatchPoint SingleRactorMode
  v36:HeapBasicObject = GuardType v6, HeapBasicObject
  v37:CShape = LoadField v36, :shape_id@0x4
  v38:CShape[0x180009] = GuardBitEquals v37, CShape(0x180009)
  v39:BasicObject = LoadField v36, :@attribute_types@0x10
  CheckInterrupts
  v15:CBool = Test v39
  v16:Truthy = RefineType v39, Truthy
  CondBranch v15, bb4(v36, v16), bb5()

Optimized HIR:
fn attribute_types@../test.rb:9:
bb3(v6:BasicObject):
  PatchPoint SingleRactorMode
  v36:HeapBasicObject = GuardType v6, HeapBasicObject
  v37:CShape = LoadField v36, :shape_id@0x4
  v38:CShape[0x180009] = GuardBitEquals v37, CShape(0x180009)
  v39:BasicObject = LoadField v36, :@attribute_types@0x10
  CheckInterrupts
  v15:CBool = Test v39
  v16:Truthy = RefineType v39, Truthy
  CondBranch v15, bb4(v36, v16), bb5()
```

Note that the `attribute_types` method stays monomorphic.

After this patch, the HIR looks like this:

```
Optimized HIR:
fn attribute_types@../test.rb:9:
bb3(v6:BasicObject):
  PatchPoint SingleRactorMode
  v36:HeapBasicObject = GuardType v6, HeapBasicObject
  v37:CShape = LoadField v36, :shape_id@0x4
  v38:CShape[0x180009] = GuardBitEquals v37, CShape(0x180009) recompile
  v39:BasicObject = LoadField v36, :@attribute_types@0x10
  CheckInterrupts
  v15:CBool = Test v39
  v16:Truthy = RefineType v39, Truthy
  CondBranch v15, bb4(v36, v16), bb5()

Optimized HIR:
fn attribute_types@../test.rb:9:
bb3(v6:BasicObject):
  PatchPoint SingleRactorMode
  v11:HeapBasicObject = GuardType v6, HeapBasicObject
  v12:CUInt64 = LoadField v11, :RBASIC_FLAGS@0x0
  v14:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
  v15:CPtr[CPtr(0x18000900000001)] = Const CPtr(0x18000900000001)
  v16 = RefineType v15, CUInt64
  v17:CInt64 = IntAnd v12, v14
  v18:CBool = IsBitEqual v17, v16
  CondBranch v18, bb6(), bb7()
bb7():
  v22:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
  v23:CPtr[CPtr(0x18000a00000001)] = Const CPtr(0x18000a00000001)
  v24 = RefineType v23, CUInt64
  v25:CInt64 = IntAnd v12, v22
  v26:CBool = IsBitEqual v25, v24
  CondBranch v26, bb8(), bb9()
bb9():
  v30:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
  v31:CPtr[CPtr(0x18000800000001)] = Const CPtr(0x18000800000001)
  v32 = RefineType v31, CUInt64
  v33:CInt64 = IntAnd v12, v30
  v34:CBool = IsBitEqual v33, v32
  CondBranch v34, bb10(), bb11()
```

You can see it's polymorphic now