### PR TITLE
YJIT: Fix local register mapping overflow

### DIFF
--- a/bootstraptest/test_yjit.rb
+++ b/bootstraptest/test_yjit.rb
@@ -5460,3 +5460,23 @@ assert_normal_exit %q{
   test
   test
 }
+
+# regression test for register mapping of methods with over 256 locals
+# [Bug #22074]
+assert_equal "ok", %q{
+  source = +"def many_locals\n"
+  source << "  total = 0\n"
+
+  128.times do |i|
+    source << "  y#{i} = 1\n"
+    source << "  x#{i} = Object.new\n"
+  end
+
+  source << "  total += 1\n"
+  source << "  raise total.inspect unless total == 1\n"
+  source << "end\n"
+
+  eval(source)
+  many_locals
+  "ok"
+}

--- a/yjit/src/backend/ir.rs
+++ b/yjit/src/backend/ir.rs
@@ -6,7 +6,7 @@ use crate::codegen::{gen_counted_exit, gen_outlined_exit};
 use crate::cruby::{vm_stack_canary, SIZEOF_VALUE_I32, VALUE, VM_ENV_DATA_SIZE};
 use crate::virtualmem::CodePtr;
 use crate::asm::{CodeBlock, OutlinedCb};
-use crate::core::{Context, RegMapping, RegOpnd, MAX_CTX_TEMPS};
+use crate::core::{Context, RegMapping, RegOpnd, MAX_CTX_LOCALS, MAX_CTX_TEMPS};
 use crate::options::*;
 use crate::stats::*;
 
@@ -242,7 +242,9 @@ impl Opnd
                     let last_idx = stack_size as i32 + VM_ENV_DATA_SIZE as i32 - 1;
                     assert!(last_idx <= idx, "Local index {} must be >= last local index {}", idx, last_idx);
                     assert!(idx <= last_idx + num_locals as i32, "Local index {} must be < last local index {} + local size {}", idx, last_idx, num_locals);
-                    RegOpnd::Local((last_idx + num_locals as i32 - idx) as u8)
+                    // Indices that don't fit in u8 are capped to MAX_CTX_LOCALS, which is untrackable.
+                    let local_idx = last_idx + num_locals as i32 - idx;
+                    RegOpnd::Local(local_idx.try_into().unwrap_or(MAX_CTX_LOCALS as u8))
                 } else {
                     assert!(idx < stack_size as i32);
                     RegOpnd::Stack((stack_size as i32 - idx - 1) as u8)

--- a/yjit/src/core.rs
+++ b/yjit/src/core.rs
@@ -34,7 +34,7 @@ use crate::invariants::*;
 pub const MAX_CTX_TEMPS: usize = 8;
 
 // Maximum number of local variable types or registers we keep track of
-const MAX_CTX_LOCALS: usize = 8;
+pub const MAX_CTX_LOCALS: usize = 8;
 
 /// An index into `ISEQ_BODY(iseq)->iseq_encoded`. Points
 /// to a YARV instruction or an instruction operand.


### PR DESCRIPTION
Previously, local indices greater than 255 were truncated when
converted to RegOpnd::Local. This could make a high-index local alias
a tracked low-index local in the register mapping and produce incorrect
values after compilation.

Cap overflowing indices to MAX_CTX_LOCALS. RegMapping treats that index
as untrackable because it is just outside the tracked local range.

Fixes [Backport #22074].