### PR TITLE
ZJIT: Materialize JITFrame on exit trampoline

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -574,13 +574,6 @@ jit_exec(rb_execution_context_t *ec)
         rb_jit_func_t func = zjit_compile(ec);
         if (func) {
             VALUE result = ((rb_zjit_func_t)zjit_entry)(ec, ec->cfp, func);
-            // Materialize any remaining lightweight ZJIT frames on side exit.
-            // This is done here (once per JIT entry) instead of in each side exit
-            // to reduce generated code size.
-            if (UNDEF_P(result)) {
-                ec->cfp->jit_return = 0; // exit code already cleared most fields except jit_return
-                rb_zjit_materialize_frames(ec, ec->cfp);
-            }
             return result;
         }
     }

--- a/vm_exec.h
+++ b/vm_exec.h
@@ -189,10 +189,6 @@ default:                        \
             rb_jit_func_t func = zjit_compile(ec); \
             if (func) { \
                 val = zjit_entry(ec, ec->cfp, func); \
-                if (UNDEF_P(val)) { \
-                    ec->cfp->jit_return = 0; \
-                    rb_zjit_materialize_frames(ec, ec->cfp); \
-                } \
             } \
         } \
     } \

--- a/zjit/src/backend/lir.rs
+++ b/zjit/src/backend/lir.rs
@@ -4,7 +4,7 @@ use std::mem::take;
 use std::rc::Rc;
 use crate::bitset::BitSet;
 use crate::codegen::{local_size_and_idx_to_ep_offset, perf_symbol_range_start, perf_symbol_range_end};
-use crate::cruby::{IseqPtr, Qundef, RUBY_OFFSET_CFP_ISEQ, RUBY_OFFSET_CFP_JIT_RETURN, RUBY_OFFSET_CFP_PC, RUBY_OFFSET_CFP_SP, SIZEOF_VALUE_I32, vm_stack_canary};
+use crate::cruby::{IseqPtr, RUBY_OFFSET_CFP_ISEQ, RUBY_OFFSET_CFP_JIT_RETURN, RUBY_OFFSET_CFP_PC, RUBY_OFFSET_CFP_SP, SIZEOF_VALUE_I32, vm_stack_canary};
 use crate::hir::{Invariant, SideExitReason};
 use crate::hir;
 use crate::options::{TraceExits, PerfMap, get_option};
@@ -13,7 +13,7 @@ use crate::payload::IseqVersionRef;
 use crate::stats::{exit_counter_ptr, exit_counter_ptr_for_opcode, side_exit_counter, CompileError};
 use crate::virtualmem::CodePtr;
 use crate::asm::{CodeBlock, Label};
-use crate::state::rb_zjit_record_exit_stack;
+use crate::state::{ZJITState, rb_zjit_record_exit_stack};
 
 /// LIR Block ID. Unique ID for each block, and also defined in LIR so
 /// we can differentiate it from HIR block ids.
@@ -2380,7 +2380,7 @@ impl Assembler
             asm_comment!(asm, "save cfp->iseq");
             asm.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_ISEQ), VALUE::from(*iseq).into());
 
-            // cfp->block_code and cfp->jit_return are cleared by the caller jit_exec() or JIT_EXEC()
+            // cfp->block_code and cfp->jit_return are cleared by the materialize_exit trampoline
 
             if !stack.is_empty() {
                 asm_comment!(asm, "write stack slots: {}", join_opnds(&stack, ", "));
@@ -2400,8 +2400,7 @@ impl Assembler
         /// Tear down the JIT frame and return to the interpreter.
         fn compile_exit_return(asm: &mut Assembler) {
             asm_comment!(asm, "exit to the interpreter");
-            asm.frame_teardown(&[]); // matching the setup in gen_entry_point()
-            asm.cret(Opnd::UImm(Qundef.as_u64()));
+            asm.jmp(Target::CodePtr(ZJITState::get_materialize_exit_trampoline()));
         }
 
         fn compile_exit_recompile(asm: &mut Assembler, exit: &SideExit) {
@@ -2434,7 +2433,7 @@ impl Assembler
             compile_exit_save_state(asm, exit);
             if trace_reason.is_some() || exit.recompile.is_some() {
                 // Clear cfp->jit_return to prepare for a C call. Normally, cfp->jit_return
-                // is cleared by the caller jit_exec() or JIT_EXEC(), but if we're about to
+                // is cleared by the materialize_exit trampoline, but if we're about to
                 // make a C call, we need to clear any stale JITFrame.
                 asm_comment!(asm, "clear cfp->jit_return");
                 asm.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), 0.into());

--- a/zjit/src/codegen.rs
+++ b/zjit/src/codegen.rs
@@ -3098,7 +3098,7 @@ c_callable! {
             // If we side-exit from function_stub_hit (before JIT code runs), we need to set them here.
             fn prepare_for_exit(iseq: IseqPtr, cfp: CfpPtr, sp: *mut VALUE, argc: u16, num_opts_filled: u16, compile_error: &CompileError) {
                 unsafe {
-                    // Caller frames are materialized by jit_exec() after the entry trampoline returns.
+                    // Caller frames are materialized by the materialize_exit trampoline before unwinding native frames.
                     // The current frame's pc and iseq are already set by function_stub_hit before this point.
 
                     // Set SP which gen_push_frame() doesn't set
@@ -3186,7 +3186,7 @@ c_callable! {
                 unsafe { Rc::increment_strong_count(iseq_call_ptr as *const IseqCall); }
 
                 prepare_for_exit(iseq, cfp, sp, argc, num_opts_filled, compile_error);
-                return ZJITState::get_exit_trampoline_with_counter().raw_ptr(cb);
+                return ZJITState::get_materialize_exit_trampoline_with_counter().raw_ptr(cb);
             }
 
             // Otherwise, attempt to compile the ISEQ. We have to mark_all_executable() beyond this point.
@@ -3201,7 +3201,7 @@ c_callable! {
                 unsafe { Rc::increment_strong_count(iseq_call_ptr as *const IseqCall); }
 
                 prepare_for_exit(iseq, cfp, sp, argc, num_opts_filled, &compile_error);
-                ZJITState::get_exit_trampoline_with_counter()
+                ZJITState::get_materialize_exit_trampoline_with_counter()
             });
             cb.mark_all_executable();
             code_ptr.raw_ptr(cb)
@@ -3332,14 +3332,34 @@ pub fn gen_exit_trampoline(cb: &mut CodeBlock) -> Result<CodePtr, CompileError> 
     })
 }
 
-/// Generate a trampoline that increments exit_compilation_failure and jumps to exit_trampoline.
-pub fn gen_exit_trampoline_with_counter(cb: &mut CodeBlock, exit_trampoline: CodePtr) -> Result<CodePtr, CompileError> {
+/// Generate a trampoline that materializes ZJIT frames before unwinding native frames.
+pub fn gen_materialize_exit_trampoline(cb: &mut CodeBlock, exit_trampoline: CodePtr) -> Result<CodePtr, CompileError> {
+    unsafe extern "C" {
+        fn rb_zjit_materialize_frames(ec: EcPtr, cfp: CfpPtr);
+    }
+
     let mut asm = Assembler::new();
-    asm.new_block_without_id("exit_trampoline_with_counter");
+    asm.new_block_without_id("materialize_exit_trampoline");
+
+    asm_comment!(asm, "materialize ZJIT frames");
+    asm.store(Opnd::mem(64, CFP, RUBY_OFFSET_CFP_JIT_RETURN), 0.into());
+    asm_ccall!(asm, rb_zjit_materialize_frames, EC, CFP);
+    asm.jmp(Target::CodePtr(exit_trampoline));
+
+    asm.compile(cb).map(|(code_ptr, gc_offsets)| {
+        assert_eq!(gc_offsets.len(), 0);
+        code_ptr
+    })
+}
+
+/// Generate a trampoline that increments exit_compilation_failure and jumps to materialize_exit_trampoline.
+pub fn gen_materialize_exit_trampoline_with_counter(cb: &mut CodeBlock, materialize_exit_trampoline: CodePtr) -> Result<CodePtr, CompileError> {
+    let mut asm = Assembler::new();
+    asm.new_block_without_id("materialize_exit_trampoline_with_counter");
 
     asm_comment!(asm, "function stub exit trampoline");
     gen_incr_counter(&mut asm, exit_compile_error);
-    asm.jmp(Target::CodePtr(exit_trampoline));
+    asm.jmp(Target::CodePtr(materialize_exit_trampoline));
 
     asm.compile(cb).map(|(code_ptr, gc_offsets)| {
         assert_eq!(gc_offsets.len(), 0);

--- a/zjit/src/state.rs
+++ b/zjit/src/state.rs
@@ -1,6 +1,6 @@
 //! Runtime state of ZJIT.
 
-use crate::codegen::{gen_entry_trampoline, gen_exit_trampoline, gen_exit_trampoline_with_counter, gen_function_stub_hit_trampoline};
+use crate::codegen::{gen_entry_trampoline, gen_exit_trampoline, gen_function_stub_hit_trampoline, gen_materialize_exit_trampoline, gen_materialize_exit_trampoline_with_counter};
 use crate::cruby::{self, rb_bug_panic_hook, rb_vm_insn_count, src_loc, EcPtr, Qnil, Qtrue, rb_profile_frames, rb_profile_frame_full_label, rb_profile_frame_absolute_path, rb_profile_frame_path, VALUE, VM_INSTRUCTION_SIZE, with_vm_lock, rust_str_to_id, rb_funcallv, rb_const_get, rb_cRubyVM};
 use crate::cruby_methods;
 use cruby::{ID, rb_callable_method_entry, get_def_method_serial, rb_gc_register_mark_object, ruby_str_to_rust_string_result};
@@ -51,8 +51,11 @@ pub struct ZJITState {
     /// Trampoline to side-exit without restoring PC or the stack
     exit_trampoline: CodePtr,
 
-    /// Trampoline to side-exit and increment exit_compilation_failure
-    exit_trampoline_with_counter: CodePtr,
+    /// Trampoline to materialize JIT frames before side-exiting
+    materialize_exit_trampoline: CodePtr,
+
+    /// Trampoline to materialize JIT frames and increment exit_compilation_failure
+    materialize_exit_trampoline_with_counter: CodePtr,
 
     /// Trampoline to call function_stub_hit
     function_stub_hit_trampoline: CodePtr,
@@ -126,6 +129,7 @@ impl ZJITState {
 
         let entry_trampoline = gen_entry_trampoline(&mut cb).unwrap().raw_ptr(&cb);
         let exit_trampoline = gen_exit_trampoline(&mut cb).unwrap();
+        let materialize_exit_trampoline = gen_materialize_exit_trampoline(&mut cb, exit_trampoline).unwrap();
         let function_stub_hit_trampoline = gen_function_stub_hit_trampoline(&mut cb).unwrap();
 
         let perfetto_tracer = if get_option!(trace_side_exits).is_some() || get_option!(trace_compiles) || get_option!(trace_invalidation) {
@@ -144,8 +148,9 @@ impl ZJITState {
             assert_compiles: false,
             method_annotations,
             exit_trampoline,
+            materialize_exit_trampoline,
+            materialize_exit_trampoline_with_counter: materialize_exit_trampoline,
             function_stub_hit_trampoline,
-            exit_trampoline_with_counter: exit_trampoline,
             full_frame_cfunc_counter_pointers: HashMap::new(),
             not_annotated_frame_cfunc_counter_pointers: HashMap::new(),
             ccall_counter_pointers: HashMap::new(),
@@ -160,8 +165,8 @@ impl ZJITState {
         // on the counter, so ZJIT_STATE needs to be initialized first.
         if get_option!(stats) {
             let cb = ZJITState::get_code_block();
-            let code_ptr = gen_exit_trampoline_with_counter(cb, exit_trampoline).unwrap();
-            ZJITState::get_instance().exit_trampoline_with_counter = code_ptr;
+            let code_ptr = gen_materialize_exit_trampoline_with_counter(cb, materialize_exit_trampoline).unwrap();
+            ZJITState::get_instance().materialize_exit_trampoline_with_counter = code_ptr;
         }
 
         entry_trampoline
@@ -288,9 +293,14 @@ impl ZJITState {
         ZJITState::get_instance().exit_trampoline
     }
 
-    /// Return a code pointer to the exit trampoline for function stubs
-    pub fn get_exit_trampoline_with_counter() -> CodePtr {
-        ZJITState::get_instance().exit_trampoline_with_counter
+    /// Return a code pointer to the materialize_exit trampoline
+    pub fn get_materialize_exit_trampoline() -> CodePtr {
+        ZJITState::get_instance().materialize_exit_trampoline
+    }
+
+    /// Return a code pointer to the materialize_exit trampoline for function stubs
+    pub fn get_materialize_exit_trampoline_with_counter() -> CodePtr {
+        ZJITState::get_instance().materialize_exit_trampoline_with_counter
     }
 
     /// Return a code pointer to the function stub hit trampoline


### PR DESCRIPTION
This PR changes side exit code to call `rb_zjit_materialize_frames` before unwinding native frames for JIT code.

When JIT code returns to the interpreter, it expires native frames that hold the `JITFrame` pointer on their stack. The `JITFrame` needs to be materialized before functions called by the interpreter clobber `JITFrame` stack slots.

## Benchmarks

It doesn't seem to have a significant impact on performance:

```
before: ruby 4.1.0dev (2026-05-28T15:58:58Z master f6886fc1cc) +ZJIT +PRISM [x86_64-linux]
after: ruby 4.1.0dev (2026-05-28T20:47:33Z zjit-materialize-t.. 159efb790f) +ZJIT +PRISM [x86_64-linux]

--------------  -------------  -------------  -------------  ------------
bench             before (ms)     after (ms)  after 1st itr  before/after
activerecord     203.6 ± 3.3%   201.3 ± 1.2%          1.025         1.012
chunky-png       641.4 ± 0.2%   633.4 ± 0.3%          1.017         1.013
erubi-rails      946.7 ± 0.7%   945.8 ± 0.4%          0.998         1.001
hexapdf         2455.5 ± 1.0%  2458.9 ± 0.8%          1.007         0.999
liquid-c          65.9 ± 7.3%    65.9 ± 6.9%          1.006         1.001
liquid-compile   49.4 ± 10.4%   48.9 ± 10.4%          0.975         1.010
liquid-render    139.5 ± 3.2%   138.2 ± 2.9%          1.014         1.009
lobsters        1186.0 ± 2.6%  1193.9 ± 1.8%          1.007         0.993
mail             156.8 ± 3.7%   154.8 ± 3.3%          0.986         1.013
psych-load      2021.3 ± 0.4%  2009.8 ± 0.4%          1.007         1.006
railsbench      2289.5 ± 1.2%  2298.2 ± 1.4%          1.002         0.996
rubocop          213.8 ± 9.4%  214.0 ± 10.7%          1.018         0.999
ruby-lsp         159.3 ± 3.2%   159.1 ± 3.4%          1.000         1.001
sequel            66.3 ± 5.4%    66.1 ± 5.9%          0.892         1.003
shipit          2084.8 ± 1.8%  2098.1 ± 1.9%          1.001         0.994
--------------  -------------  -------------  -------------  ------------
```