### PR TITLE
Use nprocessors as default_max_cpu for M:N scheduler

### DIFF
--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -269,7 +269,8 @@ class TestRactor < Test::Unit::TestCase
   end
 
   def test_mn_threads
-    # Ideally, we would assert that vm->ractor.sched.max_cpu equals n when RUBY_MAX_CPU is not set.
+    # Ideally, we would assert that vm->ractor.sched.max_cpu equals sysconf(_SC_NPROCESSORS_ONLN)
+    # when RUBY_MAX_CPU is not set.
     assert_ractor(<<~'RUBY', args: [{ "RUBY_MN_THREADS" => "1" }])
       require "etc"
       n = Etc.respond_to?(:nprocessors) ? Etc.nprocessors : 8

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -268,6 +268,16 @@ class TestRactor < Test::Unit::TestCase
     RUBY
   end
 
+  def test_mn_threads
+    # Ideally, we would assert that vm->ractor.sched.max_cpu equals n when RUBY_MAX_CPU is not set.
+    assert_ractor(<<~'RUBY', args: [{ "RUBY_MN_THREADS" => "1" }])
+      require "etc"
+      n = Etc.respond_to?(:nprocessors) ? Etc.nprocessors : 8
+      rs = n.times.map { Ractor.new { :ok } }
+      assert_equal [:ok] * n, rs.map(&:value)
+    RUBY
+  end
+
   def test_symbol_proc_is_shareable
     pr = :symbol.to_proc
     assert_make_shareable(pr)

--- a/thread_pthread.c
+++ b/thread_pthread.c
@@ -1799,7 +1799,12 @@ ruby_mn_threads_params(void)
     main_ractor->threads.sched.enable_mn_threads = enable_mn_threads;
 
     const char *max_cpu_cstr = getenv("RUBY_MAX_CPU");
-    const int default_max_cpu = 8; // TODO: CPU num?
+#if defined(HAVE_SYSCONF) && defined(_SC_NPROCESSORS_ONLN)
+    long nprocessors = sysconf(_SC_NPROCESSORS_ONLN);
+    const int default_max_cpu = (nprocessors > 0) ? (int)nprocessors : 8;
+#else
+    const int default_max_cpu = 8;
+#endif
     int max_cpu = default_max_cpu;
 
     if (USE_MN_THREADS && max_cpu_cstr)  {


### PR DESCRIPTION
Hi!

This PR proposes to remove the hardcoded `default_max_cpu` value.
Instead, `default_max_cpu` will be initialized using the value returned by `sysconf(_SC_NPROCESSORS_ONLN)`.

`default_max_cpu` has a default value that is hardcoded to 8, with a `TODO: CPU num?` comment. This PR

- sets `default_max_cpu` to the value returned by `sysconf(_SC_NPROCESSORS_ONLN)`
    - to use the number of online CPUs instead of a fixed value
- fallbacks to 8 for platforms where `_SC_NPROCESSORS_ONLN` is unavailable

If you intentionally (temporarily) hardcoded it to 8, please close this pull request.