### PR TITLE
Improve performance of `String#inspect` with an ASCII bulk-skip fast path

### DIFF
--- a/benchmark/string_inspect.yml
+++ b/benchmark/string_inspect.yml
@@ -1,0 +1,13 @@
+prelude: |
+  ascii = "Hello, World! This is a benchmark test string." * 100
+  utf8 = "こんにちは世界。これはベンチマーク用のテスト文字列です。" * 100
+  mixed = ("Hello World! " + "テスト" + " is great! ") * 100
+  binary = ("\xE3\x81\x82" * 100).b
+  escapy = "\n\t\"\\\#" * 100
+
+benchmark:
+  inspect_ascii: ascii.inspect
+  inspect_utf8: utf8.inspect
+  inspect_mixed: mixed.inspect
+  inspect_binary: binary.inspect
+  inspect_escapy: escapy.inspect

--- a/string.c
+++ b/string.c
@@ -7251,6 +7251,21 @@ rb_str_escape(VALUE str)
     return result;
 }
 
+/* Lookup table for the inspect fast path. 1 marks bytes that need
+ * no escaping. 0 marks bytes that need escape inspection: 0x00-0x1F
+ * (control), 0x22 ("), 0x23 (#), 0x5C (\), 0x7F (DEL), 0x80-0xFF
+ * (non-ASCII). */
+static const bool inspect_no_escape[256] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x00-0x0F */
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, /* 0x10-0x1F */
+    1, 1, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x20-0x2F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x30-0x3F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x40-0x4F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, /* 0x50-0x5F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, /* 0x60-0x6F */
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, /* 0x70-0x7F */
+};
+
 /*
  *  call-seq:
  *    inspect -> string
@@ -7266,10 +7281,11 @@ rb_str_inspect(VALUE str)
     rb_encoding *enc = rb_enc_from_index(encidx);
     const char *p, *pend, *prev;
     char buf[CHAR_ESC_LEN + 1];
-    VALUE result = rb_str_buf_new(0);
+    VALUE result = rb_str_buf_new(RSTRING_LEN(str) + 2); /* string content + surrounding quotes */
     rb_encoding *resenc = rb_default_internal_encoding();
     int unicode_p = rb_enc_unicode_p(enc);
     int asciicompat = rb_enc_asciicompat(enc);
+    int cr = rb_enc_str_coderange(str);
 
     if (resenc == NULL) resenc = rb_default_external_encoding();
     if (!rb_enc_asciicompat(resenc)) resenc = rb_usascii_encoding();
@@ -7281,6 +7297,15 @@ rb_str_inspect(VALUE str)
     while (p < pend) {
         unsigned int c, cc;
         int n;
+
+        /* Fast path: bulk-skip runs of safe ASCII bytes via a lookup table.
+         * Only well-formed strings (CR=7BIT for any encoding, or UTF-8 VALID)
+         * are eligible. */
+        if (cr == ENC_CODERANGE_7BIT ||
+            (encidx == ENCINDEX_UTF_8 && cr == ENC_CODERANGE_VALID)) {
+            while (p < pend && inspect_no_escape[(unsigned char)*p]) p++;
+            if (p >= pend) break;
+        }
 
         n = rb_enc_precise_mbclen(p, pend, enc);
         if (!MBCLEN_CHARFOUND_P(n)) {


### PR DESCRIPTION
## Background

Currently, `String#inspect` processes strings character by character using `rb_enc_precise_mbclen` and `rb_enc_mbc_to_codepoint`. This process is slow for UTF-8 strings, even when most of the characters are simple ASCII bytes that do not require escaping.

## Proposal

Add a fast path for strings that are `CR=7BIT` or valid UTF-8 (`CR=VALID`).

We can use a 256-byte lookup table (`inspect_no_escape`) to quickly skip unescaped ASCII bytes in bulk. If a byte requires escaping, the code falls back to the original decoder.

The lookup table (`inspect_no_escape`) marks `1` for bytes that can be emitted as-is (everything except `0x00-0x1F`, `"`, `#`, `\`, `0x7F`, `0x80+`). The fallback are all unchanged on the original path.

### Results

Measured with `benchmark/string_inspect.yml`, 3 runs, best:

| Benchmark      | Master    | This PR   | Ratio  |
| :------------- | --------: | --------: | :----- |
| inspect_ascii  | 49.8k/s   | 616.5k/s  | 12.39x |
| inspect_utf8   | 22.8k/s   | 22.9k/s   | ~1.0x  |
| inspect_mixed  | 71.7k/s   | 247.1k/s  | 3.45x  |
| inspect_binary | 103.2k/s  | 107.7k/s  | ~1.0x  |
| inspect_escapy | 175.0k/s  | 166.4k/s  | 0.95x  |

`inspect_binary` (ASCII-8BIT, off the fast path) and `inspect_utf8` (all-multibyte) confirm no slow-path regression.

### Tradeoffs

The `inspect_escapy` test is about 5% slower. This test uses a string where every byte requires escaping (like `\n\t"\\#`). Because none of the bytes can be emitted as-is, the fast path always fails, adding a small overhead. However, real-world strings composed entirely of escape-requiring characters are very rare.