### PR TITLE
Use stack callinfo/calldata for super dispatch

### DIFF
--- a/insns.def
+++ b/insns.def
@@ -1099,9 +1099,24 @@ invokesuper
 // attr rb_snum_t comptime_sp_inc = sp_inc_of_sendish(ci);
 // attr bool zjit_profile = true;
 {
-    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), cd->ci, blockiseq, true);
-    val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_super);
+    struct rb_callinfo adjusted_ci = VM_CI_ON_STACK(vm_ci_mid(cd->ci),
+                                                   vm_ci_flag(cd->ci),
+                                                   vm_ci_argc(cd->ci),
+                                                   vm_ci_kwarg(cd->ci));
+    const struct rb_callcache *original_cc = rbimpl_atomic_ptr_load((void **)&cd->cc, RBIMPL_ATOMIC_ACQUIRE);
+    struct rb_call_data adjusted_cd = {
+        .ci = &adjusted_ci,
+        .cc = original_cc,
+    };
+
+    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), adjusted_cd.ci, blockiseq, true);
+    val = vm_sendish(ec, GET_CFP(), &adjusted_cd, bh, mexp_search_super);
     JIT_EXEC(ec, val);
+
+    if (original_cc != adjusted_cd.cc && vm_cc_markable(adjusted_cd.cc)) {
+        rbimpl_atomic_ptr_store((volatile void **)&cd->cc, (void *)adjusted_cd.cc, RBIMPL_ATOMIC_RELEASE);
+        RB_OBJ_WRITTEN(GET_ISEQ(), Qundef, adjusted_cd.cc);
+    }
 
     if (UNDEF_P(val)) {
         RESTORE_REGS();

--- a/test/ruby/test_ractor.rb
+++ b/test/ruby/test_ractor.rb
@@ -42,6 +42,59 @@ class TestRactor < Test::Unit::TestCase
 =end
   end
 
+  def test_shareable_proc_define_method_super_method_missing
+    assert_ractor(<<~'RUBY', timeout: 30)
+      iterations = 1_000_000
+
+      class SuperFromShareableProcMethodMissingBase
+        def method_missing(mid, *) = mid
+      end
+
+      class SuperFromShareableProcMethodMissingChild < SuperFromShareableProcMethodMissingBase
+        BODY = Ractor.shareable_proc { super() }
+        define_method(:foo, &BODY)
+        define_method(:bar, &BODY)
+      end
+
+      [:foo, :bar].map do |mid|
+        Ractor.new(mid, iterations) do |mid, iterations|
+          obj = SuperFromShareableProcMethodMissingChild.new
+          iterations.times do
+            got = obj.__send__(mid)
+            raise "#{mid} returned #{got.inspect}" unless got == mid
+          end
+        end
+      end.each(&:value)
+    RUBY
+  end
+
+  def test_shareable_proc_define_method_super_method_entry
+    assert_ractor(<<~'RUBY', timeout: 30)
+      iterations = 1_000_000
+
+      class SuperFromShareableProcBase
+        def foo = :foo
+        def bar = :bar
+      end
+
+      class SuperFromShareableProcChild < SuperFromShareableProcBase
+        BODY = Ractor.shareable_proc { super() }
+        define_method(:foo, &BODY)
+        define_method(:bar, &BODY)
+      end
+
+      [:foo, :bar].map do |mid|
+        Ractor.new(mid, iterations) do |mid, iterations|
+          obj = SuperFromShareableProcChild.new
+          iterations.times do
+            got = obj.__send__(mid)
+            raise "#{mid} returned #{got.inspect}" unless got == mid
+          end
+        end
+      end.each(&:value)
+    RUBY
+  end
+
   def test_shareability_error_uses_inspect
     x = (+"").instance_exec { method(:to_s) }
     def x.to_s

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -6080,8 +6080,23 @@ rb_vm_invokesuper(rb_execution_context_t *ec, rb_control_frame_t *reg_cfp, CALL_
 {
     stack_check(ec);
 
-    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), cd->ci, blockiseq, true);
-    VALUE val = vm_sendish(ec, GET_CFP(), cd, bh, mexp_search_super);
+    struct rb_callinfo adjusted_ci = VM_CI_ON_STACK(vm_ci_mid(cd->ci),
+                                                   vm_ci_flag(cd->ci),
+                                                   vm_ci_argc(cd->ci),
+                                                   vm_ci_kwarg(cd->ci));
+    const struct rb_callcache *original_cc = rbimpl_atomic_ptr_load((void **)&cd->cc, RBIMPL_ATOMIC_ACQUIRE);
+    struct rb_call_data adjusted_cd = {
+        .ci = &adjusted_ci,
+        .cc = original_cc,
+    };
+
+    VALUE bh = vm_caller_setup_arg_block(ec, GET_CFP(), adjusted_cd.ci, blockiseq, true);
+    VALUE val = vm_sendish(ec, GET_CFP(), &adjusted_cd, bh, mexp_search_super);
+
+    if (original_cc != adjusted_cd.cc && vm_cc_markable(adjusted_cd.cc)) {
+        rbimpl_atomic_ptr_store((volatile void **)&cd->cc, (void *)adjusted_cd.cc, RBIMPL_ATOMIC_RELEASE);
+        RB_OBJ_WRITTEN(CFP_ISEQ(GET_CFP()), Qundef, adjusted_cd.cc);
+    }
 
     VM_EXEC(ec, val);
     return val;

--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -1984,9 +1984,10 @@ impl<'a> std::fmt::Display for InsnPrinter<'a> {
             Insn::FixnumAref { recv, index } => write!(f, "FixnumAref {recv}, {index}"),
             Insn::Jump(target) => { write!(f, "Jump {target}") }
             Insn::CondBranch { val, if_true, if_false } => { write!(f, "CondBranch {val}, {if_true}, {if_false}") },
-            Insn::SendDirect { recv, cd, iseq, args, block, .. } => {
+            Insn::SendDirect { recv, cme, iseq, args, block, .. } => {
                 let blockiseq = block.map(|bh| match bh { BlockHandler::BlockIseq(iseq) => iseq, BlockHandler::BlockArg => unreachable!() });
-                write!(f, "SendDirect {recv}, {:p}, :{} ({:?})", self.ptr_map.map_ptr(&blockiseq), ruby_call_method_name(*cd), self.ptr_map.map_ptr(iseq))?;
+                let method_name = unsafe { (**cme).called_id };
+                write!(f, "SendDirect {recv}, {:p}, :{} ({:?})", self.ptr_map.map_ptr(&blockiseq), method_name, self.ptr_map.map_ptr(iseq))?;
                 for arg in args {
                     write!(f, ", {arg}")?;
                 }


### PR DESCRIPTION
This fixes a race condition when two Ractors might be racing to update the `ci` and `cc`. This also avoids allocating new CIs at runtime and assigning them to the iseq (I _think_ in all cases).

This implementation is very similar to what we did for `sendforward`/`invokesuperforward`.

I also found from testing that, at least on arm, we need to use atomics to properly publish/read the callcache when being used by multiple ractors.

This makes super calls which include kwargs (or anything else that doesn't result in a packed CI) faster and avoid allocations, but "boring" super calls marginally slower on my M4 mac.

I think we could make things faster by specializing the common case where the CI doesn't need to be rewritten

``` ruby
require "ips"

class Base
  def pos(x) = x
  def kw(x:) = x
end

class Child < Base
  def pos(x) = super(x)
  def kw(x:) = super(x:)
end

obj = Child.new

IPS.ips do |x|
  x.report("super arg") { obj.pos(1) }
  x.report("super kwarg") { obj.kw(x: 1) }
end
```


```
$ ips --ruby ./miniruby_before --ruby ./miniruby bench_super.rb
ruby 4.1.0dev (2026-05-27T17:13:54Z super_callinfo 1ef2f82004) +PRISM [arm64-darwin25]
           super arg:    26.454M i/s (± 1.1%)
         super kwarg:    12.042M i/s (± 0.8%, GC 15.3%)

ruby 4.1.0dev (2026-05-27T17:27:51Z super_callinfo b57f8425a3) +PRISM [arm64-darwin25]
           super arg:    25.955M i/s (± 0.7%)
         super kwarg:    19.544M i/s (± 0.7%)


Summary
  super arg (ruby ./miniruby_before) ran
    1.02 ± 0.01 times faster than super arg (ruby ./miniruby)
    1.35 ± 0.02 times faster than super kwarg (ruby ./miniruby)
    2.20 ± 0.03 times faster than super kwarg (ruby ./miniruby_before)
```