### PR TITLE
ZJIT: Stop tracking locals in FrameState and instead use EP memory

### DIFF
--- a/zjit/src/backend/arm64/mod.rs
+++ b/zjit/src/backend/arm64/mod.rs
@@ -1763,7 +1763,7 @@ mod tests {
 
         let val64 = asm.add(CFP, Opnd::UImm(64));
         asm.store(Opnd::mem(64, SP, 0x10), val64);
-        let side_exit = Target::SideExit { reason: SideExitReason::Interrupt, exit: SideExit { pc: 0.into(), iseq: std::ptr::null(), stack: vec![], locals: vec![], recompile: None } };
+        let side_exit = Target::SideExit { reason: SideExitReason::Interrupt, exit: SideExit { pc: 0.into(), iseq: std::ptr::null(), stack: vec![], recompile: None } };
         asm.push_insn(Insn::Joz(val64, side_exit));
         asm.mov(C_ARG_OPNDS[0], C_RET_OPND.with_num_bits(32));
         asm.mov(C_ARG_OPNDS[1], Opnd::mem(64, SP, -8));

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::mem::take;
 use std::rc::Rc;
 use crate::bitset::BitSet;
-use crate::codegen::{local_size_and_idx_to_ep_offset, perf_symbol_range_start, perf_symbol_range_end};
+use crate::codegen::{perf_symbol_range_start, perf_symbol_range_end};
 use crate::cruby::{IseqPtr, Qundef, RUBY_OFFSET_CFP_ISEQ, RUBY_OFFSET_CFP_JIT_RETURN, RUBY_OFFSET_CFP_PC, RUBY_OFFSET_CFP_SP, SIZEOF_VALUE_I32, vm_stack_canary};
 use crate::hir::{Invariant, SideExitReason};
 use crate::hir;
@@ -548,7 +548,6 @@ impl From<VALUE> for Opnd {
 pub struct SideExit {
     pub pc: Opnd,
     pub stack: Vec<Opnd>,
-    pub locals: Vec<Opnd>,
     pub iseq: IseqPtr,
     /// If set, the side exit will call the recompile function with these arguments
     /// to profile the send and invalidate the ISEQ for recompilation.
@@ -1121,17 +1120,10 @@ impl<'a> Iterator for InsnOpndIterator<'a> {
             Insn::LeaJumpTarget { target, .. } |
             Insn::PatchPoint { target, .. } => {
                 match target {
-                    Target::SideExit { exit: SideExit { stack, locals, .. }, .. } => {
+                    Target::SideExit { exit: SideExit { stack, .. }, .. } => {
                         let stack_idx = self.idx;
                         if stack_idx < stack.len() {
                             let opnd = &stack[stack_idx];
-                            self.idx += 1;
-                            return Some(opnd);
-                        }
-
-                        let local_idx = self.idx - stack.len();
-                        if local_idx < locals.len() {
-                            let opnd = &locals[local_idx];
                             self.idx += 1;
                             return Some(opnd);
                         }
@@ -1157,17 +1149,10 @@ impl<'a> Iterator for InsnOpndIterator<'a> {
                 }
 
                 match target {
-                    Target::SideExit { exit: SideExit { stack, locals, .. }, .. } => {
+                    Target::SideExit { exit: SideExit { stack, .. }, .. } => {
                         let stack_idx = self.idx - 1;
                         if stack_idx < stack.len() {
                             let opnd = &stack[stack_idx];
-                            self.idx += 1;
-                            return Some(opnd);
-                        }
-
-                        let local_idx = stack_idx - stack.len();
-                        if local_idx < locals.len() {
-                            let opnd = &locals[local_idx];
                             self.idx += 1;
                             return Some(opnd);
                         }
@@ -1299,17 +1284,10 @@ impl<'a> InsnOpndMutIterator<'a> {
             Insn::LeaJumpTarget { target, .. } |
             Insn::PatchPoint { target, .. } => {
                 match target {
-                    Target::SideExit { exit: SideExit { stack, locals, .. }, .. } => {
+                    Target::SideExit { exit: SideExit { stack, .. }, .. } => {
                         let stack_idx = self.idx;
                         if stack_idx < stack.len() {
                             let opnd = &mut stack[stack_idx];
-                            self.idx += 1;
-                            return Some(opnd);
-                        }
-
-                        let local_idx = self.idx - stack.len();
-                        if local_idx < locals.len() {
-                            let opnd = &mut locals[local_idx];
                             self.idx += 1;
                             return Some(opnd);
                         }
@@ -1335,17 +1313,10 @@ impl<'a> InsnOpndMutIterator<'a> {
                 }
 
                 match target {
-                    Target::SideExit { exit: SideExit { stack, locals, .. }, .. } => {
+                    Target::SideExit { exit: SideExit { stack, .. }, .. } => {
                         let stack_idx = self.idx - 1;
                         if stack_idx < stack.len() {
                             let opnd = &mut stack[stack_idx];
-                            self.idx += 1;
-                            return Some(opnd);
-                        }
-
-                        let local_idx = stack_idx - stack.len();
-                        if local_idx < locals.len() {
-                            let opnd = &mut locals[local_idx];
                             self.idx += 1;
                             return Some(opnd);
                         }
@@ -2620,9 +2591,9 @@ impl Assembler
     /// Returns the exit code as a list of instructions to be appended after the main
     /// code is linearized and split.
     pub fn compile_exits(&mut self) -> Vec<Insn> {
-        /// Restore VM state (cfp->pc, cfp->sp, stack, locals) for the side exit.
+        /// Restore VM state (cfp->pc, cfp->sp, stack) for the side exit.
         fn compile_exit_save_state(asm: &mut Assembler, exit: &SideExit) {
-            let SideExit { pc, stack, locals, iseq, .. } = exit;
+            let SideExit { pc, stack, iseq, .. } = exit;
 
             // Side exit blocks are not part of the CFG at the moment,
             // so we need to manually ensure that patchpoints get padded
@@ -2644,13 +2615,6 @@ impl Assembler
                 asm_comment!(asm, "write stack slots: {}", join_opnds(&stack, ", "));
                 for (idx, &opnd) in stack.iter().enumerate() {
                     asm.store(Opnd::mem(64, SP, idx as i32 * SIZEOF_VALUE_I32), opnd);
-                }
-            }
-
-            if !locals.is_empty() {
-                asm_comment!(asm, "write locals: {}", join_opnds(&locals, ", "));
-                for (idx, &opnd) in locals.iter().enumerate() {
-                    asm.store(Opnd::mem(64, SP, (-local_size_and_idx_to_ep_offset(locals.len(), idx) - 1) * SIZEOF_VALUE_I32), opnd);
                 }
             }
         }

--- a/zjit/src/backend/x86_64/mod.rs
+++ b/zjit/src/backend/x86_64/mod.rs
@@ -1395,7 +1395,7 @@ mod tests {
 
         let val64 = asm.add(CFP, Opnd::UImm(64));
         asm.store(Opnd::mem(64, SP, 0x10), val64);
-        let side_exit = Target::SideExit { reason: SideExitReason::Interrupt, exit: SideExit { pc: 0.into(), iseq: std::ptr::null(), stack: vec![], locals: vec![], recompile: None } };
+        let side_exit = Target::SideExit { reason: SideExitReason::Interrupt, exit: SideExit { pc: 0.into(), iseq: std::ptr::null(), stack: vec![], recompile: None } };
         asm.push_insn(Insn::Joz(val64, side_exit));
         asm.mov(C_ARG_OPNDS[0], C_RET_OPND.with_num_bits(32));
         asm.mov(C_ARG_OPNDS[1], Opnd::mem(64, SP, -8));

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -2777,14 +2777,9 @@ fn gen_save_sp(asm: &mut Assembler, stack_size: usize) {
     asm.mov(cfp_sp, sp_addr);
 }
 
-/// Spill locals onto the stack.
-fn gen_spill_locals(jit: &JITState, asm: &mut Assembler, state: &FrameState) {
-    // TODO: Avoid spilling locals that have been spilled before and not changed.
-    gen_incr_counter(asm, Counter::vm_write_locals_count);
-    asm_comment!(asm, "spill locals");
-    for (idx, &insn_id) in state.locals().enumerate() {
-        asm.mov(Opnd::mem(64, SP, (-local_idx_to_ep_offset(state.iseq, idx) - 1) * SIZEOF_VALUE_I32), jit.get_opnd(insn_id));
-    }
+/// Spill locals onto the stack. Does nothing for now since locals are eagerly
+/// written through EP.
+fn gen_spill_locals(_jit: &JITState, _asm: &mut Assembler, _state: &FrameState) {
 }
 
 /// Spill the virtual stack onto the stack.
@@ -2972,15 +2967,9 @@ fn build_side_exit(jit: &JITState, state: &FrameState) -> SideExit {
         stack.push(jit.get_opnd(insn_id));
     }
 
-    let mut locals = Vec::new();
-    for &insn_id in state.locals() {
-        locals.push(jit.get_opnd(insn_id));
-    }
-
     SideExit{
         pc: Opnd::const_ptr(state.pc),
         stack,
-        locals,
         iseq: state.iseq,
         recompile: None,
     }

--- a/zjit/src/codegen_tests.rs
+++ b/zjit/src/codegen_tests.rs
@@ -6,7 +6,7 @@ use crate::backend::lir::Assembler;
 use crate::codegen::max_iseq_versions;
 use crate::cruby::*;
 use crate::hir::{Insn, iseq_to_hir};
-use crate::options::{rb_zjit_prepare_options, set_call_threshold};
+use crate::options::{rb_zjit_prepare_options, set_call_threshold, self};
 use crate::payload::IseqVersion;
 use crate::hir::tests::hir_build_tests::assert_contains_opcode;
 use crate::payload::*;
@@ -5710,4 +5710,42 @@ fn test_getlocal_level_zero_after_setlocal_wc_0() {
         end
         test
     "#), @"2");
+}
+
+#[test]
+fn test_disable_hir_opt_with_eval() {
+    // Regression test: --zjit-disable-hir-opt did not properly
+    // use speculations related to environment escape
+    set_call_threshold(1);
+    options::disable_hir_opt();
+    assert_snapshot!(inspect("
+        def test
+          ofor = nil
+          n = 0
+          eval('n = 2')
+          raise unless ofor.nil?
+          raise %Q(n=#{n} and !=2) unless n == 2
+        end
+        test
+        test
+    "), @"nil");
+}
+
+#[test]
+fn test_local_access_around_trivial_inlining() {
+    // Regression test for https://github.com/Shopify/ruby/issues/976
+    // where local variable reloading logic had a conflict with
+    // the trivial inliner, giving incorrect results.
+    set_call_threshold(2);
+    assert_snapshot!(inspect("
+        def foo(&block) = 1
+
+        def test
+          a = 1
+          foo {}
+          a
+        end
+
+        [test, test]
+    "), @"[1, 1]");
 }

--- a/zjit/src/cruby_methods.rs
+++ b/zjit/src/cruby_methods.rs
@@ -1013,6 +1013,7 @@ fn inline_kernel_class(fun: &mut hir::Function, block: hir::BlockId, _recv: hir:
 /// num is always a Fixnum (starts at 0 and is incremented by fixnum_inc).
 fn inline_fixnum_inc(fun: &mut hir::Function, block: hir::BlockId, _recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[_self, num] = args else { return None; };
+    let num = fun.coerce_to(block, num, types::Fixnum, state);
     let one = fun.push_insn(block, hir::Insn::Const { val: hir::Const::Value(VALUE::fixnum_from_usize(1)) });
     let result = fun.push_insn(block, hir::Insn::FixnumAdd { left: num, right: one, state });
     Some(result)
@@ -1023,6 +1024,7 @@ fn inline_fixnum_inc(fun: &mut hir::Function, block: hir::BlockId, _recv: hir::I
 fn inline_ary_at(fun: &mut hir::Function, block: hir::BlockId, _recv: hir::InsnId, args: &[hir::InsnId], _state: hir::InsnId) -> Option<hir::InsnId> {
     let &[recv, index] = args else { return None; };
     let recv = fun.push_insn(block, hir::Insn::RefineType { val: recv, new_type: types::Array });
+    let index = fun.coerce_to(block, index, types::Fixnum, _state);
     let index = fun.push_insn(block, hir::Insn::UnboxFixnum { val: index });
     let result = fun.push_insn(block, hir::Insn::ArrayAref { array: recv, index });
     Some(result)
@@ -1033,6 +1035,7 @@ fn inline_ary_at(fun: &mut hir::Function, block: hir::BlockId, _recv: hir::InsnI
 fn inline_ary_at_end(fun: &mut hir::Function, block: hir::BlockId, _recv: hir::InsnId, args: &[hir::InsnId], state: hir::InsnId) -> Option<hir::InsnId> {
     let &[recv, index] = args else { return None; };
     let recv = fun.push_insn(block, hir::Insn::RefineType { val: recv, new_type: types::Array });
+    let index = fun.coerce_to(block, index, types::Fixnum, state);
     let length_cint = fun.push_insn(block, hir::Insn::ArrayLength { array: recv });
     let length = fun.push_insn(block, hir::Insn::BoxFixnum { val: length_cint, state });
     let result = fun.push_insn(block, hir::Insn::FixnumGe { left: index, right: length });

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1318,7 +1318,6 @@ macro_rules! for_each_operand_impl {
             }
             Insn::Snapshot { state } => {
                 $visit_many!(state.stack);
-                $visit_many!(state.locals);
             }
             Insn::FixnumAdd { left, right, state }
             | Insn::FixnumSub { left, right, state }
@@ -3022,20 +3021,7 @@ impl Function {
 
     /// Set self.param_types. They are copied to the param types of jit_entry_blocks.
     fn set_param_types(&mut self) {
-        let iseq = self.iseq;
-        let params = unsafe { iseq.params() };
-        let param_size = params.size.to_usize();
-        let rest_param_idx = iseq_rest_param_idx(params);
-
         self.param_types.push(types::BasicObject); // self
-        for local_idx in 0..param_size {
-            let param_type = if Some(local_idx as i32) == rest_param_idx {
-                types::ArrayExact // Rest parameters are always ArrayExact
-            } else {
-                types::BasicObject
-            };
-            self.param_types.push(param_type);
-        }
     }
 
     /// Copy self.param_types to the param types of jit_entry_blocks.
@@ -4571,17 +4557,6 @@ impl Function {
     fn gen_patch_points_for_optimized_ccall(&mut self, block: BlockId, recv_class: VALUE, method_id: ID, cme: *const rb_callable_method_entry_struct, state: InsnId) {
         self.push_insn(block, Insn::PatchPoint { invariant: Invariant::NoTracePoint, state });
         self.push_insn(block, Insn::PatchPoint { invariant: Invariant::MethodRedefined { klass: recv_class, method: method_id, cme }, state });
-    }
-
-    /// Side exit back to the state after a block-backed send.
-    /// Using the pre-send snapshot would re-execute the send in the interpreter.
-    fn gen_post_send_no_ep_escape_patch_point(&mut self, block: BlockId, state: &FrameState, insn_idx: u32) {
-        let iseq = state.iseq;
-        let mut reload_state = state.clone();
-        reload_state.insn_idx = insn_idx as usize;
-        reload_state.pc = unsafe { rb_iseq_pc_at_idx(iseq, insn_idx) };
-        let reload_exit_id = self.push_insn(block, Insn::Snapshot { state: reload_state.without_locals() });
-        self.push_insn(block, Insn::PatchPoint { invariant: Invariant::NoEPEscape(iseq), state: reload_exit_id });
     }
 
     fn count_not_inlined_cfunc(&mut self, block: BlockId, cme: *const rb_callable_method_entry_t) {
@@ -6313,20 +6288,12 @@ pub struct FrameState {
     pub pc: *const VALUE,
 
     stack: Vec<InsnId>,
-    locals: Vec<InsnId>,
 }
 
 impl FrameState {
     /// Get the YARV instruction index for the current instruction
     pub fn insn_idx(&self) -> YarvInsnIdx {
         self.insn_idx
-    }
-
-    /// Return itself without locals. Useful for side-exiting without spilling locals.
-    fn without_locals(&self) -> Self {
-        let mut state = self.clone();
-        state.locals.clear();
-        state
     }
 
     /// Return itself without stack. Used by leaf calls with GC to reset SP to the base pointer.
@@ -6348,11 +6315,6 @@ impl FrameState {
 
     fn replace(&mut self, old: InsnId, new: InsnId) {
         for slot in &mut self.stack {
-            if *slot == old {
-                *slot = new;
-            }
-        }
-        for slot in &mut self.locals {
             if *slot == old {
                 *slot = new;
             }
@@ -6394,7 +6356,7 @@ fn ep_offset_to_local_idx(iseq: IseqPtr, ep_offset: u32) -> usize {
 
 impl FrameState {
     fn new(iseq: IseqPtr) -> FrameState {
-        FrameState { iseq, pc: std::ptr::null::<VALUE>(), insn_idx: 0, stack: vec![], locals: vec![] }
+        FrameState { iseq, pc: std::ptr::null::<VALUE>(), insn_idx: 0, stack: vec![] }
     }
 
     /// Get the number of stack operands
@@ -6405,11 +6367,6 @@ impl FrameState {
     /// Iterate over all stack slots
     pub fn stack(&self) -> Iter<'_, InsnId> {
         self.stack.iter()
-    }
-
-    /// Iterate over all local variables
-    pub fn locals(&self) -> Iter<'_, InsnId> {
-        self.locals.iter()
     }
 
     /// Push a stack operand
@@ -6449,16 +6406,6 @@ impl FrameState {
         self.stack.get(idx).ok_or_else(|| ParseError::StackUnderflow(self.clone())).copied()
     }
 
-    fn setlocal(&mut self, ep_offset: u32, opnd: InsnId) {
-        let idx = ep_offset_to_local_idx(self.iseq, ep_offset);
-        self.locals[idx] = opnd;
-    }
-
-    fn getlocal(&mut self, ep_offset: u32) -> InsnId {
-        let idx = ep_offset_to_local_idx(self.iseq, ep_offset);
-        self.locals[idx]
-    }
-
     fn as_args(&self, self_param: InsnId) -> Vec<InsnId> {
         // We're currently passing around the self parameter as a basic block
         // argument because the register allocator uses a fixed register based
@@ -6467,7 +6414,7 @@ impl FrameState {
         // TODO: Modify the register allocator to allow reusing an argument
         // of another basic block.
         let mut args = vec![self_param];
-        args.extend(self.locals.iter().chain(self.stack.iter()).copied());
+        args.extend(self.stack.iter().copied());
         args
     }
 
@@ -6486,14 +6433,7 @@ impl Display for FrameStatePrinter<'_> {
         let inner = self.inner;
         write!(f, "FrameState {{ pc: {:?}, stack: ", self.ptr_map.map_ptr(inner.pc))?;
         write_vec(f, &inner.stack)?;
-        write!(f, ", locals: [")?;
-        for (idx, local) in inner.locals.iter().enumerate() {
-            let name: ID = unsafe { rb_zjit_local_id(inner.iseq, idx.try_into().unwrap()) };
-            let name = name.contents_lossy();
-            if idx > 0 { write!(f, ", ")?; }
-            write!(f, "{name}={local}")?;
-        }
-        write!(f, "] }}")
+        write!(f, " }}")
     }
 }
 
@@ -6632,24 +6572,6 @@ impl ProfileOracle {
     }
 }
 
-fn invalidates_locals(opcode: u32, operands: *const VALUE) -> bool {
-    match opcode {
-        // Control-flow is non-leaf in the interpreter because it can execute arbitrary code on
-        // interrupt. But in the JIT, we side-exit if there is a pending interrupt.
-        YARVINSN_jump
-        | YARVINSN_branchunless
-        | YARVINSN_branchif
-        | YARVINSN_branchnil
-        | YARVINSN_jump_without_ints
-        | YARVINSN_branchunless_without_ints
-        | YARVINSN_branchif_without_ints
-        | YARVINSN_branchnil_without_ints
-        | YARVINSN_leave => false,
-        // TODO(max): Read the invokebuiltin target from operands and determine if it's leaf
-        _ => unsafe { !rb_zjit_insn_leaf(opcode as i32, operands) }
-    }
-}
-
 /// The index of the self parameter in the HIR function
 pub const SELF_PARAM_IDX: usize = 0;
 
@@ -6695,25 +6617,17 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
         compile_jit_entry_block(&mut fun, jit_entry_idx, target_block);
     }
 
-    // Check if the EP is escaped for the ISEQ from the beginning. We give up
-    // optimizing locals in that case because they're shared with other frames.
-    let ep_starts_escaped = iseq_escapes_ep(iseq);
-    // Check if the EP has been escaped at some point in the ISEQ. If it has, then we assume that
-    // its EP is shared with other frames.
-    let ep_has_been_escaped = crate::invariants::iseq_escapes_ep(iseq);
-    let ep_escaped = ep_starts_escaped || ep_has_been_escaped;
-
     // Iteratively fill out basic blocks using a queue.
     // TODO(max): Basic block arguments at edges
     let mut queue = VecDeque::new();
     for &insn_idx in jit_entry_insns.iter() {
-        queue.push_back((FrameState::new(iseq), insn_idx_to_block[&insn_idx], /*insn_idx=*/insn_idx, /*local_inval=*/false));
+        queue.push_back((FrameState::new(iseq), insn_idx_to_block[&insn_idx], /*insn_idx=*/insn_idx));
     }
 
     // Keep compiling blocks until the queue becomes empty
     let mut visited = HashSet::new();
     let iseq_size = unsafe { get_iseq_encoded_size(iseq) };
-    while let Some((incoming_state, mut block, mut insn_idx, mut local_inval)) = queue.pop_front() {
+    while let Some((incoming_state, mut block, mut insn_idx)) = queue.pop_front() {
         // Compile each block only once
         if visited.contains(&block) { continue; }
         visited.insert(block);
@@ -6722,10 +6636,6 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
         let mut self_param = fun.push_insn(block, Insn::Param);
         let mut state = {
             let mut result = FrameState::new(iseq);
-            let local_size = if jit_entry_insns.contains(&insn_idx) { num_locals(iseq) } else { incoming_state.locals.len() };
-            for _ in 0..local_size {
-                result.locals.push(fun.push_insn(block, Insn::Param));
-            }
             for _ in incoming_state.stack {
                 result.stack.push(fun.push_insn(block, Insn::Param));
             }
@@ -6818,11 +6728,6 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
             }
             else {
                 profiles.profile_stack(&exit_state);
-            }
-
-            // Flag a future getlocal/setlocal to add a patch point if this instruction is not leaf.
-            if invalidates_locals(opcode, unsafe { pc.offset(1) }) {
-                local_inval = true;
             }
 
             // We add NoTracePoint patch points before every instruction that could be affected by TracePoint.
@@ -7090,18 +6995,8 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let ep_offset = get_arg(pc, 0).as_u32();
                     let index = get_arg(pc, 1).as_u64();
                     let index: u8 = index.try_into().map_err(|_| ParseError::MalformedIseq(insn_idx))?;
-                    // Use FrameState to get kw_bits when possible, just like getlocal_WC_0.
-                    let val = if !local_inval {
-                        state.getlocal(ep_offset)
-                    } else if ep_escaped {
-                        let ep = fun.push_insn(block, Insn::GetEP { level: 0 });
-                        fun.get_local_from_ep(block, ep, ep_offset, 0, types::BasicObject)
-                    } else {
-                        let exit_id = fun.push_insn(block, Insn::Snapshot { state: exit_state.without_locals() });
-                        fun.push_insn(block, Insn::PatchPoint { invariant: Invariant::NoEPEscape(iseq), state: exit_id });
-                        local_inval = false;
-                        state.getlocal(ep_offset)
-                    };
+                    let ep = fun.push_insn(block, Insn::GetEP { level: 0 });
+                    let val = fun.get_local_from_ep(block, ep, ep_offset, 0, types::BasicObject);
                     state.stack_push(fun.push_insn(block, Insn::FixnumBitCheck { val, index }));
                 }
                 YARVINSN_checkmatch => {
@@ -7173,7 +7068,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let not_nil_false_type = types::Truthy;
                     let not_nil_false = fun.push_insn(block, Insn::RefineType { val, new_type: not_nil_false_type });
                     state.replace(val, not_nil_false);
-                    queue.push_back((state.clone(), target, target_idx, local_inval));
+                    queue.push_back((state.clone(), target, target_idx));
                 }
                 YARVINSN_branchif | YARVINSN_branchif_without_ints => {
                     if opcode == YARVINSN_branchif {
@@ -7202,7 +7097,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let nil_false_type = types::Falsy;
                     let nil_false = fun.push_insn(block, Insn::RefineType { val, new_type: nil_false_type });
                     state.replace(val, nil_false);
-                    queue.push_back((state.clone(), target, target_idx, local_inval));
+                    queue.push_back((state.clone(), target, target_idx));
                 }
                 YARVINSN_branchnil | YARVINSN_branchnil_without_ints => {
                     if opcode == YARVINSN_branchnil {
@@ -7229,7 +7124,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let new_type = types::NotNil;
                     let not_nil = fun.push_insn(block, Insn::RefineType { val, new_type });
                     state.replace(val, not_nil);
-                    queue.push_back((state.clone(), target, target_idx, local_inval));
+                    queue.push_back((state.clone(), target, target_idx));
                 }
                 YARVINSN_opt_case_dispatch => {
                     // TODO: Some keys are visible at compile time, so in the future we can
@@ -7261,7 +7156,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                         if_false: BranchEdge { target, args: state.as_args(self_param) }
                     });
                     block = fall_through;
-                    queue.push_back((state.clone(), target, target_idx, local_inval));
+                    queue.push_back((state.clone(), target, target_idx));
 
                     // Move on to the fast path
                     let insn_id = fun.push_insn(block, Insn::ObjectAlloc { val, state: exit_id });
@@ -7278,50 +7173,19 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let _branch_id = fun.push_insn(block, Insn::Jump(
                         BranchEdge { target, args: state.as_args(self_param) }
                     ));
-                    queue.push_back((state.clone(), target, target_idx, local_inval));
+                    queue.push_back((state.clone(), target, target_idx));
                     break;  // Don't enqueue the next block as a successor
                 }
                 YARVINSN_getlocal_WC_0 => {
                     let ep_offset = get_arg(pc, 0).as_u32();
-                    if !local_inval {
-                        // The FrameState is the source of truth for locals until invalidated.
-                        // In case of JIT-to-JIT send locals might never end up in EP memory.
-                        let val = state.getlocal(ep_offset);
-                        state.stack_push(val);
-                    } else if ep_escaped {
-                        // Read the local using EP
-                        let ep = fun.push_insn(block, Insn::GetEP { level: 0 });
-                        let val = fun.get_local_from_ep(block, ep, ep_offset, 0, types::BasicObject);
-                        state.setlocal(ep_offset, val); // remember the result to spill on side-exits
-                        state.stack_push(val);
-                    } else {
-                        assert!(local_inval); // if check above
-                        // There has been some non-leaf call since JIT entry or the last patch point,
-                        // so add a patch point to make sure locals have not been escaped.
-                        let exit_id = fun.push_insn(block, Insn::Snapshot { state: exit_state.without_locals() }); // skip spilling locals
-                        fun.push_insn(block, Insn::PatchPoint { invariant: Invariant::NoEPEscape(iseq), state: exit_id });
-                        local_inval = false;
-
-                        // Read the local from FrameState
-                        let val = state.getlocal(ep_offset);
-                        state.stack_push(val);
-                    }
+                    let ep = fun.push_insn(block, Insn::GetEP { level: 0 });
+                    let val = fun.get_local_from_ep(block, ep, ep_offset, 0, types::BasicObject);
+                    state.stack_push(val);
                 }
                 YARVINSN_setlocal_WC_0 => {
                     let ep_offset = get_arg(pc, 0).as_u32();
                     let val = state.stack_pop()?;
-                    if ep_escaped {
-                        // Write the local using EP
-                        fun.push_insn(block, Insn::SetLocal { val, ep_offset, level: 0 });
-                    } else if local_inval {
-                        // If there has been any non-leaf call since JIT entry or the last patch point,
-                        // add a patch point to make sure locals have not been escaped.
-                        let exit_id = fun.push_insn(block, Insn::Snapshot { state: exit_state.without_locals() }); // skip spilling locals
-                        fun.push_insn(block, Insn::PatchPoint { invariant: Invariant::NoEPEscape(iseq), state: exit_id });
-                        local_inval = false;
-                    }
-                    // Write the local into FrameState
-                    state.setlocal(ep_offset, val);
+                    fun.push_insn(block, Insn::SetLocal { val, ep_offset, level: 0 });
                 }
                 YARVINSN_getlocal_WC_1 => {
                     let ep_offset = get_arg(pc, 0).as_u32();
@@ -7335,32 +7199,21 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                 YARVINSN_getlocal => {
                     let ep_offset = get_arg(pc, 0).as_u32();
                     let level = get_arg(pc, 1).as_u32();
-                    if level == 0 && !local_inval {
-                        // Same optimization as getlocal_WC_0: use FrameState
-                        let val = state.getlocal(ep_offset);
-                        state.stack_push(val);
-                    } else {
-                        let ep = fun.push_insn(block, Insn::GetEP { level });
-                        let val = fun.get_local_from_ep(block, ep, ep_offset, level, types::BasicObject);
-                        if level == 0 {
-                            state.setlocal(ep_offset, val);
-                        }
-                        state.stack_push(val);
-                    }
+                    let ep = fun.push_insn(block, Insn::GetEP { level });
+                    let val = fun.get_local_from_ep(block, ep, ep_offset, level, types::BasicObject);
+                    state.stack_push(val);
                 }
                 YARVINSN_setlocal => {
                     let ep_offset = get_arg(pc, 0).as_u32();
                     let level = get_arg(pc, 1).as_u32();
-                    fun.push_insn(block, Insn::SetLocal { val: state.stack_pop()?, ep_offset, level });
+                    let val = state.stack_pop()?;
+                    fun.push_insn(block, Insn::SetLocal { val, ep_offset, level });
                 }
                 YARVINSN_setblockparam => {
                     let ep_offset = get_arg(pc, 0).as_u32();
                     let level = get_arg(pc, 1).as_u32();
                     let val = state.stack_pop()?;
                     fun.push_insn(block, Insn::SetLocal { val, ep_offset, level });
-                    if level == 0 {
-                        state.setlocal(ep_offset, val);
-                    }
                     let ep = fun.push_insn(block, Insn::GetEP { level });
                     let flags = fun.push_insn(block, Insn::LoadField {
                         recv: ep,
@@ -7412,7 +7265,6 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let unmodified_block = fun.new_block(branch_insn_idx);
                     let join_block = insn_idx_to_block.get(&insn_idx).copied().unwrap_or_else(|| fun.new_block(insn_idx));
                     let join_result = fun.push_insn(join_block, Insn::Param);
-                    let join_local = if level == 0 { Some(fun.push_insn(join_block, Insn::Param)) } else { None };
 
                     let ep = fun.push_insn(block, Insn::GetEP { level });
                     let flags = fun.load_ep_flags(block, ep);
@@ -7426,14 +7278,11 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
                     // Push modified block: load the block local via EP.
                     let modified_val = fun.get_local_from_ep(modified_block, ep, ep_offset, level, types::BasicObject);
-                    let mut modified_args = vec![modified_val];
-                    if level == 0 { modified_args.push(modified_val); }
-                    fun.push_insn(modified_block, Insn::Jump(BranchEdge { target: join_block, args: modified_args }));
+                    fun.push_insn(modified_block, Insn::Jump(BranchEdge { target: join_block, args: vec![modified_val] }));
 
                     // Push unmodified block: inspect the current block handler to
                     // decide whether this path returns `nil` or `BlockParamProxy`.
                     let block_handler = fun.push_insn(unmodified_block, Insn::LoadField { recv: ep, id: FieldName::VM_ENV_DATA_INDEX_SPECVAL, offset: SIZEOF_VALUE_I32 * VM_ENV_DATA_INDEX_SPECVAL, return_type: types::CInt64 });
-                    let original_local = if level == 0 { Some(state.getlocal(ep_offset)) } else { None };
                     // `block_handler & 1 == 1` accepts both ISEQ (0b01) and ifunc
                     // (0b11) handlers. Keep a compile-time check that this shortcut
                     // does not accidentally accept symbol block handlers.
@@ -7474,10 +7323,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyFallbackMiss, state: exit_id });
                             // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                             let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
-                            let mut args = vec![proxy_val];
-                            if let Some(local) = original_local {
-                                args.push(local);
-                            }
+                            let args = vec![proxy_val];
                             fun.push_insn(unmodified_block, Insn::Jump(BranchEdge { target: join_block, args }));
                         }
                         // A single supported profiled family. Emit a monomorphic fast path
@@ -7485,10 +7331,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             ProfiledBlockHandlerFamily::Nil => {
                                 fun.push_insn(unmodified_block, Insn::GuardBitEquals { val: block_handler, expected: Const::CInt64(VM_BLOCK_HANDLER_NONE.into()), reason: SideExitReason::BlockParamProxyNotNil, state: exit_id, recompile: None });
                                 let nil_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(Qnil) });
-                                let mut args = vec![nil_val];
-                                if let Some(local) = original_local {
-                                    args.push(local);
-                                }
+                                let args = vec![nil_val];
                                 fun.push_insn(unmodified_block, Insn::Jump(BranchEdge { target: join_block, args }));
                             }
                             ProfiledBlockHandlerFamily::IseqOrIfunc => {
@@ -7502,10 +7345,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                                 fun.push_insn(unmodified_block, Insn::GuardAnyBitSet { val: block_handler, mask: Const::CUInt64(0x1), mask_name: None, reason: SideExitReason::BlockParamProxyNotIseqOrIfunc, state: exit_id });
                                 // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                                 let proxy_val = fun.push_insn(unmodified_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
-                                let mut args = vec![proxy_val];
-                                if let Some(local) = original_local {
-                                    args.push(local);
-                                }
+                                let args = vec![proxy_val];
                                 fun.push_insn(unmodified_block, Insn::Jump(BranchEdge { target: join_block, args }));
                             }
                         },
@@ -7539,8 +7379,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                                         current_block = next_block;
 
                                         let val = fun.push_insn(profiled_block, Insn::Const { val: Const::Value(Qnil) });
-                                        let mut args = vec![val];
-                                        if let Some(local) = original_local { args.push(local); }
+                                        let args = vec![val];
                                         fun.push_insn(profiled_block, Insn::Jump(BranchEdge { target: join_block, args }));
 
                                     }
@@ -7569,8 +7408,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
                                         // TODO(Shopify/ruby#753): GC root, so we should be able to avoid unnecessary GC tracing
                                         let val = fun.push_insn(profiled_block, Insn::Const { val: Const::Value(unsafe { rb_block_param_proxy }) });
-                                        let mut args = vec![val];
-                                        if let Some(local) = original_local { args.push(local); }
+                                        let args = vec![val];
                                         fun.push_insn(profiled_block, Insn::Jump(BranchEdge { target: join_block, args }));
                                     },
                                 }
@@ -7582,9 +7420,6 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
 
                     // Continue compilation from the merged continuation block at the next
                     // instruction.
-                    if let Some(local_param) = join_local {
-                        state.setlocal(ep_offset, local_param);
-                    }
                     state.stack_push(join_result);
                     block = join_block;
                 }
@@ -7623,9 +7458,6 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     fun.push_insn(unmodified_block, Insn::Jump(BranchEdge { target: join_block, args: vec![unmodified_val] }));
 
                     // Continue compilation from the join block at the next instruction.
-                    if level == 0 {
-                        state.setlocal(ep_offset, join_param);
-                    }
                     state.stack_push(join_param);
                     block = join_block;
                 }
@@ -7824,16 +7656,13 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             new_type: Type,
                             insn_idx: u32,
                             exit_state: &FrameState,
-                            locals_count: usize,
                             stack_count: usize,
                             join_block: BlockId,
                         ) -> BlockId {
                             let block = fun.new_block(insn_idx);
                             let self_param = fun.push_insn(block, Insn::Param);
                             let mut state = exit_state.clone();
-                            state.locals.clear();
                             state.stack.clear();
-                            state.locals.extend((0..locals_count).map(|_| fun.push_insn(block, Insn::Param)));
                             state.stack.extend((0..stack_count).map(|_| fun.push_insn(block, Insn::Param)));
                             let snapshot = fun.push_insn(block, Insn::Snapshot { state: state.clone() });
                             let args = state.stack_pop_n(argc).unwrap();
@@ -7846,7 +7675,6 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             block
                         }
                         let branch_insn_idx = exit_state.insn_idx as u32;
-                        let locals_count = state.locals.len();
                         let stack_count = state.stack.len();
                         let recv = state.stack_topn(argc as usize)?;  // args are on top
                         let entry_args = state.as_args(self_param);
@@ -7864,7 +7692,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                                 seen_types.push(expected);
                                 let has_type = fun.push_insn(block, Insn::HasType { val: recv, expected });
                                 let iftrue_block =
-                                    new_branch_block(&mut fun, cd, argc as usize, opcode, expected, branch_insn_idx, &exit_state, locals_count, stack_count, join_block);
+                                    new_branch_block(&mut fun, cd, argc as usize, opcode, expected, branch_insn_idx, &exit_state, stack_count, join_block);
                                 let target = BranchEdge { target: iftrue_block, args: entry_args.clone() };
                                 let fall_through = fun.new_block(insn_idx);
                                 fun.push_insn(block, Insn::CondBranch {
@@ -7880,7 +7708,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                             // make the right number of Params
                             let mut join_state = state.clone();
                             join_state.stack_pop_n(argc as usize)?;
-                            queue.push_back((join_state, join_block, insn_idx, local_inval));
+                            queue.push_back((join_state, join_block, insn_idx));
                             // In the fallthrough case, do a generic interpreter send and then join.
                             let args = state.stack_pop_n(argc as usize)?;
                             let recv = state.stack_pop()?;
@@ -7925,31 +7753,6 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     };
                     let send = fun.push_insn(block, Insn::Send { recv, cd, block: block_handler, args, state: exit_id, reason: Uncategorized(opcode) });
                     state.stack_push(send);
-
-                    if let Some(BlockHandler::BlockIseq(_)) = block_handler {
-                        // Reload locals that may have been modified by the blockiseq.
-                        // TODO: Avoid reloading locals that are not referenced by the blockiseq
-                        // or not used after this. Max thinks we could eventually DCE them.
-                        if !ep_escaped && !state.locals.is_empty() {
-                            fun.gen_post_send_no_ep_escape_patch_point(block, &state, insn_idx);
-                        }
-                        let mut base: Option<InsnId> = None;
-                        for local_idx in 0..state.locals.len() {
-                            let ep_offset = local_idx_to_ep_offset(iseq, local_idx);
-                            let ep_offset_u32 = u32::try_from(ep_offset)
-                                .unwrap_or_else(|_| panic!("Could not convert ep_offset {ep_offset} to u32"));
-                            let recv = *base.get_or_insert_with(|| {
-                                let base_insn = if !ep_escaped { Insn::LoadSP } else { Insn::GetEP { level: 0 } };
-                                fun.push_insn(block, base_insn)
-                            });
-                            let val = if !ep_escaped {
-                                fun.get_local_from_sp(block, recv, ep_offset_u32, types::BasicObject)
-                            } else {
-                                fun.get_local_from_ep(block, recv, ep_offset_u32, 0, types::BasicObject)
-                            };
-                            state.setlocal(ep_offset_u32, val);
-                        }
-                    }
                 }
                 YARVINSN_sendforward => {
                     let cd: *const rb_call_data = get_arg(pc, 0).as_ptr();
@@ -7973,29 +7776,6 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let recv = state.stack_pop()?;
                     let send_forward = fun.push_insn(block, Insn::SendForward { recv, cd, blockiseq, args, state: exit_id, reason: SendForwardNotSpecialized });
                     state.stack_push(send_forward);
-
-                    if !blockiseq.is_null() {
-                        // Reload locals that may have been modified by the blockiseq.
-                        if !ep_escaped && !state.locals.is_empty() {
-                            fun.gen_post_send_no_ep_escape_patch_point(block, &state, insn_idx);
-                        }
-                        let mut base: Option<InsnId> = None;
-                        for local_idx in 0..state.locals.len() {
-                            let ep_offset = local_idx_to_ep_offset(iseq, local_idx);
-                            let ep_offset_u32 = u32::try_from(ep_offset)
-                                .unwrap_or_else(|_| panic!("Could not convert ep_offset {ep_offset} to u32"));
-                            let recv = *base.get_or_insert_with(|| {
-                                let base_insn = if !ep_escaped { Insn::LoadSP } else { Insn::GetEP { level: 0 } };
-                                fun.push_insn(block, base_insn)
-                            });
-                            let val = if !ep_escaped {
-                                fun.get_local_from_sp(block, recv, ep_offset_u32, types::BasicObject)
-                            } else {
-                                fun.get_local_from_ep(block, recv, ep_offset_u32, 0, types::BasicObject)
-                            };
-                            state.setlocal(ep_offset_u32, val);
-                        }
-                    }
                 }
                 YARVINSN_invokesuper => {
                     let cd: *const rb_call_data = get_arg(pc, 0).as_ptr();
@@ -8016,31 +7796,6 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let blockiseq: IseqPtr = get_arg(pc, 1).as_ptr();
                     let result = fun.push_insn(block, Insn::InvokeSuper { recv, cd, blockiseq, args, state: exit_id, reason: Uncategorized(opcode) });
                     state.stack_push(result);
-
-                    if !blockiseq.is_null() {
-                        // Reload locals that may have been modified by the blockiseq.
-                        // TODO: Avoid reloading locals that are not referenced by the blockiseq
-                        // or not used after this. Max thinks we could eventually DCE them.
-                        if !ep_escaped && !state.locals.is_empty() {
-                            fun.gen_post_send_no_ep_escape_patch_point(block, &state, insn_idx);
-                        }
-                        let mut base: Option<InsnId> = None;
-                        for local_idx in 0..state.locals.len() {
-                            let ep_offset = local_idx_to_ep_offset(iseq, local_idx);
-                            let ep_offset_u32 = u32::try_from(ep_offset)
-                                .unwrap_or_else(|_| panic!("Could not convert ep_offset {ep_offset} to u32"));
-                            let recv = *base.get_or_insert_with(|| {
-                                let base_insn = if !ep_escaped { Insn::LoadSP } else { Insn::GetEP { level: 0 } };
-                                fun.push_insn(block, base_insn)
-                            });
-                            let val = if !ep_escaped {
-                                fun.get_local_from_sp(block, recv, ep_offset_u32, types::BasicObject)
-                            } else {
-                                fun.get_local_from_ep(block, recv, ep_offset_u32, 0, types::BasicObject)
-                            };
-                            state.setlocal(ep_offset_u32, val);
-                        }
-                    }
                 }
                 YARVINSN_invokesuperforward => {
                     let cd: *const rb_call_data = get_arg(pc, 0).as_ptr();
@@ -8063,31 +7818,6 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let recv = state.stack_pop()?;
                     let result = fun.push_insn(block, Insn::InvokeSuperForward { recv, cd, blockiseq, args, state: exit_id, reason: InvokeSuperForwardNotSpecialized });
                     state.stack_push(result);
-
-                    if !blockiseq.is_null() {
-                        // Reload locals that may have been modified by the blockiseq.
-                        // TODO: Avoid reloading locals that are not referenced by the blockiseq
-                        // or not used after this. Max thinks we could eventually DCE them.
-                        if !ep_escaped && !state.locals.is_empty() {
-                            fun.gen_post_send_no_ep_escape_patch_point(block, &state, insn_idx);
-                        }
-                        let mut base: Option<InsnId> = None;
-                        for local_idx in 0..state.locals.len() {
-                            let ep_offset = local_idx_to_ep_offset(iseq, local_idx);
-                            let ep_offset_u32 = u32::try_from(ep_offset)
-                                .unwrap_or_else(|_| panic!("Could not convert ep_offset {ep_offset} to u32"));
-                            let recv = *base.get_or_insert_with(|| {
-                                let base_insn = if !ep_escaped { Insn::LoadSP } else { Insn::GetEP { level: 0 } };
-                                fun.push_insn(block, base_insn)
-                            });
-                            let val = if !ep_escaped {
-                                fun.get_local_from_sp(block, recv, ep_offset_u32, types::BasicObject)
-                            } else {
-                                fun.get_local_from_ep(block, recv, ep_offset_u32, 0, types::BasicObject)
-                            };
-                            state.setlocal(ep_offset_u32, val);
-                        }
-                    }
                 }
                 YARVINSN_invokeblock => {
                     let cd: *const rb_call_data = get_arg(pc, 0).as_ptr();
@@ -8325,8 +8055,12 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
                     let argc = bf.argc as usize;
 
                     let mut args = vec![self_param];
-                    for &local in state.locals().skip(index).take(argc) {
-                        args.push(local);
+                    let ep = fun.push_insn(block, Insn::GetEP { level: 0 });
+                    for local_idx in index..index + argc {
+                        let ep_offset = local_idx_to_ep_offset(iseq, local_idx);
+                        let ep_offset = u32::try_from(ep_offset)
+                            .unwrap_or_else(|_| panic!("Could not convert ep_offset {ep_offset} to u32"));
+                        args.push(fun.get_local_from_ep(block, ep, ep_offset, 0, types::BasicObject));
                     }
 
                     // Check if this builtin is annotated
@@ -8418,7 +8152,7 @@ pub fn iseq_to_hir(iseq: *const rb_iseq_t) -> Result<Function, ParseError> {
             if insn_idx_to_block.contains_key(&insn_idx) {
                 let target = insn_idx_to_block[&insn_idx];
                 fun.push_insn(block, Insn::Jump(BranchEdge { target, args: state.as_args(self_param) }));
-                queue.push_back((state, target, insn_idx, local_inval));
+                queue.push_back((state, target, insn_idx));
                 break;  // End the block
             }
         }
@@ -8494,41 +8228,9 @@ fn compile_entry_state(fun: &mut Function) -> (InsnId, FrameState) {
     fun.push_insn(entry_block, Insn::EntryPoint { jit_entry_idx: None });
 
     let iseq = fun.iseq;
-    let params = unsafe { iseq.params() };
-    let param_size = params.size.to_usize();
-    let rest_param_idx = iseq_rest_param_idx(params);
 
     let self_param = fun.push_insn(entry_block, Insn::LoadSelf);
-    let mut entry_state = FrameState::new(iseq);
-    // If the ISEQ does not escape EP, we can assume EP + 1 == SP
-    // TODO: This should maybe also consider if the EP has historically been escaped in this iseq.
-    // (see: https://github.com/Shopify/ruby/issues/774)
-    let use_sp = !iseq_escapes_ep(iseq);
-    let mut base: Option<InsnId> = None;
-    for local_idx in 0..num_locals(iseq) {
-        if local_idx < param_size {
-            let ep_offset = local_idx_to_ep_offset(iseq, local_idx);
-            let ep_offset_u32 = u32::try_from(ep_offset)
-                .unwrap_or_else(|_| panic!("Could not convert ep_offset {ep_offset} to u32"));
-            let return_type = if Some(local_idx as i32) == rest_param_idx {
-                types::ArrayExact
-            } else {
-                types::BasicObject
-            };
-            let recv = *base.get_or_insert_with(|| {
-                let base_insn = if use_sp { Insn::LoadSP } else { Insn::GetEP { level: 0 } };
-                fun.push_insn(entry_block, base_insn)
-            });
-            let val = if use_sp {
-                fun.get_local_from_sp(entry_block, recv, ep_offset_u32, return_type)
-            } else {
-                fun.get_local_from_ep(entry_block, recv, ep_offset_u32, 0, return_type)
-            };
-            entry_state.locals.push(val);
-        } else {
-            entry_state.locals.push(fun.push_insn(entry_block, Insn::Const { val: Const::Value(Qnil) }));
-        }
-    }
+    let entry_state = FrameState::new(iseq);
     (self_param, entry_state)
 }
 
@@ -8571,34 +8273,49 @@ fn compile_jit_entry_state(fun: &mut Function, jit_entry_block: BlockId, jit_ent
     let mut arg_idx: u32 = 0;
     let self_param = fun.push_insn(jit_entry_block, Insn::LoadArg { idx: arg_idx, id: FieldName::SelfParam, val_type: types::BasicObject });
     arg_idx += 1;
-    let mut entry_state = FrameState::new(iseq);
+    let entry_state = FrameState::new(iseq);
     let mut ep: Option<InsnId> = None;
     for local_idx in 0..num_locals(iseq) {
-        if (lead_num + passed_opt_num..lead_num + opt_num).contains(&local_idx) {
+        let ep_offset = local_idx_to_ep_offset(iseq, local_idx);
+        let ep_offset_u32 = u32::try_from(ep_offset)
+            .unwrap_or_else(|_| panic!("Could not convert ep_offset {ep_offset} to u32"));
+        let val = if (lead_num + passed_opt_num..lead_num + opt_num).contains(&local_idx) {
             // Omitted optionals are locals, so they start as nils before their code run
-            entry_state.locals.push(fun.push_insn(jit_entry_block, Insn::Const { val: Const::Value(Qnil) }));
+            fun.push_insn(jit_entry_block, Insn::Const { val: Const::Value(Qnil) })
         } else if Some(local_idx) == kw_bits_idx {
             // Read the kw_bits value written by the caller to the callee frame.
             // This tells us which optional keywords were NOT provided and need their defaults evaluated.
             // Note: The caller writes kw_bits to memory via gen_send_iseq_direct but does NOT pass it
             // as a C argument, so we must read it from EP memory rather than Param.
-            let ep_offset = local_idx_to_ep_offset(iseq, local_idx);
-            let ep_offset_u32 = u32::try_from(ep_offset)
-                .unwrap_or_else(|_| panic!("Could not convert ep_offset {ep_offset} to u32"));
             let ep = *ep.get_or_insert_with(|| fun.push_insn(jit_entry_block, Insn::GetEP { level: 0 }));
-            entry_state.locals.push(fun.get_local_from_ep(
-                jit_entry_block,
-                ep,
-                ep_offset_u32,
-                0,
-                types::BasicObject,
-            ));
+            fun.get_local_from_ep(jit_entry_block, ep, ep_offset_u32, 0, types::BasicObject)
         } else if local_idx < param_size {
             let id = unsafe { rb_zjit_local_id(iseq, local_idx.try_into().unwrap()) };
-            entry_state.locals.push(fun.push_insn(jit_entry_block, Insn::LoadArg { idx: arg_idx, id: id.into(), val_type: types::BasicObject }));
+            let v = fun.push_insn(jit_entry_block, Insn::LoadArg { idx: arg_idx, id: id.into(), val_type: types::BasicObject });
             arg_idx += 1;
+            v
         } else {
-            entry_state.locals.push(fun.push_insn(jit_entry_block, Insn::Const { val: Const::Value(Qnil) }));
+            fun.push_insn(jit_entry_block, Insn::Const { val: Const::Value(Qnil) })
+        };
+        // The JIT-to-JIT calling convention passes params in registers (via LoadArg), so EP memory
+        // is not eagerly populated. Spill every local to its EP slot here so subsequent getlocal/
+        // setlocal instructions, which always go through memory, see the correct values.
+        // kw_bits already lives in EP memory, so skip rewriting it.
+        if Some(local_idx) != kw_bits_idx {
+            // Set the local using EP.
+            // NOTE: Using raw StoreFields here instead of SetLocal since JIT-to-JIT calls never
+            // start with an escaped envrionment
+            let ep = *ep.get_or_insert_with(|| fun.push_insn(jit_entry_block, Insn::GetEP { level: 0 }));
+            let ep_offset = i32::try_from(ep_offset_u32)
+                .unwrap_or_else(|_| panic!("Could not convert ep_offset {ep_offset} to i32"));
+            let offset = -(SIZEOF_VALUE_I32 * ep_offset);
+
+            fun.push_insn(jit_entry_block, Insn::StoreField {
+                recv: ep,
+                id: get_local_var_id(iseq, 0, ep_offset_u32).into(),
+                offset,
+                val,
+            });
         }
     }
     (self_param, entry_state)

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -43,18 +43,30 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :cond@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:TrueClass = Const Value(true)
+          SetLocal :cond, l0, EP@3, v13
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :cond@0x1000
           CheckInterrupts
-          v25:Fixnum[3] = Const Value(3)
-          Return v25
+          v22:CBool = Test v19
+          CondBranch v22, bb5(), bb4(v9)
+        bb5():
+          v28:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Return v28
+        bb4(v33:BasicObject):
+          v37:Fixnum[4] = Const Value(4)
+          CheckInterrupts
+          Return v37
         ");
     }
 
@@ -75,18 +87,30 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :cond@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:FalseClass = Const Value(false)
+          SetLocal :cond, l0, EP@3, v13
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :cond@0x1000
           CheckInterrupts
-          v35:Fixnum[4] = Const Value(4)
-          Return v35
+          v22:CBool = Test v19
+          CondBranch v22, bb5(), bb4(v9)
+        bb5():
+          v28:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Return v28
+        bb4(v33:BasicObject):
+          v37:Fixnum[4] = Const Value(4)
+          CheckInterrupts
+          Return v37
         ");
     }
 
@@ -211,24 +235,30 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :n@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :n@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:Fixnum[0] = Const Value(0)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :n@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :n@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:Fixnum[0] = Const Value(0)
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :n@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, *@0x1010, cme:0x1018)
-          v36:Fixnum = GuardType v10, Fixnum
-          v46:Fixnum[0] = Const Value(0)
-          v47:Fixnum[0] = Const Value(0)
+          v39:Fixnum = GuardType v16, Fixnum
+          v49:Fixnum[0] = Const Value(0)
+          v21:CPtr = GetEP 0
+          v22:BasicObject = LoadField v21, :n@0x1000
+          v24:Fixnum[0] = Const Value(0)
+          v43:Fixnum = GuardType v22, Fixnum
+          v50:Fixnum[0] = Const Value(0)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1040, cme:0x1048)
-          v48:Fixnum[0] = Const Value(0)
+          v51:Fixnum[0] = Const Value(0)
           CheckInterrupts
-          Return v48
+          Return v51
         ");
     }
 
@@ -999,25 +1029,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :arr@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[0] = Const Value(0)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :arr@0x1000
+          v16:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v27:ArrayExact = GuardType v10, ArrayExact
-          v35:CInt64[0] = Const CInt64(0)
-          v29:CInt64 = ArrayLength v27
-          v30:CInt64[0] = GuardLess v35, v29
-          v34:BasicObject = ArrayAref v27, v30
+          v28:ArrayExact = GuardType v14, ArrayExact
+          v36:CInt64[0] = Const CInt64(0)
+          v30:CInt64 = ArrayLength v28
+          v31:CInt64[0] = GuardLess v36, v30
+          v35:BasicObject = ArrayAref v28, v31
           CheckInterrupts
-          Return v34
+          Return v35
         ");
     }
 
@@ -1032,25 +1064,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :arr@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[0] = Const Value(0)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :arr@0x1000
+          v16:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v27:ArrayExact = GuardType v10, ArrayExact
-          v35:CInt64[0] = Const CInt64(0)
-          v29:CInt64 = ArrayLength v27
-          v30:CInt64[0] = GuardLess v35, v29
-          v34:BasicObject = ArrayAref v27, v30
+          v28:ArrayExact = GuardType v14, ArrayExact
+          v36:CInt64[0] = Const CInt64(0)
+          v30:CInt64 = ArrayLength v28
+          v31:CInt64[0] = GuardLess v36, v30
+          v35:BasicObject = ArrayAref v28, v31
           CheckInterrupts
-          Return v34
+          Return v35
         ");
     }
 
@@ -1116,22 +1150,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :object@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :object@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :object@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :object@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :object@0x1000
+          v16:CPtr = GetEP 0
+          v17:BasicObject = LoadField v16, :object@0x1000
           PatchPoint NoSingletonClass(CustomEq@0x1008)
           PatchPoint MethodRedefined(CustomEq@0x1008, !=@0x1010, cme:0x1018)
-          v30:ObjectSubclass[class_exact:CustomEq] = GuardType v10, ObjectSubclass[class_exact:CustomEq]
-          v31:BoolExact = CCallWithFrame v30, :BasicObject#!=@0x1040, v30
-          v21:NilClass = Const Value(nil)
+          v33:ObjectSubclass[class_exact:CustomEq] = GuardType v14, ObjectSubclass[class_exact:CustomEq]
+          v34:BoolExact = CCallWithFrame v33, :BasicObject#!=@0x1040, v17
+          v24:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v21
+          Return v24
         ");
     }
 
@@ -1148,21 +1186,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[1] = Const Value(1)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
+          v16:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
-          v27:Fixnum = FixnumAdd v26, v15
+          v27:Fixnum = GuardType v14, Fixnum
+          v28:Fixnum = FixnumAdd v27, v16
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -1180,87 +1220,92 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:ArrayExact = LoadField v2, :array@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :array@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :array@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :array@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :array@0x1000
           CheckInterrupts
-          Return v10
+          Return v14
 
         fn kw@<compiled>:3:
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :k@0x1000
-          v4:BasicObject = LoadField v2, :<empty>@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :k@1
-          v9:CPtr = GetEP 0
-          v10:BasicObject = LoadField v9, :<empty>@0x1002
-          Jump bb3(v7, v8, v10)
-        bb3(v12:BasicObject, v13:BasicObject, v14:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :k@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :k@0x1000, v5
+          Jump bb3(v4)
+        bb3(v10:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :k@0x1000
           CheckInterrupts
-          Return v13
+          Return v15
 
         fn kw_rest@<compiled>:4:
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :k@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :k@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :k@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :k@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :k@0x1000
           CheckInterrupts
-          Return v10
+          Return v14
 
         fn block@<compiled>:6:
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :b@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :b@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:NilClass = Const Value(nil)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :b@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :b@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v14
+          Return v13
 
         fn post@<compiled>:5:
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:ArrayExact = LoadField v2, :rest@0x1000
-          v4:BasicObject = LoadField v2, :post@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :rest@1
-          v9:BasicObject = LoadArg :post@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :rest@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :rest@0x1000, v5
+          v8:BasicObject = LoadArg :post@2
+          StoreField v6, :post@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :post@0x1001
           CheckInterrupts
-          Return v13
+          Return v16
         ");
     }
 
@@ -1398,24 +1443,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, fun_new_map@0x1010, cme:0x1018)
-          v27:ArraySubclass[class_exact:C] = GuardType v10, ArraySubclass[class_exact:C]
-          v28:BasicObject = SendDirect v27, 0x1040, :fun_new_map (0x1050)
-          PatchPoint NoEPEscape(test)
-          v18:CPtr = LoadSP
-          v19:BasicObject = LoadField v18, :o@0x1000
+          v24:ArraySubclass[class_exact:C] = GuardType v14, ArraySubclass[class_exact:C]
+          v25:BasicObject = SendDirect v24, 0x1040, :fun_new_map (0x1050)
           CheckInterrupts
-          Return v28
+          Return v25
         ");
     }
 
@@ -1435,24 +1479,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, bar@0x1010, cme:0x1018)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v29:BasicObject = CCallWithFrame v28, :Enumerable#bar@0x1040, block=0x1048
-          PatchPoint NoEPEscape(test)
-          v18:CPtr = LoadSP
-          v19:BasicObject = LoadField v18, :o@0x1000
+          v25:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v26:BasicObject = CCallWithFrame v25, :Enumerable#bar@0x1040, block=0x1048
           CheckInterrupts
-          Return v29
+          Return v26
         ");
     }
 
@@ -1472,22 +1515,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, length@0x1010, cme:0x1018)
-          v24:ArrayExact = GuardType v10, ArrayExact
-          v25:CInt64 = ArrayLength v24
-          v26:Fixnum = BoxFixnum v25
+          v25:ArrayExact = GuardType v14, ArrayExact
+          v26:CInt64 = ArrayLength v25
+          v27:Fixnum = BoxFixnum v26
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -1803,22 +1848,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v27:Fixnum = GuardType v12, Fixnum
-          v29:Fixnum[100] = Const Value(100)
+          v29:Fixnum = GuardType v16, Fixnum
+          v31:Fixnum[100] = Const Value(100)
           CheckInterrupts
-          Return v29
+          Return v31
         ");
     }
 
@@ -1833,23 +1882,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v28:Fixnum = GuardType v12, Fixnum
-          v29:Fixnum = GuardType v13, Fixnum
-          v30:Fixnum = FixnumAdd v28, v29
+          v30:Fixnum = GuardType v16, Fixnum
+          v31:Fixnum = GuardType v19, Fixnum
+          v32:Fixnum = FixnumAdd v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -1864,21 +1917,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[1] = Const Value(1)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
+          v16:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
-          v27:Fixnum = FixnumAdd v26, v15
+          v27:Fixnum = GuardType v14, Fixnum
+          v28:Fixnum = FixnumAdd v27, v16
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -1893,21 +1948,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:Fixnum[1] = Const Value(1)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:Fixnum[1] = Const Value(1)
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v27:Fixnum = GuardType v10, Fixnum
-          v28:Fixnum = FixnumAdd v14, v27
+          v28:Fixnum = GuardType v16, Fixnum
+          v29:Fixnum = FixnumAdd v13, v28
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -1922,23 +1979,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, []@0x1010, cme:0x1018)
-          v28:Fixnum = GuardType v12, Fixnum
-          v29:Fixnum = GuardType v13, Fixnum
-          v30:Fixnum = FixnumAref v28, v29
+          v30:Fixnum = GuardType v16, Fixnum
+          v31:Fixnum = GuardType v19, Fixnum
+          v32:Fixnum = FixnumAref v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -2033,23 +2094,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, <@0x1010, cme:0x1018)
-          v28:Fixnum = GuardType v12, Fixnum
-          v29:Fixnum = GuardType v13, Fixnum
-          v30:BoolExact = FixnumLt v28, v29
+          v30:Fixnum = GuardType v16, Fixnum
+          v31:Fixnum = GuardType v19, Fixnum
+          v32:BoolExact = FixnumLt v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -2064,21 +2129,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[1] = Const Value(1)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
+          v16:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, <@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
-          v27:BoolExact = FixnumLt v26, v15
+          v27:Fixnum = GuardType v14, Fixnum
+          v28:BoolExact = FixnumLt v27, v16
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -2093,21 +2160,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:Fixnum[1] = Const Value(1)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:Fixnum[1] = Const Value(1)
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, <@0x1010, cme:0x1018)
-          v27:Fixnum = GuardType v10, Fixnum
-          v28:BoolExact = FixnumLt v14, v27
+          v28:Fixnum = GuardType v16, Fixnum
+          v29:BoolExact = FixnumLt v13, v28
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -2125,19 +2194,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:Fixnum[2] = Const Value(2)
-          v17:Fixnum[1] = Const Value(1)
-          v26:RangeExact = NewRangeFixnum v17 NewRangeInclusive v13
+          SetLocal :a, l0, EP@3, v13
+          v18:Fixnum[1] = Const Value(1)
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :a@0x1000
+          v29:Fixnum = GuardType v21, Fixnum
+          v30:RangeExact = NewRangeFixnum v18 NewRangeInclusive v29
           CheckInterrupts
-          Return v26
+          Return v30
         ");
     }
 
@@ -2156,19 +2230,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:Fixnum[2] = Const Value(2)
-          v17:Fixnum[1] = Const Value(1)
-          v26:RangeExact = NewRangeFixnum v17 NewRangeExclusive v13
+          SetLocal :a, l0, EP@3, v13
+          v18:Fixnum[1] = Const Value(1)
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :a@0x1000
+          v29:Fixnum = GuardType v21, Fixnum
+          v30:RangeExact = NewRangeFixnum v18 NewRangeExclusive v29
           CheckInterrupts
-          Return v26
+          Return v30
         ");
     }
 
@@ -2185,20 +2264,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:Fixnum[1] = Const Value(1)
-          v23:Fixnum = GuardType v10, Fixnum
-          v24:RangeExact = NewRangeFixnum v14 NewRangeInclusive v23
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:Fixnum[1] = Const Value(1)
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v24:Fixnum = GuardType v16, Fixnum
+          v25:RangeExact = NewRangeFixnum v13 NewRangeInclusive v24
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -2215,20 +2296,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:Fixnum[1] = Const Value(1)
-          v23:Fixnum = GuardType v10, Fixnum
-          v24:RangeExact = NewRangeFixnum v14 NewRangeExclusive v23
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:Fixnum[1] = Const Value(1)
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v24:Fixnum = GuardType v16, Fixnum
+          v25:RangeExact = NewRangeFixnum v13 NewRangeExclusive v24
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -2245,20 +2328,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[10] = Const Value(10)
-          v23:Fixnum = GuardType v10, Fixnum
-          v24:RangeExact = NewRangeFixnum v23 NewRangeInclusive v15
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
+          v16:Fixnum[10] = Const Value(10)
+          v24:Fixnum = GuardType v14, Fixnum
+          v25:RangeExact = NewRangeFixnum v24 NewRangeInclusive v16
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -2275,20 +2360,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[10] = Const Value(10)
-          v23:Fixnum = GuardType v10, Fixnum
-          v24:RangeExact = NewRangeFixnum v23 NewRangeExclusive v15
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
+          v16:Fixnum[10] = Const Value(10)
+          v24:Fixnum = GuardType v14, Fixnum
+          v25:RangeExact = NewRangeFixnum v24 NewRangeExclusive v16
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -2306,18 +2393,20 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :c@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:ArrayExact = NewArray
-          v17:Fixnum[5] = Const Value(5)
+          SetLocal :c, l0, EP@3, v13
+          v18:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -2333,25 +2422,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :arr@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[0] = Const Value(0)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :arr@0x1000
+          v16:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v27:ArrayExact = GuardType v10, ArrayExact
-          v35:CInt64[0] = Const CInt64(0)
-          v29:CInt64 = ArrayLength v27
-          v30:CInt64[0] = GuardLess v35, v29
-          v34:BasicObject = ArrayAref v27, v30
+          v28:ArrayExact = GuardType v14, ArrayExact
+          v36:CInt64[0] = Const CInt64(0)
+          v30:CInt64 = ArrayLength v28
+          v31:CInt64[0] = GuardLess v36, v30
+          v35:BasicObject = ArrayAref v28, v31
           CheckInterrupts
-          Return v34
+          Return v35
         ");
         assert_snapshot!(inspect("test [1,2,3]"), @"1");
     }
@@ -2368,22 +2459,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :arr@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[0] = Const Value(0)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :arr@0x1000
+          v16:Fixnum[0] = Const Value(0)
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, []@0x1010, cme:0x1018)
-          v27:HashExact = GuardType v10, HashExact
-          v28:BasicObject = HashAref v27, v15
+          v28:HashExact = GuardType v14, HashExact
+          v29:BasicObject = HashAref v28, v16
           CheckInterrupts
-          Return v28
+          Return v29
         ");
         assert_snapshot!(inspect("test({0 => 4})"), @"4");
     }
@@ -2402,18 +2495,20 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
-          v13:RangeExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v17:Fixnum[5] = Const Value(5)
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :c@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:RangeExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          SetLocal :c, l0, EP@3, v13
+          v18:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -2431,23 +2526,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :_@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_UMINUS)
-          v14:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v16:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v16:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
           v17:StringExact = StringCopy v16
           v19:RangeExact = NewRange v14 NewRangeInclusive v17
-          PatchPoint NoEPEscape(test)
-          v25:Fixnum[0] = Const Value(0)
+          SetLocal :_, l0, EP@3, v19
+          v24:Fixnum[0] = Const Value(0)
           CheckInterrupts
-          Return v25
+          Return v24
         ");
     }
 
@@ -2465,21 +2561,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:NilClass = Const Value(nil)
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
-          v18:ArrayExact = NewArray v12
-          v22:Fixnum[5] = Const Value(5)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :c@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:ArrayExact = NewArray v16
+          SetLocal :c, l0, EP@3, v18
+          v23:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v22
+          Return v23
         ");
     }
 
@@ -2496,19 +2595,20 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :c@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:HashExact = NewHash
-          PatchPoint NoEPEscape(test)
-          v19:Fixnum[5] = Const Value(5)
+          SetLocal :c, l0, EP@3, v13
+          v18:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v19
+          Return v18
         ");
     }
 
@@ -2525,23 +2625,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :aval@0x1000
-          v4:BasicObject = LoadField v2, :bval@0x1001
-          v5:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v8:BasicObject = LoadArg :self@0
-          v9:BasicObject = LoadArg :aval@1
-          v10:BasicObject = LoadArg :bval@2
-          v11:NilClass = Const Value(nil)
-          Jump bb3(v8, v9, v10, v11)
-        bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:NilClass):
-          v20:StaticSymbol[:a] = Const Value(VALUE(0x1008))
-          v23:StaticSymbol[:b] = Const Value(VALUE(0x1010))
-          v26:HashExact = NewHash v20: v14, v23: v15
-          PatchPoint NoEPEscape(test)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :aval@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :aval@0x1000, v5
+          v8:BasicObject = LoadArg :bval@2
+          StoreField v6, :bval@0x1001, v8
+          v10:NilClass = Const Value(nil)
+          StoreField v6, :c@0x1002, v10
+          Jump bb3(v4)
+        bb3(v13:BasicObject):
+          v17:StaticSymbol[:a] = Const Value(VALUE(0x1008))
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :aval@0x1000
+          v22:StaticSymbol[:b] = Const Value(VALUE(0x1010))
+          v24:CPtr = GetEP 0
+          v25:BasicObject = LoadField v24, :bval@0x1001
+          v27:HashExact = NewHash v17: v20, v22: v25
+          SetLocal :c, l0, EP@3, v27
           v32:Fixnum[5] = Const Value(5)
           CheckInterrupts
           Return v32
@@ -2562,19 +2666,21 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
-          v13:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :c@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v14:ArrayExact = ArrayDup v13
-          v18:Fixnum[5] = Const Value(5)
+          SetLocal :c, l0, EP@3, v14
+          v19:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v18
+          Return v19
         ");
     }
 
@@ -2591,19 +2697,21 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
-          v13:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :c@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:HashExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v14:HashExact = HashDup v13
-          v18:Fixnum[5] = Const Value(5)
+          SetLocal :c, l0, EP@3, v14
+          v19:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v18
+          Return v19
         ");
     }
 
@@ -2621,17 +2729,19 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
-          v16:Fixnum[5] = Const Value(5)
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :c@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          SetLocal :c, l0, EP@3, v9
+          v17:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v16
+          Return v17
         ");
     }
 
@@ -2649,19 +2759,21 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
-          v13:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :c@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v14:StringExact = StringCopy v13
-          v18:Fixnum[5] = Const Value(5)
+          SetLocal :c, l0, EP@3, v14
+          v19:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v18
+          Return v19
         ");
     }
 
@@ -2679,23 +2791,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
-          v33:Fixnum = GuardType v13, Fixnum
-          v24:Fixnum[5] = Const Value(5)
+          v34:Fixnum = GuardType v16, Fixnum
+          v35:Fixnum = GuardType v19, Fixnum
+          v26:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v24
+          Return v26
         ");
     }
 
@@ -2713,23 +2829,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, -@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
-          v33:Fixnum = GuardType v13, Fixnum
-          v24:Fixnum[5] = Const Value(5)
+          v34:Fixnum = GuardType v16, Fixnum
+          v35:Fixnum = GuardType v19, Fixnum
+          v26:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v24
+          Return v26
         ");
     }
 
@@ -2747,23 +2867,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, *@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
-          v33:Fixnum = GuardType v13, Fixnum
-          v24:Fixnum[5] = Const Value(5)
+          v34:Fixnum = GuardType v16, Fixnum
+          v35:Fixnum = GuardType v19, Fixnum
+          v26:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v24
+          Return v26
         ");
     }
 
@@ -2781,24 +2905,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, /@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
-          v33:Fixnum = GuardType v13, Fixnum
-          v34:Fixnum = FixnumDiv v32, v33
-          v24:Fixnum[5] = Const Value(5)
+          v34:Fixnum = GuardType v16, Fixnum
+          v35:Fixnum = GuardType v19, Fixnum
+          v36:Fixnum = FixnumDiv v34, v35
+          v26:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v24
+          Return v26
         ");
     }
 
@@ -2816,24 +2944,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, %@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
-          v33:Fixnum = GuardType v13, Fixnum
-          v34:Fixnum = FixnumMod v32, v33
-          v24:Fixnum[5] = Const Value(5)
+          v34:Fixnum = GuardType v16, Fixnum
+          v35:Fixnum = GuardType v19, Fixnum
+          v36:Fixnum = FixnumMod v34, v35
+          v26:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v24
+          Return v26
         ");
     }
 
@@ -2851,23 +2983,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, <@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
-          v33:Fixnum = GuardType v13, Fixnum
-          v24:Fixnum[5] = Const Value(5)
+          v34:Fixnum = GuardType v16, Fixnum
+          v35:Fixnum = GuardType v19, Fixnum
+          v26:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v24
+          Return v26
         ");
     }
 
@@ -2885,23 +3021,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, <=@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
-          v33:Fixnum = GuardType v13, Fixnum
-          v24:Fixnum[5] = Const Value(5)
+          v34:Fixnum = GuardType v16, Fixnum
+          v35:Fixnum = GuardType v19, Fixnum
+          v26:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v24
+          Return v26
         ");
     }
 
@@ -2919,23 +3059,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, >@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
-          v33:Fixnum = GuardType v13, Fixnum
-          v24:Fixnum[5] = Const Value(5)
+          v34:Fixnum = GuardType v16, Fixnum
+          v35:Fixnum = GuardType v19, Fixnum
+          v26:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v24
+          Return v26
         ");
     }
 
@@ -2953,23 +3097,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, >=@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
-          v33:Fixnum = GuardType v13, Fixnum
-          v24:Fixnum[5] = Const Value(5)
+          v34:Fixnum = GuardType v16, Fixnum
+          v35:Fixnum = GuardType v19, Fixnum
+          v26:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v24
+          Return v26
         ");
     }
 
@@ -2987,23 +3135,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, ==@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
-          v33:Fixnum = GuardType v13, Fixnum
-          v24:Fixnum[5] = Const Value(5)
+          v34:Fixnum = GuardType v16, Fixnum
+          v35:Fixnum = GuardType v19, Fixnum
+          v26:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v24
+          Return v26
         ");
     }
 
@@ -3021,24 +3173,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, !=@0x1010, cme:0x1018)
-          v32:Fixnum = GuardType v12, Fixnum
+          v34:Fixnum = GuardType v16, Fixnum
           PatchPoint BOPRedefined(INTEGER_REDEFINED_OP_FLAG, BOP_EQ)
-          v34:Fixnum = GuardType v13, Fixnum
-          v24:Fixnum[5] = Const Value(5)
+          v36:Fixnum = GuardType v19, Fixnum
+          v26:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v24
+          Return v26
         ");
     }
 
@@ -3081,20 +3237,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :klass@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :klass@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:FalseClass = Const Value(false)
-          v17:BasicObject = GetConstant v10, :ARGV, v15
-          v21:Fixnum[5] = Const Value(5)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :klass@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :klass@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :klass@0x1000
+          v16:FalseClass = Const Value(false)
+          v18:BasicObject = GetConstant v14, :ARGV, v16
+          v22:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v21
+          Return v22
         ");
     }
 
@@ -3110,19 +3268,21 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, itself@0x1010, cme:0x1018)
-          v23:Fixnum = GuardType v10, Fixnum
+          v24:Fixnum = GuardType v14, Fixnum
           CheckInterrupts
-          Return v23
+          Return v24
         ");
     }
 
@@ -3163,21 +3323,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:ArrayExact = NewArray
-          PatchPoint NoSingletonClass(Array@0x1000)
-          PatchPoint MethodRedefined(Array@0x1000, itself@0x1008, cme:0x1010)
-          PatchPoint NoEPEscape(test)
-          v21:Fixnum[1] = Const Value(1)
+          PatchPoint NoSingletonClass(Array@0x1008)
+          PatchPoint MethodRedefined(Array@0x1008, itself@0x1010, cme:0x1018)
+          SetLocal :x, l0, EP@3, v13
+          v20:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v21
+          Return v20
         ");
     }
 
@@ -3196,24 +3357,25 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           PatchPoint SingleRactorMode
-          PatchPoint StableConstantNames(0x1000, M)
-          v29:ModuleExact[M@0x1008] = Const Value(VALUE(0x1008))
-          PatchPoint NoSingletonClass(Module@0x1010)
-          PatchPoint MethodRedefined(Module@0x1010, name@0x1018, cme:0x1020)
-          v34:StringExact|NilClass = CCall v29, :Module#name@0x1048
-          PatchPoint NoEPEscape(test)
-          v21:Fixnum[1] = Const Value(1)
+          PatchPoint StableConstantNames(0x1008, M)
+          v28:ModuleExact[M@0x1010] = Const Value(VALUE(0x1010))
+          PatchPoint NoSingletonClass(Module@0x1018)
+          PatchPoint MethodRedefined(Module@0x1018, name@0x1020, cme:0x1028)
+          v33:StringExact|NilClass = CCall v28, :Module#name@0x1050
+          SetLocal :x, l0, EP@3, v33
+          v20:Fixnum[1] = Const Value(1)
           CheckInterrupts
-          Return v21
+          Return v20
         ");
     }
 
@@ -3502,20 +3664,20 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:Fixnum[1] = Const Value(1)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, zero?@0x1010, cme:0x1018)
-          v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v14
+          v23:BoolExact = InvokeBuiltin leaf <inline_expr>, v13
           CheckInterrupts
-          Return v24
+          Return v23
         ");
     }
 
@@ -3532,24 +3694,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:NilClass = Const Value(nil)
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
-          v17:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v18:ArrayExact = ArrayDup v17
-          PatchPoint NoSingletonClass(Array@0x1010)
-          PatchPoint MethodRedefined(Array@0x1010, first@0x1018, cme:0x1020)
-          v32:BasicObject = InvokeBuiltin leaf <inline_expr>, v18
-          CheckInterrupts
-          Return v32
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :a@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v16:ArrayExact = ArrayDup v15
+          SetLocal :a, l0, EP@3, v16
+          v21:CPtr = GetEP 0
+          v22:BasicObject = LoadField v21, :a@0x1001
+          SideExit NoProfileSend recompile
         ");
     }
 
@@ -3601,21 +3762,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :c@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :c@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :c@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :c@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :c@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v24:BasicObject = SendDirect v23, 0x1040, :foo (0x1050)
+          v24:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v25:BasicObject = SendDirect v24, 0x1040, :foo (0x1050)
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -3666,23 +3829,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:Fixnum[1] = Const Value(1)
-          PatchPoint MethodRedefined(Object@0x1000, foo@0x1008, cme:0x1010)
-          v34:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v8, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
-          v36:Fixnum[1] = Const Value(1)
-          PatchPoint NoEPEscape(test)
-          v21:CPtr = LoadSP
-          v22:BasicObject = LoadField v21, :a@0x1038
+          SetLocal :a, l0, EP@3, v13
+          PatchPoint MethodRedefined(Object@0x1008, foo@0x1010, cme:0x1018)
+          v31:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)]
+          v23:CPtr = GetEP 0
+          v24:BasicObject = LoadField v23, :a@0x1000
           CheckInterrupts
-          Return v22
+          Return v24
         ");
     }
 
@@ -3704,26 +3867,25 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:Fixnum[1] = Const Value(1)
           SetLocal :a, l0, EP@3, v13
-          PatchPoint MethodRedefined(Object@0x1000, lambda@0x1008, cme:0x1010)
-          v45:ObjectSubclass[class_exact*:Object@VALUE(0x1000)] = GuardType v8, ObjectSubclass[class_exact*:Object@VALUE(0x1000)]
-          v46:BasicObject = CCallWithFrame v45, :Kernel#lambda@0x1038, block=0x1040
-          v20:CPtr = GetEP 0
-          v21:BasicObject = LoadField v20, :a@0x1048
-          PatchPoint MethodRedefined(Object@0x1000, foo@0x1049, cme:0x1050)
-          v32:CPtr = GetEP 0
-          v33:BasicObject = LoadField v32, :a@0x1048
+          PatchPoint MethodRedefined(Object@0x1008, lambda@0x1010, cme:0x1018)
+          v41:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)]
+          v42:BasicObject = CCallWithFrame v41, :Kernel#lambda@0x1040, block=0x1048
+          PatchPoint MethodRedefined(Object@0x1008, foo@0x1050, cme:0x1058)
+          v28:CPtr = GetEP 0
+          v29:BasicObject = LoadField v28, :a@0x1000
           CheckInterrupts
-          Return v33
+          Return v29
         ");
     }
 
@@ -4303,26 +4465,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          v4:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :s@1
-          v9:NilClass = Const Value(nil)
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
-          v17:ArrayExact = NewArray
-          v22:TrueClass = Const Value(true)
-          v24:BasicObject = Send v12, 0x1008, :each_line, v22 # SendFallbackReason: Complex argument passing
-          PatchPoint NoEPEscape(test)
-          v27:CPtr = LoadSP
-          v28:BasicObject = LoadField v27, :s@0x1000
-          v29:BasicObject = LoadField v27, :a@0x1030
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :a@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:ArrayExact = NewArray
+          SetLocal :a, l0, EP@3, v15
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :s@0x1000
+          v23:TrueClass = Const Value(true)
+          v25:BasicObject = Send v21, 0x1008, :each_line, v23 # SendFallbackReason: Complex argument passing
+          v29:CPtr = GetEP 0
+          v30:BasicObject = LoadField v29, :a@0x1001
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -4814,24 +4977,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v19:ArrayExact = NewArray v12, v13
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v21:ArrayExact = NewArray v16, v19
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, length@0x1010, cme:0x1018)
-          v31:CInt64 = ArrayLength v19
-          v32:Fixnum = BoxFixnum v31
+          v33:CInt64 = ArrayLength v21
+          v34:Fixnum = BoxFixnum v33
           CheckInterrupts
-          Return v32
+          Return v34
         ");
     }
 
@@ -4845,24 +5012,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v19:ArrayExact = NewArray v12, v13
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v21:ArrayExact = NewArray v16, v19
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, size@0x1010, cme:0x1018)
-          v31:CInt64 = ArrayLength v19
-          v32:Fixnum = BoxFixnum v31
+          v33:CInt64 = ArrayLength v21
+          v34:Fixnum = BoxFixnum v33
           CheckInterrupts
-          Return v32
+          Return v34
         ");
     }
 
@@ -4876,28 +5047,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :block@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v17:CPtr = GetEP 0
-          v18:CUInt64 = LoadField v17, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v19:CBool = IsBlockParamModified v18
-          CondBranch v19, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:CUInt64 = LoadField v15, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v17:CBool = IsBlockParamModified v16
+          CondBranch v17, bb4(), bb5()
         bb4():
-          v21:BasicObject = LoadField v17, :block@0x1002
-          Jump bb6(v21, v21)
+          v19:BasicObject = LoadField v15, :block@0x1000
+          Jump bb6(v19)
         bb5():
-          v23:CInt64 = LoadField v17, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v24:CInt64 = GuardAnyBitSet v23, CUInt64(1)
-          v25:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v25, v10)
-        bb6(v15:BasicObject, v16:BasicObject):
+          v21:CInt64 = LoadField v15, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
+          v22:CInt64 = GuardAnyBitSet v21, CUInt64(1)
+          v23:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v23)
+        bb6(v14:BasicObject):
           SideExit NoProfileSend recompile
         ");
     }
@@ -4916,41 +5087,42 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          v4:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :block@1
-          v9:NilClass = Const Value(nil)
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
-          v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v20:CBool = IsBlockParamModified v19
-          CondBranch v20, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v16:CPtr = GetEP 0
+          v17:CUInt64 = LoadField v16, :VM_ENV_DATA_INDEX_FLAGS@0x1002
+          v18:CBool = IsBlockParamModified v17
+          CondBranch v18, bb4(), bb5()
         bb4():
-          v22:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v22)
+          v20:BasicObject = LoadField v16, :block@0x1000
+          Jump bb6(v20)
         bb5():
-          v24:BasicObject = GetBlockParam :block, l0, EP@4
-          Jump bb6(v24)
-        bb6(v17:BasicObject):
-          v32:CPtr = GetEP 0
-          v33:CUInt64 = LoadField v32, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v34:CBool = IsBlockParamModified v33
-          CondBranch v34, bb7(), bb8()
+          v22:BasicObject = GetBlockParam :block, l0, EP@4
+          Jump bb6(v22)
+        bb6(v15:BasicObject):
+          SetLocal :b, l0, EP@3, v15
+          v30:CPtr = GetEP 0
+          v31:CUInt64 = LoadField v30, :VM_ENV_DATA_INDEX_FLAGS@0x1002
+          v32:CBool = IsBlockParamModified v31
+          CondBranch v32, bb7(), bb8()
         bb7():
-          v36:BasicObject = LoadField v32, :block@0x1002
-          Jump bb9(v36, v36)
+          v34:BasicObject = LoadField v30, :block@0x1000
+          Jump bb9(v34)
         bb8():
-          v38:CInt64 = LoadField v32, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v39:CInt64 = GuardAnyBitSet v38, CUInt64(1)
-          v40:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb9(v40, v17)
-        bb9(v30:BasicObject, v31:BasicObject):
+          v36:CInt64 = LoadField v30, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
+          v37:CInt64 = GuardAnyBitSet v36, CUInt64(1)
+          v38:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb9(v38)
+        bb9(v29:BasicObject):
           SideExit NoProfileSend recompile
         ");
     }
@@ -4970,38 +5142,40 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :b@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v14:CPtr = GetEP 1
-          v15:CUInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000
+          v15:CUInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v16:CBool = IsBlockParamModified v15
           CondBranch v16, bb4(), bb5()
         bb4():
-          v18:BasicObject = LoadField v14, :block@0x1001
+          v18:BasicObject = LoadField v14, :block@0x1000
           Jump bb6(v18)
         bb5():
           v20:BasicObject = GetBlockParam :block, l1, EP@3
           Jump bb6(v20)
         bb6(v13:BasicObject):
-          v27:CPtr = GetEP 1
-          v28:CUInt64 = LoadField v27, :VM_ENV_DATA_INDEX_FLAGS@0x1000
-          v29:CBool = IsBlockParamModified v28
-          CondBranch v29, bb7(), bb8()
+          SetLocal :b, l0, EP@3, v13
+          v28:CPtr = GetEP 1
+          v29:CUInt64 = LoadField v28, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v30:CBool = IsBlockParamModified v29
+          CondBranch v30, bb7(), bb8()
         bb7():
-          v31:BasicObject = LoadField v27, :block@0x1001
-          Jump bb9(v31)
+          v32:BasicObject = LoadField v28, :block@0x1000
+          Jump bb9(v32)
         bb8():
-          v33:CInt64 = LoadField v27, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
-          v34:CInt64 = GuardAnyBitSet v33, CUInt64(1)
-          v35:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb9(v35)
-        bb9(v26:BasicObject):
+          v34:CInt64 = LoadField v28, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
+          v35:CInt64 = GuardAnyBitSet v34, CUInt64(1)
+          v36:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb9(v36)
+        bb9(v27:BasicObject):
           SideExit NoProfileSend recompile
         ");
     }
@@ -5023,43 +5197,43 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :block@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:Fixnum[0] = Const Value(0)
-          v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v20:CBool = IsBlockParamModified v19
-          CondBranch v20, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:Fixnum[0] = Const Value(0)
+          v16:CPtr = GetEP 0
+          v17:CUInt64 = LoadField v16, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v18:CBool = IsBlockParamModified v17
+          CondBranch v18, bb4(), bb5()
         bb4():
-          v22:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v22, v22)
+          v20:BasicObject = LoadField v16, :block@0x1000
+          Jump bb6(v20)
         bb5():
-          v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v25:CInt64[1] = Const CInt64(1)
-          v26:CInt64 = IntAnd v24, v25
-          v27:CBool = IsBitEqual v26, v25
-          CondBranch v27, bb7(), bb9()
+          v22:CInt64 = LoadField v16, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
+          v23:CInt64[1] = Const CInt64(1)
+          v24:CInt64 = IntAnd v22, v23
+          v25:CBool = IsBitEqual v24, v23
+          CondBranch v25, bb7(), bb9()
         bb7():
-          v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v29, v10)
+          v27:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v27)
         bb9():
-          v31:CInt64[0] = Const CInt64(0)
-          v32:CBool = IsBitEqual v24, v31
-          CondBranch v32, bb8(), bb10()
+          v29:CInt64[0] = Const CInt64(0)
+          v30:CBool = IsBitEqual v22, v29
+          CondBranch v30, bb8(), bb10()
         bb8():
-          v34:NilClass = Const Value(nil)
-          Jump bb6(v34, v10)
-        bb6(v16:BasicObject, v17:BasicObject):
-          v38:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Complex argument passing
+          v32:NilClass = Const Value(nil)
+          Jump bb6(v32)
+        bb6(v15:BasicObject):
+          v36:BasicObject = Send v13, &block, :then, v15 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v38
+          Return v36
         bb10():
           SideExit BlockParamProxyProfileNotCovered
         ");
@@ -5075,28 +5249,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :block@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:CPtr = GetEP 0
-          v16:CUInt64 = LoadField v15, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v17:CBool = IsBlockParamModified v16
-          CondBranch v17, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:CUInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v16:CBool = IsBlockParamModified v15
+          CondBranch v16, bb4(), bb5()
         bb4():
-          v19:BasicObject = LoadField v15, :block@0x1002
-          Jump bb6(v19)
+          v18:BasicObject = LoadField v14, :block@0x1000
+          Jump bb6(v18)
         bb5():
-          v21:BasicObject = GetBlockParam :block, l0, EP@3
-          Jump bb6(v21)
-        bb6(v14:BasicObject):
+          v20:BasicObject = GetBlockParam :block, l0, EP@3
+          Jump bb6(v20)
+        bb6(v13:BasicObject):
           CheckInterrupts
-          Return v14
+          Return v13
         ");
     }
 
@@ -5149,24 +5323,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :block@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:NilClass = Const Value(nil)
-          SetLocal :block, l0, EP@3, v14
-          v18:CPtr = GetEP 0
-          v19:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v20:CInt64[512] = Const CInt64(512)
-          v21:CInt64 = IntOr v19, v20
-          StoreField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001, v21
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:NilClass = Const Value(nil)
+          SetLocal :block, l0, EP@3, v13
+          v17:CPtr = GetEP 0
+          v18:CInt64 = LoadField v17, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v19:CInt64[512] = Const CInt64(512)
+          v20:CInt64 = IntOr v18, v19
+          StoreField v17, :VM_ENV_DATA_INDEX_FLAGS@0x1001, v20
           CheckInterrupts
-          Return v14
+          Return v13
         ");
     }
 
@@ -5316,22 +5490,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :p@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :p@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[1] = Const Value(1)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :p@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :p@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :p@0x1000
+          v16:Fixnum[1] = Const Value(1)
           PatchPoint NoSingletonClass(Proc@0x1008)
           PatchPoint MethodRedefined(Proc@0x1008, call@0x1010, cme:0x1018)
-          v25:ObjectSubclass[class_exact:Proc] = GuardType v10, ObjectSubclass[class_exact:Proc]
-          v26:BasicObject = InvokeProc v25, v15
+          v26:ObjectSubclass[class_exact:Proc] = GuardType v14, ObjectSubclass[class_exact:Proc]
+          v27:BasicObject = InvokeProc v26, v16
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -5349,22 +5525,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :p@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :p@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[2] = Const Value(2)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :p@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :p@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :p@0x1000
+          v16:Fixnum[2] = Const Value(2)
           PatchPoint NoSingletonClass(Proc@0x1008)
           PatchPoint MethodRedefined(Proc@0x1008, []@0x1010, cme:0x1018)
-          v26:ObjectSubclass[class_exact:Proc] = GuardType v10, ObjectSubclass[class_exact:Proc]
-          v27:BasicObject = InvokeProc v26, v15
+          v27:ObjectSubclass[class_exact:Proc] = GuardType v14, ObjectSubclass[class_exact:Proc]
+          v28:BasicObject = InvokeProc v27, v16
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -5382,22 +5560,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :p@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :p@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[3] = Const Value(3)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :p@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :p@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :p@0x1000
+          v16:Fixnum[3] = Const Value(3)
           PatchPoint NoSingletonClass(Proc@0x1008)
           PatchPoint MethodRedefined(Proc@0x1008, yield@0x1010, cme:0x1018)
-          v25:ObjectSubclass[class_exact:Proc] = GuardType v10, ObjectSubclass[class_exact:Proc]
-          v26:BasicObject = InvokeProc v25, v15
+          v26:ObjectSubclass[class_exact:Proc] = GuardType v14, ObjectSubclass[class_exact:Proc]
+          v27:BasicObject = InvokeProc v26, v16
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -5415,22 +5595,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :p@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :p@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[1] = Const Value(1)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :p@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :p@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :p@0x1000
+          v16:Fixnum[1] = Const Value(1)
           PatchPoint NoSingletonClass(Proc@0x1008)
           PatchPoint MethodRedefined(Proc@0x1008, ===@0x1010, cme:0x1018)
-          v25:ObjectSubclass[class_exact:Proc] = GuardType v10, ObjectSubclass[class_exact:Proc]
-          v26:BasicObject = InvokeProc v25, v15
+          v26:ObjectSubclass[class_exact:Proc] = GuardType v14, ObjectSubclass[class_exact:Proc]
+          v27:BasicObject = InvokeProc v26, v16
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -5449,22 +5631,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :p@0x1000
-          v4:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :p@1
-          v9:NilClass = Const Value(nil)
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
-          v17:ArrayExact = NewArray
-          v23:ArrayExact = ToArray v17
-          v25:BasicObject = Send v12, :call, v23 # SendFallbackReason: Complex argument passing
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :p@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :p@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :empty@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:ArrayExact = NewArray
+          SetLocal :empty, l0, EP@3, v15
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :p@0x1000
+          v23:CPtr = GetEP 0
+          v24:BasicObject = LoadField v23, :empty@0x1001
+          v26:ArrayExact = ToArray v24
+          v28:BasicObject = Send v21, :call, v26 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v25
+          Return v28
         ");
     }
 
@@ -5482,19 +5669,21 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :p@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :p@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[1] = Const Value(1)
-          v17:BasicObject = Send v10, :call, v15 # SendFallbackReason: Complex argument passing
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :p@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :p@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :p@0x1000
+          v16:Fixnum[1] = Const Value(1)
+          v18:BasicObject = Send v14, :call, v16 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -6287,21 +6476,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
           PatchPoint NoSingletonClass(String@0x1010)
-          v29:String = GuardType v10, String
-          v22:StringExact = StringConcat v14, v29
+          v30:String = GuardType v16, String
+          v23:StringExact = StringConcat v13, v30
           CheckInterrupts
-          Return v22
+          Return v23
         ");
     }
 
@@ -6322,21 +6513,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
           PatchPoint NoSingletonClass(MyString@0x1010)
-          v29:String = GuardType v10, String
-          v22:StringExact = StringConcat v14, v29
+          v30:String = GuardType v16, String
+          v23:StringExact = StringConcat v13, v30
           CheckInterrupts
-          Return v22
+          Return v23
         ");
     }
 
@@ -6354,24 +6547,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v28:ArrayExact = GuardType v10, ArrayExact
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v29:ArrayExact = GuardType v16, ArrayExact
           PatchPoint NoSingletonClass(Array@0x1010)
           PatchPoint MethodRedefined(Array@0x1010, to_s@0x1018, cme:0x1020)
-          v34:BasicObject = CCallWithFrame v28, :Array#to_s@0x1048
-          v20:String = AnyToString v28, str: v34
-          v22:StringExact = StringConcat v14, v20
+          v35:BasicObject = CCallWithFrame v29, :Array#to_s@0x1048
+          v21:String = AnyToString v29, str: v35
+          v23:StringExact = StringConcat v13, v21
           CheckInterrupts
-          Return v22
+          Return v23
         ");
     }
 
@@ -6389,18 +6584,29 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:NilClass = Const Value(nil)
+          SetLocal :x, l0, EP@3, v13
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :x@0x1000
           CheckInterrupts
-          v21:NilClass = Const Value(nil)
-          Return v21
+          v23:CBool = IsNil v19
+          v24:NilClass = Const Value(nil)
+          CondBranch v23, bb4(v9, v24), bb5()
+        bb4(v30:BasicObject, v31:NilClass):
+          CheckInterrupts
+          Return v31
+        bb5():
+          v26:NotNil = RefineType v19, NotNil
+          SideExit NoProfileSend recompile
         ");
     }
 
@@ -6418,19 +6624,29 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:Fixnum[1] = Const Value(1)
+          SetLocal :x, l0, EP@3, v13
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :x@0x1000
           CheckInterrupts
-          v23:Fixnum[1] = RefineType v13, NotNil
-          PatchPoint MethodRedefined(Integer@0x1000, itself@0x1008, cme:0x1010)
-          Return v23
+          v23:CBool = IsNil v19
+          v24:NilClass = Const Value(nil)
+          CondBranch v23, bb4(v9, v24), bb5()
+        bb4(v30:BasicObject, v31:NilClass):
+          CheckInterrupts
+          Return v31
+        bb5():
+          v26:NotNil = RefineType v19, NotNil
+          SideExit NoProfileSend recompile
         ");
     }
 
@@ -6631,17 +6847,19 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :arr@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v17:Fixnum[1] = Const Value(1)
-          v19:Fixnum[10] = Const Value(10)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :arr@0x1000
+          v18:Fixnum[1] = Const Value(1)
+          v20:Fixnum[10] = Const Value(10)
           SideExit NoProfileSend recompile
         ");
     }
@@ -6951,20 +7169,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :val@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :val@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :val@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :val@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :val@0x1000
           PatchPoint MethodRedefined(NilClass@0x1008, nil?@0x1010, cme:0x1018)
-          v24:NilClass = GuardType v10, NilClass
-          v25:TrueClass = Const Value(true)
+          v25:NilClass = GuardType v14, NilClass
+          v26:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -6980,20 +7200,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :val@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :val@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :val@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :val@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :val@0x1000
           PatchPoint MethodRedefined(FalseClass@0x1008, nil?@0x1010, cme:0x1018)
-          v24:FalseClass = GuardType v10, FalseClass
-          v25:FalseClass = Const Value(false)
+          v25:FalseClass = GuardType v14, FalseClass
+          v26:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -7009,20 +7231,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :val@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :val@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :val@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :val@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :val@0x1000
           PatchPoint MethodRedefined(TrueClass@0x1008, nil?@0x1010, cme:0x1018)
-          v24:TrueClass = GuardType v10, TrueClass
-          v25:FalseClass = Const Value(false)
+          v25:TrueClass = GuardType v14, TrueClass
+          v26:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -7038,20 +7262,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :val@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :val@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :val@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :val@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :val@0x1000
           PatchPoint MethodRedefined(Symbol@0x1008, nil?@0x1010, cme:0x1018)
-          v24:StaticSymbol = GuardType v10, StaticSymbol
-          v25:FalseClass = Const Value(false)
+          v25:StaticSymbol = GuardType v14, StaticSymbol
+          v26:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -7067,20 +7293,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :val@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :val@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :val@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :val@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :val@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, nil?@0x1010, cme:0x1018)
-          v24:Fixnum = GuardType v10, Fixnum
-          v25:FalseClass = Const Value(false)
+          v25:Fixnum = GuardType v14, Fixnum
+          v26:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -7096,20 +7324,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :val@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :val@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :val@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :val@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :val@0x1000
           PatchPoint MethodRedefined(Float@0x1008, nil?@0x1010, cme:0x1018)
-          v24:Flonum = GuardType v10, Flonum
-          v25:FalseClass = Const Value(false)
+          v25:Flonum = GuardType v14, Flonum
+          v26:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -7125,21 +7355,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :val@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :val@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :val@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :val@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :val@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, nil?@0x1010, cme:0x1018)
-          v25:StringExact = GuardType v10, StringExact
-          v26:FalseClass = Const Value(false)
+          v26:StringExact = GuardType v14, StringExact
+          v27:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -7155,21 +7387,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, !@0x1010, cme:0x1018)
-          v25:ArrayExact = GuardType v10, ArrayExact
-          v26:FalseClass = Const Value(false)
+          v26:ArrayExact = GuardType v14, ArrayExact
+          v27:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -7185,20 +7419,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
           PatchPoint MethodRedefined(FalseClass@0x1008, !@0x1010, cme:0x1018)
-          v24:FalseClass = GuardType v10, FalseClass
-          v25:TrueClass = Const Value(true)
+          v25:FalseClass = GuardType v14, FalseClass
+          v26:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -7214,20 +7450,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
           PatchPoint MethodRedefined(NilClass@0x1008, !@0x1010, cme:0x1018)
-          v24:NilClass = GuardType v10, NilClass
-          v25:TrueClass = Const Value(true)
+          v25:NilClass = GuardType v14, NilClass
+          v26:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -7246,33 +7484,33 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
           CheckInterrupts
-          v16:CBool = Test v10
-          v17:Falsy = RefineType v10, Falsy
-          CondBranch v16, bb6(), bb4(v9, v17)
+          v17:CBool = Test v14
+          CondBranch v17, bb6(), bb4(v9)
         bb6():
-          v19:Truthy = RefineType v10, Truthy
-          v21:FalseClass = Const Value(false)
+          v22:FalseClass = Const Value(false)
           CheckInterrupts
-          Jump bb5(v9, v19, v21)
-        bb4(v25:BasicObject, v26:Falsy):
+          Jump bb5(v9, v22)
+        bb4(v26:BasicObject):
           v29:NilClass = Const Value(nil)
-          Jump bb5(v25, v26, v29)
-        bb5(v31:BasicObject, v32:BasicObject, v33:Falsy):
+          Jump bb5(v26, v29)
+        bb5(v31:BasicObject, v32:Falsy):
           PatchPoint MethodRedefined(NilClass@0x1008, !@0x1010, cme:0x1018)
-          v45:NilClass = GuardType v33, NilClass
-          v46:TrueClass = Const Value(true)
+          v44:NilClass = GuardType v32, NilClass
+          v45:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v46
+          Return v45
         ");
     }
 
@@ -7288,24 +7526,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, empty?@0x1010, cme:0x1018)
-          v25:ArrayExact = GuardType v10, ArrayExact
-          v26:CInt64 = ArrayLength v25
-          v27:CInt64[0] = Const CInt64(0)
-          v28:CBool = IsBitEqual v26, v27
-          v29:BoolExact = BoxBool v28
+          v26:ArrayExact = GuardType v14, ArrayExact
+          v27:CInt64 = ArrayLength v26
+          v28:CInt64[0] = Const CInt64(0)
+          v29:CBool = IsBitEqual v27, v28
+          v30:BoolExact = BoxBool v29
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -7321,21 +7561,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, empty?@0x1010, cme:0x1018)
-          v25:HashExact = GuardType v10, HashExact
-          v26:BoolExact = CCall v25, :Hash#empty?@0x1040
+          v26:HashExact = GuardType v14, HashExact
+          v27:BoolExact = CCall v26, :Hash#empty?@0x1040
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -7352,24 +7594,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, ==@0x1010, cme:0x1018)
-          v29:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C]
-          v30:CBool = IsBitEqual v29, v13
-          v31:BoolExact = BoxBool v30
+          v31:ObjectSubclass[class_exact:C] = GuardType v16, ObjectSubclass[class_exact:C]
+          v32:CBool = IsBitEqual v31, v19
+          v33:BoolExact = BoxBool v32
           CheckInterrupts
-          Return v31
+          Return v33
         ");
     }
 
@@ -7385,23 +7631,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, &@0x1010, cme:0x1018)
-          v28:Fixnum = GuardType v12, Fixnum
-          v29:Fixnum = GuardType v13, Fixnum
-          v30:Fixnum = FixnumAnd v28, v29
+          v30:Fixnum = GuardType v16, Fixnum
+          v31:Fixnum = GuardType v19, Fixnum
+          v32:Fixnum = FixnumAnd v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -7417,23 +7667,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, |@0x1010, cme:0x1018)
-          v28:Fixnum = GuardType v12, Fixnum
-          v29:Fixnum = GuardType v13, Fixnum
-          v30:Fixnum = FixnumOr v28, v29
+          v30:Fixnum = GuardType v16, Fixnum
+          v31:Fixnum = GuardType v19, Fixnum
+          v32:Fixnum = FixnumOr v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -7485,23 +7739,25 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v26:CShape = LoadField v23, :shape_id@0x1040
-          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
-          v28:BasicObject = LoadField v23, :@foo@0x1042
+          v24:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v27:CShape = LoadField v24, :shape_id@0x1040
+          v28:CShape[0x1041] = GuardBitEquals v27, CShape(0x1041) recompile
+          v29:BasicObject = LoadField v24, :@foo@0x1042
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -7528,21 +7784,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v24:BasicObject = GetIvar v23, :@foo
+          v24:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v25:BasicObject = GetIvar v24, :@foo
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -7722,24 +7980,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :obj@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :obj@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v17:Fixnum[5] = Const Value(5)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :obj@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :obj@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :obj@0x1000
+          v18:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v31:CShape = LoadField v28, :shape_id@0x1040
-          v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
-          StoreField v28, :@foo@0x1042, v17
-          WriteBarrier v28, v17
+          v29:ObjectSubclass[class_exact:C] = GuardType v16, ObjectSubclass[class_exact:C]
+          v32:CShape = LoadField v29, :shape_id@0x1040
+          v33:CShape[0x1041] = GuardBitEquals v32, CShape(0x1041)
+          StoreField v29, :@foo@0x1042, v18
+          WriteBarrier v29, v18
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -8357,29 +8617,31 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          CondBranch v15, bb5(v9, v10, v10), bb6()
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:CBool = HasType v14, ObjectSubclass[class_exact:C]
+          CondBranch v16, bb5(v9, v14), bb6()
+        bb5(v17:BasicObject, v18:BasicObject):
           v20:ObjectSubclass[class_exact:C] = RefineType v18, ObjectSubclass[class_exact:C]
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v37:BasicObject = GetIvar v20, :@foo
-          Jump bb4(v16, v17, v37)
+          v36:BasicObject = GetIvar v20, :@foo
+          Jump bb4(v17, v36)
         bb6():
-          v24:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v24)
-        bb4(v26:BasicObject, v27:BasicObject, v28:BasicObject):
+          v24:BasicObject = Send v14, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v24)
+        bb4(v26:BasicObject, v27:BasicObject):
           CheckInterrupts
-          Return v28
+          Return v27
         ");
     }
 
@@ -8404,21 +8666,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v24:BasicObject = GetIvar v23, :@foo
+          v24:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v25:BasicObject = GetIvar v24, :@foo
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -8468,28 +8732,29 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :result@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:ArrayExact = NewArray
+          SetLocal :result, l0, EP@3, v13
           PatchPoint SingleRactorMode
-          PatchPoint StableConstantNames(0x1000, A)
-          v38:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          PatchPoint StableConstantNames(0x1010, B)
-          v41:ArrayExact[VALUE(0x1018)] = Const Value(VALUE(0x1018))
-          PatchPoint NoSingletonClass(Array@0x1020)
-          PatchPoint MethodRedefined(Array@0x1020, zip@0x1028, cme:0x1030)
-          v46:BasicObject = CCallVariadic v38, :Array#zip@0x1058, v41
-          PatchPoint NoEPEscape(test)
-          v24:CPtr = LoadSP
-          v25:BasicObject = LoadField v24, :result@0x1060
+          PatchPoint StableConstantNames(0x1008, A)
+          v35:ArrayExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
+          PatchPoint StableConstantNames(0x1018, B)
+          v38:ArrayExact[VALUE(0x1020)] = Const Value(VALUE(0x1020))
+          PatchPoint NoSingletonClass(Array@0x1028)
+          PatchPoint MethodRedefined(Array@0x1028, zip@0x1030, cme:0x1038)
+          v43:BasicObject = CCallVariadic v35, :Array#zip@0x1060, v38
+          v26:CPtr = GetEP 0
+          v27:BasicObject = LoadField v26, :result@0x1000
           CheckInterrupts
-          Return v25
+          Return v27
         ");
     }
 
@@ -8504,32 +8769,32 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :block@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:ArrayExact = NewArray
-          v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v20:CBool = IsBlockParamModified v19
-          CondBranch v20, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:ArrayExact = NewArray
+          v16:CPtr = GetEP 0
+          v17:CUInt64 = LoadField v16, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v18:CBool = IsBlockParamModified v17
+          CondBranch v18, bb4(), bb5()
         bb4():
-          v22:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v22, v22)
+          v20:BasicObject = LoadField v16, :block@0x1000
+          Jump bb6(v20)
         bb5():
-          v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v25:CInt64 = GuardAnyBitSet v24, CUInt64(1)
-          v26:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v26, v10)
-        bb6(v16:BasicObject, v17:BasicObject):
-          v29:BasicObject = Send v14, &block, :map, v16 # SendFallbackReason: Complex argument passing
+          v22:CInt64 = LoadField v16, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
+          v23:CInt64 = GuardAnyBitSet v22, CUInt64(1)
+          v24:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v24)
+        bb6(v15:BasicObject):
+          v27:BasicObject = Send v13, &block, :map, v15 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v29
+          Return v27
         ");
     }
 
@@ -8544,32 +8809,32 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :block@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:ArrayExact = NewArray
-          v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v20:CBool = IsBlockParamModified v19
-          CondBranch v20, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:ArrayExact = NewArray
+          v16:CPtr = GetEP 0
+          v17:CUInt64 = LoadField v16, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v18:CBool = IsBlockParamModified v17
+          CondBranch v18, bb4(), bb5()
         bb4():
-          v22:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v22, v22)
+          v20:BasicObject = LoadField v16, :block@0x1000
+          Jump bb6(v20)
         bb5():
-          v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v25:CInt64[0] = GuardBitEquals v24, CInt64(0)
-          v26:NilClass = Const Value(nil)
-          Jump bb6(v26, v10)
-        bb6(v16:BasicObject, v17:BasicObject):
-          v29:BasicObject = Send v14, &block, :map, v16 # SendFallbackReason: Complex argument passing
+          v22:CInt64 = LoadField v16, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
+          v23:CInt64[0] = GuardBitEquals v22, CInt64(0)
+          v24:NilClass = Const Value(nil)
+          Jump bb6(v24)
+        bb6(v15:BasicObject):
+          v27:BasicObject = Send v13, &block, :map, v15 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v29
+          Return v27
         ");
     }
 
@@ -8793,23 +9058,25 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v26:CShape = LoadField v23, :shape_id@0x1040
-          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
-          v28:NilClass = Const Value(nil)
+          v24:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v27:CShape = LoadField v24, :shape_id@0x1040
+          v28:CShape[0x1041] = GuardBitEquals v27, CShape(0x1041) recompile
+          v29:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -8829,23 +9096,25 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v26:CShape = LoadField v23, :shape_id@0x1040
-          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
-          v28:NilClass = Const Value(nil)
+          v24:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v27:CShape = LoadField v24, :shape_id@0x1040
+          v28:CShape[0x1041] = GuardBitEquals v27, CShape(0x1041) recompile
+          v29:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -8865,26 +9134,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v17:Fixnum[5] = Const Value(5)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :o@0x1000
+          v18:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v31:CShape = LoadField v28, :shape_id@0x1040
-          v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
-          StoreField v28, :@foo@0x1042, v17
-          WriteBarrier v28, v17
-          v35:CShape[0x1043] = Const CShape(0x1043)
-          StoreField v28, :shape_id@0x1040, v35
+          v29:ObjectSubclass[class_exact:C] = GuardType v16, ObjectSubclass[class_exact:C]
+          v32:CShape = LoadField v29, :shape_id@0x1040
+          v33:CShape[0x1041] = GuardBitEquals v32, CShape(0x1041)
+          StoreField v29, :@foo@0x1042, v18
+          WriteBarrier v29, v18
+          v36:CShape[0x1043] = Const CShape(0x1043)
+          StoreField v29, :shape_id@0x1040, v36
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -8904,26 +9175,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v17:Fixnum[5] = Const Value(5)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :o@0x1000
+          v18:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v31:CShape = LoadField v28, :shape_id@0x1040
-          v32:CShape[0x1041] = GuardBitEquals v31, CShape(0x1041)
-          StoreField v28, :@foo@0x1042, v17
-          WriteBarrier v28, v17
-          v35:CShape[0x1043] = Const CShape(0x1043)
-          StoreField v28, :shape_id@0x1040, v35
+          v29:ObjectSubclass[class_exact:C] = GuardType v16, ObjectSubclass[class_exact:C]
+          v32:CShape = LoadField v29, :shape_id@0x1040
+          v33:CShape[0x1041] = GuardBitEquals v32, CShape(0x1041)
+          StoreField v29, :@foo@0x1042, v18
+          WriteBarrier v29, v18
+          v36:CShape[0x1043] = Const CShape(0x1043)
+          StoreField v29, :shape_id@0x1040, v36
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -8940,21 +9213,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v24:BasicObject = LoadField v23, :foo@0x1040
+          v24:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v25:BasicObject = LoadField v24, :foo@0x1040
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -8971,22 +9246,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v24:CPtr = LoadField v23, :as_heap@0x1040
-          v25:BasicObject = LoadField v24, :foo@0x1041
+          v24:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v25:CPtr = LoadField v24, :as_heap@0x1040
+          v26:BasicObject = LoadField v25, :foo@0x1041
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -9006,21 +9283,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v27:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v19:Fixnum[5] = Const Value(5)
+          v28:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v20:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v19
+          Return v20
         ");
     }
 
@@ -9038,26 +9317,30 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          v4:BasicObject = LoadField v2, :v@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :o@1
-          v9:BasicObject = LoadArg :v@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          v8:BasicObject = LoadArg :v@2
+          StoreField v6, :v@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v17:CPtr = GetEP 0
+          v18:BasicObject = LoadField v17, :o@0x1000
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :v@0x1001
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v31:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C]
-          v32:CUInt64 = LoadField v31, :RBASIC_FLAGS@0x1040
-          v33:CUInt64 = GuardNoBitsSet v32, RUBY_FL_FREEZE=CUInt64(2048)
-          StoreField v31, :foo=@0x1041, v13
-          WriteBarrier v31, v13
+          v33:ObjectSubclass[class_exact:C] = GuardType v18, ObjectSubclass[class_exact:C]
+          v34:CUInt64 = LoadField v33, :RBASIC_FLAGS@0x1040
+          v35:CUInt64 = GuardNoBitsSet v34, RUBY_FL_FREEZE=CUInt64(2048)
+          StoreField v33, :foo=@0x1041, v21
+          WriteBarrier v33, v21
           CheckInterrupts
-          Return v13
+          Return v21
         ");
     }
 
@@ -9075,27 +9358,31 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          v4:BasicObject = LoadField v2, :v@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :o@1
-          v9:BasicObject = LoadArg :v@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          v8:BasicObject = LoadArg :v@2
+          StoreField v6, :v@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v17:CPtr = GetEP 0
+          v18:BasicObject = LoadField v17, :o@0x1000
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :v@0x1001
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo=@0x1010, cme:0x1018)
-          v31:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C]
-          v32:CUInt64 = LoadField v31, :RBASIC_FLAGS@0x1040
-          v33:CUInt64 = GuardNoBitsSet v32, RUBY_FL_FREEZE=CUInt64(2048)
-          v34:CPtr = LoadField v31, :as_heap@0x1041
-          StoreField v34, :foo=@0x1042, v13
-          WriteBarrier v31, v13
+          v33:ObjectSubclass[class_exact:C] = GuardType v18, ObjectSubclass[class_exact:C]
+          v34:CUInt64 = LoadField v33, :RBASIC_FLAGS@0x1040
+          v35:CUInt64 = GuardNoBitsSet v34, RUBY_FL_FREEZE=CUInt64(2048)
+          v36:CPtr = LoadField v33, :as_heap@0x1041
+          StoreField v36, :foo=@0x1042, v21
+          WriteBarrier v33, v21
           CheckInterrupts
-          Return v13
+          Return v21
         ");
     }
 
@@ -9240,20 +9527,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, to_s@0x1010, cme:0x1018)
-          v24:StringExact = GuardType v10, StringExact
+          v25:StringExact = GuardType v14, StringExact
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -9268,20 +9557,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v23:Fixnum = GuardType v10, Fixnum
-          v24:StringExact = CCallVariadic v23, :Integer#to_s@0x1040
+          v24:Fixnum = GuardType v14, Fixnum
+          v25:StringExact = CCallVariadic v24, :Integer#to_s@0x1040
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -9296,20 +9587,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v23:Bignum = GuardType v10, Bignum
-          v24:StringExact = CCallVariadic v23, :Integer#to_s@0x1040
+          v24:Bignum = GuardType v14, Bignum
+          v25:StringExact = CCallVariadic v24, :Integer#to_s@0x1040
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -9324,22 +9617,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v28:Fixnum = GuardType v10, Fixnum
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v29:Fixnum = GuardType v16, Fixnum
           PatchPoint MethodRedefined(Integer@0x1010, to_s@0x1018, cme:0x1020)
-          v33:StringExact = CCallVariadic v28, :Integer#to_s@0x1048
-          v22:StringExact = StringConcat v14, v33
+          v34:StringExact = CCallVariadic v29, :Integer#to_s@0x1048
+          v23:StringExact = StringConcat v13, v34
           CheckInterrupts
-          Return v22
+          Return v23
         ");
     }
 
@@ -9356,25 +9651,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
-          v13:ArrayExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v14:ArrayExact = ArrayDup v13
-          v19:Fixnum[0] = Const Value(0)
-          PatchPoint NoSingletonClass(Array@0x1008)
-          PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v38:CInt64[0] = Const CInt64(0)
-          v32:CInt64 = ArrayLength v14
-          v33:CInt64[0] = GuardLess v38, v32
-          v37:BasicObject = ArrayAref v14, v33
-          CheckInterrupts
-          Return v37
+          SetLocal :arr, l0, EP@3, v14
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :arr@0x1000
+          v22:Fixnum[0] = Const Value(0)
+          SideExit NoProfileSend recompile
         ");
     }
 
@@ -9391,30 +9683,34 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          v4:BasicObject = LoadField v2, :idx@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :arr@1
-          v9:BasicObject = LoadArg :idx@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          v8:BasicObject = LoadArg :idx@2
+          StoreField v6, :idx@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :arr@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :idx@0x1001
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v29:ArrayExact = GuardType v12, ArrayExact
-          v30:Fixnum = GuardType v13, Fixnum
-          v31:CInt64 = UnboxFixnum v30
-          v32:CInt64 = ArrayLength v29
-          v33:CInt64 = GuardLess v31, v32
-          v34:CInt64 = AdjustBounds v33, v32
-          v35:CInt64[0] = Const CInt64(0)
-          v36:CInt64 = GuardGreaterEq v34, v35
-          v37:BasicObject = ArrayAref v29, v36
+          v31:ArrayExact = GuardType v16, ArrayExact
+          v32:Fixnum = GuardType v19, Fixnum
+          v33:CInt64 = UnboxFixnum v32
+          v34:CInt64 = ArrayLength v31
+          v35:CInt64 = GuardLess v33, v34
+          v36:CInt64 = AdjustBounds v35, v34
+          v37:CInt64[0] = Const CInt64(0)
+          v38:CInt64 = GuardGreaterEq v36, v37
+          v39:BasicObject = ArrayAref v31, v38
           CheckInterrupts
-          Return v37
+          Return v39
         ");
     }
 
@@ -9432,30 +9728,34 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          v4:BasicObject = LoadField v2, :idx@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :arr@1
-          v9:BasicObject = LoadArg :idx@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          v8:BasicObject = LoadArg :idx@2
+          StoreField v6, :idx@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :arr@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :idx@0x1001
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, []@0x1010, cme:0x1018)
-          v29:ArraySubclass[class_exact:C] = GuardType v12, ArraySubclass[class_exact:C]
-          v30:Fixnum = GuardType v13, Fixnum
-          v31:CInt64 = UnboxFixnum v30
-          v32:CInt64 = ArrayLength v29
-          v33:CInt64 = GuardLess v31, v32
-          v34:CInt64 = AdjustBounds v33, v32
-          v35:CInt64[0] = Const CInt64(0)
-          v36:CInt64 = GuardGreaterEq v34, v35
-          v37:BasicObject = ArrayAref v29, v36
+          v31:ArraySubclass[class_exact:C] = GuardType v16, ArraySubclass[class_exact:C]
+          v32:Fixnum = GuardType v19, Fixnum
+          v33:CInt64 = UnboxFixnum v32
+          v34:CInt64 = ArrayLength v31
+          v35:CInt64 = GuardLess v33, v34
+          v36:CInt64 = AdjustBounds v35, v34
+          v37:CInt64[0] = Const CInt64(0)
+          v38:CInt64 = GuardGreaterEq v36, v37
+          v39:BasicObject = ArrayAref v31, v38
           CheckInterrupts
-          Return v37
+          Return v39
         ");
     }
 
@@ -9472,22 +9772,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
-          v13:HashExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:HashExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v14:HashExact = HashDup v13
-          v19:Fixnum[1] = Const Value(1)
-          PatchPoint NoSingletonClass(Hash@0x1008)
-          PatchPoint MethodRedefined(Hash@0x1008, []@0x1010, cme:0x1018)
-          v31:BasicObject = HashAref v14, v19
-          CheckInterrupts
-          Return v31
+          SetLocal :arr, l0, EP@3, v14
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :arr@0x1000
+          v22:Fixnum[1] = Const Value(1)
+          SideExit NoProfileSend recompile
         ");
     }
 
@@ -9504,23 +9804,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :hash@0x1000
-          v4:BasicObject = LoadField v2, :key@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :hash@1
-          v9:BasicObject = LoadArg :key@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :hash@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :hash@0x1000, v5
+          v8:BasicObject = LoadArg :key@2
+          StoreField v6, :key@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :hash@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :key@0x1001
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, []@0x1010, cme:0x1018)
-          v29:HashExact = GuardType v12, HashExact
-          v30:BasicObject = HashAref v29, v13
+          v31:HashExact = GuardType v16, HashExact
+          v32:BasicObject = HashAref v31, v19
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -9538,23 +9842,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :hash@0x1000
-          v4:BasicObject = LoadField v2, :key@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :hash@1
-          v9:BasicObject = LoadArg :key@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :hash@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :hash@0x1000, v5
+          v8:BasicObject = LoadArg :key@2
+          StoreField v6, :key@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :hash@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :key@0x1001
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, []@0x1010, cme:0x1018)
-          v29:HashSubclass[class_exact:C] = GuardType v12, HashSubclass[class_exact:C]
-          v30:BasicObject = CCallWithFrame v29, :Hash#[]@0x1040, v13
+          v31:HashSubclass[class_exact:C] = GuardType v16, HashSubclass[class_exact:C]
+          v32:BasicObject = CCallWithFrame v31, :Hash#[]@0x1040, v19
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -9601,23 +9909,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :h@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:HashExact = NewHash
-          PatchPoint NoEPEscape(test)
-          v22:Fixnum[1] = Const Value(1)
-          v24:Fixnum[3] = Const Value(3)
-          PatchPoint NoSingletonClass(Hash@0x1000)
-          PatchPoint MethodRedefined(Hash@0x1000, []=@0x1008, cme:0x1010)
-          HashAset v13, v22, v24
-          CheckInterrupts
-          Return v24
+          SetLocal :h, l0, EP@3, v13
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :h@0x1000
+          v23:Fixnum[1] = Const Value(1)
+          v25:Fixnum[3] = Const Value(3)
+          SideExit NoProfileSend recompile
         ");
     }
 
@@ -9634,25 +9941,31 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :hash@0x1000
-          v4:BasicObject = LoadField v2, :key@0x1001
-          v5:BasicObject = LoadField v2, :val@0x1002
-          Jump bb3(v1, v3, v4, v5)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v8:BasicObject = LoadArg :self@0
-          v9:BasicObject = LoadArg :hash@1
-          v10:BasicObject = LoadArg :key@2
-          v11:BasicObject = LoadArg :val@3
-          Jump bb3(v8, v9, v10, v11)
-        bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :hash@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :hash@0x1000, v5
+          v8:BasicObject = LoadArg :key@2
+          StoreField v6, :key@0x1001, v8
+          v10:BasicObject = LoadArg :val@3
+          StoreField v6, :val@0x1002, v10
+          Jump bb3(v4)
+        bb3(v13:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :hash@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :key@0x1001
+          v25:CPtr = GetEP 0
+          v26:BasicObject = LoadField v25, :val@0x1002
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, []=@0x1010, cme:0x1018)
-          v37:HashExact = GuardType v14, HashExact
-          HashAset v37, v15, v16
+          v40:HashExact = GuardType v20, HashExact
+          HashAset v40, v23, v26
           CheckInterrupts
-          Return v16
+          Return v26
         ");
     }
 
@@ -9670,25 +9983,31 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :hash@0x1000
-          v4:BasicObject = LoadField v2, :key@0x1001
-          v5:BasicObject = LoadField v2, :val@0x1002
-          Jump bb3(v1, v3, v4, v5)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v8:BasicObject = LoadArg :self@0
-          v9:BasicObject = LoadArg :hash@1
-          v10:BasicObject = LoadArg :key@2
-          v11:BasicObject = LoadArg :val@3
-          Jump bb3(v8, v9, v10, v11)
-        bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :hash@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :hash@0x1000, v5
+          v8:BasicObject = LoadArg :key@2
+          StoreField v6, :key@0x1001, v8
+          v10:BasicObject = LoadArg :val@3
+          StoreField v6, :val@0x1002, v10
+          Jump bb3(v4)
+        bb3(v13:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :hash@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :key@0x1001
+          v25:CPtr = GetEP 0
+          v26:BasicObject = LoadField v25, :val@0x1002
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, []=@0x1010, cme:0x1018)
-          v37:HashSubclass[class_exact:C] = GuardType v14, HashSubclass[class_exact:C]
-          v38:BasicObject = CCallWithFrame v37, :Hash#[]=@0x1040, v15, v16
+          v40:HashSubclass[class_exact:C] = GuardType v20, HashSubclass[class_exact:C]
+          v41:BasicObject = CCallWithFrame v40, :Hash#[]=@0x1040, v23, v26
           CheckInterrupts
-          Return v16
+          Return v26
         ");
     }
 
@@ -9734,30 +10053,32 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :arr@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v17:Fixnum[1] = Const Value(1)
-          v19:Fixnum[10] = Const Value(10)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :arr@0x1000
+          v18:Fixnum[1] = Const Value(1)
+          v20:Fixnum[10] = Const Value(10)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []=@0x1010, cme:0x1018)
-          v33:ArrayExact = GuardType v10, ArrayExact
-          v34:CUInt64 = LoadField v33, :RBASIC_FLAGS@0x1040
-          v35:CUInt64 = GuardNoBitsSet v34, RUBY_FL_FREEZE=CUInt64(2048)
-          v37:CUInt64 = GuardNoBitsSet v35, RUBY_ELTS_SHARED=CUInt64(4096)
-          v46:CInt64[1] = Const CInt64(1)
-          v39:CInt64 = ArrayLength v33
-          v40:CInt64[1] = GuardLess v46, v39
-          ArrayAset v33, v40, v19
-          WriteBarrier v33, v19
+          v34:ArrayExact = GuardType v16, ArrayExact
+          v35:CUInt64 = LoadField v34, :RBASIC_FLAGS@0x1040
+          v36:CUInt64 = GuardNoBitsSet v35, RUBY_FL_FREEZE=CUInt64(2048)
+          v38:CUInt64 = GuardNoBitsSet v36, RUBY_ELTS_SHARED=CUInt64(4096)
+          v47:CInt64[1] = Const CInt64(1)
+          v40:CInt64 = ArrayLength v34
+          v41:CInt64[1] = GuardLess v47, v40
+          ArrayAset v34, v41, v20
+          WriteBarrier v34, v20
           CheckInterrupts
-          Return v19
+          Return v20
         ");
     }
 
@@ -9774,36 +10095,42 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          v4:BasicObject = LoadField v2, :index@0x1001
-          v5:BasicObject = LoadField v2, :val@0x1002
-          Jump bb3(v1, v3, v4, v5)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v8:BasicObject = LoadArg :self@0
-          v9:BasicObject = LoadArg :arr@1
-          v10:BasicObject = LoadArg :index@2
-          v11:BasicObject = LoadArg :val@3
-          Jump bb3(v8, v9, v10, v11)
-        bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          v8:BasicObject = LoadArg :index@2
+          StoreField v6, :index@0x1001, v8
+          v10:BasicObject = LoadArg :val@3
+          StoreField v6, :val@0x1002, v10
+          Jump bb3(v4)
+        bb3(v13:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :arr@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :index@0x1001
+          v25:CPtr = GetEP 0
+          v26:BasicObject = LoadField v25, :val@0x1002
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, []=@0x1010, cme:0x1018)
-          v37:ArrayExact = GuardType v14, ArrayExact
-          v38:Fixnum = GuardType v15, Fixnum
-          v39:CUInt64 = LoadField v37, :RBASIC_FLAGS@0x1040
-          v40:CUInt64 = GuardNoBitsSet v39, RUBY_FL_FREEZE=CUInt64(2048)
-          v42:CUInt64 = GuardNoBitsSet v40, RUBY_ELTS_SHARED=CUInt64(4096)
-          v43:CInt64 = UnboxFixnum v38
-          v44:CInt64 = ArrayLength v37
-          v45:CInt64 = GuardLess v43, v44
-          v46:CInt64 = AdjustBounds v45, v44
-          v47:CInt64[0] = Const CInt64(0)
-          v48:CInt64 = GuardGreaterEq v46, v47
-          ArrayAset v37, v48, v16
-          WriteBarrier v37, v16
+          v40:ArrayExact = GuardType v20, ArrayExact
+          v41:Fixnum = GuardType v23, Fixnum
+          v42:CUInt64 = LoadField v40, :RBASIC_FLAGS@0x1040
+          v43:CUInt64 = GuardNoBitsSet v42, RUBY_FL_FREEZE=CUInt64(2048)
+          v45:CUInt64 = GuardNoBitsSet v43, RUBY_ELTS_SHARED=CUInt64(4096)
+          v46:CInt64 = UnboxFixnum v41
+          v47:CInt64 = ArrayLength v40
+          v48:CInt64 = GuardLess v46, v47
+          v49:CInt64 = AdjustBounds v48, v47
+          v50:CInt64[0] = Const CInt64(0)
+          v51:CInt64 = GuardGreaterEq v49, v50
+          ArrayAset v40, v51, v26
+          WriteBarrier v40, v26
           CheckInterrupts
-          Return v16
+          Return v26
         ");
     }
 
@@ -9822,25 +10149,31 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          v4:BasicObject = LoadField v2, :index@0x1001
-          v5:BasicObject = LoadField v2, :val@0x1002
-          Jump bb3(v1, v3, v4, v5)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v8:BasicObject = LoadArg :self@0
-          v9:BasicObject = LoadArg :arr@1
-          v10:BasicObject = LoadArg :index@2
-          v11:BasicObject = LoadArg :val@3
-          Jump bb3(v8, v9, v10, v11)
-        bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          v8:BasicObject = LoadArg :index@2
+          StoreField v6, :index@0x1001, v8
+          v10:BasicObject = LoadArg :val@3
+          StoreField v6, :val@0x1002, v10
+          Jump bb3(v4)
+        bb3(v13:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :arr@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :index@0x1001
+          v25:CPtr = GetEP 0
+          v26:BasicObject = LoadField v25, :val@0x1002
           PatchPoint NoSingletonClass(MyArray@0x1008)
           PatchPoint MethodRedefined(MyArray@0x1008, []=@0x1010, cme:0x1018)
-          v37:ArraySubclass[class_exact:MyArray] = GuardType v14, ArraySubclass[class_exact:MyArray]
-          v38:BasicObject = CCallVariadic v37, :Array#[]=@0x1040, v15, v16
+          v40:ArraySubclass[class_exact:MyArray] = GuardType v20, ArraySubclass[class_exact:MyArray]
+          v41:BasicObject = CCallVariadic v40, :Array#[]=@0x1040, v23, v26
           CheckInterrupts
-          Return v16
+          Return v26
         ");
     }
 
@@ -9857,24 +10190,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :arr@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[1] = Const Value(1)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :arr@0x1000
+          v16:Fixnum[1] = Const Value(1)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, <<@0x1010, cme:0x1018)
-          v27:ArrayExact = GuardType v10, ArrayExact
-          v28:CUInt64 = LoadField v27, :RBASIC_FLAGS@0x1040
-          v29:CUInt64 = GuardNoBitsSet v28, RUBY_FL_FREEZE=CUInt64(2048)
-          ArrayPush v27, v15
+          v28:ArrayExact = GuardType v14, ArrayExact
+          v29:CUInt64 = LoadField v28, :RBASIC_FLAGS@0x1040
+          v30:CUInt64 = GuardNoBitsSet v29, RUBY_FL_FREEZE=CUInt64(2048)
+          ArrayPush v28, v16
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -9891,24 +10226,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :arr@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[1] = Const Value(1)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :arr@0x1000
+          v16:Fixnum[1] = Const Value(1)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, push@0x1010, cme:0x1018)
-          v26:ArrayExact = GuardType v10, ArrayExact
-          v27:CUInt64 = LoadField v26, :RBASIC_FLAGS@0x1040
-          v28:CUInt64 = GuardNoBitsSet v27, RUBY_FL_FREEZE=CUInt64(2048)
-          ArrayPush v26, v15
+          v27:ArrayExact = GuardType v14, ArrayExact
+          v28:CUInt64 = LoadField v27, :RBASIC_FLAGS@0x1040
+          v29:CUInt64 = GuardNoBitsSet v28, RUBY_FL_FREEZE=CUInt64(2048)
+          ArrayPush v27, v16
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -9925,24 +10262,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :arr@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[1] = Const Value(1)
-          v17:Fixnum[2] = Const Value(2)
-          v19:Fixnum[3] = Const Value(3)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :arr@0x1000
+          v16:Fixnum[1] = Const Value(1)
+          v18:Fixnum[2] = Const Value(2)
+          v20:Fixnum[3] = Const Value(3)
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, push@0x1010, cme:0x1018)
-          v30:ArrayExact = GuardType v10, ArrayExact
-          v31:BasicObject = CCallVariadic v30, :Array#push@0x1040, v15, v17, v19
+          v31:ArrayExact = GuardType v14, ArrayExact
+          v32:BasicObject = CCallVariadic v31, :Array#push@0x1040, v16, v18, v20
           CheckInterrupts
-          Return v31
+          Return v32
         ");
     }
 
@@ -9960,27 +10299,29 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :val@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :val@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :val@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :val@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :val@0x1000
           PatchPoint MethodRedefined(Array@0x1008, <<@0x1010, cme:0x1018)
-          v23:CPtr = GetEP 0
-          v24:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
-          v25:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v24, Value(VALUE(0x1048))
-          v26:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
-          v27:FalseClass = GuardBitEquals v26, Value(false)
-          v28:Array = GuardType v9, Array
-          v29:CUInt64 = LoadField v28, :RBASIC_FLAGS@0x1051
-          v30:CUInt64 = GuardNoBitsSet v29, RUBY_FL_FREEZE=CUInt64(2048)
-          ArrayPush v28, v10
+          v24:CPtr = GetEP 0
+          v25:RubyValue = LoadField v24, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
+          v26:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v25, Value(VALUE(0x1048))
+          v27:RubyValue = LoadField v24, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
+          v28:FalseClass = GuardBitEquals v27, Value(false)
+          v29:Array = GuardType v9, Array
+          v30:CUInt64 = LoadField v29, :RBASIC_FLAGS@0x1051
+          v31:CUInt64 = GuardNoBitsSet v30, RUBY_FL_FREEZE=CUInt64(2048)
+          ArrayPush v29, v15
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -10039,37 +10380,39 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :idx@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :idx@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :idx@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :idx@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :idx@0x1000
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v23:CPtr = GetEP 0
-          v24:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
-          v25:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v24, Value(VALUE(0x1048))
-          v26:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
-          v27:FalseClass = GuardBitEquals v26, Value(false)
-          v38:CPtr = GetEP 0
-          v39:RubyValue = LoadField v38, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
-          v40:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v39, Value(VALUE(0x1048))
-          v41:RubyValue = LoadField v38, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
-          v42:FalseClass = GuardBitEquals v41, Value(false)
-          v28:Array = GuardType v9, Array
-          v29:Fixnum = GuardType v10, Fixnum
-          v30:CInt64 = UnboxFixnum v29
-          v31:CInt64 = ArrayLength v28
-          v32:CInt64 = GuardLess v30, v31
-          v33:CInt64 = AdjustBounds v32, v31
-          v34:CInt64[0] = Const CInt64(0)
-          v35:CInt64 = GuardGreaterEq v33, v34
-          v36:BasicObject = ArrayAref v28, v35
+          v24:CPtr = GetEP 0
+          v25:RubyValue = LoadField v24, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
+          v26:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v25, Value(VALUE(0x1048))
+          v27:RubyValue = LoadField v24, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
+          v28:FalseClass = GuardBitEquals v27, Value(false)
+          v39:CPtr = GetEP 0
+          v40:RubyValue = LoadField v39, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
+          v41:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v40, Value(VALUE(0x1048))
+          v42:RubyValue = LoadField v39, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
+          v43:FalseClass = GuardBitEquals v42, Value(false)
+          v29:Array = GuardType v9, Array
+          v30:Fixnum = GuardType v15, Fixnum
+          v31:CInt64 = UnboxFixnum v30
+          v32:CInt64 = ArrayLength v29
+          v33:CInt64 = GuardLess v31, v32
+          v34:CInt64 = AdjustBounds v33, v32
+          v35:CInt64[0] = Const CInt64(0)
+          v36:CInt64 = GuardGreaterEq v34, v35
+          v37:BasicObject = ArrayAref v29, v36
           CheckInterrupts
-          Return v36
+          Return v37
         ");
     }
 
@@ -10087,24 +10430,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :idx@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :idx@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :idx@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :idx@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :idx@0x1000
           PatchPoint MethodRedefined(Array@0x1008, []@0x1010, cme:0x1018)
-          v23:CPtr = GetEP 0
-          v24:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
-          v25:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v24, Value(VALUE(0x1048))
-          v26:RubyValue = LoadField v23, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
-          v27:FalseClass = GuardBitEquals v26, Value(false)
-          v28:BasicObject = CCallVariadic v9, :Array#[]@0x1058, v10
+          v24:CPtr = GetEP 0
+          v25:RubyValue = LoadField v24, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
+          v26:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v25, Value(VALUE(0x1048))
+          v27:RubyValue = LoadField v24, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
+          v28:FalseClass = GuardBitEquals v27, Value(false)
+          v29:BasicObject = CCallVariadic v9, :Array#[]@0x1058, v15
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -10120,22 +10465,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :arr@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :arr@0x1000
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, length@0x1010, cme:0x1018)
-          v25:ArrayExact = GuardType v10, ArrayExact
-          v26:CInt64 = ArrayLength v25
-          v27:Fixnum = BoxFixnum v26
+          v26:ArrayExact = GuardType v14, ArrayExact
+          v27:CInt64 = ArrayLength v26
+          v28:Fixnum = BoxFixnum v27
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -10151,22 +10498,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arr@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :arr@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arr@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arr@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :arr@0x1000
           PatchPoint NoSingletonClass(Array@0x1008)
           PatchPoint MethodRedefined(Array@0x1008, size@0x1010, cme:0x1018)
-          v25:ArrayExact = GuardType v10, ArrayExact
-          v26:CInt64 = ArrayLength v25
-          v27:Fixnum = BoxFixnum v26
+          v26:ArrayExact = GuardType v14, ArrayExact
+          v27:CInt64 = ArrayLength v26
+          v28:Fixnum = BoxFixnum v27
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -10182,22 +10531,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :s@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:RegexpExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :s@0x1000
+          v16:RegexpExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, =~@0x1018, cme:0x1020)
-          v27:StringExact = GuardType v10, StringExact
-          v28:BasicObject = CCallWithFrame v27, :String#=~@0x1048, v15
+          v28:StringExact = GuardType v14, StringExact
+          v29:BasicObject = CCallWithFrame v28, :String#=~@0x1048, v16
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -10212,30 +10563,34 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          v4:BasicObject = LoadField v2, :i@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :s@1
-          v9:BasicObject = LoadArg :i@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          v8:BasicObject = LoadArg :i@2
+          StoreField v6, :i@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :s@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :i@0x1001
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, getbyte@0x1010, cme:0x1018)
-          v28:StringExact = GuardType v12, StringExact
-          v29:Fixnum = GuardType v13, Fixnum
-          v30:CInt64 = UnboxFixnum v29
-          v31:CInt64 = LoadField v28, :len@0x1040
-          v32:CInt64 = GuardLess v30, v31
-          v33:CInt64 = AdjustBounds v32, v31
-          v34:CInt64[0] = Const CInt64(0)
-          v35:CInt64 = GuardGreaterEq v33, v34
-          v36:Fixnum = StringGetbyte v28, v35
+          v30:StringExact = GuardType v16, StringExact
+          v31:Fixnum = GuardType v19, Fixnum
+          v32:CInt64 = UnboxFixnum v31
+          v33:CInt64 = LoadField v30, :len@0x1040
+          v34:CInt64 = GuardLess v32, v33
+          v35:CInt64 = AdjustBounds v34, v33
+          v36:CInt64[0] = Const CInt64(0)
+          v37:CInt64 = GuardGreaterEq v35, v36
+          v38:Fixnum = StringGetbyte v30, v37
           CheckInterrupts
-          Return v36
+          Return v38
         ");
     }
 
@@ -10253,30 +10608,34 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          v4:BasicObject = LoadField v2, :i@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :s@1
-          v9:BasicObject = LoadArg :i@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          v8:BasicObject = LoadArg :i@2
+          StoreField v6, :i@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :s@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :i@0x1001
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, getbyte@0x1010, cme:0x1018)
-          v32:StringExact = GuardType v12, StringExact
-          v33:Fixnum = GuardType v13, Fixnum
-          v34:CInt64 = UnboxFixnum v33
-          v35:CInt64 = LoadField v32, :len@0x1040
-          v36:CInt64 = GuardLess v34, v35
-          v37:CInt64 = AdjustBounds v36, v35
-          v38:CInt64[0] = Const CInt64(0)
-          v39:CInt64 = GuardGreaterEq v37, v38
-          v23:Fixnum[5] = Const Value(5)
+          v34:StringExact = GuardType v16, StringExact
+          v35:Fixnum = GuardType v19, Fixnum
+          v36:CInt64 = UnboxFixnum v35
+          v37:CInt64 = LoadField v34, :len@0x1040
+          v38:CInt64 = GuardLess v36, v37
+          v39:CInt64 = AdjustBounds v38, v37
+          v40:CInt64[0] = Const CInt64(0)
+          v41:CInt64 = GuardGreaterEq v39, v40
+          v25:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v23
+          Return v25
         ");
     }
 
@@ -10293,35 +10652,41 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          v4:BasicObject = LoadField v2, :idx@0x1001
-          v5:BasicObject = LoadField v2, :val@0x1002
-          Jump bb3(v1, v3, v4, v5)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v8:BasicObject = LoadArg :self@0
-          v9:BasicObject = LoadArg :s@1
-          v10:BasicObject = LoadArg :idx@2
-          v11:BasicObject = LoadArg :val@3
-          Jump bb3(v8, v9, v10, v11)
-        bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          v8:BasicObject = LoadArg :idx@2
+          StoreField v6, :idx@0x1001, v8
+          v10:BasicObject = LoadArg :val@3
+          StoreField v6, :val@0x1002, v10
+          Jump bb3(v4)
+        bb3(v13:BasicObject):
+          v17:CPtr = GetEP 0
+          v18:BasicObject = LoadField v17, :s@0x1000
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :idx@0x1001
+          v23:CPtr = GetEP 0
+          v24:BasicObject = LoadField v23, :val@0x1002
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, setbyte@0x1010, cme:0x1018)
-          v32:StringExact = GuardType v14, StringExact
-          v33:Fixnum = GuardType v15, Fixnum
-          v34:Fixnum = GuardType v16, Fixnum
-          v35:CInt64 = UnboxFixnum v33
-          v36:CInt64 = LoadField v32, :len@0x1040
-          v37:CInt64 = GuardLess v35, v36
-          v38:CInt64 = AdjustBounds v37, v36
-          v39:CInt64[0] = Const CInt64(0)
-          v40:CInt64 = GuardGreaterEq v38, v39
-          v41:CUInt64 = LoadField v32, :RBASIC_FLAGS@0x1041
-          v42:CUInt64 = GuardNoBitsSet v41, RUBY_FL_FREEZE=CUInt64(2048)
-          v43:Fixnum = StringSetbyteFixnum v32, v33, v34
+          v35:StringExact = GuardType v18, StringExact
+          v36:Fixnum = GuardType v21, Fixnum
+          v37:Fixnum = GuardType v24, Fixnum
+          v38:CInt64 = UnboxFixnum v36
+          v39:CInt64 = LoadField v35, :len@0x1040
+          v40:CInt64 = GuardLess v38, v39
+          v41:CInt64 = AdjustBounds v40, v39
+          v42:CInt64[0] = Const CInt64(0)
+          v43:CInt64 = GuardGreaterEq v41, v42
+          v44:CUInt64 = LoadField v35, :RBASIC_FLAGS@0x1041
+          v45:CUInt64 = GuardNoBitsSet v44, RUBY_FL_FREEZE=CUInt64(2048)
+          v46:Fixnum = StringSetbyteFixnum v35, v36, v37
           CheckInterrupts
-          Return v34
+          Return v37
         ");
     }
 
@@ -10340,35 +10705,41 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          v4:BasicObject = LoadField v2, :idx@0x1001
-          v5:BasicObject = LoadField v2, :val@0x1002
-          Jump bb3(v1, v3, v4, v5)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v8:BasicObject = LoadArg :self@0
-          v9:BasicObject = LoadArg :s@1
-          v10:BasicObject = LoadArg :idx@2
-          v11:BasicObject = LoadArg :val@3
-          Jump bb3(v8, v9, v10, v11)
-        bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          v8:BasicObject = LoadArg :idx@2
+          StoreField v6, :idx@0x1001, v8
+          v10:BasicObject = LoadArg :val@3
+          StoreField v6, :val@0x1002, v10
+          Jump bb3(v4)
+        bb3(v13:BasicObject):
+          v17:CPtr = GetEP 0
+          v18:BasicObject = LoadField v17, :s@0x1000
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :idx@0x1001
+          v23:CPtr = GetEP 0
+          v24:BasicObject = LoadField v23, :val@0x1002
           PatchPoint NoSingletonClass(MyString@0x1008)
           PatchPoint MethodRedefined(MyString@0x1008, setbyte@0x1010, cme:0x1018)
-          v32:StringSubclass[class_exact:MyString] = GuardType v14, StringSubclass[class_exact:MyString]
-          v33:Fixnum = GuardType v15, Fixnum
-          v34:Fixnum = GuardType v16, Fixnum
-          v35:CInt64 = UnboxFixnum v33
-          v36:CInt64 = LoadField v32, :len@0x1040
-          v37:CInt64 = GuardLess v35, v36
-          v38:CInt64 = AdjustBounds v37, v36
-          v39:CInt64[0] = Const CInt64(0)
-          v40:CInt64 = GuardGreaterEq v38, v39
-          v41:CUInt64 = LoadField v32, :RBASIC_FLAGS@0x1041
-          v42:CUInt64 = GuardNoBitsSet v41, RUBY_FL_FREEZE=CUInt64(2048)
-          v43:Fixnum = StringSetbyteFixnum v32, v33, v34
+          v35:StringSubclass[class_exact:MyString] = GuardType v18, StringSubclass[class_exact:MyString]
+          v36:Fixnum = GuardType v21, Fixnum
+          v37:Fixnum = GuardType v24, Fixnum
+          v38:CInt64 = UnboxFixnum v36
+          v39:CInt64 = LoadField v35, :len@0x1040
+          v40:CInt64 = GuardLess v38, v39
+          v41:CInt64 = AdjustBounds v40, v39
+          v42:CInt64[0] = Const CInt64(0)
+          v43:CInt64 = GuardGreaterEq v41, v42
+          v44:CUInt64 = LoadField v35, :RBASIC_FLAGS@0x1041
+          v45:CUInt64 = GuardNoBitsSet v44, RUBY_FL_FREEZE=CUInt64(2048)
+          v46:Fixnum = StringSetbyteFixnum v35, v36, v37
           CheckInterrupts
-          Return v34
+          Return v37
         ");
     }
 
@@ -10385,25 +10756,31 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          v4:BasicObject = LoadField v2, :idx@0x1001
-          v5:BasicObject = LoadField v2, :val@0x1002
-          Jump bb3(v1, v3, v4, v5)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v8:BasicObject = LoadArg :self@0
-          v9:BasicObject = LoadArg :s@1
-          v10:BasicObject = LoadArg :idx@2
-          v11:BasicObject = LoadArg :val@3
-          Jump bb3(v8, v9, v10, v11)
-        bb3(v13:BasicObject, v14:BasicObject, v15:BasicObject, v16:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          v8:BasicObject = LoadArg :idx@2
+          StoreField v6, :idx@0x1001, v8
+          v10:BasicObject = LoadArg :val@3
+          StoreField v6, :val@0x1002, v10
+          Jump bb3(v4)
+        bb3(v13:BasicObject):
+          v17:CPtr = GetEP 0
+          v18:BasicObject = LoadField v17, :s@0x1000
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :idx@0x1001
+          v23:CPtr = GetEP 0
+          v24:BasicObject = LoadField v23, :val@0x1002
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, setbyte@0x1010, cme:0x1018)
-          v32:StringExact = GuardType v14, StringExact
-          v33:BasicObject = CCallWithFrame v32, :String#setbyte@0x1040, v15, v16
+          v35:StringExact = GuardType v18, StringExact
+          v36:BasicObject = CCallWithFrame v35, :String#setbyte@0x1040, v21, v24
           CheckInterrupts
-          Return v33
+          Return v36
         ");
     }
 
@@ -10420,24 +10797,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :s@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :s@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, empty?@0x1010, cme:0x1018)
-          v25:StringExact = GuardType v10, StringExact
-          v26:CInt64 = LoadField v25, :len@0x1040
-          v27:CInt64[0] = Const CInt64(0)
-          v28:CBool = IsBitEqual v26, v27
-          v29:BoolExact = BoxBool v28
+          v26:StringExact = GuardType v14, StringExact
+          v27:CInt64 = LoadField v26, :len@0x1040
+          v28:CInt64[0] = Const CInt64(0)
+          v29:CBool = IsBitEqual v27, v28
+          v30:BoolExact = BoxBool v29
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -10455,21 +10834,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :s@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :s@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, empty?@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v10, StringExact
-          v20:Fixnum[4] = Const Value(4)
+          v30:StringExact = GuardType v14, StringExact
+          v21:Fixnum[4] = Const Value(4)
           CheckInterrupts
-          Return v20
+          Return v21
         ");
     }
 
@@ -10485,21 +10866,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, succ@0x1010, cme:0x1018)
-          v24:Fixnum = GuardType v10, Fixnum
-          v25:Fixnum[1] = Const Value(1)
-          v26:Fixnum = FixnumAdd v24, v25
+          v25:Fixnum = GuardType v14, Fixnum
+          v26:Fixnum[1] = Const Value(1)
+          v27:Fixnum = FixnumAdd v25, v26
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -10515,20 +10898,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, succ@0x1010, cme:0x1018)
-          v24:Bignum = GuardType v10, Bignum
-          v25:BasicObject = CCallWithFrame v24, :Integer#succ@0x1040
+          v25:Bignum = GuardType v14, Bignum
+          v26:BasicObject = CCallWithFrame v25, :Integer#succ@0x1040
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -10544,21 +10929,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[5] = Const Value(5)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
+          v16:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(Integer@0x1008, <<@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
-          v27:Fixnum = FixnumLShift v26, v15
+          v27:Fixnum = GuardType v14, Fixnum
+          v28:Fixnum = FixnumLShift v27, v16
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -10574,21 +10961,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[-5] = Const Value(-5)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
+          v16:Fixnum[-5] = Const Value(-5)
           PatchPoint MethodRedefined(Integer@0x1008, <<@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
-          v27:BasicObject = CCallWithFrame v26, :Integer#<<@0x1040, v15
+          v27:Fixnum = GuardType v14, Fixnum
+          v28:BasicObject = CCallWithFrame v27, :Integer#<<@0x1040, v16
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -10604,21 +10993,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[64] = Const Value(64)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
+          v16:Fixnum[64] = Const Value(64)
           PatchPoint MethodRedefined(Integer@0x1008, <<@0x1010, cme:0x1018)
-          v26:Fixnum = GuardType v10, Fixnum
-          v27:BasicObject = CCallWithFrame v26, :Integer#<<@0x1040, v15
+          v27:Fixnum = GuardType v14, Fixnum
+          v28:BasicObject = CCallWithFrame v27, :Integer#<<@0x1040, v16
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -10634,22 +11025,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, <<@0x1010, cme:0x1018)
-          v28:Fixnum = GuardType v12, Fixnum
-          v29:BasicObject = CCallWithFrame v28, :Integer#<<@0x1040, v13
+          v30:Fixnum = GuardType v16, Fixnum
+          v31:BasicObject = CCallWithFrame v30, :Integer#<<@0x1040, v19
           CheckInterrupts
-          Return v29
+          Return v31
         ");
     }
 
@@ -10664,21 +11059,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[5] = Const Value(5)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
+          v16:Fixnum[5] = Const Value(5)
           PatchPoint MethodRedefined(Integer@0x1008, >>@0x1010, cme:0x1018)
-          v25:Fixnum = GuardType v10, Fixnum
-          v26:Fixnum = FixnumRShift v25, v15
+          v26:Fixnum = GuardType v14, Fixnum
+          v27:Fixnum = FixnumRShift v26, v16
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -10693,21 +11090,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[-5] = Const Value(-5)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
+          v16:Fixnum[-5] = Const Value(-5)
           PatchPoint MethodRedefined(Integer@0x1008, >>@0x1010, cme:0x1018)
-          v25:Fixnum = GuardType v10, Fixnum
-          v26:BasicObject = CCallWithFrame v25, :Integer#>>@0x1040, v15
+          v26:Fixnum = GuardType v14, Fixnum
+          v27:BasicObject = CCallWithFrame v26, :Integer#>>@0x1040, v16
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -10722,21 +11121,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[64] = Const Value(64)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
+          v16:Fixnum[64] = Const Value(64)
           PatchPoint MethodRedefined(Integer@0x1008, >>@0x1010, cme:0x1018)
-          v25:Fixnum = GuardType v10, Fixnum
-          v26:BasicObject = CCallWithFrame v25, :Integer#>>@0x1040, v15
+          v26:Fixnum = GuardType v14, Fixnum
+          v27:BasicObject = CCallWithFrame v26, :Integer#>>@0x1040, v16
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -10751,22 +11152,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, >>@0x1010, cme:0x1018)
-          v27:Fixnum = GuardType v12, Fixnum
-          v28:BasicObject = CCallWithFrame v27, :Integer#>>@0x1040, v13
+          v29:Fixnum = GuardType v16, Fixnum
+          v30:BasicObject = CCallWithFrame v29, :Integer#>>@0x1040, v19
           CheckInterrupts
-          Return v28
+          Return v30
         ");
     }
 
@@ -10781,24 +11186,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
-          v30:String = GuardType v13, String
-          v31:StringExact = StringAppend v29, v30
+          v31:StringExact = GuardType v16, StringExact
+          v32:String = GuardType v19, String
+          v33:StringExact = StringAppend v31, v32
           CheckInterrupts
-          Return v29
+          Return v31
         ");
     }
 
@@ -10813,24 +11222,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
-          v30:Fixnum = GuardType v13, Fixnum
-          v31:StringExact = StringAppendCodepoint v29, v30
+          v31:StringExact = GuardType v16, StringExact
+          v32:Fixnum = GuardType v19, Fixnum
+          v33:StringExact = StringAppendCodepoint v31, v32
           CheckInterrupts
-          Return v29
+          Return v31
         ");
     }
 
@@ -10847,24 +11260,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
-          v30:String = GuardType v13, String
-          v31:StringExact = StringAppend v29, v30
+          v31:StringExact = GuardType v16, StringExact
+          v32:String = GuardType v19, String
+          v33:StringExact = StringAppend v31, v32
           CheckInterrupts
-          Return v29
+          Return v31
         ");
     }
 
@@ -10881,23 +11298,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint NoSingletonClass(MyString@0x1008)
           PatchPoint MethodRedefined(MyString@0x1008, <<@0x1010, cme:0x1018)
-          v29:StringSubclass[class_exact:MyString] = GuardType v12, StringSubclass[class_exact:MyString]
-          v30:BasicObject = CCallWithFrame v29, :String#<<@0x1040, v13
+          v31:StringSubclass[class_exact:MyString] = GuardType v16, StringSubclass[class_exact:MyString]
+          v32:BasicObject = CCallWithFrame v31, :String#<<@0x1040, v19
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -10966,21 +11387,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ascii_only?@0x1010, cme:0x1018)
-          v24:StringExact = GuardType v10, StringExact
-          v25:BoolExact = CCall v24, :String#ascii_only?@0x1040
+          v25:StringExact = GuardType v14, StringExact
+          v26:BoolExact = CCall v25, :String#ascii_only?@0x1040
           CheckInterrupts
-          Return v25
+          Return v26
         ");
     }
 
@@ -11043,23 +11466,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, ^@0x1010, cme:0x1018)
-          v27:Fixnum = GuardType v12, Fixnum
-          v28:Fixnum = GuardType v13, Fixnum
-          v29:Fixnum = FixnumXor v27, v28
+          v29:Fixnum = GuardType v16, Fixnum
+          v30:Fixnum = GuardType v19, Fixnum
+          v31:Fixnum = FixnumXor v29, v30
           CheckInterrupts
-          Return v29
+          Return v31
         ");
     }
 
@@ -11077,23 +11504,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, ^@0x1010, cme:0x1018)
-          v31:Fixnum = GuardType v12, Fixnum
-          v32:Fixnum = GuardType v13, Fixnum
-          v23:Fixnum[42] = Const Value(42)
+          v33:Fixnum = GuardType v16, Fixnum
+          v34:Fixnum = GuardType v19, Fixnum
+          v25:Fixnum[42] = Const Value(42)
           CheckInterrupts
-          Return v23
+          Return v25
         ");
     }
 
@@ -11108,22 +11539,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, ^@0x1010, cme:0x1018)
-          v27:Bignum = GuardType v12, Bignum
-          v28:BasicObject = CCallWithFrame v27, :Integer#^@0x1040, v13
+          v29:Bignum = GuardType v16, Bignum
+          v30:BasicObject = CCallWithFrame v29, :Integer#^@0x1040, v19
           CheckInterrupts
-          Return v28
+          Return v30
         ");
     }
 
@@ -11138,22 +11573,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint MethodRedefined(Integer@0x1008, ^@0x1010, cme:0x1018)
-          v27:Fixnum = GuardType v12, Fixnum
-          v28:BasicObject = CCallWithFrame v27, :Integer#^@0x1040, v13
+          v29:Fixnum = GuardType v16, Fixnum
+          v30:BasicObject = CCallWithFrame v29, :Integer#^@0x1040, v19
           CheckInterrupts
-          Return v28
+          Return v30
         ");
     }
 
@@ -11168,22 +11607,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
           PatchPoint MethodRedefined(TrueClass@0x1008, ^@0x1010, cme:0x1018)
-          v27:TrueClass = GuardType v12, TrueClass
-          v28:BasicObject = CCallWithFrame v27, :TrueClass#^@0x1040, v13
+          v29:TrueClass = GuardType v16, TrueClass
+          v30:BasicObject = CCallWithFrame v29, :TrueClass#^@0x1040, v19
           CheckInterrupts
-          Return v28
+          Return v30
         ");
     }
 
@@ -11197,17 +11640,19 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
           SideExit NoProfileSend recompile
         ");
     }
@@ -11223,21 +11668,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :hash@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :hash@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :hash@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :hash@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :hash@0x1000
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, size@0x1010, cme:0x1018)
-          v25:HashExact = GuardType v10, HashExact
-          v26:Fixnum = CCall v25, :Hash#size@0x1040
+          v26:HashExact = GuardType v14, HashExact
+          v27:Fixnum = CCall v26, :Hash#size@0x1040
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -11255,21 +11702,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :hash@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :hash@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :hash@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :hash@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :hash@0x1000
           PatchPoint NoSingletonClass(Hash@0x1008)
           PatchPoint MethodRedefined(Hash@0x1008, size@0x1010, cme:0x1018)
-          v29:HashExact = GuardType v10, HashExact
-          v20:Fixnum[5] = Const Value(5)
+          v30:HashExact = GuardType v14, HashExact
+          v21:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v20
+          Return v21
         ");
     }
 
@@ -11287,23 +11736,25 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v27:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
-          v30:TrueClass = Const Value(true)
+          v31:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -11320,24 +11771,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v27:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1010, respond_to_missing?@0x1048, cme:0x1050)
           PatchPoint MethodRedefined(C@0x1010, foo@0x1078, cme:0x1080)
-          v32:FalseClass = Const Value(false)
+          v33:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 
@@ -11356,23 +11809,25 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v27:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
-          v30:FalseClass = Const Value(false)
+          v31:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -11391,24 +11846,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
-          v17:FalseClass = Const Value(false)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
+          v18:FalseClass = Const Value(false)
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v29:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
-          v32:FalseClass = Const Value(false)
+          v33:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 
@@ -11427,24 +11884,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
-          v17:NilClass = Const Value(nil)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
+          v18:NilClass = Const Value(nil)
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v29:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
-          v32:FalseClass = Const Value(false)
+          v33:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 
@@ -11463,24 +11922,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
-          v17:TrueClass = Const Value(true)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
+          v18:TrueClass = Const Value(true)
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v29:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
-          v32:TrueClass = Const Value(true)
+          v33:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 
@@ -11498,24 +11959,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
-          v17:Fixnum[4] = Const Value(4)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
+          v18:Fixnum[4] = Const Value(4)
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v29:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
-          v32:TrueClass = Const Value(true)
+          v33:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 
@@ -11533,24 +11996,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
-          v17:NilClass = Const Value(nil)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
+          v18:NilClass = Const Value(nil)
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v28:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v29:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1010, foo@0x1048, cme:0x1050)
-          v32:TrueClass = Const Value(true)
+          v33:TrueClass = Const Value(true)
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 
@@ -11567,24 +12032,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
+          v27:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
           PatchPoint MethodRedefined(C@0x1010, respond_to_missing?@0x1048, cme:0x1050)
           PatchPoint MethodRedefined(C@0x1010, foo@0x1078, cme:0x1080)
-          v32:FalseClass = Const Value(false)
+          v33:FalseClass = Const Value(false)
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 
@@ -11604,22 +12071,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:StaticSymbol[:foo] = Const Value(VALUE(0x1008))
           PatchPoint NoSingletonClass(C@0x1010)
           PatchPoint MethodRedefined(C@0x1010, respond_to?@0x1018, cme:0x1020)
-          v26:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v27:BasicObject = CCallVariadic v26, :Kernel#respond_to?@0x1048, v15
+          v27:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v28:BasicObject = CCallVariadic v27, :Kernel#respond_to?@0x1048, v16
           CheckInterrupts
-          Return v27
+          Return v28
         ");
     }
 
@@ -11878,27 +12347,33 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :empty@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:ArrayExact = NewArray
-          v19:ArrayExact = ToArray v13
-          v21:BasicObject = Send v8, :foo, v19 # SendFallbackReason: Complex argument passing
-          v25:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v26:StringExact = StringCopy v25
-          PatchPoint NoEPEscape(test)
-          v31:ArrayExact = ToArray v13
-          v33:BasicObject = Send v26, :display, v31 # SendFallbackReason: Complex argument passing
-          PatchPoint NoEPEscape(test)
-          v41:ArrayExact = ToArray v13
-          v43:BasicObject = Send v8, :itself, v41 # SendFallbackReason: Complex argument passing
+          SetLocal :empty, l0, EP@3, v13
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :empty@0x1000
+          v22:ArrayExact = ToArray v20
+          v24:BasicObject = Send v9, :foo, v22 # SendFallbackReason: Complex argument passing
+          v28:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v29:StringExact = StringCopy v28
+          v31:CPtr = GetEP 0
+          v32:BasicObject = LoadField v31, :empty@0x1000
+          v34:ArrayExact = ToArray v32
+          v36:BasicObject = Send v29, :display, v34 # SendFallbackReason: Complex argument passing
+          v41:CPtr = GetEP 0
+          v42:BasicObject = LoadField v41, :empty@0x1000
+          v44:ArrayExact = ToArray v42
+          v46:BasicObject = Send v9, :itself, v44 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v43
+          Return v46
         ");
     }
 
@@ -11913,19 +12388,21 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint MethodRedefined(Symbol@0x1008, to_sym@0x1010, cme:0x1018)
-          v22:StaticSymbol = GuardType v10, StaticSymbol
+          v23:StaticSymbol = GuardType v14, StaticSymbol
           CheckInterrupts
-          Return v22
+          Return v23
         ");
     }
 
@@ -11940,19 +12417,21 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, to_i@0x1010, cme:0x1018)
-          v22:Fixnum = GuardType v10, Fixnum
+          v23:Fixnum = GuardType v14, Fixnum
           CheckInterrupts
-          Return v22
+          Return v23
         ");
     }
 
@@ -12087,32 +12566,32 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :block@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:ArrayExact = NewArray
-          v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v20:CBool = IsBlockParamModified v19
-          CondBranch v20, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:ArrayExact = NewArray
+          v16:CPtr = GetEP 0
+          v17:CUInt64 = LoadField v16, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v18:CBool = IsBlockParamModified v17
+          CondBranch v18, bb4(), bb5()
         bb4():
-          v22:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v22, v22)
+          v20:BasicObject = LoadField v16, :block@0x1000
+          Jump bb6(v20)
         bb5():
-          v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v25:CInt64 = GuardAnyBitSet v24, CUInt64(1)
-          v26:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v26, v10)
-        bb6(v16:BasicObject, v17:BasicObject):
-          v29:BasicObject = Send v14, &block, :map, v16 # SendFallbackReason: Complex argument passing
+          v22:CInt64 = LoadField v16, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
+          v23:CInt64 = GuardAnyBitSet v22, CUInt64(1)
+          v24:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v24)
+        bb6(v15:BasicObject):
+          v27:BasicObject = Send v13, &block, :map, v15 # SendFallbackReason: Complex argument passing
           CheckInterrupts
-          Return v29
+          Return v27
         ");
     }
 
@@ -12127,24 +12606,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :l@0x1000
-          v4:BasicObject = LoadField v2, :r@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :l@1
-          v9:BasicObject = LoadArg :r@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :l@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :l@0x1000, v5
+          v8:BasicObject = LoadArg :r@2
+          StoreField v6, :r@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :l@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :r@0x1001
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
-          v30:String = GuardType v13, String
-          v31:BoolExact = StringEqual v29, v30
+          v31:StringExact = GuardType v16, StringExact
+          v32:String = GuardType v19, String
+          v33:BoolExact = StringEqual v31, v32
           CheckInterrupts
-          Return v31
+          Return v33
         ");
     }
 
@@ -12161,24 +12644,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :l@0x1000
-          v4:BasicObject = LoadField v2, :r@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :l@1
-          v9:BasicObject = LoadArg :r@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :l@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :l@0x1000, v5
+          v8:BasicObject = LoadArg :r@2
+          StoreField v6, :r@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :l@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :r@0x1001
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, ==@0x1010, cme:0x1018)
-          v29:StringSubclass[class_exact:C] = GuardType v12, StringSubclass[class_exact:C]
-          v30:String = GuardType v13, String
-          v31:BoolExact = StringEqual v29, v30
+          v31:StringSubclass[class_exact:C] = GuardType v16, StringSubclass[class_exact:C]
+          v32:String = GuardType v19, String
+          v33:BoolExact = StringEqual v31, v32
           CheckInterrupts
-          Return v31
+          Return v33
         ");
     }
 
@@ -12195,24 +12682,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :l@0x1000
-          v4:BasicObject = LoadField v2, :r@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :l@1
-          v9:BasicObject = LoadArg :r@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :l@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :l@0x1000, v5
+          v8:BasicObject = LoadArg :r@2
+          StoreField v6, :r@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :l@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :r@0x1001
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
-          v30:String = GuardType v13, String
-          v31:BoolExact = StringEqual v29, v30
+          v31:StringExact = GuardType v16, StringExact
+          v32:String = GuardType v19, String
+          v33:BoolExact = StringEqual v31, v32
           CheckInterrupts
-          Return v31
+          Return v33
         ");
     }
 
@@ -12227,24 +12718,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :l@0x1000
-          v4:BasicObject = LoadField v2, :r@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :l@1
-          v9:BasicObject = LoadArg :r@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :l@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :l@0x1000, v5
+          v8:BasicObject = LoadArg :r@2
+          StoreField v6, :r@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :l@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :r@0x1001
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ===@0x1010, cme:0x1018)
-          v28:StringExact = GuardType v12, StringExact
-          v29:String = GuardType v13, String
-          v30:BoolExact = StringEqual v28, v29
+          v30:StringExact = GuardType v16, StringExact
+          v31:String = GuardType v19, String
+          v32:BoolExact = StringEqual v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -12261,24 +12756,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :l@0x1000
-          v4:BasicObject = LoadField v2, :r@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :l@1
-          v9:BasicObject = LoadArg :r@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :l@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :l@0x1000, v5
+          v8:BasicObject = LoadArg :r@2
+          StoreField v6, :r@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :l@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :r@0x1001
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, ===@0x1010, cme:0x1018)
-          v28:StringSubclass[class_exact:C] = GuardType v12, StringSubclass[class_exact:C]
-          v29:String = GuardType v13, String
-          v30:BoolExact = StringEqual v28, v29
+          v30:StringSubclass[class_exact:C] = GuardType v16, StringSubclass[class_exact:C]
+          v31:String = GuardType v19, String
+          v32:BoolExact = StringEqual v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -12295,24 +12794,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :l@0x1000
-          v4:BasicObject = LoadField v2, :r@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :l@1
-          v9:BasicObject = LoadArg :r@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :l@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :l@0x1000, v5
+          v8:BasicObject = LoadArg :r@2
+          StoreField v6, :r@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :l@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :r@0x1001
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ===@0x1010, cme:0x1018)
-          v28:StringExact = GuardType v12, StringExact
-          v29:String = GuardType v13, String
-          v30:BoolExact = StringEqual v28, v29
+          v30:StringExact = GuardType v16, StringExact
+          v31:String = GuardType v19, String
+          v32:BoolExact = StringEqual v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -12327,21 +12830,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :s@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :s@0x1000
+          v16:CPtr = GetEP 0
+          v17:BasicObject = LoadField v16, :s@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1010, cme:0x1018)
-          v26:StringExact = GuardType v10, StringExact
-          v29:TrueClass = Const Value(true)
+          v29:StringExact = GuardType v14, StringExact
+          v30:String = GuardType v17, String
+          v31:BoolExact = StringEqual v29, v30
           CheckInterrupts
-          Return v29
+          Return v31
         ");
     }
 
@@ -12356,21 +12864,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :s@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :s@0x1000
+          v16:CPtr = GetEP 0
+          v17:BasicObject = LoadField v16, :s@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ===@0x1010, cme:0x1018)
-          v25:StringExact = GuardType v10, StringExact
-          v28:TrueClass = Const Value(true)
+          v28:StringExact = GuardType v14, StringExact
+          v29:String = GuardType v17, String
+          v30:BoolExact = StringEqual v28, v29
           CheckInterrupts
-          Return v28
+          Return v30
         ");
     }
 
@@ -12390,21 +12903,29 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :str@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           PatchPoint BOPRedefined(STRING_REDEFINED_OP_FLAG, BOP_FREEZE)
-          v14:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          PatchPoint NoSingletonClass(String@0x1008)
-          PatchPoint MethodRedefined(String@0x1008, ==@0x1010, cme:0x1018)
-          v32:TrueClass = Const Value(true)
+          v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          SetLocal :str, l0, EP@3, v14
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :str@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :str@0x1000
+          PatchPoint NoSingletonClass(String@0x1010)
+          PatchPoint MethodRedefined(String@0x1010, ==@0x1018, cme:0x1020)
+          v35:StringExact = GuardType v20, StringExact
+          v36:String = GuardType v23, String
+          v37:BoolExact = StringEqual v35, v36
           CheckInterrupts
-          Return v32
+          Return v37
         ");
     }
 
@@ -12588,31 +13109,42 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          v3:NilClass = Const Value(nil)
-          Jump bb3(v1, v2, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:NilClass = Const Value(nil)
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
           v8:NilClass = Const Value(nil)
-          Jump bb3(v6, v7, v8)
-        bb3(v10:BasicObject, v11:NilClass, v12:NilClass):
-          v16:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v17:StringExact = StringCopy v16
-          v21:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v16:StringExact = StringCopy v15
+          SetLocal :a, l0, EP@4, v16
+          v21:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v22:StringExact = StringCopy v21
-          v27:StringExact[VALUE(0x1000)] = Const Value(VALUE(0x1000))
-          v28:StringExact = StringCopy v27
-          PatchPoint NoSingletonClass(String@0x1008)
-          PatchPoint MethodRedefined(String@0x1008, <<@0x1010, cme:0x1018)
-          v50:StringExact = StringAppend v17, v28
-          PatchPoint NoEPEscape(test)
-          PatchPoint NoSingletonClass(String@0x1008)
-          PatchPoint MethodRedefined(String@0x1008, ==@0x1040, cme:0x1048)
-          v55:BoolExact = StringEqual v17, v22
+          SetLocal :b, l0, EP@3, v22
+          v27:CPtr = GetEP 0
+          v28:BasicObject = LoadField v27, :a@0x1000
+          v30:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v31:StringExact = StringCopy v30
+          PatchPoint NoSingletonClass(String@0x1010)
+          PatchPoint MethodRedefined(String@0x1010, <<@0x1018, cme:0x1020)
+          v54:StringExact = GuardType v28, StringExact
+          v55:StringExact = StringAppend v54, v31
+          v38:CPtr = GetEP 0
+          v39:BasicObject = LoadField v38, :a@0x1000
+          v41:CPtr = GetEP 0
+          v42:BasicObject = LoadField v41, :b@0x1001
+          PatchPoint NoSingletonClass(String@0x1010)
+          PatchPoint MethodRedefined(String@0x1010, ==@0x1048, cme:0x1050)
+          v59:StringExact = GuardType v39, StringExact
+          v60:String = GuardType v42, String
+          v61:BoolExact = StringEqual v59, v60
           CheckInterrupts
-          Return v55
+          Return v61
         ");
     }
 
@@ -12628,24 +13160,28 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          v4:BasicObject = LoadField v2, :t@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :s@1
-          v9:BasicObject = LoadArg :t@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          v8:BasicObject = LoadArg :t@2
+          StoreField v6, :t@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :s@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :t@0x1001
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, ==@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
-          v30:String = GuardType v13, String
-          v31:BoolExact = StringEqual v29, v30
+          v31:StringExact = GuardType v16, StringExact
+          v32:String = GuardType v19, String
+          v33:BoolExact = StringEqual v31, v32
           CheckInterrupts
-          Return v31
+          Return v33
         ");
     }
 
@@ -12661,23 +13197,25 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :s@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v15:StringExact = StringCopy v14
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v14:StringExact = StringCopy v13
+          v16:CPtr = GetEP 0
+          v17:BasicObject = LoadField v16, :s@0x1000
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, ==@0x1018, cme:0x1020)
-          v29:String = GuardType v10, String
-          v30:BoolExact = StringEqual v15, v29
+          v30:String = GuardType v17, String
+          v31:BoolExact = StringEqual v14, v30
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -12696,22 +13234,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :str@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :str@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:NilClass = Const Value(nil)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :str@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :str@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :str@0x1000
+          v16:NilClass = Const Value(nil)
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, !=@0x1010, cme:0x1018)
-          v27:StringExact = GuardType v10, StringExact
-          v28:BoolExact = CCallWithFrame v27, :BasicObject#!=@0x1040, v15
+          v28:StringExact = GuardType v14, StringExact
+          v29:BoolExact = CCallWithFrame v28, :BasicObject#!=@0x1040, v16
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -12728,28 +13268,32 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          v4:BasicObject = LoadField v2, :t@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :s@1
-          v9:BasicObject = LoadArg :t@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          v8:BasicObject = LoadArg :t@2
+          StoreField v6, :t@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :s@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :t@0x1001
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, !=@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v12, StringExact
+          v31:StringExact = GuardType v16, StringExact
           PatchPoint MethodRedefined(String@0x1008, ==@0x1040, cme:0x1048)
-          v33:String = GuardType v13, String
-          v34:BoolExact = StringEqual v29, v33
-          v35:TrueClass = Const Value(true)
-          v36:CBool = IsBitNotEqual v34, v35
-          v37:BoolExact = BoxBool v36
+          v35:String = GuardType v19, String
+          v36:BoolExact = StringEqual v31, v35
+          v37:TrueClass = Const Value(true)
+          v38:CBool = IsBitNotEqual v36, v37
+          v39:BoolExact = BoxBool v38
           CheckInterrupts
-          Return v37
+          Return v39
         ");
     }
 
@@ -12766,25 +13310,30 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :s@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :s@0x1000
+          v16:CPtr = GetEP 0
+          v17:BasicObject = LoadField v16, :s@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, !=@0x1010, cme:0x1018)
-          v26:StringExact = GuardType v10, StringExact
+          v29:StringExact = GuardType v14, StringExact
           PatchPoint MethodRedefined(String@0x1008, ==@0x1040, cme:0x1048)
+          v33:String = GuardType v17, String
+          v34:BoolExact = StringEqual v29, v33
           v35:TrueClass = Const Value(true)
-          v32:TrueClass = Const Value(true)
-          v33:CBool = IsBitNotEqual v35, v32
-          v34:BoolExact = BoxBool v33
+          v36:CBool = IsBitNotEqual v34, v35
+          v37:BoolExact = BoxBool v36
           CheckInterrupts
-          Return v34
+          Return v37
         ");
     }
 
@@ -12801,21 +13350,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :s@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :s@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, size@0x1010, cme:0x1018)
-          v25:StringExact = GuardType v10, StringExact
-          v26:Fixnum = CCall v25, :String#size@0x1040
+          v26:StringExact = GuardType v14, StringExact
+          v27:Fixnum = CCall v26, :String#size@0x1040
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -12833,21 +13384,23 @@ mod hir_opt_tests {
        bb1():
          EntryPoint interpreter
          v1:BasicObject = LoadSelf
-         v2:CPtr = LoadSP
-         v3:BasicObject = LoadField v2, :s@0x1000
-         Jump bb3(v1, v3)
+         Jump bb3(v1)
        bb2():
          EntryPoint JIT(0)
-         v6:BasicObject = LoadArg :self@0
-         v7:BasicObject = LoadArg :s@1
-         Jump bb3(v6, v7)
-       bb3(v9:BasicObject, v10:BasicObject):
+         v4:BasicObject = LoadArg :self@0
+         v5:BasicObject = LoadArg :s@1
+         v6:CPtr = GetEP 0
+         StoreField v6, :s@0x1000, v5
+         Jump bb3(v4)
+       bb3(v9:BasicObject):
+         v13:CPtr = GetEP 0
+         v14:BasicObject = LoadField v13, :s@0x1000
          PatchPoint NoSingletonClass(String@0x1008)
          PatchPoint MethodRedefined(String@0x1008, size@0x1010, cme:0x1018)
-         v29:StringExact = GuardType v10, StringExact
-         v20:Fixnum[5] = Const Value(5)
+         v30:StringExact = GuardType v14, StringExact
+         v21:Fixnum[5] = Const Value(5)
          CheckInterrupts
-         Return v20
+         Return v21
        ");
     }
 
@@ -12864,22 +13417,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :s@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :s@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, bytesize@0x1010, cme:0x1018)
-          v24:StringExact = GuardType v10, StringExact
-          v25:CInt64 = LoadField v24, :len@0x1040
-          v26:Fixnum = BoxFixnum v25
+          v25:StringExact = GuardType v14, StringExact
+          v26:CInt64 = LoadField v25, :len@0x1040
+          v27:Fixnum = BoxFixnum v26
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -12897,21 +13452,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :s@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :s@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, bytesize@0x1010, cme:0x1018)
-          v28:StringExact = GuardType v10, StringExact
-          v19:Fixnum[5] = Const Value(5)
+          v29:StringExact = GuardType v14, StringExact
+          v20:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v19
+          Return v20
         ");
     }
 
@@ -12928,21 +13485,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :s@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :s@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, length@0x1010, cme:0x1018)
-          v25:StringExact = GuardType v10, StringExact
-          v26:Fixnum = CCall v25, :String#length@0x1040
+          v26:StringExact = GuardType v14, StringExact
+          v27:Fixnum = CCall v26, :String#length@0x1040
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -12957,23 +13516,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, String)
-          v27:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
-          PatchPoint NoEPEscape(test)
+          v26:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :o@0x1000
           PatchPoint MethodRedefined(Class@0x1018, ===@0x1020, cme:0x1028)
-          v31:BoolExact = IsA v10, v27
+          v30:BoolExact = IsA v16, v26
           CheckInterrupts
-          Return v31
+          Return v30
         ");
     }
 
@@ -12988,23 +13548,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Kernel)
-          v27:ModuleSubclass[Kernel@0x1010] = Const Value(VALUE(0x1010))
-          PatchPoint NoEPEscape(test)
+          v26:ModuleSubclass[Kernel@0x1010] = Const Value(VALUE(0x1010))
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :o@0x1000
           PatchPoint MethodRedefined(Module@0x1018, ===@0x1020, cme:0x1028)
-          v31:BoolExact = CCall v27, :Module#===@0x1050, v10
+          v30:BoolExact = CCall v26, :Module#===@0x1050, v16
           CheckInterrupts
-          Return v31
+          Return v30
         ");
     }
 
@@ -13019,24 +13580,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, String)
-          v25:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
+          v26:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, is_a?@0x1011, cme:0x1018)
-          v29:StringExact = GuardType v10, StringExact
-          v30:BoolExact = IsA v29, v25
+          v30:StringExact = GuardType v14, StringExact
+          v31:BoolExact = IsA v30, v26
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -13051,24 +13614,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Kernel)
-          v25:ModuleSubclass[Kernel@0x1010] = Const Value(VALUE(0x1010))
+          v26:ModuleSubclass[Kernel@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, is_a?@0x1020, cme:0x1028)
-          v29:StringExact = GuardType v10, StringExact
-          v30:BasicObject = CCallWithFrame v29, :Kernel#is_a?@0x1050, v25
+          v30:StringExact = GuardType v14, StringExact
+          v31:BasicObject = CCallWithFrame v30, :Kernel#is_a?@0x1050, v26
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -13086,24 +13651,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Integer)
-          v29:ClassSubclass[Integer@0x1010] = Const Value(VALUE(0x1010))
+          v30:ClassSubclass[Integer@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, is_a?@0x1020, cme:0x1028)
-          v33:StringExact = GuardType v10, StringExact
-          v21:Fixnum[5] = Const Value(5)
+          v34:StringExact = GuardType v14, StringExact
+          v22:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v21
+          Return v22
         ");
     }
 
@@ -13121,23 +13688,24 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Integer)
-          v31:ClassSubclass[Integer@0x1010] = Const Value(VALUE(0x1010))
-          PatchPoint NoEPEscape(test)
+          v30:ClassSubclass[Integer@0x1010] = Const Value(VALUE(0x1010))
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :o@0x1000
           PatchPoint MethodRedefined(Class@0x1018, ===@0x1020, cme:0x1028)
-          v23:Fixnum[5] = Const Value(5)
+          v22:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v23
+          Return v22
         ");
     }
 
@@ -13152,24 +13720,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, String)
-          v25:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
+          v26:ClassSubclass[String@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1010)
           PatchPoint MethodRedefined(String@0x1010, kind_of?@0x1011, cme:0x1018)
-          v29:StringExact = GuardType v10, StringExact
-          v30:BoolExact = IsA v29, v25
+          v30:StringExact = GuardType v14, StringExact
+          v31:BoolExact = IsA v30, v26
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -13184,24 +13754,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Kernel)
-          v25:ModuleSubclass[Kernel@0x1010] = Const Value(VALUE(0x1010))
+          v26:ModuleSubclass[Kernel@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, kind_of?@0x1020, cme:0x1028)
-          v29:StringExact = GuardType v10, StringExact
-          v30:BasicObject = CCallWithFrame v29, :Kernel#kind_of?@0x1050, v25
+          v30:StringExact = GuardType v14, StringExact
+          v31:BasicObject = CCallWithFrame v30, :Kernel#kind_of?@0x1050, v26
           CheckInterrupts
-          Return v30
+          Return v31
         ");
     }
 
@@ -13219,24 +13791,26 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint SingleRactorMode
           PatchPoint StableConstantNames(0x1008, Integer)
-          v29:ClassSubclass[Integer@0x1010] = Const Value(VALUE(0x1010))
+          v30:ClassSubclass[Integer@0x1010] = Const Value(VALUE(0x1010))
           PatchPoint NoSingletonClass(String@0x1018)
           PatchPoint MethodRedefined(String@0x1018, kind_of?@0x1020, cme:0x1028)
-          v33:StringExact = GuardType v10, StringExact
-          v21:Fixnum[5] = Const Value(5)
+          v34:StringExact = GuardType v14, StringExact
+          v22:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v21
+          Return v22
         ");
     }
 
@@ -13453,21 +14027,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :s@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :s@0x1000
           PatchPoint NoSingletonClass(String@0x1008)
           PatchPoint MethodRedefined(String@0x1008, length@0x1010, cme:0x1018)
-          v29:StringExact = GuardType v10, StringExact
-          v20:Fixnum[4] = Const Value(4)
+          v30:StringExact = GuardType v14, StringExact
+          v21:Fixnum[4] = Const Value(4)
           CheckInterrupts
-          Return v20
+          Return v21
         ");
     }
 
@@ -13529,23 +14105,25 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, class@0x1010, cme:0x1018)
-          v25:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v28:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
+          v26:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v29:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           PatchPoint MethodRedefined(Class@0x1040, name@0x1048, cme:0x1050)
-          v32:StringExact|NilClass = CCall v28, :Module#name@0x1078
+          v33:StringExact|NilClass = CCall v29, :Module#name@0x1078
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 
@@ -13561,21 +14139,23 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, class@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:C] = GuardType v10, ObjectSubclass[class_exact:C]
-          v26:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
+          v24:ObjectSubclass[class_exact:C] = GuardType v14, ObjectSubclass[class_exact:C]
+          v27:ClassSubclass[C@0x1008] = Const Value(VALUE(0x1008))
           CheckInterrupts
-          Return v26
+          Return v27
         ");
     }
 
@@ -13683,35 +14263,41 @@ mod hir_opt_tests {
        bb1():
          EntryPoint interpreter
          v1:BasicObject = LoadSelf
-         v2:CPtr = LoadSP
-         v3:BasicObject = LoadField v2, :a@0x1000
-         v4:BasicObject = LoadField v2, :_b@0x1001
-         v5:BasicObject = LoadField v2, :_c@0x1002
-         v6:NilClass = Const Value(nil)
-         Jump bb3(v1, v3, v4, v5, v6)
+         Jump bb3(v1)
        bb2():
          EntryPoint JIT(0)
-         v9:BasicObject = LoadArg :self@0
-         v10:BasicObject = LoadArg :a@1
-         v11:BasicObject = LoadArg :_b@2
-         v12:BasicObject = LoadArg :_c@3
-         v13:NilClass = Const Value(nil)
-         Jump bb3(v9, v10, v11, v12, v13)
-       bb3(v15:BasicObject, v16:BasicObject, v17:BasicObject, v18:BasicObject, v19:NilClass):
+         v4:BasicObject = LoadArg :self@0
+         v5:BasicObject = LoadArg :a@1
+         v6:CPtr = GetEP 0
+         StoreField v6, :a@0x1000, v5
+         v8:BasicObject = LoadArg :_b@2
+         StoreField v6, :_b@0x1001, v8
+         v10:BasicObject = LoadArg :_c@3
+         StoreField v6, :_c@0x1002, v10
+         v12:NilClass = Const Value(nil)
+         StoreField v6, :formatted@0x1003, v12
+         Jump bb3(v4)
+       bb3(v15:BasicObject):
+         v19:CPtr = GetEP 0
+         v20:BasicObject = LoadField v19, :formatted@0x1003
          CheckInterrupts
-         SetLocal :formatted, l0, EP@3, v16
+         v23:CBool = Test v20
+         CondBranch v23, bb4(v15), bb5()
+       bb5():
+         v28:CPtr = GetEP 0
+         v29:BasicObject = LoadField v28, :a@0x1000
+         SetLocal :formatted, l0, EP@3, v29
+         Jump bb4(v15)
+       bb4(v33:BasicObject):
+         v37:CPtr = GetEP 0
+         v38:BasicObject = LoadField v37, :formatted@0x1003
          PatchPoint SingleRactorMode
-         SetIvar v15, :@formatted, v16
-         v47:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
+         SetIvar v33, :@formatted, v38
+         v45:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
          PatchPoint MethodRedefined(Class@0x1010, lambda@0x1018, cme:0x1020)
-         v63:BasicObject = CCallWithFrame v47, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
-         v50:CPtr = GetEP 0
-         v51:BasicObject = LoadField v50, :a@0x1001
-         v52:BasicObject = LoadField v50, :_b@0x1002
-         v53:BasicObject = LoadField v50, :_c@0x1058
-         v54:BasicObject = LoadField v50, :formatted@0x1059
+         v56:BasicObject = CCallWithFrame v45, :RubyVM::FrozenCore.lambda@0x1048, block=0x1050
          CheckInterrupts
-         Return v63
+         Return v56
        ");
     }
 
@@ -14052,23 +14638,25 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :obj@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :obj@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :obj@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :obj@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :obj@0x1000
           PatchPoint NoSingletonClass(TestDynamic@0x1008)
           PatchPoint MethodRedefined(TestDynamic@0x1008, val@0x1010, cme:0x1018)
-          v23:ObjectSubclass[class_exact:TestDynamic] = GuardType v10, ObjectSubclass[class_exact:TestDynamic]
-          v26:CShape = LoadField v23, :shape_id@0x1040
-          v27:CShape[0x1041] = GuardBitEquals v26, CShape(0x1041) recompile
-          v28:BasicObject = LoadField v23, :@val@0x1042
+          v24:ObjectSubclass[class_exact:TestDynamic] = GuardType v14, ObjectSubclass[class_exact:TestDynamic]
+          v27:CShape = LoadField v24, :shape_id@0x1040
+          v28:CShape[0x1041] = GuardBitEquals v27, CShape(0x1041) recompile
+          v29:BasicObject = LoadField v24, :@val@0x1042
           CheckInterrupts
-          Return v28
+          Return v29
         ");
     }
 
@@ -14381,26 +14969,31 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :s@0x1000
-          v4:BasicObject = LoadField v2, :proc@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :s@1
-          v9:BasicObject = LoadArg :proc@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v19:BasicObject = Send v12, :length # SendFallbackReason: Singleton class previously created for receiver class
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :s@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :s@0x1000, v5
+          v8:BasicObject = LoadArg :proc@2
+          StoreField v6, :proc@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :s@0x1000
+          v19:BasicObject = Send v16, :length # SendFallbackReason: Singleton class previously created for receiver class
+          v23:CPtr = GetEP 0
+          v24:BasicObject = LoadField v23, :proc@0x1001
           PatchPoint NoSingletonClass(Proc@0x1008)
           PatchPoint MethodRedefined(Proc@0x1008, call@0x1010, cme:0x1018)
-          v40:ObjectSubclass[class_exact:Proc] = GuardType v13, ObjectSubclass[class_exact:Proc]
-          v41:BasicObject = InvokeProc v40
-          PatchPoint NoEPEscape(test)
-          v32:BasicObject = Send v12, :length # SendFallbackReason: Singleton class previously created for receiver class
+          v42:ObjectSubclass[class_exact:Proc] = GuardType v24, ObjectSubclass[class_exact:Proc]
+          v43:BasicObject = InvokeProc v42
+          v30:CPtr = GetEP 0
+          v31:BasicObject = LoadField v30, :s@0x1000
+          v34:BasicObject = Send v31, :length # SendFallbackReason: Singleton class previously created for receiver class
           CheckInterrupts
-          Return v32
+          Return v34
         ");
     }
 
@@ -14533,28 +15126,30 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :x@0x1000
           PatchPoint MethodRedefined(A@0x1008, foo@0x1010, cme:0x1018)
-          v28:CPtr = GetEP 0
-          v29:RubyValue = LoadField v28, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
-          v30:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v29, Value(VALUE(0x1048))
-          v31:RubyValue = LoadField v28, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
-          v32:FalseClass = GuardBitEquals v31, Value(false)
-          v33:BasicObject = SendDirect v9, 0x1058, :foo (0x1068), v10
-          v18:Fixnum[1] = Const Value(1)
+          v29:CPtr = GetEP 0
+          v30:RubyValue = LoadField v29, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
+          v31:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v30, Value(VALUE(0x1048))
+          v32:RubyValue = LoadField v29, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
+          v33:FalseClass = GuardBitEquals v32, Value(false)
+          v34:BasicObject = SendDirect v9, 0x1058, :foo (0x1068), v15
+          v19:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v36:Fixnum = GuardType v33, Fixnum
-          v37:Fixnum = FixnumAdd v36, v18
+          v37:Fixnum = GuardType v34, Fixnum
+          v38:Fixnum = FixnumAdd v37, v19
           CheckInterrupts
-          Return v37
+          Return v38
         ");
     }
 
@@ -14585,19 +15180,21 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:ArrayExact = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:ArrayExact = ToArray v10
-          v18:BasicObject = InvokeSuper v9, 0x1008, v16 # SendFallbackReason: super: complex argument passing to `super` call
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :x@0x1000
+          v17:ArrayExact = ToArray v15
+          v19:BasicObject = InvokeSuper v9, 0x1008, v17 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
-          Return v18
+          Return v19
         ");
     }
 
@@ -14734,40 +15331,48 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :needle@0x1000
-          v4:BasicObject = LoadField v2, :offset@0x1001
-          v5:CPtr = LoadPC
-          v6:CPtr[CPtr(0x1002)] = Const CPtr(0x1002)
-          v7:CBool = IsBitEqual v5, v6
-          CondBranch v7, bb3(v1, v3, v4), bb6()
+          v2:CPtr = LoadPC
+          v3:CPtr[CPtr(0x1000)] = Const CPtr(0x1000)
+          v4:CBool = IsBitEqual v2, v3
+          CondBranch v4, bb3(v1), bb6()
         bb6():
-          Jump bb5(v1, v3, v4)
+          Jump bb5(v1)
         bb2():
           EntryPoint JIT(0)
-          v11:BasicObject = LoadArg :self@0
-          v12:BasicObject = LoadArg :needle@1
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v11, v12, v13)
-        bb3(v20:BasicObject, v21:BasicObject, v22:BasicObject):
-          v25:Fixnum[0] = Const Value(0)
-          Jump bb5(v20, v21, v25)
+          v8:BasicObject = LoadArg :self@0
+          v9:BasicObject = LoadArg :needle@1
+          v10:CPtr = GetEP 0
+          StoreField v10, :needle@0x1001, v9
+          v12:NilClass = Const Value(nil)
+          StoreField v10, :offset@0x1002, v12
+          Jump bb3(v8)
+        bb3(v23:BasicObject):
+          v26:Fixnum[0] = Const Value(0)
+          SetLocal :offset, l0, EP@3, v26
+          Jump bb5(v23)
         bb4():
           EntryPoint JIT(1)
           v16:BasicObject = LoadArg :self@0
           v17:BasicObject = LoadArg :needle@1
-          v18:BasicObject = LoadArg :offset@2
-          Jump bb5(v16, v17, v18)
-        bb5(v28:BasicObject, v29:BasicObject, v30:BasicObject):
+          v18:CPtr = GetEP 0
+          StoreField v18, :needle@0x1001, v17
+          v20:BasicObject = LoadArg :offset@2
+          StoreField v18, :offset@0x1002, v20
+          Jump bb5(v16)
+        bb5(v30:BasicObject):
+          v35:CPtr = GetEP 0
+          v36:BasicObject = LoadField v35, :needle@0x1001
+          v38:CPtr = GetEP 0
+          v39:BasicObject = LoadField v38, :offset@0x1002
           PatchPoint MethodRedefined(String@0x1008, byteindex@0x1010, cme:0x1018)
-          v44:CPtr = GetEP 0
-          v45:RubyValue = LoadField v44, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
-          v46:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v45, Value(VALUE(0x1048))
-          v47:RubyValue = LoadField v44, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
-          v48:FalseClass = GuardBitEquals v47, Value(false)
-          v49:BasicObject = CCallVariadic v28, :String#byteindex@0x1058, v29, v30
+          v48:CPtr = GetEP 0
+          v49:RubyValue = LoadField v48, :VM_ENV_DATA_INDEX_ME_CREF@0x1040
+          v50:CallableMethodEntry[VALUE(0x1048)] = GuardBitEquals v49, Value(VALUE(0x1048))
+          v51:RubyValue = LoadField v48, :VM_ENV_DATA_INDEX_SPECVAL@0x1050
+          v52:FalseClass = GuardBitEquals v51, Value(false)
+          v53:BasicObject = CCallVariadic v30, :String#byteindex@0x1058, v36, v39
           CheckInterrupts
-          Return v49
+          Return v53
         ");
     }
 
@@ -14799,29 +15404,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :blk@0x1000
-          v4:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :blk@1
-          v9:NilClass = Const Value(nil)
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :blk@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :blk@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :other_block@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
           PatchPoint NoSingletonClass(B@0x1008)
           PatchPoint MethodRedefined(B@0x1008, proc@0x1010, cme:0x1018)
-          v39:ObjectSubclass[class_exact:B] = GuardType v11, ObjectSubclass[class_exact:B]
-          v40:BasicObject = CCallWithFrame v39, :Kernel#proc@0x1040, block=0x1048
-          v19:CPtr = GetEP 0
-          v20:BasicObject = LoadField v19, :blk@0x1050
-          SetLocal :other_block, l0, EP@3, v40
-          v27:CPtr = GetEP 0
-          v28:BasicObject = LoadField v27, :other_block@0x1051
-          v30:BasicObject = InvokeSuper v39, 0x1058, v28 # SendFallbackReason: super: complex argument passing to `super` call
+          v34:ObjectSubclass[class_exact:B] = GuardType v11, ObjectSubclass[class_exact:B]
+          v35:BasicObject = CCallWithFrame v34, :Kernel#proc@0x1040, block=0x1048
+          SetLocal :other_block, l0, EP@3, v35
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :other_block@0x1001
+          v25:BasicObject = InvokeSuper v34, 0x1050, v23 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
-          Return v30
+          Return v25
         ");
     }
 
@@ -14852,19 +15455,21 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :items@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :items@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:StaticSymbol[:succ] = Const Value(VALUE(0x1008))
-          v18:BasicObject = InvokeSuper v9, 0x1010, v10, v16 # SendFallbackReason: super: complex argument passing to `super` call
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :items@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :items@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :items@0x1000
+          v17:StaticSymbol[:succ] = Const Value(VALUE(0x1008))
+          v19:BasicObject = InvokeSuper v9, 0x1010, v15, v17 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
-          Return v18
+          Return v19
         ");
     }
 
@@ -14894,32 +15499,37 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :content@0x1000
-          v4:CPtr = LoadPC
-          v5:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v6:CBool = IsBitEqual v4, v5
-          CondBranch v6, bb3(v1, v3), bb6()
+          v2:CPtr = LoadPC
+          v3:CPtr[CPtr(0x1000)] = Const CPtr(0x1000)
+          v4:CBool = IsBitEqual v2, v3
+          CondBranch v4, bb3(v1), bb6()
         bb6():
-          Jump bb5(v1, v3)
+          Jump bb5(v1)
         bb2():
           EntryPoint JIT(0)
-          v10:BasicObject = LoadArg :self@0
-          v11:NilClass = Const Value(nil)
-          Jump bb3(v10, v11)
-        bb3(v17:BasicObject, v18:BasicObject):
-          v21:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v22:StringExact = StringCopy v21
-          Jump bb5(v17, v22)
+          v8:BasicObject = LoadArg :self@0
+          v9:NilClass = Const Value(nil)
+          v10:CPtr = GetEP 0
+          StoreField v10, :content@0x1001, v9
+          Jump bb3(v8)
+        bb3(v19:BasicObject):
+          v22:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v23:StringExact = StringCopy v22
+          SetLocal :content, l0, EP@3, v23
+          Jump bb5(v19)
         bb4():
           EntryPoint JIT(1)
           v14:BasicObject = LoadArg :self@0
           v15:BasicObject = LoadArg :content@1
-          Jump bb5(v14, v15)
-        bb5(v25:BasicObject, v26:BasicObject):
-          v32:BasicObject = InvokeSuper v25, 0x1010, v26 # SendFallbackReason: super: complex argument passing to `super` call
+          v16:CPtr = GetEP 0
+          StoreField v16, :content@0x1001, v15
+          Jump bb5(v14)
+        bb5(v27:BasicObject):
+          v32:CPtr = GetEP 0
+          v33:BasicObject = LoadField v32, :content@0x1001
+          v35:BasicObject = InvokeSuper v27, 0x1010, v33 # SendFallbackReason: super: complex argument passing to `super` call
           CheckInterrupts
-          Return v32
+          Return v35
         ");
     }
 
@@ -14947,28 +15557,48 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           CheckInterrupts
-          v16:CBool = Test v10
-          v17:Falsy = RefineType v10, Falsy
-          CondBranch v16, bb7(), bb6(v9, v17)
+          v17:CBool = Test v14
+          CondBranch v17, bb7(), bb6(v9)
         bb7():
-          v19:Truthy = RefineType v10, Truthy
+          v23:CPtr = GetEP 0
+          v24:BasicObject = LoadField v23, :x@0x1000
           CheckInterrupts
-          v38:Fixnum[3] = Const Value(3)
-          Return v38
-        bb6(v43:BasicObject, v44:Falsy):
-          v48:Fixnum[6] = Const Value(6)
+          v27:CBool = Test v24
+          CondBranch v27, bb8(), bb5(v9)
+        bb8():
+          v33:CPtr = GetEP 0
+          v34:BasicObject = LoadField v33, :x@0x1000
           CheckInterrupts
-          Return v48
+          v37:CBool = Test v34
+          CondBranch v37, bb9(), bb4(v9)
+        bb9():
+          v43:Fixnum[3] = Const Value(3)
+          CheckInterrupts
+          Return v43
+        bb4(v66:BasicObject):
+          v70:Fixnum[4] = Const Value(4)
+          CheckInterrupts
+          Return v70
+        bb5(v57:BasicObject):
+          v61:Fixnum[5] = Const Value(5)
+          CheckInterrupts
+          Return v61
+        bb6(v48:BasicObject):
+          v52:Fixnum[6] = Const Value(6)
+          CheckInterrupts
+          Return v52
         ");
     }
 
@@ -14995,40 +15625,42 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          CondBranch v15, bb5(v9, v10, v10), bb6()
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:CBool = HasType v14, ObjectSubclass[class_exact:C]
+          CondBranch v16, bb5(v9, v14), bb6()
+        bb5(v17:BasicObject, v18:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v55:Fixnum[3] = Const Value(3)
-          Jump bb4(v16, v17, v55)
+          v53:Fixnum[3] = Const Value(3)
+          Jump bb4(v17, v53)
         bb6():
-          v24:CBool = HasType v10, ObjectSubclass[class_exact:D]
-          CondBranch v24, bb7(v9, v10, v10), bb8()
-        bb7(v25:BasicObject, v26:BasicObject, v27:BasicObject):
+          v24:CBool = HasType v14, ObjectSubclass[class_exact:D]
+          CondBranch v24, bb7(v9, v14), bb8()
+        bb7(v25:BasicObject, v26:BasicObject):
           PatchPoint NoSingletonClass(D@0x1040)
           PatchPoint MethodRedefined(D@0x1040, foo@0x1010, cme:0x1048)
-          v56:Fixnum[4] = Const Value(4)
-          Jump bb4(v25, v26, v56)
+          v54:Fixnum[4] = Const Value(4)
+          Jump bb4(v25, v54)
         bb8():
-          v33:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
-          v40:Fixnum[2] = Const Value(2)
+          v32:BasicObject = Send v14, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v32)
+        bb4(v34:BasicObject, v35:BasicObject):
+          v38:Fixnum[2] = Const Value(2)
           PatchPoint MethodRedefined(Integer@0x1070, +@0x1078, cme:0x1080)
-          v59:Fixnum = GuardType v37, Fixnum
-          v60:Fixnum = FixnumAdd v59, v40
+          v57:Fixnum = GuardType v35, Fixnum
+          v58:Fixnum = FixnumAdd v57, v38
           CheckInterrupts
-          Return v60
+          Return v58
         ");
     }
 
@@ -15049,35 +15681,37 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          CondBranch v15, bb5(v9, v10, v10), bb6()
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:CBool = HasType v14, ObjectSubclass[class_exact:C]
+          CondBranch v16, bb5(v9, v14), bb6()
+        bb5(v17:BasicObject, v18:BasicObject):
           v20:ObjectSubclass[class_exact:C] = RefineType v18, ObjectSubclass[class_exact:C]
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, itself@0x1010, cme:0x1018)
-          Jump bb4(v16, v17, v20)
+          Jump bb4(v17, v20)
         bb6():
-          v24:CBool = HasType v10, Fixnum
-          CondBranch v24, bb7(v9, v10, v10), bb8()
-        bb7(v25:BasicObject, v26:BasicObject, v27:BasicObject):
-          v29:Fixnum = RefineType v27, Fixnum
+          v24:CBool = HasType v14, Fixnum
+          CondBranch v24, bb7(v9, v14), bb8()
+        bb7(v25:BasicObject, v26:BasicObject):
+          v28:Fixnum = RefineType v26, Fixnum
           PatchPoint MethodRedefined(Integer@0x1040, itself@0x1010, cme:0x1018)
-          Jump bb4(v25, v26, v29)
+          Jump bb4(v25, v28)
         bb8():
-          v33:BasicObject = Send v10, :itself # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          v32:BasicObject = Send v14, :itself # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v32)
+        bb4(v34:BasicObject, v35:BasicObject):
           CheckInterrupts
-          Return v37
+          Return v35
         ");
     }
 
@@ -15104,36 +15738,38 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, Fixnum
-          CondBranch v15, bb5(v9, v10, v10), bb6()
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
+          v16:CBool = HasType v14, Fixnum
+          CondBranch v16, bb5(v9, v14), bb6()
+        bb5(v17:BasicObject, v18:BasicObject):
           v20:Fixnum = RefineType v18, Fixnum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v46:StringExact = CCallVariadic v20, :Integer#to_s@0x1040
-          Jump bb4(v16, v17, v46)
+          v44:StringExact = CCallVariadic v20, :Integer#to_s@0x1040
+          Jump bb4(v17, v44)
         bb6():
-          v24:CBool = HasType v10, Bignum
-          CondBranch v24, bb7(v9, v10, v10), bb8()
-        bb7(v25:BasicObject, v26:BasicObject, v27:BasicObject):
-          v29:Bignum = RefineType v27, Bignum
+          v24:CBool = HasType v14, Bignum
+          CondBranch v24, bb7(v9, v14), bb8()
+        bb7(v25:BasicObject, v26:BasicObject):
+          v28:Bignum = RefineType v26, Bignum
           PatchPoint MethodRedefined(Integer@0x1008, to_s@0x1010, cme:0x1018)
-          v49:StringExact = CCallVariadic v29, :Integer#to_s@0x1040
-          Jump bb4(v25, v26, v49)
+          v47:StringExact = CCallVariadic v28, :Integer#to_s@0x1040
+          Jump bb4(v25, v47)
         bb8():
-          v33:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          v32:BasicObject = Send v14, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v32)
+        bb4(v34:BasicObject, v35:BasicObject):
           CheckInterrupts
-          Return v37
+          Return v35
         ");
     }
 
@@ -15157,36 +15793,38 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, Flonum
-          CondBranch v15, bb5(v9, v10, v10), bb6()
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
+          v16:CBool = HasType v14, Flonum
+          CondBranch v16, bb5(v9, v14), bb6()
+        bb5(v17:BasicObject, v18:BasicObject):
           v20:Flonum = RefineType v18, Flonum
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v46:BasicObject = CCallWithFrame v20, :Float#to_s@0x1040
-          Jump bb4(v16, v17, v46)
+          v44:BasicObject = CCallWithFrame v20, :Float#to_s@0x1040
+          Jump bb4(v17, v44)
         bb6():
-          v24:CBool = HasType v10, HeapFloat
-          CondBranch v24, bb7(v9, v10, v10), bb8()
-        bb7(v25:BasicObject, v26:BasicObject, v27:BasicObject):
-          v29:HeapFloat = RefineType v27, HeapFloat
+          v24:CBool = HasType v14, HeapFloat
+          CondBranch v24, bb7(v9, v14), bb8()
+        bb7(v25:BasicObject, v26:BasicObject):
+          v28:HeapFloat = RefineType v26, HeapFloat
           PatchPoint MethodRedefined(Float@0x1008, to_s@0x1010, cme:0x1018)
-          v49:BasicObject = CCallWithFrame v29, :Float#to_s@0x1040
-          Jump bb4(v25, v26, v49)
+          v47:BasicObject = CCallWithFrame v28, :Float#to_s@0x1040
+          Jump bb4(v25, v47)
         bb8():
-          v33:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          v32:BasicObject = Send v14, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v32)
+        bb4(v34:BasicObject, v35:BasicObject):
           CheckInterrupts
-          Return v37
+          Return v35
         ");
     }
 
@@ -15210,36 +15848,38 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, StaticSymbol
-          CondBranch v15, bb5(v9, v10, v10), bb6()
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
+          v16:CBool = HasType v14, StaticSymbol
+          CondBranch v16, bb5(v9, v14), bb6()
+        bb5(v17:BasicObject, v18:BasicObject):
           v20:StaticSymbol = RefineType v18, StaticSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v48:StringExact = InvokeBuiltin leaf <inline_expr>, v20
-          Jump bb4(v16, v17, v48)
+          v46:StringExact = InvokeBuiltin leaf <inline_expr>, v20
+          Jump bb4(v17, v46)
         bb6():
-          v24:CBool = HasType v10, DynamicSymbol
-          CondBranch v24, bb7(v9, v10, v10), bb8()
-        bb7(v25:BasicObject, v26:BasicObject, v27:BasicObject):
-          v29:DynamicSymbol = RefineType v27, DynamicSymbol
+          v24:CBool = HasType v14, DynamicSymbol
+          CondBranch v24, bb7(v9, v14), bb8()
+        bb7(v25:BasicObject, v26:BasicObject):
+          v28:DynamicSymbol = RefineType v26, DynamicSymbol
           PatchPoint MethodRedefined(Symbol@0x1008, to_s@0x1010, cme:0x1018)
-          v49:StringExact = InvokeBuiltin leaf <inline_expr>, v29
-          Jump bb4(v25, v26, v49)
+          v47:StringExact = InvokeBuiltin leaf <inline_expr>, v28
+          Jump bb4(v25, v47)
         bb8():
-          v33:BasicObject = Send v10, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v33)
-        bb4(v35:BasicObject, v36:BasicObject, v37:BasicObject):
+          v32:BasicObject = Send v14, :to_s # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v32)
+        bb4(v34:BasicObject, v35:BasicObject):
           CheckInterrupts
-          Return v37
+          Return v35
         ");
     }
 
@@ -15267,28 +15907,30 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:CBool = HasType v10, ObjectSubclass[class_exact:C]
-          CondBranch v15, bb5(v9, v10, v10), bb6()
-        bb5(v16:BasicObject, v17:BasicObject, v18:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v16:CBool = HasType v14, ObjectSubclass[class_exact:C]
+          CondBranch v16, bb5(v9, v14), bb6()
+        bb5(v17:BasicObject, v18:BasicObject):
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, foo@0x1010, cme:0x1018)
-          v38:Fixnum[3] = Const Value(3)
-          Jump bb4(v16, v17, v38)
+          v37:Fixnum[3] = Const Value(3)
+          Jump bb4(v17, v37)
         bb6():
-          v24:BasicObject = Send v10, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
-          Jump bb4(v9, v10, v24)
-        bb4(v26:BasicObject, v27:BasicObject, v28:BasicObject):
+          v24:BasicObject = Send v14, :foo # SendFallbackReason: SendWithoutBlock: polymorphic fallback
+          Jump bb4(v9, v24)
+        bb4(v26:BasicObject, v27:BasicObject):
           CheckInterrupts
-          Return v28
+          Return v27
         ");
     }
 
@@ -15387,86 +16029,87 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :list@0x1000
-          v4:BasicObject = LoadField v2, :sep@0x1001
-          v5:BasicObject = LoadField v2, :iter_method@0x1002
-          v6:NilClass = Const Value(nil)
-          v7:CPtr = LoadPC
-          v8:CPtr[CPtr(0x1003)] = Const CPtr(0x1003)
-          v9:CBool = IsBitEqual v7, v8
-          CondBranch v9, bb3(v1, v3, v4, v5, v6), bb9()
+          v2:CPtr = LoadPC
+          v3:CPtr[CPtr(0x1000)] = Const CPtr(0x1000)
+          v4:CBool = IsBitEqual v2, v3
+          CondBranch v4, bb3(v1), bb9()
         bb9():
-          v11:CPtr[CPtr(0x1004)] = Const CPtr(0x1004)
-          v12:CBool = IsBitEqual v7, v11
-          CondBranch v12, bb5(v1, v3, v4, v5, v6), bb10()
+          v6:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
+          v7:CBool = IsBitEqual v2, v6
+          CondBranch v7, bb5(v1), bb10()
         bb10():
-          Jump bb7(v1, v3, v4, v5, v6)
+          Jump bb7(v1)
         bb2():
           EntryPoint JIT(0)
-          v16:BasicObject = LoadArg :self@0
-          v17:BasicObject = LoadArg :list@1
-          v18:NilClass = Const Value(nil)
+          v11:BasicObject = LoadArg :self@0
+          v12:BasicObject = LoadArg :list@1
+          v13:CPtr = GetEP 0
+          StoreField v13, :list@0x1002, v12
+          v15:NilClass = Const Value(nil)
+          StoreField v13, :sep@0x1003, v15
+          v17:NilClass = Const Value(nil)
+          StoreField v13, :iter_method@0x1004, v17
           v19:NilClass = Const Value(nil)
-          v20:NilClass = Const Value(nil)
-          Jump bb3(v16, v17, v18, v19, v20)
-        bb3(v36:BasicObject, v37:BasicObject, v38:BasicObject, v39:BasicObject, v40:NilClass):
-          v43:NilClass = Const Value(nil)
-          SetLocal :sep, l0, EP@5, v43
-          Jump bb5(v36, v37, v43, v39, v40)
+          StoreField v13, :kwsplat@0x1005, v19
+          Jump bb3(v11)
+        bb3(v46:BasicObject):
+          v49:NilClass = Const Value(nil)
+          SetLocal :sep, l0, EP@5, v49
+          Jump bb5(v46)
         bb4():
           EntryPoint JIT(1)
           v23:BasicObject = LoadArg :self@0
           v24:BasicObject = LoadArg :list@1
-          v25:BasicObject = LoadArg :sep@2
-          v26:NilClass = Const Value(nil)
-          v27:NilClass = Const Value(nil)
-          Jump bb5(v23, v24, v25, v26, v27)
-        bb5(v47:BasicObject, v48:BasicObject, v49:BasicObject, v50:BasicObject, v51:NilClass):
-          v54:StaticSymbol[:each] = Const Value(VALUE(0x1008))
-          SetLocal :iter_method, l0, EP@4, v54
-          Jump bb7(v47, v48, v49, v54, v51)
+          v25:CPtr = GetEP 0
+          StoreField v25, :list@0x1002, v24
+          v27:BasicObject = LoadArg :sep@2
+          StoreField v25, :sep@0x1003, v27
+          v29:NilClass = Const Value(nil)
+          StoreField v25, :iter_method@0x1004, v29
+          v31:NilClass = Const Value(nil)
+          StoreField v25, :kwsplat@0x1005, v31
+          Jump bb5(v23)
+        bb5(v53:BasicObject):
+          v56:StaticSymbol[:each] = Const Value(VALUE(0x1008))
+          SetLocal :iter_method, l0, EP@4, v56
+          Jump bb7(v53)
         bb6():
           EntryPoint JIT(2)
-          v30:BasicObject = LoadArg :self@0
-          v31:BasicObject = LoadArg :list@1
-          v32:BasicObject = LoadArg :sep@2
-          v33:BasicObject = LoadArg :iter_method@3
-          v34:NilClass = Const Value(nil)
-          Jump bb7(v30, v31, v32, v33, v34)
-        bb7(v58:BasicObject, v59:BasicObject, v60:BasicObject, v61:BasicObject, v62:NilClass):
+          v35:BasicObject = LoadArg :self@0
+          v36:BasicObject = LoadArg :list@1
+          v37:CPtr = GetEP 0
+          StoreField v37, :list@0x1002, v36
+          v39:BasicObject = LoadArg :sep@2
+          StoreField v37, :sep@0x1003, v39
+          v41:BasicObject = LoadArg :iter_method@3
+          StoreField v37, :iter_method@0x1004, v41
+          v43:NilClass = Const Value(nil)
+          StoreField v37, :kwsplat@0x1005, v43
+          Jump bb7(v35)
+        bb7(v60:BasicObject):
+          v64:CPtr = GetEP 0
+          v65:BasicObject = LoadField v64, :sep@0x1003
           CheckInterrupts
-          v68:CBool = Test v60
-          v69:Truthy = RefineType v60, Truthy
-          CondBranch v68, bb8(v58, v59, v69, v61, v62), bb11()
+          v68:CBool = Test v65
+          CondBranch v68, bb8(v60), bb11()
         bb11():
-          v71:Falsy = RefineType v60, Falsy
           PatchPoint MethodRedefined(Object@0x1010, lambda@0x1018, cme:0x1020)
-          v118:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v58, ObjectSubclass[class_exact*:Object@VALUE(0x1010)]
-          v119:BasicObject = CCallWithFrame v118, :Kernel#lambda@0x1048, block=0x1050
-          v75:CPtr = GetEP 0
-          v76:BasicObject = LoadField v75, :list@0x1001
-          v78:BasicObject = LoadField v75, :iter_method@0x1058
-          v79:BasicObject = LoadField v75, :kwsplat@0x1059
-          SetLocal :sep, l0, EP@5, v119
-          Jump bb8(v118, v76, v119, v78, v79)
-        bb8(v83:BasicObject, v84:BasicObject, v85:BasicObject, v86:BasicObject, v87:BasicObject):
+          v104:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v60, ObjectSubclass[class_exact*:Object@VALUE(0x1010)]
+          v105:BasicObject = CCallWithFrame v104, :Kernel#lambda@0x1048, block=0x1050
+          SetLocal :sep, l0, EP@5, v105
+          Jump bb8(v104)
+        bb8(v78:BasicObject):
           PatchPoint SingleRactorMode
-          PatchPoint StableConstantNames(0x1060, CONST)
-          v115:HashExact[VALUE(0x1068)] = Const Value(VALUE(0x1068))
-          SetLocal :kwsplat, l0, EP@3, v115
-          v96:CPtr = GetEP 0
-          v97:BasicObject = LoadField v96, :list@0x1001
-          v99:CPtr = GetEP 0
-          v100:BasicObject = LoadField v99, :iter_method@0x1058
-          v102:BasicObject = Send v97, 0x1070, :__send__, v100 # SendFallbackReason: Send: unsupported method type Optimized
-          v103:CPtr = GetEP 0
-          v104:BasicObject = LoadField v103, :list@0x1001
-          v105:BasicObject = LoadField v103, :sep@0x1002
-          v106:BasicObject = LoadField v103, :iter_method@0x1058
-          v107:BasicObject = LoadField v103, :kwsplat@0x1059
+          PatchPoint StableConstantNames(0x1058, CONST)
+          v101:HashExact[VALUE(0x1060)] = Const Value(VALUE(0x1060))
+          SetLocal :kwsplat, l0, EP@3, v101
+          v87:CPtr = GetEP 0
+          v88:BasicObject = LoadField v87, :list@0x1002
+          v90:CPtr = GetEP 0
+          v91:BasicObject = LoadField v90, :iter_method@0x1004
+          v93:BasicObject = Send v88, 0x1068, :__send__, v91 # SendFallbackReason: Send: unsupported method type Optimized
           CheckInterrupts
-          Return v102
+          Return v93
         ");
     }
 
@@ -15478,41 +16121,52 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :i@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:NilClass = Const Value(nil)
           v15:TrueClass|NilClass = Defined yield, v13
           v17:CBool = Test v15
-          CondBranch v17, bb9(), bb4(v8, v9)
+          CondBranch v17, bb9(), bb4(v9)
         bb9():
-          v35:Fixnum[0] = Const Value(0)
-          Jump bb8(v8, v35)
-        bb8(v48:BasicObject, v49:Fixnum):
-          v84:Array = RefineType v48, Array
-          v85:CInt64 = ArrayLength v84
-          v86:Fixnum = BoxFixnum v85
-          v87:BoolExact = FixnumGe v49, v86
-          v54:CBool = Test v87
-          CondBranch v54, bb10(), bb7(v48, v49)
+          v34:Fixnum[0] = Const Value(0)
+          SetLocal :i, l0, EP@3, v34
+          Jump bb8(v9)
+        bb8(v47:BasicObject):
+          v50:CPtr = GetEP 0
+          v51:BasicObject = LoadField v50, :i@0x1000
+          v86:Array = RefineType v47, Array
+          v87:Fixnum = GuardType v51, Fixnum
+          v88:CInt64 = ArrayLength v86
+          v89:Fixnum = BoxFixnum v88
+          v90:BoolExact = FixnumGe v87, v89
+          v54:CBool = Test v90
+          CondBranch v54, bb10(), bb7(v47)
         bb10():
           CheckInterrupts
-          Return v48
-        bb7(v67:BasicObject, v68:Fixnum):
-          v88:Array = RefineType v67, Array
-          v89:CInt64 = UnboxFixnum v68
-          v90:BasicObject = ArrayAref v88, v89
-          v74:BasicObject = InvokeBlock, v90 # SendFallbackReason: InvokeBlock: not yet specialized
-          v91:Fixnum[1] = Const Value(1)
-          v92:Fixnum = FixnumAdd v68, v91
-          PatchPoint NoEPEscape(each)
-          Jump bb8(v67, v92)
-        bb4(v23:BasicObject, v24:NilClass):
+          Return v47
+        bb7(v67:BasicObject):
+          v71:CPtr = GetEP 0
+          v72:BasicObject = LoadField v71, :i@0x1000
+          v91:Array = RefineType v67, Array
+          v92:Fixnum = GuardType v72, Fixnum
+          v93:CInt64 = UnboxFixnum v92
+          v94:BasicObject = ArrayAref v91, v93
+          v75:BasicObject = InvokeBlock, v94 # SendFallbackReason: InvokeBlock: not yet specialized
+          v79:CPtr = GetEP 0
+          v80:BasicObject = LoadField v79, :i@0x1000
+          v95:Fixnum = GuardType v80, Fixnum
+          v96:Fixnum[1] = Const Value(1)
+          v97:Fixnum = FixnumAdd v95, v96
+          SetLocal :i, l0, EP@3, v97
+          Jump bb8(v67)
+        bb4(v23:BasicObject):
           v28:BasicObject = InvokeBuiltin <inline_expr>, v23
           CheckInterrupts
           Return v28
@@ -15537,29 +16191,35 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:Fixnum[1] = Const Value(1)
+          SetLocal :a, l0, EP@3, v13
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :a@0x1000
           PatchPoint SingleRactorMode
-          v35:HeapBasicObject = GuardType v8, HeapBasicObject
-          v36:CShape = LoadField v35, :shape_id@0x1000
-          v37:CShape[0x1001] = GuardBitEquals v36, CShape(0x1001) recompile
-          StoreField v35, :@a@0x1002, v13
-          WriteBarrier v35, v13
-          v40:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v35, :shape_id@0x1000, v40
-          v20:HeapBasicObject = RefineType v35, HeapBasicObject
-          PatchPoint NoEPEscape(initialize)
+          v38:HeapBasicObject = GuardType v9, HeapBasicObject
+          v39:CShape = LoadField v38, :shape_id@0x1001
+          v40:CShape[0x1002] = GuardBitEquals v39, CShape(0x1002) recompile
+          StoreField v38, :@a@0x1003, v19
+          WriteBarrier v38, v19
+          v43:CShape[0x1004] = Const CShape(0x1004)
+          StoreField v38, :shape_id@0x1001, v43
+          v23:HeapBasicObject = RefineType v38, HeapBasicObject
+          v26:CPtr = GetEP 0
+          v27:BasicObject = LoadField v26, :a@0x1000
           PatchPoint SingleRactorMode
-          WriteBarrier v20, v13
+          StoreField v23, :@a@0x1003, v27
+          WriteBarrier v23, v27
           CheckInterrupts
-          Return v13
+          Return v27
         ");
     }
 
@@ -15583,34 +16243,50 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          v3:NilClass = Const Value(nil)
-          Jump bb3(v1, v2, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:NilClass = Const Value(nil)
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
           v8:NilClass = Const Value(nil)
-          Jump bb3(v6, v7, v8)
-        bb3(v10:BasicObject, v11:NilClass, v12:NilClass):
-          v16:Fixnum[1] = Const Value(1)
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:Fixnum[1] = Const Value(1)
+          SetLocal :a, l0, EP@4, v15
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :a@0x1000
           PatchPoint SingleRactorMode
-          v49:HeapBasicObject = GuardType v10, HeapBasicObject
-          v50:CShape = LoadField v49, :shape_id@0x1000
-          v51:CShape[0x1001] = GuardBitEquals v50, CShape(0x1001) recompile
-          StoreField v49, :@a@0x1002, v16
-          WriteBarrier v49, v16
-          v54:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v49, :shape_id@0x1000, v54
-          v23:HeapBasicObject = RefineType v49, HeapBasicObject
-          v26:Fixnum[5] = Const Value(5)
-          PatchPoint NoEPEscape(initialize)
+          v57:HeapBasicObject = GuardType v11, HeapBasicObject
+          v58:CShape = LoadField v57, :shape_id@0x1002
+          v59:CShape[0x1003] = GuardBitEquals v58, CShape(0x1003) recompile
+          StoreField v57, :@a@0x1004, v21
+          WriteBarrier v57, v21
+          v62:CShape[0x1005] = Const CShape(0x1005)
+          StoreField v57, :shape_id@0x1002, v62
+          v25:HeapBasicObject = RefineType v57, HeapBasicObject
+          v28:Fixnum[5] = Const Value(5)
+          SetLocal :b, l0, EP@3, v28
+          v33:CPtr = GetEP 0
+          v34:BasicObject = LoadField v33, :b@0x1001
+          v36:CPtr = GetEP 0
+          v37:BasicObject = LoadField v36, :a@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
-          v65:Fixnum[6] = Const Value(6)
+          v71:Fixnum = GuardType v34, Fixnum
+          v72:Fixnum = GuardType v37, Fixnum
+          v73:Fixnum = FixnumAdd v71, v72
+          SetLocal :b, l0, EP@3, v73
+          v45:CPtr = GetEP 0
+          v46:BasicObject = LoadField v45, :a@0x1000
           PatchPoint SingleRactorMode
-          WriteBarrier v23, v16
+          v65:CShape = LoadField v25, :shape_id@0x1002
+          v66:CShape[0x1005] = GuardBitEquals v65, CShape(0x1005) recompile
+          StoreField v25, :@a@0x1004, v46
+          WriteBarrier v25, v46
           CheckInterrupts
-          Return v16
+          Return v46
         ");
     }
 
@@ -15633,31 +16309,41 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:Fixnum[1] = Const Value(1)
+          SetLocal :a, l0, EP@3, v13
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :a@0x1000
           PatchPoint SingleRactorMode
-          v43:HeapBasicObject = GuardType v8, HeapBasicObject
-          v44:CShape = LoadField v43, :shape_id@0x1000
-          v45:CShape[0x1001] = GuardBitEquals v44, CShape(0x1001) recompile
-          StoreField v43, :@a@0x1002, v13
-          WriteBarrier v43, v13
-          v48:CShape[0x1003] = Const CShape(0x1003)
-          StoreField v43, :shape_id@0x1000, v48
-          v20:HeapBasicObject = RefineType v43, HeapBasicObject
-          PatchPoint NoEPEscape(initialize)
+          v46:HeapBasicObject = GuardType v9, HeapBasicObject
+          v47:CShape = LoadField v46, :shape_id@0x1001
+          v48:CShape[0x1002] = GuardBitEquals v47, CShape(0x1002) recompile
+          StoreField v46, :@a@0x1003, v19
+          WriteBarrier v46, v19
+          v51:CShape[0x1004] = Const CShape(0x1004)
+          StoreField v46, :shape_id@0x1001, v51
+          v23:HeapBasicObject = RefineType v46, HeapBasicObject
+          v26:CPtr = GetEP 0
+          v27:BasicObject = LoadField v26, :a@0x1000
           PatchPoint SingleRactorMode
-          WriteBarrier v20, v13
-          v28:HeapBasicObject = RefineType v20, HeapBasicObject
-          WriteBarrier v28, v13
+          StoreField v23, :@a@0x1003, v27
+          WriteBarrier v23, v27
+          v31:HeapBasicObject = RefineType v23, HeapBasicObject
+          v34:CPtr = GetEP 0
+          v35:BasicObject = LoadField v34, :a@0x1000
+          PatchPoint SingleRactorMode
+          StoreField v31, :@a@0x1003, v35
+          WriteBarrier v31, v35
           CheckInterrupts
-          Return v13
+          Return v35
         ");
     }
 
@@ -15733,33 +16419,33 @@ mod hir_opt_tests {
 
         // After profiling via the side exit, rebuilding HIR should now
         // have a SendDirect for greet_recompile instead of SideExit.
-        assert_snapshot!(hir_string("test_no_profile_recompile"), @r"
+        assert_snapshot!(hir_string("test_no_profile_recompile"), @"
         fn test_no_profile_recompile@<compiled>:4:
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :flag@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :flag@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :flag@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :flag@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :flag@0x1000
           CheckInterrupts
-          v16:CBool = Test v10
-          v17:Falsy = RefineType v10, Falsy
-          CondBranch v16, bb5(), bb4(v9, v17)
+          v17:CBool = Test v14
+          CondBranch v17, bb5(), bb4(v9)
         bb5():
-          v19:Truthy = RefineType v10, Truthy
-          v23:Fixnum[42] = Const Value(42)
+          v24:Fixnum[42] = Const Value(42)
           PatchPoint MethodRedefined(Object@0x1008, greet_recompile@0x1010, cme:0x1018)
           v43:ObjectSubclass[class_exact*:Object@VALUE(0x1008)] = GuardType v9, ObjectSubclass[class_exact*:Object@VALUE(0x1008)]
-          v44:BasicObject = SendDirect v43, 0x1040, :greet_recompile (0x1050), v23
+          v44:BasicObject = SendDirect v43, 0x1040, :greet_recompile (0x1050), v24
           CheckInterrupts
           Return v44
-        bb4(v30:BasicObject, v31:Falsy):
+        bb4(v31:BasicObject):
           v35:StringExact[VALUE(0x1058)] = Const Value(VALUE(0x1058))
           v36:StringExact = StringCopy v35
           CheckInterrupts
@@ -15792,31 +16478,31 @@ mod hir_opt_tests {
         eval("3.times { test_final_version(false) }");
 
         // On the final version, greet_final should be a Send fallback, not a SideExit.
-        assert_snapshot!(hir_string("test_final_version"), @r"
+        assert_snapshot!(hir_string("test_final_version"), @"
         fn test_final_version@<compiled>:4:
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :flag@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :flag@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :flag@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :flag@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :flag@0x1000
           CheckInterrupts
-          v16:CBool = Test v10
-          v17:Falsy = RefineType v10, Falsy
-          CondBranch v16, bb5(), bb4(v9, v17)
+          v17:CBool = Test v14
+          CondBranch v17, bb5(), bb4(v9)
         bb5():
-          v19:Truthy = RefineType v10, Truthy
-          v23:Fixnum[42] = Const Value(42)
-          v25:BasicObject = Send v9, :greet_final, v23 # SendFallbackReason: SendWithoutBlock: no profile data available
+          v24:Fixnum[42] = Const Value(42)
+          v26:BasicObject = Send v9, :greet_final, v24 # SendFallbackReason: SendWithoutBlock: no profile data available
           CheckInterrupts
-          Return v25
-        bb4(v30:BasicObject, v31:Falsy):
+          Return v26
+        bb4(v31:BasicObject):
           v35:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
           v36:StringExact = StringCopy v35
           CheckInterrupts
@@ -15898,30 +16584,35 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :n@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :n@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[1] = Const Value(1)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :n@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :n@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :n@0x1000
+          v16:Fixnum[1] = Const Value(1)
           PatchPoint MethodRedefined(Integer@0x1008, -@0x1010, cme:0x1018)
-          v35:Fixnum = GuardType v10, Fixnum
-          v36:Fixnum = FixnumSub v35, v15
-          v21:Fixnum[2] = Const Value(2)
-          v40:Fixnum = FixnumSub v35, v21
+          v38:Fixnum = GuardType v14, Fixnum
+          v39:Fixnum = FixnumSub v38, v16
+          v21:CPtr = GetEP 0
+          v22:BasicObject = LoadField v21, :n@0x1000
+          v24:Fixnum[2] = Const Value(2)
+          v42:Fixnum = GuardType v22, Fixnum
+          v43:Fixnum = FixnumSub v42, v24
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1040, cme:0x1048)
-          v44:Fixnum = FixnumAdd v36, v40
+          v47:Fixnum = FixnumAdd v39, v43
           CheckInterrupts
-          Return v44
+          Return v47
         ");
     }
 
     #[test]
-    fn test_dedup_guard_type_across_cfg_join() {
+    fn test_guard_type_with_ep_locals_across_cfg_join() {
         eval("
             def test(n, cond)
               if cond
@@ -15936,8 +16627,8 @@ mod hir_opt_tests {
         let hir = hir_string("test");
         let guard_count = hir.matches("GuardType").count();
         assert_eq!(
-            guard_count, 2,
-            "expected 2 GuardType instructions after cross-block dedup, found {guard_count}\n\nHIR:\n{hir}"
+            guard_count, 4,
+            "expected 4 GuardType instructions with EP-local reloads across the CFG join, found {guard_count}\n\nHIR:\n{hir}"
         );
     }
 
@@ -15978,8 +16669,8 @@ mod hir_opt_tests {
         let hir = hir_string("test");
         let guard_count = hir.matches("GuardType").count();
         assert_eq!(
-            guard_count, 1,
-            "expected 1 GuardType (merge block only), found {guard_count}\n\nHIR:\n{hir}"
+            guard_count, 2,
+            "expected 2 GuardType instructions for merge-block EP-local reloads, found {guard_count}\n\nHIR:\n{hir}"
         );
     }
 
@@ -16006,77 +16697,86 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :i@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:Fixnum[0] = Const Value(0)
+          SetLocal :i, l0, EP@3, v13
           CheckInterrupts
-          Jump bb6(v8, v13)
-        bb6(v19:BasicObject, v20:Fixnum):
-          v24:Fixnum[10] = Const Value(10)
-          PatchPoint MethodRedefined(Integer@0x1000, <@0x1008, cme:0x1010)
-          v110:BoolExact = FixnumLt v20, v24
+          Jump bb6(v9)
+        bb6(v20:BasicObject):
+          v23:CPtr = GetEP 0
+          v24:BasicObject = LoadField v23, :i@0x1000
+          v26:Fixnum[10] = Const Value(10)
+          PatchPoint MethodRedefined(Integer@0x1008, <@0x1010, cme:0x1018)
+          v110:Fixnum = GuardType v24, Fixnum
+          v111:BoolExact = FixnumLt v110, v26
           CheckInterrupts
-          v30:CBool = Test v110
-          CondBranch v30, bb4(v19, v20), bb7()
-        bb4(v40:BasicObject, v41:Fixnum):
+          v32:CBool = Test v111
+          CondBranch v32, bb4(v20), bb7()
+        bb4(v42:BasicObject):
           PatchPoint SingleRactorMode
-          v46:HeapBasicObject = GuardType v40, HeapBasicObject
-          v47:CUInt64 = LoadField v46, :RBASIC_FLAGS@0x1038
-          v49:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v50:CPtr[CPtr(0x1039)] = Const CPtr(0x1039)
-          v51 = RefineType v50, CUInt64
-          v52:CInt64 = IntAnd v47, v49
-          v53:CBool = IsBitEqual v52, v51
-          CondBranch v53, bb9(), bb10()
+          v47:HeapBasicObject = GuardType v42, HeapBasicObject
+          v48:CUInt64 = LoadField v47, :RBASIC_FLAGS@0x1040
+          v50:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v51:CPtr[CPtr(0x1041)] = Const CPtr(0x1041)
+          v52 = RefineType v51, CUInt64
+          v53:CInt64 = IntAnd v48, v50
+          v54:CBool = IsBitEqual v53, v52
+          CondBranch v54, bb9(), bb10()
         bb9():
-          v55:BasicObject = LoadField v46, :@levar@0x103a
-          Jump bb8(v55)
+          v56:BasicObject = LoadField v47, :@levar@0x1042
+          Jump bb8(v56)
         bb10():
-          v57:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
-          v58:CPtr[CPtr(0x103b)] = Const CPtr(0x103b)
-          v59 = RefineType v58, CUInt64
-          v60:CInt64 = IntAnd v47, v57
-          v61:CBool = IsBitEqual v60, v59
-          CondBranch v61, bb11(), bb12()
+          v58:CUInt64[0xffffffff0000001f] = Const CUInt64(0xffffffff0000001f)
+          v59:CPtr[CPtr(0x1043)] = Const CPtr(0x1043)
+          v60 = RefineType v59, CUInt64
+          v61:CInt64 = IntAnd v48, v58
+          v62:CBool = IsBitEqual v61, v60
+          CondBranch v62, bb11(), bb12()
         bb11():
-          v63:NilClass = Const Value(nil)
-          Jump bb8(v63)
+          v64:NilClass = Const Value(nil)
+          Jump bb8(v64)
         bb12():
-          v97:CShape = LoadField v46, :shape_id@0x103c
-          v98:CShape[0x103d] = GuardBitEquals v97, CShape(0x103d) recompile
-          v99:BasicObject = LoadField v46, :@levar@0x103a
-          Jump bb8(v99)
-        bb8(v48:BasicObject):
+          v98:CShape = LoadField v47, :shape_id@0x1044
+          v99:CShape[0x1045] = GuardBitEquals v98, CShape(0x1045) recompile
+          v100:BasicObject = LoadField v47, :@levar@0x1042
+          Jump bb8(v100)
+        bb8(v49:BasicObject):
           CheckInterrupts
-          v69:CBool = Test v48
-          CondBranch v69, bb5(v46, v41), bb13()
+          v70:CBool = Test v49
+          CondBranch v70, bb5(v47), bb13()
         bb13():
-          PatchPoint NoEPEscape(set_value_loop)
+          v75:CPtr = GetEP 0
+          v76:BasicObject = LoadField v75, :i@0x1000
           PatchPoint SingleRactorMode
-          v101:CShape = LoadField v46, :shape_id@0x103c
-          v102:CShape[0x103e] = GuardBitEquals v101, CShape(0x103e) recompile
-          StoreField v46, :@levar@0x103a, v41
-          WriteBarrier v46, v41
-          v105:CShape[0x103d] = Const CShape(0x103d)
-          StoreField v46, :shape_id@0x103c, v105
-          v79:HeapBasicObject = RefineType v46, HeapBasicObject
-          Jump bb5(v79, v41)
-        bb5(v81:HeapBasicObject, v82:Fixnum):
-          PatchPoint NoEPEscape(set_value_loop)
+          v102:CShape = LoadField v47, :shape_id@0x1044
+          v103:CShape[0x1046] = GuardBitEquals v102, CShape(0x1046) recompile
+          StoreField v47, :@levar@0x1042, v76
+          WriteBarrier v47, v76
+          v106:CShape[0x1045] = Const CShape(0x1045)
+          StoreField v47, :shape_id@0x1044, v106
+          v80:HeapBasicObject = RefineType v47, HeapBasicObject
+          Jump bb5(v80)
+        bb5(v82:HeapBasicObject):
+          v86:CPtr = GetEP 0
+          v87:BasicObject = LoadField v86, :i@0x1000
           v89:Fixnum[1] = Const Value(1)
-          PatchPoint MethodRedefined(Integer@0x1000, +@0x103f, cme:0x1040)
-          v114:Fixnum = FixnumAdd v82, v89
-          Jump bb6(v81, v114)
+          PatchPoint MethodRedefined(Integer@0x1008, +@0x1047, cme:0x1048)
+          v114:Fixnum = GuardType v87, Fixnum
+          v115:Fixnum = FixnumAdd v114, v89
+          SetLocal :i, l0, EP@3, v115
+          Jump bb6(v82)
         bb7():
-          v35:NilClass = Const Value(nil)
+          v37:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v35
+          Return v37
         ");
     }
 
@@ -16091,20 +16791,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Float@0x1008, nan?@0x1010, cme:0x1018)
-          v23:Flonum = GuardType v10, Flonum
-          v24:BoolExact = CCall v23, :Float#nan?@0x1040
+          v24:Flonum = GuardType v14, Flonum
+          v25:BoolExact = CCall v24, :Float#nan?@0x1040
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -16119,20 +16821,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Float@0x1008, finite?@0x1010, cme:0x1018)
-          v23:Flonum = GuardType v10, Flonum
-          v24:BoolExact = CCall v23, :Float#finite?@0x1040
+          v24:Flonum = GuardType v14, Flonum
+          v25:BoolExact = CCall v24, :Float#finite?@0x1040
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -16147,20 +16851,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Float@0x1008, infinite?@0x1010, cme:0x1018)
-          v23:Flonum = GuardType v10, Flonum
-          v24:NilClass|Fixnum = CCall v23, :Float#infinite?@0x1040
+          v24:Flonum = GuardType v14, Flonum
+          v25:NilClass|Fixnum = CCall v24, :Float#infinite?@0x1040
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -16175,20 +16881,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, even?@0x1010, cme:0x1018)
-          v22:Fixnum = GuardType v10, Fixnum
-          v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
+          v23:Fixnum = GuardType v14, Fixnum
+          v25:BoolExact = InvokeBuiltin leaf <inline_expr>, v23
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -16203,20 +16911,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Integer@0x1008, odd?@0x1010, cme:0x1018)
-          v22:Fixnum = GuardType v10, Fixnum
-          v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
+          v23:Fixnum = GuardType v14, Fixnum
+          v25:BoolExact = InvokeBuiltin leaf <inline_expr>, v23
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -16231,20 +16941,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Float@0x1008, zero?@0x1010, cme:0x1018)
-          v22:Flonum = GuardType v10, Flonum
-          v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
+          v23:Flonum = GuardType v14, Flonum
+          v25:BoolExact = InvokeBuiltin leaf <inline_expr>, v23
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -16259,20 +16971,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Float@0x1008, positive?@0x1010, cme:0x1018)
-          v22:Flonum = GuardType v10, Flonum
-          v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
+          v23:Flonum = GuardType v14, Flonum
+          v25:BoolExact = InvokeBuiltin leaf <inline_expr>, v23
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -16287,20 +17001,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint MethodRedefined(Float@0x1008, negative?@0x1010, cme:0x1018)
-          v22:Flonum = GuardType v10, Flonum
-          v24:BoolExact = InvokeBuiltin leaf <inline_expr>, v22
+          v23:Flonum = GuardType v14, Flonum
+          v25:BoolExact = InvokeBuiltin leaf <inline_expr>, v23
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
     #[test]
@@ -16314,23 +17030,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Float@0x1008, +@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum
-          v29:Flonum = GuardType v13, Flonum
-          v30:Float = FloatAdd v28, v29
+          v30:Flonum = GuardType v16, Flonum
+          v31:Flonum = GuardType v19, Flonum
+          v32:Float = FloatAdd v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -16345,23 +17065,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum
-          v29:Flonum = GuardType v13, Flonum
-          v30:Float = FloatMul v28, v29
+          v30:Flonum = GuardType v16, Flonum
+          v31:Flonum = GuardType v19, Flonum
+          v32:Float = FloatMul v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -16376,23 +17100,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Float@0x1008, -@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum
-          v29:Flonum = GuardType v13, Flonum
-          v30:Float = FloatSub v28, v29
+          v30:Flonum = GuardType v16, Flonum
+          v31:Flonum = GuardType v19, Flonum
+          v32:Float = FloatSub v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -16407,23 +17135,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Float@0x1008, /@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum
-          v29:Flonum = GuardType v13, Flonum
-          v30:Float = FloatDiv v28, v29
+          v30:Flonum = GuardType v16, Flonum
+          v31:Flonum = GuardType v19, Flonum
+          v32:Float = FloatDiv v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -16438,20 +17170,22 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
           PatchPoint MethodRedefined(Float@0x1008, to_i@0x1010, cme:0x1018)
-          v23:Flonum = GuardType v10, Flonum
-          v24:Integer = FloatToInt v23
+          v24:Flonum = GuardType v14, Flonum
+          v25:Integer = FloatToInt v24
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -16466,23 +17200,27 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint MethodRedefined(Float@0x1008, *@0x1010, cme:0x1018)
-          v28:Flonum = GuardType v12, Flonum
-          v29:Fixnum = GuardType v13, Fixnum
-          v30:Float = FloatMul v28, v29
+          v30:Flonum = GuardType v16, Flonum
+          v31:Fixnum = GuardType v19, Fixnum
+          v32:Float = FloatMul v30, v31
           CheckInterrupts
-          Return v30
+          Return v32
         ");
     }
 
@@ -16511,37 +17249,153 @@ mod hir_opt_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :obj@0x1000
-          v4:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :obj@1
-          v9:NilClass = Const Value(nil)
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
-          v17:Fixnum[0] = Const Value(0)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :obj@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :obj@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :sum@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:Fixnum[0] = Const Value(0)
+          SetLocal :sum, l0, EP@3, v15
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :sum@0x1001
+          v23:CPtr = GetEP 0
+          v24:BasicObject = LoadField v23, :obj@0x1000
           PatchPoint NoSingletonClass(C@0x1008)
           PatchPoint MethodRedefined(C@0x1008, var@0x1010, cme:0x1018)
-          v138:ObjectSubclass[class_exact:C] = GuardType v12, ObjectSubclass[class_exact:C]
-          v139:BasicObject = LoadField v138, :var@0x1040
+          v169:ObjectSubclass[class_exact:C] = GuardType v24, ObjectSubclass[class_exact:C]
+          v170:BasicObject = LoadField v169, :var@0x1040
           PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
-          v179:Fixnum = GuardType v139, Fixnum
-          v180:Fixnum = FixnumAdd v17, v179
-          PatchPoint NoEPEscape(test)
-          v185:Fixnum = FixnumAdd v180, v179
-          v190:Fixnum = FixnumAdd v185, v179
-          v195:Fixnum = FixnumAdd v190, v179
-          v200:Fixnum = FixnumAdd v195, v179
-          v205:Fixnum = FixnumAdd v200, v179
-          v210:Fixnum = FixnumAdd v205, v179
-          v215:Fixnum = FixnumAdd v210, v179
-          v220:Fixnum = FixnumAdd v215, v179
-          v225:Fixnum = FixnumAdd v220, v179
+          v209:Fixnum = GuardType v21, Fixnum
+          v210:Fixnum = GuardType v170, Fixnum
+          v211:Fixnum = FixnumAdd v209, v210
+          SetLocal :sum, l0, EP@3, v211
+          v34:CPtr = GetEP 0
+          v35:BasicObject = LoadField v34, :sum@0x1001
+          v37:CPtr = GetEP 0
+          v38:BasicObject = LoadField v37, :obj@0x1000
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, var@0x1010, cme:0x1018)
+          v173:ObjectSubclass[class_exact:C] = GuardType v38, ObjectSubclass[class_exact:C]
+          v174:BasicObject = LoadField v173, :var@0x1040
+          PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
+          v214:Fixnum = GuardType v35, Fixnum
+          v215:Fixnum = GuardType v174, Fixnum
+          v216:Fixnum = FixnumAdd v214, v215
+          SetLocal :sum, l0, EP@3, v216
+          v48:CPtr = GetEP 0
+          v49:BasicObject = LoadField v48, :sum@0x1001
+          v51:CPtr = GetEP 0
+          v52:BasicObject = LoadField v51, :obj@0x1000
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, var@0x1010, cme:0x1018)
+          v177:ObjectSubclass[class_exact:C] = GuardType v52, ObjectSubclass[class_exact:C]
+          v178:BasicObject = LoadField v177, :var@0x1040
+          PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
+          v219:Fixnum = GuardType v49, Fixnum
+          v220:Fixnum = GuardType v178, Fixnum
+          v221:Fixnum = FixnumAdd v219, v220
+          SetLocal :sum, l0, EP@3, v221
+          v62:CPtr = GetEP 0
+          v63:BasicObject = LoadField v62, :sum@0x1001
+          v65:CPtr = GetEP 0
+          v66:BasicObject = LoadField v65, :obj@0x1000
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, var@0x1010, cme:0x1018)
+          v181:ObjectSubclass[class_exact:C] = GuardType v66, ObjectSubclass[class_exact:C]
+          v182:BasicObject = LoadField v181, :var@0x1040
+          PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
+          v224:Fixnum = GuardType v63, Fixnum
+          v225:Fixnum = GuardType v182, Fixnum
+          v226:Fixnum = FixnumAdd v224, v225
+          SetLocal :sum, l0, EP@3, v226
+          v76:CPtr = GetEP 0
+          v77:BasicObject = LoadField v76, :sum@0x1001
+          v79:CPtr = GetEP 0
+          v80:BasicObject = LoadField v79, :obj@0x1000
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, var@0x1010, cme:0x1018)
+          v185:ObjectSubclass[class_exact:C] = GuardType v80, ObjectSubclass[class_exact:C]
+          v186:BasicObject = LoadField v185, :var@0x1040
+          PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
+          v229:Fixnum = GuardType v77, Fixnum
+          v230:Fixnum = GuardType v186, Fixnum
+          v231:Fixnum = FixnumAdd v229, v230
+          SetLocal :sum, l0, EP@3, v231
+          v90:CPtr = GetEP 0
+          v91:BasicObject = LoadField v90, :sum@0x1001
+          v93:CPtr = GetEP 0
+          v94:BasicObject = LoadField v93, :obj@0x1000
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, var@0x1010, cme:0x1018)
+          v189:ObjectSubclass[class_exact:C] = GuardType v94, ObjectSubclass[class_exact:C]
+          v190:BasicObject = LoadField v189, :var@0x1040
+          PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
+          v234:Fixnum = GuardType v91, Fixnum
+          v235:Fixnum = GuardType v190, Fixnum
+          v236:Fixnum = FixnumAdd v234, v235
+          SetLocal :sum, l0, EP@3, v236
+          v104:CPtr = GetEP 0
+          v105:BasicObject = LoadField v104, :sum@0x1001
+          v107:CPtr = GetEP 0
+          v108:BasicObject = LoadField v107, :obj@0x1000
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, var@0x1010, cme:0x1018)
+          v193:ObjectSubclass[class_exact:C] = GuardType v108, ObjectSubclass[class_exact:C]
+          v194:BasicObject = LoadField v193, :var@0x1040
+          PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
+          v239:Fixnum = GuardType v105, Fixnum
+          v240:Fixnum = GuardType v194, Fixnum
+          v241:Fixnum = FixnumAdd v239, v240
+          SetLocal :sum, l0, EP@3, v241
+          v118:CPtr = GetEP 0
+          v119:BasicObject = LoadField v118, :sum@0x1001
+          v121:CPtr = GetEP 0
+          v122:BasicObject = LoadField v121, :obj@0x1000
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, var@0x1010, cme:0x1018)
+          v197:ObjectSubclass[class_exact:C] = GuardType v122, ObjectSubclass[class_exact:C]
+          v198:BasicObject = LoadField v197, :var@0x1040
+          PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
+          v244:Fixnum = GuardType v119, Fixnum
+          v245:Fixnum = GuardType v198, Fixnum
+          v246:Fixnum = FixnumAdd v244, v245
+          SetLocal :sum, l0, EP@3, v246
+          v132:CPtr = GetEP 0
+          v133:BasicObject = LoadField v132, :sum@0x1001
+          v135:CPtr = GetEP 0
+          v136:BasicObject = LoadField v135, :obj@0x1000
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, var@0x1010, cme:0x1018)
+          v201:ObjectSubclass[class_exact:C] = GuardType v136, ObjectSubclass[class_exact:C]
+          v202:BasicObject = LoadField v201, :var@0x1040
+          PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
+          v249:Fixnum = GuardType v133, Fixnum
+          v250:Fixnum = GuardType v202, Fixnum
+          v251:Fixnum = FixnumAdd v249, v250
+          SetLocal :sum, l0, EP@3, v251
+          v146:CPtr = GetEP 0
+          v147:BasicObject = LoadField v146, :sum@0x1001
+          v149:CPtr = GetEP 0
+          v150:BasicObject = LoadField v149, :obj@0x1000
+          PatchPoint NoSingletonClass(C@0x1008)
+          PatchPoint MethodRedefined(C@0x1008, var@0x1010, cme:0x1018)
+          v205:ObjectSubclass[class_exact:C] = GuardType v150, ObjectSubclass[class_exact:C]
+          v206:BasicObject = LoadField v205, :var@0x1040
+          PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
+          v254:Fixnum = GuardType v147, Fixnum
+          v255:Fixnum = GuardType v206, Fixnum
+          v256:Fixnum = FixnumAdd v254, v255
+          SetLocal :sum, l0, EP@3, v256
+          v160:CPtr = GetEP 0
+          v161:BasicObject = LoadField v160, :sum@0x1001
           CheckInterrupts
-          Return v225
+          Return v161
         ");
     }
 

--- a/zjit/src/hir/tests.rs
+++ b/zjit/src/hir/tests.rs
@@ -44,14 +44,14 @@ mod snapshot_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v8:Any = Snapshot FrameState { pc: 0x1000, stack: [], locals: [] }
+          v8:Any = Snapshot FrameState { pc: 0x1000, stack: [] }
           PatchPoint NoTracePoint
           v10:Fixnum[1] = Const Value(1)
           v12:Fixnum[2] = Const Value(2)
-          v13:Any = Snapshot FrameState { pc: 0x1008, stack: [v10, v12], locals: [] }
+          v13:Any = Snapshot FrameState { pc: 0x1008, stack: [v10, v12] }
           PatchPoint MethodRedefined(Integer@0x1010, +@0x1018, cme:0x1020)
           v35:Fixnum[6] = Const Value(6)
-          v21:Any = Snapshot FrameState { pc: 0x1048, stack: [v35], locals: [] }
+          v21:Any = Snapshot FrameState { pc: 0x1048, stack: [v35] }
           CheckInterrupts
           Return v35
         ");
@@ -67,27 +67,31 @@ mod snapshot_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v14:Any = Snapshot FrameState { pc: 0x1008, stack: [], locals: [a=v12, b=v13] }
-          v15:Any = Snapshot FrameState { pc: 0x1010, stack: [], locals: [a=v12, b=v13] }
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v12:Any = Snapshot FrameState { pc: 0x1008, stack: [] }
+          v13:Any = Snapshot FrameState { pc: 0x1010, stack: [] }
           PatchPoint NoTracePoint
-          v17:Any = Snapshot FrameState { pc: 0x1018, stack: [v12], locals: [a=v12, b=v13] }
-          v18:Any = Snapshot FrameState { pc: 0x1020, stack: [v12, v13], locals: [a=v12, b=v13] }
-          v19:ArrayExact = NewArray v12, v13
-          v20:Any = Snapshot FrameState { pc: 0x1028, stack: [v19], locals: [a=v12, b=v13] }
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v17:Any = Snapshot FrameState { pc: 0x1018, stack: [v16] }
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v20:Any = Snapshot FrameState { pc: 0x1020, stack: [v16, v19] }
+          v21:ArrayExact = NewArray v16, v19
+          v22:Any = Snapshot FrameState { pc: 0x1028, stack: [v21] }
           PatchPoint NoTracePoint
           CheckInterrupts
-          Return v19
+          Return v21
         ");
     }
 
@@ -112,17 +116,17 @@ mod snapshot_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v8:Any = Snapshot FrameState { pc: 0x1000, stack: [], locals: [] }
+          v8:Any = Snapshot FrameState { pc: 0x1000, stack: [] }
           PatchPoint NoTracePoint
           v11:Fixnum[3] = Const Value(3)
           v13:Fixnum[1] = Const Value(1)
           v15:Fixnum[2] = Const Value(2)
-          v16:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v11, v13, v15], locals: [] }
-          v23:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v13, v15, v11], locals: [] }
+          v16:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v11, v13, v15] }
+          v23:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v13, v15, v11] }
           PatchPoint MethodRedefined(Object@0x1010, foo@0x1018, cme:0x1020)
           v25:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)]
           v26:BasicObject = SendDirect v25, 0x1048, :foo (0x1058), v13, v15, v11
-          v18:Any = Snapshot FrameState { pc: 0x1060, stack: [v26], locals: [] }
+          v18:Any = Snapshot FrameState { pc: 0x1060, stack: [v26] }
           PatchPoint NoTracePoint
           CheckInterrupts
           Return v26
@@ -150,15 +154,15 @@ mod snapshot_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v8:Any = Snapshot FrameState { pc: 0x1000, stack: [], locals: [] }
+          v8:Any = Snapshot FrameState { pc: 0x1000, stack: [] }
           PatchPoint NoTracePoint
           v11:Fixnum[1] = Const Value(1)
           v13:Fixnum[2] = Const Value(2)
-          v14:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v11, v13], locals: [] }
+          v14:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v11, v13] }
           PatchPoint MethodRedefined(Object@0x1010, foo@0x1018, cme:0x1020)
           v22:ObjectSubclass[class_exact*:Object@VALUE(0x1010)] = GuardType v6, ObjectSubclass[class_exact*:Object@VALUE(0x1010)]
           v23:BasicObject = SendDirect v22, 0x1048, :foo (0x1058), v11, v13
-          v16:Any = Snapshot FrameState { pc: 0x1060, stack: [v23], locals: [] }
+          v16:Any = Snapshot FrameState { pc: 0x1060, stack: [v23] }
           PatchPoint NoTracePoint
           CheckInterrupts
           Return v23
@@ -186,7 +190,7 @@ mod snapshot_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v8:Any = Snapshot FrameState { pc: 0x1000, stack: [], locals: [] }
+          v8:Any = Snapshot FrameState { pc: 0x1000, stack: [] }
           PatchPoint NoTracePoint
           v11:Fixnum[5] = Const Value(5)
           v13:Fixnum[6] = Const Value(6)
@@ -196,9 +200,9 @@ mod snapshot_tests {
           v21:Fixnum[2] = Const Value(2)
           v23:Fixnum[7] = Const Value(7)
           v25:Fixnum[8] = Const Value(8)
-          v26:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v11, v13, v15, v17, v19, v21, v23, v25], locals: [] }
+          v26:Any = Snapshot FrameState { pc: 0x1008, stack: [v6, v11, v13, v15, v17, v19, v21, v23, v25] }
           v27:BasicObject = Send v6, :foo, v11, v13, v15, v17, v19, v21, v23, v25 # SendFallbackReason: Too many arguments for LIR
-          v28:Any = Snapshot FrameState { pc: 0x1010, stack: [v27], locals: [] }
+          v28:Any = Snapshot FrameState { pc: 0x1010, stack: [v27] }
           PatchPoint NoTracePoint
           CheckInterrupts
           Return v27
@@ -291,31 +295,34 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:CPtr = LoadPC
-          v5:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v6:CBool = IsBitEqual v4, v5
-          CondBranch v6, bb3(v1, v3), bb6()
+          v2:CPtr = LoadPC
+          v3:CPtr[CPtr(0x1000)] = Const CPtr(0x1000)
+          v4:CBool = IsBitEqual v2, v3
+          CondBranch v4, bb3(v1), bb6()
         bb6():
-          Jump bb5(v1, v3)
+          Jump bb5(v1)
         bb2():
           EntryPoint JIT(0)
-          v10:BasicObject = LoadArg :self@0
-          v11:NilClass = Const Value(nil)
-          Jump bb3(v10, v11)
-        bb3(v17:BasicObject, v18:BasicObject):
-          v21:Fixnum[1] = Const Value(1)
-          Jump bb5(v17, v21)
+          v8:BasicObject = LoadArg :self@0
+          v9:NilClass = Const Value(nil)
+          v10:CPtr = GetEP 0
+          StoreField v10, :x@0x1001, v9
+          Jump bb3(v8)
+        bb3(v19:BasicObject):
+          v22:Fixnum[1] = Const Value(1)
+          SetLocal :x, l0, EP@3, v22
+          Jump bb5(v19)
         bb4():
           EntryPoint JIT(1)
           v14:BasicObject = LoadArg :self@0
           v15:BasicObject = LoadArg :x@1
-          Jump bb5(v14, v15)
-        bb5(v24:BasicObject, v25:BasicObject):
-          v29:Fixnum[123] = Const Value(123)
+          v16:CPtr = GetEP 0
+          StoreField v16, :x@0x1001, v15
+          Jump bb5(v14)
+        bb5(v26:BasicObject):
+          v30:Fixnum[123] = Const Value(123)
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -359,31 +366,33 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:NilClass = Const Value(nil)
-          v18:BasicObject = GetConstantPath 0x1008
-          v20:BasicObject = CheckMatch v10, v18, CASE
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:NilClass = Const Value(nil)
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :o@0x1000
+          v19:BasicObject = GetConstantPath 0x1008
+          v21:BasicObject = CheckMatch v16, v19, CASE
           CheckInterrupts
-          v23:CBool = Test v20
-          v24:Truthy = RefineType v20, Truthy
-          CondBranch v23, bb4(v9, v10, v14, v10), bb5()
-        bb4(v36:BasicObject, v37:BasicObject, v38:NilClass, v39:BasicObject):
+          v24:CBool = Test v21
+          v25:Truthy = RefineType v21, Truthy
+          CondBranch v24, bb4(v9, v13, v16), bb5()
+        bb4(v37:BasicObject, v38:NilClass, v39:BasicObject):
           v44:Fixnum[1] = Const Value(1)
           CheckInterrupts
           Return v44
         bb5():
-          v26:Falsy = RefineType v20, Falsy
-          v31:Fixnum[2] = Const Value(2)
+          v27:Falsy = RefineType v21, Falsy
+          v32:Fixnum[2] = Const Value(2)
           CheckInterrupts
-          Return v31
+          Return v32
         ");
     }
 
@@ -406,31 +415,33 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :o@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v17:ArrayExact = ArrayDup v16
-          v19:BasicObject = CheckMatch v10, v17, CASE|ARRAY
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :o@0x1000
+          v17:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v18:ArrayExact = ArrayDup v17
+          v20:BasicObject = CheckMatch v14, v18, CASE|ARRAY
           CheckInterrupts
-          v22:CBool = Test v19
-          v23:Truthy = RefineType v19, Truthy
-          CondBranch v22, bb4(v9, v10, v10), bb5()
-        bb4(v34:BasicObject, v35:BasicObject, v36:BasicObject):
+          v23:CBool = Test v20
+          v24:Truthy = RefineType v20, Truthy
+          CondBranch v23, bb4(v9, v14), bb5()
+        bb4(v35:BasicObject, v36:BasicObject):
           v41:Fixnum[1] = Const Value(1)
           CheckInterrupts
           Return v41
         bb5():
-          v25:Falsy = RefineType v19, Falsy
-          v29:Fixnum[2] = Const Value(2)
+          v26:Falsy = RefineType v20, Falsy
+          v30:Fixnum[2] = Const Value(2)
           CheckInterrupts
-          Return v29
+          Return v30
         ");
     }
 
@@ -509,18 +520,20 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:ArrayExact = NewArray v10
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
+          v16:ArrayExact = NewArray v14
           CheckInterrupts
-          Return v15
+          Return v16
         ");
     }
 
@@ -533,20 +546,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v19:ArrayExact = NewArray v12, v13
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v21:ArrayExact = NewArray v16, v19
           CheckInterrupts
-          Return v19
+          Return v21
         ");
     }
 
@@ -559,19 +576,21 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[10] = Const Value(10)
-          v17:RangeExact = NewRange v10 NewRangeInclusive v15
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
+          v16:Fixnum[10] = Const Value(10)
+          v18:RangeExact = NewRange v14 NewRangeInclusive v16
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -584,20 +603,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v19:RangeExact = NewRange v12 NewRangeInclusive v13
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v21:RangeExact = NewRange v16 NewRangeInclusive v19
           CheckInterrupts
-          Return v19
+          Return v21
         ");
     }
 
@@ -610,19 +633,21 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[10] = Const Value(10)
-          v17:RangeExact = NewRange v10 NewRangeExclusive v15
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
+          v16:Fixnum[10] = Const Value(10)
+          v18:RangeExact = NewRange v14 NewRangeExclusive v16
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -635,20 +660,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v19:RangeExact = NewRange v12 NewRangeExclusive v13
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v21:RangeExact = NewRange v16 NewRangeExclusive v19
           CheckInterrupts
-          Return v19
+          Return v21
         ");
     }
 
@@ -726,22 +755,26 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :aval@0x1000
-          v4:BasicObject = LoadField v2, :bval@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :aval@1
-          v9:BasicObject = LoadArg :bval@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v17:StaticSymbol[:a] = Const Value(VALUE(0x1008))
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :aval@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :aval@0x1000, v5
+          v8:BasicObject = LoadArg :bval@2
+          StoreField v6, :bval@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:StaticSymbol[:a] = Const Value(VALUE(0x1008))
+          v17:CPtr = GetEP 0
+          v18:BasicObject = LoadField v17, :aval@0x1000
           v20:StaticSymbol[:b] = Const Value(VALUE(0x1010))
-          v23:HashExact = NewHash v17: v12, v20: v13
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :bval@0x1001
+          v25:HashExact = NewHash v15: v18, v20: v23
           CheckInterrupts
-          Return v23
+          Return v25
         ");
     }
 
@@ -1080,17 +1113,21 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:Fixnum[1] = Const Value(1)
+          SetLocal :a, l0, EP@3, v13
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :a@0x1000
           CheckInterrupts
-          Return v13
+          Return v19
         ");
     }
 
@@ -1159,34 +1196,43 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:NilClass = Const Value(nil)
-          v5:CPtr = LoadPC
-          v6:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v7:CBool = IsBitEqual v5, v6
-          CondBranch v7, bb3(v1, v3, v4), bb6()
+          v2:CPtr = LoadPC
+          v3:CPtr[CPtr(0x1000)] = Const CPtr(0x1000)
+          v4:CBool = IsBitEqual v2, v3
+          CondBranch v4, bb3(v1), bb6()
         bb6():
-          Jump bb5(v1, v3, v4)
+          Jump bb5(v1)
         bb2():
           EntryPoint JIT(0)
-          v11:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :self@0
+          v9:NilClass = Const Value(nil)
+          v10:CPtr = GetEP 0
+          StoreField v10, :a@0x1001, v9
           v12:NilClass = Const Value(nil)
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v11, v12, v13)
-        bb3(v20:BasicObject, v21:BasicObject, v22:NilClass):
-          v26:Fixnum[1] = Const Value(1)
-          Jump bb5(v20, v26, v26)
+          StoreField v10, :b@0x1002, v12
+          Jump bb3(v8)
+        bb3(v23:BasicObject):
+          v27:Fixnum[1] = Const Value(1)
+          SetLocal :b, l0, EP@3, v27
+          SetLocal :a, l0, EP@4, v27
+          Jump bb5(v23)
         bb4():
           EntryPoint JIT(1)
           v16:BasicObject = LoadArg :self@0
           v17:BasicObject = LoadArg :a@1
-          v18:NilClass = Const Value(nil)
-          Jump bb5(v16, v17, v18)
-        bb5(v31:BasicObject, v32:BasicObject, v33:NilClass|Fixnum):
-          v39:ArrayExact = NewArray v32, v33
+          v18:CPtr = GetEP 0
+          StoreField v18, :a@0x1001, v17
+          v20:NilClass = Const Value(nil)
+          StoreField v18, :b@0x1002, v20
+          Jump bb5(v16)
+        bb5(v34:BasicObject):
+          v38:CPtr = GetEP 0
+          v39:BasicObject = LoadField v38, :a@0x1001
+          v41:CPtr = GetEP 0
+          v42:BasicObject = LoadField v41, :b@0x1002
+          v44:ArrayExact = NewArray v39, v42
           CheckInterrupts
-          Return v39
+          Return v44
         ");
     }
 
@@ -1202,33 +1248,40 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:NilClass = Const Value(nil)
-          v5:CPtr = LoadPC
-          v6:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v7:CBool = IsBitEqual v5, v6
-          CondBranch v7, bb3(v1, v3, v4), bb6()
+          v2:CPtr = LoadPC
+          v3:CPtr[CPtr(0x1000)] = Const CPtr(0x1000)
+          v4:CBool = IsBitEqual v2, v3
+          CondBranch v4, bb3(v1), bb6()
         bb6():
-          Jump bb5(v1, v3, v4)
+          Jump bb5(v1)
         bb2():
           EntryPoint JIT(0)
-          v11:BasicObject = LoadArg :self@0
+          v8:BasicObject = LoadArg :self@0
+          v9:NilClass = Const Value(nil)
+          v10:CPtr = GetEP 0
+          StoreField v10, :a@0x1001, v9
           v12:NilClass = Const Value(nil)
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v11, v12, v13)
-        bb3(v20:BasicObject, v21:BasicObject, v22:NilClass):
+          StoreField v10, :b@0x1002, v12
+          Jump bb3(v8)
+        bb3(v23:BasicObject):
           SideExit UnhandledYARVInsn(trace_putobject_INT2FIX_1_)
         bb4():
           EntryPoint JIT(1)
           v16:BasicObject = LoadArg :self@0
           v17:BasicObject = LoadArg :a@1
-          v18:NilClass = Const Value(nil)
-          Jump bb5(v16, v17, v18)
-        bb5(v27:BasicObject, v28:BasicObject, v29:NilClass):
-          v35:ArrayExact = NewArray v28, v29
+          v18:CPtr = GetEP 0
+          StoreField v18, :a@0x1001, v17
+          v20:NilClass = Const Value(nil)
+          StoreField v18, :b@0x1002, v20
+          Jump bb5(v16)
+        bb5(v28:BasicObject):
+          v32:CPtr = GetEP 0
+          v33:BasicObject = LoadField v32, :a@0x1001
+          v35:CPtr = GetEP 0
+          v36:BasicObject = LoadField v35, :b@0x1002
+          v38:ArrayExact = NewArray v33, v36
           CheckInterrupts
-          Return v35
+          Return v38
         ");
     }
 
@@ -1242,29 +1295,33 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:CPtr = LoadPC
-          v5:CPtr[CPtr(0x1001)] = Const CPtr(0x1001)
-          v6:CBool = IsBitEqual v4, v5
-          CondBranch v6, bb3(v1, v3), bb6()
+          v2:CPtr = LoadPC
+          v3:CPtr[CPtr(0x1000)] = Const CPtr(0x1000)
+          v4:CBool = IsBitEqual v2, v3
+          CondBranch v4, bb3(v1), bb6()
         bb6():
-          Jump bb5(v1, v3)
+          Jump bb5(v1)
         bb2():
           EntryPoint JIT(0)
-          v10:BasicObject = LoadArg :self@0
-          v11:NilClass = Const Value(nil)
-          Jump bb3(v10, v11)
-        bb3(v17:BasicObject, v18:BasicObject):
+          v8:BasicObject = LoadArg :self@0
+          v9:NilClass = Const Value(nil)
+          v10:CPtr = GetEP 0
+          StoreField v10, :a@0x1001, v9
+          Jump bb3(v8)
+        bb3(v19:BasicObject):
           SideExit UnhandledYARVInsn(definemethod)
         bb4():
           EntryPoint JIT(1)
           v14:BasicObject = LoadArg :self@0
           v15:BasicObject = LoadArg :a@1
-          Jump bb5(v14, v15)
-        bb5(v23:BasicObject, v24:BasicObject):
+          v16:CPtr = GetEP 0
+          StoreField v16, :a@0x1001, v15
+          Jump bb5(v14)
+        bb5(v24:BasicObject):
+          v28:CPtr = GetEP 0
+          v29:BasicObject = LoadField v28, :a@0x1001
           CheckInterrupts
-          Return v24
+          Return v29
         ");
     }
 
@@ -1278,22 +1335,26 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:NilClass = Const Value(nil)
-          Jump bb3(v6, v7)
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
         bb4():
           EntryPoint JIT(1)
           v10:BasicObject = LoadArg :self@0
           v11:BasicObject = LoadArg :a@1
-          Jump bb3(v10, v11)
-        bb3(v13:BasicObject, v14:BasicObject):
+          v12:CPtr = GetEP 0
+          StoreField v12, :a@0x1000, v11
+          Jump bb3(v10)
+        bb3(v15:BasicObject):
+          v21:CPtr = GetEP 0
+          v22:BasicObject = LoadField v21, :a@0x1000
           CheckInterrupts
-          Return v14
+          Return v22
         ");
     }
 
@@ -1453,25 +1514,27 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :cond@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :cond@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :cond@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :cond@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :cond@0x1000
           CheckInterrupts
-          v16:CBool = Test v10
-          v17:Falsy = RefineType v10, Falsy
-          CondBranch v16, bb5(), bb4(v9, v17)
+          v17:CBool = Test v14
+          v18:Falsy = RefineType v14, Falsy
+          CondBranch v17, bb5(), bb4(v9)
         bb5():
-          v19:Truthy = RefineType v10, Truthy
-          v22:Fixnum[3] = Const Value(3)
+          v20:Truthy = RefineType v14, Truthy
+          v23:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v22
-        bb4(v27:BasicObject, v28:Falsy):
+          Return v23
+        bb4(v28:BasicObject):
           v32:Fixnum[4] = Const Value(4)
           CheckInterrupts
           Return v32
@@ -1495,32 +1558,38 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :cond@0x1000
-          v4:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :cond@1
-          v9:NilClass = Const Value(nil)
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :cond@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :cond@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :result@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :cond@0x1000
           CheckInterrupts
-          v19:CBool = Test v12
-          v20:Falsy = RefineType v12, Falsy
-          CondBranch v19, bb6(), bb4(v11, v20, v13)
+          v19:CBool = Test v16
+          v20:Falsy = RefineType v16, Falsy
+          CondBranch v19, bb6(), bb4(v11)
         bb6():
-          v22:Truthy = RefineType v12, Truthy
+          v22:Truthy = RefineType v16, Truthy
           v25:Fixnum[3] = Const Value(3)
+          SetLocal :result, l0, EP@3, v25
           CheckInterrupts
-          Jump bb5(v11, v22, v25)
-        bb4(v30:BasicObject, v31:Falsy, v32:NilClass):
-          v36:Fixnum[4] = Const Value(4)
-          Jump bb5(v30, v31, v36)
-        bb5(v39:BasicObject, v40:BasicObject, v41:Fixnum):
+          Jump bb5(v11)
+        bb4(v31:BasicObject):
+          v35:Fixnum[4] = Const Value(4)
+          SetLocal :result, l0, EP@3, v35
+          Jump bb5(v31)
+        bb5(v39:BasicObject):
+          v43:CPtr = GetEP 0
+          v44:BasicObject = LoadField v43, :result@0x1001
           CheckInterrupts
-          Return v41
+          Return v44
         ");
     }
 
@@ -1536,20 +1605,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :+, v13 # SendFallbackReason: Uncategorized(opt_plus)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v22:BasicObject = Send v16, :+, v19 # SendFallbackReason: Uncategorized(opt_plus)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -1565,20 +1638,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :-, v13 # SendFallbackReason: Uncategorized(opt_minus)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v22:BasicObject = Send v16, :-, v19 # SendFallbackReason: Uncategorized(opt_minus)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -1594,20 +1671,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :*, v13 # SendFallbackReason: Uncategorized(opt_mult)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v22:BasicObject = Send v16, :*, v19 # SendFallbackReason: Uncategorized(opt_mult)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -1623,20 +1704,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :/, v13 # SendFallbackReason: Uncategorized(opt_div)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v22:BasicObject = Send v16, :/, v19 # SendFallbackReason: Uncategorized(opt_div)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -1652,20 +1737,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :%, v13 # SendFallbackReason: Uncategorized(opt_mod)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v22:BasicObject = Send v16, :%, v19 # SendFallbackReason: Uncategorized(opt_mod)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -1681,20 +1770,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :==, v13 # SendFallbackReason: Uncategorized(opt_eq)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v22:BasicObject = Send v16, :==, v19 # SendFallbackReason: Uncategorized(opt_eq)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -1710,20 +1803,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :!=, v13 # SendFallbackReason: Uncategorized(opt_neq)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v22:BasicObject = Send v16, :!=, v19 # SendFallbackReason: Uncategorized(opt_neq)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -1739,20 +1836,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :<, v13 # SendFallbackReason: Uncategorized(opt_lt)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v22:BasicObject = Send v16, :<, v19 # SendFallbackReason: Uncategorized(opt_lt)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -1768,20 +1869,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :<=, v13 # SendFallbackReason: Uncategorized(opt_le)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v22:BasicObject = Send v16, :<=, v19 # SendFallbackReason: Uncategorized(opt_le)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -1797,20 +1902,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :>, v13 # SendFallbackReason: Uncategorized(opt_gt)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v22:BasicObject = Send v16, :>, v19 # SendFallbackReason: Uncategorized(opt_gt)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -1833,38 +1942,51 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          v3:NilClass = Const Value(nil)
-          Jump bb3(v1, v2, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:NilClass = Const Value(nil)
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :result@0x1000, v5
           v8:NilClass = Const Value(nil)
-          Jump bb3(v6, v7, v8)
-        bb3(v10:BasicObject, v11:NilClass, v12:NilClass):
-          v16:Fixnum[0] = Const Value(0)
+          StoreField v6, :times@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:Fixnum[0] = Const Value(0)
+          SetLocal :result, l0, EP@4, v15
           v20:Fixnum[10] = Const Value(10)
+          SetLocal :times, l0, EP@3, v20
           CheckInterrupts
-          Jump bb5(v10, v16, v20)
-        bb5(v26:BasicObject, v27:BasicObject, v28:BasicObject):
-          v32:Fixnum[0] = Const Value(0)
-          v35:BasicObject = Send v28, :>, v32 # SendFallbackReason: Uncategorized(opt_gt)
+          Jump bb5(v11)
+        bb5(v27:BasicObject):
+          v30:CPtr = GetEP 0
+          v31:BasicObject = LoadField v30, :times@0x1001
+          v33:Fixnum[0] = Const Value(0)
+          v36:BasicObject = Send v31, :>, v33 # SendFallbackReason: Uncategorized(opt_gt)
           CheckInterrupts
-          v38:CBool = Test v35
-          v39:Truthy = RefineType v35, Truthy
-          CondBranch v38, bb4(v26, v27, v28), bb6()
-        bb4(v51:BasicObject, v52:BasicObject, v53:BasicObject):
-          v58:Fixnum[1] = Const Value(1)
-          v61:BasicObject = Send v52, :+, v58 # SendFallbackReason: Uncategorized(opt_plus)
-          v66:Fixnum[1] = Const Value(1)
-          v69:BasicObject = Send v53, :-, v66 # SendFallbackReason: Uncategorized(opt_minus)
-          Jump bb5(v51, v61, v69)
+          v39:CBool = Test v36
+          v40:Truthy = RefineType v36, Truthy
+          CondBranch v39, bb4(v27), bb6()
+        bb4(v54:BasicObject):
+          v58:CPtr = GetEP 0
+          v59:BasicObject = LoadField v58, :result@0x1000
+          v61:Fixnum[1] = Const Value(1)
+          v64:BasicObject = Send v59, :+, v61 # SendFallbackReason: Uncategorized(opt_plus)
+          SetLocal :result, l0, EP@4, v64
+          v69:CPtr = GetEP 0
+          v70:BasicObject = LoadField v69, :times@0x1001
+          v72:Fixnum[1] = Const Value(1)
+          v75:BasicObject = Send v70, :-, v72 # SendFallbackReason: Uncategorized(opt_minus)
+          SetLocal :times, l0, EP@3, v75
+          Jump bb5(v54)
         bb6():
-          v41:Falsy = RefineType v35, Falsy
-          v43:NilClass = Const Value(nil)
+          v42:Falsy = RefineType v36, Falsy
+          v44:NilClass = Const Value(nil)
+          v48:CPtr = GetEP 0
+          v49:BasicObject = LoadField v48, :result@0x1000
           CheckInterrupts
-          Return v27
+          Return v49
         ");
     }
 
@@ -1880,20 +2002,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :>=, v13 # SendFallbackReason: Uncategorized(opt_ge)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v22:BasicObject = Send v16, :>=, v19 # SendFallbackReason: Uncategorized(opt_ge)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -1914,28 +2040,32 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :cond@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:TrueClass = Const Value(true)
+          SetLocal :cond, l0, EP@3, v13
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :cond@0x1000
           CheckInterrupts
-          v19:CBool[true] = Test v13
-          v20 = RefineType v13, Falsy
-          CondBranch v19, bb5(), bb4(v8, v20)
+          v22:CBool = Test v19
+          v23:Falsy = RefineType v19, Falsy
+          CondBranch v22, bb5(), bb4(v9)
         bb5():
-          v22:TrueClass = RefineType v13, Truthy
-          v25:Fixnum[3] = Const Value(3)
+          v25:Truthy = RefineType v19, Truthy
+          v28:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v25
-        bb4(v30, v31):
-          v35 = Const Value(4)
+          Return v28
+        bb4(v33:BasicObject):
+          v37:Fixnum[4] = Const Value(4)
           CheckInterrupts
-          Return v35
+          Return v37
         ");
     }
 
@@ -1985,21 +2115,20 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:BasicObject = Send v10, 0x1008, :each # SendFallbackReason: Uncategorized(send)
-          PatchPoint NoEPEscape(test)
-          v18:CPtr = LoadSP
-          v19:BasicObject = LoadField v18, :a@0x1000
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
+          v16:BasicObject = Send v14, 0x1008, :each # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v15
+          Return v16
         ");
     }
 
@@ -2073,19 +2202,21 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:ArrayExact = ToArray v10
-          v18:BasicObject = Send v9, :foo, v16 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :a@0x1000
+          v17:ArrayExact = ToArray v15
+          v19:BasicObject = Send v9, :foo, v17 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v18
+          Return v19
         ");
     }
 
@@ -2099,18 +2230,20 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:BasicObject = Send v9, &block, :foo, v10 # SendFallbackReason: Uncategorized(send)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :a@0x1000
+          v17:BasicObject = Send v9, &block, :foo, v15 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v16
+          Return v17
         ");
     }
 
@@ -2124,19 +2257,19 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[1] = Const Value(1)
-          v17:BasicObject = Send v9, :foo, v15 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:Fixnum[1] = Const Value(1)
+          v16:BasicObject = Send v9, :foo, v14 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v17
+          Return v16
         ");
     }
 
@@ -2150,18 +2283,20 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:BasicObject = Send v9, :foo, v10 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :a@0x1000
+          v17:BasicObject = Send v9, :foo, v15 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v16
+          Return v17
         ");
     }
 
@@ -2244,18 +2379,20 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :...@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :...@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:BasicObject = InvokeSuperForward v9, 0x1008, v10 # SendFallbackReason: InvokeSuperForward: not yet specialized
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :...@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :...@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :...@0x1000
+          v17:BasicObject = InvokeSuperForward v9, 0x1008, v15 # SendFallbackReason: InvokeSuperForward: not yet specialized
           CheckInterrupts
-          Return v16
+          Return v17
         ");
     }
 
@@ -2269,21 +2406,20 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :...@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :...@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:BasicObject = InvokeSuperForward v9, 0x1008, v10 # SendFallbackReason: InvokeSuperForward: not yet specialized
-          PatchPoint NoEPEscape(test)
-          v19:CPtr = LoadSP
-          v20:BasicObject = LoadField v19, :...@0x1000
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :...@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :...@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :...@0x1000
+          v17:BasicObject = InvokeSuperForward v9, 0x1008, v15 # SendFallbackReason: InvokeSuperForward: not yet specialized
           CheckInterrupts
-          Return v16
+          Return v17
         ");
     }
 
@@ -2297,20 +2433,22 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :...@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :...@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:BasicObject = InvokeSuperForward v9, 0x1008, v10 # SendFallbackReason: InvokeSuperForward: not yet specialized
-          v18:Fixnum[1] = Const Value(1)
-          v21:BasicObject = Send v16, :+, v18 # SendFallbackReason: Uncategorized(opt_plus)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :...@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :...@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :...@0x1000
+          v17:BasicObject = InvokeSuperForward v9, 0x1008, v15 # SendFallbackReason: InvokeSuperForward: not yet specialized
+          v19:Fixnum[1] = Const Value(1)
+          v22:BasicObject = Send v17, :+, v19 # SendFallbackReason: Uncategorized(opt_plus)
           CheckInterrupts
-          Return v21
+          Return v22
         ");
     }
 
@@ -2324,19 +2462,21 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :...@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :...@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:Fixnum[1] = Const Value(1)
-          v18:BasicObject = InvokeSuperForward v9, 0x1008, v15, v10 # SendFallbackReason: InvokeSuperForward: not yet specialized
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :...@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :...@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:Fixnum[1] = Const Value(1)
+          v16:CPtr = GetEP 0
+          v17:BasicObject = LoadField v16, :...@0x1000
+          v19:BasicObject = InvokeSuperForward v9, 0x1008, v14, v17 # SendFallbackReason: InvokeSuperForward: not yet specialized
           CheckInterrupts
-          Return v18
+          Return v19
         ");
     }
 
@@ -2348,18 +2488,18 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :...@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :...@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:NilClass = Const Value(nil)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :...@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :...@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v14
+          Return v13
         ");
     }
 
@@ -2375,26 +2515,27 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
-          v17:HashExact = NewHash
-          PatchPoint NoEPEscape(test)
-          v22:BasicObject = Send v15, :core#hash_merge_kwd, v17, v10 # SendFallbackReason: Uncategorized(opt_send_without_block)
-          v24:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
-          v27:StaticSymbol[:b] = Const Value(VALUE(0x1010))
-          v29:Fixnum[1] = Const Value(1)
-          v31:BasicObject = Send v24, :core#hash_merge_ptr, v22, v27, v29 # SendFallbackReason: Uncategorized(opt_send_without_block)
-          v33:BasicObject = Send v9, :foo, v31 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
+          v16:HashExact = NewHash
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :a@0x1000
+          v21:BasicObject = Send v14, :core#hash_merge_kwd, v16, v19 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v23:ClassSubclass[VMFrozenCore] = Const Value(VALUE(0x1008))
+          v26:StaticSymbol[:b] = Const Value(VALUE(0x1010))
+          v28:Fixnum[1] = Const Value(1)
+          v30:BasicObject = Send v23, :core#hash_merge_ptr, v21, v26, v28 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v32:BasicObject = Send v9, :foo, v30 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v33
+          Return v32
         ");
     }
 
@@ -2408,23 +2549,25 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:ArrayExact = LoadField v2, :*@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :*@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:ArrayExact = ToNewArray v10
-          v18:Fixnum[1] = Const Value(1)
-          v20:CUInt64 = LoadField v16, :RBASIC_FLAGS@0x1001
-          v21:CUInt64 = GuardNoBitsSet v20, RUBY_FL_FREEZE=CUInt64(2048)
-          ArrayPush v16, v18
-          v24:BasicObject = Send v9, :foo, v16 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :*@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :*@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :*@0x1000
+          v17:ArrayExact = ToNewArray v15
+          v19:Fixnum[1] = Const Value(1)
+          v21:CUInt64 = LoadField v17, :RBASIC_FLAGS@0x1001
+          v22:CUInt64 = GuardNoBitsSet v21, RUBY_FL_FREEZE=CUInt64(2048)
+          ArrayPush v17, v19
+          v25:BasicObject = Send v9, :foo, v17 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v24
+          Return v25
         ");
     }
 
@@ -2438,18 +2581,20 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :...@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :...@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:BasicObject = SendForward v9, 0x1008, :foo, v10 # SendFallbackReason: SendForward: not yet specialized
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :...@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :...@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:BasicObject = LoadField v14, :...@0x1000
+          v17:BasicObject = SendForward v9, 0x1008, :foo, v15 # SendFallbackReason: SendForward: not yet specialized
           CheckInterrupts
-          Return v16
+          Return v17
         ");
     }
 
@@ -2463,38 +2608,43 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:ArrayExact = LoadField v2, :*@0x1001
-          v5:BasicObject = LoadField v2, :**@0x1002
-          v6:BasicObject = LoadField v2, :&@0x1003
-          v7:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6, v7)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v10:BasicObject = LoadArg :self@0
-          v11:BasicObject = LoadArg :a@1
-          v12:BasicObject = LoadArg :*@2
-          v13:BasicObject = LoadArg :**@3
-          v14:BasicObject = LoadArg :&@4
-          v15:NilClass = Const Value(nil)
-          Jump bb3(v10, v11, v12, v13, v14, v15)
-        bb3(v17:BasicObject, v18:BasicObject, v19:BasicObject, v20:BasicObject, v21:BasicObject, v22:NilClass):
-          v29:ArrayExact = ToArray v19
-          PatchPoint NoEPEscape(test)
-          v36:CPtr = GetEP 0
-          v37:CUInt64 = LoadField v36, :VM_ENV_DATA_INDEX_FLAGS@0x1004
-          v38:CBool = IsBlockParamModified v37
-          CondBranch v38, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :*@2
+          StoreField v6, :*@0x1001, v8
+          v10:BasicObject = LoadArg :**@3
+          StoreField v6, :**@0x1002, v10
+          v12:BasicObject = LoadArg :&@4
+          StoreField v6, :&@0x1003, v12
+          v14:NilClass = Const Value(nil)
+          StoreField v6, :...@0x1004, v14
+          Jump bb3(v4)
+        bb3(v17:BasicObject):
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :a@0x1000
+          v25:CPtr = GetEP 0
+          v26:BasicObject = LoadField v25, :*@0x1001
+          v28:ArrayExact = ToArray v26
+          v30:CPtr = GetEP 0
+          v31:BasicObject = LoadField v30, :**@0x1002
+          v34:CPtr = GetEP 0
+          v35:CUInt64 = LoadField v34, :VM_ENV_DATA_INDEX_FLAGS@0x1005
+          v36:CBool = IsBlockParamModified v35
+          CondBranch v36, bb4(), bb5()
         bb4():
-          v40:BasicObject = LoadField v36, :&@0x1005
-          Jump bb6(v40, v40)
+          v38:BasicObject = LoadField v34, :&@0x1003
+          Jump bb6(v38)
         bb5():
-          v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
-          v43:CInt64 = GuardAnyBitSet v42, CUInt64(1)
-          v44:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v44, v21)
-        bb6(v34:BasicObject, v35:BasicObject):
+          v40:CInt64 = LoadField v34, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
+          v41:CInt64 = GuardAnyBitSet v40, CUInt64(1)
+          v42:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v42)
+        bb6(v33:BasicObject):
           SideExit SplatKwNotProfiled
         ");
     }
@@ -2571,21 +2721,25 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_MAX)
-          v20:BasicObject = ArrayMax v12, v13
+          v22:BasicObject = ArrayMax v16, v19
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -2607,17 +2761,21 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_MAX))
         ");
     }
@@ -2658,21 +2816,25 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_MIN)
-          v20:BasicObject = ArrayMin v12, v13
+          v22:BasicObject = ArrayMin v16, v19
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -2694,17 +2856,21 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_MIN))
         ");
     }
@@ -2725,31 +2891,41 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          v5:NilClass = Const Value(nil)
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v9:BasicObject = LoadArg :self@0
-          v10:BasicObject = LoadArg :a@1
-          v11:BasicObject = LoadArg :b@2
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          v10:NilClass = Const Value(nil)
+          StoreField v6, :sum@0x1002, v10
           v12:NilClass = Const Value(nil)
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v9, v10, v11, v12, v13)
-        bb3(v15:BasicObject, v16:BasicObject, v17:BasicObject, v18:NilClass, v19:NilClass):
-          v26:BasicObject = Send v16, :+, v17 # SendFallbackReason: Uncategorized(opt_plus)
+          StoreField v6, :result@0x1003, v12
+          Jump bb3(v4)
+        bb3(v15:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :a@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :b@0x1001
+          v26:BasicObject = Send v20, :+, v23 # SendFallbackReason: Uncategorized(opt_plus)
+          SetLocal :sum, l0, EP@4, v26
+          v31:CPtr = GetEP 0
+          v32:BasicObject = LoadField v31, :a@0x1000
+          v34:CPtr = GetEP 0
+          v35:BasicObject = LoadField v34, :b@0x1001
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_HASH)
-          v33:Fixnum = ArrayHash v16, v17
-          PatchPoint NoEPEscape(test)
-          v40:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v41:ArrayExact = ArrayDup v40
-          v43:BasicObject = Send v15, :puts, v41 # SendFallbackReason: Uncategorized(opt_send_without_block)
-          PatchPoint NoEPEscape(test)
+          v38:Fixnum = ArrayHash v32, v35
+          SetLocal :result, l0, EP@3, v38
+          v44:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v45:ArrayExact = ArrayDup v44
+          v47:BasicObject = Send v15, :puts, v45 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v51:CPtr = GetEP 0
+          v52:BasicObject = LoadField v51, :result@0x1003
           CheckInterrupts
-          Return v33
+          Return v52
         ");
     }
 
@@ -2771,22 +2947,31 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          v5:NilClass = Const Value(nil)
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v9:BasicObject = LoadArg :self@0
-          v10:BasicObject = LoadArg :a@1
-          v11:BasicObject = LoadArg :b@2
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          v10:NilClass = Const Value(nil)
+          StoreField v6, :sum@0x1002, v10
           v12:NilClass = Const Value(nil)
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v9, v10, v11, v12, v13)
-        bb3(v15:BasicObject, v16:BasicObject, v17:BasicObject, v18:NilClass, v19:NilClass):
-          v26:BasicObject = Send v16, :+, v17 # SendFallbackReason: Uncategorized(opt_plus)
+          StoreField v6, :result@0x1003, v12
+          Jump bb3(v4)
+        bb3(v15:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :a@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :b@0x1001
+          v26:BasicObject = Send v20, :+, v23 # SendFallbackReason: Uncategorized(opt_plus)
+          SetLocal :sum, l0, EP@4, v26
+          v31:CPtr = GetEP 0
+          v32:BasicObject = LoadField v31, :a@0x1000
+          v34:CPtr = GetEP 0
+          v35:BasicObject = LoadField v34, :b@0x1001
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_HASH))
         ");
     }
@@ -2807,33 +2992,43 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          v5:NilClass = Const Value(nil)
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v9:BasicObject = LoadArg :self@0
-          v10:BasicObject = LoadArg :a@1
-          v11:BasicObject = LoadArg :b@2
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          v10:NilClass = Const Value(nil)
+          StoreField v6, :sum@0x1002, v10
           v12:NilClass = Const Value(nil)
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v9, v10, v11, v12, v13)
-        bb3(v15:BasicObject, v16:BasicObject, v17:BasicObject, v18:NilClass, v19:NilClass):
-          v26:BasicObject = Send v16, :+, v17 # SendFallbackReason: Uncategorized(opt_plus)
-          v32:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v33:StringExact = StringCopy v32
+          StoreField v6, :result@0x1003, v12
+          Jump bb3(v4)
+        bb3(v15:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :a@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :b@0x1001
+          v26:BasicObject = Send v20, :+, v23 # SendFallbackReason: Uncategorized(opt_plus)
+          SetLocal :sum, l0, EP@4, v26
+          v31:CPtr = GetEP 0
+          v32:BasicObject = LoadField v31, :a@0x1000
+          v34:CPtr = GetEP 0
+          v35:BasicObject = LoadField v34, :b@0x1001
+          v37:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v38:StringExact = StringCopy v37
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_PACK)
-          v36:String = ArrayPackBuffer v16, v17, fmt: v33
-          PatchPoint NoEPEscape(test)
-          v43:ArrayExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
-          v44:ArrayExact = ArrayDup v43
-          v46:BasicObject = Send v15, :puts, v44 # SendFallbackReason: Uncategorized(opt_send_without_block)
-          PatchPoint NoEPEscape(test)
+          v41:String = ArrayPackBuffer v32, v35, fmt: v38
+          SetLocal :result, l0, EP@3, v41
+          v47:ArrayExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
+          v48:ArrayExact = ArrayDup v47
+          v50:BasicObject = Send v15, :puts, v48 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v54:CPtr = GetEP 0
+          v55:BasicObject = LoadField v54, :result@0x1003
           CheckInterrupts
-          Return v36
+          Return v55
         ");
     }
 
@@ -2856,24 +3051,33 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          v5:NilClass = Const Value(nil)
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v9:BasicObject = LoadArg :self@0
-          v10:BasicObject = LoadArg :a@1
-          v11:BasicObject = LoadArg :b@2
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          v10:NilClass = Const Value(nil)
+          StoreField v6, :sum@0x1002, v10
           v12:NilClass = Const Value(nil)
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v9, v10, v11, v12, v13)
-        bb3(v15:BasicObject, v16:BasicObject, v17:BasicObject, v18:NilClass, v19:NilClass):
-          v26:BasicObject = Send v16, :+, v17 # SendFallbackReason: Uncategorized(opt_plus)
-          v32:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v33:StringExact = StringCopy v32
+          StoreField v6, :result@0x1003, v12
+          Jump bb3(v4)
+        bb3(v15:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :a@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :b@0x1001
+          v26:BasicObject = Send v20, :+, v23 # SendFallbackReason: Uncategorized(opt_plus)
+          SetLocal :sum, l0, EP@4, v26
+          v31:CPtr = GetEP 0
+          v32:BasicObject = LoadField v31, :a@0x1000
+          v34:CPtr = GetEP 0
+          v35:BasicObject = LoadField v34, :b@0x1001
+          v37:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v38:StringExact = StringCopy v37
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_PACK))
         ");
     }
@@ -2894,31 +3098,44 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          v5:NilClass = Const Value(nil)
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v9:BasicObject = LoadArg :self@0
-          v10:BasicObject = LoadArg :a@1
-          v11:BasicObject = LoadArg :b@2
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          v10:NilClass = Const Value(nil)
+          StoreField v6, :sum@0x1002, v10
           v12:NilClass = Const Value(nil)
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v9, v10, v11, v12, v13)
-        bb3(v15:BasicObject, v16:BasicObject, v17:BasicObject, v18:NilClass, v19:NilClass):
-          v26:BasicObject = Send v16, :+, v17 # SendFallbackReason: Uncategorized(opt_plus)
-          v30:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v31:StringExact = StringCopy v30
-          v37:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
-          v38:StringExact = StringCopy v37
+          StoreField v6, :buf@0x1003, v12
+          Jump bb3(v4)
+        bb3(v15:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :a@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :b@0x1001
+          v26:BasicObject = Send v20, :+, v23 # SendFallbackReason: Uncategorized(opt_plus)
+          SetLocal :sum, l0, EP@4, v26
+          v31:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v32:StringExact = StringCopy v31
+          SetLocal :buf, l0, EP@3, v32
+          v37:CPtr = GetEP 0
+          v38:BasicObject = LoadField v37, :a@0x1000
+          v40:CPtr = GetEP 0
+          v41:BasicObject = LoadField v40, :b@0x1001
+          v43:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
+          v44:StringExact = StringCopy v43
+          v46:CPtr = GetEP 0
+          v47:BasicObject = LoadField v46, :buf@0x1003
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_PACK)
-          v42:String = ArrayPackBuffer v16, v17, fmt: v38, buf: v31
-          PatchPoint NoEPEscape(test)
+          v50:String = ArrayPackBuffer v38, v41, fmt: v44, buf: v47
+          v54:CPtr = GetEP 0
+          v55:BasicObject = LoadField v54, :buf@0x1003
           CheckInterrupts
-          Return v31
+          Return v55
         ");
     }
 
@@ -2941,26 +3158,38 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          v5:NilClass = Const Value(nil)
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v9:BasicObject = LoadArg :self@0
-          v10:BasicObject = LoadArg :a@1
-          v11:BasicObject = LoadArg :b@2
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          v10:NilClass = Const Value(nil)
+          StoreField v6, :sum@0x1002, v10
           v12:NilClass = Const Value(nil)
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v9, v10, v11, v12, v13)
-        bb3(v15:BasicObject, v16:BasicObject, v17:BasicObject, v18:NilClass, v19:NilClass):
-          v26:BasicObject = Send v16, :+, v17 # SendFallbackReason: Uncategorized(opt_plus)
-          v30:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v31:StringExact = StringCopy v30
-          v37:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
-          v38:StringExact = StringCopy v37
+          StoreField v6, :buf@0x1003, v12
+          Jump bb3(v4)
+        bb3(v15:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :a@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :b@0x1001
+          v26:BasicObject = Send v20, :+, v23 # SendFallbackReason: Uncategorized(opt_plus)
+          SetLocal :sum, l0, EP@4, v26
+          v31:StringExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v32:StringExact = StringCopy v31
+          SetLocal :buf, l0, EP@3, v32
+          v37:CPtr = GetEP 0
+          v38:BasicObject = LoadField v37, :a@0x1000
+          v40:CPtr = GetEP 0
+          v41:BasicObject = LoadField v40, :b@0x1001
+          v43:StringExact[VALUE(0x1010)] = Const Value(VALUE(0x1010))
+          v44:StringExact = StringCopy v43
+          v46:CPtr = GetEP 0
+          v47:BasicObject = LoadField v46, :buf@0x1003
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_PACK))
         ");
     }
@@ -2981,31 +3210,43 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          v5:NilClass = Const Value(nil)
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v9:BasicObject = LoadArg :self@0
-          v10:BasicObject = LoadArg :a@1
-          v11:BasicObject = LoadArg :b@2
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          v10:NilClass = Const Value(nil)
+          StoreField v6, :sum@0x1002, v10
           v12:NilClass = Const Value(nil)
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v9, v10, v11, v12, v13)
-        bb3(v15:BasicObject, v16:BasicObject, v17:BasicObject, v18:NilClass, v19:NilClass):
-          v26:BasicObject = Send v16, :+, v17 # SendFallbackReason: Uncategorized(opt_plus)
+          StoreField v6, :result@0x1003, v12
+          Jump bb3(v4)
+        bb3(v15:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :a@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :b@0x1001
+          v26:BasicObject = Send v20, :+, v23 # SendFallbackReason: Uncategorized(opt_plus)
+          SetLocal :sum, l0, EP@4, v26
+          v31:CPtr = GetEP 0
+          v32:BasicObject = LoadField v31, :a@0x1000
+          v34:CPtr = GetEP 0
+          v35:BasicObject = LoadField v34, :b@0x1001
+          v37:CPtr = GetEP 0
+          v38:BasicObject = LoadField v37, :b@0x1001
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_INCLUDE_P)
-          v34:BoolExact = ArrayInclude v16, v17 | v17
-          PatchPoint NoEPEscape(test)
-          v41:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-          v42:ArrayExact = ArrayDup v41
-          v44:BasicObject = Send v15, :puts, v42 # SendFallbackReason: Uncategorized(opt_send_without_block)
-          PatchPoint NoEPEscape(test)
+          v41:BoolExact = ArrayInclude v32, v35 | v38
+          SetLocal :result, l0, EP@3, v41
+          v47:ArrayExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+          v48:ArrayExact = ArrayDup v47
+          v50:BasicObject = Send v15, :puts, v48 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v54:CPtr = GetEP 0
+          v55:BasicObject = LoadField v54, :result@0x1003
           CheckInterrupts
-          Return v34
+          Return v55
         ");
     }
 
@@ -3032,22 +3273,33 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          v5:NilClass = Const Value(nil)
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v9:BasicObject = LoadArg :self@0
-          v10:BasicObject = LoadArg :a@1
-          v11:BasicObject = LoadArg :b@2
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          v10:NilClass = Const Value(nil)
+          StoreField v6, :sum@0x1002, v10
           v12:NilClass = Const Value(nil)
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v9, v10, v11, v12, v13)
-        bb3(v15:BasicObject, v16:BasicObject, v17:BasicObject, v18:NilClass, v19:NilClass):
-          v26:BasicObject = Send v16, :+, v17 # SendFallbackReason: Uncategorized(opt_plus)
+          StoreField v6, :result@0x1003, v12
+          Jump bb3(v4)
+        bb3(v15:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :a@0x1000
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :b@0x1001
+          v26:BasicObject = Send v20, :+, v23 # SendFallbackReason: Uncategorized(opt_plus)
+          SetLocal :sum, l0, EP@4, v26
+          v31:CPtr = GetEP 0
+          v32:BasicObject = LoadField v31, :a@0x1000
+          v34:CPtr = GetEP 0
+          v35:BasicObject = LoadField v34, :b@0x1001
+          v37:CPtr = GetEP 0
+          v38:BasicObject = LoadField v37, :b@0x1001
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_INCLUDE_P))
         ");
     }
@@ -3065,19 +3317,21 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           PatchPoint BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_INCLUDE_P)
-          v16:BoolExact = DupArrayInclude VALUE(0x1008) | v10
+          v17:BoolExact = DupArrayInclude VALUE(0x1008) | v14
           CheckInterrupts
-          Return v16
+          Return v17
         ");
     }
 
@@ -3100,15 +3354,17 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           SideExit PatchPoint(BOPRedefined(ARRAY_REDEFINED_OP_FLAG, BOP_INCLUDE_P))
         ");
     }
@@ -3124,21 +3380,25 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v19:ArrayExact = NewArray v12, v13
-          v22:BasicObject = Send v19, :length # SendFallbackReason: Uncategorized(opt_length)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v21:ArrayExact = NewArray v16, v19
+          v24:BasicObject = Send v21, :length # SendFallbackReason: Uncategorized(opt_length)
           CheckInterrupts
-          Return v22
+          Return v24
         ");
     }
 
@@ -3153,21 +3413,25 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v19:ArrayExact = NewArray v12, v13
-          v22:BasicObject = Send v19, :size # SendFallbackReason: Uncategorized(opt_size)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v21:ArrayExact = NewArray v16, v19
+          v24:BasicObject = Send v21, :size # SendFallbackReason: Uncategorized(opt_size)
           CheckInterrupts
-          Return v22
+          Return v24
         ");
     }
 
@@ -3184,19 +3448,21 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :klass@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :klass@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:FalseClass = Const Value(false)
-          v17:BasicObject = GetConstant v10, :ARGV, v15
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :klass@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :klass@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :klass@0x1000
+          v16:FalseClass = Const Value(false)
+          v18:BasicObject = GetConstant v14, :ARGV, v16
           CheckInterrupts
-          Return v17
+          Return v18
         ");
     }
 
@@ -3393,28 +3659,28 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :block@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:CPtr = GetEP 0
-          v16:CUInt64 = LoadField v15, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v17:CBool = IsBlockParamModified v16
-          CondBranch v17, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v14:CPtr = GetEP 0
+          v15:CUInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v16:CBool = IsBlockParamModified v15
+          CondBranch v16, bb4(), bb5()
         bb4():
-          v19:BasicObject = LoadField v15, :block@0x1002
-          Jump bb6(v19)
+          v18:BasicObject = LoadField v14, :block@0x1000
+          Jump bb6(v18)
         bb5():
-          v21:BasicObject = GetBlockParam :block, l0, EP@3
-          Jump bb6(v21)
-        bb6(v14:BasicObject):
+          v20:BasicObject = GetBlockParam :block, l0, EP@3
+          Jump bb6(v20)
+        bb6(v13:BasicObject):
           CheckInterrupts
-          Return v14
+          Return v13
         ");
     }
 
@@ -3429,31 +3695,31 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :block@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v17:CPtr = GetEP 0
-          v18:CUInt64 = LoadField v17, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v19:CBool = IsBlockParamModified v18
-          CondBranch v19, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:CUInt64 = LoadField v15, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v17:CBool = IsBlockParamModified v16
+          CondBranch v17, bb4(), bb5()
         bb4():
-          v21:BasicObject = LoadField v17, :block@0x1002
-          Jump bb6(v21, v21)
+          v19:BasicObject = LoadField v15, :block@0x1000
+          Jump bb6(v19)
         bb5():
-          v23:CInt64 = LoadField v17, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v24:CInt64 = GuardAnyBitSet v23, CUInt64(1)
-          v25:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v25, v10)
-        bb6(v15:BasicObject, v16:BasicObject):
-          v28:BasicObject = Send v9, &block, :tap, v15 # SendFallbackReason: Uncategorized(send)
+          v21:CInt64 = LoadField v15, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
+          v22:CInt64 = GuardAnyBitSet v21, CUInt64(1)
+          v23:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v23)
+        bb6(v14:BasicObject):
+          v26:BasicObject = Send v9, &block, :tap, v14 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v28
+          Return v26
         ");
     }
 
@@ -3471,44 +3737,45 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          v4:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :block@1
-          v9:NilClass = Const Value(nil)
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:NilClass):
-          v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v20:CBool = IsBlockParamModified v19
-          CondBranch v20, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v16:CPtr = GetEP 0
+          v17:CUInt64 = LoadField v16, :VM_ENV_DATA_INDEX_FLAGS@0x1002
+          v18:CBool = IsBlockParamModified v17
+          CondBranch v18, bb4(), bb5()
         bb4():
-          v22:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v22)
+          v20:BasicObject = LoadField v16, :block@0x1000
+          Jump bb6(v20)
         bb5():
-          v24:BasicObject = GetBlockParam :block, l0, EP@4
-          Jump bb6(v24)
-        bb6(v17:BasicObject):
-          v32:CPtr = GetEP 0
-          v33:CUInt64 = LoadField v32, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v34:CBool = IsBlockParamModified v33
-          CondBranch v34, bb7(), bb8()
+          v22:BasicObject = GetBlockParam :block, l0, EP@4
+          Jump bb6(v22)
+        bb6(v15:BasicObject):
+          SetLocal :b, l0, EP@3, v15
+          v30:CPtr = GetEP 0
+          v31:CUInt64 = LoadField v30, :VM_ENV_DATA_INDEX_FLAGS@0x1002
+          v32:CBool = IsBlockParamModified v31
+          CondBranch v32, bb7(), bb8()
         bb7():
-          v36:BasicObject = LoadField v32, :block@0x1002
-          Jump bb9(v36, v36)
+          v34:BasicObject = LoadField v30, :block@0x1000
+          Jump bb9(v34)
         bb8():
-          v38:CInt64 = LoadField v32, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v39:CInt64 = GuardAnyBitSet v38, CUInt64(1)
-          v40:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb9(v40, v17)
-        bb9(v30:BasicObject, v31:BasicObject):
-          v43:BasicObject = Send v11, &block, :tap, v30 # SendFallbackReason: Uncategorized(send)
+          v36:CInt64 = LoadField v30, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
+          v37:CInt64 = GuardAnyBitSet v36, CUInt64(1)
+          v38:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb9(v38)
+        bb9(v29:BasicObject):
+          v41:BasicObject = Send v11, &block, :tap, v29 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v43
+          Return v41
         ");
     }
 
@@ -3527,41 +3794,43 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :b@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v14:CPtr = GetEP 1
-          v15:CUInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1000
+          v15:CUInt64 = LoadField v14, :VM_ENV_DATA_INDEX_FLAGS@0x1001
           v16:CBool = IsBlockParamModified v15
           CondBranch v16, bb4(), bb5()
         bb4():
-          v18:BasicObject = LoadField v14, :block@0x1001
+          v18:BasicObject = LoadField v14, :block@0x1000
           Jump bb6(v18)
         bb5():
           v20:BasicObject = GetBlockParam :block, l1, EP@3
           Jump bb6(v20)
         bb6(v13:BasicObject):
-          v27:CPtr = GetEP 1
-          v28:CUInt64 = LoadField v27, :VM_ENV_DATA_INDEX_FLAGS@0x1000
-          v29:CBool = IsBlockParamModified v28
-          CondBranch v29, bb7(), bb8()
+          SetLocal :b, l0, EP@3, v13
+          v28:CPtr = GetEP 1
+          v29:CUInt64 = LoadField v28, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v30:CBool = IsBlockParamModified v29
+          CondBranch v30, bb7(), bb8()
         bb7():
-          v31:BasicObject = LoadField v27, :block@0x1001
-          Jump bb9(v31)
+          v32:BasicObject = LoadField v28, :block@0x1000
+          Jump bb9(v32)
         bb8():
-          v33:CInt64 = LoadField v27, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
-          v34:CInt64 = GuardAnyBitSet v33, CUInt64(1)
-          v35:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb9(v35)
-        bb9(v26:BasicObject):
-          v38:BasicObject = Send v8, &block, :tap, v26 # SendFallbackReason: Uncategorized(send)
+          v34:CInt64 = LoadField v28, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
+          v35:CInt64 = GuardAnyBitSet v34, CUInt64(1)
+          v36:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb9(v36)
+        bb9(v27:BasicObject):
+          v39:BasicObject = Send v9, &block, :tap, v27 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v38
+          Return v39
         ");
     }
 
@@ -3582,43 +3851,43 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :block@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:Fixnum[0] = Const Value(0)
-          v18:CPtr = GetEP 0
-          v19:CUInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v20:CBool = IsBlockParamModified v19
-          CondBranch v20, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:Fixnum[0] = Const Value(0)
+          v16:CPtr = GetEP 0
+          v17:CUInt64 = LoadField v16, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v18:CBool = IsBlockParamModified v17
+          CondBranch v18, bb4(), bb5()
         bb4():
-          v22:BasicObject = LoadField v18, :block@0x1002
-          Jump bb6(v22, v22)
+          v20:BasicObject = LoadField v16, :block@0x1000
+          Jump bb6(v20)
         bb5():
-          v24:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
-          v25:CInt64[1] = Const CInt64(1)
-          v26:CInt64 = IntAnd v24, v25
-          v27:CBool = IsBitEqual v26, v25
-          CondBranch v27, bb7(), bb9()
+          v22:CInt64 = LoadField v16, :VM_ENV_DATA_INDEX_SPECVAL@0x1002
+          v23:CInt64[1] = Const CInt64(1)
+          v24:CInt64 = IntAnd v22, v23
+          v25:CBool = IsBitEqual v24, v23
+          CondBranch v25, bb7(), bb9()
         bb7():
-          v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v29, v10)
+          v27:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v27)
         bb9():
-          v31:CInt64[0] = Const CInt64(0)
-          v32:CBool = IsBitEqual v24, v31
-          CondBranch v32, bb8(), bb10()
+          v29:CInt64[0] = Const CInt64(0)
+          v30:CBool = IsBitEqual v22, v29
+          CondBranch v30, bb8(), bb10()
         bb8():
-          v34:NilClass = Const Value(nil)
-          Jump bb6(v34, v10)
-        bb6(v16:BasicObject, v17:BasicObject):
-          v38:BasicObject = Send v14, &block, :then, v16 # SendFallbackReason: Uncategorized(send)
+          v32:NilClass = Const Value(nil)
+          Jump bb6(v32)
+        bb6(v15:BasicObject):
+          v36:BasicObject = Send v13, &block, :then, v15 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v38
+          Return v36
         bb10():
           SideExit BlockParamProxyProfileNotCovered
         ");
@@ -3673,24 +3942,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :block@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :block@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:NilClass = Const Value(nil)
-          SetLocal :block, l0, EP@3, v14
-          v18:CPtr = GetEP 0
-          v19:CInt64 = LoadField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001
-          v20:CInt64[512] = Const CInt64(512)
-          v21:CInt64 = IntOr v19, v20
-          StoreField v18, :VM_ENV_DATA_INDEX_FLAGS@0x1001, v21
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :block@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :block@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:NilClass = Const Value(nil)
+          SetLocal :block, l0, EP@3, v13
+          v17:CPtr = GetEP 0
+          v18:CInt64 = LoadField v17, :VM_ENV_DATA_INDEX_FLAGS@0x1001
+          v19:CInt64[512] = Const CInt64(512)
+          v20:CInt64 = IntOr v18, v19
+          StoreField v17, :VM_ENV_DATA_INDEX_FLAGS@0x1001, v20
           CheckInterrupts
-          Return v14
+          Return v13
         ");
     }
 
@@ -3738,30 +4007,32 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :kw@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :kw@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v21:CPtr = GetEP 0
-          v22:CUInt64 = LoadField v21, :VM_ENV_DATA_INDEX_FLAGS@0x1002
-          v23:CBool = IsBlockParamModified v22
-          CondBranch v23, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :kw@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :kw@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v16:CPtr = GetEP 0
+          v17:BasicObject = LoadField v16, :kw@0x1000
+          v20:CPtr = GetEP 0
+          v21:CUInt64 = LoadField v20, :VM_ENV_DATA_INDEX_FLAGS@0x1002
+          v22:CBool = IsBlockParamModified v21
+          CondBranch v22, bb4(), bb5()
         bb4():
-          v25:BasicObject = LoadField v21, :b@0x1003
-          Jump bb6(v25, v25)
+          v24:BasicObject = LoadField v20, :b@0x1001
+          Jump bb6(v24)
         bb5():
-          v27:CInt64 = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
-          v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
-          v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v29, v13)
-        bb6(v19:BasicObject, v20:BasicObject):
+          v26:CInt64 = LoadField v20, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
+          v27:CInt64 = GuardAnyBitSet v26, CUInt64(1)
+          v28:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v28)
+        bb6(v19:BasicObject):
           SideExit SplatKwNotProfiled
         ");
     }
@@ -3779,42 +4050,47 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:ArrayExact = LoadField v2, :*@0x1001
-          v5:BasicObject = LoadField v2, :**@0x1002
-          v6:BasicObject = LoadField v2, :&@0x1003
-          v7:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6, v7)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v10:BasicObject = LoadArg :self@0
-          v11:BasicObject = LoadArg :a@1
-          v12:BasicObject = LoadArg :*@2
-          v13:BasicObject = LoadArg :**@3
-          v14:BasicObject = LoadArg :&@4
-          v15:NilClass = Const Value(nil)
-          Jump bb3(v10, v11, v12, v13, v14, v15)
-        bb3(v17:BasicObject, v18:BasicObject, v19:BasicObject, v20:BasicObject, v21:BasicObject, v22:NilClass):
-          v29:ArrayExact = ToArray v19
-          PatchPoint NoEPEscape(test)
-          v36:CPtr = GetEP 0
-          v37:CUInt64 = LoadField v36, :VM_ENV_DATA_INDEX_FLAGS@0x1004
-          v38:CBool = IsBlockParamModified v37
-          CondBranch v38, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :*@2
+          StoreField v6, :*@0x1001, v8
+          v10:BasicObject = LoadArg :**@3
+          StoreField v6, :**@0x1002, v10
+          v12:BasicObject = LoadArg :&@4
+          StoreField v6, :&@0x1003, v12
+          v14:NilClass = Const Value(nil)
+          StoreField v6, :...@0x1004, v14
+          Jump bb3(v4)
+        bb3(v17:BasicObject):
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :a@0x1000
+          v25:CPtr = GetEP 0
+          v26:BasicObject = LoadField v25, :*@0x1001
+          v28:ArrayExact = ToArray v26
+          v30:CPtr = GetEP 0
+          v31:BasicObject = LoadField v30, :**@0x1002
+          v34:CPtr = GetEP 0
+          v35:CUInt64 = LoadField v34, :VM_ENV_DATA_INDEX_FLAGS@0x1005
+          v36:CBool = IsBlockParamModified v35
+          CondBranch v36, bb4(), bb5()
         bb4():
-          v40:BasicObject = LoadField v36, :&@0x1005
-          Jump bb6(v40, v40)
+          v38:BasicObject = LoadField v34, :&@0x1003
+          Jump bb6(v38)
         bb5():
-          v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
-          v43:CInt64[0] = GuardBitEquals v42, CInt64(0)
-          v44:NilClass = Const Value(nil)
-          Jump bb6(v44, v21)
-        bb6(v34:BasicObject, v35:BasicObject):
-          v47:NilClass = GuardType v20, NilClass
-          v49:BasicObject = Send v17, &block, :foo, v18, v29, v47, v34 # SendFallbackReason: Uncategorized(send)
+          v40:CInt64 = LoadField v34, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
+          v41:CInt64[0] = GuardBitEquals v40, CInt64(0)
+          v42:NilClass = Const Value(nil)
+          Jump bb6(v42)
+        bb6(v33:BasicObject):
+          v45:NilClass = GuardType v31, NilClass
+          v47:BasicObject = Send v17, &block, :foo, v23, v28, v45, v33 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v49
+          Return v47
         ");
     }
 
@@ -3831,34 +4107,36 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :kw@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :kw@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v21:CPtr = GetEP 0
-          v22:CUInt64 = LoadField v21, :VM_ENV_DATA_INDEX_FLAGS@0x1002
-          v23:CBool = IsBlockParamModified v22
-          CondBranch v23, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :kw@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :kw@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v16:CPtr = GetEP 0
+          v17:BasicObject = LoadField v16, :kw@0x1000
+          v20:CPtr = GetEP 0
+          v21:CUInt64 = LoadField v20, :VM_ENV_DATA_INDEX_FLAGS@0x1002
+          v22:CBool = IsBlockParamModified v21
+          CondBranch v22, bb4(), bb5()
         bb4():
-          v25:BasicObject = LoadField v21, :b@0x1003
-          Jump bb6(v25, v25)
+          v24:BasicObject = LoadField v20, :b@0x1001
+          Jump bb6(v24)
         bb5():
-          v27:CInt64 = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
-          v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
-          v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v29, v13)
-        bb6(v19:BasicObject, v20:BasicObject):
-          v32:HashExact = GuardType v12, HashExact
-          v34:BasicObject = Send v11, &block, :foo, v32, v19 # SendFallbackReason: Uncategorized(send)
+          v26:CInt64 = LoadField v20, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
+          v27:CInt64 = GuardAnyBitSet v26, CUInt64(1)
+          v28:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v28)
+        bb6(v19:BasicObject):
+          v31:HashExact = GuardType v17, HashExact
+          v33:BasicObject = Send v11, &block, :foo, v31, v19 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v34
+          Return v33
         ");
     }
 
@@ -3875,34 +4153,36 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :kw@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :kw@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v21:CPtr = GetEP 0
-          v22:CUInt64 = LoadField v21, :VM_ENV_DATA_INDEX_FLAGS@0x1002
-          v23:CBool = IsBlockParamModified v22
-          CondBranch v23, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :kw@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :kw@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v16:CPtr = GetEP 0
+          v17:BasicObject = LoadField v16, :kw@0x1000
+          v20:CPtr = GetEP 0
+          v21:CUInt64 = LoadField v20, :VM_ENV_DATA_INDEX_FLAGS@0x1002
+          v22:CBool = IsBlockParamModified v21
+          CondBranch v22, bb4(), bb5()
         bb4():
-          v25:BasicObject = LoadField v21, :b@0x1003
-          Jump bb6(v25, v25)
+          v24:BasicObject = LoadField v20, :b@0x1001
+          Jump bb6(v24)
         bb5():
-          v27:CInt64 = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
-          v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
-          v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v29, v13)
-        bb6(v19:BasicObject, v20:BasicObject):
-          v32:HashExact = GuardType v12, HashExact
-          v34:BasicObject = Send v11, &block, :foo, v32, v19 # SendFallbackReason: Uncategorized(send)
+          v26:CInt64 = LoadField v20, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
+          v27:CInt64 = GuardAnyBitSet v26, CUInt64(1)
+          v28:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v28)
+        bb6(v19:BasicObject):
+          v31:HashExact = GuardType v17, HashExact
+          v33:BasicObject = Send v11, &block, :foo, v31, v19 # SendFallbackReason: Uncategorized(send)
           CheckInterrupts
-          Return v34
+          Return v33
         ");
     }
 
@@ -3921,38 +4201,43 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:ArrayExact = LoadField v2, :*@0x1001
-          v5:BasicObject = LoadField v2, :**@0x1002
-          v6:BasicObject = LoadField v2, :&@0x1003
-          v7:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6, v7)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v10:BasicObject = LoadArg :self@0
-          v11:BasicObject = LoadArg :a@1
-          v12:BasicObject = LoadArg :*@2
-          v13:BasicObject = LoadArg :**@3
-          v14:BasicObject = LoadArg :&@4
-          v15:NilClass = Const Value(nil)
-          Jump bb3(v10, v11, v12, v13, v14, v15)
-        bb3(v17:BasicObject, v18:BasicObject, v19:BasicObject, v20:BasicObject, v21:BasicObject, v22:NilClass):
-          v29:ArrayExact = ToArray v19
-          PatchPoint NoEPEscape(test)
-          v36:CPtr = GetEP 0
-          v37:CUInt64 = LoadField v36, :VM_ENV_DATA_INDEX_FLAGS@0x1004
-          v38:CBool = IsBlockParamModified v37
-          CondBranch v38, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :*@2
+          StoreField v6, :*@0x1001, v8
+          v10:BasicObject = LoadArg :**@3
+          StoreField v6, :**@0x1002, v10
+          v12:BasicObject = LoadArg :&@4
+          StoreField v6, :&@0x1003, v12
+          v14:NilClass = Const Value(nil)
+          StoreField v6, :...@0x1004, v14
+          Jump bb3(v4)
+        bb3(v17:BasicObject):
+          v22:CPtr = GetEP 0
+          v23:BasicObject = LoadField v22, :a@0x1000
+          v25:CPtr = GetEP 0
+          v26:BasicObject = LoadField v25, :*@0x1001
+          v28:ArrayExact = ToArray v26
+          v30:CPtr = GetEP 0
+          v31:BasicObject = LoadField v30, :**@0x1002
+          v34:CPtr = GetEP 0
+          v35:CUInt64 = LoadField v34, :VM_ENV_DATA_INDEX_FLAGS@0x1005
+          v36:CBool = IsBlockParamModified v35
+          CondBranch v36, bb4(), bb5()
         bb4():
-          v40:BasicObject = LoadField v36, :&@0x1005
-          Jump bb6(v40, v40)
+          v38:BasicObject = LoadField v34, :&@0x1003
+          Jump bb6(v38)
         bb5():
-          v42:CInt64 = LoadField v36, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
-          v43:CInt64[0] = GuardBitEquals v42, CInt64(0)
-          v44:NilClass = Const Value(nil)
-          Jump bb6(v44, v21)
-        bb6(v34:BasicObject, v35:BasicObject):
+          v40:CInt64 = LoadField v34, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
+          v41:CInt64[0] = GuardBitEquals v40, CInt64(0)
+          v42:NilClass = Const Value(nil)
+          Jump bb6(v42)
+        bb6(v33:BasicObject):
           SideExit SplatKwPolymorphic
         ");
     }
@@ -3972,30 +4257,32 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :obj@0x1000
-          v4:BasicObject = LoadField v2, :block@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :obj@1
-          v9:BasicObject = LoadArg :block@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v21:CPtr = GetEP 0
-          v22:CUInt64 = LoadField v21, :VM_ENV_DATA_INDEX_FLAGS@0x1002
-          v23:CBool = IsBlockParamModified v22
-          CondBranch v23, bb4(), bb5()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :obj@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :obj@0x1000, v5
+          v8:BasicObject = LoadArg :block@2
+          StoreField v6, :block@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v16:CPtr = GetEP 0
+          v17:BasicObject = LoadField v16, :obj@0x1000
+          v20:CPtr = GetEP 0
+          v21:CUInt64 = LoadField v20, :VM_ENV_DATA_INDEX_FLAGS@0x1002
+          v22:CBool = IsBlockParamModified v21
+          CondBranch v22, bb4(), bb5()
         bb4():
-          v25:BasicObject = LoadField v21, :block@0x1003
-          Jump bb6(v25, v25)
+          v24:BasicObject = LoadField v20, :block@0x1001
+          Jump bb6(v24)
         bb5():
-          v27:CInt64 = LoadField v21, :VM_ENV_DATA_INDEX_SPECVAL@0x1004
-          v28:CInt64 = GuardAnyBitSet v27, CUInt64(1)
-          v29:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb6(v29, v13)
-        bb6(v19:BasicObject, v20:BasicObject):
+          v26:CInt64 = LoadField v20, :VM_ENV_DATA_INDEX_SPECVAL@0x1003
+          v27:CInt64 = GuardAnyBitSet v26, CUInt64(1)
+          v28:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb6(v28)
+        bb6(v19:BasicObject):
           SideExit SplatKwNotNilOrHash
         ");
     }
@@ -4011,18 +4298,20 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:ArrayExact = ToNewArray v10
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
+          v16:ArrayExact = ToNewArray v14
           CheckInterrupts
-          Return v15
+          Return v16
         ");
     }
 
@@ -4037,21 +4326,23 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:Fixnum[1] = Const Value(1)
-          v16:ArrayExact = NewArray v14
-          v19:ArrayExact = ToArray v10
-          ArrayExtend v16, v19
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:Fixnum[1] = Const Value(1)
+          v15:ArrayExact = NewArray v13
+          v17:CPtr = GetEP 0
+          v18:BasicObject = LoadField v17, :a@0x1000
+          v20:ArrayExact = ToArray v18
+          ArrayExtend v15, v20
           CheckInterrupts
-          Return v16
+          Return v15
         ");
     }
 
@@ -4066,22 +4357,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:ArrayExact = ToNewArray v10
-          v17:Fixnum[1] = Const Value(1)
-          v19:CUInt64 = LoadField v15, :RBASIC_FLAGS@0x1001
-          v20:CUInt64 = GuardNoBitsSet v19, RUBY_FL_FREEZE=CUInt64(2048)
-          ArrayPush v15, v17
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
+          v16:ArrayExact = ToNewArray v14
+          v18:Fixnum[1] = Const Value(1)
+          v20:CUInt64 = LoadField v16, :RBASIC_FLAGS@0x1001
+          v21:CUInt64 = GuardNoBitsSet v20, RUBY_FL_FREEZE=CUInt64(2048)
+          ArrayPush v16, v18
           CheckInterrupts
-          Return v15
+          Return v16
         ");
     }
 
@@ -4096,26 +4389,28 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :a@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v15:ArrayExact = ToNewArray v10
-          v17:Fixnum[1] = Const Value(1)
-          v19:Fixnum[2] = Const Value(2)
-          v21:Fixnum[3] = Const Value(3)
-          v23:CUInt64 = LoadField v15, :RBASIC_FLAGS@0x1001
-          v24:CUInt64 = GuardNoBitsSet v23, RUBY_FL_FREEZE=CUInt64(2048)
-          ArrayPush v15, v17
-          ArrayPush v15, v19
-          ArrayPush v15, v21
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :a@0x1000
+          v16:ArrayExact = ToNewArray v14
+          v18:Fixnum[1] = Const Value(1)
+          v20:Fixnum[2] = Const Value(2)
+          v22:Fixnum[3] = Const Value(3)
+          v24:CUInt64 = LoadField v16, :RBASIC_FLAGS@0x1001
+          v25:CUInt64 = GuardNoBitsSet v24, RUBY_FL_FREEZE=CUInt64(2048)
+          ArrayPush v16, v18
+          ArrayPush v16, v20
+          ArrayPush v16, v22
           CheckInterrupts
-          Return v15
+          Return v16
         ");
     }
 
@@ -4130,22 +4425,26 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v17:NilClass = Const Value(nil)
-          v21:Fixnum[1] = Const Value(1)
-          v25:BasicObject = Send v12, :[]=, v13, v21 # SendFallbackReason: Uncategorized(opt_aset)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:NilClass = Const Value(nil)
+          v17:CPtr = GetEP 0
+          v18:BasicObject = LoadField v17, :a@0x1000
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :b@0x1001
+          v23:Fixnum[1] = Const Value(1)
+          v27:BasicObject = Send v18, :[]=, v21, v23 # SendFallbackReason: Uncategorized(opt_aset)
           CheckInterrupts
-          Return v21
+          Return v23
         ");
     }
 
@@ -4160,20 +4459,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :a@0x1000
-          v4:BasicObject = LoadField v2, :b@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :a@1
-          v9:BasicObject = LoadArg :b@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :[], v13 # SendFallbackReason: Uncategorized(opt_aref)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :a@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:BasicObject = LoadArg :b@2
+          StoreField v6, :b@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :a@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :b@0x1001
+          v22:BasicObject = Send v16, :[], v19 # SendFallbackReason: Uncategorized(opt_aref)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -4188,18 +4491,20 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:BasicObject = Send v10, :empty? # SendFallbackReason: Uncategorized(opt_empty_p)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
+          v17:BasicObject = Send v14, :empty? # SendFallbackReason: Uncategorized(opt_empty_p)
           CheckInterrupts
-          Return v16
+          Return v17
         ");
     }
 
@@ -4214,18 +4519,20 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:BasicObject = Send v10, :succ # SendFallbackReason: Uncategorized(opt_succ)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
+          v17:BasicObject = Send v14, :succ # SendFallbackReason: Uncategorized(opt_succ)
           CheckInterrupts
-          Return v16
+          Return v17
         ");
     }
 
@@ -4240,20 +4547,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :&, v13 # SendFallbackReason: Uncategorized(opt_and)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
+          v22:BasicObject = Send v16, :&, v19 # SendFallbackReason: Uncategorized(opt_and)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -4268,20 +4579,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :|, v13 # SendFallbackReason: Uncategorized(opt_or)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
+          v22:BasicObject = Send v16, :|, v19 # SendFallbackReason: Uncategorized(opt_or)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -4296,18 +4611,20 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v16:BasicObject = Send v10, :! # SendFallbackReason: Uncategorized(opt_not)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
+          v17:BasicObject = Send v14, :! # SendFallbackReason: Uncategorized(opt_not)
           CheckInterrupts
-          Return v16
+          Return v17
         ");
     }
 
@@ -4322,20 +4639,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :regexp@0x1000
-          v4:BasicObject = LoadField v2, :matchee@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :regexp@1
-          v9:BasicObject = LoadArg :matchee@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v20:BasicObject = Send v12, :=~, v13 # SendFallbackReason: Uncategorized(opt_regexpmatch2)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :regexp@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :regexp@0x1000, v5
+          v8:BasicObject = LoadArg :matchee@2
+          StoreField v6, :matchee@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :regexp@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :matchee@0x1001
+          v22:BasicObject = Send v16, :=~, v19 # SendFallbackReason: Uncategorized(opt_regexpmatch2)
           CheckInterrupts
-          Return v20
+          Return v22
         ");
     }
 
@@ -4390,59 +4711,80 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          v3:NilClass = Const Value(nil)
-          v4:NilClass = Const Value(nil)
-          Jump bb3(v1, v2, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
           v8:NilClass = Const Value(nil)
-          v9:NilClass = Const Value(nil)
+          StoreField v6, :b@0x1001, v8
           v10:NilClass = Const Value(nil)
-          Jump bb3(v7, v8, v9, v10)
-        bb3(v12:BasicObject, v13:NilClass, v14:NilClass, v15:NilClass):
+          StoreField v6, :c@0x1002, v10
+          Jump bb3(v4)
+        bb3(v13:BasicObject):
           PatchPoint SingleRactorMode
-          v20:BasicObject = GetIvar v12, :@a
+          v18:BasicObject = GetIvar v13, :@a
           PatchPoint SingleRactorMode
-          v23:BasicObject = GetIvar v12, :@b
+          v21:BasicObject = GetIvar v13, :@b
           PatchPoint SingleRactorMode
-          v26:BasicObject = GetIvar v12, :@c
-          PatchPoint NoEPEscape(reverse_odd)
-          v38:ArrayExact = NewArray v20, v23, v26
+          v24:BasicObject = GetIvar v13, :@c
+          SetLocal :a, l0, EP@5, v18
+          SetLocal :b, l0, EP@4, v21
+          SetLocal :c, l0, EP@3, v24
+          v34:CPtr = GetEP 0
+          v35:BasicObject = LoadField v34, :a@0x1000
+          v37:CPtr = GetEP 0
+          v38:BasicObject = LoadField v37, :b@0x1001
+          v40:CPtr = GetEP 0
+          v41:BasicObject = LoadField v40, :c@0x1002
+          v43:ArrayExact = NewArray v35, v38, v41
           CheckInterrupts
-          Return v38
+          Return v43
 
         fn reverse_even@<compiled>:8:
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          v3:NilClass = Const Value(nil)
-          v4:NilClass = Const Value(nil)
-          v5:NilClass = Const Value(nil)
-          Jump bb3(v1, v2, v3, v4, v5)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v8:BasicObject = LoadArg :self@0
-          v9:NilClass = Const Value(nil)
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :a@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :b@0x1001, v8
           v10:NilClass = Const Value(nil)
-          v11:NilClass = Const Value(nil)
+          StoreField v6, :c@0x1002, v10
           v12:NilClass = Const Value(nil)
-          Jump bb3(v8, v9, v10, v11, v12)
-        bb3(v14:BasicObject, v15:NilClass, v16:NilClass, v17:NilClass, v18:NilClass):
+          StoreField v6, :d@0x1003, v12
+          Jump bb3(v4)
+        bb3(v15:BasicObject):
           PatchPoint SingleRactorMode
-          v23:BasicObject = GetIvar v14, :@a
+          v20:BasicObject = GetIvar v15, :@a
           PatchPoint SingleRactorMode
-          v26:BasicObject = GetIvar v14, :@b
+          v23:BasicObject = GetIvar v15, :@b
           PatchPoint SingleRactorMode
-          v29:BasicObject = GetIvar v14, :@c
+          v26:BasicObject = GetIvar v15, :@c
           PatchPoint SingleRactorMode
-          v32:BasicObject = GetIvar v14, :@d
-          PatchPoint NoEPEscape(reverse_even)
-          v46:ArrayExact = NewArray v23, v26, v29, v32
+          v29:BasicObject = GetIvar v15, :@d
+          SetLocal :a, l0, EP@6, v20
+          SetLocal :b, l0, EP@5, v23
+          SetLocal :c, l0, EP@4, v26
+          SetLocal :d, l0, EP@3, v29
+          v41:CPtr = GetEP 0
+          v42:BasicObject = LoadField v41, :a@0x1000
+          v44:CPtr = GetEP 0
+          v45:BasicObject = LoadField v44, :b@0x1001
+          v47:CPtr = GetEP 0
+          v48:BasicObject = LoadField v47, :c@0x1002
+          v50:CPtr = GetEP 0
+          v51:BasicObject = LoadField v50, :d@0x1003
+          v53:ArrayExact = NewArray v42, v45, v48, v51
           CheckInterrupts
-          Return v46
+          Return v53
         ");
     }
 
@@ -4457,24 +4799,26 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           CheckInterrupts
-          v17:CBool = IsNil v10
-          v18:NilClass = Const Value(nil)
-          CondBranch v17, bb4(v9, v18, v18), bb5()
+          v18:CBool = IsNil v14
+          v19:NilClass = Const Value(nil)
+          CondBranch v18, bb4(v9, v19), bb5()
         bb5():
-          v20:NotNil = RefineType v10, NotNil
-          v22:BasicObject = Send v20, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
-          Jump bb4(v9, v20, v22)
-        bb4(v24:BasicObject, v25:BasicObject, v26:BasicObject):
+          v21:NotNil = RefineType v14, NotNil
+          v23:BasicObject = Send v21, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
+          Jump bb4(v9, v23)
+        bb4(v25:BasicObject, v26:BasicObject):
           CheckInterrupts
           Return v26
         ");
@@ -4498,36 +4842,40 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           CheckInterrupts
-          v16:CBool = Test v10
-          v17:Falsy = RefineType v10, Falsy
-          CondBranch v16, bb6(), bb4(v9, v17)
+          v17:CBool = Test v14
+          v18:Falsy = RefineType v14, Falsy
+          CondBranch v17, bb6(), bb4(v9)
         bb6():
-          v19:Truthy = RefineType v10, Truthy
+          v20:Truthy = RefineType v14, Truthy
+          v23:CPtr = GetEP 0
+          v24:BasicObject = LoadField v23, :x@0x1000
           CheckInterrupts
-          v25:CBool[false] = IsNil v19
-          v26:NilClass = Const Value(nil)
-          CondBranch v25, bb5(v9, v26, v26), bb7()
+          v28:CBool = IsNil v24
+          v29:NilClass = Const Value(nil)
+          CondBranch v28, bb5(v9, v29), bb7()
         bb7():
-          v28:Truthy = RefineType v19, NotNil
-          v30:BasicObject = Send v28, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v31:NotNil = RefineType v24, NotNil
+          v33:BasicObject = Send v31, :itself # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v30
-        bb4(v35:BasicObject, v36:Falsy):
-          v40:Fixnum[4] = Const Value(4)
-          Jump bb5(v35, v36, v40)
-        bb5(v42:BasicObject, v43:Falsy, v44:Fixnum[4]):
+          Return v33
+        bb4(v38:BasicObject):
+          v42:Fixnum[4] = Const Value(4)
+          Jump bb5(v38, v42)
+        bb5(v44:BasicObject, v45:NilClass|Fixnum):
           CheckInterrupts
-          Return v44
+          Return v45
         ");
     }
 
@@ -4555,48 +4903,54 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :x@0x1000
           CheckInterrupts
-          v16:CBool = Test v10
-          v17:Falsy = RefineType v10, Falsy
-          CondBranch v16, bb7(), bb6(v9, v17)
+          v17:CBool = Test v14
+          v18:Falsy = RefineType v14, Falsy
+          CondBranch v17, bb7(), bb6(v9)
         bb7():
-          v19:Truthy = RefineType v10, Truthy
+          v20:Truthy = RefineType v14, Truthy
+          v23:CPtr = GetEP 0
+          v24:BasicObject = LoadField v23, :x@0x1000
           CheckInterrupts
-          v24:CBool[true] = Test v19
-          v25 = RefineType v19, Falsy
-          CondBranch v24, bb8(), bb5(v9, v25)
+          v27:CBool = Test v24
+          v28:Falsy = RefineType v24, Falsy
+          CondBranch v27, bb8(), bb5(v9)
         bb8():
-          v27:Truthy = RefineType v19, Truthy
+          v30:Truthy = RefineType v24, Truthy
+          v33:CPtr = GetEP 0
+          v34:BasicObject = LoadField v33, :x@0x1000
           CheckInterrupts
-          v32:CBool[true] = Test v27
-          v33 = RefineType v27, Falsy
-          CondBranch v32, bb9(), bb4(v9, v33)
+          v37:CBool = Test v34
+          v38:Falsy = RefineType v34, Falsy
+          CondBranch v37, bb9(), bb4(v9)
         bb9():
-          v35:Truthy = RefineType v27, Truthy
-          v38:Fixnum[3] = Const Value(3)
+          v40:Truthy = RefineType v34, Truthy
+          v43:Fixnum[3] = Const Value(3)
           CheckInterrupts
-          Return v38
-        bb4(v63, v64):
-          v68 = Const Value(4)
+          Return v43
+        bb4(v66:BasicObject):
+          v70:Fixnum[4] = Const Value(4)
           CheckInterrupts
-          Return v68
-        bb5(v53, v54):
-          v58 = Const Value(5)
+          Return v70
+        bb5(v57:BasicObject):
+          v61:Fixnum[5] = Const Value(5)
           CheckInterrupts
-          Return v58
-        bb6(v43:BasicObject, v44:Falsy):
-          v48:Fixnum[6] = Const Value(6)
+          Return v61
+        bb6(v48:BasicObject):
+          v52:Fixnum[6] = Const Value(6)
           CheckInterrupts
-          Return v48
+          Return v52
         ");
     }
 
@@ -4608,25 +4962,26 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :arg@0x1000
-          v4:BasicObject = LoadField v2, :exception@0x1001
-          v5:BasicObject = LoadField v2, :<empty>@0x1002
-          Jump bb3(v1, v3, v4, v5)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v8:BasicObject = LoadArg :self@0
-          v9:BasicObject = LoadArg :arg@1
-          v10:BasicObject = LoadArg :exception@2
-          v11:CPtr = GetEP 0
-          v12:BasicObject = LoadField v11, :<empty>@0x1003
-          Jump bb3(v8, v9, v10, v12)
-        bb3(v14:BasicObject, v15:BasicObject, v16:BasicObject, v17:BasicObject):
-          v21:Float = InvokeBuiltin rb_f_float, v14, v15, v16
-          Jump bb4(v14, v15, v16, v17, v21)
-        bb4(v23:BasicObject, v24:BasicObject, v25:BasicObject, v26:BasicObject, v27:Float):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :arg@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :arg@0x1000, v5
+          v8:BasicObject = LoadArg :exception@2
+          StoreField v6, :exception@0x1001, v8
+          v10:BasicObject = LoadField v6, :<empty>@0x1002
+          Jump bb3(v4)
+        bb3(v12:BasicObject):
+          v16:CPtr = GetEP 0
+          v17:BasicObject = LoadField v16, :arg@0x1000
+          v18:BasicObject = LoadField v16, :exception@0x1001
+          v19:Float = InvokeBuiltin rb_f_float, v12, v17, v18
+          Jump bb4(v12, v19)
+        bb4(v21:BasicObject, v22:Float):
           CheckInterrupts
-          Return v27
+          Return v22
         ");
     }
 
@@ -4644,11 +4999,12 @@ pub(crate) mod hir_build_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v10:Class = InvokeBuiltin leaf <inline_expr>, v6
-          Jump bb4(v6, v10)
-        bb4(v12:BasicObject, v13:Class):
+          v10:CPtr = GetEP 0
+          v11:Class = InvokeBuiltin leaf <inline_expr>, v6
+          Jump bb4(v6, v11)
+        bb4(v13:BasicObject, v14:Class):
           CheckInterrupts
-          Return v13
+          Return v14
         ");
     }
 
@@ -4663,52 +5019,59 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :name@0x1000
-          v4:BasicObject = LoadField v2, :encoding@0x1001
-          v5:BasicObject = LoadField v2, :<empty>@0x1002
-          v6:BasicObject = LoadField v2, :block@0x1003
-          v7:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6, v7)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v10:BasicObject = LoadArg :self@0
-          v11:BasicObject = LoadArg :name@1
-          v12:BasicObject = LoadArg :encoding@2
-          v13:CPtr = GetEP 0
-          v14:BasicObject = LoadField v13, :<empty>@0x1003
-          v15:BasicObject = LoadArg :block@3
-          v16:NilClass = Const Value(nil)
-          Jump bb3(v10, v11, v12, v14, v15, v16)
-        bb3(v18:BasicObject, v19:BasicObject, v20:BasicObject, v21:BasicObject, v22:BasicObject, v23:NilClass):
-          v27:BasicObject = InvokeBuiltin dir_s_open, v18, v19, v20
-          PatchPoint NoEPEscape(open)
-          v35:CPtr = GetEP 0
-          v36:CUInt64 = LoadField v35, :VM_ENV_DATA_INDEX_FLAGS@0x1004
-          v37:CBool = IsBlockParamModified v36
-          CondBranch v37, bb5(), bb6()
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :name@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :name@0x1000, v5
+          v8:BasicObject = LoadArg :encoding@2
+          StoreField v6, :encoding@0x1001, v8
+          v10:BasicObject = LoadField v6, :<empty>@0x1002
+          v11:BasicObject = LoadArg :block@3
+          StoreField v6, :block@0x1003, v11
+          v13:NilClass = Const Value(nil)
+          StoreField v6, :dir@0x1004, v13
+          Jump bb3(v4)
+        bb3(v16:BasicObject):
+          v20:CPtr = GetEP 0
+          v21:BasicObject = LoadField v20, :name@0x1000
+          v22:BasicObject = LoadField v20, :encoding@0x1001
+          v23:BasicObject = InvokeBuiltin dir_s_open, v16, v21, v22
+          SetLocal :dir, l0, EP@3, v23
+          v29:CPtr = GetEP 0
+          v30:CUInt64 = LoadField v29, :VM_ENV_DATA_INDEX_FLAGS@0x1005
+          v31:CBool = IsBlockParamModified v30
+          CondBranch v31, bb5(), bb6()
         bb5():
-          v39:BasicObject = LoadField v35, :block@0x1005
-          Jump bb7(v39, v39)
+          v33:BasicObject = LoadField v29, :block@0x1003
+          Jump bb7(v33)
         bb6():
-          v41:CInt64 = LoadField v35, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
-          v42:CInt64 = GuardAnyBitSet v41, CUInt64(1)
-          v43:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
-          Jump bb7(v43, v22)
-        bb7(v33:BasicObject, v34:BasicObject):
+          v35:CInt64 = LoadField v29, :VM_ENV_DATA_INDEX_SPECVAL@0x1006
+          v36:CInt64 = GuardAnyBitSet v35, CUInt64(1)
+          v37:ObjectSubclass[BlockParamProxy] = Const Value(VALUE(0x1008))
+          Jump bb7(v37)
+        bb7(v28:BasicObject):
           CheckInterrupts
-          v47:CBool = Test v33
-          v48:Falsy = RefineType v33, Falsy
-          CondBranch v47, bb8(), bb4(v18, v19, v20, v21, v34, v27)
+          v41:CBool = Test v28
+          v42:Falsy = RefineType v28, Falsy
+          CondBranch v41, bb8(), bb4(v16)
         bb8():
-          v50:Truthy = RefineType v33, Truthy
-          v54:BasicObject = InvokeBlock, v27 # SendFallbackReason: InvokeBlock: not yet specialized
-          v57:BasicObject = InvokeBuiltin dir_s_close, v18, v27
+          v44:Truthy = RefineType v28, Truthy
+          v47:CPtr = GetEP 0
+          v48:BasicObject = LoadField v47, :dir@0x1004
+          v50:BasicObject = InvokeBlock, v48 # SendFallbackReason: InvokeBlock: not yet specialized
+          v53:CPtr = GetEP 0
+          v54:BasicObject = LoadField v53, :dir@0x1004
+          v55:BasicObject = InvokeBuiltin dir_s_close, v16, v54
           CheckInterrupts
-          Return v54
-        bb4(v63:BasicObject, v64:BasicObject, v65:BasicObject, v66:BasicObject, v67:BasicObject, v68:BasicObject):
+          Return v50
+        bb4(v61:BasicObject):
+          v65:CPtr = GetEP 0
+          v66:BasicObject = LoadField v65, :dir@0x1004
           CheckInterrupts
-          Return v68
+          Return v66
         ");
     }
 
@@ -4728,11 +5091,12 @@ pub(crate) mod hir_build_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v10:BasicObject = InvokeBuiltin gc_enable, v6
-          Jump bb4(v6, v10)
-        bb4(v12:BasicObject, v13:BasicObject):
+          v10:CPtr = GetEP 0
+          v11:BasicObject = InvokeBuiltin gc_enable, v6
+          Jump bb4(v6, v11)
+        bb4(v13:BasicObject, v14:BasicObject):
           CheckInterrupts
-          Return v13
+          Return v14
         ");
     }
 
@@ -4746,24 +5110,28 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :full_mark@0x1000
-          v4:BasicObject = LoadField v2, :immediate_mark@0x1001
-          v5:BasicObject = LoadField v2, :immediate_sweep@0x1002
-          v6:BasicObject = LoadField v2, :<empty>@0x1003
-          Jump bb3(v1, v3, v4, v5, v6)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v9:BasicObject = LoadArg :self@0
-          v10:BasicObject = LoadArg :full_mark@1
-          v11:BasicObject = LoadArg :immediate_mark@2
-          v12:BasicObject = LoadArg :immediate_sweep@3
-          v13:CPtr = GetEP 0
-          v14:BasicObject = LoadField v13, :<empty>@0x1004
-          Jump bb3(v9, v10, v11, v12, v14)
-        bb3(v16:BasicObject, v17:BasicObject, v18:BasicObject, v19:BasicObject, v20:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :full_mark@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :full_mark@0x1000, v5
+          v8:BasicObject = LoadArg :immediate_mark@2
+          StoreField v6, :immediate_mark@0x1001, v8
+          v10:BasicObject = LoadArg :immediate_sweep@3
+          StoreField v6, :immediate_sweep@0x1002, v10
+          v12:BasicObject = LoadField v6, :<empty>@0x1003
+          Jump bb3(v4)
+        bb3(v14:BasicObject):
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :full_mark@0x1000
+          v21:CPtr = GetEP 0
+          v22:BasicObject = LoadField v21, :immediate_mark@0x1001
+          v24:CPtr = GetEP 0
+          v25:BasicObject = LoadField v24, :immediate_sweep@0x1002
           v27:FalseClass = Const Value(false)
-          v29:BasicObject = InvokeBuiltin gc_start_internal, v16, v17, v18, v19, v27
+          v29:BasicObject = InvokeBuiltin gc_start_internal, v14, v19, v22, v25, v27
           CheckInterrupts
           Return v29
         ");
@@ -4784,11 +5152,12 @@ pub(crate) mod hir_build_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v10:StringExact = InvokeBuiltin leaf <inline_expr>, v6
-          Jump bb4(v6, v10)
-        bb4(v12:BasicObject, v13:StringExact):
+          v10:CPtr = GetEP 0
+          v11:StringExact = InvokeBuiltin leaf <inline_expr>, v6
+          Jump bb4(v6, v11)
+        bb4(v13:BasicObject, v14:StringExact):
           CheckInterrupts
-          Return v13
+          Return v14
         ");
     }
 
@@ -4807,11 +5176,12 @@ pub(crate) mod hir_build_tests {
           v4:BasicObject = LoadArg :self@0
           Jump bb3(v4)
         bb3(v6:BasicObject):
-          v10:StringExact = InvokeBuiltin leaf <inline_expr>, v6
-          Jump bb4(v6, v10)
-        bb4(v12:BasicObject, v13:StringExact):
+          v10:CPtr = GetEP 0
+          v11:StringExact = InvokeBuiltin leaf <inline_expr>, v6
+          Jump bb4(v6, v11)
+        bb4(v13:BasicObject, v14:StringExact):
           CheckInterrupts
-          Return v13
+          Return v14
         ");
     }
 
@@ -4826,32 +5196,34 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          Jump bb3(v1, v3)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v6:BasicObject = LoadArg :self@0
-          v7:BasicObject = LoadArg :x@1
-          Jump bb3(v6, v7)
-        bb3(v9:BasicObject, v10:BasicObject):
-          v14:NilClass = Const Value(nil)
-          v17:Fixnum[0] = Const Value(0)
-          v19:Fixnum[1] = Const Value(1)
-          v22:BasicObject = Send v10, :[], v17, v19 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
+          v13:NilClass = Const Value(nil)
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:Fixnum[0] = Const Value(0)
+          v20:Fixnum[1] = Const Value(1)
+          v23:BasicObject = Send v16, :[], v18, v20 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          v26:CBool = Test v22
-          v27:Truthy = RefineType v22, Truthy
-          CondBranch v26, bb4(v9, v10, v14, v10, v17, v19, v27), bb5()
-        bb4(v41:BasicObject, v42:BasicObject, v43:NilClass, v44:BasicObject, v45:Fixnum[0], v46:Fixnum[1], v47:Truthy):
+          v27:CBool = Test v23
+          v28:Truthy = RefineType v23, Truthy
+          CondBranch v27, bb4(v9, v13, v16, v18, v20, v28), bb5()
+        bb4(v42:BasicObject, v43:NilClass, v44:BasicObject, v45:Fixnum[0], v46:Fixnum[1], v47:Truthy):
           CheckInterrupts
           Return v47
         bb5():
-          v29:Falsy = RefineType v22, Falsy
-          v32:Fixnum[2] = Const Value(2)
-          v35:BasicObject = Send v10, :[]=, v17, v19, v32 # SendFallbackReason: Uncategorized(opt_send_without_block)
+          v30:Falsy = RefineType v23, Falsy
+          v33:Fixnum[2] = Const Value(2)
+          v36:BasicObject = Send v16, :[]=, v18, v20, v33 # SendFallbackReason: Uncategorized(opt_send_without_block)
           CheckInterrupts
-          Return v32
+          Return v33
         ");
     }
 
@@ -5075,20 +5447,24 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :x@0x1000
-          v4:BasicObject = LoadField v2, :y@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :x@1
-          v9:BasicObject = LoadArg :y@2
-          Jump bb3(v7, v8, v9)
-        bb3(v11:BasicObject, v12:BasicObject, v13:BasicObject):
-          v19:BasicObject = InvokeBlock, v12, v13 # SendFallbackReason: InvokeBlock: not yet specialized
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :x@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :x@0x1000, v5
+          v8:BasicObject = LoadArg :y@2
+          StoreField v6, :y@0x1001, v8
+          Jump bb3(v4)
+        bb3(v11:BasicObject):
+          v15:CPtr = GetEP 0
+          v16:BasicObject = LoadField v15, :x@0x1000
+          v18:CPtr = GetEP 0
+          v19:BasicObject = LoadField v18, :y@0x1001
+          v21:BasicObject = InvokeBlock, v16, v19 # SendFallbackReason: InvokeBlock: not yet specialized
           CheckInterrupts
-          Return v19
+          Return v21
         ");
     }
 
@@ -5105,30 +5481,33 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          v4:NilClass = Const Value(nil)
-          v5:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v8:BasicObject = LoadArg :self@0
-          v9:BasicObject = LoadArg :o@1
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :a@0x1001, v8
           v10:NilClass = Const Value(nil)
-          v11:NilClass = Const Value(nil)
-          Jump bb3(v8, v9, v10, v11)
-        bb3(v13:BasicObject, v14:BasicObject, v15:NilClass, v16:NilClass):
-          v22:ArrayExact = GuardType v14, ArrayExact
-          v23:CInt64 = ArrayLength v22
-          v24:CInt64[2] = Const CInt64(2)
-          v25:CInt64 = GuardGreaterEq v23, v24
-          v26:CInt64[1] = Const CInt64(1)
-          v27:BasicObject = ArrayAref v22, v26
-          v28:CInt64[0] = Const CInt64(0)
-          v29:BasicObject = ArrayAref v22, v28
-          PatchPoint NoEPEscape(test)
+          StoreField v6, :b@0x1002, v10
+          Jump bb3(v4)
+        bb3(v13:BasicObject):
+          v17:CPtr = GetEP 0
+          v18:BasicObject = LoadField v17, :o@0x1000
+          v21:ArrayExact = GuardType v18, ArrayExact
+          v22:CInt64 = ArrayLength v21
+          v23:CInt64[2] = Const CInt64(2)
+          v24:CInt64 = GuardGreaterEq v22, v23
+          v25:CInt64[1] = Const CInt64(1)
+          v26:BasicObject = ArrayAref v21, v25
+          v27:CInt64[0] = Const CInt64(0)
+          v28:BasicObject = ArrayAref v21, v27
+          SetLocal :a, l0, EP@4, v28
+          SetLocal :b, l0, EP@3, v26
           CheckInterrupts
-          Return v14
+          Return v18
         ");
     }
 
@@ -5145,19 +5524,21 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          v4:NilClass = Const Value(nil)
-          v5:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v8:BasicObject = LoadArg :self@0
-          v9:BasicObject = LoadArg :o@1
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :a@0x1001, v8
           v10:NilClass = Const Value(nil)
-          v11:NilClass = Const Value(nil)
-          Jump bb3(v8, v9, v10, v11)
-        bb3(v13:BasicObject, v14:BasicObject, v15:NilClass, v16:NilClass):
+          StoreField v6, :b@0x1002, v10
+          Jump bb3(v4)
+        bb3(v13:BasicObject):
+          v17:CPtr = GetEP 0
+          v18:BasicObject = LoadField v17, :o@0x1000
           SideExit UnhandledYARVInsn(expandarray)
         ");
     }
@@ -5175,21 +5556,23 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :o@0x1000
-          v4:NilClass = Const Value(nil)
-          v5:NilClass = Const Value(nil)
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v1, v3, v4, v5, v6)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v9:BasicObject = LoadArg :self@0
-          v10:BasicObject = LoadArg :o@1
-          v11:NilClass = Const Value(nil)
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :o@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :o@0x1000, v5
+          v8:NilClass = Const Value(nil)
+          StoreField v6, :a@0x1001, v8
+          v10:NilClass = Const Value(nil)
+          StoreField v6, :b@0x1002, v10
           v12:NilClass = Const Value(nil)
-          v13:NilClass = Const Value(nil)
-          Jump bb3(v9, v10, v11, v12, v13)
-        bb3(v15:BasicObject, v16:BasicObject, v17:NilClass, v18:NilClass, v19:NilClass):
+          StoreField v6, :c@0x1003, v12
+          Jump bb3(v4)
+        bb3(v15:BasicObject):
+          v19:CPtr = GetEP 0
+          v20:BasicObject = LoadField v19, :o@0x1000
           SideExit UnhandledYARVInsn(expandarray)
         ");
     }
@@ -5205,32 +5588,35 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :kw@0x1000
-          v4:BasicObject = LoadField v2, :<empty>@0x1001
-          Jump bb3(v1, v3, v4)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v7:BasicObject = LoadArg :self@0
-          v8:BasicObject = LoadArg :kw@1
-          v9:CPtr = GetEP 0
-          v10:BasicObject = LoadField v9, :<empty>@0x1002
-          Jump bb3(v7, v8, v10)
-        bb3(v12:BasicObject, v13:BasicObject, v14:BasicObject):
-          v17:BoolExact = FixnumBitCheck v14, 0
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :kw@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :kw@0x1000, v5
+          v8:BasicObject = LoadField v6, :<empty>@0x1001
+          Jump bb3(v4)
+        bb3(v10:BasicObject):
+          v13:CPtr = GetEP 0
+          v14:BasicObject = LoadField v13, :<empty>@0x1001
+          v15:BoolExact = FixnumBitCheck v14, 0
           CheckInterrupts
-          v20:CBool = Test v17
-          v21:TrueClass = RefineType v17, Truthy
-          CondBranch v20, bb4(v12, v13, v14), bb5()
+          v18:CBool = Test v15
+          v19:TrueClass = RefineType v15, Truthy
+          CondBranch v18, bb4(v10), bb5()
         bb5():
-          v23:FalseClass = RefineType v17, Falsy
+          v21:FalseClass = RefineType v15, Falsy
+          v23:Fixnum[1] = Const Value(1)
           v25:Fixnum[1] = Const Value(1)
-          v27:Fixnum[1] = Const Value(1)
-          v30:BasicObject = Send v25, :+, v27 # SendFallbackReason: Uncategorized(opt_plus)
-          Jump bb4(v12, v30, v14)
-        bb4(v33:BasicObject, v34:BasicObject, v35:BasicObject):
+          v28:BasicObject = Send v23, :+, v25 # SendFallbackReason: Uncategorized(opt_plus)
+          SetLocal :kw, l0, EP@4, v28
+          Jump bb4(v10)
+        bb4(v32:BasicObject):
+          v36:CPtr = GetEP 0
+          v37:BasicObject = LoadField v36, :kw@0x1000
           CheckInterrupts
-          Return v34
+          Return v37
         ");
     }
 
@@ -5251,82 +5637,80 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:CPtr = LoadSP
-          v3:BasicObject = LoadField v2, :k1@0x1000
-          v4:BasicObject = LoadField v2, :k2@0x1001
-          v5:BasicObject = LoadField v2, :k3@0x1002
-          v6:BasicObject = LoadField v2, :k4@0x1003
-          v7:BasicObject = LoadField v2, :k5@0x1004
-          v8:BasicObject = LoadField v2, :k6@0x1005
-          v9:BasicObject = LoadField v2, :k7@0x1006
-          v10:BasicObject = LoadField v2, :k8@0x1007
-          v11:BasicObject = LoadField v2, :k9@0x1008
-          v12:BasicObject = LoadField v2, :k10@0x1009
-          v13:BasicObject = LoadField v2, :k11@0x100a
-          v14:BasicObject = LoadField v2, :k12@0x100b
-          v15:BasicObject = LoadField v2, :k13@0x100c
-          v16:BasicObject = LoadField v2, :k14@0x100d
-          v17:BasicObject = LoadField v2, :k15@0x100e
-          v18:BasicObject = LoadField v2, :k16@0x100f
-          v19:BasicObject = LoadField v2, :k17@0x1010
-          v20:BasicObject = LoadField v2, :k18@0x1011
-          v21:BasicObject = LoadField v2, :k19@0x1012
-          v22:BasicObject = LoadField v2, :k20@0x1013
-          v23:BasicObject = LoadField v2, :k21@0x1014
-          v24:BasicObject = LoadField v2, :k22@0x1015
-          v25:BasicObject = LoadField v2, :k23@0x1016
-          v26:BasicObject = LoadField v2, :k24@0x1017
-          v27:BasicObject = LoadField v2, :k25@0x1018
-          v28:BasicObject = LoadField v2, :k26@0x1019
-          v29:BasicObject = LoadField v2, :k27@0x101a
-          v30:BasicObject = LoadField v2, :k28@0x101b
-          v31:BasicObject = LoadField v2, :k29@0x101c
-          v32:BasicObject = LoadField v2, :k30@0x101d
-          v33:BasicObject = LoadField v2, :k31@0x101e
-          v34:BasicObject = LoadField v2, :k32@0x101f
-          v35:BasicObject = LoadField v2, :k33@0x1020
-          v36:BasicObject = LoadField v2, :<empty>@0x1021
-          Jump bb3(v1, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25, v26, v27, v28, v29, v30, v31, v32, v33, v34, v35, v36)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v39:BasicObject = LoadArg :self@0
-          v40:BasicObject = LoadArg :k1@1
-          v41:BasicObject = LoadArg :k2@2
-          v42:BasicObject = LoadArg :k3@3
-          v43:BasicObject = LoadArg :k4@4
-          v44:BasicObject = LoadArg :k5@5
-          v45:BasicObject = LoadArg :k6@6
-          v46:BasicObject = LoadArg :k7@7
-          v47:BasicObject = LoadArg :k8@8
-          v48:BasicObject = LoadArg :k9@9
-          v49:BasicObject = LoadArg :k10@10
-          v50:BasicObject = LoadArg :k11@11
-          v51:BasicObject = LoadArg :k12@12
-          v52:BasicObject = LoadArg :k13@13
-          v53:BasicObject = LoadArg :k14@14
-          v54:BasicObject = LoadArg :k15@15
-          v55:BasicObject = LoadArg :k16@16
-          v56:BasicObject = LoadArg :k17@17
-          v57:BasicObject = LoadArg :k18@18
-          v58:BasicObject = LoadArg :k19@19
-          v59:BasicObject = LoadArg :k20@20
-          v60:BasicObject = LoadArg :k21@21
-          v61:BasicObject = LoadArg :k22@22
-          v62:BasicObject = LoadArg :k23@23
-          v63:BasicObject = LoadArg :k24@24
-          v64:BasicObject = LoadArg :k25@25
-          v65:BasicObject = LoadArg :k26@26
-          v66:BasicObject = LoadArg :k27@27
-          v67:BasicObject = LoadArg :k28@28
-          v68:BasicObject = LoadArg :k29@29
-          v69:BasicObject = LoadArg :k30@30
-          v70:BasicObject = LoadArg :k31@31
-          v71:BasicObject = LoadArg :k32@32
-          v72:BasicObject = LoadArg :k33@33
-          v73:CPtr = GetEP 0
-          v74:BasicObject = LoadField v73, :<empty>@0x1022
-          Jump bb3(v39, v40, v41, v42, v43, v44, v45, v46, v47, v48, v49, v50, v51, v52, v53, v54, v55, v56, v57, v58, v59, v60, v61, v62, v63, v64, v65, v66, v67, v68, v69, v70, v71, v72, v74)
-        bb3(v76:BasicObject, v77:BasicObject, v78:BasicObject, v79:BasicObject, v80:BasicObject, v81:BasicObject, v82:BasicObject, v83:BasicObject, v84:BasicObject, v85:BasicObject, v86:BasicObject, v87:BasicObject, v88:BasicObject, v89:BasicObject, v90:BasicObject, v91:BasicObject, v92:BasicObject, v93:BasicObject, v94:BasicObject, v95:BasicObject, v96:BasicObject, v97:BasicObject, v98:BasicObject, v99:BasicObject, v100:BasicObject, v101:BasicObject, v102:BasicObject, v103:BasicObject, v104:BasicObject, v105:BasicObject, v106:BasicObject, v107:BasicObject, v108:BasicObject, v109:BasicObject, v110:BasicObject):
+          v4:BasicObject = LoadArg :self@0
+          v5:BasicObject = LoadArg :k1@1
+          v6:CPtr = GetEP 0
+          StoreField v6, :k1@0x1000, v5
+          v8:BasicObject = LoadArg :k2@2
+          StoreField v6, :k2@0x1001, v8
+          v10:BasicObject = LoadArg :k3@3
+          StoreField v6, :k3@0x1002, v10
+          v12:BasicObject = LoadArg :k4@4
+          StoreField v6, :k4@0x1003, v12
+          v14:BasicObject = LoadArg :k5@5
+          StoreField v6, :k5@0x1004, v14
+          v16:BasicObject = LoadArg :k6@6
+          StoreField v6, :k6@0x1005, v16
+          v18:BasicObject = LoadArg :k7@7
+          StoreField v6, :k7@0x1006, v18
+          v20:BasicObject = LoadArg :k8@8
+          StoreField v6, :k8@0x1007, v20
+          v22:BasicObject = LoadArg :k9@9
+          StoreField v6, :k9@0x1008, v22
+          v24:BasicObject = LoadArg :k10@10
+          StoreField v6, :k10@0x1009, v24
+          v26:BasicObject = LoadArg :k11@11
+          StoreField v6, :k11@0x100a, v26
+          v28:BasicObject = LoadArg :k12@12
+          StoreField v6, :k12@0x100b, v28
+          v30:BasicObject = LoadArg :k13@13
+          StoreField v6, :k13@0x100c, v30
+          v32:BasicObject = LoadArg :k14@14
+          StoreField v6, :k14@0x100d, v32
+          v34:BasicObject = LoadArg :k15@15
+          StoreField v6, :k15@0x100e, v34
+          v36:BasicObject = LoadArg :k16@16
+          StoreField v6, :k16@0x100f, v36
+          v38:BasicObject = LoadArg :k17@17
+          StoreField v6, :k17@0x1010, v38
+          v40:BasicObject = LoadArg :k18@18
+          StoreField v6, :k18@0x1011, v40
+          v42:BasicObject = LoadArg :k19@19
+          StoreField v6, :k19@0x1012, v42
+          v44:BasicObject = LoadArg :k20@20
+          StoreField v6, :k20@0x1013, v44
+          v46:BasicObject = LoadArg :k21@21
+          StoreField v6, :k21@0x1014, v46
+          v48:BasicObject = LoadArg :k22@22
+          StoreField v6, :k22@0x1015, v48
+          v50:BasicObject = LoadArg :k23@23
+          StoreField v6, :k23@0x1016, v50
+          v52:BasicObject = LoadArg :k24@24
+          StoreField v6, :k24@0x1017, v52
+          v54:BasicObject = LoadArg :k25@25
+          StoreField v6, :k25@0x1018, v54
+          v56:BasicObject = LoadArg :k26@26
+          StoreField v6, :k26@0x1019, v56
+          v58:BasicObject = LoadArg :k27@27
+          StoreField v6, :k27@0x101a, v58
+          v60:BasicObject = LoadArg :k28@28
+          StoreField v6, :k28@0x101b, v60
+          v62:BasicObject = LoadArg :k29@29
+          StoreField v6, :k29@0x101c, v62
+          v64:BasicObject = LoadArg :k30@30
+          StoreField v6, :k30@0x101d, v64
+          v66:BasicObject = LoadArg :k31@31
+          StoreField v6, :k31@0x101e, v66
+          v68:BasicObject = LoadArg :k32@32
+          StoreField v6, :k32@0x101f, v68
+          v70:BasicObject = LoadArg :k33@33
+          StoreField v6, :k33@0x1020, v70
+          v72:BasicObject = LoadField v6, :<empty>@0x1021
+          Jump bb3(v4)
+        bb3(v74:BasicObject):
           SideExit TooManyKeywordParameters
         ");
     }
@@ -5338,47 +5722,56 @@ pub(crate) mod hir_build_tests {
         bb1():
           EntryPoint interpreter
           v1:BasicObject = LoadSelf
-          v2:NilClass = Const Value(nil)
-          Jump bb3(v1, v2)
+          Jump bb3(v1)
         bb2():
           EntryPoint JIT(0)
-          v5:BasicObject = LoadArg :self@0
-          v6:NilClass = Const Value(nil)
-          Jump bb3(v5, v6)
-        bb3(v8:BasicObject, v9:NilClass):
+          v4:BasicObject = LoadArg :self@0
+          v5:NilClass = Const Value(nil)
+          v6:CPtr = GetEP 0
+          StoreField v6, :i@0x1000, v5
+          Jump bb3(v4)
+        bb3(v9:BasicObject):
           v13:NilClass = Const Value(nil)
           v15:TrueClass|NilClass = Defined yield, v13
           v17:CBool = Test v15
           v18:NilClass = RefineType v15, Falsy
-          CondBranch v17, bb9(), bb4(v8, v9)
+          CondBranch v17, bb9(), bb4(v9)
         bb9():
           v20:TrueClass = RefineType v15, Truthy
-          Jump bb6(v8, v9)
-        bb6(v30:BasicObject, v31:NilClass):
-          v35:Fixnum[0] = Const Value(0)
-          Jump bb8(v30, v35)
-        bb8(v48:BasicObject, v49:Fixnum):
-          v52:BoolExact = InvokeBuiltin rb_jit_ary_at_end, v48, v49
+          Jump bb6(v9)
+        bb6(v30:BasicObject):
+          v34:Fixnum[0] = Const Value(0)
+          SetLocal :i, l0, EP@3, v34
+          Jump bb8(v30)
+        bb8(v47:BasicObject):
+          v50:CPtr = GetEP 0
+          v51:BasicObject = LoadField v50, :i@0x1000
+          v52:BoolExact = InvokeBuiltin rb_jit_ary_at_end, v47, v51
           v54:CBool = Test v52
           v55:FalseClass = RefineType v52, Falsy
-          CondBranch v54, bb10(), bb7(v48, v49)
+          CondBranch v54, bb10(), bb7(v47)
         bb10():
           v57:TrueClass = RefineType v52, Truthy
           v59:NilClass = Const Value(nil)
           CheckInterrupts
-          Return v48
-        bb7(v67:BasicObject, v68:Fixnum):
-          v72:BasicObject = InvokeBuiltin rb_jit_ary_at, v67, v68
-          v74:BasicObject = InvokeBlock, v72 # SendFallbackReason: InvokeBlock: not yet specialized
-          v78:Fixnum = InvokeBuiltin rb_jit_fixnum_inc, v67, v68
-          PatchPoint NoEPEscape(each)
-          Jump bb8(v67, v78)
-        bb4(v23:BasicObject, v24:NilClass):
+          Return v47
+        bb7(v67:BasicObject):
+          v71:CPtr = GetEP 0
+          v72:BasicObject = LoadField v71, :i@0x1000
+          v73:BasicObject = InvokeBuiltin rb_jit_ary_at, v67, v72
+          v75:BasicObject = InvokeBlock, v73 # SendFallbackReason: InvokeBlock: not yet specialized
+          v79:CPtr = GetEP 0
+          v80:BasicObject = LoadField v79, :i@0x1000
+          v81:Fixnum = InvokeBuiltin rb_jit_fixnum_inc, v67, v80
+          SetLocal :i, l0, EP@3, v81
+          Jump bb8(v67)
+        bb4(v23:BasicObject):
+          v27:CPtr = GetEP 0
           v28:BasicObject = InvokeBuiltin <inline_expr>, v23
-          Jump bb5(v23, v24, v28)
-        bb5(v40:BasicObject, v41:NilClass, v42:BasicObject):
+          Jump bb5(v23, v28)
+        bb5(v40:BasicObject, v41:BasicObject):
           CheckInterrupts
-          Return v42
+          Return v41
         ");
     }
 
@@ -5539,20 +5932,22 @@ pub(crate) mod hir_build_tests {
       bb1():
         EntryPoint interpreter
         v1:BasicObject = LoadSelf
-        v2:CPtr = LoadSP
-        v3:BasicObject = LoadField v2, :a@0x1000
-        Jump bb3(v1, v3)
+        Jump bb3(v1)
       bb2():
         EntryPoint JIT(0)
-        v6:BasicObject = LoadArg :self@0
-        v7:BasicObject = LoadArg :a@1
-        Jump bb3(v6, v7)
-      bb3(v9:BasicObject, v10:BasicObject):
-        v15:RegexpExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-        v18:BasicObject = Send v10, :=~, v15 # SendFallbackReason: Uncategorized(opt_regexpmatch2)
-        v22:StringExact|NilClass = GetSpecialNumber 2
+        v4:BasicObject = LoadArg :self@0
+        v5:BasicObject = LoadArg :a@1
+        v6:CPtr = GetEP 0
+        StoreField v6, :a@0x1000, v5
+        Jump bb3(v4)
+      bb3(v9:BasicObject):
+        v13:CPtr = GetEP 0
+        v14:BasicObject = LoadField v13, :a@0x1000
+        v16:RegexpExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+        v19:BasicObject = Send v14, :=~, v16 # SendFallbackReason: Uncategorized(opt_regexpmatch2)
+        v23:StringExact|NilClass = GetSpecialNumber 2
         CheckInterrupts
-        Return v22
+        Return v23
       ");
     }
 
@@ -5569,20 +5964,22 @@ pub(crate) mod hir_build_tests {
       bb1():
         EntryPoint interpreter
         v1:BasicObject = LoadSelf
-        v2:CPtr = LoadSP
-        v3:BasicObject = LoadField v2, :a@0x1000
-        Jump bb3(v1, v3)
+        Jump bb3(v1)
       bb2():
         EntryPoint JIT(0)
-        v6:BasicObject = LoadArg :self@0
-        v7:BasicObject = LoadArg :a@1
-        Jump bb3(v6, v7)
-      bb3(v9:BasicObject, v10:BasicObject):
-        v15:RegexpExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
-        v18:BasicObject = Send v10, :=~, v15 # SendFallbackReason: Uncategorized(opt_regexpmatch2)
-        v22:StringExact|NilClass = GetSpecialSymbol LastMatch
+        v4:BasicObject = LoadArg :self@0
+        v5:BasicObject = LoadArg :a@1
+        v6:CPtr = GetEP 0
+        StoreField v6, :a@0x1000, v5
+        Jump bb3(v4)
+      bb3(v9:BasicObject):
+        v13:CPtr = GetEP 0
+        v14:BasicObject = LoadField v13, :a@0x1000
+        v16:RegexpExact[VALUE(0x1008)] = Const Value(VALUE(0x1008))
+        v19:BasicObject = Send v14, :=~, v16 # SendFallbackReason: Uncategorized(opt_regexpmatch2)
+        v23:StringExact|NilClass = GetSpecialSymbol LastMatch
         CheckInterrupts
-        Return v22
+        Return v23
       ");
     }
 }

--- a/zjit/src/invariants.rs
+++ b/zjit/src/invariants.rs
@@ -224,10 +224,7 @@ pub extern "C" fn rb_zjit_invalidate_no_ep_escape(iseq: IseqPtr) {
             compile_patch_points!(cb, patch_points, EP, "EP is escaped: {}", iseq_name(iseq));
 
             // Also invalidate the ISEQ version so the method falls back to the
-            // interpreter on the next call. NoEPEscape PatchPoint side exits use
-            // without_locals() and don't save locals to the frame. If a PatchPoint
-            // fires on a later call (where EP hasn't escaped), the interpreter would
-            // read stale locals (e.g., nil instead of [] for keyword defaults).
+            // interpreter on the next call.
             //
             // We can't use invalidate_iseq_version() here because it skips when
             // at MAX_ISEQ_VERSIONS (to prevent unbounded recompilation). Instead,

--- a/zjit/src/options.rs
+++ b/zjit/src/options.rs
@@ -537,6 +537,13 @@ pub fn enable_zjit_stats() {
     unsafe { OPTIONS.as_mut() }.unwrap().stats = true;
 }
 
+/// Enable --zjit-disable-hir-opt for testing
+#[cfg(test)]
+pub fn disable_hir_opt() {
+    rb_zjit_prepare_options();
+    unsafe { OPTIONS.as_mut() }.unwrap().disable_hir_opt = true;
+}
+
 /// Print ZJIT options for `ruby --help`. `width` is width of option parts, and
 /// `columns` is indent width of descriptions.
 #[unsafe(no_mangle)]


### PR DESCRIPTION

This patch deletes local variable tracking in `FrameState` and its derivative `SideExit`, opting to instead always use environment memory like the interpreter for local variable storage.
We've had many bugs with the previous implementation, two of which are fixed here. By rolling back to a simpler scheme, this patch prepares us for lightweight frames stack maps.

In terms of performance, this patch runs about as fast as before:

```
master: ruby 4.1.0dev (2026-05-25T19:45:30Z master d5aa01f53a) +ZJIT +PRISM [x86_64-linux]              
+patch: ruby 4.1.0dev (2026-05-26T21:29:21Z +patch d3163ca850) +ZJIT +PRISM [x86_64-linux]              
                                                                                                        
--------------  -------------  -------------  --------------  -------------                             
bench             master (ms)    +patch (ms)  +patch 1st itr  master/+patch                             
activerecord     211.1 ± 6.0%   193.9 ± 1.3%           1.021          1.088                             
chunky-png       711.0 ± 0.2%   715.6 ± 0.2%           1.006          0.994                             
erubi-rails      916.5 ± 0.6%   908.9 ± 0.6%           1.022          1.008                             
hexapdf         2462.5 ± 0.9%  2408.8 ± 1.3%           1.038          1.022                             
liquid-c          64.2 ± 6.2%    64.4 ± 6.6%           1.094          0.997                             
liquid-compile    48.2 ± 7.8%    47.9 ± 7.9%           1.142          1.007                             
liquid-render    132.9 ± 2.9%   130.2 ± 3.2%           1.094          1.021                             
lobsters         996.2 ± 1.4%  1006.3 ± 4.1%           1.093          0.990                             
mail             147.5 ± 3.3%   145.7 ± 3.9%           1.280          1.012                             
psych-load      1990.2 ± 1.2%  1942.4 ± 1.2%           1.027          1.025                             
railsbench      2019.2 ± 1.2%  2009.4 ± 1.0%           1.038          1.005                             
rubocop         194.3 ± 16.7%  185.7 ± 11.4%           0.715          1.046                             
ruby-lsp         156.0 ± 3.2%   152.9 ± 2.8%           1.125          1.020                             
sequel            65.2 ± 5.1%    64.5 ± 5.2%           1.153          1.010                             
shipit          1763.9 ± 1.3%  1757.6 ± 1.7%           1.050          1.004                             
--------------  -------------  -------------  --------------  -------------                             
                                                                                                        
Legend:                                                                                                 
- +patch 1st itr: ratio of master/+patch time for the first benchmarking iteration.                     
- master/+patch: ratio of master/+patch time. Higher is better for +patch. Above 1 represents a speedup.

```

Code size
---

`Legend: field=code_region_bytes; ratio=+patch/master; ratio < 1 means +patch is smaller.`

| benchmark      |   master |   patch |     diff | ratio |
| -------------- | -------: | ------: | -------: | ----: |
| activerecord   |  2215936 | 1794048 |  -421888 |  0.81 |
| chunky-png     |   475136 |  376832 |   -98304 | 0.793 |
| erubi-rails    |  2281472 | 1642496 |  -638976 |  0.72 |
| hexapdf        |  2080768 | 1556480 |  -524288 | 0.748 |
| liquid-c       |   929792 |  700416 |  -229376 | 0.753 |
| liquid-compile |   790528 |  602112 |  -188416 | 0.762 |
| liquid-render  |  1126400 |  843776 |  -282624 | 0.749 |
| lobsters       | 12161024 | 9134080 | -3026944 | 0.751 |
| mail           |  1785856 | 1150976 |  -634880 | 0.644 |
| psych-load     |   430080 |  335872 |   -94208 | 0.781 |
| railsbench     |  5066752 | 3854336 | -1212416 | 0.761 |
| rubocop        |  7581696 | 7217152 |  -364544 | 0.952 |
| ruby-lsp       |  1421312 | 1069056 |  -352256 | 0.752 |
| sequel         |   745472 |  602112 |  -143360 | 0.808 |
| shipit         |  9687040 | 7540736 | -2146304 | 0.778 |


Side Exit Size
---

`Legend: field=side_exit_size; ratio=+patch/master; ratio < 1 means +patch is smaller.`

| benchmark       | master   | patch    | diff      | ratio |
| ---             | ---:     | ---:     | ---:      | ---: |
| activerecord    | 1075876  | 764817   | -311059   | 0.711 |
| chunky-png      | 238557   | 166253   | -72304    | 0.697 |
| erubi-rails     | 1157593  | 716960   | -440633   | 0.619 |
| hexapdf         | 1051297  | 688900   | -362397   | 0.655 |
| liquid-c        | 475735   | 312164   | -163571   | 0.656 |
| liquid-compile  | 401194   | 267086   | -134108   | 0.666 |
| liquid-render   | 572426   | 372872   | -199554   | 0.651 |
| lobsters        | 5795335  | 3693397  | -2101938  | 0.637 |
| mail            | 942467   | 499908   | -442559   | 0.53 |
| psych-load      | 222742   | 151915   | -70827    | 0.682 |
| railsbench      | 2558302  | 1680637  | -877665   | 0.657 |
| rubocop         | 3710403  | 3134616  | -575787   | 0.845 |
| ruby-lsp        | 746831   | 483001   | -263830   | 0.647 |
| sequel          | 380884   | 273039   | -107845   | 0.717 |
| shipit          | 4514976  | 3029810  | -1485166  | 0.671 |

Compile Time
---

`Legend: field=compile_time_ns; ratio=+patch/master; ratio < 1 means +patch is faster.`

| benchmark      |     master |      patch |       diff | ratio |
| -------------- | ---------: | ---------: | ---------: | ----: |
| activerecord   |  846611458 |  747845404 |  -98766054 | 0.883 |
| chunky-png     |  172837566 |  148731899 |  -24105667 | 0.861 |
| erubi-rails    |  746949513 |  625165068 | -121784445 | 0.837 |
| hexapdf        |  738238077 |  628730980 | -109507097 | 0.852 |
| liquid-c       |  321488415 |  270644632 |  -50843783 | 0.842 |
| liquid-compile |  273464204 |  231406582 |  -42057622 | 0.846 |
| liquid-render  |  385904605 |  323507000 |  -62397605 | 0.838 |
| lobsters       | 4362737663 | 3761274905 | -601462758 | 0.862 |
| mail           |  622057950 |  451939808 | -170118142 | 0.727 |
| psych-load     |  159396342 |  135221510 |  -24174832 | 0.848 |
| railsbench     | 1764853132 | 1509273103 | -255580029 | 0.855 |
| rubocop        | 3475795791 | 4403194003 |  927398212 | 1.267 |
| ruby-lsp       |  488235892 |  413644147 |  -74591745 | 0.847 |
| sequel         |  278325642 |  243034329 |  -35291313 | 0.873 |
| shipit         | 3573314110 | 3105473076 | -467841034 | 0.869 |

Side-exit count
---

`Legend: jq_qury=.side_exit_count; ratio=+patch/master; ratio < 1 means +patch is lower.`

| benchmark       | master      | patch       | diff        | ratio |
| ---             | ---:        | ---:        | ---:        | ---: |
| activerecord    | `11437845`  | `11149517`  | `-288328`   | `0.975` |
| chunky-png      | `551`       | `597`       | `46`        | `1.083` |
| erubi-rails     | `4136848`   | `4136863`   | `15`        | `1` |
| hexapdf         | `13870384`  | `13870392`  | `8`         | `1` |
| liquid-c        | `5097841`   | `4986070`   | `-111771`   | `0.978` |
| liquid-compile  | `3981912`   | `3886139`   | `-95773`    | `0.976` |
| liquid-render   | `12233421`  | `6887332`   | `-5346089`  | `0.563` |
| lobsters        | `8762521`   | `8575184`   | `-187337`   | `0.979` |
| mail            | `788643`    | `765309`    | `-23334`    | `0.97` |
| psych-load      | `7490413`   | `7490418`   | `5`         | `1` |
| railsbench      | `3337893`   | `3288229`   | `-49664`    | `0.985` |
| rubocop         | `3091190`   | `2902985`   | `-188205`   | `0.939` |
| ruby-lsp        | `3265905`   | `2853024`   | `-412881`   | `0.874` |
| sequel          | `1274504`   | `1242502`   | `-32002`    | `0.975` |
| shipit          | `17022359`  | `17022255`  | `-104`      | `1` |



## The Diff

A knock-on effect of the deletion is that we now no longer port around local variables as HIR block parameters, locking in a cleanup possible thanks to the global register allocator. This however, means pretty much all test snapshots are changed.


Fixes: https://github.com/Shopify/ruby/issues/970
Fixes: https://github.com/Shopify/ruby/issues/976 
