### PR TITLE
Fix call-seq return values in C extensions

### DIFF
--- a/ext/date/date_core.c
+++ b/ext/date/date_core.c
@@ -6003,7 +6003,7 @@ dup_obj_with_new_start(VALUE obj, double sg)
 
 /*
  * call-seq:
- *   new_start(start = Date::ITALY]) -> new_date
+ *   new_start(start = Date::ITALY) -> new_date
  *
  * Returns a copy of +self+ with the given +start+ value:
  *

--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -550,7 +550,7 @@ nogvl_getch(void *p)
 
 /*
  * call-seq:
- *   io.getch(min: nil, time: nil, intr: nil) -> char
+ *   io.getch(min: nil, time: nil, intr: nil) -> char or nil
  *
  * Reads and returns a character in raw mode.
  *
@@ -1776,7 +1776,7 @@ console_dev(int argc, VALUE *argv, VALUE klass)
 
 /*
  * call-seq:
- *   io.getch(min: nil, time: nil, intr: nil) -> char
+ *   io.getch(min: nil, time: nil, intr: nil) -> char or nil
  *
  * See IO#getch.
  */

--- a/ext/openssl/ossl_ssl.c
+++ b/ext/openssl/ossl_ssl.c
@@ -2196,9 +2196,12 @@ ossl_ssl_write(VALUE self, VALUE str)
 /*
  * call-seq:
  *    ssl.syswrite_nonblock(string) => Integer
+ *    ssl.syswrite_nonblock(string, opts) => Integer
  *
  * Writes _string_ to the SSL connection in a non-blocking manner.  Raises an
- * SSLError if writing would block.
+ * SSLError if writing would block.  If "exception: false" is passed, this
+ * method returns a symbol of :wait_readable or :wait_writable, rather than
+ * raising an exception.
  */
 static VALUE
 ossl_ssl_write_nonblock(int argc, VALUE *argv, VALUE self)

--- a/ext/strscan/strscan.c
+++ b/ext/strscan/strscan.c
@@ -822,7 +822,7 @@ strscan_scan(VALUE self, VALUE re)
  * :include: strscan/link_refs.txt
  *
  * call-seq:
- *   match?(pattern) -> updated_position or nil
+ *   match?(pattern) -> match_size or nil
  *
  * Attempts to [match][17] the given `pattern`
  * at the beginning of the [target substring][3];
@@ -882,7 +882,7 @@ strscan_match_p(VALUE self, VALUE re)
 /*
  * :markup: markdown
  * call-seq:
- *   skip(pattern) match_size or nil
+ *   skip(pattern) -> match_size or nil
  *
  * :include: strscan/link_refs.txt
  * :include: strscan/methods/skip.md
@@ -956,7 +956,7 @@ strscan_check(VALUE self, VALUE re)
 
 /*
  * call-seq:
- *   scan_full(pattern, advance_pointer_p, return_string_p) -> matched_substring or nil
+ *   scan_full(pattern, advance_pointer_p, return_string_p) -> matched_substring or length or nil
  *
  * Equivalent to one of the following:
  *
@@ -1202,7 +1202,7 @@ strscan_getch(VALUE self)
 
 /*
  * call-seq:
- *   scan_byte -> integer_byte
+ *   scan_byte -> integer_byte or nil
  *
  * Scans one byte and returns it as an integer.
  * This method is not multibyte character sensitive.


### PR DESCRIPTION
Some `call-seq` comments in C extensions did not match the actual return values. This fixes them (documentation only, no behavior change).

* **openssl**: `syswrite_nonblock` accepts `opts` and can return a symbol with `exception: false`
* **strscan**: `match?` returns the match size (not a position); `skip` was missing the `->` arrow; `scan_full` and `scan_byte` can return values other than documented
* **date**: `Date#new_start` had a stray `]` in its call-seq
* **io/console**: `getch` can return `nil` on EOF or timeout