### PR TITLE
[Bug #22079] Fix `Float#ceil` and `Float#floor` edge cases

### DIFF
--- a/internal/rational.h
+++ b/internal/rational.h
@@ -38,7 +38,7 @@ VALUE rb_rational_cmp(VALUE self, VALUE other);
 VALUE rb_rational_pow(VALUE self, VALUE other);
 VALUE rb_rational_floor(VALUE self, int ndigits);
 VALUE rb_numeric_quo(VALUE x, VALUE y);
-VALUE rb_flo_round_by_rational(int argc, VALUE *argv, VALUE num);
+VALUE rb_flo_round_by_rational(VALUE num, int ndigits, enum ruby_num_rounding_mode mode);
 VALUE rb_float_numerator(VALUE x);
 VALUE rb_float_denominator(VALUE x);
 

--- a/internal/rational.h
+++ b/internal/rational.h
@@ -39,6 +39,8 @@ VALUE rb_rational_pow(VALUE self, VALUE other);
 VALUE rb_rational_floor(VALUE self, int ndigits);
 VALUE rb_numeric_quo(VALUE x, VALUE y);
 VALUE rb_flo_round_by_rational(VALUE num, int ndigits, enum ruby_num_rounding_mode mode);
+VALUE rb_flo_ceil_by_rational(VALUE num, int ndigits);
+VALUE rb_flo_floor_by_rational(VALUE num, int ndigits);
 VALUE rb_float_numerator(VALUE x);
 VALUE rb_float_denominator(VALUE x);
 

--- a/numeric.c
+++ b/numeric.c
@@ -75,6 +75,8 @@
 #define DBL_EPSILON 2.2204460492503131e-16
 #endif
 
+#define ACCURATE_POW10(ndigits) ((ndigits) < DBL_DIG)
+
 #ifndef USE_RB_INFINITY
 #elif !defined(WORDS_BIGENDIAN) /* BYTE_ORDER == LITTLE_ENDIAN */
 const union bytesequence4_or_float rb_infinity = {{0x00, 0x00, 0x80, 0x7f}};
@@ -2490,9 +2492,8 @@ flo_round(int argc, VALUE *argv, VALUE num)
         frexp(number, &binexp);
         if (float_round_overflow(ndigits, binexp)) return num;
         if (float_round_underflow(ndigits, binexp)) return DBL2NUM(0);
-        if (ndigits >= DBL_DIG) {
-            /* In this case, pow(10, ndigits) may not be accurate. */
-            return rb_flo_round_by_rational(argc, argv, num);
+        if (!ACCURATE_POW10(ndigits)) {
+            return rb_flo_round_by_rational(num, ndigits, mode);
         }
         f = pow(10, ndigits);
         x = ROUND_CALL(mode, round, (number, f));

--- a/numeric.c
+++ b/numeric.c
@@ -2020,6 +2020,9 @@ rb_float_floor(VALUE num, int ndigits)
         if (float_round_overflow(ndigits, binexp)) return num;
         if (number > 0.0 && float_round_underflow(ndigits, binexp))
             return DBL2NUM(0.0);
+        if (!ACCURATE_POW10(ndigits)) {
+            return rb_flo_floor_by_rational(num, ndigits);
+        }
         f = pow(10, ndigits);
         mul = floor(number * f);
         res = (mul + 1) / f;
@@ -2228,6 +2231,9 @@ rb_float_ceil(VALUE num, int ndigits)
         if (float_round_overflow(ndigits, binexp)) return num;
         if (number < 0.0 && float_round_underflow(ndigits, binexp))
             return DBL2NUM(0.0);
+        if (!ACCURATE_POW10(ndigits)) {
+            return rb_flo_ceil_by_rational(num, ndigits);
+        }
         f = pow(10, ndigits);
         f = ceil(number * f) / f;
         return DBL2NUM(f);

--- a/numeric.c
+++ b/numeric.c
@@ -2490,7 +2490,7 @@ flo_round(int argc, VALUE *argv, VALUE num)
         frexp(number, &binexp);
         if (float_round_overflow(ndigits, binexp)) return num;
         if (float_round_underflow(ndigits, binexp)) return DBL2NUM(0);
-        if (ndigits > 14) {
+        if (ndigits >= DBL_DIG) {
             /* In this case, pow(10, ndigits) may not be accurate. */
             return rb_flo_round_by_rational(argc, argv, num);
         }

--- a/rational.c
+++ b/rational.c
@@ -1374,10 +1374,12 @@ nurat_round_half_even(VALUE self)
     return num;
 }
 
+static VALUE f_round_n(VALUE self, VALUE n, VALUE (*func)(VALUE)) ;
+
 static VALUE
 f_round_common(int argc, VALUE *argv, VALUE self, VALUE (*func)(VALUE))
 {
-    VALUE n, b, s;
+    VALUE n;
 
     if (rb_check_arity(argc, 0, 1) == 0)
         return (*func)(self);
@@ -1386,6 +1388,14 @@ f_round_common(int argc, VALUE *argv, VALUE self, VALUE (*func)(VALUE))
 
     if (!k_integer_p(n))
         rb_raise(rb_eTypeError, "not an integer");
+
+    return f_round_n(self, n, func);
+}
+
+static VALUE
+f_round_n(VALUE self, VALUE n, VALUE (*func)(VALUE))
+{
+    VALUE b, s;
 
     b = f_expt10(n);
     s = rb_rational_mul(self, b);
@@ -1417,8 +1427,7 @@ rb_rational_floor(VALUE self, int ndigits)
         return nurat_floor(self);
     }
     else {
-        VALUE n = INT2NUM(ndigits);
-        return f_round_common(1, &n, self, nurat_floor);
+        return f_round_n(self, INT2NUM(ndigits), nurat_floor);
     }
 }
 
@@ -1561,9 +1570,10 @@ nurat_round_n(int argc, VALUE *argv, VALUE self)
 }
 
 VALUE
-rb_flo_round_by_rational(int argc, VALUE *argv, VALUE num)
+rb_flo_round_by_rational(VALUE num, int ndigits, enum ruby_num_rounding_mode mode)
 {
-    return nurat_to_f(nurat_round_n(argc, argv, float_to_r(num)));
+    VALUE (*round_func)(VALUE) = ROUND_FUNC(mode, nurat_round);
+    return nurat_to_f(f_round_n(float_to_r(num), INT2NUM(ndigits), round_func));
 }
 
 static double

--- a/rational.c
+++ b/rational.c
@@ -1576,6 +1576,18 @@ rb_flo_round_by_rational(VALUE num, int ndigits, enum ruby_num_rounding_mode mod
     return nurat_to_f(f_round_n(float_to_r(num), INT2NUM(ndigits), round_func));
 }
 
+VALUE
+rb_flo_ceil_by_rational(VALUE num, int ndigits)
+{
+    return nurat_to_f(f_round_n(float_to_r(num), INT2NUM(ndigits), nurat_ceil));
+}
+
+VALUE
+rb_flo_floor_by_rational(VALUE num, int ndigits)
+{
+    return nurat_to_f(f_round_n(float_to_r(num), INT2NUM(ndigits), nurat_floor));
+}
+
 static double
 nurat_to_double(VALUE self)
 {

--- a/test/ruby/test_float.rb
+++ b/test/ruby/test_float.rb
@@ -492,6 +492,14 @@ class TestFloat < Test::Unit::TestCase
     assert_equal(-1.26, -1.255.round(2))
   end
 
+  def test_round_ndigits
+    bug14635 = "[ruby-core:86323]"
+    f = 0.5
+    31.times do |i|
+      assert_equal(0.5, f.round(i+1), bug14635 + " (argument: #{i+1})")
+    end
+  end
+
   def test_round_half_even_with_precision
     assert_equal(767573.18759, 767573.1875850001.round(5, half: :even))
     assert_equal(767573.18758, 767573.187585.round(5, half: :even))

--- a/test/ruby/test_float.rb
+++ b/test/ruby/test_float.rb
@@ -500,6 +500,14 @@ class TestFloat < Test::Unit::TestCase
     end
   end
 
+  def test_round_with_precision_min
+    (0..3).each do |n|
+      n -= Float::MIN_10_EXP
+      f = Float::MIN.round(n)
+      assert_include([Float::MIN.floor(n), Float::MIN.ceil(n)], f, "round(#{n})")
+    end
+  end
+
   def test_round_half_even_with_precision
     assert_equal(767573.18759, 767573.1875850001.round(5, half: :even))
     assert_equal(767573.18758, 767573.187585.round(5, half: :even))
@@ -544,6 +552,16 @@ class TestFloat < Test::Unit::TestCase
     assert_equal(-100000000000000000000000000000000000000000000000000, -1.0.floor(-50), "[Bug #20654]")
   end
 
+  def test_floor_with_precision_min
+    min = Float::MIN
+    (0..3).each do |n|
+      n -= Float::MIN_10_EXP
+      f = min.floor(n)
+      assert_operator(f, :<=, Float::MIN, "floor(#{n})")
+      assert_operator(f, :>=, Float::MIN.floor(n-1), "ceil(#{n})")
+    end
+  end
+
   def test_ceil_with_precision
     assert_equal(+0.1, +0.001.ceil(1))
     assert_equal(-0.0, -0.001.ceil(1))
@@ -573,6 +591,19 @@ class TestFloat < Test::Unit::TestCase
     assert_equal(10000000000, 1.0.ceil(-10), "[Bug #20654]")
     assert_equal(100000000000000000000, 1.0.ceil(-20), "[Bug #20654]")
     assert_equal(100000000000000000000000000000000000000000000000000, 1.0.ceil(-50), "[Bug #20654]")
+  end
+
+  def test_ceil_with_precision_min
+    min = Float::MIN
+    (-Float::MIN_10_EXP).times do |n|
+      assert_equal(10.pow(-n), min.ceil(n))
+    end
+    (0..3).each do |n|
+      n -= Float::MIN_10_EXP
+      f = min.ceil(n)
+      assert_operator(f, :>=, Float::MIN, "ceil(#{n})")
+      assert_operator(f, :<=, Float::MIN.ceil(n-1), "ceil(#{n})")
+    end
   end
 
   def test_truncate_with_precision

--- a/test/ruby/test_numeric.rb
+++ b/test/ruby/test_numeric.rb
@@ -206,14 +206,6 @@ class TestNumeric < Test::Unit::TestCase
     assert_nil(a <=> :foo)
   end
 
-  def test_float_round_ndigits
-    bug14635 = "[ruby-core:86323]"
-    f = 0.5
-    31.times do |i|
-      assert_equal(0.5, f.round(i+1), bug14635 + " (argument: #{i+1})")
-    end
-  end
-
   def test_floor_ceil_round_truncate
     a = Class.new(Numeric) do
       def to_f; 1.5; end


### PR DESCRIPTION
[[Bug #22079]](https://bugs.ruby-lang.org/issues/22079)