### PR TITLE
Fix documentation indentation for thread_sync.rb

### DIFF
--- a/thread_sync.rb
+++ b/thread_sync.rb
@@ -11,23 +11,23 @@ class Thread
   #
   #  Example:
   #
-  #    	queue = Thread::Queue.new
+  #     queue = Thread::Queue.new
   #
-  #	    producer = Thread.new do
-  #	      5.times do |i|
-  #	        sleep rand(i) # simulate expense
-  #	        queue << i
-  #	        puts "#{i} produced"
-  #	      end
-  #	    end
+  #     producer = Thread.new do
+  #       5.times do |i|
+  #         sleep rand(i) # simulate expense
+  #         queue << i
+  #         puts "#{i} produced"
+  #       end
+  #     end
   #
-  #	    consumer = Thread.new do
-  #	      5.times do |i|
-  #	        value = queue.pop
-  #	        sleep rand(i/2) # simulate expense
-  #	        puts "consumed #{value}"
-  #	      end
-  #	    end
+  #     consumer = Thread.new do
+  #       5.times do |i|
+  #         value = queue.pop
+  #         sleep rand(i/2) # simulate expense
+  #         puts "consumed #{value}"
+  #       end
+  #     end
   #
   #     consumer.join
   class Queue
@@ -42,13 +42,13 @@ class Thread
     #
     # Example:
     #
-    #    	q = Thread::Queue.new
+    #     q = Thread::Queue.new
     #     #=> #<Thread::Queue:0x00007ff7501110d0>
     #     q.empty?
     #     #=> true
     #
-    #    	q = Thread::Queue.new([1, 2, 3])
-    #    	#=> #<Thread::Queue:0x00007ff7500ec500>
+    #     q = Thread::Queue.new([1, 2, 3])
+    #     #=> #<Thread::Queue:0x00007ff7500ec500>
     #     q.empty?
     #     #=> false
     #     q.pop
@@ -113,7 +113,7 @@ class Thread
     #
     # Example:
     #
-    #    	q = Thread::Queue.new
+    #      q = Thread::Queue.new
     #      Thread.new{
     #        while e = q.deq # wait for nil to break loop
     #          # ...


### PR DESCRIPTION
The documentation for `Thread::Queue` and `Thread::Queue.new` includes tabs that have misformatted the indentations.

## Before

**Thread::Queue**
<img width="944" height="643" alt="image" src="https://github.com/user-attachments/assets/43d61dcf-ea8d-4503-bbc0-58439052d920" />

**Thread::Queue.new**
<img width="923" height="413" alt="image" src="https://github.com/user-attachments/assets/d8f52528-1bdf-4165-9ffb-2064ad3c20fa" />

## After

<img width="986" height="661" alt="image" src="https://github.com/user-attachments/assets/a775e591-0520-4995-ae8a-b2b456ea3679" />

<img width="921" height="400" alt="image" src="https://github.com/user-attachments/assets/7772268e-1aff-4fcd-a65d-1a930baa0c93" />
