### PR TITLE
ZJIT: Fold arithmetic identity operations

### DIFF
--- a/zjit/src/hir.rs
+++ b/zjit/src/hir.rs
@@ -5194,18 +5194,32 @@ impl Function {
                         }
                     }
                     Insn::FixnumAdd { left, right, .. } => {
+                        match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
+                            (Some(0), _) => { self.make_equal_to(insn_id, right); continue; }
+                            (_, Some(0)) => { self.make_equal_to(insn_id, left); continue; }
+                            _ => {}
+                        }
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => l.checked_add(r),
                             _ => None,
                         })
                     }
                     Insn::FixnumSub { left, right, .. } => {
+                        match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
+                            (_, Some(0)) => { self.make_equal_to(insn_id, left); continue; }
+                            _ => {}
+                        }
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => l.checked_sub(r),
                             _ => None,
                         })
                     }
                     Insn::FixnumMult { left, right, .. } => {
+                        match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
+                            (Some(1), _) => { self.make_equal_to(insn_id, right); continue; }
+                            (_, Some(1)) => { self.make_equal_to(insn_id, left); continue; }
+                            _ => {}
+                        }
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) => l.checked_mul(r),
                             (Some(0), _) | (_, Some(0)) => Some(0),
@@ -5213,6 +5227,10 @@ impl Function {
                         })
                     }
                     Insn::FixnumDiv { left, right, .. } => {
+                        match (self.type_of(left).fixnum_value(), self.type_of(right).fixnum_value()) {
+                            (_, Some(1)) => { self.make_equal_to(insn_id, left); continue; }
+                            _ => {}
+                        }
                         self.fold_fixnum_bop(insn_id, left, right, |l, r| match (l, r) {
                             (Some(l), Some(r)) if l == (RUBY_FIXNUM_MIN as i64) && r == -1 => None, // Avoid Fixnum overflow
                             (Some(_l), Some(r)) if r == 0 => None, // Avoid Divide by zero.

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -121,7 +121,7 @@ mod hir_opt_tests {
     fn test_fold_fixnum_add_zero() {
         eval("
             def test(n)
-              0 + n + 0;
+              0 + n + 0
             end
             test 1; test 2;
         ");
@@ -205,7 +205,7 @@ mod hir_opt_tests {
     fn test_fold_fixnum_sub_zero() {
         eval("
             def test(n)
-              n - 0;
+              n - 0
             end
             test 1; test 2;
         ");
@@ -295,7 +295,7 @@ mod hir_opt_tests {
     fn test_fold_fixnum_mult_one() {
         eval("
             def test(n)
-              1 * n + n * 1;
+              1 * n + n * 1
             end
             test 1; test 2
         ");
@@ -435,7 +435,7 @@ mod hir_opt_tests {
     fn test_fold_fixnum_div_one() {
         eval("
             def test(n)
-              n / 1;
+              n / 1
             end
             test 1; test 2
         ");

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -123,7 +123,7 @@ mod hir_opt_tests {
             def test(n)
               0 + n + 0
             end
-            test 1; test 2;
+            test 1; test 2
         ");
         assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:
@@ -207,7 +207,7 @@ mod hir_opt_tests {
             def test(n)
               n - 0
             end
-            test 1; test 2;
+            test 1; test 2
         ");
         assert_snapshot!(hir_string("test"), @"
         fn test@<compiled>:3:

--- a/zjit/src/hir/opt_tests.rs
+++ b/zjit/src/hir/opt_tests.rs
@@ -118,6 +118,36 @@ mod hir_opt_tests {
     }
 
     #[test]
+    fn test_fold_fixnum_add_zero() {
+        eval("
+            def test(n)
+              0 + n + 0;
+            end
+            test 1; test 2;
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v14:Fixnum[0] = Const Value(0)
+          PatchPoint MethodRedefined(Integer@0x1008, +@0x1010, cme:0x1018)
+          v32:Fixnum = GuardType v10, Fixnum
+          CheckInterrupts
+          Return v32
+        ");
+    }
+
+    #[test]
     fn test_fold_fixnum_sub() {
         eval("
             def test
@@ -168,6 +198,36 @@ mod hir_opt_tests {
           v24:Fixnum[-1073741825] = Const Value(-1073741825)
           CheckInterrupts
           Return v24
+        ");
+    }
+
+    #[test]
+    fn test_fold_fixnum_sub_zero() {
+        eval("
+            def test(n)
+              n - 0;
+            end
+            test 1; test 2;
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v15:Fixnum[0] = Const Value(0)
+          PatchPoint MethodRedefined(Integer@0x1008, -@0x1010, cme:0x1018)
+          v26:Fixnum = GuardType v10, Fixnum
+          CheckInterrupts
+          Return v26
         ");
     }
 
@@ -226,9 +286,40 @@ mod hir_opt_tests {
           v46:Fixnum[0] = Const Value(0)
           v47:Fixnum[0] = Const Value(0)
           PatchPoint MethodRedefined(Integer@0x1008, +@0x1040, cme:0x1048)
-          v48:Fixnum[0] = Const Value(0)
           CheckInterrupts
-          Return v48
+          Return v47
+        ");
+    }
+
+    #[test]
+    fn test_fold_fixnum_mult_one() {
+        eval("
+            def test(n)
+              1 * n + n * 1;
+            end
+            test 1; test 2
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v14:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Integer@0x1008, *@0x1010, cme:0x1018)
+          v36:Fixnum = GuardType v10, Fixnum
+          PatchPoint MethodRedefined(Integer@0x1008, +@0x1040, cme:0x1048)
+          v45:Fixnum = FixnumAdd v36, v36
+          CheckInterrupts
+          Return v45
         ");
     }
 
@@ -337,6 +428,36 @@ mod hir_opt_tests {
           v23:Fixnum = FixnumDiv v10, v12
           CheckInterrupts
           Return v23
+        ");
+    }
+
+    #[test]
+    fn test_fold_fixnum_div_one() {
+        eval("
+            def test(n)
+              n / 1;
+            end
+            test 1; test 2
+        ");
+        assert_snapshot!(hir_string("test"), @"
+        fn test@<compiled>:3:
+        bb1():
+          EntryPoint interpreter
+          v1:BasicObject = LoadSelf
+          v2:CPtr = LoadSP
+          v3:BasicObject = LoadField v2, :n@0x1000
+          Jump bb3(v1, v3)
+        bb2():
+          EntryPoint JIT(0)
+          v6:BasicObject = LoadArg :self@0
+          v7:BasicObject = LoadArg :n@1
+          Jump bb3(v6, v7)
+        bb3(v9:BasicObject, v10:BasicObject):
+          v15:Fixnum[1] = Const Value(1)
+          PatchPoint MethodRedefined(Integer@0x1008, /@0x1010, cme:0x1018)
+          v26:Fixnum = GuardType v10, Fixnum
+          CheckInterrupts
+          Return v26
         ");
     }
 
@@ -16519,9 +16640,8 @@ mod hir_opt_tests {
           v139:BasicObject = LoadField v138, :var@0x1040
           PatchPoint MethodRedefined(Integer@0x1048, +@0x1050, cme:0x1058)
           v179:Fixnum = GuardType v139, Fixnum
-          v180:Fixnum = FixnumAdd v17, v179
           PatchPoint NoEPEscape(test)
-          v185:Fixnum = FixnumAdd v180, v179
+          v185:Fixnum = FixnumAdd v179, v179
           v190:Fixnum = FixnumAdd v185, v179
           v195:Fixnum = FixnumAdd v190, v179
           v200:Fixnum = FixnumAdd v195, v179


### PR DESCRIPTION
Arithmetic identity operations such as `x + 0`, `x - 0`, `x * 1`, `x / 1` in `fold_constants`.
