### PR TITLE
[Backport #22072] Fix rb_cvar_set for multi-Ractor

### DIFF
--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -81,6 +81,22 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+
+  def test_class_variables
+    # [Bug #22072]
+    assert_ractor(<<~'RUBY')
+      module Foo
+        def self.foo = @@foo
+      end
+
+      Foo.class_variable_set(:@@foo, 1)
+
+      10.times { |i| Foo.class_variable_set(:"@@bar#{i}", i) }
+
+      assert_equal(Foo.foo, 1)
+    RUBY
+  end
+
   def test_struct_instance_variables
     assert_ractor(<<~'RUBY')
       StructIvar = Struct.new(:member) do

--- a/variable.c
+++ b/variable.c
@@ -4294,7 +4294,7 @@ rb_cvar_set(VALUE klass, ID id, VALUE val)
             new_cvc_tbl = rb_marked_id_table_new(2);
         }
         else if (rb_multi_ractor_p()) {
-            new_cvc_tbl = rb_marked_id_table_new(rb_marked_id_table_size(cvc_tbl) + 1);
+            new_cvc_tbl = rb_marked_id_table_dup(cvc_tbl);
         }
 
         rb_marked_id_table_insert(new_cvc_tbl, id, (VALUE)ent);


### PR DESCRIPTION
rb_cvar_set breaks the RCLASS_CVC_TBL because it creates a new cvc_tbl but
forgets to copy the contents over. This causes the following script to
crash:

    r = Ractor.new {}

    module Foo
      def self.foo = @@foo
    end

    Foo.class_variable_set(:@@foo, nil)
    Foo.class_variable_set(:@@bar, nil)

    puts Foo.foo

Crashes with:

    test.rb:4: [BUG] should have cvar cache entry
    ruby 4.1.0dev (2026-05-16T21:11:21Z define-obj-has-suf.. 642cfc59a7) +PRISM [x86_64-linux]

    -- Control frame information -----------------------------------------------
    c:0003 p:0003 s:0012 e:000011 l:y b:0001 r:(nil) METHOD test.rb:4
    c:0002 p:0036 s:0008 E:001118 l:n b:---- r:(nil) EVAL   test.rb:10 [FINISH]
    c:0001 p:0000 s:0003 E:0013c0 l:y b:---- r:(nil) DUMMY  [FINISH]

    -- Ruby level backtrace information ----------------------------------------
    test.rb:10:in '<main>'
    test.rb:4:in 'foo'

    -- Threading information ---------------------------------------------------
    Total ractor count: 1
    Ruby thread count for this ractor: 1

    -- C level backtrace information -------------------------------------------
    miniruby(rb_print_backtrace+0x24) [0x5701425120eb] vm_dump.c:1108
    miniruby(rb_vm_bugreport+0x374) [0x5701425128f2] vm_dump.c:1456
    miniruby(rb_bug_without_die_internal+0xa0) [0x5701422ad332] error.c:1107
    miniruby(rb_bug+0xb5) [0x5701422ad4de] error.c:1125
    miniruby(update_classvariable_cache+0xd1) [0x5701424d159c] vm_insnhelper.c:1501
    miniruby(vm_getclassvariable+0xd1) [0x5701424d16e4] vm_insnhelper.c:1532
    miniruby(vm_exec_core+0xfa6) [0x5701424e6fa9] insns.def:243
    miniruby(rb_vm_exec+0x140) [0x570142504532] vm.c:2805
    miniruby(rb_iseq_eval_main+0x3d) [0x5701425054c8] vm.c:3101
    miniruby(rb_ec_exec_node+0x128) [0x5701422b914a] eval.c:284
    miniruby(ruby_run_node+0x8d) [0x5701422b92be] eval.c:322
    miniruby(rb_main+0x4c) [0x5701421ccd8e] main.c:42
    miniruby(main+0x4b) [0x5701421ccdef] main.c:62
