### PR TITLE
Trim `tarball-*` reusable inputs

### DIFF
--- a/.github/actions/make-snapshot/action.yml
+++ b/.github/actions/make-snapshot/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'srcdir for tool/make-snapshot. Empty = clone ruby/ruby into ./ruby.'
     required: false
     default: ''
+  upload-artifact:
+    description: 'Upload Packages and Info as workflow artifacts. Pass "false" when callers run in a matrix that would collide on artifact names.'
+    required: false
+    default: 'true'
 
 runs:
   using: "composite"
@@ -65,7 +69,9 @@ runs:
       with:
         name: Packages
         path: pkg
+      if: ${{ inputs.upload-artifact == 'true' }}
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: Info
         path: pkg/info
+      if: ${{ inputs.upload-artifact == 'true' }}

--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -57,8 +57,11 @@ jobs:
       - name: make install
         run: cd "$ARCHNAME/" && sudo make $JOBS install
         if: matrix.test_task == 'check'
-      - name: ruby -v
-        run: /usr/local/bin/ruby -v
+      - name: Verify installed binaries
+        run: |
+          /usr/local/bin/ruby -v
+          /usr/local/bin/gem -v
+          /usr/local/bin/bundle -v
         if: matrix.test_task == 'check'
       - uses: ruby/action-slack@54175162371f1f7c8eb94d7c8644ee2479fcd375 # v3.2.2
         with:

--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -7,11 +7,6 @@ on:
         description: 'archname (e.g. snapshot-master, snapshot-ruby_3_3)'
         required: true
         type: string
-      allow-failures:
-        description: 'TEST_BUNDLED_GEMS_ALLOW_FAILURES value'
-        required: false
-        type: string
-        default: ''
 
 jobs:
   macos:
@@ -26,7 +21,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       ARCHNAME: ${{ inputs.archname }}
-      TEST_BUNDLED_GEMS_ALLOW_FAILURES: ${{ inputs.allow-failures }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: ''
-      rebuild-homebrew-ruby:
-        description: 'Uninstall and reinstall Homebrew Ruby on macos-15-intel'
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   macos:
@@ -46,13 +41,6 @@ jobs:
           }
           set -x
           with_retry brew install gmp libffi openssl@1.1 zlib autoconf automake libtool readline libyaml
-      - name: Uninstall Homebrew Ruby
-        run: |
-          for formula in $(brew list 2>/dev/null | grep '^ruby'); do
-            brew uninstall --force "$formula"
-          done
-          sudo rm -rf /usr/local/lib/ruby
-        if: inputs.rebuild-homebrew-ruby && matrix.os == 'macos-15-intel'
       - name: Set ENV
         run: |
           echo "JOBS=-j$((1 + $(sysctl -n hw.activecpu)))" >> $GITHUB_ENV
@@ -60,9 +48,6 @@ jobs:
         run: cd "$ARCHNAME/" && ./configure --with-openssl-dir=$(brew --prefix openssl@1.1) --with-readline-dir=$(brew --prefix readline) --with-libyaml-dir=$(brew --prefix libyaml)
       - name: make
         run: cd "$ARCHNAME/" && make $JOBS
-      - name: Reinstall Homebrew Ruby
-        run: brew install ruby
-        if: inputs.rebuild-homebrew-ruby && matrix.os == 'macos-15-intel' && (matrix.test_task == 'test-bundled-gems' || matrix.test_task == 'test-bundler-parallel')
       - name: Tests
         run: cd "$ARCHNAME/" && make $JOBS -s ${{ matrix.test_task }}
         env:

--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: ''
-      patch-url:
-        description: 'Patch URL forwarded from workflow_dispatch'
-        required: false
-        type: string
-        default: ''
       rebuild-homebrew-ruby:
         description: 'Uninstall and reinstall Homebrew Ruby on macos-15-intel'
         required: false
@@ -44,16 +39,6 @@ jobs:
           path: pkg
       - name: Extract
         run: tar xf pkg/*.tar.xz
-      - name: Apply patch
-        run: |
-          set -x
-          curl -sSL "${RUBY_PATCH_URL}" -o ruby.patch
-          cd "$ARCHNAME/"
-          git apply ../ruby.patch
-        shell: bash
-        env:
-          RUBY_PATCH_URL: ${{ inputs.patch-url }}
-        if: inputs.patch-url != ''
       - name: Install libraries
         run: |
           with_retry () {

--- a/.github/workflows/tarball-macos.yml
+++ b/.github/workflows/tarball-macos.yml
@@ -7,6 +7,11 @@ on:
         description: 'archname (e.g. snapshot-master, snapshot-ruby_3_3)'
         required: true
         type: string
+      notify-release-channel:
+        description: 'Also send failure notifications to SNAPSHOT_SLACK_WEBHOOK_URL (schedule/release builds).'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   macos:
@@ -67,6 +72,19 @@ jobs:
         with:
           payload: |
             {
+              "ci": "GitHub Actions",
+              "env": "snapshot: ${{ matrix.os }} / ${{ matrix.test_task }}",
+              "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "commit": "${{ github.sha }}",
+              "branch": "${{ github.ref_name }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }}
+        if: failure()
+      - uses: ruby/action-slack@54175162371f1f7c8eb94d7c8644ee2479fcd375 # v3.2.2
+        with:
+          payload: |
+            {
               "attachments": [{
                 "text": "${{ job.status }}: ${{ matrix.os }} / ${{ matrix.test_task }} <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>",
                 "color": "danger"
@@ -74,4 +92,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SNAPSHOT_SLACK_WEBHOOK_URL }}
-        if: failure() && github.event_name == 'schedule'
+        if: failure() && inputs.notify-release-channel

--- a/.github/workflows/tarball-test-schedule.yml
+++ b/.github/workflows/tarball-test-schedule.yml
@@ -19,7 +19,7 @@ jobs:
           - ruby_3_3
     steps:
       - name: Trigger tarball-test on ${{ matrix.branch }}
-        run: gh workflow run tarball-test.yml --ref "$BRANCH" --repo "$GITHUB_REPOSITORY"
+        run: gh workflow run tarball-test.yml --ref "$BRANCH" --repo "$GITHUB_REPOSITORY" -f notify-release-channel=true
         env:
           BRANCH: ${{ matrix.branch }}
           GH_TOKEN: ${{ secrets.MATZBOT_GITHUB_ACTION_TOKEN }}

--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -58,7 +58,7 @@ jobs:
     uses: ./.github/workflows/tarball-ubuntu.yml
     with:
       archname: snapshot-${{ needs.tarball.outputs.branch }}
-      notify-release-channel: ${{ inputs.notify-release-channel || false }}
+      notify-release-channel: ${{ github.event_name == 'workflow_dispatch' && inputs.notify-release-channel || false }}
     secrets: inherit
 
   macos:
@@ -66,7 +66,7 @@ jobs:
     uses: ./.github/workflows/tarball-macos.yml
     with:
       archname: snapshot-${{ needs.tarball.outputs.branch }}
-      notify-release-channel: ${{ inputs.notify-release-channel || false }}
+      notify-release-channel: ${{ github.event_name == 'workflow_dispatch' && inputs.notify-release-channel || false }}
     secrets: inherit
 
   windows:
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/tarball-windows.yml
     with:
       archname: snapshot-${{ needs.tarball.outputs.branch }}
-      notify-release-channel: ${{ inputs.notify-release-channel || false }}
+      notify-release-channel: ${{ github.event_name == 'workflow_dispatch' && inputs.notify-release-channel || false }}
     secrets: inherit
 
   non_development:

--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -53,7 +53,6 @@ jobs:
     uses: ./.github/workflows/tarball-ubuntu.yml
     with:
       archname: snapshot-${{ needs.tarball.outputs.branch }}
-      allow-failures: power_assert
       remove-gnupg: true
       notify-ruby-sha: true
       branch-label: ${{ needs.tarball.outputs.branch }}
@@ -64,7 +63,6 @@ jobs:
     uses: ./.github/workflows/tarball-macos.yml
     with:
       archname: snapshot-${{ needs.tarball.outputs.branch }}
-      allow-failures: power_assert
     secrets: inherit
 
   windows:

--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -13,6 +13,11 @@ on:
     # https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks
   merge_group:
   workflow_dispatch:
+    inputs:
+      notify-release-channel:
+        description: 'Also send failure notifications to SNAPSHOT_SLACK_WEBHOOK_URL (set by tarball-test-schedule).'
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }} / ${{ startsWith(github.event_name, 'pull') && github.ref_name || github.sha }}
@@ -53,8 +58,7 @@ jobs:
     uses: ./.github/workflows/tarball-ubuntu.yml
     with:
       archname: snapshot-${{ needs.tarball.outputs.branch }}
-      notify-ruby-sha: true
-      branch-label: ${{ needs.tarball.outputs.branch }}
+      notify-release-channel: ${{ inputs.notify-release-channel || false }}
     secrets: inherit
 
   macos:
@@ -62,6 +66,7 @@ jobs:
     uses: ./.github/workflows/tarball-macos.yml
     with:
       archname: snapshot-${{ needs.tarball.outputs.branch }}
+      notify-release-channel: ${{ inputs.notify-release-channel || false }}
     secrets: inherit
 
   windows:
@@ -69,6 +74,7 @@ jobs:
     uses: ./.github/workflows/tarball-windows.yml
     with:
       archname: snapshot-${{ needs.tarball.outputs.branch }}
+      notify-release-channel: ${{ inputs.notify-release-channel || false }}
     secrets: inherit
 
   non_development:

--- a/.github/workflows/tarball-test.yml
+++ b/.github/workflows/tarball-test.yml
@@ -53,7 +53,6 @@ jobs:
     uses: ./.github/workflows/tarball-ubuntu.yml
     with:
       archname: snapshot-${{ needs.tarball.outputs.branch }}
-      remove-gnupg: true
       notify-ruby-sha: true
       branch-label: ${{ needs.tarball.outputs.branch }}
     secrets: inherit

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -7,11 +7,6 @@ on:
         description: 'archname (e.g. snapshot-master, snapshot-ruby_3_3)'
         required: true
         type: string
-      fixed-dirs-extra:
-        description: 'Create $HOME/.local/share, $HOME/.ssh on top of minimal fixed dirs'
-        required: false
-        type: boolean
-        default: true
       notify-ruby-sha:
         description: 'Post ruby SHA failure notification to SIMPLER_ALERTS_URL'
         required: false
@@ -52,20 +47,16 @@ jobs:
         if: matrix.test_task == 'test-bundled-gems'
       - name: Fixed world writable dirs
         run: |
-          mkdir -p $HOME/.local
+          mkdir -p $HOME/.local/share
           mkdir -p $HOME/.cache/gem/specs
           mkdir -p $HOME/.bundle/cache
+          mkdir -p $HOME/.ssh
           chmod a-w $HOME/.bundle
           # chmod a-w $HOME
           # allow to write $HOME and check stats of HOME around tests (see below)
           chmod -v a-w $HOME/.config
           sudo chmod -R a-w /usr/share
           sudo bash -c 'IFS=:; for d in '"$PATH"'; do chmod -v a-w $d; done' || :
-      - name: Fixed world writable dirs (extra)
-        run: |
-          mkdir -p $HOME/.local/share
-          mkdir -p $HOME/.ssh
-        if: inputs.fixed-dirs-extra
       - name: Set ENV
         run: |
           echo "JOBS=-j$((1 + $(nproc --all)))" >> $GITHUB_ENV

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -146,8 +146,11 @@ jobs:
       - name: make install
         run: cd "$ARCHNAME/" && sudo make $JOBS install
         if: matrix.test_task == 'check'
-      - name: ruby -v
-        run: /usr/local/bin/ruby -v
+      - name: Verify installed binaries
+        run: |
+          /usr/local/bin/ruby -v
+          /usr/local/bin/gem -v
+          /usr/local/bin/bundle -v
         if: matrix.test_task == 'check'
       - name: Show .local
         run: find $HOME/.local -ls

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -17,11 +17,6 @@ on:
         required: false
         type: boolean
         default: true
-      remove-gnupg:
-        description: 'Forcibly remove ~/.gnupg after tests'
-        required: false
-        type: boolean
-        default: false
       fixed-dirs-extra:
         description: 'Create $HOME/.local/share, $HOME/.ssh on top of minimal fixed dirs'
         required: false
@@ -170,11 +165,6 @@ jobs:
         run: cd "$ARCHNAME/" && make $JOBS -s ${{ matrix.test_task }}
         env:
           RUBY_TESTOPTS: "-q --tty=no"
-      # not sure why ~/.gnupg is remained
-      # see tool/test/test_sync_default_gems.rb
-      - name: Forcibly remove test directory
-        run: rm -rf $HOME/.gnupg
-        if: inputs.remove-gnupg
       - name: Diff stats of HOME
         run: |
           set -euxo pipefail

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: ''
-      patch-url:
-        description: 'Patch URL forwarded from workflow_dispatch'
-        required: false
-        type: string
-        default: ''
       apt-mode:
         description: '"none" | "git-only" | "ruby-and-git" — controls per-test_task apt install handling'
         required: false
@@ -71,16 +66,6 @@ jobs:
           path: pkg
       - name: Extract
         run: tar xf pkg/*.tar.xz
-      - name: Apply patch
-        run: |
-          set -x
-          curl -sSL "${RUBY_PATCH_URL}" -o ruby.patch
-          cd "$ARCHNAME/"
-          git apply ../ruby.patch
-        shell: bash
-        env:
-          RUBY_PATCH_URL: ${{ inputs.patch-url }}
-        if: inputs.patch-url != ''
       - name: Install libraries (apt-mode=none)
         run: |
           set -x

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: boolean
         default: true
-      ruby-bin:
-        description: 'Path to ruby for post-install version check'
-        required: false
-        type: string
-        default: '/usr/local/bin/ruby'
       notify-ruby-sha:
         description: 'Post ruby SHA failure notification to SIMPLER_ALERTS_URL'
         required: false
@@ -152,9 +147,7 @@ jobs:
         run: cd "$ARCHNAME/" && sudo make $JOBS install
         if: matrix.test_task == 'check'
       - name: ruby -v
-        env:
-          RUBY_BIN: ${{ inputs.ruby-bin }}
-        run: '"$RUBY_BIN" -v'
+        run: /usr/local/bin/ruby -v
         if: matrix.test_task == 'check'
       - name: Show .local
         run: find $HOME/.local -ls

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -7,16 +7,11 @@ on:
         description: 'archname (e.g. snapshot-master, snapshot-ruby_3_3)'
         required: true
         type: string
-      notify-ruby-sha:
-        description: 'Post ruby SHA failure notification to SIMPLER_ALERTS_URL'
+      notify-release-channel:
+        description: 'Also send failure notifications to SNAPSHOT_SLACK_WEBHOOK_URL (schedule/release builds).'
         required: false
         type: boolean
         default: false
-      branch-label:
-        description: 'Branch label for SIMPLER_ALERTS_URL notification. Defaults to "master".'
-        required: false
-        type: string
-        default: 'master'
 
 jobs:
   ubuntu:
@@ -149,6 +144,19 @@ jobs:
         with:
           payload: |
             {
+              "ci": "GitHub Actions",
+              "env": "snapshot: ${{ matrix.os }} / ${{ matrix.test_task }}",
+              "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "commit": "${{ github.sha }}",
+              "branch": "${{ github.ref_name }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }}
+        if: failure()
+      - uses: ruby/action-slack@54175162371f1f7c8eb94d7c8644ee2479fcd375 # v3.2.2
+        with:
+          payload: |
+            {
               "attachments": [{
                 "text": "${{ job.status }}: ${{ matrix.os }} / ${{ matrix.test_task }} <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>",
                 "color": "danger"
@@ -156,21 +164,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SNAPSHOT_SLACK_WEBHOOK_URL }}
-        if: failure() && github.event_name == 'schedule'
-      - name: Get ruby/ruby sha
-        id: ruby_sha
-        run: cd "$ARCHNAME/" && ./ruby -e 'puts "sha=#{RUBY_REVISION}"' >> $GITHUB_OUTPUT
-        if: failure() && inputs.notify-ruby-sha && github.event_name == 'schedule'
-      - uses: ruby/action-slack@54175162371f1f7c8eb94d7c8644ee2479fcd375 # v3.2.2
-        with:
-          payload: |
-            {
-              "ci": "GitHub Actions",
-              "env": "snapshot: ${{ matrix.os }} / ${{ matrix.test_task }}",
-              "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "commit": "${{ steps.ruby_sha.outputs.sha }}",
-              "branch": "${{ inputs.branch-label }}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }}
-        if: failure() && inputs.notify-ruby-sha && github.event_name == 'schedule'
+        if: failure() && inputs.notify-release-channel

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -7,11 +7,6 @@ on:
         description: 'archname (e.g. snapshot-master, snapshot-ruby_3_3)'
         required: true
         type: string
-      allow-failures:
-        description: 'TEST_BUNDLED_GEMS_ALLOW_FAILURES value'
-        required: false
-        type: string
-        default: ''
       apt-mode:
         description: '"none" | "git-only" | "ruby-and-git" — controls per-test_task apt install handling'
         required: false
@@ -58,7 +53,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       ARCHNAME: ${{ inputs.archname }}
-      TEST_BUNDLED_GEMS_ALLOW_FAILURES: ${{ inputs.allow-failures }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -7,11 +7,6 @@ on:
         description: 'archname (e.g. snapshot-master, snapshot-ruby_3_3)'
         required: true
         type: string
-      apt-mode:
-        description: '"none" | "git-only" | "ruby-and-git" — controls per-test_task apt install handling'
-        required: false
-        type: string
-        default: 'none'
       fixed-dirs-extra:
         description: 'Create $HOME/.local/share, $HOME/.ssh on top of minimal fixed dirs'
         required: false
@@ -50,55 +45,11 @@ jobs:
           path: pkg
       - name: Extract
         run: tar xf pkg/*.tar.xz
-      - name: Install libraries (apt-mode=none)
+      - name: Install libraries
         run: |
           set -x
           sudo apt-get update -q
           sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev bison- autoconf-
-        if: inputs.apt-mode == 'none'
-      - name: Install libraries (apt-mode=git-only)
-        run: |
-          set -x
-          sudo apt-get update -q || :
-          # postfix `-` means `uninstall`
-          APT_INSTALL_GIT=git-
-          case "${{ matrix.test_task }}" in
-            test-bundled-gems)
-              # test-bundled-gems-fetch requires git
-              unset APT_INSTALL_GIT
-              ;;
-            test-bundler*)
-              # avoid Bundler::Source::Git::GitNotInstalledError
-              unset APT_INSTALL_GIT
-              ;;
-            *)
-              ;;
-          esac
-          sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev bison- autoconf- $APT_INSTALL_GIT
-        if: inputs.apt-mode == 'git-only'
-      - name: Install libraries (apt-mode=ruby-and-git)
-        run: |
-          set -x
-          sudo apt-get update -q || :
-          # postfix `-` means `uninstall`
-          APT_INSTALL_RUBY=ruby-
-          APT_INSTALL_GIT=git-
-          case "${{ matrix.test_task }}" in
-            test-bundled-gems)
-              # test-bundled-gems requires executable host ruby
-              APT_INSTALL_RUBY=ruby
-              # test-bundled-gems-fetch requires git
-              unset APT_INSTALL_GIT
-              ;;
-            test-bundler*)
-              # avoid Bundler::Source::Git::GitNotInstalledError
-              unset APT_INSTALL_GIT
-              ;;
-            *)
-              ;;
-          esac
-          sudo apt-get install --no-install-recommends -q -y build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev bison- autoconf- $APT_INSTALL_RUBY $APT_INSTALL_GIT
-        if: inputs.apt-mode == 'ruby-and-git'
       - uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f # v1.306.0
         with:
           ruby-version: 3.2

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -12,11 +12,6 @@ on:
         required: false
         type: string
         default: 'none'
-      setup-host-ruby:
-        description: 'Install Ruby 3.2 via ruby/setup-ruby for test-bundled-gems'
-        required: false
-        type: boolean
-        default: true
       fixed-dirs-extra:
         description: 'Create $HOME/.local/share, $HOME/.ssh on top of minimal fixed dirs'
         required: false
@@ -108,7 +103,7 @@ jobs:
         with:
           ruby-version: 3.2
         # test-bundled-gems requires executable host ruby
-        if: inputs.setup-host-ruby && matrix.test_task == 'test-bundled-gems'
+        if: matrix.test_task == 'test-bundled-gems'
       - name: Fixed world writable dirs
         run: |
           mkdir -p $HOME/.local

--- a/.github/workflows/tarball-ubuntu.yml
+++ b/.github/workflows/tarball-ubuntu.yml
@@ -92,6 +92,10 @@ jobs:
         run: cd "$ARCHNAME/" && make $JOBS -s ${{ matrix.test_task }}
         env:
           RUBY_TESTOPTS: "-q --tty=no"
+      # test_sync_default_gems triggers gpg, whose agent processes leave
+      # $HOME/.gnupg around even when GNUPGHOME points elsewhere.
+      - name: Forcibly remove ~/.gnupg
+        run: rm -rf $HOME/.gnupg
       - name: Diff stats of HOME
         run: |
           set -euxo pipefail

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -118,13 +118,8 @@ jobs:
         env:
           YACC: win_bison
 
-      - name: Verify built binaries
-        env:
-          ARCHNAME: ${{ inputs.archname }}
-        run: |
-          .\ruby -v
-          .\ruby ..\%ARCHNAME%\bin\gem -v
-          .\ruby ..\%ARCHNAME%\bin\bundle -v
+      - name: ruby -v
+        run: .\ruby -v
 
       - run: nmake test
         timeout-minutes: 5

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -113,9 +113,13 @@ jobs:
         env:
           YACC: win_bison
 
-      - name: ruby -v
+      - name: Verify built binaries
+        env:
+          ARCHNAME: ${{ inputs.archname }}
         run: |
           .\ruby -v
+          .\ruby ..\%ARCHNAME%\bin\gem -v
+          .\ruby ..\%ARCHNAME%\bin\bundle -v
 
       - run: nmake test
         timeout-minutes: 5

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -7,11 +7,6 @@ on:
         description: 'archname (e.g. snapshot-master)'
         required: true
         type: string
-      patch-url:
-        description: 'Patch URL forwarded from workflow_dispatch'
-        required: false
-        type: string
-        default: ''
 
 jobs:
   windows:
@@ -72,18 +67,6 @@ jobs:
           path: pkg
       - name: Extract
         run: 7z x pkg/*.zip
-        working-directory:
-      - name: Apply patch
-        run: |
-          set -x
-          curl -sSL "${RUBY_PATCH_URL}" -o ruby.patch
-          cd "$ARCHNAME"
-          git apply ../ruby.patch
-        shell: bash
-        env:
-          RUBY_PATCH_URL: ${{ inputs.patch-url }}
-          ARCHNAME: ${{ inputs.archname }}
-        if: inputs.patch-url != ''
         working-directory:
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/tarball-windows.yml
+++ b/.github/workflows/tarball-windows.yml
@@ -7,6 +7,11 @@ on:
         description: 'archname (e.g. snapshot-master)'
         required: true
         type: string
+      notify-release-channel:
+        description: 'Also send failure notifications to SNAPSHOT_SLACK_WEBHOOK_URL (schedule/release builds).'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   windows:
@@ -134,6 +139,19 @@ jobs:
         with:
           payload: |
             {
+              "ci": "GitHub Actions",
+              "env": "snapshot: ${{ env.OS_VER }} / ${{ matrix.test_task }}",
+              "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "commit": "${{ github.sha }}",
+              "branch": "${{ github.ref_name }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SIMPLER_ALERTS_URL }}
+        if: failure()
+      - uses: ruby/action-slack@54175162371f1f7c8eb94d7c8644ee2479fcd375 # v3.2.2
+        with:
+          payload: |
+            {
               "attachments": [{
                 "text": "${{ job.status }}: ${{ env.OS_VER }} / ${{ matrix.test_task }} <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>",
                 "color": "danger"
@@ -141,4 +159,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SNAPSHOT_SLACK_WEBHOOK_URL }}
-        if: failure() && github.event_name == 'schedule'
+        if: failure() && inputs.notify-release-channel


### PR DESCRIPTION
The reusable workflows for `tarball-test` had accumulated several inputs that were either unused, branch-specific workarounds that have aged out, or knobs whose master defaults are good enough.

This PR trimed and reorganized them.