### PR TITLE
Clean rb_reg_new_ary() up

### DIFF
--- a/internal/re.h
+++ b/internal/re.h
@@ -68,7 +68,6 @@ VALUE rb_reg_equal(VALUE re1, VALUE re2);
 VALUE rb_backref_set_string(VALUE string, long pos, long len);
 void rb_match_unbusy(VALUE);
 int rb_match_count(VALUE match);
-VALUE rb_reg_new_ary(VALUE ary, int options);
 VALUE rb_reg_new_from_values(long cnt, const VALUE *elements, int opt);
 VALUE rb_reg_last_defined(VALUE match);
 

--- a/re.c
+++ b/re.c
@@ -3523,16 +3523,10 @@ rb_reg_init_str_enc(VALUE re, VALUE s, rb_encoding *enc, int options)
 }
 
 VALUE
-rb_reg_new_ary(VALUE ary, int opt)
-{
-    return rb_reg_new_str(rb_reg_preprocess_dregexp(ary, opt), opt);
-}
-
-VALUE
 rb_reg_new_from_values(long cnt, const VALUE *elements, int opt)
 {
     const VALUE ary = rb_ary_tmp_new_from_values(0, cnt, elements);
-    VALUE val = rb_reg_new_ary(ary, (int)opt);
+    VALUE val = rb_reg_new_str(rb_reg_preprocess_dregexp(ary, opt), opt);
     rb_ary_clear(ary);
     return val;
 }

--- a/yjit/bindgen/src/main.rs
+++ b/yjit/bindgen/src/main.rs
@@ -180,7 +180,7 @@ fn main() {
         .allowlist_function("rb_reg_match_post")
         .allowlist_function("rb_reg_match_last")
         .allowlist_function("rb_reg_nth_match")
-        .allowlist_function("rb_reg_new_ary")
+        .allowlist_function("rb_reg_new_from_values")
 
         // `ruby_value_type` is a C enum and this stops it from
         // prefixing all the members with the name of the type

--- a/yjit/src/codegen.rs
+++ b/yjit/src/codegen.rs
@@ -10180,45 +10180,18 @@ fn gen_toregexp(
     let opt = jit.get_arg(0).as_i64();
     let cnt = jit.get_arg(1).as_usize();
 
-    // Save the PC and SP because this allocates an object and could
-    // raise an exception.
+    // Allocates objects and could raise an exception.
     jit_prepare_non_leaf_call(jit, asm);
 
     let values_ptr = asm.lea(asm.ctx.sp_opnd(-(cnt as i32)));
 
-    let ary = asm.ccall(
-        rb_ary_tmp_new_from_values as *const u8,
-        vec![
-            Opnd::Imm(0),
-            cnt.into(),
-            values_ptr,
-        ]
+    let regexp = asm.ccall(
+        rb_reg_new_from_values as _,
+        vec![cnt.into(), values_ptr, opt.into()],
     );
     asm.stack_pop(cnt); // Let ccall spill them
-
-    // Save the array so we can clear it later
-    asm.cpush(ary);
-    asm.cpush(ary); // Alignment
-
-    let val = asm.ccall(
-        rb_reg_new_ary as *const u8,
-        vec![
-            ary,
-            Opnd::Imm(opt),
-        ]
-    );
-
-    // The actual regex is in RAX now.  Pop the temp array from
-    // rb_ary_tmp_new_from_values into C arg regs so we can clear it
-    let ary = asm.cpop(); // Alignment
-    asm.cpop_into(ary);
-
-    // The value we want to push on the stack is in RAX right now
     let stack_ret = asm.stack_push(Type::UnknownHeap);
-    asm.mov(stack_ret, val);
-
-    // Clear the temp array.
-    asm.ccall(rb_ary_clear as *const u8, vec![ary]);
+    asm.mov(stack_ret, regexp);
 
     Some(KeepCompiling)
 }

--- a/yjit/src/cruby_bindings.inc.rs
+++ b/yjit/src/cruby_bindings.inc.rs
@@ -1076,7 +1076,11 @@ extern "C" {
     pub fn rb_obj_info_dump(obj: VALUE);
     pub fn rb_class_allocate_instance(klass: VALUE) -> VALUE;
     pub fn rb_obj_equal(obj1: VALUE, obj2: VALUE) -> VALUE;
-    pub fn rb_reg_new_ary(ary: VALUE, options: ::std::os::raw::c_int) -> VALUE;
+    pub fn rb_reg_new_from_values(
+        cnt: ::std::os::raw::c_long,
+        elements: *const VALUE,
+        opt: ::std::os::raw::c_int,
+    ) -> VALUE;
     pub fn rb_ary_tmp_new_from_values(
         arg1: VALUE,
         arg2: ::std::os::raw::c_long,

--- a/zjit/bindgen/src/main.rs
+++ b/zjit/bindgen/src/main.rs
@@ -215,7 +215,6 @@ fn main() {
         .allowlist_function("rb_reg_match_post")
         .allowlist_function("rb_reg_match_last")
         .allowlist_function("rb_reg_nth_match")
-        .allowlist_function("rb_reg_new_ary")
         .allowlist_function("rb_reg_new_from_values")
         .allowlist_var("ARG_ENCODING_FIXED")
         .allowlist_var("ARG_ENCODING_NONE")

--- a/zjit/src/cruby_bindings.inc.rs
+++ b/zjit/src/cruby_bindings.inc.rs
@@ -2059,7 +2059,6 @@ unsafe extern "C" {
     pub fn rb_const_get(space: VALUE, name: ID) -> VALUE;
     pub fn rb_class_allocate_instance(klass: VALUE) -> VALUE;
     pub fn rb_obj_equal(obj1: VALUE, obj2: VALUE) -> VALUE;
-    pub fn rb_reg_new_ary(ary: VALUE, options: ::std::os::raw::c_int) -> VALUE;
     pub fn rb_reg_new_from_values(
         cnt: ::std::os::raw::c_long,
         elements: *const VALUE,


### PR DESCRIPTION
ref: https://github.com/ruby/ruby/pull/17092#issuecomment-4523613486

    Delete now-unused rb_reg_new_ary()
    
    No more usages outside re.c, so let's clean it up. Thanks to @nobu for
    noticing!

---

    ZJIT: Delete binding for unused rb_reg_new_ary()

---

    YJIT: Use rb_reg_new_from_values() instead of rb_reg_new_ary()
    
    To sync up with ZJIT and insns.def.
