### PR TITLE
Fix tautological assertions in test_each_value in test_hash.rb

### DIFF
--- a/test/ruby/test_hash.rb
+++ b/test/ruby/test_hash.rb
@@ -465,10 +465,10 @@ class TestHash < Test::Unit::TestCase
   def test_each_value
     res = []
     @cls[].each_value { |v| res << v }
-    assert_equal(0, [].length)
+    assert_equal(0, res.length)
 
     @h.each_value { |v| res << v }
-    assert_equal(0, [].length)
+    assert_equal(@h.size, res.length)
 
     expected = []
     @h.each { |k, v| expected << v }


### PR DESCRIPTION
Both assertions tested `[].length == 0` rather than `res.length`, so the test passed even when `each_value` yielded nothing.