### PR TITLE
[DOC] Document that RUBY_MAX_CPU affects ractors

### DIFF
--- a/man/erb.1
+++ b/man/erb.1
@@ -1,5 +1,5 @@
 .\"Ruby is copyrighted by Yukihiro Matsumoto <matz@netlab.jp>.
-.Dd March 27, 2026
+.Dd June 07, 2026
 .Dt ERB 1 "Ruby Programmer's Reference Guide"
 .Os UNIX
 .Sh NAME

--- a/man/goruby.1
+++ b/man/goruby.1
@@ -1,5 +1,5 @@
 .\"Ruby is copyrighted by Yukihiro Matsumoto <matz@netlab.jp>.
-.Dd March 27, 2026
+.Dd June 07, 2026
 .Dt GORUBY 1 "Ruby Programmer's Reference Guide"
 .Os UNIX
 .Sh NAME

--- a/man/ruby.1
+++ b/man/ruby.1
@@ -1,5 +1,5 @@
 .\"Ruby is copyrighted by Yukihiro Matsumoto <matz@netlab.jp>.
-.Dd March 27, 2026
+.Dd June 07, 2026
 .Dt RUBY 1 "Ruby Programmer's Reference Guide"
 .Os UNIX
 .Sh NAME
@@ -536,7 +536,9 @@ The custom default buffer size of
 .Pp
 .It Ev RUBY_MAX_CPU
 The maximum number of native threads used by M:N Threads scheduler
-Introduced in Ruby 3.3, default: 8.
+Introduced in Ruby 3.3, default: number of online CPUs.
+As non-main ractors use M:N Threads scheduler, this also sets the
+maximum number of native threads that non-main ractors will use.
 .Pp
 .It Ev RUBY_MN_THREADS
 If set to


### PR DESCRIPTION
This is implied by the fact that non-main ractors use the M:N thread scheduler, but I expect that some users are not aware of this.