### PR TITLE
Fix defined? for protected methods defined in a module

### DIFF
--- a/test/ruby/test_defined.rb
+++ b/test/ruby/test_defined.rb
@@ -62,6 +62,34 @@ class TestDefined < Test::Unit::TestCase
     f.bar(Class.new(Foo).new) { |v| assert(v, "inherited protected method") }
   end
 
+  module ProtectedInModule
+    def m
+      :m
+    end
+    protected :m
+    def call_m(o)
+      o.m
+    end
+    def defined_m(o)
+      defined?(o.m)
+    end
+  end
+  class ProtectedIncluderA
+    include ProtectedInModule
+  end
+  class ProtectedIncluderB
+    include ProtectedInModule
+  end
+
+  def test_defined_protected_method_in_included_module
+    a = ProtectedIncluderA.new
+    b = ProtectedIncluderB.new
+    assert_equal(:m, a.call_m(a))
+    assert_equal(:m, a.call_m(b))
+    assert_equal("method", a.defined_m(a))
+    assert_equal("method", a.defined_m(b))
+  end
+
   def test_defined_undefined_method
     f = Foo.new
     assert_nil(defined?(f.quux))        # undefined method

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -5485,21 +5485,21 @@ vm_defined(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, rb_num_t op_
         break;
       case DEFINED_METHOD:{
         VALUE klass = CLASS_OF(v);
-        const rb_method_entry_t *me = rb_method_entry_with_refinements(klass, SYM2ID(obj), NULL);
+        const rb_callable_method_entry_t *cme = rb_callable_method_entry_with_refinements(klass, SYM2ID(obj), NULL);
 
-        if (me) {
-            switch (METHOD_ENTRY_VISI(me)) {
+        if (cme) {
+            switch (METHOD_ENTRY_VISI(cme)) {
               case METHOD_VISI_PRIVATE:
                 break;
               case METHOD_VISI_PROTECTED:
-                if (!rb_obj_is_kind_of(GET_SELF(), rb_class_real(me->defined_class))) {
+                if (!rb_obj_is_kind_of(GET_SELF(), vm_defined_class_for_protected_call(cme))) {
                     break;
                 }
               case METHOD_VISI_PUBLIC:
                 return true;
                 break;
               default:
-                rb_bug("vm_defined: unreachable: %u", (unsigned int)METHOD_ENTRY_VISI(me));
+                rb_bug("vm_defined: unreachable: %u", (unsigned int)METHOD_ENTRY_VISI(cme));
             }
         }
         else {


### PR DESCRIPTION
`me->defined_class` is 0 for methods stored on a module, so the protected visibility check in `vm_defined` always failed and `defined?` returned nil even when the call would succeed.

Use `rb_callable_method_entry_with_refinements` (where `defined_class` is populated) and the same `vm_defined_class_for_protected_call` helper as the call path. `defined?` now agrees with whether the method could actually be called.

Filed a bug report to confirm that this is something that should be fixed:
[Bug #22076](https://bugs.ruby-lang.org/issues/22076)