### PR TITLE
Remove duplicate GC guard

### DIFF
--- a/process.c
+++ b/process.c
@@ -2888,7 +2888,6 @@ void
 rb_execarg_parent_end(VALUE execarg_obj)
 {
     execarg_parent_end(execarg_obj);
-    RB_GC_GUARD(execarg_obj);
 }
 
 static void


### PR DESCRIPTION
Now there is a guard also in `execarg_parent_end` since commit 9ae6ee5a59e74e629f73222938b53a6eae8d2ded.