### PR TITLE
[DOC] Fix incorrect Hash comparison operator examples

### DIFF
--- a/hash.c
+++ b/hash.c
@@ -3995,8 +3995,8 @@ hash_equal(VALUE hash1, VALUE hash2, int eql)
  *    h == {bar: 1, foo: 0} # => true   # Equal entries (different order).
  *    h == 1                            # => false  # Object not a hash.
  *    h == {}                           # => false  # Different number of entries.
- *    h == {foo: 0, bar: 1} # => false  # Different key.
- *    h == {foo: 0, bar: 1} # => false  # Different value.
+ *    h == {foo: 0, bat: 1} # => false  # Different key.
+ *    h == {foo: 0, bar: 2} # => false  # Different value.
  *
  *  Related: see {Methods for Comparing}[rdoc-ref:Hash@Methods+for+Comparing].
  */
@@ -4927,8 +4927,8 @@ rb_hash_le(VALUE hash, VALUE other)
  *    h < {baz: 2, bar: 1, foo: 0} # => true   # Order may differ.
  *    h < h                        # => false  # Not a proper subset.
  *    h < {bar: 1, foo: 0}         # => false  # Not a proper subset.
- *    h < {foo: 0, bar: 1, baz: 2} # => false  # Different key.
- *    h < {foo: 0, bar: 1, baz: 2} # => false  # Different value.
+ *    h < {foo: 0, bat: 1, baz: 2} # => false  # Different key.
+ *    h < {foo: 0, bar: 3, baz: 2} # => false  # Different value.
  *
  *  See {Hash Inclusion}[rdoc-ref:language/hash_inclusion.rdoc].
  *
@@ -4981,8 +4981,8 @@ rb_hash_ge(VALUE hash, VALUE other)
  *    h > {bar: 1, foo: 0}         # => true   # Order may differ.
  *    h > h                        # => false  # Not a proper superset.
  *    h > {baz: 2, bar: 1, foo: 0} # => false  # Not a proper superset.
- *    h > {foo: 0, bar: 1}         # => false  # Different key.
- *    h > {foo: 0, bar: 1}         # => false  # Different value.
+ *    h > {foo: 0, bat: 1}         # => false  # Different key.
+ *    h > {foo: 0, bar: 3}         # => false  # Different value.
  *
  *  See {Hash Inclusion}[rdoc-ref:language/hash_inclusion.rdoc].
  *


### PR DESCRIPTION
I noticed some incorrect examples in the Hash documentation. See this irb session, running commands copied directly from the current [`Hash#==` docs](https://docs.ruby-lang.org/en/4.0/Hash.html#method-i-3D-3D):

```
irb(main):001> h =  {foo: 0, bar: 1}
=> {foo: 0, bar: 1}
irb(main):002> h == {foo: 0, bar: 1} # => true   # Equal entries (same order)
=> true
irb(main):003> h == {bar: 1, foo: 0} # => true   # Equal entries (different order).
=> true
irb(main):004> h == 1                            # => false  # Object not a hash.
=> false
irb(main):005> h == {}                           # => false  # Different number of entries.
=> false
irb(main):006> h == {foo: 0, bar: 1} # => false  # Different key.
=> true
irb(main):007> h == {foo: 0, bar: 1} # => false  # Different value.
=> true
```

Note the differences in output of the last two statements.

This PR fixes similar mistakes in `Hash#<` and `Hash#>` as well.